### PR TITLE
Better widget image scaling support.

### DIFF
--- a/res/skins/Deere/deck_inner_column.xml
+++ b/res/skins/Deere/deck_inner_column.xml
@@ -54,8 +54,8 @@
         <MinimumSize>40,50</MinimumSize>
         <MaximumSize>40,-1</MaximumSize>
         <SizePolicy>,me</SizePolicy>
-        <Slider>slider-vertical.svg</Slider>
-        <Handle>handle-vertical.svg</Handle>
+        <Slider scalemode="STRETCH">slider-vertical.svg</Slider>
+        <Handle scalemode="STRETCH_ASPECT">handle-vertical.svg</Handle>
         <Connection>
           <ConfigKey><Variable name="group"/>,rate</ConfigKey>
         </Connection>

--- a/res/skins/Deere/deck_mixer_controls_col2.xml
+++ b/res/skins/Deere/deck_mixer_controls_col2.xml
@@ -15,8 +15,8 @@
         <SizePolicy>min,me</SizePolicy>
         <MinimumSize>40,100</MinimumSize>
         <MaximumSize>40,-1</MaximumSize>
-        <Handle>handle-vertical.svg</Handle>
-        <Slider>slider-vertical.svg</Slider>
+        <Slider scalemode="STRETCH">slider-vertical.svg</Slider>
+        <Handle scalemode="STRETCH_ASPECT">handle-vertical.svg</Handle>
         <Horizontal>false</Horizontal>
         <Connection>
           <ConfigKey><Variable name="group"/>,volume</ConfigKey>

--- a/res/skins/Deere/mixer.xml
+++ b/res/skins/Deere/mixer.xml
@@ -56,8 +56,8 @@
             <SizePolicy>me,min</SizePolicy>
             <MinimumSize>-1,40</MinimumSize>
             <MaximumSize>-1,40</MaximumSize>
-            <Slider>slider-horizontal.svg</Slider>
-            <Handle>handle-horizontal.svg</Handle>
+            <Slider scalemode="STRETCH">slider-horizontal.svg</Slider>
+            <Handle scalemode="STRETCH_ASPECT">handle-horizontal.svg</Handle>
             <Horizontal>true</Horizontal>
             <Connection>
               <ConfigKey>[Master],crossfader</ConfigKey>

--- a/res/skins/LateNight/deck.xml
+++ b/res/skins/LateNight/deck.xml
@@ -322,9 +322,9 @@
 		                        <Size>2me,10f</Size>
 		                        <TooltipId>vinylcontrol_status</TooltipId>
 		                        <NumberPos>3</NumberPos>
-		                        <PathStatusLight sizemode="RESIZE">btn_vinylcontrol_indicator_horizontal1.png</PathStatusLight>
-		                        <PathStatusLight2 sizemode="RESIZE">btn_vinylcontrol_indicator_horizontal2.png</PathStatusLight2>
-		                        <PathStatusLight3 sizemode="RESIZE">btn_vinylcontrol_indicator_horizontal3.png</PathStatusLight3>
+		                        <PathStatusLight scalemode="STRETCH">btn_vinylcontrol_indicator_horizontal1.png</PathStatusLight>
+		                        <PathStatusLight2 scalemode="STRETCH">btn_vinylcontrol_indicator_horizontal2.png</PathStatusLight2>
+		                        <PathStatusLight3 scalemode="STRETCH">btn_vinylcontrol_indicator_horizontal3.png</PathStatusLight3>
 		                        <Connection>
 		                            <ConfigKey>[Channel<Variable name="channum"/>],vinylcontrol_status</ConfigKey>
 		                        </Connection>

--- a/src/skin/pixmapsource.h
+++ b/src/skin/pixmapsource.h
@@ -1,6 +1,9 @@
 #ifndef PIXMAPSOURCE_H
 #define PIXMAPSOURCE_H
 
+#include <QString>
+#include <QByteArray>
+
 // A class representing an image source for a pixmap
 // A bundle of a file path, raw data or inline svg
 class PixmapSource {

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -263,6 +263,14 @@ PixmapSource SkinContext::getPixmapSource(const QDomNode& pixmapNode) const {
     return source;
 }
 
+Paintable::DrawMode SkinContext::selectScaleMode(
+        const QDomElement& element,
+        Paintable::DrawMode defaultDrawMode) const {
+    QString drawModeStr = selectAttributeString(
+            element, "scalemode", Paintable::DrawModeToString(defaultDrawMode));
+    return Paintable::DrawModeFromString(drawModeStr);
+}
+
 /**
  * All the methods below exist to access some of the scriptEngine features
  * from the svgParser.

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -11,6 +11,7 @@
 
 #include "configobject.h"
 #include "skin/pixmapsource.h"
+#include "widget/wpixmapstore.h"
 
 // A class for managing the current context/environment when processing a
 // skin. Used hierarchically by LegacySkinParser to create new contexts and
@@ -63,6 +64,8 @@ class SkinContext {
                                   QString defaultValue) const;
     QString nodeToString(const QDomNode& node) const;
     PixmapSource getPixmapSource(const QDomNode& pixmapNode) const;
+    Paintable::DrawMode selectScaleMode(const QDomElement& element,
+                                        Paintable::DrawMode defaultDrawMode) const;
 
     QScriptValue evaluateScript(const QString& expression,
                                 const QString& filename=QString(),

--- a/src/widget/wdisplay.h
+++ b/src/widget/wdisplay.h
@@ -46,7 +46,7 @@ class WDisplay : public WWidget {
 
   private:
     void setPixmap(QVector<PaintablePointer>* pPixmaps, int iPos,
-                   const QString& filename);
+                   const QString& filename, Paintable::DrawMode mode);
 
     void setPixmapBackground(PixmapSource source, Paintable::DrawMode mode);
 

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -1,5 +1,6 @@
 #include <QStylePainter>
 #include <QStyleOption>
+#include <QTransform>
 
 #include "widget/wknobcomposed.h"
 
@@ -18,15 +19,16 @@ void WKnobComposed::setup(QDomNode node, const SkinContext& context) {
 
     // Set background pixmap if available
     if (context.hasNode(node, "BackPath")) {
-        QString mode_str = context.selectAttributeString(
-                context.selectElement(node, "BackPath"), "scalemode", "TILE");
-        setPixmapBackground(context.getPixmapSource(context.selectNode(node, "BackPath")),
-                            Paintable::DrawModeFromString(mode_str));
+        QDomElement backPathElement = context.selectElement(node, "BackPath");
+        setPixmapBackground(context.getPixmapSource(backPathElement),
+                            context.selectScaleMode(backPathElement, Paintable::TILE));
     }
 
-    // Set background pixmap if available
+    // Set knob pixmap if available
     if (context.hasNode(node, "Knob")) {
-        setPixmapKnob(context.getPixmapSource(context.selectNode(node, "Knob")));
+        QDomElement knobNode = context.selectElement(node, "Knob");
+        setPixmapKnob(context.getPixmapSource(knobNode),
+                      context.selectScaleMode(knobNode, Paintable::STRETCH));
     }
 
     if (context.hasNode(node, "MinAngle")) {
@@ -52,8 +54,9 @@ void WKnobComposed::setPixmapBackground(PixmapSource source,
     }
 }
 
-void WKnobComposed::setPixmapKnob(PixmapSource source) {
-    m_pKnob = WPixmapStore::getPaintable(source, Paintable::STRETCH);
+void WKnobComposed::setPixmapKnob(PixmapSource source,
+                                  Paintable::DrawMode mode) {
+    m_pKnob = WPixmapStore::getPaintable(source, mode);
     if (m_pKnob.isNull() || m_pKnob->isNull()) {
         qDebug() << metaObject()->className()
                  << "Error loading knob pixmap:" << source.getPath();
@@ -83,18 +86,25 @@ void WKnobComposed::paintEvent(QPaintEvent* e) {
     p.drawPrimitive(QStyle::PE_Widget, option);
 
     if (m_pPixmapBack) {
-        m_pPixmapBack->draw(0, 0, &p);
+        m_pPixmapBack->draw(rect(), &p);
     }
 
+    QTransform transform;
     if (!m_pKnob.isNull() && !m_pKnob->isNull()) {
-        p.translate(width() / 2.0, height() / 2.0);
+        qreal tx = width() / 2.0;
+        qreal ty = height() / 2.0;
+        transform.translate(-tx, -ty);
+        p.translate(tx, ty);
 
         // We update m_dCurrentAngle since onConnectedControlChanged uses it for
         // no-op detection.
         m_dCurrentAngle = m_dMinAngle + (m_dMaxAngle - m_dMinAngle) * getControlParameterDisplay();
         p.rotate(m_dCurrentAngle);
 
-        m_pKnob->draw(-m_pKnob->width() / 2.0, -m_pKnob->height() / 2.0, &p);
+        // Need to convert from QRect to a QRectF to avoid losing precison.
+        QRectF targetRect = rect();
+        m_pKnob->drawCentered(transform.mapRect(targetRect), &p,
+                              m_pKnob->rect());
     }
 }
 

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -32,7 +32,7 @@ class WKnobComposed : public WWidget {
   private:
     void clear();
     void setPixmapBackground(PixmapSource source, Paintable::DrawMode mode);
-    void setPixmapKnob(PixmapSource source);
+    void setPixmapKnob(PixmapSource source, Paintable::DrawMode mode);
 
     double m_dCurrentAngle;
     PaintablePointer m_pKnob;

--- a/src/widget/wpixmapstore.cpp
+++ b/src/widget/wpixmapstore.cpp
@@ -26,6 +26,7 @@
 QHash<QString, WeakPaintablePointer> WPixmapStore::m_paintableCache;
 QSharedPointer<ImgSource> WPixmapStore::m_loader = QSharedPointer<ImgSource>();
 
+// static
 Paintable::DrawMode Paintable::DrawModeFromString(const QString& str) {
     if (str.compare("FIXED", Qt::CaseInsensitive) == 0) {
         return FIXED;
@@ -36,8 +37,29 @@ Paintable::DrawMode Paintable::DrawModeFromString(const QString& str) {
     } else if (str.compare("TILE", Qt::CaseInsensitive) == 0) {
         return TILE;
     }
-    qWarning() << "Unknown string for Paintable drawing mode " << str << ", using TILE";
-    return TILE;
+
+    // Fall back on the implicit default from before Mixxx supported draw modes.
+    qWarning() << "Unknown DrawMode string in DrawModeFromString:"
+               << str << "using FIXED";
+    return FIXED;
+}
+
+// static
+QString Paintable::DrawModeToString(DrawMode mode) {
+    switch (mode) {
+        case FIXED:
+            return "FIXED";
+        case STRETCH:
+            return "STRETCH";
+        case STRETCH_ASPECT:
+            return "STRETCH_ASPECT";
+        case TILE:
+            return "TILE";
+    }
+    // Fall back on the implicit default from before Mixxx supported draw modes.
+    qWarning() << "Unknown DrawMode in DrawModeToString " << mode
+               << "using FIXED";
+    return "FIXED";
 }
 
 Paintable::Paintable(QImage* pImage, DrawMode mode)

--- a/src/widget/wpixmapstore.cpp
+++ b/src/widget/wpixmapstore.cpp
@@ -20,15 +20,21 @@
 #include <QString>
 #include <QtDebug>
 
+#include "util/math.h"
+
 // static
 QHash<QString, WeakPaintablePointer> WPixmapStore::m_paintableCache;
 QSharedPointer<ImgSource> WPixmapStore::m_loader = QSharedPointer<ImgSource>();
 
-Paintable::DrawMode Paintable::DrawModeFromString(QString str) {
-    if (str.toUpper() == "TILE") {
-        return TILE;
-    } else if (str.toUpper() == "STRETCH") {
+Paintable::DrawMode Paintable::DrawModeFromString(const QString& str) {
+    if (str.compare("FIXED", Qt::CaseInsensitive) == 0) {
+        return FIXED;
+    } else if (str.compare("STRETCH", Qt::CaseInsensitive) == 0) {
         return STRETCH;
+    } else if (str.compare("STRETCH_ASPECT", Qt::CaseInsensitive) == 0) {
+        return STRETCH_ASPECT;
+    } else if (str.compare("TILE", Qt::CaseInsensitive) == 0) {
+        return TILE;
     }
     qWarning() << "Unknown string for Paintable drawing mode " << str << ", using TILE";
     return TILE;
@@ -48,9 +54,7 @@ Paintable::Paintable(QImage* pImage, DrawMode mode)
 Paintable::Paintable(const QString& fileName, DrawMode mode)
         : m_draw_mode(mode) {
     if (fileName.endsWith(".svg", Qt::CaseInsensitive)) {
-        if (mode == STRETCH) {
-            m_pSvg.reset(new QSvgRenderer(fileName));
-        } else if (mode == TILE) {
+        if (mode == TILE) {
             // The SVG renderer doesn't directly support tiling, so we render
             // it to a pixmap which will then get tiled.
             QSvgRenderer renderer(fileName);
@@ -61,7 +65,7 @@ Paintable::Paintable(const QString& fileName, DrawMode mode)
             renderer.render(&painter);
             m_pPixmap->convertFromImage(copy_buffer);
         } else {
-            qWarning() << "Error, unknown drawing mode!";
+            m_pSvg.reset(new QSvgRenderer(fileName));
         }
     } else {
         m_pPixmap.reset(new QPixmap(fileName));
@@ -78,9 +82,7 @@ Paintable::Paintable(const PixmapSource& source, DrawMode mode)
             pSvgRenderer->load(source.getData());
         }
 
-        if (mode == STRETCH) {
-            m_pSvg.reset(pSvgRenderer.take());
-        } else if (mode == TILE) {
+        if (mode == TILE) {
             // The SVG renderer doesn't directly support tiling, so we render
             // it to a pixmap which will then get tiled.
             QImage copy_buffer(pSvgRenderer->defaultSize(), QImage::Format_ARGB32);
@@ -90,7 +92,7 @@ Paintable::Paintable(const PixmapSource& source, DrawMode mode)
             pSvgRenderer->render(&painter);
             m_pPixmap->convertFromImage(copy_buffer);
         } else {
-            qWarning() << "Error, unknown drawing mode!";
+            m_pSvg.reset(pSvgRenderer.take());
         }
     } else {
         QPixmap * pPixmap = new QPixmap();
@@ -142,73 +144,99 @@ int Paintable::height() const {
     return 0;
 }
 
-void Paintable::draw(const QRectF& targetRect, QPainter* pPainter) {
-    if (!targetRect.isValid()) {
-        return;
+QRectF Paintable::rect() const {
+    if (!m_pPixmap.isNull()) {
+        return m_pPixmap->rect();
+    } else if (!m_pSvg.isNull()) {
+        return QRectF(QPointF(0, 0), m_pSvg->defaultSize());
     }
-
-    if (!m_pPixmap.isNull() && !m_pPixmap->isNull()) {
-        if (m_draw_mode == Paintable::STRETCH) {
-            pPainter->drawPixmap(targetRect, *m_pPixmap, m_pPixmap->rect());
-        } else if (m_draw_mode == Paintable::TILE) {
-            pPainter->drawTiledPixmap(targetRect, *m_pPixmap, QPoint(0,0));
-        }
-    } else if (!m_pSvg.isNull() && m_pSvg->isValid()) {
-        if (m_draw_mode == Paintable::TILE) {
-            qWarning() << "Tiled SVG should have been rendered to pixmap!";
-        }
-        m_pSvg->render(pPainter, targetRect);
-    }
+    return QRectF();
 }
 
-void Paintable::draw(const QRectF& targetRect, QPainter* pPainter,
-                     const QRectF& sourceRect) {
-    if (!targetRect.isValid() || !sourceRect.isValid()) {
-        return;
-    }
-
-    if (m_pPixmap && !m_pPixmap->isNull()) {
-        pPainter->drawPixmap(targetRect, *m_pPixmap, sourceRect);
-    } else if (m_pSvg && m_pSvg->isValid()) {
-        resizeSvgPixmap(targetRect, sourceRect);
-
-        QRectF newSource(m_pPixmapSvg->width() * sourceRect.x() / sourceRect.width(),
-                         m_pPixmapSvg->height() * sourceRect.y() / sourceRect.height(),
-                         targetRect.width(), targetRect.height());
-        pPainter->drawPixmap(targetRect, *m_pPixmapSvg, newSource);
-    }
+void Paintable::draw(const QRectF& targetRect, QPainter* pPainter) {
+    // The sourceRect is implicitly the entire Paintable.
+    draw(targetRect, pPainter, rect());
 }
 
 void Paintable::draw(int x, int y, QPainter* pPainter) {
-    if (m_pPixmap && !m_pPixmap->isNull()) {
-        pPainter->drawPixmap(x, y, *m_pPixmap);
-    } else if (m_pSvg && m_pSvg->isValid()) {
-        QRectF targetRect(QPointF(x, y), m_pSvg->defaultSize());
-        m_pSvg->render(pPainter, targetRect);
-    }
+    QRectF sourceRect(rect());
+    QRectF targetRect(QPointF(x, y), sourceRect.size());
+    draw(targetRect, pPainter, sourceRect);
 }
 
 void Paintable::draw(const QPointF& point, QPainter* pPainter, const QRectF& sourceRect) {
     return draw(QRectF(point, sourceRect.size()), pPainter, sourceRect);
 }
 
-void Paintable::resizeSvgPixmap(const QRectF& targetRect,
-                                const QRectF& sourceRect) {
-    if (m_pSvg.isNull() || !m_pSvg->isValid()) {
+void Paintable::draw(const QRectF& targetRect, QPainter* pPainter,
+                     const QRectF& sourceRect) {
+    if (!targetRect.isValid() || !sourceRect.isValid() || isNull()) {
         return;
     }
 
-    double sx = targetRect.width() / sourceRect.width();
-    double sy = targetRect.height() / sourceRect.height();
+    if (m_draw_mode == Paintable::FIXED) {
+        // Only render the minimum overlapping rectangle between the source
+        // and target.
+        QSizeF fixedSize(math_min(sourceRect.width(), targetRect.width()),
+                         math_min(sourceRect.height(), targetRect.height()));
+        QRectF adjustedTarget(targetRect.topLeft(), fixedSize);
+        QRectF adjustedSource(sourceRect.topLeft(), fixedSize);
+        return drawInternal(adjustedTarget, pPainter, adjustedSource);
+    } else if (m_draw_mode == Paintable::STRETCH_ASPECT) {
+        qreal sx = targetRect.width() / sourceRect.width();
+        qreal sy = targetRect.height() / sourceRect.height();
 
-    QSize originalSize = m_pSvg->defaultSize();
-    QSize projectedSize(originalSize.width() * sx,
-                        originalSize.height() * sy);
+        // Adjust the scale so that the scaling in both axes is equal.
+        if (sx != sy) {
+            qreal scale = math_min(sx, sy);
+            QRectF adjustedTarget(targetRect.x(),
+                                  targetRect.y(),
+                                  scale * sourceRect.width(),
+                                  scale * sourceRect.height());
+            return drawInternal(adjustedTarget, pPainter, sourceRect);
+        } else {
+            return drawInternal(targetRect, pPainter, sourceRect);
+        }
+    } else if (m_draw_mode == Paintable::STRETCH) {
+        return drawInternal(targetRect, pPainter, sourceRect);
+    } else if (m_draw_mode == Paintable::TILE) {
+        return drawInternal(targetRect, pPainter, sourceRect);
+    }
+}
 
-    if (m_pPixmapSvg.isNull() || m_pPixmapSvg->size() != projectedSize) {
-        m_pPixmapSvg.reset(new QPixmap(projectedSize));
-        QPainter pixmapPainter(m_pPixmapSvg.data());
-        m_pSvg->render(&pixmapPainter);
+void Paintable::drawInternal(const QRectF& targetRect, QPainter* pPainter,
+                             const QRectF& sourceRect) {
+    //qDebug() << "Paintable::drawInternal" << targetRect << sourceRect;
+    if (m_pPixmap) {
+        if (m_draw_mode == Paintable::TILE) {
+            // TODO(rryan): Using a source rectangle doesn't make much sense
+            // with tiling. Ignore the source rect and tile our natural size
+            // across the target rect. What's the right general behavior here?
+            // NOTE(rryan): We round our target/source rectangles to the nearest
+            // pixel for raster images.
+            pPainter->drawTiledPixmap(targetRect.toRect(), *m_pPixmap, QPoint(0,0));
+        } else {
+            // NOTE(rryan): We round our target/source rectangles to the nearest
+            // pixel for raster images.
+            pPainter->drawPixmap(targetRect.toRect(), *m_pPixmap,
+                                 sourceRect.toRect());
+        }
+    } else if (m_pSvg) {
+        if (m_draw_mode == Paintable::TILE) {
+            qWarning() << "Tiled SVG should have been rendered to pixmap!";
+        } else {
+            // NOTE(rryan): QSvgRenderer render does not clip for us -- it
+            // applies a world transformation using viewBox and renders the
+            // entire SVG to the painter. We save/restore the QPainter in case
+            // there is an existing clip region (I don't know of any Mixxx code
+            // that uses one but we may in the future).
+            pPainter->save();
+            pPainter->setClipping(true);
+            pPainter->setClipRect(targetRect);
+            m_pSvg->setViewBox(sourceRect);
+            m_pSvg->render(pPainter, targetRect);
+            pPainter->restore();
+        }
     }
 }
 

--- a/src/widget/wpixmapstore.h
+++ b/src/widget/wpixmapstore.h
@@ -37,7 +37,13 @@ class QString;
 class Paintable {
   public:
     enum DrawMode {
+        // Draw the image in its native dimensions with no stretching or tiling.
+        FIXED,
+        // Stretch the image.
         STRETCH,
+        // Stretch the image maintaining its aspect ratio.
+        STRETCH_ASPECT,
+        // Tile the image.
         TILE
     };
 
@@ -49,6 +55,10 @@ class Paintable {
     QSize size() const;
     int width() const;
     int height() const;
+    QRectF rect() const;
+    DrawMode drawMode() const {
+        return m_draw_mode;
+    }
 
     void draw(int x, int y, QPainter* pPainter);
     void draw(const QPointF& point, QPainter* pPainter,
@@ -57,14 +67,14 @@ class Paintable {
     void draw(const QRectF& targetRect, QPainter* pPainter,
               const QRectF& sourceRect);
     bool isNull() const;
-    static DrawMode DrawModeFromString(QString str);
+    static DrawMode DrawModeFromString(const QString& str);
 
   private:
-    void resizeSvgPixmap(const QRectF& targetRect, const QRectF& sourceRect);
+    void drawInternal(const QRectF& targetRect, QPainter* pPainter,
+                      const QRectF& sourceRect);
 
     QScopedPointer<QPixmap> m_pPixmap;
     QScopedPointer<QSvgRenderer> m_pSvg;
-    QScopedPointer<QPixmap> m_pPixmapSvg;
     DrawMode m_draw_mode;
 };
 

--- a/src/widget/wpixmapstore.h
+++ b/src/widget/wpixmapstore.h
@@ -65,6 +65,8 @@ class Paintable {
     void draw(const QRectF& targetRect, QPainter* pPainter);
     void draw(const QRectF& targetRect, QPainter* pPainter,
               const QRectF& sourceRect);
+    void drawCentered(const QRectF& targetRect, QPainter* pPainter,
+                      const QRectF& sourceRect);
     bool isNull() const;
 
     static DrawMode DrawModeFromString(const QString& str);

--- a/src/widget/wpixmapstore.h
+++ b/src/widget/wpixmapstore.h
@@ -26,11 +26,10 @@
 #include <QScopedPointer>
 #include <QPainter>
 #include <QRectF>
+#include <QString>
 
 #include "skin/imgsource.h"
-#include "skin/skincontext.h"
-
-class QString;
+#include "skin/pixmapsource.h"
 
 // Wrapper around QImage and QSvgRenderer to support rendering SVG images in
 // high fidelity.

--- a/src/widget/wpixmapstore.h
+++ b/src/widget/wpixmapstore.h
@@ -66,7 +66,9 @@ class Paintable {
     void draw(const QRectF& targetRect, QPainter* pPainter,
               const QRectF& sourceRect);
     bool isNull() const;
+
     static DrawMode DrawModeFromString(const QString& str);
+    static QString DrawModeToString(DrawMode mode);
 
   private:
     void drawInternal(const QRectF& targetRect, QPainter* pPainter,

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -86,7 +86,8 @@ class WPushButton : public WWidget {
     void restyleAndRepaint();
 
     // Associates a pixmap of a given state of the button with the widget
-    void setPixmap(int iState, bool bPressed, PixmapSource source);
+    void setPixmap(int iState, bool bPressed, PixmapSource source,
+                   Paintable::DrawMode mode);
 
     // Associates a background pixmap with the widget. This is only needed if
     // the button pixmaps contains alpha channel values.

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -43,8 +43,9 @@ class WSliderComposed : public WWidget  {
     virtual ~WSliderComposed();
 
     void setup(QDomNode node, const SkinContext& context);
-    void setSliderPixmap(PixmapSource sourceSlider);
-    void setHandlePixmap(bool bHorizontal, PixmapSource sourceHandle);
+    void setSliderPixmap(PixmapSource sourceSlider, Paintable::DrawMode mode);
+    void setHandlePixmap(bool bHorizontal, PixmapSource sourceHandle,
+                         Paintable::DrawMode mode);
     inline bool isHorizontal() const { return m_bHorizontal; };
 
   public slots:
@@ -60,6 +61,7 @@ class WSliderComposed : public WWidget  {
     virtual void resizeEvent(QResizeEvent* e);
 
   private:
+    double calculateHandleLength();
     void unsetPixmaps();
 
     double m_dOldValue;

--- a/src/widget/wstatuslight.h
+++ b/src/widget/wstatuslight.h
@@ -34,16 +34,10 @@
 class WStatusLight : public WWidget  {
    Q_OBJECT
   public:
-    enum SizeMode {
-        FIXED,
-        RESIZE,
-    };
-
     WStatusLight(QWidget *parent=0);
     virtual ~WStatusLight();
 
     void setup(QDomNode node, const SkinContext& context);
-    static SizeMode SizeModeFromString(QString str);
 
   public slots:
     void onConnectedControlChanged(double dParameter, double dValue);
@@ -52,7 +46,7 @@ class WStatusLight : public WWidget  {
     void paintEvent(QPaintEvent *);
 
   private:
-    void setPixmap(int iState, PixmapSource source, SizeMode mode);
+    void setPixmap(int iState, PixmapSource source, Paintable::DrawMode mode);
     void setNoPos(int iNoPos);
 
     // Current position

--- a/src/widget/wvumeter.h
+++ b/src/widget/wvumeter.h
@@ -46,35 +46,36 @@ class WVuMeter : public WWidget  {
     void maybeUpdate();
 
   private:
-    /** Set position number to zero and deallocate pixmaps */
-    void resetPositions();
     void paintEvent(QPaintEvent *);
-    void setPeak(int pos, double parameter);
+    void setPeak(double parameter);
 
-    // Current position in the pixmap.
-    int m_iPos;
+    // Current parameter and peak parameter.
     double m_dParameter;
-    // Number of positions in the pixmap.
-    int m_iNoPos;
-    // Current position in the widget.
-    int m_iWidgetPos;
+    double m_dPeakParameter;
 
+    // The last parameter and peak parameter values at the time of
+    // rendering. Used to check whether the widget state has changed since the
+    // last render in maybeUpdate.
+    double m_dLastParameter;
+    double m_dLastPeakParameter;
 
-    /** Associated pixmaps */
+    // Length of the VU-meter pixmap along the relevant axis.
+    int m_iPixmapLength;
+
+    // Associated pixmaps
     PaintablePointer m_pPixmapBack;
     PaintablePointer m_pPixmapVu;
-    /** True if it's a horizontal vu meter */
+
+    // True if it's a horizontal vu meter
     bool m_bHorizontal;
 
     int m_iPeakHoldSize;
     int m_iPeakFallStep;
     int m_iPeakHoldTime;
     int m_iPeakFallTime;
-    int m_iPeakPos;
-    double m_dPeakParameter;
-    int m_iPeakHoldCountdown;
-    int m_iLastPos;
-    int m_iLastPeakPos;
+
+    // The peak hold time remaining in milliseconds.
+    double m_dPeakHoldCountdownMs;
 
     PerformanceTimer m_timer;
 };

--- a/src/widget/wvumeter.h
+++ b/src/widget/wvumeter.h
@@ -36,9 +36,10 @@ class WVuMeter : public WWidget  {
     virtual ~WVuMeter();
 
     void setup(QDomNode node, const SkinContext& context);
-    void setPixmapBackground(PixmapSource source);
+    void setPixmapBackground(PixmapSource source, Paintable::DrawMode mode);
     void setPixmaps(PixmapSource source,
-                    bool bHorizontal=false);
+                    bool bHorizontal,
+                    Paintable::DrawMode mode);
     void onConnectedControlChanged(double dParameter, double dValue);
 
   protected slots:

--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -83,10 +83,9 @@ void WWidgetGroup::setup(QDomNode node, const SkinContext& context) {
 
     // Set background pixmap if available
     if (context.hasNode(node, "BackPath")) {
-        QString mode_str = context.selectAttributeString(
-                context.selectElement(node, "BackPath"), "scalemode", "TILE");
-        setPixmapBackground(context.getPixmapSource(context.selectNode(node, "BackPath")),
-                            Paintable::DrawModeFromString(mode_str));
+        QDomElement backPathNode = context.selectElement(node, "BackPath");
+        setPixmapBackground(context.getPixmapSource(backPathNode),
+                            context.selectScaleMode(backPathNode, Paintable::TILE));
     }
 
     QLayout* pLayout = NULL;


### PR DESCRIPTION
- Add STRETCH_ASPECT and FIXED DrawModes.
- Guard (almost) all setFixedSize calls in widgets on FIXED DrawMode.
- Remove WStatusLight SizeMode since it was added to allow side-stepping setFixedSize calls.
- Remove pixmap fall-back for SVGs when rendering with a source rectangle (i.e. VU meters). I finally got this working with QSvgRenderer.
- De-dupe logic in Paintable::draw methods so they all funnel through one handler -- drawInternal.
- Use floating point for rectangle calculations in WVuMeter instead of integers.
- SkinContext helper for extracting scalemode.
- Support for "scalemode" attribute on (almost) all widget images.

The only remaining widget that doesn't have scalemode support and still calls setFixedSize is WSpinny -- which uses QImage's instead of Paintables.
