### PR TITLE
Fix tracks clipping at unity.

### DIFF
--- a/src/engine/enginedeck.h
+++ b/src/engine/enginedeck.h
@@ -30,7 +30,6 @@
 class EngineBuffer;
 class EnginePregain;
 class EngineBuffer;
-class EngineClipping;
 class EngineMaster;
 class EngineVuMeter;
 class EngineVinylSoundEmu;

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -31,7 +31,6 @@ class EngineWorkerScheduler;
 class EngineBuffer;
 class EngineChannel;
 class EngineDeck;
-class EngineClipping;
 class EngineFlanger;
 class EngineVuMeter;
 class ControlPotmeter;

--- a/src/sampleutil.cpp
+++ b/src/sampleutil.cpp
@@ -178,12 +178,10 @@ void SampleUtil::copyWithRampingGain(CSAMPLE* pDest, const CSAMPLE* pSrc,
 // static
 void SampleUtil::convertS16ToFloat32(CSAMPLE* pDest, const SAMPLE* pSrc,
         unsigned int iNumSamples) {
-    // Sample min can be -32768 instead of -32767, so make sure our conversion
-    // scale is picking the largest possible absolute value.
+    // -32768 is a valid low sample, whereas 32767 is the highest valid sample.
     // Note that this means that although some sample values convert to -1.0,
     // none will convert to +1.0.
-    static const CSAMPLE kConversionFactor = math_max(CSAMPLE(-SAMPLE_MIN),
-                                                      CSAMPLE(SAMPLE_MAX));
+    const CSAMPLE kConversionFactor = 0x8000;
     for (unsigned int i = 0; i < iNumSamples; ++i) {
         pDest[i] = CSAMPLE(pSrc[i]) / kConversionFactor;
     }

--- a/src/sampleutil.cpp
+++ b/src/sampleutil.cpp
@@ -178,8 +178,14 @@ void SampleUtil::copyWithRampingGain(CSAMPLE* pDest, const CSAMPLE* pSrc,
 // static
 void SampleUtil::convertS16ToFloat32(CSAMPLE* pDest, const SAMPLE* pSrc,
         unsigned int iNumSamples) {
+    // Sample min can be -32768 instead of -32767, so make sure our conversion
+    // scale is picking the largest possible absolute value.
+    // Note that this means that although some sample values convert to -1.0,
+    // none will convert to +1.0.
+    static const CSAMPLE kConversionFactor = math_max(CSAMPLE(-SAMPLE_MIN),
+                                                      CSAMPLE(SAMPLE_MAX));
     for (unsigned int i = 0; i < iNumSamples; ++i) {
-        pDest[i] = CSAMPLE(pSrc[i]) / CSAMPLE(SAMPLE_MAX);
+        pDest[i] = CSAMPLE(pSrc[i]) / kConversionFactor;
     }
 }
 

--- a/src/test/sampleutiltest.cpp
+++ b/src/test/sampleutiltest.cpp
@@ -315,6 +315,9 @@ TEST_F(SampleUtilTest, copy3WithGainAliased) {
 }
 
 TEST_F(SampleUtilTest, convertS16ToFloat32) {
+    // Shorts are asymmetric, so SAMPLE_MAX is less than -SAMPLE_MIN.
+    const float expectedMax = static_cast<float>(SAMPLE_MAX) /
+                              static_cast<float>(-SAMPLE_MIN);
     while (sseAvailable-- >= 0) {
         for (int i = 0; i < buffers.size(); ++i) {
             CSAMPLE* buffer = buffers[i];
@@ -326,7 +329,7 @@ TEST_F(SampleUtilTest, convertS16ToFloat32) {
             }
             SampleUtil::convertS16ToFloat32(buffer, s16, size);
             for (int j = 0; j < size; ++j) {
-                EXPECT_FLOAT_EQ(1.0f, buffer[j]);
+                EXPECT_FLOAT_EQ(expectedMax, buffer[j]);
             }
             FillBuffer(buffer, 0.0f, size);
             for (int j = 0; j < size; ++j) {
@@ -338,7 +341,7 @@ TEST_F(SampleUtilTest, convertS16ToFloat32) {
             }
             FillBuffer(buffer, -1.0f, size);
             for (int j = 0; j < size; ++j) {
-                s16[j] = -SAMPLE_MAX;
+                s16[j] = SAMPLE_MIN;
             }
             SampleUtil::convertS16ToFloat32(buffer, s16, size);
             for (int j = 0; j < size; ++j) {


### PR DESCRIPTION
CSAMPLE values of -32768 were being converted to -1.00003, which
is interpretted as clipping.  Fixed our conversion code to scale
by whichever is larger, SAMPLE_MAX or -SAMPLE_MIN.  On most modern
platforms that should be 32768, but the spec says that SHRT_MIN
could be -32767 in which case the conversion factor would be
32767.

Fixed the existing test, which assumed symmetry between SHRT_MIN
and SHRT_MAX.

fixes lp:#1408011
