### PR TITLE
Fix unusable channel pairings (2-3, 4-5, etc.) when configuring sound hardware

### DIFF
--- a/src/dlgprefsounditem.cpp
+++ b/src/dlgprefsounditem.cpp
@@ -100,7 +100,7 @@ void DlgPrefSoundItem::deviceChanged(int index) {
     } else {
         unsigned char channelsForType =
             AudioPath::channelsNeededForType(m_type);
-        for (unsigned int i = 1; i + (channelsForType - 1) <= numChannels; ++i) {
+        for (unsigned int i = 1; i + (channelsForType - 1) <= numChannels; i += channelsForType) {
             if (channelsForType == 1) {
                 channelComboBox->addItem(
                     QString(tr("Channel %1")).arg(i), i - 1);


### PR DESCRIPTION
This patch sits on LP for some time and is quite useful.
https://bugs.launchpad.net/mixxx/+bug/1071495
