### PR TITLE
Support for Liine Lemur Daemon virtual MIDI ports

### DIFF
--- a/src/controllers/midi/midicontroller_name_regexps.h
+++ b/src/controllers/midi/midicontroller_name_regexps.h
@@ -1,0 +1,17 @@
+/**
+* @file midicontroller_name_regexps.h
+* @author Ilkka Tuohela hile@iki.fi
+* @date Tue 24 Jul 2013
+* @brief List of regexps to match certain MIDI IN/OUT port names
+*/
+
+#ifndef MIDICONTROLLER_NAME_REGEXPS
+#define MIDICONTROLLER_NAME_REGEXPS
+
+#include <QRegExp>
+
+// Linee Lemur Daemon input output ports (8 pairs)
+const QRegExp LEMUR_INPUT_RE = QRegExp("^Daemon Input (\\d+)$");
+const QRegExp LEMUR_OUTPUT_RE = QRegExp("^Daemon Output (\\d+)$");
+
+#endif

--- a/src/controllers/midi/midienumerator.h
+++ b/src/controllers/midi/midienumerator.h
@@ -13,6 +13,7 @@
 
 #include "controllers/controllerenumerator.h"
 #include "controllers/midi/midicontroller.h"
+#include "controllers/midi/midicontroller_name_regexps.h"
 
 class MidiEnumerator : public ControllerEnumerator {
     Q_OBJECT

--- a/src/controllers/midi/portmidienumerator.cpp
+++ b/src/controllers/midi/portmidienumerator.cpp
@@ -85,6 +85,7 @@ bool namesMatchPattern(const QString input_name,
 bool shouldLinkInputToOutput(const QString input_name,
                              const QString output_name) {
 
+    int input_offset = -1;
     int offset = -1;
 
     // Early exit.
@@ -127,6 +128,16 @@ bool shouldLinkInputToOutput(const QString input_name,
         namesMatchPattern(input_name, output_name)) {
         return true;
     }
+
+    // Linee Lemur Daemon support
+    input_offset = LEMUR_INPUT_RE.indexIn(input_name);
+    offset = LEMUR_OUTPUT_RE.indexIn(output_name);
+    if (input_offset>-1 && offset>-1) {
+        // Ports are for lemur, check it's same port index (1-8)
+        if (LEMUR_INPUT_RE.cap(1) == LEMUR_OUTPUT_RE.cap(1))
+            return true;
+    }
+
     return false;
 }
 

--- a/src/test/portmidienumeratortest.cpp
+++ b/src/test/portmidienumeratortest.cpp
@@ -78,6 +78,20 @@ TEST_F(PortMidiEnumeratorTest, InputOutputPortsLinked) {
         "Traktor Kontrol X1 - 1 MIDI input 0",
         "Traktor Kontrol X1 - 1 MIDI output 0"));
 
+    // Lemur Daemon shows 8 port pairs named like:
+    // 'Daemon Input 1' and 'Daemon Output 2'
+    // We explicitly only support such names with numeric index, case sensitively
+    ASSERT_TRUE(shouldLinkInputToOutput("Daemon Input 1", "Daemon Output 1"));
+    ASSERT_TRUE(shouldLinkInputToOutput("Daemon Input 2", "Daemon Output 2"));
+    ASSERT_TRUE(shouldLinkInputToOutput("Daemon Input 1234", "Daemon Output 1234"));
+    ASSERT_FALSE(shouldLinkInputToOutput("Daemon Input", "Daemon Output"));
+    ASSERT_FALSE(shouldLinkInputToOutput("Daemon Input ", "Daemon Output "));
+    ASSERT_FALSE(shouldLinkInputToOutput("Daemon Input 1", "Daemon Input 1"));
+    ASSERT_FALSE(shouldLinkInputToOutput("Daemon Input 1", "daemon output 1"));
+    ASSERT_FALSE(shouldLinkInputToOutput("Daemon Input 1", "Daemon Output 1 "));
+    ASSERT_FALSE(shouldLinkInputToOutput("Daemon Input 1", "Daemon Output 11"));
+    ASSERT_FALSE(shouldLinkInputToOutput("Daemon Input 2", "Daemon Output 12"));
+
     // Dangling numerals after the device name but before MIDI are fine.
     ASSERT_TRUE(shouldLinkInputToOutput(
         "Vestax VCI-100 2 MIDI 12",


### PR DESCRIPTION
This patch adds support for Liine Lemur Daemon (daemon for virtual midi ports used by Lemur for iOS) MIDI ports, where the input and output ports are named like 'Daemon Input 0' and 'Daemon Output 0' with currently ports 0-7 implemented in the daemon.

It's a kind of hack, these kinds of regexp matches should have a bit more generic matching I guess, but it works.
