### PR TITLE
Denon MC6000MK2: Reconnect controls for version 1.12

### DIFF
--- a/res/controllers/Denon-MC6000MK2-scripts.js
+++ b/res/controllers/Denon-MC6000MK2-scripts.js
@@ -901,7 +901,6 @@ DenonMC6000MK2.Deck.prototype.scratchJog = function (jogDelta) {
 
 DenonMC6000MK2.Deck.prototype.onVinylModeValue = function () {
 	this.vinylModeLed.setStateBoolean(this.vinylMode);
-	engine.setValue("[Spinny" + this.number + "]", "show_spinny", this.vinylMode);
 };
 
 DenonMC6000MK2.Deck.prototype.updateVinylMode = function () {

--- a/res/controllers/Denon-MC6000MK2-scripts.js
+++ b/res/controllers/Denon-MC6000MK2-scripts.js
@@ -884,20 +884,16 @@ DenonMC6000MK2.Deck.prototype.isScratching = function () {
 };
 
 DenonMC6000MK2.Deck.prototype.enableScratching = function () {
-	if (!this.isScratching()) {
-		engine.scratchEnable(this.number,
-			DenonMC6000MK2.JOG_RESOLUTION,
-			DenonMC6000MK2.JOG_SCRATCH_RPM,
-			DenonMC6000MK2.JOG_SCRATCH_ALPHA,
-			DenonMC6000MK2.JOG_SCRATCH_BETA,
-			DenonMC6000MK2.JOG_SCRATCH_RAMP);
-	}
+	engine.scratchEnable(this.number,
+		DenonMC6000MK2.JOG_RESOLUTION,
+		DenonMC6000MK2.JOG_SCRATCH_RPM,
+		DenonMC6000MK2.JOG_SCRATCH_ALPHA,
+		DenonMC6000MK2.JOG_SCRATCH_BETA,
+		DenonMC6000MK2.JOG_SCRATCH_RAMP);
 };
 
 DenonMC6000MK2.Deck.prototype.disableScratching = function () {
-	if (this.isScratching()) {
-		engine.scratchDisable(this.number, DenonMC6000MK2.JOG_SCRATCH_RAMP);
-	}
+	engine.scratchDisable(this.number, DenonMC6000MK2.JOG_SCRATCH_RAMP);
 };
 
 DenonMC6000MK2.Deck.prototype.scratchJog = function (jogDelta) {
@@ -943,7 +939,9 @@ DenonMC6000MK2.Deck.prototype.spinJogVinyl = function (jogDelta) {
 	if (this.isScratching()) {
 		this.scratchJog(jogDelta);
 	} else {
-		this.spinJog(jogDelta);
+		if (this.isPlaying()) {
+			this.spinJog(jogDelta);
+		}
 	}
 };
 

--- a/res/controllers/Denon-MC6000MK2-scripts.js
+++ b/res/controllers/Denon-MC6000MK2-scripts.js
@@ -117,11 +117,11 @@ DenonMC6000MK2.SAMPLER_MODE = {
 
 DenonMC6000MK2.DEFAULT_SAMPLER_MODE = DenonMC6000MK2.SAMPLER_MODE.HOLD;
 
-DenonMC6000MK2.JOG_SPIN_CUE_PEAK = 0.7; // [0.0, 1.0]
-DenonMC6000MK2.JOG_SPIN_CUE_EXPONENT = 0.5; // 1.0 = linear response
+DenonMC6000MK2.JOG_SPIN_CUE_PEAK = 0.2; // [0.0, 1.0]
+DenonMC6000MK2.JOG_SPIN_CUE_EXPONENT = 0.7; // 1.0 = linear response
 
-DenonMC6000MK2.JOG_SPIN_PLAY_PEAK = 0.5; // [0.0, 1.0]
-DenonMC6000MK2.JOG_SPIN_PLAY_EXPONENT = 0.5; // 1.0 = linear response
+DenonMC6000MK2.JOG_SPIN_PLAY_PEAK = 0.3; // [0.0, 1.0]
+DenonMC6000MK2.JOG_SPIN_PLAY_EXPONENT = 0.7; // 1.0 = linear response
 
 DenonMC6000MK2.JOG_SCRATCH_RPM = 33.333333; // 33 1/3
 DenonMC6000MK2.JOG_SCRATCH_ALPHA = 0.125; // 1/8
@@ -130,7 +130,7 @@ DenonMC6000MK2.JOG_SCRATCH_RAMP = true;
 
 // Seeking: Number of revolutions needed to seek from the beginning
 // to the end of the track.
-DenonMC6000MK2.JOG_SEEK_REVOLUTIONS = 3;
+DenonMC6000MK2.JOG_SEEK_REVOLUTIONS = 2;
 
 DenonMC6000MK2.GLOBAL_SHIFT_STATE = true;
 
@@ -1282,7 +1282,7 @@ DenonMC6000MK2.setValue = function (key, value) {
 
 DenonMC6000MK2.getJogDeltaValue = function (value) {
 	if (0x00 === value) {
-		return 0;
+		return 0x00;
 	} else {
 		return value - DenonMC6000MK2.MIDI_JOG_DELTA_BIAS;
 	}

--- a/res/controllers/Denon-MC6000MK2-scripts.js
+++ b/res/controllers/Denon-MC6000MK2-scripts.js
@@ -1254,7 +1254,14 @@ DenonMC6000MK2.Side.prototype.onEfxBeatsKnobDelta = function (delta) {
 	if (this.getShiftState()) {
 		engine.setValue(this.efxGroup, "chain_selector", delta);
 	} else {
-		// TODO: Change key of current deck
+		var newKey = this.activeDeck.getValue("key") + delta;
+		if (newKey < 1) {
+			newKey = 12;
+		}
+		if (newKey > 12) {
+			newKey = 1;
+		}
+		this.activeDeck.setValue("key", newKey);
 	}
 };
 

--- a/res/controllers/Denon-MC6000MK2-scripts.js
+++ b/res/controllers/Denon-MC6000MK2-scripts.js
@@ -577,7 +577,6 @@ DenonMC6000MK2.Deck = function (number, midiChannel) {
 	this.side = undefined;
 	this.number = number;
 	this.group = "[Channel" + number + "]";
-	this.eqGroup = "[EqualizerEffectRack1_" + this.group + "]"
 	this.filterGroup = "[QuickEffectRack1_" + this.group + "]"
 	this.midiChannel = midiChannel;
 	this.jogTouchState = false;

--- a/res/controllers/Denon-MC6000MK2-scripts.js
+++ b/res/controllers/Denon-MC6000MK2-scripts.js
@@ -1123,6 +1123,7 @@ DenonMC6000MK2.Side = function (decks, efxGroup, filterGroup, samplerMidiChannel
 		this.decksByGroup[deck.group] = deck;
 		DenonMC6000MK2.sidesByGroup[deck.group] = this;
 	}
+	this.activeDeck = decks[0];
 	this.shiftState = false;
 	this.efxGroup = efxGroup;
 	DenonMC6000MK2.sidesByGroup[efxGroup] = this;
@@ -1157,6 +1158,10 @@ DenonMC6000MK2.Side.prototype.getDeckByGroup = function (group) {
 		DenonMC6000MK2.logError("No deck found for " + group);
 	}
 	return deck;
+};
+
+DenonMC6000MK2.Side.prototype.activateDeckByGroup = function (group) {
+	this.activeDeck = this.getDeckByGroup(group);
 };
 
 /* Startup */
@@ -1667,6 +1672,20 @@ DenonMC6000MK2.leftSide.onEfxTapButton = function (channel, control, value, stat
 DenonMC6000MK2.rightSide.onEfxTapButton = function (channel, control, value, status, group) {
 	var isButtonPressed = DenonMC6000MK2.isButtonPressed(value);
 	DenonMC6000MK2.rightSide.onEfxTapButton(isButtonPressed);
+};
+
+DenonMC6000MK2.leftSide.onDeckButton = function (channel, control, value, status, group) {
+	var isButtonPressed = DenonMC6000MK2.isButtonPressed(value);
+	if (isButtonPressed) {
+		DenonMC6000MK2.leftSide.activateDeckByGroup(group);
+	}
+};
+
+DenonMC6000MK2.rightSide.onDeckButton = function (channel, control, value, status, group) {
+	var isButtonPressed = DenonMC6000MK2.isButtonPressed(value);
+	if (isButtonPressed) {
+		DenonMC6000MK2.rightSide.activateDeckByGroup(group);
+	}
 };
 
 

--- a/res/controllers/Denon-MC6000MK2-scripts.js
+++ b/res/controllers/Denon-MC6000MK2-scripts.js
@@ -577,7 +577,7 @@ DenonMC6000MK2.Deck = function (number, midiChannel) {
 	this.side = undefined;
 	this.number = number;
 	this.group = "[Channel" + number + "]";
-	this.filterGroup = "[QuickEffectRack1_" + this.group + "]"
+	this.filterGroup = "[QuickEffectRack1_" + this.group + "]";
 	this.midiChannel = midiChannel;
 	this.jogTouchState = false;
 	this.jogTouchVinylState = false;
@@ -856,7 +856,7 @@ DenonMC6000MK2.Deck.prototype.seekJog = function (jogDelta) {
 	} else {
 		return false;
 	}
-}
+};
 
 DenonMC6000MK2.Deck.prototype.spinJog = function (jogDelta) {
 	if (!this.seekJog(jogDelta)) {
@@ -1355,20 +1355,21 @@ DenonMC6000MK2.connectLeds = function () {
 };
 
 DenonMC6000MK2.connectControls = function () {
+	var deck, deckGroup;
 	DenonMC6000MK2.leftSide.connectControls();
 	//DenonMC6000MK2.connectControl("", "", DenonMC6000MK2.leftSide.onEfx1EnabledValueCB);
 	//DenonMC6000MK2.connectControl("", "", DenonMC6000MK2.leftSide.onEfx2EnabledValueCB);
 	DenonMC6000MK2.connectControl(DenonMC6000MK2.leftSide.efxGroup, "enabled", DenonMC6000MK2.leftSide.onEfx3EnabledValueCB);
-	for (var deckGroup in DenonMC6000MK2.leftSide.decksByGroup) {
-		var deck = this.decksByGroup[deckGroup];
+	for (deckGroup in DenonMC6000MK2.leftSide.decksByGroup) {
+		deck = this.decksByGroup[deckGroup];
 		DenonMC6000MK2.connectControl(deck.filterGroup, "enabled", DenonMC6000MK2.leftSide.onFilterEnabledValueCB);
 	}
 	DenonMC6000MK2.rightSide.connectControls();
 	//DenonMC6000MK2.connectControl("", "", DenonMC6000MK2.rightSide.onEfx1EnabledValueCB);
 	//DenonMC6000MK2.connectControl("", "", DenonMC6000MK2.rightSide.onEfx2EnabledValueCB);
 	DenonMC6000MK2.connectControl(DenonMC6000MK2.rightSide.efxGroup, "enabled", DenonMC6000MK2.rightSide.onEfx3EnabledValueCB);
-	for (var deckGroup in DenonMC6000MK2.rightSide.decksByGroup) {
-		var deck = this.decksByGroup[deckGroup];
+	for (deckGroup in DenonMC6000MK2.rightSide.decksByGroup) {
+		deck = this.decksByGroup[deckGroup];
 		DenonMC6000MK2.connectControl(deck.filterGroup, "enabled", DenonMC6000MK2.rightSide.onFilterEnabledValueCB);
 	}
 };

--- a/res/controllers/Denon-MC6000MK2-scripts.js
+++ b/res/controllers/Denon-MC6000MK2-scripts.js
@@ -660,6 +660,12 @@ DenonMC6000MK2.Deck.prototype.onKeyLockValue = function (value) {
 	this.keyLockLed.setStateBoolean(value);
 };
 
+/* Key Control */
+
+DenonMC6000MK2.Deck.prototype.resetKey = function () {
+	this.setValue("reset_key", true);
+};
+
 /* Sync Mode */
 
 DenonMC6000MK2.Deck.prototype.disableSyncMode = function () {
@@ -1248,7 +1254,7 @@ DenonMC6000MK2.Side.prototype.onEfxBeatsKnobDelta = function (delta) {
 	if (this.getShiftState()) {
 		engine.setValue(this.efxGroup, "chain_selector", delta);
 	} else {
-		// TODO
+		// TODO: Change key of current deck
 	}
 };
 
@@ -1662,6 +1668,20 @@ DenonMC6000MK2.leftSide.onEfxBeatsKnob = function (channel, control, value, stat
 DenonMC6000MK2.rightSide.onEfxBeatsKnob = function (channel, control, value, status, group) {
 	var delta = DenonMC6000MK2.getKnobDelta(value);
 	DenonMC6000MK2.rightSide.onEfxBeatsKnobDelta(delta);
+};
+
+DenonMC6000MK2.leftSide.onEfxBeatsButton = function (channel, control, value, status, group) {
+	var isButtonPressed = DenonMC6000MK2.isButtonPressed(value);
+	if (isButtonPressed) {
+		DenonMC6000MK2.leftSide.activeDeck.resetKey();
+	}
+};
+
+DenonMC6000MK2.rightSide.onEfxBeatsButton = function (channel, control, value, status, group) {
+	var isButtonPressed = DenonMC6000MK2.isButtonPressed(value);
+	if (isButtonPressed) {
+		DenonMC6000MK2.rightSide.activeDeck.resetKey();
+	}
 };
 
 DenonMC6000MK2.leftSide.onEfxTapButton = function (channel, control, value, status, group) {

--- a/res/controllers/Denon-MC6000MK2-scripts.js
+++ b/res/controllers/Denon-MC6000MK2-scripts.js
@@ -11,9 +11,14 @@
 ////////////////////////////////////////////////////////////////////////
 // Controller: Denon MC6000MK2
 // Author: Uwe Klotz a/k/a tapir
-// Revision: 2015-01-16
+// Revision: 2015-01-25
 //
 // Changelog:
+// 2015-01-25 Reconnect controls for version 1.12
+//    - Connect filter effect to QuickEffectRack
+//    - Connect channel EQs to EqualizerRack
+//    - Connect FX Beats knob to musical key controls (next/prev/reset)
+//    - Fine-tune jog wheel parameters
 // 2015-01-16 Filter effect parameter update
 //    - Rename filter effect parameter from "parameter" to "super1"
 // 2014-08-20 Sync mapping with push-and-hold

--- a/res/controllers/Denon-MC6000MK2.midi.xml
+++ b/res/controllers/Denon-MC6000MK2.midi.xml
@@ -444,22 +444,22 @@
 				<key>pregain</key>
 			</control>
 			<control>
-				<group>[Channel1]</group>
-				<midino>0x02</midino>
-				<status>0xB0</status>
-				<key>filterHigh</key>
-			</control>
-			<control>
-				<group>[Channel1]</group>
-				<midino>0x03</midino>
-				<status>0xB0</status>
-				<key>filterMid</key>
-			</control>
-			<control>
-				<group>[Channel1]</group>
+				<group>[EqualizerRack1_[Channel1]_Effect1]</group>
 				<midino>0x04</midino>
 				<status>0xB0</status>
-				<key>filterLow</key>
+				<key>parameter1</key>
+			</control>
+			<control>
+				<group>[EqualizerRack1_[Channel1]_Effect1]</group>
+				<midino>0x03</midino>
+				<status>0xB0</status>
+				<key>parameter2</key>
+			</control>
+			<control>
+				<group>[EqualizerRack1_[Channel1]_Effect1]</group>
+				<midino>0x02</midino>
+				<status>0xB0</status>
+				<key>parameter3</key>
 			</control>
 			<control>
 				<group>[Channel1]</group>
@@ -867,22 +867,22 @@
 				<key>pregain</key>
 			</control>
 			<control>
-				<group>[Channel2]</group>
-				<midino>0x08</midino>
-				<status>0xB0</status>
-				<key>filterHigh</key>
-			</control>
-			<control>
-				<group>[Channel2]</group>
-				<midino>0x09</midino>
-				<status>0xB0</status>
-				<key>filterMid</key>
-			</control>
-			<control>
-				<group>[Channel2]</group>
+				<group>[EqualizerRack1_[Channel2]_Effect1]</group>
 				<midino>0x0A</midino>
 				<status>0xB0</status>
-				<key>filterLow</key>
+				<key>parameter1</key>
+			</control>
+			<control>
+				<group>[EqualizerRack1_[Channel2]_Effect1]</group>
+				<midino>0x09</midino>
+				<status>0xB0</status>
+				<key>parameter2</key>
+			</control>
+			<control>
+				<group>[EqualizerRack1_[Channel2]_Effect1]</group>
+				<midino>0x08</midino>
+				<status>0xB0</status>
+				<key>parameter3</key>
 			</control>
 			<control>
 				<group>[Channel2]</group>
@@ -1290,22 +1290,22 @@
 				<key>pregain</key>
 			</control>
 			<control>
-				<group>[Channel3]</group>
-				<midino>0x0D</midino>
-				<status>0xB0</status>
-				<key>filterHigh</key>
-			</control>
-			<control>
-				<group>[Channel3]</group>
-				<midino>0x0E</midino>
-				<status>0xB0</status>
-				<key>filterMid</key>
-			</control>
-			<control>
-				<group>[Channel3]</group>
+				<group>[EqualizerRack1_[Channel3]_Effect1]</group>
 				<midino>0x0F</midino>
 				<status>0xB0</status>
-				<key>filterLow</key>
+				<key>parameter1</key>
+			</control>
+			<control>
+				<group>[EqualizerRack1_[Channel3]_Effect1]</group>
+				<midino>0x0E</midino>
+				<status>0xB0</status>
+				<key>parameter2</key>
+			</control>
+			<control>
+				<group>[EqualizerRack1_[Channel3]_Effect1]</group>
+				<midino>0x0D</midino>
+				<status>0xB0</status>
+				<key>parameter3</key>
 			</control>
 			<control>
 				<group>[Channel3]</group>
@@ -1713,22 +1713,22 @@
 				<key>pregain</key>
 			</control>
 			<control>
-				<group>[Channel4]</group>
-				<midino>0x12</midino>
-				<status>0xB0</status>
-				<key>filterHigh</key>
-			</control>
-			<control>
-				<group>[Channel4]</group>
-				<midino>0x13</midino>
-				<status>0xB0</status>
-				<key>filterMid</key>
-			</control>
-			<control>
-				<group>[Channel4]</group>
+				<group>[EqualizerRack1_[Channel4]_Effect1]</group>
 				<midino>0x14</midino>
 				<status>0xB0</status>
-				<key>filterLow</key>
+				<key>parameter1</key>
+			</control>
+			<control>
+				<group>[EqualizerRack1_[Channel4]_Effect1]</group>
+				<midino>0x13</midino>
+				<status>0xB0</status>
+				<key>parameter2</key>
+			</control>
+			<control>
+				<group>[EqualizerRack1_[Channel4]_Effect1]</group>
+				<midino>0x12</midino>
+				<status>0xB0</status>
+				<key>parameter3</key>
 			</control>
 			<control>
 				<group>[Channel4]</group>

--- a/res/controllers/Denon-MC6000MK2.midi.xml
+++ b/res/controllers/Denon-MC6000MK2.midi.xml
@@ -486,6 +486,15 @@
 			<!-- [Channel1] - MIDI Ch0 Controls -->
 			<control>
 				<group>[Channel1]</group>
+				<midino>0x03</midino>
+				<status>0x90</status>
+				<key>DenonMC6000MK2.leftSide.onDeckButton</key>
+				<options>
+					<script-binding/>
+				</options>
+			</control>
+			<control>
+				<group>[Channel1]</group>
 				<midino>0x04</midino>
 				<status>0x90</status>
 				<key>DenonMC6000MK2.onVinylButton</key>
@@ -898,6 +907,15 @@
 			</control>
 
 			<!-- [Channel2] - MIDI Ch2 Controls -->
+			<control>
+				<group>[Channel2]</group>
+				<midino>0x08</midino>
+				<status>0x92</status>
+				<key>DenonMC6000MK2.rightSide.onDeckButton</key>
+				<options>
+					<script-binding/>
+				</options>
+			</control>
 			<control>
 				<group>[Channel2]</group>
 				<midino>0x04</midino>
@@ -1314,6 +1332,15 @@
 			<!-- [Channel3] - MIDI Ch1 Controls -->
 			<control>
 				<group>[Channel3]</group>
+				<midino>0x09</midino>
+				<status>0x91</status>
+				<key>DenonMC6000MK2.leftSide.onDeckButton</key>
+				<options>
+					<script-binding/>
+				</options>
+			</control>
+			<control>
+				<group>[Channel3]</group>
 				<midino>0x04</midino>
 				<status>0x91</status>
 				<key>DenonMC6000MK2.onVinylButton</key>
@@ -1726,6 +1753,15 @@
 			</control>
 
 			<!-- [Channel4] - MIDI Ch3 Controls -->
+			<control>
+				<group>[Channel4]</group>
+				<midino>0x0A</midino>
+				<status>0x93</status>
+				<key>DenonMC6000MK2.rightSide.onDeckButton</key>
+				<options>
+					<script-binding/>
+				</options>
+			</control>
 			<control>
 				<group>[Channel4]</group>
 				<midino>0x04</midino>

--- a/res/controllers/Denon-MC6000MK2.midi.xml
+++ b/res/controllers/Denon-MC6000MK2.midi.xml
@@ -120,6 +120,14 @@
 				</options>
 			</control>
 			<control>
+				<midino>0x40</midino>
+				<status>0x90</status>
+				<key>DenonMC6000MK2.leftSide.onEfxBeatsButton</key>
+				<options>
+					<script-binding/>
+				</options>
+			</control>
+			<control>
 				<midino>0x46</midino>
 				<status>0x90</status>
 				<key>DenonMC6000MK2.leftSide.onEfxTapButton</key>
@@ -180,6 +188,14 @@
 				<midino>0x5C</midino>
 				<status>0xB0</status>
 				<key>DenonMC6000MK2.rightSide.onEfxBeatsKnob</key>
+				<options>
+					<script-binding/>
+				</options>
+			</control>
+			<control>
+				<midino>0x41</midino>
+				<status>0x90</status>
+				<key>DenonMC6000MK2.rightSide.onEfxBeatsButton</key>
 				<options>
 					<script-binding/>
 				</options>

--- a/res/controllers/Denon-MC6000MK2.midi.xml
+++ b/res/controllers/Denon-MC6000MK2.midi.xml
@@ -22,29 +22,37 @@
 			</control>
 			<!-- left filter efx (deck 1+3) -->
 			<control>
-				<group>[EffectRack1_EffectUnit2]</group>
 				<midino>0x16</midino>
 				<status>0x90</status>
-				<key>enabled</key>
+				<key>DenonMC6000MK2.leftSide.onFilterButton</key>
+				<options>
+					<script-binding/>
+				</options>
 			</control>
 			<control>
-				<group>[EffectRack1_EffectUnit2]</group>
 				<midino>0x66</midino>
 				<status>0xB0</status>
-				<key>super1</key>
+				<key>DenonMC6000MK2.leftSide.onFilterParam</key>
+				<options>
+					<script-binding/>
+				</options>
 			</control>
 			<!-- right filter efx (deck 2+4) -->
 			<control>
-				<group>[EffectRack1_EffectUnit3]</group>
 				<midino>0x1E</midino>
 				<status>0x90</status>
-				<key>enabled</key>
+				<key>DenonMC6000MK2.rightSide.onFilterButton</key>
+				<options>
+					<script-binding/>
+				</options>
 			</control>
 			<control>
-				<group>[EffectRack1_EffectUnit3]</group>
 				<midino>0x67</midino>
 				<status>0xB0</status>
-				<key>super1</key>
+				<key>DenonMC6000MK2.rightSide.onFilterParam</key>
+				<options>
+					<script-binding/>
+				</options>
 			</control>
 			<!-- left efx unit -->
 			<control>
@@ -66,7 +74,7 @@
 			<control>
 				<midino>0x55</midino>
 				<status>0xB0</status>
-				<key>DenonMC6000MK2.leftSide.onEfx1Knob</key>
+				<key>DenonMC6000MK2.leftSide.onEfx1Param</key>
 				<options>
 					<script-binding/>
 				</options>
@@ -90,7 +98,7 @@
 			<control>
 				<midino>0x56</midino>
 				<status>0xB0</status>
-				<key>DenonMC6000MK2.leftSide.onEfx2Knob</key>
+				<key>DenonMC6000MK2.leftSide.onEfx2Param</key>
 				<options>
 					<script-binding/>
 				</options>
@@ -106,7 +114,7 @@
 			<control>
 				<midino>0x57</midino>
 				<status>0xB0</status>
-				<key>DenonMC6000MK2.leftSide.onEfx3Knob</key>
+				<key>DenonMC6000MK2.leftSide.onEfx3Param</key>
 				<options>
 					<script-binding/>
 				</options>
@@ -147,7 +155,7 @@
 			<control>
 				<midino>0x59</midino>
 				<status>0xB0</status>
-				<key>DenonMC6000MK2.rightSide.onEfx1Knob</key>
+				<key>DenonMC6000MK2.rightSide.onEfx1Param</key>
 				<options>
 					<script-binding/>
 				</options>
@@ -163,7 +171,7 @@
 			<control>
 				<midino>0x5A</midino>
 				<status>0xB0</status>
-				<key>DenonMC6000MK2.rightSide.onEfx2Knob</key>
+				<key>DenonMC6000MK2.rightSide.onEfx2Param</key>
 				<options>
 					<script-binding/>
 				</options>
@@ -179,7 +187,7 @@
 			<control>
 				<midino>0x5B</midino>
 				<status>0xB0</status>
-				<key>DenonMC6000MK2.rightSide.onEfx3Knob</key>
+				<key>DenonMC6000MK2.rightSide.onEfx3Param</key>
 				<options>
 					<script-binding/>
 				</options>
@@ -466,7 +474,7 @@
 				<key>group_[Channel1]_enable</key>
 			</control>
 			<control>
-				<group>[EffectRack1_EffectUnit4]</group>
+				<group>[EffectRack1_EffectUnit2]</group>
 				<midino>0x5C</midino>
 				<status>0x90</status>
 				<key>group_[Channel1]_enable</key>
@@ -889,7 +897,7 @@
 				<key>group_[Channel2]_enable</key>
 			</control>
 			<control>
-				<group>[EffectRack1_EffectUnit4]</group>
+				<group>[EffectRack1_EffectUnit2]</group>
 				<midino>0x5D</midino>
 				<status>0x90</status>
 				<key>group_[Channel2]_enable</key>
@@ -1312,7 +1320,7 @@
 				<key>group_[Channel3]_enable</key>
 			</control>
 			<control>
-				<group>[EffectRack1_EffectUnit4]</group>
+				<group>[EffectRack1_EffectUnit2]</group>
 				<midino>0x5E</midino>
 				<status>0x90</status>
 				<key>group_[Channel3]_enable</key>
@@ -1735,7 +1743,7 @@
 				<key>group_[Channel4]_enable</key>
 			</control>
 			<control>
-				<group>[EffectRack1_EffectUnit4]</group>
+				<group>[EffectRack1_EffectUnit2]</group>
 				<midino>0x5F</midino>
 				<status>0x90</status>
 				<key>group_[Channel4]_enable</key>


### PR DESCRIPTION
- Connect filter effect to QuickEffectRack
- Connect channel EQs to EqualizerRack
- Connect FX Beats knob to musical key controls (next/prev/reset)
- Fine-tune jog wheel parameters
