### PR TITLE
Stringatom

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -494,6 +494,7 @@ class MixxxCore(Feature):
                    "control/control.cpp",
                    "control/controlbehavior.cpp",
                    "control/controlmodel.cpp",
+                   "control/stringatom.cpp",
                    "controlobject.cpp",
                    "controlobjectslave.cpp",
                    "controlobjectthread.cpp",

--- a/src/baseplayer.cpp
+++ b/src/baseplayer.cpp
@@ -1,6 +1,6 @@
 #include "baseplayer.h"
 
-BasePlayer::BasePlayer(QObject* pParent, QString group)
+BasePlayer::BasePlayer(QObject* pParent, const StringAtom& group)
         : QObject(pParent),
           m_group(group) {
 }

--- a/src/baseplayer.cpp
+++ b/src/baseplayer.cpp
@@ -9,6 +9,6 @@ BasePlayer::~BasePlayer() {
 
 }
 
-const QString BasePlayer::getGroup() {
+const StringAtom& BasePlayer::getGroup() {
     return m_group;
 }

--- a/src/baseplayer.h
+++ b/src/baseplayer.h
@@ -8,7 +8,7 @@
 class BasePlayer : public QObject {
     Q_OBJECT
   public:
-    BasePlayer(QObject* pParent, QString group);
+    BasePlayer(QObject* pParent, const StringAtom& group);
     virtual ~BasePlayer();
 
     const StringAtom& getGroup();

--- a/src/baseplayer.h
+++ b/src/baseplayer.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QString>
+#include "control/stringatom.h"
 
 class BasePlayer : public QObject {
     Q_OBJECT
@@ -10,10 +11,10 @@ class BasePlayer : public QObject {
     BasePlayer(QObject* pParent, QString group);
     virtual ~BasePlayer();
 
-    const QString getGroup();
+    const StringAtom& getGroup();
 
   private:
-    const QString m_group;
+    const StringAtom m_group;
 };
 
 #endif /* BASEPLAYER_H */

--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -66,9 +66,9 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
             this, SLOT(slotUnloadTrack(TrackPointer)));
 
     // Get loop point control objects
-    m_pLoopInPoint = new ControlObjectThread(
+    m_pLoopInPoint = new ControlObjectSlave(
             getGroup(),"loop_start_position");
-    m_pLoopOutPoint = new ControlObjectThread(
+    m_pLoopOutPoint = new ControlObjectSlave(
             getGroup(),"loop_end_position");
 
     // Duration of the current song, we create this one because nothing else does.
@@ -89,12 +89,11 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
 
     m_pPreGain = new ControlObjectSlave(ConfigKey(group, "pregain"));
     //BPM of the current song
-    m_pBPM = new ControlObjectThread(group, "file_bpm");
-    m_pKey = new ControlObjectThread(group, "file_key");
-    m_pReplayGain = new ControlObjectThread(group, "replaygain");
-    m_pPlay = new ControlObjectThread(group, "play");
-    connect(m_pPlay, SIGNAL(valueChanged(double)),
-            this, SLOT(slotPlayToggled(double)));
+    m_pBPM = new ControlObjectSlave(group, "file_bpm");
+    m_pKey = new ControlObjectSlave(group, "file_key");
+    m_pReplayGain = new ControlObjectSlave(group, "replaygain");
+    m_pPlay = new ControlObjectSlave(group, "play", this);
+    m_pPlay->connectValueChanged(SLOT(slotPlayToggled(double)));
 }
 
 BaseTrackPlayerImpl::~BaseTrackPlayerImpl() {
@@ -114,7 +113,6 @@ BaseTrackPlayerImpl::~BaseTrackPlayerImpl() {
     delete m_pBPM;
     delete m_pKey;
     delete m_pReplayGain;
-    delete m_pPlay;
     delete m_pLowFilter;
     delete m_pMidFilter;
     delete m_pHighFilter;

--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -15,8 +15,9 @@
 #include "analyserqueue.h"
 #include "util/sandbox.h"
 #include "effects/effectsmanager.h"
+#include "control/stringatom.h"
 
-BaseTrackPlayer::BaseTrackPlayer(QObject* pParent, const QString& group)
+BaseTrackPlayer::BaseTrackPlayer(QObject* pParent, const StringAtom& group)
         : BasePlayer(pParent, group) {
 }
 
@@ -25,7 +26,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
                                          EngineMaster* pMixingEngine,
                                          EffectsManager* pEffectsManager,
                                          EngineChannel::ChannelOrientation defaultOrientation,
-                                         QString group,
+                                         const StringAtom& group,
                                          bool defaultMaster,
                                          bool defaultHeadphones)
         : BaseTrackPlayer(pParent, group),

--- a/src/basetrackplayer.h
+++ b/src/basetrackplayer.h
@@ -20,16 +20,16 @@ class EffectsManager;
 class BaseTrackPlayer : public BasePlayer {
     Q_OBJECT
   public:
-    BaseTrackPlayer(QObject* pParent, const QString& group);
+    BaseTrackPlayer(QObject* pParent, const StringAtom& group);
     virtual ~BaseTrackPlayer() {}
 
     virtual TrackPointer getLoadedTrack() const = 0;
 
   public slots:
-    virtual void slotLoadTrack(TrackPointer pTrack, bool bPlay=false) = 0;
+    virtual void slotLoadTrack(TrackPointer pTrack, bool bPlay = false) = 0;
 
   signals:
-    void loadTrack(TrackPointer pTrack, bool bPlay=false);
+    void loadTrack(TrackPointer pTrack, bool bPlay = false);
     void loadTrackFailed(TrackPointer pTrack);
     void newTrackLoaded(TrackPointer pLoadedTrack);
     void unloadingTrack(TrackPointer pAboutToBeUnloaded);
@@ -43,7 +43,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
                         EngineMaster* pMixingEngine,
                         EffectsManager* pEffectsManager,
                         EngineChannel::ChannelOrientation defaultOrientation,
-                        QString group,
+                        const StringAtom& group,
                         bool defaultMaster,
                         bool defaultHeadphones);
     virtual ~BaseTrackPlayerImpl();

--- a/src/basetrackplayer.h
+++ b/src/basetrackplayer.h
@@ -72,13 +72,13 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     ControlPotmeter* m_pWaveformZoom;
     ControlObject* m_pEndOfTrack;
 
-    ControlObjectThread* m_pLoopInPoint;
-    ControlObjectThread* m_pLoopOutPoint;
+    ControlObjectSlave* m_pLoopInPoint;
+    ControlObjectSlave* m_pLoopOutPoint;
     ControlObject* m_pDuration;
-    ControlObjectThread* m_pBPM;
-    ControlObjectThread* m_pKey;
-    ControlObjectThread* m_pReplayGain;
-    ControlObjectThread* m_pPlay;
+    ControlObjectSlave* m_pBPM;
+    ControlObjectSlave* m_pKey;
+    ControlObjectSlave* m_pReplayGain;
+    ControlObjectSlave* m_pPlay;
     ControlObjectSlave* m_pLowFilter;
     ControlObjectSlave* m_pMidFilter;
     ControlObjectSlave* m_pHighFilter;

--- a/src/cachingreader.cpp
+++ b/src/cachingreader.cpp
@@ -17,7 +17,7 @@
 //static
 const int CachingReader::maximumChunksInMemory = 80;
 
-CachingReader::CachingReader(QString group,
+CachingReader::CachingReader(const StringAtom& group,
                              ConfigObject<ConfigValue>* config)
         : m_pConfig(config),
           m_chunkReadRequestFIFO(1024),

--- a/src/cachingreader.h
+++ b/src/cachingreader.h
@@ -17,6 +17,7 @@
 #include "engine/engineworker.h"
 #include "util/fifo.h"
 #include "cachingreaderworker.h"
+#include "control/stringatom.h"
 
 // A Hint is an indication to the CachingReader that a certain section of a
 // SoundSource will be used 'soon' and so it should be brought into memory by
@@ -71,8 +72,8 @@ class CachingReader : public QObject {
 
   public:
     // Construct a CachingReader with the given group.
-    CachingReader(QString group,
-                  ConfigObject<ConfigValue>* _config);
+    CachingReader(const StringAtom& group,
+                  ConfigObject<ConfigValue>* config);
     virtual ~CachingReader();
 
     virtual void process();

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -26,7 +26,7 @@ const int CachingReaderWorker::kChunkLength = CHUNK_LENGTH;
 const int CachingReaderWorker::kSamplesPerChunk = CHUNK_LENGTH / sizeof(CSAMPLE);
 
 
-CachingReaderWorker::CachingReaderWorker(QString group,
+CachingReaderWorker::CachingReaderWorker(const StringAtom& group,
         FIFO<ChunkReadRequest>* pChunkReadRequestFIFO,
         FIFO<ReaderStatusUpdate>* pReaderStatusFIFO)
         : m_group(group),

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -65,7 +65,7 @@ class CachingReaderWorker : public EngineWorker {
 
   public:
     // Construct a CachingReader with the given group.
-    CachingReaderWorker(QString group,
+    CachingReaderWorker(const StringAtom& group,
             FIFO<ChunkReadRequest>* pChunkReadRequestFIFO,
             FIFO<ReaderStatusUpdate>* pReaderStatusFIFO);
     virtual ~CachingReaderWorker();

--- a/src/configobject.cpp
+++ b/src/configobject.cpp
@@ -29,12 +29,22 @@
 ConfigKey::ConfigKey() {
 }
 
+ConfigKey::ConfigKey(const StringAtom& g, const QString& i)
+    : group(g),
+      item(i) {
+}
+
 ConfigKey::ConfigKey(const QString& g, const QString& i)
     : group(g),
       item(i) {
 }
 
 ConfigKey::ConfigKey(const char* g, const char* i)
+    : group(g),
+      item(i) {
+}
+
+ConfigKey::ConfigKey(const char* g, const QString& i)
     : group(g),
       item(i) {
 }

--- a/src/configobject.h
+++ b/src/configobject.h
@@ -27,6 +27,7 @@
 #include <QMetaType>
 
 #include "util/debug.h"
+#include "control/stringatom.h"
 
 
 // Class for the key for a specific configuration element. A key consists of a
@@ -35,8 +36,10 @@
 class ConfigKey {
   public:
     ConfigKey();
+    ConfigKey(const StringAtom& g, const QString& i);
     ConfigKey(const QString& g, const QString& i);
     ConfigKey(const char* g, const char* i);
+    ConfigKey(const char* g, const QString& i);
     static ConfigKey parseCommaSeparated(QString key);
 
     inline bool isNull() const {

--- a/src/control/stringatom.cpp
+++ b/src/control/stringatom.cpp
@@ -1,0 +1,75 @@
+#include <QtDebug>
+#include <QMutexLocker>
+
+#include "control/stringatom.h"
+
+#include "util/stat.h"
+#include "util/timer.h"
+
+// Static member variable definition
+QHash<QString, const QString*> StringAtom::s_stringHash;
+QMutex StringAtom::s_stringHashMutex;
+
+StringAtom::StringAtom()
+        : m_pString(NULL) {
+}
+
+StringAtom::StringAtom(const char* asciiString) {
+    QString string(asciiString);
+    initalize(string);
+}
+
+StringAtom::StringAtom(const QString& string) {
+    initalize(string);
+}
+
+StringAtom::StringAtom(const QString* pString)
+        : m_pString(pString) {
+}
+
+StringAtom::~StringAtom() {
+    // do not delete m_pString here, it is owned by the s_stringHash
+}
+
+void StringAtom::initalize(const QString& string) {
+    QMutexLocker locker(&s_stringHashMutex);
+    const QString* pString = getInner(string);
+    if (!pString) {
+        pString = new QString(string);
+        QString key = *pString;
+        s_stringHash.insert(key, pString);
+    }
+    m_pString = pString;
+}
+
+/*
+StringAtom& StringAtom::operator= (const QString & string) {
+    return *this;
+}
+*/
+
+QByteArray StringAtom::toAscii() const {
+    return m_pString->toAscii();
+}
+
+const QString& StringAtom::toString() const {
+    return *m_pString;
+}
+
+// static
+const StringAtom StringAtom::get(const char* asciiString) {
+    QString string(asciiString);
+    return get(string);
+}
+
+// static
+const StringAtom StringAtom::get(const QString& string) {
+    QMutexLocker locker(&s_stringHashMutex);
+    const QString* pString = getInner(string);
+    return StringAtom(pString);
+}
+
+// static
+const QString* StringAtom::getInner(const QString& string) {
+    return s_stringHash.value(string);
+}

--- a/src/control/stringatom.cpp
+++ b/src/control/stringatom.cpp
@@ -32,6 +32,7 @@ StringAtom::~StringAtom() {
 }
 
 void StringAtom::initalize(const QString& string) {
+    qDebug() << "StringAtom::initalize()" << string;
     QMutexLocker locker(&s_stringHashMutex);
     const QString* pString = getInner(string);
     if (!pString) {

--- a/src/control/stringatom.h
+++ b/src/control/stringatom.h
@@ -23,8 +23,17 @@ class StringAtom {
         return m_pString ? true : false;
     }
 
-    inline bool operator==(const StringAtom& other) {
+    inline bool operator==(const StringAtom& other) const {
         return this->m_pString == other.m_pString;
+    }
+
+    inline bool operator==(const QString& other) const {
+        return this->m_pString == get(other).m_pString;
+    }
+
+    // For QMap
+    inline bool operator<(const StringAtom& other) const {
+        return this->m_pString < other.m_pString;
     }
 
     inline operator QString() {

--- a/src/control/stringatom.h
+++ b/src/control/stringatom.h
@@ -39,6 +39,7 @@ class StringAtom {
     inline operator const QString&() const {
         return *m_pString;
     }
+
 /*
     StringAtom& operator= (char* asciiString);
     StringAtom& operator= (const QString & other);
@@ -55,5 +56,6 @@ class StringAtom {
     // Mutex guarding access to s_stringHash
     static QMutex s_stringHashMutex;
 };
+Q_DECLARE_METATYPE(StringAtom);
 
 #endif // STRINGATOM_H

--- a/src/control/stringatom.h
+++ b/src/control/stringatom.h
@@ -23,6 +23,13 @@ class StringAtom {
         return m_pString ? true : false;
     }
 
+    inline bool isEmpty() {
+        if (m_pString) {
+            return m_pString->isEmpty();
+        }
+        return true;
+    }
+
     inline bool operator==(const StringAtom& other) const {
         return this->m_pString == other.m_pString;
     }

--- a/src/control/stringatom.h
+++ b/src/control/stringatom.h
@@ -63,6 +63,7 @@ class StringAtom {
     // Mutex guarding access to s_stringHash
     static QMutex s_stringHashMutex;
 };
+
 Q_DECLARE_METATYPE(StringAtom);
 
 #endif // STRINGATOM_H

--- a/src/control/stringatom.h
+++ b/src/control/stringatom.h
@@ -1,0 +1,50 @@
+#ifndef STRINGATOM_H
+#define STRINGATOM_H
+
+#include <QHash>
+#include <QMutex>
+#include <QString>
+#include <QAtomicPointer>
+
+class StringAtom {
+  public:
+    StringAtom();
+    StringAtom(const char* asciiString);
+    StringAtom(const QString& string);
+    ~StringAtom();
+
+    QByteArray toAscii() const;
+    const QString& toString() const;
+
+    static const StringAtom get(const char* asciiString);
+    static const StringAtom get(const QString& string);
+
+    inline bool isValid() {
+        return m_pString ? true : false;
+    }
+
+    inline bool operator==(const StringAtom& other) {
+        return this->m_pString == other.m_pString;
+    }
+
+    inline operator QString() {
+        return QString(*m_pString);
+    }
+/*
+    StringAtom& operator= (char* asciiString);
+    StringAtom& operator= (const QString & other);
+*/
+
+  private:
+    StringAtom(const QString* pString);
+    void initalize(const QString& string);
+    static const QString* getInner(const QString& string);
+
+    const QString* m_pString;
+    // Hash of all StringAtomic instantiations.
+    static QHash<QString, const QString*> s_stringHash;
+    // Mutex guarding access to s_stringHash
+    static QMutex s_stringHashMutex;
+};
+
+#endif // STRINGATOM_H

--- a/src/control/stringatom.h
+++ b/src/control/stringatom.h
@@ -36,8 +36,8 @@ class StringAtom {
         return this->m_pString < other.m_pString;
     }
 
-    inline operator QString() {
-        return QString(*m_pString);
+    inline operator const QString&() const {
+        return *m_pString;
     }
 /*
     StringAtom& operator= (char* asciiString);

--- a/src/control/stringatom.h
+++ b/src/control/stringatom.h
@@ -5,6 +5,7 @@
 #include <QMutex>
 #include <QString>
 #include <QAtomicPointer>
+#include <QMetaType>
 
 class StringAtom {
   public:

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -466,7 +466,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                 ConfigKey("[Master]", "num_decks"));
             for (int iDeckNumber = 1; iDeckNumber <= iNumDecks; ++iDeckNumber) {
                 // PlayerManager::groupForDeck is 0-indexed.
-                QString playerGroup = PlayerManager::groupForDeck(iDeckNumber - 1);
+                StringAtom playerGroup = PlayerManager::groupForDeck(iDeckNumber - 1);
                 // TODO(owen): Fix bad i18n here.
                 addPrefixedControl(effectUnitGroup,
                                    QString("group_%1_enable").arg(playerGroup),

--- a/src/controlobjectslave.cpp
+++ b/src/controlobjectslave.cpp
@@ -9,12 +9,20 @@ ControlObjectSlave::ControlObjectSlave(QObject* pParent)
           m_pControl(NULL) {
 }
 
-ControlObjectSlave::ControlObjectSlave(const QString& g, const QString& i, QObject* pParent)
+ControlObjectSlave::ControlObjectSlave(const StringAtom& g, const QString& i,
+                                       QObject* pParent)
         : QObject(pParent) {
     initialize(ConfigKey(g, i));
 }
 
-ControlObjectSlave::ControlObjectSlave(const char* g, const char* i, QObject* pParent)
+ControlObjectSlave::ControlObjectSlave(const QString& g, const QString& i,
+                                       QObject* pParent)
+        : QObject(pParent) {
+    initialize(ConfigKey(g, i));
+}
+
+ControlObjectSlave::ControlObjectSlave(const char* g, const char* i,
+                                       QObject* pParent)
         : QObject(pParent) {
     initialize(ConfigKey(g, i));
 }

--- a/src/controlobjectslave.h
+++ b/src/controlobjectslave.h
@@ -6,6 +6,7 @@
 #include <QString>
 
 #include "control/control.h"
+#include "control/stringatom.h"
 #include "configobject.h"
 
 // This class is the successor of ControlObjectThread. It should be used for new
@@ -17,6 +18,7 @@ class ControlObjectSlave : public QObject {
     Q_OBJECT
   public:
     ControlObjectSlave(QObject* pParent = NULL);
+    ControlObjectSlave(const StringAtom& g, const QString& i, QObject* pParent = NULL);
     ControlObjectSlave(const QString& g, const QString& i, QObject* pParent = NULL);
     ControlObjectSlave(const char* g, const char* i, QObject* pParent = NULL);
     ControlObjectSlave(const ConfigKey& key, QObject* pParent = NULL);

--- a/src/deck.cpp
+++ b/src/deck.cpp
@@ -5,7 +5,7 @@ Deck::Deck(QObject* pParent,
            EngineMaster* pMixingEngine,
            EffectsManager* pEffectsManager,
            EngineChannel::ChannelOrientation defaultOrientation,
-           QString group) :
+           const StringAtom& group) :
         BaseTrackPlayerImpl(pParent, pConfig, pMixingEngine, pEffectsManager,
                             defaultOrientation, group, true, false) {
 }

--- a/src/deck.h
+++ b/src/deck.h
@@ -13,7 +13,7 @@ class Deck : public BaseTrackPlayerImpl {
          EngineMaster* pMixingEngine,
          EffectsManager* pEffectsManager,
          EngineChannel::ChannelOrientation defaultOrientation,
-         QString group);
+         const StringAtom& group);
     virtual ~Deck();
 };
 

--- a/src/dlganalysis.cpp
+++ b/src/dlganalysis.cpp
@@ -24,8 +24,8 @@ DlgAnalysis::DlgAnalysis(QWidget* parent,
     m_pAnalysisLibraryTableView = new WAnalysisLibraryTableView(this, pConfig, pTrackCollection);
     connect(m_pAnalysisLibraryTableView, SIGNAL(loadTrack(TrackPointer)),
             this, SIGNAL(loadTrack(TrackPointer)));
-    connect(m_pAnalysisLibraryTableView, SIGNAL(loadTrackToPlayer(TrackPointer, QString)),
-            this, SIGNAL(loadTrackToPlayer(TrackPointer, QString)));
+    connect(m_pAnalysisLibraryTableView, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom)),
+            this, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom)));
 
     connect(m_pAnalysisLibraryTableView, SIGNAL(trackSelected(TrackPointer)),
             this, SIGNAL(trackSelected(TrackPointer)));

--- a/src/dlganalysis.h
+++ b/src/dlganalysis.h
@@ -7,6 +7,7 @@
 #include "library/libraryview.h"
 #include "library/trackcollection.h"
 #include "library/analysislibrarytablemodel.h"
+#include "control/stringatom.h"
 
 class AnalysisLibraryTableModel;
 class WAnalysisLibraryTableView;
@@ -44,7 +45,7 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
 
   signals:
     void loadTrack(TrackPointer pTrack);
-    void loadTrackToPlayer(TrackPointer pTrack, QString player);
+    void loadTrackToPlayer(TrackPointer pTrack, StringAtom group);
     void analyzeTracks(QList<int> trackIds);
     void stopAnalysis();
     void trackSelected(TrackPointer pTrack);

--- a/src/dlgautodj.cpp
+++ b/src/dlgautodj.cpp
@@ -24,8 +24,8 @@ DlgAutoDJ::DlgAutoDJ(QWidget* parent,
     m_pTrackTableView->installEventFilter(pKeyboard);
     connect(m_pTrackTableView, SIGNAL(loadTrack(TrackPointer)),
             this, SIGNAL(loadTrack(TrackPointer)));
-    connect(m_pTrackTableView, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)),
-            this, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)));
+    connect(m_pTrackTableView, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)),
+            this, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)));
     connect(m_pTrackTableView, SIGNAL(trackSelected(TrackPointer)),
             this, SIGNAL(trackSelected(TrackPointer)));
     connect(pLibrary, SIGNAL(setTrackTableFont(QFont)),

--- a/src/dlgautodj.h
+++ b/src/dlgautodj.h
@@ -46,7 +46,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
   signals:
     void addRandomButton(bool buttonChecked);
     void loadTrack(TrackPointer tio);
-    void loadTrackToPlayer(TrackPointer tio, QString group, bool);
+    void loadTrackToPlayer(TrackPointer tio, StringAtom group, bool);
     void trackSelected(TrackPointer pTrack);
 
   private:

--- a/src/dlgprefautodj.cpp
+++ b/src/dlgprefautodj.cpp
@@ -74,9 +74,6 @@ DlgPrefAutoDJ::DlgPrefAutoDJ(QWidget* pParent,
     autoDjIgnoreTimeEdit->setVisible(false);
     GridLayout1->removeWidget(autoDjIgnoreTimeEdit);
 #endif // __AUTODJCRATES__
-    // Connect the global cancell signal
-       connect(this,SIGNAL(cancelPreferences()),this,
-               SLOT(slotCancel()));
 }
 
 DlgPrefAutoDJ::~DlgPrefAutoDJ() {

--- a/src/dlgrecording.cpp
+++ b/src/dlgrecording.cpp
@@ -25,8 +25,8 @@ DlgRecording::DlgRecording(QWidget* parent, ConfigObject<ConfigValue>* pConfig,
 
     connect(m_pTrackTableView, SIGNAL(loadTrack(TrackPointer)),
             this, SIGNAL(loadTrack(TrackPointer)));
-    connect(m_pTrackTableView, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)),
-            this, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)));
+    connect(m_pTrackTableView, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)),
+            this, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)));
     connect(pLibrary, SIGNAL(setTrackTableFont(QFont)),
             m_pTrackTableView, SLOT(setTrackTableFont(QFont)));
     connect(pLibrary, SIGNAL(setTrackTableRowHeight(int)),

--- a/src/dlgrecording.h
+++ b/src/dlgrecording.h
@@ -44,7 +44,7 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
 
   signals:
     void loadTrack(TrackPointer tio);
-    void loadTrackToPlayer(TrackPointer tio, QString group, bool play);
+    void loadTrackToPlayer(TrackPointer tio, StringAtom group, bool play);
     void restoreSearch(QString search);
 
   private:

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -22,9 +22,9 @@ const int filterLength = 5;
 // the actual number of beats is this x2.
 const int kLocalBpmSpan = 4;
 
-BpmControl::BpmControl(QString group,
-                       ConfigObject<ConfigValue>* _config) :
-        EngineControl(group, _config),
+BpmControl::BpmControl(const StringAtom& group,
+                       ConfigObject<ConfigValue>* pConfig) :
+        EngineControl(group, pConfig),
         m_dPreviousSample(0),
         m_dSyncTargetBeatDistance(0.0),
         m_dSyncInstantaneousBpm(0.0),

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -32,7 +32,7 @@ BpmControl::BpmControl(const StringAtom& group,
         m_resetSyncAdjustment(false),
         m_dUserOffset(0.0),
         m_tapFilter(this, filterLength, maxInterval),
-        m_sGroup(group) {
+        m_group(group) {
     m_pPlayButton = new ControlObjectSlave(group, "play", this);
     m_pPlayButton->connectValueChanged(SLOT(slotControlPlay(double)), Qt::DirectConnection);
     m_pReverseButton = new ControlObjectSlave(group, "reverse", this);

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -160,7 +160,7 @@ class BpmControl : public EngineControl {
     TrackPointer m_pTrack;
     BeatsPointer m_pBeats;
 
-    QString m_sGroup;
+    const StringAtom m_group;
 };
 
 

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -22,7 +22,7 @@ class BpmControl : public EngineControl {
     Q_OBJECT
 
   public:
-    BpmControl(QString group, ConfigObject<ConfigValue>* _config);
+    BpmControl(const StringAtom& group, ConfigObject<ConfigValue>* pConfig);
     virtual ~BpmControl();
 
     double getBpm() const;

--- a/src/engine/clockcontrol.cpp
+++ b/src/engine/clockcontrol.cpp
@@ -6,7 +6,7 @@
 #include "engine/enginecontrol.h"
 #include "controlobjectslave.h"
 
-ClockControl::ClockControl(QString group, ConfigObject<ConfigValue>* pConfig)
+ClockControl::ClockControl(const StringAtom& group, ConfigObject<ConfigValue>* pConfig)
         : EngineControl(group, pConfig) {
     m_pCOBeatActive = new ControlObject(ConfigKey(group, "beat_active"));
     m_pCOBeatActive->set(0.0);

--- a/src/engine/clockcontrol.h
+++ b/src/engine/clockcontrol.h
@@ -12,7 +12,7 @@ class ControlObjectSlave;
 class ClockControl: public EngineControl {
     Q_OBJECT
   public:
-    ClockControl(QString group,
+    ClockControl(const StringAtom& group,
                  ConfigObject<ConfigValue>* pConfig);
 
     virtual ~ClockControl();

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -17,9 +17,9 @@ static const double CUE_MODE_PIONEER = 1.0;
 static const double CUE_MODE_DENON = 2.0;
 static const double CUE_MODE_NUMARK = 3.0;
 
-CueControl::CueControl(QString group,
-                       ConfigObject<ConfigValue>* _config) :
-        EngineControl(group, _config),
+CueControl::CueControl(const StringAtom& group,
+                       ConfigObject<ConfigValue>* pConfig) :
+        EngineControl(group, pConfig),
         m_bHotcueCancel(false),
         m_bPreviewing(false),
         m_bPreviewingHotcue(false),

--- a/src/engine/cuecontrol.h
+++ b/src/engine/cuecontrol.h
@@ -83,8 +83,8 @@ class HotcueControl : public QObject {
 class CueControl : public EngineControl {
     Q_OBJECT
   public:
-    CueControl(QString group,
-               ConfigObject<ConfigValue>* _config);
+    CueControl(const StringAtom& group,
+               ConfigObject<ConfigValue>* pConfig);
     virtual ~CueControl();
 
     virtual void hintReader(HintVector* pHintList);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -62,11 +62,11 @@
 
 const double kLinearScalerElipsis = 1.00058; // 2^(0.01/12): changes < 1 cent allows a linear scaler
 
-EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
+EngineBuffer::EngineBuffer(const StringAtom& group, ConfigObject<ConfigValue>* pConfig,
                            EngineChannel* pChannel, EngineMaster* pMixingEngine)
         : m_engineLock(QMutex::Recursive),
           m_group(group),
-          m_pConfig(_config),
+          m_pConfig(pConfig),
           m_pLoopingControl(NULL),
           m_pSyncControl(NULL),
           m_pVinylControlControl(NULL),
@@ -126,7 +126,7 @@ EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
     m_fLastSampleValue[0] = 0;
     m_fLastSampleValue[1] = 0;
 
-    m_pReader = new CachingReader(group, _config);
+    m_pReader = new CachingReader(group, pConfig);
     connect(m_pReader, SIGNAL(trackLoading()),
             this, SLOT(slotTrackLoading()),
             Qt::DirectConnection);
@@ -226,29 +226,29 @@ EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
     // Quantization Controller for enabling and disabling the
     // quantization (alignment) of loop in/out positions and (hot)cues with
     // beats.
-    addControl(new QuantizeControl(group, _config));
+    addControl(new QuantizeControl(group, pConfig));
     m_pQuantize = ControlObject::getControl(ConfigKey(group, "quantize"));
 
     // Create the Loop Controller
-    m_pLoopingControl = new LoopingControl(group, _config);
+    m_pLoopingControl = new LoopingControl(group, pConfig);
     addControl(m_pLoopingControl);
 
     m_pEngineSync = pMixingEngine->getEngineSync();
 
-    m_pSyncControl = new SyncControl(group, _config, pChannel, m_pEngineSync);
+    m_pSyncControl = new SyncControl(group, pConfig, pChannel, m_pEngineSync);
     addControl(m_pSyncControl);
 
 #ifdef __VINYLCONTROL__
-    m_pVinylControlControl = new VinylControlControl(group, _config);
+    m_pVinylControlControl = new VinylControlControl(group, pConfig);
     addControl(m_pVinylControlControl);
 #endif
 
-    m_pRateControl = new RateControl(group, _config);
+    m_pRateControl = new RateControl(group, pConfig);
     // Add the Rate Controller
     addControl(m_pRateControl);
 
     // Create the BPM Controller
-    m_pBpmControl = new BpmControl(group, _config);
+    m_pBpmControl = new BpmControl(group, pConfig);
     addControl(m_pBpmControl);
 
     // TODO(rryan) remove this dependence?
@@ -259,15 +259,15 @@ EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
     m_fwdButton = ControlObject::getControl(ConfigKey(group, "fwd"));
     m_backButton = ControlObject::getControl(ConfigKey(group, "back"));
 
-    m_pKeyControl = new KeyControl(group, _config);
+    m_pKeyControl = new KeyControl(group, pConfig);
     addControl(m_pKeyControl);
 
     // Create the clock controller
-    m_pClockControl = new ClockControl(group, _config);
+    m_pClockControl = new ClockControl(group, pConfig);
     addControl(m_pClockControl);
 
     // Create the cue controller
-    m_pCueControl = new CueControl(group, _config);
+    m_pCueControl = new CueControl(group, pConfig);
     addControl(m_pCueControl);
 
     m_pReadAheadManager = new ReadAheadManager(m_pReader);

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -29,6 +29,7 @@
 #include "configobject.h"
 #include "rotary.h"
 #include "control/controlvalue.h"
+#include "control/stringatom.h"
 #include "cachingreader.h"
 
 //for the writer
@@ -117,7 +118,7 @@ class EngineBuffer : public EngineObject {
         KEYLOCK_ENGINE_COUNT,
     };
 
-    EngineBuffer(QString _group, ConfigObject<ConfigValue>* _config,
+    EngineBuffer(const StringAtom& group, ConfigObject<ConfigValue>* config,
                  EngineChannel* pChannel, EngineMaster* pMixingEngine);
     virtual ~EngineBuffer();
 
@@ -237,7 +238,7 @@ class EngineBuffer : public EngineObject {
     QMutex m_engineLock;
 
     // Holds the name of the control group
-    QString m_group;
+    StringAtom m_group;
     ConfigObject<ConfigValue>* m_pConfig;
 
     LoopingControl* m_pLoopingControl;

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -71,7 +71,7 @@ double EngineControl::getTotalSamples() const {
     return m_dTotalSamples;
 }
 
-QString EngineControl::getGroup() const {
+const StringAtom& EngineControl::getGroup() const {
     return m_group;
 }
 

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -6,10 +6,10 @@
 #include "engine/enginebuffer.h"
 #include "playermanager.h"
 
-EngineControl::EngineControl(QString group,
-                             ConfigObject<ConfigValue>* _config)
+EngineControl::EngineControl(const StringAtom& group,
+                             ConfigObject<ConfigValue>* pConfig)
         : m_group(group),
-          m_pConfig(_config),
+          m_pConfig(pConfig),
           m_dTotalSamples(0),
           m_pEngineMaster(NULL),
           m_pEngineBuffer(NULL),

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -70,7 +70,7 @@ class EngineControl : public QObject {
     virtual void setCurrentSample(const double dCurrentSample, const double dTotalSamples);
     double getCurrentSample() const;
     double getTotalSamples() const;
-    QString getGroup() const;
+    const StringAtom& getGroup() const;
 
     // Called to collect player features for effects processing.
     virtual void collectFeatureState(GroupFeatureState* pGroupFeatures) const {

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -35,8 +35,8 @@ const double kNoTrigger = -1;
 class EngineControl : public QObject {
     Q_OBJECT
   public:
-    EngineControl(QString group,
-                  ConfigObject<ConfigValue>* _config);
+    EngineControl(const StringAtom& group,
+                  ConfigObject<ConfigValue>* pConfig);
     virtual ~EngineControl();
 
     // Called by EngineBuffer::process every latency period. See the above
@@ -95,7 +95,7 @@ class EngineControl : public QObject {
     EngineMaster* getEngineMaster();
     EngineBuffer* getEngineBuffer();
 
-    QString m_group;
+    StringAtom m_group;
     ConfigObject<ConfigValue>* m_pConfig;
 
   private:

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -26,7 +26,7 @@
 
 #include "sampleutil.h"
 
-EngineDeck::EngineDeck(QString group,
+EngineDeck::EngineDeck(const StringAtom& group,
                        ConfigObject<ConfigValue>* pConfig,
                        EngineMaster* pMixingEngine,
                        EffectsManager* pEffectsManager,

--- a/src/engine/enginedeck.h
+++ b/src/engine/enginedeck.h
@@ -40,7 +40,7 @@ class ControlPushButton;
 class EngineDeck : public EngineChannel, public AudioDestination {
     Q_OBJECT
   public:
-    EngineDeck(QString group, ConfigObject<ConfigValue>* pConfig,
+    EngineDeck(const StringAtom& group, ConfigObject<ConfigValue>* pConfig,
                EngineMaster* pMixingEngine, EffectsManager* pEffectsManager,
                EngineChannel::ChannelOrientation defaultOrientation = CENTER);
     virtual ~EngineDeck();

--- a/src/engine/enginepregain.cpp
+++ b/src/engine/enginepregain.cpp
@@ -31,7 +31,7 @@ ControlObject* EnginePregain::s_pEnableReplayGain = NULL;
 /*----------------------------------------------------------------
    A pregaincontrol is ... a pregain.
    ----------------------------------------------------------------*/
-EnginePregain::EnginePregain(QString group)
+EnginePregain::EnginePregain(const StringAtom& group)
         : m_dSpeed(0),
           m_fPrevGain(1.0),
           m_bSmoothFade(false) {

--- a/src/engine/enginepregain.h
+++ b/src/engine/enginepregain.h
@@ -27,7 +27,7 @@ class ControlObject;
 
 class EnginePregain : public EngineObject {
   public:
-    EnginePregain(QString group);
+    EnginePregain(const StringAtom& group);
     virtual ~EnginePregain();
 
     void setSpeed(double speed);

--- a/src/engine/enginevumeter.cpp
+++ b/src/engine/enginevumeter.cpp
@@ -20,7 +20,7 @@
 #include "sampleutil.h"
 #include "util/math.h"
 
-EngineVuMeter::EngineVuMeter(QString group) {
+EngineVuMeter::EngineVuMeter(const StringAtom& group) {
     // The VUmeter widget is controlled via a controlpotmeter, which means
     // that it should react on the setValue(int) signal.
     m_ctrlVuMeter = new ControlPotmeter(ConfigKey(group, "VuMeter"), 0., 1.);

--- a/src/engine/enginevumeter.h
+++ b/src/engine/enginevumeter.h
@@ -18,6 +18,7 @@
 #define ENGINEVUMETER_H
 
 #include "engine/engineobject.h"
+#include "control/stringatom.h"
 
 // Rate at which the vumeter is updated (using a sample rate of 44100 Hz):
 #define VU_UPDATE_RATE 30 // in 1/s, fits to display frame rate
@@ -34,7 +35,7 @@ class ControlObjectSlave;
 class EngineVuMeter : public EngineObject {
     Q_OBJECT
   public:
-    EngineVuMeter(QString group);
+    EngineVuMeter(const StringAtom& group);
     virtual ~EngineVuMeter();
 
     virtual void process(CSAMPLE* pInOut, const int iBufferSize);

--- a/src/engine/keycontrol.cpp
+++ b/src/engine/keycontrol.cpp
@@ -12,7 +12,7 @@
 static const double kLockOriginalKey = 0;
 static const double kLockCurrentKey = 1;
 
-KeyControl::KeyControl(QString group,
+KeyControl::KeyControl(const StringAtom& group,
                        ConfigObject<ConfigValue>* pConfig)
         : EngineControl(group, pConfig) {
     m_pitchRateInfo.pitchRatio = 1.0;

--- a/src/engine/keycontrol.h
+++ b/src/engine/keycontrol.h
@@ -25,7 +25,7 @@ class KeyControl : public EngineControl {
         bool keylock;
     };
 
-    KeyControl(QString group, ConfigObject<ConfigValue>* pConfig);
+    KeyControl(const StringAtom& group, ConfigObject<ConfigValue>* pConfig);
     virtual ~KeyControl();
 
     // Returns a struct, with the results of the last pitch and tempo calculations

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -903,7 +903,7 @@ void LoopingControl::seekInsideAdjustedLoop(int old_loop_in, int old_loop_out,
     }
 }
 
-BeatJumpControl::BeatJumpControl(QString group, double size)
+BeatJumpControl::BeatJumpControl(const StringAtom& group, double size)
         : m_dBeatJumpSize(size) {
     m_pJumpForward = new ControlPushButton(
             keyForControl(group, "beatjump_%1_forward", size));
@@ -934,7 +934,7 @@ void BeatJumpControl::slotJumpForward(double v) {
     }
 }
 
-LoopMoveControl::LoopMoveControl(QString group, double size)
+LoopMoveControl::LoopMoveControl(const StringAtom& group, double size)
         : m_dLoopMoveSize(size) {
     m_pMoveForward = new ControlPushButton(
             keyForControl(group, "loop_move_%1_forward", size));
@@ -965,7 +965,7 @@ void LoopMoveControl::slotMoveForward(double v) {
     }
 }
 
-BeatLoopingControl::BeatLoopingControl(QString group, double size)
+BeatLoopingControl::BeatLoopingControl(const StringAtom& group, double size)
         : m_dBeatLoopSize(size),
           m_bActive(false) {
     // This is the original beatloop control which is now deprecated. Its value

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -37,9 +37,9 @@ QList<double> LoopingControl::getBeatSizes() {
     return result;
 }
 
-LoopingControl::LoopingControl(QString group,
-                               ConfigObject<ConfigValue>* _config)
-        : EngineControl(group, _config) {
+LoopingControl::LoopingControl(const StringAtom& group,
+                               ConfigObject<ConfigValue>* config)
+        : EngineControl(group, config) {
     m_bLoopingEnabled = false;
     m_bLoopRollActive = false;
     m_iLoopStartSample = kNoTrigger;

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -26,7 +26,7 @@ class LoopingControl : public EngineControl {
   public:
     static QList<double> getBeatSizes();
 
-    LoopingControl(QString group, ConfigObject<ConfigValue>* _config);
+    LoopingControl(const StringAtom& group, ConfigObject<ConfigValue>* pConfig);
     virtual ~LoopingControl();
 
     // process() updates the internal state of the LoopingControl to reflect the

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -140,7 +140,7 @@ class LoopingControl : public EngineControl {
 class LoopMoveControl : public QObject {
     Q_OBJECT
   public:
-    LoopMoveControl(QString group, double size);
+    LoopMoveControl(const StringAtom& group, double size);
     virtual ~LoopMoveControl();
 
   signals:
@@ -161,7 +161,7 @@ class LoopMoveControl : public QObject {
 class BeatJumpControl : public QObject {
     Q_OBJECT
   public:
-    BeatJumpControl(QString group, double size);
+    BeatJumpControl(const StringAtom& group, double size);
     virtual ~BeatJumpControl();
 
   signals:
@@ -182,7 +182,7 @@ class BeatJumpControl : public QObject {
 class BeatLoopingControl : public QObject {
     Q_OBJECT
   public:
-    BeatLoopingControl(QString group, double size);
+    BeatLoopingControl(const StringAtom& group, double size);
     virtual ~BeatLoopingControl();
 
     void activate();

--- a/src/engine/positionscratchcontroller.cpp
+++ b/src/engine/positionscratchcontroller.cpp
@@ -62,7 +62,7 @@ class RateIIFilter {
     double m_last_rate;
 };
 
-PositionScratchController::PositionScratchController(QString group)
+PositionScratchController::PositionScratchController(const StringAtom& group)
     : m_group(group),
       m_bScratching(false),
       m_bEnableInertia(false),

--- a/src/engine/positionscratchcontroller.h
+++ b/src/engine/positionscratchcontroller.h
@@ -11,7 +11,7 @@ class RateIIFilter;
 
 class PositionScratchController : public QObject {
   public:
-    PositionScratchController(QString group);
+    PositionScratchController(const StringAtom& group);
     virtual ~PositionScratchController();
 
     void process(double currentSample, double releaseRate,

--- a/src/engine/quantizecontrol.cpp
+++ b/src/engine/quantizecontrol.cpp
@@ -11,7 +11,7 @@
 #include "engine/quantizecontrol.h"
 #include "engine/enginecontrol.h"
 
-QuantizeControl::QuantizeControl(QString group,
+QuantizeControl::QuantizeControl(const StringAtom& group,
                                  ConfigObject<ConfigValue>* pConfig)
         : EngineControl(group, pConfig) {
     // Turn quantize OFF by default. See Bug #898213

--- a/src/engine/quantizecontrol.h
+++ b/src/engine/quantizecontrol.h
@@ -16,7 +16,7 @@ class ControlObjectThread;
 class QuantizeControl : public EngineControl {
     Q_OBJECT
   public:
-    QuantizeControl(QString group, ConfigObject<ConfigValue>* pConfig);
+    QuantizeControl(const StringAtom& group, ConfigObject<ConfigValue>* pConfig);
     virtual ~QuantizeControl();
 
     double process(const double dRate,

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -30,7 +30,7 @@ const double RateControl::kWheelMultiplier = 40.0;
 const double RateControl::kPausedJogMultiplier = 18.0;
 enum RateControl::RATERAMP_MODE RateControl::m_eRateRampMode = RateControl::RATERAMP_STEP;
 
-RateControl::RateControl(QString group,
+RateControl::RateControl(const StringAtom& group,
                          ConfigObject<ConfigValue>* _config)
     : EngineControl(group, _config),
       m_pBpmControl(NULL),

--- a/src/engine/ratecontrol.h
+++ b/src/engine/ratecontrol.h
@@ -31,7 +31,7 @@ class PositionScratchController;
 class RateControl : public EngineControl {
     Q_OBJECT
 public:
-    RateControl(QString group, ConfigObject<ConfigValue>* _config);
+    RateControl(const StringAtom& group, ConfigObject<ConfigValue>* _config);
     virtual ~RateControl();
 
     void setBpmControl(BpmControl* bpmcontrol);

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -16,7 +16,7 @@ const double SyncControl::kBpmUnity = 1.0;
 const double SyncControl::kBpmHalve = 0.5;
 const double SyncControl::kBpmDouble = 2.0;
 
-SyncControl::SyncControl(QString group, ConfigObject<ConfigValue>* pConfig,
+SyncControl::SyncControl(const StringAtom& group, ConfigObject<ConfigValue>* pConfig,
                          EngineChannel* pChannel, SyncableListener* pEngineSync)
         : EngineControl(group, pConfig),
           m_sGroup(group),

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -19,7 +19,7 @@ const double SyncControl::kBpmDouble = 2.0;
 SyncControl::SyncControl(const StringAtom& group, ConfigObject<ConfigValue>* pConfig,
                          EngineChannel* pChannel, SyncableListener* pEngineSync)
         : EngineControl(group, pConfig),
-          m_sGroup(group),
+          m_group(group),
           m_pChannel(pChannel),
           m_pEngineSync(pEngineSync),
           m_pBpmControl(NULL),

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -20,7 +20,7 @@ class SyncControl : public EngineControl, public Syncable {
     static const double kBpmUnity;
     static const double kBpmHalve;
     static const double kBpmDouble;
-    SyncControl(QString group, ConfigObject<ConfigValue>* pConfig,
+    SyncControl(const StringAtom& group, ConfigObject<ConfigValue>* pConfig,
                 EngineChannel* pChannel, SyncableListener* pEngineSync);
     virtual ~SyncControl();
 

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -24,7 +24,7 @@ class SyncControl : public EngineControl, public Syncable {
                 EngineChannel* pChannel, SyncableListener* pEngineSync);
     virtual ~SyncControl();
 
-    const QString& getGroup() const { return m_sGroup; }
+    const QString& getGroup() const { return m_group; }
     EngineChannel* getChannel() const { return m_pChannel; }
     double getBpm() const;
 
@@ -95,7 +95,7 @@ class SyncControl : public EngineControl, public Syncable {
     double determineBpmMultiplier(double myBpm, double targetBpm) const;
     void updateTargetBeatDistance();
 
-    QString m_sGroup;
+    const StringAtom m_group;
     // The only reason we have this pointer is an optimzation so that the
     // EngineSync can ask us what our EngineChannel is. EngineMaster in turn
     // asks EngineSync what EngineChannel is the "master" channel.

--- a/src/engine/vinylcontrolcontrol.cpp
+++ b/src/engine/vinylcontrolcontrol.cpp
@@ -4,7 +4,7 @@
 #include "library/dao/cue.h"
 #include "util/math.h"
 
-VinylControlControl::VinylControlControl(QString group, ConfigObject<ConfigValue>* pConfig)
+VinylControlControl::VinylControlControl(const StringAtom& group, ConfigObject<ConfigValue>* pConfig)
         : EngineControl(group, pConfig),
           m_bSeekRequested(false) {
     m_pControlVinylStatus = new ControlObject(ConfigKey(group, "vinylcontrol_status"));

--- a/src/engine/vinylcontrolcontrol.h
+++ b/src/engine/vinylcontrolcontrol.h
@@ -11,7 +11,7 @@
 class VinylControlControl : public EngineControl {
     Q_OBJECT
   public:
-    VinylControlControl(QString group, ConfigObject<ConfigValue>* pConfig);
+    VinylControlControl(const StringAtom& group, ConfigObject<ConfigValue>* pConfig);
     virtual ~VinylControlControl();
 
     void trackLoaded(TrackPointer pTrack);

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -65,8 +65,8 @@ void AnalysisFeature::bindWidget(WLibrary* libraryWidget,
                                       m_pTrackCollection);
     connect(m_pAnalysisView, SIGNAL(loadTrack(TrackPointer)),
             this, SIGNAL(loadTrack(TrackPointer)));
-    connect(m_pAnalysisView, SIGNAL(loadTrackToPlayer(TrackPointer, QString)),
-            this, SIGNAL(loadTrackToPlayer(TrackPointer, QString)));
+    connect(m_pAnalysisView, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom)),
+            this, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom)));
     connect(m_pAnalysisView, SIGNAL(analyzeTracks(QList<int>)),
             this, SLOT(analyzeTracks(QList<int>)));
     connect(m_pAnalysisView, SIGNAL(stopAnalysis()),

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -55,8 +55,8 @@ AutoDJFeature::AutoDJFeature(Library* pLibrary,
     qRegisterMetaType<AutoDJProcessor::AutoDJState>("AutoDJState");
     m_pAutoDJProcessor = new AutoDJProcessor(
             this, m_pConfig, pPlayerManager, m_iAutoDJPlaylistId, m_pTrackCollection);
-    connect(m_pAutoDJProcessor, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)),
-            this, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)));
+    connect(m_pAutoDJProcessor, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)),
+            this, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)));
 
 #ifdef __AUTODJCRATES__
 
@@ -116,8 +116,8 @@ void AutoDJFeature::bindWidget(WLibrary* libraryWidget,
     libraryWidget->registerView(m_sAutoDJViewName, m_pAutoDJView);
     connect(m_pAutoDJView, SIGNAL(loadTrack(TrackPointer)),
             this, SIGNAL(loadTrack(TrackPointer)));
-    connect(m_pAutoDJView, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)),
-            this, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)));
+    connect(m_pAutoDJView, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)),
+            this, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)));
 
     connect(m_pAutoDJView, SIGNAL(trackSelected(TrackPointer)),
             this, SIGNAL(trackSelected(TrackPointer)));

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -101,7 +101,7 @@ AutoDJProcessor::AutoDJProcessor(QObject* pParent,
     // TODO(rryan) listen to signals from PlayerManager and add/remove as decks
     // are created.
     for (unsigned int i = 0; i < pPlayerManager->numberOfDecks(); ++i) {
-        QString group = PlayerManager::groupForDeck(i);
+        StringAtom group = PlayerManager::groupForDeck(i);
         BaseTrackPlayer* pPlayer = pPlayerManager->getPlayer(group);
         // Shouldn't be possible.
         if (pPlayer == NULL) {

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -80,7 +80,7 @@ class DeckAttributes : public QObject {
 
   public:
     int index;
-    QString group;
+    StringAtom group;
     double posThreshold;
     double fadeDuration;
 

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -11,6 +11,7 @@
 #include "library/playlisttablemodel.h"
 #include "engine/enginechannel.h"
 #include "controlobjectslave.h"
+#include "control/stringatom.h"
 
 class ControlPushButton;
 class TrackCollection;
@@ -139,11 +140,11 @@ class AutoDJProcessor : public QObject {
     AutoDJError toggleAutoDJ(bool enable);
 
   signals:
-    virtual void loadTrackToPlayer(TrackPointer pTrack, QString group,
+    void loadTrackToPlayer(TrackPointer pTrack, StringAtom group,
                                    bool play);
-    virtual void transitionTimeChanged(int time);
-    virtual void autoDJStateChanged(AutoDJProcessor::AutoDJState state);
-    virtual void randomTrackRequested(int);
+    void transitionTimeChanged(int time);
+    void autoDJStateChanged(AutoDJProcessor::AutoDJState state);
+    void randomTrackRequested(int);
 
   private slots:
     void playerPositionChanged(DeckAttributes* pDeck, double position);

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -174,8 +174,8 @@ void Library::bindWidget(WLibrary* pLibraryWidget,
             pTrackTableView, SLOT(loadTrackModel(QAbstractItemModel*)));
     connect(pTrackTableView, SIGNAL(loadTrack(TrackPointer)),
             this, SLOT(slotLoadTrack(TrackPointer)));
-    connect(pTrackTableView, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)),
-            this, SLOT(slotLoadTrackToPlayer(TrackPointer, QString, bool)));
+    connect(pTrackTableView, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)),
+            this, SLOT(slotLoadTrackToPlayer(TrackPointer, StringAtom, bool)));
     pLibraryWidget->registerView(m_sTrackViewName, pTrackTableView);
 
     connect(this, SIGNAL(switchToView(const QString&)),
@@ -215,8 +215,8 @@ void Library::addFeature(LibraryFeature* feature) {
             this, SLOT(slotSwitchToView(const QString&)));
     connect(feature, SIGNAL(loadTrack(TrackPointer)),
             this, SLOT(slotLoadTrack(TrackPointer)));
-    connect(feature, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)),
-            this, SLOT(slotLoadTrackToPlayer(TrackPointer, QString, bool)));
+    connect(feature, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)),
+            this, SLOT(slotLoadTrackToPlayer(TrackPointer, StringAtom, bool)));
     connect(feature, SIGNAL(restoreSearch(const QString&)),
             this, SLOT(slotRestoreSearch(const QString&)));
     connect(feature, SIGNAL(enableCoverArtDisplay(bool)),
@@ -245,13 +245,13 @@ void Library::slotLoadTrack(TrackPointer pTrack) {
     emit(loadTrack(pTrack));
 }
 
-void Library::slotLoadLocationToPlayer(QString location, QString group) {
+void Library::slotLoadLocationToPlayer(QString location, StringAtom group) {
     TrackPointer pTrack = m_pTrackCollection->getTrackDAO()
             .getOrAddTrack(location, true, NULL);
     emit(loadTrackToPlayer(pTrack, group));
 }
 
-void Library::slotLoadTrackToPlayer(TrackPointer pTrack, QString group, bool play) {
+void Library::slotLoadTrackToPlayer(TrackPointer pTrack, StringAtom group, bool play) {
     emit(loadTrackToPlayer(pTrack, group, play));
 }
 

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -17,6 +17,7 @@
 #include "recording/recordingmanager.h"
 #include "analysisfeature.h"
 #include "library/coverartcache.h"
+#include "control/stringatom.h"
 
 class TrackModel;
 class TrackCollection;
@@ -79,8 +80,8 @@ public:
     void slotShowTrackModel(QAbstractItemModel* model);
     void slotSwitchToView(const QString& view);
     void slotLoadTrack(TrackPointer pTrack);
-    void slotLoadTrackToPlayer(TrackPointer pTrack, QString group, bool play);
-    void slotLoadLocationToPlayer(QString location, QString group);
+    void slotLoadTrackToPlayer(TrackPointer pTrack, StringAtom group, bool play);
+    void slotLoadLocationToPlayer(QString location, StringAtom group);
     void slotRestoreSearch(const QString& text);
     void slotRefreshLibraryModels();
     void slotCreatePlaylist();
@@ -96,7 +97,7 @@ public:
     void showTrackModel(QAbstractItemModel* model);
     void switchToView(const QString& view);
     void loadTrack(TrackPointer pTrack);
-    void loadTrackToPlayer(TrackPointer pTrack, QString group, bool play = false);
+    void loadTrackToPlayer(TrackPointer pTrack, StringAtom group, bool play = false);
     void restoreSearch(const QString&);
     void search(const QString& text);
     void searchCleared();

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -16,6 +16,7 @@
 #include "trackinfoobject.h"
 #include "treeitemmodel.h"
 #include "library/coverartcache.h"
+#include "control/stringatom.h"
 
 class TrackModel;
 class WLibrarySidebar;
@@ -84,7 +85,7 @@ class LibraryFeature : public QObject {
     void showTrackModel(QAbstractItemModel* model);
     void switchToView(const QString& view);
     void loadTrack(TrackPointer pTrack);
-    void loadTrackToPlayer(TrackPointer pTrack, QString group, bool play = false);
+    void loadTrackToPlayer(TrackPointer pTrack, StringAtom group, bool play = false);
     void restoreSearch(const QString&);
     // emit this signal before you parse a large music collection, e.g., iTunes, Traktor.
     // The second arg indicates if the feature should be "selected" when loading starts

--- a/src/library/previewbuttondelegate.cpp
+++ b/src/library/previewbuttondelegate.cpp
@@ -20,8 +20,8 @@ PreviewButtonDelegate::PreviewButtonDelegate(QObject *parent, int column)
             this, SLOT(previewDeckPlayChanged(double)));
 
     // This assumes that the parent is wtracktableview
-    connect(this, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)),
-            parent, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)));
+    connect(this, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)),
+            parent, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)));
 
     if (QTableView *tableView = qobject_cast<QTableView*>(parent)) {
         m_pTableView = tableView;

--- a/src/library/previewbuttondelegate.h
+++ b/src/library/previewbuttondelegate.h
@@ -6,6 +6,7 @@
 #include <QTableView>
 
 #include "trackinfoobject.h"
+#include "control/stringatom.h"
 
 class ControlObjectThread;
 
@@ -31,7 +32,7 @@ class PreviewButtonDelegate : public QStyledItemDelegate {
                               const QModelIndex &index) const;
 
   signals:
-    void loadTrackToPlayer(TrackPointer Track, QString group, bool play);
+    void loadTrackToPlayer(TrackPointer Track, StringAtom group, bool play);
     void buttonSetChecked(bool);
 
   public slots:

--- a/src/library/recording/recordingfeature.cpp
+++ b/src/library/recording/recordingfeature.cpp
@@ -52,8 +52,8 @@ void RecordingFeature::bindWidget(WLibrary* pLibraryWidget,
     pLibraryWidget->registerView(m_sRecordingViewName, pRecordingView);
     connect(pRecordingView, SIGNAL(loadTrack(TrackPointer)),
             this, SIGNAL(loadTrack(TrackPointer)));
-    connect(pRecordingView, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)),
-            this, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)));
+    connect(pRecordingView, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)),
+            this, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)));
     connect(this, SIGNAL(refreshBrowseModel()),
             pRecordingView, SLOT(refreshBrowseModel()));
     connect(this, SIGNAL(requestRestoreSearch()),

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -264,7 +264,7 @@ void PlayerManager::addConfiguredDecks() {
 
 void PlayerManager::addDeckInner() {
     // Do not lock m_mutex here.
-    StringAtom group = groupForDeck(m_decks.count());
+    StringAtom group = groupForDeck(m_decks.count(), true);
     DEBUG_ASSERT_AND_HANDLE(!m_players.contains(group)) {
         return;
     }
@@ -321,7 +321,7 @@ void PlayerManager::addSampler() {
 
 void PlayerManager::addSamplerInner() {
     // Do not lock m_mutex here.
-    StringAtom group = groupForSampler(m_samplers.count());
+    StringAtom group = groupForSampler(m_samplers.count(), true);
 
     DEBUG_ASSERT_AND_HANDLE(!m_players.contains(group)) {
         return;
@@ -349,7 +349,7 @@ void PlayerManager::addPreviewDeck() {
 
 void PlayerManager::addPreviewDeckInner() {
     // Do not lock m_mutex here.
-    StringAtom group = groupForPreviewDeck(m_preview_decks.count());
+    StringAtom group = groupForPreviewDeck(m_preview_decks.count(), true);
     DEBUG_ASSERT_AND_HANDLE(!m_players.contains(group)) {
         return;
     }
@@ -470,4 +470,55 @@ void PlayerManager::slotLoadTrackIntoNextAvailableSampler(TrackPointer pTrack) {
         }
         ++it;
     }
+}
+
+// static
+StringAtom PlayerManager::groupForSampler(int i, bool add) {
+    static QList<StringAtom> groupForSamplerList;
+    if (add) {
+        DEBUG_ASSERT_AND_HANDLE(i == groupForSamplerList.count()) {
+            return StringAtom();
+        }
+        StringAtom group = StringAtom(QString("[Sampler%1]").arg(i+1));
+        groupForSamplerList.append(group);
+        return group;
+    }
+    DEBUG_ASSERT_AND_HANDLE(i < groupForSamplerList.count()) {
+        return StringAtom();
+    }
+    return groupForSamplerList.at(i);
+}
+
+//static
+StringAtom PlayerManager::groupForDeck(int i, bool add) {
+    static QList<StringAtom> groupForDeckList;
+    if (add) {
+        DEBUG_ASSERT_AND_HANDLE(i == groupForDeckList.count()) {
+            return StringAtom();
+        }
+        StringAtom group = StringAtom(QString("[Channel%1]").arg(i+1));
+        groupForDeckList.append(group);
+        return group;
+    }
+    DEBUG_ASSERT_AND_HANDLE(i < groupForDeckList.count()) {
+        return StringAtom();
+    }
+    return groupForDeckList.at(i);
+}
+
+//static
+StringAtom PlayerManager::groupForPreviewDeck(int i, bool add) {
+    static QList<StringAtom> groupForPreviewDeckList;
+    if (add) {
+        DEBUG_ASSERT_AND_HANDLE(i == groupForPreviewDeckList.count()) {
+            return StringAtom();
+        }
+        StringAtom group = StringAtom(QString("[PreviewDeck%1]").arg(i+1));
+        groupForPreviewDeckList.append(group);
+        return group;
+    }
+    DEBUG_ASSERT_AND_HANDLE(i < groupForPreviewDeckList.count()) {
+        return StringAtom();
+    }
+    return groupForPreviewDeckList.at(i);
 }

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -264,7 +264,7 @@ void PlayerManager::addConfiguredDecks() {
 
 void PlayerManager::addDeckInner() {
     // Do not lock m_mutex here.
-    QString group = groupForDeck(m_decks.count());
+    StringAtom group = groupForDeck(m_decks.count());
     DEBUG_ASSERT_AND_HANDLE(!m_players.contains(group)) {
         return;
     }
@@ -283,7 +283,7 @@ void PlayerManager::addDeckInner() {
                 m_pAnalyserQueue, SLOT(slotAnalyseTrack(TrackPointer)));
     }
 
-    m_players[group] = pDeck;
+    m_players.insert(group, pDeck);
     m_decks.append(pDeck);
 
     // Register the deck output with SoundManager (deck is 0-indexed to SoundManager)
@@ -321,7 +321,7 @@ void PlayerManager::addSampler() {
 
 void PlayerManager::addSamplerInner() {
     // Do not lock m_mutex here.
-    QString group = groupForSampler(m_samplers.count());
+    StringAtom group = groupForSampler(m_samplers.count());
 
     DEBUG_ASSERT_AND_HANDLE(!m_players.contains(group)) {
         return;
@@ -337,7 +337,7 @@ void PlayerManager::addSamplerInner() {
                 m_pAnalyserQueue, SLOT(slotAnalyseTrack(TrackPointer)));
     }
 
-    m_players[group] = pSampler;
+    m_players.insert(group, pSampler);
     m_samplers.append(pSampler);
 }
 
@@ -349,7 +349,7 @@ void PlayerManager::addPreviewDeck() {
 
 void PlayerManager::addPreviewDeckInner() {
     // Do not lock m_mutex here.
-    QString group = groupForPreviewDeck(m_preview_decks.count());
+    StringAtom group = groupForPreviewDeck(m_preview_decks.count());
     DEBUG_ASSERT_AND_HANDLE(!m_players.contains(group)) {
         return;
     }
@@ -365,16 +365,13 @@ void PlayerManager::addPreviewDeckInner() {
                 m_pAnalyserQueue, SLOT(slotAnalyseTrack(TrackPointer)));
     }
 
-    m_players[group] = pPreviewDeck;
+    m_players.insert(group, pPreviewDeck);
     m_preview_decks.append(pPreviewDeck);
 }
 
-BaseTrackPlayer* PlayerManager::getPlayer(QString group) const {
+BaseTrackPlayer* PlayerManager::getPlayer(const StringAtom& group) const {
     QMutexLocker locker(&m_mutex);
-    if (m_players.contains(group)) {
-        return m_players[group];
-    }
-    return NULL;
+    return m_players.value(group, NULL);
 }
 
 Deck* PlayerManager::getDeck(unsigned int deck) const {

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -21,6 +21,7 @@
 #include "engine/enginedeck.h"
 #include "util/assert.h"
 
+
 PlayerManager::PlayerManager(ConfigObject<ConfigValue>* pConfig,
                              SoundManager* pSoundManager,
                              EffectsManager* pEffectsManager,

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -86,12 +86,12 @@ PlayerManager::~PlayerManager() {
 
 void PlayerManager::bindToLibrary(Library* pLibrary) {
     QMutexLocker locker(&m_mutex);
-    connect(pLibrary, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)),
-            this, SLOT(slotLoadTrackToPlayer(TrackPointer, QString, bool)));
+    connect(pLibrary, SIGNAL(loadTrackToPlayer(TrackPointer, StringAtom, bool)),
+            this, SLOT(slotLoadTrackToPlayer(TrackPointer, StringAtom, bool)));
     connect(pLibrary, SIGNAL(loadTrack(TrackPointer)),
             this, SLOT(slotLoadTrackIntoNextAvailableDeck(TrackPointer)));
-    connect(this, SIGNAL(loadLocationToPlayer(QString, QString)),
-            pLibrary, SLOT(slotLoadLocationToPlayer(QString, QString)));
+    connect(this, SIGNAL(loadLocationToPlayer(QString, StringAtom)),
+            pLibrary, SLOT(slotLoadLocationToPlayer(QString, StringAtom)));
 
     m_pAnalyserQueue = AnalyserQueue::createDefaultAnalyserQueue(m_pConfig,
             pLibrary->getTrackCollection());
@@ -409,7 +409,7 @@ bool PlayerManager::hasVinylInput(int inputnum) const {
     return m_pSoundManager->getConfig().getInputs().values().contains(vinyl_input);
 }
 
-void PlayerManager::slotLoadTrackToPlayer(TrackPointer pTrack, QString group, bool play) {
+void PlayerManager::slotLoadTrackToPlayer(TrackPointer pTrack, StringAtom group, bool play) {
     // Do not lock mutex in this method unless it is changed to access
     // PlayerManager state.
     BaseTrackPlayer* pPlayer = getPlayer(group);
@@ -422,7 +422,7 @@ void PlayerManager::slotLoadTrackToPlayer(TrackPointer pTrack, QString group, bo
     pPlayer->slotLoadTrack(pTrack, play);
 }
 
-void PlayerManager::slotLoadToPlayer(QString location, QString group) {
+void PlayerManager::slotLoadToPlayer(QString location, StringAtom group) {
     // The library will get the track and then signal back to us to load the
     // track via slotLoadTrackToPlayer.
     emit(loadLocationToPlayer(location, group));

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -10,6 +10,7 @@
 #include "configobject.h"
 #include "trackinfoobject.h"
 #include "control/stringatom.h"
+#include "util/assert.h"
 
 class ControlObject;
 class Deck;
@@ -116,19 +117,11 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     void bindToLibrary(Library* pLibrary);
 
     // Returns the group for the ith sampler where i is zero indexed
-    static StringAtom groupForSampler(int i) {
-        return StringAtom(QString("[Sampler%1]").arg(i+1));
-    }
-
+    static StringAtom groupForSampler(int i, bool add = false);
     // Returns the group for the ith deck where i is zero indexed
-    static StringAtom groupForDeck(int i) {
-        return StringAtom(QString("[Channel%1]").arg(i+1));
-    }
-
+    static StringAtom groupForDeck(int i, bool add = false);
     // Returns the group for the ith PreviewDeck where i is zero indexed
-    static StringAtom groupForPreviewDeck(int i) {
-        return StringAtom(QString("[PreviewDeck%1]").arg(i+1));
-    }
+    static StringAtom groupForPreviewDeck(int i, bool add = false);
 
     // Used to determine if the user has configured an input for the given vinyl deck.
     bool hasVinylInput(int inputnum) const;

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -135,8 +135,8 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
 
   public slots:
     // Slots for loading tracks into a Player, which is either a Sampler or a Deck
-    void slotLoadTrackToPlayer(TrackPointer pTrack, QString group, bool play = false);
-    void slotLoadToPlayer(QString location, QString group);
+    void slotLoadTrackToPlayer(TrackPointer pTrack, StringAtom group, bool play = false);
+    void slotLoadToPlayer(QString location, StringAtom group);
 
     // Slots for loading tracks to decks
     void slotLoadTrackIntoNextAvailableDeck(TrackPointer pTrack);
@@ -155,7 +155,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     void slotNumPreviewDecksControlChanged(double v);
 
   signals:
-    void loadLocationToPlayer(QString location, QString group);
+    void loadLocationToPlayer(QString location, StringAtom group);
 
   private:
     TrackPointer lookupTrack(QString location);

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -9,6 +9,7 @@
 
 #include "configobject.h"
 #include "trackinfoobject.h"
+#include "control/stringatom.h"
 
 class ControlObject;
 class Deck;
@@ -115,18 +116,18 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     void bindToLibrary(Library* pLibrary);
 
     // Returns the group for the ith sampler where i is zero indexed
-    static QString groupForSampler(int i) {
-        return QString("[Sampler%1]").arg(i+1);
+    static StringAtom groupForSampler(int i) {
+        return StringAtom(QString("[Sampler%1]").arg(i+1));
     }
 
     // Returns the group for the ith deck where i is zero indexed
-    static QString groupForDeck(int i) {
-        return QString("[Channel%1]").arg(i+1);
+    static StringAtom groupForDeck(int i) {
+        return StringAtom(QString("[Channel%1]").arg(i+1));
     }
 
     // Returns the group for the ith PreviewDeck where i is zero indexed
-    static QString groupForPreviewDeck(int i) {
-        return QString("[PreviewDeck%1]").arg(i+1);
+    static StringAtom groupForPreviewDeck(int i) {
+        return StringAtom(QString("[PreviewDeck%1]").arg(i+1));
     }
 
     // Used to determine if the user has configured an input for the given vinyl deck.

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -28,7 +28,7 @@ class TrackCollection;
 class PlayerManagerInterface {
   public:
     // Get a BaseTrackPlayer (i.e. a Deck or a Sampler) by its group
-    virtual BaseTrackPlayer* getPlayer(QString group) const = 0;
+    virtual BaseTrackPlayer* getPlayer(const StringAtom& group) const = 0;
 
     // Get the deck by its deck number. Decks are numbered starting with 1.
     virtual Deck* getDeck(unsigned int player) const = 0;
@@ -101,7 +101,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     }
 
     // Get a BaseTrackPlayer (i.e. a Deck or a Sampler) by its group
-    BaseTrackPlayer* getPlayer(QString group) const;
+    BaseTrackPlayer* getPlayer(const StringAtom& group) const;
 
     // Get the deck by its deck number. Decks are numbered starting with 1.
     Deck* getDeck(unsigned int player) const;
@@ -184,7 +184,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     QList<Deck*> m_decks;
     QList<Sampler*> m_samplers;
     QList<PreviewDeck*> m_preview_decks;
-    QMap<QString, BaseTrackPlayer*> m_players;
+    QMap<StringAtom, BaseTrackPlayer*> m_players;
 };
 
 #endif // PLAYERMANAGER_H

--- a/src/previewdeck.cpp
+++ b/src/previewdeck.cpp
@@ -5,7 +5,7 @@ PreviewDeck::PreviewDeck(QObject* pParent,
                          EngineMaster* pMixingEngine,
                          EffectsManager* pEffectsManager,
                          EngineChannel::ChannelOrientation defaultOrientation,
-                         QString group) :
+                         const StringAtom& group) :
         BaseTrackPlayerImpl(pParent, pConfig, pMixingEngine, pEffectsManager,
                             defaultOrientation, group, false, true) {
 }

--- a/src/previewdeck.h
+++ b/src/previewdeck.h
@@ -11,7 +11,7 @@ class PreviewDeck : public BaseTrackPlayerImpl {
                 EngineMaster* pMixingEngine,
                 EffectsManager* pEffectsManager,
                 EngineChannel::ChannelOrientation defaultOrientation,
-                QString group);
+                const StringAtom& group);
     virtual ~PreviewDeck();
 };
 

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -7,7 +7,7 @@ Sampler::Sampler(QObject* pParent,
                  EngineMaster* pMixingEngine,
                  EffectsManager* pEffectsManager,
                  EngineChannel::ChannelOrientation defaultOrientation,
-                 QString group) :
+                 const StringAtom& group) :
         BaseTrackPlayerImpl(pParent, pConfig, pMixingEngine, pEffectsManager,
                             defaultOrientation, group, true, false) {
 }

--- a/src/sampler.h
+++ b/src/sampler.h
@@ -11,7 +11,7 @@ class Sampler : public BaseTrackPlayerImpl {
             EngineMaster* pMixingEngine,
             EffectsManager* pEffectsManager,
             EngineChannel::ChannelOrientation defaultOrientation,
-            QString group);
+            const StringAtom& group);
     virtual ~Sampler();
 };
 

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -75,6 +75,7 @@
 #include "widget/wsingletoncontainer.h"
 #include "util/valuetransformer.h"
 #include "util/cmdlineargs.h"
+#include "control/stringatom.h"
 
 using mixxx::skin::SkinManifest;
 
@@ -793,9 +794,7 @@ void LegacySkinParser::setupLabelWidget(QDomElement element, WLabel* pLabel) {
 }
 
 QWidget* LegacySkinParser::parseOverview(QDomElement node) {
-    QString channelStr = lookupNodeGroup(node);
-
-    const char* pSafeChannelStr = safeChannelString(channelStr);
+    StringAtom channelStr = lookupNodeGroup(node);
 
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
 
@@ -807,11 +806,11 @@ QWidget* LegacySkinParser::parseOverview(QDomElement node) {
     // "RGB" = "2", "HSV" = "1" or "Filtered" = "0" (LMH) waveform overview type
     int type = m_pConfig->getValueString(ConfigKey("[Waveform]","WaveformOverviewType"), "0").toInt();
     if (type == 0) {
-        overviewWidget = new WOverviewLMH(pSafeChannelStr, m_pConfig, m_pParent);
+        overviewWidget = new WOverviewLMH(channelStr, m_pConfig, m_pParent);
     } else if (type == 1) {
-        overviewWidget = new WOverviewHSV(pSafeChannelStr, m_pConfig, m_pParent);
+        overviewWidget = new WOverviewHSV(channelStr, m_pConfig, m_pParent);
     } else {
-        overviewWidget = new WOverviewRGB(pSafeChannelStr, m_pConfig, m_pParent);
+        overviewWidget = new WOverviewRGB(channelStr, m_pConfig, m_pParent);
     }
 
     connect(overviewWidget, SIGNAL(trackDropped(QString, StringAtom)),
@@ -840,15 +839,13 @@ QWidget* LegacySkinParser::parseOverview(QDomElement node) {
 }
 
 QWidget* LegacySkinParser::parseVisual(QDomElement node) {
-    QString channelStr = lookupNodeGroup(node);
+    StringAtom channelStr(lookupNodeGroup(node));
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
-
-    const char* pSafeChannelStr = safeChannelString(channelStr);
 
     if (pPlayer == NULL)
         return NULL;
 
-    WWaveformViewer* viewer = new WWaveformViewer(pSafeChannelStr, m_pConfig, m_pParent);
+    WWaveformViewer* viewer = new WWaveformViewer(channelStr, m_pConfig, m_pParent);
     viewer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     WaveformWidgetFactory* factory = WaveformWidgetFactory::instance();
     factory->setWaveformWidget(viewer, node, *m_pContext);
@@ -877,15 +874,14 @@ QWidget* LegacySkinParser::parseVisual(QDomElement node) {
 }
 
 QWidget* LegacySkinParser::parseText(QDomElement node) {
-    QString channelStr = lookupNodeGroup(node);
-    const char* pSafeChannelStr = safeChannelString(channelStr);
+    StringAtom channelStr = lookupNodeGroup(node);
 
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
 
     if (!pPlayer)
         return NULL;
 
-    WTrackText* p = new WTrackText(pSafeChannelStr, m_pConfig, m_pParent);
+    WTrackText* p = new WTrackText(channelStr, m_pConfig, m_pParent);
     setupLabelWidget(node, p);
 
     connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
@@ -893,7 +889,7 @@ QWidget* LegacySkinParser::parseText(QDomElement node) {
     connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
             p, SLOT(slotTrackUnloaded(TrackPointer)));
     connect(p, SIGNAL(trackDropped(QString, StringAtom)),
-            m_pPlayerManager, SLOT(slotLoadToPlayer(QString,StringAtom)));
+            m_pPlayerManager, SLOT(slotLoadToPlayer(QString, StringAtom)));
 
     TrackPointer pTrack = pPlayer->getLoadedTrack();
     if (pTrack) {
@@ -904,15 +900,13 @@ QWidget* LegacySkinParser::parseText(QDomElement node) {
 }
 
 QWidget* LegacySkinParser::parseTrackProperty(QDomElement node) {
-    QString channelStr = lookupNodeGroup(node);
-    const char* pSafeChannelStr = safeChannelString(channelStr);
-
+    StringAtom channelStr = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
 
     if (!pPlayer)
         return NULL;
 
-    WTrackProperty* p = new WTrackProperty(pSafeChannelStr, m_pConfig, m_pParent);
+    WTrackProperty* p = new WTrackProperty(channelStr, m_pConfig, m_pParent);
     setupLabelWidget(node, p);
 
     connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
@@ -931,7 +925,7 @@ QWidget* LegacySkinParser::parseTrackProperty(QDomElement node) {
 }
 
 QWidget* LegacySkinParser::parseStarRating(QDomElement node) {
-    QString channelStr = lookupNodeGroup(node);
+    StringAtom channelStr = lookupNodeGroup(node);
     const char* pSafeChannelStr = safeChannelString(channelStr);
 
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
@@ -958,7 +952,7 @@ QWidget* LegacySkinParser::parseStarRating(QDomElement node) {
 
 
 QWidget* LegacySkinParser::parseNumberRate(QDomElement node) {
-    QString channelStr = lookupNodeGroup(node);
+    StringAtom channelStr = lookupNodeGroup(node);
 
     const char* pSafeChannelStr = safeChannelString(channelStr);
 
@@ -982,7 +976,7 @@ QWidget* LegacySkinParser::parseNumberRate(QDomElement node) {
 }
 
 QWidget* LegacySkinParser::parseNumberPos(QDomElement node) {
-    QString channelStr = lookupNodeGroup(node);
+    StringAtom channelStr = lookupNodeGroup(node);
 
     const char* pSafeChannelStr = safeChannelString(channelStr);
 
@@ -992,7 +986,7 @@ QWidget* LegacySkinParser::parseNumberPos(QDomElement node) {
 }
 
 QWidget* LegacySkinParser::parseEngineKey(QDomElement node) {
-    QString channelStr = lookupNodeGroup(node);
+    StringAtom channelStr = lookupNodeGroup(node);
     const char* pSafeChannelStr = safeChannelString(channelStr);
     WKey* pEngineKey = new WKey(pSafeChannelStr, m_pParent);
     setupLabelWidget(node, pEngineKey);
@@ -1000,7 +994,7 @@ QWidget* LegacySkinParser::parseEngineKey(QDomElement node) {
 }
 
 QWidget* LegacySkinParser::parseSpinny(QDomElement node) {
-    QString channelStr = lookupNodeGroup(node);
+    StringAtom channelStr = lookupNodeGroup(node);
     if (CmdlineArgs::Instance().getSafeMode()) {
         WLabel* dummy = new WLabel(m_pParent);
         //: Shown when Mixxx is running in safe mode.
@@ -1058,7 +1052,7 @@ QWidget* LegacySkinParser::parseSearchBox(QDomElement node) {
 }
 
 QWidget* LegacySkinParser::parseCoverArt(QDomElement node) {
-    QString channel = lookupNodeGroup(node);
+    StringAtom channel = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channel);
 
     WCoverArt* pCoverArt = new WCoverArt(m_pParent, m_pConfig, channel);
@@ -1426,20 +1420,21 @@ QList<QWidget*> LegacySkinParser::parseTemplate(QDomElement node) {
     return widgets;
 }
 
-QString LegacySkinParser::lookupNodeGroup(QDomElement node) {
-    QString group = m_pContext->selectString(node, "Group");
+StringAtom LegacySkinParser::lookupNodeGroup(QDomElement node) {
+    QString groupString = m_pContext->selectString(node, "Group");
+    if (groupString.size() > 0) {
+        return StringAtom(groupString);
+    }
 
     // If the group is not present, then check for a Channel, since legacy skins
     // will specify the channel as either 1 or 2.
-    if (group.size() == 0) {
-        int channel = m_pContext->selectInt(node, "Channel");
-        if (channel > 0) {
-            // groupForDeck is 0-indexed
-            group = PlayerManager::groupForDeck(channel - 1);
-        }
+    int channel = m_pContext->selectInt(node, "Channel");
+    if (channel > 0) {
+        // groupForDeck is 0-indexed
+        return PlayerManager::groupForDeck(channel - 1);
     }
 
-    return group;
+    return StringAtom();
 }
 
 // static

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -814,8 +814,8 @@ QWidget* LegacySkinParser::parseOverview(QDomElement node) {
         overviewWidget = new WOverviewRGB(pSafeChannelStr, m_pConfig, m_pParent);
     }
 
-    connect(overviewWidget, SIGNAL(trackDropped(QString, QString)),
-            m_pPlayerManager, SLOT(slotLoadToPlayer(QString, QString)));
+    connect(overviewWidget, SIGNAL(trackDropped(QString, StringAtom)),
+            m_pPlayerManager, SLOT(slotLoadToPlayer(QString, StringAtom)));
 
     commonWidgetSetup(node, overviewWidget);
     overviewWidget->setup(node, *m_pContext);
@@ -867,8 +867,8 @@ QWidget* LegacySkinParser::parseVisual(QDomElement node) {
     QObject::connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
                      viewer, SLOT(onTrackUnloaded(TrackPointer)));
 
-    connect(viewer, SIGNAL(trackDropped(QString, QString)),
-            m_pPlayerManager, SLOT(slotLoadToPlayer(QString, QString)));
+    connect(viewer, SIGNAL(trackDropped(QString, StringAtom)),
+            m_pPlayerManager, SLOT(slotLoadToPlayer(QString, StringAtom)));
 
     // if any already loaded
     viewer->onTrackLoaded(pPlayer->getLoadedTrack());
@@ -892,8 +892,8 @@ QWidget* LegacySkinParser::parseText(QDomElement node) {
             p, SLOT(slotTrackLoaded(TrackPointer)));
     connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
             p, SLOT(slotTrackUnloaded(TrackPointer)));
-    connect(p, SIGNAL(trackDropped(QString,QString)),
-            m_pPlayerManager, SLOT(slotLoadToPlayer(QString,QString)));
+    connect(p, SIGNAL(trackDropped(QString, StringAtom)),
+            m_pPlayerManager, SLOT(slotLoadToPlayer(QString,StringAtom)));
 
     TrackPointer pTrack = pPlayer->getLoadedTrack();
     if (pTrack) {
@@ -919,8 +919,8 @@ QWidget* LegacySkinParser::parseTrackProperty(QDomElement node) {
             p, SLOT(slotTrackLoaded(TrackPointer)));
     connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
             p, SLOT(slotTrackUnloaded(TrackPointer)));
-    connect(p, SIGNAL(trackDropped(QString,QString)),
-            m_pPlayerManager, SLOT(slotLoadToPlayer(QString,QString)));
+    connect(p, SIGNAL(trackDropped(QString, StringAtom)),
+            m_pPlayerManager, SLOT(slotLoadToPlayer(QString, StringAtom)));
 
     TrackPointer pTrack = pPlayer->getLoadedTrack();
     if (pTrack) {
@@ -1019,8 +1019,8 @@ QWidget* LegacySkinParser::parseSpinny(QDomElement node) {
     commonWidgetSetup(node, spinny);
 
     WaveformWidgetFactory::instance()->addTimerListener(spinny);
-    connect(spinny, SIGNAL(trackDropped(QString, QString)),
-            m_pPlayerManager, SLOT(slotLoadToPlayer(QString, QString)));
+    connect(spinny, SIGNAL(trackDropped(QString, StringAtom)),
+            m_pPlayerManager, SLOT(slotLoadToPlayer(QString, StringAtom)));
 
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
     if (pPlayer != NULL) {
@@ -1079,8 +1079,8 @@ QWidget* LegacySkinParser::parseCoverArt(QDomElement node) {
                 pCoverArt, SLOT(slotLoadTrack(TrackPointer)));
         connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
                 pCoverArt, SLOT(slotReset()));
-        connect(pCoverArt, SIGNAL(trackDropped(QString, QString)),
-                m_pPlayerManager, SLOT(slotLoadToPlayer(QString, QString)));
+        connect(pCoverArt, SIGNAL(trackDropped(QString, StringAtom)),
+                m_pPlayerManager, SLOT(slotLoadToPlayer(QString, StringAtom)));
 
         // just in case a track is already loaded
         pCoverArt->slotLoadTrack(pPlayer->getLoadedTrack());

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -978,17 +978,14 @@ QWidget* LegacySkinParser::parseNumberRate(QDomElement node) {
 QWidget* LegacySkinParser::parseNumberPos(QDomElement node) {
     StringAtom channelStr = lookupNodeGroup(node);
 
-    const char* pSafeChannelStr = safeChannelString(channelStr);
-
-    WNumberPos* p = new WNumberPos(pSafeChannelStr, m_pParent);
+    WNumberPos* p = new WNumberPos(channelStr, m_pParent);
     setupLabelWidget(node, p);
     return p;
 }
 
 QWidget* LegacySkinParser::parseEngineKey(QDomElement node) {
     StringAtom channelStr = lookupNodeGroup(node);
-    const char* pSafeChannelStr = safeChannelString(channelStr);
-    WKey* pEngineKey = new WKey(pSafeChannelStr, m_pParent);
+    WKey* pEngineKey = new WKey(channelStr, m_pParent);
     setupLabelWidget(node, pEngineKey);
     return pEngineKey;
 }

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -12,6 +12,7 @@
 #include "vinylcontrol/vinylcontrolmanager.h"
 #include "skin/tooltips.h"
 #include "proto/skin.pb.h"
+#include "control/stringatom.h"
 
 class WBaseWidget;
 class Library;
@@ -117,7 +118,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     QString getLibraryStyle(QDomNode node);
     QString getStyleFromNode(QDomNode node);
 
-    QString lookupNodeGroup(QDomElement node);
+    StringAtom lookupNodeGroup(QDomElement node);
     static const char* safeChannelString(QString channelStr);
     ControlObject* controlFromConfigNode(QDomElement element,
                                          const QString& nodeName,

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -11,6 +11,7 @@
 #include "controllinpotmeter.h"
 #include "playermanager.h"
 #include "basetrackplayer.h"
+#include "control/stringatom.h"
 
 using ::testing::_;
 using ::testing::Return;
@@ -129,7 +130,7 @@ class MockAutoDJProcessor : public AutoDJProcessor {
     virtual ~MockAutoDJProcessor() {
     }
 
-    MOCK_METHOD3(loadTrackToPlayer, void(TrackPointer, QString, bool));
+    MOCK_METHOD3(loadTrackToPlayer, void(TrackPointer, StringAtom, bool));
     MOCK_METHOD1(transitionTimeChanged, void(int));
     MOCK_METHOD1(autoDJStateChanged, void(AutoDJProcessor::AutoDJState));
 };
@@ -240,7 +241,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped) {
     // Expect that we switch into ADJ_ENABLE_P1LOADED first.
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_ENABLE_P1LOADED));
     // Expect that we get a load-and-play signal for [Channel1].
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel1]"), true));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel1]"), true));
 
     AutoDJProcessor::AutoDJError err = pProcessor->toggleAutoDJ(true);
     EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
@@ -256,7 +257,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped) {
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
     // Expect that we will receive a load call for [Channel2] after we get the
     // first playposition update from deck 1.
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel2]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel2]"), false));
 
     // Pretend a track loaded successfully and that it is now playing. This
     // triggers a call to AutoDJProcessor::playerPlayChanged and
@@ -294,7 +295,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFails) {
     // Expect that we switch into ADJ_ENABLE_P1LOADED first.
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_ENABLE_P1LOADED));
     // Expect that we get a load-and-play signal for [Channel1].
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel1]"), true));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel1]"), true));
 
     AutoDJProcessor::AutoDJError err = pProcessor->toggleAutoDJ(true);
     EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
@@ -308,7 +309,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFails) {
 
     // Once the track load fails, we should get another load-and-play request
     // for Deck 1.
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel1]"), true));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel1]"), true));
 
     // Load the track and mark it playing (as the loadTrackToPlayer signal would
     // have connected to this eventually).
@@ -337,7 +338,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFails) {
 
     // Expect that we will receive a load call for [Channel2] after we get the
     // first playposition update from deck 1.
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel2]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel2]"), false));
 
     // Expect that we will switch into ADJ_IDLE.
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
@@ -365,7 +366,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFailsRightDeck)
     // Expect that we switch into ADJ_ENABLE_P1LOADED first.
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_ENABLE_P1LOADED));
     // Expect that we get a load-and-play signal for [Channel1].
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel1]"), true));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel1]"), true));
 
     AutoDJProcessor::AutoDJError err = pProcessor->toggleAutoDJ(true);
     EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
@@ -391,7 +392,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFailsRightDeck)
 
     // Expect that we will receive a load call for [Channel2] after we get the
     // first playposition update from deck 1.
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel2]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel2]"), false));
 
     // Pretend the engine moved forward on the deck. This will request a track
     // load on deck 2 and put us in IDLE mode.
@@ -402,7 +403,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFailsRightDeck)
 
     // Expect that we will receive another load call for [Channel2] after we get
     // the track load failed signal.
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel2]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel2]"), false));
 
     // Now pretend that the deck2 load request failed.
     deck2.slotLoadTrack(pTrack, false);
@@ -441,7 +442,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1) {
     pAutoDJTableModel->appendTrack(testId);
 
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel2]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel2]"), false));
 
     AutoDJProcessor::AutoDJError err = pProcessor->toggleAutoDJ(true);
     EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
@@ -484,7 +485,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1_TrackLoadFailed) {
     pAutoDJTableModel->appendTrack(testId);
 
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel2]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel2]"), false));
 
     AutoDJProcessor::AutoDJError err = pProcessor->toggleAutoDJ(true);
     EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
@@ -497,7 +498,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1_TrackLoadFailed) {
 
     // After the load failed signal we will receive another track load signal
     // for deck 2.
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel2]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel2]"), false));
 
     // Pretend the track load fails.
     deck2.slotLoadTrack(pTrack, false);
@@ -539,7 +540,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2) {
     pAutoDJTableModel->appendTrack(testId);
 
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel1]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel1]"), false));
 
     AutoDJProcessor::AutoDJError err = pProcessor->toggleAutoDJ(true);
     EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
@@ -582,7 +583,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2_TrackLoadFailed) {
     pAutoDJTableModel->appendTrack(testId);
 
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel1]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel1]"), false));
 
     AutoDJProcessor::AutoDJError err = pProcessor->toggleAutoDJ(true);
     EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
@@ -595,7 +596,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2_TrackLoadFailed) {
 
     // After the load failed signal we will receive another track load signal
     // for deck 1.
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel1]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel1]"), false));
 
     // Pretend the track load fails.
     deck1.slotLoadTrack(pTrack, false);
@@ -639,7 +640,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadSuccess) {
     pAutoDJTableModel->appendTrack(testId);
 
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel1]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel1]"), false));
 
     // Enable AutoDJ, we immediately transition into IDLE and request a track
     // load on deck1.
@@ -676,7 +677,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadSuccess) {
     // Expect that we will transition into IDLE mode and receive a track-load
     // request for deck 2 after deck 1 starts playing.
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel2]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel2]"), false));
 
     // Now start deck1 playing.
     deck1.playposition.set(0.1);
@@ -722,7 +723,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
     pAutoDJTableModel->appendTrack(testId);
 
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel1]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel1]"), false));
 
     // Enable AutoDJ, we immediately transition into IDLE and request a track
     // load on deck1.
@@ -759,7 +760,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
     // Expect that we will transition into IDLE mode and receive a track-load
     // request for deck 2 after deck 1 starts playing.
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel2]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel2]"), false));
 
     // Now start deck1 playing.
     deck1.playposition.set(0.1);
@@ -773,7 +774,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
 
     // Expect we will receive another track load request for deck 2 after we
     // fail the first request.
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel2]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel2]"), false));
 
     // Pretend the track load request fails.
     deck2.slotLoadTrack(pTrack, false);
@@ -817,7 +818,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadSuccess) {
     pAutoDJTableModel->appendTrack(testId);
 
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel2]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel2]"), false));
 
     // Enable AutoDJ, we immediately transition into IDLE and request a track
     // load on deck2.
@@ -854,7 +855,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadSuccess) {
     // Expect that we will transition into IDLE mode and receive a track-load
     // request for deck 1 after deck 2 starts playing.
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel1]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel1]"), false));
 
     // Now start deck2 playing.
     deck2.playposition.set(0.1);
@@ -900,7 +901,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
     pAutoDJTableModel->appendTrack(testId);
 
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel2]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel2]"), false));
 
     // Enable AutoDJ, we immediately transition into IDLE and request a track
     // load on deck2.
@@ -937,7 +938,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
     // Expect that we will transition into IDLE mode and receive a track-load
     // request for deck 1 after deck 2 starts playing.
     EXPECT_CALL(*pProcessor, autoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel1]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel1]"), false));
 
     // Now start deck2 playing.
     deck2.playposition.set(0.1);
@@ -951,7 +952,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
 
     // Expect we will receive another track load request for deck 1 after we
     // fail the first request.
-    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, QString("[Channel1]"), false));
+    EXPECT_CALL(*pProcessor, loadTrackToPlayer(_, StringAtom("[Channel1]"), false));
 
     // Pretend the track load request fails.
     deck1.slotLoadTrack(pTrack, false);

--- a/src/visualplayposition.cpp
+++ b/src/visualplayposition.cpp
@@ -7,22 +7,23 @@
 #include "waveform/vsyncthread.h"
 
 //static
-QMap<QString, QWeakPointer<VisualPlayPosition> > VisualPlayPosition::m_listVisualPlayPosition;
+QMap<StringAtom, QWeakPointer<VisualPlayPosition> > VisualPlayPosition::m_listVisualPlayPosition;
 PaStreamCallbackTimeInfo VisualPlayPosition::m_timeInfo = { 0.0, 0.0, 0.0 };
 PerformanceTimer VisualPlayPosition::m_timeInfoTime;
 
-VisualPlayPosition::VisualPlayPosition(const QString& key)
+VisualPlayPosition::VisualPlayPosition(const StringAtom& group)
         : m_valid(false),
-          m_key(key),
+          m_group(group),
           m_invalidTimeInfoWarned(false) {
     m_audioBufferSize = new ControlObjectSlave("[Master]", "audio_buffer_size");
     m_audioBufferSize->connectValueChanged(
             this, SLOT(slotAudioBufferSizeChanged(double)));
+    // TODO() m_dAudioBufferSize can become static
     m_dAudioBufferSize = m_audioBufferSize->get();
 }
 
 VisualPlayPosition::~VisualPlayPosition() {
-    m_listVisualPlayPosition.remove(m_key);
+    m_listVisualPlayPosition.remove(m_group);
     delete m_audioBufferSize;
 }
 
@@ -106,7 +107,7 @@ void VisualPlayPosition::slotAudioBufferSizeChanged(double size) {
 }
 
 //static
-QSharedPointer<VisualPlayPosition> VisualPlayPosition::getVisualPlayPosition(QString group) {
+QSharedPointer<VisualPlayPosition> VisualPlayPosition::getVisualPlayPosition(const StringAtom& group) {
     QSharedPointer<VisualPlayPosition> vpp = m_listVisualPlayPosition.value(group);
     if (vpp.isNull()) {
         vpp = QSharedPointer<VisualPlayPosition>(new VisualPlayPosition(group));

--- a/src/visualplayposition.h
+++ b/src/visualplayposition.h
@@ -10,6 +10,7 @@
 
 #include "util/performancetimer.h"
 #include "control/controlvalue.h"
+#include "control/stringatom.h"
 
 class ControlObjectSlave;
 class VSyncThread;
@@ -42,7 +43,7 @@ class VisualPlayPositionData {
 class VisualPlayPosition : public QObject {
     Q_OBJECT
   public:
-    VisualPlayPosition(const QString& m_key);
+    VisualPlayPosition(const StringAtom& group);
     virtual ~VisualPlayPosition();
 
     // WARNING: Not thread safe. This function must be called only from the
@@ -54,7 +55,7 @@ class VisualPlayPosition : public QObject {
 
     // WARNING: Not thread safe. This function must only be called from the main
     // thread.
-    static QSharedPointer<VisualPlayPosition> getVisualPlayPosition(QString group);
+    static QSharedPointer<VisualPlayPosition> getVisualPlayPosition(const StringAtom& group);
 
     // This is called by SoundDevicePortAudio just after the callback starts.
     static void setTimeInfo(const PaStreamCallbackTimeInfo *timeInfo);
@@ -69,10 +70,11 @@ class VisualPlayPosition : public QObject {
     ControlObjectSlave* m_audioBufferSize;
     double m_dAudioBufferSize; // Audio buffer size in ms
     bool m_valid;
-    QString m_key;
+    StringAtom m_group;
     bool m_invalidTimeInfoWarned;
 
-    static QMap<QString, QWeakPointer<VisualPlayPosition> > m_listVisualPlayPosition;
+    static QMap<StringAtom, QWeakPointer<VisualPlayPosition> >
+            m_listVisualPlayPosition;
     // Time info from the Sound device, updated just after audio callback is called
     static PaStreamCallbackTimeInfo m_timeInfo;
     // Time stamp for m_timeInfo in main CPU time

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -4,7 +4,7 @@
 #include "waveform/waveform.h"
 #include "widget/wwidget.h"
 #include "controlobject.h"
-#include "controlobjectthread.h"
+#include "controlobjectslave.h"
 #include "visualplayposition.h"
 #include "util/math.h"
 #include "util/performancetimer.h"
@@ -77,15 +77,15 @@ bool WaveformWidgetRenderer::init() {
     //qDebug() << "WaveformWidgetRenderer::init";
     m_visualPlayPosition = VisualPlayPosition::getVisualPlayPosition(m_group);
 
-    m_pRateControlObject = new ControlObjectThread(
+    m_pRateControlObject = new ControlObjectSlave(
             m_group, "rate");
-    m_pRateRangeControlObject = new ControlObjectThread(
+    m_pRateRangeControlObject = new ControlObjectSlave(
             m_group, "rateRange");
-    m_pRateDirControlObject = new ControlObjectThread(
+    m_pRateDirControlObject = new ControlObjectSlave(
             m_group, "rate_dir");
-    m_pGainControlObject = new ControlObjectThread(
+    m_pGainControlObject = new ControlObjectSlave(
             m_group, "total_gain");
-    m_pTrackSamplesControlObject = new ControlObjectThread(
+    m_pTrackSamplesControlObject = new ControlObjectSlave(
             m_group, "track_samples");
 
     for (int i = 0; i < m_rendererStack.size(); ++i) {

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -12,7 +12,7 @@
 const int WaveformWidgetRenderer::s_waveformMinZoom = 1;
 const int WaveformWidgetRenderer::s_waveformMaxZoom = 6;
 
-WaveformWidgetRenderer::WaveformWidgetRenderer(const char* group)
+WaveformWidgetRenderer::WaveformWidgetRenderer(const StringAtom& group)
     : m_group(group),
       m_height(-1),
       m_width(-1),

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -10,6 +10,7 @@
 #include "util.h"
 #include "waveform/renderers/waveformrendererabstract.h"
 #include "waveform/renderers/waveformsignalcolors.h"
+#include "control/stringatom.h"
 
 //#define WAVEFORMWIDGETRENDERER_DEBUG
 
@@ -24,7 +25,7 @@ class WaveformWidgetRenderer {
     static const int s_waveformMaxZoom;
 
   public:
-    explicit WaveformWidgetRenderer(const char* group);
+    explicit WaveformWidgetRenderer(const StringAtom& group);
     virtual ~WaveformWidgetRenderer();
 
     bool init();
@@ -34,7 +35,7 @@ class WaveformWidgetRenderer {
     void onPreRender(VSyncThread* vsyncThread);
     void draw(QPainter* painter, QPaintEvent* event);
 
-    inline const char* getGroup() const { return m_group;}
+    inline const StringAtom getGroup() const { return m_group;}
     const TrackPointer getTrackInfo() const { return m_pTrack;}
 
     double getFirstDisplayedPosition() const { return m_firstDisplayedPosition;}
@@ -84,7 +85,7 @@ class WaveformWidgetRenderer {
     void setTrack(TrackPointer track);
 
   protected:
-    const char* m_group;
+    StringAtom m_group;
     TrackPointer m_pTrack;
     QList<WaveformRendererAbstract*> m_rendererStack;
     int m_height;

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -15,7 +15,7 @@
 //#define WAVEFORMWIDGETRENDERER_DEBUG
 
 class TrackInfoObject;
-class ControlObjectThread;
+class ControlObjectSlave;
 class VisualPlayPosition;
 class VSyncThread;
 
@@ -106,15 +106,15 @@ class WaveformWidgetRenderer {
     QSharedPointer<VisualPlayPosition> m_visualPlayPosition;
     double m_playPos;
     int m_playPosVSample;
-    ControlObjectThread* m_pRateControlObject;
+    ControlObjectSlave* m_pRateControlObject;
     double m_rate;
-    ControlObjectThread* m_pRateRangeControlObject;
+    ControlObjectSlave* m_pRateRangeControlObject;
     double m_rateRange;
-    ControlObjectThread* m_pRateDirControlObject;
+    ControlObjectSlave* m_pRateDirControlObject;
     double m_rateDir;
-    ControlObjectThread* m_pGainControlObject;
+    ControlObjectSlave* m_pGainControlObject;
     double m_gain;
-    ControlObjectThread* m_pTrackSamplesControlObject;
+    ControlObjectSlave* m_pTrackSamplesControlObject;
     int m_trackSamples;
 
 #ifdef WAVEFORMWIDGETRENDERER_DEBUG

--- a/src/waveform/widgets/emptywaveformwidget.cpp
+++ b/src/waveform/widgets/emptywaveformwidget.cpp
@@ -5,7 +5,7 @@
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/renderers/waveformrenderbackground.h"
 
-EmptyWaveformWidget::EmptyWaveformWidget(const char* group, QWidget* parent)
+EmptyWaveformWidget::EmptyWaveformWidget(const StringAtom& group, QWidget* parent)
         : QWidget(parent),
           WaveformWidgetAbstract(group) {
     //Empty means just a background ;)

--- a/src/waveform/widgets/emptywaveformwidget.h
+++ b/src/waveform/widgets/emptywaveformwidget.h
@@ -26,7 +26,7 @@ class EmptyWaveformWidget : public QWidget, public WaveformWidgetAbstract {
     virtual int render();
 
   private:
-    EmptyWaveformWidget(const char* group, QWidget* parent);
+    EmptyWaveformWidget(const StringAtom& group, QWidget* parent);
     friend class WaveformWidgetFactory;
 };
 

--- a/src/waveform/widgets/glrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/glrgbwaveformwidget.cpp
@@ -13,7 +13,7 @@
 
 #include "util/performancetimer.h"
 
-GLRGBWaveformWidget::GLRGBWaveformWidget(const char* group, QWidget* parent)
+GLRGBWaveformWidget::GLRGBWaveformWidget(const StringAtom& group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
 

--- a/src/waveform/widgets/glrgbwaveformwidget.h
+++ b/src/waveform/widgets/glrgbwaveformwidget.h
@@ -8,7 +8,7 @@
 class GLRGBWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    GLRGBWaveformWidget(const char* group, QWidget* parent);
+    GLRGBWaveformWidget(const StringAtom& group, QWidget* parent);
     virtual ~GLRGBWaveformWidget();
 
     virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::GLRGBWaveform; }

--- a/src/waveform/widgets/glsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/glsimplewaveformwidget.cpp
@@ -15,7 +15,7 @@
 
 #include "util/performancetimer.h"
 
-GLSimpleWaveformWidget::GLSimpleWaveformWidget(const char* group, QWidget* parent)
+GLSimpleWaveformWidget::GLSimpleWaveformWidget(const StringAtom& group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
     addRenderer<WaveformRenderBackground>();

--- a/src/waveform/widgets/glsimplewaveformwidget.h
+++ b/src/waveform/widgets/glsimplewaveformwidget.h
@@ -8,7 +8,7 @@
 class GLSimpleWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    GLSimpleWaveformWidget(const char* group, QWidget* parent);
+    GLSimpleWaveformWidget(const StringAtom& group, QWidget* parent);
     virtual ~GLSimpleWaveformWidget();
 
     virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::GLSimpleWaveform; }

--- a/src/waveform/widgets/glslwaveformwidget.cpp
+++ b/src/waveform/widgets/glslwaveformwidget.cpp
@@ -15,16 +15,16 @@
 
 #include "util/performancetimer.h"
 
-GLSLFilteredWaveformWidget::GLSLFilteredWaveformWidget(const char* group,
+GLSLFilteredWaveformWidget::GLSLFilteredWaveformWidget(const StringAtom& group,
                                                        QWidget* parent)
         : GLSLWaveformWidget(group, parent, false) {
 }
 
-GLSLRGBWaveformWidget::GLSLRGBWaveformWidget(const char* group, QWidget* parent)
+GLSLRGBWaveformWidget::GLSLRGBWaveformWidget(const StringAtom& group, QWidget* parent)
         : GLSLWaveformWidget(group, parent, true) {
 }
 
-GLSLWaveformWidget::GLSLWaveformWidget(const char* group, QWidget* parent,
+GLSLWaveformWidget::GLSLWaveformWidget(const StringAtom& group, QWidget* parent,
                                        bool rgbRenderer)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {

--- a/src/waveform/widgets/glslwaveformwidget.h
+++ b/src/waveform/widgets/glslwaveformwidget.h
@@ -10,7 +10,7 @@ class GLSLWaveformRendererSignal;
 class GLSLWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    GLSLWaveformWidget(const char* group, QWidget* parent,
+    GLSLWaveformWidget(const StringAtom& group, QWidget* parent,
                        bool rgbRenderer);
     virtual ~GLSLWaveformWidget();
 
@@ -30,7 +30,7 @@ class GLSLWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
 
 class GLSLFilteredWaveformWidget : public GLSLWaveformWidget {
   public:
-    GLSLFilteredWaveformWidget(const char* group, QWidget* parent);
+    GLSLFilteredWaveformWidget(const StringAtom& group, QWidget* parent);
     virtual ~GLSLFilteredWaveformWidget() {}
 
     virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::GLSLFilteredWaveform; }
@@ -43,7 +43,7 @@ class GLSLFilteredWaveformWidget : public GLSLWaveformWidget {
 
 class GLSLRGBWaveformWidget : public GLSLWaveformWidget {
   public:
-    GLSLRGBWaveformWidget(const char* group, QWidget* parent);
+    GLSLRGBWaveformWidget(const StringAtom& group, QWidget* parent);
     virtual ~GLSLRGBWaveformWidget() {}
 
     virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::GLSLRGBWaveform; }

--- a/src/waveform/widgets/glvsynctestwidget.cpp
+++ b/src/waveform/widgets/glvsynctestwidget.cpp
@@ -15,7 +15,7 @@
 
 #include "util/performancetimer.h"
 
-GLVSyncTestWidget::GLVSyncTestWidget(const char* group, QWidget* parent)
+GLVSyncTestWidget::GLVSyncTestWidget(const StringAtom& group, QWidget* parent)
     : QGLWidget(parent, SharedGLContext::getWidget()),
       WaveformWidgetAbstract(group) {
 

--- a/src/waveform/widgets/glvsynctestwidget.h
+++ b/src/waveform/widgets/glvsynctestwidget.h
@@ -8,7 +8,7 @@
 class GLVSyncTestWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    GLVSyncTestWidget(const char* group, QWidget* parent);
+    GLVSyncTestWidget(const StringAtom& group, QWidget* parent);
     virtual ~GLVSyncTestWidget();
 
     virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::GLVSyncTest; }

--- a/src/waveform/widgets/glwaveformwidget.cpp
+++ b/src/waveform/widgets/glwaveformwidget.cpp
@@ -15,7 +15,7 @@
 #include "sharedglcontext.h"
 #include "util/performancetimer.h"
 
-GLWaveformWidget::GLWaveformWidget(const char* group, QWidget* parent)
+GLWaveformWidget::GLWaveformWidget(const StringAtom& group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
 

--- a/src/waveform/widgets/glwaveformwidget.h
+++ b/src/waveform/widgets/glwaveformwidget.h
@@ -8,7 +8,7 @@
 class GLWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    GLWaveformWidget(const char* group, QWidget* parent);
+    GLWaveformWidget(const StringAtom& group, QWidget* parent);
     virtual ~GLWaveformWidget();
 
     virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::GLFilteredWaveform; }

--- a/src/waveform/widgets/hsvwaveformwidget.cpp
+++ b/src/waveform/widgets/hsvwaveformwidget.cpp
@@ -11,7 +11,7 @@
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 
-HSVWaveformWidget::HSVWaveformWidget(const char* group, QWidget* parent)
+HSVWaveformWidget::HSVWaveformWidget(const StringAtom& group, QWidget* parent)
     : QWidget(parent),
       WaveformWidgetAbstract(group) {
     addRenderer<WaveformRenderBackground>();

--- a/src/waveform/widgets/hsvwaveformwidget.h
+++ b/src/waveform/widgets/hsvwaveformwidget.h
@@ -22,7 +22,7 @@ class HSVWaveformWidget : public QWidget, public WaveformWidgetAbstract {
     virtual void paintEvent(QPaintEvent* event);
 
   private:
-    HSVWaveformWidget(const char* group, QWidget* parent);
+    HSVWaveformWidget(const StringAtom& group, QWidget* parent);
     friend class WaveformWidgetFactory;
 };
 

--- a/src/waveform/widgets/qtsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/qtsimplewaveformwidget.cpp
@@ -15,7 +15,7 @@
 
 #include "util/performancetimer.h"
 
-QtSimpleWaveformWidget::QtSimpleWaveformWidget(const char* group, QWidget* parent)
+QtSimpleWaveformWidget::QtSimpleWaveformWidget(const StringAtom& group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
     addRenderer<WaveformRenderBackground>();

--- a/src/waveform/widgets/qtsimplewaveformwidget.h
+++ b/src/waveform/widgets/qtsimplewaveformwidget.h
@@ -8,7 +8,7 @@
 class QtSimpleWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    QtSimpleWaveformWidget(const char* group, QWidget* parent);
+    QtSimpleWaveformWidget(const StringAtom& group, QWidget* parent);
     virtual ~QtSimpleWaveformWidget();
 
 

--- a/src/waveform/widgets/qtwaveformwidget.cpp
+++ b/src/waveform/widgets/qtwaveformwidget.cpp
@@ -16,7 +16,7 @@
 
 #include "util/performancetimer.h"
 
-QtWaveformWidget::QtWaveformWidget(const char* group, QWidget* parent)
+QtWaveformWidget::QtWaveformWidget(const StringAtom& group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
     addRenderer<WaveformRenderBackground>();

--- a/src/waveform/widgets/qtwaveformwidget.h
+++ b/src/waveform/widgets/qtwaveformwidget.h
@@ -8,7 +8,7 @@
 class QtWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
     Q_OBJECT
   public:
-    QtWaveformWidget(const char* group, QWidget* parent);
+    QtWaveformWidget(const StringAtom& group, QWidget* parent);
     virtual ~QtWaveformWidget();
 
     virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::QtWaveform; }

--- a/src/waveform/widgets/rgbwaveformwidget.cpp
+++ b/src/waveform/widgets/rgbwaveformwidget.cpp
@@ -11,7 +11,7 @@
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 
-RGBWaveformWidget::RGBWaveformWidget(const char* group, QWidget* parent)
+RGBWaveformWidget::RGBWaveformWidget(const StringAtom& group, QWidget* parent)
         : QWidget(parent),
           WaveformWidgetAbstract(group) {
     addRenderer<WaveformRenderBackground>();

--- a/src/waveform/widgets/rgbwaveformwidget.h
+++ b/src/waveform/widgets/rgbwaveformwidget.h
@@ -22,7 +22,7 @@ class RGBWaveformWidget : public QWidget, public WaveformWidgetAbstract {
     virtual void paintEvent(QPaintEvent* event);
 
   private:
-    RGBWaveformWidget(const char* group, QWidget* parent);
+    RGBWaveformWidget(const StringAtom& group, QWidget* parent);
     friend class WaveformWidgetFactory;
 };
 

--- a/src/waveform/widgets/softwarewaveformwidget.cpp
+++ b/src/waveform/widgets/softwarewaveformwidget.cpp
@@ -11,7 +11,7 @@
 #include "waveform/renderers/waveformrendererendoftrack.h"
 #include "waveform/renderers/waveformrenderbeat.h"
 
-SoftwareWaveformWidget::SoftwareWaveformWidget(const char* group, QWidget* parent)
+SoftwareWaveformWidget::SoftwareWaveformWidget(const StringAtom& group, QWidget* parent)
     : QWidget(parent),
       WaveformWidgetAbstract(group) {
     addRenderer<WaveformRenderBackground>();

--- a/src/waveform/widgets/softwarewaveformwidget.h
+++ b/src/waveform/widgets/softwarewaveformwidget.h
@@ -22,7 +22,7 @@ class SoftwareWaveformWidget : public QWidget, public WaveformWidgetAbstract {
     virtual void paintEvent(QPaintEvent* event);
 
   private:
-    SoftwareWaveformWidget(const char* group, QWidget* parent);
+    SoftwareWaveformWidget(const StringAtom& group, QWidget* parent);
     friend class WaveformWidgetFactory;
 };
 

--- a/src/waveform/widgets/waveformwidgetabstract.cpp
+++ b/src/waveform/widgets/waveformwidgetabstract.cpp
@@ -5,7 +5,7 @@
 #include <QWidget>
 
 
-WaveformWidgetAbstract::WaveformWidgetAbstract(const char* group)
+WaveformWidgetAbstract::WaveformWidgetAbstract(const StringAtom& group)
     : WaveformWidgetRenderer(group),
       m_initSuccess(false) {
     m_widget = NULL;

--- a/src/waveform/widgets/waveformwidgetabstract.h
+++ b/src/waveform/widgets/waveformwidgetabstract.h
@@ -7,6 +7,7 @@
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveformwidgettype.h"
 #include "trackinfoobject.h"
+#include "control/stringatom.h"
 
 class VSyncThread;
 
@@ -17,7 +18,7 @@ class VSyncThread;
 
 class WaveformWidgetAbstract : public WaveformWidgetRenderer {
   public:
-    WaveformWidgetAbstract(const char* group);
+    WaveformWidgetAbstract(const StringAtom& group);
     virtual ~WaveformWidgetAbstract();
 
     //Type is use by the factory to safely up-cast waveform widgets

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -16,7 +16,7 @@
 
 WCoverArt::WCoverArt(QWidget* parent,
                      ConfigObject<ConfigValue>* pConfig,
-                     const QString& group)
+                     const StringAtom& group)
         : QWidget(parent),
           WBaseWidget(this),
           m_group(group),

--- a/src/widget/wcoverart.h
+++ b/src/widget/wcoverart.h
@@ -19,7 +19,7 @@ class WCoverArt : public QWidget, public WBaseWidget {
     Q_OBJECT
   public:
     WCoverArt(QWidget* parent, ConfigObject<ConfigValue>* pConfig,
-              const QString& group);
+              const StringAtom& group);
     virtual ~WCoverArt();
 
     void setup(QDomNode node, const SkinContext& context);
@@ -52,7 +52,7 @@ class WCoverArt : public QWidget, public WBaseWidget {
   private:
     QPixmap scaledCoverArt(const QPixmap& normal);
 
-    QString m_group;
+    StringAtom m_group;
     ConfigObject<ConfigValue>* m_pConfig;
     bool m_bEnable;
     WCoverArtMenu* m_pMenu;

--- a/src/widget/wcoverart.h
+++ b/src/widget/wcoverart.h
@@ -13,6 +13,7 @@
 #include "skin/skincontext.h"
 #include "widget/wbasewidget.h"
 #include "widget/wcoverartmenu.h"
+#include "control/stringatom.h"
 
 class WCoverArt : public QWidget, public WBaseWidget {
     Q_OBJECT
@@ -29,7 +30,7 @@ class WCoverArt : public QWidget, public WBaseWidget {
     void slotEnable(bool);
 
   signals:
-    void trackDropped(QString filename, QString group);
+    void trackDropped(QString filename, StringAtom group);
 
   private slots:
     void slotCoverFound(const QObject* pRequestor, int requestReference,

--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -2,16 +2,18 @@
 #include "track/keys.h"
 #include "track/keyutils.h"
 
-WKey::WKey(const char* group, QWidget* pParent)
+WKey::WKey(const StringAtom& group, QWidget* pParent)
         : WLabel(pParent),
-          m_dOldValue(0),
-          m_preferencesUpdated(ConfigKey("[Preferences]", "updated")),
-          m_engineKeyDistance(ConfigKey(group, "visual_key_distance")) {
+          m_dOldValue(0) {
     setValue(m_dOldValue);
-    connect(&m_preferencesUpdated, SIGNAL(valueChanged(double)),
-            this, SLOT(preferencesUpdated(double)));
-    connect(&m_engineKeyDistance, SIGNAL(valueChanged(double)),
-            this, SLOT(setCents()));
+    m_pPreferencesUpdated = new ControlObjectSlave(
+            "[Preferences]", "updated", this);
+    m_pPreferencesUpdated->connectValueChanged(SLOT(preferencesUpdated(double)));
+
+    m_pEngineKeyDistance = new ControlObjectSlave(
+            group, "visual_key_distance", this);
+
+    m_pEngineKeyDistance->connectValueChanged(SLOT(setCents()));
 }
 
 WKey::~WKey() {
@@ -37,7 +39,7 @@ void WKey::setValue(double dValue) {
         // Render this key with the user-provided notation.
         QString keyStr = KeyUtils::keyToString(key);
         if (m_displayCents) {
-            double diff_cents = m_engineKeyDistance.get();
+            double diff_cents = m_pEngineKeyDistance->get();
             int cents_to_display = static_cast<int>(diff_cents * 100);
             char sign = ' ';
             if (diff_cents < 0) {

--- a/src/widget/wkey.h
+++ b/src/widget/wkey.h
@@ -4,12 +4,12 @@
 #include <QLabel>
 
 #include "widget/wlabel.h"
-#include "controlobjectthread.h"
+#include "controlobjectslave.h"
 
 class WKey : public WLabel  {
     Q_OBJECT
   public:
-    WKey(const char* group, QWidget* pParent=NULL);
+    WKey(const StringAtom& group, QWidget* pParent = NULL);
     virtual ~WKey();
 
     virtual void onConnectedControlChanged(double dParameter, double dValue);
@@ -23,8 +23,8 @@ class WKey : public WLabel  {
   private:
     double m_dOldValue;
     bool m_displayCents;
-    ControlObjectThread m_preferencesUpdated;
-    ControlObjectThread m_engineKeyDistance;
+    ControlObjectSlave* m_pPreferencesUpdated;
+    ControlObjectSlave* m_pEngineKeyDistance;
 };
 
 #endif /* WKEY_H */

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -12,6 +12,7 @@
 #include "library/libraryview.h"
 #include "trackinfoobject.h"
 #include "library/coverartcache.h"
+#include "control/stringatom.h"
 
 
 class WLibraryTableView : public QTableView, public virtual LibraryView {
@@ -26,7 +27,7 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
 
   signals:
     void loadTrack(TrackPointer pTrack);
-    void loadTrackToPlayer(TrackPointer pTrack, QString group,
+    void loadTrackToPlayer(TrackPointer pTrack, StringAtom group,
             bool play = false);
     void trackSelected(TrackPointer pTrack);
     void onlyCachedCoverArt(bool);

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -4,11 +4,11 @@
 
 #include "widget/wnumberpos.h"
 #include "controlobject.h"
-#include "controlobjectthread.h"
+#include "controlobjectslave.h"
 #include "util/math.h"
 #include "util/time.h"
 
-WNumberPos::WNumberPos(const char* group, QWidget* parent)
+WNumberPos::WNumberPos(const StringAtom& group, QWidget* parent)
         : WNumber(parent),
           m_dOldValue(0.0),
           m_dTrackSamples(0.0),
@@ -16,10 +16,9 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
           m_bRemain(false) {
     m_qsText = "";
 
-    m_pShowTrackTimeRemaining = new ControlObjectThread(
-            "[Controls]", "ShowDurationRemaining");
-    m_pShowTrackTimeRemaining->connectValueChanged(
-            this, SLOT(slotSetRemain(double)));
+    m_pShowTrackTimeRemaining = new ControlObjectSlave(
+            "[Controls]", "ShowDurationRemaining", this);
+    m_pShowTrackTimeRemaining->connectValueChanged(SLOT(slotSetRemain(double)));
     slotSetRemain(m_pShowTrackTimeRemaining->get());
 
     // We use the engine's playposition value directly because the parameter
@@ -27,22 +26,20 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
     // because the range of playposition was -0.14 to 1.14 in 1.11.x. As a
     // result, the <Connection> parameter is no longer necessary in skin
     // definitions, but leaving it in is harmless.
-    m_pVisualPlaypos = new ControlObjectThread(group, "playposition");
-    m_pVisualPlaypos->connectValueChanged(this, SLOT(slotSetValue(double)));
+    m_pVisualPlaypos = new ControlObjectSlave(group, "playposition", this);
+    m_pVisualPlaypos->connectValueChanged(SLOT(slotSetValue(double)));
 
-    m_pTrackSamples = new ControlObjectThread(
-            group, "track_samples");
-    m_pTrackSamples->connectValueChanged(
-            this, SLOT(slotSetTrackSamples(double)));
+    m_pTrackSamples = new ControlObjectSlave(
+            group, "track_samples", this);
+    m_pTrackSamples->connectValueChanged(SLOT(slotSetTrackSamples(double)));
 
     // Tell the CO to re-emit its value since we could be created after it was
     // set to a valid value.
     m_pTrackSamples->emitValueChanged();
 
-    m_pTrackSampleRate = new ControlObjectThread(
-            group, "track_samplerate");
-    m_pTrackSampleRate->connectValueChanged(
-            this, SLOT(slotSetTrackSampleRate(double)));
+    m_pTrackSampleRate = new ControlObjectSlave(
+            group, "track_samplerate", this);
+    m_pTrackSampleRate->connectValueChanged(SLOT(slotSetTrackSampleRate(double)));
 
     // Tell the CO to re-emit its value since we could be created after it was
     // set to a valid value.
@@ -52,10 +49,6 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
 }
 
 WNumberPos::~WNumberPos() {
-    delete m_pTrackSampleRate;
-    delete m_pTrackSamples;
-    delete m_pVisualPlaypos;
-    delete m_pShowTrackTimeRemaining;
 }
 
 void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -6,13 +6,14 @@
 #include <QMouseEvent>
 
 #include "wnumber.h"
+#include "control/stringatom.h"
 
-class ControlObjectThread;
+class ControlObjectSlave;
 
 class WNumberPos : public WNumber {
     Q_OBJECT
   public:
-    WNumberPos(const char *group, QWidget *parent=0);
+    WNumberPos(const StringAtom& group, QWidget *parent = NULL);
     virtual ~WNumberPos();
 
     // Set if the display shows remaining time (true) or position (false)
@@ -35,11 +36,11 @@ class WNumberPos : public WNumber {
     double m_dTrackSampleRate;
     // True if remaining content is being shown
     bool m_bRemain;
-    ControlObjectThread* m_pShowTrackTimeRemaining;
+    ControlObjectSlave* m_pShowTrackTimeRemaining;
     // Pointer to control object for position, rate, and track info
-    ControlObjectThread* m_pVisualPlaypos;
-    ControlObjectThread* m_pTrackSamples;
-    ControlObjectThread* m_pTrackSampleRate;
+    ControlObjectSlave* m_pVisualPlaypos;
+    ControlObjectSlave* m_pTrackSamples;
+    ControlObjectSlave* m_pTrackSampleRate;
 };
 
 #endif

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -29,18 +29,19 @@
 #include "util/math.h"
 #include "util/timer.h"
 #include "util/dnd.h"
+#include "control/stringatom.h"
 
 #include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"
 
-WOverview::WOverview(const char *pGroup, ConfigObject<ConfigValue>* pConfig, QWidget* parent) :
+WOverview::WOverview(const StringAtom& group, ConfigObject<ConfigValue>* pConfig, QWidget* parent) :
         WWidget(parent),
         m_pWaveformSourceImage(NULL),
         m_actualCompletion(0),
         m_pixmapDone(false),
         m_waveformPeak(-1.0),
         m_diffGain(0),
-        m_group(pGroup),
+        m_group(group),
         m_pConfig(pConfig),
         m_endOfTrack(0),
         m_bDrag(false),

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -51,19 +51,15 @@ WOverview::WOverview(const StringAtom& group, ConfigObject<ConfigValue>* pConfig
         m_dAnalyserProgress(-1.0),
         m_bAnalyserFinalizing(false),
         m_trackLoaded(false) {
-    m_endOfTrackControl = new ControlObjectThread(
-            m_group, "end_of_track");
-    connect(m_endOfTrackControl, SIGNAL(valueChanged(double)),
-             this, SLOT(onEndOfTrackChange(double)));
-    m_trackSamplesControl = new ControlObjectThread(m_group, "track_samples");
-    m_playControl = new ControlObjectThread(m_group, "play");
+    m_endOfTrackControl = new ControlObjectSlave(
+            m_group, "end_of_track", this);
+    m_endOfTrackControl->connectValueChanged(SLOT(onEndOfTrackChange(double)));
+    m_trackSamplesControl = new ControlObjectSlave(m_group, "track_samples", this);
+    m_playControl = new ControlObjectSlave(m_group, "play", this);
     setAcceptDrops(true);
 }
 
 WOverview::~WOverview() {
-    delete m_endOfTrackControl;
-    delete m_trackSamplesControl;
-    delete m_playControl;
     if (m_pWaveformSourceImage) {
         delete m_pWaveformSourceImage;
     }

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -34,7 +34,7 @@ class Waveform;
 class WOverview : public WWidget {
     Q_OBJECT
   public:
-    WOverview(const char* pGroup, ConfigObject<ConfigValue>* pConfig, QWidget* parent=NULL);
+    WOverview(const StringAtom& group, ConfigObject<ConfigValue>* pConfig, QWidget* parent=NULL);
     virtual ~WOverview();
 
     void setup(QDomNode node, const SkinContext& context);
@@ -94,7 +94,7 @@ class WOverview : public WWidget {
         return (static_cast<double>(position) + m_b) / m_a;
     }
 
-    const QString m_group;
+    const StringAtom m_group;
     ConfigObject<ConfigValue>* m_pConfig;
     ControlObjectThread* m_endOfTrackControl;
     double m_endOfTrack;

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -25,6 +25,7 @@
 #include "waveform/renderers/waveformmarkset.h"
 #include "waveform/renderers/waveformmarkrange.h"
 #include "skin/skincontext.h"
+#include "control/stringatom.h"
 
 // Waveform overview display
 // @author Tue Haste Andersen
@@ -45,7 +46,7 @@ class WOverview : public WWidget {
     void slotUnloadTrack(TrackPointer pTrack);
 
   signals:
-    void trackDropped(QString filename, QString group);
+    void trackDropped(QString filename, StringAtom group);
 
   protected:
     void mouseMoveEvent(QMouseEvent *e);

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -96,10 +96,10 @@ class WOverview : public WWidget {
 
     const StringAtom m_group;
     ConfigObject<ConfigValue>* m_pConfig;
-    ControlObjectThread* m_endOfTrackControl;
+    ControlObjectSlave* m_endOfTrackControl;
     double m_endOfTrack;
-    ControlObjectThread* m_trackSamplesControl;
-    ControlObjectThread* m_playControl;
+    ControlObjectSlave* m_trackSamplesControl;
+    ControlObjectSlave* m_playControl;
 
     // Current active track
     TrackPointer m_pCurrentTrack;

--- a/src/widget/woverviewhsv.cpp
+++ b/src/widget/woverviewhsv.cpp
@@ -7,9 +7,9 @@
 #include "util/math.h"
 #include "waveform/waveform.h"
 
-WOverviewHSV::WOverviewHSV(const char* pGroup,
+WOverviewHSV::WOverviewHSV(const StringAtom& group,
                            ConfigObject<ConfigValue>* pConfig, QWidget* parent)
-        : WOverview(pGroup, pConfig, parent)  {
+        : WOverview(group, pConfig, parent)  {
 }
 
 bool WOverviewHSV::drawNextPixmapPart() {

--- a/src/widget/woverviewhsv.h
+++ b/src/widget/woverviewhsv.h
@@ -5,7 +5,7 @@
 
 class WOverviewHSV : public WOverview {
   public:
-    WOverviewHSV(const char *pGroup, ConfigObject<ConfigValue>* pConfig, QWidget* parent);
+    WOverviewHSV(const StringAtom& pGroup, ConfigObject<ConfigValue>* pConfig, QWidget* parent);
 
   private:
     virtual bool drawNextPixmapPart();

--- a/src/widget/woverviewlmh.cpp
+++ b/src/widget/woverviewlmh.cpp
@@ -8,9 +8,9 @@
 #include "util/math.h"
 #include "waveform/waveform.h"
 
-WOverviewLMH::WOverviewLMH(const char *pGroup,
+WOverviewLMH::WOverviewLMH(const StringAtom& group,
                            ConfigObject<ConfigValue>* pConfig, QWidget * parent)
-        : WOverview(pGroup, pConfig, parent)  {
+        : WOverview(group, pConfig, parent)  {
 }
 
 

--- a/src/widget/woverviewlmh.h
+++ b/src/widget/woverviewlmh.h
@@ -5,7 +5,7 @@
 
 class WOverviewLMH : public WOverview {
   public:
-    WOverviewLMH(const char *pGroup, ConfigObject<ConfigValue>* pConfig, QWidget* parent);
+    WOverviewLMH(const StringAtom& pGroup, ConfigObject<ConfigValue>* pConfig, QWidget* parent);
 
   private:
     virtual bool drawNextPixmapPart();

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -6,9 +6,9 @@
 #include "util/math.h"
 #include "waveform/waveform.h"
 
-WOverviewRGB::WOverviewRGB(const char* pGroup,
+WOverviewRGB::WOverviewRGB(const StringAtom& group,
                            ConfigObject<ConfigValue>* pConfig, QWidget* parent)
-        : WOverview(pGroup, pConfig, parent)  {
+        : WOverview(group, pConfig, parent)  {
 }
 
 bool WOverviewRGB::drawNextPixmapPart() {

--- a/src/widget/woverviewrgb.h
+++ b/src/widget/woverviewrgb.h
@@ -5,7 +5,7 @@
 
 class WOverviewRGB : public WOverview {
   public:
-    WOverviewRGB(const char *pGroup, ConfigObject<ConfigValue>* pConfig, QWidget* parent);
+    WOverviewRGB(const StringAtom& pGroup, ConfigObject<ConfigValue>* pConfig, QWidget* parent);
 
   private:
     virtual bool drawNextPixmapPart();

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -17,7 +17,7 @@
 #include "wimagestore.h"
 
 // The SampleBuffers format enables antialiasing.
-WSpinny::WSpinny(QWidget* parent, const QString& group,
+WSpinny::WSpinny(QWidget* parent, const StringAtom& group,
                  ConfigObject<ConfigValue>* pConfig,
                  VinylControlManager* pVCMan)
         : QGLWidget(QGLFormat(QGL::SampleBuffers), parent, SharedGLContext::getWidget()),

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -5,7 +5,7 @@
 #include <QStylePainter>
 
 #include "controlobject.h"
-#include "controlobjectthread.h"
+#include "controlobjectslave.h"
 #include "library/coverartcache.h"
 #include "sharedglcontext.h"
 #include "util/dnd.h"
@@ -87,18 +87,6 @@ WSpinny::~WSpinny() {
     WImageStore::deleteImage(m_pMaskImage);
     WImageStore::deleteImage(m_pFgImage);
     WImageStore::deleteImage(m_pGhostImage);
-    delete m_pPlay;
-    delete m_pPlayPos;
-    delete m_pTrackSamples;
-    delete m_pTrackSampleRate;
-    delete m_pScratchToggle;
-    delete m_pScratchPos;
-    delete m_pSlipEnabled;
-#ifdef __VINYLCONTROL__
-    delete m_pVinylControlSpeedType;
-    delete m_pVinylControlEnabled;
-    delete m_pSignalEnabled;
-#endif
 }
 
 void WSpinny::onVinylSignalQualityUpdate(const VinylSignalQualityReport& report) {
@@ -175,51 +163,44 @@ void WSpinny::setup(QDomNode node, const SkinContext& context) {
     m_qImage.fill(qRgba(0,0,0,0));
 #endif
 
-    m_pPlay = new ControlObjectThread(
-            m_group, "play");
-    m_pPlayPos = new ControlObjectThread(
-            m_group, "playposition");
+    m_pPlay = new ControlObjectSlave(
+            m_group, "play", this);
+    m_pPlayPos = new ControlObjectSlave(
+            m_group, "playposition", this);
     m_pVisualPlayPos = VisualPlayPosition::getVisualPlayPosition(m_group);
-    m_pTrackSamples = new ControlObjectThread(
-            m_group, "track_samples");
-    m_pTrackSampleRate = new ControlObjectThread(
-            m_group, "track_samplerate");
+    m_pTrackSamples = new ControlObjectSlave(
+            m_group, "track_samples", this);
+    m_pTrackSampleRate = new ControlObjectSlave(
+            m_group, "track_samplerate", this);
 
-    m_pScratchToggle = new ControlObjectThread(
-            m_group, "scratch_position_enable");
-    m_pScratchPos = new ControlObjectThread(
-            m_group, "scratch_position");
+    m_pScratchToggle = new ControlObjectSlave(
+            m_group, "scratch_position_enable", this);
+    m_pScratchPos = new ControlObjectSlave(
+            m_group, "scratch_position", this);
 
-    m_pSlipEnabled = new ControlObjectThread(
-            m_group, "slip_enabled");
-    connect(m_pSlipEnabled, SIGNAL(valueChanged(double)),
-            this, SLOT(updateSlipEnabled(double)));
+    m_pSlipEnabled = new ControlObjectSlave(
+            m_group, "slip_enabled", this);
+    m_pSlipEnabled->connectValueChanged(SLOT(updateSlipEnabled(double)));
 
 #ifdef __VINYLCONTROL__
-    m_pVinylControlSpeedType = new ControlObjectThread(
-            m_group, "vinylcontrol_speed_type");
-    if (m_pVinylControlSpeedType)
-    {
-        //Initialize the rotational speed.
-        this->updateVinylControlSpeed(m_pVinylControlSpeedType->get());
-    }
+    m_pVinylControlSpeedType = new ControlObjectSlave(
+            m_group, "vinylcontrol_speed_type", this);
+    // Initialize the rotational speed.
+    updateVinylControlSpeed(m_pVinylControlSpeedType->get());
 
-    m_pVinylControlEnabled = new ControlObjectThread(
-            m_group, "vinylcontrol_enabled");
-    connect(m_pVinylControlEnabled, SIGNAL(valueChanged(double)),
-            this, SLOT(updateVinylControlEnabled(double)));
+    m_pVinylControlEnabled = new ControlObjectSlave(
+            m_group, "vinylcontrol_enabled", this);
+    m_pVinylControlEnabled->connectValueChanged(SLOT(updateVinylControlEnabled(double)));
 
-    m_pSignalEnabled = new ControlObjectThread(
-            m_group, "vinylcontrol_signal_enabled");
-    connect(m_pSignalEnabled, SIGNAL(valueChanged(double)),
-            this, SLOT(updateVinylControlSignalEnabled(double)));
+    m_pSignalEnabled = new ControlObjectSlave(
+            m_group, "vinylcontrol_signal_enabled", this);
+    m_pSignalEnabled->connectValueChanged(
+            SLOT(updateVinylControlSignalEnabled(double)));
 
-    //Match the vinyl control's set RPM so that the spinny widget rotates at the same
-    //speed as your physical decks, if you're using vinyl control.
-    connect(m_pVinylControlSpeedType, SIGNAL(valueChanged(double)),
-            this, SLOT(updateVinylControlSpeed(double)));
-
-
+    // Match the vinyl control's set RPM so that the spinny widget rotates at
+    // the same speed as your physical decks, if you're using vinyl control.
+    m_pVinylControlSpeedType->connectValueChanged(
+            SLOT(updateVinylControlSpeed(double)));
 
 #else
     //if no vinyl control, just call it 33

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -22,7 +22,7 @@ class VinylControlManager;
 class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityListener {
     Q_OBJECT
   public:
-    WSpinny(QWidget* parent, const QString& group,
+    WSpinny(QWidget* parent, const StringAtom& group,
             ConfigObject<ConfigValue>* pConfig,
             VinylControlManager* pVCMan);
     virtual ~WSpinny();
@@ -68,7 +68,7 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
     QPixmap scaledCoverArt(const QPixmap& normal);
 
   private:
-    QString m_group;
+    StringAtom m_group;
     ConfigObject<ConfigValue>* m_pConfig;
     QImage* m_pBgImage;
     QImage* m_pMaskImage;

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -76,17 +76,17 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
     QImage m_fgImageScaled;
     QImage* m_pGhostImage;
     QImage m_ghostImageScaled;
-    ControlObjectThread* m_pPlay;
-    ControlObjectThread* m_pPlayPos;
+    ControlObjectSlave* m_pPlay;
+    ControlObjectSlave* m_pPlayPos;
     QSharedPointer<VisualPlayPosition> m_pVisualPlayPos;
-    ControlObjectThread* m_pTrackSamples;
-    ControlObjectThread* m_pTrackSampleRate;
-    ControlObjectThread* m_pScratchToggle;
-    ControlObjectThread* m_pScratchPos;
-    ControlObjectThread* m_pVinylControlSpeedType;
-    ControlObjectThread* m_pVinylControlEnabled;
-    ControlObjectThread* m_pSignalEnabled;
-    ControlObjectThread* m_pSlipEnabled;
+    ControlObjectSlave* m_pTrackSamples;
+    ControlObjectSlave* m_pTrackSampleRate;
+    ControlObjectSlave* m_pScratchToggle;
+    ControlObjectSlave* m_pScratchPos;
+    ControlObjectSlave* m_pVinylControlSpeedType;
+    ControlObjectSlave* m_pVinylControlEnabled;
+    ControlObjectSlave* m_pSignalEnabled;
+    ControlObjectSlave* m_pSlipEnabled;
 
     TrackPointer m_loadedTrack;
     QPixmap m_loadedCover;

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -13,6 +13,7 @@
 #include "vinylcontrol/vinylsignalquality.h"
 #include "widget/wbasewidget.h"
 #include "widget/wwidget.h"
+#include "control/stringatom.h"
 
 class ControlObjectThread;
 class VisualPlayPosition;
@@ -48,7 +49,7 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
 
 
   signals:
-    void trackDropped(QString filename, QString group);
+    void trackDropped(QString filename, StringAtom group);
 
   protected:
     //QWidget:

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -6,7 +6,7 @@
 #include "widget/wtrackproperty.h"
 #include "util/dnd.h"
 
-WTrackProperty::WTrackProperty(const char* group,
+WTrackProperty::WTrackProperty(const StringAtom& group,
                                ConfigObject<ConfigValue>* pConfig,
                                QWidget* pParent)
         : WLabel(pParent),

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -9,6 +9,7 @@
 #include "skin/skincontext.h"
 #include "trackinfoobject.h"
 #include "widget/wlabel.h"
+#include "control/stringatom.h"
 
 class WTrackProperty : public WLabel {
     Q_OBJECT
@@ -19,7 +20,7 @@ class WTrackProperty : public WLabel {
     void setup(QDomNode node, const SkinContext& context);
 
   signals:
-    void trackDropped(QString filename, QString group);
+    void trackDropped(QString filename, StringAtom group);
 
   public slots:
     void slotTrackLoaded(TrackPointer track);

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -14,7 +14,7 @@
 class WTrackProperty : public WLabel {
     Q_OBJECT
   public:
-    WTrackProperty(const char* group, ConfigObject<ConfigValue>* pConfig, QWidget* pParent);
+    WTrackProperty(const StringAtom& group, ConfigObject<ConfigValue>* pConfig, QWidget* pParent);
     virtual ~WTrackProperty();
 
     void setup(QDomNode node, const SkinContext& context);
@@ -34,7 +34,7 @@ class WTrackProperty : public WLabel {
     void dropEvent(QDropEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
 
-    const char* m_pGroup;
+    StringAtom m_pGroup;
     ConfigObject<ConfigValue>* m_pConfig;
     TrackPointer m_pCurrentTrack;
     QString m_property;

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -6,7 +6,7 @@
 #include "widget/wtracktext.h"
 #include "util/dnd.h"
 
-WTrackText::WTrackText(const char *group, ConfigObject<ConfigValue> *pConfig, QWidget* pParent)
+WTrackText::WTrackText(const StringAtom& group, ConfigObject<ConfigValue> *pConfig, QWidget* pParent)
         : WLabel(pParent),
           m_pGroup(group),
           m_pConfig(pConfig) {

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -13,7 +13,7 @@
 class WTrackText : public WLabel {
     Q_OBJECT
   public:
-    WTrackText(const char* group, ConfigObject<ConfigValue>* pConfig, QWidget *parent);
+    WTrackText(const StringAtom& group, ConfigObject<ConfigValue>* pConfig, QWidget *parent);
     virtual ~WTrackText();
 
   signals:
@@ -31,7 +31,7 @@ class WTrackText : public WLabel {
     void dropEvent(QDropEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
 
-    const char* m_pGroup;
+    const StringAtom m_pGroup;
     ConfigObject<ConfigValue>* m_pConfig;
     TrackPointer m_pCurrentTrack;
 };

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -8,6 +8,7 @@
 #include "configobject.h"
 #include "trackinfoobject.h"
 #include "widget/wlabel.h"
+#include "control/stringatom.h"
 
 class WTrackText : public WLabel {
     Q_OBJECT
@@ -16,7 +17,7 @@ class WTrackText : public WLabel {
     virtual ~WTrackText();
 
   signals:
-    void trackDropped(QString fileName, QString group);
+    void trackDropped(QString fileName, StringAtom group);
 
   public slots:
     void slotTrackLoaded(TrackPointer track);

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -16,7 +16,7 @@
 #include "util/dnd.h"
 #include "util/math.h"
 
-WWaveformViewer::WWaveformViewer(const char *group, ConfigObject<ConfigValue>* pConfig, QWidget * parent)
+WWaveformViewer::WWaveformViewer(const StringAtom& group, ConfigObject<ConfigValue>* pConfig, QWidget * parent)
         : WWidget(parent),
           m_pGroup(group),
           m_pConfig(pConfig),

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -20,7 +20,7 @@ class ControlPotmeter;
 class WWaveformViewer : public WWidget {
     Q_OBJECT
   public:
-    WWaveformViewer(const char *group, ConfigObject<ConfigValue>* pConfig, QWidget *parent=0);
+    WWaveformViewer(const StringAtom& group, ConfigObject<ConfigValue>* pConfig, QWidget *parent=0);
     virtual ~WWaveformViewer();
 
     const StringAtom& getGroup() const { return m_pGroup;}

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -11,6 +11,7 @@
 #include "trackinfoobject.h"
 #include "widget/wwidget.h"
 #include "skin/skincontext.h"
+#include "control/stringatom.h"
 
 class ControlObjectSlave;
 class WaveformWidgetAbstract;
@@ -22,7 +23,7 @@ class WWaveformViewer : public WWidget {
     WWaveformViewer(const char *group, ConfigObject<ConfigValue>* pConfig, QWidget *parent=0);
     virtual ~WWaveformViewer();
 
-    const char* getGroup() const { return m_pGroup;}
+    const StringAtom& getGroup() const { return m_pGroup;}
     void setup(QDomNode node, const SkinContext& context);
 
     void dragEnterEvent(QDragEnterEvent *event);
@@ -58,7 +59,7 @@ private:
     void setZoom(int zoom);
 
 private:
-    const char* m_pGroup;
+    StringAtom m_pGroup;
     ConfigObject<ConfigValue>* m_pConfig;
     int m_zoomZoneWidth;
     ControlObjectSlave* m_pZoom;

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -34,7 +34,7 @@ class WWaveformViewer : public WWidget {
     void mouseReleaseEvent(QMouseEvent *);
 
 signals:
-    void trackDropped(QString filename, QString group);
+    void trackDropped(QString filename, StringAtom group);
 
 public slots:
     void onTrackLoaded(TrackPointer track);


### PR DESCRIPTION
This is a work in progress PR for the new StringAtom class. 
It aims to be a 1:1 replacement of all programmatic strings. 

It will finally fix:
https://bugs.launchpad.net/mixxx/+bug/1283471

As discussed it Launchpad, it is desirable to have a index based lookup instead of a pointer lookup, which is implemented here. It turns out the we have too many and dynamic growing groups string amount to have an effective index lookup. 
And we have also at least two independent domains for such indexes: the Master Channels (currently limited by 32) and the Effect Channels (dynamic) 
I plan to introduce an inherited class, that has an additional index per indexing domain, assigned be EffectManager and EngineMaster.  
I hope the code stays maintainable but becomes faster. 

Any Ideas or comments? 
