### PR TITLE
Enabling parsed svg for spinny + cleaning

### DIFF
--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -14,6 +14,7 @@ SkinContext::SkinContext(ConfigObject<ConfigValue>* pConfig,
                          const QString& xmlPath)
         : m_pConfig(pConfig),
           m_xmlPath(xmlPath) {
+    enableDebugger();
 }
 
 SkinContext::SkinContext(const SkinContext& parent)
@@ -26,12 +27,7 @@ SkinContext::SkinContext(const SkinContext& parent)
          it != m_variables.end(); ++it) {
         context.setProperty(it.key(), it.value());
     }
-
-    if (CmdlineArgs::Instance().getDeveloper() && m_pConfig->getValueString(
-        ConfigKey("[ScriptDebugger]", "Enabled")) == "1") {
-        // Enable script debugger
-        m_debugger.attachTo(&m_scriptEngine);
-    }
+    enableDebugger();
 }
 
 SkinContext::~SkinContext() {
@@ -45,6 +41,13 @@ SkinContext& SkinContext::operator=(const SkinContext& other) {
         context.setProperty(it.key(), it.value());
     }
     return *this;
+}
+
+void SkinContext::enableDebugger() const {
+    if (CmdlineArgs::Instance().getDeveloper() && m_pConfig->getValueString(
+        ConfigKey("[ScriptDebugger]", "Enabled")) == "1") {
+        m_debugger.attachTo(&m_scriptEngine);
+    }
 }
 
 QString SkinContext::variable(const QString& name) const {

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -14,7 +14,7 @@ SkinContext::SkinContext(ConfigObject<ConfigValue>* pConfig,
                          const QString& xmlPath)
         : m_pConfig(pConfig),
           m_xmlPath(xmlPath) {
-    enableDebugger();
+    enableScriptDebugger();
 }
 
 SkinContext::SkinContext(const SkinContext& parent)
@@ -27,7 +27,7 @@ SkinContext::SkinContext(const SkinContext& parent)
          it != m_variables.end(); ++it) {
         context.setProperty(it.key(), it.value());
     }
-    enableDebugger();
+    enableScriptDebugger();
 }
 
 SkinContext::~SkinContext() {
@@ -43,7 +43,7 @@ SkinContext& SkinContext::operator=(const SkinContext& other) {
     return *this;
 }
 
-void SkinContext::enableDebugger() const {
+void SkinContext::enableScriptDebugger() {
     if (CmdlineArgs::Instance().getDeveloper() && m_pConfig->getValueString(
         ConfigKey("[ScriptDebugger]", "Enabled")) == "1") {
         m_debugger.attachTo(&m_scriptEngine);

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -73,7 +73,7 @@ class SkinContext {
                                 int lineNumber=1);
     QScriptValue importScriptExtension(const QString& extensionName);
     const QScriptEngine& getScriptEngine() const;
-    void enableDebugger() const;
+    void enableScriptDebugger();
 
   private:
     QString variableNodeToText(const QDomElement& element) const;

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -73,6 +73,7 @@ class SkinContext {
                                 int lineNumber=1);
     QScriptValue importScriptExtension(const QString& extensionName);
     const QScriptEngine& getScriptEngine() const;
+    void enableDebugger() const;
 
   private:
     QString variableNodeToText(const QDomElement& element) const;

--- a/src/widget/wimagestore.cpp
+++ b/src/widget/wimagestore.cpp
@@ -34,12 +34,11 @@ QImage* WImageStore::getImage(const PixmapSource& source) {
     // Image wasn't found, construct it
     //qDebug() << "WImageStore Loading Image from file" << source.getPath();
 
-    QImage* loadedImage = getImageNoCache(source.getPath());
+    QImage* loadedImage = getImageNoCache(source);
 
     if (loadedImage == NULL) {
         return NULL;
     }
-
 
     if (loadedImage->isNull()) {
         qDebug() << "WImageStore couldn't load:" << source.getPath() << (loadedImage == NULL);
@@ -54,7 +53,6 @@ QImage* WImageStore::getImage(const PixmapSource& source) {
     return info->image;
 }
 
-/**/
 // static
 QImage* WImageStore::getImageNoCache(const PixmapSource& source) {
     QImage* pImage;

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -75,14 +75,15 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
             
             int iState = stateContext.selectInt(state, "Number");
             if (iState < m_iNoStates) {
-                PixmapSource pixmapSource;
                 
-                pixmapSource = stateContext.getPixmapSource(stateContext.selectNode(state, "Unpressed"));
+                PixmapSource pixmapSource = stateContext.getPixmapSource(
+                    stateContext.selectNode(state, "Unpressed"));
                 if (!pixmapSource.isEmpty()) {
                     setPixmap(iState, false, pixmapSource);
                 }
                 
-                pixmapSource = stateContext.getPixmapSource(stateContext.selectNode(state, "Pressed"));
+                pixmapSource = stateContext.getPixmapSource(
+                    stateContext.selectNode(state, "Pressed"));
                 if (!pixmapSource.isEmpty()) {
                     setPixmap(iState, true, pixmapSource);
                 }


### PR DESCRIPTION
- The parsed svg wasn't use by wimagestore for the spinny widget.
- The script debugger wasn't enabled in the root skincontext.
- Cleaning
