### PR TITLE
Applied patch to allow passing stdlib scons flag

### DIFF
--- a/build/mixxx.py
+++ b/build/mixxx.py
@@ -261,8 +261,26 @@ class MixxxBuild(object):
             print 'Automatically detecting Mac OS X SDK.'
 
             # SDK versions in order of precedence.
-            sdk_versions = ['10.9', '10.8', '10.7', '10.6', '10.5']
-            min_sdk_version = '10.5'
+            sdk_versions = ( '10.9', '10.8', '10.7', '10.6', '10.5', )
+            clang_sdk_versions = ( '10.9', '10.8', '10.7', )
+            valid_cpp_lib_versions = ( 'libstdc++', 'libc++', )
+
+            # By default use old gcc C++ library version
+            osx_stdlib = Script.ARGUMENTS.get('stdlib', 'libstdc++')
+            if osx_stdlib not in valid_cpp_lib_versions:
+                raise Exception('Unsupportd C++ stdlib version')
+
+            if osx_stdlib == 'libc++':
+                sdk_version_default = '10.9'
+            else:
+                sdk_version_default = '10.5'
+
+            min_sdk_version = Script.ARGUMENTS.get('macosx-version-min', sdk_version_default)
+            if min_sdk_version not in sdk_versions:
+                raise Exception('Unsupported macosx-version-min value')
+
+            if osx_stdlib == 'libc++' and min_sdk_version not in clang_sdk_versions:
+                raise Exception('stdlib=libc++ requires macosx-version-min > 10.7')
 
             print "XCode developer directory:", os.popen('xcode-select -p').readline().strip()
             for sdk in sdk_versions:
@@ -271,17 +289,12 @@ class MixxxBuild(object):
                 if sdk_path:
                     print "Automatically selected OS X SDK:", sdk_path
 
-                    # NOTE(rryan): A quick note about mmacosx-version-min. With
-                    # the OS X 10.9 SDK Clang changed the standard library from
-                    # libstdc++ to libc++. If you set -mmacosx-version-min=<10.9
-                    # then this uses libstdc++. libstdc++ and libc++ are not
-                    # binary compatible so if you want to build Mixxx with
-                    # libc++ then all dependencies have to be built with
-                    # libc++.
-
                     common_flags = ['-isysroot', sdk_path,
                                     '-mmacosx-version-min=%s' % min_sdk_version]
-                    link_flags = ['-Wl,-syslibroot,' + sdk_path]
+                    link_flags = [
+                        '-Wl,-syslibroot,' + sdk_path,
+                        '-stdlib=%s' % osx_stdlib
+                    ]
                     self.env.Append(CCFLAGS=common_flags)
                     self.env.Append(LINKFLAGS=common_flags + link_flags)
                     return

--- a/src/util/threadcputimer.cpp
+++ b/src/util/threadcputimer.cpp
@@ -18,82 +18,9 @@
 #include <windows.h>
 #endif
 
-// mac/unix code heavily copied from QElapsedTimer
-
-
-////////////////////////////// Mac //////////////////////////////
-#if defined(Q_OS_MAC)
-
-static mach_timebase_info_data_t info = {0,0};
-static qint64 absoluteToNSecs(qint64 cpuTime)
-{
-    if (info.denom == 0)
-        mach_timebase_info(&info);
-    qint64 nsecs = cpuTime * info.numer / info.denom;
-    return nsecs;
-}
-
-void PerformanceTimer::start()
-{
-    t1 = mach_absolute_time();
-}
-
-qint64 PerformanceTimer::elapsed() const
-{
-    uint64_t cpu_time = mach_absolute_time();
-    return absoluteToNSecs(cpu_time - t1);
-}
-
-qint64 PerformanceTimer::restart()
-{
-    qint64 start;
-    start = t1;
-    t1 = mach_absolute_time();
-    return absoluteToNSecs(t1-start);
-}
-
-qint64 PerformanceTimer::difference(PerformanceTimer* timer)
-{
-    return absoluteToNSecs(t1 - timer->t1);
-}
-
-////////////////////////////// Symbian //////////////////////////////
-#elif defined(Q_OS_SYMBIAN)
-
-static qint64 getTimeFromTick(quint64 elapsed)
-{
-    static TInt freq = 0;
-    if (!freq)
-        HAL::Get(HALData::EFastCounterFrequency, freq);
-
-    return (elapsed * 1000000000) / freq;
-}
-
-void PerformanceTimer::start()
-{
-    t1 = User::FastCounter();
-}
-
-qint64 PerformanceTimer::elapsed() const
-{
-    return getTimeFromTick(User::FastCounter() - t1);
-}
-
-qint64 PerformanceTimer::restart()
-{
-    qint64 start;
-    start = t1;
-    t1 = User::FastCounter();
-    return getTimeFromTick(t1 - start);
-}
-
-qint64 PerformanceTimer::difference(PerformanceTimer* timer)
-{
-    return getTimeFromTick(t1 - timer->t1);
-}
 
 ////////////////////////////// Unix //////////////////////////////
-#elif defined(Q_OS_UNIX)
+#if defined(Q_OS_UNIX)
 
 #if (_POSIX_THREAD_CPUTIME-0 != 0)
 static const bool threadCpuTimeChecked = true;
@@ -169,60 +96,25 @@ qint64 ThreadCpuTimer::restart()
     return sec * Q_INT64_C(1000000000) + frac;
 }
 
-////////////////////////////// Windows //////////////////////////////
-#elif defined(Q_OS_WIN)
-
-static qint64 getTimeFromTick(quint64 elapsed)
-{
-    static LARGE_INTEGER freq = {{ 0, 0 }};
-    if (!freq.QuadPart)
-        QueryPerformanceFrequency(&freq);
-    return 1000000000 * elapsed / freq.QuadPart;
-}
-
-void PerformanceTimer::start()
-{
-    LARGE_INTEGER li;
-    QueryPerformanceCounter(&li);
-    t1 = li.QuadPart;
-}
-
-qint64 PerformanceTimer::elapsed() const
-{
-    LARGE_INTEGER li;
-    QueryPerformanceCounter(&li);
-    return getTimeFromTick(li.QuadPart - t1);
-}
-
-qint64 PerformanceTimer::restart()
-{
-    LARGE_INTEGER li;
-    qint64 start;
-    start = t1;
-    QueryPerformanceCounter(&li);
-    t1 = li.QuadPart;
-    return getTimeFromTick(t1 - start);
-}
-
 ////////////////////////////// Default //////////////////////////////
 #else
 
 // default implementation (no hi-perf timer) does nothing
-void PerformanceTimer::start()
+void ThreadCpuTimer::start()
 {
 }
 
-qint64 PerformanceTimer::elapsed() const
-{
-    return 0;
-}
-
-qint64 PerformanceTimer::restart() const
+qint64 ThreadCpuTimer::elapsed() const
 {
     return 0;
 }
 
-qint64 PerformanceTimer::difference(PerformanceTimer* timer)
+qint64 ThreadCpuTimer::restart() const
+{
+    return 0;
+}
+
+qint64 ThreadCpuTimer::difference(ThreadCpuTimer* timer)
 {
     return 0;
 }

--- a/src/util/threadcputimer.h
+++ b/src/util/threadcputimer.h
@@ -14,4 +14,4 @@ private:
     qint64 t2;
 };
 
-#endif // PERFORMANCETIMER_H
+#endif // THREADCPUTIMER_H


### PR DESCRIPTION
This patch allows two new scons flags, with which you can compile for various of OS X build targets and C++ library versions.

On a OS X Mavericks 10.9 with freshly compiled homebrew libraries, you should now run with:

export QTDIR=/usr/local/Cellar/qt/HEAD
scons stdlib=libc++ verbose=1

This sets QTDIR explicitly to homebrew's Qt4 port (until QtTouchEvent issues are fixed for Qt5) and uses clang libc++ when linking: all current homebrew packages are linked with libc++ not libstdc++.

Please note that testing this on master right now fails, because of two linux specific commits which break compile on OS/X: I tested compile with 699232d578b170d92f21fb17e5f1a2e99786fb68 and it works now fine.
