### PR TITLE
Eliminate unnecessary widget renders from control changes.

### DIFF
--- a/src/widget/wdisplay.h
+++ b/src/widget/wdisplay.h
@@ -35,6 +35,8 @@ class WDisplay : public WWidget {
 
     void setup(QDomNode node, const SkinContext& context);
 
+    void onConnectedControlChanged(double dParameter, double dValue);
+
   protected:
     void paintEvent(QPaintEvent*);
 
@@ -50,7 +52,9 @@ class WDisplay : public WWidget {
 
     void setPositions(int iNoPos);
 
-    int getActivePixmapIndex() const;
+    int getPixmapForParameter(double dParameter) const;
+
+    int m_iCurrentPixmap;
 
     // Free existing pixmaps.
     void resetPositions();

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -20,6 +20,8 @@ class WKnobComposed : public WWidget {
 
     void setup(QDomNode node, const SkinContext& context);
 
+    void onConnectedControlChanged(double dParameter, double dValue);
+
   protected:
     void wheelEvent(QWheelEvent *e);
     void mouseMoveEvent(QMouseEvent *e);
@@ -32,6 +34,7 @@ class WKnobComposed : public WWidget {
     void setPixmapBackground(const QString& filename, Paintable::DrawMode mode);
     void setPixmapKnob(const QString& filename);
 
+    double m_dCurrentAngle;
     PaintablePointer m_pKnob;
     PaintablePointer m_pPixmapBack;
     KnobEventHandler<WKnobComposed> m_handler;

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -227,6 +227,10 @@ void WPushButton::onConnectedControlChanged(double dParameter, double dValue) {
     if (m_iNoStates == 1) {
         m_bPressed = (dValue == 1.0);
     }
+
+    // Since we expect button connections to not change at high frequency we
+    // don't try to detect whether things have changed for WPushButton, we just
+    // re-render.
     update();
 }
 

--- a/src/widget/wstatuslight.cpp
+++ b/src/widget/wstatuslight.cpp
@@ -120,22 +120,22 @@ void WStatusLight::onConnectedControlChanged(double dParameter, double dValue) {
     // Enums are not currently represented using parameter space so it doesn't
     // make sense to use the parameter here yet.
     Q_UNUSED(dParameter);
-    int val = static_cast<int>(dValue);
-    if (m_iPos == val) {
-        return;
-    }
+    int newPos = static_cast<int>(dValue);
 
     if (m_pixmaps.size() == 2) {
         // original behavior for two-state lights: any non-zero value is "on"
-        m_iPos = val > 0 ? 1 : 0;
-        update();
-    } else if (val < m_pixmaps.size() && val >= 0) {
-        // multi-state behavior: values must be correct
-        m_iPos = val;
-        update();
+        newPos = newPos > 0 ? 1 : 0;
+    } else if (newPos < m_pixmaps.size() && newPos >= 0) {
+        // multi-state behavior: values lie within the correct ranges
     } else {
         qDebug() << "Warning: wstatuslight asked for invalid position:"
-                 << val << "max val:" << m_pixmaps.size()-1;
+                 << newPos << "max val:" << m_pixmaps.size()-1;
+        return;
+    }
+
+    if (newPos != m_iPos) {
+        m_iPos = newPos;
+        update();
     }
 }
 

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -35,12 +35,6 @@ WWidget::~WWidget() {
     delete m_pTouchShift;
 }
 
-void WWidget::onConnectedControlChanged(double dParameter, double dValue) {
-    Q_UNUSED(dParameter);
-    Q_UNUSED(dValue);
-    update();
-}
-
 bool WWidget::touchIsRightButton() {
     return (m_pTouchShift->get() != 0.0);
 }

--- a/src/widget/wwidget.h
+++ b/src/widget/wwidget.h
@@ -45,8 +45,6 @@ class WWidget : public QWidget, public WBaseWidget {
 
     Q_PROPERTY(double value READ getControlParameterDisplay);
 
-    virtual void onConnectedControlChanged(double dParameter, double dValue);
-
   protected:
     bool touchIsRightButton();
     bool event(QEvent* e);


### PR DESCRIPTION
Instead of re-rendering on every control change (via
WWidget::onConnectedControlChanged), check for changes in what we would render
first.

Updated: WDisplay, WKnob, WKnobComposed, WSliderComposed, WStatusLight
Left unchanged: WWaveformViewer, WPushButton, WOverview, WVuMeter
