### PR TITLE
1.12 performance low-hanging fruit

### DIFF
--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -147,7 +147,7 @@ class EngineBuffer : public EngineObject {
     void postProcess(const int iBufferSize);
 
     QString getGroup();
-    bool isTrackLoaded();
+    bool isTrackLoaded() const;
     TrackPointer getLoadedTrack() const;
 
     double getVisualPlayPos();
@@ -376,6 +376,7 @@ class EngineBuffer : public EngineObject {
     //int m_iRampIter;
 
     TrackPointer m_pCurrentTrack;
+    bool m_bTrackLoaded;
 #ifdef __SCALER_DEBUG__
     QFile df;
     QTextStream writer;

--- a/src/engine/enginevinylsoundemu.cpp
+++ b/src/engine/enginevinylsoundemu.cpp
@@ -60,6 +60,11 @@ void EngineVinylSoundEmu::process(CSAMPLE* pInOut, const int iBufferSize) {
     const CSAMPLE curQuieting =
             fabs(m_dSpeed) < thresholdSpeed ? fabs(m_dSpeed) / thresholdSpeed : 1.;
 
+    if (!wasDithering && !isDithering && !prevQuieting && !curQuieting) {
+        m_dOldSpeed = m_dSpeed;
+        return;
+    }
+
     // If necessary, process with the old parameters and crossfade.
     if (wasDithering != isDithering || prevQuieting != curQuieting) {
         for (int i = 0; i < iBufferSize; i += 2) {


### PR DESCRIPTION
I've been doing a little profiling, because I've been seeing more buffer underruns than normal.  I identified the following issues:
- vinyl spinny quality drawing was super slow, and the work was being done even if vinyl wasn't active or drawing was off.  I fixed this during the spinny work.
- EngineFilterDelay::process takes lots of CPU for some reason, I don't know why.  It's often the top item in the profile.
- EngineBuffer::isActive is super slow.  Apparently checking a QSharedPointer for non-null is slow3.  Adding a bool that tracks the null/notnull status of the pointer solves the problem, but we have to think about possible race conditions.
- EngineVinylSoundEmu is slow.  It should noop if all of the conditions are false (!wasDithering && !isDithering && !prevQuieting && !curQuieting)

Of these, I have fixes for all of them except the Delay issue.  
