### PR TITLE
Ignore MIDI_NOTE when dParam == 0 mapping Midi Pushbuttons.

### DIFF
--- a/src/control/controlbehavior.cpp
+++ b/src/control/controlbehavior.cpp
@@ -184,19 +184,15 @@ ControlPushButtonBehavior::ControlPushButtonBehavior(ButtonMode buttonMode,
 
 void ControlPushButtonBehavior::setValueFromMidiParameter(
         MidiOpCode o, double dParam, ControlDoublePrivate* pControl) {
+    Q_UNUSED(o);
     // This block makes push-buttons act as power window buttons.
     if (m_buttonMode == POWERWINDOW && m_iNumStates == 2) {
-        if (o == MIDI_NOTE_ON) {
-            if (dParam > 0.) {
-                double value = pControl->get();
-                pControl->set(!value, NULL);
-                m_pushTimer.setSingleShot(true);
-                m_pushTimer.start(kPowerWindowTimeMillis);
-            }
-        } else if (o == MIDI_NOTE_OFF) {
-            if (!m_pushTimer.isActive()) {
-                pControl->set(0.0, NULL);
-            }
+        if (dParam > 0.) {
+            pControl->set(1., NULL);
+            m_pushTimer.setSingleShot(true);
+            m_pushTimer.start(kPowerWindowTimeMillis);
+        } else if (!m_pushTimer.isActive()) {
+            pControl->set(0., NULL);
         }
     } else if (m_buttonMode == TOGGLE || m_buttonMode == LONGPRESSLATCHING) {
         // This block makes push-buttons act as toggle buttons.
@@ -213,22 +209,22 @@ void ControlPushButtonBehavior::setValueFromMidiParameter(
                     m_pushTimer.setSingleShot(true);
                     m_pushTimer.start(kLongPressLatchingTimeMillis);
                 }
-            } else if (o == MIDI_NOTE_OFF) {
+            } else {
                 double value = pControl->get();
                 if (m_buttonMode == LONGPRESSLATCHING &&
-                        m_pushTimer.isActive() && value >= 1.0) {
+                        m_pushTimer.isActive() && value >= 1.) {
                     // revert toggle if button is released too early
-                    value = (int)(value - 1.0) % m_iNumStates;
+                    value = (int)(value - 1.) % m_iNumStates;
                     pControl->set(value, NULL);
                 }
             }
         }
     } else { // Not a toggle button (trigger only when button pushed)
-        if (o == MIDI_NOTE_ON) {
-            double value = pControl->get();
-            pControl->set(!value, NULL);
-        } else if (o == MIDI_NOTE_OFF) {
-            pControl->set(0.0, NULL);
+        if (dParam > 0.) {
+            pControl->set(1., NULL);
+        } else {
+            pControl->set(0., NULL);
         }
     }
 }
+


### PR DESCRIPTION
The code inside Mixxx assumes that the Buttons on the Midi device will send
MIDI_NOTE_ON and
MIDI_NOTE_OFF

At least the RMX2 controller sends allays MIDI_NOTE_ON

Debug [Controller]: "MIDI status 0x90 (ch 1, opcode 0x9), ctrl 0x23, val 0x7F"
Debug [Controller]: "MIDI status 0x90 (ch 1, opcode 0x9), ctrl 0x23, val 0x00"

According to http://de.wikipedia.org/wiki/Musical_Instrument_Digital_Interface
status 0x90 (ch 1, opcode 0x9), ctrl 0x23, val 0x00
should be interpreted as released. 

This is fixed by here.
