### PR TITLE
AA VMS2 - Change mapping of pitch bend buttons

### DIFF
--- a/res/controllers/American Audio VMS2 Alternative.midi.xml
+++ b/res/controllers/American Audio VMS2 Alternative.midi.xml
@@ -78,7 +78,7 @@ Loading all work like in the original VMS4 script.
       <control>
 	<!-- on -->
 	<group>[Channel1]</group>
-	<key>rate_temp_down</key>
+	<key>rate_temp_up</key>
 	<status>0x90</status>
 	<midino>0x0F</midino>
 	<options>
@@ -88,7 +88,7 @@ Loading all work like in the original VMS4 script.
       <control>
 	<!-- off -->
 	<group>[Channel1]</group>
-	<key>rate_temp_down</key>
+	<key>rate_temp_up</key>
 	<status>0x80</status>
 	<midino>0x0F</midino>
 	<options>
@@ -98,7 +98,7 @@ Loading all work like in the original VMS4 script.
       <control>
 	<!-- on -->
 	<group>[Channel1]</group>
-	<key>rate_temp_up</key>
+	<key>rate_temp_down</key>
 	<status>0x90</status>
 	<midino>0x10</midino>
 	<options>
@@ -108,7 +108,7 @@ Loading all work like in the original VMS4 script.
       <control>
 	<!-- off -->
 	<group>[Channel1]</group>
-	<key>rate_temp_up</key>
+	<key>rate_temp_down</key>
 	<status>0x80</status>
 	<midino>0x10</midino>
 	<options>
@@ -665,7 +665,7 @@ Loading all work like in the original VMS4 script.
       <control>
 	<!-- on -->
 	<group>[Channel2]</group>
-	<key>rate_temp_down</key>
+	<key>rate_temp_up</key>
 	<status>0x90</status>
 	<midino>0x31</midino>
 	<options>
@@ -675,7 +675,7 @@ Loading all work like in the original VMS4 script.
       <control>
 	<!-- off -->
 	<group>[Channel2]</group>
-	<key>rate_temp_down</key>
+	<key>rate_temp_up</key>
 	<status>0x80</status>
 	<midino>0x31</midino>
 	<options>
@@ -685,7 +685,7 @@ Loading all work like in the original VMS4 script.
       <control>
 	<!-- on -->
 	<group>[Channel2]</group>
-	<key>rate_temp_up</key>
+	<key>rate_temp_down</key>
 	<status>0x90</status>
 	<midino>0x32</midino>
 	<options>
@@ -695,7 +695,7 @@ Loading all work like in the original VMS4 script.
       <control>
 	<!-- off -->
 	<group>[Channel2]</group>
-	<key>rate_temp_up</key>
+	<key>rate_temp_down</key>
 	<status>0x80</status>
 	<midino>0x32</midino>
 	<options>


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/mixxx/+bug/1272728 by reversing the rate_temp_up and _down mapping for American Audio VMS2 (Alternative) xml file.

The rate_temp_up and _down mappings refer to the effect of moving the pitch slider up/down respectively.
Since AA VMS2 sliders are labeled as "up decreases rate", the pitch bend [-] button is mapped to rate_temp_up.
