### PR TITLE
Wpushbutton default

### DIFF
--- a/src/controllers/controllerlearningeventfilter.cpp
+++ b/src/controllers/controllerlearningeventfilter.cpp
@@ -87,7 +87,7 @@ bool ControllerLearningEventFilter::eventFilter(QObject* pObject, QEvent* pEvent
 void ControllerLearningEventFilter::addWidgetClickInfo(
         QWidget* pWidget, Qt::MouseButton buttonState,
         ControlObject* pControl,
-        ControlWidgetConnection::EmitOption emitOption) {
+        ControlParameterWidgetConnection::EmitOption emitOption) {
     ControlInfo& info = m_widgetControlInfo[pWidget];
 
     if (buttonState == Qt::LeftButton) {

--- a/src/controllers/controllerlearningeventfilter.h
+++ b/src/controllers/controllerlearningeventfilter.h
@@ -10,19 +10,19 @@
 struct ControlInfo {
     ControlInfo()
             : clickControl(NULL),
-              emitOption(ControlWidgetConnection::EMIT_ON_PRESS_AND_RELEASE),
+              emitOption(ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE),
               leftClickControl(NULL),
-              leftEmitOption(ControlWidgetConnection::EMIT_ON_PRESS_AND_RELEASE),
+              leftEmitOption(ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE),
               rightClickControl(NULL),
-              rightEmitOption(ControlWidgetConnection::EMIT_ON_PRESS_AND_RELEASE) {
+              rightEmitOption(ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE) {
     }
 
     ControlObject* clickControl;
-    ControlWidgetConnection::EmitOption emitOption;
+    ControlParameterWidgetConnection::EmitOption emitOption;
     ControlObject* leftClickControl;
-    ControlWidgetConnection::EmitOption leftEmitOption;
+    ControlParameterWidgetConnection::EmitOption leftEmitOption;
     ControlObject* rightClickControl;
-    ControlWidgetConnection::EmitOption rightEmitOption;
+    ControlParameterWidgetConnection::EmitOption rightEmitOption;
 };
 
 class ControllerLearningEventFilter : public QObject {
@@ -35,7 +35,7 @@ class ControllerLearningEventFilter : public QObject {
 
     void addWidgetClickInfo(QWidget* pWidget, Qt::MouseButton buttonState,
                             ControlObject* pControl,
-                            ControlWidgetConnection::EmitOption emitOption);
+                            ControlParameterWidgetConnection::EmitOption emitOption);
 
   public slots:
     void startListening();

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -439,10 +439,11 @@ QList<QWidget*> LegacySkinParser::parseNode(QDomElement node) {
 
 QWidget* LegacySkinParser::parseSplitter(QDomElement node) {
     WSplitter* pSplitter = new WSplitter(m_pParent);
+    setupConnections(node, pSplitter);
     setupBaseWidget(node, pSplitter);
     setupWidget(node, pSplitter);
     pSplitter->setup(node, *m_pContext);
-    setupConnections(node, pSplitter);
+    pSplitter->Init();
 
     QDomNode childrenNode = m_pContext->selectNode(node, "Children");
     QWidget* pOldParent = m_pParent;
@@ -495,10 +496,11 @@ QWidget* LegacySkinParser::parseSplitter(QDomElement node) {
 
 QWidget* LegacySkinParser::parseWidgetGroup(QDomElement node) {
     WWidgetGroup* pGroup = new WWidgetGroup(m_pParent);
+    setupConnections(node, pGroup);
     setupBaseWidget(node, pGroup);
     setupWidget(node, pGroup);
     pGroup->setup(node, *m_pContext);
-    setupConnections(node, pGroup);
+    pGroup->Init();
 
     QDomNode childrenNode = m_pContext->selectNode(node, "Children");
 
@@ -538,9 +540,11 @@ QWidget* LegacySkinParser::parseWidgetStack(QDomElement node) {
     WWidgetStack* pStack = new WWidgetStack(m_pParent, pNextControl, pPrevControl);
     pStack->setObjectName("WidgetStack");
     pStack->setContentsMargins(0, 0, 0, 0);
+    setupConnections(node, pStack);
     setupBaseWidget(node, pStack);
     setupWidget(node, pStack);
-    setupConnections(node, pStack);
+    pStack->Init();
+
 
     if (createdNext && pNextControl) {
         pNextControl->setParent(pStack);
@@ -661,6 +665,7 @@ QWidget* LegacySkinParser::parseStandardWidget(QDomElement element,
     pWidget->installEventFilter(m_pKeyboard);
     pWidget->installEventFilter(
             m_pControllerManager->getControllerLearningEventFilter());
+    pWidget->Init();
     return pWidget;
 }
 
@@ -678,12 +683,13 @@ void LegacySkinParser::setupLabelWidget(QDomElement element, WLabel* pLabel) {
     // set before the palette is set then the custom palette will not take
     // effect which breaks color scheme support.
     pLabel->setup(element, *m_pContext);
+    setupConnections(element, pLabel);
     setupBaseWidget(element, pLabel);
     setupWidget(element, pLabel);
-    setupConnections(element, pLabel);
     pLabel->installEventFilter(m_pKeyboard);
     pLabel->installEventFilter(
             m_pControllerManager->getControllerLearningEventFilter());
+    pLabel->Init();
 }
 
 QWidget* LegacySkinParser::parseOverview(QDomElement node) {
@@ -709,12 +715,13 @@ QWidget* LegacySkinParser::parseOverview(QDomElement node) {
     connect(overviewWidget, SIGNAL(trackDropped(QString, QString)),
             m_pPlayerManager, SLOT(slotLoadToPlayer(QString, QString)));
 
+    setupConnections(node, overviewWidget);
     setupBaseWidget(node, overviewWidget);
     setupWidget(node, overviewWidget);
     overviewWidget->setup(node, *m_pContext);
-    setupConnections(node, overviewWidget);
     overviewWidget->installEventFilter(m_pKeyboard);
     overviewWidget->installEventFilter(m_pControllerManager->getControllerLearningEventFilter());
+    overviewWidget->Init();
 
     // Connect the player's load and unload signals to the overview widget.
     connect(pPlayer, SIGNAL(loadTrack(TrackPointer)),
@@ -752,16 +759,16 @@ QWidget* LegacySkinParser::parseVisual(QDomElement node) {
     viewer->installEventFilter(m_pKeyboard);
     viewer->installEventFilter(m_pControllerManager->getControllerLearningEventFilter());
 
+    setupConnections(node, viewer);
     setupBaseWidget(node, viewer);
     setupWidget(node, viewer);
+    viewer->Init();
 
     // connect display with loading/unloading of tracks
     QObject::connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
                      viewer, SLOT(onTrackLoaded(TrackPointer)));
     QObject::connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
                      viewer, SLOT(onTrackUnloaded(TrackPointer)));
-
-    setupConnections(node, viewer);
 
     connect(viewer, SIGNAL(trackDropped(QString, QString)),
             m_pPlayerManager, SLOT(slotLoadToPlayer(QString, QString)));
@@ -871,6 +878,7 @@ QWidget* LegacySkinParser::parseSpinny(QDomElement node) {
         dummy->setText(tr("No OpenGL\nsupport."));
         return dummy;
     }
+    setupConnections(node, spinny);
     setupBaseWidget(node, spinny);
     setupWidget(node, spinny);
 
@@ -879,9 +887,9 @@ QWidget* LegacySkinParser::parseSpinny(QDomElement node) {
             m_pPlayerManager, SLOT(slotLoadToPlayer(QString, QString)));
 
     spinny->setup(node, *m_pContext, pSafeChannelStr);
-    setupConnections(node, spinny);
     spinny->installEventFilter(m_pKeyboard);
     spinny->installEventFilter(m_pControllerManager->getControllerLearningEventFilter());
+    spinny->Init();
     return spinny;
 }
 

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1457,7 +1457,6 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
     QDomNode con = m_pContext->selectNode(node, "Connection");
 
     ControlWidgetConnection* pLastLeftOrNoButtonConnection = NULL;
-    ControlWidgetConnection* pLastRightButtonConnection = NULL;
 
     while (!con.isNull()) {
         // Check that the control exists
@@ -1591,9 +1590,6 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
                 break;
             case Qt::RightButton:
                 pWidget->addRightConnection(pConnection);
-                if (directionOption & ControlWidgetConnection::DIR_TO_WIDGET) {
-                    pLastRightButtonConnection = pConnection;
-                }
                 break;
             default:
                 break;
@@ -1687,8 +1683,6 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
     // display connection.
     if (pLastLeftOrNoButtonConnection != NULL) {
         pWidget->setDisplayConnection(pLastLeftOrNoButtonConnection);
-    } else if (pLastRightButtonConnection != NULL) {
-        pWidget->setDisplayConnection(pLastRightButtonConnection);
     }
 }
 

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1456,7 +1456,7 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
     // For each connection
     QDomNode con = m_pContext->selectNode(node, "Connection");
 
-    ControlWidgetConnection* pLastLeftOrNoButtonConnection = NULL;
+    ControlParameterWidgetConnection* pLastLeftOrNoButtonConnection = NULL;
 
     while (!con.isNull()) {
         // Check that the control exists
@@ -1479,10 +1479,10 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
                     new ControlObjectSlave(control->getKey(),
                                            pWidget->toQWidget());
 
-            ControlWidgetConnection* pConnection =
+            ControlWidgetPropertyConnection* pConnection =
                     new ControlWidgetPropertyConnection(pWidget, pControlWidget,
                                                         pTransformer, property);
-            pWidget->addConnection(pConnection);
+            pWidget->addPropertyConnection(pConnection);
 
             // If we created this control, bind it to the
             // ControlWidgetConnection so that it is deleted when the connection
@@ -1502,13 +1502,13 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
             }
 
             bool directionOptionSet = false;
-            int directionOption = ControlWidgetConnection::DIR_FROM_AND_TO_WIDGET;
+            int directionOption = ControlParameterWidgetConnection::DIR_FROM_AND_TO_WIDGET;
             if(m_pContext->hasNodeSelectBool(
                     con, "ConnectValueFromWidget", &nodeValue)) {
                 if (nodeValue) {
-                    directionOption = directionOption | ControlWidgetConnection::DIR_FROM_WIDGET;
+                    directionOption = directionOption | ControlParameterWidgetConnection::DIR_FROM_WIDGET;
                 } else {
-                    directionOption = directionOption & ~ControlWidgetConnection::DIR_FROM_WIDGET;
+                    directionOption = directionOption & ~ControlParameterWidgetConnection::DIR_FROM_WIDGET;
                 }
                 directionOptionSet = true;
             }
@@ -1516,9 +1516,9 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
             if(m_pContext->hasNodeSelectBool(
                     con, "ConnectValueToWidget", &nodeValue)) {
                 if (nodeValue) {
-                    directionOption = directionOption | ControlWidgetConnection::DIR_TO_WIDGET;
+                    directionOption = directionOption | ControlParameterWidgetConnection::DIR_TO_WIDGET;
                 } else {
-                    directionOption = directionOption & ~ControlWidgetConnection::DIR_TO_WIDGET;
+                    directionOption = directionOption & ~ControlParameterWidgetConnection::DIR_TO_WIDGET;
                 }
                 directionOptionSet = true;
             }
@@ -1527,22 +1527,22 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
                 // default:
                 // no direction option is explicite set
                 // Set default flag to allow the widget to change this during setup
-                directionOption |= ControlWidgetConnection::DIR_DEFAULT;
+                directionOption |= ControlParameterWidgetConnection::DIR_DEFAULT;
             }
 
             int emitOption =
-                    ControlWidgetConnection::EMIT_ON_PRESS;
+                    ControlParameterWidgetConnection::EMIT_ON_PRESS;
             if(m_pContext->hasNodeSelectBool(
                     con, "EmitOnDownPress", &nodeValue)) {
                 if (nodeValue) {
-                    emitOption = ControlWidgetConnection::EMIT_ON_PRESS;
+                    emitOption = ControlParameterWidgetConnection::EMIT_ON_PRESS;
                 } else {
-                    emitOption = ControlWidgetConnection::EMIT_ON_RELEASE;
+                    emitOption = ControlParameterWidgetConnection::EMIT_ON_RELEASE;
                 }
             } else  if(m_pContext->hasNodeSelectBool(
                     con, "EmitOnPressAndRelease", &nodeValue)) {
                 if (nodeValue) {
-                    emitOption = ControlWidgetConnection::EMIT_ON_PRESS_AND_RELEASE;
+                    emitOption = ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE;
                 } else {
                     qWarning() << "LegacySkinParser::setupConnections(): EmitOnPressAndRelease must not set false";
                 }
@@ -1550,17 +1550,17 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
                 // default:
                 // no emit option is set
                 // Allow to change the emitOption from Widget
-                emitOption |= ControlWidgetConnection::EMIT_DEFAULT;
+                emitOption |= ControlParameterWidgetConnection::EMIT_DEFAULT;
             }
 
             // Connect control proxy to widget. Parented to pWidget so it is not
             // leaked.
             ControlObjectSlave* pControlWidget = new ControlObjectSlave(
                     control->getKey(), pWidget->toQWidget());
-            ControlWidgetConnection* pConnection = new ControlParameterWidgetConnection(
+            ControlParameterWidgetConnection* pConnection = new ControlParameterWidgetConnection(
                     pWidget, pControlWidget, pTransformer,
-                    static_cast<ControlWidgetConnection::DirectionOption>(directionOption),
-                    static_cast<ControlWidgetConnection::EmitOption>(emitOption));
+                    static_cast<ControlParameterWidgetConnection::DirectionOption>(directionOption),
+                    static_cast<ControlParameterWidgetConnection::EmitOption>(emitOption));
 
             // If we created this control, bind it to the
             // ControlWidgetConnection so that it is deleted when the connection
@@ -1572,13 +1572,13 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
             switch (state) {
             case Qt::NoButton:
                 pWidget->addConnection(pConnection);
-                if (directionOption & ControlWidgetConnection::DIR_TO_WIDGET) {
+                if (directionOption & ControlParameterWidgetConnection::DIR_TO_WIDGET) {
                     pLastLeftOrNoButtonConnection = pConnection;
                 }
                 break;
             case Qt::LeftButton:
                 pWidget->addLeftConnection(pConnection);
-                if (directionOption & ControlWidgetConnection::DIR_TO_WIDGET) {
+                if (directionOption & ControlParameterWidgetConnection::DIR_TO_WIDGET) {
                     pLastLeftOrNoButtonConnection = pConnection;
                 }
                 break;
@@ -1591,10 +1591,10 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
 
             // We only add info for controls that this widget affects, not
             // controls that only affect the widget.
-            if (directionOption & ControlWidgetConnection::DIR_FROM_WIDGET) {
+            if (directionOption & ControlParameterWidgetConnection::DIR_FROM_WIDGET) {
                 m_pControllerManager->getControllerLearningEventFilter()
                         ->addWidgetClickInfo(pWidget->toQWidget(), state, control,
-                                static_cast<ControlWidgetConnection::EmitOption>(emitOption));
+                                static_cast<ControlParameterWidgetConnection::EmitOption>(emitOption));
 
                 // Add keyboard shortcut info to tooltip string
                 QString key = m_pContext->selectString(con, "ConfigKey");

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -52,9 +52,7 @@ ControlParameterWidgetConnection::ControlParameterWidgetConnection(WBaseWidget* 
         : ControlWidgetConnection(pBaseWidget, pControl, pTransformer),
           m_directionOption(directionOption),
           m_emitOption(emitOption) {
-    if (directionOption & DIR_TO_WIDGET) {
-        slotControlValueChanged(m_pControl->get());
-    }
+    slotControlValueChanged(m_pControl->get());
 }
 
 ControlParameterWidgetConnection::~ControlParameterWidgetConnection() {
@@ -128,23 +126,4 @@ void ControlWidgetPropertyConnection::slotControlValueChanged(double v) {
         qDebug() << "Setting property" << m_propertyName
                  << "to widget failed. Value:" << dParameter;
     }
-}
-
-void ControlWidgetPropertyConnection::resetControl() {
-    // Do nothing.
-}
-
-void ControlWidgetPropertyConnection::setControlParameter(double v) {
-    // Do nothing.
-    Q_UNUSED(v);
-}
-
-void ControlWidgetPropertyConnection::setControlParameterDown(double v) {
-    // Do nothing.
-    Q_UNUSED(v);
-}
-
-void ControlWidgetPropertyConnection::setControlParameterUp(double v) {
-    // Do nothing.
-    Q_UNUSED(v);
 }

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -52,10 +52,13 @@ ControlParameterWidgetConnection::ControlParameterWidgetConnection(WBaseWidget* 
         : ControlWidgetConnection(pBaseWidget, pControl, pTransformer),
           m_directionOption(directionOption),
           m_emitOption(emitOption) {
-    slotControlValueChanged(m_pControl->get());
 }
 
 ControlParameterWidgetConnection::~ControlParameterWidgetConnection() {
+}
+
+void ControlParameterWidgetConnection::Init() {
+    slotControlValueChanged(m_pControl->get());
 }
 
 QString ControlParameterWidgetConnection::toDebugString() const {

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -59,7 +59,7 @@ ControlParameterWidgetConnection::~ControlParameterWidgetConnection() {
 }
 
 QString ControlParameterWidgetConnection::toDebugString() const {
-    const ConfigKey& key = m_pControl->getKey();
+    const ConfigKey& key = getKey();
     return QString("%1,%2 Parameter: %3 Direction: %4 Emit: %5")
             .arg(key.group, key.item,
                  QString::number(m_pControl->getParameter()),
@@ -80,21 +80,21 @@ void ControlParameterWidgetConnection::resetControl() {
     }
 }
 
-void ControlParameterWidgetConnection::setControlParameter(double v) {
+void ControlParameterWidgetConnection::setControlParameterFromWidget(double v) {
     if (m_directionOption & DIR_FROM_WIDGET) {
-        m_pControl->setParameter(v);
+        setControlParameter(v);
     }
 }
 
 void ControlParameterWidgetConnection::setControlParameterDown(double v) {
     if ((m_directionOption & DIR_FROM_WIDGET) && (m_emitOption & EMIT_ON_PRESS)) {
-        m_pControl->setParameter(v);
+        setControlParameter(v);
     }
 }
 
 void ControlParameterWidgetConnection::setControlParameterUp(double v) {
     if ((m_directionOption & DIR_FROM_WIDGET) && (m_emitOption & EMIT_ON_RELEASE)) {
-        m_pControl->setParameter(v);
+        setControlParameter(v);
     }
 }
 
@@ -111,7 +111,7 @@ ControlWidgetPropertyConnection::~ControlWidgetPropertyConnection() {
 }
 
 QString ControlWidgetPropertyConnection::toDebugString() const {
-    const ConfigKey& key = m_pControl->getKey();
+    const ConfigKey& key = getKey();
     return QString("%1,%2 Parameter: %3 Property: %4 Value: %5").arg(
         key.group, key.item, QString::number(m_pControl->getParameter()), m_propertyName,
         m_pWidget->toQWidget()->property(

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -83,21 +83,21 @@ void ControlParameterWidgetConnection::resetControl() {
     }
 }
 
-void ControlParameterWidgetConnection::setControlParameterFromWidget(double v) {
+void ControlParameterWidgetConnection::setControlParameter(double v) {
     if (m_directionOption & DIR_FROM_WIDGET) {
-        setControlParameter(v);
+        ControlWidgetConnection::setControlParameter(v);
     }
 }
 
 void ControlParameterWidgetConnection::setControlParameterDown(double v) {
     if ((m_directionOption & DIR_FROM_WIDGET) && (m_emitOption & EMIT_ON_PRESS)) {
-        setControlParameter(v);
+        ControlWidgetConnection::setControlParameter(v);
     }
 }
 
 void ControlParameterWidgetConnection::setControlParameterUp(double v) {
     if ((m_directionOption & DIR_FROM_WIDGET) && (m_emitOption & EMIT_ON_RELEASE)) {
-        setControlParameter(v);
+        ControlWidgetConnection::setControlParameter(v);
     }
 }
 

--- a/src/widget/controlwidgetconnection.h
+++ b/src/widget/controlwidgetconnection.h
@@ -36,6 +36,8 @@ class ControlWidgetConnection : public QObject {
   protected:
     WBaseWidget* m_pWidget;
     QScopedPointer<ControlObjectSlave> m_pControl;
+
+  private:
     QScopedPointer<ValueTransformer> m_pValueTransformer;
 };
 
@@ -104,12 +106,12 @@ class ControlParameterWidgetConnection : public ControlWidgetConnection {
     void setEmitOption(enum EmitOption v) { m_emitOption = v; };
 
     void resetControl();
-    void setControlParameter(double v);
+    void setControlParameterFromWidget(double v);
     void setControlParameterDown(double v);
     void setControlParameterUp(double v);
 
   private slots:
-    void slotControlValueChanged(double v);
+    virtual void slotControlValueChanged(double v);
 
   private:
     DirectionOption m_directionOption;
@@ -128,7 +130,7 @@ class ControlWidgetPropertyConnection : public ControlWidgetConnection {
     QString toDebugString() const;
 
   private slots:
-    void slotControlValueChanged(double v);
+    virtual void slotControlValueChanged(double v);
 
   private:
     QByteArray m_propertyName;

--- a/src/widget/controlwidgetconnection.h
+++ b/src/widget/controlwidgetconnection.h
@@ -97,6 +97,8 @@ class ControlParameterWidgetConnection : public ControlWidgetConnection {
                                      EmitOption emitOption);
     virtual ~ControlParameterWidgetConnection();
 
+    void Init();
+
     QString toDebugString() const;
 
     int getDirectionOption() const { return m_directionOption; };

--- a/src/widget/controlwidgetconnection.h
+++ b/src/widget/controlwidgetconnection.h
@@ -21,7 +21,6 @@ class ControlWidgetConnection : public QObject {
     virtual ~ControlWidgetConnection();
 
     double getControlParameter() const;
-    void setControlParameter(double v);
     double getControlParameterForValue(double value) const;
 
     const ConfigKey& getKey() const {
@@ -34,6 +33,8 @@ class ControlWidgetConnection : public QObject {
     virtual void slotControlValueChanged(double v) = 0;
 
   protected:
+    void setControlParameter(double v);
+
     WBaseWidget* m_pWidget;
     QScopedPointer<ControlObjectSlave> m_pControl;
 
@@ -108,7 +109,7 @@ class ControlParameterWidgetConnection : public ControlWidgetConnection {
     void setEmitOption(enum EmitOption v) { m_emitOption = v; };
 
     void resetControl();
-    void setControlParameterFromWidget(double v);
+    void setControlParameter(double v);
     void setControlParameterDown(double v);
     void setControlParameterUp(double v);
 

--- a/src/widget/controlwidgetconnection.h
+++ b/src/widget/controlwidgetconnection.h
@@ -6,7 +6,8 @@
 #include <QScopedPointer>
 #include <QByteArray>
 
-class ControlObjectSlave;
+#include "controlobjectslave.h"
+
 class WBaseWidget;
 class ValueTransformer;
 
@@ -17,11 +18,12 @@ class ControlWidgetConnection : public QObject {
         EMIT_NEVER                = 0x00,
         EMIT_ON_PRESS             = 0x01,
         EMIT_ON_RELEASE           = 0x02,
-        EMIT_ON_PRESS_AND_RELEASE = 0x03
+        EMIT_ON_PRESS_AND_RELEASE = 0x03,
+        EMIT_DEFAULT              = 0x04
     };
 
     static QString emitOptionToString(EmitOption option) {
-        switch (option) {
+        switch (option & EMIT_ON_PRESS_AND_RELEASE) {
             case EMIT_NEVER:
                 return "NEVER";
             case EMIT_ON_PRESS:
@@ -39,11 +41,12 @@ class ControlWidgetConnection : public QObject {
         DIR_NON                  = 0x00,
         DIR_FROM_WIDGET          = 0x01,
         DIR_TO_WIDGET            = 0x02,
-        DIR_FROM_AND_TO_WIDGET   = 0x03
+        DIR_FROM_AND_TO_WIDGET   = 0x03,
+        DIR_DEFAULT              = 0x04
     };
 
     static QString directionOptionToString(DirectionOption option) {
-        switch (option) {
+        switch (option & DIR_FROM_AND_TO_WIDGET) {
             case DIR_NON:
                 return "NON";
             case DIR_FROM_WIDGET:
@@ -66,6 +69,10 @@ class ControlWidgetConnection : public QObject {
     double getControlParameter() const;
     void setControlParameter(double v);
     double getControlParameterForValue(double value) const;
+
+    const ConfigKey& getKey() const {
+        return m_pControl->getKey();
+    }
 
     virtual void resetControl() = 0;
     virtual void setControlParameterDown(double v) = 0;

--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -30,7 +30,7 @@ class KnobEventHandler {
         }
 
         // For legacy (MIDI) reasons this is tuned to 127.
-        double value = pWidget->getControlParameterLeft() + dist / 127.0;
+        double value = pWidget->getControlParameter() + dist / 127.0;
 
         // Clamp to [0.0, 1.0]
         value = math_max(0.0, math_min(1.0, value));
@@ -42,7 +42,7 @@ class KnobEventHandler {
         if (!m_bRightButtonPressed) {
             QCursor::setPos(m_startPos);
             double value = valueFromMouseEvent(pWidget, e);
-            pWidget->setControlParameterLeftDown(value);
+            pWidget->setControlParameter(value);
             pWidget->update();
         }
     }
@@ -71,12 +71,11 @@ class KnobEventHandler {
                 QCursor::setPos(m_startPos);
                 QApplication::restoreOverrideCursor();
                 value = valueFromMouseEvent(pWidget, e);
-                pWidget->setControlParameterLeftUp(value);
+                pWidget->setControlParameter(value);
                 pWidget->update();
                 break;
             case Qt::RightButton:
                 m_bRightButtonPressed = false;
-                //pWidget->setControlParameterRightUp(pWidget->getValue());
                 break;
             default:
                 break;

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -98,24 +98,12 @@ void WBaseWidget::setControlParameter(double v) {
 }
 
 void WBaseWidget::setControlParameterUp(double v) {
-    foreach (ControlParameterWidgetConnection* pControlConnection, m_leftConnections) {
-        pControlConnection->setControlParameterUp(v);
-    }
-    foreach (ControlParameterWidgetConnection* pControlConnection, m_rightConnections) {
-        pControlConnection->setControlParameterUp(v);
-    }
     foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
         pControlConnection->setControlParameterUp(v);
     }
 }
 
 void WBaseWidget::setControlParameterDown(double v) {
-    foreach (ControlParameterWidgetConnection* pControlConnection, m_leftConnections) {
-        pControlConnection->setControlParameterDown(v);
-    }
-    foreach (ControlParameterWidgetConnection* pControlConnection, m_rightConnections) {
-        pControlConnection->setControlParameterDown(v);
-    }
     foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
         pControlConnection->setControlParameterDown(v);
     }

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -27,6 +27,12 @@ WBaseWidget::~WBaseWidget() {
     }
 }
 
+void WBaseWidget::Init() {
+    if (m_pDisplayConnection) {
+        m_pDisplayConnection->Init();
+    }
+}
+
 void WBaseWidget::setDisplayConnection(ControlParameterWidgetConnection* pConnection) {
     //qDebug() << "WBaseWidget::setDisplayConnection()" << pConnection->toDebugString();
     m_pDisplayConnection = pConnection;

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -22,23 +22,30 @@ WBaseWidget::~WBaseWidget() {
     while (!m_connections.isEmpty()) {
         delete m_connections.takeLast();
     }
+    while (!m_propertyConnections.isEmpty()) {
+        delete m_propertyConnections.takeLast();
+    }
 }
 
-void WBaseWidget::setDisplayConnection(ControlWidgetConnection* pConnection) {
+void WBaseWidget::setDisplayConnection(ControlParameterWidgetConnection* pConnection) {
     //qDebug() << "WBaseWidget::setDisplayConnection()" << pConnection->toDebugString();
     m_pDisplayConnection = pConnection;
 }
 
-void WBaseWidget::addConnection(ControlWidgetConnection* pConnection) {
+void WBaseWidget::addConnection(ControlParameterWidgetConnection* pConnection) {
     m_connections.append(pConnection);
 }
 
-void WBaseWidget::addLeftConnection(ControlWidgetConnection* pConnection) {
+void WBaseWidget::addLeftConnection(ControlParameterWidgetConnection* pConnection) {
     m_leftConnections.append(pConnection);
 }
 
-void WBaseWidget::addRightConnection(ControlWidgetConnection* pConnection) {
+void WBaseWidget::addRightConnection(ControlParameterWidgetConnection* pConnection) {
     m_rightConnections.append(pConnection);
+}
+
+void WBaseWidget::addPropertyConnection(ControlWidgetPropertyConnection* pConnection) {
+    m_propertyConnections.append(pConnection);
 }
 
 double WBaseWidget::getControlParameter() const {
@@ -73,24 +80,24 @@ double WBaseWidget::getControlParameterDisplay() const {
 }
 
 void WBaseWidget::resetControlParameter() {
-    foreach (ControlWidgetConnection* pControlConnection, m_connections) {
+    foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
         pControlConnection->resetControl();
     }
 }
 
 void WBaseWidget::setControlParameter(double v) {
-    foreach (ControlWidgetConnection* pControlConnection, m_connections) {
+    foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
         pControlConnection->setControlParameter(v);
     }
 }
 
 void WBaseWidget::setControlParameterLeftDown(double v) {
     if (!m_leftConnections.isEmpty()) {
-        foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
+        foreach (ControlParameterWidgetConnection* pControlConnection, m_leftConnections) {
             pControlConnection->setControlParameterDown(v);
         }
     } else {
-        foreach (ControlWidgetConnection* pControlConnection, m_connections) {
+        foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
             pControlConnection->setControlParameterDown(v);
         }
     }
@@ -98,24 +105,24 @@ void WBaseWidget::setControlParameterLeftDown(double v) {
 
 void WBaseWidget::setControlParameterLeftUp(double v) {
     if (!m_leftConnections.isEmpty()) {
-        foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
+        foreach (ControlParameterWidgetConnection* pControlConnection, m_leftConnections) {
             pControlConnection->setControlParameterUp(v);
         }
     } else {
-        foreach (ControlWidgetConnection* pControlConnection, m_connections) {
+        foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
             pControlConnection->setControlParameterUp(v);
         }
     }
 }
 
 void WBaseWidget::setControlParameterRightDown(double v) {
-    foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
+    foreach (ControlParameterWidgetConnection* pControlConnection, m_rightConnections) {
         pControlConnection->setControlParameterDown(v);
     }
 }
 
 void WBaseWidget::setControlParameterRightUp(double v) {
-    foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
+    foreach (ControlParameterWidgetConnection* pControlConnection, m_rightConnections) {
         pControlConnection->setControlParameterUp(v);
     }
 }

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -7,8 +7,8 @@
 #include "util/debug.h"
 
 WBaseWidget::WBaseWidget(QWidget* pWidget)
-        : m_pWidget(pWidget),
-          m_pDisplayConnection(NULL) {
+        : m_pDisplayConnection(NULL),
+          m_pWidget(pWidget) {
 }
 
 WBaseWidget::~WBaseWidget() {

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -87,7 +87,7 @@ void WBaseWidget::resetControlParameter() {
 
 void WBaseWidget::setControlParameter(double v) {
     foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
-        pControlConnection->setControlParameter(v);
+        pControlConnection->setControlParameterFromWidget(v);
     }
 }
 

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -93,7 +93,7 @@ void WBaseWidget::resetControlParameter() {
 
 void WBaseWidget::setControlParameter(double v) {
     foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
-        pControlConnection->setControlParameterFromWidget(v);
+        pControlConnection->setControlParameter(v);
     }
 }
 

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -42,12 +42,6 @@ void WBaseWidget::addRightConnection(ControlWidgetConnection* pConnection) {
 }
 
 double WBaseWidget::getControlParameter() const {
-    if (!m_leftConnections.isEmpty()) {
-        return m_leftConnections.at(0)->getControlParameter();
-    }
-    if (!m_rightConnections.isEmpty()) {
-        return m_rightConnections.at(0)->getControlParameter();
-    }
     if (!m_connections.isEmpty()) {
         return m_connections.at(0)->getControlParameter();
     }
@@ -67,9 +61,6 @@ double WBaseWidget::getControlParameterLeft() const {
 double WBaseWidget::getControlParameterRight() const {
     if (!m_rightConnections.isEmpty()) {
         return m_rightConnections.at(0)->getControlParameter();
-    }
-    if (!m_connections.isEmpty()) {
-        return m_connections.at(0)->getControlParameter();
     }
     return 0.0;
 }
@@ -94,20 +85,26 @@ void WBaseWidget::setControlParameter(double v) {
 }
 
 void WBaseWidget::setControlParameterLeftDown(double v) {
-    foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
-        pControlConnection->setControlParameterDown(v);
-    }
-    foreach (ControlWidgetConnection* pControlConnection, m_connections) {
-        pControlConnection->setControlParameterDown(v);
+    if (!m_leftConnections.isEmpty()) {
+        foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
+            pControlConnection->setControlParameterDown(v);
+        }
+    } else {
+        foreach (ControlWidgetConnection* pControlConnection, m_connections) {
+            pControlConnection->setControlParameterDown(v);
+        }
     }
 }
 
 void WBaseWidget::setControlParameterLeftUp(double v) {
-    foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
-        pControlConnection->setControlParameterUp(v);
-    }
-    foreach (ControlWidgetConnection* pControlConnection, m_connections) {
-        pControlConnection->setControlParameterUp(v);
+    if (!m_leftConnections.isEmpty()) {
+        foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
+            pControlConnection->setControlParameterUp(v);
+        }
+    } else {
+        foreach (ControlWidgetConnection* pControlConnection, m_connections) {
+            pControlConnection->setControlParameterUp(v);
+        }
     }
 }
 
@@ -115,16 +112,10 @@ void WBaseWidget::setControlParameterRightDown(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
         pControlConnection->setControlParameterDown(v);
     }
-    foreach (ControlWidgetConnection* pControlConnection, m_connections) {
-        pControlConnection->setControlParameterDown(v);
-    }
 }
 
 void WBaseWidget::setControlParameterRightUp(double v) {
     foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
-        pControlConnection->setControlParameterUp(v);
-    }
-    foreach (ControlWidgetConnection* pControlConnection, m_connections) {
         pControlConnection->setControlParameterUp(v);
     }
 }

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -58,13 +58,15 @@ class WBaseWidget {
     void updateTooltip();
     virtual void fillDebugTooltip(QStringList* debug);
 
-  private:
-    QWidget* m_pWidget;
-    QString m_baseTooltip;
+  protected:
     QList<ControlWidgetConnection*> m_connections;
     ControlWidgetConnection* m_pDisplayConnection;
     QList<ControlWidgetConnection*> m_leftConnections;
     QList<ControlWidgetConnection*> m_rightConnections;
+
+  private:
+    QWidget* m_pWidget;
+    QString m_baseTooltip;
 
     friend class ControlParameterWidgetConnection;
 };

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -44,11 +44,6 @@ class WBaseWidget {
     double getControlParameterRight() const;
     double getControlParameterDisplay() const;
 
-    virtual ControlWidgetConnection::EmitOption getDefaultEmitOption(
-        Qt::MouseButton state);
-    virtual ControlWidgetConnection::DirectionOption getDefaultDirectionOption(
-        Qt::MouseButton state);
-
   protected:
     virtual void onConnectedControlValueChanged(double v) {
         Q_UNUSED(v);

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -5,7 +5,8 @@
 #include <QWidget>
 #include <QList>
 
-class ControlWidgetConnection;
+class ControlWidgetPropertyConnection;
+class ControlParameterWidgetConnection;
 
 class WBaseWidget {
   public:
@@ -25,14 +26,16 @@ class WBaseWidget {
         return m_baseTooltip;
     }
 
-    void addLeftConnection(ControlWidgetConnection* pConnection);
-    void addRightConnection(ControlWidgetConnection* pConnection);
-    void addConnection(ControlWidgetConnection* pConnection);
+    void addLeftConnection(ControlParameterWidgetConnection* pConnection);
+    void addRightConnection(ControlParameterWidgetConnection* pConnection);
+    void addConnection(ControlParameterWidgetConnection* pConnection);
+
+    void addPropertyConnection(ControlWidgetPropertyConnection* pConnection);
 
     // Set a ControlWidgetConnection to be the display connection for the
     // widget. The connection should also be added via an addConnection method
     // or it will not be deleted or receive updates.
-    void setDisplayConnection(ControlWidgetConnection* pConnection);
+    void setDisplayConnection(ControlParameterWidgetConnection* pConnection);
 
     double getControlParameter() const;
     double getControlParameterLeft() const;
@@ -59,10 +62,12 @@ class WBaseWidget {
     virtual void fillDebugTooltip(QStringList* debug);
 
   protected:
-    QList<ControlWidgetConnection*> m_connections;
-    ControlWidgetConnection* m_pDisplayConnection;
-    QList<ControlWidgetConnection*> m_leftConnections;
-    QList<ControlWidgetConnection*> m_rightConnections;
+    QList<ControlParameterWidgetConnection*> m_connections;
+    ControlParameterWidgetConnection* m_pDisplayConnection;
+    QList<ControlParameterWidgetConnection*> m_leftConnections;
+    QList<ControlParameterWidgetConnection*> m_rightConnections;
+
+    QList<ControlWidgetPropertyConnection*> m_propertyConnections;
 
   private:
     QWidget* m_pWidget;

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -13,6 +13,8 @@ class WBaseWidget {
     WBaseWidget(QWidget* pWidget);
     virtual ~WBaseWidget();
 
+    void Init();
+
     QWidget* toQWidget() {
         return m_pWidget;
     }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -24,6 +24,7 @@
 #include "controlobjectthread.h"
 #include "woverview.h"
 #include "wskincolor.h"
+#include "widget/controlwidgetconnection.h"
 #include "trackinfoobject.h"
 #include "mathstuff.h"
 #include "util/timer.h"
@@ -119,6 +120,16 @@ void WOverview::setup(QDomNode node, const SkinContext& context) {
 
     //qDebug() << "WOverview : m_marks" << m_marks.size();
     //qDebug() << "WOverview : m_markRanges" << m_markRanges.size();
+
+    ControlParameterWidgetConnection* defaultConnection = m_connections.at(0);
+    if (defaultConnection) {
+        if (defaultConnection->getEmitOption() &
+                ControlParameterWidgetConnection::EMIT_DEFAULT) {
+            // ON_PRESS means here value change on mouse move during press
+            defaultConnection->setEmitOption(
+                    ControlParameterWidgetConnection::EMIT_ON_RELEASE);
+        }
+    }
 }
 
 void WOverview::onConnectedControlValueChanged(double dValue) {
@@ -250,11 +261,7 @@ void WOverview::mouseReleaseEvent(QMouseEvent* e) {
     double dValue = positionToValue(m_iPos);
     //qDebug() << "WOverview::mouseReleaseEvent" << e->pos() << m_iPos << ">>" << dValue;
 
-    if (e->button() == Qt::RightButton) {
-        setControlParameterRightUp(dValue);
-    } else {
-        setControlParameterLeftUp(dValue);
-    }
+    setControlParameterUp(dValue);
     m_bDrag = false;
 }
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -120,14 +120,15 @@ void WOverview::setup(QDomNode node, const SkinContext& context) {
 
     //qDebug() << "WOverview : m_marks" << m_marks.size();
     //qDebug() << "WOverview : m_markRanges" << m_markRanges.size();
-
-    ControlParameterWidgetConnection* defaultConnection = m_connections.at(0);
-    if (defaultConnection) {
-        if (defaultConnection->getEmitOption() &
-                ControlParameterWidgetConnection::EMIT_DEFAULT) {
-            // ON_PRESS means here value change on mouse move during press
-            defaultConnection->setEmitOption(
-                    ControlParameterWidgetConnection::EMIT_ON_RELEASE);
+    if (!m_connections.isEmpty()) {
+        ControlParameterWidgetConnection* defaultConnection = m_connections.at(0);
+        if (defaultConnection) {
+            if (defaultConnection->getEmitOption() &
+                    ControlParameterWidgetConnection::EMIT_DEFAULT) {
+                // ON_PRESS means here value change on mouse move during press
+                defaultConnection->setEmitOption(
+                        ControlParameterWidgetConnection::EMIT_ON_RELEASE);
+            }
         }
     }
 }

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -95,7 +95,7 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
         bool leftClickForcePush = context.selectBool(node, "LeftClickIsPushButton", false);
         m_leftButtonMode = ControlPushButton::PUSH;
         if (!leftClickForcePush) {
-            const ConfigKey configKey = leftConnection->getKey();
+            const ConfigKey& configKey = leftConnection->getKey();
             ControlPushButton* p = dynamic_cast<ControlPushButton*>(
                     ControlObject::getControl(configKey));
             if (p) {

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -54,11 +54,6 @@ class WPushButton : public WWidget {
     // associated pixmaps.
     void setStates(int iStatesW);
 
-    ControlWidgetConnection::EmitOption
-            getDefaultEmitOption(Qt::MouseButton state);
-    ControlWidgetConnection::DirectionOption
-            getDefaultDirectionOption(Qt::MouseButton state);
-
   public slots:
     void onConnectedControlValueChanged(double);
 
@@ -92,7 +87,6 @@ class WPushButton : public WWidget {
     // short click toggle button long click push button
     ControlPushButton::ButtonMode m_leftButtonMode;
     ControlPushButton::ButtonMode m_rightButtonMode;
-    bool m_hasDisplayConnection;
     QTimer m_clickTimer;
 };
 

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -63,14 +63,15 @@ void WSliderComposed::setup(QDomNode node, const SkinContext& context) {
             m_bEventWhileDrag = false;
         }
     }
-
-    ControlParameterWidgetConnection* defaultConnection = m_connections.at(0);
-    if (defaultConnection) {
-        if (defaultConnection->getEmitOption() &
-                ControlParameterWidgetConnection::EMIT_DEFAULT) {
-            // ON_PRESS means here value change on mouse move during press
-            defaultConnection->setEmitOption(
-                    ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE);
+    if (!m_connections.isEmpty()) {
+        ControlParameterWidgetConnection* defaultConnection = m_connections.at(0);
+        if (defaultConnection) {
+            if (defaultConnection->getEmitOption() &
+                    ControlParameterWidgetConnection::EMIT_DEFAULT) {
+                // ON_PRESS means here value change on mouse move during press
+                defaultConnection->setEmitOption(
+                        ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE);
+            }
         }
     }
 }

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -27,7 +27,7 @@
 
 WSliderComposed::WSliderComposed(QWidget * parent)
     : WWidget(parent),
-      m_dOldValue(0.0),
+      m_dOldValue(-1.0), // virgin
       m_bRightButtonPressed(false),
       m_iPos(0),
       m_iStartHandlePos(0),

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -83,7 +83,7 @@ void WSliderComposed::setHandlePixmap(bool bHorizontal, const QString& filenameH
         m_iHandleLength = m_bHorizontal ?
                 m_pHandle->width() : m_pHandle->height();
 
-        onConnectedControlValueChanged(getControlParameterLeft());
+        onConnectedControlValueChanged(getControlParameter());
         update();
     }
 }

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -23,6 +23,7 @@
 
 #include "defs.h"
 #include "widget/wpixmapstore.h"
+#include "widget/controlwidgetconnection.h"
 #include "util/debug.h"
 
 WSliderComposed::WSliderComposed(QWidget * parent)
@@ -60,6 +61,16 @@ void WSliderComposed::setup(QDomNode node, const SkinContext& context) {
     if (context.hasNode(node, "EventWhileDrag")) {
         if (context.selectString(node, "EventWhileDrag").contains("no")) {
             m_bEventWhileDrag = false;
+        }
+    }
+
+    ControlParameterWidgetConnection* defaultConnection = m_connections.at(0);
+    if (defaultConnection) {
+        if (defaultConnection->getEmitOption() &
+                ControlParameterWidgetConnection::EMIT_DEFAULT) {
+            // ON_PRESS means here value change on mouse move during press
+            defaultConnection->setEmitOption(
+                    ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE);
         }
     }
 }

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -151,7 +151,7 @@ void WSliderComposed::mouseMoveEvent(QMouseEvent * e) {
 void WSliderComposed::wheelEvent(QWheelEvent *e) {
     // For legacy (MIDI) reasons this is tuned to 127.
     double wheelDirection = ((QWheelEvent *)e)->delta() / (120.0 * 127.0);
-    double newValue = getControlParameter() + wheelDirection;
+    double newValue = m_dOldValue + wheelDirection;
 
     // Clamp to [0.0, 1.0]
     newValue = math_max(0.0, math_min(1.0, newValue));

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -140,7 +140,7 @@ void WSliderComposed::mouseMoveEvent(QMouseEvent * e) {
 
         // Emit valueChanged signal
         if (m_bEventWhileDrag) {
-            setControlParameterUp(newValue);
+            setControlParameterDown(newValue);
         }
 
         // Update display
@@ -156,7 +156,7 @@ void WSliderComposed::wheelEvent(QWheelEvent *e) {
     // Clamp to [0.0, 1.0]
     newValue = math_max(0.0, math_min(1.0, newValue));
 
-    setControlParameter(newValue);
+    setControlParameterDown(newValue);
     onConnectedControlValueChanged(newValue);
     update();
 
@@ -172,6 +172,8 @@ void WSliderComposed::mouseReleaseEvent(QMouseEvent * e) {
     }
     if (e->button() == Qt::RightButton) {
         m_bRightButtonPressed = false;
+    } else {
+        setControlParameterUp(m_dOldValue);
     }
 }
 

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -157,7 +157,7 @@ void WSliderComposed::wheelEvent(QWheelEvent *e) {
     // Clamp to [0.0, 1.0]
     newValue = math_max(0.0, math_min(1.0, newValue));
 
-    setControlParameterDown(newValue);
+    setControlParameter(newValue);
     onConnectedControlValueChanged(newValue);
     update();
 


### PR DESCRIPTION
In this PR, I have moved the connection setup in front of the widget setup. This way, the widget has all Information in its connection, to pick suitable defaults. 
I have introduced a 0x4 *_DEFAULT flag, to indicate, that there are no user connection options set.
To reduce the complexity, I have removed the option to set a right button connection as display connection. The same function can achieved, by setting the "right button control" as no-button connection.

Now the no-button connection defaults to the left button connection, only if no button connection options are set. This way the skin designer has more control over what is emitted when. Here are the resulting Rules:
- A no-button connection defaults to the left-button AND display connection 
- A left-button connection is also the display connection if not explicit disabled 
- If there is a left button connection and a no-button connection, the no-button connection becomes the display connection 
- A right-button connection defaults to a "from widget" connection only 

Only the fist connected control is considered by the widget for e.g. toggle. So only this one receives the calculated defaults. Additional COs connected to the same widget function have to be set up manually.   

I have removed the right/Left nature from the sliders and knops. Currently there are no alternative features implemented. This give us the freedom, to fix the touch issues an possible implement a well thought alternative function later. 

It was also required to separate the property connection from the parameter connection. 
The list of property connection is intended to connect COs to different widget properties, while the list  parameter connections are allays connection to the same widget function. So it is better to have them separate anyway.    
