### PR TITLE
Micro optimize ControlObject::set() double vs double&

### DIFF
--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -85,23 +85,22 @@ void ControlDoublePrivate::reset() {
     set(defaultValue, NULL);
 }
 
-void ControlDoublePrivate::set(const double& value, QObject* pSender) {
+void ControlDoublePrivate::set(double value, QObject* pSender) {
     if (m_bIgnoreNops && get() == value) {
         return;
     }
 
-    double dValue = value;
     // If the behavior says to ignore the set, ignore it.
     ControlNumericBehavior* pBehavior = m_pBehavior;
-    if (pBehavior && !pBehavior->setFilter(&dValue)) {
+    if (pBehavior && !pBehavior->setFilter(&value)) {
         return;
     }
-    m_value.setValue(dValue);
-    emit(valueChanged(dValue, pSender));
+    m_value.setValue(value);
+    emit(valueChanged(value, pSender));
 
     if (m_bTrack) {
         Stat::track(m_trackKey, static_cast<Stat::StatType>(m_trackType),
-                    static_cast<Stat::ComputeFlags>(m_trackFlags), dValue);
+                    static_cast<Stat::ComputeFlags>(m_trackFlags), value);
     }
 }
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -32,7 +32,7 @@ class ControlDoublePrivate : public QObject {
     }
 
     // Sets the control value.
-    void set(const double& value, QObject* pSender);
+    void set(double value, QObject* pSender);
     // Gets the control value.
     double get() const;
     // Resets the control value to its default.

--- a/src/controlobject.cpp
+++ b/src/controlobject.cpp
@@ -147,7 +147,7 @@ void ControlObject::reset() {
     }
 }
 
-void ControlObject::set(const double& value) {
+void ControlObject::set(double value) {
     if (m_pControl) {
         m_pControl->set(value, this);
     }

--- a/src/controlobject.h
+++ b/src/controlobject.h
@@ -55,7 +55,7 @@ class ControlObject : public QObject {
     // Instantly returns the value of the ControlObject
     static double get(const ConfigKey& key);
     // Sets the ControlObject value
-    void set(const double& value);
+    void set(double value);
     // Instantly sets the value of the ControlObject
     static void set(const ConfigKey& key, const double& value);
     // Sets the default value


### PR DESCRIPTION
This version is faster on 64 bit machines anyway. On 32 bit targets this version benefits from compatible method parameters. Not proved, because asm code is not comparable due to inter-function optimization. Bud it should not be worse. 
see: https://github.com/mixxxdj/mixxx/pull/28/files#r4952818
