### PR TITLE
Shoutcast/Icecast: Do not skip metadata for the first song on reconnect

### DIFF
--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -368,6 +368,11 @@ bool EngineShoutcast::serverConnect() {
     // set to a high number to automatically update the metadata
     // on the first change
     m_iMetaDataLife = 31337;
+    // clear metadata, to make sure the first track is not skipped
+    // because it was sent via an previous connection (see metaDataHasChanged)
+    if(m_pMetaData) {
+        m_pMetaData.clear();
+    }
     //If static metadata is available, we only need to send metadata one time
     m_firstCall = false;
 


### PR DESCRIPTION
Hi Mixxx team,

Former testing with Mixxx revealed another bug concerning the sending of metadata. 

The metadata is (as expected) updated only when the track changes. To achieve this the current tack information is compared with those last sent to the server. The scope of responsible pointer holding that information is not connection specific and is therefore reused for every connection made during a session. 

If one disconnects and reconnects to the server (due to network errors for example), the metadata is not updated because the track did not change, which in this case leaves the stream without any information about the currently running song until the track changes.

This patch fixes this problem by clearing the held information on connect, which was already the case for other values.
I don’t see a possibility for side effects in Mixxx here (unless I misunderstood how QWeakPointer works, I have no knowledge about QT). 

The song will of course most probably be listed twice in logfiles which the servers usually create, but from a technical point of view that would be correct, as this case is “some kind of new transmission” and I think that is the lesser impact in comparison to the original problem. 

I can create a bug on Launchpad in addition to this pull request if you think that is necessary. Just drop me a line.
