### PR TITLE
Add patch to fix compile errors on OS/X

### DIFF
--- a/build/mixxx.py
+++ b/build/mixxx.py
@@ -261,8 +261,26 @@ class MixxxBuild(object):
             print 'Automatically detecting Mac OS X SDK.'
 
             # SDK versions in order of precedence.
-            sdk_versions = ['10.9', '10.8', '10.7', '10.6', '10.5']
-            min_sdk_version = '10.5'
+            sdk_versions = ( '10.9', '10.8', '10.7', '10.6', '10.5', )
+            clang_sdk_versions = ( '10.9', '10.8', '10.7', )
+            valid_cpp_lib_versions = ( 'libstdc++', 'libc++', )
+
+            # By default use old gcc C++ library version
+            osx_stdlib = Script.ARGUMENTS.get('stdlib', 'libstdc++')
+            if osx_stdlib not in valid_cpp_lib_versions:
+                raise Exception('Unsupportd C++ stdlib version')
+
+            if osx_stdlib == 'libc++':
+                sdk_version_default = '10.9'
+            else:
+                sdk_version_default = '10.5'
+
+            min_sdk_version = Script.ARGUMENTS.get('macosx-version-min', sdk_version_default)
+            if min_sdk_version not in sdk_versions:
+                raise Exception('Unsupported macosx-version-min value')
+
+            if osx_stdlib == 'libc++' and min_sdk_version not in clang_sdk_versions:
+                raise Exception('stdlib=libc++ requires macosx-version-min > 10.7')
 
             print "XCode developer directory:", os.popen('xcode-select -p').readline().strip()
             for sdk in sdk_versions:
@@ -271,17 +289,12 @@ class MixxxBuild(object):
                 if sdk_path:
                     print "Automatically selected OS X SDK:", sdk_path
 
-                    # NOTE(rryan): A quick note about mmacosx-version-min. With
-                    # the OS X 10.9 SDK Clang changed the standard library from
-                    # libstdc++ to libc++. If you set -mmacosx-version-min=<10.9
-                    # then this uses libstdc++. libstdc++ and libc++ are not
-                    # binary compatible so if you want to build Mixxx with
-                    # libc++ then all dependencies have to be built with
-                    # libc++.
-
                     common_flags = ['-isysroot', sdk_path,
                                     '-mmacosx-version-min=%s' % min_sdk_version]
-                    link_flags = ['-Wl,-syslibroot,' + sdk_path]
+                    link_flags = [
+                        '-Wl,-syslibroot,' + sdk_path,
+                        '-stdlib=%s' % osx_stdlib
+                    ]
                     self.env.Append(CCFLAGS=common_flags)
                     self.env.Append(LINKFLAGS=common_flags + link_flags)
                     return


### PR DESCRIPTION
This patch allows compiling cleanly on OS X 10.9 with newly compiled homebrew libraries, which use clang libc++ instead of gcc's libstdc++. 

If you have upgraded from previous OS X versions and have not recompiled homebrew packages on 10.9, you need to use the old commands. Upgrading to 10.9 without compiling homebrew packages again is not recommended, because it may cause linker errors: for example taglib from old setup with libstdc++ and later compiled vamp-plugins with libc++.

To compile cleanly for mixxx 1.12 with QT 4.x series and current homebrew on OS X 10.9:

scons stdlib=libc++ qtdir=/usr/local/Cellar/qt/HEAD

Also please remember QT 5.x does not currently work with mixxx 1.12 code base.
