### PR TITLE
Longpresslatching

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -216,7 +216,8 @@ class Qt(Dependence):
                                      'QT_TABLET_SUPPORT'])
         qt_modules = [
             'QtCore', 'QtGui', 'QtOpenGL', 'QtXml', 'QtSvg',
-            'QtSql', 'QtScript', 'QtXmlPatterns', 'QtNetwork'
+            'QtSql', 'QtScript', 'QtXmlPatterns', 'QtNetwork',
+            'QtTest'
         ]
 
         if qt5:

--- a/src/control/controlbehavior.cpp
+++ b/src/control/controlbehavior.cpp
@@ -188,6 +188,20 @@ void ControlPushButtonBehavior::setValueFromMidiParameter(
                 pControl->set(0.0, NULL);
             }
         }
+    } else if (m_buttonMode == LATCHING && m_iNumStates == 2) {
+        if (o == MIDI_NOTE_ON) {
+            if (dParam > 0.) {
+                double value = pControl->get();
+                pControl->set(!value, NULL);
+                m_pushTimer.setSingleShot(true);
+                m_pushTimer.start(kLatchingTimeMillis);
+            }
+        } else if (o == MIDI_NOTE_OFF) {
+            // Opposite of powerwindow -- only release the button if within time window.
+            if (m_pushTimer.isActive()) {
+                pControl->set(0.0, NULL);
+            }
+        }
     } else if (m_buttonMode == TOGGLE) {
         // This block makes push-buttons act as toggle buttons.
         if (m_iNumStates > 2) { // multistate button

--- a/src/control/controlbehavior.cpp
+++ b/src/control/controlbehavior.cpp
@@ -164,6 +164,7 @@ double ControlTTRotaryBehavior::widgetParameterToValue(double dParam) {
 
 // static
 const int ControlPushButtonBehavior::kPowerWindowTimeMillis = 300;
+const int ControlPushButtonBehavior::kLatchingTimeMillis = 500;
 
 ControlPushButtonBehavior::ControlPushButtonBehavior(ButtonMode buttonMode,
                                                      int iNumStates)

--- a/src/control/controlbehavior.h
+++ b/src/control/controlbehavior.h
@@ -78,13 +78,15 @@ class ControlTTRotaryBehavior : public ControlNumericBehavior {
 class ControlPushButtonBehavior : public ControlNumericBehavior {
   public:
     static const int kPowerWindowTimeMillis;
+    static const int kLongPressLatchingTimeMillis;
 
     // TODO(XXX) Duplicated from ControlPushButton. It's complicated and
     // annoying to share them so I just copied them.
     enum ButtonMode {
          PUSH = 0,
          TOGGLE,
-         POWERWINDOW
+         POWERWINDOW,
+         LONGPRESSLATCHING,
     };
 
     ControlPushButtonBehavior(ButtonMode buttonMode, int iNumStates);

--- a/src/control/controlbehavior.h
+++ b/src/control/controlbehavior.h
@@ -85,7 +85,8 @@ class ControlPushButtonBehavior : public ControlNumericBehavior {
     enum ButtonMode {
          PUSH = 0,
          TOGGLE,
-         POWERWINDOW
+         POWERWINDOW,
+         LATCHING
     };
 
     ControlPushButtonBehavior(ButtonMode buttonMode, int iNumStates);

--- a/src/control/controlbehavior.h
+++ b/src/control/controlbehavior.h
@@ -78,6 +78,7 @@ class ControlTTRotaryBehavior : public ControlNumericBehavior {
 class ControlPushButtonBehavior : public ControlNumericBehavior {
   public:
     static const int kPowerWindowTimeMillis;
+    static const int kLatchingTimeMillis;
 
     // TODO(XXX) Duplicated from ControlPushButton. It's complicated and
     // annoying to share them so I just copied them.

--- a/src/controlobjectthreadwidget.cpp
+++ b/src/controlobjectthreadwidget.cpp
@@ -73,9 +73,8 @@ void ControlObjectThreadWidget::setWidget(QWidget * widget, bool connectValueFro
     emit(valueChanged(get()));
 }
 
-void ControlObjectThreadWidget::setWidgetOnOff(QWidget* widget)
-{
-    QApplication::connect(this, SIGNAL(valueChanged(double)),
+void ControlObjectThreadWidget::setWidgetOnOff(QWidget* widget) {
+    connect(this, SIGNAL(valueChanged(double)),
                           widget, SLOT(setOnOff(double)));
     emit(valueChanged(get()));
 }

--- a/src/controlobjectthreadwidget.h
+++ b/src/controlobjectthreadwidget.h
@@ -42,7 +42,6 @@ class ControlObjectThreadWidget : public ControlObjectThreadMain {
                    EmitOption emitOption=EMIT_ON_PRESS, Qt::MouseButton state=Qt::NoButton);
     // Associates a the enabled/disabled state of a widget with the state of a ControlObject. */
     void setWidgetOnOff(QWidget *widget);
-    void setIndicatorWidget(QWidget *widget);
 
     virtual double get();
 

--- a/src/controlobjectthreadwidget.h
+++ b/src/controlobjectthreadwidget.h
@@ -36,12 +36,13 @@ class ControlObjectThreadWidget : public ControlObjectThreadMain {
     ControlObjectThreadWidget(const char* g, const char* i, QObject* pParent = NULL);
     ControlObjectThreadWidget(const QString& g, const QString& i, QObject* pParent = NULL);
     virtual ~ControlObjectThreadWidget();
-    /** Associates a QWidget with the ControlObject. */
+    // Associates a QWidget with the ControlObject.
     void setWidget(QWidget *widget,
                    bool connectValueFromWidget=true, bool connectValueToWidget = true,
                    EmitOption emitOption=EMIT_ON_PRESS, Qt::MouseButton state=Qt::NoButton);
-    /** Associates a the enabled/disabled state of a widget with the state of a ControlObject. */
+    // Associates a the enabled/disabled state of a widget with the state of a ControlObject. */
     void setWidgetOnOff(QWidget *widget);
+    void setIndicatorWidget(QWidget *widget);
 
     virtual double get();
 

--- a/src/controlpushbutton.h
+++ b/src/controlpushbutton.h
@@ -32,7 +32,8 @@ class ControlPushButton : public ControlObject {
     enum ButtonMode {
          PUSH = 0,
          TOGGLE,
-         POWERWINDOW
+         POWERWINDOW,
+         LONGPRESSLATCHING,
     };
 
     ControlPushButton(ConfigKey key);

--- a/src/controlpushbutton.h
+++ b/src/controlpushbutton.h
@@ -32,7 +32,8 @@ class ControlPushButton : public ControlObject {
     enum ButtonMode {
          PUSH = 0,
          TOGGLE,
-         POWERWINDOW
+         POWERWINDOW,
+         LATCHING
     };
 
     ControlPushButton(ConfigKey key);

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -50,7 +50,6 @@ BpmControl::BpmControl(const char* _group,
 
     // Beat sync (scale buffer tempo relative to tempo of other buffer)
     m_pButtonSync = new ControlPushButton(ConfigKey(_group, "beatsync"));
-    m_pButtonSync->setButtonMode(ControlPushButton::LONGPRESSLATCHING);
     connect(m_pButtonSync, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlBeatSync(double)),
             Qt::DirectConnection);

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -50,6 +50,7 @@ BpmControl::BpmControl(const char* _group,
 
     // Beat sync (scale buffer tempo relative to tempo of other buffer)
     m_pButtonSync = new ControlPushButton(ConfigKey(_group, "beatsync"));
+    m_pButtonSync->setButtonMode(ControlPushButton::LONGPRESSLATCHING);
     connect(m_pButtonSync, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlBeatSync(double)),
             Qt::DirectConnection);

--- a/src/test/control_push_button_test.cpp
+++ b/src/test/control_push_button_test.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <QApplication>
 #include <QTestEventList>
 #include <QScopedPointer>
 
@@ -12,10 +11,7 @@
 class ControlPushButtonTest : public MixxxTest {
   public:
     ControlPushButtonTest()
-          : m_pGroup("[Channel1]"),
-            m_argc(1),
-            m_argv("testApp") {
-        m_pApplication.reset(new QApplication(m_argc, m_argv));
+          : m_pGroup("[Channel1]"){
     }
 
   protected:
@@ -24,9 +20,6 @@ class ControlPushButtonTest : public MixxxTest {
         m_pButton->setStates(2);
     }
 
-    int m_argc;
-    const char* m_argv;
-    QScopedPointer<QApplication> m_pApplication;
     QScopedPointer<WPushButton> m_pButton;
     QTestEventList m_Events;
     const char* m_pGroup;

--- a/src/test/control_push_button_test.cpp
+++ b/src/test/control_push_button_test.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QTestEventList>
+#include <QScopedPointer>
+
+#include "mixxxtest.h"
+#include "controlobject.h"
+#include "controlpushbutton.h"
+#include "widget/wpushbutton.h"
+
+class ControlPushButtonTest : public MixxxTest {
+  public:
+    ControlPushButtonTest()
+          : m_pGroup("[Channel1]"),
+            m_argc(1),
+            m_argv("testApp") {
+        m_pApplication.reset(new QApplication(m_argc, m_argv));
+    }
+
+  protected:
+    virtual void SetUp() {
+        m_pButton.reset(new WPushButton());
+        m_pButton->setStates(2);
+    }
+
+    int m_argc;
+    const char* m_argv;
+    QScopedPointer<QApplication> m_pApplication;
+    QScopedPointer<WPushButton> m_pButton;
+    QTestEventList m_Events;
+    const char* m_pGroup;
+};
+
+TEST_F(ControlPushButtonTest, QuickPressNoLatchTest) {
+    m_pButton.reset(new WPushButton(NULL, ControlPushButton::LATCHING,
+                                    ControlPushButton::PUSH));
+
+    m_Events.addMousePress(Qt::LeftButton, 0, QPoint(), 100);
+    m_Events.addMouseRelease(Qt::LeftButton);
+
+    m_Events.simulate(m_pButton.data());
+
+    ASSERT_EQ(0.0, m_pButton->getValue());
+}
+
+TEST_F(ControlPushButtonTest, LongPressLatchTest) {
+    m_pButton.reset(new WPushButton(NULL, ControlPushButton::LATCHING,
+                                    ControlPushButton::PUSH));
+
+    m_Events.addMousePress(Qt::LeftButton, 0, QPoint(), 1000);
+    m_Events.addMouseRelease(Qt::LeftButton);
+
+    m_Events.simulate(m_pButton.data());
+
+    ASSERT_EQ(1.0, m_pButton->getValue());
+}
+
+

--- a/src/test/control_push_button_test.cpp
+++ b/src/test/control_push_button_test.cpp
@@ -28,9 +28,10 @@ class ControlPushButtonTest : public MixxxTest {
 TEST_F(ControlPushButtonTest, QuickPressNoLatchTest) {
     m_pButton.reset(new WPushButton(NULL, ControlPushButton::LATCHING,
                                     ControlPushButton::PUSH));
+    m_pButton->setStates(2);
 
-    m_Events.addMousePress(Qt::LeftButton, 0, QPoint(), 100);
-    m_Events.addMouseRelease(Qt::LeftButton);
+    m_Events.addMousePress(Qt::LeftButton);
+    m_Events.addMouseRelease(Qt::LeftButton, 0, QPoint(), 100);
 
     m_Events.simulate(m_pButton.data());
 
@@ -40,9 +41,10 @@ TEST_F(ControlPushButtonTest, QuickPressNoLatchTest) {
 TEST_F(ControlPushButtonTest, LongPressLatchTest) {
     m_pButton.reset(new WPushButton(NULL, ControlPushButton::LATCHING,
                                     ControlPushButton::PUSH));
+    m_pButton->setStates(2);
 
-    m_Events.addMousePress(Qt::LeftButton, 0, QPoint(), 1000);
-    m_Events.addMouseRelease(Qt::LeftButton);
+    m_Events.addMousePress(Qt::LeftButton);
+    m_Events.addMouseRelease(Qt::LeftButton, 0, QPoint(), 1000);
 
     m_Events.simulate(m_pButton.data());
 

--- a/src/widget/wdisplay.cpp
+++ b/src/widget/wdisplay.cpp
@@ -77,7 +77,7 @@ void WDisplay::setPixmap(int iPos, const QString &filename) {
 
 void WDisplay::paintEvent(QPaintEvent *) {
     if (m_pPixmaps) {
-        int idx = (int)(m_fValue*(float)(m_iNoPos)/128.);
+        int idx = (int)(m_value*(float)(m_iNoPos)/128.);
         // Range check
         if (idx>(m_iNoPos-1))
             idx = m_iNoPos-1;

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -140,14 +140,14 @@ void WKnob::mouseMoveEvent(QMouseEvent * e)
             dist = -dist;
         }
 
-        m_fValue += dist;
+        m_value += dist;
         QCursor::setPos(m_startPos);
 
-        if (m_fValue>127.)
-            m_fValue = 127.;
-        else if (m_fValue<0.)
-            m_fValue = 0.;
-        emit(valueChangedLeftDown(m_fValue));
+        if (m_value>127.)
+            m_value = 127.;
+        else if (m_value<0.)
+            m_value = 0.;
+        emit(valueChangedLeftDown(m_value));
         update();
     }
 }
@@ -176,7 +176,7 @@ void WKnob::mouseReleaseEvent(QMouseEvent * e)
     case Qt::MidButton:
         QCursor::setPos(m_startPos);
         QApplication::restoreOverrideCursor();
-        emit(valueChangedLeftUp(m_fValue));
+        emit(valueChangedLeftUp(m_value));
         break;
     case Qt::RightButton:
         m_bRightButtonPressed = false;
@@ -208,7 +208,7 @@ void WKnob::paintEvent(QPaintEvent *)
 {
     if (m_pPixmaps)
     {
-        int idx = (int)(((m_fValue-64.)*(((float)m_iNoPos-1.)/127.))+((float)m_iNoPos/2.));
+        int idx = (int)(((m_value-64.)*(((float)m_iNoPos-1.)/127.))+((float)m_iNoPos/2.));
         // Range check
         if (idx>(m_iNoPos-1))
             idx = m_iNoPos-1;

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -322,8 +322,6 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
             if (leftLongPressLatchingStyle && m_clickTimer.isActive() && m_value >= 1.0) {
                 // revert toggle if button is released too early
                 m_value = emitValue = (int)(m_value - 1.0) % m_iNoStates;
-                m_clickTimer.setSingleShot(true);
-                m_clickTimer.start(ControlPushButtonBehavior::kPowerWindowTimeMillis);
             } else {
                 // Nothing special happens when releasing a normal toggle button
             }

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -33,6 +33,8 @@ const int PB_SHORTKLICKTIME = 200;
 
 WPushButton::WPushButton(QWidget* parent)
         : WWidget(parent),
+          m_bLeftClickForcePush(false),
+          m_bRightClickForcePush(false),
           m_pPixmaps(NULL),
           m_pPixmapBack(NULL),
           m_leftButtonMode(ControlPushButton::PUSH),
@@ -42,12 +44,14 @@ WPushButton::WPushButton(QWidget* parent)
 }
 
 WPushButton::WPushButton(QWidget *parent, ControlPushButton::ButtonMode leftButtonMode,
-                         ControlPushButton::ButtonMode rightButtonMode) :
-        WWidget(parent),
-        m_pPixmaps(NULL),
-        m_pPixmapBack(NULL),
-        m_leftButtonMode(leftButtonMode),
-        m_rightButtonMode(rightButtonMode) {
+                         ControlPushButton::ButtonMode rightButtonMode)
+        : WWidget(parent),
+          m_bLeftClickForcePush(false),
+          m_bRightClickForcePush(false),
+          m_pPixmaps(NULL),
+          m_pPixmapBack(NULL),
+          m_leftButtonMode(leftButtonMode),
+          m_rightButtonMode(rightButtonMode) {
     setStates(0);
 }
 

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -170,6 +170,14 @@ void WPushButton::setValue(double v) {
     update();
 }
 
+void WPushButton::slotCheckSetLatching() {
+    // If the left button is still being held, activate latching mode.
+    if (m_bPressed && m_bLatchActive) {
+        emit(valueChangedLatched(1.0));
+    }
+    m_bLatchActive = false;
+}
+
 void WPushButton::paintEvent(QPaintEvent *) {
     if (m_iNoStates>0)     {
         int idx = (((int)m_fValue % m_iNoStates) * 2) + m_bPressed;
@@ -216,6 +224,8 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
     }
 
     if (rightClick) {
+        // Right click cancels latching.
+        m_bLatchActive = false;
         // This is the secondary button function, it does not change m_fValue
         // due the leak of visual feedback we do not allow a toggle function
         if (m_bRightClickForcePush) {

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -31,7 +31,7 @@
 
 const int PB_SHORTKLICKTIME = 200;
 
-WPushButton::WPushButton(QWidget * parent) :
+WPushButton::WPushButton(QWidget *parent) :
         WWidget(parent),
         m_pPixmaps(NULL),
         m_pPixmapBack(NULL),
@@ -39,6 +39,16 @@ WPushButton::WPushButton(QWidget * parent) :
         m_rightButtonMode(ControlPushButton::PUSH) {
     setStates(0);
     //setBackgroundMode(Qt::NoBackground); //obsolete? removal doesn't seem to change anything on the GUI --kousu 2009/03
+}
+
+WPushButton::WPushButton(QWidget *parent, ControlPushButton::ButtonMode leftButtonMode,
+                         ControlPushButton::ButtonMode rightButtonMode) :
+        WWidget(parent),
+        m_pPixmaps(NULL),
+        m_pPixmapBack(NULL),
+        m_leftButtonMode(leftButtonMode),
+        m_rightButtonMode(rightButtonMode) {
+    setStates(0);
 }
 
 WPushButton::~WPushButton() {

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -274,15 +274,15 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
 
     if (rightClick) {
         // This is the secondary clickButton function, it does not change
-        // m_fValue due the leak of visual feedback we do not allow a toggle
+        // m_value due the leak of visual feedback we do not allow a toggle
         // function
         if (m_bRightClickForcePush) {
             m_bPressed = false;
-            emit(valueChangedRightDown(0.0f));
+            emit(valueChangedRightUp(0.0f));
             update();
         } else if (m_iNoStates == 1) {
             m_bPressed = false;
-            emit(valueChangedRightDown(0.0f));
+            emit(valueChangedRightUp(0.0f));
             update();
         }
         return;
@@ -301,7 +301,7 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
             // Nothing special happens when releasing a toggle button
         }
         m_bPressed = false;
-        emit(valueChangedLeftDown(emitValue));
+        emit(valueChangedLeftUp(emitValue));
         update();
     }
 }

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -74,9 +74,9 @@ void WPushButton::setup(QDomNode node) {
     m_bLeftClickForcePush = selectNodeQString(node, "LeftClickIsPushButton")
             .contains("true", Qt::CaseInsensitive);
 
-    if (!selectNodeQString(node, "RightClickIsPushButton").isEmpty()) {
-        qDebug() << "using <RightClickIsPushButton> in skins is obsolete.";
-    }
+    m_bRightClickForcePush = selectNodeQString(node, "RightClickIsPushButton")
+            .contains("true", Qt::CaseInsensitive);
+
 
     QDomNode con = selectNode(node, "Connection");
     while (!con.isNull()) {
@@ -204,12 +204,19 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
     }
 
     if (rightClick) {
-        // This is the secondary button function, it does not change m_value
-        // Due the leak of visual feedback the right button is always a
-        // pushbutton so "RightClickIsPushButton" is obsolete
-        m_bPressed = true;
-        emit(valueChangedRightDown(1.0f));
-        update();
+        // This is the secondary button function, it does not change m_fValue
+        // due the leak of visual feedback we do not allow a toggle function
+        if (m_bRightClickForcePush) {
+            m_bPressed = true;
+            emit(valueChangedRightDown(1.0f));
+            update();
+        } else if (m_iNoStates == 1) {
+            // This is a Pushbutton
+            m_value = 1.0f;
+            m_bPressed = true;
+            emit(valueChangedRightDown(1.0f));
+            update();
+        }
 
         // Do not allow right-clicks to change button state other than when
         // forced to be a push button. This is how Mixxx <1.8.0 worked so

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -74,9 +74,9 @@ void WPushButton::setup(QDomNode node) {
     m_bLeftClickForcePush = selectNodeQString(node, "LeftClickIsPushButton")
             .contains("true", Qt::CaseInsensitive);
 
-    m_bRightClickForcePush = selectNodeQString(node, "RightClickIsPushButton")
-            .contains("true", Qt::CaseInsensitive);
-
+    if (!selectNodeQString(node, "RightClickIsPushButton").isEmpty()) {
+        qDebug() << "using <RightClickIsPushButton> in skins is obsolete.";
+    }
 
     QDomNode con = selectNode(node, "Connection");
     while (!con.isNull()) {
@@ -204,19 +204,12 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
     }
 
     if (rightClick) {
-        // This is the secondary button function, it does not change m_fValue
-        // due the leak of visual feedback we do not allow a toggle function
-        if (m_bRightClickForcePush) {
-            m_bPressed = true;
-            emit(valueChangedRightDown(1.0f));
-            update();
-        } else if (m_iNoStates == 1) {
-            // This is a Pushbutton
-            m_value = 1.0f;
-            m_bPressed = true;
-            emit(valueChangedRightDown(1.0f));
-            update();
-        }
+        // This is the secondary button function, it does not change m_value
+        // Due the leak of visual feedback the right button is always a
+        // pushbutton so "RightClickIsPushButton" is obsolete
+        m_bPressed = true;
+        emit(valueChangedRightDown(1.0f));
+        update();
 
         // Do not allow right-clicks to change button state other than when
         // forced to be a push button. This is how Mixxx <1.8.0 worked so
@@ -284,15 +277,9 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
         // m_value due the leak of visual feedback we do not allow a toggle
         // function. It is always a pushbutton, so "RightClickIsPushButton"
         // is obsolete
-        if (m_bRightClickForcePush) {
-            m_bPressed = false;
-            emit(valueChangedRightUp(0.0f));
-            update();
-        } else if (m_iNoStates == 1) {
-            m_bPressed = false;
-            emit(valueChangedRightUp(0.0f));
-            update();
-        }
+        m_bPressed = false;
+        emit(valueChangedRightUp(0.0f));
+        update();
         return;
     }
 

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -170,14 +170,6 @@ void WPushButton::setValue(double v) {
     update();
 }
 
-void WPushButton::slotCheckSetLatching() {
-    // If the left button is still being held, activate latching mode.
-    if (m_bPressed && m_bLatchActive) {
-        emit(valueChangedLatched(1.0));
-    }
-    m_bLatchActive = false;
-}
-
 void WPushButton::paintEvent(QPaintEvent *) {
     if (m_iNoStates>0)     {
         int idx = (((int)m_fValue % m_iNoStates) * 2) + m_bPressed;
@@ -224,8 +216,6 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
     }
 
     if (rightClick) {
-        // Right click cancels latching.
-        m_bLatchActive = false;
         // This is the secondary button function, it does not change m_fValue
         // due the leak of visual feedback we do not allow a toggle function
         if (m_bRightClickForcePush) {

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -281,12 +281,17 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
 
     if (rightClick) {
         // This is the secondary clickButton function, it does not change
-        // m_value due the leak of visual feedback we do not allow a toggle
-        // function. It is always a pushbutton, so "RightClickIsPushButton"
-        // is obsolete
-        m_bPressed = false;
-        emit(valueChangedRightUp(0.0f));
-        update();
+        // m_fValue due the leak of visual feedback we do not allow a toggle
+        // function
+        if (m_bRightClickForcePush) {
+            m_bPressed = false;
+            emit(valueChangedRightUp(0.0f));
+            update();
+        } else if (m_iNoStates == 1) {
+            m_bPressed = false;
+            emit(valueChangedRightUp(0.0f));
+            update();
+        }
         return;
     }
 

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -65,7 +65,7 @@ class WPushButton : public WWidget
     bool m_bPressed;
 
   private:
-    bool m_bLeftClickForcePush;
+    bool m_bLeftClickForcePush, m_bRightClickForcePush;
     // Number of states associated with this button
     int m_iNoStates;
     // Array of associated pixmaps

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -55,6 +55,12 @@ class WPushButton : public WWidget
   public slots:
     void setValue(double);
 
+  private slots:
+    void slotCheckSetLatching();
+
+  signals:
+    void valueChangedLatched(double);
+
   protected:
     virtual void paintEvent(QPaintEvent *);
     virtual void mousePressEvent(QMouseEvent *e);
@@ -72,8 +78,11 @@ class WPushButton : public WWidget
     QPixmap **m_pPixmaps;
     // Associated background pixmap
     QPixmap *m_pPixmapBack;
+    // short click toggle button long click push button.
     ControlPushButton::ButtonMode m_leftButtonMode, m_rightButtonMode;
     QTimer m_clickTimer;
+    // Keep track if latching is still valid.
+    bool m_bLatchActive;
 };
 
 #endif

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -38,6 +38,8 @@ class WPushButton : public WWidget
     Q_OBJECT
   public:
     WPushButton(QWidget *parent=0);
+    WPushButton(QWidget *parent, ControlPushButton::ButtonMode leftButtonMode,
+                ControlPushButton::ButtonMode rightButtonMode);
     ~WPushButton();
     void setup(QDomNode node);
 

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -55,12 +55,6 @@ class WPushButton : public WWidget
   public slots:
     void setValue(double);
 
-  private slots:
-    void slotCheckSetLatching();
-
-  signals:
-    void valueChangedLatched(double);
-
   protected:
     virtual void paintEvent(QPaintEvent *);
     virtual void mousePressEvent(QMouseEvent *e);
@@ -78,11 +72,8 @@ class WPushButton : public WWidget
     QPixmap **m_pPixmaps;
     // Associated background pixmap
     QPixmap *m_pPixmapBack;
-    // short click toggle button long click push button.
     ControlPushButton::ButtonMode m_leftButtonMode, m_rightButtonMode;
     QTimer m_clickTimer;
-    // Keep track if latching is still valid.
-    bool m_bLatchActive;
 };
 
 #endif

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -69,12 +69,15 @@ class WPushButton : public WWidget
     // Number of states associated with this button
     int m_iNoStates;
     // Array of associated pixmaps
-    QPixmap **m_pPixmaps;
+    QPixmap** m_pPixmaps;
     // Associated background pixmap
-    QPixmap *m_pPixmapBack;
-    /** short click toggle button long click push button **/
-    ControlPushButton::ButtonMode m_leftButtonMode, m_rightButtonMode;
+    QPixmap* m_pPixmapBack;
+    // short click toggle button long click push button
+    ControlPushButton::ButtonMode m_leftButtonMode;
+    ControlPushButton::ButtonMode m_rightButtonMode;
     QTimer m_clickTimer;
+    // to distinguish if the Button is painted by the indicator or the main value
+    bool m_indicatorConnected;
 };
 
 #endif

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -55,6 +55,12 @@ class WPushButton : public WWidget
   public slots:
     void setValue(double);
 
+  private slots:
+    void slotCheckSetLatching();
+
+  signals:
+    void valueChangedLatched(double);
+
   protected:
     virtual void paintEvent(QPaintEvent *);
     virtual void mousePressEvent(QMouseEvent *e);
@@ -72,9 +78,11 @@ class WPushButton : public WWidget
     QPixmap **m_pPixmaps;
     // Associated background pixmap
     QPixmap *m_pPixmapBack;
-    /** short click toggle button long click push button **/
+    // short click toggle button long click push button.
     ControlPushButton::ButtonMode m_leftButtonMode, m_rightButtonMode;
     QTimer m_clickTimer;
+    // Keep track if latching is still valid.
+    bool m_bLatchActive;
 };
 
 #endif

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -76,8 +76,6 @@ class WPushButton : public WWidget
     ControlPushButton::ButtonMode m_leftButtonMode;
     ControlPushButton::ButtonMode m_rightButtonMode;
     QTimer m_clickTimer;
-    // to distinguish if the Button is painted by the indicator or the main value
-    bool m_indicatorConnected;
 };
 
 #endif

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -65,7 +65,7 @@ class WPushButton : public WWidget
     bool m_bPressed;
 
   private:
-    bool m_bLeftClickForcePush, m_bRightClickForcePush;
+    bool m_bLeftClickForcePush;
     // Number of states associated with this button
     int m_iNoStates;
     // Array of associated pixmaps

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -85,7 +85,7 @@ void WSliderComposed::setPixmaps(bool bHorizontal, const QString &filenameSlider
             setFixedSize(m_pSlider->size());
         }
 
-        setValue(m_fValue);
+        setValue(m_value);
 
         repaint();
     }
@@ -120,17 +120,17 @@ void WSliderComposed::mouseMoveEvent(QMouseEvent * e) {
         }
 
         // value ranges from 0 to 127
-        m_fValue = (double)m_iPos * (127. / (double)(m_iSliderLength - m_iHandleLength));
+        m_value = (double)m_iPos * (127. / (double)(m_iSliderLength - m_iHandleLength));
         if (!m_bHorizontal) {
-            m_fValue = 127. - m_fValue;
+            m_value = 127. - m_value;
         }
 
         // Emit valueChanged signal
         if (m_bEventWhileDrag) {
             if (e->button() == Qt::RightButton) {
-                emit(valueChangedRightUp(m_fValue));
+                emit(valueChangedRightUp(m_value));
             } else {
-                emit(valueChangedLeftUp(m_fValue));
+                emit(valueChangedLeftUp(m_value));
             }
         }
 
@@ -154,9 +154,9 @@ void WSliderComposed::mouseReleaseEvent(QMouseEvent * e) {
         mouseMoveEvent(e);
 
         if (e->button() == Qt::RightButton) {
-            emit(valueChangedRightUp(m_fValue));
+            emit(valueChangedRightUp(m_value));
         } else {
-            emit(valueChangedLeftUp(m_fValue));
+            emit(valueChangedLeftUp(m_value));
         }
 
         m_bDrag = false;
@@ -207,10 +207,10 @@ void WSliderComposed::paintEvent(QPaintEvent *) {
 }
 
 void WSliderComposed::setValue(double fValue) {
-    if (!m_bDrag && m_fValue != fValue) {
+    if (!m_bDrag && m_value != fValue) {
         // Set value without emitting a valueChanged signal
         // and force display update
-        m_fValue = fValue;
+        m_value = fValue;
 
         // Calculate handle position
         if (!m_bHorizontal) {

--- a/src/widget/wstatuslight.cpp
+++ b/src/widget/wstatuslight.cpp
@@ -53,7 +53,7 @@ void WStatusLight::setNoPos(int iNoPos)
     if (iNoPos < 2)
         iNoPos = 2; //values less than 2 make no sense (need at least off, on)
     m_iNoPos = iNoPos;
-    m_fValue = 0.;
+    m_value = 0.;
 
     m_pPixmapSLs = new QPixmap*[m_iNoPos];
     for (int i = 0; i < m_iNoPos; ++i) {

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -113,7 +113,7 @@ void WVuMeter::setValue(double fValue)
         idx = 0;
 
     setPeak(idx);
-    m_fValue = fValue;
+    m_value = fValue;
 
     QTime currentTime = QTime::currentTime();
     int msecsElapsed = m_lastUpdate.msecsTo(currentTime);
@@ -156,7 +156,7 @@ void WVuMeter::paintEvent(QPaintEvent *)
 {
     ScopedTimer t("WVuMeter::paintEvent");
     if (m_pPixmapBack && m_pPixmapVu) {
-        int idx = (int)(m_fValue*(float)(m_iNoPos)/128.);
+        int idx = (int)(m_value*(float)(m_iNoPos)/128.);
 
         // Range check
         if (idx>m_iNoPos)

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -24,11 +24,10 @@
 // Static member variable definition
 QString WWidget::m_qPath;
 
-WWidget::WWidget(QWidget * parent, Qt::WindowFlags flags) : QWidget(parent, flags)
-{
-
-    m_fValue = 0.;
-    m_bOff = false;
+WWidget::WWidget(QWidget* parent, Qt::WindowFlags flags)
+        : QWidget(parent, flags),
+          m_value(0.0),
+          m_bOff(false) {
     connect(this, SIGNAL(valueChangedLeftDown(double)), this, SLOT(slotReEmitValueDown(double)));
     connect(this, SIGNAL(valueChangedRightDown(double)), this, SLOT(slotReEmitValueDown(double)));
     connect(this, SIGNAL(valueChangedLeftUp(double)), this, SLOT(slotReEmitValueUp(double)));
@@ -36,41 +35,34 @@ WWidget::WWidget(QWidget * parent, Qt::WindowFlags flags) : QWidget(parent, flag
 
     setAttribute(Qt::WA_StaticContents);
     setFocusPolicy(Qt::ClickFocus);
-    //setBackgroundMode(Qt::NoBackground); //this is deprecated, and commenting it out doesn't seem to change anything -kousu 2009/03
 }
 
-WWidget::~WWidget()
-{
+WWidget::~WWidget() {
 }
 
-void WWidget::setValue(double fValue)
-{
-    m_fValue = fValue;
+void WWidget::setValue(double value) {
+    m_value = value;
     update();
 }
 
-void WWidget::setOnOff(double d)
-{
-    if (d==0.)
+void WWidget::setOnOff(double d) {
+    if (d == 0.) {
         m_bOff = false;
-    else
+    } else {
         m_bOff = true;
-
+    }
     repaint();
 }
 
-void WWidget::slotReEmitValueDown(double fValue)
-{
-    emit(valueChangedDown(fValue));
+void WWidget::slotReEmitValueDown(double value) {
+    emit(valueChangedDown(value));
 }
 
-void WWidget::slotReEmitValueUp(double fValue)
-{
-    emit(valueChangedUp(fValue));
+void WWidget::slotReEmitValueUp(double value) {
+    emit(valueChangedUp(value));
 }
 
-int WWidget::selectNodeInt(const QDomNode &nodeHeader, const QString sNode)
-{
+int WWidget::selectNodeInt(const QDomNode &nodeHeader, const QString sNode) {
     QString text = selectNode(nodeHeader, sNode).toElement().text();
     bool ok;
     int conv = text.toInt(&ok, 0);
@@ -81,13 +73,11 @@ int WWidget::selectNodeInt(const QDomNode &nodeHeader, const QString sNode)
     }
 }
 
-float WWidget::selectNodeFloat(const QDomNode &nodeHeader, const QString sNode)
-{
+float WWidget::selectNodeFloat(const QDomNode &nodeHeader, const QString sNode) {
     return selectNode(nodeHeader, sNode).toElement().text().toFloat();
 }
 
-QString WWidget::selectNodeQString(const QDomNode &nodeHeader, const QString sNode)
-{
+QString WWidget::selectNodeQString(const QDomNode &nodeHeader, const QString sNode) {
     QString ret;
     QDomNode node = selectNode(nodeHeader, sNode);
     if (!node.isNull())
@@ -97,8 +87,7 @@ QString WWidget::selectNodeQString(const QDomNode &nodeHeader, const QString sNo
     return ret;
 }
 
-QDomNode WWidget::selectNode(const QDomNode &nodeHeader, const QString sNode)
-{
+QDomNode WWidget::selectNode(const QDomNode &nodeHeader, const QString sNode) {
     QDomNode node = nodeHeader.firstChild();
     while (!node.isNull())
     {
@@ -109,24 +98,21 @@ QDomNode WWidget::selectNode(const QDomNode &nodeHeader, const QString sNode)
     return node;
 }
 
-const QString WWidget::getPath(QString location)
-{
+const QString WWidget::getPath(QString location) {
     QString l(location);
     return l.prepend(m_qPath);
 }
 
-void WWidget::setPixmapPath(QString qPath)
-{
+void WWidget::setPixmapPath(QString qPath) {
     m_qPath = qPath;
 }
 
 double WWidget::getValue() {
-   return m_fValue;
+   return m_value;
 }
 
-void WWidget::updateValue(double fValue)
-{
-    setValue(fValue);
-    emit(valueChangedUp(fValue));
-    emit(valueChangedDown(fValue));
+void WWidget::updateValue(double value) {
+    setValue(value);
+    emit(valueChangedUp(value));
+    emit(valueChangedDown(value));
 }

--- a/src/widget/wwidget.h
+++ b/src/widget/wwidget.h
@@ -40,14 +40,14 @@ public:
     WWidget(QWidget *parent=0, Qt::WindowFlags flags=0);
     virtual ~WWidget();
 
-    /** Sets the path used to find pixmaps */
+    // Sets the path used to find pixmaps
     static void setPixmapPath(QString qPath);
     static QDomNode selectNode(const QDomNode &nodeHeader, const QString sNode);
     static int selectNodeInt(const QDomNode &nodeHeader, const QString sNode);
     static float selectNodeFloat(const QDomNode &nodeHeader, const QString sNode);
     static QString selectNodeQString(const QDomNode &nodeHeader, const QString sNode);
 
-    /** Given a filename of a pixmap, returns its path */
+    // Given a filename of a pixmap, returns its path
     static const QString getPath(QString location);
     double getValue();
     // Sometimes WWidget's compose a QWidget (like a label). This is used during
@@ -55,8 +55,8 @@ public:
     virtual QWidget* getComposedWidget() { return NULL; }
 
   public slots:
-    virtual void setValue(double fValue);
-    void updateValue(double fValue);
+    virtual void setValue(double value);
+    void updateValue(double value);
     void setOnOff(double);
 
   private slots:
@@ -73,16 +73,16 @@ public:
     void valueChangedRightUp(double);
 
   protected:
-    /** Value/state of widget */
-    double m_fValue;
-    /** Is true if widget is off */
+    // Value/state of widget
+    double m_value;
+    // Is true if widget is off
     bool m_bOff;
 
   private:
-    /** Variable containing the path to the pixmaps */
+    // Variable containing the path to the pixmaps
     static QString m_qPath;
-    /** Property used when connecting to ControlObject */
-    bool m_bEmitOnDownPress;
+    // Property used when connecting to ControlObject
+    //bool m_bEmitOnDownPress;
 };
 
 #endif


### PR DESCRIPTION
This branch introduces a new ControlPushButton::LONGPRESSLATCHING.
It was original part of the cdj branch. 

I have tested it with this patch:

```
diff --git a/src/engine/enginemicrophone.cpp b/src/engine/enginemicrophone.cpp
index 4ddb21d..1c274d4 100644
--- a/src/engine/enginemicrophone.cpp
+++ b/src/engine/enginemicrophone.cpp
@@ -18,7 +18,7 @@ EngineMicrophone::EngineMicrophone(const char* pGroup)
           // Need a +1 here because the CircularBuffer only allows its size-1
           // items to be held at once (it keeps a blank spot open persistently)
           m_sampleBuffer(MAX_BUFFER_LEN+1) {
-    m_pControlTalkover->setButtonMode(ControlPushButton::POWERWINDOW);
+    m_pControlTalkover->setButtonMode(ControlPushButton::LONGPRESSLATCHING);
 }

 EngineMicrophone::~EngineMicrophone() {
```
