### PR TITLE
fix #1273333. Don't rollback on cancel

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1284,7 +1284,7 @@ void TrackDAO::markTrackLocationsAsDeleted(const QString& directory) {
     }
 }
 
-// Look for moved files. Look for files that have been marked as "deleted on disk"
+// Look for moved files. Look for files that have been marked as "need verification"
 // and see if another "file" with the same name and filesize exists in the track_locations
 // table. That means the file has moved instead of being deleted outright, and so
 // we can salvage your existing metadata that you have in your DB (like cue points, etc.).
@@ -1304,7 +1304,7 @@ void TrackDAO::detectMovedFiles(QSet<int>* pTracksMovedSetOld, QSet<int>* pTrack
 
     query.prepare("SELECT track_locations.id, filename, duration FROM track_locations "
                   "INNER JOIN library ON track_locations.id=library.location "
-                  "WHERE fs_deleted=1");
+                  "WHERE needs_verification=1");
 
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
@@ -1312,7 +1312,7 @@ void TrackDAO::detectMovedFiles(QSet<int>* pTracksMovedSetOld, QSet<int>* pTrack
 
     query2.prepare("SELECT track_locations.id FROM track_locations "
                    "INNER JOIN library ON track_locations.id=library.location "
-                   "WHERE fs_deleted=0 AND "
+                   "WHERE needs_verification=0 AND "
                    "filename=:filename AND "
                    "duration=:duration");
 

--- a/src/library/libraryscanner.cpp
+++ b/src/library/libraryscanner.cpp
@@ -371,20 +371,20 @@ bool LibraryScanner::recursiveScan(const QDir& dir, QStringList& verifiedDirecto
 
     // Compare the hashes, and if they don't match, rescan the files in that directory!
     if (prevHash != newHash) {
-        //If we didn't know about this directory before...
-        if (!prevHashExists) {
-            m_libraryHashDao.saveDirectoryHash(dirPath, newHash);
-        } else {
-            // Contents of a known directory have changed. Just need to update
-            // the old hash in the database and then rescan it.
-            qDebug() << "old hash was" << prevHash << "and new hash is" << newHash;
-            m_libraryHashDao.updateDirectoryHash(dirPath, newHash, 0);
-        }
-
         // Rescan that mofo! If importing fails then the scan was cancelled so
         // we return immediately.
         if (!importFiles(filesToImport)) {
             return false;
+        }
+        // If we didn't know about this directory before...
+        // save the hash after we imported everything in it
+        if (!prevHashExists) {
+            m_libraryHashDao.saveDirectoryHash(dirPath, newHash);
+        } else {
+            // Contents of a known directory have changed. Just need to update
+            // the old hash in the database
+            qDebug() << "old hash was" << prevHash << "and new hash is" << newHash;
+            m_libraryHashDao.updateDirectoryHash(dirPath, newHash, 0);
         }
     } else { //prevHash == newHash
         // Add the directory to the verifiedDirectories list, so that later they

--- a/src/library/libraryscanner.cpp
+++ b/src/library/libraryscanner.cpp
@@ -42,8 +42,7 @@ LibraryScanner::LibraryScanner(TrackCollection* collection)
                 // conn is in the right thread.
                 m_extensionFilter(SoundSourceProxy::supportedFileExtensionsRegex(),
                                   Qt::CaseInsensitive),
-    m_bCancelLibraryScan(false) {
-
+                m_bCancelLibraryScan(false) {
     qDebug() << "Constructed LibraryScanner";
 
     // Force the GUI thread's TrackInfoObject cache to be cleared when a library
@@ -137,7 +136,7 @@ LibraryScanner::~LibraryScanner() {
 void LibraryScanner::run() {
     Trace trace("LibraryScanner");
     unsigned static id = 0; // the id of this thread, for debugging purposes
-            //XXX copypasta (should factor this out somehow), -kousu 2/2009
+    //XXX copypasta (should factor this out somehow), -kousu 2/2009
     QThread::currentThread()->setObjectName(QString("LibraryScanner %1").arg(++id));
     //m_pProgress->slotStartTiming();
 
@@ -226,10 +225,10 @@ void LibraryScanner::run() {
     // Recursivly scan each directory in the directories table.
     foreach (const QString& dir, dirs) {
         bScanFinishedCleanly = recursiveScan(dir, verifiedDirectories);
-        if (!bScanFinishedCleanly) {
-            qDebug() << "Recursive scaning (" << dir << ") interrupted.";
+        if (bScanFinishedCleanly) {
+            qDebug() << "Recursive scanning (" << dir << ") finished cleanly.";
         } else {
-            qDebug() << "Recursive scaning (" << dir << ") finished cleanly.";
+            qDebug() << "Recursive scanning (" << dir << ") interrupted.";
         }
     }
 
@@ -242,8 +241,8 @@ void LibraryScanner::run() {
     }
 
     // Clean up and commit or rollback the transaction depending on
-    // bScanFinishedCleanly.
-    m_trackDao.addTracksFinish(!bScanFinishedCleanly);
+    // bScanFinishedCleanly or if the scan was canceled..
+    m_trackDao.addTracksFinish(!(m_bCancelLibraryScan || bScanFinishedCleanly));
 
     // At the end of a scan, mark all tracks and directories that
     // weren't "verified" as "deleted" (as long as the scan wasn't canceled


### PR DESCRIPTION
Only rollback the library if we had another problem then canceling the
recursive scan.
