### PR TITLE
Bug #1430565 - Exiting search box behavior erratic, not predictable

### DIFF
--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -26,11 +26,6 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
         QKeySequence(tr("Ctrl+F", "Search|Focus")), this);
     connect(setFocusShortcut, SIGNAL(activated()),
             this, SLOT(setFocus()));
-    QShortcut *clearTextShortcut = new QShortcut(
-        QKeySequence(tr("Esc", "Search|Clear")), this, 0, 0,
-        Qt::WidgetShortcut);
-    connect(clearTextShortcut, SIGNAL(activated()),
-            this, SLOT(onSearchTextCleared()));
 
     connect(this, SIGNAL(textChanged(const QString&)),
             this, SLOT(slotTextChanged(const QString&)));

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -3,6 +3,7 @@
 #include <QDesktopServices>
 #include <QUrl>
 #include <QDrag>
+#include <QShortcut>
 
 #include "widget/wwidget.h"
 #include "widget/wskincolor.h"
@@ -110,6 +111,11 @@ WTrackTableView::WTrackTableView(QWidget * parent,
 
     connect(this, SIGNAL(scrollValueChanged(int)),
             this, SLOT(slotScrollValueChanged(int)));
+
+    QShortcut *setFocusShortcut = new QShortcut(
+        QKeySequence(tr("ESC", "Focus")), this);
+    connect(setFocusShortcut, SIGNAL(activated()),
+            this, SLOT(setFocus()));
 }
 
 WTrackTableView::~WTrackTableView() {


### PR DESCRIPTION
Now when you press ESC the focus from searchbox shifts to library. 
