### PR TITLE
Use QString instead of char* in Constructor

### DIFF
--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -28,12 +28,7 @@ BaseTrackPlayer::BaseTrackPlayer(QObject* pParent,
           m_pConfig(pConfig),
           m_pLoadedTrack(),
           m_replaygainPending(false) {
-    // Need to strdup the string because EngineChannel will save the pointer,
-    // but we might get deleted before the EngineChannel. TODO(XXX)
-    // pSafeGroupName is leaked. It's like 5 bytes so whatever.
-    const char* pSafeGroupName = strdup(getGroup().toAscii().constData());
-
-    m_pChannel = new EngineDeck(pSafeGroupName, pConfig, pMixingEngine,
+    m_pChannel = new EngineDeck(getGroup(), pConfig, pMixingEngine,
                                 pEffectsManager, defaultOrientation);
 
     EngineBuffer* pEngineBuffer = m_pChannel->getEngineBuffer();

--- a/src/cachingreader.cpp
+++ b/src/cachingreader.cpp
@@ -16,7 +16,7 @@
 //static
 const int CachingReader::maximumChunksInMemory = 80;
 
-CachingReader::CachingReader(const char* group,
+CachingReader::CachingReader(QString group,
                              ConfigObject<ConfigValue>* config)
         : m_pConfig(config),
           m_chunkReadRequestFIFO(1024),

--- a/src/cachingreader.h
+++ b/src/cachingreader.h
@@ -46,7 +46,7 @@ class CachingReader : public QObject {
 
   public:
     // Construct a CachingReader with the given group.
-    CachingReader(const char* _group,
+    CachingReader(QString group,
                   ConfigObject<ConfigValue>* _config);
     virtual ~CachingReader();
 

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -26,11 +26,11 @@ const int CachingReaderWorker::kChunkLength = CHUNK_LENGTH;
 const int CachingReaderWorker::kSamplesPerChunk = CHUNK_LENGTH / sizeof(CSAMPLE);
 
 
-CachingReaderWorker::CachingReaderWorker(const char* group,
+CachingReaderWorker::CachingReaderWorker(QString group,
         FIFO<ChunkReadRequest>* pChunkReadRequestFIFO,
         FIFO<ReaderStatusUpdate>* pReaderStatusFIFO)
-        : m_pGroup(group),
-          m_tag(QString("CachingReaderWorker %1").arg(m_pGroup)),
+        : m_group(group),
+          m_tag(QString("CachingReaderWorker %1").arg(m_group)),
           m_pChunkReadRequestFIFO(pChunkReadRequestFIFO),
           m_pReaderStatusFIFO(pReaderStatusFIFO),
           m_pCurrentSoundSource(NULL),
@@ -132,7 +132,7 @@ void CachingReaderWorker::run() {
 }
 
 void CachingReaderWorker::loadTrack(TrackPointer pTrack) {
-    //qDebug() << m_pGroup << "CachingReaderWorker::loadTrack() lock acquired for load.";
+    //qDebug() << m_group << "CachingReaderWorker::loadTrack() lock acquired for load.";
 
     // Emit that a new track is loading, stops the current track
     emit(trackLoading());
@@ -152,7 +152,7 @@ void CachingReaderWorker::loadTrack(TrackPointer pTrack) {
 
     if (filename.isEmpty() || !pTrack->exists()) {
         // Must unlock before emitting to avoid deadlock
-        qDebug() << m_pGroup << "CachingReaderWorker::loadTrack() load failed for\""
+        qDebug() << m_group << "CachingReaderWorker::loadTrack() load failed for\""
                  << filename << "\", unlocked reader lock";
         status.status = TRACK_NOT_LOADED;
         m_pReaderStatusFIFO->writeBlocking(&status, 1);
@@ -169,7 +169,7 @@ void CachingReaderWorker::loadTrack(TrackPointer pTrack) {
 
     if (!openSucceeded || m_iTrackNumSamples == 0 || trackSampleRate == 0) {
         // Must unlock before emitting to avoid deadlock
-        qDebug() << m_pGroup << "CachingReaderWorker::loadTrack() load failed for\""
+        qDebug() << m_group << "CachingReaderWorker::loadTrack() load failed for\""
                  << filename << "\", file invalid, unlocked reader lock";
         status.status = TRACK_NOT_LOADED;
         m_pReaderStatusFIFO->writeBlocking(&status, 1);

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -57,7 +57,7 @@ class CachingReaderWorker : public EngineWorker {
 
   public:
     // Construct a CachingReader with the given group.
-    CachingReaderWorker(const char* group,
+    CachingReaderWorker(QString group,
             FIFO<ChunkReadRequest>* pChunkReadRequestFIFO,
             FIFO<ReaderStatusUpdate>* pReaderStatusFIFO);
     virtual ~CachingReaderWorker();
@@ -88,7 +88,7 @@ class CachingReaderWorker : public EngineWorker {
 
   private:
 
-    const char* m_pGroup;
+    QString m_group;
     QString m_tag;
 
     // Thread-safe FIFOs for communication between the engine callback and

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -19,9 +19,9 @@ const int minBpm = 30;
 const int maxInterval = (int)(1000.*(60./(CSAMPLE)minBpm));
 const int filterLength = 5;
 
-BpmControl::BpmControl(const char* _group,
+BpmControl::BpmControl(QString group,
                        ConfigObject<ConfigValue>* _config) :
-        EngineControl(_group, _config),
+        EngineControl(group, _config),
         m_dPreviousSample(0),
         m_dSyncTargetBeatDistance(0.0),
         m_dSyncInstantaneousBpm(0.0),
@@ -29,39 +29,39 @@ BpmControl::BpmControl(const char* _group,
         m_resetSyncAdjustment(false),
         m_dUserOffset(0.0),
         m_tapFilter(this, filterLength, maxInterval),
-        m_sGroup(_group) {
-    m_pPlayButton = new ControlObjectSlave(_group, "play", this);
+        m_sGroup(group) {
+    m_pPlayButton = new ControlObjectSlave(group, "play", this);
     m_pPlayButton->connectValueChanged(SLOT(slotControlPlay(double)), Qt::DirectConnection);
-    m_pReverseButton = new ControlObjectSlave(_group, "reverse", this);
-    m_pRateSlider = new ControlObjectSlave(_group, "rate", this);
+    m_pReverseButton = new ControlObjectSlave(group, "reverse", this);
+    m_pRateSlider = new ControlObjectSlave(group, "rate", this);
     m_pRateSlider->connectValueChanged(SLOT(slotAdjustRateSlider()), Qt::DirectConnection);
-    m_pQuantize = ControlObject::getControl(_group, "quantize");
-    m_pRateRange = new ControlObjectSlave(_group, "rateRange", this);
+    m_pQuantize = ControlObject::getControl(group, "quantize");
+    m_pRateRange = new ControlObjectSlave(group, "rateRange", this);
     m_pRateRange->connectValueChanged(SLOT(slotAdjustRateSlider()), Qt::DirectConnection);
-    m_pRateDir = new ControlObjectSlave(_group, "rate_dir", this);
+    m_pRateDir = new ControlObjectSlave(group, "rate_dir", this);
     m_pRateDir->connectValueChanged(SLOT(slotAdjustRateSlider()), Qt::DirectConnection);
 
-    m_pLoopEnabled = new ControlObjectSlave(_group, "loop_enabled", this);
-    m_pLoopStartPosition = new ControlObjectSlave(_group, "loop_start_position", this);
-    m_pLoopEndPosition = new ControlObjectSlave(_group, "loop_end_position", this);
+    m_pLoopEnabled = new ControlObjectSlave(group, "loop_enabled", this);
+    m_pLoopStartPosition = new ControlObjectSlave(group, "loop_start_position", this);
+    m_pLoopEndPosition = new ControlObjectSlave(group, "loop_end_position", this);
 
-    m_pFileBpm = new ControlObject(ConfigKey(_group, "file_bpm"));
+    m_pFileBpm = new ControlObject(ConfigKey(group, "file_bpm"));
     connect(m_pFileBpm, SIGNAL(valueChanged(double)),
             this, SLOT(slotFileBpmChanged(double)),
             Qt::DirectConnection);
-    m_pAdjustBeatsFaster = new ControlPushButton(ConfigKey(_group, "beats_adjust_faster"), false);
+    m_pAdjustBeatsFaster = new ControlPushButton(ConfigKey(group, "beats_adjust_faster"), false);
     connect(m_pAdjustBeatsFaster, SIGNAL(valueChanged(double)),
             this, SLOT(slotAdjustBeatsFaster(double)),
             Qt::DirectConnection);
-    m_pAdjustBeatsSlower = new ControlPushButton(ConfigKey(_group, "beats_adjust_slower"), false);
+    m_pAdjustBeatsSlower = new ControlPushButton(ConfigKey(group, "beats_adjust_slower"), false);
     connect(m_pAdjustBeatsSlower, SIGNAL(valueChanged(double)),
             this, SLOT(slotAdjustBeatsSlower(double)),
             Qt::DirectConnection);
-    m_pTranslateBeatsEarlier = new ControlPushButton(ConfigKey(_group, "beats_translate_earlier"), false);
+    m_pTranslateBeatsEarlier = new ControlPushButton(ConfigKey(group, "beats_translate_earlier"), false);
     connect(m_pTranslateBeatsEarlier, SIGNAL(valueChanged(double)),
             this, SLOT(slotTranslateBeatsEarlier(double)),
             Qt::DirectConnection);
-    m_pTranslateBeatsLater = new ControlPushButton(ConfigKey(_group, "beats_translate_later"), false);
+    m_pTranslateBeatsLater = new ControlPushButton(ConfigKey(group, "beats_translate_later"), false);
     connect(m_pTranslateBeatsLater, SIGNAL(valueChanged(double)),
             this, SLOT(slotTranslateBeatsLater(double)),
             Qt::DirectConnection);
@@ -71,33 +71,33 @@ BpmControl::BpmControl(const char* _group,
     // bpm_down controls.
     // bpm_up / bpm_down steps by 1
     // bpm_up_small / bpm_down_small steps by 0.1
-    m_pEngineBpm = new ControlLinPotmeter(ConfigKey(_group, "bpm"), 1, 200, 1, 0.1, true);
+    m_pEngineBpm = new ControlLinPotmeter(ConfigKey(group, "bpm"), 1, 200, 1, 0.1, true);
     connect(m_pEngineBpm, SIGNAL(valueChanged(double)),
             this, SLOT(slotSetEngineBpm(double)),
             Qt::DirectConnection);
 
-    m_pButtonTap = new ControlPushButton(ConfigKey(_group, "bpm_tap"));
+    m_pButtonTap = new ControlPushButton(ConfigKey(group, "bpm_tap"));
     connect(m_pButtonTap, SIGNAL(valueChanged(double)),
             this, SLOT(slotBpmTap(double)),
             Qt::DirectConnection);
 
     // Beat sync (scale buffer tempo relative to tempo of other buffer)
-    m_pButtonSync = new ControlPushButton(ConfigKey(_group, "beatsync"));
+    m_pButtonSync = new ControlPushButton(ConfigKey(group, "beatsync"));
     connect(m_pButtonSync, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlBeatSync(double)),
             Qt::DirectConnection);
 
-    m_pButtonSyncPhase = new ControlPushButton(ConfigKey(_group, "beatsync_phase"));
+    m_pButtonSyncPhase = new ControlPushButton(ConfigKey(group, "beatsync_phase"));
     connect(m_pButtonSyncPhase, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlBeatSyncPhase(double)),
             Qt::DirectConnection);
 
-    m_pButtonSyncTempo = new ControlPushButton(ConfigKey(_group, "beatsync_tempo"));
+    m_pButtonSyncTempo = new ControlPushButton(ConfigKey(group, "beatsync_tempo"));
     connect(m_pButtonSyncTempo, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlBeatSyncTempo(double)),
             Qt::DirectConnection);
 
-    m_pTranslateBeats = new ControlPushButton(ConfigKey(_group, "beats_translate_curpos"));
+    m_pTranslateBeats = new ControlPushButton(ConfigKey(group, "beats_translate_curpos"));
     connect(m_pTranslateBeats, SIGNAL(valueChanged(double)),
             this, SLOT(slotBeatsTranslate(double)),
             Qt::DirectConnection);
@@ -107,8 +107,8 @@ BpmControl::BpmControl(const char* _group,
             Qt::DirectConnection);
 
     // Measures distance from last beat in percentage: 0.5 = half-beat away.
-    m_pThisBeatDistance = new ControlObjectSlave(_group, "beat_distance", this);
-    m_pSyncMode = ControlObject::getControl(ConfigKey(_group, "sync_mode"));
+    m_pThisBeatDistance = new ControlObjectSlave(group, "beat_distance", this);
+    m_pSyncMode = ControlObject::getControl(ConfigKey(group, "sync_mode"));
 }
 
 BpmControl::~BpmControl() {

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -1,4 +1,3 @@
-
 // bpmcontrol.h
 // Created 7/5/2009 by RJ Ryan (rryan@mit.edu)
 
@@ -21,7 +20,7 @@ class BpmControl : public EngineControl {
     Q_OBJECT
 
   public:
-    BpmControl(const char* _group, ConfigObject<ConfigValue>* _config);
+    BpmControl(QString group, ConfigObject<ConfigValue>* _config);
     virtual ~BpmControl();
 
     double getBpm() const;

--- a/src/engine/clockcontrol.cpp
+++ b/src/engine/clockcontrol.cpp
@@ -6,9 +6,9 @@
 #include "engine/enginecontrol.h"
 #include "controlobjectslave.h"
 
-ClockControl::ClockControl(const char* pGroup, ConfigObject<ConfigValue>* pConfig)
-        : EngineControl(pGroup, pConfig) {
-    m_pCOBeatActive = new ControlObject(ConfigKey(pGroup, "beat_active"));
+ClockControl::ClockControl(QString group, ConfigObject<ConfigValue>* pConfig)
+        : EngineControl(group, pConfig) {
+    m_pCOBeatActive = new ControlObject(ConfigKey(group, "beat_active"));
     m_pCOBeatActive->set(0.0);
     m_pCOSampleRate = new ControlObjectSlave("[Master]","samplerate");
 }

--- a/src/engine/clockcontrol.h
+++ b/src/engine/clockcontrol.h
@@ -12,7 +12,7 @@ class ControlObjectSlave;
 class ClockControl: public EngineControl {
     Q_OBJECT
   public:
-    ClockControl(const char* pGroup,
+    ClockControl(QString group,
                  ConfigObject<ConfigValue>* pConfig);
 
     virtual ~ClockControl();

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -17,14 +17,14 @@ static const double CUE_MODE_PIONEER = 1.0;
 static const double CUE_MODE_DENON = 2.0;
 static const double CUE_MODE_NUMARK = 3.0;
 
-CueControl::CueControl(const char* _group,
+CueControl::CueControl(QString group,
                        ConfigObject<ConfigValue>* _config) :
-        EngineControl(_group, _config),
+        EngineControl(group, _config),
         m_bHotcueCancel(false),
         m_bPreviewing(false),
         m_bPreviewingHotcue(false),
-        m_pPlayButton(ControlObject::getControl(ConfigKey(_group, "play"))),
-        m_pStopButton(ControlObject::getControl(ConfigKey(_group, "stop"))),
+        m_pPlayButton(ControlObject::getControl(ConfigKey(group, "play"))),
+        m_pStopButton(ControlObject::getControl(ConfigKey(group, "stop"))),
         m_iCurrentlyPreviewingHotcues(0),
         m_iNumHotCues(NUM_HOT_CUES),
         m_pLoadedTrack(),
@@ -33,65 +33,65 @@ CueControl::CueControl(const char* _group,
     Q_UNUSED(CUE_MODE_PIONEER);
     createControls();
 
-    m_pTrackSamples = ControlObject::getControl(ConfigKey(_group, "track_samples"));
+    m_pTrackSamples = ControlObject::getControl(ConfigKey(group, "track_samples"));
 
-    m_pQuantizeEnabled = ControlObject::getControl(ConfigKey(_group, "quantize"));
+    m_pQuantizeEnabled = ControlObject::getControl(ConfigKey(group, "quantize"));
 
-    m_pNextBeat = ControlObject::getControl(ConfigKey(_group, "beat_next"));
-    m_pClosestBeat = ControlObject::getControl(ConfigKey(_group, "beat_closest"));
+    m_pNextBeat = ControlObject::getControl(ConfigKey(group, "beat_next"));
+    m_pClosestBeat = ControlObject::getControl(ConfigKey(group, "beat_closest"));
 
-    m_pCuePoint = new ControlObject(ConfigKey(_group, "cue_point"));
+    m_pCuePoint = new ControlObject(ConfigKey(group, "cue_point"));
     m_pCuePoint->set(-1.0);
 
-    m_pCueMode = new ControlObject(ConfigKey(_group, "cue_mode"));
+    m_pCueMode = new ControlObject(ConfigKey(group, "cue_mode"));
     // 0.0 -> Pioneer mode
     // 1.0 -> Denon mode
 
-    m_pCueSet = new ControlPushButton(ConfigKey(_group, "cue_set"));
+    m_pCueSet = new ControlPushButton(ConfigKey(group, "cue_set"));
     m_pCueSet->setButtonMode(ControlPushButton::TRIGGER);
     connect(m_pCueSet, SIGNAL(valueChanged(double)),
             this, SLOT(cueSet(double)),
             Qt::DirectConnection);
 
-    m_pCueGoto = new ControlPushButton(ConfigKey(_group, "cue_goto"));
+    m_pCueGoto = new ControlPushButton(ConfigKey(group, "cue_goto"));
     connect(m_pCueGoto, SIGNAL(valueChanged(double)),
             this, SLOT(cueGoto(double)),
             Qt::DirectConnection);
 
     m_pCueGotoAndPlay =
-            new ControlPushButton(ConfigKey(_group, "cue_gotoandplay"));
+            new ControlPushButton(ConfigKey(group, "cue_gotoandplay"));
     connect(m_pCueGotoAndPlay, SIGNAL(valueChanged(double)),
             this, SLOT(cueGotoAndPlay(double)),
             Qt::DirectConnection);
 
     m_pCueGotoAndStop =
-            new ControlPushButton(ConfigKey(_group, "cue_gotoandstop"));
+            new ControlPushButton(ConfigKey(group, "cue_gotoandstop"));
     connect(m_pCueGotoAndStop, SIGNAL(valueChanged(double)),
             this, SLOT(cueGotoAndStop(double)),
             Qt::DirectConnection);
 
-    m_pCuePreview = new ControlPushButton(ConfigKey(_group, "cue_preview"));
+    m_pCuePreview = new ControlPushButton(ConfigKey(group, "cue_preview"));
     connect(m_pCuePreview, SIGNAL(valueChanged(double)),
             this, SLOT(cuePreview(double)),
             Qt::DirectConnection);
 
-    m_pCueCDJ = new ControlPushButton(ConfigKey(_group, "cue_cdj"));
+    m_pCueCDJ = new ControlPushButton(ConfigKey(group, "cue_cdj"));
     connect(m_pCueCDJ, SIGNAL(valueChanged(double)),
             this, SLOT(cueCDJ(double)),
             Qt::DirectConnection);
 
-    m_pCueDefault = new ControlPushButton(ConfigKey(_group, "cue_default"));
+    m_pCueDefault = new ControlPushButton(ConfigKey(group, "cue_default"));
     connect(m_pCueDefault, SIGNAL(valueChanged(double)),
             this, SLOT(cueDefault(double)),
             Qt::DirectConnection);
 
-    m_pPlayStutter = new ControlPushButton(ConfigKey(_group, "play_stutter"));
+    m_pPlayStutter = new ControlPushButton(ConfigKey(group, "play_stutter"));
     connect(m_pPlayStutter, SIGNAL(valueChanged(double)),
             this, SLOT(playStutter(double)),
             Qt::DirectConnection);
 
-    m_pCueIndicator = new ControlIndicator(ConfigKey(_group, "cue_indicator"));
-    m_pPlayIndicator = new ControlIndicator(ConfigKey(_group, "play_indicator"));
+    m_pCueIndicator = new ControlIndicator(ConfigKey(group, "cue_indicator"));
+    m_pPlayIndicator = new ControlIndicator(ConfigKey(group, "play_indicator"));
 }
 
 CueControl::~CueControl() {
@@ -923,14 +923,14 @@ bool CueControl::isTrackAtCue() {
 
 ConfigKey HotcueControl::keyForControl(int hotcue, QString name) {
     ConfigKey key;
-    key.group = m_pGroup;
+    key.group = m_group;
     // Add one to hotcue so that we dont have a hotcue_0
     key.item = QString("hotcue_%1_%2").arg(QString::number(hotcue+1), name);
     return key;
 }
 
-HotcueControl::HotcueControl(const char* pGroup, int i)
-        : m_pGroup(pGroup),
+HotcueControl::HotcueControl(QString group, int i)
+        : m_group(group),
           m_iHotcueNumber(i),
           m_pCue(NULL),
           m_bPreviewing(false),

--- a/src/engine/cuecontrol.h
+++ b/src/engine/cuecontrol.h
@@ -21,7 +21,7 @@ class ControlIndicator;
 class HotcueControl : public QObject {
     Q_OBJECT
   public:
-    HotcueControl(const char* pGroup, int hotcueNumber);
+    HotcueControl(QString group, int hotcueNumber);
     virtual ~HotcueControl();
 
     inline int getHotcueNumber() { return m_iHotcueNumber; }
@@ -60,7 +60,7 @@ class HotcueControl : public QObject {
   private:
     ConfigKey keyForControl(int hotcue, QString name);
 
-    const char* m_pGroup;
+    QString m_group;
     int m_iHotcueNumber;
     Cue* m_pCue;
 
@@ -83,7 +83,7 @@ class HotcueControl : public QObject {
 class CueControl : public EngineControl {
     Q_OBJECT
   public:
-    CueControl(const char* _group,
+    CueControl(QString group,
                ConfigObject<ConfigValue>* _config);
     virtual ~CueControl();
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -58,10 +58,10 @@
 
 #include "trackinfoobject.h"
 
-EngineBuffer::EngineBuffer(const char* _group, ConfigObject<ConfigValue>* _config,
+EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
                            EngineChannel* pChannel, EngineMaster* pMixingEngine)
         : m_engineLock(QMutex::Recursive),
-          m_group(_group),
+          m_group(group),
           m_pConfig(_config),
           m_pLoopingControl(NULL),
           m_pSyncControl(NULL),
@@ -123,7 +123,7 @@ EngineBuffer::EngineBuffer(const char* _group, ConfigObject<ConfigValue>* _confi
     m_fLastSampleValue[0] = 0;
     m_fLastSampleValue[1] = 0;
 
-    m_pReader = new CachingReader(_group, _config);
+    m_pReader = new CachingReader(group, _config);
     connect(m_pReader, SIGNAL(trackLoading()),
             this, SLOT(slotTrackLoading()),
             Qt::DirectConnection);
@@ -223,29 +223,29 @@ EngineBuffer::EngineBuffer(const char* _group, ConfigObject<ConfigValue>* _confi
     // Quantization Controller for enabling and disabling the
     // quantization (alignment) of loop in/out positions and (hot)cues with
     // beats.
-    addControl(new QuantizeControl(_group, _config));
-    m_pQuantize = ControlObject::getControl(ConfigKey(_group, "quantize"));
+    addControl(new QuantizeControl(group, _config));
+    m_pQuantize = ControlObject::getControl(ConfigKey(group, "quantize"));
 
     // Create the Loop Controller
-    m_pLoopingControl = new LoopingControl(_group, _config);
+    m_pLoopingControl = new LoopingControl(group, _config);
     addControl(m_pLoopingControl);
 
     m_pEngineSync = pMixingEngine->getEngineSync();
 
-    m_pSyncControl = new SyncControl(_group, _config, pChannel, m_pEngineSync);
+    m_pSyncControl = new SyncControl(group, _config, pChannel, m_pEngineSync);
     addControl(m_pSyncControl);
 
 #ifdef __VINYLCONTROL__
-    m_pVinylControlControl = new VinylControlControl(_group, _config);
+    m_pVinylControlControl = new VinylControlControl(group, _config);
     addControl(m_pVinylControlControl);
 #endif
 
-    m_pRateControl = new RateControl(_group, _config);
+    m_pRateControl = new RateControl(group, _config);
     // Add the Rate Controller
     addControl(m_pRateControl);
 
     // Create the BPM Controller
-    m_pBpmControl = new BpmControl(_group, _config);
+    m_pBpmControl = new BpmControl(group, _config);
     addControl(m_pBpmControl);
 
     // TODO(rryan) remove this dependence?
@@ -253,19 +253,19 @@ EngineBuffer::EngineBuffer(const char* _group, ConfigObject<ConfigValue>* _confi
     m_pSyncControl->setEngineControls(m_pRateControl, m_pBpmControl);
     pMixingEngine->getEngineSync()->addSyncableDeck(m_pSyncControl);
 
-    m_fwdButton = ControlObject::getControl(ConfigKey(_group, "fwd"));
-    m_backButton = ControlObject::getControl(ConfigKey(_group, "back"));
+    m_fwdButton = ControlObject::getControl(ConfigKey(group, "fwd"));
+    m_backButton = ControlObject::getControl(ConfigKey(group, "back"));
 
-    m_pKeyControl = new KeyControl(_group, _config);
+    m_pKeyControl = new KeyControl(group, _config);
     addControl(m_pKeyControl);
     m_pPitchControl = new ControlObjectSlave(m_group, "pitch", this);
 
     // Create the clock controller
-    m_pClockControl = new ClockControl(_group, _config);
+    m_pClockControl = new ClockControl(group, _config);
     addControl(m_pClockControl);
 
     // Create the cue controller
-    m_pCueControl = new CueControl(_group, _config);
+    m_pCueControl = new CueControl(group, _config);
     addControl(m_pCueControl);
 
     m_pReadAheadManager = new ReadAheadManager(m_pReader);
@@ -284,7 +284,7 @@ EngineBuffer::EngineBuffer(const char* _group, ConfigObject<ConfigValue>* _confi
     }
     enablePitchAndTimeScaling(false);
 
-    m_pPassthroughEnabled.reset(new ControlObjectSlave(_group, "passthrough", this));
+    m_pPassthroughEnabled.reset(new ControlObjectSlave(group, "passthrough", this));
     m_pPassthroughEnabled->connectValueChanged(this, SLOT(slotPassthroughChanged(double)),
                                                Qt::DirectConnection);
 
@@ -482,7 +482,7 @@ void EngineBuffer::setNewPlaypos(double newpos) {
     m_engineLock.unlock();
 }
 
-const char* EngineBuffer::getGroup()
+QString EngineBuffer::getGroup()
 {
     return m_group;
 }

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -118,7 +118,7 @@ class EngineBuffer : public EngineObject {
         KEYLOCK_ENGINE_COUNT,
     };
 
-    EngineBuffer(const char* _group, ConfigObject<ConfigValue>* _config,
+    EngineBuffer(QString _group, ConfigObject<ConfigValue>* _config,
                  EngineChannel* pChannel, EngineMaster* pMixingEngine);
     virtual ~EngineBuffer();
     bool getPitchIndpTimeStretch(void);
@@ -147,7 +147,7 @@ class EngineBuffer : public EngineObject {
     void processSlip(int iBufferSize);
     void postProcess(const int iBufferSize);
 
-    const char* getGroup();
+    QString getGroup();
     bool isTrackLoaded();
     TrackPointer getLoadedTrack() const;
 
@@ -239,7 +239,7 @@ class EngineBuffer : public EngineObject {
     QMutex m_engineLock;
 
     // Holds the name of the control group
-    const char* m_group;
+    QString m_group;
     ConfigObject<ConfigValue>* m_pConfig;
 
     LoopingControl* m_pLoopingControl;

--- a/src/engine/enginechannel.cpp
+++ b/src/engine/enginechannel.cpp
@@ -20,7 +20,7 @@
 #include "controlobject.h"
 #include "controlpushbutton.h"
 
-EngineChannel::EngineChannel(const char* pGroup,
+EngineChannel::EngineChannel(QString pGroup,
                              EngineChannel::ChannelOrientation defaultOrientation)
         : m_group(pGroup) {
     m_pPFL = new ControlPushButton(ConfigKey(m_group, "pfl"));

--- a/src/engine/enginechannel.h
+++ b/src/engine/enginechannel.h
@@ -38,7 +38,7 @@ class EngineChannel : public EngineObject {
         RIGHT,
     };
 
-    EngineChannel(const char* pGroup, ChannelOrientation defaultOrientation = CENTER);
+    EngineChannel(QString pGroup, ChannelOrientation defaultOrientation = CENTER);
     virtual ~EngineChannel();
 
     virtual ChannelOrientation getOrientation() const;

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -6,9 +6,9 @@
 #include "engine/enginebuffer.h"
 #include "playermanager.h"
 
-EngineControl::EngineControl(const char* _group,
+EngineControl::EngineControl(QString group,
                              ConfigObject<ConfigValue>* _config)
-        : m_pGroup(_group),
+        : m_group(group),
           m_pConfig(_config),
           m_dTotalSamples(0),
           m_pEngineMaster(NULL),
@@ -71,8 +71,8 @@ double EngineControl::getTotalSamples() const {
     return m_dTotalSamples;
 }
 
-const char* EngineControl::getGroup() const {
-    return m_pGroup;
+QString EngineControl::getGroup() const {
+    return m_group;
 }
 
 ConfigObject<ConfigValue>* EngineControl::getConfig() {

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -35,7 +35,7 @@ const double kNoTrigger = -1;
 class EngineControl : public QObject {
     Q_OBJECT
   public:
-    EngineControl(const char* _group,
+    EngineControl(QString group,
                   ConfigObject<ConfigValue>* _config);
     virtual ~EngineControl();
 
@@ -70,7 +70,7 @@ class EngineControl : public QObject {
     virtual void setCurrentSample(const double dCurrentSample, const double dTotalSamples);
     double getCurrentSample() const;
     double getTotalSamples() const;
-    const char* getGroup() const;
+    QString getGroup() const;
 
     // Called to collect player features for effects processing.
     virtual void collectFeatureState(GroupFeatureState* pGroupFeatures) const {
@@ -95,7 +95,7 @@ class EngineControl : public QObject {
     EngineMaster* getEngineMaster();
     EngineBuffer* getEngineBuffer();
 
-    const char* m_pGroup;
+    QString m_group;
     ConfigObject<ConfigValue>* m_pConfig;
 
   private:

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -28,7 +28,7 @@
 
 #include "sampleutil.h"
 
-EngineDeck::EngineDeck(const char* group,
+EngineDeck::EngineDeck(QString group,
                        ConfigObject<ConfigValue>* pConfig,
                        EngineMaster* pMixingEngine,
                        EffectsManager* pEffectsManager,

--- a/src/engine/enginedeck.h
+++ b/src/engine/enginedeck.h
@@ -42,7 +42,7 @@ class ControlPushButton;
 class EngineDeck : public EngineChannel, public AudioDestination {
     Q_OBJECT
   public:
-    EngineDeck(const char* group, ConfigObject<ConfigValue>* pConfig,
+    EngineDeck(QString group, ConfigObject<ConfigValue>* pConfig,
                EngineMaster* pMixingEngine, EffectsManager* pEffectsManager,
                EngineChannel::ChannelOrientation defaultOrientation = CENTER);
     virtual ~EngineDeck();

--- a/src/engine/enginefilterblock.cpp
+++ b/src/engine/enginefilterblock.cpp
@@ -33,7 +33,7 @@ ControlPotmeter* EngineFilterBlock::s_hiEqFreq = NULL;
 ControlPushButton* EngineFilterBlock::s_lofiEq = NULL;
 ControlPushButton* EngineFilterBlock::s_EnableEq = NULL;
 
-EngineFilterBlock::EngineFilterBlock(const char* group)
+EngineFilterBlock::EngineFilterBlock(QString group)
 {
     ilowFreq = 0;
     ihighFreq = 0;

--- a/src/engine/enginefilterblock.h
+++ b/src/engine/enginefilterblock.h
@@ -41,7 +41,7 @@ class ControlPushButton;
 class EngineFilterBlock : public EngineObject {
     Q_OBJECT
   public:
-    EngineFilterBlock(const char* group);
+    EngineFilterBlock(QString group);
     virtual ~EngineFilterBlock();
 
     void process(CSAMPLE* pInOut, const int iBufferSize);

--- a/src/engine/enginemicrophone.cpp
+++ b/src/engine/enginemicrophone.cpp
@@ -12,7 +12,7 @@
 #include "controlaudiotaperpot.h"
 
 
-EngineMicrophone::EngineMicrophone(const char* pGroup, EffectsManager* pEffectsManager)
+EngineMicrophone::EngineMicrophone(QString pGroup, EffectsManager* pEffectsManager)
         : EngineChannel(pGroup, EngineChannel::CENTER),
           m_pEngineEffectsManager(pEffectsManager ? pEffectsManager->getEngineEffectsManager() : NULL),
           m_vuMeter(pGroup),

--- a/src/engine/enginemicrophone.h
+++ b/src/engine/enginemicrophone.h
@@ -21,7 +21,7 @@ class ControlAudioTaperPot;
 class EngineMicrophone : public EngineChannel, public AudioDestination {
     Q_OBJECT
   public:
-    EngineMicrophone(const char* pGroup, EffectsManager* pEffectsManager);
+    EngineMicrophone(QString pGroup, EffectsManager* pEffectsManager);
     virtual ~EngineMicrophone();
 
     bool isActive();

--- a/src/engine/enginepregain.cpp
+++ b/src/engine/enginepregain.cpp
@@ -31,7 +31,7 @@ ControlObject* EnginePregain::s_pEnableReplayGain = NULL;
 /*----------------------------------------------------------------
    A pregaincontrol is ... a pregain.
    ----------------------------------------------------------------*/
-EnginePregain::EnginePregain(const char* group)
+EnginePregain::EnginePregain(QString group)
 {
     m_pPotmeterPregain = new ControlAudioTaperPot(ConfigKey(group, "pregain"), -12, +12, 0.5);
     //Replay Gain things

--- a/src/engine/enginepregain.h
+++ b/src/engine/enginepregain.h
@@ -27,7 +27,7 @@ class ControlObject;
 
 class EnginePregain : public EngineObject {
   public:
-    EnginePregain(const char* group);
+    EnginePregain(QString group);
     virtual ~EnginePregain();
 
     void process(CSAMPLE* pInOut, const int iBufferSize);

--- a/src/engine/enginevinylsoundemu.cpp
+++ b/src/engine/enginevinylsoundemu.cpp
@@ -27,7 +27,7 @@
  *   these slow speeds.
  */
 
-EngineVinylSoundEmu::EngineVinylSoundEmu(const char* group)
+EngineVinylSoundEmu::EngineVinylSoundEmu(QString group)
         : m_dSpeed(0.0),
           m_dOldSpeed(0.0),
           m_iNoisePos(0) {

--- a/src/engine/enginevinylsoundemu.h
+++ b/src/engine/enginevinylsoundemu.h
@@ -28,7 +28,7 @@ class ControlObject;
 class EngineVinylSoundEmu : public EngineObject {
     Q_OBJECT
   public:
-    EngineVinylSoundEmu(const char* group);
+    EngineVinylSoundEmu(QString group);
     virtual ~EngineVinylSoundEmu();
 
     void setSpeed(double speed);

--- a/src/engine/enginevumeter.cpp
+++ b/src/engine/enginevumeter.cpp
@@ -20,7 +20,7 @@
 #include "sampleutil.h"
 #include "util/math.h"
 
-EngineVuMeter::EngineVuMeter(const char* group) {
+EngineVuMeter::EngineVuMeter(QString group) {
     // The VUmeter widget is controlled via a controlpotmeter, which means
     // that it should react on the setValue(int) signal.
     m_ctrlVuMeter = new ControlPotmeter(ConfigKey(group, "VuMeter"), 0., 1.);
@@ -29,8 +29,10 @@ EngineVuMeter::EngineVuMeter(const char* group) {
     // right channel VU meter
     m_ctrlVuMeterR = new ControlPotmeter(ConfigKey(group, "VuMeterL"), 0., 1.);
 
-    // Used controlpotmeter as the example used it :/ perhaps someone with more knowledge could use something more suitable...
-    m_ctrlPeakIndicator = new ControlPotmeter(ConfigKey(group, "PeakIndicator"), 0., 1.);
+    // Used controlpotmeter as the example used it :/ perhaps someone with more
+    // knowledge could use something more suitable...
+    m_ctrlPeakIndicator = new ControlPotmeter(ConfigKey(group, "PeakIndicator"),
+                                              0., 1.);
 
     m_pSampleRate = new ControlObjectSlave("[Master]", "samplerate", this);
 

--- a/src/engine/enginevumeter.h
+++ b/src/engine/enginevumeter.h
@@ -34,7 +34,7 @@ class ControlObjectSlave;
 class EngineVuMeter : public EngineObject {
     Q_OBJECT
   public:
-    EngineVuMeter(const char*);
+    EngineVuMeter(QString group);
     virtual ~EngineVuMeter();
 
     virtual void process(CSAMPLE* pInOut, const int iBufferSize);

--- a/src/engine/keycontrol.cpp
+++ b/src/engine/keycontrol.cpp
@@ -9,14 +9,14 @@
 #include "engine/enginebuffer.h"
 #include "track/keyutils.h"
 
-KeyControl::KeyControl(const char* pGroup,
+KeyControl::KeyControl(QString group,
                        ConfigObject<ConfigValue>* pConfig)
-        : EngineControl(pGroup, pConfig),
+        : EngineControl(group, pConfig),
           m_dOldRate(0.0),
           m_bOldKeylock(false),
           m_dPitchCompensation(0.0),
           m_dPitchCompensationOldPitch(0.0) {
-    m_pPitch = new ControlPotmeter(ConfigKey(pGroup, "pitch"), -1.f, 1.f);
+    m_pPitch = new ControlPotmeter(ConfigKey(group, "pitch"), -1.f, 1.f);
     // Course adjust by full step.
     m_pPitch->setStepCount(24);
     // Fine adjust by half-step / semitone.
@@ -29,25 +29,25 @@ KeyControl::KeyControl(const char* pGroup,
             this, SLOT(slotPitchChanged(double)),
             Qt::DirectConnection);
 
-    m_pButtonSyncKey = new ControlPushButton(ConfigKey(pGroup, "sync_key"));
+    m_pButtonSyncKey = new ControlPushButton(ConfigKey(group, "sync_key"));
     connect(m_pButtonSyncKey, SIGNAL(valueChanged(double)),
             this, SLOT(slotSyncKey(double)),
             Qt::DirectConnection);
 
-    m_pFileKey = new ControlObject(ConfigKey(pGroup, "file_key"));
+    m_pFileKey = new ControlObject(ConfigKey(group, "file_key"));
     connect(m_pFileKey, SIGNAL(valueChanged(double)),
             this, SLOT(slotFileKeyChanged(double)),
             Qt::DirectConnection);
 
-    m_pEngineKey = new ControlObject(ConfigKey(pGroup, "key"));
+    m_pEngineKey = new ControlObject(ConfigKey(group, "key"));
     connect(m_pEngineKey, SIGNAL(valueChanged(double)),
             this, SLOT(slotSetEngineKey(double)),
             Qt::DirectConnection);
 
-    m_pEngineKeyDistance = new ControlPotmeter(ConfigKey(pGroup, "visual_key_distance"),
+    m_pEngineKeyDistance = new ControlPotmeter(ConfigKey(group, "visual_key_distance"),
                                                -0.5, 0.5);
 
-    m_pRateSlider = ControlObject::getControl(ConfigKey(pGroup, "rate"));
+    m_pRateSlider = ControlObject::getControl(ConfigKey(group, "rate"));
     connect(m_pRateSlider, SIGNAL(valueChanged(double)),
             this, SLOT(slotRateChanged()),
             Qt::DirectConnection);
@@ -55,7 +55,7 @@ KeyControl::KeyControl(const char* pGroup,
             this, SLOT(slotRateChanged()),
             Qt::DirectConnection);
 
-    m_pRateRange = ControlObject::getControl(ConfigKey(pGroup, "rateRange"));
+    m_pRateRange = ControlObject::getControl(ConfigKey(group, "rateRange"));
     connect(m_pRateRange, SIGNAL(valueChanged(double)),
             this, SLOT(slotRateChanged()),
             Qt::DirectConnection);
@@ -63,7 +63,7 @@ KeyControl::KeyControl(const char* pGroup,
             this, SLOT(slotRateChanged()),
             Qt::DirectConnection);
 
-    m_pRateDir = ControlObject::getControl(ConfigKey(pGroup, "rate_dir"));
+    m_pRateDir = ControlObject::getControl(ConfigKey(group, "rate_dir"));
     connect(m_pRateDir, SIGNAL(valueChanged(double)),
             this, SLOT(slotRateChanged()),
             Qt::DirectConnection);
@@ -71,7 +71,7 @@ KeyControl::KeyControl(const char* pGroup,
             this, SLOT(slotRateChanged()),
             Qt::DirectConnection);
 
-    m_pKeylock = ControlObject::getControl(ConfigKey(pGroup, "keylock"));
+    m_pKeylock = ControlObject::getControl(ConfigKey(group, "keylock"));
     connect(m_pKeylock, SIGNAL(valueChanged(double)),
             this, SLOT(slotRateChanged()),
             Qt::DirectConnection);

--- a/src/engine/keycontrol.h
+++ b/src/engine/keycontrol.h
@@ -11,7 +11,7 @@ class ControlPushButton;
 class KeyControl : public EngineControl {
     Q_OBJECT
   public:
-    KeyControl(const char* pGroup, ConfigObject<ConfigValue>* pConfig);
+    KeyControl(QString group, ConfigObject<ConfigValue>* pConfig);
     virtual ~KeyControl();
 
     // Returns a value describing the pitch adjustment measured in octaves. A

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -26,7 +26,7 @@ class LoopingControl : public EngineControl {
   public:
     static QList<double> getBeatSizes();
 
-    LoopingControl(const char* _group, ConfigObject<ConfigValue>* _config);
+    LoopingControl(QString group, ConfigObject<ConfigValue>* _config);
     virtual ~LoopingControl();
 
     // process() updates the internal state of the LoopingControl to reflect the
@@ -140,7 +140,7 @@ class LoopingControl : public EngineControl {
 class LoopMoveControl : public QObject {
     Q_OBJECT
   public:
-    LoopMoveControl(const char* pGroup, double size);
+    LoopMoveControl(QString group, double size);
     virtual ~LoopMoveControl();
 
   signals:
@@ -161,7 +161,7 @@ class LoopMoveControl : public QObject {
 class BeatJumpControl : public QObject {
     Q_OBJECT
   public:
-    BeatJumpControl(const char* pGroup, double size);
+    BeatJumpControl(QString group, double size);
     virtual ~BeatJumpControl();
 
   signals:
@@ -182,7 +182,7 @@ class BeatJumpControl : public QObject {
 class BeatLoopingControl : public QObject {
     Q_OBJECT
   public:
-    BeatLoopingControl(const char* pGroup, double size);
+    BeatLoopingControl(QString group, double size);
     virtual ~BeatLoopingControl();
 
     void activate();

--- a/src/engine/positionscratchcontroller.cpp
+++ b/src/engine/positionscratchcontroller.cpp
@@ -62,8 +62,8 @@ class RateIIFilter {
     double m_last_rate;
 };
 
-PositionScratchController::PositionScratchController(const char* pGroup)
-    : m_group(pGroup),
+PositionScratchController::PositionScratchController(QString group)
+    : m_group(group),
       m_bScratching(false),
       m_bEnableInertia(false),
       m_dLastPlaypos(0),
@@ -73,8 +73,8 @@ PositionScratchController::PositionScratchController(const char* pGroup)
       m_dRate(0),
       m_dMoveDelay(0),
       m_dMouseSampeTime(0) {
-    m_pScratchEnable = new ControlObject(ConfigKey(pGroup, "scratch_position_enable"));
-    m_pScratchPosition = new ControlObject(ConfigKey(pGroup, "scratch_position"));
+    m_pScratchEnable = new ControlObject(ConfigKey(group, "scratch_position_enable"));
+    m_pScratchPosition = new ControlObject(ConfigKey(group, "scratch_position"));
     m_pMasterSampleRate = ControlObject::getControl(ConfigKey("[Master]", "samplerate"));
     m_pVelocityController = new VelocityController();
     m_pRateIIFilter = new RateIIFilter;

--- a/src/engine/positionscratchcontroller.h
+++ b/src/engine/positionscratchcontroller.h
@@ -11,7 +11,7 @@ class RateIIFilter;
 
 class PositionScratchController : public QObject {
   public:
-    PositionScratchController(const char* pGroup);
+    PositionScratchController(QString group);
     virtual ~PositionScratchController();
 
     void process(double currentSample, double releaseRate,

--- a/src/engine/quantizecontrol.cpp
+++ b/src/engine/quantizecontrol.cpp
@@ -11,17 +11,17 @@
 #include "engine/quantizecontrol.h"
 #include "engine/enginecontrol.h"
 
-QuantizeControl::QuantizeControl(const char* pGroup,
+QuantizeControl::QuantizeControl(QString group,
                                  ConfigObject<ConfigValue>* pConfig)
-        : EngineControl(pGroup, pConfig) {
+        : EngineControl(group, pConfig) {
     // Turn quantize OFF by default. See Bug #898213
-    m_pCOQuantizeEnabled = new ControlPushButton(ConfigKey(pGroup, "quantize"));
+    m_pCOQuantizeEnabled = new ControlPushButton(ConfigKey(group, "quantize"));
     m_pCOQuantizeEnabled->setButtonMode(ControlPushButton::TOGGLE);
-    m_pCONextBeat = new ControlObject(ConfigKey(pGroup, "beat_next"));
+    m_pCONextBeat = new ControlObject(ConfigKey(group, "beat_next"));
     m_pCONextBeat->set(-1);
-    m_pCOPrevBeat = new ControlObject(ConfigKey(pGroup, "beat_prev"));
+    m_pCOPrevBeat = new ControlObject(ConfigKey(group, "beat_prev"));
     m_pCOPrevBeat->set(-1);
-    m_pCOClosestBeat = new ControlObject(ConfigKey(pGroup, "beat_closest"));
+    m_pCOClosestBeat = new ControlObject(ConfigKey(group, "beat_closest"));
     m_pCOClosestBeat->set(-1);
 }
 

--- a/src/engine/quantizecontrol.h
+++ b/src/engine/quantizecontrol.h
@@ -16,7 +16,7 @@ class ControlObjectThread;
 class QuantizeControl : public EngineControl {
     Q_OBJECT
   public:
-    QuantizeControl(const char* pGroup, ConfigObject<ConfigValue>* pConfig);
+    QuantizeControl(QString group, ConfigObject<ConfigValue>* pConfig);
     virtual ~QuantizeControl();
 
     double process(const double dRate,

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -30,9 +30,9 @@ const double RateControl::kWheelMultiplier = 40.0;
 const double RateControl::kPausedJogMultiplier = 18.0;
 enum RateControl::RATERAMP_MODE RateControl::m_eRateRampMode = RateControl::RATERAMP_STEP;
 
-RateControl::RateControl(const char* _group,
+RateControl::RateControl(QString group,
                          ConfigObject<ConfigValue>* _config)
-    : EngineControl(_group, _config),
+    : EngineControl(group, _config),
       m_pBpmControl(NULL),
       m_ePbCurrent(0),
       m_ePbPressed(0),
@@ -41,43 +41,43 @@ RateControl::RateControl(const char* _group,
       m_dRateTemp(0.0),
       m_eRampBackMode(RATERAMP_RAMPBACK_NONE),
       m_dRateTempRampbackChange(0.0) {
-    m_pScratchController = new PositionScratchController(_group);
+    m_pScratchController = new PositionScratchController(group);
 
-    m_pRateDir = new ControlObject(ConfigKey(_group, "rate_dir"));
-    m_pRateRange = new ControlObject(ConfigKey(_group, "rateRange"));
+    m_pRateDir = new ControlObject(ConfigKey(group, "rate_dir"));
+    m_pRateRange = new ControlObject(ConfigKey(group, "rateRange"));
     // Allow rate slider to go out of bounds so that master sync rate
     // adjustments are not capped.
-    m_pRateSlider = new ControlPotmeter(ConfigKey(_group, "rate"),
+    m_pRateSlider = new ControlPotmeter(ConfigKey(group, "rate"),
                                         -1.0, 1.0, true);
 
     // Search rate. Rate used when searching in sound. This overrules the
     // playback rate
-    m_pRateSearch = new ControlPotmeter(ConfigKey(_group, "rateSearch"), -300., 300.);
+    m_pRateSearch = new ControlPotmeter(ConfigKey(group, "rateSearch"), -300., 300.);
 
     // Reverse button
-    m_pReverseButton = new ControlPushButton(ConfigKey(_group, "reverse"));
+    m_pReverseButton = new ControlPushButton(ConfigKey(group, "reverse"));
     m_pReverseButton->set(0);
 
     // Forward button
-    m_pForwardButton = new ControlPushButton(ConfigKey(_group, "fwd"));
+    m_pForwardButton = new ControlPushButton(ConfigKey(group, "fwd"));
     connect(m_pForwardButton, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlFastForward(double)),
             Qt::DirectConnection);
     m_pForwardButton->set(0);
 
     // Back button
-    m_pBackButton = new ControlPushButton(ConfigKey(_group, "back"));
+    m_pBackButton = new ControlPushButton(ConfigKey(group, "back"));
     connect(m_pBackButton, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlFastBack(double)),
             Qt::DirectConnection);
     m_pBackButton->set(0);
 
-    m_pReverseRollButton = new ControlPushButton(ConfigKey(_group, "reverseroll"));
+    m_pReverseRollButton = new ControlPushButton(ConfigKey(group, "reverseroll"));
     connect(m_pReverseRollButton, SIGNAL(valueChanged(double)),
             this, SLOT(slotReverseRollActivate(double)),
             Qt::DirectConnection);
 
-    m_pSlipEnabled = new ControlObjectSlave(_group, "slip_enabled", this);
+    m_pSlipEnabled = new ControlObjectSlave(group, "slip_enabled", this);
 
     m_pVCEnabled = ControlObject::getControl(ConfigKey(getGroup(), "vinylcontrol_enabled"));
     m_pVCScratching = ControlObject::getControl(ConfigKey(getGroup(), "vinylcontrol_scratching"));
@@ -86,50 +86,50 @@ RateControl::RateControl(const char* _group,
 
     // Permanent rate-change buttons
     buttonRatePermDown =
-        new ControlPushButton(ConfigKey(_group,"rate_perm_down"));
+        new ControlPushButton(ConfigKey(group,"rate_perm_down"));
     connect(buttonRatePermDown, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlRatePermDown(double)),
             Qt::DirectConnection);
 
     buttonRatePermDownSmall =
-        new ControlPushButton(ConfigKey(_group,"rate_perm_down_small"));
+        new ControlPushButton(ConfigKey(group,"rate_perm_down_small"));
     connect(buttonRatePermDownSmall, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlRatePermDownSmall(double)),
             Qt::DirectConnection);
 
     buttonRatePermUp =
-        new ControlPushButton(ConfigKey(_group,"rate_perm_up"));
+        new ControlPushButton(ConfigKey(group,"rate_perm_up"));
     connect(buttonRatePermUp, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlRatePermUp(double)),
             Qt::DirectConnection);
 
     buttonRatePermUpSmall =
-        new ControlPushButton(ConfigKey(_group,"rate_perm_up_small"));
+        new ControlPushButton(ConfigKey(group,"rate_perm_up_small"));
     connect(buttonRatePermUpSmall, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlRatePermUpSmall(double)),
             Qt::DirectConnection);
 
     // Temporary rate-change buttons
     buttonRateTempDown =
-        new ControlPushButton(ConfigKey(_group,"rate_temp_down"));
+        new ControlPushButton(ConfigKey(group,"rate_temp_down"));
     connect(buttonRateTempDown, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlRateTempDown(double)),
             Qt::DirectConnection);
 
     buttonRateTempDownSmall =
-        new ControlPushButton(ConfigKey(_group,"rate_temp_down_small"));
+        new ControlPushButton(ConfigKey(group,"rate_temp_down_small"));
     connect(buttonRateTempDownSmall, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlRateTempDownSmall(double)),
             Qt::DirectConnection);
 
     buttonRateTempUp =
-        new ControlPushButton(ConfigKey(_group,"rate_temp_up"));
+        new ControlPushButton(ConfigKey(group,"rate_temp_up"));
     connect(buttonRateTempUp, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlRateTempUp(double)),
             Qt::DirectConnection);
 
     buttonRateTempUpSmall =
-        new ControlPushButton(ConfigKey(_group,"rate_temp_up_small"));
+        new ControlPushButton(ConfigKey(group,"rate_temp_up_small"));
     connect(buttonRateTempUpSmall, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlRateTempUpSmall(double)),
             Qt::DirectConnection);
@@ -139,24 +139,24 @@ RateControl::RateControl(const char* _group,
     m_pSampleRate = ControlObject::getControl(ConfigKey("[Master]","samplerate"));
 
     // Wheel to control playback position/speed
-    m_pWheel = new ControlTTRotary(ConfigKey(_group, "wheel"));
+    m_pWheel = new ControlTTRotary(ConfigKey(group, "wheel"));
 
     // Scratch controller, this is an accumulator which is useful for
     // controllers that return individiual +1 or -1s, these get added up and
     // cleared when we read
-    m_pScratch2 = new ControlObject(ConfigKey(_group, "scratch2"));
+    m_pScratch2 = new ControlObject(ConfigKey(group, "scratch2"));
 
     // Scratch enable toggle
-    m_pScratch2Enable = new ControlPushButton(ConfigKey(_group, "scratch2_enable"));
+    m_pScratch2Enable = new ControlPushButton(ConfigKey(group, "scratch2_enable"));
     m_pScratch2Enable->set(0);
 
-    m_pScratch2Scratching = new ControlPushButton(ConfigKey(_group,
+    m_pScratch2Scratching = new ControlPushButton(ConfigKey(group,
                                                             "scratch2_indicates_scratching"));
     // Enable by default, because it was always scratching befor introducing this control.
     m_pScratch2Scratching->set(1.0);
 
 
-    m_pJog = new ControlObject(ConfigKey(_group, "jog"));
+    m_pJog = new ControlObject(ConfigKey(group, "jog"));
     m_pJogFilter = new Rotary();
     // FIXME: This should be dependent on sample rate/block size or something
     m_pJogFilter->setFilterLength(25);
@@ -170,7 +170,7 @@ RateControl::RateControl(const char* _group,
     m_iRateRampSensitivity =
             getConfig()->getValueString(ConfigKey("[Controls]","RateRampSensitivity")).toInt();
 
-    m_pSyncMode = new ControlObjectSlave(_group, "sync_mode", this);
+    m_pSyncMode = new ControlObjectSlave(group, "sync_mode", this);
 }
 
 RateControl::~RateControl() {

--- a/src/engine/ratecontrol.h
+++ b/src/engine/ratecontrol.h
@@ -31,7 +31,7 @@ class PositionScratchController;
 class RateControl : public EngineControl {
     Q_OBJECT
 public:
-    RateControl(const char* _group, ConfigObject<ConfigValue>* _config);
+    RateControl(QString group, ConfigObject<ConfigValue>* _config);
     virtual ~RateControl();
 
     void setBpmControl(BpmControl* bpmcontrol);

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -15,10 +15,10 @@ const double SyncControl::kBpmUnity = 1.0;
 const double SyncControl::kBpmHalve = 0.5;
 const double SyncControl::kBpmDouble = 2.0;
 
-SyncControl::SyncControl(const char* pGroup, ConfigObject<ConfigValue>* pConfig,
+SyncControl::SyncControl(QString group, ConfigObject<ConfigValue>* pConfig,
                          EngineChannel* pChannel, SyncableListener* pEngineSync)
-        : EngineControl(pGroup, pConfig),
-          m_sGroup(pGroup),
+        : EngineControl(group, pConfig),
+          m_sGroup(group),
           m_pChannel(pChannel),
           m_pEngineSync(pEngineSync),
           m_pBpmControl(NULL),
@@ -29,36 +29,36 @@ SyncControl::SyncControl(const char* pGroup, ConfigObject<ConfigValue>* pConfig,
           m_beatDistance(0.0) {
     // Play button.  We only listen to this to disable master if the deck is
     // stopped.
-    m_pPlayButton.reset(new ControlObjectSlave(pGroup, "play", this));
+    m_pPlayButton.reset(new ControlObjectSlave(group, "play", this));
     m_pPlayButton->connectValueChanged(this, SLOT(slotControlPlay(double)),
                                        Qt::DirectConnection);
 
-    m_pSyncMode.reset(new ControlPushButton(ConfigKey(pGroup, "sync_mode")));
+    m_pSyncMode.reset(new ControlPushButton(ConfigKey(group, "sync_mode")));
     m_pSyncMode->setButtonMode(ControlPushButton::TOGGLE);
     m_pSyncMode->setStates(SYNC_NUM_MODES);
     m_pSyncMode->connectValueChangeRequest(
             this, SLOT(slotSyncModeChangeRequest(double)), Qt::DirectConnection);
 
     m_pSyncMasterEnabled.reset(
-            new ControlPushButton(ConfigKey(pGroup, "sync_master")));
+            new ControlPushButton(ConfigKey(group, "sync_master")));
     m_pSyncMasterEnabled->setButtonMode(ControlPushButton::TOGGLE);
     m_pSyncMasterEnabled->connectValueChangeRequest(
             this, SLOT(slotSyncMasterEnabledChangeRequest(double)), Qt::DirectConnection);
 
     m_pSyncEnabled.reset(
-            new ControlPushButton(ConfigKey(pGroup, "sync_enabled")));
+            new ControlPushButton(ConfigKey(group, "sync_enabled")));
     m_pSyncEnabled->setButtonMode(ControlPushButton::LONGPRESSLATCHING);
     m_pSyncEnabled->connectValueChangeRequest(
             this, SLOT(slotSyncEnabledChangeRequest(double)), Qt::DirectConnection);
 
     m_pSyncBeatDistance.reset(
-            new ControlObject(ConfigKey(pGroup, "beat_distance")));
+            new ControlObject(ConfigKey(group, "beat_distance")));
 
-    m_pPassthroughEnabled.reset(new ControlObjectSlave(pGroup, "passthrough", this));
+    m_pPassthroughEnabled.reset(new ControlObjectSlave(group, "passthrough", this));
     m_pPassthroughEnabled->connectValueChanged(this, SLOT(slotPassthroughChanged(double)),
                                                Qt::DirectConnection);
 
-    m_pEjectButton.reset(new ControlObjectSlave(pGroup, "eject", this));
+    m_pEjectButton.reset(new ControlObjectSlave(group, "eject", this));
     m_pEjectButton->connectValueChanged(this, SLOT(slotEjectPushed(double)),
                                         Qt::DirectConnection);
 

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -20,7 +20,7 @@ class SyncControl : public EngineControl, public Syncable {
     static const double kBpmUnity;
     static const double kBpmHalve;
     static const double kBpmDouble;
-    SyncControl(const char* pGroup, ConfigObject<ConfigValue>* pConfig,
+    SyncControl(QString group, ConfigObject<ConfigValue>* pConfig,
                 EngineChannel* pChannel, SyncableListener* pEngineSync);
     virtual ~SyncControl();
 

--- a/src/engine/vinylcontrolcontrol.cpp
+++ b/src/engine/vinylcontrolcontrol.cpp
@@ -4,14 +4,14 @@
 #include "library/dao/cue.h"
 #include "util/math.h"
 
-VinylControlControl::VinylControlControl(const char* pGroup, ConfigObject<ConfigValue>* pConfig)
-        : EngineControl(pGroup, pConfig),
+VinylControlControl::VinylControlControl(QString group, ConfigObject<ConfigValue>* pConfig)
+        : EngineControl(group, pConfig),
           m_bSeekRequested(false) {
-    m_pControlVinylStatus = new ControlObject(ConfigKey(pGroup, "vinylcontrol_status"));
-    m_pControlVinylSpeedType = new ControlObject(ConfigKey(pGroup, "vinylcontrol_speed_type"));
+    m_pControlVinylStatus = new ControlObject(ConfigKey(group, "vinylcontrol_status"));
+    m_pControlVinylSpeedType = new ControlObject(ConfigKey(group, "vinylcontrol_speed_type"));
 
     //Convert the ConfigKey's value into a double for the CO (for fast reads).
-    QString strVinylSpeedType = pConfig->getValueString(ConfigKey(pGroup,
+    QString strVinylSpeedType = pConfig->getValueString(ConfigKey(group,
                                                       "vinylcontrol_speed_type"));
     if (strVinylSpeedType == MIXXX_VINYL_SPEED_33) {
         m_pControlVinylSpeedType->set(MIXXX_VINYL_SPEED_33_NUM);
@@ -21,32 +21,32 @@ VinylControlControl::VinylControlControl(const char* pGroup, ConfigObject<Config
         m_pControlVinylSpeedType->set(MIXXX_VINYL_SPEED_33_NUM);
     }
 
-    m_pControlVinylSeek = new ControlObject(ConfigKey(pGroup, "vinylcontrol_seek"));
+    m_pControlVinylSeek = new ControlObject(ConfigKey(group, "vinylcontrol_seek"));
     connect(m_pControlVinylSeek, SIGNAL(valueChanged(double)),
             this, SLOT(slotControlVinylSeek(double)),
             Qt::DirectConnection);
 
-    m_pControlVinylRate = new ControlObject(ConfigKey(pGroup, "vinylcontrol_rate"));
-    m_pControlVinylScratching = new ControlPushButton(ConfigKey(pGroup, "vinylcontrol_scratching"));
+    m_pControlVinylRate = new ControlObject(ConfigKey(group, "vinylcontrol_rate"));
+    m_pControlVinylScratching = new ControlPushButton(ConfigKey(group, "vinylcontrol_scratching"));
     m_pControlVinylScratching->set(0);
     m_pControlVinylScratching->setButtonMode(ControlPushButton::TOGGLE);
-    m_pControlVinylEnabled = new ControlPushButton(ConfigKey(pGroup, "vinylcontrol_enabled"));
+    m_pControlVinylEnabled = new ControlPushButton(ConfigKey(group, "vinylcontrol_enabled"));
     m_pControlVinylEnabled->set(0);
     m_pControlVinylEnabled->setButtonMode(ControlPushButton::TOGGLE);
-    m_pControlVinylWantEnabled = new ControlPushButton(ConfigKey(pGroup, "vinylcontrol_wantenabled"));
+    m_pControlVinylWantEnabled = new ControlPushButton(ConfigKey(group, "vinylcontrol_wantenabled"));
     m_pControlVinylWantEnabled->set(0);
     m_pControlVinylWantEnabled->setButtonMode(ControlPushButton::TOGGLE);
-    m_pControlVinylMode = new ControlPushButton(ConfigKey(pGroup, "vinylcontrol_mode"));
+    m_pControlVinylMode = new ControlPushButton(ConfigKey(group, "vinylcontrol_mode"));
     m_pControlVinylMode->setStates(3);
     m_pControlVinylMode->setButtonMode(ControlPushButton::TOGGLE);
-    m_pControlVinylCueing = new ControlPushButton(ConfigKey(pGroup, "vinylcontrol_cueing"));
+    m_pControlVinylCueing = new ControlPushButton(ConfigKey(group, "vinylcontrol_cueing"));
     m_pControlVinylCueing->setStates(3);
     m_pControlVinylCueing->setButtonMode(ControlPushButton::TOGGLE);
-    m_pControlVinylSignalEnabled = new ControlPushButton(ConfigKey(pGroup, "vinylcontrol_signal_enabled"));
+    m_pControlVinylSignalEnabled = new ControlPushButton(ConfigKey(group, "vinylcontrol_signal_enabled"));
     m_pControlVinylSignalEnabled->set(1);
     m_pControlVinylSignalEnabled->setButtonMode(ControlPushButton::TOGGLE);
 
-    m_pPlayEnabled = new ControlObjectSlave(pGroup, "play", this);
+    m_pPlayEnabled = new ControlObjectSlave(group, "play", this);
 }
 
 VinylControlControl::~VinylControlControl() {

--- a/src/engine/vinylcontrolcontrol.h
+++ b/src/engine/vinylcontrolcontrol.h
@@ -11,7 +11,7 @@
 class VinylControlControl : public EngineControl {
     Q_OBJECT
   public:
-    VinylControlControl(const char* pGroup, ConfigObject<ConfigValue>* pConfig);
+    VinylControlControl(QString group, ConfigObject<ConfigValue>* pConfig);
     virtual ~VinylControlControl();
 
     void trackLoaded(TrackPointer pTrack);

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -175,8 +175,7 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
         // We don't know if something downstream expects the string to persist,
         // so dupe it (probably leaking it).
         EngineMicrophone* pMicrophone =
-                new EngineMicrophone(strdup(group.toStdString().c_str()),
-                                     m_pEffectsManager);
+                new EngineMicrophone(group, m_pEffectsManager);
         // What should channelbase be?
         AudioInput micInput = AudioInput(AudioPath::MICROPHONE, 0, 0, i);
         m_pEngine->addChannel(pMicrophone);


### PR DESCRIPTION
This should replace all appearances of `const char*` with a `QString` in
all classes contained  in src/engine. This thing felt like fighting
against a hydra -.-

This should help anyone to tries to find memory leaks with valgrind.
