### PR TITLE
Fix inconsistent colors in waveforms for Deere and LateNight (LP#1321562)

### DIFF
--- a/res/skins/Deere/left_gutter.xml
+++ b/res/skins/Deere/left_gutter.xml
@@ -13,7 +13,7 @@
       <Template src="skin:deck_left.xml">
         <SetVariable name="i">1</SetVariable>
         <!-- Traditional Blue -->
-        <SetVariable name="DeckColor">#0099FF</SetVariable>
+        <SetVariable name="DeckColor">#007BCD</SetVariable>
         <SetVariable name="DeckColorMuted">#001726</SetVariable>
       </Template>
 
@@ -23,7 +23,7 @@
           <Template src="skin:deck_left.xml">
             <SetVariable name="i">3</SetVariable>
             <!-- Violet -->
-            <SetVariable name="DeckColor">#EE82EE</SetVariable>
+            <SetVariable name="DeckColor">#B500B5</SetVariable>
             <SetVariable name="DeckColorMuted">#261526</SetVariable>
           </Template>
         </Children>

--- a/res/skins/Deere/right_gutter.xml
+++ b/res/skins/Deere/right_gutter.xml
@@ -13,7 +13,7 @@
       <Template src="skin:deck_right.xml">
         <SetVariable name="i">2</SetVariable>
         <!-- Traditional Orange -->
-        <SetVariable name="DeckColor">#E17800</SetVariable>
+        <SetVariable name="DeckColor">#E67A00</SetVariable>
         <SetVariable name="DeckColorMuted">#261400</SetVariable>
       </Template>
 
@@ -23,7 +23,7 @@
           <Template src="skin:deck_right.xml">
             <SetVariable name="i">4</SetVariable>
             <!-- Lime -->
-            <SetVariable name="DeckColor">#CDDC39</SetVariable>
+            <SetVariable name="DeckColor">#AABD00</SetVariable>
             <SetVariable name="DeckColorMuted">#24260A</SetVariable>
           </Template>
         </Children>

--- a/res/skins/LateNight/deck_row_5.xml
+++ b/res/skins/LateNight/deck_row_5.xml
@@ -15,7 +15,7 @@
 				-->
 				<SizePolicy>me,min</SizePolicy>
 				<MinimumSize>-1,-1</MinimumSize>
-				<SignalColor><Variable name="deck_color" /></SignalColor>
+				<SignalColor><Variable name="signal_color" /></SignalColor>
                 <SignalRGBLowColor><Variable name="SignalRGBLowColor"/></SignalRGBLowColor>
                 <SignalRGBMidColor><Variable name="SignalRGBMidColor"/></SignalRGBMidColor>
                 <SignalRGBHighColor><Variable name="SignalRGBHighColor"/></SignalRGBHighColor>

--- a/res/skins/LateNight/decks_left.xml
+++ b/res/skins/LateNight/decks_left.xml
@@ -11,7 +11,7 @@
                 <Children>
                     <Template src="skin:deck.xml">
         	            <SetVariable name="channum">1</SetVariable>
-                        <SetVariable name="deck_color">#EECE33</SetVariable>
+                        <SetVariable name="signal_color">#E7C413</SetVariable>
                         <SetVariable name="SignalBgColor">#2f290a</SetVariable>
                         <SetVariable name="SignalRGBLowColor">#ff2a00</SetVariable>
                         <SetVariable name="SignalRGBMidColor">#33f600</SetVariable>
@@ -22,7 +22,7 @@
                         <Children>
                             <Template src="skin:deck.xml">
                                 <SetVariable name="channum">3</SetVariable>
-                                <SetVariable name="deck_color">#09B2AE</SetVariable>
+                                <SetVariable name="signal_color">#09B2AE</SetVariable>
                                 <SetVariable name="SignalBgColor">#2f290a</SetVariable>
                                 <SetVariable name="SignalRGBLowColor">#ff2a00</SetVariable>
                                 <SetVariable name="SignalRGBMidColor">#33f600</SetVariable>

--- a/res/skins/LateNight/decks_right.xml
+++ b/res/skins/LateNight/decks_right.xml
@@ -11,7 +11,7 @@
                 <Children>
                     <Template src="skin:deck.xml">
         	            <SetVariable name="channum">2</SetVariable>
-                        <SetVariable name="deck_color">#EECE33</SetVariable>
+                        <SetVariable name="signal_color">#E7C413</SetVariable>
                         <SetVariable name="SignalBgColor">#2f290a</SetVariable>
                         <SetVariable name="SignalRGBLowColor">#ff2a00</SetVariable>
                         <SetVariable name="SignalRGBMidColor">#33f600</SetVariable>
@@ -22,7 +22,7 @@
                         <Children>
                             <Template src="skin:deck.xml">
                                 <SetVariable name="channum">4</SetVariable>
-                                <SetVariable name="deck_color">#09B2AE</SetVariable>
+                                <SetVariable name="signal_color">#09B2AE</SetVariable>
                                 <SetVariable name="SignalBgColor">#2f290a</SetVariable>
                                 <SetVariable name="SignalRGBLowColor">#ff2a00</SetVariable>
                                 <SetVariable name="SignalRGBMidColor">#33f600</SetVariable>

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -28,7 +28,7 @@
 				<!--<Size>i,110</Size>-->
 				<BgColor><Variable name="SignalBgColor"/></BgColor>
 				<!--<BgPixmap>style/style_bg_waveform1.png</BgPixmap>-->
-				<SignalColor><Variable name="deck_color"/></SignalColor>
+				<SignalColor><Variable name="signal_color"/></SignalColor>
                 <SignalRGBLowColor><Variable name="SignalRGBLowColor"/></SignalRGBLowColor>
                 <SignalRGBMidColor><Variable name="SignalRGBMidColor"/></SignalRGBMidColor>
                 <SignalRGBHighColor><Variable name="SignalRGBHighColor"/></SignalRGBHighColor>

--- a/res/skins/LateNight/waveform_and_mixer.xml
+++ b/res/skins/LateNight/waveform_and_mixer.xml
@@ -135,7 +135,7 @@
 					</Template>
 					<Template src="skin:waveform.xml">
 						<SetVariable name="channum">3</SetVariable>
-                        <SetVariable name="deck_color">#09B2AE</SetVariable>
+                        <SetVariable name="signal_color">#09B2AE</SetVariable>
                         <SetVariable name="SignalBgColor">#012322</SetVariable>
                         <SetVariable name="SignalRGBLowColor">#cb3433</SetVariable>
                         <SetVariable name="SignalRGBMidColor">#00ff33</SetVariable>
@@ -157,7 +157,7 @@
 					</Template>
 					<Template src="skin:waveform.xml">
 						<SetVariable name="channum">1</SetVariable>
-                        <SetVariable name="deck_color">#E7C413</SetVariable>
+                        <SetVariable name="signal_color">#E7C413</SetVariable>
                         <SetVariable name="SignalBgColor">#2f290a</SetVariable>
                         <SetVariable name="SignalRGBLowColor">#ff2a00</SetVariable>
                         <SetVariable name="SignalRGBMidColor">#33f600</SetVariable>
@@ -175,7 +175,7 @@
 					</Template>
 					<Template src="skin:waveform.xml">
 						<SetVariable name="channum">2</SetVariable>
-                        <SetVariable name="deck_color">#E7C413</SetVariable>
+                        <SetVariable name="signal_color">#E7C413</SetVariable>
                         <SetVariable name="SignalBgColor">#2f290a</SetVariable>
                         <SetVariable name="SignalRGBLowColor">#ff2a00</SetVariable>
                         <SetVariable name="SignalRGBMidColor">#33f600</SetVariable>
@@ -193,7 +193,7 @@
 					</Template>
 					<Template src="skin:waveform.xml">
 						<SetVariable name="channum">4</SetVariable>
-                        <SetVariable name="deck_color">#09B2AE</SetVariable>
+                        <SetVariable name="signal_color">#09B2AE</SetVariable>
                         <SetVariable name="SignalBgColor">#012322</SetVariable>
                         <SetVariable name="SignalRGBLowColor">#cb3433</SetVariable>
                         <SetVariable name="SignalRGBMidColor">#00ff33</SetVariable>

--- a/res/skins/LateNight/waveform_and_mixer.xml
+++ b/res/skins/LateNight/waveform_and_mixer.xml
@@ -157,7 +157,7 @@
 					</Template>
 					<Template src="skin:waveform.xml">
 						<SetVariable name="channum">1</SetVariable>
-                        <SetVariable name="deck_color">#EECE33</SetVariable>
+                        <SetVariable name="deck_color">#E7C413</SetVariable>
                         <SetVariable name="SignalBgColor">#2f290a</SetVariable>
                         <SetVariable name="SignalRGBLowColor">#ff2a00</SetVariable>
                         <SetVariable name="SignalRGBMidColor">#33f600</SetVariable>
@@ -175,7 +175,7 @@
 					</Template>
 					<Template src="skin:waveform.xml">
 						<SetVariable name="channum">2</SetVariable>
-                        <SetVariable name="deck_color">#EECE33</SetVariable>
+                        <SetVariable name="deck_color">#E7C413</SetVariable>
                         <SetVariable name="SignalBgColor">#2f290a</SetVariable>
                         <SetVariable name="SignalRGBLowColor">#ff2a00</SetVariable>
                         <SetVariable name="SignalRGBMidColor">#33f600</SetVariable>


### PR DESCRIPTION
See the [corresponding bug on Launchpad](https://bugs.launchpad.net/mixxx/+bug/1321562)

Instead of setting each variable for low, mid and high, I decided to only modify the HSL values for DeckColor (in Deere) and deck_color (in LateNight) in order to have them all in the same lightness bracket (0.1 < l <0.5) so waveformsignalcolors.cpp would do the same calculations for each deck. This way, all decks are consistent and have:
- high = light
- mid = mid
- low = dark

See the example screenshots:

LateNight before:
![LateNight before](https://cloud.githubusercontent.com/assets/1747497/6213450/ab67e7a0-b63b-11e4-8ca6-b84426182fb9.png)

LateNight after:
![LateNight after](https://cloud.githubusercontent.com/assets/1747497/6213453/b1354d62-b63b-11e4-84e7-b4f4c9f43fb2.png)

Deere after:
![Deere after](https://cloud.githubusercontent.com/assets/1747497/6213543/69353f12-b63c-11e4-90c0-a254acdbbaed.png)

The next step could be to modify /src/waveform/renderers/waveformsignalcolors.cpp so it does not reverse the order of the shades.
