### PR TITLE
Restart scanner after cancel

### DIFF
--- a/src/library/scanner/importfilestask.cpp
+++ b/src/library/scanner/importfilestask.cpp
@@ -63,6 +63,6 @@ void ImportFilesTask::run() {
         }
     }
     // Insert or update the hash in the database.
-    emit(directoryHashed(m_dirPath, !m_prevHashExists, m_newHash));
+    emit(directoryHashedAndScanned(m_dirPath, !m_prevHashExists, m_newHash));
     setSuccess(true);
 }

--- a/src/library/scanner/importfilestask.cpp
+++ b/src/library/scanner/importfilestask.cpp
@@ -6,10 +6,14 @@
 
 ImportFilesTask::ImportFilesTask(LibraryScanner* pScanner,
                                  const ScannerGlobalPointer scannerGlobal,
+                                 const QString& dirPath,
+                                 const bool prevHashExists,
+                                 const int newHash,
                                  const QLinkedList<QFileInfo>& filesToImport,
                                  const QLinkedList<QFileInfo>& possibleCovers,
                                  SecurityTokenPointer pToken)
-        : ScannerTask(pScanner, scannerGlobal),
+        : ScannerTask(pScanner, scannerGlobal), m_dirPath(dirPath),
+          m_prevHashExists(prevHashExists), m_newHash(newHash),
           m_filesToImport(filesToImport),
           m_possibleCovers(possibleCovers),
           m_pToken(pToken) {
@@ -58,5 +62,7 @@ void ImportFilesTask::run() {
             emit(addNewTrack(pTrack));
         }
     }
+    // Insert or update the hash in the database.
+    emit(directoryHashed(m_dirPath, !m_prevHashExists, m_newHash));
     setSuccess(true);
 }

--- a/src/library/scanner/importfilestask.h
+++ b/src/library/scanner/importfilestask.h
@@ -15,6 +15,9 @@ class ImportFilesTask : public ScannerTask {
   public:
     ImportFilesTask(LibraryScanner* pScanner,
                     const ScannerGlobalPointer scannerGlobal,
+                    const QString& dirPath,
+                    const bool prevHashExists,
+                    const int newHash,
                     const QLinkedList<QFileInfo>& filesToImport,
                     const QLinkedList<QFileInfo>& possibleCovers,
                     SecurityTokenPointer pToken);
@@ -23,6 +26,9 @@ class ImportFilesTask : public ScannerTask {
     virtual void run();
 
   private:
+    const QString m_dirPath;
+    const bool m_prevHashExists;
+    const int m_newHash;
     const QLinkedList<QFileInfo> m_filesToImport;
     const QLinkedList<QFileInfo> m_possibleCovers;
     SecurityTokenPointer m_pToken;

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -384,8 +384,8 @@ void LibraryScanner::queueTask(ScannerTask* pTask) {
             this, SLOT(taskDone(bool)));
     connect(pTask, SIGNAL(queueTask(ScannerTask*)),
             this, SLOT(queueTask(ScannerTask*)));
-    connect(pTask, SIGNAL(directoryHashed(QString, bool, int)),
-            this, SLOT(directoryHashed(QString, bool, int)));
+    connect(pTask, SIGNAL(directoryHashedAndScanned(QString, bool, int)),
+            this, SLOT(directoryHashedAndScanned(QString, bool, int)));
     connect(pTask, SIGNAL(directoryUnchanged(QString)),
             this, SLOT(directoryUnchanged(QString)));
     connect(pTask, SIGNAL(trackExists(QString)),
@@ -402,10 +402,10 @@ void LibraryScanner::queueTask(ScannerTask* pTask) {
     m_pool.start(pTask);
 }
 
-void LibraryScanner::directoryHashed(const QString& directoryPath,
-                                     bool newDirectory, int hash) {
-    ScopedTimer timer("LibraryScanner::directoryHashed");
-    // qDebug() << "LibraryScanner::directoryHashed" << directoryPath
+void LibraryScanner::directoryHashedAndScanned(const QString& directoryPath,
+                                               bool newDirectory, int hash) {
+    ScopedTimer timer("LibraryScanner::directoryHashedAndScanned");
+    // qDebug() << "LibraryScanner::directoryHashedAndScanned" << directoryPath
     //          << newDirectory << hash;
 
     // For statistics tracking -- if we hashed a directory then we scanned it

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -84,8 +84,8 @@ class LibraryScanner : public QThread {
 
     // ScannerTask signal handlers.
     void taskDone(bool success);
-    void directoryHashed(const QString& directoryPath, bool newDirectory,
-                         int hash);
+    void directoryHashedAndScanned(const QString& directoryPath,
+                                   bool newDirectory, int hash);
     void directoryUnchanged(const QString& directoryPath);
     void trackExists(const QString& trackPath);
     void addNewTrack(TrackPointer pTrack);

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -79,11 +79,14 @@ void RecursiveScanDirectoryTask::run() {
     if (prevHash != newHash) {
         // Rescan that mofo! If importing fails then the scan was cancelled so
         // we return immediately.
-        m_pScanner->queueTask(new ImportFilesTask(m_pScanner, m_scannerGlobal,
-                                                  dirPath, newHash, prevHashExists,
-                                                  filesToImport, possibleCovers,
-                                                  m_pToken));
-
+        if (!filesToImport.isEmpty()) {
+            m_pScanner->queueTask(new ImportFilesTask(m_pScanner, m_scannerGlobal,
+                                                    dirPath, newHash, prevHashExists,
+                                                    filesToImport, possibleCovers,
+                                                    m_pToken));
+        } else {
+            emit(directoryHashed(dirPath, !prevHashExists, newHash));
+        }
     } else {
         emit(directoryUnchanged(dirPath));
     }

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -79,14 +79,11 @@ void RecursiveScanDirectoryTask::run() {
     if (prevHash != newHash) {
         // Rescan that mofo! If importing fails then the scan was cancelled so
         // we return immediately.
-        if (!filesToImport.isEmpty()) {
-            m_pScanner->queueTask(new ImportFilesTask(m_pScanner, m_scannerGlobal,
-                                                      filesToImport, possibleCovers,
-                                                      m_pToken));
-        }
+        m_pScanner->queueTask(new ImportFilesTask(m_pScanner, m_scannerGlobal,
+                                                  dirPath, newHash, prevHashExists,
+                                                  filesToImport, possibleCovers,
+                                                  m_pToken));
 
-        // Insert or update the hash in the database.
-        emit(directoryHashed(dirPath, !prevHashExists, newHash));
     } else {
         emit(directoryUnchanged(dirPath));
     }

--- a/src/library/scanner/scannertask.cpp
+++ b/src/library/scanner/scannertask.cpp
@@ -7,6 +7,8 @@ ScannerTask::ScannerTask(LibraryScanner* pScanner,
           m_scannerGlobal(scannerGlobal),
           m_success(false) {
     setAutoDelete(true);
+    connect(this, SIGNAL(directoryHashed(QString, bool, int)),
+            this, SIGNAL(directoryHashedAndScanned(QString, bool, int)));
 }
 
 ScannerTask::~ScannerTask() {

--- a/src/library/scanner/scannertask.h
+++ b/src/library/scanner/scannertask.h
@@ -21,8 +21,8 @@ class ScannerTask : public QObject, public QRunnable {
   signals:
     void taskDone(bool success);
     void queueTask(ScannerTask* pTask);
-    void directoryHashed(const QString& directoryPath, bool newDirectory,
-                         int hash);
+    void directoryHashedAndScanned(const QString& directoryPath,
+                                   bool newDirectory, int hash);
     void directoryUnchanged(const QString& directoryPath);
     void trackExists(const QString& filePath);
     void addNewTrack(TrackPointer pTrack);

--- a/src/library/scanner/scannertask.h
+++ b/src/library/scanner/scannertask.h
@@ -23,6 +23,8 @@ class ScannerTask : public QObject, public QRunnable {
     void queueTask(ScannerTask* pTask);
     void directoryHashedAndScanned(const QString& directoryPath,
                                    bool newDirectory, int hash);
+    void directoryHashed(const QString& directoryPath, bool newDirectory,
+                         int hash);
     void directoryUnchanged(const QString& directoryPath);
     void trackExists(const QString& filePath);
     void addNewTrack(TrackPointer pTrack);


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1425705

This shifts the responsibility to notify about hashed AND scanned directories to the importFiles task. I think this is the clearest way to do this. I personally don't care much about the extra work of scheduling another task.

@rryan do you think there is a better way to do this? 
