### PR TITLE
Add OSX-specific default binding for preferences

### DIFF
--- a/res/keyboard/en_US.kbd.cfg
+++ b/res/keyboard/en_US.kbd.cfg
@@ -132,6 +132,5 @@ ViewMenu_ShowPreviewDeck Ctrl+4
 OptionsMenu_EnableLiveBroadcasting Ctrl+l
 OptionsMenu_EnableVinyl1 Ctrl+y
 OptionsMenu_EnableVinyl2 Ctrl+u
-OptionsMenu_Preferences Ctrl+p
 OptionsMenu_RecordMix Ctrl+r
 OptionsMenu_ReloadSkin Ctrl+Shift+R

--- a/res/keyboard/en_US.kbd.cfg
+++ b/res/keyboard/en_US.kbd.cfg
@@ -65,9 +65,9 @@ beatloop_4_toggle q
 loop_halve w
 loop_double e
 
-passthrough Control+g
-vinylcontrol_mode Control+Shift+Y
-vinylcontrol_cueing Control+Alt+Y
+passthrough Ctrl+j
+vinylcontrol_mode Ctrl+Shift+Y
+vinylcontrol_cueing Ctrl+Alt+Y
 
 [Channel2]
 play l
@@ -115,9 +115,9 @@ beatloop_4_toggle u
 loop_halve i
 loop_double o
 
-passthrough Control+h
-vinylcontrol_mode Control+Shift+U
-vinylcontrol_cueing Control+Alt+U
+passthrough Ctrl+k
+vinylcontrol_mode Ctrl+Shift+U
+vinylcontrol_cueing Ctrl+Alt+U
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -956,10 +956,17 @@ void MixxxApp::initActions()
     QString preferencesTitle = tr("&Preferences");
     QString preferencesText = tr("Change Mixxx settings (e.g. playback, MIDI, controls)");
     m_pOptionsPreferences = new QAction(preferencesTitle, this);
+#ifdef __APPLE__
+    m_pOptionsPreferences->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "OptionsMenu_Preferences"),
+                                                  tr("Ctrl+,"))));
+#else
     m_pOptionsPreferences->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                   "OptionsMenu_Preferences"),
                                                   tr("Ctrl+P"))));
+#endif
     m_pOptionsPreferences->setShortcutContext(Qt::ApplicationShortcut);
     m_pOptionsPreferences->setStatusTip(preferencesText);
     m_pOptionsPreferences->setWhatsThis(buildWhatsThis(preferencesTitle, preferencesText));


### PR DESCRIPTION
Can someone on OSX confirm that this is the right choice of binding for OSX and that it works?  (I'm assuming QT maps "ctrl" to "command")
