### PR TITLE
Major refactor of EngineSync / RateControl / BpmControl for master sync.

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -547,6 +547,7 @@ class MixxxCore(Feature):
                    "engine/enginechannel.cpp",
                    "engine/enginemaster.cpp",
                    "engine/enginesync.cpp",
+                   "engine/synccontrol.cpp",
                    "engine/internalclock.cpp",
                    "engine/enginedelay.cpp",
                    "engine/engineflanger.cpp",

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -7,7 +7,7 @@
 
 #include "controlobject.h"
 #include "engine/enginecontrol.h"
-#include "engine/enginesync.h"
+#include "engine/syncable.h"
 #include "tapfilter.h"
 
 class ControlObject;
@@ -30,14 +30,13 @@ class BpmControl : public EngineControl {
     // Get the phase offset from the specified position.
     double getPhaseOffset(double reference_position);
 
-    void notifyModeChanged(EngineSync::SyncMode mode);
-    void notifyMasterSyncSliderChanged(double bpm);
-
     void setCurrentSample(const double dCurrentSample, const double dTotalSamples);
     double process(const double dRate,
                    const double dCurrentSample,
                    const double dTotalSamples,
                    const int iBufferSize);
+    void setTargetBeatDistance(double beatDistance);
+    void setBpmFromMaster(double);
 
     // Calculates contextual information about beats: the previous beat, the
     // next beat, the current beat length, and the beat ratio (how far dPosition
@@ -73,13 +72,10 @@ class BpmControl : public EngineControl {
     void slotAdjustRateSlider();
     void slotUpdatedTrackBeats();
     void slotBeatsTranslate(double);
-    void slotMasterSyncSliderChanged(double);
-    void slotSyncModeChanged(double);
-    void slotSetStatuses();
 
   private:
-    EngineSync::SyncMode getSyncMode() const {
-        return EngineSync::syncModeFromDouble(m_pSyncMode->get());
+    SyncMode getSyncMode() const {
+        return syncModeFromDouble(m_pSyncMode->get());
     }
     double getBeatDistance(double dThisPosition) const;
     bool syncTempo();
@@ -91,8 +87,6 @@ class BpmControl : public EngineControl {
     ControlObject* m_pQuantize;
     ControlObjectSlave* m_pRateRange;
     ControlObjectSlave* m_pRateDir;
-
-    ControlObject* m_pThisBeatDistance;
 
     // Is vinyl control enabled?
     ControlObject* m_pVCEnabled;
@@ -124,11 +118,10 @@ class BpmControl : public EngineControl {
     double m_dPreviousSample;
 
     // Master Sync objects and values.
-    ControlObject *m_pMasterBpm, *m_pMasterSyncSlider;
-    ControlObject *m_pSyncInternalEnabled;
-    ControlObject *m_pSyncMasterEnabled, *m_pSyncEnabled;
-    ControlObject *m_pSyncMode;
-    ControlObject* m_pMasterBeatDistance;
+    ControlObject* m_pMasterBpm;
+    ControlObject* m_pSyncMode;
+    ControlObjectSlave* m_pThisBeatDistance;
+    double m_dSyncTargetBeatDistance;
     double m_dSyncAdjustment;
     double m_dUserOffset;
 

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -33,10 +33,12 @@
 #include <QTextStream>
 #endif
 
+class EngineChannel;
 class EngineControl;
 class BpmControl;
 class KeyControl;
 class RateControl;
+class SyncControl;
 class LoopingControl;
 class ClockControl;
 class CueControl;
@@ -92,8 +94,8 @@ class EngineBuffer : public EngineObject {
      Q_OBJECT
 public:
     EngineBuffer(const char *_group, ConfigObject<ConfigValue> *_config,
-                 EngineMaster* pMixingEngine);
-    ~EngineBuffer();
+                 EngineChannel* pChannel, EngineMaster* pMixingEngine);
+    virtual ~EngineBuffer();
     bool getPitchIndpTimeStretch(void);
 
     void bindWorkers(EngineWorkerScheduler* pWorkerScheduler);
@@ -185,6 +187,7 @@ public:
 
     LoopingControl* m_pLoopingControl;
     EngineSync* m_pEngineSync;
+    SyncControl* m_pSyncControl;
     RateControl* m_pRateControl;
     BpmControl* m_pBpmControl;
     KeyControl* m_pKeyControl;

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -57,7 +57,7 @@ EngineDeck::EngineDeck(const char* group,
     m_pFlanger = new EngineFlanger(group);
     m_pFilterEffect = new EngineFilterEffect(group);
     m_pClipping = new EngineClipping(group);
-    m_pBuffer = new EngineBuffer(group, pConfig, pMixingEngine);
+    m_pBuffer = new EngineBuffer(group, pConfig, this, pMixingEngine);
     m_pVinylSoundEmu = new EngineVinylSoundEmu(pConfig, group);
     m_pVUMeter = new EngineVuMeter(group);
 }

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -432,8 +432,6 @@ void EngineMaster::addChannel(EngineChannel* pChannel) {
         pBuffer->bindWorkers(m_pWorkerScheduler);
         pBuffer->setEngineMaster(this);
     }
-
-    m_pMasterSync->addChannel(pChannel);
 }
 
 EngineChannel* EngineMaster::getChannel(QString group) {

--- a/src/engine/enginesync.cpp
+++ b/src/engine/enginesync.cpp
@@ -282,8 +282,7 @@ void EngineSync::notifyInstantaneousBpmChanged(Syncable* pSyncable, double bpm) 
 }
 
 void EngineSync::notifyBeatDistanceChanged(Syncable* pSyncable, double beat_distance) {
-    qDebug() << "EngineSync::notifyBeatDistanceChanged" << pSyncable->getGroup() << beat_distance;
-    if (pSyncable->getSyncMode() == SYNC_NONE) {
+    //qDebug() << "EngineSync::notifyBeatDistanceChanged" << pSyncable->getGroup() << beat_distance;
     if (pSyncable->getSyncMode() != SYNC_MASTER) {
         return;
     }

--- a/src/engine/enginesync.cpp
+++ b/src/engine/enginesync.cpp
@@ -284,6 +284,7 @@ void EngineSync::notifyInstantaneousBpmChanged(Syncable* pSyncable, double bpm) 
 void EngineSync::notifyBeatDistanceChanged(Syncable* pSyncable, double beat_distance) {
     qDebug() << "EngineSync::notifyBeatDistanceChanged" << pSyncable->getGroup() << beat_distance;
     if (pSyncable->getSyncMode() == SYNC_NONE) {
+    if (pSyncable->getSyncMode() != SYNC_MASTER) {
         return;
     }
 

--- a/src/engine/enginesync.h
+++ b/src/engine/enginesync.h
@@ -68,8 +68,8 @@ class EngineSync : public EngineControl, public SyncableListener {
     // Choices about master selection often hinge on how many decks are playing back.
     int playingSyncDeckCount() const;
 
-    // Activate a specific channel as master.
-    bool activateChannelMaster(Syncable* pSyncable);
+    // Activate a specific syncable as master.
+    void activateMaster(Syncable* pSyncable);
 
     // Activate a specific channel as Follower. Sets the syncable's bpm and
     // beat_distance to match the master.

--- a/src/engine/internalclock.cpp
+++ b/src/engine/internalclock.cpp
@@ -66,7 +66,7 @@ double InternalClock::getBeatDistance() const {
 }
 
 void InternalClock::setBeatDistance(double beatDistance) {
-    qDebug() << "InternalClock::setBeatDistance" << beatDistance;
+    //qDebug() << "InternalClock::setBeatDistance" << beatDistance;
     m_dClockPosition = beatDistance * m_dBeatLength;
 }
 

--- a/src/engine/internalclock.cpp
+++ b/src/engine/internalclock.cpp
@@ -1,23 +1,60 @@
 #include <QtDebug>
 
 #include "engine/internalclock.h"
+
+#include "engine/enginesync.h"
 #include "controlobject.h"
+#include "controlpushbutton.h"
 #include "configobject.h"
 
-InternalClock::InternalClock(const char* pGroup)
+InternalClock::InternalClock(const char* pGroup, EngineSync* pEngineSync)
         : m_group(pGroup),
+          m_pEngineSync(pEngineSync),
+          m_mode(SYNC_NONE),
           m_iOldSampleRate(44100),
           m_dOldBpm(0.0),
           m_dBeatLength(0),
           m_dClockPosition(0) {
-    m_pClockBpm = new ControlObject(ConfigKey(m_group, "bpm"));
-    connect(m_pClockBpm, SIGNAL(valueChanged(double)),
+    m_pClockBpm.reset(new ControlObject(ConfigKey(m_group, "bpm")));
+    connect(m_pClockBpm.data(), SIGNAL(valueChanged(double)),
             this, SLOT(slotBpmChanged(double)),
             Qt::DirectConnection);
+
+    m_pSyncMasterEnabled.reset(
+        new ControlPushButton(ConfigKey(pGroup, "sync_master")));
+    m_pSyncMasterEnabled->setButtonMode(ControlPushButton::TOGGLE);
+    m_pSyncMasterEnabled->connectValueChangeRequest(
+        this, SLOT(slotSyncMasterEnabledChangeRequest(double)),
+        Qt::DirectConnection);
 }
 
 InternalClock::~InternalClock() {
-    delete m_pClockBpm;
+}
+
+void InternalClock::notifySyncModeChanged(SyncMode mode) {
+    // Syncable has absolutely no say in the matter. This is what EngineSync
+    // requires. Bypass confirmation by using setAndConfirm.
+    m_mode = mode;
+    m_pSyncMasterEnabled->setAndConfirm(mode == SYNC_MASTER);
+}
+
+void InternalClock::slotSyncMasterEnabledChangeRequest(double state) {
+    bool currentlyMaster = getSyncMode() == SYNC_MASTER;
+
+    if (state > 0.0) {
+        if (currentlyMaster) {
+            // Already master.
+            return;
+        }
+        m_pEngineSync->requestSyncMode(this, SYNC_MASTER);
+    } else {
+        // Turning off master goes back to follower mode.
+        if (!currentlyMaster) {
+            // Already not master.
+            return;
+        }
+        m_pEngineSync->requestSyncMode(this, SYNC_FOLLOWER);
+    }
 }
 
 double InternalClock::getBeatDistance() const {
@@ -29,6 +66,7 @@ double InternalClock::getBeatDistance() const {
 }
 
 void InternalClock::setBeatDistance(double beatDistance) {
+    qDebug() << "InternalClock::setBeatDistance" << beatDistance;
     m_dClockPosition = beatDistance * m_dBeatLength;
 }
 
@@ -37,12 +75,14 @@ double InternalClock::getBpm() const {
 }
 
 void InternalClock::setBpm(double bpm) {
+    qDebug() << "InternalClock::setBpm" << bpm;
     m_pClockBpm->set(bpm);
     updateBeatLength(m_iOldSampleRate, bpm);
 }
 
 void InternalClock::slotBpmChanged(double bpm) {
     updateBeatLength(m_iOldSampleRate, bpm);
+    m_pEngineSync->notifyBpmChanged(this, bpm);
 }
 
 void InternalClock::updateBeatLength(int sampleRate, double bpm) {
@@ -96,4 +136,7 @@ void InternalClock::onCallbackStart(int sampleRate, int bufferSize) {
     while (m_dClockPosition >= m_dBeatLength) {
         m_dClockPosition -= m_dBeatLength;
     }
+
+    m_pEngineSync->notifyBeatDistanceChanged(this, getBeatDistance());
+    m_pEngineSync->notifyInstantaneousBpmChanged(this, getBpm());
 }

--- a/src/engine/syncable.h
+++ b/src/engine/syncable.h
@@ -1,0 +1,59 @@
+#ifndef SYNCABLE_H
+#define SYNCABLE_H
+
+#include <QString>
+
+class EngineChannel;
+
+enum SyncMode {
+    SYNC_NONE = 0,
+    SYNC_FOLLOWER = 1,
+    SYNC_MASTER = 2,
+    SYNC_NUM_MODES
+};
+
+inline SyncMode syncModeFromDouble(double value) {
+    SyncMode mode = static_cast<SyncMode>(value);
+    if (mode >= SYNC_NUM_MODES || mode < 0) {
+        return SYNC_NONE;
+    }
+    return mode;
+}
+
+class Syncable {
+  public:
+    virtual const QString& getGroup() const = 0;
+    virtual EngineChannel* getChannel() const = 0;
+
+    // Notify a Syncable that their mode has changed. The Syncable must record
+    // this mode and return the latest mode received via notifySyncModeChanged
+    // in response to getMode().
+    virtual void notifySyncModeChanged(SyncMode mode) = 0;
+
+    // Must NEVER return a mode that was not set directly via
+    // notifySyncModeChanged.
+    virtual SyncMode getSyncMode() const = 0;
+
+    // Only relevant for player Syncables.
+    virtual bool isPlaying() const = 0;
+
+    virtual double getBeatDistance() const = 0;
+    virtual void setBeatDistance(double beatDistance) = 0;
+
+    virtual double getBpm() const = 0;
+    virtual void setBpm(double bpm) = 0;
+};
+
+class SyncableListener {
+  public:
+    virtual void requestSyncMode(Syncable* pSyncable, SyncMode mode) = 0;
+    virtual void requestEnableSync(Syncable* pSyncable, bool enabled) = 0;
+    virtual void notifyBpmChanged(Syncable* pSyncable, double bpm,
+                                  bool fileChanged=false) = 0;
+    virtual void notifyInstantaneousBpmChanged(Syncable* pSyncable, double bpm) = 0;
+    virtual void notifyBeatDistanceChanged(
+        Syncable* pSyncable, double beatDistance) = 0;
+    virtual void notifyPlaying(Syncable* pSyncable, bool playing) = 0;
+};
+
+#endif /* SYNCABLE_H */

--- a/src/engine/synccontrol.cpp
+++ b/src/engine/synccontrol.cpp
@@ -1,0 +1,190 @@
+#include "engine/synccontrol.h"
+
+#include "controlobject.h"
+#include "controlpushbutton.h"
+#include "controlobjectslave.h"
+#include "engine/ratecontrol.h"
+#include "engine/bpmcontrol.h"
+#include "engine/enginesync.h"
+
+const double kTrackPositionMasterHandoff = 0.99;
+
+SyncControl::SyncControl(const char* pGroup, ConfigObject<ConfigValue>* pConfig,
+                         EngineChannel* pChannel, EngineSync* pEngineSync)
+        : EngineControl(pGroup, pConfig),
+          m_sGroup(pGroup),
+          m_pChannel(pChannel),
+          m_pEngineSync(pEngineSync) {
+    // Play button.  We only listen to this to disable master if the deck is
+    // stopped.
+    m_pPlayButton.reset(new ControlObjectSlave(pGroup, "play", this));
+    m_pPlayButton->connectValueChanged(this, SLOT(slotControlPlay(double)),
+                                       Qt::DirectConnection);
+
+    m_pSyncMode.reset(new ControlObject(ConfigKey(pGroup, "sync_mode")));
+    m_pSyncMode->connectValueChangeRequest(
+        this, SLOT(slotSyncModeChangeRequest(double)),
+        Qt::DirectConnection);
+
+    m_pSyncMasterEnabled.reset(
+        new ControlPushButton(ConfigKey(pGroup, "sync_master")));
+    m_pSyncMasterEnabled->setButtonMode(ControlPushButton::TOGGLE);
+    m_pSyncMasterEnabled->connectValueChangeRequest(
+        this, SLOT(slotSyncMasterEnabledChangeRequest(double)),
+        Qt::DirectConnection);
+
+    m_pSyncEnabled.reset(
+        new ControlPushButton(ConfigKey(pGroup, "sync_enabled")));
+    m_pSyncEnabled->setButtonMode(ControlPushButton::LONGPRESSLATCHING);
+    m_pSyncEnabled->connectValueChangeRequest(
+        this, SLOT(slotSyncEnabledChangeRequest(double)),
+        Qt::DirectConnection);
+
+    m_pSyncBeatDistance.reset(
+        new ControlObject(ConfigKey(pGroup, "beat_distance")));
+    connect(m_pSyncBeatDistance.data(), SIGNAL(valueChanged(double)),
+            this, SLOT(slotBeatDistanceChanged(double)),
+            Qt::DirectConnection);
+}
+
+SyncControl::~SyncControl() {
+}
+
+void SyncControl::setEngineControls(RateControl* pRateControl,
+                                    BpmControl* pBpmControl) {
+    m_pRateControl = pRateControl;
+    m_pBpmControl = pBpmControl;
+
+    // We set this to change the effective BPM in BpmControl. We do not listen
+    // to changes from this control because changes in rate, rate_dir, rateRange
+    // and file_bpm result in changes to this control.
+    m_pBpm.reset(new ControlObjectSlave(getGroup(), "bpm", this));
+
+    m_pFileBpm.reset(new ControlObjectSlave(getGroup(), "file_bpm", this));
+    m_pFileBpm->connectValueChanged(this, SLOT(slotFileBpmChanged()),
+                                    Qt::DirectConnection);
+
+    m_pRateSlider.reset(new ControlObjectSlave(getGroup(), "rate", this));
+    m_pRateSlider->connectValueChanged(this, SLOT(slotRateChanged()),
+                                       Qt::DirectConnection);
+
+    m_pRateDirection.reset(new ControlObjectSlave(getGroup(), "rate_dir", this));
+    m_pRateDirection->connectValueChanged(this, SLOT(slotRateChanged()),
+                                          Qt::DirectConnection);
+
+    m_pRateRange.reset(new ControlObjectSlave(getGroup(), "rateRange", this));
+    m_pRateRange->connectValueChanged(this, SLOT(slotRateChanged()),
+                                      Qt::DirectConnection);
+
+    m_pRateEngine.reset(new ControlObjectSlave(getGroup(), "rateEngine", this));
+    m_pRateEngine->connectValueChanged(this, SLOT(slotRateEngineChanged(double)),
+                                       Qt::DirectConnection);
+
+}
+
+void SyncControl::notifySyncModeChanged(SyncMode mode) {
+    qDebug() << "SyncControl::notifySyncModeChanged" << getGroup() << mode;
+    // SyncControl has absolutely no say in the matter. This is what EngineSync
+    // requires. Bypass confirmation by using setAndConfirm.
+    m_pSyncMode->setAndConfirm(mode);
+    m_pSyncEnabled->setAndConfirm(mode != SYNC_NONE);
+    m_pSyncMasterEnabled->setAndConfirm(mode == SYNC_MASTER);
+}
+
+double SyncControl::getBeatDistance() const {
+    return m_pSyncBeatDistance->get();
+}
+
+void SyncControl::setBeatDistance(double beatDistance) {
+    qDebug() << "SyncControl::setBeatDistance" << getGroup() << beatDistance;
+    // Set the BpmControl target beat distance to beatDistance.
+    m_pBpmControl->setTargetBeatDistance(beatDistance);
+}
+
+double SyncControl::getBpm() const {
+    return m_pBpm->get();
+}
+
+void SyncControl::setBpm(double bpm) {
+    qDebug() << "SyncControl::setBpm" << getGroup() << bpm;
+    // Sets the effective BPM in BpmControl (results in changes to rate and
+    m_pBpmControl->setBpmFromMaster(bpm);
+}
+
+void SyncControl::checkTrackPosition(double fractionalPlaypos) {
+    // If we're close to the end, and master, disable master so we don't stop
+    // the party.
+    if (getSyncMode() == SYNC_MASTER &&
+            fractionalPlaypos > kTrackPositionMasterHandoff) {
+        m_pEngineSync->requestSyncMode(this, SYNC_NONE);
+    }
+}
+
+bool SyncControl::isPlaying() const {
+    return m_pPlayButton->get() > 0.0;
+}
+
+void SyncControl::slotControlPlay(double play) {
+    m_pEngineSync->notifyPlaying(this, play > 0.0);
+}
+
+void SyncControl::slotSyncModeChangeRequest(double state) {
+    m_pEngineSync->requestSyncMode(this, syncModeFromDouble(state));
+}
+
+void SyncControl::slotSyncMasterEnabledChangeRequest(double state) {
+    bool currentlyMaster = getSyncMode() == SYNC_MASTER;
+
+    if (state > 0.0) {
+        if (currentlyMaster) {
+            // Already master.
+            return;
+        }
+        m_pEngineSync->requestSyncMode(this, SYNC_MASTER);
+    } else {
+        // Turning off master goes back to follower mode.
+        if (!currentlyMaster) {
+            // Already not master.
+            return;
+        }
+        m_pEngineSync->requestSyncMode(this, SYNC_FOLLOWER);
+    }
+}
+
+void SyncControl::slotSyncEnabledChangeRequest(double enabled) {
+    bool bEnabled = enabled > 0.0;
+    bool syncEnabled = getSyncMode() != SYNC_NONE;
+
+    // If we are not already in the enabled state requested, request a
+    // transition.
+    if (bEnabled ^ syncEnabled) {
+        m_pEngineSync->requestEnableSync(this, bEnabled);
+    }
+}
+
+SyncMode SyncControl::getSyncMode() const {
+    return syncModeFromDouble(m_pSyncMode->get());
+}
+
+void SyncControl::slotFileBpmChanged() {
+    // This slot is fired by file_bpm changes.
+    const double rate = 1.0 + m_pRateSlider->get() * m_pRateRange->get() * m_pRateDirection->get();
+    double bpm = m_pFileBpm ? m_pFileBpm->get() * rate : 0.0;
+    m_pEngineSync->notifyBpmChanged(this, bpm, true);
+}
+
+void SyncControl::slotRateChanged() {
+    // This slot is fired by rate, rate_dir, rateRange, and file_bpm.
+    const double rate = 1.0 + m_pRateSlider->get() * m_pRateRange->get() * m_pRateDirection->get();
+    double bpm = m_pFileBpm ? m_pFileBpm->get() * rate : 0.0;
+    m_pEngineSync->notifyBpmChanged(this, bpm, false);
+}
+
+void SyncControl::slotBeatDistanceChanged(double beatDistance) {
+    m_pEngineSync->notifyBeatDistanceChanged(this, beatDistance);
+}
+
+void SyncControl::slotRateEngineChanged(double rateEngine) {
+    double instantaneous_bpm = m_pFileBpm->get() * rateEngine;
+    m_pEngineSync->notifyInstantaneousBpmChanged(this, instantaneous_bpm);
+}

--- a/src/engine/synccontrol.cpp
+++ b/src/engine/synccontrol.cpp
@@ -96,7 +96,7 @@ double SyncControl::getBeatDistance() const {
 }
 
 void SyncControl::setBeatDistance(double beatDistance) {
-    qDebug() << "SyncControl::setBeatDistance" << getGroup() << beatDistance;
+    //qDebug() << "SyncControl::setBeatDistance" << getGroup() << beatDistance;
     // Set the BpmControl target beat distance to beatDistance.
     m_pBpmControl->setTargetBeatDistance(beatDistance);
 }

--- a/src/engine/synccontrol.h
+++ b/src/engine/synccontrol.h
@@ -1,0 +1,86 @@
+#ifndef SYNCCONTROL_H
+#define SYNCCONTROL_H
+
+#include <QScopedPointer>
+
+#include "engine/enginecontrol.h"
+#include "engine/syncable.h"
+
+class EngineChannel;
+class EngineSync;
+class BpmControl;
+class RateControl;
+class ControlObject;
+class ControlObjectSlave;
+class ControlPushButton;
+
+class SyncControl : public EngineControl, public Syncable {
+    Q_OBJECT
+  public:
+    SyncControl(const char* pGroup, ConfigObject<ConfigValue>* pConfig,
+                EngineChannel* pChannel, EngineSync* pEngineSync);
+    virtual ~SyncControl();
+
+    const QString& getGroup() const { return m_sGroup; }
+    EngineChannel* getChannel() const { return m_pChannel; }
+
+    SyncMode getSyncMode() const;
+    void notifySyncModeChanged(SyncMode mode);
+    bool isPlaying() const;
+
+    double getBeatDistance() const;
+    void setBeatDistance(double beatDistance);
+
+    double getBpm() const;
+    void setBpm(double bpm);
+
+    void setEngineControls(RateControl* pRateControl, BpmControl* pBpmControl);
+    void checkTrackPosition(double fractionalPlaypos);
+
+  private slots:
+    // Fired by changes in play.
+    void slotControlPlay(double v);
+
+    // Fired by changes in rate, rate_dir, rateRange.
+    void slotRateChanged();
+
+    // Fired by changes in file_bpm.
+    void slotFileBpmChanged();
+
+    // Fired by changed to beat_distance (typically only from BpmControl during
+    // BpmControl::process()).
+    void slotBeatDistanceChanged(double beatDistance);
+
+    void slotRateEngineChanged(double rate);
+
+    // Change request handlers for sync properties.
+    void slotSyncModeChangeRequest(double state);
+    void slotSyncEnabledChangeRequest(double enabled);
+    void slotSyncMasterEnabledChangeRequest(double state);
+
+  private:
+    QString m_sGroup;
+    // The only reason we have this pointer is an optimzation so that the
+    // EngineSync can ask us what our EngineChannel is. EngineMaster in turn
+    // asks EngineSync what EngineChannel is the "master" channel.
+    EngineChannel* m_pChannel;
+    EngineSync* m_pEngineSync;
+    BpmControl* m_pBpmControl;
+    RateControl* m_pRateControl;
+
+    QScopedPointer<ControlObject> m_pSyncMode;
+    QScopedPointer<ControlPushButton> m_pSyncMasterEnabled;
+    QScopedPointer<ControlPushButton> m_pSyncEnabled;
+    QScopedPointer<ControlObject> m_pSyncBeatDistance;
+
+    QScopedPointer<ControlObjectSlave> m_pPlayButton;
+    QScopedPointer<ControlObjectSlave> m_pBpm;
+    QScopedPointer<ControlObjectSlave> m_pFileBpm;
+    QScopedPointer<ControlObjectSlave> m_pRateSlider;
+    QScopedPointer<ControlObjectSlave> m_pRateDirection;
+    QScopedPointer<ControlObjectSlave> m_pRateRange;
+    QScopedPointer<ControlObjectSlave> m_pRateEngine;
+};
+
+
+#endif /* SYNCCONTROL_H */

--- a/src/test/mockedenginebackendtest.h
+++ b/src/test/mockedenginebackendtest.h
@@ -54,6 +54,7 @@ class MockedEngineBackendTest : public MixxxTest {
         m_pNumDecks->set(3);
 
         m_pEngineMaster = new EngineMaster(m_pConfig.data(), "[Master]", false, false);
+
         m_pChannel1 = new EngineDeck(m_sGroup1, m_pConfig.data(), m_pEngineMaster, EngineChannel::CENTER);
         ControlObject::getControl(ConfigKey(m_sGroup1, "master"))->set(1);
         m_pChannel2 = new EngineDeck(m_sGroup2, m_pConfig.data(), m_pEngineMaster, EngineChannel::CENTER);
@@ -64,9 +65,6 @@ class MockedEngineBackendTest : public MixxxTest {
         m_pEngineMaster->addChannel(m_pChannel2);
         m_pEngineMaster->addChannel(m_pChannel3);
         m_pEngineSync = m_pEngineMaster->getEngineSync();
-        m_pRateControl1 = m_pEngineSync->getRateControlForGroup(m_sGroup1);
-        m_pRateControl2 = m_pEngineSync->getRateControlForGroup(m_sGroup2);
-        m_pRateControl3 = m_pEngineSync->getRateControlForGroup(m_sGroup3);
 
         m_pMockScaler1 = new MockScaler();
         m_pMockScaler2 = new MockScaler();
@@ -77,10 +75,6 @@ class MockedEngineBackendTest : public MixxxTest {
         m_pChannel1->getEngineBuffer()->loadFakeTrack();
         m_pChannel2->getEngineBuffer()->loadFakeTrack();
         m_pChannel3->getEngineBuffer()->loadFakeTrack();
-
-        m_pEngineSync->addChannel(m_pChannel1);
-        m_pEngineSync->addChannel(m_pChannel2);
-        m_pEngineSync->addChannel(m_pChannel3);
     }
 
     virtual void TearDown() {
@@ -136,7 +130,6 @@ class MockedEngineBackendTest : public MixxxTest {
 
     EngineSync* m_pEngineSync;
     EngineMaster* m_pEngineMaster;
-    RateControl *m_pRateControl1, *m_pRateControl2, *m_pRateControl3;
     EngineDeck *m_pChannel1, *m_pChannel2, *m_pChannel3;
     MockScaler *m_pMockScaler1, *m_pMockScaler2, *m_pMockScaler3;
 


### PR DESCRIPTION
- Add SyncControl, an EngineControl that manages syncing for decks.
- Remove most BpmControl / RateControl logic dealing with sync.
- Add Syncable interface and make InternalClock and SyncControl implement it.
- Remove tracking the master with its group string -- instead use Syncable
  pointer to decide what is master.
- Treat InternalClock the same as SyncControls in master / follower logic.
- Add a SyncableListener interface for EngineSync (eventually use that instead
  of EngineSync to prevent future developers from calling methods on EngineSync
  we do not allow).
- Reduce risks of signal infinite loops by using a request/response setup where
  EngineSync makes all decisions.
- Some minor hacks were needed -- I hope to remove them.
- Tests pass but I had to change something I thought was a bug in the
  test. Please review, @owilliams.
- Left some tracing qDebugs in. These aren't too spammy and are quite helpful
  for debugging. I think we should leave them on during alpha testing.
- SyncControl gets its EngineChannel via its constructor instead of EngineSync
  dealing with setting up the EngineChannel of its syncables.
