### PR TITLE
[#1392917-fixed]Revert "Only lookup cached track if it is dirty in BaseTrackCache."

### DIFF
--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -124,9 +124,8 @@ void BaseTrackCache::ensureCached(QSet<int> trackIds) {
 }
 
 TrackPointer BaseTrackCache::lookupCachedTrack(int trackId) const {
-    // Only get the track from the TrackDAO if it's in the cache and marked as
-    // dirty.
-    if (m_bIsCaching && m_dirtyTracks.contains(trackId)) {
+    // Only get the Track from the TrackDAO if it's in the cache
+    if (m_bIsCaching) {
         return m_trackDAO.getTrack(trackId, true);
     }
     return TrackPointer();


### PR DESCRIPTION
This reverts commit efb0e8923018bc8adce9749902ecf341aeaa6021.

https://bugs.launchpad.net/mixxx/+bug/1392917

@rryan, it may justifies the performance gain that you noticed. (?!)
