### PR TITLE
Make RGB overview use colors from skin

### DIFF
--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -62,6 +62,17 @@ bool WOverviewRGB::drawNextPixmapPart() {
 
     unsigned char low, mid, high;
 
+    qreal lowColor_r, lowColor_g, lowColor_b;
+    m_signalColors.getRgbLowColor().getRgbF(&lowColor_r, &lowColor_g, &lowColor_b);
+
+    qreal midColor_r, midColor_g, midColor_b;
+    m_signalColors.getRgbMidColor().getRgbF(&midColor_r, &midColor_g, &midColor_b);
+
+    qreal highColor_r, highColor_g, highColor_b;
+    m_signalColors.getRgbHighColor().getRgbF(&highColor_r, &highColor_g, &highColor_b);
+
+    float red, green, blue;
+
     // Maximum is needed for normalization
     float max;
 
@@ -75,9 +86,13 @@ bool WOverviewRGB::drawNextPixmapPart() {
         mid = pWaveform->getMid(currentCompletion);
         high = pWaveform->getHigh(currentCompletion);
 
-        max = (float) math_max3(low, mid, high);
+        red   = low * lowColor_r + mid * midColor_r + high * highColor_r;
+        green = low * lowColor_g + mid * midColor_g + high * highColor_g;
+        blue  = low * lowColor_b + mid * midColor_b + high * highColor_b;
+
+        max = math_max3(red, green, blue);
         if (max > 0.0f) {
-            color.setRgbF(low / max, mid / max, high / max);
+            color.setRgbF(red / max, green / max, blue / max);
             painter.setPen(color);
             painter.drawLine(currentCompletion / 2, -left, currentCompletion / 2, 0);
         }
@@ -86,9 +101,13 @@ bool WOverviewRGB::drawNextPixmapPart() {
         mid = pWaveform->getMid(currentCompletion + 1);
         high = pWaveform->getHigh(currentCompletion + 1);
 
-        max = (float) math_max3(low, mid, high);
+        red   = low * lowColor_r + mid * midColor_r + high * highColor_r;
+        green = low * lowColor_g + mid * midColor_g + high * highColor_g;
+        blue  = low * lowColor_b + mid * midColor_b + high * highColor_b;
+
+        max = math_max3(red, green, blue);
         if (max > 0.0f) {
-            color.setRgbF(low / max, mid / max, high / max);
+            color.setRgbF(red / max, green / max, blue / max);
             painter.setPen(color);
             painter.drawLine(currentCompletion / 2, 0, currentCompletion / 2, right);
         }

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -60,8 +60,6 @@ bool WOverviewRGB::drawNextPixmapPart() {
 
     QColor color;
 
-    unsigned char low, mid, high;
-
     qreal lowColor_r, lowColor_g, lowColor_b;
     m_signalColors.getRgbLowColor().getRgbF(&lowColor_r, &lowColor_g, &lowColor_b);
 
@@ -71,10 +69,12 @@ bool WOverviewRGB::drawNextPixmapPart() {
     qreal highColor_r, highColor_g, highColor_b;
     m_signalColors.getRgbHighColor().getRgbF(&highColor_r, &highColor_g, &highColor_b);
 
-    float red, green, blue;
+    qreal low, mid, high;
+
+    qreal red, green, blue;
 
     // Maximum is needed for normalization
-    float max;
+    qreal max;
 
     for (currentCompletion = m_actualCompletion;
             currentCompletion < nextCompletion; currentCompletion += 2) {
@@ -82,9 +82,9 @@ bool WOverviewRGB::drawNextPixmapPart() {
         unsigned char left = pWaveform->getAll(currentCompletion);
         unsigned char right = pWaveform->getAll(currentCompletion + 1);
 
-        low = pWaveform->getLow(currentCompletion);
-        mid = pWaveform->getMid(currentCompletion);
-        high = pWaveform->getHigh(currentCompletion);
+        low  = (qreal) pWaveform->getLow(currentCompletion);
+        mid  = (qreal) pWaveform->getMid(currentCompletion);
+        high = (qreal) pWaveform->getHigh(currentCompletion);
 
         red   = low * lowColor_r + mid * midColor_r + high * highColor_r;
         green = low * lowColor_g + mid * midColor_g + high * highColor_g;
@@ -97,9 +97,9 @@ bool WOverviewRGB::drawNextPixmapPart() {
             painter.drawLine(currentCompletion / 2, -left, currentCompletion / 2, 0);
         }
 
-        low = pWaveform->getLow(currentCompletion + 1);
-        mid = pWaveform->getMid(currentCompletion + 1);
-        high = pWaveform->getHigh(currentCompletion + 1);
+        low  = (qreal) pWaveform->getLow(currentCompletion + 1);
+        mid  = (qreal) pWaveform->getMid(currentCompletion + 1);
+        high = (qreal) pWaveform->getHigh(currentCompletion + 1);
 
         red   = low * lowColor_r + mid * midColor_r + high * highColor_r;
         green = low * lowColor_g + mid * midColor_g + high * highColor_g;

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -69,8 +69,10 @@ bool WOverviewRGB::drawNextPixmapPart() {
     qreal highColor_r, highColor_g, highColor_b;
     m_signalColors.getRgbHighColor().getRgbF(&highColor_r, &highColor_g, &highColor_b);
 
+    // "Raw" LMH values
     qreal low, mid, high;
 
+    // Non-normalized RGB values
     qreal red, green, blue;
 
     // Maximum is needed for normalization
@@ -86,10 +88,12 @@ bool WOverviewRGB::drawNextPixmapPart() {
         mid  = (qreal) pWaveform->getMid(currentCompletion);
         high = (qreal) pWaveform->getHigh(currentCompletion);
 
+        // Do matrix multiplication
         red   = low * lowColor_r + mid * midColor_r + high * highColor_r;
         green = low * lowColor_g + mid * midColor_g + high * highColor_g;
         blue  = low * lowColor_b + mid * midColor_b + high * highColor_b;
 
+        // Normalize and draw
         max = math_max3(red, green, blue);
         if (max > 0.0f) {
             color.setRgbF(red / max, green / max, blue / max);
@@ -101,10 +105,12 @@ bool WOverviewRGB::drawNextPixmapPart() {
         mid  = (qreal) pWaveform->getMid(currentCompletion + 1);
         high = (qreal) pWaveform->getHigh(currentCompletion + 1);
 
+        // Do matrix multiplication
         red   = low * lowColor_r + mid * midColor_r + high * highColor_r;
         green = low * lowColor_g + mid * midColor_g + high * highColor_g;
         blue  = low * lowColor_b + mid * midColor_b + high * highColor_b;
 
+        // Normalize and draw
         max = math_max3(red, green, blue);
         if (max > 0.0f) {
             color.setRgbF(red / max, green / max, blue / max);

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -84,9 +84,9 @@ bool WOverviewRGB::drawNextPixmapPart() {
         unsigned char left = pWaveform->getAll(currentCompletion);
         unsigned char right = pWaveform->getAll(currentCompletion + 1);
 
-        low  = (qreal) pWaveform->getLow(currentCompletion);
-        mid  = (qreal) pWaveform->getMid(currentCompletion);
-        high = (qreal) pWaveform->getHigh(currentCompletion);
+        low  = static_cast<qreal>(pWaveform->getLow(currentCompletion));
+        mid  = static_cast<qreal>(pWaveform->getMid(currentCompletion));
+        high = static_cast<qreal>(pWaveform->getHigh(currentCompletion));
 
         // Do matrix multiplication
         red   = low * lowColor_r + mid * midColor_r + high * highColor_r;
@@ -95,15 +95,15 @@ bool WOverviewRGB::drawNextPixmapPart() {
 
         // Normalize and draw
         max = math_max3(red, green, blue);
-        if (max > 0.0f) {
+        if (max > 0.0) {
             color.setRgbF(red / max, green / max, blue / max);
             painter.setPen(color);
             painter.drawLine(currentCompletion / 2, -left, currentCompletion / 2, 0);
         }
 
-        low  = (qreal) pWaveform->getLow(currentCompletion + 1);
-        mid  = (qreal) pWaveform->getMid(currentCompletion + 1);
-        high = (qreal) pWaveform->getHigh(currentCompletion + 1);
+        low  = static_cast<qreal>(pWaveform->getLow(currentCompletion + 1));
+        mid  = static_cast<qreal>(pWaveform->getMid(currentCompletion + 1));
+        high = static_cast<qreal>(pWaveform->getHigh(currentCompletion + 1));
 
         // Do matrix multiplication
         red   = low * lowColor_r + mid * midColor_r + high * highColor_r;
@@ -112,7 +112,7 @@ bool WOverviewRGB::drawNextPixmapPart() {
 
         // Normalize and draw
         max = math_max3(red, green, blue);
-        if (max > 0.0f) {
+        if (max > 0.0) {
             color.setRgbF(red / max, green / max, blue / max);
             painter.setPen(color);
             painter.drawLine(currentCompletion / 2, 0, currentCompletion / 2, right);

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -69,46 +69,39 @@ bool WOverviewRGB::drawNextPixmapPart() {
     qreal highColor_r, highColor_g, highColor_b;
     m_signalColors.getRgbHighColor().getRgbF(&highColor_r, &highColor_g, &highColor_b);
 
-    // "Raw" LMH values
-    qreal low, mid, high;
-
-    // Non-normalized RGB values
-    qreal red, green, blue;
-
-    // Maximum is needed for normalization
-    qreal max;
-
     for (currentCompletion = m_actualCompletion;
             currentCompletion < nextCompletion; currentCompletion += 2) {
 
         unsigned char left = pWaveform->getAll(currentCompletion);
         unsigned char right = pWaveform->getAll(currentCompletion + 1);
 
-        low  = static_cast<qreal>(pWaveform->getLow(currentCompletion));
-        mid  = static_cast<qreal>(pWaveform->getMid(currentCompletion));
-        high = static_cast<qreal>(pWaveform->getHigh(currentCompletion));
+        // Retrieve "raw" LMH values from waveform
+        qreal low = static_cast<qreal>(pWaveform->getLow(currentCompletion));
+        qreal mid = static_cast<qreal>(pWaveform->getMid(currentCompletion));
+        qreal high = static_cast<qreal>(pWaveform->getHigh(currentCompletion));
 
         // Do matrix multiplication
-        red   = low * lowColor_r + mid * midColor_r + high * highColor_r;
-        green = low * lowColor_g + mid * midColor_g + high * highColor_g;
-        blue  = low * lowColor_b + mid * midColor_b + high * highColor_b;
+        qreal red = low * lowColor_r + mid * midColor_r + high * highColor_r;
+        qreal green = low * lowColor_g + mid * midColor_g + high * highColor_g;
+        qreal blue = low * lowColor_b + mid * midColor_b + high * highColor_b;
 
         // Normalize and draw
-        max = math_max3(red, green, blue);
+        qreal max = math_max3(red, green, blue);
         if (max > 0.0) {
             color.setRgbF(red / max, green / max, blue / max);
             painter.setPen(color);
             painter.drawLine(currentCompletion / 2, -left, currentCompletion / 2, 0);
         }
 
-        low  = static_cast<qreal>(pWaveform->getLow(currentCompletion + 1));
-        mid  = static_cast<qreal>(pWaveform->getMid(currentCompletion + 1));
+        // Retrieve "raw" LMH values from waveform
+        low = static_cast<qreal>(pWaveform->getLow(currentCompletion + 1));
+        mid = static_cast<qreal>(pWaveform->getMid(currentCompletion + 1));
         high = static_cast<qreal>(pWaveform->getHigh(currentCompletion + 1));
 
         // Do matrix multiplication
-        red   = low * lowColor_r + mid * midColor_r + high * highColor_r;
+        red = low * lowColor_r + mid * midColor_r + high * highColor_r;
         green = low * lowColor_g + mid * midColor_g + high * highColor_g;
-        blue  = low * lowColor_b + mid * midColor_b + high * highColor_b;
+        blue = low * lowColor_b + mid * midColor_b + high * highColor_b;
 
         // Normalize and draw
         max = math_max3(red, green, blue);


### PR DESCRIPTION
This makes RGB overview use colors defined by `<SignalRGB*Color>` tags in skin, as discussed on:
- https://bugs.launchpad.net/mixxx/+bug/1376989
- https://bugs.launchpad.net/mixxx/+bug/1404637
