### PR TITLE
Don't process EQ until the user actually changes an EQ value.  

### DIFF
--- a/src/engine/enginefilterblock.h
+++ b/src/engine/enginefilterblock.h
@@ -62,6 +62,7 @@ class EngineFilterBlock : public EngineObject {
 
     int ilowFreq, ihighFreq;
     bool blofi;
+    bool m_eqNeverTouched;
 };
 
 #endif


### PR DESCRIPTION
Saves CPU for our many users who never touch the controls.
TESTED=hand tested, didn't hear popping when the changeover happens, also spat out debug output to confirm it did what I thought
