### PR TITLE
Add <Transform> support to <Connection> blocks in the skin.

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -838,6 +838,7 @@ class MixxxCore(Feature):
                    "util/performancetimer.cpp",
                    "util/version.cpp",
                    "util/rlimit.cpp",
+                   "util/valuetransformer.cpp",
 
                    '#res/mixxx.qrc'
                    ]

--- a/src/test/wpushbutton_test.cpp
+++ b/src/test/wpushbutton_test.cpp
@@ -38,7 +38,7 @@ TEST_F(WPushButtonTest, QuickPressNoLatchTest) {
     m_pButton->addLeftConnection(
         new ControlParameterWidgetConnection(
             m_pButton.data(),
-            new ControlObjectSlave(pPushControl->getKey()),
+            new ControlObjectSlave(pPushControl->getKey()), NULL,
             true, true, ControlWidgetConnection::EMIT_ON_PRESS_AND_RELEASE));
 
     m_Events.addMousePress(Qt::LeftButton);
@@ -60,7 +60,7 @@ TEST_F(WPushButtonTest, LongPressLatchTest) {
     m_pButton->addLeftConnection(
         new ControlParameterWidgetConnection(
             m_pButton.data(),
-            new ControlObjectSlave(pPushControl->getKey()),
+            new ControlObjectSlave(pPushControl->getKey()), NULL,
             true, true, ControlWidgetConnection::EMIT_ON_PRESS_AND_RELEASE));
 
     m_Events.addMousePress(Qt::LeftButton);

--- a/src/util/valuetransformer.cpp
+++ b/src/util/valuetransformer.cpp
@@ -1,0 +1,56 @@
+#include <QtDebug>
+
+#include "util/valuetransformer.h"
+
+ValueTransformer::ValueTransformer() {
+}
+
+void ValueTransformer::addTransformer(TransformNode* pTransformer) {
+    m_transformers.append(pTransformer);
+}
+
+double ValueTransformer::transform(double argument) const {
+    foreach (const TransformNode* pNode, m_transformers) {
+        argument = pNode->transform(argument);
+    }
+    return argument;
+}
+
+double ValueTransformer::transformInverse(double argument) const {
+    for (int i = m_transformers.size() - 1; i >= 0; --i) {
+        const TransformNode* pNode = m_transformers[i];
+        argument = pNode->transformInverse(argument);
+    }
+    return argument;
+}
+
+// static
+ValueTransformer* ValueTransformer::parseFromXml(QDomElement transformElement,
+                                                 const SkinContext& context) {
+    if (transformElement.isNull() || !transformElement.hasChildNodes()) {
+        return NULL;
+    }
+
+    ValueTransformer* pTransformer = new ValueTransformer();
+    QDomNodeList children = transformElement.childNodes();
+    for (int i = 0; i < children.count(); ++i) {
+        QDomNode node = children.at(i);
+        if (!node.isElement()) {
+            continue;
+        }
+
+        QDomElement element = node.toElement();
+        if (element.nodeName() == "Invert") {
+            pTransformer->addTransformer(new TransformInvert());
+        } else if (element.nodeName() == "Add") {
+            QString value = context.nodeToString(element);
+            bool ok = false;
+            double addend = value.toDouble(&ok);
+            if (ok) {
+                pTransformer->addTransformer(new TransformAdd(addend));
+            }
+        }
+    }
+
+    return pTransformer;
+}

--- a/src/util/valuetransformer.h
+++ b/src/util/valuetransformer.h
@@ -1,0 +1,62 @@
+#ifndef VALUETRANSFORMER_H
+#define VALUETRANSFORMER_H
+
+#include <QList>
+#include <QDomElement>
+
+#include "skin/skincontext.h"
+
+class TransformNode {
+  public:
+    TransformNode() {}
+
+    virtual double transform(double argument) const = 0;
+    virtual double transformInverse(double argument) const = 0;
+};
+
+class TransformAdd : public TransformNode {
+  public:
+    TransformAdd(double addend) : m_addend(addend) {}
+
+    double transform(double argument) const {
+        return argument + m_addend;
+    }
+
+    double transformInverse(double argument) const {
+        return argument - m_addend;
+    }
+
+  private:
+    double m_addend;
+};
+
+class TransformInvert : public TransformNode {
+  public:
+    TransformInvert() {}
+
+    double transform(double argument) const {
+        return -argument;
+    }
+
+    double transformInverse(double argument) const {
+        return -argument;
+    }
+};
+
+class ValueTransformer {
+  public:
+    double transform(double argument) const;
+    double transformInverse(double argument) const;
+
+    static ValueTransformer* parseFromXml(QDomElement transformElement,
+                                          const SkinContext& context);
+
+  private:
+    ValueTransformer();
+
+    void addTransformer(TransformNode* pTransformer);
+
+    QList<TransformNode*> m_transformers;
+};
+
+#endif /* VALUETRANSFORMER_H */

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -3,11 +3,14 @@
 #include "widget/wbasewidget.h"
 #include "controlobjectslave.h"
 #include "util/debug.h"
+#include "util/valuetransformer.h"
 
 ControlWidgetConnection::ControlWidgetConnection(WBaseWidget* pBaseWidget,
-                                                 ControlObjectSlave* pControl)
+                                                 ControlObjectSlave* pControl,
+                                                 ValueTransformer* pTransformer)
         : m_pWidget(pBaseWidget),
-          m_pControl(pControl) {
+          m_pControl(pControl),
+          m_pValueTransformer(pTransformer) {
     // If pControl is NULL then the creator of ControlWidgetConnection has
     // screwed up badly enough that we should just crash. This will not go
     // unnoticed in development.
@@ -18,16 +21,36 @@ ControlWidgetConnection::ControlWidgetConnection(WBaseWidget* pBaseWidget,
 ControlWidgetConnection::~ControlWidgetConnection() {
 }
 
+void ControlWidgetConnection::setControlParameter(double parameter) {
+    if (m_pValueTransformer != NULL) {
+        parameter = m_pValueTransformer->transformInverse(parameter);
+    }
+    m_pControl->setParameter(parameter);
+}
+
 double ControlWidgetConnection::getControlParameter() const {
-    return m_pControl->getParameter();
+    double parameter = m_pControl->getParameter();
+    if (m_pValueTransformer != NULL) {
+        parameter = m_pValueTransformer->transform(parameter);
+    }
+    return parameter;
+}
+
+double ControlWidgetConnection::getControlParameterForValue(double value) const {
+    double parameter = m_pControl->getParameterForValue(value);
+    if (m_pValueTransformer != NULL) {
+        parameter = m_pValueTransformer->transform(parameter);
+    }
+    return parameter;
 }
 
 ControlParameterWidgetConnection::ControlParameterWidgetConnection(WBaseWidget* pBaseWidget,
                                                                    ControlObjectSlave* pControl,
+                                                                   ValueTransformer* pTransformer,
                                                                    bool connectValueFromWidget,
                                                                    bool connectValueToWidget,
                                                                    EmitOption emitOption)
-        : ControlWidgetConnection(pBaseWidget, pControl),
+        : ControlWidgetConnection(pBaseWidget, pControl, pTransformer),
           m_bConnectValueFromWidget(connectValueFromWidget),
           m_bConnectValueToWidget(connectValueToWidget),
           m_emitOption(emitOption) {
@@ -51,8 +74,8 @@ QString ControlParameterWidgetConnection::toDebugString() const {
 
 void ControlParameterWidgetConnection::slotControlValueChanged(double v) {
     if (m_bConnectValueToWidget) {
-        m_pWidget->onConnectedControlValueChanged(
-                m_pControl->getParameterForValue(v));
+        double parameter = getControlParameterForValue(v);
+        m_pWidget->onConnectedControlValueChanged(parameter);
         // TODO(rryan): copied from WWidget. Keep?
         //m_pWidget->toQWidget()->update();
     }
@@ -66,21 +89,22 @@ void ControlParameterWidgetConnection::resetControl() {
 
 void ControlParameterWidgetConnection::setControlParameterDown(double v) {
     if (m_bConnectValueFromWidget && m_emitOption & EMIT_ON_PRESS) {
-        m_pControl->setParameter(v);
+        setControlParameter(v);
     }
 }
 
 void ControlParameterWidgetConnection::setControlParameterUp(double v) {
     if (m_bConnectValueFromWidget && m_emitOption & EMIT_ON_RELEASE) {
-        m_pControl->setParameter(v);
+        setControlParameter(v);
     }
 }
 
 ControlWidgetPropertyConnection::ControlWidgetPropertyConnection(WBaseWidget* pBaseWidget,
                                                                  ControlObjectSlave* pControl,
+                                                                 ValueTransformer* pTransformer,
                                                                  ConfigObject<ConfigValue>* pConfig,
                                                                  const QString& propertyName)
-        : ControlWidgetConnection(pBaseWidget, pControl),
+        : ControlWidgetConnection(pBaseWidget, pControl, pTransformer),
           m_pConfig(pConfig),
           m_propertyName(propertyName.toAscii()) {
     // Behavior copied from PropertyBinder: load config value for the control on
@@ -90,7 +114,7 @@ ControlWidgetPropertyConnection::ControlWidgetPropertyConnection(WBaseWidget* pB
     bool ok = false;
     double dValue = m_pConfig->getValueString(m_pControl->getKey()).toDouble(&ok);
     if (ok) {
-        m_pControl->setParameter(dValue);
+        setControlParameter(dValue);
     }
     slotControlValueChanged(m_pControl->get());
 }
@@ -107,7 +131,7 @@ QString ControlWidgetPropertyConnection::toDebugString() const {
 }
 
 void ControlWidgetPropertyConnection::slotControlValueChanged(double v) {
-    double dParameter = m_pControl->getParameterForValue(v);
+    double dParameter = getControlParameterForValue(v);
 
     if (!m_pWidget->toQWidget()->setProperty(m_propertyName.constData(),
                                              QVariant(dParameter))) {

--- a/src/widget/controlwidgetconnection.h
+++ b/src/widget/controlwidgetconnection.h
@@ -10,6 +10,7 @@
 
 class ControlObjectSlave;
 class WBaseWidget;
+class ValueTransformer;
 
 class ControlWidgetConnection : public QObject {
     Q_OBJECT
@@ -36,12 +37,15 @@ class ControlWidgetConnection : public QObject {
         }
     }
 
-    // Takes ownership of pControl.
+    // Takes ownership of pControl and pTransformer.
     ControlWidgetConnection(WBaseWidget* pBaseWidget,
-                            ControlObjectSlave* pControl);
+                            ControlObjectSlave* pControl,
+                            ValueTransformer* pTransformer);
     virtual ~ControlWidgetConnection();
 
     double getControlParameter() const;
+    void setControlParameter(double v);
+    double getControlParameterForValue(double value) const;
 
     virtual void resetControl() = 0;
     virtual void setControlParameterDown(double v) = 0;
@@ -55,6 +59,7 @@ class ControlWidgetConnection : public QObject {
   protected:
     WBaseWidget* m_pWidget;
     QScopedPointer<ControlObjectSlave> m_pControl;
+    QScopedPointer<ValueTransformer> m_pValueTransformer;
 };
 
 class ControlParameterWidgetConnection : public ControlWidgetConnection {
@@ -62,6 +67,7 @@ class ControlParameterWidgetConnection : public ControlWidgetConnection {
   public:
     ControlParameterWidgetConnection(WBaseWidget* pBaseWidget,
                                      ControlObjectSlave* pControl,
+                                     ValueTransformer* pTransformer,
                                      bool connectValueFromWidget,
                                      bool connectValueToWidget,
                                      EmitOption emitOption);
@@ -88,6 +94,7 @@ class ControlWidgetPropertyConnection : public ControlWidgetConnection {
   public:
     ControlWidgetPropertyConnection(WBaseWidget* pBaseWidget,
                                     ControlObjectSlave* pControl,
+                                    ValueTransformer* pTransformer,
                                     ConfigObject<ConfigValue>* pConfig,
                                     const QString& property);
     virtual ~ControlWidgetPropertyConnection();


### PR DESCRIPTION
Adds a general ValueTransformer class that does simple, invertible
transformations on numbers. We could re-use this in other places, e.g. MIDI
mappings to allow customizability to advanced users.
