### PR TITLE
Memory "Leak" during library scan

### DIFF
--- a/src/library/libraryscanner.cpp
+++ b/src/library/libraryscanner.cpp
@@ -464,8 +464,7 @@ bool LibraryScanner::importFiles(const QLinkedList<QFileInfo>& files,
             // this changes in the future you MUST check that the cover art is
             // not USER_SELECTED first.
             TrackPointer pTrack = TrackPointer(
-                new TrackInfoObject(filePath, pToken, true, true),
-                    &QObject::deleteLater);
+                new TrackInfoObject(filePath, pToken, true, true));
 
             // If cover art is not found in the track metadata, populate from
             // possibleCovers.


### PR DESCRIPTION
Otherwise the TIO will be deleted once they the library scanner finishes
and we potentially freeze machines for large libraries

For more information see the Bug report
https://bugs.launchpad.net/mixxx/+bug/1391178
