### PR TITLE
Simplify and untangle SoundSource

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -659,6 +659,7 @@ class MixxxCore(Feature):
                    "upgrade.cpp",
 
                    "soundsource.cpp",
+                   "soundsourcetaglib.cpp",
 
                    "sharedglcontext.cpp",
                    "widget/controlwidgetconnection.cpp",

--- a/plugins/soundsourcem4a/SConscript
+++ b/plugins/soundsourcem4a/SConscript
@@ -11,8 +11,9 @@ Import('build')
 # On Posix default SCons.LIBPREFIX = 'lib', on Windows default SCons.LIBPREFIX = ''
 
 m4a_sources = [
-    "soundsource.cpp", # required to subclass soundsource
     "soundsourcem4a.cpp",  # MP4/M4A Support through FAAD/libmp4v2
+    "soundsourcetaglib.cpp", # TagLib dependencies
+    "soundsource.cpp", # required to subclass SoundSource
     "sampleutil.cpp", # utility functions
 ]
 

--- a/plugins/soundsourcem4a/m4a/mp4-mixxx.cpp
+++ b/plugins/soundsourcem4a/m4a/mp4-mixxx.cpp
@@ -124,6 +124,10 @@ static MP4TrackId mp4_get_track(MP4FileHandle *handle)
     return MP4_INVALID_TRACK_ID;
 }
 
+static void mp4_init(struct input_plugin_data *ip_data) {
+    memset(ip_data, 0, sizeof(*ip_data));
+}
+
 static int mp4_open(struct input_plugin_data *ip_data)
 {
     struct mp4_private *priv;

--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 #include "soundsourcem4a.h"
+#include "soundsourcetaglib.h"
 #include "sampleutil.h"
 
 #include <taglib/mp4file.h>
@@ -41,7 +42,8 @@ SoundSourceM4A::SoundSourceM4A(QString qFileName)
     // Initialize variables to invalid values in case loading fails.
     mp4file = MP4_INVALID_FILE_HANDLE;
     filelength = 0;
-    memset(&ipd, 0, sizeof(ipd));
+    setType("m4a");
+    mp4_init(&ipd);
 }
 
 SoundSourceM4A::~SoundSourceM4A() {
@@ -61,7 +63,7 @@ Result SoundSourceM4A::open()
     //Initialize the FAAD2 decoder...
     initializeDecoder();
 
-    //qDebug() << "SSM4A: channels:" << m_iChannels
+    //qDebug() << "SSM4A: channels:" << getChannels()
     //         << "filelength:" << filelength
     //         << "Sample Rate:" << m_iSampleRate;
     return OK;
@@ -70,8 +72,7 @@ Result SoundSourceM4A::open()
 int SoundSourceM4A::initializeDecoder()
 {
     // Copy QString to char[] buffer for mp4_open to read from later
-    QByteArray qbaFileName;
-    qbaFileName = m_qFilename.toLocal8Bit();
+    const QByteArray qbaFileName(getFilename().toLocal8Bit());
     int bytes = qbaFileName.length() + 1;
     ipd.filename = new char[bytes];
     strncpy(ipd.filename, qbaFileName.constData(), bytes);
@@ -84,7 +85,7 @@ int SoundSourceM4A::initializeDecoder()
     int mp4_open_status = mp4_open(&ipd);
     if (mp4_open_status != 0) {
         qWarning() << "SSM4A::initializeDecoder failed"
-                 << m_qFilename << " with status:" << mp4_open_status;
+                 << getFilename() << " with status:" << mp4_open_status;
         return ERR;
     }
 
@@ -93,8 +94,8 @@ int SoundSourceM4A::initializeDecoder()
     Q_ASSERT(mp);
     mp4file = mp->mp4.handle;
     filelength = mp4_total_samples(&ipd);
-    m_iSampleRate = mp->sample_rate;
-    m_iChannels = mp->channels;
+    setSampleRate(mp->sample_rate);
+    setChannels(mp->channels);
 
     return OK;
 }
@@ -106,10 +107,10 @@ long SoundSourceM4A::seek(long filepos){
 
     //qDebug() << "SSM4A::seek()" << filepos;
 
-    // qDebug() << "MP4SEEK: seek time:" << filepos / (m_iChannels * m_iSampleRate) ;
+    // qDebug() << "MP4SEEK: seek time:" << filepos / (getChannels() * m_iSampleRate) ;
 
     int position = mp4_seek_sample(&ipd, filepos);
-    //int position = mp4_seek(&ipd, filepos / (m_iChannels * m_iSampleRate));
+    //int position = mp4_seek(&ipd, filepos / (getChannels() * m_iSampleRate));
     return position;
 }
 
@@ -125,7 +126,7 @@ unsigned SoundSourceM4A::read(volatile unsigned long size, const SAMPLE* destina
     // sample is 16-bits = 2 bytes here, so we multiply size by channels to
     // get the number of bytes we want to decode.
 
-    int total_bytes_to_decode = size * m_iChannels;
+    int total_bytes_to_decode = size * getChannels();
     int total_bytes_decoded = 0;
     int num_bytes_req = 4096;
     char* buffer = (char*)destination;
@@ -148,7 +149,7 @@ unsigned SoundSourceM4A::read(volatile unsigned long size, const SAMPLE* destina
 
     // At this point *destination should be filled. If mono : double all samples
     // (L => R)
-    if (m_iChannels == 1) {
+    if (getChannels() == 1) {
         SampleUtil::doubleMonoToDualMono(as_buffer, total_bytes_decoded / 2);
     }
 
@@ -168,30 +169,40 @@ unsigned SoundSourceM4A::read(volatile unsigned long size, const SAMPLE* destina
 
 inline long unsigned SoundSourceM4A::length(){
     return filelength;
-    //return m_iChannels * mp4_duration(&ipd) * m_iSampleRate;
+    //return getChannels() * mp4_duration(&ipd) * m_iSampleRate;
 }
 
 Result SoundSourceM4A::parseHeader(){
-    setType("m4a");
-
     TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
 
-    bool result = processTaglibFile(f);
-    TagLib::MP4::Tag* tag = f.tag();
-
-    if (tag) {
-        processMP4Tag(tag);
+    if (!readFileHeader(this, f)) {
+        return ERR;
     }
 
-    if (result)
-        return OK;
-    return ERR;
+    TagLib::MP4::Tag *mp4(f.tag());
+    if (mp4) {
+        readMP4Tag(this, *mp4);
+    } else {
+        // fallback
+        const TagLib::Tag *tag(f.tag());
+        if (tag) {
+            readTag(this, *tag);
+        } else {
+            return ERR;
+        }
+    }
+
+    return OK;
 }
 
 QImage SoundSourceM4A::parseCoverArt() {
-    setType("m4a");
     TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
-    return getCoverInMP4Tag(f.tag());
+    TagLib::MP4::Tag *mp4(f.tag());
+    if (mp4) {
+        return getCoverInMP4Tag(*mp4);
+    } else {
+        return QImage();
+    }
 }
 
 QList<QString> SoundSourceM4A::supportedFileExtensions()

--- a/plugins/soundsourcem4a/soundsourcem4a.h
+++ b/plugins/soundsourcem4a/soundsourcem4a.h
@@ -43,7 +43,7 @@ namespace Mixxx {
 
 class SoundSourceM4A : public SoundSource {
     public:
-        SoundSourceM4A(QString qFileName);
+        explicit SoundSourceM4A(QString qFileName);
         ~SoundSourceM4A();
         Result open();
         long seek(long);

--- a/plugins/soundsourcemediafoundation/SConscript
+++ b/plugins/soundsourcemediafoundation/SConscript
@@ -18,7 +18,7 @@ if int(build.flags['mediafoundation']):
     else:
         env["LINKFLAGS"].remove("/subsystem:windows,5.01")
     ssmediafoundation_bin = env.SharedLibrary('soundsourcemediafoundation',
-        ['soundsource.cpp', 'soundsourcemediafoundation.cpp'],
+        ['soundsource.cpp', 'soundsourcetaglib.cpp', 'soundsourcemediafoundation.cpp'],
         LINKCOM  = [env['LINKCOM'],
             'mt.exe -nologo -manifest ${TARGET}.manifest -outputresource:$TARGET;1'])
     Return("ssmediafoundation_bin")

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
@@ -58,7 +58,6 @@ class SoundSourceMediaFoundation : public Mixxx::SoundSource {
     static inline qint64 mfFromSeconds(qreal sec);
     static inline qint64 frameFromMF(qint64 mf);
     static inline qint64 mfFromFrame(qint64 frame);
-    QFile m_file;
     IMFSourceReader *m_pReader;
     IMFMediaType *m_pAudioType;
     wchar_t *m_wcFilename;

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
@@ -39,7 +39,7 @@ class IMFMediaSource;
 
 class SoundSourceMediaFoundation : public Mixxx::SoundSource {
   public:
-    SoundSourceMediaFoundation(QString filename);
+    explicit SoundSourceMediaFoundation(QString filename);
     ~SoundSourceMediaFoundation();
     Result open();
     long seek(long filepos);

--- a/plugins/soundsourcewv/SConscript
+++ b/plugins/soundsourcewv/SConscript
@@ -11,8 +11,9 @@ Import('build')
 # On Posix default SCons.LIBPREFIX = 'lib', on Windows default SCons.LIBPREFIX = ''
 
 wv_sources = [
-    "soundsource.cpp", # required to subclass soundsource
     "soundsourcewv.cpp",  # Wavpack support
+    "soundsourcetaglib.cpp", # TagLib dependencies
+    "soundsource.cpp", # required to subclass SoundSource
     "sampleutil.cpp", # utility functions
 ]
 

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -5,17 +5,19 @@
 
 #include <QtDebug>
 
-#include <taglib/wavpackfile.h>
-
 #include "soundsourcewv.h"
+#include "soundsourcetaglib.h"
 #include "sampleutil.h"
 
+#include <taglib/wavpackfile.h>
 namespace Mixxx {
 
-SoundSourceWV::SoundSourceWV(QString qFilename) : SoundSource(qFilename)
-{
-    // Initialize variables to invalid values in case loading fails.
-    filewvc=NULL;
+SoundSourceWV::SoundSourceWV(QString qFilename)
+    : SoundSource(qFilename),
+    filewvc(NULL),
+    Bps(0),
+    filelength(0) {
+    setType("wv");
 }
 
 
@@ -36,12 +38,12 @@ QList<QString> SoundSourceWV::supportedFileExtensions()
 
 Result SoundSourceWV::open()
 {
-    QByteArray qBAFilename = m_qFilename.toLocal8Bit();
-    char msg[80];   //hold posible error message
+    QByteArray qBAFilename(getFilename().toLocal8Bit());
+    char msg[80];   //hold possible error message
 
-    filewvc = WavpackOpenFileInput(qBAFilename.constData(), msg,OPEN_2CH_MAX | OPEN_WVC,0);
+    filewvc = WavpackOpenFileInput(qBAFilename.constData(), msg, OPEN_2CH_MAX | OPEN_WVC,0);
     if (!filewvc) {
-        qDebug() << "SSWV::open: failed to open file : "<<msg;
+        qDebug() << "SSWV::open: failed to open file : "<< msg;
         return ERR;
     }
     if (WavpackGetMode(filewvc) & MODE_FLOAT) {
@@ -52,11 +54,11 @@ Result SoundSourceWV::open()
     }
     // wavpack_open succeeded -> populate variables
     filelength = WavpackGetNumSamples(filewvc);
-    m_iSampleRate=WavpackGetSampleRate(filewvc);
-    m_iChannels=WavpackGetReducedChannels(filewvc);
+    setSampleRate(WavpackGetSampleRate(filewvc));
+    setChannels(WavpackGetReducedChannels(filewvc));
     Bps=WavpackGetBytesPerSample(filewvc);
-    qDebug () << "SSWV::open: opened filewvc with filelength: "<<filelength<<" SampleRate: " << m_iSampleRate
-        << " channels: " << m_iChannels << " bytes per samp: "<<Bps;
+    qDebug () << "SSWV::open: opened filewvc with filelength: "<<filelength<<" SampleRate: " << getSampleRate()
+        << " channels: " << getChannels() << " bytes per samp: "<<Bps;
     if (Bps>2) {
         qDebug() << "SSWV::open: warning: input file has > 2 bytes per sample, will be truncated to 16bits";
     }
@@ -82,15 +84,15 @@ unsigned SoundSourceWV::read(volatile unsigned long size, const SAMPLE* destinat
     //tempbuffer is fixed size : WV_BUF_LENGTH of uint32
     while (sampsread != size) {
         timesamps=(size-sampsread)>>1;      //timesamps still remaining
-        if (timesamps > (WV_BUF_LENGTH/m_iChannels)) {  //if requested size requires more than one buffer filling
-            timesamps=(WV_BUF_LENGTH/m_iChannels);      //tempbuffer must hold (timesamps * channels) samples
+        if (timesamps > (WV_BUF_LENGTH / getChannels())) {  //if requested size requires more than one buffer filling
+            timesamps=(WV_BUF_LENGTH / getChannels());      //tempbuffer must hold (timesamps * channels) samples
             qDebug() << "SSWV::read : performance warning, size requested > buffer size !";
         }
 
         tsdone=WavpackUnpackSamples(filewvc, tempbuffer, timesamps);    //fill temp buffer with timesamps*4bytes*channels
                 //data is right justified, format_samples() fixes that.
 
-        SoundSourceWV::format_samples(Bps, (char *) (dest + (sampsread>>1)*m_iChannels), tempbuffer, tsdone*m_iChannels);
+        SoundSourceWV::format_samples(Bps, (char *) (dest + (sampsread>>1) * getChannels()), tempbuffer, tsdone*getChannels());
                                 //this will unpack the 4byte/sample
                                 //output of wUnpackSamples(), sign-extending or truncating to output 16bit / sample.
                                 //specifying dest+sampsread should resume the conversion where it was left if size requested
@@ -104,7 +106,7 @@ unsigned SoundSourceWV::read(volatile unsigned long size, const SAMPLE* destinat
 
     }
 
-    if (m_iChannels==1) {       //if MONO : expand array to double it's size; see ssov.cpp
+    if (getChannels() == 1) { //if MONO : expand array to double it's size; see ssov.cpp
         SampleUtil::doubleMonoToDualMono(dest, sampsread / 2);
     }
 
@@ -119,29 +121,37 @@ inline long unsigned SoundSourceWV::length(){
 
 
 Result SoundSourceWV::parseHeader() {
-    setType("wv");
-
-    QByteArray qBAFilename = m_qFilename.toLocal8Bit();
+    const QByteArray qBAFilename(getFilename().toLocal8Bit());
     TagLib::WavPack::File f(qBAFilename.constData());
 
-    // Takes care of all the default metadata
-    bool result = processTaglibFile(f);
+    if (!readFileHeader(this, f)) {
+        return ERR;
+    }
 
     TagLib::APE::Tag *ape = f.APETag();
     if (ape) {
-        processAPETag(ape);
+        readAPETag(this, *ape);
+    } else {
+        // fallback
+        const TagLib::Tag *tag(f.tag());
+        if (tag) {
+            readTag(this, *tag);
+        } else {
+            return ERR;
+        }
     }
 
-    if (result)
-        return OK;
-    return ERR;
+    return OK;
 }
 
 QImage SoundSourceWV::parseCoverArt() {
-    setType("wv");
-    TagLib::WavPack::File f(m_qFilename.toLocal8Bit().constData());
+    TagLib::WavPack::File f(getFilename().toLocal8Bit().constData());
     TagLib::APE::Tag *ape = f.APETag();
-    return getCoverInAPETag(ape);
+    if (ape) {
+        return Mixxx::getCoverInAPETag(*ape);
+    } else {
+        return QImage();
+    }
 }
 
 void SoundSourceWV::format_samples(int Bps, char *dst, int32_t *src, uint32_t count)

--- a/plugins/soundsourcewv/soundsourcewv.h
+++ b/plugins/soundsourcewv/soundsourcewv.h
@@ -35,9 +35,9 @@ class SoundSourceWV : public SoundSource {
   QImage parseCoverArt();
   static QList<QString> supportedFileExtensions();
  private:
+  WavpackContext * filewvc; //works as a file handle to access the wv file.
   int Bps;
   unsigned long filelength;
-  WavpackContext * filewvc;	//works as a file handle to access the wv file.
   int32_t tempbuffer[WV_BUF_LENGTH];	//hax ! legacy from cmus. this is 64k*4bytes.
   void format_samples(int, char *, int32_t *, uint32_t);
 };

--- a/plugins/soundsourcewv/soundsourcewv.h
+++ b/plugins/soundsourcewv/soundsourcewv.h
@@ -25,7 +25,7 @@ namespace Mixxx {
 
 class SoundSourceWV : public SoundSource {
  public:
-  SoundSourceWV(QString qFilename);
+  explicit SoundSourceWV(QString qFilename);
   ~SoundSourceWV();
   Result open();
   long seek(long);

--- a/src/analyserqueue.cpp
+++ b/src/analyserqueue.cpp
@@ -301,14 +301,9 @@ void AnalyserQueue::run() {
 
         // Get the audio
         SoundSourceProxy soundSourceProxy(nextTrack);
-        if (OK != soundSourceProxy.open()) { //Open the file for reading
-            qWarning() << "Failed to open file for analyzing:" << soundSourceProxy.getFilename();
-            continue;
-        }
-
-        Mixxx::SoundSourcePointer pSoundSource(soundSourceProxy.getSoundSource());
+        Mixxx::SoundSourcePointer pSoundSource(soundSourceProxy.open());
         if (pSoundSource.isNull()) {
-            qWarning() << "Skipping unsupported file:" << nextTrack->getLocation();
+            qWarning() << "Failed to open file for analyzing:" << nextTrack->getLocation();
             continue;
         }
 

--- a/src/analyserqueue.cpp
+++ b/src/analyserqueue.cpp
@@ -160,7 +160,7 @@ TrackPointer AnalyserQueue::dequeueNextBlocking() {
 }
 
 // This is called from the AnalyserQueue thread
-bool AnalyserQueue::doAnalysis(TrackPointer tio, SoundSourceProxy* pSoundSource) {
+bool AnalyserQueue::doAnalysis(TrackPointer tio, const Mixxx::SoundSourcePointer& pSoundSource) {
     int totalSamples = pSoundSource->length();
     //qDebug() << tio->getFilename() << " has " << totalSamples << " samples.";
     int processedSamples = 0;
@@ -300,13 +300,18 @@ void AnalyserQueue::run() {
         Trace trace("AnalyserQueue analyzing track");
 
         // Get the audio
-        SoundSourceProxy soundSource(nextTrack);
-        soundSource.open(); //Open the file for reading
-        int iNumSamples = soundSource.length();
-        int iSampleRate = soundSource.getSampleRate();
+        SoundSourceProxy soundSourceProxy(nextTrack);
+        if (OK != soundSourceProxy.open()) { //Open the file for reading
+            qWarning() << "Failed to open file for analyzing:" << soundSourceProxy.getFilename();
+            continue;
+        }
+
+        Mixxx::SoundSourcePointer pSoundSource(soundSourceProxy.getSoundSource());
+        int iNumSamples = pSoundSource->length();
+        int iSampleRate = pSoundSource->getSampleRate();
 
         if (iNumSamples == 0 || iSampleRate == 0) {
-            qDebug() << "Skipping invalid file:" << nextTrack->getLocation();
+            qWarning() << "Skipping invalid file:" << nextTrack->getLocation();
             continue;
         }
 
@@ -325,7 +330,7 @@ void AnalyserQueue::run() {
 
         if (processTrack) {
             emitUpdateProgress(nextTrack, 0);
-            bool completed = doAnalysis(nextTrack, &soundSource);
+            bool completed = doAnalysis(nextTrack, pSoundSource);
             if (!completed) {
                 //This track was cancelled
                 QListIterator<Analyser*> itf(m_aq);

--- a/src/analyserqueue.cpp
+++ b/src/analyserqueue.cpp
@@ -307,6 +307,11 @@ void AnalyserQueue::run() {
         }
 
         Mixxx::SoundSourcePointer pSoundSource(soundSourceProxy.getSoundSource());
+        if (pSoundSource.isNull()) {
+            qWarning() << "Skipping unsupported file:" << nextTrack->getLocation();
+            continue;
+        }
+
         int iNumSamples = pSoundSource->length();
         int iSampleRate = pSoundSource->getSampleRate();
 

--- a/src/analyserqueue.h
+++ b/src/analyserqueue.h
@@ -9,9 +9,9 @@
 
 #include "configobject.h"
 #include "analyser.h"
+#include "soundsource.h"
 #include "trackinfoobject.h"
 
-class SoundSourceProxy;
 class TrackCollection;
 
 class AnalyserQueue : public QThread {
@@ -58,7 +58,7 @@ class AnalyserQueue : public QThread {
 
     bool isLoadedTrackWaiting(TrackPointer tio);
     TrackPointer dequeueNextBlocking();
-    bool doAnalysis(TrackPointer tio, SoundSourceProxy* pSoundSource);
+    bool doAnalysis(TrackPointer tio, const Mixxx::SoundSourcePointer& pSoundSource);
     void emitUpdateProgress(TrackPointer tio, int progress);
 
     bool m_exit;

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -130,7 +130,8 @@ namespace
             qWarning() << "Unsupported file:" << pTrack->getLocation();
             return Mixxx::SoundSourcePointer();
         }
-        if (OK != pSoundSource->open()) {
+        // Open the SoundSource through SoundSourceProxy!
+        if (OK != soundSourceProxy.open()) {
             qWarning() << "Failed to open file:" << pTrack->getLocation();
             return Mixxx::SoundSourcePointer();
         }

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -125,17 +125,12 @@ namespace
 {
     Mixxx::SoundSourcePointer openSoundSourceForReading(const TrackPointer& pTrack) {
         SoundSourceProxy soundSourceProxy(pTrack);
-        Mixxx::SoundSourcePointer pSoundSource(soundSourceProxy.getSoundSource());
+        Mixxx::SoundSourcePointer pSoundSource(soundSourceProxy.open());
         if (pSoundSource.isNull()) {
-            qWarning() << "Unsupported file:" << pTrack->getLocation();
-            return Mixxx::SoundSourcePointer();
-        }
-        // Open the SoundSource through SoundSourceProxy!
-        if (OK != soundSourceProxy.open()) {
             qWarning() << "Failed to open file:" << pTrack->getLocation();
             return Mixxx::SoundSourcePointer();
         }
-        if ((pSoundSource->length() > 0) && (pSoundSource->getSampleRate() > 0)) {
+        if (pSoundSource->length() > 0) {
             // successfully opened and readable
             return pSoundSource;
         } else {

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -121,14 +121,37 @@ void CachingReaderWorker::run() {
     }
 }
 
-void CachingReaderWorker::loadTrack(TrackPointer pTrack) {
+namespace
+{
+    Mixxx::SoundSourcePointer openSoundSourceForReading(const TrackPointer& pTrack) {
+        SoundSourceProxy soundSourceProxy(pTrack);
+        Mixxx::SoundSourcePointer pSoundSource(soundSourceProxy.getSoundSource());
+        if (pSoundSource.isNull()) {
+            qWarning() << "Unsupported file:" << pTrack->getLocation();
+            return Mixxx::SoundSourcePointer();
+        }
+        if (OK != pSoundSource->open()) {
+            qWarning() << "Failed to open file:" << pTrack->getLocation();
+            return Mixxx::SoundSourcePointer();
+        }
+        if ((pSoundSource->length() > 0) && (pSoundSource->getSampleRate() > 0)) {
+            // successfully opened and readable
+            return pSoundSource;
+        } else {
+            qWarning() << "Invalid file:" << pTrack->getLocation();
+            return Mixxx::SoundSourcePointer();
+        }
+    }
+}
+
+void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     //qDebug() << m_group << "CachingReaderWorker::loadTrack() lock acquired for load.";
 
     // Emit that a new track is loading, stops the current track
     emit(trackLoading());
 
     ReaderStatusUpdate status;
-    status.status = TRACK_LOADED;
+    status.status = TRACK_NOT_LOADED;
     status.chunk = NULL;
     status.trackNumSamples = 0;
 
@@ -141,30 +164,25 @@ void CachingReaderWorker::loadTrack(TrackPointer pTrack) {
         // Must unlock before emitting to avoid deadlock
         qDebug() << m_group << "CachingReaderWorker::loadTrack() load failed for\""
                  << filename << "\", unlocked reader lock";
-        status.status = TRACK_NOT_LOADED;
         m_pReaderStatusFIFO->writeBlocking(&status, 1);
         emit(trackLoadFailed(
             pTrack, QString("The file '%1' could not be found.").arg(filename)));
         return;
     }
-    SoundSourceProxy soundSourceProxy(pTrack);
-    Mixxx::SoundSourcePointer pSoundSource(soundSourceProxy.getSoundSource());
-    bool openSucceeded = (pSoundSource->open() == OK); //Open the song for reading
-    m_iTrackNumSamples = status.trackNumSamples = pSoundSource->length();
 
-    if (!openSucceeded || m_iTrackNumSamples == 0 || pSoundSource->getSampleRate() == 0) {
+    m_pCurrentSoundSource = openSoundSourceForReading(pTrack);
+    if (m_pCurrentSoundSource.isNull()) {
         // Must unlock before emitting to avoid deadlock
         qDebug() << m_group << "CachingReaderWorker::loadTrack() load failed for\""
                  << filename << "\", file invalid, unlocked reader lock";
-        status.status = TRACK_NOT_LOADED;
         m_pReaderStatusFIFO->writeBlocking(&status, 1);
         emit(trackLoadFailed(
             pTrack, QString("The file '%1' could not be loaded.").arg(filename)));
         return;
     }
 
-    m_pCurrentSoundSource = pSoundSource;
-
+    m_iTrackNumSamples = status.trackNumSamples = m_pCurrentSoundSource->length();
+    status.status = TRACK_LOADED;
     m_pReaderStatusFIFO->writeBlocking(&status, 1);
 
     // Clear the chunks to read list.

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -61,7 +61,7 @@ class CachingReaderWorker : public EngineWorker {
             FIFO<ReaderStatusUpdate>* pReaderStatusFIFO);
     virtual ~CachingReaderWorker();
 
-    // Request to load a new track. wake() must be called afer wards.
+    // Request to load a new track. wake() must be called afterwards.
     virtual void newTrack(TrackPointer pTrack);
 
     // Run upkeep operations like loading tracks and reading from file. Run by a
@@ -101,7 +101,7 @@ class CachingReaderWorker : public EngineWorker {
     TrackPointer m_newTrack;
 
     // Internal method to load a track. Emits trackLoaded when finished.
-    void loadTrack(TrackPointer pTrack);
+    void loadTrack(const TrackPointer& pTrack);
 
     // Read the given chunk_number from the file into pChunk's data
     // buffer. Fills length/sample information about Chunk* as well.

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -8,15 +8,12 @@
 #include <QString>
 #include <QScopedPointer>
 
+#include "soundsource.h"
 #include "trackinfoobject.h"
 #include "engine/engineworker.h"
 #include "util/fifo.h"
 #include "util/types.h"
 
-
-namespace Mixxx {
-    class SoundSource;
-}
 
 // A Chunk is a section of audio that is being cached. The chunk_number can be
 // used to figure out the sample number of the first sample in data by using
@@ -112,7 +109,7 @@ class CachingReaderWorker : public EngineWorker {
                                  ReaderStatusUpdate* update);
 
     // The current sound source of the track loaded
-    QScopedPointer<Mixxx::SoundSource> m_pCurrentSoundSource;
+    Mixxx::SoundSourcePointer m_pCurrentSoundSource;
     int m_iTrackNumSamples;
 
     // Temporary buffer for reading from SoundSources

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -41,7 +41,7 @@ class CoverArtUtils {
         }
         SoundSourceProxy proxy(trackLocation, pToken);
         Mixxx::SoundSourcePointer pSoundSource(proxy.getSoundSource());
-        if (pSoundSource == NULL) {
+        if (pSoundSource.isNull()) {
             return QImage();
         }
         return pSoundSource->parseCoverArt();

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -40,7 +40,11 @@ class CoverArtUtils {
             return QImage();
         }
         SoundSourceProxy proxy(trackLocation, pToken);
-        return proxy.parseCoverArt();
+        Mixxx::SoundSourcePointer pSoundSource(proxy.getSoundSource());
+        if (pSoundSource == NULL) {
+            return QImage();
+        }
+        return pSoundSource->parseCoverArt();
     }
 
     static QImage loadCover(const CoverInfo& info) {

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1591,7 +1591,7 @@ bool TrackDAO::verifyRemainingTracks(volatile bool* pCancel) {
 
 namespace
 {
-    QImage parseCoverArt(const QFileInfo fileInfo) {
+    QImage parseCoverArt(const QFileInfo& fileInfo) {
         SecurityTokenPointer pToken = Sandbox::openSecurityToken(fileInfo, true);
         SoundSourceProxy proxy(fileInfo.filePath(), pToken);
         Mixxx::SoundSourcePointer pSoundSource(proxy.getSoundSource());

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1589,6 +1589,20 @@ bool TrackDAO::verifyRemainingTracks(volatile bool* pCancel) {
     return true;
 }
 
+namespace
+{
+    QImage parseCoverArt(const QFileInfo fileInfo) {
+        SecurityTokenPointer pToken = Sandbox::openSecurityToken(fileInfo, true);
+        SoundSourceProxy proxy(fileInfo.filePath(), pToken);
+        Mixxx::SoundSourcePointer pSoundSource(proxy.getSoundSource());
+        if (pSoundSource) {
+            return pSoundSource->parseCoverArt();
+        } else {
+            return QImage();
+        }
+    }
+}
+
 void TrackDAO::detectCoverArtForUnknownTracks(volatile const bool* pCancel,
                                               QSet<int>* pTracksChanged) {
     // WARNING TO ANYONE TOUCHING THIS IN THE FUTURE
@@ -1659,9 +1673,7 @@ void TrackDAO::detectCoverArtForUnknownTracks(volatile const bool* pCancel,
             continue;
         }
 
-        SecurityTokenPointer pToken = Sandbox::openSecurityToken(trackInfo, true);
-        SoundSourceProxy proxy(trackLocation, pToken);
-        QImage image = proxy.parseCoverArt();
+        QImage image(parseCoverArt(trackInfo));
         if (!image.isNull()) {
             updateQuery.bindValue(":coverart_type",
                                   static_cast<int>(CoverInfo::METADATA));

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -11,15 +11,16 @@ ChromaPrinter::ChromaPrinter(QObject* parent)
 
 QString ChromaPrinter::getFingerPrint(TrackPointer pTrack){
     SoundSourceProxy soundSourceProxy(pTrack);
-    if (OK == soundSourceProxy.open()) {
-        Mixxx::SoundSourcePointer pSoundSource(soundSourceProxy.getSoundSource());
-        if (pSoundSource && (0 < pSoundSource->length()) && (0 < pSoundSource->getSampleRate())) {
-            return calcFingerPrint(pSoundSource);
-        }
+    Mixxx::SoundSourcePointer pSoundSource(soundSourceProxy.open());
+    if (pSoundSource.isNull()) {
+        qDebug() << "Skipping invalid file:" << pTrack->getLocation();
+        return QString();
     }
-    qDebug() << "Skipping invalid file:" << soundSourceProxy.getFilename();
-    return QString();
-
+    if (0 >= pSoundSource->length()) {
+        qDebug() << "Skipping empty file:" << pTrack->getLocation();
+        return QString();
+    }
+    return calcFingerPrint(pSoundSource);
 }
 
 QString ChromaPrinter::calcFingerPrint(const Mixxx::SoundSourcePointer& pSoundSource) {

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -6,41 +6,37 @@
 #include "soundsourceproxy.h"
 
 ChromaPrinter::ChromaPrinter(QObject* parent)
-             : QObject(parent),
-               m_NumSamples(0),
-               m_SampleRate(0) {
+             : QObject(parent) {
 }
 
 QString ChromaPrinter::getFingerPrint(TrackPointer pTrack){
-    SoundSourceProxy soundSource(pTrack);
-    return calcFingerPrint(soundSource);
+    SoundSourceProxy soundSourceProxy(pTrack);
+    if (OK == soundSourceProxy.open()) {
+        Mixxx::SoundSourcePointer pSoundSource(soundSourceProxy.getSoundSource());
+        if (pSoundSource && (0 < pSoundSource->length()) && (0 < pSoundSource->getSampleRate())) {
+            return calcFingerPrint(pSoundSource);
+        }
+    }
+    qDebug() << "Skipping invalid file:" << soundSourceProxy.getFilename();
+    return QString();
+
 }
 
-QString ChromaPrinter::calcFingerPrint(SoundSourceProxy& soundSource){
-    soundSource.open();
-    m_SampleRate = soundSource.getSampleRate();
-    unsigned int length = soundSource.length();
-    if (m_SampleRate == 0 ){
-        qDebug() << "Skipping invalid file:" << soundSource.getFilename();
-        return QString();
-    }
+QString ChromaPrinter::calcFingerPrint(const Mixxx::SoundSourcePointer& pSoundSource) {
 
     // this is worth 2min of audio, multiply by 2 because we have 2 channels
     // AcoustID only stores a fingerprint for the first two minutes of a song
     // on their server so we need only a fingerprint of the first two minutes
     // --kain88 July 2012
-    m_NumSamples = 120*2*m_SampleRate;
-    // check that the song is actually longer then the amount of audio we use
-    if (m_NumSamples > length) {
-        m_NumSamples = length;
-    }
+    unsigned long maxFingerprintSamples = 120 * 2 * pSoundSource->getSampleRate();
+    unsigned long numFingerprintSamples = math_min(pSoundSource->length(), maxFingerprintSamples);
 
-    SAMPLE *pData = new SAMPLE[m_NumSamples];
+    SAMPLE *pData = new SAMPLE[numFingerprintSamples];
     QTime timerReadingFile;
     timerReadingFile.start();
-    unsigned int read = soundSource.read(m_NumSamples, pData);
+    unsigned int read = pSoundSource->read(numFingerprintSamples, pData);
 
-    if (read!=m_NumSamples) {
+    if (read!=numFingerprintSamples) {
         qDebug() << "oh that's embarrasing I couldn't read the track";
         return QString();
     }
@@ -48,11 +44,11 @@ QString ChromaPrinter::calcFingerPrint(SoundSourceProxy& soundSource){
 
     ChromaprintContext* ctx = chromaprint_new(CHROMAPRINT_ALGORITHM_DEFAULT);
     // we have 2 channels in mixxx always
-    chromaprint_start(ctx, m_SampleRate, 2);
+    chromaprint_start(ctx, pSoundSource->getSampleRate(), 2);
 
     QTime timerGeneratingFingerPrint;
     timerGeneratingFingerPrint.start();
-    int success = chromaprint_feed(ctx, pData, m_NumSamples);
+    int success = chromaprint_feed(ctx, pData, numFingerprintSamples);
     if (!success) {
         qDebug() << "could not generate fingerprint";
         delete [] pData;

--- a/src/musicbrainz/chromaprinter.h
+++ b/src/musicbrainz/chromaprinter.h
@@ -3,9 +3,8 @@
 
 #include <QObject>
 
+#include "soundsource.h"
 #include "trackinfoobject.h"
-
-class SoundSourceProxy;
 
 class ChromaPrinter: public QObject {
   Q_OBJECT
@@ -16,9 +15,7 @@ class ChromaPrinter: public QObject {
 
   private:
 
-    QString calcFingerPrint(SoundSourceProxy& soundSource);
-    unsigned int m_NumSamples;
-    unsigned int m_SampleRate;
+    QString calcFingerPrint(const Mixxx::SoundSourcePointer& pSoundSource);
 };
 
 #endif //CHROMAPRINTER_H

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -17,18 +17,6 @@
 
 #include <QtDebug>
 
-#include <taglib/attachedpictureframe.h>
-#include <taglib/audioproperties.h>
-#include <taglib/flacpicture.h>
-#include <taglib/id3v1tag.h>
-#include <taglib/id3v2frame.h>
-#include <taglib/id3v2header.h>
-#include <taglib/tag.h>
-#include <taglib/textidentificationframe.h>
-#include <taglib/tmap.h>
-#include <taglib/tstringlist.h>
-#include <taglib/vorbisfile.h>
-#include <taglib/wavpackfile.h>
 
 #include "soundsource.h"
 #include "util/math.h"
@@ -36,607 +24,61 @@
 namespace Mixxx
 {
 
-// static
-const bool SoundSource::s_bDebugMetadata = false;
+namespace
+{
+    const float BPM_ZERO = 0.0f;
+    const float BPM_MIN = 60.0f;
+    const float BPM_MAX = 300.0f;
 
-/*
-   SoundSource is an Uber-class for the reading and decoding of audio-files.
-   Each class must have the following member functions:
-   initializer with a filename
-   seek()
-   read()
-   length()
-   In addition there must be a static member:
-   int ParseHeader(TrackInfoObject *Track)
-   which is used for parsing header information, like trackname,length etc. The
-   return type is int: 0 for OK, -1 for an error.
- */
+    float parseBpmString(const QString& sBpm) {
+        float bpm = sBpm.toFloat();
+        if (bpm < BPM_MIN) {
+            bpm = BPM_ZERO;
+        } else {
+            while(bpm > BPM_MAX) {
+                bpm /= 10.0f;
+            }
+        }
+        return bpm;
+    }
+
+    float parseReplayGainString(QString sReplayGain) {
+        QString ReplayGainstring = sReplayGain.remove( " dB" );
+        float fReplayGain = db2ratio(ReplayGainstring.toFloat());
+        // I found some mp3s of mine with replaygain tag set to 0dB even if not normalized.
+        // This is because of Rapid Evolution 3, I suppose. I prefer to rescan them by setting value to 0 (i.e. rescan via analyserrg)
+        if (fReplayGain == 1.0f) {
+            fReplayGain = 0.0f;
+        }
+        return fReplayGain;
+    }
+
+}
+
 SoundSource::SoundSource(QString qFilename)
         : m_qFilename(qFilename),
-          m_fReplayGain(0.0f),
-          m_fBPM(0.0f),
-          m_iDuration(0),
-          m_iBitrate(0),
+          m_iChannels(0),
           m_iSampleRate(0),
-          m_iChannels(0) {
+          m_fReplayGain(0.0f),
+          m_fBpm(0.0f),
+          m_iBitrate(0),
+          m_iDuration(0) {
 }
 
 SoundSource::~SoundSource() {
 }
 
-QList<long> *SoundSource::getCuePoints()
-{
-    return 0;
-}
-
-QString SoundSource::getFilename()
-{
-    return m_qFilename;
-}
-
-float SoundSource::str2bpm( QString sBpm ) {
-  float bpm = sBpm.toFloat();
-  if(bpm < 60) bpm = 0;
-  while( bpm > 300 ) bpm = bpm / 10.;
-  return bpm;
-}
-
-QString SoundSource::getArtist()
-{
-    return m_sArtist;
-}
-QString SoundSource::getTitle()
-{
-    return m_sTitle;
-}
-QString SoundSource::getAlbum()
-{
-    return m_sAlbum;
-}
-QString SoundSource::getAlbumArtist()
-{
-    return m_sAlbumArtist;
-}
-QString SoundSource::getType()
-{
-    return m_sType;
-}
-QString SoundSource::getComment()
-{
-    return m_sComment;
-}
-QString SoundSource::getYear()
-{
-    return m_sYear;
-}
-QString SoundSource::getGenre()
-{
-    return m_sGenre;
-}
-QString SoundSource::getComposer()
-{
-    return m_sComposer;
-}
-QString SoundSource::getGrouping()
-{
-    return m_sGrouping;
-}
-QString SoundSource::getTrackNumber()
-{
-    return m_sTrackNumber;
-}
-float SoundSource::getReplayGain()
-{
-    return m_fReplayGain;
-}
-float SoundSource::getBPM()
-{
-    return m_fBPM;
-}
-int SoundSource::getDuration()
-{
-    return m_iDuration;
-}
-int SoundSource::getBitrate()
-{
-    return m_iBitrate;
-}
-unsigned int SoundSource::getSampleRate()
-{
-    return m_iSampleRate;
-}
-int SoundSource::getChannels()
-{
-    return m_iChannels;
-}
-
-void SoundSource::setArtist(QString artist)
-{
-    m_sArtist = artist;
-}
-void SoundSource::setTitle(QString title)
-{
-    m_sTitle = title;
-}
-void SoundSource::setAlbumArtist(QString albumArtist)
-{
-    m_sAlbumArtist = albumArtist;
-}
-void SoundSource::setAlbum(QString album)
-{
-    m_sAlbum = album;
-}
-void SoundSource::setComment(QString comment)
-{
-    m_sComment = comment;
-}
-void SoundSource::setType(QString type)
-{
-    m_sType = type;
-}
-void SoundSource::setYear(QString year)
-{
-    m_sYear = year;
-}
-void SoundSource::setGenre(QString genre)
-{
-    m_sGenre = genre;
-}
-void SoundSource::setComposer(QString composer)
-{
-    m_sComposer = composer;
-}
-void SoundSource::setGrouping(QString grouping)
-{
-    m_sGrouping = grouping;
-}
-void SoundSource::setTrackNumber(QString trackNumber)
-{
-    m_sTrackNumber = trackNumber;
-}
-void SoundSource::setReplayGain(float replaygain)
-{
-    m_fReplayGain = replaygain;
-}
-void SoundSource::setBPM(float bpm)
-{
-    m_fBPM = bpm;
-}
-void SoundSource::setDuration(int duration)
-{
-    m_iDuration = duration;
-}
-void SoundSource::setBitrate(int bitrate)
-{
-    m_iBitrate = bitrate;
-}
-void SoundSource::setSampleRate(unsigned int samplerate)
-{
-    m_iSampleRate = samplerate;
-}
-void SoundSource::setChannels(int channels)
-{
-    m_iChannels = channels;
-}
-QString SoundSource::getKey(){
-    return m_sKey;
-}
-void SoundSource::setKey(QString key){
-    m_sKey = key;
-}
-
-QString SoundSource::toQString(TagLib::String tstring) const {
-    if (tstring == TagLib::String::null) {
-        return QString();
-    }
-    return TStringToQString(tstring);
-}
-
-bool SoundSource::processTaglibFile(TagLib::File& f) {
-    if (s_bDebugMetadata)
-        qDebug() << "Parsing" << getFilename();
-
-    if (f.isValid()) {
-        TagLib::Tag *tag = f.tag();
-        if (tag) {
-            QString title = toQString(tag->title());
-            setTitle(title);
-
-            QString artist = toQString(tag->artist());
-            setArtist(artist);
-
-            QString album = toQString(tag->album());
-            setAlbum(album);
-
-            QString comment = toQString(tag->comment());
-            setComment(comment);
-
-            QString genre = toQString(tag->genre());
-            setGenre(genre);
-
-            int iYear = tag->year();
-            QString year = "";
-            if (iYear > 0) {
-                year = QString("%1").arg(iYear);
-                setYear(year);
-            }
-
-            int iTrack = tag->track();
-            QString trackNumber = "";
-            if (iTrack > 0) {
-                trackNumber = QString("%1").arg(iTrack);
-                setTrackNumber(trackNumber);
-            }
-
-            if (s_bDebugMetadata)
-                qDebug() << "TagLib" << "title" << title << "artist" << artist << "album" << album << "comment" << comment << "genre" << genre << "year" << year << "trackNumber" << trackNumber;
-        }
-
-        TagLib::AudioProperties *properties = f.audioProperties();
-        if (properties) {
-            int lengthSeconds = properties->length();
-            int bitrate = properties->bitrate();
-            int sampleRate = properties->sampleRate();
-            int channels = properties->channels();
-
-            if (s_bDebugMetadata)
-                qDebug() << "TagLib" << "length" << lengthSeconds << "bitrate" << bitrate << "sampleRate" << sampleRate << "channels" << channels;
-
-            setDuration(lengthSeconds);
-            setBitrate(bitrate);
-            setSampleRate(sampleRate);
-            setChannels(channels);
-        }
-
-        // If we didn't get any audio properties, this was a failure.
-        return (properties!=NULL);
-    }
-    return false;
-}
-
-void SoundSource::parseReplayGainString (QString sReplayGain) {
-    QString ReplayGainstring = sReplayGain.remove( " dB" );
-    float fReplayGain = db2ratio(ReplayGainstring.toFloat());
-    // I found some mp3s of mine with replaygain tag set to 0dB even if not normalized.
-    // This is because of Rapid Evolution 3, I suppose. I prefer to rescan them by setting value to 0 (i.e. rescan via analyserrg)
-    if (fReplayGain == 1.0f) {
-        fReplayGain = 0.0f;
-    }
-    setReplayGain(fReplayGain);
-}
-
-void SoundSource::processBpmString(QString tagName, QString sBpm) {
-    if (s_bDebugMetadata)
-        qDebug() << tagName << "BPM" << sBpm;
-    if (sBpm.length() > 0) {
-        float fBpm = str2bpm(sBpm);
-        if (fBpm > 0)
-            setBPM(fBpm);
-    }
-}
-
-bool SoundSource::processID3v2Tag(TagLib::ID3v2::Tag* id3v2) {
-
-    // Print every frame in the file.
-    if (s_bDebugMetadata) {
-        TagLib::ID3v2::FrameList::ConstIterator it = id3v2->frameList().begin();
-        for(; it != id3v2->frameList().end(); it++) {
-            qDebug() << "ID3V2" << (*it)->frameID().data() << "-"
-                    << toQString((*it)->toString());
+void SoundSource::setBpmString(QString sBpm) {
+    if (!sBpm.isEmpty()) {
+        float fBpm = parseBpmString(sBpm);
+        if (BPM_ZERO < fBpm) {
+            setBpm(fBpm);
         }
     }
-
-    TagLib::ID3v2::FrameList bpmFrame = id3v2->frameListMap()["TBPM"];
-    if (!bpmFrame.isEmpty()) {
-        QString sBpm = toQString(bpmFrame.front()->toString());
-        processBpmString("ID3v2", sBpm);
-    }
-
-    TagLib::ID3v2::FrameList keyFrame = id3v2->frameListMap()["TKEY"];
-    if (!keyFrame.isEmpty()) {
-        QString sKey = toQString(keyFrame.front()->toString());
-        setKey(sKey);
-    }
-    // Foobar2000-style ID3v2.3.0 tags
-    // TODO: Check if everything is ok.
-    TagLib::ID3v2::FrameList frames = id3v2->frameListMap()["TXXX"];
-    for ( TagLib::ID3v2::FrameList::Iterator it = frames.begin(); it != frames.end(); ++it ) {
-        TagLib::ID3v2::UserTextIdentificationFrame* ReplayGainframe =
-                dynamic_cast<TagLib::ID3v2::UserTextIdentificationFrame*>( *it );
-        if ( ReplayGainframe && ReplayGainframe->fieldList().size() >= 2 )
-        {
-            QString desc = toQString( ReplayGainframe->description() ).toLower();
-            if ( desc == "replaygain_album_gain" ){
-                QString sReplayGain = toQString( ReplayGainframe->fieldList()[1]);
-                parseReplayGainString(sReplayGain);
-            }
-            if ( desc == "replaygain_track_gain" ){
-                QString sReplayGain = toQString( ReplayGainframe->fieldList()[1]);
-                parseReplayGainString(sReplayGain);
-            }
-        }
-    }
-
-    TagLib::ID3v2::FrameList albumArtistFrame = id3v2->frameListMap()["TPE2"];
-    if (!albumArtistFrame.isEmpty()) {
-        QString sAlbumArtist = toQString(albumArtistFrame.front()->toString());
-        setAlbumArtist(sAlbumArtist);
-
-        if (getArtist().length() == 0) {
-           setArtist(sAlbumArtist);
-        }
-    }
-    TagLib::ID3v2::FrameList originalAlbumFrame = id3v2->frameListMap()["TOAL"];
-    if (getAlbum().length() == 0 && !originalAlbumFrame.isEmpty()) {
-        QString sOriginalAlbum = TStringToQString(originalAlbumFrame.front()->toString());
-        setAlbum(sOriginalAlbum);
-    }
-    TagLib::ID3v2::FrameList composerFrame = id3v2->frameListMap()["TCOM"];
-    if (!composerFrame.isEmpty()) {
-        QString sComposer = toQString(composerFrame.front()->toString());
-        setComposer(sComposer);
-    }
-    TagLib::ID3v2::FrameList groupingFrame = id3v2->frameListMap()["TIT1"];
-    if (!groupingFrame.isEmpty()) {
-        QString sGrouping = toQString(groupingFrame.front()->toString());
-        setGrouping(sGrouping);
-    }
-
-    return true;
 }
 
-bool SoundSource::processAPETag(TagLib::APE::Tag* ape) {
-    if (s_bDebugMetadata) {
-        for(TagLib::APE::ItemListMap::ConstIterator it = ape->itemListMap().begin();
-                it != ape->itemListMap().end(); ++it) {
-                qDebug() << "APE" << toQString((*it).first) << "-" << toQString((*it).second.toString());
-        }
-    }
-
-    if (ape->itemListMap().contains("BPM")) {
-        QString sBpm = toQString(ape->itemListMap()["BPM"].toString());
-        processBpmString("APE", sBpm);
-    }
-
-    if (ape->itemListMap().contains("REPLAYGAIN_ALBUM_GAIN")) {
-        QString sReplayGain = toQString(ape->itemListMap()["REPLAYGAIN_ALBUM_GAIN"].toString());
-        parseReplayGainString(sReplayGain);
-    }
-
-    //Prefer track gain over album gain.
-    if (ape->itemListMap().contains("REPLAYGAIN_TRACK_GAIN")) {
-        QString sReplayGain = toQString(ape->itemListMap()["REPLAYGAIN_TRACK_GAIN"].toString());
-        parseReplayGainString(sReplayGain);
-    }
-
-    if (ape->itemListMap().contains("Album Artist")) {
-        m_sAlbumArtist = toQString(ape->itemListMap()["Album Artist"].toString());
-    }
-
-    if (ape->itemListMap().contains("Composer")) {
-        m_sComposer = toQString(ape->itemListMap()["Composer"].toString());
-    }
-
-    if (ape->itemListMap().contains("Grouping")) {
-        m_sGrouping = toQString(ape->itemListMap()["Grouping"].toString());
-    }
-
-    return true;
-}
-
-bool SoundSource::processXiphComment(TagLib::Ogg::XiphComment* xiph) {
-    if (s_bDebugMetadata) {
-        for (TagLib::Ogg::FieldListMap::ConstIterator it = xiph->fieldListMap().begin();
-                it != xiph->fieldListMap().end(); ++it) {
-            qDebug() << "XIPH" << toQString((*it).first) << "-" << toQString((*it).second.toString());
-        }
-    }
-
-    // Some tags use "BPM" so check for that.
-    if (xiph->fieldListMap().contains("BPM")) {
-        TagLib::StringList bpmString = xiph->fieldListMap()["BPM"];
-        QString sBpm = toQString(bpmString.toString());
-        processBpmString("XIPH-BPM", sBpm);
-    }
-
-    // Give preference to the "TEMPO" tag which seems to be more standard
-    if (xiph->fieldListMap().contains("TEMPO")) {
-        TagLib::StringList bpmString = xiph->fieldListMap()["TEMPO"];
-        QString sBpm = toQString(bpmString.toString());
-        processBpmString("XIPH-TEMPO", sBpm);
-    }
-
-    if (xiph->fieldListMap().contains("REPLAYGAIN_ALBUM_GAIN")) {
-        TagLib::StringList rgainString = xiph->fieldListMap()["REPLAYGAIN_ALBUM_GAIN"];
-        QString sReplayGain = toQString(rgainString.toString());
-        parseReplayGainString(sReplayGain);
-    }
-
-    if (xiph->fieldListMap().contains("REPLAYGAIN_TRACK_GAIN")) {
-        TagLib::StringList rgainString = xiph->fieldListMap()["REPLAYGAIN_TRACK_GAIN"];
-        QString sReplayGain = toQString(rgainString.toString());
-        parseReplayGainString(sReplayGain);
-    }
-
-    /*
-     * Reading key code information
-     * Unlike, ID3 tags, there's no standard or recommendation on how to store 'key' code
-     *
-     * Luckily, there are only a few tools for that, e.g., Rapid Evolution (RE).
-     * Assuming no distinction between start and end key, RE uses a "INITIALKEY"
-     * or a "KEY" vorbis comment.
-     */
-    if (xiph->fieldListMap().contains("KEY")) {
-        TagLib::StringList keyStr = xiph->fieldListMap()["KEY"];
-        QString key = toQString(keyStr.toString());
-        setKey(key);
-    }
-    if (getKey().isEmpty() && xiph->fieldListMap().contains("INITIALKEY")) {
-        TagLib::StringList keyStr = xiph->fieldListMap()["INITIALKEY"];
-        QString key = toQString(keyStr.toString());
-        setKey(key);
-    }
-
-    if (xiph->fieldListMap().contains("ALBUMARTIST")) {
-        TagLib::StringList albumArtistString = xiph->fieldListMap()["ALBUMARTIST"];
-        m_sAlbumArtist = toQString(albumArtistString.toString());
-    } else {
-        // try alternative field name
-        if (xiph->fieldListMap().contains("ALBUM_ARTIST")) {
-            TagLib::StringList albumArtistString = xiph->fieldListMap()["ALBUM_ARTIST"];
-            m_sAlbumArtist = toQString(albumArtistString.toString());
-        }
-    }
-
-    if (xiph->fieldListMap().contains("COMPOSER")) {
-        TagLib::StringList composerString = xiph->fieldListMap()["COMPOSER"];
-        m_sComposer = toQString(composerString.toString());
-    }
-
-    if (xiph->fieldListMap().contains("GROUPING")) {
-        TagLib::StringList groupingString = xiph->fieldListMap()["GROUPING"];
-        m_sGrouping = toQString(groupingString.toString());
-    }
-
-    return true;
-}
-
-bool SoundSource::processMP4Tag(TagLib::MP4::Tag* mp4) {
-    if (s_bDebugMetadata) {
-        for(TagLib::MP4::ItemListMap::ConstIterator it = mp4->itemListMap().begin();
-            it != mp4->itemListMap().end(); ++it) {
-            qDebug() << "MP4" << toQString((*it).first) << "-"
-                     << toQString((*it).second.toStringList().toString());
-        }
-    }
-
-    // Get BPM
-    if (mp4->itemListMap().contains("tmpo")) {
-        QString sBpm = toQString(
-            mp4->itemListMap()["tmpo"].toStringList().toString());
-        processBpmString("MP4", sBpm);
-    } else if (mp4->itemListMap().contains("----:com.apple.iTunes:BPM")) {
-        // This is an alternate way of storing BPM.
-        QString sBpm = toQString(mp4->itemListMap()[
-            "----:com.apple.iTunes:BPM"].toStringList().toString());
-        processBpmString("MP4", sBpm);
-    }
-
-    // Get Album Artist
-    if (mp4->itemListMap().contains("aART")) {
-        // this is technically a list of values -> concatenate into single string
-        QString albumArtist = toQString(
-            mp4->itemListMap()["aART"].toStringList().toString());
-        setAlbumArtist(albumArtist);
-    }
-
-    // Get Composer
-    if (mp4->itemListMap().contains("\251wrt")) {
-        // rryan 1/2012 I believe this is technically a list of composers. We
-        // don't support multiple composers in Mixxx, so just use them joined.
-        QString composer = toQString(
-            mp4->itemListMap()["\251wrt"].toStringList().toString());
-        setComposer(composer);
-    }
-
-    // Get Grouping
-    if (mp4->itemListMap().contains("\251grp")) {
-        QString grouping = toQString(
-            mp4->itemListMap()["\251grp"].toStringList().toString());
-        setGrouping(grouping);
-    }
-
-    // Get KEY (conforms to Rapid Evolution)
-    if (mp4->itemListMap().contains("----:com.apple.iTunes:KEY")) {
-        QString key = toQString(
-            mp4->itemListMap()["----:com.apple.iTunes:KEY"].toStringList().toString());
-        setKey(key);
-    }
-
-    // Apparently iTunes stores replaygain in this property.
-    if (mp4->itemListMap().contains(
-        "----:com.apple.iTunes:replaygain_track_gain")) {
-        // TODO(XXX) find tracks with this property and check what it looks
-        // like.
-
-        //QString replaygain = toQString(mp4->itemListMap()["----:com.apple.iTunes:replaygain_track_gain"].toStringList().toString());
-    }
-
-    return true;
-}
-
-QImage SoundSource::getCoverInID3v2Tag(TagLib::ID3v2::Tag *id3v2) {
-    if (!id3v2) {
-        return QImage();
-    }
-
-    QImage coverArt;
-    TagLib::ID3v2::FrameList covertArtFrame = id3v2->frameListMap()["APIC"];
-    if (!covertArtFrame.isEmpty()) {
-        TagLib::ID3v2::AttachedPictureFrame* picframe = static_cast
-                <TagLib::ID3v2::AttachedPictureFrame*>(covertArtFrame.front());
-        TagLib::ByteVector data = picframe->picture();
-        coverArt = QImage::fromData(
-            reinterpret_cast<const uchar *>(data.data()), data.size());
-    }
-    return coverArt;
-}
-
-QImage SoundSource::getCoverInAPETag(TagLib::APE::Tag *ape) {
-    if (!ape) {
-        return QImage();
-    }
-
-    QImage coverArt;
-    if (ape->itemListMap().contains("COVER ART (FRONT)"))
-    {
-        const TagLib::ByteVector nullStringTerminator(1, 0);
-        TagLib::ByteVector item = ape->itemListMap()["COVER ART (FRONT)"].value();
-        int pos = item.find(nullStringTerminator);	// skip the filename
-        if (++pos > 0) {
-            const TagLib::ByteVector& data = item.mid(pos);
-            coverArt = QImage::fromData(
-                reinterpret_cast<const uchar *>(data.data()), data.size());
-        }
-    }
-    return coverArt;
-}
-
-QImage SoundSource::getCoverInXiphComment(TagLib::Ogg::XiphComment *xiph) {
-    if (!xiph) {
-        return QImage();
-    }
-
-    QImage coverArt;
-    if (xiph->fieldListMap().contains("METADATA_BLOCK_PICTURE")) {
-        QByteArray data(QByteArray::fromBase64(
-            xiph->fieldListMap()["METADATA_BLOCK_PICTURE"].front().toCString()));
-        TagLib::ByteVector tdata(data.data(), data.size());
-        TagLib::FLAC::Picture p(tdata);
-        data = QByteArray(p.data().data(), p.data().size());
-        coverArt = QImage::fromData(data);
-    } else if (xiph->fieldListMap().contains("COVERART")) {
-        QByteArray data(QByteArray::fromBase64(
-            xiph->fieldListMap()["COVERART"].toString().toCString()));
-        coverArt = QImage::fromData(data);
-    }
-    return coverArt;
-}
-
-QImage SoundSource::getCoverInMP4Tag(TagLib::MP4::Tag *mp4) {
-    if (!mp4) {
-        return QImage();
-    }
-
-    QImage coverArt;
-    if (mp4->itemListMap().contains("covr")) {
-        TagLib::MP4::CoverArtList coverArtList = mp4->itemListMap()["covr"]
-                                                        .toCoverArtList();
-        TagLib::ByteVector data = coverArtList.front().data();
-        coverArt = QImage::fromData(
-            reinterpret_cast<const uchar *>(data.data()), data.size());
-    }
-    return coverArt;
+void SoundSource::setReplayGainString(QString sReplayGain) {
+    setReplayGain(parseReplayGainString(sReplayGain));
 }
 
 } //namespace Mixxx

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -27,17 +27,12 @@ namespace Mixxx
 namespace
 {
     const float BPM_ZERO = 0.0f;
-    const float BPM_MIN = 60.0f;
     const float BPM_MAX = 300.0f;
 
     float parseBpmString(const QString& sBpm) {
         float bpm = sBpm.toFloat();
-        if (bpm < BPM_MIN) {
-            bpm = BPM_ZERO;
-        } else {
-            while(bpm > BPM_MAX) {
-                bpm /= 10.0f;
-            }
+        while(bpm > BPM_MAX) {
+            bpm /= 10.0f;
         }
         return bpm;
     }
@@ -60,7 +55,7 @@ SoundSource::SoundSource(QString qFilename)
           m_iChannels(0),
           m_iSampleRate(0),
           m_fReplayGain(0.0f),
-          m_fBpm(0.0f),
+          m_fBpm(BPM_ZERO),
           m_iBitrate(0),
           m_iDuration(0) {
 }

--- a/src/soundsource.h
+++ b/src/soundsource.h
@@ -18,9 +18,6 @@
 #ifndef SOUNDSOURCE_H
 #define SOUNDSOURCE_H
 
-#include <QImage>
-#include <QString>
-
 #include <taglib/tfile.h>
 #include <taglib/apetag.h>
 #include <taglib/id3v2tag.h>
@@ -29,6 +26,10 @@
 
 #include "util/types.h"
 #include "util/defs.h"
+
+#include <QImage>
+#include <QString>
+#include <QSharedPointer>
 
 #define MIXXX_SOUNDSOURCE_API_VERSION 6
 /** @note SoundSource API Version history:
@@ -165,6 +166,9 @@ protected:
 
     static const bool s_bDebugMetadata;
 };
+
+typedef QSharedPointer<SoundSource> SoundSourcePointer;
+
 } //namespace Mixxx
 
 #endif

--- a/src/soundsource.h
+++ b/src/soundsource.h
@@ -18,12 +18,6 @@
 #ifndef SOUNDSOURCE_H
 #define SOUNDSOURCE_H
 
-#include <taglib/tfile.h>
-#include <taglib/apetag.h>
-#include <taglib/id3v2tag.h>
-#include <taglib/xiphcomment.h>
-#include <taglib/mp4tag.h>
-
 #include "util/types.h"
 #include "util/defs.h"
 
@@ -60,111 +54,163 @@ namespace Mixxx
 class SoundSource
 {
 public:
-    SoundSource(QString qFilename);
     virtual ~SoundSource();
+
     virtual Result open() = 0;
     virtual long seek(long) = 0;
     virtual unsigned read(unsigned long size, const SAMPLE*) = 0;
     virtual long unsigned length() = 0;
-    static float str2bpm( QString sBpm );
     virtual Result parseHeader() = 0;
 
     // Returns the first cover art image embedded within the file (if any).
     virtual QImage parseCoverArt() = 0;
 
-    //static QList<QString> supportedFileExtensions(); //CRAP can't do this!
-    /** Return a list of cue points stored in the file */
-    virtual QList<long> *getCuePoints();
-    /** Returns filename */
-    virtual QString getFilename();
-    /** Return artist name */
-    virtual QString getArtist();
-    /** Return track title */
-    virtual QString getTitle();
-    virtual QString getAlbum();
-    virtual QString getAlbumArtist();
-    virtual QString getType();
-    virtual QString getComment();
-    virtual QString getYear();
-    virtual QString getGenre();
-    virtual QString getComposer();
-    virtual QString getGrouping();
-    virtual QString getTrackNumber();
-    virtual float getReplayGain();
-    virtual QString getKey();
-    virtual float getBPM();
-    virtual int getDuration();
-    virtual int getBitrate();
-    virtual unsigned int getSampleRate();
-    virtual int getChannels();
+    inline const QString& getType() const {
+        return m_sType;
+    }
+    inline const QString& getFilename() const {
+        return m_qFilename;
+    }
+    inline const QString& getArtist() const {
+        return m_sArtist;
+    }
+    inline const QString& getTitle() const {
+        return m_sTitle;
+    }
+    inline const QString& getAlbum() const {
+        return m_sAlbum;
+    }
+    inline const QString& getAlbumArtist() const {
+        return m_sAlbumArtist;
+    }
+    inline const QString& getComment() const {
+        return m_sComment;
+    }
+    inline const QString& getYear() const {
+        return m_sYear;
+    }
+    inline const QString& getGenre() const {
+        return m_sGenre;
+    }
+    inline const QString& getComposer() const {
+        return m_sComposer;
+    }
+    inline const QString& getGrouping() const {
+        return m_sGrouping;
+    }
+    inline const QString& getTrackNumber() const {
+        return m_sTrackNumber;
+    }
+    inline float getReplayGain() const {
+        return m_fReplayGain;
+    }
+    inline const QString& getKey() const {
+        return m_sKey;
+    }
+    inline float getBPM() const {
+        return m_fBpm;
+    }
+    inline int getBitrate() const {
+        return m_iBitrate;
+    }
+    inline int getDuration() const {
+        return m_iDuration;
+    }
 
-    virtual void setArtist(QString);
-    virtual void setTitle(QString);
-    virtual void setAlbum(QString);
-    virtual void setAlbumArtist(QString);
-    virtual void setType(QString);
-    virtual void setComment(QString);
-    virtual void setYear(QString);
-    virtual void setGenre(QString);
-    virtual void setComposer(QString);
-    virtual void setGrouping(QString);
-    virtual void setTrackNumber(QString);
-    virtual void setReplayGain(float);
-    virtual void setKey(QString);
-    virtual void setBPM(float);
-    virtual void setDuration(int);
-    virtual void setBitrate(int);
-    virtual void setSampleRate(unsigned int);
-    virtual void setChannels(int);
+    inline void setArtist(QString artist) {
+        m_sArtist = artist;
+    }
+    inline void setTitle(QString title) {
+        m_sTitle = title;
+    }
+    inline void setAlbum(QString album) {
+        m_sAlbum = album;
+    }
+    inline void setAlbumArtist(QString albumArtist) {
+        m_sAlbumArtist = albumArtist;
+    }
+    inline void setComment(QString comment) {
+        m_sComment = comment;
+    }
+    inline void setYear(QString year) {
+        m_sYear = year;
+    }
+    inline void setGenre(QString genre) {
+        m_sGenre = genre;
+    }
+    inline void setComposer(QString composer) {
+        m_sComposer = composer;
+    }
+    inline void setGrouping(QString grouping) {
+        m_sGrouping = grouping;
+    }
+    inline void setTrackNumber(QString trackNumber) {
+        m_sTrackNumber = trackNumber;
+    }
+    inline void setKey(QString key){
+        m_sKey = key;
+    }
+    inline void setBpm(float bpm) {
+        m_fBpm = bpm;
+    }
+    void setBpmString(QString sBpm);
+    inline void setReplayGain(float replayGain) {
+        m_fReplayGain = replayGain;
+    }
+    void setReplayGainString(QString sReplayGain);
+
+    inline void setChannels(int channels) {
+        m_iChannels = channels;
+    }
+    inline void setSampleRate(unsigned int sampleRate) {
+        m_iSampleRate = sampleRate;
+    }
+    inline void setBitrate(int bitrate) {
+        m_iBitrate = bitrate;
+    }
+    inline void setDuration(int duration) {
+        m_iDuration = duration;
+    }
+
+    inline int getChannels() const {
+        return m_iChannels;
+    }
+    inline unsigned int getSampleRate() const {
+        return m_iSampleRate;
+    }
 
 protected:
-    // Automatically collects generic data from a TagLib File: title, artist,
-    // album, comment, genre, year, tracknumber, duration, bitrate, samplerate,
-    // and channels.
-    bool processTaglibFile(TagLib::File& f);
-    bool processID3v2Tag(TagLib::ID3v2::Tag* id3v2);
-    bool processAPETag(TagLib::APE::Tag* ape);
-    bool processXiphComment(TagLib::Ogg::XiphComment* xiph);
-    bool processMP4Tag(TagLib::MP4::Tag* mp4);
-    void processBpmString(QString tagName, QString sBpm);
-    void parseReplayGainString(QString sReplayGain);
+    explicit SoundSource(QString qFilename);
 
-    // In order to avoid processing images when it's not
-    // needed (TIO building), we must process it separately.
-    QImage getCoverInID3v2Tag(TagLib::ID3v2::Tag* id3v2);
-    QImage getCoverInAPETag(TagLib::APE::Tag* ape);
-    QImage getCoverInXiphComment(TagLib::Ogg::XiphComment* xiph);
-    QImage getCoverInMP4Tag(TagLib::MP4::Tag* mp4);
+    inline void setType(QString type) {
+        m_sType = type;
+    }
 
-    // Taglib strings can be NULL and using it could cause some segfaults,
-    // so in this case it will return a QString()
-    QString toQString(TagLib::String tstring) const;
+private:
+    const QString m_qFilename;
 
-    /** File name */
-    QString m_qFilename;
-
+    QString m_sType;
     QString m_sArtist;
     QString m_sTitle;
     QString m_sAlbum;
     QString m_sAlbumArtist;
-    QString m_sType;
     QString m_sComment;
     QString m_sYear;
     QString m_sGenre;
     QString m_sComposer;
     QString m_sGrouping;
     QString m_sTrackNumber;
-    float m_fReplayGain;
     QString m_sKey;
-    float m_fBPM;
-    int m_iDuration;
-    int m_iBitrate;
-    /** Sample rate of the file */
-    unsigned int m_iSampleRate;
-    int m_iChannels;
-    //Dontcha be forgettin' to initialize these variables.... arr
 
-    static const bool s_bDebugMetadata;
+    // The following members need to be initialized
+    // explicitly in the constructor! Otherwise their
+    // value is undefined.
+    int m_iChannels;
+    unsigned int m_iSampleRate;
+    float m_fReplayGain;
+    float m_fBpm;
+    int m_iBitrate;
+    int m_iDuration;
 };
 
 typedef QSharedPointer<SoundSource> SoundSourcePointer;

--- a/src/soundsourcecoreaudio.cpp
+++ b/src/soundsourcecoreaudio.cpp
@@ -141,7 +141,7 @@ long SoundSourceCoreAudio::seek(long filepos) {
 
     //err = ExtAudioFileSeek(m_audioFile, filepos / 2);
     if (err != noErr) {
-        qDebug() << "SSCA: Error seeking to" << filepos << " (file " << m_qFilename << ")";// << GetMacOSStatusErrorString(err) << GetMacOSStatusCommentString(err);
+        qDebug() << "SSCA: Error seeking to" << filepos << " (file " << getFilename() << ")";// << GetMacOSStatusErrorString(err) << GetMacOSStatusCommentString(err);
     }
     return filepos;
 }

--- a/src/soundsourcecoreaudio.cpp
+++ b/src/soundsourcecoreaudio.cpp
@@ -18,10 +18,11 @@
 #include <taglib/mp4file.h>
 
 #include "soundsourcecoreaudio.h"
+#include "soundsourcetaglib.h"
 #include "util/math.h"
 
 SoundSourceCoreAudio::SoundSourceCoreAudio(QString filename)
-        : Mixxx::SoundSource(filename),
+        : SoundSource(filename),
           m_samples(0),
           m_headerFrames(0) {
 }
@@ -37,7 +38,7 @@ Result SoundSourceCoreAudio::open() {
 
     /** This code blocks works with OS X 10.5+ only. DO NOT DELETE IT for now. */
     CFStringRef urlStr = CFStringCreateWithCharacters(
-        0, reinterpret_cast<const UniChar *>(m_qFilename.unicode()), m_qFilename.size());
+        0, reinterpret_cast<const UniChar *>(getFilename().unicode()), getFilename().size());
     CFURLRef urlRef = CFURLCreateWithFileSystemPath(NULL, urlStr, kCFURLPOSIXPathStyle, false);
     err = ExtAudioFileOpenURL(urlRef, &m_audioFile);
     CFRelease(urlStr);
@@ -52,7 +53,7 @@ Result SoundSourceCoreAudio::open() {
     */
 
     if (err != noErr) {
-        qDebug() << "SSCA: Error opening file " << m_qFilename;
+        qDebug() << "SSCA: Error opening file " << getFilename();
         return ERR;
     }
 
@@ -62,7 +63,7 @@ Result SoundSourceCoreAudio::open() {
     m_inputFormat = inputFormat;
     err = ExtAudioFileGetProperty(m_audioFile, kExtAudioFileProperty_FileDataFormat, &size, &inputFormat);
     if (err != noErr) {
-        qDebug() << "SSCA: Error getting file format (" << m_qFilename << ")";
+        qDebug() << "SSCA: Error getting file format (" << getFilename() << ")";
         return ERR;
     }
 
@@ -83,8 +84,7 @@ Result SoundSourceCoreAudio::open() {
         return ERR;
     }
 
-    // Set m_iChannels and m_samples.
-    m_iChannels = m_outputFormat.NumberChannels();
+    setChannels(m_outputFormat.NumberChannels());
 
     //get the total length in frames of the audio file - copypasta: http://discussions.apple.com/thread.jspa?threadID=2364583&tstart=47
     UInt32        dataSize;
@@ -114,10 +114,10 @@ Result SoundSourceCoreAudio::open() {
         m_headerFrames=primeInfo.leadingFrames;
     }
 
-    m_samples = (totalFrameCount/*-m_headerFrames*/)*m_iChannels;
-    m_iDuration = m_samples / (inputFormat.mSampleRate * m_iChannels);
-    m_iSampleRate = inputFormat.mSampleRate;
-    qDebug() << m_samples << totalFrameCount << m_iChannels;
+    m_samples = (totalFrameCount/* - m_headerFrames*/) * getChannels();
+    setDuration(m_samples / (inputFormat.mSampleRate * getChannels()));
+    setSampleRate(inputFormat.mSampleRate);
+    qDebug() << m_samples << totalFrameCount << getChannels();
 
     //Seek to position 0, which forces us to skip over all the header frames.
     //This makes sure we're ready to just let the Analyser rip and it'll
@@ -185,45 +185,55 @@ inline unsigned long SoundSourceCoreAudio::length() {
 }
 
 Result SoundSourceCoreAudio::parseHeader() {
-    if (getFilename().endsWith(".m4a"))
+    if (getFilename().endsWith(".m4a")) {
         setType("m4a");
-    else if (getFilename().endsWith(".mp3"))
-        setType("mp3");
-    else if (getFilename().endsWith(".mp2"))
-        setType("mp2");
-
-    bool result = false;
-
-    if (getType() == "m4a") {
         TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
-        result = processTaglibFile(f);
-        TagLib::MP4::Tag* tag = f.tag();
-        if (tag) {
-            processMP4Tag(tag);
+        if (!readFileHeader(this, f)) {
+            return ERR;
         }
-    } else if (getType() == "mp3") {
-        // No need for toLocal8Bit on Windows since CoreAudio is OS X only.
+        TagLib::MP4::Tag *mp4(f.tag());
+        if (mp4) {
+            readMP4Tag(this, *mp4);
+        } else {
+            // fallback
+            const TagLib::Tag *tag(f.tag());
+            if (tag) {
+                readTag(this, *tag);
+            } else {
+                return ERR;
+            }
+        }
+    } else if (getFilename().endsWith(".mp3")) {
+        setType("mp3");
         TagLib::MPEG::File f(getFilename().toLocal8Bit().constData());
-
-        // Takes care of all the default metadata
-        result = processTaglibFile(f);
-
-        // Now look for MP3 specific metadata (e.g. BPM)
+        if (!readFileHeader(this, f)) {
+            return ERR;
+        }
         TagLib::ID3v2::Tag* id3v2 = f.ID3v2Tag();
         if (id3v2) {
-            processID3v2Tag(id3v2);
+            readID3v2Tag(this, *id3v2);
+        } else {
+            TagLib::APE::Tag *ape = f.APETag();
+            if (ape) {
+                readAPETag(this, *ape);
+            } else {
+                // fallback
+                const TagLib::Tag *tag(f.tag());
+                if (tag) {
+                    readTag(this, *tag);
+                } else {
+                    return ERR;
+                }
+            }
         }
-
-        TagLib::APE::Tag *ape = f.APETag();
-        if (ape) {
-            processAPETag(ape);
-        }
-    } else if (getType() == "mp2") {
+    } else if (getFilename().endsWith(".mp2")) {
+        setType("mp2");
         //TODO: MP2 metadata. Does anyone use mp2 files anymore?
         //      Feels like 1995 again...
+        return ERR;
     }
 
-    return result ? OK : ERR;
+    return OK;
 }
 
 QImage SoundSourceCoreAudio::parseCoverArt() {
@@ -231,14 +241,26 @@ QImage SoundSourceCoreAudio::parseCoverArt() {
     if (getFilename().endsWith(".m4a")) {
         setType("m4a");
         TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
-        coverArt = getCoverInMP4Tag(f.tag());
+        TagLib::MP4::Tag *mp4(f.tag());
+        if (mp4) {
+            return Mixxx::getCoverInMP4Tag(*mp4);
+        } else {
+            return QImage();
+        }
     } else if (getFilename().endsWith(".mp3")) {
         setType("mp3");
         TagLib::MPEG::File f(getFilename().toLocal8Bit().constData());
-        coverArt = getCoverInID3v2Tag(f.ID3v2Tag());
-        if (coverArt.isNull()) {
-            coverArt = getCoverInAPETag(f.APETag());
+        TagLib::ID3v2::Tag* id3v2 = f.ID3v2Tag();
+        if (id3v2) {
+            coverArt = Mixxx::getCoverInID3v2Tag(*id3v2);
         }
+        if (coverArt.isNull()) {
+            TagLib::APE::Tag *ape = f.APETag();
+            if (ape) {
+                coverArt = Mixxx::getCoverInAPETag(*ape);
+            }
+        }
+        return coverArt;
     }
     return coverArt;
 }

--- a/src/soundsourcecoreaudio.h
+++ b/src/soundsourcecoreaudio.h
@@ -43,7 +43,7 @@
 
 class SoundSourceCoreAudio : public Mixxx::SoundSource {
 public:
-    SoundSourceCoreAudio(QString filename);
+    explicit SoundSourceCoreAudio(QString filename);
     ~SoundSourceCoreAudio();
     Result open();
     long seek(long filepos);

--- a/src/soundsourceffmpeg.h
+++ b/src/soundsourceffmpeg.h
@@ -91,16 +91,15 @@ protected:
 
 private:
     int m_iAudioStream;
-    quint64 filelength;
-    QString m_qFilename;
+    quint64 m_filelength;
     AVFormatContext *m_pFormatCtx;
     AVInputFormat *m_pIformat;
     AVCodecContext *m_pCodecCtx;
     AVCodec *m_pCodec;
 
-    qint64 m_iCurrentMixxTs;
-
     EncoderFfmpegResample *m_pResample;
+
+    qint64 m_iCurrentMixxTs;
 
     bool m_bIsSeeked;
 

--- a/src/soundsourceffmpeg.h
+++ b/src/soundsourceffmpeg.h
@@ -65,7 +65,7 @@ struct ffmpegCacheObject {
 
 class SoundSourceFFmpeg : public Mixxx::SoundSource {
 public:
-    SoundSourceFFmpeg(QString qFilename);
+    explicit SoundSourceFFmpeg(QString qFilename);
     ~SoundSourceFFmpeg();
     Result open();
     long seek(long);

--- a/src/soundsourceflac.cpp
+++ b/src/soundsourceflac.cpp
@@ -13,11 +13,14 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <cstring> // memcpy
-#include <QtDebug>
+#include "soundsourceflac.h"
+#include "soundsourcetaglib.h"
+
 #include <taglib/flacfile.h>
 
-#include "soundsourceflac.h"
+#include <QtDebug>
+
+#include <cstring> // memcpy
 
 SoundSourceFLAC::SoundSourceFLAC(QString filename)
     : Mixxx::SoundSource(filename)
@@ -95,7 +98,7 @@ decoderError:
     FLAC__stream_decoder_delete(m_decoder);
     m_decoder = NULL;
 
-    qWarning() << "SSFLAC: Decoder error at file" << m_qFilename;
+    qWarning() << "SSFLAC: Decoder error at file" << getFilename();
     return ERR;
 }
 
@@ -107,7 +110,7 @@ long SoundSourceFLAC::seek(long filepos) {
     // -- bkgood
     bool result = FLAC__stream_decoder_seek_absolute(m_decoder, filepos / 2);
     if (!result)
-        qWarning() << "SSFLAC: Seeking error at file" << m_qFilename;
+        qWarning() << "SSFLAC: Seeking error at file" << getFilename();
     m_leftoverBufferLength = 0; // clear internal buffer since we moved
     return filepos;
 }
@@ -123,7 +126,7 @@ unsigned int SoundSourceFLAC::read(unsigned long size, const SAMPLE *destination
         if (m_flacBufferLength == 0) {
             i = 0;
             if (!FLAC__stream_decoder_process_single(m_decoder)) {
-                qWarning() << "SSFLAC: decoder_process_single returned false (" << m_qFilename << ")";
+                qWarning() << "SSFLAC: decoder_process_single returned false (" << getFilename() << ")";
                 break;
             } else if (m_flacBufferLength == 0) {
                 // EOF
@@ -152,37 +155,55 @@ inline unsigned long SoundSourceFLAC::length() {
 }
 
 Result SoundSourceFLAC::parseHeader() {
-    setType("flac");
-    QByteArray qBAFilename = m_qFilename.toLocal8Bit();
+    const QByteArray qBAFilename(getFilename().toLocal8Bit());
     TagLib::FLAC::File f(qBAFilename.constData());
-    bool result = processTaglibFile(f);
-    TagLib::ID3v2::Tag *id3v2(f.ID3v2Tag());
-    TagLib::Ogg::XiphComment *xiph(f.xiphComment());
-    if (id3v2) {
-        processID3v2Tag(id3v2);
-    }
-    if (xiph) {
-        processXiphComment(xiph);
+
+    if (!readFileHeader(this, f)) {
+        return ERR;
     }
 
-    return result ? OK : ERR;
+    TagLib::Ogg::XiphComment *xiph(f.xiphComment());
+    if (xiph) {
+        readXiphComment(this, *xiph);
+    } else {
+        TagLib::ID3v2::Tag *id3v2(f.ID3v2Tag());
+        if (id3v2) {
+            readID3v2Tag(this, *id3v2);
+        } else {
+            // fallback
+            const TagLib::Tag *tag(f.tag());
+            if (tag) {
+                readTag(this, *tag);
+            } else {
+                return ERR;
+            }
+        }
+    }
+
+    return OK;
 }
 
 QImage SoundSourceFLAC::parseCoverArt() {
+    const QByteArray qBAFilename(getFilename().toLocal8Bit());
+    TagLib::FLAC::File f(qBAFilename.constData());
     QImage coverArt;
-    setType("flac");
-    TagLib::FLAC::File f(m_qFilename.toLocal8Bit().constData());
-    coverArt = getCoverInID3v2Tag(f.ID3v2Tag());
-    if (coverArt.isNull()) {
-        coverArt = getCoverInXiphComment(f.xiphComment());
+    TagLib::Ogg::XiphComment *xiph(f.xiphComment());
+    if (xiph) {
+        coverArt = Mixxx::getCoverInXiphComment(*xiph);
     }
     if (coverArt.isNull()) {
-        TagLib::List<TagLib::FLAC::Picture*> covers = f.pictureList();
-        if (!covers.isEmpty()) {
-            std::list<TagLib::FLAC::Picture*>::iterator it = covers.begin();
-            TagLib::FLAC::Picture* cover = *it;
-            coverArt = QImage::fromData(
-                QByteArray(cover->data().data(), cover->data().size()));
+        TagLib::ID3v2::Tag *id3v2(f.ID3v2Tag());
+        if (id3v2) {
+            coverArt = Mixxx::getCoverInID3v2Tag(*id3v2);
+        }
+        if (coverArt.isNull()) {
+            TagLib::List<TagLib::FLAC::Picture*> covers = f.pictureList();
+            if (!covers.isEmpty()) {
+                std::list<TagLib::FLAC::Picture*>::iterator it = covers.begin();
+                TagLib::FLAC::Picture* cover = *it;
+                coverArt = QImage::fromData(
+                        QByteArray(cover->data().data(), cover->data().size()));
+            }
         }
     }
     return coverArt;
@@ -237,7 +258,7 @@ FLAC__StreamDecoderSeekStatus SoundSourceFLAC::flacSeek(FLAC__uint64 offset) {
     if (m_file.seek(offset)) {
         return FLAC__STREAM_DECODER_SEEK_STATUS_OK;
     } else {
-        qWarning() << "SSFLAC: An unrecoverable error occurred (" << m_qFilename << ")";
+        qWarning() << "SSFLAC: An unrecoverable error occurred (" << getFilename() << ")";
         return FLAC__STREAM_DECODER_SEEK_STATUS_ERROR;
     }
 }
@@ -289,14 +310,14 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata *metadata) {
     switch (metadata->type) {
     case FLAC__METADATA_TYPE_STREAMINFO:
         m_samples = metadata->data.stream_info.total_samples;
-        m_iChannels = metadata->data.stream_info.channels;
-        m_iSampleRate = metadata->data.stream_info.sample_rate;
+        setChannels(metadata->data.stream_info.channels);
+        setSampleRate(metadata->data.stream_info.sample_rate);
         m_bps = metadata->data.stream_info.bits_per_sample;
         m_minBlocksize = metadata->data.stream_info.min_blocksize;
         m_maxBlocksize = metadata->data.stream_info.max_blocksize;
         m_minFramesize = metadata->data.stream_info.min_framesize;
         m_maxFramesize = metadata->data.stream_info.max_framesize;
-//        qDebug() << "FLAC file " << m_qFilename;
+//        qDebug() << "FLAC file " << getFilename();
 //        qDebug() << m_iChannels << " @ " << m_iSampleRate << " Hz, " << m_samples
 //            << " total, " << m_bps << " bps";
 //        qDebug() << "Blocksize in [" << m_minBlocksize << ", " << m_maxBlocksize
@@ -326,7 +347,7 @@ void SoundSourceFLAC::flacError(FLAC__StreamDecoderErrorStatus status) {
         break;
     }
     qWarning() << "SSFLAC got error" << error << "from libFLAC for file"
-        << m_qFilename;
+        << getFilename();
     // not much else to do here... whatever function that initiated whatever
     // decoder method resulted in this error will return an error, and the caller
     // will bail. libFLAC docs say to not close the decoder here -- bkgood

--- a/src/soundsourceflac.h
+++ b/src/soundsourceflac.h
@@ -29,7 +29,6 @@
 
 class SoundSourceFLAC : public Mixxx::SoundSource {
 public:
-    SoundSourceFLAC(QString filename);
     ~SoundSourceFLAC();
     Result open();
     long seek(long filepos);
@@ -38,6 +37,7 @@ public:
     Result parseHeader();
     QImage parseCoverArt();
     static QList<QString> supportedFileExtensions();
+    explicit SoundSourceFLAC(QString filename);
     // callback methods
     FLAC__StreamDecoderReadStatus flacRead(FLAC__byte buffer[], size_t *bytes);
     FLAC__StreamDecoderSeekStatus flacSeek(FLAC__uint64 offset);

--- a/src/soundsourcemodplug.cpp
+++ b/src/soundsourcemodplug.cpp
@@ -22,10 +22,10 @@ SoundSourceModPlug::SoundSourceModPlug(QString qFilename) :
     m_fileLength = 0;
     m_pModFile = 0;
 
-    qDebug() << "[ModPlug] Loading ModPlug module " << m_qFilename;
+    qDebug() << "[ModPlug] Loading ModPlug module " << getFilename();
 
     // read module file to byte array
-    QFile modFile(m_qFilename);
+    QFile modFile(getFilename());
     modFile.open(QIODevice::ReadOnly);
     m_fileBuf = modFile.readAll();
     modFile.close();
@@ -76,7 +76,7 @@ Result SoundSourceModPlug::open() {
         // an error occured
         t.cancel();
         qDebug() << "[ModPlug] Could not load module file: "
-                 << m_qFilename;
+                 << getFilename();
         return ERR;
     }
 
@@ -122,7 +122,7 @@ Result SoundSourceModPlug::open() {
     // We count the number of samples by dividing number of
     // bytes in m_sampleBuf by 2 (bytes per sample).
     m_fileLength = m_sampleBuf.length() >> 1;
-    m_iSampleRate = 44100; // ModPlug always uses 44.1kHz
+    setSampleRate(44100); // ModPlug always uses 44.1kHz
     m_opened = true;
     m_seekPos = 0;
     return OK;
@@ -153,7 +153,7 @@ unsigned SoundSourceModPlug::read(unsigned long size,
 Result SoundSourceModPlug::parseHeader() {
     if (m_pModFile == NULL) {
         // an error occured
-        qDebug() << "Could not parse module header of " << m_qFilename;
+        qDebug() << "Could not parse module header of " << getFilename();
         return ERR;
     }
 

--- a/src/soundsourcemodplug.h
+++ b/src/soundsourcemodplug.h
@@ -21,7 +21,7 @@ namespace ModPlug {
 class SoundSourceModPlug : public Mixxx::SoundSource
 {
   public:
-    SoundSourceModPlug(QString qFilename);
+    explicit SoundSourceModPlug(QString qFilename);
     ~SoundSourceModPlug();
     Result open();
     long seek(long);

--- a/src/soundsourcemp3.cpp
+++ b/src/soundsourcemp3.cpp
@@ -14,17 +14,20 @@
 *                                                                         *
 ***************************************************************************/
 
-#include <QtDebug>
+#include "soundsourcemp3.h"
+#include "soundsourcetaglib.h"
+#include "util/math.h"
 
 #include <taglib/mpegfile.h>
 
-#include "soundsourcemp3.h"
-#include "util/math.h"
+#include <QtDebug>
+
 
 SoundSourceMp3::SoundSourceMp3(QString qFilename) :
         Mixxx::SoundSource(qFilename),
         m_file(qFilename)
 {
+    setType("mp3");
     inputbuf = NULL;
     Stream = new mad_stream;
     mad_stream_init(Stream);
@@ -78,9 +81,9 @@ QList<QString> SoundSourceMp3::supportedFileExtensions()
 }
 
 Result SoundSourceMp3::open() {
-    m_file.setFileName(m_qFilename);
+    m_file.setFileName(getFilename());
     if (!m_file.open(QIODevice::ReadOnly)) {
-        //qDebug() << "MAD: Open failed:" << m_qFilename;
+        //qDebug() << "MAD: Open failed:" << getFilename();
         return ERR;
     }
 
@@ -126,18 +129,19 @@ Result SoundSourceMp3::open() {
             continue;
         }
 
-        // Grab data from Header
+        // Grab data from madHeader
 
         // This warns us only when the reported sample rate changes. (and when
         // it is first set)
-        if (m_iSampleRate == 0 && Header.samplerate > 0) {
+        if (getSampleRate() == 0 && Header.samplerate > 0) {
             setSampleRate(Header.samplerate);
-        } else if (m_iSampleRate != Header.samplerate) {
+        } else if (getSampleRate() != Header.samplerate) {
             qDebug() << "SSMP3: file has differing samplerate in some headers:"
-                     << m_qFilename
-                     << m_iSampleRate << "vs" << Header.samplerate;
+                     << getFilename()
+                     << getSampleRate() << "vs" << Header.samplerate;
         }
 
+        setChannels(2); // always pretend to read 2 channels
         m_iChannels = MAD_NCHANNELS(&Header);
         mad_timer_add (&filelength, Header.duration);
         bitrate += Header.bitrate;
@@ -155,7 +159,7 @@ Result SoundSourceMp3::open() {
 
     // This is not a working MP3 file.
     if (currentframe == 0) {
-        qDebug() << "SSMP3: This is not a working MP3 file:" << m_qFilename;
+        qDebug() << "SSMP3: This is not a working MP3 file:" << getFilename();
         return ERR;
     }
 
@@ -212,7 +216,7 @@ long SoundSourceMp3::seek(long filepos) {
     }
 
     if (!isValid()) {
-        qDebug() << "SSMP3: Error wile seeking file " << m_qFilename;
+        qDebug() << "SSMP3: Error wile seeking file " << getFilename();
         return 0;
     }
 
@@ -355,7 +359,7 @@ long SoundSourceMp3::seek(long filepos) {
 inline long unsigned SoundSourceMp3::length() {
     enum mad_units units;
 
-    switch (m_iSampleRate)
+    switch (getSampleRate())
     {
     case 8000:
         units = MAD_UNITS_8000_HZ;
@@ -386,12 +390,12 @@ inline long unsigned SoundSourceMp3::length() {
         break;
     default:             //By the MP3 specs, an MP3 _has_ to have one of the above samplerates...
         units = MAD_UNITS_44100_HZ;
-        qWarning() << "MP3 with corrupt samplerate (" << m_iSampleRate << "), defaulting to 44100";
+        qWarning() << "MP3 with corrupt samplerate (" << getSampleRate() << "), defaulting to 44100";
 
-        m_iSampleRate = 44100; //Prevents division by zero errors.
+        setSampleRate(44100); //Prevents division by zero errors.
     }
 
-    return (long unsigned) 2 *mad_timer_count(filelength, units);
+    return 2 * mad_timer_count(filelength, units);
 }
 
 /*
@@ -435,9 +439,13 @@ unsigned long SoundSourceMp3::discard(unsigned long samples_wanted) {
 unsigned SoundSourceMp3::read(unsigned long samples_wanted, const SAMPLE * _destination)
 {
     if (!isValid()) {
-        qDebug() << "SSMP3: Error while reading " << m_qFilename;
+        qDebug() << "SSMP3: Error while reading " << getFilename();
         return 0;
     }
+
+    // TODO(uklotzde): This implicit assumption will be dropped
+    // with the introduction of the new SoundSource API!
+    Q_ASSERT(2 == getChannels());
 
     // Ensure that we are reading an even number of samples. Otherwise this function may
     // go into an infinite loop
@@ -559,34 +567,47 @@ unsigned SoundSourceMp3::read(unsigned long samples_wanted, const SAMPLE * _dest
 }
 
 Result SoundSourceMp3::parseHeader() {
-    setType("mp3");
-    QByteArray qBAFilename = m_qFilename.toLocal8Bit();
+    QByteArray qBAFilename(getFilename().toLocal8Bit());
     TagLib::MPEG::File f(qBAFilename.constData());
 
-    // Takes care of all the default metadata
-    bool result = processTaglibFile(f);
+    if (!readFileHeader(this, f)) {
+        return ERR;
+    }
 
     // Now look for MP3 specific metadata (e.g. BPM)
     TagLib::ID3v2::Tag* id3v2 = f.ID3v2Tag();
     if (id3v2) {
-        processID3v2Tag(id3v2);
+        readID3v2Tag(this, *id3v2);
+    } else {
+        TagLib::APE::Tag *ape = f.APETag();
+        if (ape) {
+            readAPETag(this, *ape);
+        } else {
+            // fallback
+            const TagLib::Tag *tag(f.tag());
+            if (tag) {
+                readTag(this, *tag);
+            } else {
+                return ERR;
+            }
+        }
     }
 
-    TagLib::APE::Tag *ape = f.APETag();
-    if (ape) {
-        processAPETag(ape);
-    }
-
-    return result ? OK : ERR;
+    return OK;
 }
 
 QImage SoundSourceMp3::parseCoverArt() {
     QImage coverArt;
-    setType("mp3");
-    TagLib::MPEG::File f(m_qFilename.toLocal8Bit().constData());
-    coverArt = getCoverInID3v2Tag(f.ID3v2Tag());
+    TagLib::MPEG::File f(getFilename().toLocal8Bit().constData());
+    TagLib::ID3v2::Tag* id3v2 = f.ID3v2Tag();
+    if (id3v2) {
+        coverArt = Mixxx::getCoverInID3v2Tag(*id3v2);
+    }
     if (coverArt.isNull()) {
-        coverArt = getCoverInAPETag(f.APETag());
+        TagLib::APE::Tag *ape = f.APETag();
+        if (ape) {
+            coverArt = Mixxx::getCoverInAPETag(*ape);
+        }
     }
     return coverArt;
 }

--- a/src/soundsourcemp3.cpp
+++ b/src/soundsourcemp3.cpp
@@ -443,10 +443,6 @@ unsigned SoundSourceMp3::read(unsigned long samples_wanted, const SAMPLE * _dest
         return 0;
     }
 
-    // TODO(uklotzde): This implicit assumption will be dropped
-    // with the introduction of the new SoundSource API!
-    Q_ASSERT(2 == getChannels());
-
     // Ensure that we are reading an even number of samples. Otherwise this function may
     // go into an infinite loop
     if (samples_wanted % 2 != 0) {

--- a/src/soundsourcemp3.h
+++ b/src/soundsourcemp3.h
@@ -18,6 +18,8 @@
 #ifndef SOUNDSOURCEMP3_H
 #define SOUNDSOURCEMP3_H
 
+#include "soundsource.h"
+
 #include <errno.h>
 #include <id3tag.h>
 #ifdef _MSC_VER
@@ -34,10 +36,6 @@
 #include <QObject>
 #include <QFile>
 
-#include "util/defs.h"
-#include "util/types.h"
-#include "soundsource.h"
-
 #define READLENGTH 5000
 
 /** Struct used to store mad frames for seeking */
@@ -53,7 +51,6 @@ typedef struct MadSeekFrameType {
 
 class SoundSourceMp3 : public Mixxx::SoundSource {
 public:
-    SoundSourceMp3(QString qFilename);
     ~SoundSourceMp3();
     Result open();
     long seek(long);
@@ -65,6 +62,7 @@ public:
     QImage parseCoverArt();
     static QList<QString> supportedFileExtensions();
 
+    explicit SoundSourceMp3(QString qFilename);
 private:
     /** Returns the position of the frame which was found. The found frame is set to
       * the current element in m_qSeekList */

--- a/src/soundsourceoggvorbis.h
+++ b/src/soundsourceoggvorbis.h
@@ -25,7 +25,7 @@
 
 class SoundSourceOggVorbis : public Mixxx::SoundSource {
  public:
-  SoundSourceOggVorbis(QString qFilename);
+  explicit SoundSourceOggVorbis(QString qFilename);
   ~SoundSourceOggVorbis();
   Result open();
   long seek(long);

--- a/src/soundsourceopus.cpp
+++ b/src/soundsourceopus.cpp
@@ -17,7 +17,7 @@
 #endif
 
 // Include this if taglib if new enough (version 1.9.1 have opusfile)
-#if (TAGLIB_MAJOR_VERSION >= 1) && (TAGLIB_MINOR_VERSION >= 9)
+#if (TAGLIB_MAJOR_VERSION > 1) || ((TAGLIB_MAJOR_VERSION == 1) && (TAGLIB_MINOR_VERSION >= 9))
 #include <taglib/opusfile.h>
 #endif
 
@@ -187,7 +187,7 @@ Result SoundSourceOpus::parseHeader() {
     this->setDuration(l_lLength / (getSampleRate() * getChannels()));
 
 // If we don't have new enough Taglib we use libopusfile parser!
-#if (TAGLIB_MAJOR_VERSION >= 1) && (TAGLIB_MINOR_VERSION >= 9)
+#if (TAGLIB_MAJOR_VERSION > 1) || ((TAGLIB_MAJOR_VERSION == 1) && (TAGLIB_MINOR_VERSION >= 9))
     TagLib::Ogg::Opus::File f(qBAFilename.constData());
 
     if (!readFileHeader(this, f)) {
@@ -271,7 +271,7 @@ QList<QString> SoundSourceOpus::supportedFileExtensions() {
 }
 
 QImage SoundSourceOpus::parseCoverArt() {
-#if (TAGLIB_MAJOR_VERSION >= 1) && (TAGLIB_MINOR_VERSION >= 9)
+#if (TAGLIB_MAJOR_VERSION > 1) || ((TAGLIB_MAJOR_VERSION == 1) && (TAGLIB_MINOR_VERSION >= 9))
     TagLib::Ogg::Opus::File f(getFilename().toLocal8Bit().constData());
     TagLib::Ogg::XiphComment *xiph = f.tag();
     if (xiph) {

--- a/src/soundsourceopus.h
+++ b/src/soundsourceopus.h
@@ -26,9 +26,8 @@ class SoundSourceOpus : public Mixxx::SoundSource {
     static QList<QString> supportedFileExtensions();
 	
   private:
-    int m_iChannels;
-    quint64 m_lFilelength;
     OggOpusFile *m_ptrOpusFile;
+    quint64 m_lFilelength;
 };
 
 #endif

--- a/src/soundsourceopus.h
+++ b/src/soundsourceopus.h
@@ -14,7 +14,7 @@
 
 class SoundSourceOpus : public Mixxx::SoundSource {
   public:
-    SoundSourceOpus(QString qFilename);
+    explicit SoundSourceOpus(QString qFilename);
     virtual ~SoundSourceOpus();
 	
     Result open();

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -56,38 +56,32 @@ QMap<QString, QLibrary*> SoundSourceProxy::m_plugins;
 QMap<QString, getSoundSourceFunc> SoundSourceProxy::m_extensionsSupportedByPlugins;
 QMutex SoundSourceProxy::m_extensionsMutex;
 
+namespace
+{
+    SecurityTokenPointer openSecurityToken(QString qFilename, SecurityTokenPointer pToken) {
+        if (pToken.isNull()) {
+            // Open a security token for the file if we are in a sandbox.
+            QFileInfo info(qFilename);
+            return Sandbox::openSecurityToken(info, true);
+        } else {
+            return pToken;
+        }
+    }
+}
+
 //Constructor
 SoundSourceProxy::SoundSourceProxy(QString qFilename, SecurityTokenPointer pToken)
-    : Mixxx::SoundSource(qFilename),
-      m_pSoundSource(NULL),
-      m_pSecurityToken(pToken) {
-    if (pToken.isNull()) {
-        // Open a security token for the file if we are in a sandbox.
-        QFileInfo info(m_qFilename);
-        m_pSecurityToken = Sandbox::openSecurityToken(info, true);
-    }
-
-    // Create the underlying SoundSource.
-    m_pSoundSource = initialize(qFilename);
+    : m_qFilename(qFilename)
+    , m_pSecurityToken(openSecurityToken(m_qFilename, pToken))
+    , m_pSoundSource(initialize(m_qFilename)) {
 }
 
 //Other constructor
 SoundSourceProxy::SoundSourceProxy(TrackPointer pTrack)
-    : SoundSource(pTrack->getLocation()),
-      m_pSoundSource(NULL),
-      m_pTrack(pTrack),
-      m_pSecurityToken(pTrack->getSecurityToken()) {
-    if (m_pSecurityToken.isNull()) {
-        // Open a security token for the file if we are in a sandbox.
-        QFileInfo info(m_qFilename);
-        m_pSecurityToken = Sandbox::openSecurityToken(info, true);
-    }
-
-    m_pSoundSource = initialize(pTrack->getLocation());
-}
-
-SoundSourceProxy::~SoundSourceProxy() {
-    delete m_pSoundSource;
+    : m_qFilename(pTrack->getLocation())
+    , m_pTrack(pTrack)
+    , m_pSecurityToken(openSecurityToken(m_qFilename, pTrack->getSecurityToken()))
+    , m_pSoundSource(initialize(m_qFilename)) {
 }
 
 // static
@@ -171,52 +165,52 @@ void SoundSourceProxy::loadPlugins() {
 }
 
 // static
-Mixxx::SoundSource* SoundSourceProxy::initialize(QString qFilename) {
+Mixxx::SoundSourcePointer SoundSourceProxy::initialize(QString qFilename) {
     QString extension = qFilename;
     extension.remove(0, (qFilename.lastIndexOf(".")+1));
     extension = extension.toLower();
 
 #ifdef __FFMPEGFILE__
-    return new SoundSourceFFmpeg(qFilename);
+    return Mixxx::SoundSourcePointer(new SoundSourceFFmpeg(qFilename));
 #endif
     if (SoundSourceOggVorbis::supportedFileExtensions().contains(extension)) {
-        return new SoundSourceOggVorbis(qFilename);
+        return Mixxx::SoundSourcePointer(new SoundSourceOggVorbis(qFilename));
 #ifdef __OPUS__
     } else if (SoundSourceOpus::supportedFileExtensions().contains(extension)) {
-        return new SoundSourceOpus(qFilename);
+        return Mixxx::SoundSourcePointer(new SoundSourceOpus(qFilename));
 #endif
 #ifdef __MAD__
     } else if (SoundSourceMp3::supportedFileExtensions().contains(extension)) {
-        return new SoundSourceMp3(qFilename);
+        return Mixxx::SoundSourcePointer(new SoundSourceMp3(qFilename));
 #endif
     } else if (SoundSourceFLAC::supportedFileExtensions().contains(extension)) {
-        return new SoundSourceFLAC(qFilename);
+        return Mixxx::SoundSourcePointer(new SoundSourceFLAC(qFilename));
 #ifdef __COREAUDIO__
     } else if (SoundSourceCoreAudio::supportedFileExtensions().contains(extension)) {
-        return new SoundSourceCoreAudio(qFilename);
+        return Mixxx::SoundSourcePointer(new SoundSourceCoreAudio(qFilename));
 #endif
 #ifdef __MODPLUG__
     } else if (SoundSourceModPlug::supportedFileExtensions().contains(extension)) {
-        return new SoundSourceModPlug(qFilename);
+        return Mixxx::SoundSourcePointer(new SoundSourceModPlug(qFilename));
 #endif
     } else if (m_extensionsSupportedByPlugins.contains(extension)) {
         getSoundSourceFunc getter = m_extensionsSupportedByPlugins.value(extension);
         if (getter)
         {
             qDebug() << "Getting SoundSource plugin object for" << extension;
-            return getter(qFilename);
+            return Mixxx::SoundSourcePointer(getter(qFilename));
         }
         else {
             qDebug() << "Failed to resolve getSoundSource in plugin for" <<
                         extension;
-            return NULL; //Failed to load plugin
+            return Mixxx::SoundSourcePointer(); //Failed to load plugin
         }
 #ifdef __SNDFILE__
     } else if (SoundSourceSndFile::supportedFileExtensions().contains(extension)) {
-        return new SoundSourceSndFile(qFilename);
+        return Mixxx::SoundSourcePointer(new SoundSourceSndFile(qFilename));
 #endif
     } else { //Unsupported filetype
-        return NULL;
+        return Mixxx::SoundSourcePointer();
     }
 }
 
@@ -312,7 +306,21 @@ Result SoundSourceProxy::open() {
     if (!m_pSoundSource) {
         return ERR;
     }
+
     Result retVal = m_pSoundSource->open();
+    if (OK != retVal) {
+        qWarning() << "Failed to open SoundSource";
+        return retVal;
+    }
+
+    if (0 >= m_pSoundSource->getChannels()) {
+        qWarning() << "Invalid number of channels" << m_pSoundSource->getChannels();
+        return ERR;
+    }
+    if (0 >= m_pSoundSource->getSampleRate()) {
+        qWarning() << "Invalid sample rate" << m_pSoundSource->getSampleRate();
+        return ERR;
+    }
 
     //Update some metadata (currently only the duration)
     //after a song is open()'d. Eg. We don't know the length
@@ -330,38 +338,6 @@ Result SoundSourceProxy::open() {
     }
 
     return retVal;
-}
-
-long SoundSourceProxy::seek(long l)
-{
-    if (!m_pSoundSource) {
-	return 0;
-    }
-    return m_pSoundSource->seek(l);
-}
-
-unsigned SoundSourceProxy::read(unsigned long size, const SAMPLE * p)
-{
-    if (!m_pSoundSource) {
-    return 0;
-    }
-    return m_pSoundSource->read(size, p);
-}
-
-long unsigned SoundSourceProxy::length()
-{
-    if (!m_pSoundSource) {
-        return 0;
-    }
-    return m_pSoundSource->length();
-}
-
-Result SoundSourceProxy::parseHeader() {
-    return m_pSoundSource ? m_pSoundSource->parseHeader() : ERR;
-}
-
-QImage SoundSourceProxy::parseCoverArt() {
-    return m_pSoundSource ? m_pSoundSource->parseCoverArt() : QImage();
 }
 
 // static
@@ -424,22 +400,4 @@ bool SoundSourceProxy::isFilenameSupported(QString fileName) {
         m_supportedFileRegex = QRegExp(regex, Qt::CaseInsensitive);
     }
     return fileName.contains(m_supportedFileRegex);
-}
-
-
-unsigned int SoundSourceProxy::getSampleRate()
-{
-    if (!m_pSoundSource) {
-    return 0;
-    }
-    return m_pSoundSource->getSampleRate();
-}
-
-
-QString SoundSourceProxy::getFilename()
-{
-    if (!m_pSoundSource) {
-    return "";
-    }
-    return m_pSoundSource->getFilename();
 }

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -33,51 +33,52 @@
   */
 
 
-/*
-  Base class for sound sources.
-*/
-class SoundSourceProxy : public Mixxx::SoundSource
+/**
+ * Creates sound sources for filenames or tracks.
+ */
+class SoundSourceProxy
 {
 public:
-    SoundSourceProxy(QString qFilename, SecurityTokenPointer pToken);
-    SoundSourceProxy(TrackPointer pTrack);
-    ~SoundSourceProxy();
     static void loadPlugins();
-    Result open();
-    long seek(long);
-    unsigned read(unsigned long size, const SAMPLE*);
-    long unsigned length();
-    Result parseHeader();
-
-    // Returns the first cover art image embedded within the file (if any).
-    QImage parseCoverArt();
-
-    unsigned int getSampleRate();
-    /** Returns filename */
-    QString getFilename();
-
-    SoundSource* getProxiedSoundSource() {
-        return m_pSoundSource;
-    }
 
     static QStringList supportedFileExtensions();
     static QStringList supportedFileExtensionsByPlugins();
     static QString supportedFileExtensionsString();
     static QString supportedFileExtensionsRegex();
     static bool isFilenameSupported(QString filename);
+
+    SoundSourceProxy(QString qFilename, SecurityTokenPointer pToken);
+    explicit SoundSourceProxy(TrackPointer pTrack);
+
+    const QString& getFilename() const {
+        return m_qFilename;
+    }
+    const TrackPointer& getTrack() const {
+        return m_pTrack;
+    }
+    const Mixxx::SoundSourcePointer& getSoundSource() const {
+        return m_pSoundSource;
+    }
+
+    // Opening the audio data through the proxy will update the some metadata of the track object.
+    Result open();
+
 private:
-    static SoundSource* initialize(QString qFilename);
-    //void initPlugin(QString lib_filename, QString track_filename);
-    static QLibrary* getPlugin(QString lib_filename);
-
-    SoundSource* m_pSoundSource;
-    TrackPointer m_pTrack;
-    SecurityTokenPointer m_pSecurityToken;
-
     static QRegExp m_supportedFileRegex;
     static QMap<QString, QLibrary*> m_plugins;
     static QMap<QString, getSoundSourceFunc> m_extensionsSupportedByPlugins;
     static QMutex m_extensionsMutex;
+
+    static QLibrary* getPlugin(QString lib_filename);
+
+    static Mixxx::SoundSourcePointer initialize(QString qFilename);
+
+    const QString m_qFilename;
+    const TrackPointer m_pTrack;
+
+    const SecurityTokenPointer m_pSecurityToken;
+
+    const Mixxx::SoundSourcePointer m_pSoundSource;
 };
 
 #endif

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -50,18 +50,14 @@ public:
     SoundSourceProxy(QString qFilename, SecurityTokenPointer pToken);
     explicit SoundSourceProxy(TrackPointer pTrack);
 
-    const QString& getFilename() const {
-        return m_qFilename;
-    }
-    const TrackPointer& getTrack() const {
-        return m_pTrack;
-    }
     const Mixxx::SoundSourcePointer& getSoundSource() const {
         return m_pSoundSource;
     }
 
-    // Opening the audio data through the proxy will update the some metadata of the track object.
-    Result open();
+    // Opens the audio data through the proxy will
+    // update the some metadata of the track object.
+    // Returns a null pointer on failure.
+    Mixxx::SoundSourcePointer open() const;
 
 private:
     static QRegExp m_supportedFileRegex;
@@ -71,11 +67,9 @@ private:
 
     static QLibrary* getPlugin(QString lib_filename);
 
-    static Mixxx::SoundSourcePointer initialize(QString qFilename);
+    static Mixxx::SoundSourcePointer initialize(const QString& qFilename);
 
-    const QString m_qFilename;
     const TrackPointer m_pTrack;
-
     const SecurityTokenPointer m_pSecurityToken;
 
     const Mixxx::SoundSourcePointer m_pSoundSource;

--- a/src/soundsourcesndfile.h
+++ b/src/soundsourcesndfile.h
@@ -31,7 +31,7 @@
 class SoundSourceSndFile : public Mixxx::SoundSource
 {
 public:
-    SoundSourceSndFile(QString qFilename);
+    explicit SoundSourceSndFile(QString qFilename);
     ~SoundSourceSndFile();
     Result open();
     long seek(long);

--- a/src/soundsourcetaglib.cpp
+++ b/src/soundsourcetaglib.cpp
@@ -1,0 +1,408 @@
+/***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#include "soundsourcetaglib.h"
+
+#include <taglib/tag.h>
+#include <taglib/audioproperties.h>
+#include <taglib/vorbisfile.h>
+#include <taglib/id3v2frame.h>
+#include <taglib/id3v2header.h>
+#include <taglib/id3v1tag.h>
+#include <taglib/tmap.h>
+#include <taglib/tstringlist.h>
+#include <taglib/textidentificationframe.h>
+#include <taglib/wavpackfile.h>
+#include <taglib/attachedpictureframe.h>
+#include <taglib/flacpicture.h>
+
+
+#include <QtDebug>
+
+
+namespace Mixxx
+{
+
+// static
+namespace
+{
+    const bool s_bDebugMetadata = false;
+
+    // Taglib strings can be NULL and using it could cause some segfaults,
+    // so in this case it will return a QString()
+    inline
+    QString toQString(const TagLib::String& tString) {
+        if (tString.isNull()) {
+            return QString();
+        } else {
+            return TStringToQString(tString);
+        }
+    }
+
+    // Concatenates the elements of a TagLib string list
+    // into a single string.
+    inline
+    QString toQString(const TagLib::StringList& strList) {
+        return toQString(strList.toString());
+    }
+
+    // Concatenates the string list of an MP4 atom
+    // into a single string
+    inline
+    QString toQString(const TagLib::MP4::Item& mp4Item) {
+        return toQString(mp4Item.toStringList());
+    }
+
+    inline
+    QString toQString(const TagLib::APE::Item& apeItem) {
+        return toQString(apeItem.toString());
+    }
+}
+
+
+bool readFileHeader(SoundSource* pSoundSource, const TagLib::File& f) {
+    if (s_bDebugMetadata) {
+        qDebug() << "Parsing" << pSoundSource->getFilename();
+    }
+
+    if (f.isValid()) {
+        const TagLib::AudioProperties *properties = f.audioProperties();
+        if (properties) {
+            pSoundSource->setDuration(properties->length());
+            pSoundSource->setBitrate(properties->bitrate());
+            pSoundSource->setSampleRate(properties->sampleRate());
+            pSoundSource->setChannels(properties->channels());
+
+            if (s_bDebugMetadata) {
+                qDebug() << "TagLib"
+                        << "duration" << pSoundSource->getDuration()
+                        << "bitrate" << pSoundSource->getBitrate()
+                        << "sampleRate" << pSoundSource->getSampleRate()
+                        << "channels" << pSoundSource->getChannels();
+            }
+
+            return true;
+        }
+    }
+    return false;
+}
+
+void readTag(SoundSource* pSoundSource, const TagLib::Tag& tag) {
+    pSoundSource->setTitle(toQString(tag.title()));
+    pSoundSource->setArtist(toQString(tag.artist()));
+    pSoundSource->setAlbum(toQString(tag.album()));
+    pSoundSource->setComment(toQString(tag.comment()));
+    pSoundSource->setGenre(toQString(tag.genre()));
+
+    int iYear = tag.year();
+    if (iYear > 0) {
+        pSoundSource->setYear(QString("%1").arg(iYear));
+    }
+
+    int iTrack = tag.track();
+    if (iTrack > 0) {
+        pSoundSource->setTrackNumber(QString("%1").arg(iTrack));
+    }
+
+    if (s_bDebugMetadata) {
+        qDebug() << "TagLib"
+                << "title" << pSoundSource->getTitle()
+                << "artist" << pSoundSource->getArtist()
+                << "album" << pSoundSource->getAlbum()
+                << "comment" << pSoundSource->getComment()
+                << "genre" << pSoundSource->getGenre()
+                << "year" << pSoundSource->getYear()
+                << "trackNumber" << pSoundSource->getTrackNumber();
+    }
+}
+
+void readID3v2Tag(SoundSource* pSoundSource, const TagLib::ID3v2::Tag& id3v2) {
+
+    // Print every frame in the file.
+    if (s_bDebugMetadata) {
+        TagLib::ID3v2::FrameList::ConstIterator it = id3v2.frameList().begin();
+        for(; it != id3v2.frameList().end(); it++) {
+            qDebug() << "ID3V2" << (*it)->frameID().data() << "-"
+                    << toQString((*it)->toString());
+        }
+    }
+
+    readTag(pSoundSource, id3v2);
+
+    TagLib::ID3v2::FrameList bpmFrame = id3v2.frameListMap()["TBPM"];
+    if (!bpmFrame.isEmpty()) {
+        QString sBpm = toQString(bpmFrame.front()->toString());
+        pSoundSource->setBpmString(sBpm);
+    }
+
+    TagLib::ID3v2::FrameList keyFrame = id3v2.frameListMap()["TKEY"];
+    if (!keyFrame.isEmpty()) {
+        QString sKey = toQString(keyFrame.front()->toString());
+        pSoundSource->setKey(sKey);
+    }
+
+    // Foobar2000-style ID3v2.3.0 tags
+    // TODO: Check if everything is ok.
+    TagLib::ID3v2::FrameList frames = id3v2.frameListMap()["TXXX"];
+    for ( TagLib::ID3v2::FrameList::Iterator it = frames.begin(); it != frames.end(); ++it ) {
+        TagLib::ID3v2::UserTextIdentificationFrame* ReplayGainframe =
+                dynamic_cast<TagLib::ID3v2::UserTextIdentificationFrame*>( *it );
+        if ( ReplayGainframe && ReplayGainframe->fieldList().size() >= 2 )
+        {
+            QString desc = toQString( ReplayGainframe->description() ).toLower();
+            if ( desc == "replaygain_album_gain" ){
+                QString sReplayGain = toQString( ReplayGainframe->fieldList()[1]);
+                pSoundSource->setReplayGainString(sReplayGain);
+            }
+            //Prefer track gain over album gain.
+            if ( desc == "replaygain_track_gain" ){
+                QString sReplayGain = toQString( ReplayGainframe->fieldList()[1]);
+                pSoundSource->setReplayGainString(sReplayGain);
+            }
+        }
+    }
+
+    TagLib::ID3v2::FrameList albumArtistFrame = id3v2.frameListMap()["TPE2"];
+    if (!albumArtistFrame.isEmpty()) {
+        QString sAlbumArtist = toQString(albumArtistFrame.front()->toString());
+        pSoundSource->setAlbumArtist(sAlbumArtist);
+
+        if (pSoundSource->getArtist().length() == 0) {
+            pSoundSource->setArtist(sAlbumArtist);
+        }
+    }
+    TagLib::ID3v2::FrameList originalAlbumFrame = id3v2.frameListMap()["TOAL"];
+    if (pSoundSource->getAlbum().length() == 0 && !originalAlbumFrame.isEmpty()) {
+        QString sOriginalAlbum = TStringToQString(originalAlbumFrame.front()->toString());
+        pSoundSource->setAlbum(sOriginalAlbum);
+    }
+
+    TagLib::ID3v2::FrameList composerFrame = id3v2.frameListMap()["TCOM"];
+    if (!composerFrame.isEmpty()) {
+        QString sComposer = toQString(composerFrame.front()->toString());
+        pSoundSource->setComposer(sComposer);
+    }
+
+    TagLib::ID3v2::FrameList groupingFrame = id3v2.frameListMap()["TIT1"];
+    if (!groupingFrame.isEmpty()) {
+        QString sGrouping = toQString(groupingFrame.front()->toString());
+        pSoundSource->setGrouping(sGrouping);
+    }
+}
+
+void readAPETag(SoundSource* pSoundSource, const TagLib::APE::Tag& ape) {
+    if (s_bDebugMetadata) {
+        for(TagLib::APE::ItemListMap::ConstIterator it = ape.itemListMap().begin();
+                it != ape.itemListMap().end(); ++it) {
+                qDebug() << "APE" << toQString((*it).first) << "-" << toQString((*it).second.toString());
+        }
+    }
+
+    readTag(pSoundSource, ape);
+
+    if (ape.itemListMap().contains("BPM")) {
+        pSoundSource->setBpmString(toQString(ape.itemListMap()["BPM"]));
+    }
+
+    if (ape.itemListMap().contains("REPLAYGAIN_ALBUM_GAIN")) {
+        pSoundSource->setReplayGainString(toQString(ape.itemListMap()["REPLAYGAIN_ALBUM_GAIN"]));
+    }
+    //Prefer track gain over album gain.
+    if (ape.itemListMap().contains("REPLAYGAIN_TRACK_GAIN")) {
+        pSoundSource->setReplayGainString(toQString(ape.itemListMap()["REPLAYGAIN_TRACK_GAIN"]));
+    }
+
+    if (ape.itemListMap().contains("Album Artist")) {
+        pSoundSource->setAlbumArtist(toQString(ape.itemListMap()["Album Artist"]));
+    }
+
+    if (ape.itemListMap().contains("Composer")) {
+        pSoundSource->setComposer(toQString(ape.itemListMap()["Composer"]));
+    }
+
+    if (ape.itemListMap().contains("Grouping")) {
+        pSoundSource->setGrouping(toQString(ape.itemListMap()["Grouping"]));
+    }
+}
+
+void readXiphComment(SoundSource* pSoundSource, const TagLib::Ogg::XiphComment& xiph) {
+    if (s_bDebugMetadata) {
+        for (TagLib::Ogg::FieldListMap::ConstIterator it = xiph.fieldListMap().begin();
+                it != xiph.fieldListMap().end(); ++it) {
+            qDebug() << "XIPH" << toQString((*it).first) << "-" << toQString((*it).second.toString());
+        }
+    }
+
+    readTag(pSoundSource, xiph);
+
+    // Some tags use "BPM" so check for that.
+    if (xiph.fieldListMap().contains("BPM")) {
+        pSoundSource->setBpmString(toQString(xiph.fieldListMap()["BPM"]));
+    }
+
+    // Give preference to the "TEMPO" tag which seems to be more standard
+    if (xiph.fieldListMap().contains("TEMPO")) {
+        pSoundSource->setBpmString(toQString(xiph.fieldListMap()["TEMPO"]));
+    }
+
+    if (xiph.fieldListMap().contains("REPLAYGAIN_ALBUM_GAIN")) {
+        pSoundSource->setReplayGainString(toQString(xiph.fieldListMap()["REPLAYGAIN_ALBUM_GAIN"]));
+    }
+    //Prefer track gain over album gain.
+    if (xiph.fieldListMap().contains("REPLAYGAIN_TRACK_GAIN")) {
+        pSoundSource->setReplayGainString(toQString(xiph.fieldListMap()["REPLAYGAIN_TRACK_GAIN"]));
+    }
+
+    /*
+     * Reading key code information
+     * Unlike, ID3 tags, there's no standard or recommendation on how to store 'key' code
+     *
+     * Luckily, there are only a few tools for that, e.g., Rapid Evolution (RE).
+     * Assuming no distinction between start and end key, RE uses a "INITIALKEY"
+     * or a "KEY" vorbis comment.
+     */
+    if (xiph.fieldListMap().contains("KEY")) {
+        pSoundSource->setKey(toQString(xiph.fieldListMap()["KEY"]));
+    }
+    if (pSoundSource->getKey().isEmpty() && xiph.fieldListMap().contains("INITIALKEY")) {
+        pSoundSource->setKey(toQString(xiph.fieldListMap()["INITIALKEY"]));
+    }
+
+    if (xiph.fieldListMap().contains("ALBUMARTIST")) {
+        pSoundSource->setAlbumArtist(toQString(xiph.fieldListMap()["ALBUMARTIST"]));
+    } else {
+        // try alternative field name
+        if (xiph.fieldListMap().contains("ALBUM_ARTIST")) {
+            pSoundSource->setAlbumArtist(toQString(xiph.fieldListMap()["ALBUM_ARTIST"]));
+        }
+    }
+
+    if (xiph.fieldListMap().contains("COMPOSER")) {
+        pSoundSource->setComposer(toQString(xiph.fieldListMap()["COMPOSER"]));
+    }
+
+    if (xiph.fieldListMap().contains("GROUPING")) {
+        pSoundSource->setGrouping(toQString(xiph.fieldListMap()["GROUPING"]));
+    }
+}
+
+void readMP4Tag(SoundSource* pSoundSource, /*const*/ TagLib::MP4::Tag& mp4) {
+    if (s_bDebugMetadata) {
+        for(TagLib::MP4::ItemListMap::ConstIterator it = mp4.itemListMap().begin();
+            it != mp4.itemListMap().end(); ++it) {
+            qDebug() << "MP4" << toQString((*it).first) << "-"
+                     << toQString((*it).second);
+        }
+    }
+
+    readTag(pSoundSource, mp4);
+
+    // Get BPM
+    if (mp4.itemListMap().contains("tmpo")) {
+        pSoundSource->setBpmString(toQString(mp4.itemListMap()["tmpo"]));
+    } else if (mp4.itemListMap().contains("----:com.apple.iTunes:BPM")) {
+        // This is an alternate way of storing BPM.
+        pSoundSource->setBpmString(toQString(mp4.itemListMap()["----:com.apple.iTunes:BPM"]));
+    }
+
+    // Get Album Artist
+    if (mp4.itemListMap().contains("aART")) {
+        pSoundSource->setAlbumArtist(toQString(mp4.itemListMap()["aART"]));
+    }
+
+    // Get Composer
+    if (mp4.itemListMap().contains("\251wrt")) {
+        pSoundSource->setComposer(toQString(mp4.itemListMap()["\251wrt"]));
+    }
+
+    // Get Grouping
+    if (mp4.itemListMap().contains("\251grp")) {
+        pSoundSource->setGrouping(toQString(mp4.itemListMap()["\251grp"]));
+    }
+
+    // Get KEY (conforms to Rapid Evolution)
+    if (mp4.itemListMap().contains("----:com.apple.iTunes:KEY")) {
+        QString key = toQString(
+            mp4.itemListMap()["----:com.apple.iTunes:KEY"]);
+        pSoundSource->setKey(key);
+    }
+
+    // Apparently iTunes stores replaygain in this property.
+    if (mp4.itemListMap().contains("----:com.apple.iTunes:replaygain_album_gain")) {
+        // TODO(XXX) find tracks with this property and check what it looks
+        // like.
+        //QString replaygain = toQString(mp4.itemListMap()["----:com.apple.iTunes:replaygain_album_gain"]);
+    }
+    //Prefer track gain over album gain.
+    if (mp4.itemListMap().contains("----:com.apple.iTunes:replaygain_track_gain")) {
+        // TODO(XXX) find tracks with this property and check what it looks
+        // like.
+        //QString replaygain = toQString(mp4.itemListMap()["----:com.apple.iTunes:replaygain_track_gain"]);
+    }
+}
+
+QImage getCoverInID3v2Tag(const TagLib::ID3v2::Tag& id3v2) {
+    QImage coverArt;
+    TagLib::ID3v2::FrameList covertArtFrame = id3v2.frameListMap()["APIC"];
+    if (!covertArtFrame.isEmpty()) {
+        TagLib::ID3v2::AttachedPictureFrame* picframe = static_cast
+                <TagLib::ID3v2::AttachedPictureFrame*>(covertArtFrame.front());
+        TagLib::ByteVector data = picframe->picture();
+        coverArt = QImage::fromData(
+            reinterpret_cast<const uchar *>(data.data()), data.size());
+    }
+    return coverArt;
+}
+
+QImage getCoverInAPETag(const TagLib::APE::Tag& ape) {
+    QImage coverArt;
+    if (ape.itemListMap().contains("COVER ART (FRONT)"))
+    {
+        const TagLib::ByteVector nullStringTerminator(1, 0);
+        TagLib::ByteVector item = ape.itemListMap()["COVER ART (FRONT)"].value();
+        int pos = item.find(nullStringTerminator);  // skip the filename
+        if (++pos > 0) {
+            const TagLib::ByteVector& data = item.mid(pos);
+            coverArt = QImage::fromData(
+                reinterpret_cast<const uchar *>(data.data()), data.size());
+        }
+    }
+    return coverArt;
+}
+
+QImage getCoverInXiphComment(const TagLib::Ogg::XiphComment& xiph) {
+    QImage coverArt;
+    if (xiph.fieldListMap().contains("METADATA_BLOCK_PICTURE")) {
+        QByteArray data(QByteArray::fromBase64(
+            xiph.fieldListMap()["METADATA_BLOCK_PICTURE"].front().toCString()));
+        TagLib::ByteVector tdata(data.data(), data.size());
+        TagLib::FLAC::Picture p(tdata);
+        data = QByteArray(p.data().data(), p.data().size());
+        coverArt = QImage::fromData(data);
+    } else if (xiph.fieldListMap().contains("COVERART")) {
+        QByteArray data(QByteArray::fromBase64(
+            xiph.fieldListMap()["COVERART"].toString().toCString()));
+        coverArt = QImage::fromData(data);
+    }
+    return coverArt;
+}
+
+QImage getCoverInMP4Tag(/*const*/ TagLib::MP4::Tag& mp4) {
+    QImage coverArt;
+    if (mp4.itemListMap().contains("covr")) {
+        TagLib::MP4::CoverArtList coverArtList = mp4.itemListMap()["covr"]
+                                                        .toCoverArtList();
+        TagLib::ByteVector data = coverArtList.front().data();
+        coverArt = QImage::fromData(
+            reinterpret_cast<const uchar *>(data.data()), data.size());
+    }
+    return coverArt;
+}
+
+} //namespace Mixxx

--- a/src/soundsourcetaglib.h
+++ b/src/soundsourcetaglib.h
@@ -1,0 +1,45 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef SOUNDSOURCETAGLIB_H
+#define SOUNDSOURCETAGLIB_H
+
+#include "soundsource.h"
+
+#include <taglib/tfile.h>
+#include <taglib/apetag.h>
+#include <taglib/id3v2tag.h>
+#include <taglib/xiphcomment.h>
+#include <taglib/mp4tag.h>
+
+
+namespace Mixxx
+{
+    bool readFileHeader(SoundSource* pSoundSource, const TagLib::File& taglibFile);
+
+    // Read generic tags (will implicitly be invoked from the specialized functions)
+    void readTag(SoundSource* pSoundSource, const TagLib::Tag& tag);
+
+    // Read specific tags
+    void readID3v2Tag(SoundSource* pSoundSource, const TagLib::ID3v2::Tag& id3v2Tag);
+    void readAPETag(SoundSource* pSoundSource, const TagLib::APE::Tag& ape);
+    void readXiphComment(SoundSource* pSoundSource, const TagLib::Ogg::XiphComment& xiph);
+    void readMP4Tag(SoundSource* pSoundSource, /*const*/ TagLib::MP4::Tag& mp4);
+
+    // In order to avoid processing images when it's not
+    // needed (TIO building), we must process it separately.
+    QImage getCoverInID3v2Tag(const TagLib::ID3v2::Tag& id3v2);
+    QImage getCoverInAPETag(const TagLib::APE::Tag& ape);
+    QImage getCoverInXiphComment(const TagLib::Ogg::XiphComment& xiph);
+    QImage getCoverInMP4Tag(/*const*/ TagLib::MP4::Tag& mp4);
+
+} //namespace Mixxx
+
+
+#endif

--- a/src/test/coverartcache_test.cpp
+++ b/src/test/coverartcache_test.cpp
@@ -52,7 +52,9 @@ TEST_F(CoverArtCacheTest, loadCover) {
     SecurityTokenPointer securityToken = Sandbox::openSecurityToken(
         QDir(kTrackLocationTest), true);
     SoundSourceProxy proxy(kTrackLocationTest, securityToken);
-    img = proxy.parseCoverArt();
+    Mixxx::SoundSourcePointer pSoundSource(proxy.getSoundSource());
+    ASSERT_TRUE(pSoundSource);
+    img = pSoundSource->parseCoverArt();
 
     EXPECT_EQ(img, res.cover.image);
 }

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -17,15 +17,15 @@ class SoundSourceProxyTest : public MixxxTest {
         delete m_pProxy;
     }
 
-    Mixxx::SoundSource* loadProxy(const QString& track) {
+    Mixxx::SoundSourcePointer loadProxy(const QString& track) {
         SecurityTokenPointer securityToken = Sandbox::openSecurityToken(
             QDir(track), true);
         if (m_pProxy != NULL) {
             delete m_pProxy;
         }
         m_pProxy = new SoundSourceProxy(track, securityToken);
-        Mixxx::SoundSource* pProxiedSoundSource = m_pProxy->getProxiedSoundSource();
-        EXPECT_TRUE(pProxiedSoundSource != NULL && m_pProxy->parseHeader() == OK);
+        Mixxx::SoundSourcePointer pProxiedSoundSource(m_pProxy->getSoundSource());
+        EXPECT_TRUE(pProxiedSoundSource && pProxiedSoundSource->parseHeader() == OK);
         return pProxiedSoundSource;
     }
 
@@ -34,14 +34,14 @@ class SoundSourceProxyTest : public MixxxTest {
 
 
 TEST_F(SoundSourceProxyTest, readArtist) {
-    Mixxx::SoundSource* p = loadProxy(
-        QDir::currentPath().append("/src/test/id3-test-data/artist.mp3"));
+    Mixxx::SoundSourcePointer p(loadProxy(
+        QDir::currentPath().append("/src/test/id3-test-data/artist.mp3")));
     EXPECT_EQ("Test Artist", p->getArtist());
 }
 
 TEST_F(SoundSourceProxyTest, TOAL_TPE2) {
-    Mixxx::SoundSource* p = loadProxy(
-        QDir::currentPath().append("/src/test/id3-test-data/TOAL_TPE2.mp3"));
+    Mixxx::SoundSourcePointer p(loadProxy(
+        QDir::currentPath().append("/src/test/id3-test-data/TOAL_TPE2.mp3")));
     EXPECT_EQ("TITLE2", p->getArtist());
     EXPECT_EQ("ARTIST", p->getAlbum());
     EXPECT_EQ("TITLE", p->getAlbumArtist());

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -160,8 +160,8 @@ void TrackInfoObject::parse(bool parseCoverArt) {
 
     // Parse the information stored in the sound file.
     SoundSourceProxy proxy(canonicalLocation, m_pSecurityToken);
-    Mixxx::SoundSource* pProxiedSoundSource = proxy.getProxiedSoundSource();
-    if (pProxiedSoundSource != NULL && proxy.parseHeader() == OK) {
+    Mixxx::SoundSourcePointer pSoundSource(proxy.getSoundSource());
+    if (pSoundSource && pSoundSource->parseHeader() == OK) {
 
         // Dump the metadata extracted from the file into the track.
 
@@ -172,54 +172,54 @@ void TrackInfoObject::parse(bool parseCoverArt) {
         // If Artist, Title and Type fields are not blank, modify them.
         // Otherwise, keep their current values.
         // TODO(rryan): Should we re-visit this decision?
-        if (!(pProxiedSoundSource->getArtist().isEmpty())) {
-            setArtist(pProxiedSoundSource->getArtist());
+        if (!(pSoundSource->getArtist().isEmpty())) {
+            setArtist(pSoundSource->getArtist());
         } else {
             parseArtist();
         }
 
-        if (!(pProxiedSoundSource->getTitle().isEmpty())) {
-            setTitle(pProxiedSoundSource->getTitle());
+        if (!(pSoundSource->getTitle().isEmpty())) {
+            setTitle(pSoundSource->getTitle());
         } else {
             parseTitle();
         }
 
-        if (!(pProxiedSoundSource->getType().isEmpty())) {
-            setType(pProxiedSoundSource->getType());
+        if (!(pSoundSource->getType().isEmpty())) {
+            setType(pSoundSource->getType());
         }
 
-        setAlbum(pProxiedSoundSource->getAlbum());
-        setAlbumArtist(pProxiedSoundSource->getAlbumArtist());
-        setYear(pProxiedSoundSource->getYear());
-        setGenre(pProxiedSoundSource->getGenre());
-        setComposer(pProxiedSoundSource->getComposer());
-        setGrouping(pProxiedSoundSource->getGrouping());
-        setComment(pProxiedSoundSource->getComment());
-        setTrackNumber(pProxiedSoundSource->getTrackNumber());
-        float replayGain = pProxiedSoundSource->getReplayGain();
+        setAlbum(pSoundSource->getAlbum());
+        setAlbumArtist(pSoundSource->getAlbumArtist());
+        setYear(pSoundSource->getYear());
+        setGenre(pSoundSource->getGenre());
+        setComposer(pSoundSource->getComposer());
+        setGrouping(pSoundSource->getGrouping());
+        setComment(pSoundSource->getComment());
+        setTrackNumber(pSoundSource->getTrackNumber());
+        float replayGain = pSoundSource->getReplayGain();
         if (replayGain != 0) {
             setReplayGain(replayGain);
         }
-        setDuration(pProxiedSoundSource->getDuration());
-        setBitrate(pProxiedSoundSource->getBitrate());
-        setSampleRate(pProxiedSoundSource->getSampleRate());
-        setChannels(pProxiedSoundSource->getChannels());
+        setDuration(pSoundSource->getDuration());
+        setBitrate(pSoundSource->getBitrate());
+        setSampleRate(pSoundSource->getSampleRate());
+        setChannels(pSoundSource->getChannels());
 
         // Need to set BPM after sample rate since beat grid creation depends on
         // knowing the sample rate. Bug #1020438.
-        float bpm = pProxiedSoundSource->getBPM();
+        float bpm = pSoundSource->getBPM();
         if (bpm > 0) {
             // do not delete beat grid if bpm is not set in file
             setBpm(bpm);
         }
 
-        QString key = pProxiedSoundSource->getKey();
+        QString key = pSoundSource->getKey();
         if (!key.isEmpty()) {
             setKeyText(key, mixxx::track::io::key::FILE_METADATA);
         }
 
         if (parseCoverArt) {
-            m_coverArt.image = proxy.parseCoverArt();
+            m_coverArt.image = pSoundSource->parseCoverArt();
             if (!m_coverArt.image.isNull()) {
                 m_coverArt.info.hash = CoverArtUtils::calculateHash(
                     m_coverArt.image);


### PR DESCRIPTION
Some preparations before introducing the new API.

Eliminated the inheritance relationship between SoundSourceProxy and SoundSource:
- It's not necessary and was only partially implemented..
- SoundSourceProxy might be renamed eventually to better reflect its purpose.

Removed TagLib dependencies from the SoundSource base class:
- There is no reason why these functions were provided by the base class.
- Outsourced into standalone utility functions that access SoundSource through its public interface.
