### PR TITLE
Fix for Bug #1023804: Stop AutoDJ shuffle from putting two of the same song together

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -777,13 +777,13 @@ void PlaylistDAO::moveTrack(const int playlistId, const int oldPosition, const i
     emit(changed(playlistId));
 }
 
-void searchForDuplicateTrack(const int fromPosition,
-                             const int toPosition,
-                             const int trackID,
-                             const int excludePosition,
-                             const int otherTrackPosition,
-                             const QHash<int,int>* pTrackPositionIds,
-                             int* pTrackDistance) {
+void PlaylistDAO::searchForDuplicateTrack(const int fromPosition,
+                                          const int toPosition,
+                                          const int trackID,
+                                          const int excludePosition,
+                                          const int otherTrackPosition,
+                                          const QHash<int,int>* pTrackPositionIds,
+                                          int* pTrackDistance) {
     //qDebug() << "        Searching from " << fromPosition << " to " << toPosition;
     for (int pos = fromPosition; pos <= toPosition; pos++) {
         if (pTrackPositionIds->value(pos) == trackID &&
@@ -847,7 +847,7 @@ void PlaylistDAO::shuffleTracks(const int playlistId, const QList<int>& position
 
         for (int limit = 10; limit > 0 && conflictFound; limit--) {
             int randomShuffleSetIndex =
-                (int)(qrand() / (RAND_MAX + 1.0) * (newPositions.count()));
+                    (int)(qrand() / (RAND_MAX + 1.0) * (newPositions.count()));
             trackBPosition = positions.at(randomShuffleSetIndex);
             trackBId = trackPositionIds.value(trackBPosition);
             conflictFound = false;
@@ -859,48 +859,45 @@ void PlaylistDAO::shuffleTracks(const int playlistId, const QList<int>& position
 
             // Search around Track B for Track A
             searchForDuplicateTrack(
-                math_clamp(trackBPosition - searchDistance, 0, playlistEnd),
-                math_clamp(trackBPosition + searchDistance, 0, playlistEnd),
-                trackAId, trackAPosition, trackBPosition,
-                &trackPositionIds, &trackDistance);
+                    math_clamp(trackBPosition - searchDistance, 0, playlistEnd),
+                    math_clamp(trackBPosition + searchDistance, 0, playlistEnd),
+                    trackAId, trackAPosition, trackBPosition,
+                    &trackPositionIds, &trackDistance);
             // Wrap search if needed
             if (trackBPosition - searchDistance < 1) {
                 searchForDuplicateTrack(
-                    playlistEnd + (trackBPosition - searchDistance),
-                    playlistEnd,
-                    trackAId, trackAPosition, trackBPosition,
-                    &trackPositionIds, &trackDistance);
+                        playlistEnd + (trackBPosition - searchDistance),
+                        playlistEnd,
+                        trackAId, trackAPosition, trackBPosition,
+                        &trackPositionIds, &trackDistance);
             }
             if (trackBPosition + searchDistance > playlistEnd) {
                 searchForDuplicateTrack(
-                    1,
-                    (trackBPosition + searchDistance) - playlistEnd,
-                    trackAId, trackAPosition, trackBPosition,
-                    &trackPositionIds, &trackDistance);
+                        1,
+                        (trackBPosition + searchDistance) - playlistEnd,
+                        trackAId, trackAPosition, trackBPosition,
+                        &trackPositionIds, &trackDistance);
             }
             // Search around Track A for Track B
             searchForDuplicateTrack(
-                math_clamp(trackAPosition - searchDistance, 0, playlistEnd),
-                math_clamp(trackAPosition + searchDistance, 0, playlistEnd),
-                trackBId,
-                trackBPosition,
-                trackAPosition,
-                &trackPositionIds,
-                &trackDistance);
+                    math_clamp(trackAPosition - searchDistance, 0, playlistEnd),
+                    math_clamp(trackAPosition + searchDistance, 0, playlistEnd),
+                    trackBId, trackBPosition, trackAPosition,
+                    &trackPositionIds, &trackDistance);
             // Wrap search if needed
             if (trackAPosition - searchDistance < 1) {
                 searchForDuplicateTrack(
-                    playlistEnd + (trackAPosition - searchDistance),
-                    playlistEnd,
-                    trackBId, trackBPosition, trackAPosition,
-                    &trackPositionIds, &trackDistance);
+                        playlistEnd + (trackAPosition - searchDistance),
+                        playlistEnd,
+                        trackBId, trackBPosition, trackAPosition,
+                        &trackPositionIds, &trackDistance);
             }
             if (trackAPosition + searchDistance > playlistEnd) {
                 searchForDuplicateTrack(
-                    1,
-                    (trackAPosition + searchDistance) - playlistEnd,
-                    trackBId, trackBPosition, trackAPosition,
-                    &trackPositionIds, &trackDistance);
+                        1,
+                        (trackAPosition + searchDistance) - playlistEnd,
+                        trackBId, trackBPosition, trackAPosition,
+                        &trackPositionIds, &trackDistance);
             }
 
             conflictFound = trackDistance != -1;

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -111,6 +111,13 @@ class PlaylistDAO : public QObject, public virtual DAO {
 
   private:
     void removeTracksFromPlaylistsInner(const QStringList& idList);
+    void searchForDuplicateTrack(const int fromPosition,
+                                 const int toPosition,
+                                 const int trackID,
+                                 const int excludePosition,
+                                 const int otherTrackPosition,
+                                 const QHash<int,int>* pTrackPositionIds,
+                                 int* pTrackDistance);
 
     QSqlDatabase& m_database;
     DISALLOW_COPY_AND_ASSIGN(PlaylistDAO);

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -1,6 +1,7 @@
 #ifndef PLAYLISTDAO_H
 #define PLAYLISTDAO_H
 
+#include <QHash>
 #include <QObject>
 #include <QSqlDatabase>
 
@@ -97,7 +98,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     void moveTrack(const int playlistId,
             const int oldPosition, const int newPosition);
     // shuffles all tracks in the position List
-    void shuffleTracks(const int playlistId, const QList<int>& positions);
+    void shuffleTracks(const int playlistId, const QList<int>& positions, const QHash<int,int>& allIds);
 
   signals:
     void added(int playlistId);

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -161,10 +161,12 @@ bool PlaylistTableModel::isLocked(){
 
 void PlaylistTableModel::shuffleTracks(const QModelIndexList& shuffle, const QModelIndex& exclude) {
     QList<int> positions;
+    QHash<int,int> allIds;
     const int positionColumn = fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION);
+    const int idColumn = fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ID);
     int excludePos = -1;
     if (exclude.row() > -1) {
-        // this is uses to exclude the already loaded track at pos #1 if used from running Auto-DJ
+        // this is used to exclude the already loaded track at pos #1 if used from running Auto-DJ
         excludePos = exclude.sibling(exclude.row(), positionColumn).data().toInt();
     }
     if (shuffle.count() > 1) {
@@ -176,7 +178,7 @@ void PlaylistTableModel::shuffleTracks(const QModelIndexList& shuffle, const QMo
             }
         }
     } else {
-        // if there is only on track selected, shuffle all tracks
+        // if there is only one track selected, shuffle all tracks
         int numOfTracks = rowCount();
         for (int i = 0; i < numOfTracks; i++) {
             int oldPosition = index(i, positionColumn).data().toInt();
@@ -185,8 +187,14 @@ void PlaylistTableModel::shuffleTracks(const QModelIndexList& shuffle, const QMo
             }
         }
     }
-
-    m_playlistDao.shuffleTracks(m_iPlaylistId, positions);
+    // Set up list of all IDs
+    int numOfTracks = rowCount();
+    for (int i=0; i < numOfTracks; i++) {
+        int position = index(i, positionColumn).data().toInt();
+        int id = index(i, idColumn).data().toInt();
+        allIds.insert(position, id);
+    }
+    m_playlistDao.shuffleTracks(m_iPlaylistId, positions, allIds);
 }
 
 bool PlaylistTableModel::isColumnInternal(int column) {

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -189,7 +189,7 @@ void PlaylistTableModel::shuffleTracks(const QModelIndexList& shuffle, const QMo
     }
     // Set up list of all IDs
     int numOfTracks = rowCount();
-    for (int i=0; i < numOfTracks; i++) {
+    for (int i = 0; i < numOfTracks; i++) {
         int position = index(i, positionColumn).data().toInt();
         int id = index(i, idColumn).data().toInt();
         allIds.insert(position, id);


### PR DESCRIPTION
I've modified the shuffling algorithm to try to keep 1/4 of the length of the playlist between tracks. It works in both normal and extreme situations at an acceptable rate, still taking a fraction of a second shuffling a playlist of 1600+ of the same 80 tracks. Details of the algorithm can be found in the comments and the 2nd commit message. I've tried to adhere to the style guidelines but this is my first time contributing, so I'm all ears if I've missed anything!
