### PR TITLE
Remove widget values.

### DIFF
--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1674,6 +1674,12 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
                     break;
             }
 
+            // Legacy behavior, the last widget that is marked
+            // connectValueToWidget is the display connection.
+            if (connectValueToWidget) {
+                pWidget->setDisplayConnection(pConnection);
+            }
+
             // We only add info for controls that this widget affects, not
             // controls that only affect the widget.
             if (connectValueFromWidget) {

--- a/src/test/wpushbutton_test.cpp
+++ b/src/test/wpushbutton_test.cpp
@@ -35,7 +35,7 @@ TEST_F(WPushButtonTest, QuickPressNoLatchTest) {
 
     m_Events.simulate(m_pButton.data());
 
-    ASSERT_EQ(0.0, m_pButton->getValue());
+    ASSERT_EQ(0.0, m_pButton->getConnectedDisplayValue());
 }
 
 TEST_F(WPushButtonTest, LongPressLatchTest) {
@@ -48,5 +48,5 @@ TEST_F(WPushButtonTest, LongPressLatchTest) {
 
     m_Events.simulate(m_pButton.data());
 
-    ASSERT_EQ(1.0, m_pButton->getValue());
+    ASSERT_EQ(1.0, m_pButton->getConnectedDisplayValue());
 }

--- a/src/test/wpushbutton_test.cpp
+++ b/src/test/wpushbutton_test.cpp
@@ -35,7 +35,7 @@ TEST_F(WPushButtonTest, QuickPressNoLatchTest) {
 
     m_Events.simulate(m_pButton.data());
 
-    ASSERT_EQ(0.0, m_pButton->getConnectedDisplayValue());
+    ASSERT_EQ(0.0, m_pButton->getControlParameterDisplay());
 }
 
 TEST_F(WPushButtonTest, LongPressLatchTest) {
@@ -48,5 +48,5 @@ TEST_F(WPushButtonTest, LongPressLatchTest) {
 
     m_Events.simulate(m_pButton.data());
 
-    ASSERT_EQ(1.0, m_pButton->getConnectedDisplayValue());
+    ASSERT_EQ(1.0, m_pButton->getControlParameterDisplay());
 }

--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -30,7 +30,7 @@ class KnobEventHandler {
         }
 
         // For legacy (MIDI) reasons this is tuned to 127.
-        double value = pWidget->getConnectedControlLeft() + dist / 127.0;
+        double value = pWidget->getControlParameterLeft() + dist / 127.0;
 
         // Clamp to [0.0, 1.0]
         value = math_max(0.0, math_min(1.0, value));
@@ -42,7 +42,7 @@ class KnobEventHandler {
         if (!m_bRightButtonPressed) {
             QCursor::setPos(m_startPos);
             double value = valueFromMouseEvent(pWidget, e);
-            pWidget->setConnectedControlLeftDown(value);
+            pWidget->setControlParameterLeftDown(value);
             pWidget->update();
         }
     }
@@ -50,7 +50,7 @@ class KnobEventHandler {
     void mousePressEvent(T* pWidget, QMouseEvent* e) {
         switch (e->button()) {
             case Qt::RightButton:
-                pWidget->resetConnectedControls();
+                pWidget->resetControlParameters();
                 m_bRightButtonPressed = true;
                 break;
             case Qt::LeftButton:
@@ -71,12 +71,12 @@ class KnobEventHandler {
                 QCursor::setPos(m_startPos);
                 QApplication::restoreOverrideCursor();
                 value = valueFromMouseEvent(pWidget, e);
-                pWidget->setConnectedControlLeftUp(value);
+                pWidget->setControlParameterLeftUp(value);
                 pWidget->update();
                 break;
             case Qt::RightButton:
                 m_bRightButtonPressed = false;
-                //pWidget->setConnectedControlRightUp(pWidget->getValue());
+                //pWidget->setControlParameterRightUp(pWidget->getValue());
                 break;
             default:
                 break;
@@ -87,13 +87,13 @@ class KnobEventHandler {
     void wheelEvent(T* pWidget, QWheelEvent* e) {
         // For legacy (MIDI) reasons this is tuned to 127.
         double wheelDirection = e->delta() / (120.0 * 127.0);
-        double newValue = pWidget->getConnectedControl() + wheelDirection;
+        double newValue = pWidget->getControlParameter() + wheelDirection;
 
         // Clamp to [0.0, 1.0]
         newValue = math_max(0.0, math_min(1.0, newValue));
 
-        pWidget->setConnectedControlDown(newValue);
-        pWidget->setConnectedControlUp(newValue);
+        pWidget->setControlParameterDown(newValue);
+        pWidget->setControlParameterUp(newValue);
         pWidget->update();
         e->accept();
     }

--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -16,29 +16,32 @@ class KnobEventHandler {
             : m_bRightButtonPressed(false) {
     }
 
+    double valueFromMouseEvent(T* pWidget, QMouseEvent* e) {
+        QPoint cur(e->globalPos());
+        QPoint diff(cur - m_startPos);
+        double dist = sqrt(static_cast<double>(diff.x() * diff.x() + diff.y() * diff.y()));
+        bool y_dominant = abs(diff.y()) > abs(diff.x());
+
+        // if y is dominant, then thread an increase in dy as negative (y is
+        // pointed downward). Otherwise, if y is not dominant and x has
+        // decreased, then thread it as negative.
+        if ((y_dominant && diff.y() > 0) || (!y_dominant && diff.x() < 0)) {
+            dist = -dist;
+        }
+
+        // For legacy (MIDI) reasons this is tuned to 127.
+        double value = pWidget->getConnectedControlLeft() + dist / 127.0;
+
+        // Clamp to [0.0, 1.0]
+        value = math_max(0.0, math_min(1.0, value));
+
+        return value;
+    }
+
     void mouseMoveEvent(T* pWidget, QMouseEvent* e) {
         if (!m_bRightButtonPressed) {
-            QPoint cur(e->globalPos());
-            QPoint diff(cur - m_startPos);
-            double dist = sqrt(static_cast<double>(diff.x() * diff.x() + diff.y() * diff.y()));
-            bool y_dominant = abs(diff.y()) > abs(diff.x());
-
-            // if y is dominant, then thread an increase in dy as negative (y is
-            // pointed downward). Otherwise, if y is not dominant and x has
-            // decreased, then thread it as negative.
-            if ((y_dominant && diff.y() > 0) || (!y_dominant && diff.x() < 0)) {
-                dist = -dist;
-            }
-
-            double value = pWidget->getValue();
-            // For legacy (MIDI) reasons this is tuned to 127.
-            value += dist / 127.0;
             QCursor::setPos(m_startPos);
-
-            // Clamp to [0.0, 1.0]
-            value = math_max(0.0, math_min(1.0, value));
-
-            pWidget->onConnectedControlValueChanged(value);
+            double value = valueFromMouseEvent(pWidget, e);
             pWidget->setConnectedControlLeftDown(value);
             pWidget->update();
         }
@@ -61,12 +64,15 @@ class KnobEventHandler {
     }
 
     void mouseReleaseEvent(T* pWidget, QMouseEvent* e) {
+        double value = 0.0;
         switch (e->button()) {
             case Qt::LeftButton:
             case Qt::MidButton:
                 QCursor::setPos(m_startPos);
                 QApplication::restoreOverrideCursor();
-                pWidget->setConnectedControlLeftUp(pWidget->getValue());
+                value = valueFromMouseEvent(pWidget, e);
+                pWidget->setConnectedControlLeftUp(value);
+                pWidget->update();
                 break;
             case Qt::RightButton:
                 m_bRightButtonPressed = false;
@@ -81,12 +87,11 @@ class KnobEventHandler {
     void wheelEvent(T* pWidget, QWheelEvent* e) {
         // For legacy (MIDI) reasons this is tuned to 127.
         double wheelDirection = e->delta() / (120.0 * 127.0);
-        double newValue = pWidget->getValue() + wheelDirection;
+        double newValue = pWidget->getConnectedControl() + wheelDirection;
 
         // Clamp to [0.0, 1.0]
         newValue = math_max(0.0, math_min(1.0, newValue));
 
-        pWidget->setValue(newValue);
         pWidget->setConnectedControlDown(newValue);
         pWidget->setConnectedControlUp(newValue);
         pWidget->update();

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -119,7 +119,7 @@ void WBaseWidget::addRightConnection(ControlWidgetConnection* pConnection) {
     m_rightConnections.append(pConnection);
 }
 
-double WBaseWidget::getConnectedControl() const {
+double WBaseWidget::getControlParameter() const {
     if (!m_leftConnections.isEmpty()) {
         return m_leftConnections.at(0)->getControlParameter();
     }
@@ -132,7 +132,7 @@ double WBaseWidget::getConnectedControl() const {
     return 0.0;
 }
 
-double WBaseWidget::getConnectedControlLeft() const {
+double WBaseWidget::getControlParameterLeft() const {
     if (!m_leftConnections.isEmpty()) {
         return m_leftConnections.at(0)->getControlParameter();
     }
@@ -142,7 +142,7 @@ double WBaseWidget::getConnectedControlLeft() const {
     return 0.0;
 }
 
-double WBaseWidget::getConnectedControlRight() const {
+double WBaseWidget::getControlParameterRight() const {
     if (!m_rightConnections.isEmpty()) {
         return m_rightConnections.at(0)->getControlParameter();
     }
@@ -152,14 +152,14 @@ double WBaseWidget::getConnectedControlRight() const {
     return 0.0;
 }
 
-double WBaseWidget::getConnectedDisplayValue() const {
+double WBaseWidget::getControlParameterDisplay() const {
     if (m_pDisplayConnection) {
         return m_pDisplayConnection->getControlParameter();
     }
     return 0.0;
 }
 
-void WBaseWidget::resetConnectedControls() {
+void WBaseWidget::resetControlParameters() {
     foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
         pControlConnection->reset();
     }
@@ -171,7 +171,7 @@ void WBaseWidget::resetConnectedControls() {
     }
 }
 
-void WBaseWidget::setConnectedControlDown(double v) {
+void WBaseWidget::setControlParameterDown(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
         pControlConnection->setControlParameterDown(v);
     }
@@ -183,7 +183,7 @@ void WBaseWidget::setConnectedControlDown(double v) {
     }
 }
 
-void WBaseWidget::setConnectedControlUp(double v) {
+void WBaseWidget::setControlParameterUp(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
         pControlConnection->setControlParameterUp(v);
     }
@@ -195,7 +195,7 @@ void WBaseWidget::setConnectedControlUp(double v) {
     }
 }
 
-void WBaseWidget::setConnectedControlLeftDown(double v) {
+void WBaseWidget::setControlParameterLeftDown(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
         pControlConnection->setControlParameterDown(v);
     }
@@ -204,7 +204,7 @@ void WBaseWidget::setConnectedControlLeftDown(double v) {
     }
 }
 
-void WBaseWidget::setConnectedControlLeftUp(double v) {
+void WBaseWidget::setControlParameterLeftUp(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
         pControlConnection->setControlParameterUp(v);
     }
@@ -213,7 +213,7 @@ void WBaseWidget::setConnectedControlLeftUp(double v) {
     }
 }
 
-void WBaseWidget::setConnectedControlRightDown(double v) {
+void WBaseWidget::setControlParameterRightDown(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
         pControlConnection->setControlParameterDown(v);
     }
@@ -222,7 +222,7 @@ void WBaseWidget::setConnectedControlRightDown(double v) {
     }
 }
 
-void WBaseWidget::setConnectedControlRightUp(double v) {
+void WBaseWidget::setControlParameterRightUp(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
         pControlConnection->setControlParameterUp(v);
     }

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -14,6 +14,10 @@ ControlWidgetConnection::ControlWidgetConnection(WBaseWidget* pBaseWidget,
 ControlWidgetConnection::~ControlWidgetConnection() {
 }
 
+double ControlWidgetConnection::get() const {
+    return m_pControl->get();
+}
+
 ValueControlWidgetConnection::ValueControlWidgetConnection(WBaseWidget* pBaseWidget,
                                                            ControlObjectSlave* pControl,
                                                            bool connectValueFromWidget,
@@ -88,10 +92,15 @@ void DisabledControlWidgetConnection::setUp(double v) {
 
 WBaseWidget::WBaseWidget(QWidget* pWidget)
         : m_pWidget(pWidget),
-          m_bDisabled(false) {
+          m_bDisabled(false),
+          m_pDisplayConnection(NULL) {
 }
 
 WBaseWidget::~WBaseWidget() {
+}
+
+void WBaseWidget::setDisplayConnection(ControlWidgetConnection* pConnection) {
+    m_pDisplayConnection = pConnection;
 }
 
 void WBaseWidget::addConnection(ControlWidgetConnection* pConnection) {
@@ -104,6 +113,46 @@ void WBaseWidget::addLeftConnection(ControlWidgetConnection* pConnection) {
 
 void WBaseWidget::addRightConnection(ControlWidgetConnection* pConnection) {
     m_rightConnections.append(pConnection);
+}
+
+double WBaseWidget::getConnectedControl() const {
+    if (!m_leftConnections.isEmpty()) {
+        return m_leftConnections[0]->get();
+    }
+    if (!m_rightConnections.isEmpty()) {
+        return m_rightConnections[0]->get();
+    }
+    if (!m_connections.isEmpty()) {
+        return m_connections[0]->get();
+    }
+    return 0.0;
+}
+
+double WBaseWidget::getConnectedControlLeft() const {
+    if (!m_leftConnections.isEmpty()) {
+        return m_leftConnections[0]->get();
+    }
+    if (!m_connections.isEmpty()) {
+        return m_connections[0]->get();
+    }
+    return 0.0;
+}
+
+double WBaseWidget::getConnectedControlRight() const {
+    if (!m_rightConnections.isEmpty()) {
+        return m_rightConnections[0]->get();
+    }
+    if (!m_connections.isEmpty()) {
+        return m_connections[0]->get();
+    }
+    return 0.0;
+}
+
+double WBaseWidget::getConnectedDisplayValue() const {
+    if (m_pDisplayConnection) {
+        return m_pDisplayConnection->get();
+    }
+    return 0.0;
 }
 
 void WBaseWidget::resetConnectedControls() {
@@ -119,12 +168,24 @@ void WBaseWidget::resetConnectedControls() {
 }
 
 void WBaseWidget::setConnectedControlDown(double v) {
+    foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
+        pControlConnection->setDown(v);
+    }
+    foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
+        pControlConnection->setDown(v);
+    }
     foreach (ControlWidgetConnection* pControlConnection, m_connections) {
         pControlConnection->setDown(v);
     }
 }
 
 void WBaseWidget::setConnectedControlUp(double v) {
+    foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
+        pControlConnection->setUp(v);
+    }
+    foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
+        pControlConnection->setUp(v);
+    }
     foreach (ControlWidgetConnection* pControlConnection, m_connections) {
         pControlConnection->setUp(v);
     }
@@ -134,26 +195,34 @@ void WBaseWidget::setConnectedControlLeftDown(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
         pControlConnection->setDown(v);
     }
-    setConnectedControlDown(v);
+    foreach (ControlWidgetConnection* pControlConnection, m_connections) {
+        pControlConnection->setDown(v);
+    }
 }
 
 void WBaseWidget::setConnectedControlLeftUp(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
         pControlConnection->setUp(v);
     }
-    setConnectedControlUp(v);
+    foreach (ControlWidgetConnection* pControlConnection, m_connections) {
+        pControlConnection->setUp(v);
+    }
 }
 
 void WBaseWidget::setConnectedControlRightDown(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
         pControlConnection->setDown(v);
     }
-    setConnectedControlDown(v);
+    foreach (ControlWidgetConnection* pControlConnection, m_connections) {
+        pControlConnection->setDown(v);
+    }
 }
 
 void WBaseWidget::setConnectedControlRightUp(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
         pControlConnection->setUp(v);
     }
-    setConnectedControlUp(v);
+    foreach (ControlWidgetConnection* pControlConnection, m_connections) {
+        pControlConnection->setUp(v);
+    }
 }

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -48,7 +48,7 @@ void ValueControlWidgetConnection::slotControlValueChanged(double v) {
     }
 }
 
-void ValueControlWidgetConnection::reset() {
+void ValueControlWidgetConnection::resetControl() {
     if (m_bConnectValueFromWidget) {
         m_pControl->reset();
     }
@@ -80,7 +80,7 @@ void DisabledControlWidgetConnection::slotControlValueChanged(double v) {
     m_pWidget->toQWidget()->update();
 }
 
-void DisabledControlWidgetConnection::reset() {
+void DisabledControlWidgetConnection::resetControl() {
     // Do nothing.
 }
 
@@ -171,13 +171,13 @@ double WBaseWidget::getControlParameterDisplay() const {
 
 void WBaseWidget::resetControlParameters() {
     foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
-        pControlConnection->reset();
+        pControlConnection->resetControl();
     }
     foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
-        pControlConnection->reset();
+        pControlConnection->resetControl();
     }
     foreach (ControlWidgetConnection* pControlConnection, m_connections) {
-        pControlConnection->reset();
+        pControlConnection->resetControl();
     }
 }
 

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -163,7 +163,7 @@ double WBaseWidget::getControlParameterRight() const {
 }
 
 double WBaseWidget::getControlParameterDisplay() const {
-    if (m_pDisplayConnection) {
+    if (m_pDisplayConnection != NULL) {
         return m_pDisplayConnection->getControlParameter();
     }
     return 0.0;

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -16,16 +16,6 @@ ControlWidgetConnection::ControlWidgetConnection(WBaseWidget* pBaseWidget,
 }
 
 ControlWidgetConnection::~ControlWidgetConnection() {
-    m_pDisplayConnection = NULL;
-    while (!m_leftConnections.isEmpty()) {
-        delete m_leftConnections.takeLast();
-    }
-    while (!m_rightConnections.isEmpty()) {
-        delete m_rightConnections.takeLast();
-    }
-    while (!m_connections.isEmpty()) {
-        delete m_connections.takeLast();
-    }
 }
 
 double ControlWidgetConnection::getControlParameter() const {
@@ -111,6 +101,16 @@ WBaseWidget::WBaseWidget(QWidget* pWidget)
 }
 
 WBaseWidget::~WBaseWidget() {
+    m_pDisplayConnection = NULL;
+    while (!m_leftConnections.isEmpty()) {
+        delete m_leftConnections.takeLast();
+    }
+    while (!m_rightConnections.isEmpty()) {
+        delete m_rightConnections.takeLast();
+    }
+    while (!m_connections.isEmpty()) {
+        delete m_connections.takeLast();
+    }
 }
 
 void WBaseWidget::setDisplayConnection(ControlWidgetConnection* pConnection) {

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -18,8 +18,8 @@ ControlWidgetConnection::ControlWidgetConnection(WBaseWidget* pBaseWidget,
 ControlWidgetConnection::~ControlWidgetConnection() {
 }
 
-double ControlWidgetConnection::get() const {
-    return m_pControl->get();
+double ControlWidgetConnection::getControlParameter() const {
+    return m_pControl->getParameter();
 }
 
 ValueControlWidgetConnection::ValueControlWidgetConnection(WBaseWidget* pBaseWidget,
@@ -54,13 +54,13 @@ void ValueControlWidgetConnection::reset() {
     }
 }
 
-void ValueControlWidgetConnection::setDown(double v) {
+void ValueControlWidgetConnection::setControlParameterDown(double v) {
     if (m_bConnectValueFromWidget && m_emitOption & EMIT_ON_PRESS) {
         m_pControl->setParameter(v);
     }
 }
 
-void ValueControlWidgetConnection::setUp(double v) {
+void ValueControlWidgetConnection::setControlParameterUp(double v) {
     if (m_bConnectValueFromWidget && m_emitOption & EMIT_ON_RELEASE) {
         m_pControl->setParameter(v);
     }
@@ -84,12 +84,12 @@ void DisabledControlWidgetConnection::reset() {
     // Do nothing.
 }
 
-void DisabledControlWidgetConnection::setDown(double v) {
+void DisabledControlWidgetConnection::setControlParameterDown(double v) {
     // Do nothing.
     Q_UNUSED(v);
 }
 
-void DisabledControlWidgetConnection::setUp(double v) {
+void DisabledControlWidgetConnection::setControlParameterUp(double v) {
     // Do nothing.
     Q_UNUSED(v);
 }
@@ -121,40 +121,40 @@ void WBaseWidget::addRightConnection(ControlWidgetConnection* pConnection) {
 
 double WBaseWidget::getConnectedControl() const {
     if (!m_leftConnections.isEmpty()) {
-        return m_leftConnections[0]->get();
+        return m_leftConnections.at(0)->getControlParameter();
     }
     if (!m_rightConnections.isEmpty()) {
-        return m_rightConnections[0]->get();
+        return m_rightConnections.at(0)->getControlParameter();
     }
     if (!m_connections.isEmpty()) {
-        return m_connections[0]->get();
+        return m_connections.at(0)->getControlParameter();
     }
     return 0.0;
 }
 
 double WBaseWidget::getConnectedControlLeft() const {
     if (!m_leftConnections.isEmpty()) {
-        return m_leftConnections[0]->get();
+        return m_leftConnections.at(0)->getControlParameter();
     }
     if (!m_connections.isEmpty()) {
-        return m_connections[0]->get();
+        return m_connections.at(0)->getControlParameter();
     }
     return 0.0;
 }
 
 double WBaseWidget::getConnectedControlRight() const {
     if (!m_rightConnections.isEmpty()) {
-        return m_rightConnections[0]->get();
+        return m_rightConnections.at(0)->getControlParameter();
     }
     if (!m_connections.isEmpty()) {
-        return m_connections[0]->get();
+        return m_connections.at(0)->getControlParameter();
     }
     return 0.0;
 }
 
 double WBaseWidget::getConnectedDisplayValue() const {
     if (m_pDisplayConnection) {
-        return m_pDisplayConnection->get();
+        return m_pDisplayConnection->getControlParameter();
     }
     return 0.0;
 }
@@ -173,60 +173,60 @@ void WBaseWidget::resetConnectedControls() {
 
 void WBaseWidget::setConnectedControlDown(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
-        pControlConnection->setDown(v);
+        pControlConnection->setControlParameterDown(v);
     }
     foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
-        pControlConnection->setDown(v);
+        pControlConnection->setControlParameterDown(v);
     }
     foreach (ControlWidgetConnection* pControlConnection, m_connections) {
-        pControlConnection->setDown(v);
+        pControlConnection->setControlParameterDown(v);
     }
 }
 
 void WBaseWidget::setConnectedControlUp(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
-        pControlConnection->setUp(v);
+        pControlConnection->setControlParameterUp(v);
     }
     foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
-        pControlConnection->setUp(v);
+        pControlConnection->setControlParameterUp(v);
     }
     foreach (ControlWidgetConnection* pControlConnection, m_connections) {
-        pControlConnection->setUp(v);
+        pControlConnection->setControlParameterUp(v);
     }
 }
 
 void WBaseWidget::setConnectedControlLeftDown(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
-        pControlConnection->setDown(v);
+        pControlConnection->setControlParameterDown(v);
     }
     foreach (ControlWidgetConnection* pControlConnection, m_connections) {
-        pControlConnection->setDown(v);
+        pControlConnection->setControlParameterDown(v);
     }
 }
 
 void WBaseWidget::setConnectedControlLeftUp(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
-        pControlConnection->setUp(v);
+        pControlConnection->setControlParameterUp(v);
     }
     foreach (ControlWidgetConnection* pControlConnection, m_connections) {
-        pControlConnection->setUp(v);
+        pControlConnection->setControlParameterUp(v);
     }
 }
 
 void WBaseWidget::setConnectedControlRightDown(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
-        pControlConnection->setDown(v);
+        pControlConnection->setControlParameterDown(v);
     }
     foreach (ControlWidgetConnection* pControlConnection, m_connections) {
-        pControlConnection->setDown(v);
+        pControlConnection->setControlParameterDown(v);
     }
 }
 
 void WBaseWidget::setConnectedControlRightUp(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
-        pControlConnection->setUp(v);
+        pControlConnection->setControlParameterUp(v);
     }
     foreach (ControlWidgetConnection* pControlConnection, m_connections) {
-        pControlConnection->setUp(v);
+        pControlConnection->setControlParameterUp(v);
     }
 }

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -16,6 +16,16 @@ ControlWidgetConnection::ControlWidgetConnection(WBaseWidget* pBaseWidget,
 }
 
 ControlWidgetConnection::~ControlWidgetConnection() {
+    m_pDisplayConnection = NULL;
+    while (!m_leftConnections.isEmpty()) {
+        delete m_leftConnections.takeLast();
+    }
+    while (!m_rightConnections.isEmpty()) {
+        delete m_rightConnections.takeLast();
+    }
+    while (!m_connections.isEmpty()) {
+        delete m_connections.takeLast();
+    }
 }
 
 double ControlWidgetConnection::getControlParameter() const {

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -8,6 +8,10 @@ ControlWidgetConnection::ControlWidgetConnection(WBaseWidget* pBaseWidget,
                                                  ControlObjectSlave* pControl)
         : m_pWidget(pBaseWidget),
           m_pControl(pControl) {
+    // If pControl is NULL then the creator of ControlWidgetConnection has
+    // screwed up badly enough that we should just crash. This will not go
+    // unnoticed in development.
+    Q_ASSERT(pControl);
     pControl->connectValueChanged(this, SLOT(slotControlValueChanged(double)));
 }
 

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -111,23 +111,23 @@ class WBaseWidget {
     void addConnection(ControlWidgetConnection* pConnection);
     void setDisplayConnection(ControlWidgetConnection* pConnection);
 
-    double getConnectedControl() const;
-    double getConnectedControlLeft() const;
-    double getConnectedControlRight() const;
-    double getConnectedDisplayValue() const;
+    double getControlParameter() const;
+    double getControlParameterLeft() const;
+    double getControlParameterRight() const;
+    double getControlParameterDisplay() const;
 
   protected:
     virtual void onConnectedControlValueChanged(double v) {
         Q_UNUSED(v);
     }
 
-    void resetConnectedControls();
-    void setConnectedControlDown(double v);
-    void setConnectedControlUp(double v);
-    void setConnectedControlLeftDown(double v);
-    void setConnectedControlLeftUp(double v);
-    void setConnectedControlRightDown(double v);
-    void setConnectedControlRightUp(double v);
+    void resetControlParameters();
+    void setControlParameterDown(double v);
+    void setControlParameterUp(double v);
+    void setControlParameterLeftDown(double v);
+    void setControlParameterLeftUp(double v);
+    void setControlParameterRightDown(double v);
+    void setControlParameterRightUp(double v);
 
   private:
     QWidget* m_pWidget;

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -28,7 +28,7 @@ class ControlWidgetConnection : public QObject {
 
     double getControlParameter() const;
 
-    virtual void reset() = 0;
+    virtual void resetControl() = 0;
     virtual void setControlParameterDown(double v) = 0;
     virtual void setControlParameterUp(double v) = 0;
 
@@ -51,7 +51,7 @@ class ValueControlWidgetConnection : public ControlWidgetConnection {
     virtual ~ValueControlWidgetConnection();
 
   protected:
-    void reset();
+    void resetControl();
     void setControlParameterDown(double v);
     void setControlParameterUp(double v);
 
@@ -72,7 +72,7 @@ class DisabledControlWidgetConnection : public ControlWidgetConnection {
     virtual ~DisabledControlWidgetConnection();
 
   protected:
-    void reset();
+    void resetControl();
     void setControlParameterDown(double v);
     void setControlParameterUp(double v);
 

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -109,6 +109,10 @@ class WBaseWidget {
     void addLeftConnection(ControlWidgetConnection* pConnection);
     void addRightConnection(ControlWidgetConnection* pConnection);
     void addConnection(ControlWidgetConnection* pConnection);
+
+    // Set a ControlWidgetConnection to be the display connection for the
+    // widget. The connection should also be added via an addConnection method
+    // or it will not be deleted or receive updates.
     void setDisplayConnection(ControlWidgetConnection* pConnection);
 
     double getControlParameter() const;

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -26,11 +26,11 @@ class ControlWidgetConnection : public QObject {
                             ControlObjectSlave* pControl);
     virtual ~ControlWidgetConnection();
 
-    double get() const;
+    double getControlParameter() const;
 
     virtual void reset() = 0;
-    virtual void setDown(double v) = 0;
-    virtual void setUp(double v) = 0;
+    virtual void setControlParameterDown(double v) = 0;
+    virtual void setControlParameterUp(double v) = 0;
 
   protected slots:
     virtual void slotControlValueChanged(double v) = 0;
@@ -52,8 +52,8 @@ class ValueControlWidgetConnection : public ControlWidgetConnection {
 
   protected:
     void reset();
-    void setDown(double v);
-    void setUp(double v);
+    void setControlParameterDown(double v);
+    void setControlParameterUp(double v);
 
   protected slots:
     void slotControlValueChanged(double v);
@@ -73,8 +73,8 @@ class DisabledControlWidgetConnection : public ControlWidgetConnection {
 
   protected:
     void reset();
-    void setDown(double v);
-    void setUp(double v);
+    void setControlParameterDown(double v);
+    void setControlParameterUp(double v);
 
   protected slots:
     void slotControlValueChanged(double v);

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -26,6 +26,8 @@ class ControlWidgetConnection : public QObject {
                             ControlObjectSlave* pControl);
     virtual ~ControlWidgetConnection();
 
+    double get() const;
+
     virtual void reset() = 0;
     virtual void setDown(double v) = 0;
     virtual void setUp(double v) = 0;
@@ -107,6 +109,12 @@ class WBaseWidget {
     void addLeftConnection(ControlWidgetConnection* pConnection);
     void addRightConnection(ControlWidgetConnection* pConnection);
     void addConnection(ControlWidgetConnection* pConnection);
+    void setDisplayConnection(ControlWidgetConnection* pConnection);
+
+    double getConnectedControl() const;
+    double getConnectedControlLeft() const;
+    double getConnectedControlRight() const;
+    double getConnectedDisplayValue() const;
 
   protected:
     virtual void onConnectedControlValueChanged(double v) {
@@ -126,6 +134,7 @@ class WBaseWidget {
     bool m_bDisabled;
     QString m_baseTooltip;
     QList<ControlWidgetConnection*> m_connections;
+    ControlWidgetConnection* m_pDisplayConnection;
     QList<ControlWidgetConnection*> m_leftConnections;
     QList<ControlWidgetConnection*> m_rightConnections;
 

--- a/src/widget/wdisplay.cpp
+++ b/src/widget/wdisplay.cpp
@@ -145,7 +145,7 @@ int WDisplay::getActivePixmapIndex() const {
     // Subtracting an epsilon prevents out of bound values at the end of the
     // range and biases the middle value towards the lower of the 2 center
     // pixmaps when there are an even number of pixmaps.
-    return static_cast<int>(getValue() * numPixmaps() - 0.00001);
+    return static_cast<int>(getConnectedDisplayValue() * numPixmaps() - 0.00001);
 }
 
 void WDisplay::paintEvent(QPaintEvent* ) {

--- a/src/widget/wdisplay.cpp
+++ b/src/widget/wdisplay.cpp
@@ -145,7 +145,7 @@ int WDisplay::getActivePixmapIndex() const {
     // Subtracting an epsilon prevents out of bound values at the end of the
     // range and biases the middle value towards the lower of the 2 center
     // pixmaps when there are an even number of pixmaps.
-    return static_cast<int>(getConnectedDisplayValue() * numPixmaps() - 0.00001);
+    return static_cast<int>(getControlParameterDisplay() * numPixmaps() - 0.00001);
 }
 
 void WDisplay::paintEvent(QPaintEvent* ) {

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -72,7 +72,7 @@ void WKnobComposed::paintEvent(QPaintEvent* e) {
         p.translate(width() / 2.0, height() / 2.0);
 
         // Value is in the range [0, 1].
-        double value = getValue();
+        double value = getConnectedDisplayValue();
 
         double angle = m_dMinAngle + (m_dMaxAngle - m_dMinAngle) * value;
         p.rotate(angle);

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -72,7 +72,7 @@ void WKnobComposed::paintEvent(QPaintEvent* e) {
         p.translate(width() / 2.0, height() / 2.0);
 
         // Value is in the range [0, 1].
-        double value = getConnectedDisplayValue();
+        double value = getControlParameterDisplay();
 
         double angle = m_dMinAngle + (m_dMaxAngle - m_dMinAngle) * value;
         p.rotate(angle);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -252,9 +252,9 @@ void WOverview::mouseReleaseEvent(QMouseEvent* e) {
     //qDebug() << "WOverview::mouseReleaseEvent" << e->pos() << m_iPos << ">>" << dValue;
 
     if (e->button() == Qt::RightButton) {
-        setConnectedControlRightUp(dValue);
+        setControlParameterRightUp(dValue);
     } else {
-        setConnectedControlLeftUp(dValue);
+        setControlParameterLeftUp(dValue);
     }
     m_bDrag = false;
 }

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -185,7 +185,7 @@ void WPushButton::paintEvent(QPaintEvent* e) {
     QStylePainter p(this);
     p.drawPrimitive(QStyle::PE_Widget, option);
 
-    double value = getConnectedDisplayValue();
+    double value = getControlParameterDisplay();
     if (m_iNoStates == 0) {
         return;
     }
@@ -223,12 +223,12 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
 
     if (leftPowerWindowStyle && m_iNoStates == 2) {
         if (leftClick) {
-            if (getConnectedControlLeft() == 0.0) {
+            if (getControlParameterLeft() == 0.0) {
                 m_clickTimer.setSingleShot(true);
                 m_clickTimer.start(ControlPushButtonBehavior::kPowerWindowTimeMillis);
             }
             m_bPressed = true;
-            setConnectedControlLeftDown(1.0);
+            setControlParameterLeftDown(1.0);
             update();
         }
         // discharge right clicks here, because is used for latching in POWERWINDOW mode
@@ -240,12 +240,12 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
         // due the leak of visual feedback we do not allow a toggle function
         if (m_bRightClickForcePush) {
             m_bPressed = true;
-            setConnectedControlRightDown(1.0);
+            setControlParameterRightDown(1.0);
             update();
         } else if (m_iNoStates == 1) {
             // This is a Pushbutton
             m_bPressed = true;
-            setConnectedControlRightDown(1.0);
+            setControlParameterRightDown(1.0);
             update();
         }
 
@@ -267,14 +267,14 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
             emitValue = 1.0;
         } else {
             // Toggle thru the states
-            emitValue = (int)(getConnectedControlLeft() + 1.0) % m_iNoStates;
+            emitValue = (int)(getControlParameterLeft() + 1.0) % m_iNoStates;
             if (leftLongPressLatchingStyle) {
                 m_clickTimer.setSingleShot(true);
                 m_clickTimer.start(ControlPushButtonBehavior::kLongPressLatchingTimeMillis);
             }
         }
         m_bPressed = true;
-        setConnectedControlLeftDown(emitValue);
+        setControlParameterLeftDown(emitValue);
         update();
     }
 }
@@ -296,7 +296,7 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
             const bool rightButtonDown = QApplication::mouseButtons() & Qt::RightButton;
             if (m_bPressed && !m_clickTimer.isActive() && !rightButtonDown) {
                 // Release button after timer, but not if right button is clicked
-                setConnectedControlLeftUp(0.0);
+                setControlParameterLeftUp(0.0);
             }
             m_bPressed = false;
         } else if (rightClick) {
@@ -312,18 +312,18 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
         // function
         if (m_bRightClickForcePush) {
             m_bPressed = false;
-            setConnectedControlRightUp(0.0);
+            setControlParameterRightUp(0.0);
             update();
         } else if (m_iNoStates == 1) {
             m_bPressed = false;
-            setConnectedControlRightUp(0.0);
+            setControlParameterRightUp(0.0);
             update();
         }
         return;
     }
 
     if (leftClick) {
-        double emitValue = getConnectedControlLeft();
+        double emitValue = getControlParameterLeft();
         if (m_bLeftClickForcePush) {
             // This may a klickButton with different functions on each mouse button
             // m_fValue is changed by a separate feedback connection
@@ -340,7 +340,7 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
             }
         }
         m_bPressed = false;
-        setConnectedControlLeftUp(emitValue);
+        setControlParameterLeftUp(emitValue);
         update();
     }
 }

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -267,7 +267,7 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
             emitValue = 1.0;
         } else {
             // Toggle thru the states
-            emitValue = (int)(getControlParameterLeft() + 1.0) % m_iNoStates;
+            emitValue = static_cast<int>(getControlParameterLeft() + 1.0) % m_iNoStates;
             if (leftLongPressLatchingStyle) {
                 m_clickTimer.setSingleShot(true);
                 m_clickTimer.start(ControlPushButtonBehavior::kLongPressLatchingTimeMillis);
@@ -334,7 +334,7 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
         } else {
             if (leftLongPressLatchingStyle && m_clickTimer.isActive() && emitValue >= 1.0) {
                 // revert toggle if button is released too early
-                emitValue = (int)(emitValue - 1.0) % m_iNoStates;
+                emitValue = static_cast<int>(emitValue - 1.0) % m_iNoStates;
             } else {
                 // Nothing special happens when releasing a normal toggle button
             }

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -262,6 +262,8 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
     if (leftClick) {
         double emitValue;
         if (m_bLeftClickForcePush || m_iNoStates == 1) {
+            // This is either forced to behave like a push button on left-click
+            // or this is a push button.
             emitValue = 1.0;
         } else {
             // Toggle thru the states

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -173,7 +173,7 @@ void WPushButton::setPixmapBackground(const QString &filename) {
 
 void WPushButton::onConnectedControlValueChanged(double v) {
     if (m_iNoStates == 1) {
-        m_bPressed = v == 1.0;
+        m_bPressed = (v == 1.0);
     }
     update();
 }

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -82,7 +82,7 @@ void WSliderComposed::setHandlePixmap(bool bHorizontal, const QString& filenameH
         m_iHandleLength = m_bHorizontal ?
                 m_pHandle->width() : m_pHandle->height();
 
-        onConnectedControlValueChanged(getConnectedControlLeft());
+        onConnectedControlValueChanged(getControlParameterLeft());
         update();
     }
 }
@@ -127,9 +127,9 @@ void WSliderComposed::mouseMoveEvent(QMouseEvent * e) {
         // Emit valueChanged signal
         if (m_bEventWhileDrag) {
             if (e->button() == Qt::RightButton) {
-                setConnectedControlRightUp(newValue);
+                setControlParameterRightUp(newValue);
             } else {
-                setConnectedControlLeftUp(newValue);
+                setControlParameterLeftUp(newValue);
             }
         }
 
@@ -141,13 +141,13 @@ void WSliderComposed::mouseMoveEvent(QMouseEvent * e) {
 void WSliderComposed::wheelEvent(QWheelEvent *e) {
     // For legacy (MIDI) reasons this is tuned to 127.
     double wheelDirection = ((QWheelEvent *)e)->delta() / (120.0 * 127.0);
-    double newValue = getConnectedControl() + wheelDirection;
+    double newValue = getControlParameter() + wheelDirection;
 
     // Clamp to [0.0, 1.0]
     newValue = math_max(0.0, math_min(1.0, newValue));
 
-    setConnectedControlDown(newValue);
-    setConnectedControlUp(newValue);
+    setControlParameterDown(newValue);
+    setControlParameterUp(newValue);
     update();
 
     e->accept();
@@ -160,9 +160,9 @@ void WSliderComposed::mouseReleaseEvent(QMouseEvent * e) {
         mouseMoveEvent(e);
 
         if (e->button() == Qt::RightButton) {
-            setConnectedControlRightUp(getConnectedControlRight());
+            setControlParameterRightUp(getControlParameterRight());
         } else {
-            setConnectedControlLeftUp(getConnectedControlLeft());
+            setControlParameterLeftUp(getControlParameterLeft());
         }
 
         m_bDrag = false;
@@ -180,7 +180,7 @@ void WSliderComposed::mousePressEvent(QMouseEvent * e) {
         m_bDrag = true;
     } else {
         if (e->button() == Qt::RightButton) {
-            resetConnectedControls();
+            resetControlParameters();
             m_bRightButtonPressed = true;
         } else {
             if (m_bHorizontal) {

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -55,6 +55,7 @@ public slots:
 private:
     void unsetPixmaps();
 
+    double m_dOldValue;
     // True if right mouse button is pressed.
     bool m_bRightButtonPressed;
     /** Internal storage of slider position in pixels */

--- a/src/widget/wstatuslight.cpp
+++ b/src/widget/wstatuslight.cpp
@@ -45,7 +45,6 @@ void WStatusLight::setNoPos(int iNoPos) {
         iNoPos = 2;
     }
     m_pixmaps.resize(iNoPos);
-    setValue(0.0);
 }
 
 void WStatusLight::setup(QDomNode node, const SkinContext& context) {

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -112,7 +112,6 @@ void WVuMeter::onConnectedControlValueChanged(double dValue) {
         idx = 0;
 
     setPeak(idx);
-    setValue(dValue);
 
     QTime currentTime = QTime::currentTime();
     int msecsElapsed = m_lastUpdate.msecsTo(currentTime);
@@ -159,7 +158,7 @@ void WVuMeter::paintEvent(QPaintEvent *) {
     }
 
     if (!m_pPixmapVu.isNull() && !m_pPixmapVu->isNull()) {
-        int idx = static_cast<int>(getValue() * m_iNoPos);
+        int idx = static_cast<int>(getConnectedDisplayValue() * m_iNoPos);
 
         // Range check
         if (idx > m_iNoPos)

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -158,7 +158,7 @@ void WVuMeter::paintEvent(QPaintEvent *) {
     }
 
     if (!m_pPixmapVu.isNull() && !m_pPixmapVu->isNull()) {
-        int idx = static_cast<int>(getConnectedDisplayValue() * m_iNoPos);
+        int idx = static_cast<int>(getControlParameterDisplay() * m_iNoPos);
 
         // Range check
         if (idx > m_iNoPos)

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -66,7 +66,7 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
         // If we are pitch-bending then disable and reset because the two
         // shouldn't be used at once.
         if (m_bBending) {
-            setConnectedControlRightDown(0.5);
+            setControlParameterRightDown(0.5);
             m_bBending = false;
         }
         m_bScratching = true;
@@ -81,7 +81,7 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
             m_pScratchPositionEnable->slotSet(0.0f);
             m_bScratching = false;
         }
-        setConnectedControlRightDown(0.5);
+        setControlParameterRightDown(0.5);
         m_bBending = true;
     }
 
@@ -109,7 +109,7 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
         double v = 0.5 + (diff.x() / 1270.0);
         // clamp to [0.0, 1.0]
         v = math_min(1.0, math_max(0.0, v));
-        setConnectedControlRightDown(v);
+        setControlParameterRightDown(v);
     }
 }
 
@@ -119,7 +119,7 @@ void WWaveformViewer::mouseReleaseEvent(QMouseEvent* /*event*/) {
         m_bScratching = false;
     }
     if (m_bBending) {
-        setConnectedControlRightDown(0.5);
+        setControlParameterRightDown(0.5);
         m_bBending = false;
     }
     m_mouseAnchor = QPoint();

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -21,8 +21,7 @@
 
 WWidget::WWidget(QWidget* parent, Qt::WindowFlags flags)
         : QWidget(parent, flags),
-          WBaseWidget(this),
-          m_value(0.0) {
+          WBaseWidget(this) {
     setAttribute(Qt::WA_StaticContents);
     setFocusPolicy(Qt::ClickFocus);
 }
@@ -31,6 +30,6 @@ WWidget::~WWidget() {
 }
 
 void WWidget::onConnectedControlValueChanged(double value) {
-    m_value = value;
+    Q_UNUSED(value);
     update();
 }

--- a/src/widget/wwidget.h
+++ b/src/widget/wwidget.h
@@ -42,7 +42,7 @@ public:
     virtual ~WWidget();
 
     Q_PROPERTY(bool controlDisabled READ controlDisabled);
-    Q_PROPERTY(double value READ getConnectedDisplayValue);
+    Q_PROPERTY(double value READ getControlParameterDisplay);
 
     virtual void onConnectedControlValueChanged(double value);
 };

--- a/src/widget/wwidget.h
+++ b/src/widget/wwidget.h
@@ -42,21 +42,9 @@ public:
     virtual ~WWidget();
 
     Q_PROPERTY(bool controlDisabled READ controlDisabled);
-    Q_PROPERTY(double value READ getValue);
-
-    double getValue() const {
-        return m_value;
-    }
-
-    void setValue(double value) {
-        m_value = value;
-    }
+    Q_PROPERTY(double value READ getConnectedDisplayValue);
 
     virtual void onConnectedControlValueChanged(double value);
-
-  private:
-    // Value/state of widget
-    double m_value;
 };
 
 #endif


### PR DESCRIPTION
- WWidget no longer stores a value independent of its connected controls.
- Make a connection explicitly the display value. For legacy reasons this is the
  last connection with connectValueToWidget.
- Update all WWidget descendents to use the connected display value when
  painting.
- Push buttons update the left or right connected control for push-button
  behavior or toggling.

This allows WPushButton to toggle a multi-state button on left and right
click. This was previously impossible.
