### PR TITLE
some fixes for skins containing the cover art widget

### DIFF
--- a/res/skins/Deere/library.xml
+++ b/res/skins/Deere/library.xml
@@ -44,6 +44,10 @@
                   <CoverArt>
                     <SizePolicy>me,me</SizePolicy>
                     <MinimumSize>100,100</MinimumSize>
+                    <Connection>
+                      <ConfigKey>[Library],show_coverart</ConfigKey>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
                   </CoverArt>
                 </Children>
               </WidgetGroup>

--- a/res/skins/Deere/skin.xml
+++ b/res/skins/Deere/skin.xml
@@ -21,6 +21,7 @@
       <attribute config_key="[Vinylcontrol],show_vinylcontrol">0</attribute>
       <attribute config_key="[PreviewDeck],show_previewdeck">0</attribute>
       <attribute config_key="[Library],show_library">1</attribute>
+      <attribute config_key="[Library],show_coverart">0</attribute>
     </attributes>
   </manifest>
 

--- a/res/skins/LateNight/library.xml
+++ b/res/skins/LateNight/library.xml
@@ -31,11 +31,10 @@
 									<CoverArt>
 										<SizePolicy>me,me</SizePolicy>
 										<MinimumSize>100,100</MinimumSize>
-										<!-- TODO: uncomment this when there is a control for showing/hiding cover art.
-											<Connection>
+										<Connection>
 											<ConfigKey>[Library],show_coverart</ConfigKey>
 											<BindProperty>visible</BindProperty>
-										</Connection> -->
+										</Connection>
 									</CoverArt>
 								</Children>
 							</WidgetGroup>

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -545,8 +545,8 @@
 												<LibrarySidebar></LibrarySidebar>
 												<!--Cover Art-->
 												<CoverArt>
-													<MinimumSize>16,16</MinimumSize>
 													<SizePolicy>me,me</SizePolicy>
+													<MinimumSize>100,100</MinimumSize>
 													<Connection>
 														<ConfigKey persist="true">[Library],show_coverart</ConfigKey>
 														<BindProperty>visible</BindProperty>


### PR DESCRIPTION
Supported skins:
- Shade
- LateNight
- Deere

To show/hide the cover art widget use [ctrl+5] or [View->show cover art]
