### PR TITLE
Fix bug that produces a suddent crossfader jump ..

### DIFF
--- a/src/dlgautodj.cpp
+++ b/src/dlgautodj.cpp
@@ -169,11 +169,23 @@ double DlgAutoDJ::getCrossfader() const {
     return m_pCOCrossfader->get();
 }
 
-void DlgAutoDJ::setCrossfader(double value) {
+void DlgAutoDJ::setCrossfader(double value, bool right) {
     if (m_pCOCrossfaderReverse->get() > 0.0) {
         value *= -1.0;
+        right = !right;
     }
-    m_pCOCrossfader->slotSet(value);
+    double current_value = m_pCOCrossfader->get();
+    if (right) {
+        // ignore if we move slider left
+        if (value > current_value) {
+            m_pCOCrossfader->set(value);
+        }
+    } else {
+        // ignore if we move slider right
+        if (value < current_value) {
+            m_pCOCrossfader->set(value);
+        }
+    }
 }
 
 void DlgAutoDJ::loadSelectedTrack() {
@@ -365,7 +377,7 @@ void DlgAutoDJ::player1PositionChanged(double value) {
     if (m_eState == ADJ_ENABLE_P1LOADED) {
         // Auto DJ Start
         if (!deck1Playing && !deck2Playing) {
-            setCrossfader(-1.0);  // Move crossfader to the left!
+            setCrossfader(-1.0, false);  // Move crossfader to the left!
             m_pCOPlay1->slotSet(1.0);  // Play the track in player 1
             removePlayingTrackFromQueue("[Channel1]");
         } else {
@@ -388,7 +400,7 @@ void DlgAutoDJ::player1PositionChanged(double value) {
     if (m_eState == ADJ_P2FADING) {
         if (deck1Playing && !deck2Playing) {
             // End State
-            setCrossfader(-1.0);  // Move crossfader to the left!
+            setCrossfader(-1.0, false);  // Move crossfader to the left!
             m_eState = ADJ_IDLE;
             pushButtonFadeNow->setEnabled(true);
             loadNextTrackFromQueue();
@@ -437,7 +449,7 @@ void DlgAutoDJ::player1PositionChanged(double value) {
                     2*(value-m_posThreshold1)/(posFadeEnd-m_posThreshold1);
             // crossfadeValue = -1.0f -> + 1.0f
             // Move crossfader to the right!
-            setCrossfader(crossfadeValue);
+            setCrossfader(crossfadeValue, true);
         }
     }
 }
@@ -462,7 +474,7 @@ void DlgAutoDJ::player2PositionChanged(double value) {
         if (!deck1Playing && deck2Playing) {
             // End State
             // Move crossfader to the right!
-            setCrossfader(1.0);
+            setCrossfader(1.0, true);
             m_eState = ADJ_IDLE;
             pushButtonFadeNow->setEnabled(true);
             loadNextTrackFromQueue();
@@ -510,7 +522,7 @@ void DlgAutoDJ::player2PositionChanged(double value) {
             float crossfadeValue = 1.0f -
                     2*(value-m_posThreshold2)/(posFadeEnd-m_posThreshold2);
             // crossfadeValue = 1.0f -> + -1.0f
-            setCrossfader(crossfadeValue); //Move crossfader to the right!
+            setCrossfader(crossfadeValue, false); // Move crossfader to the left!
         }
     }
 }

--- a/src/dlgautodj.h
+++ b/src/dlgautodj.h
@@ -66,7 +66,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     // right side. (prevents AutoDJ logic from having to check for hamster mode
     // every time)
     double getCrossfader() const;
-    void setCrossfader(double value);
+    void setCrossfader(double value, bool right);
 
     TrackPointer getNextTrackFromQueue();
     bool loadNextTrackFromQueue();


### PR DESCRIPTION
when using auto dj and you have moved the crossfader manually.
The fix is a kind of softtacover for the crossfader from auto DJ.
