### PR TITLE
Cppcheck found some issues. Solved some of them.

### DIFF
--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -12,7 +12,10 @@ QMutex ControlDoublePrivate::m_sqCOHashMutex;
 
 ControlDoublePrivate::ControlDoublePrivate()
         : m_bIgnoreNops(true),
-          m_bTrack(false) {
+          m_bTrack(false),
+          m_trackType(Stat::UNSPECIFIED),
+          m_trackFlags(Stat::COUNT | Stat::SUM | Stat::AVERAGE |
+                       Stat::SAMPLE_VARIANCE | Stat::MIN | Stat::MAX) {
     m_defaultValue.setValue(0);
     m_value.setValue(0);
 }

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -338,7 +338,7 @@ const QString BaseSqlTableModel::currentSearch() const {
     return m_currentSearch;
 }
 
-void BaseSqlTableModel::setSearch(const QString& searchText, const QString extraFilter) {
+void BaseSqlTableModel::setSearch(const QString& searchText, const QString& extraFilter) {
     if (sDebug) {
         qDebug() << this << "setSearch" << searchText;
     }

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -51,7 +51,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     bool initialized() const { return m_bInitialized; }
     int getTrackId(const QModelIndex& index) const;
     void search(const QString& searchText, const QString& extraFilter=QString());
-    void setSearch(const QString& searchText, const QString extraFilter=QString());
+    void setSearch(const QString& searchText, const QString& extraFilter=QString());
     const QString currentSearch() const;
     void setSort(int column, Qt::SortOrder order);
     void hideTracks(const QModelIndexList& indices);

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -50,8 +50,8 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     // to cause instability / crashes.
     bool initialized() const { return m_bInitialized; }
     int getTrackId(const QModelIndex& index) const;
-    void search(const QString& searchText, const QString& extraFilter=QString());
-    void setSearch(const QString& searchText, const QString& extraFilter=QString());
+    void search(const QString& searchText, const QString& extraFilter = QString());
+    void setSearch(const QString& searchText, const QString& extraFilter = QString());
     const QString currentSearch() const;
     void setSort(int column, Qt::SortOrder order);
     void hideTracks(const QModelIndexList& indices);
@@ -64,10 +64,10 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     void sort(int column, Qt::SortOrder order);
     int rowCount(const QModelIndex& parent=QModelIndex()) const;
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
-    bool setData(const QModelIndex& index, const QVariant& value, int role=Qt::EditRole);
-    int columnCount(const QModelIndex& parent=QModelIndex()) const;
+    bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole);
+    int columnCount(const QModelIndex& parent = QModelIndex()) const;
     bool setHeaderData(int section, Qt::Orientation orientation,
-                               const QVariant &value, int role=Qt::EditRole);
+                               const QVariant &value, int role = Qt::EditRole);
     QVariant headerData(int section, Qt::Orientation orientation,
                                 int role=Qt::DisplayRole) const;
     virtual QMimeData* mimeData(const QModelIndexList &indexes) const;

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -185,12 +185,12 @@ PlaylistDAO& TrackCollection::getPlaylistDAO() {
 }
 
 QSharedPointer<BaseTrackCache> TrackCollection::getTrackSource(
-    const QString name) {
+    const QString& name) {
     return m_trackSources.value(name, QSharedPointer<BaseTrackCache>());
 }
 
 void TrackCollection::addTrackSource(
-    const QString name, QSharedPointer<BaseTrackCache> trackSource) {
+    const QString& name, QSharedPointer<BaseTrackCache> trackSource) {
     Q_ASSERT(!m_trackSources.contains(name));
     m_trackSources[name] = trackSource;
 }

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -59,8 +59,8 @@ class TrackCollection : public QObject
     CrateDAO& getCrateDAO();
     TrackDAO& getTrackDAO();
     PlaylistDAO& getPlaylistDAO();
-    QSharedPointer<BaseTrackCache> getTrackSource(const QString name);
-    void addTrackSource(const QString name, QSharedPointer<BaseTrackCache> trackSource);
+    QSharedPointer<BaseTrackCache> getTrackSource(const QString& name);
+    void addTrackSource(const QString& name, QSharedPointer<BaseTrackCache> trackSource);
     void cancelLibraryScan();
 
     ConfigObject<ConfigValue>* getConfig() {

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -58,6 +58,7 @@ QString chromaprinter::calcFingerPrint(SoundSourceProxy& soundSource){
     int success = chromaprint_feed(ctx, pData, m_NumSamples);
     if (!success) {
         qDebug() << "could not generate fingerprint";
+        delete pData;
         return QString();
     }
     chromaprint_finish(ctx);

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -365,7 +365,7 @@ int SoundSourceProxy::ParseHeader(TrackInfoObject* p)
     }
     delete sndsrc;
 
-    return 0;
+    return OK;
 }
 
 // static

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -34,7 +34,7 @@ class BeatMapIterator : public BeatIterator {
               m_endBeat(end) {
         // Advance to the first enabled beat.
         while (m_currentBeat != m_endBeat && !m_currentBeat->enabled()) {
-            m_currentBeat++;
+            ++m_currentBeat;
         }
     }
 
@@ -44,9 +44,9 @@ class BeatMapIterator : public BeatIterator {
 
     virtual double next() {
         double beat = framesToSamples(m_currentBeat->frame_position());
-        m_currentBeat++;
+        ++m_currentBeat;
         while (m_currentBeat != m_endBeat && !m_currentBeat->enabled()) {
-            m_currentBeat++;
+            ++m_currentBeat;
         }
         return beat;
     }
@@ -189,15 +189,15 @@ double BeatMap::findNthBeat(double dSamples, int n) const {
         // Count down until n=1
         while (it != m_beats.end()) {
             if (!it->enabled()) {
-                it++;
+                ++it;
                 continue;
             }
             if (n == 1) {
                 // Return a sample offset
                 return framesToSamples(it->frame_position());
             }
-            it++;
-            n--;
+            ++it;
+            --n;
         }
     } else if (n < 0) {
         BeatList::const_iterator it =
@@ -211,7 +211,7 @@ double BeatMap::findNthBeat(double dSamples, int n) const {
             // last instance of dSamples-or-smaller, we decrement it by 1 before
             // touching it. The guard of this while loop guarantees this does
             // not put us before the start of the loop.
-            it--;
+            --it;
             if (!it->enabled()) {
                 continue;
             }
@@ -450,7 +450,7 @@ double BeatMap::calculateBpm(const Beat& startBeat, const Beat& stopBeat) const 
             qUpperBound(m_beats.begin(), m_beats.end(), stopBeat, BeatLessThan);
 
     QVector<double> beatvect;
-    for (; curBeat != lastBeat; curBeat++) {
+    for (; curBeat != lastBeat; ++curBeat) {
         const Beat& beat = *curBeat;
         if (beat.enabled()) {
             beatvect.append(beat.frame_position());

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -195,7 +195,7 @@ int TrackInfoObject::parse()
     parseFilename();
 
     // Parse the using information stored in the sound file
-    bool result = SoundSourceProxy::ParseHeader(this);
+    int result = SoundSourceProxy::ParseHeader(this);
     m_bIsValid = result == OK;
     return result;
 }

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -223,7 +223,7 @@ void GLSLWaveformRendererSignal::createFrameBuffers()
     if (!m_framebuffer->isValid())
         qWarning() << "GLSLWaveformRendererSignal::createFrameBuffer - frame buffer not valid";
 
-    m_frameBuffersValid = m_framebuffer->isValid() && m_framebuffer->isValid();
+    m_frameBuffersValid = m_framebuffer->isValid() /*&& m_framebuffer->isValid()*/;
 
     //qDebug() << m_waveformRenderer->getWidth();
     //qDebug() << m_waveformRenderer->getWidth()*3;

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -223,7 +223,7 @@ void GLSLWaveformRendererSignal::createFrameBuffers()
     if (!m_framebuffer->isValid())
         qWarning() << "GLSLWaveformRendererSignal::createFrameBuffer - frame buffer not valid";
 
-    m_frameBuffersValid = m_framebuffer->isValid() /*&& m_framebuffer->isValid()*/;
+    m_frameBuffersValid = m_framebuffer->isValid() && m_signalMaxbuffer->isValid();
 
     //qDebug() << m_waveformRenderer->getWidth();
     //qDebug() << m_waveformRenderer->getWidth()*3;

--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -185,7 +185,7 @@ void WTrackTableViewHeader::showOrHideColumn(int column) {
 int WTrackTableViewHeader::hiddenCount() {
     int count = 0;
     for (QMap<int, QAction*>::iterator it = m_columnActions.begin();
-         it != m_columnActions.end(); it++) {
+         it != m_columnActions.end(); ++it) {
         QAction* pAction = *it;
         if (!pAction->isChecked())
             count += 1;


### PR DESCRIPTION
- Member variables `ControlDoublePrivate::m_trackType` and
  `ControlDoublePrivate::m_trackFlags` was not initialized in the
  constructor.
- `SoundSourceProxy::ParseHeader`: return `OK` instead of `0`.
- `TrackInfoObject::parse`: omitted implicit cast.
- `TrackCollection`: added references to arguments in methods
  `getTrackSource...`
- `chromaprinter.cpp`: Memory leak: `pData` (return without freeing
  `pData`).
- In `GLSLWaveformRendererSignal::createFrameBuffers` was strange
  expression: `m_framebuffer->isValid() && m_framebuffer->isValid()`.
- Lots of postfix ++/-- changed to prefix form.
