### PR TITLE
fix windows build and m_spec overflow

### DIFF
--- a/src/engine/enginefilterbiquad1.cpp
+++ b/src/engine/enginefilterbiquad1.cpp
@@ -13,7 +13,7 @@ void EngineFilterBiquad1LowShelving::setFrequencyCorners(int sampleRate,
                                                          double centerFreq,
                                                          double Q,
                                                          double dBgain) {
-    snprintf(m_spec, sizeof(m_spec), "LsBq/%.10f/%.10f", Q, dBgain);
+    format_fidspec(m_spec, sizeof(m_spec), "LsBq/%.10f/%.10f", Q, dBgain);
     setCoefs(m_spec, sampleRate, centerFreq);
 }
 
@@ -27,7 +27,7 @@ void EngineFilterBiquad1Peaking::setFrequencyCorners(int sampleRate,
                                                      double centerFreq,
                                                      double Q,
                                                      double dBgain) {
-    snprintf(m_spec, sizeof(m_spec), "PkBq/%.10f/%.10f", Q, dBgain);
+    format_fidspec(m_spec, sizeof(m_spec), "PkBq/%.10f/%.10f", Q, dBgain);
     setCoefs(m_spec, sampleRate, centerFreq);
 }
 
@@ -42,7 +42,7 @@ void EngineFilterBiquad1HighShelving::setFrequencyCorners(int sampleRate,
                                                           double centerFreq,
                                                           double Q,
                                                           double dBgain) {
-    snprintf(m_spec, sizeof(m_spec), "HsBq/%.10f/%.10f", Q, dBgain);
+    format_fidspec(m_spec, sizeof(m_spec), "HsBq/%.10f/%.10f", Q, dBgain);
     setCoefs(m_spec, sampleRate, centerFreq);
 }
 
@@ -55,7 +55,7 @@ EngineFilterBiquad1Low::EngineFilterBiquad1Low(int sampleRate,
 void EngineFilterBiquad1Low::setFrequencyCorners(int sampleRate,
                                                  double centerFreq,
                                                  double Q) {
-    snprintf(m_spec, sizeof(m_spec), "LpBq/%.10f", Q);
+    format_fidspec(m_spec, sizeof(m_spec), "LpBq/%.10f", Q);
     setCoefs(m_spec, sampleRate, centerFreq);
 }
 
@@ -68,7 +68,7 @@ EngineFilterBiquad1Band::EngineFilterBiquad1Band(int sampleRate,
 void EngineFilterBiquad1Band::setFrequencyCorners(int sampleRate,
                                                   double centerFreq,
                                                   double Q) {
-    snprintf(m_spec, sizeof(m_spec), "BpBq/%.10f", Q);
+    format_fidspec(m_spec, sizeof(m_spec), "BpBq/%.10f", Q);
     setCoefs(m_spec, sampleRate, centerFreq);
 }
 
@@ -81,6 +81,6 @@ EngineFilterBiquad1High::EngineFilterBiquad1High(int sampleRate,
 void EngineFilterBiquad1High::setFrequencyCorners(int sampleRate,
                                                   double centerFreq,
                                                   double Q) {
-    snprintf(m_spec, sizeof(m_spec), "HpBq/%.10f", Q);
+    format_fidspec(m_spec, sizeof(m_spec), "HpBq/%.10f", Q);
     setCoefs(m_spec, sampleRate, centerFreq);
 }

--- a/src/engine/enginefilterbiquad1.h
+++ b/src/engine/enginefilterbiquad1.h
@@ -3,6 +3,13 @@
 
 #include "engine/enginefilteriir.h"
 
+#ifdef _MSC_VER
+    // Visual Studio doesn't have snprintf
+    #define format_fidspec sprintf_s
+#else
+    #define format_fidspec snprintf
+#endif
+
 class EngineFilterBiquad1LowShelving : public EngineFilterIIR<5, IIR_BP> {
     Q_OBJECT
   public:
@@ -11,7 +18,7 @@ class EngineFilterBiquad1LowShelving : public EngineFilterIIR<5, IIR_BP> {
                              double Q, double dBgain);
 
   private:
-    char m_spec[32];
+    char m_spec[FIDSPEC_LENGTH];
 };
 
 class EngineFilterBiquad1Peaking : public EngineFilterIIR<5, IIR_BP> {
@@ -22,7 +29,7 @@ class EngineFilterBiquad1Peaking : public EngineFilterIIR<5, IIR_BP> {
                              double Q, double dBgain);
 
   private:
-    char m_spec[32];
+    char m_spec[FIDSPEC_LENGTH];
 };
 
 class EngineFilterBiquad1HighShelving : public EngineFilterIIR<5, IIR_BP> {
@@ -33,7 +40,7 @@ class EngineFilterBiquad1HighShelving : public EngineFilterIIR<5, IIR_BP> {
                              double Q, double dBgain);
 
   private:
-    char m_spec[32];
+    char m_spec[FIDSPEC_LENGTH];
 };
 
 class EngineFilterBiquad1Low : public EngineFilterIIR<2, IIR_LP> {
@@ -43,7 +50,7 @@ class EngineFilterBiquad1Low : public EngineFilterIIR<2, IIR_LP> {
     void setFrequencyCorners(int sampleRate, double centerFreq, double Q);
 
   private:
-    char m_spec[32];
+    char m_spec[FIDSPEC_LENGTH];
 };
 
 class EngineFilterBiquad1Band : public EngineFilterIIR<2, IIR_BP> {
@@ -53,7 +60,7 @@ class EngineFilterBiquad1Band : public EngineFilterIIR<2, IIR_BP> {
     void setFrequencyCorners(int sampleRate, double centerFreq, double Q);
 
   private:
-    char m_spec[32];
+    char m_spec[FIDSPEC_LENGTH];
 };
 
 class EngineFilterBiquad1High : public EngineFilterIIR<2, IIR_HP> {
@@ -63,7 +70,7 @@ class EngineFilterBiquad1High : public EngineFilterIIR<2, IIR_HP> {
     void setFrequencyCorners(int sampleRate, double centerFreq, double Q);
 
   private:
-    char m_spec[32];
+    char m_spec[FIDSPEC_LENGTH];
 };
 
 #endif // ENGINEFILTERBIQUAD1_H

--- a/src/engine/enginefilteriir.h
+++ b/src/engine/enginefilteriir.h
@@ -13,6 +13,9 @@ enum IIRPass {
     IIR_HP
 };
 
+// length of the 3rd argument to fid_design_coef
+#define FIDSPEC_LENGTH 40
+
 template<unsigned int SIZE, enum IIRPass PASS>
 class EngineFilterIIR : public EngineObjectConstIn {
   public:
@@ -49,7 +52,7 @@ class EngineFilterIIR : public EngineObjectConstIn {
     void setCoefs(const char* spec, double sampleRate,
             double freq0, double freq1 = 0, int adj = 0) {
 
-        char spec_d[32];
+        char spec_d[FIDSPEC_LENGTH];
         if (strlen(spec) < sizeof(spec_d)) {
             // Copy to dynamic-ish memory to prevent fidlib API breakage.
             strcpy(spec_d, spec);

--- a/src/test/enginefilterbiquadtest.cpp
+++ b/src/test/enginefilterbiquadtest.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+#include <clocale>
+#include <QString>
+
+#include "engine/enginefilterbiquad1.h"
+
+namespace {
+
+class EngineFilterBiquadTest : public testing::Test {
+  protected:
+    QString originalLocale;
+
+    virtual void SetUp() {
+        originalLocale = setlocale(LC_ALL, NULL);
+    }
+    virtual void TearDown() {
+        setlocale(LC_ALL, originalLocale.toStdString().c_str());
+    }
+};
+
+TEST_F(EngineFilterBiquadTest, fidlibInputRespectsLocale) {
+    char spec[FIDSPEC_LENGTH];
+
+    // Indonesia uses commas as a decimal separator.
+    setlocale(LC_ALL, "Indonesian_Indonesia.1252");    
+    format_fidspec(spec, sizeof(spec), "LsBq/%.10f/%.10f", 1.22, -12.0);
+    ASSERT_STREQ("LsBq/1,2200000000/-12,0000000000", spec);
+    // The reason this is important is that fidlib will do strtod on parts
+    // of this string:
+    ASSERT_DOUBLE_EQ(1.22, strtod("1,2200000000", NULL));
+}
+
+}


### PR DESCRIPTION
Note that a char[32] was too small. The test is implicitly testing this as well.
