### PR TITLE
Effect order by similarity

### DIFF
--- a/src/effects/effectsbackend.cpp
+++ b/src/effects/effectsbackend.cpp
@@ -10,6 +10,7 @@ EffectsBackend::EffectsBackend(QObject* pParent, QString name)
 
 EffectsBackend::~EffectsBackend() {
     m_registeredEffects.clear();
+    m_effectIds.clear();
 }
 
 const QString EffectsBackend::getName() const {
@@ -26,11 +27,12 @@ void EffectsBackend::registerEffect(const QString& id,
 
     m_registeredEffects[id] = QPair<EffectManifest, EffectInstantiatorPointer>(
             manifest, pInstantiator);
+    m_effectIds.append(id);
     emit(effectRegistered());
 }
 
-const QSet<QString> EffectsBackend::getEffectIds() const {
-    return QSet<QString>::fromList(m_registeredEffects.keys());
+const QList<QString>& EffectsBackend::getEffectIds() const {
+    return m_effectIds;
 }
 
 EffectManifest EffectsBackend::getManifest(const QString& effectId) const {

--- a/src/effects/effectsbackend.cpp
+++ b/src/effects/effectsbackend.cpp
@@ -25,7 +25,7 @@ void EffectsBackend::registerEffect(const QString& id,
     }
 
     m_registeredEffects[id] = QPair<EffectManifest, EffectInstantiatorPointer>(
-        manifest, pInstantiator);
+            manifest, pInstantiator);
     emit(effectRegistered());
 }
 

--- a/src/effects/effectsbackend.h
+++ b/src/effects/effectsbackend.h
@@ -24,6 +24,7 @@ class EffectsBackend : public QObject {
 
     virtual const QString getName() const;
 
+    // returns a list sorted like it should be displayed in the GUI 
     virtual const QList<QString>& getEffectIds() const;
     virtual EffectManifest getManifest(const QString& effectId) const;
     virtual bool canInstantiateEffect(const QString& effectId) const;

--- a/src/effects/effectsbackend.h
+++ b/src/effects/effectsbackend.h
@@ -24,7 +24,7 @@ class EffectsBackend : public QObject {
 
     virtual const QString getName() const;
 
-    virtual const QSet<QString> getEffectIds() const;
+    virtual const QList<QString>& getEffectIds() const;
     virtual EffectManifest getManifest(const QString& effectId) const;
     virtual bool canInstantiateEffect(const QString& effectId) const;
     virtual EffectPointer instantiateEffect(
@@ -50,6 +50,7 @@ class EffectsBackend : public QObject {
   private:
     QString m_name;
     QMap<QString, QPair<EffectManifest, EffectInstantiatorPointer> > m_registeredEffects;
+    QList<QString> m_effectIds;
 };
 
 #endif /* EFFECTSBACKEND_H */

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -49,17 +49,17 @@ const QSet<QString>& EffectsManager::registeredGroups() const {
     return m_pEffectChainManager->registeredGroups();
 }
 
-const QSet<QString> EffectsManager::getAvailableEffects() const {
-    QSet<QString> availableEffects;
+const QList<QString> EffectsManager::getAvailableEffects() const {
+    QList<QString> availableEffects;
 
     foreach (EffectsBackend* pBackend, m_effectsBackends) {
-        QSet<QString> backendEffects = pBackend->getEffectIds();
+        const QList<QString>& backendEffects = pBackend->getEffectIds();
         foreach (QString effectId, backendEffects) {
             if (availableEffects.contains(effectId)) {
                 qWarning() << "WARNING: Duplicate effect ID" << effectId;
                 continue;
             }
-            availableEffects.insert(effectId);
+            availableEffects.append(effectId);
         }
     }
 
@@ -67,10 +67,8 @@ const QSet<QString> EffectsManager::getAvailableEffects() const {
 }
 
 QString EffectsManager::getNextEffectId(const QString& effectId) {
-    // TODO(rryan): HACK SUPER JANK ALERT. REPLACE THIS WITH SOMETHING NOT
-    // STUPID
-    QList<QString> effects = getAvailableEffects().toList();
-    qSort(effects.begin(), effects.end());
+    const QList<QString> effects = getAvailableEffects();
+    //qSort(effects.begin(), effects.end()); For alphabetical order
 
     if (effects.isEmpty()) {
         return QString();
@@ -80,20 +78,16 @@ QString EffectsManager::getNextEffectId(const QString& effectId) {
         return effects.first();
     }
 
-    QList<QString>::const_iterator it =
-            qUpperBound(effects.constBegin(), effects.constEnd(), effectId);
-    if (it == effects.constEnd()) {
-        return effects.first();
+    int index = effects.indexOf(effectId);
+    if (++index >= effects.size()) {
+        index = 0;
     }
-
-    return *it;
+    return effects.at(index);
 }
 
 QString EffectsManager::getPrevEffectId(const QString& effectId) {
-    // TODO(rryan): HACK SUPER JANK ALERT. REPLACE THIS WITH SOMETHING NOT
-    // STUPID
-    QList<QString> effects = getAvailableEffects().toList();
-    qSort(effects.begin(), effects.end());
+    const QList<QString> effects = getAvailableEffects();
+    qSort(effects.begin(), effects.end());  For alphabetical order
 
     if (effects.isEmpty()) {
         return QString();
@@ -103,14 +97,12 @@ QString EffectsManager::getPrevEffectId(const QString& effectId) {
         return effects.last();
     }
 
-    QList<QString>::const_iterator it =
-            qLowerBound(effects.constBegin(), effects.constEnd(), effectId);
-    if (it == effects.constBegin()) {
-        return effects.last();
+    int index = effects.indexOf(effectId);
+    if (--index < 0) {
+        index = effects.size() - 1;
     }
+    return effects.at(index);
 
-    --it;
-    return *it;
 }
 
 EffectManifest EffectsManager::getEffectManifest(const QString& effectId) const {

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -68,7 +68,6 @@ const QList<QString> EffectsManager::getAvailableEffects() const {
 
 QString EffectsManager::getNextEffectId(const QString& effectId) {
     const QList<QString> effects = getAvailableEffects();
-    //qSort(effects.begin(), effects.end()); For alphabetical order
 
     if (effects.isEmpty()) {
         return QString();

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -149,8 +149,6 @@ void EffectsManager::setupDefaults() {
     pRack->addEffectChainSlot();
     pRack->addEffectChainSlot();
 
-    QSet<QString> effects = getAvailableEffects();
-
     EffectChainPointer pChain = EffectChainPointer(new EffectChain(
         this, "org.mixxx.effectchain.flanger"));
     pChain->setName(tr("Flanger"));

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -87,7 +87,7 @@ QString EffectsManager::getNextEffectId(const QString& effectId) {
 
 QString EffectsManager::getPrevEffectId(const QString& effectId) {
     const QList<QString> effects = getAvailableEffects();
-    qSort(effects.begin(), effects.end());  For alphabetical order
+    //qSort(effects.begin(), effects.end());  For alphabetical order
 
     if (effects.isEmpty()) {
         return QString();

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -47,7 +47,7 @@ class EffectsManager : public QObject {
     QString getNextEffectId(const QString& effectId);
     QString getPrevEffectId(const QString& effectId);
 
-    const QSet<QString> getAvailableEffects() const;
+    const QList<QString> getAvailableEffects() const;
     EffectManifest getEffectManifest(const QString& effectId) const;
     EffectPointer instantiateEffect(const QString& effectId);
 

--- a/src/effects/native/nativebackend.cpp
+++ b/src/effects/native/nativebackend.cpp
@@ -16,18 +16,18 @@
 
 NativeBackend::NativeBackend(QObject* pParent)
         : EffectsBackend(pParent, tr("Native")) {
-    registerEffect<FlangerEffect>();
-    registerEffect<BitCrusherEffect>();
+    registerEffect<Bessel4LVMixEQEffect>();
+    registerEffect<Bessel8LVMixEQEffect>();
+    registerEffect<LinkwitzRiley8EQEffect>();
+    registerEffect<GraphicEQEffect>();
     registerEffect<FilterEffect>();
     registerEffect<MoogLadder4FilterEffect>();
+    registerEffect<BitCrusherEffect>();
+    registerEffect<FlangerEffect>();
+    registerEffect<EchoEffect>();
 #ifndef __MACAPPSTORE__
     registerEffect<ReverbEffect>();
 #endif
-    registerEffect<EchoEffect>();
-    registerEffect<LinkwitzRiley8EQEffect>();
-    registerEffect<Bessel4LVMixEQEffect>();
-    registerEffect<Bessel8LVMixEQEffect>();
-    registerEffect<GraphicEQEffect>();
 }
 
 NativeBackend::~NativeBackend() {

--- a/src/effects/native/nativebackend.cpp
+++ b/src/effects/native/nativebackend.cpp
@@ -16,13 +16,18 @@
 
 NativeBackend::NativeBackend(QObject* pParent)
         : EffectsBackend(pParent, tr("Native")) {
+    // Keep this list in a reasonable order 
+    // Mixing EQs
     registerEffect<Bessel4LVMixEQEffect>();
     registerEffect<Bessel8LVMixEQEffect>();
     registerEffect<LinkwitzRiley8EQEffect>();
+    // Compensations EQs    
     registerEffect<GraphicEQEffect>();
+    // Fading Effcts
     registerEffect<FilterEffect>();
     registerEffect<MoogLadder4FilterEffect>();
     registerEffect<BitCrusherEffect>();
+    // Fancy effects    
     registerEffect<FlangerEffect>();
     registerEffect<EchoEffect>();
 #ifndef __MACAPPSTORE__


### PR DESCRIPTION
currently the effects are ordered by the programmatic effect ID.
This feels random, since the ID is not shown. 
I prefer a order by similarity.

Now we have 
- EQs
- Fading effect 
- Misc  

this was original requested by @esbrandt at 
https://github.com/mixxxdj/mixxx/pull/373

https://bugs.launchpad.net/mixxx/+bug/1391320
