### PR TITLE
fixed sampler bank file dialog export

### DIFF
--- a/src/samplerbank.cpp
+++ b/src/samplerbank.cpp
@@ -40,6 +40,7 @@ void SamplerBank::slotSaveSamplerBank(double v) {
     }
     // Manually add extension due to bug in QFileDialog
     // via https://bugreports.qt-project.org/browse/QTBUG-27186
+    // Can be removed after switch to Qt5
     QFileInfo fileName(samplerBankPath);
     if (fileName.suffix().isNull() || fileName.suffix().isEmpty()) {
     	QString ext = filefilter.section(".",1,1);

--- a/src/samplerbank.cpp
+++ b/src/samplerbank.cpp
@@ -42,9 +42,9 @@ void SamplerBank::slotSaveSamplerBank(double v) {
     // via https://bugreports.qt-project.org/browse/QTBUG-27186
     // Can be removed after switch to Qt5
     QFileInfo fileName(samplerBankPath);
-    if (fileName.suffix().isNull() || fileName.suffix().isEmpty()) {
+    if (fileName.suffix().isEmpty()) {
     	QString ext = filefilter.section(".",1,1);
-        ext.chop(1);
+    	ext.chop(1);
         samplerBankPath.append(".").append(ext);
         }
 

--- a/src/samplerbank.cpp
+++ b/src/samplerbank.cpp
@@ -29,14 +29,23 @@ void SamplerBank::slotSaveSamplerBank(double v) {
     if (v == 0.0 || m_pPlayerManager == NULL) {
         return;
     }
-
+    QString filefilter = tr("Mixxx Sampler Banks (*.xml)");
     QString samplerBankPath = QFileDialog::getSaveFileName(
             NULL, tr("Save Sampler Bank"),
             QString(),
-            tr("Mixxx Sampler Banks (*.xml)"));
-    if (samplerBankPath.isEmpty()) {
+            tr("Mixxx Sampler Banks (*.xml)"),
+            &filefilter);
+    if (samplerBankPath.isNull() || samplerBankPath.isEmpty()) {
         return;
     }
+    // Manually add extension due to bug in QFileDialog
+    // via https://bugreports.qt-project.org/browse/QTBUG-27186
+    QFileInfo fileName(samplerBankPath);
+    if (fileName.suffix().isNull() || fileName.suffix().isEmpty()) {
+    	QString ext = filefilter.section(".",1,1);
+        ext.chop(1);
+        samplerBankPath.append(".").append(ext);
+        }
 
     // The user has picked a new directory via a file dialog. This means the
     // system sandboxer (if we are sandboxed) has granted us permission to this

--- a/src/samplerbank.cpp
+++ b/src/samplerbank.cpp
@@ -43,10 +43,10 @@ void SamplerBank::slotSaveSamplerBank(double v) {
     // Can be removed after switch to Qt5
     QFileInfo fileName(samplerBankPath);
     if (fileName.suffix().isEmpty()) {
-    	QString ext = filefilter.section(".",1,1);
-    	ext.chop(1);
+        QString ext = filefilter.section(".",1,1);
+        ext.chop(1);
         samplerBankPath.append(".").append(ext);
-        }
+    }
 
     // The user has picked a new directory via a file dialog. This means the
     // system sandboxer (if we are sandboxed) has granted us permission to this


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1403223

Although i did not find the dialog in question, i realized it is the same issue with QFileDialog under Linux as https://github.com/mixxxdj/mixxx/pull/430

I am unsure whether bug occurs under same environment in void SamplerBank::slotLoadSamplerBank() as well. Might need further attention.
