### PR TITLE
Remove race possibilities from slip mode

### DIFF
--- a/src/analyserqueue.cpp
+++ b/src/analyserqueue.cpp
@@ -236,7 +236,7 @@ bool AnalyserQueue::doAnalysis(TrackPointer tio, SoundSourceProxy* pSoundSource)
         //QThread::usleep(10);
 
         //has something new entered the queue?
-        if (deref(m_aiCheckPriorities)) {
+        if (load_atomic(m_aiCheckPriorities)) {
             m_aiCheckPriorities = false;
             if (isLoadedTrackWaiting(tio)) {
                 qDebug() << "Interrupting analysis to give preference to a loaded track.";

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -112,7 +112,7 @@ void CachingReaderWorker::run() {
     ReaderStatusUpdate status;
 
     Event::start(m_tag);
-    while (!deref(m_stop)) {
+    while (!load_atomic(m_stop)) {
         if (m_newTrack) {
             m_newTrackMutex.lock();
             pLoadTrack = m_newTrack;

--- a/src/control/controlvalue.h
+++ b/src/control/controlvalue.h
@@ -68,7 +68,7 @@ class ControlValueAtomicBase {
   public:
     inline T getValue() const {
         T value = T();
-        unsigned int index = static_cast<unsigned int>(deref(m_readIndex)) % (cRingSize);
+        unsigned int index = static_cast<unsigned int>(load_atomic(m_readIndex)) % (cRingSize);
         while (m_ring[index].tryGet(&value) == false) {
             // We are here if
             // 1) there are more then cReaderSlotCnt reader (get) reading the same value or

--- a/src/controllers/bulk/bulkcontroller.cpp
+++ b/src/controllers/bulk/bulkcontroller.cpp
@@ -31,7 +31,7 @@ void BulkReader::run() {
     m_stop = 0;
     unsigned char data[255];
 
-    while (deref(m_stop) == 0) {
+    while (load_atomic(m_stop) == 0) {
         // Blocked polling: The only problem with this is that we can't close
         // the device until the block is released, which means the controller
         // has to send more data

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -26,7 +26,7 @@ HidReader::~HidReader() {
 void HidReader::run() {
     m_stop = 0;
     unsigned char *data = new unsigned char[255];
-    while (deref(m_stop) == 0) {
+    while (load_atomic(m_stop) == 0) {
         // Blocked polling: The only problem with this is that we can't close
         // the device until the block is released, which means the controller
         // has to send more data

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1019,7 +1019,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize)
 void EngineBuffer::processSlip(int iBufferSize) {
     // Do a single read from m_bSlipEnabled so we don't run in to race conditions.
     bool enabled = m_bSlipEnabled;
-    if (m_bSlipEnabled != m_bSlipEnabledProcessing) {
+    if (enabled != m_bSlipEnabledProcessing) {
         m_bSlipEnabledProcessing = enabled;
         if (enabled) {
             m_dSlipPosition = m_filepos_play;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -82,7 +82,7 @@ EngineBuffer::EngineBuffer(const char* _group, ConfigObject<ConfigValue>* _confi
           m_iUiSlowTick(0),
           m_dSlipPosition(0.),
           m_dSlipRate(1.0),
-          m_bSlipEnabled(false),
+          m_slipEnabled(0),
           m_bSlipEnabledProcessing(false),
           m_pRepeat(NULL),
           m_startButton(NULL),
@@ -691,7 +691,7 @@ void EngineBuffer::slotControlStop(double v)
 
 void EngineBuffer::slotControlSlip(double v)
 {
-    m_bSlipEnabled = v > 0.0;
+    m_slipEnabled = static_cast<int>(v > 0.0);
 }
 
 void EngineBuffer::slotKeylockEngineChanged(double d_index) {
@@ -1018,7 +1018,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize)
 
 void EngineBuffer::processSlip(int iBufferSize) {
     // Do a single read from m_bSlipEnabled so we don't run in to race conditions.
-    bool enabled = m_bSlipEnabled;
+    bool enabled = static_cast<bool>(m_slipEnabled);
     if (enabled != m_bSlipEnabledProcessing) {
         m_bSlipEnabledProcessing = enabled;
         if (enabled) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -82,7 +82,8 @@ EngineBuffer::EngineBuffer(const char* _group, ConfigObject<ConfigValue>* _confi
           m_iUiSlowTick(0),
           m_dSlipPosition(0.),
           m_dSlipRate(1.0),
-          m_SlipStatus(0),
+          m_bSlipEnabled(false),
+          m_bSlipEnabledProcessing(false),
           m_pRepeat(NULL),
           m_startButton(NULL),
           m_endButton(NULL),
@@ -690,13 +691,7 @@ void EngineBuffer::slotControlStop(double v)
 
 void EngineBuffer::slotControlSlip(double v)
 {
-    bool enabled = v > 0.0;
-    bool slip_enabled = m_SlipStatus.fetchAndAddAcquire(0) & SLIP_ENABLED;
-    if (enabled == slip_enabled) {
-        return;
-    }
-    int maskval = (enabled ? SLIP_ENABLED : 0) + SLIP_TOGGLED;
-    m_SlipStatus.fetchAndStoreRelease(maskval);
+    m_bSlipEnabled = v > 0.0;
 }
 
 void EngineBuffer::slotKeylockEngineChanged(double d_index) {
@@ -1022,10 +1017,10 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize)
 }
 
 void EngineBuffer::processSlip(int iBufferSize) {
-    int maskval = m_SlipStatus.fetchAndAddAcquire(0);
-    bool enabled = maskval & SLIP_ENABLED;
-    bool toggled = maskval & SLIP_TOGGLED;
-    if (toggled) {
+    // Do a single read from m_bSlipEnabled so we don't run in to race conditions.
+    bool enabled = m_bSlipEnabled;
+    if (m_bSlipEnabled != m_bSlipEnabledProcessing) {
+        m_bSlipEnabledProcessing = enabled;
         if (enabled) {
             m_dSlipPosition = m_filepos_play;
             m_dSlipRate = m_rate_old;
@@ -1034,15 +1029,12 @@ void EngineBuffer::processSlip(int iBufferSize) {
             slotControlSeekExact(m_dSlipPosition);
             m_dSlipPosition = 0;
         }
-        toggled = false;
     }
 
     // Increment slip position even if it was just toggled -- this ensures the position is correct.
     if (enabled) {
         m_dSlipPosition += static_cast<double>(iBufferSize) * m_dSlipRate;
     }
-    maskval = (toggled ? SLIP_TOGGLED : 0) + (enabled ? SLIP_ENABLED : 0);
-    m_SlipStatus.fetchAndStoreRelease(maskval);
 }
 
 void EngineBuffer::processSyncRequests() {
@@ -1181,8 +1173,7 @@ void EngineBuffer::hintReader(const double dRate) {
     m_pReadAheadManager->hintReader(dRate, &m_hintList);
 
     //if slipping, hint about virtual position so we're ready for it
-    bool slip_enabled = m_SlipStatus.fetchAndAddAcquire(0) & SLIP_ENABLED;
-    if (slip_enabled) {
+    if (m_bSlipEnabledProcessing) {
         Hint hint;
         hint.length = 2048; //default length please
         hint.sample = m_dSlipRate >= 0 ? m_dSlipPosition : m_dSlipPosition - 2048;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -398,7 +398,7 @@ void EngineBuffer::queueNewPlaypos(double newpos, enum SeekRequest seekType) {
     // Write the position before the seek type, to reduce a possible race
     // condition effect
     m_queuedPosition.setValue(newpos);
-    m_iSeekQueued = deref(seekType);
+    m_iSeekQueued = load_atomic(seekType);
 }
 
 void EngineBuffer::requestSyncPhase() {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -628,7 +628,7 @@ double EngineBuffer::updateIndicatorsAndModifyPlay(double v) {
     // allow the set since it might apply to a track we are loading due to the
     // asynchrony.
     bool playPossible = true;
-    if ((!m_pCurrentTrack && deref(m_iTrackLoading) == 0) ||
+    if ((!m_pCurrentTrack && atomic_load(m_iTrackLoading) == 0) ||
             (m_pCurrentTrack && m_filepos_play >= m_file_length_old && !m_iSeekQueued)) {
         // play not possible
         playPossible = false;
@@ -722,7 +722,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize)
     bool bCurBufferPaused = false;
     double rate = 0;
 
-    bool bTrackLoading = deref(m_iTrackLoading) != 0;
+    bool bTrackLoading = atomic_load(m_iTrackLoading) != 0;
     if (!bTrackLoading && m_pause.tryLock()) {
         ScopedTimer t("EngineBuffer::process_pauselock");
         float sr = m_pSampleRate->get();

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -303,9 +303,12 @@ class EngineBuffer : public EngineObject {
     double m_dSlipPosition;
     // Saved value of rate for slip mode
     double m_dSlipRate;
-    // Slip Status
-    bool m_bSlipEnabled;
-    bool m_bSlipToggled;
+    // Slip Status -- a bitmask.
+    QAtomicInt m_SlipStatus;
+    enum {
+        SLIP_ENABLED = 1,
+        SLIP_TOGGLED = 2
+    };
 
 
     ControlObject* m_pTrackSamples;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -303,9 +303,9 @@ class EngineBuffer : public EngineObject {
     double m_dSlipPosition;
     // Saved value of rate for slip mode
     double m_dSlipRate;
-    // m_bSlipEnabled can be written from any thread by way of a slot, but
-    // m_bSlipEnabledProcessing is only changed by the engine processing thread.
-    bool m_bSlipEnabled;
+    // m_slipEnabled is a boolean accessed from multiple threads, so we use an atomic int.
+    QAtomicInt m_slipEnabled;
+    // m_bSlipEnabledProcessing is only used by the engine processing thread.
     bool m_bSlipEnabledProcessing;
 
     ControlObject* m_pTrackSamples;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -303,13 +303,10 @@ class EngineBuffer : public EngineObject {
     double m_dSlipPosition;
     // Saved value of rate for slip mode
     double m_dSlipRate;
-    // Slip Status -- a bitmask.
-    QAtomicInt m_SlipStatus;
-    enum {
-        SLIP_ENABLED = 1,
-        SLIP_TOGGLED = 2
-    };
-
+    // m_bSlipEnabled can be written from any thread by way of a slot, but
+    // m_bSlipEnabledProcessing is only changed by the engine processing thread.
+    bool m_bSlipEnabled;
+    bool m_bSlipEnabledProcessing;
 
     ControlObject* m_pTrackSamples;
     ControlObject* m_pTrackSampleRate;

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -773,7 +773,7 @@ void TrackInfoObject::waveformSummaryNew() {
 
 void TrackInfoObject::setAnalyserProgress(int progress) {
     // progress in 0 .. 1000. QAtomicInt so no need for lock.
-    if (progress != deref(m_analyserProgress)) {
+    if (progress != atomic_load(m_analyserProgress)) {
         m_analyserProgress = progress;
         emit(analyserProgress(progress));
     }
@@ -781,7 +781,7 @@ void TrackInfoObject::setAnalyserProgress(int progress) {
 
 int TrackInfoObject::getAnalyserProgress() const {
     // QAtomicInt so no need for lock.
-    return deref(m_analyserProgress);
+    return atomic_load(m_analyserProgress);
 }
 
 void TrackInfoObject::setCuePoint(float cue) {

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -773,7 +773,7 @@ void TrackInfoObject::waveformSummaryNew() {
 
 void TrackInfoObject::setAnalyserProgress(int progress) {
     // progress in 0 .. 1000. QAtomicInt so no need for lock.
-    if (progress != atomic_load(m_analyserProgress)) {
+    if (progress != load_atomic(m_analyserProgress)) {
         m_analyserProgress = progress;
         emit(analyserProgress(progress));
     }
@@ -781,7 +781,7 @@ void TrackInfoObject::setAnalyserProgress(int progress) {
 
 int TrackInfoObject::getAnalyserProgress() const {
     // QAtomicInt so no need for lock.
-    return atomic_load(m_analyserProgress);
+    return load_atomic(m_analyserProgress);
 }
 
 void TrackInfoObject::setCuePoint(float cue) {

--- a/src/util/compatibility.h
+++ b/src/util/compatibility.h
@@ -12,7 +12,7 @@
 #include <QInputMethod>
 #endif
 
-inline int deref(const QAtomicInt& value) {
+inline int load_atomic(const QAtomicInt& value) {
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     return value;
 #else

--- a/src/util/statsmanager.cpp
+++ b/src/util/statsmanager.cpp
@@ -205,7 +205,7 @@ void StatsManager::run() {
         processIncomingStatReports();
         m_statsPipeLock.unlock();
 
-        if (deref(m_emitAllStats) == 1) {
+        if (load_atomic(m_emitAllStats) == 1) {
             for (QMap<QString, Stat>::const_iterator it = m_stats.begin();
                  it != m_stats.end(); ++it) {
                 emit(statUpdated(it.value()));
@@ -213,7 +213,7 @@ void StatsManager::run() {
             m_emitAllStats = 0;
         }
 
-        if (deref(m_quit) == 1) {
+        if (load_atomic(m_quit) == 1) {
             qDebug() << "StatsManager thread shutting down.";
             break;
         }

--- a/src/waveform/waveform.h
+++ b/src/waveform/waveform.h
@@ -66,14 +66,14 @@ class Waveform {
 
     // Atomically lookup the completion of the waveform. Represents the number
     // of data elements that have been processed out of dataSize.
-    int getCompletion() const { return deref(m_completion); }
+    int getCompletion() const { return load_atomic(m_completion); }
     int getTextureStride() const { return m_textureStride; }
     int getTextureSize() const { return m_data.size(); }
 
     // Atomically get the number of data elements in this Waveform. You do not
     // need to lock the Waveform's mutex before calling this method.
-    int getDataSize() const { return deref(m_dataSize); }
-    int getNumChannels() const { return deref(m_numChannels); }
+    int getDataSize() const { return load_atomic(m_dataSize); }
+    int getNumChannels() const { return load_atomic(m_numChannels); }
 
     const std::vector<WaveformData>& getConstData() const { return m_data;}
 


### PR DESCRIPTION
I think this was causing https://bugs.launchpad.net/mixxx/+bug/1362394, and I know for sure there were races in this code, so even if it doesn't fix that bug it's an improvement.
