### PR TITLE
Output buses [was bug #970965: Allow sending the crossfader inputs to an external mixer]

### DIFF
--- a/src/dlgprefsounditem.cpp
+++ b/src/dlgprefsounditem.cpp
@@ -37,13 +37,8 @@ DlgPrefSoundItem::DlgPrefSoundItem(QWidget *parent, AudioPathType type,
         , m_savedDevice("")
         , m_savedChannel(0) {
     setupUi(this);
-    if (AudioPath::isIndexed(type)) {
-        typeLabel->setText(
-            QString("%1 %2").arg(AudioPath::getTrStringFromType(type),
-                                 QString::number(index + 1)));
-    } else {
-        typeLabel->setText(AudioPath::getTrStringFromType(type));
-    }
+    typeLabel->setText(AudioPath::getTrStringFromType(type, index));
+
     deviceComboBox->addItem(tr("None"), "None");
     connect(deviceComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(deviceChanged(int)));

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -75,6 +75,7 @@ class EngineMaster : public EngineObject, public AudioSource {
     // These are really only exposed for tests to use.
     const CSAMPLE* getMasterBuffer() const;
     const CSAMPLE* getHeadphoneBuffer() const;
+    const CSAMPLE* getOutputBusBuffer(unsigned int i) const;
     const CSAMPLE* getDeckBuffer(unsigned int i) const;
     const CSAMPLE* getChannelBuffer(QString name) const;
 
@@ -130,9 +131,13 @@ class EngineMaster : public EngineObject, public AudioSource {
     };
 
     QList<ChannelInfo*> m_channels;
-    QList<CSAMPLE> m_channelMasterGainCache;
     QList<CSAMPLE> m_channelHeadphoneGainCache;
 
+    struct OutputBus {
+        CSAMPLE *m_pBuffer;
+        OrientationVolumeGainCalculator m_gain;
+        QList<CSAMPLE> m_gainCache;
+    } m_OutputBus[3];
     CSAMPLE* m_pMaster;
     CSAMPLE* m_pHead;
 

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -57,6 +57,10 @@ PlayerManager::PlayerManager(ConfigObject<ConfigValue>* pConfig,
             m_pEngine);
     m_pSoundManager->registerOutput(AudioOutput(AudioOutput::HEADPHONES),
             m_pEngine);
+    for (int o = EngineChannel::LEFT; o <= EngineChannel::RIGHT; o++) {
+      m_pSoundManager->registerOutput(AudioOutput(AudioOutput::BUS, 0, o),
+                                      m_pEngine);
+    }
 }
 
 PlayerManager::~PlayerManager() {

--- a/src/soundmanager.cpp
+++ b/src/soundmanager.cpp
@@ -321,7 +321,8 @@ int SoundManager::setupDevices() {
             if (err != OK) goto closeAndError;
             if (out.getType() == AudioOutput::MASTER) {
                 m_pClkRefDevice = device;
-            } else if (out.getType() == AudioOutput::DECK
+            } else if ((out.getType() == AudioOutput::DECK ||
+                        out.getType() == AudioOutput::BUS)
                     && !m_pClkRefDevice) {
                 m_pClkRefDevice = device;
             }

--- a/src/soundmanagerutil.cpp
+++ b/src/soundmanagerutil.cpp
@@ -15,6 +15,7 @@
 
 #include <QtCore>
 #include "soundmanagerutil.h"
+#include "engine/enginechannel.h"
 
 /**
  * Constructs a ChannelGroup.
@@ -154,6 +155,8 @@ QString AudioPath::getStringFromType(AudioPathType type) {
         return QString::fromAscii("Master");
     case HEADPHONES:
         return QString::fromAscii("Headphones");
+    case BUS:
+        return QString::fromAscii("Bus");
     case DECK:
         return QString::fromAscii("Deck");
     case VINYLCONTROL:
@@ -180,6 +183,17 @@ QString AudioPath::getTrStringFromType(AudioPathType type, unsigned char index) 
         return QString(QObject::tr("Master"));
     case HEADPHONES:
         return QString(QObject::tr("Headphones"));
+    case BUS:
+        switch (index) {
+        case EngineChannel::LEFT:
+            return QString(QObject::tr("Left bus"));
+        case EngineChannel::CENTER:
+            return QString(QObject::tr("Center bus"));
+        case EngineChannel::RIGHT:
+            return QString(QObject::tr("Right bus"));
+        default:
+            return QObject::tr("Invalid Bus");
+        }
     case DECK:
         return QString("%1 %2").arg(QObject::tr("Deck"),
                                     QString::number(index + 1));
@@ -203,6 +217,8 @@ AudioPathType AudioPath::getTypeFromString(QString string) {
         return AudioPath::MASTER;
     } else if (string == AudioPath::getStringFromType(AudioPath::HEADPHONES).toLower()) {
         return AudioPath::HEADPHONES;
+    } else if (string == AudioPath::getStringFromType(AudioPath::BUS).toLower()) {
+        return AudioPath::BUS;
     } else if (string == AudioPath::getStringFromType(AudioPath::DECK).toLower()) {
         return AudioPath::DECK;
     } else if (string == AudioPath::getStringFromType(AudioPath::VINYLCONTROL).toLower()) {
@@ -222,6 +238,7 @@ AudioPathType AudioPath::getTypeFromString(QString string) {
  */
 bool AudioPath::isIndexed(AudioPathType type) {
     switch (type) {
+    case BUS:
     case DECK:
     case VINYLCONTROL:
     case EXTPASSTHROUGH:
@@ -309,6 +326,7 @@ QList<AudioPathType> AudioOutput::getSupportedTypes() {
     QList<AudioPathType> types;
     types.append(MASTER);
     types.append(HEADPHONES);
+    types.append(BUS);
     types.append(DECK);
     return types;
 }

--- a/src/soundmanagerutil.cpp
+++ b/src/soundmanagerutil.cpp
@@ -136,11 +136,7 @@ bool AudioPath::channelsClash(const AudioPath &other) const {
  * Returns a string describing the AudioPath for user benefit.
  */
 QString AudioPath::getString() const {
-    if (isIndexed(getType())) {
-        return QString("%1 %2").arg(getTrStringFromType(getType()),
-                                    QString::number(m_index + 1));
-    }
-    return getTrStringFromType(getType());
+    return getTrStringFromType(m_type, m_index);
 }
 
 /**
@@ -174,7 +170,7 @@ QString AudioPath::getStringFromType(AudioPathType type) {
  * Returns a translated string given an AudioPathType.
  * @note This method is static.
  */
-QString AudioPath::getTrStringFromType(AudioPathType type) {
+QString AudioPath::getTrStringFromType(AudioPathType type, unsigned char index) {
     switch (type) {
     case INVALID:
         // this shouldn't happen but g++ complains if I don't
@@ -185,7 +181,8 @@ QString AudioPath::getTrStringFromType(AudioPathType type) {
     case HEADPHONES:
         return QString(QObject::tr("Headphones"));
     case DECK:
-        return QString(QObject::tr("Deck"));
+        return QString("%1 %2").arg(QObject::tr("Deck"),
+                                    QString::number(index + 1));
     case VINYLCONTROL:
         return QString(QObject::tr("Vinyl Control"));
     case MICROPHONE:

--- a/src/soundmanagerutil.h
+++ b/src/soundmanagerutil.h
@@ -55,6 +55,7 @@ public:
     enum AudioPathType {
         MASTER,
         HEADPHONES,
+        BUS,
         DECK,
         VINYLCONTROL,
         MICROPHONE,

--- a/src/soundmanagerutil.h
+++ b/src/soundmanagerutil.h
@@ -70,7 +70,7 @@ public:
     bool channelsClash(const AudioPath &other) const;
     QString getString() const;
     static QString getStringFromType(AudioPathType type);
-    static QString getTrStringFromType(AudioPathType type);
+    static QString getTrStringFromType(AudioPathType type, unsigned char index);
     static AudioPathType getTypeFromString(QString string);
     static bool isIndexed(AudioPathType type);
     static AudioPathType getTypeFromInt(int typeInt);


### PR DESCRIPTION
An updated version of the feature I submitted in bug [#970965](https://bugs.launchpad.net/mixxx/+bug/970965). It add outputs for the Left, Center and Right buses, as an alternative to the deck outputs that still allow using the samplers with an external mixer.
