### PR TITLE
Support Mac OS X Sandboxing

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -79,6 +79,24 @@ class OpenGL(Dependence):
             raise Exception('Did not find GLU development files')
 
 
+class SecurityFramework(Dependence):
+    """The iOS/OS X security framework is used to implement sandboxing."""
+    def configure(self, build, conf):
+        if not build.platform_is_osx:
+            return
+        build.env.Append(CPPPATH='/System/Library/Frameworks/Security.framework/Headers/')
+        build.env.Append(LINKFLAGS='-framework Security')
+
+
+class CoreServices(Dependence):
+    """The iOS/OS X security framework is used to implement sandboxing."""
+    def configure(self, build, conf):
+        if not build.platform_is_osx:
+            return
+        build.env.Append(CPPPATH='/System/Library/Frameworks/CoreServices.framework/Headers/')
+        build.env.Append(LINKFLAGS='-framework CoreServices')
+
+
 class OggVorbis(Dependence):
 
     def configure(self, build, conf):
@@ -1034,7 +1052,7 @@ class MixxxCore(Feature):
     def depends(self, build):
         return [SoundTouch, ReplayGain, PortAudio, PortMIDI, Qt,
                 FidLib, SndFile, FLAC, OggVorbis, OpenGL, TagLib, ProtoBuf,
-                Chromaprint, RubberBand]
+                Chromaprint, RubberBand, SecurityFramework, CoreServices]
 
     def post_dependency_check_configure(self, build, conf):
         """Sets up additional things in the Environment that must happen

--- a/build/depends.py
+++ b/build/depends.py
@@ -89,7 +89,6 @@ class SecurityFramework(Dependence):
 
 
 class CoreServices(Dependence):
-    """The iOS/OS X security framework is used to implement sandboxing."""
     def configure(self, build, conf):
         if not build.platform_is_osx:
             return

--- a/build/depends.py
+++ b/build/depends.py
@@ -862,6 +862,7 @@ class MixxxCore(Feature):
                    "util/version.cpp",
                    "util/rlimit.cpp",
                    "util/valuetransformer.cpp",
+                   "util/sandbox.cpp",
                    "util/mac.cpp",
 
                    '#res/mixxx.qrc'

--- a/build/depends.py
+++ b/build/depends.py
@@ -862,6 +862,7 @@ class MixxxCore(Feature):
                    "util/version.cpp",
                    "util/rlimit.cpp",
                    "util/valuetransformer.cpp",
+                   "util/mac.cpp",
 
                    '#res/mixxx.qrc'
                    ]

--- a/build/depends.py
+++ b/build/depends.py
@@ -863,6 +863,7 @@ class MixxxCore(Feature):
                    "util/rlimit.cpp",
                    "util/valuetransformer.cpp",
                    "util/sandbox.cpp",
+                   "util/file.cpp",
                    "util/mac.cpp",
 
                    '#res/mixxx.qrc'

--- a/build/osx/OSConsX.py
+++ b/build/osx/OSConsX.py
@@ -476,14 +476,16 @@ def do_codesign(target, source, env):
             # Don't descend.
             del dirs[:]
 
-        # Codesign binaries.
-        for root, dirs, files in os.walk(binary_path):
-            for filename in files:
-                codesign_path(application_identity, keychain, entitlements, os.path.join(root, filename))
         # Codesign plugins.
         for root, dirs, files in os.walk(plugins_path):
             for filename in files:
                 codesign_path(application_identity, keychain, entitlements, os.path.join(root, filename))
+
+        # Codesign binaries.
+        for root, dirs, files in os.walk(binary_path):
+            for filename in files:
+                codesign_path(application_identity, keychain, entitlements, os.path.join(root, filename))
+
         # Codesign the bundle.
         codesign_path(application_identity, keychain, entitlements, bundle)
 CodeSign = Builder(action = do_codesign)

--- a/build/osx/entitlements.plist
+++ b/build/osx/entitlements.plist
@@ -6,6 +6,8 @@
     <true/>
     <key>com.apple.security.assets.music.read-write</key>
     <true/>
+    <key>com.apple.security.files.downloads.read-write</key>
+    <true/>
     <key>com.apple.security.device.firewire</key>
     <true/>
     <key>com.apple.security.device.microphone</key>
@@ -16,9 +18,7 @@
     <true/>
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
-    <key>com.apple.security.temporary-exception.files.absolute-path.read-write</key>
-    <array>
-      <string>/</string>
-    </array>
+    <key>com.apple.security.files.bookmarks.app-scope</key>
+    <true/>
   </dict>
 </plist>

--- a/src/SConscript
+++ b/src/SConscript
@@ -425,6 +425,7 @@ if build.platform_is_osx and 'bundle' in COMMAND_LINE_TARGETS:
                 CODESIGN_KEYCHAIN=codesign_keychain,
                 CODESIGN_KEYCHAIN_PASSWORD=codesign_keychain_password,
                 CODESIGN_ENTITLEMENTS=codesign_entitlements)
+        env.AlwaysBuild(codesign)
         env.Alias('sign', codesign)
         env.AlwaysBuild(codesign)
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -427,7 +427,6 @@ if build.platform_is_osx and 'bundle' in COMMAND_LINE_TARGETS:
                 CODESIGN_ENTITLEMENTS=codesign_entitlements)
         env.AlwaysBuild(codesign)
         env.Alias('sign', codesign)
-        env.AlwaysBuild(codesign)
 
         package_name = 'mixxx'
         package_version = osx_construct_version(build, mixxx_version, branch_name, vcs_revision)

--- a/src/audiotagger.h
+++ b/src/audiotagger.h
@@ -3,20 +3,19 @@
 #define AUDIOTAGGER_H
 
 #include <QString>
+#include <QFileInfo>
 #include <taglib/apetag.h>
 #include <taglib/id3v2tag.h>
 #include <taglib/xiphcomment.h>
 #include <taglib/mp4tag.h>
 
+#include "util/sandbox.h"
 
-
-class AudioTagger
-{
-public:
-
-
-    AudioTagger (QString file);
+class AudioTagger {
+  public:
+    AudioTagger(const QString& file, SecurityTokenPointer pToken);
     virtual ~AudioTagger ( );
+
     void setArtist (QString artist );
     void setTitle (QString title );
     void setAlbum (QString album );
@@ -31,8 +30,7 @@ public:
     void setTracknumber (QString tracknumber );
     bool save();
 
-
-private:
+  private:
     QString m_artist;
     QString m_title;
     QString m_albumArtist;
@@ -46,7 +44,8 @@ private:
     QString m_bpm;
     QString m_tracknumber;
 
-    QString m_file;
+    SecurityTokenPointer m_pSecurityToken;
+    QFileInfo m_file;
 
     /** adds or modifies the ID3v2 tag to include BPM and KEY information **/
     void addID3v2Tag(TagLib::ID3v2::Tag* id3v2);

--- a/src/audiotagger.h
+++ b/src/audiotagger.h
@@ -44,8 +44,8 @@ class AudioTagger {
     QString m_bpm;
     QString m_tracknumber;
 
-    SecurityTokenPointer m_pSecurityToken;
     QFileInfo m_file;
+    SecurityTokenPointer m_pSecurityToken;
 
     /** adds or modifies the ID3v2 tag to include BPM and KEY information **/
     void addID3v2Tag(TagLib::ID3v2::Tag* id3v2);

--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -103,7 +103,7 @@ BaseTrackPlayer::~BaseTrackPlayer()
 
 void BaseTrackPlayer::slotLoadTrack(TrackPointer track, bool bPlay) {
     // Before loading the track, ensure we have access:
-    if (track && !Sandbox::instance()->askForAccess(track->getCanonicalLocation())) {
+    if (track && !Sandbox::askForAccess(track->getCanonicalLocation())) {
         // We don't have access.
         return;
     }

--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -102,8 +102,9 @@ BaseTrackPlayer::~BaseTrackPlayer()
 }
 
 void BaseTrackPlayer::slotLoadTrack(TrackPointer track, bool bPlay) {
-    // Before loading the track, ensure we have access:
-    if (track && !Sandbox::askForAccess(track->getCanonicalLocation())) {
+    // Before loading the track, ensure we have access. This uses lazy
+    // evaluation to make sure track isn't NULL before we dereference it.
+    if (!track.isNull() && !Sandbox::askForAccess(track->getCanonicalLocation())) {
         // We don't have access.
         return;
     }

--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -14,6 +14,7 @@
 #include "track/beatgrid.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "analyserqueue.h"
+#include "util/sandbox.h"
 
 BaseTrackPlayer::BaseTrackPlayer(QObject* pParent,
                                  ConfigObject<ConfigValue>* pConfig,
@@ -101,6 +102,11 @@ BaseTrackPlayer::~BaseTrackPlayer()
 }
 
 void BaseTrackPlayer::slotLoadTrack(TrackPointer track, bool bPlay) {
+    // Before loading the track, ensure we have access:
+    if (track && !Sandbox::instance()->askForAccess(track->getCanonicalLocation())) {
+        // We don't have access.
+        return;
+    }
 
     //Disconnect the old track's signals.
     if (m_pLoadedTrack) {

--- a/src/dlgprefrecord.cpp
+++ b/src/dlgprefrecord.cpp
@@ -244,7 +244,7 @@ void DlgPrefRecord::slotBrowseRecordingsDir() {
         // that we can access the folder on future runs. We need to canonicalize
         // the path so we first wrap the directory string with a QDir.
         QDir directory(fd);
-        Sandbox::instance()->createSecurityToken(directory);
+        Sandbox::createSecurityToken(directory);
         LineEditRecordings->setText(fd);
     }
 }

--- a/src/dlgprefrecord.cpp
+++ b/src/dlgprefrecord.cpp
@@ -23,6 +23,7 @@
 #include "controlobject.h"
 #include "encoder/encoder.h"
 #include "controlobjectthread.h"
+#include "util/sandbox.h"
 
 DlgPrefRecord::DlgPrefRecord(QWidget* parent, ConfigObject<ConfigValue>* pConfig)
         : DlgPreferencePage(parent),
@@ -231,10 +232,19 @@ void DlgPrefRecord::slotUpdate() {
 }
 
 void DlgPrefRecord::slotBrowseRecordingsDir() {
-    QString fd = QFileDialog::getExistingDirectory(this, tr("Choose recordings directory"),
-                                            m_pConfig->getValueString(
-                                                        ConfigKey(RECORDING_PREF_KEY, "Directory")));
+    QString fd = QFileDialog::getExistingDirectory(
+            this, tr("Choose recordings directory"),
+            m_pConfig->getValueString(ConfigKey(RECORDING_PREF_KEY,
+                                                "Directory")));
+
     if (fd != "") {
+        // The user has picked a new directory via a file dialog. This means the
+        // system sandboxer (if we are sandboxed) has granted us permission to
+        // this folder. Create a security bookmark while we have permission so
+        // that we can access the folder on future runs. We need to canonicalize
+        // the path so we first wrap the directory string with a QDir.
+        QDir directory(fd);
+        Sandbox::instance()->createSecurityToken(directory);
         LineEditRecordings->setText(fd);
     }
 }

--- a/src/dlgtrackinfo.cpp
+++ b/src/dlgtrackinfo.cpp
@@ -367,7 +367,8 @@ void DlgTrackInfo::slotBpmTap() {
 
 void DlgTrackInfo::reloadTrackMetadata() {
     if (m_pLoadedTrack) {
-        TrackPointer pTrack(new TrackInfoObject(m_pLoadedTrack->getLocation()));
+        TrackPointer pTrack(new TrackInfoObject(m_pLoadedTrack->getLocation(),
+                                                true, m_pLoadedTrack->getSecurityToken()));
         populateFields(pTrack);
     }
 }

--- a/src/dlgtrackinfo.cpp
+++ b/src/dlgtrackinfo.cpp
@@ -368,7 +368,7 @@ void DlgTrackInfo::slotBpmTap() {
 void DlgTrackInfo::reloadTrackMetadata() {
     if (m_pLoadedTrack) {
         TrackPointer pTrack(new TrackInfoObject(m_pLoadedTrack->getLocation(),
-                                                true, m_pLoadedTrack->getSecurityToken()));
+                                                m_pLoadedTrack->getSecurityToken()));
         populateFields(pTrack);
     }
 }

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -12,6 +12,7 @@
 #include "mixxxkeyboard.h"
 #include "analyserqueue.h"
 #include "soundsourceproxy.h"
+#include "util/dnd.h"
 
 const QString AnalysisFeature::m_sAnalysisViewName = QString("Analysis");
 
@@ -134,15 +135,7 @@ void AnalysisFeature::cleanupAnalyser() {
 
 bool AnalysisFeature::dropAccept(QList<QUrl> urls, QObject* pSource) {
     Q_UNUSED(pSource);
-    QList<QFileInfo> files;
-    foreach (QUrl url, urls) {
-        // XXX: Possible WTF alert - Previously we thought we needed toString() here
-        // but what you actually want in any case when converting a QUrl to a file
-        // system path is QUrl::toLocalFile(). This is the second time we have
-        // flip-flopped on this, but I think toLocalFile() should work in any
-        // case. toString() absolutely does not work when you pass the result to a
-        files.append(url.toLocalFile());
-    }
+    QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
     // Adds track, does not insert duplicates, handles unremoving logic.
     QList<int> trackIds = m_pTrackCollection->getTrackDAO().addTracks(files, true);
     analyzeTracks(trackIds);

--- a/src/library/autodjfeature.cpp
+++ b/src/library/autodjfeature.cpp
@@ -15,6 +15,7 @@
 #include "widget/wlibrary.h"
 #include "mixxxkeyboard.h"
 #include "soundsourceproxy.h"
+#include "util/dnd.h"
 
 const QString AutoDJFeature::m_sAutoDJViewName = QString("Auto DJ");
 
@@ -119,17 +120,10 @@ bool AutoDJFeature::dropAccept(QList<QUrl> urls, QObject* pSource) {
     //TODO: Filter by supported formats regex and reject anything that doesn't match.
     TrackDAO &trackDao = m_pTrackCollection->getTrackDAO();
 
-    //If a track is dropped onto a playlist's name, but the track isn't in the library,
-    //then add the track to the library before adding it to the playlist.
-    QList<QFileInfo> files;
-    foreach (QUrl url, urls) {
-        //XXX: See the note in PlaylistFeature::dropAccept() about using QUrl::toLocalFile()
-        //     instead of toString()
-        QFileInfo file = url.toLocalFile();
-        if (SoundSourceProxy::isFilenameSupported(file.fileName())) {
-            files.append(file);
-        }
-    }
+    // If a track is dropped onto a playlist's name, but the track isn't in the
+    // library, then add the track to the library before adding it to the
+    // playlist.
+    QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
     QList<int> trackIds;
     if (pSource) {
         trackIds = trackDao.getTrackIds(files);

--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -304,6 +304,11 @@ void BasePlaylistFeature::slotImportPlaylist() {
     m_pConfig->set(ConfigKey("[Library]","LastImportExportPlaylistDirectory"),
                 ConfigValue(fileName.dir().absolutePath()));
 
+    // The user has picked a new directory via a file dialog. This means the
+    // system sandboxer (if we are sandboxed) has granted us permission to this
+    // folder. We don't need access to this file on a regular basis so we do not
+    // register a security bookmark.
+
     Parser* playlist_parser = NULL;
 
     if (playlist_file.endsWith(".m3u", Qt::CaseInsensitive) ||
@@ -356,6 +361,11 @@ void BasePlaylistFeature::slotExportPlaylist() {
     QFileInfo fileName(file_location);
     m_pConfig->set(ConfigKey("[Library]","LastImportExportPlaylistDirectory"),
                 ConfigValue(fileName.dir().absolutePath()));
+
+    // The user has picked a new directory via a file dialog. This means the
+    // system sandboxer (if we are sandboxed) has granted us permission to this
+    // folder. We don't need access to this file on a regular basis so we do not
+    // register a security bookmark.
 
     // Create a new table model since the main one might have an active search.
     // This will only export songs that we think exist on default

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -16,6 +16,7 @@
 #include "playerinfo.h"
 #include "track/keyutils.h"
 #include "util/time.h"
+#include "util/dnd.h"
 
 const bool sDebug = false;
 
@@ -852,7 +853,7 @@ QMimeData* BaseSqlTableModel::mimeData(const QModelIndexList &indexes) const {
             continue;
         }
         rows.insert(index.row());
-        QUrl url = QUrl::fromLocalFile(getTrackLocation(index));
+        QUrl url = DragAndDropHelper::urlFromLocation(getTrackLocation(index));
         if (!url.isValid()) {
             qDebug() << this << "ERROR: invalid url" << url;
             continue;

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -185,9 +185,19 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
 
     QString path = item->dataPath().toString();
     if (path == QUICK_LINK_NODE || path == DEVICE_NODE) {
-        m_browseModel.setPath("");
+        m_browseModel.setPath(MDir());
     } else {
-        m_browseModel.setPath(path);
+        MDir dir(path);
+        if (!dir.canAccess()) {
+            if (!Sandbox::askForAccess(path)) {
+                // TODO(rryan): Activate an info page about sandboxing?
+                return;
+            } else {
+                // Re-create to get a new token.
+                dir = MDir(path);
+            }
+        }
+        m_browseModel.setPath(dir);
     }
     emit(showTrackModel(&m_proxyModel));
 }

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -17,6 +17,7 @@
 #include "widget/wlibrarytextbrowser.h"
 #include "widget/wlibrary.h"
 #include "mixxxkeyboard.h"
+#include "util/sandbox.h"
 
 const QString kQuickLinksSeparator = "-+-";
 
@@ -181,7 +182,13 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
     TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
     qDebug() << "BrowseFeature::activateChild " << item->data() << " "
              << item->dataPath();
-    m_browseModel.setPath(item->dataPath().toString());
+
+    QString path = item->dataPath().toString();
+    if (path == QUICK_LINK_NODE || path == DEVICE_NODE) {
+        m_browseModel.setPath("");
+    } else {
+        m_browseModel.setPath(path);
+    }
     emit(showTrackModel(&m_proxyModel));
 }
 

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -187,6 +187,8 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
     if (path == QUICK_LINK_NODE || path == DEVICE_NODE) {
         m_browseModel.setPath(MDir());
     } else {
+        // Open a security token for this path and if we do not have access, ask
+        // for it.
         MDir dir(path);
         if (!dir.canAccess()) {
             if (!Sandbox::askForAccess(path)) {

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -191,12 +191,12 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
         // for it.
         MDir dir(path);
         if (!dir.canAccess()) {
-            if (!Sandbox::askForAccess(path)) {
-                // TODO(rryan): Activate an info page about sandboxing?
-                return;
-            } else {
+            if (Sandbox::askForAccess(path)) {
                 // Re-create to get a new token.
                 dir = MDir(path);
+            } else {
+                // TODO(rryan): Activate an info page about sandboxing?
+                return;
             }
         }
         m_browseModel.setPath(dir);

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -259,7 +259,7 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex &index){
             TreeItem* driveLetter = new TreeItem(
                 drive.canonicalPath(), // displays C:
                 drive.filePath(), //Displays C:/
-                this ,
+                this,
                 item);
             folders << driveLetter;
         }
@@ -355,7 +355,7 @@ QStringList BrowseFeature::getDefaultQuickLinks() const {
     foreach (QString dirPath, mixxxMusicDirs) {
         QDir dir(dirPath);
         // Skip directories we don't have permission to.
-        if (!Sandbox::instance()->canAccessFile(dir)) {
+        if (!Sandbox::canAccessFile(dir)) {
             continue;
         }
         if (dir == osMusicDir) {
@@ -373,22 +373,22 @@ QStringList BrowseFeature::getDefaultQuickLinks() const {
         result << dir.canonicalPath() + "/";
     }
 
-    if (!osMusicDirIncluded && Sandbox::instance()->canAccessFile(osMusicDir)) {
+    if (!osMusicDirIncluded && Sandbox::canAccessFile(osMusicDir)) {
         result << osMusicDir.canonicalPath() + "/";
     }
 
     if (downloadsExists && !osDownloadsDirIncluded &&
-            Sandbox::instance()->canAccessFile(osDownloadsDir)) {
+            Sandbox::canAccessFile(osDownloadsDir)) {
         result << osDownloadsDir.canonicalPath() + "/";
     }
 
     if (!osDesktopDirIncluded &&
-            Sandbox::instance()->canAccessFile(osDesktopDir)) {
+            Sandbox::canAccessFile(osDesktopDir)) {
         result << osDesktopDir.canonicalPath() + "/";
     }
 
     if (!osDocumentsDirIncluded &&
-            Sandbox::instance()->canAccessFile(osDocumentsDir)) {
+            Sandbox::canAccessFile(osDocumentsDir)) {
         result << osDocumentsDir.canonicalPath() + "/";
     }
 

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -259,8 +259,9 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex &index){
     } else {
         // we assume that the path refers to a folder in the file system
         // populate childs
-        QDir dir(path);
-        QFileInfoList all = dir.entryInfoList(
+        MDir dir(path);
+
+        QFileInfoList all = dir.dir().entryInfoList(
             QDir::Dirs | QDir::NoDotAndDotDot);
 
         // loop through all the item and construct the childs

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -202,7 +202,7 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, QModelIndex index
 
     QString path = item->dataPath().toString();
 
-    if (path == QUICK_LINK_NODE || path == DEVICE_NODE || path == "/") {
+    if (path == QUICK_LINK_NODE || path == DEVICE_NODE) {
         return;
     }
 

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -12,8 +12,6 @@
 #include "controlobject.h"
 #include "library/dao/trackdao.h"
 #include "audiotagger.h"
-#include "util/sandbox.h"
-
 
 BrowseTableModel::BrowseTableModel(QObject* parent,
                                    TrackCollection* pTrackCollection,
@@ -82,13 +80,8 @@ void BrowseTableModel::addSearchColumn(int index) {
     m_searchColumns.push_back(index);
 }
 
-void BrowseTableModel::setPath(QString absPath) {
-    if (!Sandbox::askForAccess(absPath)) {
-        // TODO(rryan): Activate an info page about sandboxing.
-        return;
-    }
-
-    m_current_directory = MDir(absPath);
+void BrowseTableModel::setPath(const MDir& path) {
+    m_current_directory = path;
     BrowseThread::getInstance()->executePopulation(m_current_directory, this);
 }
 

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -12,6 +12,7 @@
 #include "controlobject.h"
 #include "library/dao/trackdao.h"
 #include "audiotagger.h"
+#include "util/dnd.h"
 
 BrowseTableModel::BrowseTableModel(QObject* parent,
                                    TrackCollection* pTrackCollection,
@@ -231,13 +232,12 @@ QMimeData* BrowseTableModel::mimeData(const QModelIndexList &indexes) const {
         if (index.isValid()) {
             if (!rows.contains(index.row())) {
                 rows.push_back(index.row());
-                QUrl url = QUrl::fromLocalFile(getTrackLocation(index));
+                QUrl url = DragAndDropHelper::urlFromLocation(getTrackLocation(index));
                 if (!url.isValid()) {
-                    qDebug() << "ERROR invalid url\n";
-                } else {
-                    urls.append(url);
-                    qDebug() << "Appending URL:" << url;
+                    qDebug() << "ERROR invalid url" << url;
+                    continue;
                 }
+                urls.append(url);
             }
         }
     }

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -83,7 +83,7 @@ void BrowseTableModel::addSearchColumn(int index) {
 }
 
 void BrowseTableModel::setPath(QString absPath) {
-    if (!Sandbox::instance()->askForAccess(absPath)) {
+    if (!Sandbox::askForAccess(absPath)) {
         // TODO(rryan): Activate an info page about sandboxing.
         return;
     }

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -319,7 +319,7 @@ bool BrowseTableModel::setData(const QModelIndex &index, const QVariant &value,
     int row = index.row();
     int col = index.column();
     QString track_location = getTrackLocation(index);
-    AudioTagger tagger(track_location);
+    AudioTagger tagger(track_location, m_current_directory.token());
 
     // set tagger information
     tagger.setArtist(this->index(row, COLUMN_ARTIST).data().toString());

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -89,8 +89,7 @@ void BrowseTableModel::setPath(QString absPath) {
     }
 
     m_current_directory = MDir(absPath);
-    BrowseThread::getInstance()->executePopulation(
-            m_current_directory.dir().canonicalPath(), this);
+    BrowseThread::getInstance()->executePopulation(m_current_directory, this);
 }
 
 TrackPointer BrowseTableModel::getTrack(const QModelIndex& index) const {
@@ -215,8 +214,8 @@ void BrowseTableModel::removeTracks(QStringList trackLocations) {
 
     // Repopulate model if any tracks were actually deleted
     if (any_deleted) {
-        BrowseThread::getInstance()->executePopulation(
-                m_current_directory.dir().canonicalPath(), this);
+        BrowseThread::getInstance()->executePopulation(m_current_directory,
+                                                       this);
     }
 }
 

--- a/src/library/browse/browsetablemodel.h
+++ b/src/library/browse/browsetablemodel.h
@@ -37,7 +37,7 @@ class BrowseTableModel : public QStandardItemModel, public virtual TrackModel {
   public:
     BrowseTableModel(QObject* parent, TrackCollection* pTrackCollection, RecordingManager* pRec);
     virtual ~BrowseTableModel();
-    void setPath(QString absPath);
+    void setPath(const MDir& path);
     //reimplemented from TrackModel class
     virtual TrackPointer getTrack(const QModelIndex& index) const;
     virtual TrackModel::CapabilitiesFlags getCapabilities() const;

--- a/src/library/browse/browsetablemodel.h
+++ b/src/library/browse/browsetablemodel.h
@@ -7,6 +7,7 @@
 #include "library/trackmodel.h"
 #include "library/trackcollection.h"
 #include "recording/recordingmanager.h"
+#include "util/file.h"
 
 //constants
 const int COLUMN_FILENAME = 0;
@@ -69,7 +70,7 @@ class BrowseTableModel : public QStandardItemModel, public virtual TrackModel {
     void addSearchColumn(int index);
     bool isTrackInUse(const QString& file) const;
     QList<int> m_searchColumns;
-    QString m_current_path;
+    MDir m_current_directory;
     TrackCollection* m_pTrackCollection;
     RecordingManager* m_pRecordingManager;
 };

--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -67,7 +67,7 @@ void BrowseThread::destroyInstance()
     s_Mutex.unlock();
 }
 
-void BrowseThread::executePopulation(QString& path, BrowseTableModel* client) {
+void BrowseThread::executePopulation(const QString& path, BrowseTableModel* client) {
     m_path_mutex.lock();
     m_path = path;
     m_model_observer = client;

--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -67,7 +67,7 @@ void BrowseThread::destroyInstance()
     s_Mutex.unlock();
 }
 
-void BrowseThread::executePopulation(const QString& path, BrowseTableModel* client) {
+void BrowseThread::executePopulation(const MDir& path, BrowseTableModel* client) {
     m_path_mutex.lock();
     m_path = path;
     m_model_observer = client;
@@ -95,14 +95,15 @@ void BrowseThread::run() {
 
 void BrowseThread::populateModel() {
     m_path_mutex.lock();
-    QString thisPath = m_path;
+    MDir thisPath = m_path;
     BrowseTableModel* thisModelObserver = m_model_observer;
     m_path_mutex.unlock();
 
     // Refresh the name filters in case we loaded new SoundSource plugins.
     QStringList nameFilters(SoundSourceProxy::supportedFileExtensionsString().split(" "));
 
-    QDirIterator fileIt(thisPath, nameFilters, QDir::Files | QDir::NoDotAndDotDot);
+    QDirIterator fileIt(thisPath.dir().canonicalPath(), nameFilters,
+                        QDir::Files | QDir::NoDotAndDotDot);
 
     // remove all rows
     // This is a blocking operation
@@ -117,16 +118,16 @@ void BrowseThread::populateModel() {
         // If a user quickly jumps through the folders
         // the current task becomes "dirty"
         m_path_mutex.lock();
-        QString newPath = m_path;
+        MDir newPath = m_path;
         m_path_mutex.unlock();
 
-        if(thisPath != newPath) {
+        if (thisPath.dir() != newPath.dir()) {
             qDebug() << "Abort populateModel()";
             return populateModel();
         }
 
         QString filepath = fileIt.next();
-        TrackInfoObject tio(filepath);
+        TrackInfoObject tio(filepath, true, thisPath.token());
         QList<QStandardItem*> row_data;
 
         QStandardItem* item = new QStandardItem(tio.getFilename());

--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -127,7 +127,7 @@ void BrowseThread::populateModel() {
         }
 
         QString filepath = fileIt.next();
-        TrackInfoObject tio(filepath, true, thisPath.token());
+        TrackInfoObject tio(filepath, thisPath.token());
         QList<QStandardItem*> row_data;
 
         QStandardItem* item = new QStandardItem(tio.getFilename());

--- a/src/library/browse/browsethread.h
+++ b/src/library/browse/browsethread.h
@@ -11,6 +11,8 @@
 #include <QStandardItem>
 #include <QList>
 
+#include "util/file.h"
+
 // This class is a singleton and represents a thread
 // that is used to read ID3 metadata
 // from a particular folder.
@@ -23,7 +25,7 @@ class BrowseTableModel;
 class BrowseThread : public QThread {
     Q_OBJECT
   public:
-    void executePopulation(const QString& path, BrowseTableModel* client);
+    void executePopulation(const MDir& path, BrowseTableModel* client);
     void run();
     static BrowseThread* getInstance();
     static void destroyInstance();
@@ -44,7 +46,7 @@ class BrowseThread : public QThread {
 
     // You must hold m_path_mutex to touch m_path or m_model_observer
     QMutex m_path_mutex;
-    QString m_path;
+    MDir m_path;
     BrowseTableModel* m_model_observer;
 
     static BrowseThread* m_instance;

--- a/src/library/browse/browsethread.h
+++ b/src/library/browse/browsethread.h
@@ -23,7 +23,7 @@ class BrowseTableModel;
 class BrowseThread : public QThread {
     Q_OBJECT
   public:
-    void executePopulation(QString& path, BrowseTableModel* client);
+    void executePopulation(const QString& path, BrowseTableModel* client);
     void run();
     static BrowseThread* getInstance();
     static void destroyInstance();

--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -15,6 +15,7 @@
 #include "library/treeitem.h"
 #include "library/browse/foldertreemodel.h"
 #include "library/browse/browsefeature.h"
+#include "util/file.h"
 
 FolderTreeModel::FolderTreeModel(QObject *parent)
         : TreeItemModel(parent) {
@@ -53,6 +54,9 @@ bool FolderTreeModel::directoryHasChildren(const QString& path) const {
     if (it != m_directoryCache.end()) {
         return it.value();
     }
+
+    // Acquire a security token for the path.
+    MDir dir(path);
 
     /*
      *  The following code is too expensive, general and SLOW since

--- a/src/library/cratefeature.cpp
+++ b/src/library/cratefeature.cpp
@@ -491,7 +491,12 @@ void CrateFeature::slotImportPlaylist() {
     // Update the import/export crate directory
     QFileInfo fileName(playlist_file);
     m_pConfig->set(ConfigKey("[Library]","LastImportExportCrateDirectory"),
-                ConfigValue(fileName.dir().absolutePath()));
+                   ConfigValue(fileName.dir().absolutePath()));
+
+    // The user has picked a new directory via a file dialog. This means the
+    // system sandboxer (if we are sandboxed) has granted us permission to this
+    // folder. We don't need access to this file on a regular basis so we do not
+    // register a security bookmark.
 
     Parser* playlist_parser = NULL;
 
@@ -550,6 +555,11 @@ void CrateFeature::slotExportPlaylist() {
     QFileInfo fileName(file_location);
     m_pConfig->set(ConfigKey("[Library]","LastImportExportCrateDirectory"),
                 ConfigValue(fileName.dir().absolutePath()));
+
+    // The user has picked a new directory via a file dialog. This means the
+    // system sandboxer (if we are sandboxed) has granted us permission to this
+    // folder. We don't need access to this file on a regular basis so we do not
+    // register a security bookmark.
 
     // check config if relative paths are desired
     bool useRelativePath = static_cast<bool>(

--- a/src/library/cratefeature.cpp
+++ b/src/library/cratefeature.cpp
@@ -20,6 +20,7 @@
 #include "mixxxkeyboard.h"
 #include "treeitem.h"
 #include "soundsourceproxy.h"
+#include "util/dnd.h"
 
 CrateFeature::CrateFeature(QObject* parent,
                            TrackCollection* pTrackCollection,
@@ -114,13 +115,7 @@ bool CrateFeature::dropAcceptChild(const QModelIndex& index, QList<QUrl> urls,
                                    QObject* pSource) {
     QString crateName = index.data().toString();
     int crateId = m_crateDao.getCrateIdByName(crateName);
-    QList<QFileInfo> files;
-    foreach (QUrl url, urls) {
-        //XXX: See the comment in PlaylistFeature::dropAcceptChild() about
-        //     QUrl::toLocalFile() vs. QUrl::toString() usage.
-        files.append(url.toLocalFile());
-    }
-
+    QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
     QList<int> trackIds;
     if (pSource) {
         trackIds = m_pTrackCollection->getTrackDAO().getTrackIds(files);

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1453,7 +1453,7 @@ void TrackDAO::markTracksAsMixxxDeleted(const QString& dir) {
 
 void TrackDAO::writeAudioMetaData(TrackInfoObject* pTrack){
     if (m_pConfig && m_pConfig->getValueString(ConfigKey("[Library]","WriteAudioTags")).toInt() == 1) {
-        AudioTagger tagger(pTrack->getLocation());
+        AudioTagger tagger(pTrack->getLocation(), pTrack->getSecurityToken());
 
         tagger.setArtist(pTrack->getArtist());
         tagger.setTitle(pTrack->getTitle());

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -917,7 +917,9 @@ TrackPointer TrackDAO::getTrackFromDB(const int id) const {
             bool header_parsed = query.value(headerParsedColumn).toBool();
             bool has_bpm_lock = query.value(bpmLockColumn).toBool();
 
-            TrackPointer pTrack = TrackPointer(new TrackInfoObject(location, false), &TrackDAO::deleteTrack);
+            TrackPointer pTrack = TrackPointer(
+                    new TrackInfoObject(location, SecurityTokenPointer(), false),
+                    &TrackDAO::deleteTrack);
 
             // TIO already stats the file to see if it exists, what its length is,
             // etc. So don't bother setting it.

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -134,7 +134,7 @@ void ITunesFeature::activate(bool forceReload) {
             // Users of Mixxx <1.12.0 didn't support sandboxing. If we are sandboxed
             // and using a custom iTunes path then we have to ask for access to this
             // file.
-            Sandbox::instance()->askForAccess(m_dbfile);
+            Sandbox::askForAccess(m_dbfile);
         } else {
             // if the path we got between the default and the database doesn't
             // exist, ask for a new one and use/save it if it exists
@@ -151,7 +151,7 @@ void ITunesFeature::activate(bool forceReload) {
             // this folder. Create a security bookmark while we have permission so
             // that we can access the folder on future runs. We need to canonicalize
             // the path so we first wrap the directory string with a QDir.
-            Sandbox::instance()->createSecurityToken(dbFile);
+            Sandbox::createSecurityToken(dbFile);
             settings.setValue(ITDB_PATH_KEY, m_dbfile);
         }
         m_isActivated =  true;
@@ -213,7 +213,7 @@ void ITunesFeature::onRightClick(const QPoint& globalPos) {
         // this folder. Create a security bookmark while we have permission so
         // that we can access the folder on future runs. We need to canonicalize
         // the path so we first wrap the directory string with a QDir.
-        Sandbox::instance()->createSecurityToken(dbFileInfo);
+        Sandbox::createSecurityToken(dbFileInfo);
 
         settings.setValue(ITDB_PATH_KEY, dbfile);
         activate(true); // clears tables before parsing

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -6,6 +6,7 @@
 #include <QMenu>
 #include <QAction>
 #include <QUrl>
+#include <QFileInfo>
 
 #include "library/itunes/itunesfeature.h"
 
@@ -15,6 +16,7 @@
 #include "library/baseexternalplaylistmodel.h"
 #include "library/queryutil.h"
 #include "util/lcs.h"
+#include "util/sandbox.h"
 
 const QString ITunesFeature::ITDB_PATH_KEY = "mixxx.itunesfeature.itdbpath";
 
@@ -126,15 +128,30 @@ void ITunesFeature::activate(bool forceReload) {
             // No Path in settings, try the default
             m_dbfile = getiTunesMusicPath();
         }
-        // if the path we got between the default and the database doesn't
-        // exist, ask for a new one and use/save it if it exists
-        if (!QFile::exists(m_dbfile)) {
+
+        QFileInfo dbFile(m_dbfile);
+        if (!m_dbfile.isEmpty() && dbFile.exists()) {
+            // Users of Mixxx <1.12.0 didn't support sandboxing. If we are sandboxed
+            // and using a custom iTunes path then we have to ask for access to this
+            // file.
+            Sandbox::instance()->askForAccess(m_dbfile);
+        } else {
+            // if the path we got between the default and the database doesn't
+            // exist, ask for a new one and use/save it if it exists
             m_dbfile = QFileDialog::getOpenFileName(
                 NULL, tr("Select your iTunes library"), QDir::homePath(), "*.xml");
-            if (m_dbfile.isEmpty() || !QFile::exists(m_dbfile)) {
+            QFileInfo dbFile(m_dbfile);
+            if (m_dbfile.isEmpty() || !dbFile.exists()) {
                 emit(showTrackModel(m_pITunesTrackModel));
                 return;
             }
+
+            // The user has picked a new directory via a file dialog. This means the
+            // system sandboxer (if we are sandboxed) has granted us permission to
+            // this folder. Create a security bookmark while we have permission so
+            // that we can access the folder on future runs. We need to canonicalize
+            // the path so we first wrap the directory string with a QDir.
+            Sandbox::instance()->createSecurityToken(dbFile);
             settings.setValue(ITDB_PATH_KEY, m_dbfile);
         }
         m_isActivated =  true;
@@ -186,9 +203,18 @@ void ITunesFeature::onRightClick(const QPoint& globalPos) {
         SettingsDAO settings(m_database);
         QString dbfile = QFileDialog::getOpenFileName(
             NULL, tr("Select your iTunes library"), QDir::homePath(), "*.xml");
-        if (dbfile.isEmpty() || !QFile::exists(dbfile)) {
+
+        QFileInfo dbFileInfo(dbfile);
+        if (dbfile.isEmpty() || !dbFileInfo.exists()) {
             return;
         }
+        // The user has picked a new directory via a file dialog. This means the
+        // system sandboxer (if we are sandboxed) has granted us permission to
+        // this folder. Create a security bookmark while we have permission so
+        // that we can access the folder on future runs. We need to canonicalize
+        // the path so we first wrap the directory string with a QDir.
+        Sandbox::instance()->createSecurityToken(dbFileInfo);
+
         settings.setValue(ITDB_PATH_KEY, dbfile);
         activate(true); // clears tables before parsing
     }
@@ -521,13 +547,13 @@ void ITunesFeature::parseTrack(QXmlStreamReader &xml, QSqlQuery &query) {
             break;
         }
     }
-    
+
     // If file is a remote file from iTunes Match, don't save it to the database.
     // There's no way that mixxx can access it.
     if (tracktype == "Remote") {
         return;
     }
-    
+
     // If we reach the end of <dict>
     // Save parsed track to database
     query.bindValue(":id", id);

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -95,7 +95,7 @@ Library::Library(QObject* parent, ConfigObject<ConfigValue>* pConfig,
     qDebug() << "Checking for access to user's library directories:";
     foreach (QString directoryPath, directories) {
         QFileInfo directory(directoryPath);
-        bool hasAccess = Sandbox::instance()->askForAccess(directory.canonicalFilePath());
+        bool hasAccess = Sandbox::askForAccess(directory.canonicalFilePath());
         qDebug() << "Checking for access to" << directoryPath << ":" << hasAccess;
     }
 }
@@ -248,7 +248,7 @@ void Library::slotRequestAddDir(QString dir) {
     // to canonicalize the path so we first wrap the directory string with a
     // QDir.
     QDir directory(dir);
-    Sandbox::instance()->createSecurityToken(directory);
+    Sandbox::createSecurityToken(directory);
 
     if (!m_pTrackCollection->getDirectoryDAO().addDirectory(dir)) {
         QMessageBox::information(0, tr("Add Directory to Library"),
@@ -307,7 +307,7 @@ void Library::slotRequestRelocateDir(QString oldDir, QString newDir) {
     // to canonicalize the path so we first wrap the directory string with a
     // QDir.
     QDir directory(newDir);
-    Sandbox::instance()->createSecurityToken(directory);
+    Sandbox::createSecurityToken(directory);
 
     QSet<int> movedIds = m_pTrackCollection->getDirectoryDAO().relocateDirectory(oldDir, newDir);
 

--- a/src/library/libraryscanner.cpp
+++ b/src/library/libraryscanner.cpp
@@ -26,6 +26,7 @@
 #include "library/queryutil.h"
 #include "trackinfoobject.h"
 #include "util/trace.h"
+#include "util/file.h"
 
 LibraryScanner::LibraryScanner(TrackCollection* collection)
               : m_pCollection(collection),

--- a/src/library/libraryscanner.cpp
+++ b/src/library/libraryscanner.cpp
@@ -418,7 +418,8 @@ bool LibraryScanner::recursiveScan(const QDir& dir, QStringList& verifiedDirecto
     return true;
 }
 
-bool LibraryScanner::importFiles(const QLinkedList<QFileInfo>& files) {
+bool LibraryScanner::importFiles(const QLinkedList<QFileInfo>& files,
+                                 SecurityTokenPointer pToken) {
     foreach (const QFileInfo& file, files) {
         // If a flag was raised telling us to cancel the library scan then stop.
         if (m_bCancelLibraryScan) {

--- a/src/library/libraryscanner.cpp
+++ b/src/library/libraryscanner.cpp
@@ -223,12 +223,18 @@ void LibraryScanner::run() {
     QStringList dirs = m_directoryDao.getDirs();
     bool bScanFinishedCleanly = false;
     // Recursivly scan each directory in the directories table.
-    foreach (const QString& dir, dirs) {
-        bScanFinishedCleanly = recursiveScan(dir, verifiedDirectories);
+    foreach (const QString& dirPath, dirs) {
+        // Acquire a security bookmark for this directory if we are in a
+        // sandbox. For speed we avoid opening security bookmarks when recursive
+        // scanning so that relies on having an open bookmark for the containing
+        // directory.
+        MDir dir(dirPath);
+
+        bScanFinishedCleanly = recursiveScan(dirPath, verifiedDirectories);
         if (bScanFinishedCleanly) {
-            qDebug() << "Recursive scanning (" << dir << ") finished cleanly.";
+            qDebug() << "Recursive scanning (" << dirPath << ") finished cleanly.";
         } else {
-            qDebug() << "Recursive scanning (" << dir << ") interrupted.";
+            qDebug() << "Recursive scanning (" << dirPath << ") interrupted.";
         }
     }
 

--- a/src/library/libraryscanner.cpp
+++ b/src/library/libraryscanner.cpp
@@ -442,7 +442,7 @@ bool LibraryScanner::importFiles(const QLinkedList<QFileInfo>& files,
             emit(progressLoading(file.fileName()));
 
             TrackPointer pTrack = TrackPointer(
-                    new TrackInfoObject(filePath, true, pToken),
+                    new TrackInfoObject(filePath, pToken),
                     &QObject::deleteLater);
             if (m_trackDao.addTracksAdd(pTrack.data(), false)) {
                 // Successfully added. Signal the main instance of TrackDAO,

--- a/src/library/libraryscanner.h
+++ b/src/library/libraryscanner.h
@@ -39,6 +39,7 @@
 #include "library/dao/analysisdao.h"
 #include "libraryscannerdlg.h"
 #include "trackcollection.h"
+#include "util/sandbox.h"
 
 class TrackInfoObject;
 
@@ -66,11 +67,13 @@ class LibraryScanner : public QThread {
     // directories that have already been scanned and have not changed. Changes
     // are tracked by performing a hash of the directory's file list, and those
     // hashes are stored in the database.
-    bool recursiveScan(const QDir& dirPath, QStringList& verifiedDirectories);
+    bool recursiveScan(const QDir& dirPath, QStringList& verifiedDirectories,
+                       SecurityTokenPointer pToken);
 
     // Import the provided files. Returns true if the scan completed without
     // being cancelled. False if the scan was cancelled part-way through.
-    bool importFiles(const QLinkedList<QFileInfo>& files);
+    bool importFiles(const QLinkedList<QFileInfo>& files,
+                     SecurityTokenPointer pToken);
 
     // The library trackcollection
     TrackCollection* m_pCollection;

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -14,6 +14,7 @@
 #include "treeitem.h"
 #include "soundsourceproxy.h"
 #include "widget/wlibrary.h"
+#include "util/dnd.h"
 
 MixxxLibraryFeature::MixxxLibraryFeature(QObject* parent,
                                          TrackCollection* pTrackCollection,
@@ -162,15 +163,7 @@ bool MixxxLibraryFeature::dropAccept(QList<QUrl> urls, QObject* pSource) {
     if (pSource) {
         return false;
     } else {
-        QList<QFileInfo> files;
-        foreach (QUrl url, urls) {
-            // XXX: Possible WTF alert - Previously we thought we needed toString() here
-            // but what you actually want in any case when converting a QUrl to a file
-            // system path is QUrl::toLocalFile(). This is the second time we have
-            // flip-flopped on this, but I think toLocalFile() should work in any
-            // case. toString() absolutely does not work when you pass the result to a
-            files.append(url.toLocalFile());
-        }
+        QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
 
         // Adds track, does not insert duplicates, handles unremoving logic.
         QList<int> trackIds = m_trackDao.addTracks(files, true);

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -32,6 +32,7 @@
 #include "library/dao/playlistdao.h"
 #include "library/dao/analysisdao.h"
 #include "library/dao/directorydao.h"
+#include "util/sandbox.h"
 
 class TrackInfoObject;
 

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -32,7 +32,6 @@
 #include "library/dao/playlistdao.h"
 #include "library/dao/analysisdao.h"
 #include "library/dao/directorydao.h"
-#include "util/sandbox.h"
 
 class TrackInfoObject;
 

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -15,6 +15,7 @@
 #include "library/queryutil.h"
 #include "library/trackcollection.h"
 #include "library/treeitem.h"
+#include "util/sandbox.h"
 
 TraktorTrackModel::TraktorTrackModel(QObject* parent,
                                      TrackCollection* pTrackCollection,
@@ -556,7 +557,13 @@ QString TraktorFeature::getTraktorMusicDatabase() {
     //Let's try to detect the latest Traktor version and its collection.nml
     QString myDocuments = QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation);
     QDir ni_directory(myDocuments +"/Native Instruments/");
-    ni_directory.setFilter(QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks) ;
+    ni_directory.setFilter(QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks);
+
+    // We may not have access to this directory since it is in the user's
+    // Documents folder. Ask for access if we don't have it.
+    if (ni_directory.exists()) {
+        Sandbox::instance()->askForAccess(ni_directory.canonicalPath());
+    }
 
     //Iterate over the subfolders
     QFileInfoList list = ni_directory.entryInfoList();
@@ -595,7 +602,7 @@ void TraktorFeature::onTrackCollectionLoaded() {
     TreeItem* root = m_future.result();
     if (root) {
         m_childModel.setRootItem(root);
-        // Tell the rhythmbox track source that it should re-build its index.
+        // Tell the traktor track source that it should re-build its index.
         m_trackSource->buildIndex();
 
         //m_pTraktorTableModel->select();

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -562,7 +562,7 @@ QString TraktorFeature::getTraktorMusicDatabase() {
     // We may not have access to this directory since it is in the user's
     // Documents folder. Ask for access if we don't have it.
     if (ni_directory.exists()) {
-        Sandbox::instance()->askForAccess(ni_directory.canonicalPath());
+        Sandbox::askForAccess(ni_directory.canonicalPath());
     }
 
     //Iterate over the subfolders

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -102,8 +102,7 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
     m_pConfig = upgrader.versionUpgrade(args.getSettingsPath());
     ControlDoublePrivate::setUserConfig(m_pConfig);
 
-    Sandbox* pSandbox = Sandbox::create();
-    pSandbox->setPermissionsFile(m_pConfig->getSettingsPath().append("/sandbox.cfg"));
+    Sandbox::initialize(m_pConfig->getSettingsPath().append("/sandbox.cfg"));
 
     // Only record stats in developer mode.
     if (m_cmdLineArgs.getDeveloper()) {
@@ -483,7 +482,7 @@ MixxxMainWindow::~MixxxMainWindow() {
     delete m_pPrefDlg;
 
     qDebug() << "delete config " << qTime.elapsed();
-    Sandbox::destroy();
+    Sandbox::shutdown();
 
     ControlDoublePrivate::setUserConfig(NULL);
     delete m_pConfig;
@@ -1311,7 +1310,8 @@ void MixxxMainWindow::slotFileLoadSongPlayer(int deck) {
         // we can access the folder on future runs. We need to canonicalize the
         // path so we first wrap the directory string with a QDir.
         QFileInfo trackInfo(s);
-        Sandbox::instance()->createSecurityToken(trackInfo);
+        Sandbox::createSecurityToken(trackInfo);
+
         m_pPlayerManager->slotLoadToDeck(s, deck);
     }
 }

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1305,6 +1305,13 @@ void MixxxMainWindow::slotFileLoadSongPlayer(int deck) {
 
 
     if (!s.isNull()) {
+        // The user has picked a file via a file dialog. This means the system
+        // sandboxer (if we are sandboxed) has granted us permission to this
+        // folder. Create a security bookmark while we have permission so that
+        // we can access the folder on future runs. We need to canonicalize the
+        // path so we first wrap the directory string with a QDir.
+        QFileInfo trackInfo(s);
+        Sandbox::instance()->createSecurityToken(trackInfo);
         m_pPlayerManager->slotLoadToDeck(s, deck);
     }
 }

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1294,7 +1294,7 @@ void MixxxMainWindow::slotFileLoadSongPlayer(int deck) {
             return;
     }
 
-    QString s =
+    QString trackPath =
         QFileDialog::getOpenFileName(
             this,
             loadTrackText,
@@ -1303,16 +1303,16 @@ void MixxxMainWindow::slotFileLoadSongPlayer(int deck) {
                 .arg(SoundSourceProxy::supportedFileExtensionsString()));
 
 
-    if (!s.isNull()) {
+    if (!trackPath.isNull()) {
         // The user has picked a file via a file dialog. This means the system
         // sandboxer (if we are sandboxed) has granted us permission to this
         // folder. Create a security bookmark while we have permission so that
         // we can access the folder on future runs. We need to canonicalize the
         // path so we first wrap the directory string with a QDir.
-        QFileInfo trackInfo(s);
+        QFileInfo trackInfo(trackPath);
         Sandbox::createSecurityToken(trackInfo);
 
-        m_pPlayerManager->slotLoadToDeck(s, deck);
+        m_pPlayerManager->slotLoadToDeck(trackPath, deck);
     }
 }
 

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -15,11 +15,6 @@ QString chromaprinter::getFingerPrint(TrackPointer pTrack){
     return calcFingerPrint(soundSource);
 }
 
-QString chromaprinter::getFingerPrint(QString location){
-    SoundSourceProxy soundSource(location);
-    return calcFingerPrint(soundSource);
-}
-
 QString chromaprinter::calcFingerPrint(SoundSourceProxy& soundSource){
     soundSource.open();
     m_SampleRate = soundSource.getSampleRate();

--- a/src/musicbrainz/chromaprinter.h
+++ b/src/musicbrainz/chromaprinter.h
@@ -13,7 +13,6 @@ class chromaprinter: public QObject {
   public:
     chromaprinter(QObject* parent=NULL);
     QString getFingerPrint(TrackPointer pTrack);
-    QString getFingerPrint(QString location);
 
   private:
 

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -114,7 +114,8 @@ void TagFetcher::tagsFetched(int index, const MusicBrainzClient::ResultList& res
     QList<TrackPointer> tracksGuessed;
 
     foreach (const MusicBrainzClient::Result& result, results) {
-        TrackPointer track(new TrackInfoObject(originalTrack->getLocation(),false),
+        TrackPointer track(new TrackInfoObject(originalTrack->getLocation(),
+                                               false, originalTrack->getSecurityToken()),
                            &QObject::deleteLater);
         track->setTitle(result.m_title);
         track->setArtist(result.m_artist);

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -115,7 +115,8 @@ void TagFetcher::tagsFetched(int index, const MusicBrainzClient::ResultList& res
 
     foreach (const MusicBrainzClient::Result& result, results) {
         TrackPointer track(new TrackInfoObject(originalTrack->getLocation(),
-                                               false, originalTrack->getSecurityToken()),
+                                               originalTrack->getSecurityToken(),
+                                               false),
                            &QObject::deleteLater);
         track->setTitle(result.m_title);
         track->setArtist(result.m_artist);

--- a/src/samplerbank.cpp
+++ b/src/samplerbank.cpp
@@ -29,6 +29,11 @@ void SamplerBank::slotSaveSamplerBank(double v) {
 
     QString s = QFileDialog::getSaveFileName(NULL, tr("Save Sampler Bank"));
 
+    // The user has picked a new directory via a file dialog. This means the
+    // system sandboxer (if we are sandboxed) has granted us permission to this
+    // folder. We don't need access to this file on a regular basis so we do not
+    // register a security bookmark.
+
     QFile file(s);
     if (!file.open(QIODevice::WriteOnly)) {
         QMessageBox::warning(NULL,
@@ -67,6 +72,11 @@ void SamplerBank::slotLoadSamplerBank(double v) {
         return;
 
     QString s = QFileDialog::getOpenFileName(NULL, tr("Load Sampler Bank"));
+
+    // The user has picked a new directory via a file dialog. This means the
+    // system sandboxer (if we are sandboxed) has granted us permission to this
+    // folder. We don't need access to this file on a regular basis so we do not
+    // register a security bookmark.
 
     QFile file(s);
     if (!file.open(QIODevice::WriteOnly)) {

--- a/src/samplerbank.cpp
+++ b/src/samplerbank.cpp
@@ -27,18 +27,19 @@ void SamplerBank::slotSaveSamplerBank(double v) {
     if (v == 0.0)
         return;
 
-    QString s = QFileDialog::getSaveFileName(NULL, tr("Save Sampler Bank"));
+    QString samplerBankPath = QFileDialog::getSaveFileName(NULL, tr("Save Sampler Bank"));
 
     // The user has picked a new directory via a file dialog. This means the
     // system sandboxer (if we are sandboxed) has granted us permission to this
     // folder. We don't need access to this file on a regular basis so we do not
     // register a security bookmark.
 
-    QFile file(s);
+    QFile file(samplerBankPath);
     if (!file.open(QIODevice::WriteOnly)) {
         QMessageBox::warning(NULL,
                              tr("Error Saving Sampler Bank"),
-                             tr("Could not write the sampler bank to '%1'.").arg(s));
+                             tr("Could not write the sampler bank to '%1'.")
+                             .arg(samplerBankPath));
         return;
     }
 
@@ -71,18 +72,19 @@ void SamplerBank::slotLoadSamplerBank(double v) {
     if (v == 0.0)
         return;
 
-    QString s = QFileDialog::getOpenFileName(NULL, tr("Load Sampler Bank"));
+    QString samplerBankPath = QFileDialog::getOpenFileName(NULL, tr("Load Sampler Bank"));
 
     // The user has picked a new directory via a file dialog. This means the
     // system sandboxer (if we are sandboxed) has granted us permission to this
     // folder. We don't need access to this file on a regular basis so we do not
     // register a security bookmark.
 
-    QFile file(s);
+    QFile file(samplerBankPath);
     if (!file.open(QIODevice::WriteOnly)) {
         QMessageBox::warning(NULL,
                              tr("Error Reading Sampler Bank"),
-                             tr("Could not open the sampler bank file '%1'.").arg(s));
+                             tr("Could not open the sampler bank file '%1'.")
+                             .arg(samplerBankPath));
         return;
     }
 
@@ -91,7 +93,8 @@ void SamplerBank::slotLoadSamplerBank(double v) {
     if (!doc.setContent(file.readAll())) {
         QMessageBox::warning(NULL,
                              tr("Error Reading Sampler Bank"),
-                             tr("Could not read the sampler bank file '%1'.").arg(s));
+                             tr("Could not read the sampler bank file '%1'.")
+                             .arg(samplerBankPath));
         return;
     }
 
@@ -99,7 +102,8 @@ void SamplerBank::slotLoadSamplerBank(double v) {
     if(root.tagName() != "samplerbank") {
         QMessageBox::warning(NULL,
                              tr("Error Reading Sampler Bank"),
-                             tr("Could not read the sampler bank file '%1'.").arg(s));
+                             tr("Could not read the sampler bank file '%1'.")
+                             .arg(samplerBankPath));
         return;
     }
 

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -29,7 +29,6 @@
 #include <taglib/wavpackfile.h>
 
 #include "soundsource.h"
-#include "util/sandbox.h"
 
 namespace Mixxx
 {

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -56,17 +56,11 @@ SoundSource::SoundSource(QString qFilename)
           m_iDuration(0),
           m_iBitrate(0),
           m_iSampleRate(0),
-          m_iChannels(0),
-          m_pSecurityToken(NULL) {
-    // Open a security token for the file if we are in a sandbox.
-    QFileInfo info(m_qFilename);
-    m_pSecurityToken = Sandbox::instance()->openSecurityToken(info, true);
+          m_iChannels(0) {
 }
 
 SoundSource::~SoundSource() {
-    Sandbox::instance()->closeSecurityToken(m_pSecurityToken);
 }
-
 
 QList<long> *SoundSource::getCuePoints()
 {

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -29,6 +29,7 @@
 #include <taglib/wavpackfile.h>
 
 #include "soundsource.h"
+#include "util/sandbox.h"
 
 namespace Mixxx
 {
@@ -49,18 +50,21 @@ const bool SoundSource::s_bDebugMetadata = false;
    return type is int: 0 for OK, -1 for an error.
  */
 SoundSource::SoundSource(QString qFilename)
-    : m_qFilename(qFilename)
-{
-    m_iSampleRate = 0;
-    m_fBPM = 0.0f;
-    m_fReplayGain = 0.0f;
-    m_iDuration = 0;
-    m_iBitrate = 0;
-    m_iChannels = 0;
+        : m_qFilename(qFilename),
+          m_fReplayGain(0.0f),
+          m_fBPM(0.0f),
+          m_iDuration(0),
+          m_iBitrate(0),
+          m_iSampleRate(0),
+          m_iChannels(0),
+          m_pSecurityToken(NULL) {
+    // Open a security token for the file if we are in a sandbox.
+    QFileInfo info(m_qFilename);
+    m_pSecurityToken = Sandbox::instance()->openSecurityToken(info, true);
 }
 
-SoundSource::~SoundSource()
-{
+SoundSource::~SoundSource() {
+    Sandbox::instance()->closeSecurityToken(m_pSecurityToken);
 }
 
 

--- a/src/soundsource.h
+++ b/src/soundsource.h
@@ -28,8 +28,6 @@
 
 #include "defs.h"
 
-struct SandboxSecurityToken;
-
 #define MIXXX_SOUNDSOURCE_API_VERSION 5
 /** @note SoundSource API Version history:
            1 - Mixxx 1.8.0 Beta 2
@@ -146,8 +144,6 @@ protected:
     unsigned int m_iSampleRate;
     int m_iChannels;
     //Dontcha be forgettin' to initialize these variables.... arr
-
-    SandboxSecurityToken* m_pSecurityToken;
 
     static const bool s_bDebugMetadata;
 };

--- a/src/soundsource.h
+++ b/src/soundsource.h
@@ -18,6 +18,8 @@
 #ifndef SOUNDSOURCE_H
 #define SOUNDSOURCE_H
 
+#include <QString>
+
 #include <taglib/tfile.h>
 #include <taglib/apetag.h>
 #include <taglib/id3v2tag.h>
@@ -25,7 +27,8 @@
 #include <taglib/mp4tag.h>
 
 #include "defs.h"
-#include <QString>
+
+struct SandboxSecurityToken;
 
 #define MIXXX_SOUNDSOURCE_API_VERSION 5
 /** @note SoundSource API Version history:
@@ -143,6 +146,8 @@ protected:
     unsigned int m_iSampleRate;
     int m_iChannels;
     //Dontcha be forgettin' to initialize these variables.... arr
+
+    SandboxSecurityToken* m_pSecurityToken;
 
     static const bool s_bDebugMetadata;
 };

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -104,7 +104,7 @@ void SoundSourceProxy::loadPlugins() {
     // ../lib/mixxx/plugins/soundsource.
     QDir libPluginDir(UNIX_LIB_PATH);
     if (libPluginDir.cd("plugins") && libPluginDir.cd("soundsource")) {
-	pluginDirs << libPluginDir
+	pluginDirs << libPluginDir;
     }
 
     QDir dataPluginDir(QDesktopServices::storageLocation(QDesktopServices::DataLocation));

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -61,7 +61,7 @@ SoundSourceProxy::SoundSourceProxy(QString qFilename)
       m_pSecurityToken(NULL) {
     // Open a security token for the file if we are in a sandbox.
     QFileInfo info(m_qFilename);
-    m_pSecurityToken = Sandbox::instance()->openSecurityToken(info, true);
+    m_pSecurityToken = Sandbox::openSecurityToken(info, true);
 
     // Create the underlying SoundSource.
     m_pSoundSource = initialize(qFilename);
@@ -75,14 +75,14 @@ SoundSourceProxy::SoundSourceProxy(TrackPointer pTrack)
       m_pSecurityToken(NULL) {
     // Open a security token for the file if we are in a sandbox.
     QFileInfo info(pTrack->getFileInfo());
-    m_pSecurityToken = Sandbox::instance()->openSecurityToken(info, true);
+    m_pSecurityToken = Sandbox::openSecurityToken(info, true);
 
     m_pSoundSource = initialize(pTrack->getLocation());
 }
 
 SoundSourceProxy::~SoundSourceProxy() {
     delete m_pSoundSource;
-    Sandbox::instance()->closeSecurityToken(m_pSecurityToken);
+    Sandbox::closeSecurityToken(m_pSecurityToken);
 }
 
 // static

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -45,7 +45,6 @@
 #endif
 #include "soundsourceflac.h"
 #include "util/cmdlineargs.h"
-#include "util/sandbox.h"
 
 //Static memory allocation
 QRegExp SoundSourceProxy::m_supportedFileRegex;
@@ -53,16 +52,15 @@ QMap<QString, QLibrary*> SoundSourceProxy::m_plugins;
 QMap<QString, getSoundSourceFunc> SoundSourceProxy::m_extensionsSupportedByPlugins;
 QMutex SoundSourceProxy::m_extensionsMutex;
 
-
 //Constructor
 SoundSourceProxy::SoundSourceProxy(QString qFilename, SecurityTokenPointer pToken)
     : Mixxx::SoundSource(qFilename),
       m_pSoundSource(NULL),
       m_pSecurityToken(pToken) {
     if (pToken.isNull()) {
-	// Open a security token for the file if we are in a sandbox.
-	QFileInfo info(m_qFilename);
-	m_pSecurityToken = Sandbox::openSecurityToken(info, true);
+        // Open a security token for the file if we are in a sandbox.
+        QFileInfo info(m_qFilename);
+        m_pSecurityToken = Sandbox::openSecurityToken(info, true);
     }
 
     // Create the underlying SoundSource.
@@ -76,9 +74,9 @@ SoundSourceProxy::SoundSourceProxy(TrackPointer pTrack)
       m_pTrack(pTrack),
       m_pSecurityToken(pTrack->getSecurityToken()) {
     if (m_pSecurityToken.isNull()) {
-	// Open a security token for the file if we are in a sandbox.
-	QFileInfo info(m_qFilename);
-	m_pSecurityToken = Sandbox::openSecurityToken(info, true);
+        // Open a security token for the file if we are in a sandbox.
+        QFileInfo info(m_qFilename);
+        m_pSecurityToken = Sandbox::openSecurityToken(info, true);
     }
 
     m_pSoundSource = initialize(pTrack->getLocation());

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -57,8 +57,7 @@ QMutex SoundSourceProxy::m_extensionsMutex;
 //Constructor
 SoundSourceProxy::SoundSourceProxy(QString qFilename)
     : Mixxx::SoundSource(qFilename),
-      m_pSoundSource(NULL),
-      m_pSecurityToken(NULL) {
+      m_pSoundSource(NULL) {
     // Open a security token for the file if we are in a sandbox.
     QFileInfo info(m_qFilename);
     m_pSecurityToken = Sandbox::openSecurityToken(info, true);
@@ -71,8 +70,7 @@ SoundSourceProxy::SoundSourceProxy(QString qFilename)
 SoundSourceProxy::SoundSourceProxy(TrackPointer pTrack)
     : SoundSource(pTrack->getLocation()),
       m_pSoundSource(NULL),
-      m_pTrack(pTrack),
-      m_pSecurityToken(NULL) {
+      m_pTrack(pTrack) {
     // Open a security token for the file if we are in a sandbox.
     QFileInfo info(pTrack->getFileInfo());
     m_pSecurityToken = Sandbox::openSecurityToken(info, true);
@@ -82,7 +80,6 @@ SoundSourceProxy::SoundSourceProxy(TrackPointer pTrack)
 
 SoundSourceProxy::~SoundSourceProxy() {
     delete m_pSoundSource;
-    Sandbox::closeSecurityToken(m_pSecurityToken);
 }
 
 // static

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -55,12 +55,15 @@ QMutex SoundSourceProxy::m_extensionsMutex;
 
 
 //Constructor
-SoundSourceProxy::SoundSourceProxy(QString qFilename)
+SoundSourceProxy::SoundSourceProxy(QString qFilename, SecurityTokenPointer pToken)
     : Mixxx::SoundSource(qFilename),
-      m_pSoundSource(NULL) {
-    // Open a security token for the file if we are in a sandbox.
-    QFileInfo info(m_qFilename);
-    m_pSecurityToken = Sandbox::openSecurityToken(info, true);
+      m_pSoundSource(NULL),
+      m_pSecurityToken(pToken) {
+    if (pToken.isNull()) {
+	// Open a security token for the file if we are in a sandbox.
+	QFileInfo info(m_qFilename);
+	m_pSecurityToken = Sandbox::openSecurityToken(info, true);
+    }
 
     // Create the underlying SoundSource.
     m_pSoundSource = initialize(qFilename);
@@ -70,10 +73,13 @@ SoundSourceProxy::SoundSourceProxy(QString qFilename)
 SoundSourceProxy::SoundSourceProxy(TrackPointer pTrack)
     : SoundSource(pTrack->getLocation()),
       m_pSoundSource(NULL),
-      m_pTrack(pTrack) {
-    // Open a security token for the file if we are in a sandbox.
-    QFileInfo info(pTrack->getFileInfo());
-    m_pSecurityToken = Sandbox::openSecurityToken(info, true);
+      m_pTrack(pTrack),
+      m_pSecurityToken(pTrack->getSecurityToken()) {
+    if (m_pSecurityToken.isNull()) {
+	// Open a security token for the file if we are in a sandbox.
+	QFileInfo info(m_qFilename);
+	m_pSecurityToken = Sandbox::openSecurityToken(info, true);
+    }
 
     m_pSoundSource = initialize(pTrack->getLocation());
 }

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -104,17 +104,17 @@ void SoundSourceProxy::loadPlugins() {
     // ../lib/mixxx/plugins/soundsource.
     QDir libPluginDir(UNIX_LIB_PATH);
     if (libPluginDir.cd("plugins") && libPluginDir.cd("soundsource")) {
-	pluginDirs << libPluginDir;
+        pluginDirs << libPluginDir;
     }
 
     QDir dataPluginDir(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
     if (dataPluginDir.cd("plugins") && dataPluginDir.cd("soundsource")) {
-	pluginDirs << dataPluginDir;
+        pluginDirs << dataPluginDir;
     }
 #elif __WINDOWS__
     QDir appPluginDir(QCoreApplication::applicationDirPath());
     if (appPluginDir.cd("plugins") && appPluginDir.cd("soundsource")) {
-	pluginDirs << appPluginDir;
+        pluginDirs << appPluginDir;
     }
 #elif __APPLE__
     // blah/Mixxx.app/Contents/MacOS/../PlugIns/
@@ -123,12 +123,12 @@ void SoundSourceProxy::loadPlugins() {
     //blah/Mixxx.app/Contents/PlugIns/soundsource
     QDir bundlePluginDir(QCoreApplication::applicationDirPath());
     if (bundlePluginDir.cdUp() && bundlePluginDir.cd("PlugIns")) {
-	pluginDirs << bundlePluginDir;
+        pluginDirs << bundlePluginDir;
     }
 
     QDir dataPluginDir(QDesktopServices::storageLocation(QDesktopServices::DataLocation));
     if (dataPluginDir.cd("Plugins") && dataPluginDir.cd("soundsource")) {
-	pluginDirs << dataPluginDir;
+        pluginDirs << dataPluginDir;
     }
 
     nameFilters << "libsoundsource*";

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -39,7 +39,7 @@
 class SoundSourceProxy : public Mixxx::SoundSource
 {
 public:
-    SoundSourceProxy(QString qFilename);
+    SoundSourceProxy(QString qFilename, SecurityTokenPointer pToken);
     SoundSourceProxy(TrackPointer pTrack);
     ~SoundSourceProxy();
     static void loadPlugins();
@@ -66,7 +66,7 @@ private:
     //void initPlugin(QString lib_filename, QString track_filename);
     static QLibrary* getPlugin(QString lib_filename);
 
-    SoundSource *m_pSoundSource;
+    SoundSource* m_pSoundSource;
     TrackPointer m_pTrack;
     SecurityTokenPointer m_pSecurityToken;
 

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -26,8 +26,7 @@
 
 #include "soundsource.h"
 #include "trackinfoobject.h"
-
-struct SandboxSecurityToken;
+#include "util/sandbox.h"
 
 /**
   *@author Tue Haste Andersen
@@ -69,7 +68,7 @@ private:
 
     SoundSource *m_pSoundSource;
     TrackPointer m_pTrack;
-    SandboxSecurityToken* m_pSecurityToken;
+    SecurityTokenPointer m_pSecurityToken;
 
     static QRegExp m_supportedFileRegex;
     static QMap<QString, QLibrary*> m_plugins;

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -27,7 +27,7 @@
 #include "soundsource.h"
 #include "trackinfoobject.h"
 
-class QLibrary;
+struct SandboxSecurityToken;
 
 /**
   *@author Tue Haste Andersen
@@ -69,6 +69,7 @@ private:
 
     SoundSource *m_pSoundSource;
     TrackPointer m_pTrack;
+    SandboxSecurityToken* m_pSecurityToken;
 
     static QRegExp m_supportedFileRegex;
     static QMap<QString, QLibrary*> m_plugins;

--- a/src/test/directorydoatest.cpp
+++ b/src/test/directorydoatest.cpp
@@ -143,10 +143,14 @@ TEST_F(DirectoryDAOTest, relocateDirTest) {
     TrackDAO &trackDAO = m_pTrackCollection->getTrackDAO();
     // ok now lets create some tracks here
     trackDAO.addTracksPrepare();
-    trackDAO.addTracksAdd(new TrackInfoObject(testdir + "/a", false), false);
-    trackDAO.addTracksAdd(new TrackInfoObject(testdir + "/b", false), false);
-    trackDAO.addTracksAdd(new TrackInfoObject(test2 + "/c", false), false);
-    trackDAO.addTracksAdd(new TrackInfoObject(test2 + "/d", false), false);
+    trackDAO.addTracksAdd(new TrackInfoObject(
+            testdir + "/a", SecurityTokenPointer(), false), false);
+    trackDAO.addTracksAdd(new TrackInfoObject(
+            testdir + "/b", SecurityTokenPointer(), false), false);
+    trackDAO.addTracksAdd(new TrackInfoObject(
+            test2 + "/c", SecurityTokenPointer(), false), false);
+    trackDAO.addTracksAdd(new TrackInfoObject(
+            test2 + "/d", SecurityTokenPointer(), false), false);
     trackDAO.addTracksFinish(false);
 
     QSet<int> ids = directoryDao.relocateDirectory(testdir, testnew);

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -252,6 +252,13 @@ QString TrackInfoObject::getCanonicalLocation() const {
     return m_fileInfo.canonicalFilePath();
 }
 
+QFileInfo TrackInfoObject::getFileInfo() const {
+    // No need for locking since we are passing a copy by value. Qt doesn't say
+    // that QFileInfo is thread-safe but its copy constructor just copies the
+    // d_ptr.
+    return m_fileInfo;
+}
+
 QString TrackInfoObject::getDirectory() const {
     QMutexLocker lock(&m_qMutex);
     return m_fileInfo.absolutePath();

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -247,6 +247,11 @@ QString TrackInfoObject::getLocation() const {
     return m_fileInfo.absoluteFilePath();
 }
 
+QString TrackInfoObject::getCanonicalLocation() const {
+    QMutexLocker lock(&m_qMutex);
+    return m_fileInfo.canonicalFilePath();
+}
+
 QString TrackInfoObject::getDirectory() const {
     QMutexLocker lock(&m_qMutex);
     return m_fileInfo.absolutePath();

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -36,8 +36,9 @@
 #include "util/cmdlineargs.h"
 #include "util/time.h"
 
-TrackInfoObject::TrackInfoObject(const QString& file, bool parseHeader,
-                                 SecurityTokenPointer pToken)
+TrackInfoObject::TrackInfoObject(const QString& file,
+                                 SecurityTokenPointer pToken,
+                                 bool parseHeader)
         : m_fileInfo(file),
           m_pSecurityToken(pToken.isNull() ? Sandbox::openSecurityToken(
                   m_fileInfo, true) : pToken),
@@ -48,8 +49,9 @@ TrackInfoObject::TrackInfoObject(const QString& file, bool parseHeader,
     initialize(parseHeader);
 }
 
-TrackInfoObject::TrackInfoObject(const QFileInfo& fileInfo, bool parseHeader,
-                                 SecurityTokenPointer pToken)
+TrackInfoObject::TrackInfoObject(const QFileInfo& fileInfo,
+                                 SecurityTokenPointer pToken,
+                                 bool parseHeader)
         : m_fileInfo(fileInfo),
           m_pSecurityToken(pToken.isNull() ? Sandbox::openSecurityToken(
                   m_fileInfo, true) : pToken),

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -94,6 +94,8 @@ public:
 
     // Returns absolute path to the file, including the filename.
     QString getLocation() const;
+    QString getCanonicalLocation() const;
+
     // Returns the absolute path to the directory containing the file
     QString getDirectory() const;
     // Returns the filename of the file.

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -33,6 +33,7 @@
 #include "track/keys.h"
 #include "proto/keys.pb.h"
 #include "library/dao/cue.h"
+#include "util/sandbox.h"
 
 class QString;
 class QDomElement;
@@ -53,9 +54,11 @@ class TrackInfoObject : public QObject
     Q_OBJECT
 public:
     // Initialize a new track with the filename.
-    TrackInfoObject(const QString& file="", bool parseHeader=true);
+    TrackInfoObject(const QString& file="", bool parseHeader=true,
+                    SecurityTokenPointer pToken=SecurityTokenPointer());
     // Initialize track with a QFileInfo class
-    TrackInfoObject(const QFileInfo& fileInfo, bool parseHeader=true);
+    TrackInfoObject(const QFileInfo& fileInfo, bool parseHeader=true,
+                    SecurityTokenPointer pToken=SecurityTokenPointer());
     // Creates a new track given information from the xml file.
     TrackInfoObject(const QDomNode &);
     virtual ~TrackInfoObject();
@@ -96,6 +99,7 @@ public:
     QString getLocation() const;
     QString getCanonicalLocation() const;
     QFileInfo getFileInfo() const;
+    SecurityTokenPointer getSecurityToken();
 
     // Returns the absolute path to the directory containing the file
     QString getDirectory() const;
@@ -309,6 +313,8 @@ public:
 
     // The file
     QFileInfo m_fileInfo;
+
+    SecurityTokenPointer m_pSecurityToken;
 
     // Metadata
     // Album

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -95,6 +95,7 @@ public:
     // Returns absolute path to the file, including the filename.
     QString getLocation() const;
     QString getCanonicalLocation() const;
+    QFileInfo getFileInfo() const;
 
     // Returns the absolute path to the directory containing the file
     QString getDirectory() const;

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -54,11 +54,13 @@ class TrackInfoObject : public QObject
     Q_OBJECT
 public:
     // Initialize a new track with the filename.
-    TrackInfoObject(const QString& file="", bool parseHeader=true,
-                    SecurityTokenPointer pToken=SecurityTokenPointer());
+    TrackInfoObject(const QString& file="",
+                    SecurityTokenPointer pToken=SecurityTokenPointer(),
+                    bool parseHeader=true);
     // Initialize track with a QFileInfo class
-    TrackInfoObject(const QFileInfo& fileInfo, bool parseHeader=true,
-                    SecurityTokenPointer pToken=SecurityTokenPointer());
+    TrackInfoObject(const QFileInfo& fileInfo,
+                    SecurityTokenPointer pToken=SecurityTokenPointer(),
+                    bool parseHeader=true);
     // Creates a new track given information from the xml file.
     TrackInfoObject(const QDomNode &);
     virtual ~TrackInfoObject();

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -327,6 +327,7 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
             qDebug() << "Upgrade Failed";
         }
     }
+
     if (configVersion.startsWith("1.11")) {
         qDebug() << "Upgrading from v1.11.x...";
 
@@ -335,8 +336,14 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
         // directories table
         TrackCollection tc(config);
         DirectoryDAO directoryDAO = tc.getDirectoryDAO();
-        bool successful = directoryDAO.addDirectory(currentFolder);
 
+        // NOTE(rryan): We don't have to ask for sandbox permission to this
+        // directory because the normal startup integrity check in Library will
+        // notice if we don't have permission and ask for access. Also, the
+        // Sandbox isn't setup yet at this point in startup because it relies on
+        // the config settings path and this function is what loads the config
+        // so it's not ready yet.
+        bool successful = directoryDAO.addDirectory(currentFolder);
         if (successful) {
             configVersion = VERSION;
             m_bUpgraded = true;

--- a/src/util/dnd.h
+++ b/src/util/dnd.h
@@ -2,6 +2,8 @@
 #define DND_H
 
 #include <QUrl>
+#include <QDrag>
+#include <QMimeData>
 #include <QList>
 #include <QString>
 #include <QFileInfo>
@@ -67,7 +69,42 @@ class DragAndDropHelper {
         return fileLocations;
     }
 
+    static QDrag* dragTrack(TrackPointer pTrack, QWidget* pDragSource) {
+        QList<QUrl> locationUrls;
+        locationUrls.append(urlFromLocation(pTrack->getLocation()));
+        return dragUrls(locationUrls, pDragSource);
+    }
+
+    static QDrag* dragTrackLocations(const QList<QString>& locations,
+                                     QWidget* pDragSource) {
+        QList<QUrl> locationUrls;
+        foreach (QString location, locations) {
+            locationUrls.append(urlFromLocation(location));
+        }
+        return dragUrls(locationUrls, pDragSource);
+    }
+
+    static QUrl urlFromLocation(const QString& trackLocation) {
+        return QUrl::fromLocalFile(trackLocation);
+    }
+
   private:
+    static QDrag* dragUrls(const QList<QUrl>& locationUrls,
+                           QWidget* pDragSource) {
+        if (locationUrls.isEmpty()) {
+            return NULL;
+        }
+
+        QMimeData* mimeData = new QMimeData();
+        mimeData->setUrls(locationUrls);
+
+        QDrag* drag = new QDrag(pDragSource);
+        drag->setMimeData(mimeData);
+        drag->setPixmap(QPixmap(":images/library/ic_library_drag_and_drop.png"));
+        drag->exec(Qt::CopyAction);
+
+        return drag;
+    }
 
     static bool addFileToList(const QString& file, QList<QFileInfo>* files) {
         QFileInfo fileInfo(file);

--- a/src/util/dnd.h
+++ b/src/util/dnd.h
@@ -1,0 +1,95 @@
+#ifndef DND_H
+#define DND_H
+
+#include <QUrl>
+#include <QList>
+#include <QString>
+#include <QFileInfo>
+#include <QRegExp>
+#include <QScopedPointer>
+
+#include "soundsourceproxy.h"
+#include "library/parser.h"
+#include "library/parserm3u.h"
+#include "library/parserpls.h"
+#include "library/parsercsv.h"
+#include "util/sandbox.h"
+
+class DragAndDropHelper {
+  public:
+    static QList<QFileInfo> supportedTracksFromUrls(const QList<QUrl>& urls,
+                                                    bool firstOnly,
+                                                    bool acceptPlaylists) {
+        QList<QFileInfo> fileLocations;
+        foreach (const QUrl& url, urls) {
+
+            // XXX: Possible WTF alert - Previously we thought we needed
+            // toString() here but what you actually want in any case when
+            // converting a QUrl to a file system path is
+            // QUrl::toLocalFile(). This is the second time we have flip-flopped
+            // on this, but I think toLocalFile() should work in any
+            // case. toString() absolutely does not work when you pass the
+            // result to a (this comment was never finished by the original
+            // author).
+            QString file(url.toLocalFile());
+
+            // If the file is on a network share, try just converting the URL to
+            // a string...
+            if (file.isEmpty()) {
+                file = url.toString();
+            }
+
+            if (file.isEmpty()) {
+                continue;
+            }
+
+            if (acceptPlaylists && (file.endsWith(".m3u") || file.endsWith(".m3u8"))) {
+                QScopedPointer<ParserM3u> playlist_parser(new ParserM3u());
+                QList<QString> track_list = playlist_parser->parse(file);
+                foreach (const QString& playlistFile, track_list) {
+                    addFileToList(playlistFile, &fileLocations);
+                }
+            } else if (acceptPlaylists && url.toString().endsWith(".pls")) {
+                QScopedPointer<ParserPls> playlist_parser(new ParserPls());
+                QList<QString> track_list = playlist_parser->parse(file);
+                foreach (const QString& playlistFile, track_list) {
+                    addFileToList(playlistFile, &fileLocations);
+                }
+            } else {
+                addFileToList(file, &fileLocations);
+            }
+
+            if (firstOnly && !fileLocations.isEmpty()) {
+                break;
+            }
+        }
+
+        return fileLocations;
+    }
+
+  private:
+
+    static bool addFileToList(const QString& file, QList<QFileInfo>* files) {
+        QFileInfo fileInfo(file);
+
+        // Since the user just dropped these files into Mixxx we have permission
+        // to touch the file. Create a security token to keep this permission
+        // across reboots.
+        Sandbox::createSecurityToken(fileInfo);
+
+        if (!fileInfo.exists()) {
+            return false;
+        }
+
+        // Filter out invalid URLs (eg. files that aren't supported audio
+        // filetypes, etc.)
+        if (!SoundSourceProxy::isFilenameSupported(fileInfo.fileName())) {
+            return false;
+        }
+
+        files->append(fileInfo);
+        return true;
+    }
+};
+
+#endif /* DND_H */

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -17,14 +17,12 @@ MFile::MFile(const MFile& other)
 }
 
 MFile::~MFile() {
-    Sandbox::closeSecurityToken(m_pSecurityToken);
 }
 
 MFile& MFile::operator=(const MFile& other) {
-    Sandbox::closeSecurityToken(m_pSecurityToken);
     m_fileName = other.m_fileName;
     m_file.setFileName(m_fileName);
-    m_pSecurityToken = Sandbox::openSecurityToken(m_file, true);
+    m_pSecurityToken = other.m_pSecurityToken;
     return *this;
 }
 
@@ -45,13 +43,11 @@ MDir::MDir(const MDir& other)
 }
 
 MDir::~MDir() {
-    Sandbox::closeSecurityToken(m_pSecurityToken);
 }
 
 MDir& MDir::operator=(const MDir& other) {
-    Sandbox::closeSecurityToken(m_pSecurityToken);
     m_dirPath = other.m_dirPath;
     m_dir = QDir(m_dirPath);
-    m_pSecurityToken = Sandbox::openSecurityToken(m_dir, true);
+    m_pSecurityToken = other.m_pSecurityToken;
     return *this;
 }

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -5,7 +5,14 @@ MFile::MFile()
 }
 
 MFile::MFile(const QString& file)
-        : m_file(file),
+        : m_fileName(file),
+          m_file(file),
+          m_pSecurityToken(Sandbox::instance()->openSecurityToken(m_file, true)) {
+}
+
+MFile::MFile(const MFile& other)
+        : m_fileName(other.m_fileName),
+          m_file(m_fileName),
           m_pSecurityToken(Sandbox::instance()->openSecurityToken(m_file, true)) {
 }
 
@@ -13,15 +20,38 @@ MFile::~MFile() {
     Sandbox::instance()->closeSecurityToken(m_pSecurityToken);
 }
 
+MFile& MFile::operator=(const MFile& other) {
+    Sandbox::instance()->closeSecurityToken(m_pSecurityToken);
+    m_fileName = other.m_fileName;
+    m_file.setFileName(m_fileName);
+    m_pSecurityToken = Sandbox::instance()->openSecurityToken(m_file, true);
+    return *this;
+}
+
 MDir::MDir()
         : m_pSecurityToken(NULL) {
 }
 
 MDir::MDir(const QString& path)
-        : m_dir(path),
+        : m_dirPath(path),
+          m_dir(path),
+          m_pSecurityToken(Sandbox::instance()->openSecurityToken(m_dir, true)) {
+}
+
+MDir::MDir(const MDir& other)
+        : m_dirPath(other.m_dirPath),
+          m_dir(m_dirPath),
           m_pSecurityToken(Sandbox::instance()->openSecurityToken(m_dir, true)) {
 }
 
 MDir::~MDir() {
     Sandbox::instance()->closeSecurityToken(m_pSecurityToken);
+}
+
+MDir& MDir::operator=(const MDir& other) {
+    Sandbox::instance()->closeSecurityToken(m_pSecurityToken);
+    m_dirPath = other.m_dirPath;
+    m_dir = QDir(m_dirPath);
+    m_pSecurityToken = Sandbox::instance()->openSecurityToken(m_dir, true);
+    return *this;
 }

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -1,0 +1,27 @@
+#include "util/file.h"
+
+MFile::MFile()
+        : m_pSecurityToken(NULL) {
+}
+
+MFile::MFile(const QString& file)
+        : m_file(file),
+          m_pSecurityToken(Sandbox::instance()->openSecurityToken(m_file, true)) {
+}
+
+MFile::~MFile() {
+    Sandbox::instance()->closeSecurityToken(m_pSecurityToken);
+}
+
+MDir::MDir()
+        : m_pSecurityToken(NULL) {
+}
+
+MDir::MDir(const QString& path)
+        : m_dir(path),
+          m_pSecurityToken(Sandbox::instance()->openSecurityToken(m_dir, true)) {
+}
+
+MDir::~MDir() {
+    Sandbox::instance()->closeSecurityToken(m_pSecurityToken);
+}

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -27,7 +27,7 @@ MFile& MFile::operator=(const MFile& other) {
 
 bool MFile::canAccess() {
     QFileInfo info(m_file);
-    return Sandbox::canAccessPath(info.canonicalFilePath());
+    return Sandbox::canAccessFile(info);
 }
 
 MDir::MDir() {
@@ -56,5 +56,5 @@ MDir& MDir::operator=(const MDir& other) {
 }
 
 bool MDir::canAccess() {
-    return Sandbox::canAccessPath(m_dir.canonicalPath());
+    return Sandbox::canAccessFile(m_dir);
 }

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -7,24 +7,24 @@ MFile::MFile()
 MFile::MFile(const QString& file)
         : m_fileName(file),
           m_file(file),
-          m_pSecurityToken(Sandbox::instance()->openSecurityToken(m_file, true)) {
+          m_pSecurityToken(Sandbox::openSecurityToken(m_file, true)) {
 }
 
 MFile::MFile(const MFile& other)
         : m_fileName(other.m_fileName),
           m_file(m_fileName),
-          m_pSecurityToken(Sandbox::instance()->openSecurityToken(m_file, true)) {
+          m_pSecurityToken(Sandbox::openSecurityToken(m_file, true)) {
 }
 
 MFile::~MFile() {
-    Sandbox::instance()->closeSecurityToken(m_pSecurityToken);
+    Sandbox::closeSecurityToken(m_pSecurityToken);
 }
 
 MFile& MFile::operator=(const MFile& other) {
-    Sandbox::instance()->closeSecurityToken(m_pSecurityToken);
+    Sandbox::closeSecurityToken(m_pSecurityToken);
     m_fileName = other.m_fileName;
     m_file.setFileName(m_fileName);
-    m_pSecurityToken = Sandbox::instance()->openSecurityToken(m_file, true);
+    m_pSecurityToken = Sandbox::openSecurityToken(m_file, true);
     return *this;
 }
 
@@ -35,23 +35,23 @@ MDir::MDir()
 MDir::MDir(const QString& path)
         : m_dirPath(path),
           m_dir(path),
-          m_pSecurityToken(Sandbox::instance()->openSecurityToken(m_dir, true)) {
+          m_pSecurityToken(Sandbox::openSecurityToken(m_dir, true)) {
 }
 
 MDir::MDir(const MDir& other)
         : m_dirPath(other.m_dirPath),
           m_dir(m_dirPath),
-          m_pSecurityToken(Sandbox::instance()->openSecurityToken(m_dir, true)) {
+          m_pSecurityToken(Sandbox::openSecurityToken(m_dir, true)) {
 }
 
 MDir::~MDir() {
-    Sandbox::instance()->closeSecurityToken(m_pSecurityToken);
+    Sandbox::closeSecurityToken(m_pSecurityToken);
 }
 
 MDir& MDir::operator=(const MDir& other) {
-    Sandbox::instance()->closeSecurityToken(m_pSecurityToken);
+    Sandbox::closeSecurityToken(m_pSecurityToken);
     m_dirPath = other.m_dirPath;
     m_dir = QDir(m_dirPath);
-    m_pSecurityToken = Sandbox::instance()->openSecurityToken(m_dir, true);
+    m_pSecurityToken = Sandbox::openSecurityToken(m_dir, true);
     return *this;
 }

--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -1,7 +1,6 @@
 #include "util/file.h"
 
-MFile::MFile()
-        : m_pSecurityToken(NULL) {
+MFile::MFile() {
 }
 
 MFile::MFile(const QString& file)
@@ -13,7 +12,7 @@ MFile::MFile(const QString& file)
 MFile::MFile(const MFile& other)
         : m_fileName(other.m_fileName),
           m_file(m_fileName),
-          m_pSecurityToken(Sandbox::openSecurityToken(m_file, true)) {
+          m_pSecurityToken(other.m_pSecurityToken) {
 }
 
 MFile::~MFile() {
@@ -26,8 +25,12 @@ MFile& MFile::operator=(const MFile& other) {
     return *this;
 }
 
-MDir::MDir()
-        : m_pSecurityToken(NULL) {
+bool MFile::canAccess() {
+    QFileInfo info(m_file);
+    return Sandbox::canAccessPath(info.canonicalFilePath());
+}
+
+MDir::MDir() {
 }
 
 MDir::MDir(const QString& path)
@@ -39,7 +42,7 @@ MDir::MDir(const QString& path)
 MDir::MDir(const MDir& other)
         : m_dirPath(other.m_dirPath),
           m_dir(m_dirPath),
-          m_pSecurityToken(Sandbox::openSecurityToken(m_dir, true)) {
+          m_pSecurityToken(other.m_pSecurityToken) {
 }
 
 MDir::~MDir() {
@@ -50,4 +53,8 @@ MDir& MDir::operator=(const MDir& other) {
     m_dir = QDir(m_dirPath);
     m_pSecurityToken = other.m_pSecurityToken;
     return *this;
+}
+
+bool MDir::canAccess() {
+    return Sandbox::canAccessPath(m_dir.canonicalPath());
 }

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -26,7 +26,7 @@ class MFile {
   private:
     QString m_fileName;
     QFile m_file;
-    SandboxSecurityToken* m_pSecurityToken;
+    SecurityTokenPointer m_pSecurityToken;
 };
 
 class MDir {
@@ -49,7 +49,7 @@ class MDir {
   private:
     QString m_dirPath;
     QDir m_dir;
-    SandboxSecurityToken* m_pSecurityToken;
+    SecurityTokenPointer m_pSecurityToken;
 };
 
 #endif /* FILE_H */

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -21,6 +21,10 @@ class MFile {
         return m_file;
     }
 
+    SecurityTokenPointer token() {
+        return m_pSecurityToken;
+    }
+
     MFile& operator=(const MFile& other);
 
   private:
@@ -42,6 +46,10 @@ class MDir {
 
     const QDir& dir() const {
         return m_dir;
+    }
+
+    SecurityTokenPointer token() {
+        return m_pSecurityToken;
     }
 
     MDir& operator=(const MDir& other);

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -1,0 +1,37 @@
+#ifndef FILE_H
+#define FILE_H
+
+#include <QFile>
+#include <QDir>
+
+#include "util/sandbox.h"
+
+class MFile {
+  public:
+    MFile();
+    MFile(const QString& name);
+    virtual ~MFile();
+
+    QFile& file();
+
+  private:
+    QFile m_file;
+    SandboxSecurityToken* m_pSecurityToken;
+};
+
+class MDir {
+  public:
+    MDir();
+    MDir(const QString& name);
+    virtual ~MDir();
+
+    QDir& dir() {
+        return m_dir;
+    }
+
+  private:
+    QDir m_dir;
+    SandboxSecurityToken* m_pSecurityToken;
+};
+
+#endif /* FILE_H */

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -10,11 +10,21 @@ class MFile {
   public:
     MFile();
     MFile(const QString& name);
+    MFile(const MFile& other);
     virtual ~MFile();
 
-    QFile& file();
+    QFile& file() {
+        return m_file;
+    }
+
+    const QFile& file() const {
+        return m_file;
+    }
+
+    MFile& operator=(const MFile& other);
 
   private:
+    QString m_fileName;
     QFile m_file;
     SandboxSecurityToken* m_pSecurityToken;
 };
@@ -23,13 +33,21 @@ class MDir {
   public:
     MDir();
     MDir(const QString& name);
+    MDir(const MDir& other);
     virtual ~MDir();
 
     QDir& dir() {
         return m_dir;
     }
 
+    const QDir& dir() const {
+        return m_dir;
+    }
+
+    MDir& operator=(const MDir& other);
+
   private:
+    QString m_dirPath;
     QDir m_dir;
     SandboxSecurityToken* m_pSecurityToken;
 };

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -25,6 +25,8 @@ class MFile {
         return m_pSecurityToken;
     }
 
+    bool canAccess();
+
     MFile& operator=(const MFile& other);
 
   private:
@@ -51,6 +53,8 @@ class MDir {
     SecurityTokenPointer token() {
         return m_pSecurityToken;
     }
+
+    bool canAccess();
 
     MDir& operator=(const MDir& other);
 

--- a/src/util/mac.cpp
+++ b/src/util/mac.cpp
@@ -1,0 +1,17 @@
+#include "util/mac.h"
+
+#ifdef Q_OS_MAC
+QString CFStringToQString(CFStringRef str) {
+    if (!str)
+        return QString();
+
+    CFIndex length = CFStringGetLength(str);
+    if (length == 0)
+        return QString();
+
+    QString string(length, Qt::Uninitialized);
+    CFStringGetCharacters(str, CFRangeMake(0, length), reinterpret_cast<UniChar *>
+        (const_cast<QChar *>(string.unicode())));
+    return string;
+}
+#endif

--- a/src/util/mac.cpp
+++ b/src/util/mac.cpp
@@ -14,4 +14,9 @@ QString CFStringToQString(CFStringRef str) {
         (const_cast<QChar *>(string.unicode())));
     return string;
 }
+
+CFStringRef QStringToCFString(const QString& string) {
+    return CFStringCreateWithCharacters(0, reinterpret_cast<const UniChar *>(string.unicode()),
+                                        string.length());
+}
 #endif

--- a/src/util/mac.h
+++ b/src/util/mac.h
@@ -9,6 +9,7 @@
 #include <CoreFoundation/CFString.h>
 
 QString CFStringToQString(CFStringRef str);
+CFStringRef QStringToCFString(const QString& str);
 
 #endif
 

--- a/src/util/mac.h
+++ b/src/util/mac.h
@@ -1,0 +1,15 @@
+// Platform-specific helpers for OS X and iOS.
+#ifndef MAC_H
+#define MAC_H
+
+#include <QtGlobal>
+
+#ifdef Q_OS_MAC
+#include <QString>
+#include <CoreFoundation/CFString.h>
+
+QString CFStringToQString(CFStringRef str);
+
+#endif
+
+#endif /* MAC_H */

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -1,0 +1,283 @@
+#include "util/sandbox.h"
+
+#include <QtDebug>
+#include <QFileInfo>
+#include <QFileDialog>
+#include <QObject>
+
+#include "util/mac.h"
+
+#ifdef Q_OS_MAC
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreServices/CoreServices.h>
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6
+#include <Security/SecCode.h>
+#include <Security/SecRequirement.h>
+#endif
+#endif
+
+Sandbox::Sandbox()
+        : m_bInSandbox(false),
+          m_pSandboxPermissions(NULL) {
+#ifdef Q_OS_MAC
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6
+    // If we are running on at least 10.7.0 and have the com.apple.security.app-sandbox
+    // entitlement, we are in a sandbox
+    SInt32 version = 0;
+    Gestalt(gestaltSystemVersion, &version);
+    SecCodeRef secCodeSelf;
+    if (version >= 0x1070 && SecCodeCopySelf(kSecCSDefaultFlags, &secCodeSelf) == errSecSuccess) {
+        SecRequirementRef sandboxReq;
+        CFStringRef entitlement = CFSTR("entitlement [\"com.apple.security.app-sandbox\"]");
+        if (SecRequirementCreateWithString(entitlement, kSecCSDefaultFlags,
+                                           &sandboxReq) == errSecSuccess) {
+            if (SecCodeCheckValidity(secCodeSelf, kSecCSDefaultFlags,
+                                     sandboxReq) == errSecSuccess) {
+                m_bInSandbox = true;
+            }
+            CFRelease(sandboxReq);
+        }
+        CFRelease(secCodeSelf);
+    }
+#endif
+#endif
+}
+
+Sandbox::~Sandbox() {
+    if (m_pSandboxPermissions) {
+        m_pSandboxPermissions->Save();
+    }
+}
+
+bool Sandbox::askForAccess(const QString& canonicalPath) {
+    qDebug() << "Sandbox::askForAccess" << canonicalPath;
+    QFileInfo info(canonicalPath);
+
+    // We always want read/write access because we wouldn't want to have to
+    // re-ask for access in the future if we need to write.
+    if (canAccessFile(info)) {
+        return true;
+    }
+
+    qDebug() << "Sandbox: Requesting user access to" << canonicalPath;
+    QString title = QObject::tr("Mixxx Needs Access to: %1")
+            .arg(info.fileName());
+
+    QMessageBox::StandardButton button = QMessageBox::question(
+        NULL, title,
+        QObject::tr(
+            "Due to Mac Sandboxing, we need your permission to access this file:"
+            "\n %1\n"
+            "After clicking OK, you will see a file picker. "
+            "To give Mixxx permission, you must select '%2' to proceed."
+            "If you do not want to grant Mixxx access, click Cancel on the file dialog."
+            "We're sorry for this inconvenience.\n\n"
+            "To abort this action, press Cancel on the file dialog.")
+        .arg(canonicalPath, info.fileName()));
+
+    QString result;
+    QFileInfo resultInfo;
+    while (true) {
+        if (info.isFile()) {
+            result = QFileDialog::getOpenFileName(NULL, title, canonicalPath);
+        } else if (info.isDir()) {
+            result = QFileDialog::getExistingDirectory(NULL, title, canonicalPath);
+
+        }
+
+        if (result.isNull()) {
+            qDebug() << "Sandbox: User rejected access to" << canonicalPath;
+            return false;
+        }
+
+        qDebug() << "Sandbox: User selected" << result;
+        resultInfo = QFileInfo(result);
+        if (resultInfo == info) {
+            break;
+        }
+
+        qDebug() << "User selected the wrong file.";
+        QMessageBox::question(
+            NULL, title,
+            QObject::tr("You selected the wrong file. To grant Mixxx access, "
+                        "please select the file '%1'. If you do not want to "
+                        "continue, press Cancel.").arg(info.fileName()));
+    }
+
+    return createSecurityToken(resultInfo);
+}
+
+ConfigKey Sandbox::keyForCanonicalPath(const QString& canonicalPath) const {
+    return ConfigKey("[OSXBookmark]",
+                     QString(canonicalPath.toLocal8Bit().toBase64()));
+}
+
+void Sandbox::setPermissionsFile(const QString& path) {
+    m_pSandboxPermissions = new ConfigObject<ConfigValue>(path);
+}
+
+bool Sandbox::createSecurityToken(const QString& canonicalPath,
+                                  bool isDirectory) {
+    qDebug() << "createSecurityToken" << canonicalPath << isDirectory;
+    if (m_pSandboxPermissions == NULL) {
+        return false;
+    }
+    CFURLRef url = CFURLCreateWithFileSystemPath(
+            kCFAllocatorDefault, QStringToCFString(canonicalPath),
+            kCFURLPOSIXPathStyle, isDirectory);
+    if (url) {
+        CFErrorRef error = NULL;
+        CFDataRef bookmark = CFURLCreateBookmarkData(
+                kCFAllocatorDefault, url,
+                kCFURLBookmarkCreationWithSecurityScope, nil, nil, &error);
+        CFRelease(url);
+        if (bookmark) {
+            QByteArray bookmarkBA = QByteArray(
+                    reinterpret_cast<const char*>(CFDataGetBytePtr(bookmark)),
+                    CFDataGetLength(bookmark));
+
+            QString bookmarkBase64 = QString(bookmarkBA.toBase64());
+
+            m_pSandboxPermissions->set(keyForCanonicalPath(canonicalPath),
+                                       bookmarkBase64);
+            CFRelease(bookmark);
+            return true;
+        } else {
+            qDebug() << "Failed to create security-scoped bookmark for" << canonicalPath;
+            if (error != NULL) {
+                qDebug() << "Error:" << CFStringToQString(CFErrorCopyDescription(error));
+            }
+        }
+    } else {
+        qDebug() << "Failed to create security-scoped bookmark URL for" << canonicalPath;
+    }
+    return false;
+}
+
+SandboxSecurityToken* Sandbox::openSecurityToken(const QFileInfo& file, bool create) {
+    qDebug() << "openSecurityToken QFileInfo" << file.canonicalFilePath() << create;
+    if (m_pSandboxPermissions == NULL) {
+        return NULL;
+    }
+
+    if (file.isDir()) {
+        return openSecurityToken(QDir(file.canonicalFilePath()), create);
+    }
+
+    // First, check for a bookmark of the key itself.
+    ConfigKey key = keyForCanonicalPath(file.canonicalFilePath());
+    if (m_pSandboxPermissions->exists(key)) {
+        return openTokenFromBookmark(
+                file.canonicalFilePath(),
+                m_pSandboxPermissions->getValueString(key));
+    }
+
+    // Next, try to open a bookmark for an existing directory but don't create a
+    // bookmark.
+    SandboxSecurityToken* pDirToken = openSecurityToken(file.dir(), false);
+    if (pDirToken != NULL) {
+        return pDirToken;
+    }
+
+    if (!create) {
+        return NULL;
+    }
+
+    // Otherwise, try to create a token.
+    bool created = createSecurityToken(file);
+
+    if (created) {
+        return openTokenFromBookmark(
+                file.canonicalFilePath(),
+                m_pSandboxPermissions->getValueString(key));
+    }
+    return NULL;
+}
+
+SandboxSecurityToken* Sandbox::openSecurityToken(const QDir& dir, bool create) {
+    qDebug() << "openSecurityToken QDir" << dir.canonicalPath() << create;
+    if (m_pSandboxPermissions == NULL) {
+        return NULL;
+    }
+
+    QDir walkDir = dir;
+    ConfigKey key = keyForCanonicalPath(walkDir.canonicalPath());
+
+    while (!m_pSandboxPermissions->exists(key)) {
+        // There's nothing higher. Bail.
+        if (!walkDir.cdUp()) {
+            if (create && createSecurityToken(dir.canonicalPath(), true)) {
+                key = keyForCanonicalPath(dir.canonicalPath());
+                return openTokenFromBookmark(
+                        dir.canonicalPath(),
+                        m_pSandboxPermissions->getValueString(key));
+            }
+            return NULL;
+        }
+
+        key = keyForCanonicalPath(walkDir.canonicalPath());
+    }
+
+    // At this point, key is present in m_pSandboxPermissions.
+    return openTokenFromBookmark(dir.canonicalPath(),
+                                 m_pSandboxPermissions->getValueString(key));
+}
+
+SandboxSecurityToken* Sandbox::openTokenFromBookmark(const QString& canonicalPath,
+                                                     const QString& bookmarkBase64) {
+    QByteArray bookmarkBA = QByteArray::fromBase64(bookmarkBase64.toLatin1());
+#ifdef Q_OS_MAC
+    if (!bookmarkBA.isEmpty()) {
+        CFDataRef bookmarkData = CFDataCreate(
+                kCFAllocatorDefault, reinterpret_cast<const UInt8*>(bookmarkBA.constData()),
+                bookmarkBA.length());
+        Boolean stale;
+        CFErrorRef error = NULL;
+        CFURLRef url = CFURLCreateByResolvingBookmarkData(
+                kCFAllocatorDefault, bookmarkData,
+                kCFURLBookmarkResolutionWithSecurityScope, NULL, NULL,
+                &stale, &error);
+        if (error != NULL) {
+            qDebug() << "Error creating URL from bookmark data:"
+                     << CFStringToQString(CFErrorCopyDescription(error));
+        }
+        CFRelease(bookmarkData);
+        if (url != NULL) {
+            if (!CFURLStartAccessingSecurityScopedResource(url)) {
+                qDebug() << "CFURLStartAccessingSecurityScopedResource failed for"
+                         << canonicalPath;
+            } else {
+                return new SandboxSecurityToken(canonicalPath, url);
+            }
+        } else {
+            qDebug() << "Cannot resolve security-scoped bookmark for" << canonicalPath;
+        }
+    }
+#endif
+    return NULL;
+}
+
+bool Sandbox::closeSecurityToken(SandboxSecurityToken* pToken) {
+    if (pToken) {
+        qDebug() << "closeSecurityToken" << pToken->m_path;;
+        delete pToken;
+    }
+    return true;
+}
+
+#ifdef Q_OS_MAC
+SandboxSecurityToken::SandboxSecurityToken(const QString& path, CFURLRef url)
+        : m_path(path),
+          m_url(url) {
+}
+#endif
+
+SandboxSecurityToken::~SandboxSecurityToken() {
+#ifdef Q_OS_MAC
+    if (m_url) {
+        CFURLStopAccessingSecurityScopedResource(m_url);
+        CFRelease(m_url);
+        m_url = 0;
+    }
+#endif
+}

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -69,8 +69,8 @@ bool Sandbox::askForAccess(const QString& canonicalPath) {
         // Pretend we have access.
         return true;
     }
-    QFileInfo info(canonicalPath);
 
+    QFileInfo info(canonicalPath);
     // We always want read/write access because we wouldn't want to have to
     // re-ask for access in the future if we need to write.
     if (canAccessFile(info)) {
@@ -85,10 +85,10 @@ bool Sandbox::askForAccess(const QString& canonicalPath) {
         NULL, title,
         QObject::tr(
             "Due to Mac Sandboxing, we need your permission to access this file:"
-            "\n %1\n"
+            "\n\n%1\n\n"
             "After clicking OK, you will see a file picker. "
-            "To give Mixxx permission, you must select '%2' to proceed."
-            "If you do not want to grant Mixxx access, click Cancel on the file dialog."
+            "To give Mixxx permission, you must select '%2' to proceed. "
+            "If you do not want to grant Mixxx access click Cancel on the file picker. "
             "We're sorry for this inconvenience.\n\n"
             "To abort this action, press Cancel on the file dialog.")
         .arg(canonicalPath, info.fileName()));
@@ -100,7 +100,6 @@ bool Sandbox::askForAccess(const QString& canonicalPath) {
             result = QFileDialog::getOpenFileName(NULL, title, canonicalPath);
         } else if (info.isDir()) {
             result = QFileDialog::getExistingDirectory(NULL, title, canonicalPath);
-
         }
 
         if (result.isNull()) {

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -317,7 +317,7 @@ SandboxSecurityToken::SandboxSecurityToken(const QString& path, CFURLRef url)
         : m_path(path),
           m_url(url) {
     if (m_url) {
-        qDebug() << "SandboxSecurityToken successfully created for" << path;
+        qDebug() << "SandboxSecurityToken successfully opened for" << path;
     }
 }
 #endif

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -271,6 +271,9 @@ SecurityTokenPointer Sandbox::openTokenFromBookmark(const QString& canonicalPath
 SandboxSecurityToken::SandboxSecurityToken(const QString& path, CFURLRef url)
         : m_path(path),
           m_url(url) {
+    if (m_url) {
+        qDebug() << "SandboxSecurityToken successfully created for" << path;
+    }
 }
 #endif
 

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -46,6 +46,7 @@ Sandbox::Sandbox()
 Sandbox::~Sandbox() {
     if (m_pSandboxPermissions) {
         m_pSandboxPermissions->Save();
+        delete m_pSandboxPermissions;
     }
 }
 

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -66,7 +66,8 @@ void Sandbox::shutdown() {
 bool Sandbox::askForAccess(const QString& canonicalPath) {
     qDebug() << "Sandbox::askForAccess" << canonicalPath;
     if (!enabled()) {
-        return false;
+        // Pretend we have access.
+        return true;
     }
     QFileInfo info(canonicalPath);
 

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -1,8 +1,6 @@
 #ifndef SANDBOX_H
 #define SANDBOX_H
 
-#include <unistd.h>
-
 #include <QFile>
 #include <QDir>
 #include <QFileInfo>
@@ -44,19 +42,13 @@ class Sandbox {
 
     static bool canAccessFile(const QFileInfo& file) {
         SecurityTokenPointer pToken = openSecurityToken(file, true);
-        bool result = canAccessPath(file.absoluteFilePath());
-        return result;
+        return file.isReadable();
     }
 
     static bool canAccessFile(const QDir& dir) {
         SecurityTokenPointer pToken = openSecurityToken(dir, true);
-        bool result = canAccessPath(dir.canonicalPath());
-        return result;
-    }
-
-    static bool canAccessPath(const QString& canonicalPath) {
-        QByteArray pathEncoded = canonicalPath.toLocal8Bit();
-        return access(pathEncoded.constData(), R_OK) == 0;
+        QFileInfo info(dir.canonicalPath());
+        return info.isReadable();
     }
 
     static bool createSecurityToken(const QFileInfo& info) {

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -54,6 +54,11 @@ class Sandbox {
         return result;
     }
 
+    static bool canAccessPath(const QString& canonicalPath) {
+        QByteArray pathEncoded = canonicalPath.toLocal8Bit();
+        return access(pathEncoded.constData(), R_OK) == 0;
+    }
+
     static bool createSecurityToken(const QFileInfo& info) {
         return createSecurityToken(info.canonicalFilePath(), info.isDir());
     }
@@ -76,11 +81,6 @@ class Sandbox {
 
     // Creates a security token. s_mutex is not needed for this method.
     static bool createSecurityToken(const QString& canonicalPath, bool isDirectory);
-
-    static bool canAccessPath(const QString& canonicalPath) {
-        QByteArray pathEncoded = canonicalPath.toLocal8Bit();
-        return access(pathEncoded.constData(), R_OK) == 0;
-    }
 
     static QMutex s_mutex;
     static bool s_bInSandbox;

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -1,0 +1,85 @@
+#ifndef SANDBOX_H
+#define SANDBOX_H
+
+#include <unistd.h>
+
+#include <QFile>
+#include <QDir>
+#include <QFileInfo>
+
+#include "configobject.h"
+#include "util/singleton.h"
+
+#ifdef Q_OS_MAC
+#include <CoreFoundation/CFURL.h>
+#endif
+
+struct SandboxSecurityToken {
+    ~SandboxSecurityToken();
+    QString m_path;
+#ifdef Q_OS_MAC
+    SandboxSecurityToken(const QString& path, CFURLRef url);
+    CFURLRef m_url;
+#endif
+};
+
+class Sandbox : public Singleton<Sandbox> {
+  public:
+    Sandbox();
+    ~Sandbox();
+
+    void setPermissionsFile(const QString& file);
+
+    // Returns true if we are in a sandbox.
+    bool enabled() const {
+        return m_bInSandbox;
+    }
+
+    // Prompt the user to give us access to the path with an open-file dialog.
+    bool askForAccess(const QString& canonicalPath);
+
+    bool canAccessFile(const QFileInfo& file) {
+        SandboxSecurityToken* pToken = openSecurityToken(file, true);
+        bool result = canAccessPath(file.absoluteFilePath());
+        closeSecurityToken(pToken);
+        return result;
+    }
+
+    bool canAccessFile(const QDir& dir) {
+        SandboxSecurityToken* pToken = openSecurityToken(dir, true);
+        bool result = canAccessPath(dir.canonicalPath());
+        closeSecurityToken(pToken);
+        return result;
+    }
+
+    bool createSecurityToken(const QFileInfo& info) {
+        return createSecurityToken(info.canonicalFilePath(), info.isDir());
+    }
+
+    bool createSecurityToken(const QDir& dir) {
+        return createSecurityToken(dir.canonicalPath(), true);
+    }
+
+    SandboxSecurityToken* openSecurityToken(const QFileInfo& info, bool create);
+    SandboxSecurityToken* openSecurityToken(const QDir& dir, bool create);
+
+
+    bool closeSecurityToken(SandboxSecurityToken* pToken);
+
+  private:
+    ConfigKey keyForCanonicalPath(const QString& canonicalPath) const;
+    SandboxSecurityToken* openTokenFromBookmark(const QString& canonicalPath,
+                                                const QString& bookmarkBase64);
+    bool createSecurityToken(const QString& canonicalPath, bool isDirectory);
+
+    bool canAccessPath(const QString& canonicalPath) const {
+        QByteArray pathEncoded = canonicalPath.toLocal8Bit();
+        return access(pathEncoded.constData(), R_OK) == 0;
+    }
+
+    bool m_bInSandbox;
+    ConfigObject<ConfigValue>* m_pSandboxPermissions;
+};
+
+
+#endif /* SANDBOX_H */

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -8,7 +8,6 @@
 #include <QFileInfo>
 
 #include "configobject.h"
-#include "util/singleton.h"
 
 #ifdef Q_OS_MAC
 #include <CoreFoundation/CFURL.h>
@@ -23,62 +22,60 @@ struct SandboxSecurityToken {
 #endif
 };
 
-class Sandbox : public Singleton<Sandbox> {
+class Sandbox {
   public:
-    Sandbox();
-    ~Sandbox();
-
-    void setPermissionsFile(const QString& file);
+    static void initialize(const QString& permissionsFile);
+    static void shutdown();
 
     // Returns true if we are in a sandbox.
-    bool enabled() const {
-        return m_bInSandbox;
+    static bool enabled() {
+        return s_bInSandbox;
     }
 
     // Prompt the user to give us access to the path with an open-file dialog.
-    bool askForAccess(const QString& canonicalPath);
+    static bool askForAccess(const QString& canonicalPath);
 
-    bool canAccessFile(const QFileInfo& file) {
+    static bool canAccessFile(const QFileInfo& file) {
         SandboxSecurityToken* pToken = openSecurityToken(file, true);
         bool result = canAccessPath(file.absoluteFilePath());
         closeSecurityToken(pToken);
         return result;
     }
 
-    bool canAccessFile(const QDir& dir) {
+    static bool canAccessFile(const QDir& dir) {
         SandboxSecurityToken* pToken = openSecurityToken(dir, true);
         bool result = canAccessPath(dir.canonicalPath());
         closeSecurityToken(pToken);
         return result;
     }
 
-    bool createSecurityToken(const QFileInfo& info) {
+    static bool createSecurityToken(const QFileInfo& info) {
         return createSecurityToken(info.canonicalFilePath(), info.isDir());
     }
 
-    bool createSecurityToken(const QDir& dir) {
+    static bool createSecurityToken(const QDir& dir) {
         return createSecurityToken(dir.canonicalPath(), true);
     }
 
-    SandboxSecurityToken* openSecurityToken(const QFileInfo& info, bool create);
-    SandboxSecurityToken* openSecurityToken(const QDir& dir, bool create);
-
-
-    bool closeSecurityToken(SandboxSecurityToken* pToken);
+    static SandboxSecurityToken* openSecurityToken(const QFileInfo& info, bool create);
+    static SandboxSecurityToken* openSecurityToken(const QDir& dir, bool create);
+    static bool closeSecurityToken(SandboxSecurityToken* pToken);
 
   private:
-    ConfigKey keyForCanonicalPath(const QString& canonicalPath) const;
-    SandboxSecurityToken* openTokenFromBookmark(const QString& canonicalPath,
-                                                const QString& bookmarkBase64);
-    bool createSecurityToken(const QString& canonicalPath, bool isDirectory);
+    Sandbox() {}
 
-    bool canAccessPath(const QString& canonicalPath) const {
+    static ConfigKey keyForCanonicalPath(const QString& canonicalPath);
+    static SandboxSecurityToken* openTokenFromBookmark(const QString& canonicalPath,
+                                                       const QString& bookmarkBase64);
+    static bool createSecurityToken(const QString& canonicalPath, bool isDirectory);
+
+    static bool canAccessPath(const QString& canonicalPath) {
         QByteArray pathEncoded = canonicalPath.toLocal8Bit();
         return access(pathEncoded.constData(), R_OK) == 0;
     }
 
-    bool m_bInSandbox;
-    ConfigObject<ConfigValue>* m_pSandboxPermissions;
+    static bool s_bInSandbox;
+    static ConfigObject<ConfigValue>* s_pSandboxPermissions;
 };
 
 

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -6,6 +6,7 @@
 #include <QFile>
 #include <QDir>
 #include <QFileInfo>
+#include <QSharedPointer>
 
 #include "configobject.h"
 
@@ -22,6 +23,9 @@ struct SandboxSecurityToken {
 #endif
 };
 
+// Reference counted pointer to SandboxSecurityToken.
+typedef QSharedPointer<SandboxSecurityToken> SecurityTokenPointer;
+
 class Sandbox {
   public:
     static void initialize(const QString& permissionsFile);
@@ -36,16 +40,14 @@ class Sandbox {
     static bool askForAccess(const QString& canonicalPath);
 
     static bool canAccessFile(const QFileInfo& file) {
-        SandboxSecurityToken* pToken = openSecurityToken(file, true);
+        SecurityTokenPointer pToken = openSecurityToken(file, true);
         bool result = canAccessPath(file.absoluteFilePath());
-        closeSecurityToken(pToken);
         return result;
     }
 
     static bool canAccessFile(const QDir& dir) {
-        SandboxSecurityToken* pToken = openSecurityToken(dir, true);
+        SecurityTokenPointer pToken = openSecurityToken(dir, true);
         bool result = canAccessPath(dir.canonicalPath());
-        closeSecurityToken(pToken);
         return result;
     }
 
@@ -57,16 +59,15 @@ class Sandbox {
         return createSecurityToken(dir.canonicalPath(), true);
     }
 
-    static SandboxSecurityToken* openSecurityToken(const QFileInfo& info, bool create);
-    static SandboxSecurityToken* openSecurityToken(const QDir& dir, bool create);
-    static bool closeSecurityToken(SandboxSecurityToken* pToken);
+    static SecurityTokenPointer openSecurityToken(const QFileInfo& info, bool create);
+    static SecurityTokenPointer openSecurityToken(const QDir& dir, bool create);
 
   private:
     Sandbox() {}
 
     static ConfigKey keyForCanonicalPath(const QString& canonicalPath);
-    static SandboxSecurityToken* openTokenFromBookmark(const QString& canonicalPath,
-                                                       const QString& bookmarkBase64);
+    static SecurityTokenPointer openTokenFromBookmark(const QString& canonicalPath,
+                                                      const QString& bookmarkBase64);
     static bool createSecurityToken(const QString& canonicalPath, bool isDirectory);
 
     static bool canAccessPath(const QString& canonicalPath) {

--- a/src/vamp/vampanalyser.cpp
+++ b/src/vamp/vampanalyser.cpp
@@ -38,8 +38,11 @@ void VampAnalyser::initializePluginPaths() {
             : QStringList();
 
     const QString homeLocation = QDesktopServices::storageLocation(
-        QDesktopServices::HomeLocation);
-    QString applicationPath = QCoreApplication::applicationDirPath();
+            QDesktopServices::HomeLocation);
+    const QString dataLocation = QDesktopServices::storageLocation(
+            QDesktopServices::DataLocation);
+    const QString applicationPath = QCoreApplication::applicationDirPath();
+
 #ifdef __WINDOWS__
     QDir winVampPath(applicationPath);
     if (winVampPath.cd("plugins")) {
@@ -53,20 +56,46 @@ void VampAnalyser::initializePluginPaths() {
     }
 #elif __APPLE__
     // Location within the OS X bundle that we store plugins.
-    pathElements << applicationPath +"/../Plugins";
+    // blah/Mixxx.app/Contents/MacOS/
+    QDir bundlePluginDir(applicationPath);
+    if (bundlePluginDir.cdUp() && bundlePluginDir.cd("PlugIns")) {
+        pathElements << bundlePluginDir.absolutePath();
+    }
+
     // For people who build from source.
-    pathElements << applicationPath + "/osx32_build/vamp-plugins";
-    pathElements << applicationPath + "/osx64_build/vamp-plugins";
-    pathElements << homeLocation + "/Library/Application Support/Mixxx/Plugins/vamp/";
+    QDir developer32Root(applicationPath);
+    if (developer32Root.cd("osx32_build") && developer32Root.cd("vamp-plugins")) {
+        pathElements << developer32Root.absolutePath();
+    }
+    QDir developer64Root(applicationPath);
+    if (developer64Root.cd("osx64_build") && developer64Root.cd("vamp-plugins")) {
+        pathElements << developer64Root.absolutePath();
+    }
+
+    QDir dataPluginDir(dataLocation);
+    if (dataPluginDir.cd("Plugins") && dataPluginDir.cd("vamp")) {
+        pathElements << dataPluginDir.absolutePath();
+    }
 #elif __LINUX__
     QDir libPath(UNIX_LIB_PATH);
     if (libPath.cd("plugins") && libPath.cd("vamp")) {
         pathElements << libPath.absolutePath();
     }
-    pathElements << homeLocation + "/.mixxx/plugins/vamp/";
+
+    QDir dataPluginDir(dataLocation);
+    if (dataPluginDir.cd("plugins") && dataPluginDir.cd("vamp")) {
+        pathElements << dataPluginDir.absolutePath();
+    }
+
     // For people who build from source.
-    pathElements << applicationPath + "/lin32_build/vamp-plugins";
-    pathElements << applicationPath + "/lin64_build/vamp-plugins";
+    QDir developer32Root(applicationPath);
+    if (developer32Root.cd("lin32_build") && developer32Root.cd("vamp-plugins")) {
+        pathElements << developer32Root.absolutePath();
+    }
+    QDir developer64Root(applicationPath);
+    if (developer64Root.cd("lin32_build") && developer64Root.cd("vamp-plugins")) {
+        pathElements << developer64Root.absolutePath();
+    }
 #endif
 
     QString newPath = pathElements.join(PATH_SEPARATOR);

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -111,7 +111,6 @@ void WLibrarySidebar::timerEvent(QTimerEvent *event) {
 // Drag-and-drop "drop" event. Occurs when something is dropped onto the track sources view
 void WLibrarySidebar::dropEvent(QDropEvent * event) {
     if (event->mimeData()->hasUrls()) {
-        QList<QUrl> urls(event->mimeData()->urls());
         // Drag and drop within this widget
         if ((event->source() == this)
                 && (event->possibleActions() & Qt::MoveAction)) {
@@ -127,6 +126,7 @@ void WLibrarySidebar::dropEvent(QDropEvent * event) {
                 QModelIndex destIndex = indexAt(event->pos());
                 // event->source() will return NULL if something is droped from
                 // a different application
+                QList<QUrl> urls(event->mimeData()->urls());
                 if (sidebarModel->dropAccept(destIndex, urls, event->source())) {
                     event->acceptProposedAction();
                 } else {

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -27,6 +27,7 @@
 #include "trackinfoobject.h"
 #include "mathstuff.h"
 #include "util/timer.h"
+#include "util/dnd.h"
 
 #include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"
@@ -499,18 +500,14 @@ void WOverview::dragEnterEvent(QDragEnterEvent* event) {
 }
 
 void WOverview::dropEvent(QDropEvent* event) {
-    if (event->mimeData()->hasUrls() &&
-            event->mimeData()->urls().size() > 0) {
-        QList<QUrl> urls(event->mimeData()->urls());
-        QUrl url = urls.first();
-        QString name = url.toLocalFile();
-        //If the file is on a network share, try just converting the URL to a string...
-        if (name == "") {
-            name = url.toString();
+    if (event->mimeData()->hasUrls()) {
+        QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(
+                event->mimeData()->urls(), true, false);
+        if (!files.isEmpty()) {
+            event->accept();
+            emit(trackDropped(files.at(0).canonicalFilePath(), m_group));
+            return;
         }
-        event->accept();
-        emit(trackDropped(name, m_group));
-    } else {
-        event->ignore();
     }
+    event->ignore();
 }

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -15,6 +15,7 @@
 #include "widget/wspinny.h"
 #include "vinylcontrol/vinylcontrolmanager.h"
 #include "vinylcontrol/vinylcontrol.h"
+#include "util/dnd.h"
 
 WSpinny::WSpinny(QWidget* parent, VinylControlManager* pVCMan)
         : QGLWidget(parent, SharedGLContext::getWidget()),
@@ -498,19 +499,15 @@ void WSpinny::dragEnterEvent(QDragEnterEvent * event)
     }
 }
 
-void WSpinny::dropEvent(QDropEvent * event)
-{
+void WSpinny::dropEvent(QDropEvent * event) {
     if (event->mimeData()->hasUrls()) {
-        QList<QUrl> urls(event->mimeData()->urls());
-        QUrl url = urls.first();
-        QString name = url.toLocalFile();
-        //If the file is on a network share, try just converting the URL to a string...
-        if (name == "")
-            name = url.toString();
-
-        event->accept();
-        emit(trackDropped(name, m_group));
-    } else {
-        event->ignore();
+        QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(
+                event->mimeData()->urls(), true, false);
+        if (!files.isEmpty()) {
+            event->accept();
+            emit(trackDropped(files.at(0).canonicalFilePath(), m_group));
+            return;
+        }
     }
+    event->ignore();
 }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -808,31 +808,16 @@ void WTrackTableView::mouseMoveEvent(QMouseEvent* pEvent) {
         return;
     // qDebug() << "MouseMoveEvent";
     // Iterate over selected rows and append each item's location url to a list.
-    QList<QUrl> locationUrls;
+    QList<QString> locations;
     QModelIndexList indices = selectionModel()->selectedRows();
+
     foreach (QModelIndex index, indices) {
         if (!index.isValid()) {
             continue;
         }
-        QUrl url = QUrl::fromLocalFile(trackModel->getTrackLocation(index));
-        if (!url.isValid()) {
-            qDebug() << this << "ERROR: invalid url" << url;
-            continue;
-        }
-        locationUrls.append(url);
+        locations.append(trackModel->getTrackLocation(index));
     }
-
-    if (locationUrls.empty()) {
-        return;
-    }
-
-    QMimeData* mimeData = new QMimeData();
-    mimeData->setUrls(locationUrls);
-
-    QDrag* drag = new QDrag(this);
-    drag->setMimeData(mimeData);
-    drag->setPixmap(QPixmap(":images/library/ic_library_drag_and_drop.png"));
-    drag->exec(Qt::CopyAction);
+    DragAndDropHelper::dragTrackLocations(locations, this);
 }
 
 // Drag enter event, happens when a dragged item hovers over the track table view


### PR DESCRIPTION
This branch implements Apple's sandboxing and security scoped bookmarks. This fixes Bug #1257340 and should complete the Mac App Store blueprint. 

I have a few more things to do but the code is in a pretty stable state so I'd appreciate some extra eyes or testers.

Summary:
- Maintain a security bookmark while a TrackInfoObject or SoundSourceProxy is active for it.
- Register security bookmarks every time we open a QFileDialog.
- Provide wrapper classes for QFile and QDir that open bookmarks.
- Provide an "ask for access" flow for letting users grant access when upgrading from a pre-sandbox library.
- Fix browse mode to only add quick links we have access to.
- Cache and reference-count active security bookmarks and only close it when the last reference expires.
- Store bookmarks base64-encoded in a new config file "sandbox.cfg" in the settings path.

Cases currently handled:
- Adding or relocating a library directory.
- Loading a file to a deck.
- Recording.
- Changing the recording path.
- Library scanner (only one bookmark open per library directory -- very efficient)
- Browse feature (if you pick a volume that we don't have access to it starts the "ask for access" flow)
- iTunes feature
- Traktor feature (we have to ask for access to the Traktor folder on the first use).
- AudioTagger
- DlgTrackInfo
- Creation of bookmarks for dropped files.
- Vamp and SoundSource plugin paths use the right user-data location.

Migration:
- On bootup, we check for permissions to every library directory. If we can't access one we prompt for access.
- If the iTunes saved library path is not accessible, we ask for access.
- As a last-chance, if a track is about to be loaded to a deck that we don't have access to we pop up the "ask for access" flow.

Still TODO:
- Browse mode selection of volumes is still a little wonky.
- Text in the ask-for-access flow needs tightening.
- Playlist import -- ask for access to files that are not covered.

[1] https://developer.apple.com/library/mac/documentation/security/conceptual/AppSandboxDesignGuide/AboutAppSandbox/AboutAppSandbox.html#//apple_ref/doc/uid/TP40011183-CH1-SW1
[2] https://bugs.launchpad.net/mixxx/+bug/1257340
[3] https://blueprints.launchpad.net/mixxx/+spec/macappstore
