### PR TITLE
AutoDJ fixes.

### DIFF
--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -11,6 +11,7 @@
 #include "library/autodj/autodjfeature.h"
 
 #include "library/parser.h"
+#include "playermanager.h"
 #include "library/autodj/autodjprocessor.h"
 #include "library/trackcollection.h"
 #include "dlgautodj.h"
@@ -24,6 +25,7 @@ const QString AutoDJFeature::m_sAutoDJViewName = QString("Auto DJ");
 
 AutoDJFeature::AutoDJFeature(QObject* parent,
                              ConfigObject<ConfigValue>* pConfig,
+                             PlayerManagerInterface* pPlayerManager,
                              TrackCollection* pTrackCollection)
         : LibraryFeature(parent),
           m_pConfig(pConfig),
@@ -49,7 +51,7 @@ AutoDJFeature::AutoDJFeature(QObject* parent,
     }
     qRegisterMetaType<AutoDJProcessor::AutoDJState>("AutoDJState");
     m_pAutoDJProcessor = new AutoDJProcessor(
-            this, m_pConfig, m_iAutoDJPlaylistId, m_pTrackCollection);
+            this, m_pConfig, pPlayerManager, m_iAutoDJPlaylistId, m_pTrackCollection);
     connect(m_pAutoDJProcessor, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)),
             this, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)));
 

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -25,6 +25,7 @@
 #include "library/dao/autodjcratesdao.h"
 #endif // __AUTODJCRATES__
 
+class PlayerManagerInterface;
 class TrackCollection;
 class AutoDJProcessor;
 
@@ -33,6 +34,7 @@ class AutoDJFeature : public LibraryFeature {
   public:
     AutoDJFeature(QObject* parent,
                   ConfigObject<ConfigValue>* pConfig,
+                  PlayerManagerInterface* pPlayerManager,
                   TrackCollection* pTrackCollection);
     virtual ~AutoDJFeature();
 

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -2,7 +2,6 @@
 
 #include "library/trackcollection.h"
 #include "controlpushbutton.h"
-#include "controlobjectthread.h"
 #include "controlobjectslave.h"
 #include "util/math.h"
 #include "playermanager.h"
@@ -22,9 +21,9 @@ DeckAttributes::DeckAttributes(int index,
           posThreshold(1.0),
           fadeDuration(0.0),
           m_orientation(orientation),
-          m_pPlayPos(new ControlObjectThread(group, "playposition")),
-          m_pPlay(new ControlObjectThread(group, "play")),
-          m_pRepeat(new ControlObjectSlave(group, "repeat")),
+          m_playPos(group, "playposition"),
+          m_play(group, "play"),
+          m_repeat(group, "repeat"),
           m_pPlayer(pPlayer) {
     connect(m_pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
             this, SLOT(slotTrackLoaded(TrackPointer)));
@@ -32,16 +31,11 @@ DeckAttributes::DeckAttributes(int index,
             this, SLOT(slotTrackLoadFailed(TrackPointer)));
     connect(m_pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
             this, SLOT(slotTrackUnloaded(TrackPointer)));
-    connect(m_pPlayPos, SIGNAL(valueChanged(double)),
-            this, SLOT(slotPlayPosChanged(double)));
-    connect(m_pPlay, SIGNAL(valueChanged(double)),
-            this, SLOT(slotPlayChanged(double)));
+    m_playPos.connectValueChanged(this, SLOT(slotPlayPosChanged(double)));
+    m_play.connectValueChanged(this, SLOT(slotPlayChanged(double)));
 }
 
 DeckAttributes::~DeckAttributes() {
-    delete m_pPlayPos;
-    delete m_pPlay;
-    delete m_pRepeat;
 }
 
 void DeckAttributes::slotPlayChanged(double v) {

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -4,20 +4,78 @@
 #include "controlpushbutton.h"
 #include "controlobjectthread.h"
 #include "controlobjectslave.h"
-#include "playerinfo.h"
 #include "util/math.h"
 #include "playermanager.h"
+#include "basetrackplayer.h"
 
 #define kConfigKey "[Auto DJ]"
 const char* kTransitionPreferenceName = "Transition";
 const int kTransitionPreferenceDefault = 10;
 
+static const bool sDebug = false;
+
+DeckAttributes::DeckAttributes(int index,
+                               BaseTrackPlayer* pPlayer,
+                               EngineChannel::ChannelOrientation orientation)
+        : index(index),
+          group(pPlayer->getGroup()),
+          orientation(orientation),
+          pPlayPos(new ControlObjectThread(group, "playposition")),
+          pPlay(new ControlObjectThread(group, "play")),
+          pRepeat(new ControlObjectSlave(group, "repeat")),
+          posThreshold(1.0),
+          fadeDuration(0.0),
+          m_pPlayer(pPlayer) {
+    connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
+            this, SLOT(slotTrackLoaded(TrackPointer)));
+    connect(pPlayer, SIGNAL(loadTrackFailed(TrackPointer)),
+            this, SLOT(slotTrackLoadFailed(TrackPointer)));
+    connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
+            this, SLOT(slotTrackUnloaded(TrackPointer)));
+    connect(pPlayPos, SIGNAL(valueChanged(double)),
+            this, SLOT(slotPlayPosChanged(double)));
+    connect(pPlay, SIGNAL(valueChanged(double)),
+            this, SLOT(slotPlayChanged(double)));
+}
+
+DeckAttributes::~DeckAttributes() {
+    delete pPlayPos;
+    delete pPlay;
+    delete pRepeat;
+}
+
+void DeckAttributes::slotPlayChanged(double v) {
+    emit(playChanged(this, v > 0.0));
+}
+
+void DeckAttributes::slotPlayPosChanged(double v) {
+    emit(playPositionChanged(this, v));
+}
+
+void DeckAttributes::slotTrackLoaded(TrackPointer pTrack) {
+    emit(trackLoaded(this, pTrack));
+}
+
+void DeckAttributes::slotTrackLoadFailed(TrackPointer pTrack) {
+    emit(trackLoadFailed(this, pTrack));
+}
+
+void DeckAttributes::slotTrackUnloaded(TrackPointer pTrack) {
+    emit(trackUnloaded(this, pTrack));
+}
+
+TrackPointer DeckAttributes::getLoadedTrack() const {
+    return m_pPlayer != NULL ? m_pPlayer->getLoadedTrack() : TrackPointer();
+}
+
 AutoDJProcessor::AutoDJProcessor(QObject* pParent,
                                  ConfigObject<ConfigValue>* pConfig,
+                                 PlayerManagerInterface* pPlayerManager,
                                  int iAutoDJPlaylistId,
                                  TrackCollection* pTrackCollection)
         : QObject(pParent),
           m_pConfig(pConfig),
+          m_pPlayerManager(pPlayerManager),
           m_pAutoDJTableModel(NULL),
           m_eState(ADJ_DISABLED),
           m_iTransitionTime(kTransitionPreferenceDefault) {
@@ -46,22 +104,19 @@ AutoDJProcessor::AutoDJProcessor(QObject* pParent,
     connect(m_pEnabledAutoDJ, SIGNAL(valueChanged(double)),
             this, SLOT(controlEnable(double)));
 
-    connect(&m_playPosMapper, SIGNAL(mapped(int)),
-            this, SLOT(playerPositionChanged(int)));
-    connect(&m_playMapper, SIGNAL(mapped(int)),
-            this, SLOT(playerPlayChanged(int)));
-
-    m_pNumDecks = new ControlObjectSlave("[Master]", "num_decks");
-    // TODO(owilliams): Right now num_decks is NULL on startup.
-    for (int i = 0; i < 4; ++i) {
+    // TODO(rryan) listen to signals from PlayerManager and add/remove as decks
+    // are created.
+    for (unsigned int i = 0; i < pPlayerManager->numberOfDecks(); ++i) {
         QString group = PlayerManager::groupForDeck(i);
+        BaseTrackPlayer* pPlayer = pPlayerManager->getPlayer(group);
+        // Shouldn't be possible.
+        if (pPlayer == NULL) {
+            qWarning() << "PROGRAMMING ERROR deck does not exist" << i;
+            continue;
+        }
         EngineChannel::ChannelOrientation orientation =
                 (i % 2 == 0) ? EngineChannel::LEFT : EngineChannel::RIGHT;
-        DeckAttributes* attrs = new DeckAttributes(i, group, orientation);
-        m_playPosMapper.setMapping(attrs->pPlayPos, i);
-        m_playMapper.setMapping(attrs->pPlay, i);
-        m_repeatMapper.setMapping(attrs->pRepeat, i);
-        m_decks.append(attrs);
+        m_decks.append(new DeckAttributes(i, pPlayer, orientation));
     }
     m_pCOCrossfader = new ControlObjectSlave("[Master]", "crossfader");
     m_pCOCrossfaderReverse = new ControlObjectSlave("[Mixer Profile]", "xFaderReverse");
@@ -158,10 +213,10 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::skipNext() {
     DeckAttributes& leftDeck = *m_decks[0];
     DeckAttributes& rightDeck = *m_decks[1];
     if (!leftDeck.isPlaying()) {
-        removeLoadedTrackFromTopOfQueue(leftDeck.group);
+        removeLoadedTrackFromTopOfQueue(leftDeck);
         loadNextTrackFromQueue(leftDeck);
     } else if (!rightDeck.isPlaying()) {
-        removeLoadedTrackFromTopOfQueue(rightDeck.group);
+        removeLoadedTrackFromTopOfQueue(rightDeck);
         loadNextTrackFromQueue(rightDeck);
     }
     return ADJ_OK;
@@ -183,10 +238,10 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
 
         // Never load the same track if it is already playing
         if (deck1Playing) {
-            removeLoadedTrackFromTopOfQueue(leftDeck.group);
+            removeLoadedTrackFromTopOfQueue(leftDeck);
         }
         if (deck2Playing) {
-            removeLoadedTrackFromTopOfQueue(rightDeck.group);
+            removeLoadedTrackFromTopOfQueue(rightDeck);
         }
 
         TrackPointer nextTrack = getNextTrackFromQueue();
@@ -205,15 +260,31 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         }
         qDebug() << "Auto DJ enabled";
 
-        connect(leftDeck.pPlayPos, SIGNAL(valueChanged(double)),
-                &m_playPosMapper, SLOT(map()));
-        connect(rightDeck.pPlayPos, SIGNAL(valueChanged(double)),
-                &m_playPosMapper, SLOT(map()));
+        connect(&leftDeck, SIGNAL(playPositionChanged(DeckAttributes*, double)),
+                this, SLOT(playerPositionChanged(DeckAttributes*, double)));
+        connect(&rightDeck, SIGNAL(playPositionChanged(DeckAttributes*, double)),
+                this, SLOT(playerPositionChanged(DeckAttributes*, double)));
 
-        connect(leftDeck.pPlay, SIGNAL(valueChanged(double)),
-                &m_playMapper, SLOT(map()));
-        connect(rightDeck.pPlay, SIGNAL(valueChanged(double)),
-                &m_playMapper, SLOT(map()));
+        connect(&leftDeck, SIGNAL(playChanged(DeckAttributes*, bool)),
+                this, SLOT(playerPlayChanged(DeckAttributes*, bool)));
+        connect(&rightDeck, SIGNAL(playChanged(DeckAttributes*, bool)),
+                this, SLOT(playerPlayChanged(DeckAttributes*, bool)));
+
+        connect(&leftDeck, SIGNAL(trackLoaded(DeckAttributes*, TrackPointer)),
+                this, SLOT(playerTrackLoaded(DeckAttributes*, TrackPointer)));
+        connect(&rightDeck, SIGNAL(trackLoaded(DeckAttributes*, TrackPointer)),
+                this, SLOT(playerTrackLoaded(DeckAttributes*, TrackPointer)));
+
+        connect(&leftDeck, SIGNAL(trackUnloaded(DeckAttributes*, TrackPointer)),
+                this, SLOT(playerTrackUnloaded(DeckAttributes*, TrackPointer)));
+        connect(&rightDeck, SIGNAL(trackUnloaded(DeckAttributes*, TrackPointer)),
+                this, SLOT(playerTrackUnloaded(DeckAttributes*, TrackPointer)));
+
+        connect(&leftDeck, SIGNAL(trackLoadFailed(DeckAttributes*, TrackPointer)),
+                this, SLOT(playerTrackLoadFailed(DeckAttributes*, TrackPointer)));
+        connect(&rightDeck, SIGNAL(trackLoadFailed(DeckAttributes*, TrackPointer)),
+                this, SLOT(playerTrackLoadFailed(DeckAttributes*, TrackPointer)));
+
 
         if (!deck1Playing && !deck2Playing) {
             // Both decks are stopped. Load a track into deck 1 and start it
@@ -223,7 +294,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
             // loaded track from the queue and wait for the next call to
             // playerPositionChanged for deck1 after the track is loaded.
             m_eState = ADJ_ENABLE_P1LOADED;
-            playerPositionChanged(&leftDeck);
+            playerPositionChanged(&leftDeck, leftDeck.playPosition());
 
             // Load track into the left deck and play. Once it starts playing,
             // we will receive a playerPositionChanged update for deck 1 which
@@ -257,10 +328,8 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         }
         qDebug() << "Auto DJ disabled";
         m_eState = ADJ_DISABLED;
-        leftDeck.pPlayPos->disconnect(this);
-        rightDeck.pPlayPos->disconnect(this);
-        leftDeck.pPlay->disconnect(this);
-        rightDeck.pPlay->disconnect(this);
+        leftDeck.disconnect(this);
+        rightDeck.disconnect(this);
         m_pCOCrossfader->set(0);
         emit(autoDJStateChanged(m_eState));
     }
@@ -289,17 +358,12 @@ void AutoDJProcessor::controlSkipNext(double value) {
     }
 }
 
-void AutoDJProcessor::playerPositionChanged(int index) {
-    if (index < 0 || index >= m_decks.size()) {
-        return;
+void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
+                                            double thisPlayPosition) {
+    if (sDebug) {
+        qDebug() << this << "playerPositionChanged" << pAttributes->group
+                 << thisPlayPosition;
     }
-    playerPositionChanged(m_decks[index]);
-}
-
-void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes) {
-    // This is one of the primary AutoDJ decks.
-    double thisPlayPosition = pAttributes->playPosition();
-
     // 95% playback is when we crossfade and do stuff
     // const double posThreshold = 0.95;
 
@@ -403,7 +467,7 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes) {
 
             // Now that we have started the other deck playing, remove the track
             // that was "on deck" from the top of the queue.
-            removeLoadedTrackFromTopOfQueue(otherDeck.group);
+            removeLoadedTrackFromTopOfQueue(otherDeck);
 
             // Set the state as FADING.
             m_eState = thisDeck.isLeft() ? ADJ_P1FADING : ADJ_P2FADING;
@@ -476,9 +540,9 @@ bool AutoDJProcessor::loadNextTrackFromQueue(const DeckAttributes& deck) {
     return true;
 }
 
-bool AutoDJProcessor::removeLoadedTrackFromTopOfQueue(const QString& group) {
+bool AutoDJProcessor::removeLoadedTrackFromTopOfQueue(const DeckAttributes& deck) {
     // Get loaded track for this group.
-    TrackPointer loadedTrack = PlayerInfo::instance().getTrackInfo(group);
+    TrackPointer loadedTrack = deck.getLoadedTrack();
 
     // No loaded track in this group.
     if (loadedTrack.isNull()) {
@@ -525,15 +589,20 @@ bool AutoDJProcessor::removeTrackFromTopOfQueue(TrackPointer pTrack) {
     return true;
 }
 
-void AutoDJProcessor::playerPlayChanged(int index) {
-    if (index < 0 || index >= m_decks.size()) {
-        return;
+void AutoDJProcessor::playerPlayChanged(DeckAttributes* pAttributes, bool playing) {
+    if (sDebug) {
+        qDebug() << this << "playerPlayChanged" << pAttributes->group << playing;
     }
-    calculateFadeThresholds(m_decks[index]);
+    // We may want to do more than just calculate fade thresholds when playing
+    // state changes so keep these two as separate methods for now.
+    calculateFadeThresholds(pAttributes);
 }
 
 void AutoDJProcessor::calculateFadeThresholds(DeckAttributes* pAttributes) {
     bool playing = pAttributes->isPlaying();
+    if (sDebug) {
+        qDebug() << this << "calculateFadeThresholds" << pAttributes->group << playing;
+    }
 
     //qDebug() << "player" << pAttributes->group << "PlayChanged(" << playing << ")";
 
@@ -543,8 +612,7 @@ void AutoDJProcessor::calculateFadeThresholds(DeckAttributes* pAttributes) {
     // is loaded we should be able to calculate the fadeDuration and
     // posThreshold regardless of the rest of the ADJ.
     if (playing && m_eState == ADJ_IDLE) {
-        TrackPointer loadedTrack =
-                PlayerInfo::instance().getTrackInfo(pAttributes->group);
+        TrackPointer loadedTrack = pAttributes->getLoadedTrack();
         if (loadedTrack) {
             // TODO(rryan): Duration is super inaccurate! We should be using
             // track_samples / track_samplerate instead.
@@ -574,7 +642,32 @@ void AutoDJProcessor::calculateFadeThresholds(DeckAttributes* pAttributes) {
     }
 }
 
+void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTrack) {
+    if (sDebug) {
+        qDebug() << this << "playerTrackLoaded" << pDeck->group
+                 << (pTrack.isNull() ? "(null)" : pTrack->getLocation());
+    }
+}
+
+void AutoDJProcessor::playerTrackLoadFailed(DeckAttributes* pDeck, TrackPointer pTrack) {
+    if (sDebug) {
+        qDebug() << this << "playerTrackLoadFailed" << pDeck->group
+                 << (pTrack.isNull() ? "(null)" : pTrack->getLocation());
+    }
+
+}
+
+void AutoDJProcessor::playerTrackUnloaded(DeckAttributes* pDeck, TrackPointer pTrack) {
+    if (sDebug) {
+        qDebug() << this << "playerTrackUnloaded" << pDeck->group
+                 << (pTrack.isNull() ? "(null)" : pTrack->getLocation());
+    }
+}
+
 void AutoDJProcessor::setTransitionTime(int time) {
+    if (sDebug) {
+        qDebug() << this << "setTransitionTime" << time;
+    }
     // Update the transition time first.
     m_pConfig->set(ConfigKey(kConfigKey, kTransitionPreferenceName),
                    ConfigValue(time));

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -19,29 +19,29 @@ DeckAttributes::DeckAttributes(int index,
                                EngineChannel::ChannelOrientation orientation)
         : index(index),
           group(pPlayer->getGroup()),
-          orientation(orientation),
-          pPlayPos(new ControlObjectThread(group, "playposition")),
-          pPlay(new ControlObjectThread(group, "play")),
-          pRepeat(new ControlObjectSlave(group, "repeat")),
           posThreshold(1.0),
           fadeDuration(0.0),
+          m_orientation(orientation),
+          m_pPlayPos(new ControlObjectThread(group, "playposition")),
+          m_pPlay(new ControlObjectThread(group, "play")),
+          m_pRepeat(new ControlObjectSlave(group, "repeat")),
           m_pPlayer(pPlayer) {
-    connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
+    connect(m_pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
             this, SLOT(slotTrackLoaded(TrackPointer)));
-    connect(pPlayer, SIGNAL(loadTrackFailed(TrackPointer)),
+    connect(m_pPlayer, SIGNAL(loadTrackFailed(TrackPointer)),
             this, SLOT(slotTrackLoadFailed(TrackPointer)));
-    connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
+    connect(m_pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
             this, SLOT(slotTrackUnloaded(TrackPointer)));
-    connect(pPlayPos, SIGNAL(valueChanged(double)),
+    connect(m_pPlayPos, SIGNAL(valueChanged(double)),
             this, SLOT(slotPlayPosChanged(double)));
-    connect(pPlay, SIGNAL(valueChanged(double)),
+    connect(m_pPlay, SIGNAL(valueChanged(double)),
             this, SLOT(slotPlayChanged(double)));
 }
 
 DeckAttributes::~DeckAttributes() {
-    delete pPlayPos;
-    delete pPlay;
-    delete pRepeat;
+    delete m_pPlayPos;
+    delete m_pPlay;
+    delete m_pRepeat;
 }
 
 void DeckAttributes::slotPlayChanged(double v) {

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -27,39 +27,39 @@ class DeckAttributes : public QObject {
     virtual ~DeckAttributes();
 
     bool isLeft() const {
-        return orientation == EngineChannel::LEFT;
+        return m_orientation == EngineChannel::LEFT;
     }
 
     bool isRight() const {
-        return orientation == EngineChannel::RIGHT;
+        return m_orientation == EngineChannel::RIGHT;
     }
 
     bool isPlaying() const {
-        return pPlay->get() > 0.0;
+        return m_pPlay->get() > 0.0;
     }
 
     void stop() {
-        pPlay->set(0.0);
+        m_pPlay->set(0.0);
     }
 
     void play() {
-        pPlay->set(1.0);
+        m_pPlay->set(1.0);
     }
 
     double playPosition() const {
-        return pPlayPos->get();
+        return m_pPlayPos->get();
     }
 
     void setPlayPosition(double playpos) {
-        pPlayPos->set(playpos);
+        m_pPlayPos->set(playpos);
     }
 
     bool isRepeat() const {
-        return pRepeat->get() > 0.0;
+        return m_pRepeat->get() > 0.0;
     }
 
     void setRepeat(bool enabled) {
-        pRepeat->set(enabled ? 1.0 : 0.0);
+        m_pRepeat->set(enabled ? 1.0 : 0.0);
     }
 
     TrackPointer getLoadedTrack() const;
@@ -81,14 +81,14 @@ class DeckAttributes : public QObject {
   public:
     int index;
     QString group;
-    EngineChannel::ChannelOrientation orientation;
-    ControlObjectThread* pPlayPos;
-    ControlObjectThread* pPlay;
-    ControlObjectSlave* pRepeat;
     double posThreshold;
     double fadeDuration;
 
   private:
+    EngineChannel::ChannelOrientation m_orientation;
+    ControlObjectThread* m_pPlayPos;
+    ControlObjectThread* m_pPlay;
+    ControlObjectSlave* m_pRepeat;
     BaseTrackPlayer* m_pPlayer;
 };
 

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -10,7 +10,6 @@
 #include "configobject.h"
 #include "library/playlisttablemodel.h"
 #include "engine/enginechannel.h"
-#include "controlobjectthread.h"
 #include "controlobjectslave.h"
 
 class ControlPushButton;
@@ -35,31 +34,31 @@ class DeckAttributes : public QObject {
     }
 
     bool isPlaying() const {
-        return m_pPlay->get() > 0.0;
+        return m_play.toBool();
     }
 
     void stop() {
-        m_pPlay->set(0.0);
+        m_play.set(0.0);
     }
 
     void play() {
-        m_pPlay->set(1.0);
+        m_play.set(1.0);
     }
 
     double playPosition() const {
-        return m_pPlayPos->get();
+        return m_playPos.get();
     }
 
     void setPlayPosition(double playpos) {
-        m_pPlayPos->set(playpos);
+        m_playPos.set(playpos);
     }
 
     bool isRepeat() const {
-        return m_pRepeat->get() > 0.0;
+        return m_repeat.toBool();
     }
 
     void setRepeat(bool enabled) {
-        m_pRepeat->set(enabled ? 1.0 : 0.0);
+        m_repeat.set(enabled ? 1.0 : 0.0);
     }
 
     TrackPointer getLoadedTrack() const;
@@ -86,9 +85,9 @@ class DeckAttributes : public QObject {
 
   private:
     EngineChannel::ChannelOrientation m_orientation;
-    ControlObjectThread* m_pPlayPos;
-    ControlObjectThread* m_pPlay;
-    ControlObjectSlave* m_pRepeat;
+    ControlObjectSlave m_playPos;
+    ControlObjectSlave m_play;
+    ControlObjectSlave m_repeat;
     BaseTrackPlayer* m_pPlayer;
 };
 

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -15,6 +15,82 @@
 
 class ControlPushButton;
 class TrackCollection;
+class PlayerManagerInterface;
+class BaseTrackPlayer;
+
+class DeckAttributes : public QObject {
+    Q_OBJECT
+  public:
+    DeckAttributes(int index,
+                   BaseTrackPlayer* pPlayer,
+                   EngineChannel::ChannelOrientation orientation);
+    virtual ~DeckAttributes();
+
+    bool isLeft() const {
+        return orientation == EngineChannel::LEFT;
+    }
+
+    bool isRight() const {
+        return orientation == EngineChannel::RIGHT;
+    }
+
+    bool isPlaying() const {
+        return pPlay->get() > 0.0;
+    }
+
+    void stop() {
+        pPlay->set(0.0);
+    }
+
+    void play() {
+        pPlay->set(1.0);
+    }
+
+    double playPosition() const {
+        return pPlayPos->get();
+    }
+
+    void setPlayPosition(double playpos) {
+        pPlayPos->set(playpos);
+    }
+
+    bool isRepeat() const {
+        return pRepeat->get() > 0.0;
+    }
+
+    void setRepeat(bool enabled) {
+        pRepeat->set(enabled ? 1.0 : 0.0);
+    }
+
+    TrackPointer getLoadedTrack() const;
+
+  signals:
+    void playChanged(DeckAttributes* deck, bool playing);
+    void playPositionChanged(DeckAttributes* deck, double playPosition);
+    void trackLoaded(DeckAttributes* deck, TrackPointer pTrack);
+    void trackLoadFailed(DeckAttributes* deck, TrackPointer pTrack);
+    void trackUnloaded(DeckAttributes* deck, TrackPointer pTrack);
+
+  private slots:
+    void slotPlayPosChanged(double v);
+    void slotPlayChanged(double v);
+    void slotTrackLoaded(TrackPointer pTrack);
+    void slotTrackLoadFailed(TrackPointer pTrack);
+    void slotTrackUnloaded(TrackPointer pTrack);
+
+  public:
+    int index;
+    QString group;
+    EngineChannel::ChannelOrientation orientation;
+    ControlObjectThread* pPlayPos;
+    ControlObjectThread* pPlay;
+    ControlObjectSlave* pRepeat;
+    double posThreshold;
+    double fadeDuration;
+
+  private:
+    BaseTrackPlayer* m_pPlayer;
+};
 
 class AutoDJProcessor : public QObject {
     Q_OBJECT
@@ -37,6 +113,7 @@ class AutoDJProcessor : public QObject {
 
     AutoDJProcessor(QObject* pParent,
                     ConfigObject<ConfigValue>* pConfig,
+                    PlayerManagerInterface* pPlayerManager,
                     int iAutoDJPlaylistId,
                     TrackCollection* pCollection);
     virtual ~AutoDJProcessor();
@@ -68,8 +145,11 @@ class AutoDJProcessor : public QObject {
     virtual void autoDJStateChanged(AutoDJProcessor::AutoDJState state);
 
   private slots:
-    void playerPositionChanged(int index);
-    void playerPlayChanged(int index);
+    void playerPositionChanged(DeckAttributes* pDeck, double position);
+    void playerPlayChanged(DeckAttributes* pDeck, bool playing);
+    void playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTrack);
+    void playerTrackLoadFailed(DeckAttributes* pDeck, TrackPointer pTrack);
+    void playerTrackUnloaded(DeckAttributes* pDeck, TrackPointer pTrack);
 
     void controlEnable(double value);
     void controlFadeNow(double value);
@@ -77,72 +157,6 @@ class AutoDJProcessor : public QObject {
     void controlSkipNext(double value);
 
   private:
-    struct DeckAttributes {
-        DeckAttributes(int index,
-                       const QString& group,
-                       EngineChannel::ChannelOrientation orientation)
-                : index(index),
-                  group(group),
-                  orientation(orientation),
-                  pPlayPos(new ControlObjectThread(group, "playposition")),
-                  pPlay(new ControlObjectThread(group, "play")),
-                  pRepeat(new ControlObjectSlave(group, "repeat")),
-                  posThreshold(1.0),
-                  fadeDuration(0.0) {
-        }
-
-        ~DeckAttributes() {
-            delete pPlayPos;
-            delete pPlay;
-            delete pRepeat;
-        }
-
-        bool isLeft() const {
-            return orientation == EngineChannel::LEFT;
-        }
-
-        bool isRight() const {
-            return orientation == EngineChannel::RIGHT;
-        }
-
-        bool isPlaying() const {
-            return pPlay->get() > 0.0;
-        }
-
-        void stop() {
-            pPlay->set(0.0);
-        }
-
-        void play() {
-            pPlay->set(1.0);
-        }
-
-        double playPosition() const {
-            return pPlayPos->get();
-        }
-
-        void setPlayPosition(double playpos) {
-            pPlayPos->set(playpos);
-        }
-
-        bool isRepeat() const {
-            return pRepeat->get() > 0.0;
-        }
-
-        void setRepeat(bool enabled) {
-            pRepeat->set(enabled ? 1.0 : 0.0);
-        }
-
-        int index;
-        QString group;
-        EngineChannel::ChannelOrientation orientation;
-        ControlObjectThread* pPlayPos;
-        ControlObjectThread* pPlay;
-        ControlObjectSlave* pRepeat;
-        double posThreshold;
-        double fadeDuration;
-    };
-
     // Gets or sets the crossfader position while normalizing it so that -1 is
     // all the way mixed to the left side and 1 is all the way mixed to the
     // right side. (prevents AutoDJ logic from having to check for hamster mode
@@ -152,18 +166,18 @@ class AutoDJProcessor : public QObject {
 
     TrackPointer getNextTrackFromQueue();
     bool loadNextTrackFromQueue(const DeckAttributes& pDeck);
-    void playerPositionChanged(DeckAttributes* pAttributes);
     void calculateFadeThresholds(DeckAttributes* pAttributes);
 
     // Removes the track loaded to the player group from the top of the AutoDJ
     // queue if it is present.
-    bool removeLoadedTrackFromTopOfQueue(const QString& group);
+    bool removeLoadedTrackFromTopOfQueue(const DeckAttributes& deck);
 
     // Removes the provided track from the top of the AutoDJ queue if it is
     // present.
     bool removeTrackFromTopOfQueue(TrackPointer pTrack);
 
     ConfigObject<ConfigValue>* m_pConfig;
+    PlayerManagerInterface* m_pPlayerManager;
     PlaylistTableModel* m_pAutoDJTableModel;
 
     AutoDJState m_eState;
@@ -171,13 +185,8 @@ class AutoDJProcessor : public QObject {
 
     QList<DeckAttributes*> m_decks;
 
-    QSignalMapper m_playPosMapper;
-    QSignalMapper m_playMapper;
-    QSignalMapper m_repeatMapper;
-
     ControlObjectSlave* m_pCOCrossfader;
     ControlObjectSlave* m_pCOCrossfaderReverse;
-    ControlObjectSlave* m_pNumDecks;
 
     ControlPushButton* m_pSkipNext;
     ControlPushButton* m_pFadeNow;

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -6,6 +6,7 @@
 #include <QTranslator>
 #include <QDir>
 
+#include "playermanager.h"
 #include "library/library.h"
 #include "library/library_preferences.h"
 #include "library/libraryfeature.h"
@@ -38,6 +39,7 @@
 const QString Library::m_sTrackViewName = QString("WTrackTableView");
 
 Library::Library(QObject* parent, ConfigObject<ConfigValue>* pConfig,
+                 PlayerManagerInterface* pPlayerManager,
                  RecordingManager* pRecordingManager) :
         m_pConfig(pConfig),
         m_pSidebarModel(new SidebarModel(parent)),
@@ -51,7 +53,7 @@ Library::Library(QObject* parent, ConfigObject<ConfigValue>* pConfig,
     m_pMixxxLibraryFeature = new MixxxLibraryFeature(this, m_pTrackCollection,m_pConfig);
     addFeature(m_pMixxxLibraryFeature);
 
-    addFeature(new AutoDJFeature(this, pConfig, m_pTrackCollection));
+    addFeature(new AutoDJFeature(this, pConfig, pPlayerManager, m_pTrackCollection));
     m_pPlaylistFeature = new PlaylistFeature(this, m_pTrackCollection, m_pConfig);
     addFeature(m_pPlaylistFeature);
     m_pCrateFeature = new CrateFeature(this, m_pTrackCollection, m_pConfig);

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -30,12 +30,14 @@ class PlaylistFeature;
 class CrateFeature;
 class LibraryControl;
 class MixxxKeyboard;
+class PlayerManagerInterface;
 
 class Library : public QObject {
     Q_OBJECT
 public:
     Library(QObject* parent,
             ConfigObject<ConfigValue>* pConfig,
+            PlayerManagerInterface* pPlayerManager,
             RecordingManager* pRecordingManager);
     virtual ~Library();
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -273,6 +273,7 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
     CoverArtCache::create();
 
     m_pLibrary = new Library(this, m_pConfig,
+                             m_pPlayerManager,
                              m_pRecordingManager);
     m_pPlayerManager->bindToLibrary(m_pLibrary);
 
@@ -499,9 +500,6 @@ MixxxMainWindow::~MixxxMainWindow() {
     delete m_PassthroughMapper;
     delete m_AuxiliaryMapper;
     delete m_TalkoverMapper;
-    // PlayerManager depends on Engine, SoundManager, VinylControlManager, and Config
-    qDebug() << "delete playerManager " << qTime.elapsed();
-    delete m_pPlayerManager;
 
     // LibraryScanner depends on Library
     qDebug() << "delete library scanner " <<  qTime.elapsed();
@@ -511,10 +509,14 @@ MixxxMainWindow::~MixxxMainWindow() {
     CoverArtCache::destroy();
 
     // Delete the library after the view so there are no dangling pointers to
-    // Depends on RecordingManager
     // the data models.
+    // Depends on RecordingManager and PlayerManager
     qDebug() << "delete library " << qTime.elapsed();
     delete m_pLibrary;
+
+    // PlayerManager depends on Engine, SoundManager, VinylControlManager, and Config
+    qDebug() << "delete playerManager " << qTime.elapsed();
+    delete m_pPlayerManager;
 
     // RecordingManager depends on config, engine
     qDebug() << "delete RecordingManager " << qTime.elapsed();

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -175,7 +175,6 @@ class AutoDJProcessorTest : public LibraryTest {
     }
 
     FakeMaster master;
-    ControlObject numDecks;
     FakeDeck deck1;
     FakeDeck deck2;
     FakeDeck deck3;

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -9,9 +9,11 @@
 #include "controlpushbutton.h"
 #include "controlpotmeter.h"
 #include "controllinpotmeter.h"
-#include "playerinfo.h"
+#include "playermanager.h"
+#include "basetrackplayer.h"
 
 using ::testing::_;
+using ::testing::Return;
 
 static int kDefaultTransitionTime = 10;
 const QString kTrackLocationTest(QDir::currentPath() %
@@ -29,28 +31,92 @@ class FakeMaster {
     ControlPushButton crossfaderReverse;
 };
 
-class FakeDeck {
+class FakeDeck : public BaseTrackPlayer {
   public:
     FakeDeck(const QString& group)
-            : playposition(ConfigKey(group, "playposition"), 0.0, 1.0, true),
+            : BaseTrackPlayer(NULL, group),
+              playposition(ConfigKey(group, "playposition"), 0.0, 1.0, true),
               play(ConfigKey(group, "play")),
               repeat(ConfigKey(group, "repeat")) {
         play.setButtonMode(ControlPushButton::TOGGLE);
         repeat.setButtonMode(ControlPushButton::TOGGLE);
     }
 
+    void fakeTrackLoadedEvent(TrackPointer pTrack) {
+        loadedTrack = pTrack;
+        emit(newTrackLoaded(pTrack));
+    }
+
+    void fakeTrackLoadFailedEvent(TrackPointer pTrack) {
+        emit(loadTrackFailed(pTrack));
+    }
+
+    void fakeUnloadingTrackEvent(TrackPointer pTrack) {
+        emit(unloadingTrack(pTrack));
+        loadedTrack.clear();
+    }
+
+    TrackPointer getLoadedTrack() const {
+        return loadedTrack;
+    }
+
+    void slotLoadTrack(TrackPointer pTrack, bool bPlay) {
+        loadedTrack = pTrack;
+        play.set(bPlay);
+    }
+
+    TrackPointer loadedTrack;
     ControlLinPotmeter playposition;
     ControlPushButton play;
     ControlPushButton repeat;
+};
+
+class MockPlayerManager : public PlayerManagerInterface {
+  public:
+    MockPlayerManager()
+            : numDecks(ConfigKey("[Master]", "num_decks"), true),
+              numSamplers(ConfigKey("[Master]", "num_samplers"), true),
+              numPreviewDecks(ConfigKey("[Master]", "num_preview_decks"),
+                              true) {
+    }
+
+    virtual ~MockPlayerManager() {
+    }
+
+    MOCK_CONST_METHOD1(getPlayer, BaseTrackPlayer*(QString));
+    MOCK_CONST_METHOD1(getDeck, Deck*(unsigned int));
+    MOCK_CONST_METHOD1(getPreviewDeck, PreviewDeck*(unsigned int));
+    MOCK_CONST_METHOD1(getSampler, Sampler*(unsigned int));
+
+    unsigned int numberOfDecks() const {
+        return static_cast<unsigned int>(numDecks.get());
+    }
+
+    unsigned int numberOfSamplers() const {
+        return static_cast<unsigned int>(numSamplers.get());
+    }
+
+    unsigned int numberOfPreviewDecks() const {
+        return static_cast<unsigned int>(numPreviewDecks.get());
+    }
+
+    ControlObject numDecks;
+    ControlObject numSamplers;
+    ControlObject numPreviewDecks;
 };
 
 class MockAutoDJProcessor : public AutoDJProcessor {
   public:
     MockAutoDJProcessor(QObject* pParent,
                         ConfigObject<ConfigValue>* pConfig,
+                        PlayerManagerInterface* pPlayerManager,
                         int iAutoDJPlaylistId,
                         TrackCollection* pCollection)
-            : AutoDJProcessor(pParent, pConfig, iAutoDJPlaylistId, pCollection) {
+            : AutoDJProcessor(pParent, pConfig, pPlayerManager,
+                              iAutoDJPlaylistId, pCollection) {
+    }
+
+    virtual ~MockAutoDJProcessor() {
     }
 
     MOCK_METHOD3(loadTrackToPlayer, void(TrackPointer, QString, bool));
@@ -73,8 +139,27 @@ class AutoDJProcessorTest : public LibraryTest {
                     AUTODJ_TABLE, PlaylistDAO::PLHT_AUTO_DJ);
         }
 
-        pProcessor.reset(new MockAutoDJProcessor(NULL, config(), m_iAutoDJPlaylistId,
-                                                 collection()));
+        pPlayerManager.reset(new MockPlayerManager());
+
+        // Setup 4 fake decks.
+        ON_CALL(*pPlayerManager, getPlayer(QString("[Channel1]")))
+                .WillByDefault(Return(&deck1));
+        ON_CALL(*pPlayerManager, getPlayer(QString("[Channel2]")))
+                .WillByDefault(Return(&deck2));
+        ON_CALL(*pPlayerManager, getPlayer(QString("[Channel3]")))
+                .WillByDefault(Return(&deck3));
+        ON_CALL(*pPlayerManager, getPlayer(QString("[Channel4]")))
+                .WillByDefault(Return(&deck4));
+        pPlayerManager->numDecks.set(4);
+
+        EXPECT_CALL(*pPlayerManager, getPlayer(QString("[Channel1]"))).Times(1);
+        EXPECT_CALL(*pPlayerManager, getPlayer(QString("[Channel2]"))).Times(1);
+        EXPECT_CALL(*pPlayerManager, getPlayer(QString("[Channel3]"))).Times(1);
+        EXPECT_CALL(*pPlayerManager, getPlayer(QString("[Channel4]"))).Times(1);
+
+        pProcessor.reset(new MockAutoDJProcessor(
+                NULL, config(), pPlayerManager.data(),
+                m_iAutoDJPlaylistId, collection()));
     }
 
     virtual ~AutoDJProcessorTest() {
@@ -85,10 +170,12 @@ class AutoDJProcessorTest : public LibraryTest {
     }
 
     FakeMaster master;
+    ControlObject numDecks;
     FakeDeck deck1;
     FakeDeck deck2;
     FakeDeck deck3;
     FakeDeck deck4;
+    QScopedPointer<MockPlayerManager> pPlayerManager;
     int m_iAutoDJPlaylistId;
     QScopedPointer<MockAutoDJProcessor> pProcessor;
 };
@@ -96,8 +183,15 @@ class AutoDJProcessorTest : public LibraryTest {
 TEST_F(AutoDJProcessorTest, TransitionTimeLoadedFromConfig) {
     EXPECT_EQ(kDefaultTransitionTime, pProcessor->getTransitionTime());
     config()->set(ConfigKey("[Auto DJ]", "Transition"), QString("25"));
-    pProcessor.reset(new MockAutoDJProcessor(NULL, config(), m_iAutoDJPlaylistId,
-                                             collection()));
+    // Creating a new MockAutoDJProcessor will get each player from player
+    // manager.
+    EXPECT_CALL(*pPlayerManager, getPlayer(QString("[Channel1]"))).Times(1);
+    EXPECT_CALL(*pPlayerManager, getPlayer(QString("[Channel2]"))).Times(1);
+    EXPECT_CALL(*pPlayerManager, getPlayer(QString("[Channel3]"))).Times(1);
+    EXPECT_CALL(*pPlayerManager, getPlayer(QString("[Channel4]"))).Times(1);
+    pProcessor.reset(new MockAutoDJProcessor(
+            NULL, config(), pPlayerManager.data(),
+            m_iAutoDJPlaylistId, collection()));
     EXPECT_EQ(25, pProcessor->getTransitionTime());
 }
 
@@ -161,8 +255,8 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1) {
     // Pretend a track is playing on deck 1.
     TrackPointer pTrack(new TrackInfoObject());
     setTrackId(pTrack, testId + 1);
-    PlayerInfo::instance().setTrackInfo("[Channel1]", pTrack);
-    deck1.play.set(1);
+    // Load track and mark it playing.
+    deck1.slotLoadTrack(pTrack, true);
 
     // Arbitrary to check that it was unchanged.
     master.crossfader.set(0.2447);
@@ -190,8 +284,8 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2) {
     // Pretend a track is playing on deck 2.
     TrackPointer pTrack(new TrackInfoObject());
     setTrackId(pTrack, testId + 1);
-    PlayerInfo::instance().setTrackInfo("[Channel2]", pTrack);
-    deck2.play.set(1);
+    // Load track and mark it playing.
+    deck2.slotLoadTrack(pTrack, true);
 
     // Arbitrary to check that it was unchanged.
     master.crossfader.set(0.2447);


### PR DESCRIPTION
- Remove QSignalMapper usage and instead proxy signals from
  DeckAttributes.
- Connect track load / unload / failed-to-load signals from
  BaseTrackPlayer. Lays the groundwork for solving Bug #1396931.
- Add a helpful debug flag for tracing AutoDJ calls.
- Remove PlayerInfo usage from AutoDJ for getting the loaded
  track. Instead, use BaseTrackPlayer itself.
