### PR TITLE
Phantom column in library table ---(Bug #1258776) fixed

### DIFF
--- a/src/library/baseexternalplaylistmodel.cpp
+++ b/src/library/baseexternalplaylistmodel.cpp
@@ -77,7 +77,6 @@ TrackPointer BaseExternalPlaylistModel::getTrack(const QModelIndex& index) const
 
 bool BaseExternalPlaylistModel::isColumnInternal(int column) {
     if (column == fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_TRACKID) ||
-            column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID)||
             (PlayerManager::numPreviewDecks() == 0 &&
              column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW))) {
         return true;

--- a/src/library/baseexternalplaylistmodel.cpp
+++ b/src/library/baseexternalplaylistmodel.cpp
@@ -77,6 +77,7 @@ TrackPointer BaseExternalPlaylistModel::getTrack(const QModelIndex& index) const
 
 bool BaseExternalPlaylistModel::isColumnInternal(int column) {
     if (column == fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_TRACKID) ||
+            column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID)||
             (PlayerManager::numPreviewDecks() == 0 &&
              column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW))) {
         return true;

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -68,8 +68,7 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
 bool BaseExternalTrackModel::isColumnInternal(int column) {
     // Used for preview deck widgets.
     if (column == fieldIndex(LIBRARYTABLE_ID) ||
-            column==fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID)||
-            (PlayerManager::numPreviewDecks() == 0 &&
+           (PlayerManager::numPreviewDecks() == 0 &&
              column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW))) {
         return true;
     }

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -68,6 +68,7 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
 bool BaseExternalTrackModel::isColumnInternal(int column) {
     // Used for preview deck widgets.
     if (column == fieldIndex(LIBRARYTABLE_ID) ||
+            column==fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID)||
             (PlayerManager::numPreviewDecks() == 0 &&
              column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW))) {
         return true;

--- a/src/library/cratetablemodel.cpp
+++ b/src/library/cratetablemodel.cpp
@@ -135,6 +135,7 @@ bool CrateTableModel::isColumnInternal(int column) {
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PLAYED) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_MIXXXDELETED) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK) ||
+            column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID)||
             column == fieldIndex(ColumnCache::COLUMN_TRACKLOCATIONSTABLE_FSDELETED) ||
             (PlayerManager::numPreviewDecks() == 0 &&
              column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW))) {

--- a/src/library/hiddentablemodel.cpp
+++ b/src/library/hiddentablemodel.cpp
@@ -76,6 +76,7 @@ bool HiddenTableModel::isColumnInternal(int column) {
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PLAYED) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_MIXXXDELETED) ||
+            column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID)||
             column == fieldIndex(ColumnCache::COLUMN_TRACKLOCATIONSTABLE_FSDELETED)) {
         return true;
     }

--- a/src/library/librarytablemodel.cpp
+++ b/src/library/librarytablemodel.cpp
@@ -66,6 +66,7 @@ bool LibraryTableModel::isColumnInternal(int column) {
             (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_MIXXXDELETED)) ||
             (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_HEADERPARSED)) ||
             (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PLAYED)) ||
+            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID))||
             (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK)) ||
             (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_CHANNELS)) ||
             (column == fieldIndex(ColumnCache::COLUMN_TRACKLOCATIONSTABLE_FSDELETED)) ||

--- a/src/library/missingtablemodel.cpp
+++ b/src/library/missingtablemodel.cpp
@@ -72,6 +72,7 @@ bool MissingTableModel::isColumnInternal(int column) {
     if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ID) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PLAYED) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK) ||
+            column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID)||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_MIXXXDELETED) ||
             column == fieldIndex(ColumnCache::COLUMN_TRACKLOCATIONSTABLE_FSDELETED)) {
         return true;

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -195,6 +195,7 @@ bool PlaylistTableModel::isColumnInternal(int column) {
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PLAYED) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_MIXXXDELETED) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK) ||
+            column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID)||
             column == fieldIndex(ColumnCache::COLUMN_TRACKLOCATIONSTABLE_FSDELETED) ||
             (PlayerManager::numPreviewDecks() == 0 &&
              column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW))) {


### PR DESCRIPTION
Bug #1258776 
there is a ambiguous column in library table(actually almost in all table)  in latest git master. which is of "KEY_ID" column. which is not supposed to be there though it is needed for "KEY" column.  
Now i have made this column internal by changing isColumnInternal() function in following files.

 src/library/baseexternalplaylistmodel.cpp
 src/library/baseexternaltrackmodel.cpp
 src/library/cratetablemodel.cpp
 src/library/hiddentablemodel.cpp
 src/library/librarytablemodel.cpp
 src/library/missingtablemodel.cpp
 src/library/playlisttablemodel.cpp 

and Now no more "KEY_ID" column in Tables.
i have added the resulting screen shot.  
![bugfix](https://f.cloud.github.com/assets/5162252/2301142/cacb2842-a128-11e3-985d-87e8778b6b47.png)
