### PR TITLE
Change wording for effective key widget tooltip

### DIFF
--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -213,6 +213,7 @@ void Tooltips::addStandardTooltips() {
             << tempoDisplay;
 
     add("visual_key")
+            //: The musical key of a track
             << tr("Key")
             << tr("Displays the current musical key of the loaded track after pitch shifting.");
 

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -214,7 +214,7 @@ void Tooltips::addStandardTooltips() {
 
     add("visual_key")
             << tr("Key")
-            << tr("Displays the harmonic key of the loaded track.");
+            << tr("Displays the current musical key of the loaded track after pitch shifting.");
 
     add("bpm_tap")
             << tr("BPM Tap")


### PR DESCRIPTION
Change ambiguous description and print what this widget actually do. More easy for translators too.
