### PR TITLE
add bindings for other vinylcontrol functions

### DIFF
--- a/res/keyboard/en_US.kbd.cfg
+++ b/res/keyboard/en_US.kbd.cfg
@@ -65,6 +65,9 @@ beatloop_4_toggle q
 loop_halve w
 loop_double e
 
+passthrough Control+g
+vinylcontrol_mode Control+Shift+Y
+vinylcontrol_cueing Control+Alt+Y
 
 [Channel2]
 play l
@@ -111,3 +114,7 @@ reloop_exit 9
 beatloop_4_toggle u
 loop_halve i
 loop_double o
+
+passthrough Control+h
+vinylcontrol_mode Control+Shift+U
+vinylcontrol_cueing Control+Alt+U

--- a/res/keyboard/en_US.kbd.cfg
+++ b/res/keyboard/en_US.kbd.cfg
@@ -119,25 +119,19 @@ passthrough Control+h
 vinylcontrol_mode Control+Shift+U
 vinylcontrol_cueing Control+Alt+U
 
-[FileMenu]
-LoadDeck1 Ctrl+o
-LoadDeck2 Ctrl+Shift+O
-Quit Ctrl+q
-
-[LibraryMenu]
-NewPlaylist Ctrl+n
-NewCrate Ctrl+Shift+N
-
-[ViewMenu]
-ShowSamplers Ctrl+1
-ShowMicrophone Ctrl+2
-ShowVinylControl Ctrl+3
-ShowPreviewDeck Ctrl+4
-
-[OptionsMenu]
-EnableLiveBroadcasting Ctrl+l
-EnableVinyl1 Ctrl+y
-EnableVinyl2 Ctrl+u
-Preferences Ctrl+p
-RecordMix Ctrl+r
-ReloadSkin Ctrl+Shift+R
+[KeyboardShortcuts]
+FileMenu_LoadDeck1 Ctrl+o
+FileMenu_LoadDeck2 Ctrl+Shift+O
+FileMenu_Quit Ctrl+q
+LibraryMenu_NewPlaylist Ctrl+n
+LibraryMenu_NewCrate Ctrl+Shift+N
+ViewMenu_ShowSamplers Ctrl+1
+ViewMenu_ShowMicrophone Ctrl+2
+ViewMenu_ShowVinylControl Ctrl+3
+ViewMenu_ShowPreviewDeck Ctrl+4
+OptionsMenu_EnableLiveBroadcasting Ctrl+l
+OptionsMenu_EnableVinyl1 Ctrl+y
+OptionsMenu_EnableVinyl2 Ctrl+u
+OptionsMenu_Preferences Ctrl+p
+OptionsMenu_RecordMix Ctrl+r
+OptionsMenu_ReloadSkin Ctrl+Shift+R

--- a/res/keyboard/en_US.kbd.cfg
+++ b/res/keyboard/en_US.kbd.cfg
@@ -118,3 +118,26 @@ loop_double o
 passthrough Control+h
 vinylcontrol_mode Control+Shift+U
 vinylcontrol_cueing Control+Alt+U
+
+[FileMenu]
+LoadDeck1 Ctrl+o
+LoadDeck2 Ctrl+Shift+O
+Quit Ctrl+q
+
+[LibraryMenu]
+NewPlaylist Ctrl+n
+NewCrate Ctrl+Shift+N
+
+[ViewMenu]
+ShowSamplers Ctrl+1
+ShowMicrophone Ctrl+2
+ShowVinylControl Ctrl+3
+ShowPreviewDeck Ctrl+4
+
+[OptionsMenu]
+EnableLiveBroadcasting Ctrl+l
+EnableVinyl1 Ctrl+y
+EnableVinyl2 Ctrl+u
+Preferences Ctrl+p
+RecordMix Ctrl+r
+ReloadSkin Ctrl+Shift+R

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -842,7 +842,8 @@ void MixxxApp::initActions()
     QString player1LoadStatusText = loadTrackStatusText.arg(QString::number(1));
     m_pFileLoadSongPlayer1 = new QAction(loadTrackText.arg(QString::number(1)), this);
     m_pFileLoadSongPlayer1->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "FileMenu_LoadDeck1"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "FileMenu_LoadDeck1"),
                                                   tr("Ctrl+o"))));
     m_pFileLoadSongPlayer1->setShortcutContext(Qt::ApplicationShortcut);
     m_pFileLoadSongPlayer1->setStatusTip(player1LoadStatusText);
@@ -854,7 +855,8 @@ void MixxxApp::initActions()
     QString player2LoadStatusText = loadTrackStatusText.arg(QString::number(2));
     m_pFileLoadSongPlayer2 = new QAction(loadTrackText.arg(QString::number(2)), this);
     m_pFileLoadSongPlayer2->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "FileMenu_LoadDeck2"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "FileMenu_LoadDeck2"),
                                                   tr("Ctrl+Shift+O"))));
     m_pFileLoadSongPlayer2->setShortcutContext(Qt::ApplicationShortcut);
     m_pFileLoadSongPlayer2->setStatusTip(player2LoadStatusText);
@@ -887,7 +889,8 @@ void MixxxApp::initActions()
     QString createPlaylistText = tr("Create a new playlist");
     m_pPlaylistsNew = new QAction(createPlaylistTitle, this);
     m_pPlaylistsNew->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "LibraryMenu_NewPlaylist"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "LibraryMenu_NewPlaylist"),
                                                   tr("Ctrl+n"))));
     m_pPlaylistsNew->setShortcutContext(Qt::ApplicationShortcut);
     m_pPlaylistsNew->setStatusTip(createPlaylistText);
@@ -899,7 +902,8 @@ void MixxxApp::initActions()
     QString createCrateText = tr("Create a new crate");
     m_pCratesNew = new QAction(createCrateTitle, this);
     m_pCratesNew->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "LibraryMenu_NewCrate"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "LibraryMenu_NewCrate"),
                                                   tr("Ctrl+Shift+N"))));
     m_pCratesNew->setShortcutContext(Qt::ApplicationShortcut);
     m_pCratesNew->setStatusTip(createCrateText);
@@ -916,7 +920,8 @@ void MixxxApp::initActions()
     QString fullscreen_key = tr("F11");
 #endif
     m_pViewFullScreen->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "ViewMenu_Fullscreen"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "ViewMenu_Fullscreen"),
                                                   fullscreen_key)));
     m_pViewFullScreen->setShortcutContext(Qt::ApplicationShortcut);
     // QShortcut * shortcut = new QShortcut(QKeySequence(tr("Esc")),  this);
@@ -934,7 +939,8 @@ void MixxxApp::initActions()
         ConfigKey("[Keyboard]", "Enabled")) == "1";
     m_pOptionsKeyboard = new QAction(keyboardShortcutTitle, this);
     m_pOptionsKeyboard->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_EnableShortcuts"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "OptionsMenu_EnableShortcuts"),
                                                   tr("Ctrl+`"))));
     m_pOptionsKeyboard->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsKeyboard->setCheckable(true);
@@ -948,7 +954,8 @@ void MixxxApp::initActions()
     QString preferencesText = tr("Change Mixxx settings (e.g. playback, MIDI, controls)");
     m_pOptionsPreferences = new QAction(preferencesTitle, this);
     m_pOptionsPreferences->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_Preferences"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "OptionsMenu_Preferences"),
                                                   tr("Ctrl+P"))));
     m_pOptionsPreferences->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsPreferences->setStatusTip(preferencesText);
@@ -999,7 +1006,8 @@ void MixxxApp::initActions()
 
     m_pOptionsVinylControl = new QAction(vinylControlTitle1, this);
     m_pOptionsVinylControl->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_EnableVinyl1"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "OptionsMenu_EnableVinyl1"),
                                                   tr("Ctrl+y"))));
     m_pOptionsVinylControl->setShortcutContext(Qt::ApplicationShortcut);
     // Either check or uncheck the vinyl control menu item depending on what
@@ -1017,7 +1025,8 @@ void MixxxApp::initActions()
 
     m_pOptionsVinylControl2 = new QAction(vinylControlTitle2, this);
     m_pOptionsVinylControl2->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_EnableVinyl2"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "OptionsMenu_EnableVinyl2"),
                                                   tr("Ctrl+U"))));
     m_pOptionsVinylControl2->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsVinylControl2->setCheckable(true);
@@ -1038,7 +1047,8 @@ void MixxxApp::initActions()
     QString shoutcastText = tr("Stream your mixes to a shoutcast or icecast server");
     m_pOptionsShoutcast = new QAction(shoutcastTitle, this);
     m_pOptionsShoutcast->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_EnableLiveBroadcasting"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "OptionsMenu_EnableLiveBroadcasting"),
                                                   tr("Ctrl+L"))));
     m_pOptionsShoutcast->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsShoutcast->setCheckable(true);
@@ -1057,7 +1067,8 @@ void MixxxApp::initActions()
     m_pViewShowSamplers = new QAction(showSamplersTitle, this);
     m_pViewShowSamplers->setCheckable(true);
     m_pViewShowSamplers->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowSamplers"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "ViewMenu_ShowSamplers"),
                                                   tr("Ctrl+1", "Menubar|View|Show Samplers"))));
     m_pViewShowSamplers->setStatusTip(showSamplersText);
     m_pViewShowSamplers->setWhatsThis(buildWhatsThis(showSamplersTitle, showSamplersText));
@@ -1098,7 +1109,8 @@ void MixxxApp::initActions()
     m_pViewShowPreviewDeck = new QAction(showPreviewDeckTitle, this);
     m_pViewShowPreviewDeck->setCheckable(true);
     m_pViewShowPreviewDeck->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowPreviewDeck"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "ViewMenu_ShowPreviewDeck"),
                                                   tr("Ctrl+4", "Menubar|View|Show Preview Deck"))));
     m_pViewShowPreviewDeck->setStatusTip(showPreviewDeckText);
     m_pViewShowPreviewDeck->setWhatsThis(buildWhatsThis(showPreviewDeckTitle, showPreviewDeckText));
@@ -1110,7 +1122,8 @@ void MixxxApp::initActions()
     QString recordText = tr("Record your mix to a file");
     m_pOptionsRecord = new QAction(recordTitle, this);
     m_pOptionsRecord->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_RecordMix"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "OptionsMenu_RecordMix"),
                                                   tr("Ctrl+R"))));
     m_pOptionsRecord->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsRecord->setCheckable(true);
@@ -1123,7 +1136,8 @@ void MixxxApp::initActions()
     QString reloadSkinText = tr("Reload the skin");
     m_pDeveloperReloadSkin = new QAction(reloadSkinTitle, this);
     m_pDeveloperReloadSkin->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_ReloadSkin"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "OptionsMenu_ReloadSkin"),
                                                   tr("Ctrl+Shift+R"))));
     m_pDeveloperReloadSkin->setShortcutContext(Qt::ApplicationShortcut);
     m_pDeveloperReloadSkin->setCheckable(true);

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -842,7 +842,7 @@ void MixxxApp::initActions()
     QString player1LoadStatusText = loadTrackStatusText.arg(QString::number(1));
     m_pFileLoadSongPlayer1 = new QAction(loadTrackText.arg(QString::number(1)), this);
     m_pFileLoadSongPlayer1->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[FileMenu]", "LoadDeck1"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "FileMenu_LoadDeck1"),
                                                   tr("Ctrl+o"))));
     m_pFileLoadSongPlayer1->setShortcutContext(Qt::ApplicationShortcut);
     m_pFileLoadSongPlayer1->setStatusTip(player1LoadStatusText);
@@ -854,7 +854,7 @@ void MixxxApp::initActions()
     QString player2LoadStatusText = loadTrackStatusText.arg(QString::number(2));
     m_pFileLoadSongPlayer2 = new QAction(loadTrackText.arg(QString::number(2)), this);
     m_pFileLoadSongPlayer2->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[FileMenu]", "LoadDeck2"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "FileMenu_LoadDeck2"),
                                                   tr("Ctrl+Shift+O"))));
     m_pFileLoadSongPlayer2->setShortcutContext(Qt::ApplicationShortcut);
     m_pFileLoadSongPlayer2->setStatusTip(player2LoadStatusText);
@@ -867,7 +867,7 @@ void MixxxApp::initActions()
     QString quitText = tr("Quits Mixxx");
     m_pFileQuit = new QAction(quitTitle, this);
     m_pFileQuit->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[FileMenu]", "Quit"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "FileMenu_Quit"),
                                                   tr("Ctrl+q"))));
     m_pFileQuit->setShortcutContext(Qt::ApplicationShortcut);
     m_pFileQuit->setStatusTip(quitText);
@@ -887,7 +887,7 @@ void MixxxApp::initActions()
     QString createPlaylistText = tr("Create a new playlist");
     m_pPlaylistsNew = new QAction(createPlaylistTitle, this);
     m_pPlaylistsNew->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[LibraryMenu]", "NewPlaylist"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "LibraryMenu_NewPlaylist"),
                                                   tr("Ctrl+n"))));
     m_pPlaylistsNew->setShortcutContext(Qt::ApplicationShortcut);
     m_pPlaylistsNew->setStatusTip(createPlaylistText);
@@ -899,7 +899,7 @@ void MixxxApp::initActions()
     QString createCrateText = tr("Create a new crate");
     m_pCratesNew = new QAction(createCrateTitle, this);
     m_pCratesNew->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[LibraryMenu]", "NewCrate"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "LibraryMenu_NewCrate"),
                                                   tr("Ctrl+Shift+N"))));
     m_pCratesNew->setShortcutContext(Qt::ApplicationShortcut);
     m_pCratesNew->setStatusTip(createCrateText);
@@ -916,7 +916,7 @@ void MixxxApp::initActions()
     QString fullscreen_key = tr("F11");
 #endif
     m_pViewFullScreen->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[ViewMenu]", "Fullscreen"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "ViewMenu_Fullscreen"),
                                                   fullscreen_key)));
     m_pViewFullScreen->setShortcutContext(Qt::ApplicationShortcut);
     // QShortcut * shortcut = new QShortcut(QKeySequence(tr("Esc")),  this);
@@ -934,7 +934,7 @@ void MixxxApp::initActions()
         ConfigKey("[Keyboard]", "Enabled")) == "1";
     m_pOptionsKeyboard = new QAction(keyboardShortcutTitle, this);
     m_pOptionsKeyboard->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "EnableShortcuts"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_EnableShortcuts"),
                                                   tr("Ctrl+`"))));
     m_pOptionsKeyboard->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsKeyboard->setCheckable(true);
@@ -948,7 +948,7 @@ void MixxxApp::initActions()
     QString preferencesText = tr("Change Mixxx settings (e.g. playback, MIDI, controls)");
     m_pOptionsPreferences = new QAction(preferencesTitle, this);
     m_pOptionsPreferences->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "Preferences"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_Preferences"),
                                                   tr("Ctrl+P"))));
     m_pOptionsPreferences->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsPreferences->setStatusTip(preferencesText);
@@ -999,7 +999,7 @@ void MixxxApp::initActions()
 
     m_pOptionsVinylControl = new QAction(vinylControlTitle1, this);
     m_pOptionsVinylControl->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "EnableVinyl1"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_EnableVinyl1"),
                                                   tr("Ctrl+y"))));
     m_pOptionsVinylControl->setShortcutContext(Qt::ApplicationShortcut);
     // Either check or uncheck the vinyl control menu item depending on what
@@ -1017,7 +1017,7 @@ void MixxxApp::initActions()
 
     m_pOptionsVinylControl2 = new QAction(vinylControlTitle2, this);
     m_pOptionsVinylControl2->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "EnableVinyl2"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_EnableVinyl2"),
                                                   tr("Ctrl+U"))));
     m_pOptionsVinylControl2->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsVinylControl2->setCheckable(true);
@@ -1038,7 +1038,7 @@ void MixxxApp::initActions()
     QString shoutcastText = tr("Stream your mixes to a shoutcast or icecast server");
     m_pOptionsShoutcast = new QAction(shoutcastTitle, this);
     m_pOptionsShoutcast->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "EnableLiveBroadcasting"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_EnableLiveBroadcasting"),
                                                   tr("Ctrl+L"))));
     m_pOptionsShoutcast->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsShoutcast->setCheckable(true);
@@ -1057,7 +1057,7 @@ void MixxxApp::initActions()
     m_pViewShowSamplers = new QAction(showSamplersTitle, this);
     m_pViewShowSamplers->setCheckable(true);
     m_pViewShowSamplers->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[ViewMenu]", "ShowSamplers"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowSamplers"),
                                                   tr("Ctrl+1", "Menubar|View|Show Samplers"))));
     m_pViewShowSamplers->setStatusTip(showSamplersText);
     m_pViewShowSamplers->setWhatsThis(buildWhatsThis(showSamplersTitle, showSamplersText));
@@ -1071,7 +1071,7 @@ void MixxxApp::initActions()
     m_pViewVinylControl->setCheckable(true);
     m_pViewVinylControl->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(
-            ConfigKey("[ViewMenu]", "ShowVinylControl"),
+            ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowVinylControl"),
             tr("Ctrl+3", "Menubar|View|Show Vinyl Control Section"))));
     m_pViewVinylControl->setStatusTip(showVinylControlText);
     m_pViewVinylControl->setWhatsThis(buildWhatsThis(showVinylControlTitle, showVinylControlText));
@@ -1085,7 +1085,7 @@ void MixxxApp::initActions()
     m_pViewShowMicrophone->setCheckable(true);
     m_pViewShowMicrophone->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(
-            ConfigKey("[ViewMenu]", "ShowMicrophone"),
+            ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowMicrophone"),
             tr("Ctrl+2", "Menubar|View|Show Microphone Section"))));
     m_pViewShowMicrophone->setStatusTip(showMicrophoneText);
     m_pViewShowMicrophone->setWhatsThis(buildWhatsThis(showMicrophoneTitle, showMicrophoneText));
@@ -1098,7 +1098,7 @@ void MixxxApp::initActions()
     m_pViewShowPreviewDeck = new QAction(showPreviewDeckTitle, this);
     m_pViewShowPreviewDeck->setCheckable(true);
     m_pViewShowPreviewDeck->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[ViewMenu]", "ShowPreviewDeck"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowPreviewDeck"),
                                                   tr("Ctrl+4", "Menubar|View|Show Preview Deck"))));
     m_pViewShowPreviewDeck->setStatusTip(showPreviewDeckText);
     m_pViewShowPreviewDeck->setWhatsThis(buildWhatsThis(showPreviewDeckTitle, showPreviewDeckText));
@@ -1110,7 +1110,7 @@ void MixxxApp::initActions()
     QString recordText = tr("Record your mix to a file");
     m_pOptionsRecord = new QAction(recordTitle, this);
     m_pOptionsRecord->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "RecordMix"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_RecordMix"),
                                                   tr("Ctrl+R"))));
     m_pOptionsRecord->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsRecord->setCheckable(true);
@@ -1123,7 +1123,7 @@ void MixxxApp::initActions()
     QString reloadSkinText = tr("Reload the skin");
     m_pDeveloperReloadSkin = new QAction(reloadSkinTitle, this);
     m_pDeveloperReloadSkin->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "ReloadSkin"),
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "OptionsMenu_ReloadSkin"),
                                                   tr("Ctrl+Shift+R"))));
     m_pDeveloperReloadSkin->setShortcutContext(Qt::ApplicationShortcut);
     m_pDeveloperReloadSkin->setCheckable(true);

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -841,7 +841,9 @@ void MixxxApp::initActions()
 
     QString player1LoadStatusText = loadTrackStatusText.arg(QString::number(1));
     m_pFileLoadSongPlayer1 = new QAction(loadTrackText.arg(QString::number(1)), this);
-    m_pFileLoadSongPlayer1->setShortcut(QKeySequence(tr("Ctrl+O")));
+    m_pFileLoadSongPlayer1->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[FileMenu]", "LoadDeck1"),
+                                                  tr("Ctrl+o"))));
     m_pFileLoadSongPlayer1->setShortcutContext(Qt::ApplicationShortcut);
     m_pFileLoadSongPlayer1->setStatusTip(player1LoadStatusText);
     m_pFileLoadSongPlayer1->setWhatsThis(
@@ -851,7 +853,9 @@ void MixxxApp::initActions()
 
     QString player2LoadStatusText = loadTrackStatusText.arg(QString::number(2));
     m_pFileLoadSongPlayer2 = new QAction(loadTrackText.arg(QString::number(2)), this);
-    m_pFileLoadSongPlayer2->setShortcut(QKeySequence(tr("Ctrl+Shift+O")));
+    m_pFileLoadSongPlayer2->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[FileMenu]", "LoadDeck2"),
+                                                  tr("Ctrl+Shift+O"))));
     m_pFileLoadSongPlayer2->setShortcutContext(Qt::ApplicationShortcut);
     m_pFileLoadSongPlayer2->setStatusTip(player2LoadStatusText);
     m_pFileLoadSongPlayer2->setWhatsThis(
@@ -862,7 +866,9 @@ void MixxxApp::initActions()
     QString quitTitle = tr("&Exit");
     QString quitText = tr("Quits Mixxx");
     m_pFileQuit = new QAction(quitTitle, this);
-    m_pFileQuit->setShortcut(QKeySequence(tr("Ctrl+Q")));
+    m_pFileQuit->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[FileMenu]", "Quit"),
+                                                  tr("Ctrl+q"))));
     m_pFileQuit->setShortcutContext(Qt::ApplicationShortcut);
     m_pFileQuit->setStatusTip(quitText);
     m_pFileQuit->setWhatsThis(buildWhatsThis(quitTitle, quitText));
@@ -880,7 +886,9 @@ void MixxxApp::initActions()
     QString createPlaylistTitle = tr("Add &New Playlist");
     QString createPlaylistText = tr("Create a new playlist");
     m_pPlaylistsNew = new QAction(createPlaylistTitle, this);
-    m_pPlaylistsNew->setShortcut(QKeySequence(tr("Ctrl+N")));
+    m_pPlaylistsNew->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[LibraryMenu]", "NewPlaylist"),
+                                                  tr("Ctrl+n"))));
     m_pPlaylistsNew->setShortcutContext(Qt::ApplicationShortcut);
     m_pPlaylistsNew->setStatusTip(createPlaylistText);
     m_pPlaylistsNew->setWhatsThis(buildWhatsThis(createPlaylistTitle, createPlaylistText));
@@ -890,7 +898,9 @@ void MixxxApp::initActions()
     QString createCrateTitle = tr("Add New &Crate");
     QString createCrateText = tr("Create a new crate");
     m_pCratesNew = new QAction(createCrateTitle, this);
-    m_pCratesNew->setShortcut(QKeySequence(tr("Ctrl+Shift+N")));
+    m_pCratesNew->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[LibraryMenu]", "NewCrate"),
+                                                  tr("Ctrl+Shift+N"))));
     m_pCratesNew->setShortcutContext(Qt::ApplicationShortcut);
     m_pCratesNew->setStatusTip(createCrateText);
     m_pCratesNew->setWhatsThis(buildWhatsThis(createCrateTitle, createCrateText));
@@ -901,10 +911,13 @@ void MixxxApp::initActions()
     QString fullScreenText = tr("Display Mixxx using the full screen");
     m_pViewFullScreen = new QAction(fullScreenTitle, this);
 #ifdef __APPLE__
-    m_pViewFullScreen->setShortcut(QKeySequence(tr("Ctrl+Shift+F")));
+    QString fullscreen_key = tr("Ctrl+Shift+F");
 #else
-    m_pViewFullScreen->setShortcut(QKeySequence(tr("F11")));
+    QString fullscreen_key = tr("F11");
 #endif
+    m_pViewFullScreen->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[ViewMenu]", "Fullscreen"),
+                                                  fullscreen_key)));
     m_pViewFullScreen->setShortcutContext(Qt::ApplicationShortcut);
     // QShortcut * shortcut = new QShortcut(QKeySequence(tr("Esc")),  this);
     // connect(shortcut, SIGNAL(triggered()), this, SLOT(slotQuitFullScreen()));
@@ -920,7 +933,9 @@ void MixxxApp::initActions()
     bool keyboardShortcutsEnabled = m_pConfig->getValueString(
         ConfigKey("[Keyboard]", "Enabled")) == "1";
     m_pOptionsKeyboard = new QAction(keyboardShortcutTitle, this);
-    m_pOptionsKeyboard->setShortcut(tr("Ctrl+`"));
+    m_pOptionsKeyboard->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "EnableShortcuts"),
+                                                  tr("Ctrl+`"))));
     m_pOptionsKeyboard->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsKeyboard->setCheckable(true);
     m_pOptionsKeyboard->setChecked(keyboardShortcutsEnabled);
@@ -932,7 +947,9 @@ void MixxxApp::initActions()
     QString preferencesTitle = tr("&Preferences");
     QString preferencesText = tr("Change Mixxx settings (e.g. playback, MIDI, controls)");
     m_pOptionsPreferences = new QAction(preferencesTitle, this);
-    m_pOptionsPreferences->setShortcut(QKeySequence(tr("Ctrl+P")));
+    m_pOptionsPreferences->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "Preferences"),
+                                                  tr("Ctrl+P"))));
     m_pOptionsPreferences->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsPreferences->setStatusTip(preferencesText);
     m_pOptionsPreferences->setWhatsThis(buildWhatsThis(preferencesTitle, preferencesText));
@@ -981,7 +998,9 @@ void MixxxApp::initActions()
     QString vinylControlTitle2 = tr("Enable Vinyl Control &2");
 
     m_pOptionsVinylControl = new QAction(vinylControlTitle1, this);
-    m_pOptionsVinylControl->setShortcut(QKeySequence(tr("Ctrl+Y")));
+    m_pOptionsVinylControl->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "EnableVinyl1"),
+                                                  tr("Ctrl+y"))));
     m_pOptionsVinylControl->setShortcutContext(Qt::ApplicationShortcut);
     // Either check or uncheck the vinyl control menu item depending on what
     // it was saved as.
@@ -997,7 +1016,9 @@ void MixxxApp::initActions()
             SLOT(slotControlVinylControl(double)));
 
     m_pOptionsVinylControl2 = new QAction(vinylControlTitle2, this);
-    m_pOptionsVinylControl2->setShortcut(tr("Ctrl+U"));
+    m_pOptionsVinylControl2->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "EnableVinyl2"),
+                                                  tr("Ctrl+U"))));
     m_pOptionsVinylControl2->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsVinylControl2->setCheckable(true);
     m_pOptionsVinylControl2->setChecked(false);
@@ -1016,7 +1037,9 @@ void MixxxApp::initActions()
     QString shoutcastTitle = tr("Enable Live &Broadcasting");
     QString shoutcastText = tr("Stream your mixes to a shoutcast or icecast server");
     m_pOptionsShoutcast = new QAction(shoutcastTitle, this);
-    m_pOptionsShoutcast->setShortcut(tr("Ctrl+L"));
+    m_pOptionsShoutcast->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "EnableLiveBroadcasting"),
+                                                  tr("Ctrl+L"))));
     m_pOptionsShoutcast->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsShoutcast->setCheckable(true);
     m_pOptionsShoutcast->setChecked(m_pShoutcastManager->isEnabled());
@@ -1033,7 +1056,9 @@ void MixxxApp::initActions()
             " " + mayNotBeSupported;
     m_pViewShowSamplers = new QAction(showSamplersTitle, this);
     m_pViewShowSamplers->setCheckable(true);
-    m_pViewShowSamplers->setShortcut(tr("Ctrl+1", "Menubar|View|Show Samplers"));
+    m_pViewShowSamplers->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[ViewMenu]", "ShowSamplers"),
+                                                  tr("Ctrl+1", "Menubar|View|Show Samplers"))));
     m_pViewShowSamplers->setStatusTip(showSamplersText);
     m_pViewShowSamplers->setWhatsThis(buildWhatsThis(showSamplersTitle, showSamplersText));
     connect(m_pViewShowSamplers, SIGNAL(toggled(bool)),
@@ -1044,7 +1069,10 @@ void MixxxApp::initActions()
             " " + mayNotBeSupported;
     m_pViewVinylControl = new QAction(showVinylControlTitle, this);
     m_pViewVinylControl->setCheckable(true);
-    m_pViewVinylControl->setShortcut(tr("Ctrl+3", "Menubar|View|Show Vinyl Control Section"));
+    m_pViewVinylControl->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(
+            ConfigKey("[ViewMenu]", "ShowVinylControl"),
+            tr("Ctrl+3", "Menubar|View|Show Vinyl Control Section"))));
     m_pViewVinylControl->setStatusTip(showVinylControlText);
     m_pViewVinylControl->setWhatsThis(buildWhatsThis(showVinylControlTitle, showVinylControlText));
     connect(m_pViewVinylControl, SIGNAL(toggled(bool)),
@@ -1055,7 +1083,10 @@ void MixxxApp::initActions()
             " " + mayNotBeSupported;
     m_pViewShowMicrophone = new QAction(showMicrophoneTitle, this);
     m_pViewShowMicrophone->setCheckable(true);
-    m_pViewShowMicrophone->setShortcut(tr("Ctrl+2", "Menubar|View|Show Microphone Section"));
+    m_pViewShowMicrophone->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(
+            ConfigKey("[ViewMenu]", "ShowMicrophone"),
+            tr("Ctrl+2", "Menubar|View|Show Microphone Section"))));
     m_pViewShowMicrophone->setStatusTip(showMicrophoneText);
     m_pViewShowMicrophone->setWhatsThis(buildWhatsThis(showMicrophoneTitle, showMicrophoneText));
     connect(m_pViewShowMicrophone, SIGNAL(toggled(bool)),
@@ -1066,7 +1097,9 @@ void MixxxApp::initActions()
     " " + mayNotBeSupported;
     m_pViewShowPreviewDeck = new QAction(showPreviewDeckTitle, this);
     m_pViewShowPreviewDeck->setCheckable(true);
-    m_pViewShowPreviewDeck->setShortcut(tr("Ctrl+4", "Menubar|View|Show Preview Deck"));
+    m_pViewShowPreviewDeck->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[ViewMenu]", "ShowPreviewDeck"),
+                                                  tr("Ctrl+4", "Menubar|View|Show Preview Deck"))));
     m_pViewShowPreviewDeck->setStatusTip(showPreviewDeckText);
     m_pViewShowPreviewDeck->setWhatsThis(buildWhatsThis(showPreviewDeckTitle, showPreviewDeckText));
     connect(m_pViewShowPreviewDeck, SIGNAL(toggled(bool)),
@@ -1076,7 +1109,9 @@ void MixxxApp::initActions()
     QString recordTitle = tr("&Record Mix");
     QString recordText = tr("Record your mix to a file");
     m_pOptionsRecord = new QAction(recordTitle, this);
-    m_pOptionsRecord->setShortcut(tr("Ctrl+R"));
+    m_pOptionsRecord->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "RecordMix"),
+                                                  tr("Ctrl+R"))));
     m_pOptionsRecord->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsRecord->setCheckable(true);
     m_pOptionsRecord->setStatusTip(recordText);
@@ -1087,7 +1122,9 @@ void MixxxApp::initActions()
     QString reloadSkinTitle = tr("&Reload Skin");
     QString reloadSkinText = tr("Reload the skin");
     m_pDeveloperReloadSkin = new QAction(reloadSkinTitle, this);
-    m_pDeveloperReloadSkin->setShortcut(QKeySequence(tr("Ctrl+Shift+R")));
+    m_pDeveloperReloadSkin->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[OptionsMenu]", "ReloadSkin"),
+                                                  tr("Ctrl+Shift+R"))));
     m_pDeveloperReloadSkin->setShortcutContext(Qt::ApplicationShortcut);
     m_pDeveloperReloadSkin->setCheckable(true);
     m_pDeveloperReloadSkin->setChecked(false);

--- a/src/mixxxkeyboard.cpp
+++ b/src/mixxxkeyboard.cpp
@@ -60,9 +60,7 @@ bool MixxxKeyboard::eventFilter(QObject *, QEvent * e) {
         {
             // Check if a shortcut is defined
             ConfigKey * pConfigKey = m_pKbdConfigObject->get(ConfigValueKbd(ks));
-
-            if (pConfigKey)
-            {
+            if (pConfigKey && pConfigKey->group != "[KeyboardShortcuts]") {
                 ControlObject* control = ControlObject::getControl(*pConfigKey);
                 if (control) {
                     control->setValueFromMidi(MIDI_NOTE_ON, 1);


### PR DESCRIPTION
is this what you guys were looking for in: https://bugs.launchpad.net/mixxx/+bug/864600 ?

right now ctrl-y is enable vinyl so I was building on that.  I don't like how some mappings are hard-coded, but I guess that's because they are menu bindings.
