### PR TITLE
Add option to persist control values.

### DIFF
--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -43,7 +43,7 @@ ControlDoublePrivate::ControlDoublePrivate(ConfigKey key,
 void ControlDoublePrivate::initialize() {
     double value = 0;
     if (m_bPersistInConfiguration) {
-        ConfigObject<ConfigValue>* pConfig = ControlDoublePrivate::getUserConfig();
+        ConfigObject<ConfigValue>* pConfig = ControlDoublePrivate::s_pUserConfig;
         if (pConfig != NULL) {
             bool ok = false;
             double configValue = pConfig->getValueString(m_key).toDouble(&ok);
@@ -70,7 +70,7 @@ ControlDoublePrivate::~ControlDoublePrivate() {
     s_qCOHashMutex.unlock();
 
     if (m_bPersistInConfiguration) {
-        ConfigObject<ConfigValue>* pConfig = ControlDoublePrivate::getUserConfig();
+        ConfigObject<ConfigValue>* pConfig = ControlDoublePrivate::s_pUserConfig;
         if (pConfig != NULL) {
             pConfig->set(m_key, QString::number(get()));
         }

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -45,11 +45,8 @@ void ControlDoublePrivate::initialize() {
     if (m_bPersistInConfiguration) {
         ConfigObject<ConfigValue>* pConfig = ControlDoublePrivate::s_pUserConfig;
         if (pConfig != NULL) {
-            bool ok = false;
-            double configValue = pConfig->getValueString(m_key).toDouble(&ok);
-            if (ok) {
-                value = configValue;
-            }
+            // Assume toDouble() returns 0 if conversion fails.
+            value = pConfig->getValueString(m_key).toDouble();
         }
     }
     m_defaultValue.setValue(0);

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -116,13 +116,6 @@ class ControlDoublePrivate : public QObject {
     void valueChangeRequest(double value);
 
   private:
-    // Used to implement control persistence. Do not make public -- we don't
-    // want this to turn into a way to get the configuration object from
-    // anywhere in Mixxx.
-    static ConfigObject<ConfigValue>* getUserConfig() {
-        return s_pUserConfig;
-    }
-
     ControlDoublePrivate(ConfigKey key, ControlObject* pCreatorCO,
                          bool bIgnoreNops, bool bTrack, bool bPersist);
     void initialize();

--- a/src/controlobject.cpp
+++ b/src/controlobject.cpp
@@ -28,9 +28,9 @@
 ControlObject::ControlObject() {
 }
 
-ControlObject::ControlObject(ConfigKey key, bool bIgnoreNops, bool bTrack)
+ControlObject::ControlObject(ConfigKey key, bool bIgnoreNops, bool bTrack, bool bPersist)
         : m_pControl(NULL) {
-    initialize(key, bIgnoreNops, bTrack);
+    initialize(key, bIgnoreNops, bTrack, bPersist);
 }
 
 ControlObject::~ControlObject() {
@@ -39,9 +39,12 @@ ControlObject::~ControlObject() {
     }
 }
 
-void ControlObject::initialize(ConfigKey key, bool bIgnoreNops, bool bTrack) {
+void ControlObject::initialize(ConfigKey key, bool bIgnoreNops, bool bTrack,
+                               bool bPersist) {
     m_key = key;
-    m_pControl = ControlDoublePrivate::getControl(m_key, true, this, bIgnoreNops, bTrack);
+    m_pControl = ControlDoublePrivate::getControl(m_key, true, this,
+                                                  bIgnoreNops, bTrack,
+                                                  bPersist);
     connect(m_pControl.data(), SIGNAL(valueChanged(double, QObject*)),
             this, SLOT(privateValueChanged(double, QObject*)),
             Qt::DirectConnection);

--- a/src/controlobject.h
+++ b/src/controlobject.h
@@ -31,7 +31,8 @@ class ControlObject : public QObject {
   public:
     ControlObject();
     ControlObject(ConfigKey key,
-                  bool bIgnoreNops=true, bool bTrack=false);
+                  bool bIgnoreNops=true, bool bTrack=false,
+                  bool bPersist=false);
     virtual ~ControlObject();
 
     // Returns a pointer to the ControlObject matching the given ConfigKey
@@ -113,7 +114,8 @@ class ControlObject : public QObject {
     void privateValueChanged(double value, QObject* pSetter);
 
   private:
-    void initialize(ConfigKey key, bool bIgnoreNops, bool bTrack);
+    void initialize(ConfigKey key, bool bIgnoreNops, bool bTrack,
+                    bool bPersist);
     inline bool ignoreNops() const {
         return m_pControl ? m_pControl->ignoreNops() : true;
     }

--- a/src/controlpushbutton.cpp
+++ b/src/controlpushbutton.cpp
@@ -21,8 +21,8 @@
    Purpose: Creates a new simulated latching push-button.
    Input:   key - Key for the configuration file
    -------- ------------------------------------------------------ */
-ControlPushButton::ControlPushButton(ConfigKey key)
-        : ControlObject(key, false),
+ControlPushButton::ControlPushButton(ConfigKey key, bool bPersist)
+        : ControlObject(key, false, false, bPersist),
           m_buttonMode(PUSH),
           m_iNoStates(2) {
     if (m_pControl) {
@@ -59,4 +59,3 @@ void ControlPushButton::setStates(int num_states) {
                             m_iNoStates));
     }
 }
-

--- a/src/controlpushbutton.h
+++ b/src/controlpushbutton.h
@@ -51,7 +51,7 @@ class ControlPushButton : public ControlObject {
         }
     }
 
-    ControlPushButton(ConfigKey key);
+    ControlPushButton(ConfigKey key, bool bPersist=false);
     virtual ~ControlPushButton();
 
     inline ButtonMode getButtonMode() const {

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -265,6 +265,7 @@ MixxxApp::MixxxApp(QApplication *pApp, const CmdlineArgs& args)
     // after an upgrade and make any needed changes.
     Upgrade upgrader;
     m_pConfig = upgrader.versionUpgrade(args.getSettingsPath());
+    ControlDoublePrivate::setUserConfig(m_pConfig);
 
     QString resourcePath = m_pConfig->getResourcePath();
 
@@ -637,6 +638,7 @@ MixxxApp::~MixxxApp() {
     delete m_pPrefDlg;
 
     qDebug() << "delete config " << qTime.elapsed();
+    ControlDoublePrivate::setUserConfig(NULL);
     delete m_pConfig;
 
     PlayerInfo::destroy();

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -65,8 +65,9 @@ using mixxx::skin::SkinManifest;
 QList<const char*> LegacySkinParser::s_channelStrs;
 QMutex LegacySkinParser::s_safeStringMutex;
 
-ControlObject* controlFromConfigKey(ConfigKey configKey, bool* created) {
-    ControlObject* pControl = ControlObject::getControl(configKey);
+ControlObject* controlFromConfigKey(ConfigKey key, bool bPersist,
+                                    bool* created) {
+    ControlObject* pControl = ControlObject::getControl(key);
 
     if (pControl) {
         if (created) {
@@ -77,16 +78,32 @@ ControlObject* controlFromConfigKey(ConfigKey configKey, bool* created) {
 
     // TODO(rryan): Make this configurable by the skin.
     qWarning() << "Requested control does not exist:"
-               << QString("%1,%2").arg(configKey.group, configKey.item)
+               << QString("%1,%2").arg(key.group, key.item)
                << "Creating it.";
     // Since the usual behavior here is to create a skin-defined push
     // button, actually make it a push button and set it to toggle.
-    ControlPushButton* controlButton = new ControlPushButton(configKey);
+    ControlPushButton* controlButton = new ControlPushButton(key, bPersist);
     controlButton->setButtonMode(ControlPushButton::TOGGLE);
     if (created) {
         *created = true;
     }
     return controlButton;
+}
+
+ControlObject* LegacySkinParser::controlFromConfigNode(QDomElement element,
+                                                       const QString& nodeName,
+                                                       bool* created) {
+    if (element.isNull() || !m_pContext->hasNode(element, nodeName)) {
+        return NULL;
+    }
+
+    QDomElement keyElement = m_pContext->selectElement(element, nodeName);
+    QString name = m_pContext->nodeToString(keyElement);
+    ConfigKey key = ConfigKey::parseCommaSeparated(name);
+
+    bool bPersist = m_pContext->selectAttributeBool(keyElement, "persist", false);
+
+    return controlFromConfigKey(key, bPersist, created);
 }
 
 LegacySkinParser::LegacySkinParser(ConfigObject<ConfigValue>* pConfig,
@@ -510,21 +527,13 @@ QWidget* LegacySkinParser::parseWidgetGroup(QDomElement node) {
 }
 
 QWidget* LegacySkinParser::parseWidgetStack(QDomElement node) {
-    ControlObject* pNextControl = NULL;
-    QString nextControl = m_pContext->selectString(node, "NextControl");
     bool createdNext = false;
-    if (nextControl.length() > 0) {
-        ConfigKey nextConfigKey = ConfigKey::parseCommaSeparated(nextControl);
-        pNextControl = controlFromConfigKey(nextConfigKey, &createdNext);
-    }
+    ControlObject* pNextControl = controlFromConfigNode(
+            node.toElement(), "NextControl", &createdNext);
 
-    ControlObject* pPrevControl = NULL;
     bool createdPrev = false;
-    QString prevControl = m_pContext->selectString(node, "PrevControl");
-    if (prevControl.length() > 0) {
-        ConfigKey prevConfigKey = ConfigKey::parseCommaSeparated(prevControl);
-        pPrevControl = controlFromConfigKey(prevConfigKey, &createdPrev);
-    }
+    ControlObject* pPrevControl = controlFromConfigNode(
+            node.toElement(), "PrevControl", &createdPrev);
 
     WWidgetStack* pStack = new WWidgetStack(m_pParent, pNextControl, pPrevControl);
     pStack->setObjectName("WidgetStack");
@@ -580,7 +589,9 @@ QWidget* LegacySkinParser::parseWidgetStack(QDomElement node) {
             if (trigger_configkey.length() > 0) {
                 ConfigKey configKey = ConfigKey::parseCommaSeparated(trigger_configkey);
                 bool created;
-                pControl = controlFromConfigKey(configKey, &created);
+                // TODO(rryan): Allow persist enabling. Not sure what the best
+                // option is -- need to think about it.
+                pControl = controlFromConfigKey(configKey, false, &created);
                 if (created) {
                     // If we created the control, parent it to the child widget so
                     // it doesn't leak.
@@ -1450,16 +1461,11 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
     ControlWidgetConnection* pLastLeftOrNoButtonConnection = NULL;
     ControlWidgetConnection* pLastRightButtonConnection = NULL;
 
-    while (!con.isNull())
-    {
-        // Get ConfigKey
-        QString key = m_pContext->selectString(con, "ConfigKey");
-
-        ConfigKey configKey = ConfigKey::parseCommaSeparated(key);
-
+    while (!con.isNull()) {
         // Check that the control exists
         bool created = false;
-        ControlObject* control = controlFromConfigKey(configKey, &created);
+        ControlObject* control = controlFromConfigNode(
+                con.toElement(), "ConfigKey", &created);
 
         if (m_pContext->hasNode(con, "BindProperty")) {
             QString property = m_pContext->selectString(con, "BindProperty");
@@ -1471,7 +1477,7 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
 
             ControlWidgetConnection* pConnection =
                     new ControlWidgetPropertyConnection(pWidget, pControlWidget,
-                                                        m_pConfig, property);
+                                                        property);
             pWidget->addConnection(pConnection);
 
             // If we created this control, bind it to the
@@ -1551,6 +1557,9 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
 
             // Add keyboard shortcut info to tooltip string
             if (connectValueFromWidget) {
+                QString key = m_pContext->selectString(con, "ConfigKey");
+                ConfigKey configKey = ConfigKey::parseCommaSeparated(key);
+
                 // do not add Shortcut string for feedback connections
                 QString shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(configKey);
                 addShortcutToToolTip(pWidget, shortcut, QString(""));

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -20,6 +20,7 @@ class PlayerManager;
 class ControllerManager;
 class SkinContext;
 class WLabel;
+class ControlObject;
 
 class LegacySkinParser : public QObject, public SkinParser {
     Q_OBJECT
@@ -99,6 +100,9 @@ class LegacySkinParser : public QObject, public SkinParser {
 
     QString lookupNodeGroup(QDomElement node);
     static const char* safeChannelString(QString channelStr);
+    ControlObject* controlFromConfigNode(QDomElement element,
+                                         const QString& nodeName,
+                                         bool* created);
 
     ConfigObject<ConfigValue>* m_pConfig;
     MixxxKeyboard* m_pKeyboard;

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -119,6 +119,16 @@ bool SkinContext::selectBool(const QDomNode& node,
     return defaultValue;
 }
 
+bool SkinContext::selectAttributeBool(const QDomElement& element,
+                                      const QString& attributeName,
+                                      bool defaultValue) const {
+    if (element.hasAttribute(attributeName)) {
+        QString stringValue = element.attribute(attributeName);
+        return stringValue.contains("true", Qt::CaseInsensitive);
+    }
+    return defaultValue;
+}
+
 QString SkinContext::variableNodeToText(const QDomElement& variableNode) const {
     if (variableNode.hasAttribute("expression")) {
         QScriptValue result = m_scriptEngine.evaluate(

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -51,6 +51,9 @@ class SkinContext {
     double selectDouble(const QDomNode& node, const QString& nodeName) const;
     int selectInt(const QDomNode& node, const QString& nodeName) const;
     bool selectBool(const QDomNode& node, const QString& nodeName, bool defaultValue) const;
+    bool selectAttributeBool(const QDomElement& element,
+                             const QString& attributeName,
+                             bool defaultValue) const;
     QString nodeToString(const QDomNode& node) const;
 
   private:

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -78,20 +78,9 @@ void ControlParameterWidgetConnection::setControlParameterUp(double v) {
 
 ControlWidgetPropertyConnection::ControlWidgetPropertyConnection(WBaseWidget* pBaseWidget,
                                                                  ControlObjectSlave* pControl,
-                                                                 ConfigObject<ConfigValue>* pConfig,
                                                                  const QString& propertyName)
         : ControlWidgetConnection(pBaseWidget, pControl),
-          m_pConfig(pConfig),
           m_propertyName(propertyName.toAscii()) {
-    // Behavior copied from PropertyBinder: load config value for the control on
-    // creation.
-    // TODO(rryan): Remove this in favor of a better solution. See discussion on
-    // Bug #1091147.
-    bool ok = false;
-    double dValue = m_pConfig->getValueString(m_pControl->getKey()).toDouble(&ok);
-    if (ok) {
-        m_pControl->setParameter(dValue);
-    }
     slotControlValueChanged(m_pControl->get());
 }
 
@@ -114,12 +103,6 @@ void ControlWidgetPropertyConnection::slotControlValueChanged(double v) {
         qDebug() << "Setting property" << m_propertyName
                  << "to widget failed. Value:" << dParameter;
     }
-
-    // Behavior copied from PropertyBinder: save config value for the control on
-    // every change.
-    // TODO(rryan): Remove this in favor of a better solution. See discussion on
-    // Bug #1091147.
-    m_pConfig->set(m_pControl->getKey(), QString::number(dParameter));
 }
 
 void ControlWidgetPropertyConnection::resetControl() {

--- a/src/widget/controlwidgetconnection.h
+++ b/src/widget/controlwidgetconnection.h
@@ -6,8 +6,6 @@
 #include <QScopedPointer>
 #include <QByteArray>
 
-#include "configobject.h"
-
 class ControlObjectSlave;
 class WBaseWidget;
 
@@ -88,7 +86,6 @@ class ControlWidgetPropertyConnection : public ControlWidgetConnection {
   public:
     ControlWidgetPropertyConnection(WBaseWidget* pBaseWidget,
                                     ControlObjectSlave* pControl,
-                                    ConfigObject<ConfigValue>* pConfig,
                                     const QString& property);
     virtual ~ControlWidgetPropertyConnection();
 
@@ -103,10 +100,7 @@ class ControlWidgetPropertyConnection : public ControlWidgetConnection {
     void slotControlValueChanged(double v);
 
   private:
-    ConfigObject<ConfigValue>* m_pConfig;
     QByteArray m_propertyName;
 };
-
-
 
 #endif /* CONTROLWIDGETCONNECTION_H */


### PR DESCRIPTION
- Add support to persist a control value in the user configuration. 
- Allow skin-created controls to be marked persistent.
- Remove ControlWidgetPropertyConnection loading/saving of control values from config.

Fixes Bug #1190797.
