### PR TITLE
Add "passthrough" and "filter" effect to Controller wizard

### DIFF
--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -183,7 +183,7 @@ DlgControllerLearning::DlgControllerLearning(QWidget * parent,
     addControl("[Playlist]", "LoadSelectedIntoFirstStopped", tr("Load selected track into first stopped deck"),
                libraryMenu);
     addDeckAndSamplerControl("LoadSelectedTrack", tr("Load selected track"), libraryMenu);
-    aaddDeckAndSamplerAndPreviewDeckControl("LoadSelectedTrackAndPlay", tr("Load selected track and play"), libraryMenu);
+    addDeckAndSamplerAndPreviewDeckControl("LoadSelectedTrackAndPlay", tr("Load selected track and play"), libraryMenu);
 
     // Effect Controls
     QMenu* effectsMenu = addSubmenu(tr("Effects"));

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -103,6 +103,7 @@ DlgControllerLearning::DlgControllerLearning(QWidget * parent,
     addDeckControl("vinylcontrol_enabled", tr("Toggle vinyl-control (ON/OFF)"), vinylControlMenu);
     addDeckControl("vinylcontrol_cueing", tr("Toggle vinyl-control cueing mode (OFF/ONE/HOT)"), vinylControlMenu);
     addDeckControl("vinylcontrol_mode", tr("Toggle vinyl-control mode (ABS/REL/CONST)"), vinylControlMenu);
+    addDeckControl("passthrough", tr("Pass through external audio into the internal mixer"), vinylControlMenu);
     addControl(VINYL_PREF_KEY, "Toggle", tr("Single deck mode - Toggle vinyl control to next deck"), vinylControlMenu);
 
     // Cues
@@ -184,12 +185,14 @@ DlgControllerLearning::DlgControllerLearning(QWidget * parent,
     addDeckAndSamplerControl("LoadSelectedTrack", tr("Load selected track"), libraryMenu);
     addDeckAndSamplerControl("LoadSelectedTrackAndPlay", tr("Load selected track and play"), libraryMenu);
 
-    // Flanger Controls
+    // Effect Controls
     QMenu* effectsMenu = addSubmenu(tr("Effects"));
     addDeckControl("flanger", tr("Toggle flange effect"), effectsMenu);
     addControl("[Flanger]", "lfoPeriod", tr("Flange effect: Wavelength/period"), effectsMenu, true);
     addControl("[Flanger]", "lfoDepth", tr("Flange effect: Intensity"), effectsMenu, true);
     addControl("[Flanger]", "lfoDelay", tr("Flange effect: Phase delay"), effectsMenu, true);
+    addDeckControl("filter", tr("Toggle filter effect"), effectsMenu);
+    addDeckControl("filterDepth", tr("Filter effect: Intensity"), effectsMenu, true);
 
     // Microphone Controls
     QMenu* microphoneMenu = addSubmenu(tr("Microphone"));

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -183,7 +183,7 @@ DlgControllerLearning::DlgControllerLearning(QWidget * parent,
     addControl("[Playlist]", "LoadSelectedIntoFirstStopped", tr("Load selected track into first stopped deck"),
                libraryMenu);
     addDeckAndSamplerControl("LoadSelectedTrack", tr("Load selected track"), libraryMenu);
-    addDeckAndSamplerControl("LoadSelectedTrackAndPlay", tr("Load selected track and play"), libraryMenu);
+    aaddDeckAndSamplerAndPreviewDeckControl("LoadSelectedTrackAndPlay", tr("Load selected track and play"), libraryMenu);
 
     // Effect Controls
     QMenu* effectsMenu = addSubmenu(tr("Effects"));


### PR DESCRIPTION
Add the possibility to map the controls to a MIDI device using the Controller wizard. Lacks GUI feedback with the current skins, but works. 
