### PR TITLE
Move TrackDAO save logic for deleted TrackInfoObjects to ~TrackInfoObject

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -266,18 +266,6 @@ void TrackDAO::slotTrackChanged(TrackInfoObject* pTrack) {
     }
 }
 
-void TrackDAO::slotTrackSave(TrackInfoObject* pTrack) {
-    //qDebug() << "TrackDAO::slotTrackSave" << pTrack->getId() << pTrack->getInfo();
-    // This is a private slot that is connected to TIO's created by this
-    // TrackDAO. It is a way for the track to ask that it be saved. The last
-    // time it is used is when the track is being deleted (i.e. its reference
-    // count has dropped to 0). The TIO is deleted with QObject:deleteLater, so
-    // Qt will wait for this slot to complete.
-    if (pTrack) {
-        saveTrack(pTrack);
-    }
-}
-
 // No need to check here if the querys exist, this is already done in
 // addTracksAdd, which is the only function that calls this
 void TrackDAO::bindTrackToTrackLocationsInsert(TrackInfoObject* pTrack) {
@@ -813,24 +801,19 @@ void TrackDAO::purgeTracks(const QList<int>& ids) {
     emit(tracksRemoved(tracksRemovedSet));
 }
 
-// deleter of the TrackInfoObject, for delete a Track from Library use hide or purge
-// static
-void TrackDAO::deleteTrack(TrackInfoObject* pTrack) {
+void TrackDAO::slotTrackDeleted(TrackInfoObject* pTrack) {
     Q_ASSERT(pTrack);
     //qDebug() << "Garbage Collecting" << pTrack << "ID" << pTrack->getId() << pTrack->getInfo();
 
     // Save the track if it is dirty.
     if (pTrack->isDirty()) {
-        pTrack->doSave();
+        saveTrack(pTrack);
     }
 
     // Delete Track from weak reference cache
     m_sTracksMutex.lock();
     m_sTracks.remove(pTrack->getId());
     m_sTracksMutex.unlock();
-
-    // Now Qt will delete it in the event loop.
-    pTrack->deleteLater();
 }
 
 TrackPointer TrackDAO::getTrackFromDB(const int id) const {
@@ -919,7 +902,7 @@ TrackPointer TrackDAO::getTrackFromDB(const int id) const {
 
             TrackPointer pTrack = TrackPointer(
                     new TrackInfoObject(location, SecurityTokenPointer(), false),
-                    &TrackDAO::deleteTrack);
+                    &QObject::deleteLater);
 
             // TIO already stats the file to see if it exists, what its length is,
             // etc. So don't bother setting it.
@@ -999,8 +982,8 @@ TrackPointer TrackDAO::getTrackFromDB(const int id) const {
             connect(pTrack.data(), SIGNAL(changed(TrackInfoObject*)),
                     this, SLOT(slotTrackChanged(TrackInfoObject*)),
                     Qt::DirectConnection);
-            connect(pTrack.data(), SIGNAL(save(TrackInfoObject*)),
-                    this, SLOT(slotTrackSave(TrackInfoObject*)),
+            connect(pTrack.data(), SIGNAL(deleted(TrackInfoObject*)),
+                    this, SLOT(slotTrackDeleted(TrackInfoObject*)),
                     Qt::DirectConnection);
 
             m_sTracksMutex.lock();

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -136,7 +136,8 @@ class TrackDAO : public QObject, public virtual DAO {
     void slotTrackDirty(TrackInfoObject* pTrack);
     void slotTrackChanged(TrackInfoObject* pTrack);
     void slotTrackClean(TrackInfoObject* pTrack);
-    void slotTrackSave(TrackInfoObject* pTrack);
+    // Called by ~TrackInfoObject right before the track is destroyed.
+    void slotTrackDeleted(TrackInfoObject* pTrack);
 
   private:
     bool isTrackFormatSupported(TrackInfoObject* pTrack) const;
@@ -150,8 +151,6 @@ class TrackDAO : public QObject, public virtual DAO {
     void bindTrackToLibraryInsert(TrackInfoObject* pTrack, int trackLocationId);
 
     void writeAudioMetaData(TrackInfoObject* pTrack);
-    // Called when the TIO reference count drops to 0
-    static void deleteTrack(TrackInfoObject* pTrack);
 
     QSqlDatabase& m_database;
     CueDAO& m_cueDao;

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -137,13 +137,13 @@ void TrackInfoObject::initialize(bool parseHeader) {
 
 TrackInfoObject::~TrackInfoObject() {
     //qDebug() << "~TrackInfoObject()" << m_iId << getInfo();
+
+    // Notifies TrackDAO and other listeners that this track is about to be
+    // deleted and should be saved to the database, removed from caches, etc.
+    emit(deleted(this));
+
     delete m_waveform;
     delete m_waveformSummary;
-}
-
-void TrackInfoObject::doSave() {
-    //qDebug() << "TIO::doSave()" << getInfo();
-    emit(save(this));
 }
 
 void TrackInfoObject::parse() {

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -234,10 +234,6 @@ class TrackInfoObject : public QObject {
 
     bool isDirty();
 
-    // Signals to the creator of this TrackInfoObject to save the Track as it
-    // may be deleted.
-    void doSave();
-
     // Returns true if the track location has changed
     bool locationChanged();
 
@@ -276,7 +272,7 @@ class TrackInfoObject : public QObject {
     void changed(TrackInfoObject* pTrack);
     void dirty(TrackInfoObject* pTrack);
     void clean(TrackInfoObject* pTrack);
-    void save(TrackInfoObject* pTrack);
+    void deleted(TrackInfoObject* pTrack);
 
   private slots:
     void slotBeatsUpdated();


### PR DESCRIPTION
Don't run TrackInfoObject database interactions the moment its TrackPointer
refcount drops to 0. Instead move this logic into the TrackInfoObject destructor
and run it on the next time through the Qt event loop. This helps prevent
action-at-a-distance re-entrancy bugs where you need to drop a TrackPointer
reference but your context isn't safe to do so.
