### PR TITLE
Mastersync sync phase on enable

### DIFF
--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -113,6 +113,7 @@ class EngineBuffer : public EngineObject {
     void setEngineMaster(EngineMaster*);
 
     void queueNewPlaypos(double newpos);
+    void requestSyncPhase();
 
     // Reset buffer playpos and set file playpos. This must only be called
     // while holding the pause mutex
@@ -294,6 +295,7 @@ class EngineBuffer : public EngineObject {
     bool m_bScalerOverride;
 
     QAtomicInt m_bSeekQueued;
+    QAtomicInt m_bSyncPhaseQueued;
     // TODO(XXX) make a macro or something.
 #if defined(__GNUC__)
     double m_dQueuedPosition __attribute__ ((aligned(sizeof(double))));

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -95,6 +95,7 @@ void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
     }
 
     if (bEnabled) {
+        int playing_decks = playingSyncDeckCount();
         if (m_pMasterSyncable == NULL) {
             // There is no master. If any other deck is playing we will match
             // the first available bpm -- sync won't be enabled on these decks,
@@ -133,14 +134,18 @@ void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
                 setMasterBpm(pSyncable, pSyncable->getBpm());
                 setMasterBeatDistance(pSyncable, pSyncable->getBeatDistance());
             }
-        } else if (m_pMasterSyncable == m_pInternalClock &&
-                   playingSyncDeckCount() == 0) {
+        } else if (m_pMasterSyncable == m_pInternalClock && playing_decks == 0) {
             // If there are no active followers, reset the internal clock bpm
             // and beat distance.
             setMasterBpm(pSyncable, pSyncable->getBpm());
             setMasterBeatDistance(pSyncable, pSyncable->getBeatDistance());
         }
         activateFollower(pSyncable);
+
+        if (m_pMasterSyncable == m_pInternalClock && playing_decks > 0) {
+            // If there are active followers, also synchronize phase
+            pSyncable->notifySyncPhase();
+        }
     } else {
         deactivateSync(pSyncable);
     }

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -141,11 +141,13 @@ void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
             // and beat distance.
             setMasterBpm(pSyncable, pSyncable->getBpm());
             setMasterBeatDistance(pSyncable, pSyncable->getBeatDistance());
+        } else if (m_pMasterSyncable != NULL) {
+            foundPlayingDeck = true;
         }
         activateFollower(pSyncable);
         if (foundPlayingDeck) {
             // Users also expect phase to be aligned when they press the sync button.
-            pSyncable->notifySyncPhase();
+            pSyncable->requestSyncPhase();
         }
     } else {
         deactivateSync(pSyncable);

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -96,6 +96,7 @@ void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
 
     if (bEnabled) {
         int playing_decks = playingSyncDeckCount();
+        bool foundPlayingDeck = false;
         if (m_pMasterSyncable == NULL) {
             // There is no master. If any other deck is playing we will match
             // the first available bpm -- sync won't be enabled on these decks,
@@ -117,9 +118,10 @@ void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
                     targetBeatDistance = other_deck->getBeatDistance();
 
                     // If the other deck is playing we stop looking
-                    // immediately. Otherwise continue looking for a playign
+                    // immediately. Otherwise continue looking for a playing
                     // deck with bpm > 0.0.
                     if (other_deck->isPlaying()) {
+                        foundPlayingDeck = true;
                         break;
                     }
                 }
@@ -141,9 +143,8 @@ void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
             setMasterBeatDistance(pSyncable, pSyncable->getBeatDistance());
         }
         activateFollower(pSyncable);
-
-        if (m_pMasterSyncable == m_pInternalClock && playing_decks > 0) {
-            // If there are active followers, also synchronize phase
+        if (foundPlayingDeck) {
+            // Users also expect phase to be aligned when they press the sync button.
             pSyncable->notifySyncPhase();
         }
     } else {

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -43,6 +43,10 @@ void InternalClock::notifySyncModeChanged(SyncMode mode) {
     m_pSyncMasterEnabled->setAndConfirm(mode == SYNC_MASTER);
 }
 
+void InternalClock::notifySyncPhase() {
+    // TODO(owilliams): This should probably be how we reset the internal beat distance.
+}
+
 void InternalClock::slotSyncMasterEnabledChangeRequest(double state) {
     bool currentlyMaster = getSyncMode() == SYNC_MASTER;
 

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -43,7 +43,7 @@ void InternalClock::notifySyncModeChanged(SyncMode mode) {
     m_pSyncMasterEnabled->setAndConfirm(mode == SYNC_MASTER);
 }
 
-void InternalClock::notifySyncPhase() {
+void InternalClock::requestSyncPhase() {
     // TODO(owilliams): This should probably be how we reset the internal beat distance.
 }
 

--- a/src/engine/sync/internalclock.h
+++ b/src/engine/sync/internalclock.h
@@ -27,7 +27,7 @@ class InternalClock : public QObject, public Clock, public Syncable {
     }
 
     void notifySyncModeChanged(SyncMode mode);
-    void notifySyncPhase();
+    void requestSyncPhase();
     SyncMode getSyncMode() const {
         return m_mode;
     }

--- a/src/engine/sync/internalclock.h
+++ b/src/engine/sync/internalclock.h
@@ -27,6 +27,7 @@ class InternalClock : public QObject, public Clock, public Syncable {
     }
 
     void notifySyncModeChanged(SyncMode mode);
+    void notifySyncPhase();
     SyncMode getSyncMode() const {
         return m_mode;
     }

--- a/src/engine/sync/syncable.h
+++ b/src/engine/sync/syncable.h
@@ -31,6 +31,9 @@ class Syncable {
     // in response to getMode().
     virtual void notifySyncModeChanged(SyncMode mode) = 0;
 
+    // Notify a Synacable that they should sync phase.
+    virtual void notifySyncPhase() = 0;
+
     // Must NEVER return a mode that was not set directly via
     // notifySyncModeChanged.
     virtual SyncMode getSyncMode() const = 0;

--- a/src/engine/sync/syncable.h
+++ b/src/engine/sync/syncable.h
@@ -32,7 +32,7 @@ class Syncable {
     virtual void notifySyncModeChanged(SyncMode mode) = 0;
 
     // Notify a Synacable that they should sync phase.
-    virtual void notifySyncPhase() = 0;
+    virtual void requestSyncPhase() = 0;
 
     // Must NEVER return a mode that was not set directly via
     // notifySyncModeChanged.

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -3,8 +3,10 @@
 #include "controlobject.h"
 #include "controlpushbutton.h"
 #include "controlobjectslave.h"
-#include "engine/ratecontrol.h"
 #include "engine/bpmcontrol.h"
+#include "engine/enginebuffer.h"
+#include "engine/enginechannel.h"
+#include "engine/ratecontrol.h"
 
 const double kTrackPositionMasterHandoff = 0.99;
 
@@ -121,9 +123,8 @@ void SyncControl::notifySyncModeChanged(SyncMode mode) {
     }
 }
 
-void SyncControl::notifySyncPhase() {
-    m_pSyncPhaseButton->set(1.0);
-    m_pSyncPhaseButton->set(0.0);
+void SyncControl::requestSyncPhase() {
+    m_pChannel->getEngineBuffer()->requestSyncPhase();
 }
 
 double SyncControl::getBeatDistance() const {

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -84,6 +84,8 @@ void SyncControl::setEngineControls(RateControl* pRateControl,
     m_pRateRange->connectValueChanged(this, SLOT(slotRateChanged()),
                                       Qt::DirectConnection);
 
+    m_pSyncPhaseButton.reset(new ControlObjectSlave(getGroup(), "beatsync_phase", this));
+
 #ifdef __VINYLCONTROL__
     m_pVCEnabled.reset(new ControlObjectSlave(
         getGroup(), "vinylcontrol_enabled", this));
@@ -104,9 +106,14 @@ void SyncControl::notifySyncModeChanged(SyncMode mode) {
     m_pSyncMode->setAndConfirm(mode);
     m_pSyncEnabled->setAndConfirm(mode != SYNC_NONE);
     m_pSyncMasterEnabled->setAndConfirm(mode == SYNC_MASTER);
-    if (mode == SYNC_FOLLOWER && m_pVCEnabled->get()) {
-        // If follower mode is enabled, disable vinyl control.
-        m_pVCEnabled->set(0.0);
+    if (mode == SYNC_FOLLOWER) {
+        if (m_pVCEnabled->get()) {
+            // If follower mode is enabled, disable vinyl control.
+            m_pVCEnabled->set(0.0);
+        }
+        // Tell bpmcontrol to sync phase.
+        m_pSyncPhaseButton->set(1.0);
+        m_pSyncPhaseButton->set(0.0);
     }
     if (mode != SYNC_NONE && m_pPassthroughEnabled->get()) {
         // If any sync mode is enabled and passthrough was on somehow, disable passthrough.

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -111,9 +111,6 @@ void SyncControl::notifySyncModeChanged(SyncMode mode) {
             // If follower mode is enabled, disable vinyl control.
             m_pVCEnabled->set(0.0);
         }
-        // Tell bpmcontrol to sync phase.
-        m_pSyncPhaseButton->set(1.0);
-        m_pSyncPhaseButton->set(0.0);
     }
     if (mode != SYNC_NONE && m_pPassthroughEnabled->get()) {
         // If any sync mode is enabled and passthrough was on somehow, disable passthrough.
@@ -122,6 +119,11 @@ void SyncControl::notifySyncModeChanged(SyncMode mode) {
                       "must disable passthrough";
         m_pPassthroughEnabled->set(0.0);
     }
+}
+
+void SyncControl::notifySyncPhase() {
+    m_pSyncPhaseButton->set(1.0);
+    m_pSyncPhaseButton->set(0.0);
 }
 
 double SyncControl::getBeatDistance() const {

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -104,6 +104,7 @@ class SyncControl : public EngineControl, public Syncable {
     QScopedPointer<ControlObjectSlave> m_pVCEnabled;
     QScopedPointer<ControlObjectSlave> m_pPassthroughEnabled;
     QScopedPointer<ControlObjectSlave> m_pEjectButton;
+    QScopedPointer<ControlObjectSlave> m_pSyncPhaseButton;
 };
 
 

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -25,6 +25,7 @@ class SyncControl : public EngineControl, public Syncable {
 
     SyncMode getSyncMode() const;
     void notifySyncModeChanged(SyncMode mode);
+    void notifySyncPhase();
     bool isPlaying() const;
 
     double getBeatDistance() const;

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -25,7 +25,7 @@ class SyncControl : public EngineControl, public Syncable {
 
     SyncMode getSyncMode() const;
     void notifySyncModeChanged(SyncMode mode);
-    void notifySyncPhase();
+    void requestSyncPhase();
     bool isPlaying() const;
 
     double getBeatDistance() const;


### PR DESCRIPTION
I think this is better if it only syncs phase when quantize is on.  That's consistent with how sync works in general, and it prevents sudden slight seeks if the DJ wants to transition from unsynced to synced.
