### PR TITLE
Filter effect

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -481,6 +481,7 @@ class MixxxCore(Feature):
                    "engine/enginemaster.cpp",
                    "engine/enginedelay.cpp",
                    "engine/engineflanger.cpp",
+                   "engine/enginefiltereffect.cpp",
                    "engine/enginevumeter.cpp",
                    "engine/enginevinylsoundemu.cpp",
                    "engine/sidechain/enginesidechain.cpp",

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -22,6 +22,7 @@
 #include "engineclipping.h"
 #include "enginepregain.h"
 #include "engineflanger.h"
+#include "enginefiltereffect.h"
 #include "enginefilterblock.h"
 #include "enginevumeter.h"
 #include "enginefilteriir.h"
@@ -53,6 +54,7 @@ EngineDeck::EngineDeck(const char* group,
     m_pPregain = new EnginePregain(group);
     m_pFilter = new EngineFilterBlock(group);
     m_pFlanger = new EngineFlanger(group);
+    m_pFilterEffect = new EngineFilterEffect(group);
     m_pClipping = new EngineClipping(group);
     m_pBuffer = new EngineBuffer(group, pConfig);
     m_pVinylSoundEmu = new EngineVinylSoundEmu(pConfig, group);
@@ -67,6 +69,7 @@ EngineDeck::~EngineDeck() {
     delete m_pClipping;
     delete m_pFilter;
     delete m_pFlanger;
+    delete m_pFilterEffect;
     delete m_pPregain;
     delete m_pVinylSoundEmu;
     delete m_pVUMeter;
@@ -108,6 +111,7 @@ void EngineDeck::process(const CSAMPLE*, const CSAMPLE * pOutput, const int iBuf
     m_pFilter->process(pOut, pOut, iBufferSize);
     // TODO(XXX) LADSPA
     m_pFlanger->process(pOut, pOut, iBufferSize);
+    m_pFilterEffect->process(pOut, pOut, iBufferSize);
     // Apply clipping
     m_pClipping->process(pOut, pOut, iBufferSize);
     // Update VU meter

--- a/src/engine/enginedeck.h
+++ b/src/engine/enginedeck.h
@@ -32,6 +32,7 @@ class EngineBuffer;
 class EngineFilterBlock;
 class EngineClipping;
 class EngineFlanger;
+class EngineFilterEffect;
 class EngineVuMeter;
 class EngineVinylSoundEmu;
 class ControlPushButton;
@@ -74,6 +75,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     EngineClipping* m_pClipping;
     EngineFilterBlock* m_pFilter;
     EngineFlanger* m_pFlanger;
+    EngineFilterEffect* m_pFilterEffect;
     EnginePregain* m_pPregain;
     EngineVinylSoundEmu* m_pVinylSoundEmu;
     EngineVuMeter* m_pVUMeter;

--- a/src/engine/enginefiltereffect.cpp
+++ b/src/engine/enginefiltereffect.cpp
@@ -24,12 +24,17 @@ EngineFilterEffect::EngineFilterEffect(const char* group) {
 
     m_pCrossfade_buffer = SampleUtil::alloc(MAX_BUFFER_LEN);
     m_pBandpass_buffer = SampleUtil::alloc(MAX_BUFFER_LEN);
+
+    old_depth = 1.0f;
 }
 
 EngineFilterEffect::~EngineFilterEffect() {
     delete m_pLowFilter;
     delete m_pBandpassFilter;
     delete m_pHighFilter;
+
+    delete potmeterDepth;
+    delete filterEnable;
 
     SampleUtil::free(m_pCrossfade_buffer);
     SampleUtil::free(m_pBandpass_buffer);

--- a/src/engine/enginefiltereffect.cpp
+++ b/src/engine/enginefiltereffect.cpp
@@ -1,0 +1,122 @@
+#include "enginefiltereffect.h"
+
+#include "sampleutil.h"
+#include "controlobject.h"
+#include "enginefilterbutterworth8.h"
+#include "controlpushbutton.h"
+#include "controlpotmeter.h"
+
+EngineFilterEffect::EngineFilterEffect(const char * group)
+{
+    potmeterDepth = ControlObject::getControl(ConfigKey(group, "filterDepth"));
+    if (potmeterDepth == NULL)
+        potmeterDepth = new ControlPotmeter(ConfigKey(group, "filterDepth"),
+                                            -1., 1.);
+
+    filterEnable = new ControlPushButton(ConfigKey(group, "filter"));
+    filterEnable->setButtonMode(ControlPushButton::TOGGLE);
+
+    m_pLowFilter = new EngineFilterButterworth8Low(44100, 20);
+    m_pBandpassFilter = new EngineFilterButterworth8Band(44100, 20, 200);
+    m_pHighFilter = new EngineFilterButterworth8High(44100, 20);
+
+    m_pCrossfade_buffer = SampleUtil::alloc(MAX_BUFFER_LEN);
+    m_pBandpass_buffer = SampleUtil::alloc(MAX_BUFFER_LEN);
+}
+
+EngineFilterEffect::~EngineFilterEffect()
+{
+    delete m_pLowFilter;
+    delete m_pBandpassFilter;
+    delete m_pHighFilter;
+
+    SampleUtil::free(m_pCrossfade_buffer);
+    SampleUtil::free(m_pBandpass_buffer);
+}
+
+void EngineFilterEffect::applyFilters(const CSAMPLE *pIn, CSAMPLE *pOut,
+                                      const int iBufferSize)
+{
+    // Gain of bandpass filter
+    float bandpass_gain = 0.3f;
+
+    if (potmeterDepth->get() < 0.0f) {
+        // Apply lowpass filter into output buffer
+        m_pLowFilter->process(pIn, pOut, iBufferSize);
+        // Apply bandpass filter into bandpass buffer
+        m_pBandpassFilter->process(pIn, m_pBandpass_buffer, iBufferSize);
+    } else {
+        // Apply highpass filter into output buffer
+        m_pHighFilter->process(pIn, pOut, iBufferSize);
+        // Apply bandpass filter into bandpass buffer
+        m_pBandpassFilter->process(pIn, m_pBandpass_buffer, iBufferSize);
+    }
+
+    // Mix output buffer with bandpass buffer
+    SampleUtil::addWithGain(pOut, m_pBandpass_buffer, bandpass_gain, iBufferSize);
+}
+
+void EngineFilterEffect::process(const CSAMPLE *pIn, const CSAMPLE *pOut,
+                                 const int iBufferSize)
+{   
+    CSAMPLE * pOutput = (CSAMPLE *)pOut;
+    float depth = potmeterDepth->get();
+
+    // Filter is disabled
+    if (filterEnable->get() == 0.0f) {
+        return SampleUtil::copyWithGain(pOutput, pIn, 1.0f, iBufferSize);
+    }
+
+    if(depth == 0.0f) {
+        // Nothing to do
+        old_depth = depth;
+        return SampleUtil::copyWithGain(pOutput, pIn, 1.0f, iBufferSize);
+    } else if(depth == -1.0f || depth == 1.0f ) {
+        // Kill sound
+        old_depth = depth;
+        return SampleUtil::copyWithGain(pOutput, pIn, 0.0f, iBufferSize);
+    }
+
+    float freq, freq2;
+    // Length of bandpass filter
+    float bandpass_size = 0.01f;
+
+    // Need to apply old filters value into crossfade buffer and reset filters
+    if (old_depth != depth) {
+        // Apply old value into crossfade buffer
+        if (old_depth == 0.0f) {
+            SampleUtil::copyWithGain(m_pCrossfade_buffer, pIn, 1.0f, iBufferSize);
+        } else if (old_depth == -1.0f || old_depth == 1.0f) {
+            SampleUtil::copyWithGain(m_pCrossfade_buffer, pIn, 0.0f, iBufferSize);
+        } else {
+            applyFilters(pIn, m_pCrossfade_buffer, iBufferSize);
+        }
+
+        if (depth < 0.0f) {
+            // Lowpass + bandpass
+            // Freq from 2^5=32Hz to 2^(5+9)=16384
+            freq = pow(2.0, 5.0f+(depth+1.0f)*9.0f);
+            freq2 = pow(2.0, 5.0f+(depth+1.0f+bandpass_size)*9.0f);
+            m_pLowFilter->setFrequencyCorners(freq2);
+            m_pBandpassFilter->setFrequencyCorners(freq, freq2);
+        } else {
+            // Highpass + bandpass
+            freq = pow(2.0, 5.0f+depth*9.0f);
+            freq2 = pow(2.0, 5.0f+(depth+bandpass_size)*9.0f);
+            m_pHighFilter->setFrequencyCorners(freq);
+            m_pBandpassFilter->setFrequencyCorners(freq, freq2);
+        }
+    }
+
+    applyFilters(pIn, pOutput, iBufferSize);
+
+    // Crossfade old and new depth values
+    if( depth != old_depth ) {
+        SampleUtil::linearCrossfadeBuffers(pOutput, m_pCrossfade_buffer,
+                                           pOutput, iBufferSize);
+    }
+
+    // Save current depth value
+    old_depth = depth;
+}
+

--- a/src/engine/enginefiltereffect.cpp
+++ b/src/engine/enginefiltereffect.cpp
@@ -8,9 +8,10 @@
 
 EngineFilterEffect::EngineFilterEffect(const char* group) {
     potmeterDepth = ControlObject::getControl(ConfigKey(group, "filterDepth"));
-    if (potmeterDepth == NULL)
+    if (potmeterDepth == NULL) {
         potmeterDepth = new ControlPotmeter(ConfigKey(group, "filterDepth"),
                                             -1., 1.);
+    }
 
     filterEnable = new ControlPushButton(ConfigKey(group, "filter"));
     filterEnable->setButtonMode(ControlPushButton::TOGGLE);
@@ -40,18 +41,13 @@ void EngineFilterEffect::applyFilters(const CSAMPLE* pIn, CSAMPLE* pOut,
     float bandpass_gain = 0.3f;
 
     if (potmeterDepth->get() < 0.0f) {
-        // Apply lowpass filter into output buffer
         m_pLowFilter->process(pIn, pOut, iBufferSize);
-        // Apply bandpass filter into bandpass buffer
         m_pBandpassFilter->process(pIn, m_pBandpass_buffer, iBufferSize);
     } else {
-        // Apply highpass filter into output buffer
         m_pHighFilter->process(pIn, pOut, iBufferSize);
-        // Apply bandpass filter into bandpass buffer
         m_pBandpassFilter->process(pIn, m_pBandpass_buffer, iBufferSize);
     }
 
-    // Mix output buffer with bandpass buffer
     SampleUtil::addWithGain(pOut, m_pBandpass_buffer, bandpass_gain, iBufferSize);
 }
 

--- a/src/engine/enginefiltereffect.cpp
+++ b/src/engine/enginefiltereffect.cpp
@@ -84,7 +84,7 @@ void EngineFilterEffect::process(const CSAMPLE* pIn, const CSAMPLE* pOut,
             freq2 = pow(2.0, 5.0f + (depth + 1.0f + bandpass_size) * 9.0f);
             m_pLowFilter->setFrequencyCorners(freq2);
             m_pBandpassFilter->setFrequencyCorners(freq, freq2);
-        } else {
+        } else if (depth > 0.0f) {
             // Highpass + bandpass
             freq = pow(2.0, 5.0f + depth * 9.0f);
             freq2 = pow(2.0, 5.0f + (depth + bandpass_size) * 9.0f);

--- a/src/engine/enginefiltereffect.cpp
+++ b/src/engine/enginefiltereffect.cpp
@@ -41,11 +41,11 @@ EngineFilterEffect::~EngineFilterEffect() {
 }
 
 void EngineFilterEffect::applyFilters(const CSAMPLE* pIn, CSAMPLE* pOut,
-                                      const int iBufferSize) {
+                                      const int iBufferSize, float depth) {
     // Gain of bandpass filter
     float bandpass_gain = 0.3f;
 
-    if (potmeterDepth->get() < 0.0f) {
+    if (depth < 0.0f) {
         m_pLowFilter->process(pIn, pOut, iBufferSize);
         m_pBandpassFilter->process(pIn, m_pBandpass_buffer, iBufferSize);
     } else {
@@ -75,7 +75,7 @@ void EngineFilterEffect::process(const CSAMPLE* pIn, const CSAMPLE* pOut,
         } else if (old_depth == -1.0f || old_depth == 1.0f) {
             SampleUtil::copyWithGain(m_pCrossfade_buffer, pIn, 0.0f, iBufferSize);
         } else {
-            applyFilters(pIn, m_pCrossfade_buffer, iBufferSize);
+            applyFilters(pIn, m_pCrossfade_buffer, iBufferSize, old_depth);
         }
         if (depth < 0.0f) {
             // Lowpass + bandpass
@@ -98,7 +98,7 @@ void EngineFilterEffect::process(const CSAMPLE* pIn, const CSAMPLE* pOut,
     } else if (depth == -1.0f || depth == 1.0f) {
         SampleUtil::copyWithGain(pOutput, pIn, 0.0f, iBufferSize);
     } else {
-        applyFilters(pIn, pOutput, iBufferSize);
+        applyFilters(pIn, pOutput, iBufferSize, depth);
     }
 
     if (depth != old_depth) {

--- a/src/engine/enginefiltereffect.cpp
+++ b/src/engine/enginefiltereffect.cpp
@@ -25,7 +25,7 @@ EngineFilterEffect::EngineFilterEffect(const char* group) {
     m_pCrossfade_buffer = SampleUtil::alloc(MAX_BUFFER_LEN);
     m_pBandpass_buffer = SampleUtil::alloc(MAX_BUFFER_LEN);
 
-    old_depth = 1.0f;
+    old_depth = 0.0f;
 }
 
 EngineFilterEffect::~EngineFilterEffect() {

--- a/src/engine/enginefiltereffect.cpp
+++ b/src/engine/enginefiltereffect.cpp
@@ -15,6 +15,8 @@ EngineFilterEffect::EngineFilterEffect(const char* group) {
     filterEnable = new ControlPushButton(ConfigKey(group, "filter"));
     filterEnable->setButtonMode(ControlPushButton::TOGGLE);
 
+    // TODO(XXX) 44100 should be changed to real sample rate
+    // https://bugs.launchpad.net/mixxx/+bug/1208816
     m_pLowFilter = new EngineFilterButterworth8Low(44100, 20);
     m_pBandpassFilter = new EngineFilterButterworth8Band(44100, 20, 200);
     m_pHighFilter = new EngineFilterButterworth8High(44100, 20);

--- a/src/engine/enginefiltereffect.cpp
+++ b/src/engine/enginefiltereffect.cpp
@@ -91,14 +91,14 @@ void EngineFilterEffect::process(const CSAMPLE* pIn, const CSAMPLE* pOut,
         if (depth < 0.0f) {
             // Lowpass + bandpass
             // Freq from 2^5=32Hz to 2^(5+9)=16384
-            freq = pow(2.0, 5.0f+(depth+1.0f)*9.0f);
-            freq2 = pow(2.0, 5.0f+(depth+1.0f+bandpass_size)*9.0f);
+            freq = pow(2.0, 5.0f + (depth + 1.0f) * 9.0f);
+            freq2 = pow(2.0, 5.0f + (depth + 1.0f + bandpass_size) * 9.0f);
             m_pLowFilter->setFrequencyCorners(freq2);
             m_pBandpassFilter->setFrequencyCorners(freq, freq2);
         } else {
             // Highpass + bandpass
-            freq = pow(2.0, 5.0f+depth*9.0f);
-            freq2 = pow(2.0, 5.0f+(depth+bandpass_size)*9.0f);
+            freq = pow(2.0, 5.0f + depth * 9.0f);
+            freq2 = pow(2.0, 5.0f + (depth + bandpass_size) * 9.0f);
             m_pHighFilter->setFrequencyCorners(freq);
             m_pBandpassFilter->setFrequencyCorners(freq, freq2);
         }

--- a/src/engine/enginefiltereffect.cpp
+++ b/src/engine/enginefiltereffect.cpp
@@ -6,8 +6,7 @@
 #include "controlpushbutton.h"
 #include "controlpotmeter.h"
 
-EngineFilterEffect::EngineFilterEffect(const char * group)
-{
+EngineFilterEffect::EngineFilterEffect(const char* group) {
     potmeterDepth = ControlObject::getControl(ConfigKey(group, "filterDepth"));
     if (potmeterDepth == NULL)
         potmeterDepth = new ControlPotmeter(ConfigKey(group, "filterDepth"),
@@ -24,8 +23,7 @@ EngineFilterEffect::EngineFilterEffect(const char * group)
     m_pBandpass_buffer = SampleUtil::alloc(MAX_BUFFER_LEN);
 }
 
-EngineFilterEffect::~EngineFilterEffect()
-{
+EngineFilterEffect::~EngineFilterEffect() {
     delete m_pLowFilter;
     delete m_pBandpassFilter;
     delete m_pHighFilter;
@@ -34,9 +32,8 @@ EngineFilterEffect::~EngineFilterEffect()
     SampleUtil::free(m_pBandpass_buffer);
 }
 
-void EngineFilterEffect::applyFilters(const CSAMPLE *pIn, CSAMPLE *pOut,
-                                      const int iBufferSize)
-{
+void EngineFilterEffect::applyFilters(const CSAMPLE* pIn, CSAMPLE* pOut,
+                                      const int iBufferSize) {
     // Gain of bandpass filter
     float bandpass_gain = 0.3f;
 
@@ -56,10 +53,9 @@ void EngineFilterEffect::applyFilters(const CSAMPLE *pIn, CSAMPLE *pOut,
     SampleUtil::addWithGain(pOut, m_pBandpass_buffer, bandpass_gain, iBufferSize);
 }
 
-void EngineFilterEffect::process(const CSAMPLE *pIn, const CSAMPLE *pOut,
-                                 const int iBufferSize)
-{   
-    CSAMPLE * pOutput = (CSAMPLE *)pOut;
+void EngineFilterEffect::process(const CSAMPLE* pIn, const CSAMPLE* pOut,
+                                 const int iBufferSize) {
+    CSAMPLE* pOutput = (CSAMPLE*)pOut;
     float depth = potmeterDepth->get();
 
     // Filter is disabled
@@ -67,11 +63,11 @@ void EngineFilterEffect::process(const CSAMPLE *pIn, const CSAMPLE *pOut,
         return SampleUtil::copyWithGain(pOutput, pIn, 1.0f, iBufferSize);
     }
 
-    if(depth == 0.0f) {
+    if (depth == 0.0f) {
         // Nothing to do
         old_depth = depth;
         return SampleUtil::copyWithGain(pOutput, pIn, 1.0f, iBufferSize);
-    } else if(depth == -1.0f || depth == 1.0f ) {
+    } else if (depth == -1.0f || depth == 1.0f ) {
         // Kill sound
         old_depth = depth;
         return SampleUtil::copyWithGain(pOutput, pIn, 0.0f, iBufferSize);
@@ -111,7 +107,7 @@ void EngineFilterEffect::process(const CSAMPLE *pIn, const CSAMPLE *pOut,
     applyFilters(pIn, pOutput, iBufferSize);
 
     // Crossfade old and new depth values
-    if( depth != old_depth ) {
+    if (depth != old_depth) {
         SampleUtil::linearCrossfadeBuffers(pOutput, m_pCrossfade_buffer,
                                            pOutput, iBufferSize);
     }

--- a/src/engine/enginefiltereffect.h
+++ b/src/engine/enginefiltereffect.h
@@ -9,24 +9,23 @@ class EngineFilterButterworth8Low;
 class EngineFilterButterworth8Band;
 class EngineFilterButterworth8High;
 
-class EngineFilterEffect : public EngineObject
-{
-public:
-    EngineFilterEffect(const char * group);
+class EngineFilterEffect : public EngineObject {
+  public:
+    EngineFilterEffect(const char* group);
     ~EngineFilterEffect();
 
-    void process(const CSAMPLE *pIn, const CSAMPLE *pOut, const int iBufferSize);
-private:
-    void applyFilters(const CSAMPLE *pIn, CSAMPLE *pOut, const int iBufferSize);
+    void process(const CSAMPLE* pIn, const CSAMPLE* pOut, const int iBufferSize);
+  private:
+    void applyFilters(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize);
 
     // Buffers for old filter's value and for bandpass filter
-    CSAMPLE *m_pCrossfade_buffer, *m_pBandpass_buffer;
-    EngineFilterButterworth8Low *m_pLowFilter;
-    EngineFilterButterworth8Band *m_pBandpassFilter;
-    EngineFilterButterworth8High *m_pHighFilter;
+    CSAMPLE* m_pCrossfade_buffer, *m_pBandpass_buffer;
+    EngineFilterButterworth8Low* m_pLowFilter;
+    EngineFilterButterworth8Band* m_pBandpassFilter;
+    EngineFilterButterworth8High* m_pHighFilter;
 
-    ControlObject *potmeterDepth;
-    ControlPushButton *filterEnable;
+    ControlObject* potmeterDepth;
+    ControlPushButton* filterEnable;
 
     float old_depth;
 };

--- a/src/engine/enginefiltereffect.h
+++ b/src/engine/enginefiltereffect.h
@@ -1,0 +1,34 @@
+#ifndef ENGINEFILTEREFFECT_H
+#define ENGINEFILTEREFFECT_H
+
+#include "engineobject.h"
+
+class ControlObject;
+class ControlPushButton;
+class EngineFilterButterworth8Low;
+class EngineFilterButterworth8Band;
+class EngineFilterButterworth8High;
+
+class EngineFilterEffect : public EngineObject
+{
+public:
+    EngineFilterEffect(const char * group);
+    ~EngineFilterEffect();
+
+    void process(const CSAMPLE *pIn, const CSAMPLE *pOut, const int iBufferSize);
+private:
+    void applyFilters(const CSAMPLE *pIn, CSAMPLE *pOut, const int iBufferSize);
+
+    // Buffers for old filter's value and for bandpass filter
+    CSAMPLE *m_pCrossfade_buffer, *m_pBandpass_buffer;
+    EngineFilterButterworth8Low *m_pLowFilter;
+    EngineFilterButterworth8Band *m_pBandpassFilter;
+    EngineFilterButterworth8High *m_pHighFilter;
+
+    ControlObject *potmeterDepth;
+    ControlPushButton *filterEnable;
+
+    float old_depth;
+};
+
+#endif // ENGINEFILTEREFFECT_H

--- a/src/engine/enginefiltereffect.h
+++ b/src/engine/enginefiltereffect.h
@@ -19,7 +19,8 @@ class EngineFilterEffect : public EngineObject {
     void applyFilters(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize);
 
     // Buffers for old filter's value and for bandpass filter
-    CSAMPLE* m_pCrossfade_buffer, *m_pBandpass_buffer;
+    CSAMPLE* m_pCrossfade_buffer;
+    CSAMPLE* m_pBandpass_buffer;
     EngineFilterButterworth8Low* m_pLowFilter;
     EngineFilterButterworth8Band* m_pBandpassFilter;
     EngineFilterButterworth8High* m_pHighFilter;

--- a/src/engine/enginefiltereffect.h
+++ b/src/engine/enginefiltereffect.h
@@ -16,7 +16,8 @@ class EngineFilterEffect : public EngineObject {
 
     void process(const CSAMPLE* pIn, const CSAMPLE* pOut, const int iBufferSize);
   private:
-    void applyFilters(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize);
+    void applyFilters(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize,
+                      float depth);
 
     // Buffers for old filter's value and for bandpass filter
     CSAMPLE* m_pCrossfade_buffer;

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -435,7 +435,15 @@ void Tooltips::addStandardTooltips() {
             << tr("Flanger LFO Period")
             << tr("Adjusts the wavelength of the flange effect (when active).")
             << QString("%1: %2").arg(rightClick, resetToDefault);
-    
+
+    add("filter")
+            << tr("Filter")
+            << tr("Toggles the filter effect. Use the depth knobs to adjust.");
+
+    add("filterDepth")
+            << tr("Filter Depth")
+            << tr("Adjusts the intensity of the filter effect (when active).");
+
     add("time")
             << tr("Clock")
             << tr("Displays the current time.");


### PR DESCRIPTION
Hi!
I think filter effect is done. Clicks and ticks are removed, thanks to @ywwg's crossfade function.

You can listen how it sounds here: http://www.youtube.com/watch?v=nVnN0z2OXhA But in video I've used flanger's controls for changing depth end enabling effect. In this commit, I made separate controls for each decks (Flanger is still works too).

For testing you need to add knob and push button in the skin, or just download and replace "res/skins/LateNight1366x768-WXGA/skin.xml" from this commit https://github.com/xorik/mixxx/commit/4950363ca371b7c54d306c9193570e7af32acbac.

What need to do:
1) Check how it works on any controller (I think there are no problems here, I just can't test at this moment)
~~2) I don't know why, but tooltips are not worked~~
3) Also big problem is hardcoded 44100Hz in filters, but I think it is easy to fix (just replace with real sample rate). https://bugs.launchpad.net/mixxx/+bug/1208816
4) This filter has small resonance effect (which easy to remove, but it sounds good), but it is unable to change resonance force without patching and recompiling filter.

P.S. This effect is VERY useful when mixing: it sounds more smoothly, when you slowly kills sound with filter, not with volume.
