### PR TITLE
Partially fix a few issues wiht fidlib

### DIFF
--- a/src/engine/enginefilteriir.h
+++ b/src/engine/enginefilteriir.h
@@ -2,10 +2,10 @@
 #define ENGINEFILTERIIR_H
 
 #include <string.h>
+#include <fidlib.h>
 
 #include "engine/engineobject.h"
 #define MIXXX
-#include <fidlib.h>
 
 enum IIRPass {
     IIR_LP,
@@ -47,8 +47,12 @@ class EngineFilterIIR : public EngineObjectConstIn {
             double freq0, double freq1 = 0, int adj = 0) {
         // Copy the old coefficients into m_oldCoef
         memcpy(m_oldCoef, m_coef, sizeof(m_coef));
+		
+		char* spec_d = malloc(strlen(spec) + 1);
+		strcpy(spec_d, spec);
         m_coef[0] = fid_design_coef(m_coef + 1, SIZE,
-                spec, sampleRate, freq0, freq1, adj);
+                spec_d, sampleRate, freq0, freq1, adj);
+		free(spec_d);
         initBuffers();
     }
 

--- a/src/engine/enginefilteriir.h
+++ b/src/engine/enginefilteriir.h
@@ -47,12 +47,12 @@ class EngineFilterIIR : public EngineObjectConstIn {
             double freq0, double freq1 = 0, int adj = 0) {
         // Copy the old coefficients into m_oldCoef
         memcpy(m_oldCoef, m_coef, sizeof(m_coef));
-		
-		char* spec_d = (char*) malloc(strlen(spec) + 1);
-		strcpy(spec_d, spec);
+
+        char* spec_d = (char*) malloc(strlen(spec) + 1);
+        strcpy(spec_d, spec);
         m_coef[0] = fid_design_coef(m_coef + 1, SIZE,
                 spec_d, sampleRate, freq0, freq1, adj);
-		free(spec_d);
+        free(spec_d);
         initBuffers();
     }
 

--- a/src/engine/enginefilteriir.h
+++ b/src/engine/enginefilteriir.h
@@ -2,10 +2,10 @@
 #define ENGINEFILTERIIR_H
 
 #include <string.h>
-#include <fidlib.h>
 
 #include "engine/engineobject.h"
 #define MIXXX
+#include <fidlib.h>
 
 enum IIRPass {
     IIR_LP,
@@ -48,7 +48,7 @@ class EngineFilterIIR : public EngineObjectConstIn {
         // Copy the old coefficients into m_oldCoef
         memcpy(m_oldCoef, m_coef, sizeof(m_coef));
 		
-		char* spec_d = malloc(strlen(spec) + 1);
+		char* spec_d = (char*) malloc(strlen(spec) + 1);
 		strcpy(spec_d, spec);
         m_coef[0] = fid_design_coef(m_coef + 1, SIZE,
                 spec_d, sampleRate, freq0, freq1, adj);

--- a/src/engine/enginefilteriir.h
+++ b/src/engine/enginefilteriir.h
@@ -46,7 +46,7 @@ class EngineFilterIIR : public EngineObjectConstIn {
     void setCoefs(const char* spec, double sampleRate,
             double freq0, double freq1 = 0, int adj = 0) {
 
-        char* spec_d[32];
+        char spec_d[32];
         if (strlen(spec) < sizeof(spec_d)) {
             // Copy to dynamic-ish memory to prevent fidlib API breakage.
             strcpy(spec_d, spec);

--- a/src/engine/enginefilteriir.h
+++ b/src/engine/enginefilteriir.h
@@ -45,15 +45,20 @@ class EngineFilterIIR : public EngineObjectConstIn {
 
     void setCoefs(const char* spec, double sampleRate,
             double freq0, double freq1 = 0, int adj = 0) {
-        // Copy the old coefficients into m_oldCoef
-        memcpy(m_oldCoef, m_coef, sizeof(m_coef));
 
-        char* spec_d = (char*) malloc(strlen(spec) + 1);
-        strcpy(spec_d, spec);
-        m_coef[0] = fid_design_coef(m_coef + 1, SIZE,
-                spec_d, sampleRate, freq0, freq1, adj);
-        free(spec_d);
-        initBuffers();
+        char* spec_d[32];
+        if (strlen(spec) < sizeof(spec_d)) {
+            // Copy to dynamic-ish memory to prevent fidlib API breakage.
+            strcpy(spec_d, spec);
+
+            // Copy the old coefficients into m_oldCoef
+            memcpy(m_oldCoef, m_coef, sizeof(m_coef));
+
+            m_coef[0] = fid_design_coef(m_coef + 1, SIZE,
+                    spec_d, sampleRate, freq0, freq1, adj);
+
+            initBuffers();
+        }
     }
 
     virtual void process(const CSAMPLE* pIn, CSAMPLE* pOutput,

--- a/src/engine/enginefilteriir.h
+++ b/src/engine/enginefilteriir.h
@@ -5,7 +5,7 @@
 
 #include "engine/engineobject.h"
 #define MIXXX
-#include "fidlib.h"
+#include <fidlib.h>
 
 enum IIRPass {
     IIR_LP,


### PR DESCRIPTION
This was breaking for me when externalizing fidlib.  Other places in the src currently use #include 
&lt;fidlib.h&gt;.

The fidlib api has been patched int he mixxx source which is causing some issues for external depends.  Has upstream been notified of these "fixes?"  Is this project still developed?  If not, time for a fork?  This patch includes a ~~workaround~~ hack for the api breakage that just copies the const string to a dynamic one to satisfy the api.
