### PR TITLE
Library scanner performance improvements.

### DIFF
--- a/src/library/libraryscanner.cpp
+++ b/src/library/libraryscanner.cpp
@@ -17,6 +17,7 @@
 
 #include <QtDebug>
 #include <QDesktopServices>
+#include <QLinkedList>
 
 #include "soundsourceproxy.h"
 #include "library/legacylibraryimporter.h"
@@ -39,7 +40,8 @@ LibraryScanner::LibraryScanner(TrackCollection* collection)
                            m_analysisDao,m_directoryDao, collection->getConfig()),
                 // Don't initialize m_database here, we need to do it in run() so the DB
                 // conn is in the right thread.
-                m_nameFilters(SoundSourceProxy::supportedFileExtensionsString().split(" ")),
+                m_extensionFilter(SoundSourceProxy::supportedFileExtensionsRegex(),
+                                  Qt::CaseInsensitive),
     m_bCancelLibraryScan(false) {
 
     qDebug() << "Constructed LibraryScanner";
@@ -194,9 +196,9 @@ void LibraryScanner::run() {
         qDebug("Legacy importer took %d ms", t2.elapsed());
     }
 
-    // Refresh the name filters in case we loaded new
-    // SoundSource plugins.
-    m_nameFilters = SoundSourceProxy::supportedFileExtensionsString().split(" ");
+    // Refresh the name filters in case we loaded new SoundSource plugins.
+    m_extensionFilter = QRegExp(SoundSourceProxy::supportedFileExtensionsRegex(),
+                                Qt::CaseInsensitive);
 
     // Time the library scanner.
     QTime t;
@@ -305,7 +307,7 @@ void LibraryScanner::scan(QWidget* parent) {
     // processed immediately, we have to use
     // BlockingQueuedConnection. (DirectConnection isn't an option for sending
     // signals across threads.)
-    connect(m_pCollection, SIGNAL(progressLoading(QString)),
+    connect(this, SIGNAL(progressLoading(QString)),
             m_pProgress, SLOT(slotUpdate(QString)));
             //Qt::BlockingQueuedConnection);
     connect(this, SIGNAL(progressHashing(QString)),
@@ -328,32 +330,46 @@ void LibraryScanner::resetCancel() {
     m_bCancelLibraryScan = false;
 }
 
-// Recursively scan a music library. Doesn't import tracks for any directories that
-// have already been scanned and have not changed. Changes are tracked by performing
-// a hash of the directory's file list, and those hashes are stored in the database.
-bool LibraryScanner::recursiveScan(const QString& dirPath, QStringList& verifiedDirectories) {
-    QDirIterator fileIt(dirPath, m_nameFilters, QDir::Files | QDir::NoDotAndDotDot);
+bool LibraryScanner::recursiveScan(const QDir& dir, QStringList& verifiedDirectories) {
+    QDirIterator it(dir.path(), QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
     QString currentFile;
+    QFileInfo currentFileInfo;
     bool bScanFinishedCleanly = true;
-    //qDebug() << "Scanning dir:" << dirPath;
+    QLinkedList<QFileInfo> filesToImport;
+    QLinkedList<QDir> dirsToScan;
+
     QString newHashStr;
     bool prevHashExists = false;
     int newHash = -1;
     int prevHash = -1;
     // Note: A hash of "0" is a real hash if the directory contains no files!
 
-    while (fileIt.hasNext()) {
-        currentFile = fileIt.next();
-        //qDebug() << currentFile;
-        newHashStr += currentFile;
+    while (it.hasNext()) {
+        currentFile = it.next();
+        currentFileInfo = it.fileInfo();
+
+        if (currentFileInfo.isFile()) {
+            if (m_extensionFilter.indexIn(currentFileInfo.fileName()) != -1) {
+                newHashStr += currentFile;
+                filesToImport.append(currentFileInfo);
+            }
+        } else {
+            // File is a directory. Add it to our list of directories to scan.
+            // Skip the iTunes Album Art Folder since it is probably a waste of
+            // time.
+            if (!m_directoriesBlacklist.contains(currentFile)) {
+                dirsToScan.append(QDir(currentFile));
+            }
+        }
     }
 
     // Calculate a hash of the directory's file list.
     newHash = qHash(newHashStr);
 
+    QString dirPath = dir.path();
     // Try to retrieve a hash from the last time that directory was scanned.
     prevHash = m_libraryHashDao.getDirectoryHash(dirPath);
-    prevHashExists = !(prevHash == -1);
+    prevHashExists = prevHash != -1;
 
     // Compare the hashes, and if they don't match, rescan the files in that directory!
     if (prevHash != newHash) {
@@ -368,9 +384,7 @@ bool LibraryScanner::recursiveScan(const QString& dirPath, QStringList& verified
         }
 
         // Rescan that mofo!
-        bScanFinishedCleanly = m_pCollection->importDirectory(dirPath, m_trackDao,
-                                                              m_nameFilters,
-                                                              &m_bCancelLibraryScan);
+        bScanFinishedCleanly = importFiles(filesToImport);
     } else { //prevHash == newHash
         // Add the directory to the verifiedDirectories list, so that later they
         // (and the tracks inside them) will be marked as verified
@@ -383,22 +397,61 @@ bool LibraryScanner::recursiveScan(const QString& dirPath, QStringList& verified
     if (m_bCancelLibraryScan) {
         return false;
     }
-    // Look at all the subdirectories and scan them recursively...
-    QDirIterator dirIt(dirPath, QDir::Dirs | QDir::NoDotAndDotDot);
-    while (dirIt.hasNext() && bScanFinishedCleanly) {
-        QString nextPath = dirIt.next();
-        //qDebug() << "nextPath: " << nextPath;
 
-        // Skip the iTunes Album Art Folder since it is probably a waste of
-        // time.
-        if (m_directoriesBlacklist.contains(nextPath)) {
-            continue;
+    // Process all of the sub-directories.
+    foreach (const QDir& nextDir, dirsToScan) {
+        if (!bScanFinishedCleanly) {
+            break;
         }
-        if (!recursiveScan(nextPath, verifiedDirectories)) {
+
+        if (!recursiveScan(nextDir, verifiedDirectories)) {
             bScanFinishedCleanly = false;
         }
     }
+
     return bScanFinishedCleanly;
+}
+
+bool LibraryScanner::importFiles(const QLinkedList<QFileInfo>& files) {
+    foreach (const QFileInfo& file, files) {
+        // If a flag was raised telling us to cancel the library scan then stop.
+        if (m_bCancelLibraryScan) {
+            return false;
+        }
+
+        QString filePath = file.filePath();
+        //qDebug() << "TrackCollection::importFiles" << filePath;
+
+        // If the track is in the database, mark it as existing. This code gets
+        // exectuted when other files in the same directory have changed (the
+        // directory hash has changed).
+        m_trackDao.markTrackLocationAsVerified(filePath);
+
+        // If the file already exists in the database, continue and go on to the
+        // next file.
+
+        // If the file doesn't already exist in the database, then add it. If it
+        // does exist in the database, then it is either in the user's library
+        // OR the user has "removed" the track via "Right-Click ->
+        // Remove". These tracks stay in the library, but their mixxx_deleted
+        // column is 1.
+        if (!m_trackDao.trackExistsInDatabase(filePath)) {
+            emit(progressLoading(file.fileName()));
+
+            TrackPointer pTrack = TrackPointer(new TrackInfoObject(filePath),
+                                               &QObject::deleteLater);
+            if (m_trackDao.addTracksAdd(pTrack.data(), false)) {
+                // Successful added
+                // signal the main instance of TrackDao, that there is a
+                // new Track in the database
+                m_pCollection->getTrackDAO().databaseTrackAdded(pTrack);
+            } else {
+                qDebug() << "Track ("+filePath+") could not be added";
+            }
+        }
+    }
+
+    return true;
 }
 
 // Table: LibraryHashes

--- a/src/library/libraryscanner.h
+++ b/src/library/libraryscanner.h
@@ -26,6 +26,9 @@
 #include <QWidget>
 #include <QSqlDatabase>
 #include <QStringList>
+#include <QRegExp>
+#include <QFileInfo>
+#include <QLinkedList>
 
 #include "library/dao/cratedao.h"
 #include "library/dao/cuedao.h"
@@ -56,13 +59,25 @@ class LibraryScanner : public QThread {
   signals:
     void scanFinished();
     void progressHashing(QString);
+    void progressLoading(QString path);
 
   private:
-    bool recursiveScan(const QString& dirPath, QStringList& verifiedDirectories);
-    TrackCollection* m_pCollection; // The library trackcollection
-    QSqlDatabase m_database; // Hang on to a different DB connection
-                             // since we run in a different thread
-    LibraryScannerDlg* m_pProgress; // The library scanning window
+    // Recursively scan a music library. Doesn't import tracks for any
+    // directories that have already been scanned and have not changed. Changes
+    // are tracked by performing a hash of the directory's file list, and those
+    // hashes are stored in the database.
+    bool recursiveScan(const QDir& dirPath, QStringList& verifiedDirectories);
+
+    // Import the provided files. Returns true if the scan completed without
+    // being cancelled. False if the scan was cancelled part-way through.
+    bool importFiles(const QLinkedList<QFileInfo>& files);
+
+    // The library trackcollection
+    TrackCollection* m_pCollection;
+    // Hang on to a different DB connection since we run in a different thread
+    QSqlDatabase m_database;
+    // The library scanning window
+    LibraryScannerDlg* m_pProgress;
     LibraryHashDAO m_libraryHashDao;
     CueDAO m_cueDao;
     PlaylistDAO m_playlistDao;
@@ -70,7 +85,7 @@ class LibraryScanner : public QThread {
     DirectoryDAO m_directoryDao;
     AnalysisDao m_analysisDao;
     TrackDAO m_trackDao;
-    QStringList m_nameFilters;
+    QRegExp m_extensionFilter;
     volatile bool m_bCancelLibraryScan;
     QStringList m_directoriesBlacklist;
 };

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -116,59 +116,6 @@ QSqlDatabase& TrackCollection::getDatabase() {
     return m_db;
 }
 
-/** Do a non-recursive import of all the songs in a directory. Does NOT decend into subdirectories.
-    @param trackDao The track data access object which provides a connection to the database. We use this parameter in order to make this function callable from separate threads. You need to use a different DB connection for each thread.
-    @return true if the scan completed without being cancelled. False if the scan was cancelled part-way through.
-*/
-bool TrackCollection::importDirectory(const QString& directory, TrackDAO& trackDao,
-                                      const QStringList& nameFilters,
-                                      volatile bool* cancel) {
-    //qDebug() << "TrackCollection::importDirectory(" << directory<< ")";
-
-    // QFileInfoList files;
-
-    //get a list of the contents of the directory and go through it.
-    QDirIterator it(directory, nameFilters, QDir::Files | QDir::NoDotAndDotDot);
-    while (it.hasNext()) {
-
-        //If a flag was raised telling us to cancel the library scan then stop.
-        if (*cancel) {
-            return false;
-        }
-
-        QString absoluteFilePath = it.next();
-
-        // If the track is in the database, mark it as existing. This code gets exectuted
-        // when other files in the same directory have changed (the directory hash has changed).
-        trackDao.markTrackLocationAsVerified(absoluteFilePath);
-
-        // If the file already exists in the database, continue and go on to
-        // the next file.
-
-        // If the file doesn't already exist in the database, then add
-        // it. If it does exist in the database, then it is either in the
-        // user's library OR the user has "removed" the track via
-        // "Right-Click -> Remove". These tracks stay in the library, but
-        // their mixxx_deleted column is 1.
-        if (!trackDao.trackExistsInDatabase(absoluteFilePath)) {
-            //qDebug() << "Loading" << it.fileName();
-            emit(progressLoading(it.fileName()));
-
-            TrackPointer pTrack = TrackPointer(new TrackInfoObject(
-                              absoluteFilePath), &QObject::deleteLater);
-            if (trackDao.addTracksAdd(pTrack.data(), false)) {
-                // Successful added
-                // signal the main instance of TrackDao, that there is a
-                // new Track in the database
-                m_trackDao.databaseTrackAdded(pTrack);
-            } else {
-                qDebug() << "Track ("+absoluteFilePath+") could not be added";
-            }
-        }
-    }
-    return true;
-}
-
 CrateDAO& TrackCollection::getCrateDAO() {
     return m_crateDao;
 }

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -50,10 +50,6 @@ class TrackCollection : public QObject
     ~TrackCollection();
     bool checkForTables();
 
-    /** Import the files in a given diretory, without recursing into subdirectories */
-    bool importDirectory(const QString& directory, TrackDAO& trackDao,
-                         const QStringList& nameFilters, volatile bool* cancel);
-
     void resetLibaryCancellation();
     QSqlDatabase& getDatabase();
 
@@ -68,9 +64,6 @@ class TrackCollection : public QObject
     ConfigObject<ConfigValue>* getConfig() {
         return m_pConfig;
     }
-
-  signals:
-    void progressLoading(QString path);
 
   private:
     ConfigObject<ConfigValue>* m_pConfig;


### PR DESCRIPTION
For every directory, we were:
- Scanning the directory 3 times (once for hash, once for import, once for
  recursive descent).
- Continuously re-parsing the name-filters into regexps for every call to
  QDirIterator.

This change does one QDirIterator pass over the directory and uses a
pre-compiled QRegExp to check for compatible file names.

On a music collection of 18GB, 5000+ files and 1000+ folders, this produces a
20% speedup on first scan.
