### PR TITLE
iTunes match bug fix (lp 1174604)

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -85,14 +85,5 @@ inline double zap_denormal(double x)
 #define math_min(a,b)            (((a) < (b)) ? (a) : (b))
 #endif
 
-// MSVC 2005/2008 needs these
-#ifndef fmax
-#define fmax math_max
-#endif
-
-#ifndef fmin
-#define fmin math_min
-#endif
-
 #endif
 

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -426,6 +426,7 @@ void ITunesFeature::parseTrack(QXmlStreamReader &xml, QSqlQuery &query) {
     int rating = 0;
     QString comment;
     QString tracknumber;
+    QString tracktype;
 
     while (!xml.atEnd()) {
         xml.readNext();
@@ -509,6 +510,10 @@ void ITunesFeature::parseTrack(QXmlStreamReader &xml, QSqlQuery &query) {
                     rating = (content.toInt() / 20);
                     continue;
                 }
+                if (key == "Track Type") {
+                    tracktype = content;
+                    continue;
+                }
             }
         }
         //exit loop on closing </dict>
@@ -516,6 +521,13 @@ void ITunesFeature::parseTrack(QXmlStreamReader &xml, QSqlQuery &query) {
             break;
         }
     }
+    
+    // If file is a remote file from iTunes Match, don't save it to the database.
+    // There's no way that mixxx can access it.
+    if (tracktype == "Remote") {
+        return;
+    }
+    
     // If we reach the end of <dict>
     // Save parsed track to database
     query.bindValue(":id", id);


### PR DESCRIPTION
Fixes problem with remote iTunes tracks that are inaccessible to Mixxx when using iTunes match.  See: https://bugs.launchpad.net/mixxx/+bug/1174604

Also includes code cleanup that fixes an error when compiling on OSX using libC++.
