### PR TITLE
Fix eq apply-to-all in preferences.

### DIFF
--- a/src/dlgprefeq.h
+++ b/src/dlgprefeq.h
@@ -42,6 +42,8 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     QString getQuickEffectGroupForDeck(int deck) const;
 
   public slots:
+    void slotEqEffectChangedOnDeck(int effectIndex);
+    void slotQuickEffectChangedOnDeck(int effectIndex);
     void slotNumDecksChanged(double numDecks);
     void slotSingleEqChecked(int checked);
     // Slot for toggling between advanced and basic views

--- a/src/dlgprefeq.h
+++ b/src/dlgprefeq.h
@@ -42,8 +42,6 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     QString getQuickEffectGroupForDeck(int deck) const;
 
   public slots:
-    void slotEqEffectChangedOnDeck(int effectIndex);
-    void slotQuickEffectChangedOnDeck(int effectIndex);
     void slotNumDecksChanged(double numDecks);
     void slotSingleEqChecked(int checked);
     // Slot for toggling between advanced and basic views

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -348,13 +348,6 @@ bool EqualizerRack::loadEffectToGroup(const QString& group,
     }
 
     pChain->replaceEffect(0, pEffect);
-
-    // Force update the new effect to match the current superknob position.
-    EffectSlotPointer pEffectSlot = pChainSlot->getEffectSlot(0);
-    if (pEffectSlot) {
-        pEffectSlot->onChainSuperParameterChanged(
-                pChainSlot->getSuperParameter(), true);
-    }
     return true;
 }
 

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -331,6 +331,34 @@ EqualizerRack::EqualizerRack(EffectsManager* pEffectsManager,
                        EqualizerRack::formatGroupString(iRackNumber)) {
 }
 
+bool EqualizerRack::loadEffectToGroup(const QString& group,
+                                      EffectPointer pEffect) {
+    EffectChainSlotPointer pChainSlot = getGroupEffectChainSlot(group);
+    if (pChainSlot.isNull()) {
+        qWarning() << "No chain for group" << group;
+        return false;
+    }
+
+    EffectChainPointer pChain = pChainSlot->getEffectChain();
+    if (pChain.isNull()) {
+        pChain = makeEmptyChain();
+        pChainSlot->loadEffectChain(pChain);
+        pChain->enableForGroup(group);
+        pChain->setMix(1.0);
+    }
+
+    pChain->replaceEffect(0, pEffect);
+
+    // Force update the new effect to match the current superknob position.
+    EffectSlotPointer pEffectSlot = pChainSlot->getEffectSlot(0);
+    if (pEffectSlot) {
+        pEffectSlot->onChainSuperParameterChanged(
+                pChainSlot->getSuperParameter(), true);
+    }
+    return true;
+}
+
+
 void EqualizerRack::configureEffectChainSlotForGroup(EffectChainSlotPointer pSlot,
                                                      const QString& group) {
     // Register this group alone with the chain slot.

--- a/src/effects/effectrack.h
+++ b/src/effects/effectrack.h
@@ -192,6 +192,8 @@ class EqualizerRack : public PerGroupRack {
                   const unsigned int iRackNumber);
     virtual ~EqualizerRack() {}
 
+    bool loadEffectToGroup(const QString& group, EffectPointer pEffect);
+
     static QString formatGroupString(const unsigned int iRackNumber) {
         return QString("[EqualizerRack%1]")
                 .arg(QString::number(iRackNumber + 1));


### PR DESCRIPTION
- slotLoadEffectChainInSlot was deleted, so the emit did nothing.  Create
  a function to fix that behavior.
- Don't instant-apply eq and quickeffect selections -- wait for the user to hit apply.
  (Otherwise, what's the point of an apply button?)

fixes lp:1404525
