### PR TITLE
BeatMap: Fix bpm and sync behavior with beatmaps.

### DIFF
--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -26,7 +26,7 @@ class BpmControl : public EngineControl {
     virtual ~BpmControl();
 
     double getBpm() const;
-    double getFileBpm() const { return m_pFileBpm ? m_pFileBpm->get() : 0.0; }
+    double getLocalBpm() const { return m_pLocalBpm ? m_pLocalBpm->get() : 0.0; }
     // When in master sync mode, ratecontrol calls calcSyncedRate to figure out
     // how fast the track should play back.  The returned rate is usually just
     // the correct pitch to match bpms.  The usertweak argument represents
@@ -48,6 +48,7 @@ class BpmControl : public EngineControl {
     void setTargetBeatDistance(double beatDistance);
     void setInstantaneousBpm(double instantaneousBpm);
     void resetSyncAdjustment();
+    double updateLocalBpm();
     double updateBeatDistance();
 
     void collectFeatures(GroupFeatureState* pGroupFeatures) const;
@@ -116,6 +117,8 @@ class BpmControl : public EngineControl {
 
     // The current loaded file's detected BPM
     ControlObject* m_pFileBpm;
+    // The bpm around the current playposition;
+    ControlObject* m_pLocalBpm;
     ControlPushButton* m_pAdjustBeatsFaster;
     ControlPushButton* m_pAdjustBeatsSlower;
     ControlPushButton* m_pTranslateBeatsEarlier;

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -117,7 +117,7 @@ class BpmControl : public EngineControl {
 
     // The current loaded file's detected BPM
     ControlObject* m_pFileBpm;
-    // The bpm around the current playposition;
+    // The average bpm around the current playposition;
     ControlObject* m_pLocalBpm;
     ControlPushButton* m_pAdjustBeatsFaster;
     ControlPushButton* m_pAdjustBeatsSlower;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -383,8 +383,8 @@ double EngineBuffer::getBpm()
     return m_pBpmControl->getBpm();
 }
 
-double EngineBuffer::getFileBpm() {
-    return m_pBpmControl->getFileBpm();
+double EngineBuffer::getLocalBpm() {
+    return m_pBpmControl->getLocalBpm();
 }
 
 void EngineBuffer::setEngineMaster(EngineMaster* pEngineMaster) {
@@ -1136,12 +1136,15 @@ void EngineBuffer::postProcess(const int iBufferSize) {
     // The order of events here is very delicate.  It's necessary to update
     // some values before others, because the later updates may require
     // values from the first update.
+    double local_bpm = m_pBpmControl->updateLocalBpm();
     double beat_distance = m_pBpmControl->updateBeatDistance();
     SyncMode mode = m_pSyncControl->getSyncMode();
     if (mode == SYNC_MASTER) {
+        m_pSyncControl->setLocalBpm(local_bpm);
         m_pEngineSync->notifyBeatDistanceChanged(m_pSyncControl, beat_distance);
     } else if (mode == SYNC_FOLLOWER) {
         // Report our speed to SyncControl.  If we are master, we already did this.
+        m_pSyncControl->setLocalBpm(local_bpm);
         m_pSyncControl->reportPlayerSpeed(m_speed_old, m_scratching_old);
         m_pSyncControl->setBeatDistance(beat_distance);
     }

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -131,8 +131,8 @@ class EngineBuffer : public EngineObject {
     double getSpeed();
     // Returns current bpm value (not thread-safe)
     double getBpm();
-    // Returns the BPM of the loaded track (not thread-safe)
-    double getFileBpm();
+    // Returns the BPM of the loaded track around the current position (not thread-safe)
+    double getLocalBpm();
     // Sets pointer to other engine buffer/channel
     void setEngineMaster(EngineMaster*);
 

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -397,7 +397,7 @@ void SyncControl::setLocalBpm(double local_bpm) {
     if (local_bpm == m_prevLocalBpm) {
         return;
     }
-    if (local_bpm == 0 && getSyncMode() != SYNC_NONE && m_pPlayButton->get()) {
+    if (local_bpm == 0 && getSyncMode() != SYNC_NONE && m_pPlayButton->toBool()) {
         // If the local bpm is suddenly zero and sync was active and we are playing,
         // stick with the previous localbpm.
         // I think this can only happen if the beatgrid is reset.

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -37,6 +37,7 @@ class SyncControl : public EngineControl, public Syncable {
     double getBeatDistance() const;
     void setBeatDistance(double beatDistance);
     double getBaseBpm() const;
+    void setLocalBpm(double local_bpm);
 
     // Must never result in a call to
     // SyncableListener::notifyBeatDistanceChanged or signal loops could occur.
@@ -114,6 +115,7 @@ class SyncControl : public EngineControl, public Syncable {
     // multiplier changes and we need to recalculate the target distance.
     double m_unmultipliedTargetBeatDistance;
     double m_beatDistance;
+    double m_prevLocalBpm;
 
     QScopedPointer<ControlPushButton> m_pSyncMode;
     QScopedPointer<ControlPushButton> m_pSyncMasterEnabled;
@@ -122,6 +124,7 @@ class SyncControl : public EngineControl, public Syncable {
 
     QScopedPointer<ControlObjectSlave> m_pPlayButton;
     QScopedPointer<ControlObjectSlave> m_pBpm;
+    QScopedPointer<ControlObjectSlave> m_pLocalBpm;
     QScopedPointer<ControlObjectSlave> m_pFileBpm;
     QScopedPointer<ControlObjectSlave> m_pRateSlider;
     QScopedPointer<ControlObjectSlave> m_pRateDirection;

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -203,4 +203,42 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     }
 }
 
+TEST_F(BeatMapTest, TestBpmAround) {
+    const double filebpm = 60.0;
+    double approx_beat_length = getBeatLengthSamples(filebpm);
+    m_pTrack->setBpm(filebpm);
+    m_pTrack->setSampleRate(m_iSampleRate);
+    const int numBeats = 64;
+
+    QVector<double> beats;
+    double beat_pos = 0;
+    for (unsigned int i = 0, bpm=60; i < numBeats; ++i, ++bpm) {
+        double beat_length = getBeatLengthFrames(bpm);
+        beats.append(beat_pos);
+        beat_pos += beat_length;
+    }
+
+    BeatMap* pMap = new BeatMap(m_pTrack, 0, beats);
+
+    // The average of the first 8 beats should be different than the average
+    // of the last 8 beats.
+    EXPECT_DOUBLE_EQ(64.024390243902445,
+                     pMap->getBpmAroundPosition(4 * approx_beat_length, 4));
+    EXPECT_DOUBLE_EQ(118.98016997167139,
+                     pMap->getBpmAroundPosition(60 * approx_beat_length, 4));
+    // Also test at the beginning and end of the track
+    EXPECT_DOUBLE_EQ(62.968515742128936,
+                     pMap->getBpmAroundPosition(0, 4));
+    EXPECT_DOUBLE_EQ(118.98016997167139,
+                     pMap->getBpmAroundPosition(65 * approx_beat_length, 4));
+    delete pMap;
+
+    // Try a really, really short track
+    beats = createBeatVector(10, 3, getBeatLengthFrames(filebpm));
+    pMap = new BeatMap(m_pTrack, 0, beats);
+
+    EXPECT_DOUBLE_EQ(filebpm, pMap->getBpmAroundPosition(1 * approx_beat_length, 4));
+    delete pMap;
+}
+
 }  // namespace

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -694,7 +694,9 @@ TEST_F(EngineSyncTest, EnableOneDeckInitsMaster) {
                                                         "beat_distance"))->get());
 
     // Enable second deck, beat distance should still match original setting.
-    ControlObject::getControl(ConfigKey(m_sGroup2, "file_bpm"))->set(140.0);
+    QScopedPointer<ControlObjectThread> pFileBpm2(getControlObjectThread(
+        ConfigKey(m_sGroup2, "file_bpm")));
+    pFileBpm2->set(140.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->set(getRateSliderValue(1.0));
     ControlObject::getControl(ConfigKey(m_sGroup2, "beat_distance"))->set(0.2);
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
@@ -1081,8 +1083,12 @@ TEST_F(EngineSyncTest, ZeroBPMRateAdjustIgnored) {
 TEST_F(EngineSyncTest, ZeroLatencyRateChange) {
     // Confirm that a rate change in an explicit master is instantly communicated
     // to followers.
-    ControlObject::getControl(ConfigKey(m_sGroup1, "file_bpm"))->set(128.0);
-    ControlObject::getControl(ConfigKey(m_sGroup2, "file_bpm"))->set(128.0);
+    QScopedPointer<ControlObjectThread> pFileBpm1(getControlObjectThread(
+        ConfigKey(m_sGroup1, "file_bpm")));
+    QScopedPointer<ControlObjectThread> pFileBpm2(getControlObjectThread(
+        ConfigKey(m_sGroup2, "file_bpm")));
+    pFileBpm1->set(128.0);
+    pFileBpm2->set(128.0);
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1.data(), 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
     BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2.data(), 128, 0.0);
@@ -1115,10 +1121,14 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChange) {
 }
 
 TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
-    ControlObject::getControl(ConfigKey(m_sGroup1, "file_bpm"))->set(70);
+    QScopedPointer<ControlObjectThread> pFileBpm1(getControlObjectThread(
+        ConfigKey(m_sGroup1, "file_bpm")));
+    pFileBpm1->set(70);
     BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1.data(), 70, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    ControlObject::getControl(ConfigKey(m_sGroup2, "file_bpm"))->set(140);
+    QScopedPointer<ControlObjectThread> pFileBpm2(getControlObjectThread(
+        ConfigKey(m_sGroup2, "file_bpm")));
+    pFileBpm2->set(140);
     BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2.data(), 140, 0.0);
     m_pTrack2->setBeats(pBeats2);
 

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -228,6 +228,17 @@ double BeatGrid::getBpmRange(double startSample, double stopSample) const {
     return bpm();
 }
 
+double BeatGrid::getBpmAroundPosition(double curSample, int n) const {
+    Q_UNUSED(curSample);
+    Q_UNUSED(n);
+
+    QMutexLocker locker(&m_mutex);
+    if (!isValid()) {
+        return -1;
+    }
+    return bpm();
+}
+
 void BeatGrid::addBeat(double dBeatSample) {
     Q_UNUSED(dBeatSample);
     //QMutexLocker locker(&m_mutex);

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -53,6 +53,7 @@ class BeatGrid : public QObject, public virtual Beats {
     virtual bool hasBeatInRange(double startSample, double stopSample) const;
     virtual double getBpm() const;
     virtual double getBpmRange(double startSample, double stopSample) const;
+    virtual double getBpmAroundPosition(double curSample, int n) const;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat mutations

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -317,6 +317,37 @@ double BeatMap::getBpmRange(double startSample, double stopSample) const {
     return calculateBpm(startBeat, stopBeat);
 }
 
+double BeatMap::getBpmAroundPosition(double curSample, int n) const {
+    QMutexLocker locker(&m_mutex);
+    if (!isValid())
+        return -1;
+
+    // To make sure we are always counting n beats, iterate backward to the
+    // lower bound, then iterate forward from there to the upper bound.
+    // a value of -1 indicates we went off the map -- count from the beginning.
+    double lower_bound = findNthBeat(curSample, -n);
+    if (lower_bound == -1) {
+        lower_bound = framesToSamples(m_beats.first().frame_position());
+    }
+
+    // If we hit the end of the beat map, recalculate the lower bound.
+    double upper_bound = findNthBeat(lower_bound, n * 2);
+    if (upper_bound == -1) {
+        upper_bound = framesToSamples(m_beats.last().frame_position());
+        lower_bound = findNthBeat(upper_bound, n * -2);
+        // Super edge-case -- the track doesn't have n beats!  Do the best
+        // we can.
+        if (lower_bound == -1) {
+            lower_bound = framesToSamples(m_beats.first().frame_position());
+        }
+    }
+
+    Beat startBeat, stopBeat;
+    startBeat.set_frame_position(samplesToFrames(lower_bound));
+    stopBeat.set_frame_position(samplesToFrames(upper_bound));
+    return calculateBpm(startBeat, stopBeat);
+}
+
 void BeatMap::addBeat(double dBeatSample) {
     QMutexLocker locker(&m_mutex);
     Beat beat;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -61,6 +61,7 @@ class BeatMap : public QObject, public Beats {
 
     virtual double getBpm() const;
     virtual double getBpmRange(double startSample, double stopSample) const;
+    virtual double getBpmAroundPosition(double curSample, int n) const;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat mutations

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -89,6 +89,10 @@ class Beats {
     // specified in samples if the BPM is valid, otherwise returns -1
     virtual double getBpmRange(double startSample, double stopSample) const = 0;
 
+    // Return the average BPM over the range of n*2 beats centered around
+    // curSample.  (An n of 4 results in an averaging of 8 beats).
+    virtual double getBpmAroundPosition(double curSample, int n) const = 0;
+
     ////////////////////////////////////////////////////////////////////////////
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -90,7 +90,8 @@ class Beats {
     virtual double getBpmRange(double startSample, double stopSample) const = 0;
 
     // Return the average BPM over the range of n*2 beats centered around
-    // curSample.  (An n of 4 results in an averaging of 8 beats).
+    // curSample.  (An n of 4 results in an averaging of 8 beats).  Invalid
+    // BPM returns -1.
     virtual double getBpmAroundPosition(double curSample, int n) const = 0;
 
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
YOUR BPM INDICATOR IS LYING TO YOU.  Since a beatmap
doesn't have a constant bpm, using the "file_bpm" value
for sync and slider display is misleading.  This commit introduces
a new ControlObject, "local_bpm", which represents the average
bpm value around the closest 8 beat span.  It's still a fairly
noisy value, so it may require tuning.  This local_bpm
value is used to display the visual_bpm, so now you can
watch the bpm of your crazy track change over time.  Also it's
used for master sync, so you can watch the pitch slider
of your track wobble around as it tries to stay in sync.

TESTED=existing tests pass, and some new tests for the bpm averaging function.
