### PR TITLE
Create a new config key for skin setting.

### DIFF
--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -324,7 +324,7 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
             this, SLOT(slotSetRateRampSensitivity(int)));
     SliderRateRampSensitivity->setValue(m_pConfig->getValueString(
             ConfigKey("[Controls]", "RateRampSensitivity")).toInt());
-    
+
     // Update Speed Auto Reset Slider Box
     // Cue recall
     ComboBoxResetSpeedAndPitch->addItem(tr("On track load"));
@@ -534,7 +534,7 @@ void DlgPrefControls::slotSetScheme(int) {
 }
 
 void DlgPrefControls::slotSetSkin(int) {
-    m_pConfig->set(ConfigKey("[Config]", "Skin"), ComboBoxSkinconf->currentText());
+    m_pConfig->set(ConfigKey("[Config]", "ResizableSkin"), ComboBoxSkinconf->currentText());
     m_mixxx->rebootMixxxView();
     checkSkinResolution(ComboBoxSkinconf->currentText())
             ? warningLabel->hide() : warningLabel->show();
@@ -618,7 +618,7 @@ void DlgPrefControls::slotApply() {
     } else {
         m_pConfig->set(ConfigKey("[Controls]", "RateDir"), ConfigValue(1));
     }
-    
+
     m_pConfig->set(ConfigKey("[Controls]", "SpeedAutoReset"),
             ConfigValue(m_speedAutoReset));
 

--- a/src/skin/skinloader.cpp
+++ b/src/skin/skinloader.cpp
@@ -45,9 +45,22 @@ QList<QDir> SkinLoader::getSkinSearchPaths() {
 }
 
 QString SkinLoader::getConfiguredSkinPath() {
-    QString configSkin = m_pConfig->getValueString(ConfigKey("[Config]", "Skin"));
+    QString configSkin = m_pConfig->getValueString(ConfigKey("[Config]", "ResizableSkin"));
+
+    // If we don't have a skin defined, we might be migrating from 1.11 and
+    // should pick the closest-possible skin.
     if (configSkin.isEmpty()) {
-        return QString();
+        QString oldSkin = m_pConfig->getValueString(ConfigKey("[Config]", "Skin"));
+        if (!oldSkin.isEmpty()) {
+            configSkin = pickResizableSkin(oldSkin);
+        }
+        // If the old skin was empty or we couldn't guess a skin, go with the
+        // default.
+        if (configSkin.isEmpty()) {
+            configSkin = getDefaultSkinName();
+        }
+        m_pConfig->set(ConfigKey("[Config]", "ResizableSkin"),
+                       ConfigValue(configSkin));
     }
 
     QList<QDir> skinSearchPaths = getSkinSearchPaths();
@@ -60,15 +73,18 @@ QString SkinLoader::getConfiguredSkinPath() {
     return QString();
 }
 
-QString SkinLoader::getDefaultSkinPath() {
-    // Fall back to default skin.
-    QString defaultSkin;
+QString SkinLoader::getDefaultSkinName() const {
     QRect screenGeo = QApplication::desktop()->screenGeometry();
     if (screenGeo.width() >= 1280 && screenGeo.height() >= 800) {
-        defaultSkin = "LateNight";
+        return "LateNight";
     } else {
-        defaultSkin = "Shade";
+        return "Shade";
     }
+}
+
+QString SkinLoader::getDefaultSkinPath() {
+    // Fall back to default skin.
+    QString defaultSkin = getDefaultSkinName();
 
     QList<QDir> skinSearchPaths = getSkinSearchPaths();
     foreach (QDir dir, skinSearchPaths) {
@@ -109,4 +125,17 @@ QWidget* SkinLoader::loadDefaultSkin(QWidget* pParent,
                             pControllerManager, pLibrary, pVCMan,
                             pEffectsManager);
     return legacy.parseSkin(skinPath, pParent);
+}
+
+QString SkinLoader::pickResizableSkin(QString oldSkin) {
+    if (oldSkin.contains("latenight", Qt::CaseInsensitive)) {
+        return "LateNight";
+    }
+    if (oldSkin.contains("deere", Qt::CaseInsensitive)) {
+        return "Deere";
+    }
+    if (oldSkin.contains("shade", Qt::CaseInsensitive)) {
+        return "Shade";
+    }
+    return QString();
 }

--- a/src/skin/skinloader.h
+++ b/src/skin/skinloader.h
@@ -32,7 +32,9 @@ class SkinLoader {
 
   private:
     QString getConfiguredSkinPath();
+    QString getDefaultSkinName() const;
     QString getDefaultSkinPath();
+    QString pickResizableSkin(QString oldSkin);
 
     ConfigObject<ConfigValue>* m_pConfig;
 };


### PR DESCRIPTION
When moving from 1.11, guess a good resizable skin based on the user's
previous choice.  The user can still go back and select the old skin
if they want.

When moving back to 1.11, the old setting will still be there.

(I am not 100% sure about the name choice -- maybe just Skin2 is better so we can more easily create newer skin versions later?)
