### PR TITLE
changed toUtf8 to toLocal8Bit for all targets,

### DIFF
--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -70,12 +70,7 @@ int SoundSourceM4A::initializeDecoder()
 {
     // Copy QString to char[] buffer for mp4_open to read from later
     QByteArray qbaFileName;
-#ifdef Q_OS_WIN32
-    // fopen() doesn't do utf8 on windows
     qbaFileName = m_qFilename.toLocal8Bit();
-#else
-    qbaFileName = m_qFilename.toUtf8();
-#endif
     int bytes = qbaFileName.length() + 1;
     ipd.filename = new char[bytes];
     strncpy(ipd.filename, qbaFileName.constData(), bytes);
@@ -182,13 +177,8 @@ inline long unsigned SoundSourceM4A::length(){
 
 int SoundSourceM4A::parseHeader(){
     setType("m4a");
-    
-#ifdef __WINDOWS__
-    // fopen() doesn't do utf8 on windows
+
     TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
-#else
-    TagLib::MP4::File f(getFilename().toUtf8().constData());
-#endif
 
     bool result = processTaglibFile(f);
     TagLib::MP4::Tag* tag = f.tag();

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -35,10 +35,10 @@ QList<QString> SoundSourceWV::supportedFileExtensions()
 
 int SoundSourceWV::open()
 {
-	QByteArray qBAFilename = m_qFilename.toUtf8();
+	QByteArray qBAFilename = m_qFilename.toLocal8Bit();
 	char msg[80];	//hold posible error message
 
-	filewvc = WavpackOpenFileInput(qBAFilename.data(),msg,OPEN_2CH_MAX | OPEN_WVC,0);
+	filewvc = WavpackOpenFileInput(qBAFilename.constData(), msg,OPEN_2CH_MAX | OPEN_WVC,0);
 	if (!filewvc) {
 		qDebug() << "SSWV::open: failed to open file : "<<msg;
 		return ERR;
@@ -123,19 +123,7 @@ inline long unsigned SoundSourceWV::length(){
 int SoundSourceWV::parseHeader() {
     setType("wv");
 
-#ifdef __WINDOWS__
-    /* From Tobias: A Utf-8 string did not work on my Windows XP (German edition)
-     * If you try this conversion, f.isValid() will return false in many cases
-     * and processTaglibFile() will fail
-     *
-     * The method toLocal8Bit() returns the local 8-bit representation of the string as a QByteArray.
-     * The returned byte array is undefined if the string contains characters not supported
-     * by the local 8-bit encoding.
-     */
     QByteArray qBAFilename = m_qFilename.toLocal8Bit();
-#else
-    QByteArray qBAFilename = m_qFilename.toUtf8();
-#endif
     TagLib::WavPack::File f(qBAFilename.constData());
 
     // Takes care of all the default metadata

--- a/src/audiotagger.cpp
+++ b/src/audiotagger.cpp
@@ -80,46 +80,46 @@ bool AudioTagger::save() {
     TagLib::File* file = NULL;
 
     if (m_file.endsWith(".mp3", Qt::CaseInsensitive)) {
-        file =  new TagLib::MPEG::File(m_file.toUtf8().constData());
-        //process special ID3 fields, APEv2 fiels, etc
+        file = new TagLib::MPEG::File(m_file.toLocal8Bit().constData());
+        // process special ID3 fields, APEv2 fiels, etc
 
-        //If the mp3 has no ID3v2 tag, we create a new one and add the TBPM and TKEY frame
+        // If the mp3 has no ID3v2 tag, we create a new one and add the TBPM and TKEY frame
         addID3v2Tag(((TagLib::MPEG::File*) file)->ID3v2Tag(true));
-        //If the mp3 has an APE tag, we update
+        // If the mp3 has an APE tag, we update
         addAPETag(((TagLib::MPEG::File*) file)->APETag(false));
-
     }
+
     if (m_file.endsWith(".m4a", Qt::CaseInsensitive)) {
-        file =  new TagLib::MP4::File(m_file.toUtf8().constData());
-        //process special ID3 fields, APEv2 fiels, etc
+        file = new TagLib::MP4::File(m_file.toLocal8Bit().constData());
+        // process special ID3 fields, APEv2 fiels, etc
         processMP4Tag(((TagLib::MP4::File*) file)->tag());
 
     }
     if (m_file.endsWith(".ogg", Qt::CaseInsensitive)) {
-        file =  new TagLib::Ogg::Vorbis::File(m_file.toUtf8().constData());
-        //process special ID3 fields, APEv2 fiels, etc
-        addXiphComment(((TagLib::Ogg::Vorbis::File*) file)->tag());
+        file = new TagLib::Ogg::Vorbis::File(m_file.toLocal8Bit().constData());
+        // process special ID3 fields, APEv2 fiels, etc
+        addXiphComment(((TagLib::Ogg::Vorbis::File*)file)->tag());
 
     }
     if (m_file.endsWith(".wav", Qt::CaseInsensitive)) {
-        file =  new TagLib::RIFF::WAV::File(m_file.toUtf8().constData());
+        file = new TagLib::RIFF::WAV::File(m_file.toLocal8Bit().constData());
         //If the flac has no ID3v2 tag, we create a new one and add the TBPM and TKEY frame
-        addID3v2Tag(((TagLib::RIFF::WAV::File*) file)->tag());
+        addID3v2Tag(((TagLib::RIFF::WAV::File*)file)->tag());
 
     }
     if (m_file.endsWith(".flac", Qt::CaseInsensitive)) {
-        file =  new TagLib::FLAC::File(m_file.toUtf8().constData());
+        file = new TagLib::FLAC::File(m_file.toLocal8Bit().constData());
 
         //If the flac has no ID3v2 tag, we create a new one and add the TBPM and TKEY frame
-        addID3v2Tag(((TagLib::FLAC::File*) file)->ID3v2Tag(true) );
+        addID3v2Tag(((TagLib::FLAC::File*)file)->ID3v2Tag(true) );
         //If the flac has no APE tag, we create a new one and add the TBPM and TKEY frame
         addXiphComment(((TagLib::FLAC::File*) file)->xiphComment(true));
 
     }
     if (m_file.endsWith(".aif", Qt::CaseInsensitive) || m_file.endsWith(".aiff", Qt::CaseInsensitive)) {
-        file =  new TagLib::RIFF::AIFF::File(m_file.toUtf8().constData());
+        file =  new TagLib::RIFF::AIFF::File(m_file.toLocal8Bit().constData());
         //If the flac has no ID3v2 tag, we create a new one and add the TBPM and TKEY frame
-        addID3v2Tag(((TagLib::RIFF::AIFF::File*) file)->tag());
+        addID3v2Tag(((TagLib::RIFF::AIFF::File*)file)->tag());
 
     }
 

--- a/src/cachingreader.cpp
+++ b/src/cachingreader.cpp
@@ -303,7 +303,6 @@ int CachingReader::read(int sample, int num_samples, CSAMPLE* buffer) {
     // Check for bad inputs
     if (sample % 2 != 0 || num_samples < 0 || !buffer) {
         QString temp = QString("Sample = %1").arg(sample);
-        QByteArray tempBA = QString(temp).toUtf8();
         qDebug() << "CachingReader::read() invalid arguments sample:" << sample
                  << "num_samples:" << num_samples << "buffer:" << buffer;
         return 0;

--- a/src/soundsourcecoreaudio.cpp
+++ b/src/soundsourcecoreaudio.cpp
@@ -198,8 +198,7 @@ int SoundSourceCoreAudio::parseHeader() {
     bool result = false;
 
     if (getType() == "m4a") {
-        // No need for toLocal8Bit on Windows since CoreAudio is OS X only.
-        TagLib::MP4::File f(getFilename().toUtf8().constData());
+        TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
         result = processTaglibFile(f);
         TagLib::MP4::Tag* tag = f.tag();
         if (tag) {
@@ -207,7 +206,7 @@ int SoundSourceCoreAudio::parseHeader() {
         }
     } else if (getType() == "mp3") {
         // No need for toLocal8Bit on Windows since CoreAudio is OS X only.
-        TagLib::MPEG::File f(getFilename().toUtf8().constData());
+        TagLib::MPEG::File f(getFilename().toLocal8Bit().constData());
 
         // Takes care of all the default metadata
         result = processTaglibFile(f);

--- a/src/soundsourceffmpeg.cpp
+++ b/src/soundsourceffmpeg.cpp
@@ -140,22 +140,8 @@ int SoundSourceFFmpeg::open() {
     AVDictionary *l_iFormatOpts = NULL;
 
     m_iOffset = 0;
-#ifdef __WINDOWS__
-    // From Tobias: A Utf-8 string did not work on my Windows XP (German edition)
-    // If you try this conversion, f.isValid() will return false in many cases
-    // and processTaglibFile() will fail
-    //
-    // The method toLocal8Bit() returns the local 8-bit representation
-    // of the string as a QByteArray. The returned byte array is undefined if
-    // the string contains characters not supported
-    // by the local 8-bit encoding.
-    //
-    // See https://ffmpeg.org/trac/ffmpeg/ticket/819 for relevant bug report.
-    //
     QByteArray qBAFilename = m_qFilename.toLocal8Bit();
-#else
-    QByteArray qBAFilename = m_qFilename.toUtf8();
-#endif
+
     // Initialize FFMPEG
     // FFmpegInit();
 
@@ -647,22 +633,7 @@ unsigned int SoundSourceFFmpeg::read(unsigned long size,
 
 int SoundSourceFFmpeg::parseHeader() {
     qDebug() << "ffmpeg: SoundSourceFFmpeg::parseHeader" << m_qFilename;
-#ifdef __WINDOWS__
-    // From Tobias: A Utf-8 string did not work on my Windows XP (German edition)
-    // If you try this conversion, f.isValid() will return false in many cases
-    // and processTaglibFile() will fail
-    //
-    // The method toLocal8Bit() returns the local 8-bit representation of
-    // the string as a QByteArray. The returned byte array is undefined if the
-    // string contains characters not supported
-    // by the local 8-bit encoding.
-    //
-    // See https://ffmpeg.org/trac/ffmpeg/ticket/819 for relevant bug report.
-    //
     QByteArray qBAFilename = m_qFilename.toLocal8Bit();
-#else
-    QByteArray qBAFilename = m_qFilename.toUtf8();
-#endif
 
     AVFormatContext * FmtCtx = avformat_alloc_context();
     AVCodecContext * CodecCtx;

--- a/src/soundsourceflac.cpp
+++ b/src/soundsourceflac.cpp
@@ -150,19 +150,7 @@ inline unsigned long SoundSourceFLAC::length() {
 
 int SoundSourceFLAC::parseHeader() {
     setType("flac");
-#ifdef __WINDOWS__
-    /* From Tobias: A Utf-8 string did not work on my Windows XP (German edition)
-     * If you try this conversion, f.isValid() will return false in many cases
-     * and processTaglibFile() will fail
-     *
-     * The method toLocal8Bit() returns the local 8-bit representation of the string as a QByteArray.
-     * The returned byte array is undefined if the string contains characters not supported
-     * by the local 8-bit encoding.
-     */
     QByteArray qBAFilename = m_qFilename.toLocal8Bit();
-#else
-    QByteArray qBAFilename = m_qFilename.toUtf8();
-#endif
     TagLib::FLAC::File f(qBAFilename.constData());
     bool result = processTaglibFile(f);
     TagLib::ID3v2::Tag *id3v2(f.ID3v2Tag());

--- a/src/soundsourcemp3.cpp
+++ b/src/soundsourcemp3.cpp
@@ -554,19 +554,7 @@ unsigned SoundSourceMp3::read(unsigned long samples_wanted, const SAMPLE * _dest
 int SoundSourceMp3::parseHeader()
 {
     setType("mp3");
-#ifdef __WINDOWS__
-    /* From Tobias: A Utf-8 string did not work on my Windows XP (German edition)
-     * If you try this conversion, f.isValid() will return false in many cases
-     * and processTaglibFile() will fail
-     *
-     * The method toLocal8Bit() returns the local 8-bit representation of the string as a QByteArray.
-     * The returned byte array is undefined if the string contains characters not supported
-     * by the local 8-bit encoding.
-     */
     QByteArray qBAFilename = m_qFilename.toLocal8Bit();
-#else
-    QByteArray qBAFilename = m_qFilename.toUtf8();
-#endif
     TagLib::MPEG::File f(qBAFilename.constData());
 
     // Takes care of all the default metadata

--- a/src/soundsourceoggvorbis.cpp
+++ b/src/soundsourceoggvorbis.cpp
@@ -229,20 +229,7 @@ unsigned SoundSourceOggVorbis::read(volatile unsigned long size, const SAMPLE * 
  */
 int SoundSourceOggVorbis::parseHeader() {
     setType("ogg");
-
-#ifdef __WINDOWS__
-    /* From Tobias: A Utf-8 string did not work on my Windows XP (German edition)
-     * If you try this conversion, f.isValid() will return false in many cases
-     * and processTaglibFile() will fail
-     *
-     * The method toLocal8Bit() returns the local 8-bit representation of the string as a QByteArray.
-     * The returned byte array is undefined if the string contains characters not supported
-     * by the local 8-bit encoding.
-     */
     QByteArray qBAFilename = m_qFilename.toLocal8Bit();
-#else
-    QByteArray qBAFilename = m_qFilename.toUtf8();
-#endif
     TagLib::Ogg::Vorbis::File f(qBAFilename.constData());
 
     // Takes care of all the default metadata

--- a/src/soundsourcesndfile.cpp
+++ b/src/soundsourcesndfile.cpp
@@ -169,20 +169,7 @@ int SoundSourceSndFile::parseHeader()
     bool result;
     bool is_flac = location.endsWith("flac", Qt::CaseInsensitive);
     bool is_wav = location.endsWith("wav", Qt::CaseInsensitive);
-
-#ifdef __WINDOWS__
-    /* From Tobias: A Utf-8 string did not work on my Windows XP (German edition)
-     * If you try this conversion, f.isValid() will return false in many cases
-     * and processTaglibFile() will fail
-     *
-     * The method toLocal8Bit() returns the local 8-bit representation of the string as a QByteArray.
-     * The returned byte array is undefined if the string contains characters not supported
-     * by the local 8-bit encoding.
-     */
     QByteArray qBAFilename = m_qFilename.toLocal8Bit();
-#else
-    QByteArray qBAFilename = m_qFilename.toUtf8();
-#endif
 
     if (is_flac) {
         TagLib::FLAC::File f(qBAFilename.constData());


### PR DESCRIPTION
 .. because this way we have always the right codec for system calls.

This commit is untested, but I think we can merge it after a strong review. 
