### PR TITLE
[WORK IN PROGRESS] SoundSource fixes

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -659,6 +659,7 @@ class MixxxCore(Feature):
                    "upgrade.cpp",
 
                    "soundsource.cpp",
+                   "soundsourcetaglib.cpp",
 
                    "sharedglcontext.cpp",
                    "widget/controlwidgetconnection.cpp",

--- a/plugins/soundsourcem4a/SConscript
+++ b/plugins/soundsourcem4a/SConscript
@@ -13,6 +13,7 @@ Import('build')
 m4a_sources = [
     "soundsource.cpp", # required to subclass soundsource
     "soundsourcem4a.cpp",  # MP4/M4A Support through FAAD/libmp4v2
+    "sampleutil.cpp", # utility functions
 ]
 
 #Tell SCons to build the SoundSourceM4A plugin

--- a/plugins/soundsourcem4a/SConscript
+++ b/plugins/soundsourcem4a/SConscript
@@ -12,6 +12,7 @@ Import('build')
 
 m4a_sources = [
     "soundsource.cpp", # required to subclass soundsource
+    "soundsourcetaglib.cpp", # TagLib dependencies
     "soundsourcem4a.cpp",  # MP4/M4A Support through FAAD/libmp4v2
     "sampleutil.cpp", # utility functions
 ]

--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -30,6 +30,7 @@
 
 #include <QtDebug>
 #include "soundsourcem4a.h"
+#include "sampleutil.h"
 #include "m4a/mp4-mixxx.cpp"
 
 namespace Mixxx {
@@ -147,13 +148,8 @@ unsigned SoundSourceM4A::read(volatile unsigned long size, const SAMPLE* destina
 
     // At this point *destination should be filled. If mono : double all samples
     // (L => R)
-    if (m_iChannels == 1) {
-        for (int i = total_bytes_decoded/2-1; i >= 0; --i) {
-            // as_buffer[i] is an audio sample (s16)
-            //scroll through , copying L->R & expanding buffer
-            as_buffer[i*2+1] = as_buffer[i];
-            as_buffer[i*2] = as_buffer[i];
-        }
+    if (1 == m_iChannels) {
+        SampleUtil::inPlaceMonoToStereo(as_buffer, total_bytes_decoded / 2);
     }
 
     // Tell us about it only if we end up decoding a different value

--- a/plugins/soundsourcem4a/soundsourcem4a.h
+++ b/plugins/soundsourcem4a/soundsourcem4a.h
@@ -52,10 +52,11 @@ class SoundSourceM4A : public SoundSource {
         QImage parseCoverArt();
         static QList<QString> supportedFileExtensions();
     private:
-        int trackId;
-        unsigned long filelength;
         MP4FileHandle mp4file;
         input_plugin_data ipd;
+        int trackId;
+        int channels;
+        unsigned long filelength;
 };
 
 extern "C" MY_EXPORT const char* getMixxxVersion()

--- a/plugins/soundsourcem4a/soundsourcem4a.h
+++ b/plugins/soundsourcem4a/soundsourcem4a.h
@@ -17,6 +17,12 @@
 #ifndef SOUNDSOURCEM4A_H
 #define SOUNDSOURCEM4A_H
 
+#include "soundsource.h"
+
+#include "m4a/ip.h"
+
+#include "defs_version.h"
+
 #ifdef __MP4V2__
     #include <mp4v2/mp4v2.h>
 #else
@@ -24,11 +30,9 @@
 #endif
 
 #include <neaacdec.h>
+
 #include <QString>
-#include "soundsource.h"
-#include "defs_version.h"
-#include "m4a/ip.h"
-#include "util/defs.h"
+#include <QDebug>
 
 //As per QLibrary docs: http://doc.trolltech.com/4.6/qlibrary.html#resolve
 #ifdef Q_OS_WIN
@@ -36,6 +40,7 @@
 #else
 #define MY_EXPORT
 #endif
+
 
 namespace Mixxx {
 

--- a/plugins/soundsourcemediafoundation/SConscript
+++ b/plugins/soundsourcemediafoundation/SConscript
@@ -18,7 +18,7 @@ if int(build.flags['mediafoundation']):
     else:
         env["LINKFLAGS"].remove("/subsystem:windows,5.01")
     ssmediafoundation_bin = env.SharedLibrary('soundsourcemediafoundation',
-        ['soundsource.cpp', 'soundsourcemediafoundation.cpp'],
+        ['soundsource.cpp', 'soundsourcetaglib.cpp', 'soundsourcemediafoundation.cpp'],
         LINKCOM  = [env['LINKCOM'],
             'mt.exe -nologo -manifest ${TARGET}.manifest -outputresource:$TARGET;1'])
     Return("ssmediafoundation_bin")

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -88,11 +88,11 @@ SoundSourceMediaFoundation::~SoundSourceMediaFoundation()
 Result SoundSourceMediaFoundation::open()
 {
     if (sDebug) {
-        qDebug() << "open()" << m_qFilename;
+        qDebug() << "open()" << getFilename();
     }
 
-    QString qurlStr(m_qFilename);
-    int wcFilenameLength(m_qFilename.toWCharArray(m_wcFilename));
+    QString qurlStr(getFilename());
+    int wcFilenameLength(getFilename().toWCharArray(m_wcFilename));
     // toWCharArray does not append a null terminator to the string!
     m_wcFilename[wcFilenameLength] = '\0';
 
@@ -114,7 +114,7 @@ Result SoundSourceMediaFoundation::open()
     // Create the source reader to read the input file.
     hr = MFCreateSourceReaderFromURL(m_wcFilename, NULL, &m_pReader);
     if (FAILED(hr)) {
-        qWarning() << "SSMF: Error opening input file:" << m_qFilename;
+        qWarning() << "SSMF: Error opening input file:" << getFilename();
         return ERR;
     }
 

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -30,6 +30,7 @@
 #include <propvarutil.h>
 
 #include "soundsourcemediafoundation.h"
+#include "soundsourcetaglib.h"
 
 const int kBitsPerSample = 16;
 const int kNumChannels = 2;
@@ -379,22 +380,23 @@ Result SoundSourceMediaFoundation::parseHeader()
 
     // Must be toLocal8Bit since Windows fopen does not do UTF-8
     TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
-    bool result = processTaglibFile(f);
-    TagLib::MP4::Tag* tag = f.tag();
-
-    if (tag) {
-        processMP4Tag(tag);
+    if (!readFileHeader(this, f)) {
+        return ERR;
+    }
+    TagLib::MP4::Tag *mp4(f.tag());
+    if (mp4) {
+        readMP4Tag(this, *mp4);
+    } else {
+        return ERR;
     }
 
-    if (result)
-        return OK;
-    return ERR;
+    return OK;
 }
 
 QImage SoundSourceMediaFoundation::parseCoverArt() {
     setType("m4a");
     TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
-    return getCoverInMP4Tag(f.tag());
+    return Mixxx::getCoverInMP4Tag(f.tag());
 }
 
 // static

--- a/plugins/soundsourcewv/SConscript
+++ b/plugins/soundsourcewv/SConscript
@@ -12,6 +12,7 @@ Import('build')
 
 wv_sources = [
     "soundsource.cpp", # required to subclass soundsource
+    "soundsourcetaglib.cpp", # TagLib dependencies
     "soundsourcewv.cpp",  # Wavpack support
     "sampleutil.cpp", # utility functions
 ]

--- a/plugins/soundsourcewv/SConscript
+++ b/plugins/soundsourcewv/SConscript
@@ -13,6 +13,7 @@ Import('build')
 wv_sources = [
     "soundsource.cpp", # required to subclass soundsource
     "soundsourcewv.cpp",  # Wavpack support
+    "sampleutil.cpp", # utility functions
 ]
 
 

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -8,6 +8,7 @@
 #include <taglib/wavpackfile.h>
 
 #include "soundsourcewv.h"
+#include "sampleutil.h"
 
 namespace Mixxx {
 
@@ -104,10 +105,7 @@ unsigned SoundSourceWV::read(volatile unsigned long size, const SAMPLE* destinat
     }
 
     if (m_iChannels==1) {       //if MONO : expand array to double it's size; see ssov.cpp
-        for(int i=(sampsread/2-1); i>=0; i--) { //algo courtesy of rryan !
-            dest[i*2]     = dest[i];    //go through array backwards, expanding and copying L -> R
-            dest[(i*2)+1] = dest[i];
-        }
+        SampleUtil::inPlaceMonoToStereo(dest, sampsread / 2);
     }
 
     return sampsread;

--- a/plugins/soundsourcewv/soundsourcewv.h
+++ b/plugins/soundsourcewv/soundsourcewv.h
@@ -35,9 +35,10 @@ class SoundSourceWV : public SoundSource {
   QImage parseCoverArt();
   static QList<QString> supportedFileExtensions();
  private:
+  WavpackContext * filewvc; //works as a file handle to access the wv file.
   int Bps;
+  int channels;
   unsigned long filelength;
-  WavpackContext * filewvc;	//works as a file handle to access the wv file.
   int32_t tempbuffer[WV_BUF_LENGTH];	//hax ! legacy from cmus. this is 64k*4bytes.
   void format_samples(int, char *, int32_t *, uint32_t);
 };

--- a/src/analyserqueue.cpp
+++ b/src/analyserqueue.cpp
@@ -8,6 +8,7 @@
 #include "analyserqueue.h"
 #include "soundsourceproxy.h"
 #include "playerinfo.h"
+#include "sampleutil.h"
 #include "util/timer.h"
 #include "library/trackcollection.h"
 #include "analyserwaveform.h"
@@ -199,9 +200,7 @@ bool AnalyserQueue::doAnalysis(TrackPointer tio, Mixxx::SoundSource* pSoundSourc
 
         // Normalize the samples from [SHRT_MIN, SHRT_MAX] to [-1.0, 1.0].
         // TODO(rryan): Change the SoundSource API to do this for us.
-        for (int i = 0; i < read; ++i) {
-            m_pSamples[i] = static_cast<CSAMPLE>(m_pSamplesPCM[i]) / SHRT_MAX;
-        }
+        SampleUtil::convertS16ToFloat32(m_pSamples, m_pSamplesPCM, read);
 
         QListIterator<Analyser*> it(m_aq);
 

--- a/src/analyserqueue.cpp
+++ b/src/analyserqueue.cpp
@@ -160,7 +160,7 @@ TrackPointer AnalyserQueue::dequeueNextBlocking() {
 }
 
 // This is called from the AnalyserQueue thread
-bool AnalyserQueue::doAnalysis(TrackPointer tio, Mixxx::SoundSource* pSoundSource) {
+bool AnalyserQueue::doAnalysis(TrackPointer tio, Mixxx::SoundSourcePointer pSoundSource) {
     int totalSamples = pSoundSource->length();
     //qDebug() << tio->getFilename() << " has " << totalSamples << " samples.";
     int processedSamples = 0;
@@ -308,10 +308,10 @@ void AnalyserQueue::run() {
             continue;
         }
 
-        Mixxx::SoundSource* pSoundSource = soundSourceProxy.getProxiedSoundSource();
+        Mixxx::SoundSourcePointer pSoundSource(soundSourceProxy.getSoundSource());
+
         int iNumSamples = pSoundSource->length();
         int iSampleRate = pSoundSource->getSampleRate();
-
         if (iNumSamples == 0 || iSampleRate == 0) {
             qDebug() << "Skipping invalid file:" << nextTrack->getLocation();
             continue;

--- a/src/analyserqueue.h
+++ b/src/analyserqueue.h
@@ -11,7 +11,11 @@
 #include "analyser.h"
 #include "trackinfoobject.h"
 
-class SoundSourceProxy;
+namespace Mixxx
+{
+    // forward declaration(s) from namespace Mixxx
+    class SoundSource;
+}
 class TrackCollection;
 
 class AnalyserQueue : public QThread {
@@ -58,7 +62,7 @@ class AnalyserQueue : public QThread {
 
     bool isLoadedTrackWaiting(TrackPointer tio);
     TrackPointer dequeueNextBlocking();
-    bool doAnalysis(TrackPointer tio, SoundSourceProxy* pSoundSource);
+    bool doAnalysis(TrackPointer tio, Mixxx::SoundSource* pSoundSource);
     void emitUpdateProgress(TrackPointer tio, int progress);
 
     bool m_exit;

--- a/src/analyserqueue.h
+++ b/src/analyserqueue.h
@@ -10,12 +10,8 @@
 #include "configobject.h"
 #include "analyser.h"
 #include "trackinfoobject.h"
+#include "soundsource.h"
 
-namespace Mixxx
-{
-    // forward declaration(s) from namespace Mixxx
-    class SoundSource;
-}
 class TrackCollection;
 
 class AnalyserQueue : public QThread {
@@ -62,7 +58,7 @@ class AnalyserQueue : public QThread {
 
     bool isLoadedTrackWaiting(TrackPointer tio);
     TrackPointer dequeueNextBlocking();
-    bool doAnalysis(TrackPointer tio, Mixxx::SoundSource* pSoundSource);
+    bool doAnalysis(TrackPointer tio, Mixxx::SoundSourcePointer pSoundSource);
     void emitUpdateProgress(TrackPointer tio, int progress);
 
     bool m_exit;

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -82,13 +82,9 @@ void CachingReaderWorker::processChunkReadRequest(ChunkReadRequest* request,
     // SSE.
     CSAMPLE* buffer = request->chunk->data;
     //qDebug() << "Reading into " << buffer;
-    SampleUtil::convert(buffer, m_pSample, samples_read);
-
     // Normalize the samples from [SHRT_MIN, SHRT_MAX] to [-1.0, 1.0].
     // TODO(rryan): Change the SoundSource API to do this for us.
-    for (int i = 0; i < samples_read; ++i) {
-        buffer[i] /= SHRT_MAX;
-    }
+    SampleUtil::convertS16ToFloat32(buffer, m_pSample, samples_read);
 
     update->status = CHUNK_READ_SUCCESS;
     update->chunk->length = samples_read;

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -33,7 +33,6 @@ CachingReaderWorker::CachingReaderWorker(const char* group,
           m_tag(QString("CachingReaderWorker %1").arg(m_pGroup)),
           m_pChunkReadRequestFIFO(pChunkReadRequestFIFO),
           m_pReaderStatusFIFO(pReaderStatusFIFO),
-          m_pCurrentSoundSource(NULL),
           m_iTrackNumSamples(0),
           m_pSample(NULL),
           m_stop(0) {
@@ -42,7 +41,6 @@ CachingReaderWorker::CachingReaderWorker(const char* group,
 
 CachingReaderWorker::~CachingReaderWorker() {
     delete [] m_pSample;
-    delete m_pCurrentSoundSource;
 }
 
 void CachingReaderWorker::processChunkReadRequest(ChunkReadRequest* request,
@@ -52,7 +50,7 @@ void CachingReaderWorker::processChunkReadRequest(ChunkReadRequest* request,
     update->chunk = request->chunk;
     update->chunk->length = 0;
 
-    if (m_pCurrentSoundSource == NULL || chunk_number < 0) {
+    if (!m_pCurrentSoundSource || chunk_number < 0) {
         update->status = CHUNK_READ_INVALID;
         return;
     }
@@ -142,10 +140,7 @@ void CachingReaderWorker::loadTrack(TrackPointer pTrack) {
     status.chunk = NULL;
     status.trackNumSamples = 0;
 
-    if (m_pCurrentSoundSource != NULL) {
-        delete m_pCurrentSoundSource;
-        m_pCurrentSoundSource = NULL;
-    }
+    m_pCurrentSoundSource.reset();
     m_iTrackNumSamples = 0;
 
     QString filename = pTrack->getLocation();
@@ -161,7 +156,7 @@ void CachingReaderWorker::loadTrack(TrackPointer pTrack) {
         return;
     }
 
-    m_pCurrentSoundSource = new SoundSourceProxy(pTrack);
+    m_pCurrentSoundSource.reset(new SoundSourceProxy(pTrack));
     bool openSucceeded = (m_pCurrentSoundSource->open() == OK); //Open the song for reading
     unsigned int trackSampleRate = m_pCurrentSoundSource->getSampleRate();
     m_iTrackNumSamples = status.trackNumSamples =

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -6,17 +6,16 @@
 #include <QSemaphore>
 #include <QThread>
 #include <QString>
-#include <QScopedPointer>
 
+#include "soundsource.h"
 #include "trackinfoobject.h"
 #include "engine/engineworker.h"
 #include "util/fifo.h"
 #include "util/types.h"
 
 
-namespace Mixxx {
-    class SoundSource;
-}
+// forward declaration(s)
+class SoundSourceProxy;
 
 // A Chunk is a section of audio that is being cached. The chunk_number can be
 // used to figure out the sample number of the first sample in data by using
@@ -113,7 +112,7 @@ class CachingReaderWorker : public EngineWorker {
                                  ReaderStatusUpdate* update);
 
     // The current sound source of the track loaded
-    QScopedPointer<Mixxx::SoundSource> m_pCurrentSoundSource;
+    Mixxx::SoundSourcePointer m_pCurrentSoundSource;
     int m_iTrackNumSamples;
 
     // Temporary buffer for reading from SoundSources

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -6,11 +6,13 @@
 #include <QSemaphore>
 #include <QThread>
 #include <QString>
+#include <QScopedPointer>
 
 #include "trackinfoobject.h"
 #include "engine/engineworker.h"
 #include "util/fifo.h"
 #include "util/types.h"
+
 
 namespace Mixxx {
     class SoundSource;
@@ -110,7 +112,7 @@ class CachingReaderWorker : public EngineWorker {
                                  ReaderStatusUpdate* update);
 
     // The current sound source of the track loaded
-    Mixxx::SoundSource* m_pCurrentSoundSource;
+    QScopedPointer<Mixxx::SoundSource> m_pCurrentSoundSource;
     int m_iTrackNumSamples;
 
     // Temporary buffer for reading from SoundSources

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -48,9 +48,10 @@ typedef struct ReaderStatusUpdate {
     ReaderStatus status;
     Chunk* chunk;
     int trackNumSamples;
-    ReaderStatusUpdate() {
-        status = INVALID;
-        chunk = NULL;
+    ReaderStatusUpdate()
+        : status(INVALID)
+        , chunk(NULL)
+        , trackNumSamples(0) {
     }
 } ReaderStatusUpdate;
 

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -41,11 +41,11 @@ class CoverArtUtils {
         SecurityTokenPointer securityToken = Sandbox::openSecurityToken(
             QDir(trackLocation), true);
         SoundSourceProxy proxy(trackLocation, securityToken);
-        Mixxx::SoundSource* pProxiedSoundSource = proxy.getProxiedSoundSource();
+        Mixxx::SoundSourcePointer pProxiedSoundSource(proxy.getSoundSource());
         if (pProxiedSoundSource == NULL) {
             return QImage();
         }
-        return proxy.parseCoverArt();
+        return pProxiedSoundSource->parseCoverArt();
     }
 
     static QImage loadCover(const CoverInfo& info) {

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1625,9 +1625,9 @@ void TrackDAO::detectCoverArtForUnknownTracks(volatile bool* pCancel,
 
         SecurityTokenPointer pToken = Sandbox::openSecurityToken(trackInfo, true);
         SoundSourceProxy proxy(trackLocation, pToken);
-        Mixxx::SoundSource* pProxiedSoundSource = proxy.getProxiedSoundSource();
-        if (pProxiedSoundSource != NULL) {
-            QImage image = proxy.parseCoverArt();
+        Mixxx::SoundSourcePointer pProxiedSoundSource(proxy.getSoundSource());
+        if (pProxiedSoundSource) {
+            QImage image = pProxiedSoundSource->parseCoverArt();
             if (!image.isNull()) {
                 updateQuery.bindValue(":coverart_type",
                                       static_cast<int>(CoverInfo::METADATA));

--- a/src/musicbrainz/chromaprinter.h
+++ b/src/musicbrainz/chromaprinter.h
@@ -5,7 +5,11 @@
 
 #include "trackinfoobject.h"
 
-class SoundSourceProxy;
+// forward declaration(s)
+namespace Mixxx
+{
+    class SoundSource;
+}
 
 class chromaprinter: public QObject {
   Q_OBJECT
@@ -16,7 +20,7 @@ class chromaprinter: public QObject {
 
   private:
 
-    QString calcFingerPrint(SoundSourceProxy& soundSource);
+    QString calcFingerPrint(Mixxx::SoundSource* pSoundSource);
     unsigned int m_NumSamples;
     unsigned int m_SampleRate;
 };

--- a/src/sampleutil.cpp
+++ b/src/sampleutil.cpp
@@ -189,11 +189,15 @@ void SampleUtil::copyWithRampingGain(CSAMPLE* pDest, const CSAMPLE* pSrc,
     // applyGain(pDest, gain);
 }
 
+namespace
+{
+    CSAMPLE const kSampleScale(1.0f / CSAMPLE(SHRT_MAX));
+}
+
 // static
-void SampleUtil::convert(CSAMPLE* pDest, const SAMPLE* pSrc,
-                         int iNumSamples) {
+void SampleUtil::convertS16ToFloat32(CSAMPLE* pDest, const SAMPLE* pSrc, int iNumSamples) {
     for (int i = 0; i < iNumSamples; ++i) {
-        pDest[i] = pSrc[i];
+        pDest[i] = CSAMPLE(pSrc[i]) * kSampleScale;
     }
 }
 

--- a/src/sampleutil.cpp
+++ b/src/sampleutil.cpp
@@ -12,6 +12,8 @@ typedef qint32 int32_t;
 #include "sampleutil.h"
 #include "util/math.h"
 
+#include <climits>
+
 // static
 CSAMPLE* SampleUtil::alloc(unsigned int size) {
     // TODO(XXX) align the array
@@ -240,6 +242,15 @@ void SampleUtil::copyClampBuffer(CSAMPLE* pDest, const CSAMPLE* pSrc,
                                  int iNumSamples) {
     for (int i = 0; i < iNumSamples; ++i) {
         pDest[i] = clampSample(pSrc[i]);
+    }
+}
+
+// static
+void SampleUtil::inPlaceMonoToStereo(SAMPLE* pBuffer, int numMonoSamples) {
+    int sampleOffset = numMonoSamples;
+    while (0 < sampleOffset--) {
+        pBuffer[sampleOffset * 2] = pBuffer[sampleOffset];
+        pBuffer[sampleOffset * 2 + 1] = pBuffer[sampleOffset];
     }
 }
 

--- a/src/sampleutil.h
+++ b/src/sampleutil.h
@@ -124,6 +124,10 @@ class SampleUtil {
         return in;
     }
 
+    // Doubles the samples in pBuffer in-place. pBuffer must have at least
+    // space for (numMonoSamples * 2) samples.
+    static void inPlaceMonoToStereo(SAMPLE* pBuffer, int numMonoSamples);
+
     // Interleave the samples in pSrc1 and pSrc2 into pDest. iNumSamples must be
     // the number of samples in pSrc1 and pSrc2, and pDest must have at least
     // space for iNumSamples*2 samples. pDest must not be an alias of pSrc1 or

--- a/src/sampleutil.h
+++ b/src/sampleutil.h
@@ -90,9 +90,9 @@ class SampleUtil {
     static void copyWithRampingGain(CSAMPLE* pDest, const CSAMPLE* pSrc,
                                     CSAMPLE old_gain, CSAMPLE new_gain, int iNumSamples);
 
-    // Convert a buffer of SAMPLEs to a buffer of CSAMPLEs. Does not work
-    // in-place! pDest and pSrc must not be aliased.
-    static void convert(CSAMPLE* pDest, const SAMPLE* pSrc, int iNumSamples);
+    // Convert and normalize a buffer of SAMPLEs in the range [-SHRT_MAX, SHRT_MAX]
+    // to a buffer of CSAMPLEs in the range [-1.0, 1.0].
+    static void convertS16ToFloat32(CSAMPLE* pDest, const SAMPLE* pSrc, int iNumSamples);
 
     // For each pair of samples in pBuffer (l,r) -- stores the sum of the
     // absolute values of l in pfAbsL, and the sum of the absolute values of r

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -36,8 +36,28 @@
 namespace Mixxx
 {
 
-// static
-const bool SoundSource::s_bDebugMetadata = false;
+namespace
+{
+    const bool s_bDebugMetadata = false;
+
+    // Taglib strings can be NULL and using it could cause some segfaults,
+    // so in this case it will return a QString()
+    inline
+    QString toQString(TagLib::String tstring) {
+        if (tstring == TagLib::String::null) {
+            return QString();
+        }
+        return TStringToQString(tstring);
+    }
+
+    float str2bpm( QString sBpm ) {
+      float bpm = sBpm.toFloat();
+      if(bpm < 60) bpm = 0;
+      while( bpm > 300 ) bpm = bpm / 10.;
+      return bpm;
+    }
+
+}
 
 /*
    SoundSource is an Uber-class for the reading and decoding of audio-files.
@@ -55,181 +75,13 @@ SoundSource::SoundSource(QString qFilename)
         : m_qFilename(qFilename),
           m_fReplayGain(0.0f),
           m_fBPM(0.0f),
-          m_iDuration(0),
+          m_iChannels(0),
           m_iBitrate(0),
           m_iSampleRate(0),
-          m_iChannels(0) {
+          m_iDuration(0) {
 }
 
 SoundSource::~SoundSource() {
-}
-
-QList<long> *SoundSource::getCuePoints()
-{
-    return 0;
-}
-
-QString SoundSource::getFilename()
-{
-    return m_qFilename;
-}
-
-float SoundSource::str2bpm( QString sBpm ) {
-  float bpm = sBpm.toFloat();
-  if(bpm < 60) bpm = 0;
-  while( bpm > 300 ) bpm = bpm / 10.;
-  return bpm;
-}
-
-QString SoundSource::getArtist()
-{
-    return m_sArtist;
-}
-QString SoundSource::getTitle()
-{
-    return m_sTitle;
-}
-QString SoundSource::getAlbum()
-{
-    return m_sAlbum;
-}
-QString SoundSource::getAlbumArtist()
-{
-    return m_sAlbumArtist;
-}
-QString SoundSource::getType()
-{
-    return m_sType;
-}
-QString SoundSource::getComment()
-{
-    return m_sComment;
-}
-QString SoundSource::getYear()
-{
-    return m_sYear;
-}
-QString SoundSource::getGenre()
-{
-    return m_sGenre;
-}
-QString SoundSource::getComposer()
-{
-    return m_sComposer;
-}
-QString SoundSource::getGrouping()
-{
-    return m_sGrouping;
-}
-QString SoundSource::getTrackNumber()
-{
-    return m_sTrackNumber;
-}
-float SoundSource::getReplayGain()
-{
-    return m_fReplayGain;
-}
-float SoundSource::getBPM()
-{
-    return m_fBPM;
-}
-int SoundSource::getDuration()
-{
-    return m_iDuration;
-}
-int SoundSource::getBitrate()
-{
-    return m_iBitrate;
-}
-unsigned int SoundSource::getSampleRate()
-{
-    return m_iSampleRate;
-}
-int SoundSource::getChannels()
-{
-    return m_iChannels;
-}
-
-void SoundSource::setArtist(QString artist)
-{
-    m_sArtist = artist;
-}
-void SoundSource::setTitle(QString title)
-{
-    m_sTitle = title;
-}
-void SoundSource::setAlbumArtist(QString albumArtist)
-{
-    m_sAlbumArtist = albumArtist;
-}
-void SoundSource::setAlbum(QString album)
-{
-    m_sAlbum = album;
-}
-void SoundSource::setComment(QString comment)
-{
-    m_sComment = comment;
-}
-void SoundSource::setType(QString type)
-{
-    m_sType = type;
-}
-void SoundSource::setYear(QString year)
-{
-    m_sYear = year;
-}
-void SoundSource::setGenre(QString genre)
-{
-    m_sGenre = genre;
-}
-void SoundSource::setComposer(QString composer)
-{
-    m_sComposer = composer;
-}
-void SoundSource::setGrouping(QString grouping)
-{
-    m_sGrouping = grouping;
-}
-void SoundSource::setTrackNumber(QString trackNumber)
-{
-    m_sTrackNumber = trackNumber;
-}
-void SoundSource::setReplayGain(float replaygain)
-{
-    m_fReplayGain = replaygain;
-}
-void SoundSource::setBPM(float bpm)
-{
-    m_fBPM = bpm;
-}
-void SoundSource::setDuration(int duration)
-{
-    m_iDuration = duration;
-}
-void SoundSource::setBitrate(int bitrate)
-{
-    m_iBitrate = bitrate;
-}
-void SoundSource::setSampleRate(unsigned int samplerate)
-{
-    m_iSampleRate = samplerate;
-}
-void SoundSource::setChannels(int channels)
-{
-    m_iChannels = channels;
-}
-QString SoundSource::getKey(){
-    return m_sKey;
-}
-void SoundSource::setKey(QString key){
-    m_sKey = key;
-}
-
-QString SoundSource::toQString(TagLib::String tstring) const {
-    if (tstring == TagLib::String::null) {
-        return QString();
-    }
-    return TStringToQString(tstring);
 }
 
 bool SoundSource::processTaglibFile(TagLib::File& f) {

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -17,21 +17,9 @@
 
 #include <QtDebug>
 
-#include <taglib/attachedpictureframe.h>
-#include <taglib/audioproperties.h>
-#include <taglib/flacpicture.h>
-#include <taglib/id3v1tag.h>
-#include <taglib/id3v2frame.h>
-#include <taglib/id3v2header.h>
-#include <taglib/tag.h>
-#include <taglib/textidentificationframe.h>
-#include <taglib/tmap.h>
-#include <taglib/tstringlist.h>
-#include <taglib/vorbisfile.h>
-#include <taglib/wavpackfile.h>
-
 #include "soundsource.h"
 #include "util/math.h"
+
 
 namespace Mixxx
 {
@@ -40,21 +28,32 @@ namespace
 {
     const bool s_bDebugMetadata = false;
 
-    // Taglib strings can be NULL and using it could cause some segfaults,
-    // so in this case it will return a QString()
+    const float BPM_ZERO = 0.0f;
+    const float BPM_MIN = 60.0f;
+    const float BPM_MAX = 300.0f;
+
     inline
-    QString toQString(TagLib::String tstring) {
-        if (tstring == TagLib::String::null) {
-            return QString();
+    float parseBpmString(const QString& sBpm) {
+        float bpm = sBpm.toFloat();
+        if (bpm < BPM_MIN) {
+            bpm = BPM_ZERO;
+        } else {
+            while(bpm > BPM_MAX) {
+                bpm /= 10.0f;
+            }
         }
-        return TStringToQString(tstring);
+        return bpm;
     }
 
-    float str2bpm( QString sBpm ) {
-      float bpm = sBpm.toFloat();
-      if(bpm < 60) bpm = 0;
-      while( bpm > 300 ) bpm = bpm / 10.;
-      return bpm;
+    float parseReplayGainString (QString sReplayGain) {
+        QString ReplayGainstring = sReplayGain.remove( " dB" );
+        float fReplayGain = db2ratio(ReplayGainstring.toFloat());
+        // I found some mp3s of mine with replaygain tag set to 0dB even if not normalized.
+        // This is because of Rapid Evolution 3, I suppose. I prefer to rescan them by setting value to 0 (i.e. rescan via analyserrg)
+        if (fReplayGain == 1.0f) {
+            fReplayGain = 0.0f;
+        }
+        return fReplayGain;
     }
 
 }
@@ -74,7 +73,7 @@ namespace
 SoundSource::SoundSource(QString qFilename)
         : m_qFilename(qFilename),
           m_fReplayGain(0.0f),
-          m_fBPM(0.0f),
+          m_fBpm(0.0f),
           m_iChannels(0),
           m_iBitrate(0),
           m_iSampleRate(0),
@@ -84,411 +83,17 @@ SoundSource::SoundSource(QString qFilename)
 SoundSource::~SoundSource() {
 }
 
-bool SoundSource::processTaglibFile(TagLib::File& f) {
-    if (s_bDebugMetadata)
-        qDebug() << "Parsing" << getFilename();
-
-    if (f.isValid()) {
-        TagLib::Tag *tag = f.tag();
-        if (tag) {
-            QString title = toQString(tag->title());
-            setTitle(title);
-
-            QString artist = toQString(tag->artist());
-            setArtist(artist);
-
-            QString album = toQString(tag->album());
-            setAlbum(album);
-
-            QString comment = toQString(tag->comment());
-            setComment(comment);
-
-            QString genre = toQString(tag->genre());
-            setGenre(genre);
-
-            int iYear = tag->year();
-            QString year = "";
-            if (iYear > 0) {
-                year = QString("%1").arg(iYear);
-                setYear(year);
-            }
-
-            int iTrack = tag->track();
-            QString trackNumber = "";
-            if (iTrack > 0) {
-                trackNumber = QString("%1").arg(iTrack);
-                setTrackNumber(trackNumber);
-            }
-
-            if (s_bDebugMetadata)
-                qDebug() << "TagLib" << "title" << title << "artist" << artist << "album" << album << "comment" << comment << "genre" << genre << "year" << year << "trackNumber" << trackNumber;
+void SoundSource::setBpmString(const QString& sBpm) {
+    if (!sBpm.isEmpty()) {
+        float fBpm = parseBpmString(sBpm);
+        if (BPM_ZERO < fBpm) {
+            setBpm(fBpm);
         }
-
-        TagLib::AudioProperties *properties = f.audioProperties();
-        if (properties) {
-            int lengthSeconds = properties->length();
-            int bitrate = properties->bitrate();
-            int sampleRate = properties->sampleRate();
-            int channels = properties->channels();
-
-            if (s_bDebugMetadata)
-                qDebug() << "TagLib" << "length" << lengthSeconds << "bitrate" << bitrate << "sampleRate" << sampleRate << "channels" << channels;
-
-            setDuration(lengthSeconds);
-            setBitrate(bitrate);
-            setSampleRate(sampleRate);
-            setChannels(channels);
-        }
-
-        // If we didn't get any audio properties, this was a failure.
-        return (properties!=NULL);
-    }
-    return false;
-}
-
-void SoundSource::parseReplayGainString (QString sReplayGain) {
-    QString ReplayGainstring = sReplayGain.remove( " dB" );
-    float fReplayGain = db2ratio(ReplayGainstring.toFloat());
-    // I found some mp3s of mine with replaygain tag set to 0dB even if not normalized.
-    // This is because of Rapid Evolution 3, I suppose. I prefer to rescan them by setting value to 0 (i.e. rescan via analyserrg)
-    if (fReplayGain == 1.0f) {
-        fReplayGain = 0.0f;
-    }
-    setReplayGain(fReplayGain);
-}
-
-void SoundSource::processBpmString(QString tagName, QString sBpm) {
-    if (s_bDebugMetadata)
-        qDebug() << tagName << "BPM" << sBpm;
-    if (sBpm.length() > 0) {
-        float fBpm = str2bpm(sBpm);
-        if (fBpm > 0)
-            setBPM(fBpm);
     }
 }
 
-bool SoundSource::processID3v2Tag(TagLib::ID3v2::Tag* id3v2) {
-
-    // Print every frame in the file.
-    if (s_bDebugMetadata) {
-        TagLib::ID3v2::FrameList::ConstIterator it = id3v2->frameList().begin();
-        for(; it != id3v2->frameList().end(); it++) {
-            qDebug() << "ID3V2" << (*it)->frameID().data() << "-"
-                    << toQString((*it)->toString());
-        }
-    }
-
-    TagLib::ID3v2::FrameList bpmFrame = id3v2->frameListMap()["TBPM"];
-    if (!bpmFrame.isEmpty()) {
-        QString sBpm = toQString(bpmFrame.front()->toString());
-        processBpmString("ID3v2", sBpm);
-    }
-
-    TagLib::ID3v2::FrameList keyFrame = id3v2->frameListMap()["TKEY"];
-    if (!keyFrame.isEmpty()) {
-        QString sKey = toQString(keyFrame.front()->toString());
-        setKey(sKey);
-    }
-    // Foobar2000-style ID3v2.3.0 tags
-    // TODO: Check if everything is ok.
-    TagLib::ID3v2::FrameList frames = id3v2->frameListMap()["TXXX"];
-    for ( TagLib::ID3v2::FrameList::Iterator it = frames.begin(); it != frames.end(); ++it ) {
-        TagLib::ID3v2::UserTextIdentificationFrame* ReplayGainframe =
-                dynamic_cast<TagLib::ID3v2::UserTextIdentificationFrame*>( *it );
-        if ( ReplayGainframe && ReplayGainframe->fieldList().size() >= 2 )
-        {
-            QString desc = toQString( ReplayGainframe->description() ).toLower();
-            if ( desc == "replaygain_album_gain" ){
-                QString sReplayGain = toQString( ReplayGainframe->fieldList()[1]);
-                parseReplayGainString(sReplayGain);
-            }
-            if ( desc == "replaygain_track_gain" ){
-                QString sReplayGain = toQString( ReplayGainframe->fieldList()[1]);
-                parseReplayGainString(sReplayGain);
-            }
-        }
-    }
-
-    TagLib::ID3v2::FrameList albumArtistFrame = id3v2->frameListMap()["TPE2"];
-    if (!albumArtistFrame.isEmpty()) {
-        QString sAlbumArtist = toQString(albumArtistFrame.front()->toString());
-        setAlbumArtist(sAlbumArtist);
-
-        if (getArtist().length() == 0) {
-           setArtist(sAlbumArtist);
-        }
-    }
-    TagLib::ID3v2::FrameList originalAlbumFrame = id3v2->frameListMap()["TOAL"];
-    if (getAlbum().length() == 0 && !originalAlbumFrame.isEmpty()) {
-        QString sOriginalAlbum = TStringToQString(originalAlbumFrame.front()->toString());
-        setAlbum(sOriginalAlbum);
-    }
-    TagLib::ID3v2::FrameList composerFrame = id3v2->frameListMap()["TCOM"];
-    if (!composerFrame.isEmpty()) {
-        QString sComposer = toQString(composerFrame.front()->toString());
-        setComposer(sComposer);
-    }
-    TagLib::ID3v2::FrameList groupingFrame = id3v2->frameListMap()["TIT1"];
-    if (!groupingFrame.isEmpty()) {
-        QString sGrouping = toQString(groupingFrame.front()->toString());
-        setGrouping(sGrouping);
-    }
-
-    return true;
-}
-
-bool SoundSource::processAPETag(TagLib::APE::Tag* ape) {
-    if (s_bDebugMetadata) {
-        for(TagLib::APE::ItemListMap::ConstIterator it = ape->itemListMap().begin();
-                it != ape->itemListMap().end(); ++it) {
-                qDebug() << "APE" << toQString((*it).first) << "-" << toQString((*it).second.toString());
-        }
-    }
-
-    if (ape->itemListMap().contains("BPM")) {
-        QString sBpm = toQString(ape->itemListMap()["BPM"].toString());
-        processBpmString("APE", sBpm);
-    }
-
-    if (ape->itemListMap().contains("REPLAYGAIN_ALBUM_GAIN")) {
-        QString sReplayGain = toQString(ape->itemListMap()["REPLAYGAIN_ALBUM_GAIN"].toString());
-        parseReplayGainString(sReplayGain);
-    }
-
-    //Prefer track gain over album gain.
-    if (ape->itemListMap().contains("REPLAYGAIN_TRACK_GAIN")) {
-        QString sReplayGain = toQString(ape->itemListMap()["REPLAYGAIN_TRACK_GAIN"].toString());
-        parseReplayGainString(sReplayGain);
-    }
-
-    if (ape->itemListMap().contains("Album Artist")) {
-        m_sAlbumArtist = toQString(ape->itemListMap()["Album Artist"].toString());
-    }
-
-    if (ape->itemListMap().contains("Composer")) {
-        m_sComposer = toQString(ape->itemListMap()["Composer"].toString());
-    }
-
-    if (ape->itemListMap().contains("Grouping")) {
-        m_sGrouping = toQString(ape->itemListMap()["Grouping"].toString());
-    }
-
-    return true;
-}
-
-bool SoundSource::processXiphComment(TagLib::Ogg::XiphComment* xiph) {
-    if (s_bDebugMetadata) {
-        for (TagLib::Ogg::FieldListMap::ConstIterator it = xiph->fieldListMap().begin();
-                it != xiph->fieldListMap().end(); ++it) {
-            qDebug() << "XIPH" << toQString((*it).first) << "-" << toQString((*it).second.toString());
-        }
-    }
-
-    // Some tags use "BPM" so check for that.
-    if (xiph->fieldListMap().contains("BPM")) {
-        TagLib::StringList bpmString = xiph->fieldListMap()["BPM"];
-        QString sBpm = toQString(bpmString.toString());
-        processBpmString("XIPH-BPM", sBpm);
-    }
-
-    // Give preference to the "TEMPO" tag which seems to be more standard
-    if (xiph->fieldListMap().contains("TEMPO")) {
-        TagLib::StringList bpmString = xiph->fieldListMap()["TEMPO"];
-        QString sBpm = toQString(bpmString.toString());
-        processBpmString("XIPH-TEMPO", sBpm);
-    }
-
-    if (xiph->fieldListMap().contains("REPLAYGAIN_ALBUM_GAIN")) {
-        TagLib::StringList rgainString = xiph->fieldListMap()["REPLAYGAIN_ALBUM_GAIN"];
-        QString sReplayGain = toQString(rgainString.toString());
-        parseReplayGainString(sReplayGain);
-    }
-
-    if (xiph->fieldListMap().contains("REPLAYGAIN_TRACK_GAIN")) {
-        TagLib::StringList rgainString = xiph->fieldListMap()["REPLAYGAIN_TRACK_GAIN"];
-        QString sReplayGain = toQString(rgainString.toString());
-        parseReplayGainString(sReplayGain);
-    }
-
-    /*
-     * Reading key code information
-     * Unlike, ID3 tags, there's no standard or recommendation on how to store 'key' code
-     *
-     * Luckily, there are only a few tools for that, e.g., Rapid Evolution (RE).
-     * Assuming no distinction between start and end key, RE uses a "INITIALKEY"
-     * or a "KEY" vorbis comment.
-     */
-    if (xiph->fieldListMap().contains("KEY")) {
-        TagLib::StringList keyStr = xiph->fieldListMap()["KEY"];
-        QString key = toQString(keyStr.toString());
-        setKey(key);
-    }
-    if (getKey().isEmpty() && xiph->fieldListMap().contains("INITIALKEY")) {
-        TagLib::StringList keyStr = xiph->fieldListMap()["INITIALKEY"];
-        QString key = toQString(keyStr.toString());
-        setKey(key);
-    }
-
-    if (xiph->fieldListMap().contains("ALBUMARTIST")) {
-        TagLib::StringList albumArtistString = xiph->fieldListMap()["ALBUMARTIST"];
-        m_sAlbumArtist = toQString(albumArtistString.toString());
-    } else {
-        // try alternative field name
-        if (xiph->fieldListMap().contains("ALBUM_ARTIST")) {
-            TagLib::StringList albumArtistString = xiph->fieldListMap()["ALBUM_ARTIST"];
-            m_sAlbumArtist = toQString(albumArtistString.toString());
-        }
-    }
-
-    if (xiph->fieldListMap().contains("COMPOSER")) {
-        TagLib::StringList composerString = xiph->fieldListMap()["COMPOSER"];
-        m_sComposer = toQString(composerString.toString());
-    }
-
-    if (xiph->fieldListMap().contains("GROUPING")) {
-        TagLib::StringList groupingString = xiph->fieldListMap()["GROUPING"];
-        m_sGrouping = toQString(groupingString.toString());
-    }
-
-    return true;
-}
-
-bool SoundSource::processMP4Tag(TagLib::MP4::Tag* mp4) {
-    if (s_bDebugMetadata) {
-        for(TagLib::MP4::ItemListMap::ConstIterator it = mp4->itemListMap().begin();
-            it != mp4->itemListMap().end(); ++it) {
-            qDebug() << "MP4" << toQString((*it).first) << "-"
-                     << toQString((*it).second.toStringList().toString());
-        }
-    }
-
-    // Get BPM
-    if (mp4->itemListMap().contains("tmpo")) {
-        QString sBpm = toQString(
-            mp4->itemListMap()["tmpo"].toStringList().toString());
-        processBpmString("MP4", sBpm);
-    } else if (mp4->itemListMap().contains("----:com.apple.iTunes:BPM")) {
-        // This is an alternate way of storing BPM.
-        QString sBpm = toQString(mp4->itemListMap()[
-            "----:com.apple.iTunes:BPM"].toStringList().toString());
-        processBpmString("MP4", sBpm);
-    }
-
-    // Get Album Artist
-    if (mp4->itemListMap().contains("aART")) {
-        // this is technically a list of values -> concatenate into single string
-        QString albumArtist = toQString(
-            mp4->itemListMap()["aART"].toStringList().toString());
-        setAlbumArtist(albumArtist);
-    }
-
-    // Get Composer
-    if (mp4->itemListMap().contains("\251wrt")) {
-        // rryan 1/2012 I believe this is technically a list of composers. We
-        // don't support multiple composers in Mixxx, so just use them joined.
-        QString composer = toQString(
-            mp4->itemListMap()["\251wrt"].toStringList().toString());
-        setComposer(composer);
-    }
-
-    // Get Grouping
-    if (mp4->itemListMap().contains("\251grp")) {
-        QString grouping = toQString(
-            mp4->itemListMap()["\251grp"].toStringList().toString());
-        setGrouping(grouping);
-    }
-
-    // Get KEY (conforms to Rapid Evolution)
-    if (mp4->itemListMap().contains("----:com.apple.iTunes:KEY")) {
-        QString key = toQString(
-            mp4->itemListMap()["----:com.apple.iTunes:KEY"].toStringList().toString());
-        setKey(key);
-    }
-
-    // Apparently iTunes stores replaygain in this property.
-    if (mp4->itemListMap().contains(
-        "----:com.apple.iTunes:replaygain_track_gain")) {
-        // TODO(XXX) find tracks with this property and check what it looks
-        // like.
-
-        //QString replaygain = toQString(mp4->itemListMap()["----:com.apple.iTunes:replaygain_track_gain"].toStringList().toString());
-    }
-
-    return true;
-}
-
-QImage SoundSource::getCoverInID3v2Tag(TagLib::ID3v2::Tag *id3v2) {
-    if (!id3v2) {
-        return QImage();
-    }
-
-    QImage coverArt;
-    TagLib::ID3v2::FrameList covertArtFrame = id3v2->frameListMap()["APIC"];
-    if (!covertArtFrame.isEmpty()) {
-        TagLib::ID3v2::AttachedPictureFrame* picframe = static_cast
-                <TagLib::ID3v2::AttachedPictureFrame*>(covertArtFrame.front());
-        TagLib::ByteVector data = picframe->picture();
-        coverArt = QImage::fromData(
-            reinterpret_cast<const uchar *>(data.data()), data.size());
-    }
-    return coverArt;
-}
-
-QImage SoundSource::getCoverInAPETag(TagLib::APE::Tag *ape) {
-    if (!ape) {
-        return QImage();
-    }
-
-    QImage coverArt;
-    if (ape->itemListMap().contains("COVER ART (FRONT)"))
-    {
-        const TagLib::ByteVector nullStringTerminator(1, 0);
-        TagLib::ByteVector item = ape->itemListMap()["COVER ART (FRONT)"].value();
-        int pos = item.find(nullStringTerminator);	// skip the filename
-        if (++pos > 0) {
-            const TagLib::ByteVector& data = item.mid(pos);
-            coverArt = QImage::fromData(
-                reinterpret_cast<const uchar *>(data.data()), data.size());
-        }
-    }
-    return coverArt;
-}
-
-QImage SoundSource::getCoverInXiphComment(TagLib::Ogg::XiphComment *xiph) {
-    if (!xiph) {
-        return QImage();
-    }
-
-    QImage coverArt;
-    if (xiph->fieldListMap().contains("METADATA_BLOCK_PICTURE")) {
-        QByteArray data(QByteArray::fromBase64(
-            xiph->fieldListMap()["METADATA_BLOCK_PICTURE"].front().toCString()));
-        TagLib::ByteVector tdata(data.data(), data.size());
-        TagLib::FLAC::Picture p(tdata);
-        data = QByteArray(p.data().data(), p.data().size());
-        coverArt = QImage::fromData(data);
-    } else if (xiph->fieldListMap().contains("COVERART")) {
-        QByteArray data(QByteArray::fromBase64(
-            xiph->fieldListMap()["COVERART"].toString().toCString()));
-        coverArt = QImage::fromData(data);
-    }
-    return coverArt;
-}
-
-QImage SoundSource::getCoverInMP4Tag(TagLib::MP4::Tag *mp4) {
-    if (!mp4) {
-        return QImage();
-    }
-
-    QImage coverArt;
-    if (mp4->itemListMap().contains("covr")) {
-        TagLib::MP4::CoverArtList coverArtList = mp4->itemListMap()["covr"]
-                                                        .toCoverArtList();
-        TagLib::ByteVector data = coverArtList.front().data();
-        coverArt = QImage::fromData(
-            reinterpret_cast<const uchar *>(data.data()), data.size());
-    }
-    return coverArt;
+void SoundSource::setReplayGainString (QString sReplayGain) {
+    setReplayGain(parseReplayGainString(sReplayGain));
 }
 
 } //namespace Mixxx

--- a/src/soundsource.h
+++ b/src/soundsource.h
@@ -22,12 +22,6 @@
 #include <QString>
 #include <QSharedPointer>
 
-#include <taglib/tfile.h>
-#include <taglib/apetag.h>
-#include <taglib/id3v2tag.h>
-#include <taglib/xiphcomment.h>
-#include <taglib/mp4tag.h>
-
 #include "util/types.h"
 #include "util/defs.h"
 
@@ -117,7 +111,7 @@ public:
         return m_sKey;
     }
     float getBPM() const {
-        return m_fBPM;
+        return m_fBpm;
     }
     int getChannels() const {
         return m_iChannels;
@@ -162,22 +156,17 @@ public:
     void setTrackNumber(QString trackNumber) {
         m_sTrackNumber = trackNumber;
     }
-    void setReplayGain(float replayGain) {
-        m_fReplayGain = replayGain;
-    }
     void setKey(QString key){
         m_sKey = key;
     }
-    void setBPM(float bpm) {
-        m_fBPM = bpm;
+    void setBpm(float bpm) {
+        m_fBpm = bpm;
     }
-
-protected:
-    explicit SoundSource(QString qFilename);
-
-    void setType(QString type) {
-        m_sType = type;
+    void setBpmString(const QString& sBpm);
+    void setReplayGain(float replayGain) {
+        m_fReplayGain = replayGain;
     }
+    void setReplayGainString(QString sReplayGain);
 
     void setChannels(int channels) {
         m_iChannels = channels;
@@ -192,24 +181,12 @@ protected:
         m_iDuration = duration;
     }
 
-    // Automatically collects generic data from a TagLib File: title, artist,
-    // album, comment, genre, year, tracknumber, duration, bitrate, samplerate,
-    // and channels.
-    bool processTaglibFile(TagLib::File& f);
-    bool processID3v2Tag(TagLib::ID3v2::Tag* id3v2);
-    bool processAPETag(TagLib::APE::Tag* ape);
-    bool processXiphComment(TagLib::Ogg::XiphComment* xiph);
-    bool processMP4Tag(TagLib::MP4::Tag* mp4);
+protected:
+    explicit SoundSource(QString qFilename);
 
-    void processBpmString(QString tagName, QString sBpm);
-    void parseReplayGainString(QString sReplayGain);
-
-    // In order to avoid processing images when it's not
-    // needed (TIO building), we must process it separately.
-    QImage getCoverInID3v2Tag(TagLib::ID3v2::Tag* id3v2);
-    QImage getCoverInAPETag(TagLib::APE::Tag* ape);
-    QImage getCoverInXiphComment(TagLib::Ogg::XiphComment* xiph);
-    QImage getCoverInMP4Tag(TagLib::MP4::Tag* mp4);
+    void setType(QString type) {
+        m_sType = type;
+    }
 
 private:
     const QString m_qFilename;
@@ -229,7 +206,7 @@ private:
 
     //Dontcha be forgettin' to initialize these variables.... arr
     float m_fReplayGain;
-    float m_fBPM;
+    float m_fBpm;
     int m_iChannels;
     int m_iBitrate;
     unsigned int m_iSampleRate;

--- a/src/soundsource.h
+++ b/src/soundsource.h
@@ -20,6 +20,7 @@
 
 #include <QImage>
 #include <QString>
+#include <QSharedPointer>
 
 #include <taglib/tfile.h>
 #include <taglib/apetag.h>
@@ -59,64 +60,138 @@ namespace Mixxx
 class SoundSource
 {
 public:
-    SoundSource(QString qFilename);
     virtual ~SoundSource();
-    virtual Result open() = 0;
-    virtual long seek(long) = 0;
-    virtual unsigned read(unsigned long size, const SAMPLE*) = 0;
-    virtual long unsigned length() = 0;
-    static float str2bpm( QString sBpm );
+
+    // Parses the metadata before actually opening the file for reading the audio stream.
     virtual Result parseHeader() = 0;
 
     // Returns the first cover art image embedded within the file (if any).
     virtual QImage parseCoverArt() = 0;
 
-    //static QList<QString> supportedFileExtensions(); //CRAP can't do this!
-    /** Return a list of cue points stored in the file */
-    virtual QList<long> *getCuePoints();
-    /** Returns filename */
-    virtual QString getFilename();
-    /** Return artist name */
-    virtual QString getArtist();
-    /** Return track title */
-    virtual QString getTitle();
-    virtual QString getAlbum();
-    virtual QString getAlbumArtist();
-    virtual QString getType();
-    virtual QString getComment();
-    virtual QString getYear();
-    virtual QString getGenre();
-    virtual QString getComposer();
-    virtual QString getGrouping();
-    virtual QString getTrackNumber();
-    virtual float getReplayGain();
-    virtual QString getKey();
-    virtual float getBPM();
-    virtual int getDuration();
-    virtual int getBitrate();
-    virtual unsigned int getSampleRate();
-    virtual int getChannels();
+    // Functions for reading the audio data of the file.
+    virtual Result open() = 0;
+    virtual long unsigned length() = 0;
+    virtual long seek(long) = 0;
+    virtual unsigned read(unsigned long size, const SAMPLE*) = 0;
 
-    virtual void setArtist(QString);
-    virtual void setTitle(QString);
-    virtual void setAlbum(QString);
-    virtual void setAlbumArtist(QString);
-    virtual void setType(QString);
-    virtual void setComment(QString);
-    virtual void setYear(QString);
-    virtual void setGenre(QString);
-    virtual void setComposer(QString);
-    virtual void setGrouping(QString);
-    virtual void setTrackNumber(QString);
-    virtual void setReplayGain(float);
-    virtual void setKey(QString);
-    virtual void setBPM(float);
-    virtual void setDuration(int);
-    virtual void setBitrate(int);
-    virtual void setSampleRate(unsigned int);
-    virtual void setChannels(int);
+    const QString& getType() const {
+        return m_sType;
+    }
+    const QString& getFilename() const {
+        return m_qFilename;
+    }
+    const QString& getArtist() const {
+        return m_sArtist;
+    }
+    const QString& getTitle() const {
+        return m_sTitle;
+    }
+    const QString& getAlbum() const {
+        return m_sAlbum;
+    }
+    const QString& getAlbumArtist() const {
+        return m_sAlbumArtist;
+    }
+    const QString& getComment() const {
+        return m_sComment;
+    }
+    const QString& getYear() const {
+        return m_sYear;
+    }
+    const QString& getGenre() const {
+        return m_sGenre;
+    }
+    const QString& getComposer() const {
+        return m_sComposer;
+    }
+    const QString& getGrouping() const {
+        return m_sGrouping;
+    }
+    const QString& getTrackNumber() const {
+        return m_sTrackNumber;
+    }
+    float getReplayGain() const {
+        return m_fReplayGain;
+    }
+    const QString& getKey() const {
+        return m_sKey;
+    }
+    float getBPM() const {
+        return m_fBPM;
+    }
+    int getChannels() const {
+        return m_iChannels;
+    }
+    int getBitrate() const {
+        return m_iBitrate;
+    }
+    int getSampleRate() const {
+        return m_iSampleRate;
+    }
+    int getDuration() const {
+        return m_iDuration;
+    }
+
+    void setArtist(QString artist) {
+        m_sArtist = artist;
+    }
+    void setTitle(QString title) {
+        m_sTitle = title;
+    }
+    void setAlbum(QString album) {
+        m_sAlbum = album;
+    }
+    void setAlbumArtist(QString albumArtist) {
+        m_sAlbumArtist = albumArtist;
+    }
+    void setComment(QString comment) {
+        m_sComment = comment;
+    }
+    void setYear(QString year) {
+        m_sYear = year;
+    }
+    void setGenre(QString genre) {
+        m_sGenre = genre;
+    }
+    void setComposer(QString composer) {
+        m_sComposer = composer;
+    }
+    void setGrouping(QString grouping) {
+        m_sGrouping = grouping;
+    }
+    void setTrackNumber(QString trackNumber) {
+        m_sTrackNumber = trackNumber;
+    }
+    void setReplayGain(float replayGain) {
+        m_fReplayGain = replayGain;
+    }
+    void setKey(QString key){
+        m_sKey = key;
+    }
+    void setBPM(float bpm) {
+        m_fBPM = bpm;
+    }
 
 protected:
+    explicit SoundSource(QString qFilename);
+
+    void setType(QString type) {
+        m_sType = type;
+    }
+
+    void setChannels(int channels) {
+        m_iChannels = channels;
+    }
+    void setSampleRate(int sampleRate) {
+        m_iSampleRate = sampleRate;
+    }
+    void setBitrate(int bitrate) {
+        m_iBitrate = bitrate;
+    }
+    void setDuration(int duration) {
+        m_iDuration = duration;
+    }
+
     // Automatically collects generic data from a TagLib File: title, artist,
     // album, comment, genre, year, tracknumber, duration, bitrate, samplerate,
     // and channels.
@@ -125,6 +200,7 @@ protected:
     bool processAPETag(TagLib::APE::Tag* ape);
     bool processXiphComment(TagLib::Ogg::XiphComment* xiph);
     bool processMP4Tag(TagLib::MP4::Tag* mp4);
+
     void processBpmString(QString tagName, QString sBpm);
     void parseReplayGainString(QString sReplayGain);
 
@@ -135,36 +211,33 @@ protected:
     QImage getCoverInXiphComment(TagLib::Ogg::XiphComment* xiph);
     QImage getCoverInMP4Tag(TagLib::MP4::Tag* mp4);
 
-    // Taglib strings can be NULL and using it could cause some segfaults,
-    // so in this case it will return a QString()
-    QString toQString(TagLib::String tstring) const;
+private:
+    const QString m_qFilename;
 
-    /** File name */
-    QString m_qFilename;
-
+    QString m_sType;
     QString m_sArtist;
     QString m_sTitle;
     QString m_sAlbum;
     QString m_sAlbumArtist;
-    QString m_sType;
     QString m_sComment;
     QString m_sYear;
     QString m_sGenre;
     QString m_sComposer;
     QString m_sGrouping;
     QString m_sTrackNumber;
-    float m_fReplayGain;
     QString m_sKey;
-    float m_fBPM;
-    int m_iDuration;
-    int m_iBitrate;
-    /** Sample rate of the file */
-    unsigned int m_iSampleRate;
-    int m_iChannels;
-    //Dontcha be forgettin' to initialize these variables.... arr
 
-    static const bool s_bDebugMetadata;
+    //Dontcha be forgettin' to initialize these variables.... arr
+    float m_fReplayGain;
+    float m_fBPM;
+    int m_iChannels;
+    int m_iBitrate;
+    unsigned int m_iSampleRate;
+    int m_iDuration;
 };
+
+typedef QSharedPointer<SoundSource> SoundSourcePointer;
+
 } //namespace Mixxx
 
 #endif

--- a/src/soundsourcecoreaudio.h
+++ b/src/soundsourcecoreaudio.h
@@ -53,11 +53,11 @@ public:
     QImage parseCoverArt();
     static QList<QString> supportedFileExtensions();
 private:
-    unsigned int m_samples; // total number of samples
-    SInt64 m_headerFrames;
     ExtAudioFileRef m_audioFile;
     CAStreamBasicDescription m_inputFormat;
     CAStreamBasicDescription m_outputFormat;
+    SInt64 m_headerFrames;
+    unsigned int m_samples; // total number of samples
 };
 
 

--- a/src/soundsourceffmpeg.cpp
+++ b/src/soundsourceffmpeg.cpp
@@ -21,37 +21,32 @@
 *                                                                         *
 ***************************************************************************/
 
-#include "trackinfoobject.h"
 #include "soundsourceffmpeg.h"
 
 #include <QtDebug>
 #include <QBuffer>
-
-static QMutex ffmpegmutex;
 
 #define SOUNDSOURCEFFMPEG_CACHESIZE 1000
 #define SOUNDSOURCEFFMPEG_POSDISTANCE ((1024 * 1000) / 8)
 
 SoundSourceFFmpeg::SoundSourceFFmpeg(QString filename)
     : Mixxx::SoundSource(filename)
-    , m_qFilename(filename) {
-    m_iAudioStream = -1;
-    filelength = -1;
-    m_pFormatCtx = NULL;
-    m_pCodecCtx = NULL;
-    m_pCodec = NULL;
-    m_bIsSeeked = FALSE;
-    m_pResample = NULL;
-    m_iCurrentMixxTs = 0;
-    m_lCacheBytePos = 0;
-    m_lCacheStartByte = 0;
-    m_lCacheEndByte = 0;
-    m_lCacheLastPos = 0;
-    m_lLastStoredPos = 0;
-    m_lStoredSeekPoint = -1;
-    m_SCache.clear();
-
-    this->setType(filename.section(".",-1).toLower());
+    , m_iAudioStream(-1)
+    , filelength(-1)
+    , m_pFormatCtx(NULL)
+    , m_pIformat(NULL)
+    , m_pCodecCtx(NULL)
+    , m_pCodec(NULL)
+    , m_iCurrentMixxTs(0)
+    , m_pResample(NULL)
+    , m_bIsSeeked(false)
+    , m_lCacheBytePos(0)
+    , m_lCacheStartByte(0)
+    , m_lCacheEndByte(0)
+    , m_lCacheLastPos(0)
+    , m_lLastStoredPos(0)
+    , m_lStoredSeekPoint(-1) {
+    setType(filename.section(".",-1).toLower());
 }
 
 SoundSourceFFmpeg::~SoundSourceFFmpeg() {
@@ -88,14 +83,6 @@ AVFormatContext *SoundSourceFFmpeg::getFormatContext() {
 
 int SoundSourceFFmpeg::getAudioStreamIndex() {
     return m_iAudioStream;
-}
-
-void SoundSourceFFmpeg::lock() {
-    ffmpegmutex.lock();
-}
-
-void SoundSourceFFmpeg::unlock() {
-    ffmpegmutex.unlock();
 }
 
 bool SoundSourceFFmpeg::clearCache() {
@@ -368,7 +355,7 @@ Result SoundSourceFFmpeg::open() {
     unsigned int i;
     AVDictionary *l_iFormatOpts = NULL;
 
-    QByteArray qBAFilename = m_qFilename.toLocal8Bit();
+    QByteArray qBAFilename = getFilename().toLocal8Bit();
 
     qDebug() << "New SoundSourceFFmpeg :" << qBAFilename;
 
@@ -532,8 +519,8 @@ unsigned int SoundSourceFFmpeg::read(unsigned long size,
 }
 
 Result SoundSourceFFmpeg::parseHeader() {
-    qDebug() << "ffmpeg: SoundSourceFFmpeg::parseHeader" << m_qFilename;
-    QByteArray qBAFilename = m_qFilename.toLocal8Bit();
+    qDebug() << "ffmpeg: SoundSourceFFmpeg::parseHeader" << getFilename();
+    QByteArray qBAFilename = getFilename().toLocal8Bit();
 
     AVFormatContext *FmtCtx = avformat_alloc_context();
     AVCodecContext *CodecCtx;
@@ -582,16 +569,25 @@ Result SoundSourceFFmpeg::parseHeader() {
                                  AV_DICT_IGNORE_SUFFIX))) {
         QString strValue (QString::fromUtf8 (FmtTag->value));
 
+        // TODO: More sophisticated metadata reading
         if (!strncmp(FmtTag->key, "artist", 7)) {
             this->setArtist(strValue);
+        } else if (!strncmp(FmtTag->key, "title", 5)) {
+            this->setTitle(strValue);
+        } else if (!strncmp(FmtTag->key, "album_artist", 12)) {
+            this->setAlbumArtist(strValue);
+        } else if (!strncmp(FmtTag->key, "albumartist", 11)) {
+            this->setAlbumArtist(strValue);
         } else if (!strncmp(FmtTag->key, "album", 5)) {
+            this->setAlbum(strValue);
+        } else if (!strncmp(FmtTag->key, "TOAL", 4)) {
             this->setAlbum(strValue);
         } else if (!strncmp(FmtTag->key, "date", 4)) {
             this->setYear(strValue);
         } else if (!strncmp(FmtTag->key, "genre", 5)) {
             this->setGenre(strValue);
-        } else if (!strncmp(FmtTag->key, "title", 5)) {
-            this->setTitle(strValue);
+        } else if (!strncmp(FmtTag->key, "comment", 7)) {
+            this->setComment(strValue);
         }
 
 
@@ -622,7 +618,7 @@ Result SoundSourceFFmpeg::parseHeader() {
 
     }
 
-    this->setType(m_qFilename.section(".",-1).toLower());
+    this->setType(getFilename().section(".",-1).toLower());
     this->setDuration(FmtCtx->duration / AV_TIME_BASE);
     this->setBitrate((int)(CodecCtx->bit_rate / 1000));
     this->setSampleRate(CodecCtx->sample_rate);

--- a/src/soundsourceffmpeg.cpp
+++ b/src/soundsourceffmpeg.cpp
@@ -610,7 +610,7 @@ Result SoundSourceFFmpeg::parseHeader() {
             this->setTitle(strValue);
         } else if (!strncmp(FmtTag->key, "REPLAYGAIN_TRACK_PEAK", 20)) {
         } else if (!strncmp(FmtTag->key, "REPLAYGAIN_TRACK_GAIN", 20)) {
-            this->parseReplayGainString (strValue);
+            this->setReplayGainString (strValue);
         } else if (!strncmp(FmtTag->key, "REPLAYGAIN_ALBUM_PEAK", 20)) {
         } else if (!strncmp(FmtTag->key, "REPLAYGAIN_ALBUM_GAIN", 20)) {
         }

--- a/src/soundsourceffmpeg.h
+++ b/src/soundsourceffmpeg.h
@@ -71,7 +71,7 @@ public:
     long seek(long);
     unsigned int read(unsigned long size, const SAMPLE*);
     Result parseHeader();
-    QImage parseCoverArt();
+    QImage parseCoverArt() { return QImage(); /* TODO */ }
     inline long unsigned length();
     bool readInput();
     static QList<QString> supportedFileExtensions();

--- a/src/soundsourceffmpeg.h
+++ b/src/soundsourceffmpeg.h
@@ -81,9 +81,6 @@ public:
 
 
 protected:
-    void lock();
-    void unlock();
-
     bool readFramesToCache(unsigned int count, qint64 offset);
     bool getBytesFromCache(char *buffer, quint64 offset, quint64 size);
     quint64 getSizeofCache();
@@ -92,7 +89,6 @@ protected:
 private:
     int m_iAudioStream;
     quint64 filelength;
-    QString m_qFilename;
     AVFormatContext *m_pFormatCtx;
     AVInputFormat *m_pIformat;
     AVCodecContext *m_pCodecCtx;

--- a/src/soundsourcemodplug.h
+++ b/src/soundsourcemodplug.h
@@ -39,10 +39,9 @@ class SoundSourceModPlug : public Mixxx::SoundSource
     static int s_bufferSizeLimit; // max track buffer length (bytes)
     static ModPlug::ModPlug_Settings s_settings; // modplug decoder parameters
 
-    bool m_opened;
+    ModPlug::ModPlugFile *m_pModFile; // modplug file descriptor
     unsigned long m_fileLength; // length of file in samples
     unsigned long m_seekPos; // current read position
-    ModPlug::ModPlugFile *m_pModFile; // modplug file descriptor
     QByteArray m_fileBuf; // original module file data
     QByteArray m_sampleBuf; // 16bit stereo samples, 44.1kHz
 

--- a/src/soundsourcemp3.h
+++ b/src/soundsourcemp3.h
@@ -83,9 +83,9 @@ private:
     /** current play position. */
     mad_timer_t pos;
     mad_timer_t filelength;
-    mad_stream *Stream;
-    mad_frame *Frame;
-    mad_synth *Synth;
+    mad_stream madStream;
+    mad_frame madFrame;
+    mad_synth madSynth;
     unsigned inputbuf_len;
     unsigned char *inputbuf;
 

--- a/src/soundsourceoggvorbis.cpp
+++ b/src/soundsourceoggvorbis.cpp
@@ -19,6 +19,7 @@
 
 #include "trackinfoobject.h"
 #include "soundsourceoggvorbis.h"
+#include "sampleutil.h"
 #include <QtDebug>
 #ifdef __WINDOWS__
 #include <io.h>
@@ -202,18 +203,7 @@ unsigned SoundSourceOggVorbis::read(volatile unsigned long size, const SAMPLE * 
 
     // convert into stereo if file is mono
     if (channels == 1) {
-        // rryan 2/2009
-        // Mini-proof of the below:
-        // size = 20, destination is a 20 element array 0-19
-        // readNo = 10 (or less, but 10 in this case)
-        // i = 10-1 = 9, so dest[9*2] and dest[9*2+1],
-        // so the first iteration touches the very ends of destination
-        // on the last iteration, dest[0] and dest[1] are assigned to dest[0]
-        for(int i=(index/2-1); i>=0; i--) {
-            dest[i*2]     = dest[i];
-            dest[(i*2)+1] = dest[i];
-        }
-
+        SampleUtil::inPlaceMonoToStereo(dest, index / 2);
         // Pretend we read twice as many bytes as we did, since we just repeated
         // each pair of bytes.
         index *= 2;

--- a/src/soundsourceoggvorbis.h
+++ b/src/soundsourceoggvorbis.h
@@ -35,9 +35,9 @@ class SoundSourceOggVorbis : public Mixxx::SoundSource {
   QImage parseCoverArt();
   static QList<QString> supportedFileExtensions();
  private:
+  OggVorbis_File vf;
   int channels;
   unsigned long filelength;
-  OggVorbis_File vf;
   int current_section;
 };
 

--- a/src/soundsourceopus.h
+++ b/src/soundsourceopus.h
@@ -26,9 +26,9 @@ class SoundSourceOpus : public Mixxx::SoundSource {
     static QList<QString> supportedFileExtensions();
 	
   private:
+    OggOpusFile *m_ptrOpusFile;
     int m_iChannels;
     quint64 m_lFilelength;
-    OggOpusFile *m_ptrOpusFile;
 };
 
 #endif

--- a/src/soundsourceopus.h
+++ b/src/soundsourceopus.h
@@ -22,7 +22,7 @@ class SoundSourceOpus : public Mixxx::SoundSource {
     unsigned read(unsigned long size, const SAMPLE*);
     inline long unsigned length();
     Result parseHeader();
-    QImage parseCoverArt();
+    QImage parseCoverArt() { return QImage(); /* TODO */ }
     static QList<QString> supportedFileExtensions();
 	
   private:

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -33,51 +33,52 @@
   */
 
 
-/*
-  Base class for sound sources.
-*/
-class SoundSourceProxy : public Mixxx::SoundSource
+/**
+ * Creates sound sources for filenames or tracks.
+ */
+class SoundSourceProxy
 {
 public:
-    SoundSourceProxy(QString qFilename, SecurityTokenPointer pToken);
-    SoundSourceProxy(TrackPointer pTrack);
-    ~SoundSourceProxy();
     static void loadPlugins();
-    Result open();
-    long seek(long);
-    unsigned read(unsigned long size, const SAMPLE*);
-    long unsigned length();
-    Result parseHeader();
-
-    // Returns the first cover art image embedded within the file (if any).
-    QImage parseCoverArt();
-
-    unsigned int getSampleRate();
-    /** Returns filename */
-    QString getFilename();
-
-    SoundSource* getProxiedSoundSource() {
-        return m_pSoundSource;
-    }
 
     static QStringList supportedFileExtensions();
     static QStringList supportedFileExtensionsByPlugins();
     static QString supportedFileExtensionsString();
     static QString supportedFileExtensionsRegex();
     static bool isFilenameSupported(QString filename);
+
+    SoundSourceProxy(QString qFilename, SecurityTokenPointer pToken);
+    explicit SoundSourceProxy(TrackPointer pTrack);
+
+    const QString& getFilename() const {
+        return m_qFilename;
+    }
+    const TrackPointer& getTrack() const {
+        return m_pTrack;
+    }
+    const Mixxx::SoundSourcePointer& getSoundSource() const {
+        return m_pSoundSource;
+    }
+
+    // Opening the audio data through the proxy will update the some metadata of the track object.
+    Result open();
+
 private:
-    static SoundSource* initialize(QString qFilename);
-    //void initPlugin(QString lib_filename, QString track_filename);
-    static QLibrary* getPlugin(QString lib_filename);
-
-    SoundSource* m_pSoundSource;
-    TrackPointer m_pTrack;
-    SecurityTokenPointer m_pSecurityToken;
-
     static QRegExp m_supportedFileRegex;
     static QMap<QString, QLibrary*> m_plugins;
     static QMap<QString, getSoundSourceFunc> m_extensionsSupportedByPlugins;
     static QMutex m_extensionsMutex;
+
+    static QLibrary* getPlugin(QString lib_filename);
+
+    static Mixxx::SoundSourcePointer initialize(QString qFilename);
+
+    const QString m_qFilename;
+    const TrackPointer m_pTrack;
+
+    const SecurityTokenPointer m_pSecurityToken;
+
+    const Mixxx::SoundSourcePointer m_pSoundSource;
 };
 
 #endif

--- a/src/soundsourcesndfile.cpp
+++ b/src/soundsourcesndfile.cpp
@@ -35,9 +35,9 @@ SoundSourceSndFile::SoundSourceSndFile(QString qFilename)
       channels(0),
       fh(NULL)
 {
+    // Must be set to 0 per the API for reading (non-RAW files)
+    memset(&info, 0, sizeof(info));
     m_bOpened = false;
-    info = new SF_INFO;
-    info->format = 0;   // Must be set to 0 per the API for reading (non-RAW files)
     filelength = 0;
 }
 
@@ -63,10 +63,10 @@ Result SoundSourceSndFile::open() {
 #ifdef __WINDOWS__
     // Pointer valid until string changed
     LPCWSTR lpcwFilename = (LPCWSTR)m_qFilename.utf16();
-    fh = sf_wchar_open(lpcwFilename, SFM_READ, info);
+    fh = sf_wchar_open(lpcwFilename, SFM_READ, &info);
 #else
     QByteArray qbaFilename = m_qFilename.toLocal8Bit();
-    fh = sf_open(qbaFilename.constData(), SFM_READ, info);
+    fh = sf_open(qbaFilename.constData(), SFM_READ, &info);
 #endif
 
     if (fh == NULL) {   // sf_format_check is only for writes
@@ -194,8 +194,8 @@ Result SoundSourceSndFile::parseHeader()
                 open();
             }
 
-            if (info->samplerate > 0) {
-                setDuration(info->frames / info->samplerate);
+            if (info.samplerate > 0) {
+                setDuration(info.frames / info.samplerate);
             } else {
                 qDebug() << "WARNING: WAV file with invalid samplerate."
                          << "Can't get duration using libsndfile.";

--- a/src/soundsourcesndfile.cpp
+++ b/src/soundsourcesndfile.cpp
@@ -23,6 +23,7 @@
 #include <QtDebug>
 
 #include "soundsourcesndfile.h"
+#include "sampleutil.h"
 #include "trackinfoobject.h"
 #include "util/math.h"
 
@@ -137,18 +138,7 @@ unsigned SoundSourceSndFile::read(unsigned long size, const SAMPLE * destination
 
             // readNo*2 is strictly less than available buffer space
 
-            // rryan 2/2009
-            // Mini-proof of the below:
-            // size = 20, destination is a 20 element array 0-19
-            // readNo = 10 (or less, but 10 in this case)
-            // i = 10-1 = 9, so dest[9*2] and dest[9*2+1],
-            // so the first iteration touches the very ends of destination
-            // on the last iteration, dest[0] and dest[1] are assigned to dest[0]
-
-            for(int i=(readNo-1); i>=0; i--) {
-                dest[i*2]     = dest[i];
-                dest[(i*2)+1] = dest[i];
-            }
+            SampleUtil::inPlaceMonoToStereo(dest, readNo);
 
             // We doubled the readNo bytes we read into stereo.
             return readNo * 2;

--- a/src/soundsourcesndfile.h
+++ b/src/soundsourcesndfile.h
@@ -42,10 +42,9 @@ public:
     static QList<QString> supportedFileExtensions();
 
 private:
-    bool m_bOpened;
-    int channels;
     SNDFILE *fh;
     SF_INFO info;
+    int channels;
     unsigned long filelength;
 };
 

--- a/src/soundsourcesndfile.h
+++ b/src/soundsourcesndfile.h
@@ -45,7 +45,7 @@ private:
     bool m_bOpened;
     int channels;
     SNDFILE *fh;
-    SF_INFO *info;
+    SF_INFO info;
     unsigned long filelength;
 };
 

--- a/src/soundsourcetaglib.cpp
+++ b/src/soundsourcetaglib.cpp
@@ -1,0 +1,408 @@
+/***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#include "soundsourcetaglib.h"
+
+#include <taglib/tag.h>
+#include <taglib/audioproperties.h>
+#include <taglib/vorbisfile.h>
+#include <taglib/id3v2frame.h>
+#include <taglib/id3v2header.h>
+#include <taglib/id3v1tag.h>
+#include <taglib/tmap.h>
+#include <taglib/tstringlist.h>
+#include <taglib/textidentificationframe.h>
+#include <taglib/wavpackfile.h>
+#include <taglib/attachedpictureframe.h>
+#include <taglib/flacpicture.h>
+
+
+#include <QtDebug>
+
+
+namespace Mixxx
+{
+
+// static
+namespace
+{
+    const bool s_bDebugMetadata = false;
+
+    // Taglib strings can be NULL and using it could cause some segfaults,
+    // so in this case it will return a QString()
+    inline
+    QString toQString(const TagLib::String& tString) {
+        if (tString.isNull()) {
+            return QString();
+        } else {
+            return TStringToQString(tString);
+        }
+    }
+
+    // Concatenates the elements of a TagLib string list
+    // into a single string.
+    inline
+    QString toQString(const TagLib::StringList& strList) {
+        return toQString(strList.toString());
+    }
+
+    // Concatenates the string list of an MP4 atom
+    // into a single string
+    inline
+    QString toQString(const TagLib::MP4::Item& mp4Item) {
+        return toQString(mp4Item.toStringList());
+    }
+
+    inline
+    QString toQString(const TagLib::APE::Item& apeItem) {
+        return toQString(apeItem.toString());
+    }
+}
+
+
+bool readFileHeader(SoundSource* pSoundSource, const TagLib::File& f) {
+    if (s_bDebugMetadata) {
+        qDebug() << "Parsing" << pSoundSource->getFilename();
+    }
+
+    if (f.isValid()) {
+        const TagLib::AudioProperties *properties = f.audioProperties();
+        if (properties) {
+            pSoundSource->setDuration(properties->length());
+            pSoundSource->setBitrate(properties->bitrate());
+            pSoundSource->setSampleRate(properties->sampleRate());
+            pSoundSource->setChannels(properties->channels());
+
+            if (s_bDebugMetadata) {
+                qDebug() << "TagLib"
+                        << "duration" << pSoundSource->getDuration()
+                        << "bitrate" << pSoundSource->getBitrate()
+                        << "sampleRate" << pSoundSource->getSampleRate()
+                        << "channels" << pSoundSource->getChannels();
+            }
+
+            return true;
+        }
+    }
+    return false;
+}
+
+void readTag(SoundSource* pSoundSource, const TagLib::Tag& tag) {
+    pSoundSource->setTitle(toQString(tag.title()));
+    pSoundSource->setArtist(toQString(tag.artist()));
+    pSoundSource->setAlbum(toQString(tag.album()));
+    pSoundSource->setComment(toQString(tag.comment()));
+    pSoundSource->setGenre(toQString(tag.genre()));
+
+    int iYear = tag.year();
+    if (iYear > 0) {
+        pSoundSource->setYear(QString("%1").arg(iYear));
+    }
+
+    int iTrack = tag.track();
+    if (iTrack > 0) {
+        pSoundSource->setTrackNumber(QString("%1").arg(iTrack));
+    }
+
+    if (s_bDebugMetadata) {
+        qDebug() << "TagLib"
+                << "title" << pSoundSource->getTitle()
+                << "artist" << pSoundSource->getArtist()
+                << "album" << pSoundSource->getAlbum()
+                << "comment" << pSoundSource->getComment()
+                << "genre" << pSoundSource->getGenre()
+                << "year" << pSoundSource->getYear()
+                << "trackNumber" << pSoundSource->getTrackNumber();
+    }
+}
+
+void readID3v2Tag(SoundSource* pSoundSource, const TagLib::ID3v2::Tag& id3v2) {
+
+    // Print every frame in the file.
+    if (s_bDebugMetadata) {
+        TagLib::ID3v2::FrameList::ConstIterator it = id3v2.frameList().begin();
+        for(; it != id3v2.frameList().end(); it++) {
+            qDebug() << "ID3V2" << (*it)->frameID().data() << "-"
+                    << toQString((*it)->toString());
+        }
+    }
+
+    readTag(pSoundSource, id3v2);
+
+    TagLib::ID3v2::FrameList bpmFrame = id3v2.frameListMap()["TBPM"];
+    if (!bpmFrame.isEmpty()) {
+        QString sBpm = toQString(bpmFrame.front()->toString());
+        pSoundSource->setBpmString(sBpm);
+    }
+
+    TagLib::ID3v2::FrameList keyFrame = id3v2.frameListMap()["TKEY"];
+    if (!keyFrame.isEmpty()) {
+        QString sKey = toQString(keyFrame.front()->toString());
+        pSoundSource->setKey(sKey);
+    }
+
+    // Foobar2000-style ID3v2.3.0 tags
+    // TODO: Check if everything is ok.
+    TagLib::ID3v2::FrameList frames = id3v2.frameListMap()["TXXX"];
+    for ( TagLib::ID3v2::FrameList::Iterator it = frames.begin(); it != frames.end(); ++it ) {
+        TagLib::ID3v2::UserTextIdentificationFrame* ReplayGainframe =
+                dynamic_cast<TagLib::ID3v2::UserTextIdentificationFrame*>( *it );
+        if ( ReplayGainframe && ReplayGainframe->fieldList().size() >= 2 )
+        {
+            QString desc = toQString( ReplayGainframe->description() ).toLower();
+            if ( desc == "replaygain_album_gain" ){
+                QString sReplayGain = toQString( ReplayGainframe->fieldList()[1]);
+                pSoundSource->setReplayGainString(sReplayGain);
+            }
+            //Prefer track gain over album gain.
+            if ( desc == "replaygain_track_gain" ){
+                QString sReplayGain = toQString( ReplayGainframe->fieldList()[1]);
+                pSoundSource->setReplayGainString(sReplayGain);
+            }
+        }
+    }
+
+    TagLib::ID3v2::FrameList albumArtistFrame = id3v2.frameListMap()["TPE2"];
+    if (!albumArtistFrame.isEmpty()) {
+        QString sAlbumArtist = toQString(albumArtistFrame.front()->toString());
+        pSoundSource->setAlbumArtist(sAlbumArtist);
+
+        if (pSoundSource->getArtist().length() == 0) {
+            pSoundSource->setArtist(sAlbumArtist);
+        }
+    }
+    TagLib::ID3v2::FrameList originalAlbumFrame = id3v2.frameListMap()["TOAL"];
+    if (pSoundSource->getAlbum().length() == 0 && !originalAlbumFrame.isEmpty()) {
+        QString sOriginalAlbum = TStringToQString(originalAlbumFrame.front()->toString());
+        pSoundSource->setAlbum(sOriginalAlbum);
+    }
+
+    TagLib::ID3v2::FrameList composerFrame = id3v2.frameListMap()["TCOM"];
+    if (!composerFrame.isEmpty()) {
+        QString sComposer = toQString(composerFrame.front()->toString());
+        pSoundSource->setComposer(sComposer);
+    }
+
+    TagLib::ID3v2::FrameList groupingFrame = id3v2.frameListMap()["TIT1"];
+    if (!groupingFrame.isEmpty()) {
+        QString sGrouping = toQString(groupingFrame.front()->toString());
+        pSoundSource->setGrouping(sGrouping);
+    }
+}
+
+void readAPETag(SoundSource* pSoundSource, const TagLib::APE::Tag& ape) {
+    if (s_bDebugMetadata) {
+        for(TagLib::APE::ItemListMap::ConstIterator it = ape.itemListMap().begin();
+                it != ape.itemListMap().end(); ++it) {
+                qDebug() << "APE" << toQString((*it).first) << "-" << toQString((*it).second.toString());
+        }
+    }
+
+    readTag(pSoundSource, ape);
+
+    if (ape.itemListMap().contains("BPM")) {
+        pSoundSource->setBpmString(toQString(ape.itemListMap()["BPM"]));
+    }
+
+    if (ape.itemListMap().contains("REPLAYGAIN_ALBUM_GAIN")) {
+        pSoundSource->setReplayGainString(toQString(ape.itemListMap()["REPLAYGAIN_ALBUM_GAIN"]));
+    }
+    //Prefer track gain over album gain.
+    if (ape.itemListMap().contains("REPLAYGAIN_TRACK_GAIN")) {
+        pSoundSource->setReplayGainString(toQString(ape.itemListMap()["REPLAYGAIN_TRACK_GAIN"]));
+    }
+
+    if (ape.itemListMap().contains("Album Artist")) {
+        pSoundSource->setAlbumArtist(toQString(ape.itemListMap()["Album Artist"]));
+    }
+
+    if (ape.itemListMap().contains("Composer")) {
+        pSoundSource->setComposer(toQString(ape.itemListMap()["Composer"]));
+    }
+
+    if (ape.itemListMap().contains("Grouping")) {
+        pSoundSource->setGrouping(toQString(ape.itemListMap()["Grouping"]));
+    }
+}
+
+void readXiphComment(SoundSource* pSoundSource, const TagLib::Ogg::XiphComment& xiph) {
+    if (s_bDebugMetadata) {
+        for (TagLib::Ogg::FieldListMap::ConstIterator it = xiph.fieldListMap().begin();
+                it != xiph.fieldListMap().end(); ++it) {
+            qDebug() << "XIPH" << toQString((*it).first) << "-" << toQString((*it).second.toString());
+        }
+    }
+
+    readTag(pSoundSource, xiph);
+
+    // Some tags use "BPM" so check for that.
+    if (xiph.fieldListMap().contains("BPM")) {
+        pSoundSource->setBpmString(toQString(xiph.fieldListMap()["BPM"]));
+    }
+
+    // Give preference to the "TEMPO" tag which seems to be more standard
+    if (xiph.fieldListMap().contains("TEMPO")) {
+        pSoundSource->setBpmString(toQString(xiph.fieldListMap()["TEMPO"]));
+    }
+
+    if (xiph.fieldListMap().contains("REPLAYGAIN_ALBUM_GAIN")) {
+        pSoundSource->setReplayGainString(toQString(xiph.fieldListMap()["REPLAYGAIN_ALBUM_GAIN"]));
+    }
+    //Prefer track gain over album gain.
+    if (xiph.fieldListMap().contains("REPLAYGAIN_TRACK_GAIN")) {
+        pSoundSource->setReplayGainString(toQString(xiph.fieldListMap()["REPLAYGAIN_TRACK_GAIN"]));
+    }
+
+    /*
+     * Reading key code information
+     * Unlike, ID3 tags, there's no standard or recommendation on how to store 'key' code
+     *
+     * Luckily, there are only a few tools for that, e.g., Rapid Evolution (RE).
+     * Assuming no distinction between start and end key, RE uses a "INITIALKEY"
+     * or a "KEY" vorbis comment.
+     */
+    if (xiph.fieldListMap().contains("KEY")) {
+        pSoundSource->setKey(toQString(xiph.fieldListMap()["KEY"]));
+    }
+    if (pSoundSource->getKey().isEmpty() && xiph.fieldListMap().contains("INITIALKEY")) {
+        pSoundSource->setKey(toQString(xiph.fieldListMap()["INITIALKEY"]));
+    }
+
+    if (xiph.fieldListMap().contains("ALBUMARTIST")) {
+        pSoundSource->setAlbumArtist(toQString(xiph.fieldListMap()["ALBUMARTIST"]));
+    } else {
+        // try alternative field name
+        if (xiph.fieldListMap().contains("ALBUM_ARTIST")) {
+            pSoundSource->setAlbumArtist(toQString(xiph.fieldListMap()["ALBUM_ARTIST"]));
+        }
+    }
+
+    if (xiph.fieldListMap().contains("COMPOSER")) {
+        pSoundSource->setComposer(toQString(xiph.fieldListMap()["COMPOSER"]));
+    }
+
+    if (xiph.fieldListMap().contains("GROUPING")) {
+        pSoundSource->setGrouping(toQString(xiph.fieldListMap()["GROUPING"]));
+    }
+}
+
+void readMP4Tag(SoundSource* pSoundSource, /*const*/ TagLib::MP4::Tag& mp4) {
+    if (s_bDebugMetadata) {
+        for(TagLib::MP4::ItemListMap::ConstIterator it = mp4.itemListMap().begin();
+            it != mp4.itemListMap().end(); ++it) {
+            qDebug() << "MP4" << toQString((*it).first) << "-"
+                     << toQString((*it).second);
+        }
+    }
+
+    readTag(pSoundSource, mp4);
+
+    // Get BPM
+    if (mp4.itemListMap().contains("tmpo")) {
+        pSoundSource->setBpmString(toQString(mp4.itemListMap()["tmpo"]));
+    } else if (mp4.itemListMap().contains("----:com.apple.iTunes:BPM")) {
+        // This is an alternate way of storing BPM.
+        pSoundSource->setBpmString(toQString(mp4.itemListMap()["----:com.apple.iTunes:BPM"]));
+    }
+
+    // Get Album Artist
+    if (mp4.itemListMap().contains("aART")) {
+        pSoundSource->setAlbumArtist(toQString(mp4.itemListMap()["aART"]));
+    }
+
+    // Get Composer
+    if (mp4.itemListMap().contains("\251wrt")) {
+        pSoundSource->setComposer(toQString(mp4.itemListMap()["\251wrt"]));
+    }
+
+    // Get Grouping
+    if (mp4.itemListMap().contains("\251grp")) {
+        pSoundSource->setGrouping(toQString(mp4.itemListMap()["\251grp"]));
+    }
+
+    // Get KEY (conforms to Rapid Evolution)
+    if (mp4.itemListMap().contains("----:com.apple.iTunes:KEY")) {
+        QString key = toQString(
+            mp4.itemListMap()["----:com.apple.iTunes:KEY"]);
+        pSoundSource->setKey(key);
+    }
+
+    // Apparently iTunes stores replaygain in this property.
+    if (mp4.itemListMap().contains("----:com.apple.iTunes:replaygain_album_gain")) {
+        // TODO(XXX) find tracks with this property and check what it looks
+        // like.
+        //QString replaygain = toQString(mp4.itemListMap()["----:com.apple.iTunes:replaygain_album_gain"]);
+    }
+    //Prefer track gain over album gain.
+    if (mp4.itemListMap().contains("----:com.apple.iTunes:replaygain_track_gain")) {
+        // TODO(XXX) find tracks with this property and check what it looks
+        // like.
+        //QString replaygain = toQString(mp4.itemListMap()["----:com.apple.iTunes:replaygain_track_gain"]);
+    }
+}
+
+QImage getCoverInID3v2Tag(const TagLib::ID3v2::Tag& id3v2) {
+    QImage coverArt;
+    TagLib::ID3v2::FrameList covertArtFrame = id3v2.frameListMap()["APIC"];
+    if (!covertArtFrame.isEmpty()) {
+        TagLib::ID3v2::AttachedPictureFrame* picframe = static_cast
+                <TagLib::ID3v2::AttachedPictureFrame*>(covertArtFrame.front());
+        TagLib::ByteVector data = picframe->picture();
+        coverArt = QImage::fromData(
+            reinterpret_cast<const uchar *>(data.data()), data.size());
+    }
+    return coverArt;
+}
+
+QImage getCoverInAPETag(const TagLib::APE::Tag& ape) {
+    QImage coverArt;
+    if (ape.itemListMap().contains("COVER ART (FRONT)"))
+    {
+        const TagLib::ByteVector nullStringTerminator(1, 0);
+        TagLib::ByteVector item = ape.itemListMap()["COVER ART (FRONT)"].value();
+        int pos = item.find(nullStringTerminator);  // skip the filename
+        if (++pos > 0) {
+            const TagLib::ByteVector& data = item.mid(pos);
+            coverArt = QImage::fromData(
+                reinterpret_cast<const uchar *>(data.data()), data.size());
+        }
+    }
+    return coverArt;
+}
+
+QImage getCoverInXiphComment(const TagLib::Ogg::XiphComment& xiph) {
+    QImage coverArt;
+    if (xiph.fieldListMap().contains("METADATA_BLOCK_PICTURE")) {
+        QByteArray data(QByteArray::fromBase64(
+            xiph.fieldListMap()["METADATA_BLOCK_PICTURE"].front().toCString()));
+        TagLib::ByteVector tdata(data.data(), data.size());
+        TagLib::FLAC::Picture p(tdata);
+        data = QByteArray(p.data().data(), p.data().size());
+        coverArt = QImage::fromData(data);
+    } else if (xiph.fieldListMap().contains("COVERART")) {
+        QByteArray data(QByteArray::fromBase64(
+            xiph.fieldListMap()["COVERART"].toString().toCString()));
+        coverArt = QImage::fromData(data);
+    }
+    return coverArt;
+}
+
+QImage getCoverInMP4Tag(/*const*/ TagLib::MP4::Tag& mp4) {
+    QImage coverArt;
+    if (mp4.itemListMap().contains("covr")) {
+        TagLib::MP4::CoverArtList coverArtList = mp4.itemListMap()["covr"]
+                                                        .toCoverArtList();
+        TagLib::ByteVector data = coverArtList.front().data();
+        coverArt = QImage::fromData(
+            reinterpret_cast<const uchar *>(data.data()), data.size());
+    }
+    return coverArt;
+}
+
+} //namespace Mixxx

--- a/src/soundsourcetaglib.h
+++ b/src/soundsourcetaglib.h
@@ -1,0 +1,45 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef SOUNDSOURCETAGLIB_H
+#define SOUNDSOURCETAGLIB_H
+
+#include "soundsource.h"
+
+#include <taglib/tfile.h>
+#include <taglib/apetag.h>
+#include <taglib/id3v2tag.h>
+#include <taglib/xiphcomment.h>
+#include <taglib/mp4tag.h>
+
+
+namespace Mixxx
+{
+    bool readFileHeader(SoundSource* pSoundSource, const TagLib::File& taglibFile);
+
+    // Read generic tags (will implicitly be invoked from the specialized functions)
+    void readTag(SoundSource* pSoundSource, const TagLib::Tag& tag);
+
+    // Read specific tags
+    void readID3v2Tag(SoundSource* pSoundSource, const TagLib::ID3v2::Tag& id3v2Tag);
+    void readAPETag(SoundSource* pSoundSource, const TagLib::APE::Tag& ape);
+    void readXiphComment(SoundSource* pSoundSource, const TagLib::Ogg::XiphComment& xiph);
+    void readMP4Tag(SoundSource* pSoundSource, /*const*/ TagLib::MP4::Tag& mp4);
+
+    // In order to avoid processing images when it's not
+    // needed (TIO building), we must process it separately.
+    QImage getCoverInID3v2Tag(const TagLib::ID3v2::Tag& id3v2);
+    QImage getCoverInAPETag(const TagLib::APE::Tag& ape);
+    QImage getCoverInXiphComment(const TagLib::Ogg::XiphComment& xiph);
+    QImage getCoverInMP4Tag(/*const*/ TagLib::MP4::Tag& mp4);
+
+} //namespace Mixxx
+
+
+#endif

--- a/src/test/coverartcache_test.cpp
+++ b/src/test/coverartcache_test.cpp
@@ -52,9 +52,9 @@ TEST_F(CoverArtCacheTest, loadCover) {
     SecurityTokenPointer securityToken = Sandbox::openSecurityToken(
         QDir(kTrackLocationTest), true);
     SoundSourceProxy proxy(kTrackLocationTest, securityToken);
-    Mixxx::SoundSource* pProxiedSoundSource = proxy.getProxiedSoundSource();
-    ASSERT_TRUE(pProxiedSoundSource != NULL);
-    img = proxy.parseCoverArt();
+    Mixxx::SoundSourcePointer pProxiedSoundSource(proxy.getSoundSource());
+    ASSERT_TRUE(pProxiedSoundSource);
+    img = pProxiedSoundSource->parseCoverArt();
 
     EXPECT_EQ(img, res.cover.image);
 }

--- a/src/test/sampleutiltest.cpp
+++ b/src/test/sampleutiltest.cpp
@@ -316,19 +316,35 @@ TEST_F(SampleUtilTest, copy3WithGainAliased) {
     }
 }
 
-TEST_F(SampleUtilTest, convert) {
+TEST_F(SampleUtilTest, convertS16ToFloat32) {
     while (sseAvailable-- >= 0) {
         for (int i = 0; i < buffers.size(); ++i) {
             CSAMPLE* buffer = buffers[i];
             int size = sizes[i];
-            FillBuffer(buffer, 1.0f, size);
             SAMPLE* s16 = new SAMPLE[size];
+            FillBuffer(buffer, 1.0f, size);
             for (int j = 0; j < size; ++j) {
-                s16[j] = j;
+                s16[j] = SHRT_MAX;
             }
-            SampleUtil::convert(buffer, s16, size);
+            SampleUtil::convertS16ToFloat32(buffer, s16, size);
             for (int j = 0; j < size; ++j) {
-                EXPECT_FLOAT_EQ(j, buffer[j]);
+                EXPECT_FLOAT_EQ(1.0f, buffer[j]);
+            }
+            FillBuffer(buffer, 0.0f, size);
+            for (int j = 0; j < size; ++j) {
+                s16[j] = 0;
+            }
+            SampleUtil::convertS16ToFloat32(buffer, s16, size);
+            for (int j = 0; j < size; ++j) {
+                EXPECT_FLOAT_EQ(0.0f, buffer[j]);
+            }
+            FillBuffer(buffer, -1.0f, size);
+            for (int j = 0; j < size; ++j) {
+                s16[j] = -SHRT_MAX;
+            }
+            SampleUtil::convertS16ToFloat32(buffer, s16, size);
+            for (int j = 0; j < size; ++j) {
+                EXPECT_FLOAT_EQ(-1.0f, buffer[j]);
             }
             delete [] s16;
         }

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -17,15 +17,15 @@ class SoundSourceProxyTest : public MixxxTest {
         delete m_pProxy;
     }
 
-    Mixxx::SoundSource* loadProxy(const QString& track) {
+    Mixxx::SoundSourcePointer loadProxy(const QString& track) {
         SecurityTokenPointer securityToken = Sandbox::openSecurityToken(
             QDir(track), true);
         if (m_pProxy != NULL) {
             delete m_pProxy;
         }
         m_pProxy = new SoundSourceProxy(track, securityToken);
-        Mixxx::SoundSource* pProxiedSoundSource = m_pProxy->getProxiedSoundSource();
-        EXPECT_TRUE(pProxiedSoundSource != NULL && m_pProxy->parseHeader() == OK);
+        Mixxx::SoundSourcePointer pProxiedSoundSource(m_pProxy->getSoundSource());
+        EXPECT_TRUE(pProxiedSoundSource && pProxiedSoundSource->parseHeader() == OK);
         return pProxiedSoundSource;
     }
 
@@ -34,14 +34,14 @@ class SoundSourceProxyTest : public MixxxTest {
 
 
 TEST_F(SoundSourceProxyTest, readArtist) {
-    Mixxx::SoundSource* p = loadProxy(
-        QDir::currentPath().append("/src/test/id3-test-data/artist.mp3"));
+    Mixxx::SoundSourcePointer p(loadProxy(
+        QDir::currentPath().append("/src/test/id3-test-data/artist.mp3")));
     EXPECT_EQ("Test Artist", p->getArtist());
 }
 
 TEST_F(SoundSourceProxyTest, TOAL_TPE2) {
-    Mixxx::SoundSource* p = loadProxy(
-        QDir::currentPath().append("/src/test/id3-test-data/TOAL_TPE2.mp3"));
+    Mixxx::SoundSourcePointer p(loadProxy(
+        QDir::currentPath().append("/src/test/id3-test-data/TOAL_TPE2.mp3")));
     EXPECT_EQ("TITLE2", p->getArtist());
     EXPECT_EQ("ARTIST", p->getAlbum());
     EXPECT_EQ("TITLE", p->getAlbumArtist());

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -160,8 +160,8 @@ void TrackInfoObject::parse(bool parseCoverArt) {
 
     // Parse the information stored in the sound file.
     SoundSourceProxy proxy(canonicalLocation, m_pSecurityToken);
-    Mixxx::SoundSource* pProxiedSoundSource = proxy.getProxiedSoundSource();
-    if (pProxiedSoundSource != NULL && proxy.parseHeader() == OK) {
+    Mixxx::SoundSourcePointer pSoundSource(proxy.getSoundSource());
+    if (pSoundSource && pSoundSource->parseHeader() == OK) {
 
         // Dump the metadata extracted from the file into the track.
 
@@ -172,50 +172,50 @@ void TrackInfoObject::parse(bool parseCoverArt) {
         // If Artist, Title and Type fields are not blank, modify them.
         // Otherwise, keep their current values.
         // TODO(rryan): Should we re-visit this decision?
-        if (!(pProxiedSoundSource->getArtist().isEmpty())) {
-            setArtist(pProxiedSoundSource->getArtist());
+        if (!(pSoundSource->getArtist().isEmpty())) {
+            setArtist(pSoundSource->getArtist());
         } else {
             parseArtist();
         }
 
-        if (!(pProxiedSoundSource->getTitle().isEmpty())) {
-            setTitle(pProxiedSoundSource->getTitle());
+        if (!(pSoundSource->getTitle().isEmpty())) {
+            setTitle(pSoundSource->getTitle());
         } else {
             parseTitle();
         }
 
-        if (!(pProxiedSoundSource->getType().isEmpty())) {
-            setType(pProxiedSoundSource->getType());
+        if (!(pSoundSource->getType().isEmpty())) {
+            setType(pSoundSource->getType());
         }
 
-        setAlbum(pProxiedSoundSource->getAlbum());
-        setAlbumArtist(pProxiedSoundSource->getAlbumArtist());
-        setYear(pProxiedSoundSource->getYear());
-        setGenre(pProxiedSoundSource->getGenre());
-        setComposer(pProxiedSoundSource->getComposer());
-        setGrouping(pProxiedSoundSource->getGrouping());
-        setComment(pProxiedSoundSource->getComment());
-        setTrackNumber(pProxiedSoundSource->getTrackNumber());
-        float replayGain = pProxiedSoundSource->getReplayGain();
+        setAlbum(pSoundSource->getAlbum());
+        setAlbumArtist(pSoundSource->getAlbumArtist());
+        setYear(pSoundSource->getYear());
+        setGenre(pSoundSource->getGenre());
+        setComposer(pSoundSource->getComposer());
+        setGrouping(pSoundSource->getGrouping());
+        setComment(pSoundSource->getComment());
+        setTrackNumber(pSoundSource->getTrackNumber());
+        float replayGain = pSoundSource->getReplayGain();
         if (replayGain != 0) {
             setReplayGain(replayGain);
         }
-        float bpm = pProxiedSoundSource->getBPM();
+        float bpm = pSoundSource->getBPM();
         if (bpm > 0) {
             // do not delete beat grid if bpm is not set in file
             setBpm(bpm);
         }
-        setDuration(pProxiedSoundSource->getDuration());
-        setBitrate(pProxiedSoundSource->getBitrate());
-        setSampleRate(pProxiedSoundSource->getSampleRate());
-        setChannels(pProxiedSoundSource->getChannels());
-        QString key = pProxiedSoundSource->getKey();
+        setDuration(pSoundSource->getDuration());
+        setBitrate(pSoundSource->getBitrate());
+        setSampleRate(pSoundSource->getSampleRate());
+        setChannels(pSoundSource->getChannels());
+        QString key = pSoundSource->getKey();
         if (!key.isEmpty()) {
             setKeyText(key, mixxx::track::io::key::FILE_METADATA);
         }
 
         if (parseCoverArt) {
-            m_coverArt.image = proxy.parseCoverArt();
+            m_coverArt.image = pSoundSource->parseCoverArt();
             if (!m_coverArt.image.isNull()) {
                 m_coverArt.info.hash = CoverArtUtils::calculateHash(
                     m_coverArt.image);


### PR DESCRIPTION
THIS PULL REQUEST IS OBSOLETE!

Some minor fixes and cleanups.

SoundSource actually needs a complete re-design:
- Clear separation between audio and other metadata -> AudioSource
- Setters/getters for metadata in SoundSource do not need to be virtual
- TagLib dependencies could be removed from the header file of the base class
- SoundSourceProxy IS NOT a SoundSource, but rather a factory that creates SoundSource objects
- Clear distinction between "frames" and "samples" when reading audio data
- The code in the subclasses of SoundSource is even worse with lots of unnecessary cruft
