### PR TITLE
Scoped Timer speed up if not used

### DIFF
--- a/src/sounddeviceportaudio.cpp
+++ b/src/sounddeviceportaudio.cpp
@@ -320,18 +320,18 @@ int SoundDevicePortAudio::callbackProcess(const unsigned int framesPerBuffer,
 
     // Send audio from the soundcard's input off to the SoundManager...
     if (in) {
-        ScopedTimer t("SoundDevicePortAudio::callbackProcess input " + getInternalName());
+        ScopedTimer t("SoundDevicePortAudio::callbackProcess input %1", getInternalName());
         m_pSoundManager->pushBuffer(m_audioInputs, in, framesPerBuffer,
                                     m_inputParams.channelCount);
     }
 
     if (m_pSoundManager->isDeviceClkRef(this)) {
-        ScopedTimer t("SoundDevicePortAudio::callbackProcess prepare " + getInternalName());
+        ScopedTimer t("SoundDevicePortAudio::callbackProcess prepare %1", getInternalName());
         m_pSoundManager->onDeviceOutputCallback(framesPerBuffer);
     }
 
     if (output) {
-        ScopedTimer t("SoundDevicePortAudio::callbackProcess output " + getInternalName());
+        ScopedTimer t("SoundDevicePortAudio::callbackProcess output %1", getInternalName());
 
         if (m_outputParams.channelCount <= 0) {
             qWarning() << "SoundDevicePortAudio::callbackProcess m_outputParams channel count is zero or less:" << m_outputParams.channelCount;

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -33,24 +33,6 @@ class Timer {
     PerformanceTimer m_time;
 };
 
-class TimerAtMem : public Timer {
-  public:
-    TimerAtMem(const QString& key,
-                 Stat::ComputeFlags compute = kDefaultComputeFlags)
-            : Timer(key, compute) {
-    }
-    static inline void* operator new(size_t size, void* ptr) {
-        Q_UNUSED(size);
-        return ptr;
-    } // TimerAtMen's default ctor implicitly called here
-
-    static inline void operator delete(void *p, void* ptr) {
-        Q_UNUSED(p);
-        Q_UNUSED(ptr);
-    } // TimerAtMem's dtor implicitly called at this point
-};
-
-
 class SuspendableTimer : public Timer {
   public:
     SuspendableTimer(const QString& key,
@@ -71,7 +53,7 @@ class ScopedTimer {
             : m_pTimer(NULL),
               m_cancel(false) {
         if (CmdlineArgs::Instance().getDeveloper()) {
-            initalize(QString(key), QString().number(i), compute);
+            initalize(QString(key), QString::number(i), compute);
         }
     }
 

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -3,6 +3,7 @@
 
 #include "util/stat.h"
 #include "util/performancetimer.h"
+#include "util/cmdlineargs.h"
 
 const Stat::ComputeFlags kDefaultComputeFlags = Stat::COUNT | Stat::SUM | Stat::AVERAGE |
         Stat::MAX | Stat::MIN | Stat::SAMPLE_VARIANCE;
@@ -65,12 +66,33 @@ class SuspendableTimer : public Timer {
 
 class ScopedTimer {
   public:
-    ScopedTimer(const QString& key,
+    ScopedTimer(const char* key, int i,
                 Stat::ComputeFlags compute = kDefaultComputeFlags)
             : m_pTimer(NULL),
               m_cancel(false) {
-        initalize(key, compute);
+        if (CmdlineArgs::Instance().getDeveloper()) {
+            initalize(QString(key), QString().number(i), compute);
+        }
     }
+
+    ScopedTimer(const char* key, const char *arg = NULL,
+                Stat::ComputeFlags compute = kDefaultComputeFlags)
+            : m_pTimer(NULL),
+              m_cancel(false) {
+        if (CmdlineArgs::Instance().getDeveloper()) {
+            initalize(QString(key), arg ? QString(arg) : QString(), compute);
+        }
+    }
+
+    ScopedTimer(const char* key, const QString& arg,
+                Stat::ComputeFlags compute = kDefaultComputeFlags)
+            : m_pTimer(NULL),
+              m_cancel(false) {
+        if (CmdlineArgs::Instance().getDeveloper()) {
+            initalize(QString(key), arg, compute);
+        }
+    }
+
     virtual ~ScopedTimer() {
         if (m_pTimer) {
             if (!m_cancel) {
@@ -80,9 +102,15 @@ class ScopedTimer {
         }
     }
 
-    inline void initalize(const QString& key,
-            Stat::ComputeFlags compute = kDefaultComputeFlags) {
-        m_pTimer = new(m_timerMem) Timer(key, compute);
+    inline void initalize(const QString& key, const QString& arg,
+                Stat::ComputeFlags compute = kDefaultComputeFlags) {
+        QString strKey;
+        if (arg.isEmpty()) {
+            strKey = key;
+        } else {
+            strKey = key.arg(arg);
+        }
+        m_pTimer = new(m_timerMem) Timer(strKey, compute);
         m_pTimer->start();
     }
 

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -418,8 +418,7 @@ void WaveformWidgetFactory::notifyZoomChange(WWaveformViewer* viewer) {
 }
 
 void WaveformWidgetFactory::render() {
-    ScopedTimer t(QString("WaveformWidgetFactory::render() %1waveforms")
-            .arg(m_waveformWidgetHolders.size()));
+    ScopedTimer t("WaveformWidgetFactory::render() %1waveforms", m_waveformWidgetHolders.size());
 
     //int paintersSetupTime0 = 0;
     //int paintersSetupTime1 = 0;
@@ -466,8 +465,7 @@ void WaveformWidgetFactory::render() {
 }
 
 void WaveformWidgetFactory::swap() {
-    ScopedTimer t(QString("WaveformWidgetFactory::swap() %1waveforms")
-            .arg(m_waveformWidgetHolders.size()));
+    ScopedTimer t((const char*)"WaveformWidgetFactory::swap() %1waveforms", m_waveformWidgetHolders.size());
 
     // Do this in an extra slot to be sure to hit the desired interval
     if (!m_skipRender) {

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -465,7 +465,7 @@ void WaveformWidgetFactory::render() {
 }
 
 void WaveformWidgetFactory::swap() {
-    ScopedTimer t((const char*)"WaveformWidgetFactory::swap() %1waveforms", m_waveformWidgetHolders.size());
+    ScopedTimer t("WaveformWidgetFactory::swap() %1waveforms", m_waveformWidgetHolders.size());
 
     // Do this in an extra slot to be sure to hit the desired interval
     if (!m_skipRender) {


### PR DESCRIPTION
Now it should use much less CPU resources when --developer is not set.
