### PR TITLE
Rename the "Reload from Musicbrainz" option in the context menu and opti...

### DIFF
--- a/src/dlgtagfetcher.ui
+++ b/src/dlgtagfetcher.ui
@@ -135,7 +135,7 @@
            <item alignment="Qt::AlignHCenter">
             <widget class="QLabel" name="message1">
              <property name="text">
-              <string>Fetching track data from MusicBrainz</string>
+              <string>Fetching track data from the MusicBrainz database</string>
              </property>
             </widget>
            </item>
@@ -241,7 +241,7 @@
          <item alignment="Qt::AlignHCenter">
           <widget class="QLabel" name="label_7">
            <property name="styleSheet">
-            <string notr="true">font: 75 12pt &quot;Courier 10 Pitch&quot;;</string>
+            <string notr="true"/>
            </property>
            <property name="text">
             <string>Error</string>
@@ -379,7 +379,7 @@
          <item alignment="Qt::AlignHCenter">
           <widget class="QLabel" name="label_5">
            <property name="styleSheet">
-            <string notr="true">font: 75 12pt &quot;DejaVu Serif&quot;;</string>
+            <string notr="true"/>
            </property>
            <property name="text">
             <string>Error</string>
@@ -480,17 +480,17 @@
          <item alignment="Qt::AlignHCenter">
           <widget class="QLabel" name="label">
            <property name="styleSheet">
-            <string notr="true">font: 75 16pt &quot;DejaVu Serif&quot;;</string>
+            <string notr="true"/>
            </property>
            <property name="text">
-            <string>Sorry</string>
+            <string>Error</string>
            </property>
           </widget>
          </item>
          <item alignment="Qt::AlignHCenter">
           <widget class="QLabel" name="label_2">
            <property name="text">
-            <string>Mixxx could not find this song</string>
+            <string>Mixxx could not find this track in the MusicBrainz database</string>
            </property>
           </widget>
          </item>
@@ -533,7 +533,7 @@
            <item>
             <widget class="QPushButton" name="btnApikey">
              <property name="text">
-              <string>get API-Key</string>
+              <string comment="To be able to submit audio fingerprints to the MusicBrainz database, a free application programming interface key (API key) is required.">Get API-Key</string>
              </property>
             </widget>
            </item>
@@ -566,7 +566,7 @@
            <item>
             <widget class="QPushButton" name="btnSubmit">
              <property name="text">
-              <string>Submit</string>
+              <string comment="Submits audio fingerprints to the MusicBrainz database.">Submit</string>
              </property>
             </widget>
            </item>
@@ -635,14 +635,14 @@
       <item>
        <widget class="QPushButton" name="btnPrev">
         <property name="text">
-         <string>Prev</string>
+         <string>&amp;Previous</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QPushButton" name="btnNext">
         <property name="text">
-         <string>Next</string>
+         <string>&amp;Next</string>
         </property>
        </widget>
       </item>
@@ -662,14 +662,14 @@
       <item>
        <widget class="QPushButton" name="btnApply">
         <property name="text">
-         <string>Apply</string>
+         <string>&amp;Apply</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QPushButton" name="btnQuit">
         <property name="text">
-         <string>Close</string>
+         <string>&amp;Close</string>
         </property>
        </widget>
       </item>
@@ -678,6 +678,17 @@
    </layout>
   </widget>
  </widget>
+ <tabstops>
+  <tabstop>results</tabstop>
+  <tabstop>apikey</tabstop>
+  <tabstop>btnApikey</tabstop>
+  <tabstop>btnSubmit</tabstop>
+  <tabstop>submit_tree</tabstop>
+  <tabstop>btnPrev</tabstop>
+  <tabstop>btnNext</tabstop>
+  <tabstop>btnApply</tabstop>
+  <tabstop>btnQuit</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/dlgtrackinfo.ui
+++ b/src/dlgtrackinfo.ui
@@ -216,9 +216,9 @@
           </widget>
          </item>
          <item row="14" column="1" colspan="3">
-          <widget class="QPushButton" name="btnReloadFromFile">
+          <widget class="QPushButton" name="btnFetchTag">
            <property name="text">
-            <string>Reload track metadata from file.</string>
+            <string>Get track metadata from MusicBrainz</string>
            </property>
           </widget>
          </item>
@@ -279,9 +279,9 @@
           </widget>
          </item>
          <item row="13" column="1" colspan="3">
-          <widget class="QPushButton" name="btnFetchTag">
+          <widget class="QPushButton" name="btnReloadFromFile">
            <property name="text">
-            <string>Reload track metadata from musicBrainz</string>
+            <string>Reload track metadata from file</string>
            </property>
           </widget>
          </item>
@@ -637,8 +637,8 @@
   <tabstop>txtTrackNumber</tabstop>
   <tabstop>txtKey</tabstop>
   <tabstop>txtComment</tabstop>
-  <tabstop>btnFetchTag</tabstop>
   <tabstop>btnReloadFromFile</tabstop>
+  <tabstop>btnFetchTag</tabstop>
   <tabstop>btnPrev</tabstop>
   <tabstop>btnNext</tabstop>
   <tabstop>btnCancel</tabstop>

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -302,11 +302,11 @@ void WTrackTableView::createActions() {
     connect(m_pAutoDJTopAct, SIGNAL(triggered()),
             this, SLOT(slotSendToAutoDJTop()));
 
-    m_pReloadMetadataAct = new QAction(tr("Reload Track Metadata"), this);
+    m_pReloadMetadataAct = new QAction(tr("Reload Metadata from File"), this);
     connect(m_pReloadMetadataAct, SIGNAL(triggered()),
             this, SLOT(slotReloadTrackMetadata()));
 
-    m_pReloadMetadataFromMusicBrainzAct = new QAction(tr("Reload from Musicbrainz"),this);
+    m_pReloadMetadataFromMusicBrainzAct = new QAction(tr("Get Metadata from MusicBrainz"),this);
     connect(m_pReloadMetadataFromMusicBrainzAct, SIGNAL(triggered()),
             this, SLOT(slotShowDlgTagFetcher()));
 
@@ -732,6 +732,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
         m_pMenu->addAction(m_pReloadMetadataFromMusicBrainzAct);
     }
     // REMOVE and HIDE should not be at the first menu position to avoid accidental clicks
+    m_pMenu->addSeparator();
     if (modelHasCapabilities(TrackModel::TRACKMODELCAPS_REMOVE)) {
         m_pRemoveAct->setEnabled(!locked);
         m_pMenu->addAction(m_pRemoveAct);


### PR DESCRIPTION
...mize MB dialog, https://bugs.launchpad.net/mixxx/+bug/1184157
- Add separator in the context menu to group metadata related menu points
- Rename available options to "Reload Metadata from File" and "Get Metadata from MusicBrainz"
  Since all options in this menu are somehow related to a track, it was reasonable to drop the extra  "track" from 
  both menu points.
- In the MusicBrainz fetcher dialog:
  - Add descriptive Title to the dialog window
  - Add some translator comments
  - Change Song -> Track
  - Change button order to be like in the Tracks Properties dialog
  - Use Ampersands (&) for button text to quickly access that particular GUI element.
  - Fix tab order.
  - Removes styling for some text in error messages. We already have different styles in the preferences dialogs (which is bad and needs clean up), go with the system default instead.
- In the Tracks Properties dialog, metadata buttons are now in the same order like in the context menu. Also fix tab order.
