### PR TITLE
Soft takeover fixes

### DIFF
--- a/src/controllers/softtakeover.cpp
+++ b/src/controllers/softtakeover.cpp
@@ -63,8 +63,6 @@ bool SoftTakeoverCtrl::ignore(ControlObject* control, double newParameter) {
 SoftTakeover::SoftTakeover()
     : m_time(0),
       m_prevParameter(0),
-      // 3/128 units away from the current is enough to catch fast non-sequential moves
-      //  but not cause an audibly noticeable jump.
       m_dThreshold(kDefaultTakeoverThreshold) {
 }
 

--- a/src/controllers/softtakeover.cpp
+++ b/src/controllers/softtakeover.cpp
@@ -66,6 +66,8 @@ SoftTakeover::SoftTakeover()
       m_dThreshold(kDefaultTakeoverThreshold) {
 }
 
+const double SoftTakeover::kDefaultTakeoverThreshold = 3.0 / 128;
+
 void SoftTakeover::setThreshold(double threshold) {
     m_dThreshold = threshold;
 }

--- a/src/controllers/softtakeover.cpp
+++ b/src/controllers/softtakeover.cpp
@@ -62,7 +62,14 @@ bool SoftTakeoverCtrl::ignore(ControlObject* control, double newParameter) {
 
 SoftTakeover::SoftTakeover()
     : m_time(0),
-      m_prevParameter(0) {
+      m_prevParameter(0),
+      // 3/128 units away from the current is enough to catch fast non-sequential moves
+      //  but not cause an audibly noticeable jump.
+      m_dThreshold(kDefaultTakeoverThreshold) {
+}
+
+void SoftTakeover::setThreshold(double threshold) {
+    m_dThreshold = threshold;
 }
 
 bool SoftTakeover::ignore(ControlObject* control, double newParameter) {
@@ -71,10 +78,6 @@ bool SoftTakeover::ignore(ControlObject* control, double newParameter) {
     //  - its previous and new values are far away from and on the same side
     //      of the current value of the control
     //  - it's been awhile since the controller last affected this control
-
-    // 3/128 units away from the current is enough to catch fast non-sequential moves
-    //  but not cause an audibly noticeable jump.
-    const double threshold = 3.0f / 128;
 
     uint currentTime = Time::elapsedMsecs();
     // We will get a sudden jump if we don't ignore the first value.
@@ -91,8 +94,7 @@ bool SoftTakeover::ignore(ControlObject* control, double newParameter) {
         if ((prevDiff < 0 && difference < 0) ||
                 (prevDiff > 0 && difference > 0)) {
             // On same site (still on ignore site)
-            if (fabs(difference) > threshold &&
-                    fabs(prevDiff) > threshold) {
+            if (fabs(difference) > m_dThreshold && fabs(prevDiff) > m_dThreshold) {
                 // difference is above threshold
                 ignore = true;
             }

--- a/src/controllers/softtakeover.h
+++ b/src/controllers/softtakeover.h
@@ -13,6 +13,8 @@
 
 class ControlObject;
 
+// 3/128 units away from the current is enough to catch fast non-sequential moves
+//  but not cause an audibly noticeable jump.
 static const double kDefaultTakeoverThreshold = 3.0 / 128;
 
 class SoftTakeover {

--- a/src/controllers/softtakeover.h
+++ b/src/controllers/softtakeover.h
@@ -13,12 +13,14 @@
 
 class ControlObject;
 
+static const double kDefaultTakeoverThreshold = 3.0 / 128;
 
 class SoftTakeover {
   public:
     SoftTakeover();
     bool ignore(ControlObject* control, double newParameter);
     void ignoreNext();
+    void setThreshold(double threshold);
 
   private:
     // If a new value is received within this amount of time, jump to it
@@ -29,6 +31,7 @@ class SoftTakeover {
 
     uint m_time;
     double m_prevParameter;
+    double m_dThreshold;
 };
 
 class SoftTakeoverCtrl {

--- a/src/controllers/softtakeover.h
+++ b/src/controllers/softtakeover.h
@@ -15,10 +15,12 @@ class ControlObject;
 
 // 3/128 units away from the current is enough to catch fast non-sequential moves
 //  but not cause an audibly noticeable jump.
-static const double kDefaultTakeoverThreshold = 3.0 / 128;
+
 
 class SoftTakeover {
   public:
+    static const double kDefaultTakeoverThreshold;
+
     SoftTakeover();
     bool ignore(ControlObject* control, double newParameter);
     void ignoreNext();

--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -95,10 +95,6 @@ void EffectParameterSlot::loadEffect(EffectPointer pEffect) {
 
             connect(m_pEffectParameter, SIGNAL(valueChanged(double)),
                     this, SLOT(slotParameterValueChanged(double)));
-            // Setting the link type or link inverse calls soft takeover's
-            // ignoreNext method which ignores the first superknob update,
-            // so we need to sync softtakeover explicitly.
-            syncSofttakeover();
         }
     }
     emit(updated());

--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -95,6 +95,9 @@ void EffectParameterSlot::loadEffect(EffectPointer pEffect) {
 
             connect(m_pEffectParameter, SIGNAL(valueChanged(double)),
                     this, SLOT(slotParameterValueChanged(double)));
+            // Setting the link type or link inverse calls soft takeover's
+            // ignoreNext method which ignores the first superknob update,
+            // so we need to sync softtakeover explicitly.
             syncSofttakeover();
         }
     }
@@ -113,7 +116,7 @@ void EffectParameterSlot::clear() {
     m_pControlValue->setDefaultValue(0.0);
     m_pControlType->setAndConfirm(0.0);
     m_pControlLinkType->setAndConfirm(EffectManifestParameter::LINK_NONE);
-    m_pSoftTakeover->setThreshold(kDefaultTakeoverThreshold);
+    m_pSoftTakeover->setThreshold(SoftTakeover::kDefaultTakeoverThreshold);
     m_pControlLinkInverse->set(0.0);
     emit(updated());
 }
@@ -124,7 +127,6 @@ void EffectParameterSlot::slotParameterValueChanged(double value) {
 }
 
 void EffectParameterSlot::slotLinkTypeChanging(double v) {
-    Q_UNUSED(v);
     m_pSoftTakeover->ignoreNext();
     if (v > EffectManifestParameter::LINK_LINKED) {
         double neutral = m_pEffectParameter->getNeutralPointOnScale();
@@ -134,11 +136,12 @@ void EffectParameterSlot::slotLinkTypeChanging(double v) {
             v = EffectManifestParameter::LINK_NONE;
         }
     }
-    if (v == EffectManifestParameter::LINK_LINKED_LEFT ||
-            v == EffectManifestParameter::LINK_LINKED_RIGHT) {
-        m_pSoftTakeover->setThreshold(kDefaultTakeoverThreshold * 2.0);
+    if (static_cast<int>(v) == EffectManifestParameter::LINK_LINKED_LEFT ||
+            static_cast<int>(v) == EffectManifestParameter::LINK_LINKED_RIGHT) {
+        m_pSoftTakeover->setThreshold(
+                SoftTakeover::kDefaultTakeoverThreshold * 2.0);
     } else {
-        m_pSoftTakeover->setThreshold(kDefaultTakeoverThreshold);
+        m_pSoftTakeover->setThreshold(SoftTakeover::kDefaultTakeoverThreshold);
     }
     m_pControlLinkType->setAndConfirm(v);
 }

--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -95,6 +95,7 @@ void EffectParameterSlot::loadEffect(EffectPointer pEffect) {
 
             connect(m_pEffectParameter, SIGNAL(valueChanged(double)),
                     this, SLOT(slotParameterValueChanged(double)));
+            syncSofttakeover();
         }
     }
     emit(updated());
@@ -112,6 +113,7 @@ void EffectParameterSlot::clear() {
     m_pControlValue->setDefaultValue(0.0);
     m_pControlType->setAndConfirm(0.0);
     m_pControlLinkType->setAndConfirm(EffectManifestParameter::LINK_NONE);
+    m_pSoftTakeover->setThreshold(kDefaultTakeoverThreshold);
     m_pControlLinkInverse->set(0.0);
     emit(updated());
 }
@@ -131,6 +133,12 @@ void EffectParameterSlot::slotLinkTypeChanging(double v) {
             // Toggle back to 0
             v = EffectManifestParameter::LINK_NONE;
         }
+    }
+    if (v == EffectManifestParameter::LINK_LINKED_LEFT ||
+            v == EffectManifestParameter::LINK_LINKED_RIGHT) {
+        m_pSoftTakeover->setThreshold(kDefaultTakeoverThreshold * 2.0);
+    } else {
+        m_pSoftTakeover->setThreshold(kDefaultTakeoverThreshold);
     }
     m_pControlLinkType->setAndConfirm(v);
 }

--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -131,7 +131,9 @@ void EffectParameterSlot::slotLinkTypeChanging(double v) {
     if (v > EffectManifestParameter::LINK_LINKED) {
         double neutral = m_pEffectParameter->getNeutralPointOnScale();
         if (neutral > 0.0 && neutral < 1.0) {
-            // Button is already a split button
+            // Knob is already a split knob, meaning it has a positive and
+            // negative effect if it's twisted above the neutral point or
+            // below the neutral point.
             // Toggle back to 0
             v = EffectManifestParameter::LINK_NONE;
         }
@@ -173,8 +175,8 @@ void EffectParameterSlot::onChainSuperParameterChanged(double parameter, bool fo
                             // the neutral position must stick where it is
                             neutral = 1.0 - neutral;
                         }
-                        // Button is already a split button
-                        // Match to center position of Super button
+                        // Knob is already a split knob
+                        // Match to center position of Super knob
                         if (parameter <= 0.5) {
                             parameter /= 0.5;
                             parameter *= neutral;

--- a/src/test/super_link_test.cpp
+++ b/src/test/super_link_test.cpp
@@ -121,6 +121,36 @@ TEST_F(SuperLinkTest, HalfLinkTakeover) {
     // An effect that is linked to half of a knob should be more tolerant of
     // takeover changes.
 
+    // We have to recreate the effect because we want a neutral point at
+    // 0 or 1.
+    QString group = StandardEffectRack::formatEffectSlotGroupString(
+        0, 0, 0);
+    EffectManifest manifest;
+    manifest.setId("org.mixxx.test.effect2");
+    manifest.setName("Test Effect2");
+    EffectManifestParameter* low = manifest.addParameter();
+    low->setId("low");
+    low->setName(QObject::tr("Low"));
+    low->setDescription(QObject::tr("Gain for Low Filter (neutral at 0.0)"));
+    low->setControlHint(EffectManifestParameter::CONTROL_KNOB_LINEAR);
+    low->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
+    low->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
+    low->setNeutralPointOnScale(1.0);
+    low->setDefault(1.0);
+    low->setMinimum(0);
+    low->setMaximum(1.0);
+    registerTestEffect(manifest, false);
+    // Check the controls reflect the state of their loaded effect.
+    EffectPointer pEffect = m_pEffectsManager->instantiateEffect(manifest.id());
+    m_pEffectSlot->loadEffect(pEffect);
+    QString itemPrefix = EffectParameterSlot::formatItemPrefix(0);
+    m_pControlValue.reset(new ControlObjectThread(group, itemPrefix));
+    m_pControlLinkType.reset(new ControlObjectThread(group,
+            itemPrefix + QString("_link_type")));
+    m_pControlLinkInverse.reset(new ControlObjectThread(group,
+            itemPrefix + QString("_link_inverse")));
+
+    // OK now the actual test.
     // 1.5 is a bit of a magic number, but it's enough that a regular
     // linked control will fail the soft takeover test and not change the
     // value...

--- a/src/test/super_link_test.cpp
+++ b/src/test/super_link_test.cpp
@@ -131,7 +131,7 @@ TEST_F(SuperLinkTest, HalfLinkTakeover) {
     EffectManifestParameter* low = manifest.addParameter();
     low->setId("low");
     low->setName(QObject::tr("Low"));
-    low->setDescription(QObject::tr("Gain for Low Filter (neutral at 0.0)"));
+    low->setDescription(QObject::tr("Gain for Low Filter (neutral at 1.0)"));
     low->setControlHint(EffectManifestParameter::CONTROL_KNOB_LINEAR);
     low->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
     low->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);


### PR DESCRIPTION
- sync soft takeover on effect load
- double the takeover threshold for half-linked parameters
