### PR TITLE
Channel handle

### DIFF
--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -40,9 +40,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
           m_pSpeed(NULL),
           m_pPitch(NULL),
           m_replaygainPending(false) {
-    ChannelHandleAndGroup channelGroup =
-            pMixingEngine->registerChannelGroup(group);
-    m_pChannel = new EngineDeck(channelGroup, pConfig, pMixingEngine,
+    m_pChannel = new EngineDeck(group, pConfig, pMixingEngine,
                                 pEffectsManager, defaultOrientation);
 
     EngineBuffer* pEngineBuffer = m_pChannel->getEngineBuffer();

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -151,7 +151,7 @@ void EffectChain::enableForChannel(const ChannelHandleAndGroup& handle_group) {
         request->channel = handle_group.handle();
         m_pEffectsManager->writeRequest(request);
 
-        emit(channelStatusChanged(handle_group.name(), true));
+        emit(channelStatusChanged(handle_group.group(), true));
     }
 }
 
@@ -171,7 +171,7 @@ void EffectChain::disableForChannel(const ChannelHandleAndGroup& handle_group) {
         request->channel = handle_group.handle();
         m_pEffectsManager->writeRequest(request);
 
-        emit(channelStatusChanged(handle_group.name(), false));
+        emit(channelStatusChanged(handle_group.group(), false));
     }
 }
 

--- a/src/effects/effectchainmanager.cpp
+++ b/src/effects/effectchainmanager.cpp
@@ -20,15 +20,15 @@ EffectChainManager::~EffectChainManager() {
 }
 
 ChannelHandle EffectChainManager::registerChannel(const QString& group) {
-    ChannelHandle handle(m_registeredChannels.size());
-    ChannelHandleAndGroup handle_group(handle, group);
     foreach(ChannelHandleAndGroup hg, m_registeredChannels) {
         if (group == hg.group()) {
             qWarning() << debugString() << "WARNING: Channel already registered:"
-                       << handle_group.group();
+                       << group;
             return hg.handle();
         }
     }
+    ChannelHandle handle(m_registeredChannels.size());
+    ChannelHandleAndGroup handle_group(handle, group);
     m_registeredChannels.append(handle_group);
 
     foreach (StandardEffectRackPointer pRack, m_standardEffectRacks) {

--- a/src/effects/effectchainmanager.cpp
+++ b/src/effects/effectchainmanager.cpp
@@ -19,17 +19,20 @@ EffectChainManager::~EffectChainManager() {
     //qDebug() << debugString() << "destroyed";
 }
 
-void EffectChainManager::registerChannel(const ChannelHandleAndGroup& handle_group) {
+ChannelHandle EffectChainManager::registerChannel(const QString& group) {
+    ChannelHandle handle = m_groupHandleFactory.getOrCreateHandle(group);
+    ChannelHandleAndGroup handle_group(handle, group);
     if (m_registeredChannels.contains(handle_group)) {
         qWarning() << debugString() << "WARNING: Channel already registered:"
                    << handle_group.name();
-        return;
-    }
-    m_registeredChannels.insert(handle_group);
+    } else {
+        m_registeredChannels.insert(handle_group);
 
-    foreach (StandardEffectRackPointer pRack, m_standardEffectRacks) {
-        pRack->registerChannel(handle_group);
+        foreach (StandardEffectRackPointer pRack, m_standardEffectRacks) {
+            pRack->registerChannel(handle_group);
+        }
     }
+    return handle;
 }
 
 StandardEffectRackPointer EffectChainManager::addStandardEffectRack() {

--- a/src/effects/effectchainmanager.cpp
+++ b/src/effects/effectchainmanager.cpp
@@ -23,9 +23,9 @@ ChannelHandle EffectChainManager::registerChannel(const QString& group) {
     ChannelHandle handle(m_registeredChannels.size());
     ChannelHandleAndGroup handle_group(handle, group);
     foreach(ChannelHandleAndGroup hg, m_registeredChannels) {
-        if (group == hg.name()) {
+        if (group == hg.group()) {
             qWarning() << debugString() << "WARNING: Channel already registered:"
-                       << handle_group.name();
+                       << handle_group.group();
             return hg.handle();
         }
     }

--- a/src/effects/effectchainmanager.cpp
+++ b/src/effects/effectchainmanager.cpp
@@ -20,17 +20,19 @@ EffectChainManager::~EffectChainManager() {
 }
 
 ChannelHandle EffectChainManager::registerChannel(const QString& group) {
-    ChannelHandle handle = m_groupHandleFactory.getOrCreateHandle(group);
+    ChannelHandle handle(m_registeredChannels.size());
     ChannelHandleAndGroup handle_group(handle, group);
-    if (m_registeredChannels.contains(handle_group)) {
-        qWarning() << debugString() << "WARNING: Channel already registered:"
-                   << handle_group.name();
-    } else {
-        m_registeredChannels.insert(handle_group);
-
-        foreach (StandardEffectRackPointer pRack, m_standardEffectRacks) {
-            pRack->registerChannel(handle_group);
+    foreach(ChannelHandleAndGroup hg, m_registeredChannels) {
+        if (group == hg.name()) {
+            qWarning() << debugString() << "WARNING: Channel already registered:"
+                       << handle_group.name();
+            return hg.handle();
         }
+    }
+    m_registeredChannels.append(handle_group);
+
+    foreach (StandardEffectRackPointer pRack, m_standardEffectRacks) {
+        pRack->registerChannel(handle_group);
     }
     return handle;
 }

--- a/src/effects/effectchainmanager.h
+++ b/src/effects/effectchainmanager.h
@@ -66,7 +66,6 @@ class EffectChainManager : public QObject {
     QList<EffectChainPointer> m_effectChains;
     QSet<ChannelHandleAndGroup> m_registeredChannelsSet;
     QList<ChannelHandleAndGroup> m_registeredChannels;
-    ChannelHandleFactory m_groupHandleFactory;
     DISALLOW_COPY_AND_ASSIGN(EffectChainManager);
 };
 

--- a/src/effects/effectchainmanager.h
+++ b/src/effects/effectchainmanager.h
@@ -23,7 +23,7 @@ class EffectChainManager : public QObject {
                        EffectsManager* pEffectsManager);
     virtual ~EffectChainManager();
 
-    void registerChannel(const ChannelHandleAndGroup& handle_group);
+    ChannelHandle registerChannel(const QString& group);
     const QSet<ChannelHandleAndGroup>& registeredChannels() const {
         return m_registeredChannels;
     }
@@ -65,6 +65,7 @@ class EffectChainManager : public QObject {
     QHash<QString, EffectRackPointer> m_effectRacksByGroup;
     QList<EffectChainPointer> m_effectChains;
     QSet<ChannelHandleAndGroup> m_registeredChannels;
+    ChannelHandleFactory m_groupHandleFactory;
     DISALLOW_COPY_AND_ASSIGN(EffectChainManager);
 };
 

--- a/src/effects/effectchainmanager.h
+++ b/src/effects/effectchainmanager.h
@@ -64,7 +64,6 @@ class EffectChainManager : public QObject {
     QList<QuickEffectRackPointer> m_quickEffectRacks;
     QHash<QString, EffectRackPointer> m_effectRacksByGroup;
     QList<EffectChainPointer> m_effectChains;
-    QSet<ChannelHandleAndGroup> m_registeredChannelsSet;
     QList<ChannelHandleAndGroup> m_registeredChannels;
     DISALLOW_COPY_AND_ASSIGN(EffectChainManager);
 };

--- a/src/effects/effectchainmanager.h
+++ b/src/effects/effectchainmanager.h
@@ -24,7 +24,7 @@ class EffectChainManager : public QObject {
     virtual ~EffectChainManager();
 
     ChannelHandle registerChannel(const QString& group);
-    const QSet<ChannelHandleAndGroup>& registeredChannels() const {
+    const QList<ChannelHandleAndGroup>& registeredChannels() const {
         return m_registeredChannels;
     }
 
@@ -64,7 +64,8 @@ class EffectChainManager : public QObject {
     QList<QuickEffectRackPointer> m_quickEffectRacks;
     QHash<QString, EffectRackPointer> m_effectRacksByGroup;
     QList<EffectChainPointer> m_effectChains;
-    QSet<ChannelHandleAndGroup> m_registeredChannels;
+    QSet<ChannelHandleAndGroup> m_registeredChannelsSet;
+    QList<ChannelHandleAndGroup> m_registeredChannels;
     ChannelHandleFactory m_groupHandleFactory;
     DISALLOW_COPY_AND_ASSIGN(EffectChainManager);
 };

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -266,19 +266,19 @@ EffectSlotPointer EffectChainSlot::addEffectSlot(const QString& group) {
 }
 
 void EffectChainSlot::registerChannel(const ChannelHandleAndGroup& handle_group) {
-    if (m_channelInfoByName.contains(handle_group.name())) {
+    if (m_channelInfoByName.contains(handle_group.group())) {
         qWarning() << debugString()
                    << "WARNING: registerChannel already has channel registered:"
-                   << handle_group.name();
+                   << handle_group.group();
         return;
     }
     ControlPushButton* pEnableControl = new ControlPushButton(
-            ConfigKey(m_group, QString("group_%1_enable").arg(handle_group.name())));
+            ConfigKey(m_group, QString("group_%1_enable").arg(handle_group.group())));
     pEnableControl->setButtonMode(ControlPushButton::POWERWINDOW);
 
     ChannelInfo* pInfo = new ChannelInfo(handle_group, pEnableControl);
-    m_channelInfoByName[handle_group.name()] = pInfo;
-    m_channelStatusMapper.setMapping(pEnableControl, handle_group.name());
+    m_channelInfoByName[handle_group.group()] = pInfo;
+    m_channelStatusMapper.setMapping(pEnableControl, handle_group.group());
     connect(pEnableControl, SIGNAL(valueChanged(double)),
             &m_channelStatusMapper, SLOT(map()));
 }

--- a/src/effects/effectprocessor.h
+++ b/src/effects/effectprocessor.h
@@ -24,7 +24,7 @@ class EffectProcessor {
     virtual ~EffectProcessor() { }
 
     virtual void initialize(
-            const QSet<ChannelHandleAndGroup>& registeredChannels) = 0;
+            const QList<ChannelHandleAndGroup>& registeredChannels) = 0;
 
     // Take a buffer of numSamples samples of audio from a channel, provided as
     // pInput, process the buffer according to Effect-specific logic, and output
@@ -65,7 +65,7 @@ class PerChannelEffectProcessor : public EffectProcessor {
     }
 
     virtual void initialize(
-            const QSet<ChannelHandleAndGroup>& registeredChannels) {
+            const QList<ChannelHandleAndGroup>& registeredChannels) {
         foreach (const ChannelHandleAndGroup& channel, registeredChannels) {
             getOrCreateChannelState(channel.handle());
         }
@@ -94,6 +94,8 @@ class PerChannelEffectProcessor : public EffectProcessor {
     inline T* getOrCreateChannelState(const ChannelHandle& handle) {
         ChannelStateHolder& holder = m_channelState[handle];
         if (holder.state == NULL) {
+            // holder is the reference to fresh constructed the array
+            // element. Now we link a new ChannelState object to it.
             holder.state = new T();
         }
         return holder.state;

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -260,7 +260,7 @@ EffectChainSlotPointer PerGroupRack::addEffectChainSlotForGroup(const QString& g
     // TODO(rryan): remove.
     foreach (const ChannelHandleAndGroup& handle_group,
              m_pEffectChainManager->registeredChannels()) {
-        if (handle_group.name() == groupName) {
+        if (handle_group.group() == groupName) {
             configureEffectChainSlotForGroup(pChainSlotPointer, handle_group);
             return pChainSlotPointer;
         }
@@ -290,7 +290,7 @@ void QuickEffectRack::configureEffectChainSlotForGroup(
 
     // Add a single EffectSlot for the quick effect.
     pSlot->addEffectSlot(QuickEffectRack::formatEffectSlotGroupString(
-            getRackNumber(), handle_group.name()));
+            getRackNumber(), handle_group.group()));
 
     // TODO(rryan): Set up next/prev signals.
 
@@ -325,7 +325,7 @@ bool QuickEffectRack::loadEffectToGroup(const QString& groupName,
         // TODO(rryan): remove.
         foreach (const ChannelHandleAndGroup& handle_group,
                  m_pEffectChainManager->registeredChannels()) {
-            if (handle_group.name() == groupName) {
+            if (handle_group.group() == groupName) {
                 pChain->enableForChannel(handle_group);
             }
         }
@@ -365,7 +365,7 @@ bool EqualizerRack::loadEffectToGroup(const QString& groupName,
         // TODO(rryan): remove.
         foreach (const ChannelHandleAndGroup& handle_group,
                  m_pEffectChainManager->registeredChannels()) {
-            if (handle_group.name() == groupName) {
+            if (handle_group.group() == groupName) {
                 pChain->enableForChannel(handle_group);
             }
         }
@@ -379,7 +379,7 @@ bool EqualizerRack::loadEffectToGroup(const QString& groupName,
 
 void EqualizerRack::configureEffectChainSlotForGroup(EffectChainSlotPointer pSlot,
                                                      const ChannelHandleAndGroup& handle_group) {
-    const QString& groupName = handle_group.name();
+    const QString& groupName = handle_group.group();
 
     // Register this channel alone with the chain slot.
     pSlot->registerChannel(handle_group);

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -218,9 +218,8 @@ EffectChainSlotPointer StandardEffectRack::addEffectChainSlot() {
             this, SLOT(loadPrevEffect(unsigned int, unsigned int, EffectPointer)));
 
     // Register all the existing channels with the new EffectChain.
-    const QSet<ChannelHandleAndGroup>& registeredChannels =
-            m_pEffectChainManager->registeredChannels();
-    foreach (const ChannelHandleAndGroup& handle_group, registeredChannels) {
+    foreach (const ChannelHandleAndGroup& handle_group,
+            m_pEffectChainManager->registeredChannels()) {
         pChainSlot->registerChannel(handle_group);
     }
 

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -62,8 +62,8 @@ void EffectsManager::addEffectsBackend(EffectsBackend* pBackend) {
             this, SIGNAL(availableEffectsUpdated()));
 }
 
-void EffectsManager::registerChannel(const ChannelHandleAndGroup& handle_group) {
-    m_pEffectChainManager->registerChannel(handle_group);
+ChannelHandle EffectsManager::registerChannel(const QString& group) {
+    return m_pEffectChainManager->registerChannel(group);
 }
 
 const QSet<ChannelHandleAndGroup>& EffectsManager::registeredChannels() const {

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -66,7 +66,7 @@ ChannelHandle EffectsManager::registerChannel(const QString& group) {
     return m_pEffectChainManager->registerChannel(group);
 }
 
-const QSet<ChannelHandleAndGroup>& EffectsManager::registeredChannels() const {
+const QList<ChannelHandleAndGroup>& EffectsManager::registeredChannels() const {
     return m_pEffectChainManager->registeredChannels();
 }
 

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -44,7 +44,7 @@ class EffectsManager : public QObject {
     // takes ownership of the backend, and will delete it when EffectsManager is
     // being deleted. Not thread safe -- use only from the GUI thread.
     void addEffectsBackend(EffectsBackend* pEffectsBackend);
-    void registerChannel(const ChannelHandleAndGroup& handle_group);
+    ChannelHandle registerChannel(const QString& group);
     const QSet<ChannelHandleAndGroup>& registeredChannels() const;
 
     StandardEffectRackPointer addStandardEffectRack();

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -45,7 +45,7 @@ class EffectsManager : public QObject {
     // being deleted. Not thread safe -- use only from the GUI thread.
     void addEffectsBackend(EffectsBackend* pEffectsBackend);
     ChannelHandle registerChannel(const QString& group);
-    const QSet<ChannelHandleAndGroup>& registeredChannels() const;
+    const QList<ChannelHandleAndGroup>& registeredChannels() const;
 
     StandardEffectRackPointer addStandardEffectRack();
     StandardEffectRackPointer getStandardEffectRack(int rack);

--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -75,13 +75,13 @@ inline uint qHash(const ChannelHandle& handle) {
 // custom equality and hash methods that save the cost of touching the QString.
 class ChannelHandleAndGroup {
   public:
-    ChannelHandleAndGroup(const ChannelHandle& handle, const QString& name)
+    ChannelHandleAndGroup(const ChannelHandle& handle, const QString& group)
             : m_handle(handle),
-              m_name(name) {
+              m_group(group) {
     }
 
-    inline const QString& name() const {
-        return m_name;
+    inline const QString& group() const {
+        return m_group;
     }
 
     inline const ChannelHandle& handle() const {
@@ -89,7 +89,7 @@ class ChannelHandleAndGroup {
     }
 
     const ChannelHandle m_handle;
-    const QString m_name;
+    const QString m_group;
 };
 
 inline bool operator==(const ChannelHandleAndGroup& g1, const ChannelHandleAndGroup& g2) {
@@ -101,7 +101,7 @@ inline bool operator!=(const ChannelHandleAndGroup& g1, const ChannelHandleAndGr
 }
 
 inline QDebug operator<<(QDebug stream, const ChannelHandleAndGroup& g) {
-    stream << "ChannelHandleAndGroup(" << g.name() << "," << g.handle() << ")";
+    stream << "ChannelHandleAndGroup(" << g.group() << "," << g.handle() << ")";
     return stream;
 }
 

--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -51,6 +51,7 @@ class ChannelHandle {
     int m_iHandle;
 
     friend class ChannelHandleFactory;
+    friend class EffectChainManager;
 };
 
 inline bool operator==(const ChannelHandle& h1, const ChannelHandle& h2) {
@@ -153,6 +154,7 @@ template <class T>
 class ChannelHandleMap {
     static const int kMaxExpectedGroups = 256;
     typedef QVarLengthArray<T, kMaxExpectedGroups> container_type;
+
   public:
     typedef typename QVarLengthArray<T, kMaxExpectedGroups>::const_iterator const_iterator;
     typedef typename QVarLengthArray<T, kMaxExpectedGroups>::iterator iterator;
@@ -206,6 +208,8 @@ class ChannelHandleMap {
   private:
     inline void maybeExpand(int iSize) {
         if (m_data.size() < iSize) {
+            // resize adds uninitialized POT types
+            // or calls T() for complex types
             m_data.resize(iSize);
         }
     }

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -3,7 +3,7 @@
 
 
 EngineEffect::EngineEffect(const EffectManifest& manifest,
-                           const QSet<ChannelHandleAndGroup>& registeredChannels,
+                           const QList<ChannelHandleAndGroup>& registeredChannels,
                            EffectInstantiatorPointer pInstantiator)
         : m_manifest(manifest),
           m_enableState(EffectProcessor::ENABLING),

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -19,7 +19,7 @@
 class EngineEffect : public EffectsRequestHandler {
   public:
     EngineEffect(const EffectManifest& manifest,
-                 const QSet<ChannelHandleAndGroup>& registeredChannels,
+                 const QList<ChannelHandleAndGroup>& registeredChannels,
                  EffectInstantiatorPointer pInstantiator);
     virtual ~EngineEffect();
 

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -215,8 +215,8 @@ void EngineEffectChain::process(const ChannelHandle& handle,
                 // TODO(rryan): benchmark applyGain followed by addWithGain versus
                 // copy2WithGain.
                 SampleUtil::copy2WithRampingGain(
-                    pInOut, pInOut, 1.0 - wet_gain_old, 1.0 - wet_gain,
-                    m_pBuffer, wet_gain_old, wet_gain, numSamples);
+                        pInOut, pInOut, 1.0 - wet_gain_old, 1.0 - wet_gain,
+                        m_pBuffer, wet_gain_old, wet_gain, numSamples);
             }
         }
     } else { // SEND mode: output = input + effect(input) * wet

--- a/src/engine/engineaux.cpp
+++ b/src/engine/engineaux.cpp
@@ -12,8 +12,8 @@
 #include "engine/effects/engineeffectsmanager.h"
 #include "controlaudiotaperpot.h"
 
-EngineAux::EngineAux(const ChannelHandleAndGroup& handle_group, EffectsManager* pEffectsManager)
-        : EngineChannel(handle_group, EngineChannel::CENTER),
+EngineAux::EngineAux(const QString& group, EffectsManager* pEffectsManager)
+        : EngineChannel(group, EngineChannel::CENTER),
           m_pEngineEffectsManager(pEffectsManager ? pEffectsManager->getEngineEffectsManager() : NULL),
           m_vuMeter(getGroup()),
           m_pEnabled(new ControlObject(ConfigKey(getGroup(), "enabled"))),
@@ -22,7 +22,8 @@ EngineAux::EngineAux(const ChannelHandleAndGroup& handle_group, EffectsManager* 
           m_sampleBuffer(NULL),
           m_wasActive(false) {
     if (pEffectsManager != NULL) {
-        pEffectsManager->registerChannel(handle_group);
+        ChannelHandle handle = pEffectsManager->registerChannel(group);
+        setEffectChannelHandle(handle);
     }
     m_pPassing->setButtonMode(ControlPushButton::POWERWINDOW);
 
@@ -99,7 +100,7 @@ void EngineAux::process(CSAMPLE* pOut, const int iBufferSize) {
         // volume.
         m_vuMeter.collectFeatures(&features);
         // Process effects enabled for this channel
-        m_pEngineEffectsManager->process(getHandle(), pOut, iBufferSize,
+        m_pEngineEffectsManager->process(getEffectChannelHandle(), pOut, iBufferSize,
                                          m_pSampleRate->get(), features);
     }
     // Update VU meter

--- a/src/engine/engineaux.h
+++ b/src/engine/engineaux.h
@@ -21,7 +21,7 @@ class ControlAudioTaperPot;
 class EngineAux : public EngineChannel, public AudioDestination {
     Q_OBJECT
   public:
-    EngineAux(const ChannelHandleAndGroup& handle_group, EffectsManager* pEffectsManager);
+    EngineAux(const QString& group, EffectsManager* pEffectsManager);
     virtual ~EngineAux();
 
     bool isActive();

--- a/src/engine/enginechannel.cpp
+++ b/src/engine/enginechannel.cpp
@@ -20,9 +20,9 @@
 #include "controlobject.h"
 #include "controlpushbutton.h"
 
-EngineChannel::EngineChannel(const ChannelHandleAndGroup& handle_group,
+EngineChannel::EngineChannel(const QString& group,
                              EngineChannel::ChannelOrientation defaultOrientation)
-        : m_group(handle_group) {
+        : m_group(group) {
     m_pPFL = new ControlPushButton(ConfigKey(getGroup(), "pfl"));
     m_pPFL->setButtonMode(ControlPushButton::TOGGLE);
     m_pMaster = new ControlPushButton(ConfigKey(getGroup(), "master"));

--- a/src/engine/enginechannel.h
+++ b/src/engine/enginechannel.h
@@ -38,18 +38,22 @@ class EngineChannel : public EngineObject {
         RIGHT,
     };
 
-    EngineChannel(const ChannelHandleAndGroup& handle_group,
+    EngineChannel(const QString& group,
                   ChannelOrientation defaultOrientation = CENTER);
     virtual ~EngineChannel();
 
     virtual ChannelOrientation getOrientation() const;
 
-    inline const ChannelHandle& getHandle() const {
-        return m_group.handle();
+    inline const ChannelHandle& getEffectChannelHandle() const {
+        return m_effectChannelHandle;
+    }
+
+    inline void setEffectChannelHandle(const ChannelHandle& handle) {
+        m_effectChannelHandle = handle;
     }
 
     virtual const QString& getGroup() const {
-        return m_group.name();
+        return m_group;
     }
 
     virtual bool isActive() = 0;
@@ -74,7 +78,8 @@ class EngineChannel : public EngineObject {
     void slotOrientationCenter(double v);
 
   private:
-    const ChannelHandleAndGroup m_group;
+    ChannelHandle m_effectChannelHandle;
+    const QString m_group;
     ControlPushButton* m_pMaster;
     ControlPushButton* m_pPFL;
     ControlPushButton* m_pOrientation;

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -26,12 +26,12 @@
 
 #include "sampleutil.h"
 
-EngineDeck::EngineDeck(const ChannelHandleAndGroup& handle_group,
+EngineDeck::EngineDeck(const QString& group,
                        ConfigObject<ConfigValue>* pConfig,
                        EngineMaster* pMixingEngine,
                        EffectsManager* pEffectsManager,
                        EngineChannel::ChannelOrientation defaultOrientation)
-        : EngineChannel(handle_group, defaultOrientation),
+        : EngineChannel(group, defaultOrientation),
           m_pConfig(pConfig),
           m_pEngineEffectsManager(pEffectsManager ? pEffectsManager->getEngineEffectsManager() : NULL),
           m_pPassing(new ControlPushButton(ConfigKey(getGroup(), "passthrough"))),
@@ -39,7 +39,8 @@ EngineDeck::EngineDeck(const ChannelHandleAndGroup& handle_group,
           // items to be held at once (it keeps a blank spot open persistently)
           m_sampleBuffer(NULL) {
     if (pEffectsManager != NULL) {
-        pEffectsManager->registerChannel(handle_group);
+        ChannelHandle handle = pEffectsManager->registerChannel(group);
+        setEffectChannelHandle(handle);
     }
 
     // Set up passthrough utilities and fields
@@ -101,7 +102,7 @@ void EngineDeck::process(CSAMPLE* pOut, const int iBufferSize) {
         // volume.
         m_pVUMeter->collectFeatures(&features);
         m_pEngineEffectsManager->process(
-                getHandle(), pOut, iBufferSize,
+                getEffectChannelHandle(), pOut, iBufferSize,
                 static_cast<unsigned int>(m_pSampleRate->get()), features);
     }
     // Update VU meter

--- a/src/engine/enginedeck.h
+++ b/src/engine/enginedeck.h
@@ -39,7 +39,7 @@ class ControlPushButton;
 class EngineDeck : public EngineChannel, public AudioDestination {
     Q_OBJECT
   public:
-    EngineDeck(const ChannelHandleAndGroup& handle_group, ConfigObject<ConfigValue>* pConfig,
+    EngineDeck(const QString& handle_group, ConfigObject<ConfigValue>* pConfig,
                EngineMaster* pMixingEngine, EffectsManager* pEffectsManager,
                EngineChannel::ChannelOrientation defaultOrientation = CENTER);
     virtual ~EngineDeck();

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -63,28 +63,23 @@ class EngineMaster : public QObject, public AudioSource {
     const CSAMPLE* buffer(AudioOutput output) const;
 
     inline const QString& getMasterGroup() const {
-        return m_masterHandle.name();
+        return m_masterGroup;
     }
 
     inline const QString& getHeadphoneGroup() const {
-        return m_headphoneHandle.name();
+        return m_headphoneGroup;
     }
 
     inline const QString& getBusLeftGroup() const {
-        return m_busLeftHandle.name();
+        return m_busLeftGroup;
     }
 
     inline const QString& getBusCenterGroup() const {
-        return m_busCenterHandle.name();
+        return m_busCenterGroup;
     }
 
     inline const QString& getBusRightGroup() const {
-        return m_busRightHandle.name();
-    }
-
-    ChannelHandleAndGroup registerChannelGroup(const QString& group) {
-        return ChannelHandleAndGroup(
-                m_groupHandleFactory.getOrCreateHandle(group), group);
+        return m_busRightGroup;
     }
 
     // WARNING: These methods are called by the main thread. They should only
@@ -140,7 +135,6 @@ class EngineMaster : public QObject, public AudioSource {
                   m_pMuteControl(NULL),
                   m_index(index) {
         }
-        ChannelHandle m_handle;
         EngineChannel* m_pChannel;
         CSAMPLE* m_pBuffer;
         ControlObject* m_pVolumeControl;
@@ -264,7 +258,6 @@ class EngineMaster : public QObject, public AudioSource {
             FastVector<ChannelInfo*, kMaxChannels>* talkoverChannels,
             int iBufferSize);
 
-    ChannelHandleFactory m_groupHandleFactory;
     EngineEffectsManager* m_pEngineEffectsManager;
     bool m_bRampingGain;
     FastVector<ChannelInfo*, kMaxChannels> m_channels;
@@ -313,11 +306,17 @@ class EngineMaster : public QObject, public AudioSource {
     CSAMPLE m_headphoneMasterGainOld;
     CSAMPLE m_headphoneGainOld;
 
-    const ChannelHandleAndGroup m_masterHandle;
-    const ChannelHandleAndGroup m_headphoneHandle;
-    const ChannelHandleAndGroup m_busLeftHandle;
-    const ChannelHandleAndGroup m_busCenterHandle;
-    const ChannelHandleAndGroup m_busRightHandle;
+    const QString m_masterGroup;
+    const QString m_headphoneGroup;
+    const QString m_busLeftGroup;
+    const QString m_busCenterGroup;
+    const QString m_busRightGroup;
+
+    ChannelHandle m_masterHandle;
+    ChannelHandle m_headphoneHandle;
+    ChannelHandle m_busLeftHandle;
+    ChannelHandle m_busCenterHandle;
+    ChannelHandle m_busRightHandle;
 
     // Produce the Master Mixxx, not Required if connected to left
     // and right Bus and no recording and broadcast active

--- a/src/engine/enginemicrophone.cpp
+++ b/src/engine/enginemicrophone.cpp
@@ -12,9 +12,9 @@
 #include "controlaudiotaperpot.h"
 
 
-EngineMicrophone::EngineMicrophone(const ChannelHandleAndGroup& handle_group,
+EngineMicrophone::EngineMicrophone(const QString& group,
                                    EffectsManager* pEffectsManager)
-        : EngineChannel(handle_group, EngineChannel::CENTER),
+        : EngineChannel(group, EngineChannel::CENTER),
           m_pEngineEffectsManager(pEffectsManager ? pEffectsManager->getEngineEffectsManager() : NULL),
           m_vuMeter(getGroup()),
           m_pEnabled(new ControlObject(ConfigKey(getGroup(), "enabled"))),
@@ -22,7 +22,8 @@ EngineMicrophone::EngineMicrophone(const ChannelHandleAndGroup& handle_group,
           m_sampleBuffer(NULL),
           m_wasActive(false) {
     if (pEffectsManager != NULL) {
-        pEffectsManager->registerChannel(handle_group);
+        ChannelHandle handle = pEffectsManager->registerChannel(group);
+        setEffectChannelHandle(handle);
     }
 
     setMaster(false); // Use "talkover" button to enable microphones
@@ -93,7 +94,7 @@ void EngineMicrophone::process(CSAMPLE* pOut, const int iBufferSize) {
         // This is out of date by a callback but some effects will want the RMS
         // volume.
         m_vuMeter.collectFeatures(&features);
-        m_pEngineEffectsManager->process(getHandle(), pOut, iBufferSize,
+        m_pEngineEffectsManager->process(getEffectChannelHandle(), pOut, iBufferSize,
                                          m_pSampleRate->get(), features);
     }
     // Update VU meter

--- a/src/engine/enginemicrophone.h
+++ b/src/engine/enginemicrophone.h
@@ -21,7 +21,7 @@ class ControlAudioTaperPot;
 class EngineMicrophone : public EngineChannel, public AudioDestination {
     Q_OBJECT
   public:
-    EngineMicrophone(const ChannelHandleAndGroup& handle_group,
+    EngineMicrophone(const QString& group,
                      EffectsManager* pEffectsManager);
     virtual ~EngineMicrophone();
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -177,10 +177,8 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
         if (i > 0) {
             group = QString("[Microphone%1]").arg(i + 1);
         }
-        ChannelHandleAndGroup channelGroup =
-                m_pEngine->registerChannelGroup(group);
         EngineMicrophone* pMicrophone =
-                new EngineMicrophone(channelGroup, m_pEffectsManager);
+                new EngineMicrophone(group, m_pEffectsManager);
 
         // What should channelbase be?
         AudioInput micInput = AudioInput(AudioPath::MICROPHONE, 0, 0, i);
@@ -202,8 +200,7 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
 
     for (int i = 0; i < kAuxiliaryCount; ++i) {
         QString group = QString("[Auxiliary%1]").arg(i + 1);
-        ChannelHandleAndGroup channelGroup = m_pEngine->registerChannelGroup(group);
-        EngineAux* pAux = new EngineAux(channelGroup, m_pEffectsManager);
+        EngineAux* pAux = new EngineAux(group, m_pEffectsManager);
 
         // What should channelbase be?
         AudioInput auxInput = AudioInput(AudioPath::AUXILIARY, 0, 0, i);

--- a/src/test/baseeffecttest.h
+++ b/src/test/baseeffecttest.h
@@ -41,7 +41,7 @@ class MockEffectProcessor : public EffectProcessor {
                                const EffectProcessor::EnableState enableState,
                                const GroupFeatureState& groupFeatures));
 
-    MOCK_METHOD1(initialize, void(const QSet<ChannelHandleAndGroup>& registeredChannels));
+    MOCK_METHOD1(initialize, void(const QList<ChannelHandleAndGroup>& registeredChannels));
 };
 
 class MockEffectInstantiator : public EffectInstantiator {

--- a/src/test/effectchainslottest.cpp
+++ b/src/test/effectchainslottest.cpp
@@ -17,14 +17,12 @@ using ::testing::_;
 
 class EffectChainSlotTest : public BaseEffectTest {
   protected:
-    EffectChainSlotTest()
-            : m_master(m_factory.getOrCreateHandle("[Master]"), "[Master]"),
-              m_headphone(m_factory.getOrCreateHandle("[Headphone]"), "[Headphone]") {
-        m_pEffectsManager->registerChannel(m_master);
-        m_pEffectsManager->registerChannel(m_headphone);
+    EffectChainSlotTest() :
+        m_master(ChannelHandleAndGroup(
+               m_pEffectsManager->registerChannel("[Master]"), "[Master]")),
+        m_headphone(ChannelHandleAndGroup(
+               m_pEffectsManager->registerChannel("[Headphone]"), "[Headphone]")) {
     }
-
-    ChannelHandleFactory m_factory;
     ChannelHandleAndGroup m_master;
     ChannelHandleAndGroup m_headphone;
 };

--- a/src/test/effectslottest.cpp
+++ b/src/test/effectslottest.cpp
@@ -19,14 +19,12 @@ using ::testing::_;
 class EffectSlotTest : public BaseEffectTest {
   protected:
     EffectSlotTest()
-            : m_master(m_factory.getOrCreateHandle("[Master]"), "[Master]"),
-              m_headphone(m_factory.getOrCreateHandle("[Headphone]"), "[Headphone]") {
-        m_pEffectsManager->registerChannel(m_master);
-        m_pEffectsManager->registerChannel(m_headphone);
+            : m_master(ChannelHandleAndGroup(
+                    m_pEffectsManager->registerChannel("[Master]"), "[Master]")),
+              m_headphone(ChannelHandleAndGroup(
+                      m_pEffectsManager->registerChannel("[Headphone]"), "[Headphone]")) {
         registerTestBackend();
     }
-
-    ChannelHandleFactory m_factory;
     ChannelHandleAndGroup m_master;
     ChannelHandleAndGroup m_headphone;
 };

--- a/src/test/enginemastertest.cpp
+++ b/src/test/enginemastertest.cpp
@@ -22,8 +22,8 @@ class EngineChannelMock : public EngineChannel {
     EngineChannelMock(const QString& group,
                       ChannelOrientation defaultOrientation,
                       EngineMaster* pMaster)
-            : EngineChannel(pMaster->registerChannelGroup(group),
-                            defaultOrientation) {
+            : EngineChannel(group, defaultOrientation) {
+        Q_UNUSED(pMaster);
     }
 
     void applyVolume(CSAMPLE* pBuff, const int iBufferSize) {

--- a/src/test/enginemicrophonetest.cpp
+++ b/src/test/enginemicrophonetest.cpp
@@ -22,8 +22,7 @@ class EngineMicrophoneTest : public testing::Test {
         test = SampleUtil::alloc(outputLength);
 
         // No need for a real handle in this test.
-        m_pMicrophone = new EngineMicrophone(
-                ChannelHandleAndGroup(ChannelHandle(), "[Microphone]"), NULL);
+        m_pMicrophone = new EngineMicrophone("[Microphone]", NULL);
         m_pTalkover = ControlObject::getControl(ConfigKey("[Microphone]", "talkover"));
     }
 

--- a/src/test/mockedenginebackendtest.h
+++ b/src/test/mockedenginebackendtest.h
@@ -51,15 +51,15 @@ class MockedEngineBackendTest : public MixxxTest {
                                            m_pEffectsManager, false, false);
 
         m_pChannel1 = new EngineDeck(
-                m_pEngineMaster->registerChannelGroup(m_sGroup1),
+                m_sGroup1,
                 m_pConfig.data(), m_pEngineMaster, m_pEffectsManager,
                 EngineChannel::CENTER);
         m_pChannel2 = new EngineDeck(
-                m_pEngineMaster->registerChannelGroup(m_sGroup2),
+                m_sGroup2,
                 m_pConfig.data(), m_pEngineMaster, m_pEffectsManager,
                 EngineChannel::CENTER);
         m_pChannel3 = new EngineDeck(
-                m_pEngineMaster->registerChannelGroup(m_sGroup3),
+                m_sGroup3,
                 m_pConfig.data(), m_pEngineMaster, m_pEffectsManager,
                 EngineChannel::CENTER);
         m_pPreview1 = new PreviewDeck(NULL, m_pConfig.data(),

--- a/src/test/super_link_test.cpp
+++ b/src/test/super_link_test.cpp
@@ -12,10 +12,10 @@
 class SuperLinkTest : public BaseEffectTest {
   protected:
     SuperLinkTest()
-            : m_master(m_factory.getOrCreateHandle("[Master]"), "[Master]"),
-              m_headphone(m_factory.getOrCreateHandle("[Headphone]"), "[Headphone]") {
-        m_pEffectsManager->registerChannel(m_master);
-        m_pEffectsManager->registerChannel(m_headphone);
+            : m_master(ChannelHandleAndGroup(
+                    m_pEffectsManager->registerChannel("[Master]"), "[Master]")),
+              m_headphone(ChannelHandleAndGroup(
+                      m_pEffectsManager->registerChannel("[Headphone]"), "[Headphone]")) {
         registerTestBackend();
 
         EffectChainPointer pChain(new EffectChain(m_pEffectsManager.data(),
@@ -68,7 +68,6 @@ class SuperLinkTest : public BaseEffectTest {
                 itemPrefix + QString("_link_inverse")));
     }
 
-    ChannelHandleFactory m_factory;
     ChannelHandleAndGroup m_master;
     ChannelHandleAndGroup m_headphone;
 


### PR DESCRIPTION
This is now a version that uses the EffectChainManager as indexing Domain for the Effect framework. 

This has some advantage, the registration process is streamlined. 
Imho it is also better to understand, base it focuses exactly the problem.

I have changed the indexing container class to a QList, that allows much (x45)  faster iterations over the whole list.
Hers some test data for container class filled with key values from 0 ... 999
The time is in ns for 10000 iterations.

Iteration
Debug [Main]: list      51,314,075 
Debug [Main]: set 2,296,160,300 
Debug [Main]: map  262,436,844 

Contains()
Debug [Main]: list    41,891,643 
Debug [Main]: set   10,882,746
Debug [Main]: map 24,066,919 

I have also noticed that you have placed some todos for removing the list access. 
They are not at time critical path, but removing this will need some work we can do later.
