### PR TITLE
Deck deletion

### DIFF
--- a/mixxx/src/basetrackplayer.cpp
+++ b/mixxx/src/basetrackplayer.cpp
@@ -117,6 +117,7 @@ void BaseTrackPlayer::finalize() {
 
 BaseTrackPlayer::~BaseTrackPlayer()
 {
+    qDebug() << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~BASETRACKPLAYER";
     if (m_pLoadedTrack) {
         emit(unloadingTrack(m_pLoadedTrack));
         m_pLoadedTrack.clear();

--- a/mixxx/src/basetrackplayer.cpp
+++ b/mixxx/src/basetrackplayer.cpp
@@ -109,6 +109,12 @@ BaseTrackPlayer::BaseTrackPlayer(QObject* pParent,
         ControlObject::getControl(ConfigKey(group, "play")));
 }
 
+void BaseTrackPlayer::finalize() {
+    m_pChannel->finalize();
+    EngineBuffer* pEngineBuffer = m_pChannel->getEngineBuffer();
+    pEngineBuffer->slotControlStop(1.0);
+}
+
 BaseTrackPlayer::~BaseTrackPlayer()
 {
     if (m_pLoadedTrack) {

--- a/mixxx/src/basetrackplayer.h
+++ b/mixxx/src/basetrackplayer.h
@@ -31,6 +31,9 @@ class BaseTrackPlayer : public BasePlayer {
     // connected. Delete me when EngineMaster supports AudioInput assigning.
     EngineDeck* getEngineDeck() const;
 
+    // Tell the player we are about to delete it.
+    void finalize();
+
   public slots:
     void slotLoadTrack(TrackPointer track, bool bPlay=false);
     void slotFinishLoading(TrackPointer pTrackInfoObject);

--- a/mixxx/src/deck.cpp
+++ b/mixxx/src/deck.cpp
@@ -10,5 +10,5 @@ Deck::Deck(QObject* pParent,
 }
 
 Deck::~Deck() {
+    qDebug() << "deck deleteeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeed";
 }
-

--- a/mixxx/src/engine/enginebuffer.cpp
+++ b/mixxx/src/engine/enginebuffer.cpp
@@ -235,6 +235,7 @@ EngineBuffer::EngineBuffer(const char * _group, ConfigObject<ConfigValue> * _con
 
 EngineBuffer::~EngineBuffer()
 {
+    qDebug() << "~~~~~~~~~~~~~~~~~~~~~~~~~~~enginebuffer";
 #ifdef __SCALER_DEBUG__
     //close the writer
     df.close();

--- a/mixxx/src/engine/enginechannel.cpp
+++ b/mixxx/src/engine/enginechannel.cpp
@@ -22,7 +22,8 @@
 
 EngineChannel::EngineChannel(const char* pGroup,
                              EngineChannel::ChannelOrientation defaultOrientation)
-        : m_group(pGroup) {
+        : m_group(pGroup),
+          m_bDying(false) {
     m_pPFL = new ControlPushButton(ConfigKey(m_group, "pfl"));
     m_pPFL->setButtonMode(ControlPushButton::TOGGLE);
     m_pMaster = new ControlPushButton(ConfigKey(m_group, "master"));

--- a/mixxx/src/engine/enginechannel.h
+++ b/mixxx/src/engine/enginechannel.h
@@ -52,6 +52,9 @@ class EngineChannel : public EngineObject {
     virtual bool isPFL();
     virtual bool isMaster();
 
+    void finalize() { m_bDying = true; }
+    bool isDying() const { return m_bDying; }
+
     virtual void process(const CSAMPLE *pIn, const CSAMPLE *pOut, const int iBufferSize) = 0;
 
     // TODO(XXX) This hack needs to be removed.
@@ -64,6 +67,7 @@ class EngineChannel : public EngineObject {
     ControlPushButton* m_pMaster;
     ControlPushButton* m_pPFL;
     ControlObject* m_pOrientation;
+    bool m_bDying;
 };
 
 #endif

--- a/mixxx/src/engine/enginechannel.h
+++ b/mixxx/src/engine/enginechannel.h
@@ -52,7 +52,7 @@ class EngineChannel : public EngineObject {
     virtual bool isPFL();
     virtual bool isMaster();
 
-    void finalize() { m_bDying = true; }
+    void finalize() { m_bDying = true; qDebug() << "DYING NOW " << m_group;}
     bool isDying() const { return m_bDying; }
 
     virtual void process(const CSAMPLE *pIn, const CSAMPLE *pOut, const int iBufferSize) = 0;

--- a/mixxx/src/engine/enginemaster.h
+++ b/mixxx/src/engine/enginemaster.h
@@ -134,7 +134,7 @@ class EngineMaster : public EngineObject, public AudioSource {
                      CSAMPLE* pOutput, unsigned int iBufferSize, GainCalculator* pGainCalculator);
 
 
-    void removeChannelInfo(QList<ChannelInfo*>::iterator& dyingIt);
+    void removeChannelInfo(ChannelInfo* pChannel);
 
     QList<ChannelInfo*> m_channels;
 

--- a/mixxx/src/engine/enginemaster.h
+++ b/mixxx/src/engine/enginemaster.h
@@ -84,6 +84,9 @@ class EngineMaster : public EngineObject, public AudioSource {
         return m_pSideChain;
     }
 
+  signals:
+    void DeckRemoved(QString group);
+
   private:
     struct ChannelInfo {
         EngineChannel* m_pChannel;
@@ -129,6 +132,9 @@ class EngineMaster : public EngineObject, public AudioSource {
 
     void mixChannels(unsigned int channelBitvector, unsigned int maxChannels,
                      CSAMPLE* pOutput, unsigned int iBufferSize, GainCalculator* pGainCalculator);
+
+
+    void removeChannelInfo(QList<ChannelInfo*>::iterator& dyingIt);
 
     QList<ChannelInfo*> m_channels;
 

--- a/mixxx/src/engine/enginemicrophone.cpp
+++ b/mixxx/src/engine/enginemicrophone.cpp
@@ -29,6 +29,7 @@ EngineMicrophone::~EngineMicrophone() {
 }
 
 bool EngineMicrophone::isActive() {
+    if (isDying()) { return false; }
     bool enabled = m_pEnabled->get() > 0.0;
     return enabled && !m_sampleBuffer.isEmpty();
 }
@@ -65,7 +66,7 @@ void EngineMicrophone::onInputDisconnected(AudioInput input) {
 }
 
 void EngineMicrophone::receiveBuffer(AudioInput input, const short* pBuffer, unsigned int iNumSamples) {
-
+    if (isDying()) return;
     if (input.getType() != AudioPath::MICROPHONE ||
         AudioInput::channelsNeededForType(input.getType()) != 1) {
         // This is an error!
@@ -106,6 +107,7 @@ void EngineMicrophone::receiveBuffer(AudioInput input, const short* pBuffer, uns
 
 void EngineMicrophone::process(const CSAMPLE* pInput, const CSAMPLE* pOutput, const int iBufferSize) {
     Q_UNUSED(pInput);
+    if (isDying()) return;
     CSAMPLE* pOut = const_cast<CSAMPLE*>(pOutput);
 
     // If talkover is enabled, then read into the output buffer. Otherwise, skip

--- a/mixxx/src/engine/enginepassthrough.cpp
+++ b/mixxx/src/engine/enginepassthrough.cpp
@@ -30,6 +30,7 @@ EnginePassthrough::~EnginePassthrough() {
 }
 
 bool EnginePassthrough::isActive() {
+    if (isDying()) { return false; }
     bool enabled = m_pEnabled->get() > 0.0;
     return enabled && !m_sampleBuffer.isEmpty();
 }
@@ -63,7 +64,7 @@ void EnginePassthrough::onInputDisconnected(AudioInput input) {
 }
 
 void EnginePassthrough::receiveBuffer(AudioInput input, const short* pBuffer, unsigned int nFrames) {
-
+    if (isDying()) return;
     if (input.getType() != AudioPath::EXTPASSTHROUGH) {
         // This is an error!
         qDebug() << "WARNING: EnginePassthrough receieved an AudioInput for a non-passthrough type!";
@@ -96,6 +97,7 @@ void EnginePassthrough::receiveBuffer(AudioInput input, const short* pBuffer, un
 }
 
 void EnginePassthrough::process(const CSAMPLE* pInput, const CSAMPLE* pOutput, const int iBufferSize) {
+    if (isDying()) return;
     CSAMPLE* pOut = const_cast<CSAMPLE*>(pOutput);
     Q_UNUSED(pInput);
 

--- a/mixxx/src/engine/enginepregain.cpp
+++ b/mixxx/src/engine/enginepregain.cpp
@@ -48,6 +48,7 @@ EnginePregain::EnginePregain(const char * group)
 
 EnginePregain::~EnginePregain()
 {
+    qDebug() << "DELETED PREGAIN";
     delete potmeterPregain;
     delete m_pControlReplayGain;
     delete m_pTotalGain;

--- a/mixxx/src/mixxx.cpp
+++ b/mixxx/src/mixxx.cpp
@@ -638,10 +638,9 @@ MixxxApp::~MixxxApp()
     ControlObject::getControls(&leakedControls);
 
     if (leakedControls.size() > 0) {
-        qDebug() << "WARNING: The following" << leakedControls.size() << "controls were leaked:";
+        qDebug() << "WARNING: " << leakedControls.size() << "controls were leaked";
         foreach (ControlObject* pControl, leakedControls) {
             ConfigKey key = pControl->getKey();
-            qDebug() << key.group << key.item;
             leakedConfigKeys.append(key);
         }
 

--- a/mixxx/src/playermanager.h
+++ b/mixxx/src/playermanager.h
@@ -106,11 +106,17 @@ class PlayerManager : public QObject {
   signals:
     void loadLocationToPlayer(QString location, QString group);
 
+  private slots:
+    void slotDeckRemoved(QString group);
+
   private:
     TrackPointer lookupTrack(QString location);
     // Must hold m_mutex before calling this method. Internal method that
     // creates a new deck.
     void addDeckInner();
+    // Must hold m_mutex before calling this method. Internal method that
+    // removes decks give by count starting from the end.
+    void initiateRemoveDecks(int count);
     // Must hold m_mutex before calling this method. Internal method that
     // creates a new sampler.
     void addSamplerInner();

--- a/mixxx/src/soundmanager.cpp
+++ b/mixxx/src/soundmanager.cpp
@@ -576,9 +576,9 @@ void SoundManager::registerOutput(AudioOutput output, const AudioSource *src) {
 void SoundManager::unregisterOutput(AudioOutput output) {
     if (!m_registeredSources.contains(output)) {
         qDebug() << "WARNING: AudioOutput not registered, can't remove!";
-        return;
+    } else {
+        m_registeredSources.remove(output);
     }
-    m_registeredSources.remove(output);
 }
 
 void SoundManager::registerInput(AudioInput input, AudioDestination *dest) {
@@ -590,9 +590,9 @@ void SoundManager::registerInput(AudioInput input, AudioDestination *dest) {
 void SoundManager::unregisterInput(AudioInput input, AudioDestination *dest) {
     if (!m_registeredDestinations.contains(input, dest)) {
         qDebug() << "WARNING: AudioInput not registered, can't remove!";
-        return;
+    } else {
+        m_registeredDestinations.remove(input, dest);
     }
-    m_registeredDestinations.remove(input, dest);
 }
 
 QList<AudioOutput> SoundManager::registeredOutputs() const {

--- a/mixxx/src/soundmanager.cpp
+++ b/mixxx/src/soundmanager.cpp
@@ -573,16 +573,26 @@ void SoundManager::registerOutput(AudioOutput output, const AudioSource *src) {
     emit(outputRegistered(output, src));
 }
 
-void SoundManager::registerInput(AudioInput input, AudioDestination *dest) {
-    if (m_registeredDestinations.contains(input)) {
-        // note that this can be totally ok if we just want a certain
-        // AudioInput to be going to a different AudioDest -bkgood
-        qDebug() << "WARNING: AudioInput already registered!";
+void SoundManager::unregisterOutput(AudioOutput output) {
+    if (!m_registeredSources.contains(output)) {
+        qDebug() << "WARNING: AudioOutput not registered, can't remove!";
+        return;
     }
+    m_registeredSources.remove(output);
+}
 
+void SoundManager::registerInput(AudioInput input, AudioDestination *dest) {
     m_registeredDestinations.insertMulti(input, dest);
 
     emit(inputRegistered(input, dest));
+}
+
+void SoundManager::unregisterInput(AudioInput input, AudioDestination *dest) {
+    if (!m_registeredDestinations.contains(input, dest)) {
+        qDebug() << "WARNING: AudioInput not registered, can't remove!";
+        return;
+    }
+    m_registeredDestinations.remove(input, dest);
 }
 
 QList<AudioOutput> SoundManager::registeredOutputs() const {

--- a/mixxx/src/soundmanager.h
+++ b/mixxx/src/soundmanager.h
@@ -97,6 +97,8 @@ class SoundManager : public QObject {
 
     void registerOutput(AudioOutput output, const AudioSource *src);
     void registerInput(AudioInput input, AudioDestination *dest);
+    void unregisterOutput(AudioOutput output);
+    void unregisterInput(AudioInput input, AudioDestination *dest);
     QList<AudioOutput> registeredOutputs() const;
     QList<AudioInput> registeredInputs() const;
 
@@ -126,7 +128,7 @@ class SoundManager : public QObject {
     SoundManagerConfig m_config;
     SoundDevice* m_pErrorDevice;
     QHash<AudioOutput, const AudioSource*> m_registeredSources;
-    QHash<AudioInput, AudioDestination*> m_registeredDestinations;
+    QMultiHash<AudioInput, AudioDestination*> m_registeredDestinations;
     ControlObject* m_pControlObjectSoundStatus;
     ControlObjectThreadMain* m_pControlObjectVinylControlGain;
 };


### PR DESCRIPTION
FYI: this doesn't work.

Trying to implement removal of Deck objects in a way that doesn't crash everything and carefully unhooks all of the complicated relationships.  Right now it works as far as going from 4 decks down to 2, but when I go back to 4, I can't play back tracks.  Any ideas about what's not being torn down / set up correctly welcome
