### PR TITLE
#1300006 - Add locale besides language name

### DIFF
--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -142,7 +142,6 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     QStringList fileNames = translationsDir.entryList(QStringList("mixxx_*.qm"));
 
     ComboBoxLocale->addItem("System", ""); // System default locale
-    ComboBoxLocale->setCurrentIndex(0);
 
     for (int i = 0; i < fileNames.size(); ++i) {
         // Extract locale from filename
@@ -154,12 +153,14 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
         if (lang == "C") { // Ugly hack to remove the non-resolving locales
             continue;
         }
-
+        lang = QString("%1 (%2)").arg(lang).arg(locale);
         ComboBoxLocale->addItem(lang, locale); // locale as userdata (for storing to config)
-        if (locale == currentLocale) { // Set the currently selected locale
-            ComboBoxLocale->setCurrentIndex(ComboBoxLocale->count() - 1);
-        }
     }
+    // Set the currently selected locale
+    int selectedIndex = ComboBoxLocale->findData(currentLocale);
+    selectedIndex = selectedIndex>0? selectedIndex:0;
+    ComboBoxLocale->setCurrentIndex(selectedIndex);
+
     connect(ComboBoxLocale, SIGNAL(activated(int)),
             this, SLOT(slotSetLocale(int)));
 

--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -140,10 +140,7 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
 
     QDir translationsDir(translationsFolder);
     QStringList fileNames = translationsDir.entryList(QStringList("mixxx_*.qm"));
-
-    ComboBoxLocale->addItem("System", ""); // System default locale
-    int selectedIndex = 0;
-
+    bool indexFlag = false; // it'll indicate if the selected index changed.
     for (int i = 0; i < fileNames.size(); ++i) {
         // Extract locale from filename
         QString locale = fileNames[i];
@@ -158,12 +155,17 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
         }
         lang = QString("%1 (%2)").arg(lang).arg(country);
         ComboBoxLocale->addItem(lang, locale); // locale as userdata (for storing to config)
-        if (locale == currentLocale) { // updates selected locale
-            selectedIndex = ComboBoxLocale->count() - 1;
+        if (locale == currentLocale) { // Set the currently selected locale
+            ComboBoxLocale->setCurrentIndex(ComboBoxLocale->count() - 1);
+            indexFlag = true;
         }
     }
-    ComboBoxLocale->setCurrentIndex(selectedIndex); // Set the currently selected locale
-    ComboBoxLocale->model()->sort(); // Sort languages list
+    ComboBoxLocale->model()->sort(0); // Sort languages list
+
+    ComboBoxLocale->insertItem(0,"System", ""); // System default locale - insert at the top
+    if (!indexFlag) { // if selectedIndex didn't change - select system default
+        ComboBoxLocale->setCurrentIndex(0);
+    }
 
     connect(ComboBoxLocale, SIGNAL(activated(int)),
             this, SLOT(slotSetLocale(int)));

--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -162,8 +162,8 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
             selectedIndex = ComboBoxLocale->count() - 1;
         }
     }
-    // Set the currently selected locale
-    ComboBoxLocale->setCurrentIndex(selectedIndex);
+    ComboBoxLocale->setCurrentIndex(selectedIndex); // Set the currently selected locale
+    ComboBoxLocale->model()->sort(); // Sort languages list
 
     connect(ComboBoxLocale, SIGNAL(activated(int)),
             this, SLOT(slotSetLocale(int)));

--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -140,6 +140,8 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
 
     QDir translationsDir(translationsFolder);
     QStringList fileNames = translationsDir.entryList(QStringList("mixxx_*.qm"));
+    fileNames.push_back("mixxx_en_US.qm"); // add source language as a fake value
+
     bool indexFlag = false; // it'll indicate if the selected index changed.
     for (int i = 0; i < fileNames.size(); ++i) {
         // Extract locale from filename

--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -142,6 +142,7 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     QStringList fileNames = translationsDir.entryList(QStringList("mixxx_*.qm"));
 
     ComboBoxLocale->addItem("System", ""); // System default locale
+    int selectedIndex = 0;
 
     for (int i = 0; i < fileNames.size(); ++i) {
         // Extract locale from filename
@@ -157,10 +158,11 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
         }
         lang = QString("%1 (%2)").arg(lang).arg(country);
         ComboBoxLocale->addItem(lang, locale); // locale as userdata (for storing to config)
+        if (locale == currentLocale) { // updates selected locale
+            selectedIndex = ComboBoxLocale->count() - 1;
+        }
     }
     // Set the currently selected locale
-    int selectedIndex = ComboBoxLocale->findData(currentLocale);
-    selectedIndex = selectedIndex>0? selectedIndex:0;
     ComboBoxLocale->setCurrentIndex(selectedIndex);
 
     connect(ComboBoxLocale, SIGNAL(activated(int)),

--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -148,12 +148,14 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
         QString locale = fileNames[i];
         locale.truncate(locale.lastIndexOf('.'));
         locale.remove(0, locale.indexOf('_') + 1);
+        QLocale qlocale = QLocale(locale);
 
-        QString lang = QLocale::languageToString(QLocale(locale).language());
+        QString lang = QLocale::languageToString(qlocale.language());
+        QString country = QLocale::countryToString(qlocale.country());
         if (lang == "C") { // Ugly hack to remove the non-resolving locales
             continue;
         }
-        lang = QString("%1 (%2)").arg(lang).arg(locale);
+        lang = QString("%1 (%2)").arg(lang).arg(country);
         ComboBoxLocale->addItem(lang, locale); // locale as userdata (for storing to config)
     }
     // Set the currently selected locale

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -661,6 +661,11 @@ void MixxxMainWindow::initializeTranslations(QApplication* pApp) {
         userLocale = m_pConfig->getValueString(ConfigKey("[Config]","Locale"));
     }
 
+    // source language
+    if (userLocale == "en_US") {
+        return;
+    }
+
     // Load Qt translations for this locale from the system translation
     // path. This is the lowest precedence QTranslator.
     QTranslator* qtTranslator = new QTranslator(pApp);


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1300006

All languages ​​are displayed from the "basic name" of QLocale and this makes that same language names are repeated...
eg. Chinese and Portuguese.
And in this way is impossible discover which one is correct...
-Portuguese of Portugal? Portuguese of Brazil?
-Chinese of China? Chinese of Taiwan?

My suggestion is to add the location next to the language, for example:
QString ("%language (%locale)")
> English (en)
 > Portuguese (pt_BR)
