### PR TITLE
Midi learn ui

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -56,9 +56,6 @@ class PortMIDI(Dependence):
         if not conf.CheckLib(libs) or not conf.CheckHeader(headers):
             raise Exception("Did not find PortMidi or its development headers.")
 
-        # Turn on PortMidi support in Mixxx
-        build.env.Append(CPPDEFINES='__PORTMIDI__')
-
     def sources(self, build):
         return ['controllers/midi/portmidienumerator.cpp', 'controllers/midi/portmidicontroller.cpp']
 

--- a/build/depends.py
+++ b/build/depends.py
@@ -56,6 +56,9 @@ class PortMIDI(Dependence):
         if not conf.CheckLib(libs) or not conf.CheckHeader(headers):
             raise Exception("Did not find PortMidi or its development headers.")
 
+        # Turn on PortMidi support in Mixxx
+        build.env.Append(CPPDEFINES='__PORTMIDI__')
+
     def sources(self, build):
         return ['controllers/midi/portmidienumerator.cpp', 'controllers/midi/portmidicontroller.cpp']
 

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -23,8 +23,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     m_auxStr = tr("Auxiliary %1");
     m_resetStr = tr("Reset to default");
     m_effectRackStr = tr("Effect Rack %1");
-    m_effectUnitStr = tr("Effect Unit %1");
-    m_effectStr = tr("Effect Slot %1");
+    m_effectUnitStr = tr("Unit %1");
+    m_effectStr = tr("Slot %1");
     m_parameterStr = tr("Parameter %1");
 
     // Master Controls
@@ -569,6 +569,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
         }
     }
 
+    /* DEPRECATED EFFECTS
     addDeckControl("flanger",
                    tr("Flange Toggle"),
                    tr("Toggle flange effect"),
@@ -588,6 +589,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addDeckControl("filterDepth",
                    tr("Filter Intensity"),
                    tr("Filter effect: Intensity"), effectsMenu, true);
+    */
 
     // Microphone Controls
     QMenu* microphoneMenu = addSubmenu(tr("Microphone / Auxiliary"));
@@ -892,7 +894,7 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
                 QAction* pResetAction = resetControlMenu->addAction(
                     m_auxStr.arg(i), &m_actionMapper, SLOT(map()));
                 m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-                addAvailableControl(ConfigKey(group, resetControl), controlTitle, resetDescription);
+                addAvailableControl(ConfigKey(group, resetControl), resetTitle, resetDescription);
             }
         }
     }

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -86,8 +86,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                    tr("Align beatgrid to current position"), bpmMenu);
     addDeckAndSamplerControl("quantize", tr("Quantize Mode"), tr("Toggle quantize mode"), bpmMenu);
 
-    QMenu* syncMenu = addSubmenu(tr("BPM"));
-
+    QMenu* syncMenu = addSubmenu(tr("Sync"));
     addDeckAndSamplerControl("sync_enabled", tr("Sync Mode"),
                              tr("Tap to sync, hold to enable sync mode"), syncMenu);
     addControl("[InternalClock]", "sync_master", tr("Internal Sync Master"),

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -508,29 +508,30 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                 QMenu* effectSlotMenu = addSubmenu(m_effectStr.arg(iEffectSlotNumber),
                                                    effectUnitMenu);
 
-                descriptionPrefix.append(QString(", %1").arg(
-                    m_effectStr.arg(iEffectSlotNumber)));
+                QString slotDescriptionPrefix =
+                        QString("%1, %2").arg(descriptionPrefix,
+                                              m_effectStr.arg(iEffectSlotNumber));
 
                 addEffectControl(effectSlotGroup, "clear",
                                  tr("Effect Clear"), tr("Clear the current effect"),
-                                 descriptionPrefix,
+                                 slotDescriptionPrefix,
                                  effectSlotMenu);
                 addEffectControl(effectSlotGroup, "enabled",
                                  tr("Effect Toggle"), tr("Toggle the current effect"),
-                                 descriptionPrefix,
+                                 slotDescriptionPrefix,
                                  effectSlotMenu);
                 addEffectControl(effectSlotGroup, "next_effect",
                                  tr("Effect Next"), tr("Switch to next effect"),
-                                 descriptionPrefix,
+                                 slotDescriptionPrefix,
                                  effectSlotMenu);
                 addEffectControl(effectSlotGroup, "prev_effect",
                                  tr("Previous effect"), tr("Switch to the previous effect"),
-                                 descriptionPrefix,
+                                 slotDescriptionPrefix,
                                  effectSlotMenu);
                 addEffectControl(effectSlotGroup, "effect_selector",
                                  tr("Effect Next or Previous"),
                                  tr("Switch to either next or previous effect"),
-                                 descriptionPrefix,
+                                 slotDescriptionPrefix,
                                  effectSlotMenu);
 
                 const int numParameterSlots = ControlObject::get(
@@ -546,20 +547,22 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                         m_parameterStr.arg(iParameterSlotNumber),
                         effectSlotMenu);
 
-                    descriptionPrefix.append(QString(", %1").arg(
-                        m_parameterStr.arg(iParameterSlotNumber)));
+                    QString parameterDescriptionPrefix =
+                            QString("%1, %2").arg(slotDescriptionPrefix,
+                                                  m_parameterStr.arg(iParameterSlotNumber));
 
                     // Likely to change soon.
                     addEffectControl(parameterSlotGroup, parameterSlotItemPrefix,
                                      tr("Effect Parameter Value"),
                                      tr("Effect Parameter Value"),
-                                     descriptionPrefix,
+                                     parameterDescriptionPrefix,
                                      parameterSlotMenu, true);
 
                     addEffectControl(parameterSlotGroup, parameterSlotItemPrefix + "_link_type",
                                      tr("Effect Super Knob Mode"),
                                      tr("3-state Super Knob Link Toggle (unlinked, linear, inverse)"),
-                                     descriptionPrefix, parameterSlotMenu);
+                                     parameterDescriptionPrefix,
+                                     parameterSlotMenu);
 
                 }
             }
@@ -715,26 +718,30 @@ void ControlPickerMenu::addControl(QString group, QString control, QString title
 }
 
 void ControlPickerMenu::addEffectControl(QString group, QString control,
-                                         QString title,
-                                         QString menuDescription, QString descriptionPrefix,
+                                         QString controlTitle,
+                                         QString controlDescription, QString descriptionPrefix,
                                          QMenu* pMenu, bool addReset) {
-    QAction* pAction = pMenu->addAction(title, &m_actionMapper, SLOT(map()));
+    QAction* pAction = pMenu->addAction(controlTitle, &m_actionMapper, SLOT(map()));
     m_actionMapper.setMapping(pAction, m_controlsAvailable.size());
 
+    QString title = QString("%1: %2").arg(descriptionPrefix, controlTitle);
     QString description = QString("%1: %2").arg(descriptionPrefix,
-                                                menuDescription);
+                                                controlDescription);
     addAvailableControl(ConfigKey(group, control), title, description);
 
     if (addReset) {
-        QString resetMenuDescription = QString("%1 (%2)").arg(title, m_resetStr);
+        QString resetMenuTitle = QString("%1 (%2)").arg(controlTitle, m_resetStr);
+        QString resetMenuDescription = QString("%1 (%2)").arg(controlDescription, m_resetStr);
         QString resetControl = QString("%1_set_default").arg(control);
         QAction* pResetAction = pMenu->addAction(title,
                                                  &m_actionMapper, SLOT(map()));
+        QString resetTitle = QString("%1: %2").arg(descriptionPrefix,
+                                                   resetMenuTitle);
         QString resetDescription = QString("%1: %2").arg(descriptionPrefix,
                                                          resetMenuDescription);
         m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
         addAvailableControl(ConfigKey(group, resetControl),
-                            title, resetDescription);
+                            resetTitle, resetDescription);
     }
 }
 
@@ -771,10 +778,11 @@ void ControlPickerMenu::addPlayerControl(QString control, QString controlTitle,
         addAvailableControl(ConfigKey(group, control), title, description);
 
         if (resetControlMenu) {
+            QString resetTitle = QString("%1 (%2)").arg(title, m_resetStr);
             QString resetDescription = QString("%1 (%2)").arg(description, m_resetStr);
             QAction* pResetAction = resetControlMenu->addAction(m_deckStr.arg(i), &m_actionMapper, SLOT(map()));
             m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-            addAvailableControl(ConfigKey(group, resetControl), controlTitle, resetDescription);
+            addAvailableControl(ConfigKey(group, resetControl), resetTitle, resetDescription);
         }
     }
 
@@ -790,10 +798,11 @@ void ControlPickerMenu::addPlayerControl(QString control, QString controlTitle,
         addAvailableControl(ConfigKey(group, control), title, description);
 
         if (resetControlMenu) {
+            QString resetTitle = QString("%1 (%2)").arg(title, m_resetStr);
             QString resetDescription = QString("%1 (%2)").arg(description, m_resetStr);
             QAction* pResetAction = resetControlMenu->addAction(m_previewdeckStr.arg(i), &m_actionMapper, SLOT(map()));
             m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-            addAvailableControl(ConfigKey(group, resetControl), title, resetDescription);
+            addAvailableControl(ConfigKey(group, resetControl), resetTitle, resetDescription);
         }
     }
 
@@ -809,28 +818,29 @@ void ControlPickerMenu::addPlayerControl(QString control, QString controlTitle,
         addAvailableControl(ConfigKey(group, control), title, description);
 
         if (resetControlMenu) {
+            QString resetTitle = QString("%1 (%2)").arg(title, m_resetStr);
             QString resetDescription = QString("%1 (%2)").arg(description, m_resetStr);
             QAction* pResetAction = resetControlMenu->addAction(m_samplerStr.arg(i), &m_actionMapper, SLOT(map()));
             m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-            addAvailableControl(ConfigKey(group, resetControl), title, resetDescription);
+            addAvailableControl(ConfigKey(group, resetControl), resetTitle, resetDescription);
         }
     }
 }
 
 void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
-                                                   QString title,
+                                                   QString controlTitle,
                                                    QString controlDescription,
                                                    QMenu* pMenu,
                                                    bool microhoneControls,
                                                    bool auxControls,
                                                    bool addReset) {
-    QMenu* controlMenu = new QMenu(title, pMenu);
+    QMenu* controlMenu = new QMenu(controlTitle, pMenu);
     pMenu->addMenu(controlMenu);
 
     QMenu* resetControlMenu = NULL;
     QString resetControl = QString("%1_set_default").arg(control);
     if (addReset) {
-        QString resetHelpText = QString("%1 (%2)").arg(title, m_resetStr);
+        QString resetHelpText = QString("%1 (%2)").arg(controlTitle, m_resetStr);
         resetControlMenu = new QMenu(resetHelpText, pMenu);
         pMenu->addMenu(resetControlMenu);
     }
@@ -843,6 +853,8 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
                 group = QString("[Microphone%1]").arg(i);
             }
 
+            QString title = QString("%1: %2").arg(
+                m_microphoneStr.arg(QString::number(i)), controlTitle);
             QString description = QString("%1: %2").arg(
                 m_microphoneStr.arg(QString::number(i)), controlDescription);
             QAction* pAction = controlMenu->addAction(m_microphoneStr.arg(i),
@@ -851,11 +863,12 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
             addAvailableControl(ConfigKey(group, control), title, description);
 
             if (addReset) {
+                QString resetTitle = QString("%1 (%2)").arg(controlTitle, m_resetStr);
                 QString resetDescription = QString("%1 (%2)").arg(controlDescription, m_resetStr);
                 QAction* pResetAction = resetControlMenu->addAction(
                     m_microphoneStr.arg(i), &m_actionMapper, SLOT(map()));
                 m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-                addAvailableControl(ConfigKey(group, resetControl), title, resetDescription);
+                addAvailableControl(ConfigKey(group, resetControl), resetTitle, resetDescription);
             }
         }
     }
@@ -864,19 +877,22 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
     if (auxControls) {
         for (int i = 1; i <= kNumAuxiliaries; ++i) {
             QString group = QString("[Auxiliary%1]").arg(i);
+            QString title = QString("%1: %2").arg(
+                m_auxStr.arg(QString::number(i)), controlTitle);
             QString description = QString("%1: %2").arg(
-                m_auxStr.arg(QString::number(i)), title);
+                m_auxStr.arg(QString::number(i)), controlDescription);
             QAction* pAction = controlMenu->addAction(m_auxStr.arg(i),
                                                       &m_actionMapper, SLOT(map()));
             m_actionMapper.setMapping(pAction, m_controlsAvailable.size());
             addAvailableControl(ConfigKey(group, control), title, description);
 
             if (addReset) {
+                QString resetTitle = QString("%1 (%2)").arg(title, m_resetStr);
                 QString resetDescription = QString("%1 (%2)").arg(description, m_resetStr);
                 QAction* pResetAction = resetControlMenu->addAction(
                     m_auxStr.arg(i), &m_actionMapper, SLOT(map()));
                 m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-                addAvailableControl(ConfigKey(group, resetControl), title, resetDescription);
+                addAvailableControl(ConfigKey(group, resetControl), controlTitle, resetDescription);
             }
         }
     }

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -748,3 +748,8 @@ void ControlPickerMenu::addAvailableControl(ConfigKey key,
 QString ControlPickerMenu::descriptionForConfigKey(ConfigKey key) const {
     return m_descriptionsByKey.value(key, QString());
 }
+
+QString ControlPickerMenu::prettyNameForConfigKey(ConfigKey key) const {
+    // We need a short name list.
+    return m_descriptionsByKey.value(key, QString());
+}

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -29,147 +29,208 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
     // Master Controls
     QMenu* mixerMenu = addSubmenu(tr("Mixer"));
-    addControl("[Master]", "crossfader", tr("Crossfader"), mixerMenu, true);
-    addControl("[Master]", "volume", tr("Master volume"), mixerMenu, true);
-    addControl("[Master]", "balance", tr("Master balance"), mixerMenu, true);
-    addControl("[Master]", "delay", tr("Master delay"), mixerMenu, true);
-    addControl("[Master]", "headVolume", tr("Headphone volume"), mixerMenu, true);
-    addControl("[Master]", "headMix", tr("Headphone mix (pre/main)"), mixerMenu, true);
-    addControl("[Master]", "headSplit", tr("Toggle headphone split cueing"), mixerMenu);
-    addControl("[Master]", "headDelay", tr("Headphone delay"), mixerMenu, true);
+    addControl("[Master]", "crossfader", tr("Crossfader"), tr("Crossfader"), mixerMenu, true);
+    addControl("[Master]", "volume", tr("Master volume"), tr("Master volume"), mixerMenu, true);
+    addControl("[Master]", "balance", tr("Master balance"), tr("Master balance"), mixerMenu, true);
+    addControl("[Master]", "delay", tr("Master delay"), tr("Master delay"), mixerMenu, true);
+    addControl("[Master]", "headVolume", tr("Headphone volume"), tr("Headphone volume"), mixerMenu, true);
+    addControl("[Master]", "headMix", tr("Headphone mix (pre/main)"), tr("Headphone mix (pre/main)"), mixerMenu, true);
+    addControl("[Master]", "headSplit", tr("Headphone split cue"), tr("Toggle headphone split cueing"), mixerMenu);
+    addControl("[Master]", "headDelay", tr("Headphone delay"), tr("Headphone delay"), mixerMenu, true);
 
     // Transport
     QMenu* transportMenu = addSubmenu(tr("Transport"));
-    addDeckAndSamplerAndPreviewDeckControl("playposition", tr("Strip-search through track"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("play", tr("Play button"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("playposition", tr("Strip Search"),
+                                           tr("Strip-search through track"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("play", tr("Play"), tr("Play button"), transportMenu);
     // Preview deck does not go to master so volume does not matter.
-    addDeckAndSamplerControl("volume", tr("Volume fader"), transportMenu, true);
-    addDeckAndSamplerControl("volume_set_one", tr("Set to full volume"), transportMenu);
-    addDeckAndSamplerControl("volume_set_zero", tr("Set to zero volume"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("back", tr("Fast rewind button"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("fwd", tr("Fast forward button"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("stop", tr("Stop button"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("start", tr("Jump to start of track"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("start_play", tr("Jump to start of track and play"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("start_stop", tr("Jump to start of track and stop"), transportMenu);
+    addDeckAndSamplerControl("volume", tr("Volume"), tr("Volume fader"), transportMenu, true);
+    addDeckAndSamplerControl("volume_set_one", tr("Full volume"), tr("Sets volume to full"), transportMenu);
+    addDeckAndSamplerControl("volume_set_zero", tr("Zero volume"), tr("Sets volume to zero"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("back", tr("Fast Rewind"), tr("Fast Rewind button"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("fwd", tr("Fast Forward"), tr("Fast Forward button"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("stop", tr("Stop"), tr("Stop button"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("start", tr("Jump to start"), tr("Jumps to start of track"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("start_play", tr("Play From Start"),
+                                           tr("Jump to start of track and play"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("start_stop", tr("Stop and Jump to start"),
+                                           tr("Stop playnack and jump to start of track"), transportMenu);
 
-    addDeckAndSamplerAndPreviewDeckControl("end", tr("Jump to end of track"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("reverse", tr("Play reverse button"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("reverseroll", tr("Reverse roll (Censor) button"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("pregain", tr("Gain knob"), transportMenu, true);
-    addDeckAndSamplerControl("pfl", tr("Headphone listen button"), transportMenu);
-    addDeckAndSamplerControl("mute", tr("Mute button"), transportMenu);
-    addDeckAndSamplerControl("repeat", tr("Toggle repeat mode"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("eject", tr("Eject track"), transportMenu);
-    addDeckAndSamplerControl("orientation", tr("Mix orientation (e.g. left, right, center)"), transportMenu);
-    addDeckAndSamplerControl("orientation_left", tr("Set mix orientation to left"), transportMenu);
-    addDeckAndSamplerControl("orientation_center", tr("Set mix orientation to center"), transportMenu);
-    addDeckAndSamplerControl("orientation_right", tr("Set mix orientation to right"), transportMenu);
-    addDeckAndSamplerControl("slip_enabled", tr("Toggle slip mode"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("end", tr("Jump to End"), tr("Jump to end of track"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("reverse", tr("Play Reverse"), tr("Play Reverse button"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("reverseroll", tr("Reverse Roll (Censor)"),
+                                           tr("Reverse roll (Censor) button"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("pregain", tr("Track Gain"), tr("Track Gain knob"), transportMenu, true);
+    addDeckAndSamplerControl("pfl", tr("Headphone listen"), tr("Headphone listen (pfl) button"), transportMenu);
+    addDeckAndSamplerControl("mute", tr("Mute"), tr("Mute button"), transportMenu);
+    addDeckAndSamplerControl("repeat", tr("Repeat Mode"), tr("Toggle repeat mode"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("eject", tr("Eject"), tr("Eject track"), transportMenu);
+    addDeckAndSamplerControl("orientation", tr("Orientation"),
+                             tr("Mix orientation (e.g. left, right, center)"), transportMenu);
+    addDeckAndSamplerControl("orientation_left", tr("Orient Left"),
+                             tr("Set mix orientation to left"), transportMenu);
+    addDeckAndSamplerControl("orientation_center", tr("Orient Center"),
+                             tr("Set mix orientation to center"), transportMenu);
+    addDeckAndSamplerControl("orientation_right", tr("Orient Right"),
+                             tr("Set mix orientation to right"), transportMenu);
+    addDeckAndSamplerControl("slip_enabled", tr("Slip Mode"), tr("Toggle slip mode"), transportMenu);
 
     // BPM & Sync
     QMenu* bpmMenu = addSubmenu(tr("BPM and Sync"));
-    addDeckAndSamplerControl("bpm", tr("BPM"), bpmMenu, true);
-    addDeckAndSamplerControl("bpm_up", tr("Increase BPM by 1"), bpmMenu);
-    addDeckAndSamplerControl("bpm_down", tr("Decrease BPM by 1"), bpmMenu);
-    addDeckAndSamplerControl("bpm_up_small", tr("Increase BPM by 0.1"), bpmMenu);
-    addDeckAndSamplerControl("bpm_down_small", tr("Decrease BPM by 0.1"), bpmMenu);
-    addDeckAndSamplerControl("bpm_tap", tr("BPM tap button"), bpmMenu);
-    addDeckControl("beats_translate_curpos", tr("Adjust beatgrid"), bpmMenu);
-    addDeckAndSamplerControl("quantize", tr("Toggle quantize mode"), bpmMenu);
-    addDeckAndSamplerControl("sync_enabled", tr("Sync button. Tap to sync, hold to enable sync mode"), bpmMenu);
-    addControl("[InternalClock]", "sync_master", tr("Toggle internal sync master"), bpmMenu);
-    addControl("[InternalClock]", "bpm", tr("Internal master BPM"), bpmMenu);
-    addControl("[InternalClock]", "bpm_up", tr("Increase internal master BPM by 1"), bpmMenu);
+    addDeckAndSamplerControl("bpm", tr("BPM"), tr("BPM"), bpmMenu, true);
+    addDeckAndSamplerControl("bpm_up", tr("BPM +1"), tr("Increase BPM by 1"), bpmMenu);
+    addDeckAndSamplerControl("bpm_down", tr("BPM -1"), tr("Decrease BPM by 1"), bpmMenu);
+    addDeckAndSamplerControl("bpm_up_small", tr("BPM +0.1"), tr("Increase BPM by 0.1"), bpmMenu);
+    addDeckAndSamplerControl("bpm_down_small", tr("BPM -0.1"), tr("Decrease BPM by 0.1"), bpmMenu);
+    addDeckAndSamplerControl("bpm_tap", tr("BPM Tap"), tr("BPM tap button"), bpmMenu);
+    addDeckControl("beats_translate_curpos", tr("BPM Adjust Beatgrid"),
+                   tr("Align beatgrid to current position"), bpmMenu);
+    addDeckAndSamplerControl("quantize", tr("Quantize Mode"), tr("Toggle quantize mode"), bpmMenu);
+    addDeckAndSamplerControl("sync_enabled", tr("Sync Mode"),
+                             tr("Tap to sync, hold to enable sync mode"), bpmMenu);
+    addControl("[InternalClock]", "sync_master", tr("Internal Sync Master"),
+               tr("Toggle Internal Sync Master"), bpmMenu);
+    addControl("[InternalClock]", "bpm", tr("Internal Master BPM"),
+               tr("Internal master BPM"), bpmMenu);
+    addControl("[InternalClock]", "bpm_up", tr("Internal Master BPM +1"),
+               tr("Increase internal master BPM by 1"), bpmMenu);
 
-    addControl("[InternalClock]", "bpm_down", tr("Decrease internal master BPM by 1"), bpmMenu);
+    addControl("[InternalClock]", "bpm_down", tr("Internal Master BPM -1"),
+               tr("Decrease internal master BPM by 1"), bpmMenu);
 
-    addControl("[InternalClock]", "bpm_up_small", tr("Increase internal master BPM by 0.1"), bpmMenu);
-    addControl("[InternalClock]", "bpm_down_small", tr("Decrease internal master BPM by 0.1"), bpmMenu);
-    addDeckAndSamplerControl("sync_master", tr("Toggle sync master"), bpmMenu);
-    addDeckAndSamplerControl("sync_mode", tr("Sync mode 3-state toggle (OFF, FOLLOWER, MASTER)"), bpmMenu);
-    addDeckAndSamplerControl("beatsync", tr("One-time beat sync (tempo and phase)"), bpmMenu);
-    addDeckAndSamplerControl("beatsync_tempo", tr("One-time beat sync (tempo only)"), bpmMenu);
-    addDeckAndSamplerControl("beatsync_phase", tr("One-time beat sync (phase only)"), bpmMenu);
+    addControl("[InternalClock]", "bpm_up_small", tr("Internal Master BPM +0.1"),
+               tr("Increase internal master BPM by 0.1"), bpmMenu);
+    addControl("[InternalClock]", "bpm_down_small", tr("Internal Master BPM -0.1"),
+               tr("Decrease internal master BPM by 0.1"), bpmMenu);
+    addDeckAndSamplerControl("sync_master", tr("Sync Master"), tr("Toggle sync master"), bpmMenu);
+    addDeckAndSamplerControl("sync_mode", tr("Sync Mode"),
+                             tr("Sync mode 3-state toggle (OFF, FOLLOWER, MASTER)"), bpmMenu);
+    addDeckAndSamplerControl("beatsync", tr("Sync Beat One-shot"),
+                             tr("One-time beat sync (tempo and phase)"), bpmMenu);
+    addDeckAndSamplerControl("beatsync_tempo", tr("Sync Tempo One-shot"),
+                             tr("One-time beat sync (tempo only)"), bpmMenu);
+    addDeckAndSamplerControl("beatsync_phase", tr("Sync Phase One-shot"),
+                             tr("One-time beat sync (phase only)"), bpmMenu);
 
     // Rate
     QMenu* rateMenu = addSubmenu(tr("Pitch and Rate"));
-    addDeckAndSamplerControl("keylock", tr("Toggle keylock mode"), rateMenu);
-    addDeckAndSamplerControl("rate", tr("Speed control slider"), rateMenu, true);
-    addDeckAndSamplerControl("pitch", tr("Pitch control slider"), rateMenu, true);
-    addDeckAndSamplerControl("sync_key", tr("Sync key"), rateMenu, true);
-    addDeckAndSamplerControl("rate_perm_up", tr("Adjust rate up (coarse)"), rateMenu);
-    addDeckAndSamplerControl("rate_perm_up_small", tr("Adjust rate up (fine)"), rateMenu);
-    addDeckAndSamplerControl("rate_perm_down", tr("Adjust rate down (coarse)"), rateMenu);
-    addDeckAndSamplerControl("rate_perm_down_small", tr("Adjust rate down (fine)"), rateMenu);
-    addDeckAndSamplerControl("rate_temp_up", tr("Pitch-bend rate up (coarse)"), rateMenu);
-    addDeckAndSamplerControl("rate_temp_up_small", tr("Pitch-bend rate up (fine)"), rateMenu);
-    addDeckAndSamplerControl("rate_temp_down", tr("Pitch-bend rate down (coarse)"), rateMenu);
-    addDeckAndSamplerControl("rate_temp_down_small", tr("Pitch-bend rate down (fine)"), rateMenu);
+    addDeckAndSamplerControl("keylock", tr("Keylock Mode"),
+                             tr("Toggle keylock mode"), rateMenu);
+    addDeckAndSamplerControl("rate", tr("Playback Speed Slider"),
+                             tr("Playback speed control slider"), rateMenu, true);
+    addDeckAndSamplerControl("pitch", tr("Pitch Slider (musical)"),
+                             tr("Pitch control slider (does not affect speed)"), rateMenu, true);
+    addDeckAndSamplerControl("sync_key", tr("Sync key"), tr("Match musical key"), rateMenu, true);
+    addDeckAndSamplerControl("rate_perm_up", tr("Rate Up"), tr("Adjust rate up (coarse)"), rateMenu);
+    addDeckAndSamplerControl("rate_perm_up_small", tr("Rate Up (fine)"),
+                             tr("Adjust rate up (fine)"), rateMenu);
+    addDeckAndSamplerControl("rate_perm_down", tr("Rate Down"), tr("Adjust rate down (coarse)"), rateMenu);
+    addDeckAndSamplerControl("rate_perm_down_small", tr("Rate Down (fine)"),
+                             tr("Adjust rate down (fine)"), rateMenu);
+    addDeckAndSamplerControl("rate_temp_up", tr("Pitch-Bend Rate Up (coarse)"),
+                             tr("Pitch-bend rate up (coarse)"), rateMenu);
+    addDeckAndSamplerControl("rate_temp_up_small", tr("Pitch-Bend Rate Up (fine)"),
+                             tr("Pitch-bend rate up (fine)"), rateMenu);
+    addDeckAndSamplerControl("rate_temp_down", tr("Pitch-Bend Rate Down (coarse)"),
+                             tr("Pitch-bend rate down (coarse)"), rateMenu);
+    addDeckAndSamplerControl("rate_temp_down_small", tr("Pitch-Bend Rate Down (fine)"),
+                             tr("Pitch-bend rate down (fine)"), rateMenu);
 
     // EQs
     QMenu* eqMenu = addSubmenu(tr("Equalizers"));
-    addDeckControl("filterHigh", tr("High EQ knob"), eqMenu, true);
-    addDeckControl("filterMid", tr("Mid EQ knob"), eqMenu, true);
-    addDeckControl("filterLow", tr("Low EQ knob"), eqMenu, true);
-    addDeckControl("filterHighKill", tr("High EQ kill"), eqMenu);
-    addDeckControl("filterMidKill", tr("Mid EQ kill"), eqMenu);
-    addDeckControl("filterLowKill", tr("Low EQ kill"), eqMenu);
+    addDeckControl("filterHigh", tr("EQ High"), tr("High EQ knob"), eqMenu, true);
+    addDeckControl("filterMid", tr("EQ Mid"), tr("Mid EQ knob"), eqMenu, true);
+    addDeckControl("filterLow", tr("EQ Low"), tr("Low EQ knob"), eqMenu, true);
+    addDeckControl("filterHighKill", tr("EQ High kill"), tr("High EQ kill"), eqMenu);
+    addDeckControl("filterMidKill", tr("EQ Mid kill"), tr("Mid EQ kill"), eqMenu);
+    addDeckControl("filterLowKill", tr("EQ Low kill"), tr("Low EQ kill"), eqMenu);
 
     // Vinyl Control
     QMenu* vinylControlMenu = addSubmenu(tr("Vinyl Control"));
-    addDeckControl("vinylcontrol_enabled", tr("Toggle vinyl-control (ON/OFF)"), vinylControlMenu);
-    addDeckControl("vinylcontrol_cueing", tr("Toggle vinyl-control cueing mode (OFF/ONE/HOT)"), vinylControlMenu);
-    addDeckControl("vinylcontrol_mode", tr("Toggle vinyl-control mode (ABS/REL/CONST)"), vinylControlMenu);
-    addDeckControl("passthrough", tr("Pass through external audio into the internal mixer"), vinylControlMenu);
-    addControl(VINYL_PREF_KEY, "Toggle", tr("Single deck mode - Toggle vinyl control to next deck"), vinylControlMenu);
+    addDeckControl("vinylcontrol_enabled", tr("Vinyl Control Toggle"),
+                   tr("Toggle Vinyl Control (ON/OFF)"), vinylControlMenu);
+    addDeckControl("vinylcontrol_mode", tr("Vinyl Control Mode"),
+                   tr("Toggle vinyl-control mode (ABS/REL/CONST)"), vinylControlMenu);
+    addDeckControl("vinylcontrol_cueing", tr("Vinyl Control Cueing Mode"),
+                   tr("Toggle vinyl-control cueing mode (OFF/ONE/HOT)"), vinylControlMenu);
+    addDeckControl("passthrough", tr("Vinyl Control Passthrough"),
+                   tr("Pass through external audio into the internal mixer"), vinylControlMenu);
+    addControl(VINYL_PREF_KEY, "Toggle", tr("Vinyl Control Next Deck"),
+               tr("Single deck mode - Switch vinyl control to next deck"), vinylControlMenu);
 
     // Cues
     QMenu* cueMenu = addSubmenu(tr("Cues"));
-    addDeckControl("cue_default", tr("Cue button"), cueMenu);
-    addDeckControl("cue_set", tr("Set cue point"), cueMenu);
-    addDeckControl("cue_goto", tr("Go to cue point"), cueMenu);
-    addDeckControl("cue_gotoandplay", tr("Go to cue point and play"), cueMenu);
-    addDeckControl("cue_gotoandstop", tr("Go to cue point and stop"), cueMenu);
-    addDeckControl("cue_preview", tr("Preview from cue point"), cueMenu);
-    addDeckControl("cue_cdj", tr("Cue button (CDJ mode)"), cueMenu);
-    addDeckControl("play_stutter", tr("Stutter cue"), cueMenu);
+    addDeckControl("cue_default", tr("Cue"), tr("Cue button"), cueMenu);
+    addDeckControl("cue_set", tr("Cue Set"), tr("Set cue point"), cueMenu);
+    addDeckControl("cue_goto", tr("Cue Go-To"), tr("Go to cue point"), cueMenu);
+    addDeckControl("cue_gotoandplay", tr("Cue Go-To and Play"),
+                   tr("Go to cue point and play"), cueMenu);
+    addDeckControl("cue_gotoandstop", tr("Cue Go-To and Stop"),
+                   tr("Go to cue point and stop"), cueMenu);
+    addDeckControl("cue_preview", tr("Cue Preview"),
+                   tr("Preview from cue point"), cueMenu);
+    addDeckControl("cue_cdj", tr("Cue (CDJ mode)"),
+                   tr("Cue button (CDJ mode)"), cueMenu);
+    addDeckControl("play_stutter", tr("Cue Stutter"),
+                   tr("Stutter cue"), cueMenu);
 
     // Hotcues
     QMenu* hotcueMenu = addSubmenu(tr("Hotcues"));
-    QString hotcueActivate = tr("Set, preview from or jump to hotcue %1");
-    QString hotcueClear = tr("Clear hotcue %1");
-    QString hotcueSet = tr("Set hotcue %1");
-    QString hotcueGoto = tr("Jump to hotcue %1");
-    QString hotcueGotoAndStop = tr("Jump to hotcue %1 and stop");
-    QString hotcueGotoAndPlay = tr("Jump to hotcue %1 and play");
-    QString hotcuePreview = tr("Preview from hotcue %1");
+    QString hotcueActivateTitle = tr("Hotcue %1");
+    QString hotcueClearTitle = tr("Hotcue Clear %1");
+    QString hotcueSetTitle = tr("Hotcue Set %1");
+    QString hotcueGotoTitle = tr("Hotcue Jump %1");
+    QString hotcueGotoAndStopTitle = tr("Hotcue %1 Jump To and Stop");
+    QString hotcueGotoAndPlayTitle = tr("Hotcue %1 Jump To and Play");
+    QString hotcuePreviewTitle = tr("Hotcue Preview %1");
+    QString hotcueActivateDescription = tr("Set, preview from or jump to hotcue %1");
+    QString hotcueClearDescription = tr("Clear hotcue %1");
+    QString hotcueSetDescription = tr("Set hotcue %1");
+    QString hotcueGotoDescription = tr("Jump to hotcue %1");
+    QString hotcueGotoAndStopDescription = tr("Jump to hotcue %1 and stop");
+    QString hotcueGotoAndPlayDescription = tr("Jump to hotcue %1 and play");
+    QString hotcuePreviewDescription = tr("Preview from hotcue %1");
     for (int i = 1; i <= NUM_HOT_CUES; ++i) {
         QMenu* hotcueSubMenu = addSubmenu(tr("Hotcue %1").arg(QString::number(i)), hotcueMenu);
         addDeckAndSamplerControl(QString("hotcue_%1_activate").arg(i),
-                                 hotcueActivate.arg(QString::number(i)), hotcueSubMenu);
+                                 hotcueActivateTitle.arg(QString::number(i)),
+                                 hotcueActivateDescription.arg(QString::number(i)),
+                                 hotcueSubMenu);
         addDeckAndSamplerControl(QString("hotcue_%1_clear").arg(i),
-                                 hotcueClear.arg(QString::number(i)), hotcueSubMenu);
+                                 hotcueClearTitle.arg(QString::number(i)),
+                                 hotcueClearDescription.arg(QString::number(i)),
+                                 hotcueSubMenu);
         addDeckAndSamplerControl(QString("hotcue_%1_set").arg(i),
-                                 hotcueSet.arg(QString::number(i)), hotcueSubMenu);
+                                 hotcueSetTitle.arg(QString::number(i)),
+                                 hotcueSetDescription.arg(QString::number(i)),
+                                 hotcueSubMenu);
         addDeckAndSamplerControl(QString("hotcue_%1_goto").arg(i),
-                                 hotcueGoto.arg(QString::number(i)), hotcueSubMenu);
+                                 hotcueGotoTitle.arg(QString::number(i)),
+                                 hotcueGotoDescription.arg(QString::number(i)),
+                                 hotcueSubMenu);
         addDeckAndSamplerControl(QString("hotcue_%1_gotoandstop").arg(i),
-                                 hotcueGotoAndStop.arg(QString::number(i)), hotcueSubMenu);
+                                 hotcueGotoAndStopTitle.arg(QString::number(i)),
+                                 hotcueGotoAndStopDescription.arg(QString::number(i)),
+                                 hotcueSubMenu);
         addDeckAndSamplerControl(QString("hotcue_%1_gotoandplay").arg(i),
-                                 hotcueGotoAndPlay.arg(QString::number(i)), hotcueSubMenu);
+                                 hotcueGotoAndPlayTitle.arg(QString::number(i)),
+                                 hotcueGotoAndPlayDescription.arg(QString::number(i)),
+                                 hotcueSubMenu);
         addDeckAndSamplerControl(QString("hotcue_%1_activate_preview").arg(i),
-                                 hotcuePreview.arg(QString::number(i)), hotcueSubMenu);
+                                 hotcuePreviewTitle.arg(QString::number(i)),
+                                 hotcuePreviewDescription.arg(QString::number(i)),
+                                 hotcueSubMenu);
     }
 
     // Loops
     QMenu* loopMenu = addSubmenu(tr("Looping"));
-    addDeckControl("loop_in", tr("Loop In button"), loopMenu);
-    addDeckControl("loop_out", tr("Loop Out button"), loopMenu);
-    addDeckControl("loop_exit", tr("Loop Exit button"), loopMenu);
-    addDeckControl("reloop_exit", tr("Reloop / Exit button"), loopMenu);
-    addDeckControl("loop_halve", tr("Halve the current loop's length"), loopMenu);
-    addDeckControl("loop_double", tr("Double the current loop's length"), loopMenu);
+    addDeckControl("loop_in", tr("Loop In"), tr("Loop In button"), loopMenu);
+    addDeckControl("loop_out", tr("Loop Out"), tr("Loop Out button"), loopMenu);
+    addDeckControl("loop_exit", tr("Loop Exit"), tr("Loop Exit button"), loopMenu);
+    addDeckControl("reloop_exit", tr("Loop Reloop / Exit"), tr("Reloop / Exit button"), loopMenu);
+    addDeckControl("loop_halve", tr("Loop Halve"), tr("Halve the current loop's length"), loopMenu);
+    addDeckControl("loop_double", tr("Loop Double"),
+                   tr("Double the current loop's length"), loopMenu);
 
     QList<double> beatSizes = LoopingControl::getBeatSizes();
 
@@ -188,77 +249,110 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     humanBeatSizes[64] = tr("64");
 
     // Loop moving
-    QString loopMoveForward = tr("Move loop forward by %1 beats");
-    QString loopMoveBackward = tr("Move loop backward by %1 beats");
+    QString loopMoveForwardTitle = tr("Loop Move +%1 beats");
+    QString loopMoveBackwardTitle = tr("Loop Move -%1 beats");
+    QString loopMoveForwardDescription = tr("Move loop forward by %1 beats");
+    QString loopMoveBackwardDescription = tr("Move loop backward by %1 beats");
 
     foreach (double beats, beatSizes) {
         QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
         addDeckControl(QString("loop_move_%1_forward").arg(beats),
-                       loopMoveForward.arg(humanBeats), loopMenu);
+                       loopMoveForwardTitle.arg(humanBeats),
+                       loopMoveForwardDescription.arg(humanBeats), loopMenu);
     }
 
     foreach (double beats, beatSizes) {
         QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
         addDeckControl(QString("loop_move_%1_backward").arg(beats),
-                       loopMoveBackward.arg(humanBeats), loopMenu);
+                       loopMoveBackwardTitle.arg(humanBeats),
+                       loopMoveBackwardDescription.arg(humanBeats), loopMenu);
     }
 
     // Beatloops
     QMenu* beatLoopMenu = addSubmenu(tr("Beat-Looping"));
-    QString beatLoop = tr("Create %1-beat loop");
-    QString beatLoopRoll = tr("Create temporary %1-beat loop roll");
+    QString beatLoopTitle = tr("Loop %1-beats");
+    QString beatLoopRollTitle = tr("Loop Roll %1-beats");
+    QString beatLoopDescription = tr("Create %1-beat loop");
+    QString beatLoopRollDescription = tr("Create temporary %1-beat loop roll");
 
     foreach (double beats, beatSizes) {
         QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
         addDeckControl(QString("beatloop_%1_toggle").arg(beats),
-                       beatLoop.arg(humanBeats), beatLoopMenu);
+                       beatLoopTitle.arg(humanBeats),
+                       beatLoopDescription.arg(humanBeats), beatLoopMenu);
     }
 
     foreach (double beats, beatSizes) {
         QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
         addDeckControl(QString("beatlooproll_%1_activate").arg(beats),
-                       beatLoopRoll.arg(humanBeats), beatLoopMenu);
+                       beatLoopRollTitle.arg(humanBeats),
+                       beatLoopRollDescription.arg(humanBeats), beatLoopMenu);
     }
 
     // Beat jumping
     QMenu* beatJumpMenu = addSubmenu(tr("Beat-Jump"));
-    QString beatJumpForward = tr("Jump forward by %1 beats");
-    QString beatJumpBackward = tr("Jump backward by %1 beats");
+    QString beatJumpForwardTitle = tr("Jump +%1 beats");
+    QString beatJumpBackwardTitle = tr("Jump -%1 beats");
+    QString beatJumpForwardDescription = tr("Jump forward by %1 beats");
+    QString beatJumpBackwardDescription = tr("Jump backward by %1 beats");
 
     foreach (double beats, beatSizes) {
         QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
         addDeckControl(QString("beatjump_%1_forward").arg(beats),
-                       beatJumpForward.arg(humanBeats), beatJumpMenu);
+                       beatJumpForwardTitle.arg(humanBeats),
+                       beatJumpForwardDescription.arg(humanBeats), beatJumpMenu);
     }
 
     foreach (double beats, beatSizes) {
         QString humanBeats = humanBeatSizes.value(beats, QString::number(beats));
         addDeckControl(QString("beatjump_%1_backward").arg(beats),
-                       beatJumpBackward.arg(humanBeats), beatJumpMenu);
+                       beatJumpBackwardTitle.arg(humanBeats),
+                       beatJumpBackwardDescription.arg(humanBeats), beatJumpMenu);
     }
 
     // Library Controls
     QMenu* libraryMenu = addSubmenu(tr("Library"));
-    addControl("[Playlist]", "ToggleSelectedSidebarItem", tr("Expand/collapse the selected view (library, playlist..)"),
+    addControl("[Playlist]", "ToggleSelectedSidebarItem",
+               tr("View Expand/Collapse"),
+               tr("Expand/collapse the selected view (library, playlist..)"),
                libraryMenu);
-    addControl("[Playlist]", "SelectPlaylist", tr("Switch to the next or previous view (library, playlist..)"),
+    addControl("[Playlist]", "SelectPlaylist",
+               tr("View Switch Next/Previous"),
+               tr("Switch to the next or previous view (library, playlist..)"),
                libraryMenu);
-    addControl("[Playlist]", "SelectNextPlaylist", tr("Switch to the next view (library, playlist..)"),
+    addControl("[Playlist]", "SelectNextPlaylist",
+               tr("View Switch Next"),
+               tr("Switch to the next view (library, playlist..)"),
                libraryMenu);
-    addControl("[Playlist]", "SelectPrevPlaylist", tr("Switch to the previous view (library, playlist..)"),
+    addControl("[Playlist]", "SelectPrevPlaylist",
+               tr("View Switch Previous"),
+               tr("Switch to the previous view (library, playlist..)"),
                libraryMenu);
-    addControl("[Playlist]", "SelectTrackKnob", tr("Scroll up or down in library/playlist"),
+    addControl("[Playlist]", "SelectTrackKnob",
+               tr("View Scroll Next/Previous"),
+               tr("Scroll up or down in library/playlist"),
                libraryMenu);
-    addControl("[Playlist]", "SelectNextTrack", tr("Scroll to next track in library/playlist"),
+    addControl("[Playlist]", "SelectNextTrack",
+               tr("View Scroll Next"),
+               tr("Scroll to next track in library/playlist"),
                libraryMenu);
-    addControl("[Playlist]", "SelectPrevTrack", tr("Scroll to previous track in library/playlist"),
+    addControl("[Playlist]", "SelectPrevTrack",
+               tr("View Scroll Previous"),
+               tr("Scroll to previous track in library/playlist"),
                libraryMenu);
-    addControl("[Playlist]", "LoadSelectedIntoFirstStopped", tr("Load selected track into first stopped deck"),
+    addControl("[Playlist]", "LoadSelectedIntoFirstStopped",
+               tr("View Load Track Into Stopped"),
+               tr("Load selected track into first stopped deck"),
                libraryMenu);
-    addDeckAndSamplerControl("LoadSelectedTrack", tr("Load selected track"), libraryMenu);
-    addDeckAndSamplerAndPreviewDeckControl("LoadSelectedTrackAndPlay", tr("Load selected track and play"), libraryMenu);
+    addDeckAndSamplerControl("LoadSelectedTrack",
+                             tr("View Load Track"),
+                             tr("Load selected track"), libraryMenu);
+    addDeckAndSamplerAndPreviewDeckControl("LoadSelectedTrackAndPlay", tr("Track Load and Play"),
+                                           tr("Load selected track and play"), libraryMenu);
 
-    addControl("[Recording]", "toggle_recording", tr("Toggle mix recording"), libraryMenu);
+    addControl("[Recording]", "toggle_recording",
+               tr("Record Mix"),
+               tr("Toggle mix recording"), libraryMenu);
 
     // Effect Controls
     QMenu* effectsMenu = addSubmenu(tr("Effects"));
@@ -270,7 +364,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
         QMenu* rackMenu = addSubmenu(m_effectRackStr.arg(iRackNumber), effectsMenu);
         QString descriptionPrefix = m_effectRackStr.arg(iRackNumber);
 
-        addEffectControl(rackGroup, "clear", tr("Clear effect rack"),
+        addEffectControl(rackGroup, "clear",
+                         tr("Effect Rack Clear"), tr("Clear effect rack"),
                          descriptionPrefix, rackMenu);
 
         const int numEffectUnits = ControlObject::get(
@@ -286,28 +381,37 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             QMenu* effectUnitMenu = addSubmenu(m_effectUnitStr.arg(iEffectUnitNumber),
                                                rackMenu);
             addEffectControl(effectUnitGroup, "clear",
+                             tr("Effect Unit Clear"),
                              tr("Clear effect unit"), descriptionPrefix,
                              effectUnitMenu);
             addEffectControl(effectUnitGroup, "enabled",
+                             tr("Effect Unit Toggle"),
                              tr("Toggle effect unit"), descriptionPrefix,
                              effectUnitMenu, false);
             addEffectControl(effectUnitGroup, "mix",
+                             tr("Effect Dry/Wet"),
                              tr("Dry/Wet"), descriptionPrefix,
                              effectUnitMenu, true);
             addEffectControl(effectUnitGroup, "parameter",
+                             tr("Effect Super Knob"),
                              tr("Super Knob (Control Linked Effect Parameters)"),
                              descriptionPrefix,
                              effectUnitMenu, true);
             addEffectControl(effectUnitGroup, "insertion_type",
-                             tr("Insert / Send Toggle"), descriptionPrefix,
+                             tr("Effect Insert / Send Toggle"),
+                             tr("Insert / Send Toggle"),
+                             descriptionPrefix,
                              effectUnitMenu);
             addEffectControl(effectUnitGroup, "next_chain",
+                             tr("Effect Next Chain"),
                              tr("Next chain preset"), descriptionPrefix,
                              effectUnitMenu);
             addEffectControl(effectUnitGroup, "prev_chain",
+                             tr("Effect Previous Chain"),
                              tr("Previous chain preset"), descriptionPrefix,
                              effectUnitMenu);
             addEffectControl(effectUnitGroup, "chain_selector",
+                             tr("Effect Chain Next/Previous"),
                              tr("Next or previous chain preset"), descriptionPrefix,
                              effectUnitMenu);
 
@@ -441,82 +545,141 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
         }
     }
 
-    addDeckControl("flanger", tr("Toggle flange effect"), effectsMenu);
-    addControl("[Flanger]", "lfoPeriod", tr("Flange effect: Wavelength/period"), effectsMenu, true);
-    addControl("[Flanger]", "lfoDepth", tr("Flange effect: Intensity"), effectsMenu, true);
-    addControl("[Flanger]", "lfoDelay", tr("Flange effect: Phase delay"), effectsMenu, true);
-    addDeckControl("filter", tr("Toggle filter effect"), effectsMenu);
-    addDeckControl("filterDepth", tr("Filter effect: Intensity"), effectsMenu, true);
+    addDeckControl("flanger",
+                   tr("Flange Toggle"),
+                   tr("Toggle flange effect"),
+                   effectsMenu);
+    addControl("[Flanger]", "lfoPeriod",
+               tr("Flange Wavelength/Period"),
+               tr("Flange effect: Wavelength/period"), effectsMenu, true);
+    addControl("[Flanger]", "lfoDepth",
+               tr("Flange Intensity"),
+               tr("Flange effect: Intensity"), effectsMenu, true);
+    addControl("[Flanger]", "lfoDelay",
+               tr("Flange Phase Delay"),
+               tr("Flange effect: Phase delay"), effectsMenu, true);
+    addDeckControl("filter",
+                   tr("Filter Toggle"),
+                   tr("Toggle filter effect"), effectsMenu);
+    addDeckControl("filterDepth",
+                   tr("Filter Intensity"),
+                   tr("Filter effect: Intensity"), effectsMenu, true);
 
     // Microphone Controls
     QMenu* microphoneMenu = addSubmenu(tr("Microphone / Auxiliary"));
 
-    addMicrophoneAndAuxControl("talkover", tr("Microphone on/off"), microphoneMenu,
+    addMicrophoneAndAuxControl("talkover",
+                               tr("Microphone on/off"),
+                               tr("Microphone on/off"), microphoneMenu,
                                true, false);
     addControl("[Master]", "duckStrength",
-               tr("Microphone ducking strength"), microphoneMenu, true);
+               tr("Microphone ducking strength"),
+               tr("Microphone ducking strength"),
+               microphoneMenu, true);
     addControl("[Master]", "talkoverDucking",
+               tr("Microphone Ducking Mode"),
                tr("Toggle microphone ducking mode (OFF, AUTO, MANUAL)"),
                microphoneMenu);
-    addMicrophoneAndAuxControl("passthrough", tr("Auxiliary on/off"), microphoneMenu,
+    addMicrophoneAndAuxControl("passthrough",
+                               tr("Auxiliary on/off"),
+                               tr("Auxiliary on/off"),
+                               microphoneMenu,
                                false, true);
-    addMicrophoneAndAuxControl("volume", tr("Volume fader"), microphoneMenu,
+    addMicrophoneAndAuxControl("volume",
+                               tr("Volume fader"),
+                               tr("Volume fader"), microphoneMenu,
                                true, true, true);
-    addMicrophoneAndAuxControl("volume_set_one", tr("Set to full volume"), microphoneMenu,
+    addMicrophoneAndAuxControl("volume_set_one",
+                               tr("Volume Full"),
+                               tr("Set to full volume"), microphoneMenu,
                                true, true);
-    addMicrophoneAndAuxControl("volume_set_zero", tr("Set to zero volume"), microphoneMenu,
+    addMicrophoneAndAuxControl("volume_set_zero",
+                               tr("Volume Zero"),
+                               tr("Set to zero volume"), microphoneMenu,
                                true, true);
-    addMicrophoneAndAuxControl("mute", tr("Mute button"), microphoneMenu,
+    addMicrophoneAndAuxControl("mute",
+                               tr("Mute"),
+                               tr("Mute button"), microphoneMenu,
                                true, true);
-    addMicrophoneAndAuxControl("orientation", tr("Mix orientation (e.g. left, right, center)"),
+    addMicrophoneAndAuxControl("orientation",
+                               tr("Orientation"),
+                               tr("Mix orientation (e.g. left, right, center)"),
                                microphoneMenu, true, true);
-    addMicrophoneAndAuxControl("orientation_left", tr("Set mix orientation to left"), microphoneMenu,
+    addMicrophoneAndAuxControl("orientation_left",
+                               tr("Orient Left"),
+                               tr("Set mix orientation to left"),
+                               microphoneMenu,
                                true, true);
-    addMicrophoneAndAuxControl("orientation_center", tr("Set mix orientation to center"), microphoneMenu,
+    addMicrophoneAndAuxControl("orientation_center",
+                               tr("Orient Center"),
+                               tr("Set mix orientation to center"), microphoneMenu,
                                true, true);
-    addMicrophoneAndAuxControl("orientation_right", tr("Set mix orientation to right"), microphoneMenu,
+    addMicrophoneAndAuxControl("orientation_right",
+                               tr("Orient Right"),
+                               tr("Set mix orientation to right"), microphoneMenu,
                                true, true);
-    addMicrophoneAndAuxControl("pfl", tr("Headphone listen button"), microphoneMenu,
+    addMicrophoneAndAuxControl("pfl",
+                               tr("Headphone Listen"),
+                               tr("Headphone listen button"), microphoneMenu,
                                true, true);
 
     // AutoDJ Controls
     QMenu* autodjMenu = addSubmenu(tr("Auto DJ"));
-    addControl("[AutoDJ]", "shuffle_playlist", tr("Shuffle the content of the Auto DJ playlist"), autodjMenu);
-    addControl("[AutoDJ]", "skip_next", tr("Skip the next track in the Auto DJ playlist"), autodjMenu);
-    addControl("[AutoDJ]", "fade_now", tr("Trigger the transition to the next track"), autodjMenu);
-    addControl("[AutoDJ]", "enabled", tr("Toggle Auto DJ (ON/OFF)"), autodjMenu);
+    addControl("[AutoDJ]", "shuffle_playlist",
+               tr("Auto DJ Shuffle"),
+               tr("Shuffle the content of the Auto DJ playlist"),
+               autodjMenu);
+    addControl("[AutoDJ]", "skip_next",
+               tr("Auto DJ Skip Next"),
+               tr("Skip the next track in the Auto DJ playlist"), autodjMenu);
+    addControl("[AutoDJ]", "fade_now",
+               tr("Auto DJ Fade To Next"),
+               tr("Trigger the transition to the next track"), autodjMenu);
+    addControl("[AutoDJ]", "enabled",
+               tr("Auto DJ Toggle"),
+               tr("Toggle Auto DJ On/Off"), autodjMenu);
 
     // Skin Controls
     QMenu* guiMenu = addSubmenu(tr("User Interface"));
-    addControl("[Samplers]", "show_samplers", tr("Show/hide the sampler section"), guiMenu);
-    addControl("[Microphone]", "show_microphone", tr("Show/hide the microphone section"), guiMenu);
-    addControl(VINYL_PREF_KEY, "show_vinylcontrol", tr("Show/hide the vinyl control section"), guiMenu);
-    addControl("[PreviewDeck]", "show_previewdeck", tr("Show/hide the preview deck"), guiMenu);
+    addControl("[Samplers]", "show_samplers",
+               tr("Samplers Show/Hide"),
+               tr("Show/hide the sampler section"), guiMenu);
+    addControl("[Microphone]", "show_microphone",
+               tr("Microphone Show/Hide"),
+               tr("Show/hide the microphone section"), guiMenu);
+    addControl(VINYL_PREF_KEY, "show_vinylcontrol",
+               tr("Vinyl Control Show/Hide"),
+               tr("Show/hide the vinyl control section"), guiMenu);
+    addControl("[PreviewDeck]", "show_previewdeck",
+               tr("Preview Deck Show/Hide"),
+               tr("Show/hide the preview deck"), guiMenu);
 
     const int iNumDecks = ControlObject::get(ConfigKey("[Master]", "num_decks"));
-    QString spinnyText = tr("Show/hide spinning vinyl widget");
+    QString spinnyTitle = tr("Vinyl Spinner Show/Hide");
+    QString spinnyDescription = tr("Show/hide spinning vinyl widget");
     for (int i = 1; i <= iNumDecks; ++i) {
         addControl(QString("[Spinny%1]").arg(i), "show_spinny",
-                   QString("%1: %2").arg(m_deckStr.arg(i), spinnyText), guiMenu);
+                   QString("%1: %2").arg(m_deckStr.arg(i), spinnyTitle),
+                   QString("%1: %2").arg(m_deckStr.arg(i), spinnyDescription), guiMenu);
 
     }
 
-    addDeckControl("waveform_zoom", tr("Waveform zoom"), guiMenu);
-    addDeckControl("waveform_zoom_down", tr("Zoom waveform in"), guiMenu);
-    addDeckControl("waveform_zoom_up", tr("Zoom waveform out"), guiMenu);
-
+    addDeckControl("waveform_zoom", tr("Waveform Zoom"), tr("Waveform zoom"), guiMenu);
+    addDeckControl("waveform_zoom_down", tr("Waveform Zoom In"), tr("Zoom waveform in"), guiMenu);
+    addDeckControl("waveform_zoom_up", tr("Waveform Zoom Out"), tr("Zoom waveform out"), guiMenu);
 }
 
 ControlPickerMenu::~ControlPickerMenu() {
 }
 
-void ControlPickerMenu::addControl(QString group, QString control, QString description,
+void ControlPickerMenu::addControl(QString group, QString control, QString title,
+                                   QString description,
                                    QMenu* pMenu,
                                    bool addReset) {
     QAction* pAction = pMenu->addAction(description, &m_actionMapper,
                                         SLOT(map()));
     m_actionMapper.setMapping(pAction, m_controlsAvailable.size());
-    addAvailableControl(ConfigKey(group, control), description);
+    addAvailableControl(ConfigKey(group, control), title, description);
 
     if (addReset) {
         QString resetDescription = QString("%1 (%2)").arg(description,
@@ -525,11 +688,13 @@ void ControlPickerMenu::addControl(QString group, QString control, QString descr
         QAction* pResetAction = pMenu->addAction(resetDescription,
                                                  &m_actionMapper, SLOT(map()));
         m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-        addAvailableControl(ConfigKey(group, resetControl), resetDescription);
+        addAvailableControl(ConfigKey(group, resetControl),
+                            title, resetDescription);
     }
 }
 
 void ControlPickerMenu::addEffectControl(QString group, QString control,
+                                         QString title,
                                          QString menuDescription, QString descriptionPrefix,
                                          QMenu* pMenu, bool addReset) {
     QAction* pAction = pMenu->addAction(menuDescription, &m_actionMapper, SLOT(map()));
@@ -537,7 +702,7 @@ void ControlPickerMenu::addEffectControl(QString group, QString control,
 
     QString description = QString("%1: %2").arg(descriptionPrefix,
                                                 menuDescription);
-    addAvailableControl(ConfigKey(group, control), description);
+    addAvailableControl(ConfigKey(group, control), title, description);
 
     if (addReset) {
         QString resetMenuDescription = QString("%1 (%2)").arg(description, m_resetStr);
@@ -547,11 +712,13 @@ void ControlPickerMenu::addEffectControl(QString group, QString control,
         QString resetDescription = QString("%1: %2").arg(descriptionPrefix,
                                                          resetMenuDescription);
         m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-        addAvailableControl(ConfigKey(group, resetControl), resetDescription);
+        addAvailableControl(ConfigKey(group, resetControl),
+                            title, resetDescription);
     }
 }
 
-void ControlPickerMenu::addPlayerControl(QString control, QString controlDescription,
+void ControlPickerMenu::addPlayerControl(QString control, QString title,
+                                         QString controlDescription,
                                          QMenu* pMenu,
                                          bool deckControls, bool samplerControls,
                                          bool previewdeckControls,
@@ -578,13 +745,13 @@ void ControlPickerMenu::addPlayerControl(QString control, QString controlDescrip
             m_deckStr.arg(QString::number(i)), controlDescription);
         QAction* pAction = controlMenu->addAction(m_deckStr.arg(i), &m_actionMapper, SLOT(map()));
         m_actionMapper.setMapping(pAction, m_controlsAvailable.size());
-        addAvailableControl(ConfigKey(group, control), description);
+        addAvailableControl(ConfigKey(group, control), title, description);
 
         if (resetControlMenu) {
             QString resetDescription = QString("%1 (%2)").arg(description, m_resetStr);
             QAction* pResetAction = resetControlMenu->addAction(m_deckStr.arg(i), &m_actionMapper, SLOT(map()));
             m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-            addAvailableControl(ConfigKey(group, resetControl), resetDescription);
+            addAvailableControl(ConfigKey(group, resetControl), title, resetDescription);
         }
     }
 
@@ -595,13 +762,13 @@ void ControlPickerMenu::addPlayerControl(QString control, QString controlDescrip
             m_previewdeckStr.arg(QString::number(i)), controlDescription);
         QAction* pAction = controlMenu->addAction(m_previewdeckStr.arg(i), &m_actionMapper, SLOT(map()));
         m_actionMapper.setMapping(pAction, m_controlsAvailable.size());
-        addAvailableControl(ConfigKey(group, control), description);
+        addAvailableControl(ConfigKey(group, control), title, description);
 
         if (resetControlMenu) {
             QString resetDescription = QString("%1 (%2)").arg(description, m_resetStr);
             QAction* pResetAction = resetControlMenu->addAction(m_previewdeckStr.arg(i), &m_actionMapper, SLOT(map()));
             m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-            addAvailableControl(ConfigKey(group, resetControl), resetDescription);
+            addAvailableControl(ConfigKey(group, resetControl), title, resetDescription);
         }
     }
 
@@ -612,18 +779,20 @@ void ControlPickerMenu::addPlayerControl(QString control, QString controlDescrip
             m_samplerStr.arg(QString::number(i)), controlDescription);
         QAction* pAction = controlMenu->addAction(m_samplerStr.arg(i), &m_actionMapper, SLOT(map()));
         m_actionMapper.setMapping(pAction, m_controlsAvailable.size());
-        addAvailableControl(ConfigKey(group, control), description);
+        addAvailableControl(ConfigKey(group, control), title, description);
 
         if (resetControlMenu) {
             QString resetDescription = QString("%1 (%2)").arg(description, m_resetStr);
             QAction* pResetAction = resetControlMenu->addAction(m_samplerStr.arg(i), &m_actionMapper, SLOT(map()));
             m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-            addAvailableControl(ConfigKey(group, resetControl), resetDescription);
+            addAvailableControl(ConfigKey(group, resetControl), title, resetDescription);
         }
     }
 }
 
-void ControlPickerMenu::addMicrophoneAndAuxControl(QString control, QString controlDescription,
+void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
+                                                   QString title,
+                                                   QString controlDescription,
                                                    QMenu* pMenu,
                                                    bool microhoneControls,
                                                    bool auxControls,
@@ -652,14 +821,14 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control, QString cont
             QAction* pAction = controlMenu->addAction(m_microphoneStr.arg(i),
                                                       &m_actionMapper, SLOT(map()));
             m_actionMapper.setMapping(pAction, m_controlsAvailable.size());
-            addAvailableControl(ConfigKey(group, control), description);
+            addAvailableControl(ConfigKey(group, control), title, description);
 
             if (addReset) {
                 QString resetDescription = QString("%1 (%2)").arg(description, m_resetStr);
                 QAction* pResetAction = resetControlMenu->addAction(
                     m_microphoneStr.arg(i), &m_actionMapper, SLOT(map()));
                 m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-                addAvailableControl(ConfigKey(group, resetControl), resetDescription);
+                addAvailableControl(ConfigKey(group, resetControl), title, resetDescription);
             }
         }
     }
@@ -673,54 +842,72 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control, QString cont
             QAction* pAction = controlMenu->addAction(m_auxStr.arg(i),
                                                       &m_actionMapper, SLOT(map()));
             m_actionMapper.setMapping(pAction, m_controlsAvailable.size());
-            addAvailableControl(ConfigKey(group, control), description);
+            addAvailableControl(ConfigKey(group, control), title, description);
 
             if (addReset) {
                 QString resetDescription = QString("%1 (%2)").arg(description, m_resetStr);
                 QAction* pResetAction = resetControlMenu->addAction(
                     m_auxStr.arg(i), &m_actionMapper, SLOT(map()));
                 m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-                addAvailableControl(ConfigKey(group, resetControl), resetDescription);
+                addAvailableControl(ConfigKey(group, resetControl), title, resetDescription);
             }
         }
     }
 }
 
-void ControlPickerMenu::addDeckAndSamplerControl(QString control, QString controlDescription,
+void ControlPickerMenu::addDeckAndSamplerControl(QString control,
+                                                 QString controlDescription,
                                                  QMenu* pMenu,
                                                  bool addReset) {
-    addPlayerControl(control, controlDescription, pMenu, true, true, false, addReset);
+    addPlayerControl(control, controlDescription, controlDescription, pMenu, true, true, false, addReset);
 }
 
-void ControlPickerMenu::addDeckAndPreviewDeckControl(QString control, QString controlDescription,
+void ControlPickerMenu::addDeckAndSamplerControl(QString control,
+                                                 QString title,
+                                                 QString controlDescription,
+                                                 QMenu* pMenu,
+                                                 bool addReset) {
+    addPlayerControl(control, title, controlDescription, pMenu, true, true, false, addReset);
+}
+
+void ControlPickerMenu::addDeckAndPreviewDeckControl(QString control,
+                                                     QString title,
+                                                     QString controlDescription,
                                                      QMenu* pMenu,
                                                      bool addReset) {
-    addPlayerControl(control, controlDescription, pMenu, true, false, true, addReset);
+    addPlayerControl(control, title, controlDescription, pMenu, true, false, true, addReset);
 }
 
 void ControlPickerMenu::addDeckAndSamplerAndPreviewDeckControl(QString control,
+                                                               QString title,
                                                                QString controlDescription,
                                                                QMenu* pMenu,
                                                                bool addReset) {
-    addPlayerControl(control, controlDescription, pMenu, true, true, true, addReset);
+    addPlayerControl(control, title, controlDescription, pMenu, true, true, true, addReset);
 }
 
-void ControlPickerMenu::addDeckControl(QString control, QString controlDescription,
+void ControlPickerMenu::addDeckControl(QString control,
+                                       QString title,
+                                       QString controlDescription,
                                        QMenu* pMenu,
                                        bool addReset) {
-    addPlayerControl(control, controlDescription, pMenu, true, false, false, addReset);
+    addPlayerControl(control, title, controlDescription, pMenu, true, false, false, addReset);
 }
 
-void ControlPickerMenu::addSamplerControl(QString control, QString controlDescription,
+void ControlPickerMenu::addSamplerControl(QString control,
+                                          QString title,
+                                          QString controlDescription,
                                           QMenu* pMenu,
                                           bool addReset) {
-    addPlayerControl(control, controlDescription, pMenu, false, true, false, addReset);
+    addPlayerControl(control, title, controlDescription, pMenu, false, true, false, addReset);
 }
 
-void ControlPickerMenu::addPreviewDeckControl(QString control, QString controlDescription,
+void ControlPickerMenu::addPreviewDeckControl(QString control,
+                                              QString title,
+                                              QString controlDescription,
                                               QMenu* pMenu,
                                               bool addReset) {
-    addPlayerControl(control, controlDescription, pMenu, false, false, true, addReset);
+    addPlayerControl(control, title, controlDescription, pMenu, false, false, true, addReset);
 }
 
 QMenu* ControlPickerMenu::addSubmenu(QString title, QMenu* pParent) {
@@ -740,16 +927,17 @@ void ControlPickerMenu::controlChosen(int controlIndex) {
 }
 
 void ControlPickerMenu::addAvailableControl(ConfigKey key,
+                                            QString title,
                                             QString description) {
     m_controlsAvailable.append(key);
     m_descriptionsByKey.insert(key, description);
+    m_titlesByKey.insert(key, title);
 }
 
 QString ControlPickerMenu::descriptionForConfigKey(ConfigKey key) const {
     return m_descriptionsByKey.value(key, QString());
 }
 
-QString ControlPickerMenu::prettyNameForConfigKey(ConfigKey key) const {
-    // We need a short name list.
-    return m_descriptionsByKey.value(key, QString());
+QString ControlPickerMenu::controlTitleForConfigKey(ConfigKey key) const {
+    return m_titlesByKey.value(key, QString());
 }

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -971,6 +971,10 @@ void ControlPickerMenu::addAvailableControl(ConfigKey key,
     m_titlesByKey.insert(key, title);
 }
 
+bool ControlPickerMenu::controlExists(ConfigKey key) const {
+    return m_titlesByKey.contains(key);
+}
+
 QString ControlPickerMenu::descriptionForConfigKey(ConfigKey key) const {
     return m_descriptionsByKey.value(key, QString());
 }

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -14,8 +14,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     connect(&m_actionMapper, SIGNAL(mapped(int)),
             this, SLOT(controlChosen(int)));
 
-    m_effectMasterOutputStr = tr("Effect Master Output");
-    m_effectHeadphoneOutputStr = tr("Effect Headphone Output");
+    m_effectMasterOutputStr = tr("Master Output");
+    m_effectHeadphoneOutputStr = tr("Headphone Output");
     m_deckStr = tr("Deck %1");
     m_samplerStr = tr("Sampler %1");
     m_previewdeckStr = tr("Preview Deck %1");
@@ -383,37 +383,37 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             QMenu* effectUnitMenu = addSubmenu(m_effectUnitStr.arg(iEffectUnitNumber),
                                                rackMenu);
             addEffectControl(effectUnitGroup, "clear",
-                             tr("Effect Unit Clear"),
+                             tr("Unit Clear"),
                              tr("Clear effect unit"), descriptionPrefix,
                              effectUnitMenu);
             addEffectControl(effectUnitGroup, "enabled",
-                             tr("Effect Unit Toggle"),
+                             tr("Unit Toggle"),
                              tr("Toggle effect unit"), descriptionPrefix,
                              effectUnitMenu, false);
             addEffectControl(effectUnitGroup, "mix",
-                             tr("Effect Dry/Wet"),
+                             tr("Dry/Wet"),
                              tr("Dry/Wet"), descriptionPrefix,
                              effectUnitMenu, true);
             addEffectControl(effectUnitGroup, "parameter",
-                             tr("Effect Super Knob"),
+                             tr("Super Knob"),
                              tr("Super Knob (Control Linked Effect Parameters)"),
                              descriptionPrefix,
                              effectUnitMenu, true);
             addEffectControl(effectUnitGroup, "insertion_type",
-                             tr("Effect Insert / Send Toggle"),
+                             tr("Insert / Send Toggle"),
                              tr("Insert / Send Toggle"),
                              descriptionPrefix,
                              effectUnitMenu);
             addEffectControl(effectUnitGroup, "next_chain",
-                             tr("Effect Next Chain"),
+                             tr("Next Chain"),
                              tr("Next chain preset"), descriptionPrefix,
                              effectUnitMenu);
             addEffectControl(effectUnitGroup, "prev_chain",
-                             tr("Effect Previous Chain"),
+                             tr("Previous Chain"),
                              tr("Previous chain preset"), descriptionPrefix,
                              effectUnitMenu);
             addEffectControl(effectUnitGroup, "chain_selector",
-                             tr("Effect Chain Next/Previous"),
+                             tr("Chain Next/Previous"),
                              tr("Next or previous chain preset"), descriptionPrefix,
                              effectUnitMenu);
 
@@ -443,8 +443,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                 // TODO(owen): Fix bad i18n here.
                 addEffectControl(effectUnitGroup,
                                  QString("group_%1_enable").arg(playerGroup),
-                                 tr("Effects Enable ") + m_deckStr.arg(iDeckNumber),
-                                 tr("Effects Enable ") + m_deckStr.arg(iDeckNumber),
+                                 tr("Assign ") + m_deckStr.arg(iDeckNumber),
+                                 tr("Assign ") + m_deckStr.arg(iDeckNumber),
                                  groupDescriptionPrefix,
                                  effectUnitGroups);
 
@@ -459,8 +459,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                 // TODO(owen): Fix bad i18n here.
                 addEffectControl(effectUnitGroup,
                                  QString("group_%1_enable").arg(playerGroup),
-                                 tr("Effects Enable ") + m_samplerStr.arg(iSamplerNumber),
-                                 tr("Effects Enable ") + m_samplerStr.arg(iSamplerNumber),
+                                 tr("Assign ") + m_samplerStr.arg(iSamplerNumber),
+                                 tr("Assign ") + m_samplerStr.arg(iSamplerNumber),
                                  groupDescriptionPrefix,
                                  effectUnitGroups);
 
@@ -477,8 +477,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                 // TODO(owen): Fix bad i18n here.
                 addEffectControl(effectUnitGroup,
                                  QString("group_%1_enable").arg(micGroup),
-                                 tr("Effects Enable ") + m_microphoneStr.arg(iMicrophoneNumber),
-                                 tr("Effects Enable ") + m_microphoneStr.arg(iMicrophoneNumber),
+                                 tr("Assign ") + m_microphoneStr.arg(iMicrophoneNumber),
+                                 tr("Assign ") + m_microphoneStr.arg(iMicrophoneNumber),
                                  groupDescriptionPrefix,
                                  effectUnitGroups);
             }
@@ -491,8 +491,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                 // TODO(owen): Fix bad i18n here.
                 addEffectControl(effectUnitGroup,
                                  QString("group_%1_enable").arg(auxGroup),
-                                 tr("Effects Enable ") + m_auxStr.arg(iAuxiliaryNumber),
-                                 tr("Effects Enable ") + m_auxStr.arg(iAuxiliaryNumber),
+                                 tr("Assign ") + m_auxStr.arg(iAuxiliaryNumber),
+                                 tr("Assign ") + m_auxStr.arg(iAuxiliaryNumber),
                                  groupDescriptionPrefix,
                                  effectUnitGroups);
             }
@@ -513,23 +513,23 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                                               m_effectStr.arg(iEffectSlotNumber));
 
                 addEffectControl(effectSlotGroup, "clear",
-                                 tr("Effect Clear"), tr("Clear the current effect"),
+                                 tr("Clear"), tr("Clear the current effect"),
                                  slotDescriptionPrefix,
                                  effectSlotMenu);
                 addEffectControl(effectSlotGroup, "enabled",
-                                 tr("Effect Toggle"), tr("Toggle the current effect"),
+                                 tr("Toggle"), tr("Toggle the current effect"),
                                  slotDescriptionPrefix,
                                  effectSlotMenu);
                 addEffectControl(effectSlotGroup, "next_effect",
-                                 tr("Effect Next"), tr("Switch to next effect"),
+                                 tr("Next"), tr("Switch to next effect"),
                                  slotDescriptionPrefix,
                                  effectSlotMenu);
                 addEffectControl(effectSlotGroup, "prev_effect",
-                                 tr("Previous effect"), tr("Switch to the previous effect"),
+                                 tr("Previous"), tr("Switch to the previous effect"),
                                  slotDescriptionPrefix,
                                  effectSlotMenu);
                 addEffectControl(effectSlotGroup, "effect_selector",
-                                 tr("Effect Next or Previous"),
+                                 tr("Next or Previous"),
                                  tr("Switch to either next or previous effect"),
                                  slotDescriptionPrefix,
                                  effectSlotMenu);
@@ -553,13 +553,13 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
                     // Likely to change soon.
                     addEffectControl(parameterSlotGroup, parameterSlotItemPrefix,
-                                     tr("Effect Parameter Value"),
-                                     tr("Effect Parameter Value"),
+                                     tr("Parameter Value"),
+                                     tr("Parameter Value"),
                                      parameterDescriptionPrefix,
                                      parameterSlotMenu, true);
 
                     addEffectControl(parameterSlotGroup, parameterSlotItemPrefix + "_link_type",
-                                     tr("Effect Super Knob Mode"),
+                                     tr("Super Knob Mode"),
                                      tr("3-state Super Knob Link Toggle (unlinked, linear, inverse)"),
                                      parameterDescriptionPrefix,
                                      parameterSlotMenu);

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -57,8 +57,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                                            tr("Stop playback and jump to start of track"), transportMenu);
     addDeckAndSamplerAndPreviewDeckControl("end", tr("Jump to End"), tr("Jump to end of track"), transportMenu);
     addDeckAndSamplerControl("volume", tr("Volume"), tr("Volume Fader"), transportMenu, true);
-    addDeckAndSamplerControl("volume_set_one", tr("Volume Full"), tr("Sets volume to full"), transportMenu);
-    addDeckAndSamplerControl("volume_set_zero", tr("Volume Zero"), tr("Sets volume to zero"), transportMenu);
+    addDeckAndSamplerControl("volume_set_one", tr("Full Volume"), tr("Sets volume to full"), transportMenu);
+    addDeckAndSamplerControl("volume_set_zero", tr("Zero Volume"), tr("Sets volume to zero"), transportMenu);
     addDeckAndSamplerAndPreviewDeckControl("pregain", tr("Track Gain"), tr("Track Gain knob"), transportMenu, true);
     addDeckAndSamplerControl("mute", tr("Mute"), tr("Mute button"), transportMenu);
     addDeckAndSamplerAndPreviewDeckControl("eject", tr("Eject"), tr("Eject track"), transportMenu);
@@ -107,7 +107,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addDeckAndSamplerControl("sync_master", tr("Sync Master"), tr("Toggle sync master"), syncMenu);
     addDeckAndSamplerControl("sync_mode", tr("Sync Mode"),
                              tr("Sync mode 3-state toggle (OFF, FOLLOWER, MASTER)"), syncMenu);
-    addDeckAndSamplerControl("beatsync", tr("Sync Beat One-shot"),
+    addDeckAndSamplerControl("beatsync", tr("Beat Sync One-shot"),
                              tr("One-time beat sync (tempo and phase)"), syncMenu);
     addDeckAndSamplerControl("beatsync_tempo", tr("Sync Tempo One-shot"),
                              tr("One-time beat sync (tempo only)"), syncMenu);
@@ -140,16 +140,16 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
     // EQs
     QMenu* eqMenu = addSubmenu(tr("Equalizers"));
-    addDeckControl("filterHigh", tr("EQ High"), tr("High EQ knob"), eqMenu, true);
-    addDeckControl("filterMid", tr("EQ Mid"), tr("Mid EQ knob"), eqMenu, true);
-    addDeckControl("filterLow", tr("EQ Low"), tr("Low EQ knob"), eqMenu, true);
-    addDeckControl("filterHighKill", tr("EQ Kill High"), tr("High EQ kill"), eqMenu);
-    addDeckControl("filterMidKill", tr("EQ Kill Mid"), tr("Mid EQ kill"), eqMenu);
-    addDeckControl("filterLowKill", tr("EQ Kill Low"), tr("Low EQ kill"), eqMenu);
+    addDeckControl("filterHigh", tr("High EQ"), tr("High EQ knob"), eqMenu, true);
+    addDeckControl("filterMid", tr("Mid EQ"), tr("Mid EQ knob"), eqMenu, true);
+    addDeckControl("filterLow", tr("Low EQ"), tr("Low EQ knob"), eqMenu, true);
+    addDeckControl("filterHighKill", tr("Kill EQ High"), tr("High EQ kill"), eqMenu);
+    addDeckControl("filterMidKill", tr("Kill EQ Mid"), tr("Mid EQ kill"), eqMenu);
+    addDeckControl("filterLowKill", tr("Kill EQ Low"), tr("Low EQ kill"), eqMenu);
 
     // Vinyl Control
     QMenu* vinylControlMenu = addSubmenu(tr("Vinyl Control"));
-    addDeckControl("vinylcontrol_enabled", tr("Vinyl Control Toggle"),
+    addDeckControl("vinylcontrol_enabled", tr("Toggle Vinyl Control"),
                    tr("Toggle Vinyl Control (ON/OFF)"), vinylControlMenu);
     addDeckControl("vinylcontrol_mode", tr("Vinyl Control Mode"),
                    tr("Toggle vinyl-control mode (ABS/REL/CONST)"), vinylControlMenu);
@@ -163,28 +163,28 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     // Cues
     QMenu* cueMenu = addSubmenu(tr("Cues"));
     addDeckControl("cue_default", tr("Cue"), tr("Cue button"), cueMenu);
-    addDeckControl("cue_set", tr("Cue Set"), tr("Set cue point"), cueMenu);
-    addDeckControl("cue_goto", tr("Cue Go-To"), tr("Go to cue point"), cueMenu);
-    addDeckControl("cue_gotoandplay", tr("Cue Go-To and Play"),
+    addDeckControl("cue_set", tr("Set Cue"), tr("Set cue point"), cueMenu);
+    addDeckControl("cue_goto", tr("Go-To Cue"), tr("Go to cue point"), cueMenu);
+    addDeckControl("cue_gotoandplay", tr("Go-To Cue and Play"),
                    tr("Go to cue point and play"), cueMenu);
-    addDeckControl("cue_gotoandstop", tr("Cue Go-To and Stop"),
+    addDeckControl("cue_gotoandstop", tr("Go-To Cue and Stop"),
                    tr("Go to cue point and stop"), cueMenu);
-    addDeckControl("cue_preview", tr("Cue Preview"),
+    addDeckControl("cue_preview", tr("Preview Cue"),
                    tr("Preview from cue point"), cueMenu);
     addDeckControl("cue_cdj", tr("Cue (CDJ mode)"),
                    tr("Cue button (CDJ mode)"), cueMenu);
-    addDeckControl("play_stutter", tr("Cue Stutter"),
+    addDeckControl("play_stutter", tr("Stutter Cue"),
                    tr("Stutter cue"), cueMenu);
 
     // Hotcues
     QMenu* hotcueMenu = addSubmenu(tr("Hotcues"));
     QString hotcueActivateTitle = tr("Hotcue %1");
-    QString hotcueClearTitle = tr("Hotcue Clear %1");
-    QString hotcueSetTitle = tr("Hotcue Set %1");
-    QString hotcueGotoTitle = tr("Hotcue Jump %1");
-    QString hotcueGotoAndStopTitle = tr("Hotcue %1 Jump To and Stop");
-    QString hotcueGotoAndPlayTitle = tr("Hotcue %1 Jump To and Play");
-    QString hotcuePreviewTitle = tr("Hotcue Preview %1");
+    QString hotcueClearTitle = tr("Clear Hotcue %1");
+    QString hotcueSetTitle = tr("Set Hotcue %1");
+    QString hotcueGotoTitle = tr("Jump to Hotcue %1");
+    QString hotcueGotoAndStopTitle = tr("Jump To Hotcue %1 and Stop");
+    QString hotcueGotoAndPlayTitle = tr("Jump To Hotcue %1 and Play");
+    QString hotcuePreviewTitle = tr("Preview Hotcue %1");
     QString hotcueActivateDescription = tr("Set, preview from or jump to hotcue %1");
     QString hotcueClearDescription = tr("Clear hotcue %1");
     QString hotcueSetDescription = tr("Set hotcue %1");
@@ -229,7 +229,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addDeckControl("loop_in", tr("Loop In"), tr("Loop In button"), loopMenu);
     addDeckControl("loop_out", tr("Loop Out"), tr("Loop Out button"), loopMenu);
     addDeckControl("loop_exit", tr("Loop Exit"), tr("Loop Exit button"), loopMenu);
-    addDeckControl("reloop_exit", tr("Loop Reloop / Exit"), tr("Reloop / Exit button"), loopMenu);
+    addDeckControl("reloop_exit", tr("Reloop / Exit Loop"), tr("Reloop / Exit button"), loopMenu);
     addDeckControl("loop_halve", tr("Loop Halve"), tr("Halve the current loop's length"), loopMenu);
     addDeckControl("loop_double", tr("Loop Double"),
                    tr("Double the current loop's length"), loopMenu);
@@ -251,8 +251,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     humanBeatSizes[64] = tr("64");
 
     // Loop moving
-    QString loopMoveForwardTitle = tr("Loop Move +%1 beats");
-    QString loopMoveBackwardTitle = tr("Loop Move -%1 beats");
+    QString loopMoveForwardTitle = tr("Move Loop +%1 beats");
+    QString loopMoveBackwardTitle = tr("Move Loop -%1 beats");
     QString loopMoveForwardDescription = tr("Move loop forward by %1 beats");
     QString loopMoveBackwardDescription = tr("Move loop backward by %1 beats");
 
@@ -315,39 +315,39 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     // Library Controls
     QMenu* libraryMenu = addSubmenu(tr("Library"));
     addControl("[Playlist]", "ToggleSelectedSidebarItem",
-               tr("View Expand/Collapse"),
+               tr("Expand/Collapse View"),
                tr("Expand/collapse the selected view (library, playlist..)"),
                libraryMenu);
     addControl("[Playlist]", "SelectPlaylist",
-               tr("View Switch Next/Previous"),
+               tr("Switch Next/Previous View"),
                tr("Switch to the next or previous view (library, playlist..)"),
                libraryMenu);
     addControl("[Playlist]", "SelectNextPlaylist",
-               tr("View Switch Next"),
+               tr("Switch To Next View"),
                tr("Switch to the next view (library, playlist..)"),
                libraryMenu);
     addControl("[Playlist]", "SelectPrevPlaylist",
-               tr("View Switch Previous"),
+               tr("Switch To Previous View"),
                tr("Switch to the previous view (library, playlist..)"),
                libraryMenu);
     addControl("[Playlist]", "SelectTrackKnob",
-               tr("View Scroll Next/Previous"),
+               tr("Scroll To Next/Previous Track"),
                tr("Scroll up or down in library/playlist"),
                libraryMenu);
     addControl("[Playlist]", "SelectNextTrack",
-               tr("View Scroll Next"),
+               tr("Scroll To Next Track"),
                tr("Scroll to next track in library/playlist"),
                libraryMenu);
     addControl("[Playlist]", "SelectPrevTrack",
-               tr("View Scroll Previous"),
+               tr("Scroll To Previous Track"),
                tr("Scroll to previous track in library/playlist"),
                libraryMenu);
     addControl("[Playlist]", "LoadSelectedIntoFirstStopped",
-               tr("View Load Track Into Stopped"),
+               tr("Load Track Into Stopped Deck"),
                tr("Load selected track into first stopped deck"),
                libraryMenu);
     addDeckAndSamplerControl("LoadSelectedTrack",
-                             tr("View Load Track"),
+                             tr("Load Track"),
                              tr("Load selected track"), libraryMenu);
     addDeckAndSamplerAndPreviewDeckControl("LoadSelectedTrackAndPlay", tr("Track Load and Play"),
                                            tr("Load selected track and play"), libraryMenu);
@@ -367,7 +367,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
         QString descriptionPrefix = m_effectRackStr.arg(iRackNumber);
 
         addEffectControl(rackGroup, "clear",
-                         tr("Effect Rack Clear"), tr("Clear effect rack"),
+                         tr("Clear Effect Rack"), tr("Clear effect rack"),
                          descriptionPrefix, rackMenu);
 
         const int numEffectUnits = ControlObject::get(
@@ -383,11 +383,11 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             QMenu* effectUnitMenu = addSubmenu(m_effectUnitStr.arg(iEffectUnitNumber),
                                                rackMenu);
             addEffectControl(effectUnitGroup, "clear",
-                             tr("Unit Clear"),
+                             tr("Clear Unit"),
                              tr("Clear effect unit"), descriptionPrefix,
                              effectUnitMenu);
             addEffectControl(effectUnitGroup, "enabled",
-                             tr("Unit Toggle"),
+                             tr("Toggle Unit"),
                              tr("Toggle effect unit"), descriptionPrefix,
                              effectUnitMenu, false);
             addEffectControl(effectUnitGroup, "mix",
@@ -413,7 +413,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                              tr("Previous chain preset"), descriptionPrefix,
                              effectUnitMenu);
             addEffectControl(effectUnitGroup, "chain_selector",
-                             tr("Chain Next/Previous"),
+                             tr("Next/Previous Chain"),
                              tr("Next or previous chain preset"), descriptionPrefix,
                              effectUnitMenu);
 

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -14,8 +14,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     connect(&m_actionMapper, SIGNAL(mapped(int)),
             this, SLOT(controlChosen(int)));
 
-    m_masterOutputStr = tr("Master Output");
-    m_headphoneOutputStr = tr("Headphone Output");
+    m_effectMasterOutputStr = tr("Effect Master Output");
+    m_effectHeadphoneOutputStr = tr("Effect Headphone Output");
     m_deckStr = tr("Deck %1");
     m_samplerStr = tr("Sampler %1");
     m_previewdeckStr = tr("Preview Deck %1");
@@ -30,41 +30,41 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     // Master Controls
     QMenu* mixerMenu = addSubmenu(tr("Mixer"));
     addControl("[Master]", "crossfader", tr("Crossfader"), tr("Crossfader"), mixerMenu, true);
-    addControl("[Master]", "volume", tr("Master volume"), tr("Master volume"), mixerMenu, true);
-    addControl("[Master]", "balance", tr("Master balance"), tr("Master balance"), mixerMenu, true);
-    addControl("[Master]", "delay", tr("Master delay"), tr("Master delay"), mixerMenu, true);
-    addControl("[Master]", "headVolume", tr("Headphone volume"), tr("Headphone volume"), mixerMenu, true);
-    addControl("[Master]", "headMix", tr("Headphone mix (pre/main)"), tr("Headphone mix (pre/main)"), mixerMenu, true);
-    addControl("[Master]", "headSplit", tr("Headphone split cue"), tr("Toggle headphone split cueing"), mixerMenu);
-    addControl("[Master]", "headDelay", tr("Headphone delay"), tr("Headphone delay"), mixerMenu, true);
+    addControl("[Master]", "volume", tr("Master Volume"), tr("Master volume"), mixerMenu, true);
+    addControl("[Master]", "balance", tr("Master Balance"), tr("Master balance"), mixerMenu, true);
+    addControl("[Master]", "delay", tr("Master Delay"), tr("Master delay"), mixerMenu, true);
+    addControl("[Master]", "headVolume", tr("Headphone Volume"), tr("Headphone volume"), mixerMenu, true);
+    addControl("[Master]", "headMix", tr("Headphone Mix (pre/main)"), tr("Headphone mix (pre/main)"), mixerMenu, true);
+    addControl("[Master]", "headSplit", tr("Headphone Split Cue"), tr("Toggle headphone split cueing"), mixerMenu);
+    addControl("[Master]", "headDelay", tr("Headphone Delay"), tr("Headphone delay"), mixerMenu, true);
 
     // Transport
     QMenu* transportMenu = addSubmenu(tr("Transport"));
-    addDeckAndSamplerAndPreviewDeckControl("playposition", tr("Strip Search"),
-                                           tr("Strip-search through track"), transportMenu);
     addDeckAndSamplerAndPreviewDeckControl("play", tr("Play"), tr("Play button"), transportMenu);
     // Preview deck does not go to master so volume does not matter.
-    addDeckAndSamplerControl("volume", tr("Volume"), tr("Volume fader"), transportMenu, true);
-    addDeckAndSamplerControl("volume_set_one", tr("Full volume"), tr("Sets volume to full"), transportMenu);
-    addDeckAndSamplerControl("volume_set_zero", tr("Zero volume"), tr("Sets volume to zero"), transportMenu);
     addDeckAndSamplerAndPreviewDeckControl("back", tr("Fast Rewind"), tr("Fast Rewind button"), transportMenu);
     addDeckAndSamplerAndPreviewDeckControl("fwd", tr("Fast Forward"), tr("Fast Forward button"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("stop", tr("Stop"), tr("Stop button"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("start", tr("Jump to start"), tr("Jumps to start of track"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("start_play", tr("Play From Start"),
-                                           tr("Jump to start of track and play"), transportMenu);
-    addDeckAndSamplerAndPreviewDeckControl("start_stop", tr("Stop and Jump to start"),
-                                           tr("Stop playnack and jump to start of track"), transportMenu);
-
-    addDeckAndSamplerAndPreviewDeckControl("end", tr("Jump to End"), tr("Jump to end of track"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("playposition", tr("Strip Search"),
+                                           tr("Strip-search through track"), transportMenu);
     addDeckAndSamplerAndPreviewDeckControl("reverse", tr("Play Reverse"), tr("Play Reverse button"), transportMenu);
     addDeckAndSamplerAndPreviewDeckControl("reverseroll", tr("Reverse Roll (Censor)"),
                                            tr("Reverse roll (Censor) button"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("start", tr("Jump to Start"), tr("Jumps to start of track"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("start_play", tr("Play From Start"),
+                                           tr("Jump to start of track and play"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("stop", tr("Stop"), tr("Stop button"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("start_stop", tr("Stop and Jump to Start"),
+                                           tr("Stop playback and jump to start of track"), transportMenu);
+    addDeckAndSamplerAndPreviewDeckControl("end", tr("Jump to End"), tr("Jump to end of track"), transportMenu);
+    addDeckAndSamplerControl("volume", tr("Volume"), tr("Volume Fader"), transportMenu, true);
+    addDeckAndSamplerControl("volume_set_one", tr("Volume Full"), tr("Sets volume to full"), transportMenu);
+    addDeckAndSamplerControl("volume_set_zero", tr("Volume Zero"), tr("Sets volume to zero"), transportMenu);
     addDeckAndSamplerAndPreviewDeckControl("pregain", tr("Track Gain"), tr("Track Gain knob"), transportMenu, true);
-    addDeckAndSamplerControl("pfl", tr("Headphone listen"), tr("Headphone listen (pfl) button"), transportMenu);
     addDeckAndSamplerControl("mute", tr("Mute"), tr("Mute button"), transportMenu);
-    addDeckAndSamplerControl("repeat", tr("Repeat Mode"), tr("Toggle repeat mode"), transportMenu);
     addDeckAndSamplerAndPreviewDeckControl("eject", tr("Eject"), tr("Eject track"), transportMenu);
+    addDeckAndSamplerControl("pfl", tr("Headphone listen"), tr("Headphone listen (pfl) button"), transportMenu);
+    addDeckAndSamplerControl("repeat", tr("Repeat Mode"), tr("Toggle repeat mode"), transportMenu);
+    addDeckAndSamplerControl("slip_enabled", tr("Slip Mode"), tr("Toggle slip mode"), transportMenu);
     addDeckAndSamplerControl("orientation", tr("Orientation"),
                              tr("Mix orientation (e.g. left, right, center)"), transportMenu);
     addDeckAndSamplerControl("orientation_left", tr("Orient Left"),
@@ -73,10 +73,9 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                              tr("Set mix orientation to center"), transportMenu);
     addDeckAndSamplerControl("orientation_right", tr("Orient Right"),
                              tr("Set mix orientation to right"), transportMenu);
-    addDeckAndSamplerControl("slip_enabled", tr("Slip Mode"), tr("Toggle slip mode"), transportMenu);
 
     // BPM & Sync
-    QMenu* bpmMenu = addSubmenu(tr("BPM and Sync"));
+    QMenu* bpmMenu = addSubmenu(tr("BPM"));
     addDeckAndSamplerControl("bpm", tr("BPM"), tr("BPM"), bpmMenu, true);
     addDeckAndSamplerControl("bpm_up", tr("BPM +1"), tr("Increase BPM by 1"), bpmMenu);
     addDeckAndSamplerControl("bpm_down", tr("BPM -1"), tr("Decrease BPM by 1"), bpmMenu);
@@ -86,31 +85,34 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addDeckControl("beats_translate_curpos", tr("BPM Adjust Beatgrid"),
                    tr("Align beatgrid to current position"), bpmMenu);
     addDeckAndSamplerControl("quantize", tr("Quantize Mode"), tr("Toggle quantize mode"), bpmMenu);
+
+    QMenu* syncMenu = addSubmenu(tr("BPM"));
+
     addDeckAndSamplerControl("sync_enabled", tr("Sync Mode"),
-                             tr("Tap to sync, hold to enable sync mode"), bpmMenu);
+                             tr("Tap to sync, hold to enable sync mode"), syncMenu);
     addControl("[InternalClock]", "sync_master", tr("Internal Sync Master"),
-               tr("Toggle Internal Sync Master"), bpmMenu);
+               tr("Toggle Internal Sync Master"), syncMenu);
     addControl("[InternalClock]", "bpm", tr("Internal Master BPM"),
-               tr("Internal master BPM"), bpmMenu);
+               tr("Internal Master BPM"), syncMenu);
     addControl("[InternalClock]", "bpm_up", tr("Internal Master BPM +1"),
-               tr("Increase internal master BPM by 1"), bpmMenu);
+               tr("Increase internal master BPM by 1"), syncMenu);
 
     addControl("[InternalClock]", "bpm_down", tr("Internal Master BPM -1"),
-               tr("Decrease internal master BPM by 1"), bpmMenu);
+               tr("Decrease internal master BPM by 1"), syncMenu);
 
     addControl("[InternalClock]", "bpm_up_small", tr("Internal Master BPM +0.1"),
-               tr("Increase internal master BPM by 0.1"), bpmMenu);
+               tr("Increase internal master BPM by 0.1"), syncMenu);
     addControl("[InternalClock]", "bpm_down_small", tr("Internal Master BPM -0.1"),
-               tr("Decrease internal master BPM by 0.1"), bpmMenu);
-    addDeckAndSamplerControl("sync_master", tr("Sync Master"), tr("Toggle sync master"), bpmMenu);
+               tr("Decrease internal master BPM by 0.1"), syncMenu);
+    addDeckAndSamplerControl("sync_master", tr("Sync Master"), tr("Toggle sync master"), syncMenu);
     addDeckAndSamplerControl("sync_mode", tr("Sync Mode"),
-                             tr("Sync mode 3-state toggle (OFF, FOLLOWER, MASTER)"), bpmMenu);
+                             tr("Sync mode 3-state toggle (OFF, FOLLOWER, MASTER)"), syncMenu);
     addDeckAndSamplerControl("beatsync", tr("Sync Beat One-shot"),
-                             tr("One-time beat sync (tempo and phase)"), bpmMenu);
+                             tr("One-time beat sync (tempo and phase)"), syncMenu);
     addDeckAndSamplerControl("beatsync_tempo", tr("Sync Tempo One-shot"),
-                             tr("One-time beat sync (tempo only)"), bpmMenu);
+                             tr("One-time beat sync (tempo only)"), syncMenu);
     addDeckAndSamplerControl("beatsync_phase", tr("Sync Phase One-shot"),
-                             tr("One-time beat sync (phase only)"), bpmMenu);
+                             tr("One-time beat sync (phase only)"), syncMenu);
 
     // Rate
     QMenu* rateMenu = addSubmenu(tr("Pitch and Rate"));
@@ -120,7 +122,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                              tr("Playback speed control slider"), rateMenu, true);
     addDeckAndSamplerControl("pitch", tr("Pitch Slider (musical)"),
                              tr("Pitch control slider (does not affect speed)"), rateMenu, true);
-    addDeckAndSamplerControl("sync_key", tr("Sync key"), tr("Match musical key"), rateMenu, true);
+    addDeckAndSamplerControl("sync_key", tr("Sync Key"), tr("Match musical key"), rateMenu, true);
     addDeckAndSamplerControl("rate_perm_up", tr("Rate Up"), tr("Adjust rate up (coarse)"), rateMenu);
     addDeckAndSamplerControl("rate_perm_up_small", tr("Rate Up (fine)"),
                              tr("Adjust rate up (fine)"), rateMenu);
@@ -141,9 +143,9 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addDeckControl("filterHigh", tr("EQ High"), tr("High EQ knob"), eqMenu, true);
     addDeckControl("filterMid", tr("EQ Mid"), tr("Mid EQ knob"), eqMenu, true);
     addDeckControl("filterLow", tr("EQ Low"), tr("Low EQ knob"), eqMenu, true);
-    addDeckControl("filterHighKill", tr("EQ High kill"), tr("High EQ kill"), eqMenu);
-    addDeckControl("filterMidKill", tr("EQ Mid kill"), tr("Mid EQ kill"), eqMenu);
-    addDeckControl("filterLowKill", tr("EQ Low kill"), tr("Low EQ kill"), eqMenu);
+    addDeckControl("filterHighKill", tr("EQ Kill High"), tr("High EQ kill"), eqMenu);
+    addDeckControl("filterMidKill", tr("EQ Kill Mid"), tr("Mid EQ kill"), eqMenu);
+    addDeckControl("filterLowKill", tr("EQ Kill Low"), tr("Low EQ kill"), eqMenu);
 
     // Vinyl Control
     QMenu* vinylControlMenu = addSubmenu(tr("Vinyl Control"));
@@ -291,8 +293,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
     // Beat jumping
     QMenu* beatJumpMenu = addSubmenu(tr("Beat-Jump"));
-    QString beatJumpForwardTitle = tr("Jump +%1 beats");
-    QString beatJumpBackwardTitle = tr("Jump -%1 beats");
+    QString beatJumpForwardTitle = tr("Jump Forward %1 beats");
+    QString beatJumpBackwardTitle = tr("Jump Back %1 beats");
     QString beatJumpForwardDescription = tr("Jump forward by %1 beats");
     QString beatJumpBackwardDescription = tr("Jump backward by %1 beats");
 
@@ -425,10 +427,12 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                     enableOn);
 
             addEffectControl(effectUnitGroup, "group_[Master]_enable",
-                             m_masterOutputStr, groupDescriptionPrefix,
+                             m_effectMasterOutputStr,
+                             m_effectMasterOutputStr, groupDescriptionPrefix,
                              effectUnitGroups);
             addEffectControl(effectUnitGroup, "group_[Headphone]_enable",
-                             m_headphoneOutputStr, groupDescriptionPrefix,
+                             m_effectHeadphoneOutputStr,
+                             m_effectHeadphoneOutputStr, groupDescriptionPrefix,
                              effectUnitGroups);
 
             const int iNumDecks = ControlObject::get(
@@ -436,9 +440,11 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             for (int iDeckNumber = 1; iDeckNumber <= iNumDecks; ++iDeckNumber) {
                 // PlayerManager::groupForDeck is 0-indexed.
                 QString playerGroup = PlayerManager::groupForDeck(iDeckNumber - 1);
+                // TODO(owen): Fix bad i18n here.
                 addEffectControl(effectUnitGroup,
                                  QString("group_%1_enable").arg(playerGroup),
-                                 m_deckStr.arg(iDeckNumber),
+                                 tr("Effects Enable ") + m_deckStr.arg(iDeckNumber),
+                                 tr("Effects Enable ") + m_deckStr.arg(iDeckNumber),
                                  groupDescriptionPrefix,
                                  effectUnitGroups);
 
@@ -450,9 +456,11 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                  ++iSamplerNumber) {
                 // PlayerManager::groupForSampler is 0-indexed.
                 QString playerGroup = PlayerManager::groupForSampler(iSamplerNumber - 1);
+                // TODO(owen): Fix bad i18n here.
                 addEffectControl(effectUnitGroup,
                                  QString("group_%1_enable").arg(playerGroup),
-                                 m_samplerStr.arg(iSamplerNumber),
+                                 tr("Effects Enable ") + m_samplerStr.arg(iSamplerNumber),
+                                 tr("Effects Enable ") + m_samplerStr.arg(iSamplerNumber),
                                  groupDescriptionPrefix,
                                  effectUnitGroups);
 
@@ -466,9 +474,11 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                 if (iMicrophoneNumber > 1) {
                     micGroup = QString("[Microphone%1]").arg(iMicrophoneNumber);
                 }
+                // TODO(owen): Fix bad i18n here.
                 addEffectControl(effectUnitGroup,
                                  QString("group_%1_enable").arg(micGroup),
-                                 m_microphoneStr.arg(iMicrophoneNumber),
+                                 tr("Effects Enable ") + m_microphoneStr.arg(iMicrophoneNumber),
+                                 tr("Effects Enable ") + m_microphoneStr.arg(iMicrophoneNumber),
                                  groupDescriptionPrefix,
                                  effectUnitGroups);
             }
@@ -478,9 +488,11 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             for (int iAuxiliaryNumber = 1; iAuxiliaryNumber <= iNumAuxiliaries;
                  ++iAuxiliaryNumber) {
                 QString auxGroup = QString("[Auxiliary%1]").arg(iAuxiliaryNumber);
+                // TODO(owen): Fix bad i18n here.
                 addEffectControl(effectUnitGroup,
                                  QString("group_%1_enable").arg(auxGroup),
-                                 m_auxStr.arg(iAuxiliaryNumber),
+                                 tr("Effects Enable ") + m_auxStr.arg(iAuxiliaryNumber),
+                                 tr("Effects Enable ") + m_auxStr.arg(iAuxiliaryNumber),
                                  groupDescriptionPrefix,
                                  effectUnitGroups);
             }
@@ -500,19 +512,25 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                     m_effectStr.arg(iEffectSlotNumber)));
 
                 addEffectControl(effectSlotGroup, "clear",
-                                 tr("Clear effect"), descriptionPrefix,
+                                 tr("Effect Clear"), tr("Clear the current effect"),
+                                 descriptionPrefix,
                                  effectSlotMenu);
                 addEffectControl(effectSlotGroup, "enabled",
-                                 tr("Toggle effect"), descriptionPrefix,
+                                 tr("Effect Toggle"), tr("Toggle the current effect"),
+                                 descriptionPrefix,
                                  effectSlotMenu);
                 addEffectControl(effectSlotGroup, "next_effect",
-                                 tr("Next effect"), descriptionPrefix,
+                                 tr("Effect Next"), tr("Switch to next effect"),
+                                 descriptionPrefix,
                                  effectSlotMenu);
                 addEffectControl(effectSlotGroup, "prev_effect",
-                                 tr("Previous effect"), descriptionPrefix,
+                                 tr("Previous effect"), tr("Switch to the previous effect"),
+                                 descriptionPrefix,
                                  effectSlotMenu);
                 addEffectControl(effectSlotGroup, "effect_selector",
-                                 tr("Next or previous effect"), descriptionPrefix,
+                                 tr("Effect Next or Previous"),
+                                 tr("Switch to either next or previous effect"),
+                                 descriptionPrefix,
                                  effectSlotMenu);
 
                 const int numParameterSlots = ControlObject::get(
@@ -533,10 +551,13 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
                     // Likely to change soon.
                     addEffectControl(parameterSlotGroup, parameterSlotItemPrefix,
-                                     tr("Parameter value"), descriptionPrefix,
+                                     tr("Effect Parameter Value"),
+                                     tr("Effect Parameter Value"),
+                                     descriptionPrefix,
                                      parameterSlotMenu, true);
 
                     addEffectControl(parameterSlotGroup, parameterSlotItemPrefix + "_link_type",
+                                     tr("Effect Super Knob Mode"),
                                      tr("3-state Super Knob Link Toggle (unlinked, linear, inverse)"),
                                      descriptionPrefix, parameterSlotMenu);
 
@@ -569,25 +590,25 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     QMenu* microphoneMenu = addSubmenu(tr("Microphone / Auxiliary"));
 
     addMicrophoneAndAuxControl("talkover",
-                               tr("Microphone on/off"),
+                               tr("Microphone On/Off"),
                                tr("Microphone on/off"), microphoneMenu,
                                true, false);
     addControl("[Master]", "duckStrength",
-               tr("Microphone ducking strength"),
-               tr("Microphone ducking strength"),
+               tr("Microphone Ducking Strength"),
+               tr("Microphone Ducking Strength"),
                microphoneMenu, true);
     addControl("[Master]", "talkoverDucking",
                tr("Microphone Ducking Mode"),
                tr("Toggle microphone ducking mode (OFF, AUTO, MANUAL)"),
                microphoneMenu);
     addMicrophoneAndAuxControl("passthrough",
-                               tr("Auxiliary on/off"),
+                               tr("Auxiliary On/Off"),
                                tr("Auxiliary on/off"),
                                microphoneMenu,
                                false, true);
     addMicrophoneAndAuxControl("volume",
-                               tr("Volume fader"),
-                               tr("Volume fader"), microphoneMenu,
+                               tr("Volume Fader"),
+                               tr("Volume Fader"), microphoneMenu,
                                true, true, true);
     addMicrophoneAndAuxControl("volume_set_one",
                                tr("Volume Full"),
@@ -676,13 +697,13 @@ void ControlPickerMenu::addControl(QString group, QString control, QString title
                                    QString description,
                                    QMenu* pMenu,
                                    bool addReset) {
-    QAction* pAction = pMenu->addAction(description, &m_actionMapper,
+    QAction* pAction = pMenu->addAction(title, &m_actionMapper,
                                         SLOT(map()));
     m_actionMapper.setMapping(pAction, m_controlsAvailable.size());
     addAvailableControl(ConfigKey(group, control), title, description);
 
     if (addReset) {
-        QString resetDescription = QString("%1 (%2)").arg(description,
+        QString resetDescription = QString("%1 (%2)").arg(title,
                                                           m_resetStr);
         QString resetControl = QString("%1_set_default").arg(control);
         QAction* pResetAction = pMenu->addAction(resetDescription,
@@ -697,7 +718,7 @@ void ControlPickerMenu::addEffectControl(QString group, QString control,
                                          QString title,
                                          QString menuDescription, QString descriptionPrefix,
                                          QMenu* pMenu, bool addReset) {
-    QAction* pAction = pMenu->addAction(menuDescription, &m_actionMapper, SLOT(map()));
+    QAction* pAction = pMenu->addAction(title, &m_actionMapper, SLOT(map()));
     m_actionMapper.setMapping(pAction, m_controlsAvailable.size());
 
     QString description = QString("%1: %2").arg(descriptionPrefix,
@@ -705,9 +726,9 @@ void ControlPickerMenu::addEffectControl(QString group, QString control,
     addAvailableControl(ConfigKey(group, control), title, description);
 
     if (addReset) {
-        QString resetMenuDescription = QString("%1 (%2)").arg(description, m_resetStr);
+        QString resetMenuDescription = QString("%1 (%2)").arg(title, m_resetStr);
         QString resetControl = QString("%1_set_default").arg(control);
-        QAction* pResetAction = pMenu->addAction(resetMenuDescription,
+        QAction* pResetAction = pMenu->addAction(title,
                                                  &m_actionMapper, SLOT(map()));
         QString resetDescription = QString("%1: %2").arg(descriptionPrefix,
                                                          resetMenuDescription);
@@ -717,7 +738,7 @@ void ControlPickerMenu::addEffectControl(QString group, QString control,
     }
 }
 
-void ControlPickerMenu::addPlayerControl(QString control, QString title,
+void ControlPickerMenu::addPlayerControl(QString control, QString controlTitle,
                                          QString controlDescription,
                                          QMenu* pMenu,
                                          bool deckControls, bool samplerControls,
@@ -727,13 +748,13 @@ void ControlPickerMenu::addPlayerControl(QString control, QString title,
     const int iNumDecks = ControlObject::get(ConfigKey("[Master]", "num_decks"));
     const int iNumPreviewDecks = ControlObject::get(ConfigKey("[Master]", "num_preview_decks"));
 
-    QMenu* controlMenu = new QMenu(controlDescription, pMenu);
+    QMenu* controlMenu = new QMenu(controlTitle, pMenu);
     pMenu->addMenu(controlMenu);
 
     QMenu* resetControlMenu = NULL;
     QString resetControl = QString("%1_set_default").arg(control);
     if (addReset) {
-        QString resetHelpText = QString("%1 (%2)").arg(controlDescription, m_resetStr);
+        QString resetHelpText = QString("%1 (%2)").arg(controlTitle, m_resetStr);
         resetControlMenu = new QMenu(resetHelpText, pMenu);
         pMenu->addMenu(resetControlMenu);
     }
@@ -741,6 +762,8 @@ void ControlPickerMenu::addPlayerControl(QString control, QString title,
     for (int i = 1; deckControls && i <= iNumDecks; ++i) {
         // PlayerManager::groupForDeck is 0-indexed.
         QString group = PlayerManager::groupForDeck(i - 1);
+        QString title = QString("%1: %2").arg(
+            m_deckStr.arg(QString::number(i)), controlTitle);
         QString description = QString("%1: %2").arg(
             m_deckStr.arg(QString::number(i)), controlDescription);
         QAction* pAction = controlMenu->addAction(m_deckStr.arg(i), &m_actionMapper, SLOT(map()));
@@ -751,13 +774,15 @@ void ControlPickerMenu::addPlayerControl(QString control, QString title,
             QString resetDescription = QString("%1 (%2)").arg(description, m_resetStr);
             QAction* pResetAction = resetControlMenu->addAction(m_deckStr.arg(i), &m_actionMapper, SLOT(map()));
             m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
-            addAvailableControl(ConfigKey(group, resetControl), title, resetDescription);
+            addAvailableControl(ConfigKey(group, resetControl), controlTitle, resetDescription);
         }
     }
 
     for (int i = 1; previewdeckControls && i <= iNumPreviewDecks; ++i) {
         // PlayerManager::groupForPreviewDeck is 0-indexed.
         QString group = PlayerManager::groupForPreviewDeck(i - 1);
+        QString title = QString("%1: %2").arg(
+            m_previewdeckStr.arg(QString::number(i)), controlTitle);
         QString description = QString("%1: %2").arg(
             m_previewdeckStr.arg(QString::number(i)), controlDescription);
         QAction* pAction = controlMenu->addAction(m_previewdeckStr.arg(i), &m_actionMapper, SLOT(map()));
@@ -775,6 +800,8 @@ void ControlPickerMenu::addPlayerControl(QString control, QString title,
     for (int i = 1; samplerControls && i <= iNumSamplers; ++i) {
         // PlayerManager::groupForSampler is 0-indexed.
         QString group = PlayerManager::groupForSampler(i - 1);
+        QString title = QString("%1: %2").arg(
+            m_samplerStr.arg(QString::number(i)), controlTitle);
         QString description = QString("%1: %2").arg(
             m_samplerStr.arg(QString::number(i)), controlDescription);
         QAction* pAction = controlMenu->addAction(m_samplerStr.arg(i), &m_actionMapper, SLOT(map()));
@@ -797,13 +824,13 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
                                                    bool microhoneControls,
                                                    bool auxControls,
                                                    bool addReset) {
-    QMenu* controlMenu = new QMenu(controlDescription, pMenu);
+    QMenu* controlMenu = new QMenu(title, pMenu);
     pMenu->addMenu(controlMenu);
 
     QMenu* resetControlMenu = NULL;
     QString resetControl = QString("%1_set_default").arg(control);
     if (addReset) {
-        QString resetHelpText = QString("%1 (%2)").arg(controlDescription, m_resetStr);
+        QString resetHelpText = QString("%1 (%2)").arg(title, m_resetStr);
         resetControlMenu = new QMenu(resetHelpText, pMenu);
         pMenu->addMenu(resetControlMenu);
     }
@@ -824,7 +851,7 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
             addAvailableControl(ConfigKey(group, control), title, description);
 
             if (addReset) {
-                QString resetDescription = QString("%1 (%2)").arg(description, m_resetStr);
+                QString resetDescription = QString("%1 (%2)").arg(controlDescription, m_resetStr);
                 QAction* pResetAction = resetControlMenu->addAction(
                     m_microphoneStr.arg(i), &m_actionMapper, SLOT(map()));
                 m_actionMapper.setMapping(pResetAction, m_controlsAvailable.size());
@@ -838,7 +865,7 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
         for (int i = 1; i <= kNumAuxiliaries; ++i) {
             QString group = QString("[Auxiliary%1]").arg(i);
             QString description = QString("%1: %2").arg(
-                m_auxStr.arg(QString::number(i)), controlDescription);
+                m_auxStr.arg(QString::number(i)), title);
             QAction* pAction = controlMenu->addAction(m_auxStr.arg(i),
                                                       &m_actionMapper, SLOT(map()));
             m_actionMapper.setMapping(pAction, m_controlsAvailable.size());
@@ -853,13 +880,6 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
             }
         }
     }
-}
-
-void ControlPickerMenu::addDeckAndSamplerControl(QString control,
-                                                 QString controlDescription,
-                                                 QMenu* pMenu,
-                                                 bool addReset) {
-    addPlayerControl(control, controlDescription, controlDescription, pMenu, true, true, false, addReset);
 }
 
 void ControlPickerMenu::addDeckAndSamplerControl(QString control,

--- a/src/controllers/controlpickermenu.h
+++ b/src/controllers/controlpickermenu.h
@@ -18,7 +18,7 @@ class ControlPickerMenu : public QMenu {
     }
 
     QString descriptionForConfigKey(ConfigKey key) const;
-    QString prettyNameForConfigKey(ConfigKey key) const;
+    QString controlTitleForConfigKey(ConfigKey key) const;
 
   signals:
     // Emitted when the user selects a control from the menu.
@@ -30,31 +30,34 @@ class ControlPickerMenu : public QMenu {
 
   private:
     QMenu* addSubmenu(QString title, QMenu* pParent=NULL);
-    void addControl(QString group, QString control, QString helpText,
-                    QMenu* pMenu, bool addReset=false);
-    void addPlayerControl(QString control, QString helpText, QMenu* pMenu,
-                          bool deckControls, bool samplerControls,
+    void addControl(QString group, QString control, QString title,
+                    QString helpText, QMenu* pMenu, bool addReset=false);
+    void addPlayerControl(QString control, QString title, QString helpText,
+                          QMenu* pMenu, bool deckControls, bool samplerControls,
                           bool previewdeckControls, bool addReset=false);
-    void addDeckAndSamplerControl(QString control, QString helpText,
-                                  QMenu* pMenu, bool addReset=false);
-    void addDeckAndPreviewDeckControl(QString control, QString helpText,
-                                      QMenu* pMenu, bool addReset=false);
-    void addDeckAndSamplerAndPreviewDeckControl(QString control,
+    void addDeckAndSamplerControl(QString control, QString title,
+                                  QString helpText, QMenu* pMenu,
+                                  bool addReset=false);
+    void addDeckAndPreviewDeckControl(QString control, QString title,
+                                      QString helpText, QMenu* pMenu,
+                                      bool addReset=false);
+    void addDeckAndSamplerAndPreviewDeckControl(QString control, QString title,
                                                 QString helpText, QMenu* pMenu,
                                                 bool addReset=false);
-    void addDeckControl(QString control, QString helpText, QMenu* pMenu,
-                        bool addReset=false);
-    void addSamplerControl(QString control, QString helpText, QMenu* pMenu,
-                           bool addReset=false);
-    void addPreviewDeckControl(QString control, QString helpText, QMenu* pMenu,
-                               bool addReset=false);
-    void addMicrophoneAndAuxControl(QString control, QString helpText, QMenu* pMenu,
+    void addDeckControl(QString control, QString title, QString helpText,
+                        QMenu* pMenu, bool addReset=false);
+    void addSamplerControl(QString control, QString title, QString helpText,
+                           QMenu* pMenu, bool addReset=false);
+    void addPreviewDeckControl(QString control, QString title, QString helpText,
+                               QMenu* pMenu, bool addReset=false);
+    void addMicrophoneAndAuxControl(QString control, QString title,
+                                    QString helpText, QMenu* pMenu,
                                     bool microhoneControls, bool auxControls,
                                     bool addReset=false);
-    void addEffectControl(QString group, QString control, QString menuDescription,
-                          QString descriptionPrefix,
+    void addEffectControl(QString group, QString control, QString title,
+                          QString menuDescription, QString descriptionPrefix,
                           QMenu* pMenu, bool addReset=false);
-    void addAvailableControl(ConfigKey key, QString description);
+    void addAvailableControl(ConfigKey key, QString title, QString description);
 
     QString m_masterOutputStr;
     QString m_headphoneOutputStr;
@@ -72,6 +75,7 @@ class ControlPickerMenu : public QMenu {
     QSignalMapper m_actionMapper;
     QList<ConfigKey> m_controlsAvailable;
     QHash<ConfigKey, QString> m_descriptionsByKey;
+    QHash<ConfigKey, QString> m_titlesByKey;
 };
 
 #endif /* CONTROLPICKERMENU_H */

--- a/src/controllers/controlpickermenu.h
+++ b/src/controllers/controlpickermenu.h
@@ -17,6 +17,7 @@ class ControlPickerMenu : public QMenu {
         return m_controlsAvailable;
     }
 
+    bool controlExists(ConfigKey key) const;
     QString descriptionForConfigKey(ConfigKey key) const;
     QString controlTitleForConfigKey(ConfigKey key) const;
 

--- a/src/controllers/controlpickermenu.h
+++ b/src/controllers/controlpickermenu.h
@@ -18,6 +18,7 @@ class ControlPickerMenu : public QMenu {
     }
 
     QString descriptionForConfigKey(ConfigKey key) const;
+    QString prettyNameForConfigKey(ConfigKey key) const;
 
   signals:
     // Emitted when the user selects a control from the menu.

--- a/src/controllers/controlpickermenu.h
+++ b/src/controllers/controlpickermenu.h
@@ -59,8 +59,8 @@ class ControlPickerMenu : public QMenu {
                           QMenu* pMenu, bool addReset=false);
     void addAvailableControl(ConfigKey key, QString title, QString description);
 
-    QString m_masterOutputStr;
-    QString m_headphoneOutputStr;
+    QString m_effectMasterOutputStr;
+    QString m_effectHeadphoneOutputStr;
     QString m_deckStr;
     QString m_previewdeckStr;
     QString m_samplerStr;

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -456,14 +456,28 @@ void DlgControllerLearning::controlClicked(ControlObject* pControl) {
         return;
     }
 
-    controlPicked(pControl->getKey());
+    ConfigKey key = pControl->getKey();
+    if (!m_controlPickerMenu.controlExists(key)) {
+        qWarning() << "Mixxx UI element clicked for which there is no "
+                      "learnable control " << key.group << " " << key.item;
+        QMessageBox::warning(
+                    this,
+                    tr("Mixxx"),
+                    tr("The control you clicked in Mixxx is not learnable.\n"
+                       "This could be because you are using an old skin"
+                       " and this control is no longer supported.\n"
+                       "\nYou tried to learn: %1,%2").arg(key.group, key.item),
+                    QMessageBox::Ok, QMessageBox::Ok);
+        return;
+    }
+    controlPicked(key);
 }
 
 void DlgControllerLearning::comboboxIndexChanged(int index) {
     ConfigKey control =
             comboBoxChosenControl->itemData(index).value<ConfigKey>();
     if (control.isNull()) {
-        labelDescription->setText(tr("");
+        labelDescription->setText(tr(""));
         pushButtonStartLearn->setDisabled(true);
         return;
     }

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -367,7 +367,7 @@ void DlgControllerLearning::loadControl(const ConfigKey& key, QString descriptio
             .arg(description);
     controlToMapMessage->setText(message);
     comboBoxChosenControl->setEditText(
-            m_controlPickerMenu.prettyNameForConfigKey(key));
+            m_controlPickerMenu.controlTitleForConfigKey(key));
     labelMappedTo->setText("");
 }
 

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -58,7 +58,7 @@ DlgControllerLearning::DlgControllerLearning(QWidget * parent,
     labelNextHelp->setTextFormat(Qt::RichText);
     labelNextHelp->setText(QString(
             "<p><span style=\"font-weight:600;\">%1</span></p>"
-            "<p>%2</p><br/><p><span style=\"font-weight:600;\">%3</span></p>"
+            "<p>%2</p><p><span style=\"font-weight:600;\">%3</span></p>"
             "<p>%4</p>").arg(
                     nextTitle, nextInstructionBody,
                     nextTroubleshootTitle, nextTroubleshootBody));
@@ -83,6 +83,7 @@ DlgControllerLearning::DlgControllerLearning(QWidget * parent,
     connect(pushButtonChooseControl, SIGNAL(clicked()), this, SLOT(showControlMenu()));
     connect(pushButtonClose, SIGNAL(clicked()), this, SLOT(close()));
     connect(pushButtonClose_2, SIGNAL(clicked()), this, SLOT(close()));
+    connect(pushButtonCancelLearn, SIGNAL(clicked()), this, SLOT(slotCancelLearn()));
     connect(pushButtonRetry, SIGNAL(clicked()), this, SLOT(slotRetry()));
     connect(pushButtonStartLearn, SIGNAL(clicked()), this, SLOT(slotStartLearningPressed()));
     connect(pushButtonLearnAnother, SIGNAL(clicked()), this, SLOT(slotChooseControlPressed()));
@@ -140,6 +141,8 @@ void DlgControllerLearning::populateComboBox() {
 }
 
 void DlgControllerLearning::resetWizard(bool keepCurrentControl) {
+    m_firstMessageTimer.stop();
+    m_lastMessageTimer.stop();
     emit(clearTemporaryInputMappings());
 
     if (!keepCurrentControl) {
@@ -247,16 +250,22 @@ void DlgControllerLearning::slotMessageReceived(unsigned char status,
     }
 }
 
+void DlgControllerLearning::slotCancelLearn() {
+    resetWizard(true);
+    stackedWidget->setCurrentWidget(page1Choose);
+    startListening();
+}
+
 void DlgControllerLearning::slotFirstMessageTimeout() {
+    resetWizard(true);
     if (m_messages.length() == 0) {
         labelErrorText->setText(tr("Didn't get any midi messages.  Please try again."));
-        m_messages.clear();
-        // No need to reset everything.
-        stackedWidget->setCurrentWidget(page1Choose);
-        startListening();
     } else {
-        qWarning() << "we shouldn't time out if we never got anything";
+        qWarning() << "we shouldn't time out if we got something";
+        m_messages.clear();
     }
+    stackedWidget->setCurrentWidget(page1Choose);
+    startListening();
 }
 
 void DlgControllerLearning::slotTimerExpired() {

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -34,7 +34,7 @@ DlgControllerLearning::DlgControllerLearning(QWidget * parent,
     labelMappedTo->setText("");
     // Ensure the first page is always shown regardless of the last page shown
     // when the .ui file was saved.
-    stackedWidget->setCurrentIndex(0);
+    stackedWidget->setCurrentWidget(page1Choose);
 
     // Delete this dialog when its closed. We don't want any persistence.
     setAttribute(Qt::WA_DeleteOnClose);
@@ -132,7 +132,7 @@ void DlgControllerLearning::resetWizard(bool keepCurrentControl) {
 
 void DlgControllerLearning::slotChooseControlPressed() {
     resetWizard();
-    stackedWidget->setCurrentIndex(page1Choose);
+    stackedWidget->setCurrentWidget(page1Choose);
     startListening();
 }
 
@@ -150,7 +150,7 @@ void DlgControllerLearning::slotStartLearningPressed() {
         return;
     }
     m_firstMessageTimer.start();
-    stackedWidget->setCurrentIndex(page2Learn);
+    stackedWidget->setCurrentWidget(page2Learn);
 }
 
 #ifdef CONTROLLERLESSTESTING
@@ -189,7 +189,7 @@ void DlgControllerLearning::slotMessageReceived(unsigned char status,
     if (m_messages.length() == 0) {
         // If an advanced user started wiggling a control without bothering to
         // click the Learn button, take them to the learning screen.
-        stackedWidget->setCurrentIndex(page2Learn);
+        stackedWidget->setCurrentWidget(page2Learn);
     }
 
     if (status == MIDI_CC) {
@@ -221,7 +221,7 @@ void DlgControllerLearning::slotFirstMessageTimeout() {
         labelErrorText->setText(tr("Didn't get any midi messages.  Please try again."));
         m_messages.clear();
         // No need to reset everything.
-        stackedWidget->setCurrentIndex(page1Choose);
+        stackedWidget->setCurrentWidget(page1Choose);
         startListening();
     } else {
         qWarning() << "we shouldn't time out if we never got anything";
@@ -247,7 +247,7 @@ void DlgControllerLearning::slotTimerExpired() {
         labelErrorText->setText(tr("Unable to detect a mapping -- please try again. Be sure to only touch one control at once."));
         m_messages.clear();
         // Don't reset the wizard.
-        stackedWidget->setCurrentIndex(page1Choose);
+        stackedWidget->setCurrentWidget(page1Choose);
         startListening();
         return;
     }
@@ -291,7 +291,7 @@ void DlgControllerLearning::slotTimerExpired() {
     QString mapMessage = QString("%1 %2").arg(tr("Successfully mapped to:"),
                                               midiControl);
     labelMappedTo->setText(mapMessage);
-    stackedWidget->setCurrentIndex(page3Confirm);
+    stackedWidget->setCurrentWidget(page3Confirm);
 }
 
 void DlgControllerLearning::slotRetry() {
@@ -365,7 +365,7 @@ DlgControllerLearning::~DlgControllerLearning() {
     if (m_messagesLearned) {
         commitMapping();
         resetWizard();
-        stackedWidget->setCurrentIndex(page1Choose);
+        stackedWidget->setCurrentWidget(page1Choose);
     }
 
     //If there was any ongoing learning, cancel it (benign if there wasn't).
@@ -385,7 +385,7 @@ void DlgControllerLearning::loadControl(const ConfigKey& key,
     if (m_messagesLearned) {
         commitMapping();
         resetWizard();
-        stackedWidget->setCurrentIndex(page1Choose);
+        stackedWidget->setCurrentWidget(page1Choose);
         startListening();
     }
     m_currentControl = key;

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -32,6 +32,37 @@ DlgControllerLearning::DlgControllerLearning(QWidget * parent,
 
     setupUi(this);
     labelMappedTo->setText("");
+
+    QString helpTitle(tr("Click anywhere in Mixxx or Choose a control to Learn"));
+    QString helpBody(tr("You can click on any button, slider, or knob in Mixxx "
+                        "to teach it that control.  You can also type in the "
+                        "box to search for a control by name, or click the "
+                        "Choose Control button to select from a list."));
+    labelMappingHelp->setTextFormat(Qt::RichText);
+    labelMappingHelp->setText(QString(
+            "<p><span style=\"font-weight:600;\">%1</span></p>"
+            "<p>%2</p>").arg(
+                    helpTitle, helpBody));
+
+
+    QString nextTitle(tr("Now test it out!"));
+    QString nextInstructionBody(tr(
+            "If you manipulate the control, you should see the Mixxx UI "
+            "respond the way you expect."));
+    QString nextTroubleshootTitle(tr("Not quite right?"));
+    QString nextTroubleshootBody(tr(
+            "If the mapping is not working try enabling an advanced option "
+            "below and then try the control again. Or click Retry to redetect "
+            "the midi control."));
+
+    labelNextHelp->setTextFormat(Qt::RichText);
+    labelNextHelp->setText(QString(
+            "<p><span style=\"font-weight:600;\">%1</span></p>"
+            "<p>%2</p><br/><p><span style=\"font-weight:600;\">%3</span></p>"
+            "<p>%4</p>").arg(
+                    nextTitle, nextInstructionBody,
+                    nextTroubleshootTitle, nextTroubleshootBody));
+
     // Ensure the first page is always shown regardless of the last page shown
     // when the .ui file was saved.
     stackedWidget->setCurrentWidget(page1Choose);
@@ -288,8 +319,8 @@ void DlgControllerLearning::slotTimerExpired() {
         qDebug() << "DlgControllerLearning learned input mapping:" << mappingStr;
     }
 
-    QString mapMessage = QString("%1 %2").arg(tr("Successfully mapped to:"),
-                                              midiControl);
+    QString mapMessage = QString("<i>%1 %2</i>").arg(
+            tr("Successfully mapped control:"), midiControl);
     labelMappedTo->setText(mapMessage);
     stackedWidget->setCurrentWidget(page3Confirm);
 }

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -148,6 +148,8 @@ void DlgControllerLearning::resetWizard(bool keepCurrentControl) {
     if (!keepCurrentControl) {
         m_currentControl = ConfigKey();
         comboBoxChosenControl->setCurrentIndex(0);
+        labelDescription->setText("");
+        pushButtonStartLearn->setDisabled(true);
     }
     m_messagesLearned = false;
     m_messages.clear();
@@ -161,7 +163,6 @@ void DlgControllerLearning::resetWizard(bool keepCurrentControl) {
 
     labelMappedTo->setText("");
     labelErrorText->setText("");
-    labelDescription->setText("");
 }
 
 void DlgControllerLearning::slotChooseControlPressed() {
@@ -434,11 +435,14 @@ void DlgControllerLearning::loadControl(const ConfigKey& key,
         description = key.group + "," + key.item;
     }
     comboBoxChosenControl->setEditText(title);
-    labelDescription->setText(description);
-    QString message = tr("Learning: %1. Now move a control on your controller.")
+
+    labelDescription->setText(tr("<i>Ready to learn %1</i>").arg(description));
+    QString learnmessage = tr("Learning: %1. Now move a control on your controller.")
             .arg(title);
-    controlToMapMessage->setText(message);
+    controlToMapMessage->setText(learnmessage);
     labelMappedTo->setText("");
+    pushButtonStartLearn->setDisabled(false);
+    pushButtonStartLearn->setFocus();
 }
 
 void DlgControllerLearning::controlPicked(ConfigKey control) {
@@ -459,6 +463,8 @@ void DlgControllerLearning::comboboxIndexChanged(int index) {
     ConfigKey control =
             comboBoxChosenControl->itemData(index).value<ConfigKey>();
     if (control.isNull()) {
+        labelDescription->setText(tr("");
+        pushButtonStartLearn->setDisabled(true);
         return;
     }
     controlPicked(control);

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -55,8 +55,13 @@ DlgControllerLearning::DlgControllerLearning(QWidget * parent,
     connect(pushButtonRetry, SIGNAL(clicked()), this, SLOT(slotRetry()));
     connect(pushButtonStartLearn, SIGNAL(clicked()), this, SLOT(slotStartLearningPressed()));
     connect(pushButtonLearnAnother, SIGNAL(clicked()), this, SLOT(slotChooseControlPressed()));
+#ifdef CONTROLLERLESSTESTING
     connect(pushButtonFakeControl, SIGNAL(clicked()), this, SLOT(DEBUGFakeMidiMessage()));
     connect(pushButtonFakeControl2, SIGNAL(clicked()), this, SLOT(DEBUGFakeMidiMessage2()));
+#else
+    pushButtonFakeControl->hide();
+    pushButtonFakeControl2->hide();
+#endif
 
     // We only want to listen to clicked() so we don't fire
     // slotMidiOptionsChanged when we change the checkboxes programmatically.
@@ -148,6 +153,7 @@ void DlgControllerLearning::slotStartLearningPressed() {
     stackedWidget->setCurrentIndex(page2Learn);
 }
 
+#ifdef CONTROLLERLESSTESTING
 void DlgControllerLearning::DEBUGFakeMidiMessage() {
     slotMessageReceived(MIDI_CC, 0x20, 0x41);
 }
@@ -155,6 +161,7 @@ void DlgControllerLearning::DEBUGFakeMidiMessage() {
 void DlgControllerLearning::DEBUGFakeMidiMessage2() {
     slotMessageReceived(MIDI_CC, 0x20, 0x3F);
 }
+#endif
 
 void DlgControllerLearning::slotMessageReceived(unsigned char status,
                                                 unsigned char control,

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -113,6 +113,7 @@ void DlgControllerLearning::resetWizard(bool keepCurrentControl) {
 
     if (!keepCurrentControl) {
         m_currentControl = ConfigKey();
+        comboBoxChosenControl->setCurrentIndex(0);
     }
     m_messagesLearned = false;
     m_messages.clear();
@@ -121,7 +122,6 @@ void DlgControllerLearning::resetWizard(bool keepCurrentControl) {
     midiOptionSelectKnob->setChecked(false);
     midiOptionSoftTakeover->setChecked(false);
     midiOptionSwitchMode->setChecked(false);
-    comboBoxChosenControl->setCurrentIndex(0);
 
     progressBarWiggleFeedback->hide();
 
@@ -297,7 +297,7 @@ void DlgControllerLearning::slotTimerExpired() {
 void DlgControllerLearning::slotRetry() {
     // If the user hit undo, instruct the controller to forget the mapping we
     // just added. So reset, but keep the control currently being learned.
-    resetWizard(false);
+    resetWizard(true);
     slotStartLearningPressed();
 }
 

--- a/src/controllers/dlgcontrollerlearning.h
+++ b/src/controllers/dlgcontrollerlearning.h
@@ -67,11 +67,11 @@ class DlgControllerLearning : public QDialog,
                              unsigned char control,
                              unsigned char value);
 
-    void slotChooseControl();
+    void slotChooseControlPressed();
     void slotTimerExpired();
     void slotFirstMessageTimeout();
     void slotRetry();
-    void slotStartLearning();
+    void slotStartLearningPressed();
     void slotMidiOptionsChanged();
 
   private slots:
@@ -81,7 +81,9 @@ class DlgControllerLearning : public QDialog,
 
   private:
     void loadControl(const ConfigKey& key, QString description);
-    void resetMapping(bool commit);
+    void startListening();
+    void commitMapping();
+    void resetWizard(bool keepCurrentControl = true);
 
     Controller* m_pController;
     MidiController* m_pMidiController;

--- a/src/controllers/dlgcontrollerlearning.h
+++ b/src/controllers/dlgcontrollerlearning.h
@@ -29,6 +29,12 @@ class DlgControllerLearning : public QDialog,
                               public ControllerVisitor,
                               public Ui::DlgControllerLearning {
     Q_OBJECT
+    enum DialogPages {
+        page1Choose,
+        page2Learn,
+        page3Confirm
+    };
+
   public:
     DlgControllerLearning(QWidget *parent, Controller *controller);
     virtual ~DlgControllerLearning();
@@ -61,22 +67,29 @@ class DlgControllerLearning : public QDialog,
                              unsigned char control,
                              unsigned char value);
 
+    void slotChooseControl();
     void slotTimerExpired();
-    void slotUndo();
+    void slotFirstMessageTimeout();
+    void slotRetry();
+    void slotStartLearning();
     void slotMidiOptionsChanged();
 
   private slots:
     void showControlMenu();
+    void DEBUGFakeMidiMessage();
+    void DEBUGFakeMidiMessage2();
 
   private:
     void loadControl(const ConfigKey& key, QString description);
     void resetMapping(bool commit);
 
+    Controller* m_pController;
     MidiController* m_pMidiController;
     ControlPickerMenu m_controlPickerMenu;
     ConfigKey m_currentControl;
     QString m_currentDescription;
     bool m_messagesLearned;
+    QTimer m_firstMessageTimer;
     QTimer m_lastMessageTimer;
     QList<QPair<MidiKey, unsigned char> > m_messages;
     MidiInputMappings m_mappings;

--- a/src/controllers/dlgcontrollerlearning.h
+++ b/src/controllers/dlgcontrollerlearning.h
@@ -24,6 +24,7 @@
 #include "configobject.h"
 
 class ControllerPreset;
+class QCompleter;
 
 class DlgControllerLearning : public QDialog,
                               public ControllerVisitor,
@@ -62,6 +63,7 @@ class DlgControllerLearning : public QDialog,
     void controlPicked(ConfigKey control);
     // Triggered when user clicks a control from the GUI
     void controlClicked(ControlObject* pControl);
+    void comboboxIndexChanged(int index);
 
     void slotMessageReceived(unsigned char status,
                              unsigned char control,
@@ -80,16 +82,16 @@ class DlgControllerLearning : public QDialog,
     void DEBUGFakeMidiMessage2();
 
   private:
-    void loadControl(const ConfigKey& key, QString description);
+    void loadControl(const ConfigKey& key, QString title, QString description);
     void startListening();
     void commitMapping();
     void resetWizard(bool keepCurrentControl = true);
+    void populateComboBox();
 
     Controller* m_pController;
     MidiController* m_pMidiController;
     ControlPickerMenu m_controlPickerMenu;
     ConfigKey m_currentControl;
-    QString m_currentDescription;
     bool m_messagesLearned;
     QTimer m_firstMessageTimer;
     QTimer m_lastMessageTimer;

--- a/src/controllers/dlgcontrollerlearning.h
+++ b/src/controllers/dlgcontrollerlearning.h
@@ -24,7 +24,8 @@
 #include "configobject.h"
 
 class ControllerPreset;
-class QCompleter;
+
+//#define CONTROLLERLESSTESTING
 
 class DlgControllerLearning : public QDialog,
                               public ControllerVisitor,
@@ -78,8 +79,10 @@ class DlgControllerLearning : public QDialog,
 
   private slots:
     void showControlMenu();
+#ifdef CONTROLLERLESSTESTING
     void DEBUGFakeMidiMessage();
     void DEBUGFakeMidiMessage2();
+#endif
 
   private:
     void loadControl(const ConfigKey& key, QString title, QString description);

--- a/src/controllers/dlgcontrollerlearning.h
+++ b/src/controllers/dlgcontrollerlearning.h
@@ -83,7 +83,7 @@ class DlgControllerLearning : public QDialog,
     void loadControl(const ConfigKey& key, QString title, QString description);
     void startListening();
     void commitMapping();
-    void resetWizard(bool keepCurrentControl = true);
+    void resetWizard(bool keepCurrentControl = false);
     void populateComboBox();
 
     Controller* m_pController;

--- a/src/controllers/dlgcontrollerlearning.h
+++ b/src/controllers/dlgcontrollerlearning.h
@@ -65,6 +65,7 @@ class DlgControllerLearning : public QDialog,
                              unsigned char control,
                              unsigned char value);
 
+    void slotCancelLearn();
     void slotChooseControlPressed();
     void slotTimerExpired();
     void slotFirstMessageTimeout();

--- a/src/controllers/dlgcontrollerlearning.h
+++ b/src/controllers/dlgcontrollerlearning.h
@@ -31,11 +31,6 @@ class DlgControllerLearning : public QDialog,
                               public ControllerVisitor,
                               public Ui::DlgControllerLearning {
     Q_OBJECT
-    enum DialogPages {
-        page1Choose,
-        page2Learn,
-        page3Confirm
-    };
 
   public:
     DlgControllerLearning(QWidget *parent, Controller *controller);

--- a/src/controllers/dlgcontrollerlearning.ui
+++ b/src/controllers/dlgcontrollerlearning.ui
@@ -35,7 +35,7 @@
    <item row="0" column="0">
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="page1Choose">
       <property name="sizePolicy">
@@ -148,259 +148,245 @@
      </widget>
      <widget class="QWidget" name="page2Learn">
       <property name="sizePolicy">
-       <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <widget class="QWidget" name="verticalLayoutWidget_2">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>461</width>
-         <height>281</height>
-        </rect>
+      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,2,3,4,5">
+       <property name="spacing">
+        <number>6</number>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,2,3,4,5">
-        <property name="spacing">
-         <number>6</number>
-        </property>
-        <item>
-         <widget class="QLabel" name="controlToMapMessage">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string notr="true"/>
-          </property>
-          <property name="text">
-           <string notr="true">(control ready to map message goes here)</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Hints: If you're mapping a button or switch, only press or flip it once.  For knobs and sliders, move the control in both directions for best results. Make sure to touch one control at a time.</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QProgressBar" name="progressBarWiggleFeedback">
-          <property name="maximum">
-           <number>10</number>
-          </property>
-          <property name="value">
-           <number>0</number>
-          </property>
-          <property name="format">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButtonFakeControl2">
-          <property name="text">
-           <string>Debug Fake Pushbutton Control2</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButtonFakeControl">
-          <property name="text">
-           <string>Debug Fake Pushbutton Control</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </widget>
+       <property name="sizePolicy" stdset="0">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <item>
+        <widget class="QLabel" name="controlToMapMessage">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string notr="true"/>
+         </property>
+         <property name="text">
+          <string notr="true">(control ready to map message goes here)</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Hints: If you're mapping a button or switch, only press or flip it once.  For knobs and sliders, move the control in both directions for best results. Make sure to touch one control at a time.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QProgressBar" name="progressBarWiggleFeedback">
+         <property name="maximum">
+          <number>10</number>
+         </property>
+         <property name="value">
+          <number>0</number>
+         </property>
+         <property name="format">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButtonFakeControl2">
+         <property name="text">
+          <string>Debug Fake Pushbutton Control2</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButtonFakeControl">
+         <property name="text">
+          <string>Debug Fake Pushbutton Control</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="page3Confirm">
       <property name="sizePolicy">
-       <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <widget class="QWidget" name="verticalLayoutWidget">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>471</width>
-         <height>281</height>
-        </rect>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout">
-        <item>
-         <widget class="QLabel" name="labelMappedTo">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string notr="true"/>
-          </property>
-          <property name="text">
-           <string notr="true">(successfully mapped to message goes here)</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="labelNextHelp">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Now test it out!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If you manipulate the control, you should see the Mixxx UI respond the way you expect. If the mapping is not working click Retry to try again or try enabling an advanced option below and then try the control again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="midiOptions">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="title">
-           <string>Advanced MIDI Options</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_2">
-           <item row="1" column="1">
-            <widget class="QCheckBox" name="midiOptionSwitchMode">
-             <property name="toolTip">
-              <string>Switch mode interprets all messages for the control as button presses.</string>
-             </property>
-             <property name="text">
-              <string>Switch Mode</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QCheckBox" name="midiOptionSoftTakeover">
-             <property name="toolTip">
-              <string>Ignores slider or knob movements until they are close to the internal value. This helps prevent unwanted extreme changes while mixing but can accidentally ignore intentional rapid movements.</string>
-             </property>
-             <property name="text">
-              <string>Soft Takeover</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QCheckBox" name="midiOptionInvert">
-             <property name="toolTip">
-              <string>Reverses the direction of the control.</string>
-             </property>
-             <property name="text">
-              <string>Invert</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QCheckBox" name="midiOptionSelectKnob">
-             <property name="toolTip">
-              <string>For jog wheels or infinite-scroll knobs. Interprets incoming messages in two's complement.</string>
-             </property>
-             <property name="text">
-              <string>Jog Wheel / Select Knob</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <property name="spacing">
-           <number>10</number>
-          </property>
-          <item>
-           <widget class="QPushButton" name="pushButtonRetry">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QLabel" name="labelMappedTo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string notr="true"/>
+         </property>
+         <property name="text">
+          <string notr="true">(successfully mapped to message goes here)</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelNextHelp">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Now test it out!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If you manipulate the control, you should see the Mixxx UI respond the way you expect. If the mapping is not working click Retry to try again or try enabling an advanced option below and then try the control again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="midiOptions">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Advanced MIDI Options</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="midiOptionSwitchMode">
+            <property name="toolTip">
+             <string>Switch mode interprets all messages for the control as button presses.</string>
+            </property>
             <property name="text">
-             <string>Retry</string>
+             <string>Switch Mode</string>
             </property>
            </widget>
           </item>
-          <item>
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="midiOptionSoftTakeover">
+            <property name="toolTip">
+             <string>Ignores slider or knob movements until they are close to the internal value. This helps prevent unwanted extreme changes while mixing but can accidentally ignore intentional rapid movements.</string>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="pushButtonLearnAnother">
             <property name="text">
-             <string>Learn Another</string>
+             <string>Soft Takeover</string>
             </property>
            </widget>
           </item>
-          <item>
-           <widget class="QPushButton" name="pushButtonClose_2">
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="midiOptionInvert">
+            <property name="toolTip">
+             <string>Reverses the direction of the control.</string>
+            </property>
             <property name="text">
-             <string>Done</string>
+             <string>Invert</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="midiOptionSelectKnob">
+            <property name="toolTip">
+             <string>For jog wheels or infinite-scroll knobs. Interprets incoming messages in two's complement.</string>
+            </property>
+            <property name="text">
+             <string>Jog Wheel / Select Knob</string>
             </property>
            </widget>
           </item>
          </layout>
-        </item>
-       </layout>
-      </widget>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="spacing">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="pushButtonRetry">
+           <property name="text">
+            <string>Retry</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButtonLearnAnother">
+           <property name="text">
+            <string>Learn Another</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButtonClose_2">
+           <property name="text">
+            <string>Done</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
      </widget>
     </widget>
    </item>

--- a/src/controllers/dlgcontrollerlearning.ui
+++ b/src/controllers/dlgcontrollerlearning.ui
@@ -274,7 +274,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Now test it out!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If you manipulate the control, you should see the Mixxx UI respond the way you expect. If the mapping is not working click Retry to try again or try enabling an advanced option below and then try the control again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Now test it out!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If you manipulate the control, you should see the Mixxx UI respond the way you expect.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Not quite right?&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If the mapping is not working try enabling an advanced option below and then try the control again. Or click Retry to redetect the midi control.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/src/controllers/dlgcontrollerlearning.ui
+++ b/src/controllers/dlgcontrollerlearning.ui
@@ -35,7 +35,7 @@
    <item row="0" column="0">
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="page1Choose">
       <property name="sizePolicy">
@@ -156,12 +156,6 @@
       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,2,3,4,5">
        <property name="spacing">
         <number>6</number>
-       </property>
-       <property name="sizePolicy" stdset="0">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
        </property>
        <item>
         <widget class="QLabel" name="controlToMapMessage">

--- a/src/controllers/dlgcontrollerlearning.ui
+++ b/src/controllers/dlgcontrollerlearning.ui
@@ -163,7 +163,7 @@
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,2,3,4,5">
+      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,2,3,4,5,0">
        <property name="spacing">
         <number>6</number>
        </property>
@@ -236,6 +236,33 @@
          </property>
         </spacer>
        </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout3">
+         <property name="spacing">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="pushButtonCancelLearn">
+           <property name="text">
+            <string>Cancel</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="page3Confirm">
@@ -268,7 +295,7 @@
        <item>
         <widget class="QLabel" name="labelNextHelp">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>

--- a/src/controllers/dlgcontrollerlearning.ui
+++ b/src/controllers/dlgcontrollerlearning.ui
@@ -45,7 +45,7 @@
        </sizepolicy>
       </property>
       <layout class="QGridLayout" name="gridLayout_5">
-       <item row="5" column="0" colspan="3">
+       <item row="6" column="0" colspan="3">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -58,7 +58,7 @@
          </property>
         </spacer>
        </item>
-       <item row="11" column="2">
+       <item row="12" column="2">
         <widget class="QPushButton" name="pushButtonStartLearn">
          <property name="minimumSize">
           <size>
@@ -74,14 +74,14 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <widget class="QPushButton" name="pushButtonClose">
          <property name="text">
           <string>Close</string>
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <spacer name="horizontalSpacer">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -106,6 +106,9 @@
            </property>
            <property name="editable">
             <bool>true</bool>
+           </property>
+           <property name="insertPolicy">
+            <enum>QComboBox::InsertAlphabetically</enum>
            </property>
           </widget>
          </item>
@@ -137,10 +140,17 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0" colspan="3">
+       <item row="5" column="0" colspan="3">
         <widget class="QLabel" name="labelErrorText">
          <property name="text">
           <string>(error text)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="labelDescription">
+         <property name="text">
+          <string>(Description text)</string>
          </property>
         </widget>
        </item>

--- a/src/controllers/dlgcontrollerlearning.ui
+++ b/src/controllers/dlgcontrollerlearning.ui
@@ -133,7 +133,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Click anywhere in Mixxx or Choose a control to Learn&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You can click on any button, slider, or knob in Mixxx to teach it that control.  You can also type in the box to search for a control by name, or click the Choose Control button to select from a list.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>(html help)</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -147,7 +147,7 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="4" column="0" colspan="3">
         <widget class="QLabel" name="labelDescription">
          <property name="text">
           <string>(description text)</string>
@@ -274,7 +274,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Now test it out!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If you manipulate the control, you should see the Mixxx UI respond the way you expect.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Not quite right?&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If the mapping is not working try enabling an advanced option below and then try the control again. Or click Retry to redetect the midi control.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>(html text)</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/src/controllers/dlgcontrollerlearning.ui
+++ b/src/controllers/dlgcontrollerlearning.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>487</width>
-    <height>500</height>
+    <width>542</width>
+    <height>369</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,7 @@
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>500</height>
+    <height>300</height>
    </size>
   </property>
   <property name="maximumSize">
@@ -32,12 +32,12 @@
    <string>Controller Learning Wizard</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="1">
+   <item row="0" column="0">
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
-     <widget class="QWidget" name="page">
+     <widget class="QWidget" name="page1Choose">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
         <horstretch>0</horstretch>
@@ -45,110 +45,7 @@
        </sizepolicy>
       </property>
       <layout class="QGridLayout" name="gridLayout_5">
-       <item row="0" column="0" colspan="3">
-        <widget class="QLabel" name="labelMappingHelp">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Click any control in the Mixxx interface or choose one from the list. Then move a control on your controller to map it. Repeat this as many times as you wish. When you are finished mapping controls, click Done.</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
        <item row="5" column="0" colspan="3">
-        <widget class="QGroupBox" name="midiOptions">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>Advanced MIDI Options</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_2">
-          <item row="0" column="1">
-           <widget class="QCheckBox" name="midiOptionSwitchMode">
-            <property name="toolTip">
-             <string>Switch mode interprets all messages for the control as button presses.</string>
-            </property>
-            <property name="text">
-             <string>Switch Mode</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="midiOptionSoftTakeover">
-            <property name="toolTip">
-             <string>Ignores slider or knob movements until they are close to the internal value. This helps prevent unwanted extreme changes while mixing but can accidentally ignore intentional rapid movements.</string>
-            </property>
-            <property name="text">
-             <string>Soft Takeover</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="midiOptionInvert">
-            <property name="toolTip">
-             <string>Reverses the direction of the control.</string>
-            </property>
-            <property name="text">
-             <string>Invert</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QCheckBox" name="midiOptionSelectKnob">
-            <property name="toolTip">
-             <string>For jog wheels or infinite-scroll knobs. Interprets incoming messages in two's complement.</string>
-            </property>
-            <property name="text">
-             <string>Jog Wheel / Select Knob</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="10" column="0">
-        <spacer name="horizontalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="3" column="0" colspan="3">
-        <widget class="QLabel" name="labelMappedTo">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string notr="true"/>
-         </property>
-         <property name="text">
-          <string notr="true">(successfully mapped to message goes here)</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0" colspan="3">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -161,97 +58,349 @@
          </property>
         </spacer>
        </item>
+       <item row="11" column="2">
+        <widget class="QPushButton" name="pushButtonStartLearn">
+         <property name="minimumSize">
+          <size>
+           <width>90</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Learn</string>
+         </property>
+         <property name="default">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QPushButton" name="pushButtonClose">
+         <property name="text">
+          <string>Close</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="3" column="0" colspan="3">
+        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="3,0">
+         <item>
+          <widget class="QComboBox" name="comboBoxChosenControl">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="editable">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButtonChooseControl">
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Choose Control</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="0" column="0" rowspan="2" colspan="3">
+        <widget class="QLabel" name="labelMappingHelp">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Choose a control for Mixxx to learn&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Click anywhere in Mixxx to teach it that control, you can type in the box to search for a control by name, or click the Choose Control button to select from a list.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
        <item row="4" column="0" colspan="3">
-        <widget class="QLabel" name="labelNextHelp">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
+        <widget class="QLabel" name="labelErrorText">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Now test it out! If everything works as expected then click a new control in the Mixxx interface or choose one from the list to continue. If the mapping is not working click Undo to try again or try enabling an advanced option.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0" colspan="3">
-        <widget class="QLabel" name="controlToMapMessage">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string notr="true"/>
-         </property>
-         <property name="text">
-          <string notr="true">(control ready to map message goes here)</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="2">
-        <widget class="QPushButton" name="pushButtonDone">
-         <property name="minimumSize">
-          <size>
-           <width>90</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Done</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0" colspan="3">
-        <widget class="QPushButton" name="pushButtonChooseControl">
-         <property name="mouseTracking">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Choose Control</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1">
-        <widget class="QPushButton" name="pushButtonUndo">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>90</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Reverts the most recently mapped control.</string>
-         </property>
-         <property name="text">
-          <string>Undo</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0" colspan="3">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Hints: Move knobs and sliders in both directions for best results. Make sure to touch one control at a time.</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
+          <string>(error text)</string>
          </property>
         </widget>
        </item>
       </layout>
+     </widget>
+     <widget class="QWidget" name="page2Learn">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <widget class="QWidget" name="verticalLayoutWidget_2">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>461</width>
+         <height>281</height>
+        </rect>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,2,3,4,5">
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="controlToMapMessage">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string notr="true"/>
+          </property>
+          <property name="text">
+           <string notr="true">(control ready to map message goes here)</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Hints: If you're mapping a button or switch, only press or flip it once.  For knobs and sliders, move the control in both directions for best results. Make sure to touch one control at a time.</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QProgressBar" name="progressBarWiggleFeedback">
+          <property name="maximum">
+           <number>10</number>
+          </property>
+          <property name="value">
+           <number>0</number>
+          </property>
+          <property name="format">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButtonFakeControl2">
+          <property name="text">
+           <string>Debug Fake Pushbutton Control2</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButtonFakeControl">
+          <property name="text">
+           <string>Debug Fake Pushbutton Control</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+     <widget class="QWidget" name="page3Confirm">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <widget class="QWidget" name="verticalLayoutWidget">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>471</width>
+         <height>281</height>
+        </rect>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QLabel" name="labelMappedTo">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string notr="true"/>
+          </property>
+          <property name="text">
+           <string notr="true">(successfully mapped to message goes here)</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelNextHelp">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Now test it out!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If you manipulate the control, you should see the Mixxx UI respond the way you expect. If the mapping is not working click Retry to try again or try enabling an advanced option below and then try the control again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="midiOptions">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="title">
+           <string>Advanced MIDI Options</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_2">
+           <item row="1" column="1">
+            <widget class="QCheckBox" name="midiOptionSwitchMode">
+             <property name="toolTip">
+              <string>Switch mode interprets all messages for the control as button presses.</string>
+             </property>
+             <property name="text">
+              <string>Switch Mode</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QCheckBox" name="midiOptionSoftTakeover">
+             <property name="toolTip">
+              <string>Ignores slider or knob movements until they are close to the internal value. This helps prevent unwanted extreme changes while mixing but can accidentally ignore intentional rapid movements.</string>
+             </property>
+             <property name="text">
+              <string>Soft Takeover</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QCheckBox" name="midiOptionInvert">
+             <property name="toolTip">
+              <string>Reverses the direction of the control.</string>
+             </property>
+             <property name="text">
+              <string>Invert</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QCheckBox" name="midiOptionSelectKnob">
+             <property name="toolTip">
+              <string>For jog wheels or infinite-scroll knobs. Interprets incoming messages in two's complement.</string>
+             </property>
+             <property name="text">
+              <string>Jog Wheel / Select Knob</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="spacing">
+           <number>10</number>
+          </property>
+          <item>
+           <widget class="QPushButton" name="pushButtonRetry">
+            <property name="text">
+             <string>Retry</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pushButtonLearnAnother">
+            <property name="text">
+             <string>Learn Another</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pushButtonClose_2">
+            <property name="text">
+             <string>Done</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </widget>
    </item>

--- a/src/controllers/dlgcontrollerlearning.ui
+++ b/src/controllers/dlgcontrollerlearning.ui
@@ -118,7 +118,7 @@
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>Choose Control</string>
+            <string>Choose Control...</string>
            </property>
           </widget>
          </item>
@@ -133,7 +133,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Choose a control for Mixxx to learn&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Click anywhere in Mixxx to teach it that control, you can type in the box to search for a control by name, or click the Choose Control button to select from a list.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Click anywhere in Mixxx or Choose a control to Learn&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You can click on any button, slider, or knob in Mixxx to teach it that control.  You can also type in the box to search for a control by name, or click the Choose Control button to select from a list.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -150,7 +150,7 @@
        <item row="4" column="0">
         <widget class="QLabel" name="labelDescription">
          <property name="text">
-          <string>(Description text)</string>
+          <string>(description text)</string>
          </property>
         </widget>
        </item>

--- a/src/controllers/dlgcontrollerlearning.ui
+++ b/src/controllers/dlgcontrollerlearning.ui
@@ -108,7 +108,7 @@
             <bool>true</bool>
            </property>
            <property name="insertPolicy">
-            <enum>QComboBox::InsertAlphabetically</enum>
+            <enum>QComboBox::NoInsert</enum>
            </property>
           </widget>
          </item>
@@ -133,7 +133,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>(html help)</string>
+          <string notr="true">(html help)</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -143,14 +143,14 @@
        <item row="5" column="0" colspan="3">
         <widget class="QLabel" name="labelErrorText">
          <property name="text">
-          <string>(error text)</string>
+          <string notr="true">(error text)</string>
          </property>
         </widget>
        </item>
        <item row="4" column="0" colspan="3">
         <widget class="QLabel" name="labelDescription">
          <property name="text">
-          <string>(description text)</string>
+          <string notr="true">(description text)</string>
          </property>
         </widget>
        </item>
@@ -274,7 +274,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>(html text)</string>
+          <string notr="true">(html text)</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>


### PR DESCRIPTION
A rework of the midi learning interface.  Instead of one crowded dialog box, a three-state wizard with clear flow between states!  Instead of a giant, unorganized dropdown list; a giant, organized dropdown list and a searchable combo box!  

(you may have to forcibly delete lin64_build/controllers/ui_dlgcontrollerlearning.h or similar to get it to compile correctly.)
