### PR TITLE
Ensure that audio connections for decks > 2 will succeed on startup.

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -340,8 +340,19 @@ MixxxApp::MixxxApp(QApplication *pApp, const CmdlineArgs& args)
 
     // Create the player manager.
     m_pPlayerManager = new PlayerManager(m_pConfig, m_pSoundManager, m_pEngine);
-    m_pPlayerManager->addDeck();
-    m_pPlayerManager->addDeck();
+
+    // Add the same number of decks that were last used.  This ensures that when
+    // audio inputs and outputs are set up, connections for decks > 2 will
+    // succeed.
+    int deck_count = m_pConfig->getValueString(ConfigKey("[Master]",
+                                                         "num_decks"),
+                                               "2").toInt();
+    if (deck_count < 2) {
+        deck_count = 2;
+    }
+    for (int i = 0; i < deck_count; ++i) {
+        m_pPlayerManager->addDeck();
+    }
     m_pPlayerManager->addSampler();
     m_pPlayerManager->addSampler();
     m_pPlayerManager->addSampler();


### PR DESCRIPTION
This loads the number of decks from the configuration file, so if the user had 4 decks loaded we create four decks off the bat.

Without this fix, audio connections to inputs will succeed but cause crashes.  audio connections for outputs will fail.  This means the user would have to re-set up their audio connections every time they started the program.
