### PR TITLE
Remove vinyl control mode preference.  

### DIFF
--- a/src/dlgprefvinyl.cpp
+++ b/src/dlgprefvinyl.cpp
@@ -38,11 +38,6 @@ DlgPrefVinyl::DlgPrefVinyl(QWidget * parent, VinylControlManager *pVCMan,
 
     setupUi(this);
 
-    //Set up a button group for the vinyl control behavior options
-    QButtonGroup vinylControlMode;
-    vinylControlMode.addButton(AbsoluteMode);
-    vinylControlMode.addButton(RelativeMode);
-
     delete groupBoxSignalQuality->layout();
     QHBoxLayout *layout = new QHBoxLayout;
 
@@ -187,8 +182,6 @@ void DlgPrefVinyl::slotResetToDefaults() {
     LeadinTime2->setText(QString("%1").arg(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN));
     LeadinTime3->setText(QString("%1").arg(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN));
     LeadinTime4->setText(QString("%1").arg(MIXXX_VINYL_SERATOCV02VINYLSIDEA_LEADIN));
-    AbsoluteMode->setChecked(false);
-    RelativeMode->setChecked(true);
     SignalQualityEnable->setChecked(true);
     VinylGain->setValue(0);
 }
@@ -254,13 +247,6 @@ void DlgPrefVinyl::slotUpdate() {
     LeadinTime4->setText(config->getValueString(ConfigKey("[Channel4]",
                                                           "vinylcontrol_lead_in_time"), "0"));
 
-    // set Relative mode
-    int iMode = config->getValueString(ConfigKey(VINYL_PREF_KEY,"mode")).toInt();
-    if (iMode == MIXXX_VCMODE_ABSOLUTE)
-        AbsoluteMode->setChecked(true);
-    else if (iMode == MIXXX_VCMODE_RELATIVE)
-        RelativeMode->setChecked(true);
-
     SignalQualityEnable->setChecked(
             (bool)config->getValueString(ConfigKey(VINYL_PREF_KEY, "show_signal_quality")).toInt());
 
@@ -316,13 +302,6 @@ void DlgPrefVinyl::slotApply()
     VinylTypeSlotApply();
     VinylGainSlotApply();
 
-    int iMode = 0;
-    if (AbsoluteMode->isChecked())
-        iMode = MIXXX_VCMODE_ABSOLUTE;
-    if (RelativeMode->isChecked())
-        iMode = MIXXX_VCMODE_RELATIVE;
-
-    config->set(ConfigKey(VINYL_PREF_KEY, "mode"), ConfigValue(iMode));
     config->set(ConfigKey(VINYL_PREF_KEY,"show_signal_quality"),
                 ConfigValue((int)(SignalQualityEnable->isChecked())));
 

--- a/src/dlgprefvinyl.cpp
+++ b/src/dlgprefvinyl.cpp
@@ -89,6 +89,7 @@ DlgPrefVinyl::DlgPrefVinyl(QWidget * parent, VinylControlManager *pVCMan,
     ComboBoxVinylSpeed4->addItem(MIXXX_VINYL_SPEED_33);
     ComboBoxVinylSpeed4->addItem(MIXXX_VINYL_SPEED_45);
 
+    // TODO: Convert gain to logarithmic and db visual scale.
     connect(VinylGain, SIGNAL(sliderReleased()), this, SLOT(VinylGainSlotApply()));
     //connect(ComboBoxDeviceDeck1, SIGNAL(currentIndexChanged()), this, SLOT(()));
 

--- a/src/dlgprefvinyldlg.ui
+++ b/src/dlgprefvinyldlg.ui
@@ -14,57 +14,6 @@
    <string>Vinyl Control Preferences</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="2" column="0" rowspan="3">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Control Mode</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-     <layout class="QVBoxLayout">
-      <item>
-       <widget class="QRadioButton" name="AbsoluteMode">
-        <property name="text">
-         <string>Absolute Mode</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="RelativeMode">
-        <property name="text">
-         <string>Relative Mode</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="1" column="0" colspan="3">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
@@ -735,7 +684,7 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="1" rowspan="3" colspan="2">
+   <item row="2" column="0" rowspan="2" colspan="1">
     <widget class="QGroupBox" name="groupBoxSignalQuality">
      <property name="title">
       <string>Signal Quality</string>
@@ -760,7 +709,7 @@
      </layout>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="5" column="1">
     <widget class="QLabel" name="label">
      <property name="enabled">
       <bool>false</bool>
@@ -776,7 +725,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="3">
+   <item row="4" column="0" colspan="3">
     <widget class="QGroupBox" name="Hints">
      <property name="title">
       <string>Hints</string>
@@ -808,7 +757,7 @@
      </layout>
     </widget>
    </item>
-   <item row="7" column="2">
+   <item row="6" column="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/vinylcontrol/vinylcontrolmanager.cpp
+++ b/src/vinylcontrol/vinylcontrolmanager.cpp
@@ -42,9 +42,12 @@ VinylControlManager::~VinylControlManager() {
     for (int i = 0; i < m_iNumConfiguredDecks; ++i) {
         QString group = PlayerManager::groupForDeck(i);
         m_pConfig->set(ConfigKey(group, "vinylcontrol_enabled"), false);
-        m_pConfig->set(ConfigKey(VINYL_PREF_KEY, QString("cueing_ch%1").arg(i)),
-            ConfigValue((int)ControlObject::get(
-                ConfigKey(group, "vinylcontrol_cueing"))));
+        m_pConfig->set(ConfigKey(VINYL_PREF_KEY, QString("cueing_ch%1").arg(i + 1)),
+            ConfigValue(static_cast<int>(ControlObject::get(
+                ConfigKey(group, "vinylcontrol_cueing")))));
+        m_pConfig->set(ConfigKey(VINYL_PREF_KEY, QString("mode_ch%1").arg(i + 1)),
+            ConfigValue(static_cast<int>(ControlObject::get(
+                ConfigKey(group, "vinylcontrol_mode")))));
     }
 }
 
@@ -75,12 +78,17 @@ void VinylControlManager::slotNumDecksChanged(double dNumDecks) {
         m_pVcEnabled.push_back(new ControlObjectThread(group, "vinylcontrol_enabled", this));
         m_pVcEnabled.back()->set(0);
 
-        ControlObject::set(ConfigKey(group, "vinylcontrol_mode"),
-                           m_pConfig->getValueString(ConfigKey(VINYL_PREF_KEY, "mode")).toDouble());
-
+        // Default cueing should be off.
         ControlObject::set(ConfigKey(group, "vinylcontrol_cueing"),
-                           m_pConfig->getValueString(ConfigKey(VINYL_PREF_KEY,
-                                                               "cueing_ch1")).toDouble());
+                           m_pConfig->getValueString(ConfigKey(
+                                   VINYL_PREF_KEY,
+                                   QString("cueing_ch%1").arg(i + 1)), "0").toDouble());
+        // Default mode should be relative.
+        const QString kDefaultMode = QString::number(MIXXX_VCMODE_RELATIVE);
+        ControlObject::set(ConfigKey(group, "vinylcontrol_mode"),
+                           m_pConfig->getValueString(ConfigKey(
+                                   VINYL_PREF_KEY,
+                                   QString("mode_ch%1").arg(i + 1)), kDefaultMode).toDouble());
     }
     m_iNumConfiguredDecks = num_decks;
 }


### PR DESCRIPTION
Instead remember last-used mode per-deck, the same as we do for cueing mode.

https://bugs.launchpad.net/mixxx/+bug/1417275
