### PR TITLE
Aux: Remove redundant passthrough control

### DIFF
--- a/src/engine/engineaux.cpp
+++ b/src/engine/engineaux.cpp
@@ -17,14 +17,12 @@ EngineAux::EngineAux(const ChannelHandleAndGroup& handle_group, EffectsManager* 
           m_pEngineEffectsManager(pEffectsManager ? pEffectsManager->getEngineEffectsManager() : NULL),
           m_vuMeter(getGroup()),
           m_pEnabled(new ControlObject(ConfigKey(getGroup(), "enabled"))),
-          m_pPassing(new ControlPushButton(ConfigKey(getGroup(), "passthrough"))),
           m_pPregain(new ControlAudioTaperPot(ConfigKey(getGroup(), "pregain"), -12, 12, 0.5)),
           m_sampleBuffer(NULL),
           m_wasActive(false) {
     if (pEffectsManager != NULL) {
         pEffectsManager->registerChannel(handle_group);
     }
-    m_pPassing->setButtonMode(ControlPushButton::POWERWINDOW);
 
     // by default Aux is enabled on the master and disabled on PFL. User
     // can over-ride by setting the "pfl" or "master" controls.
@@ -36,7 +34,6 @@ EngineAux::EngineAux(const ChannelHandleAndGroup& handle_group, EffectsManager* 
 EngineAux::~EngineAux() {
     qDebug() << "~EngineAux()";
     delete m_pEnabled;
-    delete m_pPassing;
     delete m_pPregain;
     delete m_pSampleRate;
 }
@@ -76,11 +73,7 @@ void EngineAux::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,
                               unsigned int nFrames) {
     Q_UNUSED(input);
     Q_UNUSED(nFrames);
-    if (m_pPassing->get() <= 0.0) {
-        m_sampleBuffer = NULL;
-    } else {
-        m_sampleBuffer = pBuffer;
-    }
+    m_sampleBuffer = pBuffer;
 }
 
 void EngineAux::process(CSAMPLE* pOut, const int iBufferSize) {

--- a/src/engine/engineaux.h
+++ b/src/engine/engineaux.h
@@ -50,7 +50,6 @@ class EngineAux : public EngineChannel, public AudioDestination {
     EngineEffectsManager* m_pEngineEffectsManager;
     EngineVuMeter m_vuMeter;
     ControlObject* m_pEnabled;
-    ControlPushButton* m_pPassing;
     ControlAudioTaperPot* m_pPregain;
     ControlObjectSlave* m_pSampleRate;
     const CSAMPLE* volatile m_sampleBuffer;


### PR DESCRIPTION
Since https://github.com/mixxxdj/mixxx/pull/474 we have reworked signal routing that makes [AuxilaryN],passthrough redundant.  

It suffers some issues anyway: 
- Name is misleading, since "passthrough" is associated to the function of passing the vinyl control signal to master  
- It is default off so it forces to be used from the skin 
- It disables the VU meter 
- It prevents pre-fader-listening 

[AuxilaryN],mute is the perfect replacement for instant control with non of these issues. 
[AuxilaryN],master is also viable to control the signal routing, but not intended to be used in skins 

This is the current signal routing: 

```
  pfl         /------------------|--------------------\0----------\
   /0-|PFL   /                   V ducking             1           \
  /         1           mute     |    /-L-------x--\    \           \
-/---------/0-------/0---/0 --x--x---+--M-----------+----+----\------+---|sidechain
         talkover  master   volume    \-R-------X--/  micMix   \---|master output
                                  orientation  xFader
```
