### PR TITLE
Allow inline svg handling Variable elements in skins

### DIFF
--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -210,87 +210,87 @@ QString SkinContext::nodeToString(const QDomNode& node) const {
 
 // look for the document of a node
 QDomDocument SkinContext::getDocument(const QDomNode& node) const {
-	
-	QDomDocument document;
-	QDomNode parentNode = node;
-	// QString parentTagName = varValueNode.parentNode().toElement().tagName();
-	while( !parentNode.isNull() ){
-		if( parentNode.isDocument() )
-			document = parentNode.toDocument();
-		parentNode = parentNode.parentNode();
-	}
-	
-	return document;
+    
+    QDomDocument document;
+    QDomNode parentNode = node;
+    // QString parentTagName = varValueNode.parentNode().toElement().tagName();
+    while( !parentNode.isNull() ){
+        if( parentNode.isDocument() )
+            document = parentNode.toDocument();
+        parentNode = parentNode.parentNode();
+    }
+    
+    return document;
 }
 
 
 // replaces Variables nodes in an svg dom tree
 QString SkinContext::setVariablesInSvg(const QDomNode& svgSkinNode) const {
-	
-	// clone svg to don't alter xml input
-	QDomNode svgNode = svgSkinNode.cloneNode(true);
-	
-	QDomDocument document = getDocument(svgNode);
-	
-	QDomElement svgElement = svgNode.toElement();
-	
-	QDomNodeList variablesElements = svgElement.elementsByTagName("Variable");
-	
-	// replace variables
-	uint variableIndex;
-	QDomElement varElement;
-	QString varName, varValue;
-	QDomNode varNode;
-	QDomNode varParentNode;
-	QDomNode oldChild;
-	QDomText varValueNode;
-	
-	for (variableIndex=0; variableIndex < variablesElements.length(); variableIndex++){
-		
-		// retrieve value
-		varNode = variablesElements.item(variableIndex);
-		varElement = varNode.toElement();
-		varName = varElement.attribute("name");
-		varValue = variable(varName);
-		
-		// qWarning()
-				// << "SVG : " << varName << " => " << varValue << "\n";
-		
-		// replace node by its value
-		varParentNode = varNode.parentNode();
-		
-		varValueNode = document.createTextNode(varValue);
-		
-		oldChild = varParentNode.replaceChild( varValueNode, varNode );
-		if( oldChild.isNull() ){
-			// replaceChild has a really weird behaviour so I add this check
-			qDebug()
-					<< "SVG : unable to replace dom node changed. \n";
-		}
-	}
-	
-	// Save the new svg in a temp file to use it with setPixmap
-	QTemporaryFile svgFile;
-	svgFile.setFileTemplate("/tmp/qt_temp.XXXXXX.svg");
-	
-	// the file will be removed before being parsed in skin if set to true
-	svgFile.setAutoRemove( false );
-	
-	QString svgTempFileName;
-	if( svgFile.open() ){
-		QTextStream out(&svgFile);
-		
-		svgNode.save( out, -1 );
-		
-		// qWarning()
-				// << "SVG : Temp filename" << svgFile.fileName() << " \n";
-		
-		svgFile.close();
-		
-		svgTempFileName = svgFile.fileName();
-	} else {
-		qDebug() << "Unable to open temp file for inline svg \n";
-	}
-	
-	return svgTempFileName;
+    
+    // clone svg to don't alter xml input
+    QDomNode svgNode = svgSkinNode.cloneNode(true);
+    
+    QDomDocument document = getDocument(svgNode);
+    
+    QDomElement svgElement = svgNode.toElement();
+    
+    QDomNodeList variablesElements = svgElement.elementsByTagName("Variable");
+    
+    // replace variables
+    uint variableIndex;
+    QDomElement varElement;
+    QString varName, varValue;
+    QDomNode varNode;
+    QDomNode varParentNode;
+    QDomNode oldChild;
+    QDomText varValueNode;
+    
+    for (variableIndex=0; variableIndex < variablesElements.length(); variableIndex++){
+        
+        // retrieve value
+        varNode = variablesElements.item(variableIndex);
+        varElement = varNode.toElement();
+        varName = varElement.attribute("name");
+        varValue = variable(varName);
+        
+        // qWarning()
+                // << "SVG : " << varName << " => " << varValue << "\n";
+        
+        // replace node by its value
+        varParentNode = varNode.parentNode();
+        
+        varValueNode = document.createTextNode(varValue);
+        
+        oldChild = varParentNode.replaceChild( varValueNode, varNode );
+        if( oldChild.isNull() ){
+            // replaceChild has a really weird behaviour so I add this check
+            qDebug()
+                    << "SVG : unable to replace dom node changed. \n";
+        }
+    }
+    
+    // Save the new svg in a temp file to use it with setPixmap
+    QTemporaryFile svgFile;
+    svgFile.setFileTemplate("/tmp/qt_temp.XXXXXX.svg");
+    
+    // the file will be removed before being parsed in skin if set to true
+    svgFile.setAutoRemove( false );
+    
+    QString svgTempFileName;
+    if( svgFile.open() ){
+        QTextStream out(&svgFile);
+        
+        svgNode.save( out, -1 );
+        
+        // qWarning()
+                // << "SVG : Temp filename" << svgFile.fileName() << " \n";
+        
+        svgFile.close();
+        
+        svgTempFileName = svgFile.fileName();
+    } else {
+        qDebug() << "Unable to open temp file for inline svg \n";
+    }
+    
+    return svgTempFileName;
 }

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -6,6 +6,7 @@
 #include <QDomNode>
 #include <QDomElement>
 #include <QScriptEngine>
+#include <QDir>
 
 // A class for managing the current context/environment when processing a
 // skin. Used hierarchically by LegacySkinParser to create new contexts and
@@ -20,8 +21,9 @@ class SkinContext {
 
     // Gets a path relative to the skin path.
     QString getSkinPath(const QString& relativePath) const {
-        QString l(relativePath);
-        return l.prepend(m_skinBasePath);
+        // QString l(relativePath);
+        // return l.prepend(m_skinBasePath);
+        return QDir(m_skinBasePath).filePath(relativePath);
     }
 
     // Sets the base path used by getSkinPath.

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -62,6 +62,8 @@ class SkinContext {
                                   const QString& attributeName,
                                   QString defaultValue) const;
     QString nodeToString(const QDomNode& node) const;
+    QDomDocument getDocument(const QDomNode& node) const;
+    QString setVariablesInSvg(const QDomNode& svgNode) const;
 
   private:
     QString variableNodeToText(const QDomElement& element) const;
@@ -69,6 +71,7 @@ class SkinContext {
     mutable QScriptEngine m_scriptEngine;
     QHash<QString, QString> m_variables;
     QString m_skinBasePath;
+    
 };
 
 #endif /* SKINCONTEXT_H */

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -25,7 +25,6 @@
 #include <QTouchEvent>
 #include <QPaintEvent>
 #include <QApplication>
-#include <QTemporaryFile>
 
 #include "widget/wpixmapstore.h"
 #include "controlobject.h"
@@ -78,116 +77,14 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
                 if (!pressedNode.isNull()) {
 					
 					// inline svg
-					QDomNode svgNode,
-						svgNodeTemp = context.selectNode(pressedNode, "svg");
-					
-					if (!svgNodeTemp.isNull()) {
+					QDomNode svgNode = context.selectNode(pressedNode, "svg");
+					if (!svgNode.isNull()) {
+						// qWarning()
+								// << "SVG : SVG node present";
 						
-						svgNode = svgNodeTemp.cloneNode( true );
-						
-						QDomDocument document;
-						QDomNode parentNode = svgNode;
-						// QString parentTagName = varValueNode.parentNode().toElement().tagName();
-						while( !parentNode.isNull() ){
-							if( parentNode.isDocument() )
-								document = parentNode.toDocument();
-							parentNode = parentNode.parentNode();
-						}
-						
-						
-						QDomElement svgElement = svgNode.toElement();
-						
-						qWarning()
-								<< "SVG : SVG node present";
-						
-						QDomNodeList variablesElements = svgElement.elementsByTagName( "Variable" );
-						
-						qWarning()
-								<< "SVG : " << variablesElements.count() << "\n";
-						
-						// replace variables
-						uint variableIndex;
-						QDomElement varElement;
-						QString varName, varValue;
-						QDomNode varNode;
-						// QDomText *varValueNode;
-						QDomText varValueNode;
-						QDomNode varParentNode;
-						QDomNode oldChild;
-						
-						for (variableIndex=0; variableIndex < variablesElements.length(); variableIndex++){
-							
-							varNode = variablesElements.item(variableIndex);
-							
-							// retrieve value
-							varElement = varNode.toElement();
-							varName = varElement.attribute("name");
-							varValue = context.variable(varName);
-							
-							qWarning()
-									<< "SVG : " << varName << " => " << varValue << "\n";
-							
-							// replace node by its value
-							varParentNode = varNode.parentNode();
-							
-							if( varParentNode.isNull() ){
-								
-								qWarning()
-										<< "SVG : no parent for dom node \n";
-							}
-							
-							varValueNode = document.createTextNode(varValue);
-							
-							// newChild = varParentNode.insertAfter( varValueNode, varNode );
-							
-							oldChild = varParentNode.replaceChild( varValueNode, varNode );
-							if( oldChild.isNull() ){
-								
-								qWarning()
-										<< "SVG : unable to replace dom node changed. \n";
-							} else {
-								
-								// varParentNode.removeChild( varNode );
-								qWarning()
-										<< "SVG : " << varName << " => " << varValue << " changed. \n";
-							}
-							
-							
-							
-							
-						}
-						
-						// QDomNode parentNode = varParentNode;
-						parentNode = varParentNode;
-						// QString parentTagName = varValueNode.parentNode().toElement().tagName();
-						while( !parentNode.isNull() && parentNode.toElement().tagName() != "svg" ){
-							parentNode = parentNode.parentNode();
-						}
-						
-						
-						
-						// svgContent = "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\"><rect x=\"0\" y=\"0\" width=\"12\" height=\"25\" style=\"fill:#ff0000; stroke-width:1; stroke:#ff0000; stroke-linecap:sqare;\" /></svg>";
-						
-						QTemporaryFile svgFile;
-						svgFile.setAutoRemove( false );
-						svgFile.setFileTemplate("qt_temp.XXXXXX.svg");
-						
-						
-						if( svgFile.open() ){
-							QTextStream out(&svgFile);
-							
-							parentNode.save( out, -1 );
-							
-							// qWarning()
-									// << "SVG : Temp filename" << svgFile.fileName() << " \n";
-							
-							svgFile.close();
-							
-							setPixmap(iState, false, context.getSkinPath(svgFile.fileName()));
-						} else {
-							qWarning()
-									<< "SVG : unable to open svg buffer. Enough space? \n";
-						}
+						QString svgTempFilename = context.setVariablesInSvg(svgNode);
+						// setPixmap(iState, false, context.getSkinPath(svgTempFilename));
+						setPixmap(iState, false, svgTempFilename);
 						
 					} else {
 						// filename

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -25,6 +25,7 @@
 #include <QTouchEvent>
 #include <QPaintEvent>
 #include <QApplication>
+#include <QTemporaryFile>
 
 #include "widget/wpixmapstore.h"
 #include "controlobject.h"
@@ -73,14 +74,136 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
             int iState = context.selectInt(state, "Number");
             if (iState < m_iNoStates) {
                 QString pixmapName;
+                QDomNode pressedNode = context.selectNode(state, "Unpressed");
+                if (!pressedNode.isNull()) {
+					
+					// inline svg
+					QDomNode svgNode,
+						svgNodeTemp = context.selectNode(pressedNode, "svg");
+					
+					if (!svgNodeTemp.isNull()) {
+						
+						svgNode = svgNodeTemp.cloneNode( true );
+						
+						QDomDocument document;
+						QDomNode parentNode = svgNode;
+						// QString parentTagName = varValueNode.parentNode().toElement().tagName();
+						while( !parentNode.isNull() ){
+							if( parentNode.isDocument() )
+								document = parentNode.toDocument();
+							parentNode = parentNode.parentNode();
+						}
+						
+						
+						QDomElement svgElement = svgNode.toElement();
+						
+						qWarning()
+								<< "SVG : SVG node present";
+						
+						QDomNodeList variablesElements = svgElement.elementsByTagName( "Variable" );
+						
+						qWarning()
+								<< "SVG : " << variablesElements.count() << "\n";
+						
+						// replace variables
+						uint variableIndex;
+						QDomElement varElement;
+						QString varName, varValue;
+						QDomNode varNode;
+						// QDomText *varValueNode;
+						QDomText varValueNode;
+						QDomNode varParentNode;
+						QDomNode oldChild;
+						
+						for (variableIndex=0; variableIndex < variablesElements.length(); variableIndex++){
+							
+							varNode = variablesElements.item(variableIndex);
+							
+							// retrieve value
+							varElement = varNode.toElement();
+							varName = varElement.attribute("name");
+							varValue = context.variable(varName);
+							
+							qWarning()
+									<< "SVG : " << varName << " => " << varValue << "\n";
+							
+							// replace node by its value
+							varParentNode = varNode.parentNode();
+							
+							if( varParentNode.isNull() ){
+								
+								qWarning()
+										<< "SVG : no parent for dom node \n";
+							}
+							
+							varValueNode = document.createTextNode(varValue);
+							
+							// newChild = varParentNode.insertAfter( varValueNode, varNode );
+							
+							oldChild = varParentNode.replaceChild( varValueNode, varNode );
+							if( oldChild.isNull() ){
+								
+								qWarning()
+										<< "SVG : unable to replace dom node changed. \n";
+							} else {
+								
+								// varParentNode.removeChild( varNode );
+								qWarning()
+										<< "SVG : " << varName << " => " << varValue << " changed. \n";
+							}
+							
+							
+							
+							
+						}
+						
+						// QDomNode parentNode = varParentNode;
+						parentNode = varParentNode;
+						// QString parentTagName = varValueNode.parentNode().toElement().tagName();
+						while( !parentNode.isNull() && parentNode.toElement().tagName() != "svg" ){
+							parentNode = parentNode.parentNode();
+						}
+						
+						
+						
+						// svgContent = "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\"><rect x=\"0\" y=\"0\" width=\"12\" height=\"25\" style=\"fill:#ff0000; stroke-width:1; stroke:#ff0000; stroke-linecap:sqare;\" /></svg>";
+						
+						QTemporaryFile svgFile;
+						svgFile.setAutoRemove( false );
+						svgFile.setFileTemplate("qt_temp.XXXXXX.svg");
+						
+						
+						if( svgFile.open() ){
+							QTextStream out(&svgFile);
+							
+							parentNode.save( out, -1 );
+							
+							// qWarning()
+									// << "SVG : Temp filename" << svgFile.fileName() << " \n";
+							
+							svgFile.close();
+							
+							setPixmap(iState, false, context.getSkinPath(svgFile.fileName()));
+						} else {
+							qWarning()
+									<< "SVG : unable to open svg buffer. Enough space? \n";
+						}
+						
+					} else {
+						// filename
+						pixmapName = context.nodeToString(pressedNode);
+						if (!pixmapName.isEmpty()) {
+							setPixmap(iState, false, context.getSkinPath(pixmapName));
+						}
+					}
+					
+				}
+                
                 if (context.hasNodeSelectString(state, "Pressed", &pixmapName) &&
                         !pixmapName.isEmpty()) {
                     setPixmap(iState, true, context.getSkinPath(pixmapName));
                 }
-                if (context.hasNodeSelectString(state, "Unpressed", &pixmapName) &&
-                        !pixmapName.isEmpty()) {
-                    setPixmap(iState, false, context.getSkinPath(pixmapName));
-                }
+                
                 m_text.replace(iState, context.selectString(state, "Text"));
                 QString alignment = context.selectString(state, "Alignment");
                 if (alignment == "left") {

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -73,32 +73,43 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
             int iState = context.selectInt(state, "Number");
             if (iState < m_iNoStates) {
                 QString pixmapName;
-                QDomNode pressedNode = context.selectNode(state, "Unpressed");
-                if (!pressedNode.isNull()) {
-					
-					// inline svg
-					QDomNode svgNode = context.selectNode(pressedNode, "svg");
-					if (!svgNode.isNull()) {
-						// qWarning()
-								// << "SVG : SVG node present";
-						
-						QString svgTempFilename = context.setVariablesInSvg(svgNode);
-						// setPixmap(iState, false, context.getSkinPath(svgTempFilename));
-						setPixmap(iState, false, svgTempFilename);
-						
-					} else {
-						// filename
-						pixmapName = context.nodeToString(pressedNode);
-						if (!pixmapName.isEmpty()) {
-							setPixmap(iState, false, context.getSkinPath(pixmapName));
-						}
-					}
-					
-				}
                 
-                if (context.hasNodeSelectString(state, "Pressed", &pixmapName) &&
-                        !pixmapName.isEmpty()) {
-                    setPixmap(iState, true, context.getSkinPath(pixmapName));
+                QDomNode unpressedNode = context.selectNode(state, "Unpressed");
+                if (!unpressedNode.isNull()) {
+                    
+                    QDomNode svgNode = context.selectNode(unpressedNode, "svg");
+                    if (!svgNode.isNull()) {
+                        // inline svg
+                        QString svgTempFilename = context.setVariablesInSvg(svgNode);
+                        setPixmap(iState, false, svgTempFilename);
+                        
+                    } else {
+                        // filename
+                        pixmapName = context.nodeToString(unpressedNode);
+                        if (!pixmapName.isEmpty()) {
+                            setPixmap(iState, false, context.getSkinPath(pixmapName));
+                        }
+                    }
+                    
+                }
+                
+                QDomNode pressedNode = context.selectNode(state, "Pressed");
+                if (!pressedNode.isNull()) {
+                    
+                    QDomNode svgNode = context.selectNode(pressedNode, "svg");
+                    if (!svgNode.isNull()) {
+                        // inline svg
+                        QString svgTempFilename = context.setVariablesInSvg(svgNode);
+                        setPixmap(iState, true, svgTempFilename);
+                        
+                    } else {
+                        // filename
+                        pixmapName = context.nodeToString(pressedNode);
+                        if (!pixmapName.isEmpty()) {
+                            setPixmap(iState, true, context.getSkinPath(pixmapName));
+                        }
+                    }
+                    
                 }
                 
                 m_text.replace(iState, context.selectString(state, "Text"));

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -36,7 +36,6 @@ WSliderComposed::WSliderComposed(QWidget * parent)
       m_iHandleLength(0),
       m_bHorizontal(false),
       m_bReverse(false),
-      // m_eDirection(up),
       m_bEventWhileDrag(true),
       m_bDrag(false),
       m_pSlider(NULL),

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -35,6 +35,8 @@ WSliderComposed::WSliderComposed(QWidget * parent)
       m_iStartMousePos(0),
       m_iHandleLength(0),
       m_bHorizontal(false),
+      m_bReverse(false),
+      // m_eDirection(up),
       m_bEventWhileDrag(true),
       m_bDrag(false),
       m_pSlider(NULL),
@@ -57,6 +59,8 @@ void WSliderComposed::setup(QDomNode node, const SkinContext& context) {
     QString pathHandle = context.getSkinPath(context.selectString(node, "Handle"));
     bool h = context.selectBool(node, "Horizontal", false);
     setHandlePixmap(h, pathHandle);
+    
+    m_bReverse = context.selectBool(node, "Reverse", false);
 
     if (context.hasNode(node, "EventWhileDrag")) {
         if (context.selectString(node, "EventWhileDrag").contains("no")) {
@@ -116,11 +120,12 @@ void WSliderComposed::mouseMoveEvent(QMouseEvent * e) {
             m_iPos = e->y() - m_iHandleLength / 2;
         }
 
-        //qDebug() << "start " << m_iStartPos << ", pos " << m_iPos;
         m_iPos = m_iStartHandlePos + (m_iPos - m_iStartMousePos);
 
-        int sliderLength = m_bHorizontal ? width() : height();
+        // qDebug() << "mouseMoveEvent pos " << m_iPos;
 
+        int sliderLength = m_bHorizontal ? width() : height();
+        
         // Clamp to the range [0, sliderLength - m_iHandleLength].
         if (m_iPos > (sliderLength - m_iHandleLength)) {
             m_iPos = sliderLength - m_iHandleLength;
@@ -133,6 +138,10 @@ void WSliderComposed::mouseMoveEvent(QMouseEvent * e) {
         double newValue = static_cast<double>(m_iPos) /
                 static_cast<double>(sliderLength - m_iHandleLength);
         if (!m_bHorizontal) {
+            newValue = 1.0 - newValue;
+        }
+
+        if (m_bReverse) {
             newValue = 1.0 - newValue;
         }
 
@@ -153,11 +162,15 @@ void WSliderComposed::mouseMoveEvent(QMouseEvent * e) {
 void WSliderComposed::wheelEvent(QWheelEvent *e) {
     // For legacy (MIDI) reasons this is tuned to 127.
     double wheelDirection = ((QWheelEvent *)e)->delta() / (120.0 * 127.0);
+    if (m_bReverse) {
+        wheelDirection = - wheelDirection;
+    }
     double newValue = m_dOldValue + wheelDirection;
 
     // Clamp to [0.0, 1.0]
     newValue = math_clamp(newValue, 0.0, 1.0);
-
+    // qDebug() << "wheelEvent value " << newValue;
+    
     setControlParameter(newValue);
     // Value is unused in WSliderComposed.
     onConnectedControlChanged(newValue, 0);
@@ -227,6 +240,7 @@ void WSliderComposed::resizeEvent(QResizeEvent* pEvent) {
 }
 
 void WSliderComposed::onConnectedControlChanged(double dParameter, double) {
+    qDebug() << "onConnectedControlChanged dParameter " << dParameter;
     // WARNING: The second parameter to this method is unused and called with
     // invalid values in parts of WSliderComposed. Do not use it unless you fix
     // this.
@@ -259,6 +273,11 @@ void WSliderComposed::onConnectedControlChanged(double dParameter, double) {
         // really sure we need to since this involves painting ALL of its
         // parents.
         if (newPos != m_iPos) {
+            
+            if (m_bReverse) {
+                newPos = sliderLength - newPos - m_iHandleLength;
+            }
+            
             m_iPos = newPos;
             update();
         }

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -71,6 +71,8 @@ class WSliderComposed : public WWidget  {
     int m_iHandleLength;
     // True if it's a horizontal slider
     bool m_bHorizontal;
+    // True to get the opposit value
+    bool m_bReverse;
     // Is true if events is emitted while the slider is dragged
     bool m_bEventWhileDrag;
     // True if slider is dragged. Only used when m_bEventWhileDrag is false


### PR DESCRIPTION
I needed the skin parser to be able to manage Variable elements in svg for cues and loops buttons so I added a function to do it and hooked it directly if a svg element is present in a (un)pressed element.

So now, I can handle inlined svg in my pushbuttons like this : 

``` xml
<Pressed>
    <svg height="16" width="16">
        <rect x="0" y="0" width="16" height="16" style="fill:#000000; stroke-width:1; stroke:#ff0000; stroke-linecap:sqare;" />
        <text x="0" y="15" style="fill:#ff0000; font-size: 16px; font-weight: bold;">
            <Variable name="number"/>
        </text>
    </svg>
</Pressed>
```

Should I continue in this direction and do I do this well?
If yes, what do you think I should begin with?

Thanks in advance!
