### PR TITLE
 replace underscores with spaces when parsing track file name

### DIFF
--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -331,7 +331,7 @@ int SoundSourceProxy::ParseHeader(TrackInfoObject* p)
 
     if (sndsrc->parseHeader() == OK) {
         //Dump the metadata from the soundsource into the TIO
-        //qDebug() << "Album:" << sndsrc->getAlbum(); //Sanity check to make setType(ure we've actually parsed metadata and not the filename
+        //qDebug() << "Album:" << sndsrc->getAlbum(); //Sanity check to make sure we've actually parsed metadata and not the filename
 
         // If Artist, Title and Type fields are not blank, modify them.
         // Otherwise, keep the values extracted by the function TrackInfoObject::parseFilename()

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -334,7 +334,7 @@ int SoundSourceProxy::ParseHeader(TrackInfoObject* p)
         //qDebug() << "Album:" << sndsrc->getAlbum(); //Sanity check to make setType(ure we've actually parsed metadata and not the filename
 
         // If Artist, Title and Type fields are not blank, modify them.
-        // Otherwise, keep the values extracted by the function TrackInfoObject::parseFilename
+        // Otherwise, keep the values extracted by the function TrackInfoObject::parseFilename()
         if (!(sndsrc->getArtist().isEmpty())) {
             p->setArtist(sndsrc->getArtist());
         }

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -331,20 +331,24 @@ int SoundSourceProxy::ParseHeader(TrackInfoObject* p)
 
     if (sndsrc->parseHeader() == OK) {
         //Dump the metadata from the soundsource into the TIO
-        //qDebug() << "Album:" << sndsrc->getAlbum(); //Sanity check to make sure we've actually parsed metadata and not the filename
-        p->setArtist(sndsrc->getArtist());
-        QString title = sndsrc->getTitle();
-        if (title.isEmpty()) {
-            // If no title is returned, use the file name (without the extension)
-            int start = qFilename.lastIndexOf(QRegExp("[/\\\\]"))+1;
-            int end = qFilename.lastIndexOf('.');
-            if (end == -1) end = qFilename.length();
-            title = qFilename.mid(start,end-start);
+        //qDebug() << "Album:" << sndsrc->getAlbum(); //Sanity check to make setType(ure we've actually parsed metadata and not the filename
+
+        // If Artist, Title and Type fields are not blank, modify them.
+        // Otherwise, keep the values extracted by the function TrackInfoObject::parseFilename
+        if (!(sndsrc->getArtist().isEmpty())) {
+            p->setArtist(sndsrc->getArtist());
         }
-        p->setTitle(title);
+
+        if (!(sndsrc->getTitle().isEmpty())) {
+            p->setTitle(sndsrc->getTitle());
+        }
+
+        if (!(sndsrc->getType().isEmpty())) {
+            p->setType(sndsrc->getType());
+        }
+
         p->setAlbum(sndsrc->getAlbum());
         p->setAlbumArtist(sndsrc->getAlbumArtist());
-        p->setType(sndsrc->getType());
         p->setYear(sndsrc->getYear());
         p->setGenre(sndsrc->getGenre());
         p->setComposer(sndsrc->getComposer());

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -165,6 +165,8 @@ bool TrackInfoObject::isValid() const {
 
 
 int TrackInfoObject::parse() {
+    m_sFilename = m_sFilename.replace("_", " ");
+
     // Add basic information derived from the filename:
     parseFilename();
 
@@ -187,10 +189,10 @@ void TrackInfoObject::parseFilename() {
     else
     {
         m_sTitle = m_sFilename.section('.',0,-2).trimmed(); // Remove the ending;
-        m_sType = m_sFilename.section('.',-1).trimmed(); // Get the ending
     }
 
     if (m_sTitle.length() == 0) {
+        m_sArtist = "";
         m_sTitle = m_sFilename.section('.',0,-2).trimmed();
     }
 

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -178,17 +178,14 @@ int TrackInfoObject::parse() {
 void TrackInfoObject::parseFilename() {
     QMutexLocker lock(&m_qMutex);
 
-    if (m_sFilename.indexOf('-') != -1) {
+    // If the file name has the following form: "Artist - Title.type", extract
+    // Artist, Title and type fields
+    if (m_sFilename.count('-') == 1) {
         m_sArtist = m_sFilename.section('-',0,0).trimmed(); // Get the first part
         m_sTitle = m_sFilename.section('-',1,1); // Get the second part
         m_sTitle = m_sTitle.section('.',0,-2).trimmed(); // Remove the ending
     } else {
         m_sTitle = m_sFilename.section('.',0,-2).trimmed(); // Remove the ending;
-    }
-
-    if (m_sTitle.length() == 0) {
-        m_sArtist = "";
-        m_sTitle = m_sFilename.section('.',0,-2).trimmed();
     }
 
     // Replace underscores with spaces for Artist and Title

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -165,8 +165,6 @@ bool TrackInfoObject::isValid() const {
 
 
 int TrackInfoObject::parse() {
-    m_sFilename = m_sFilename.replace("_", " ");
-
     // Add basic information derived from the filename:
     parseFilename();
 
@@ -195,6 +193,10 @@ void TrackInfoObject::parseFilename() {
         m_sArtist = "";
         m_sTitle = m_sFilename.section('.',0,-2).trimmed();
     }
+
+    // Replace underscores with spaces for Artist and Title
+    m_sArtist = m_sArtist.replace("_", " ");
+    m_sTitle = m_sTitle.replace("_", " ");
 
     // Add no comment
     m_sComment = QString("");

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -168,7 +168,7 @@ int TrackInfoObject::parse() {
     // Add basic information derived from the filename:
     parseFilename();
 
-    // Parse the using information stored in the sound file
+    // Parse the information stored in the sound file
     int result = SoundSourceProxy::ParseHeader(this);
     m_bIsValid = result == OK;
     return result;

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -178,14 +178,11 @@ int TrackInfoObject::parse() {
 void TrackInfoObject::parseFilename() {
     QMutexLocker lock(&m_qMutex);
 
-    if (m_sFilename.indexOf('-') != -1)
-    {
+    if (m_sFilename.indexOf('-') != -1) {
         m_sArtist = m_sFilename.section('-',0,0).trimmed(); // Get the first part
         m_sTitle = m_sFilename.section('-',1,1); // Get the second part
         m_sTitle = m_sTitle.section('.',0,-2).trimmed(); // Remove the ending
-    }
-    else
-    {
+    } else {
         m_sTitle = m_sFilename.section('.',0,-2).trimmed(); // Remove the ending;
     }
 


### PR DESCRIPTION
Fix for [Bug #1254534](https://bugs.launchpad.net/mixxx/+bug/1254534).
I found out that the metadata obtained by the `TrackInfoObject::parseFilename()` method was never used, because it was overridden by `SoundSourceProxy::ParseHeader()`.

So, right now, in case the [`SoundSource::parseHeader() method`](https://github.com/mixxxdj/mixxx/blob/master/src/soundsourceproxy.cpp#L332) is not getting any metadata for Author, Title, or Type, it will use the values got by `TrackInfoObject::parseFilename()`.
