### PR TITLE
Master Sync: if only one playing sync deck, reset user offset and reinit...

### DIFF
--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -150,8 +150,7 @@ void BpmControl::slotFileBpmChanged(double bpm) {
     if (getSyncMode() == SYNC_NONE) {
         slotAdjustRateSlider();
     }
-    m_dUserOffset = 0.0;
-    m_resetSyncAdjustment = true;
+    resetSyncAdjustment();
 }
 
 void BpmControl::slotAdjustBeatsFaster(double v) {
@@ -445,7 +444,8 @@ double BpmControl::calcSyncAdjustment(double my_percentage, bool userTweakingSyn
     /*qDebug() << m_sGroup << m_dUserOffset;
     qDebug() << "master beat distance:" << master_percentage;
     qDebug() << "my     beat distance:" << my_percentage;
-    qDebug() << "error               :" << (shortest_distance - m_dUserOffset);*/
+    qDebug() << "error               :" << (shortest_distance - m_dUserOffset);
+    qDebug() << "user offset         :" << m_dUserOffset;*/
 
     double adjustment = 1.0;
 
@@ -702,8 +702,7 @@ void BpmControl::trackLoaded(TrackPointer pTrack) {
     }
 
     // reset for new track
-    m_dUserOffset = 0.0;
-    m_resetSyncAdjustment = true;
+    resetSyncAdjustment();
 
     if (pTrack) {
         m_pTrack = pTrack;
@@ -728,8 +727,7 @@ void BpmControl::trackUnloaded(TrackPointer pTrack) {
 void BpmControl::slotUpdatedTrackBeats()
 {
     if (m_pTrack) {
-        m_dUserOffset = 0.0;
-        m_resetSyncAdjustment = true;
+        resetSyncAdjustment();
         m_pBeats = m_pTrack->getBeats();
     }
 }
@@ -788,6 +786,14 @@ void BpmControl::setTargetBeatDistance(double beatDistance) {
 
 void BpmControl::setInstantaneousBpm(double instantaneousBpm) {
     m_dSyncInstantaneousBpm = instantaneousBpm;
+}
+
+void BpmControl::resetSyncAdjustment() {
+    // Immediately edit the beat distance to reflect the new reality.
+    double new_distance = m_pThisBeatDistance->get() + m_dUserOffset;
+    m_pThisBeatDistance->set(new_distance);
+    m_dUserOffset = 0.0;
+    m_resetSyncAdjustment = true;
 }
 
 void BpmControl::collectFeatures(GroupFeatureState* pGroupFeatures) const {

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -4,6 +4,8 @@
 #ifndef BPMCONTROL_H
 #define BPMCONTROL_H
 
+#include <gtest/gtest_prod.h>
+
 #include "controlobject.h"
 #include "engine/enginecontrol.h"
 #include "engine/sync/syncable.h"
@@ -45,6 +47,7 @@ class BpmControl : public EngineControl {
                    const int iBufferSize);
     void setTargetBeatDistance(double beatDistance);
     void setInstantaneousBpm(double instantaneousBpm);
+    void resetSyncAdjustment();
     double updateBeatDistance();
 
     void collectFeatures(GroupFeatureState* pGroupFeatures) const;
@@ -144,6 +147,7 @@ class BpmControl : public EngineControl {
     double m_dSyncInstantaneousBpm;
     double m_dLastSyncAdjustment;
     bool m_resetSyncAdjustment;
+    FRIEND_TEST(EngineSyncTest, UserTweakBeatDistance);
     double m_dUserOffset;
 
     TapFilter m_tapFilter;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -248,6 +248,7 @@ class EngineBuffer : public EngineObject {
     FRIEND_TEST(SyncControlTest, TestDetermineBpmMultiplier);
     FRIEND_TEST(EngineSyncTest, HalfDoubleBpmTest);
     FRIEND_TEST(EngineSyncTest, HalfDoubleThenPlay);
+    FRIEND_TEST(EngineSyncTest, UserTweakBeatDistance);
     EngineSync* m_pEngineSync;
     SyncControl* m_pSyncControl;
     VinylControlControl* m_pVinylControlControl;

--- a/src/engine/sync/basesyncablelistener.cpp
+++ b/src/engine/sync/basesyncablelistener.cpp
@@ -162,3 +162,25 @@ void BaseSyncableListener::setMasterParams(Syncable* pSource, double beat_distan
         pSyncable->setMasterParams(beat_distance, base_bpm, bpm);
     }
 }
+
+void BaseSyncableListener::checkUniquePlayingSyncable() {
+    int playing_sync_decks = 0;
+    Syncable* unique_syncable = NULL;
+    foreach (Syncable* pSyncable, m_syncables) {
+        SyncMode sync_mode = pSyncable->getSyncMode();
+        if (sync_mode == SYNC_NONE) {
+            continue;
+        }
+
+        if (pSyncable->isPlaying()) {
+            if (playing_sync_decks > 0) {
+                return;
+            }
+            unique_syncable = pSyncable;
+            ++playing_sync_decks;
+        }
+    }
+    if (playing_sync_decks == 1) {
+        unique_syncable->notifyOnlyPlayingSyncable();
+    }
+}

--- a/src/engine/sync/basesyncablelistener.h
+++ b/src/engine/sync/basesyncablelistener.h
@@ -82,6 +82,9 @@ class BaseSyncableListener : public SyncableListener {
     void setMasterParams(Syncable* pSource, double beat_distance,
                          double base_bpm, double bpm);
 
+    // Check if there is only one playing syncable deck, and notify it if so.
+    void checkUniquePlayingSyncable();
+
     ConfigObject<ConfigValue>* m_pConfig;
     // The InternalClock syncable.
     InternalClock* m_pInternalClock;

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -84,6 +84,7 @@ void EngineSync::requestSyncMode(Syncable* pSyncable, SyncMode mode) {
             deactivateSync(pSyncable);
         }
     }
+    checkUniquePlayingSyncable();
 }
 
 void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
@@ -162,6 +163,7 @@ void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
     } else {
         deactivateSync(pSyncable);
     }
+    checkUniquePlayingSyncable();
 }
 
 void EngineSync::notifyPlaying(Syncable* pSyncable, bool playing) {
@@ -176,11 +178,11 @@ void EngineSync::notifyPlaying(Syncable* pSyncable, bool playing) {
         // If there is only one deck playing, set internal clock beat distance
         // to match it, unless there is a single other playing deck, in which
         // case we should match that.
-        const Syncable* uniqueSyncEnabled = NULL;
+        Syncable* uniqueSyncEnabled = NULL;
         const Syncable* uniqueSyncDisabled = NULL;
         int playing_sync_decks = 0;
         int playing_nonsync_decks = 0;
-        foreach (const Syncable* pOtherSyncable, m_syncables) {
+        foreach (Syncable* pOtherSyncable, m_syncables) {
             if (pOtherSyncable->isPlaying()) {
                 if (pOtherSyncable->getSyncMode() != SYNC_NONE) {
                     uniqueSyncEnabled = pOtherSyncable;
@@ -192,6 +194,7 @@ void EngineSync::notifyPlaying(Syncable* pSyncable, bool playing) {
             }
         }
         if (playing_sync_decks == 1) {
+            uniqueSyncEnabled->notifyOnlyPlayingSyncable();
             if (playing_nonsync_decks == 1) {
                 m_pInternalClock->setMasterBeatDistance(uniqueSyncDisabled->getBeatDistance());
             } else {

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -50,6 +50,10 @@ void InternalClock::notifySyncModeChanged(SyncMode mode) {
     m_pSyncMasterEnabled->setAndConfirm(mode == SYNC_MASTER);
 }
 
+void InternalClock::notifyOnlyPlayingSyncable() {
+    // No action necessary.
+}
+
 void InternalClock::requestSyncPhase() {
     // TODO(owilliams): This should probably be how we reset the internal beat distance.
 }

--- a/src/engine/sync/internalclock.h
+++ b/src/engine/sync/internalclock.h
@@ -28,6 +28,7 @@ class InternalClock : public QObject, public Clock, public Syncable {
     }
 
     void notifySyncModeChanged(SyncMode mode);
+    void notifyOnlyPlayingSyncable();
     void requestSyncPhase();
     SyncMode getSyncMode() const {
         return m_mode;

--- a/src/engine/sync/syncable.h
+++ b/src/engine/sync/syncable.h
@@ -33,6 +33,9 @@ class Syncable {
     // in response to getMode().
     virtual void notifySyncModeChanged(SyncMode mode) = 0;
 
+    // Notify a Syncable that it is now the only currently-playing syncable.
+    virtual void notifyOnlyPlayingSyncable() = 0;
+
     // Notify a Syncable that they should sync phase.
     virtual void requestSyncPhase() = 0;
 

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -143,6 +143,12 @@ void SyncControl::notifySyncModeChanged(SyncMode mode) {
     }
 }
 
+void SyncControl::notifyOnlyPlayingSyncable() {
+    // If we are the only remaining playing sync deck, we can reset the user
+    // tweak info.
+    m_pBpmControl->resetSyncAdjustment();
+}
+
 void SyncControl::requestSyncPhase() {
     m_pChannel->getEngineBuffer()->requestSyncPhase();
 }

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -30,6 +30,7 @@ class SyncControl : public EngineControl, public Syncable {
 
     SyncMode getSyncMode() const;
     void notifySyncModeChanged(SyncMode mode);
+    void notifyOnlyPlayingSyncable();
     void requestSyncPhase();
     bool isPlaying() const;
 


### PR DESCRIPTION
... master beat distance.

This should help prevent user offsets from accumulating over the course
of a set, which is really annoying and makes master sync feel bad.
There's a chance that the master beat distance could be
incorrectly tweaked, which would be user-visible as tracks that were in
sync suddenly offset by a small amount.  I will do some on-decks testing
to make sure this isn't happening.
