### PR TITLE
Allow out-of-bound values for controlpotmeters

### DIFF
--- a/src/control/controlbehavior.cpp
+++ b/src/control/controlbehavior.cpp
@@ -39,11 +39,7 @@ ControlPotmeterBehavior::~ControlPotmeterBehavior() {
 }
 
 bool ControlPotmeterBehavior::setFilter(double* dValue) {
-    if (*dValue > m_dMaxValue) {
-        *dValue = m_dMaxValue;
-    } else if (*dValue < m_dMinValue) {
-        *dValue = m_dMinValue;
-    }
+    Q_UNUSED(dValue);
     return true;
 }
 
@@ -53,6 +49,11 @@ double ControlPotmeterBehavior::defaultValue(double dDefault) const {
 }
 
 double ControlPotmeterBehavior::valueToWidgetParameter(double dValue) {
+    if (dValue > m_dMaxValue) {
+        dValue = m_dMaxValue;
+    } else if (dValue < m_dMinValue) {
+        dValue = m_dMinValue;
+    }
     double dNorm = (dValue - m_dMinValue) / m_dValueRange;
     return dNorm < 0.5 ? dNorm * 128.0 : dNorm * 126.0 + 1.0;
 }
@@ -98,6 +99,11 @@ double ControlLogpotmeterBehavior::defaultValue(double dDefault) {
 }
 
 double ControlLogpotmeterBehavior::valueToWidgetParameter(double dValue) {
+    if (dValue > m_dMaxValue) {
+        dValue = m_dMaxValue;
+    } else if (dValue < m_dMinValue) {
+        dValue = m_dMinValue;
+    }
     if (!m_bTwoState) {
         return log10(dValue + 1) / m_dB1;
     } else {
@@ -129,6 +135,11 @@ ControlLinPotmeterBehavior::~ControlLinPotmeterBehavior() {
 }
 
 double ControlLinPotmeterBehavior::valueToWidgetParameter(double dValue) {
+    if (dValue > m_dMaxValue) {
+        dValue = m_dMaxValue;
+    } else if (dValue < m_dMinValue) {
+        dValue = m_dMinValue;
+    }
     double dNorm = (dValue - m_dMinValue) / m_dValueRange;
     return math_min(dNorm * 128, 127);
 }
@@ -209,4 +220,3 @@ void ControlPushButtonBehavior::setValueFromMidiParameter(
         }
     }
 }
-

--- a/src/control/controlbehavior.cpp
+++ b/src/control/controlbehavior.cpp
@@ -55,11 +55,11 @@ double ControlPotmeterBehavior::valueToWidgetParameter(double dValue) {
         dValue = m_dMinValue;
     }
     double dNorm = (dValue - m_dMinValue) / m_dValueRange;
-    return dNorm < 0.5 ? dNorm * 128.0 : dNorm * 126.0 + 1.0;
+    return dNorm < 0.5 ? dNorm * 127.0 : dNorm * 126.0 + 1.0;
 }
 
 double ControlPotmeterBehavior::widgetParameterToValue(double dParam) {
-    double dNorm = dParam < 64 ? dParam / 128.0 : (dParam - 1.0) / 126.0;
+    double dNorm = dParam < 64 ? dParam / 127.0 : (dParam - 1.0) / 126.0;
     return m_dMinValue + dNorm * m_dValueRange;
 }
 
@@ -141,11 +141,11 @@ double ControlLinPotmeterBehavior::valueToWidgetParameter(double dValue) {
         dValue = m_dMinValue;
     }
     double dNorm = (dValue - m_dMinValue) / m_dValueRange;
-    return math_min(dNorm * 128, 127);
+    return math_min(dNorm * 127, 127);
 }
 
 double ControlLinPotmeterBehavior::widgetParameterToValue(double dParam) {
-    double dNorm = dParam / 128.0;
+    double dNorm = dParam / 127.0;
     return m_dMinValue + dNorm * m_dValueRange;
 }
 

--- a/src/dlgautodj.cpp
+++ b/src/dlgautodj.cpp
@@ -106,7 +106,6 @@ DlgAutoDJ::DlgAutoDJ(QWidget* parent, ConfigObject<ConfigValue>* pConfig,
     connect(m_pCOTEnabledAutoDJ, SIGNAL(valueChanged(double)),
             this, SLOT(enableAutoDJCo(double)));
 
-    // playposition is from -0.14 to + 1.14
     m_pCOPlayPos1 = new ControlObjectThreadMain("[Channel1]", "playposition");
     m_pCOPlayPos2 = new ControlObjectThreadMain("[Channel2]", "playposition");
     m_pCOPlay1 = new ControlObjectThreadMain("[Channel1]", "play");

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -45,8 +45,8 @@
 
 #include "trackinfoobject.h"
 
-const double kMaxPlayposRange = 1.14;
-const double kMinPlayposRange = -0.14;
+const double kMaxPlayposRange = 1.0;
+const double kMinPlayposRange = 0.0;
 
 EngineBuffer::EngineBuffer(const char * _group, ConfigObject<ConfigValue> * _config) :
     m_engineLock(QMutex::Recursive),
@@ -159,7 +159,6 @@ EngineBuffer::EngineBuffer(const char * _group, ConfigObject<ConfigValue> * _con
     m_visualBpm = new ControlObject(ConfigKey(m_group, "visual_bpm"));
 
     // Slider to show and change song position
-    //these bizarre choices map conveniently to the 0-127 range of midi
     m_playposSlider = new ControlLinPotmeter(
         ConfigKey(m_group, "playposition"), kMinPlayposRange, kMaxPlayposRange);
     connect(m_playposSlider, SIGNAL(valueChanged(double)),
@@ -451,7 +450,7 @@ void EngineBuffer::ejectTrack() {
 // WARNING: This method runs in both the GUI thread and the Engine Thread
 void EngineBuffer::slotControlSeek(double change)
 {
-    if(isnan(change) || change > kMaxPlayposRange || change < kMinPlayposRange) {
+    if(isnan(change)) {
         // This seek is ridiculous.
         return;
     }

--- a/src/engine/vinylcontrolcontrol.cpp
+++ b/src/engine/vinylcontrolcontrol.cpp
@@ -63,7 +63,7 @@ void VinylControlControl::trackUnloaded(TrackPointer pTrack) {
 }
 
 void VinylControlControl::slotControlVinylSeek(double change) {
-    if(isnan(change) || change > 1.14 || change < -1.14) {
+    if(isnan(change)) {
         // This seek is ridiculous.
         return;
     }

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -10,7 +10,7 @@ VinylControl::VinylControl(ConfigObject<ConfigValue> * pConfig, QString group)
     iSampleRate = m_pConfig->getValueString(ConfigKey("[Soundcard]","Samplerate")).toULong();
 
     // Get Control objects
-    playPos             = new ControlObjectThread(group, "playposition");    //Range: -.14 to 1.14
+    playPos             = new ControlObjectThread(group, "playposition");
     trackSamples        = new ControlObjectThread(group, "track_samples");
     trackSampleRate     = new ControlObjectThread(group, "track_samplerate");
     vinylSeek           = new ControlObjectThread(group, "vinylcontrol_seek");
@@ -111,4 +111,3 @@ float VinylControl::getSpeed()
 {
     return dVinylScratch;
 }
-

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -23,6 +23,9 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
             this, SLOT(slotSetRemain(double)));
     slotSetRemain(m_pShowTrackTimeRemaining->get());
 
+    m_pVisualPlaypos = new ControlObjectThreadMain(group, "visual_playposition");
+    connect(m_pVisualPlaypos, SIGNAL(valueChanged(double)), this, SLOT(slotSetValue(double)));
+
     m_pTrackSamples = new ControlObjectThreadWidget(
             group, "track_samples");
     connect(m_pTrackSamples, SIGNAL(valueChanged(double)),
@@ -66,13 +69,18 @@ void WNumberPos::slotSetTrackSampleRate(double dSampleRate) {
 }
 
 void WNumberPos::setValue(double dValue) {
+    // Ignore midi-scaled signals from the skin connection.
+    Q_UNUSED(dValue);
+}
+
+void WNumberPos::slotSetValue(double dValue) {
     m_dOldValue = dValue;
 
     double valueMillis = 0.0f;
     double durationMillis = 0.0f;
     if (m_dTrackSamples > 0 && m_dTrackSampleRate > 0) {
         double dDuration = m_dTrackSamples / m_dTrackSampleRate / 2.0;
-        valueMillis = dValue * 500.0f / 127.0f * m_dTrackSamples / m_dTrackSampleRate;
+        valueMillis = dValue * 500.0f * m_dTrackSamples / m_dTrackSampleRate;
         durationMillis = dDuration * 1000.0f;
         if (m_bRemain)
             valueMillis = math_max(durationMillis - valueMillis, 0.0f);
@@ -111,3 +119,9 @@ void WNumberPos::setRemain(bool bRemain)
     // Have the widget redraw itself with its current value.
     setValue(m_dOldValue);
 }
+
+
+
+
+
+

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -23,6 +23,9 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
             this, SLOT(slotSetRemain(double)));
     slotSetRemain(m_pShowTrackTimeRemaining->get());
 
+    // Use the engine's playposition value instead of midi-clamped value for displaying position.
+    // This allows us to display preroll values like -5:00.  It also means that the
+    // <Connection> parameter is no longer necessary in skin definitions.
     m_pVisualPlaypos = new ControlObjectThreadMain(group, "visual_playposition");
     connect(m_pVisualPlaypos, SIGNAL(valueChanged(double)), this, SLOT(slotSetValue(double)));
 
@@ -66,11 +69,6 @@ void WNumberPos::slotSetTrackSamples(double dSamples) {
 void WNumberPos::slotSetTrackSampleRate(double dSampleRate) {
     m_dTrackSampleRate = dSampleRate;
     setValue(m_dOldValue);
-}
-
-void WNumberPos::setValue(double dValue) {
-    // Ignore midi-scaled signals from the skin connection.
-    Q_UNUSED(dValue);
 }
 
 void WNumberPos::slotSetValue(double dValue) {
@@ -119,9 +117,3 @@ void WNumberPos::setRemain(bool bRemain)
     // Have the widget redraw itself with its current value.
     setValue(m_dOldValue);
 }
-
-
-
-
-
-

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -63,12 +63,17 @@ void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {
 
 void WNumberPos::slotSetTrackSamples(double dSamples) {
     m_dTrackSamples = dSamples;
-    setValue(m_dOldValue);
+    slotSetValue(m_dOldValue);
 }
 
 void WNumberPos::slotSetTrackSampleRate(double dSampleRate) {
     m_dTrackSampleRate = dSampleRate;
-    setValue(m_dOldValue);
+    slotSetValue(m_dOldValue);
+}
+
+void WNumberPos::setValue(double dValue) {
+    // Ignore midi-scaled signals from the skin connection.
+    Q_UNUSED(dValue);
 }
 
 void WNumberPos::slotSetValue(double dValue) {
@@ -115,5 +120,5 @@ void WNumberPos::setRemain(bool bRemain)
         m_qsText = "";
 
     // Have the widget redraw itself with its current value.
-    setValue(m_dOldValue);
+    slotSetValue(m_dOldValue);
 }

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -26,7 +26,7 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
     // Use the engine's playposition value instead of midi-clamped value for displaying position.
     // This allows us to display preroll values like -5:00.  It also means that the
     // <Connection> parameter is no longer necessary in skin definitions.
-    m_pVisualPlaypos = new ControlObjectThreadMain(group, "visual_playposition");
+    m_pVisualPlaypos = new ControlObjectThreadMain(group, "playposition");
     connect(m_pVisualPlaypos, SIGNAL(valueChanged(double)), this, SLOT(slotSetValue(double)));
 
     m_pTrackSamples = new ControlObjectThreadWidget(

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -71,9 +71,8 @@ void WNumberPos::setValue(double dValue) {
     double valueMillis = 0.0f;
     double durationMillis = 0.0f;
     if (m_dTrackSamples > 0 && m_dTrackSampleRate > 0) {
-        //map midi value taking in to account 14 = 0 and 114 = 1
         double dDuration = m_dTrackSamples / m_dTrackSampleRate / 2.0;
-        valueMillis = (dValue - 14) * 1000.0f * m_dTrackSamples / 2.0f / 100.0f / m_dTrackSampleRate;
+        valueMillis = dValue * 500.0f / 127.0f * m_dTrackSamples / m_dTrackSampleRate;
         durationMillis = dDuration * 1000.0f;
         if (m_bRemain)
             valueMillis = math_max(durationMillis - valueMillis, 0.0f);
@@ -112,9 +111,3 @@ void WNumberPos::setRemain(bool bRemain)
     // Have the widget redraw itself with its current value.
     setValue(m_dOldValue);
 }
-
-
-
-
-
-

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -26,6 +26,7 @@ class WNumberPos : public WNumber {
     void mousePressEvent(QMouseEvent* pEvent);
 
   private slots:
+    void slotSetValue(double);
     void slotSetRemain(double dRemain);
     void slotSetTrackSampleRate(double dSampleRate);
     void slotSetTrackSamples(double dSamples);
@@ -38,8 +39,9 @@ class WNumberPos : public WNumber {
     /** True if remaining content is being shown */
     bool m_bRemain;
     ControlObjectThreadMain* m_pShowTrackTimeRemaining;
-    // Pointer to control object for rate and track info
-    ControlObjectThreadWidget* m_pTrackSamples; 
+    // Pointer to control object for position, rate, and track info
+    ControlObjectThreadMain* m_pVisualPlaypos;
+    ControlObjectThreadWidget* m_pTrackSamples;
     ControlObjectThreadWidget* m_pTrackSampleRate;
 };
 

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -18,7 +18,6 @@ class WNumberPos : public WNumber {
     WNumberPos(const char *group, QWidget *parent=0);
     virtual ~WNumberPos();
 
-    void setValue(double dValue);
     /** Set if the display shows remaining time (true) or position (false) */
     void setRemain(bool bRemain);
 

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -18,6 +18,7 @@ class WNumberPos : public WNumber {
     WNumberPos(const char *group, QWidget *parent=0);
     virtual ~WNumberPos();
 
+    void setValue(double dValue);
     /** Set if the display shows remaining time (true) or position (false) */
     void setRemain(bool bRemain);
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -471,7 +471,7 @@ void WOverview::paintText(const QString &text, QPainter *painter) {
 
 void WOverview::resizeEvent(QResizeEvent *) {
     //Those coeficient map position from [0;width-1] to value [0;127]
-    m_a = (float)((width()-1))/(127.f);
+    m_a = static_cast<float>(width() - 1) / 127.f;
     m_waveformImageScaled = QImage();
     m_diffGain = 0;
 }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -44,7 +44,6 @@ WOverview::WOverview(const char *pGroup, ConfigObject<ConfigValue>* pConfig, QWi
         m_bDrag(false),
         m_iPos(0),
         m_a(1.0),
-        m_b(0.0),
         m_analyserProgress(-1),
         m_trackLoaded(false) {
     m_endOfTrackControl = new ControlObjectThreadMain(
@@ -471,9 +470,8 @@ void WOverview::paintText(const QString &text, QPainter *painter) {
 }
 
 void WOverview::resizeEvent(QResizeEvent *) {
-    //Those coeficient map position from [0;width-1] to value [14;114]
-    m_a = (float)((width()-1))/( 114.f - 14.f);
-    m_b = 14.f * m_a;
+    //Those coeficient map position from [0;width-1] to value [0;127]
+    m_a = (float)((width()-1))/(127.f);
     m_waveformImageScaled = QImage();
     m_diffGain = 0;
 }

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -89,7 +89,6 @@ class WOverview : public WWidget {
     }
     inline double positionToValue(int position) const {
         return static_cast<float>(position) / m_a;
-
     }
 
     const QString m_group;

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -85,10 +85,10 @@ class WOverview : public WWidget {
     virtual bool drawNextPixmapPart() = 0;
     void paintText(const QString &text, QPainter *painter);
     inline int valueToPosition(float value) const {
-        return (int)(m_a * value);
+        return static_cast<int>(m_a * value);
     }
     inline double positionToValue(int position) const {
-        return ((float)position) / m_a;
+        return static_cast<float>(position) / m_a;
 
     }
 

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -85,10 +85,10 @@ class WOverview : public WWidget {
     virtual bool drawNextPixmapPart() = 0;
     void paintText(const QString &text, QPainter *painter);
     inline int valueToPosition(float value) const {
-        return (int)(m_a * value - m_b + 0.5);
+        return (int)(m_a * value);
     }
     inline double positionToValue(int position) const {
-        return ((float)position + m_b) / m_a;
+        return ((float)position) / m_a;
 
     }
 
@@ -118,7 +118,6 @@ class WOverview : public WWidget {
 
     // Coefficient value-position linear transposition
     float m_a;
-    float m_b;
 
     int m_analyserProgress; // In 0.1%
     bool m_trackLoaded;


### PR DESCRIPTION
Allow potmeters to hold values outside their ranges, but clamp their ranges when converting to midi.  This allows for preroll without the ugly 14-114 midi hack!  It also allows range sliders to be increased outside of their visible range, which is important for master sync.
