### PR TITLE
Fixing beatloop start position, when beat length<1

### DIFF
--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -646,6 +646,13 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint) {
                 if( beats >= 1.0f ) {
                     loop_in = prevBeat;
                 } else {
+                    // In case of beat length less then 1 beat:
+                    // (| - beats, ^ - current track's position):
+                    //
+                    // ...|...................^........|...
+                    //
+                    // If we press 1/2 beatloop we want loop from 50% to 100%,
+                    // If I press 1/4 beatloop, we want loop from 50% to 75% etc
                     double nextBeat =
                             floorf(m_pBeats->findNextBeat(cur_pos));
                     double beat_len = nextBeat - prevBeat;

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -640,8 +640,27 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint) {
             // TODO: If in reverse, should probably choose nextBeat.
             double prevBeat =
                     floorf(m_pBeats->findPrevBeat(getCurrentSample()));
-            loop_in = (m_pQuantizeEnabled->get() > 0.0 && prevBeat != -1) ?
-                    prevBeat : floorf(getCurrentSample());
+
+            if (m_pQuantizeEnabled->get() > 0.0 && prevBeat != -1) {
+                if( beats >= 1.0f ) {
+                    loop_in = prevBeat;
+                } else {
+                    double nextBeat =
+                            floorf(m_pBeats->findNextBeat(getCurrentSample()));
+                    double beat_len = nextBeat - prevBeat;
+                    double loops_per_beat = 1.0 / beats;
+                    double beat_pos = getCurrentSample() - prevBeat;
+                    int beat_frac =
+                            static_cast<int>(floor((beat_pos / beat_len) *
+                                                   loops_per_beat));
+                    loop_in = prevBeat + beat_len/loops_per_beat*beat_frac;
+                }
+
+            } else {
+                loop_in = floorf(getCurrentSample());
+            }
+
+
             if (!even(loop_in)) {
                 loop_in--;
             }

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -638,18 +638,19 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint) {
             // loop_in is set to the previous beat if quantize is on.  The
             // closest beat might be ahead of play position which would cause a seek.
             // TODO: If in reverse, should probably choose nextBeat.
+            double cur_pos = getCurrentSample();
             double prevBeat =
-                    floorf(m_pBeats->findPrevBeat(getCurrentSample()));
+                    floorf(m_pBeats->findPrevBeat(cur_pos));
 
             if (m_pQuantizeEnabled->get() > 0.0 && prevBeat != -1) {
                 if( beats >= 1.0f ) {
                     loop_in = prevBeat;
                 } else {
                     double nextBeat =
-                            floorf(m_pBeats->findNextBeat(getCurrentSample()));
+                            floorf(m_pBeats->findNextBeat(cur_pos));
                     double beat_len = nextBeat - prevBeat;
                     double loops_per_beat = 1.0 / beats;
-                    double beat_pos = getCurrentSample() - prevBeat;
+                    double beat_pos = cur_pos - prevBeat;
                     int beat_frac =
                             static_cast<int>(floor((beat_pos / beat_len) *
                                                    loops_per_beat));
@@ -657,7 +658,7 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint) {
                 }
 
             } else {
-                loop_in = floorf(getCurrentSample());
+                loop_in = floorf(cur_pos);
             }
 
 

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -653,7 +653,7 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint) {
                     int beat_frac =
                             static_cast<int>(floor((beat_pos / beat_len) *
                                                    loops_per_beat));
-                    loop_in = prevBeat + beat_len/loops_per_beat*beat_frac;
+                    loop_in = prevBeat + beat_len / loops_per_beat * beat_frac;
                 }
 
             } else {


### PR DESCRIPTION
I have been noticed: when I press beatloop button, it always starts loop in the start of the beat (if quantize is enabled of course).

When length of beat is >=1 it is ok, but when I need beat len<1 it is not good behavior.

EXAMPLE
(`|` - beats, `^` - current track's position):

```
...|...................^........|...
```

When I press 1/2 beatloop, it create loop from 0% to 50%, but I want from 50% to 100%
If I press 1/4 beatloop, I want loop from 50% to 75% etc

This patch is fix the problem.

It is also possible to make cool effect with slip_mode+beatloops now (add some echo, double beats etc, or even extra short loops like here: http://www.youtube.com/watch?feature=player_detailpage&v=_qiYi8H2nDU&t=108 on 1:48 - 2:05)
