### PR TITLE
fix modplug support

### DIFF
--- a/src/dlgprefmodplugdlg.ui
+++ b/src/dlgprefmodplugdlg.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>DlgPrefModplug</class>
- <widget class="QDialog" name="DlgPrefModplug">
+ <widget class="QWidget" name="DlgPrefModplug">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -29,6 +29,9 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
@@ -40,7 +43,7 @@
    <item row="9" column="0" colspan="6">
     <widget class="QGroupBox" name="advancedSettings">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -375,7 +378,7 @@
    <item row="10" column="0" colspan="6">
     <widget class="QGroupBox" name="Hints">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -413,7 +416,7 @@
    <item row="1" column="0" colspan="6">
     <widget class="QGroupBox" name="decodingOptions">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -538,30 +541,6 @@
   <tabstop>surround</tabstop>
   <tabstop>surroundDepth</tabstop>
   <tabstop>surroundDelay</tabstop>
-  <tabstop>maxMixChannels_2</tabstop>
-  <tabstop>surroundDelay_2</tabstop>
-  <tabstop>bassCutoff_2</tabstop>
-  <tabstop>stereoSeparation_2</tabstop>
-  <tabstop>bassDepth_2</tabstop>
-  <tabstop>reverbDepth_2</tabstop>
-  <tabstop>surroundDepth_2</tabstop>
-  <tabstop>megabass_2</tabstop>
-  <tabstop>reverbDelay_2</tabstop>
-  <tabstop>surround_2</tabstop>
-  <tabstop>reverb_2</tabstop>
-  <tabstop>noiseReduction_2</tabstop>
-  <tabstop>maxMixChannels_3</tabstop>
-  <tabstop>surroundDelay_3</tabstop>
-  <tabstop>bassCutoff_3</tabstop>
-  <tabstop>stereoSeparation_3</tabstop>
-  <tabstop>bassDepth_3</tabstop>
-  <tabstop>reverbDepth_3</tabstop>
-  <tabstop>surroundDepth_3</tabstop>
-  <tabstop>megabass_3</tabstop>
-  <tabstop>reverbDelay_3</tabstop>
-  <tabstop>surround_3</tabstop>
-  <tabstop>reverb_3</tabstop>
-  <tabstop>noiseReduction_3</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/soundsourcemodplug.cpp
+++ b/src/soundsourcemodplug.cpp
@@ -103,7 +103,7 @@ int SoundSourceModPlug::open() {
         // reserve enough space in sample buffer
         m_sampleBuf.resize(currentSize + CHUNKSIZE);
         bytesRead = ModPlug::ModPlug_Read(m_pModFile,
-                                          m_sampleBuf.constData() + currentSize,
+                                          m_sampleBuf.data() + currentSize,
                                           CHUNKSIZE);
         // adapt to actual size
         currentSize += bytesRead;


### PR DESCRIPTION
Fix build error due to passing a const pointer to modplug read function.
Fix UI baseclass (QWidget instead of QDialog)
Fix UI size behavior for ModPlug Decoder Preferences.
Remove superfluous tabstops that were giving warnings.

Signed-off-by: Stefan Nuernberger kabelfrickler@gmail.com
