### PR TITLE
Seek test

### DIFF
--- a/src/soundsourcemp3.cpp
+++ b/src/soundsourcemp3.cpp
@@ -249,6 +249,10 @@ long SoundSourceMp3::seek(long filepos) {
                           inputbuf_len-(long int)(cur->m_pStreamPos-(unsigned char *)inputbuf));
         mad_synth_init(Synth);
         mad_frame_init(Frame);
+        // Decode first header here, to start without extra mad_frame_decode
+        if (mad_header_decode(&Frame->header, Stream)) {
+            // TODO(error)
+        }
     } else {
         // Start four frames before wanted frame to get in sync...
         m_currentSeekFrameIndex -= kPreSeekFrames;
@@ -262,6 +266,10 @@ long SoundSourceMp3::seek(long filepos) {
             //        qDebug() << "mp3 restore " << cur->m_pStreamPos;
             mad_stream_buffer(Stream, (const unsigned char *)(cur->m_pStreamPos),
                               inputbuf_len-(long int)(cur->m_pStreamPos-(unsigned char *)inputbuf));
+            // Decode first header here, to start without extra mad_frame_decode
+            if (mad_header_decode(&Frame->header, Stream)) {
+                // TODO(error)
+            }
 
             // Mute'ing is done here to eliminate potential pops/clicks from skipping
             // Rob Leslie explains why here:

--- a/src/soundsourcemp3.cpp
+++ b/src/soundsourcemp3.cpp
@@ -151,9 +151,9 @@ Result SoundSourceMp3::open() {
         p->m_pStreamPos = (unsigned char *)Stream->this_frame;
         p->pos = length();
         mad_timer_add (&filelength, Header.duration);
-        if (m_qSeekList.size() < 40) {
+        //if (m_qSeekList.size() < 40) {
             qDebug() << p->m_pStreamPos << *p->m_pStreamPos << p->pos << m_qSeekList.size();
-        }
+        //}
         m_qSeekList.append(p);
         currentframe++;
     }

--- a/src/soundsourcemp3.cpp
+++ b/src/soundsourcemp3.cpp
@@ -22,7 +22,7 @@
 
 #include <QtDebug>
 
-const int kPreSeekFrames = 4; // Start four frames before wanted frame to get in sync...
+const int kPreSeekFrames = 29; // Start four frames before wanted frame to get in sync...
 
 SoundSourceMp3::SoundSourceMp3(QString qFilename) :
         Mixxx::SoundSource(qFilename),
@@ -151,9 +151,9 @@ Result SoundSourceMp3::open() {
         p->m_pStreamPos = (unsigned char *)Stream->this_frame;
         p->pos = length();
         mad_timer_add (&filelength, Header.duration);
-        //if (m_qSeekList.size() < 11) {
-        //    qDebug() << p->m_pStreamPos << *p->m_pStreamPos << p->pos << m_qSeekList.size();
-        //}
+        if (m_qSeekList.size() < 40) {
+            qDebug() << p->m_pStreamPos << *p->m_pStreamPos << p->pos << m_qSeekList.size();
+        }
         m_qSeekList.append(p);
         currentframe++;
     }
@@ -461,7 +461,7 @@ unsigned SoundSourceMp3::read(unsigned long samples_wanted, const SAMPLE * _dest
     while (Total_samples_decoded < samples_wanted)
     {
         // qDebug() << "no " << Total_samples_decoded;
-        //qDebug() << "mad_frame_decode" << "read" << Stream->this_frame;
+        qDebug() << "mad_frame_decode" << "read" << Stream->this_frame;
         unsigned char const *frameBefore = Stream->this_frame;
         if(mad_frame_decode(Frame,Stream))
         {

--- a/src/soundsourcemp3.cpp
+++ b/src/soundsourcemp3.cpp
@@ -144,13 +144,16 @@ Result SoundSourceMp3::open() {
 
         setChannels(2); // always pretend to read 2 channels
         m_iChannels = MAD_NCHANNELS(&Header);
-        mad_timer_add (&filelength, Header.duration);
         bitrate += Header.bitrate;
 
         // Add frame to list of frames
         MadSeekFrameType * p = new MadSeekFrameType;
         p->m_pStreamPos = (unsigned char *)Stream->this_frame;
         p->pos = length();
+        mad_timer_add (&filelength, Header.duration);
+        //if (m_qSeekList.size() < 11) {
+        //    qDebug() << p->m_pStreamPos << *p->m_pStreamPos << p->pos << m_qSeekList.size();
+        //}
         m_qSeekList.append(p);
         currentframe++;
     }
@@ -226,134 +229,73 @@ long SoundSourceMp3::seek(long filepos) {
 
     MadSeekFrameType* cur = NULL;
 
-    if (filepos == 0) {
-        // Seek to beginning of file
+    int framePos = findFrame(filepos);
+    if (framePos == 0 || framePos > filepos || m_currentSeekFrameIndex <= kPreSeekFrames) {
+        //qDebug() << "Problem finding good seek frame (wanted " << filepos << ", got " << framePos << "), starting from 0";
+
+        rest = -1;
+        m_currentSeekFrameIndex = 0;
+        cur = getSeekFrame(m_currentSeekFrameIndex);
+
+        //qDebug() << "seek" << cur->m_pStreamPos;
 
         // Re-init buffer:
+        mad_frame_finish(Frame);
+        mad_synth_finish(Synth);
         mad_stream_finish(Stream);
         mad_stream_init(Stream);
         mad_stream_options(Stream, MAD_OPTION_IGNORECRC);
-        mad_stream_buffer(Stream, (unsigned char *) inputbuf, inputbuf_len);
-        mad_frame_init(Frame);
+        mad_stream_buffer(Stream, (const unsigned char *)(cur->m_pStreamPos),
+                          inputbuf_len-(long int)(cur->m_pStreamPos-(unsigned char *)inputbuf));
         mad_synth_init(Synth);
-        rest=-1;
-
-        m_currentSeekFrameIndex = 0;
-        //cur = getSeekFrame(0);
-        //frameIterator.toFront(); //Might not need to do this -- Albert June 19/2010 (during Qt3 purge)
+        mad_frame_init(Frame);
     } else {
-        //qDebug() << "seek precise";
-        // Perform precise seek accomplished by using a frame in the seek list
-
-        // Find the frame to seek to in the list
-        /*
-           MadSeekFrameType *cur = m_qSeekList.last();
-           int k=0;
-           while (cur!=0 && cur->pos>filepos)
-           {
-            cur = m_qSeekList.prev();
-         ++k;
-           }
-         */
-
-        int framePos = findFrame(filepos);
-        if (framePos == 0 || framePos > filepos || m_currentSeekFrameIndex <= kPreSeekFrames) {
-            qDebug() << "Problem finding good seek frame (wanted " << filepos << ", got " << framePos << "), starting from 0";
-
-            // Re-init buffer:
+        // Start four frames before wanted frame to get in sync...
+        m_currentSeekFrameIndex -= kPreSeekFrames;
+        cur = getSeekFrame(m_currentSeekFrameIndex);
+        if (cur != NULL) {
+            //qDebug() << "frame pos " << cur->pos;
+            // Start from the new frame
             mad_stream_finish(Stream);
             mad_stream_init(Stream);
             mad_stream_options(Stream, MAD_OPTION_IGNORECRC);
-            mad_stream_buffer(Stream, (unsigned char *) inputbuf, inputbuf_len);
-            mad_frame_init(Frame);
-            mad_synth_init(Synth);
+            //        qDebug() << "mp3 restore " << cur->m_pStreamPos;
+            mad_stream_buffer(Stream, (const unsigned char *)(cur->m_pStreamPos),
+                              inputbuf_len-(long int)(cur->m_pStreamPos-(unsigned char *)inputbuf));
+
+            // Mute'ing is done here to eliminate potential pops/clicks from skipping
+            // Rob Leslie explains why here:
+            // http://www.mars.org/mailman/public/mad-dev/2001-August/000321.html
+            mad_synth_mute(Synth);
+            mad_frame_mute(Frame);
+
+            /*
+            // Decode the three frames before
+            mad_frame_decode(Frame, Stream);
+            mad_frame_decode(Frame, Stream);
+            mad_frame_decode(Frame, Stream);
+            mad_frame_decode(Frame, Stream);
+
+            // this is also explained in the above mad-dev post
+            mad_synth_frame(Synth, Frame);
+
+
+            // Set current position
             rest = -1;
-            m_currentSeekFrameIndex = 0;
+            m_currentSeekFrameIndex += kPreSeekFrames;
+            */
+            // Set current position
+            rest = -1;
             cur = getSeekFrame(m_currentSeekFrameIndex);
-        } else {
-            //if (cur != NULL) {
-            //    qDebug() << "frame pos " << cur->pos;
-            //}
-
-            // Start four frames before wanted frame to get in sync...
-            m_currentSeekFrameIndex -= kPreSeekFrames;
-            cur = getSeekFrame(m_currentSeekFrameIndex);
-            if (cur != NULL) {
-                // Start from the new frame
-                mad_stream_finish(Stream);
-                mad_stream_init(Stream);
-                mad_stream_options(Stream, MAD_OPTION_IGNORECRC);
-                //        qDebug() << "mp3 restore " << cur->m_pStreamPos;
-                mad_stream_buffer(Stream, (const unsigned char *)cur->m_pStreamPos,
-                                  inputbuf_len-(long int)(cur->m_pStreamPos-(unsigned char *)inputbuf));
-
-                // Mute'ing is done here to eliminate potential pops/clicks from skipping
-                // Rob Leslie explains why here:
-                // http://www.mars.org/mailman/public/mad-dev/2001-August/000321.html
-                mad_synth_mute(Synth);
-                mad_frame_mute(Frame);
-
-                // Decode the three frames before
-                mad_frame_decode(Frame, Stream);
-                mad_frame_decode(Frame, Stream);
-                mad_frame_decode(Frame, Stream);
-                mad_frame_decode(Frame, Stream);
-
-                // this is also explained in the above mad-dev post
-                mad_synth_frame(Synth, Frame);
-
-                // Set current position
-                rest = -1;
-                m_currentSeekFrameIndex += kPreSeekFrames;
-                cur = getSeekFrame(m_currentSeekFrameIndex);
-            }
         }
-
-        // Synthesize the samples from the frame which should be discard to reach the requested position
-        if (cur != NULL) //the "if" prevents crashes on bad files.
-            discard(filepos-cur->pos);
     }
-/*
-    else
-    {
-        qDebug() << "seek unprecise";
-        // Perform seek which is can not be done precise because no frames is in the seek list
 
-        int newpos = (int)(inputbuf_len * ((float)filepos/(float)length()));
-   //        qDebug() << "Seek to " << filepos << " " << inputbuf_len << " " << newpos;
-
-        // Go to an approximate position:
-        mad_stream_buffer(Stream, (unsigned char *) (inputbuf+newpos), inputbuf_len-newpos);
-        mad_synth_mute(Synth);
-        mad_frame_mute(Frame);
-
-        // Decode a few (possible wrong) buffers:
-        int no = 0;
-        int succesfull = 0;
-        while ((no<10) && (succesfull<2))
-        {
-            if (!mad_frame_decode(Frame, Stream))
-            succesfull ++;
-            no ++;
-        }
-
-        // Discard the first synth:
-        mad_synth_frame(Synth, Frame);
-
-        // Remaining samples in buffer are useless
-        rest = -1;
-
-        // Reset seek frame list
-        m_qSeekList.clear();
-        MadSeekFrameType *p = new MadSeekFrameType;
-        p->m_pStreamPos = (unsigned char*)Stream->this_frame;
-        p->pos = filepos;
-        m_qSeekList.append(p);
-        m_iSeekListMinPos = filepos;
-        m_iSeekListMaxPos = filepos;
-        m_iCurFramePos = filepos;
+    // Synthesize the samples from the frame which should be discard to reach the requested position
+    if (cur != NULL) { //the "if" prevents crashes on bad files.
+        SoundSourceMp3::read(filepos - cur->pos, NULL);
+        // discard(filepos - cur->pos);
     }
- */
+
 
     // Unfortunately we don't know the exact fileposition. The returned position is thus an
     // approximation only:
@@ -408,32 +350,45 @@ inline long unsigned SoundSourceMp3::length() {
 
 unsigned long SoundSourceMp3::discard(unsigned long samples_wanted) {
     unsigned long Total_samples_decoded = 0;
-    int no = 0;
 
-    if (rest > 0)
-        Total_samples_decoded += 2*(Synth->pcm.length-rest);
+    if (rest > 0) {
+        Total_samples_decoded += 2 * (Synth->pcm.length - rest);
+    }
 
     while (Total_samples_decoded < samples_wanted) {
+        //qDebug() << "mad_frame_decode" << "discard" << Stream->this_frame;
         if (mad_frame_decode(Frame, Stream)) {
-            if (MAD_RECOVERABLE(Stream->error)) {
+            if(MAD_RECOVERABLE(Stream->error))
+            {
+                if(Stream->error == MAD_ERROR_LOSTSYNC) {
+                    // Ignore LOSTSYNC due to ID3 tags
+                    int tagsize = id3_tag_query(Stream->this_frame, Stream->bufend - Stream->this_frame);
+                    if(tagsize > 0) {
+                        //qDebug() << "SSMP3::Read Skipping ID3 tag size: " << tagsize;
+                        mad_stream_skip(Stream, tagsize);
+                    }
+                    continue;
+                }
+                //qDebug() << "MAD: Recoverable frame level ERR (" << mad_stream_errorstr(Stream) << ")";
                 continue;
-            } else if(Stream->error == MAD_ERROR_BUFLEN) {
+            } else if(Stream->error==MAD_ERROR_BUFLEN) {
+                // qDebug() << "MAD: buflen ERR";
                 break;
             } else {
+                // qDebug() << "MAD: Unrecoverable frame level ERR (" << mad_stream_errorstr(Stream) << ").";
                 break;
             }
         }
         mad_synth_frame(Synth, Frame);
-        no = math_min<int>(Synth->pcm.length,(samples_wanted-Total_samples_decoded)/2);
-        Total_samples_decoded += 2*no;
+        //qDebug() << Synth->pcm.length << "discard";
+        Total_samples_decoded += 2 * Synth->pcm.length;
     }
 
-    if (Synth->pcm.length > no)
-        rest = no;
-    else
-        rest = -1;
+    rest = (Total_samples_decoded - samples_wanted) / 2;
 
-    return Total_samples_decoded;
+    //qDebug() << "discard" << Total_samples_decoded << samples_wanted;
+
+    return samples_wanted;
 }
 
 /*
@@ -459,33 +414,35 @@ unsigned SoundSourceMp3::read(unsigned long samples_wanted, const SAMPLE * _dest
     unsigned Total_samples_decoded = 0;
     int i;
 
+    //qDebug() << "rest" << rest;
+
     // If samples are left from previous read, then copy them to start of destination
     // Make sure to take into account the case where there are more samples left over
     // from the previous read than the client requested.
     if (rest > 0)
     {
-        for (i=rest; i<Synth->pcm.length && Total_samples_decoded < samples_wanted; i++)
+        for (i = Synth->pcm.length - rest; i < Synth->pcm.length && Total_samples_decoded < samples_wanted; i++)
         {
-            // Left channel
-            *(destination++) = madScale(Synth->pcm.samples[0][i]);
+            if ( destination) {
 
-            /* Right channel. If the decoded stream is monophonic then
-            * the right output channel is the same as the left one. */
-            if (m_iChannels>1)
-                *(destination++) = madScale(Synth->pcm.samples[1][i]);
-            else
+                // Left channel
                 *(destination++) = madScale(Synth->pcm.samples[0][i]);
+
+                /* Right channel. If the decoded stream is monophonic then
+                * the right output channel is the same as the left one. */
+                if (m_iChannels>1)
+                    *(destination++) = madScale(Synth->pcm.samples[1][i]);
+                else
+                    *(destination++) = madScale(Synth->pcm.samples[0][i]);
+            }
 
             // This is safe because we have checked that samples_wanted is even.
             Total_samples_decoded += 2;
+            rest--;
 
         }
 
         if(Total_samples_decoded >= samples_wanted) {
-            if(i < Synth->pcm.length)
-                rest = i;
-            else
-                rest = -1;
             return Total_samples_decoded;
         }
     }
@@ -496,6 +453,8 @@ unsigned SoundSourceMp3::read(unsigned long samples_wanted, const SAMPLE * _dest
     while (Total_samples_decoded < samples_wanted)
     {
         // qDebug() << "no " << Total_samples_decoded;
+        //qDebug() << "mad_frame_decode" << "read" << Stream->this_frame;
+        unsigned char const *frameBefore = Stream->this_frame;
         if(mad_frame_decode(Frame,Stream))
         {
             if(MAD_RECOVERABLE(Stream->error))
@@ -519,6 +478,10 @@ unsigned SoundSourceMp3::read(unsigned long samples_wanted, const SAMPLE * _dest
                 break;
             }
         }
+        if (frameBefore == Stream->this_frame) {
+            // No seek, try again
+            continue;
+        }
 
         ++frames;
 
@@ -526,6 +489,7 @@ unsigned SoundSourceMp3::read(unsigned long samples_wanted, const SAMPLE * _dest
          * are reported by mad_synth_frame();
          */
         mad_synth_frame(Synth,Frame);
+        //qDebug() << "mad_synth_frame";
 
         // Number of channels in frame
         //ch = MAD_NCHANNELS(&Frame->header);
@@ -539,28 +503,28 @@ unsigned SoundSourceMp3::read(unsigned long samples_wanted, const SAMPLE * _dest
 
 //         qDebug() << "synthlen " << Synth->pcm.length << ", remain " << (samples_wanted-Total_samples_decoded);
         no = math_min<int>(Synth->pcm.length,(samples_wanted-Total_samples_decoded)/2);
-        for (i=0; i<no; i++)
+        rest = Synth->pcm.length;
+        for (i = 0; i < no; i++)
         {
-            // Left channel
-            *(destination++) = madScale(Synth->pcm.samples[0][i]);
-
-            /* Right channel. If the decoded stream is monophonic then
-            * the right output channel is the same as the left one. */
-            if (m_iChannels==2)
-                *(destination++) = madScale(Synth->pcm.samples[1][i]);
-            else
+            if ( destination) {
+                // Left channel
                 *(destination++) = madScale(Synth->pcm.samples[0][i]);
+
+                /* Right channel. If the decoded stream is monophonic then
+                * the right output channel is the same as the left one. */
+                if (m_iChannels==2)
+                    *(destination++) = madScale(Synth->pcm.samples[1][i]);
+                else
+                    *(destination++) = madScale(Synth->pcm.samples[0][i]);
+            }
+
+            Total_samples_decoded += 2;
+            rest--;
         }
-        Total_samples_decoded += 2*no;
+
 
         // qDebug() << "decoded: " << Total_samples_decoded << ", wanted: " << samples_wanted;
     }
-
-    // If samples are still left in buffer, set rest to the index of the unused samples
-    if (Synth->pcm.length > no)
-        rest = no;
-    else
-        rest = -1;
 
     // qDebug() << "decoded " << Total_samples_decoded << " samples in " << frames << " frames, rest: " << rest << ", chan " << m_iChannels;
     return Total_samples_decoded;

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -56,3 +56,38 @@ TEST_F(SoundSourceProxyTest, TOAL_TPE2) {
     EXPECT_EQ("ARTIST", p->getAlbum());
     EXPECT_EQ("TITLE", p->getAlbumArtist());
 }
+
+TEST_F(SoundSourceProxyTest, seekTheSame) {
+    const int kTestSampleCount = 10;
+    const int kSeekSample = 10000;
+
+    const QString kFilePath(
+            QDir::currentPath() + "/src/test/id3-test-data/cover-test.");
+
+    QStringList extensions;
+    extensions << "aiff" << "flac" << "mp3" << "ogg" << "wav";
+
+    foreach (const QString& extension, extensions) {
+        QString filePath = kFilePath + extension;
+
+        Mixxx::SoundSourcePointer pSoundSource1(loadProxy(filePath));
+        EXPECT_EQ(OK, pSoundSource1->open());
+        SAMPLE *pData1 = new SAMPLE[kTestSampleCount];
+        pSoundSource1->seek(kSeekSample);
+        unsigned int read1 = pSoundSource1->read(kTestSampleCount, pData1);
+        EXPECT_EQ(read1, kTestSampleCount);
+
+        Mixxx::SoundSourcePointer pSoundSource2(loadProxy(filePath));
+        EXPECT_EQ(OK, pSoundSource2->open());
+        SAMPLE *pData2 = new SAMPLE[kTestSampleCount];
+        pSoundSource2->seek(kSeekSample);
+        unsigned int read2 = pSoundSource2->read(kTestSampleCount, pData2);
+        EXPECT_EQ(read2, kTestSampleCount);
+
+        for( int i = 0; i < kTestSampleCount; i++) {
+            EXPECT_EQ(pData1[i], pData2[i]);
+            //qDebug() << pData1[i];
+        }
+    }
+}
+

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -86,8 +86,93 @@ TEST_F(SoundSourceProxyTest, seekTheSame) {
 
         for( int i = 0; i < kTestSampleCount; i++) {
             EXPECT_EQ(pData1[i], pData2[i]);
+            if (pData1[i] != pData2[i]) {
+                qDebug() << filePath << "Test Sample"  << i;
+                break;
+            }
             //qDebug() << pData1[i];
         }
     }
 }
+
+
+TEST_F(SoundSourceProxyTest, readBeforeSeek) {
+    const int kTestSampleCount = 10;
+    const int kSeekSample = 10000;
+
+    const QString kFilePath(
+            QDir::currentPath() + "/src/test/id3-test-data/cover-test.");
+
+    QStringList extensions;
+    extensions << "aiff" << "flac" << "mp3" << "ogg" << "wav";
+
+    foreach (const QString& extension, extensions) {
+        QString filePath = kFilePath + extension;
+
+        Mixxx::SoundSourcePointer pSoundSource1(loadProxy(filePath));
+        EXPECT_EQ(OK, pSoundSource1->open());
+        SAMPLE *pData1 = new SAMPLE[kTestSampleCount];
+        unsigned int read1 = pSoundSource1->read(kTestSampleCount, pData1);
+        EXPECT_EQ(read1, kTestSampleCount);
+        pSoundSource1->seek(kSeekSample);
+        read1 = pSoundSource1->read(kTestSampleCount, pData1);
+        EXPECT_EQ(read1, kTestSampleCount);
+
+        Mixxx::SoundSourcePointer pSoundSource2(loadProxy(filePath));
+        EXPECT_EQ(OK, pSoundSource2->open());
+        SAMPLE *pData2 = new SAMPLE[kTestSampleCount];
+        pSoundSource2->seek(kSeekSample);
+        unsigned int read2 = pSoundSource2->read(kTestSampleCount, pData2);
+        EXPECT_EQ(read2, kTestSampleCount);
+
+        for( int i = 0; i < kTestSampleCount; i++) {
+            EXPECT_EQ(pData1[i], pData2[i]);
+            if (pData1[i] != pData2[i]) {
+                qDebug() << filePath << "Test Sample"  << i;
+                break;
+            }
+            //qDebug() << pData1[i];
+        }
+    }
+}
+
+TEST_F(SoundSourceProxyTest, seekForward) {
+    const int kTestSampleCount = 10;
+    const int kSeekSample = 10000;
+
+    const QString kFilePath(
+            QDir::currentPath() + "/src/test/id3-test-data/cover-test.");
+
+    QStringList extensions;
+    extensions << "aiff" << "flac" << "wav"  << "ogg" << "mp3";
+
+    foreach (const QString& extension, extensions) {
+        QString filePath = kFilePath + extension;
+
+        Mixxx::SoundSourcePointer pSoundSource1(loadProxy(filePath));
+        EXPECT_EQ(OK, pSoundSource1->open());
+        SAMPLE *pData1 = new SAMPLE[kTestSampleCount];
+        for(int i = 0; i <= kSeekSample / kTestSampleCount; ++i) {
+            unsigned int read1 = pSoundSource1->read(kTestSampleCount, pData1);
+            EXPECT_EQ(read1, kTestSampleCount);
+        }
+
+        Mixxx::SoundSourcePointer pSoundSource2(loadProxy(filePath));
+        EXPECT_EQ(OK, pSoundSource2->open());
+        SAMPLE *pData2 = new SAMPLE[kTestSampleCount];
+        pSoundSource2->seek(kSeekSample);
+        unsigned int read2 = pSoundSource2->read(kTestSampleCount, pData2);
+        EXPECT_EQ(read2, kTestSampleCount);
+
+        for( int i = 0; i < kTestSampleCount; i++) {
+            EXPECT_EQ(pData1[i], pData2[i]);
+            if (pData1[i] != pData2[i]) {
+                qDebug() << filePath << "Test Sample" << i;
+                break;
+            }
+        }
+    }
+}
+
+
 

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -66,20 +66,21 @@ TEST_F(SoundSourceProxyTest, seekTheSame) {
 
     QStringList extensions;
     extensions << "aiff" << "flac" << "mp3" << "ogg" << "wav";
+    
+    SAMPLE *pData1 = new SAMPLE[kTestSampleCount];
+    SAMPLE *pData2 = new SAMPLE[kTestSampleCount];
 
     foreach (const QString& extension, extensions) {
         QString filePath = kFilePath + extension;
 
         Mixxx::SoundSourcePointer pSoundSource1(loadProxy(filePath));
         EXPECT_EQ(OK, pSoundSource1->open());
-        SAMPLE *pData1 = new SAMPLE[kTestSampleCount];
         pSoundSource1->seek(kSeekSample);
         unsigned int read1 = pSoundSource1->read(kTestSampleCount, pData1);
         EXPECT_EQ(read1, kTestSampleCount);
 
         Mixxx::SoundSourcePointer pSoundSource2(loadProxy(filePath));
         EXPECT_EQ(OK, pSoundSource2->open());
-        SAMPLE *pData2 = new SAMPLE[kTestSampleCount];
         pSoundSource2->seek(kSeekSample);
         unsigned int read2 = pSoundSource2->read(kTestSampleCount, pData2);
         EXPECT_EQ(read2, kTestSampleCount);
@@ -93,6 +94,8 @@ TEST_F(SoundSourceProxyTest, seekTheSame) {
             //qDebug() << pData1[i];
         }
     }
+    delete[] pData1;
+    delete[] pData2;
 }
 
 
@@ -105,6 +108,9 @@ TEST_F(SoundSourceProxyTest, readBeforeSeek) {
 
     QStringList extensions;
     extensions << "aiff" << "flac" << "mp3" << "ogg" << "wav";
+
+    SAMPLE *pData1 = new SAMPLE[kTestSampleCount];
+    SAMPLE *pData2 = new SAMPLE[kTestSampleCount];
 
     foreach (const QString& extension, extensions) {
         QString filePath = kFilePath + extension;
@@ -134,6 +140,8 @@ TEST_F(SoundSourceProxyTest, readBeforeSeek) {
             //qDebug() << pData1[i];
         }
     }
+    delete[] pData1;
+    delete[] pData2;
 }
 
 TEST_F(SoundSourceProxyTest, seekForward) {
@@ -146,12 +154,14 @@ TEST_F(SoundSourceProxyTest, seekForward) {
     QStringList extensions;
     extensions << "aiff" << "flac" << "wav"  << "ogg" << "mp3";
 
+    SAMPLE *pData1 = new SAMPLE[kTestSampleCount];
+    SAMPLE *pData2 = new SAMPLE[kTestSampleCount];
+
     foreach (const QString& extension, extensions) {
         QString filePath = kFilePath + extension;
 
         Mixxx::SoundSourcePointer pSoundSource1(loadProxy(filePath));
         EXPECT_EQ(OK, pSoundSource1->open());
-        SAMPLE *pData1 = new SAMPLE[kTestSampleCount];
         for(int i = 0; i <= kSeekSample / kTestSampleCount; ++i) {
             unsigned int read1 = pSoundSource1->read(kTestSampleCount, pData1);
             EXPECT_EQ(read1, kTestSampleCount);
@@ -159,7 +169,6 @@ TEST_F(SoundSourceProxyTest, seekForward) {
 
         Mixxx::SoundSourcePointer pSoundSource2(loadProxy(filePath));
         EXPECT_EQ(OK, pSoundSource2->open());
-        SAMPLE *pData2 = new SAMPLE[kTestSampleCount];
         pSoundSource2->seek(kSeekSample);
         unsigned int read2 = pSoundSource2->read(kTestSampleCount, pData2);
         EXPECT_EQ(read2, kTestSampleCount);
@@ -172,7 +181,6 @@ TEST_F(SoundSourceProxyTest, seekForward) {
             }
         }
     }
+    delete[] pData1;
+    delete[] pData2;
 }
-
-
-

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -145,8 +145,10 @@ TEST_F(SoundSourceProxyTest, readBeforeSeek) {
 }
 
 TEST_F(SoundSourceProxyTest, seekForward) {
-    const int kTestSampleCount = 10;
-    const int kSeekSample = 10000;
+    const unsigned int kSeekFrameIndex = 10000;
+    const unsigned int kTestFrameCount = 100;
+
+    EXPECT_EQ(0, int(kSeekFrameIndex % kTestFrameCount));
 
     const QString kFilePath(
             QDir::currentPath() + "/src/test/id3-test-data/cover-test.");
@@ -154,30 +156,37 @@ TEST_F(SoundSourceProxyTest, seekForward) {
     QStringList extensions;
     extensions << "aiff" << "flac" << "wav"  << "ogg" << "mp3";
 
-    SAMPLE *pData1 = new SAMPLE[kTestSampleCount];
-    SAMPLE *pData2 = new SAMPLE[kTestSampleCount];
+    SAMPLE *pData1 = new SAMPLE[kTestFrameCount];
+    SAMPLE *pData2 = new SAMPLE[kTestFrameCount];
 
-    foreach (const QString& extension, extensions) {
-        QString filePath = kFilePath + extension;
+    for (unsigned int seekFrameIndex = 0; 1200000 > seekFrameIndex; seekFrameIndex += kSeekFrameIndex) {
+        qDebug() << "seekFrameIndex =" << seekFrameIndex;
+        foreach (const QString& extension, extensions) {
+            QString filePath = kFilePath + extension;
 
-        Mixxx::SoundSourcePointer pSoundSource1(loadProxy(filePath));
-        EXPECT_EQ(OK, pSoundSource1->open());
-        for(int i = 0; i <= kSeekSample / kTestSampleCount; ++i) {
-            unsigned int read1 = pSoundSource1->read(kTestSampleCount, pData1);
-            EXPECT_EQ(read1, kTestSampleCount);
-        }
+            Mixxx::SoundSourcePointer pSoundSource1(loadProxy(filePath));
+            EXPECT_EQ(OK, pSoundSource1->open());
+            unsigned int frameIndex1 = 0;
+            while (frameIndex1 < seekFrameIndex) {
+                unsigned int readCount1 = pSoundSource1->read(kTestFrameCount, pData1);
+                EXPECT_EQ(kTestFrameCount, readCount1);
+                frameIndex1 += readCount1;
+            }
+            EXPECT_EQ(seekFrameIndex, frameIndex1);
+            unsigned int readCount1 = pSoundSource1->read(kTestFrameCount, pData1);
 
-        Mixxx::SoundSourcePointer pSoundSource2(loadProxy(filePath));
-        EXPECT_EQ(OK, pSoundSource2->open());
-        pSoundSource2->seek(kSeekSample);
-        unsigned int read2 = pSoundSource2->read(kTestSampleCount, pData2);
-        EXPECT_EQ(read2, kTestSampleCount);
+            Mixxx::SoundSourcePointer pSoundSource2(loadProxy(filePath));
+            EXPECT_EQ(OK, pSoundSource2->open());
+            pSoundSource2->seek(seekFrameIndex);
+            unsigned int read2 = pSoundSource2->read(kTestFrameCount, pData2);
+            EXPECT_EQ(read2, kTestFrameCount);
 
-        for( int i = 0; i < kTestSampleCount; i++) {
-            EXPECT_EQ(pData1[i], pData2[i]);
-            if (pData1[i] != pData2[i]) {
-                qDebug() << filePath << "Test Sample" << i;
-                break;
+            for( int i = 0; i < kTestFrameCount; i++) {
+                EXPECT_EQ(pData1[i], pData2[i]);
+                if (pData1[i] != pData2[i]) {
+                    qDebug() << filePath << "Test Sample" << i;
+                    break;
+                }
             }
         }
     }

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -182,7 +182,7 @@ TEST_F(SoundSourceProxyTest, seekForward) {
             EXPECT_EQ(read2, kTestFrameCount);
 
             for( int i = 0; i < kTestFrameCount; i++) {
-                EXPECT_EQ(pData1[i], pData2[i]);
+                ASSERT_EQ(pData1[i], pData2[i]);
                 if (pData1[i] != pData2[i]) {
                     qDebug() << filePath << "Test Sample" << i;
                     break;


### PR DESCRIPTION
This adds some seek tests and make it work with soundsourcemp3 

The changes insoundsourcemp3 are ugly hacks. 
I would prefer to fix this on Uwes new base. 

A backward seek from a late position in the fill still produces a big offset.
IMHO the current state is petty useless for reliable beatmaching :-(

@uklotzde will your new API work with these tests? 
Do you see a chance to fix the seek errors in a way that it will merge well later with our code? 
It is not much fun to to the work twice.
