### PR TITLE
New math_clamp() variants

### DIFF
--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -330,7 +330,7 @@ void EffectChainSlot::slotControlChainMix(double v) {
     // Clamp to [0.0, 1.0]
     if (v < 0.0 || v > 1.0) {
         qWarning() << debugString() << "value out of limits";
-        v = math_clamp_fast(v, 0.0, 1.0);
+        v = math_clamp_unsafe(v, 0.0, 1.0);
         m_pControlChainMix->set(v);
     }
     if (m_pEffectChain) {
@@ -344,7 +344,7 @@ void EffectChainSlot::slotControlChainParameter(double v) {
     // Clamp to [0.0, 1.0]
     if (v < 0.0 || v > 1.0) {
         qWarning() << debugString() << "value out of limits";
-        v = math_clamp_fast(v, 0.0, 1.0);
+        v = math_clamp_unsafe(v, 0.0, 1.0);
         m_pControlChainParameter->set(v);
     }
     for (int i = 0; i < m_slots.size(); ++i) {

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -330,7 +330,7 @@ void EffectChainSlot::slotControlChainMix(double v) {
     // Clamp to [0.0, 1.0]
     if (v < 0.0 || v > 1.0) {
         qWarning() << debugString() << "value out of limits";
-        v = math_clamp(v, 0.0, 1.0);
+        v = math_clamp_fast(v, 0.0, 1.0);
         m_pControlChainMix->set(v);
     }
     if (m_pEffectChain) {
@@ -344,7 +344,7 @@ void EffectChainSlot::slotControlChainParameter(double v) {
     // Clamp to [0.0, 1.0]
     if (v < 0.0 || v > 1.0) {
         qWarning() << debugString() << "value out of limits";
-        v = math_clamp(v, 0.0, 1.0);
+        v = math_clamp_fast(v, 0.0, 1.0);
         m_pControlChainParameter->set(v);
     }
     for (int i = 0; i < m_slots.size(); ++i) {

--- a/src/effects/native/bitcrushereffect.cpp
+++ b/src/effects/native/bitcrushereffect.cpp
@@ -1,5 +1,5 @@
 #include "effects/native/bitcrushereffect.h"
-#include "util/math.h"
+#include "sampleutil.h"
 
 // static
 QString BitCrusherEffect::getId() {
@@ -92,8 +92,8 @@ void BitCrusherEffect::processGroup(const QString& group,
             pState->accumulator -= 1.0;
             if (bit_depth < 16) {
 
-                pState->hold_l = floorf(CSAMPLE_clamp(pInput[i] * gainCorrection) * scale + 0.5f) / scale / gainCorrection;
-                pState->hold_r = floorf(CSAMPLE_clamp(pInput[i+1] * gainCorrection) * scale + 0.5f) / scale / gainCorrection;
+                pState->hold_l = floorf(SampleUtil::clampSample(pInput[i] * gainCorrection) * scale + 0.5f) / scale / gainCorrection;
+                pState->hold_r = floorf(SampleUtil::clampSample(pInput[i+1] * gainCorrection) * scale + 0.5f) / scale / gainCorrection;
             } else {
                 // Mixxx float has 24 bit depth, Audio CDs are 16 bit
                 // here we do not change the depth

--- a/src/effects/native/bitcrushereffect.cpp
+++ b/src/effects/native/bitcrushereffect.cpp
@@ -92,8 +92,8 @@ void BitCrusherEffect::processGroup(const QString& group,
             pState->accumulator -= 1.0;
             if (bit_depth < 16) {
 
-                pState->hold_l = floorf(math_clamp(pInput[i] * gainCorrection, -1.0f, 1.0f) * scale + 0.5f) / scale / gainCorrection;
-                pState->hold_r = floorf(math_clamp(pInput[i+1] * gainCorrection, -1.0f, 1.0f) * scale + 0.5f) / scale / gainCorrection;
+                pState->hold_l = floorf(CSAMPLE_clamp(pInput[i] * gainCorrection) * scale + 0.5f) / scale / gainCorrection;
+                pState->hold_r = floorf(CSAMPLE_clamp(pInput[i+1] * gainCorrection) * scale + 0.5f) / scale / gainCorrection;
             } else {
                 // Mixxx float has 24 bit depth, Audio CDs are 16 bit
                 // here we do not change the depth

--- a/src/engine/enginepregain.cpp
+++ b/src/engine/enginepregain.cpp
@@ -111,7 +111,7 @@ void EnginePregain::process(CSAMPLE* pInOut, const int iBufferSize) {
     // Clamp gain to within [0, 10.0] to prevent insane gains. This can happen
     // (some corrupt files get really high replay gain values).
     // 10 allows a maximum replay Gain Boost * calculated replay gain of ~2
-    fGain = fGain * math_clamp(fReplayGainCorrection, 0.0f, 10.0f);
+    fGain = fGain * math_clamp_fast(fReplayGainCorrection, 0.0f, 10.0f);
 
     m_pTotalGain->set(fGain);
 

--- a/src/engine/enginepregain.cpp
+++ b/src/engine/enginepregain.cpp
@@ -111,7 +111,7 @@ void EnginePregain::process(CSAMPLE* pInOut, const int iBufferSize) {
     // Clamp gain to within [0, 10.0] to prevent insane gains. This can happen
     // (some corrupt files get really high replay gain values).
     // 10 allows a maximum replay Gain Boost * calculated replay gain of ~2
-    fGain = fGain * math_clamp_fast(fReplayGainCorrection, 0.0f, 10.0f);
+    fGain = fGain * math_clamp_unsafe(fReplayGainCorrection, 0.0f, 10.0f);
 
     m_pTotalGain->set(fGain);
 

--- a/src/test/mathutiltest.cpp
+++ b/src/test/mathutiltest.cpp
@@ -1,0 +1,69 @@
+#include <gtest/gtest.h>
+#include "util/math.h"
+
+#include <QtDebug>
+
+namespace {
+
+class MathUtilTest : public testing::Test {
+  protected:
+
+    MathUtilTest() {
+    }
+
+    virtual void SetUp() {
+    }
+
+    virtual void TearDown() {
+    }
+
+    static const int MIN;
+    static const int MAX;
+
+    static const int VALUE_MIN;
+    static const int VALUE_MAX;
+};
+
+const int MathUtilTest::MIN = -10;
+const int MathUtilTest::MAX = 10;
+
+const int MathUtilTest::VALUE_MIN = 2 * MathUtilTest::MIN;
+const int MathUtilTest::VALUE_MAX = 2  * MathUtilTest::MAX;
+
+TEST_F(MathUtilTest, MathClampUnsafe) {
+    for (int i = VALUE_MIN; i <= VALUE_MAX; ++i) {
+        EXPECT_LE(MIN, math_clamp_unsafe(i, MIN, MAX));
+        EXPECT_GE(MAX, math_clamp_unsafe(i, MIN, MAX));
+        EXPECT_EQ(MIN, math_clamp_unsafe(i, MIN, MIN));
+        EXPECT_EQ(MAX, math_clamp_unsafe(i, MAX, MAX));
+        if (MIN >= i) {
+            EXPECT_EQ(MIN, math_clamp_unsafe(i, MIN, MAX));
+        }
+        if (MAX <= i) {
+            EXPECT_EQ(MAX, math_clamp_unsafe(i, MIN, MAX));
+        }
+    }
+}
+
+TEST_F(MathUtilTest, MathClampSafe) {
+    for (int i = VALUE_MIN; i <= VALUE_MAX; ++i) {
+        EXPECT_LE(MIN, math_clamp_safe(i, MIN, MAX));
+        EXPECT_GE(MAX, math_clamp_safe(i, MIN, MAX));
+        EXPECT_EQ(MIN, math_clamp_safe(i, MIN, MIN));
+        EXPECT_EQ(MAX, math_clamp_safe(i, MAX, MAX));
+        if (MIN >= i) {
+            EXPECT_EQ(MIN, math_clamp_safe(i, MIN, MAX));
+        }
+        if (MAX <= i) {
+            EXPECT_EQ(MAX, math_clamp_safe(i, MIN, MAX));
+        }
+    }
+}
+
+TEST_F(MathUtilTest, MathClampSafeInvalidBounds) {
+    for (int i = VALUE_MIN; i <= VALUE_MAX; ++i) {
+        EXPECT_EQ(i, math_clamp_safe(i, MAX, MIN));
+    }
+}
+
+}  // namespace

--- a/src/util/math.h
+++ b/src/util/math.h
@@ -20,14 +20,24 @@ using std::fabs;
 #define math_max3(a, b, c) math_max(math_max((a), (b)), (c))
 
 template <typename T>
-inline T math_clamp(T value, T min, T max) {
+inline T math_clamp_fast(T value, T min, T max) {
+    return math_max(min, math_min(max, value));
+}
+
+template <typename T>
+inline T math_clamp_safe(T value, T min, T max) {
     // XXX: If max < min, behavior is undefined, and has been causing problems.
     // if debugging is on, assert when this happens.
     if (CmdlineArgs::Instance().getDeveloper() && max < min) {
         qWarning() << "PROGRAMMING ERROR: math_clamp called with max < min! "
                    << max << " " << min;
     }
-    return math_max(min, math_min(max, value));
+    return math_clamp_fast(value, min, max);
+}
+
+template <typename T>
+inline T math_clamp(T value, T min, T max) {
+    return math_clamp_safe(value, min, max);
 }
 
 // NOTE(rryan): It is an error to call even() on a floating point number. Do not

--- a/src/util/math.h
+++ b/src/util/math.h
@@ -9,8 +9,6 @@
 
 #include <QtDebug>
 
-#include "util/cmdlineargs.h"
-
 // If we don't do this then we get the C90 fabs from the global namespace which
 // is only defined for double.
 using std::fabs;
@@ -28,7 +26,7 @@ template <typename T>
 inline T math_clamp_safe(T value, T min, T max) {
     // XXX: If max < min, behavior is undefined, and has been causing problems.
     // if debugging is on, assert when this happens.
-    if (CmdlineArgs::Instance().getDeveloper() && max < min) {
+    if (max < min) {
         qWarning() << "PROGRAMMING ERROR: math_clamp called with max < min! "
                    << max << " " << min;
     }

--- a/src/util/math.h
+++ b/src/util/math.h
@@ -17,15 +17,17 @@ using std::fabs;
 #define math_min std::min
 #define math_max3(a, b, c) math_max(math_max((a), (b)), (c))
 
+// Restrict value to the range [min, max]. Undefined behavior
+// if min > max.
 template <typename T>
 inline T math_clamp_unsafe(T value, T min, T max) {
     return math_max(min, math_min(max, value));
 }
 
+// Clamp with bounds checking to avoid undefined behavior
+// on invalid min/max parameters.
 template <typename T>
 inline T math_clamp_safe(T value, T min, T max) {
-    // XXX: If max < min, behavior is undefined, and has been causing problems.
-    // if debugging is on, assert when this happens.
     if (min <= max) {
         // valid bounds
         return math_clamp_unsafe(value, min, max);

--- a/src/util/math.h
+++ b/src/util/math.h
@@ -26,11 +26,16 @@ template <typename T>
 inline T math_clamp_safe(T value, T min, T max) {
     // XXX: If max < min, behavior is undefined, and has been causing problems.
     // if debugging is on, assert when this happens.
-    if (max < min) {
-        qWarning() << "PROGRAMMING ERROR: math_clamp called with max < min! "
-                   << max << " " << min;
+    if (min <= max) {
+        // valid bounds
+        return math_clamp_unsafe(value, min, max);
+    } else {
+        // invalid bounds
+        qWarning() << "PROGRAMMING ERROR: math_clamp_safe() called with min > max!"
+                   << min << ">" << max;
+        // simply return the value unchanged
+        return value;
     }
-    return math_clamp_unsafe(value, min, max);
 }
 
 template <typename T>

--- a/src/util/math.h
+++ b/src/util/math.h
@@ -18,7 +18,7 @@ using std::fabs;
 #define math_max3(a, b, c) math_max(math_max((a), (b)), (c))
 
 template <typename T>
-inline T math_clamp_fast(T value, T min, T max) {
+inline T math_clamp_unsafe(T value, T min, T max) {
     return math_max(min, math_min(max, value));
 }
 
@@ -30,7 +30,7 @@ inline T math_clamp_safe(T value, T min, T max) {
         qWarning() << "PROGRAMMING ERROR: math_clamp called with max < min! "
                    << max << " " << min;
     }
-    return math_clamp_fast(value, min, max);
+    return math_clamp_unsafe(value, min, max);
 }
 
 template <typename T>

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -15,13 +15,13 @@ const SAMPLE SAMPLE_MAX = SHRT_MAX;
 // Limits the range of a SAMPLE value to [SAMPLE_MIN, SAMPLE_MAX].
 inline
 SAMPLE SAMPLE_clamp(SAMPLE in) {
-    return math_clamp(in, SAMPLE_MIN, SAMPLE_MAX);
+    return math_clamp_fast(in, SAMPLE_MIN, SAMPLE_MAX);
 }
 
 // Limits the range of a SAMPLE value to [-SAMPLE_MAX, SAMPLE_MAX].
 inline
 SAMPLE SAMPLE_clampSymmetric(SAMPLE in) {
-    return math_clamp(in, static_cast<SAMPLE>(-SAMPLE_MAX), SAMPLE_MAX);
+    return math_clamp_fast(in, static_cast<SAMPLE>(-SAMPLE_MAX), SAMPLE_MAX);
 }
 
 // 32-bit single precision floating-point sample data
@@ -37,7 +37,7 @@ const CSAMPLE CSAMPLE_PEAK = CSAMPLE_ONE;
 // Limits the range of a CSAMPLE value to [-CSAMPLE_PEAK, CSAMPLE_PEAK].
 inline
 CSAMPLE CSAMPLE_clamp(CSAMPLE in) {
-    return math_clamp(in, -CSAMPLE_PEAK, CSAMPLE_PEAK);
+    return math_clamp_fast(in, -CSAMPLE_PEAK, CSAMPLE_PEAK);
 }
 
 // Gain values for weighted calculations of CSAMPLE
@@ -52,7 +52,7 @@ const float CSAMPLE_GAIN_MAX = CSAMPLE_GAIN_ONE;
 // Limits the range of a CSAMPLE_GAIN value to [CSAMPLE_GAIN_MIN, CSAMPLE_GAIN_MAX].
 inline
 CSAMPLE_GAIN CSAMPLE_GAIN_clamp(CSAMPLE_GAIN in) {
-    return math_clamp(in, CSAMPLE_GAIN_MIN, CSAMPLE_GAIN_MAX);
+    return math_clamp_fast(in, CSAMPLE_GAIN_MIN, CSAMPLE_GAIN_MAX);
 }
 
 #endif /* TYPES_H */

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -15,13 +15,13 @@ const SAMPLE SAMPLE_MAX = SHRT_MAX;
 // Limits the range of a SAMPLE value to [SAMPLE_MIN, SAMPLE_MAX].
 inline
 SAMPLE SAMPLE_clamp(SAMPLE in) {
-    return math_clamp_fast(in, SAMPLE_MIN, SAMPLE_MAX);
+    return math_clamp_unsafe(in, SAMPLE_MIN, SAMPLE_MAX);
 }
 
 // Limits the range of a SAMPLE value to [-SAMPLE_MAX, SAMPLE_MAX].
 inline
 SAMPLE SAMPLE_clampSymmetric(SAMPLE in) {
-    return math_clamp_fast(in, static_cast<SAMPLE>(-SAMPLE_MAX), SAMPLE_MAX);
+    return math_clamp_unsafe(in, static_cast<SAMPLE>(-SAMPLE_MAX), SAMPLE_MAX);
 }
 
 // 32-bit single precision floating-point sample data
@@ -37,7 +37,7 @@ const CSAMPLE CSAMPLE_PEAK = CSAMPLE_ONE;
 // Limits the range of a CSAMPLE value to [-CSAMPLE_PEAK, CSAMPLE_PEAK].
 inline
 CSAMPLE CSAMPLE_clamp(CSAMPLE in) {
-    return math_clamp_fast(in, -CSAMPLE_PEAK, CSAMPLE_PEAK);
+    return math_clamp_unsafe(in, -CSAMPLE_PEAK, CSAMPLE_PEAK);
 }
 
 // Gain values for weighted calculations of CSAMPLE
@@ -52,7 +52,7 @@ const float CSAMPLE_GAIN_MAX = CSAMPLE_GAIN_ONE;
 // Limits the range of a CSAMPLE_GAIN value to [CSAMPLE_GAIN_MIN, CSAMPLE_GAIN_MAX].
 inline
 CSAMPLE_GAIN CSAMPLE_GAIN_clamp(CSAMPLE_GAIN in) {
-    return math_clamp_fast(in, CSAMPLE_GAIN_MIN, CSAMPLE_GAIN_MAX);
+    return math_clamp_unsafe(in, CSAMPLE_GAIN_MIN, CSAMPLE_GAIN_MAX);
 }
 
 #endif /* TYPES_H */

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -274,7 +274,7 @@ bool WaveformWidgetFactory::setWaveformWidget(WWaveformViewer* viewer,
 }
 
 void WaveformWidgetFactory::setFrameRate(int frameRate) {
-    m_frameRate = math_clamp(frameRate, 1, 120);
+    m_frameRate = math_clamp_fast(frameRate, 1, 120);
     if (m_config) {
         m_config->set(ConfigKey("[Waveform]","FrameRate"), ConfigValue(m_frameRate));
     }

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -274,7 +274,7 @@ bool WaveformWidgetFactory::setWaveformWidget(WWaveformViewer* viewer,
 }
 
 void WaveformWidgetFactory::setFrameRate(int frameRate) {
-    m_frameRate = math_clamp_fast(frameRate, 1, 120);
+    m_frameRate = math_clamp_unsafe(frameRate, 1, 120);
     if (m_config) {
         m_config->set(ConfigKey("[Waveform]","FrameRate"), ConfigValue(m_frameRate));
     }

--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -33,7 +33,7 @@ class KnobEventHandler {
         double value = pWidget->getControlParameter() + dist / 127.0;
 
         // Clamp to [0.0, 1.0]
-        value = math_clamp(value, 0.0, 1.0);
+        value = math_clamp_fast(value, 0.0, 1.0);
 
         return value;
     }
@@ -89,7 +89,7 @@ class KnobEventHandler {
         double newValue = pWidget->getControlParameter() + wheelDirection;
 
         // Clamp to [0.0, 1.0]
-        newValue = math_clamp(newValue, 0.0, 1.0);
+        newValue = math_clamp_fast(newValue, 0.0, 1.0);
 
         pWidget->setControlParameter(newValue);
         pWidget->update();

--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -33,7 +33,7 @@ class KnobEventHandler {
         double value = pWidget->getControlParameter() + dist / 127.0;
 
         // Clamp to [0.0, 1.0]
-        value = math_clamp_fast(value, 0.0, 1.0);
+        value = math_clamp_unsafe(value, 0.0, 1.0);
 
         return value;
     }
@@ -89,7 +89,7 @@ class KnobEventHandler {
         double newValue = pWidget->getControlParameter() + wheelDirection;
 
         // Clamp to [0.0, 1.0]
-        newValue = math_clamp_fast(newValue, 0.0, 1.0);
+        newValue = math_clamp_unsafe(newValue, 0.0, 1.0);
 
         pWidget->setControlParameter(newValue);
         pWidget->update();

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -138,7 +138,7 @@ void WOverview::onConnectedControlChanged(double dParameter, double dValue) {
     if (!m_bDrag) {
         // Calculate handle position. Clamp the value within 0-1 because that's
         // all we represent with this widget.
-        dParameter = math_clamp(dParameter, 0.0, 1.0);
+        dParameter = math_clamp_fast(dParameter, 0.0, 1.0);
 
         int iPos = valueToPosition(dParameter);
         if (iPos != m_iPos) {

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -138,7 +138,7 @@ void WOverview::onConnectedControlChanged(double dParameter, double dValue) {
     if (!m_bDrag) {
         // Calculate handle position. Clamp the value within 0-1 because that's
         // all we represent with this widget.
-        dParameter = math_clamp_fast(dParameter, 0.0, 1.0);
+        dParameter = math_clamp_unsafe(dParameter, 0.0, 1.0);
 
         int iPos = valueToPosition(dParameter);
         if (iPos != m_iPos) {

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -156,7 +156,7 @@ void WSliderComposed::wheelEvent(QWheelEvent *e) {
     double newValue = m_dOldValue + wheelDirection;
 
     // Clamp to [0.0, 1.0]
-    newValue = math_clamp(newValue, 0.0, 1.0);
+    newValue = math_clamp_fast(newValue, 0.0, 1.0);
 
     setControlParameter(newValue);
     // Value is unused in WSliderComposed.

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -156,7 +156,7 @@ void WSliderComposed::wheelEvent(QWheelEvent *e) {
     double newValue = m_dOldValue + wheelDirection;
 
     // Clamp to [0.0, 1.0]
-    newValue = math_clamp_fast(newValue, 0.0, 1.0);
+    newValue = math_clamp_unsafe(newValue, 0.0, 1.0);
 
     setControlParameter(newValue);
     // Value is unused in WSliderComposed.

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -161,7 +161,7 @@ void WVuMeter::updateState(double msecsElapsed) {
     m_dPeakParameter -= static_cast<double>(m_iPeakFallStep) *
             msecsElapsed /
             static_cast<double>(m_iPeakFallTime * m_iNoPos);
-    m_dPeakParameter = math_clamp(m_dPeakParameter, 0.0, 1.0);
+    m_dPeakParameter = math_clamp_fast(m_dPeakParameter, 0.0, 1.0);
     m_iPeakPos = math_clamp(static_cast<int>(m_dPeakParameter * m_iNoPos),
                             0, m_iNoPos);
 }

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -161,7 +161,7 @@ void WVuMeter::updateState(double msecsElapsed) {
     m_dPeakParameter -= static_cast<double>(m_iPeakFallStep) *
             msecsElapsed /
             static_cast<double>(m_iPeakFallTime * m_iNoPos);
-    m_dPeakParameter = math_clamp_fast(m_dPeakParameter, 0.0, 1.0);
+    m_dPeakParameter = math_clamp_unsafe(m_dPeakParameter, 0.0, 1.0);
     m_iPeakPos = math_clamp(static_cast<int>(m_dPeakParameter * m_iNoPos),
                             0, m_iNoPos);
 }

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -110,7 +110,7 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
         // where this value is handled.
         double v = 0.5 + (diff.x() / 1270.0);
         // clamp to [0.0, 1.0]
-        v = math_clamp_fast(v, 0.0, 1.0);
+        v = math_clamp_unsafe(v, 0.0, 1.0);
         m_pWheel->setParameter(v);
     }
 }

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -110,7 +110,7 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
         // where this value is handled.
         double v = 0.5 + (diff.x() / 1270.0);
         // clamp to [0.0, 1.0]
-        v = math_clamp(v, 0.0, 1.0);
+        v = math_clamp_fast(v, 0.0, 1.0);
         m_pWheel->setParameter(v);
     }
 }


### PR DESCRIPTION
There are several cases that don't need an additional runtime check of the bounds. The default math_clamp() function will still use the safe variant as before.
