### PR TITLE
Add "invert" attribute to BindProperty.

### DIFF
--- a/res/skins/LateNight/waveform_and_mixer.xml
+++ b/res/skins/LateNight/waveform_and_mixer.xml
@@ -84,7 +84,29 @@
                     <ConfigKey>[Master],show_mixer</ConfigKey>
                     <BindProperty>visible</BindProperty>
                 </Connection>
-            </WidgetGroup> 
+            </WidgetGroup>
+            <WidgetGroup>
+                <ObjectName>AlignRightBottom</ObjectName>
+                <Layout>horizontal</Layout>
+                <SizePolicy>min,f</SizePolicy>
+                <Children>
+                    <WidgetGroup> <!-- spacer to push logo to the right -->
+                        <Layout>horizontal</Layout>
+                        <SizePolicy>e,min</SizePolicy>
+                        <Children/>
+                    </WidgetGroup>
+                    <WidgetGroup>
+                        <Layout>horizontal</Layout>
+                        <SizePolicy>f,f</SizePolicy>
+                        <Size>103,40</Size>
+                        <BackPath>style/mixxx_logo.png</BackPath>
+                    </WidgetGroup>
+                </Children>
+                <Connection>
+                    <ConfigKey>[Master],show_mixer</ConfigKey>
+                    <BindProperty invert="true">visible</BindProperty>
+                </Connection>
+            </WidgetGroup>
 		</Children>
 	</WidgetGroup>
 </Template>

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1711,13 +1711,17 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
             QString property = m_pContext->selectString(con, "BindProperty");
             //qDebug() << "Making property connection for" << property;
 
+            QDomElement bind = m_pContext->selectElement(con, "BindProperty");
+            bool invert = m_pContext->selectAttributeBool(bind, "invert", false);
+
             ControlObjectSlave* pControlWidget =
                     new ControlObjectSlave(control->getKey(),
                                            pWidget->toQWidget());
 
             ControlWidgetPropertyConnection* pConnection =
                     new ControlWidgetPropertyConnection(pWidget, pControlWidget,
-                                                        pTransformer, property);
+                                                        pTransformer, property,
+                                                        invert);
             pWidget->addPropertyConnection(pConnection);
 
             // If we created this control, bind it to the

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -104,9 +104,11 @@ void ControlParameterWidgetConnection::setControlParameterUp(double v) {
 ControlWidgetPropertyConnection::ControlWidgetPropertyConnection(WBaseWidget* pBaseWidget,
                                                                  ControlObjectSlave* pControl,
                                                                  ValueTransformer* pTransformer,
-                                                                 const QString& propertyName)
+                                                                 const QString& propertyName,
+                                                                 bool invert)
         : ControlWidgetConnection(pBaseWidget, pControl, pTransformer),
-          m_propertyName(propertyName.toAscii()) {
+          m_propertyName(propertyName.toAscii()),
+          m_invert(invert) {
     slotControlValueChanged(m_pControl->get());
 }
 
@@ -127,6 +129,9 @@ void ControlWidgetPropertyConnection::slotControlValueChanged(double v) {
     QVariant property = pWidget->property(m_propertyName.constData());
     if (property.type() == QVariant::Bool) {
         parameter = getControlParameterForValue(v) > 0;
+        if (m_invert) {
+            parameter = !(parameter.toBool());
+        }
     } else {
         parameter = getControlParameterForValue(v);
     }

--- a/src/widget/controlwidgetconnection.h
+++ b/src/widget/controlwidgetconnection.h
@@ -127,7 +127,8 @@ class ControlWidgetPropertyConnection : public ControlWidgetConnection {
     ControlWidgetPropertyConnection(WBaseWidget* pBaseWidget,
                                     ControlObjectSlave* pControl,
                                     ValueTransformer* pTransformer,
-                                    const QString& property);
+                                    const QString& property,
+                                    bool invert);
     virtual ~ControlWidgetPropertyConnection();
 
     QString toDebugString() const;
@@ -137,6 +138,7 @@ class ControlWidgetPropertyConnection : public ControlWidgetConnection {
 
   private:
     QByteArray m_propertyName;
+    bool m_invert;
 };
 
 #endif /* CONTROLWIDGETCONNECTION_H */


### PR DESCRIPTION
This is handy if you want to show something when a config value
is false.  See the example in LateNight where the logo is shown
if the mixer is hidden.
