### PR TITLE
Remove deprecated Q_WS_* defines that are removed in Qt5

### DIFF
--- a/plugins/soundsourcem4a/soundsourcem4a.h
+++ b/plugins/soundsourcem4a/soundsourcem4a.h
@@ -30,7 +30,7 @@
 #include "m4a/ip.h"
 
 //As per QLibrary docs: http://doc.trolltech.com/4.6/qlibrary.html#resolve
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
 #define MY_EXPORT __declspec(dllexport)
 #else
 #define MY_EXPORT

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
@@ -27,7 +27,7 @@
 #include "defs_version.h"
 #include "soundsource.h"
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
 #define MY_EXPORT __declspec(dllexport)
 #else
 #define MY_EXPORT

--- a/plugins/soundsourcewv/soundsourcewv.h
+++ b/plugins/soundsourcewv/soundsourcewv.h
@@ -12,7 +12,7 @@
 
 #include "wavpack/wavpack.h"
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
 #define MY_EXPORT __declspec(dllexport)
 #else
 #define MY_EXPORT

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,7 +45,7 @@ extern "C" {
 #include <ladspa/ladspaloader.h>
 #endif
 
-#ifdef Q_WS_X11
+#ifdef Q_OS_LINUX 
 #include <X11/Xlib.h>
 #endif
 
@@ -158,7 +158,7 @@ void MessageHandler(QtMsgType type,
 int main(int argc, char * argv[])
 {
 
-#ifdef Q_WS_X11
+#ifdef Q_OS_LINUX 
     XInitThreads();
 #endif
 

--- a/src/util/performancetimer.cpp
+++ b/src/util/performancetimer.cpp
@@ -54,7 +54,7 @@
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
-#elif defined(Q_WS_WIN)
+#elif defined(Q_OS_WIN)
 #include <windows.h>
 #endif
 
@@ -226,7 +226,7 @@ qint64 PerformanceTimer::difference(PerformanceTimer* timer)
 }
 
 ////////////////////////////// Windows //////////////////////////////
-#elif defined(Q_WS_WIN)
+#elif defined(Q_OS_WIN)
 
 static qint64 getTimeFromTick(quint64 elapsed)
 {


### PR DESCRIPTION
All the Q_WS_blah defines are gone in Qt5. The Q_OS_blah macros are present in Qt 4.8, and probably earlier.

This pull request fixes all the occurrences of Q_WS_ that are in master right now. This will fix some mystery problems and compile errors that are occurring with Qt 5 on Windows, and everything should still work with Qt 4.
