### PR TITLE
"no-op" refactor of slider logic into an event handler

### DIFF
--- a/res/skins/LateNight/mixer.xml
+++ b/res/skins/LateNight/mixer.xml
@@ -105,9 +105,9 @@
 											<Template src="skin:mixer_channel.xml">
 												<SetVariable name="channum">1</SetVariable>
 											</Template>
-											<!-- <Template src="skin:mixer_channel_reversed.xml">
+											<Template src="skin:mixer_channel_reversed.xml">
 												<SetVariable name="channum">2</SetVariable>
-											</Template> -->
+											</Template>
 				                           <WidgetGroup>
 				                                <SizePolicy>max,min</SizePolicy>
 		                                        <Layout>horizontal</Layout>
@@ -123,7 +123,7 @@
 		                                    </WidgetGroup>
 										</Children>
 									</WidgetGroup>
-									<!-- <WidgetGroup>
+									<WidgetGroup>
 									    <ObjectName>CrossFadeContainer</ObjectName>
 										<Layout>horizontal</Layout>
 										<SizePolicy>me,max</SizePolicy>
@@ -146,7 +146,7 @@
 												</Children>
 											</WidgetGroup>
 										</Children>
-									</WidgetGroup> -->
+									</WidgetGroup>
 								</Children>
 							</WidgetGroup>
 							<WidgetGroup>

--- a/res/skins/LateNight/mixer.xml
+++ b/res/skins/LateNight/mixer.xml
@@ -105,9 +105,9 @@
 											<Template src="skin:mixer_channel.xml">
 												<SetVariable name="channum">1</SetVariable>
 											</Template>
-											<Template src="skin:mixer_channel_reversed.xml">
+											<!-- <Template src="skin:mixer_channel_reversed.xml">
 												<SetVariable name="channum">2</SetVariable>
-											</Template>
+											</Template> -->
 				                           <WidgetGroup>
 				                                <SizePolicy>max,min</SizePolicy>
 		                                        <Layout>horizontal</Layout>
@@ -123,7 +123,7 @@
 		                                    </WidgetGroup>
 										</Children>
 									</WidgetGroup>
-									<WidgetGroup>
+									<!-- <WidgetGroup>
 									    <ObjectName>CrossFadeContainer</ObjectName>
 										<Layout>horizontal</Layout>
 										<SizePolicy>me,max</SizePolicy>
@@ -146,7 +146,7 @@
 												</Children>
 											</WidgetGroup>
 										</Children>
-									</WidgetGroup>
+									</WidgetGroup> -->
 								</Children>
 							</WidgetGroup>
 							<WidgetGroup>

--- a/src/widget/slidereventhandler.h
+++ b/src/widget/slidereventhandler.h
@@ -77,7 +77,6 @@ class SliderEventHandler {
         } else {
             if (e->button() == Qt::RightButton) {
                 pWidget->resetControlParameter();
-                pWidget->update();
                 m_bRightButtonPressed = true;
             } else {
                 if (m_bHorizontal) {
@@ -111,12 +110,12 @@ class SliderEventHandler {
         newParameter = math_clamp_unsafe(newParameter, 0.0, 1.0);
 
         pWidget->setControlParameter(newParameter);
-        onConnectedControlChanged(pWidget, newParameter, 0);
+        onConnectedControlChanged(pWidget, newParameter);
         pWidget->update();
         e->accept();
     }
 
-    void onConnectedControlChanged(T* pWidget, double dParameter, double) {
+    void onConnectedControlChanged(T* pWidget, double dParameter) {
         // WARNING: The second parameter to this method is unused and called with
         // invalid values in parts of WSliderComposed. Do not use it unless you fix
         // this.
@@ -194,9 +193,6 @@ class SliderEventHandler {
     bool m_bDrag;
     // Is true if events is emitted while the slider is dragged
     bool m_bEventWhileDrag;
-
-    // Starting point when left mouse button is pressed
-    QPoint m_startPos;
 };
 
 #endif /* SLIDEREVENTHANDLER_H */

--- a/src/widget/slidereventhandler.h
+++ b/src/widget/slidereventhandler.h
@@ -16,7 +16,7 @@ class SliderEventHandler {
             : m_dStartHandlePos(0),
               m_dStartMousePos(0),
               m_bRightButtonPressed(false),
-              m_dOldCOValue(-1.0), // virgin
+              m_dOldParameter(-1.0), // virgin
               m_dPos(0.0),
               m_dHandleLength(0),
               m_dSliderLength(0),
@@ -52,15 +52,15 @@ class SliderEventHandler {
 
             // Clamp to the range [0, sliderLength - m_dHandleLength].
             m_dPos = math_clamp_unsafe(m_dPos, 0.0, m_dSliderLength - m_dHandleLength);
-            double newCOValue = positionToValue(m_dPos);
+            double newParameter = positionToParameter(m_dPos);
 
             // If we don't change this, then updates might be rejected in
             // onConnectedControlChanged.
-            m_dOldCOValue = newCOValue;
+            m_dOldParameter = newParameter;
 
             // Emit valueChanged signal
             if (m_bEventWhileDrag) {
-                pWidget->setControlParameter(newCOValue);
+                pWidget->setControlParameter(newParameter);
             }
 
             // Update display
@@ -98,20 +98,20 @@ class SliderEventHandler {
         if (e->button() == Qt::RightButton) {
             m_bRightButtonPressed = false;
         } else {
-            pWidget->setControlParameter(m_dOldCOValue);
+            pWidget->setControlParameter(m_dOldParameter);
         }
     }
 
     void wheelEvent(T* pWidget, QWheelEvent* e) {
         // For legacy (MIDI) reasons this is tuned to 127.
         double wheelAdjustment = ((QWheelEvent *)e)->delta() / (120.0 * 127.0);
-        double newValue = pWidget->getControlParameter() + wheelAdjustment;
+        double newParameter = pWidget->getControlParameter() + wheelAdjustment;
 
         // Clamp to [0.0, 1.0]
-        newValue = math_clamp_unsafe(newValue, 0.0, 1.0);
+        newParameter = math_clamp_unsafe(newParameter, 0.0, 1.0);
 
-        pWidget->setControlParameter(newValue);
-        onConnectedControlChanged(pWidget, newValue, 0);
+        pWidget->setControlParameter(newParameter);
+        onConnectedControlChanged(pWidget, newParameter, 0);
         pWidget->update();
         e->accept();
     }
@@ -128,10 +128,10 @@ class SliderEventHandler {
             return;
         }
 
-        if (m_dOldCOValue != dParameter) {
-            m_dOldCOValue = dParameter;
+        if (m_dOldParameter != dParameter) {
+            m_dOldParameter = dParameter;
 
-            double newPos = valueToPosition(dParameter);
+            double newPos = parameterToPosition(dParameter);
 
             // Clamp to [0.0, sliderLength - m_dHandleLength].
             newPos = math_clamp_unsafe(newPos, 0.0, m_dSliderLength - m_dHandleLength);
@@ -151,20 +151,20 @@ class SliderEventHandler {
     void resizeEvent(T* pWidget, QResizeEvent* pEvent) {
         Q_UNUSED(pEvent);
         // m_dSliderLength and m_dHandleLength are explicitly updated.
-        m_dPos = valueToPosition(pWidget->getControlParameter());
-        m_dOldCOValue = -1;
+        m_dPos = parameterToPosition(pWidget->getControlParameter());
+        m_dOldParameter = -1;
     }
 
-    // Convert CO value to a handle pixel position.
-    double valueToPosition(double value) const {
+    // Convert CO parameter value to a handle pixel position.
+    double parameterToPosition(double parameter) const {
         if (!m_bHorizontal) {
-            value = 1.0 - value;
+            parameter = 1.0 - parameter;
         }
-        return value * (m_dSliderLength - m_dHandleLength);
+        return parameter * (m_dSliderLength - m_dHandleLength);
     }
 
-    // Convert handle pixel position to a CO value.
-    double positionToValue(double pos) const {
+    // Convert handle pixel position to a CO parameter value.
+    double positionToParameter(double pos) const {
         double val = pos / (m_dSliderLength - m_dHandleLength);
         if (!m_bHorizontal) {
             return 1.0 - val;
@@ -180,8 +180,8 @@ class SliderEventHandler {
     double m_dStartMousePos;
     // True while right mouse button is pressed.
     bool m_bRightButtonPressed;
-    // Previous value of the control object, 0 to 1
-    double m_dOldCOValue;
+    // Previous parameter value of the control object, 0 to 1
+    double m_dOldParameter;
     // Internal storage of slider position in pixels
     double m_dPos;
     // Length of handle in pixels

--- a/src/widget/slidereventhandler.h
+++ b/src/widget/slidereventhandler.h
@@ -1,0 +1,217 @@
+#ifndef SLIDEREVENTHANDLER_H
+#define SLIDEREVENTHANDLER_H
+
+#include <QMouseEvent>
+#include <QWheelEvent>
+#include <QCursor>
+#include <QApplication>
+#include <QPoint>
+
+#include "util/math.h"
+
+template <class T>
+class SliderEventHandler {
+  public:
+    SliderEventHandler()
+            : m_dStartHandlePos(0),
+              m_dStartMousePos(0),
+              m_bRightButtonPressed(false),
+              m_dOldValue(-1.0), // virgin
+              m_dPos(1.0),
+              m_dHandleLength(0),
+              m_dSliderLength(0),
+              m_bHorizontal(false),
+              m_bDrag(false),
+              m_bEventWhileDrag(true) {
+    }
+
+    void setHorizontal(bool horiz) {
+        m_bHorizontal = horiz;
+    }
+
+    void setHandleLength(double len) {
+        m_dHandleLength = len;
+    }
+
+    void setEventWhileDrag(bool eventwhile) {
+        m_bEventWhileDrag = eventwhile;
+    }
+
+    void mouseMoveEvent(T* pWidget, QMouseEvent* e) {
+        if (!m_bRightButtonPressed) {
+            if (m_bHorizontal) {
+                m_dPos = e->x() - m_dHandleLength / 2;
+            } else {
+                m_dPos = e->y() - m_dHandleLength / 2;
+            }
+
+            qDebug() << "start " << m_dStartHandlePos << ", pos " << m_dPos;
+            m_dPos = m_dStartHandlePos + (m_dPos - m_dStartMousePos);
+
+            //double sliderLength = m_bHorizontal ? pWidget->width() : pWidget->height();
+
+            // Clamp to the range [0, sliderLength - m_dHandleLength].
+            m_dPos = math_clamp_unsafe(m_dPos, 0.0, m_dSliderLength - m_dHandleLength);
+
+            // Divide by (sliderLength - m_dHandleLength) to produce a normalized
+            // value in the range of [0.0, 1.0].
+            double newValue = normalizePos(pWidget);
+            qDebug() << "new val1 " << newValue;
+            if (!m_bHorizontal) {
+                newValue = 1.0 - newValue;
+            }
+            qDebug() << "newVal2 " << newValue;
+
+            // If we don't change this, then updates might be rejected in
+            // onConnectedControlChanged.
+            m_dOldValue = newValue;
+
+            // Emit valueChanged signal
+            if (m_bEventWhileDrag) {
+                qDebug() << "EVENT WHILE DRAG " << newValue;
+                pWidget->setControlParameter(newValue);
+            }
+
+            // Update display
+            pWidget->update();
+        }
+    }
+
+    void mousePressEvent(T* pWidget, QMouseEvent* e) {
+        if (!m_bEventWhileDrag) {
+            m_dStartMousePos = 0;
+            m_dStartHandlePos = 0;
+            pWidget->mouseMoveEvent(e);
+            m_bDrag = true;
+        } else {
+            if (e->button() == Qt::RightButton) {
+                pWidget->setControlParameter(0.0);
+                onConnectedControlChanged(pWidget, 0.0, 0);
+                pWidget->update();
+                m_bRightButtonPressed = true;
+            } else {
+                if (m_bHorizontal) {
+                    m_dStartMousePos = e->x() - m_dHandleLength / 2;
+                } else {
+                    m_dStartMousePos = e->y() - m_dHandleLength / 2;
+                }
+                m_dStartHandlePos = m_dPos;
+                qDebug() << "start handle pos is " << m_dStartHandlePos;
+            }
+        }
+    }
+
+    void mouseReleaseEvent(T* pWidget, QMouseEvent* e) {
+        if (!m_bEventWhileDrag) {
+            pWidget->mouseMoveEvent(e);
+            m_bDrag = false;
+        }
+        if (e->button() == Qt::RightButton) {
+            m_bRightButtonPressed = false;
+        } else {
+            qDebug() << "old value " << m_dOldValue;
+            pWidget->setControlParameter(m_dOldValue);
+        }
+    }
+
+    void wheelEvent(T* pWidget, QWheelEvent* e) {
+        // For legacy (MIDI) reasons this is tuned to 127.
+        double wheelDirection = ((QWheelEvent *)e)->delta() / (120.0 * 127.0);
+//        if (!m_bHorizontal) {
+//            wheelDirection *= -1;
+//        }
+        double newValue = pWidget->getControlParameter() + wheelDirection;
+        qDebug() << "wheel: " << pWidget->getControlParameter() << " " << newValue;
+
+        // Clamp to [0.0, 1.0]
+        newValue = math_clamp_unsafe(newValue, 0.0, 1.0);
+
+        qDebug() << "value is now " << newValue;
+        pWidget->setControlParameter(newValue);
+        //pWidget->onConnectedControlChanged(newValue, 0);
+        pWidget->update();
+        e->accept();
+    }
+
+    void onConnectedControlChanged(T* pWidget, double dParameter, double) {
+        // WARNING: The second parameter to this method is unused and called with
+        // invalid values in parts of WSliderComposed. Do not use it unless you fix
+        // this.
+
+        // We don't update slider values while you're dragging them. This way you
+        // don't have to "fight" with a controller that is also changing the
+        // control.
+        if (m_bDrag) {
+            return;
+        }
+
+        if (m_dOldValue != dParameter) {
+            qDebug() << "UPDATING SLIDER " << dParameter;
+            m_dOldValue = dParameter;
+
+            // Calculate handle position
+            if (!m_bHorizontal) {
+                dParameter = 1.0 - dParameter;
+            }
+            //double sliderLength = m_bHorizontal ? pWidget->width() : pWidget->height();
+
+            double newPos = dParameter * (m_dSliderLength - m_dHandleLength);
+
+            // Clamp to [0.0, sliderLength - m_dHandleLength].
+            newPos = math_clamp_unsafe(newPos, 0.0, m_dSliderLength - m_dHandleLength);
+
+            // Check a second time for no-ops. It's possible the parameter changed
+            // but the visible pixmap didn't. Only update() the widget if we're
+            // really sure we need to since this involves painting ALL of its
+            // parents.
+            if (newPos != m_dPos) {
+                m_dPos = newPos;
+                qDebug() << "pos now " << m_dPos;
+                pWidget->setControlParameter(dParameter);
+                pWidget->update();
+            }
+        }
+    }
+
+    void resizeEvent(T* pWidget, QResizeEvent* pEvent) {
+        Q_UNUSED(pEvent);
+        qDebug () << "RESIZE";
+        m_dOldValue = -1;
+        m_dPos = -1;
+        m_dSliderLength = m_bHorizontal ? pWidget->width() : pWidget->height();
+    }
+
+  private:
+    double normalizePos(T* pWidget) {
+        if (m_dSliderLength <= 0) {
+            m_dSliderLength = m_bHorizontal ? pWidget->width() : pWidget->height();
+        }
+        qDebug() << "normalized pos " << m_dPos << m_dSliderLength << " "
+                << m_dHandleLength << " to " << m_dPos / (m_dSliderLength - m_dHandleLength);
+        return m_dPos / (m_dSliderLength - m_dHandleLength);
+    }
+
+
+    // Internal storage of slider position in pixels
+    double m_dStartHandlePos, m_dStartMousePos;
+    // True if right mouse button is pressed.
+    bool m_bRightButtonPressed;
+    // Previous value of the control object, 0 to 1
+    double m_dOldValue;
+    // Internal storage of slider position in pixels
+    double m_dPos;
+    // Length of handle in pixels
+    double m_dHandleLength;
+    double m_dSliderLength;
+    // True if it's a horizontal slider
+    bool m_bHorizontal;
+    // True if slider is dragged. Only used when m_bEventWhileDrag is false
+    bool m_bDrag;
+    // Is true if events is emitted while the slider is dragged
+    bool m_bEventWhileDrag;
+
+    // Starting point when left mouse button is pressed
+    QPoint m_startPos;
+};
+
+#endif /* SLIDEREVENTHANDLER_H */

--- a/src/widget/slidereventhandler.h
+++ b/src/widget/slidereventhandler.h
@@ -22,9 +22,7 @@ class SliderEventHandler {
               m_dSliderLength(0),
               m_bHorizontal(false),
               m_bDrag(false),
-              m_bEventWhileDrag(true) {
-        qDebug() << "dpos now111 " << m_dPos;
-    }
+              m_bEventWhileDrag(true) { }
 
     void setHorizontal(bool horiz) {
         m_bHorizontal = horiz;
@@ -34,45 +32,35 @@ class SliderEventHandler {
         m_dHandleLength = len;
     }
 
+    void setSliderLength(double len) {
+        m_dSliderLength = len;
+    }
+
     void setEventWhileDrag(bool eventwhile) {
         m_bEventWhileDrag = eventwhile;
     }
 
     void mouseMoveEvent(T* pWidget, QMouseEvent* e) {
         if (!m_bRightButtonPressed) {
-            double abs_pos = 0.0;
             if (m_bHorizontal) {
-                abs_pos = e->x() - m_dHandleLength / 2;
+                m_dPos = e->x() - m_dHandleLength / 2;
             } else {
-                abs_pos = e->y() - m_dHandleLength / 2;
+                m_dPos = e->y() - m_dHandleLength / 2;
             }
 
-            qDebug() << "start " << m_dStartHandlePos << ", abs pos " << abs_pos;
-            m_dPos = m_dStartHandlePos + (abs_pos - m_dStartMousePos);
-            qDebug() << "new dpos " << m_dPos;
-
-            //double sliderLength = m_bHorizontal ? pWidget->width() : pWidget->height();
+            m_dPos = m_dStartHandlePos + (m_dPos - m_dStartMousePos);
 
             // Clamp to the range [0, sliderLength - m_dHandleLength].
             m_dPos = math_clamp_unsafe(m_dPos, 0.0, m_dSliderLength - m_dHandleLength);
-            qDebug() << "clamped dpos " << m_dPos;
-
-            // Divide by (sliderLength - m_dHandleLength) to produce a normalized
-            // value in the range of [0.0, 1.0].
-            double newValue = positionToValue(pWidget);
-            if (!m_bHorizontal) {
-                newValue = 1.0 - newValue;
-            }
-            qDebug() << "new CO val " << newValue;
+            double newCOValue = positionToValue(m_dPos);
 
             // If we don't change this, then updates might be rejected in
             // onConnectedControlChanged.
-            m_dOldCOValue = newValue;
+            m_dOldCOValue = newCOValue;
 
             // Emit valueChanged signal
             if (m_bEventWhileDrag) {
-                qDebug() << "EVENT WHILE DRAG " << newValue;
-                pWidget->setControlParameter(newValue);
+                pWidget->setControlParameter(newCOValue);
             }
 
             // Update display
@@ -88,20 +76,16 @@ class SliderEventHandler {
             m_bDrag = true;
         } else {
             if (e->button() == Qt::RightButton) {
-//                pWidget->setControlParameter(1.0);
-//                onConnectedControlChanged(pWidget, 1.0, 0);
                 pWidget->resetControlParameter();
                 pWidget->update();
                 m_bRightButtonPressed = true;
             } else {
-                qDebug() << "get start pos " << e->y() << " " << m_dHandleLength / 2;
                 if (m_bHorizontal) {
                     m_dStartMousePos = e->x() - m_dHandleLength / 2;
                 } else {
                     m_dStartMousePos = e->y() - m_dHandleLength / 2;
                 }
                 m_dStartHandlePos = m_dPos;
-                qDebug() << "start handle pos is " << m_dStartHandlePos;
             }
         }
     }
@@ -114,7 +98,6 @@ class SliderEventHandler {
         if (e->button() == Qt::RightButton) {
             m_bRightButtonPressed = false;
         } else {
-            qDebug() << "restore old value " << m_dOldCOValue;
             pWidget->setControlParameter(m_dOldCOValue);
         }
     }
@@ -123,12 +106,10 @@ class SliderEventHandler {
         // For legacy (MIDI) reasons this is tuned to 127.
         double wheelAdjustment = ((QWheelEvent *)e)->delta() / (120.0 * 127.0);
         double newValue = pWidget->getControlParameter() + wheelAdjustment;
-        qDebug() << "wheel: " << pWidget->getControlParameter() << "--> " << newValue;
 
         // Clamp to [0.0, 1.0]
         newValue = math_clamp_unsafe(newValue, 0.0, 1.0);
 
-        qDebug() << "CO value is now " << newValue;
         pWidget->setControlParameter(newValue);
         onConnectedControlChanged(pWidget, newValue, 0);
         pWidget->update();
@@ -147,16 +128,10 @@ class SliderEventHandler {
             return;
         }
 
-        qDebug() << "got an update " << dParameter;
-
         if (m_dOldCOValue != dParameter) {
-            qDebug() << "UPDATING SLIDER " << dParameter;
             m_dOldCOValue = dParameter;
 
-            qDebug() << "parameter now " << dParameter;
-            //double sliderLength = m_bHorizontal ? pWidget->width() : pWidget->height();
-
-            double newPos = valueToPosition(pWidget, dParameter);
+            double newPos = valueToPosition(dParameter);
 
             // Clamp to [0.0, sliderLength - m_dHandleLength].
             newPos = math_clamp_unsafe(newPos, 0.0, m_dSliderLength - m_dHandleLength);
@@ -167,7 +142,6 @@ class SliderEventHandler {
             // parents.
             if (newPos != m_dPos) {
                 m_dPos = newPos;
-                qDebug() << "dpos now " << m_dPos;
                 pWidget->setControlParameter(dParameter);
                 pWidget->update();
             }
@@ -176,39 +150,35 @@ class SliderEventHandler {
 
     void resizeEvent(T* pWidget, QResizeEvent* pEvent) {
         Q_UNUSED(pEvent);
-        qDebug () << "RESIZE";
-        m_dSliderLength = m_bHorizontal ? pWidget->width() : pWidget->height();
-        m_dPos = valueToPosition(pWidget, pWidget->getControlParameter());
+        // m_dSliderLength and m_dHandleLength are explicitly updated.
+        m_dPos = valueToPosition(pWidget->getControlParameter());
         m_dOldCOValue = -1;
-        qDebug() << "dpos now " << m_dPos;
     }
 
-  private:
-    double valueToPosition(T* pWidget, double value) {
-        if (m_dSliderLength <= 0) {
-            m_dSliderLength = m_bHorizontal ? pWidget->width() : pWidget->height();
-        }
+    // Convert CO value to a handle pixel position.
+    double valueToPosition(double value) const {
         if (!m_bHorizontal) {
             value = 1.0 - value;
         }
-        qDebug() << "eventhandler denormalized " << value << " " << m_dSliderLength << " "
-                << m_dHandleLength << " " << (value * (m_dSliderLength - m_dHandleLength));
         return value * (m_dSliderLength - m_dHandleLength);
     }
 
-    double positionToValue(T* pWidget) {
-        if (m_dSliderLength <= 0) {
-            m_dSliderLength = m_bHorizontal ? pWidget->width() : pWidget->height();
+    // Convert handle pixel position to a CO value.
+    double positionToValue(double pos) const {
+        double val = pos / (m_dSliderLength - m_dHandleLength);
+        if (!m_bHorizontal) {
+            return 1.0 - val;
         }
-        qDebug() << "convert pos to CO val " << m_dPos << m_dSliderLength << " "
-                << m_dHandleLength << " to " << m_dPos / (m_dSliderLength - m_dHandleLength);
-        return m_dPos / (m_dSliderLength - m_dHandleLength);
+        return val;
     }
 
-
-    // Internal storage of slider position in pixels
-    double m_dStartHandlePos, m_dStartMousePos;
-    // True if right mouse button is pressed.
+  private:
+    // This is the position the handle was when a drag started.
+    double m_dStartHandlePos;
+    // We record where the mouse was when the user started clicking so they
+    // don't need to perfectly grab the slider handle.
+    double m_dStartMousePos;
+    // True while right mouse button is pressed.
     bool m_bRightButtonPressed;
     // Previous value of the control object, 0 to 1
     double m_dOldCOValue;
@@ -216,10 +186,11 @@ class SliderEventHandler {
     double m_dPos;
     // Length of handle in pixels
     double m_dHandleLength;
+    // Length of the slider in pixels
     double m_dSliderLength;
     // True if it's a horizontal slider
     bool m_bHorizontal;
-    // True if slider is dragged. Only used when m_bEventWhileDrag is false
+    // True if slider is being dragged. Only used when m_bEventWhileDrag is false
     bool m_bDrag;
     // Is true if events is emitted while the slider is dragged
     bool m_bEventWhileDrag;

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -154,7 +154,7 @@ void WSliderComposed::paintEvent(QPaintEvent *) {
     }
 
     if (!m_pHandle.isNull() && !m_pHandle->isNull()) {
-        double drawPos = denormalizePos(1.0 - getControlParameterDisplay());
+        double drawPos = valueToPosition(getControlParameterDisplay());
         qDebug() << "Drawing! " << drawPos;
         if (m_bHorizontal) {
             // Stretch the pixmap to be the height of the widget.

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -155,7 +155,7 @@ void WSliderComposed::paintEvent(QPaintEvent *) {
 
     if (!m_pHandle.isNull() && !m_pHandle->isNull()) {
         double drawPos = valueToPosition(getControlParameterDisplay());
-        qDebug() << "Drawing! " << drawPos;
+        qDebug() << "Drawing! " << getControlParameterDisplay() << " at pos " << drawPos;
         if (m_bHorizontal) {
             // Stretch the pixmap to be the height of the widget.
             QRectF targetRect(drawPos, 0, m_dHandleLength, height());
@@ -191,6 +191,7 @@ void WSliderComposed::resizeEvent(QResizeEvent* pEvent) {
             m_dHandleLength = m_pHandle->height();
         }
     }
+    m_dSliderLength = m_bHorizontal ? width() : height();
     m_handler.setHandleLength(m_dHandleLength);
 
     // Re-calculate state based on our new width/height.

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -154,8 +154,7 @@ void WSliderComposed::paintEvent(QPaintEvent *) {
     }
 
     if (!m_pHandle.isNull() && !m_pHandle->isNull()) {
-        double drawPos = valueToPosition(getControlParameterDisplay());
-        qDebug() << "Drawing! " << getControlParameterDisplay() << " at pos " << drawPos;
+        double drawPos = m_handler.valueToPosition(getControlParameterDisplay());
         if (m_bHorizontal) {
             // Stretch the pixmap to be the height of the widget.
             QRectF targetRect(drawPos, 0, m_dHandleLength, height());
@@ -170,7 +169,6 @@ void WSliderComposed::paintEvent(QPaintEvent *) {
 
 void WSliderComposed::resizeEvent(QResizeEvent* pEvent) {
     Q_UNUSED(pEvent);
-    m_handler.resizeEvent(this, pEvent);
 
     if (m_bHorizontal) {
         // Stretch the pixmap to be the height of the widget.
@@ -192,7 +190,9 @@ void WSliderComposed::resizeEvent(QResizeEvent* pEvent) {
         }
     }
     m_dSliderLength = m_bHorizontal ? width() : height();
+    m_handler.setSliderLength(m_dSliderLength);
     m_handler.setHandleLength(m_dHandleLength);
+    m_handler.resizeEvent(this, pEvent);
 
     // Re-calculate state based on our new width/height.
     onConnectedControlChanged(getControlParameter(), 0);
@@ -206,7 +206,8 @@ void WSliderComposed::fillDebugTooltip(QStringList* debug) {
     WWidget::fillDebugTooltip(debug);
     int sliderLength = m_bHorizontal ? width() : height();
     *debug << QString("Horizontal: %1").arg(toDebugString(m_bHorizontal))
-           << QString("SliderPosition: %1").arg(getControlParameterDisplay())
+           << QString("SliderPosition: %1").arg(
+                   m_handler.valueToPosition(getControlParameterDisplay()))
            << QString("SliderLength: %1").arg(sliderLength)
            << QString("HandleLength: %1").arg(m_dHandleLength);
 }

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -90,32 +90,13 @@ void WSliderComposed::setHandlePixmap(bool bHorizontal,
                                       PixmapSource sourceHandle,
                                       Paintable::DrawMode mode) {
     m_bHorizontal = bHorizontal;
+    m_handler.setHorizontal(m_bHorizontal);
     m_pHandle = WPixmapStore::getPaintable(sourceHandle, mode);
     m_dHandleLength = calculateHandleLength();
+    m_handler.setHandleLength(m_dHandleLength);
     if (!m_pHandle) {
         qDebug() << "WSliderComposed: Error loading handle pixmap:" << sourceHandle.getPath();
     } else {
-        if (m_bHorizontal) {
-            // Stretch the pixmap to be the height of the widget.
-            if (m_pHandle->height() != 0.0) {
-                const qreal aspect = static_cast<double>(m_pHandle->width()) /
-                        static_cast<double>(m_pHandle->height());
-                m_dHandleLength = aspect * height();
-            } else {
-                m_dHandleLength = m_pHandle->width();
-            }
-        } else {
-            // Stretch the pixmap to be the width of the widget.
-            if (m_pHandle->width() != 0.0) {
-                const qreal aspect = static_cast<double>(m_pHandle->height()) /
-                        static_cast<double>(m_pHandle->width());
-                m_dHandleLength = aspect * width();
-            } else {
-                m_dHandleLength = m_pHandle->height();
-            }
-        }
-        m_handler.setHandleLength(m_dHandleLength);
-
         // Value is unused in WSliderComposed.
         onConnectedControlChanged(getControlParameter(), 0);
         update();
@@ -156,11 +137,11 @@ void WSliderComposed::paintEvent(QPaintEvent *) {
     if (!m_pHandle.isNull() && !m_pHandle->isNull()) {
         double drawPos = m_handler.valueToPosition(getControlParameterDisplay());
         if (m_bHorizontal) {
-            // Stretch the pixmap to be the height of the widget.
+            // The handle's draw mode determines whether it is stretched.
             QRectF targetRect(drawPos, 0, m_dHandleLength, height());
             m_pHandle->draw(targetRect, &p);
         } else {
-            // Stretch the pixmap to be the width of the widget.
+            // The handle's draw mode determines whether it is stretched.
             QRectF targetRect(0, drawPos, width(), m_dHandleLength);
             m_pHandle->draw(targetRect, &p);
         }
@@ -170,28 +151,10 @@ void WSliderComposed::paintEvent(QPaintEvent *) {
 void WSliderComposed::resizeEvent(QResizeEvent* pEvent) {
     Q_UNUSED(pEvent);
 
-    if (m_bHorizontal) {
-        // Stretch the pixmap to be the height of the widget.
-        if (m_pHandle->height() != 0.0) {
-            const qreal aspect = static_cast<double>(m_pHandle->width()) /
-                    static_cast<double>(m_pHandle->height());
-            m_dHandleLength = aspect * height();
-        } else {
-            m_dHandleLength = m_pHandle->width();
-        }
-    } else {
-        // Stretch the pixmap to be the width of the widget.
-        if (m_pHandle->width() != 0.0) {
-            const qreal aspect = static_cast<double>(m_pHandle->height()) /
-                    static_cast<double>(m_pHandle->width());
-            m_dHandleLength = aspect * width();
-        } else {
-            m_dHandleLength = m_pHandle->height();
-        }
-    }
+    m_dHandleLength = calculateHandleLength();
+    m_handler.setHandleLength(m_dHandleLength);
     m_dSliderLength = m_bHorizontal ? width() : height();
     m_handler.setSliderLength(m_dSliderLength);
-    m_handler.setHandleLength(m_dHandleLength);
     m_handler.resizeEvent(this, pEvent);
 
     // Re-calculate state based on our new width/height.

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -28,15 +28,7 @@
 
 WSliderComposed::WSliderComposed(QWidget * parent)
     : WWidget(parent),
-      m_dOldValue(-1.0), // virgin
-      m_bRightButtonPressed(false),
-      m_dPos(0),
-      m_dStartHandlePos(0),
-      m_dStartMousePos(0),
       m_dHandleLength(0),
-      m_bHorizontal(false),
-      m_bEventWhileDrag(true),
-      m_bDrag(false),
       m_pSlider(NULL),
       m_pHandle(NULL) {
 }
@@ -67,7 +59,7 @@ void WSliderComposed::setup(QDomNode node, const SkinContext& context) {
 
     if (context.hasNode(node, "EventWhileDrag")) {
         if (context.selectString(node, "EventWhileDrag").contains("no")) {
-            m_bEventWhileDrag = false;
+            m_handler.setEventWhileDrag(false);
         }
     }
     if (!m_connections.isEmpty()) {
@@ -103,6 +95,27 @@ void WSliderComposed::setHandlePixmap(bool bHorizontal,
     if (!m_pHandle) {
         qDebug() << "WSliderComposed: Error loading handle pixmap:" << sourceHandle.getPath();
     } else {
+        if (m_bHorizontal) {
+            // Stretch the pixmap to be the height of the widget.
+            if (m_pHandle->height() != 0.0) {
+                const qreal aspect = static_cast<double>(m_pHandle->width()) /
+                        static_cast<double>(m_pHandle->height());
+                m_dHandleLength = aspect * height();
+            } else {
+                m_dHandleLength = m_pHandle->width();
+            }
+        } else {
+            // Stretch the pixmap to be the width of the widget.
+            if (m_pHandle->width() != 0.0) {
+                const qreal aspect = static_cast<double>(m_pHandle->height()) /
+                        static_cast<double>(m_pHandle->width());
+                m_dHandleLength = aspect * width();
+            } else {
+                m_dHandleLength = m_pHandle->height();
+            }
+        }
+        m_handler.setHandleLength(m_dHandleLength);
+
         // Value is unused in WSliderComposed.
         onConnectedControlChanged(getControlParameter(), 0);
         update();
@@ -115,91 +128,19 @@ void WSliderComposed::unsetPixmaps() {
 }
 
 void WSliderComposed::mouseMoveEvent(QMouseEvent * e) {
-    if (!m_bRightButtonPressed) {
-        if (m_bHorizontal) {
-            m_dPos = e->x() - m_dHandleLength / 2;
-        } else {
-            m_dPos = e->y() - m_dHandleLength / 2;
-        }
-
-        //qDebug() << "start " << m_dStartPos << ", pos " << m_dPos;
-        m_dPos = m_dStartHandlePos + (m_dPos - m_dStartMousePos);
-
-        double sliderLength = m_bHorizontal ? width() : height();
-
-        // Clamp to the range [0, sliderLength - m_dHandleLength].
-        m_dPos = math_clamp_unsafe(m_dPos, 0.0, sliderLength - m_dHandleLength);
-
-        // Divide by (sliderLength - m_dHandleLength) to produce a normalized
-        // value in the range of [0.0, 1.0].
-        double newValue = m_dPos / (sliderLength - m_dHandleLength);
-        if (!m_bHorizontal) {
-            newValue = 1.0 - newValue;
-        }
-
-        // If we don't change this, then updates might be rejected in
-        // onConnectedControlChanged.
-        m_dOldValue = newValue;
-
-        // Emit valueChanged signal
-        if (m_bEventWhileDrag) {
-            setControlParameter(newValue);
-        }
-
-        // Update display
-        update();
-    }
+    m_handler.mouseMoveEvent(this, e);
 }
 
 void WSliderComposed::wheelEvent(QWheelEvent *e) {
-    // For legacy (MIDI) reasons this is tuned to 127.
-    double wheelDirection = ((QWheelEvent *)e)->delta() / (120.0 * 127.0);
-    double newValue = m_dOldValue + wheelDirection;
-
-    // Clamp to [0.0, 1.0]
-    newValue = math_clamp_unsafe(newValue, 0.0, 1.0);
-
-    setControlParameter(newValue);
-    // Value is unused in WSliderComposed.
-    onConnectedControlChanged(newValue, 0);
-    update();
-
-    e->accept();
-
-    //e->ignore();
+    m_handler.wheelEvent(this, e);
 }
 
 void WSliderComposed::mouseReleaseEvent(QMouseEvent * e) {
-    if (!m_bEventWhileDrag) {
-        mouseMoveEvent(e);
-        m_bDrag = false;
-    }
-    if (e->button() == Qt::RightButton) {
-        m_bRightButtonPressed = false;
-    } else {
-        setControlParameter(m_dOldValue);
-    }
+    m_handler.mouseReleaseEvent(this, e);
 }
 
 void WSliderComposed::mousePressEvent(QMouseEvent * e) {
-    if (!m_bEventWhileDrag) {
-        m_dStartMousePos = 0;
-        m_dStartHandlePos = 0;
-        mouseMoveEvent(e);
-        m_bDrag = true;
-    } else {
-        if (e->button() == Qt::RightButton) {
-            resetControlParameter();
-            m_bRightButtonPressed = true;
-        } else {
-            if (m_bHorizontal) {
-                m_dStartMousePos = e->x() - m_dHandleLength / 2;
-            } else {
-                m_dStartMousePos = e->y() - m_dHandleLength / 2;
-            }
-            m_dStartHandlePos = m_dPos;
-        }
-    }
+    m_handler.mousePressEvent(this, e);
 }
 
 void WSliderComposed::paintEvent(QPaintEvent *) {
@@ -213,13 +154,15 @@ void WSliderComposed::paintEvent(QPaintEvent *) {
     }
 
     if (!m_pHandle.isNull() && !m_pHandle->isNull()) {
+        double drawPos = denormalizePos(1.0 - getControlParameterDisplay());
+        qDebug() << "Drawing! " << drawPos;
         if (m_bHorizontal) {
-            // The handle's draw mode determines whether it is stretched.
-            QRectF targetRect(m_dPos, 0, m_dHandleLength, height());
+            // Stretch the pixmap to be the height of the widget.
+            QRectF targetRect(drawPos, 0, m_dHandleLength, height());
             m_pHandle->draw(targetRect, &p);
         } else {
-            // The handle's draw mode determines whether it is stretched.
-            QRectF targetRect(0, m_dPos, width(), m_dHandleLength);
+            // Stretch the pixmap to be the width of the widget.
+            QRectF targetRect(0, drawPos, width(), m_dHandleLength);
             m_pHandle->draw(targetRect, &p);
         }
     }
@@ -227,56 +170,42 @@ void WSliderComposed::paintEvent(QPaintEvent *) {
 
 void WSliderComposed::resizeEvent(QResizeEvent* pEvent) {
     Q_UNUSED(pEvent);
-    m_dOldValue = -1;
-    m_dPos = -1;
-    m_dHandleLength = calculateHandleLength();
+    m_handler.resizeEvent(this, pEvent);
 
-    // Re-calculate m_dPos based on our new width/height.
+    if (m_bHorizontal) {
+        // Stretch the pixmap to be the height of the widget.
+        if (m_pHandle->height() != 0.0) {
+            const qreal aspect = static_cast<double>(m_pHandle->width()) /
+                    static_cast<double>(m_pHandle->height());
+            m_dHandleLength = aspect * height();
+        } else {
+            m_dHandleLength = m_pHandle->width();
+        }
+    } else {
+        // Stretch the pixmap to be the width of the widget.
+        if (m_pHandle->width() != 0.0) {
+            const qreal aspect = static_cast<double>(m_pHandle->height()) /
+                    static_cast<double>(m_pHandle->width());
+            m_dHandleLength = aspect * width();
+        } else {
+            m_dHandleLength = m_pHandle->height();
+        }
+    }
+    m_handler.setHandleLength(m_dHandleLength);
+
+    // Re-calculate state based on our new width/height.
     onConnectedControlChanged(getControlParameter(), 0);
 }
 
-void WSliderComposed::onConnectedControlChanged(double dParameter, double) {
-    // WARNING: The second parameter to this method is unused and called with
-    // invalid values in parts of WSliderComposed. Do not use it unless you fix
-    // this.
-
-    // We don't update slider values while you're dragging them. This way you
-    // don't have to "fight" with a controller that is also changing the
-    // control.
-    if (m_bDrag) {
-        return;
-    }
-
-    if (m_dOldValue != dParameter) {
-        m_dOldValue = dParameter;
-
-        // Calculate handle position
-        if (!m_bHorizontal) {
-            dParameter = 1.0 - dParameter;
-        }
-        double sliderLength = m_bHorizontal ? width() : height();
-
-        double newPos = dParameter * (sliderLength - m_dHandleLength);
-
-        // Clamp to [0.0, sliderLength - m_dHandleLength].
-        newPos = math_clamp_unsafe(newPos, 0.0, sliderLength - m_dHandleLength);
-
-        // Check a second time for no-ops. It's possible the parameter changed
-        // but the visible pixmap didn't. Only update() the widget if we're
-        // really sure we need to since this involves painting ALL of its
-        // parents.
-        if (newPos != m_dPos) {
-            m_dPos = newPos;
-            update();
-        }
-    }
+void WSliderComposed::onConnectedControlChanged(double dParameter, double x) {
+    m_handler.onConnectedControlChanged(this, dParameter, x);
 }
 
 void WSliderComposed::fillDebugTooltip(QStringList* debug) {
     WWidget::fillDebugTooltip(debug);
     int sliderLength = m_bHorizontal ? width() : height();
     *debug << QString("Horizontal: %1").arg(toDebugString(m_bHorizontal))
-           << QString("SliderPosition: %1").arg(m_dPos)
+           << QString("SliderPosition: %1").arg(getControlParameterDisplay())
            << QString("SliderLength: %1").arg(sliderLength)
            << QString("HandleLength: %1").arg(m_dHandleLength);
 }

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -135,7 +135,7 @@ void WSliderComposed::paintEvent(QPaintEvent *) {
     }
 
     if (!m_pHandle.isNull() && !m_pHandle->isNull()) {
-        double drawPos = m_handler.valueToPosition(getControlParameterDisplay());
+        double drawPos = m_handler.parameterToPosition(getControlParameterDisplay());
         if (m_bHorizontal) {
             // The handle's draw mode determines whether it is stretched.
             QRectF targetRect(drawPos, 0, m_dHandleLength, height());
@@ -161,8 +161,8 @@ void WSliderComposed::resizeEvent(QResizeEvent* pEvent) {
     onConnectedControlChanged(getControlParameter(), 0);
 }
 
-void WSliderComposed::onConnectedControlChanged(double dParameter, double x) {
-    m_handler.onConnectedControlChanged(this, dParameter, x);
+void WSliderComposed::onConnectedControlChanged(double dParameter, double) {
+    m_handler.onConnectedControlChanged(this, dParameter);
 }
 
 void WSliderComposed::fillDebugTooltip(QStringList* debug) {
@@ -170,7 +170,7 @@ void WSliderComposed::fillDebugTooltip(QStringList* debug) {
     int sliderLength = m_bHorizontal ? width() : height();
     *debug << QString("Horizontal: %1").arg(toDebugString(m_bHorizontal))
            << QString("SliderPosition: %1").arg(
-                   m_handler.valueToPosition(getControlParameterDisplay()))
+                   m_handler.parameterToPosition(getControlParameterDisplay()))
            << QString("SliderLength: %1").arg(sliderLength)
            << QString("HandleLength: %1").arg(m_dHandleLength);
 }

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -66,16 +66,19 @@ class WSliderComposed : public WWidget  {
     void unsetPixmaps();
 
     double valueToPosition(double value) {
-        int sliderLength = m_bHorizontal ? width() : height();
-        qDebug() << "denormalized " << value << " " << sliderLength << " "
-                << m_dHandleLength << " " << (value * (sliderLength - m_dHandleLength));
-        return (1.0 - value) * (sliderLength - m_dHandleLength);
+        if (!m_bHorizontal) {
+            value = 1.0 - value;
+        }
+        qDebug() << "denormalized " << value << " " << m_dSliderLength << " "
+                << m_dHandleLength << " " << (value * (m_dSliderLength - m_dHandleLength));
+        return value * (m_dSliderLength - m_dHandleLength);
     }
 
     // True if right mouse button is pressed.
     bool m_bRightButtonPressed;
     // Length of handle in pixels
     double m_dHandleLength;
+    double m_dSliderLength;
     // True if it's a horizontal slider
     bool m_bHorizontal;
     // Pointer to pixmap of the slider

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -65,11 +65,11 @@ class WSliderComposed : public WWidget  {
     double calculateHandleLength();
     void unsetPixmaps();
 
-    double denormalizePos(double pos) {
+    double valueToPosition(double value) {
         int sliderLength = m_bHorizontal ? width() : height();
-        qDebug() << "denormalized " << pos << " " << sliderLength << " "
-                << m_dHandleLength << " " << (pos * (sliderLength - m_dHandleLength));
-        return pos * (sliderLength - m_dHandleLength);
+        qDebug() << "denormalized " << value << " " << sliderLength << " "
+                << m_dHandleLength << " " << (value * (sliderLength - m_dHandleLength));
+        return (1.0 - value) * (sliderLength - m_dHandleLength);
     }
 
     // True if right mouse button is pressed.

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -26,6 +26,7 @@
 #include <QMouseEvent>
 #include <QResizeEvent>
 
+#include "widget/slidereventhandler.h"
 #include "widget/wwidget.h"
 #include "widget/wpixmapstore.h"
 #include "skin/skincontext.h"
@@ -64,23 +65,26 @@ class WSliderComposed : public WWidget  {
     double calculateHandleLength();
     void unsetPixmaps();
 
-    double m_dOldValue;
+    double denormalizePos(double pos) {
+        int sliderLength = m_bHorizontal ? width() : height();
+        qDebug() << "denormalized " << pos << " " << sliderLength << " "
+                << m_dHandleLength << " " << (pos * (sliderLength - m_dHandleLength));
+        return pos * (sliderLength - m_dHandleLength);
+    }
+
     // True if right mouse button is pressed.
     bool m_bRightButtonPressed;
-    // Internal storage of slider position in pixels
-    double m_dPos, m_dStartHandlePos, m_dStartMousePos;
     // Length of handle in pixels
     double m_dHandleLength;
     // True if it's a horizontal slider
     bool m_bHorizontal;
-    // Is true if events is emitted while the slider is dragged
-    bool m_bEventWhileDrag;
-    // True if slider is dragged. Only used when m_bEventWhileDrag is false
-    bool m_bDrag;
     // Pointer to pixmap of the slider
     PaintablePointer m_pSlider;
     // Pointer to pixmap of the handle
     PaintablePointer m_pHandle;
+    SliderEventHandler<WSliderComposed> m_handler;
+
+    friend class SliderEventHandler<WSliderComposed>;
 };
 
 #endif

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -65,19 +65,11 @@ class WSliderComposed : public WWidget  {
     double calculateHandleLength();
     void unsetPixmaps();
 
-    double valueToPosition(double value) {
-        if (!m_bHorizontal) {
-            value = 1.0 - value;
-        }
-        qDebug() << "denormalized " << value << " " << m_dSliderLength << " "
-                << m_dHandleLength << " " << (value * (m_dSliderLength - m_dHandleLength));
-        return value * (m_dSliderLength - m_dHandleLength);
-    }
-
     // True if right mouse button is pressed.
     bool m_bRightButtonPressed;
     // Length of handle in pixels
     double m_dHandleLength;
+    // Length of the slider in pixels.
     double m_dSliderLength;
     // True if it's a horizontal slider
     bool m_bHorizontal;


### PR DESCRIPTION
Move all of the logic for slider mouse event handling into a separate class, like with knobeventhandler.  This will make it easier to test sliders and add features later.

I had to clean up a lot, so it's not just a cut-and-paste.

TESTED=horizontal and vertical sliders.  Did not test midi interaction to confirm I didn't break anything there
