### PR TITLE
Implement findPrevNextBeats to reduce Beats mutex locking.

### DIFF
--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -535,11 +535,9 @@ bool BpmControl::getBeatContext(const BeatsPointer& pBeats,
         return false;
     }
 
-    QPair<double, double> beat_pair = pBeats->findPrevNextBeats(dPosition);
-    double dPrevBeat = beat_pair.first;
-    double dNextBeat = beat_pair.second;
-
-    if (dPrevBeat == -1 || dNextBeat == -1) {
+    double dPrevBeat;
+    double dNextBeat;
+    if (!pBeats->findPrevNextBeats(dPosition, &dPrevBeat, &dNextBeat)) {
         return false;
     }
 

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -535,18 +535,11 @@ bool BpmControl::getBeatContext(const BeatsPointer& pBeats,
         return false;
     }
 
-    double dPrevBeat = pBeats->findPrevBeat(dPosition);
-    double dNextBeat = pBeats->findNextBeat(dPosition);
+    QPair<double, double> beat_pair = pBeats->findPrevNextBeats(dPosition);
+    double dPrevBeat = beat_pair.first;
+    double dNextBeat = beat_pair.second;
 
     if (dPrevBeat == -1 || dNextBeat == -1) {
-        return false;
-    }
-
-    if (fabs(dPrevBeat - dNextBeat) <= beatEpsilon) {
-        dNextBeat = pBeats->findNthBeat(dPosition, 2);
-    }
-
-    if (dNextBeat == -1) {
         return false;
     }
 

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -729,7 +729,9 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint) {
             // closest beat might be ahead of play position which would cause a seek.
             // TODO: If in reverse, should probably choose nextBeat.
             double cur_pos = getCurrentSample();
-            double prevBeat = floor(m_pBeats->findPrevBeat(cur_pos));
+            QPair<double, double> beat_pair = m_pBeats->findPrevNextBeats(cur_pos);
+            double prevBeat = floor(beat_pair.first);
+            double nextBeat = floor(beat_pair.second);
 
             if (m_pQuantizeEnabled->get() > 0.0 && prevBeat != -1) {
                 if (beats >= 1.0) {
@@ -742,7 +744,6 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint) {
                     //
                     // If we press 1/2 beatloop we want loop from 50% to 100%,
                     // If I press 1/4 beatloop, we want loop from 50% to 75% etc
-                    double nextBeat = floor(m_pBeats->findNextBeat(cur_pos));
                     double beat_len = nextBeat - prevBeat;
                     double loops_per_beat = 1.0 / beats;
                     double beat_pos = cur_pos - prevBeat;
@@ -773,6 +774,7 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint) {
         if (fullbeats > 0) {
             // Add the length between this beat and the fullbeats'th beat to the
             // loop_out position;
+            // TODO: figure out how to convert this to a findPrevNext call.
             double this_beat = m_pBeats->findNthBeat(loop_in, 1);
             double nth_beat = m_pBeats->findNthBeat(loop_in, 1 + fullbeats);
             loop_out += (nth_beat - this_beat);
@@ -781,6 +783,7 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint) {
         if (fracbeats > 0) {
             // Add the fraction of the beat following the current loop_out
             // position to loop out.
+            // TODO: figure out how to convert this to a findPrevNext call.
             double loop_out_beat = m_pBeats->findNthBeat(loop_out, 1);
             double loop_out_next_beat = m_pBeats->findNthBeat(loop_out, 2);
             loop_out += (loop_out_next_beat - loop_out_beat) * fracbeats;

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -729,9 +729,9 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint) {
             // closest beat might be ahead of play position which would cause a seek.
             // TODO: If in reverse, should probably choose nextBeat.
             double cur_pos = getCurrentSample();
-            QPair<double, double> beat_pair = m_pBeats->findPrevNextBeats(cur_pos);
-            double prevBeat = floor(beat_pair.first);
-            double nextBeat = floor(beat_pair.second);
+            double prevBeat;
+            double nextBeat;
+            m_pBeats->findPrevNextBeats(cur_pos, &prevBeat, &nextBeat);
 
             if (m_pQuantizeEnabled->get() > 0.0 && prevBeat != -1) {
                 if (beats >= 1.0) {

--- a/src/engine/quantizecontrol.cpp
+++ b/src/engine/quantizecontrol.cpp
@@ -87,10 +87,12 @@ double QuantizeControl::process(const double dRate,
 
     // Calculate this by hand since we may also want the beat locations themselves
     // and duplicating the work would double the number of mutex locks.
-    QPair<double, double> beat_pair = m_pBeats->findPrevNextBeats(iCurrentSample);
+    double updatedPrev;
+    double updatedNext;
+    m_pBeats->findPrevNextBeats(iCurrentSample, &updatedPrev, &updatedNext);
     double currentClosestBeat =
-            (beat_pair.second - iCurrentSample > iCurrentSample - beat_pair.first) ?
-                    beat_pair.first : beat_pair.second;
+            (updatedNext - iCurrentSample > iCurrentSample - updatedPrev) ?
+                    updatedPrev : updatedNext;
 
     if (closestBeat != currentClosestBeat) {
         if (!even(static_cast<int>(currentClosestBeat))) {
@@ -101,8 +103,8 @@ double QuantizeControl::process(const double dRate,
 
     if (prevBeat == -1 || nextBeat == -1 ||
         currentSample >= nextBeat || currentSample <= prevBeat) {
-        m_pCOPrevBeat->set(beat_pair.first);
-        m_pCONextBeat->set(beat_pair.second);
+        m_pCOPrevBeat->set(updatedPrev);
+        m_pCONextBeat->set(updatedNext);
     }
 
     return kNoTrigger;

--- a/src/engine/quantizecontrol.cpp
+++ b/src/engine/quantizecontrol.cpp
@@ -90,15 +90,26 @@ double QuantizeControl::process(const double dRate,
     double updatedPrev;
     double updatedNext;
     m_pBeats->findPrevNextBeats(iCurrentSample, &updatedPrev, &updatedNext);
-    double currentClosestBeat =
-            (updatedNext - iCurrentSample > iCurrentSample - updatedPrev) ?
-                    updatedPrev : updatedNext;
 
-    if (closestBeat != currentClosestBeat) {
-        if (!even(static_cast<int>(currentClosestBeat))) {
-            currentClosestBeat--;
+    if (updatedPrev == -1) {
+        if (updatedNext != -1) {
+            m_pCOClosestBeat->set(updatedNext);
+        } else {
+            // Likely no beat information -- can't set closest beat value.
         }
-        m_pCOClosestBeat->set(currentClosestBeat);
+    } else if (updatedNext == -1) {
+        m_pCOClosestBeat->set(updatedPrev);
+    } else {
+        double currentClosestBeat =
+                (updatedNext - iCurrentSample > iCurrentSample - updatedPrev) ?
+                        updatedPrev : updatedNext;
+
+        if (closestBeat != currentClosestBeat) {
+            if (!even(static_cast<int>(currentClosestBeat))) {
+                currentClosestBeat--;
+            }
+            m_pCOClosestBeat->set(currentClosestBeat);
+        }
     }
 
     if (prevBeat == -1 || nextBeat == -1 ||

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -64,6 +64,15 @@ TEST_F(BeatGridTest, TestNthBeatWhenOnBeat) {
         EXPECT_EQ(position + beatLength*(i-1), pGrid->findNthBeat(position, i));
         EXPECT_EQ(position + beatLength*(-i+1), pGrid->findNthBeat(position, -i));
     }
+
+    // Also test prev/next beat calculation.
+    QPair<double, double> beat_pair = pGrid->findPrevNextBeats(position);
+    EXPECT_EQ(position, beat_pair.first);
+    EXPECT_EQ(position + beatLength, beat_pair.second);
+
+    // Both previous and next beat should return the current position.
+    EXPECT_EQ(position, pGrid->findNextBeat(position));
+    EXPECT_EQ(position, pGrid->findPrevBeat(position));
 }
 
 TEST_F(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
@@ -92,6 +101,15 @@ TEST_F(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
         EXPECT_EQ(kClosestBeat + beatLength*(i-1), pGrid->findNthBeat(position, i));
         EXPECT_EQ(kClosestBeat + beatLength*(-i+1), pGrid->findNthBeat(position, -i));
     }
+
+    // Also test prev/next beat calculation.
+    QPair<double, double> beat_pair = pGrid->findPrevNextBeats(position);
+    EXPECT_EQ(kClosestBeat, beat_pair.first);
+    EXPECT_EQ(kClosestBeat + beatLength, beat_pair.second);
+
+    // Both previous and next beat should return the closest beat.
+    EXPECT_EQ(kClosestBeat, pGrid->findNextBeat(position));
+    EXPECT_EQ(kClosestBeat, pGrid->findPrevBeat(position));
 }
 
 TEST_F(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
@@ -120,6 +138,15 @@ TEST_F(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
         EXPECT_EQ(kClosestBeat + beatLength*(i-1), pGrid->findNthBeat(position, i));
         EXPECT_EQ(kClosestBeat + beatLength*(-i+1), pGrid->findNthBeat(position, -i));
     }
+
+    // Also test prev/next beat calculation.
+    QPair<double, double> beat_pair = pGrid->findPrevNextBeats(position);
+    EXPECT_EQ(kClosestBeat, beat_pair.first);
+    EXPECT_EQ(kClosestBeat + beatLength, beat_pair.second);
+
+    // Both previous and next beat should return the closest beat.
+    EXPECT_EQ(kClosestBeat, pGrid->findNextBeat(position));
+    EXPECT_EQ(kClosestBeat, pGrid->findPrevBeat(position));
 }
 
 TEST_F(BeatGridTest, TestNthBeatWhenNotOnBeat) {
@@ -148,6 +175,11 @@ TEST_F(BeatGridTest, TestNthBeatWhenNotOnBeat) {
         EXPECT_EQ(nextBeat + beatLength*(i-1), pGrid->findNthBeat(position, i));
         EXPECT_EQ(previousBeat + beatLength*(-i+1), pGrid->findNthBeat(position, -i));
     }
+
+    // Also test prev/next beat calculation
+    QPair<double, double> beat_pair = pGrid->findPrevNextBeats(position);
+    EXPECT_EQ(previousBeat, beat_pair.first);
+    EXPECT_EQ(nextBeat, beat_pair.second);
 }
 
 }  // namespace

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -66,9 +66,10 @@ TEST_F(BeatGridTest, TestNthBeatWhenOnBeat) {
     }
 
     // Also test prev/next beat calculation.
-    QPair<double, double> beat_pair = pGrid->findPrevNextBeats(position);
-    EXPECT_EQ(position, beat_pair.first);
-    EXPECT_EQ(position + beatLength, beat_pair.second);
+    double prevBeat, nextBeat;
+    pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat);
+    EXPECT_EQ(position, prevBeat);
+    EXPECT_EQ(position + beatLength, nextBeat);
 
     // Both previous and next beat should return the current position.
     EXPECT_EQ(position, pGrid->findNextBeat(position));
@@ -103,9 +104,10 @@ TEST_F(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     }
 
     // Also test prev/next beat calculation.
-    QPair<double, double> beat_pair = pGrid->findPrevNextBeats(position);
-    EXPECT_EQ(kClosestBeat, beat_pair.first);
-    EXPECT_EQ(kClosestBeat + beatLength, beat_pair.second);
+    double prevBeat, nextBeat;
+    pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat);
+    EXPECT_EQ(kClosestBeat, prevBeat);
+    EXPECT_EQ(kClosestBeat + beatLength, nextBeat);
 
     // Both previous and next beat should return the closest beat.
     EXPECT_EQ(kClosestBeat, pGrid->findNextBeat(position));
@@ -140,9 +142,10 @@ TEST_F(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     }
 
     // Also test prev/next beat calculation.
-    QPair<double, double> beat_pair = pGrid->findPrevNextBeats(position);
-    EXPECT_EQ(kClosestBeat, beat_pair.first);
-    EXPECT_EQ(kClosestBeat + beatLength, beat_pair.second);
+    double prevBeat, nextBeat;
+    pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat);
+    EXPECT_EQ(kClosestBeat, prevBeat);
+    EXPECT_EQ(kClosestBeat + beatLength, nextBeat);
 
     // Both previous and next beat should return the closest beat.
     EXPECT_EQ(kClosestBeat, pGrid->findNextBeat(position));
@@ -177,9 +180,10 @@ TEST_F(BeatGridTest, TestNthBeatWhenNotOnBeat) {
     }
 
     // Also test prev/next beat calculation
-    QPair<double, double> beat_pair = pGrid->findPrevNextBeats(position);
-    EXPECT_EQ(previousBeat, beat_pair.first);
-    EXPECT_EQ(nextBeat, beat_pair.second);
+    double foundPrevBeat, foundNextBeat;
+    pGrid->findPrevNextBeats(position, &foundPrevBeat, &foundNextBeat);
+    EXPECT_EQ(previousBeat, foundPrevBeat);
+    EXPECT_EQ(nextBeat, foundNextBeat);
 }
 
 }  // namespace

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -87,13 +87,14 @@ TEST_F(BeatMapTest, TestNthBeat) {
     EXPECT_EQ(firstBeat, pMap->findPrevBeat(firstBeat));
     EXPECT_EQ(-1, pMap->findNthBeat(firstBeat, -2));
 
-    QPair<double, double> beat_pair = pMap->findPrevNextBeats(lastBeat);
-    EXPECT_EQ(lastBeat, beat_pair.first);
-    EXPECT_EQ(-1, beat_pair.second);
+    double prevBeat, nextBeat;
+    pMap->findPrevNextBeats(lastBeat, &prevBeat, &nextBeat);
+    EXPECT_EQ(lastBeat, prevBeat);
+    EXPECT_EQ(-1, nextBeat);
 
-    beat_pair = pMap->findPrevNextBeats(firstBeat);
-    EXPECT_EQ(firstBeat, beat_pair.first);
-    EXPECT_EQ(firstBeat + beatLengthSamples, beat_pair.second);
+    pMap->findPrevNextBeats(firstBeat, &prevBeat, &nextBeat);
+    EXPECT_EQ(firstBeat, prevBeat);
+    EXPECT_EQ(firstBeat + beatLengthSamples, nextBeat);
 }
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
@@ -124,9 +125,10 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
     }
 
     // Also test prev/next beat calculation.
-    QPair<double, double> beat_pair = pMap->findPrevNextBeats(position);
-    EXPECT_EQ(position, beat_pair.first);
-    EXPECT_EQ(position + beatLengthSamples, beat_pair.second);
+    double prevBeat, nextBeat;
+    pMap->findPrevNextBeats(position, &prevBeat, &nextBeat);
+    EXPECT_EQ(position, prevBeat);
+    EXPECT_EQ(position + beatLengthSamples, nextBeat);
 
     // Both previous and next beat should return the current position.
     EXPECT_EQ(position, pMap->findNextBeat(position));
@@ -162,9 +164,10 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     }
 
     // Also test prev/next beat calculation
-    QPair<double, double> beat_pair = pMap->findPrevNextBeats(position);
-    EXPECT_EQ(kClosestBeat, beat_pair.first);
-    EXPECT_EQ(kClosestBeat + beatLengthSamples, beat_pair.second);
+    double prevBeat, nextBeat;
+    pMap->findPrevNextBeats(position, &prevBeat, &nextBeat);
+    EXPECT_EQ(kClosestBeat, prevBeat);
+    EXPECT_EQ(kClosestBeat + beatLengthSamples, nextBeat);
 
     // Both previous and next beat should return the closest beat.
     EXPECT_EQ(kClosestBeat, pMap->findNextBeat(position));
@@ -203,9 +206,10 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     }
 
     // Also test prev/next beat calculation.
-    QPair<double, double> beat_pair = pMap->findPrevNextBeats(position);
-    EXPECT_EQ(kClosestBeat, beat_pair.first);
-    EXPECT_EQ(kClosestBeat + beatLengthSamples, beat_pair.second);
+    double prevBeat, nextBeat;
+    pMap->findPrevNextBeats(position, &prevBeat, &nextBeat);
+    EXPECT_EQ(kClosestBeat, prevBeat);
+    EXPECT_EQ(kClosestBeat + beatLengthSamples, nextBeat);
 
     // Both previous and next beat should return the closest beat.
     EXPECT_EQ(kClosestBeat, pMap->findNextBeat(position));
@@ -243,9 +247,10 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     }
 
     // Also test prev/next beat calculation
-    QPair<double, double> beat_pair = pMap->findPrevNextBeats(position);
-    EXPECT_EQ(previousBeat, beat_pair.first);
-    EXPECT_EQ(nextBeat, beat_pair.second);
+    double foundPrevBeat, foundNextBeat;
+    pMap->findPrevNextBeats(position, &foundPrevBeat, &foundNextBeat);
+    EXPECT_EQ(previousBeat, foundPrevBeat);
+    EXPECT_EQ(nextBeat, foundNextBeat);
 }
 
 TEST_F(BeatMapTest, TestBpmAround) {

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -193,6 +193,8 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     // The spec dictates that a value of 0 is always invalid and returns -1
     EXPECT_EQ(-1, pMap->findNthBeat(position, 0));
 
+    EXPECT_EQ(kClosestBeat, pMap->findClosestBeat(position));
+
     // findNthBeat should return exactly the current beat if we ask for 1 or
     // -1. For all other values, it should return n times the beat length.
     for (int i = 1; i < curBeat; ++i) {
@@ -208,7 +210,6 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     // Both previous and next beat should return the closest beat.
     EXPECT_EQ(kClosestBeat, pMap->findNextBeat(position));
     EXPECT_EQ(kClosestBeat, pMap->findPrevBeat(position));
-
 }
 
 TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
@@ -240,7 +241,6 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
         EXPECT_DOUBLE_EQ(previousBeat - beatLengthSamples*(i-1),
                          pMap->findNthBeat(position, -i));
     }
-
 
     // Also test prev/next beat calculation
     QPair<double, double> beat_pair = pMap->findPrevNextBeats(position);

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -81,9 +81,19 @@ TEST_F(BeatMapTest, TestNthBeat) {
     double firstBeat = startOffsetSamples + beatLengthSamples * 0;
     double lastBeat = startOffsetSamples + beatLengthSamples * (numBeats - 1);
     EXPECT_EQ(lastBeat, pMap->findNthBeat(lastBeat, 1));
+    EXPECT_EQ(lastBeat, pMap->findNextBeat(lastBeat));
     EXPECT_EQ(-1, pMap->findNthBeat(lastBeat, 2));
     EXPECT_EQ(firstBeat, pMap->findNthBeat(firstBeat, -1));
+    EXPECT_EQ(firstBeat, pMap->findPrevBeat(firstBeat));
     EXPECT_EQ(-1, pMap->findNthBeat(firstBeat, -2));
+
+    QPair<double, double> beat_pair = pMap->findPrevNextBeats(lastBeat);
+    EXPECT_EQ(lastBeat, beat_pair.first);
+    EXPECT_EQ(-1, beat_pair.second);
+
+    beat_pair = pMap->findPrevNextBeats(firstBeat);
+    EXPECT_EQ(firstBeat, beat_pair.first);
+    EXPECT_EQ(firstBeat + beatLengthSamples, beat_pair.second);
 }
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
@@ -112,6 +122,15 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
         EXPECT_DOUBLE_EQ(position + beatLengthSamples*(i-1), pMap->findNthBeat(position, i));
         EXPECT_DOUBLE_EQ(position + beatLengthSamples*(-i+1), pMap->findNthBeat(position, -i));
     }
+
+    // Also test prev/next beat calculation.
+    QPair<double, double> beat_pair = pMap->findPrevNextBeats(position);
+    EXPECT_EQ(position, beat_pair.first);
+    EXPECT_EQ(position + beatLengthSamples, beat_pair.second);
+
+    // Both previous and next beat should return the current position.
+    EXPECT_EQ(position, pMap->findNextBeat(position));
+    EXPECT_EQ(position, pMap->findPrevBeat(position));
 }
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
@@ -141,6 +160,16 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
         EXPECT_DOUBLE_EQ(kClosestBeat + beatLengthSamples*(i-1), pMap->findNthBeat(position, i));
         EXPECT_DOUBLE_EQ(kClosestBeat + beatLengthSamples*(-i+1), pMap->findNthBeat(position, -i));
     }
+
+    // Also test prev/next beat calculation
+    QPair<double, double> beat_pair = pMap->findPrevNextBeats(position);
+    EXPECT_EQ(kClosestBeat, beat_pair.first);
+    EXPECT_EQ(kClosestBeat + beatLengthSamples, beat_pair.second);
+
+    // Both previous and next beat should return the closest beat.
+    EXPECT_EQ(kClosestBeat, pMap->findNextBeat(position));
+    EXPECT_EQ(kClosestBeat, pMap->findPrevBeat(position));
+
 }
 
 TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
@@ -170,6 +199,16 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
         EXPECT_DOUBLE_EQ(kClosestBeat + beatLengthSamples*(i-1), pMap->findNthBeat(position, i));
         EXPECT_DOUBLE_EQ(kClosestBeat + beatLengthSamples*(-i+1), pMap->findNthBeat(position, -i));
     }
+
+    // Also test prev/next beat calculation.
+    QPair<double, double> beat_pair = pMap->findPrevNextBeats(position);
+    EXPECT_EQ(kClosestBeat, beat_pair.first);
+    EXPECT_EQ(kClosestBeat + beatLengthSamples, beat_pair.second);
+
+    // Both previous and next beat should return the closest beat.
+    EXPECT_EQ(kClosestBeat, pMap->findNextBeat(position));
+    EXPECT_EQ(kClosestBeat, pMap->findPrevBeat(position));
+
 }
 
 TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
@@ -201,6 +240,12 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
         EXPECT_DOUBLE_EQ(previousBeat - beatLengthSamples*(i-1),
                          pMap->findNthBeat(position, -i));
     }
+
+
+    // Also test prev/next beat calculation
+    QPair<double, double> beat_pair = pMap->findPrevNextBeats(position);
+    EXPECT_EQ(previousBeat, beat_pair.first);
+    EXPECT_EQ(nextBeat, beat_pair.second);
 }
 
 TEST_F(BeatMapTest, TestBpmAround) {

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -142,7 +142,8 @@ double BeatGrid::findClosestBeat(double dSamples) const {
     double nextBeat;
     findPrevNextBeats(dSamples, &prevBeat, &nextBeat);
     if (prevBeat == -1) {
-        return nextBeat == -1 ? -1 : nextBeat;
+        // If both values are -1, we correctly return -1.
+        return nextBeat;
     } else if (nextBeat == -1) {
         return prevBeat;
     }
@@ -203,6 +204,7 @@ bool BeatGrid::findPrevNextBeats(double dSamples,
                                  double* dpPrevBeatSamples,
                                  double* dpNextBeatSamples) const {
     double dFirstBeatSample;
+    double dBeatLength;
     {
         QMutexLocker locker(&m_mutex);
         if (!isValid()) {
@@ -211,9 +213,10 @@ bool BeatGrid::findPrevNextBeats(double dSamples,
             return false;
         }
         dFirstBeatSample = firstBeatSample();
+        dBeatLength = m_dBeatLength;
     }
 
-    double beatFraction = (dSamples - dFirstBeatSample) / m_dBeatLength;
+    double beatFraction = (dSamples - dFirstBeatSample) / dBeatLength;
     double prevBeat = floor(beatFraction);
     double nextBeat = ceil(beatFraction);
 
@@ -230,8 +233,8 @@ bool BeatGrid::findPrevNextBeats(double dSamples,
         // And nextBeat needs to be incremented.
         ++nextBeat;
     }
-    *dpPrevBeatSamples = floor(prevBeat * m_dBeatLength + dFirstBeatSample);
-    *dpNextBeatSamples = floor(nextBeat * m_dBeatLength + dFirstBeatSample);
+    *dpPrevBeatSamples = floor(prevBeat * dBeatLength + dFirstBeatSample);
+    *dpNextBeatSamples = floor(nextBeat * dBeatLength + dFirstBeatSample);
     if (!even(static_cast<int>(*dpPrevBeatSamples))) {
         --*dpPrevBeatSamples;
     }

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -47,7 +47,9 @@ class BeatGrid : public QObject, public virtual Beats {
 
     virtual double findNextBeat(double dSamples) const;
     virtual double findPrevBeat(double dSamples) const;
-    virtual QPair<double, double> findPrevNextBeats(double dSamples) const;
+    virtual bool findPrevNextBeats(double dSamples,
+                                   double* dpPrevBeatSamples,
+                                   double* dpNextBeatSamples) const;
     virtual double findClosestBeat(double dSamples) const;
     virtual double findNthBeat(double dSamples, int n) const;
     virtual BeatIterator* findBeats(double startSample, double stopSample) const;

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -47,6 +47,7 @@ class BeatGrid : public QObject, public virtual Beats {
 
     virtual double findNextBeat(double dSamples) const;
     virtual double findPrevBeat(double dSamples) const;
+    virtual QPair<double, double> findPrevNextBeats(double dSamples) const;
     virtual double findClosestBeat(double dSamples) const;
     virtual double findNthBeat(double dSamples, int n) const;
     virtual BeatIterator* findBeats(double startSample, double stopSample) const;

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -21,8 +21,8 @@ inline double samplesToFrames(const double samples) {
     return floor(samples / kFrameSize);
 }
 
-inline double framesToSamples(const double frames) {
-    return floor(frames) * kFrameSize;
+inline double framesToSamples(const int frames) {
+    return frames * kFrameSize;
 }
 
 bool BeatLessThan(const Beat& beat1, const Beat& beat2) {
@@ -180,7 +180,8 @@ double BeatMap::findClosestBeat(double dSamples) const {
     double nextBeat;
     findPrevNextBeats(dSamples, &prevBeat, &nextBeat);
     if (prevBeat == -1) {
-        return nextBeat == -1 ? -1 : nextBeat;
+        // If both values are -1, we correctly return -1.
+        return nextBeat;
     } else if (nextBeat == -1) {
         return prevBeat;
     }

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -176,12 +176,14 @@ double BeatMap::findClosestBeat(double dSamples) const {
     if (!isValid()) {
         return -1;
     }
-    QPair<double, double> beat_pair = findPrevNextBeats(dSamples);
-    if (beat_pair.first == -1 || beat_pair.second == -1) {
-        return -1;
+    double prevBeat;
+    double nextBeat;
+    findPrevNextBeats(dSamples, &prevBeat, &nextBeat);
+    if (prevBeat == -1) {
+        return nextBeat == -1 ? -1 : nextBeat;
+    } else if (nextBeat == -1) {
+        return prevBeat;
     }
-    double prevBeat = beat_pair.first;
-    double nextBeat = beat_pair.second;
     return (nextBeat - dSamples > dSamples - prevBeat) ? prevBeat : nextBeat;
 }
 
@@ -272,11 +274,15 @@ double BeatMap::findNthBeat(double dSamples, int n) const {
     return -1;
 }
 
-QPair<double, double> BeatMap::findPrevNextBeats(double dSamples) const {
+bool BeatMap::findPrevNextBeats(double dSamples,
+                                double* dpPrevBeatSamples,
+                                double* dpNextBeatSamples) const {
     QMutexLocker locker(&m_mutex);
 
     if (!isValid()) {
-        return qMakePair(-1.0, -1.0);
+        *dpPrevBeatSamples = -1;
+        *dpNextBeatSamples = -1;
+        return false;
     }
 
     Beat beat;
@@ -329,20 +335,20 @@ QPair<double, double> BeatMap::findPrevNextBeats(double dSamples) const {
         next_beat = on_beat + 1;
     }
 
-    double dPrevSamples = -1;
-    double dNextSamples = -1;
+    *dpPrevBeatSamples = -1;
+    *dpNextBeatSamples = -1;
 
     for (; next_beat != m_beats.end(); ++next_beat) {
         if (!next_beat->enabled()) {
             continue;
         }
-        dNextSamples = framesToSamples(next_beat->frame_position());
+        *dpNextBeatSamples = framesToSamples(next_beat->frame_position());
         break;
     }
     if (previous_beat != m_beats.end()) {
         for (; true; --previous_beat) {
             if (previous_beat->enabled()) {
-                dPrevSamples = framesToSamples(previous_beat->frame_position());
+                *dpPrevBeatSamples = framesToSamples(previous_beat->frame_position());
                 break;
             }
 
@@ -352,7 +358,7 @@ QPair<double, double> BeatMap::findPrevNextBeats(double dSamples) const {
             }
         }
     }
-    return qMakePair(dPrevSamples, dNextSamples);
+    return *dpPrevBeatSamples != -1 && *dpNextBeatSamples != -1;
 }
 
 BeatIterator* BeatMap::findBeats(double startSample, double stopSample) const {

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -22,7 +22,7 @@ inline double samplesToFrames(const double samples) {
 }
 
 inline double framesToSamples(const double frames) {
-    return frames * kFrameSize;
+    return floor(frames) * kFrameSize;
 }
 
 bool BeatLessThan(const Beat& beat1, const Beat& beat2) {
@@ -176,8 +176,12 @@ double BeatMap::findClosestBeat(double dSamples) const {
     if (!isValid()) {
         return -1;
     }
-    double nextBeat = findNextBeat(dSamples);
-    double prevBeat = findPrevBeat(dSamples);
+    QPair<double, double> beat_pair = findPrevNextBeats(dSamples);
+    if (beat_pair.first == -1 || beat_pair.second == -1) {
+        return -1;
+    }
+    double nextBeat = beat_pair.first;
+    double prevBeat = beat_pair.second;
     return (nextBeat - dSamples > dSamples - prevBeat) ? prevBeat : nextBeat;
 }
 
@@ -266,6 +270,89 @@ double BeatMap::findNthBeat(double dSamples, int n) const {
         }
     }
     return -1;
+}
+
+QPair<double, double> BeatMap::findPrevNextBeats(double dSamples) const {
+    QMutexLocker locker(&m_mutex);
+
+    if (!isValid()) {
+        return qMakePair(-1.0, -1.0);
+    }
+
+    Beat beat;
+    // Reduce sample offset to a frame offset.
+    beat.set_frame_position(samplesToFrames(dSamples));
+
+    // it points at the first occurence of beat or the next largest beat
+    BeatList::const_iterator it =
+            qLowerBound(m_beats.begin(), m_beats.end(), beat, BeatLessThan);
+
+    // If the position is within 1/10th of a second of the next or previous
+    // beat, pretend we are on that beat.
+    const double kFrameEpsilon = 0.1 * m_iSampleRate;
+
+    // Back-up by one.
+    if (it != m_beats.begin()) {
+        --it;
+    }
+
+    // Scan forward to find whether we are on a beat.
+    BeatList::const_iterator on_beat = m_beats.end();
+    BeatList::const_iterator previous_beat = m_beats.end();
+    BeatList::const_iterator next_beat = m_beats.end();
+    for (; it != m_beats.end(); ++it) {
+        qint32 delta = it->frame_position() - beat.frame_position();
+
+        // We are "on" this beat.
+        if (abs(delta) < kFrameEpsilon) {
+            on_beat = it;
+            break;
+        }
+
+        if (delta < 0) {
+            // If we are not on the beat and delta < 0 then this beat comes
+            // before our current position.
+            previous_beat = it;
+        } else {
+            // If we are past the beat and we aren't on it then this beat comes
+            // after our current position.
+            next_beat = it;
+            // Stop because we have everything we need now.
+            break;
+        }
+    }
+
+    // If we are within epsilon samples of a beat then the immediately next and
+    // previous beats are the beat we are on.
+    if (on_beat != m_beats.end()) {
+        previous_beat = on_beat;
+        next_beat = on_beat + 1;
+    }
+
+    double dPrevSamples = -1;
+    double dNextSamples = -1;
+
+    for (; next_beat != m_beats.end(); ++next_beat) {
+        if (!next_beat->enabled()) {
+            continue;
+        }
+        dNextSamples = framesToSamples(next_beat->frame_position());
+        break;
+    }
+    if (previous_beat != m_beats.end()) {
+        for (; true; --previous_beat) {
+            if (previous_beat->enabled()) {
+                dPrevSamples = framesToSamples(previous_beat->frame_position());
+                break;
+            }
+
+            // Don't step before the start of the list.
+            if (previous_beat == m_beats.begin()) {
+                break;
+            }
+        }
+    }
+    return qMakePair(dPrevSamples, dNextSamples);
 }
 
 BeatIterator* BeatMap::findBeats(double startSample, double stopSample) const {

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -180,8 +180,8 @@ double BeatMap::findClosestBeat(double dSamples) const {
     if (beat_pair.first == -1 || beat_pair.second == -1) {
         return -1;
     }
-    double nextBeat = beat_pair.first;
-    double prevBeat = beat_pair.second;
+    double prevBeat = beat_pair.first;
+    double nextBeat = beat_pair.second;
     return (nextBeat - dSamples > dSamples - prevBeat) ? prevBeat : nextBeat;
 }
 

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -54,7 +54,9 @@ class BeatMap : public QObject, public Beats {
 
     virtual double findNextBeat(double dSamples) const;
     virtual double findPrevBeat(double dSamples) const;
-    virtual QPair<double, double> findPrevNextBeats(double dSamples) const;
+    virtual bool findPrevNextBeats(double dSamples,
+                                   double* dpPrevBeatSamples,
+                                   double* dpNextBeatSamples) const;
     virtual double findClosestBeat(double dSamples) const;
     virtual double findNthBeat(double dSamples, int n) const;
     virtual BeatIterator* findBeats(double startSample, double stopSample) const;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -54,6 +54,7 @@ class BeatMap : public QObject, public Beats {
 
     virtual double findNextBeat(double dSamples) const;
     virtual double findPrevBeat(double dSamples) const;
+    virtual QPair<double, double> findPrevNextBeats(double dSamples) const;
     virtual double findClosestBeat(double dSamples) const;
     virtual double findNthBeat(double dSamples, int n) const;
     virtual BeatIterator* findBeats(double startSample, double stopSample) const;

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -61,8 +61,16 @@ class Beats {
     // beat, dSamples is returned.
     virtual double findPrevBeat(double dSamples) const = 0;
 
+    // Starting from sample dSamples, return the sample of the previous beat
+    // and next beat.  Either can be -1 if none exists.  If dSamples refers
+    // to the location of the beat, the first value is dSamples, and the second
+    // value is the next beat position.  Non- -1 values are guaranteed to be
+    // even.
+    virtual QPair<double, double> findPrevNextBeats(double dSamples) const = 0;
+
     // Starting from sample dSamples, return the sample of the closest beat in
-    // the track, or -1 if none exists.
+    // the track, or -1 if none exists.  Non- -1 values are guaranteed to be
+    // even.
     virtual double findClosestBeat(double dSamples) const = 0;
 
     // Find the Nth beat from sample dSamples. Works with both positive and

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -51,6 +51,9 @@ class Beats {
     // Beat calculations
     ////////////////////////////////////////////////////////////////////////////
 
+    // TODO: We may want all of these find functions to return an integer
+    //       instead of a double.
+
     // Starting from sample dSamples, return the sample of the next beat in the
     // track, or -1 if none exists. If dSamples refers to the location of a
     // beat, dSamples is returned.

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -61,12 +61,15 @@ class Beats {
     // beat, dSamples is returned.
     virtual double findPrevBeat(double dSamples) const = 0;
 
-    // Starting from sample dSamples, return the sample of the previous beat
+    // Starting from sample dSamples, fill the samples of the previous beat
     // and next beat.  Either can be -1 if none exists.  If dSamples refers
     // to the location of the beat, the first value is dSamples, and the second
     // value is the next beat position.  Non- -1 values are guaranteed to be
-    // even.
-    virtual QPair<double, double> findPrevNextBeats(double dSamples) const = 0;
+    // even.  Returns false if *at least one* sample is -1.  (Can return false
+    // with one beat successfully filled)
+    virtual bool findPrevNextBeats(double dSamples,
+                                   double* dpPrevBeatSamples,
+                                   double* dpNextBeatSamples) const = 0;
 
     // Starting from sample dSamples, return the sample of the closest beat in
     // the track, or -1 if none exists.  Non- -1 values are guaranteed to be

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -53,6 +53,8 @@ class Beats {
 
     // TODO: We may want all of these find functions to return an integer
     //       instead of a double.
+    // TODO: We may want to implement these with common code that returns
+    //       the triple of closest, next, and prev.
 
     // Starting from sample dSamples, return the sample of the next beat in the
     // track, or -1 if none exists. If dSamples refers to the location of a


### PR DESCRIPTION
Change paired calls to findnext and findprev to use the new function.
Added tests to confirm it works as intended.
