### PR TITLE
Use unicode with libsndfile on Windows

### DIFF
--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -274,7 +274,13 @@ bool EngineRecord::openFile() {
             m_sfInfo.format = SF_FORMAT_AIFF | SF_FORMAT_PCM_16;
 
         // Creates a new WAVE or AIFF file and writes header information.
-        m_pSndfile = sf_open(m_fileName.toLocal8Bit(), SFM_WRITE, &m_sfInfo);
+#ifdef __WINDOWS__
+        LPCWSTR lpcwFilename = (LPCWSTR)m_fileName.utf16(); //Pointer valid until string changed
+        m_pSndfile = sf_wchar_open( lpcwFilename, SFM_WRITE, &m_sfInfo);
+#else
+        QByteArray qbaFilename = m_fileName.toUtf8();
+        m_pSndfile = sf_open(qbaFilename.data(), SFM_WRITE, &m_sfInfo);
+#endif
         if (m_pSndfile) {
             sf_command(m_pSndfile, SFC_SET_NORM_FLOAT, NULL, SF_FALSE) ;
             // Set meta data

--- a/src/engine/sidechain/enginerecord.h
+++ b/src/engine/sidechain/enginerecord.h
@@ -20,6 +20,12 @@
 #include <QDataStream>
 #include <QFile>
 
+#ifdef Q_OS_WIN
+//Enable unicode in libsndfile on Windows
+//(sf_open uses UTF-8 otherwise)
+#include <windows.h>
+#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
+#endif
 #include <sndfile.h>
 
 #include "encoder/encodercallback.h"

--- a/src/soundsourcesndfile.cpp
+++ b/src/soundsourcesndfile.cpp
@@ -55,13 +55,15 @@ QList<QString> SoundSourceSndFile::supportedFileExtensions()
     return list;
 }
 
-int SoundSourceSndFile::open() {
+int SoundSourceSndFile::open() 
+{
 #ifdef __WINDOWS__
-    QByteArray qbaFilename = m_qFilename.toLocal8Bit();
+    LPCWSTR lpcwFilename = (LPCWSTR)m_qFilename.utf16(); //Pointer valid until string changed
+    fh = sf_wchar_open( lpcwFilename, SFM_READ, info );
 #else
     QByteArray qbaFilename = m_qFilename.toUtf8();
-#endif
     fh = sf_open( qbaFilename.data(), SFM_READ, info );
+#endif
 
     if (fh == NULL) {   // sf_format_check is only for writes
         qWarning() << "libsndfile: Error opening file" << m_qFilename << sf_strerror(fh);

--- a/src/soundsourcesndfile.h
+++ b/src/soundsourcesndfile.h
@@ -19,7 +19,14 @@
 
 #include "soundsource.h"
 #include <stdio.h>
+#ifdef Q_OS_WIN
+//Enable unicode in libsndfile on Windows
+//(sf_open uses UTF-8 otherwise)
+#include <windows.h>
+#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
+#endif
 #include <sndfile.h>
+
 
 class SoundSourceSndFile : public Mixxx::SoundSource
 {


### PR DESCRIPTION
- Fixes recording and WAV problems with unicode files on Windows
