### PR TITLE
Auto DJ should show tracks that have been hidden in the library.

### DIFF
--- a/src/dlgautodj.cpp
+++ b/src/dlgautodj.cpp
@@ -44,8 +44,10 @@ DlgAutoDJ::DlgAutoDJ(QWidget* parent, ConfigObject<ConfigValue>* pConfig,
     m_pTrackTablePlaceholder->hide();
     box->insertWidget(1, m_pTrackTableView);
 
+    // Auto DJ should show tracks that have been hidden in the library.
     m_pAutoDJTableModel = new PlaylistTableModel(this, pTrackCollection,
-                                                 "mixxx.db.model.autodj");
+                                                 "mixxx.db.model.autodj",
+                                                 true);
     PlaylistDAO& playlistDao = pTrackCollection->getPlaylistDAO();
     int playlistId = playlistDao.getPlaylistIdFromName(AUTODJ_TABLE);
     if (playlistId < 0) {

--- a/src/dlgautodj.cpp
+++ b/src/dlgautodj.cpp
@@ -44,10 +44,8 @@ DlgAutoDJ::DlgAutoDJ(QWidget* parent, ConfigObject<ConfigValue>* pConfig,
     m_pTrackTablePlaceholder->hide();
     box->insertWidget(1, m_pTrackTableView);
 
-    // Auto DJ should show tracks that have been hidden in the library.
     m_pAutoDJTableModel = new PlaylistTableModel(this, pTrackCollection,
-                                                 "mixxx.db.model.autodj",
-                                                 true);
+                                                 "mixxx.db.model.autodj");
     PlaylistDAO& playlistDao = pTrackCollection->getPlaylistDAO();
     int playlistId = playlistDao.getPlaylistIdFromName(AUTODJ_TABLE);
     if (playlistId < 0) {

--- a/src/library/autodjfeature.cpp
+++ b/src/library/autodjfeature.cpp
@@ -127,6 +127,7 @@ bool AutoDJFeature::dropAccept(QList<QUrl> urls, QObject* pSource) {
     QList<int> trackIds;
     if (pSource) {
         trackIds = trackDao.getTrackIds(files);
+        trackDao.unhideTracks(trackIds);
     } else {
         trackIds = trackDao.addTracks(files, true);
     }

--- a/src/library/cratefeature.cpp
+++ b/src/library/cratefeature.cpp
@@ -141,6 +141,7 @@ bool CrateFeature::dropAcceptChild(const QModelIndex& index, QList<QUrl> urls,
     QList<int> trackIds;
     if (pSource) {
         trackIds = m_pTrackCollection->getTrackDAO().getTrackIds(files);
+        m_pTrackCollection->getTrackDAO().unhideTracks(trackIds);
     } else {
         // Adds track, does not insert duplicates, handles unremoving logic.
         trackIds = m_pTrackCollection->getTrackDAO().addTracks(files, true);

--- a/src/library/playlistfeature.cpp
+++ b/src/library/playlistfeature.cpp
@@ -92,6 +92,7 @@ bool PlaylistFeature::dropAcceptChild(const QModelIndex& index, QList<QUrl> urls
     QList<int> trackIds;
     if (pSource) {
         trackIds = m_pTrackCollection->getTrackDAO().getTrackIds(files);
+        m_pTrackCollection->getTrackDAO().unhideTracks(trackIds);
     } else {
         // If a track is dropped onto a playlist's name, but the track isn't in the
         // library, then add the track to the library before adding it to the


### PR DESCRIPTION
I often pull random tracks from my filesystem for autodj, so even if I've previously hidden them they should show up.
