### PR TITLE
Master mono

### DIFF
--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -132,6 +132,15 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
             this, SLOT(masterMixChanged(int)));
     m_pMasterEnabled->connectValueChanged(this, SLOT(masterEnabledChanged(double)));
 
+    m_pMasterMono =
+            new ControlObjectSlave("[Master]", "mono", this);
+    masterMonoComboBox->addItem(tr("Stereo"));
+    masterMonoComboBox->addItem(tr("Mono"));
+    masterMonoComboBox->setCurrentIndex(m_pMasterMono->get() ? 1 : 0);
+    connect(masterMonoComboBox, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(masterMonoChanged(int)));
+    m_pMasterMono->connectValueChanged(this, SLOT(masterMonoChanged(double)));
+
 
     m_pKeylockEngine =
             new ControlObjectSlave("[Master]", "keylock_engine", this);
@@ -553,4 +562,11 @@ void DlgPrefSound::masterEnabledChanged(double value) {
     masterMixComboBox->setCurrentIndex(value ? 1 : 0);
 }
 
+void DlgPrefSound::masterMonoChanged(int value) {
+    m_pMasterMono->set(value);
+}
+
+void DlgPrefSound::masterMonoChanged(double value) {
+    masterMonoComboBox->setCurrentIndex(value ? 1 : 0);
+}
 

--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -133,8 +133,8 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     masterMonoComboBox->addItem(tr("Mono"));
     masterMonoComboBox->setCurrentIndex(m_pMasterMono->get() ? 1 : 0);
     connect(masterMonoComboBox, SIGNAL(currentIndexChanged(int)),
-            this, SLOT(masterMonoChanged(int)));
-    m_pMasterMono->connectValueChanged(this, SLOT(masterMonoChanged(double)));
+            this, SLOT(masterMonoComboBoxChanged(int)));
+    m_pMasterMono->connectValueChanged(this, SLOT(masterMonoCoChanged(double)));
 
 
     m_pKeylockEngine =
@@ -557,11 +557,11 @@ void DlgPrefSound::masterEnabledChanged(double value) {
     masterMixComboBox->setCurrentIndex(value ? 1 : 0);
 }
 
-void DlgPrefSound::masterMonoChanged(int value) {
-    m_pMasterMono->set(value);
+void DlgPrefSound::masterMonoComboBoxChanged(int value) {
+    m_pMasterMono->set((double)value);
 }
 
-void DlgPrefSound::masterMonoChanged(double value) {
+void DlgPrefSound::masterMonoCoChanged(double value) {
     masterMonoComboBox->setCurrentIndex(value ? 1 : 0);
 }
 

--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -110,21 +110,17 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
             new ControlObjectSlave("[Master]", "audio_latency_overload_count", this);
     m_pMasterAudioLatencyOverloadCount->connectValueChanged(SLOT(bufferUnderflow(double)));
 
-    m_pMasterLatency =
-            new ControlObjectSlave("[Master]", "latency", this);
+    m_pMasterLatency = new ControlObjectSlave("[Master]", "latency", this);
     m_pMasterLatency->connectValueChanged(SLOT(masterLatencyChanged(double)));
 
 
-    m_pHeadDelay =
-            new ControlObjectSlave("[Master]", "headDelay", this);
-    m_pMasterDelay =
-            new ControlObjectSlave("[Master]", "delay", this);
+    m_pHeadDelay = new ControlObjectSlave("[Master]", "headDelay", this);
+    m_pMasterDelay = new ControlObjectSlave("[Master]", "delay", this);
 
     headDelaySpinBox->setValue(m_pHeadDelay->get());
     masterDelaySpinBox->setValue(m_pMasterDelay->get());
 
-    m_pMasterEnabled =
-            new ControlObjectSlave("[Master]", "enabled", this);
+    m_pMasterEnabled = new ControlObjectSlave("[Master]", "enabled", this);
     masterMixComboBox->addItem(tr("Disabled"));
     masterMixComboBox->addItem(tr("Enabled"));
     masterMixComboBox->setCurrentIndex(m_pMasterEnabled->get() ? 1 : 0);
@@ -132,8 +128,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
             this, SLOT(masterMixChanged(int)));
     m_pMasterEnabled->connectValueChanged(this, SLOT(masterEnabledChanged(double)));
 
-    m_pMasterMono =
-            new ControlObjectSlave("[Master]", "mono", this);
+    m_pMasterMono = new ControlObjectSlave("[Master]", "mono", this);
     masterMonoComboBox->addItem(tr("Stereo"));
     masterMonoComboBox->addItem(tr("Mono"));
     masterMonoComboBox->setCurrentIndex(m_pMasterMono->get() ? 1 : 0);

--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -128,13 +128,13 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
             this, SLOT(masterMixChanged(int)));
     m_pMasterEnabled->connectValueChanged(this, SLOT(masterEnabledChanged(double)));
 
-    m_pMasterMono = new ControlObjectSlave("[Master]", "mono", this);
-    masterMonoComboBox->addItem(tr("Stereo"));
-    masterMonoComboBox->addItem(tr("Mono"));
-    masterMonoComboBox->setCurrentIndex(m_pMasterMono->get() ? 1 : 0);
-    connect(masterMonoComboBox, SIGNAL(currentIndexChanged(int)),
-            this, SLOT(masterMonoComboBoxChanged(int)));
-    m_pMasterMono->connectValueChanged(this, SLOT(masterMonoCoChanged(double)));
+    m_pMasterMonoMixdown = new ControlObjectSlave("[Master]", "mono_mixdown", this);
+    masterOutputModeComboBox->addItem(tr("Stereo"));
+    masterOutputModeComboBox->addItem(tr("Mono"));
+    masterOutputModeComboBox->setCurrentIndex(m_pMasterMonoMixdown->get() ? 1 : 0);
+    connect(masterOutputModeComboBox, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(masterOutputModeComboBoxChanged(int)));
+    m_pMasterMonoMixdown->connectValueChanged(this, SLOT(masterMonoMixdownChanged(double)));
 
 
     m_pKeylockEngine =
@@ -557,11 +557,11 @@ void DlgPrefSound::masterEnabledChanged(double value) {
     masterMixComboBox->setCurrentIndex(value ? 1 : 0);
 }
 
-void DlgPrefSound::masterMonoComboBoxChanged(int value) {
-    m_pMasterMono->set((double)value);
+void DlgPrefSound::masterOutputModeComboBoxChanged(int value) {
+    m_pMasterMonoMixdown->set((double)value);
 }
 
-void DlgPrefSound::masterMonoCoChanged(double value) {
-    masterMonoComboBox->setCurrentIndex(value ? 1 : 0);
+void DlgPrefSound::masterMonoMixdownChanged(double value) {
+    masterOutputModeComboBox->setCurrentIndex(value ? 1 : 0);
 }
 

--- a/src/dlgprefsound.h
+++ b/src/dlgprefsound.h
@@ -63,6 +63,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void masterDelayChanged(double value);
     void masterMixChanged(int value);
     void masterEnabledChanged(double value);
+    void masterMonoChanged(int value);
+    void masterMonoChanged(double value);
 
   private slots:
     void addPath(AudioOutput output);
@@ -93,6 +95,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlObjectSlave* m_pMasterDelay;
     ControlObjectSlave* m_pKeylockEngine;
     ControlObjectSlave* m_pMasterEnabled;
+    ControlObjectSlave* m_pMasterMono;
     QList<SoundDevice*> m_inputDevices;
     QList<SoundDevice*> m_outputDevices;
     bool m_settingsModified;

--- a/src/dlgprefsound.h
+++ b/src/dlgprefsound.h
@@ -63,8 +63,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void masterDelayChanged(double value);
     void masterMixChanged(int value);
     void masterEnabledChanged(double value);
-    void masterMonoComboBoxChanged(int value);
-    void masterMonoCoChanged(double value);
+    void masterOutputModeComboBoxChanged(int value);
+    void masterMonoMixdownChanged(double value);
 
   private slots:
     void addPath(AudioOutput output);
@@ -95,7 +95,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlObjectSlave* m_pMasterDelay;
     ControlObjectSlave* m_pKeylockEngine;
     ControlObjectSlave* m_pMasterEnabled;
-    ControlObjectSlave* m_pMasterMono;
+    ControlObjectSlave* m_pMasterMonoMixdown;
     QList<SoundDevice*> m_inputDevices;
     QList<SoundDevice*> m_outputDevices;
     bool m_settingsModified;

--- a/src/dlgprefsound.h
+++ b/src/dlgprefsound.h
@@ -63,8 +63,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void masterDelayChanged(double value);
     void masterMixChanged(int value);
     void masterEnabledChanged(double value);
-    void masterMonoChanged(int value);
-    void masterMonoChanged(double value);
+    void masterMonoComboBoxChanged(int value);
+    void masterMonoCoChanged(double value);
 
   private slots:
     void addPath(AudioOutput output);

--- a/src/dlgprefsounddlg.ui
+++ b/src/dlgprefsounddlg.ui
@@ -181,7 +181,7 @@
      <item row="6" column="0">
       <widget class="QLabel" name="masterMonoLabel">
        <property name="text">
-        <string>Master Mono</string>
+        <string>Master Channels</string>
        </property>
       </widget>
      </item>

--- a/src/dlgprefsounddlg.ui
+++ b/src/dlgprefsounddlg.ui
@@ -186,7 +186,7 @@
       </widget>
      </item>
      <item row="6" column="1">
-      <widget class="QComboBox" name="masterMonoComboBox"/>
+      <widget class="QComboBox" name="masterOutputModeComboBox"/>
      </item>
     </layout>
    </item>

--- a/src/dlgprefsounddlg.ui
+++ b/src/dlgprefsounddlg.ui
@@ -179,7 +179,7 @@
       <widget class="QComboBox" name="keylockComboBox"/>
      </item>
      <item row="6" column="0">
-      <widget class="QLabel" name="masterMonoLable">
+      <widget class="QLabel" name="masterMonoLabel">
        <property name="text">
         <string>Master Mono</string>
        </property>

--- a/src/dlgprefsounddlg.ui
+++ b/src/dlgprefsounddlg.ui
@@ -19,7 +19,7 @@
      <item row="0" column="1">
       <widget class="QComboBox" name="apiComboBox"/>
      </item>
-     <item row="6" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="headDelayLabel">
        <property name="text">
         <string>Headphone Delay</string>
@@ -36,7 +36,7 @@
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
+     <item row="8" column="1">
       <widget class="QDoubleSpinBox" name="masterDelaySpinBox">
        <property name="suffix">
         <string extracomment="milliseconds"> ms</string>
@@ -49,7 +49,7 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
+     <item row="9" column="1">
       <widget class="QLabel" name="currentLatency">
        <property name="text">
         <string>20 ms</string>
@@ -66,10 +66,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QComboBox" name="keylockComboBox"/>
-     </item>
-     <item row="10" column="0">
+     <item row="11" column="0">
       <spacer name="outputVSpacer_3">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -88,7 +85,7 @@
      <item row="1" column="1">
       <widget class="QComboBox" name="sampleRateComboBox"/>
      </item>
-     <item row="8" column="0">
+     <item row="9" column="0">
       <widget class="QLabel" name="latencyLabel">
        <property name="text">
         <string>Known Latency</string>
@@ -98,7 +95,7 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="0">
+     <item row="10" column="0">
       <widget class="QLabel" name="underflowLabel">
        <property name="text">
         <string>Buffer Underflow Count</string>
@@ -121,14 +118,14 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
+     <item row="10" column="1">
       <widget class="QLabel" name="bufferUnderflowCount">
        <property name="text">
         <string>0</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="7" column="1">
       <widget class="QDoubleSpinBox" name="headDelaySpinBox">
        <property name="suffix">
         <string extracomment="milliseconds"> ms</string>
@@ -141,20 +138,10 @@
        </property>
       </widget>
      </item>
-     <item row="7" column="0">
+     <item row="8" column="0">
       <widget class="QLabel" name="masterDelayLabel">
        <property name="text">
         <string>Master Delay</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="keylockLabel">
-       <property name="text">
-        <string>Keylock/Pitch-Bending Engine</string>
-       </property>
-       <property name="buddy">
-        <cstring>keylockComboBox</cstring>
        </property>
       </widget>
      </item>
@@ -168,15 +155,38 @@
      <item row="3" column="1">
       <widget class="QComboBox" name="deviceSyncComboBox"/>
      </item>
-     <item row="4" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="masteMixLabel">
        <property name="text">
         <string>Master Mix</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <widget class="QComboBox" name="masterMixComboBox"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="keylockLabel">
+       <property name="text">
+        <string>Keylock/Pitch-Bending Engine</string>
+       </property>
+       <property name="buddy">
+        <cstring>keylockComboBox</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QComboBox" name="keylockComboBox"/>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="masterMonoLable">
+       <property name="text">
+        <string>Master Mono</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QComboBox" name="masterMonoComboBox"/>
      </item>
     </layout>
    </item>
@@ -317,7 +327,6 @@
   <tabstop>sampleRateComboBox</tabstop>
   <tabstop>audioBufferComboBox</tabstop>
   <tabstop>deviceSyncComboBox</tabstop>
-  <tabstop>keylockComboBox</tabstop>
   <tabstop>headDelaySpinBox</tabstop>
   <tabstop>masterDelaySpinBox</tabstop>
   <tabstop>ioTabs</tabstop>

--- a/src/dlgprefsounddlg.ui
+++ b/src/dlgprefsounddlg.ui
@@ -181,7 +181,7 @@
      <item row="6" column="0">
       <widget class="QLabel" name="masterMonoLabel">
        <property name="text">
-        <string>Master Channels</string>
+        <string>Master Output Mode</string>
        </property>
       </widget>
      </item>

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -510,9 +510,7 @@ void EngineMaster::process(const int iBufferSize) {
 
     if (m_pMasterMono->get()) {
         // Mix two Mono channels. This is useful for outdoor gigs
-        for (int i = 0; i + 1 < iBufferSize; i += 2) {
-            m_pMaster[i + 1] = m_pMaster[i] = (m_pMaster[i] + m_pMaster[i + 1]) / 2;
-        }
+        SampleUtil::mixStereoToMono(m_pMaster, m_pMaster, iBufferSize);
     }
 
     if (masterEnabled) {

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -152,7 +152,7 @@ EngineMaster::EngineMaster(ConfigObject<ConfigValue>* _config,
 
     m_pMasterEnabled = new ControlObject(ConfigKey(group, "enabled"),
             true, false, true);  // persist = true
-    m_pMasterMono = new ControlObject(ConfigKey(group, "mono"),
+    m_pMasterMonoMixdown = new ControlObject(ConfigKey(group, "mono_mixdown"),
             true, false, true);  // persist = true
     m_pHeadphoneEnabled = new ControlObject(ConfigKey(group, "headEnabled"));
 }
@@ -187,7 +187,7 @@ EngineMaster::~EngineMaster() {
     delete m_pAudioLatencyOverload;
 
     delete m_pMasterEnabled;
-    delete m_pMasterMono;
+    delete m_pMasterMonoMixdown;
     delete m_pHeadphoneEnabled;
 
     SampleUtil::free(m_pHead);
@@ -508,7 +508,7 @@ void EngineMaster::process(const int iBufferSize) {
         }
     }
 
-    if (m_pMasterMono->get()) {
+    if (m_pMasterMonoMixdown->get()) {
         SampleUtil::mixStereoToMono(m_pMaster, m_pMaster, iBufferSize);
     }
 

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -150,8 +150,10 @@ EngineMaster::EngineMaster(ConfigObject<ConfigValue>* _config,
     m_pKeylockEngine->set(_config->getValueString(
             ConfigKey(group, "keylock_engine")).toDouble());
 
-    m_pMasterEnabled = new ControlObject(ConfigKey(group, "enabled"),true, false, true); // persist = true
-    m_pMasterMono = new ControlObject(ConfigKey(group, "mono"),true, false, true); // persist = true
+    m_pMasterEnabled = new ControlObject(ConfigKey(group, "enabled"),
+            true, false, true);  // persist = true
+    m_pMasterMono = new ControlObject(ConfigKey(group, "mono"),
+            true, false, true);  // persist = true
     m_pHeadphoneEnabled = new ControlObject(ConfigKey(group, "headEnabled"));
 }
 

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -509,7 +509,6 @@ void EngineMaster::process(const int iBufferSize) {
     }
 
     if (m_pMasterMono->get()) {
-        // Mix two Mono channels. This is useful for outdoor gigs
         SampleUtil::mixStereoToMono(m_pMaster, m_pMaster, iBufferSize);
     }
 

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -151,6 +151,7 @@ EngineMaster::EngineMaster(ConfigObject<ConfigValue>* _config,
             ConfigKey(group, "keylock_engine")).toDouble());
 
     m_pMasterEnabled = new ControlObject(ConfigKey(group, "enabled"),true, false, true); // persist = true
+    m_pMasterMono = new ControlObject(ConfigKey(group, "mono"),true, false, true); // persist = true
     m_pHeadphoneEnabled = new ControlObject(ConfigKey(group, "headEnabled"));
 }
 
@@ -184,6 +185,7 @@ EngineMaster::~EngineMaster() {
     delete m_pAudioLatencyOverload;
 
     delete m_pMasterEnabled;
+    delete m_pMasterMono;
     delete m_pHeadphoneEnabled;
 
     SampleUtil::free(m_pHead);
@@ -501,6 +503,13 @@ void EngineMaster::process(const int iBufferSize) {
                 m_pHead[i] = (m_pHead[i] + m_pHead[i + 1]) / 2;
                 m_pHead[i + 1] = (m_pMaster[i] + m_pMaster[i + 1]) / 2;
             }
+        }
+    }
+
+    if (m_pMasterMono->get()) {
+        // Mix two Mono channels. This is useful for outdoor gigs
+        for (int i = 0; i + 1 < iBufferSize; i += 2) {
+            m_pMaster[i + 1] = m_pMaster[i] = (m_pMaster[i] + m_pMaster[i + 1]) / 2;
         }
     }
 

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -252,7 +252,7 @@ class EngineMaster : public QObject, public AudioSource {
     // and right Bus and no recording and broadcast active
     ControlObject* m_pMasterEnabled;
     // Mix two Mono channels. This is useful for outdoor gigs
-    ControlObject* m_pMasterMono;
+    ControlObject* m_pMasterMonoMixdown;
     ControlObject* m_pHeadphoneEnabled;
 
     volatile bool m_bBusOutputConnected[3];

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -249,6 +249,7 @@ class EngineMaster : public QObject, public AudioSource {
     CSAMPLE m_headphoneVolumeOld;
 
     ControlObject* m_pMasterEnabled;
+    ControlObject* m_pMasterMono;
     ControlObject* m_pHeadphoneEnabled;
 
     volatile bool m_bBusOutputConnected[3];

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -248,7 +248,10 @@ class EngineMaster : public QObject, public AudioSource {
     CSAMPLE m_headphoneMasterGainOld;
     CSAMPLE m_headphoneVolumeOld;
 
+    // Produce the Master Mixxx, not Required if connected to left
+    // and right Bus and no recording and broadcast active
     ControlObject* m_pMasterEnabled;
+    // Mix two Mono channels. This is useful for outdoor gigs
     ControlObject* m_pMasterMono;
     ControlObject* m_pHeadphoneEnabled;
 


### PR DESCRIPTION
Added an option for two channel mono output. 

Mixxx has already a mono down-mix when using only one sound card channel.  
But it you need to feed a stereo amp with the mono signal you need a special cable. 

With this patch, you can switch beween Mono and Stereo without tweaking the hardware. 

This feature is required for outdoor gigs, where a Stereo effect is not possible due to the speaker positions.
