### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: c++
-# command to install dependencies
+# to run compilation/tests with gcc and clang
+compiler:
+    - gcc
+    - clang
 before_install:
+  # update virtual machine
+  - sudo apt-get update -qq
   # Dependencies from  <http://mixxx.org/wiki/doku.php/compiling_on_linux>
   - sudo apt-get install git scons libqt4-dev libqt4-sql-sqlite libportmidi-dev libshout3-dev libtag1-dev libprotobuf-dev protobuf-compiler libvamp-hostsdk3 vamp-plugin-sdk libusb-1.0-0-dev libfftw3-dev libmad0-dev portaudio19-dev libchromaprint-dev librubberband-dev libsqlite3-dev libsndfile1-dev libflac-dev libid3tag0-dev
-  # Virtual X
+  # Virtual X, needed for analyser waveform tests
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 install:
-  - scons
-  - scons test=1
+  - scons test=1 mad=1 opus=1 localecompare=1
 script:
-  # `scons test` can't connect to X server for some reason
   - ./mixxx-test


### PR DESCRIPTION
Use clang and GCC to build and test mixxx. It is also a recommended practice for Travis to update the virtual machine on every run.
I also changed the scons options to the ones we use on the jenkins build server. It mainly concerns some plugins that are disabled in the default settings.

If wanted we can also have a change that we are notified via mail/IRC when a build fails.
