### PR TITLE
Bug 1210846 Auto Reset Gain & Eq after each song

### DIFF
--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -77,7 +77,10 @@ BaseTrackPlayer::BaseTrackPlayer(QObject* pParent,
 
     m_pEndOfTrack = new ControlObject(ConfigKey(group, "end_of_track"));
     m_pEndOfTrack->set(0.);
-
+    m_pLowFilterControlObject = new ControlObjectSlave(group,"filterLow");
+    m_pMidFilterControlObject = new ControlObjectSlave(group,"filterMid");
+    m_pHighFilterControlObject = new ControlObjectSlave(group,"filterHigh");
+    m_pPreGain = new ControlObjectSlave(ConfigKey(group, "pregain"));
     //BPM of the current song
     m_pBPM = new ControlObjectThread(group, "file_bpm");
     m_pKey = new ControlObjectThread(group, "file_key");
@@ -241,6 +244,12 @@ void BaseTrackPlayer::slotFinishLoading(TrackPointer pTrackInfoObject)
                 break;
             }
         }
+    }
+    if(m_pConfig->getValueString(ConfigKey("[Mixer Profile]", "EqAutoReset")).toInt()) {
+        m_pLowFilterControlObject->set(1.0);
+        m_pMidFilterControlObject->set(1.0);
+        m_pHighFilterControlObject->set(1.0);
+        m_pPreGain->set(1.0);
     }
 
     emit(newTrackLoaded(m_pLoadedTrack));

--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -249,7 +249,7 @@ void BaseTrackPlayer::slotFinishLoading(TrackPointer pTrackInfoObject)
             }
         }
     }
-    if(m_pConfig->getValueString(ConfigKey("[Mixer Profile]", "EqAutoReset")).toInt()) {
+    if(m_pConfig->getValueString(ConfigKey("[Mixer Profile]", "EqAutoReset"), 0).toInt()) {
         m_pLowFilter->set(1.0);
         m_pMidFilter->set(1.0);
         m_pHighFilter->set(1.0);

--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -77,9 +77,9 @@ BaseTrackPlayer::BaseTrackPlayer(QObject* pParent,
 
     m_pEndOfTrack = new ControlObject(ConfigKey(group, "end_of_track"));
     m_pEndOfTrack->set(0.);
-    m_pLowFilterControlObject = new ControlObjectSlave(group,"filterLow");
-    m_pMidFilterControlObject = new ControlObjectSlave(group,"filterMid");
-    m_pHighFilterControlObject = new ControlObjectSlave(group,"filterHigh");
+    m_pLowFilter = new ControlObjectSlave(group,"filterLow");
+    m_pMidFilter = new ControlObjectSlave(group,"filterMid");
+    m_pHighFilter = new ControlObjectSlave(group,"filterHigh");
     m_pPreGain = new ControlObjectSlave(ConfigKey(group, "pregain"));
     //BPM of the current song
     m_pBPM = new ControlObjectThread(group, "file_bpm");
@@ -104,6 +104,10 @@ BaseTrackPlayer::~BaseTrackPlayer()
     delete m_pKey;
     delete m_pReplayGain;
     delete m_pPlay;
+    delete m_pLowFilter;
+    delete m_pMidFilter;
+    delete m_pHighFilter;
+    delete m_pPreGain;
 }
 
 void BaseTrackPlayer::slotLoadTrack(TrackPointer track, bool bPlay) {
@@ -246,9 +250,9 @@ void BaseTrackPlayer::slotFinishLoading(TrackPointer pTrackInfoObject)
         }
     }
     if(m_pConfig->getValueString(ConfigKey("[Mixer Profile]", "EqAutoReset")).toInt()) {
-        m_pLowFilterControlObject->set(1.0);
-        m_pMidFilterControlObject->set(1.0);
-        m_pHighFilterControlObject->set(1.0);
+        m_pLowFilter->set(1.0);
+        m_pMidFilter->set(1.0);
+        m_pHighFilter->set(1.0);
         m_pPreGain->set(1.0);
     }
 

--- a/src/basetrackplayer.h
+++ b/src/basetrackplayer.h
@@ -11,6 +11,7 @@ class EngineMaster;
 class ControlObject;
 class ControlPotmeter;
 class ControlObjectThread;
+class ControlObjectSlave;
 class AnalyserQueue;
 class EffectsManager;
 
@@ -61,6 +62,10 @@ class BaseTrackPlayer : public BasePlayer {
     ControlObjectThread* m_pKey;
     ControlObjectThread* m_pReplayGain;
     ControlObjectThread* m_pPlay;
+    ControlObjectSlave* m_pLowFilterControlObject;
+    ControlObjectSlave* m_pMidFilterControlObject;
+    ControlObjectSlave* m_pHighFilterControlObject;
+    ControlObjectSlave* m_pPreGain;
     EngineDeck* m_pChannel;
 };
 

--- a/src/basetrackplayer.h
+++ b/src/basetrackplayer.h
@@ -62,9 +62,9 @@ class BaseTrackPlayer : public BasePlayer {
     ControlObjectThread* m_pKey;
     ControlObjectThread* m_pReplayGain;
     ControlObjectThread* m_pPlay;
-    ControlObjectSlave* m_pLowFilterControlObject;
-    ControlObjectSlave* m_pMidFilterControlObject;
-    ControlObjectSlave* m_pHighFilterControlObject;
+    ControlObjectSlave* m_pLowFilter;
+    ControlObjectSlave* m_pMidFilter;
+    ControlObjectSlave* m_pHighFilter;
     ControlObjectSlave* m_pPreGain;
     EngineDeck* m_pChannel;
 };

--- a/src/dlgprefeq.cpp
+++ b/src/dlgprefeq.cpp
@@ -37,9 +37,9 @@ DlgPrefEQ::DlgPrefEQ(QWidget* pParent, ConfigObject<ConfigValue>* pConfig)
           m_COTEnableEq(CONFIG_KEY, ENABLE_INTERNAL_EQ),
           m_pConfig(pConfig),
           m_lowEqFreq(0.0),
+          m_bEqAutoReset(false),
           m_highEqFreq(0.0) {
     setupUi(this);
-
     // Connection
     connect(SliderHiEQ, SIGNAL(valueChanged(int)), this, SLOT(slotUpdateHiEQ()));
     connect(SliderHiEQ, SIGNAL(sliderMoved(int)), this, SLOT(slotUpdateHiEQ()));
@@ -52,7 +52,7 @@ DlgPrefEQ::DlgPrefEQ(QWidget* pParent, ConfigObject<ConfigValue>* pConfig)
     connect(radioButton_bypass, SIGNAL(clicked()), this, SLOT(slotEqChanged()));
     connect(radioButton_bessel4, SIGNAL(clicked()), this, SLOT(slotEqChanged()));
     connect(radioButton_butterworth8, SIGNAL(clicked()), this, SLOT(slotEqChanged()));
-
+    connect(bEqAutoReset, SIGNAL(stateChanged(int)), this, SLOT(slotEqAutoReset(int)));
     loadSettings();
     slotUpdate();
     slotApply();
@@ -66,6 +66,7 @@ void DlgPrefEQ::loadSettings() {
     QString highEqPrecise = m_pConfig->getValueString(ConfigKey(CONFIG_KEY, "HiEQFrequencyPrecise"));
     QString lowEqCourse = m_pConfig->getValueString(ConfigKey(CONFIG_KEY, "LoEQFrequency"));
     QString lowEqPrecise = m_pConfig->getValueString(ConfigKey(CONFIG_KEY, "LoEQFrequencyPrecise"));
+    m_bEqAutoReset = static_cast<bool>(m_pConfig->getValueString(ConfigKey(CONFIG_KEY, "EqAutoReset")).toInt());
 
     double lowEqFreq = 0.0;
     double highEqFreq = 0.0;
@@ -121,6 +122,7 @@ void DlgPrefEQ::slotResetToDefaults() {
     radioButton_bypass->setChecked(false);
     radioButton_butterworth8->setChecked(false);
     radioButton_bessel4->setChecked(true);
+    m_bEqAutoReset = false;
     slotEqChanged();
     setDefaultShelves();
     loadSettings();
@@ -207,7 +209,9 @@ int DlgPrefEQ::getSliderPosition(double eqFreq, int minValue, int maxValue)
 void DlgPrefEQ::slotApply() {
     m_COTLoFreq.slotSet(m_lowEqFreq);
     m_COTHiFreq.slotSet(m_highEqFreq);
-
+    
+    m_pConfig->set(ConfigKey(CONFIG_KEY,"EqAutoReset"),
+            ConfigValue(m_bEqAutoReset? 1 : 0));
     m_COTLoFi.slotSet((m_pConfig->getValueString(
             ConfigKey(CONFIG_KEY, "LoFiEQs")) == QString("yes")));
     m_COTEnableEq.slotSet((m_pConfig->getValueString(
@@ -218,6 +222,12 @@ void DlgPrefEQ::slotUpdate() {
     slotUpdateLoEQ();
     slotUpdateHiEQ();
     slotEqChanged();
+    bEqAutoReset->setChecked(m_bEqAutoReset);
+}
+
+void DlgPrefEQ::slotEqAutoReset(int i) {
+    m_bEqAutoReset = static_cast<bool>(i);
+    slotUpdate();
 }
 
 double DlgPrefEQ::getEqFreq(int sliderVal, int minValue, int maxValue) {

--- a/src/dlgprefeq.cpp
+++ b/src/dlgprefeq.cpp
@@ -31,13 +31,13 @@ const int kFrequencyLowerLimit = 16;
 
 DlgPrefEQ::DlgPrefEQ(QWidget* pParent, ConfigObject<ConfigValue>* pConfig)
         : DlgPreferencePage(pParent),
+          m_bEqAutoReset(false),
           m_COTLoFreq(CONFIG_KEY, "LoEQFrequency"),
           m_COTHiFreq(CONFIG_KEY, "HiEQFrequency"),
           m_COTLoFi(CONFIG_KEY, "LoFiEQs"),
           m_COTEnableEq(CONFIG_KEY, ENABLE_INTERNAL_EQ),
           m_pConfig(pConfig),
           m_lowEqFreq(0.0),
-          m_bEqAutoReset(false),
           m_highEqFreq(0.0) {
     setupUi(this);
     // Connection
@@ -53,6 +53,7 @@ DlgPrefEQ::DlgPrefEQ(QWidget* pParent, ConfigObject<ConfigValue>* pConfig)
     connect(radioButton_bessel4, SIGNAL(clicked()), this, SLOT(slotEqChanged()));
     connect(radioButton_butterworth8, SIGNAL(clicked()), this, SLOT(slotEqChanged()));
     connect(bEqAutoReset, SIGNAL(stateChanged(int)), this, SLOT(slotEqAutoReset(int)));
+
     loadSettings();
     slotUpdate();
     slotApply();
@@ -211,7 +212,7 @@ void DlgPrefEQ::slotApply() {
     m_COTHiFreq.slotSet(m_highEqFreq);
     
     m_pConfig->set(ConfigKey(CONFIG_KEY,"EqAutoReset"),
-            ConfigValue(m_bEqAutoReset? 1 : 0));
+            ConfigValue(m_bEqAutoReset ? 1 : 0));
     m_COTLoFi.slotSet((m_pConfig->getValueString(
             ConfigKey(CONFIG_KEY, "LoFiEQs")) == QString("yes")));
     m_COTEnableEq.slotSet((m_pConfig->getValueString(

--- a/src/dlgprefeq.h
+++ b/src/dlgprefeq.h
@@ -29,12 +29,12 @@
 /**
   *@author John Sully
   */
-
 class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     Q_OBJECT
   public:
     DlgPrefEQ(QWidget *parent, ConfigObject<ConfigValue>* _config);
     virtual ~DlgPrefEQ();
+    bool m_bEqAutoReset;
 
   public slots:
     void slotEqChanged();
@@ -46,6 +46,7 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     void slotApply();
     void slotUpdate();
     void slotResetToDefaults();
+    void slotEqAutoReset(int);
 
   signals:
     void apply(const QString &);

--- a/src/dlgprefeqdlg.ui
+++ b/src/dlgprefeqdlg.ui
@@ -58,7 +58,10 @@
      <item>
       <widget class="QCheckBox" name="bEqAutoReset">
        <property name="text">
-        <string>Enable Equalizer Auto Reset</string>
+        <string>Reset equalizers on track load</string>
+       </property>
+       <property name="toolTip">
+        <string>Resets the equalizers to their default values when loading a track</string>
        </property>
       </widget>
      </item> 

--- a/src/dlgprefeqdlg.ui
+++ b/src/dlgprefeqdlg.ui
@@ -55,6 +55,13 @@
        </attribute>
       </widget>
      </item>
+     <item>
+      <widget class="QCheckBox" name="bEqAutoReset">
+       <property name="text">
+        <string>Enable Equalizer Auto Reset</string>
+       </property>
+      </widget>
+     </item> 
     </layout>
    </item>
    <item>


### PR DESCRIPTION
-Added a checkbox under preferences->equalizers for enabling Auto EQ/Gain
Reset
-If checked, resets the pregain, lowgain, midgain & highgain to defaults when a new
song is loaded
