### PR TITLE
Explicit Master should get processed first

### DIFF
--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -381,6 +381,10 @@ double BpmControl::getSyncAdjustment(bool userTweakingSync) {
         // No beat information.
         return 1.0;
     }
+    if (getSyncMode() == SYNC_MASTER) {
+        m_dSyncAdjustment = 1.0;
+        return m_dSyncAdjustment;
+    }
     if (m_pReverseButton->get()) {
         // If we are going backwards, we can't do the math correctly.
         m_dSyncAdjustment = 1.0;

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -25,7 +25,8 @@ BpmControl::BpmControl(const char* _group,
         m_dPreviousSample(0),
         m_dSyncTargetBeatDistance(0.0),
         m_dSyncInstantaneousBpm(0.0),
-        m_dSyncAdjustment(1.0),
+        m_dLastSyncAdjustment(1.0),
+        m_resetSyncAdjustment(false),
         m_dUserOffset(0.0),
         m_tapFilter(this, filterLength, maxInterval),
         m_sGroup(_group) {
@@ -141,7 +142,7 @@ void BpmControl::slotFileBpmChanged(double bpm) {
         slotAdjustRateSlider();
     }
     m_dUserOffset = 0.0;
-    m_dSyncAdjustment = 1.0;
+    m_resetSyncAdjustment = true;
 }
 
 void BpmControl::slotAdjustBeatsFaster(double v) {
@@ -327,17 +328,6 @@ bool BpmControl::syncTempo() {
     return false;
 }
 
-double BpmControl::getSyncedRate() const {
-    // TODO: let's ignore x2, /2 issues for now
-    // This is reproduced from bpmcontrol::syncTempo -- should break this out
-    if (m_pFileBpm->get() == 0.0) {
-        // XXX TODO: what to do about this case
-        return 1.0;
-    } else {
-        return m_dSyncInstantaneousBpm / m_pFileBpm->get();
-    }
-}
-
 // static
 double BpmControl::shortestPercentageChange(const double& current_percentage,
                                             const double& target_percentage) {
@@ -374,48 +364,57 @@ double BpmControl::shortestPercentageChange(const double& current_percentage,
     }
 }
 
-double BpmControl::getSyncAdjustment(bool userTweakingSync) {
-    // This runs when ratecontrol wants to know what rate to use.
-
-    if (m_pBeats == NULL) {
-        // No beat information.
-        return 1.0;
-    }
-    if (getSyncMode() == SYNC_MASTER) {
-        m_dSyncAdjustment = 1.0;
-        return m_dSyncAdjustment;
-    }
-    if (m_pReverseButton->get()) {
-        // If we are going backwards, we can't do the math correctly.
-        m_dSyncAdjustment = 1.0;
-        return m_dSyncAdjustment;
+double BpmControl::calcSyncedRate(double userTweak) {
+    double rate = 1.0;
+    // Don't know what to do if there's no bpm.
+    if (m_pFileBpm->get() != 0.0) {
+        rate = m_dSyncInstantaneousBpm / m_pFileBpm->get();
     }
 
-    // This is the deck position at the start of the callback.
+    // If we are not quantized, or there are no beats, or we're master,
+    // or we're in reverse, just return the rate as-is.
+    if (!m_pQuantize->get() ||
+        getSyncMode() == SYNC_MASTER ||
+        m_pBeats == NULL ||
+        m_pReverseButton->get()) {
+        m_resetSyncAdjustment = true;
+        return rate;
+    }
+
+    // Now we need to get our beat distance so we can figure out how
+    // out of phase we are.
     double dThisPosition = getCurrentSample();
-    double dPrevBeat;
-    double dNextBeat;
     double dBeatLength;
     double my_percentage;
 
     if (!BpmControl::getBeatContext(m_pBeats, dThisPosition,
-                                    &dPrevBeat, &dNextBeat,
+                                    NULL, NULL,
                                     &dBeatLength, &my_percentage, 0.01)) {
-        return 1.0;
+        m_resetSyncAdjustment = true;
+        return rate;
     }
 
-    // If we aren't quantized or we are in a <1 beat loop, don't worry about
-    // offset.
+    // Now that we have our beat distance we can also check how large the
+    // current loop is.  If we are in a <1 beat loop, don't worry about offset.
     const bool loop_enabled = m_pLoopEnabled->get() > 0.0;
     const double loop_size = (m_pLoopEndPosition->get() -
                               m_pLoopStartPosition->get()) /
                               dBeatLength;
-    if (!m_pQuantize->get() || (loop_enabled && loop_size < 1.0 && loop_size > 0)) {
-        m_dSyncAdjustment = 1.0;
-        return m_dSyncAdjustment;
+    if (loop_enabled && loop_size < 1.0 && loop_size > 0) {
+        m_resetSyncAdjustment = true;
+        return rate;
     }
 
-    double master_percentage = m_dSyncTargetBeatDistance;
+    // Now we have all we need to calculate the sync adjustment if any.
+    double adjustment = calcSyncAdjustment(my_percentage, userTweak != 0.0);
+    return (rate + userTweak) * adjustment;
+}
+
+double BpmControl::calcSyncAdjustment(double my_percentage, bool userTweakingSync) {
+    if (m_resetSyncAdjustment) {
+        m_resetSyncAdjustment = false;
+        m_dLastSyncAdjustment = 1.0;
+    }
 
     // Either shortest distance is directly to the master or backwards.
 
@@ -429,6 +428,8 @@ double BpmControl::getSyncAdjustment(bool userTweakingSync) {
     // setpoint should be tracking the true offset in "samples traveled" rather
     // than modular 1.0 beat fractions. This will allow sync to work across loop
     // boundaries too.
+
+    double master_percentage = m_dSyncTargetBeatDistance;
     double shortest_distance = shortestPercentageChange(
         master_percentage, my_percentage);
 
@@ -437,9 +438,11 @@ double BpmControl::getSyncAdjustment(bool userTweakingSync) {
     qDebug() << "my     beat distance:" << my_percentage;
     qDebug() << m_sGroup << sample_offset << m_dUserOffset;*/
 
+    double adjustment = 1.0;
+
     if (userTweakingSync) {
         // Don't do anything else, leave it
-        m_dSyncAdjustment = 1.0;
+        adjustment = 1.0;
         m_dUserOffset = shortest_distance;
     } else {
         double error = shortest_distance - m_dUserOffset;
@@ -452,7 +455,7 @@ double BpmControl::getSyncAdjustment(bool userTweakingSync) {
         const double kSyncAdjustmentCap = 0.05;
         if (fabs(error) > kTrainWreckThreshold) {
             // Assume poor reflexes (late button push) -- speed up to catch the other track.
-            m_dSyncAdjustment = 1.0 + kSyncAdjustmentCap;
+            adjustment = 1.0 + kSyncAdjustmentCap;
         } else if (fabs(error) > kErrorThreshold) {
             // Proportional control constant. The higher this is, the more we
             // influence sync.
@@ -462,19 +465,20 @@ double BpmControl::getSyncAdjustment(bool userTweakingSync) {
             // TODO(owilliams): There are a lot of "1.0"s in this code -- can we eliminate them?
             const double adjust = 1.0 + (-error * kSyncAdjustmentProportional);
             // Cap the difference between the last adjustment and this one.
-            double delta = adjust - m_dSyncAdjustment;
+            double delta = adjust - m_dLastSyncAdjustment;
             delta = math_clamp(delta, -kSyncDeltaCap, kSyncDeltaCap);
 
             // Cap the adjustment between -kSyncAdjustmentCap and +kSyncAdjustmentCap
-            m_dSyncAdjustment = 1.0 + math_clamp(
-                    m_dSyncAdjustment - 1.0 + delta,
+            adjustment = 1.0 + math_clamp(
+                    m_dLastSyncAdjustment - 1.0 + delta,
                     -kSyncAdjustmentCap, kSyncAdjustmentCap);
         } else {
             // We are in sync, no adjustment needed.
-            m_dSyncAdjustment = 1.0;
+            adjustment = 1.0;
         }
     }
-    return m_dSyncAdjustment;
+    m_dLastSyncAdjustment = adjustment;
+    return adjustment;
 }
 
 double BpmControl::getBeatDistance(double dThisPosition) const {
@@ -677,7 +681,7 @@ void BpmControl::trackLoaded(TrackPointer pTrack) {
 
     // reset for new track
     m_dUserOffset = 0.0;
-    m_dSyncAdjustment = 1.0;
+    m_resetSyncAdjustment = true;
 
     if (pTrack) {
         m_pTrack = pTrack;
@@ -696,14 +700,14 @@ void BpmControl::trackUnloaded(TrackPointer pTrack) {
         m_pBeats.clear();
     }
     m_dUserOffset = 0.0;
-    m_dSyncAdjustment = 1.0;
+    m_dLastSyncAdjustment = 1.0;
 }
 
 void BpmControl::slotUpdatedTrackBeats()
 {
     if (m_pTrack) {
         m_dUserOffset = 0.0;
-        m_dSyncAdjustment = 1.0;
+        m_resetSyncAdjustment = true;
         m_pBeats = m_pTrack->getBeats();
     }
 }

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -26,8 +26,11 @@ class BpmControl : public EngineControl {
 
     double getBpm() const;
     double getFileBpm() const { return m_pFileBpm ? m_pFileBpm->get() : 0.0; }
-    double getSyncAdjustment(bool userTweakingSync);
-    double getSyncedRate() const;
+    // When in master sync mode, ratecontrol calls calcSyncedRate to figure out
+    // how fast the track should play back.  The rate may be adjusted (ie,
+    // not precisely equal to the ratio of the bpms) if the
+    // user tweaked the sync position or if the tracks are falling out of sync.
+    double calcSyncedRate(double userTweak);
     // Get the phase offset from the specified position.
     double getPhaseOffset(double reference_position);
     double getBeatDistance(double dThisPosition) const;
@@ -88,6 +91,7 @@ class BpmControl : public EngineControl {
         return syncModeFromDouble(m_pSyncMode->get());
     }
     bool syncTempo();
+    double calcSyncAdjustment(double my_percentage, bool userTweakingSync);
 
     friend class SyncControl;
 
@@ -133,7 +137,8 @@ class BpmControl : public EngineControl {
     ControlObjectSlave* m_pThisBeatDistance;
     double m_dSyncTargetBeatDistance;
     double m_dSyncInstantaneousBpm;
-    double m_dSyncAdjustment;
+    double m_dLastSyncAdjustment;
+    bool m_resetSyncAdjustment;
     double m_dUserOffset;
 
     TapFilter m_tapFilter;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1012,6 +1012,12 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize)
     }
 #endif
 
+    if (m_pSyncControl->getSyncMode() == SYNC_MASTER) {
+        // Report our speed to SyncControl immediately instead of waiting
+        // for postProcess so we can broadcast this update to followers.
+        m_pSyncControl->reportPlayerSpeed(m_speed_old, m_scratching_old);
+    }
+
     m_bLastBufferPaused = bCurBufferPaused;
     m_iLastBufferSize = iBufferSize;
 }
@@ -1112,10 +1118,10 @@ void EngineBuffer::postProcess(const int iBufferSize) {
     double beat_distance = m_pBpmControl->updateBeatDistance();
     if (m_pSyncControl->getSyncMode() == SYNC_MASTER) {
         m_pEngineSync->notifyBeatDistanceChanged(m_pSyncControl, beat_distance);
+    } else {
+        // Report our speed to SyncControl.  If we are master, we already did this.
+        m_pSyncControl->reportPlayerSpeed(m_speed_old, m_scratching_old);
     }
-    // Report our speed to SyncControl. If we are the master then it will
-    // broadcast this update to followers.
-    m_pSyncControl->reportPlayerSpeed(m_speed_old, m_scratching_old);
 
     // Update all the indicators that EngineBuffer publishes to allow
     // external parts of Mixxx to observe its status.

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -230,7 +230,8 @@ void EngineMaster::processChannels(unsigned int* busChannelConnectionFlags,
     m_pTalkoverDucking->clearKeys();
 
     EngineChannel* pMasterChannel = m_pMasterSync->getMaster();
-    QList<ChannelInfo*> processed_channels;
+    QList<ChannelInfo*> activeChannels;
+    activeChannels.reserve(m_channels.size());
     it = m_channels.begin();
     for (unsigned int channel_number = 0;
          it != m_channels.end(); ++it, ++channel_number) {
@@ -259,15 +260,15 @@ void EngineMaster::processChannels(unsigned int* busChannelConnectionFlags,
         if (needsProcessing) {
             if (pChannel == pMasterChannel) {
                 // If this is the sync master, it should be processed first.
-                processed_channels.prepend(pChannelInfo);
+                activeChannels.prepend(pChannelInfo);
             } else {
-                processed_channels.append(pChannelInfo);
+                activeChannels.append(pChannelInfo);
             }
         }
     }
 
     // Now that the list is built and ordered, do the processing.
-    foreach (ChannelInfo* pChannelInfo, processed_channels) {
+    foreach (ChannelInfo* pChannelInfo, activeChannels) {
         EngineChannel* pChannel = pChannelInfo->m_pChannel;
         pChannel->process(pChannelInfo->m_pBuffer, iBufferSize);
 
@@ -281,7 +282,7 @@ void EngineMaster::processChannels(unsigned int* busChannelConnectionFlags,
     // which ensures that all channels are updating certain values at the
     // same point in time.  This prevents sync from failing depending on
     // if the sync target was processed before or after the sync origin.
-    foreach (ChannelInfo* pChannelInfo, processed_channels) {
+    foreach (ChannelInfo* pChannelInfo, activeChannels) {
         pChannelInfo->m_pChannel->postProcess(iBufferSize);
     }
 }

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -230,8 +230,8 @@ void EngineMaster::processChannels(unsigned int* busChannelConnectionFlags,
     m_pTalkoverDucking->clearKeys();
 
     EngineChannel* pMasterChannel = m_pMasterSync->getMaster();
-    QList<ChannelInfo*> activeChannels;
-    activeChannels.reserve(m_channels.size());
+    m_activeChannels.clear();
+    m_activeChannels.reserve(m_channels.size());
     it = m_channels.begin();
     for (unsigned int channel_number = 0;
          it != m_channels.end(); ++it, ++channel_number) {
@@ -260,15 +260,15 @@ void EngineMaster::processChannels(unsigned int* busChannelConnectionFlags,
         if (needsProcessing) {
             if (pChannel == pMasterChannel) {
                 // If this is the sync master, it should be processed first.
-                activeChannels.prepend(pChannelInfo);
+                m_activeChannels.prepend(pChannelInfo);
             } else {
-                activeChannels.append(pChannelInfo);
+                m_activeChannels.append(pChannelInfo);
             }
         }
     }
 
     // Now that the list is built and ordered, do the processing.
-    foreach (ChannelInfo* pChannelInfo, activeChannels) {
+    foreach (ChannelInfo* pChannelInfo, m_activeChannels) {
         EngineChannel* pChannel = pChannelInfo->m_pChannel;
         pChannel->process(pChannelInfo->m_pBuffer, iBufferSize);
 
@@ -282,7 +282,7 @@ void EngineMaster::processChannels(unsigned int* busChannelConnectionFlags,
     // which ensures that all channels are updating certain values at the
     // same point in time.  This prevents sync from failing depending on
     // if the sync target was processed before or after the sync origin.
-    foreach (ChannelInfo* pChannelInfo, activeChannels) {
+    foreach (ChannelInfo* pChannelInfo, m_activeChannels) {
         pChannelInfo->m_pChannel->postProcess(iBufferSize);
     }
 }

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -229,7 +229,8 @@ void EngineMaster::processChannels(unsigned int* busChannelConnectionFlags,
     // Clear talkover compressor for the next round of gain calculation.
     m_pTalkoverDucking->clearKeys();
 
-    QSet<EngineChannel*> processed_channels;
+    EngineChannel* pMasterChannel = m_pMasterSync->getMaster();
+    QList<ChannelInfo*> processed_channels;
     it = m_channels.begin();
     for (unsigned int channel_number = 0;
          it != m_channels.end(); ++it, ++channel_number) {
@@ -254,15 +255,25 @@ void EngineMaster::processChannels(unsigned int* busChannelConnectionFlags,
             needsProcessing = true;
         }
 
-        // Process the buffer if necessary
+        // If necessary, add the channel to the list of buffers to process.
         if (needsProcessing) {
-            processed_channels.insert(pChannel);
-            pChannel->process(pChannelInfo->m_pBuffer, iBufferSize);
-
-            if (m_pTalkoverDucking->getMode() != EngineTalkoverDucking::OFF &&
-                    pChannel->isTalkover()) {
-                m_pTalkoverDucking->processKey(pChannelInfo->m_pBuffer, iBufferSize);
+            if (pChannel == pMasterChannel) {
+                // If this is the sync master, it should be processed first.
+                processed_channels.prepend(pChannelInfo);
+            } else {
+                processed_channels.append(pChannelInfo);
             }
+        }
+    }
+
+    // Now that the list is built and ordered, do the processing.
+    foreach (ChannelInfo* pChannelInfo, processed_channels) {
+        EngineChannel* pChannel = pChannelInfo->m_pChannel;
+        pChannel->process(pChannelInfo->m_pBuffer, iBufferSize);
+
+        if (m_pTalkoverDucking->getMode() != EngineTalkoverDucking::OFF &&
+                pChannel->isTalkover()) {
+            m_pTalkoverDucking->processKey(pChannelInfo->m_pBuffer, iBufferSize);
         }
     }
 
@@ -270,8 +281,8 @@ void EngineMaster::processChannels(unsigned int* busChannelConnectionFlags,
     // which ensures that all channels are updating certain values at the
     // same point in time.  This prevents sync from failing depending on
     // if the sync target was processed before or after the sync origin.
-    foreach (EngineChannel* channel, processed_channels) {
-        channel->postProcess(iBufferSize);
+    foreach (ChannelInfo* pChannelInfo, processed_channels) {
+        pChannelInfo->m_pChannel->postProcess(iBufferSize);
     }
 }
 

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -206,6 +206,7 @@ class EngineMaster : public QObject, public AudioSource {
     EngineEffectsManager* m_pEngineEffectsManager;
     bool m_bRampingGain;
     QList<ChannelInfo*> m_channels;
+    QList<ChannelInfo*> m_activeChannels;
     QList<CSAMPLE> m_channelMasterGainCache;
     QList<CSAMPLE> m_channelHeadphoneGainCache;
 

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -489,12 +489,8 @@ double RateControl::calculateRate(double baserate, bool paused,
                     return 1.0;
                 }
 
-                rate = m_pBpmControl->getSyncedRate();
                 double userTweak = getTempRate() + wheelFactor + jogFactor;
-                bool userTweakingSync = userTweak != 0.0;
-                rate += userTweak;
-
-                rate *= m_pBpmControl->getSyncAdjustment(userTweakingSync);
+                rate = m_pBpmControl->calcSyncedRate(userTweak);
             }
             // If we are reversing (and not scratching,) flip the rate.  This is ok even when syncing.
             // Reverse with vinyl is only ok if absolute mode isn't on.

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1059,6 +1059,10 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChange) {
     ProcessBuffer();
     ProcessBuffer();
 
+    // Make sure we're actually going somewhere!
+    EXPECT_GT(ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->get(),
+              0);
+    // Buffers should be in sync.
     EXPECT_EQ(ControlObject::getControl(ConfigKey(m_sGroup2, "beat_distance"))->get(),
               ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->get());
 }


### PR DESCRIPTION
When there is an explicit master, make sure rates are instantly communicated
to followers.

Added a unit test that confirms that the tracks remain locked in sync.
