### PR TITLE
Reset column configuration when database changes.  

### DIFF
--- a/res/schema.xml
+++ b/res/schema.xml
@@ -291,8 +291,6 @@ METADATA
     </description>
     <sql>
       ALTER TABLE library ADD COLUMN composer varchar(64) DEFAULT "";
-
-      DELETE FROM settings WHERE name like "%header_state";
     </sql>
   </revision>
   <revision version="15" min_compatible="3">
@@ -338,8 +336,6 @@ METADATA
       ALTER TABLE Library ADD COLUMN keys BLOB;
       ALTER TABLE Library ADD COLUMN keys_version TEXT;
       ALTER TABLE Library ADD COLUMN keys_sub_version TEXT;
-
-      DELETE FROM settings WHERE name like "%header_state";
     </sql>
   </revision>
   <revision version="19" min_compatible="3">
@@ -366,8 +362,6 @@ METADATA
     <sql>
       ALTER TABLE Library ADD COLUMN grouping TEXT DEFAULT "";
       ALTER TABLE Library ADD COLUMN album_artist TEXT DEFAULT "";
-
-      DELETE FROM settings WHERE name like "%header_state";
     </sql>
   </revision>
   <revision version="22" min_compatible="3">

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -291,6 +291,12 @@ METADATA
     </description>
     <sql>
       ALTER TABLE library ADD COLUMN composer varchar(64) DEFAULT "";
+
+      DELETE FROM settings WHERE name="mixxx.db.model.library.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.playlist.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.crate.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.prepare.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.missing.header_state";
     </sql>
   </revision>
   <revision version="15" min_compatible="3">
@@ -336,6 +342,12 @@ METADATA
       ALTER TABLE Library ADD COLUMN keys BLOB;
       ALTER TABLE Library ADD COLUMN keys_version TEXT;
       ALTER TABLE Library ADD COLUMN keys_sub_version TEXT;
+
+      DELETE FROM settings WHERE name="mixxx.db.model.library.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.playlist.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.crate.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.prepare.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.missing.header_state";
     </sql>
   </revision>
   <revision version="19" min_compatible="3">
@@ -362,6 +374,12 @@ METADATA
     <sql>
       ALTER TABLE Library ADD COLUMN grouping TEXT DEFAULT "";
       ALTER TABLE Library ADD COLUMN album_artist TEXT DEFAULT "";
+
+      DELETE FROM settings WHERE name="mixxx.db.model.library.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.playlist.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.crate.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.prepare.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.missing.header_state";
     </sql>
   </revision>
   <revision version="22" min_compatible="3">
@@ -393,6 +411,16 @@ METADATA
       ALTER TABLE library ADD COLUMN coverart_type INTEGER DEFAULT 0;
       ALTER TABLE library ADD COLUMN coverart_location TEXT DEFAULT "";
       ALTER TABLE library ADD COLUMN coverart_hash INTEGER DEFAULT 0;
+
+      <!-- Every time a visible column is added to the library, we have to
+      reset the column headers because they will just be broken.  In the future
+      we hope to develop a way of saving as much column data as possible to make
+      upgrading easier. -->
+      DELETE FROM settings WHERE name="mixxx.db.model.library.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.playlist.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.crate.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.prepare.header_state";
+      DELETE FROM settings WHERE name="mixxx.db.model.missing.header_state";
     </sql>
   </revision>
 </schema>

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -393,12 +393,6 @@ METADATA
       ALTER TABLE library ADD COLUMN coverart_type INTEGER DEFAULT 0;
       ALTER TABLE library ADD COLUMN coverart_location TEXT DEFAULT "";
       ALTER TABLE library ADD COLUMN coverart_hash INTEGER DEFAULT 0;
-
-      <!-- Every time a visible column is added to the library, we have to
-      reset the column headers because they will just be broken.  In the future
-      we hope to develop a way of saving as much column data as possible to make
-      upgrading easier. -->
-      DELETE FROM settings WHERE name like "%header_state";
     </sql>
   </revision>
 </schema>

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -292,11 +292,7 @@ METADATA
     <sql>
       ALTER TABLE library ADD COLUMN composer varchar(64) DEFAULT "";
 
-      DELETE FROM settings WHERE name="mixxx.db.model.library.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.playlist.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.crate.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.prepare.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.missing.header_state";
+      DELETE FROM settings WHERE name like "%header_state";
     </sql>
   </revision>
   <revision version="15" min_compatible="3">
@@ -343,11 +339,7 @@ METADATA
       ALTER TABLE Library ADD COLUMN keys_version TEXT;
       ALTER TABLE Library ADD COLUMN keys_sub_version TEXT;
 
-      DELETE FROM settings WHERE name="mixxx.db.model.library.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.playlist.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.crate.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.prepare.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.missing.header_state";
+      DELETE FROM settings WHERE name like "%header_state";
     </sql>
   </revision>
   <revision version="19" min_compatible="3">
@@ -375,11 +367,7 @@ METADATA
       ALTER TABLE Library ADD COLUMN grouping TEXT DEFAULT "";
       ALTER TABLE Library ADD COLUMN album_artist TEXT DEFAULT "";
 
-      DELETE FROM settings WHERE name="mixxx.db.model.library.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.playlist.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.crate.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.prepare.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.missing.header_state";
+      DELETE FROM settings WHERE name like "%header_state";
     </sql>
   </revision>
   <revision version="22" min_compatible="3">
@@ -416,11 +404,7 @@ METADATA
       reset the column headers because they will just be broken.  In the future
       we hope to develop a way of saving as much column data as possible to make
       upgrading easier. -->
-      DELETE FROM settings WHERE name="mixxx.db.model.library.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.playlist.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.crate.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.prepare.header_state";
-      DELETE FROM settings WHERE name="mixxx.db.model.missing.header_state";
+      DELETE FROM settings WHERE name like "%header_state";
     </sql>
   </revision>
 </schema>

--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -375,9 +375,3 @@ bool BansheePlaylistModel::isColumnInternal(int column) {
     Q_UNUSED(column);
     return false;
 }
-
-// if no header state exists, we may hide some columns so that the user can reactivate them
-bool BansheePlaylistModel::isColumnHiddenByDefault(int column) {
-    Q_UNUSED(column);
-    return false;
-}

--- a/src/library/banshee/bansheeplaylistmodel.h
+++ b/src/library/banshee/bansheeplaylistmodel.h
@@ -22,7 +22,6 @@ class BansheePlaylistModel : public BaseSqlTableModel {
     virtual TrackPointer getTrack(const QModelIndex& index) const;
     virtual QString getTrackLocation(const QModelIndex& index) const;
     virtual bool isColumnInternal(int column);
-    virtual bool isColumnHiddenByDefault(int column);
 
     virtual Qt::ItemFlags flags(const QModelIndex &index) const;
     TrackModel::CapabilitiesFlags getCapabilities() const;

--- a/src/library/baseexternalplaylistmodel.cpp
+++ b/src/library/baseexternalplaylistmodel.cpp
@@ -140,11 +140,6 @@ void BaseExternalPlaylistModel::setPlaylist(QString playlist_path) {
     setSearch("");
 }
 
-bool BaseExternalPlaylistModel::isColumnHiddenByDefault(int column) {
-    Q_UNUSED(column);
-    return false;
-}
-
 TrackModel::CapabilitiesFlags BaseExternalPlaylistModel::getCapabilities() const {
     // See src/library/trackmodel.h for the list of TRACKMODELCAPS
     return TRACKMODELCAPS_NONE

--- a/src/library/baseexternalplaylistmodel.h
+++ b/src/library/baseexternalplaylistmodel.h
@@ -24,7 +24,6 @@ class BaseExternalPlaylistModel : public BaseSqlTableModel {
 
     virtual TrackPointer getTrack(const QModelIndex& index) const;
     virtual bool isColumnInternal(int column);
-    virtual bool isColumnHiddenByDefault(int column);
     Qt::ItemFlags flags(const QModelIndex &index) const;
     void setPlaylist(QString path_name);
     virtual TrackModel::CapabilitiesFlags getCapabilities() const;

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -79,11 +79,6 @@ Qt::ItemFlags BaseExternalTrackModel::flags(const QModelIndex &index) const {
     return readOnlyFlags(index);
 }
 
-bool BaseExternalTrackModel::isColumnHiddenByDefault(int column) {
-    Q_UNUSED(column);
-    return false;
-}
-
 TrackModel::CapabilitiesFlags BaseExternalTrackModel::getCapabilities() const {
     // See src/library/trackmodel.h for the list of TRACKMODELCAPS
     return TRACKMODELCAPS_NONE

--- a/src/library/baseexternaltrackmodel.h
+++ b/src/library/baseexternaltrackmodel.h
@@ -24,7 +24,6 @@ class BaseExternalTrackModel : public BaseSqlTableModel {
     virtual TrackModel::CapabilitiesFlags getCapabilities() const;
     TrackPointer getTrack(const QModelIndex& index) const;
     virtual bool isColumnInternal(int column);
-    virtual bool isColumnHiddenByDefault(int column);
     Qt::ItemFlags flags(const QModelIndex &index) const;
 
   private:

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -46,54 +46,104 @@ BaseSqlTableModel::~BaseSqlTableModel() {
 void BaseSqlTableModel::initHeaderData() {
     // Set the column heading labels, rename them for translations and have
     // proper capitalization
+
+    // TODO(owilliams): Clean this up to make it readable.
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TIMESPLAYED),
                   Qt::Horizontal, tr("Played"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TIMESPLAYED),
+                  Qt::Horizontal, 50, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ARTIST),
                   Qt::Horizontal, tr("Artist"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ARTIST),
+                  Qt::Horizontal, 200, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TITLE),
                   Qt::Horizontal, tr("Title"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TITLE),
+                  Qt::Horizontal, 300, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUM),
                   Qt::Horizontal, tr("Album"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUM),
+                  Qt::Horizontal, 200, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUMARTIST),
                   Qt::Horizontal, tr("Album Artist"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUMARTIST),
+                  Qt::Horizontal, 100, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_GENRE),
                   Qt::Horizontal, tr("Genre"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_GENRE),
+                  Qt::Horizontal, 100, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMPOSER),
                   Qt::Horizontal, tr("Composer"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMPOSER),
+                  Qt::Horizontal, 50, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_GROUPING),
                   Qt::Horizontal, tr("Grouping"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_GROUPING),
+                  Qt::Horizontal, 10, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_YEAR),
                   Qt::Horizontal, tr("Year"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_YEAR),
+                  Qt::Horizontal, 40, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_FILETYPE),
                   Qt::Horizontal, tr("Type"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_FILETYPE),
+                  Qt::Horizontal, 50, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_LOCATION),
                   Qt::Horizontal, tr("Location"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_LOCATION),
+                  Qt::Horizontal, 100, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMMENT),
                   Qt::Horizontal, tr("Comment"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMMENT),
+                  Qt::Horizontal, 250, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DURATION),
                   Qt::Horizontal, tr("Duration"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DURATION),
+                  Qt::Horizontal, 70, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_RATING),
                   Qt::Horizontal, tr("Rating"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_RATING),
+                  Qt::Horizontal, 100, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BITRATE),
                   Qt::Horizontal, tr("Bitrate"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BITRATE),
+                  Qt::Horizontal, 50, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM),
                   Qt::Horizontal, tr("BPM"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM),
+                  Qt::Horizontal, 70, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER),
                   Qt::Horizontal, tr("Track #"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER),
+                  Qt::Horizontal, 10, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DATETIMEADDED),
                   Qt::Horizontal, tr("Date Added"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DATETIMEADDED),
+                  Qt::Horizontal, 90, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION),
                   Qt::Horizontal, tr("#"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION),
+                  Qt::Horizontal, 10, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED),
                   Qt::Horizontal, tr("Timestamp"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED),
+                  Qt::Horizontal, 80, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY),
                   Qt::Horizontal, tr("Key"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY),
+                  Qt::Horizontal, 50, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK),
                   Qt::Horizontal, tr("BPM Lock"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK),
+                  Qt::Horizontal, 10, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW),
                   Qt::Horizontal, tr("Preview"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW),
+                  Qt::Horizontal, 50, TrackModel::kHeaderWidthRole);
     setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART),
                   Qt::Horizontal, tr("Cover Art"));
+    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART),
+                  Qt::Horizontal, 90, TrackModel::kHeaderWidthRole);
 }
 
 QSqlDatabase BaseSqlTableModel::database() const {
@@ -133,6 +183,12 @@ QVariant BaseSqlTableModel::headerData(int section, Qt::Orientation orientation,
             headerValue = QVariant(section).toString();
         }
         return headerValue;
+    } else if (role == TrackModel::kHeaderWidthRole && orientation == Qt::Horizontal) {
+        QVariant widthValue = m_headerInfo.value(section).value(role);
+        if (!widthValue.isValid()) {
+            return 0;
+        }
+        return widthValue;
     }
     return QAbstractTableModel::headerData(section, orientation, role);
 }

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -48,106 +48,66 @@ void BaseSqlTableModel::initHeaderData() {
     // proper capitalization
 
     // TODO(owilliams): Clean this up to make it readable.
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TIMESPLAYED),
-                  Qt::Horizontal, tr("Played"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TIMESPLAYED),
-                  Qt::Horizontal, 50, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ARTIST),
-                  Qt::Horizontal, tr("Artist"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ARTIST),
-                  Qt::Horizontal, 200, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TITLE),
-                  Qt::Horizontal, tr("Title"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TITLE),
-                  Qt::Horizontal, 300, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUM),
-                  Qt::Horizontal, tr("Album"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUM),
-                  Qt::Horizontal, 200, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUMARTIST),
-                  Qt::Horizontal, tr("Album Artist"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUMARTIST),
-                  Qt::Horizontal, 100, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_GENRE),
-                  Qt::Horizontal, tr("Genre"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_GENRE),
-                  Qt::Horizontal, 100, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMPOSER),
-                  Qt::Horizontal, tr("Composer"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMPOSER),
-                  Qt::Horizontal, 50, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_GROUPING),
-                  Qt::Horizontal, tr("Grouping"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_GROUPING),
-                  Qt::Horizontal, 10, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_YEAR),
-                  Qt::Horizontal, tr("Year"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_YEAR),
-                  Qt::Horizontal, 40, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_FILETYPE),
-                  Qt::Horizontal, tr("Type"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_FILETYPE),
-                  Qt::Horizontal, 50, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_LOCATION),
-                  Qt::Horizontal, tr("Location"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_LOCATION),
-                  Qt::Horizontal, 100, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMMENT),
-                  Qt::Horizontal, tr("Comment"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMMENT),
-                  Qt::Horizontal, 250, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DURATION),
-                  Qt::Horizontal, tr("Duration"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DURATION),
-                  Qt::Horizontal, 70, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_RATING),
-                  Qt::Horizontal, tr("Rating"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_RATING),
-                  Qt::Horizontal, 100, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BITRATE),
-                  Qt::Horizontal, tr("Bitrate"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BITRATE),
-                  Qt::Horizontal, 50, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM),
-                  Qt::Horizontal, tr("BPM"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM),
-                  Qt::Horizontal, 70, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER),
-                  Qt::Horizontal, tr("Track #"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER),
-                  Qt::Horizontal, 10, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DATETIMEADDED),
-                  Qt::Horizontal, tr("Date Added"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DATETIMEADDED),
-                  Qt::Horizontal, 90, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION),
-                  Qt::Horizontal, tr("#"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION),
-                  Qt::Horizontal, 10, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED),
-                  Qt::Horizontal, tr("Timestamp"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED),
-                  Qt::Horizontal, 80, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY),
-                  Qt::Horizontal, tr("Key"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY),
-                  Qt::Horizontal, 50, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK),
-                  Qt::Horizontal, tr("BPM Lock"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK),
-                  Qt::Horizontal, 10, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW),
-                  Qt::Horizontal, tr("Preview"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW),
-                  Qt::Horizontal, 50, TrackModel::kHeaderWidthRole);
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART),
-                  Qt::Horizontal, tr("Cover Art"));
-    setHeaderData(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART),
-                  Qt::Horizontal, 90, TrackModel::kHeaderWidthRole);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_TIMESPLAYED,
+                        tr("Played"), 50);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_ARTIST,
+                        tr("Artist"), 200);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_TITLE,
+                        tr("Title"), 300);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_ALBUM,
+                        tr("Album"), 200);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_ALBUMARTIST,
+                        tr("Album Artist"), 100);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_GENRE,
+                        tr("Genre"), 100);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_COMPOSER,
+                        tr("Composer"), 50);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_GROUPING,
+                        tr("Grouping"), 10);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_YEAR,
+                        tr("Year"), 40);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_FILETYPE,
+                        tr("Type"), 50);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_LOCATION,
+                        tr("Location"), 100);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_COMMENT,
+                        tr("Comment"), 250);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_DURATION,
+                        tr("Duration"), 70);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_RATING,
+                        tr("Rating"), 100);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_BITRATE,
+                        tr("Bitrate"), 50);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_BPM,
+                        tr("BPM"), 70);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER,
+                        tr("Track #"), 10);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_DATETIMEADDED,
+                        tr("Date Added"), 90);
+    setHeaderProperties(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION,
+                        tr("#"), 30);
+    setHeaderProperties(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED,
+                        tr("Timestamp"), 80);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_KEY,
+                        tr("Key"), 50);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK,
+                        tr("BPM Lock"), 10);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW,
+                        tr("Preview"), 50);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_COVERART,
+                        tr("Cover Art"), 90);
 }
 
 QSqlDatabase BaseSqlTableModel::database() const {
     return m_database;
+}
+
+void BaseSqlTableModel::setHeaderProperties(
+        ColumnCache::Column column, QString title, int defaultWidth) {
+    setHeaderData(fieldIndex(column), Qt::Horizontal, title,
+                  Qt::DisplayRole);
+    setHeaderData(fieldIndex(column), Qt::Horizontal, defaultWidth,
+                  TrackModel::kHeaderWidthRole);
 }
 
 bool BaseSqlTableModel::setHeaderData(int section, Qt::Orientation orientation,
@@ -191,6 +151,19 @@ QVariant BaseSqlTableModel::headerData(int section, Qt::Orientation orientation,
         return widthValue;
     }
     return QAbstractTableModel::headerData(section, orientation, role);
+}
+
+
+bool BaseSqlTableModel::isColumnHiddenByDefault(int column) {
+    if ((column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMPOSER)) ||
+            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER)) ||
+            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_YEAR)) ||
+            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_GROUPING)) ||
+            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_LOCATION)) ||
+            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUMARTIST))) {
+        return true;
+    }
+    return false;
 }
 
 QString BaseSqlTableModel::orderByClause() const {

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -100,7 +100,9 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     void refreshCell(int row, int column);
 
   private:
-    // A simple helper function for initializing header defaults and data.
+    // A simple helper function for initializing header title and width.  Note
+    // that the ideal width of a column is based on the width of its data,
+    // not the title string itself.
     void setHeaderProperties(ColumnCache::Column column, QString title, int defaultWidth);
     inline void setTrackValueForColumn(TrackPointer pTrack, int column, QVariant value);
     QVariant getBaseValue(const QModelIndex& index, int role = Qt::DisplayRole) const;

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -68,7 +68,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole);
     int columnCount(const QModelIndex& parent = QModelIndex()) const;
     bool setHeaderData(int section, Qt::Orientation orientation,
-                       const QVariant &value, int role = Qt::EditRole);
+                       const QVariant &value, int role = Qt::DisplayRole);
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role=Qt::DisplayRole) const;
     virtual QMimeData* mimeData(const QModelIndexList &indexes) const;

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -29,7 +29,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     //  m_database, m_pTrackCollection, m_trackDAO
 
     virtual bool isColumnInternal(int column) = 0;
-    virtual bool isColumnHiddenByDefault(int column) = 0;
+    virtual bool isColumnHiddenByDefault(int column);
     virtual TrackModel::CapabilitiesFlags getCapabilities() const = 0;
 
     // functions that can be implemented
@@ -100,6 +100,8 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     void refreshCell(int row, int column);
 
   private:
+    // A simple helper function for initializing header defaults and data.
+    void setHeaderProperties(ColumnCache::Column column, QString title, int defaultWidth);
     inline void setTrackValueForColumn(TrackPointer pTrack, int column, QVariant value);
     QVariant getBaseValue(const QModelIndex& index, int role = Qt::DisplayRole) const;
     // Set the columns used for searching. Names must correspond to the column

--- a/src/library/cratetablemodel.cpp
+++ b/src/library/cratetablemodel.cpp
@@ -158,11 +158,6 @@ bool CrateTableModel::isColumnInternal(int column) {
     return false;
 }
 
-bool CrateTableModel::isColumnHiddenByDefault(int column) {
-    Q_UNUSED(column);
-    return false;
-}
-
 TrackModel::CapabilitiesFlags CrateTableModel::getCapabilities() const {
     CapabilitiesFlags caps =  TRACKMODELCAPS_NONE
             | TRACKMODELCAPS_RECEIVEDROPS

--- a/src/library/cratetablemodel.h
+++ b/src/library/cratetablemodel.h
@@ -20,7 +20,6 @@ class CrateTableModel : public BaseSqlTableModel {
 
     // From TrackModel
     bool isColumnInternal(int column);
-    bool isColumnHiddenByDefault(int column);
     void removeTracks(const QModelIndexList& indices);
     bool addTrack(const QModelIndex &index, QString location);
     // Returns the number of unsuccessful track additions

--- a/src/library/hiddentablemodel.cpp
+++ b/src/library/hiddentablemodel.cpp
@@ -86,10 +86,6 @@ bool HiddenTableModel::isColumnInternal(int column) {
     }
     return false;
 }
-bool HiddenTableModel::isColumnHiddenByDefault(int column) {
-    Q_UNUSED(column);
-    return false;
-}
 
 // Override flags from BaseSqlModel since we don't want edit this model
 Qt::ItemFlags HiddenTableModel::flags(const QModelIndex &index) const {

--- a/src/library/hiddentablemodel.h
+++ b/src/library/hiddentablemodel.h
@@ -11,7 +11,6 @@ class HiddenTableModel : public BaseSqlTableModel {
 
     void setTableModel(int id = -1);
     bool isColumnInternal(int column);
-    bool isColumnHiddenByDefault(int column);
     void purgeTracks(const QModelIndexList& indices);
     void unhideTracks(const QModelIndexList& indices);
     Qt::ItemFlags flags(const QModelIndex &index) const;

--- a/src/library/librarytablemodel.cpp
+++ b/src/library/librarytablemodel.cpp
@@ -87,20 +87,6 @@ bool LibraryTableModel::isColumnInternal(int column) {
     return false;
 }
 
-bool LibraryTableModel::isColumnHiddenByDefault(int column) {
-    // TODO(owilliams): Make these defaults that are inherited by the other
-    // classes.
-    if ((column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMPOSER)) ||
-            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER)) ||
-            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_YEAR)) ||
-            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_GROUPING)) ||
-            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_LOCATION)) ||
-            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUMARTIST))) {
-        return true;
-    }
-    return false;
-}
-
 TrackModel::CapabilitiesFlags LibraryTableModel::getCapabilities() const {
     return TRACKMODELCAPS_NONE
             | TRACKMODELCAPS_RECEIVEDROPS

--- a/src/library/librarytablemodel.cpp
+++ b/src/library/librarytablemodel.cpp
@@ -88,7 +88,16 @@ bool LibraryTableModel::isColumnInternal(int column) {
 }
 
 bool LibraryTableModel::isColumnHiddenByDefault(int column) {
-    Q_UNUSED(column);
+    // TODO(owilliams): Make these defaults that are inherited by the other
+    // classes.
+    if ((column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMPOSER)) ||
+            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER)) ||
+            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_YEAR)) ||
+            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_GROUPING)) ||
+            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_LOCATION)) ||
+            (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUMARTIST))) {
+        return true;
+    }
     return false;
 }
 

--- a/src/library/librarytablemodel.h
+++ b/src/library/librarytablemodel.h
@@ -11,7 +11,6 @@ class LibraryTableModel : public BaseSqlTableModel {
     virtual ~LibraryTableModel();
     void setTableModel(int id =-1);
     bool isColumnInternal(int column);
-    bool isColumnHiddenByDefault(int column);
     // Takes a list of locations and add the tracks to the library. Returns the
     // number of successful additions.
     int addTracks(const QModelIndex& index, const QList<QString>& locations);

--- a/src/library/missingtablemodel.cpp
+++ b/src/library/missingtablemodel.cpp
@@ -84,11 +84,6 @@ bool MissingTableModel::isColumnInternal(int column) {
     return false;
 }
 
-bool MissingTableModel::isColumnHiddenByDefault(int column) {
-    Q_UNUSED(column);
-    return false;
-}
-
 // Override flags from BaseSqlModel since we don't want edit this model
 Qt::ItemFlags MissingTableModel::flags(const QModelIndex &index) const {
     return readOnlyFlags(index);

--- a/src/library/missingtablemodel.h
+++ b/src/library/missingtablemodel.h
@@ -19,7 +19,6 @@ class MissingTableModel : public BaseSqlTableModel {
 
     void setTableModel(int id = -1);
     bool isColumnInternal(int column);
-    bool isColumnHiddenByDefault(int column);
     void purgeTracks(const QModelIndexList& indices);
     Qt::ItemFlags flags(const QModelIndex &index) const;
     TrackModel::CapabilitiesFlags getCapabilities() const;

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -33,24 +33,24 @@ MixxxLibraryFeature::MixxxLibraryFeature(QObject* parent,
             << "library." + LIBRARYTABLE_PLAYED
             << "library." + LIBRARYTABLE_TIMESPLAYED
             //has to be up here otherwise Played and TimesPlayed are not show
+            << "library." + LIBRARYTABLE_ALBUMARTIST
+            << "library." + LIBRARYTABLE_ALBUM
             << "library." + LIBRARYTABLE_ARTIST
             << "library." + LIBRARYTABLE_TITLE
-            << "library." + LIBRARYTABLE_ALBUM
-            << "library." + LIBRARYTABLE_ALBUMARTIST
             << "library." + LIBRARYTABLE_YEAR
-            << "library." + LIBRARYTABLE_DURATION
             << "library." + LIBRARYTABLE_RATING
             << "library." + LIBRARYTABLE_GENRE
             << "library." + LIBRARYTABLE_COMPOSER
             << "library." + LIBRARYTABLE_GROUPING
-            << "library." + LIBRARYTABLE_FILETYPE
             << "library." + LIBRARYTABLE_TRACKNUMBER
             << "library." + LIBRARYTABLE_KEY
             << "library." + LIBRARYTABLE_KEY_ID
-            << "library." + LIBRARYTABLE_DATETIMEADDED
             << "library." + LIBRARYTABLE_BPM
             << "library." + LIBRARYTABLE_BPM_LOCK
+            << "library." + LIBRARYTABLE_DURATION
             << "library." + LIBRARYTABLE_BITRATE
+            << "library." + LIBRARYTABLE_FILETYPE
+            << "library." + LIBRARYTABLE_DATETIMEADDED
             << "track_locations.location"
             << "track_locations.fs_deleted"
             << "library." + LIBRARYTABLE_COMMENT

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -226,8 +226,10 @@ bool PlaylistTableModel::isColumnInternal(int column) {
 bool PlaylistTableModel::isColumnHiddenByDefault(int column) {
     if (column == fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED)) {
         return true;
+    } else if (column == fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION)) {
+        return false;
     }
-    return false;
+    return BaseSqlTableModel::isColumnHiddenByDefault(column);
 }
 
 TrackModel::CapabilitiesFlags PlaylistTableModel::getCapabilities() const {

--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -64,7 +64,6 @@ bool ProxyTrackModel::isColumnHiddenByDefault(int column) {
     return m_pTrackModel->isColumnHiddenByDefault(column);
 }
 
-
 void ProxyTrackModel::removeTracks(const QModelIndexList& indices) {
     QModelIndexList translatedList;
     foreach (QModelIndex index, indices) {

--- a/src/library/schemamanager.cpp
+++ b/src/library/schemamanager.cpp
@@ -136,6 +136,22 @@ int SchemaManager::upgradeToSchemaVersion(const QString& schemaFilename,
         }
     }
 
+    // Every time a visible column is added to the library, we have to
+    // reset the column headers because they will just be broken.  In the future
+    // we hope to develop a way of saving as much column data as possible to make
+    // upgrading easier.  Not all upgrades change the library schema, but
+    // it's easier to just do it every time.
+    if (success == 0) {
+        QSqlQuery query(db);
+        query.prepare("DELETE FROM settings WHERE name LIKE \"%header_state\";");
+
+        if (!query.exec()) {
+            success = -1;
+            qDebug() << "Deleting header_state settings failed"
+                     << query.lastError();
+        }
+    }
+
     return success;
 }
 

--- a/src/library/schemamanager.cpp
+++ b/src/library/schemamanager.cpp
@@ -147,7 +147,7 @@ int SchemaManager::upgradeToSchemaVersion(const QString& schemaFilename,
 
         if (!query.exec()) {
             success = -1;
-            qDebug() << "Deleting header_state settings failed"
+            LOG_FAILED_QUERY(query) << "Deleting header_state settings failed"
                      << query.lastError();
         }
     }

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -13,6 +13,8 @@
     display track lists. */
 class TrackModel {
   public:
+    static const int kHeaderWidthRole = Qt::UserRole + 0;
+
     TrackModel(QSqlDatabase db,
                const char* settingsNamespace)
             : m_db(db),

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -30,7 +30,7 @@ bool TraktorTrackModel::isColumnHiddenByDefault(int column) {
     if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BITRATE)) {
         return true;
     }
-    return false;
+    return BaseSqlTableModel::isColumnHiddenByDefault(column);
 }
 
 TraktorPlaylistModel::TraktorPlaylistModel(QObject* parent,
@@ -47,7 +47,7 @@ bool TraktorPlaylistModel::isColumnHiddenByDefault(int column) {
     if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BITRATE)) {
         return true;
     }
-    return false;
+    return BaseSqlTableModel::isColumnHiddenByDefault(column);
 }
 
 TraktorFeature::TraktorFeature(QObject* parent, TrackCollection* pTrackCollection)

--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -130,13 +130,25 @@ void WTrackTableViewHeader::restoreHeaderState() {
     }
 
     QString headerStateString = track_model->getModelSetting("header_state");
-    if (!headerStateString.isNull()) {
+    if (headerStateString.isNull()) {
+        loadDefaultHeaderState();
+    } else {
         // Load the previous header state (stored as a Base 64 string). Decode
         // it and restore it.
         //qDebug() << "Restoring header state" << headerStateString;
         QByteArray headerState = headerStateString.toAscii();
         headerState = QByteArray::fromBase64(headerState);
         restoreState(headerState);
+    }
+}
+
+void WTrackTableViewHeader::loadDefaultHeaderState() {
+    for (int i = 0; i < count(); ++i) {
+        int header_size = model()->headerData(
+                i, orientation(), TrackModel::kHeaderWidthRole).toInt();
+        if (header_size > 0) {
+            resizeSection(i, header_size);
+        }
     }
 }
 

--- a/src/widget/wtracktableviewheader.h
+++ b/src/widget/wtracktableviewheader.h
@@ -25,6 +25,7 @@ class WTrackTableViewHeader : public QHeaderView {
 
     void saveHeaderState();
     void restoreHeaderState();
+    void loadDefaultHeaderState();
      /** returns false if the header state is stored in the database (on first time usgae) **/
     bool hasPersistedHeaderState();
 


### PR DESCRIPTION
This is necessary because the header_state blobs break between versions.

Also set up some much nicer column width defaults so it's not such a shock when a users' settings are blown away
