### PR TITLE
Humanreadable search

### DIFF
--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -253,11 +253,12 @@ double DurationFilterNode::parse(const QString& arg, bool* ok){
     QStringList caps = regex.capturedTexts();
     double m = 0;
     double s = 0;
-    if (caps.at(3).isEmpty()) {
+    // if only a number is entered parse as seconds
+    if (caps.at(3).isEmpty() && caps.at(2).isEmpty()) {
         s = caps.at(1).toDouble(ok);
     } else {
         m = caps.at(1).toDouble(ok);
-        s = caps.at(3).toDouble(ok);
+        s = caps.at(3).toDouble();
     }
 
     if (!*ok) {

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -172,7 +172,6 @@ NumericFilterNode::NumericFilterNode(const QStringList& sqlColumns,
 
 QString NumericFilterNode::parseHumanReadableTime(QString durationHumanReadable) {
     QStringList durationRanges = durationHumanReadable.split("-");
-    qDebug()<<durationHumanReadable;
     if (durationRanges.length() == 1) {
         //qDebug()<<"only one parameter";
         return getTimeInHMS(durationHumanReadable);
@@ -186,7 +185,7 @@ QString NumericFilterNode::parseHumanReadableTime(QString durationHumanReadable)
 }
 
 QString NumericFilterNode::getTimeInHMS(QString durationHumanReadable) {
-    durationHumanReadable = formateInput(durationHumanReadable);
+    durationHumanReadable = formatInput(durationHumanReadable);
     bool parseable = false;
     double totalTime = -1;
     totalTime = durationHumanReadable.toDouble(&parseable);
@@ -250,18 +249,17 @@ QString NumericFilterNode::getTimeInHMS(QString durationHumanReadable) {
     return QString::number(totalTime);
 }
 
-QString NumericFilterNode::formateInput(QString inputDuration) {
+QString NumericFilterNode::formatInput(QString inputDuration) {
     QRegExp hour_minute_second_regexp("^(\\d+:\\d+:\\d+[hH]?)$");
     QRegExp minute_second_regexp("^(\\d+:\\d+[mM]?)$");
-    QRegExp colone_regexp(":");
 
     if (inputDuration.contains(hour_minute_second_regexp)) {
         //qDebug()<<"it's hour minute second";
         //qDebug()<<inputDuration;
         if (inputDuration.endsWith("h",Qt::CaseInsensitive)) {
                inputDuration.chop(1);
-            }
-        QStringList timeSeparated = inputDuration.split(colone_regexp);
+        }
+        QStringList timeSeparated = inputDuration.split(QRegExp(":"));
         QString hour = timeSeparated.at(0);
         QString minute = timeSeparated.at(1);
         QString second = timeSeparated.at(2);
@@ -273,8 +271,8 @@ QString NumericFilterNode::formateInput(QString inputDuration) {
         //qDebug()<<inputDuration;
         if (inputDuration.endsWith("m",Qt::CaseInsensitive)) {
                inputDuration.chop(1);
-            }
-        QStringList timeSeparated = inputDuration.split(colone_regexp);
+        }
+        QStringList timeSeparated = inputDuration.split(QRegExp(":"));
         QString minute = timeSeparated.at(0);
         QString second = timeSeparated.at(1);
         QStringList timeJoined;

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -172,6 +172,7 @@ NumericFilterNode::NumericFilterNode(const QStringList& sqlColumns)
           m_dRangeLow(0.0),
           m_dRangeHigh(0.0) {
 }
+
 bool NumericFilterNode::match(const TrackPointer& pTrack) const {
     foreach (QString sqlColumn, m_sqlColumns) {
         QVariant value = getTrackValueForColumn(pTrack, sqlColumn);
@@ -255,20 +256,16 @@ DurationFilterNode::DurationFilterNode(const QStringList& sqlColumns,
 
 double DurationFilterNode::parseTime(QString time, bool* ok){
     QRegExp regex("^(\\d*)(m|:)?([0-6]?\\d)?s?$");
-    if (!regex.exactMatch(time)) {
-        qDebug() << time << " did not match regexp";
+    if (regex.indexIn(time) == -1) {
         *ok = false;
         return 0;
     }
-    // Need to call this function once for Qt to parse the string. I don't
-    // know why they don't call this parse -- (kain88, Aug 2014)
-    regex.indexIn(time);
-    QStringList caps = regex.capturedTexts();
 
     // You can check that the minutes are parsed to entry 2 of the list and the
     // seconds are in the 4th entry. If you don't believe me or this doesn't
     // work anymore because we changed our Qt version just have a look at caps.
     // -- (kain88, Aug 2014)
+    QStringList caps = regex.capturedTexts();
     double m = 0;
     double s = 0;
     if (caps.at(3).isEmpty()) {

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -142,6 +142,12 @@ NumericFilterNode::NumericFilterNode(const QStringList& sqlColumns,
         m_operator = operatorMatcher.cap(1);
         argument = operatorMatcher.cap(2);
     }
+    // first check if the query is about duration
+    if (sqlColumns.at(0) == "duration") {
+        // if it is duration then humanreadable time will be converted to computable time(second)
+        argument = parseHumanReadableTime(argument);
+    }
+
 
     bool parsed = false;
     // Try to convert to see if it parses.
@@ -163,6 +169,122 @@ NumericFilterNode::NumericFilterNode(const QStringList& sqlColumns,
     }
 
 }
+
+QString NumericFilterNode::parseHumanReadableTime(QString durationHumanReadable) {
+    QStringList durationRanges = durationHumanReadable.split("-");
+    qDebug()<<durationHumanReadable;
+    if (durationRanges.length() == 1) {
+        //qDebug()<<"only one parameter";
+        return getTimeInHMS(durationHumanReadable);
+    } else if (durationRanges.length() == 2) {
+         //qDebug()<<"two parameter";
+         return getTimeInHMS(durationRanges[0]) + "-" + getTimeInHMS(durationRanges[1]);
+    } else {
+        //qDebug()<<"undefind";
+        return durationHumanReadable;
+    }
+}
+
+QString NumericFilterNode::getTimeInHMS(QString durationHumanReadable) {
+    durationHumanReadable = formateInput(durationHumanReadable);
+    bool parseable = false;
+    double totalTime = -1;
+    totalTime = durationHumanReadable.toDouble(&parseable);
+    if (parseable) {
+        return  durationHumanReadable;
+    }
+
+    QString holdDigits;
+    bool hour = false;
+    bool miniute = false;
+    bool second = false;
+
+    for(int i = 0; i< durationHumanReadable.length(); i++) {
+        if ((durationHumanReadable.at(i) == 'h'
+                ||  durationHumanReadable.at(i) == 'H'
+                ||  durationHumanReadable.at(i) == 'm'
+                ||  durationHumanReadable.at(i) == 'M'
+                ||  durationHumanReadable.at(i) == 's'
+                ||  durationHumanReadable.at(i) == 'S')
+                && !holdDigits.isEmpty()) {
+            bool parsed = false;
+            // Try to convert to see if it parses.
+            double dbl = holdDigits.trimmed().toDouble(&parsed);
+            if (parsed) {
+                if ((durationHumanReadable.at(i) == 'h' || durationHumanReadable.at(i) == 'H')
+                    && !hour) {
+                    totalTime+= dbl*3600;
+                    hour = true;
+                }
+                if ((durationHumanReadable.at(i) == 'm' || durationHumanReadable.at(i) == 'M')
+                    && !miniute) {
+                    totalTime+= dbl*60;
+                    miniute = true;
+                }
+                if ((durationHumanReadable.at(i) == 's' || durationHumanReadable.at(i) == 'S')
+                    && !second) {
+                    totalTime+= dbl;
+                    second = true;
+                }
+                //qDebug()<<dbl<<durationHumanReadable.at(i);
+                holdDigits = "";
+            } else {
+                return durationHumanReadable;
+            }
+        } else {
+              holdDigits.append(durationHumanReadable.at(i));
+        }
+    }
+
+    // if there is no Hour/miniute/second identification then it will taken as second
+    if (!holdDigits.isEmpty() && !second) {
+        bool parsed = false;
+        double dbl = holdDigits.trimmed().toDouble(&parsed);
+        if (parsed) {
+            totalTime+= dbl;
+        } else {
+            return durationHumanReadable;
+        }
+    }   
+    //qDebug()<<totalTime;
+    return QString::number(totalTime);
+}
+
+QString NumericFilterNode::formateInput(QString inputDuration) {
+    QRegExp hour_minute_second_regexp("^(\\d+:\\d+:\\d+[hH]?)$");
+    QRegExp minute_second_regexp("^(\\d+:\\d+[mM]?)$");
+    QRegExp colone_regexp(":");
+
+    if (inputDuration.contains(hour_minute_second_regexp)) {
+        //qDebug()<<"it's hour minute second";
+        //qDebug()<<inputDuration;
+        if (inputDuration.endsWith("h",Qt::CaseInsensitive)) {
+               inputDuration.chop(1);
+            }
+        QStringList timeSeparated = inputDuration.split(colone_regexp);
+        QString hour = timeSeparated.at(0);
+        QString minute = timeSeparated.at(1);
+        QString second = timeSeparated.at(2);
+        QStringList timeJoined;
+        timeJoined<<hour.append('h')<<minute.append('m')<<second.append('s');
+        return timeJoined.join("");
+    } else if (inputDuration.contains(minute_second_regexp)) {
+        //qDebug()<<"it's minute second";
+        //qDebug()<<inputDuration;
+        if (inputDuration.endsWith("m",Qt::CaseInsensitive)) {
+               inputDuration.chop(1);
+            }
+        QStringList timeSeparated = inputDuration.split(colone_regexp);
+        QString minute = timeSeparated.at(0);
+        QString second = timeSeparated.at(1);
+        QStringList timeJoined;
+        timeJoined<<minute.append('m')<<second.append('s');
+        return timeJoined.join("");
+    } else {
+        return inputDuration;
+    }
+}
+
 
 bool NumericFilterNode::match(const TrackPointer& pTrack) const {
     foreach (QString sqlColumn, m_sqlColumns) {

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -80,6 +80,9 @@ class NumericFilterNode : public QueryNode {
     QString toSql() const;
 
   private:
+    QString parseHumanReadableTime(QString durationHumanReadable);
+    QString getTimeInHMS(QString durationHumanReadable);
+    QString formateInput(QString inputDuration);
     QStringList m_sqlColumns;
     bool m_bOperatorQuery;
     QString m_operator;

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -80,9 +80,6 @@ class NumericFilterNode : public QueryNode {
     QString toSql() const;
 
   private:
-    QString parseHumanReadableTime(QString durationHumanReadable);
-    QString getTimeInHMS(QString durationHumanReadable);
-    QString formatInput(QString inputDuration);
     QStringList m_sqlColumns;
     bool m_bOperatorQuery;
     QString m_operator;
@@ -101,6 +98,25 @@ class KeyFilterNode : public QueryNode {
 
   private:
     QList<mixxx::track::io::key::ChromaticKey> m_matchKeys;
+};
+
+class DurationFilterNode : public QueryNode {
+  public:
+    DurationFilterNode(const QStringList& sqlColumns, QString argument);
+    bool match(const TrackPointer& pTrack) const;
+    QString toSql() const;
+
+  private:
+    QString parseHumanReadableTime(QString durationHumanReadable);
+    QString getTimeInHMS(QString durationHumanReadable);
+    QString formatInput(QString inputDuration);
+    QStringList m_sqlColumns;
+    bool m_bOperatorQuery;
+    QString m_operator;
+    double m_dOperatorArgument;
+    bool m_bRangeQuery;
+    double m_dRangeLow;
+    double m_dRangeHigh;
 };
 
 class SqlNode : public QueryNode {

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -81,6 +81,8 @@ class NumericFilterNode : public QueryNode {
     QString toSql() const;
 
   protected:
+    virtual void init(QString argument);
+    virtual double parse(const QString& arg, bool *ok);
     QStringList m_sqlColumns;
     bool m_bOperatorQuery;
     QString m_operator;
@@ -95,7 +97,7 @@ class DurationFilterNode : public NumericFilterNode {
     DurationFilterNode(const QStringList& sqlColumns, QString argument);
 
   private:
-    double parseTime(QString time, bool* ok);
+    virtual double parse(const QString& arg, bool* ok);
 };
 
 class KeyFilterNode : public QueryNode {

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -76,10 +76,11 @@ class TextFilterNode : public QueryNode {
 class NumericFilterNode : public QueryNode {
   public:
     NumericFilterNode(const QStringList& sqlColumns, QString argument);
+    NumericFilterNode(const QStringList& sqlColumns);
     bool match(const TrackPointer& pTrack) const;
     QString toSql() const;
 
-  private:
+  protected:
     QStringList m_sqlColumns;
     bool m_bOperatorQuery;
     QString m_operator;
@@ -87,6 +88,14 @@ class NumericFilterNode : public QueryNode {
     bool m_bRangeQuery;
     double m_dRangeLow;
     double m_dRangeHigh;
+};
+
+class DurationFilterNode : public NumericFilterNode {
+  public:
+    DurationFilterNode(const QStringList& sqlColumns, QString argument);
+
+  private:
+    double parseTime(QString time, bool* ok);
 };
 
 class KeyFilterNode : public QueryNode {
@@ -98,23 +107,6 @@ class KeyFilterNode : public QueryNode {
 
   private:
     QList<mixxx::track::io::key::ChromaticKey> m_matchKeys;
-};
-
-class DurationFilterNode : public QueryNode {
-  public:
-    DurationFilterNode(const QStringList& sqlColumns, QString argument);
-    bool match(const TrackPointer& pTrack) const;
-    QString toSql() const;
-
-  private:
-    double parseTime(QString time, bool* ok);
-    QStringList m_sqlColumns;
-    bool m_bOperatorQuery;
-    QString m_operator;
-    double m_dOperatorArgument;
-    bool m_bRangeQuery;
-    double m_dRangeLow;
-    double m_dRangeHigh;
 };
 
 class SqlNode : public QueryNode {

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -82,7 +82,7 @@ class NumericFilterNode : public QueryNode {
   private:
     QString parseHumanReadableTime(QString durationHumanReadable);
     QString getTimeInHMS(QString durationHumanReadable);
-    QString formateInput(QString inputDuration);
+    QString formatInput(QString inputDuration);
     QStringList m_sqlColumns;
     bool m_bOperatorQuery;
     QString m_operator;

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -107,9 +107,7 @@ class DurationFilterNode : public QueryNode {
     QString toSql() const;
 
   private:
-    QString parseHumanReadableTime(QString durationHumanReadable);
-    QString getTimeInHMS(QString durationHumanReadable);
-    QString formatInput(QString inputDuration);
+    double parseTime(QString time, bool* ok);
     QStringList m_sqlColumns;
     bool m_bOperatorQuery;
     QString m_operator;

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -106,31 +106,21 @@ void SearchQueryParser::parseTokens(QStringList tokens,
             continue;
         }
 
-        bool consumed = false;
-
-        if (!consumed && m_fuzzyMatcher.indexIn(token) != -1) {
+        if (m_fuzzyMatcher.indexIn(token) != -1) {
             // TODO(XXX): implement this feature.
-        }
-
-        if (!consumed && m_textFilterMatcher.indexIn(token) != -1) {
+        } else if (m_textFilterMatcher.indexIn(token) != -1) {
             QString field = m_textFilterMatcher.cap(1);
             QString argument = getTextArgument(
                 m_textFilterMatcher.cap(2), &tokens).trimmed();
             pQuery->addNode(new TextFilterNode(
                 m_database, m_fieldToSqlColumns[field], argument));
-            consumed = true;
-        }
-
-        if (!consumed && m_numericFilterMatcher.indexIn(token) != -1) {
+        } else if (m_numericFilterMatcher.indexIn(token) != -1) {
             QString field = m_numericFilterMatcher.cap(1);
             QString argument = getTextArgument(
                 m_numericFilterMatcher.cap(2), &tokens).trimmed();
             pQuery->addNode(new NumericFilterNode(
                 m_fieldToSqlColumns[field], argument));
-            consumed = true;
-        }
-
-        if (!consumed && m_specialFilterMatcher.indexIn(token) != -1) {
+        } else if (m_specialFilterMatcher.indexIn(token) != -1) {
             QString field = m_specialFilterMatcher.cap(1);
             QString argument = getTextArgument(
                 m_specialFilterMatcher.cap(2), &tokens).trimmed();
@@ -144,15 +134,11 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                 } else {
                     pQuery->addNode(new KeyFilterNode(key, fuzzy));
                 }
-                consumed = true;
             }
-        }
-
+        } else {
         // If no advanced search feature matched, treat it as a search term.
-        if (!consumed) {
             pQuery->addNode(new TextFilterNode(
                 m_database, searchColumns, token));
-            consumed = true;
         }
     }
 }

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -16,11 +16,11 @@ SearchQueryParser::SearchQueryParser(QSqlDatabase& database)
     m_numericFilters << "year"
                      << "track"
                      << "bpm"
-                     << "duration"
                      << "played"
                      << "rating"
                      << "bitrate";
-    m_specialFilters << "key";
+    m_specialFilters << "key"
+                     << "duration";
 
     m_fieldToSqlColumns["artist"] << "artist" << "album_artist";
     m_fieldToSqlColumns["album_artist"] << "album_artist";
@@ -134,6 +134,9 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                 } else {
                     pQuery->addNode(new KeyFilterNode(key, fuzzy));
                 }
+            } else if (field == "duration") {
+                pQuery->addNode(new DurationFilterNode(
+                    m_fieldToSqlColumns[field], argument));
             }
         } else {
         // If no advanced search feature matched, treat it as a search term.

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -364,7 +364,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearch) {
     EXPECT_STREQ(
         qPrintable(QString("(duration = 90)")),
         qPrintable(pQuery->toSql()));
-    
+
     pQuery.reset(m_parser.parseQuery("duration:1m30s", searchColumns, ""));
     pTrack->setDuration(91);
     EXPECT_FALSE(pQuery->match(pTrack));
@@ -374,7 +374,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearch) {
     EXPECT_STREQ(
         qPrintable(QString("(duration = 90)")),
         qPrintable(pQuery->toSql()));
-    
+
     pQuery.reset(m_parser.parseQuery("duration:90", searchColumns, ""));
     pTrack->setDuration(91);
     EXPECT_FALSE(pQuery->match(pTrack));
@@ -421,15 +421,6 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     EXPECT_STREQ(
         qPrintable(QString("(duration >= 90)")),
         qPrintable(pQuery->toSql()));
-    
-    pQuery.reset(m_parser.parseQuery("duration:>=1:30m", searchColumns, ""));
-    pTrack->setDuration(89);
-    EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->setDuration(90);
-    EXPECT_TRUE(pQuery->match(pTrack));
-    EXPECT_STREQ(
-        qPrintable(QString("(duration >= 90)")),
-        qPrintable(pQuery->toSql()));
 
     pQuery.reset(m_parser.parseQuery("duration:<2:30", searchColumns, ""));
     pTrack->setDuration(151);
@@ -448,7 +439,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     EXPECT_STREQ(
         qPrintable(QString("(duration <= 150)")),
         qPrintable(pQuery->toSql()));
-    
+
     pQuery.reset(m_parser.parseQuery("duration:<=150", searchColumns, ""));
     pTrack->setDuration(191);
     EXPECT_FALSE(pQuery->match(pTrack));
@@ -456,8 +447,8 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
         qPrintable(QString("(duration <= 150)")),
-        qPrintable(pQuery->toSql())); 
-    
+        qPrintable(pQuery->toSql()));
+
     pQuery.reset(m_parser.parseQuery("duration:<=2m30s", searchColumns, ""));
     pTrack->setDuration(191);
     EXPECT_FALSE(pQuery->match(pTrack));
@@ -488,7 +479,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
     EXPECT_STREQ(
         qPrintable(QString("(duration >= 150 AND duration <= 200)")),
         qPrintable(pQuery->toSql()));
-    
+
     pQuery.reset(m_parser.parseQuery("duration:2:30-200", searchColumns, ""));
     pTrack->setSampleRate(44100);
     pTrack->setDuration(80);

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -328,7 +328,6 @@ TEST_F(SearchQueryParserTest, MultipleFilters) {
         qPrintable(pQuery->toSql()));
 }
 
-
 TEST_F(SearchQueryParserTest, ExtraFilterAppended) {
     QStringList searchColumns;
     searchColumns << "artist";
@@ -344,5 +343,188 @@ TEST_F(SearchQueryParserTest, ExtraFilterAppended) {
 
     EXPECT_STREQ(
         qPrintable(QString("(1 > 2) AND (artist LIKE '%asdf%')")),
+        qPrintable(pQuery->toSql()));
+}
+
+TEST_F(SearchQueryParserTest, HumanReadableDurationSearch) {
+    QStringList searchColumns;
+    searchColumns << "artist"
+                  << "album";
+
+    QScopedPointer<QueryNode> pQuery(
+        m_parser.parseQuery("duration:1:30", searchColumns, ""));
+
+    TrackPointer pTrack(new TrackInfoObject());
+    pTrack->setSampleRate(44100);
+    pTrack->setDuration(91);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(90);
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+        qPrintable(QString("(duration = 90)")),
+        qPrintable(pQuery->toSql()));
+    
+    pQuery.reset(m_parser.parseQuery("duration:1m30s", searchColumns, ""));
+    pTrack->setDuration(91);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(90);
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+        qPrintable(QString("(duration = 90)")),
+        qPrintable(pQuery->toSql()));
+    
+    pQuery.reset(m_parser.parseQuery("duration:90", searchColumns, ""));
+    pTrack->setDuration(91);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(90);
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+        qPrintable(QString("(duration = 90)")),
+        qPrintable(pQuery->toSql()));
+}
+
+TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
+    QStringList searchColumns;
+    searchColumns << "artist"
+                  << "album";
+
+    QScopedPointer<QueryNode> pQuery(
+        m_parser.parseQuery("duration:>1:30", searchColumns, ""));
+
+    TrackPointer pTrack(new TrackInfoObject());
+    pTrack->setSampleRate(44100);
+    pTrack->setDuration(89);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(91);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    EXPECT_STREQ(
+        qPrintable(QString("(duration > 90)")),
+        qPrintable(pQuery->toSql()));
+
+    pQuery.reset(m_parser.parseQuery("duration:>=90", searchColumns, ""));
+    pTrack->setDuration(89);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(90);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    EXPECT_STREQ(
+        qPrintable(QString("(duration >= 90)")),
+        qPrintable(pQuery->toSql()));
+
+    pQuery.reset(m_parser.parseQuery("duration:>=1:30", searchColumns, ""));
+    pTrack->setDuration(89);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(90);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    EXPECT_STREQ(
+        qPrintable(QString("(duration >= 90)")),
+        qPrintable(pQuery->toSql()));
+    
+    pQuery.reset(m_parser.parseQuery("duration:>=1:30m", searchColumns, ""));
+    pTrack->setDuration(89);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(90);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    EXPECT_STREQ(
+        qPrintable(QString("(duration >= 90)")),
+        qPrintable(pQuery->toSql()));
+
+    pQuery.reset(m_parser.parseQuery("duration:<2:30", searchColumns, ""));
+    pTrack->setDuration(151);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(89);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    EXPECT_STREQ(
+        qPrintable(QString("(duration < 150)")),
+        qPrintable(pQuery->toSql()));
+
+    pQuery.reset(m_parser.parseQuery("duration:<=2:30", searchColumns, ""));
+    pTrack->setDuration(191);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(150);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    EXPECT_STREQ(
+        qPrintable(QString("(duration <= 150)")),
+        qPrintable(pQuery->toSql()));
+    
+    pQuery.reset(m_parser.parseQuery("duration:<=150", searchColumns, ""));
+    pTrack->setDuration(191);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(150);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    EXPECT_STREQ(
+        qPrintable(QString("(duration <= 150)")),
+        qPrintable(pQuery->toSql())); 
+    
+    pQuery.reset(m_parser.parseQuery("duration:<=2m30s", searchColumns, ""));
+    pTrack->setDuration(191);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(150);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    EXPECT_STREQ(
+        qPrintable(QString("(duration <= 150)")),
+        qPrintable(pQuery->toSql()));
+}
+
+TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
+    QStringList searchColumns;
+    searchColumns << "artist"
+                  << "album";
+
+    QScopedPointer<QueryNode> pQuery(
+        m_parser.parseQuery("duration:2:30-3:20", searchColumns, ""));
+
+    TrackPointer pTrack(new TrackInfoObject());
+    pTrack->setSampleRate(44100);
+    pTrack->setDuration(80);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(150);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    pTrack->setDuration(199);
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+        qPrintable(QString("(duration >= 150 AND duration <= 200)")),
+        qPrintable(pQuery->toSql()));
+    
+    pQuery.reset(m_parser.parseQuery("duration:2:30-200", searchColumns, ""));
+    pTrack->setSampleRate(44100);
+    pTrack->setDuration(80);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(150);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    pTrack->setDuration(199);
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+        qPrintable(QString("(duration >= 150 AND duration <= 200)")),
+        qPrintable(pQuery->toSql()));
+
+    pQuery.reset(m_parser.parseQuery("duration:150-200", searchColumns, ""));
+    pTrack->setSampleRate(44100);
+    pTrack->setDuration(80);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(150);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    pTrack->setDuration(199);
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+        qPrintable(QString("(duration >= 150 AND duration <= 200)")),
+        qPrintable(pQuery->toSql()));
+
+    pQuery.reset(m_parser.parseQuery("duration:2m30s-3m20s", searchColumns, ""));
+    pTrack->setSampleRate(44100);
+    pTrack->setDuration(80);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(150);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    pTrack->setDuration(199);
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+        qPrintable(QString("(duration >= 150 AND duration <= 200)")),
         qPrintable(pQuery->toSql()));
 }

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -457,6 +457,33 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     EXPECT_STREQ(
         qPrintable(QString("(duration <= 150)")),
         qPrintable(pQuery->toSql()));
+
+    pQuery.reset(m_parser.parseQuery("duration:<=2m", searchColumns, ""));
+    pTrack->setDuration(191);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(110);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    EXPECT_STREQ(
+        qPrintable(QString("(duration <= 120)")),
+        qPrintable(pQuery->toSql()));
+
+    pQuery.reset(m_parser.parseQuery("duration:<=2:", searchColumns, ""));
+    pTrack->setDuration(191);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(110);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    EXPECT_STREQ(
+        qPrintable(QString("(duration <= 120)")),
+        qPrintable(pQuery->toSql()));
+
+    pQuery.reset(m_parser.parseQuery("duration:>=1:3", searchColumns, ""));
+    pTrack->setDuration(60);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setDuration(150);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    EXPECT_STREQ(
+        qPrintable(QString("(duration >= 63)")),
+        qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {


### PR DESCRIPTION
This is based on the #186. I refactored the parsing of the time input to use QRegexp directly and added a special query node for the time-querys because they are now not purely numeric anymore. 

To search for a track of exactly 90 seconds the following terms are equivalent.

90
90s
1m30
1m30s
1:30

searching for 62 seconds can be entered as

62
62s
1m2
1m2s
1m02s
1:2
