### PR TITLE
Skin tooltips

### DIFF
--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -24,7 +24,6 @@
 #UILowerHalf {
   background-color: #0f0f0f;
   qproperty-layoutAlignment: 'AlignHCenter | AlignTop';
-  padding-top: 10px;
 }
 
 #HorizBorder {
@@ -606,14 +605,16 @@
   background-color: #0e0e0e;
   border-top: 1px solid #585858;
   /*border-bottom: 1px solid #585858;*/
-  padding: 2px;
-  padding-left: 0px;
+  padding-bottom: 0px;
+  padding-left: 5px;
+  padding-right: 5px;
+  padding-top: 5px;
 }
 
 #SamplerDeck {
-  padding: 0px;
-  margin: 10px;
-  margin-top: 0px;
+  margin-top: 5px;
+  margin-left: 5px;
+  margin-right: 5px;
   border: 1px solid #585858;
   background-color: #1e1e1e;
 }
@@ -742,7 +743,7 @@
 
 #EffectRackContainer {
   background-color: #0e0e0e;
-  padding-bottom:5px;
+  padding-top: 5px;
   /*border-bottom: 10px solid #585858;*/
 }
 
@@ -794,10 +795,10 @@
 /* this is now inline in the pushbutton so we can change styles */
 /*#EffectUnitGroupControlButton {
   font: bold 11px/13px Lucida Grande, Lucida Sans Unicode, Arial, Verdana, sans-serif;
-  color: #e17800;
+  color: #eece33;
   text-transform: none;
   text-align: center;
-  border: 1px solid #e17800;
+  border: 1px solid #eece33;
   margin: 1px;
 }*/
 
@@ -816,7 +817,7 @@
     font: bold 11px/13px Lucida Grande, Lucida Sans Unicode,
           Arial, Verdana, sans-serif;
     color: #0e0e0e;
-    background-color: #e17800;
+    background-color: #eece33;
     text-transform: none;
     text-align: center;
     border: 1px solid #585858;
@@ -839,7 +840,7 @@
           Lucida Sans Unicode, Arial,
           Verdana, sans-serif;
     color: #0e0e0e;
-    background-color: #e17800;
+    background-color: #eece33;
     margin-right: 1px;
 }
 

--- a/res/skins/LateNight/toolbar_full.xml
+++ b/res/skins/LateNight/toolbar_full.xml
@@ -11,6 +11,7 @@
                 <Children>
                     <PushButton>
                         <Size>50f,20f</Size>
+                        <TooltipId>show_library</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>
@@ -38,6 +39,7 @@
                 <Children>
                     <PushButton>
                         <Size>55f,20f</Size>
+                        <TooltipId>show_effects</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>
@@ -65,6 +67,7 @@
                 <Children>
                     <PushButton>
                         <Size>62f,20f</Size>
+                        <TooltipId>show_samplers</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>
@@ -92,6 +95,7 @@
                 <Children>
                     <PushButton>
                         <Size>40f,20f</Size>
+                        <TooltipId>show_vinylcontrol</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>
@@ -128,6 +132,7 @@
                         is the pushed state.  So we have to invert everything so the
                         default is 'don't make the library huge' -->
                         <Size>80f,20f</Size>
+                        <TooltipId>show_big_library</TooltipId>
                         <ObjectName>GuiToggleButtonInverted</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>

--- a/res/skins/LateNight/toolbar_full.xml
+++ b/res/skins/LateNight/toolbar_full.xml
@@ -132,7 +132,7 @@
                         is the pushed state.  So we have to invert everything so the
                         default is 'don't make the library huge' -->
                         <Size>80f,20f</Size>
-                        <TooltipId>show_big_library</TooltipId>
+                        <TooltipId>toggle_expanded_library</TooltipId>
                         <ObjectName>GuiToggleButtonInverted</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>

--- a/res/skins/LateNight/toolbar_med.xml
+++ b/res/skins/LateNight/toolbar_med.xml
@@ -11,6 +11,7 @@
                 <Children>
                     <PushButton>
                         <Size>50f,20f</Size>
+                        <TooltipId>show_library</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>
@@ -38,6 +39,7 @@
                 <Children>
                     <PushButton>
                         <Size>55f,20f</Size>
+                        <TooltipId>show_effects</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>
@@ -65,6 +67,7 @@
                 <Children>
                     <PushButton>
                         <Size>62f,20f</Size>
+                        <TooltipId>show_samplers</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>
@@ -92,6 +95,7 @@
                 <Children>
                     <PushButton>
                         <Size>40f,20f</Size>
+                        <TooltipId>show_vinylcontrol</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>
@@ -128,6 +132,7 @@
                         is the pushed state.  So we have to invert everything so the
                         default is 'don't make the library huge' -->
                         <Size>80f,20f</Size>
+                        <TooltipId>show_big_library</TooltipId>
                         <ObjectName>GuiToggleButtonInverted</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>

--- a/res/skins/LateNight/toolbar_med.xml
+++ b/res/skins/LateNight/toolbar_med.xml
@@ -132,7 +132,7 @@
                         is the pushed state.  So we have to invert everything so the
                         default is 'don't make the library huge' -->
                         <Size>80f,20f</Size>
-                        <TooltipId>show_big_library</TooltipId>
+                        <TooltipId>toggle_expanded_library</TooltipId>
                         <ObjectName>GuiToggleButtonInverted</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>

--- a/res/skins/LateNight/toolbar_small.xml
+++ b/res/skins/LateNight/toolbar_small.xml
@@ -136,7 +136,7 @@
                         is the pushed state.  So we have to invert everything so the
                         default is 'don't make the library huge' -->
                         <Size>80f,20f</Size>
-                        <TooltipId>show_big_library</TooltipId>
+                        <TooltipId>toggle_expanded_library</TooltipId>
                         <ObjectName>GuiToggleButtonInverted</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>

--- a/res/skins/LateNight/toolbar_small.xml
+++ b/res/skins/LateNight/toolbar_small.xml
@@ -1,5 +1,9 @@
 <Template>
     <WidgetGroup>
+        <SizePolicy>me,me</SizePolicy>
+        <Children/>
+    </WidgetGroup>
+    <WidgetGroup>
         <ObjectName>UIButtons</ObjectName>
         <Layout>horizontal</Layout>
         <SizePolicy>e,min</SizePolicy>
@@ -11,6 +15,7 @@
                 <Children>
                     <PushButton>
                         <Size>50f,20f</Size>
+                        <TooltipId>show_library</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>
@@ -38,6 +43,7 @@
                 <Children>
                     <PushButton>
                         <Size>55f,20f</Size>
+                        <TooltipId>show_effects</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>
@@ -49,11 +55,11 @@
                           <Text>EFFECTS</Text>
                         </State>
                         <Connection>
-                          <ConfigKey persist="true">[EffectRack1],show_tab</ConfigKey>
+                          <ConfigKey persist="true">[EffectRack1],show_tab_small</ConfigKey>
                           <ButtonState>LeftButton</ButtonState>
                         </Connection>
                         <Connection>
-                          <ConfigKey persist="true">[EffectRack1],show_tab</ConfigKey>
+                          <ConfigKey persist="true">[EffectRack1],show_tab_small</ConfigKey>
                         </Connection>
                     </PushButton>
                 </Children>
@@ -65,6 +71,7 @@
                 <Children>
                     <PushButton>
                         <Size>62f,20f</Size>
+                        <TooltipId>show_samplers</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>
@@ -76,11 +83,11 @@
                           <Text>SAMPLERS</Text>
                         </State>
                         <Connection>
-                          <ConfigKey persist="true">[Samplers],show_samplers_tab</ConfigKey>
+                          <ConfigKey persist="true">[Samplers],show_samplers_tab_small</ConfigKey>
                           <ButtonState>LeftButton</ButtonState>
                         </Connection>
                         <Connection>
-                          <ConfigKey persist="true">[Samplers],show_samplers_tab</ConfigKey>
+                          <ConfigKey persist="true">[Samplers],show_samplers_tab_small</ConfigKey>
                         </Connection>
                     </PushButton>
                 </Children>
@@ -92,6 +99,7 @@
                 <Children>
                     <PushButton>
                         <Size>40f,20f</Size>
+                        <TooltipId>show_vinylcontrol</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>
@@ -128,6 +136,7 @@
                         is the pushed state.  So we have to invert everything so the
                         default is 'don't make the library huge' -->
                         <Size>80f,20f</Size>
+                        <TooltipId>show_big_library</TooltipId>
                         <ObjectName>GuiToggleButtonInverted</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>

--- a/res/skins/LateNight/waveform_and_mixer.xml
+++ b/res/skins/LateNight/waveform_and_mixer.xml
@@ -16,6 +16,7 @@
                         <Children>
                             <PushButton>
                                 <Size>50f,20f</Size>
+                                <TooltipId>toggle_4decks</TooltipId>
                                 <ObjectName>GuiToggleButton</ObjectName>
                                 <NumberStates>2</NumberStates>
                                 <State>
@@ -43,6 +44,7 @@
                         <Children>
                             <PushButton>
                                 <Size>40f,20f</Size>
+                                <TooltipId>show_mixer</TooltipId>
                                 <ObjectName>GuiToggleButton</ObjectName>
                                 <NumberStates>2</NumberStates>
                                 <State>

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -168,7 +168,7 @@ void Tooltips::addStandardTooltips() {
             << tr("Show Effects Rack")
             << tr("Show or hide the effects rack.");
 
-    add("show_big_library")
+    add("toggle_expanded_library")
             << tr("Toggle Big Library")
             << tr("Makes the library fill the screen.");
 

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -156,6 +156,26 @@ void Tooltips::addStandardTooltips() {
             << tr("Cover Art")
             << tr("Show/hide Cover Art.");
 
+    add("toggle_4decks")
+            << tr("Toggle 4 Decks")
+            << tr("Switches between showing 2 decks and 4 decks.");
+
+    add("show_library")
+            << tr("Show Library")
+            << tr("Show or hide the track library.");
+
+    add("show_effects")
+            << tr("Show Effects Rack")
+            << tr("Show or hide the effects rack.");
+
+    add("show_big_library")
+            << tr("Toggle Big Library")
+            << tr("Makes the library fill the screen.");
+
+    add("show_mixer")
+            << tr("Toggle Mixer")
+            << tr("Show or hide the mixer.");
+
     add("microphone_volume")
             << tr("Microphone Volume")
             << tr("Adjusts the microphone volume.")


### PR DESCRIPTION
I'm not sure if these tooltips are generic enough -- Deere uses small/large widgets to collapse things, whereas LateNight does show/hide. 
