### PR TITLE
Audio CPU usage ControlPotmeter 

### DIFF
--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -95,9 +95,9 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     connect(m_pSoundManager, SIGNAL(inputRegistered(AudioInput, AudioDestination*)),
             this, SLOT(loadSettings()));
 
-    m_pMasterAudioCpuOverloadCount =
-            new ControlObjectSlave("[Master]", "audio_cpu_overload_count", this);
-    m_pMasterAudioCpuOverloadCount->connectValueChanged(SLOT(bufferUnderflow(double)));
+    m_pMasterAudioLatencyOverloadCount =
+            new ControlObjectSlave("[Master]", "audio_latency_overload_count", this);
+    m_pMasterAudioLatencyOverloadCount->connectValueChanged(SLOT(bufferUnderflow(double)));
 
     m_pMasterLatency =
             new ControlObjectSlave("[Master]", "latency", this);

--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -95,9 +95,9 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     connect(m_pSoundManager, SIGNAL(inputRegistered(AudioInput, AudioDestination*)),
             this, SLOT(loadSettings()));
 
-    m_pMasterUnderflowCount =
-            new ControlObjectSlave("[Master]", "underflow_count", this);
-    m_pMasterUnderflowCount->connectValueChanged(SLOT(bufferUnderflow(double)));
+    m_pMasterAudioCpuOverloadCount =
+            new ControlObjectSlave("[Master]", "audio_cpu_overload_count", this);
+    m_pMasterAudioCpuOverloadCount->connectValueChanged(SLOT(bufferUnderflow(double)));
 
     m_pMasterLatency =
             new ControlObjectSlave("[Master]", "latency", this);

--- a/src/dlgprefsound.h
+++ b/src/dlgprefsound.h
@@ -85,7 +85,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     SoundManager *m_pSoundManager;
     PlayerManager *m_pPlayerManager;
     ConfigObject<ConfigValue> *m_pConfig;
-    ControlObjectSlave* m_pMasterAudioCpuOverloadCount;
+    ControlObjectSlave* m_pMasterAudioLatencyOverloadCount;
     ControlObjectSlave* m_pMasterLatency;
     ControlObjectSlave* m_pHeadDelay;
     ControlObjectSlave* m_pMasterDelay;

--- a/src/dlgprefsound.h
+++ b/src/dlgprefsound.h
@@ -85,7 +85,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     SoundManager *m_pSoundManager;
     PlayerManager *m_pPlayerManager;
     ConfigObject<ConfigValue> *m_pConfig;
-    ControlObjectSlave* m_pMasterUnderflowCount;
+    ControlObjectSlave* m_pMasterAudioCpuOverloadCount;
     ControlObjectSlave* m_pMasterLatency;
     ControlObjectSlave* m_pHeadDelay;
     ControlObjectSlave* m_pMasterDelay;

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -74,7 +74,7 @@ EngineMaster::EngineMaster(ConfigObject<ConfigValue>* _config,
     m_pMasterLatency = new ControlObject(ConfigKey(group, "latency"), true, true);
     m_pMasterAudioBufferSize = new ControlObject(ConfigKey(group, "audio_buffer_size"));
     m_pAudioCpuOverloadCount = new ControlObject(ConfigKey(group, "audio_cpu_overload_count"), true, true);
-    m_pAudioCpuUsage = new ControlPotmeter(ConfigKey(group, "audio_cpu_usage"), 0.0, 1.0);
+    m_pAudioCpuUsage = new ControlPotmeter(ConfigKey(group, "audio_cpu_usage"), 0.0, 0.25);
     m_pAudioCpuOverload  = new ControlPotmeter(ConfigKey(group, "audio_cpu_overload"), 0.0, 1.0);
 
     // Master rate

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -73,9 +73,9 @@ EngineMaster::EngineMaster(ConfigObject<ConfigValue>* _config,
     // Latency control
     m_pMasterLatency = new ControlObject(ConfigKey(group, "latency"), true, true);
     m_pMasterAudioBufferSize = new ControlObject(ConfigKey(group, "audio_buffer_size"));
-    m_pAudioCpuOverloadCount = new ControlObject(ConfigKey(group, "audio_cpu_overload_count"), true, true);
-    m_pAudioCpuUsage = new ControlPotmeter(ConfigKey(group, "audio_cpu_usage"), 0.0, 0.25);
-    m_pAudioCpuOverload  = new ControlPotmeter(ConfigKey(group, "audio_cpu_overload"), 0.0, 1.0);
+    m_pAudioLatencyOverloadCount = new ControlObject(ConfigKey(group, "audio_latency_overload_count"), true, true);
+    m_pAudioLatencyUsage = new ControlPotmeter(ConfigKey(group, "audio_latency_usage"), 0.0, 0.25);
+    m_pAudioLatencyOverload  = new ControlPotmeter(ConfigKey(group, "audio_latency_overload"), 0.0, 1.0);
 
     // Master rate
     m_pMasterRate = new ControlPotmeter(ConfigKey(group, "rate"), -1.0, 1.0);
@@ -168,9 +168,9 @@ EngineMaster::~EngineMaster() {
     delete m_pMasterLatency;
     delete m_pMasterAudioBufferSize;
     delete m_pMasterRate;
-    delete m_pAudioCpuOverloadCount;
-    delete m_pAudioCpuUsage;
-    delete m_pAudioCpuOverload;
+    delete m_pAudioLatencyOverloadCount;
+    delete m_pAudioLatencyUsage;
+    delete m_pAudioLatencyOverload;
 
     SampleUtil::free(m_pHead);
     SampleUtil::free(m_pMaster);

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -74,6 +74,8 @@ EngineMaster::EngineMaster(ConfigObject<ConfigValue>* _config,
     m_pMasterLatency = new ControlObject(ConfigKey(group, "latency"), true, true);
     m_pMasterAudioBufferSize = new ControlObject(ConfigKey(group, "audio_buffer_size"));
     m_pMasterUnderflowCount = new ControlObject(ConfigKey(group, "underflow_count"), true, true);
+    m_pAudioCpuUsage = new ControlPotmeter(ConfigKey(group, "audio_cpu_usage"), 0.0, 1.0);
+    m_pAudioCpuOverload  = new ControlPotmeter(ConfigKey(group, "audio_cpu_overload"), 0.0, 1.0);
 
     // Master rate
     m_pMasterRate = new ControlPotmeter(ConfigKey(group, "rate"), -1.0, 1.0);
@@ -167,6 +169,8 @@ EngineMaster::~EngineMaster() {
     delete m_pMasterAudioBufferSize;
     delete m_pMasterRate;
     delete m_pMasterUnderflowCount;
+    delete m_pAudioCpuUsage;
+    delete m_pAudioCpuOverload;
 
     SampleUtil::free(m_pHead);
     SampleUtil::free(m_pMaster);

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -73,7 +73,7 @@ EngineMaster::EngineMaster(ConfigObject<ConfigValue>* _config,
     // Latency control
     m_pMasterLatency = new ControlObject(ConfigKey(group, "latency"), true, true);
     m_pMasterAudioBufferSize = new ControlObject(ConfigKey(group, "audio_buffer_size"));
-    m_pMasterUnderflowCount = new ControlObject(ConfigKey(group, "underflow_count"), true, true);
+    m_pAudioCpuOverloadCount = new ControlObject(ConfigKey(group, "audio_cpu_overload_count"), true, true);
     m_pAudioCpuUsage = new ControlPotmeter(ConfigKey(group, "audio_cpu_usage"), 0.0, 1.0);
     m_pAudioCpuOverload  = new ControlPotmeter(ConfigKey(group, "audio_cpu_overload"), 0.0, 1.0);
 
@@ -168,7 +168,7 @@ EngineMaster::~EngineMaster() {
     delete m_pMasterLatency;
     delete m_pMasterAudioBufferSize;
     delete m_pMasterRate;
-    delete m_pMasterUnderflowCount;
+    delete m_pAudioCpuOverloadCount;
     delete m_pAudioCpuUsage;
     delete m_pAudioCpuOverload;
 

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -208,10 +208,10 @@ class EngineMaster : public QObject, public AudioSource {
     ControlObject* m_pMasterSampleRate;
     ControlObject* m_pMasterLatency;
     ControlObject* m_pMasterAudioBufferSize;
-    ControlObject* m_pAudioCpuOverloadCount;
+    ControlObject* m_pAudioLatencyOverloadCount;
     ControlPotmeter* m_pMasterRate;
-    ControlPotmeter* m_pAudioCpuUsage;
-    ControlPotmeter* m_pAudioCpuOverload;
+    ControlPotmeter* m_pAudioLatencyUsage;
+    ControlPotmeter* m_pAudioLatencyOverload;
     EngineTalkoverDucking* m_pTalkoverDucking;
     EngineDelay* m_pMasterDelay;
     EngineDelay* m_pHeadDelay;

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -208,7 +208,7 @@ class EngineMaster : public QObject, public AudioSource {
     ControlObject* m_pMasterSampleRate;
     ControlObject* m_pMasterLatency;
     ControlObject* m_pMasterAudioBufferSize;
-    ControlObject* m_pMasterUnderflowCount;
+    ControlObject* m_pAudioCpuOverloadCount;
     ControlPotmeter* m_pMasterRate;
     ControlPotmeter* m_pAudioCpuUsage;
     ControlPotmeter* m_pAudioCpuOverload;

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -210,6 +210,8 @@ class EngineMaster : public QObject, public AudioSource {
     ControlObject* m_pMasterAudioBufferSize;
     ControlObject* m_pMasterUnderflowCount;
     ControlPotmeter* m_pMasterRate;
+    ControlPotmeter* m_pAudioCpuUsage;
+    ControlPotmeter* m_pAudioCpuOverload;
     EngineTalkoverDucking* m_pTalkoverDucking;
     EngineDelay* m_pMasterDelay;
     EngineDelay* m_pHeadDelay;

--- a/src/engine/enginevumeter.cpp
+++ b/src/engine/enginevumeter.cpp
@@ -88,16 +88,10 @@ void EngineVuMeter::process(const CSAMPLE* pIn, CSAMPLE*, const int iBufferSize)
     }
 
     if (clipped) {
-        if (m_ctrlPeakIndicator->get() != 1.) {
-            m_ctrlPeakIndicator->set(1.);
-        }
+        m_ctrlPeakIndicator->set(1.);
         m_peakDuration = PEAK_DURATION * sampleRate / iBufferSize / 2000;
-    }
-
-    if (m_peakDuration <= 0) {
-        if (m_ctrlPeakIndicator->get() == 1.) {
-            m_ctrlPeakIndicator->set(0.);
-        }
+    } else if (m_peakDuration <= 0) {
+        m_ctrlPeakIndicator->set(0.);
     } else {
         --m_peakDuration;
     }

--- a/src/sounddeviceportaudio.cpp
+++ b/src/sounddeviceportaudio.cpp
@@ -64,7 +64,7 @@ SoundDevicePortAudio::SoundDevicePortAudio(ConfigObject<ConfigValue> *config, So
     m_iNumInputChannels = m_deviceInfo->maxInputChannels;
     m_iNumOutputChannels = m_deviceInfo->maxOutputChannels;
 
-    m_pMasterUnderflowCount = new ControlObjectSlave("[Master]", "underflow_count");
+    m_pMasterUnderflowCount = new ControlObjectSlave("[Master]", "audio_cpu_overload_count");
     m_pMasterAudioCpuUsage = new ControlObjectSlave("[Master]", "audio_cpu_usage");
     m_pMasterAudioCpuOverload  = new ControlObjectSlave("[Master]", "audio_cpu_overload");
 }

--- a/src/sounddeviceportaudio.cpp
+++ b/src/sounddeviceportaudio.cpp
@@ -795,7 +795,7 @@ int SoundDevicePortAudio::callbackProcessClkRef(const unsigned int framesPerBuff
         m_pMasterAudioCpuUsage->set(secInAudioCb/(m_framesSinceAudioCpuUsageUpdate/m_dSampleRate));
         m_nsInAudioCb = 0;
         m_framesSinceAudioCpuUsageUpdate = 0;
-        qDebug() << m_pMasterAudioCpuUsage << m_pMasterAudioCpuUsage->get() << secInAudioCb;
+        //qDebug() << m_pMasterAudioCpuUsage << m_pMasterAudioCpuUsage->get() << secInAudioCb;
     }
 
     //Note: Input is processed first so that any ControlObject changes made in

--- a/src/sounddeviceportaudio.cpp
+++ b/src/sounddeviceportaudio.cpp
@@ -559,7 +559,7 @@ int SoundDevicePortAudio::callbackProcessDrift(const unsigned int framesPerBuffe
                                           const PaStreamCallbackTimeInfo *timeInfo,
                                           PaStreamCallbackFlags statusFlags) {
     Q_UNUSED(timeInfo);
-    Trace trace("SoundDevicePortAudio::callbackProcessDrift " + getInternalName());
+    //Trace trace("SoundDevicePortAudio::callbackProcessDrift " + getInternalName());
 
     //qDebug() << "SoundDevicePortAudio::callbackProcess:" << getInternalName();
     // Turn on TimeCritical priority for the callback thread. If we are running
@@ -695,7 +695,7 @@ int SoundDevicePortAudio::callbackProcess(const unsigned int framesPerBuffer,
                                           const PaStreamCallbackTimeInfo *timeInfo,
                                           PaStreamCallbackFlags statusFlags) {
     Q_UNUSED(timeInfo);
-    Trace trace("SoundDevicePortAudio::callbackProcess " + getInternalName());
+    //Trace trace("SoundDevicePortAudio::callbackProcess " + getInternalName());
 
     //qDebug() << "SoundDevicePortAudio::callbackProcess:" << getInternalName();
     // Turn on TimeCritical priority for the callback thread. If we are running

--- a/src/sounddeviceportaudio.h
+++ b/src/sounddeviceportaudio.h
@@ -91,13 +91,13 @@ class SoundDevicePortAudio : public SoundDevice {
     QString m_lastError;
     // Whether we have set the thread priority to realtime or not.
     bool m_bSetThreadPriority;
-    ControlObjectSlave* m_pMasterUnderflowCount;
-    ControlObjectSlave* m_pMasterAudioCpuUsage;
-    ControlObjectSlave* m_pMasterAudioCpuOverload;
+    ControlObjectSlave* m_pMasterAudioLatencyOverloadCount;
+    ControlObjectSlave* m_pMasterAudioLatencyUsage;
+    ControlObjectSlave* m_pMasterAudioLatencyOverload;
     int m_underflowUpdateCount;
     static volatile int m_underflowHappend;
     int m_nsInAudioCb;
-    int m_framesSinceAudioCpuUsageUpdate;
+    int m_framesSinceAudioLatencyUsageUpdate;
     int m_syncBuffers;
 };
 

--- a/src/sounddeviceportaudio.h
+++ b/src/sounddeviceportaudio.h
@@ -24,7 +24,11 @@
 
 #include "sounddevice.h"
 
+#define CPU_USAGE_UPDATE_RATE 30 // in 1/s, fits to display frame rate
+#define CPU_OVERLOAD_DURATION 500 // in ms
+
 class SoundManager;
+class ControlObjectSlave;
 
 /** Dynamically resolved function which allows us to enable a realtime-priority callback
     thread from ALSA/PortAudio. This must be dynamically resolved because PortAudio can't
@@ -87,7 +91,9 @@ class SoundDevicePortAudio : public SoundDevice {
     QString m_lastError;
     // Whether we have set the thread priority to realtime or not.
     bool m_bSetThreadPriority;
-    ControlObject* m_pMasterUnderflowCount;
+    ControlObjectSlave* m_pMasterUnderflowCount;
+    ControlObjectSlave* m_pMasterAudioCpuUsage;
+    ControlObjectSlave* m_pMasterAudioCpuOverload;
     int m_underflowUpdateCount;
     static volatile int m_underflowHappend;
     int m_syncBuffers;

--- a/src/sounddeviceportaudio.h
+++ b/src/sounddeviceportaudio.h
@@ -96,6 +96,8 @@ class SoundDevicePortAudio : public SoundDevice {
     ControlObjectSlave* m_pMasterAudioCpuOverload;
     int m_underflowUpdateCount;
     static volatile int m_underflowHappend;
+    int m_nsInAudioCb;
+    int m_framesSinceAudioCpuUsageUpdate;
     int m_syncBuffers;
 };
 


### PR DESCRIPTION
This PR adds:

[Master] "audio_cpu_usage"
[Master] "audio_cpu_overload"
[Master] "audio_cpu_overload_count"

 "audio_cpu_usage" is scaled to 25% CPU in Audio callback. 25% turns out to be a hight underflow risk.  

Fixes https://bugs.launchpad.net/mixxx/+bug/892981

It can be tested with developed_skins/Deere1366x768-WXGA-master-sync-key
https://github.com/mixxxdj/developer_skins/commit/ac5cb054e02a2d7117f8d23171a75d288e9e3fe9
The preview deck VU meter is a CPU meter. 
