### PR TITLE
Performance improvements.

### DIFF
--- a/src/analyserbeats.cpp
+++ b/src/analyserbeats.cpp
@@ -136,7 +136,7 @@ bool AnalyserBeats::loadStored(TrackPointer tio) const {
     if (library.isEmpty() || library.isNull())
         library = "libmixxxminimal";
     if (pluginID.isEmpty() || pluginID.isNull())
-        pluginID="qm-tempotracker:0";
+        pluginID = "qm-tempotracker:0";
 
     // If the track already has a Beats object then we need to decide whether to
     // analyze this track or not.
@@ -187,8 +187,7 @@ void AnalyserBeats::process(const CSAMPLE *pIn, const int iLen) {
     }
 }
 
-void AnalyserBeats::cleanup(TrackPointer tio)
-{
+void AnalyserBeats::cleanup(TrackPointer tio) {
     Q_UNUSED(tio);
     delete m_pVamp;
     m_pVamp = NULL;

--- a/src/cachingreader.cpp
+++ b/src/cachingreader.cpp
@@ -36,7 +36,7 @@ CachingReader::CachingReader(QString group,
     // Divide up the allocated raw memory buffer into total_chunks
     // chunks. Initialize each chunk to hold nothing and add it to the free
     // list.
-    for (int i=0; i < maximumChunksInMemory; i++) {
+    for (int i = 0; i < maximumChunksInMemory; ++i) {
         Chunk* c = new Chunk;
         c->chunk_number = -1;
         c->length = 0;
@@ -76,12 +76,7 @@ CachingReader::~CachingReader() {
     m_freeChunks.clear();
     m_allocatedChunks.clear();
     m_lruChunk = m_mruChunk = NULL;
-
-    for (int i=0; i < m_chunks.size(); i++) {
-        Chunk* c = m_chunks[i];
-        delete c;
-    }
-
+    qDeleteAll(m_chunks);
     delete [] m_pRawMemoryBuffer;
     m_pRawMemoryBuffer = NULL;
 }
@@ -202,11 +197,8 @@ Chunk* CachingReader::allocateChunkExpireLRU() {
 
 Chunk* CachingReader::lookupChunk(int chunk_number) {
     // Defaults to NULL if it's not in the hash.
-    Chunk* chunk = NULL;
-
-    if (m_allocatedChunks.contains(chunk_number)) {
-        chunk = m_allocatedChunks.value(chunk_number);
-
+    Chunk* chunk = m_allocatedChunks.value(chunk_number, NULL);
+    if (chunk != NULL) {
         // Make sure we're all in agreement here.
         if (chunk_number != chunk->chunk_number) {
             qDebug() << "ERROR: Inconsistent chunk has chunk_number that doesn't match allocated-chunks key.";

--- a/src/cachingreader.cpp
+++ b/src/cachingreader.cpp
@@ -441,13 +441,11 @@ int CachingReader::read(int sample, int num_samples, CSAMPLE* buffer) {
     return zerosWritten + num_samples - samples_remaining;
 }
 
-void CachingReader::hintAndMaybeWake(const QVector<Hint>& hintList) {
+void CachingReader::hintAndMaybeWake(const HintVector& hintList) {
     // If no file is loaded, skip.
     if (m_readerStatus != TRACK_LOADED) {
         return;
     }
-
-    QVectorIterator<Hint> iterator(hintList);
 
     // To prevent every bit of code having to guess how many samples
     // forward it makes sense to keep in memory, the hinter can provide
@@ -460,9 +458,10 @@ void CachingReader::hintAndMaybeWake(const QVector<Hint>& hintList) {
     const int default_samples = 2048;
 
     QSet<int> chunksToFreshen;
-    while (iterator.hasNext()) {
+    for (HintVector::const_iterator it = hintList.constBegin();
+         it != hintList.constEnd(); ++it) {
         // Copy, don't use reference.
-        Hint hint = iterator.next();
+        Hint hint = *it;
 
         if (hint.length == 0) {
             hint.length = default_samples;

--- a/src/cachingreader.h
+++ b/src/cachingreader.h
@@ -9,6 +9,7 @@
 #include <QVector>
 #include <QLinkedList>
 #include <QHash>
+#include <QVarLengthArray>
 
 #include "util/types.h"
 #include "configobject.h"
@@ -33,6 +34,8 @@ typedef struct Hint {
     // priority >10.
     int priority;
 } Hint;
+
+typedef QVarLengthArray<Hint, 512> HintVector;
 
 // CachingReader provides a layer on top of a SoundSource for reading samples
 // from a file. A cache is provided so that repeated reads to a certain section
@@ -60,7 +63,7 @@ class CachingReader : public QObject {
     // that is not in the cache. If any hints do request a chunk not in cache,
     // then wake the reader so that it can process them. Must only be called
     // from the engine callback.
-    virtual void hintAndMaybeWake(const QVector<Hint>& hintList);
+    virtual void hintAndMaybeWake(const HintVector& hintList);
 
     // Request that the CachingReader load a new track. These requests are
     // processed in the work thread, so the reader must be woken up via wake()

--- a/src/cachingreader.h
+++ b/src/cachingreader.h
@@ -115,7 +115,7 @@ class CachingReader : public QObject {
 
     ReaderStatus m_readerStatus;
 
-    // Keeps track of free Chunks we've allocated
+    // Keeps track of all Chunks we've allocated.
     QVector<Chunk*> m_chunks;
     // List of free chunks available for use.
     QList<Chunk*> m_freeChunks;

--- a/src/cachingreader.h
+++ b/src/cachingreader.h
@@ -100,9 +100,17 @@ class CachingReader : public QObject {
     FIFO<ChunkReadRequest> m_chunkReadRequestFIFO;
     FIFO<ReaderStatusUpdate> m_readerStatusFIFO;
 
-     // Looks for the provided chunk number in the index of in-memory chunks and
+    // Looks for the provided chunk number in the index of in-memory chunks and
+    // returns it if it is present. If not, returns NULL. If it is present then
+    // freshenChunk is called on the chunk to make it the MRU chunk.
+    Chunk* lookupChunkAndFreshen(int chunk_number);
+
+    // Looks for the provided chunk number in the index of in-memory chunks and
     // returns it if it is present. If not, returns NULL.
     Chunk* lookupChunk(int chunk_number);
+
+    // Moves the provided chunk to the MRU position.
+    void freshenChunk(Chunk* pChunk);
 
     // Returns a Chunk to the free list
     void freeChunk(Chunk* pChunk);
@@ -111,19 +119,19 @@ class CachingReader : public QObject {
     void freeAllChunks();
 
     // Gets a chunk from the free list. Returns NULL if none available.
-    Chunk* allocateChunk();
+    Chunk* allocateChunk(int chunk);
 
     // Gets a chunk from the free list, frees the LRU Chunk if none available.
-    Chunk* allocateChunkExpireLRU();
+    Chunk* allocateChunkExpireLRU(int chunk);
 
     ReaderStatus m_readerStatus;
 
     // Keeps track of all Chunks we've allocated.
     QVector<Chunk*> m_chunks;
-    // List of free chunks available for use.
-    QList<Chunk*> m_freeChunks;
-    // List of reserved chunks with reads in progress
-    QHash<int, Chunk*> m_chunksBeingRead;
+
+    // List of free chunks. Linked list so that we have constant time insertions
+    // and deletions. Iteration is not necessary.
+    QLinkedList<Chunk*> m_freeChunks;
 
     // Keeps track of what Chunks we've allocated and indexes them based on what
     // chunk number they are allocated to.

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -24,6 +24,14 @@ typedef struct Chunk {
     CSAMPLE* data;
     Chunk* prev_lru;
     Chunk* next_lru;
+
+    enum State {
+        FREE,
+        ALLOCATED,
+        READ_IN_PROGRESS,
+        READ
+    };
+    State state;
 } Chunk;
 
 typedef struct ChunkReadRequest {

--- a/src/control/controlbehavior.cpp
+++ b/src/control/controlbehavior.cpp
@@ -161,7 +161,7 @@ double ControlAudioTaperPotBehavior::valueToParameter(double dValue) {
     } else if (dValue < 1.0) {
         // db + linear overlay to reach
         // m_minDB = 0
-        // 0 dB = m_neutralParame;
+        // 0 dB = m_neutralParameter
         double overlay = m_offset * (1 - dValue);
         if (m_minDB) {
             dParam = (ratio2db(dValue + overlay) - m_minDB) / m_minDB * m_neutralParameter * -1;
@@ -172,7 +172,7 @@ double ControlAudioTaperPotBehavior::valueToParameter(double dValue) {
         dParam = m_neutralParameter;
     } else if (dValue < m_dMaxValue) {
         // m_maxDB = 1
-        // 0 dB = m_neutralParame;
+        // 0 dB = m_neutralParameter
         dParam = (ratio2db(dValue) / m_maxDB * (1 - m_neutralParameter)) + m_neutralParameter;
     }
     //qDebug() << "ControlAudioTaperPotBehavior::valueToParameter" << "value =" << dValue << "dParam =" << dParam;
@@ -186,7 +186,7 @@ double ControlAudioTaperPotBehavior::parameterToValue(double dParam) {
     } else if (dParam < m_neutralParameter) {
         // db + linear overlay to reach
         // m_minDB = 0
-        // 0 dB = m_neutralParame;
+        // 0 dB = m_neutralParameter;
         if (m_minDB) {
             double db = (dParam * m_minDB / (m_neutralParameter * -1)) + m_minDB;
             dValue = (db2ratio(db) - m_offset) / (1 - m_offset) ;

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -107,10 +107,7 @@ CueControl::~CueControl() {
     delete m_pPlayStutter;
     delete m_pCueIndicator;
     delete m_pPlayIndicator;
-    while (m_hotcueControl.size() > 0) {
-        HotcueControl* pControl = m_hotcueControl.takeLast();
-        delete pControl;
-    }
+    qDeleteAll(m_hotcueControl);
 }
 
 void CueControl::createControls() {
@@ -147,10 +144,10 @@ void CueControl::createControls() {
 }
 
 void CueControl::attachCue(Cue* pCue, int hotCue) {
-    if (hotCue < 0 || hotCue >= m_iNumHotCues) {
+    HotcueControl* pControl = m_hotcueControl.value(hotCue, NULL);
+    if (pControl == NULL) {
         return;
     }
-    HotcueControl* pControl = m_hotcueControl[hotCue];
     if (pControl->getCue() != NULL) {
         detachCue(pControl->getHotcueNumber());
     }
@@ -164,10 +161,10 @@ void CueControl::attachCue(Cue* pCue, int hotCue) {
 }
 
 void CueControl::detachCue(int hotCue) {
-    if (hotCue < 0 || hotCue >= m_iNumHotCues) {
+    HotcueControl* pControl = m_hotcueControl.value(hotCue, NULL);
+    if (pControl == NULL) {
         return;
     }
-    HotcueControl* pControl = m_hotcueControl[hotCue];
     Cue* pCue = pControl->getCue();
     if (!pCue)
         return;
@@ -282,7 +279,13 @@ void CueControl::trackCuesUpdated() {
 
         int hotcue = pCue->getHotCue();
         if (hotcue != -1) {
-            HotcueControl* pControl = m_hotcueControl[hotcue];
+            HotcueControl* pControl = m_hotcueControl.value(hotcue, NULL);
+
+            // Cue's hotcue doesn't have a hotcue control.
+            if (pControl == NULL) {
+                continue;
+            }
+
             Cue* pOldCue = pControl->getCue();
 
             // If the old hotcue is different than this one.
@@ -563,8 +566,9 @@ void CueControl::hintReader(QVector<Hint>* pHintList) {
         pHintList->append(cue_hint);
     }
 
-    for (int i = 0; i < m_iNumHotCues; ++i) {
-        HotcueControl* pControl = m_hotcueControl[i];
+    for (QList<HotcueControl*>::const_iterator it = m_hotcueControl.constBegin();
+         it != m_hotcueControl.constEnd(); ++it) {
+        HotcueControl* pControl = *it;
         Cue *pCue = pControl->getCue();
         if (pCue != NULL) {
             double position = pControl->getPosition()->get();

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -554,7 +554,7 @@ void CueControl::hotcuePositionChanged(HotcueControl* pControl, double newPositi
     }
 }
 
-void CueControl::hintReader(QVector<Hint>* pHintList) {
+void CueControl::hintReader(HintVector* pHintList) {
     QMutexLocker lock(&m_mutex);
 
     Hint cue_hint;
@@ -578,7 +578,7 @@ void CueControl::hintReader(QVector<Hint>* pHintList) {
                     cue_hint.sample--;
                 cue_hint.length = 0;
                 cue_hint.priority = 10;
-                pHintList->push_back(cue_hint);
+                pHintList->append(cue_hint);
             }
         }
     }

--- a/src/engine/cuecontrol.h
+++ b/src/engine/cuecontrol.h
@@ -87,7 +87,7 @@ class CueControl : public EngineControl {
                ConfigObject<ConfigValue>* _config);
     virtual ~CueControl();
 
-    virtual void hintReader(QVector<Hint>* pHintList);
+    virtual void hintReader(HintVector* pHintList);
     double updateIndicatorsAndModifyPlay(double play, bool playPossible);
     void updateIndicators();
     bool isTrackAtCue();

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -129,7 +129,7 @@ bool EngineEffectChain::processEffectsRequest(const EffectsRequest& message,
 }
 
 bool EngineEffectChain::enableForGroup(const QString& group) {
-    GroupStatus& status = m_groupStatus[group];
+    GroupStatus& status = getGroupStatus(group);
     if (status.enable_state != EffectProcessor::ENABLED) {
         status.enable_state = EffectProcessor::ENABLING;
     }
@@ -137,11 +137,24 @@ bool EngineEffectChain::enableForGroup(const QString& group) {
 }
 
 bool EngineEffectChain::disableForGroup(const QString& group) {
-    GroupStatus& status = m_groupStatus[group];
+    GroupStatus& status = getGroupStatus(group);
     if (status.enable_state != EffectProcessor::DISABLED) {
         status.enable_state = EffectProcessor::DISABLING;
     }
     return true;
+}
+
+EngineEffectChain::GroupStatus& EngineEffectChain::getGroupStatus(const QString& group) {
+    for (QLinkedList<GroupStatus>::iterator it = m_groupStatus.begin(),
+                 end = m_groupStatus.end(); it != end; ++it) {
+        GroupStatus& status = *it;
+        if (status.group == group) {
+            return status;
+        }
+    }
+    GroupStatus status(group);
+    m_groupStatus.append(status);
+    return m_groupStatus.last();
 }
 
 void EngineEffectChain::process(const QString& group,
@@ -149,7 +162,7 @@ void EngineEffectChain::process(const QString& group,
                                 const unsigned int numSamples,
                                 const unsigned int sampleRate,
                                 const GroupFeatureState& groupFeatures) {
-    GroupStatus& group_info = m_groupStatus[group];
+    GroupStatus& group_info = getGroupStatus(group);
 
     if (m_enableState == EffectProcessor::DISABLED
             || group_info.enable_state == EffectProcessor::DISABLED) {

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -1,3 +1,4 @@
+
 #include "engine/effects/engineeffectchain.h"
 
 #include "engine/effects/engineeffect.h"
@@ -129,7 +130,7 @@ bool EngineEffectChain::processEffectsRequest(const EffectsRequest& message,
 }
 
 bool EngineEffectChain::enableForGroup(const QString& group) {
-    GroupStatus& status = getGroupStatus(group);
+    GroupStatus& status = m_groupStatus[group];
     if (status.enable_state != EffectProcessor::ENABLED) {
         status.enable_state = EffectProcessor::ENABLING;
     }
@@ -137,24 +138,11 @@ bool EngineEffectChain::enableForGroup(const QString& group) {
 }
 
 bool EngineEffectChain::disableForGroup(const QString& group) {
-    GroupStatus& status = getGroupStatus(group);
+    GroupStatus& status = m_groupStatus[group];
     if (status.enable_state != EffectProcessor::DISABLED) {
         status.enable_state = EffectProcessor::DISABLING;
     }
     return true;
-}
-
-EngineEffectChain::GroupStatus& EngineEffectChain::getGroupStatus(const QString& group) {
-    for (QLinkedList<GroupStatus>::iterator it = m_groupStatus.begin(),
-                 end = m_groupStatus.end(); it != end; ++it) {
-        GroupStatus& status = *it;
-        if (status.group == group) {
-            return status;
-        }
-    }
-    GroupStatus status(group);
-    m_groupStatus.append(status);
-    return m_groupStatus.last();
 }
 
 void EngineEffectChain::process(const QString& group,
@@ -162,7 +150,7 @@ void EngineEffectChain::process(const QString& group,
                                 const unsigned int numSamples,
                                 const unsigned int sampleRate,
                                 const GroupFeatureState& groupFeatures) {
-    GroupStatus& group_info = getGroupStatus(group);
+    GroupStatus& group_info = m_groupStatus[group];
 
     if (m_enableState == EffectProcessor::DISABLED
             || group_info.enable_state == EffectProcessor::DISABLED) {

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -1,4 +1,3 @@
-
 #include "engine/effects/engineeffectchain.h"
 
 #include "engine/effects/engineeffect.h"
@@ -130,7 +129,7 @@ bool EngineEffectChain::processEffectsRequest(const EffectsRequest& message,
 }
 
 bool EngineEffectChain::enableForGroup(const QString& group) {
-    GroupStatus& status = m_groupStatus[group];
+    GroupStatus& status = getGroupStatus(group);
     if (status.enable_state != EffectProcessor::ENABLED) {
         status.enable_state = EffectProcessor::ENABLING;
     }
@@ -138,11 +137,24 @@ bool EngineEffectChain::enableForGroup(const QString& group) {
 }
 
 bool EngineEffectChain::disableForGroup(const QString& group) {
-    GroupStatus& status = m_groupStatus[group];
+    GroupStatus& status = getGroupStatus(group);
     if (status.enable_state != EffectProcessor::DISABLED) {
         status.enable_state = EffectProcessor::DISABLING;
     }
     return true;
+}
+
+EngineEffectChain::GroupStatus& EngineEffectChain::getGroupStatus(const QString& group) {
+    for (QLinkedList<GroupStatus>::iterator it = m_groupStatus.begin(),
+                 end = m_groupStatus.end(); it != end; ++it) {
+        GroupStatus& status = *it;
+        if (status.group == group) {
+            return status;
+        }
+    }
+    GroupStatus status(group);
+    m_groupStatus.append(status);
+    return m_groupStatus.last();
 }
 
 void EngineEffectChain::process(const QString& group,
@@ -150,7 +162,7 @@ void EngineEffectChain::process(const QString& group,
                                 const unsigned int numSamples,
                                 const unsigned int sampleRate,
                                 const GroupFeatureState& groupFeatures) {
-    GroupStatus& group_info = m_groupStatus[group];
+    GroupStatus& group_info = getGroupStatus(group);
 
     if (m_enableState == EffectProcessor::DISABLED
             || group_info.enable_state == EffectProcessor::DISABLED) {

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -3,7 +3,7 @@
 
 #include <QString>
 #include <QList>
-#include <QSet>
+#include <QLinkedList>
 
 #include "util.h"
 #include "util/types.h"
@@ -35,6 +35,17 @@ class EngineEffectChain : public EffectsRequestHandler {
     bool enabledForGroup(const QString& group) const;
 
   private:
+    struct GroupStatus {
+        GroupStatus(const QString& group)
+                : group(group),
+                  old_gain(0),
+                  enable_state(EffectProcessor::DISABLED) {
+        }
+        QString group;
+        CSAMPLE old_gain;
+        EffectProcessor::EnableState enable_state;
+    };
+
     QString debugString() const {
         return QString("EngineEffectChain(%1)").arg(m_id);
     }
@@ -45,21 +56,17 @@ class EngineEffectChain : public EffectsRequestHandler {
     bool enableForGroup(const QString& group);
     bool disableForGroup(const QString& group);
 
+    // Gets or creates a GroupStatus entry in m_groupStatus for the provided
+    // group.
+    GroupStatus& getGroupStatus(const QString& group);
+
     QString m_id;
     EffectProcessor::EnableState m_enableState;
     EffectChain::InsertionType m_insertionType;
     CSAMPLE m_dMix;
     QList<EngineEffect*> m_effects;
     CSAMPLE* m_pBuffer;
-    struct GroupStatus {
-        GroupStatus()
-                : old_gain(0),
-                  enable_state(EffectProcessor::DISABLED) {
-        }
-        CSAMPLE old_gain;
-        EffectProcessor::EnableState enable_state;
-    };
-    QMap<QString, GroupStatus> m_groupStatus;
+    QLinkedList<GroupStatus> m_groupStatus;
 
     DISALLOW_COPY_AND_ASSIGN(EngineEffectChain);
 };

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -3,7 +3,7 @@
 
 #include <QString>
 #include <QList>
-#include <QLinkedList>
+#include <QHash>
 
 #include "util.h"
 #include "util/types.h"
@@ -36,12 +36,10 @@ class EngineEffectChain : public EffectsRequestHandler {
 
   private:
     struct GroupStatus {
-        GroupStatus(const QString& group)
-                : group(group),
-                  old_gain(0),
+        GroupStatus()
+                : old_gain(0),
                   enable_state(EffectProcessor::DISABLED) {
         }
-        QString group;
         CSAMPLE old_gain;
         EffectProcessor::EnableState enable_state;
     };
@@ -56,17 +54,13 @@ class EngineEffectChain : public EffectsRequestHandler {
     bool enableForGroup(const QString& group);
     bool disableForGroup(const QString& group);
 
-    // Gets or creates a GroupStatus entry in m_groupStatus for the provided
-    // group.
-    GroupStatus& getGroupStatus(const QString& group);
-
     QString m_id;
     EffectProcessor::EnableState m_enableState;
     EffectChain::InsertionType m_insertionType;
     CSAMPLE m_dMix;
     QList<EngineEffect*> m_effects;
     CSAMPLE* m_pBuffer;
-    QLinkedList<GroupStatus> m_groupStatus;
+    QHash<QString, GroupStatus> m_groupStatus;
 
     DISALLOW_COPY_AND_ASSIGN(EngineEffectChain);
 };

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -3,7 +3,7 @@
 
 #include <QString>
 #include <QList>
-#include <QHash>
+#include <QLinkedList>
 
 #include "util.h"
 #include "util/types.h"
@@ -36,10 +36,12 @@ class EngineEffectChain : public EffectsRequestHandler {
 
   private:
     struct GroupStatus {
-        GroupStatus()
-                : old_gain(0),
+        GroupStatus(const QString& group)
+                : group(group),
+                  old_gain(0),
                   enable_state(EffectProcessor::DISABLED) {
         }
+        QString group;
         CSAMPLE old_gain;
         EffectProcessor::EnableState enable_state;
     };
@@ -54,13 +56,17 @@ class EngineEffectChain : public EffectsRequestHandler {
     bool enableForGroup(const QString& group);
     bool disableForGroup(const QString& group);
 
+    // Gets or creates a GroupStatus entry in m_groupStatus for the provided
+    // group.
+    GroupStatus& getGroupStatus(const QString& group);
+
     QString m_id;
     EffectProcessor::EnableState m_enableState;
     EffectChain::InsertionType m_insertionType;
     CSAMPLE m_dMix;
     QList<EngineEffect*> m_effects;
     CSAMPLE* m_pBuffer;
-    QHash<QString, GroupStatus> m_groupStatus;
+    QLinkedList<GroupStatus> m_groupStatus;
 
     DISALLOW_COPY_AND_ASSIGN(EngineEffectChain);
 };

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -296,9 +296,6 @@ EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
     df.open(QIODevice::WriteOnly | QIODevice::Text);
     writer.setDevice(&df);
 #endif
-
-
-    m_hintList.reserve(256); // Avoid reallocation
 }
 
 EngineBuffer::~EngineBuffer()

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -29,6 +29,7 @@
 #include "configobject.h"
 #include "rotary.h"
 #include "control/controlvalue.h"
+#include "cachingreader.h"
 
 //for the writer
 #ifdef __SCALER_DEBUG__
@@ -65,8 +66,6 @@ class EngineSync;
 class EngineWorkerScheduler;
 class VisualPlayPosition;
 class EngineMaster;
-
-struct Hint;
 
 /**
   *@author Tue and Ken Haste Andersen
@@ -266,7 +265,7 @@ class EngineBuffer : public EngineObject {
     CachingReader* m_pReader;
 
     // List of hints to provide to the CachingReader
-    QVector<Hint> m_hintList;
+    HintVector m_hintList;
 
     // The current sample to play in the file.
     double m_filepos_play;

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -47,7 +47,7 @@ void EngineControl::trackLoaded(TrackPointer) {
 void EngineControl::trackUnloaded(TrackPointer) {
 }
 
-void EngineControl::hintReader(QVector<Hint>*) {
+void EngineControl::hintReader(HintVector*) {
 }
 
 void EngineControl::setEngineMaster(EngineMaster* pEngineMaster) {

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -12,10 +12,10 @@
 #include "trackinfoobject.h"
 #include "control/controlvalue.h"
 #include "engine/effects/groupfeaturestate.h"
+#include "cachingreader.h"
 
 class EngineMaster;
 class EngineBuffer;
-struct Hint;
 
 const double kNoTrigger = -1;
 
@@ -63,7 +63,7 @@ class EngineControl : public QObject {
     // hintReader allows the EngineControl to provide hints to the reader to
     // indicate that the given portion of a song is a potential imminent seek
     // target.
-    virtual void hintReader(QVector<Hint>* pHintList);
+    virtual void hintReader(HintVector* pHintList);
 
     virtual void setEngineMaster(EngineMaster* pEngineMaster);
     void setEngineBuffer(EngineBuffer* pEngineBuffer);

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -244,10 +244,9 @@ void EngineMaster::processChannels(unsigned int* busChannelConnectionFlags,
 
     EngineChannel* pMasterChannel = m_pMasterSync->getMaster();
     m_activeChannels.clear();
-    m_activeChannels.reserve(m_channels.size());
-    QList<ChannelInfo*>::iterator it = m_channels.begin();
-    for (unsigned int channel_number = 0;
-         it != m_channels.end(); ++it, ++channel_number) {
+    QList<ChannelInfo*>::const_iterator it = m_channels.constBegin();
+    QList<ChannelInfo*>::const_iterator end = m_channels.constEnd();
+    for (unsigned int channel_number = 0; it != end; ++it, ++channel_number) {
         ChannelInfo* pChannelInfo = *it;
         EngineChannel* pChannel = pChannelInfo->m_pChannel;
 

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -541,8 +541,8 @@ void EngineMaster::addChannel(EngineChannel* pChannel) {
 }
 
 EngineChannel* EngineMaster::getChannel(QString group) {
-    for (QList<ChannelInfo*>::const_iterator i = m_channels.begin();
-         i != m_channels.end(); ++i) {
+    for (QList<ChannelInfo*>::const_iterator i = m_channels.constBegin();
+         i != m_channels.constEnd(); ++i) {
         ChannelInfo* pChannelInfo = *i;
         if (pChannelInfo->m_pChannel->getGroup() == group) {
             return pChannelInfo->m_pChannel;

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -54,7 +54,12 @@ EngineMaster::EngineMaster(ConfigObject<ConfigValue>* _config,
           m_bRampingGain(bRampingGain),
           m_masterVolumeOld(0.0),
           m_headphoneMasterGainOld(0.0),
-          m_headphoneVolumeOld(1.0) {
+          m_headphoneVolumeOld(1.0),
+          m_masterGroup("[Master]"),
+          m_headphoneGroup("[Headphone]"),
+          m_busLeftGroup("[BusLeft]"),
+          m_busCenterGroup("[BusCenter]"),
+          m_busRightGroup("[BusRight]") {
     m_bBusOutputConnected[0] = false;
     m_bBusOutputConnected[1] = false;
     m_bBusOutputConnected[2] = false;

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -60,26 +60,25 @@ class EngineMaster : public QObject, public AudioSource {
     // be called by SoundManager.
     const CSAMPLE* buffer(AudioOutput output) const;
 
-    const QString getMasterGroup() const {
-        return QString("[Master]");
+    inline const QString& getMasterGroup() const {
+        return m_masterGroup;
     }
 
-    const QString getHeadphoneGroup() const {
-        return QString("[Headphone]");
+    inline const QString& getHeadphoneGroup() const {
+        return m_headphoneGroup;
     }
 
-    const QString getBusLeftGroup() const {
-        return QString("[BusLeft]");
+    inline const QString& getBusLeftGroup() const {
+        return m_busLeftGroup;
     }
 
-    const QString getBusCenterGroup() const {
-        return QString("[BusCenter]");
+    inline const QString& getBusCenterGroup() const {
+        return m_busCenterGroup;
     }
 
-    const QString getBusRightGroup() const {
-        return QString("[BusRight]");
+    inline const QString& getBusRightGroup() const {
+        return m_busRightGroup;
     }
-
 
     // WARNING: These methods are called by the main thread. They should only
     // touch the volatile bool connected indicators (see below). However, when
@@ -248,6 +247,12 @@ class EngineMaster : public QObject, public AudioSource {
     CSAMPLE m_masterVolumeOld;
     CSAMPLE m_headphoneMasterGainOld;
     CSAMPLE m_headphoneVolumeOld;
+
+    const QString m_masterGroup;
+    const QString m_headphoneGroup;
+    const QString m_busLeftGroup;
+    const QString m_busCenterGroup;
+    const QString m_busRightGroup;
 
     // Produce the Master Mixxx, not Required if connected to left
     // and right Bus and no recording and broadcast active

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -19,6 +19,7 @@
 #define ENGINEMASTER_H
 
 #include <QObject>
+#include <QVarLengthArray>
 
 #include "controlobject.h"
 #include "controlpushbutton.h"
@@ -205,7 +206,7 @@ class EngineMaster : public QObject, public AudioSource {
     EngineEffectsManager* m_pEngineEffectsManager;
     bool m_bRampingGain;
     QList<ChannelInfo*> m_channels;
-    QList<ChannelInfo*> m_activeChannels;
+    QVarLengthArray<ChannelInfo*, 128> m_activeChannels;
     QList<CSAMPLE> m_channelMasterGainCache;
     QList<CSAMPLE> m_channelHeadphoneGainCache;
 

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -358,7 +358,7 @@ double LoopingControl::getTrigger(const double dRate,
     return kNoTrigger;
 }
 
-void LoopingControl::hintReader(QVector<Hint>* pHintList) {
+void LoopingControl::hintReader(HintVector* pHintList) {
     Hint loop_hint;
     // If the loop is enabled, then this is high priority because we will loop
     // sometime potentially very soon! The current audio itself is priority 1,

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -53,7 +53,7 @@ class LoopingControl : public EngineControl {
 
     // hintReader will add to hintList hints both the loop in and loop out
     // sample, if set.
-    void hintReader(QVector<Hint>* pHintList);
+    void hintReader(HintVector* pHintList);
 
     void notifySeek(double dNewPlaypos);
 

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -158,7 +158,7 @@ void ReadAheadManager::notifySeek(int iSeekPosition) {
     // }
 }
 
-void ReadAheadManager::hintReader(double dRate, QVector<Hint>* pHintList) {
+void ReadAheadManager::hintReader(double dRate, HintVector* pHintList) {
     bool in_reverse = dRate < 0;
     Hint current_position;
 

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -36,7 +36,7 @@ int ReadAheadManager::getNextSamples(double dRate, CSAMPLE* buffer,
 
     // A loop will only limit the amount we can read in one shot.
 
-    const double loop_trigger = m_sEngineControls[0]->nextTrigger(
+    const double loop_trigger = m_sEngineControls.at(0)->nextTrigger(
         dRate, m_iCurrentPosition, 0, 0);
     bool loop_active = loop_trigger != kNoTrigger;
     int preloop_samples = 0;
@@ -83,7 +83,7 @@ int ReadAheadManager::getNextSamples(double dRate, CSAMPLE* buffer,
     if (loop_active) {
         // LoopingControl makes the decision about whether we should loop or
         // not.
-        const double loop_target = m_sEngineControls[0]->
+        const double loop_target = m_sEngineControls.at(0)->
                 process(dRate, m_iCurrentPosition, 0, 0);
 
         if (loop_target != kNoTrigger) {

--- a/src/engine/readaheadmanager.h
+++ b/src/engine/readaheadmanager.h
@@ -11,8 +11,8 @@
 
 #include "util/types.h"
 #include "util/math.h"
+#include "cachingreader.h"
 
-struct Hint;
 class EngineControl;
 class CachingReader;
 
@@ -54,7 +54,7 @@ class ReadAheadManager {
 
     // hintReader allows the ReadAheadManager to provide hints to the reader to
     // indicate that the given portion of a song is about to be read.
-    virtual void hintReader(double dRate, QVector<Hint>* hintList);
+    virtual void hintReader(double dRate, HintVector* hintList);
 
     virtual int getEffectiveVirtualPlaypositionFromLog(double currentVirtualPlayposition,
                                                        double numConsumedSamples);

--- a/src/sounddevice.cpp
+++ b/src/sounddevice.cpp
@@ -40,14 +40,6 @@ SoundDevice::SoundDevice(ConfigObject<ConfigValue> * config, SoundManager * sm)
 SoundDevice::~SoundDevice() {
 }
 
-QString SoundDevice::getDisplayName() const {
-    return m_strDisplayName;
-}
-
-QString SoundDevice::getHostAPI() const {
-    return m_hostAPI;
-}
-
 int SoundDevice::getNumInputChannels() const {
     return m_iNumInputChannels;
 }

--- a/src/sounddevice.h
+++ b/src/sounddevice.h
@@ -42,11 +42,15 @@ class SoundDevice {
     SoundDevice(ConfigObject<ConfigValue> *config, SoundManager* sm);
     virtual ~SoundDevice();
 
-    inline QString getInternalName() const {
+    inline const QString& getInternalName() const {
         return m_strInternalName;
     }
-    QString getDisplayName() const;
-    QString getHostAPI() const;
+    inline const QString& getDisplayName() const {
+        return m_strDisplayName;
+    }
+    inline const QString& getHostAPI() const {
+        return m_hostAPI;
+    }
     void setHostAPI(QString api);
     void setSampleRate(double sampleRate);
     void setFramesPerBuffer(unsigned int framesPerBuffer);

--- a/src/sounddeviceportaudio.cpp
+++ b/src/sounddeviceportaudio.cpp
@@ -752,9 +752,9 @@ int SoundDevicePortAudio::callbackProcess(const unsigned int framesPerBuffer,
 }
 
 int SoundDevicePortAudio::callbackProcessClkRef(const unsigned int framesPerBuffer,
-                                          CSAMPLE *out, const CSAMPLE *in,
-                                          const PaStreamCallbackTimeInfo *timeInfo,
-                                          PaStreamCallbackFlags statusFlags) {
+                                                CSAMPLE *out, const CSAMPLE *in,
+                                                const PaStreamCallbackTimeInfo *timeInfo,
+                                                PaStreamCallbackFlags statusFlags) {
     PerformanceTimer timer;
     timer.start();
     Trace trace("SoundDevicePortAudio::callbackProcessClkRef " + getInternalName());

--- a/src/sounddeviceportaudio.cpp
+++ b/src/sounddeviceportaudio.cpp
@@ -833,7 +833,7 @@ int SoundDevicePortAudio::callbackProcessClkRef(const unsigned int framesPerBuff
 
     m_pSoundManager->writeProcess();
 
-    m_nsInAudioCb += (int)timer.elapsed();
+    m_nsInAudioCb += timer.elapsed();
     return paContinue;
 }
 

--- a/src/sounddeviceportaudio.cpp
+++ b/src/sounddeviceportaudio.cpp
@@ -559,7 +559,7 @@ int SoundDevicePortAudio::callbackProcessDrift(const unsigned int framesPerBuffe
                                           const PaStreamCallbackTimeInfo *timeInfo,
                                           PaStreamCallbackFlags statusFlags) {
     Q_UNUSED(timeInfo);
-    Trace trace("SoundDevicePortAudio::callbackProcessDrift " + getInternalName());
+    Trace trace("SoundDevicePortAudio::callbackProcessDrift %1", getInternalName());
 
     //qDebug() << "SoundDevicePortAudio::callbackProcess:" << getInternalName();
     // Turn on TimeCritical priority for the callback thread. If we are running
@@ -695,7 +695,7 @@ int SoundDevicePortAudio::callbackProcess(const unsigned int framesPerBuffer,
                                           const PaStreamCallbackTimeInfo *timeInfo,
                                           PaStreamCallbackFlags statusFlags) {
     Q_UNUSED(timeInfo);
-    Trace trace("SoundDevicePortAudio::callbackProcess " + getInternalName());
+    Trace trace("SoundDevicePortAudio::callbackProcess %1", getInternalName());
 
     //qDebug() << "SoundDevicePortAudio::callbackProcess:" << getInternalName();
     // Turn on TimeCritical priority for the callback thread. If we are running
@@ -757,7 +757,8 @@ int SoundDevicePortAudio::callbackProcessClkRef(const unsigned int framesPerBuff
                                                 PaStreamCallbackFlags statusFlags) {
     PerformanceTimer timer;
     timer.start();
-    Trace trace("SoundDevicePortAudio::callbackProcessClkRef " + getInternalName());
+
+    Trace trace("SoundDevicePortAudio::callbackProcessClkRef %1", getInternalName());
 
     //qDebug() << "SoundDevicePortAudio::callbackProcess:" << getInternalName();
     // Turn on TimeCritical priority for the callback thread. If we are running

--- a/src/sounddeviceportaudio.h
+++ b/src/sounddeviceportaudio.h
@@ -96,7 +96,7 @@ class SoundDevicePortAudio : public SoundDevice {
     ControlObjectSlave* m_pMasterAudioLatencyOverload;
     int m_underflowUpdateCount;
     static volatile int m_underflowHappend;
-    int m_nsInAudioCb;
+    qint64 m_nsInAudioCb;
     int m_framesSinceAudioLatencyUsageUpdate;
     int m_syncBuffers;
 };

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -69,7 +69,7 @@ BeatMap::BeatMap(TrackPointer pTrack, int iSampleRate,
 }
 
 BeatMap::BeatMap(TrackPointer pTrack, int iSampleRate,
-                 const QVector<double> beats)
+                 const QVector<double>& beats)
         : QObject(),
           m_mutex(QMutex::Recursive) {
     initialize(pTrack, iSampleRate);
@@ -123,7 +123,7 @@ void BeatMap::readByteArray(const QByteArray* pByteArray) {
     onBeatlistChanged();
 }
 
-void BeatMap::createFromBeatVector(QVector<double> beats) {
+void BeatMap::createFromBeatVector(const QVector<double>& beats) {
     if (beats.isEmpty()) {
        return;
     }
@@ -534,7 +534,7 @@ double BeatMap::calculateBpm(const Beat& startBeat, const Beat& stopBeat) const 
         }
     }
 
-    if (beatvect.size() == 0) {
+    if (beatvect.isEmpty()) {
         return -1;
     }
 

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -33,7 +33,7 @@ class BeatMap : public QObject, public Beats {
     // zero then the track's sample rate will be used. A list of beat locations
     // in audio frames may be provided.
     BeatMap(TrackPointer pTrack, int iSampleRate,
-            const QVector<double> beats = QVector<double>());
+            const QVector<double>& beats);
     virtual ~BeatMap();
 
     // See method comments in beats.h
@@ -80,7 +80,7 @@ class BeatMap : public QObject, public Beats {
   private:
     void initialize(TrackPointer pTrack, int iSampleRate);
     void readByteArray(const QByteArray* pByteArray);
-    void createFromBeatVector(QVector<double> beats);
+    void createFromBeatVector(const QVector<double>& beats);
     void onBeatlistChanged();
 
     double calculateBpm(const mixxx::track::io::Beat& startBeat,

--- a/src/util/timer.cpp
+++ b/src/util/timer.cpp
@@ -12,9 +12,9 @@ void Timer::start() {
     m_time.start();
 }
 
-int Timer::restart(bool report) {
+qint64 Timer::restart(bool report) {
     if (m_running) {
-        int nsec = m_time.restart();
+        qint64 nsec = m_time.restart();
         if (report) {
             // Ignore the report if it crosses the experiment boundary.
             Experiment::Mode oldMode = Stat::modeFromFlags(m_compute);
@@ -29,8 +29,8 @@ int Timer::restart(bool report) {
     }
 }
 
-int Timer::elapsed(bool report) {
-    int nsec = m_time.elapsed();
+qint64 Timer::elapsed(bool report) {
+    qint64 nsec = m_time.elapsed();
     if (report) {
         // Ignore the report if it crosses the experiment boundary.
         Experiment::Mode oldMode = Stat::modeFromFlags(m_compute);
@@ -53,7 +53,7 @@ void SuspendableTimer::start() {
     Timer::start();
 }
 
-int SuspendableTimer::suspend() {
+qint64 SuspendableTimer::suspend() {
     m_leapTime += m_time.elapsed();
     m_running = false;
     return m_leapTime;
@@ -63,7 +63,7 @@ void SuspendableTimer::go() {
     Timer::start();
 }
 
-int SuspendableTimer::elapsed(bool report) {
+qint64 SuspendableTimer::elapsed(bool report) {
     m_leapTime += m_time.elapsed();
     if (report) {
         // Ignore the report if it crosses the experiment boundary.

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -20,11 +20,11 @@ class Timer {
     // Restart the timer returning the nanoseconds since it was last
     // started/restarted. If report is true, reports the elapsed time to the
     // associated Stat key.
-    int restart(bool report);
+    qint64 restart(bool report);
 
     // Returns nanoseconds since start/restart was called. If report is true,
     // reports the elapsed time to the associated Stat key.
-    int elapsed(bool report);
+    qint64 elapsed(bool report);
 
   protected:
     QString m_key;
@@ -38,12 +38,12 @@ class SuspendableTimer : public Timer {
     SuspendableTimer(const QString& key,
             Stat::ComputeFlags compute = kDefaultComputeFlags);
     void start();
-    int suspend();
+    qint64 suspend();
     void go();
-    int elapsed(bool report);
+    qint64 elapsed(bool report);
 
   private:
-    int m_leapTime;
+    qint64 m_leapTime;
 };
 
 class ScopedTimer {

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -53,7 +53,7 @@ class ScopedTimer {
             : m_pTimer(NULL),
               m_cancel(false) {
         if (CmdlineArgs::Instance().getDeveloper()) {
-            initalize(QString(key), QString::number(i), compute);
+            initialize(QString(key), QString::number(i), compute);
         }
     }
 
@@ -62,7 +62,7 @@ class ScopedTimer {
             : m_pTimer(NULL),
               m_cancel(false) {
         if (CmdlineArgs::Instance().getDeveloper()) {
-            initalize(QString(key), arg ? QString(arg) : QString(), compute);
+            initialize(QString(key), arg ? QString(arg) : QString(), compute);
         }
     }
 
@@ -71,7 +71,7 @@ class ScopedTimer {
             : m_pTimer(NULL),
               m_cancel(false) {
         if (CmdlineArgs::Instance().getDeveloper()) {
-            initalize(QString(key), arg, compute);
+            initialize(QString(key), arg, compute);
         }
     }
 
@@ -84,7 +84,7 @@ class ScopedTimer {
         }
     }
 
-    inline void initalize(const QString& key, const QString& arg,
+    inline void initialize(const QString& key, const QString& arg,
                 Stat::ComputeFlags compute = kDefaultComputeFlags) {
         QString strKey;
         if (arg.isEmpty()) {

--- a/src/util/trace.h
+++ b/src/util/trace.h
@@ -11,10 +11,70 @@
 
 class Trace {
   public:
-    explicit Trace(const QString& tag, bool writeToStdout=false, bool time=true)
-            : m_tag(tag),
-              m_writeToStdout(writeToStdout),
+    Trace(const char* tag, const char* arg=NULL,
+          bool writeToStdout=false, bool time=true)
+            : m_writeToStdout(writeToStdout),
               m_time(time) {
+        if (writeToStdout || CmdlineArgs::Instance().getDeveloper()) {
+            initialize(tag, arg);
+        }
+    }
+
+    Trace(const char* tag, int arg,
+          bool writeToStdout=false, bool time=true)
+            : m_writeToStdout(writeToStdout),
+              m_time(time) {
+        if (writeToStdout || CmdlineArgs::Instance().getDeveloper()) {
+            initialize(tag, QString::number(arg));
+        }
+    }
+
+    Trace(const char* tag, const QString& arg,
+          bool writeToStdout=false, bool time=true)
+            : m_writeToStdout(writeToStdout),
+              m_time(time) {
+        if (writeToStdout || CmdlineArgs::Instance().getDeveloper()) {
+            initialize(tag, arg);
+        }
+    }
+
+    virtual ~Trace() {
+        // Proxy for whether initialize was called.
+        if (!m_tag.isEmpty()) {
+            Event::end(m_tag);
+
+            qint64 elapsed = m_time ? m_timer.elapsed() : 0;
+            if (m_writeToStdout) {
+                if (m_time) {
+                    qDebug() << "END [" << m_tag << "]"
+                             << QString("elapsed: %1ns").arg(elapsed);
+                } else {
+                    qDebug() << "END [" << m_tag << "]";
+                }
+            }
+            if (m_time) {
+                // NOTE(rryan) do we need to do this string append? We could add
+                // a check in StatsManager to infer that a DURATION_NANOSEC
+                // event for the same tag that has an EVENT_START/EVENT_END is a
+                // duration instead of changing the tag.
+                Stat::track(
+                        m_tag + "_duration",
+                        Stat::DURATION_NANOSEC,
+                        Stat::COUNT | Stat::AVERAGE | Stat::SAMPLE_VARIANCE |
+                        Stat::MAX | Stat::MIN,
+                        elapsed);
+            }
+        }
+    }
+
+  private:
+    void initialize(const QString& key, const QString& arg) {
+        if (arg.isEmpty()) {
+            m_tag = key;
+        } else {
+            m_tag = key.arg(arg);
+        }
+
         Event::start(m_tag);
         if (m_time) {
             m_timer.start();
@@ -23,28 +83,8 @@ class Trace {
             qDebug() << "START [" << m_tag << "]";
         }
     }
-    virtual ~Trace() {
-        Event::end(m_tag);
-        qint64 elapsed = m_time ? m_timer.elapsed() : 0;
-        if (m_writeToStdout) {
-            if (m_time) {
-                qDebug() << "END [" << m_tag << "]"
-                         << QString("elapsed: %1ns").arg(elapsed);
-            } else {
-                qDebug() << "END [" << m_tag << "]";
-            }
-        }
-        if (m_time) {
-            Stat::track(
-                m_tag + "_duration",
-                Stat::DURATION_NANOSEC,
-                Stat::COUNT | Stat::AVERAGE | Stat::SAMPLE_VARIANCE | Stat::MAX | Stat::MIN,
-                elapsed);
-        }
-    }
 
-  private:
-    const QString m_tag;
+    QString m_tag;
     const bool m_writeToStdout, m_time;
     PerformanceTimer m_timer;
 
@@ -52,8 +92,8 @@ class Trace {
 
 class DebugTrace : public Trace {
   public:
-    DebugTrace(const QString& tag, bool time=true)
-    : Trace(tag, CmdlineArgs::Instance().getDeveloper(), time) {
+    DebugTrace(const char* tag, bool time=true)
+            : Trace(tag, "", CmdlineArgs::Instance().getDeveloper(), time) {
     }
     virtual ~DebugTrace() {
     }


### PR DESCRIPTION
Trim some fat. Shaves about 6% off of my single-track-playing CPU usage.

My heuristic for choosing what to attack was whether it occupied more than 1% of profiler samples within the paV19CallbackClkRef tree (there were some other minor changes, too).
