### PR TITLE
Avoid hammering ->get() calls in wspinny.

### DIFF
--- a/src/visualplayposition.cpp
+++ b/src/visualplayposition.cpp
@@ -15,6 +15,9 @@ VisualPlayPosition::VisualPlayPosition(const QString& key)
         : m_valid(false),
           m_key(key) {
     m_audioBufferSize = new ControlObjectSlave("[Master]", "audio_buffer_size");
+    m_audioBufferSize->connectValueChanged(
+            this, SLOT(slotAudioBufferSizeChanged(double)));
+    m_dAudioBufferSize = m_audioBufferSize->get();
 }
 
 VisualPlayPosition::~VisualPlayPosition() {
@@ -50,7 +53,7 @@ double VisualPlayPosition::getAtNextVSync(VSyncThread* vsyncThread) {
         double playPos = data.m_enginePlayPos;  // load playPos for the first sample in Buffer
         // add the offset for the position of the sample that will be transfered to the DAC
         // When the next display frame is displayed
-        playPos += data.m_positionStep * offset * data.m_rate / m_audioBufferSize->get() / 1000;
+        playPos += data.m_positionStep * offset * data.m_rate / m_dAudioBufferSize / 1000;
         //qDebug() << "delta Pos" << playPos - m_playPosOld << offset;
         //m_playPosOld = playPos;
         return playPos;
@@ -69,7 +72,7 @@ void VisualPlayPosition::getPlaySlipAt(int usFromNow, double* playPosition, doub
         int dacFromNow = usElapsed - data.m_callbackEntrytoDac;
         int offset = dacFromNow - usFromNow;
         double playPos = data.m_enginePlayPos;  // load playPos for the first sample in Buffer
-        playPos += data.m_positionStep * offset * data.m_rate / m_audioBufferSize->get() / 1000;
+        playPos += data.m_positionStep * offset * data.m_rate / m_dAudioBufferSize / 1000;
         *playPosition = playPos;
         *slipPosition = data.m_pSlipPosition;
     }
@@ -82,6 +85,10 @@ double VisualPlayPosition::getEnginePlayPos() {
     } else {
         return -1;
     }
+}
+
+void VisualPlayPosition::slotAudioBufferSizeChanged(double size) {
+    m_dAudioBufferSize = size;
 }
 
 //static

--- a/src/visualplayposition.h
+++ b/src/visualplayposition.h
@@ -39,10 +39,11 @@ class VisualPlayPositionData {
 };
 
 
-class VisualPlayPosition {
+class VisualPlayPosition : public QObject {
+    Q_OBJECT
   public:
     VisualPlayPosition(const QString& m_key);
-    ~VisualPlayPosition();
+    virtual ~VisualPlayPosition();
 
     // WARNING: Not thread safe. This function must be called only from the
     // engine thread.
@@ -60,9 +61,13 @@ class VisualPlayPosition {
 
     void setInvalid() { m_valid = false; };
 
+  private slots:
+    void slotAudioBufferSizeChanged(double size);
+
   private:
     ControlValueAtomic<VisualPlayPositionData> m_data;
     ControlObjectSlave* m_audioBufferSize;
+    double m_dAudioBufferSize;
     bool m_valid;
     QString m_key;
 

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -48,7 +48,6 @@ WSpinny::WSpinny(QWidget* parent, VinylControlManager* pVCMan)
           m_dPrevTheta(0.),
           m_bClampFailedWarning(false),
           m_bGhostPlayback(false),
-          m_bWasGhostPlayback(false),
           m_bWidgetDirty(false) {
 #ifdef __VINYLCONTROL__
     m_pVCManager = pVCMan;
@@ -205,7 +204,6 @@ void WSpinny::maybeUpdate() {
                                     &m_dGhostAngleCurrentPlaypos);
     if (m_dAngleCurrentPlaypos != m_dAngleLastPlaypos ||
             m_dGhostAngleCurrentPlaypos != m_dGhostAngleLastPlaypos ||
-            m_bGhostPlayback != m_bWasGhostPlayback ||
             m_bWidgetDirty) {
         repaint();
     }
@@ -251,8 +249,6 @@ void WSpinny::paintEvent(QPaintEvent *e) {
         m_fGhostAngle = calculateAngle(m_dGhostAngleCurrentPlaypos);
         m_dGhostAngleLastPlaypos = m_dGhostAngleCurrentPlaypos;
     }
-
-    m_bWasGhostPlayback = m_bGhostPlayback;
 
     if (m_pFgImage && !m_pFgImage->isNull()) {
         // Now rotate the image and draw it on the screen.

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -162,6 +162,8 @@ void WSpinny::setup(QDomNode node, const SkinContext& context, QString group) {
 
     m_pSlipEnabled = new ControlObjectThread(
             group, "slip_enabled");
+    connect(m_pSlipEnabled, SIGNAL(valueChanged(double)),
+            this, SLOT(updateSlipEnabled(double)));
     m_pSlipPosition = new ControlObjectThread(
             group, "slip_playposition");
 
@@ -201,7 +203,6 @@ void WSpinny::maybeUpdate() {
     m_pVisualPlayPos->getPlaySlipAt(0,
                                     &m_dAngleCurrentPlaypos,
                                     &m_dGhostAngleCurrentPlaypos);
-    bool m_bGhostPlayback = m_pSlipEnabled->get();
     if (m_dAngleCurrentPlaypos != m_dAngleLastPlaypos ||
             m_dGhostAngleCurrentPlaypos != m_dGhostAngleLastPlaypos ||
             m_bGhostPlayback != m_bWasGhostPlayback ||
@@ -388,6 +389,11 @@ void WSpinny::updateVinylControlSignalEnabled(double enabled) {
 
 void WSpinny::updateVinylControlEnabled(double enabled) {
     m_bVinylActive = enabled;
+    m_bWidgetDirty = true;
+}
+
+void WSpinny::updateSlipEnabled(double enabled) {
+    m_bGhostPlayback = static_cast<bool>(enabled);
     m_bWidgetDirty = true;
 }
 

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -32,6 +32,7 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
     void updateVinylControlSpeed(double rpm);
     void updateVinylControlEnabled(double enabled);
     void updateVinylControlSignalEnabled(double enabled);
+    void updateSlipEnabled(double enabled);
 
   protected slots:
     void maybeUpdate();

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -98,7 +98,6 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
     double m_dRotationsPerSecond;
     bool m_bClampFailedWarning;
     bool m_bGhostPlayback;
-    bool m_bWasGhostPlayback;
     bool m_bWidgetDirty;
 };
 


### PR DESCRIPTION
I think this might help with my spinny CPU issues by avoiding 60Hz ->get() calls for values that are unlikely to change.  Also I had declared a local variable with the same name as a member variable, and that couldn't have been good!
