### PR TITLE
Bug 1160043: To make end of track flash user configurable

### DIFF
--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -77,7 +77,10 @@ BaseTrackPlayer::BaseTrackPlayer(QObject* pParent,
 
     m_pEndOfTrack = new ControlObject(ConfigKey(group, "end_of_track"));
     m_pEndOfTrack->set(0.);
-
+    m_pLowFilterControlObject = new ControlObjectThread(group,"filterLow");
+    m_pMidFilterControlObject = new ControlObjectThread(group,"filterMid");
+    m_pHighFilterControlObject = new ControlObjectThread(group,"filterHigh");
+    m_pPreGain = new ControlObjectThread(ConfigKey(group, "pregain"));
     //BPM of the current song
     m_pBPM = new ControlObjectThread(group, "file_bpm");
     m_pKey = new ControlObjectThread(group, "file_key");
@@ -241,6 +244,12 @@ void BaseTrackPlayer::slotFinishLoading(TrackPointer pTrackInfoObject)
                 break;
             }
         }
+    }
+    if(m_pConfig->getValueString(ConfigKey("[Mixer Profile]", "EqAutoReset")).toInt()) {
+        m_pLowFilterControlObject->set(1.0);
+        m_pMidFilterControlObject->set(1.0);
+        m_pHighFilterControlObject->set(1.0);
+        m_pPreGain->set(1.0);
     }
 
     emit(newTrackLoaded(m_pLoadedTrack));

--- a/src/basetrackplayer.h
+++ b/src/basetrackplayer.h
@@ -61,6 +61,10 @@ class BaseTrackPlayer : public BasePlayer {
     ControlObjectThread* m_pKey;
     ControlObjectThread* m_pReplayGain;
     ControlObjectThread* m_pPlay;
+    ControlObjectThread* m_pLowFilterControlObject;
+    ControlObjectThread* m_pMidFilterControlObject;
+    ControlObjectThread* m_pHighFilterControlObject;
+    ControlObjectThread* m_pPreGain;
     EngineDeck* m_pChannel;
 };
 

--- a/src/dlgprefeq.cpp
+++ b/src/dlgprefeq.cpp
@@ -37,9 +37,9 @@ DlgPrefEQ::DlgPrefEQ(QWidget* pParent, ConfigObject<ConfigValue>* pConfig)
           m_COTEnableEq(CONFIG_KEY, ENABLE_INTERNAL_EQ),
           m_pConfig(pConfig),
           m_lowEqFreq(0.0),
+          m_bEqAutoReset(false),
           m_highEqFreq(0.0) {
     setupUi(this);
-
     // Connection
     connect(SliderHiEQ, SIGNAL(valueChanged(int)), this, SLOT(slotUpdateHiEQ()));
     connect(SliderHiEQ, SIGNAL(sliderMoved(int)), this, SLOT(slotUpdateHiEQ()));
@@ -52,7 +52,7 @@ DlgPrefEQ::DlgPrefEQ(QWidget* pParent, ConfigObject<ConfigValue>* pConfig)
     connect(radioButton_bypass, SIGNAL(clicked()), this, SLOT(slotEqChanged()));
     connect(radioButton_bessel4, SIGNAL(clicked()), this, SLOT(slotEqChanged()));
     connect(radioButton_butterworth8, SIGNAL(clicked()), this, SLOT(slotEqChanged()));
-
+    connect(bEqAutoReset, SIGNAL(stateChanged(int)), this, SLOT(slotEqAutoReset(int)));
     loadSettings();
     slotUpdate();
     slotApply();
@@ -66,6 +66,7 @@ void DlgPrefEQ::loadSettings() {
     QString highEqPrecise = m_pConfig->getValueString(ConfigKey(CONFIG_KEY, "HiEQFrequencyPrecise"));
     QString lowEqCourse = m_pConfig->getValueString(ConfigKey(CONFIG_KEY, "LoEQFrequency"));
     QString lowEqPrecise = m_pConfig->getValueString(ConfigKey(CONFIG_KEY, "LoEQFrequencyPrecise"));
+    m_bEqAutoReset = static_cast<bool>(m_pConfig->getValueString(ConfigKey(CONFIG_KEY, "EqAutoReset")).toInt());
 
     double lowEqFreq = 0.0;
     double highEqFreq = 0.0;
@@ -121,6 +122,7 @@ void DlgPrefEQ::slotResetToDefaults() {
     radioButton_bypass->setChecked(false);
     radioButton_butterworth8->setChecked(false);
     radioButton_bessel4->setChecked(true);
+    m_bEqAutoReset = false;
     slotEqChanged();
     setDefaultShelves();
     loadSettings();
@@ -207,7 +209,9 @@ int DlgPrefEQ::getSliderPosition(double eqFreq, int minValue, int maxValue)
 void DlgPrefEQ::slotApply() {
     m_COTLoFreq.slotSet(m_lowEqFreq);
     m_COTHiFreq.slotSet(m_highEqFreq);
-
+    
+    m_pConfig->set(ConfigKey(CONFIG_KEY,"EqAutoReset"),
+            ConfigValue(m_bEqAutoReset? 1 : 0));
     m_COTLoFi.slotSet((m_pConfig->getValueString(
             ConfigKey(CONFIG_KEY, "LoFiEQs")) == QString("yes")));
     m_COTEnableEq.slotSet((m_pConfig->getValueString(
@@ -218,6 +222,12 @@ void DlgPrefEQ::slotUpdate() {
     slotUpdateLoEQ();
     slotUpdateHiEQ();
     slotEqChanged();
+    bEqAutoReset->setChecked(m_bEqAutoReset);
+}
+
+void DlgPrefEQ::slotEqAutoReset(int i) {
+    m_bEqAutoReset = static_cast<bool>(i);
+    slotUpdate();
 }
 
 double DlgPrefEQ::getEqFreq(int sliderVal, int minValue, int maxValue) {

--- a/src/dlgprefeq.h
+++ b/src/dlgprefeq.h
@@ -29,12 +29,12 @@
 /**
   *@author John Sully
   */
-
 class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     Q_OBJECT
   public:
     DlgPrefEQ(QWidget *parent, ConfigObject<ConfigValue>* _config);
     virtual ~DlgPrefEQ();
+    bool m_bEqAutoReset;
 
   public slots:
     void slotEqChanged();
@@ -46,6 +46,7 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     void slotApply();
     void slotUpdate();
     void slotResetToDefaults();
+    void slotEqAutoReset(int);
 
   signals:
     void apply(const QString &);

--- a/src/dlgprefeqdlg.ui
+++ b/src/dlgprefeqdlg.ui
@@ -55,6 +55,13 @@
        </attribute>
       </widget>
      </item>
+     <item>
+      <widget class="QCheckBox" name="bEqAutoReset">
+       <property name="text">
+        <string>Enable Equalizer Auto Reset</string>
+       </property>
+      </widget>
+     </item> 
     </layout>
    </item>
    <item>

--- a/src/dlgprefwaveform.cpp
+++ b/src/dlgprefwaveform.cpp
@@ -34,15 +34,18 @@ DlgPrefWaveform::DlgPrefWaveform(QWidget* pParent, MixxxMainWindow* pMixxx,
     // slotUpdate can generate rebootMixxxView calls.
     // TODO(XXX): Improve this awkwardness.
     slotUpdate();
-    ControlObject* p_endTime = new ControlObject(ConfigKey("[Waveform]", "endTime"));
     connect(frameRateSpinBox, SIGNAL(valueChanged(int)),
             this, SLOT(slotSetFrameRate(int)));
     connect(endTimeSpinBox, SIGNAL(valueChanged(int)),
             this, SLOT(slotSetWaveformEndRender(int)));
     connect(frameRateSlider, SIGNAL(valueChanged(int)),
             frameRateSpinBox, SLOT(setValue(int)));
+    connect(frameRateSpinBox, SIGNAL(valueChanged(int)),
+            frameRateSlider, SLOT(setValue(int)));
     connect(endTimeSlider, SIGNAL(valueChanged(int)),
             endTimeSpinBox, SLOT(setValue(int)));
+    connect(endTimeSpinBox, SIGNAL(valueChanged(int)),
+            endTimeSlider, SLOT(setValue(int)));
 
     connect(waveformTypeComboBox, SIGNAL(activated(int)),
             this, SLOT(slotSetWaveformType(int)));

--- a/src/dlgprefwaveform.cpp
+++ b/src/dlgprefwaveform.cpp
@@ -34,13 +34,15 @@ DlgPrefWaveform::DlgPrefWaveform(QWidget* pParent, MixxxMainWindow* pMixxx,
     // slotUpdate can generate rebootMixxxView calls.
     // TODO(XXX): Improve this awkwardness.
     slotUpdate();
-
+    ControlObject* p_endTime = new ControlObject(ConfigKey("[Waveform]", "endTime"));
     connect(frameRateSpinBox, SIGNAL(valueChanged(int)),
             this, SLOT(slotSetFrameRate(int)));
-    connect(frameRateSpinBox, SIGNAL(valueChanged(int)),
-            frameRateSlider, SLOT(setValue(int)));
+    connect(endTimeSpinBox, SIGNAL(valueChanged(int)),
+            this, SLOT(slotSetWaveformEndRender(int)));
     connect(frameRateSlider, SIGNAL(valueChanged(int)),
             frameRateSpinBox, SLOT(setValue(int)));
+    connect(endTimeSlider, SIGNAL(valueChanged(int)),
+            endTimeSpinBox, SLOT(setValue(int)));
 
     connect(waveformTypeComboBox, SIGNAL(activated(int)),
             this, SLOT(slotSetWaveformType(int)));
@@ -84,6 +86,8 @@ void DlgPrefWaveform::slotUpdate() {
 
     frameRateSpinBox->setValue(factory->getFrameRate());
     frameRateSlider->setValue(factory->getFrameRate());
+    endTimeSpinBox->setValue(factory->getEndTime());
+    endTimeSlider->setValue(factory->getEndTime());
     synchronizeZoomCheckBox->setChecked(factory->isZoomSync());
     allVisualGain->setValue(factory->getVisualGain(WaveformWidgetFactory::All));
     lowVisualGain->setValue(factory->getVisualGain(WaveformWidgetFactory::Low));
@@ -133,12 +137,15 @@ void DlgPrefWaveform::slotResetToDefaults() {
 
     // 30FPS is the default
     frameRateSlider->setValue(30);
+    endTimeSlider->setValue(30);
 }
 
 void DlgPrefWaveform::slotSetFrameRate(int frameRate) {
     WaveformWidgetFactory::instance()->setFrameRate(frameRate);
 }
-
+void DlgPrefWaveform::slotSetWaveformEndRender(int endTime) {
+    WaveformWidgetFactory::instance()->setEndTime(endTime);
+}
 void DlgPrefWaveform::slotSetWaveformType(int index) {
     // Ignore sets for -1 since this happens when we clear the combobox.
     if (index < 0) {

--- a/src/dlgprefwaveform.cpp
+++ b/src/dlgprefwaveform.cpp
@@ -36,16 +36,16 @@ DlgPrefWaveform::DlgPrefWaveform(QWidget* pParent, MixxxMainWindow* pMixxx,
     slotUpdate();
     connect(frameRateSpinBox, SIGNAL(valueChanged(int)),
             this, SLOT(slotSetFrameRate(int)));
-    connect(endTimeSpinBox, SIGNAL(valueChanged(int)),
+    connect(endOfTrackWarningTimeSpinBox, SIGNAL(valueChanged(int)),
             this, SLOT(slotSetWaveformEndRender(int)));
     connect(frameRateSlider, SIGNAL(valueChanged(int)),
             frameRateSpinBox, SLOT(setValue(int)));
     connect(frameRateSpinBox, SIGNAL(valueChanged(int)),
             frameRateSlider, SLOT(setValue(int)));
-    connect(endTimeSlider, SIGNAL(valueChanged(int)),
-            endTimeSpinBox, SLOT(setValue(int)));
-    connect(endTimeSpinBox, SIGNAL(valueChanged(int)),
-            endTimeSlider, SLOT(setValue(int)));
+    connect(endOfTrackWarningTimeSlider, SIGNAL(valueChanged(int)),
+            endOfTrackWarningTimeSpinBox, SLOT(setValue(int)));
+    connect(endOfTrackWarningTimeSpinBox, SIGNAL(valueChanged(int)),
+            endOfTrackWarningTimeSlider, SLOT(setValue(int)));
 
     connect(waveformTypeComboBox, SIGNAL(activated(int)),
             this, SLOT(slotSetWaveformType(int)));
@@ -89,8 +89,8 @@ void DlgPrefWaveform::slotUpdate() {
 
     frameRateSpinBox->setValue(factory->getFrameRate());
     frameRateSlider->setValue(factory->getFrameRate());
-    endTimeSpinBox->setValue(factory->getEndTime());
-    endTimeSlider->setValue(factory->getEndTime());
+    endOfTrackWarningTimeSpinBox->setValue(factory->getEndOfTrackWarningTime());
+    endOfTrackWarningTimeSlider->setValue(factory->getEndOfTrackWarningTime());
     synchronizeZoomCheckBox->setChecked(factory->isZoomSync());
     allVisualGain->setValue(factory->getVisualGain(WaveformWidgetFactory::All));
     lowVisualGain->setValue(factory->getVisualGain(WaveformWidgetFactory::Low));
@@ -140,14 +140,14 @@ void DlgPrefWaveform::slotResetToDefaults() {
 
     // 30FPS is the default
     frameRateSlider->setValue(30);
-    endTimeSlider->setValue(30);
+    endOfTrackWarningTimeSlider->setValue(30);
 }
 
 void DlgPrefWaveform::slotSetFrameRate(int frameRate) {
     WaveformWidgetFactory::instance()->setFrameRate(frameRate);
 }
 void DlgPrefWaveform::slotSetWaveformEndRender(int endTime) {
-    WaveformWidgetFactory::instance()->setEndTime(endTime);
+    WaveformWidgetFactory::instance()->setEndOfTrackWarningTime(endTime);
 }
 void DlgPrefWaveform::slotSetWaveformType(int index) {
     // Ignore sets for -1 since this happens when we clear the combobox.

--- a/src/dlgprefwaveform.h
+++ b/src/dlgprefwaveform.h
@@ -5,6 +5,8 @@
 
 #include "ui_dlgprefwaveformdlg.h"
 #include "configobject.h"
+#include "controlobject.h"
+#include "controlobjectthread.h"
 #include "preferences/dlgpreferencepage.h"
 
 class MixxxMainWindow;
@@ -20,6 +22,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotUpdate();
     void slotApply();
     void slotResetToDefaults();
+    void slotSetWaveformEndRender(int endTime);
 
   private slots:
     void slotSetFrameRate(int frameRate);

--- a/src/dlgprefwaveform.h
+++ b/src/dlgprefwaveform.h
@@ -5,8 +5,6 @@
 
 #include "ui_dlgprefwaveformdlg.h"
 #include "configobject.h"
-#include "controlobject.h"
-#include "controlobjectthread.h"
 #include "preferences/dlgpreferencepage.h"
 
 class MixxxMainWindow;

--- a/src/dlgprefwaveformdlg.ui
+++ b/src/dlgprefwaveformdlg.ui
@@ -59,7 +59,7 @@
       </widget>
      </item> 
      <item row="10" column="3">
-      <widget class="QSpinBox" name="endTimeSpinBox">
+      <widget class="QSpinBox" name="endOfTrackWarningTimeSpinBox">
        <property name="toolTip">
         <string/>
        </property>
@@ -75,15 +75,15 @@
       </widget>
      </item>
     <item row="10" column="0">
-      <widget class="QLabel" name="endTimeLabel">
+      <widget class="QLabel" name="endOfTrackWarningTimeLabel">
        <property name="text">
-        <string>End track waveform flash</string>
+        <string>End of track warning time</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
        </property>
        <property name="buddy">
-        <cstring>endTimeSlider</cstring>
+        <cstring>endOfTrackWarningTimeSlider</cstring>
        </property>
       </widget>
      </item>
@@ -208,7 +208,7 @@
       </widget>
      </item>
      <item row="10" column="1" colspan="2">
-      <widget class="QSlider" name="endTimeSlider">
+      <widget class="QSlider" name="endOfTrackWarningTimeSlider">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>

--- a/src/dlgprefwaveformdlg.ui
+++ b/src/dlgprefwaveformdlg.ui
@@ -57,6 +57,35 @@
         <cstring>frameRateSlider</cstring>
        </property>
       </widget>
+     </item> 
+     <item row="10" column="3">
+      <widget class="QSpinBox" name="endTimeSpinBox">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>60</number>
+       </property>
+       <property name="value">
+        <number>30</number>
+       </property>
+      </widget>
+     </item>
+    <item row="10" column="0">
+      <widget class="QLabel" name="endTimeLabel">
+       <property name="text">
+        <string>End track waveform flash</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+       <property name="buddy">
+        <cstring>endTimeSlider</cstring>
+       </property>
+      </widget>
      </item>
      <item row="0" column="0">
       <widget class="QLabel" name="waveformTypeLabel">
@@ -175,6 +204,34 @@
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1" colspan="2">
+      <widget class="QSlider" name="endTimeSlider">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>60</number>
+       </property>
+       <property name="value">
+        <number>30</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
       </widget>
      </item>

--- a/src/waveform/renderers/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/waveformrendererendoftrack.cpp
@@ -3,7 +3,6 @@
 #include <QPainter>
 
 #include "waveformrendererendoftrack.h"
-
 #include "waveformwidgetrenderer.h"
 
 #include "controlobject.h"
@@ -23,8 +22,8 @@ WaveformRendererEndOfTrack::WaveformRendererEndOfTrack(
       m_pPlayControl(NULL),
       m_pLoopControl(NULL),
       m_color(200, 25, 20),
-      m_blinkingPeriodMillis(1000),
-      m_remainingTimeTriggerSeconds(30.0) {
+      m_remainingTimeTriggerSeconds(30),
+      m_blinkingPeriodMillis(1000){
 }
 
 WaveformRendererEndOfTrack::~WaveformRendererEndOfTrack() {
@@ -82,7 +81,6 @@ void WaveformRendererEndOfTrack::draw(QPainter* painter,
 
     const double trackSamples = m_waveformRenderer->getTrackSamples();
     const double sampleRate = m_pTrackSampleRate->get();
-
     /*qDebug() << "WaveformRendererEndOfTrack :: "
              << "trackSamples" << trackSamples
              << "sampleRate" << sampleRate
@@ -90,8 +88,8 @@ void WaveformRendererEndOfTrack::draw(QPainter* painter,
              << "m_loopControl->get()" << m_loopControl->get();*/
 
     m_endOfTrackEnabled = m_pEndOfTrackControl->get() > 0.5;
-
-    //special case of track not long enougth
+    m_remainingTimeTriggerSeconds = WaveformWidgetFactory::instance()->getEndTime();
+    //special case of track not long enough
     const double trackLength = 0.5 * trackSamples / sampleRate;
 
     if (sampleRate < 0.1 //not ready

--- a/src/waveform/renderers/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/waveformrendererendoftrack.cpp
@@ -88,7 +88,7 @@ void WaveformRendererEndOfTrack::draw(QPainter* painter,
              << "m_loopControl->get()" << m_loopControl->get();*/
 
     m_endOfTrackEnabled = m_pEndOfTrackControl->get() > 0.5;
-    m_remainingTimeTriggerSeconds = WaveformWidgetFactory::instance()->getEndTime();
+    m_remainingTimeTriggerSeconds = WaveformWidgetFactory::instance()->getEndOfTrackWarningTime();
     //special case of track not long enough
     const double trackLength = 0.5 * trackSamples / sampleRate;
 

--- a/src/waveform/renderers/waveformrendererendoftrack.h
+++ b/src/waveform/renderers/waveformrendererendoftrack.h
@@ -5,12 +5,15 @@
 #include <QTime>
 //#include <QLinearGradient>
 
+#include "configobject.h"
 #include "util.h"
 #include "waveformrendererabstract.h"
 #include "skin/skincontext.h"
+#include "waveform/waveformwidgetfactory.h"
 
 class ControlObject;
 class ControlObjectThread;
+class WaveformWidgetFacctory;
 
 class WaveformRendererEndOfTrack : public WaveformRendererAbstract {
   public:
@@ -27,15 +30,14 @@ class WaveformRendererEndOfTrack : public WaveformRendererAbstract {
   private:
     ControlObjectThread*  m_pEndOfTrackControl;
     bool m_endOfTrackEnabled;
-
     ControlObjectThread* m_pTrackSampleRate;
     ControlObjectThread* m_pPlayControl;
     ControlObjectThread* m_pLoopControl;
 
     QColor m_color;
     QTime m_timer;
+    int m_remainingTimeTriggerSeconds;
     int m_blinkingPeriodMillis;
-    double m_remainingTimeTriggerSeconds;
 
     QVector<QRect> m_backRects;
     QPen m_pen;

--- a/src/waveform/renderers/waveformrendererendoftrack.h
+++ b/src/waveform/renderers/waveformrendererendoftrack.h
@@ -5,7 +5,6 @@
 #include <QTime>
 //#include <QLinearGradient>
 
-#include "configobject.h"
 #include "util.h"
 #include "waveformrendererabstract.h"
 #include "skin/skincontext.h"
@@ -13,7 +12,6 @@
 
 class ControlObject;
 class ControlObjectThread;
-class WaveformWidgetFacctory;
 
 class WaveformRendererEndOfTrack : public WaveformRendererAbstract {
   public:

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -60,7 +60,7 @@ WaveformWidgetFactory::WaveformWidgetFactory() :
         m_config(0),
         m_skipRender(false),
         m_frameRate(30),
-        m_endTime(30),
+        m_endOfTrackWarningTime(30),
         m_defaultZoom(3),
         m_zoomSync(false),
         m_overviewNormalized(false),
@@ -169,12 +169,12 @@ bool WaveformWidgetFactory::setConfig(ConfigObject<ConfigValue> *config) {
         m_config->set(ConfigKey("[Waveform]","FrameRate"), ConfigValue(m_frameRate));
     }
     
-    int endTime = m_config->getValueString(ConfigKey("[Waveform]","EndTime")).toInt(&ok);
+    int endTime = m_config->getValueString(ConfigKey("[Waveform]","EndOfTrackWarningTime")).toInt(&ok);
     if (ok) {
-        setEndTime(endTime);
+        setEndOfTrackWarningTime(endTime);
     } else {
-        m_config->set(ConfigKey("[Waveform]","EndTime"), ConfigValue(m_endTime));
-        }
+        m_config->set(ConfigKey("[Waveform]","EndOfTrackWarningTime"), ConfigValue(m_endOfTrackWarningTime));
+    }
 
     int vsync = m_config->getValueString(ConfigKey("[Waveform]","VSync"),"0").toInt();
     setVSyncType(vsync);
@@ -281,10 +281,10 @@ void WaveformWidgetFactory::setFrameRate(int frameRate) {
     m_vsyncThread->setUsSyncIntervalTime(1e6 / m_frameRate);
 }
 
-void WaveformWidgetFactory::setEndTime(int endTime) {
-    m_endTime = math_clamp(endTime, 0, 60);
+void WaveformWidgetFactory::setEndOfTrackWarningTime(int endTime) {
+    m_endOfTrackWarningTime = endTime;
     if (m_config) {
-        m_config->set(ConfigKey("[Waveform]","EndTime"), ConfigValue(m_endTime));
+        m_config->set(ConfigKey("[Waveform]","EndOfTrackWarningTime"), ConfigValue(m_endOfTrackWarningTime));
     }  
 }
 

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -60,6 +60,7 @@ WaveformWidgetFactory::WaveformWidgetFactory() :
         m_config(0),
         m_skipRender(false),
         m_frameRate(30),
+        m_endTime(30),
         m_defaultZoom(3),
         m_zoomSync(false),
         m_overviewNormalized(false),
@@ -167,6 +168,13 @@ bool WaveformWidgetFactory::setConfig(ConfigObject<ConfigValue> *config) {
     } else {
         m_config->set(ConfigKey("[Waveform]","FrameRate"), ConfigValue(m_frameRate));
     }
+    
+    int endTime = m_config->getValueString(ConfigKey("[Waveform]","EndTime")).toInt(&ok);
+    if (ok) {
+        setEndTime(endTime);
+    } else {
+        m_config->set(ConfigKey("[Waveform]","EndTime"), ConfigValue(m_endTime));
+        }
 
     int vsync = m_config->getValueString(ConfigKey("[Waveform]","VSync"),"0").toInt();
     setVSyncType(vsync);
@@ -273,6 +281,12 @@ void WaveformWidgetFactory::setFrameRate(int frameRate) {
     m_vsyncThread->setUsSyncIntervalTime(1e6 / m_frameRate);
 }
 
+void WaveformWidgetFactory::setEndTime(int endTime) {
+    m_endTime = math_clamp(endTime, 0, 60);
+    if (m_config) {
+        m_config->set(ConfigKey("[Waveform]","EndTime"), ConfigValue(m_endTime));
+    }  
+}
 
 void WaveformWidgetFactory::setVSyncType(int type) {
     if (m_config) {

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -68,6 +68,8 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void setFrameRate(int frameRate);
     int getFrameRate() const { return m_frameRate;}
 //    bool getVSync() const { return m_vSyncType;}
+    void setEndTime(int endTime);
+    int getEndTime() const { return m_endTime;}
 
     bool isOpenGLAvailable() const { return m_openGLAvailable;}
     QString getOpenGLVersion() const { return m_openGLVersion;}
@@ -136,6 +138,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
 
     bool m_skipRender;
     int m_frameRate;
+    int m_endTime;
     int m_defaultZoom;
     bool m_zoomSync;
     double m_visualGain[FilterCount];

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -68,8 +68,8 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void setFrameRate(int frameRate);
     int getFrameRate() const { return m_frameRate;}
 //    bool getVSync() const { return m_vSyncType;}
-    void setEndTime(int endTime);
-    int getEndTime() const { return m_endTime;}
+    void setEndOfTrackWarningTime(int endTime);
+    int getEndOfTrackWarningTime() const { return m_endOfTrackWarningTime;}
 
     bool isOpenGLAvailable() const { return m_openGLAvailable;}
     QString getOpenGLVersion() const { return m_openGLVersion;}
@@ -138,7 +138,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
 
     bool m_skipRender;
     int m_frameRate;
-    int m_endTime;
+    int m_endOfTrackWarningTime;
     int m_defaultZoom;
     bool m_zoomSync;
     double m_visualGain[FilterCount];


### PR DESCRIPTION
Added spinbox/slider in Prefrences->waveform.
 Currently, the timer ranges from 0 (no flash)
to 60 secs before the end of track.
