### PR TITLE
Fix mediafoundation after math refactor

### DIFF
--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -85,7 +85,7 @@ SoundSourceMediaFoundation::~SoundSourceMediaFoundation()
     CoUninitialize();
 }
 
-int SoundSourceMediaFoundation::open()
+Result SoundSourceMediaFoundation::open()
 {
     if (sDebug) {
         qDebug() << "open()" << m_qFilename;
@@ -373,7 +373,7 @@ inline unsigned long SoundSourceMediaFoundation::length()
     return len % kNumChannels == 0 ? len : len + 1;
 }
 
-int SoundSourceMediaFoundation::parseHeader()
+Result SoundSourceMediaFoundation::parseHeader()
 {
     setType("m4a");
 

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
@@ -23,7 +23,7 @@
 #include <QFile>
 #include <QString>
 
-#include "defs.h"
+#include "util/defs.h"
 #include "defs_version.h"
 #include "soundsource.h"
 
@@ -41,11 +41,11 @@ class SoundSourceMediaFoundation : public Mixxx::SoundSource {
   public:
     SoundSourceMediaFoundation(QString filename);
     ~SoundSourceMediaFoundation();
-    int open();
+    Result open();
     long seek(long filepos);
     unsigned read(unsigned long size, const SAMPLE *buffer);
     inline long unsigned length();
-    int parseHeader();
+    Result parseHeader();
     static QList<QString> supportedFileExtensions();
 
   private:


### PR DESCRIPTION
Started playing around with Mixxx yesterday and noticed this compilation issue.

I tried searching Launchpad for an associated bug, but I'm not confident I was using Launchpad correctly...
