### PR TITLE
FIX:1311359 add close button to dev-mode window

### DIFF
--- a/src/dlgdevelopertools.cpp
+++ b/src/dlgdevelopertools.cpp
@@ -9,6 +9,7 @@ DlgDeveloperTools::DlgDeveloperTools(QWidget* pParent,
         : QDialog(pParent) {
     Q_UNUSED(pConfig);
     setupUi(this);
+    this->setWindowFlags(Qt::Window);
 
     QList<QSharedPointer<ControlDoublePrivate> > controlsList;
     ControlDoublePrivate::getControls(&controlsList);


### PR DESCRIPTION
GTK3 does not add close buttons to a dialog window by default. Since
this is not a Dialog which requires input change the window type to
Qt::Window

Can anyone with OS X test if this is not a regression?
