### PR TITLE
Fix findnth beat so "prevbeat" returns the current beat if the playhead ...

### DIFF
--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -736,6 +736,12 @@ void BpmControl::collectFeatures(GroupFeatureState* pGroupFeatures) const {
 
     // Get the current position of this deck.
     double dThisPosition = getCurrentSample();
+
+    // No need to recalculate.
+    if (dThisPosition == m_dPreviousSample) {
+        return;
+    }
+
     double dThisPrevBeat;
     double dThisNextBeat;
     double dThisBeatLength;

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -73,7 +73,6 @@ EngineDeck::~EngineDeck() {
 }
 
 void EngineDeck::process(CSAMPLE* pOut, const int iBufferSize) {
-    GroupFeatureState features;
     // Feed the incoming audio through if passthrough is active
     const CSAMPLE* sampleBuffer = m_sampleBuffer; // save pointer on stack
     if (isPassthroughActive() && sampleBuffer) {
@@ -90,7 +89,7 @@ void EngineDeck::process(CSAMPLE* pOut, const int iBufferSize) {
 
         // Process the raw audio
         m_pBuffer->process(pOut, iBufferSize);
-        m_pBuffer->collectFeatures(&features);
+        m_pBuffer->collectFeatures(&m_groupFeatureState);
         // Emulate vinyl sounds
         m_pVinylSoundEmu->setSpeed(m_pBuffer->getSpeed());
         m_pVinylSoundEmu->process(pOut, iBufferSize);
@@ -105,9 +104,9 @@ void EngineDeck::process(CSAMPLE* pOut, const int iBufferSize) {
     if (m_pEngineEffectsManager != NULL) {
         // This is out of date by a callback but some effects will want the RMS
         // volume.
-        m_pVUMeter->collectFeatures(&features);
+        m_pVUMeter->collectFeatures(&m_groupFeatureState);
         m_pEngineEffectsManager->process(getGroup(), pOut, iBufferSize,
-                                         features);
+                                         m_groupFeatureState);
     }
     // Update VU meter
     m_pVUMeter->process(pOut, iBufferSize);

--- a/src/engine/enginedeck.h
+++ b/src/engine/enginedeck.h
@@ -83,6 +83,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     EngineVinylSoundEmu* m_pVinylSoundEmu;
     EngineVuMeter* m_pVUMeter;
     EngineEffectsManager* m_pEngineEffectsManager;
+    GroupFeatureState m_groupFeatureState;
 
     // Begin vinyl passthrough fields
     ControlPushButton* m_pPassing;

--- a/src/engine/quantizecontrol.cpp
+++ b/src/engine/quantizecontrol.cpp
@@ -13,7 +13,8 @@
 
 QuantizeControl::QuantizeControl(const char* pGroup,
                                  ConfigObject<ConfigValue>* pConfig)
-        : EngineControl(pGroup, pConfig) {
+        : EngineControl(pGroup, pConfig),
+          m_oldClosestSample(-1) {
     // Turn quantize OFF by default. See Bug #898213
     m_pCOQuantizeEnabled = new ControlPushButton(ConfigKey(pGroup, "quantize"));
     m_pCOQuantizeEnabled->setButtonMode(ControlPushButton::TOGGLE);
@@ -80,6 +81,12 @@ double QuantizeControl::process(const double dRate,
     if (!even(iCurrentSample)) {
         iCurrentSample--;
     }
+
+    // No need to recalculate if nothing changed.
+    if (iCurrentSample == m_oldClosestSample) {
+        return kNoTrigger;
+    }
+    m_oldClosestSample = iCurrentSample;
 
     double prevBeat = m_pCOPrevBeat->get();
     double nextBeat = m_pCONextBeat->get();

--- a/src/engine/quantizecontrol.h
+++ b/src/engine/quantizecontrol.h
@@ -39,6 +39,8 @@ class QuantizeControl : public EngineControl {
 
     TrackPointer m_pTrack;
     BeatsPointer m_pBeats;
+
+    int m_oldClosestSample;
 };
 
 #endif // QUANTIZECONTROL_H

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -144,17 +144,15 @@ double BeatGrid::findNthBeat(double dSamples, int n) const {
     }
 
     double beatFraction = (dSamples - firstBeatSample()) / m_dBeatLength;
-    const double prevBeat = floor(beatFraction);
-    const double nextBeat = ceil(beatFraction);
+    double prevBeat = floor(beatFraction);
+    double nextBeat = ceil(beatFraction);
 
     // If the position is within 1/100th of the next or previous beat, treat it
     // as if it is that beat.
     const double kEpsilon = .01;
-
     if (fabs(nextBeat - beatFraction) < kEpsilon) {
-        beatFraction = nextBeat;
-    } else if (fabs(prevBeat - beatFraction) < kEpsilon) {
-        beatFraction = prevBeat;
+        ++nextBeat;
+        ++prevBeat;
     }
 
     double dClosestBeat;

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -187,6 +187,12 @@ double BeatMap::findNthBeat(double dSamples, int n) const {
         BeatList::const_iterator it =
                 qLowerBound(m_beats.begin(), m_beats.end(), beat, BeatLessThan);
 
+        // If dSamples is right on the beat, LessThan will start us at the
+        // previus beat.
+        if (dSamples == framesToSamples(it->frame_position())) {
+            ++it;
+        }
+
         // Count down until n=1
         while (it != m_beats.end()) {
             if (!it->enabled()) {
@@ -204,6 +210,11 @@ double BeatMap::findNthBeat(double dSamples, int n) const {
         BeatList::const_iterator it =
                 qUpperBound(m_beats.begin(), m_beats.end(), beat, BeatLessThan);
 
+        // If dSamples is right on the beat, LessThan will start us at the
+        // previus beat.
+        if (dSamples == framesToSamples(it->frame_position())) {
+            ++it;
+        }
 
         // Count up until n=-1
         while (it != m_beats.begin()) {


### PR DESCRIPTION
...is on the beat.  This fixes the bug (https://bugs.launchpad.net/mixxx/+bug/1313063) where loops are off-by-one if the playhead started exactly on the beat.
