### PR TITLE
Don't allow the user to pick a different skin if mixxx hasn't fully started up

### DIFF
--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -328,6 +328,10 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     slotUpdate();
 }
 
+void DlgPrefControls::allowSkinChanges(bool allow) {
+    ComboBoxSkinconf->setEnabled(allow);
+}
+
 DlgPrefControls::~DlgPrefControls() {
     delete m_pControlPositionDisplay;
     qDeleteAll(m_rateControls);

--- a/src/dlgprefcontrols.h
+++ b/src/dlgprefcontrols.h
@@ -44,6 +44,8 @@ class DlgPrefControls : public DlgPreferencePage, public Ui::DlgPrefControlsDlg 
                     ConfigObject<ConfigValue> *pConfig);
     virtual ~DlgPrefControls();
 
+    void allowSkinChanges(bool allow);
+
   public slots:
     void slotUpdate();
     void slotApply();

--- a/src/dlgpreferences.cpp
+++ b/src/dlgpreferences.cpp
@@ -448,6 +448,10 @@ void DlgPreferences::switchToPage(DlgPreferencePage* pWidget) {
     pagesWidget->setCurrentWidget(pWidget->parentWidget()->parentWidget());
 }
 
+void DlgPreferences::allowSkinChanges(bool allow) {
+    m_wcontrols->allowSkinChanges(allow);
+}
+
 void DlgPreferences::moveEvent(QMoveEvent* e) {
     if (m_geometry.length() == 4) {
         m_geometry[0] = QString::number(e->pos().x());

--- a/src/dlgpreferences.h
+++ b/src/dlgpreferences.h
@@ -69,6 +69,7 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
     void removePageWidget(DlgPreferencePage* pWidget);
     void expandTreeItem(QTreeWidgetItem* pItem);
     void switchToPage(DlgPreferencePage* pWidget);
+    void allowSkinChanges(bool allow);
 
   public slots:
     void changePage(QTreeWidgetItem* current, QTreeWidgetItem* previous);

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -338,6 +338,7 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
                                     m_pConfig, m_pLibrary);
     m_pPrefDlg->setWindowIcon(QIcon(":/images/ic_mixxx_window.png"));
     m_pPrefDlg->setHidden(true);
+    m_pPrefDlg->allowSkinChanges(false);
 
     initializeKeyboard();
 
@@ -457,7 +458,7 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
         m_pLibraryScanner->scan();
     }
     slotNumDecksChanged(m_pNumDecks->get());
-
+    m_pPrefDlg->allowSkinChanges(true);
 }
 
 MixxxMainWindow::~MixxxMainWindow() {


### PR DESCRIPTION
this is for this bug: https://bugs.launchpad.net/mixxx/+bug/1315146
I tried to fix the bug itself but I kept running in to new problems, including one that completely crashed X windows.  It's easier to just not allow the user to do the bad thing than try to accommodate it.
