### PR TITLE
Prefer pre-increment operators

### DIFF
--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -170,7 +170,7 @@ void ControllerEngine::gracefulShutdown() {
         ConfigKey key = *it;
         ControlObjectThread *cot = m_controlCache.take(key);
         delete cot;
-        it++;
+        ++it;
     }
 
     delete m_pBaClass;

--- a/src/controllers/controllerpresetinfo.cpp
+++ b/src/controllers/controllerpresetinfo.cpp
@@ -150,7 +150,7 @@ PresetInfoEnumerator::PresetInfoEnumerator(ConfigObject<ConfigValue>* pConfig)
 PresetInfoEnumerator::~PresetInfoEnumerator() {
     for (QMap<QString, ControllerPresetFileHandler*>::iterator it =
                  m_presetFileHandlersByExtension.begin();
-         it != m_presetFileHandlersByExtension.end(); it++) {
+         it != m_presetFileHandlersByExtension.end(); ++it) {
         delete it.value();
         it = m_presetFileHandlersByExtension.erase(it);
     }

--- a/src/dlgdevelopertools.cpp
+++ b/src/dlgdevelopertools.cpp
@@ -15,7 +15,7 @@ DlgDeveloperTools::DlgDeveloperTools(QWidget* pParent,
     ControlDoublePrivate::getControls(&controlsList);
 
     for (QList<QSharedPointer<ControlDoublePrivate> >::const_iterator it = controlsList.begin();
-         it != controlsList.end(); it++) {
+         it != controlsList.end(); ++it) {
         const QSharedPointer<ControlDoublePrivate>& pControl = *it;
         if (pControl) {
             m_controlModel.addControl(pControl->getKey(), pControl->name(),

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -109,7 +109,7 @@ QString EffectsManager::getPrevEffectId(const QString& effectId) {
         return effects.last();
     }
 
-    it--;
+    --it;
     return *it;
 }
 

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -72,7 +72,7 @@ bool EngineEffectChain::updateParameters(const EffectsRequest& message) {
     // If our enabled state changed then tell each group to ramp in or out.
     if (wasEnabled ^ m_bEnabled) {
         for (QMap<QString, GroupStatus>::iterator it = m_groupStatus.begin();
-             it != m_groupStatus.end(); it++) {
+             it != m_groupStatus.end(); ++it) {
             GroupStatus& status = it.value();
 
             if (m_bEnabled) {

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -389,7 +389,7 @@ void PlayerManager::slotLoadTrackIntoNextAvailableDeck(TrackPointer pTrack) {
             pDeck->slotLoadTrack(pTrack, false);
             return;
         }
-        it++;
+        ++it;
     }
 }
 
@@ -405,6 +405,6 @@ void PlayerManager::slotLoadTrackIntoNextAvailableSampler(TrackPointer pTrack) {
             pSampler->slotLoadTrack(pTrack, false);
             return;
         }
-        it++;
+        ++it;
     }
 }


### PR DESCRIPTION
Slight performance gain in several locations where pre-increment operators are used now.

Pre-increment/decrement operators can be more effectient than post-increment/decrement operators, which involve keeping a copy of previous value.
