### PR TITLE
Master enabled

### DIFF
--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -514,6 +514,16 @@ void DlgPrefSound::slotResetToDefaults() {
     loadSettings(newConfig);
     keylockComboBox->setCurrentIndex(EngineBuffer::RUBBERBAND);
     m_pKeylockEngine->set(EngineBuffer::RUBBERBAND);
+
+    masterMixComboBox->setCurrentIndex(1);
+    m_pMasterEnabled->set(1.0);
+
+    masterDelaySpinBox->setValue(0.0);
+    m_pMasterDelay->set(0.0);
+
+    headDelaySpinBox->setValue(0.0);
+    m_pHeadDelay->set(0.0);
+
     settingChanged(); // force the apply button to enable
 }
 

--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -123,6 +123,15 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     headDelaySpinBox->setValue(m_pHeadDelay->get());
     masterDelaySpinBox->setValue(m_pMasterDelay->get());
 
+    m_pMasterEnabled =
+            new ControlObjectSlave("[Master]", "enabled", this);
+    masterMixComboBox->addItem("disabled");
+    masterMixComboBox->addItem("enabled");
+    masterMixComboBox->setCurrentIndex(m_pMasterEnabled->get() ? 1 : 0);
+    connect(masterMixComboBox, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(masterMixChanged(int)));
+
+
     m_pKeylockEngine =
             new ControlObjectSlave("[Master]", "keylock_engine", this);
 
@@ -523,4 +532,8 @@ void DlgPrefSound::headDelayChanged(double value) {
 
 void DlgPrefSound::masterDelayChanged(double value) {
     m_pMasterDelay->set(value);
+}
+
+void DlgPrefSound::masterMixChanged(int value) {
+    m_pMasterEnabled->set(value);
 }

--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -125,11 +125,12 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
 
     m_pMasterEnabled =
             new ControlObjectSlave("[Master]", "enabled", this);
-    masterMixComboBox->addItem("disabled");
-    masterMixComboBox->addItem("enabled");
+    masterMixComboBox->addItem(tr("Disabled"));
+    masterMixComboBox->addItem(tr("Enabled"));
     masterMixComboBox->setCurrentIndex(m_pMasterEnabled->get() ? 1 : 0);
     connect(masterMixComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(masterMixChanged(int)));
+    m_pMasterEnabled->connectValueChanged(this, SLOT(masterEnabledChanged(double)));
 
 
     m_pKeylockEngine =
@@ -537,3 +538,9 @@ void DlgPrefSound::masterDelayChanged(double value) {
 void DlgPrefSound::masterMixChanged(int value) {
     m_pMasterEnabled->set(value);
 }
+
+void DlgPrefSound::masterEnabledChanged(double value) {
+    masterMixComboBox->setCurrentIndex(value ? 1 : 0);
+}
+
+

--- a/src/dlgprefsound.h
+++ b/src/dlgprefsound.h
@@ -61,6 +61,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void masterLatencyChanged(double latency);
     void headDelayChanged(double value);
     void masterDelayChanged(double value);
+    void masterMixChanged(int value);
 
   private slots:
     void addPath(AudioOutput output);
@@ -90,6 +91,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlObjectSlave* m_pHeadDelay;
     ControlObjectSlave* m_pMasterDelay;
     ControlObjectSlave* m_pKeylockEngine;
+    ControlObjectSlave* m_pMasterEnabled;
     QList<SoundDevice*> m_inputDevices;
     QList<SoundDevice*> m_outputDevices;
     bool m_settingsModified;

--- a/src/dlgprefsound.h
+++ b/src/dlgprefsound.h
@@ -62,6 +62,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void headDelayChanged(double value);
     void masterDelayChanged(double value);
     void masterMixChanged(int value);
+    void masterEnabledChanged(double value);
 
   private slots:
     void addPath(AudioOutput output);

--- a/src/dlgprefsounddlg.ui
+++ b/src/dlgprefsounddlg.ui
@@ -19,7 +19,7 @@
      <item row="0" column="1">
       <widget class="QComboBox" name="apiComboBox"/>
      </item>
-     <item row="5" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="headDelayLabel">
        <property name="text">
         <string>Headphone Delay</string>
@@ -36,7 +36,7 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="7" column="1">
       <widget class="QDoubleSpinBox" name="masterDelaySpinBox">
        <property name="suffix">
         <string extracomment="milliseconds"> ms</string>
@@ -49,7 +49,7 @@
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
+     <item row="8" column="1">
       <widget class="QLabel" name="currentLatency">
        <property name="text">
         <string>20 ms</string>
@@ -66,10 +66,10 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <widget class="QComboBox" name="keylockComboBox"/>
      </item>
-     <item row="9" column="0">
+     <item row="10" column="0">
       <spacer name="outputVSpacer_3">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -88,7 +88,7 @@
      <item row="1" column="1">
       <widget class="QComboBox" name="sampleRateComboBox"/>
      </item>
-     <item row="7" column="0">
+     <item row="8" column="0">
       <widget class="QLabel" name="latencyLabel">
        <property name="text">
         <string>Known Latency</string>
@@ -98,7 +98,7 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="0">
+     <item row="9" column="0">
       <widget class="QLabel" name="underflowLabel">
        <property name="text">
         <string>Buffer Underflow Count</string>
@@ -121,14 +121,14 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
+     <item row="9" column="1">
       <widget class="QLabel" name="bufferUnderflowCount">
        <property name="text">
         <string>0</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="6" column="1">
       <widget class="QDoubleSpinBox" name="headDelaySpinBox">
        <property name="suffix">
         <string extracomment="milliseconds"> ms</string>
@@ -141,14 +141,14 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="masterDelayLabel">
        <property name="text">
         <string>Master Delay</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="keylockLabel">
        <property name="text">
         <string>Keylock/Pitch-Bending Engine</string>
@@ -167,6 +167,16 @@
      </item>
      <item row="3" column="1">
       <widget class="QComboBox" name="deviceSyncComboBox"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="masteMixLabel">
+       <property name="text">
+        <string>Master Mix</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QComboBox" name="masterMixComboBox"/>
      </item>
     </layout>
    </item>

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -560,11 +560,11 @@ const CSAMPLE* EngineMaster::buffer(AudioOutput output) const {
 void EngineMaster::onOutputConnected(AudioOutput output) {
     switch (output.getType()) {
         case AudioOutput::MASTER:
-            // not used, because we need the master buffer for headphone mix
-            // and recording/broadcasting as well
+            // overwrite config option if a master output is configured
+            m_pMasterEnabled->set(1.0);
             break;
         case AudioOutput::HEADPHONES:
-            m_pMasterEnabled->set(1.0);
+            m_pHeadphoneEnabled->set(1.0);
             break;
         case AudioOutput::BUS:
             m_bBusOutputConnected[output.getIndex()] = true;
@@ -584,7 +584,7 @@ void EngineMaster::onOutputDisconnected(AudioOutput output) {
             // and recording/broadcasting as well
             break;
         case AudioOutput::HEADPHONES:
-            m_pMasterEnabled->set(1.0);
+            m_pHeadphoneEnabled->set(1.0);
             break;
         case AudioOutput::BUS:
             m_bBusOutputConnected[output.getIndex()] = false;

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -330,11 +330,15 @@ void EngineMaster::process(const int iBufferSize) {
 
     // Compute headphone mix
     // Head phone left/right mix
-    CSAMPLE cf_val = m_pHeadMix->get();
-    CSAMPLE chead_gain = 0.5*(-cf_val+1.);
-    CSAMPLE cmaster_gain = 0.5*(cf_val+1.);
-    // qDebug() << "head val " << cf_val << ", head " << chead_gain
-    //          << ", master " << cmaster_gain;
+    CSAMPLE chead_gain = 1;
+    CSAMPLE cmaster_gain = 0;
+    if (masterEnabled) {
+        CSAMPLE cf_val = m_pHeadMix->get();
+        chead_gain = 0.5 * (-cf_val + 1.);
+        cmaster_gain = 0.5 * (cf_val + 1.);
+        // qDebug() << "head val " << cf_val << ", head " << chead_gain
+        //          << ", master " << cmaster_gain;
+    }
 
     // Mix all the enabled headphone channels together.
     m_headphoneGain.setGain(chead_gain);

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -233,8 +233,9 @@ class EngineMaster : public QObject, public AudioSource {
     CSAMPLE m_headphoneMasterGainOld;
     CSAMPLE m_headphoneVolumeOld;
 
-    volatile bool m_bMasterOutputConnected;
-    volatile bool m_bHeadphoneOutputConnected;
+    ControlObject* m_pMasterEnabled;
+    ControlObject* m_pHeadphoneEnabled;
+
     volatile bool m_bBusOutputConnected[3];
 };
 


### PR DESCRIPTION
This PR allows to skip some master and headphone buffer processing, when using external Mixer.
Headphone processing is disabled if no headphone is connected. Master can be disabled by a new preference option.  
Fixes https://bugs.launchpad.net/mixxx/+bug/1269139
