### PR TITLE
[HID] Continue processing packet if mindelta is undefined

### DIFF
--- a/res/controllers/common-hid-packet-parser.js
+++ b/res/controllers/common-hid-packet-parser.js
@@ -604,7 +604,7 @@ HIDPacket.prototype.parse = function(data) {
                     field_changes[bit_name] = changed_bits[bit_name];
 
             } else if (field.type=="control") {
-                if (field.value==value)
+                if (field.value==value && field.mindelta!=undefined)
                     continue;
                 if (field.ignored || field.value==undefined) {
                     field.value = value;


### PR DESCRIPTION
I have a controller I would like to create a HID mapping for, which will send the same data repeatedly if you turn its knob in the same direction.

For both connection to jog_wheel/jog_touch and using callbacks, the HID parser seems to always check for values that have changed between packets, so most of the packets from this device are ignored. What I'd like to do is explicitly set mindelta to `undefined` for this control, and then have my jog events or callbacks fire for every packet (even when no values have changed). If mindelta is left at 0, you'll still get the current behavior.

Here's an excerpt that should illustrate: https://gist.github.com/decklin/7e50cc3cd20eb087f006

Not sure if I should reply to the bot below, so I'll let someone else look at this first.
