### PR TITLE
Added custom format for shout metadata

### DIFF
--- a/src/dlgprefshoutcast.cpp
+++ b/src/dlgprefshoutcast.cpp
@@ -167,6 +167,13 @@ DlgPrefShoutcast::DlgPrefShoutcast(QWidget *parent, ConfigObject<ConfigValue> *_
     custom_title->setText(m_pConfig->getValueString(
         ConfigKey(SHOUTCAST_PREF_KEY,"custom_title")));
 
+    //Metadata format
+    tmp_string = m_pConfig->getValueString(
+        ConfigKey(SHOUTCAST_PREF_KEY,"metadata_format"));
+    if (tmp_string.isEmpty())
+        tmp_string = tr("$artist - $title");
+    metadata_format->setText(tmp_string);
+
     slotApply();
 }
 
@@ -221,6 +228,7 @@ void DlgPrefShoutcast::slotApply()
     m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "enable_metadata"),ConfigValue(enableCustomMetadata->isChecked()));
     m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "custom_artist"), ConfigValue(custom_artist->text()));
     m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "custom_title"),  ConfigValue(custom_title->text()));
+    m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "metadata_format"), ConfigValue(metadata_format->text()));
 
     //Tell the EngineShoutcast object to update with these values by toggling this control object.
     m_pUpdateShoutcastFromPrefs->slotSet(1.0);

--- a/src/dlgprefshoutcastdlg.ui
+++ b/src/dlgprefshoutcastdlg.ui
@@ -14,7 +14,7 @@
    <string>Live Broadcasting Preferences</string>
   </property>
   <layout class="QGridLayout">
-   <item row="2" column="0" rowspan="2">
+   <item row="2" column="0" rowspan="3">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="minimumSize">
       <size>
@@ -163,8 +163,8 @@
          <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Lucida Grande'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'DejaVu Sans'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Lucida Grande'; font-size:13pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>
@@ -274,8 +274,20 @@ p, li { white-space: pre-wrap; }
        <layout class="QVBoxLayout">
         <item>
          <widget class="QLabel" name="label_9">
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="lineWidth">
+           <number>1</number>
+          </property>
           <property name="text">
            <string>Channels</string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::AutoText</enum>
+          </property>
+          <property name="scaledContents">
+           <bool>false</bool>
           </property>
           <property name="buddy">
            <cstring>comboBoxEncodingChannels</cstring>
@@ -303,7 +315,7 @@ p, li { white-space: pre-wrap; }
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <widget class="QGroupBox" name="Hints">
      <property name="title">
       <string>Hints</string>
@@ -332,7 +344,20 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="6" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="1">
     <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
       <string>Custom metadata</string>
@@ -498,18 +523,24 @@ p, li { white-space: pre-wrap; }
      </layout>
     </widget>
    </item>
-   <item row="5" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="3" column="1">
+    <widget class="QGroupBox" name="verticalGroupBox">
+     <property name="title">
+      <string>Metadata format</string>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
+     <property name="flat">
+      <bool>false</bool>
      </property>
-    </spacer>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLineEdit" name="metadata_format">
+        <property name="text">
+         <string>$artist - $title</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -213,6 +213,9 @@ void EngineShoutcast::updateFromPreferences() {
     m_customArtist = m_pConfig->getValueString(
             ConfigKey(SHOUTCAST_PREF_KEY, "custom_artist"));
 
+    m_metadataFormat = m_pConfig->getValueString(
+            ConfigKey(SHOUTCAST_PREF_KEY, "metadata_format"));
+
     int format;
     int protocol;
 
@@ -611,7 +614,10 @@ void EngineShoutcast::updateMetaData() {
                 shout_metadata_add(m_pShoutMetaData, "artist",  encodeString(artist).constData());
                 shout_metadata_add(m_pShoutMetaData, "title",  encodeString(title).constData());
             } else {
-                QByteArray baSong = encodeString(artist.isEmpty() ? title : artist + " - " + title);
+                m_metadataFormat.replace(QString("$artist"), artist);
+                m_metadataFormat.replace(QString("$title"), title);
+                qWarning() << m_metadataFormat;
+                QByteArray baSong = encodeString(m_metadataFormat);
                 shout_metadata_add(m_pShoutMetaData, "song",  baSong.constData());
             }
             shout_set_metadata(m_pShout, m_pShoutMetaData);

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -616,7 +616,6 @@ void EngineShoutcast::updateMetaData() {
             } else {
                 m_metadataFormat.replace(QString("$artist"), artist);
                 m_metadataFormat.replace(QString("$title"), title);
-                qWarning() << m_metadataFormat;
                 QByteArray baSong = encodeString(m_metadataFormat);
                 shout_metadata_add(m_pShoutMetaData, "song",  baSong.constData());
             }

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -614,8 +614,30 @@ void EngineShoutcast::updateMetaData() {
                 shout_metadata_add(m_pShoutMetaData, "artist",  encodeString(artist).constData());
                 shout_metadata_add(m_pShoutMetaData, "title",  encodeString(title).constData());
             } else {
-                m_metadataFormat.replace(QString("$artist"), artist);
-                m_metadataFormat.replace(QString("$title"), title);
+                // we are going to take the metadata format and replace all
+                // the references to $title and $artist by doing a single
+                // pass over the string
+                int replaceIndex = 0;
+                do {
+                    // find the next occurrence 
+                    replaceIndex = m_metadataFormat.indexOf(
+                                      QRegExp("\\$artist|\\$title"),
+                                      replaceIndex);
+                  
+                    if (replaceIndex != -1) {
+                        if (m_metadataFormat.indexOf(
+                                          QRegExp("\\$artist"), replaceIndex)
+                                          == replaceIndex) {
+                            m_metadataFormat.replace(replaceIndex, 7, artist);
+                            // skip to the end of the replacement
+                            replaceIndex += artist.length();
+                        } else {
+                            m_metadataFormat.replace(replaceIndex, 6, title);
+                            replaceIndex += title.length();
+                        }
+                    }
+               } while (replaceIndex != -1);
+
                 QByteArray baSong = encodeString(m_metadataFormat);
                 shout_metadata_add(m_pShoutMetaData, "song",  baSong.constData());
             }

--- a/src/engine/sidechain/engineshoutcast.h
+++ b/src/engine/sidechain/engineshoutcast.h
@@ -100,6 +100,7 @@ class EngineShoutcast : public QObject, public EncoderCallback, public SideChain
     bool m_custom_metadata;
     QString m_customArtist;
     QString m_customTitle;
+    QString m_metadataFormat;
 
     // when static metadata is used, we only need calling shout_set_metedata
     // once


### PR DESCRIPTION
This patch allows people to set custom metatdata formats for the shoutcast title field. Previously only 'artist - title' was allowed.

This patch makes the custom metatdata fields a bit redundant, but they have not been touched in case of specific use cases that I am not aware of.

Tested with shoutcast and Icecast 2.
