### PR TITLE
Delete leaking controls

### DIFF
--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -299,6 +299,8 @@ DlgPrefControls::~DlgPrefControls()
     foreach (ControlObjectThreadMain* pControl, m_rateRangeControls) {
         delete pControl;
     }
+    
+    delete m_pControlPositionDisplay;
 }
 
 void DlgPrefControls::slotUpdateSchemes()

--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -287,6 +287,8 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxApp * mixxx,
 
 DlgPrefControls::~DlgPrefControls()
 {
+    delete m_pControlPositionDisplay;
+    
     foreach (ControlObjectThreadMain* pControl, m_rateControls) {
         delete pControl;
     }
@@ -299,8 +301,6 @@ DlgPrefControls::~DlgPrefControls()
     foreach (ControlObjectThreadMain* pControl, m_rateRangeControls) {
         delete pControl;
     }
-    
-    delete m_pControlPositionDisplay;
 }
 
 void DlgPrefControls::slotUpdateSchemes()

--- a/src/engine/positionscratchcontroller.cpp
+++ b/src/engine/positionscratchcontroller.cpp
@@ -87,6 +87,7 @@ PositionScratchController::PositionScratchController(const char* pGroup)
 
 PositionScratchController::~PositionScratchController() {
     delete m_pScratchEnable;
+    delete m_pScratchPosition;
     delete m_pVelocityController;
     delete m_pRateIIFilter;
 }

--- a/src/engine/positionscratchcontroller.cpp
+++ b/src/engine/positionscratchcontroller.cpp
@@ -86,10 +86,10 @@ PositionScratchController::PositionScratchController(const char* pGroup)
 }
 
 PositionScratchController::~PositionScratchController() {
-    delete m_pScratchEnable;
-    delete m_pScratchPosition;
-    delete m_pVelocityController;
     delete m_pRateIIFilter;
+    delete m_pVelocityController;
+    delete m_pScratchPosition;
+    delete m_pScratchEnable;
 }
 
 //volatile double _p = 0.3;

--- a/src/engine/vinylcontrolcontrol.cpp
+++ b/src/engine/vinylcontrolcontrol.cpp
@@ -45,15 +45,15 @@ VinylControlControl::VinylControlControl(const char* pGroup, ConfigObject<Config
 }
 
 VinylControlControl::~VinylControlControl() {
-    delete m_pControlVinylStatus;
-    delete m_pControlVinylSpeedType;
-    delete m_pControlVinylSeek;
-    delete m_pControlVinylScratching;
-    delete m_pControlVinylEnabled;
-    delete m_pControlVinylWantEnabled;
-    delete m_pControlVinylMode;
-    delete m_pControlVinylCueing;
     delete m_pControlVinylSignalEnabled;
+    delete m_pControlVinylCueing;
+    delete m_pControlVinylMode;
+    delete m_pControlVinylWantEnabled;
+    delete m_pControlVinylEnabled;
+    delete m_pControlVinylScratching;
+    delete m_pControlVinylSeek;
+    delete m_pControlVinylSpeedType;
+    delete m_pControlVinylStatus;
 }
 
 void VinylControlControl::trackLoaded(TrackPointer pTrack) {

--- a/src/engine/vinylcontrolcontrol.cpp
+++ b/src/engine/vinylcontrolcontrol.cpp
@@ -45,12 +45,15 @@ VinylControlControl::VinylControlControl(const char* pGroup, ConfigObject<Config
 }
 
 VinylControlControl::~VinylControlControl() {
-    delete m_pControlVinylSeek;
     delete m_pControlVinylStatus;
     delete m_pControlVinylSpeedType;
+    delete m_pControlVinylSeek;
+    delete m_pControlVinylScratching;
     delete m_pControlVinylEnabled;
+    delete m_pControlVinylWantEnabled;
     delete m_pControlVinylMode;
     delete m_pControlVinylCueing;
+    delete m_pControlVinylSignalEnabled;
 }
 
 void VinylControlControl::trackLoaded(TrackPointer pTrack) {

--- a/src/recording/recordingmanager.cpp
+++ b/src/recording/recordingmanager.cpp
@@ -46,6 +46,7 @@ RecordingManager::RecordingManager(ConfigObject<ConfigValue>* pConfig, EngineMas
 RecordingManager::~RecordingManager()
 {
     qDebug() << "Delete RecordingManager";
+    delete m_pToggleRecording;
     delete m_recReadyCO;
     delete m_recReady;
 }

--- a/src/recording/recordingmanager.cpp
+++ b/src/recording/recordingmanager.cpp
@@ -46,9 +46,10 @@ RecordingManager::RecordingManager(ConfigObject<ConfigValue>* pConfig, EngineMas
 RecordingManager::~RecordingManager()
 {
     qDebug() << "Delete RecordingManager";
-    delete m_pToggleRecording;
-    delete m_recReadyCO;
+    
     delete m_recReady;
+    delete m_recReadyCO;
+    delete m_pToggleRecording;
 }
 
 QString RecordingManager::formatDateTimeForFilename(QDateTime dateTime) const {


### PR DESCRIPTION
Using the shutdown command line output I found all leaking controls that I could delete and added deletion code in the relevant destructor methods.  The leaking flanger controls are a special case, so I didn't bother figuring them out right now, but I fixed all of the other leaking controls.
