### PR TITLE
Move vinyl control processing to the engine thread

### DIFF
--- a/src/vinylcontrol/vinylcontrol.h
+++ b/src/vinylcontrol/vinylcontrol.h
@@ -16,7 +16,7 @@ class VinylControl : public QObject {
 
     virtual void toggleVinylControl(bool enable);
     virtual bool isEnabled();
-    virtual void analyzeSamples(CSAMPLE* pSamples, size_t nFrames) = 0;
+    virtual void analyzeSamples(const CSAMPLE* pSamples, size_t nFrames) = 0;
     virtual bool writeQualityReport(VinylSignalQualityReport* qualityReportFifo) = 0;
 
   protected:

--- a/src/vinylcontrol/vinylcontrolmanager.cpp
+++ b/src/vinylcontrol/vinylcontrolmanager.cpp
@@ -74,6 +74,7 @@ void VinylControlManager::slotNumDecksChanged(double dNumDecks) {
         QString group = PlayerManager::groupForDeck(i);
         m_pVcEnabled.push_back(new ControlObjectThread(group, "vinylcontrol_enabled", this));
         m_pVcEnabled.back()->set(0);
+        m_pProcessor->deckAdded(group);
 
         ControlObject::set(ConfigKey(group, "vinylcontrol_mode"),
                            m_pConfig->getValueString(ConfigKey(VINYL_PREF_KEY, "mode")).toDouble());

--- a/src/vinylcontrol/vinylcontrolprocessor.cpp
+++ b/src/vinylcontrol/vinylcontrolprocessor.cpp
@@ -218,6 +218,8 @@ bool VinylControlProcessor::enabledDeckExists() const {
 }
 
 void VinylControlProcessor::toggleDeck(double value) {
+    QMutexLocker locker(&m_processorsLock);
+    int enabled = -1;
     if (!value)
         goto update_enabled;
 
@@ -234,9 +236,6 @@ void VinylControlProcessor::toggleDeck(double value) {
      */
 
     // -1 means we haven't found a proxy that's enabled
-    int enabled = -1;
-
-    QMutexLocker locker(&m_processorsLock);
 
     for (int i = 0; i < m_processors.size(); ++i) {
         VinylControl* pProcessor = m_processors.at(i);

--- a/src/vinylcontrol/vinylcontrolprocessor.h
+++ b/src/vinylcontrol/vinylcontrolprocessor.h
@@ -28,9 +28,6 @@ class VinylControlProcessor : public QObject, public AudioDestination {
     // Called from main thread. Must only touch m_bReportSignalQuality.
     void setSignalQualityReporting(bool enable);
 
-    // Called from the main thread. Must only touch m_bQuit;
-    void shutdown();
-
     // Called from the main thread. Must only touch m_bReload;
     void requestReloadConfig();
 
@@ -56,9 +53,6 @@ class VinylControlProcessor : public QObject, public AudioDestination {
     void receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
                        unsigned int iNumFrames);
 
-  protected:
-    void run();
-
   private slots:
     void toggleDeck(double value);
 
@@ -67,18 +61,11 @@ class VinylControlProcessor : public QObject, public AudioDestination {
 
     ConfigObject<ConfigValue>* m_pConfig;
     ControlPushButton* m_pToggle;
-    // A pre-allocated array of FIFOs for writing samples from the engine
-    // callback to the processor thread. There is a maximum of
-    // kMaximumVinylControlInputs pipes.
-    FIFO<CSAMPLE>* m_samplePipes[kMaximumVinylControlInputs];
     CSAMPLE* m_pWorkBuffer;
-    QWaitCondition m_samplesAvailableSignal;
-    QMutex m_waitForSampleMutex;
     QMutex m_processorsLock;
     QVector<VinylControl*> m_processors;
     FIFO<VinylSignalQualityReport> m_signalQualityFifo;
     volatile bool m_bReportSignalQuality;
-    volatile bool m_bQuit;
     volatile bool m_bReloadConfig;
 };
 

--- a/src/vinylcontrol/vinylcontrolprocessor.h
+++ b/src/vinylcontrol/vinylcontrolprocessor.h
@@ -1,6 +1,7 @@
 #ifndef VINYLCONTROLPROCESSOR_H
 #define VINYLCONTROLPROCESSOR_H
 
+#include <QAtomicPointer>
 #include <QObject>
 #include <QThread>
 #include <QVector>
@@ -40,6 +41,7 @@ class VinylControlProcessor : public QObject, public AudioDestination {
         return &m_signalQualityFifo;
     }
 
+    typedef QSharedPointer<VinylControl> SharedVC;
   public slots:
     virtual void onInputConfigured(AudioInput input);
     virtual void onInputUnconfigured(AudioInput input);
@@ -71,8 +73,7 @@ class VinylControlProcessor : public QObject, public AudioDestination {
     QList<ControlObjectSlave*> m_VCEnableds;
     ControlObjectSlave* m_pGuiTick;
     CSAMPLE* m_pWorkBuffer;
-    QMutex m_processorsLock;
-    QVector<VinylControl*> m_processors;
+    QVector<SharedVC> m_processors;
     bool m_processingActive;
     FIFO<VinylSignalQualityReport> m_signalQualityFifo;
     volatile bool m_bReportSignalQuality;

--- a/src/vinylcontrol/vinylcontrolprocessor.h
+++ b/src/vinylcontrol/vinylcontrolprocessor.h
@@ -19,7 +19,7 @@ class ControlPushButton;
 // the engine callback and feeding those samples to the VinylControl
 // classes. The most important thing is that the connection between the engine
 // callback and VinylControlProcessor (the receiveBuffer method) is lock-free.
-class VinylControlProcessor : public QThread, public AudioDestination {
+class VinylControlProcessor : public QObject, public AudioDestination {
     Q_OBJECT
   public:
     VinylControlProcessor(QObject* pParent, ConfigObject<ConfigValue>* pConfig);

--- a/src/vinylcontrol/vinylcontrolprocessor.h
+++ b/src/vinylcontrol/vinylcontrolprocessor.h
@@ -57,8 +57,6 @@ class VinylControlProcessor : public QObject, public AudioDestination {
     void toggleDeck(double value);
 
   private:
-    void reloadConfig();
-
     ConfigObject<ConfigValue>* m_pConfig;
     ControlPushButton* m_pToggle;
     CSAMPLE* m_pWorkBuffer;
@@ -66,7 +64,6 @@ class VinylControlProcessor : public QObject, public AudioDestination {
     QVector<VinylControl*> m_processors;
     FIFO<VinylSignalQualityReport> m_signalQualityFifo;
     volatile bool m_bReportSignalQuality;
-    volatile bool m_bReloadConfig;
 };
 
 

--- a/src/vinylcontrol/vinylcontrolprocessor.h
+++ b/src/vinylcontrol/vinylcontrolprocessor.h
@@ -32,6 +32,8 @@ class VinylControlProcessor : public QObject, public AudioDestination {
     // Called from the main thread. Must only touch m_bReload;
     void requestReloadConfig();
 
+    void deckAdded(QString group);
+
     bool deckConfigured(int index) const;
 
     FIFO<VinylSignalQualityReport>* getSignalQualityFifo() {
@@ -56,15 +58,22 @@ class VinylControlProcessor : public QObject, public AudioDestination {
 
   private slots:
     void slotGuiTick(double);
+    void slotVinylEnabled(double);
     void toggleDeck(double value);
 
   private:
+    // Returns the number of decks that are enabled. Does not hold the lock,
+    // so should only be used where the lock is already being held.
+    bool enabledDeckExists() const;
+
     ConfigObject<ConfigValue>* m_pConfig;
     ControlPushButton* m_pToggle;
+    QList<ControlObjectSlave*> m_VCEnableds;
     ControlObjectSlave* m_pGuiTick;
     CSAMPLE* m_pWorkBuffer;
     QMutex m_processorsLock;
     QVector<VinylControl*> m_processors;
+    bool m_processingActive;
     FIFO<VinylSignalQualityReport> m_signalQualityFifo;
     volatile bool m_bReportSignalQuality;
 };

--- a/src/vinylcontrol/vinylcontrolprocessor.h
+++ b/src/vinylcontrol/vinylcontrolprocessor.h
@@ -8,6 +8,7 @@
 #include <QWaitCondition>
 
 #include "configobject.h"
+#include "controlobjectslave.h"
 #include "util/fifo.h"
 #include "vinylcontrol/vinylsignalquality.h"
 #include "soundmanagerutil.h"
@@ -54,11 +55,13 @@ class VinylControlProcessor : public QObject, public AudioDestination {
                        unsigned int iNumFrames);
 
   private slots:
+    void slotGuiTick(double);
     void toggleDeck(double value);
 
   private:
     ConfigObject<ConfigValue>* m_pConfig;
     ControlPushButton* m_pToggle;
+    ControlObjectSlave* m_pGuiTick;
     CSAMPLE* m_pWorkBuffer;
     QMutex m_processorsLock;
     QVector<VinylControl*> m_processors;

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -197,7 +197,7 @@ bool VinylControlXwax::writeQualityReport(VinylSignalQualityReport* pReport) {
 }
 
 
-void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
+void VinylControlXwax::analyzeSamples(const CSAMPLE* pSamples, size_t nFrames) {
     ScopedTimer t("VinylControlXwax::analyzeSamples");
     CSAMPLE gain = m_pVinylControlInputGain->get();
     const int kChannels = 2;

--- a/src/vinylcontrol/vinylcontrolxwax.h
+++ b/src/vinylcontrol/vinylcontrolxwax.h
@@ -26,7 +26,7 @@ class VinylControlXwax : public VinylControl {
     virtual ~VinylControlXwax();
 
     static void freeLUTs();
-    void analyzeSamples(CSAMPLE* pSamples, size_t nFrames);
+    void analyzeSamples(const CSAMPLE* pSamples, size_t nFrames);
 
     virtual bool writeQualityReport(VinylSignalQualityReport* qualityReportFifo);
 


### PR DESCRIPTION
Get rid of the separate vinyl control processing threads.  Move various operations around to keep the engine thread operations as lightweight as possible. 
