### PR TITLE
Create an enum system for seek requests to handle different cases.

### DIFF
--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -205,7 +205,7 @@ void CueControl::trackLoaded(TrackPointer pTrack) {
     }
     // Need to unlock before emitting any signals to prevent deadlock.
     lock.unlock();
-    seekAbs(loadCuePoint);
+    seekExact(loadCuePoint);
 }
 
 void CueControl::trackUnloaded(TrackPointer pTrack) {
@@ -327,7 +327,7 @@ void CueControl::hotcueSet(HotcueControl* pControl, double v) {
     bool playing = m_pPlayButton->get() > 0;
     if (!playing && m_pQuantizeEnabled->get() > 0.0) {
         lock.unlock();  // prevent deadlock.
-        seekAbs(cuePosition);
+        seekExact(cuePosition);
     }
 }
 
@@ -347,7 +347,7 @@ void CueControl::hotcueGoto(HotcueControl* pControl, double v) {
     if (pCue) {
         int position = pCue->getPosition();
         if (position != -1) {
-            seekAbs(position);
+            seekExact(position);
         }
     }
 }
@@ -369,7 +369,7 @@ void CueControl::hotcueGotoAndStop(HotcueControl* pControl, double v) {
         int position = pCue->getPosition();
         if (position != -1) {
             m_pPlayButton->set(0.0);
-            seekAbs(position);
+            seekExact(position);
         }
     }
 }
@@ -390,7 +390,7 @@ void CueControl::hotcueGotoAndPlay(HotcueControl* pControl, double v) {
     if (pCue) {
         int position = pCue->getPosition();
         if (position != -1) {
-            seekAbs(position);
+            seekExact(position);
             m_pPlayButton->set(1.0);
         }
     }
@@ -458,7 +458,7 @@ void CueControl::hotcueActivatePreview(HotcueControl* pControl, double v) {
             // Need to unlock before emitting any signals to prevent deadlock.
             lock.unlock();
 
-            seekAbs(iPosition);
+            seekExact(iPosition);
         }
     } else if (m_bPreviewingHotcue) {
         // This is a activate release and we are previewing at least one
@@ -485,7 +485,7 @@ void CueControl::hotcueActivatePreview(HotcueControl* pControl, double v) {
                     m_pPlayButton->set(0.0);
                     // Need to unlock before emitting any signals to prevent deadlock.
                     lock.unlock();
-                    seekAbs(iPosition);
+                    seekExact(iPosition);
                 }
             }
         }
@@ -590,7 +590,7 @@ void CueControl::cueGoto(double v)
     // Need to unlock before emitting any signals to prevent deadlock.
     lock.unlock();
 
-    seekAbs(cuePoint);
+    seekExact(cuePoint);
 }
 
 void CueControl::cueGotoAndPlay(double v)
@@ -617,7 +617,7 @@ void CueControl::cueGotoAndStop(double v)
     // Need to unlock before emitting any signals to prevent deadlock.
     lock.unlock();
 
-    seekAbs(cuePoint);
+    seekExact(cuePoint);
 }
 
 void CueControl::cuePreview(double v)
@@ -637,7 +637,7 @@ void CueControl::cuePreview(double v)
     // Need to unlock before emitting any signals to prevent deadlock.
     lock.unlock();
 
-    seekAbs(cuePoint);
+    seekExact(cuePoint);
 }
 
 void CueControl::cueSimple(double v) {
@@ -656,7 +656,7 @@ void CueControl::cueSimple(double v) {
     // Need to unlock before emitting any signals to prevent deadlock.
     lock.unlock();
 
-    seekAbs(cuePoint);
+    seekExact(cuePoint);
 }
 
 void CueControl::cueCDJ(double v) {
@@ -680,7 +680,7 @@ void CueControl::cueCDJ(double v) {
             // Need to unlock before emitting any signals to prevent deadlock.
             lock.unlock();
 
-            seekAbs(cuePoint);
+            seekExact(cuePoint);
         } else {
             if (fabs(getCurrentSample() - m_pCuePoint->get()) < 1.0f) {
                 m_pPlayButton->set(1.0);
@@ -694,7 +694,7 @@ void CueControl::cueCDJ(double v) {
                 // necessarily where we currently are
                 if (m_pQuantizeEnabled->get() > 0.0) {
                     lock.unlock();  // prevent deadlock.
-                    seekAbs(m_pCuePoint->get());
+                    seekExact(m_pCuePoint->get());
                 }
             }
         }
@@ -705,7 +705,7 @@ void CueControl::cueCDJ(double v) {
         // Need to unlock before emitting any signals to prevent deadlock.
         lock.unlock();
 
-        seekAbs(cuePoint);
+        seekExact(cuePoint);
     }
     else {
         // Re-trigger the play button value so controllers get the correct one

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -937,18 +937,17 @@ void EngineBuffer::processSlip(int iBufferSize) {
 
 void EngineBuffer::processSeek() {
     bool paused = m_playButton->get() != 0.0f ? false : true;
-    bool ignore_quantize = false;
     SeekRequest seek_type =
             static_cast<SeekRequest>(m_iSeekQueued.fetchAndStoreRelease(NO_SEEK));
     switch (seek_type) {
     case NO_SEEK:
         return;
     case SEEK_EXACT:
-        ignore_quantize = true;
-        // fallthrough intended
+        setNewPlaypos(m_dQueuedPosition);
+        break;
     case SEEK_STANDARD:
         // If we are playing and quantize is on, match phase when seeking.
-        if (!paused && m_pQuantize->get() > 0.0 && !ignore_quantize) {
+        if (!paused && m_pQuantize->get() > 0.0) {
             int offset = static_cast<int>(m_pBpmControl->getPhaseOffset(m_dQueuedPosition));
             if (!even(offset)) {
                 offset--;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -90,6 +90,13 @@ const int ENGINE_RAMP_UP = 1;
 
 //const int kiRampLength = 3;
 
+enum SeekRequest {
+    NO_SEEK,
+    SEEK_STANDARD,
+    SEEK_EXACT,
+    SEEK_PHASE
+};
+
 class EngineBuffer : public EngineObject {
      Q_OBJECT
   public:
@@ -112,16 +119,17 @@ class EngineBuffer : public EngineObject {
     // Sets pointer to other engine buffer/channel
     void setEngineMaster(EngineMaster*);
 
-    void queueNewPlaypos(double newpos);
+    void queueNewPlaypos(double newpos, bool exact);
     void requestSyncPhase();
 
     // Reset buffer playpos and set file playpos. This must only be called
     // while holding the pause mutex
     void setNewPlaypos(double playpos);
 
+    // The process methods all run in the audio callback.
     void process(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize);
-
     void processSlip(int iBufferSize);
+    void processSeek();
 
     const char* getGroup();
     bool isTrackLoaded();
@@ -148,6 +156,7 @@ class EngineBuffer : public EngineObject {
     void slotControlEnd(double);
     void slotControlSeek(double);
     void slotControlSeekAbs(double);
+    void slotControlSeekExact(double);
     void slotControlSlip(double);
 
     // Request that the EngineBuffer load a track. Since the process is
@@ -179,6 +188,8 @@ class EngineBuffer : public EngineObject {
     void ejectTrack();
 
     double fractionalPlayposFromAbsolute(double absolutePlaypos);
+
+    void doSeek(double change, bool exact);
 
     // Lock for modifying local engine variables that are not thread safe, such
     // as m_engineControls and m_hintList
@@ -294,8 +305,7 @@ class EngineBuffer : public EngineObject {
     // Indicates that dependency injection has taken place.
     bool m_bScalerOverride;
 
-    QAtomicInt m_bSeekQueued;
-    QAtomicInt m_bSyncPhaseQueued;
+    QAtomicInt m_iSeekQueued;
     // TODO(XXX) make a macro or something.
 #if defined(__GNUC__)
     double m_dQueuedPosition __attribute__ ((aligned(sizeof(double))));

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -93,6 +93,12 @@ void EngineControl::seekAbs(double fractionalPosition) {
     }
 }
 
+void EngineControl::seekExact(double fractionalPosition) {
+    if (m_pEngineBuffer) {
+        m_pEngineBuffer->slotControlSeekExact(fractionalPosition);
+    }
+}
+
 void EngineControl::seek(double sample) {
     if (m_pEngineBuffer) {
         m_pEngineBuffer->slotControlSeek(sample);

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -81,6 +81,8 @@ class EngineControl : public QObject {
   protected:
     void seek(double fractionalPosition);
     void seekAbs(double sample);
+    // Seek to an exact sample and don't allow quantizing adjustment.
+    void seekExact(double sample);
     EngineBuffer* pickSyncTarget();
 
     ConfigObject<ConfigValue>* getConfig();

--- a/src/engine/vinylcontrolcontrol.cpp
+++ b/src/engine/vinylcontrolcontrol.cpp
@@ -90,7 +90,7 @@ void VinylControlControl::slotControlVinylSeek(double change) {
             return;  //if off, do nothing
         } else if (cuemode == MIXXX_RELATIVE_CUE_ONECUE) {
             //if onecue, just seek to the regular cue
-            seekAbs(m_pCurrentTrack->getCuePoint());
+            seekExact(m_pCurrentTrack->getCuePoint());
             return;
         }
 
@@ -121,7 +121,7 @@ void VinylControlControl::slotControlVinylSeek(double change) {
             }
             //if negative, allow a seek by falling down to the bottom
         } else {
-            seekAbs(nearest_playpos);
+            seekExact(nearest_playpos);
             return;
         }
     }


### PR DESCRIPTION
- changed m_bSeekQueued to m_iSeekQueued and made it refer to an enum
- created seekExact for hotcues, so the cuecontrol can override quantize mode
- get rid of m_bSyncPhaseQueued and made it another seek type.
- pull all of the seek logic into a separate function
- stop calling slotSeek directly!
