### PR TITLE
DN-MC6000MK2: Sync mapping with push-and-hold

### DIFF
--- a/res/controllers/Denon-MC6000MK2.midi.xml
+++ b/res/controllers/Denon-MC6000MK2.midi.xml
@@ -568,11 +568,14 @@
 			<control>
 				<group>[Channel1]</group>
 				<midino>0x6B</midino>
+				<status>0x80</status>
+				<key>sync_enabled</key>
+			</control>
+			<control>
+				<group>[Channel1]</group>
+				<midino>0x6B</midino>
 				<status>0x90</status>
-				<key>DenonMC6000MK2.onSyncButton</key>
-				<options>
-					<script-binding/>
-				</options>
+				<key>sync_enabled</key>
 			</control>
 			<control>
 				<group>[Channel1]</group>
@@ -979,11 +982,14 @@
 			<control>
 				<group>[Channel2]</group>
 				<midino>0x6B</midino>
+				<status>0x82</status>
+				<key>sync_enabled</key>
+			</control>
+			<control>
+				<group>[Channel2]</group>
+				<midino>0x6B</midino>
 				<status>0x92</status>
-				<key>DenonMC6000MK2.onSyncButton</key>
-				<options>
-					<script-binding/>
-				</options>
+				<key>sync_enabled</key>
 			</control>
 			<control>
 				<group>[Channel2]</group>
@@ -1390,11 +1396,14 @@
 			<control>
 				<group>[Channel3]</group>
 				<midino>0x6B</midino>
+				<status>0x81</status>
+				<key>sync_enabled</key>
+			</control>
+			<control>
+				<group>[Channel3]</group>
+				<midino>0x6B</midino>
 				<status>0x91</status>
-				<key>DenonMC6000MK2.onSyncButton</key>
-				<options>
-					<script-binding/>
-				</options>
+				<key>sync_enabled</key>
 			</control>
 			<control>
 				<group>[Channel3]</group>
@@ -1801,11 +1810,14 @@
 			<control>
 				<group>[Channel4]</group>
 				<midino>0x6B</midino>
+				<status>0x83</status>
+				<key>sync_enabled</key>
+			</control>
+			<control>
+				<group>[Channel4]</group>
+				<midino>0x6B</midino>
 				<status>0x93</status>
-				<key>DenonMC6000MK2.onSyncButton</key>
-				<options>
-					<script-binding/>
-				</options>
+				<key>sync_enabled</key>
 			</control>
 			<control>
 				<group>[Channel4]</group>


### PR DESCRIPTION
- Use MIDI mapping for "sync_enabled" to support push-and-hold
- Change sync mode indicator LED:
  MASTER=blinking, FOLLOWER=on, NONE=off
- Use setParameter() instead of setValue() for effect parameters
- Fix right effect unit enabled LED
