### PR TITLE
waveform beats always thin

### DIFF
--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -71,7 +71,7 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     painter->setRenderHint(QPainter::Antialiasing);
 
     QPen beatPen(m_beatColor);
-    beatPen.setWidthF(1.5);
+    beatPen.setWidthF(1);
     painter->setPen(beatPen);
 
     const float rendererHeight = m_waveformRenderer->getHeight();
@@ -82,6 +82,8 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
         int beatPosition = it->next();
         double xBeatPoint = m_waveformRenderer->transformSampleIndexInRendererWorld(beatPosition);
 
+        xBeatPoint = qRound(xBeatPoint);
+        
         // If we don't have enough space, double the size.
         if (beatCount >= m_beats.size()) {
             m_beats.resize(m_beats.size() * 2);


### PR DESCRIPTION
When you change the width of the waveform pixel by pixel, the beat grid can be thin or "bold" (two pixels instead of one).

This keeps the grid clear for every size.
