### PR TITLE
Added Appstream XML data for better Gnome and KDE integration.

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -213,6 +213,9 @@ docs_files += Glob('#./Mixxx-Manual.pdf')
 #.desktop file for KDE/GNOME menu
 dotdesktop_files = Glob('#src/mixxx.desktop')
 
+#.appdata.xml file for KDE/GNOME AppStream iniative
+dotappstream_files = Glob('#src/mixxx.appdata.xml')
+
 #Icon file for menu entry
 icon_files = Glob('#res/images/mixxx-icon.png')
 
@@ -294,6 +297,7 @@ if build.platform_is_linux or build.platform_is_bsd:
                 translations = env.Install(os.path.join(unix_share_path, 'mixxx', 'translations'), translation_files)
                 keyboardmappings = env.Install(os.path.join(unix_share_path, 'mixxx', 'keyboard'), keyboardmappings_files)
                 dotdesktop = env.Install(os.path.join(unix_share_path, 'applications'), dotdesktop_files)
+                dotappstream = env.Install(os.path.join(unix_share_path, 'appdata'), dotappstream_files)
                 docs = env.Install(os.path.join(unix_share_path, 'doc', 'mixxx'), docs_files)
                 icon = env.Install(os.path.join(unix_share_path, 'pixmaps'), icon_files)
                 promotracks = env.Install(os.path.join(unix_share_path, 'mixxx', 'promo'), promotracks_files)
@@ -308,6 +312,7 @@ if build.platform_is_linux or build.platform_is_bsd:
                 env.Alias('install', keyboardmappings)
                 env.Alias('install', docs)
                 env.Alias('install', dotdesktop)
+                env.Alias('install', dotappstream)
                 env.Alias('install', icon)
                 env.Alias('install', promotracks)
                 env.Alias('install', vamp_plugin)

--- a/src/mixxx.appdata.xml
+++ b/src/mixxx.appdata.xml
@@ -25,7 +25,7 @@
       <li>Shoutcast and Icecast broadcasting.</li>
       <li>Support for many DJ MIDI and HID controllers out-of-the-box.</li>
       <li>Advanced MIDI scripting engine for maximum flexibility.</li>
-      <li>Vinyl emulation with Serato,Traktor, and Mixvibes timecode support.</li>
+      <li>Vinyl emulation with Serato, Traktor, and Mixvibes timecode support.</li>
       <li>Beat and key detection.</li>
       <li>ReplayGain volume normalization.</li>
       <li>Automatic crossfading with Auto DJ.</li>

--- a/src/mixxx.appdata.xml
+++ b/src/mixxx.appdata.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 Tuukka Pasanen <pasanen.tuukka@gmail.com> -->
+<application>
+  <id type="desktop">mixxx.desktop</id>
+  <metadata_license>GPL-2.0</metadata_license>
+  <description>
+    <p>
+        The most advanced free DJ software with Incredible Features, Unbeatable Value
+    </p>
+    <p> 
+      Mixxx has everything you need to start making DJ mixes in a tight, integrated package. Whether you're DJing your next house party, spinning at a club, or broadcasting as a radio DJ, Mixxx has what you need to do it right.
+    </p>
+    <ul>
+      <li>iTunes Integration. All your playlists and songs from iTunes, automatically ready to go for your next live DJ performance.
+          DJ MIDI Controller Support</li>
+      <li>With over 30 DJ MIDI controllers supported out-of-the-box, Mixxx gives you comprehensive hardware control for your DJ mixes.
+          BPM Detection and Sync</li>
+      <li>Instantly sync the tempo of two songs for seamless beatmixing. Need a break? Create a quick playlist and let Auto DJ take over.
+          Powerful Mixing Engine</li>
+      <li>Mixxx has a cutting-edge mixing engine including support for MP3, M4A/AAC, OGG, and FLAC audio, adjustable EQ shelves, timecode vinyl control, recording, and Shoutcast broadcasting.</li>
+    </ul>
+  </description>
+  <screenshots>
+    <screenshot type="default">http://www.mixxx.org/images/press_art/mixxx_1110_default_deere_skin.png</screenshot>
+  </screenshots>
+  <url type="homepage">http://mixxx.org</url>
+  <updatecontact>pasanen_dot_tuukka_at_gmail_dot_com</updatecontact>
+</application>

--- a/src/mixxx.appdata.xml
+++ b/src/mixxx.appdata.xml
@@ -1,28 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2014 Tuukka Pasanen <pasanen.tuukka@gmail.com> -->
+<!-- Author 2014 Tuukka Pasanen <pasanen.tuukka@gmail.com> -->
 <application>
   <id type="desktop">mixxx.desktop</id>
   <metadata_license>GPL-2.0</metadata_license>
   <description>
+    <p><b>Mixxx/</b> is free DJ software that gives you
+      everything you need to perform live DJ mixes. Blend songs together with
+      automatic BPM matching and remix on-the-fly with looping and hot cues.
+      Whether you're a pro DJ or just getting started, Mixxx has you covered.
+    </p>
     <p>
-        The most advanced free DJ software with Incredible Features, Unbeatable Value
+      <b>Mixxx</b> works with ALSA, JACK, OSS and supports many popular DJ
+      controllers.
     </p>
-    <p> 
-      Mixxx has everything you need to start making DJ mixes in a tight, integrated package. Whether you're DJing your next house party, spinning at a club, or broadcasting as a radio DJ, Mixxx has what you need to do it right.
-    </p>
+    <b>KEY FEATURES</b>
     <ul>
-      <li>iTunes Integration. All your playlists and songs from iTunes, automatically ready to go for your next live DJ performance.
-          DJ MIDI Controller Support</li>
-      <li>With over 30 DJ MIDI controllers supported out-of-the-box, Mixxx gives you comprehensive hardware control for your DJ mixes.
-          BPM Detection and Sync</li>
-      <li>Instantly sync the tempo of two songs for seamless beatmixing. Need a break? Create a quick playlist and let Auto DJ take over.
-          Powerful Mixing Engine</li>
-      <li>Mixxx has a cutting-edge mixing engine including support for MP3, M4A/AAC, OGG, and FLAC audio, adjustable EQ shelves, timecode vinyl control, recording, and Shoutcast broadcasting.</li>
-    </ul>
+      <li>Parallel or split scratchable waveform displays.</li>
+      <li>MP3, OGG, WAVE, FLAC, and optional AAC (M4A) playback.</li>
+      <li>WAVE, OGG, and optional MP3 recording.</li>
+      <li>Fast, database-powered library.</li>
+      <li>Crates and playlists for organizing your music.</li>
+      <li>Reads iTunes, Traktor, and Rhythmbox libraries.</li>
+      <li>Cross-platform - works on Windows, Mac OS X and Linux.</li>
+      <li>Shoutcast and Icecast broadcasting.</li>
+      <li>Support for many DJ MIDI &#38; HID controllers out-of-the-box.</li>
+      <li>Advanced MIDI scripting engine for maximum flexibility.</li>
+      <li>Vinyl emulation with Serato,Traktor, and Mixvibes timecode support.</li>
+      <li>Bulk BPM and beat detection.</li>
+      <li>ReplayGain volume normalization.</li>
+      <li>Automatic crossfading with Auto DJ.</li>
+      <li>Skinnable interface with several skins bundled.</li>
+     </ul>
+     <p>For a full list of features go to:
+     <a href="http://mixxx.org/features/" target="_top">http://mixxx.org/features/</a>
   </description>
   <screenshots>
     <screenshot type="default">http://www.mixxx.org/images/press_art/mixxx_1110_default_deere_skin.png</screenshot>
   </screenshots>
   <url type="homepage">http://mixxx.org</url>
-  <updatecontact>pasanen_dot_tuukka_at_gmail_dot_com</updatecontact>
+  <updatecontact>Mixxx Devel <mixxx-devel@lists.sourceforge.net></updatecontact>
 </application>

--- a/src/mixxx.appdata.xml
+++ b/src/mixxx.appdata.xml
@@ -23,7 +23,7 @@
       <li>Reads iTunes, Traktor, and Rhythmbox libraries.</li>
       <li>Cross-platform - works on Windows, Mac OS X and Linux.</li>
       <li>Shoutcast and Icecast broadcasting.</li>
-      <li>Support for many DJ MIDI &#38; HID controllers out-of-the-box.</li>
+      <li>Support for many DJ MIDI and HID controllers out-of-the-box.</li>
       <li>Advanced MIDI scripting engine for maximum flexibility.</li>
       <li>Vinyl emulation with Serato,Traktor, and Mixvibes timecode support.</li>
       <li>Beat and key detection.</li>

--- a/src/mixxx.appdata.xml
+++ b/src/mixxx.appdata.xml
@@ -26,7 +26,7 @@
       <li>Support for many DJ MIDI &#38; HID controllers out-of-the-box.</li>
       <li>Advanced MIDI scripting engine for maximum flexibility.</li>
       <li>Vinyl emulation with Serato,Traktor, and Mixvibes timecode support.</li>
-      <li>Bulk BPM and beat detection.</li>
+      <li>Beat and key detection.</li>
       <li>ReplayGain volume normalization.</li>
       <li>Automatic crossfading with Auto DJ.</li>
       <li>Skinnable interface with several skins bundled.</li>


### PR DESCRIPTION
Gnome is trying to get AppData XML file for applications so AppStream Gnome system would work. Fedora 22 plans to make applications that ship Appstream appdata first class apps. So here is XML file for Mixxx. Wording and stuff should be checked also is screenshot good enough.

Also should desktop and appdata only install when you on Linux or *BSD?
