### PR TITLE
Add keyboard shortcut to maximize library view

### DIFF
--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -9,7 +9,6 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
-maximize_library space
 
 [Microphone]
 talkover \
@@ -135,6 +134,7 @@ ViewMenu_ShowVinylControl Ctrl+3
 ViewMenu_ShowPreviewDeck Ctrl+4
 ViewMenu_ShowEffects Ctrl+5
 ViewMenu_ShowCoverArt Ctrl+6
+ViewMenu_MaximizeLibrary Space
 OptionsMenu_EnableLiveBroadcasting Ctrl+l
 OptionsMenu_EnableVinyl1 Ctrl+y
 OptionsMenu_EnableVinyl2 Ctrl+u

--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -9,6 +9,7 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
+maximize_library space
 
 [Microphone]
 talkover \

--- a/res/keyboard/da_DK.kbd.cfg
+++ b/res/keyboard/da_DK.kbd.cfg
@@ -9,6 +9,7 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
+maximize_library space
 
 [Microphone]
 talkover <

--- a/res/keyboard/da_DK.kbd.cfg
+++ b/res/keyboard/da_DK.kbd.cfg
@@ -9,7 +9,6 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
-maximize_library space
 
 [Microphone]
 talkover <
@@ -135,6 +134,7 @@ ViewMenu_ShowVinylControl Ctrl+3
 ViewMenu_ShowPreviewDeck Ctrl+4
 ViewMenu_ShowEffects Ctrl+5
 ViewMenu_ShowCoverArt Ctrl+6
+ViewMenu_MaximizeLibrary Space
 OptionsMenu_EnableLiveBroadcasting Ctrl+l
 OptionsMenu_EnableVinyl1 Ctrl+y
 OptionsMenu_EnableVinyl2 Ctrl+u

--- a/res/keyboard/de_CH.kbd.cfg
+++ b/res/keyboard/de_CH.kbd.cfg
@@ -9,6 +9,7 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
+maximize_library space
 
 [Microphone]
 talkover <

--- a/res/keyboard/de_CH.kbd.cfg
+++ b/res/keyboard/de_CH.kbd.cfg
@@ -9,7 +9,6 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
-maximize_library space
 
 [Microphone]
 talkover <
@@ -132,6 +131,7 @@ ViewMenu_ShowVinylControl Ctrl+3
 ViewMenu_ShowPreviewDeck Ctrl+4
 ViewMenu_ShowEffects Ctrl+5
 ViewMenu_ShowCoverArt Ctrl+6
+ViewMenu_MaximizeLibrary Space
 OptionsMenu_EnableLiveBroadcasting Ctrl+l
 OptionsMenu_EnableVinyl1 Ctrl+t
 OptionsMenu_EnableVinyl2 Ctrl+y

--- a/res/keyboard/de_DE.kbd.cfg
+++ b/res/keyboard/de_DE.kbd.cfg
@@ -9,6 +9,7 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
+maximize_library space
 
 [Microphone]
 talkover <

--- a/res/keyboard/de_DE.kbd.cfg
+++ b/res/keyboard/de_DE.kbd.cfg
@@ -9,7 +9,6 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
-maximize_library space
 
 [Microphone]
 talkover <
@@ -135,6 +134,7 @@ ViewMenu_ShowVinylControl Ctrl+3
 ViewMenu_ShowPreviewDeck Ctrl+4
 ViewMenu_ShowEffects Ctrl+5
 ViewMenu_ShowCoverArt Ctrl+6
+ViewMenu_MaximizeLibrary Space
 OptionsMenu_EnableLiveBroadcasting Ctrl+l
 OptionsMenu_EnableVinyl1 Ctrl+z
 OptionsMenu_EnableVinyl2 Ctrl+u

--- a/res/keyboard/el_GR.kbd.cfg
+++ b/res/keyboard/el_GR.kbd.cfg
@@ -9,6 +9,7 @@ crossfader_up η
 crossfader_down γ
 crossfader_up_small Shift+Η
 crossfader_down_small Shift+Γ
+maximize_library space
 
 [Microphone]
 talkover `

--- a/res/keyboard/el_GR.kbd.cfg
+++ b/res/keyboard/el_GR.kbd.cfg
@@ -9,7 +9,6 @@ crossfader_up η
 crossfader_down γ
 crossfader_up_small Shift+Η
 crossfader_down_small Shift+Γ
-maximize_library space
 
 [Microphone]
 talkover `
@@ -135,6 +134,7 @@ ViewMenu_ShowVinylControl Ctrl+3
 ViewMenu_ShowPreviewDeck Ctrl+4
 ViewMenu_ShowEffects Ctrl+5
 ViewMenu_ShowCoverArt Ctrl+6
+ViewMenu_MaximizeLibrary Space
 OptionsMenu_EnableLiveBroadcasting Ctrl+l
 OptionsMenu_EnableVinyl1 Ctrl+y
 OptionsMenu_EnableVinyl2 Ctrl+u

--- a/res/keyboard/en_US.kbd.cfg
+++ b/res/keyboard/en_US.kbd.cfg
@@ -9,7 +9,6 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
-maximize_library space
 
 [Microphone]
 talkover `
@@ -132,6 +131,7 @@ ViewMenu_ShowVinylControl Ctrl+3
 ViewMenu_ShowPreviewDeck Ctrl+4
 ViewMenu_ShowEffects Ctrl+5
 ViewMenu_ShowCoverArt Ctrl+6
+ViewMenu_MaximizeLibrary Space
 OptionsMenu_EnableLiveBroadcasting Ctrl+l
 OptionsMenu_EnableVinyl1 Ctrl+t
 OptionsMenu_EnableVinyl2 Ctrl+y

--- a/res/keyboard/en_US.kbd.cfg
+++ b/res/keyboard/en_US.kbd.cfg
@@ -9,6 +9,7 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
+maximize_library space
 
 [Microphone]
 talkover `

--- a/res/keyboard/es_ES.kbd.cfg
+++ b/res/keyboard/es_ES.kbd.cfg
@@ -9,6 +9,7 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
+maximize_library space
 
 [Microphone]
 talkover <

--- a/res/keyboard/es_ES.kbd.cfg
+++ b/res/keyboard/es_ES.kbd.cfg
@@ -9,7 +9,6 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
-maximize_library space
 
 [Microphone]
 talkover <
@@ -135,6 +134,7 @@ ViewMenu_ShowVinylControl Ctrl+3
 ViewMenu_ShowPreviewDeck Ctrl+4
 ViewMenu_ShowEffects Ctrl+5
 ViewMenu_ShowCoverArt Ctrl+6
+ViewMenu_MaximizeLibrary Space
 OptionsMenu_EnableLiveBroadcasting Ctrl+l
 OptionsMenu_EnableVinyl1 Ctrl+y
 OptionsMenu_EnableVinyl2 Ctrl+u

--- a/res/keyboard/fi_FI.kbd.cfg
+++ b/res/keyboard/fi_FI.kbd.cfg
@@ -9,6 +9,7 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
+maximize_library space
 
 [Microphone]
 talkover <

--- a/res/keyboard/fi_FI.kbd.cfg
+++ b/res/keyboard/fi_FI.kbd.cfg
@@ -9,7 +9,6 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
-maximize_library space
 
 [Microphone]
 talkover <
@@ -135,6 +134,7 @@ ViewMenu_ShowVinylControl Ctrl+3
 ViewMenu_ShowPreviewDeck Ctrl+4
 ViewMenu_ShowEffects Ctrl+5
 ViewMenu_ShowCoverArt Ctrl+6
+ViewMenu_MaximizeLibrary Space
 OptionsMenu_EnableLiveBroadcasting Ctrl+l
 OptionsMenu_EnableVinyl1 Ctrl+y
 OptionsMenu_EnableVinyl2 Ctrl+u

--- a/res/keyboard/fr_CH.kbd.cfg
+++ b/res/keyboard/fr_CH.kbd.cfg
@@ -9,6 +9,7 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
+maximize_library space
 
 [Microphone]
 talkover <

--- a/res/keyboard/fr_CH.kbd.cfg
+++ b/res/keyboard/fr_CH.kbd.cfg
@@ -9,7 +9,6 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
-maximize_library space
 
 [Microphone]
 talkover <
@@ -132,6 +131,7 @@ ViewMenu_ShowVinylControl Ctrl+3
 ViewMenu_ShowPreviewDeck Ctrl+4
 ViewMenu_ShowEffects Ctrl+5
 ViewMenu_ShowCoverArt Ctrl+6
+ViewMenu_MaximizeLibrary Space
 OptionsMenu_EnableLiveBroadcasting Ctrl+l
 OptionsMenu_EnableVinyl1 Ctrl+t
 OptionsMenu_EnableVinyl2 Ctrl+y

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -9,6 +9,7 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
+maximize_library space
 
 [Microphone]
 talkover <

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -9,7 +9,6 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
-maximize_library space
 
 [Microphone]
 talkover <
@@ -135,6 +134,7 @@ ViewMenu_ShowVinylControl Ctrl+3
 ViewMenu_ShowPreviewDeck Ctrl+4
 ViewMenu_ShowEffects Ctrl+5
 ViewMenu_ShowCoverArt Ctrl+6
+ViewMenu_MaximizeLibrary Space
 OptionsMenu_EnableLiveBroadcasting Ctrl+l
 OptionsMenu_EnableVinyl1 Ctrl+y
 OptionsMenu_EnableVinyl2 Ctrl+u

--- a/res/keyboard/it_IT.kbd.cfg
+++ b/res/keyboard/it_IT.kbd.cfg
@@ -9,6 +9,7 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
+maximize_library space
 
 [Microphone]
 talkover <

--- a/res/keyboard/it_IT.kbd.cfg
+++ b/res/keyboard/it_IT.kbd.cfg
@@ -9,7 +9,6 @@ crossfader_up h
 crossfader_down g
 crossfader_up_small Shift+h
 crossfader_down_small Shift+g
-maximize_library space
 
 [Microphone]
 talkover <
@@ -135,6 +134,7 @@ ViewMenu_ShowVinylControl Ctrl+3
 ViewMenu_ShowPreviewDeck Ctrl+4
 ViewMenu_ShowEffects Ctrl+5
 ViewMenu_ShowCoverArt Ctrl+6
+ViewMenu_MaximizeLibrary Space
 OptionsMenu_EnableLiveBroadcasting Ctrl+l
 OptionsMenu_EnableVinyl1 Ctrl+y
 OptionsMenu_EnableVinyl2 Ctrl+u

--- a/res/keyboard/ru_RU.kbd.cfg
+++ b/res/keyboard/ru_RU.kbd.cfg
@@ -9,6 +9,7 @@ crossfader_up р
 crossfader_down п
 crossfader_up_small Shift+Р
 crossfader_down_small Shift+П
+maximize_library space
 
 [Microphone]
 talkover ]

--- a/res/keyboard/ru_RU.kbd.cfg
+++ b/res/keyboard/ru_RU.kbd.cfg
@@ -9,7 +9,6 @@ crossfader_up р
 crossfader_down п
 crossfader_up_small Shift+Р
 crossfader_down_small Shift+П
-maximize_library space
 
 [Microphone]
 talkover ]
@@ -135,6 +134,7 @@ ViewMenu_ShowVinylControl Ctrl+3
 ViewMenu_ShowPreviewDeck Ctrl+4
 ViewMenu_ShowEffects Ctrl+5
 ViewMenu_ShowCoverArt Ctrl+6
+ViewMenu_MaximizeLibrary Space
 OptionsMenu_EnableLiveBroadcasting Ctrl+l
 OptionsMenu_EnableVinyl1 Ctrl+y
 OptionsMenu_EnableVinyl2 Ctrl+u

--- a/res/skins/Deere/effect_rack.xml
+++ b/res/skins/Deere/effect_rack.xml
@@ -88,7 +88,7 @@
       </WidgetStack>
     </Children>
     <Connection>
-      <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+      <ConfigKey>[Master],maximize_library</ConfigKey>
       <BindProperty>visible</BindProperty>
       <Transform>
         <Not/>

--- a/res/skins/Deere/effect_rack.xml
+++ b/res/skins/Deere/effect_rack.xml
@@ -88,7 +88,7 @@
       </WidgetStack>
     </Children>
     <Connection>
-      <ConfigKey persist="true">[Master],show_library</ConfigKey>
+      <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
       <BindProperty>visible</BindProperty>
       <Transform>
         <Not/>

--- a/res/skins/Deere/main_decks.xml
+++ b/res/skins/Deere/main_decks.xml
@@ -14,7 +14,7 @@
       <Template src="skin:right_gutter.xml"/>
     </Children>
     <Connection>
-      <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+      <ConfigKey>[Master],maximize_library</ConfigKey>
       <BindProperty>visible</BindProperty>
       <Transform>
         <Not/>

--- a/res/skins/Deere/main_decks.xml
+++ b/res/skins/Deere/main_decks.xml
@@ -14,7 +14,7 @@
       <Template src="skin:right_gutter.xml"/>
     </Children>
     <Connection>
-      <ConfigKey persist="true">[Master],show_library</ConfigKey>
+      <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
       <BindProperty>visible</BindProperty>
       <Transform>
         <Not/>

--- a/res/skins/Deere/microphone_rack.xml
+++ b/res/skins/Deere/microphone_rack.xml
@@ -77,7 +77,7 @@
       </WidgetStack>
     </Children>
     <Connection>
-      <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+      <ConfigKey>[Master],maximize_library</ConfigKey>
       <BindProperty>visible</BindProperty>
       <Transform>
         <Not/>

--- a/res/skins/Deere/microphone_rack.xml
+++ b/res/skins/Deere/microphone_rack.xml
@@ -77,7 +77,7 @@
       </WidgetStack>
     </Children>
     <Connection>
-      <ConfigKey persist="true">[Master],show_library</ConfigKey>
+      <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
       <BindProperty>visible</BindProperty>
       <Transform>
         <Not/>

--- a/res/skins/Deere/sample_decks.xml
+++ b/res/skins/Deere/sample_decks.xml
@@ -121,7 +121,7 @@
       </WidgetStack>
     </Children>
     <Connection>
-      <ConfigKey persist="true">[Master],show_library</ConfigKey>
+      <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
       <BindProperty>visible</BindProperty>
       <Transform>
         <Not/>

--- a/res/skins/Deere/sample_decks.xml
+++ b/res/skins/Deere/sample_decks.xml
@@ -121,7 +121,7 @@
       </WidgetStack>
     </Children>
     <Connection>
-      <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+      <ConfigKey>[Master],maximize_library</ConfigKey>
       <BindProperty>visible</BindProperty>
       <Transform>
         <Not/>

--- a/res/skins/Deere/tool_bar.xml
+++ b/res/skins/Deere/tool_bar.xml
@@ -61,7 +61,7 @@
       </PushButton>
 
       <PushButton>
-        <TooltipId>toggle_expanded_library</TooltipId>
+        <TooltipId>maximize_library</TooltipId>
         <Size>40f,20f</Size>
         <NumberStates>2</NumberStates>
         <State>

--- a/res/skins/Deere/tool_bar.xml
+++ b/res/skins/Deere/tool_bar.xml
@@ -73,7 +73,7 @@
           <Text>-LIBRARY</Text>
         </State>
         <Connection>
-          <ConfigKey persist="true">[Master],show_library</ConfigKey>
+          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
           <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
         </Connection>
       </PushButton>

--- a/res/skins/Deere/tool_bar.xml
+++ b/res/skins/Deere/tool_bar.xml
@@ -73,7 +73,7 @@
           <Text>-LIBRARY</Text>
         </State>
         <Connection>
-          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+          <ConfigKey>[Master],maximize_library</ConfigKey>
           <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
         </Connection>
       </PushButton>

--- a/res/skins/LateNight/fx_samplers_container_full.xml
+++ b/res/skins/LateNight/fx_samplers_container_full.xml
@@ -6,7 +6,7 @@
         <Children>
             <WidgetStack currentpage="[Library],show_big_current" persist="true">
                 <Children>
-                    <WidgetGroup trigger="[Library],unshow_big">
+                    <WidgetGroup trigger="[Master],maximize_library">
                         <Layout>vertical</Layout>
                         <Children>
                             <WidgetStack currentpage="[Samplers],current" persist="true">

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -82,7 +82,7 @@
         <Children>
             <WidgetStack currentpage="[Library],show_big_current" persist="true">
                 <Children>
-                    <WidgetGroup trigger="[Library],unshow_big">
+                    <WidgetGroup trigger="[Master],maximize_library">
                         <Layout>horizontal</Layout>
                         <SizePolicy>i,max</SizePolicy>
                         <!-- <MinimumSize>1280,525</MinimumSize>-->

--- a/res/skins/LateNight/toolbar_full.xml
+++ b/res/skins/LateNight/toolbar_full.xml
@@ -116,11 +116,11 @@
                           <Text>BIG LIBRARY</Text>
                         </State>
                         <Connection>
-                          <ConfigKey persist="true">[Library],unshow_big</ConfigKey>
+                          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
                           <ButtonState>LeftButton</ButtonState>
                         </Connection>
                         <Connection>
-                          <ConfigKey persist="true">[Library],unshow_big</ConfigKey>
+                          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
                         </Connection>
                     </PushButton>
                 </Children>

--- a/res/skins/LateNight/toolbar_full.xml
+++ b/res/skins/LateNight/toolbar_full.xml
@@ -104,7 +104,7 @@
                         is the pushed state.  So we have to invert everything so the
                         default is 'don't make the library huge' -->
                         <Size>80f,20f</Size>
-                        <TooltipId>toggle_expanded_library</TooltipId>
+                        <TooltipId>maximize_library</TooltipId>
                         <ObjectName>GuiToggleButtonInverted</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>

--- a/res/skins/LateNight/toolbar_full.xml
+++ b/res/skins/LateNight/toolbar_full.xml
@@ -116,11 +116,11 @@
                           <Text>BIG LIBRARY</Text>
                         </State>
                         <Connection>
-                          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+                          <ConfigKey>[Master],maximize_library</ConfigKey>
                           <ButtonState>LeftButton</ButtonState>
                         </Connection>
                         <Connection>
-                          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+                          <ConfigKey>[Master],maximize_library</ConfigKey>
                         </Connection>
                     </PushButton>
                 </Children>

--- a/res/skins/LateNight/toolbar_med.xml
+++ b/res/skins/LateNight/toolbar_med.xml
@@ -116,11 +116,11 @@
                           <Text>BIG LIBRARY</Text>
                         </State>
                         <Connection>
-                          <ConfigKey persist="true">[Library],unshow_big</ConfigKey>
+                          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
                           <ButtonState>LeftButton</ButtonState>
                         </Connection>
                         <Connection>
-                          <ConfigKey persist="true">[Library],unshow_big</ConfigKey>
+                          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
                         </Connection>
                     </PushButton>
                 </Children>

--- a/res/skins/LateNight/toolbar_med.xml
+++ b/res/skins/LateNight/toolbar_med.xml
@@ -104,7 +104,7 @@
                         is the pushed state.  So we have to invert everything so the
                         default is 'don't make the library huge' -->
                         <Size>80f,20f</Size>
-                        <TooltipId>toggle_expanded_library</TooltipId>
+                        <TooltipId>maximize_library</TooltipId>
                         <ObjectName>GuiToggleButtonInverted</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>

--- a/res/skins/LateNight/toolbar_med.xml
+++ b/res/skins/LateNight/toolbar_med.xml
@@ -116,11 +116,11 @@
                           <Text>BIG LIBRARY</Text>
                         </State>
                         <Connection>
-                          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+                          <ConfigKey>[Master],maximize_library</ConfigKey>
                           <ButtonState>LeftButton</ButtonState>
                         </Connection>
                         <Connection>
-                          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+                          <ConfigKey>[Master],maximize_library</ConfigKey>
                         </Connection>
                     </PushButton>
                 </Children>

--- a/res/skins/LateNight/toolbar_small.xml
+++ b/res/skins/LateNight/toolbar_small.xml
@@ -108,7 +108,7 @@
                         is the pushed state.  So we have to invert everything so the
                         default is 'don't make the library huge' -->
                         <Size>80f,20f</Size>
-                        <TooltipId>toggle_expanded_library</TooltipId>
+                        <TooltipId>maximize_library</TooltipId>
                         <ObjectName>GuiToggleButtonInverted</ObjectName>
                         <NumberStates>2</NumberStates>
                         <State>

--- a/res/skins/LateNight/toolbar_small.xml
+++ b/res/skins/LateNight/toolbar_small.xml
@@ -120,11 +120,11 @@
                           <Text>BIG LIBRARY</Text>
                         </State>
                         <Connection>
-                          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+                          <ConfigKey>[Master],maximize_library</ConfigKey>
                           <ButtonState>LeftButton</ButtonState>
                         </Connection>
                         <Connection>
-                          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+                          <ConfigKey>[Master],maximize_library</ConfigKey>
                         </Connection>
                     </PushButton>
                 </Children>

--- a/res/skins/LateNight/toolbar_small.xml
+++ b/res/skins/LateNight/toolbar_small.xml
@@ -120,11 +120,11 @@
                           <Text>BIG LIBRARY</Text>
                         </State>
                         <Connection>
-                          <ConfigKey persist="true">[Library],unshow_big</ConfigKey>
+                          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
                           <ButtonState>LeftButton</ButtonState>
                         </Connection>
                         <Connection>
-                          <ConfigKey persist="true">[Library],unshow_big</ConfigKey>
+                          <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
                         </Connection>
                     </PushButton>
                 </Children>

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -243,7 +243,7 @@
 				</WidgetGroup>
 			</Children>
       <Connection>
-        <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+        <ConfigKey>[Master],maximize_library</ConfigKey>
         <BindProperty>visible</BindProperty>
         <Transform>
           <Not/>
@@ -290,7 +290,7 @@
 						<BindProperty>visible</BindProperty>
 					</Connection>
           <Connection>
-            <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+            <ConfigKey>[Master],maximize_library</ConfigKey>
             <BindProperty>visible</BindProperty>
             <Transform>
               <Not/>
@@ -316,7 +316,7 @@
 						<BindProperty>visible</BindProperty>
 					</Connection>
           <Connection>
-            <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+            <ConfigKey>[Master],maximize_library</ConfigKey>
             <BindProperty>visible</BindProperty>
             <Transform>
               <Not/>

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -242,8 +242,15 @@
 					</Children>
 				</WidgetGroup>
 			</Children>
-		</WidgetGroup>  	
-	
+      <Connection>
+        <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+        <BindProperty>visible</BindProperty>
+        <Transform>
+          <Not/>
+        </Transform>
+      </Connection>
+		</WidgetGroup>
+
 		<!--
 		############################################################################################
 		############################################################################################
@@ -282,9 +289,15 @@
 						<ConfigKey persist="true">[Samplers],show_samplers</ConfigKey>
 						<BindProperty>visible</BindProperty>
 					</Connection>
+          <Connection>
+            <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+            <BindProperty>visible</BindProperty>
+            <Transform>
+              <Not/>
+            </Transform>
+          </Connection>
 				</WidgetGroup>
-				
-				
+
 				<!-- EffectRack1 sub-widget -->
 				<WidgetGroup>
 					<Size>i,m</Size>
@@ -293,7 +306,7 @@
 					<Children>
   						<Template src="skin:effectunit.xml">
 							<SetVariable name="effectunitnum">1</SetVariable>
-						</Template>	
+						</Template>
 						<Template src="skin:effectunit.xml">
 							<SetVariable name="effectunitnum">2</SetVariable>
 						</Template>
@@ -302,6 +315,13 @@
 						<ConfigKey persist="true">[EffectRack1],show</ConfigKey>
 						<BindProperty>visible</BindProperty>
 					</Connection>
+          <Connection>
+            <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+            <BindProperty>visible</BindProperty>
+            <Transform>
+              <Not/>
+            </Transform>
+          </Connection>
 				</WidgetGroup>
 
 				<!--

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -267,54 +267,72 @@
 			cause push buttons in library will show up with wrong margin/padding -->
 			<Style>QGroupBox { border: 0px solid red; }</Style>
 			<Children>
-				<!-- Sampler Bank sub-widget -->
-				<WidgetGroup>
-					<Layout>horizontal</Layout>
-					<Style>QGroupBox { border: 0px solid yellow; margin: 0px 0px 6px 0px;} </Style>
-					<Children>
-  						<Template src="skin:sampler.xml">
-							<SetVariable name="samplernum">1</SetVariable>
-						</Template>	
-						<Template src="skin:sampler.xml">
-							<SetVariable name="samplernum">2</SetVariable>
-						</Template>
-						<Template src="skin:sampler.xml">
-							<SetVariable name="samplernum">3</SetVariable>
-						</Template>		
-						<Template src="skin:sampler.xml">
-							<SetVariable name="samplernum">4</SetVariable>
-						</Template>	
-					</Children>
-					<Connection>
-						<ConfigKey persist="true">[Samplers],show_samplers</ConfigKey>
-						<BindProperty>visible</BindProperty>
-					</Connection>
-          <Connection>
-            <ConfigKey>[Master],maximize_library</ConfigKey>
-            <BindProperty>visible</BindProperty>
-            <Transform>
-              <Not/>
-            </Transform>
-          </Connection>
-				</WidgetGroup>
+        <!-- Sampler Bank sub-widget -->
+        <WidgetGroup>
+          <SizePolicy>me,f</SizePolicy>
+          <Layout>horizontal</Layout>
+          <!-- I don't now why this works but a WidgetGroup wrapper around a
+             WidgetStack with a 'fixed' size policy makes the group track the
+             minimum size of the current stack widget. -->
+          <Children>
+            <WidgetGroup>
+              <Layout>horizontal</Layout>
+              <Style>QGroupBox { border: 0px solid yellow; margin: 0px 0px 6px 0px;} </Style>
+              <Children>
+                  <Template src="skin:sampler.xml">
+                  <SetVariable name="samplernum">1</SetVariable>
+                </Template>
+                <Template src="skin:sampler.xml">
+                  <SetVariable name="samplernum">2</SetVariable>
+                </Template>
+                <Template src="skin:sampler.xml">
+                  <SetVariable name="samplernum">3</SetVariable>
+                </Template>
+                <Template src="skin:sampler.xml">
+                  <SetVariable name="samplernum">4</SetVariable>
+                </Template>
+              </Children>
+              <Connection>
+                <ConfigKey persist="true">[Samplers],show_samplers</ConfigKey>
+                <BindProperty>visible</BindProperty>
+              </Connection>
+            </WidgetGroup>
+          </Children>
+           <Connection>
+             <ConfigKey>[Master],maximize_library</ConfigKey>
+             <BindProperty>visible</BindProperty>
+             <Transform>
+               <Not/>
+             </Transform>
+           </Connection>
+        </WidgetGroup>
 
-				<!-- EffectRack1 sub-widget -->
-				<WidgetGroup>
-					<Size>i,m</Size>
-					<Layout>horizontal</Layout>
-					<Style>QGroupBox { border: 0px solid yellow; margin: 0px 0px 6px 0px;} </Style>
-					<Children>
-  						<Template src="skin:effectunit.xml">
-							<SetVariable name="effectunitnum">1</SetVariable>
-						</Template>
-						<Template src="skin:effectunit.xml">
-							<SetVariable name="effectunitnum">2</SetVariable>
-						</Template>
-					</Children>
-					<Connection>
-						<ConfigKey persist="true">[EffectRack1],show</ConfigKey>
-						<BindProperty>visible</BindProperty>
-					</Connection>
+        <!-- EffectRack1 sub-widget -->
+        <WidgetGroup>
+          <SizePolicy>me,f</SizePolicy>
+          <Layout>horizontal</Layout>
+          <!-- I don't now why this works but a WidgetGroup wrapper around a
+             WidgetStack with a 'fixed' size policy makes the group track the
+             minimum size of the current stack widget. -->
+          <Children>
+            <WidgetGroup>
+              <SizePolicy>me,min</SizePolicy>
+              <Layout>horizontal</Layout>
+              <Style>QGroupBox { border: 0px solid yellow; margin: 0px 0px 6px 0px;} </Style>
+              <Children>
+                  <Template src="skin:effectunit.xml">
+                  <SetVariable name="effectunitnum">1</SetVariable>
+                </Template>
+                <Template src="skin:effectunit.xml">
+                  <SetVariable name="effectunitnum">2</SetVariable>
+                </Template>
+              </Children>
+              <Connection>
+                <ConfigKey persist="true">[EffectRack1],show</ConfigKey>
+                <BindProperty>visible</BindProperty>
+              </Connection>
+            </WidgetGroup>
+          </Children>
           <Connection>
             <ConfigKey>[Master],maximize_library</ConfigKey>
             <BindProperty>visible</BindProperty>
@@ -322,7 +340,7 @@
               <Not/>
             </Transform>
           </Connection>
-				</WidgetGroup>
+        </WidgetGroup>
 
 				<!--
 				**********************************************

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -691,6 +691,9 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addControl("[PreviewDeck]", "show_previewdeck",
                tr("Preview Deck Show/Hide"),
                tr("Show/hide the preview deck"), guiMenu);
+    addControl("[Master]", "maximize_library",
+               tr("Library Maximize/Restore"),
+               tr("Maximize the track library to take up all the available screen space."), guiMenu);
     addControl("[EffectRack1]", "show",
                tr("Effect Rack Show/Hide"),
                tr("Show/hide the effect rack"), guiMenu);

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -836,6 +836,10 @@ void MixxxMainWindow::slotViewShowCoverArt(bool enable) {
     toggleVisibility(ConfigKey("[Library]", "show_coverart"), enable);
 }
 
+void MixxxMainWindow::slotViewMaximizeLibrary(bool enable) {
+    toggleVisibility(ConfigKey("[Master]", "maximize_library"), enable);
+}
+
 void setVisibilityOptionState(QAction* pAction, ConfigKey key) {
     ControlObject* pVisibilityControl = ControlObject::getControl(key);
     pAction->setEnabled(pVisibilityControl != NULL);
@@ -857,6 +861,8 @@ void MixxxMainWindow::onNewSkinLoaded() {
                              ConfigKey("[EffectRack1]", "show"));
     setVisibilityOptionState(m_pViewShowCoverArt,
                              ConfigKey("[Library]", "show_coverart"));
+    setVisibilityOptionState(m_pViewMaximizeLibrary,
+                             ConfigKey("[Master]", "maximize_library"));
 }
 
 int MixxxMainWindow::noSoundDlg(void)
@@ -1322,6 +1328,20 @@ void MixxxMainWindow::initActions()
     connect(m_pViewShowCoverArt, SIGNAL(toggled(bool)),
             this, SLOT(slotViewShowCoverArt(bool)));
 
+    QString maximizeLibraryTitle = tr("Maximize Library");
+    QString maximizeLibraryText = tr("Maximize the track library to take up all the available screen space.") +
+            " " + mayNotBeSupported;
+    m_pViewMaximizeLibrary = new QAction(maximizeLibraryTitle, this);
+    m_pViewMaximizeLibrary->setCheckable(true);
+    m_pViewMaximizeLibrary->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                  "ViewMenu_MaximizeLibrary"),
+                                                  tr("Space", "Menubar|View|MAximize Library"))));
+    m_pViewMaximizeLibrary->setStatusTip(maximizeLibraryText);
+    m_pViewMaximizeLibrary->setWhatsThis(buildWhatsThis(maximizeLibraryTitle, maximizeLibraryText));
+    connect(m_pViewMaximizeLibrary, SIGNAL(toggled(bool)),
+            this, SLOT(slotViewMaximizeLibrary(bool)));
+    
     QString recordTitle = tr("&Record Mix");
     QString recordText = tr("Record your mix to a file");
     m_pOptionsRecord = new QAction(recordTitle, this);
@@ -1491,6 +1511,7 @@ void MixxxMainWindow::initMenuBar()
     m_pViewMenu->addAction(m_pViewShowPreviewDeck);
     m_pViewMenu->addAction(m_pViewShowEffects);
     m_pViewMenu->addAction(m_pViewShowCoverArt);
+    m_pViewMenu->addAction(m_pViewMaximizeLibrary);
     m_pViewMenu->addSeparator();
     m_pViewMenu->addAction(m_pViewFullScreen);
 

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -118,6 +118,7 @@ class MixxxMainWindow : public QMainWindow {
     void slotViewShowPreviewDeck(bool);
     void slotViewShowEffects(bool);
     void slotViewShowCoverArt(bool);
+    void slotViewMaximizeLibrary(bool);
     // toogle full screen mode
     void slotViewFullScreen(bool toggle);
     // Reload the skin.
@@ -241,6 +242,7 @@ class MixxxMainWindow : public QMainWindow {
     QAction* m_pViewShowPreviewDeck;
     QAction* m_pViewShowEffects;
     QAction* m_pViewShowCoverArt;
+    QAction* m_pViewMaximizeLibrary;
     QAction* m_pViewFullScreen;
     QAction* m_pHelpAboutApp;
     QAction* m_pHelpSupport;

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -184,9 +184,9 @@ void Tooltips::addStandardTooltips() {
             << tr("Show Effect Rack")
             << tr("Show or hide the effect rack.");
 
-    add("toggle_expanded_library")
-            << tr("Toggle Big Library")
-            << tr("Makes the library fill the screen.");
+    add("maximize_library")
+            << tr("Maximize Library")
+            << tr("Maximize the track library to take up all the available screen space.");
 
     add("show_mixer")
             << tr("Toggle Mixer")


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/mixxx/+bug/1430847

Possible extensions:
- [x] Remove `persist="true"` so you cant get stuck with just a library on reboot
- [x] Add to the `View` menu in the menu bar
- [x] Add to the Midi Wizard

Thanks for reviewing.
