### PR TITLE
Move EngineControl::pickSyncTarget to EngineSync.

### DIFF
--- a/src/engine/sync/enginesync.h
+++ b/src/engine/sync/enginesync.h
@@ -47,6 +47,9 @@ class EngineSync : public BaseSyncableListener {
     void notifyScratching(Syncable* pSyncable, bool scratching);
     void notifyTrackLoaded(Syncable* pSyncable, double suggested_bpm);
 
+    // Used to pick a sync target for non-master-sync mode.
+    EngineChannel* pickNonSyncSyncTarget(EngineChannel* pDontPick) const;
+
   private:
     // Activate a specific syncable as master.
     void activateMaster(Syncable* pSyncable);


### PR DESCRIPTION
Turns an O(n^2) loop over decks into an O(n) loop. Also drops the group string formatting.
