### PR TITLE
Allow replaygain changes during playback

### DIFF
--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -251,12 +251,7 @@ TrackPointer BaseTrackPlayer::getLoadedTrack() const {
 }
 
 void BaseTrackPlayer::slotSetReplayGain(double replayGain) {
-
-    // Do not change replay gain when track is playing because
-    // this may lead to an unexpected volume change
-    if (m_pPlay->get() == 0.0) {
-        m_pReplayGain->slotSet(replayGain);
-    }
+    m_pReplayGain->slotSet(replayGain);
 }
 
 EngineDeck* BaseTrackPlayer::getEngineDeck() const {

--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -26,7 +26,8 @@ BaseTrackPlayer::BaseTrackPlayer(QObject* pParent,
                                  bool defaultHeadphones)
         : BasePlayer(pParent, group),
           m_pConfig(pConfig),
-          m_pLoadedTrack() {
+          m_pLoadedTrack(),
+          m_replaygainPending(false) {
     // Need to strdup the string because EngineChannel will save the pointer,
     // but we might get deleted before the EngineChannel. TODO(XXX)
     // pSafeGroupName is leaked. It's like 5 bytes so whatever.
@@ -83,6 +84,10 @@ BaseTrackPlayer::BaseTrackPlayer(QObject* pParent,
     m_pKey = new ControlObjectThread(group, "file_key");
     m_pReplayGain = new ControlObjectThread(group, "replaygain");
     m_pPlay = new ControlObjectThread(group, "play");
+    connect(m_pPlay, SIGNAL(valueChanged(double)),
+            this, SLOT(slotPlayToggled(double)));
+    connect(m_pPlay, SIGNAL(valueChangedFromEngine(double)),
+            this, SLOT(slotPlayToggled(double)));
 }
 
 BaseTrackPlayer::~BaseTrackPlayer()
@@ -192,6 +197,7 @@ void BaseTrackPlayer::slotUnloadTrack(TrackPointer) {
         // for all the widgets to unload the track and blank themselves.
         emit(unloadingTrack(m_pLoadedTrack));
     }
+    m_replaygainPending = false;
     m_pDuration->set(0);
     m_pBPM->slotSet(0);
     m_pKey->slotSet(0);
@@ -207,6 +213,7 @@ void BaseTrackPlayer::slotUnloadTrack(TrackPointer) {
 
 void BaseTrackPlayer::slotFinishLoading(TrackPointer pTrackInfoObject)
 {
+    m_replaygainPending = false;
     // Read the tags if required
     if (!m_pLoadedTrack->getHeaderParsed()) {
         m_pLoadedTrack->parse();
@@ -251,7 +258,20 @@ TrackPointer BaseTrackPlayer::getLoadedTrack() const {
 }
 
 void BaseTrackPlayer::slotSetReplayGain(double replayGain) {
-    m_pReplayGain->slotSet(replayGain);
+    // Do not change replay gain when track is playing because
+    // this may lead to an unexpected volume change
+    if (m_pPlay->get() == 0.0) {
+        m_pReplayGain->slotSet(replayGain);
+    } else {
+        m_replaygainPending = true;
+    }
+}
+
+void BaseTrackPlayer::slotPlayToggled(double v) {
+    if (!v && m_replaygainPending) {
+        m_pReplayGain->slotSet(m_pLoadedTrack->getReplayGain());
+        m_replaygainPending = false;
+    }
 }
 
 EngineDeck* BaseTrackPlayer::getEngineDeck() const {

--- a/src/basetrackplayer.h
+++ b/src/basetrackplayer.h
@@ -39,6 +39,7 @@ class BaseTrackPlayer : public BasePlayer {
     void slotLoadFailed(TrackPointer pTrackInfoObject, QString reason);
     void slotUnloadTrack(TrackPointer track);
     void slotSetReplayGain(double replayGain);
+    void slotPlayToggled(double);
 
   signals:
     void loadTrack(TrackPointer pTrack, bool bPlay=false);
@@ -62,6 +63,8 @@ class BaseTrackPlayer : public BasePlayer {
     ControlObjectThread* m_pReplayGain;
     ControlObjectThread* m_pPlay;
     EngineDeck* m_pChannel;
+
+    bool m_replaygainPending;
 };
 
 


### PR DESCRIPTION
We have code to smoothly ramp replaygain changes,
so it's ok to update the value.  (Most likely the user
is still cueing a track so applying replaygain value
is preferred anyway)

This bit me while I was loading new tracks, I had happened to start playing a track before analysis was complete, so I thought replaygain had failed.
