### PR TITLE
Put audio device check last in the startup flow.

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -341,30 +341,6 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
 
     initializeKeyboard();
 
-    // Try open player device If that fails, the preference panel is opened.
-    int setupDevices = m_pSoundManager->setupDevices();
-    unsigned int numDevices = m_pSoundManager->getConfig().getOutputs().count();
-    // test for at least one out device, if none, display another dlg that
-    // says "mixxx will barely work with no outs"
-    while (setupDevices != OK || numDevices == 0) {
-        // Exit when we press the Exit button in the noSoundDlg dialog
-        // only call it if setupDevices != OK
-        if (setupDevices != OK) {
-            if (noSoundDlg() != 0) {
-                exit(0);
-            }
-        } else if (numDevices == 0) {
-            bool continueClicked = false;
-            int noOutput = noOutputDlg(&continueClicked);
-            if (continueClicked) break;
-            if (noOutput != 0) {
-                exit(0);
-            }
-        }
-        setupDevices = m_pSoundManager->setupDevices();
-        numDevices = m_pSoundManager->getConfig().getOutputs().count();
-    }
-
     // Load tracks in args.qlMusicFiles (command line arguments) into player
     // 1 and 2:
     const QList<QString>& musicFiles = args.getMusicFiles();
@@ -458,6 +434,29 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
     }
     slotNumDecksChanged(m_pNumDecks->get());
 
+    // Try open player device If that fails, the preference panel is opened.
+    int setupDevices = m_pSoundManager->setupDevices();
+    unsigned int numDevices = m_pSoundManager->getConfig().getOutputs().count();
+    // test for at least one out device, if none, display another dlg that
+    // says "mixxx will barely work with no outs"
+    while (setupDevices != OK || numDevices == 0) {
+        // Exit when we press the Exit button in the noSoundDlg dialog
+        // only call it if setupDevices != OK
+        if (setupDevices != OK) {
+            if (noSoundDlg() != 0) {
+                exit(0);
+            }
+        } else if (numDevices == 0) {
+            bool continueClicked = false;
+            int noOutput = noOutputDlg(&continueClicked);
+            if (continueClicked) break;
+            if (noOutput != 0) {
+                exit(0);
+            }
+        }
+        setupDevices = m_pSoundManager->setupDevices();
+        numDevices = m_pSoundManager->getConfig().getOutputs().count();
+    }
 }
 
 MixxxMainWindow::~MixxxMainWindow() {

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -340,17 +340,6 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
     m_pPrefDlg->setHidden(true);
 
     initializeKeyboard();
-
-    // Load tracks in args.qlMusicFiles (command line arguments) into player
-    // 1 and 2:
-    const QList<QString>& musicFiles = args.getMusicFiles();
-    for (int i = 0; i < (int)m_pPlayerManager->numDecks()
-            && i < musicFiles.count(); ++i) {
-        if (SoundSourceProxy::isFilenameSupported(musicFiles.at(i))) {
-            m_pPlayerManager->slotLoadToDeck(musicFiles.at(i), i+1);
-        }
-    }
-
     initActions();
     initMenuBar();
 
@@ -456,6 +445,16 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
         }
         setupDevices = m_pSoundManager->setupDevices();
         numDevices = m_pSoundManager->getConfig().getOutputs().count();
+    }
+
+    // Load tracks in args.qlMusicFiles (command line arguments) into player
+    // 1 and 2:
+    const QList<QString>& musicFiles = args.getMusicFiles();
+    for (int i = 0; i < (int)m_pPlayerManager->numDecks()
+            && i < musicFiles.count(); ++i) {
+        if (SoundSourceProxy::isFilenameSupported(musicFiles.at(i))) {
+            m_pPlayerManager->slotLoadToDeck(musicFiles.at(i), i+1);
+        }
     }
 }
 


### PR DESCRIPTION
An alternative solution to https://bugs.launchpad.net/mixxx/+bug/1315146.  Make sure startup is complete before checking for lack of audio devices.
