### PR TITLE
Don't allow translations in Preferences>Live Broadcasting>Shoutcast meta...

### DIFF
--- a/src/dlgprefshoutcast.cpp
+++ b/src/dlgprefshoutcast.cpp
@@ -172,7 +172,7 @@ DlgPrefShoutcast::DlgPrefShoutcast(QWidget *parent, ConfigObject<ConfigValue> *_
         ConfigKey(SHOUTCAST_PREF_KEY,"metadata_format"));
     if (tmp_string.isEmpty())
         //No tr() here, see https://bugs.launchpad.net/mixxx/+bug/1419500
-        tmp_string = ("$artist - $title");
+        tmp_string = ($artist - $title);
     metadata_format->setText(tmp_string);
 
     slotApply();

--- a/src/dlgprefshoutcast.cpp
+++ b/src/dlgprefshoutcast.cpp
@@ -171,7 +171,8 @@ DlgPrefShoutcast::DlgPrefShoutcast(QWidget *parent, ConfigObject<ConfigValue> *_
     tmp_string = m_pConfig->getValueString(
         ConfigKey(SHOUTCAST_PREF_KEY,"metadata_format"));
     if (tmp_string.isEmpty())
-        tmp_string = tr("$artist - $title");
+        //No tr() here, see https://bugs.launchpad.net/mixxx/+bug/1419500
+        tmp_string = ("$artist - $title");
     metadata_format->setText(tmp_string);
 
     slotApply();
@@ -202,7 +203,8 @@ void DlgPrefShoutcast::slotResetToDefaults() {
     comboBoxEncodingChannels->setCurrentIndex(0);
     enableUtf8Metadata->setChecked(false);
     enableCustomMetadata->setChecked(false);
-    metadata_format->setText(tr("$artist - $title"));
+    //No tr() here, see https://bugs.launchpad.net/mixxx/+bug/1419500
+    metadata_format->setText("$artist - $title");
     custom_artist->setText("");
     custom_title->setText("");
 }

--- a/src/dlgprefshoutcastdlg.ui
+++ b/src/dlgprefshoutcastdlg.ui
@@ -534,7 +534,7 @@ p, li { white-space: pre-wrap; }
       <item>
        <widget class="QLineEdit" name="metadata_format">
         <property name="text">
-         <string>$artist - $title</string>
+         <string notr="true">$artist - $title</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
...data format line edit, fixes https://bugs.launchpad.net/mixxx/+bug/1419500. Follow up to #166 

TODO after merge:
- Update Translation templates
- Merge updated translations from Transifex
- Compile `*.qm` files
