### PR TITLE
Don't show the drop-accept indicator if there are no valid urls in the drop event

### DIFF
--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -1,11 +1,13 @@
 #include "widget/wlibrarysidebar.h"
 
+#include <QFileInfo>
 #include <QHeaderView>
 #include <QUrl>
 #include <QtDebug>
 #include <QMimeData>
 
 #include "library/sidebarmodel.h"
+#include "util/dnd.h"
 
 const int expand_time = 250;
 
@@ -42,8 +44,14 @@ void WLibrarySidebar::contextMenuEvent(QContextMenuEvent *event) {
 void WLibrarySidebar::dragEnterEvent(QDragEnterEvent * event) {
     qDebug() << "WLibrarySidebar::dragEnterEvent" << event->mimeData()->formats();
     if (event->mimeData()->hasUrls()) {
-        event->acceptProposedAction();
+        QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(
+                event->mimeData()->urls(), true, false);
+        if (!files.isEmpty()) {
+            event->acceptProposedAction();
+            return;
+        }
     }
+    event->ignore();
     //QTreeView::dragEnterEvent(event);
 }
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -499,11 +499,15 @@ void WOverview::dragEnterEvent(QDragEnterEvent* event) {
     if (event->mimeData()->hasUrls() && event->mimeData()->urls().size() > 0) {
         if ((m_playControl->get() == 0.0 ||
             m_pConfig->getValueString(ConfigKey("[Controls]","AllowTrackLoadToPlayingDeck")).toInt()) || (m_group=="[PreviewDeck1]")) {
-            event->acceptProposedAction();
-        } else {
-            event->ignore();
+            QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(
+                event->mimeData()->urls(), true, false);
+            if (!files.isEmpty()) {
+                event->acceptProposedAction();
+                return;
+            }
         }
     }
+    event->ignore();
 }
 
 void WOverview::dropEvent(QDropEvent* event) {

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -524,9 +524,15 @@ void WSpinny::dragEnterEvent(QDragEnterEvent * event)
         if (m_pPlay && m_pPlay->get()) {
             event->ignore();
         } else {
-            event->acceptProposedAction();
+            QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(
+                event->mimeData()->urls(), true, false);
+            if (!files.isEmpty()) {
+                event->acceptProposedAction();
+                return;
+            }
         }
     }
+    event->ignore();
 }
 
 void WSpinny::dropEvent(QDropEvent * event) {

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -63,11 +63,15 @@ void WTrackProperty::dragEnterEvent(QDragEnterEvent *event) {
         // Accept if the Deck isn't playing or the settings allow to interrupt a playing deck
         if ((!ControlObject::get(ConfigKey(m_pGroup, "play")) ||
              m_pConfig->getValueString(ConfigKey("[Controls]", "AllowTrackLoadToPlayingDeck")).toInt())) {
-            event->acceptProposedAction();
-        } else {
-            event->ignore();
+            QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(
+                event->mimeData()->urls(), true, false);
+            if (!files.isEmpty()) {
+                event->acceptProposedAction();
+                return;
+            }
         }
     }
+    event->ignore();
 }
 
 void WTrackProperty::dropEvent(QDropEvent *event) {

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -52,11 +52,15 @@ void WTrackText::dragEnterEvent(QDragEnterEvent *event) {
         // Accept if the Deck isn't playing or the settings allow to interrupt a playing deck
         if ((!ControlObject::get(ConfigKey(m_pGroup, "play")) ||
              m_pConfig->getValueString(ConfigKey("[Controls]", "AllowTrackLoadToPlayingDeck")).toInt())) {
-            event->acceptProposedAction();
-        } else {
-            event->ignore();
+            QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(
+                event->mimeData()->urls(), true, false);
+            if (!files.isEmpty()) {
+                event->acceptProposedAction();
+                return;
+            }
         }
     }
+    event->ignore();
 }
 
 void WTrackText::dropEvent(QDropEvent *event) {

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -154,11 +154,15 @@ void WWaveformViewer::dragEnterEvent(QDragEnterEvent * event) {
         // Accept if the Deck isn't playing or the settings allow to interrupt a playing deck
         if ((!ControlObject::get(ConfigKey(m_pGroup, "play")) ||
                 m_pConfig->getValueString(ConfigKey("[Controls]","AllowTrackLoadToPlayingDeck")).toInt())) {
-            event->acceptProposedAction();
-        } else {
-            event->ignore();
+            QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(
+                event->mimeData()->urls(), true, false);
+            if (!files.isEmpty()) {
+                event->acceptProposedAction();
+                return;
+            }
         }
     }
+    event->ignore();
 }
 
 void WWaveformViewer::dropEvent(QDropEvent * event) {


### PR DESCRIPTION
Continuing on my crusade of polish bugs.  We shouldn't show the [+] in the mouse cursor if we're going to reject the drop.
