### PR TITLE
Fixed bug with seconds counter

### DIFF
--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -217,8 +217,8 @@ void EngineRecord::process(const CSAMPLE* pBuffer, const int iBufferSize) {
 
 QString EngineRecord::getRecordedDurationStr() {
     return QString("%1:%2")
-                 .arg(m_recordedDuration / 60, 2, 'f', 0, '0') // minutes
-                 .arg(m_recordedDuration, 2, 'f', 0, '0');     // seconds
+                 .arg(m_recordedDuration / 60, 2, 'f', 0, '0')   // minutes
+                 .arg(m_recordedDuration % 60, 2, 'f', 0, '0');  // seconds
 }
 
 void EngineRecord::writeCueLine() {


### PR DESCRIPTION
> @esbrandt
> Something is odd with the duration display.
> The minutes count up every 60 sec., but seconds keep going."
