### PR TITLE
Remove 32-channel restriction in the engine.

### DIFF
--- a/scripts/generate_sample_functions.py
+++ b/scripts/generate_sample_functions.py
@@ -42,8 +42,8 @@ def write_channelmixer_autogen(output, num_channels):
         else:
             header = 'void ChannelMixer::mixChannels('
         args = ['const EngineMaster::GainCalculator& gainCalculator',
-                'EngineMaster::FastVector<EngineMaster::ChannelInfo*, kMaxChannels>* activeChannels',
-                'EngineMaster::FastVector<EngineMaster::GainCache, kMaxChannels>* channelGainCache',
+                'QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>* activeChannels',
+                'QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>* channelGainCache',
                 'CSAMPLE* pOutput',
                 'unsigned int iBufferSize']
         output.extend(hanging_indent(header, args, ',', ') {'))

--- a/src/engine/channelmixer.h
+++ b/src/engine/channelmixer.h
@@ -1,6 +1,8 @@
 #ifndef CHANNELMIXER_H
 #define CHANNELMIXER_H
 
+#include <QVarLengthArray>
+
 #include "util/types.h"
 #include "engine/enginemaster.h"
 
@@ -8,14 +10,14 @@ class ChannelMixer {
   public:
     static void mixChannels(
         const EngineMaster::GainCalculator& gainCalculator,
-        EngineMaster::FastVector<EngineMaster::ChannelInfo*, kMaxChannels>* activeChannels,
-        EngineMaster::FastVector<EngineMaster::GainCache, kMaxChannels>* channelGainCache,
+        QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>* activeChannels,
+        QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>* channelGainCache,
         CSAMPLE* pOutput,
         unsigned int iBufferSize);
     static void mixChannelsRamping(
         const EngineMaster::GainCalculator& gainCalculator,
-        EngineMaster::FastVector<EngineMaster::ChannelInfo*, kMaxChannels>* activeChannels,
-        EngineMaster::FastVector<EngineMaster::GainCache, kMaxChannels>* channelGainCache,
+        QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>* activeChannels,
+        QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>* channelGainCache,
         CSAMPLE* pOutput,
         unsigned int iBufferSize);
 };

--- a/src/engine/channelmixer_autogen.cpp
+++ b/src/engine/channelmixer_autogen.cpp
@@ -8,8 +8,8 @@
 
 // static
 void ChannelMixer::mixChannels(const EngineMaster::GainCalculator& gainCalculator,
-                               EngineMaster::FastVector<EngineMaster::ChannelInfo*, kMaxChannels>* activeChannels,
-                               EngineMaster::FastVector<EngineMaster::GainCache, kMaxChannels>* channelGainCache,
+                               QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>* activeChannels,
+                               QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>* channelGainCache,
                                CSAMPLE* pOutput,
                                unsigned int iBufferSize) {
     int totalActive = activeChannels->size();
@@ -6534,8 +6534,8 @@ void ChannelMixer::mixChannels(const EngineMaster::GainCalculator& gainCalculato
     }
 }
 void ChannelMixer::mixChannelsRamping(const EngineMaster::GainCalculator& gainCalculator,
-                                      EngineMaster::FastVector<EngineMaster::ChannelInfo*, kMaxChannels>* activeChannels,
-                                      EngineMaster::FastVector<EngineMaster::GainCache, kMaxChannels>* channelGainCache,
+                                      QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>* activeChannels,
+                                      QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>* channelGainCache,
                                       CSAMPLE* pOutput,
                                       unsigned int iBufferSize) {
     int totalActive = activeChannels->size();


### PR DESCRIPTION
- Replace FastVector with QVarLengthArray.
- Pre-allocate QVarLengthArray mixing scratch buffers in
  EngineMaster::addChannel to eliminate the risk of allocation in the
  callback.
- Pre-allocate 64 channels since we are pretty close to 32 in a
  SampleGrid-style skin.

No allocation will ever occur in the callback. For users who want more than
32 channels Mixxx will behave correctly but more slowly since
ChannelMixer will fall back on mixing channels one by one.

Since Q_ASSERT is no longer active in release builds
QVarLengthArray::operator[] inlines to a memory access so it is
equivalent in speed to FastVector.
