### PR TITLE
Support mono outputs and inputs.

### DIFF
--- a/src/dlgprefsounditem.cpp
+++ b/src/dlgprefsounditem.cpp
@@ -110,6 +110,9 @@ void DlgPrefSoundItem::deviceChanged(int index) {
              channelsForType >= minChannelsForType; --channelsForType) {
             for (unsigned int i = 1; i + (channelsForType - 1) <= numChannels;
                  i += channelsForType) {
+                // Because QVariant supports QPoint natively we use a QPoint to
+                // store the channel info. x is the channel base and y is the
+                // channel count.
                 if (channelsForType == 1) {
                     channelComboBox->addItem(
                         QString(tr("Channel %1")).arg(i), QPoint(i - 1, channelsForType));
@@ -178,8 +181,11 @@ void DlgPrefSoundItem::writePath(SoundManagerConfig *config) const {
     if (device == NULL) {
         return;
     } // otherwise, this will have a valid audiopath
-    QPoint channelData = channelComboBox->itemData(channelComboBox->currentIndex()).toPoint();
+    QPoint channelData = channelComboBox->itemData(
+        channelComboBox->currentIndex()).toPoint();
 
+    // Because QVariant supports QPoint natively we use a QPoint to store the
+    // channel info. x is the channel base and y is the channel count.
     if (m_isInput) {
         config->addInput(
                 device->getInternalName(),
@@ -251,6 +257,8 @@ void DlgPrefSoundItem::setDevice(const QString &deviceName) {
  */
 void DlgPrefSoundItem::setChannel(unsigned int channelBase,
                                   unsigned int channels) {
+    // Because QVariant supports QPoint natively we use a QPoint to store the
+    // channel info. x is the channel base and y is the channel count.
     int index = channelComboBox->findData(QPoint(channelBase, channels));
     if (index != -1) {
         channelComboBox->setCurrentIndex(index);

--- a/src/dlgprefsounditem.h
+++ b/src/dlgprefsounditem.h
@@ -52,7 +52,7 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
   private:
     SoundDevice* getDevice() const; // if this returns NULL, we don't have a valid AudioPath
     void setDevice(const QString &deviceName);
-    void setChannel(unsigned int channel);
+    void setChannel(unsigned int channelBase, unsigned int channels);
     int hasSufficientChannels(const SoundDevice *device) const;
 
     AudioPathType m_type;
@@ -60,7 +60,9 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     QList<SoundDevice*> m_devices;
     bool m_isInput;
     QString m_savedDevice;
-    unsigned int m_savedChannel;
+    // Because QVariant supports QPoint natively we use a QPoint to store the
+    // channel info. x is the channel base and y is the channel count.
+    QPoint m_savedChannel;
 };
 
 #endif

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -141,7 +141,7 @@ void EngineDeck::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer, unsigne
         return;
     }
 
-    const unsigned int iChannels = AudioInput::channelsNeededForType(input.getType());
+    const unsigned int iChannels = input.getChannelGroup().getChannelCount();
 
     // Check that the number of mono frames doesn't exceed MAX_BUFFER_LEN/2
     // because thats our conversion buffer size.

--- a/src/engine/enginemicrophone.cpp
+++ b/src/engine/enginemicrophone.cpp
@@ -83,7 +83,6 @@ void EngineMicrophone::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
     unsigned int samplesToWrite = 0;
 
     if (iChannels == 1) {
-        qDebug() << "MIC IS MONO";
         // Do mono -> stereo conversion.
         for (unsigned int i = 0; i < nFrames; ++i) {
             m_pConversionBuffer[i*2 + 0] = pBuffer[i];
@@ -92,7 +91,6 @@ void EngineMicrophone::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
         pWriteBuffer = m_pConversionBuffer;
         samplesToWrite = nFrames * 2;
     } else if (iChannels == 2) {
-        qDebug() << "MIC IS STEREO";
         // Already in stereo. Use pBuffer as-is.
         pWriteBuffer = pBuffer;
         samplesToWrite = nFrames * iChannels;

--- a/src/engine/enginemicrophone.cpp
+++ b/src/engine/enginemicrophone.cpp
@@ -70,7 +70,7 @@ void EngineMicrophone::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
         return;
     }
 
-    const unsigned int iChannels = AudioInput::channelsNeededForType(input.getType());
+    const unsigned int iChannels = input.getChannelGroup().getChannelCount();
 
     // Check that the number of mono frames doesn't exceed MAX_BUFFER_LEN/2
     // because thats our conversion buffer size.
@@ -83,6 +83,7 @@ void EngineMicrophone::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
     unsigned int samplesToWrite = 0;
 
     if (iChannels == 1) {
+        qDebug() << "MIC IS MONO";
         // Do mono -> stereo conversion.
         for (unsigned int i = 0; i < nFrames; ++i) {
             m_pConversionBuffer[i*2 + 0] = pBuffer[i];
@@ -91,6 +92,7 @@ void EngineMicrophone::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
         pWriteBuffer = m_pConversionBuffer;
         samplesToWrite = nFrames * 2;
     } else if (iChannels == 2) {
+        qDebug() << "MIC IS STEREO";
         // Already in stereo. Use pBuffer as-is.
         pWriteBuffer = pBuffer;
         samplesToWrite = nFrames * iChannels;

--- a/src/engine/enginepassthrough.cpp
+++ b/src/engine/enginepassthrough.cpp
@@ -74,7 +74,7 @@ void EnginePassthrough::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
         return;
     }
 
-    const unsigned int iChannels = AudioInput::channelsNeededForType(input.getType());
+    const unsigned int iChannels = input.getChannelGroup().getChannelCount();
 
     // Check that the number of mono frames doesn't exceed MAX_BUFFER_LEN/2
     // because thats our conversion buffer size.

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -296,19 +296,19 @@ MixxxApp::MixxxApp(QApplication *pApp, const CmdlineArgs& args)
 
     EngineMicrophone* pMicrophone = new EngineMicrophone("[Microphone]");
     // What should channelbase be?
-    AudioInput micInput = AudioInput(AudioPath::MICROPHONE, 0, 0);
+    AudioInput micInput = AudioInput(AudioPath::MICROPHONE, 0, 0, 0);
     m_pEngine->addChannel(pMicrophone);
     m_pSoundManager->registerInput(micInput, pMicrophone);
 
     EnginePassthrough* pPassthrough1 = new EnginePassthrough("[Passthrough1]");
     // What should channelbase be?
-    AudioInput passthroughInput1 = AudioInput(AudioPath::EXTPASSTHROUGH, 0, 0);
+    AudioInput passthroughInput1 = AudioInput(AudioPath::EXTPASSTHROUGH, 0, 0, 0);
     m_pEngine->addChannel(pPassthrough1);
     m_pSoundManager->registerInput(passthroughInput1, pPassthrough1);
 
     EnginePassthrough* pPassthrough2 = new EnginePassthrough("[Passthrough2]");
     // What should channelbase be?
-    AudioInput passthroughInput2 = AudioInput(AudioPath::EXTPASSTHROUGH, 0, 1);
+    AudioInput passthroughInput2 = AudioInput(AudioPath::EXTPASSTHROUGH, 0, 0, 1);
     m_pEngine->addChannel(pPassthrough2);
     m_pSoundManager->registerInput(passthroughInput2, pPassthrough2);
 

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -54,12 +54,12 @@ PlayerManager::PlayerManager(ConfigObject<ConfigValue>* pConfig,
 
     // register the engine's outputs
     m_pSoundManager->registerOutput(AudioOutput(AudioOutput::MASTER),
-            m_pEngine);
+                                    m_pEngine);
     m_pSoundManager->registerOutput(AudioOutput(AudioOutput::HEADPHONES),
-            m_pEngine);
+                                    m_pEngine);
     for (int o = EngineChannel::LEFT; o <= EngineChannel::RIGHT; o++) {
-      m_pSoundManager->registerOutput(AudioOutput(AudioOutput::BUS, 0, o),
-                                      m_pEngine);
+        m_pSoundManager->registerOutput(AudioOutput(AudioOutput::BUS, 0, 0, o),
+                                        m_pEngine);
     }
 }
 
@@ -239,12 +239,12 @@ void PlayerManager::addDeckInner() {
 
     // Register the deck output with SoundManager (deck is 0-indexed to SoundManager)
     m_pSoundManager->registerOutput(
-        AudioOutput(AudioOutput::DECK, 0, number-1), m_pEngine);
+        AudioOutput(AudioOutput::DECK, 0, 0, number-1), m_pEngine);
 
     // Register vinyl input signal with deck for passthrough support.
     EngineDeck* pEngineDeck = pDeck->getEngineDeck();
     m_pSoundManager->registerInput(
-        AudioInput(AudioInput::VINYLCONTROL, 0, number-1), pEngineDeck);
+        AudioInput(AudioInput::VINYLCONTROL, 0, 0, number-1), pEngineDeck);
 }
 
 void PlayerManager::addSampler() {

--- a/src/soundmanager.cpp
+++ b/src/soundmanager.cpp
@@ -46,7 +46,8 @@ SoundManager::SoundManager(ConfigObject<ConfigValue> *pConfig,
           m_jackSampleRate(-1),
 #endif
           m_pClkRefDevice(NULL),
-          m_pErrorDevice(NULL) {
+          m_pErrorDevice(NULL),
+          m_pDownmixBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)) {
     // TODO(xxx) some of these ControlObject are not needed by soundmanager, or are unused here.
     // It is possible to take them out?
     m_pControlObjectSoundStatusCO = new ControlObject(ConfigKey("[SoundManager]", "status"));
@@ -69,6 +70,8 @@ SoundManager::SoundManager(ConfigObject<ConfigValue> *pConfig,
 }
 
 SoundManager::~SoundManager() {
+    SampleUtil::free(m_pDownmixBuffer);
+
     //Clean up devices.
     clearDeviceList();
 
@@ -478,11 +481,22 @@ void SoundManager::requestBuffer(
                  e = outputs.end(); i != e; ++i) {
         const AudioOutputBuffer& out = *i;
 
-        // buffer is always !NULL
-        const CSAMPLE* pAudioOutputBuffer = out.getBuffer();
         const ChannelGroup outChans = out.getChannelGroup();
         const int iChannelCount = outChans.getChannelCount();
         const int iChannelBase = outChans.getChannelBase();
+
+        // buffer is always !NULL
+        const CSAMPLE* pAudioOutputBuffer = out.getBuffer();
+
+        // All AudioOutputs are stereo as of Mixxx 1.12.0. If we have a mono
+        // output then we need to downsample.
+        if (iChannelCount == 1) {
+            for (int i = 0; i < iFramesPerBuffer; ++i) {
+                m_pDownmixBuffer[i] = (pAudioOutputBuffer[i*2] +
+                                       pAudioOutputBuffer[i*2 + 1]) / 2.0f;
+            }
+            pAudioOutputBuffer = m_pDownmixBuffer;
+        }
 
         for (unsigned int iFrameNo = 0; iFrameNo < iFramesPerBuffer; ++iFrameNo) {
             // iFrameBase is the "base sample" in a frame (ie. the first

--- a/src/soundmanager.h
+++ b/src/soundmanager.h
@@ -134,6 +134,7 @@ class SoundManager : public QObject {
     QHash<AudioInput, AudioDestination*> m_registeredDestinations;
     ControlObject* m_pControlObjectSoundStatusCO;
     ControlObject* m_pControlObjectVinylControlGainCO;
+    CSAMPLE* m_pDownmixBuffer;
 };
 
 #endif

--- a/src/soundmanagerutil.cpp
+++ b/src/soundmanagerutil.cpp
@@ -327,7 +327,7 @@ AudioOutput AudioOutput::fromXML(const QDomElement &xml) {
     // microphones and stereo for everything else since previously microphone
     // inputs were the only mono AudioPath.
     if (channels == 0) {
-        m_channels = type == MICROPHONE ? 1 : 2;
+        channels = type == MICROPHONE ? 1 : 2;
     }
     return AudioOutput(type, channel, channels, index);
 }
@@ -405,7 +405,7 @@ AudioInput AudioInput::fromXML(const QDomElement &xml) {
     // microphones and stereo for everything else since previously microphone
     // inputs were the only mono AudioPath.
     if (channels == 0) {
-        m_channels = type == MICROPHONE ? 1 : 2;
+        channels = type == MICROPHONE ? 1 : 2;
     }
     return AudioInput(type, channel, channels, index);
 }

--- a/src/soundmanagerutil.cpp
+++ b/src/soundmanagerutil.cpp
@@ -309,7 +309,7 @@ QDomElement AudioOutput::toXML(QDomElement *element) const {
     element->setAttribute("type", AudioPath::getStringFromType(m_type));
     element->setAttribute("index", m_index);
     element->setAttribute("channel", m_channelGroup.getChannelBase());
-    element->setAttribute("channels", m_channelGroup.getChannelCount());
+    element->setAttribute("channel_count", m_channelGroup.getChannelCount());
     return *element;
 }
 
@@ -321,7 +321,7 @@ AudioOutput AudioOutput::fromXML(const QDomElement &xml) {
     AudioPathType type(AudioPath::getTypeFromString(xml.attribute("type")));
     unsigned int index(xml.attribute("index", "0").toUInt());
     unsigned int channel(xml.attribute("channel", "0").toUInt());
-    unsigned int channels(xml.attribute("channels", "0").toUInt());
+    unsigned int channels(xml.attribute("channel_count", "0").toUInt());
     // In Mixxx <1.12.0 we didn't save channels to file since they directly
     // corresponded to the type. To migrate users over, use mono for all
     // microphones and stereo for everything else since previously microphone
@@ -387,7 +387,7 @@ QDomElement AudioInput::toXML(QDomElement *element) const {
     element->setAttribute("type", AudioPath::getStringFromType(m_type));
     element->setAttribute("index", m_index);
     element->setAttribute("channel", m_channelGroup.getChannelBase());
-    element->setAttribute("channels", m_channelGroup.getChannelCount());
+    element->setAttribute("channel_count", m_channelGroup.getChannelCount());
     return *element;
 }
 
@@ -399,7 +399,7 @@ AudioInput AudioInput::fromXML(const QDomElement &xml) {
     AudioPathType type(AudioPath::getTypeFromString(xml.attribute("type")));
     unsigned int index(xml.attribute("index", "0").toUInt());
     unsigned int channel(xml.attribute("channel", "0").toUInt());
-    unsigned int channels(xml.attribute("channels", "0").toUInt());
+    unsigned int channels(xml.attribute("channel_count", "0").toUInt());
     // In Mixxx <1.12.0 we didn't save channels to file since they directly
     // corresponded to the type. To migrate users over, use mono for all
     // microphones and stereo for everything else since previously microphone

--- a/src/soundmanagerutil.cpp
+++ b/src/soundmanagerutil.cpp
@@ -177,19 +177,19 @@ QString AudioPath::getTrStringFromType(AudioPathType type, unsigned char index) 
     case INVALID:
         // this shouldn't happen but g++ complains if I don't
         // handle this -- bkgood
-        return QString(QObject::tr("Invalid"));
+        return QObject::tr("Invalid");
     case MASTER:
-        return QString(QObject::tr("Master"));
+        return QObject::tr("Master");
     case HEADPHONES:
-        return QString(QObject::tr("Headphones"));
+        return QObject::tr("Headphones");
     case BUS:
         switch (index) {
         case EngineChannel::LEFT:
-            return QString(QObject::tr("Left Bus"));
+            return QObject::tr("Left Bus");
         case EngineChannel::CENTER:
-            return QString(QObject::tr("Center Bus"));
+            return QObject::tr("Center Bus");
         case EngineChannel::RIGHT:
-            return QString(QObject::tr("Right Bus"));
+            return QObject::tr("Right Bus");
         default:
             return QObject::tr("Invalid Bus");
         }
@@ -200,12 +200,12 @@ QString AudioPath::getTrStringFromType(AudioPathType type, unsigned char index) 
         return QString("%1 %2").arg(QObject::tr("Vinyl Control"),
                                     QString::number(index + 1));
     case MICROPHONE:
-        return QString(QObject::tr("Microphone"));
+        return QObject::tr("Microphone");
     case EXTPASSTHROUGH:
         return QString("%1 %2").arg(QObject::tr("Passthrough"),
                                     QString::number(index + 1));
     }
-    return QString(QObject::tr("Unknown path type %1")).arg(type);
+    return QObject::tr("Unknown path type %1").arg(type);
 }
 
 /**
@@ -283,10 +283,10 @@ unsigned char AudioPath::maxChannelsForType(AudioPathType type) {
 /**
  * Constructs an AudioOutput.
  */
-AudioOutput::AudioOutput(AudioPathType type /* = INVALID */,
-                         unsigned char channelBase /* = 0 */,
-                         unsigned char channels /* = 0 */,
-                         unsigned char index /* = 0 */)
+AudioOutput::AudioOutput(AudioPathType type,
+                         unsigned char channelBase,
+                         unsigned char channels,
+                         unsigned char index)
     : AudioPath(channelBase, channels) {
     setType(type);
     if (isIndexed(type)) {
@@ -361,10 +361,10 @@ void AudioOutput::setType(AudioPathType type) {
 /**
  * Constructs an AudioInput.
  */
-AudioInput::AudioInput(AudioPathType type /* = INVALID */,
-                       unsigned char channelBase /* = 0 */,
-                       unsigned char channels /* = 0 */,
-                       unsigned char index /* = 0 */)
+AudioInput::AudioInput(AudioPathType type,
+                       unsigned char channelBase,
+                       unsigned char channels,
+                       unsigned char index)
         : AudioPath(channelBase, channels) {
     setType(type);
     if (isIndexed(type)) {

--- a/src/soundmanagerutil.h
+++ b/src/soundmanagerutil.h
@@ -76,7 +76,15 @@ public:
     static AudioPathType getTypeFromString(QString string);
     static bool isIndexed(AudioPathType type);
     static AudioPathType getTypeFromInt(int typeInt);
-    static unsigned char channelsNeededForType(AudioPathType type);
+
+    // Returns the minimum number of channels needed on a sound device for an
+    // AudioPathType.
+    static unsigned char minChannelsForType(AudioPathType type);
+
+    // Returns the maximum number of channels needed on a sound device for an
+    // AudioPathType.
+    static unsigned char maxChannelsForType(AudioPathType type);
+
 protected:
     virtual void setType(AudioPathType type) = 0;
     AudioPathType m_type;
@@ -93,6 +101,7 @@ protected:
 class AudioOutput : public AudioPath {
   public:
     AudioOutput(AudioPathType type = INVALID, unsigned char channelBase = 0,
+                unsigned char channels = 0,
                 unsigned char index = 0);
     virtual ~AudioOutput();
     QDomElement toXML(QDomElement *element) const;
@@ -124,7 +133,7 @@ class AudioOutputBuffer : public AudioOutput {
 class AudioInput : public AudioPath {
   public:
     AudioInput(AudioPathType type = INVALID, unsigned char channelBase = 0,
-               unsigned char index = 0);
+               unsigned char channels = 0, unsigned char index = 0);
     virtual ~AudioInput();
     QDomElement toXML(QDomElement *element) const;
     static AudioInput fromXML(const QDomElement &xml);

--- a/src/test/enginemicrophonetest.cpp
+++ b/src/test/enginemicrophonetest.cpp
@@ -83,7 +83,7 @@ TEST_F(EngineMicrophoneTest, TestInputMatchesOutput) {
     FillBuffer<CSAMPLE>(input, 0.1f, inputLength);
     SampleUtil::applyGain(output, 0.0f, outputLength);
 
-    AudioInput micInput = AudioInput(AudioPath::MICROPHONE, 0, 0); // What should channelbase be?
+    AudioInput micInput = AudioInput(AudioPath::MICROPHONE, 0, 1, 0);
     m_pTalkover->set(1.0);
 
     m_pMicrophone->receiveBuffer(micInput, input, inputLength);
@@ -95,7 +95,7 @@ TEST_F(EngineMicrophoneTest, TestInputMatchesOutput) {
 
 TEST_F(EngineMicrophoneTest, TestTalkoverDisablesOutput) {
     SampleUtil::applyGain(output, 0.0f, outputLength);
-    AudioInput micInput = AudioInput(AudioPath::MICROPHONE, 0, 0); // What should channelbase be?
+    AudioInput micInput = AudioInput(AudioPath::MICROPHONE, 0, 1, 0);
 
     m_pTalkover->set(0.0);
     FillBuffer<CSAMPLE>(input, 0.1f, inputLength);
@@ -116,7 +116,7 @@ TEST_F(EngineMicrophoneTest, TestTalkoverDisablesOutput) {
 
 TEST_F(EngineMicrophoneTest, TestRepeatedInputMatchesOutput) {
     SampleUtil::applyGain(output, 0.0f, outputLength);
-    AudioInput micInput = AudioInput(AudioPath::MICROPHONE, 0, 0); // What should channelbase be?
+    AudioInput micInput = AudioInput(AudioPath::MICROPHONE, 0, 1, 0);
     m_pTalkover->set(1.0);
 
     for (int i = 0; i < 10; i++) {

--- a/src/vinylcontrol/vinylcontrolmanager.cpp
+++ b/src/vinylcontrol/vinylcontrolmanager.cpp
@@ -29,7 +29,7 @@ VinylControlManager::VinylControlManager(QObject* pParent,
     // VinylControlProcessor.
     for (int i = 0; i < kMaximumVinylControlInputs; ++i) {
         pSoundManager->registerInput(
-            AudioInput(AudioInput::VINYLCONTROL, 0, i), m_pProcessor);
+            AudioInput(AudioInput::VINYLCONTROL, 0, 0, i), m_pProcessor);
     }
 }
 


### PR DESCRIPTION
- Support selecting mono outputs and inputs in Sound Hardware preferences.
- Microphone can accept stereo or mono input now.
- Vinyl control (and consequently deck passthrough) does not support mono.

Tested with a stereo built-in mic on the Vinyl Control passthrough, auxilliary
passthrough, and microphone inputs.

I think PortAudio, CoreAudio, or my hardware has a bug when a single output
channel is enabled. The sound Mixxx emits to Channel 1 can be heard faintly in
Channel 2 even if we have only opened Channel 1 for output. If we have only
opened one channel for output there should be no possible way Mixxx could cause
audio to be heard in Channel 2 so this suggests it is not a Mixxx bug.

Fixes Bug #681689.
