### PR TITLE
FFMPEG cover art support

### DIFF
--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -11,9 +11,8 @@ QString sourceToString(CoverInfo::Source source) {
             return "GUESSED";
         case CoverInfo::USER_SELECTED:
             return "USER_SELECTED";
-        default:
-            return "INVALID INFO VALUE";
     }
+    return "INVALID INFO VALUE";
 }
 
 QString typeToString(CoverInfo::Type type) {
@@ -24,9 +23,8 @@ QString typeToString(CoverInfo::Type type) {
             return "METADATA";
         case CoverInfo::FILE:
             return "FILE";
-        default:
-            return "INVALID TYPE VALUE";
     }
+    return "INVALID TYPE VALUE";
 }
 
 QDebug operator<<(QDebug dbg, const CoverInfo& info) {

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -27,6 +27,9 @@
 
 #include "trackinfoobject.h"
 #include "soundsourceproxy.h"
+#ifdef __FFMPEGFILE__
+#include "soundsourceffmpeg.h"
+#else
 #ifdef __MAD__
 #include "soundsourcemp3.h"
 #endif
@@ -40,11 +43,9 @@
 #ifdef __SNDFILE__
 #include "soundsourcesndfile.h"
 #endif
-#ifdef __FFMPEGFILE__
-#include "soundsourceffmpeg.h"
-#endif
 #ifdef __MODPLUG__
 #include "soundsourcemodplug.h"
+#endif
 #endif
 #include "soundsourceflac.h"
 #include "util/cmdlineargs.h"
@@ -169,7 +170,7 @@ Mixxx::SoundSourcePointer SoundSourceProxy::initialize(const QString& qFilename)
 
 #ifdef __FFMPEGFILE__
     return Mixxx::SoundSourcePointer(new SoundSourceFFmpeg(qFilename));
-#endif
+#else
     if (SoundSourceOggVorbis::supportedFileExtensions().contains(extension)) {
         return Mixxx::SoundSourcePointer(new SoundSourceOggVorbis(qFilename));
 #ifdef __OPUS__
@@ -209,6 +210,7 @@ Mixxx::SoundSourcePointer SoundSourceProxy::initialize(const QString& qFilename)
     } else { //Unsupported filetype
         return Mixxx::SoundSourcePointer();
     }
+#endif
 }
 
 // static
@@ -344,7 +346,7 @@ QStringList SoundSourceProxy::supportedFileExtensions()
     QList<QString> supportedFileExtensions;
 #ifdef __FFMPEGFILE__
     supportedFileExtensions.append(SoundSourceFFmpeg::supportedFileExtensions());
-#endif
+#else
 #ifdef __MAD__
     supportedFileExtensions.append(SoundSourceMp3::supportedFileExtensions());
 #endif
@@ -361,8 +363,8 @@ QStringList SoundSourceProxy::supportedFileExtensions()
 #ifdef __MODPLUG__
     supportedFileExtensions.append(SoundSourceModPlug::supportedFileExtensions());
 #endif
+#endif
     supportedFileExtensions.append(m_extensionsSupportedByPlugins.keys());
-
     return supportedFileExtensions;
 }
 

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -46,9 +46,11 @@ TEST_F(CoverArtUtilTest, extractEmbeddedCover) {
     // them in a sandboxed environment.
     SecurityTokenPointer pToken;
     // aiff
+#ifndef __FFMPEGFILE__
     cover = CoverArtUtils::extractEmbeddedCover(kTestPath % "cover-test.aiff",
                                                 pToken);
     EXPECT_TRUE(!cover.isNull());
+#endif
     // flac
     cover = CoverArtUtils::extractEmbeddedCover(kTestPath % "cover-test.flac",
                                                 pToken);
@@ -62,9 +64,11 @@ TEST_F(CoverArtUtilTest, extractEmbeddedCover) {
                                                 pToken);
     EXPECT_TRUE(!cover.isNull());
     // wav
+#ifndef __FFMPEGFILE__
     cover = CoverArtUtils::extractEmbeddedCover(kTestPath % "cover-test.wav",
                                                 pToken);
     EXPECT_TRUE(!cover.isNull());
+#endif
 
 #ifdef __OPUS__
     // opus

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -1,6 +1,14 @@
 #include <gtest/gtest.h>
+#ifdef __FFMPEGFILE__
+extern "C" {
+#include <libavformat/avformat.h>
+}
+#endif
 
 int main(int argc, char **argv) {
     testing::InitGoogleTest(&argc, argv);
+#ifdef __FFMPEGFILE__
+    av_register_all();
+#endif
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Otherwise build fails with:

```
lin64_build/soundsourceffmpeg.o:(.rodata._ZTV17SoundSourceFFmpeg[vtable for SoundSourceFFmpeg]+0x48): undefined reference to `SoundSourceFFmpeg::parseCoverArt()'
collect2: ld returned 1 exit status
scons: *** [lin64_build/mixxx] Error 1
```
