### PR TITLE
Co request

### DIFF
--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -168,9 +168,8 @@ double ControlDoublePrivate::getMidiParameter() const {
 
 bool ControlDoublePrivate::connectValueChangeRequest(const QObject* receiver,
         const char* method, Qt::ConnectionType type) {
-    bool ret = false;
-    ret = connect(this, SIGNAL(valueChangeRequest(double)),
+    // confirmation is only required if connect was successful
+    m_confirmRequired = connect(this, SIGNAL(valueChangeRequest(double)),
                 receiver, method, type);
-    m_confirmRequired = ret;
-    return ret;
+    return m_confirmRequired;
 }

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -92,13 +92,17 @@ void ControlDoublePrivate::reset() {
 }
 
 void ControlDoublePrivate::set(double value, QObject* pSender) {
-    if (m_bIgnoreNops && get() == value) {
-        return;
-    }
-
     // If the behavior says to ignore the set, ignore it.
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     if (!pBehavior.isNull() && !pBehavior->setFilter(&value)) {
+        return;
+    }
+    setInner(value, pSender);
+}
+
+
+void ControlDoublePrivate::setInner(double value, QObject* pSender) {
+    if (m_bIgnoreNops && get() == value) {
         return;
     }
     m_value.setValue(value);

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -28,7 +28,8 @@ ControlDoublePrivate::ControlDoublePrivate(ConfigKey key,
           m_trackKey("control " + m_key.group + "," + m_key.item),
           m_trackType(Stat::UNSPECIFIED),
           m_trackFlags(Stat::COUNT | Stat::SUM | Stat::AVERAGE |
-                       Stat::SAMPLE_VARIANCE | Stat::MIN | Stat::MAX) {
+                       Stat::SAMPLE_VARIANCE | Stat::MIN | Stat::MAX),
+          m_confirmRequired(false) {
     initialize();
 }
 

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -100,6 +100,10 @@ void ControlDoublePrivate::set(double value, QObject* pSender) {
     setInner(value, pSender);
 }
 
+void ControlDoublePrivate::setAndConfirm(double value, QObject* pSender) {
+    setInner(value, pSender);
+}
+
 
 void ControlDoublePrivate::setInner(double value, QObject* pSender) {
     if (m_bIgnoreNops && get() == value) {

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -15,7 +15,8 @@ ControlDoublePrivate::ControlDoublePrivate()
           m_bTrack(false),
           m_trackType(Stat::UNSPECIFIED),
           m_trackFlags(Stat::COUNT | Stat::SUM | Stat::AVERAGE |
-                       Stat::SAMPLE_VARIANCE | Stat::MIN | Stat::MAX) {
+                       Stat::SAMPLE_VARIANCE | Stat::MIN | Stat::MAX),
+          m_confirmRequired(false) {
     initialize();
 }
 
@@ -97,7 +98,11 @@ void ControlDoublePrivate::set(double value, QObject* pSender) {
     if (!pBehavior.isNull() && !pBehavior->setFilter(&value)) {
         return;
     }
-    setInner(value, pSender);
+    if(m_confirmRequired) {
+        emit(valueChangeRequest(value));
+    } else {
+        setInner(value, pSender);
+    }
 }
 
 void ControlDoublePrivate::setAndConfirm(double value, QObject* pSender) {
@@ -160,3 +165,11 @@ double ControlDoublePrivate::getMidiParameter() const {
     return value;
 }
 
+bool ControlDoublePrivate::connectValueChangeRequest(const QObject* receiver,
+        const char* method, Qt::ConnectionType type) {
+    bool ret = false;
+    ret = connect(this, SIGNAL(valueChangeRequest(double)),
+                receiver, method, type);
+    m_confirmRequired = ret;
+    return ret;
+}

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -64,10 +64,14 @@ class ControlDoublePrivate : public QObject {
         return m_pBehavior ? m_pBehavior->defaultValue(default_value) : default_value;
     }
 
+    bool connectValueChangeRequest(const QObject* receiver,
+            const char* method, Qt::ConnectionType type);
+
   signals:
     // Emitted when the ControlDoublePrivate value changes. pSender is a
     // pointer to the setter of the value (potentially NULL).
     void valueChanged(double value, QObject* pSender);
+    void valueChangeRequest(double value);
 
   private:
     void initialize();
@@ -82,6 +86,7 @@ class ControlDoublePrivate : public QObject {
     QString m_trackKey;
     int m_trackType;
     int m_trackFlags;
+    bool m_confirmRequired;
 
     // The control value.
     ControlValueAtomic<double> m_value;

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -33,7 +33,8 @@ class ControlDoublePrivate : public QObject {
 
     // Sets the control value.
     void set(double value, QObject* pSender);
-    // Sets the control value.
+    // directly sets the control value. Must be used from and only from the
+    // ValueChangeRequest slot.
     void setAndConfirm(double value, QObject* pSender);
     // Gets the control value.
     double get() const;
@@ -64,6 +65,12 @@ class ControlDoublePrivate : public QObject {
         return m_pBehavior ? m_pBehavior->defaultValue(default_value) : default_value;
     }
 
+    // Connects a slot to the ValueChange request for CO validation.
+    // All change requests issued by set are routed though the connected slot
+    // This can decide with its own thread safe solution if the requested value
+    // can be confirmed by setAndConfirm() or not.
+    // Note: Once connected, the CO value itself is ONLY set by setAndConfirm() typically
+    // called in the connected slot.
     bool connectValueChangeRequest(const QObject* receiver,
             const char* method, Qt::ConnectionType type);
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -33,6 +33,8 @@ class ControlDoublePrivate : public QObject {
 
     // Sets the control value.
     void set(double value, QObject* pSender);
+    // Sets the control value.
+    void setAndConfirm(double value, QObject* pSender);
     // Gets the control value.
     double get() const;
     // Resets the control value to its default.

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -69,6 +69,7 @@ class ControlDoublePrivate : public QObject {
 
   private:
     void initialize();
+    void setInner(double value, QObject* pSender);
 
     ConfigKey m_key;
     // Whether to ignore sets which would have no effect.

--- a/src/controlobject.cpp
+++ b/src/controlobject.cpp
@@ -160,3 +160,13 @@ void ControlObject::set(const ConfigKey& key, const double& value) {
         pCop->set(value, NULL);
     }
 }
+
+bool ControlObject::connectValueChangeRequest(const QObject* receiver,
+        const char* method, Qt::ConnectionType type) {
+    bool ret = false;
+    if (m_pControl) {
+        ret = m_pControl->connectValueChangeRequest(receiver, method, type);
+    }
+    return ret;
+}
+

--- a/src/controlobject.cpp
+++ b/src/controlobject.cpp
@@ -153,6 +153,12 @@ void ControlObject::set(double value) {
     }
 }
 
+void ControlObject::setAndConfirm(double value) {
+    if (m_pControl) {
+        m_pControl->setAndConfirm(value, this);
+    }
+}
+
 // static
 void ControlObject::set(const ConfigKey& key, const double& value) {
     ControlDoublePrivate* pCop = ControlDoublePrivate::getControl(key, false);

--- a/src/controlobject.h
+++ b/src/controlobject.h
@@ -70,6 +70,9 @@ class ControlObject : public QObject {
         return m_pControl ? m_pControl->defaultValue() : 0.0;
     }
 
+    bool connectValueChangeRequest(const QObject* receiver,
+            const char* method, Qt::ConnectionType type);
+
   signals:
     void valueChanged(double);
     void valueChangedFromEngine(double);

--- a/src/controlobject.h
+++ b/src/controlobject.h
@@ -56,6 +56,8 @@ class ControlObject : public QObject {
     static double get(const ConfigKey& key);
     // Sets the ControlObject value
     void set(double value);
+    // Sets the ControlObject value
+    void setAndConfirm(double value);
     // Instantly sets the value of the ControlObject
     static void set(const ConfigKey& key, const double& value);
     // Sets the default value

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -486,9 +486,11 @@ void EngineBuffer::slotControlPlayRequest(double v)
     // If no track is currently loaded, turn play off. If a track is loading
     // allow the set since it might apply to a track we are loading due to the
     // asynchrony.
+    qDebug() << m_pCurrentTrack;
     if (v > 0.0 && !m_pCurrentTrack && m_iTrackLoading == 0) {
-        return;
+        v = 0.0;
     }
+    // set and confirm must be called in any case to update the widget toggle state
     m_playButton->setAndConfirm(v);
 }
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -108,8 +108,8 @@ EngineBuffer::EngineBuffer(const char * _group, ConfigObject<ConfigValue> * _con
     // Play button
     m_playButton = new ControlPushButton(ConfigKey(m_group, "play"));
     m_playButton->setButtonMode(ControlPushButton::TOGGLE);
-    connect(m_playButton, SIGNAL(valueChanged(double)),
-            this, SLOT(slotControlPlay(double)),
+    m_playButton->connectValueChangeRequest(
+            this, SLOT(slotControlPlayRequest(double)),
             Qt::DirectConnection);
 
     //Play from Start Button (for sampler)
@@ -481,14 +481,15 @@ void EngineBuffer::slotControlSeekAbs(double abs)
     slotControlSeek(abs / m_file_length_old);
 }
 
-void EngineBuffer::slotControlPlay(double v)
+void EngineBuffer::slotControlPlayRequest(double v)
 {
     // If no track is currently loaded, turn play off. If a track is loading
     // allow the set since it might apply to a track we are loading due to the
     // asynchrony.
     if (v > 0.0 && !m_pCurrentTrack && m_iTrackLoading == 0) {
-        m_playButton->set(0.0f);
+        return;
     }
+    m_playButton->setAndConfirm(v);
 }
 
 void EngineBuffer::slotControlStart(double v)

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -389,7 +389,8 @@ void EngineBuffer::slotTrackLoading() {
     m_iTrackLoading = 1;
     m_pause.unlock();
 
-    m_playButton->set(0.0); // Stop playback
+    // Set play here, to signal the user that the play command is adopted
+    m_playButton->set((double)m_bPlayAfterLoading);
     m_pTrackSamples->set(0); // Stop renderer
 }
 
@@ -411,16 +412,11 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
     // Start buffer processing after all EngineContols are up to date
     // with the current track e.g track is seeked to Cue
     m_iTrackLoading = 0;
-    if (m_bPlayAfterLoading) {
-        m_bPlayAfterLoading = false;
-        m_playButton->set(1);
-    }
 }
 
 // WARNING: Always called from the EngineWorker thread pool
 void EngineBuffer::slotTrackLoadFailed(TrackPointer pTrack,
                                        QString reason) {
-    m_bPlayAfterLoading = false;
     m_playButton->set(0.0f);
     ejectTrack();
     emit(trackLoadFailed(pTrack, reason));

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -389,7 +389,7 @@ void EngineBuffer::slotTrackLoading() {
     m_iTrackLoading = 1;
     m_pause.unlock();
 
-    m_playButton->set(0.0); //Stop playback
+    m_playButton->set(0.0); // Stop playback
     m_pTrackSamples->set(0); // Stop renderer
 }
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -482,7 +482,6 @@ void EngineBuffer::slotControlPlayRequest(double v)
     // If no track is currently loaded, turn play off. If a track is loading
     // allow the set since it might apply to a track we are loading due to the
     // asynchrony.
-    qDebug() << m_pCurrentTrack;
     if (v > 0.0 && !m_pCurrentTrack && m_iTrackLoading == 0) {
         v = 0.0;
     }

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -119,7 +119,7 @@ public:
     //void setReader(CachingReader* pReader);
 
   public slots:
-    void slotControlPlay(double);
+    void slotControlPlayRequest(double);
     void slotControlPlayFromStart(double);
     void slotControlJumpToStartAndStop(double);
     void slotControlStop(double);


### PR DESCRIPTION
OK, here is a possible alternative for the CO validation.
As discussed at https://github.com/mixxxdj/mixxx/pull/9 my favorite solution was to double the COs in request and feedback type. But this will clutter the COs a lot. So here is an alternative solution more like ywwg's solution but (I hope) with no race condition. 

If the CO needs validation, all requests are routed though the receiver. This can decide now at it's own atomic variables, on a single thread  or properly locked, if the requested value can be confirmed or not. The CO value itself is ONLY set by the validator. This solves the moment of the old solution where a not validated value is adopted by the CO just before it is confirmed or rejected.

With the play control I can see an other problem. It is allowed to become "1" if no track is loaded, but a new track is loading. If loading failed, play becomes "0" again. This sound complicated and I am not sure if all other parts of Mixxx are aware of this. Should we change this this?  
