### PR TITLE
Keyboard mapping fixes

### DIFF
--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -1,8 +1,8 @@
 [AutoDJ]
-shuffle_playlist F9
-skip_next F10
-fade_now F11
-enabled F12
+shuffle_playlist Shift+F9
+skip_next Shift+F10
+fade_now Shift+F11
+enabled Shift+F12
 
 [Master]
 crossfader_up h

--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -83,7 +83,7 @@ reverse Shift+j
 fwd k
 
 beatsync ž
-bpm_tap Shift+ž
+bpm_tap Shift+6
 
 rate_perm_down F5
 rate_perm_up F6
@@ -103,7 +103,7 @@ hotcue_2_activate ,
 hotcue_3_activate .
 hotcue_4_activate -
 hotcue_1_clear Shift+M
-hotcue_2_clear Shift+;
+hotcue_2_clear Shift+?
 hotcue_3_clear Shift+:
 hotcue_4_clear Shift+_
 

--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -121,3 +121,19 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
+
+[KeyboardShortcuts]
+FileMenu_LoadDeck1 Ctrl+o
+FileMenu_LoadDeck2 Ctrl+Shift+O
+FileMenu_Quit Ctrl+q
+LibraryMenu_NewPlaylist Ctrl+n
+LibraryMenu_NewCrate Ctrl+Shift+N
+ViewMenu_ShowSamplers Ctrl+1
+ViewMenu_ShowMicrophone Ctrl+2
+ViewMenu_ShowVinylControl Ctrl+3
+ViewMenu_ShowPreviewDeck Ctrl+4
+OptionsMenu_EnableLiveBroadcasting Ctrl+l
+OptionsMenu_EnableVinyl1 Ctrl+y
+OptionsMenu_EnableVinyl2 Ctrl+u
+OptionsMenu_RecordMix Ctrl+r
+OptionsMenu_ReloadSkin Ctrl+Shift+R

--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -13,6 +13,9 @@ crossfader_down_small Shift+g
 [Microphone]
 talkover ;
 
+[VinylControl]
+Toggle Ctrl+t
+
 [PreviewDeck1]
 LoadSelectedTrackAndPlay Alt+Return
 start_stop Return

--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -114,9 +114,9 @@ loop_in ý
 loop_out á
 reloop_exit í
 
-beatloop_4_toggle i
-loop_halve o
-loop_double p
+beatloop_4_toggle u
+loop_halve i
+loop_double o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -64,7 +64,7 @@ loop_in ě
 loop_out š
 reloop_exit č
 
-beatloop_4 q
+beatloop_4_toggle q
 loop_halve w
 loop_double e
 

--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -68,6 +68,9 @@ beatloop_4_toggle q
 loop_halve w
 loop_double e
 
+passthrough Ctrl+j
+vinylcontrol_mode Ctrl+Shift+Z
+vinylcontrol_cueing Ctrl+Alt+Z
 
 [Channel2]
 play l
@@ -114,3 +117,7 @@ reloop_exit í
 beatloop_4_toggle i
 loop_halve o
 loop_double p
+
+passthrough Ctrl+k
+vinylcontrol_mode Ctrl+Shift+U
+vinylcontrol_cueing Ctrl+Alt+U

--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -11,7 +11,7 @@ crossfader_up_small Shift+h
 crossfader_down_small Shift+g
 
 [Microphone]
-talkover ;
+talkover \
 
 [VinylControl]
 Toggle Ctrl+t

--- a/res/keyboard/da_DK.kbd.cfg
+++ b/res/keyboard/da_DK.kbd.cfg
@@ -114,9 +114,9 @@ loop_in 7
 loop_out 8
 reloop_exit 9
 
-beatloop_4_toggle i
-loop_halve o
-loop_double p
+beatloop_4_toggle u
+loop_halve i
+loop_double o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/da_DK.kbd.cfg
+++ b/res/keyboard/da_DK.kbd.cfg
@@ -11,7 +11,7 @@ crossfader_up_small Shift+h
 crossfader_down_small Shift+g
 
 [Microphone]
-talkover ½
+talkover <
 
 [VinylControl]
 Toggle Ctrl+t

--- a/res/keyboard/da_DK.kbd.cfg
+++ b/res/keyboard/da_DK.kbd.cfg
@@ -1,8 +1,8 @@
 [AutoDJ]
-shuffle_playlist F9
-skip_next F10
-fade_now F11
-enabled F12
+shuffle_playlist Shift+F9
+skip_next Shift+F10
+fade_now Shift+F11
+enabled Shift+F12
 
 [Master]
 crossfader_up h

--- a/res/keyboard/da_DK.kbd.cfg
+++ b/res/keyboard/da_DK.kbd.cfg
@@ -121,3 +121,19 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
+
+[KeyboardShortcuts]
+FileMenu_LoadDeck1 Ctrl+o
+FileMenu_LoadDeck2 Ctrl+Shift+O
+FileMenu_Quit Ctrl+q
+LibraryMenu_NewPlaylist Ctrl+n
+LibraryMenu_NewCrate Ctrl+Shift+N
+ViewMenu_ShowSamplers Ctrl+1
+ViewMenu_ShowMicrophone Ctrl+2
+ViewMenu_ShowVinylControl Ctrl+3
+ViewMenu_ShowPreviewDeck Ctrl+4
+OptionsMenu_EnableLiveBroadcasting Ctrl+l
+OptionsMenu_EnableVinyl1 Ctrl+y
+OptionsMenu_EnableVinyl2 Ctrl+u
+OptionsMenu_RecordMix Ctrl+r
+OptionsMenu_ReloadSkin Ctrl+Shift+R

--- a/res/keyboard/da_DK.kbd.cfg
+++ b/res/keyboard/da_DK.kbd.cfg
@@ -24,9 +24,9 @@ fwd Alt+Right
 
 [Channel1]
 play d
-cue_set Shift+D
+cue_set Shift+d
 cue_default f
-cue_gotoandstop Shift+F
+cue_gotoandstop Shift+f
 
 back a
 reverse Shift+a
@@ -74,7 +74,7 @@ vinylcontrol_cueing Ctrl+Alt+Y
 
 [Channel2]
 play l
-cue_set Shift+l
+cue_set Shift+!
 cue_default æ
 cue_gotoandstop Shift+Æ
 
@@ -83,7 +83,7 @@ reverse Shift+j
 fwd k
 
 beatsync 6
-bpm_tap Shift+6
+bpm_tap Shift+&
 
 rate_perm_down F5
 rate_perm_up F6

--- a/res/keyboard/da_DK.kbd.cfg
+++ b/res/keyboard/da_DK.kbd.cfg
@@ -13,6 +13,9 @@ crossfader_down_small Shift+g
 [Microphone]
 talkover ½
 
+[VinylControl]
+Toggle Ctrl+t
+
 [PreviewDeck1]
 LoadSelectedTrackAndPlay Alt+Return
 start_stop Return

--- a/res/keyboard/da_DK.kbd.cfg
+++ b/res/keyboard/da_DK.kbd.cfg
@@ -64,7 +64,7 @@ loop_in 2
 loop_out 3
 reloop_exit 4
 
-beatloop_4 q
+beatloop_4_toggle q
 loop_halve w
 loop_double e
 

--- a/res/keyboard/da_DK.kbd.cfg
+++ b/res/keyboard/da_DK.kbd.cfg
@@ -68,6 +68,9 @@ beatloop_4_toggle q
 loop_halve w
 loop_double e
 
+passthrough Ctrl+j
+vinylcontrol_mode Ctrl+Shift+Y
+vinylcontrol_cueing Ctrl+Alt+Y
 
 [Channel2]
 play l
@@ -114,3 +117,7 @@ reloop_exit 9
 beatloop_4_toggle i
 loop_halve o
 loop_double p
+
+passthrough Ctrl+k
+vinylcontrol_mode Ctrl+Shift+U
+vinylcontrol_cueing Ctrl+Alt+U

--- a/res/keyboard/de_DE.kbd.cfg
+++ b/res/keyboard/de_DE.kbd.cfg
@@ -76,14 +76,14 @@ vinylcontrol_cueing Ctrl+Alt+Z
 play l
 cue_set Shift+l
 cue_default ö
-cue_gotoandstop Shift+ö
+cue_gotoandstop Shift+Ö
 
 back j
 reverse Shift+j
 fwd k
 
 beatsync 6
-bpm_tap Shift+6
+bpm_tap Shift+&
 
 rate_perm_down F5
 rate_perm_up F6

--- a/res/keyboard/de_DE.kbd.cfg
+++ b/res/keyboard/de_DE.kbd.cfg
@@ -114,9 +114,9 @@ loop_in 7
 loop_out 8
 reloop_exit 9
 
-beatloop_4_toggle i
-loop_halve o
-loop_double p
+beatloop_4_toggle u
+loop_halve i
+loop_double o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/de_DE.kbd.cfg
+++ b/res/keyboard/de_DE.kbd.cfg
@@ -11,7 +11,7 @@ crossfader_up_small Shift+h
 crossfader_down_small Shift+g
 
 [Microphone]
-talkover ^
+talkover <
 
 [VinylControl]
 Toggle Ctrl+t

--- a/res/keyboard/de_DE.kbd.cfg
+++ b/res/keyboard/de_DE.kbd.cfg
@@ -1,8 +1,8 @@
 [AutoDJ]
-shuffle_playlist F9
-skip_next F10
-fade_now F11
-enabled F12
+shuffle_playlist Shift+F9
+skip_next Shift+F10
+fade_now Shift+F11
+enabled Shift+F12
 
 [Master]
 crossfader_up h

--- a/res/keyboard/de_DE.kbd.cfg
+++ b/res/keyboard/de_DE.kbd.cfg
@@ -121,3 +121,19 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
+
+[KeyboardShortcuts]
+FileMenu_LoadDeck1 Ctrl+o
+FileMenu_LoadDeck2 Ctrl+Shift+O
+FileMenu_Quit Ctrl+q
+LibraryMenu_NewPlaylist Ctrl+n
+LibraryMenu_NewCrate Ctrl+Shift+N
+ViewMenu_ShowSamplers Ctrl+1
+ViewMenu_ShowMicrophone Ctrl+2
+ViewMenu_ShowVinylControl Ctrl+3
+ViewMenu_ShowPreviewDeck Ctrl+4
+OptionsMenu_EnableLiveBroadcasting Ctrl+l
+OptionsMenu_EnableVinyl1 Ctrl+z
+OptionsMenu_EnableVinyl2 Ctrl+u
+OptionsMenu_RecordMix Ctrl+r
+OptionsMenu_ReloadSkin Ctrl+Shift+R

--- a/res/keyboard/de_DE.kbd.cfg
+++ b/res/keyboard/de_DE.kbd.cfg
@@ -68,6 +68,9 @@ beatloop_4_toggle q
 loop_halve w
 loop_double e
 
+passthrough Ctrl+j
+vinylcontrol_mode Ctrl+Shift+Z
+vinylcontrol_cueing Ctrl+Alt+Z
 
 [Channel2]
 play l
@@ -114,3 +117,7 @@ reloop_exit 9
 beatloop_4_toggle i
 loop_halve o
 loop_double p
+
+passthrough Ctrl+k
+vinylcontrol_mode Ctrl+Shift+U
+vinylcontrol_cueing Ctrl+Alt+U

--- a/res/keyboard/de_DE.kbd.cfg
+++ b/res/keyboard/de_DE.kbd.cfg
@@ -13,6 +13,9 @@ crossfader_down_small Shift+g
 [Microphone]
 talkover ^
 
+[VinylControl]
+Toggle Ctrl+t
+
 [PreviewDeck1]
 LoadSelectedTrackAndPlay Alt+Return
 start_stop Return

--- a/res/keyboard/de_DE.kbd.cfg
+++ b/res/keyboard/de_DE.kbd.cfg
@@ -64,7 +64,7 @@ loop_in 2
 loop_out 3
 reloop_exit 4
 
-beatloop_4 q
+beatloop_4_toggle q
 loop_halve w
 loop_double e
 

--- a/res/keyboard/el_GR.kbd.cfg
+++ b/res/keyboard/el_GR.kbd.cfg
@@ -13,6 +13,9 @@ crossfader_down_small Shift+γ
 [Microphone]
 talkover ,
 
+[VinylControl]
+Toggle Ctrl+τ
+
 [PreviewDeck1]
 LoadSelectedTrackAndPlay Alt+Return
 start_stop Return

--- a/res/keyboard/el_GR.kbd.cfg
+++ b/res/keyboard/el_GR.kbd.cfg
@@ -1,8 +1,8 @@
 [AutoDJ]
-shuffle_playlist F9
-skip_next F10
-fade_now F11
-enabled F12
+shuffle_playlist Shift+F9
+skip_next Shift+F10
+fade_now Shift+F11
+enabled Shift+F12
 
 [Master]
 crossfader_up η

--- a/res/keyboard/el_GR.kbd.cfg
+++ b/res/keyboard/el_GR.kbd.cfg
@@ -121,3 +121,19 @@ loop_double ο
 passthrough Ctrl+κ
 vinylcontrol_mode Ctrl+Shift+Θ
 vinylcontrol_cueing Ctrl+Alt+Θ
+
+[KeyboardShortcuts]
+FileMenu_LoadDeck1 Ctrl+o
+FileMenu_LoadDeck2 Ctrl+Shift+O
+FileMenu_Quit Ctrl+q
+LibraryMenu_NewPlaylist Ctrl+n
+LibraryMenu_NewCrate Ctrl+Shift+N
+ViewMenu_ShowSamplers Ctrl+1
+ViewMenu_ShowMicrophone Ctrl+2
+ViewMenu_ShowVinylControl Ctrl+3
+ViewMenu_ShowPreviewDeck Ctrl+4
+OptionsMenu_EnableLiveBroadcasting Ctrl+l
+OptionsMenu_EnableVinyl1 Ctrl+y
+OptionsMenu_EnableVinyl2 Ctrl+u
+OptionsMenu_RecordMix Ctrl+r
+OptionsMenu_ReloadSkin Ctrl+Shift+R

--- a/res/keyboard/el_GR.kbd.cfg
+++ b/res/keyboard/el_GR.kbd.cfg
@@ -11,7 +11,7 @@ crossfader_up_small Shift+Η
 crossfader_down_small Shift+Γ
 
 [Microphone]
-talkover ,
+talkover `
 
 [VinylControl]
 Toggle Ctrl+τ

--- a/res/keyboard/el_GR.kbd.cfg
+++ b/res/keyboard/el_GR.kbd.cfg
@@ -68,6 +68,9 @@ beatloop_4_toggle ;
 loop_halve ς
 loop_double ε
 
+passthrough Ctrl+ξ
+vinylcontrol_mode Ctrl+Shift+υ
+vinylcontrol_cueing Ctrl+Alt+υ
 
 [Channel2]
 play λ
@@ -114,3 +117,7 @@ reloop_exit 9
 beatloop_4_toggle ι
 loop_halve ο
 loop_double π
+
+passthrough Ctrl+κ
+vinylcontrol_mode Ctrl+Shift+Θ
+vinylcontrol_cueing Ctrl+Alt+Θ

--- a/res/keyboard/el_GR.kbd.cfg
+++ b/res/keyboard/el_GR.kbd.cfg
@@ -114,9 +114,9 @@ loop_in 7
 loop_out 8
 reloop_exit 9
 
-beatloop_4_toggle ι
-loop_halve ο
-loop_double π
+beatloop_4_toggle θ
+loop_halve ι
+loop_double ο
 
 passthrough Ctrl+κ
 vinylcontrol_mode Ctrl+Shift+Θ

--- a/res/keyboard/el_GR.kbd.cfg
+++ b/res/keyboard/el_GR.kbd.cfg
@@ -7,8 +7,8 @@ enabled F12
 [Master]
 crossfader_up η
 crossfader_down γ
-crossfader_up_small Shift+η
-crossfader_down_small Shift+γ
+crossfader_up_small Shift+Η
+crossfader_down_small Shift+Γ
 
 [Microphone]
 talkover ,
@@ -80,7 +80,7 @@ cue_gotoandstop Shift+"
 
 back ξ
 reverse Shift+Ξ
-fwd Κ
+fwd κ
 
 beatsync 6
 bpm_tap Shift+^

--- a/res/keyboard/el_GR.kbd.cfg
+++ b/res/keyboard/el_GR.kbd.cfg
@@ -64,7 +64,7 @@ loop_in 2
 loop_out 3
 reloop_exit 4
 
-beatloop_4 ;
+beatloop_4_toggle ;
 loop_halve ς
 loop_double ε
 

--- a/res/keyboard/en_US.kbd.cfg
+++ b/res/keyboard/en_US.kbd.cfg
@@ -1,8 +1,8 @@
 [AutoDJ]
-shuffle_playlist F9
-skip_next F10
-fade_now F11
-enabled F12
+shuffle_playlist Shift+F9
+skip_next Shift+F10
+fade_now Shift+F11
+enabled Shift+F12
 
 [Master]
 crossfader_up h

--- a/res/keyboard/en_US.kbd.cfg
+++ b/res/keyboard/en_US.kbd.cfg
@@ -13,6 +13,9 @@ crossfader_down_small Shift+g
 [Microphone]
 talkover `
 
+[VinylControl]
+Toggle Ctrl+t
+
 [PreviewDeck1]
 LoadSelectedTrackAndPlay Alt+Return
 start_stop Return

--- a/res/keyboard/es_ES.kbd.cfg
+++ b/res/keyboard/es_ES.kbd.cfg
@@ -13,6 +13,9 @@ crossfader_down_small Shift+g
 [Microphone]
 talkover º
 
+[VinylControl]
+Toggle Ctrl+t
+
 [PreviewDeck1]
 LoadSelectedTrackAndPlay Alt+Return
 start_stop Return

--- a/res/keyboard/es_ES.kbd.cfg
+++ b/res/keyboard/es_ES.kbd.cfg
@@ -114,9 +114,9 @@ loop_in 7
 loop_out 8
 reloop_exit 9
 
-beatloop_4_toggle i
-loop_halve o
-loop_double p
+beatloop_4_toggle u
+loop_halve i
+loop_double o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/es_ES.kbd.cfg
+++ b/res/keyboard/es_ES.kbd.cfg
@@ -1,8 +1,8 @@
 [AutoDJ]
-shuffle_playlist F9
-skip_next F10
-fade_now F11
-enabled F12
+shuffle_playlist Shift+F9
+skip_next Shift+F10
+fade_now Shift+F11
+enabled Shift+F12
 
 [Master]
 crossfader_up h

--- a/res/keyboard/es_ES.kbd.cfg
+++ b/res/keyboard/es_ES.kbd.cfg
@@ -52,7 +52,7 @@ hotcue_1_activate z
 hotcue_2_activate x
 hotcue_3_activate c
 hotcue_4_activate v
-hotcue_1_clear Shift+Z
+hotcue_1_clear Shift+z
 hotcue_2_clear Shift+x
 hotcue_3_clear Shift+c
 hotcue_4_clear Shift+v
@@ -83,7 +83,7 @@ reverse Shift+j
 fwd k
 
 beatsync 6
-bpm_tap Shift+6
+bpm_tap Shift+/
 
 rate_perm_down F5
 rate_perm_up F6
@@ -101,11 +101,11 @@ flanger 0
 hotcue_1_activate m
 hotcue_2_activate ,
 hotcue_3_activate .
-hotcue_4_activate -
+hotcue_4_activate ç
 hotcue_1_clear Shift+M
-hotcue_2_clear Shift+;
-hotcue_3_clear Shift+:
-hotcue_4_clear Shift+_
+hotcue_2_clear Shift+¿
+hotcue_3_clear Shift+?
+hotcue_4_clear Shift+Ç
 
 LoadSelectedTrack Shift+Right
 eject Alt+Shift+Right

--- a/res/keyboard/es_ES.kbd.cfg
+++ b/res/keyboard/es_ES.kbd.cfg
@@ -121,3 +121,19 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
+
+[KeyboardShortcuts]
+FileMenu_LoadDeck1 Ctrl+o
+FileMenu_LoadDeck2 Ctrl+Shift+O
+FileMenu_Quit Ctrl+q
+LibraryMenu_NewPlaylist Ctrl+n
+LibraryMenu_NewCrate Ctrl+Shift+N
+ViewMenu_ShowSamplers Ctrl+1
+ViewMenu_ShowMicrophone Ctrl+2
+ViewMenu_ShowVinylControl Ctrl+3
+ViewMenu_ShowPreviewDeck Ctrl+4
+OptionsMenu_EnableLiveBroadcasting Ctrl+l
+OptionsMenu_EnableVinyl1 Ctrl+y
+OptionsMenu_EnableVinyl2 Ctrl+u
+OptionsMenu_RecordMix Ctrl+r
+OptionsMenu_ReloadSkin Ctrl+Shift+R

--- a/res/keyboard/es_ES.kbd.cfg
+++ b/res/keyboard/es_ES.kbd.cfg
@@ -11,7 +11,7 @@ crossfader_up_small Shift+h
 crossfader_down_small Shift+g
 
 [Microphone]
-talkover º
+talkover <
 
 [VinylControl]
 Toggle Ctrl+t

--- a/res/keyboard/es_ES.kbd.cfg
+++ b/res/keyboard/es_ES.kbd.cfg
@@ -64,7 +64,7 @@ loop_in 2
 loop_out 3
 reloop_exit 4
 
-beatloop_4 q
+beatloop_4_toggle q
 loop_halve w
 loop_double e
 

--- a/res/keyboard/es_ES.kbd.cfg
+++ b/res/keyboard/es_ES.kbd.cfg
@@ -68,6 +68,9 @@ beatloop_4_toggle q
 loop_halve w
 loop_double e
 
+passthrough Ctrl+j
+vinylcontrol_mode Ctrl+Shift+Y
+vinylcontrol_cueing Ctrl+Alt+Y
 
 [Channel2]
 play l
@@ -114,3 +117,7 @@ reloop_exit 9
 beatloop_4_toggle i
 loop_halve o
 loop_double p
+
+passthrough Ctrl+k
+vinylcontrol_mode Ctrl+Shift+U
+vinylcontrol_cueing Ctrl+Alt+U

--- a/res/keyboard/fi_FI.kbd.cfg
+++ b/res/keyboard/fi_FI.kbd.cfg
@@ -114,9 +114,9 @@ loop_in 7
 loop_out 8
 reloop_exit 9
 
-beatloop_4_toggle i
-loop_halve o
-loop_double p
+beatloop_4_toggle u
+loop_halve i
+loop_double o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/fi_FI.kbd.cfg
+++ b/res/keyboard/fi_FI.kbd.cfg
@@ -11,7 +11,7 @@ crossfader_up_small Shift+h
 crossfader_down_small Shift+g
 
 [Microphone]
-talkover §
+talkover <
 
 [VinylControl]
 Toggle Ctrl+t

--- a/res/keyboard/fi_FI.kbd.cfg
+++ b/res/keyboard/fi_FI.kbd.cfg
@@ -1,8 +1,8 @@
 [AutoDJ]
-shuffle_playlist F9
-skip_next F10
-fade_now F11
-enabled F12
+shuffle_playlist Shift+F9
+skip_next Shift+F10
+fade_now Shift+F11
+enabled Shift+F12
 
 [Master]
 crossfader_up h

--- a/res/keyboard/fi_FI.kbd.cfg
+++ b/res/keyboard/fi_FI.kbd.cfg
@@ -121,3 +121,19 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
+
+[KeyboardShortcuts]
+FileMenu_LoadDeck1 Ctrl+o
+FileMenu_LoadDeck2 Ctrl+Shift+O
+FileMenu_Quit Ctrl+q
+LibraryMenu_NewPlaylist Ctrl+n
+LibraryMenu_NewCrate Ctrl+Shift+N
+ViewMenu_ShowSamplers Ctrl+1
+ViewMenu_ShowMicrophone Ctrl+2
+ViewMenu_ShowVinylControl Ctrl+3
+ViewMenu_ShowPreviewDeck Ctrl+4
+OptionsMenu_EnableLiveBroadcasting Ctrl+l
+OptionsMenu_EnableVinyl1 Ctrl+y
+OptionsMenu_EnableVinyl2 Ctrl+u
+OptionsMenu_RecordMix Ctrl+r
+OptionsMenu_ReloadSkin Ctrl+Shift+R

--- a/res/keyboard/fi_FI.kbd.cfg
+++ b/res/keyboard/fi_FI.kbd.cfg
@@ -52,10 +52,10 @@ hotcue_1_activate z
 hotcue_2_activate x
 hotcue_3_activate c
 hotcue_4_activate v
-hotcue_1_clear Shift+Z
-hotcue_2_clear Shift+X
-hotcue_3_clear Shift+C
-hotcue_4_clear Shift+V
+hotcue_1_clear Shift+z
+hotcue_2_clear Shift+x
+hotcue_3_clear Shift+c
+hotcue_4_clear Shift+v
 
 LoadSelectedTrack Shift+Left
 eject Alt+Shift+Left
@@ -76,14 +76,14 @@ vinylcontrol_cueing Ctrl+Alt+Y
 play l
 cue_set Shift+l
 cue_default ö
-cue_gotoandstop Shift+ö
+cue_gotoandstop Shift+Ö
 
 back j
 reverse Shift+j
 fwd k
 
 beatsync 6
-bpm_tap Shift+6
+bpm_tap Shift+&
 
 rate_perm_down F5
 rate_perm_up F6

--- a/res/keyboard/fi_FI.kbd.cfg
+++ b/res/keyboard/fi_FI.kbd.cfg
@@ -64,7 +64,7 @@ loop_in 2
 loop_out 3
 reloop_exit 4
 
-beatloop_4 q
+beatloop_4_toggle q
 loop_halve w
 loop_double e
 

--- a/res/keyboard/fi_FI.kbd.cfg
+++ b/res/keyboard/fi_FI.kbd.cfg
@@ -68,6 +68,9 @@ beatloop_4_toggle q
 loop_halve w
 loop_double e
 
+passthrough Ctrl+j
+vinylcontrol_mode Ctrl+Shift+Y
+vinylcontrol_cueing Ctrl+Alt+Y
 
 [Channel2]
 play l
@@ -114,3 +117,7 @@ reloop_exit 9
 beatloop_4_toggle i
 loop_halve o
 loop_double p
+
+passthrough Ctrl+k
+vinylcontrol_mode Ctrl+Shift+U
+vinylcontrol_cueing Ctrl+Alt+U

--- a/res/keyboard/fi_FI.kbd.cfg
+++ b/res/keyboard/fi_FI.kbd.cfg
@@ -13,6 +13,9 @@ crossfader_down_small Shift+g
 [Microphone]
 talkover §
 
+[VinylControl]
+Toggle Ctrl+t
+
 [PreviewDeck1]
 LoadSelectedTrackAndPlay Alt+Return
 start_stop Return

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -1,8 +1,8 @@
 [AutoDJ]
-shuffle_playlist F9
-skip_next F10
-fade_now F11
-enabled F12
+shuffle_playlist Shift+F9
+skip_next Shift+F10
+fade_now Shift+F11
+enabled Shift+F12
 
 [Master]
 crossfader_up h

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -121,3 +121,19 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
+
+[KeyboardShortcuts]
+FileMenu_LoadDeck1 Ctrl+o
+FileMenu_LoadDeck2 Ctrl+Shift+O
+FileMenu_Quit Ctrl+q
+LibraryMenu_NewPlaylist Ctrl+n
+LibraryMenu_NewCrate Ctrl+Shift+N
+ViewMenu_ShowSamplers Ctrl+1
+ViewMenu_ShowMicrophone Ctrl+2
+ViewMenu_ShowVinylControl Ctrl+3
+ViewMenu_ShowPreviewDeck Ctrl+4
+OptionsMenu_EnableLiveBroadcasting Ctrl+l
+OptionsMenu_EnableVinyl1 Ctrl+y
+OptionsMenu_EnableVinyl2 Ctrl+u
+OptionsMenu_RecordMix Ctrl+r
+OptionsMenu_ReloadSkin Ctrl+Shift+R

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -68,6 +68,9 @@ beatloop_4_toggle a
 loop_halve z
 loop_double e
 
+passthrough Ctrl+j
+vinylcontrol_mode Ctrl+Shift+Y
+vinylcontrol_cueing Ctrl+Alt+Y
 
 [Channel2]
 play l
@@ -114,3 +117,7 @@ reloop_exit ç
 beatloop_4_toggle i
 loop_halve o
 loop_double p
+
+passthrough Ctrl+k
+vinylcontrol_mode Ctrl+Shift+U
+vinylcontrol_cueing Ctrl+Alt+U

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -64,7 +64,7 @@ loop_in é
 loop_out "
 reloop_exit '
 
-beatloop_4 a
+beatloop_4_toggle a
 loop_halve z
 loop_double e
 

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -114,9 +114,9 @@ loop_in è
 loop_out _
 reloop_exit ç
 
-beatloop_4_toggle i
-loop_halve o
-loop_double p
+beatloop_4_toggle u
+loop_halve i
+loop_double o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -7,8 +7,8 @@ enabled F12
 [Master]
 crossfader_up h
 crossfader_down g
-crossfader_up_small Shift+H
-crossfader_down_small Shift+G
+crossfader_up_small Shift+h
+crossfader_down_small Shift+g
 
 [Microphone]
 talkover ²
@@ -24,12 +24,12 @@ fwd Alt+Right
 
 [Channel1]
 play d
-cue_set Shift+D
+cue_set Shift+d
 cue_default f
-cue_gotoandstop Shift+F
+cue_gotoandstop Shift+f
 
 back q
-reverse Shift+Q
+reverse Shift+q
 fwd s
 
 beatsync &
@@ -52,10 +52,10 @@ hotcue_1_activate w
 hotcue_2_activate x
 hotcue_3_activate c
 hotcue_4_activate v
-hotcue_1_clear Shift+W
-hotcue_2_clear Shift+X
-hotcue_3_clear Shift+C
-hotcue_4_clear Shift+V
+hotcue_1_clear Shift+z
+hotcue_2_clear Shift+x
+hotcue_3_clear Shift+c
+hotcue_4_clear Shift+v
 
 LoadSelectedTrack Shift+Left
 eject Alt+Shift+Left
@@ -74,15 +74,15 @@ vinylcontrol_cueing Ctrl+Alt+Y
 
 [Channel2]
 play l
-cue_set Shift+L
+cue_set Shift+l
 cue_default m
-cue_gotoandstop Shift+M
+cue_gotoandstop Shift+m
 
 back j
-reverse Shift+J
+reverse Shift+j
 fwd k
 
-beatsync -
+beatsync §
 bpm_tap Shift+6
 
 rate_perm_down F5
@@ -101,17 +101,17 @@ flanger à
 hotcue_1_activate ,
 hotcue_2_activate ;
 hotcue_3_activate :
-hotcue_4_activate !
+hotcue_4_activate =
 hotcue_1_clear Shift+?
 hotcue_2_clear Shift+.
 hotcue_3_clear Shift+/
-hotcue_4_clear Shift+§
+hotcue_4_clear Shift++
 
 LoadSelectedTrack Shift+Right
 eject Alt+Shift+Right
 
 loop_in è
-loop_out _
+loop_out !
 reloop_exit ç
 
 beatloop_4_toggle u

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -52,7 +52,7 @@ hotcue_1_activate w
 hotcue_2_activate x
 hotcue_3_activate c
 hotcue_4_activate v
-hotcue_1_clear Shift+z
+hotcue_1_clear Shift+w
 hotcue_2_clear Shift+x
 hotcue_3_clear Shift+c
 hotcue_4_clear Shift+v

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -11,7 +11,7 @@ crossfader_up_small Shift+h
 crossfader_down_small Shift+g
 
 [Microphone]
-talkover ²
+talkover <
 
 [VinylControl]
 Toggle Ctrl+t

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -13,6 +13,9 @@ crossfader_down_small Shift+G
 [Microphone]
 talkover ²
 
+[VinylControl]
+Toggle Ctrl+t
+
 [PreviewDeck1]
 LoadSelectedTrackAndPlay Alt+Return
 start_stop Return

--- a/res/keyboard/it_IT.kbd.cfg
+++ b/res/keyboard/it_IT.kbd.cfg
@@ -114,9 +114,9 @@ loop_in 7
 loop_out 8
 reloop_exit 9
 
-beatloop_4_toggle i
-loop_halve o
-loop_double p
+beatloop_4_toggle u
+loop_halve i
+loop_double o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/it_IT.kbd.cfg
+++ b/res/keyboard/it_IT.kbd.cfg
@@ -1,8 +1,8 @@
 [AutoDJ]
-shuffle_playlist F9
-skip_next F10
-fade_now F11
-enabled F12
+shuffle_playlist Shift+F9
+skip_next Shift+F10
+fade_now Shift+F11
+enabled Shift+F12
 
 [Master]
 crossfader_up h

--- a/res/keyboard/it_IT.kbd.cfg
+++ b/res/keyboard/it_IT.kbd.cfg
@@ -121,3 +121,19 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
+
+[KeyboardShortcuts]
+FileMenu_LoadDeck1 Ctrl+o
+FileMenu_LoadDeck2 Ctrl+Shift+O
+FileMenu_Quit Ctrl+q
+LibraryMenu_NewPlaylist Ctrl+n
+LibraryMenu_NewCrate Ctrl+Shift+N
+ViewMenu_ShowSamplers Ctrl+1
+ViewMenu_ShowMicrophone Ctrl+2
+ViewMenu_ShowVinylControl Ctrl+3
+ViewMenu_ShowPreviewDeck Ctrl+4
+OptionsMenu_EnableLiveBroadcasting Ctrl+l
+OptionsMenu_EnableVinyl1 Ctrl+y
+OptionsMenu_EnableVinyl2 Ctrl+u
+OptionsMenu_RecordMix Ctrl+r
+OptionsMenu_ReloadSkin Ctrl+Shift+R

--- a/res/keyboard/it_IT.kbd.cfg
+++ b/res/keyboard/it_IT.kbd.cfg
@@ -13,6 +13,9 @@ crossfader_down_small Shift+g
 [Microphone]
 talkover \
 
+[VinylControl]
+Toggle Ctrl+t
+
 [PreviewDeck1]
 LoadSelectedTrackAndPlay Alt+Return
 start_stop Return

--- a/res/keyboard/it_IT.kbd.cfg
+++ b/res/keyboard/it_IT.kbd.cfg
@@ -64,7 +64,7 @@ loop_in 2
 loop_out 3
 reloop_exit 4
 
-beatloop_4 q
+beatloop_4_toggle q
 loop_halve w
 loop_double e
 

--- a/res/keyboard/it_IT.kbd.cfg
+++ b/res/keyboard/it_IT.kbd.cfg
@@ -52,10 +52,10 @@ hotcue_1_activate z
 hotcue_2_activate x
 hotcue_3_activate c
 hotcue_4_activate v
-hotcue_1_clear Shift+Z
-hotcue_2_clear Shift+X
-hotcue_3_clear Shift+C
-hotcue_4_clear Shift+V
+hotcue_1_clear Shift+z
+hotcue_2_clear Shift+x
+hotcue_3_clear Shift+c
+hotcue_4_clear Shift+v
 
 LoadSelectedTrack Shift+Left
 eject Alt+Shift+Left
@@ -83,7 +83,7 @@ reverse Shift+j
 fwd k
 
 beatsync 6
-bpm_tap Shift+6
+bpm_tap Shift+&
 
 rate_perm_down F5
 rate_perm_up F6

--- a/res/keyboard/it_IT.kbd.cfg
+++ b/res/keyboard/it_IT.kbd.cfg
@@ -68,6 +68,9 @@ beatloop_4_toggle q
 loop_halve w
 loop_double e
 
+passthrough Ctrl+j
+vinylcontrol_mode Ctrl+Shift+Y
+vinylcontrol_cueing Ctrl+Alt+Y
 
 [Channel2]
 play l
@@ -114,3 +117,7 @@ reloop_exit 9
 beatloop_4_toggle i
 loop_halve o
 loop_double p
+
+passthrough Ctrl+k
+vinylcontrol_mode Ctrl+Shift+U
+vinylcontrol_cueing Ctrl+Alt+U

--- a/res/keyboard/it_IT.kbd.cfg
+++ b/res/keyboard/it_IT.kbd.cfg
@@ -11,7 +11,7 @@ crossfader_up_small Shift+h
 crossfader_down_small Shift+g
 
 [Microphone]
-talkover \
+talkover <
 
 [VinylControl]
 Toggle Ctrl+t

--- a/res/keyboard/ru_RU.kbd.cfg
+++ b/res/keyboard/ru_RU.kbd.cfg
@@ -13,6 +13,9 @@ crossfader_down_small Shift+П
 [Microphone]
 talkover ё
 
+[VinylControl]
+Toggle Ctrl+е
+
 [PreviewDeck1]
 LoadSelectedTrackAndPlay Alt+Return
 start_stop Return

--- a/res/keyboard/ru_RU.kbd.cfg
+++ b/res/keyboard/ru_RU.kbd.cfg
@@ -24,12 +24,12 @@ fwd Alt+Right
 
 [Channel1]
 play в
-cue_set Shift+В
+cue_set Shift+в
 cue_default а
-cue_gotoandstop Shift+А
+cue_gotoandstop Shift+а
 
 back ф
-reverse Shift+Ф
+reverse Shift+ф
 fwd ы
 
 beatsync 1
@@ -52,10 +52,10 @@ hotcue_1_activate я
 hotcue_2_activate ч
 hotcue_3_activate с
 hotcue_4_activate м
-hotcue_1_clear Shift+Я
-hotcue_2_clear Shift+Ч
-hotcue_3_clear Shift+С
-hotcue_4_clear Shift+М
+hotcue_1_clear Shift+я
+hotcue_2_clear Shift+ч
+hotcue_3_clear Shift+с
+hotcue_4_clear Shift+м
 
 LoadSelectedTrack Shift+Left
 eject Alt+Shift+Left
@@ -74,16 +74,16 @@ vinylcontrol_cueing Ctrl+Alt+Н
 
 [Channel2]
 play д
-cue_set Shift+Д
+cue_set Shift+д
 cue_default ж
-cue_gotoandstop Shift+Ж
+cue_gotoandstop Shift+ж
 
 back о
 reverse Shift+о
 fwd л
 
 beatsync 6
-bpm_tap Shift+:
+bpm_tap Shift+,
 
 rate_perm_down F5
 rate_perm_up F6
@@ -101,11 +101,11 @@ flanger 0
 hotcue_1_activate ь
 hotcue_2_activate б
 hotcue_3_activate ю
-hotcue_4_activate .
+hotcue_4_activate /
 hotcue_1_clear Shift+Ь
 hotcue_2_clear Shift+Б
 hotcue_3_clear Shift+Ю
-hotcue_4_clear Shift+,
+hotcue_4_clear Shift+?
 
 LoadSelectedTrack Shift+Right
 eject Alt+Shift+Right

--- a/res/keyboard/ru_RU.kbd.cfg
+++ b/res/keyboard/ru_RU.kbd.cfg
@@ -114,9 +114,9 @@ loop_in 7
 loop_out 8
 reloop_exit 9
 
-beatloop_4_toggle ш
-loop_halve щ
-loop_double з
+beatloop_4_toggle г
+loop_halve ш
+loop_double щ
 
 passthrough Ctrl+л
 vinylcontrol_mode Ctrl+Shift+Г

--- a/res/keyboard/ru_RU.kbd.cfg
+++ b/res/keyboard/ru_RU.kbd.cfg
@@ -64,7 +64,7 @@ loop_in 2
 loop_out 3
 reloop_exit 4
 
-beatloop_4 й
+beatloop_4_toggle й
 loop_halve ц
 loop_double у
 

--- a/res/keyboard/ru_RU.kbd.cfg
+++ b/res/keyboard/ru_RU.kbd.cfg
@@ -1,8 +1,8 @@
 [AutoDJ]
-shuffle_playlist F9
-skip_next F10
-fade_now F11
-enabled F12
+shuffle_playlist Shift+F9
+skip_next Shift+F10
+fade_now Shift+F11
+enabled Shift+F12
 
 [Master]
 crossfader_up р

--- a/res/keyboard/ru_RU.kbd.cfg
+++ b/res/keyboard/ru_RU.kbd.cfg
@@ -11,7 +11,7 @@ crossfader_up_small Shift+Р
 crossfader_down_small Shift+П
 
 [Microphone]
-talkover ё
+talkover ]
 
 [VinylControl]
 Toggle Ctrl+е

--- a/res/keyboard/ru_RU.kbd.cfg
+++ b/res/keyboard/ru_RU.kbd.cfg
@@ -68,6 +68,9 @@ beatloop_4_toggle й
 loop_halve ц
 loop_double у
 
+passthrough Ctrl+о
+vinylcontrol_mode Ctrl+Shift+Н
+vinylcontrol_cueing Ctrl+Alt+Н
 
 [Channel2]
 play д
@@ -114,3 +117,7 @@ reloop_exit 9
 beatloop_4_toggle ш
 loop_halve щ
 loop_double з
+
+passthrough Ctrl+л
+vinylcontrol_mode Ctrl+Shift+Г
+vinylcontrol_cueing Ctrl+Alt+Г

--- a/res/keyboard/ru_RU.kbd.cfg
+++ b/res/keyboard/ru_RU.kbd.cfg
@@ -121,3 +121,19 @@ loop_double щ
 passthrough Ctrl+л
 vinylcontrol_mode Ctrl+Shift+Г
 vinylcontrol_cueing Ctrl+Alt+Г
+
+[KeyboardShortcuts]
+FileMenu_LoadDeck1 Ctrl+o
+FileMenu_LoadDeck2 Ctrl+Shift+O
+FileMenu_Quit Ctrl+q
+LibraryMenu_NewPlaylist Ctrl+n
+LibraryMenu_NewCrate Ctrl+Shift+N
+ViewMenu_ShowSamplers Ctrl+1
+ViewMenu_ShowMicrophone Ctrl+2
+ViewMenu_ShowVinylControl Ctrl+3
+ViewMenu_ShowPreviewDeck Ctrl+4
+OptionsMenu_EnableLiveBroadcasting Ctrl+l
+OptionsMenu_EnableVinyl1 Ctrl+y
+OptionsMenu_EnableVinyl2 Ctrl+u
+OptionsMenu_RecordMix Ctrl+r
+OptionsMenu_ReloadSkin Ctrl+Shift+R


### PR DESCRIPTION
Branch attempts to fix many inconsistencies with non-english keyboard mappings. Tested with Onscreen-Keyboard on OSX.
- Fixes https://bugs.launchpad.net/mixxx/+bug/1216400
- Fixes https://bugs.launchpad.net/mixxx/+bug/907199
- Add single deck vinyl control shortcut
