### PR TITLE
Fix segfault in QTouchEvent handler

### DIFF
--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -63,8 +63,9 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
                 m_fakeMouseSourcePointId = touchPoints.first().id();
                 m_fakeMouseWidget = dynamic_cast<QWidget*>(target);
                 fakeMouseWidget = m_fakeMouseWidget;
+                break;
             }
-            break;
+            return false;
         case QEvent::TouchUpdate:
             if (m_fakeMouseWidget) {
                 eventType = QEvent::MouseMove;

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -35,6 +35,7 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
         QEvent::Type eventType = QEvent::None;
         Qt::MouseButtons buttons = Qt::NoButton;
         QWidget* fakeMouseWidget = NULL;
+        bool baseReturn;
 
         //qDebug() << "&" << touchEvent->type() << target;
 
@@ -45,7 +46,7 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
         switch (event->type()) {
         case QEvent::TouchBegin:
             // try to deliver as touch event
-            (void)QApplication::notify(target, event);
+            baseReturn = QApplication::notify(target, event);
             if (dynamic_cast<MixxxMainWindow*>(touchEvent->widget())) {
                 // the touchEvent has fallen trough to the MixxxMainWindow, because there
                 // was no touch enabled widget found.
@@ -65,7 +66,7 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
                 fakeMouseWidget = m_fakeMouseWidget;
                 break;
             }
-            return false;
+            return baseReturn;
         case QEvent::TouchUpdate:
             if (m_fakeMouseWidget) {
                 eventType = QEvent::MouseMove;


### PR DESCRIPTION
Ran into this issue when I touched the waveform overview on my Win8 machine:

If the check on line 49 ("if (dynamic_cast<MixxxMainWindow*>(touchEvent->widget()))") fails, then fakeMouseWidget remains NULL when it is used on line 94.

Is return false the right way to handle this?
