### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ install:
   - scons
   - scons test=1
 script:
-  - scons test
+  # `scons test` can't connect to X server for some reason
+  - ./mixxx-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c++
 # command to install dependencies
 before_install:
   # Dependencies from  <http://mixxx.org/wiki/doku.php/compiling_on_linux>
-  - sudo apt-get install git scons libqt4-dev libqt4-sql-sqlite libportmidi-dev libshout3-dev libtag1-dev libprotobuf-dev protobuf-compiler libvamp-hostsdk3 vamp-plugin-sdk libusb-1.0-0-dev libfftw3-dev libmad0-dev portaudio19-dev libchromaprint-dev librubberband-dev libsqlite3-dev libsndfile1-dev libflac-dev libtag1-dev
+  - sudo apt-get install git scons libqt4-dev libqt4-sql-sqlite libportmidi-dev libshout3-dev libtag1-dev libprotobuf-dev protobuf-compiler libvamp-hostsdk3 vamp-plugin-sdk libusb-1.0-0-dev libfftw3-dev libmad0-dev portaudio19-dev libchromaprint-dev librubberband-dev libsqlite3-dev libsndfile1-dev libflac-dev libid3tag0-dev
   # Virtual X
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c++
 # command to install dependencies
 before_install:
   # Dependencies from  <http://mixxx.org/wiki/doku.php/compiling_on_linux>
-  - sudo apt-get install git scons libqt4-dev libqt4-sql-sqlite libportmidi-dev libopus-dev libshout-dev libtag1-dev libprotobuf-dev protobuf-compiler libvamp-hostsdk3 vamp-plugin-sdk libusb-1.0-0-dev libfftw3-dev libmad0-dev portaudio19-dev libchromaprint-dev librubberband-dev libsqlite3-dev
+  - sudo apt-get install git scons libqt4-dev libqt4-sql-sqlite libportmidi-dev libshout3-dev libtag1-dev libprotobuf-dev protobuf-compiler libvamp-hostsdk3 vamp-plugin-sdk libusb-1.0-0-dev libfftw3-dev libmad0-dev portaudio19-dev libchromaprint-dev librubberband-dev libsqlite3-dev
   # Virtual X
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c++
+# command to install dependencies
+before_install:
+  # Dependencies from  <http://mixxx.org/wiki/doku.php/compiling_on_linux>
+  - sudo apt-get install git scons libqt4-dev libqt4-sql-sqlite libportmidi-dev libopus-dev libshout-dev libtag1-dev libprotobuf-dev protobuf-compiler libvamp-hostsdk3 vamp-plugin-sdk libusb-1.0-0-dev libfftw3-dev libmad0-dev portaudio19-dev libchromaprint-dev librubberband-dev libsqlite3-dev
+  # Virtual X
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+install:
+  - scons
+  - scons test=1
+script:
+  - scons test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c++
 # command to install dependencies
 before_install:
   # Dependencies from  <http://mixxx.org/wiki/doku.php/compiling_on_linux>
-  - sudo apt-get install git scons libqt4-dev libqt4-sql-sqlite libportmidi-dev libshout3-dev libtag1-dev libprotobuf-dev protobuf-compiler libvamp-hostsdk3 vamp-plugin-sdk libusb-1.0-0-dev libfftw3-dev libmad0-dev portaudio19-dev libchromaprint-dev librubberband-dev libsqlite3-dev
+  - sudo apt-get install git scons libqt4-dev libqt4-sql-sqlite libportmidi-dev libshout3-dev libtag1-dev libprotobuf-dev protobuf-compiler libvamp-hostsdk3 vamp-plugin-sdk libusb-1.0-0-dev libfftw3-dev libmad0-dev portaudio19-dev libchromaprint-dev librubberband-dev libsqlite3-dev libsndfile1-dev libflac-dev libtag1-dev
   # Virtual X
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
Add a travis build for as long as the actual build bot is stale. The travis build and tests intercept all Linux build and test issues, so this isn't a replacement for the Jenkins setup.
