### PR TITLE
Engineaux and Microphone improvements

### DIFF
--- a/src/engine/engineaux.cpp
+++ b/src/engine/engineaux.cpp
@@ -13,7 +13,7 @@ EngineAux::EngineAux(const char* pGroup)
         : EngineChannel(pGroup, EngineChannel::CENTER),
           m_clipping(pGroup),
           m_vuMeter(pGroup),
-          m_pEnabled(new ControlObject(ConfigKey(pGroup, "passthrough_enabled"))),
+          m_pConfigured(new ControlObject(ConfigKey(pGroup, "configured"))),
           m_pPassing(new ControlPushButton(ConfigKey(pGroup, "passthrough"))),
           m_pConversionBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)),
           // Need a +1 here because the CircularBuffer only allows its size-1
@@ -30,13 +30,13 @@ EngineAux::EngineAux(const char* pGroup)
 EngineAux::~EngineAux() {
     qDebug() << "~EngineAux()";
     SampleUtil::free(m_pConversionBuffer);
-    delete m_pEnabled;
+    delete m_pConfigured;
     delete m_pPassing;
 }
 
 bool EngineAux::isActive() const {
-    bool enabled = m_pEnabled->get() > 0.0;
-    return enabled && !m_sampleBuffer.isEmpty();
+    bool configured = m_pConfigured->get() > 0.0;
+    return configured && !m_sampleBuffer.isEmpty();
 }
 
 void EngineAux::onInputConnected(AudioInput input) {
@@ -46,7 +46,7 @@ void EngineAux::onInputConnected(AudioInput input) {
         return;
     }
     m_sampleBuffer.clear();
-    m_pEnabled->set(1.0);
+    m_pConfigured->set(1.0);
 }
 
 void EngineAux::onInputDisconnected(AudioInput input) {
@@ -56,7 +56,7 @@ void EngineAux::onInputDisconnected(AudioInput input) {
         return;
     }
     m_sampleBuffer.clear();
-    m_pEnabled->set(0.0);
+    m_pConfigured->set(0.0);
 }
 
 void EngineAux::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
@@ -67,7 +67,7 @@ void EngineAux::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
 
     if (input.getType() != AudioPath::AUXILLIARY) {
         // This is an error!
-        qDebug() << "WARNING: EngineAux receieved an AudioInput for a non-passthrough type!";
+        qDebug() << "WARNING: EngineAux received an AudioInput for a non-auxilliary type!";
         return;
     }
 

--- a/src/engine/engineaux.cpp
+++ b/src/engine/engineaux.cpp
@@ -117,22 +117,14 @@ void EngineAux::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
 void EngineAux::process(const CSAMPLE* pInput, CSAMPLE* pOut, const int iBufferSize) {
     Q_UNUSED(pInput);
 
-    // If passthrough is enabled, then read into the output buffer. Otherwise,
-    // skip the appropriate number of samples to throw them away.
-    if (m_pPassing->get() > 0.0) {
-        int samplesRead = m_sampleBuffer.read(pOut, iBufferSize);
-        if (samplesRead < iBufferSize) {
-            // Buffer underflow. There aren't getting samples fast enough. This
-            // shouldn't happen since PortAudio should feed us samples just as fast
-            // as we consume them, right?
-            qWarning() << "ERROR: Buffer underflow in EngineAux. Playing silence.";
-            SampleUtil::applyGain(pOut + samplesRead, 0.0, iBufferSize - samplesRead);
-        }
-    } else {
-        SampleUtil::applyGain(pOut, 0.0, iBufferSize);
-        m_sampleBuffer.skip(iBufferSize);
+    int samplesRead = m_sampleBuffer.read(pOut, iBufferSize);
+    if (samplesRead < iBufferSize) {
+        // Buffer underflow. There aren't getting samples fast enough. This
+        // shouldn't happen since PortAudio should feed us samples just as fast
+        // as we consume them, right?
+        qWarning() << "ERROR: Buffer underflow in EngineAux. Playing silence.";
+        SampleUtil::applyGain(pOut + samplesRead, 0.0, iBufferSize - samplesRead);
     }
-
     // Apply clipping
     m_clipping.process(pOut, pOut, iBufferSize);
     // Update VU meter

--- a/src/engine/engineaux.h
+++ b/src/engine/engineaux.h
@@ -41,7 +41,7 @@ class EngineAux : public EngineChannel, public AudioDestination {
   private:
     EngineClipping m_clipping;
     EngineVuMeter m_vuMeter;
-    ControlObject* m_pEnabled;
+    ControlObject* m_pConfigured;
     ControlPushButton* m_pPassing;
     CSAMPLE* m_pConversionBuffer;
     CircularBuffer<CSAMPLE> m_sampleBuffer;

--- a/src/engine/engineaux.h
+++ b/src/engine/engineaux.h
@@ -20,7 +20,7 @@ class EngineAux : public EngineChannel, public AudioDestination {
     EngineAux(const char* pGroup);
     virtual ~EngineAux();
 
-    bool isActive() const;
+    bool isActive();
 
     // Called by EngineMaster whenever is requesting a new buffer of audio.
     virtual void process(const CSAMPLE* pInput, CSAMPLE* pOutput, const int iBufferSize);
@@ -45,6 +45,7 @@ class EngineAux : public EngineChannel, public AudioDestination {
     ControlPushButton* m_pPassing;
     CSAMPLE* m_pConversionBuffer;
     CircularBuffer<CSAMPLE> m_sampleBuffer;
+    bool m_wasActive;
 };
 
 #endif // ENGINEAUX_H

--- a/src/engine/enginechannel.h
+++ b/src/engine/enginechannel.h
@@ -47,7 +47,7 @@ class EngineChannel : public EngineObject {
     virtual ChannelOrientation getOrientation() const;
     virtual const QString& getGroup() const;
 
-    virtual bool isActive() const = 0;
+    virtual bool isActive() = 0;
     void setPFL(bool enabled);
     virtual bool isPFL() const;
     void setMaster(bool enabled);

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -121,7 +121,7 @@ EngineBuffer* EngineDeck::getEngineBuffer() {
     return m_pBuffer;
 }
 
-bool EngineDeck::isActive() const {
+bool EngineDeck::isActive() {
     if (m_bPassthroughWasActive && !m_bPassthroughIsActive) {
         return true;
     }

--- a/src/engine/enginedeck.h
+++ b/src/engine/enginedeck.h
@@ -50,7 +50,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     // TODO(XXX) This hack needs to be removed.
     virtual EngineBuffer* getEngineBuffer();
 
-    virtual bool isActive() const;
+    virtual bool isActive();
 
     // This is called by SoundManager whenever there are new samples from the
     // deck to be processed.

--- a/src/engine/enginemicrophone.cpp
+++ b/src/engine/enginemicrophone.cpp
@@ -12,7 +12,7 @@ EngineMicrophone::EngineMicrophone(const char* pGroup)
         : EngineChannel(pGroup, EngineChannel::CENTER),
           m_clipping(pGroup),
           m_vuMeter(pGroup),
-          m_pEnabled(new ControlObject(ConfigKey(pGroup, "enabled"))),
+          m_pConfigured(new ControlObject(ConfigKey(pGroup, "configured"))),
           m_pControlTalkover(new ControlPushButton(ConfigKey(pGroup, "talkover"))),
           m_pConversionBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)),
           // Need a +1 here because the CircularBuffer only allows its size-1
@@ -30,12 +30,12 @@ EngineMicrophone::EngineMicrophone(const char* pGroup)
 EngineMicrophone::~EngineMicrophone() {
     qDebug() << "~EngineMicrophone()";
     SampleUtil::free(m_pConversionBuffer);
-    delete m_pEnabled;
+    delete m_pConfigured;
     delete m_pControlTalkover;
 }
 
 bool EngineMicrophone::isActive() {
-    bool enabled = m_pEnabled->get() > 0.0;
+    bool enabled = m_pConfigured->get() > 0.0;
     return enabled && !m_sampleBuffer.isEmpty();
 }
 
@@ -46,7 +46,7 @@ void EngineMicrophone::onInputConnected(AudioInput input) {
         return;
     }
     m_sampleBuffer.clear();
-    m_pEnabled->set(1.0);
+    m_pConfigured->set(1.0);
 }
 
 void EngineMicrophone::onInputDisconnected(AudioInput input) {
@@ -56,7 +56,7 @@ void EngineMicrophone::onInputDisconnected(AudioInput input) {
         return;
     }
     m_sampleBuffer.clear();
-    m_pEnabled->set(0.0);
+    m_pConfigured->set(0.0);
 }
 
 void EngineMicrophone::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,

--- a/src/engine/enginemicrophone.cpp
+++ b/src/engine/enginemicrophone.cpp
@@ -34,7 +34,7 @@ EngineMicrophone::~EngineMicrophone() {
     delete m_pControlTalkover;
 }
 
-bool EngineMicrophone::isActive() const {
+bool EngineMicrophone::isActive() {
     bool enabled = m_pEnabled->get() > 0.0;
     return enabled && !m_sampleBuffer.isEmpty();
 }

--- a/src/engine/enginemicrophone.h
+++ b/src/engine/enginemicrophone.h
@@ -19,7 +19,7 @@ class EngineMicrophone : public EngineChannel, public AudioDestination {
     EngineMicrophone(const char* pGroup);
     virtual ~EngineMicrophone();
 
-    bool isActive() const;
+    bool isActive();
 
     // Called by EngineMaster whenever is requesting a new buffer of audio.
     virtual void process(const CSAMPLE* pInput, CSAMPLE* pOutput, const int iBufferSize);

--- a/src/engine/enginemicrophone.h
+++ b/src/engine/enginemicrophone.h
@@ -47,6 +47,8 @@ class EngineMicrophone : public EngineChannel, public AudioDestination {
     ControlPushButton* m_pControlTalkover;
     CSAMPLE* m_pConversionBuffer;
     CircularBuffer<CSAMPLE> m_sampleBuffer;
+
+    bool m_wasActive;
 };
 
 #endif /* ENGINEMICROPHONE_H */

--- a/src/engine/enginemicrophone.h
+++ b/src/engine/enginemicrophone.h
@@ -43,7 +43,7 @@ class EngineMicrophone : public EngineChannel, public AudioDestination {
   private:
     EngineClipping m_clipping;
     EngineVuMeter m_vuMeter;
-    ControlObject* m_pEnabled;
+    ControlObject* m_pConfigured;
     ControlPushButton* m_pControlTalkover;
     CSAMPLE* m_pConversionBuffer;
     CircularBuffer<CSAMPLE> m_sampleBuffer;

--- a/src/engine/enginevumeter.cpp
+++ b/src/engine/enginevumeter.cpp
@@ -26,20 +26,13 @@ EngineVuMeter::EngineVuMeter(const char* group) {
     // The VUmeter widget is controlled via a controlpotmeter, which means
     // that it should react on the setValue(int) signal.
     m_ctrlVuMeter = new ControlPotmeter(ConfigKey(group, "VuMeter"), 0., 1.);
-    m_ctrlVuMeter->set(0);
     // left channel VU meter
     m_ctrlVuMeterL = new ControlPotmeter(ConfigKey(group, "VuMeterL"), 0., 1.);
-    m_ctrlVuMeterL->set(0);
     // right channel VU meter
     m_ctrlVuMeterR = new ControlPotmeter(ConfigKey(group, "VuMeterR"), 0., 1.);
-    m_ctrlVuMeterR->set(0);
 
     // Initialize the calculation:
-    m_iSamplesCalculated = 0;
-    m_fRMSvolumeL = 0;
-    m_fRMSvolumeSumL = 0;
-    m_fRMSvolumeR = 0;
-    m_fRMSvolumeSumR = 0;
+    reset();
 }
 
 EngineVuMeter::~EngineVuMeter()
@@ -96,3 +89,15 @@ void EngineVuMeter::doSmooth(FLOAT_TYPE &currentVolume, FLOAT_TYPE newVolume)
     if (currentVolume > 1.0)
         currentVolume=1.0;
 }
+
+void EngineVuMeter::reset() {
+    m_ctrlVuMeter->set(0);
+    m_ctrlVuMeterL->set(0);
+    m_ctrlVuMeterR->set(0);
+    m_iSamplesCalculated = 0;
+    m_fRMSvolumeL = 0;
+    m_fRMSvolumeSumL = 0;
+    m_fRMSvolumeR = 0;
+    m_fRMSvolumeSumR = 0;
+}
+

--- a/src/engine/enginevumeter.h
+++ b/src/engine/enginevumeter.h
@@ -37,6 +37,8 @@ class EngineVuMeter : public EngineObject {
 
     virtual void process(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize);
 
+    void reset();
+
   private:
     ControlPotmeter* m_ctrlVuMeter;
     ControlPotmeter* m_ctrlVuMeterL;

--- a/src/test/enginemastertest.cpp
+++ b/src/test/enginemastertest.cpp
@@ -24,7 +24,7 @@ class EngineChannelMock : public EngineChannel {
         Q_UNUSED(iBufferSize);
     }
 
-    MOCK_CONST_METHOD0(isActive, bool());
+    MOCK_METHOD0(isActive, bool());
     MOCK_CONST_METHOD0(isMaster, bool());
     MOCK_CONST_METHOD0(isPFL, bool());
     MOCK_METHOD3(process, void(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize));

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -111,7 +111,13 @@ void WVuMeter::onConnectedControlValueChanged(double dValue) {
     else if (idx < 0)
         idx = 0;
 
-    setPeak(idx);
+    if (dValue > 0.) {
+        setPeak(idx);
+    } else {
+        // A 0.0 value is very unlikely except when the VU Meter is disabled
+        m_iPeakPos = 0;
+    }
+
 
     QTime currentTime = QTime::currentTime();
     int msecsElapsed = m_lastUpdate.msecsTo(currentTime);


### PR DESCRIPTION
This fixes: 
- the stucked VU-meter when disable passthrough
- unifies the enable controls for displaying widgets (or not) to "configured"
- prevent the mic to process the input buffer when not used 
