### PR TITLE
Skin tiled backpath

### DIFF
--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -141,6 +141,16 @@ bool SkinContext::selectAttributeBool(const QDomElement& element,
     return defaultValue;
 }
 
+QString SkinContext::selectAttributeString(const QDomElement& element,
+                                           const QString& attributeName,
+                                           QString defaultValue) const {
+    if (element.hasAttribute(attributeName)) {
+        QString stringValue = element.attribute(attributeName);
+        return stringValue == "" ? defaultValue :stringValue;
+    }
+    return defaultValue;
+}
+
 QString SkinContext::variableNodeToText(const QDomElement& variableNode) const {
     if (variableNode.hasAttribute("expression")) {
         QScriptValue result = m_scriptEngine.evaluate(

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -55,6 +55,9 @@ class SkinContext {
     bool selectAttributeBool(const QDomElement& element,
                              const QString& attributeName,
                              bool defaultValue) const;
+    QString selectAttributeString(const QDomElement& element,
+                                  const QString& attributeName,
+                                  QString defaultValue) const;
     QString nodeToString(const QDomNode& node) const;
 
   private:

--- a/src/widget/wdisplay.cpp
+++ b/src/widget/wdisplay.cpp
@@ -84,7 +84,7 @@ void WDisplay::resetPositions() {
 }
 
 void WDisplay::setPixmapBackground(const QString& filename) {
-    m_pPixmapBack = WPixmapStore::getPaintable(filename);
+    m_pPixmapBack = WPixmapStore::getPaintable(filename, Paintable::TILE);
     if (m_pPixmapBack.isNull() || m_pPixmapBack->isNull()) {
         qDebug() << metaObject()->className()
                  << "Error loading background pixmap:" << filename;
@@ -97,7 +97,8 @@ void WDisplay::setPixmap(QVector<PaintablePointer>* pPixmaps, int iPos,
         return;
     }
 
-    PaintablePointer pPixmap = WPixmapStore::getPaintable(filename);
+    PaintablePointer pPixmap = WPixmapStore::getPaintable(filename,
+                                                          Paintable::TILE);
 
     if (pPixmap.isNull() || pPixmap->isNull()) {
         qDebug() << metaObject()->className()

--- a/src/widget/wdisplay.cpp
+++ b/src/widget/wdisplay.cpp
@@ -39,16 +39,10 @@ WDisplay::~WDisplay() {
 void WDisplay::setup(QDomNode node, const SkinContext& context) {
     // Set background pixmap if available
     if (context.hasNode(node, "BackPath")) {
-        QDomElement backpath = context.selectElement(node, "BackPath");
-        Paintable::DrawMode mode;
-        QString mode_str = backpath.attribute("mode", "TILE");
-        if (mode_str.toUpper() == "STRETCH") {
-            mode = Paintable::STRETCH;
-        } else {
-            mode = Paintable::TILE;
-        }
+        QString mode_str = context.selectAttributeString(
+                context.selectElement(node, "BackPath"), "mode", "TILE");
         setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")),
-                            mode);
+                            Paintable::DrawModeFromString(mode_str));
     }
 
     // Number of states

--- a/src/widget/wdisplay.cpp
+++ b/src/widget/wdisplay.cpp
@@ -39,8 +39,16 @@ WDisplay::~WDisplay() {
 void WDisplay::setup(QDomNode node, const SkinContext& context) {
     // Set background pixmap if available
     if (context.hasNode(node, "BackPath")) {
-        setPixmapBackground(context.getSkinPath(
-            context.selectString(node, "BackPath")));
+        QDomElement backpath = context.selectElement(node, "BackPath");
+        Paintable::DrawMode mode;
+        QString mode_str = backpath.attribute("mode", "TILE");
+        if (mode_str.toUpper() == "STRETCH") {
+            mode = Paintable::STRETCH;
+        } else {
+            mode = Paintable::TILE;
+        }
+        setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")),
+                            mode);
     }
 
     // Number of states
@@ -83,8 +91,9 @@ void WDisplay::resetPositions() {
     m_disabledPixmaps.resize(0);
 }
 
-void WDisplay::setPixmapBackground(const QString& filename) {
-    m_pPixmapBack = WPixmapStore::getPaintable(filename, Paintable::TILE);
+void WDisplay::setPixmapBackground(const QString& filename,
+                                   Paintable::DrawMode mode) {
+    m_pPixmapBack = WPixmapStore::getPaintable(filename, mode);
     if (m_pPixmapBack.isNull() || m_pPixmapBack->isNull()) {
         qDebug() << metaObject()->className()
                  << "Error loading background pixmap:" << filename;

--- a/src/widget/wdisplay.h
+++ b/src/widget/wdisplay.h
@@ -46,7 +46,7 @@ class WDisplay : public WWidget {
     void setPixmap(QVector<PaintablePointer>* pPixmaps, int iPos,
                    const QString& filename);
 
-    void setPixmapBackground(const QString& filename);
+    void setPixmapBackground(const QString& filename, Paintable::DrawMode mode);
 
     void setPositions(int iNoPos);
 

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -17,16 +17,10 @@ void WKnobComposed::setup(QDomNode node, const SkinContext& context) {
 
     // Set background pixmap if available
     if (context.hasNode(node, "BackPath")) {
-        QDomElement backpath = context.selectElement(node, "BackPath");
-        Paintable::DrawMode mode;
-        QString mode_str = backpath.attribute("mode", "TILE");
-        if (mode_str.toUpper() == "STRETCH") {
-            mode = Paintable::STRETCH;
-        } else {
-            mode = Paintable::TILE;
-        }
+        QString mode_str = context.selectAttributeString(
+                context.selectElement(node, "BackPath"), "mode", "TILE");
         setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")),
-                            mode);
+                            Paintable::DrawModeFromString(mode_str));
     }
 
     // Set background pixmap if available

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -17,7 +17,16 @@ void WKnobComposed::setup(QDomNode node, const SkinContext& context) {
 
     // Set background pixmap if available
     if (context.hasNode(node, "BackPath")) {
-        setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")));
+        QDomElement backpath = context.selectElement(node, "BackPath");
+        Paintable::DrawMode mode;
+        QString mode_str = backpath.attribute("mode", "TILE");
+        if (mode_str.toUpper() == "STRETCH") {
+            mode = Paintable::STRETCH;
+        } else {
+            mode = Paintable::TILE;
+        }
+        setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")),
+                            mode);
     }
 
     // Set background pixmap if available
@@ -39,8 +48,9 @@ void WKnobComposed::clear() {
     m_pKnob.clear();
 }
 
-void WKnobComposed::setPixmapBackground(const QString& filename) {
-    m_pPixmapBack = WPixmapStore::getPaintable(filename, Paintable::TILE);
+void WKnobComposed::setPixmapBackground(const QString& filename,
+                                        Paintable::DrawMode mode) {
+    m_pPixmapBack = WPixmapStore::getPaintable(filename, mode);
     if (m_pPixmapBack.isNull() || m_pPixmapBack->isNull()) {
         qDebug() << metaObject()->className()
                  << "Error loading background pixmap:" << filename;

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -40,7 +40,7 @@ void WKnobComposed::clear() {
 }
 
 void WKnobComposed::setPixmapBackground(const QString& filename) {
-    m_pPixmapBack = WPixmapStore::getPaintable(filename);
+    m_pPixmapBack = WPixmapStore::getPaintable(filename, Paintable::TILE);
     if (m_pPixmapBack.isNull() || m_pPixmapBack->isNull()) {
         qDebug() << metaObject()->className()
                  << "Error loading background pixmap:" << filename;
@@ -48,7 +48,7 @@ void WKnobComposed::setPixmapBackground(const QString& filename) {
 }
 
 void WKnobComposed::setPixmapKnob(const QString& filename) {
-    m_pKnob = WPixmapStore::getPaintable(filename);
+    m_pKnob = WPixmapStore::getPaintable(filename, Paintable::STRETCH);
     if (m_pKnob.isNull() || m_pKnob->isNull()) {
         qDebug() << metaObject()->className()
                  << "Error loading knob pixmap:" << filename;

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -29,7 +29,7 @@ class WKnobComposed : public WWidget {
 
   private:
     void clear();
-    void setPixmapBackground(const QString& filename);
+    void setPixmapBackground(const QString& filename, Paintable::DrawMode mode);
     void setPixmapKnob(const QString& filename);
 
     PaintablePointer m_pKnob;

--- a/src/widget/wpixmapstore.cpp
+++ b/src/widget/wpixmapstore.cpp
@@ -17,11 +17,22 @@
 
 #include "widget/wpixmapstore.h"
 
+#include <QString>
 #include <QtDebug>
 
 // static
 QHash<QString, WeakPaintablePointer> WPixmapStore::m_paintableCache;
 QSharedPointer<ImgSource> WPixmapStore::m_loader = QSharedPointer<ImgSource>();
+
+Paintable::DrawMode Paintable::DrawModeFromString(QString str) {
+    if (str.toUpper() == "TILE") {
+        return TILE;
+    } else if (str.toUpper() == "STRETCH") {
+        return STRETCH;
+    }
+    qWarning() << "Unknown string for drawing mode " << str << ", using TILE";
+    return TILE;
+}
 
 Paintable::Paintable(QImage* pImage, DrawMode mode)
         : m_draw_mode(mode) {

--- a/src/widget/wpixmapstore.cpp
+++ b/src/widget/wpixmapstore.cpp
@@ -91,6 +91,19 @@ void Paintable::draw(const QRectF& targetRect, QPainter* pPainter) {
     }
 }
 
+void Paintable::drawTiled(const QRectF& targetRect, QPainter* pPainter) {
+    if (!targetRect.isValid()) {
+        return;
+    }
+
+    if (!m_pPixmap.isNull() && !m_pPixmap->isNull()) {
+        pPainter->drawTiledPixmap(targetRect, *m_pPixmap, QPoint(0,0));
+    } else if (!m_pSvg.isNull() && m_pSvg->isValid()) {
+        m_pSvg->render(pPainter, targetRect);
+    }
+}
+
+
 void Paintable::draw(const QRectF& targetRect, QPainter* pPainter,
                      const QRectF& sourceRect) {
     if (!targetRect.isValid() || !sourceRect.isValid()) {

--- a/src/widget/wpixmapstore.h
+++ b/src/widget/wpixmapstore.h
@@ -33,9 +33,14 @@
 // high fidelity.
 class Paintable {
   public:
+    enum DrawMode {
+        STRETCH,
+        TILE
+    };
+
     // Takes ownership of QImage.
-    Paintable(QImage* pImage);
-    Paintable(const QString& fileName);
+    Paintable(QImage* pImage, DrawMode mode);
+    Paintable(const QString& fileName, DrawMode mode);
 
     QSize size() const;
     int width() const;
@@ -45,7 +50,6 @@ class Paintable {
     void draw(const QPointF& point, QPainter* pPainter,
               const QRectF& sourceRect);
     void draw(const QRectF& targetRect, QPainter* pPainter);
-    void drawTiled(const QRectF& targetRect, QPainter* pPainter);
     void draw(const QRectF& targetRect, QPainter* pPainter,
               const QRectF& sourceRect);
     bool isNull() const;
@@ -56,6 +60,7 @@ class Paintable {
     QScopedPointer<QPixmap> m_pPixmap;
     QScopedPointer<QSvgRenderer> m_pSvg;
     QScopedPointer<QPixmap> m_pPixmapSvg;
+    DrawMode m_draw_mode;
 };
 
 typedef QSharedPointer<Paintable> PaintablePointer;
@@ -63,7 +68,8 @@ typedef QWeakPointer<Paintable> WeakPaintablePointer;
 
 class WPixmapStore {
   public:
-    static PaintablePointer getPaintable(const QString& fileName);
+    static PaintablePointer getPaintable(const QString& fileName,
+                                         Paintable::DrawMode mode);
     static QPixmap* getPixmapNoCache(const QString& fileName);
     static void setLoader(QSharedPointer<ImgSource> ld);
 

--- a/src/widget/wpixmapstore.h
+++ b/src/widget/wpixmapstore.h
@@ -29,6 +29,8 @@
 
 #include "skin/imgsource.h"
 
+class QString;
+
 // Wrapper around QImage and QSvgRenderer to support rendering SVG images in
 // high fidelity.
 class Paintable {
@@ -53,6 +55,7 @@ class Paintable {
     void draw(const QRectF& targetRect, QPainter* pPainter,
               const QRectF& sourceRect);
     bool isNull() const;
+    static DrawMode DrawModeFromString(QString str);
 
   private:
     void resizeSvgPixmap(const QRectF& targetRect, const QRectF& sourceRect);

--- a/src/widget/wpixmapstore.h
+++ b/src/widget/wpixmapstore.h
@@ -45,6 +45,7 @@ class Paintable {
     void draw(const QPointF& point, QPainter* pPainter,
               const QRectF& sourceRect);
     void draw(const QRectF& targetRect, QPainter* pPainter);
+    void drawTiled(const QRectF& targetRect, QPainter* pPainter);
     void draw(const QRectF& targetRect, QPainter* pPainter,
               const QRectF& sourceRect);
     bool isNull() const;

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -61,7 +61,16 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
 
     // Set background pixmap if available
     if (context.hasNode(node, "BackPath")) {
-        setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")));
+        QDomElement backpath = context.selectElement(node, "BackPath");
+        Paintable::DrawMode mode;
+        QString mode_str = backpath.attribute("mode", "TILE");
+        if (mode_str.toUpper() == "STRETCH") {
+            mode = Paintable::STRETCH;
+        } else {
+            mode = Paintable::TILE;
+        }
+        setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")),
+                            mode);
     }
 
     // Load pixmaps for associated states
@@ -225,10 +234,10 @@ void WPushButton::setPixmap(int iState, bool bPressed, const QString &filename) 
     pixmaps.replace(iState, pPixmap);
 }
 
-void WPushButton::setPixmapBackground(const QString &filename) {
+void WPushButton::setPixmapBackground(const QString &filename,
+                                      Paintable::DrawMode mode) {
     // Load background pixmap
-    m_pPixmapBack = WPixmapStore::getPaintable(filename,
-                                               Paintable::TILE);
+    m_pPixmapBack = WPixmapStore::getPaintable(filename, mode);
     if (m_pPixmapBack.isNull() || m_pPixmapBack->isNull()) {
         qDebug() << "WPushButton: Error loading background pixmap:" << filename;
     }

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -213,7 +213,8 @@ void WPushButton::setPixmap(int iState, bool bPressed, const QString &filename) 
         return;
     }
 
-    PaintablePointer pPixmap = WPixmapStore::getPaintable(filename);
+    PaintablePointer pPixmap = WPixmapStore::getPaintable(filename,
+                                                          Paintable::STRETCH);
 
     if (pPixmap.isNull() || pPixmap->isNull()) {
         qDebug() << "WPushButton: Error loading pixmap:" << filename;
@@ -226,7 +227,8 @@ void WPushButton::setPixmap(int iState, bool bPressed, const QString &filename) 
 
 void WPushButton::setPixmapBackground(const QString &filename) {
     // Load background pixmap
-    m_pPixmapBack = WPixmapStore::getPaintable(filename);
+    m_pPixmapBack = WPixmapStore::getPaintable(filename,
+                                               Paintable::TILE);
     if (m_pPixmapBack.isNull() || m_pPixmapBack->isNull()) {
         qDebug() << "WPushButton: Error loading background pixmap:" << filename;
     }

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -61,16 +61,10 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
 
     // Set background pixmap if available
     if (context.hasNode(node, "BackPath")) {
-        QDomElement backpath = context.selectElement(node, "BackPath");
-        Paintable::DrawMode mode;
-        QString mode_str = backpath.attribute("mode", "TILE");
-        if (mode_str.toUpper() == "STRETCH") {
-            mode = Paintable::STRETCH;
-        } else {
-            mode = Paintable::TILE;
-        }
+        QString mode_str = context.selectAttributeString(
+                context.selectElement(node, "BackPath"), "mode", "TILE");
         setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")),
-                            mode);
+                            Paintable::DrawModeFromString(mode_str));
     }
 
     // Load pixmaps for associated states

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -75,7 +75,7 @@ class WPushButton : public WWidget {
 
     // Associates a background pixmap with the widget. This is only needed if
     // the button pixmaps contains alpha channel values.
-    void setPixmapBackground(const QString &filename);
+    void setPixmapBackground(const QString &filename, Paintable::DrawMode mode);
 
     // True, if the button is currently pressed
     bool m_bPressed;

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -65,7 +65,8 @@ void WSliderComposed::setup(QDomNode node, const SkinContext& context) {
 }
 
 void WSliderComposed::setSliderPixmap(const QString& filenameSlider) {
-    m_pSlider = WPixmapStore::getPaintable(filenameSlider);
+    m_pSlider = WPixmapStore::getPaintable(filenameSlider,
+                                           Paintable::STRETCH);
     if (!m_pSlider) {
         qDebug() << "WSliderComposed: Error loading slider pixmap:" << filenameSlider;
     } else {
@@ -76,7 +77,8 @@ void WSliderComposed::setSliderPixmap(const QString& filenameSlider) {
 
 void WSliderComposed::setHandlePixmap(bool bHorizontal, const QString& filenameHandle) {
     m_bHorizontal = bHorizontal;
-    m_pHandle = WPixmapStore::getPaintable(filenameHandle);
+    m_pHandle = WPixmapStore::getPaintable(filenameHandle,
+                                           Paintable::STRETCH);
     if (!m_pHandle) {
         qDebug() << "WSliderComposed: Error loading handle pixmap:" << filenameHandle;
     } else {

--- a/src/widget/wstatuslight.cpp
+++ b/src/widget/wstatuslight.cpp
@@ -72,7 +72,8 @@ void WStatusLight::setPixmap(int iState, const QString& filename) {
         return;
     }
 
-    PaintablePointer pPixmap = WPixmapStore::getPaintable(filename);
+    PaintablePointer pPixmap = WPixmapStore::getPaintable(filename,
+                                                          Paintable::STRETCH);
 
     if (!pPixmap.isNull() && !pPixmap->isNull()) {
         m_pixmaps[iState] = pPixmap;

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -79,7 +79,8 @@ void WVuMeter::resetPositions() {
 }
 
 void WVuMeter::setPixmapBackground(const QString& filename) {
-    m_pPixmapBack = WPixmapStore::getPaintable(filename);
+    m_pPixmapBack = WPixmapStore::getPaintable(filename,
+                                               Paintable::TILE);
     if (m_pPixmapBack.isNull() || m_pPixmapBack->isNull()) {
         qDebug() << metaObject()->className()
                  << "Error loading background pixmap:" << filename;
@@ -90,7 +91,8 @@ void WVuMeter::setPixmapBackground(const QString& filename) {
 
 void WVuMeter::setPixmaps(const QString &vuFilename,
                           bool bHorizontal) {
-    m_pPixmapVu = WPixmapStore::getPaintable(vuFilename);
+    m_pPixmapVu = WPixmapStore::getPaintable(vuFilename,
+                                             Paintable::STRETCH);
     if (m_pPixmapVu.isNull() || m_pPixmapVu->isNull()) {
         qDebug() << "WVuMeter: Error loading vu pixmap" << vuFilename;
     } else {

--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -82,7 +82,19 @@ void WWidgetGroup::setup(QDomNode node, const SkinContext& context) {
 
     // Set background pixmap if available
     if (context.hasNode(node, "BackPath")) {
-        setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")));
+        QDomElement backpath = context.selectElement(node, "BackPath");
+        Paintable::DrawMode mode;
+        QString mode_str = backpath.attribute("mode", "TILE");
+        qDebug() << "DRAWMODE " << mode_str;
+        if (mode_str.toUpper() == "STRETCH") {
+            qDebug() << "selected stretch";
+            mode = Paintable::STRETCH;
+        } else {
+            qDebug() << "selected tile";
+            mode = Paintable::TILE;
+        }
+        setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")),
+                            mode);
     }
 
     QLayout* pLayout = NULL;
@@ -123,9 +135,9 @@ void WWidgetGroup::setup(QDomNode node, const SkinContext& context) {
     }
 }
 
-void WWidgetGroup::setPixmapBackground(const QString &filename) {
+void WWidgetGroup::setPixmapBackground(const QString &filename, Paintable::DrawMode mode) {
     // Load background pixmap
-    m_pPixmapBack = WPixmapStore::getPaintable(filename);
+    m_pPixmapBack = WPixmapStore::getPaintable(filename, mode);
     if (!m_pPixmapBack) {
         qDebug() << "WWidgetGroup: Error loading background pixmap:" << filename;
     }
@@ -143,7 +155,7 @@ void WWidgetGroup::paintEvent(QPaintEvent* pe) {
 
     if (m_pPixmapBack) {
         QStylePainter p(this);
-        m_pPixmapBack->drawTiled(rect(), &p);
+        m_pPixmapBack->draw(rect(), &p);
     }
 }
 

--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -82,16 +82,10 @@ void WWidgetGroup::setup(QDomNode node, const SkinContext& context) {
 
     // Set background pixmap if available
     if (context.hasNode(node, "BackPath")) {
-        QDomElement backpath = context.selectElement(node, "BackPath");
-        Paintable::DrawMode mode;
-        QString mode_str = backpath.attribute("mode", "TILE");
-        if (mode_str.toUpper() == "STRETCH") {
-            mode = Paintable::STRETCH;
-        } else {
-            mode = Paintable::TILE;
-        }
+        QString mode_str = context.selectAttributeString(
+                context.selectElement(node, "BackPath"), "mode", "TILE");
         setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")),
-                            mode);
+                            Paintable::DrawModeFromString(mode_str));
     }
 
     QLayout* pLayout = NULL;

--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -85,12 +85,9 @@ void WWidgetGroup::setup(QDomNode node, const SkinContext& context) {
         QDomElement backpath = context.selectElement(node, "BackPath");
         Paintable::DrawMode mode;
         QString mode_str = backpath.attribute("mode", "TILE");
-        qDebug() << "DRAWMODE " << mode_str;
         if (mode_str.toUpper() == "STRETCH") {
-            qDebug() << "selected stretch";
             mode = Paintable::STRETCH;
         } else {
-            qDebug() << "selected tile";
             mode = Paintable::TILE;
         }
         setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")),

--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -143,7 +143,7 @@ void WWidgetGroup::paintEvent(QPaintEvent* pe) {
 
     if (m_pPixmapBack) {
         QStylePainter p(this);
-        m_pPixmapBack->draw(rect(), &p);
+        m_pPixmapBack->drawTiled(rect(), &p);
     }
 }
 

--- a/src/widget/wwidgetgroup.h
+++ b/src/widget/wwidgetgroup.h
@@ -43,7 +43,7 @@ class WWidgetGroup : public QFrame, public WBaseWidget {
     void setLayoutAlignment(int alignment);
 
     void setup(QDomNode node, const SkinContext& context);
-    void setPixmapBackground(const QString &filename);
+    void setPixmapBackground(const QString &filename, Paintable::DrawMode mode);
     void addWidget(QWidget* pChild);
 
   protected:


### PR DESCRIPTION
WidgetGroup backpaths should be tiled, not stretched.

I tried this in my developer skin and it worked great.
