### PR TITLE
Effect enable state

### DIFF
--- a/src/effects/effectmanifest.h
+++ b/src/effects/effectmanifest.h
@@ -21,7 +21,10 @@
 // example, a database-backed manifest)
 class EffectManifest {
   public:
-    EffectManifest() { }
+    EffectManifest()
+          : m_effectFadesFromDry(false) {
+
+    }
     virtual ~EffectManifest() {
         //qDebug() << debugString() << "deleted";
     }
@@ -80,6 +83,13 @@ class EffectManifest {
         return &m_buttonParameters.last();
     }
 
+    virtual bool effectFadesFromDry() const {
+        return m_effectFadesFromDry;
+    }
+    virtual void setEffectFadesFromDry(bool effectFadesFromDry) {
+        m_effectFadesFromDry = effectFadesFromDry;
+    }
+
   private:
     QString debugString() const {
         return QString("EffectManifest(%1)").arg(m_id);
@@ -92,6 +102,7 @@ class EffectManifest {
     QString m_description;
     QList<EffectManifestParameter> m_parameters;
     QList<EffectManifestParameter> m_buttonParameters;
+    bool m_effectFadesFromDry;
 };
 
 #endif /* EFFECTMANIFEST_H */

--- a/src/effects/effectmanifest.h
+++ b/src/effects/effectmanifest.h
@@ -22,7 +22,7 @@
 class EffectManifest {
   public:
     EffectManifest()
-          : m_effectFadesFromDry(false) {
+          : m_effectRampsFromDry(false) {
 
     }
     virtual ~EffectManifest() {
@@ -83,11 +83,11 @@ class EffectManifest {
         return &m_buttonParameters.last();
     }
 
-    virtual bool effectFadesFromDry() const {
-        return m_effectFadesFromDry;
+    virtual bool effectRampsFromDry() const {
+        return m_effectRampsFromDry;
     }
-    virtual void setEffectFadesFromDry(bool effectFadesFromDry) {
-        m_effectFadesFromDry = effectFadesFromDry;
+    virtual void setEffectRampsFromDry(bool effectFadesFromDry) {
+        m_effectRampsFromDry = effectFadesFromDry;
     }
 
   private:
@@ -102,7 +102,7 @@ class EffectManifest {
     QString m_description;
     QList<EffectManifestParameter> m_parameters;
     QList<EffectManifestParameter> m_buttonParameters;
-    bool m_effectFadesFromDry;
+    bool m_effectRampsFromDry;
 };
 
 #endif /* EFFECTMANIFEST_H */

--- a/src/effects/effectprocessor.h
+++ b/src/effects/effectprocessor.h
@@ -70,7 +70,7 @@ class GroupEffectProcessor : public EffectProcessor {
                          const CSAMPLE* pInput, CSAMPLE* pOutput,
                          const unsigned int numSamples,
                          const unsigned int sampleRate,
-                         const enum EffectProcessor::EnableState enableState,
+                         const EffectProcessor::EnableState enableState,
                          const GroupFeatureState& groupFeatures) {
         T* pState = m_groupState.value(group, NULL);
         if (pState == NULL) {
@@ -86,7 +86,7 @@ class GroupEffectProcessor : public EffectProcessor {
                               const CSAMPLE* pInput, CSAMPLE* pOutput,
                               const unsigned int numSamples,
                               const unsigned int sampleRate,
-                              const enum EffectProcessor::EnableState enableState,
+                              const EffectProcessor::EnableState enableState,
                               const GroupFeatureState& groupFeatures) = 0;
 
   private:

--- a/src/effects/effectprocessor.h
+++ b/src/effects/effectprocessor.h
@@ -31,6 +31,8 @@ class EffectProcessor {
                          const GroupFeatureState& groupFeatures) = 0;
 };
 
+// const enum EffectProcessor::EnableState enableState,
+
 // Helper class for automatically fetching group state parameters upon receipt
 // of a group-specific process call.
 template <typename T>

--- a/src/effects/effectprocessor.h
+++ b/src/effects/effectprocessor.h
@@ -11,6 +11,14 @@ class EngineEffect;
 
 class EffectProcessor {
   public:
+    enum EnableState {
+        DISABLED = 0x00,
+        ENABLED = 0x01,
+        DISABLING = 0x02,
+        ENABLING = 0x03
+    };
+
+
     virtual ~EffectProcessor() { }
 
     virtual void initialize(const QSet<QString>& registeredGroups) = 0;
@@ -28,10 +36,9 @@ class EffectProcessor {
                          const CSAMPLE* pInput, CSAMPLE* pOutput,
                          const unsigned int numSamples,
                          const unsigned int sampleRate,
+                         const enum EnableState enableState,
                          const GroupFeatureState& groupFeatures) = 0;
 };
-
-// const enum EffectProcessor::EnableState enableState,
 
 // Helper class for automatically fetching group state parameters upon receipt
 // of a group-specific process call.
@@ -63,6 +70,7 @@ class GroupEffectProcessor : public EffectProcessor {
                          const CSAMPLE* pInput, CSAMPLE* pOutput,
                          const unsigned int numSamples,
                          const unsigned int sampleRate,
+                         const enum EffectProcessor::EnableState enableState,
                          const GroupFeatureState& groupFeatures) {
         T* pState = m_groupState.value(group, NULL);
         if (pState == NULL) {
@@ -70,7 +78,7 @@ class GroupEffectProcessor : public EffectProcessor {
             m_groupState[group] = pState;
             qWarning() << "Allocated group state in the engine for" << group;
         }
-        processGroup(group, pState, pInput, pOutput, numSamples, sampleRate, groupFeatures);
+        processGroup(group, pState, pInput, pOutput, numSamples, sampleRate, enableState, groupFeatures);
     }
 
     virtual void processGroup(const QString& group,
@@ -78,6 +86,7 @@ class GroupEffectProcessor : public EffectProcessor {
                               const CSAMPLE* pInput, CSAMPLE* pOutput,
                               const unsigned int numSamples,
                               const unsigned int sampleRate,
+                              const enum EffectProcessor::EnableState enableState,
                               const GroupFeatureState& groupFeatures) = 0;
 
   private:

--- a/src/effects/effectsbackend.h
+++ b/src/effects/effectsbackend.h
@@ -41,10 +41,10 @@ class EffectsBackend : public QObject {
     template <typename EffectProcessorImpl>
     void registerEffect() {
         registerEffect(
-            EffectProcessorImpl::getId(),
-            EffectProcessorImpl::getManifest(),
-            EffectInstantiatorPointer(
-                new EffectProcessorInstantiator<EffectProcessorImpl>()));
+                EffectProcessorImpl::getId(),
+                EffectProcessorImpl::getManifest(),
+                EffectInstantiatorPointer(
+                            new EffectProcessorInstantiator<EffectProcessorImpl>()));
     }
 
   private:

--- a/src/effects/native/bessel4lvmixeqeffect.cpp
+++ b/src/effects/native/bessel4lvmixeqeffect.cpp
@@ -80,7 +80,7 @@ void Bessel4LVMixEQEffect::processGroup(const QString& group,
                                         const CSAMPLE* pInput, CSAMPLE* pOutput,
                                         const unsigned int numSamples,
                                         const unsigned int sampleRate,
-                                        const enum EffectProcessor::EnableState enableState,
+                                        const EffectProcessor::EnableState enableState,
                                         const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/bessel4lvmixeqeffect.cpp
+++ b/src/effects/native/bessel4lvmixeqeffect.cpp
@@ -16,7 +16,7 @@ EffectManifest Bessel4LVMixEQEffect::getManifest() {
     manifest.setDescription(QObject::tr(
         "A Bessel 4th order filter equalizer with Lipshitz and Vanderkooy mix (bit perfect unity, roll-off -24 db/Oct). "
         "To adjust frequency shelves see the Equalizer preferences."));
-    manifest.setEffectFadesFromDry(true);
+    manifest.setEffectRampsFromDry(true);
 
     EffectManifestParameter* low = manifest.addParameter();
     low->setId("low");

--- a/src/effects/native/bessel4lvmixeqeffect.cpp
+++ b/src/effects/native/bessel4lvmixeqeffect.cpp
@@ -79,6 +79,7 @@ void Bessel4LVMixEQEffect::processGroup(const QString& group,
                                         const CSAMPLE* pInput, CSAMPLE* pOutput,
                                         const unsigned int numSamples,
                                         const unsigned int sampleRate,
+                                        const enum EffectProcessor::EnableState enableState,
                                         const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/bessel4lvmixeqeffect.cpp
+++ b/src/effects/native/bessel4lvmixeqeffect.cpp
@@ -16,6 +16,7 @@ EffectManifest Bessel4LVMixEQEffect::getManifest() {
     manifest.setDescription(QObject::tr(
         "A Bessel 4th order filter equalizer with Lipshitz and Vanderkooy mix (bit perfect unity, roll-off -24 db/Oct). "
         "To adjust frequency shelves see the Equalizer preferences."));
+    manifest.setEffectFadesFromDry(true);
 
     EffectManifestParameter* low = manifest.addParameter();
     low->setId("low");
@@ -84,9 +85,19 @@ void Bessel4LVMixEQEffect::processGroup(const QString& group,
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);
 
-    double fLow = m_pPotLow->value().toDouble();
-    double fMid = m_pPotMid->value().toDouble();
-    double fHigh = m_pPotHigh->value().toDouble();
+    double fLow;
+    double fMid;
+    double fHigh;
+    if (enableState == EffectProcessor::DISABLING) {
+        // Ramp to dry, when disabling, this will ramp from dry when enabling as well
+        fLow = 1.0;
+        fMid = 1.0;
+        fHigh = 1.0;
+    } else {
+        fLow = m_pPotLow->value().toDouble();
+        fMid = m_pPotMid->value().toDouble();
+        fHigh = m_pPotHigh->value().toDouble();
+    }
 
     if (pState->m_oldSampleRate != sampleRate ||
             (pState->m_loFreq != m_pLoFreqCorner->get()) ||
@@ -149,4 +160,10 @@ void Bessel4LVMixEQEffect::processGroup(const QString& group,
     pState->old_low = fLow;
     pState->old_mid = fMid;
     pState->old_high = fHigh;
+
+    if (enableState == EffectProcessor::DISABLING) {
+        pState->m_delay3->pauseFilter();
+        pState->m_low2->pauseFilter();
+        pState->m_low1->pauseFilter();
+    }
 }

--- a/src/effects/native/bessel4lvmixeqeffect.h
+++ b/src/effects/native/bessel4lvmixeqeffect.h
@@ -34,7 +34,7 @@ class Bessel4LVMixEQEffect : public GroupEffectProcessor<Bessel4LVMixEQEffectGro
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
-                      const enum EffectProcessor::EnableState enableState,
+                      const EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatureState);
 
   private:

--- a/src/effects/native/bessel4lvmixeqeffect.h
+++ b/src/effects/native/bessel4lvmixeqeffect.h
@@ -34,6 +34,7 @@ class Bessel4LVMixEQEffect : public GroupEffectProcessor<Bessel4LVMixEQEffectGro
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
+                      const enum EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatureState);
 
   private:

--- a/src/effects/native/bessel8lvmixeqeffect.cpp
+++ b/src/effects/native/bessel8lvmixeqeffect.cpp
@@ -23,7 +23,7 @@ EffectManifest Bessel8LVMixEQEffect::getManifest() {
     manifest.setDescription(QObject::tr(
         "A Bessel 8th order filter equalizer with Lipshitz and Vanderkooy mix (bit perfect unity, roll-off -48 db/Oct). "
         "To adjust frequency shelves see the Equalizer preferences."));
-    manifest.setEffectFadesFromDry(true);
+    manifest.setEffectRampsFromDry(true);
 
     EffectManifestParameter* low = manifest.addParameter();
     low->setId("low");

--- a/src/effects/native/bessel8lvmixeqeffect.cpp
+++ b/src/effects/native/bessel8lvmixeqeffect.cpp
@@ -23,6 +23,7 @@ EffectManifest Bessel8LVMixEQEffect::getManifest() {
     manifest.setDescription(QObject::tr(
         "A Bessel 8th order filter equalizer with Lipshitz and Vanderkooy mix (bit perfect unity, roll-off -48 db/Oct). "
         "To adjust frequency shelves see the Equalizer preferences."));
+    manifest.setEffectFadesFromDry(true);
 
     EffectManifestParameter* low = manifest.addParameter();
     low->setId("low");
@@ -91,9 +92,19 @@ void Bessel8LVMixEQEffect::processGroup(const QString& group,
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);
 
-    double fLow = m_pPotLow->value().toDouble();
-    double fMid = m_pPotMid->value().toDouble();
-    double fHigh = m_pPotHigh->value().toDouble();
+    double fLow;
+    double fMid;
+    double fHigh;
+    if (enableState == EffectProcessor::DISABLING) {
+        // Ramp to dry, when disabling, this will ramp from dry when enabling as well
+        fLow = 1.0;
+        fMid = 1.0;
+        fHigh = 1.0;
+    } else {
+        fLow = m_pPotLow->value().toDouble();
+        fMid = m_pPotMid->value().toDouble();
+        fHigh = m_pPotHigh->value().toDouble();
+    }
 
     if (pState->m_oldSampleRate != sampleRate ||
             (pState->m_loFreq != m_pLoFreqCorner->get()) ||
@@ -156,4 +167,10 @@ void Bessel8LVMixEQEffect::processGroup(const QString& group,
     pState->old_low = fLow;
     pState->old_mid = fMid;
     pState->old_high = fHigh;
+
+    if (enableState == EffectProcessor::DISABLING) {
+        pState->m_delay3->pauseFilter();
+        pState->m_low2->pauseFilter();
+        pState->m_low1->pauseFilter();
+    }
 }

--- a/src/effects/native/bessel8lvmixeqeffect.cpp
+++ b/src/effects/native/bessel8lvmixeqeffect.cpp
@@ -86,6 +86,7 @@ void Bessel8LVMixEQEffect::processGroup(const QString& group,
                                         const CSAMPLE* pInput, CSAMPLE* pOutput,
                                         const unsigned int numSamples,
                                         const unsigned int sampleRate,
+                                        const enum EffectProcessor::EnableState enableState,
                                         const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/bessel8lvmixeqeffect.cpp
+++ b/src/effects/native/bessel8lvmixeqeffect.cpp
@@ -87,7 +87,7 @@ void Bessel8LVMixEQEffect::processGroup(const QString& group,
                                         const CSAMPLE* pInput, CSAMPLE* pOutput,
                                         const unsigned int numSamples,
                                         const unsigned int sampleRate,
-                                        const enum EffectProcessor::EnableState enableState,
+                                        const EffectProcessor::EnableState enableState,
                                         const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/bessel8lvmixeqeffect.h
+++ b/src/effects/native/bessel8lvmixeqeffect.h
@@ -36,7 +36,7 @@ class Bessel8LVMixEQEffect : public GroupEffectProcessor<Bessel8LVMixEQEffectGro
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
-                      const enum EffectProcessor::EnableState enableState,
+                      const EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatureState);
 
   private:

--- a/src/effects/native/bessel8lvmixeqeffect.h
+++ b/src/effects/native/bessel8lvmixeqeffect.h
@@ -36,6 +36,7 @@ class Bessel8LVMixEQEffect : public GroupEffectProcessor<Bessel8LVMixEQEffectGro
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
+                      const enum EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatureState);
 
   private:

--- a/src/effects/native/bitcrushereffect.cpp
+++ b/src/effects/native/bitcrushereffect.cpp
@@ -14,7 +14,7 @@ EffectManifest BitCrusherEffect::getManifest() {
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription("TODO");
-    manifest.setEffectFadesFromDry(true);
+    manifest.setEffectRampsFromDry(true);
 
     EffectManifestParameter* depth = manifest.addParameter();
     depth->setId("bit_depth");

--- a/src/effects/native/bitcrushereffect.cpp
+++ b/src/effects/native/bitcrushereffect.cpp
@@ -14,6 +14,7 @@ EffectManifest BitCrusherEffect::getManifest() {
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription("TODO");
+    manifest.setEffectFadesFromDry(true);
 
     EffectManifestParameter* depth = manifest.addParameter();
     depth->setId("bit_depth");
@@ -68,9 +69,9 @@ void BitCrusherEffect::processGroup(const QString& group,
                                     const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);
-    Q_UNUSED(sampleRate);
-    // TODO(rryan) this is broken. it needs to take into account the sample
-    // rate.
+    Q_UNUSED(sampleRate); // we are normalized to 1
+    Q_UNUSED(enableState); // no need to ramp, it is just a bitcrusher ;-)
+
     const CSAMPLE downsample = m_pDownsampleParameter ?
             m_pDownsampleParameter->value().toDouble() : 0.0;
 

--- a/src/effects/native/bitcrushereffect.cpp
+++ b/src/effects/native/bitcrushereffect.cpp
@@ -65,7 +65,7 @@ void BitCrusherEffect::processGroup(const QString& group,
                                     const CSAMPLE* pInput, CSAMPLE* pOutput,
                                     const unsigned int numSamples,
                                     const unsigned int sampleRate,
-                                    const enum EffectProcessor::EnableState enableState,
+                                    const EffectProcessor::EnableState enableState,
                                     const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/bitcrushereffect.cpp
+++ b/src/effects/native/bitcrushereffect.cpp
@@ -64,6 +64,7 @@ void BitCrusherEffect::processGroup(const QString& group,
                                     const CSAMPLE* pInput, CSAMPLE* pOutput,
                                     const unsigned int numSamples,
                                     const unsigned int sampleRate,
+                                    const enum EffectProcessor::EnableState enableState,
                                     const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/bitcrushereffect.h
+++ b/src/effects/native/bitcrushereffect.h
@@ -36,7 +36,7 @@ class BitCrusherEffect : public GroupEffectProcessor<BitCrusherGroupState> {
                       const CSAMPLE* pInput, CSAMPLE *pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
-                      const enum EffectProcessor::EnableState enableState,
+                      const EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatureState);
 
   private:

--- a/src/effects/native/bitcrushereffect.h
+++ b/src/effects/native/bitcrushereffect.h
@@ -36,6 +36,7 @@ class BitCrusherEffect : public GroupEffectProcessor<BitCrusherGroupState> {
                       const CSAMPLE* pInput, CSAMPLE *pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
+                      const enum EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatureState);
 
   private:

--- a/src/effects/native/echoeffect.cpp
+++ b/src/effects/native/echoeffect.cpp
@@ -106,7 +106,7 @@ void EchoEffect::processGroup(const QString& group, EchoGroupState* pGroupState,
                               const CSAMPLE* pInput,
                               CSAMPLE* pOutput, const unsigned int numSamples,
                               const unsigned int sampleRate,
-                              const enum EffectProcessor::EnableState enableState,
+                              const EffectProcessor::EnableState enableState,
                               const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/echoeffect.cpp
+++ b/src/effects/native/echoeffect.cpp
@@ -106,6 +106,7 @@ void EchoEffect::processGroup(const QString& group, EchoGroupState* pGroupState,
                               const CSAMPLE* pInput,
                               CSAMPLE* pOutput, const unsigned int numSamples,
                               const unsigned int sampleRate,
+                              const enum EffectProcessor::EnableState enableState,
                               const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/echoeffect.h
+++ b/src/effects/native/echoeffect.h
@@ -44,7 +44,7 @@ class EchoEffect : public GroupEffectProcessor<EchoGroupState> {
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
-                      const enum EffectProcessor::EnableState enableState,
+                      const EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatures);
 
   private:

--- a/src/effects/native/echoeffect.h
+++ b/src/effects/native/echoeffect.h
@@ -44,6 +44,7 @@ class EchoEffect : public GroupEffectProcessor<EchoGroupState> {
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
+                      const enum EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatures);
 
   private:

--- a/src/effects/native/filtereffect.cpp
+++ b/src/effects/native/filtereffect.cpp
@@ -83,6 +83,7 @@ void FilterEffect::processGroup(const QString& group,
                                 const CSAMPLE* pInput, CSAMPLE* pOutput,
                                 const unsigned int numSamples,
                                 const unsigned int sampleRate,
+                                const enum EffectProcessor::EnableState enableState,
                                 const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/filtereffect.cpp
+++ b/src/effects/native/filtereffect.cpp
@@ -83,7 +83,7 @@ void FilterEffect::processGroup(const QString& group,
                                 const CSAMPLE* pInput, CSAMPLE* pOutput,
                                 const unsigned int numSamples,
                                 const unsigned int sampleRate,
-                                const enum EffectProcessor::EnableState enableState,
+                                const EffectProcessor::EnableState enableState,
                                 const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/filtereffect.h
+++ b/src/effects/native/filtereffect.h
@@ -52,6 +52,7 @@ class FilterEffect : public GroupEffectProcessor<FilterGroupState> {
                       const CSAMPLE* pInput, CSAMPLE *pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
+                      const enum EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatures);
 
   private:

--- a/src/effects/native/filtereffect.h
+++ b/src/effects/native/filtereffect.h
@@ -52,7 +52,7 @@ class FilterEffect : public GroupEffectProcessor<FilterGroupState> {
                       const CSAMPLE* pInput, CSAMPLE *pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
-                      const enum EffectProcessor::EnableState enableState,
+                      const EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatures);
 
   private:

--- a/src/effects/native/flangereffect.cpp
+++ b/src/effects/native/flangereffect.cpp
@@ -79,7 +79,7 @@ void FlangerEffect::processGroup(const QString& group,
                                  const CSAMPLE* pInput, CSAMPLE* pOutput,
                                  const unsigned int numSamples,
                                  const unsigned int sampleRate,
-                                 const enum EffectProcessor::EnableState enableState,
+                                 const EffectProcessor::EnableState enableState,
                                  const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/flangereffect.cpp
+++ b/src/effects/native/flangereffect.cpp
@@ -79,6 +79,7 @@ void FlangerEffect::processGroup(const QString& group,
                                  const CSAMPLE* pInput, CSAMPLE* pOutput,
                                  const unsigned int numSamples,
                                  const unsigned int sampleRate,
+                                 const enum EffectProcessor::EnableState enableState,
                                  const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/flangereffect.h
+++ b/src/effects/native/flangereffect.h
@@ -38,6 +38,7 @@ class FlangerEffect : public GroupEffectProcessor<FlangerGroupState> {
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
+                      const enum EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatures);
 
   private:

--- a/src/effects/native/flangereffect.h
+++ b/src/effects/native/flangereffect.h
@@ -38,7 +38,7 @@ class FlangerEffect : public GroupEffectProcessor<FlangerGroupState> {
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
-                      const enum EffectProcessor::EnableState enableState,
+                      const EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatures);
 
   private:

--- a/src/effects/native/graphiceqeffect.cpp
+++ b/src/effects/native/graphiceqeffect.cpp
@@ -143,7 +143,7 @@ void GraphicEQEffect::processGroup(const QString& group,
                                    const CSAMPLE* pInput, CSAMPLE* pOutput,
                                    const unsigned int numSamples,
                                    const unsigned int sampleRate,
-                                   const enum EffectProcessor::EnableState enableState,
+                                   const EffectProcessor::EnableState enableState,
                                    const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/graphiceqeffect.cpp
+++ b/src/effects/native/graphiceqeffect.cpp
@@ -142,6 +142,7 @@ void GraphicEQEffect::processGroup(const QString& group,
                                    const CSAMPLE* pInput, CSAMPLE* pOutput,
                                    const unsigned int numSamples,
                                    const unsigned int sampleRate,
+                                   const enum EffectProcessor::EnableState enableState,
                                    const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/graphiceqeffect.cpp
+++ b/src/effects/native/graphiceqeffect.cpp
@@ -17,6 +17,7 @@ EffectManifest GraphicEQEffect::getManifest() {
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr(
         "An 8 band Graphic EQ based on Biquad Filters"));
+    manifest.setEffectFadesFromDry(true);
 
     // Display rounded center frequencies for each filter
     float centerFrequencies[8] = {45, 100, 220, 500, 1100, 2500,
@@ -158,10 +159,19 @@ void GraphicEQEffect::processGroup(const QString& group,
     float fMid[6];
     float fHigh;
 
-    fLow = m_pPotLow->value().toDouble();
-    fHigh = m_pPotHigh->value().toDouble();
-    for (int i = 0; i < 6; i++) {
-        fMid[i] = m_pPotMid[i]->value().toDouble();
+    if (enableState == EffectProcessor::DISABLING) {
+         // Ramp to dry, when disabling, this will ramp from dry when enabling as well
+        fLow = 1.0;
+        fHigh = 1.0;;
+        for (int i = 0; i < 6; i++) {
+            fMid[i] = 1.0;
+        }
+    } else {
+        fLow = m_pPotLow->value().toDouble();
+        fHigh = m_pPotHigh->value().toDouble();
+        for (int i = 0; i < 6; i++) {
+            fMid[i] = m_pPotMid[i]->value().toDouble();
+        }
     }
 
 
@@ -216,5 +226,13 @@ void GraphicEQEffect::processGroup(const QString& group,
     pState->m_oldHigh = fHigh;
     for (int i = 0; i < 6; i++) {
         pState->m_oldMid[i] = fMid[i];
+    }
+
+    if (enableState == EffectProcessor::DISABLING) {
+        pState->m_low->pauseFilter();
+        pState->m_high->pauseFilter();
+        for (int i = 0; i < 6; i++) {
+            pState->m_bands[i]->pauseFilter();
+        }
     }
 }

--- a/src/effects/native/graphiceqeffect.cpp
+++ b/src/effects/native/graphiceqeffect.cpp
@@ -17,7 +17,7 @@ EffectManifest GraphicEQEffect::getManifest() {
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr(
         "An 8 band Graphic EQ based on Biquad Filters"));
-    manifest.setEffectFadesFromDry(true);
+    manifest.setEffectRampsFromDry(true);
 
     // Display rounded center frequencies for each filter
     float centerFrequencies[8] = {45, 100, 220, 500, 1100, 2500,

--- a/src/effects/native/graphiceqeffect.h
+++ b/src/effects/native/graphiceqeffect.h
@@ -45,7 +45,7 @@ class GraphicEQEffect : public GroupEffectProcessor<GraphicEQEffectGroupState> {
                       const CSAMPLE* pInput, CSAMPLE *pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
-                      const enum EffectProcessor::EnableState enableState,
+                      const EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatureState);
 
   private:

--- a/src/effects/native/graphiceqeffect.h
+++ b/src/effects/native/graphiceqeffect.h
@@ -45,6 +45,7 @@ class GraphicEQEffect : public GroupEffectProcessor<GraphicEQEffectGroupState> {
                       const CSAMPLE* pInput, CSAMPLE *pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
+                      const enum EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatureState);
 
   private:

--- a/src/effects/native/linkwitzriley8eqeffect.cpp
+++ b/src/effects/native/linkwitzriley8eqeffect.cpp
@@ -119,7 +119,7 @@ void LinkwitzRiley8EQEffect::processGroup(const QString& group,
         const CSAMPLE* pInput, CSAMPLE* pOutput,
         const unsigned int numSamples,
         const unsigned int sampleRate,
-        const enum EffectProcessor::EnableState enableState,
+        const EffectProcessor::EnableState enableState,
         const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/linkwitzriley8eqeffect.cpp
+++ b/src/effects/native/linkwitzriley8eqeffect.cpp
@@ -169,7 +169,19 @@ void LinkwitzRiley8EQEffect::processGroup(const QString& group,
                 numSamples);
     }
 
-    pState->old_low = fLow;
-    pState->old_mid = fMid;
-    pState->old_high = fHigh;
+    if (enableState == EffectProcessor::DISABLING) {
+        // we rely on the ramping to dry in EngineEffect
+        // since this EQ is not fully dry at unity
+        pState->m_low1->pauseFilter();
+        pState->m_low2->pauseFilter();
+        pState->m_high1->pauseFilter();
+        pState->m_high2->pauseFilter();
+        pState->old_low = 1.0;
+        pState->old_mid = 1.0;
+        pState->old_high = 1.0;
+    } else {
+        pState->old_low = fLow;
+        pState->old_mid = fMid;
+        pState->old_high = fHigh;
+    }
 }

--- a/src/effects/native/linkwitzriley8eqeffect.cpp
+++ b/src/effects/native/linkwitzriley8eqeffect.cpp
@@ -119,6 +119,7 @@ void LinkwitzRiley8EQEffect::processGroup(const QString& group,
         const CSAMPLE* pInput, CSAMPLE* pOutput,
         const unsigned int numSamples,
         const unsigned int sampleRate,
+        const enum EffectProcessor::EnableState enableState,
         const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/linkwitzriley8eqeffect.h
+++ b/src/effects/native/linkwitzriley8eqeffect.h
@@ -53,7 +53,7 @@ class LinkwitzRiley8EQEffect : public GroupEffectProcessor<LinkwitzRiley8EQEffec
                       const CSAMPLE* pInput, CSAMPLE *pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
-                      const enum EffectProcessor::EnableState enableState,
+                      const EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatureState);
 
   private:

--- a/src/effects/native/linkwitzriley8eqeffect.h
+++ b/src/effects/native/linkwitzriley8eqeffect.h
@@ -53,6 +53,7 @@ class LinkwitzRiley8EQEffect : public GroupEffectProcessor<LinkwitzRiley8EQEffec
                       const CSAMPLE* pInput, CSAMPLE *pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
+                      const enum EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatureState);
 
   private:

--- a/src/effects/native/reverbeffect.cpp
+++ b/src/effects/native/reverbeffect.cpp
@@ -68,6 +68,7 @@ void ReverbEffect::processGroup(const QString& group,
                                 const CSAMPLE* pInput, CSAMPLE* pOutput,
                                 const unsigned int numSamples,
                                 const unsigned int sampleRate,
+                                const enum EffectProcessor::EnableState enableState,
                                 const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/reverbeffect.cpp
+++ b/src/effects/native/reverbeffect.cpp
@@ -68,7 +68,7 @@ void ReverbEffect::processGroup(const QString& group,
                                 const CSAMPLE* pInput, CSAMPLE* pOutput,
                                 const unsigned int numSamples,
                                 const unsigned int sampleRate,
-                                const enum EffectProcessor::EnableState enableState,
+                                const EffectProcessor::EnableState enableState,
                                 const GroupFeatureState& groupFeatures) {
     Q_UNUSED(group);
     Q_UNUSED(groupFeatures);

--- a/src/effects/native/reverbeffect.h
+++ b/src/effects/native/reverbeffect.h
@@ -49,7 +49,7 @@ class ReverbEffect : public GroupEffectProcessor<ReverbGroupState> {
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
-                      const enum EffectProcessor::EnableState enableState,
+                      const EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatures);
 
   private:

--- a/src/effects/native/reverbeffect.h
+++ b/src/effects/native/reverbeffect.h
@@ -49,6 +49,7 @@ class ReverbEffect : public GroupEffectProcessor<ReverbGroupState> {
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,
+                      const enum EffectProcessor::EnableState enableState,
                       const GroupFeatureState& groupFeatures);
 
   private:

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -130,9 +130,9 @@ void EngineEffect::process(const QString& group,
                            const CSAMPLE* pInput, CSAMPLE* pOutput,
                            const unsigned int numSamples,
                            const unsigned int sampleRate,
-                           const enum EffectProcessor::EnableState enableState,
+                           const EffectProcessor::EnableState enableState,
                            const GroupFeatureState& groupFeatures) {
-    enum EffectProcessor::EnableState effectiveEnableState = m_enableState;
+    EffectProcessor::EnableState effectiveEnableState = m_enableState;
     if (enableState == EffectProcessor::DISABLING) {
         effectiveEnableState = EffectProcessor::DISABLING;
     } else if (enableState == EffectProcessor::ENABLING) {

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -130,6 +130,7 @@ void EngineEffect::process(const QString& group,
                            const CSAMPLE* pInput, CSAMPLE* pOutput,
                            const unsigned int numSamples,
                            const unsigned int sampleRate,
+                           const enum EffectProcessor::EnableState enableState,
                            const GroupFeatureState& groupFeatures) {
     m_pProcessor->process(group, pInput, pOutput, numSamples, sampleRate, m_enableState, groupFeatures);
     if (!m_effectRampsFromDry) {

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -30,7 +30,7 @@ EngineEffect::EngineEffect(const EffectManifest& manifest,
     // Creating the processor must come last.
     m_pProcessor = pInstantiator->instantiate(this, manifest);
     m_pProcessor->initialize(registeredGroups);
-    m_effectFadesFromDry = manifest.effectFadesFromDry();
+    m_effectRampsFromDry = manifest.effectRampsFromDry();
 }
 
 EngineEffect::~EngineEffect() {
@@ -132,7 +132,7 @@ void EngineEffect::process(const QString& group,
                            const unsigned int sampleRate,
                            const GroupFeatureState& groupFeatures) {
     m_pProcessor->process(group, pInput, pOutput, numSamples, sampleRate, m_enableState, groupFeatures);
-    if (!m_effectFadesFromDry) {
+    if (!m_effectRampsFromDry) {
         // the effect does not fade, so we care for it
         if (m_enableState == EffectProcessor::DISABLING) {
             // Fade out (fade to dry signal)

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -149,14 +149,18 @@ void EngineEffect::process(const QString& group,
                     pInput, 0.0, 1.0,
                     pOutput, 1.0, 0.0,
                     numSamples);
-            m_enableState = EffectProcessor::DISABLED;
         } else if (effectiveEnableState == EffectProcessor::ENABLING) {
             // Fade in (fade to wet signal)
             SampleUtil::copy2WithRampingGain(pOutput,
                     pInput, 1.0, 0.0,
                     pOutput, 0.0, 1.0,
                     numSamples);
-            m_enableState = EffectProcessor::ENABLED;
         }
+    }
+
+    if (m_enableState == EffectProcessor::DISABLING) {
+        m_enableState = EffectProcessor::DISABLED;
+    } else if (m_enableState == EffectProcessor::ENABLING) {
+        m_enableState = EffectProcessor::ENABLED;
     }
 }

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -42,6 +42,7 @@ class EngineEffect : public EffectsRequestHandler {
                  const CSAMPLE* pInput, CSAMPLE* pOutput,
                  const unsigned int numSamples,
                  const unsigned int sampleRate,
+                 const enum EffectProcessor::EnableState enableState,
                  const GroupFeatureState& groupFeatures);
 
     bool enabled() const {

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -57,7 +57,7 @@ class EngineEffect : public EffectsRequestHandler {
     EffectProcessor* m_pProcessor;
     bool m_bEnabled; // [EffectRackN_EffectUnitN_EffectN], "enabled"
     enum EffectProcessor::EnableState m_enableState;
-    bool m_effectFadesFromDry;
+    bool m_effectRampsFromDry;
     // Must not be modified after construction.
     QVector<EngineEffectParameter*> m_parameters;
     QVector<EngineEffectParameter*> m_buttonParameters;

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -57,6 +57,7 @@ class EngineEffect : public EffectsRequestHandler {
     EffectProcessor* m_pProcessor;
     bool m_bEnabled; // [EffectRackN_EffectUnitN_EffectN], "enabled"
     enum EffectProcessor::EnableState m_enableState;
+    bool m_effectFadesFromDry;
     // Must not be modified after construction.
     QVector<EngineEffectParameter*> m_parameters;
     QVector<EngineEffectParameter*> m_buttonParameters;

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -56,7 +56,6 @@ class EngineEffect : public EffectsRequestHandler {
 
     EffectManifest m_manifest;
     EffectProcessor* m_pProcessor;
-    bool m_bEnabled; // [EffectRackN_EffectUnitN_EffectN], "enabled"
     EffectProcessor::EnableState m_enableState;
     bool m_effectRampsFromDry;
     // Must not be modified after construction.

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -17,6 +17,15 @@
 
 class EngineEffect : public EffectsRequestHandler {
   public:
+
+    enum EnableState {
+        DISABLED = 0x00,
+        ENABLED = 0x01,
+        DISABLING = 0x02,
+        ENABLING = 0x03
+    };
+
+
     EngineEffect(const EffectManifest& manifest,
                  const QSet<QString>& registeredGroups,
                  EffectInstantiatorPointer pInstantiator);
@@ -45,7 +54,7 @@ class EngineEffect : public EffectsRequestHandler {
                  const GroupFeatureState& groupFeatures);
 
     bool enabled() const {
-        return m_bEnabled;
+        return m_enableState != DISABLED;
     }
 
   private:
@@ -56,7 +65,7 @@ class EngineEffect : public EffectsRequestHandler {
     EffectManifest m_manifest;
     EffectProcessor* m_pProcessor;
     bool m_bEnabled; // [EffectRackN_EffectUnitN_EffectN], "enabled"
-    bool m_bOldEnabled; // [EffectRackN_EffectUnitN_EffectN], "enabled"
+    enum EnableState m_enableState;
     // Must not be modified after construction.
     QVector<EngineEffectParameter*> m_parameters;
     QVector<EngineEffectParameter*> m_buttonParameters;

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -17,15 +17,6 @@
 
 class EngineEffect : public EffectsRequestHandler {
   public:
-
-    enum EnableState {
-        DISABLED = 0x00,
-        ENABLED = 0x01,
-        DISABLING = 0x02,
-        ENABLING = 0x03
-    };
-
-
     EngineEffect(const EffectManifest& manifest,
                  const QSet<QString>& registeredGroups,
                  EffectInstantiatorPointer pInstantiator);
@@ -54,7 +45,7 @@ class EngineEffect : public EffectsRequestHandler {
                  const GroupFeatureState& groupFeatures);
 
     bool enabled() const {
-        return m_enableState != DISABLED;
+        return m_enableState != EffectProcessor::DISABLED;
     }
 
   private:
@@ -65,7 +56,7 @@ class EngineEffect : public EffectsRequestHandler {
     EffectManifest m_manifest;
     EffectProcessor* m_pProcessor;
     bool m_bEnabled; // [EffectRackN_EffectUnitN_EffectN], "enabled"
-    enum EnableState m_enableState;
+    enum EffectProcessor::EnableState m_enableState;
     // Must not be modified after construction.
     QVector<EngineEffectParameter*> m_parameters;
     QVector<EngineEffectParameter*> m_buttonParameters;

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -42,7 +42,7 @@ class EngineEffect : public EffectsRequestHandler {
                  const CSAMPLE* pInput, CSAMPLE* pOutput,
                  const unsigned int numSamples,
                  const unsigned int sampleRate,
-                 const enum EffectProcessor::EnableState enableState,
+                 const EffectProcessor::EnableState enableState,
                  const GroupFeatureState& groupFeatures);
 
     bool enabled() const {
@@ -57,7 +57,7 @@ class EngineEffect : public EffectsRequestHandler {
     EffectManifest m_manifest;
     EffectProcessor* m_pProcessor;
     bool m_bEnabled; // [EffectRackN_EffectUnitN_EffectN], "enabled"
-    enum EffectProcessor::EnableState m_enableState;
+    EffectProcessor::EnableState m_enableState;
     bool m_effectRampsFromDry;
     // Must not be modified after construction.
     QVector<EngineEffectParameter*> m_parameters;

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -55,7 +55,8 @@ class EngineEffect : public EffectsRequestHandler {
 
     EffectManifest m_manifest;
     EffectProcessor* m_pProcessor;
-    bool m_bEnabled;
+    bool m_bEnabled; // [EffectRackN_EffectUnitN_EffectN], "enabled"
+    bool m_bOldEnabled; // [EffectRackN_EffectUnitN_EffectN], "enabled"
     // Must not be modified after construction.
     QVector<EngineEffectParameter*> m_parameters;
     QVector<EngineEffectParameter*> m_buttonParameters;

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -156,7 +156,7 @@ void EngineEffectChain::process(const QString& group,
         return;
     }
 
-    enum EffectProcessor::EnableState effectiveEnableState = group_info.enable_state;
+    EffectProcessor::EnableState effectiveEnableState = group_info.enable_state;
 
     if (m_enableState == EffectProcessor::DISABLING) {
         effectiveEnableState = EffectProcessor::DISABLING;

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -6,7 +6,7 @@
 
 EngineEffectChain::EngineEffectChain(const QString& id)
         : m_id(id),
-          m_bEnabled(true),
+          m_enableState(EffectProcessor::ENABLED),
           m_insertionType(EffectChain::INSERT),
           m_dMix(0),
           m_pBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)) {
@@ -64,25 +64,13 @@ bool EngineEffectChain::removeEffect(EngineEffect* pEffect, int iIndex) {
 
 bool EngineEffectChain::updateParameters(const EffectsRequest& message) {
     // TODO(rryan): Parameter interpolation.
-    bool wasEnabled = m_bEnabled;
-    m_bEnabled = message.SetEffectChainParameters.enabled;
     m_insertionType = message.SetEffectChainParameters.insertion_type;
     m_dMix = message.SetEffectChainParameters.mix;
 
-    // If our enabled state changed then tell each group to ramp in or out.
-    if (wasEnabled ^ m_bEnabled) {
-        for (QMap<QString, GroupStatus>::iterator it = m_groupStatus.begin();
-                it != m_groupStatus.end(); ++it) {
-            GroupStatus& status = it.value();
-
-            if (m_bEnabled) {
-                // Ramp in.
-                status.old_gain = 0;
-            } else {
-                // Ramp out.
-                status.ramp_out = true;
-            }
-        }
+    if (m_enableState != EffectProcessor::DISABLED && !message.SetEffectParameters.enabled) {
+        m_enableState = EffectProcessor::DISABLING;
+    } else if (m_enableState == EffectProcessor::DISABLED && message.SetEffectParameters.enabled) {
+        m_enableState = EffectProcessor::ENABLING;
     }
     return true;
 }
@@ -138,25 +126,19 @@ bool EngineEffectChain::processEffectsRequest(const EffectsRequest& message,
     return true;
 }
 
-bool EngineEffectChain::enabledForGroup(const QString& group) const {
-    const GroupStatus& status = m_groupStatus[group];
-    return status.enabled;
-}
-
 bool EngineEffectChain::enableForGroup(const QString& group) {
     GroupStatus& status = m_groupStatus[group];
-    status.enabled = true;
-    // Ramp in to prevent clicking.
-    status.old_gain = 0;
-    status.ramp_out = false;
+    if (status.enable_state != EffectProcessor::ENABLED) {
+        status.enable_state = EffectProcessor::ENABLING;
+    }
     return true;
 }
 
 bool EngineEffectChain::disableForGroup(const QString& group) {
     GroupStatus& status = m_groupStatus[group];
-    status.enabled = false;
-    // Ramp out to prevent clicking.
-    status.ramp_out = true;
+    if (status.enable_state != EffectProcessor::DISABLED) {
+        status.enable_state = EffectProcessor::DISABLING;
+    }
     return true;
 }
 
@@ -166,17 +148,25 @@ void EngineEffectChain::process(const QString& group,
                                 const unsigned int sampleRate,
                                 const GroupFeatureState& groupFeatures) {
     GroupStatus& group_info = m_groupStatus[group];
-    bool bEnabled = m_bEnabled && group_info.enabled;
 
-    // If the chain is not enabled and the group is not enabled and we are not
-    // ramping out then do nothing.
-    if (!bEnabled && !group_info.ramp_out) {
+    if (m_enableState == EffectProcessor::DISABLED
+            || group_info.enable_state == EffectProcessor::DISABLED) {
+        // If the chain is not enabled and the group is not enabled and we are not
+        // ramping out then do nothing.
         return;
+    }
+
+    enum EffectProcessor::EnableState effectiveEnableState = group_info.enable_state;
+
+    if (m_enableState == EffectProcessor::DISABLING) {
+        effectiveEnableState = EffectProcessor::DISABLING;
+    } else if (m_enableState == EffectProcessor::ENABLING) {
+        effectiveEnableState = EffectProcessor::ENABLING;
     }
 
     // At this point either the chain and group are enabled or we are ramping
     // out. If we are ramping out then ramp to 0 instead of m_dMix.
-    CSAMPLE wet_gain = group_info.ramp_out ? 0 : m_dMix;
+    CSAMPLE wet_gain = m_dMix;
     CSAMPLE wet_gain_old = group_info.old_gain;
 
     // INSERT mode: output = input * (1-wet) + effect(input) * wet
@@ -190,7 +180,7 @@ void EngineEffectChain::process(const QString& group,
                 }
                 pEffect->process(group, pInOut, pInOut,
                                  numSamples, sampleRate,
-                                 EffectProcessor::ENABLED, groupFeatures);
+                                 effectiveEnableState, groupFeatures);
             }
         } else if (wet_gain_old == 0.0 && wet_gain == 0.0) {
             // Fully dry, no ramp, insert optimization. No action is needed
@@ -209,7 +199,7 @@ void EngineEffectChain::process(const QString& group,
                 CSAMPLE* pIntermediateOutput = m_pBuffer;
                 pEffect->process(group, pIntermediateInput, pIntermediateOutput,
                                  numSamples, sampleRate,
-                                 EffectProcessor::ENABLED, groupFeatures);
+                                 effectiveEnableState, groupFeatures);
                 anyProcessed = true;
             }
 
@@ -237,7 +227,7 @@ void EngineEffectChain::process(const QString& group,
             CSAMPLE* pIntermediateOutput = m_pBuffer;
             pEffect->process(group, pIntermediateInput,
                              pIntermediateOutput, numSamples, sampleRate,
-                             EffectProcessor::ENABLED, groupFeatures);
+                             effectiveEnableState, groupFeatures);
             anyProcessed = true;
         }
 
@@ -250,5 +240,16 @@ void EngineEffectChain::process(const QString& group,
 
     // Update GroupStatus with the latest values.
     group_info.old_gain = wet_gain;
-    group_info.ramp_out = false;
+
+    if (m_enableState == EffectProcessor::DISABLING) {
+        m_enableState = EffectProcessor::DISABLED;
+    } else if (m_enableState == EffectProcessor::ENABLING) {
+        m_enableState = EffectProcessor::ENABLED;
+    }
+
+    if (group_info.enable_state == EffectProcessor::DISABLING) {
+        group_info.enable_state = EffectProcessor::DISABLED;
+    } else if (group_info.enable_state == EffectProcessor::ENABLING) {
+        group_info.enable_state = EffectProcessor::ENABLED;
+    }
 }

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -72,7 +72,7 @@ bool EngineEffectChain::updateParameters(const EffectsRequest& message) {
     // If our enabled state changed then tell each group to ramp in or out.
     if (wasEnabled ^ m_bEnabled) {
         for (QMap<QString, GroupStatus>::iterator it = m_groupStatus.begin();
-             it != m_groupStatus.end(); ++it) {
+                it != m_groupStatus.end(); ++it) {
             GroupStatus& status = it.value();
 
             if (m_bEnabled) {

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -189,7 +189,8 @@ void EngineEffectChain::process(const QString& group,
                     continue;
                 }
                 pEffect->process(group, pInOut, pInOut,
-                                 numSamples, sampleRate, groupFeatures);
+                                 numSamples, sampleRate,
+                                 EffectProcessor::ENABLED, groupFeatures);
             }
         } else if (wet_gain_old == 0.0 && wet_gain == 0.0) {
             // Fully dry, no ramp, insert optimization. No action is needed
@@ -207,7 +208,8 @@ void EngineEffectChain::process(const QString& group,
                 const CSAMPLE* pIntermediateInput = (i == 0) ? pInOut : m_pBuffer;
                 CSAMPLE* pIntermediateOutput = m_pBuffer;
                 pEffect->process(group, pIntermediateInput, pIntermediateOutput,
-                                 numSamples, sampleRate, groupFeatures);
+                                 numSamples, sampleRate,
+                                 EffectProcessor::ENABLED, groupFeatures);
                 anyProcessed = true;
             }
 
@@ -235,7 +237,7 @@ void EngineEffectChain::process(const QString& group,
             CSAMPLE* pIntermediateOutput = m_pBuffer;
             pEffect->process(group, pIntermediateInput,
                              pIntermediateOutput, numSamples, sampleRate,
-                             groupFeatures);
+                             EffectProcessor::ENABLED, groupFeatures);
             anyProcessed = true;
         }
 

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -32,10 +32,6 @@ class EngineEffectChain : public EffectsRequestHandler {
         return m_id;
     }
 
-    bool enabled() const {
-        return m_bEnabled;
-    }
-
     bool enabledForGroup(const QString& group) const;
 
   private:

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -46,7 +46,7 @@ class EngineEffectChain : public EffectsRequestHandler {
     bool disableForGroup(const QString& group);
 
     QString m_id;
-    enum EffectProcessor::EnableState m_enableState;
+    EffectProcessor::EnableState m_enableState;
     EffectChain::InsertionType m_insertionType;
     CSAMPLE m_dMix;
     QList<EngineEffect*> m_effects;
@@ -57,7 +57,7 @@ class EngineEffectChain : public EffectsRequestHandler {
                   enable_state(EffectProcessor::DISABLED) {
         }
         CSAMPLE old_gain;
-        enum EffectProcessor::EnableState enable_state;
+        EffectProcessor::EnableState enable_state;
     };
     QMap<QString, GroupStatus> m_groupStatus;
 

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -46,19 +46,18 @@ class EngineEffectChain : public EffectsRequestHandler {
     bool disableForGroup(const QString& group);
 
     QString m_id;
-    bool m_bEnabled;
+    enum EffectProcessor::EnableState m_enableState;
     EffectChain::InsertionType m_insertionType;
     CSAMPLE m_dMix;
     QList<EngineEffect*> m_effects;
     CSAMPLE* m_pBuffer;
     struct GroupStatus {
-        GroupStatus() : enabled(false),
-                        old_gain(0),
-                        ramp_out(false) {
+        GroupStatus()
+                : old_gain(0),
+                  enable_state(EffectProcessor::DISABLED) {
         }
-        bool enabled;
         CSAMPLE old_gain;
-        bool ramp_out;
+        enum EffectProcessor::EnableState enable_state;
     };
     QMap<QString, GroupStatus> m_groupStatus;
 

--- a/src/test/baseeffecttest.h
+++ b/src/test/baseeffecttest.h
@@ -38,7 +38,7 @@ class MockEffectProcessor : public EffectProcessor {
                                CSAMPLE* pOutput,
                                const unsigned int numSamples,
                                const unsigned int sampleRate,
-                               const enum EffectProcessor::EnableState enableState,
+                               const EffectProcessor::EnableState enableState,
                                const GroupFeatureState& groupFeatures));
 
     MOCK_METHOD1(initialize, void(const QSet<QString>& registeredGroups));

--- a/src/test/baseeffecttest.h
+++ b/src/test/baseeffecttest.h
@@ -34,10 +34,11 @@ class MockEffectProcessor : public EffectProcessor {
   public:
     MockEffectProcessor() {}
 
-    MOCK_METHOD6(process, void(const QString& group, const CSAMPLE* pInput,
+    MOCK_METHOD7(process, void(const QString& group, const CSAMPLE* pInput,
                                CSAMPLE* pOutput,
                                const unsigned int numSamples,
                                const unsigned int sampleRate,
+                               const enum EffectProcessor::EnableState enableState,
                                const GroupFeatureState& groupFeatures));
 
     MOCK_METHOD1(initialize, void(const QSet<QString>& registeredGroups));


### PR DESCRIPTION
This PR pipes the enable state transitions down to the effect itself.
So the effect can cleanup or init as required.

It offers also an option to bypass the raming from the effect framework at enable transitions.
An effect can set effectRampsFromDry to true and handle the required ramping itself.
This was introduced to the bitcrusher and to the bit perfect EQs

fixes https://bugs.launchpad.net/mixxx/+bug/1377705
