### PR TITLE
Use ControlObjectSlave for widget connections.

### DIFF
--- a/src/controlobjectslave.cpp
+++ b/src/controlobjectslave.cpp
@@ -6,29 +6,21 @@
 
 ControlObjectSlave::ControlObjectSlave(QObject* pParent)
         : QObject(pParent),
-          m_pControl(NULL),
-          m_bHasValueListener(false),
-          m_bHasParameterListener(false) {
+          m_pControl(NULL) {
 }
 
 ControlObjectSlave::ControlObjectSlave(const QString& g, const QString& i, QObject* pParent)
-        : QObject(pParent),
-          m_bHasValueListener(false),
-          m_bHasParameterListener(false) {
+        : QObject(pParent) {
     initialize(ConfigKey(g, i));
 }
 
 ControlObjectSlave::ControlObjectSlave(const char* g, const char* i, QObject* pParent)
-        : QObject(pParent),
-          m_bHasValueListener(false),
-          m_bHasParameterListener(false) {
+        : QObject(pParent) {
     initialize(ConfigKey(g, i));
 }
 
 ControlObjectSlave::ControlObjectSlave(const ConfigKey& key, QObject* pParent)
-        : QObject(pParent),
-          m_bHasValueListener(false),
-          m_bHasParameterListener(false) {
+        : QObject(pParent) {
     initialize(key);
 }
 
@@ -45,7 +37,6 @@ bool ControlObjectSlave::connectValueChanged(const QObject* receiver,
     if (m_pControl) {
         ret = connect((QObject*)this, SIGNAL(valueChanged(double)),
                       receiver, method, type);
-        m_bHasValueListener = true;
         if (ret) {
             // Connect to ControlObjectPrivate only if required. Do not allow
             // duplicate connections.
@@ -61,30 +52,6 @@ bool ControlObjectSlave::connectValueChanged(const QObject* receiver,
 bool ControlObjectSlave::connectValueChanged(
         const char* method, Qt::ConnectionType type) {
     return connectValueChanged(parent(), method, type);
-}
-
-bool ControlObjectSlave::connectParameterChanged(const QObject* receiver,
-        const char* method, Qt::ConnectionType type) {
-    bool ret = false;
-    if (m_pControl) {
-        ret = connect((QObject*)this, SIGNAL(parameterChanged(double)),
-                      receiver, method, type);
-        m_bHasParameterListener = true;
-        if (ret) {
-            // Connect to ControlObjectPrivate only if required. Do not allow
-            // duplicate connections.
-            connect(m_pControl.data(), SIGNAL(valueChanged(double, QObject*)),
-                    this, SLOT(slotValueChanged(double, QObject*)),
-                    static_cast<Qt::ConnectionType>(Qt::DirectConnection |
-                                                    Qt::UniqueConnection));
-        }
-    }
-    return ret;
-}
-
-bool ControlObjectSlave::connectParameterChanged(
-        const char* method, Qt::ConnectionType type) {
-    return connectParameterChanged(parent(), method, type);
 }
 
 double ControlObjectSlave::get() {
@@ -126,18 +93,9 @@ void ControlObjectSlave::emitValueChanged() {
     emit(valueChanged(get()));
 }
 
-void ControlObjectSlave::emitParameterChanged() {
-    emit(parameterChanged(getParameter()));
-}
-
 void ControlObjectSlave::slotValueChanged(double v, QObject* pSetter) {
     if (pSetter != this) {
-        if (m_bHasValueListener) {
-            // This is base implementation of this function without scaling
-            emit(valueChanged(v));
-        }
-        if (m_bHasParameterListener) {
-            emit(parameterChanged(getParameter()));
-        }
+        // This is base implementation of this function without scaling
+        emit(valueChanged(v));
     }
 }

--- a/src/controlobjectslave.h
+++ b/src/controlobjectslave.h
@@ -30,28 +30,42 @@ class ControlObjectSlave : public QObject {
     bool connectValueChanged(
             const char* method, Qt::ConnectionType type = Qt::AutoConnection );
 
+    bool connectParameterChanged(const QObject* receiver,
+            const char* method, Qt::ConnectionType type = Qt::AutoConnection);
+    bool connectParameterChanged(
+            const char* method, Qt::ConnectionType type = Qt::AutoConnection );
 
     // Called from update();
     void emitValueChanged();
+    void emitParameterChanged();
 
     inline bool valid() const { return m_pControl != NULL; }
 
     // Returns the value of the object. Thread safe, non-blocking.
     virtual double get();
 
+    // Returns the parameterized value of the object. Thread safe, non-blocking.
+    virtual double getParameter();
+
   public slots:
     // Set the control to a new value. Non-blocking.
     virtual void slotSet(double v);
     // Sets the control value to v. Thread safe, non-blocking.
     virtual void set(double v);
+    // Sets the control parameterized value to v. Thread safe, non-blocking.
+    virtual void setParameter(double v);
     // Resets the control to its default value. Thread safe, non-blocking.
     virtual void reset();
 
   signals:
-    // This signal must not connected by connect()
-    // Use connectValueChanged() instead. It will connect
-    // to the base ControlDoublePrivate as well
+    // This signal must not connected by connect(). Use connectValueChanged()
+    // instead. It will connect to the base ControlDoublePrivate as well.
     void valueChanged(double);
+
+    // This signal must not be connected by connect(). Use
+    // connectParameterChanged() instead. It will connect to the base
+    // ControlDoublePrivate as well.
+    void parameterChanged(double);
 
   protected slots:
     // Receives the value from the master control and re-emits either
@@ -61,6 +75,10 @@ class ControlObjectSlave : public QObject {
   protected:
     // Pointer to connected control.
     QSharedPointer<ControlDoublePrivate> m_pControl;
+
+  private:
+    bool m_bHasValueListener;
+    bool m_bHasParameterListener;
 };
 
 #endif // CONTROLOBJECTSLAVE_H

--- a/src/controlobjectslave.h
+++ b/src/controlobjectslave.h
@@ -30,14 +30,8 @@ class ControlObjectSlave : public QObject {
     bool connectValueChanged(
             const char* method, Qt::ConnectionType type = Qt::AutoConnection );
 
-    bool connectParameterChanged(const QObject* receiver,
-            const char* method, Qt::ConnectionType type = Qt::AutoConnection);
-    bool connectParameterChanged(
-            const char* method, Qt::ConnectionType type = Qt::AutoConnection );
-
     // Called from update();
     void emitValueChanged();
-    void emitParameterChanged();
 
     inline bool valid() const { return m_pControl != NULL; }
 
@@ -62,11 +56,6 @@ class ControlObjectSlave : public QObject {
     // instead. It will connect to the base ControlDoublePrivate as well.
     void valueChanged(double);
 
-    // This signal must not be connected by connect(). Use
-    // connectParameterChanged() instead. It will connect to the base
-    // ControlDoublePrivate as well.
-    void parameterChanged(double);
-
   protected slots:
     // Receives the value from the master control and re-emits either
     // valueChanged(double) or valueChangedByThis(double) based on pSetter.
@@ -75,10 +64,6 @@ class ControlObjectSlave : public QObject {
   protected:
     // Pointer to connected control.
     QSharedPointer<ControlDoublePrivate> m_pControl;
-
-  private:
-    bool m_bHasValueListener;
-    bool m_bHasParameterListener;
 };
 
 #endif // CONTROLOBJECTSLAVE_H

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -15,7 +15,7 @@
 
 #include "controlobject.h"
 #include "controlobjectthreadmain.h"
-#include "controlobjectthreadwidget.h"
+#include "controlobjectslave.h"
 
 #include "mixxxkeyboard.h"
 #include "playermanager.h"
@@ -731,7 +731,7 @@ QWidget* LegacySkinParser::parseVisual(QDomElement node) {
     viewer->installEventFilter(m_pControllerManager->getControllerLearningEventFilter());
 
     // Connect control proxy to widget, so delete can be handled by the QT object tree
-    ControlObjectThreadWidget* p = new ControlObjectThreadWidget(
+    ControlObjectSlave* p = new ControlObjectSlave(
             channelStr, "wheel", viewer);
     ControlWidgetConnection* pConnection = new ValueControlWidgetConnection(
         viewer, p, true, false, ControlWidgetConnection::EMIT_ON_PRESS);
@@ -1622,9 +1622,9 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
             // leaked. OnOff controls do not use the value of the widget at all
             // so we do not give this control's info to the
             // ControllerLearningEventFilter.
-            ControlObjectThreadWidget* pControlWidget =
-                    new ControlObjectThreadWidget(control->getKey(),
-                                                  pWidget->toQWidget());
+            ControlObjectSlave* pControlWidget =
+                    new ControlObjectSlave(control->getKey(),
+                                           pWidget->toQWidget());
             ControlWidgetConnection* pConnection =
                     new DisabledControlWidgetConnection(pWidget,
                                                         pControlWidget);
@@ -1655,7 +1655,7 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
 
             // Connect control proxy to widget. Parented to pWidget so it is not
             // leaked.
-            ControlObjectThreadWidget* pControlWidget = new ControlObjectThreadWidget(
+            ControlObjectSlave* pControlWidget = new ControlObjectSlave(
                 control->getKey(), pWidget->toQWidget());
             ControlWidgetConnection* pConnection = new ValueControlWidgetConnection(
                 pWidget, pControlWidget, connectValueFromWidget,

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -8,7 +8,7 @@ ControlWidgetConnection::ControlWidgetConnection(WBaseWidget* pBaseWidget,
                                                  ControlObjectSlave* pControl)
         : m_pWidget(pBaseWidget),
           m_pControl(pControl) {
-    pControl->connectParameterChanged(this, SLOT(slotControlValueChanged(double)));
+    pControl->connectValueChanged(this, SLOT(slotControlValueChanged(double)));
 }
 
 ControlWidgetConnection::~ControlWidgetConnection() {
@@ -32,8 +32,10 @@ ValueControlWidgetConnection::~ValueControlWidgetConnection() {
 }
 
 void ValueControlWidgetConnection::slotControlValueChanged(double v) {
+    // The widget system processes widget parameterized values, not values.
+    Q_UNUSED(v);
     if (m_bConnectValueToWidget) {
-        m_pWidget->onConnectedControlValueChanged(v);
+        m_pWidget->onConnectedControlValueChanged(m_pControl->getParameter());
         // TODO(rryan): copied from WWidget. Keep?
         //m_pWidget->toQWidget()->update();
     }
@@ -67,7 +69,9 @@ DisabledControlWidgetConnection::~DisabledControlWidgetConnection() {
 }
 
 void DisabledControlWidgetConnection::slotControlValueChanged(double v) {
-    m_pWidget->setControlDisabled(v != 0.0);
+    // The widget system processes widget parameterized values, not values.
+    Q_UNUSED(v);
+    m_pWidget->setControlDisabled(m_pControl->getParameter() != 0.0);
     m_pWidget->toQWidget()->update();
 }
 

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -2,21 +2,20 @@
 
 #include "widget/wbasewidget.h"
 
-#include "controlobjectthreadwidget.h"
+#include "controlobjectslave.h"
 
 ControlWidgetConnection::ControlWidgetConnection(WBaseWidget* pBaseWidget,
-                                                 ControlObjectThreadWidget* pControl)
+                                                 ControlObjectSlave* pControl)
         : m_pWidget(pBaseWidget),
           m_pControl(pControl) {
-    connect(pControl, SIGNAL(valueChanged(double)),
-            this, SLOT(slotControlValueChanged(double)));
+    pControl->connectParameterChanged(this, SLOT(slotControlValueChanged(double)));
 }
 
 ControlWidgetConnection::~ControlWidgetConnection() {
 }
 
 ValueControlWidgetConnection::ValueControlWidgetConnection(WBaseWidget* pBaseWidget,
-                                                           ControlObjectThreadWidget* pControl,
+                                                           ControlObjectSlave* pControl,
                                                            bool connectValueFromWidget,
                                                            bool connectValueToWidget,
                                                            EmitOption emitOption)
@@ -25,7 +24,7 @@ ValueControlWidgetConnection::ValueControlWidgetConnection(WBaseWidget* pBaseWid
           m_bConnectValueToWidget(connectValueToWidget),
           m_emitOption(emitOption) {
     if (m_bConnectValueToWidget) {
-        slotControlValueChanged(m_pControl->get());
+        slotControlValueChanged(m_pControl->getParameter());
     }
 }
 
@@ -48,20 +47,20 @@ void ValueControlWidgetConnection::reset() {
 
 void ValueControlWidgetConnection::setDown(double v) {
     if (m_bConnectValueFromWidget && m_emitOption & EMIT_ON_PRESS) {
-        m_pControl->slotSet(v);
+        m_pControl->setParameter(v);
     }
 }
 
 void ValueControlWidgetConnection::setUp(double v) {
     if (m_bConnectValueFromWidget && m_emitOption & EMIT_ON_RELEASE) {
-        m_pControl->slotSet(v);
+        m_pControl->setParameter(v);
     }
 }
 
 DisabledControlWidgetConnection::DisabledControlWidgetConnection(WBaseWidget* pBaseWidget,
-                                                                 ControlObjectThreadWidget* pControl)
+                                                                 ControlObjectSlave* pControl)
         : ControlWidgetConnection(pBaseWidget, pControl) {
-    slotControlValueChanged(m_pControl->get());
+    slotControlValueChanged(m_pControl->getParameter());
 }
 
 DisabledControlWidgetConnection::~DisabledControlWidgetConnection() {

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -8,7 +8,7 @@
 #include <QScopedPointer>
 #include <QDomNode>
 
-class ControlObjectThreadWidget;
+class ControlObjectSlave;
 
 class WBaseWidget;
 class ControlWidgetConnection : public QObject {
@@ -23,7 +23,7 @@ class ControlWidgetConnection : public QObject {
 
     // Takes ownership of pControl.
     ControlWidgetConnection(WBaseWidget* pBaseWidget,
-                            ControlObjectThreadWidget* pControl);
+                            ControlObjectSlave* pControl);
     virtual ~ControlWidgetConnection();
 
     virtual void reset() = 0;
@@ -35,14 +35,14 @@ class ControlWidgetConnection : public QObject {
 
   protected:
     WBaseWidget* m_pWidget;
-    QScopedPointer<ControlObjectThreadWidget> m_pControl;
+    QScopedPointer<ControlObjectSlave> m_pControl;
 };
 
 class ValueControlWidgetConnection : public ControlWidgetConnection {
     Q_OBJECT
   public:
     ValueControlWidgetConnection(WBaseWidget* pBaseWidget,
-                                 ControlObjectThreadWidget* pControl,
+                                 ControlObjectSlave* pControl,
                                  bool connectValueFromWidget,
                                  bool connectValueToWidget,
                                  EmitOption emitOption);
@@ -66,7 +66,7 @@ class DisabledControlWidgetConnection : public ControlWidgetConnection {
     Q_OBJECT
   public:
     DisabledControlWidgetConnection(WBaseWidget* pBaseWidget,
-                                    ControlObjectThreadWidget* pControl);
+                                    ControlObjectSlave* pControl);
     virtual ~DisabledControlWidgetConnection();
 
   protected:

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -18,7 +18,7 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
 
     m_pShowTrackTimeRemaining = new ControlObjectThread(
             "[Controls]", "ShowDurationRemaining");
-    connect(m_pShowTrackTimeRemaining, SIGNAL(valueChanged(double)),
+    m_pShowTrackTimeRemaining->connectValueChanged(
             this, SLOT(slotSetRemain(double)));
     slotSetRemain(m_pShowTrackTimeRemaining->get());
 
@@ -28,21 +28,23 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
     // which is normalized from 0 to 1.  As a result, the
     // <Connection> parameter is no longer necessary in skin definitions, but
     // leaving it in is harmless.
-    m_pVisualPlaypos = new ControlObjectThreadMain(group, "playposition");
-    connect(m_pVisualPlaypos, SIGNAL(valueChanged(double)), this, SLOT(slotSetValue(double)));
+    m_pVisualPlaypos = new ControlObjectThread(group, "playposition");
+    m_pVisualPlaypos->connectValueChanged(this, SLOT(slotSetValue(double)));
 
-    m_pTrackSamples = new ControlObjectThreadMain(
+    m_pTrackSamples = new ControlObjectThread(
             group, "track_samples");
-    connect(m_pTrackSamples, SIGNAL(valueChanged(double)),
+    m_pTrackSamples->connectValueChanged(
             this, SLOT(slotSetTrackSamples(double)));
+
     // Tell the CO to re-emit its value since we could be created after it was
     // set to a valid value.
     m_pTrackSamples->emitValueChanged();
 
-    m_pTrackSampleRate = new ControlObjectThreadMain(
+    m_pTrackSampleRate = new ControlObjectThread(
             group, "track_samplerate");
-    connect(m_pTrackSampleRate, SIGNAL(valueChanged(double)),
+    m_pTrackSampleRate->connectValueChanged(
             this, SLOT(slotSetTrackSampleRate(double)));
+
     // Tell the CO to re-emit its value since we could be created after it was
     // set to a valid value.
     m_pTrackSampleRate->emitValueChanged();


### PR DESCRIPTION
After this we can delete ControlObjectThreadMain and ControlObjectThreadWidget since they are unused.
