### PR TITLE
Make samplerate an explicitly-passed variable in the effects framework.

### DIFF
--- a/src/effects/effectprocessor.h
+++ b/src/effects/effectprocessor.h
@@ -78,9 +78,6 @@ class GroupEffectProcessor : public EffectProcessor {
                               const unsigned int numSamples,
                               const unsigned int sampleRate,
                               const GroupFeatureState& groupFeatures) = 0;
-    int getSampleRate() {
-        return m_sampleRate;
-    }
 
   private:
     QMap<QString, T*> m_groupState;

--- a/src/effects/effectprocessor.h
+++ b/src/effects/effectprocessor.h
@@ -4,7 +4,6 @@
 #include <QString>
 #include <QMap>
 
-#include "controlobjectslave.h"
 #include "util/types.h"
 #include "engine/effects/groupfeaturestate.h"
 
@@ -28,6 +27,7 @@ class EffectProcessor {
     virtual void process(const QString& group,
                          const CSAMPLE* pInput, CSAMPLE* pOutput,
                          const unsigned int numSamples,
+                         const unsigned int sampleRate,
                          const GroupFeatureState& groupFeatures) = 0;
 };
 
@@ -36,8 +36,7 @@ class EffectProcessor {
 template <typename T>
 class GroupEffectProcessor : public EffectProcessor {
   public:
-    GroupEffectProcessor() {
-        m_pSampleRate = new ControlObjectSlave("[Master]", "samplerate");
+    GroupEffectProcessor() : m_sampleRate(44100) {
     }
     virtual ~GroupEffectProcessor() {
         for (typename QMap<QString, T*>::iterator it = m_groupState.begin();
@@ -46,7 +45,6 @@ class GroupEffectProcessor : public EffectProcessor {
             it = m_groupState.erase(it);
             delete pState;
         }
-        delete m_pSampleRate;
     }
 
     virtual void initialize(const QSet<QString>& registeredGroups) {
@@ -62,6 +60,7 @@ class GroupEffectProcessor : public EffectProcessor {
     virtual void process(const QString& group,
                          const CSAMPLE* pInput, CSAMPLE* pOutput,
                          const unsigned int numSamples,
+                         const unsigned int sampleRate,
                          const GroupFeatureState& groupFeatures) {
         T* pState = m_groupState.value(group, NULL);
         if (pState == NULL) {
@@ -69,21 +68,23 @@ class GroupEffectProcessor : public EffectProcessor {
             m_groupState[group] = pState;
             qWarning() << "Allocated group state in the engine for" << group;
         }
-        processGroup(group, pState, pInput, pOutput, numSamples, groupFeatures);
+        m_sampleRate = sampleRate;
+        processGroup(group, pState, pInput, pOutput, numSamples, sampleRate, groupFeatures);
     }
 
     virtual void processGroup(const QString& group,
                               T* groupState,
                               const CSAMPLE* pInput, CSAMPLE* pOutput,
                               const unsigned int numSamples,
+                              const unsigned int sampleRate,
                               const GroupFeatureState& groupFeatures) = 0;
     int getSampleRate() {
-        return static_cast<int>(m_pSampleRate->get());
+        return m_sampleRate;
     }
 
   private:
     QMap<QString, T*> m_groupState;
-    ControlObjectSlave* m_pSampleRate;
+    unsigned int m_sampleRate;
 };
 
 #endif /* EFFECTPROCESSOR_H */

--- a/src/effects/effectprocessor.h
+++ b/src/effects/effectprocessor.h
@@ -36,7 +36,7 @@ class EffectProcessor {
 template <typename T>
 class GroupEffectProcessor : public EffectProcessor {
   public:
-    GroupEffectProcessor() : m_sampleRate(44100) {
+    GroupEffectProcessor() {
     }
     virtual ~GroupEffectProcessor() {
         for (typename QMap<QString, T*>::iterator it = m_groupState.begin();
@@ -68,7 +68,6 @@ class GroupEffectProcessor : public EffectProcessor {
             m_groupState[group] = pState;
             qWarning() << "Allocated group state in the engine for" << group;
         }
-        m_sampleRate = sampleRate;
         processGroup(group, pState, pInput, pOutput, numSamples, sampleRate, groupFeatures);
     }
 
@@ -81,7 +80,6 @@ class GroupEffectProcessor : public EffectProcessor {
 
   private:
     QMap<QString, T*> m_groupState;
-    unsigned int m_sampleRate;
 };
 
 #endif /* EFFECTPROCESSOR_H */

--- a/src/effects/native/bitcrushereffect.cpp
+++ b/src/effects/native/bitcrushereffect.cpp
@@ -61,9 +61,11 @@ void BitCrusherEffect::processGroup(const QString& group,
                                     BitCrusherGroupState* pState,
                                     const CSAMPLE* pInput, CSAMPLE* pOutput,
                                     const unsigned int numSamples,
+                                    const unsigned int sampleRate,
                                     const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);
+    Q_UNUSED(sampleRate);
     // TODO(rryan) this is broken. it needs to take into account the sample
     // rate.
     const CSAMPLE downsample = m_pDownsampleParameter ?

--- a/src/effects/native/bitcrushereffect.h
+++ b/src/effects/native/bitcrushereffect.h
@@ -35,6 +35,7 @@ class BitCrusherEffect : public GroupEffectProcessor<BitCrusherGroupState> {
                       BitCrusherGroupState* pState,
                       const CSAMPLE* pInput, CSAMPLE *pOutput,
                       const unsigned int numSamples,
+                      const unsigned int sampleRate,
                       const GroupFeatureState& groupFeatureState);
 
   private:

--- a/src/effects/native/butterworth8eqeffect.cpp
+++ b/src/effects/native/butterworth8eqeffect.cpp
@@ -106,6 +106,7 @@ void Butterworth8EQEffect::processGroup(const QString& group,
                                         ButterworthEQEffectGroupState* pState,
                                         const CSAMPLE* pInput, CSAMPLE* pOutput,
                                         const unsigned int numSamples,
+                                        const unsigned int sampleRate,
                                         const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);
@@ -115,7 +116,6 @@ void Butterworth8EQEffect::processGroup(const QString& group,
     fMid = m_pPotMid->value().toDouble();
     fHigh = m_pPotHigh->value().toDouble();
 
-    int sampleRate = getSampleRate();
     if (m_oldSampleRate != sampleRate ||
             (m_loFreq != static_cast<int>(m_pLoFreqCorner->get())) ||
             (m_hiFreq != static_cast<int>(m_pHiFreqCorner->get()))) {

--- a/src/effects/native/butterworth8eqeffect.h
+++ b/src/effects/native/butterworth8eqeffect.h
@@ -47,6 +47,7 @@ class Butterworth8EQEffect : public GroupEffectProcessor<ButterworthEQEffectGrou
                       ButterworthEQEffectGroupState* pState,
                       const CSAMPLE* pInput, CSAMPLE *pOutput,
                       const unsigned int numSamples,
+                      const unsigned int sampleRate,
                       const GroupFeatureState& groupFeatureState);
 
   private:
@@ -61,7 +62,7 @@ class Butterworth8EQEffect : public GroupEffectProcessor<ButterworthEQEffectGrou
     ControlObjectSlave* m_pLoFreqCorner;
     ControlObjectSlave* m_pHiFreqCorner;
 
-    int m_oldSampleRate;
+    unsigned int m_oldSampleRate;
     int m_loFreq;
     int m_hiFreq;
 

--- a/src/effects/native/echoeffect.cpp
+++ b/src/effects/native/echoeffect.cpp
@@ -90,9 +90,8 @@ EchoEffect::~EchoEffect() {
     //qDebug() << debugString() << "destroyed";
 }
 
-int EchoEffect::getDelaySamples(double delay_time) const {
-    // TODO(owilliams): Use real samplerate.
-    int delay_samples = delay_time * 44100;
+int EchoEffect::getDelaySamples(double delay_time, const unsigned int sampleRate) const {
+    int delay_samples = delay_time * sampleRate;
     if (delay_samples % 2 == 1) {
         --delay_samples;
     }
@@ -106,6 +105,7 @@ int EchoEffect::getDelaySamples(double delay_time) const {
 void EchoEffect::processGroup(const QString& group, EchoGroupState* pGroupState,
                               const CSAMPLE* pInput,
                               CSAMPLE* pOutput, const unsigned int numSamples,
+                              const unsigned int sampleRate,
                               const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);
@@ -125,14 +125,14 @@ void EchoEffect::processGroup(const QString& group, EchoGroupState* pGroupState,
 
     if (delay_time < gs.prev_delay_time) {
         // If the delay time has shrunk, we may need to wrap the write position.
-        delay_samples = getDelaySamples(delay_time);
+        delay_samples = getDelaySamples(delay_time, sampleRate);
         gs.write_position = gs.write_position % delay_samples;
     } else if (delay_time > gs.prev_delay_time) {
         // If the delay time has grown, we need to zero out the new portion
         // of the buffer we are using.
         SampleUtil::applyGain(gs.delay_buf + gs.prev_delay_samples, 0,
                               MAX_BUFFER_LEN - gs.prev_delay_samples);
-        delay_samples = getDelaySamples(delay_time);
+        delay_samples = getDelaySamples(delay_time, sampleRate);
     }
 
     int read_position = gs.write_position;

--- a/src/effects/native/echoeffect.h
+++ b/src/effects/native/echoeffect.h
@@ -43,10 +43,11 @@ class EchoEffect : public GroupEffectProcessor<EchoGroupState> {
                       EchoGroupState* pState,
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
+                      const unsigned int sampleRate,
                       const GroupFeatureState& groupFeatures);
 
   private:
-    int getDelaySamples(double delay_time) const;
+    int getDelaySamples(double delay_time, const unsigned int sampleRate) const;
 
     QString debugString() const {
         return getId();

--- a/src/effects/native/filtereffect.cpp
+++ b/src/effects/native/filtereffect.cpp
@@ -81,6 +81,7 @@ void FilterEffect::processGroup(const QString& group,
                                 FilterGroupState* pState,
                                 const CSAMPLE* pInput, CSAMPLE* pOutput,
                                 const unsigned int numSamples,
+                                const unsigned int sampleRate,
                                 const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);
@@ -105,7 +106,7 @@ void FilterEffect::processGroup(const QString& group,
             applyFilters(pState,
                          pInput, pState->crossfadeBuffer,
                          pState->bandpassBuffer,
-                         numSamples, pState->oldDepth,
+                         numSamples, sampleRate, pState->oldDepth,
                          pState->oldBandpassGain);
         }
         if (depth < 0.0) {
@@ -130,7 +131,7 @@ void FilterEffect::processGroup(const QString& group,
         SampleUtil::copyWithGain(pOutput, pInput, 0.0, numSamples);
     } else {
         applyFilters(pState, pInput, pOutput, pState->bandpassBuffer,
-                     numSamples, depth, bandpass_gain);
+                     numSamples, sampleRate, depth, bandpass_gain);
     }
 
     if (parametersChanged) {
@@ -145,8 +146,10 @@ void FilterEffect::processGroup(const QString& group,
 void FilterEffect::applyFilters(FilterGroupState* pState,
                                 const CSAMPLE* pInput, CSAMPLE* pOutput,
                                 CSAMPLE* pTempBuffer,
-                                const int numSamples,
+                                const unsigned int numSamples,
+                                const unsigned int sampleRate,
                                 double depth, CSAMPLE bandpassGain) {
+    Q_UNUSED(sampleRate)
     if (depth < 0.0) {
         pState->lowFilter.process(pInput, pOutput, numSamples);
         pState->bandpassFilter.process(pInput, pTempBuffer, numSamples);

--- a/src/effects/native/filtereffect.h
+++ b/src/effects/native/filtereffect.h
@@ -51,6 +51,7 @@ class FilterEffect : public GroupEffectProcessor<FilterGroupState> {
                       FilterGroupState* pState,
                       const CSAMPLE* pInput, CSAMPLE *pOutput,
                       const unsigned int numSamples,
+                      const unsigned int sampleRate,
                       const GroupFeatureState& groupFeatures);
 
   private:
@@ -60,7 +61,8 @@ class FilterEffect : public GroupEffectProcessor<FilterGroupState> {
 
     void applyFilters(FilterGroupState* pState,
                       const CSAMPLE* pIn, CSAMPLE* pOut, CSAMPLE* pTempBuffer,
-                      const int numSamples, double depth, CSAMPLE bandpassGain);
+                      const unsigned int numSamples, const unsigned int sampleRate,
+                      double depth, CSAMPLE bandpassGain);
 
     EngineEffectParameter* m_pDepthParameter;
     EngineEffectParameter* m_pBandpassWidthParameter;

--- a/src/effects/native/flangereffect.cpp
+++ b/src/effects/native/flangereffect.cpp
@@ -78,9 +78,11 @@ void FlangerEffect::processGroup(const QString& group,
                                  FlangerGroupState* pState,
                                  const CSAMPLE* pInput, CSAMPLE* pOutput,
                                  const unsigned int numSamples,
+                                 const unsigned int sampleRate,
                                  const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);
+    Q_UNUSED(sampleRate);
     CSAMPLE lfoPeriod = m_pPeriodParameter ?
             m_pPeriodParameter->value().toDouble() : 0.0f;
     CSAMPLE lfoDepth = m_pDepthParameter ?

--- a/src/effects/native/flangereffect.h
+++ b/src/effects/native/flangereffect.h
@@ -37,6 +37,7 @@ class FlangerEffect : public GroupEffectProcessor<FlangerGroupState> {
                       FlangerGroupState* pState,
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
+                      const unsigned int sampleRate,
                       const GroupFeatureState& groupFeatures);
 
   private:

--- a/src/effects/native/graphiceqeffect.cpp
+++ b/src/effects/native/graphiceqeffect.cpp
@@ -123,7 +123,7 @@ void GraphicEQEffectGroupState::setFilters(int sampleRate) {
 
 GraphicEQEffect::GraphicEQEffect(EngineEffect* pEffect,
                                  const EffectManifest& manifest)
-        : m_oldSampleRate(0) {
+        : m_oldSampleRate(44100) {
     // old sample rate initialized to 0 so we're guaranteed to initialize the
     // filters.
     Q_UNUSED(manifest);

--- a/src/effects/native/graphiceqeffect.cpp
+++ b/src/effects/native/graphiceqeffect.cpp
@@ -91,8 +91,8 @@ GraphicEQEffectGroupState::GraphicEQEffectGroupState() {
     m_centerFrequencies[7] = 9828;
 
     // Initialize the filters with default parameters
-    m_low = NULL;
-    m_high = NULL;
+    m_low = new EngineFilterBiquad1LowShelving(44100, m_centerFrequencies[0], Q);
+    m_high = new EngineFilterBiquad1HighShelving(44100, m_centerFrequencies[7], Q);
     for (int i = 1; i < 7; i++) {
         m_bands.append(new EngineFilterBiquad1Peaking(44100,
                                                       m_centerFrequencies[i],
@@ -111,12 +111,6 @@ GraphicEQEffectGroupState::~GraphicEQEffectGroupState() {
 }
 
 void GraphicEQEffectGroupState::setFilters(int sampleRate) {
-    if (m_low == NULL) {
-        m_low = new EngineFilterBiquad1LowShelving(sampleRate, m_centerFrequencies[0], Q);
-    }
-    if (m_high == NULL) {
-        m_high = new EngineFilterBiquad1HighShelving(44100, m_centerFrequencies[7], Q);
-    }
     m_low->setFrequencyCorners(sampleRate, m_centerFrequencies[0], Q,
                                m_oldLow);
     m_high->setFrequencyCorners(sampleRate, m_centerFrequencies[7], Q,

--- a/src/effects/native/graphiceqeffect.cpp
+++ b/src/effects/native/graphiceqeffect.cpp
@@ -124,8 +124,6 @@ void GraphicEQEffectGroupState::setFilters(int sampleRate) {
 GraphicEQEffect::GraphicEQEffect(EngineEffect* pEffect,
                                  const EffectManifest& manifest)
         : m_oldSampleRate(44100) {
-    // old sample rate initialized to 0 so we're guaranteed to initialize the
-    // filters.
     Q_UNUSED(manifest);
     m_pPotLow = pEffect->getParameterById("low");
     for (int i = 0; i < 6; i++) {

--- a/src/effects/native/graphiceqeffect.h
+++ b/src/effects/native/graphiceqeffect.h
@@ -44,6 +44,7 @@ class GraphicEQEffect : public GroupEffectProcessor<GraphicEQEffectGroupState> {
                       GraphicEQEffectGroupState* pState,
                       const CSAMPLE* pInput, CSAMPLE *pOutput,
                       const unsigned int numSamples,
+                      const unsigned int sampleRate,
                       const GroupFeatureState& groupFeatureState);
 
   private:
@@ -54,7 +55,7 @@ class GraphicEQEffect : public GroupEffectProcessor<GraphicEQEffectGroupState> {
     EngineEffectParameter* m_pPotLow;
     QList<EngineEffectParameter*> m_pPotMid;
     EngineEffectParameter* m_pPotHigh;
-    int m_oldSampleRate;
+    unsigned int m_oldSampleRate;
 
     DISALLOW_COPY_AND_ASSIGN(GraphicEQEffect);
 };

--- a/src/effects/native/reverbeffect.cpp
+++ b/src/effects/native/reverbeffect.cpp
@@ -67,9 +67,11 @@ void ReverbEffect::processGroup(const QString& group,
                                 ReverbGroupState* pState,
                                 const CSAMPLE* pInput, CSAMPLE* pOutput,
                                 const unsigned int numSamples,
+                                const unsigned int sampleRate,
                                 const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);
+    Q_UNUSED(sampleRate);
     CSAMPLE bandwidth = m_pBandWidthParameter ?
             m_pBandWidthParameter->value().toDouble() : 1.0f;
     CSAMPLE damping = m_pDampingParameter ?

--- a/src/effects/native/reverbeffect.h
+++ b/src/effects/native/reverbeffect.h
@@ -48,6 +48,7 @@ class ReverbEffect : public GroupEffectProcessor<ReverbGroupState> {
                       ReverbGroupState* pState,
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
+                      const unsigned int sampleRate,
                       const GroupFeatureState& groupFeatures);
 
   private:

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -121,11 +121,12 @@ bool EngineEffect::processEffectsRequest(const EffectsRequest& message,
 void EngineEffect::process(const QString& group,
                            const CSAMPLE* pInput, CSAMPLE* pOutput,
                            const unsigned int numSamples,
+                           const unsigned int sampleRate,
                            const GroupFeatureState& groupFeatures) {
     // The EngineEffectChain checks if we are enabled so we don't have to.
     if (kEffectDebugOutput && !m_bEnabled) {
         qDebug() << debugString()
                  << "WARNING: EngineEffect::process() called on disabled effect.";
     }
-    m_pProcessor->process(group, pInput, pOutput, numSamples, groupFeatures);
+    m_pProcessor->process(group, pInput, pOutput, numSamples, sampleRate, groupFeatures);
 }

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -41,6 +41,7 @@ class EngineEffect : public EffectsRequestHandler {
     void process(const QString& group,
                  const CSAMPLE* pInput, CSAMPLE* pOutput,
                  const unsigned int numSamples,
+                 const unsigned int sampleRate,
                  const GroupFeatureState& groupFeatures);
 
     bool enabled() const {

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -163,6 +163,7 @@ bool EngineEffectChain::disableForGroup(const QString& group) {
 void EngineEffectChain::process(const QString& group,
                                 CSAMPLE* pInOut,
                                 const unsigned int numSamples,
+                                const unsigned int sampleRate,
                                 const GroupFeatureState& groupFeatures) {
     GroupStatus& group_info = m_groupStatus[group];
     bool bEnabled = m_bEnabled && group_info.enabled;
@@ -188,7 +189,7 @@ void EngineEffectChain::process(const QString& group,
                     continue;
                 }
                 pEffect->process(group, pInOut, pInOut,
-                                 numSamples, groupFeatures);
+                                 numSamples, sampleRate, groupFeatures);
             }
         } else if (wet_gain_old == 0.0 && wet_gain == 0.0) {
             // Fully dry, no ramp, insert optimization. No action is needed
@@ -206,7 +207,7 @@ void EngineEffectChain::process(const QString& group,
                 const CSAMPLE* pIntermediateInput = (i == 0) ? pInOut : m_pBuffer;
                 CSAMPLE* pIntermediateOutput = m_pBuffer;
                 pEffect->process(group, pIntermediateInput, pIntermediateOutput,
-                                 numSamples, groupFeatures);
+                                 numSamples, sampleRate, groupFeatures);
                 anyProcessed = true;
             }
 
@@ -233,7 +234,8 @@ void EngineEffectChain::process(const QString& group,
             const CSAMPLE* pIntermediateInput = (i == 0) ? pInOut : m_pBuffer;
             CSAMPLE* pIntermediateOutput = m_pBuffer;
             pEffect->process(group, pIntermediateInput,
-                             pIntermediateOutput, numSamples, groupFeatures);
+                             pIntermediateOutput, numSamples, sampleRate,
+                             groupFeatures);
             anyProcessed = true;
         }
 

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -25,6 +25,7 @@ class EngineEffectChain : public EffectsRequestHandler {
     void process(const QString& group,
                  CSAMPLE* pInOut,
                  const unsigned int numSamples,
+                 const unsigned int sampleRate,
                  const GroupFeatureState& groupFeatures);
 
     const QString& id() const {

--- a/src/engine/effects/engineeffectrack.cpp
+++ b/src/engine/effects/engineeffectrack.cpp
@@ -44,10 +44,11 @@ bool EngineEffectRack::processEffectsRequest(const EffectsRequest& message,
 void EngineEffectRack::process(const QString& group,
                                CSAMPLE* pInOut,
                                const unsigned int numSamples,
+                               const unsigned int sampleRate,
                                const GroupFeatureState& groupFeatures) {
     foreach (EngineEffectChain* pChain, m_chains) {
         if (pChain != NULL) {
-            pChain->process(group, pInOut, numSamples, groupFeatures);
+            pChain->process(group, pInOut, numSamples, sampleRate, groupFeatures);
         }
     }
 }

--- a/src/engine/effects/engineeffectrack.h
+++ b/src/engine/effects/engineeffectrack.h
@@ -20,6 +20,7 @@ class EngineEffectRack : public EffectsRequestHandler {
     void process(const QString& group,
                  CSAMPLE* pInOut,
                  const unsigned int numSamples,
+                 const unsigned int sampleRate,
                  const GroupFeatureState& groupFeatures);
 
     int number() const {

--- a/src/engine/effects/engineeffectsmanager.cpp
+++ b/src/engine/effects/engineeffectsmanager.cpp
@@ -134,9 +134,10 @@ void EngineEffectsManager::onCallbackStart() {
 void EngineEffectsManager::process(const QString& group,
                                    CSAMPLE* pInOut,
                                    const unsigned int numSamples,
+                                   const unsigned int sampleRate,
                                    const GroupFeatureState& groupFeatures) {
     foreach (EngineEffectRack* pRack, m_racks) {
-        pRack->process(group, pInOut, numSamples, groupFeatures);
+        pRack->process(group, pInOut, numSamples, sampleRate, groupFeatures);
     }
 }
 

--- a/src/engine/effects/engineeffectsmanager.h
+++ b/src/engine/effects/engineeffectsmanager.h
@@ -29,6 +29,7 @@ class EngineEffectsManager : public EffectsRequestHandler {
     virtual void process(const QString& group,
                          CSAMPLE* pInOut,
                          const unsigned int numSamples,
+                         const unsigned int sampleRate,
                          const GroupFeatureState& groupFeatures);
 
     bool processEffectsRequest(

--- a/src/engine/engineaux.cpp
+++ b/src/engine/engineaux.cpp
@@ -19,7 +19,6 @@ EngineAux::EngineAux(const char* pGroup, EffectsManager* pEffectsManager)
           m_pEnabled(new ControlObject(ConfigKey(pGroup, "enabled"))),
           m_pPassing(new ControlPushButton(ConfigKey(pGroup, "passthrough"))),
           m_pPregain(new ControlLogpotmeter(ConfigKey(pGroup, "pregain"), 4)),
-          m_sampleRate(44100),
           m_sampleBuffer(NULL),
           m_wasActive(false) {
     if (pEffectsManager != NULL) {
@@ -33,8 +32,6 @@ EngineAux::EngineAux(const char* pGroup, EffectsManager* pEffectsManager)
     setPFL(false);
 
     m_pSampleRate = new ControlObjectSlave("[Master]", "samplerate");
-    m_pSampleRate->connectValueChanged(this, SLOT(slotSampleRateChanged(double)),
-                                       Qt::DirectConnection);
 }
 
 EngineAux::~EngineAux() {
@@ -102,12 +99,8 @@ void EngineAux::process(CSAMPLE* pOut, const int iBufferSize) {
         m_vuMeter.collectFeatures(&features);
         // Process effects enabled for this channel
         m_pEngineEffectsManager->process(getGroup(), pOut, iBufferSize,
-                                         m_sampleRate, features);
+                                         m_pSampleRate->get(), features);
     }
     // Update VU meter
     m_vuMeter.process(pOut, iBufferSize);
-}
-
-void EngineAux::slotSampleRateChanged(double dRate) {
-    m_sampleRate = static_cast<unsigned int>(dRate);
 }

--- a/src/engine/engineaux.h
+++ b/src/engine/engineaux.h
@@ -5,10 +5,11 @@
 #ifndef ENGINEAUX_H
 #define ENGINEAUX_H
 
-#include "util/circularbuffer.h"
+#include "controlobjectslave.h"
 #include "controlpushbutton.h"
 #include "engine/enginechannel.h"
 #include "engine/enginevumeter.h"
+#include "util/circularbuffer.h"
 #include "soundmanagerutil.h"
 
 class EffectsManager;
@@ -45,12 +46,17 @@ class EngineAux : public EngineChannel, public AudioDestination {
     // a soundcard input.
     virtual void onInputUnconfigured(AudioInput input);
 
+  private slots:
+    void slotSampleRateChanged(double);
+
   private:
     EngineEffectsManager* m_pEngineEffectsManager;
     EngineVuMeter m_vuMeter;
     ControlObject* m_pEnabled;
     ControlPushButton* m_pPassing;
     ControlLogpotmeter* m_pPregain;
+    ControlObjectSlave* m_pSampleRate;
+    unsigned int m_sampleRate;
     const CSAMPLE* volatile m_sampleBuffer;
     bool m_wasActive;
 };

--- a/src/engine/engineaux.h
+++ b/src/engine/engineaux.h
@@ -46,9 +46,6 @@ class EngineAux : public EngineChannel, public AudioDestination {
     // a soundcard input.
     virtual void onInputUnconfigured(AudioInput input);
 
-  private slots:
-    void slotSampleRateChanged(double);
-
   private:
     EngineEffectsManager* m_pEngineEffectsManager;
     EngineVuMeter m_vuMeter;
@@ -56,7 +53,6 @@ class EngineAux : public EngineChannel, public AudioDestination {
     ControlPushButton* m_pPassing;
     ControlLogpotmeter* m_pPregain;
     ControlObjectSlave* m_pSampleRate;
-    unsigned int m_sampleRate;
     const CSAMPLE* volatile m_sampleBuffer;
     bool m_wasActive;
 };

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -39,8 +39,7 @@ EngineDeck::EngineDeck(const char* group,
           m_pPassing(new ControlPushButton(ConfigKey(group, "passthrough"))),
           // Need a +1 here because the CircularBuffer only allows its size-1
           // items to be held at once (it keeps a blank spot open persistently)
-          m_sampleBuffer(NULL),
-          m_sampleRate(44100) {
+          m_sampleBuffer(NULL) {
     if (pEffectsManager != NULL) {
         pEffectsManager->registerGroup(getGroup());
     }
@@ -56,8 +55,6 @@ EngineDeck::EngineDeck(const char* group,
             Qt::DirectConnection);
 
     m_pSampleRate = new ControlObjectSlave("[Master]", "samplerate");
-    m_pSampleRate->connectValueChanged(this, SLOT(slotSampleRateChanged(double)),
-                                       Qt::DirectConnection);
 
     // Set up additional engines
     m_pPregain = new EnginePregain(group);
@@ -111,8 +108,9 @@ void EngineDeck::process(CSAMPLE* pOut, const int iBufferSize) {
         // This is out of date by a callback but some effects will want the RMS
         // volume.
         m_pVUMeter->collectFeatures(&features);
-        m_pEngineEffectsManager->process(getGroup(), pOut, iBufferSize,
-                                         m_sampleRate, features);
+        m_pEngineEffectsManager->process(
+                getGroup(), pOut, iBufferSize,
+                static_cast<unsigned int>(m_pSampleRate->get()), features);
     }
     // Update VU meter
     m_pVUMeter->process(pOut, iBufferSize);
@@ -170,8 +168,4 @@ bool EngineDeck::isPassthroughActive() const {
 
 void EngineDeck::slotPassingToggle(double v) {
     m_bPassthroughIsActive = v > 0;
-}
-
-void EngineDeck::slotSampleRateChanged(double dRate) {
-    m_sampleRate = static_cast<unsigned int>(dRate);
 }

--- a/src/engine/enginedeck.h
+++ b/src/engine/enginedeck.h
@@ -18,11 +18,12 @@
 #ifndef ENGINEDECK_H
 #define ENGINEDECK_H
 
-#include "util/circularbuffer.h"
+#include "configobject.h"
+#include "controlobjectslave.h"
 #include "controlpushbutton.h"
 #include "engine/engineobject.h"
 #include "engine/enginechannel.h"
-#include "configobject.h"
+#include "util/circularbuffer.h"
 
 #include "soundmanagerutil.h"
 
@@ -76,6 +77,9 @@ class EngineDeck : public EngineChannel, public AudioDestination {
   public slots:
     void slotPassingToggle(double v);
 
+  private slots:
+    void slotSampleRateChanged(double);
+
   private:
     ConfigObject<ConfigValue>* m_pConfig;
     EngineBuffer* m_pBuffer;
@@ -84,12 +88,14 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     EngineVinylSoundEmu* m_pVinylSoundEmu;
     EngineVuMeter* m_pVUMeter;
     EngineEffectsManager* m_pEngineEffectsManager;
+    ControlObjectSlave* m_pSampleRate;
 
     // Begin vinyl passthrough fields
     ControlPushButton* m_pPassing;
     const CSAMPLE* volatile m_sampleBuffer;
     bool m_bPassthroughIsActive;
     bool m_bPassthroughWasActive;
+    unsigned int m_sampleRate;
 };
 
 #endif

--- a/src/engine/enginedeck.h
+++ b/src/engine/enginedeck.h
@@ -77,9 +77,6 @@ class EngineDeck : public EngineChannel, public AudioDestination {
   public slots:
     void slotPassingToggle(double v);
 
-  private slots:
-    void slotSampleRateChanged(double);
-
   private:
     ConfigObject<ConfigValue>* m_pConfig;
     EngineBuffer* m_pBuffer;
@@ -95,7 +92,6 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     const CSAMPLE* volatile m_sampleBuffer;
     bool m_bPassthroughIsActive;
     bool m_bPassthroughWasActive;
-    unsigned int m_sampleRate;
 };
 
 #endif

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -285,7 +285,7 @@ void EngineMaster::process(const int iBufferSize) {
     bool masterEnabled = m_pMasterEnabled->get();
     bool headphoneEnabled = m_pHeadphoneEnabled->get();
 
-    int iSampleRate = static_cast<int>(m_pMasterSampleRate->get());
+    unsigned int iSampleRate = static_cast<int>(m_pMasterSampleRate->get());
     if (m_pEngineEffectsManager) {
         m_pEngineEffectsManager->onCallbackStart();
     }
@@ -362,11 +362,11 @@ void EngineMaster::process(const int iBufferSize) {
     if (m_pEngineEffectsManager) {
         GroupFeatureState busFeatures;
         m_pEngineEffectsManager->process(getBusLeftGroup(), m_pOutputBusBuffers[0],
-                                             iBufferSize, busFeatures);
+                                             iBufferSize, iSampleRate, busFeatures);
         m_pEngineEffectsManager->process(getBusCenterGroup(), m_pOutputBusBuffers[1],
-                                             iBufferSize, busFeatures);
+                                             iBufferSize, iSampleRate, busFeatures);
         m_pEngineEffectsManager->process(getBusRightGroup(), m_pOutputBusBuffers[2],
-                                             iBufferSize, busFeatures);
+                                             iBufferSize, iSampleRate, busFeatures);
     }
 
     if (masterEnabled) {
@@ -387,7 +387,8 @@ void EngineMaster::process(const int iBufferSize) {
                 m_pVumeter->collectFeatures(&masterFeatures);
             }
             m_pEngineEffectsManager->process(getMasterGroup(), m_pMaster,
-                                             iBufferSize, masterFeatures);
+                                             iBufferSize, iSampleRate,
+                                             masterFeatures);
         }
 
         // Apply master volume after effects.
@@ -443,7 +444,7 @@ void EngineMaster::process(const int iBufferSize) {
         if (m_pEngineEffectsManager) {
             GroupFeatureState headphoneFeatures;
             m_pEngineEffectsManager->process(getHeadphoneGroup(), m_pHead,
-                                             iBufferSize, headphoneFeatures);
+                                             iBufferSize, iSampleRate, headphoneFeatures);
         }
         // Head volume
         CSAMPLE headphoneVolume = m_pHeadVolume->get();

--- a/src/engine/enginemicrophone.cpp
+++ b/src/engine/enginemicrophone.cpp
@@ -19,8 +19,7 @@ EngineMicrophone::EngineMicrophone(const char* pGroup, EffectsManager* pEffectsM
           m_pEnabled(new ControlObject(ConfigKey(pGroup, "enabled"))),
           m_pPregain(new ControlLogpotmeter(ConfigKey(pGroup, "pregain"), 4)),
           m_sampleBuffer(NULL),
-          m_wasActive(false),
-          m_sampleRate(44100) {
+          m_wasActive(false) {
     if (pEffectsManager != NULL) {
         pEffectsManager->registerGroup(getGroup());
     }
@@ -32,8 +31,6 @@ EngineMicrophone::EngineMicrophone(const char* pGroup, EffectsManager* pEffectsM
     setPFL(false);
 
     m_pSampleRate = new ControlObjectSlave("[Master]", "samplerate");
-    m_pSampleRate->connectValueChanged(this, SLOT(slotSampleRateChanged(double)),
-                                       Qt::DirectConnection);
 
 }
 
@@ -106,12 +103,8 @@ void EngineMicrophone::process(CSAMPLE* pOut, const int iBufferSize) {
         // volume.
         m_vuMeter.collectFeatures(&features);
         m_pEngineEffectsManager->process(getGroup(), pOut, iBufferSize,
-                                         m_sampleRate, features);
+                                         m_pSampleRate->get(), features);
     }
     // Update VU meter
     m_vuMeter.process(pOut, iBufferSize);
-}
-
-void EngineMicrophone::slotSampleRateChanged(double dRate) {
-    m_sampleRate = static_cast<unsigned int>(dRate);
 }

--- a/src/engine/enginemicrophone.h
+++ b/src/engine/enginemicrophone.h
@@ -49,10 +49,6 @@ class EngineMicrophone : public EngineChannel, public AudioDestination {
     bool isSolo();
     double getSoloDamping();
 
-  private slots:
-    void slotSampleRateChanged(double);
-
-
   private:
     EngineEffectsManager* m_pEngineEffectsManager;
     EngineVuMeter m_vuMeter;
@@ -62,7 +58,6 @@ class EngineMicrophone : public EngineChannel, public AudioDestination {
     const CSAMPLE* volatile m_sampleBuffer;
 
     bool m_wasActive;
-    unsigned int m_sampleRate;
 };
 
 #endif /* ENGINEMICROPHONE_H */

--- a/src/engine/enginemicrophone.h
+++ b/src/engine/enginemicrophone.h
@@ -4,10 +4,12 @@
 #ifndef ENGINEMICROPHONE_H
 #define ENGINEMICROPHONE_H
 
-#include "util/circularbuffer.h"
+#include "controlobjectslave.h"
 #include "controlpushbutton.h"
 #include "engine/enginechannel.h"
 #include "engine/enginevumeter.h"
+#include "util/circularbuffer.h"
+
 #include "soundmanagerutil.h"
 
 class EffectsManager;
@@ -47,14 +49,20 @@ class EngineMicrophone : public EngineChannel, public AudioDestination {
     bool isSolo();
     double getSoloDamping();
 
+  private slots:
+    void slotSampleRateChanged(double);
+
+
   private:
     EngineEffectsManager* m_pEngineEffectsManager;
     EngineVuMeter m_vuMeter;
     ControlObject* m_pEnabled;
     ControlLogpotmeter* m_pPregain;
+    ControlObjectSlave* m_pSampleRate;
     const CSAMPLE* volatile m_sampleBuffer;
 
     bool m_wasActive;
+    unsigned int m_sampleRate;
 };
 
 #endif /* ENGINEMICROPHONE_H */

--- a/src/test/baseeffecttest.h
+++ b/src/test/baseeffecttest.h
@@ -34,9 +34,10 @@ class MockEffectProcessor : public EffectProcessor {
   public:
     MockEffectProcessor() {}
 
-    MOCK_METHOD5(process, void(const QString& group, const CSAMPLE* pInput,
+    MOCK_METHOD6(process, void(const QString& group, const CSAMPLE* pInput,
                                CSAMPLE* pOutput,
                                const unsigned int numSamples,
+                               const unsigned int sampleRate,
                                const GroupFeatureState& groupFeatures));
 
     MOCK_METHOD1(initialize, void(const QSet<QString>& registeredGroups));


### PR DESCRIPTION
Per @rryan 's suggestion to remove control-object dependencies from the effects framework (https://github.com/mixxxdj/mixxx/pull/316/files#r16438349).  It didn't make sense to set samplerate in the initializers, though.

This avoids make the effects framework depend on control objects and prevents
possible sample-rate changes during effect processing.

TESTED=existing tests pass, and sanity-checked effects and sample rate changes.
