### PR TITLE
Changed EngineObject interface to use a common in/out buffer.

### DIFF
--- a/src/analyserwaveform.cpp
+++ b/src/analyserwaveform.cpp
@@ -14,7 +14,7 @@
 #include "trackinfoobject.h"
 #include "waveform/waveformfactory.h"
 
-#define fabs(x) (x < 0 ? -x : x)
+#define fabs(x) ((x) < 0 ? -(x) : (x))
 
 AnalyserWaveform::AnalyserWaveform(ConfigObject<ConfigValue>* pConfig) :
         m_skipProcessing(false),

--- a/src/analyserwaveform.cpp
+++ b/src/analyserwaveform.cpp
@@ -14,7 +14,9 @@
 #include "trackinfoobject.h"
 #include "waveform/waveformfactory.h"
 
-#define fabs(x) ((x) < 0 ? -(x) : (x))
+#warning "override standard fabs()"
+#define fabs(x) ((x) < 0 ? -(x) : (x)) // This is a hotfix, to avoid using the double version for float values
+
 
 AnalyserWaveform::AnalyserWaveform(ConfigObject<ConfigValue>* pConfig) :
         m_skipProcessing(false),

--- a/src/analyserwaveform.cpp
+++ b/src/analyserwaveform.cpp
@@ -14,6 +14,8 @@
 #include "trackinfoobject.h"
 #include "waveform/waveformfactory.h"
 
+#define fabs(x) (x < 0 ? -x : x)
+
 AnalyserWaveform::AnalyserWaveform(ConfigObject<ConfigValue>* pConfig) :
         m_skipProcessing(false),
         m_waveform(NULL),

--- a/src/analyserwaveform.h
+++ b/src/analyserwaveform.h
@@ -14,7 +14,7 @@
 //NOTS vrince some test to segment sound, to apply color in the waveform
 //#define TEST_HEAT_MAP
 
-class EngineObject;
+class EngineObjectConstIn;
 class EngineFilterButterworth8;
 class EngineFilterIIR;
 class Waveform;
@@ -175,7 +175,7 @@ class AnalyserWaveform : public Analyser {
     int m_currentStride;
     int m_currentSummaryStride;
 
-    EngineObject* m_filter[FilterCount];
+    EngineObjectConstIn* m_filter[FilterCount];
     std::vector<float> m_buffers[FilterCount];
 
     QTime* m_timer;

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -23,7 +23,7 @@ class EngineEffectChain : public EffectsRequestHandler {
         EffectsResponsePipe* pResponsePipe);
 
     void process(const QString& group,
-                 const CSAMPLE* pInput, CSAMPLE* pOutput,
+                 CSAMPLE* pInOut,
                  const unsigned int numSamples,
                  const GroupFeatureState& groupFeatures);
 

--- a/src/engine/effects/engineeffectrack.cpp
+++ b/src/engine/effects/engineeffectrack.cpp
@@ -42,21 +42,12 @@ bool EngineEffectRack::processEffectsRequest(const EffectsRequest& message,
 }
 
 void EngineEffectRack::process(const QString& group,
-                               const CSAMPLE* pInput, CSAMPLE* pOutput,
+                               CSAMPLE* pInOut,
                                const unsigned int numSamples,
                                const GroupFeatureState& groupFeatures) {
-    bool anyProcessed = false;
     foreach (EngineEffectChain* pChain, m_chains) {
         if (pChain != NULL) {
-            pChain->process(group, pInput, pOutput, numSamples, groupFeatures);
-            anyProcessed = true;
-        }
-    }
-    if (!anyProcessed && pInput != pOutput) {
-        SampleUtil::copyWithGain(pOutput, pInput, 1.0, numSamples);
-        if (kEffectDebugOutput) {
-            qDebug() << "WARNING: EngineEffectRack took the slow path!"
-                     << "If you want to do this talk to rryan.";
+            pChain->process(group, pInOut, numSamples, groupFeatures);
         }
     }
 }

--- a/src/engine/effects/engineeffectrack.h
+++ b/src/engine/effects/engineeffectrack.h
@@ -18,7 +18,7 @@ class EngineEffectRack : public EffectsRequestHandler {
         EffectsResponsePipe* pResponsePipe);
 
     void process(const QString& group,
-                 const CSAMPLE* pInput, CSAMPLE* pOutput,
+                 CSAMPLE* pInOut,
                  const unsigned int numSamples,
                  const GroupFeatureState& groupFeatures);
 

--- a/src/engine/effects/engineeffectsmanager.cpp
+++ b/src/engine/effects/engineeffectsmanager.cpp
@@ -131,11 +131,11 @@ void EngineEffectsManager::onCallbackStart() {
 }
 
 void EngineEffectsManager::process(const QString& group,
-                                   const CSAMPLE* pInput, CSAMPLE* pOutput,
+                                   CSAMPLE* pInOut,
                                    const unsigned int numSamples,
                                    const GroupFeatureState& groupFeatures) {
     foreach (EngineEffectRack* pRack, m_racks) {
-        pRack->process(group, pInput, pOutput, numSamples, groupFeatures);
+        pRack->process(group, pInOut, numSamples, groupFeatures);
     }
 }
 

--- a/src/engine/effects/engineeffectsmanager.h
+++ b/src/engine/effects/engineeffectsmanager.h
@@ -27,7 +27,7 @@ class EngineEffectsManager : public EffectsRequestHandler {
     // samples, so numSamples/2 left channel samples and numSamples/2 right
     // channel samples.
     virtual void process(const QString& group,
-                         const CSAMPLE* pInput, CSAMPLE* pOutput,
+                         CSAMPLE* pInOut,
                          const unsigned int numSamples,
                          const GroupFeatureState& groupFeatures);
 

--- a/src/engine/engineaux.cpp
+++ b/src/engine/engineaux.cpp
@@ -78,9 +78,7 @@ void EngineAux::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
     }
 }
 
-void EngineAux::process(const CSAMPLE* pInput, CSAMPLE* pOut, const int iBufferSize) {
-    Q_UNUSED(pInput);
-
+void EngineAux::process(CSAMPLE* pOut, const int iBufferSize) {
     const CSAMPLE* sampleBuffer = m_sampleBuffer; // save pointer on stack
     if (sampleBuffer) {
         memcpy(pOut, sampleBuffer, iBufferSize * sizeof(pOut[0]));
@@ -95,9 +93,9 @@ void EngineAux::process(const CSAMPLE* pInput, CSAMPLE* pOut, const int iBufferS
         // volume.
         m_vuMeter.collectFeatures(&features);
         // Process effects enabled for this channel
-        m_pEngineEffectsManager->process(getGroup(), pOut, pOut, iBufferSize,
+        m_pEngineEffectsManager->process(getGroup(), pOut, iBufferSize,
                                          features);
     }
     // Update VU meter
-    m_vuMeter.process(pOut, pOut, iBufferSize);
+    m_vuMeter.process(pOut, iBufferSize);
 }

--- a/src/engine/engineaux.h
+++ b/src/engine/engineaux.h
@@ -25,7 +25,7 @@ class EngineAux : public EngineChannel, public AudioDestination {
     bool isActive();
 
     // Called by EngineMaster whenever is requesting a new buffer of audio.
-    virtual void process(const CSAMPLE* pInput, CSAMPLE* pOutput, const int iBufferSize);
+    virtual void process(CSAMPLE* pOutput, const int iBufferSize);
 
     // This is called by SoundManager whenever there are new samples from the
     // configured input to be processed. This is run in the callback thread of

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -669,7 +669,7 @@ void EngineBuffer::slotKeylockEngineChanged(double d_index) {
 }
 
 
-void EngineBuffer::process(const CSAMPLE*, CSAMPLE* pOutput, const int iBufferSize)
+void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize)
 {
     Q_ASSERT(even(iBufferSize));
     m_pReader->process();

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -133,7 +133,7 @@ class EngineBuffer : public EngineObject {
     void requestSyncPhase();
 
     // The process methods all run in the audio callback.
-    void process(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize);
+    void process(CSAMPLE* pOut, const int iBufferSize);
     void processSlip(int iBufferSize);
 
     const char* getGroup();

--- a/src/engine/enginechannel.h
+++ b/src/engine/enginechannel.h
@@ -52,7 +52,7 @@ class EngineChannel : public EngineObject {
     void setTalkover(bool enabled);
     virtual bool isTalkover() const;
 
-    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize) = 0;
+    virtual void process(CSAMPLE* pOut, const int iBufferSize) = 0;
 
     // TODO(XXX) This hack needs to be removed.
     virtual EngineBuffer* getEngineBuffer() {

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -72,7 +72,7 @@ EngineDeck::~EngineDeck() {
     delete m_pVUMeter;
 }
 
-void EngineDeck::process(const CSAMPLE*, CSAMPLE* pOut, const int iBufferSize) {
+void EngineDeck::process(CSAMPLE* pOut, const int iBufferSize) {
     GroupFeatureState features;
     // Feed the incoming audio through if passthrough is active
     const CSAMPLE* sampleBuffer = m_sampleBuffer; // save pointer on stack
@@ -89,28 +89,28 @@ void EngineDeck::process(const CSAMPLE*, CSAMPLE* pOut, const int iBufferSize) {
         }
 
         // Process the raw audio
-        m_pBuffer->process(0, pOut, iBufferSize);
+        m_pBuffer->process(pOut, iBufferSize);
         m_pBuffer->collectFeatures(&features);
         // Emulate vinyl sounds
         m_pVinylSoundEmu->setSpeed(m_pBuffer->getSpeed());
-        m_pVinylSoundEmu->process(pOut, pOut, iBufferSize);
+        m_pVinylSoundEmu->process(pOut, iBufferSize);
         m_bPassthroughWasActive = false;
     }
 
     // Apply pregain
-    m_pPregain->process(pOut, pOut, iBufferSize);
+    m_pPregain->process(pOut, iBufferSize);
     // Filter the channel with EQs
-    m_pFilter->process(pOut, pOut, iBufferSize);
+    m_pFilter->process(pOut, iBufferSize);
     // Process effects enabled for this channel
     if (m_pEngineEffectsManager != NULL) {
         // This is out of date by a callback but some effects will want the RMS
         // volume.
         m_pVUMeter->collectFeatures(&features);
-        m_pEngineEffectsManager->process(getGroup(), pOut, pOut, iBufferSize,
+        m_pEngineEffectsManager->process(getGroup(), pOut, iBufferSize,
                                          features);
     }
     // Update VU meter
-    m_pVUMeter->process(pOut, pOut, iBufferSize);
+    m_pVUMeter->process(pOut, iBufferSize);
 }
 
 EngineBuffer* EngineDeck::getEngineBuffer() {

--- a/src/engine/enginedeck.h
+++ b/src/engine/enginedeck.h
@@ -46,7 +46,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
                EngineChannel::ChannelOrientation defaultOrientation = CENTER);
     virtual ~EngineDeck();
 
-    virtual void process(const CSAMPLE* pInput, CSAMPLE* pOutput, const int iBufferSize);
+    virtual void process(CSAMPLE* pOutput, const int iBufferSize);
 
     // TODO(XXX) This hack needs to be removed.
     virtual EngineBuffer* getEngineBuffer();

--- a/src/engine/enginedelay.cpp
+++ b/src/engine/enginedelay.cpp
@@ -57,7 +57,7 @@ void EngineDelay::slotDelayChanged() {
 }
 
 
-void EngineDelay::process(const CSAMPLE* pIn, CSAMPLE* pOutput, const int iBufferSize) {
+void EngineDelay::process(CSAMPLE* pInOut, const int iBufferSize) {
     if (m_iDelay > 0) {
         int iDelaySourcePos = (m_iDelayPos + kiMaxDelay - m_iDelay) % kiMaxDelay;
 
@@ -66,15 +66,12 @@ void EngineDelay::process(const CSAMPLE* pIn, CSAMPLE* pOutput, const int iBuffe
 
         for (int i = 0; i < iBufferSize; ++i) {
             // put sample into delay buffer:
-            m_pDelayBuffer[m_iDelayPos] = pIn[i];
+            m_pDelayBuffer[m_iDelayPos] = pInOut[i];
             m_iDelayPos = (m_iDelayPos + 1) % kiMaxDelay;
 
             // Take delayed sample from delay buffer and copy it to dest buffer:
-            pOutput[i] = m_pDelayBuffer[iDelaySourcePos];
+            pInOut[i] = m_pDelayBuffer[iDelaySourcePos];
             iDelaySourcePos = (iDelaySourcePos + 1) % kiMaxDelay;
         }
-    } else {
-        // Does nothing in case of pOutput == pIn
-        SampleUtil::copyWithGain(pOutput, pIn, 1.0, iBufferSize);
     }
 }

--- a/src/engine/enginedelay.h
+++ b/src/engine/enginedelay.h
@@ -29,7 +29,7 @@ class EngineDelay : public EngineObject {
     EngineDelay(const char* group, ConfigKey delayControl);
     virtual ~EngineDelay();
 
-    void process(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize);
+    void process(CSAMPLE* pInOut, const int iBufferSize);
 
   public slots:
     void slotDelayChanged();

--- a/src/engine/enginefilter.cpp
+++ b/src/engine/enginefilter.cpp
@@ -70,18 +70,18 @@ EngineFilter::~EngineFilter()
 
 
 
-void EngineFilter::process(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize)
+void EngineFilter::process(CSAMPLE* pInOut, const int iBufferSize)
 {
     int i;
-    for(i=0; i < iBufferSize; i+=2)
+    for(i = 0; i < iBufferSize; i += 2)
     {
-        pOut[i] = (CSAMPLE) processSample(fbuf1, (double) pIn[i]);
-        pOut[i+1] = (CSAMPLE) processSample(fbuf2, (double) pIn[i+1]);
+        pInOut[i] = (CSAMPLE) processSample(fbuf1, (double) pInOut[i]);
+        pInOut[i + 1] = (CSAMPLE) processSample(fbuf2, (double) pInOut[i + 1]);
     }
 }
 
 
-//250Hz-3Khz Butterworth
+// 250Hz-3Khz Butterworth
 double processSampleBp(void *bufIn, const double sample)
 {
     double *buf = (double*) bufIn;

--- a/src/engine/enginefilter.h
+++ b/src/engine/enginefilter.h
@@ -33,7 +33,7 @@ class EngineFilter : public EngineObject {
     EngineFilter(char* conf, int predefinedType = 0);
     virtual ~EngineFilter();
 
-    void process(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize);
+    void process(CSAMPLE* pInOut, const int iBufferSize);
 
   protected:
     double iir;

--- a/src/engine/enginefilterblock.h
+++ b/src/engine/enginefilterblock.h
@@ -42,13 +42,13 @@ class EngineFilterBlock : public EngineObject {
     EngineFilterBlock(const char* group);
     virtual ~EngineFilterBlock();
 
-    void process(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize);
+    void process(CSAMPLE* pInOut, const int iBufferSize);
 
   private:
     void setFilters(bool forceSetting = false);
 
     CSAMPLE *m_pTemp1, *m_pTemp2, *m_pTemp3;
-    EngineObject *low, *band, *high;
+    EngineObjectConstIn *low, *band, *high;
     ControlLogpotmeter *filterpotLow, *filterpotMid, *filterpotHigh;
     ControlPushButton *filterKillLow, *filterKillMid, *filterKillHigh;
     ControlObjectSlave* m_pSampleRate;

--- a/src/engine/enginefilterbutterworth8.h
+++ b/src/engine/enginefilterbutterworth8.h
@@ -6,7 +6,7 @@
 
 #include "engine/enginefilter.h"
 
-class EngineFilterButterworth8 : public EngineObject {
+class EngineFilterButterworth8 : public EngineObjectConstIn {
     Q_OBJECT
   public:
     EngineFilterButterworth8(int sampleRate, int bufSize);

--- a/src/engine/enginefilteriir.h
+++ b/src/engine/enginefilteriir.h
@@ -20,7 +20,7 @@
 #include "engine/engineobject.h"
 #include "defs.h"
 
-class EngineFilterIIR : public EngineObject {
+class EngineFilterIIR : public EngineObjectConstIn {
     Q_OBJECT
   public:
     EngineFilterIIR(const double* pCoefs, int iOrder);

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -245,7 +245,7 @@ void EngineMaster::processChannels(unsigned int* busChannelConnectionFlags,
 
                 // Process the buffer if necessary, which it damn well better be
                 if (needsProcessing) {
-                    pChannel->process(NULL, pChannelInfo->m_pBuffer, iBufferSize);
+                    pChannel->process(pChannelInfo->m_pBuffer, iBufferSize);
 
                     if (m_pTalkoverDucking->getMode() != EngineTalkoverDucking::OFF &&
                             pChannel->isTalkover()) {
@@ -288,7 +288,7 @@ void EngineMaster::processChannels(unsigned int* busChannelConnectionFlags,
 
         // Process the buffer if necessary
         if (needsProcessing) {
-            pChannel->process(NULL, pChannelInfo->m_pBuffer, iBufferSize);
+            pChannel->process(pChannelInfo->m_pBuffer, iBufferSize);
 
             if (m_pTalkoverDucking->getMode() != EngineTalkoverDucking::OFF &&
                     pChannel->isTalkover()) {
@@ -391,7 +391,7 @@ void EngineMaster::process(const int iBufferSize) {
         if (m_pVumeter != NULL) {
             m_pVumeter->collectFeatures(&masterFeatures);
         }
-        m_pEngineEffectsManager->process(getMasterGroup(), m_pMaster, m_pMaster,
+        m_pEngineEffectsManager->process(getMasterGroup(), m_pMaster,
                                          iBufferSize, masterFeatures);
     }
 
@@ -420,7 +420,7 @@ void EngineMaster::process(const int iBufferSize) {
     // Update VU meter (it does not return anything). Needs to be here so that
     // master balance is reflected in the VU meter.
     if (m_pVumeter != NULL) {
-        m_pVumeter->process(m_pMaster, m_pMaster, iBufferSize);
+        m_pVumeter->process(m_pMaster, iBufferSize);
     }
 
     // Submit master samples to the side chain to do shoutcasting, recording,
@@ -442,7 +442,7 @@ void EngineMaster::process(const int iBufferSize) {
     // Process headphone channel effects
     if (m_pEngineEffectsManager) {
         GroupFeatureState headphoneFeatures;
-        m_pEngineEffectsManager->process(getHeadphoneGroup(), m_pHead, m_pHead,
+        m_pEngineEffectsManager->process(getHeadphoneGroup(), m_pHead,
                                          iBufferSize, headphoneFeatures);
     }
 
@@ -466,8 +466,8 @@ void EngineMaster::process(const int iBufferSize) {
         }
     }
 
-    m_pMasterDelay->process(m_pMaster, m_pMaster, iBufferSize);
-    m_pHeadDelay->process(m_pHead, m_pHead, iBufferSize);
+    m_pMasterDelay->process(m_pMaster, iBufferSize);
+    m_pHeadDelay->process(m_pHead, iBufferSize);
 
     //Master/headphones interleaving is now done in
     //SoundManager::requestBuffer() - Albert Nov 18/07

--- a/src/engine/enginemicrophone.cpp
+++ b/src/engine/enginemicrophone.cpp
@@ -78,8 +78,7 @@ void EngineMicrophone::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
     }
 }
 
-void EngineMicrophone::process(const CSAMPLE* pInput, CSAMPLE* pOut, const int iBufferSize) {
-    Q_UNUSED(pInput);
+void EngineMicrophone::process(CSAMPLE* pOut, const int iBufferSize) {
 
     // If talkover is enabled, then read into the output buffer. Otherwise, skip
     // the appropriate number of samples to throw them away.
@@ -97,9 +96,9 @@ void EngineMicrophone::process(const CSAMPLE* pInput, CSAMPLE* pOut, const int i
         // This is out of date by a callback but some effects will want the RMS
         // volume.
         m_vuMeter.collectFeatures(&features);
-        m_pEngineEffectsManager->process(getGroup(), pOut, pOut, iBufferSize,
+        m_pEngineEffectsManager->process(getGroup(), pOut, iBufferSize,
                                          features);
     }
     // Update VU meter
-    m_vuMeter.process(pOut, pOut, iBufferSize);
+    m_vuMeter.process(pOut, iBufferSize);
 }

--- a/src/engine/enginemicrophone.h
+++ b/src/engine/enginemicrophone.h
@@ -24,7 +24,7 @@ class EngineMicrophone : public EngineChannel, public AudioDestination {
     bool isActive();
 
     // Called by EngineMaster whenever is requesting a new buffer of audio.
-    virtual void process(const CSAMPLE* pInput, CSAMPLE* pOutput, const int iBufferSize);
+    virtual void process(CSAMPLE* pOutput, const int iBufferSize);
 
     // This is called by SoundManager whenever there are new samples from the
     // configured input to be processed. This is run in the callback thread of

--- a/src/engine/engineobject.cpp
+++ b/src/engine/engineobject.cpp
@@ -17,27 +17,17 @@
 
 #include "engineobject.h"
 
-// Static member variable definition
-//int EngineObject::PLAY_SRATE = 0;
-
-EngineObject::EngineObject()
-{
+EngineObject::EngineObject() {
 }
 
-EngineObject::~EngineObject()
-{
+EngineObject::~EngineObject() {
 }
 
-/*
-   void EngineObject::setPlaySrate(int srate)
-   {
-    PLAY_SRATE = srate;
-   }
+EngineObjectConstIn::EngineObjectConstIn() {
+}
 
-   int EngineObject::getPlaySrate()
-   {
-    return PLAY_SRATE;
-   }
+EngineObjectConstIn::~EngineObjectConstIn() {
+}
 
- */
+
 

--- a/src/engine/engineobject.h
+++ b/src/engine/engineobject.h
@@ -32,15 +32,24 @@ class EngineObject : public QObject {
   public:
     EngineObject();
     virtual ~EngineObject();
-
-    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOut,
-                         const int iLen) = 0;
+    virtual void process(CSAMPLE* pInOut,
+                         const int iBufferSize) = 0;
 
     // Sub-classes re-implement and populate GroupFeatureState with the features
     // they extract.
     virtual void collectFeatures(GroupFeatureState* pGroupFeatures) const {
         Q_UNUSED(pGroupFeatures);
     }
+};
+
+class EngineObjectConstIn : public QObject {
+    Q_OBJECT
+  public:
+    EngineObjectConstIn();
+    virtual ~EngineObjectConstIn();
+
+    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOut,
+                         const int iBufferSize) = 0;
 };
 
 #endif

--- a/src/engine/enginepregain.cpp
+++ b/src/engine/enginepregain.cpp
@@ -60,7 +60,7 @@ EnginePregain::~EnginePregain()
     s_pReplayGainBoost = NULL;
 }
 
-void EnginePregain::process(const CSAMPLE* pIn, CSAMPLE* pOutput, const int iBufferSize) {
+void EnginePregain::process(CSAMPLE* pInOut, const int iBufferSize) {
 
     float fEnableReplayGain = s_pEnableReplayGain->get();
     float fReplayGainBoost = s_pReplayGainBoost->get();
@@ -117,10 +117,10 @@ void EnginePregain::process(const CSAMPLE* pIn, CSAMPLE* pOutput, const int iBuf
 
     if (fGain != m_fPrevGain) {
         // Prevent soundwave discontinuities by interpolating from old to new gain.
-        SampleUtil::copyWithRampingGain(pOutput, pIn, m_fPrevGain, fGain, iBufferSize);
+        SampleUtil::applyRampingGain(pInOut, m_fPrevGain, fGain, iBufferSize);
     } else {
         // SampleUtil deals with aliased buffers and gains of 1 or 0.
-        SampleUtil::copyWithGain(pOutput, pIn, fGain, iBufferSize);
+        SampleUtil::applyGain(pInOut, fGain, iBufferSize);
     }
     m_fPrevGain = fGain;
 }

--- a/src/engine/enginepregain.h
+++ b/src/engine/enginepregain.h
@@ -30,7 +30,7 @@ class EnginePregain : public EngineObject {
     EnginePregain(const char* group);
     virtual ~EnginePregain();
 
-    void process(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize);
+    void process(CSAMPLE* pInOut, const int iBufferSize);
 
   private:
     float m_fPrevGain;

--- a/src/engine/enginevinylsoundemu.h
+++ b/src/engine/enginevinylsoundemu.h
@@ -31,7 +31,7 @@ class EngineVinylSoundEmu : public EngineObject {
     virtual ~EngineVinylSoundEmu();
 
     void setSpeed(double speed);
-    void process(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize);
+    void process(CSAMPLE* pInOut, const int iBufferSize);
 
   private:
     double m_dSpeed;

--- a/src/engine/enginevumeter.cpp
+++ b/src/engine/enginevumeter.cpp
@@ -50,7 +50,7 @@ EngineVuMeter::~EngineVuMeter()
     delete m_ctrlPeakIndicator;
 }
 
-void EngineVuMeter::process(const CSAMPLE* pIn, CSAMPLE*, const int iBufferSize) {
+void EngineVuMeter::process(CSAMPLE* pIn, const int iBufferSize) {
     CSAMPLE fVolSumL, fVolSumR;
 
     int sampleRate = (int)m_pSampleRate->get();

--- a/src/engine/enginevumeter.h
+++ b/src/engine/enginevumeter.h
@@ -37,7 +37,7 @@ class EngineVuMeter : public EngineObject {
     EngineVuMeter(const char*);
     virtual ~EngineVuMeter();
 
-    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOut, const int iBufferSize);
+    virtual void process(CSAMPLE* pInOut, const int iBufferSize);
 
     virtual void collectFeatures(GroupFeatureState* pGroupFeatures) const;
 


### PR DESCRIPTION
This clarifies code in the implemeting objects. It was a cause of bug,
fixes now in EngineVinylSoundEmu and EngineFilterBlock.

Please see my in-line comments.
