### PR TITLE
Add hercjogfast mapping mode.

### DIFF
--- a/res/controllers/Hercules DJ Console RMX 2.midi.xml
+++ b/res/controllers/Hercules DJ Console RMX 2.midi.xml
@@ -1152,7 +1152,7 @@
                 <status>0xB0</status>
                 <midino>0x54</midino>
                 <options>
-                    <hercjog/>
+                    <hercjogfast/>
                 </options>
             </control>
             <control>
@@ -1161,7 +1161,7 @@
                 <status>0xB0</status>
                 <midino>0x55</midino>
                 <options>
-                    <hercjog/>
+                    <hercjogfast/>
                 </options>
             </control>
             <control>
@@ -1170,7 +1170,7 @@
                 <status>0xB0</status>
                 <midino>0x5C</midino>
                 <options>
-                    <hercjog/>
+                    <hercjogfast/>
                 </options>
             </control>
             <control>
@@ -1179,7 +1179,7 @@
                 <status>0xB0</status>
                 <midino>0x5D</midino>
                 <options>
-                    <hercjog/>
+                    <hercjogfast/>
                 </options>
             </control>
 			<!-- Effects Controls [Effect Mode] -->

--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -485,6 +485,13 @@ double MidiController::computeValue(MidiOptions options, double _prevmidivalue, 
         //if (_prevmidivalue != 0.0) { qDebug() << "AAAAAAAAAAAA" << _prevmidivalue; }
     }
 
+    if (options.herc_jog_fast) {
+        if (_newmidivalue > 64.) {
+            _newmidivalue -= 128.;
+        }
+        _newmidivalue = _prevmidivalue + (_newmidivalue * 3);
+    }
+
     return _newmidivalue;
 }
 

--- a/src/controllers/midi/midicontrollerpresetfilehandler.cpp
+++ b/src/controllers/midi/midicontrollerpresetfilehandler.cpp
@@ -76,6 +76,7 @@ ControllerPresetPointer MidiControllerPresetFileHandler::load(const QDomElement 
             if (strMidiOption == "button")   options.button = true;
             if (strMidiOption == "switch")   options.sw = true;
             if (strMidiOption == "hercjog")  options.herc_jog = true;
+            if (strMidiOption == "hercjogfast")  options.herc_jog_fast = true;
             if (strMidiOption == "spread64") options.spread64 = true;
             if (strMidiOption == "selectknob")options.selectknob = true;
             if (strMidiOption == "soft-takeover") options.soft_takeover = true;
@@ -303,6 +304,10 @@ QDomElement MidiControllerPresetFileHandler::inputMappingToXML(
         }
         if (mapping.options.herc_jog) {
             QDomElement singleOption = doc->createElement("hercjog");
+            optionsNode.appendChild(singleOption);
+        }
+        if (mapping.options.herc_jog_fast) {
+            QDomElement singleOption = doc->createElement("hercjogfast");
             optionsNode.appendChild(singleOption);
         }
         if (mapping.options.spread64) {

--- a/src/controllers/midi/midimessage.h
+++ b/src/controllers/midi/midimessage.h
@@ -83,7 +83,7 @@ struct MidiOptions {
             bool button        : 1;    // Button Down (!=00) and Button Up (00) events happen together
             bool sw            : 1;    // button down (!=00) and button up (00) events happen seperately
             bool spread64      : 1;    // accelerated difference from 64
-            bool herc_jog      : 1;    // generic Hercules wierd range correction
+            bool herc_jog      : 1;    // generic Hercules range correction 0x01 -> +1; 0x7f -> -1
             bool selectknob    : 1;    // relative knob which can be turned forever and outputs a signed value
             bool soft_takeover : 1;    // prevents sudden changes when hardware position differs from software value
             bool script        : 1;    // maps a MIDI control to a custom MixxxScript function
@@ -91,7 +91,8 @@ struct MidiOptions {
             bool fourteen_bit_msb : 1;
             // the message supplies the LSB of a 14-bit message
             bool fourteen_bit_lsb : 1;
-            // 20 more available for future expansion
+            bool herc_jog_fast    : 1;  // generic Hercules range correction 0x01 -> +5; 0x7f -> -5
+            // 19 more available for future expansion
         };
     };
 };


### PR DESCRIPTION
This is required to map the RMX2 effect knob without need for scripting.
This results in ~ 2 turns for the complete range.
Without fast addition it was ~5 turns.
