### PR TITLE
A fix for bug 1199945: AnalysisFeature title changed when analyser queue is busy.

### DIFF
--- a/src/dlganalysis.cpp
+++ b/src/dlganalysis.cpp
@@ -147,6 +147,10 @@ void DlgAnalysis::trackAnalysisProgress(int progress) {
     }
 }
 
+int DlgAnalysis::getNumTracks() {
+	return m_tracksInQueue;
+}
+
 void DlgAnalysis::trackAnalysisStarted(int size) {
     m_tracksInQueue = size;
 }

--- a/src/dlganalysis.h
+++ b/src/dlganalysis.h
@@ -27,6 +27,7 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
     inline const QString currentSearch() {
         return m_pAnalysisLibraryTableModel->currentSearch();
     }
+    int getNumTracks();
 
   public slots:
     void tableSelectionChanged(const QItemSelection& selected,

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -13,6 +13,7 @@
 #include "analyserqueue.h"
 #include "soundsourceproxy.h"
 #include "util/dnd.h"
+#include "util/debug.h"
 
 const QString AnalysisFeature::m_sAnalysisViewName = QString("Analysis");
 
@@ -25,6 +26,7 @@ AnalysisFeature::AnalysisFeature(QObject* parent,
         m_pAnalyserQueue(NULL),
         m_iOldBpmEnabled(0),
         m_pAnalysisView(NULL) {
+	setTitleDefault();
 }
 
 AnalysisFeature::~AnalysisFeature() {
@@ -33,8 +35,27 @@ AnalysisFeature::~AnalysisFeature() {
     cleanupAnalyser();
 }
 
+// Sets the title of this feature to the default name, given by m_sAnalysisTitleName
+void AnalysisFeature::setTitleDefault() {
+	m_Title = tr(m_sAnalysisTitleName);
+	emit(featureIsLoading(this, false));	// Signals a change in title
+}
+
+// Sets the title of this feature to the default name followed by (x / y)
+// where x is the current track being analyzed and y is the total number of tracks in the job
+void AnalysisFeature::setTitleProgress(int trackNum, int totalNum) {
+	QString title = tr(m_sAnalysisTitleName);
+	title.append(" (");
+	title.append(QString::number(trackNum));
+	title.append(" / ");
+	title.append(QString::number(totalNum));
+	title.append(")");
+	m_Title = title;
+	emit(featureIsLoading(this, false));	// Signals a change in title
+}
+
 QVariant AnalysisFeature::title() {
-    return tr("Analyze");
+    return m_Title;
 }
 
 QIcon AnalysisFeature::getIcon() {
@@ -100,6 +121,8 @@ void AnalysisFeature::analyzeTracks(QList<int> trackIds) {
         connect(m_pAnalyserQueue, SIGNAL(trackProgress(int)),
                 m_pAnalysisView, SLOT(trackAnalysisProgress(int)));
         connect(m_pAnalyserQueue, SIGNAL(trackFinished(int)),
+                this, SLOT(slotProgressUpdate(int)));
+        connect(m_pAnalyserQueue, SIGNAL(trackFinished(int)),
                 m_pAnalysisView, SLOT(trackAnalysisFinished(int)));
 
         connect(m_pAnalyserQueue, SIGNAL(queueEmpty()),
@@ -114,7 +137,14 @@ void AnalysisFeature::analyzeTracks(QList<int> trackIds) {
             m_pAnalyserQueue->queueAnalyseTrack(pTrack);
         }
     }
+    if(trackIds.size() > 0)
+    	setTitleProgress(0, trackIds.size());
     emit(trackAnalysisStarted(trackIds.size()));
+}
+
+void AnalysisFeature::slotProgressUpdate(int num_left) {
+	int num_tracks = m_pAnalysisView->getNumTracks();
+	setTitleProgress(num_tracks - num_left, num_tracks);
 }
 
 void AnalysisFeature::stopAnalysis() {
@@ -125,6 +155,7 @@ void AnalysisFeature::stopAnalysis() {
 }
 
 void AnalysisFeature::cleanupAnalyser() {
+	setTitleDefault();
     emit(analysisActive(false));
     if (m_pAnalyserQueue != NULL) {
         m_pAnalyserQueue->stop();

--- a/src/library/analysisfeature.h
+++ b/src/library/analysisfeature.h
@@ -48,17 +48,24 @@ class AnalysisFeature : public LibraryFeature {
     void analyzeTracks(QList<int> trackIds);
 
   private slots:
+    void slotProgressUpdate(int num_left);
     void stopAnalysis();
     void cleanupAnalyser();
 
   private:
+    void setTitleDefault();		// Set title to tr("Analyze")
+    void setTitleProgress(int trackNum, int totalNum);	// Set title to "Analyze (x out of y)"
+
     ConfigObject<ConfigValue>* m_pConfig;
     TrackCollection* m_pTrackCollection;
     AnalyserQueue* m_pAnalyserQueue;
     // Used to temporarily enable BPM detection in the prefs before we analyse
     int m_iOldBpmEnabled;
+    // The title returned by title()
+    QVariant m_Title;
     TreeItemModel m_childModel;
     const static QString m_sAnalysisViewName;
+    const char * m_sAnalysisTitleName = "Analyze";
     DlgAnalysis* m_pAnalysisView;
 };
 

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -169,7 +169,7 @@ void ITunesFeature::activate(bool forceReload) {
         m_future_watcher.setFuture(m_future);
         m_title = tr("(loading) iTunes");
         // calls a slot in the sidebar model such that 'iTunes (isLoading)' is displayed.
-        emit (featureIsLoading(this));
+        emit (featureIsLoading(this, true));
     }
 
     emit(showTrackModel(m_pITunesTrackModel));

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -86,7 +86,8 @@ class LibraryFeature : public QObject {
     void loadTrackToPlayer(TrackPointer pTrack, QString group, bool play = false);
     void restoreSearch(const QString&);
     // emit this signal before you parse a large music collection, e.g., iTunes, Traktor.
-    void featureIsLoading(LibraryFeature*);
+    // The second arg indicates if the feature should be "selected" when loading starts
+    void featureIsLoading(LibraryFeature*, bool selectFeature);
     // emit this signal if the foreign music collection has been imported/parsed.
     void featureLoadingFinished(LibraryFeature*s);
     // emit this signal to select pFeature

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -117,7 +117,7 @@ void RhythmboxFeature::activate() {
         m_track_watcher.setFuture(m_track_future);
         m_title = "(loading) Rhythmbox";
         //calls a slot in the sidebar model such that 'Rhythmbox (isLoading)' is displayed.
-        emit (featureIsLoading(this));
+        emit (featureIsLoading(this, true));
     }
 
     emit(showTrackModel(m_pRhythmboxTrackModel));

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -18,8 +18,8 @@ SidebarModel::~SidebarModel() {
 
 void SidebarModel::addLibraryFeature(LibraryFeature* feature) {
     m_sFeatures.push_back(feature);
-    connect(feature, SIGNAL(featureIsLoading(LibraryFeature*)),
-            this, SLOT(slotFeatureIsLoading(LibraryFeature*)));
+    connect(feature, SIGNAL(featureIsLoading(LibraryFeature*, bool)),
+            this, SLOT(slotFeatureIsLoading(LibraryFeature*, bool)));
     connect(feature, SIGNAL(featureLoadingFinished(LibraryFeature*)),
             this, SLOT(slotFeatureLoadingFinished(LibraryFeature*)));
     connect(feature, SIGNAL(featureSelect(LibraryFeature*, const QModelIndex&)),
@@ -375,13 +375,13 @@ void SidebarModel::slotModelReset() {
 
 /*
  * Call this slot whenever the title of the feature has changed.
- * See RhythmboxFeature for an example.
- * While the rhythmbox music collection is parsed
- * the title becomes '(loading) Rhythmbox'
+ * See RhythmboxFeature for an example, in which the title becomes '(loading) Rhythmbox'
+ * If selectFeature is true, the feature is selected when the title change occurs.
  */
-void SidebarModel::slotFeatureIsLoading(LibraryFeature * feature) {
+void SidebarModel::slotFeatureIsLoading(LibraryFeature * feature, bool selectFeature) {
     featureRenamed(feature);
-    slotFeatureSelect(feature);
+    if(selectFeature)
+    	slotFeatureSelect(feature);
 }
 
 /* Tobias: This slot is somewhat redundant but I decided

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -56,7 +56,7 @@ class SidebarModel : public QAbstractItemModel {
     void slotRowsInserted(const QModelIndex& parent, int start, int end);
     void slotRowsRemoved(const QModelIndex& parent, int start, int end);
     void slotModelReset();
-    void slotFeatureIsLoading(LibraryFeature*);
+    void slotFeatureIsLoading(LibraryFeature*, bool selectFeature);
     void slotFeatureLoadingFinished(LibraryFeature*);
 
   signals:

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -146,7 +146,7 @@ void TraktorFeature::activate() {
         m_future_watcher.setFuture(m_future);
         m_title = tr("(loading) Traktor");
         //calls a slot in the sidebar model such that 'iTunes (isLoading)' is displayed.
-        emit (featureIsLoading(this));
+        emit (featureIsLoading(this, true));
     }
 
     emit(showTrackModel(m_pTraktorTableModel));


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1199945
Progress of the analyser queue is now visible from anywhere, via a change in the title from 'Analyze' to 'Analyze (x / y)' where x is the number of tracks that have been analyzed so far and y is the total number of tracks originally in the queue. This is an alternative to the progess bar images created by jus, as it allows for more detail in knowing how many tracks are left.
