### PR TITLE
Added 'const' or '&' to arguments when needed.

### DIFF
--- a/src/library/cratefeature.cpp
+++ b/src/library/cratefeature.cpp
@@ -116,7 +116,7 @@ bool CrateFeature::dropAcceptChild(const QModelIndex& index, QList<QUrl> urls,
             trackIds.removeAt(trackId--);
         }
     }
-    m_crateDao.addTracksToCrate(trackIds, crateId);
+    m_crateDao.addTracksToCrate(crateId, &trackIds);
     return true;
 }
 

--- a/src/library/cratetablemodel.cpp
+++ b/src/library/cratetablemodel.cpp
@@ -106,8 +106,7 @@ int CrateTableModel::addTracks(const QModelIndex& index,
 
     QList<int> trackIDs = m_trackDAO.addTracks(fileInfoList, true);
 
-    int tracksAdded = m_crateDAO.addTracksToCrate(
-        trackIDs, m_iCrateId);
+    int tracksAdded = m_crateDAO.addTracksToCrate(m_iCrateId, &trackIDs);
     if (tracksAdded > 0) {
         select();
     }

--- a/src/library/dao/analysisdao.cpp
+++ b/src/library/dao/analysisdao.cpp
@@ -46,7 +46,7 @@ QList<AnalysisDao::AnalysisInfo> AnalysisDao::getAnalysesForTrack(const int trac
         "WHERE track_id=:trackId").arg(s_analysisTableName));
     query.bindValue(":trackId", trackId);
 
-    return loadAnalysesFromQuery(trackId, query);
+    return loadAnalysesFromQuery(trackId, &query);
 }
 
 QList<AnalysisDao::AnalysisInfo> AnalysisDao::getAnalysesForTrackByType(
@@ -62,32 +62,32 @@ QList<AnalysisDao::AnalysisInfo> AnalysisDao::getAnalysesForTrackByType(
     query.bindValue(":trackId", trackId);
     query.bindValue(":type", type);
 
-    return loadAnalysesFromQuery(trackId, query);
+    return loadAnalysesFromQuery(trackId, &query);
 }
 
-QList<AnalysisDao::AnalysisInfo> AnalysisDao::loadAnalysesFromQuery(const int trackId, QSqlQuery& query) {
+QList<AnalysisDao::AnalysisInfo> AnalysisDao::loadAnalysesFromQuery(const int trackId, QSqlQuery* query) {
     QList<AnalysisDao::AnalysisInfo> analyses;
     QTime time;
     time.start();
 
-    if (!query.exec()) {
-        LOG_FAILED_QUERY(query) << "couldn't get analyses for track" << trackId;
+    if (!query->exec()) {
+        LOG_FAILED_QUERY(*query) << "couldn't get analyses for track" << trackId;
         return analyses;
     }
 
     int bytes = 0;
-    while (query.next()) {
+    while (query->next()) {
         AnalysisDao::AnalysisInfo info;
-        info.analysisId = query.value(query.record().indexOf("id")).toInt();
+        info.analysisId = query->value(query->record().indexOf("id")).toInt();
         info.trackId = trackId;
         info.type = static_cast<AnalysisType>(
-            query.value(query.record().indexOf("type")).toInt());
-        info.description = query.value(
-            query.record().indexOf("description")).toString();
-        info.version = query.value(
-            query.record().indexOf("version")).toString();
-        int checksum = query.value(
-            query.record().indexOf("data_checksum")).toInt();
+            query->value(query->record().indexOf("type")).toInt());
+        info.description = query->value(
+            query->record().indexOf("description")).toString();
+        info.version = query->value(
+            query->record().indexOf("version")).toString();
+        int checksum = query->value(
+            query->record().indexOf("data_checksum")).toInt();
         QString dataPath = getAnalysisStoragePath().absoluteFilePath(
             QString::number(info.analysisId));
         QByteArray compressedData = loadDataFromFile(dataPath);

--- a/src/library/dao/analysisdao.cpp
+++ b/src/library/dao/analysisdao.cpp
@@ -35,7 +35,7 @@ void AnalysisDao::setDatabase(QSqlDatabase& database) {
     m_db = database;
 }
 
-QList<AnalysisDao::AnalysisInfo> AnalysisDao::getAnalysesForTrack(int trackId) {
+QList<AnalysisDao::AnalysisInfo> AnalysisDao::getAnalysesForTrack(const int trackId) {
     if (!m_db.isOpen() || trackId == -1) {
         return QList<AnalysisInfo>();
     }
@@ -50,7 +50,7 @@ QList<AnalysisDao::AnalysisInfo> AnalysisDao::getAnalysesForTrack(int trackId) {
 }
 
 QList<AnalysisDao::AnalysisInfo> AnalysisDao::getAnalysesForTrackByType(
-    int trackId, AnalysisType type) {
+    const int trackId, AnalysisType type) {
     if (!m_db.isOpen() || trackId == -1) {
         return QList<AnalysisInfo>();
     }
@@ -65,7 +65,7 @@ QList<AnalysisDao::AnalysisInfo> AnalysisDao::getAnalysesForTrackByType(
     return loadAnalysesFromQuery(trackId, query);
 }
 
-QList<AnalysisDao::AnalysisInfo> AnalysisDao::loadAnalysesFromQuery(int trackId, QSqlQuery& query) {
+QList<AnalysisDao::AnalysisInfo> AnalysisDao::loadAnalysesFromQuery(const int trackId, QSqlQuery& query) {
     QList<AnalysisDao::AnalysisInfo> analyses;
     QTime time;
     time.start();
@@ -181,7 +181,7 @@ bool AnalysisDao::saveAnalysis(AnalysisDao::AnalysisInfo* info) {
     return true;
 }
 
-bool AnalysisDao::deleteAnalysis(int analysisId) {
+bool AnalysisDao::deleteAnalysis(const int analysisId) {
     if (analysisId == -1) {
         return false;
     }
@@ -201,7 +201,7 @@ bool AnalysisDao::deleteAnalysis(int analysisId) {
     return true;
 }
 
-void AnalysisDao::deleteAnalysises(QList<int> ids) {
+void AnalysisDao::deleteAnalysises(const QList<int>& ids) {
     QStringList idList;
     foreach (int id, ids) {
         idList << QString::number(id);
@@ -226,7 +226,7 @@ void AnalysisDao::deleteAnalysises(QList<int> ids) {
     }
 }
 
-bool AnalysisDao::deleteAnalysesForTrack(int trackId) {
+bool AnalysisDao::deleteAnalysesForTrack(const int trackId) {
     if (trackId == -1) {
         return false;
     }
@@ -257,7 +257,7 @@ QDir AnalysisDao::getAnalysisStoragePath() const {
     return dir.absolutePath().append("/");
 }
 
-QByteArray AnalysisDao::loadDataFromFile(QString filename) const {
+QByteArray AnalysisDao::loadDataFromFile(const QString& filename) const {
     QFile file(filename);
     if (!file.exists()) {
         return QByteArray();
@@ -268,12 +268,12 @@ QByteArray AnalysisDao::loadDataFromFile(QString filename) const {
     return file.readAll();
 }
 
-bool AnalysisDao::deleteFile(QString fileName) const {
+bool AnalysisDao::deleteFile(const QString& fileName) const {
     QFile file(fileName);
     return file.remove();
 }
 
-bool AnalysisDao::saveDataToFile(QString fileName, QByteArray data) const {
+bool AnalysisDao::saveDataToFile(const QString& fileName, QByteArray& data) const {
     QFile file(fileName);
 
     // If the file exists, do the right thing. Write to a temp file, unlink the

--- a/src/library/dao/analysisdao.cpp
+++ b/src/library/dao/analysisdao.cpp
@@ -273,7 +273,7 @@ bool AnalysisDao::deleteFile(const QString& fileName) const {
     return file.remove();
 }
 
-bool AnalysisDao::saveDataToFile(const QString& fileName, QByteArray& data) const {
+bool AnalysisDao::saveDataToFile(const QString& fileName, const QByteArray& data) const {
     QFile file(fileName);
 
     // If the file exists, do the right thing. Write to a temp file, unlink the

--- a/src/library/dao/analysisdao.h
+++ b/src/library/dao/analysisdao.h
@@ -59,7 +59,7 @@ class AnalysisDao : public DAO {
                       Waveform* waveform, AnalysisType type);
     QDir getAnalysisStoragePath() const;
     QByteArray loadDataFromFile(const QString& fileName) const;
-    bool saveDataToFile(const QString& fileName, QByteArray& data) const;
+    bool saveDataToFile(const QString& fileName, const QByteArray& data) const;
     bool deleteFile(const QString& filename) const;
     QList<AnalysisInfo> loadAnalysesFromQuery(const int trackId, QSqlQuery& query);
 

--- a/src/library/dao/analysisdao.h
+++ b/src/library/dao/analysisdao.h
@@ -42,12 +42,12 @@ class AnalysisDao : public DAO {
     bool saveWaveform(const TrackInfoObject& tio);
     bool removeWaveform(const TrackInfoObject& tio);
 
-    QList<AnalysisInfo> getAnalysesForTrackByType(int trackId, AnalysisType type);
-    QList<AnalysisInfo> getAnalysesForTrack(int trackId);
+    QList<AnalysisInfo> getAnalysesForTrackByType(const int trackId, AnalysisType type);
+    QList<AnalysisInfo> getAnalysesForTrack(const int trackId);
     bool saveAnalysis(AnalysisInfo* analysis);
-    bool deleteAnalysis(int analysisId);
-    void deleteAnalysises(QList<int> ids);
-    bool deleteAnalysesForTrack(int trackId);
+    bool deleteAnalysis(const int analysisId);
+    void deleteAnalysises(const QList<int>& ids);
+    bool deleteAnalysesForTrack(const int trackId);
 
     void saveTrackAnalyses(TrackInfoObject* pTrack);
 
@@ -58,10 +58,10 @@ class AnalysisDao : public DAO {
     bool loadWaveform(const TrackInfoObject& tio,
                       Waveform* waveform, AnalysisType type);
     QDir getAnalysisStoragePath() const;
-    QByteArray loadDataFromFile(QString fileName) const;
-    bool saveDataToFile(QString fileName, QByteArray data) const;
-    bool deleteFile(QString filename) const;
-    QList<AnalysisInfo> loadAnalysesFromQuery(int trackId, QSqlQuery& query);
+    QByteArray loadDataFromFile(const QString& fileName) const;
+    bool saveDataToFile(const QString& fileName, QByteArray& data) const;
+    bool deleteFile(const QString& filename) const;
+    QList<AnalysisInfo> loadAnalysesFromQuery(const int trackId, QSqlQuery& query);
 
     ConfigObject<ConfigValue>* m_pConfig;
     QSqlDatabase m_db;

--- a/src/library/dao/analysisdao.h
+++ b/src/library/dao/analysisdao.h
@@ -61,7 +61,7 @@ class AnalysisDao : public DAO {
     QByteArray loadDataFromFile(const QString& fileName) const;
     bool saveDataToFile(const QString& fileName, const QByteArray& data) const;
     bool deleteFile(const QString& filename) const;
-    QList<AnalysisInfo> loadAnalysesFromQuery(const int trackId, QSqlQuery& query);
+    QList<AnalysisInfo> loadAnalysesFromQuery(const int trackId, QSqlQuery* query);
 
     ConfigObject<ConfigValue>* m_pConfig;
     QSqlDatabase m_db;

--- a/src/library/dao/cratedao.cpp
+++ b/src/library/dao/cratedao.cpp
@@ -46,7 +46,7 @@ int CrateDAO::createCrate(const QString& name) {
     return crateId;
 }
 
-bool CrateDAO::renameCrate(int crateId, const QString& newName) {
+bool CrateDAO::renameCrate(const int crateId, const QString& newName) {
     QSqlQuery query(m_database);
     query.prepare("UPDATE " CRATE_TABLE " SET name = :name WHERE id = :id");
     query.bindValue(":name", newName);
@@ -60,7 +60,7 @@ bool CrateDAO::renameCrate(int crateId, const QString& newName) {
     return true;
 }
 
-bool CrateDAO::setCrateLocked(int crateId, bool locked) {
+bool CrateDAO::setCrateLocked(const int crateId, const bool locked) {
     // SQLite3 doesn't support boolean value. Using integer instead.
     int lock = locked ? 1 : 0;
     QSqlQuery query(m_database);
@@ -76,7 +76,7 @@ bool CrateDAO::setCrateLocked(int crateId, bool locked) {
     return true;
 }
 
-bool CrateDAO::isCrateLocked(int crateId) {
+bool CrateDAO::isCrateLocked(const int crateId) {
     QSqlQuery query(m_database);
     query.prepare("SELECT locked FROM " CRATE_TABLE " WHERE id = :id");
     query.bindValue(":id", crateId);
@@ -93,7 +93,7 @@ bool CrateDAO::isCrateLocked(int crateId) {
     return false;
 }
 
-bool CrateDAO::deleteCrate(int crateId) {
+bool CrateDAO::deleteCrate(const int crateId) {
     ScopedTransaction transaction(m_database);
     QSqlQuery query(m_database);
     query.prepare("DELETE FROM " CRATE_TRACKS_TABLE " WHERE crate_id = :id");
@@ -132,7 +132,7 @@ int CrateDAO::getCrateIdByName(const QString& name) {
     return -1;
 }
 
-int CrateDAO::getCrateId(int position) {
+int CrateDAO::getCrateId(const int position) {
     QSqlQuery query(m_database);
     query.prepare("SELECT id FROM " CRATE_TABLE);
     if (query.exec()) {
@@ -149,7 +149,7 @@ int CrateDAO::getCrateId(int position) {
     return -1;
 }
 
-QString CrateDAO::crateName(int crateId) {
+QString CrateDAO::crateName(const int crateId) {
     QSqlQuery query(m_database);
     query.prepare("SELECT name FROM " CRATE_TABLE " WHERE id = (:id)");
     query.bindValue(":id", crateId);
@@ -163,7 +163,7 @@ QString CrateDAO::crateName(int crateId) {
     return QString();
 }
 
-unsigned int CrateDAO::crateSize(int crateId) {
+unsigned int CrateDAO::crateSize(const int crateId) {
     QSqlQuery query(m_database);
     query.prepare("SELECT COUNT(*) FROM " CRATE_TRACKS_TABLE " WHERE crate_id = (:id)");
     query.bindValue(":id", crateId);
@@ -177,7 +177,7 @@ unsigned int CrateDAO::crateSize(int crateId) {
     return 0;
 }
 
-void CrateDAO::copyCrateTracks(int sourceCrateId, int targetCrateId) {
+void CrateDAO::copyCrateTracks(const int sourceCrateId, const int targetCrateId) {
     // Query Tracks from the source Playlist
     QSqlQuery query(m_database);
     query.prepare("SELECT track_id FROM crate_tracks "
@@ -196,7 +196,7 @@ void CrateDAO::copyCrateTracks(int sourceCrateId, int targetCrateId) {
     addTracksToCrate(trackIds, targetCrateId);
 }
 
-bool CrateDAO::addTrackToCrate(int trackId, int crateId) {
+bool CrateDAO::addTrackToCrate(const int trackId, const int crateId) {
     QSqlQuery query(m_database);
     query.prepare("INSERT INTO " CRATE_TRACKS_TABLE
                   " (crate_id, track_id) VALUES (:crate_id, :track_id)");
@@ -216,7 +216,7 @@ bool CrateDAO::addTrackToCrate(int trackId, int crateId) {
 }
 
 
-int CrateDAO::addTracksToCrate(QList<int> trackIdList, int crateId) {
+int CrateDAO::addTracksToCrate(QList<int>& trackIdList, const int crateId) {
     ScopedTransaction transaction(m_database);
     QSqlQuery query(m_database);
     query.prepare("INSERT INTO " CRATE_TRACKS_TABLE " (crate_id, track_id) VALUES (:crate_id, :track_id)");
@@ -245,7 +245,7 @@ int CrateDAO::addTracksToCrate(QList<int> trackIdList, int crateId) {
     return trackIdList.size();
 }
 
-bool CrateDAO::removeTrackFromCrate(int trackId, int crateId) {
+bool CrateDAO::removeTrackFromCrate(const int trackId, const int crateId) {
     QSqlQuery query(m_database);
     query.prepare("DELETE FROM " CRATE_TRACKS_TABLE " WHERE "
                   "crate_id = :crate_id AND track_id = :track_id");
@@ -262,7 +262,7 @@ bool CrateDAO::removeTrackFromCrate(int trackId, int crateId) {
     return true;
 }
 
-bool CrateDAO::removeTracksFromCrate(QList<int> ids, int crateId) {
+bool CrateDAO::removeTracksFromCrate(const QList<int>& ids, const int crateId) {
     QStringList idList;
     foreach (int id, ids) {
         idList << QString::number(id);
@@ -284,7 +284,7 @@ bool CrateDAO::removeTracksFromCrate(QList<int> ids, int crateId) {
     return true;
 }
 
-void CrateDAO::removeTracksFromCrates(QList<int> ids) {
+void CrateDAO::removeTracksFromCrates(const QList<int>& ids) {
     QStringList idList;
     foreach (int id, ids) {
         idList << QString::number(id);

--- a/src/library/dao/cratedao.h
+++ b/src/library/dao/cratedao.h
@@ -29,23 +29,23 @@ class CrateDAO : public QObject, public virtual DAO {
 
     unsigned int crateCount();
     int createCrate(const QString& name);
-    bool deleteCrate(int crateId);
-    bool renameCrate(int crateId, const QString& newName);
-    bool setCrateLocked(int crateId, bool locked);
-    bool isCrateLocked(int crateId);
+    bool deleteCrate(const int crateId);
+    bool renameCrate(const int crateId, const QString& newName);
+    bool setCrateLocked(const int crateId, const bool locked);
+    bool isCrateLocked(const int crateId);
     int getCrateIdByName(const QString& name);
-    int getCrateId(int position);
-    QString crateName(int crateId);
-    unsigned int crateSize(int crateId);
-    bool addTrackToCrate(int trackId, int crateId);
+    int getCrateId(const int position);
+    QString crateName(const int crateId);
+    unsigned int crateSize(const int crateId);
+    bool addTrackToCrate(const int trackId, const int crateId);
     // This method takes a list of track ids to be added to crate and returns
     // the number of successful insertions.
-    int addTracksToCrate(QList<int> trackIdList, int crateId);
-    void copyCrateTracks(int sourceCrateId, int tragetCrateId);
-    bool removeTrackFromCrate(int trackId, int crateId);
-    bool removeTracksFromCrate(QList<int> ids, int crateId);
+    int addTracksToCrate(QList<int>& trackIdList, const int crateId);
+    void copyCrateTracks(const int sourceCrateId, const int tragetCrateId);
+    bool removeTrackFromCrate(const int trackId, const int crateId);
+    bool removeTracksFromCrate(const QList<int>& ids, const int crateId);
     // remove tracks from all crates
-    void removeTracksFromCrates(QList<int> ids);
+    void removeTracksFromCrates(const QList<int>& ids);
 
   signals:
     void added(int crateId);

--- a/src/library/dao/cratedao.h
+++ b/src/library/dao/cratedao.h
@@ -40,7 +40,7 @@ class CrateDAO : public QObject, public virtual DAO {
     bool addTrackToCrate(const int trackId, const int crateId);
     // This method takes a list of track ids to be added to crate and returns
     // the number of successful insertions.
-    int addTracksToCrate(QList<int>& trackIdList, const int crateId);
+    int addTracksToCrate(const int crateId, QList<int>* trackIdList);
     void copyCrateTracks(const int sourceCrateId, const int tragetCrateId);
     bool removeTrackFromCrate(const int trackId, const int crateId);
     bool removeTracksFromCrate(const QList<int>& ids, const int crateId);

--- a/src/library/dao/cuedao.cpp
+++ b/src/library/dao/cuedao.cpp
@@ -36,7 +36,7 @@ int CueDAO::cueCount() {
     return 0;
 }
 
-int CueDAO::numCuesForTrack(int trackId) {
+int CueDAO::numCuesForTrack(const int trackId) {
     qDebug() << "CueDAO::numCuesForTrack" << QThread::currentThread() << m_database.connectionName();
     QSqlQuery query(m_database);
     query.prepare("SELECT COUNT(*) FROM " CUE_TABLE " WHERE track_id = :id");
@@ -51,7 +51,7 @@ int CueDAO::numCuesForTrack(int trackId) {
     return 0;
 }
 
-Cue* CueDAO::cueFromRow(QSqlQuery& query) const {
+Cue* CueDAO::cueFromRow(const QSqlQuery& query) const {
     QSqlRecord record = query.record();
     int id = record.value(record.indexOf("id")).toInt();
     int trackId = record.value(record.indexOf("track_id")).toInt();
@@ -66,7 +66,7 @@ Cue* CueDAO::cueFromRow(QSqlQuery& query) const {
     return cue;
 }
 
-Cue* CueDAO::getCue(int cueId) {
+Cue* CueDAO::getCue(const int cueId) {
     qDebug() << "CueDAO::getCue" << QThread::currentThread() << m_database.connectionName();
     if (m_cues.contains(cueId)) {
         return m_cues[cueId];
@@ -85,7 +85,7 @@ Cue* CueDAO::getCue(int cueId) {
     return NULL;
 }
 
-QList<Cue*> CueDAO::getCuesForTrack(int trackId) const {
+QList<Cue*> CueDAO::getCuesForTrack(const int trackId) const {
     //qDebug() << "CueDAO::getCuesForTrack" << QThread::currentThread() << m_database.connectionName();
     QList<Cue*> cues;
     QSqlQuery query(m_database);
@@ -111,7 +111,7 @@ QList<Cue*> CueDAO::getCuesForTrack(int trackId) const {
     return cues;
 }
 
-bool CueDAO::deleteCuesForTrack(int trackId) {
+bool CueDAO::deleteCuesForTrack(const int trackId) {
     qDebug() << "CueDAO::deleteCuesForTrack" << QThread::currentThread() << m_database.connectionName();
     QSqlQuery query(m_database);
     query.prepare("DELETE FROM " CUE_TABLE " WHERE track_id = :track_id");
@@ -124,7 +124,7 @@ bool CueDAO::deleteCuesForTrack(int trackId) {
     return false;
 }
 
-bool CueDAO::deleteCuesForTracks(QList<int> ids) {
+bool CueDAO::deleteCuesForTracks(const QList<int>& ids) {
     qDebug() << "CueDAO::deleteCuesForTracks" << QThread::currentThread() << m_database.connectionName();
 
     QStringList idList;
@@ -210,7 +210,7 @@ bool CueDAO::deleteCue(Cue* cue) {
     return false;
 }
 
-void CueDAO::saveTrackCues(int trackId, TrackInfoObject* pTrack) {
+void CueDAO::saveTrackCues(const int trackId, TrackInfoObject* pTrack) {
     //qDebug() << "CueDAO::saveTrackCues" << QThread::currentThread() << m_database.connectionName();
     // TODO(XXX) transaction, but people who are already in a transaction call
     // this.

--- a/src/library/dao/cuedao.h
+++ b/src/library/dao/cuedao.h
@@ -22,18 +22,18 @@ class CueDAO : public DAO {
 
     void initialize();
     int cueCount();
-    int numCuesForTrack(int trackId);
-    Cue* getCue(int cueId);
-    QList<Cue*> getCuesForTrack(int trackId) const;
-    bool deleteCuesForTrack(int trackId);
-    bool deleteCuesForTracks(QList<int> ids);
+    int numCuesForTrack(const int trackId);
+    Cue* getCue(const int cueId);
+    QList<Cue*> getCuesForTrack(const int trackId) const;
+    bool deleteCuesForTrack(const int trackId);
+    bool deleteCuesForTracks(const QList<int>& ids);
     bool saveCue(Cue* cue);
     bool deleteCue(Cue* cue);
     // TODO(XXX) once we refer to all tracks by their id and TIO has a getId()
     // method the first parameter here won't be necessary.
-    void saveTrackCues(int trackId, TrackInfoObject*);
+    void saveTrackCues(const int trackId, TrackInfoObject*);
   private:
-    Cue* cueFromRow(QSqlQuery& query) const;
+    Cue* cueFromRow(const QSqlQuery& query) const;
 
     QSqlDatabase& m_database;
     mutable QMap<int, Cue*> m_cues;

--- a/src/library/dao/libraryhashdao.cpp
+++ b/src/library/dao/libraryhashdao.cpp
@@ -17,13 +17,11 @@ LibraryHashDAO::~LibraryHashDAO()
 {
 }
 
-void LibraryHashDAO::initialize()
-{
+void LibraryHashDAO::initialize() {
     qDebug() << "LibraryHashDAO::initialize" << QThread::currentThread() << m_database.connectionName();
 }
 
-int LibraryHashDAO::getDirectoryHash(QString dirPath)
-{
+int LibraryHashDAO::getDirectoryHash(const QString& dirPath) {
     //qDebug() << "LibraryHashDAO::getDirectoryHash" << QThread::currentThread() << m_database.connectionName();
     int hash = -1;
 
@@ -47,8 +45,7 @@ int LibraryHashDAO::getDirectoryHash(QString dirPath)
     return hash;
 }
 
-void LibraryHashDAO::saveDirectoryHash(QString dirPath, int hash)
-{
+void LibraryHashDAO::saveDirectoryHash(const QString& dirPath, const int hash) {
     //qDebug() << "LibraryHashDAO::saveDirectoryHash" << QThread::currentThread() << m_database.connectionName();
     QSqlQuery query(m_database);
     query.prepare("INSERT INTO LibraryHashes (directory_path, hash, directory_deleted) "
@@ -64,8 +61,7 @@ void LibraryHashDAO::saveDirectoryHash(QString dirPath, int hash)
     //qDebug() << "created new hash" << hash;
 }
 
-void LibraryHashDAO::updateDirectoryHash(QString dirPath, int newHash, int dir_deleted)
-{
+void LibraryHashDAO::updateDirectoryHash(const QString& dirPath, const int newHash, const int dir_deleted) {
     //qDebug() << "LibraryHashDAO::updateDirectoryHash" << QThread::currentThread() << m_database.connectionName();
     QSqlQuery query(m_database);
     query.prepare("UPDATE LibraryHashes "
@@ -84,7 +80,7 @@ void LibraryHashDAO::updateDirectoryHash(QString dirPath, int newHash, int dir_d
     //qDebug() << getDirectoryHash(dirPath);
 }
 
-void LibraryHashDAO::updateDirectoryStatuses(QStringList dirPaths, bool deleted, bool verified) {
+void LibraryHashDAO::updateDirectoryStatuses(QStringList dirPaths, const bool deleted, const bool verified) {
     //qDebug() << "LibraryHashDAO::updateDirectoryStatus" << QThread::currentThread() << m_database.connectionName();
     FieldEscaper escaper(m_database);
     QMutableStringListIterator it(dirPaths);
@@ -106,8 +102,7 @@ void LibraryHashDAO::updateDirectoryStatuses(QStringList dirPaths, bool deleted,
     }
 }
 
-void LibraryHashDAO::markAsExisting(QString dirPath)
-{
+void LibraryHashDAO::markAsExisting(const QString& dirPath) {
     //qDebug() << "LibraryHashDAO::markExisting" << QThread::currentThread() << m_database.connectionName();
     QSqlQuery query(m_database);
     query.prepare("UPDATE LibraryHashes "
@@ -120,8 +115,7 @@ void LibraryHashDAO::markAsExisting(QString dirPath)
     }
 }
 
-void LibraryHashDAO::markAsVerified(QString dirPath)
-{
+void LibraryHashDAO::markAsVerified(const QString& dirPath) {
     //qDebug() << "LibraryHashDAO::markExisting" << QThread::currentThread() << m_database.connectionName();
     QSqlQuery query(m_database);
     query.prepare("UPDATE LibraryHashes "

--- a/src/library/dao/libraryhashdao.h
+++ b/src/library/dao/libraryhashdao.h
@@ -12,16 +12,16 @@ class LibraryHashDAO : public DAO {
     void setDatabase(QSqlDatabase& database) { m_database = database; };
 
     void initialize();
-    int getDirectoryHash(QString dirPath);
-    void saveDirectoryHash(QString dirPath, int hash);
-    void updateDirectoryHash(QString dirPath, int newHash, int dir_deleted);
-    void markAsExisting(QString dirPath);
-    void markAsVerified(QString dirPath);
+    int getDirectoryHash(const QString& dirPath);
+    void saveDirectoryHash(const QString& dirPath, const int hash);
+    void updateDirectoryHash(const QString& dirPath, const int newHash, const int dir_deleted);
+    void markAsExisting(const QString& dirPath);
+    void markAsVerified(const QString& dirPath);
     //void markAllDirectoriesAsDeleted();
     void invalidateAllDirectories();
     void markUnverifiedDirectoriesAsDeleted();
     void removeDeletedDirectoryHashes();
-    void updateDirectoryStatuses(QStringList dirPaths, bool deleted, bool verified);
+    void updateDirectoryStatuses(QStringList dirPaths, const bool deleted, const bool verified);
   private:
     QSqlDatabase &m_database;
 

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -19,7 +19,7 @@ void PlaylistDAO::initialize()
 {
 }
 
-int PlaylistDAO::createPlaylist(QString name, HiddenType hidden)
+int PlaylistDAO::createPlaylist(const QString& name, HiddenType hidden)
 {
     // qDebug() << "PlaylistDAO::createPlaylist"
     //          << QThread::currentThread()
@@ -64,7 +64,7 @@ int PlaylistDAO::createPlaylist(QString name, HiddenType hidden)
     return playlistId;
 }
 
-QString PlaylistDAO::getPlaylistName(int playlistId)
+QString PlaylistDAO::getPlaylistName(const int playlistId)
 {
     // qDebug() << "PlaylistDAO::getPlaylistName" << QThread::currentThread() << m_database.connectionName();
 
@@ -86,7 +86,7 @@ QString PlaylistDAO::getPlaylistName(int playlistId)
     return name;
 }
 
-int PlaylistDAO::getPlaylistIdFromName(QString name) {
+int PlaylistDAO::getPlaylistIdFromName(const QString& name) {
     // qDebug() << "PlaylistDAO::getPlaylistIdFromName" << QThread::currentThread() << m_database.connectionName();
 
     QSqlQuery query(m_database);
@@ -102,7 +102,7 @@ int PlaylistDAO::getPlaylistIdFromName(QString name) {
     return -1;
 }
 
-void PlaylistDAO::deletePlaylist(int playlistId)
+void PlaylistDAO::deletePlaylist(const int playlistId)
 {
     // qDebug() << "PlaylistDAO::deletePlaylist" << QThread::currentThread() << m_database.connectionName();
     ScopedTransaction transaction(m_database);
@@ -134,7 +134,7 @@ void PlaylistDAO::deletePlaylist(int playlistId)
     emit(deleted(playlistId));
 }
 
-void PlaylistDAO::renamePlaylist(int playlistId, const QString& newName) {
+void PlaylistDAO::renamePlaylist(const int playlistId, const QString& newName) {
     QSqlQuery query(m_database);
     query.prepare("UPDATE Playlists SET name = :name WHERE id = :id");
     query.bindValue(":name", newName);
@@ -146,11 +146,12 @@ void PlaylistDAO::renamePlaylist(int playlistId, const QString& newName) {
     emit(renamed(playlistId));
 }
 
-bool PlaylistDAO::setPlaylistLocked(int playlistId, bool locked) {
+bool PlaylistDAO::setPlaylistLocked(const int playlistId, const bool locked) {
     QSqlQuery query(m_database);
     query.prepare("UPDATE Playlists SET locked = :lock WHERE id = :id");
     // SQLite3 doesn't support boolean value. Using integer instead.
-    query.bindValue(":lock", static_cast<int>(locked));
+    int lock = locked ? 1 : 0;
+    query.bindValue(":lock", lock);
     query.bindValue(":id", playlistId);
 
     if (!query.exec()) {
@@ -161,7 +162,7 @@ bool PlaylistDAO::setPlaylistLocked(int playlistId, bool locked) {
     return true;
 }
 
-bool PlaylistDAO::isPlaylistLocked(int playlistId) {
+bool PlaylistDAO::isPlaylistLocked(const int playlistId) {
     QSqlQuery query(m_database);
     query.prepare("SELECT locked FROM Playlists WHERE id = :id");
     query.bindValue(":id", playlistId);
@@ -177,7 +178,7 @@ bool PlaylistDAO::isPlaylistLocked(int playlistId) {
     return false;
 }
 
-bool PlaylistDAO::appendTracksToPlaylist(QList<int> trackIds, int playlistId) {
+bool PlaylistDAO::appendTracksToPlaylist(const QList<int>& trackIds, const int playlistId) {
     // qDebug() << "PlaylistDAO::appendTracksToPlaylist"
     //          << QThread::currentThread() << m_database.connectionName();
 
@@ -219,7 +220,7 @@ bool PlaylistDAO::appendTracksToPlaylist(QList<int> trackIds, int playlistId) {
     return true;
 }
 
-bool PlaylistDAO::appendTrackToPlaylist(int trackId, int playlistId) {
+bool PlaylistDAO::appendTrackToPlaylist(const int trackId, const int playlistId) {
     QList<int> tracks;
     tracks.append(trackId);
     return appendTracksToPlaylist(tracks, playlistId);
@@ -242,7 +243,7 @@ unsigned int PlaylistDAO::playlistCount()
     return numRecords;
 }
 
-int PlaylistDAO::getPlaylistId(int index)
+int PlaylistDAO::getPlaylistId(const int index)
 {
     // qDebug() << "PlaylistDAO::getPlaylistId"
     //          << QThread::currentThread() << m_database.connectionName();
@@ -265,7 +266,7 @@ int PlaylistDAO::getPlaylistId(int index)
     return -1;
 }
 
-PlaylistDAO::HiddenType PlaylistDAO::getHiddenType(int playlistId) {
+PlaylistDAO::HiddenType PlaylistDAO::getHiddenType(const int playlistId) {
     // qDebug() << "PlaylistDAO::getHiddenType"
     //          << QThread::currentThread() << m_database.connectionName();
 
@@ -285,7 +286,7 @@ PlaylistDAO::HiddenType PlaylistDAO::getHiddenType(int playlistId) {
     return PLHT_UNKNOWN;
 }
 
-bool PlaylistDAO::isHidden(int playlistId) {
+bool PlaylistDAO::isHidden(const int playlistId) {
     // qDebug() << "PlaylistDAO::isHidden"
     //          << QThread::currentThread() << m_database.connectionName();
 
@@ -296,7 +297,7 @@ bool PlaylistDAO::isHidden(int playlistId) {
     return true;
 }
 
-void PlaylistDAO::removeTrackFromPlaylist(int playlistId, int position)
+void PlaylistDAO::removeTrackFromPlaylist(const int playlistId, const int position)
 {
     // qDebug() << "PlaylistDAO::removeTrackFromPlaylist"
     //          << QThread::currentThread() << m_database.connectionName();
@@ -345,7 +346,7 @@ void PlaylistDAO::removeTrackFromPlaylist(int playlistId, int position)
     emit(changed(playlistId));
 }
 
-void PlaylistDAO::removeTracksFromPlaylist(int playlistId, QList<int> positions) {
+void PlaylistDAO::removeTracksFromPlaylist(const int playlistId, QList<int>& positions) {
     // get positions in reversed order
     qSort(positions.begin(), positions.end(), qGreater<int>());
 
@@ -397,7 +398,7 @@ void PlaylistDAO::removeTracksFromPlaylist(int playlistId, QList<int> positions)
     emit(changed(playlistId));
 }
 
-bool PlaylistDAO::insertTrackIntoPlaylist(int trackId, int playlistId, int position) {
+bool PlaylistDAO::insertTrackIntoPlaylist(const int trackId, const int playlistId, int position) {
     if (playlistId < 0 || trackId < 0 || position < 0)
         return false;
 
@@ -441,7 +442,7 @@ bool PlaylistDAO::insertTrackIntoPlaylist(int trackId, int playlistId, int posit
     return true;
 }
 
-int PlaylistDAO::insertTracksIntoPlaylist(QList<int> trackIds, int playlistId, int position) {
+int PlaylistDAO::insertTracksIntoPlaylist(const QList<int>& trackIds, const int playlistId, int position) {
     if (playlistId < 0 || position < 0 ) {
         return 0;
     }
@@ -499,7 +500,7 @@ int PlaylistDAO::insertTracksIntoPlaylist(QList<int> trackIds, int playlistId, i
     return tracksAdded;
 }
 
-void PlaylistDAO::addToAutoDJQueue(int playlistId, bool bTop) {
+void PlaylistDAO::addToAutoDJQueue(const int playlistId, const bool bTop) {
     //qDebug() << "Adding tracks from playlist " << playlistId << " to the Auto-DJ Queue";
 
     // Query the PlaylistTracks database to locate tracks in the selected
@@ -530,7 +531,7 @@ void PlaylistDAO::addToAutoDJQueue(int playlistId, bool bTop) {
     }
 }
 
-int PlaylistDAO::getPreviousPlaylist(int currentPlaylistId, HiddenType hidden) {
+int PlaylistDAO::getPreviousPlaylist(const int currentPlaylistId, HiddenType hidden) {
     // Find out the highest position existing in the playlist so we know what
     // position this track should have.
     QSqlQuery query(m_database);
@@ -552,7 +553,7 @@ int PlaylistDAO::getPreviousPlaylist(int currentPlaylistId, HiddenType hidden) {
     return previousPlaylistId;
 }
 
-bool PlaylistDAO::copyPlaylistTracks(int sourcePlaylistID, int targetPlaylistID) {
+bool PlaylistDAO::copyPlaylistTracks(const int sourcePlaylistID, const int targetPlaylistID) {
     // Start the transaction
     ScopedTransaction transaction(m_database);
 
@@ -607,7 +608,7 @@ bool PlaylistDAO::copyPlaylistTracks(int sourcePlaylistID, int targetPlaylistID)
     return true;
 }
 
-int PlaylistDAO::getMaxPosition(int playlistId) {
+int PlaylistDAO::getMaxPosition(const int playlistId) {
     //Find out the highest position existing in the playlist so we know what
     //position this track should have.
     QSqlQuery query(m_database);
@@ -626,7 +627,7 @@ int PlaylistDAO::getMaxPosition(int playlistId) {
     return position;
 }
 
-void PlaylistDAO::removeTrackFromPlaylists(int trackId) {
+void PlaylistDAO::removeTrackFromPlaylists(const int trackId) {
     QSqlQuery query(m_database);
     query.prepare("DELETE FROM PlaylistTracks WHERE "
                   "track_id=:=id");
@@ -636,7 +637,7 @@ void PlaylistDAO::removeTrackFromPlaylists(int trackId) {
     }
 }
 
-void PlaylistDAO::removeTracksFromPlaylists(QList<int> ids) {
+void PlaylistDAO::removeTracksFromPlaylists(const QList<int>& ids) {
     QStringList idList;
     foreach (int id, ids) {
         idList << QString::number(id);
@@ -649,7 +650,7 @@ void PlaylistDAO::removeTracksFromPlaylists(QList<int> ids) {
     }
 }
 
-int PlaylistDAO::tracksInPlaylist(int playlistId) {
+int PlaylistDAO::tracksInPlaylist(const int playlistId) {
     QSqlQuery query(m_database);
     query.prepare("SELECT COUNT(id) AS count FROM PlaylistTracks "
                   "WHERE playlist_id = :playlist_id");

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -34,54 +34,54 @@ class PlaylistDAO : public QObject, public virtual DAO {
     void initialize();
     void setDatabase(QSqlDatabase& database) { m_database = database; };
     // Create a playlist
-    int createPlaylist(QString name, HiddenType type = PLHT_NOT_HIDDEN);
+    int createPlaylist(const QString& name, HiddenType type = PLHT_NOT_HIDDEN);
     // Delete a playlist
-    void deletePlaylist(int playlistId);
+    void deletePlaylist(const int playlistId);
     // Rename a playlist
-    void renamePlaylist(int playlistId, const QString& newName);
+    void renamePlaylist(const int playlistId, const QString& newName);
     // Lock or unlock a playlist
-    bool setPlaylistLocked(int playlistId, bool locked);
+    bool setPlaylistLocked(const int playlistId, const bool locked);
     // Find out the state of a playlist lock
-    bool isPlaylistLocked(int playlistId);
+    bool isPlaylistLocked(const int playlistId);
     // Append a list of tracks to a playlist
-    bool appendTracksToPlaylist(QList<int> trackIds, int playlistId);
+    bool appendTracksToPlaylist(const QList<int>& trackIds, const int playlistId);
     // Append a track to a playlist
-    bool appendTrackToPlaylist(int trackId, int playlistId);
+    bool appendTrackToPlaylist(const int trackId, const int playlistId);
     // Find out how many playlists exist.
     unsigned int playlistCount();
     // Find out the name of the playlist at the given Id
-    QString getPlaylistName(int playlistId);
+    QString getPlaylistName(const int playlistId);
     // Get the playlist id by its name
-    int getPlaylistIdFromName(QString name);
+    int getPlaylistIdFromName(const QString& name);
     // Get the id of the playlist at index. Note that the index is the natural
     // position in the database table, not the display order position column
     // stored in the database.
-    int getPlaylistId(int index);
+    int getPlaylistId(const int index);
     // Returns true if the playlist with playlistId is hidden
-    bool isHidden(int playlistId);
+    bool isHidden(const int playlistId);
     // Returns the HiddenType of playlistId
-    HiddenType getHiddenType(int playlistId);
+    HiddenType getHiddenType(const int playlistId);
     // Returns the maximum position of the given playlist
-    int getMaxPosition(int playlistId);
+    int getMaxPosition(const int playlistId);
     // Remove a track from all playlists
-    void removeTrackFromPlaylists(int trackId);
-    void removeTracksFromPlaylists(QList<int> ids);
+    void removeTrackFromPlaylists(const int trackId);
+    void removeTracksFromPlaylists(const QList<int>& ids);
     // Remove a track from a playlist
-    void removeTrackFromPlaylist(int playlistId, int position);
-    void removeTracksFromPlaylist(int playlistId, QList<int> positions);
+    void removeTrackFromPlaylist(const int playlistId, const int position);
+    void removeTracksFromPlaylist(const int playlistId, QList<int>& positions);
     // Insert a track into a specific position in a playlist
     bool insertTrackIntoPlaylist(int trackId, int playlistId, int position);
     // Inserts a list of tracks into playlist
-    int insertTracksIntoPlaylist(QList<int> trackIds, int playlistId, int position);
+    int insertTracksIntoPlaylist(const QList<int>& trackIds, const int playlistId, int position);
     // Add a playlist to the Auto-DJ Queue
-    void addToAutoDJQueue(int playlistId, bool bTop);
+    void addToAutoDJQueue(const int playlistId, const bool bTop);
     // Get the preceding playlist of currentPlaylistId with the HiddenType
     // hidden. Returns -1 if no such playlist exists.
-    int getPreviousPlaylist(int currentPlaylistId, HiddenType hidden);
+    int getPreviousPlaylist(const int currentPlaylistId, HiddenType hidden);
     // Append all the tracks in the source playlist to the target playlist.
-    bool copyPlaylistTracks(int sourcePlaylistID, int targetPlaylistID);
+    bool copyPlaylistTracks(const int sourcePlaylistID, const int targetPlaylistID);
     // Returns the number of tracks in the given playlist.
-    int tracksInPlaylist(int playlistId);
+    int tracksInPlaylist(const int playlistId);
   signals:
     void added(int playlistId);
     void deleted(int playlistId);

--- a/src/library/dao/settingsdao.cpp
+++ b/src/library/dao/settingsdao.cpp
@@ -14,7 +14,7 @@ SettingsDAO::~SettingsDAO() {
 void SettingsDAO::initialize() {
 }
 
-QString SettingsDAO::getValue(QString name, QString defaultValue) {
+QString SettingsDAO::getValue(const QString& name, QString defaultValue) {
     QSqlQuery query(m_db);
 
     query.prepare("SELECT value FROM settings WHERE name = :name");
@@ -27,7 +27,7 @@ QString SettingsDAO::getValue(QString name, QString defaultValue) {
     return value;
 }
 
-bool SettingsDAO::setValue(QString name, QVariant value) {
+bool SettingsDAO::setValue(const QString& name, const QVariant& value) {
     if (!qVariantCanConvert<QString>(value)) {
         return false;
     }

--- a/src/library/dao/settingsdao.h
+++ b/src/library/dao/settingsdao.h
@@ -10,8 +10,8 @@ class SettingsDAO : public QObject {
 
     virtual void initialize();
 
-    QString getValue(QString name, QString defaultValue = QString());
-    bool setValue(QString name, QVariant value);
+    QString getValue(const QString& name, QString defaultValue = QString());
+    bool setValue(const QString& name, const QVariant& value);
 
   private:
     QSqlDatabase m_db;

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -91,7 +91,7 @@ void TrackDAO::initialize() {
     @return the track id for the track located at location, or -1 if the track
             is not in the database.
 */
-int TrackDAO::getTrackId(QString absoluteFilePath) {
+int TrackDAO::getTrackId(const QString& absoluteFilePath) {
     //qDebug() << "TrackDAO::getTrackId" << QThread::currentThread() << m_database.connectionName();
 
     QSqlQuery query(m_database);
@@ -111,7 +111,7 @@ int TrackDAO::getTrackId(QString absoluteFilePath) {
     return libraryTrackId;
 }
 
-QList<int> TrackDAO::getTrackIds(QList<QFileInfo> files) {
+QList<int> TrackDAO::getTrackIds(const QList<QFileInfo>& files) {
     QStringList pathList;
     FieldEscaper escaper(m_database);
     foreach (QFileInfo file, files) {
@@ -136,7 +136,7 @@ QList<int> TrackDAO::getTrackIds(QList<QFileInfo> files) {
 
 // Some code (eg. drag and drop) needs to just get a track's location, and it's
 // not worth retrieving a whole TrackInfoObject.
-QString TrackDAO::getTrackLocation(int trackId) {
+QString TrackDAO::getTrackLocation(const int trackId) {
     qDebug() << "TrackDAO::getTrackLocation"
              << QThread::currentThread() << m_database.connectionName();
     QSqlQuery query(m_database);
@@ -160,7 +160,7 @@ QString TrackDAO::getTrackLocation(int trackId) {
     @param file_location The full path to the track on disk, including the filename.
     @return true if the track is found in the library table, false otherwise.
 */
-bool TrackDAO::trackExistsInDatabase(QString absoluteFilePath) {
+bool TrackDAO::trackExistsInDatabase(const QString& absoluteFilePath) {
     return (getTrackId(absoluteFilePath) != -1);
 }
 
@@ -526,7 +526,7 @@ void TrackDAO::addTrack(TrackInfoObject* pTrack, bool unremove) {
     addTracksFinish();
 }
 
-QList<int> TrackDAO::addTracks(const QList<QFileInfo> &fileInfoList,
+QList<int> TrackDAO::addTracks(const QList<QFileInfo>& fileInfoList,
                                bool unremove) {
     QSqlQuery query(m_database);
     QList<int> trackIDs;
@@ -610,7 +610,7 @@ QList<int> TrackDAO::addTracks(const QList<QFileInfo> &fileInfoList,
     return trackIDs;
 }
 
-void TrackDAO::hideTracks(QList<int> ids) {
+void TrackDAO::hideTracks(const QList<int>& ids) {
     QStringList idList;
     foreach (int id, ids) {
         idList.append(QString::number(id));
@@ -634,7 +634,7 @@ void TrackDAO::hideTracks(QList<int> ids) {
 // up in the library views again.
 // This function should get called if you drag-and-drop a file that's been
 // "hidden" from Mixxx back into the library view.
-void TrackDAO::unhideTracks(QList<int> ids) {
+void TrackDAO::unhideTracks(const QList<int>& ids) {
     QStringList idList;
     foreach (int id, ids) {
         idList.append(QString::number(id));
@@ -652,7 +652,7 @@ void TrackDAO::unhideTracks(QList<int> ids) {
 
 // Warning, purge cannot be undone check before if there is no reference to this
 // track id's on other library tables
-void TrackDAO::purgeTracks(QList<int> ids) {
+void TrackDAO::purgeTracks(const QList<int>& ids) {
     if (ids.empty()) {
         return;
     }
@@ -754,7 +754,7 @@ void TrackDAO::deleteTrack(TrackInfoObject* pTrack) {
     pTrack->deleteLater();
 }
 
-TrackPointer TrackDAO::getTrackFromDB(int id) const {
+TrackPointer TrackDAO::getTrackFromDB(const int id) const {
     QTime time;
     time.start();
     QSqlQuery query(m_database);
@@ -890,7 +890,7 @@ TrackPointer TrackDAO::getTrackFromDB(int id) const {
     return TrackPointer();
 }
 
-TrackPointer TrackDAO::getTrack(int id, bool cacheOnly) const {
+TrackPointer TrackDAO::getTrack(const int id, const bool cacheOnly) const {
     //qDebug() << "TrackDAO::getTrack" << QThread::currentThread() << m_database.connectionName();
     TrackPointer pTrack;
 
@@ -1052,7 +1052,7 @@ void TrackDAO::invalidateTrackLocationsInLibrary(QString libraryPath) {
     }
 }
 
-void TrackDAO::markTrackLocationAsVerified(QString location)
+void TrackDAO::markTrackLocationAsVerified(const QString& location)
 {
     //qDebug() << "TrackDAO::markTrackLocationAsVerified" << QThread::currentThread() << m_database.connectionName();
     //qDebug() << "markTrackLocationAsVerified()" << location;
@@ -1068,7 +1068,7 @@ void TrackDAO::markTrackLocationAsVerified(QString location)
     }
 }
 
-void TrackDAO::markTracksInDirectoriesAsVerified(QStringList directories) {
+void TrackDAO::markTracksInDirectoriesAsVerified(QStringList& directories) {
     //qDebug() << "TrackDAO::markTracksInDirectoryAsVerified" << QThread::currentThread() << m_database.connectionName();
     //qDebug() << "markTracksInDirectoryAsVerified()" << directory;
 
@@ -1104,7 +1104,7 @@ void TrackDAO::markUnverifiedTracksAsDeleted() {
 
 }
 
-void TrackDAO::markTrackLocationsAsDeleted(QString directory) {
+void TrackDAO::markTrackLocationsAsDeleted(const QString& directory) {
     //qDebug() << "TrackDAO::markTrackLocationsAsDeleted" << QThread::currentThread() << m_database.connectionName();
     QSqlQuery query(m_database);
     query.prepare("UPDATE track_locations "

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -74,28 +74,28 @@ class TrackDAO : public QObject, public virtual DAO {
     void setDatabase(QSqlDatabase& database) { m_database = database; };
 
     void initialize();
-    int getTrackId(QString absoluteFilePath);
-    QList<int> getTrackIds(QList<QFileInfo> files);
-    bool trackExistsInDatabase(QString absoluteFilePath);
-    QString getTrackLocation(int id);
+    int getTrackId(const QString& absoluteFilePath);
+    QList<int> getTrackIds(const QList<QFileInfo>& files);
+    bool trackExistsInDatabase(const QString& absoluteFilePath);
+    QString getTrackLocation(const int id);
     int addTrack(const QString& file, bool unremove);
     int addTrack(const QFileInfo& fileInfo, bool unremove);
     void addTracksPrepare();
     bool addTracksAdd(TrackInfoObject* pTrack, bool unremove);
     void addTracksFinish();
-    QList<int> addTracks(const QList<QFileInfo> &fileInfoList, bool unremove);
-    void hideTracks(QList<int> ids);
-    void purgeTracks(QList<int> ids);
-    void unhideTracks(QList<int> ids);
-    TrackPointer getTrack(int id, bool cacheOnly=false) const;
+    QList<int> addTracks(const QList<QFileInfo>& fileInfoList, bool unremove);
+    void hideTracks(const QList<int>& ids);
+    void purgeTracks(const QList<int>& ids);
+    void unhideTracks(const QList<int>& ids);
+    TrackPointer getTrack(const int id, const bool cacheOnly=false) const;
     bool isDirty(int trackId);
 
     // Scanning related calls. Should be elsewhere or private somehow.
-    void markTrackLocationAsVerified(QString location);
-    void markTracksInDirectoriesAsVerified(QStringList directories);
+    void markTrackLocationAsVerified(const QString& location);
+    void markTracksInDirectoriesAsVerified(QStringList& directories);
     void invalidateTrackLocationsInLibrary(QString libraryPath);
     void markUnverifiedTracksAsDeleted();
-    void markTrackLocationsAsDeleted(QString directory);
+    void markTrackLocationsAsDeleted(const QString& directory);
     void detectMovedFiles(QSet<int>* pTracksMovedSetNew, QSet<int>* pTracksMovedSetOld);
     void databaseTrackAdded(TrackPointer pTrack);
     void databaseTracksMoved(QSet<int> tracksMovedSetOld, QSet<int> tracksMovedSetNew);
@@ -134,7 +134,7 @@ class TrackDAO : public QObject, public virtual DAO {
     void saveTrack(TrackInfoObject* pTrack);
     void updateTrack(TrackInfoObject* pTrack);
     void addTrack(TrackInfoObject* pTrack, bool unremove);
-    TrackPointer getTrackFromDB(int id) const;
+    TrackPointer getTrackFromDB(const int id) const;
     QString absoluteFilePath(QString location);
 
     void bindTrackToTrackLocationsInsert(TrackInfoObject* pTrack);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1250,7 +1250,7 @@ void WTrackTableView::addSelectionToCrate(int iCrateId) {
     }
 
     if (trackIds.size() > 0) {
-        crateDao.addTracksToCrate(trackIds, iCrateId);
+        crateDao.addTracksToCrate(iCrateId, &trackIds);
     }
 }
 


### PR DESCRIPTION
I was learning DAO's code. I found that it would be more simpler to understand code if there are const qualifiers for function arguments. Also, in this way we can avoid some errors and help compiler.

About references -- whenever we don't need object's copy -- we just use it's reference.
