### PR TITLE
Fix waveform concurrency issues. Possible fix for Bug #1383404

### DIFF
--- a/src/analyserwaveform.h
+++ b/src/analyserwaveform.h
@@ -163,8 +163,8 @@ class AnalyserWaveform : public Analyser {
   private:
     bool m_skipProcessing;
 
-    Waveform* m_waveform;
-    Waveform* m_waveformSummary;
+    WaveformPointer m_waveform;
+    WaveformPointer m_waveformSummary;
     int m_waveformDataSize;
     int m_waveformSummaryDataSize;
     WaveformData* m_waveformData;

--- a/src/analyserwaveform.h
+++ b/src/analyserwaveform.h
@@ -31,7 +31,7 @@ inline CSAMPLE scaleSignal(CSAMPLE invalue, FilterIndex index = FilterCount) {
     }
 }
 
-class WaveformStride {
+struct WaveformStride {
     inline void init(double samples, double averageSamples) {
         m_length = samples;
         m_averageLength = averageSamples;
@@ -122,7 +122,6 @@ class WaveformStride {
         }
     }
 
-  private:
     int m_position;
     double m_length;
     double m_averageLength;
@@ -136,9 +135,6 @@ class WaveformStride {
     float m_averageFilteredData[ChannelCount][FilterCount];
 
     float m_postScaleConversion;
-
-  private:
-    friend class AnalyserWaveform;
 };
 
 class AnalyserWaveform : public Analyser {
@@ -165,8 +161,6 @@ class AnalyserWaveform : public Analyser {
 
     WaveformPointer m_waveform;
     WaveformPointer m_waveformSummary;
-    int m_waveformDataSize;
-    int m_waveformSummaryDataSize;
     WaveformData* m_waveformData;
     WaveformData* m_waveformSummaryData;
 

--- a/src/library/dao/analysisdao.cpp
+++ b/src/library/dao/analysisdao.cpp
@@ -320,8 +320,8 @@ void AnalysisDao::saveTrackAnalyses(TrackInfoObject* pTrack) {
         return;
     }
     const int trackId = pTrack->getId();
-    Waveform* pWaveform = pTrack->getWaveform();
-    Waveform* pWaveSummary = pTrack->getWaveformSummary();
+    ConstWaveformPointer pWaveform = pTrack->getWaveform();
+    ConstWaveformPointer pWaveSummary = pTrack->getWaveformSummary();
 
     // Don't try to save invalid or non-dirty waveforms.
     if (!pWaveform || pWaveform->getDataSize() == 0 || !pWaveform->isDirty() ||

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -48,8 +48,6 @@ TrackInfoObject::TrackInfoObject(const QString& file,
           m_pSecurityToken(pToken.isNull() ? Sandbox::openSecurityToken(
                   m_fileInfo, true) : pToken),
           m_qMutex(QMutex::Recursive),
-          m_waveform(new Waveform()),
-          m_waveformSummary(new Waveform()),
           m_analyserProgress(-1) {
     initialize(parseHeader, parseCoverArt);
 }
@@ -61,16 +59,12 @@ TrackInfoObject::TrackInfoObject(const QFileInfo& fileInfo,
           m_pSecurityToken(pToken.isNull() ? Sandbox::openSecurityToken(
                   m_fileInfo, true) : pToken),
           m_qMutex(QMutex::Recursive),
-          m_waveform(new Waveform()),
-          m_waveformSummary(new Waveform()),
           m_analyserProgress(-1) {
     initialize(parseHeader, parseCoverArt);
 }
 
 TrackInfoObject::TrackInfoObject(const QDomNode &nodeHeader)
         : m_qMutex(QMutex::Recursive),
-          m_waveform(new Waveform()),
-          m_waveformSummary(new Waveform()),
           m_analyserProgress(-1) {
     QString filename = XmlParse::selectNodeQString(nodeHeader, "Filename");
     QString location = XmlParse::selectNodeQString(nodeHeader, "Filepath") + "/" +  filename;
@@ -145,9 +139,6 @@ TrackInfoObject::~TrackInfoObject() {
     // Notifies TrackDAO and other listeners that this track is about to be
     // deleted and should be saved to the database, removed from caches, etc.
     emit(deleted(this));
-
-    delete m_waveform;
-    delete m_waveformSummary;
 }
 
 void TrackInfoObject::parse(bool parseCoverArt) {
@@ -788,16 +779,21 @@ QString TrackInfoObject::getURL() {
     return m_sURL;
 }
 
-Waveform* TrackInfoObject::getWaveform() {
+ConstWaveformPointer TrackInfoObject::getWaveform() {
     return m_waveform;
 }
 
-Waveform* TrackInfoObject::getWaveformSummary() {
+void TrackInfoObject::setWaveform(ConstWaveformPointer pWaveform) {
+    m_waveform = pWaveform;
+    emit(waveformUpdated());
+}
+
+ConstWaveformPointer TrackInfoObject::getWaveformSummary() const {
     return m_waveformSummary;
 }
 
-// called from the AnalyserQueue Thread
-void TrackInfoObject::waveformSummaryNew() {
+void TrackInfoObject::setWaveformSummary(ConstWaveformPointer pWaveform) {
+    m_waveformSummary = pWaveform;
     emit(waveformSummaryUpdated());
 }
 

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -36,9 +36,9 @@
 #include "track/beats.h"
 #include "track/keys.h"
 #include "util/sandbox.h"
+#include "waveform/waveform.h"
 
 class Cue;
-class Waveform;
 
 class TrackInfoObject;
 typedef QSharedPointer<TrackInfoObject> TrackPointer;
@@ -223,12 +223,11 @@ class TrackInfoObject : public QObject {
     // Set URL for track
     void setURL(const QString& url);
 
-    Waveform* getWaveform();
-    void waveformNew();
+    ConstWaveformPointer getWaveform();
+    void setWaveform(ConstWaveformPointer pWaveform);
 
-    Waveform* getWaveformSummary();
-    const Waveform* getWaveformSummary() const;
-    void waveformSummaryNew();
+    ConstWaveformPointer getWaveformSummary() const;
+    void setWaveformSummary(ConstWaveformPointer pWaveform);
 
     void setAnalyserProgress(int progress);
     int getAnalyserProgress() const;
@@ -396,8 +395,8 @@ class TrackInfoObject : public QObject {
     BeatsPointer m_pBeats;
 
     //Visual waveform data
-    Waveform* const m_waveform;
-    Waveform* const m_waveformSummary;
+    ConstWaveformPointer m_waveform;
+    ConstWaveformPointer m_waveformSummary;
 
     QAtomicInt m_analyserProgress; // in 0.1%
 

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -79,13 +79,13 @@ bool GLSLWaveformRendererSignal::loadShaders() {
 
 bool GLSLWaveformRendererSignal::loadTexture() {
     TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
-    Waveform* waveform = NULL;
+    ConstWaveformPointer waveform;
     int dataSize = 0;
-    WaveformData* data = NULL;
+    const WaveformData* data = NULL;
 
     if (trackInfo) {
         waveform = trackInfo->getWaveform();
-        if (waveform != NULL) {
+        if (waveform) {
             dataSize = waveform->getDataSize();
             if (dataSize > 1) {
                 data = waveform->data();
@@ -229,8 +229,8 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
         return;
     }
 
-    const Waveform* waveform = trackInfo->getWaveform();
-    if (waveform == NULL) {
+    ConstWaveformPointer waveform = trackInfo->getWaveform();
+    if (waveform.isNull()) {
         return;
     }
 

--- a/src/waveform/renderers/glvsynctestrenderer.cpp
+++ b/src/waveform/renderers/glvsynctestrenderer.cpp
@@ -38,8 +38,8 @@ void GLVSyncTestRenderer::draw(QPainter* painter, QPaintEvent* /*event*/) {
         return;
     }
 
-    const Waveform* waveform = pTrack->getWaveform();
-    if (waveform == NULL) {
+    ConstWaveformPointer waveform = pTrack->getWaveform();
+    if (waveform.isNull()) {
         return;
     }
 

--- a/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
@@ -31,8 +31,8 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
         return;
     }
 
-    const Waveform* waveform = pTrack->getWaveform();
-    if (waveform == NULL) {
+    ConstWaveformPointer waveform = pTrack->getWaveform();
+    if (waveform.isNull()) {
         return;
     }
 

--- a/src/waveform/renderers/glwaveformrendererrgb.cpp
+++ b/src/waveform/renderers/glwaveformrendererrgb.cpp
@@ -57,8 +57,8 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
         return;
     }
 
-    const Waveform* waveform = pTrack->getWaveform();
-    if (waveform == NULL) {
+    ConstWaveformPointer waveform = pTrack->getWaveform();
+    if (waveform.isNull()) {
         return;
     }
 

--- a/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
@@ -32,8 +32,8 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
         return;
     }
 
-    const Waveform* waveform = pTrack->getWaveform();
-    if (waveform == NULL) {
+    ConstWaveformPointer waveform = pTrack->getWaveform();
+    if (waveform.isNull()) {
         return;
     }
 

--- a/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
@@ -101,8 +101,8 @@ int QtWaveformRendererFilteredSignal::buildPolygon() {
         return 0;
     }
 
-    const Waveform* waveform = pTrack->getWaveform();
-    if (waveform == NULL) {
+    ConstWaveformPointer waveform = pTrack->getWaveform();
+    if (waveform.isNull()) {
         return 0;
     }
 

--- a/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
@@ -43,8 +43,8 @@ void QtWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
         return;
     }
 
-    const Waveform* waveform = pTrack->getWaveform();
-    if (waveform == NULL) {
+    ConstWaveformPointer waveform = pTrack->getWaveform();
+    if (waveform.isNull()) {
         return;
     }
 

--- a/src/waveform/renderers/waveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.cpp
@@ -34,8 +34,8 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
         return;
     }
 
-    const Waveform* waveform = trackInfo->getWaveform();
-    if (waveform == NULL) {
+    ConstWaveformPointer waveform = trackInfo->getWaveform();
+    if (waveform.isNull()) {
         return;
     }
 

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -28,8 +28,8 @@ void WaveformRendererHSV::draw(QPainter* painter,
         return;
     }
 
-    const Waveform* waveform = trackInfo->getWaveform();
-    if (waveform == NULL) {
+    ConstWaveformPointer waveform = trackInfo->getWaveform();
+    if (waveform.isNull()) {
         return;
     }
 

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -50,8 +50,8 @@ void WaveformRendererRGB::draw(QPainter* painter,
         return;
     }
 
-    const Waveform* waveform = trackInfo->getWaveform();
-    if (waveform == NULL) {
+    ConstWaveformPointer waveform = trackInfo->getWaveform();
+    if (waveform.isNull()) {
         return;
     }
 

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -121,11 +121,15 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
     double visualSamplePerPixel = m_zoomFactor * (1.0 + m_rateAdjust);
     m_visualSamplePerPixel = math_max(1.0, visualSamplePerPixel);
 
-    if (m_trackInfoObject) {
-        m_audioSamplePerPixel = m_visualSamplePerPixel * m_trackInfoObject->getWaveform()->getAudioVisualRatio();
+    TrackPointer pTrack(m_trackInfoObject);
+    ConstWaveformPointer pWaveform = pTrack ? pTrack->getWaveform() : ConstWaveformPointer();
+    int waveformDataSize = pWaveform ? pWaveform->getDataSize() : 0;
+    if (pWaveform) {
+        m_audioSamplePerPixel = m_visualSamplePerPixel * pWaveform->getAudioVisualRatio();
     } else {
         m_audioSamplePerPixel = 0.0;
     }
+
 
     m_playPos = m_visualPlayPosition->getAtNextVSync(vsyncThread);
     // m_playPos = -1 happens, when a new track is in buffer but m_visualPlayPosition was not updated
@@ -140,7 +144,7 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
         // Avoid pixel jitter in play position by rounding to the nearest track
         // pixel.
         m_playPos = round(m_playPos * m_trackPixelCount) / m_trackPixelCount; // Avoid pixel jitter in play position
-        m_playPosVSample = m_playPos * m_trackInfoObject->getWaveform()->getDataSize();
+        m_playPosVSample = m_playPos * waveformDataSize;
 
         m_firstDisplayedPosition = m_playPos - displayedLengthHalf;
         m_lastDisplayedPosition = m_playPos + displayedLengthHalf;

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -14,7 +14,6 @@ const int WaveformWidgetRenderer::s_waveformMaxZoom = 6;
 
 WaveformWidgetRenderer::WaveformWidgetRenderer(const char* group)
     : m_group(group),
-      m_trackInfoObject(0),
       m_height(-1),
       m_width(-1),
 
@@ -121,7 +120,7 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
     double visualSamplePerPixel = m_zoomFactor * (1.0 + m_rateAdjust);
     m_visualSamplePerPixel = math_max(1.0, visualSamplePerPixel);
 
-    TrackPointer pTrack(m_trackInfoObject);
+    TrackPointer pTrack(m_pTrack);
     ConstWaveformPointer pWaveform = pTrack ? pTrack->getWaveform() : ConstWaveformPointer();
     int waveformDataSize = pWaveform ? pWaveform->getDataSize() : 0;
     if (pWaveform) {
@@ -253,7 +252,7 @@ void WaveformWidgetRenderer::setZoom(int zoom) {
 }
 
 void WaveformWidgetRenderer::setTrack(TrackPointer track) {
-    m_trackInfoObject = track;
+    m_pTrack = track;
     //used to postpone first display until track sample is actually available
     m_trackSamples = -1.0;
 

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -35,7 +35,7 @@ class WaveformWidgetRenderer {
     void draw(QPainter* painter, QPaintEvent* event);
 
     inline const char* getGroup() const { return m_group;}
-    const TrackPointer getTrackInfo() const { return m_trackInfoObject;}
+    const TrackPointer getTrackInfo() const { return m_pTrack;}
 
     double getFirstDisplayedPosition() const { return m_firstDisplayedPosition;}
     double getLastDisplayedPosition() const { return m_lastDisplayedPosition;}
@@ -85,7 +85,7 @@ class WaveformWidgetRenderer {
 
   protected:
     const char* m_group;
-    TrackPointer m_trackInfoObject;
+    TrackPointer m_pTrack;
     QList<WaveformRendererAbstract*> m_rendererStack;
     int m_height;
     int m_width;

--- a/src/waveform/waveform.cpp
+++ b/src/waveform/waveform.cpp
@@ -23,7 +23,7 @@ Waveform::Waveform(const QByteArray data)
           m_dataSize(0),
           m_visualSampleRate(0),
           m_audioVisualRatio(0),
-                  m_textureStride(computeTextureStride(0)),
+          m_textureStride(computeTextureStride(0)),
           m_completion(-1) {
     readByteArray(data);
 }

--- a/src/waveform/waveform.h
+++ b/src/waveform/waveform.h
@@ -78,6 +78,8 @@ class Waveform {
         return m_bDirty;
     }
 
+    // AnalysisDAO needs to be able to set the waveform as clean so we mark this
+    // as const and m_bDirty mutable.
     void setDirty(bool bDirty) const {
         m_bDirty = bDirty;
     }
@@ -140,6 +142,7 @@ class Waveform {
 
     // If stored in the database, the ID of the waveform.
     int m_id;
+    // AnalysisDAO needs to be able to set the waveform as clean.
     mutable bool m_bDirty;
     QString m_version;
     QString m_description;

--- a/src/waveform/waveform.h
+++ b/src/waveform/waveform.h
@@ -101,16 +101,16 @@ class Waveform {
 
     // We do not lock the mutex since m_textureStride is not changed after
     // the constructor runs.
-    int getTextureStride() const { return m_textureStride; }
+    inline int getTextureStride() const { return m_textureStride; }
 
     // We do not lock the mutex since m_data is not resized after the
     // constructor runs.
-    int getTextureSize() const { return m_data.size(); }
+    inline int getTextureSize() const { return m_data.size(); }
 
     // Atomically get the number of data elements in this Waveform. We do not
     // lock the mutex since m_dataSize is not changed after the constructor
     // runs.
-    int getDataSize() const { return load_atomic(m_dataSize); }
+    inline int getDataSize() const { return m_dataSize; }
 
     inline const WaveformData& get(int i) const { return m_data[i];}
     inline unsigned char getLow(int i) const { return m_data[i].filtered.low;}
@@ -149,11 +149,14 @@ class Waveform {
 
     // The size of the waveform data stored in m_data. Not allowed to change
     // after the constructor runs.
-    QAtomicInt m_dataSize;
-    // The vector storing the waveform data. It has potentially more data
-    // allocated in it than m_dataSize since it includes padding for uploading
-    // the entire waveform as a texture in the GLSL renderer. The size is not
-    // allowed to change after the constructor runs.
+    int m_dataSize;
+    // The vector storing the waveform data. It is potentially larger than
+    // m_dataSize since it includes padding for uploading the entire waveform as
+    // a texture in the GLSL renderer. The size is not allowed to change after
+    // the constructor runs. We use a std::vector to avoid the cost of bounds
+    // checking when accessing the vector.
+    // TODO(XXX): In the future we should switch to QVector and use the raw data
+    // pointer when performance matters.
     std::vector<WaveformData> m_data;
     // Not allowed to change after the constructor runs.
     double m_visualSampleRate;

--- a/src/waveform/waveform.h
+++ b/src/waveform/waveform.h
@@ -5,6 +5,8 @@
 #include <QByteArray>
 #include <QString>
 #include <QAtomicInt>
+#include <QSharedPointer>
+#include <QMutexLocker>
 #include <vector>
 
 #include "util.h"
@@ -28,54 +30,85 @@ union WaveformData {
 
 class Waveform {
   public:
-    Waveform(const QByteArray pData = QByteArray());
+    explicit Waveform(const QByteArray pData = QByteArray());
+    Waveform(int audioSampleRate, int audioSamples,
+             int desiredVisualSampleRate, int maxVisualSamples);
+
     virtual ~Waveform();
 
-    void readByteArray(const QByteArray data);
-
     int getId() const {
+        QMutexLocker locker(&m_mutex);
         return m_id;
     }
+
     void setId(int id) {
+        QMutexLocker locker(&m_mutex);
         m_id = id;
     }
+
     QString getVersion() const {
+        QMutexLocker locker(&m_mutex);
         return m_version;
     }
+
     void setVersion(QString version) {
+        QMutexLocker locker(&m_mutex);
         m_version = version;
     }
+
     QString getDescription() const {
+        QMutexLocker locker(&m_mutex);
         return m_description;
     }
+
     void setDescription(QString description) {
+        QMutexLocker locker(&m_mutex);
         m_description = description;
     }
+
     QByteArray toByteArray() const;
 
-    void reset();
+    // We do not lock the mutex since m_dataSize and m_visualSampleRate are not
+    // changed after the constructor runs.
+    bool isValid() const {
+        return getDataSize() > 0 && getVisualSampleRate() > 0;
+    }
 
-    bool isValid() const { return getDataSize() > 0 && getVisualSampleRate() > 0; }
-    bool isDirty() const { return m_bDirty; }
-    void setDirty(bool bDirty) {
+    bool isDirty() const {
+        return m_bDirty;
+    }
+
+    void setDirty(bool bDirty) const {
         m_bDirty = bDirty;
     }
 
-    double getVisualSampleRate() const { return m_visualSampleRate; }
-    double getAudioVisualRatio() const { return m_audioVisualRatio; }
+    // We do not lock the mutex since m_audioVisualRatio is not changed after
+    // the constructor runs.
+    double getAudioVisualRatio() const {
+        return m_audioVisualRatio;
+    }
 
     // Atomically lookup the completion of the waveform. Represents the number
     // of data elements that have been processed out of dataSize.
-    int getCompletion() const { return load_atomic(m_completion); }
+    int getCompletion() const {
+        return load_atomic(m_completion);
+    }
+    void setCompletion(int completion) {
+        m_completion = completion;
+    }
+
+    // We do not lock the mutex since m_textureStride is not changed after
+    // the constructor runs.
     int getTextureStride() const { return m_textureStride; }
+
+    // We do not lock the mutex since m_data is not resized after the
+    // constructor runs.
     int getTextureSize() const { return m_data.size(); }
 
-    // Atomically get the number of data elements in this Waveform. You do not
-    // need to lock the Waveform's mutex before calling this method.
+    // Atomically get the number of data elements in this Waveform. We do not
+    // lock the mutex since m_dataSize is not changed after the constructor
+    // runs.
     int getDataSize() const { return load_atomic(m_dataSize); }
-    int getNumChannels() const { return load_atomic(m_numChannels); }
-
-    const std::vector<WaveformData>& getConstData() const { return m_data;}
 
     inline const WaveformData& get(int i) const { return m_data[i];}
     inline unsigned char getLow(int i) const { return m_data[i].filtered.low;}
@@ -83,55 +116,61 @@ class Waveform {
     inline unsigned char getHigh(int i) const { return m_data[i].filtered.high;}
     inline unsigned char getAll(int i) const { return m_data[i].filtered.all;}
 
+    // We do not lock the mutex since m_data is not resized after the
+    // constructor runs.
     WaveformData* data() { return &m_data[0];}
-    const WaveformData* data() const { return &m_data[0];}
 
-    inline QMutex* getMutex() const {
-        return m_mutex;
-    }
+    // We do not lock the mutex since m_data is not resized after the
+    // constructor runs.
+    const WaveformData* data() const { return &m_data[0];}
 
     void dump() const;
 
   private:
+    void readByteArray(const QByteArray& data);
     void resize(int size);
     void assign(int size, int value = 0);
-
-    void initalise(int audioSampleRate, int audioSamples,
-            int desiredVisualSampleRate, int maxVisualSamples = -1);
 
     inline WaveformData& at(int i) { return m_data[i];}
     inline unsigned char& low(int i) { return m_data[i].filtered.low;}
     inline unsigned char& mid(int i) { return m_data[i].filtered.mid;}
     inline unsigned char& high(int i) { return m_data[i].filtered.high;}
     inline unsigned char& all(int i) { return m_data[i].filtered.all;}
-
-    int computeTextureSize(int getDataSize);
-    void setCompletion(int completion) { m_completion = completion;}
+    double getVisualSampleRate() const { return m_visualSampleRate; }
 
     // If stored in the database, the ID of the waveform.
     int m_id;
-    bool m_bDirty;
+    mutable bool m_bDirty;
     QString m_version;
     QString m_description;
 
-    const QAtomicInt m_numChannels;
-    QAtomicInt m_dataSize; //m_data allocated size
+    // The size of the waveform data stored in m_data. Not allowed to change
+    // after the constructor runs.
+    QAtomicInt m_dataSize;
+    // The vector storing the waveform data. It has potentially more data
+    // allocated in it than m_dataSize since it includes padding for uploading
+    // the entire waveform as a texture in the GLSL renderer. The size is not
+    // allowed to change after the constructor runs.
     std::vector<WaveformData> m_data;
+    // Not allowed to change after the constructor runs.
     double m_visualSampleRate;
+    // Not allowed to change after the constructor runs.
     double m_audioVisualRatio;
 
-    //No need to store the following members they can be recomputed
-    //on waveform loading
-
+    // We create an NxN texture out of m_data's buffer in the GLSL renderer. The
+    // stride is N. Not allowed to change after the constructor runs.
     int m_textureStride;
+
+    // For performance, completion is shared as a QAtomicInt and does not lock
+    // the mutex. The completion of the waveform calculation.
     QAtomicInt m_completion;
 
-    mutable QMutex* m_mutex;
-
-    friend class AnalyserWaveform;
-    friend class WaveformStride;
+    mutable QMutex m_mutex;
 
     DISALLOW_COPY_AND_ASSIGN(Waveform);
 };
+
+typedef QSharedPointer<Waveform> WaveformPointer;
+typedef QSharedPointer<const Waveform> ConstWaveformPointer;
 
 #endif // WAVEFORM_H

--- a/src/waveform/waveformfactory.cpp
+++ b/src/waveform/waveformfactory.cpp
@@ -4,17 +4,13 @@
 #include "waveform/waveform.h"
 
 // static
-bool WaveformFactory::updateWaveformFromAnalysis(
-        Waveform* pWaveform, const AnalysisDao::AnalysisInfo& analysis) {
-    if (pWaveform) {
-        pWaveform->reset();
-        pWaveform->readByteArray(analysis.data);
-        pWaveform->setId(analysis.analysisId);
-        pWaveform->setVersion(analysis.version);
-        pWaveform->setDescription(analysis.description);
-        return true;
-    }
-    return false;
+Waveform* WaveformFactory::loadWaveformFromAnalysis(
+        const AnalysisDao::AnalysisInfo& analysis) {
+    Waveform* pWaveform = new Waveform(analysis.data);
+    pWaveform->setId(analysis.analysisId);
+    pWaveform->setVersion(analysis.version);
+    pWaveform->setDescription(analysis.description);
+    return pWaveform;
 }
 
 // static

--- a/src/waveform/waveformfactory.h
+++ b/src/waveform/waveformfactory.h
@@ -31,8 +31,8 @@ class WaveformFactory {
         VC_REMOVE
     };
 
-    static bool updateWaveformFromAnalysis(
-            Waveform* pWaveform, const AnalysisDao::AnalysisInfo& analysis);
+    static Waveform* loadWaveformFromAnalysis(
+            const AnalysisDao::AnalysisInfo& analysis);
     static VersionClass waveformVersionToVersionClass(const QString& version);
     static VersionClass waveformSummaryVersionToVersionClass(const QString& version);
     static QString currentWaveformVersion();

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -35,7 +35,6 @@
 
 WOverview::WOverview(const char *pGroup, ConfigObject<ConfigValue>* pConfig, QWidget* parent) :
         WWidget(parent),
-        m_pWaveform(NULL),
         m_pWaveformSourceImage(NULL),
         m_actualCompletion(0),
         m_pixmapDone(false),
@@ -158,10 +157,11 @@ void WOverview::onConnectedControlChanged(double dParameter, double dValue) {
 }
 
 void WOverview::slotWaveformSummaryUpdated() {
-    if (!m_pCurrentTrack) {
+    TrackPointer pTrack(m_pCurrentTrack);
+    if (!pTrack) {
         return;
     }
-    m_pWaveform = m_pCurrentTrack->getWaveformSummary();
+    m_pWaveform = pTrack->getWaveformSummary();
     // If the waveform is already complete, just draw it.
     if (m_pWaveform && m_pWaveform->getCompletion() == m_pWaveform->getDataSize()) {
         m_actualCompletion = 0;
@@ -236,7 +236,7 @@ void WOverview::slotUnloadTrack(TrackPointer /*pTrack*/) {
                    this, SLOT(slotAnalyserProgress(int)));
     }
     m_pCurrentTrack.clear();
-    m_pWaveform = NULL;
+    m_pWaveform.clear();
     m_actualCompletion = 0;
     m_waveformPeak = -1.0;
     m_pixmapDone = false;

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -56,7 +56,9 @@ class WOverview : public WWidget {
     virtual void dragEnterEvent(QDragEnterEvent* event);
     virtual void dropEvent(QDropEvent* event);
 
-    Waveform* m_pWaveform;
+    ConstWaveformPointer getWaveform() const {
+        return m_pWaveform;
+    }
 
     QImage* m_pWaveformSourceImage;
     QImage m_waveformImageScaled;
@@ -98,9 +100,9 @@ class WOverview : public WWidget {
     ControlObjectThread* m_trackSamplesControl;
     ControlObjectThread* m_playControl;
 
-
     // Current active track
     TrackPointer m_pCurrentTrack;
+    ConstWaveformPointer m_pWaveform;
 
     // True if slider is dragged. Only used when m_bEventWhileDrag is false
     bool m_bDrag;

--- a/src/widget/woverviewhsv.cpp
+++ b/src/widget/woverviewhsv.cpp
@@ -19,11 +19,12 @@ bool WOverviewHSV::drawNextPixmapPart() {
 
     int currentCompletion;
 
-    if (!m_pWaveform) {
+    ConstWaveformPointer pWaveform = getWaveform();
+    if (!pWaveform) {
         return false;
     }
 
-    const int dataSize = m_pWaveform->getDataSize();
+    const int dataSize = pWaveform->getDataSize();
     if (dataSize == 0) {
         return false;
     }
@@ -38,16 +39,12 @@ bool WOverviewHSV::drawNextPixmapPart() {
     }
 
     // Always multiple of 2
-    const int waveformCompletion = m_pWaveform->getCompletion();
+    const int waveformCompletion = pWaveform->getCompletion();
     // Test if there is some new to draw (at least of pixel width)
     const int completionIncrement = waveformCompletion - m_actualCompletion;
 
     int visiblePixelIncrement = completionIncrement * width() / dataSize;
     if (completionIncrement < 2 || visiblePixelIncrement == 0) {
-        return false;
-    }
-
-    if (!m_pWaveform->getMutex()->tryLock()) {
         return false;
     }
 
@@ -79,15 +76,15 @@ bool WOverviewHSV::drawNextPixmapPart() {
 
     for (currentCompletion = m_actualCompletion;
             currentCompletion < nextCompletion; currentCompletion += 2) {
-        maxAll[0] = m_pWaveform->getAll(currentCompletion);
-        maxAll[1] = m_pWaveform->getAll(currentCompletion+1);
+        maxAll[0] = pWaveform->getAll(currentCompletion);
+        maxAll[1] = pWaveform->getAll(currentCompletion+1);
         if (maxAll[0] || maxAll[1]) {
-            maxLow[0] = m_pWaveform->getLow(currentCompletion);
-            maxLow[1] = m_pWaveform->getLow(currentCompletion+1);
-            maxMid[0] = m_pWaveform->getMid(currentCompletion);
-            maxMid[1] = m_pWaveform->getMid(currentCompletion+1);
-            maxHigh[0] = m_pWaveform->getHigh(currentCompletion);
-            maxHigh[1] = m_pWaveform->getHigh(currentCompletion+1);
+            maxLow[0] = pWaveform->getLow(currentCompletion);
+            maxLow[1] = pWaveform->getLow(currentCompletion+1);
+            maxMid[0] = pWaveform->getMid(currentCompletion);
+            maxMid[1] = pWaveform->getMid(currentCompletion+1);
+            maxHigh[0] = pWaveform->getHigh(currentCompletion);
+            maxHigh[1] = pWaveform->getHigh(currentCompletion+1);
 
             total = (maxLow[0] + maxLow[1] + maxMid[0] + maxMid[1] +
                      maxHigh[0] + maxHigh[1]) * 1.2;
@@ -116,9 +113,9 @@ bool WOverviewHSV::drawNextPixmapPart() {
     for (currentCompletion = m_actualCompletion;
             currentCompletion < nextCompletion; currentCompletion += 2) {
         m_waveformPeak = math_max(m_waveformPeak,
-                (float)m_pWaveform->getAll(currentCompletion));
+                (float)pWaveform->getAll(currentCompletion));
         m_waveformPeak = math_max(m_waveformPeak,
-                (float)m_pWaveform->getAll(currentCompletion+1));
+                (float)pWaveform->getAll(currentCompletion+1));
     }
 
     m_actualCompletion = nextCompletion;
@@ -131,6 +128,5 @@ bool WOverviewHSV::drawNextPixmapPart() {
         //qDebug() << "m_waveformPeakRatio" << m_waveformPeak;
     }
 
-    m_pWaveform->getMutex()->unlock();
     return true;
 }

--- a/src/widget/woverviewhsv.cpp
+++ b/src/widget/woverviewhsv.cpp
@@ -112,10 +112,10 @@ bool WOverviewHSV::drawNextPixmapPart() {
 
     for (currentCompletion = m_actualCompletion;
             currentCompletion < nextCompletion; currentCompletion += 2) {
-        m_waveformPeak = math_max(m_waveformPeak,
-                (float)pWaveform->getAll(currentCompletion));
-        m_waveformPeak = math_max(m_waveformPeak,
-                (float)pWaveform->getAll(currentCompletion+1));
+        m_waveformPeak = math_max3(
+                m_waveformPeak,
+                static_cast<float>(pWaveform->getAll(currentCompletion)),
+                static_cast<float>(pWaveform->getAll(currentCompletion + 1)));
     }
 
     m_actualCompletion = nextCompletion;

--- a/src/widget/woverviewlmh.cpp
+++ b/src/widget/woverviewlmh.cpp
@@ -104,10 +104,10 @@ bool WOverviewLMH::drawNextPixmapPart() {
 
     for (currentCompletion = m_actualCompletion;
             currentCompletion < nextCompletion; currentCompletion += 2) {
-        m_waveformPeak = math_max(m_waveformPeak,
-                (float)pWaveform->getAll(currentCompletion));
-        m_waveformPeak = math_max(m_waveformPeak,
-                (float)pWaveform->getAll(currentCompletion+1));
+        m_waveformPeak = math_max3(
+                m_waveformPeak,
+                static_cast<float>(pWaveform->getAll(currentCompletion)),
+                static_cast<float>(pWaveform->getAll(currentCompletion + 1)));
     }
 
     m_actualCompletion = nextCompletion;

--- a/src/widget/woverviewlmh.cpp
+++ b/src/widget/woverviewlmh.cpp
@@ -21,11 +21,12 @@ bool WOverviewLMH::drawNextPixmapPart() {
 
     int currentCompletion;
 
-    if (!m_pWaveform) {
+    ConstWaveformPointer pWaveform = getWaveform();
+    if (!pWaveform) {
         return false;
     }
 
-    const int dataSize = m_pWaveform->getDataSize();
+    const int dataSize = pWaveform->getDataSize();
     if (dataSize == 0) {
         return false;
     }
@@ -40,16 +41,12 @@ bool WOverviewLMH::drawNextPixmapPart() {
     }
 
     // Always multiple of 2
-    const int waveformCompletion = m_pWaveform->getCompletion();
+    const int waveformCompletion = pWaveform->getCompletion();
     // Test if there is some new to draw (at least of pixel width)
     const int completionIncrement = waveformCompletion - m_actualCompletion;
 
     int visiblePixelIncrement = completionIncrement * width() / dataSize;
     if (completionIncrement < 2 || visiblePixelIncrement == 0) {
-        return false;
-    }
-
-    if (!m_pWaveform->getMutex()->tryLock()) {
         return false;
     }
 
@@ -76,8 +73,8 @@ bool WOverviewLMH::drawNextPixmapPart() {
 
     for (currentCompletion = m_actualCompletion;
             currentCompletion < nextCompletion; currentCompletion += 2) {
-        unsigned char lowNeg = m_pWaveform->getLow(currentCompletion);
-        unsigned char lowPos = m_pWaveform->getLow(currentCompletion+1);
+        unsigned char lowNeg = pWaveform->getLow(currentCompletion);
+        unsigned char lowPos = pWaveform->getLow(currentCompletion+1);
         if (lowPos || lowNeg) {
             painter.setPen(lowColorPen);
             painter.drawLine(QPoint(currentCompletion / 2, -lowNeg),
@@ -89,18 +86,18 @@ bool WOverviewLMH::drawNextPixmapPart() {
             currentCompletion < nextCompletion; currentCompletion += 2) {
         painter.setPen(midColorPen);
         painter.drawLine(QPoint(currentCompletion / 2,
-                -m_pWaveform->getMid(currentCompletion)),
+                -pWaveform->getMid(currentCompletion)),
                 QPoint(currentCompletion / 2,
-                m_pWaveform->getMid(currentCompletion+1)));
+                pWaveform->getMid(currentCompletion+1)));
     }
 
     for (currentCompletion = m_actualCompletion;
             currentCompletion < nextCompletion; currentCompletion += 2) {
         painter.setPen(highColorPen);
         painter.drawLine(QPoint(currentCompletion / 2,
-                -m_pWaveform->getHigh(currentCompletion)),
+                -pWaveform->getHigh(currentCompletion)),
                 QPoint(currentCompletion / 2,
-                m_pWaveform->getHigh(currentCompletion+1)));
+                pWaveform->getHigh(currentCompletion+1)));
     }
 
     // Evaluate waveform ratio peak
@@ -108,9 +105,9 @@ bool WOverviewLMH::drawNextPixmapPart() {
     for (currentCompletion = m_actualCompletion;
             currentCompletion < nextCompletion; currentCompletion += 2) {
         m_waveformPeak = math_max(m_waveformPeak,
-                (float)m_pWaveform->getAll(currentCompletion));
+                (float)pWaveform->getAll(currentCompletion));
         m_waveformPeak = math_max(m_waveformPeak,
-                (float)m_pWaveform->getAll(currentCompletion+1));
+                (float)pWaveform->getAll(currentCompletion+1));
     }
 
     m_actualCompletion = nextCompletion;
@@ -123,6 +120,5 @@ bool WOverviewLMH::drawNextPixmapPart() {
         //qDebug() << "m_waveformPeakRatio" << m_waveformPeak;
     }
 
-    m_pWaveform->getMutex()->unlock();
     return true;
 }

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -18,11 +18,12 @@ bool WOverviewRGB::drawNextPixmapPart() {
 
     int currentCompletion;
 
-    if (!m_pWaveform) {
+    ConstWaveformPointer pWaveform = getWaveform();
+    if (!pWaveform) {
         return false;
     }
 
-    const int dataSize = m_pWaveform->getDataSize();
+    const int dataSize = pWaveform->getDataSize();
     if (dataSize == 0) {
         return false;
     }
@@ -37,16 +38,12 @@ bool WOverviewRGB::drawNextPixmapPart() {
     }
 
     // Always multiple of 2
-    const int waveformCompletion = m_pWaveform->getCompletion();
+    const int waveformCompletion = pWaveform->getCompletion();
     // Test if there is some new to draw (at least of pixel width)
     const int completionIncrement = waveformCompletion - m_actualCompletion;
 
     int visiblePixelIncrement = completionIncrement * width() / dataSize;
     if (completionIncrement < 2 || visiblePixelIncrement == 0) {
-        return false;
-    }
-
-    if (!m_pWaveform->getMutex()->tryLock()) {
         return false;
     }
 
@@ -71,12 +68,12 @@ bool WOverviewRGB::drawNextPixmapPart() {
     for (currentCompletion = m_actualCompletion;
             currentCompletion < nextCompletion; currentCompletion += 2) {
 
-        unsigned char left = m_pWaveform->getAll(currentCompletion);
-        unsigned char right = m_pWaveform->getAll(currentCompletion + 1);
+        unsigned char left = pWaveform->getAll(currentCompletion);
+        unsigned char right = pWaveform->getAll(currentCompletion + 1);
 
-        low = m_pWaveform->getLow(currentCompletion);
-        mid = m_pWaveform->getMid(currentCompletion);
-        high = m_pWaveform->getHigh(currentCompletion);
+        low = pWaveform->getLow(currentCompletion);
+        mid = pWaveform->getMid(currentCompletion);
+        high = pWaveform->getHigh(currentCompletion);
 
         max = (float) math_max3(low, mid, high);
         if (max > 0.0f) {
@@ -85,9 +82,9 @@ bool WOverviewRGB::drawNextPixmapPart() {
             painter.drawLine(currentCompletion / 2, -left, currentCompletion / 2, 0);
         }
 
-        low = m_pWaveform->getLow(currentCompletion + 1);
-        mid = m_pWaveform->getMid(currentCompletion + 1);
-        high = m_pWaveform->getHigh(currentCompletion + 1);
+        low = pWaveform->getLow(currentCompletion + 1);
+        mid = pWaveform->getMid(currentCompletion + 1);
+        high = pWaveform->getHigh(currentCompletion + 1);
 
         max = (float) math_max3(low, mid, high);
         if (max > 0.0f) {
@@ -101,9 +98,9 @@ bool WOverviewRGB::drawNextPixmapPart() {
     for (currentCompletion = m_actualCompletion;
             currentCompletion < nextCompletion; currentCompletion += 2) {
         m_waveformPeak = math_max(m_waveformPeak,
-                (float)m_pWaveform->getAll(currentCompletion));
+                (float)pWaveform->getAll(currentCompletion));
         m_waveformPeak = math_max(m_waveformPeak,
-                (float)m_pWaveform->getAll(currentCompletion+1));
+                (float)pWaveform->getAll(currentCompletion+1));
     }
 
     m_actualCompletion = nextCompletion;
@@ -116,6 +113,5 @@ bool WOverviewRGB::drawNextPixmapPart() {
         //qDebug() << "m_waveformPeakRatio" << m_waveformPeak;
     }
 
-    m_pWaveform->getMutex()->unlock();
     return true;
 }

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -97,10 +97,10 @@ bool WOverviewRGB::drawNextPixmapPart() {
     // Evaluate waveform ratio peak
     for (currentCompletion = m_actualCompletion;
             currentCompletion < nextCompletion; currentCompletion += 2) {
-        m_waveformPeak = math_max(m_waveformPeak,
-                (float)pWaveform->getAll(currentCompletion));
-        m_waveformPeak = math_max(m_waveformPeak,
-                (float)pWaveform->getAll(currentCompletion+1));
+        m_waveformPeak = math_max3(
+                m_waveformPeak,
+                static_cast<float>(pWaveform->getAll(currentCompletion)),
+                static_cast<float>(pWaveform->getAll(currentCompletion + 1)));
     }
 
     m_actualCompletion = nextCompletion;


### PR DESCRIPTION
- Use const shared pointers for waveforms.
- Move all std::vector sizing operations to the Waveform constructor. No
  vector state is allowed to change after the constructor finishes.
- Clarify comments.
- Remove waveform mutex usage in WOverview variants.
- Use the track's waveform pointer to atomically swap the waveform
  rather than mutating the waveform in place.
- Remove unused code.
