### PR TITLE
Eliminate misleading precision in the bpm and rate displays

### DIFF
--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -63,6 +63,7 @@ VinylControlXwax::VinylControlXwax(ConfigObject<ConfigValue>* pConfig, QString g
           m_iPitchRingSize(0),
           m_iPitchRingPos(0),
           m_iPitchRingFilled(0),
+          m_dDisplayPitch(0.0),
           m_pSteadySubtle(new SteadyPitch(0.12)),
           m_pSteadyGross(new SteadyPitch(0.5)),
           m_bCDControl(false),
@@ -573,8 +574,26 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
 
         controlScratch->slotSet(averagePitch + dDriftControl);
         if (m_iPosition != -1 && reportedPlayButton && uiUpdateTime(filePosition)) {
-            rateSlider->slotSet(rateDir->get() *
-                                (fabs(averagePitch + dDriftControl) - 1.0) / rateRange->get());
+            double true_pitch = averagePitch + dDriftControl;
+            double pitch_diff_magnitude = fabs(true_pitch - m_dDisplayPitch);
+
+            // The true pitch can show a misleading amount of variance --
+            // differences of .1% or less can show up as 1 or 2 bpm changes.
+            // Therefore we react slowly to bpm changes to show a more steady
+            // number to the user.
+            if (pitch_diff_magnitude > 0.5) {
+                // For large changes in pitch (start/stop, usually), immediately
+                // update the display.
+                m_dDisplayPitch = true_pitch;
+            } else if (pitch_diff_magnitude > 0.005) {
+                // For medium changes in pitch, take 4 callback loops to
+                // converge on the correct amount.
+                m_dDisplayPitch += (true_pitch - m_dDisplayPitch) * .25;
+            } else {
+                // For extremely small changes, converge very slowly.
+                m_dDisplayPitch += (true_pitch - m_dDisplayPitch) * .01;
+            }
+            rateSlider->slotSet(rateDir->get() * (m_dDisplayPitch - 1.0) / rateRange->get());
             m_dUiUpdateTime = filePosition;
         }
 

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -575,23 +575,23 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
         controlScratch->slotSet(averagePitch + dDriftControl);
         if (m_iPosition != -1 && reportedPlayButton && uiUpdateTime(filePosition)) {
             double true_pitch = averagePitch + dDriftControl;
-            double pitch_diff_magnitude = fabs(true_pitch - m_dDisplayPitch);
+            double pitch_difference = true_pitch - m_dDisplayPitch;
 
             // The true pitch can show a misleading amount of variance --
             // differences of .1% or less can show up as 1 or 2 bpm changes.
             // Therefore we react slowly to bpm changes to show a more steady
             // number to the user.
-            if (pitch_diff_magnitude > 0.5) {
+            if (fabs(pitch_difference) > 0.5) {
                 // For large changes in pitch (start/stop, usually), immediately
                 // update the display.
                 m_dDisplayPitch = true_pitch;
-            } else if (pitch_diff_magnitude > 0.005) {
+            } else if (fabs(pitch_difference) > 0.005) {
                 // For medium changes in pitch, take 4 callback loops to
                 // converge on the correct amount.
-                m_dDisplayPitch += (true_pitch - m_dDisplayPitch) * .25;
+                m_dDisplayPitch += pitch_difference * .25;
             } else {
                 // For extremely small changes, converge very slowly.
-                m_dDisplayPitch += (true_pitch - m_dDisplayPitch) * .01;
+                m_dDisplayPitch += pitch_difference * .01;
             }
             rateSlider->slotSet(rateDir->get() * (m_dDisplayPitch - 1.0) / rateRange->get());
             m_dUiUpdateTime = filePosition;

--- a/src/vinylcontrol/vinylcontrolxwax.h
+++ b/src/vinylcontrol/vinylcontrolxwax.h
@@ -96,6 +96,8 @@ class VinylControlXwax : public VinylControl {
     // How much of the pitch ring buffer is "filled" versus empty (used before
     // it fills up completely).
     int m_iPitchRingFilled;
+    // A smoothed pitch value to show to the user.
+    double m_dDisplayPitch;
 
     // Steady pitch trackers.
     SteadyPitch* m_pSteadySubtle;

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -115,14 +115,14 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
     // we don't change the stretch at all.  Once the threshold has been crossed
     // we gradually stretch the waveform toward the new value.  This adds a small
     // amount of lag in the UI.
-    double rate_diff_magnitude = fabs(true_rate - m_rate);
-    if (rate_diff_magnitude > 1.0) {
+    double rate_difference = true_rate - m_rate;
+    if (fabs(rate_difference) > 1.0) {
         // If the difference is large, just immediately pop to the new value.
         m_rate = true_rate;
-    } else if (rate_diff_magnitude > 0.05) {
+    } else if (fabs(rate_difference) > 0.05) {
         // if the difference is small, converge slowly (10 updates to converge
         // on the new value).
-        m_rate += (true_rate - m_rate) * 0.1;
+        m_rate += rate_difference * 0.1;
     } // if the difference is even smaller, don't change the display.
 
     m_rateDir = m_pRateDirControlObject->get();

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -108,23 +108,8 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
         return;
     }
 
-    // Fetch parameters before rendering in order the display all sub-renderers with the same values
-    double true_rate = m_pRateControlObject->get();
-    // We don't keep the waveform perfectly synced to the actual pitch to avoid
-    // unnecessary stretching of the waveform display.  Within a certain variance
-    // we don't change the stretch at all.  Once the threshold has been crossed
-    // we gradually stretch the waveform toward the new value.  This adds a small
-    // amount of lag in the UI.
-    double rate_difference = true_rate - m_rate;
-    if (fabs(rate_difference) > 1.0) {
-        // If the difference is large, just immediately pop to the new value.
-        m_rate = true_rate;
-    } else if (fabs(rate_difference) > 0.05) {
-        // if the difference is small, converge slowly (10 updates to converge
-        // on the new value).
-        m_rate += rate_difference * 0.1;
-    } // if the difference is even smaller, don't change the display.
-
+    //Fetch parameters before rendering in order the display all sub-renderers with the same values
+    m_rate = m_pRateControlObject->get();
     m_rateDir = m_pRateDirControlObject->get();
     m_rateRange = m_pRateRangeControlObject->get();
     // This gain adjustment compensates for an arbitrary /2 gain chop in

--- a/src/widget/wnumber.cpp
+++ b/src/widget/wnumber.cpp
@@ -24,7 +24,7 @@
 
 WNumber::WNumber(QWidget* pParent)
         : WLabel(pParent),
-          m_iNoDigits(-1),
+          m_iNoDigits(1),
           m_dConstFactor(0.0) {
 }
 
@@ -34,10 +34,10 @@ WNumber::~WNumber() {
 void WNumber::setup(QDomNode node, const SkinContext& context) {
     WLabel::setup(node, context);
 
-    // Number of digits
-    // TODO(rryan): This has been unused for a long time yet our skins specify
-    // this value all over the place.
-    m_iNoDigits = context.selectInt(node, "NumberOfDigits");
+    // Number of digits after the decimal.
+    if (context.hasNode(node, "NumberOfDigits")) {
+        m_iNoDigits = context.selectInt(node, "NumberOfDigits");
+    }
 
     // Constant factor
     if (context.hasNode(node, "ConstFactor")) {
@@ -54,5 +54,5 @@ void WNumber::onConnectedControlValueChanged(double v) {
 void WNumber::setValue(double dValue) {
     double v = dValue + m_dConstFactor;
 
-    setText(QString(m_qsText).append(QString::number(v, 'f', 1)));
+    setText(QString(m_qsText).append(QString::number(v, 'f', m_iNoDigits)));
 }

--- a/src/widget/wnumber.cpp
+++ b/src/widget/wnumber.cpp
@@ -53,11 +53,6 @@ void WNumber::onConnectedControlValueChanged(double v) {
 
 void WNumber::setValue(double dValue) {
     double v = dValue + m_dConstFactor;
-    int d1 = (int)floor((v-floor(v))*10.);
-    int d2 = (int)floor((v-floor(v))*100.)%10;
 
-    setText(QString(m_qsText).append("%1.%2%3").arg(
-        QString("%1").arg(static_cast<int>(v), 3, 10),
-        QString("%1").arg(d1, 1, 10),
-        QString("%1").arg(d2, 1, 10)));
+    setText(QString(m_qsText).append(QString::number(v, 'f', 1)));
 }

--- a/src/widget/wnumber.cpp
+++ b/src/widget/wnumber.cpp
@@ -24,7 +24,7 @@
 
 WNumber::WNumber(QWidget* pParent)
         : WLabel(pParent),
-          m_iNoDigits(1),
+          m_iNoDigits(2),
           m_dConstFactor(0.0) {
 }
 

--- a/src/widget/wnumberrate.cpp
+++ b/src/widget/wnumberrate.cpp
@@ -49,5 +49,5 @@ void WNumberRate::setValue(double) {
     }
 
     setText(QString(m_qsText).append(sign)
-            .append("%1").arg(fabs(vsign)*100., 0, 'f', 2));
+            .append("%1").arg(fabs(vsign)*100., 0, 'f', 1));
 }

--- a/src/widget/wnumberrate.cpp
+++ b/src/widget/wnumberrate.cpp
@@ -49,5 +49,5 @@ void WNumberRate::setValue(double) {
     }
 
     setText(QString(m_qsText).append(sign)
-            .append("%1").arg(fabs(vsign)*100., 0, 'f', 1));
+            .append("%1").arg(fabs(vsign)*100., 0, 'f', m_iNoDigits));
 }


### PR DESCRIPTION
- Show only one decimal place for bpm and rate
- Waveform stretch reacts more slowly to small changes in rate.
- Vinyl control display bpm updates are much more sticky. (actual rate updates use true rate)
