### PR TITLE
 Library isn't reading artist/album tags for some MP3s 

### DIFF
--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -352,6 +352,18 @@ bool SoundSource::processID3v2Tag(TagLib::ID3v2::Tag* id3v2) {
     if (!albumArtistFrame.isEmpty()) {
         QString sAlbumArtist = TStringToQString(albumArtistFrame.front()->toString());
         setAlbumArtist(sAlbumArtist);
+
+        if (getArtist().length() == 0) {
+           setArtist(sAlbumArtist);
+        }
+    }
+    TagLib::ID3v2::FrameList originalAlbumFrame = id3v2->frameListMap()["TOAL"];
+    if (!originalAlbumFrame.isEmpty()) {
+        QString sOriginalAlbum = TStringToQString(originalAlbumFrame.front()->toString());
+
+        if (getAlbum().length() == 0) {
+           setAlbum(sOriginalAlbum);
+        }
     }
     TagLib::ID3v2::FrameList composerFrame = id3v2->frameListMap()["TCOM"];
     if (!composerFrame.isEmpty()) {

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -358,12 +358,9 @@ bool SoundSource::processID3v2Tag(TagLib::ID3v2::Tag* id3v2) {
         }
     }
     TagLib::ID3v2::FrameList originalAlbumFrame = id3v2->frameListMap()["TOAL"];
-    if (!originalAlbumFrame.isEmpty()) {
+    if (getAlbum().length() == 0 && !originalAlbumFrame.isEmpty()) {
         QString sOriginalAlbum = TStringToQString(originalAlbumFrame.front()->toString());
-
-        if (getAlbum().length() == 0) {
-           setAlbum(sOriginalAlbum);
-        }
+        setAlbum(sOriginalAlbum);
     }
     TagLib::ID3v2::FrameList composerFrame = id3v2->frameListMap()["TCOM"];
     if (!composerFrame.isEmpty()) {


### PR DESCRIPTION
Fixes MP3 reading id3v2 tags TPE1 (Lead performer(s)/Soloist(s)) and TPE2 (Band/orchestra/accompaniment) which is used in iTunes also fixes TOAL (Original album/movie/show title) and TALB (Album/Movie/Show title) situation in Bug #1266158

iTunes Uses TPE1 and TPE2 for user it confusing to see artist line empty so this easy fix fixes that situation.
As said there is very simple fix in SoundSource::processID3v2Tag() and it's little brutal (If there is Artist and AlbumArtist then Artist is used in Artist field) but should do the trick. 
