### PR TITLE
SizeAwareStack

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -663,6 +663,7 @@ class MixxxCore(Feature):
                    "widget/wwidget.cpp",
                    "widget/wwidgetgroup.cpp",
                    "widget/wwidgetstack.cpp",
+                   "widget/wsizeawarestack.cpp",
                    "widget/wlabel.cpp",
                    "widget/wtracktext.cpp",
                    "widget/wnumber.cpp",

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -64,6 +64,7 @@
 #include "widget/wskincolor.h"
 #include "widget/wpixmapstore.h"
 #include "widget/wwidgetstack.h"
+#include "widget/wsizeawarestack.h"
 #include "widget/wwidgetgroup.h"
 #include "widget/wkey.h"
 #include "widget/wcombobox.h"
@@ -443,6 +444,8 @@ QList<QWidget*> LegacySkinParser::parseNode(QDomElement node) {
         result = wrapWidget(parseWidgetGroup(node));
     } else if (nodeName == "WidgetStack") {
         result = wrapWidget(parseWidgetStack(node));
+    } else if (nodeName == "SizeAwareStack") {
+        result = wrapWidget(parseSizeAwareStack(node));
     } else if (nodeName == "EffectChainName") {
         result = wrapWidget(parseEffectChainName(node));
     } else if (nodeName == "EffectName") {
@@ -634,6 +637,55 @@ QWidget* LegacySkinParser::parseWidgetStack(QDomElement node) {
     // Init the widget last now that all the children have been created,
     // so if the current page was saved we can switch to the correct page.
     pStack->Init();
+    m_pParent = pOldParent;
+    return pStack;
+}
+
+QWidget* LegacySkinParser::parseSizeAwareStack(QDomElement node) {
+    WSizeAwareStack* pStack = new WSizeAwareStack(m_pParent);
+    pStack->setObjectName("SizeAwareStack");
+    pStack->setContentsMargins(0, 0, 0, 0);
+    setupConnections(node, pStack);
+    setupBaseWidget(node, pStack);
+    setupWidget(node, pStack);
+
+    QWidget* pOldParent = m_pParent;
+    m_pParent = pStack;
+
+    QDomNode childrenNode = m_pContext->selectNode(node, "Children");
+    if (!childrenNode.isNull()) {
+        // Descend chilren
+        QDomNodeList children = childrenNode.childNodes();
+
+        for (int i = 0; i < children.count(); ++i) {
+            QDomNode node = children.at(i);
+
+            if (!node.isElement()) {
+                continue;
+            }
+            QDomElement element = node.toElement();
+
+            QList<QWidget*> children = parseNode(element);
+
+            if (children.empty()) {
+                qWarning() << "WidgetStack child produced no widget.";
+                continue;
+            }
+
+            if (children.size() > 1) {
+                qWarning() << "WidgetStack child produced multiple widgets."
+                           << "All but the first are ignored.";
+            }
+            QWidget* pChild = children[0];
+
+            if (pChild == NULL) {
+                continue;
+            }
+
+            pStack->addWidget(pChild);
+        }
+    }
+
     m_pParent = pOldParent;
     return pStack;
 }

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -668,12 +668,12 @@ QWidget* LegacySkinParser::parseSizeAwareStack(QDomElement node) {
             QList<QWidget*> children = parseNode(element);
 
             if (children.empty()) {
-                qWarning() << "WidgetStack child produced no widget.";
+                qWarning() << "SizeAwareStack child produced no widget.";
                 continue;
             }
 
             if (children.size() > 1) {
-                qWarning() << "WidgetStack child produced multiple widgets."
+                qWarning() << "SizeAwareStack child produced multiple widgets."
                            << "All but the first are ignored.";
             }
             QWidget* pChild = children[0];

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -83,6 +83,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     // Grouping / layout.
     QWidget* parseWidgetGroup(QDomElement node);
     QWidget* parseWidgetStack(QDomElement node);
+    QWidget* parseSizeAwareStack(QDomElement node);
     QWidget* parseSplitter(QDomElement node);
 
     // Visual widgets.

--- a/src/widget/wsizeawarestack.cpp
+++ b/src/widget/wsizeawarestack.cpp
@@ -1,0 +1,97 @@
+#include <QtDebug>
+#include <QStackedLayout>
+#include <QResizeEvent>
+
+#include "widget/wsizeawarestack.h"
+
+class SizeAwareLayout : public QStackedLayout
+{
+  public:
+    QSize minimumSize() const
+    {
+        QSize s(0, 0) ;
+        QWidget *w = widget(0);
+        if (w) {
+            // Minimum Widget is at index 0;
+            s = w->minimumSize();
+        }
+        return s;
+    }
+
+    int setCurrentIndexForSize(const QSize& s) {
+        int n = count();
+        if (n <= 0) {
+            return -1;
+        }
+
+        int i = currentIndex();
+
+        QWidget *wc = widget(i);
+        bool notFit = false;
+        if (i > 0 ) {
+            // Check minimum, but not for the smallest, it is the fallback
+            notFit =  wc->minimumHeight() > s.height() || wc->minimumWidth() > s.width();
+        }
+        if (i < n - 1 && !notFit) {
+            // Check maximum, but not for the biggest, it is the fallback
+            notFit = wc->maximumHeight() < s.height() || wc->maximumWidth() < s.width();
+        }
+
+        if (notFit) {
+            QWidget *w;
+            for (i = 0; i < n; ++i) {
+                w = widget(i);
+                if (w) {
+                    if (w->maximumHeight() >= s.height() && w->maximumWidth() >= s.width() &&
+                            w->minimumHeight() <= s.height() && w->minimumWidth() <= s.width()) {
+                        // perfectly fit
+                        setCurrentIndex(i);
+                        return i;
+                    }
+                }
+            }
+            // no perfect fit, check minimum only to avoid chopping
+            for (i = n-1; i >= 0; --i) {
+                w = widget(i);
+                if (w) {
+                    if (w->minimumHeight() <= s.height() && w->minimumWidth() <= s.width()) {
+                        // fit with gap
+                        setCurrentIndex(i);
+                        return i;
+                    }
+                }
+            }
+            // fallback: take smallest
+            setCurrentIndex(0);
+            return 0;
+        }
+
+        return i;
+    }
+};
+
+WSizeAwareStack::WSizeAwareStack(QWidget* parent)
+        : QWidget(parent),
+          WBaseWidget(this) {
+    m_layout = new SizeAwareLayout();
+    setLayout(m_layout);
+}
+
+WSizeAwareStack::~WSizeAwareStack() {
+}
+
+int WSizeAwareStack::addWidget(QWidget *widget) {
+    // smallest widgets should be added first
+    return m_layout->addWidget(widget);
+}
+
+bool WSizeAwareStack::event(QEvent* pEvent) {
+    if (pEvent->type() == QEvent::ToolTip) {
+        updateTooltip();
+    }
+    return QWidget::event(pEvent);
+}
+
+void WSizeAwareStack::resizeEvent(QResizeEvent* event) {
+    m_layout->setCurrentIndexForSize(event->size());
+}

--- a/src/widget/wsizeawarestack.h
+++ b/src/widget/wsizeawarestack.h
@@ -1,0 +1,27 @@
+#ifndef WSIZEAWARESTACK_H
+#define WSIZEAWARESTACK_H
+
+#include <QWidget>
+#include <QEvent>
+
+#include "widget/wbasewidget.h"
+
+class SizeAwareLayout;
+
+class WSizeAwareStack : public QWidget, public WBaseWidget {
+    Q_OBJECT
+  public:
+    WSizeAwareStack(QWidget* pParent = NULL);
+    virtual ~WSizeAwareStack();
+
+    int addWidget(QWidget* pWidget);
+
+  protected:
+    virtual void resizeEvent(QResizeEvent* event);
+    bool event(QEvent* pEvent);
+
+  private:
+    SizeAwareLayout* m_layout;
+};
+
+#endif /* WSIZEAWARESTACK_H */


### PR DESCRIPTION
This is a simple widget stack selecting the best fitting widget. 
The algorithm is very basic and requires children sorted by size, smallest first.

It fixes bug https://bugs.launchpad.net/mixxx/+bug/1374214

```
                                        <SizeAwareStack>
                                            <Children>
                                               <WidgetGroup>
                                                    <MinimumSize>10,10</MinimumSize>
                                                    <MaximumSize>10,10</MaximumSize>
                                                    <Style> QGroupBox {
                                                        background: blue;
                                                    }
                                                    </Style>
                                               </WidgetGroup>
                                               <WidgetGroup>
                                                    <MinimumSize>100,10</MinimumSize>
                                                    <MaximumSize>100,10</MaximumSize>
                                                    <Style> QGroupBox {
                                                        background: red;
                                                    }
                                                    </Style>
                                               </WidgetGroup>
                                               <WidgetGroup>
                                                    <MinimumSize>200,10</MinimumSize>
                                                    <MaximumSize>200,10</MaximumSize>
                                                    <Style> QGroupBox {
                                                        background: green;
                                                    }
                                                    </Style>
                                               </WidgetGroup>
                                            </Children>
                                        </SizeAwareStack>
```

It can be tested with shade_dev from developer_skins
