### PR TITLE
Commented out debug statement causing compilation failure on OSX.

### DIFF
--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -102,15 +102,15 @@ DlgPrefSound::DlgPrefSound(QWidget *pParent, SoundManager *pSoundManager,
     connect(m_pMasterLatency, SIGNAL(valueChanged(double)),
             this, SLOT(masterLatencyChanged(double)));
 
-    //qDebug() << "RLimit Cur " << RLimit::getCurRtPrio();
-    //qDebug() << "RLimit Max " << RLimit::getMaxRtPrio();
-
 #ifdef __LINUX__
-    if (RLimit::isRtPrioAllowed())
-#endif // __LINUX__
-    {
+    qDebug() << "RLimit Cur " << RLimit::getCurRtPrio();
+    qDebug() << "RLimit Max " << RLimit::getMaxRtPrio();
+    
+    if (RLimit::isRtPrioAllowed()) {
         limitsHint->hide();
     }
+#endif // __LINUX__
+
 }
 
 DlgPrefSound::~DlgPrefSound() {

--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -102,8 +102,8 @@ DlgPrefSound::DlgPrefSound(QWidget *pParent, SoundManager *pSoundManager,
     connect(m_pMasterLatency, SIGNAL(valueChanged(double)),
             this, SLOT(masterLatencyChanged(double)));
 
-    qDebug() << "RLimit Cur " << RLimit::getCurRtPrio();
-    qDebug() << "RLimit Max " << RLimit::getMaxRtPrio();
+    //qDebug() << "RLimit Cur " << RLimit::getCurRtPrio();
+    //qDebug() << "RLimit Max " << RLimit::getMaxRtPrio();
 
 #ifdef __LINUX__
     if (RLimit::isRtPrioAllowed())


### PR DESCRIPTION
Two debugging lines introduced in dlgprefsound.cpp in commit aa2f6bf92b4bc911ec726381e7e5579d7399b376 caused compilation failure on Mac OSX because they referenced Linux specific rlimit code.  Removing them fixes the compilation failure.
