### PR TITLE
Use one script engine and one script debugger to avoid slow down of the skin parsing 

### DIFF
--- a/script/svg/__init__.js
+++ b/script/svg/__init__.js
@@ -3,6 +3,13 @@ __setupPackage__(__extension__);
  * This extension provides the api to add hooks into attributes in
  * the SVG parser.
  */
+
+function isNumber(n) {
+  return !isNaN(parseFloat(n)) && isFinite(n);
+}
+
+
+
 (function(){
 
     svg.templateHooks = {};

--- a/script/svg/__init__.js
+++ b/script/svg/__init__.js
@@ -3,55 +3,58 @@ __setupPackage__(__extension__);
  * This extension provides the api to add hooks into attributes in
  * the SVG parser.
  */
-svg.templateHooks = {};
+(function(){
 
-svg.regexpQuote = function (str, delimiter) {
-    return String(str).replace(
-        new RegExp(
-            '[.\\\\+*?\\[\\^\\]$(){}=!<>|:\\' + (delimiter || '') + '-]',
-            'g'
-        ),
-        '\\$&'
-    );
-}
+    svg.templateHooks = {};
 
-svg.getHooksPattern = function(){
-    var hookNames = [],
-        that = this;
-    for( var i in this.templateHooks )
-        hookNames.push(i);
-    
-    // hook_name( arg1 [, arg2]... )
-    if( hookNames.length ){
-        var pattern = "("+hookNames.join('|')+")\\(([^\\(\\)]+)\\)\\s*;?";
-        return pattern;
+    svg.regexpQuote = function (str, delimiter) {
+        return String(str).replace(
+            new RegExp(
+                '[.\\\\+*?\\[\\^\\]$(){}=!<>|:\\' + (delimiter || '') + '-]',
+                'g'
+            ),
+            '\\$&'
+        );
     }
-}
 
-global = this;
-svg.templateHooks.variable = function( varName ){
-    if( varName in global ){
-        return global[varName];
-    }
-    return '';
-}
-
-svg.templateHooks.prop = function( propName, varName ){
-    var out = '';
-    
-    if( (varName in global) ){
-        var value = global[varName];
+    svg.getHooksPattern = function(){
+        var hookNames = [],
+            that = this;
+        for( var i in this.templateHooks )
+            hookNames.push(i);
         
-        if( isNumber(value) ){
-            out = propName + ':' + value + ';';
-        } else if( value.length ) {
-            out = propName + ':' + value + ';';
+        // hook_name( arg1 [, arg2]... )
+        if( hookNames.length ){
+            var pattern = "("+hookNames.join('|')+")\\(([^\\(\\)]+)\\)\\s*;?";
+            return pattern;
+        }
+    }
+
+    var global = this;
+    svg.templateHooks.variable = function( varName ){
+        if( varName in global ){
+            return global[varName];
+        }
+        return '';
+    }
+
+    svg.templateHooks.prop = function( propName, varName ){
+        var out = '';
+        
+        if( (varName in global) ){
+            var value = global[varName];
+            
+            if( isNumber(value) ){
+                out = propName + ':' + value + ';';
+            } else if( value.length ) {
+                out = propName + ':' + value + ';';
+            }
+            
+        } else {
+            console.log( 'Unable to find ' + varName + ' for prop hook.' );
         }
         
-    } else {
-        console.log( 'Unable to find ' + varName + ' for prop hook.' );
+        return out;
     }
-    
-    return out;
-}
+})();
 

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -19,8 +19,9 @@ SkinContext::SkinContext(ConfigObject<ConfigValue>* pConfig,
           m_xmlPath(xmlPath) {
     if (CmdlineArgs::Instance().getDeveloper() && m_pConfig->getValueString(
         ConfigKey("[ScriptDebugger]", "Enabled")) == "1") {
-        m_debugger->attachTo(m_scriptEngine.data());
+        enableDebugger(true);
     }
+    // m_scriptEngine->installTranslatorFunctions();
 }
 
 SkinContext::SkinContext(const SkinContext& parent)
@@ -34,6 +35,10 @@ SkinContext::SkinContext(const SkinContext& parent)
     
     for (QHash<QString, QString>::const_iterator it = m_variables.begin();
          it != m_variables.end(); ++it) {
+        if(it.key() == "color")
+            qDebug() << "!!!!!!!!!!!!!!!!!!!!!!!! Setting variable : " << it.key() << " => " << it.value();
+        else
+            qDebug() << "Setting variable : " << it.key() << " => " << it.value();
         context.setProperty(it.key(), it.value());
     }
 }
@@ -60,6 +65,7 @@ void SkinContext::setVariable(const QString& name, const QString& value) {
     m_variables[name] = value;
     QScriptValue context = m_scriptEngine->currentContext()->activationObject();
     context.setProperty(name, value);
+    qDebug() << "!!!!!!!!!!!!!!!!!----- Setting variable : " << name << " => " << value;
 }
 
 void SkinContext::setXmlPath(const QString& xmlPath) {
@@ -280,7 +286,14 @@ QScriptValue SkinContext::importScriptExtension(const QString& extensionName) {
     return out;
 }
 
-// const QScriptEngine& SkinContext::getScriptEngine() const {
 const QScriptEngine* SkinContext::getScriptEngine() const {
     return m_scriptEngine.data();
 }
+
+void SkinContext::enableDebugger(bool state) const {
+    if( state )
+        m_debugger->attachTo(m_scriptEngine.data());
+    else 
+        m_debugger->detach();
+}
+

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -73,6 +73,7 @@ class SkinContext {
                                 int lineNumber=1);
     QScriptValue importScriptExtension(const QString& extensionName);
     const QScriptEngine* getScriptEngine() const;
+    void enableDebugger(bool state) const;
 
   private:
     QString variableNodeToText(const QDomElement& element) const;

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -23,8 +23,6 @@ class SkinContext {
     SkinContext(const SkinContext& parent);
     virtual ~SkinContext();
 
-    SkinContext& operator=(const SkinContext& other);
-
     // Gets a path relative to the skin path.
     QString getSkinPath(const QString& relativePath) const {
         return QDir(m_skinBasePath).filePath(relativePath);
@@ -72,7 +70,7 @@ class SkinContext {
                                 const QString& filename=QString(),
                                 int lineNumber=1);
     QScriptValue importScriptExtension(const QString& extensionName);
-    const QScriptEngine* getScriptEngine() const;
+    const QSharedPointer<QScriptEngine> getScriptEngine() const;
     void enableDebugger(bool state) const;
 
   private:

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -81,12 +81,9 @@ class SkinContext {
     QHash<QString, QString> m_variables;
     QString m_skinBasePath;
     ConfigObject<ConfigValue>* m_pConfig;
-    // mutable QSharedPointer<QScriptEngine> m_scriptEngine;   // todo m_pScriptEngine
-    QSharedPointer<QScriptEngine> m_scriptEngine;   // todo m_pScriptEngine
-    QSharedPointer<QScriptEngineDebugger> m_debugger;       // idem
-    QSharedPointer<QScriptContext> m_scriptContext;
+    QSharedPointer<QScriptEngine> m_pScriptEngine;
+    QSharedPointer<QScriptEngineDebugger> m_pScriptDebugger;
     QString m_xmlPath;
-    QScriptValue m_context;
     
     QHash<QString, QScriptProgram> m_scriptPrograms;
     QScriptValue m_parentGlobal;

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -81,10 +81,15 @@ class SkinContext {
     QHash<QString, QString> m_variables;
     QString m_skinBasePath;
     ConfigObject<ConfigValue>* m_pConfig;
-    mutable QSharedPointer<QScriptEngine> m_scriptEngine;   // todo m_pScriptEngine
+    // mutable QSharedPointer<QScriptEngine> m_scriptEngine;   // todo m_pScriptEngine
+    QSharedPointer<QScriptEngine> m_scriptEngine;   // todo m_pScriptEngine
     QSharedPointer<QScriptEngineDebugger> m_debugger;       // idem
+    QSharedPointer<QScriptContext> m_scriptContext;
     QString m_xmlPath;
+    QScriptValue m_context;
     
+    QHash<QString, QScriptProgram> m_scriptPrograms;
+    QScriptValue m_parentGlobal;
 };
 
 #endif /* SKINCONTEXT_H */

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -78,14 +78,13 @@ class SkinContext {
   private:
     QString variableNodeToText(const QDomElement& element) const;
 
-    QHash<QString, QString> m_variables;
+    QString m_xmlPath;
     QString m_skinBasePath;
     ConfigObject<ConfigValue>* m_pConfig;
+    
+    QHash<QString, QString> m_variables;
     QSharedPointer<QScriptEngine> m_pScriptEngine;
     QSharedPointer<QScriptEngineDebugger> m_pScriptDebugger;
-    QString m_xmlPath;
-    
-    QHash<QString, QScriptProgram> m_scriptPrograms;
     QScriptValue m_parentGlobal;
 };
 

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -72,18 +72,18 @@ class SkinContext {
                                 const QString& filename=QString(),
                                 int lineNumber=1);
     QScriptValue importScriptExtension(const QString& extensionName);
-    const QScriptEngine& getScriptEngine() const;
-    void enableScriptDebugger();
+    const QScriptEngine* getScriptEngine() const;
 
   private:
     QString variableNodeToText(const QDomElement& element) const;
 
-    mutable QScriptEngine m_scriptEngine;
-    QScriptEngineDebugger m_debugger;
     QHash<QString, QString> m_variables;
     QString m_skinBasePath;
     ConfigObject<ConfigValue>* m_pConfig;
+    mutable QSharedPointer<QScriptEngine> m_scriptEngine;   // todo m_pScriptEngine
+    QSharedPointer<QScriptEngineDebugger> m_debugger;       // idem
     QString m_xmlPath;
+    
 };
 
 #endif /* SKINCONTEXT_H */

--- a/src/skin/svgparser.cpp
+++ b/src/skin/svgparser.cpp
@@ -119,7 +119,7 @@ void SvgParser::parseAttributes(const QDomNode& node) const {
     QDomElement element = node.toElement();
 
     // Retrieving hooks pattern from script extension
-    QScriptValue global = m_context.getScriptEngine().globalObject();
+    QScriptValue global = m_context.getScriptEngine()->globalObject();
     QScriptValue hooksPattern = global.property("svg")
         .property("getHooksPattern").call(global.property("svg"));
     QRegExp hookRx;
@@ -177,7 +177,7 @@ QScriptValue SvgParser::evaluateTemplateExpression(const QString& expression,
                                                    int lineNumber) const {
     QScriptValue out = m_context.evaluateScript(
         expression, m_currentFile, lineNumber);
-    if (m_context.getScriptEngine().hasUncaughtException()) {
+    if (m_context.getScriptEngine()->hasUncaughtException()) {
         // return an empty string as replacement for the in-attribute expression
         return QScriptValue();
     } else {

--- a/src/skin/svgparser.cpp
+++ b/src/skin/svgparser.cpp
@@ -6,8 +6,7 @@
 
 SvgParser::SvgParser(const SkinContext& parent)
         : m_context(parent) {
-    m_context.importScriptExtension("console");
-    m_context.importScriptExtension("svg");
+    // m_context.importScriptExtension("svg");
 }
 
 SvgParser::~SvgParser() {
@@ -109,12 +108,8 @@ void SvgParser::parseElement(QDomNode* node) const {
         }
         // Evaluates the content of the script element
         // QString expression = m_context.nodeToString(*node);
-        QString expression = element.text();
-            QString result = evaluateTemplateExpression(
-                expression, node->lineNumber()).toString();
-        // qDebug() << expression;
-        // QScriptValue result = m_context.evaluateScript(
-            // expression, m_currentFile, node->lineNumber());
+        QScriptValue result = m_context.evaluateScript(
+            element.text(), m_currentFile, node->lineNumber());
     }
 }
 

--- a/src/skin/svgparser.cpp
+++ b/src/skin/svgparser.cpp
@@ -98,7 +98,8 @@ void SvgParser::parseElement(QDomNode* node) const {
 
     } else if (element.tagName() == "script") {
         // Look for a filepath in the "src" attribute
-        QString scriptPath = node->toElement().attribute("src");
+        // QString scriptPath = node->toElement().attribute("src");
+        QString scriptPath = element.attribute("src");
         if (!scriptPath.isNull()) {
             QFile scriptFile(m_context.getSkinPath(scriptPath));
             scriptFile.open(QIODevice::ReadOnly|QIODevice::Text);
@@ -107,9 +108,13 @@ void SvgParser::parseElement(QDomNode* node) const {
                                                            scriptPath);
         }
         // Evaluates the content of the script element
-        QString expression = m_context.nodeToString(*node);
-        QScriptValue result = m_context.evaluateScript(
-            expression, m_currentFile, node->lineNumber());
+        // QString expression = m_context.nodeToString(*node);
+        QString expression = element.text();
+            QString result = evaluateTemplateExpression(
+                expression, node->lineNumber()).toString();
+        // qDebug() << expression;
+        // QScriptValue result = m_context.evaluateScript(
+            // expression, m_currentFile, node->lineNumber());
     }
 }
 

--- a/src/skin/svgparser.cpp
+++ b/src/skin/svgparser.cpp
@@ -6,7 +6,6 @@
 
 SvgParser::SvgParser(const SkinContext& parent)
         : m_context(parent) {
-    // m_context.importScriptExtension("svg");
 }
 
 SvgParser::~SvgParser() {

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -133,6 +133,10 @@ void WSpinny::onVinylSignalQualityUpdate(const VinylSignalQualityReport& report)
 void WSpinny::setup(QDomNode node, const SkinContext& context, QString group) {
     m_group = group;
     
+    // The spinny widget causes a segfault if the debugger is enabled
+    // todo (jclaveau) : make the spinny debuggable if embeding scripts (svg)
+    context.enableDebugger(false);
+    
     // Set images
     m_pBgImage = WImageStore::getImage(context.getPixmapSource(
                         context.selectNode(node, "PathBackground")));
@@ -140,6 +144,9 @@ void WSpinny::setup(QDomNode node, const SkinContext& context, QString group) {
                         context.selectNode(node,"PathForeground")));
     m_pGhostImage = WImageStore::getImage(context.getPixmapSource(
                         context.selectNode(node,"PathGhost")));
+    
+    context.enableDebugger(true);
+    
     if (m_pBgImage && !m_pBgImage->isNull()) {
         setFixedSize(m_pBgImage->size());
     }

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -133,10 +133,6 @@ void WSpinny::onVinylSignalQualityUpdate(const VinylSignalQualityReport& report)
 void WSpinny::setup(QDomNode node, const SkinContext& context, QString group) {
     m_group = group;
     
-    // The spinny widget causes a segfault if the debugger is enabled
-    // todo (jclaveau) : make the spinny debuggable if embeding scripts (svg)
-    context.enableDebugger(false);
-    
     // Set images
     m_pBgImage = WImageStore::getImage(context.getPixmapSource(
                         context.selectNode(node, "PathBackground")));
@@ -144,8 +140,6 @@ void WSpinny::setup(QDomNode node, const SkinContext& context, QString group) {
                         context.selectNode(node,"PathForeground")));
     m_pGhostImage = WImageStore::getImage(context.getPixmapSource(
                         context.selectNode(node,"PathGhost")));
-    
-    context.enableDebugger(true);
     
     if (m_pBgImage && !m_pBgImage->isNull()) {
         setFixedSize(m_pBgImage->size());
@@ -219,9 +213,11 @@ void WSpinny::setup(QDomNode node, const SkinContext& context, QString group) {
 }
 
 void WSpinny::maybeUpdate() {
-    m_pVisualPlayPos->getPlaySlipAt(0,
-                                    &m_dAngleCurrentPlaypos,
-                                    &m_dGhostAngleCurrentPlaypos);
+    if (!m_pVisualPlayPos.isNull()) {
+        m_pVisualPlayPos->getPlaySlipAt(0,
+                                        &m_dAngleCurrentPlaypos,
+                                        &m_dGhostAngleCurrentPlaypos);
+    }
     if (m_dAngleCurrentPlaypos != m_dAngleLastPlaypos ||
             m_dGhostAngleCurrentPlaypos != m_dGhostAngleLastPlaypos ||
             m_bWidgetDirty) {


### PR DESCRIPTION
- Using the debugger is much faster than before
- The debugger is disabled on the spinny widget to avoid segfault (multithread?).
- The global object is preserved from a skin context to it's children (as when there is one scriptEngine per context).
- The translation js api is enabled (http://qt-project.org/doc/qt-4.8/qscriptengine.html#installTranslatorFunctions)
- Removal of a circular reference of the global object in the svg extension 

I have a really fast SSD here so I didn't realize the slow down was so massive. Please tell me if there is another bottleneck on different setups.
