### PR TITLE
Parallelize recursive scan phase of the library scanner.

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -775,6 +775,10 @@ class MixxxCore(Feature):
                    "library/legacylibraryimporter.cpp",
                    "library/library.cpp",
 
+                   "library/scanner/scannertask.cpp",
+                   "library/scanner/importfilestask.cpp",
+                   "library/scanner/recursivescandirectorytask.cpp",
+
                    "library/dao/cratedao.cpp",
                    "library/cratetablemodel.cpp",
                    "library/dao/cuedao.cpp",

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -108,13 +108,13 @@ class TrackDAO : public QObject, public virtual DAO {
     void markTracksAsMixxxDeleted(const QString& dir);
 
     // Scanning related calls. Should be elsewhere or private somehow.
-    void markTrackLocationAsVerified(const QString& location);
+    void markTrackLocationsAsVerified(const QStringList& locations);
     void markTracksInDirectoriesAsVerified(const QStringList& directories);
     void invalidateTrackLocationsInLibrary();
     void markUnverifiedTracksAsDeleted();
     void markTrackLocationsAsDeleted(const QString& directory);
     void detectMovedFiles(QSet<int>* tracksMovedSetNew, QSet<int>* tracksMovedSetOld);
-    bool verifyRemainingTracks(volatile bool* pCancel);
+    void verifyRemainingTracks();
     void detectCoverArtForUnknownTracks(volatile const bool* pCancel,
                                         QSet<int>* pTracksChanged);
 

--- a/src/library/libraryscanner.cpp
+++ b/src/library/libraryscanner.cpp
@@ -16,24 +16,23 @@
 ***************************************************************************/
 
 #include <QtDebug>
-#include <QDesktopServices>
-#include <QLinkedList>
 
 #include "library/libraryscanner.h"
 
 #include "soundsourceproxy.h"
 #include "library/legacylibraryimporter.h"
+#include "library/scanner/recursivescandirectorytask.h"
 #include "libraryscannerdlg.h"
 #include "library/queryutil.h"
 #include "library/coverartutils.h"
 #include "library/trackcollection.h"
 #include "util/trace.h"
 #include "util/file.h"
+#include "util/timer.h"
 #include "library/scanner/scannerutil.h"
 
-LibraryScanner::LibraryScanner(TrackCollection* collection)
+LibraryScanner::LibraryScanner(QWidget* pParentWidget, TrackCollection* collection)
               : m_pCollection(collection),
-                m_pProgress(NULL),
                 m_libraryHashDao(m_database),
                 m_cueDao(m_database),
                 m_playlistDao(m_database),
@@ -42,14 +41,28 @@ LibraryScanner::LibraryScanner(TrackCollection* collection)
                 m_analysisDao(m_database, collection->getConfig()),
                 m_trackDao(m_database, m_cueDao, m_playlistDao,
                            m_crateDao, m_analysisDao, m_libraryHashDao,
-                           collection->getConfig()),
-                // Don't initialize m_database here, we need to do it in run() so the DB
-                // conn is in the right thread.
-                m_extensionFilter(SoundSourceProxy::supportedFileExtensionsRegex(),
-                                  Qt::CaseInsensitive),
-                m_bCancelLibraryScan(false),
-                m_directoriesBlacklist(ScannerUtil::getDirectoryBlacklist()) {
-    qDebug() << "Constructed LibraryScanner";
+                           collection->getConfig()) {
+    // Don't initialize m_database here, we need to do it in run() so the DB
+    // conn is in the right thread.
+    qDebug() << "Starting LibraryScanner thread.";
+
+    // Move LibraryScanner to its own thread so that our signals/slots will
+    // queue to our event loop.
+    moveToThread(this);
+    m_pool.moveToThread(this);
+
+    unsigned static id = 0; // the id of this LibraryScanner, for debugging purposes
+    setObjectName(QString("LibraryScanner %1").arg(++id));
+
+    // TODO(rryan) make configurable
+    m_pool.setMaxThreadCount(10);
+
+    // Listen to signals from our public methods (invoked by other threads) and
+    // connect them to our slots to run the command on the scanner thread.
+    connect(this, SIGNAL(startScan()),
+            this, SLOT(slotStartScan()));
+    connect(this, SIGNAL(shutdownScanner()),
+            this, SLOT(slotShutdownScanner()));
 
     // Force the GUI thread's TrackInfoObject cache to be cleared when a library
     // scan is finished, because we might have modified the database directly
@@ -63,13 +76,43 @@ LibraryScanner::LibraryScanner(TrackCollection* collection)
             &(collection->getTrackDAO()), SLOT(databaseTracksMoved(QSet<int>, QSet<int>)));
     connect(this, SIGNAL(tracksChanged(QSet<int>)),
             &(collection->getTrackDAO()), SLOT(databaseTracksChanged(QSet<int>)));
+
+    // Parented to pParentWidget so we don't need to delete it.
+    LibraryScannerDlg* pProgress = new LibraryScannerDlg(pParentWidget);
+    connect(this, SIGNAL(progressLoading(QString)),
+            pProgress, SLOT(slotUpdate(QString)));
+    connect(this, SIGNAL(progressHashing(QString)),
+            pProgress, SLOT(slotUpdate(QString)));
+    connect(this, SIGNAL(scanStarted()),
+            pProgress, SLOT(slotScanStarted()));
+    connect(this, SIGNAL(scanFinished()),
+            pProgress, SLOT(slotScanFinished()));
+    connect(pProgress, SIGNAL(scanCancelled()),
+            this, SLOT(cancel()));
+    connect(&m_trackDao, SIGNAL(progressVerifyTracksOutside(QString)),
+            pProgress, SLOT(slotUpdate(QString)));
+    connect(&m_trackDao, SIGNAL(progressCoverArt(QString)),
+            pProgress, SLOT(slotUpdateCover(QString)));
+
+    start();
 }
 
 LibraryScanner::~LibraryScanner() {
-    if (isRunning()) {
-        // Cancel any running library scan...
+    // A scan is running.
+    if (m_scannerGlobal) {
+        // Cancel any running library scan.
         cancel();
-        wait(); // Wait for thread to finish
+
+        // Wait for the thread pool to empty. This is important because
+        // ScannerTasks have pointers to the LibraryScanner and can cause a
+        // segfault if they run after the LibraryScanner has been destroyed.
+        m_pool.waitForDone();
+
+        // Quit the event loop gracefully.
+        quit();
+
+        // Wait for thread to finish
+        wait();
     }
 
     // There should never be an outstanding transaction when this code is
@@ -91,9 +134,6 @@ LibraryScanner::~LibraryScanner() {
 
 void LibraryScanner::run() {
     Trace trace("LibraryScanner");
-    unsigned static id = 0; // the id of this thread, for debugging purposes
-    //XXX copypasta (should factor this out somehow), -kousu 2/2009
-    QThread::currentThread()->setObjectName(QString("LibraryScanner %1").arg(++id));
 
     if (!m_database.isValid()) {
         m_database = QSqlDatabase::cloneDatabase(m_pCollection->getDatabase(), "LIBRARY_SCANNER");
@@ -121,10 +161,30 @@ void LibraryScanner::run() {
     m_analysisDao.initialize();
     m_directoryDao.initialize();
 
-    resetCancel();
+    // Start the event loop.
+    qDebug() << "LibraryScanner event loop starting.";
+    exec();
+    qDebug() << "LibraryScanner event loop stopped.";
+}
 
-    QTime t2;
-    t2.start();
+void LibraryScanner::slotStartScan() {
+    qDebug() << "LibraryScanner::slotStartScan";
+    QSet<QString> trackLocations = m_trackDao.getTrackLocations();
+    QHash<QString, int> directoryHashes = m_libraryHashDao.getDirectoryHashes();
+    QRegExp extensionFilter =
+            QRegExp(SoundSourceProxy::supportedFileExtensionsRegex(),
+                    Qt::CaseInsensitive);
+    QRegExp coverExtensionFilter =
+            QRegExp(CoverArtUtils::supportedCoverArtExtensionsRegex(),
+                    Qt::CaseInsensitive);
+    QStringList directoryBlacklist = ScannerUtil::getDirectoryBlacklist();
+
+    m_scannerGlobal = ScannerGlobalPointer(
+        new ScannerGlobal(trackLocations, directoryHashes, extensionFilter,
+                          coverExtensionFilter, directoryBlacklist));
+    m_scannerGlobal->startTimer();
+
+    emit(scanStarted());
 
     // Try to upgrade the library from 1.7 (XML) to 1.8+ (DB) if needed. If the
     // upgrade_filename already exists, then do not try to upgrade since we have
@@ -135,6 +195,8 @@ void LibraryScanner::run() {
     qDebug() << "upgrade filename is " << upgrade_filename;
     QFile upgradefile(upgrade_filename);
     if (!upgradefile.exists()) {
+        QTime t2;
+        t2.start();
         LegacyLibraryImporter libImport(m_trackDao, m_playlistDao);
         connect(&libImport, SIGNAL(progress(QString)),
                 this, SIGNAL(progressLoading(QString)));
@@ -144,24 +206,15 @@ void LibraryScanner::run() {
         qDebug("Legacy importer took %d ms", t2.elapsed());
     }
 
-    // Refresh the name filters in case we loaded new SoundSource plugins.
-    m_extensionFilter = QRegExp(SoundSourceProxy::supportedFileExtensionsRegex(),
-                                Qt::CaseInsensitive);
-    m_coverExtensionFilter = QRegExp(CoverArtUtils::supportedCoverArtExtensionsRegex(),
-                                     Qt::CaseInsensitive);
-
-    // Time the library scanner.
-    QTime t;
-    t.start();
-
-    // First, we're going to mark all the directories that we've
-    // previously hashed as needing verification. As we search through the directory tree
-    // when we rescan, we'll mark any directory that does still exist as verified.
+    // First, we're going to mark all the directories that we've previously
+    // hashed as needing verification. As we search through the directory tree
+    // when we rescan, we'll mark any directory that does still exist as
+    // verified.
     m_libraryHashDao.invalidateAllDirectories();
 
-    // Mark all the tracks in the directory as needing verification of
-    // their existance... (ie. we want to check they're still on your hard
-    // drive where we think they are)
+    // Mark all the tracks in the library as needing verification of their
+    // existence. (ie. we want to check they're still on your hard drive where
+    // we think they are)
     m_trackDao.invalidateTrackLocationsInLibrary();
 
     qDebug() << "Recursively scanning library.";
@@ -170,10 +223,22 @@ void LibraryScanner::run() {
     // (must be called before calling addTracksAdd) and begins a transaction.
     m_trackDao.addTracksPrepare();
 
-    QStringList verifiedDirectories;
-    QStringList dirs = m_directoryDao.getDirs();
-    bool bScanFinishedCleanly = false;
     // Recursivly scan each directory in the directories table.
+    QStringList dirs = m_directoryDao.getDirs();
+
+    // If there are no directories then we have nothing to do. Cleanup and
+    // finish the scan immediately.
+    if (dirs.isEmpty()) {
+        slotFinishScan();
+        return;
+    }
+
+    // Queue up recursive scan tasks for every directory. When all tasks are
+    // done, TaskWatcher will signal slotFinishScan.
+    TaskWatcher* pWatcher = &m_scannerGlobal->getTaskWatcher();
+    connect(pWatcher, SIGNAL(allTasksDone()),
+            this, SLOT(slotFinishScan()));
+
     foreach (const QString& dirPath, dirs) {
         // Acquire a security bookmark for this directory if we are in a
         // sandbox. For speed we avoid opening security bookmarks when recursive
@@ -181,47 +246,66 @@ void LibraryScanner::run() {
         // directory.
         MDir dir(dirPath);
 
-        bScanFinishedCleanly = recursiveScan(dir.dir(), verifiedDirectories,
-                                             dir.token());
-        if (bScanFinishedCleanly) {
-            qDebug() << "Recursive scanning (" << dirPath << ") finished cleanly.";
-        } else {
-            qDebug() << "Recursive scanning (" << dirPath << ") interrupted.";
-        }
+        queueTask(new RecursiveScanDirectoryTask(this, m_scannerGlobal, dir.dir(),
+                                                 dir.token()));
+    }
+}
+
+void LibraryScanner::slotFinishScan() {
+    qDebug() << "LibraryScanner::slotFinishScan";
+    if (m_scannerGlobal.isNull()) {
+        qWarning() << "No scanner global state exists in LibraryScanner::slotFinishScan";
+        return;
     }
 
-    // After the recursive scan of all watched library directories there are
-    // only a few songs left to check. Mainly the ones that are not inside one
-    // of the library directories or have been moved/renamed/... since the last
-    // scan.
+    bool bScanFinishedCleanly = m_scannerGlobal->scanFinishedCleanly();
+
     if (bScanFinishedCleanly) {
-        bScanFinishedCleanly = m_trackDao.verifyRemainingTracks(&m_bCancelLibraryScan);
+        qDebug() << "Recursive scanning finished cleanly.";
+    } else {
+        qDebug() << "Recursive scanning interrupted.";
     }
 
-    // Clean up and commit or rollback the transaction depending on
-    // bScanFinishedCleanly or if the scan was canceled..
-    m_trackDao.addTracksFinish(!(m_bCancelLibraryScan || bScanFinishedCleanly));
+    // Finish adding the tracks -- rollback the transaction if the scan did not
+    // finish cleanly and the user did not cancel the transaction.
+    m_trackDao.addTracksFinish(!m_scannerGlobal->shouldCancel() &&
+                               !bScanFinishedCleanly);
 
-    // At the end of a scan, mark all tracks and directories that
-    // weren't "verified" as "deleted" (as long as the scan wasn't canceled
-    // half way through. This condition is important because our rescanning
-    // algorithm starts by marking all tracks and dirs as unverified, so a
-    // canceled scan might leave half of your library as unverified. Don't
-    // want to mark those tracks/dirs as deleted in that case) :)
-    QSet<int> tracksMovedSetOld;
-    QSet<int> tracksMovedSetNew;
-    QSet<int> coverArtTracksChanged;
+    QStringList verifiedTracks = m_scannerGlobal->verifiedTracks();
+    QStringList verifiedDirectories = m_scannerGlobal->verifiedDirectories();
+
+    // At the end of a scan, mark all tracks and directories that weren't
+    // "verified" as "deleted" (as long as the scan wasn't canceled half way
+    // through). This condition is important because our rescanning algorithm
+    // starts by marking all tracks and dirs as unverified, so a canceled scan
+    // might leave half of your library as unverified. Don't want to mark those
+    // tracks/dirs as deleted in that case) :)
     if (bScanFinishedCleanly) {
-        // Start a transaction for all the library hashing (moved file detection)
-        // stuff.
+        QSet<int> tracksMovedSetOld;
+        QSet<int> tracksMovedSetNew;
+        QSet<int> coverArtTracksChanged;
+
+        // Start a transaction for all the library hashing (moved file
+        // detection) stuff.
         ScopedTransaction transaction(m_database);
+
+        qDebug() << "Marking tracks in changed directories as verified";
+        m_trackDao.markTrackLocationsAsVerified(verifiedTracks);
 
         qDebug() << "Marking unchanged directories and tracks as verified";
         m_libraryHashDao.updateDirectoryStatuses(verifiedDirectories, false, true);
         m_trackDao.markTracksInDirectoriesAsVerified(verifiedDirectories);
 
+        // After verifying tracks and directories via recursive scanning of the
+        // library directories the only unverified tracks will be files that are
+        // outside of the library directories and files that have been
+        // moved/deleted/renamed.
+        qDebug() << "Checking remaining unverified tracks.";
+        m_trackDao.verifyRemainingTracks();
+
         qDebug() << "Marking unverified tracks as deleted.";
         m_trackDao.markUnverifiedTracksAsDeleted();
+
         qDebug() << "Marking unverified directories as deleted.";
         m_libraryHashDao.markUnverifiedDirectoriesAsDeleted();
 
@@ -230,221 +314,144 @@ void LibraryScanner::run() {
         qDebug() << "Detecting moved files.";
         m_trackDao.detectMovedFiles(&tracksMovedSetOld, &tracksMovedSetNew);
 
-        // Remove the hashes for any directories that have been
-        // marked as deleted to clean up. We need to do this otherwise
-        // we can skip over songs if you move a set of songs from directory
-        // A to B, then back to A.
+        // Remove the hashes for any directories that have been marked as
+        // deleted to clean up. We need to do this otherwise we can skip over
+        // songs if you move a set of songs from directory A to B, then back to
+        // A.
         m_libraryHashDao.removeDeletedDirectoryHashes();
 
         transaction.commit();
 
         qDebug() << "Detecting cover art for unscanned files.";
-        m_trackDao.detectCoverArtForUnknownTracks(&m_bCancelLibraryScan,
-                                                  &coverArtTracksChanged);
+        m_trackDao.detectCoverArtForUnknownTracks(
+            m_scannerGlobal->shouldCancelPointer(), &coverArtTracksChanged);
+
+        // Update BaseTrackCache via signals connected to the main TrackDAO.
+        emit(tracksMoved(tracksMovedSetOld, tracksMovedSetNew));
+        emit(tracksChanged(coverArtTracksChanged));
 
         qDebug() << "Scan finished cleanly";
     } else {
         qDebug() << "Scan cancelled";
     }
 
-    qDebug("Scan took: %d ms", t.elapsed());
-
-    m_database.close();
-
-    // Update BaseTrackCache via signals connected to the main TrackDAO.
-    emit(tracksMoved(tracksMovedSetOld, tracksMovedSetNew));
-    emit(tracksChanged(coverArtTracksChanged));
+    // TODO(XXX) doesn't take into account verifyRemainingTracks.
+    qDebug("Scan took: %lld ns. "
+           "%d unchanged directories. "
+           "%d changed/added directories. "
+           "%d tracks verified from changed/added directories. "
+           "%d new tracks.",
+           m_scannerGlobal->timerElapsed(),
+           verifiedDirectories.size(),
+           m_scannerGlobal->numScannedDirectories(),
+           verifiedTracks.size(),
+           m_scannerGlobal->numAddedTracks());
 
     emit(scanFinished());
+    m_scannerGlobal.clear();
 }
 
-void LibraryScanner::scan(QWidget* parent) {
-    m_pProgress = new LibraryScannerDlg(parent);
-    m_pProgress->setAttribute(Qt::WA_DeleteOnClose);
-
-    // The important part here is that we need to use
-    // Qt::BlockingQueuedConnection, because we're sending these signals across
-    // threads. Normally you'd use regular QueuedConnections for this, but since
-    // we don't have an event loop running and we need the signals to get
-    // processed immediately, we have to use
-    // BlockingQueuedConnection. (DirectConnection isn't an option for sending
-    // signals across threads.)
-    connect(this, SIGNAL(progressLoading(QString)),
-            m_pProgress, SLOT(slotUpdate(QString)));
-            //Qt::BlockingQueuedConnection);
-    connect(this, SIGNAL(progressHashing(QString)),
-            m_pProgress, SLOT(slotUpdate(QString)));
-            //Qt::BlockingQueuedConnection);
-    connect(this, SIGNAL(scanFinished()),
-            m_pProgress, SLOT(slotScanFinished()));
-    connect(m_pProgress, SIGNAL(scanCancelled()),
-            this, SLOT(cancel()));
-    connect(&m_trackDao, SIGNAL(progressVerifyTracksOutside(QString)),
-            m_pProgress, SLOT(slotUpdate(QString)));
-    connect(&m_trackDao, SIGNAL(progressCoverArt(QString)),
-            m_pProgress, SLOT(slotUpdateCover(QString)));
-    start(QThread::LowPriority);
+void LibraryScanner::scan() {
+    if (m_scannerGlobal) {
+        qDebug() << "Scan already in progress.";
+        return;
+    }
+    emit(startScan());
 }
 
 void LibraryScanner::cancel() {
-    m_bCancelLibraryScan = true;
+    if (m_scannerGlobal) {
+        m_scannerGlobal->setShouldCancel(true);
+    }
 }
 
-void LibraryScanner::resetCancel() {
-    m_bCancelLibraryScan = false;
+void LibraryScanner::taskDone(bool success) {
+    //qDebug() << "LibraryScanner::taskDone" << success;
+    ScopedTimer timer("LibraryScanner::taskDone");
+    if (!success && m_scannerGlobal) {
+        m_scannerGlobal->setScanFinishedCleanly(false);
+    }
 }
 
-bool LibraryScanner::recursiveScan(QDir dir, QStringList& verifiedDirectories,
-                                   SecurityTokenPointer pToken) {
-    // Note, we save on filesystem operations (and random work) by initializing
-    // a QDirIterator with a QDir instead of a QString -- but it inherits its
-    // Filter from the QDir so we have to set it first. If the QDir has not done
-    // any FS operations yet then this should be lightweight.
-    dir.setFilter(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
-    QDirIterator it(dir);
-    QString currentFile;
-    QFileInfo currentFileInfo;
-    QLinkedList<QFileInfo> filesToImport;
-    QLinkedList<QFileInfo> possibleCovers;
-    QLinkedList<QDir> dirsToScan;
-
-    QString newHashStr;
-    bool prevHashExists = false;
-    int newHash = -1;
-    int prevHash = -1;
-    // Note: A hash of "0" is a real hash if the directory contains no files!
-
-    while (it.hasNext()) {
-        currentFile = it.next();
-        currentFileInfo = it.fileInfo();
-
-        if (currentFileInfo.isFile()) {
-            if (m_extensionFilter.indexIn(currentFileInfo.fileName()) != -1) {
-                newHashStr += currentFile;
-                filesToImport.append(currentFileInfo);
-            } else if (m_coverExtensionFilter.indexIn(currentFileInfo.fileName()) != -1) {
-                possibleCovers.append(currentFileInfo);
-            }
-        } else {
-            // File is a directory. Add it to our list of directories to scan.
-            // Skip the iTunes Album Art Folder since it is probably a waste of
-            // time.
-            if (!m_directoriesBlacklist.contains(currentFile)) {
-                dirsToScan.append(QDir(currentFile));
-            }
-        }
+void LibraryScanner::queueTask(ScannerTask* pTask) {
+    //qDebug() << "LibraryScanner::queueTask" << pTask;
+    ScopedTimer timer("LibraryScanner::queueTask");
+    if (m_scannerGlobal.isNull() || m_scannerGlobal->shouldCancel()) {
+        return;
     }
+    m_scannerGlobal->getTaskWatcher().watchTask(pTask, SIGNAL(taskDone(bool)));
+    connect(pTask, SIGNAL(taskDone(bool)),
+            this, SLOT(taskDone(bool)));
+    connect(pTask, SIGNAL(queueTask(ScannerTask*)),
+            this, SLOT(queueTask(ScannerTask*)));
+    connect(pTask, SIGNAL(directoryHashed(QString, bool, int)),
+            this, SLOT(directoryHashed(QString, bool, int)));
+    connect(pTask, SIGNAL(directoryUnchanged(QString)),
+            this, SLOT(directoryUnchanged(QString)));
+    connect(pTask, SIGNAL(trackExists(QString)),
+            this, SLOT(trackExists(QString)));
+    connect(pTask, SIGNAL(addNewTrack(TrackPointer)),
+            this, SLOT(addNewTrack(TrackPointer)));
 
-    // Calculate a hash of the directory's file list.
-    newHash = qHash(newHashStr);
+    // Progress signals.
+    connect(pTask, SIGNAL(progressLoading(QString)),
+            this, SIGNAL(progressLoading(QString)));
+    connect(pTask, SIGNAL(progressHashing(QString)),
+            this, SIGNAL(progressHashing(QString)));
 
-    QString dirPath = dir.path();
-    // Try to retrieve a hash from the last time that directory was scanned.
-    prevHash = m_libraryHashDao.getDirectoryHash(dirPath);
-    prevHashExists = prevHash != -1;
-
-    // Compare the hashes, and if they don't match, rescan the files in that directory!
-    if (prevHash != newHash) {
-        // Rescan that mofo! If importing fails then the scan was cancelled so
-        // we return immediately.
-        if (!importFiles(filesToImport, possibleCovers, pToken)) {
-            return false;
-        }
-
-        // If we didn't know about this directory before...
-        // save the hash after we imported everything in it
-        if (!prevHashExists) {
-            m_libraryHashDao.saveDirectoryHash(dirPath, newHash);
-        } else {
-            // Contents of a known directory have changed. Just need to update
-            // the old hash in the database
-            qDebug() << "old hash was" << prevHash << "and new hash is" << newHash;
-            m_libraryHashDao.updateDirectoryHash(dirPath, newHash, 0);
-        }
-    } else { //prevHash == newHash
-        // Add the directory to the verifiedDirectories list, so that later they
-        // (and the tracks inside them) will be marked as verified
-        emit(progressHashing(dirPath));
-        verifiedDirectories.append(dirPath);
-    }
-
-    // Let us break out of library directory hashing (the actual file scanning
-    // stuff is in TrackCollection::importDirectory)
-    if (m_bCancelLibraryScan) {
-        return false;
-    }
-
-    // Process all of the sub-directories.
-    foreach (const QDir& nextDir, dirsToScan) {
-        if (!recursiveScan(nextDir, verifiedDirectories, pToken)) {
-            return false;
-        }
-    }
-    return true;
+    m_pool.start(pTask);
 }
 
-bool LibraryScanner::importFiles(const QLinkedList<QFileInfo>& files,
-                                 const QLinkedList<QFileInfo>& possibleCovers,
-                                 SecurityTokenPointer pToken) {
-    foreach (const QFileInfo& file, files) {
-        // If a flag was raised telling us to cancel the library scan then stop.
-        if (m_bCancelLibraryScan) {
-            return false;
-        }
+void LibraryScanner::directoryHashed(const QString& directoryPath,
+                                     bool newDirectory, int hash) {
+    ScopedTimer timer("LibraryScanner::directoryHashed");
+    // qDebug() << "LibraryScanner::directoryHashed" << directoryPath
+    //          << newDirectory << hash;
 
-        QString filePath = file.filePath();
-        //qDebug() << "TrackCollection::importFiles" << filePath;
-
-        // If the track is in the database, mark it as existing. This code gets
-        // executed when other files in the same directory have changed (the
-        // directory hash has changed).
-        m_trackDao.markTrackLocationAsVerified(filePath);
-
-        // If the file does not exist in the database then add it. If it does
-        // then it is either in the user's library OR the user has "removed" the
-        // track via "Right-Click -> Remove". These tracks stay in the library,
-        // but their mixxx_deleted column is 1.
-        if (!m_trackDao.trackExistsInDatabase(filePath)) {
-            emit(progressLoading(file.fileName()));
-
-            // Parse the track including cover art from metadata. This is a new
-            // (never before seen) track so it is safe to parse cover art
-            // without checking if we have cover art that is USER_SELECTED. If
-            // this changes in the future you MUST check that the cover art is
-            // not USER_SELECTED first.
-            TrackPointer pTrack = TrackPointer(
-                new TrackInfoObject(filePath, pToken, true, true));
-
-            // If cover art is not found in the track metadata, populate from
-            // possibleCovers.
-            if (pTrack->getCoverArt().image.isNull()) {
-                CoverArt art = CoverArtUtils::selectCoverArtForTrack(
-                    pTrack.data(), possibleCovers);
-                if (!art.image.isNull()) {
-                    pTrack->setCoverArt(art);
-                }
-            }
-
-            if (m_trackDao.addTracksAdd(pTrack.data(), false)) {
-                // Successfully added. Signal the main instance of TrackDAO,
-                // that there is a new track in the database.
-                emit(trackAdded(pTrack));
-            } else {
-                qDebug() << "Track ("+filePath+") could not be added";
-            }
-        }
+    // For statistics tracking -- if we hashed a directory then we scanned it
+    // (it was changed or new).
+    if (m_scannerGlobal) {
+        m_scannerGlobal->directoryScanned();
     }
 
-    return true;
+    if (newDirectory) {
+        m_libraryHashDao.saveDirectoryHash(directoryPath, hash);
+    } else {
+        m_libraryHashDao.updateDirectoryHash(directoryPath, hash, 0);
+    }
+    emit(progressHashing(directoryPath));
 }
 
-// Table: LibraryHashes
-// PRIMARY KEY string directory
-// string hash
+void LibraryScanner::directoryUnchanged(const QString& directoryPath) {
+    ScopedTimer timer("LibraryScanner::directoryUnchanged");
+    //qDebug() << "LibraryScanner::directoryUnchanged" << directoryPath;
+    if (m_scannerGlobal) {
+        m_scannerGlobal->addVerifiedDirectory(directoryPath);
+    }
+    emit(progressHashing(directoryPath));
+}
 
-// Recursive Algorithm:
-// 1) QDirIterator, iterate over all _files_ in a directory to construct a giant string.
-// 2) newHash = Hash that string.
-// 3) prevHash = SELECT from LibraryHashes * WHERE directory == strDirectory
-// 4) if (prevHash != newHash) scanDirectory(strDirectory); //Do a NON-RECURSIVE scan of the files in that dir.
-// 5) For each directory in strDirectory, execute this algorithm.
+void LibraryScanner::trackExists(const QString& trackPath) {
+    //qDebug() << "LibraryScanner::trackExists" << trackPath;
+    ScopedTimer timer("LibraryScanner::trackExists");
+    if (m_scannerGlobal) {
+        m_scannerGlobal->addVerifiedTrack(trackPath);
+    }
+}
+
+void LibraryScanner::addNewTrack(TrackPointer pTrack) {
+    //qDebug() << "LibraryScanner::addNewTrack" << pTrack;
+    ScopedTimer timer("LibraryScanner::addNewTrack");
+    // For statistics tracking.
+    if (m_scannerGlobal) {
+        m_scannerGlobal->trackAdded();
+    }
+    if (m_trackDao.addTracksAdd(pTrack.data(), false)) {
+        // Successfully added. Signal the main instance of TrackDAO,
+        // that there is a new track in the database.
+        emit(trackAdded(pTrack));
+        emit(progressLoading(pTrack->getLocation()));
+    } else {
+        qDebug() << "Track ("+pTrack->getLocation()+") could not be added";
+    }
+}

--- a/src/library/libraryscanner.cpp
+++ b/src/library/libraryscanner.cpp
@@ -32,7 +32,7 @@
 #include "library/scanner/scannerutil.h"
 
 // TODO(rryan) make configurable
-const int kScannerThreadPoolSize = 10;
+const int kScannerThreadPoolSize = 1;
 
 LibraryScanner::LibraryScanner(QWidget* pParentWidget, TrackCollection* collection)
               : m_pCollection(collection),

--- a/src/library/libraryscanner.cpp
+++ b/src/library/libraryscanner.cpp
@@ -31,6 +31,9 @@
 #include "util/timer.h"
 #include "library/scanner/scannerutil.h"
 
+// TODO(rryan) make configurable
+const int kScannerThreadPoolSize = 10;
+
 LibraryScanner::LibraryScanner(QWidget* pParentWidget, TrackCollection* collection)
               : m_pCollection(collection),
                 m_libraryHashDao(m_database),
@@ -54,8 +57,7 @@ LibraryScanner::LibraryScanner(QWidget* pParentWidget, TrackCollection* collecti
     unsigned static id = 0; // the id of this LibraryScanner, for debugging purposes
     setObjectName(QString("LibraryScanner %1").arg(++id));
 
-    // TODO(rryan) make configurable
-    m_pool.setMaxThreadCount(10);
+    m_pool.setMaxThreadCount(kScannerThreadPoolSize);
 
     // Listen to signals from our public methods (invoked by other threads) and
     // connect them to our slots to run the command on the scanner thread.
@@ -263,7 +265,7 @@ void LibraryScanner::slotFinishScan() {
     if (bScanFinishedCleanly) {
         qDebug() << "Recursive scanning finished cleanly.";
     } else {
-        qDebug() << "Recursive scanning interrupted.";
+        qDebug() << "Recursive scanning interrupted by the user.";
     }
 
     // Finish adding the tracks -- rollback the transaction if the scan did not
@@ -452,6 +454,6 @@ void LibraryScanner::addNewTrack(TrackPointer pTrack) {
         emit(trackAdded(pTrack));
         emit(progressLoading(pTrack->getLocation()));
     } else {
-        qDebug() << "Track ("+pTrack->getLocation()+") could not be added";
+        qWarning() << "Track ("+pTrack->getLocation()+") could not be added";
     }
 }

--- a/src/library/libraryscannerdlg.cpp
+++ b/src/library/libraryscannerdlg.cpp
@@ -48,12 +48,9 @@ LibraryScannerDlg::LibraryScannerDlg(QWidget* parent, Qt::WindowFlags f)
             pCurrent, SLOT(setText(QString)));
     pLayout->addWidget(pCurrent);
     setLayout(pLayout);
-
-    m_timer.start();
 }
 
 LibraryScannerDlg::~LibraryScannerDlg() {
-    emit(scanCancelled());
 }
 
 void LibraryScannerDlg::slotUpdate(QString path) {
@@ -85,19 +82,19 @@ void LibraryScannerDlg::slotUpdateCover(QString path) {
 void LibraryScannerDlg::slotCancel() {
     qDebug() << "Cancelling library scan...";
     m_bCancelled = true;
-
     emit(scanCancelled());
+    hide();
+}
 
-    // Need to use close() or else if you close the Mixxx window and then hit
-    // Cancel, Mixxx will not shutdown.
-    close();
+void LibraryScannerDlg::slotScanStarted() {
+    m_bCancelled = false;
+    m_timer.start();
 }
 
 void LibraryScannerDlg::slotScanFinished() {
-    m_bCancelled = true; //Raise this flag to prevent any
-                         //latent slotUpdates() from showing the dialog again.
+    // Raise this flag to prevent any latent slotUpdates() from showing the
+    // dialog again.
+    m_bCancelled = true;
 
-    // Need to use close() or else if you close the Mixxx window and then hit
-    // Cancel, Mixxx will not shutdown.
-    close();
+    hide();
 }

--- a/src/library/libraryscannerdlg.h
+++ b/src/library/libraryscannerdlg.h
@@ -35,6 +35,7 @@ class LibraryScannerDlg : public QWidget {
     void slotUpdateCover(QString path);
     void slotCancel();
     void slotScanFinished();
+    void slotScanStarted();
 
   signals:
     void scanCancelled();

--- a/src/library/scanner/importfilestask.cpp
+++ b/src/library/scanner/importfilestask.cpp
@@ -1,0 +1,65 @@
+#include "library/scanner/importfilestask.h"
+
+#include "library/libraryscanner.h"
+#include "library/coverartutils.h"
+#include "util/timer.h"
+
+ImportFilesTask::ImportFilesTask(LibraryScanner* pScanner,
+                                 const ScannerGlobalPointer scannerGlobal,
+                                 const QLinkedList<QFileInfo>& filesToImport,
+                                 const QLinkedList<QFileInfo>& possibleCovers,
+                                 SecurityTokenPointer pToken)
+        : ScannerTask(pScanner, scannerGlobal),
+          m_filesToImport(filesToImport),
+          m_possibleCovers(possibleCovers),
+          m_pToken(pToken) {
+}
+
+ImportFilesTask::~ImportFilesTask() {
+}
+
+void ImportFilesTask::run() {
+    ScopedTimer timer("ImportFilesTask::run");
+    foreach (const QFileInfo& file, m_filesToImport) {
+        // If a flag was raised telling us to cancel the library scan then stop.
+        if (m_scannerGlobal->shouldCancel()) {
+            setSuccess(false);
+            return;
+        }
+
+        QString filePath = file.filePath();
+        //qDebug() << "ImportFilesTask::run" << filePath;
+
+        // If the file does not exist in the database then add it. If it
+        // does then it is either in the user's library OR the user has
+        // "removed" the track via "Right-Click -> Remove". These tracks
+        // stay in the library, but their mixxx_deleted column is 1.
+        if (m_scannerGlobal->trackExistsInDatabase(filePath)) {
+            // If the track is in the database, mark it as existing. This code gets
+            // executed when other files in the same directory have changed (the
+            // directory hash has changed).
+            emit(trackExists(filePath));
+        } else {
+            // Parse the track including cover art from metadata. This is a new
+            // (never before seen) track so it is safe to parse cover art
+            // without checking if we have cover art that is USER_SELECTED. If
+            // this changes in the future you MUST check that the cover art is
+            // not USER_SELECTED first.
+            TrackPointer pTrack = TrackPointer(
+                new TrackInfoObject(filePath, m_pToken, true, true));
+
+            // If cover art is not found in the track metadata, populate from
+            // possibleCovers.
+            if (pTrack->getCoverArt().image.isNull()) {
+                CoverArt art = CoverArtUtils::selectCoverArtForTrack(
+                    pTrack.data(), m_possibleCovers);
+                if (!art.image.isNull()) {
+                    pTrack->setCoverArt(art);
+                }
+            }
+
+            emit(addNewTrack(pTrack));
+        }
+    }
+    setSuccess(true);
+}

--- a/src/library/scanner/importfilestask.cpp
+++ b/src/library/scanner/importfilestask.cpp
@@ -15,9 +15,6 @@ ImportFilesTask::ImportFilesTask(LibraryScanner* pScanner,
           m_pToken(pToken) {
 }
 
-ImportFilesTask::~ImportFilesTask() {
-}
-
 void ImportFilesTask::run() {
     ScopedTimer timer("ImportFilesTask::run");
     foreach (const QFileInfo& file, m_filesToImport) {

--- a/src/library/scanner/importfilestask.h
+++ b/src/library/scanner/importfilestask.h
@@ -1,0 +1,31 @@
+#ifndef IMPORTFILESTASK_H
+#define IMPORTFILESTASK_H
+
+#include <QLinkedList>
+#include <QFileInfo>
+
+#include "util/sandbox.h"
+#include "library/scanner/scannertask.h"
+#include "library/scanner/scannerglobal.h"
+
+// Import the provided files. Successful if the scan completed without being
+// cancelled. False if the scan was cancelled part-way through.
+class ImportFilesTask : public ScannerTask {
+    Q_OBJECT
+  public:
+    ImportFilesTask(LibraryScanner* pScanner,
+                    const ScannerGlobalPointer scannerGlobal,
+                    const QLinkedList<QFileInfo>& filesToImport,
+                    const QLinkedList<QFileInfo>& possibleCovers,
+                    SecurityTokenPointer pToken);
+    virtual ~ImportFilesTask();
+
+    virtual void run();
+
+  private:
+    const QLinkedList<QFileInfo> m_filesToImport;
+    const QLinkedList<QFileInfo> m_possibleCovers;
+    SecurityTokenPointer m_pToken;
+};
+
+#endif /* IMPORTFILESTASK_H */

--- a/src/library/scanner/importfilestask.h
+++ b/src/library/scanner/importfilestask.h
@@ -18,7 +18,7 @@ class ImportFilesTask : public ScannerTask {
                     const QLinkedList<QFileInfo>& filesToImport,
                     const QLinkedList<QFileInfo>& possibleCovers,
                     SecurityTokenPointer pToken);
-    virtual ~ImportFilesTask();
+    virtual ~ImportFilesTask() {}
 
     virtual void run();
 

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -1,0 +1,104 @@
+#include <QDirIterator>
+
+#include "library/scanner/recursivescandirectorytask.h"
+
+#include "library/libraryscanner.h"
+#include "library/scanner/importfilestask.h"
+#include "util/timer.h"
+
+RecursiveScanDirectoryTask::RecursiveScanDirectoryTask(
+    LibraryScanner* pScanner, const ScannerGlobalPointer scannerGlobal,
+    const QDir& dir, SecurityTokenPointer pToken)
+        : ScannerTask(pScanner, scannerGlobal),
+          m_dir(dir),
+          m_pToken(pToken) {
+}
+
+RecursiveScanDirectoryTask::~RecursiveScanDirectoryTask() {
+}
+
+void RecursiveScanDirectoryTask::run() {
+    ScopedTimer timer("RecursiveScanDirectoryTask::run");
+    if (m_scannerGlobal->shouldCancel()) {
+        setSuccess(false);
+        return;
+    }
+
+    // Note, we save on filesystem operations (and random work) by initializing
+    // a QDirIterator with a QDir instead of a QString -- but it inherits its
+    // Filter from the QDir so we have to set it first. If the QDir has not done
+    // any FS operations yet then this should be lightweight.
+    m_dir.setFilter(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
+    QDirIterator it(m_dir);
+
+    QString currentFile;
+    QFileInfo currentFileInfo;
+    QLinkedList<QFileInfo> filesToImport;
+    QLinkedList<QFileInfo> possibleCovers;
+    QLinkedList<QDir> dirsToScan;
+    QStringList newHashStr;
+
+    QRegExp supportedExtensionsRegex =
+            m_scannerGlobal->supportedExtensionsRegex();
+    QRegExp supportedCoverExtensionsRegex =
+            m_scannerGlobal->supportedCoverExtensionsRegex();
+
+    while (it.hasNext()) {
+        currentFile = it.next();
+        currentFileInfo = it.fileInfo();
+
+        if (currentFileInfo.isFile()) {
+            const QString& fileName = currentFileInfo.fileName();
+            //if (m_scannerGlobal->isAudioFileSupported(fileName)) {
+            if (supportedExtensionsRegex.indexIn(fileName) != -1) {
+                newHashStr.append(currentFile);
+                filesToImport.append(currentFileInfo);
+                //} else if (m_scannerGlobal->isCoverFileSupported(fileName)) {
+            } else if (supportedCoverExtensionsRegex.indexIn(fileName) != -1) {
+                possibleCovers.append(currentFileInfo);
+            }
+        } else {
+            // File is a directory. Add it to our list of directories to scan.
+            // Skip the iTunes Album Art Folder since it is probably a waste of
+            // time.
+            if (!m_scannerGlobal->directoryBlacklisted(currentFile)) {
+                dirsToScan.append(QDir(currentFile));
+            }
+        }
+    }
+
+    // Note: A hash of "0" is a real hash if the directory contains no files!
+    // Calculate a hash of the directory's file list.
+    int newHash = qHash(newHashStr.join(""));
+
+    QString dirPath = m_dir.path();
+
+    // Try to retrieve a hash from the last time that directory was scanned.
+    int prevHash = m_scannerGlobal->directoryHashInDatabase(dirPath);
+    bool prevHashExists = prevHash != -1;
+
+    // Compare the hashes, and if they don't match, rescan the files in that
+    // directory!
+    if (prevHash != newHash) {
+        // Rescan that mofo! If importing fails then the scan was cancelled so
+        // we return immediately.
+        if (!filesToImport.isEmpty()) {
+            m_pScanner->queueTask(new ImportFilesTask(m_pScanner, m_scannerGlobal,
+                                                      filesToImport, possibleCovers,
+                                                      m_pToken));
+        }
+
+        // Insert or update the hash in the database.
+        emit(directoryHashed(dirPath, !prevHashExists, newHash));
+    } else { //prevHash == newHash
+        emit(directoryUnchanged(dirPath));
+    }
+
+    // Process all of the sub-directories.
+    foreach (const QDir& nextDir, dirsToScan) {
+        m_pScanner->queueTask(new RecursiveScanDirectoryTask(
+            m_pScanner, m_scannerGlobal, nextDir, m_pToken));
+    }
+
+    setSuccess(true);
+}

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -38,6 +38,8 @@ void RecursiveScanDirectoryTask::run() {
     QLinkedList<QDir> dirsToScan;
     QStringList newHashStr;
 
+    // TODO(rryan) benchmark QRegExp copy versus QMutex/QRegExp in ScannerGlobal
+    // versus slicing the extension off and checking for set/list containment.
     QRegExp supportedExtensionsRegex =
             m_scannerGlobal->supportedExtensionsRegex();
     QRegExp supportedCoverExtensionsRegex =
@@ -49,11 +51,9 @@ void RecursiveScanDirectoryTask::run() {
 
         if (currentFileInfo.isFile()) {
             const QString& fileName = currentFileInfo.fileName();
-            //if (m_scannerGlobal->isAudioFileSupported(fileName)) {
             if (supportedExtensionsRegex.indexIn(fileName) != -1) {
                 newHashStr.append(currentFile);
                 filesToImport.append(currentFileInfo);
-                //} else if (m_scannerGlobal->isCoverFileSupported(fileName)) {
             } else if (supportedCoverExtensionsRegex.indexIn(fileName) != -1) {
                 possibleCovers.append(currentFileInfo);
             }

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -14,9 +14,6 @@ RecursiveScanDirectoryTask::RecursiveScanDirectoryTask(
           m_pToken(pToken) {
 }
 
-RecursiveScanDirectoryTask::~RecursiveScanDirectoryTask() {
-}
-
 void RecursiveScanDirectoryTask::run() {
     ScopedTimer timer("RecursiveScanDirectoryTask::run");
     if (m_scannerGlobal->shouldCancel()) {
@@ -90,7 +87,7 @@ void RecursiveScanDirectoryTask::run() {
 
         // Insert or update the hash in the database.
         emit(directoryHashed(dirPath, !prevHashExists, newHash));
-    } else { //prevHash == newHash
+    } else {
         emit(directoryUnchanged(dirPath));
     }
 

--- a/src/library/scanner/recursivescandirectorytask.h
+++ b/src/library/scanner/recursivescandirectorytask.h
@@ -1,0 +1,31 @@
+#ifndef RECURSIVESCANDIRECTORYTASK_H
+#define RECURSIVESCANDIRECTORYTASK_H
+
+#include <QDir>
+
+#include "library/scanner/scannertask.h"
+#include "util/sandbox.h"
+
+// Recursively scan a music library. Doesn't import tracks for any directories
+// that have already been scanned and have not changed. Changes are tracked by
+// performing a hash of the directory's file list, and those hashes are stored
+// in the database. Successful if the scan completed without being
+// cancelled. False if the scan was cancelled part-way through.
+class RecursiveScanDirectoryTask : public ScannerTask {
+    Q_OBJECT
+  public:
+
+    RecursiveScanDirectoryTask(LibraryScanner* pScanner,
+                               const ScannerGlobalPointer scannerGlobal,
+                               const QDir& dir,
+                               SecurityTokenPointer pToken);
+    virtual ~RecursiveScanDirectoryTask();
+
+    virtual void run();
+
+  private:
+    QDir m_dir;
+    SecurityTokenPointer m_pToken;
+};
+
+#endif /* RECURSIVESCANDIRECTORYTASK_H */

--- a/src/library/scanner/recursivescandirectorytask.h
+++ b/src/library/scanner/recursivescandirectorytask.h
@@ -19,7 +19,7 @@ class RecursiveScanDirectoryTask : public ScannerTask {
                                const ScannerGlobalPointer scannerGlobal,
                                const QDir& dir,
                                SecurityTokenPointer pToken);
-    virtual ~RecursiveScanDirectoryTask();
+    virtual ~RecursiveScanDirectoryTask() {}
 
     virtual void run();
 

--- a/src/library/scanner/scannerglobal.h
+++ b/src/library/scanner/scannerglobal.h
@@ -1,0 +1,166 @@
+#ifndef SCANNERGLOBAL_H
+#define SCANNERGLOBAL_H
+
+#include <QSet>
+#include <QHash>
+#include <QRegExp>
+#include <QStringList>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QSharedPointer>
+
+#include "util/task.h"
+#include "util/performancetimer.h"
+
+class ScannerGlobal {
+  public:
+    ScannerGlobal(const QSet<QString>& trackLocations,
+                  const QHash<QString, int>& directoryHashes,
+                  const QRegExp& supportedExtensionsMatcher,
+                  const QRegExp& supportedCoverExtensionsMatcher,
+                  const QStringList& directoriesBlacklist)
+            : m_trackLocations(trackLocations),
+              m_directoryHashes(directoryHashes),
+              m_supportedExtensionsMatcher(supportedExtensionsMatcher),
+              m_supportedCoverExtensionsMatcher(supportedCoverExtensionsMatcher),
+              m_directoriesBlacklist(directoriesBlacklist),
+              // Unless marked un-clean, we assume it will finish cleanly.
+              m_scanFinishedCleanly(true),
+              m_shouldCancel(false),
+              m_numAddedTracks(0),
+              m_numScannedDirectories(0) {
+    }
+
+    TaskWatcher& getTaskWatcher() {
+        return m_watcher;
+    }
+
+    // Returns whether the track already exists in the database.
+    inline bool trackExistsInDatabase(const QString& trackLocation) const {
+        return m_trackLocations.contains(trackLocation);
+    }
+
+    // Returns the directory hash if it exists or -1 if it doesn't.
+    inline int directoryHashInDatabase(const QString& directoryPath) const {
+        return m_directoryHashes.value(directoryPath, -1);
+    }
+
+    inline bool directoryBlacklisted(const QString& directoryPath) const {
+        return m_directoriesBlacklist.contains(directoryPath);
+    }
+
+    const QRegExp& supportedExtensionsRegex() const {
+        return m_supportedExtensionsMatcher;
+    }
+
+    // TODO(rryan) test whether tasks should create their own QRegExp.
+    inline bool isAudioFileSupported(const QString& fileName) const {
+        QMutexLocker locker(&m_supportedExtensionsMatcherMutex);
+        return m_supportedExtensionsMatcher.indexIn(fileName) != -1;
+    }
+
+    const QRegExp& supportedCoverExtensionsRegex() const {
+        return m_supportedCoverExtensionsMatcher;
+    }
+
+    // TODO(rryan) test whether tasks should create their own QRegExp.
+    inline bool isCoverFileSupported(const QString& fileName) const {
+        QMutexLocker locker(&m_supportedCoverExtensionsMatcherMutex);
+        return m_supportedCoverExtensionsMatcher.indexIn(fileName) != -1;
+    }
+
+    inline bool shouldCancel() const {
+        return m_shouldCancel;
+    }
+
+    inline volatile const bool* shouldCancelPointer() const {
+        return &m_shouldCancel;
+    }
+
+    void setShouldCancel(bool shouldCancel) {
+        m_shouldCancel = shouldCancel;
+    }
+
+    inline bool scanFinishedCleanly() const {
+        return m_scanFinishedCleanly;
+    }
+
+    void setScanFinishedCleanly(bool scanFinishedCleanly) {
+        m_scanFinishedCleanly = scanFinishedCleanly;
+    }
+
+    void addVerifiedDirectory(const QString& directory) {
+        m_verifiedDirectories << directory;
+    }
+
+    const QStringList& verifiedDirectories() const {
+        return m_verifiedDirectories;
+    }
+
+    void addVerifiedTrack(const QString& trackLocation) {
+        m_verifiedTracks << trackLocation;
+    }
+
+    const QStringList& verifiedTracks() const {
+        return m_verifiedTracks;
+    }
+
+    void startTimer() {
+        m_timer.start();
+    }
+
+    // Elapsed time in nanoseconds since startTimer was called.
+    qint64 timerElapsed() {
+        return m_timer.elapsed();
+    }
+
+    int numAddedTracks() const {
+        return m_numAddedTracks;
+    }
+    void trackAdded() {
+        m_numAddedTracks++;
+    }
+
+    int numScannedDirectories() const {
+        return m_numScannedDirectories;
+    }
+    void directoryScanned() {
+        m_numScannedDirectories++;
+    }
+
+
+  private:
+    TaskWatcher m_watcher;
+
+    QSet<QString> m_trackLocations;
+    QHash<QString, int> m_directoryHashes;
+
+    mutable QMutex m_supportedExtensionsMatcherMutex;
+    QRegExp m_supportedExtensionsMatcher;
+
+    mutable QMutex m_supportedCoverExtensionsMatcherMutex;
+    QRegExp m_supportedCoverExtensionsMatcher;
+
+    // Typically there are 1 to 2 entries in the blacklist so a O(n) search in a
+    // QList may have better constant factors than a O(1) QSet check. However,
+    // this has never been investigated.
+    QStringList m_directoriesBlacklist;
+
+    // The list of directories verified by the scan.
+    QStringList m_verifiedDirectories;
+
+    // The list of tracks verified by the scan.
+    QStringList m_verifiedTracks;
+
+    volatile bool m_scanFinishedCleanly;
+    volatile bool m_shouldCancel;
+
+    // Stats tracking.
+    PerformanceTimer m_timer;
+    int m_numAddedTracks;
+    int m_numScannedDirectories;
+};
+
+typedef QSharedPointer<ScannerGlobal> ScannerGlobalPointer;
+
+#endif /* SCANNERGLOBAL_H */

--- a/src/library/scanner/scannertask.cpp
+++ b/src/library/scanner/scannertask.cpp
@@ -1,0 +1,14 @@
+#include "library/scanner/scannertask.h"
+#include "library/libraryscanner.h"
+
+ScannerTask::ScannerTask(LibraryScanner* pScanner,
+                         const ScannerGlobalPointer scannerGlobal)
+        : m_pScanner(pScanner),
+          m_scannerGlobal(scannerGlobal),
+          m_success(false) {
+    setAutoDelete(true);
+}
+
+ScannerTask::~ScannerTask() {
+    emit(taskDone(m_success));
+}

--- a/src/library/scanner/scannertask.h
+++ b/src/library/scanner/scannertask.h
@@ -1,0 +1,46 @@
+#ifndef SCANNERTASK_H
+#define SCANNERTASK_H
+
+#include <QObject>
+#include <QRunnable>
+
+#include "trackinfoobject.h"
+#include "library/scanner/scannerglobal.h"
+
+class LibraryScanner;
+
+class ScannerTask : public QObject, public QRunnable {
+    Q_OBJECT
+  public:
+    ScannerTask(LibraryScanner* pScanner,
+                const ScannerGlobalPointer scannerGlobal);
+    virtual ~ScannerTask();
+
+    virtual void run() = 0;
+
+  signals:
+    void taskDone(bool success);
+    void queueTask(ScannerTask* pTask);
+    void directoryHashed(const QString& directoryPath, bool newDirectory,
+                         int hash);
+    void directoryUnchanged(const QString& directoryPath);
+    void trackExists(const QString& filePath);
+    void addNewTrack(TrackPointer pTrack);
+
+    // Feedback to GUI
+    void progressLoading(const QString& fileName);
+    void progressHashing(const QString& directoryPath);
+
+  protected:
+    void setSuccess(bool success) {
+        m_success = success;
+    }
+
+    LibraryScanner* m_pScanner;
+    const ScannerGlobalPointer m_scannerGlobal;
+
+  private:
+    bool m_success;
+};
+
+#endif /* SCANNERTASK_H */

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -449,7 +449,7 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
 
     // Scan the library directory. Initialize this after the skinloader has
     // loaded a skin, see Bug #1047435
-    m_pLibraryScanner = new LibraryScanner(m_pLibrary->getTrackCollection());
+    m_pLibraryScanner = new LibraryScanner(this, m_pLibrary->getTrackCollection());
     connect(m_pLibraryScanner, SIGNAL(scanFinished()),
             this, SLOT(slotEnableRescanLibraryAction()));
 
@@ -458,7 +458,7 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
             m_pLibrary, SLOT(slotRefreshLibraryModels()));
 
     if (rescan || hasChanged_MusicDir || upgrader.rescanLibrary()) {
-        m_pLibraryScanner->scan(this);
+        m_pLibraryScanner->scan();
     }
     slotNumDecksChanged(m_pNumDecks->get());
 
@@ -1894,7 +1894,7 @@ void MixxxMainWindow::closeEvent(QCloseEvent *event) {
 void MixxxMainWindow::slotScanLibrary() {
     emit(libraryScanStarted());
     m_pLibraryRescan->setEnabled(false);
-    m_pLibraryScanner->scan(this);
+    m_pLibraryScanner->scan();
 }
 
 void MixxxMainWindow::slotEnableRescanLibraryAction() {


### PR DESCRIPTION
This uses a thread pool to parallelize the work done in the recursive scan phase of the library scanner.

This also moves file verification work like TrackDAO::verifyTracksOutside into the final, uncancelable phase of the scanner. 

I used 10 worker threads -- this could be make configurable via the preferences.

Hopefully this will help speed up the scan with people who have gigantic libraries. I've heard it takes days for some people and that's just crazy.

A future step would be to replace QDirIterator with native filesystem access. I've profiled the scanner extensively and QDirIterator is by far the slowest part of the scanner. Tobias did something similar in foldertreemodel.cpp when he found that QDir::entryInfoList was extremely slow. People on the Qt bug tracker say that native file access is typically two orders of magnitude faster than QDirIterator.
