### PR TITLE
Master sync

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -547,6 +547,7 @@ class MixxxCore(Feature):
                    "engine/enginechannel.cpp",
                    "engine/enginemaster.cpp",
                    "engine/enginesync.cpp",
+                   "engine/internalclock.cpp",
                    "engine/enginedelay.cpp",
                    "engine/engineflanger.cpp",
                    "engine/enginefiltereffect.cpp",

--- a/src/engine/clock.h
+++ b/src/engine/clock.h
@@ -1,0 +1,12 @@
+#ifndef CLOCK_H
+#define CLOCK_H
+
+class Clock {
+    virtual double getBeatDistance() const = 0;
+    virtual void setBeatDistance(double beatDistance) = 0;
+
+    virtual double getBpm() const = 0;
+    virtual void setBpm(double bpm) = 0;
+};
+
+#endif /* CLOCK_H */

--- a/src/engine/clock.h
+++ b/src/engine/clock.h
@@ -2,6 +2,9 @@
 #define CLOCK_H
 
 class Clock {
+  public:
+    virtual ~Clock() {}
+
     virtual double getBeatDistance() const = 0;
     virtual void setBeatDistance(double beatDistance) = 0;
 

--- a/src/engine/enginesync.cpp
+++ b/src/engine/enginesync.cpp
@@ -464,6 +464,12 @@ void EngineSync::initializeInternalClockBeatDistance(RateControl* pRateControl) 
 
 void EngineSync::onCallbackStart(int sampleRate, int bufferSize) {
     m_pInternalClock->onCallbackStart(sampleRate, bufferSize);
+
+    // If the InternalClock is the master, set the master beat distance to the
+    // clock's current beat distance.
+    if (m_sSyncSource == kInternalClockGroup) {
+        m_pMasterBeatDistance->set(m_pInternalClock->getBeatDistance());
+    }
 }
 
 EngineChannel* EngineSync::getMaster() const {

--- a/src/engine/enginesync.cpp
+++ b/src/engine/enginesync.cpp
@@ -26,6 +26,7 @@
 #include "engine/enginecontrol.h"
 #include "engine/enginesync.h"
 #include "engine/ratecontrol.h"
+#include "engine/internalclock.h"
 
 static const char* kMasterSyncGroup = "[Master]";
 static const char* kInternalClockGroup = "[InternalClock]";
@@ -33,24 +34,12 @@ static const char* kInternalClockGroup = "[InternalClock]";
 EngineSync::EngineSync(ConfigObject<ConfigValue>* _config)
         : EngineControl(kMasterSyncGroup, _config),
           m_pConfig(_config),
+          m_pInternalClock(new InternalClock(kInternalClockGroup)),
           m_pChannelMaster(NULL),
           m_sSyncSource(""),
-          m_bExplicitMasterSelected(false),
-          m_dInternalClockPosition(0.0f) {
+          m_bExplicitMasterSelected(false) {
     qRegisterMetaType<EngineSync::SyncMode>("EngineSync::SyncMode");
     m_pMasterBeatDistance = new ControlObject(ConfigKey(kMasterSyncGroup, "beat_distance"));
-
-    m_pSampleRate = ControlObject::getControl(ConfigKey(kMasterSyncGroup, "samplerate"));
-    connect(m_pSampleRate, SIGNAL(valueChangedFromEngine(double)),
-            this, SLOT(slotSampleRateChanged(double)),
-            Qt::DirectConnection);
-    connect(m_pSampleRate, SIGNAL(valueChanged(double)),
-            this, SLOT(slotSampleRateChanged(double)),
-            Qt::DirectConnection);
-
-    if (m_pSampleRate->get()) {
-        m_pSampleRate->set(44100);
-    }
 
     m_pMasterBpm = new ControlObject(ConfigKey(kMasterSyncGroup, "sync_bpm"));
     // Initialize with a default value (will get overridden by config).
@@ -77,8 +66,6 @@ EngineSync::EngineSync(ConfigObject<ConfigValue>* _config)
     connect(m_pMasterRateSlider, SIGNAL(valueChangedFromEngine(double)),
             this, SLOT(slotSyncRateSliderChanged(double)),
             Qt::DirectConnection);
-
-    updateInternalClockRate();
 }
 
 EngineSync::~EngineSync() {
@@ -294,14 +281,13 @@ void EngineSync::activateInternalClockMaster() {
         m_pMasterRateSlider->set(master_bpm);
     }
     QString old_master = m_sSyncSource;
-    initializeInternalClockBeatDistance();
+    initializeInternalClockBeatDistance(m_pChannelMaster);
     RateControl* pOldChannelMaster = m_pChannelMaster;
     disconnectCurrentMaster();
     if (pOldChannelMaster) {
         pOldChannelMaster->notifyModeChanged(SYNC_FOLLOWER);
     }
     m_sSyncSource = kMasterSyncGroup;
-    updateInternalClockRate();
 
     // This is all we have to do, we'll start using the clock position right away.
     m_pInternalClockMasterEnabled->set(true);
@@ -356,7 +342,7 @@ bool EngineSync::activateChannelMaster(RateControl* pRateControl) {
             Qt::DirectConnection);
 
     // Reset internal beat distance to equal the new master
-    initializeInternalClockBeatDistance();
+    initializeInternalClockBeatDistance(m_pChannelMaster);
 
     m_pInternalClockMasterEnabled->set(false);
     slotSourceRateEngineChanged(pSourceRateEngine->get());
@@ -435,7 +421,7 @@ void EngineSync::slotSourceBpmChanged(double bpm) {
 void EngineSync::slotSourceBeatDistanceChanged(double beat_dist) {
     // Pass it on to slaves and update clock position marker.
     m_pMasterBeatDistance->set(beat_dist);
-    setInternalClockPosition(beat_dist);
+    m_pInternalClock->setBeatDistance(beat_dist);
 }
 
 void EngineSync::slotSyncRateSliderChanged(double new_bpm) {
@@ -445,28 +431,9 @@ void EngineSync::slotSyncRateSliderChanged(double new_bpm) {
 }
 
 void EngineSync::slotMasterBpmChanged(double new_bpm) {
-    if (!qFuzzyCompare(new_bpm, m_pMasterBpm->get())) {
-        updateInternalClockRate();
-
-        // This change could hypothetically push us over distance 1.0, so check
-        // XXX: is this code correct?  I think it'll work but it seems off
-        if (m_dInternalClockRate <= 0) {
-            qDebug() << "ERROR: Calculated <= 0 samples per beat which is impossible.  Forcibly "
-                     << "setting to about 124bpm at 44.1Khz.";
-            m_dInternalClockRate = 21338;
-        }
-        while (m_dInternalClockPosition >= m_dInternalClockRate) {
-            m_dInternalClockPosition -= m_dInternalClockRate;
-        }
-    }
-}
-
-void EngineSync::slotSampleRateChanged(double srate) {
-    int new_rate = static_cast<int>(srate);
-    double internal_position = getInternalClockBeatDistance();
-    // Recalculate clock buffer position based on new sample rate.
-    m_dInternalClockPosition = new_rate * internal_position / m_dInternalClockRate;
-    updateInternalClockRate();
+    // TODO(rryan): Set the enabled master's BPM, if allowed. Re-set master BPM
+    // with the master's new BPM (if it rejects it).
+    m_pInternalClock->setBpm(new_bpm);
 }
 
 void EngineSync::slotInternalClockModeChanged(double state) {
@@ -479,84 +446,24 @@ void EngineSync::slotInternalClockModeChanged(double state) {
     }
 }
 
-double EngineSync::getInternalClockBeatDistance() const {
-    // Returns number of samples distance from the last beat.
-    if (m_dInternalClockPosition < 0) {
-        qDebug() << "ERROR: Internal beat distance should never be less than zero";
-        return 0.0;
-    }
-    return m_dInternalClockPosition / m_dInternalClockRate;
-}
-
-void EngineSync::initializeInternalClockBeatDistance() {
-    if (m_pChannelMaster) {
-        initializeInternalClockBeatDistance(m_pChannelMaster);
-    }
-}
-
 void EngineSync::initializeInternalClockBeatDistance(RateControl* pRateControl) {
+    if (pRateControl == NULL) {
+        return;
+    }
     ControlObject* pSourceBeatDistance =
             ControlObject::getControl(ConfigKey(pRateControl->getGroup(), "beat_distance"));
     double beat_distance = pSourceBeatDistance ? pSourceBeatDistance->get() : 0;
 
-    m_dInternalClockPosition = beat_distance * m_dInternalClockRate;
+    m_pInternalClock->setBeatDistance(beat_distance);
     m_pMasterBeatDistance->set(beat_distance);
     if (pSourceBeatDistance) {
-        qDebug() << "Resetting clock beat distance to " << pRateControl->getGroup()
-                 << m_dInternalClockPosition << " " << beat_distance;
-    }
-}
-
-void EngineSync::updateInternalClockRate() {
-    //to get samples per beat, do:
-    //
-    // samples   samples     60 seconds     minutes
-    // ------- = -------  *  ----------  *  -------
-    //   beat    second       1 minute       beats
-
-    // that last term is 1 over bpm.
-    double master_bpm = m_pMasterBpm->get();
-    double sample_rate = m_pSampleRate->get();
-    if (qFuzzyCompare(master_bpm, 0)) {
-        qDebug() << "WARNING: Master bpm reported to be zero, internal clock guessing 60bpm";
-        m_dInternalClockRate = sample_rate;
-        return;
-    }
-    m_dInternalClockRate = (sample_rate * 60.0) / master_bpm;
-    if (m_dInternalClockRate <= 0) {
-        qDebug() << "WARNING: Tried to set samples per beat <=0";
-        m_dInternalClockRate = sample_rate;
+        qDebug() << "Reset clock beat distance to " << pRateControl->getGroup()
+                 << beat_distance;
     }
 }
 
 void EngineSync::onCallbackStart(int sampleRate, int bufferSize) {
-    // EngineMaster calls this function, it is used to keep track of the
-    // clock (when there is no other master like a deck or MIDI) the
-    // clock position is a double because we want to be precise, and beats may
-    // not line up exactly with samples.
-
-    if (m_sSyncSource != kMasterSyncGroup) {
-        // We don't care, it will get set in setClockPosition.
-        return;
-    }
-
-    m_dInternalClockPosition += bufferSize / 2; // stereo samples, so divide by 2
-
-    // Can't use mod because we're in double land.
-    if (m_dInternalClockRate <= 0) {
-        qDebug() << "ERROR: Calculated <= 0 samples per beat which is impossible.  Forcibly "
-                 << "setting to about 124 bpm at 44.1Khz.";
-        m_dInternalClockRate = 21338;
-    }
-    while (m_dInternalClockPosition >= m_dInternalClockRate) {
-        m_dInternalClockPosition -= m_dInternalClockRate;
-    }
-
-    m_pMasterBeatDistance->set(getInternalClockBeatDistance());
-}
-
-void EngineSync::setInternalClockPosition(double percent) {
-    m_dInternalClockPosition = percent * m_dInternalClockRate;
+    m_pInternalClock->onCallbackStart(sampleRate, bufferSize);
 }
 
 EngineChannel* EngineSync::getMaster() const {

--- a/src/engine/enginesync.cpp
+++ b/src/engine/enginesync.cpp
@@ -74,6 +74,7 @@ EngineSync::~EngineSync() {
     delete m_pMasterBpm;
     delete m_pMasterBeatDistance;
     delete m_pMasterRateSlider;
+    delete m_pInternalClock;
 }
 
 void EngineSync::addChannel(EngineChannel* pChannel) {

--- a/src/engine/enginesync.h
+++ b/src/engine/enginesync.h
@@ -26,6 +26,7 @@ class ControlObject;
 class ControlPushButton;
 class ControlPotmeter;
 class RateControl;
+class InternalClock;
 
 class EngineSync : public EngineControl {
     Q_OBJECT
@@ -70,7 +71,6 @@ class EngineSync : public EngineControl {
     void slotSourceRateEngineChanged(double);
     void slotSourceBpmChanged(double);
     void slotSourceBeatDistanceChanged(double);
-    void slotSampleRateChanged(double);
     void slotInternalClockModeChanged(double);
 
   private:
@@ -84,16 +84,13 @@ class EngineSync : public EngineControl {
     // Unhooks the current master's signals and resets EngineSync state so it has no master.
     // Does not actually set the sync_master CO!
     void disconnectCurrentMaster();
-    // Updates the speed of the internal clock.
-    void updateInternalClockRate();
-    void setInternalClockPosition(double percent);
     // Align the clock's beat distance with the given ratecontrol.
     void initializeInternalClockBeatDistance(RateControl* pRateControl);
-    // Align the clock's beat distance with the current master, if any.
-    void initializeInternalClockBeatDistance();
     double getInternalClockBeatDistance() const;
 
     ConfigObject<ConfigValue>* m_pConfig;
+
+    InternalClock* m_pInternalClock;
 
     RateControl* m_pChannelMaster;
 
@@ -106,12 +103,6 @@ class EngineSync : public EngineControl {
     QList<RateControl*> m_ratecontrols;
     QString m_sSyncSource;
     bool m_bExplicitMasterSelected;
-    // The internal clock rate is stored in terms of samples per beat.  Fractional values are
-    // allowed.
-    double m_dInternalClockRate;
-
-    // Used for maintaining internal clock master sync.
-    double m_dInternalClockPosition;
 };
 
 #endif

--- a/src/engine/internalclock.cpp
+++ b/src/engine/internalclock.cpp
@@ -1,0 +1,99 @@
+#include <QtDebug>
+
+#include "engine/internalclock.h"
+#include "controlobject.h"
+#include "configobject.h"
+
+InternalClock::InternalClock(const char* pGroup)
+        : m_group(pGroup),
+          m_iOldSampleRate(0),
+          m_dOldBpm(0.0),
+          m_dBeatLength(0),
+          m_dClockPosition(0) {
+    m_pClockBpm = new ControlObject(ConfigKey(m_group, "bpm"));
+    connect(m_pClockBpm, SIGNAL(valueChanged(double)),
+            this, SLOT(slotBpmChanged(double)),
+            Qt::DirectConnection);
+}
+
+InternalClock::~InternalClock() {
+    delete m_pClockBpm;
+}
+
+double InternalClock::getBeatDistance() const {
+    if (m_dBeatLength <= 0) {
+        qDebug() << "ERROR: InternalClock beat length should never be less than zero";
+        return 0.0;
+    }
+    return m_dClockPosition / m_dBeatLength;
+}
+
+void InternalClock::setBeatDistance(double beatDistance) {
+    m_dClockPosition = beatDistance * m_dBeatLength;
+}
+
+double InternalClock::getBpm() const {
+    return m_pClockBpm->get();
+}
+
+void InternalClock::setBpm(double bpm) {
+    m_pClockBpm->set(bpm);
+    updateBeatLength(m_iOldSampleRate, bpm);
+}
+
+void InternalClock::slotBpmChanged(double bpm) {
+    updateBeatLength(m_iOldSampleRate, bpm);
+}
+
+void InternalClock::updateBeatLength(int sampleRate, double bpm) {
+    if (m_iOldSampleRate == sampleRate && bpm == m_dOldBpm) {
+        return;
+    }
+
+    // Changing the beat length changes the beat distance. Record the current
+    // beat distance so we can restore it when we are done.
+    double oldBeatDistance = getBeatDistance();
+
+    //to get samples per beat, do:
+    //
+    // samples   samples     60 seconds     minutes
+    // ------- = -------  *  ----------  *  -------
+    //   beat    second       1 minute       beats
+
+    // that last term is 1 over bpm.
+
+    if (qFuzzyCompare(bpm, 0)) {
+        qDebug() << "WARNING: Master bpm reported to be zero, internal clock guessing 60bpm";
+        m_dBeatLength = sampleRate;
+    } else {
+        m_dBeatLength = (sampleRate * 60.0) / bpm;
+        if (m_dBeatLength <= 0) {
+            qDebug() << "WARNING: Tried to set samples per beat <=0";
+            m_dBeatLength = sampleRate;
+        }
+    }
+
+    m_dOldBpm = bpm;
+    m_iOldSampleRate = sampleRate;
+
+    // Restore the old beat distance.
+    setBeatDistance(oldBeatDistance);
+}
+
+void InternalClock::onCallbackStart(int sampleRate, int bufferSize) {
+    updateBeatLength(sampleRate, m_pClockBpm->get());
+
+    // stereo samples, so divide by 2
+    m_dClockPosition += bufferSize / 2;
+
+    // Can't use mod because we're in double land.
+    if (m_dBeatLength <= 0) {
+        qDebug() << "ERROR: Calculated <= 0 samples per beat which is impossible.  Forcibly "
+                 << "setting to about 124 bpm at 44.1Khz.";
+        m_dBeatLength = 21338;
+    }
+
+    while (m_dClockPosition >= m_dBeatLength) {
+        m_dClockPosition -= m_dBeatLength;
+    }
+}

--- a/src/engine/internalclock.h
+++ b/src/engine/internalclock.h
@@ -1,0 +1,45 @@
+#ifndef INTERNALCLOCK_H
+#define INTERNALCLOCK_H
+
+#include <QObject>
+#include <QString>
+
+#include "engine/clock.h"
+
+class ControlObject;
+
+class InternalClock : public QObject, public Clock {
+  public:
+    InternalClock(const char* pGroup);
+    virtual ~InternalClock();
+
+    void onCallbackStart(int sampleRate, int bufferSize);
+
+    double getBeatDistance() const;
+    void setBeatDistance(double beatDistance);
+
+    void setBpm(double bpm);
+    double getBpm() const;
+
+  private slots:
+    void slotBpmChanged(double bpm);
+
+  private:
+    void updateBeatLength(int sampleRate, double bpm);
+
+    QString m_group;
+    ControlObject* m_pClockBpm;
+
+    int m_iOldSampleRate;
+    double m_dOldBpm;
+
+    // The internal clock rate is stored in terms of samples per beat.
+    // Fractional values are allowed.
+    double m_dBeatLength;
+
+    // The current number of frames accumulated since the last beat (e.g. beat
+    // distance is m_dClockPosition / m_dBeatLength).
+    double m_dClockPosition;
+};
+
+#endif /* INTERNALCLOCK_H */

--- a/src/engine/internalclock.h
+++ b/src/engine/internalclock.h
@@ -9,6 +9,7 @@
 class ControlObject;
 
 class InternalClock : public QObject, public Clock {
+    Q_OBJECT
   public:
     InternalClock(const char* pGroup);
     virtual ~InternalClock();


### PR DESCRIPTION
Move internal clock into its own class.

This change makes EngineSync shorter (and easier to read) but my overall goal here is to move towards having an abstract virtual base class "Syncable" that all sync sources (RateControl, InternalClock, MIDIClock, etc.) implement. I think it would drastically simplify EngineSync if it didn't draw a distinction between a clock and a deck.
