### PR TITLE
Prevent some master sync party-stoppers

### DIFF
--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -423,6 +423,12 @@ double BpmControl::getBeatDistance(double dThisPosition) const {
                                    &dBeatPercentage, 0.01)) {
         return dBeatPercentage;
     }
+
+    if (getSyncMode() != SYNC_NONE && m_pQuantize->get()) {
+        qWarning() << getGroup() << "No beatgrid but sync and quantize enabled. "
+                                    "Disabling quantize mode";
+        m_pQuantize->set(0.0);
+    }
     return 0.0;
 }
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -441,7 +441,7 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
     m_pTrackSampleRate->set(iTrackSampleRate);
     m_pause.unlock();
 
-    // All EngingeControls are connected directly
+    // All EngineControls are connected directly
     emit(trackLoaded(pTrack));
     // Start buffer processing after all EngineContols are up to date
     // with the current track e.g track is seeked to Cue

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -25,28 +25,31 @@ SyncControl::SyncControl(const char* pGroup, ConfigObject<ConfigValue>* pConfig,
 
     m_pSyncMode.reset(new ControlObject(ConfigKey(pGroup, "sync_mode")));
     m_pSyncMode->connectValueChangeRequest(
-        this, SLOT(slotSyncModeChangeRequest(double)),
-        Qt::DirectConnection);
+            this, SLOT(slotSyncModeChangeRequest(double)), Qt::DirectConnection);
 
     m_pSyncMasterEnabled.reset(
-        new ControlPushButton(ConfigKey(pGroup, "sync_master")));
+            new ControlPushButton(ConfigKey(pGroup, "sync_master")));
     m_pSyncMasterEnabled->setButtonMode(ControlPushButton::TOGGLE);
     m_pSyncMasterEnabled->connectValueChangeRequest(
-        this, SLOT(slotSyncMasterEnabledChangeRequest(double)),
-        Qt::DirectConnection);
+            this, SLOT(slotSyncMasterEnabledChangeRequest(double)), Qt::DirectConnection);
 
     m_pSyncEnabled.reset(
-        new ControlPushButton(ConfigKey(pGroup, "sync_enabled")));
+            new ControlPushButton(ConfigKey(pGroup, "sync_enabled")));
     m_pSyncEnabled->setButtonMode(ControlPushButton::LONGPRESSLATCHING);
     m_pSyncEnabled->connectValueChangeRequest(
-        this, SLOT(slotSyncEnabledChangeRequest(double)),
-        Qt::DirectConnection);
+            this, SLOT(slotSyncEnabledChangeRequest(double)), Qt::DirectConnection);
 
     m_pSyncBeatDistance.reset(
-        new ControlObject(ConfigKey(pGroup, "beat_distance")));
+            new ControlObject(ConfigKey(pGroup, "beat_distance")));
     connect(m_pSyncBeatDistance.data(), SIGNAL(valueChanged(double)),
-            this, SLOT(slotBeatDistanceChanged(double)),
-            Qt::DirectConnection);
+            this, SLOT(slotBeatDistanceChanged(double)), Qt::DirectConnection);
+
+    m_pPassthroughEnabled.reset(new ControlObjectSlave(pGroup, "passthrough_enabled", this));
+    m_pPassthroughEnabled->connectValueChanged(this, SLOT(slotPassthroughChanged()),
+                                               Qt::DirectConnection);
+
+    m_pEjectButton.reset(new ControlObjectSlave(pGroup, "eject", this));
+    m_pEjectButton->connectValueChanged(this, SLOT(slotEjectPushed()), Qt::DirectConnection);
 
     // BPMControl and RateControl will be initialized later.
 }
@@ -103,6 +106,13 @@ void SyncControl::notifySyncModeChanged(SyncMode mode) {
     if (mode == SYNC_FOLLOWER && m_pVCEnabled->get()) {
         // If follower mode is enabled, disable vinyl control.
         m_pVCEnabled->set(0.0);
+    }
+    if (mode != SYNC_NONE && m_pPassthroughEnabled->get()) {
+        // If any sync mode is enabled and passthrough was on somehow, disable passthrough.
+        // This is very unlikely to happen so this deserves a warning.
+        qWarning() << "Notified of sync mode change when passthrough was active -- "
+                      "must disable passthrough";
+        m_pPassthroughEnabled->set(0.0);
     }
 }
 
@@ -171,8 +181,27 @@ void SyncControl::slotVinylControlChanged(double enabled) {
     }
 }
 
+void SyncControl::slotPassthroughChanged(double enabled) {
+    if (enabled && getSyncMode() != SYNC_NONE) {
+        // If passthrough was enabled and sync was on, disable it.
+        m_pEngineSync->requestSyncMode(this, SYNC_NONE);
+    }
+}
+
+void SyncControl::slotEjectPushed(double enabled) {
+    if (enabled && getSyncMode() == SYNC_MASTER) {
+        // If we ejected the track while master, hand off.
+        m_pEngineSync->requestSyncMode(this, SYNC_NONE);
+    }
+}
+
 void SyncControl::slotSyncModeChangeRequest(double state) {
-    m_pEngineSync->requestSyncMode(this, syncModeFromDouble(state));
+    SyncMode mode(syncModeFromDouble(state));
+    if (m_pPassthroughEnabled->get() && mode != SYNC_NONE) {
+        qDebug() << "Disallowing enabling of sync mode when passthrough active";
+    } else {
+        m_pEngineSync->requestSyncMode(this, mode);
+    }
 }
 
 void SyncControl::slotSyncMasterEnabledChangeRequest(double state) {
@@ -211,8 +240,19 @@ SyncMode SyncControl::getSyncMode() const {
 
 void SyncControl::slotFileBpmChanged() {
     // This slot is fired by file_bpm changes.
+    double file_bpm = m_pFileBpm ? m_pFileBpm->get() : 0.0;
+
+    if (file_bpm == 0 && getSyncMode() != SYNC_NONE) {
+        // If the file bpm is suddenly zero and sync was active, we have to disable sync.
+        // The track will keep playing but will not respond to rate changes.
+        qWarning() << getGroup() << " Sync is enabled on track with empty or zero bpm, "
+                                    "disabling master sync.";
+        m_pEngineSync->requestSyncMode(this, SYNC_NONE);
+        return;
+    }
+
     const double rate = 1.0 + m_pRateSlider->get() * m_pRateRange->get() * m_pRateDirection->get();
-    double bpm = m_pFileBpm ? m_pFileBpm->get() * rate : 0.0;
+    double bpm = file_bpm * rate;
     m_pEngineSync->notifyBpmChanged(this, bpm, true);
 }
 

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -170,6 +170,22 @@ bool SyncControl::isPlaying() const {
     return m_pPlayButton->get() > 0.0;
 }
 
+void SyncControl::trackLoaded(TrackPointer pTrack) {
+    Q_UNUSED(pTrack);
+    if (getSyncMode() == SYNC_MASTER) {
+        // If we loaded a new track while master, hand off.
+        m_pEngineSync->requestSyncMode(this, SYNC_NONE);
+    }
+}
+
+void SyncControl::trackUnloaded(TrackPointer pTrack) {
+    Q_UNUSED(pTrack);
+    if (getSyncMode() == SYNC_MASTER) {
+        // If we unloaded a new track while master, hand off.
+        m_pEngineSync->requestSyncMode(this, SYNC_NONE);
+    }
+}
+
 void SyncControl::slotControlPlay(double play) {
     m_pEngineSync->notifyPlaying(this, play > 0.0);
 }
@@ -189,10 +205,11 @@ void SyncControl::slotPassthroughChanged(double enabled) {
 }
 
 void SyncControl::slotEjectPushed(double enabled) {
-    if (enabled && getSyncMode() == SYNC_MASTER) {
-        // If we ejected the track while master, hand off.
-        m_pEngineSync->requestSyncMode(this, SYNC_NONE);
-    }
+    Q_UNUSED(enabled);
+    // We can't eject tracks if the decks is playing back, so if we are master
+    // and eject was pushed the deck must be stopped.  Handing off in this case
+    // actually causes the other decks to start playing, so not doing anything
+    // is preferred.
 }
 
 void SyncControl::slotSyncModeChangeRequest(double state) {

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -47,6 +47,10 @@ class SyncControl : public EngineControl, public Syncable {
     void reportTrackPosition(double fractionalPlaypos);
     void reportPlayerSpeed(double speed, bool scratching);
 
+  public slots:
+    virtual void trackLoaded(TrackPointer pTrack);
+    virtual void trackUnloaded(TrackPointer pTrack);
+
   private slots:
     // Fired by changes in play.
     void slotControlPlay(double v);

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -54,6 +54,12 @@ class SyncControl : public EngineControl, public Syncable {
     // Fired by changes in vinyl control status.
     void slotVinylControlChanged(double v);
 
+    // Fired when passthrough mode is enabled or disabled.
+    void slotPassthroughChanged(double v);
+
+    // Fired when a track is ejected.
+    void slotEjectPushed(double v);
+
     // Fired by changes in rate, rate_dir, rateRange.
     void slotRateChanged();
 
@@ -92,6 +98,8 @@ class SyncControl : public EngineControl, public Syncable {
     QScopedPointer<ControlObjectSlave> m_pRateDirection;
     QScopedPointer<ControlObjectSlave> m_pRateRange;
     QScopedPointer<ControlObjectSlave> m_pVCEnabled;
+    QScopedPointer<ControlObjectSlave> m_pPassthroughEnabled;
+    QScopedPointer<ControlObjectSlave> m_pEjectButton;
 };
 
 


### PR DESCRIPTION
- Deck passthrough activates -> sync disables
- Track ejected -> if master, sync disables, otherwise no change.
- Beatgrid on track cleared or becomes empty (0BPM) -> if quantize enabled, disable it (that's all we can do from bpmcontrol)
