### PR TITLE
Replaygain language

### DIFF
--- a/src/dlgprefreplaygain.cpp
+++ b/src/dlgprefreplaygain.cpp
@@ -108,8 +108,7 @@ void DlgPrefReplayGain::slotUpdateReplayGainBoost() {
 
 void DlgPrefReplayGain::setLabelCurrentReplayGainBoost(int value) {
     LabelCurrentReplayGainBoost->setText(
-            QString(tr("%1 dB (average %2 dB)")).arg(
-                  QString().sprintf("%+d", value), QString::number(value - 14)));
+            QString(tr("Adjust by %1 dB")).arg(QString().sprintf("%+d", value)));
 }
 
 void DlgPrefReplayGain::slotUpdateDefaultBoost() {
@@ -117,7 +116,7 @@ void DlgPrefReplayGain::slotUpdateDefaultBoost() {
     config->set(ConfigKey(kConfigKey, "InitialDefaultBoost"),
                 ConfigValue(value));
     LabelCurrentDefaultBoost->setText(
-            QString("%1 dB").arg(value));
+            QString("Adjust by %1 dB").arg(value));
     slotApply();
 }
 
@@ -125,8 +124,10 @@ void DlgPrefReplayGain::slotUpdate() {
     if (config->getValueString(
             ConfigKey(kConfigKey,"ReplayGainEnabled")).toInt() == 1) {
         SliderReplayGainBoost->setEnabled(true);
+        SliderDefaultBoost->setEnabled(true);
     } else {
         SliderReplayGainBoost->setEnabled(false);
+        SliderDefaultBoost->setEnabled(false);
     }
 }
 

--- a/src/dlgprefreplaygain.cpp
+++ b/src/dlgprefreplaygain.cpp
@@ -5,7 +5,7 @@
 
 #define kConfigKey "[ReplayGain]"
 
-static const int kReplayGainRefererencLUFS = -18; 
+static const int kReplayGainReferenceLUFS = -18; 
 
 
 DlgPrefReplayGain::DlgPrefReplayGain(QWidget * parent, ConfigObject<ConfigValue> * _config)
@@ -111,7 +111,7 @@ void DlgPrefReplayGain::slotUpdateReplayGainBoost() {
 void DlgPrefReplayGain::setLabelCurrentReplayGainBoost(int value) {
     LabelCurrentReplayGainBoost->setText(
             QString(tr("%1 LUFS (adjust by %2 dB)")).arg(
-                  QString::number(value + kReplayGainRefererencLUFS), QString().sprintf("%+d", value)));
+                  QString::number(value + kReplayGainReferenceLUFS), QString().sprintf("%+d", value)));
 }
 
 void DlgPrefReplayGain::slotUpdateDefaultBoost() {

--- a/src/dlgprefreplaygain.cpp
+++ b/src/dlgprefreplaygain.cpp
@@ -5,6 +5,8 @@
 
 #define kConfigKey "[ReplayGain]"
 
+static const int kReplayGainRefererencLUFS = -18; 
+
 
 DlgPrefReplayGain::DlgPrefReplayGain(QWidget * parent, ConfigObject<ConfigValue> * _config)
         : DlgPreferencePage(parent),
@@ -109,7 +111,7 @@ void DlgPrefReplayGain::slotUpdateReplayGainBoost() {
 void DlgPrefReplayGain::setLabelCurrentReplayGainBoost(int value) {
     LabelCurrentReplayGainBoost->setText(
             QString(tr("%1 LUFS (adjust by %2 dB)")).arg(
-                  QString::number(value - 14), QString().sprintf("%+d", value)));
+                  QString::number(value + kReplayGainRefererencLUFS), QString().sprintf("%+d", value)));
 }
 
 void DlgPrefReplayGain::slotUpdateDefaultBoost() {

--- a/src/dlgprefreplaygain.cpp
+++ b/src/dlgprefreplaygain.cpp
@@ -108,7 +108,8 @@ void DlgPrefReplayGain::slotUpdateReplayGainBoost() {
 
 void DlgPrefReplayGain::setLabelCurrentReplayGainBoost(int value) {
     LabelCurrentReplayGainBoost->setText(
-            QString(tr("Adjust by %1 dB")).arg(QString().sprintf("%+d", value)));
+            QString(tr("%1 LUFS (adjust by %2 dB)")).arg(
+                  QString::number(value - 14), QString().sprintf("%+d", value)));
 }
 
 void DlgPrefReplayGain::slotUpdateDefaultBoost() {
@@ -116,7 +117,7 @@ void DlgPrefReplayGain::slotUpdateDefaultBoost() {
     config->set(ConfigKey(kConfigKey, "InitialDefaultBoost"),
                 ConfigValue(value));
     LabelCurrentDefaultBoost->setText(
-            QString("Adjust by %1 dB").arg(value));
+            QString("%1 dB").arg(value));
     slotApply();
 }
 

--- a/src/dlgprefreplaygaindlg.ui
+++ b/src/dlgprefreplaygaindlg.ui
@@ -21,22 +21,22 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QCheckBox" name="EnableAnalyser">
-        <property name="toolTip">
-         <string>Calculate ReplayGain normalization for tracks which are missing ReplayGain metadata.</string>
-        </property>
-        <property name="text">
-         <string>Enable ReplayGain Analysis</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QCheckBox" name="EnableGain">
         <property name="toolTip">
          <string>Apply loudness normalization to loaded tracks.</string>
         </property>
         <property name="text">
          <string>Apply ReplayGain</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="EnableAnalyser">
+        <property name="toolTip">
+         <string>Calculate ReplayGain normalization for tracks which are missing ReplayGain metadata.</string>
+        </property>
+        <property name="text">
+         <string>Enable ReplayGain Analysis</string>
         </property>
        </widget>
       </item>
@@ -148,15 +148,21 @@
       </item>
       <item row="4" column="0">
        <widget class="QLabel" name="label">
+        <property name="toolTip">
+         <string>When ReplayGain is enabled, adjust tracks lacking ReplayGain information by this amount.</string>
+        </property>
         <property name="text">
-         <string>Inital boost without ReplayGain</string>
+         <string>Unanalyzed Track Volume Compensation</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_boost">
+        <property name="toolTip">
+         <string>When ReplayGain is enabled, adjust tracks with ReplayGain information by this amount.  A value of +6db will typically restore tracks to full volume without clipping.</string>
+        </property>
         <property name="text">
-         <string>Inital boost in addition to ReplayGain</string>
+         <string>ReplayGain Volume Compensation</string>
         </property>
         <property name="buddy">
          <cstring>SliderReplayGainBoost</cstring>
@@ -248,7 +254,7 @@
       <item row="4" column="0">
        <widget class="QLabel" name="label_26">
         <property name="text">
-         <string>If an unanalyzed track is playing, Mixxx won't apply a newly calculated ReplayGain to avoid an abrupt volume change. </string>
+         <string>If an unanalyzed track is playing, to avoid an abrupt volume change Mixxx won't apply a newly calculated ReplayGain value.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -258,7 +264,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>The normal average ReplayGain playback level is -14 dB. You may increase it using the inital boost, if your tracks does not require the full dynamic headroom, or reduce it if you experience that your tracks are clipping by default.</string>
+         <string>Usually, ReplayGain analysis will reduce track gain by about half, or approximately -6db. Setting an adjustment of +6db to analyzed tracks will restore ReplayGain tracks to full volume, but some tracks may clip.  Users using this setup will want to set the volume adjustment for unanalyzed tracks to 0db.  For users using a 0db adjustment to ReplayGain tracks, it's recommended to adjust unanalyzed tracks by -6db to prevent large volume changes when mixing between analyzed and unanalyzed tracks.</string>
         </property>
         <property name="scaledContents">
          <bool>true</bool>

--- a/src/dlgprefreplaygaindlg.ui
+++ b/src/dlgprefreplaygaindlg.ui
@@ -69,7 +69,7 @@
         <item>
          <widget class="QLabel" name="label_3">
           <property name="text">
-           <string>-12 dB</string>
+           <string>-26 LUFS</string>
           </property>
          </widget>
         </item>
@@ -109,7 +109,7 @@
         <item>
          <widget class="QLabel" name="label_4">
           <property name="text">
-           <string>+12 dB</string>
+           <string>-2 LUFS</string>
           </property>
          </widget>
         </item>
@@ -152,17 +152,17 @@
          <string>When ReplayGain is enabled, adjust tracks lacking ReplayGain information by this amount.</string>
         </property>
         <property name="text">
-         <string>Unanalyzed Track Volume Compensation</string>
+         <string>Inital boost without ReplayGain</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_boost">
         <property name="toolTip">
-         <string>When ReplayGain is enabled, adjust tracks with ReplayGain information by this amount.  A value of +6db will typically restore tracks to full volume without clipping.</string>
+         <string>After ReplayGain is applied, adjust the inital boost for a target loudness in LUFS (Loudness Units relative to Full Scale).</string>
         </property>
         <property name="text">
-         <string>ReplayGain Volume Compensation</string>
+         <string>Target loudness</string>
         </property>
         <property name="buddy">
          <cstring>SliderReplayGainBoost</cstring>
@@ -264,7 +264,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>Usually, ReplayGain analysis will reduce track gain by about half, or approximately -6db. Setting an adjustment of +6db to analyzed tracks will restore ReplayGain tracks to full volume, but some tracks may clip.  Users using this setup will want to set the volume adjustment for unanalyzed tracks to 0db.  For users using a 0db adjustment to ReplayGain tracks, it's recommended to adjust unanalyzed tracks by -6db to prevent large volume changes when mixing between analyzed and unanalyzed tracks.</string>
+         <string>The ReplayGain target loudness is around -14 LUFS (Loudness Units relative to Full Scale). You may increase it, if your tracks does not require the full dynamic headroom or reduce it if you experience that your tracks are clipping by default. A standard loudness for TV is -23 LUFS and for podcasting -16 LUFS.</string>
         </property>
         <property name="scaledContents">
          <bool>true</bool>

--- a/src/dlgprefreplaygaindlg.ui
+++ b/src/dlgprefreplaygaindlg.ui
@@ -152,7 +152,7 @@
          <string>When ReplayGain is enabled, adjust tracks lacking ReplayGain information by this amount.</string>
         </property>
         <property name="text">
-         <string>Inital boost without ReplayGain</string>
+         <string>Initial boost without ReplayGain</string>
         </property>
        </widget>
       </item>

--- a/src/dlgprefreplaygaindlg.ui
+++ b/src/dlgprefreplaygaindlg.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>433</width>
+    <width>509</width>
     <height>609</height>
    </rect>
   </property>
@@ -159,7 +159,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_boost">
         <property name="toolTip">
-         <string>"For tracks with ReplayGain, adjust the target loudness to this LUFS value (Loudness Units relative to Full Scale)."</string>
+         <string>&quot;For tracks with ReplayGain, adjust the target loudness to this LUFS value (Loudness Units relative to Full Scale).&quot;</string>
         </property>
         <property name="text">
          <string>Target loudness</string>
@@ -251,23 +251,25 @@
       <string>Hints</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_6">
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_26">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>When an unanalyzed track is playing, Mixxx will avoid an abrupt volume change by not applying a newly calculated ReplayGain value.</string>
+         <string>ReplayGain targets a reference loudness of -18 LUFS (Loudness Units relative to Full Scale). You may increase it if you find Mixxx is too quiet or reduce it if you find that your tracks are clipping. You may also want to decrease the volume of unanalyzed tracks if you find they are often louder than ReplayGained tracks. For podcasting a loudness of -16 LUFS is recommended.
+
+The loudness target is approximate and assumes track pregain and master output level are unchanged.</string>
+        </property>
+        <property name="scaledContents">
+         <bool>true</bool>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_8">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_26">
         <property name="text">
-         <string>ReplayGain targets a reference loudness of -18 LUFS (Loudness Units relative to Full Scale). You may increase it if you find Mixxx is too quiet or reduce it if you find that your tracks are clipping. For podcasting a loudness of -16 LUFS is recomended.</string>
-        </property>
-        <property name="scaledContents">
-         <bool>true</bool>
+         <string>When an unanalyzed track is playing, Mixxx will avoid an abrupt volume change by not applying a newly calculated ReplayGain value.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/dlgprefreplaygaindlg.ui
+++ b/src/dlgprefreplaygaindlg.ui
@@ -69,7 +69,7 @@
         <item>
          <widget class="QLabel" name="label_3">
           <property name="text">
-           <string>-26 LUFS</string>
+           <string>-30 LUFS</string>
           </property>
          </widget>
         </item>
@@ -109,7 +109,7 @@
         <item>
          <widget class="QLabel" name="label_4">
           <property name="text">
-           <string>-2 LUFS</string>
+           <string>-6 LUFS</string>
           </property>
          </widget>
         </item>
@@ -264,7 +264,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>The ReplayGain target loudness is around -14 LUFS (Loudness Units relative to Full Scale). You may increase it, if your tracks does not require the full dynamic headroom or reduce it if you experience that your tracks are clipping by default. A standard loudness for TV is -23 LUFS and for podcasting -16 LUFS.</string>
+         <string>The loudness of the ReplayGain reference signal is -18 LUFS (Loudness Units relative to Full Scale). You may increase it, if your tracks does not require the full dynamic headroom or reduce it if you experience that your tracks are clipping by default. The standard loudness for European TV is -23 LUFS and for podcasting it is -16 LUFS.</string>
         </property>
         <property name="scaledContents">
          <bool>true</bool>

--- a/src/dlgprefreplaygaindlg.ui
+++ b/src/dlgprefreplaygaindlg.ui
@@ -159,7 +159,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_boost">
         <property name="toolTip">
-         <string>After ReplayGain is applied, adjust the inital boost for a target loudness in LUFS (Loudness Units relative to Full Scale).</string>
+         <string>"For tracks with ReplayGain, adjust the target loudness to this LUFS value (Loudness Units relative to Full Scale)."</string>
         </property>
         <property name="text">
          <string>Target loudness</string>
@@ -254,7 +254,7 @@
       <item row="4" column="0">
        <widget class="QLabel" name="label_26">
         <property name="text">
-         <string>If an unanalyzed track is playing, to avoid an abrupt volume change Mixxx won't apply a newly calculated ReplayGain value.</string>
+         <string>When an unanalyzed track is playing, Mixxx will avoid an abrupt volume change by not applying a newly calculated ReplayGain value.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -264,7 +264,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>The loudness of the ReplayGain reference signal is -18 LUFS (Loudness Units relative to Full Scale). You may increase it, if your tracks does not require the full dynamic headroom or reduce it if you experience that your tracks are clipping by default. The standard loudness for European TV is -23 LUFS and for podcasting it is -16 LUFS.</string>
+         <string>ReplayGain targets a reference loudness of -18 LUFS (Loudness Units relative to Full Scale). You may increase it if you find Mixxx is too quiet or reduce it if you find that your tracks are clipping. For podcasting a loudness of -16 LUFS is recomended.</string>
         </property>
         <property name="scaledContents">
          <bool>true</bool>

--- a/src/dlgprefreplaygaindlg.ui
+++ b/src/dlgprefreplaygaindlg.ui
@@ -152,7 +152,7 @@
          <string>When ReplayGain is enabled, adjust tracks lacking ReplayGain information by this amount.</string>
         </property>
         <property name="text">
-         <string>Initial boost without ReplayGain</string>
+         <string>Initial boost without ReplayGain data</string>
         </property>
        </widget>
       </item>

--- a/src/dlgprefreplaygaindlg.ui
+++ b/src/dlgprefreplaygaindlg.ui
@@ -36,7 +36,7 @@
          <string>Calculate ReplayGain normalization for tracks which are missing ReplayGain metadata.</string>
         </property>
         <property name="text">
-         <string>Enable ReplayGain Analysis</string>
+         <string>Enable ReplayGain 1.0 Analysis</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This is the successor of @ywwg's https://github.com/mixxxdj/mixxx/pull/512

It seams that ReplayGain is about to be replaced by EBU R128 for broadcasting.
Luckily EBU has established a Unit for Loudness: LUFS, which is uses in recommendations for Apple, Soundcloud and Youtube. Apple uses explicit a Loudness of -16 LUFS for its iTunes Radio. 

The ReplayGain normalization method does not match the EBU recommendation and does not produce a constant LUFS,  but it sets the loudness to an average of about -14 LUFS. I think this is close enough to just express the loudness in LUFS inside the ReplayGain preferences (until Mixxx is able to normalize exactly according to EBU R 128)  https://bugs.launchpad.net/mixxx/+bug/1407010)

This has some advantages.
- It fixes the continuing confusion of the different dB values.  
- Broadcast user can directly set the required LUFS for their station. 
- Using a standard unit avoid to explain the underlying measurement formulas.  
