### PR TITLE
Purely cosmetic cleanups to VinylControl / VinylControlXwax.

### DIFF
--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -3,12 +3,12 @@
 #include "controlobject.h"
 
 VinylControl::VinylControl(ConfigObject<ConfigValue> * pConfig, QString group)
-{
-    m_pConfig = pConfig;
-    m_group = group;
-
-    iSampleRate = m_pConfig->getValueString(ConfigKey("[Soundcard]","Samplerate")).toULong();
-
+        : m_pConfig(pConfig),
+          m_group(group),
+          m_iLeadInTime(m_pConfig->getValueString(
+              ConfigKey(VINYL_PREF_KEY,"lead_in_time")).toInt()),
+          m_dVinylPosition(0.0),
+          m_fTimecodeQuality(0.0f) {
     // Get Control objects
     playPos             = new ControlObjectThread(group, "playposition");    //Range: -.14 to 1.14
     trackSamples        = new ControlObjectThread(group, "track_samples");
@@ -17,7 +17,6 @@ VinylControl::VinylControl(ConfigObject<ConfigValue> * pConfig, QString group)
     controlScratch      = new ControlObjectThread(group, "scratch2");
     rateSlider          = new ControlObjectThread(group, "rate");    //Range -1.0 to 1.0
     playButton          = new ControlObjectThread(group, "play");
-    reverseButton       = new ControlObjectThread(group, "reverse");
     duration            = new ControlObjectThread(group, "duration");
     mode                = new ControlObjectThread(group, "vinylcontrol_mode");
     enabled             = new ControlObjectThread(group, "vinylcontrol_enabled");
@@ -30,37 +29,23 @@ VinylControl::VinylControl(ConfigObject<ConfigValue> * pConfig, QString group)
     loopEnabled         = new ControlObjectThread(group, "loop_enabled");
     signalenabled       = new ControlObjectThread(group, "vinylcontrol_signal_enabled");
 
-    dVinylPitch = 0.0f;
-    dVinylPosition = 0.0f;
-    dVinylScratch = 0.0f;
-    dDriftControl   = 0.0f;
-    fRateRange = 0.0f;
-    m_fTimecodeQuality = 0.0f;
-
-    //Get the vinyl type
-    strVinylType = m_pConfig->getValueString(ConfigKey(group,"vinylcontrol_vinyl_type"));
-
-    //Get the vinyl speed
-    strVinylSpeed = m_pConfig->getValueString(ConfigKey(group,"vinylcontrol_speed_type"));
-
-    //Get the lead-in time
-    iLeadInTime = m_pConfig->getValueString(ConfigKey(VINYL_PREF_KEY,"lead_in_time")).toInt();
-
     //Enabled or not -- load from saved value in case vinyl control is restarting
-    bIsEnabled = wantenabled->get();
+    m_bIsEnabled = wantenabled->get() > 0.0;
 
-    //Gain
+    // Load VC pre-amp gain from the config.
+    // TODO(rryan): Should probably live in VinylControlManager since it's not
+    // specific to a VC deck.
     ControlObject::set(ConfigKey(VINYL_PREF_KEY, "gain"),
         m_pConfig->getValueString(ConfigKey(VINYL_PREF_KEY,"gain")).toInt());
 }
 
 bool VinylControl::isEnabled() {
-    return bIsEnabled;
+    return m_bIsEnabled;
 }
 
 void VinylControl::toggleVinylControl(bool enable)
 {
-    bIsEnabled = enable;
+    m_bIsEnabled = enable;
     if (m_pConfig)
     {
         m_pConfig->set(ConfigKey(m_group,"vinylcontrol_enabled"), ConfigValue((int)enable));
@@ -76,7 +61,7 @@ void VinylControl::toggleVinylControl(bool enable)
 
 VinylControl::~VinylControl()
 {
-    bool wasEnabled = bIsEnabled;
+    bool wasEnabled = m_bIsEnabled;
     enabled->slotSet(false);
     vinylStatus->slotSet(VINYL_STATUS_DISABLED);
     if (wasEnabled)
@@ -93,7 +78,6 @@ VinylControl::~VinylControl()
     delete controlScratch;
     delete rateSlider;
     delete playButton;
-    delete reverseButton;
     delete duration;
     delete mode;
     delete enabled;
@@ -106,9 +90,3 @@ VinylControl::~VinylControl()
     delete loopEnabled;
     delete signalenabled;
 }
-
-float VinylControl::getSpeed()
-{
-    return dVinylScratch;
-}
-

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -43,29 +43,25 @@ bool VinylControl::isEnabled() {
     return m_bIsEnabled;
 }
 
-void VinylControl::toggleVinylControl(bool enable)
-{
+void VinylControl::toggleVinylControl(bool enable) {
     m_bIsEnabled = enable;
-    if (m_pConfig)
-    {
+    if (m_pConfig) {
         m_pConfig->set(ConfigKey(m_group,"vinylcontrol_enabled"), ConfigValue((int)enable));
     }
 
     enabled->slotSet(enable);
 
-    //Reset the scratch control to make sure we don't get stuck moving forwards or backwards.
-    //actually that might be a good thing
+    // Reset the scratch control to make sure we don't get stuck moving forwards or backwards.
+    // actually that might be a good thing
     //if (!enable)
     //    controlScratch->slotSet(0.0f);
 }
 
-VinylControl::~VinylControl()
-{
+VinylControl::~VinylControl() {
     bool wasEnabled = m_bIsEnabled;
     enabled->slotSet(false);
     vinylStatus->slotSet(VINYL_STATUS_DISABLED);
-    if (wasEnabled)
-    {
+    if (wasEnabled) {
         //if vinyl control is just restarting, indicate that it should
         //be enabled
         wantenabled->slotSet(true);

--- a/src/vinylcontrol/vinylcontrol.h
+++ b/src/vinylcontrol/vinylcontrol.h
@@ -16,16 +16,14 @@ class VinylControl : public QObject {
     virtual void toggleVinylControl(bool enable);
     virtual bool isEnabled();
     virtual void analyzeSamples(const short* samples, size_t nFrames) = 0;
-    virtual float getSpeed();
     virtual bool writeQualityReport(VinylSignalQualityReport* qualityReportFifo) = 0;
 
   protected:
     virtual float getAngle() = 0;
 
-    QString strVinylType;
-    QString strVinylSpeed;
-    ConfigObject<ConfigValue> *m_pConfig;    /** Pointer to config database */
+    ConfigObject<ConfigValue>* m_pConfig;
     QString m_group;
+
     ControlObjectThread *playButton; //The ControlObject used to start/stop playback of the song.
     ControlObjectThread *playPos; //The ControlObject used to read the playback position in the song.
     ControlObjectThread *trackSamples;
@@ -33,7 +31,6 @@ class VinylControl : public QObject {
     ControlObjectThread *vinylSeek; //The ControlObject used to change the playback position in the song.
     ControlObjectThread *controlScratch; //The ControlObject used to seek when the record is spinning fast.
     ControlObjectThread *rateSlider; //The ControlObject used to change the speed/pitch of the song.
-    ControlObjectThread *reverseButton; //The ControlObject used to reverse playback of the song.
     ControlObjectThread *duration; //The ControlObject used to get the duration of the current song.
     ControlObjectThread *mode; //The ControlObject used to get the vinyl control mode (absolute/relative/scratch)
     ControlObjectThread *enabled; //The ControlObject used to get if the vinyl control is enabled or disabled.
@@ -45,23 +42,19 @@ class VinylControl : public QObject {
     ControlObjectThread *rateDir; //direction of rate
     ControlObjectThread *loopEnabled; //looping enabled?
     ControlObjectThread *signalenabled; //show the signal in the skin?
-    //ControlObject *vinylStatus;  //Status of vinyl control
 
-    int iLeadInTime; //The lead-in time...
-    float dVinylPitch; //The speed/pitch of the timecoded vinyl as read by scratchlib.
-    double dVinylPosition; //The position of the needle on the record as read by scratchlib.
-    double dVinylScratch;
-    double dDriftControl; //The difference between Mixxx's position and the needle's position on the record.
-    //... these two values naturally drift apart, so we need to keep making adjustments to the pitch
-    //to stop it from getting bad.
-    float fRateRange; //The pitch range setting from Mixxx's preferences
-    float m_fTimecodeQuality; //Used as a measure of the quality of the timecode signal.
+    // The lead-in time...
+    int m_iLeadInTime;
 
-    float fTrackDuration;
-    unsigned long iSampleRate;
-    bool bIsEnabled;
-    int iVCMode;
-    bool atRecordEnd;
+    // The position of the needle on the record as read by the VinylControl
+    // implementation.
+    double m_dVinylPosition;
+
+    // Used as a measure of the quality of the timecode signal.
+    float m_fTimecodeQuality;
+
+    // Whether this VinylControl instance is enabled.
+    bool m_bIsEnabled;
 };
 
 #endif

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -226,23 +226,6 @@ void VinylControlXwax::analyzeSamples(const short *samples, size_t nFrames) {
 
     double dVinylPitch = timecoder_get_pitch(&timecoder);
 
-    // if no track loaded, let track selection work but that's it
-    // TODO(rryan): This is dead code since duration is always non-NULL.
-    if (duration == NULL)
-    {
-        //until I can figure out how to detect "track 2" on serato CD,
-        //don't try track selection
-        if (!m_bCDControl)
-        {
-            bTrackSelectMode = true;
-            doTrackSelection(false, dVinylPitch, m_iPosition);
-        }
-        return;
-    }
-    //qDebug() << m_group << id << m_iPosition << when << dVinylPitch;
-
-
-
     // Has a new track been loaded? Currently we use track duration which is
     // integer seconds in the song. However, for calculations we need the
     // higher-accuracy duration found by dividing the track samples by the

--- a/src/vinylcontrol/vinylcontrolxwax.h
+++ b/src/vinylcontrol/vinylcontrolxwax.h
@@ -47,38 +47,76 @@ class VinylControlXwax : public VinylControl {
     bool uiUpdateTime(double time);
     void establishQuality(bool quality_sample);
 
-    unsigned int m_uiSafeZone; // Cache the position of the end of record
+    // Cache the position of the end of record
+    unsigned int m_uiSafeZone;
 
-    double dOldPos; // The position read last time it was polled.
+    // The position read last time it was polled.
+    double m_dOldPos;
 
-    bool bQualityRing[QUALITY_RING_SIZE];
-    int iQualPos;
-    int iQualFilled;
+    // Signal quality ring buffer.
+    // TODO(XXX): Replace with CircularBuffer instead of handling the ring logic
+    // in VinylControlXwax.
+    bool m_bQualityRing[QUALITY_RING_SIZE];
+    int m_iQualPos;
+    int m_iQualFilled;
+
+    // Keeps track of the most recent position as reported by xwax.
+    int m_iPosition;
+
+    // Records whether we reached the end of the record.
+    bool m_bAtRecordEnd;
+
+    // Whether to force a resync on the next analysis loop.
+    bool m_bForceResync;
+
+    // The Vinyl Control mode and the previous mode.
+    int m_iVCMode;
+    int m_iOldVCMode;
+
+    // The loaded track duration from the last run of analyzeSamples.
+    double m_dOldDuration;
+
+    // The approximate duration used to tell if a new track is loaded.
+    double m_dOldDurationInaccurate;
+
+    // The pitch ring buffer.
+    // TODO(XXX): Replace with CircularBuffer instead of handling the ring logic
+    // in VinylControlXwax.
+    double* m_pPitchRing;
+    // How large the pitch ring buffer is.
+    int m_iPitchRingSize;
+    // Our current position in the pitch ring buffer.
+    int m_iPitchRingPos;
+    // How much of the pitch ring buffer is "filled" versus empty (used before
+    // it fills up completely).
+    int m_iPitchRingFilled;
+
+    // Steady pitch trackers.
+    SteadyPitch* m_pSteadySubtle;
+    SteadyPitch* m_pSteadyGross;
+    QTime m_timeSinceSteadyPitch;
+
+    // Whether the configured timecode is CD-based or not.
+    bool m_bCDControl;
+
+    // Whether the needle-skip prevention user-preference is enabled.
+    bool m_bNeedleSkipPrevention;
+
+    // Controls for manipulating the library.
+    ControlObjectThread* m_pControlTrackSelector;
+    ControlObjectThread* m_pControlTrackLoader;
+
+    // The previous and current track select position. Used for track selection
+    // using the control region.
+    double m_dLastTrackSelectPos;
+    double m_dCurTrackSelectPos;
+
 
     // Local variables copied from run(). TODO(XXX): Rename and prefix.
-    int iPosition;
-    float filePosition;
     double dDriftAmt;
-    int iPitchRingSize;
-    double* m_pPitchRing;
-    int ringPos;
-    int ringFilled;
-    double old_duration;
-
-    bool bForceResync;
-    int iOldMode;
     double dOldFilePos;
-    SteadyPitch *m_pSteadySubtle, *m_pSteadyGross;
-    QTime tSinceSteadyPitch;
     double dUiUpdateTime;
-
-    ControlObjectThread *trackSelector, *trackLoader;
-    double dLastTrackSelectPos;
-    double dCurTrackSelectPos;
     bool bTrackSelectMode;
-
-    bool m_bNeedleSkipPrevention;
-    bool m_bCDControl;
 
     // Contains information that xwax's code needs internally about the timecode
     // and how to process it.

--- a/src/vinylcontrol/vinylcontrolxwax.h
+++ b/src/vinylcontrol/vinylcontrolxwax.h
@@ -51,7 +51,7 @@ class VinylControlXwax : public VinylControl {
     unsigned int m_uiSafeZone;
 
     // The position read last time it was polled.
-    double m_dOldPos;
+    double m_dVinylPositionOld;
 
     // Signal quality ring buffer.
     // TODO(XXX): Replace with CircularBuffer instead of handling the ring logic
@@ -72,6 +72,9 @@ class VinylControlXwax : public VinylControl {
     // The Vinyl Control mode and the previous mode.
     int m_iVCMode;
     int m_iOldVCMode;
+
+    // The file position from the last run of analyzeSamples.
+    double m_dOldFilePos;
 
     // The loaded track duration from the last run of analyzeSamples.
     double m_dOldDuration;
@@ -102,6 +105,9 @@ class VinylControlXwax : public VinylControl {
     // Whether the needle-skip prevention user-preference is enabled.
     bool m_bNeedleSkipPrevention;
 
+    // Whether track select mode is enabled.
+    bool m_bTrackSelectMode;
+
     // Controls for manipulating the library.
     ControlObjectThread* m_pControlTrackSelector;
     ControlObjectThread* m_pControlTrackLoader;
@@ -111,12 +117,13 @@ class VinylControlXwax : public VinylControl {
     double m_dLastTrackSelectPos;
     double m_dCurTrackSelectPos;
 
+    // The drift between the vinyl position and the file position from the most
+    // recent run of analyzeSamples.
+    double m_dDriftAmt;
 
-    // Local variables copied from run(). TODO(XXX): Rename and prefix.
-    double dDriftAmt;
-    double dOldFilePos;
-    double dUiUpdateTime;
-    bool bTrackSelectMode;
+    // Records the time of the last UI update. Used to prevent hammering the GUI
+    // with updates.
+    double m_dUiUpdateTime;
 
     // Contains information that xwax's code needs internally about the timecode
     // and how to process it.


### PR DESCRIPTION
- Delete dead code / variables.
- Initialize all variables.
- Clarify some variable names.
- Move member-variables to local when used purely as locals.
- Comment a lot of the member variables.
