### PR TITLE
Fix incorrect Metadata for Icecast2 with OGG/VORBIS (bug #1180774)

### DIFF
--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -583,50 +583,50 @@ void EngineShoutcast::updateMetaData() {
      */
 
 
-    //If we use either MP3 streaming or OGG streaming with dynamic update of metadata being enabled,
-    //we want dynamic metadata changes
+    // If we use either MP3 streaming or OGG streaming with dynamic update of
+    // metadata being enabled, we want dynamic metadata changes
     if (!m_custom_metadata && (m_format_is_mp3 || m_ogg_dynamic_update)) {
         if (m_pMetaData != NULL) {
 
             QString artist = m_pMetaData->getArtist();
             QString title = m_pMetaData->getTitle();
 
-    	    // shoutcast ( / MP3 ?) uses only "song" as field for "artist - title".
-    	    // icecast2 supports separate fields for "artist" and "title".
-        	// "song" is only an alias for title
-        	//
-        	// Note(EinWesen): I do not know, about icecast1 or MP3 on icecast2
-        	//                 so we stick to the old way for those use cases
-        	if (!m_format_is_mp3 && m_protocol_is_icecast2) {
+            // shoutcast uses only "song" as field for "artist - title".
+            // icecast2 supports separate fields for "artist" and "title", 
+            // which will get displayed accordingly if the streamingformat and
+            // player supports it. ("song" is treated as an alias for "title")
+            // 
+            // Note (EinWesen): 
+            // Currently that seems to be OGG only, although it is no problem 
+            // setting both fields for MP3, tested players do not show anything different.
+            // Also I do not know about icecast1. To be safe, i stick to the
+            // old way for those use cases.
+            if (!m_format_is_mp3 && m_protocol_is_icecast2) {
                 shout_metadata_add(m_pShoutMetaData, "artist",  encodeString(artist).constData());
                 shout_metadata_add(m_pShoutMetaData, "title",  encodeString(title).constData());
-        	} else {
+            } else {
                 QByteArray baSong = encodeString(artist.isEmpty() ? title : artist + " - " + title);
                 shout_metadata_add(m_pShoutMetaData, "song",  baSong.constData());
-        	}
+            }
             shout_set_metadata(m_pShout, m_pShoutMetaData);
 
         }
     } else {
-        //Otherwise we might use static metadata
-        /** If we use static metadata, we only need to call the following line once **/
+        // Otherwise we might use static metadata
+        // If we use static metadata, we only need to call the following line once
         if (m_custom_metadata && !m_firstCall) {
 
-        	// see comment above...
+            // see comment above...
             if (!m_format_is_mp3 && m_protocol_is_icecast2) {
-                shout_metadata_add(m_pShoutMetaData,
-                		           "artist",
-                		           encodeString(m_customArtist).constData());
+                shout_metadata_add(
+                    m_pShoutMetaData,"artist",encodeString(m_customArtist).constData());
 
-                shout_metadata_add(m_pShoutMetaData,
-                		           "title",
-                		           encodeString(m_customTitle).constData());
-        	} else {
-                QByteArray baCustomSong =
-            	    encodeString(m_customArtist.isEmpty() ? m_customTitle : m_customArtist + " - " + m_customTitle);
-
+                shout_metadata_add(
+                    m_pShoutMetaData,"title",encodeString(m_customTitle).constData());
+            } else {
+                QByteArray baCustomSong = encodeString(m_customArtist.isEmpty() ? m_customTitle : m_customArtist + " - " + m_customTitle);
                 shout_metadata_add(m_pShoutMetaData, "song", baCustomSong.constData());
-        	}
+            }
 
             shout_set_metadata(m_pShout, m_pShoutMetaData);
             m_firstCall = true;

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -173,44 +173,45 @@ void EngineShoutcast::updateFromPreferences() {
 
     // Host, server type, port, mountpoint, login, password should be latin1.
     QByteArray baHost = m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "host")).toLatin1();
+            ConfigKey(SHOUTCAST_PREF_KEY, "host")).toLatin1();
     QByteArray baServerType = m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "servertype")).toLatin1();
+            ConfigKey(SHOUTCAST_PREF_KEY, "servertype")).toLatin1();
     QByteArray baPort = m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "port")).toLatin1();
+            ConfigKey(SHOUTCAST_PREF_KEY, "port")).toLatin1();
     QByteArray baMountPoint = m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "mountpoint")).toLatin1();
+            ConfigKey(SHOUTCAST_PREF_KEY, "mountpoint")).toLatin1();
     QByteArray baLogin = m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "login")).toLatin1();
+            ConfigKey(SHOUTCAST_PREF_KEY, "login")).toLatin1();
     QByteArray baPassword = m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "password")).toLatin1();
+            ConfigKey(SHOUTCAST_PREF_KEY, "password")).toLatin1();
     QByteArray baFormat = m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "format")).toLatin1();
+            ConfigKey(SHOUTCAST_PREF_KEY, "format")).toLatin1();
     QByteArray baBitrate = m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "bitrate")).toLatin1();
+            ConfigKey(SHOUTCAST_PREF_KEY, "bitrate")).toLatin1();
 
     // Encode metadata like stream name, website, desc, genre, title/author with
     // the chosen TextCodec.
     QByteArray baStreamName = encodeString(m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "stream_name")));
+            ConfigKey(SHOUTCAST_PREF_KEY, "stream_name")));
     QByteArray baStreamWebsite = encodeString(m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "stream_website")));
+            ConfigKey(SHOUTCAST_PREF_KEY, "stream_website")));
     QByteArray baStreamDesc = encodeString(m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "stream_desc")));
+            ConfigKey(SHOUTCAST_PREF_KEY, "stream_desc")));
     QByteArray baStreamGenre = encodeString(m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "stream_genre")));
+            ConfigKey(SHOUTCAST_PREF_KEY, "stream_genre")));
     QByteArray baStreamPublic = encodeString(m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "stream_public")));
+            ConfigKey(SHOUTCAST_PREF_KEY, "stream_public")));
 
     // Dynamic Ogg metadata update
-    m_ogg_dynamic_update = (bool)m_pConfig->getValueString(ConfigKey(SHOUTCAST_PREF_KEY,"ogg_dynamicupdate")).toInt();
+    m_ogg_dynamic_update = (bool)m_pConfig->getValueString(
+	        ConfigKey(SHOUTCAST_PREF_KEY,"ogg_dynamicupdate")).toInt();
 
     m_custom_metadata = (bool)m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "enable_metadata")).toInt();
+            ConfigKey(SHOUTCAST_PREF_KEY, "enable_metadata")).toInt();
     m_customTitle = m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "custom_title"));
+            ConfigKey(SHOUTCAST_PREF_KEY, "custom_title"));
     m_customArtist = m_pConfig->getValueString(
-        ConfigKey(SHOUTCAST_PREF_KEY, "custom_artist"));
+            ConfigKey(SHOUTCAST_PREF_KEY, "custom_artist"));
 
     int format;
     int protocol;
@@ -619,10 +620,10 @@ void EngineShoutcast::updateMetaData() {
             // see comment above...
             if (!m_format_is_mp3 && m_protocol_is_icecast2) {
                 shout_metadata_add(
-                    m_pShoutMetaData,"artist",encodeString(m_customArtist).constData());
+                        m_pShoutMetaData,"artist",encodeString(m_customArtist).constData());
 
                 shout_metadata_add(
-                    m_pShoutMetaData,"title",encodeString(m_customTitle).constData());
+                        m_pShoutMetaData,"title",encodeString(m_customTitle).constData());
             } else {
                 QByteArray baCustomSong = encodeString(m_customArtist.isEmpty() ? m_customTitle : m_customArtist + " - " + m_customTitle);
                 shout_metadata_add(m_pShoutMetaData, "song", baCustomSong.constData());

--- a/src/engine/sidechain/engineshoutcast.h
+++ b/src/engine/sidechain/engineshoutcast.h
@@ -98,7 +98,8 @@ class EngineShoutcast : public QObject, public EncoderCallback, public SideChain
     volatile bool m_bQuit;
     // static metadata according to prefereneces
     bool m_custom_metadata;
-    QByteArray m_baCustomSong;
+    QString m_customArtist;
+    QString m_customTitle;
 
     // when static metadata is used, we only need calling shout_set_metedata
     // once


### PR DESCRIPTION
This patch should address the issues mentioned in bug #1180774 .

I tried listening to a stream (created with a mixx version, which included my patch) with serveral players and did not experience any problems.

If you have questions, please ask.
