### PR TITLE
Allow inline svg handling Variable elements in skins

### DIFF
--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -279,17 +279,17 @@ QString SkinContext::setVariablesInSvg(const QDomNode& svgSkinNode) const {
     return svgTempFileName;
 }
 
-QString SkinContext::getPixmapPath(const QDomNode& oneStateNode) const {
+QString SkinContext::getPixmapPath(const QDomNode& pixmapNode) const {
     QString pixmapPath, pixmapName;
     
-    if (!oneStateNode.isNull()) {
-        QDomNode svgNode = selectNode(oneStateNode, "svg");
+    if (!pixmapNode.isNull()) {
+        QDomNode svgNode = selectNode(pixmapNode, "svg");
         if (!svgNode.isNull()) {
             // inline svg
             pixmapPath = setVariablesInSvg(svgNode);
         } else {
             // filename
-            pixmapName = nodeToString(oneStateNode);
+            pixmapName = nodeToString(pixmapNode);
             if (!pixmapName.isEmpty()) {
                 pixmapPath = getSkinPath(pixmapName);
             }

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -213,7 +213,6 @@ QDomDocument SkinContext::getDocument(const QDomNode& node) const {
     
     QDomDocument document;
     QDomNode parentNode = node;
-    // QString parentTagName = varValueNode.parentNode().toElement().tagName();
     while( !parentNode.isNull() ){
         if( parentNode.isDocument() )
             document = parentNode.toDocument();
@@ -229,20 +228,15 @@ QString SkinContext::setVariablesInSvg(const QDomNode& svgSkinNode) const {
     
     // clone svg to don't alter xml input
     QDomNode svgNode = svgSkinNode.cloneNode(true);
-    
     QDomDocument document = getDocument(svgNode);
-    
     QDomElement svgElement = svgNode.toElement();
     
-    QDomNodeList variablesElements = svgElement.elementsByTagName("Variable");
-    
     // replace variables
+    QDomNodeList variablesElements = svgElement.elementsByTagName("Variable");
     uint variableIndex;
     QDomElement varElement;
     QString varName, varValue;
-    QDomNode varNode;
-    QDomNode varParentNode;
-    QDomNode oldChild;
+    QDomNode varNode, varParentNode, oldChild;
     QDomText varValueNode;
     
     for (variableIndex=0; variableIndex < variablesElements.length(); variableIndex++){
@@ -253,19 +247,14 @@ QString SkinContext::setVariablesInSvg(const QDomNode& svgSkinNode) const {
         varName = varElement.attribute("name");
         varValue = variable(varName);
         
-        // qWarning()
-                // << "SVG : " << varName << " => " << varValue << "\n";
-        
         // replace node by its value
         varParentNode = varNode.parentNode();
-        
         varValueNode = document.createTextNode(varValue);
-        
         oldChild = varParentNode.replaceChild( varValueNode, varNode );
+        
         if( oldChild.isNull() ){
             // replaceChild has a really weird behaviour so I add this check
-            qDebug()
-                    << "SVG : unable to replace dom node changed. \n";
+            qDebug() << "SVG : unable to replace dom node changed. \n";
         }
     }
     
@@ -278,15 +267,10 @@ QString SkinContext::setVariablesInSvg(const QDomNode& svgSkinNode) const {
     
     QString svgTempFileName;
     if( svgFile.open() ){
+        // qWarning() << "SVG : Temp filename" << svgFile.fileName() << " \n";
         QTextStream out(&svgFile);
-        
         svgNode.save( out, -1 );
-        
-        // qWarning()
-                // << "SVG : Temp filename" << svgFile.fileName() << " \n";
-        
         svgFile.close();
-        
         svgTempFileName = svgFile.fileName();
     } else {
         qDebug() << "Unable to open temp file for inline svg \n";

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -291,7 +291,21 @@ QString SkinContext::getPixmapPath(const QDomNode& pixmapNode) const {
             // filename
             pixmapName = nodeToString(pixmapNode);
             if (!pixmapName.isEmpty()) {
-                pixmapPath = getSkinPath(pixmapName);
+                pixmapName = getSkinPath(pixmapName);
+                if (pixmapName.endsWith(".svg", Qt::CaseInsensitive)) {
+                    
+                    QFile* file = new QFile(pixmapName);
+                    if(file->open(QIODevice::ReadWrite | QIODevice::Text)){
+                        QDomDocument document;
+                        document.setContent(file);
+                        QDomNode svgNode = document.elementsByTagName("svg").item(0);
+                        
+                        pixmapPath = setVariablesInSvg(svgNode);
+                        file->close();
+                    }
+                } else {
+                    pixmapPath = pixmapName;
+                }
             }
         }
     }

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -210,87 +210,87 @@ QString SkinContext::nodeToString(const QDomNode& node) const {
 
 // look for the document of a node
 QDomDocument SkinContext::getDocument(const QDomNode& node) const {
-	
-	QDomDocument document;
-	QDomNode parentNode = node;
-	// QString parentTagName = varValueNode.parentNode().toElement().tagName();
-	while( !parentNode.isNull() ){
-		if( parentNode.isDocument() )
-			document = parentNode.toDocument();
-		parentNode = parentNode.parentNode();
-	}
-	
-	return document;
+    
+    QDomDocument document;
+    QDomNode parentNode = node;
+    // QString parentTagName = varValueNode.parentNode().toElement().tagName();
+    while( !parentNode.isNull() ){
+        if( parentNode.isDocument() )
+            document = parentNode.toDocument();
+        parentNode = parentNode.parentNode();
+    }
+    
+    return document;
 }
 
 
 // replaces Variables nodes in an svg dom tree
 QString SkinContext::setVariablesInSvg(const QDomNode& svgSkinNode) const {
-	
-	// clone svg to don't alter xml input
-	QDomNode svgNode = svgSkinNode.cloneNode(true);
-	
-	QDomDocument document = getDocument(svgNode);
-	
-	QDomElement svgElement = svgNode.toElement();
-	
-	QDomNodeList variablesElements = svgElement.elementsByTagName("Variable");
-	
-	// replace variables
-	uint variableIndex;
-	QDomElement varElement;
-	QString varName, varValue;
-	QDomNode varNode;
-	QDomNode varParentNode;
-	QDomNode oldChild;
-	QDomText varValueNode;
-	
-	for (variableIndex=0; variableIndex < variablesElements.length(); variableIndex++){
-		
-		// retrieve value
-		varNode = variablesElements.item(variableIndex);
-		varElement = varNode.toElement();
-		varName = varElement.attribute("name");
-		varValue = variable(varName);
-		
-		// qWarning()
-				// << "SVG : " << varName << " => " << varValue << "\n";
-		
-		// replace node by its value
-		varParentNode = varNode.parentNode();
-		
-		varValueNode = document.createTextNode(varValue);
-		
-		oldChild = varParentNode.replaceChild( varValueNode, varNode );
-		if( oldChild.isNull() ){
-			// replaceChild has a really weird behaviour so I add this check
-			qDebug()
-					<< "SVG : unable to replace dom node changed. \n";
-		}
-	}
-	
-	// Save the new svg in a temp file to use it with setPixmap
-	QTemporaryFile svgFile;
-	svgFile.setFileTemplate("/tmp/qt_temp.XXXXXX.svg");
-	
-	// the file will be removed before being parsed in skin if set to true
-	svgFile.setAutoRemove( false );
-	
-	QString svgTempFileName;
-	if( svgFile.open() ){
-		QTextStream out(&svgFile);
-		
-		svgNode.save( out, -1 );
-		
-		// qWarning()
-				// << "SVG : Temp filename" << svgFile.fileName() << " \n";
-		
-		svgFile.close();
-		
-		svgTempFileName = svgFile.fileName();
-	} else {
-		qDebug() << "Unable to open temp file for inline svg \n";
-	}
-	
-	return svgTempFileName;
+    
+    // clone svg to don't alter xml input
+    QDomNode svgNode = svgSkinNode.cloneNode(true);
+    
+    QDomDocument document = getDocument(svgNode);
+    
+    QDomElement svgElement = svgNode.toElement();
+    
+    QDomNodeList variablesElements = svgElement.elementsByTagName("Variable");
+    
+    // replace variables
+    uint variableIndex;
+    QDomElement varElement;
+    QString varName, varValue;
+    QDomNode varNode;
+    QDomNode varParentNode;
+    QDomNode oldChild;
+    QDomText varValueNode;
+    
+    for (variableIndex=0; variableIndex < variablesElements.length(); variableIndex++){
+        
+        // retrieve value
+        varNode = variablesElements.item(variableIndex);
+        varElement = varNode.toElement();
+        varName = varElement.attribute("name");
+        varValue = variable(varName);
+        
+        // qWarning()
+                // << "SVG : " << varName << " => " << varValue << "\n";
+        
+        // replace node by its value
+        varParentNode = varNode.parentNode();
+        
+        varValueNode = document.createTextNode(varValue);
+        
+        oldChild = varParentNode.replaceChild( varValueNode, varNode );
+        if( oldChild.isNull() ){
+            // replaceChild has a really weird behaviour so I add this check
+            qDebug()
+                    << "SVG : unable to replace dom node changed. \n";
+        }
+    }
+    
+    // Save the new svg in a temp file to use it with setPixmap
+    QTemporaryFile svgFile;
+    svgFile.setFileTemplate("/tmp/qt_temp.XXXXXX.svg");
+    
+    // the file will be removed before being parsed in skin if set to true
+    svgFile.setAutoRemove( false );
+    
+    QString svgTempFileName;
+    if( svgFile.open() ){
+        QTextStream out(&svgFile);
+        
+        svgNode.save( out, -1 );
+        
+        // qWarning()
+                // << "SVG : Temp filename" << svgFile.fileName() << " \n";
+        
+        svgFile.close();
+        
+        svgTempFileName = svgFile.fileName();
+    } else {
+        qDebug() << "Unable to open temp file for inline svg \n";
+    }
+    
+    return svgTempFileName;
 }

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -278,3 +278,23 @@ QString SkinContext::setVariablesInSvg(const QDomNode& svgSkinNode) const {
     
     return svgTempFileName;
 }
+
+QString SkinContext::getPixmapPath(const QDomNode& oneStateNode) const {
+    QString pixmapPath, pixmapName;
+    
+    if (!oneStateNode.isNull()) {
+        QDomNode svgNode = selectNode(oneStateNode, "svg");
+        if (!svgNode.isNull()) {
+            // inline svg
+            pixmapPath = setVariablesInSvg(svgNode);
+        } else {
+            // filename
+            pixmapName = nodeToString(oneStateNode);
+            if (!pixmapName.isEmpty()) {
+                pixmapPath = getSkinPath(pixmapName);
+            }
+        }
+    }
+    
+    return pixmapPath;
+}

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -271,7 +271,7 @@ QString SkinContext::setVariablesInSvg(const QDomNode& svgSkinNode) const {
     
     // Save the new svg in a temp file to use it with setPixmap
     QTemporaryFile svgFile;
-    svgFile.setFileTemplate("/tmp/qt_temp.XXXXXX.svg");
+    svgFile.setFileTemplate(QDir::temp().filePath("qt_temp.XXXXXX.svg"));
     
     // the file will be removed before being parsed in skin if set to true
     svgFile.setAutoRemove( false );

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -6,6 +6,7 @@
 #include <QDomNode>
 #include <QDomElement>
 #include <QScriptEngine>
+#include <QDir>
 
 // A class for managing the current context/environment when processing a
 // skin. Used hierarchically by LegacySkinParser to create new contexts and
@@ -20,8 +21,9 @@ class SkinContext {
 
     // Gets a path relative to the skin path.
     QString getSkinPath(const QString& relativePath) const {
-        QString l(relativePath);
-        return l.prepend(m_skinBasePath);
+        // QString l(relativePath);
+        // return l.prepend(m_skinBasePath);
+        return QDir(m_skinBasePath).filePath(relativePath);
     }
 
     // Sets the base path used by getSkinPath.

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -62,7 +62,7 @@ class SkinContext {
     QString nodeToString(const QDomNode& node) const;
     QDomDocument getDocument(const QDomNode& node) const;
     QString setVariablesInSvg(const QDomNode& svgNode) const;
-    QString getPixmapPath(const QDomNode& oneStateNode) const;
+    QString getPixmapPath(const QDomNode& pixmapNode) const;
 
   private:
     QString variableNodeToText(const QDomElement& element) const;

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -62,6 +62,8 @@ class SkinContext {
                                   const QString& attributeName,
                                   QString defaultValue) const;
     QString nodeToString(const QDomNode& node) const;
+    QDomDocument getDocument(const QDomNode& node) const;
+    QString setVariablesInSvg(const QDomNode& svgNode) const;
 
   private:
     QString variableNodeToText(const QDomElement& element) const;
@@ -69,6 +71,7 @@ class SkinContext {
     mutable QScriptEngine m_scriptEngine;
     QHash<QString, QString> m_variables;
     QString m_skinBasePath;
+    
 };
 
 #endif /* SKINCONTEXT_H */

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -21,8 +21,6 @@ class SkinContext {
 
     // Gets a path relative to the skin path.
     QString getSkinPath(const QString& relativePath) const {
-        // QString l(relativePath);
-        // return l.prepend(m_skinBasePath);
         return QDir(m_skinBasePath).filePath(relativePath);
     }
 
@@ -64,6 +62,7 @@ class SkinContext {
     QString nodeToString(const QDomNode& node) const;
     QDomDocument getDocument(const QDomNode& node) const;
     QString setVariablesInSvg(const QDomNode& svgNode) const;
+    QString getPixmapPath(const QDomNode& oneStateNode) const;
 
   private:
     QString variableNodeToText(const QDomElement& element) const;

--- a/src/widget/wdisplay.cpp
+++ b/src/widget/wdisplay.cpp
@@ -42,7 +42,7 @@ void WDisplay::setup(QDomNode node, const SkinContext& context) {
     if (context.hasNode(node, "BackPath")) {
         QString mode_str = context.selectAttributeString(
                 context.selectElement(node, "BackPath"), "scalemode", "TILE");
-        setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")),
+        setPixmapBackground(context.getPixmapPath(context.selectNode(node, "BackPath")),
                             Paintable::DrawModeFromString(mode_str));
     }
 

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -20,13 +20,13 @@ void WKnobComposed::setup(QDomNode node, const SkinContext& context) {
     if (context.hasNode(node, "BackPath")) {
         QString mode_str = context.selectAttributeString(
                 context.selectElement(node, "BackPath"), "scalemode", "TILE");
-        setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")),
+        setPixmapBackground(context.getPixmapPath(context.selectNode(node, "BackPath")),
                             Paintable::DrawModeFromString(mode_str));
     }
 
     // Set background pixmap if available
     if (context.hasNode(node, "Knob")) {
-        setPixmapKnob(context.getSkinPath(context.selectString(node, "Knob")));
+        setPixmapKnob(context.getPixmapPath(context.selectNode(node, "Knob")));
     }
 
     if (context.hasNode(node, "MinAngle")) {

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -74,14 +74,12 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
             if (iState < m_iNoStates) {
                 QString pixmapPath;
                 
-                QDomNode unpressedNode = context.selectNode(state, "Unpressed");
-                pixmapPath = context.getPixmapPath(unpressedNode);
+                pixmapPath = context.getPixmapPath(context.selectNode(state, "Unpressed"));
                 if (!pixmapPath.isEmpty()) {
                     setPixmap(iState, false, pixmapPath);
                 }
                 
-                QDomNode pressedNode = context.selectNode(state, "Pressed");
-                pixmapPath = context.getPixmapPath(pressedNode);
+                pixmapPath = context.getPixmapPath(context.selectNode(state, "Pressed"));
                 if (!pixmapPath.isEmpty()) {
                     setPixmap(iState, true, pixmapPath);
                 }

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -25,7 +25,6 @@
 #include <QTouchEvent>
 #include <QPaintEvent>
 #include <QApplication>
-#include <QTemporaryFile>
 
 #include "widget/wpixmapstore.h"
 #include "controlobject.h"
@@ -78,116 +77,14 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
                 if (!pressedNode.isNull()) {
 					
 					// inline svg
-					QDomNode svgNode,
-						svgNodeTemp = context.selectNode(pressedNode, "svg");
-					
-					if (!svgNodeTemp.isNull()) {
+					QDomNode svgNode = context.selectNode(pressedNode, "svg");
+					if (!svgNode.isNull()) {
+						// qWarning()
+								// << "SVG : SVG node present";
 						
-						svgNode = svgNodeTemp.cloneNode( true );
-						
-						QDomDocument document;
-						QDomNode parentNode = svgNode;
-						// QString parentTagName = varValueNode.parentNode().toElement().tagName();
-						while( !parentNode.isNull() ){
-							if( parentNode.isDocument() )
-								document = parentNode.toDocument();
-							parentNode = parentNode.parentNode();
-						}
-						
-						
-						QDomElement svgElement = svgNode.toElement();
-						
-						qWarning()
-								<< "SVG : SVG node present";
-						
-						QDomNodeList variablesElements = svgElement.elementsByTagName( "Variable" );
-						
-						qWarning()
-								<< "SVG : " << variablesElements.count() << "\n";
-						
-						// replace variables
-						uint variableIndex;
-						QDomElement varElement;
-						QString varName, varValue;
-						QDomNode varNode;
-						// QDomText *varValueNode;
-						QDomText varValueNode;
-						QDomNode varParentNode;
-						QDomNode oldChild;
-						
-						for (variableIndex=0; variableIndex < variablesElements.length(); variableIndex++){
-							
-							varNode = variablesElements.item(variableIndex);
-							
-							// retrieve value
-							varElement = varNode.toElement();
-							varName = varElement.attribute("name");
-							varValue = context.variable(varName);
-							
-							qWarning()
-									<< "SVG : " << varName << " => " << varValue << "\n";
-							
-							// replace node by its value
-							varParentNode = varNode.parentNode();
-							
-							if( varParentNode.isNull() ){
-								
-								qWarning()
-										<< "SVG : no parent for dom node \n";
-							}
-							
-							varValueNode = document.createTextNode(varValue);
-							
-							// newChild = varParentNode.insertAfter( varValueNode, varNode );
-							
-							oldChild = varParentNode.replaceChild( varValueNode, varNode );
-							if( oldChild.isNull() ){
-								
-								qWarning()
-										<< "SVG : unable to replace dom node changed. \n";
-							} else {
-								
-								// varParentNode.removeChild( varNode );
-								qWarning()
-										<< "SVG : " << varName << " => " << varValue << " changed. \n";
-							}
-							
-							
-							
-							
-						}
-						
-						// QDomNode parentNode = varParentNode;
-						parentNode = varParentNode;
-						// QString parentTagName = varValueNode.parentNode().toElement().tagName();
-						while( !parentNode.isNull() && parentNode.toElement().tagName() != "svg" ){
-							parentNode = parentNode.parentNode();
-						}
-						
-						
-						
-						// svgContent = "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\"><rect x=\"0\" y=\"0\" width=\"12\" height=\"25\" style=\"fill:#ff0000; stroke-width:1; stroke:#ff0000; stroke-linecap:sqare;\" /></svg>";
-						
-						QTemporaryFile svgFile;
-						svgFile.setAutoRemove( false );
-						svgFile.setFileTemplate("qt_temp.XXXXXX.svg");
-						
-						
-						if( svgFile.open() ){
-							QTextStream out(&svgFile);
-							
-							parentNode.save( out, -1 );
-							
-							// qWarning()
-									// << "SVG : Temp filename" << svgFile.fileName() << " \n";
-							
-							svgFile.close();
-							
-							setPixmap(iState, false, context.getSkinPath(svgFile.fileName()));
-						} else {
-							qWarning()
-									<< "SVG : unable to open svg buffer. Enough space? \n";
-						}
+						QString svgTempFilename = context.setVariablesInSvg(svgNode);
+						// setPixmap(iState, false, context.getSkinPath(svgTempFilename));
+						setPixmap(iState, false, svgTempFilename);
 						
 					} else {
 						// filename

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -25,6 +25,7 @@
 #include <QTouchEvent>
 #include <QPaintEvent>
 #include <QApplication>
+#include <QTemporaryFile>
 
 #include "widget/wpixmapstore.h"
 #include "controlobject.h"
@@ -73,14 +74,136 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
             int iState = context.selectInt(state, "Number");
             if (iState < m_iNoStates) {
                 QString pixmapName;
+                QDomNode pressedNode = context.selectNode(state, "Unpressed");
+                if (!pressedNode.isNull()) {
+					
+					// inline svg
+					QDomNode svgNode,
+						svgNodeTemp = context.selectNode(pressedNode, "svg");
+					
+					if (!svgNodeTemp.isNull()) {
+						
+						svgNode = svgNodeTemp.cloneNode( true );
+						
+						QDomDocument document;
+						QDomNode parentNode = svgNode;
+						// QString parentTagName = varValueNode.parentNode().toElement().tagName();
+						while( !parentNode.isNull() ){
+							if( parentNode.isDocument() )
+								document = parentNode.toDocument();
+							parentNode = parentNode.parentNode();
+						}
+						
+						
+						QDomElement svgElement = svgNode.toElement();
+						
+						qWarning()
+								<< "SVG : SVG node present";
+						
+						QDomNodeList variablesElements = svgElement.elementsByTagName( "Variable" );
+						
+						qWarning()
+								<< "SVG : " << variablesElements.count() << "\n";
+						
+						// replace variables
+						uint variableIndex;
+						QDomElement varElement;
+						QString varName, varValue;
+						QDomNode varNode;
+						// QDomText *varValueNode;
+						QDomText varValueNode;
+						QDomNode varParentNode;
+						QDomNode oldChild;
+						
+						for (variableIndex=0; variableIndex < variablesElements.length(); variableIndex++){
+							
+							varNode = variablesElements.item(variableIndex);
+							
+							// retrieve value
+							varElement = varNode.toElement();
+							varName = varElement.attribute("name");
+							varValue = context.variable(varName);
+							
+							qWarning()
+									<< "SVG : " << varName << " => " << varValue << "\n";
+							
+							// replace node by its value
+							varParentNode = varNode.parentNode();
+							
+							if( varParentNode.isNull() ){
+								
+								qWarning()
+										<< "SVG : no parent for dom node \n";
+							}
+							
+							varValueNode = document.createTextNode(varValue);
+							
+							// newChild = varParentNode.insertAfter( varValueNode, varNode );
+							
+							oldChild = varParentNode.replaceChild( varValueNode, varNode );
+							if( oldChild.isNull() ){
+								
+								qWarning()
+										<< "SVG : unable to replace dom node changed. \n";
+							} else {
+								
+								// varParentNode.removeChild( varNode );
+								qWarning()
+										<< "SVG : " << varName << " => " << varValue << " changed. \n";
+							}
+							
+							
+							
+							
+						}
+						
+						// QDomNode parentNode = varParentNode;
+						parentNode = varParentNode;
+						// QString parentTagName = varValueNode.parentNode().toElement().tagName();
+						while( !parentNode.isNull() && parentNode.toElement().tagName() != "svg" ){
+							parentNode = parentNode.parentNode();
+						}
+						
+						
+						
+						// svgContent = "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\"><rect x=\"0\" y=\"0\" width=\"12\" height=\"25\" style=\"fill:#ff0000; stroke-width:1; stroke:#ff0000; stroke-linecap:sqare;\" /></svg>";
+						
+						QTemporaryFile svgFile;
+						svgFile.setAutoRemove( false );
+						svgFile.setFileTemplate("qt_temp.XXXXXX.svg");
+						
+						
+						if( svgFile.open() ){
+							QTextStream out(&svgFile);
+							
+							parentNode.save( out, -1 );
+							
+							// qWarning()
+									// << "SVG : Temp filename" << svgFile.fileName() << " \n";
+							
+							svgFile.close();
+							
+							setPixmap(iState, false, context.getSkinPath(svgFile.fileName()));
+						} else {
+							qWarning()
+									<< "SVG : unable to open svg buffer. Enough space? \n";
+						}
+						
+					} else {
+						// filename
+						pixmapName = context.nodeToString(pressedNode);
+						if (!pixmapName.isEmpty()) {
+							setPixmap(iState, false, context.getSkinPath(pixmapName));
+						}
+					}
+					
+				}
+                
                 if (context.hasNodeSelectString(state, "Pressed", &pixmapName) &&
                         !pixmapName.isEmpty()) {
                     setPixmap(iState, true, context.getSkinPath(pixmapName));
                 }
-                if (context.hasNodeSelectString(state, "Unpressed", &pixmapName) &&
-                        !pixmapName.isEmpty()) {
-                    setPixmap(iState, false, context.getSkinPath(pixmapName));
-                }
+                
                 m_text.replace(iState, context.selectString(state, "Text"));
                 QString alignment = context.selectString(state, "Alignment");
                 if (alignment == "left") {

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -59,10 +59,9 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
     if (context.hasNode(node, "BackPath")) {
         QString mode_str = context.selectAttributeString(
                 context.selectElement(node, "BackPath"), "scalemode", "TILE");
-        QString backPath = context.selectString(node, "BackPath");
+        QString backPath = context.getPixmapPath(context.selectNode(node, "BackPath"));
         if (!backPath.isEmpty()) {
-            setPixmapBackground(context.getSkinPath(backPath),
-                                Paintable::DrawModeFromString(mode_str));
+            setPixmapBackground(backPath, Paintable::DrawModeFromString(mode_str));
         }
     }
 

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -73,32 +73,43 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
             int iState = context.selectInt(state, "Number");
             if (iState < m_iNoStates) {
                 QString pixmapName;
-                QDomNode pressedNode = context.selectNode(state, "Unpressed");
-                if (!pressedNode.isNull()) {
-					
-					// inline svg
-					QDomNode svgNode = context.selectNode(pressedNode, "svg");
-					if (!svgNode.isNull()) {
-						// qWarning()
-								// << "SVG : SVG node present";
-						
-						QString svgTempFilename = context.setVariablesInSvg(svgNode);
-						// setPixmap(iState, false, context.getSkinPath(svgTempFilename));
-						setPixmap(iState, false, svgTempFilename);
-						
-					} else {
-						// filename
-						pixmapName = context.nodeToString(pressedNode);
-						if (!pixmapName.isEmpty()) {
-							setPixmap(iState, false, context.getSkinPath(pixmapName));
-						}
-					}
-					
-				}
                 
-                if (context.hasNodeSelectString(state, "Pressed", &pixmapName) &&
-                        !pixmapName.isEmpty()) {
-                    setPixmap(iState, true, context.getSkinPath(pixmapName));
+                QDomNode unpressedNode = context.selectNode(state, "Unpressed");
+                if (!unpressedNode.isNull()) {
+                    
+                    QDomNode svgNode = context.selectNode(unpressedNode, "svg");
+                    if (!svgNode.isNull()) {
+                        // inline svg
+                        QString svgTempFilename = context.setVariablesInSvg(svgNode);
+                        setPixmap(iState, false, svgTempFilename);
+                        
+                    } else {
+                        // filename
+                        pixmapName = context.nodeToString(unpressedNode);
+                        if (!pixmapName.isEmpty()) {
+                            setPixmap(iState, false, context.getSkinPath(pixmapName));
+                        }
+                    }
+                    
+                }
+                
+                QDomNode pressedNode = context.selectNode(state, "Pressed");
+                if (!pressedNode.isNull()) {
+                    
+                    QDomNode svgNode = context.selectNode(pressedNode, "svg");
+                    if (!svgNode.isNull()) {
+                        // inline svg
+                        QString svgTempFilename = context.setVariablesInSvg(svgNode);
+                        setPixmap(iState, true, svgTempFilename);
+                        
+                    } else {
+                        // filename
+                        pixmapName = context.nodeToString(pressedNode);
+                        if (!pixmapName.isEmpty()) {
+                            setPixmap(iState, true, context.getSkinPath(pixmapName));
+                        }
+                    }
+                    
                 }
                 
                 m_text.replace(iState, context.selectString(state, "Text"));

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -72,44 +72,18 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
         if (state.isElement() && state.nodeName() == "State") {
             int iState = context.selectInt(state, "Number");
             if (iState < m_iNoStates) {
-                QString pixmapName;
+                QString pixmapPath;
                 
                 QDomNode unpressedNode = context.selectNode(state, "Unpressed");
-                if (!unpressedNode.isNull()) {
-                    
-                    QDomNode svgNode = context.selectNode(unpressedNode, "svg");
-                    if (!svgNode.isNull()) {
-                        // inline svg
-                        QString svgTempFilename = context.setVariablesInSvg(svgNode);
-                        setPixmap(iState, false, svgTempFilename);
-                        
-                    } else {
-                        // filename
-                        pixmapName = context.nodeToString(unpressedNode);
-                        if (!pixmapName.isEmpty()) {
-                            setPixmap(iState, false, context.getSkinPath(pixmapName));
-                        }
-                    }
-                    
+                pixmapPath = context.getPixmapPath(unpressedNode);
+                if (!pixmapPath.isEmpty()) {
+                    setPixmap(iState, false, pixmapPath);
                 }
                 
                 QDomNode pressedNode = context.selectNode(state, "Pressed");
-                if (!pressedNode.isNull()) {
-                    
-                    QDomNode svgNode = context.selectNode(pressedNode, "svg");
-                    if (!svgNode.isNull()) {
-                        // inline svg
-                        QString svgTempFilename = context.setVariablesInSvg(svgNode);
-                        setPixmap(iState, true, svgTempFilename);
-                        
-                    } else {
-                        // filename
-                        pixmapName = context.nodeToString(pressedNode);
-                        if (!pixmapName.isEmpty()) {
-                            setPixmap(iState, true, context.getSkinPath(pixmapName));
-                        }
-                    }
-                    
+                pixmapPath = context.getPixmapPath(pressedNode);
+                if (!pixmapPath.isEmpty()) {
+                    setPixmap(iState, true, pixmapPath);
                 }
                 
                 m_text.replace(iState, context.selectString(state, "Text"));

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -50,11 +50,11 @@ void WSliderComposed::setup(QDomNode node, const SkinContext& context) {
     unsetPixmaps();
 
     if (context.hasNode(node, "Slider")) {
-        QString pathSlider = context.getSkinPath(context.selectString(node, "Slider"));
+        QString pathSlider = context.getPixmapPath(context.selectNode(node, "Slider"));
         setSliderPixmap(pathSlider);
     }
 
-    QString pathHandle = context.getSkinPath(context.selectString(node, "Handle"));
+    QString pathHandle = context.getPixmapPath(context.selectNode(node, "Handle"));
     bool h = context.selectBool(node, "Horizontal", false);
     setHandlePixmap(h, pathHandle);
 

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -125,11 +125,11 @@ void WSpinny::setup(QDomNode node, const SkinContext& context, QString group) {
     m_group = group;
 
     // Set images
-    m_pBgImage = WImageStore::getImage(context.getSkinPath(context.selectString(node,
+    m_pBgImage = WImageStore::getImage(context.getPixmapPath(context.selectNode(node,
                                                     "PathBackground")));
-    m_pFgImage = WImageStore::getImage(context.getSkinPath(context.selectString(node,
+    m_pFgImage = WImageStore::getImage(context.getPixmapPath(context.selectNode(node,
                                                     "PathForeground")));
-    m_pGhostImage = WImageStore::getImage(context.getSkinPath(context.selectString(node,
+    m_pGhostImage = WImageStore::getImage(context.getPixmapPath(context.selectNode(node,
                                                     "PathGhost")));
     if (m_pBgImage && !m_pBgImage->isNull()) {
         setFixedSize(m_pBgImage->size());

--- a/src/widget/wstatuslight.cpp
+++ b/src/widget/wstatuslight.cpp
@@ -68,17 +68,17 @@ void WStatusLight::setup(QDomNode node, const SkinContext& context) {
         if (context.hasNode(node, nodeName)) {
             QString mode = context.selectAttributeString(
                 context.selectElement(node, nodeName), "sizemode", "FIXED");
-            setPixmap(i, context.getSkinPath(context.selectString(node, nodeName)),
+            setPixmap(i, context.getPixmapPath(context.selectNode(node, nodeName)),
                                              SizeModeFromString(mode));
         } else if (i == 0 && context.hasNode(node, "PathBack")) {
             QString mode = context.selectAttributeString(
                 context.selectElement(node, "PathBack"), "sizemode", "FIXED");
-            setPixmap(i, context.getSkinPath(context.selectString(node, "PathBack")),
+            setPixmap(i, context.getPixmapPath(context.selectNode(node, "PathBack")),
                                              SizeModeFromString(mode));
         } else if (i == 1 && context.hasNode(node, "PathStatusLight")) {
             QString mode = context.selectAttributeString(
                 context.selectElement(node, "PathStatusLight"), "sizemode", "FIXED");
-            setPixmap(i, context.getSkinPath(context.selectString(node, "PathStatusLight")),
+            setPixmap(i, context.getPixmapPath(context.selectNode(node, "PathStatusLight")),
                                              SizeModeFromString(mode));
         } else {
             m_pixmaps[i].clear();

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -57,10 +57,10 @@ void WVuMeter::setup(QDomNode node, const SkinContext& context) {
 
     // Set background pixmap if available
     if (context.hasNode(node, "PathBack")) {
-        setPixmapBackground(context.getSkinPath(context.selectString(node, "PathBack")));
+        setPixmapBackground(context.getPixmapPath(context.selectNode(node, "PathBack")));
     }
 
-    setPixmaps(context.getSkinPath(context.selectString(node, "PathVu")), bHorizontal);
+    setPixmaps(context.getPixmapPath(context.selectNode(node, "PathVu")), bHorizontal);
 
     m_iPeakHoldSize = context.selectInt(node, "PeakHoldSize");
     if (m_iPeakHoldSize < 0 || m_iPeakHoldSize > 100)

--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -84,7 +84,7 @@ void WWidgetGroup::setup(QDomNode node, const SkinContext& context) {
     if (context.hasNode(node, "BackPath")) {
         QString mode_str = context.selectAttributeString(
                 context.selectElement(node, "BackPath"), "scalemode", "TILE");
-        setPixmapBackground(context.getSkinPath(context.selectString(node, "BackPath")),
+        setPixmapBackground(context.getPixmapPath(context.selectNode(node, "BackPath")),
                             Paintable::DrawModeFromString(mode_str));
     }
 


### PR DESCRIPTION
This is the same pr as https://github.com/mixxxdj/mixxx/pull/285 but cleaner :)

I needed the skin parser to be able to manage Variable elements in svg for cues and loops buttons so I added a function to do it and hooked it directly if a svg element is present in a (un)pressed element.

So now, I can handle inlined svg in my pushbuttons like this : 

``` xml
<Pressed>
    <svg height="16" width="16">
        <rect x="0" y="0" width="16" height="16" style="fill:#000000; stroke-width:1; stroke:#ff0000; stroke-linecap:sqare;" />
        <text x="0" y="15" style="fill:#ff0000; font-size: 16px; font-weight: bold;">
            <Variable name="number"/>
        </text>
    </svg>
</Pressed>
```

As asked, here is the cleaned branch (thanks for the git tricks).

So now some questions/todo list :
- I used QDir in getSkinPath to be able to use my QTemporaryFile. Latelly, I realized I had to place it in /tmp because I couldn't use the autoremove (the file is on close but I had to close it before setPixmap...). So it's not required for this feature but it looks more "Qt friendly" so I let it.
- I'm not sure that creating a temp file is the best way.
- I'm not sure there is a way to set attributes depending on some vars (css would be the good practice normally but are they supported now?).
- Variables are not handled in svg file, only in inline svg.
- Only WPushButton supports inline svg for the moment.

I think that the best approach is to remove the use of a temp file by making the Paintable class able to use a QByteArray as input but without certitude. 

You're insight is welcome!
