### PR TITLE
Tell user that added directories have to be scanned.

### DIFF
--- a/src/dlgpreferences.cpp
+++ b/src/dlgpreferences.cpp
@@ -92,6 +92,8 @@ DlgPreferences::DlgPreferences(MixxxMainWindow * mixxx, SkinLoader* pSkinLoader,
     addPageWidget(m_wsound);
     m_wlibrary = new DlgPrefLibrary(this, m_pConfig, pLibrary);
     addPageWidget(m_wlibrary);
+    connect(m_wlibrary, SIGNAL(scanLibrary()),
+            mixxx, SLOT(slotScanLibrary()));
     m_wcontrols = new DlgPrefControls(this, mixxx, pSkinLoader, pPlayerManager, m_pConfig);
     addPageWidget(m_wcontrols);
     m_wwaveform = new DlgPrefWaveform(this, mixxx, m_pConfig);

--- a/src/dlgpreflibrary.cpp
+++ b/src/dlgpreflibrary.cpp
@@ -32,7 +32,8 @@ DlgPrefLibrary::DlgPrefLibrary(QWidget * parent,
         : DlgPreferencePage(parent),
           m_dirListModel(),
           m_pconfig(config),
-          m_pLibrary(pLibrary) {
+          m_pLibrary(pLibrary),
+          m_baddedDirectory(false) {
     setupUi(this);
     slotUpdate();
     checkbox_ID3_sync->setVisible(false);
@@ -62,6 +63,35 @@ DlgPrefLibrary::DlgPrefLibrary(QWidget * parent,
 }
 
 DlgPrefLibrary::~DlgPrefLibrary() {
+}
+
+void DlgPrefLibrary::slotShow() {
+    m_baddedDirectory = false;
+}
+
+void DlgPrefLibrary::slotHide() {
+    if (!m_baddedDirectory) {
+        return;
+    }
+
+    QMessageBox msgBox;
+    msgBox.setIcon(QMessageBox::Warning);
+    msgBox.setWindowTitle(tr("Added Directory"));
+    msgBox.setText(tr(
+        "You added one or more library directories. These files won't be"
+        "available until you rescan. Would you like to rescan now?"));
+    QPushButton* scanButton = msgBox.addButton(
+        tr("Rescan now"), QMessageBox::AcceptRole);
+    QPushButton* laterButton = msgBox.addButton(
+        tr("Rescan later"), QMessageBox::AcceptRole);
+    msgBox.setDefaultButton(scanButton);
+    msgBox.exec();
+
+    if (msgBox.clickedButton() == laterButton) {
+        return;
+    }
+
+    emit(scanLibrary());
 }
 
 void DlgPrefLibrary::initialiseDirList(){
@@ -140,17 +170,8 @@ void DlgPrefLibrary::slotAddDir() {
     if (!fd.isEmpty()) {
         emit(requestAddDir(fd));
         slotUpdate();
+        m_baddedDirectory = true;
     }
-
-    QMessageBox addMsgBox;
-
-    addMsgBox.setIcon(QMessageBox::Warning);
-    addMsgBox.setWindowTitle(tr("Added Directory"));
-
-    addMsgBox.setText(tr(
-        "Please rescan the library to add the new tracks in Folder: ") + fd);
-
-    addMsgBox.exec();
 }
 
 void DlgPrefLibrary::slotRemoveDir() {

--- a/src/dlgpreflibrary.cpp
+++ b/src/dlgpreflibrary.cpp
@@ -141,6 +141,16 @@ void DlgPrefLibrary::slotAddDir() {
         emit(requestAddDir(fd));
         slotUpdate();
     }
+
+    QMessageBox addMsgBox;
+
+    addMsgBox.setIcon(QMessageBox::Warning);
+    addMsgBox.setWindowTitle(tr("Added Directory"));
+
+    addMsgBox.setText(tr(
+        "Please rescan the library to add the new tracks in Folder: ") + fd);
+
+    addMsgBox.exec();
 }
 
 void DlgPrefLibrary::slotRemoveDir() {

--- a/src/dlgpreflibrary.cpp
+++ b/src/dlgpreflibrary.cpp
@@ -81,17 +81,16 @@ void DlgPrefLibrary::slotHide() {
         "You added one or more library directories. These files won't be"
         "available until you rescan. Would you like to rescan now?"));
     QPushButton* scanButton = msgBox.addButton(
-        tr("Rescan now"), QMessageBox::AcceptRole);
-    QPushButton* laterButton = msgBox.addButton(
-        tr("Rescan later"), QMessageBox::AcceptRole);
+        tr("Scan"), QMessageBox::AcceptRole);
+    msgBox.addButton(
+        tr("Cancel"), QMessageBox::AcceptRole);
     msgBox.setDefaultButton(scanButton);
     msgBox.exec();
 
-    if (msgBox.clickedButton() == laterButton) {
+    if (msgBox.clickedButton() == scanButton) {
+        emit(scanLibrary());
         return;
     }
-
-    emit(scanLibrary());
 }
 
 void DlgPrefLibrary::initialiseDirList(){

--- a/src/dlgpreflibrary.h
+++ b/src/dlgpreflibrary.h
@@ -46,6 +46,8 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
   public slots:
     // Common preference page slots.
     void slotUpdate();
+    void slotShow();
+    void slotHide();
     void slotResetToDefaults();
     void slotApply();
 
@@ -57,6 +59,7 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
 
   signals:
     void apply();
+    void scanLibrary();
     void requestAddDir(QString dir);
     void requestRemoveDir(QString dir, Library::RemovalType removalType);
     void requestRelocateDir(QString currentDir, QString newDir);
@@ -66,6 +69,7 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     QStandardItemModel m_dirListModel;
     ConfigObject<ConfigValue>* m_pconfig;
     Library *m_pLibrary;
+    bool m_baddedDirectory;
 };
 
 #endif

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -137,6 +137,32 @@ void BrowseFeature::slotAddToLibrary() {
     }
     QString spath = m_pLastRightClickedItem->dataPath().toString();
     emit(requestAddDir(spath));
+
+    QMessageBox msgBox;
+    msgBox.setIcon(QMessageBox::Warning);
+    msgBox.setWindowTitle(tr("Added Directory"));
+    msgBox.setText(tr(
+        "You added one library directory. These files won't be"
+        "available until you rescan. Would you like to rescan now?"
+        "Note that you cannot add more directories until the scan is finished."));
+    QPushButton* scanButton = msgBox.addButton(
+        tr("Rescan now"), QMessageBox::AcceptRole);
+    msgBox.addButton(
+        tr("Rescan later"), QMessageBox::AcceptRole);
+    msgBox.setDefaultButton(scanButton);
+    msgBox.exec();
+
+    if (msgBox.clickedButton() == reinterpret_cast<QAbstractButton*>(scanButton)) {
+        emit(scanLibrary());
+    }
+}
+
+void BrowseFeature::slotLibraryScanStarted() {
+    m_pAddtoLibraryAction->setEnabled(false);
+}
+
+void BrowseFeature::slotLibraryScanFinished() {
+    m_pAddtoLibraryAction->setEnabled(true);
 }
 
 void BrowseFeature::slotRemoveQuickLink() {

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -9,6 +9,7 @@
 #include <QDesktopServices>
 #include <QAction>
 #include <QMenu>
+#include <QPushButton>
 
 #include "trackinfoobject.h"
 #include "library/treeitem.h"
@@ -140,19 +141,19 @@ void BrowseFeature::slotAddToLibrary() {
 
     QMessageBox msgBox;
     msgBox.setIcon(QMessageBox::Warning);
+    // strings are dupes from DlgPrefLibrary
     msgBox.setWindowTitle(tr("Added Directory"));
     msgBox.setText(tr(
-        "You added one library directory. These files won't be"
-        "available until you rescan. Would you like to rescan now?"
-        "Note that you cannot add more directories until the scan is finished."));
+        "You added one or more library directories. These files won't be"
+        "available until you rescan. Would you like to rescan now?"));
     QPushButton* scanButton = msgBox.addButton(
-        tr("Rescan now"), QMessageBox::AcceptRole);
+        tr("Scan"), QMessageBox::AcceptRole);
     msgBox.addButton(
-        tr("Rescan later"), QMessageBox::AcceptRole);
+        tr("Cancel"), QMessageBox::AcceptRole);
     msgBox.setDefaultButton(scanButton);
     msgBox.exec();
 
-    if (msgBox.clickedButton() == reinterpret_cast<QAbstractButton*>(scanButton)) {
+    if (msgBox.clickedButton() == scanButton) {
         emit(scanLibrary());
     }
 }

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -49,10 +49,13 @@ class BrowseFeature : public LibraryFeature {
     void activateChild(const QModelIndex& index);
     void onRightClickChild(const QPoint& globalPos, QModelIndex index);
     void onLazyChildExpandation(const QModelIndex& index);
+    void slotLibraryScanStarted();
+    void slotLibraryScanFinished();
 
   signals:
     void setRootIndex(const QModelIndex&);
     void requestAddDir(QString);
+    void scanLibrary();
 
   private:
     QString getRootViewHtml() const;

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -56,7 +56,15 @@ Library::Library(QObject* parent, ConfigObject<ConfigValue>* pConfig,
     addFeature(m_pPlaylistFeature);
     m_pCrateFeature = new CrateFeature(this, m_pTrackCollection, m_pConfig);
     addFeature(m_pCrateFeature);
-    addFeature(new BrowseFeature(this, pConfig, m_pTrackCollection, m_pRecordingManager));
+    BrowseFeature* browseFeature = new BrowseFeature(
+        this, pConfig, m_pTrackCollection, m_pRecordingManager);
+    connect(browseFeature, SIGNAL(scanLibrary()),
+            parent, SLOT(slotScanLibrary()));
+    connect(parent, SIGNAL(libraryScanStarted()),
+            browseFeature, SLOT(slotLibraryScanStarted()));
+    connect(parent, SIGNAL(libraryScanFinished()),
+            browseFeature, SLOT(slotLibraryScanFinished()));
+    addFeature(browseFeature);
     addFeature(new RecordingFeature(this, pConfig, m_pTrackCollection, m_pRecordingManager));
     addFeature(new SetlogFeature(this, pConfig, m_pTrackCollection));
     m_pAnalysisFeature = new AnalysisFeature(this, pConfig, m_pTrackCollection);

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1861,12 +1861,14 @@ void MixxxMainWindow::closeEvent(QCloseEvent *event) {
 }
 
 void MixxxMainWindow::slotScanLibrary() {
+    emit(libraryScanStarted());
     m_pLibraryRescan->setEnabled(false);
     m_pLibraryScanner->scan(this);
 }
 
 void MixxxMainWindow::slotEnableRescanLibraryAction() {
     m_pLibraryRescan->setEnabled(true);
+    emit(libraryScanFinished());
 }
 
 void MixxxMainWindow::slotOptionsMenuShow() {

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -137,6 +137,8 @@ class MixxxMainWindow : public QMainWindow {
 
   signals:
     void newSkinLoaded();
+    void libraryScanStarted();
+    void libraryScanFinished();
 
   protected:
     // Event filter to block certain events (eg. tooltips if tooltips are disabled)


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1273333

I added a message box to tell the user that a rescan of the library is required. 

In the bug report we talked about starting the library scan when a new directory is added. But that would inhibit use from adding more directories until the scan is finished. This is because as far as I'm aware that we can't write to the database from two different threads at the same time. So I think until we have moved the database access to a another thread I think this the best we can do.
