### PR TITLE
Master sync

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -547,6 +547,7 @@ class MixxxCore(Feature):
                    "engine/enginechannel.cpp",
                    "engine/enginemaster.cpp",
                    "engine/enginesync.cpp",
+                   "engine/internalclock.cpp",
                    "engine/enginedelay.cpp",
                    "engine/engineflanger.cpp",
                    "engine/enginefiltereffect.cpp",

--- a/src/engine/clock.h
+++ b/src/engine/clock.h
@@ -1,0 +1,12 @@
+#ifndef CLOCK_H
+#define CLOCK_H
+
+class Clock {
+    virtual double getBeatDistance() const = 0;
+    virtual void setBeatDistance(double beatDistance) = 0;
+
+    virtual double getBpm() const = 0;
+    virtual void setBpm(double bpm) = 0;
+};
+
+#endif /* CLOCK_H */

--- a/src/engine/clock.h
+++ b/src/engine/clock.h
@@ -2,6 +2,9 @@
 #define CLOCK_H
 
 class Clock {
+  public:
+    virtual ~Clock() {}
+
     virtual double getBeatDistance() const = 0;
     virtual void setBeatDistance(double beatDistance) = 0;
 

--- a/src/engine/enginesync.cpp
+++ b/src/engine/enginesync.cpp
@@ -464,6 +464,12 @@ void EngineSync::initializeInternalClockBeatDistance(RateControl* pRateControl) 
 
 void EngineSync::onCallbackStart(int sampleRate, int bufferSize) {
     m_pInternalClock->onCallbackStart(sampleRate, bufferSize);
+
+    // If the InternalClock is the master, set the master beat distance to the
+    // clock's current beat distance.
+    if (m_sSyncSource == kInternalClockGroup) {
+        m_pMasterBeatDistance->set(m_pInternalClock->getBeatDistance());
+    }
 }
 
 EngineChannel* EngineSync::getMaster() const {

--- a/src/engine/enginesync.cpp
+++ b/src/engine/enginesync.cpp
@@ -74,6 +74,7 @@ EngineSync::~EngineSync() {
     delete m_pMasterBpm;
     delete m_pMasterBeatDistance;
     delete m_pMasterRateSlider;
+    delete m_pInternalClock;
 }
 
 void EngineSync::addChannel(EngineChannel* pChannel) {

--- a/src/engine/enginesync.h
+++ b/src/engine/enginesync.h
@@ -26,6 +26,7 @@ class ControlObject;
 class ControlPushButton;
 class ControlPotmeter;
 class RateControl;
+class InternalClock;
 
 class EngineSync : public EngineControl {
     Q_OBJECT
@@ -70,7 +71,6 @@ class EngineSync : public EngineControl {
     void slotSourceRateEngineChanged(double);
     void slotSourceBpmChanged(double);
     void slotSourceBeatDistanceChanged(double);
-    void slotSampleRateChanged(double);
     void slotInternalClockModeChanged(double);
 
   private:
@@ -84,16 +84,13 @@ class EngineSync : public EngineControl {
     // Unhooks the current master's signals and resets EngineSync state so it has no master.
     // Does not actually set the sync_master CO!
     void disconnectCurrentMaster();
-    // Updates the speed of the internal clock.
-    void updateInternalClockRate();
-    void setInternalClockPosition(double percent);
     // Align the clock's beat distance with the given ratecontrol.
     void initializeInternalClockBeatDistance(RateControl* pRateControl);
-    // Align the clock's beat distance with the current master, if any.
-    void initializeInternalClockBeatDistance();
     double getInternalClockBeatDistance() const;
 
     ConfigObject<ConfigValue>* m_pConfig;
+
+    InternalClock* m_pInternalClock;
 
     RateControl* m_pChannelMaster;
 
@@ -106,12 +103,6 @@ class EngineSync : public EngineControl {
     QList<RateControl*> m_ratecontrols;
     QString m_sSyncSource;
     bool m_bExplicitMasterSelected;
-    // The internal clock rate is stored in terms of samples per beat.  Fractional values are
-    // allowed.
-    double m_dInternalClockRate;
-
-    // Used for maintaining internal clock master sync.
-    double m_dInternalClockPosition;
 };
 
 #endif

--- a/src/engine/internalclock.cpp
+++ b/src/engine/internalclock.cpp
@@ -1,0 +1,99 @@
+#include <QtDebug>
+
+#include "engine/internalclock.h"
+#include "controlobject.h"
+#include "configobject.h"
+
+InternalClock::InternalClock(const char* pGroup)
+        : m_group(pGroup),
+          m_iOldSampleRate(0),
+          m_dOldBpm(0.0),
+          m_dBeatLength(0),
+          m_dClockPosition(0) {
+    m_pClockBpm = new ControlObject(ConfigKey(m_group, "bpm"));
+    connect(m_pClockBpm, SIGNAL(valueChanged(double)),
+            this, SLOT(slotBpmChanged(double)),
+            Qt::DirectConnection);
+}
+
+InternalClock::~InternalClock() {
+    delete m_pClockBpm;
+}
+
+double InternalClock::getBeatDistance() const {
+    if (m_dBeatLength <= 0) {
+        qDebug() << "ERROR: InternalClock beat length should never be less than zero";
+        return 0.0;
+    }
+    return m_dClockPosition / m_dBeatLength;
+}
+
+void InternalClock::setBeatDistance(double beatDistance) {
+    m_dClockPosition = beatDistance * m_dBeatLength;
+}
+
+double InternalClock::getBpm() const {
+    return m_pClockBpm->get();
+}
+
+void InternalClock::setBpm(double bpm) {
+    m_pClockBpm->set(bpm);
+    updateBeatLength(m_iOldSampleRate, bpm);
+}
+
+void InternalClock::slotBpmChanged(double bpm) {
+    updateBeatLength(m_iOldSampleRate, bpm);
+}
+
+void InternalClock::updateBeatLength(int sampleRate, double bpm) {
+    if (m_iOldSampleRate == sampleRate && bpm == m_dOldBpm) {
+        return;
+    }
+
+    // Changing the beat length changes the beat distance. Record the current
+    // beat distance so we can restore it when we are done.
+    double oldBeatDistance = getBeatDistance();
+
+    //to get samples per beat, do:
+    //
+    // samples   samples     60 seconds     minutes
+    // ------- = -------  *  ----------  *  -------
+    //   beat    second       1 minute       beats
+
+    // that last term is 1 over bpm.
+
+    if (qFuzzyCompare(bpm, 0)) {
+        qDebug() << "WARNING: Master bpm reported to be zero, internal clock guessing 60bpm";
+        m_dBeatLength = sampleRate;
+    } else {
+        m_dBeatLength = (sampleRate * 60.0) / bpm;
+        if (m_dBeatLength <= 0) {
+            qDebug() << "WARNING: Tried to set samples per beat <=0";
+            m_dBeatLength = sampleRate;
+        }
+    }
+
+    m_dOldBpm = bpm;
+    m_iOldSampleRate = sampleRate;
+
+    // Restore the old beat distance.
+    setBeatDistance(oldBeatDistance);
+}
+
+void InternalClock::onCallbackStart(int sampleRate, int bufferSize) {
+    updateBeatLength(sampleRate, m_pClockBpm->get());
+
+    // stereo samples, so divide by 2
+    m_dClockPosition += bufferSize / 2;
+
+    // Can't use mod because we're in double land.
+    if (m_dBeatLength <= 0) {
+        qDebug() << "ERROR: Calculated <= 0 samples per beat which is impossible.  Forcibly "
+                 << "setting to about 124 bpm at 44.1Khz.";
+        m_dBeatLength = 21338;
+    }
+
+    while (m_dClockPosition >= m_dBeatLength) {
+        m_dClockPosition -= m_dBeatLength;
+    }
+}

--- a/src/engine/internalclock.h
+++ b/src/engine/internalclock.h
@@ -1,0 +1,45 @@
+#ifndef INTERNALCLOCK_H
+#define INTERNALCLOCK_H
+
+#include <QObject>
+#include <QString>
+
+#include "engine/clock.h"
+
+class ControlObject;
+
+class InternalClock : public QObject, public Clock {
+  public:
+    InternalClock(const char* pGroup);
+    virtual ~InternalClock();
+
+    void onCallbackStart(int sampleRate, int bufferSize);
+
+    double getBeatDistance() const;
+    void setBeatDistance(double beatDistance);
+
+    void setBpm(double bpm);
+    double getBpm() const;
+
+  private slots:
+    void slotBpmChanged(double bpm);
+
+  private:
+    void updateBeatLength(int sampleRate, double bpm);
+
+    QString m_group;
+    ControlObject* m_pClockBpm;
+
+    int m_iOldSampleRate;
+    double m_dOldBpm;
+
+    // The internal clock rate is stored in terms of samples per beat.
+    // Fractional values are allowed.
+    double m_dBeatLength;
+
+    // The current number of frames accumulated since the last beat (e.g. beat
+    // distance is m_dClockPosition / m_dBeatLength).
+    double m_dClockPosition;
+};
+
+#endif /* INTERNALCLOCK_H */

--- a/src/engine/internalclock.h
+++ b/src/engine/internalclock.h
@@ -9,6 +9,7 @@
 class ControlObject;
 
 class InternalClock : public QObject, public Clock {
+    Q_OBJECT
   public:
     InternalClock(const char* pGroup);
     virtual ~InternalClock();


### PR DESCRIPTION
Move internal clock into its own class.

This change makes EngineSync shorter (and easier to read) but my overall goal here is to move towards having an abstract virtual base class "Syncable" that all sync sources (RateControl, InternalClock, MIDIClock, etc.) implement. I think it would drastically simplify EngineSync if it didn't draw a distinction between a clock and a deck.
