### PR TITLE
Adopt naming schema from other controls in Mixxx for effect parameters

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -533,6 +533,7 @@ class MixxxCore(Feature):
                    "controlobject.cpp",
                    "controlpotmeter.cpp",
                    "controllinpotmeter.cpp",
+                   "controleffectknob.cpp",
                    "controlpushbutton.cpp",
                    "controlindicator.cpp",
                    "controlttrotary.cpp",

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -84,8 +84,9 @@ class ControlDoublePrivate : public QObject {
     }
 
     inline double defaultValue() const {
+        QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
         double default_value = m_defaultValue.getValue();
-        return m_pBehavior ? m_pBehavior->defaultValue(default_value) : default_value;
+        return !pBehavior.isNull() ? pBehavior->defaultValue(default_value) : default_value;
     }
 
     inline ControlObject* getCreatorCO() const {

--- a/src/control/controlbehavior.cpp
+++ b/src/control/controlbehavior.cpp
@@ -93,7 +93,7 @@ void ControlPotmeterBehavior::setValueFromMidiParameter(MidiOpCode o, double dPa
 #define middlePosition ((maxPosition - minPosition) / 2.0)
 #define positionrange (maxPosition - minPosition)
 
-ControlLogpotmeterBehavior::ControlLogpotmeterBehavior(double dMaxValue)
+ControlLogPotmeterBehavior::ControlLogPotmeterBehavior(double dMaxValue)
         : ControlPotmeterBehavior(0, dMaxValue, false) {
     if (dMaxValue == 1.0) {
         m_bTwoState = false;
@@ -105,15 +105,15 @@ ControlLogpotmeterBehavior::ControlLogpotmeterBehavior(double dMaxValue)
     }
 }
 
-ControlLogpotmeterBehavior::~ControlLogpotmeterBehavior() {
+ControlLogPotmeterBehavior::~ControlLogPotmeterBehavior() {
 }
 
-double ControlLogpotmeterBehavior::defaultValue(double dDefault) const {
+double ControlLogPotmeterBehavior::defaultValue(double dDefault) const {
     Q_UNUSED(dDefault);
     return 1.0;
 }
 
-double ControlLogpotmeterBehavior::valueToParameter(double dValue) {
+double ControlLogPotmeterBehavior::valueToParameter(double dValue) {
     if (dValue > m_dMaxValue) {
         dValue = m_dMaxValue;
     } else if (dValue < m_dMinValue) {
@@ -130,7 +130,7 @@ double ControlLogpotmeterBehavior::valueToParameter(double dValue) {
     }
 }
 
-double ControlLogpotmeterBehavior::parameterToValue(double dParam) {
+double ControlLogPotmeterBehavior::parameterToValue(double dParam) {
     if (!m_bTwoState) {
         return pow(10.0, m_dB1 * dParam) - 1.0;
     } else {

--- a/src/control/controlbehavior.cpp
+++ b/src/control/controlbehavior.cpp
@@ -132,7 +132,7 @@ double ControlLogPotmeterBehavior::valueToParameter(double dValue) {
 
 double ControlLogPotmeterBehavior::parameterToValue(double dParam) {
     if (!m_bTwoState) {
-        return pow(10.0, m_dB1 * dParam) - 1.0;
+        return pow(10.0, m_dB1 * dParam) - 1.0 + m_dMinValue;
     } else {
         if (dParam <= middlePosition) {
             return pow(10.0, m_dB1 * dParam) - 1;

--- a/src/control/controlbehavior.cpp
+++ b/src/control/controlbehavior.cpp
@@ -93,11 +93,11 @@ void ControlPotmeterBehavior::setValueFromMidiParameter(MidiOpCode o, double dPa
 #define middlePosition ((maxPosition - minPosition) / 2.0)
 #define positionrange (maxPosition - minPosition)
 
-ControlLogPotmeterBehavior::ControlLogPotmeterBehavior(double dMaxValue)
-        : ControlPotmeterBehavior(0, dMaxValue, false) {
-    if (dMaxValue == 1.0) {
+ControlLogPotmeterBehavior::ControlLogPotmeterBehavior(double dMinValue, double dMaxValue)
+        : ControlPotmeterBehavior(dMinValue, dMaxValue, false) {
+    if (dMaxValue == 1.0 || dMinValue != 0.0 ) {
         m_bTwoState = false;
-        m_dB1 = log10(2.0) / maxPosition;
+        m_dB1 = log10((dMaxValue - dMinValue) + 1.0) / maxPosition;
     } else {
         m_bTwoState = true;
         m_dB1 = log10(2.0) / middlePosition;
@@ -120,7 +120,7 @@ double ControlLogPotmeterBehavior::valueToParameter(double dValue) {
         dValue = m_dMinValue;
     }
     if (!m_bTwoState) {
-        return log10(dValue + 1) / m_dB1;
+        return log10((dValue - m_dMinValue) + 1) / m_dB1;
     } else {
         if (dValue > 1.0) {
             return log10(dValue) / m_dB2 + middlePosition;

--- a/src/control/controlbehavior.h
+++ b/src/control/controlbehavior.h
@@ -48,10 +48,10 @@ class ControlPotmeterBehavior : public ControlNumericBehavior {
     bool m_bAllowOutOfBounds;
 };
 
-class ControlLogpotmeterBehavior : public ControlPotmeterBehavior {
+class ControlLogPotmeterBehavior : public ControlPotmeterBehavior {
   public:
-    ControlLogpotmeterBehavior(double dMaxValue);
-    virtual ~ControlLogpotmeterBehavior();
+    ControlLogPotmeterBehavior(double dMaxValue);
+    virtual ~ControlLogPotmeterBehavior();
 
     virtual double defaultValue(double dDefault) const;
     virtual double valueToParameter(double dValue);

--- a/src/control/controlbehavior.h
+++ b/src/control/controlbehavior.h
@@ -50,7 +50,7 @@ class ControlPotmeterBehavior : public ControlNumericBehavior {
 
 class ControlLogPotmeterBehavior : public ControlPotmeterBehavior {
   public:
-    ControlLogPotmeterBehavior(double dMaxValue);
+    ControlLogPotmeterBehavior(double dMinValue, double dMaxValue);
     virtual ~ControlLogPotmeterBehavior();
 
     virtual double defaultValue(double dDefault) const;

--- a/src/controleffectknob.cpp
+++ b/src/controleffectknob.cpp
@@ -1,0 +1,28 @@
+#include "controleffectknob.h"
+#include "defs.h"
+
+#include "effects/effectmanifestparameter.h"
+
+ControlEffectKnob::ControlEffectKnob(ConfigKey key, double dMinValue, double dMaxValue)
+        : ControlPotmeter(key, dMinValue, dMaxValue),
+          m_type(0.0) {
+    if (m_pControl) {
+        m_pControl->setBehavior(
+                new ControlLinPotmeterBehavior(dMinValue, dMaxValue));
+    }
+}
+
+void ControlEffectKnob::setType(double v) {
+    if (v == m_type || m_pControl == NULL) {
+        return;
+    }
+
+    if (v == EffectManifestParameter::CONTROL_KNOB_LINEAR) {
+        m_pControl->setBehavior(
+                        new ControlLinPotmeterBehavior(m_dMinValue, m_dMaxValue));
+    } else if (v == EffectManifestParameter::CONTROL_KNOB_LOGARITHMIC) {
+        m_pControl->setBehavior(
+                        new ControlLogPotmeterBehavior(m_dMaxValue));
+    }
+    m_type = v;
+}

--- a/src/controleffectknob.cpp
+++ b/src/controleffectknob.cpp
@@ -22,7 +22,7 @@ void ControlEffectKnob::setType(double v) {
                         new ControlLinPotmeterBehavior(m_dMinValue, m_dMaxValue));
     } else if (v == EffectManifestParameter::CONTROL_KNOB_LOGARITHMIC) {
         m_pControl->setBehavior(
-                        new ControlLogPotmeterBehavior(m_dMaxValue));
+                        new ControlLogPotmeterBehavior(m_dMinValue, m_dMaxValue));
     }
     m_type = v;
 }

--- a/src/controleffectknob.h
+++ b/src/controleffectknob.h
@@ -1,0 +1,15 @@
+#ifndef CONTROLEFFECTKNOB_H
+#define CONTROLEFFECTKNOB_H
+
+#include "controlpotmeter.h"
+
+class ControlEffectKnob : public ControlPotmeter {
+    Q_OBJECT
+  public:
+    ControlEffectKnob(ConfigKey key, double dMinValue = 0.0, double dMaxValue = 1.0);
+    void setType(double type);
+  private:
+    double m_type;
+};
+
+#endif // CONTROLLEFFECTKNOB_H

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -721,7 +721,7 @@ void ControllerEngine::reset(QString group, QString name) {
    Input:   Control group, Key name, new value
    Output:  -
    -------- ------------------------------------------------------ */
-double ControllerEngine::getDefault(QString group, QString name) {
+double ControllerEngine::getDefaultValue(QString group, QString name) {
     ControlObjectThread *cot = getControlObjectThread(group, name);
 
     if (cot == NULL) {
@@ -730,6 +730,22 @@ double ControllerEngine::getDefault(QString group, QString name) {
     }
 
     return cot->getDefault();
+}
+
+/* -------- ------------------------------------------------------
+   Purpose: default parameter of a Mixxx control (for scripts)
+   Input:   Control group, Key name, new value
+   Output:  -
+   -------- ------------------------------------------------------ */
+double ControllerEngine::getDefaultParameter(QString group, QString name) {
+    ControlObjectThread *cot = getControlObjectThread(group, name);
+
+    if (cot == NULL) {
+        qWarning() << "ControllerEngine: Unknown control" << group << name << ", returning 0.0";
+        return 0.0;
+    }
+
+    return cot->getParameterForValue(cot->getDefault());
 }
 
 /* -------- ------------------------------------------------------

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -717,6 +717,22 @@ void ControllerEngine::reset(QString group, QString name) {
 }
 
 /* -------- ------------------------------------------------------
+   Purpose: default value of a Mixxx control (for scripts)
+   Input:   Control group, Key name, new value
+   Output:  -
+   -------- ------------------------------------------------------ */
+double ControllerEngine::getDefault(QString group, QString name) {
+    ControlObjectThread *cot = getControlObjectThread(group, name);
+
+    if (cot == NULL) {
+        qWarning() << "ControllerEngine: Unknown control" << group << name << ", returning 0.0";
+        return 0.0;
+    }
+
+    return cot->getDefault();
+}
+
+/* -------- ------------------------------------------------------
    Purpose: qDebugs script output so it ends up in mixxx.log
    Input:   String to log
    Output:  -

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -89,6 +89,7 @@ class ControllerEngine : public QObject {
     Q_INVOKABLE void setParameter(QString group, QString name, double newValue);
     Q_INVOKABLE double getParameterForValue(QString group, QString name, double value);
     Q_INVOKABLE void reset(QString group, QString name);
+    Q_INVOKABLE double getDefault(QString group, QString name);
     Q_INVOKABLE QScriptValue connectControl(QString group, QString name,
                                     QScriptValue function, bool disconnect = false);
     // Called indirectly by the objects returned by connectControl

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -89,7 +89,8 @@ class ControllerEngine : public QObject {
     Q_INVOKABLE void setParameter(QString group, QString name, double newValue);
     Q_INVOKABLE double getParameterForValue(QString group, QString name, double value);
     Q_INVOKABLE void reset(QString group, QString name);
-    Q_INVOKABLE double getDefault(QString group, QString name);
+    Q_INVOKABLE double getDefaultValue(QString group, QString name);
+    Q_INVOKABLE double getDefaultParameter(QString group, QString name);
     Q_INVOKABLE QScriptValue connectControl(QString group, QString name,
                                     QScriptValue function, bool disconnect = false);
     // Called indirectly by the objects returned by connectControl

--- a/src/controllinpotmeter.h
+++ b/src/controllinpotmeter.h
@@ -6,7 +6,7 @@
 class ControlLinPotmeter : public ControlPotmeter {
     Q_OBJECT
   public:
-    ControlLinPotmeter(ConfigKey key, double dMinValue=0.0, double dMaxValue=1.0);
+    ControlLinPotmeter(ConfigKey key, double dMinValue = 0.0, double dMaxValue = 1.0);
 };
 
 #endif // CONTROLLINPOTMETER_H

--- a/src/controllogpotmeter.cpp
+++ b/src/controllogpotmeter.cpp
@@ -37,6 +37,6 @@ ControlLogpotmeter::ControlLogpotmeter(ConfigKey key, double dMaxValue)
 
     if (m_pControl) {
         m_pControl->setBehavior(
-                new ControlLogpotmeterBehavior(dMaxValue));
+                new ControlLogPotmeterBehavior(dMaxValue));
     }
 }

--- a/src/controllogpotmeter.cpp
+++ b/src/controllogpotmeter.cpp
@@ -37,6 +37,6 @@ ControlLogpotmeter::ControlLogpotmeter(ConfigKey key, double dMaxValue)
 
     if (m_pControl) {
         m_pControl->setBehavior(
-                new ControlLogPotmeterBehavior(dMaxValue));
+                new ControlLogPotmeterBehavior(0, dMaxValue));
     }
 }

--- a/src/controlobjectthread.cpp
+++ b/src/controlobjectthread.cpp
@@ -79,6 +79,10 @@ double ControlObjectThread::getParameterForValue(double value) const {
     return m_pControl ? m_pControl->getParameterForValue(value) : 0.0;
 }
 
+double ControlObjectThread::getDefault() const {
+    return m_pControl ? m_pControl->defaultValue() : 0.0;
+}
+
 void ControlObjectThread::slotSet(double v) {
     set(v);
 }

--- a/src/controlobjectthread.h
+++ b/src/controlobjectthread.h
@@ -59,6 +59,9 @@ class ControlObjectThread : public QObject {
 
     double getParameterForValue(double value) const;
 
+    // Returns the normalized parameter of the object. Thread safe, non-blocking.
+    virtual double getDefault() const;
+
   public slots:
     // Set the control to a new value. Non-blocking.
     virtual void slotSet(double v);

--- a/src/controlpotmeter.h
+++ b/src/controlpotmeter.h
@@ -73,8 +73,8 @@ class PotmeterControls : public QObject {
 class ControlPotmeter : public ControlObject {
     Q_OBJECT
   public:
-    ControlPotmeter(ConfigKey key, double dMinValue=0.0, double dMaxValue=1.0,
-                    bool allowOutOfBounds=false);
+    ControlPotmeter(ConfigKey key, double dMinValue = 0.0, double dMaxValue = 1.0,
+                    bool allowOutOfBounds = false);
     virtual ~ControlPotmeter();
 
     // Returns the minimum allowed value.
@@ -86,11 +86,11 @@ class ControlPotmeter : public ControlObject {
     // Sets the small step size of the associated PushButtons.
     void setSmallStep(double);
 
-  protected:
     // Sets the minimum and maximum allowed value. The control value is reset
     // when calling this method
     void setRange(double dMinValue, double dMaxValue, bool allowOutOfBounds);
 
+  protected:
     double m_dMaxValue;
     double m_dMinValue;
     double m_dValueRange;

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -364,6 +364,7 @@ void EffectChainSlot::slotControlChainParameter(double v) {
 
 void EffectChainSlot::slotControlChainInsertionType(double v) {
     EffectChain::InsertionType type = static_cast<EffectChain::InsertionType>(v);
+    (void)v; // this avoids a false warning with g++ 4.8.1
     if (m_pEffectChain && type >= 0 &&
             type < EffectChain::NUM_INSERTION_TYPES) {
         m_pEffectChain->setInsertionType(type);

--- a/src/effects/effectparameter.cpp
+++ b/src/effects/effectparameter.cpp
@@ -209,7 +209,12 @@ void EffectParameter::onChainParameterChanged(double chainParameter) {
             }
             max = m_maximum.toDouble();
             min = m_minimum.toDouble();
-            setValue(min + chainParameter * (max - min));
+            if (m_parameter.controlHint() == EffectManifestParameter::CONTROL_KNOB_LOGARITHMIC) {
+                double dB1 = log10((max - min) + 1.0);
+                setValue(min + pow(10.0, dB1 * chainParameter) - 1.0);
+            } else {
+                setValue(min + chainParameter * (max - min));
+            }
             break;
         case EffectManifestParameter::LINK_NONE:
         default:

--- a/src/effects/effectparameter.cpp
+++ b/src/effects/effectparameter.cpp
@@ -434,6 +434,10 @@ void EffectParameter::setMaximum(QVariant maximum) {
     updateEngineState();
 }
 
+EffectManifestParameter::ControlHint EffectParameter::getControlHint() const {
+    return m_parameter.controlHint();
+}
+
 void EffectParameter::addToEngine() {
     m_bAddedToEngine = true;
 }

--- a/src/effects/effectparameter.h
+++ b/src/effects/effectparameter.h
@@ -53,6 +53,8 @@ class EffectParameter : public QObject {
     QVariant getMaximum() const;
     void setMaximum(QVariant maximum);
 
+    EffectManifestParameter::ControlHint getControlHint() const;
+
     void updateEngineState();
 
     void onChainParameterChanged(double chainParameter);

--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -1,7 +1,7 @@
 #include <QtDebug>
 
 #include "defs.h"
-#include "controllinpotmeter.h"
+#include "controleffectknob.h"
 #include "effects/effectparameterslot.h"
 #include "controlobject.h"
 #include "controlpushbutton.h"
@@ -24,7 +24,7 @@ EffectParameterSlot::EffectParameterSlot(const unsigned int iRackNumber,
         ConfigKey(m_group, itemPrefix + QString("_link_type")));
     m_pControlLinkType->setButtonMode(ControlPushButton::TOGGLE);
     m_pControlLinkType->setStates(EffectManifestParameter::NUM_LINK_TYPES);
-    m_pControlValue = new ControlLinPotmeter(
+    m_pControlValue = new ControlEffectKnob(
         ConfigKey(m_group, itemPrefix));
     m_pControlType = new ControlObject(
         ConfigKey(m_group, itemPrefix + QString("_type")));
@@ -97,8 +97,10 @@ void EffectParameterSlot::loadEffect(EffectPointer pEffect) {
             m_pControlValue->set(dValue);
             m_pControlValue->setDefaultValue(dDefault);
             m_pControlValue->setRange(dMinimum, dMaximum, false);
+            double type = m_pEffectParameter->getControlHint();
+            m_pControlValue->setType(type);
             // TODO(rryan) expose this from EffectParameter
-            m_pControlType->setAndConfirm(0);
+            m_pControlType->setAndConfirm(type);
             // Default loaded parameters to loaded and unlinked
             m_pControlLoaded->setAndConfirm(1.0);
             m_pControlLinkType->set(m_pEffectParameter->getLinkType());

--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -28,8 +28,6 @@ EffectParameterSlot::EffectParameterSlot(const unsigned int iRackNumber,
         ConfigKey(m_group, itemPrefix));
     m_pControlValueType = new ControlObject(
         ConfigKey(m_group, itemPrefix + QString("_value_type")));
-    m_pControlValueDefault = new ControlObject(
-        ConfigKey(m_group, itemPrefix + QString("_value_default")));
     m_pControlValueMaximum = new ControlObject(
         ConfigKey(m_group, itemPrefix + QString("_value_max")));
     m_pControlValueMaximumLimit = new ControlObject(
@@ -51,8 +49,6 @@ EffectParameterSlot::EffectParameterSlot(const unsigned int iRackNumber,
     // Read-only controls.
     m_pControlValueType->connectValueChangeRequest(
         this, SLOT(slotValueType(double)), Qt::AutoConnection);
-    m_pControlValueDefault->connectValueChangeRequest(
-        this, SLOT(slotValueDefault(double)), Qt::AutoConnection);
     m_pControlLoaded->connectValueChangeRequest(
         this, SLOT(slotLoaded(double)), Qt::AutoConnection);
     m_pControlValueMinimumLimit->connectValueChangeRequest(
@@ -71,7 +67,6 @@ EffectParameterSlot::~EffectParameterSlot() {
     delete m_pControlLinkType;
     delete m_pControlValue;
     delete m_pControlValueType;
-    delete m_pControlValueDefault;
     delete m_pControlValueMaximum;
     delete m_pControlValueMaximumLimit;
     delete m_pControlValueMinimum;
@@ -128,7 +123,6 @@ void EffectParameterSlot::loadEffect(EffectPointer pEffect) {
             m_pControlValueMaximumLimit->setAndConfirm(dMaximumLimit);
             // TODO(rryan) expose this from EffectParameter
             m_pControlValueType->setAndConfirm(0);
-            m_pControlValueDefault->setAndConfirm(dDefault);
             // Default loaded parameters to loaded and unlinked
             m_pControlLoaded->setAndConfirm(1.0);
             m_pControlLinkType->set(m_pEffectParameter->getLinkType());
@@ -152,7 +146,6 @@ void EffectParameterSlot::clear() {
     m_pControlValue->set(0.0);
     m_pControlValue->setDefaultValue(0.0);
     m_pControlValueType->setAndConfirm(0.0);
-    m_pControlValueDefault->setAndConfirm(0.0);
     m_pControlValueMaximum->set(0.0);
     m_pControlValueMaximumLimit->setAndConfirm(0.0);
     m_pControlValueMinimum->set(0.0);

--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -155,5 +155,6 @@ void EffectParameterSlot::slotValueType(double v) {
 
 
 void EffectParameterSlot::slotParameterValueChanged(QVariant value) {
+    qDebug() << debugString() << "slotParameterValueChanged" << value.toDouble();
     m_pControlValue->set(value.toDouble());
 }

--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -15,30 +15,31 @@ EffectParameterSlot::EffectParameterSlot(const unsigned int iRackNumber,
           m_iSlotNumber(iSlotNumber),
           m_iParameterNumber(iParameterNumber),
           m_group(formatGroupString(m_iRackNumber, m_iChainNumber,
-                                    m_iSlotNumber, m_iParameterNumber)),
+                                    m_iSlotNumber)),
           m_pEffectParameter(NULL) {
+    QString itemPrefix = QString("parameter%1").arg(QString::number(iParameterNumber+1));
     m_pControlLoaded = new ControlObject(
-        ConfigKey(m_group, QString("loaded")));
+        ConfigKey(m_group, itemPrefix + QString("_loaded")));
     m_pControlLinkType = new ControlPushButton(
-        ConfigKey(m_group, QString("link_type")));
+        ConfigKey(m_group, itemPrefix + QString("_link_type")));
     m_pControlLinkType->setButtonMode(ControlPushButton::TOGGLE);
     m_pControlLinkType->setStates(EffectManifestParameter::NUM_LINK_TYPES);
     m_pControlValue = new ControlObject(
-        ConfigKey(m_group, QString("value")));
+        ConfigKey(m_group, itemPrefix + QString("_value")));
     m_pControlValueNormalized = new ControlPotmeter(
-        ConfigKey(m_group, QString("value_normalized")), 0.0, 1.0);
+        ConfigKey(m_group, itemPrefix + QString("_value_normalized")), 0.0, 1.0);
     m_pControlValueType = new ControlObject(
-        ConfigKey(m_group, QString("value_type")));
+        ConfigKey(m_group, itemPrefix + QString("_value_type")));
     m_pControlValueDefault = new ControlObject(
-        ConfigKey(m_group, QString("value_default")));
+        ConfigKey(m_group, itemPrefix + QString("_value_default")));
     m_pControlValueMaximum = new ControlObject(
-        ConfigKey(m_group, QString("value_max")));
+        ConfigKey(m_group, itemPrefix + QString("_value_max")));
     m_pControlValueMaximumLimit = new ControlObject(
-        ConfigKey(m_group, QString("value_max_limit")));
+        ConfigKey(m_group, itemPrefix + QString("_value_max_limit")));
     m_pControlValueMinimum = new ControlObject(
-        ConfigKey(m_group, QString("value_min")));
+        ConfigKey(m_group, itemPrefix + QString("_value_min")));
     m_pControlValueMinimumLimit = new ControlObject(
-        ConfigKey(m_group, QString("value_min_limit")));
+        ConfigKey(m_group, itemPrefix + QString("_value_min_limit")));
 
     connect(m_pControlLinkType, SIGNAL(valueChanged(double)),
             this, SLOT(slotLinkType(double)));

--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -26,35 +26,19 @@ EffectParameterSlot::EffectParameterSlot(const unsigned int iRackNumber,
     m_pControlLinkType->setStates(EffectManifestParameter::NUM_LINK_TYPES);
     m_pControlValue = new ControlLinPotmeter(
         ConfigKey(m_group, itemPrefix));
-    m_pControlValueType = new ControlObject(
-        ConfigKey(m_group, itemPrefix + QString("_value_type")));
-    m_pControlValueMaximum = new ControlObject(
-        ConfigKey(m_group, itemPrefix + QString("_value_max")));
-    m_pControlValueMaximumLimit = new ControlObject(
-        ConfigKey(m_group, itemPrefix + QString("_value_max_limit")));
-    m_pControlValueMinimum = new ControlObject(
-        ConfigKey(m_group, itemPrefix + QString("_value_min")));
-    m_pControlValueMinimumLimit = new ControlObject(
-        ConfigKey(m_group, itemPrefix + QString("_value_min_limit")));
+    m_pControlType = new ControlObject(
+        ConfigKey(m_group, itemPrefix + QString("_type")));
 
     connect(m_pControlLinkType, SIGNAL(valueChanged(double)),
             this, SLOT(slotLinkType(double)));
     connect(m_pControlValue, SIGNAL(valueChanged(double)),
             this, SLOT(slotValueChanged(double)));
-    connect(m_pControlValueMaximum, SIGNAL(valueChanged(double)),
-            this, SLOT(slotValueMaximum(double)));
-    connect(m_pControlValueMinimum, SIGNAL(valueChanged(double)),
-            this, SLOT(slotValueMinimum(double)));
 
     // Read-only controls.
-    m_pControlValueType->connectValueChangeRequest(
+    m_pControlType->connectValueChangeRequest(
         this, SLOT(slotValueType(double)), Qt::AutoConnection);
     m_pControlLoaded->connectValueChangeRequest(
         this, SLOT(slotLoaded(double)), Qt::AutoConnection);
-    m_pControlValueMinimumLimit->connectValueChangeRequest(
-        this, SLOT(slotValueMaximumLimit(double)), Qt::AutoConnection);
-    m_pControlValueMaximumLimit->connectValueChangeRequest(
-        this, SLOT(slotValueMinimumLimit(double)), Qt::AutoConnection);
 
     clear();
 }
@@ -66,11 +50,7 @@ EffectParameterSlot::~EffectParameterSlot() {
     delete m_pControlLoaded;
     delete m_pControlLinkType;
     delete m_pControlValue;
-    delete m_pControlValueType;
-    delete m_pControlValueMaximum;
-    delete m_pControlValueMaximumLimit;
-    delete m_pControlValueMinimum;
-    delete m_pControlValueMinimumLimit;
+    delete m_pControlType;
 }
 
 QString EffectParameterSlot::name() const {
@@ -117,12 +97,8 @@ void EffectParameterSlot::loadEffect(EffectPointer pEffect) {
             m_pControlValue->set(dValue);
             m_pControlValue->setDefaultValue(dDefault);
             m_pControlValue->setRange(dMinimum, dMaximum, false);
-            m_pControlValueMinimum->set(dMinimum);
-            m_pControlValueMinimumLimit->setAndConfirm(dMinimumLimit);
-            m_pControlValueMaximum->set(dMaximum);
-            m_pControlValueMaximumLimit->setAndConfirm(dMaximumLimit);
             // TODO(rryan) expose this from EffectParameter
-            m_pControlValueType->setAndConfirm(0);
+            m_pControlType->setAndConfirm(0);
             // Default loaded parameters to loaded and unlinked
             m_pControlLoaded->setAndConfirm(1.0);
             m_pControlLinkType->set(m_pEffectParameter->getLinkType());
@@ -145,11 +121,7 @@ void EffectParameterSlot::clear() {
     m_pControlLoaded->setAndConfirm(0.0);
     m_pControlValue->set(0.0);
     m_pControlValue->setDefaultValue(0.0);
-    m_pControlValueType->setAndConfirm(0.0);
-    m_pControlValueMaximum->set(0.0);
-    m_pControlValueMaximumLimit->setAndConfirm(0.0);
-    m_pControlValueMinimum->set(0.0);
-    m_pControlValueMinimumLimit->setAndConfirm(0.0);
+    m_pControlType->setAndConfirm(0.0);
     m_pControlLinkType->set(EffectManifestParameter::LINK_NONE);
     emit(updated());
 }
@@ -169,15 +141,6 @@ void EffectParameterSlot::slotLinkType(double v) {
 
 void EffectParameterSlot::slotValueChanged(double v) {
     qDebug() << debugString() << "slotValueChanged" << v;
-
-    double dMin = m_pControlValueMinimum->get();
-    double dMax = m_pControlValueMaximum->get();
-    if (v < dMin || v > dMax) {
-        qDebug() << debugString() << "value out of limits";
-        v = math_clamp(v, dMin, dMax);
-        m_pControlValue->set(v);
-    }
-
     if (m_pEffectParameter) {
         m_pEffectParameter->setValue(v);
     }
@@ -188,47 +151,6 @@ void EffectParameterSlot::slotValueType(double v) {
     qDebug() << "WARNING: value_type is a read-only control.";
 }
 
-void EffectParameterSlot::slotValueDefault(double v) {
-    qDebug() << debugString() << "slotValueDefault" << v;
-    qDebug() << "WARNING: value_default is a read-only control.";
-}
-
-void EffectParameterSlot::slotValueMaximum(double v) {
-    qDebug() << debugString() << "slotValueMaximum" << v;
-    double dMaxLimit = m_pControlValueMaximumLimit->get();
-    if (v > dMaxLimit) {
-        qDebug() << "WARNING: Maximum parameter value is out of limits.";
-        v = dMaxLimit;
-        m_pControlValueMaximum->set(v);
-    }
-    if (m_pEffectParameter) {
-        m_pEffectParameter->setMaximum(v);
-    }
-}
-
-void EffectParameterSlot::slotValueMaximumLimit(double v) {
-    qDebug() << debugString() << "slotValueMaximumLimit" << v;
-    qDebug() << "WARNING: value_max_limit is a read-only control.";
-}
-
-void EffectParameterSlot::slotValueMinimum(double v) {
-    qDebug() << debugString() << "slotValueMinimum" << v;
-    double dMinLimit = m_pControlValueMinimumLimit->get();
-    if (v < dMinLimit) {
-        qDebug() << "WARNING: Minimum parameter value is out of limits.";
-        v = dMinLimit;
-        m_pControlValueMinimum->set(v);
-    }
-
-    if (m_pEffectParameter) {
-        m_pEffectParameter->setMinimum(v);
-    }
-}
-
-void EffectParameterSlot::slotValueMinimumLimit(double v) {
-    qDebug() << debugString() << "slotValueMinimumLimit" << v;
-    qDebug() << "WARNING: value_min_limit is a read-only control.";
-}
 
 void EffectParameterSlot::slotParameterValueChanged(QVariant value) {
     m_pControlValue->set(value.toDouble());

--- a/src/effects/effectparameterslot.h
+++ b/src/effects/effectparameterslot.h
@@ -26,13 +26,11 @@ class EffectParameterSlot : public QObject {
 
     static QString formatGroupString(const unsigned int iRackNumber,
                                      const unsigned int iChainNumber,
-                                     const unsigned int iSlotNumber,
-                                     const unsigned int iParameterNumber) {
-        return QString("[EffectRack%1_EffectUnit%2_Effect%3_Parameter%4]")
+                                     const unsigned int iSlotNumber) {
+        return QString("[EffectRack%1_EffectUnit%2_Effect%3]")
                 .arg(QString::number(iRackNumber+1),
                      QString::number(iChainNumber+1),
-                     QString::number(iSlotNumber+1),
-                     QString::number(iParameterNumber+1));
+                     QString::number(iSlotNumber+1));
     }
 
     // Load the parameter of the given effect into this EffectParameterSlot

--- a/src/effects/effectparameterslot.h
+++ b/src/effects/effectparameterslot.h
@@ -50,11 +50,6 @@ class EffectParameterSlot : public QObject {
     void slotLinkType(double v);
     void slotValueChanged(double v);
     void slotValueType(double v);
-    void slotValueDefault(double v);
-    void slotValueMaximum(double v);
-    void slotValueMaximumLimit(double v);
-    void slotValueMinimum(double v);
-    void slotValueMinimumLimit(double v);
 
     void slotParameterValueChanged(QVariant value);
 
@@ -81,12 +76,7 @@ class EffectParameterSlot : public QObject {
     ControlObject* m_pControlLoaded;
     ControlPushButton* m_pControlLinkType;
     ControlLinPotmeter* m_pControlValue;
-    ControlObject* m_pControlValueType;
-    ControlObject* m_pControlValueDefault;
-    ControlObject* m_pControlValueMaximum;
-    ControlObject* m_pControlValueMaximumLimit;
-    ControlObject* m_pControlValueMinimum;
-    ControlObject* m_pControlValueMinimumLimit;
+    ControlObject* m_pControlType;
 
     DISALLOW_COPY_AND_ASSIGN(EffectParameterSlot);
 };

--- a/src/effects/effectparameterslot.h
+++ b/src/effects/effectparameterslot.h
@@ -11,6 +11,7 @@
 
 class ControlObject;
 class ControlPushButton;
+class ControlLinPotmeter;
 
 class EffectParameterSlot;
 typedef QSharedPointer<EffectParameterSlot> EffectParameterSlotPointer;
@@ -47,8 +48,7 @@ class EffectParameterSlot : public QObject {
     // Solely for handling control changes
     void slotLoaded(double v);
     void slotLinkType(double v);
-    void slotValue(double v);
-    void slotValueNormalized(double v);
+    void slotValueChanged(double v);
     void slotValueType(double v);
     void slotValueDefault(double v);
     void slotValueMaximum(double v);
@@ -80,8 +80,7 @@ class EffectParameterSlot : public QObject {
 
     ControlObject* m_pControlLoaded;
     ControlPushButton* m_pControlLinkType;
-    ControlObject* m_pControlValue;
-    ControlObject* m_pControlValueNormalized;
+    ControlLinPotmeter* m_pControlValue;
     ControlObject* m_pControlValueType;
     ControlObject* m_pControlValueDefault;
     ControlObject* m_pControlValueMaximum;

--- a/src/effects/effectparameterslot.h
+++ b/src/effects/effectparameterslot.h
@@ -11,7 +11,7 @@
 
 class ControlObject;
 class ControlPushButton;
-class ControlLinPotmeter;
+class ControlEffectKnob;
 
 class EffectParameterSlot;
 typedef QSharedPointer<EffectParameterSlot> EffectParameterSlotPointer;
@@ -75,7 +75,7 @@ class EffectParameterSlot : public QObject {
 
     ControlObject* m_pControlLoaded;
     ControlPushButton* m_pControlLinkType;
-    ControlLinPotmeter* m_pControlValue;
+    ControlEffectKnob* m_pControlValue;
     ControlObject* m_pControlType;
 
     DISALLOW_COPY_AND_ASSIGN(EffectParameterSlot);

--- a/src/effects/native/bitcrushereffect.cpp
+++ b/src/effects/native/bitcrushereffect.cpp
@@ -18,11 +18,11 @@ EffectManifest BitCrusherEffect::getManifest() {
     depth->setId("bit_depth");
     depth->setName(QObject::tr("Bit Depth"));
     depth->setDescription("TODO");
-    depth->setControlHint(EffectManifestParameter::CONTROL_KNOB_LINEAR);
+    depth->setControlHint(EffectManifestParameter::CONTROL_KNOB_LOGARITHMIC);
     depth->setValueHint(EffectManifestParameter::EffectManifestParameter::VALUE_FLOAT);
     depth->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
     depth->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
-    depth->setLinkHint(EffectManifestParameter::LINK_INVERSE);
+    //depth->setLinkHint(EffectManifestParameter::LINK_INVERSE);
     depth->setDefault(16);
     depth->setMinimum(1);
     depth->setMaximum(16);
@@ -31,14 +31,14 @@ EffectManifest BitCrusherEffect::getManifest() {
     frequency->setId("downsample");
     frequency->setName(QObject::tr("Downsampling"));
     frequency->setDescription("TODO");
-    frequency->setControlHint(EffectManifestParameter::CONTROL_KNOB_LINEAR);
+    frequency->setControlHint(EffectManifestParameter::CONTROL_KNOB_LOGARITHMIC);
     frequency->setValueHint(EffectManifestParameter::VALUE_FLOAT);
     frequency->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
     frequency->setUnitsHint(EffectManifestParameter::UNITS_SAMPLERATE);
     //frequency->setLinkHint(EffectManifestParameter::LINK_LINKED);
-    frequency->setDefault(0.0);
+    frequency->setDefault(1.0);
     frequency->setMinimum(0.0);
-    frequency->setMaximum(0.9999);
+    frequency->setMaximum(1.0);
 
     return manifest;
 }
@@ -63,7 +63,6 @@ void BitCrusherEffect::processGroup(const QString& group,
     // rate.
     const CSAMPLE downsample = m_pDownsampleParameter ?
             m_pDownsampleParameter->value().toDouble() : 0.0;
-    const CSAMPLE accumulate = 1.0 - downsample;
 
     CSAMPLE bit_depth = m_pBitDepthParameter ?
             m_pBitDepthParameter->value().toDouble() : 1.0;
@@ -73,7 +72,7 @@ void BitCrusherEffect::processGroup(const QString& group,
 
     const int kChannels = 2;
     for (unsigned int i = 0; i < numSamples; i += kChannels) {
-        pState->accumulator += accumulate;
+        pState->accumulator += downsample;
 
         if (pState->accumulator >= 1.0) {
             pState->accumulator -= 1.0;

--- a/src/effects/native/bitcrushereffect.cpp
+++ b/src/effects/native/bitcrushereffect.cpp
@@ -19,7 +19,7 @@ EffectManifest BitCrusherEffect::getManifest() {
     depth->setName(QObject::tr("Bit Depth"));
     depth->setDescription("TODO");
     depth->setControlHint(EffectManifestParameter::CONTROL_KNOB_LINEAR);
-    depth->setValueHint(EffectManifestParameter::EffectManifestParameter::VALUE_INTEGRAL);
+    depth->setValueHint(EffectManifestParameter::EffectManifestParameter::VALUE_FLOAT);
     depth->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
     depth->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
     depth->setLinkHint(EffectManifestParameter::LINK_INVERSE);
@@ -35,7 +35,7 @@ EffectManifest BitCrusherEffect::getManifest() {
     frequency->setValueHint(EffectManifestParameter::VALUE_FLOAT);
     frequency->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
     frequency->setUnitsHint(EffectManifestParameter::UNITS_SAMPLERATE);
-    frequency->setLinkHint(EffectManifestParameter::LINK_LINKED);
+    //frequency->setLinkHint(EffectManifestParameter::LINK_LINKED);
     frequency->setDefault(0.0);
     frequency->setMinimum(0.0);
     frequency->setMaximum(0.9999);
@@ -65,11 +65,11 @@ void BitCrusherEffect::processGroup(const QString& group,
             m_pDownsampleParameter->value().toDouble() : 0.0;
     const CSAMPLE accumulate = 1.0 - downsample;
 
-    int bit_depth = m_pBitDepthParameter ?
-            m_pBitDepthParameter->value().toInt() : 1;
+    CSAMPLE bit_depth = m_pBitDepthParameter ?
+            m_pBitDepthParameter->value().toDouble() : 1.0;
     bit_depth = math_max(bit_depth, 1);
 
-    const CSAMPLE scale = 1 << (bit_depth-1);
+    const CSAMPLE scale = pow(2, bit_depth - 1);
 
     const int kChannels = 2;
     for (unsigned int i = 0; i < numSamples; i += kChannels) {

--- a/src/effects/native/bitcrushereffect.cpp
+++ b/src/effects/native/bitcrushereffect.cpp
@@ -22,7 +22,7 @@ EffectManifest BitCrusherEffect::getManifest() {
     depth->setValueHint(EffectManifestParameter::EffectManifestParameter::VALUE_FLOAT);
     depth->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
     depth->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
-    //depth->setLinkHint(EffectManifestParameter::LINK_INVERSE);
+    depth->setLinkHint(EffectManifestParameter::LINK_INVERSE);
     depth->setDefault(16);
     depth->setMinimum(1);
     depth->setMaximum(16);
@@ -35,7 +35,7 @@ EffectManifest BitCrusherEffect::getManifest() {
     frequency->setValueHint(EffectManifestParameter::VALUE_FLOAT);
     frequency->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
     frequency->setUnitsHint(EffectManifestParameter::UNITS_SAMPLERATE);
-    //frequency->setLinkHint(EffectManifestParameter::LINK_LINKED);
+    //frequency->setLinkHint(EffectManifestParameter::LINK_INVERSE);
     frequency->setDefault(1.0);
     frequency->setMinimum(0.0);
     frequency->setMaximum(1.0);

--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -91,6 +91,8 @@ class KnobEventHandler {
         // Clamp to [0.0, 1.0]
         newValue = math_max(0.0, math_min(1.0, newValue));
 
+        qDebug() << "newValue" << newValue;
+
         pWidget->setControlParameter(newValue);
         pWidget->update();
         e->accept();


### PR DESCRIPTION
With this PR, we are more in line with the rest of Mixxx. 
Now we have: 
- parameterN
- parameterN_up
- parameterN_down
- parameterN_up_small
- parameterN_down_small
- parameterN_set_default
- parameterN_set_zero
- parameterN_set_one
- parameterN_set_minus_one
- parameterN_toggle
- parameterN_minus_toggle
- parameterN_loaded
- parameterN_link_type
- parameterN_value_type
- parameterN_value_max
- parameterN_value_max_limit
- parameterN_value_min
- parameterN_value_min_limit
