### PR TITLE
Fix some compiler errors on OS X 10.9 with Qt5.2.0-rc1

### DIFF
--- a/src/control/controlvalue.h
+++ b/src/control/controlvalue.h
@@ -2,7 +2,7 @@
 #define CONTROLVALUE_H
 
 #include <limits>
-
+#include "util/compatibility.h"
 #include <QAtomicInt>
 #include <QObject>
 
@@ -66,7 +66,7 @@ class ControlValueAtomicBase {
   public:
     inline T getValue() const {
         T value = T();
-        unsigned int index = (unsigned int)m_readIndex.load() % (cRingSize);
+        unsigned int index = static_cast<unsigned int>(deref(m_readIndex)) % (cRingSize);
         while (m_ring[index].tryGet(&value) == false) {
             // We are here if
             // 1) there are more then cReaderSlotCnt reader (get) reading the same value or

--- a/src/control/controlvalue.h
+++ b/src/control/controlvalue.h
@@ -66,8 +66,7 @@ class ControlValueAtomicBase {
   public:
     inline T getValue() const {
         T value = T();
-        unsigned int index = (unsigned int)m_readIndex
-                % (cRingSize);
+        unsigned int index = (unsigned int)m_readIndex % (cRingSize);
         while (m_ring[index].tryGet(&value) == false) {
             // We are here if
             // 1) there are more then cReaderSlotCnt reader (get) reading the same value or

--- a/src/control/controlvalue.h
+++ b/src/control/controlvalue.h
@@ -66,7 +66,7 @@ class ControlValueAtomicBase {
   public:
     inline T getValue() const {
         T value = T();
-        unsigned int index = (unsigned int)m_readIndex % (cRingSize);
+        unsigned int index = (unsigned int)m_readIndex.load() % (cRingSize);
         while (m_ring[index].tryGet(&value) == false) {
             // We are here if
             // 1) there are more then cReaderSlotCnt reader (get) reading the same value or

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -3,6 +3,7 @@
 #include <QHeaderView>
 #include <QUrl>
 #include <QtDebug>
+#include <QMimeData>
 
 #include "library/sidebarmodel.h"
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -18,6 +18,7 @@
 #include <QtDebug>
 #include <QPixmap>
 #include <QUrl>
+#include <QMimeData>
 
 #include "controlobject.h"
 #include "controlobjectthreadmain.h"

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -4,6 +4,7 @@
 #include <QtDebug>
 #include <QApplication>
 #include <QUrl>
+#include <QMimeData>
 
 #include "mathstuff.h"
 #include "wimagestore.h"

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -2,6 +2,7 @@
 #include <QInputDialog>
 #include <QDesktopServices>
 #include <QUrl>
+#include <QDrag>
 
 #include "widget/wwidget.h"
 #include "widget/wskincolor.h"

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -5,6 +5,7 @@
 #include <QDragEnterEvent>
 #include <QUrl>
 #include <QPainter>
+#include <QMimeData>
 
 #include "controlobject.h"
 #include "controlobjectthreadmain.h"


### PR DESCRIPTION
fix one compiler error
cast QAtomicInt to (unsigned int)

and fix some compiler errors (missing includes) 
error: member access into incomplete type 'const QMimeData'
