### PR TITLE
Better support for SVG slider handles.

### DIFF
--- a/res/skins/Deere/deck_inner_column.xml
+++ b/res/skins/Deere/deck_inner_column.xml
@@ -54,6 +54,7 @@
         <MinimumSize>40,50</MinimumSize>
         <MaximumSize>40,-1</MaximumSize>
         <SizePolicy>,me</SizePolicy>
+        <Slider>slider-vertical.svg</Slider>
         <Handle>handle-vertical.svg</Handle>
         <Connection>
           <ConfigKey><Variable name="group"/>,rate</ConfigKey>

--- a/res/skins/Deere/deck_mixer_controls_col2.xml
+++ b/res/skins/Deere/deck_mixer_controls_col2.xml
@@ -16,6 +16,7 @@
         <MinimumSize>40,100</MinimumSize>
         <MaximumSize>40,-1</MaximumSize>
         <Handle>handle-vertical.svg</Handle>
+        <Slider>slider-vertical.svg</Slider>
         <Horizontal>false</Horizontal>
         <Connection>
           <ConfigKey><Variable name="group"/>,volume</ConfigKey>

--- a/res/skins/Deere/handle-horizontal.svg
+++ b/res/skins/Deere/handle-horizontal.svg
@@ -1,3 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1">
-  <rect width="10" height="20" style="fill:rgb(255,0,0);stroke-width:1;stroke:rgb(0,0,0)" />
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="100" height="200">
+  <rect x="1" y="2"
+        width="98" height="196"
+        rx="1" ry="1"
+        style="fill:rgb(54,54,54);stroke-width:2px;stroke:rgb(109,109,109)" />
+  <rect x="37" y="4"
+        width="25" height="192"
+        rx="0" ry="0"
+        style="fill:rgb(234,0,0);stroke-width:2px;stroke:rgb(0,0,0)" />
 </svg>

--- a/res/skins/Deere/handle-vertical.svg
+++ b/res/skins/Deere/handle-vertical.svg
@@ -1,3 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1">
-  <rect width="20" height="10" style="fill:rgb(255,0,0);stroke-width:1;stroke:rgb(0,0,0)" />
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="200" height="100">
+  <rect x="2" y="1"
+        width="196" height="98"
+        rx="1" ry="1"
+        style="fill:rgb(54,54,54);stroke-width:2px;stroke:rgb(109,109,109)" />
+  <rect x="4" y="37"
+        width="192" height="25"
+        rx="0" ry="0"
+        style="fill:rgb(234,0,0);stroke-width:2px;stroke:rgb(0,0,0)" />
 </svg>

--- a/res/skins/Deere/mixer.xml
+++ b/res/skins/Deere/mixer.xml
@@ -56,6 +56,7 @@
             <SizePolicy>me,min</SizePolicy>
             <MinimumSize>-1,40</MinimumSize>
             <MaximumSize>-1,40</MaximumSize>
+            <Slider>slider-horizontal.svg</Slider>
             <Handle>handle-horizontal.svg</Handle>
             <Horizontal>true</Horizontal>
             <Connection>

--- a/res/skins/Deere/slider-horizontal.svg
+++ b/res/skins/Deere/slider-horizontal.svg
@@ -1,3 +1,55 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1">
-  <rect width="100" height="20" style="fill:rgb(0,0,255);stroke-width:1;stroke:rgb(0,0,0)" />
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="180" height="40">
+  <rect x="5" y="4"
+        width="170" height="32"
+        rx="3" ry="3"
+        style="fill:rgb(153,153,153);stroke-width:5px;stroke:rgba(237,237,237,0.5)" />
+
+  <!-- marker lines every 5px -->
+
+  <!-- end marker -->
+  <line x1="10" y1="7" x2="10" y2="33" style="stroke:rgb(72,72,72);stroke-width:2px"/>
+
+  <line x1="15" y1="14" x2="15" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="20" y1="14" x2="20" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="25" y1="14" x2="25" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="30" y1="14" x2="30" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="35" y1="14" x2="35" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="40" y1="14" x2="40" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="45" y1="14" x2="45" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+
+  <!-- quarter marker -->
+  <line x1="50" y1="10" x2="50" y2="30" style="stroke:rgb(72,72,72);stroke-width:2px"/>
+
+  <line x1="55" y1="14" x2="55" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="60" y1="14" x2="60" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="65" y1="14" x2="65" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="70" y1="14" x2="70" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="75" y1="14" x2="75" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="80" y1="14" x2="80" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="85" y1="14" x2="85" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+
+  <!-- middle marker -->
+  <line x1="90" y1="12" x2="90" y2="28" style="stroke:rgb(72,72,72);stroke-width:2px"/>
+
+  <line x1="95" y1="14" x2="95" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="100" y1="14" x2="100" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="105" y1="14" x2="105" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="110" y1="14" x2="110" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="115" y1="14" x2="115" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="120" y1="14" x2="120" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="125" y1="14" x2="125" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+
+  <!-- quarter marker -->
+  <line x1="130" y1="10" x2="130" y2="30" style="stroke:rgb(72,72,72);stroke-width:2px"/>
+
+  <line x1="135" y1="14" x2="135" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="140" y1="14" x2="140" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="145" y1="14" x2="145" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="150" y1="14" x2="150" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="155" y1="14" x2="155" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="160" y1="14" x2="160" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line x1="165" y1="14" x2="165" y2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+
+  <!-- end marker -->
+  <line x1="170" y1="7" x2="170" y2="33" style="stroke:rgb(72,72,72);stroke-width:2px"/>
 </svg>

--- a/res/skins/Deere/slider-vertical.svg
+++ b/res/skins/Deere/slider-vertical.svg
@@ -1,3 +1,55 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1">
-  <rect width="20" height="100" style="fill:rgb(0,0,255);stroke-width:1;stroke:rgb(0,0,0)" />
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="40" height="180">
+  <rect x="4" y="5"
+        width="32" height="170"
+        rx="3" ry="3"
+        style="fill:rgb(153,153,153);stroke-width:5px;stroke:rgba(237,237,237,0.5)" />
+
+  <!-- marker lines every 5px -->
+
+  <!-- end marker -->
+  <line y1="10" x1="7" y2="10" x2="33" style="stroke:rgb(72,72,72);stroke-width:2px"/>
+
+  <line y1="15" x1="14" y2="15" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="20" x1="14" y2="20" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="25" x1="14" y2="25" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="30" x1="14" y2="30" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="35" x1="14" y2="35" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="40" x1="14" y2="40" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="45" x1="14" y2="45" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+
+  <!-- quarter marker -->
+  <line y1="50" x1="10" y2="50" x2="30" style="stroke:rgb(72,72,72);stroke-width:2px"/>
+
+  <line y1="55" x1="14" y2="55" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="60" x1="14" y2="60" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="65" x1="14" y2="65" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="70" x1="14" y2="70" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="75" x1="14" y2="75" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="80" x1="14" y2="80" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="85" x1="14" y2="85" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+
+  <!-- middle marker -->
+  <line y1="90" x1="12" y2="90" x2="28" style="stroke:rgb(72,72,72);stroke-width:2px"/>
+
+  <line y1="95" x1="14" y2="95" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="100" x1="14" y2="100" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="105" x1="14" y2="105" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="110" x1="14" y2="110" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="115" x1="14" y2="115" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="120" x1="14" y2="120" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="125" x1="14" y2="125" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+
+  <!-- quarter marker -->
+  <line y1="130" x1="10" y2="130" x2="30" style="stroke:rgb(72,72,72);stroke-width:2px"/>
+
+  <line y1="135" x1="14" y2="135" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="140" x1="14" y2="140" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="145" x1="14" y2="145" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="150" x1="14" y2="150" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="155" x1="14" y2="155" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="160" x1="14" y2="160" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+  <line y1="165" x1="14" y2="165" x2="26" style="stroke:rgb(120,120,120);stroke-width:1px"/>
+
+  <!-- end marker -->
+  <line y1="170" x1="7" y2="170" x2="33" style="stroke:rgb(72,72,72);stroke-width:2px"/>
 </svg>

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -66,9 +66,9 @@ class WSliderComposed : public WWidget  {
     // True if right mouse button is pressed.
     bool m_bRightButtonPressed;
     // Internal storage of slider position in pixels
-    int m_iPos, m_iStartHandlePos, m_iStartMousePos;
+    double m_dPos, m_dStartHandlePos, m_dStartMousePos;
     // Length of handle in pixels
-    int m_iHandleLength;
+    double m_dHandleLength;
     // True if it's a horizontal slider
     bool m_bHorizontal;
     // Is true if events is emitted while the slider is dragged


### PR DESCRIPTION
- Scale WSliderComposed (maintaining aspect ratio) handle to the width or height of the widget.
- Update Deere slider handles to look more like classic Deere -- still
  missing the dropshadow.

Raster handles are usually custom-built to be the same width/height as
the slider so this should not affect most existing skins.
