### PR TITLE
Fix rating column rendering issues with CSS-styled libraries.

### DIFF
--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -852,6 +852,9 @@ QTableView, QTextBrowser, QTreeView {
   color: #cfb32c;
   background-color: #0f0f0f;
   alternate-background-color: #1a1a1a;
+
+  selection-color: #cfb32c;
+  selection-background-color: #725309;
 }
 
 /* checkbox in library "Played" column */

--- a/src/library/stardelegate.cpp
+++ b/src/library/stardelegate.cpp
@@ -18,94 +18,73 @@
 
 #include <QtDebug>
 
-#include "stardelegate.h"
-#include "stareditor.h"
-#include "starrating.h"
+#include "library/stardelegate.h"
+#include "library/stareditor.h"
+#include "library/starrating.h"
 
-StarDelegate::StarDelegate(QObject *pParent)
+StarDelegate::StarDelegate(QObject* pParent)
         : QStyledItemDelegate(pParent),
+          m_pTableView(qobject_cast<QTableView*>(pParent)),
           m_isOneCellInEditMode(false) {
-    m_pTableView = qobject_cast<QTableView *>(pParent);
     connect(pParent, SIGNAL(entered(QModelIndex)),
             this, SLOT(cellEntered(QModelIndex)));
 }
 
-void StarDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
-{
-    //let the editor to the painting if this is true
+void StarDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option,
+                         const QModelIndex& index) const {
+    // let the editor do the painting if this cell is currently being edited
     if (index == m_currentEditedCellIndex) {
         return;
     }
 
     // Populate the correct colors based on the styling
-    QStyleOptionViewItem newOption = option;
+    QStyleOptionViewItemV4 newOption = option;
     initStyleOption(&newOption, index);
 
-    // Set the palette appropriately based on whether the row is selected or
-    // not. We also have to check if it is inactive or not and use the
-    // appropriate ColorGroup.
-    if (newOption.state & QStyle::State_Selected) {
-        QPalette::ColorGroup colorGroup =
-                newOption.state & QStyle::State_Active ?
-                QPalette::Active : QPalette::Inactive;
-        painter->fillRect(newOption.rect,
-            newOption.palette.color(colorGroup, QPalette::Highlight));
-        painter->setBrush(newOption.palette.color(
-            colorGroup, QPalette::HighlightedText));
-    } else {
-        painter->fillRect(newOption.rect, newOption.palette.base());
-        painter->setBrush(newOption.palette.text());
-    }
-
     StarRating starRating = qVariantValue<StarRating>(index.data());
-    starRating.paint(painter, newOption.rect, newOption.palette, StarRating::ReadOnly,
-                     newOption.state & QStyle::State_Selected);
+    StarEditor::renderHelper(painter, m_pTableView, option, &starRating);
 }
 
-QSize StarDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
-{
+QSize StarDelegate::sizeHint(const QStyleOptionViewItem& option,
+                             const QModelIndex& index) const {
     Q_UNUSED(option);
     StarRating starRating = qVariantValue<StarRating>(index.data());
     return starRating.sizeHint();
 }
 
-QWidget *StarDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option,const QModelIndex &index) const
-{
+QWidget* StarDelegate::createEditor(QWidget* parent,
+                                    const QStyleOptionViewItem& option,
+                                    const QModelIndex& index) const {
     // Populate the correct colors based on the styling
-    QStyleOptionViewItem newOption = option;
+    QStyleOptionViewItemV4 newOption = option;
     initStyleOption(&newOption, index);
 
-    StarEditor *editor = new StarEditor(parent, newOption);
+    StarEditor* editor = new StarEditor(parent, m_pTableView, index, newOption);
     connect(editor, SIGNAL(editingFinished()),
             this, SLOT(commitAndCloseEditor()));
     return editor;
 }
 
-void StarDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
-{
+void StarDelegate::setEditorData(QWidget* editor,
+                                 const QModelIndex& index) const {
     StarRating starRating = qVariantValue<StarRating>(index.data());
-    StarEditor *starEditor = qobject_cast<StarEditor *>(editor);
+    StarEditor* starEditor = qobject_cast<StarEditor*>(editor);
     starEditor->setStarRating(starRating);
 }
 
-void StarDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
-{
-    StarEditor *starEditor = qobject_cast<StarEditor *>(editor);
+void StarDelegate::setModelData(QWidget* editor, QAbstractItemModel* model,
+                                const QModelIndex& index) const {
+    StarEditor* starEditor = qobject_cast<StarEditor*>(editor);
     model->setData(index, qVariantFromValue(starEditor->starRating()));
 }
 
-/*
- * When the user is done editing, we emit commitData() and closeEditor() (both declared in QAbstractItemDelegate),
- * to tell the model that there is edited data and to inform the view that the editor is no longer needed.
- */
 void StarDelegate::commitAndCloseEditor() {
-    StarEditor *editor = qobject_cast<StarEditor *>(sender());
+    StarEditor* editor = qobject_cast<StarEditor*>(sender());
     emit commitData(editor);
     emit closeEditor(editor);
 }
 
-//cellEntered
-void StarDelegate::cellEntered(const QModelIndex &index) {
+void StarDelegate::cellEntered(const QModelIndex& index) {
     // This slot is called if the mouse pointer enters ANY cell on the
     // QTableView but the code should only be executed on a column with a
     // StarRating.

--- a/src/library/stardelegate.h
+++ b/src/library/stardelegate.h
@@ -22,39 +22,39 @@
 #include <QStyledItemDelegate>
 #include <QTableView>
 
-/*
- * When displaying data in a QListView, QTableView, or QTreeView,
- * the individual items are drawn by a delegate.
- * Also, when the user starts editing an item (e.g., by double-clicking the item),
- * the delegate provides an editor widget that is placed on top of the item while editing takes place.
- *
- * By default a QListView, QTableView, or QTreeView has a QItemDelegate attached,
- * which inherits QAbstractItemDelegate and handles the most common data types (notably int and QString).
- * If we need to support custom data types, or want to customize the rendering or the editing for
- * existing data types, we can subclass QAbstractItemDelegate or QItemDelegate or QStyledItemDelegate
- */
 class StarDelegate : public QStyledItemDelegate {
     Q_OBJECT
+  public:
+    StarDelegate(QObject* pParent = 0);
 
-public:
-    StarDelegate(QObject *pParent = 0);
-    /** reimplemented from QItemDelegate and is called whenever the view needs to repaint an item **/
-    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    /** returns an item's preferred size **/
-    QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    /** called when the user starts editing an item: **/
-    QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option,const QModelIndex &index) const;
-    /** called when an editor is created to initialize it with data from the model: **/
-    void setEditorData(QWidget *editor, const QModelIndex &index) const;
-    /** called when editing is finished, to commit data from the editor to the model: **/
-    void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;  
+    // reimplemented from QItemDelegate and is called whenever the view needs to
+    // repaint an item
+    void paint(QPainter* painter, const QStyleOptionViewItem& option,
+               const QModelIndex& index) const;
+
+    // returns an item's preferred size
+    QSize sizeHint(const QStyleOptionViewItem& option,
+                   const QModelIndex& index) const;
+
+    // called when the user starts editing an item
+    QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option,
+                          const QModelIndex& index) const;
+
+    // called when an editor is created to initialize it with data from the
+    // model
+    void setEditorData(QWidget* editor, const QModelIndex& index) const;
+
+    // called when editing is finished, to commit data from the editor to the
+    // model
+    void setModelData(QWidget* editor, QAbstractItemModel* model,
+                      const QModelIndex& index) const;
 
   private slots:
     void commitAndCloseEditor();
-    void cellEntered(const QModelIndex &index);
+    void cellEntered(const QModelIndex& index);
 
-private:
-    QTableView *m_pTableView;
+  private:
+    QTableView* m_pTableView;
     QPersistentModelIndex m_currentEditedCellIndex;
     bool m_isOneCellInEditMode;
 };

--- a/src/library/stareditor.cpp
+++ b/src/library/stareditor.cpp
@@ -24,8 +24,10 @@
  * see http://doc.trolltech.com/4.5/itemviews-stardelegate.html            *
  ***************************************************************************/
 
-#include "stareditor.h"
-#include "starrating.h"
+#include <QStylePainter>
+
+#include "library/stareditor.h"
+#include "library/starrating.h"
 
 /*
  * We enable mouse tracking on the widget so we can follow the cursor even
@@ -33,68 +35,97 @@
  * QWidget's auto-fill background feature to obtain an opaque background.
  * (Without the call, the view's background would shine through the editor.)
  */
-StarEditor::StarEditor(QWidget *parent, const QStyleOptionViewItem &option)
-        : QWidget(parent)
-{
-    setPalette(option.palette);
+StarEditor::StarEditor(QWidget *parent, QTableView* pTableView,
+                       const QModelIndex& index,
+                       const QStyleOptionViewItemV4& option)
+        : QWidget(parent),
+          m_pTableView(pTableView),
+          m_index(index),
+          m_styleOption(option) {
     setMouseTracking(true);
-    setAutoFillBackground(true);
-    m_isSelected = option.state & QStyle::State_Selected;
 }
 
-QSize StarEditor::sizeHint() const
- {
+QSize StarEditor::sizeHint() const {
     return m_starRating.sizeHint();
- }
-/*
- * We simply call StarRating::paint() to draw the stars,
- * just like we did when implementing StarDelegate
- */
-void StarEditor::paintEvent(QPaintEvent *)
- {
+}
+
+// static
+void StarEditor::renderHelper(QPainter* painter,
+                              QTableView* pTableView,
+                              const QStyleOptionViewItemV4& option,
+                              StarRating* pStarRating) {
+    painter->save();
+    painter->setClipRect(option.rect);
+
+    if (pTableView != NULL) {
+        QStyle* style = pTableView->style();
+        if (style != NULL) {
+            style->drawControl(QStyle::CE_ItemViewItem, &option, painter,
+                               pTableView);
+        }
+    }
+
+    // Set the palette appropriately based on whether the row is selected or
+    // not. We also have to check if it is inactive or not and use the
+    // appropriate ColorGroup.
+    QPalette::ColorGroup cg = option.state & QStyle::State_Enabled
+            ? QPalette::Normal : QPalette::Disabled;
+    if (cg == QPalette::Normal && !(option.state & QStyle::State_Active))
+        cg = QPalette::Inactive;
+
+    if (option.state & QStyle::State_Selected) {
+        painter->setBrush(option.palette.color(cg, QPalette::HighlightedText));
+    } else {
+        painter->setBrush(option.palette.color(cg, QPalette::Text));
+    }
+
+    pStarRating->paint(painter, option.rect);
+    painter->restore();
+}
+
+void StarEditor::paintEvent(QPaintEvent*) {
+    // If a StarEditor is open, by definition the mouse is hovering over us.
+    m_styleOption.state |= QStyle::State_MouseOver;
+    m_styleOption.rect = rect();
+
+    if (m_pTableView) {
+        QItemSelectionModel* selectionModel = m_pTableView->selectionModel();
+        if (selectionModel && selectionModel->isSelected(m_index)) {
+            m_styleOption.state |= QStyle::State_Selected;
+        }
+    }
+
     QPainter painter(this);
-    m_starRating.paint(&painter, rect(), palette(), StarRating::Editable,
-                       m_isSelected);
- }
-/*
- * In the mouse event handler, we call setStarCount() on
- * the private data member m_starRating to reflect the current cursor position,
- * and we call QWidget::update() to force a repaint.
- */
- void StarEditor::mouseMoveEvent(QMouseEvent *event)
- {
+    renderHelper(&painter, m_pTableView, m_styleOption, &m_starRating);
+}
+
+void StarEditor::mouseMoveEvent(QMouseEvent *event) {
     int star = starAtPosition(event->x());
 
     if (star != m_starRating.starCount() && star != -1) {
-       m_starRating.setStarCount(star);
-       update();
+        m_starRating.setStarCount(star);
+        update();
     }
- }
+}
 
- void StarEditor::leaveEvent(QEvent*) {
-     m_starRating.setStarCount(0);
-     update();
- }
-/*
- * When the user releases a mouse button, we simply emit the editingFinished() signal.
- */
- void StarEditor::mouseReleaseEvent(QMouseEvent * /* event */)
- {
+void StarEditor::leaveEvent(QEvent*) {
+    m_starRating.setStarCount(0);
+    update();
+}
+
+void StarEditor::mouseReleaseEvent(QMouseEvent* /* event */) {
     emit editingFinished();
- }
-/*
- * The method uses basic linear algebra to find out which star is under the cursor.
- */
- int StarEditor::starAtPosition(int x)
- {
-     // If the mouse is very close to the left edge, set 0 stars.
-     if (x < m_starRating.sizeHint().width() * 0.05) {
-         return 0;
-     }
-     int star = (x / (m_starRating.sizeHint().width() / m_starRating.maxStarCount())) + 1;
+}
 
-     if (star <= 0 || star > m_starRating.maxStarCount())
-         return 0;
+int StarEditor::starAtPosition(int x) {
+    // If the mouse is very close to the left edge, set 0 stars.
+    if (x < m_starRating.sizeHint().width() * 0.05) {
+        return 0;
+    }
+    int star = (x / (m_starRating.sizeHint().width() / m_starRating.maxStarCount())) + 1;
 
-     return star;
- }
+    if (star <= 0 || star > m_starRating.maxStarCount()) {
+        return 0;
+    }
+    return star;
+}

--- a/src/library/stareditor.h
+++ b/src/library/stareditor.h
@@ -33,35 +33,46 @@
 #include <QStyle>
 #include <QSize>
 #include <QPaintEvent>
+#include <QStyleOptionViewItemV4>
+#include <QTableView>
+#include <QModelIndex>
 
-#include "starrating.h"
+#include "library/starrating.h"
 
 class StarEditor : public QWidget {
     Q_OBJECT
   public:
-    StarEditor(QWidget *parent, const QStyleOptionViewItem& option);
+    StarEditor(QWidget* parent, QTableView* pTableView,
+               const QModelIndex& index,
+               const QStyleOptionViewItemV4& option);
 
     QSize sizeHint() const;
-    void setStarRating(const StarRating &starRating) {
+    void setStarRating(const StarRating& starRating) {
         m_starRating = starRating;
     }
     StarRating starRating() { return m_starRating; }
+
+    static void renderHelper(QPainter* painter, QTableView* pTableView,
+                             const QStyleOptionViewItemV4& option,
+                             StarRating* pStarRating);
 
   signals:
     void editingFinished();
 
   protected:
-    void paintEvent(QPaintEvent *event);
-    void mouseMoveEvent(QMouseEvent *event);
-    void mouseReleaseEvent(QMouseEvent *event);
+    void paintEvent(QPaintEvent* event);
+    void mouseMoveEvent(QMouseEvent* event);
+    void mouseReleaseEvent(QMouseEvent* event);
     //if the mouse leaves the editing index set starCount to 0
-    void leaveEvent(QEvent *);
+    void leaveEvent(QEvent*);
 
   private:
     int starAtPosition(int x);
 
+    QTableView* m_pTableView;
+    QModelIndex m_index;
+    QStyleOptionViewItemV4 m_styleOption;
     StarRating m_starRating;
-    bool m_isSelected;
 };
 
 #endif

--- a/src/library/starrating.cpp
+++ b/src/library/starrating.cpp
@@ -15,58 +15,36 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "starrating.h"
+#include "library/starrating.h"
 #include "util/math.h"
 
 const int PaintingScaleFactor = 15;
 
-
-
 StarRating::StarRating(int starCount, int maxStarCount)
-{
-    m_myStarCount = starCount;
-    m_myMaxStarCount = maxStarCount;
-
+        : m_myStarCount(starCount),
+          m_myMaxStarCount(maxStarCount) {
     m_starPolygon << QPointF(1.0, 0.5);
     for (int i = 1; i < 5; ++i)
         m_starPolygon << QPointF(0.5 + 0.5 * cos(0.8 * i * 3.14), 0.5 + 0.5 * sin(0.8 * i * 3.14));
     m_diamondPolygon << QPointF(0.4, 0.5) << QPointF(0.5, 0.4) << QPointF(0.6, 0.5) << QPointF(0.5, 0.6) << QPointF(0.4, 0.5);
 }
 
-QSize StarRating::sizeHint() const
-{
+QSize StarRating::sizeHint() const {
     return PaintingScaleFactor * QSize(m_myMaxStarCount, 1);
 }
 
-/*
- * function paints the stars in this StarRating object on a paint device
- */
-void StarRating::paint(QPainter *painter, const QRect &rect, const QPalette &palette,
-                        EditMode mode, bool isSelected) const
-{
+void StarRating::paint(QPainter *painter, const QRect &rect) const {
+    // Assume the painter is configured with the right brush.
     painter->save();
-
     painter->setRenderHint(QPainter::Antialiasing, true);
     painter->setPen(Qt::NoPen);
-
-    // Workaround for painting issue. If we are editable, assume we are
-    // selected, so use the highlight and hightlightedText colors.
-    if (mode == Editable) {
-        if (isSelected) {
-            painter->fillRect(rect, palette.highlight());
-            painter->setBrush(palette.highlightedText());
-        } else {
-            painter->fillRect(rect, palette.base());
-            painter->setBrush(palette.text());
-        }
-    }
 
     int yOffset = (rect.height() - PaintingScaleFactor) / 2;
     painter->translate(rect.x(), rect.y() + yOffset);
     painter->scale(PaintingScaleFactor, PaintingScaleFactor);
 
     //determine number of stars that are possible to paint
-    int n = rect.width()/PaintingScaleFactor;
+    int n = rect.width() / PaintingScaleFactor;
 
     for (int i = 0; i < m_myMaxStarCount && i<n; ++i) {
         if (i < m_myStarCount) {
@@ -76,6 +54,5 @@ void StarRating::paint(QPainter *painter, const QRect &rect, const QPalette &pal
         }
         painter->translate(1.0, 0.0);
     }
-
     painter->restore();
 }

--- a/src/library/starrating.h
+++ b/src/library/starrating.h
@@ -32,16 +32,13 @@
  * The myStarCount member variable stores the current rating, and myMaxStarCount stores
  * the highest possible rating (typically 5).
  */
-class StarRating
-{
- public:
+class StarRating {
+  public:
     enum EditMode { Editable, ReadOnly };
-
 
     StarRating(int starCount = 1, int maxStarCount = 5);
 
-    void paint(QPainter *painter, const QRect &rect, const QPalette &palette, EditMode mode,
-                bool isSelected) const;
+    void paint(QPainter* painter, const QRect& rect) const;
     QSize sizeHint() const;
 
     int starCount() const { return m_myStarCount; }
@@ -49,13 +46,11 @@ class StarRating
     void setStarCount(int starCount) { m_myStarCount = starCount; }
     void setMaxStarCount(int maxStarCount) { m_myMaxStarCount = maxStarCount; }
 
-
-private:
+  private:
     QPolygonF m_starPolygon;
     QPolygonF m_diamondPolygon;
     int m_myStarCount;
     int m_myMaxStarCount;
-
 };
 
 Q_DECLARE_METATYPE(StarRating)

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -76,9 +76,7 @@ void WStarRating::paintEvent(QPaintEvent *) {
     painter.setBrush(option.palette.text());
     painter.drawPrimitive(QStyle::PE_Widget, option);
 
-    m_starRating.paint(&painter, m_contentRect, option.palette,
-                       StarRating::ReadOnly,
-                       option.state & QStyle::State_Selected);
+    m_starRating.paint(&painter, m_contentRect);
 }
 
 void WStarRating::mouseMoveEvent(QMouseEvent *event) {


### PR DESCRIPTION
Uses the same tricks from #428 and cleans up the brush settings in StarDelegate.
