### PR TITLE
reset xfader to 0 when disabling autodj

### DIFF
--- a/src/dlgautodj.cpp
+++ b/src/dlgautodj.cpp
@@ -349,6 +349,7 @@ void DlgAutoDJ::toggleAutoDJButton(bool enable) {
         m_pCOPlayPos2->disconnect(this);
         m_pCOPlay1->disconnect(this);
         m_pCOPlay2->disconnect(this);
+        m_pCOCrossfader->set(0);
     }
 }
 


### PR DESCRIPTION
Sometimes (probably often), when I disable autodj to play with my music, I don't understand why I'm unable to hear one of the playing tracks, it always because autodj set the crossfader to one track and I forgot to put it back at the center.

This would avoid these frustrations! :)
