### PR TITLE
Skip unloadable tracks in the AutoDJ queue. Fixes Bug #1396931.

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -544,6 +544,8 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
 void EngineBuffer::slotTrackLoadFailed(TrackPointer pTrack,
                                        QString reason) {
     m_iTrackLoading = 0;
+    // NOTE(rryan) ejectTrack will not eject a playing track so set playing
+    // false before calling.
     m_playButton->set(0.0);
     ejectTrack();
     emit(trackLoadFailed(pTrack, reason));

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -164,7 +164,7 @@ class AutoDJProcessor : public QObject {
     void setCrossfader(double value, bool right);
 
     TrackPointer getNextTrackFromQueue();
-    bool loadNextTrackFromQueue(const DeckAttributes& pDeck);
+    bool loadNextTrackFromQueue(const DeckAttributes& pDeck, bool play=false);
     void calculateFadeThresholds(DeckAttributes* pAttributes);
 
     // Removes the track loaded to the player group from the top of the AutoDJ

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -485,7 +485,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1_TrackLoadFailed) {
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
     // After the load failed signal we will receive another track load signal
-    // for deck 1.
+    // for deck 2.
     EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel2]"), false));
 
     // Pretend the track load fails.
@@ -502,7 +502,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1_TrackLoadFailed) {
     deck2.slotLoadTrack(pTrack, false);
     deck2.fakeTrackLoadedEvent(pTrack);
 
-    // No change to the mode, crossfader or play states.
+    // No change to the mode, crossfader, or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
     EXPECT_DOUBLE_EQ(0.2447, master.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());


### PR DESCRIPTION
- On track load failed remove the failed track from the queue and load
  the next track from the queue to the deck.
- Update existing on-enable test cases to check what happens after
  receiving track load success signals.
- Add test case for ADJ_ENABLE_P1LOADED state failing to load the
  first track.
- Add test case for ADJ_ENABLE_P1LOADED state failing to load the
  second track after successfully loading the first track.
- Add test cases for single-deck-playing AutoDJ enable failing to load a
  track in the non-playing player.
- Add test cases for P1FADING / P2FADING mode successfully loading a
  track and failing to load a track.
