### PR TITLE
Don't use a keylock scaler at very slow speeds.

### DIFF
--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -77,7 +77,6 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
                 EngineBuffer::getKeylockEngineName(
                         static_cast<EngineBuffer::KeylockEngine>(i)));
     }
-    keylockComboBox->setCurrentIndex(EngineBuffer::RUBBERBAND);
 
     initializePaths();
     loadSettings();
@@ -193,6 +192,8 @@ void DlgPrefSound::slotApply() {
     }
 
     m_pKeylockEngine->set(keylockComboBox->currentIndex());
+    m_pConfig->set(ConfigKey("[Master]", "keylock_engine"),
+                   ConfigValue(keylockComboBox->currentIndex()));
 
     m_config.clearInputs();
     m_config.clearOutputs();
@@ -373,6 +374,11 @@ void DlgPrefSound::loadSettings(const SoundManagerConfig &config) {
         // "Default (long delay)" = 2 buffer
         deviceSyncComboBox->setCurrentIndex(0);
     }
+
+    // Default keylock is Rubberband.
+    int keylock_engine = m_pConfig->getValueString(
+            ConfigKey("[Master]", "keylock_engine"), "1").toInt();
+    keylockComboBox->setCurrentIndex(keylock_engine);
 
     emit(loadPaths(m_config));
     m_loading = false;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -92,10 +92,12 @@ EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
           m_startButton(NULL),
           m_endButton(NULL),
           m_pScale(NULL),
+          m_pScaleVinyl(NULL),
+          m_pScaleKeylock(NULL),
           m_pScaleLinear(NULL),
           m_pScaleST(NULL),
           m_pScaleRB(NULL),
-          m_pScaleKeylock(NULL),
+          m_pScaleDummy(NULL),
           m_bScalerChanged(false),
           m_bScalerOverride(false),
           m_iSeekQueued(NO_SEEK),
@@ -287,6 +289,7 @@ EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
     } else {
         m_pScaleKeylock = m_pScaleRB;
     }
+    m_pScaleVinyl = m_pScaleLinear;
     enableIndependentPitchTempoScaling(false, 0);
 
     m_pPassthroughEnabled.reset(new ControlObjectSlave(group, "passthrough", this));
@@ -373,9 +376,9 @@ void EngineBuffer::enableIndependentPitchTempoScaling(bool bEnable,
         m_pScale = keylock_scale;
         m_pScale->clear();
         m_bScalerChanged = true;
-    } else if (!bEnable && m_pScale != m_pScaleLinear) {
+    } else if (!bEnable && m_pScale != m_pScaleVinyl) {
         readToCrossfadeBuffer(iBufferSize);
-        m_pScale = m_pScaleLinear;
+        m_pScale = m_pScaleVinyl;
         m_pScale->clear();
         m_bScalerChanged = true;
     }
@@ -893,7 +896,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
             // wanted rate!  Make sure new scaler has proper position. This also
             // crossfades between the old scaler and new scaler to prevent
             // clicks.
-            if (m_pScale != m_pScaleLinear) { // linear scaler does this part for us now
+            if (m_pScale != m_pScaleVinyl) { // linear scaler does this part for us now
                 //XXX: Trying to force RAMAN to read from correct
                 //     playpos when rate changes direction - Albert
                 if ((m_speed_old <= 0 && speed > 0) ||
@@ -1348,11 +1351,11 @@ void EngineBuffer::setReader(CachingReader* pReader) {
 }
 */
 
-void EngineBuffer::setScalerForTest(EngineBufferScale* pScaleLinear,
+void EngineBuffer::setScalerForTest(EngineBufferScale* pScaleVinyl,
                                     EngineBufferScale* pScaleKeylock) {
-    m_pScaleLinear = pScaleLinear;
+    m_pScaleVinyl = pScaleVinyl;
     m_pScaleKeylock = pScaleKeylock;
-    m_pScale = m_pScaleLinear;
+    m_pScale = m_pScaleVinyl;
     m_pScale->clear();
     // This bool is permanently set and can't be undone.
     m_bScalerOverride = true;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -747,11 +747,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
     // We do this even if rubberband is not active.
     if (sample_rate != m_iSampleRate) {
         if (m_pScaleRB != NULL) {
-            // TODO: this cast will be removed once we refactor scalers
-            // to all have a set-sample-rate member.  For now it's ok because
-            // we know that this conversion will succeed.
-            static_cast<EngineBufferScaleRubberBand*>(m_pScaleRB)->initializeRubberBand(
-                    sample_rate);
+            m_pScaleRB->initializeRubberBand(sample_rate);
         }
         m_iSampleRate = sample_rate;
     }

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -709,6 +709,9 @@ void EngineBuffer::slotControlSlip(double v)
 }
 
 void EngineBuffer::slotKeylockEngineChanged(double dIndex) {
+    if (m_bScalerOverride) {
+        return;
+    }
     // static_cast<KeylockEngine>(dIndex); direct cast produces a "not used" warning with gcc
     int iEngine = static_cast<int>(dIndex);
     KeylockEngine engine = static_cast<KeylockEngine>(iEngine);
@@ -744,10 +747,10 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
     // We do this even if rubberband is not active.
     if (sample_rate != m_iSampleRate) {
         if (m_pScaleRB != NULL) {
-            // TODO: this dynamic cast will be removed once we refactor scalers
+            // TODO: this cast will be removed once we refactor scalers
             // to all have a set-sample-rate member.  For now it's ok because
-            // this is called very rarely.
-            dynamic_cast<EngineBufferScaleRubberBand*>(m_pScaleRB)->initializeRubberBand(
+            // we know that this conversion will succeed.
+            static_cast<EngineBufferScaleRubberBand*>(m_pScaleRB)->initializeRubberBand(
                     sample_rate);
         }
         m_iSampleRate = sample_rate;
@@ -788,8 +791,8 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
 
         // TODO(owen): Maybe change this so that rubberband doesn't disable
         // keylock on scratch. (just check m_pScaleKeylock == m_pScaleST)
-        if (is_scratching || fabs(speed) > 1.9 || fabs(speed) < 0.1) {
-            // Scratching and high or low speeds with Soundtouch always disables keylock
+        if (is_scratching || fabs(speed) > 1.9) {
+            // Scratching and high speeds with always disables keylock
             // because Soundtouch sounds terrible in these conditions.  Rubberband
             // sounds better, but still has some problems (it may reallocate in
             // a party-crashing manner at extremely slow speeds).
@@ -802,6 +805,11 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
             pitchRatio = speed;
             keylock_enabled = false;
             // This is for the natural speed pitch found on turn tables
+        } else if (fabs(speed) < 0.1 && m_pKeylockEngine->get() == RUBBERBAND) {
+            // At very slow speeds, Rubberband performs memory allocations which
+            // can cause underruns.  Disable keylock under these conditions.
+            pitchRatio = speed;
+            keylock_enabled = false;
         } else if (!keylock_enabled) {
             // We might have have temporary speed change, so adjust pitch if not locked
             // Note: This will not update key and tempo widgets

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -155,7 +155,8 @@ class EngineBuffer : public EngineObject {
     //void setReader(CachingReader* pReader);
 
     // For dependency injection of scalers.
-    void setScalerForTest(EngineBufferScale* pScale);
+    void setScalerForTest(EngineBufferScale* pScale,
+                          EngineBufferScale* pScaleKeylock);
 
     // For dependency injection of fake tracks, with an optional filebpm value.
     TrackPointer loadFakeTrack(double filebpm = 0);
@@ -346,11 +347,12 @@ class EngineBuffer : public EngineObject {
 
     // Object used to perform waveform scaling (sample rate conversion)
     EngineBufferScale* m_pScale;
+    FRIEND_TEST(EngineBufferTest, SlowRubberBand);
     // Object used for linear interpolation scaling of the audio
-    EngineBufferScaleLinear* m_pScaleLinear;
+    EngineBufferScale* m_pScaleLinear;
     // Object used for pitch-indep time stretch (key lock) scaling of the audio
-    EngineBufferScaleST* m_pScaleST;
-    EngineBufferScaleRubberBand* m_pScaleRB;
+    EngineBufferScale* m_pScaleST;
+    EngineBufferScale* m_pScaleRB;
     // The keylock engine is configurable, so it could flip flop between
     // ScaleST and ScaleRB during a single callback.
     EngineBufferScale* volatile m_pScaleKeylock;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -351,8 +351,8 @@ class EngineBuffer : public EngineObject {
     // Object used for linear interpolation scaling of the audio
     EngineBufferScale* m_pScaleLinear;
     // Object used for pitch-indep time stretch (key lock) scaling of the audio
-    EngineBufferScale* m_pScaleST;
-    EngineBufferScale* m_pScaleRB;
+    EngineBufferScaleST* m_pScaleST;
+    EngineBufferScaleRubberBand* m_pScaleRB;
     // The keylock engine is configurable, so it could flip flop between
     // ScaleST and ScaleRB during a single callback.
     EngineBufferScale* volatile m_pScaleKeylock;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -345,18 +345,22 @@ class EngineBuffer : public EngineObject {
     ControlPushButton* m_startButton;
     ControlPushButton* m_endButton;
 
-    // Object used to perform waveform scaling (sample rate conversion)
+    // Object used to perform waveform scaling (sample rate conversion).  These
+    // three pointers may be reassigned depending on configuration and tests.
     EngineBufferScale* m_pScale;
     FRIEND_TEST(EngineBufferTest, SlowRubberBand);
-    // Object used for linear interpolation scaling of the audio
-    EngineBufferScale* m_pScaleLinear;
-    // Object used for pitch-indep time stretch (key lock) scaling of the audio
-    EngineBufferScaleST* m_pScaleST;
-    EngineBufferScaleRubberBand* m_pScaleRB;
+    EngineBufferScale* m_pScaleVinyl;
     // The keylock engine is configurable, so it could flip flop between
     // ScaleST and ScaleRB during a single callback.
     EngineBufferScale* volatile m_pScaleKeylock;
+
+    // Object used for vinyl-style interpolation scaling of the audio
+    EngineBufferScaleLinear* m_pScaleLinear;
+    // Objects used for pitch-indep time stretch (key lock) scaling of the audio
+    EngineBufferScaleST* m_pScaleST;
+    EngineBufferScaleRubberBand* m_pScaleRB;
     EngineBufferScaleDummy* m_pScaleDummy;
+
     // Indicates whether the scaler has changed since the last process()
     bool m_bScalerChanged;
     // Indicates that dependency injection has taken place.

--- a/src/engine/keycontrol.cpp
+++ b/src/engine/keycontrol.cpp
@@ -161,7 +161,7 @@ void KeyControl::slotRateChanged() {
 }
 
 void KeyControl::updateRate() {
-    //qDebug() << "KeyControl::slotRateChanged 1" << m_pitchRatio << m_speedSliderPitchRatio;
+    //qDebug() << "KeyControl::slotRateChanged 1" << m_pitchRateInfo.pitchRatio;
 
     // If rate is not 1.0 then we have to try and calculate the octave change
     // caused by it.
@@ -289,9 +289,9 @@ void KeyControl::updatePitch() {
     double pitch = m_pPitch->get();
 
     //qDebug() << "KeyControl::slotPitchChanged 1" << pitch <<
-    //        pitchRateInfo.pitchRatio <<
-    //        pitchRateInfo.pitchTweakRatio <<
-    //        pitchRateInfo.tempoRatio;
+    //        m_pitchRateInfo.pitchRatio <<
+    //        m_pitchRateInfo.pitchTweakRatio <<
+    //        m_pitchRateInfo.tempoRatio;
 
     double speedSliderPitchRatio =
             m_pitchRateInfo.pitchRatio / m_pitchRateInfo.pitchTweakRatio;
@@ -306,9 +306,9 @@ void KeyControl::updatePitch() {
     updateKeyCOs(dFileKey, KeyUtils::powerOf2ToOctaveChange(pitchKnobRatio));
 
     //qDebug() << "KeyControl::slotPitchChanged 2" << pitch <<
-    //        pitchRateInfo.pitchRatio <<
-    //        pitchRateInfo.pitchTweakRatio <<
-    //        pitchRateInfo.tempoRatio;
+    //        m_pitchRateInfo.pitchRatio <<
+    //        m_pitchRateInfo.pitchTweakRatio <<
+    //        m_pitchRateInfo.tempoRatio;
 }
 
 void KeyControl::slotPitchAdjustChanged(double pitchAdjust) {
@@ -321,9 +321,9 @@ void KeyControl::updatePitchAdjust() {
     double pitchAdjust = m_pPitchAdjust->get();
 
     //qDebug() << "KeyControl::slotPitchAdjustChanged 1" << pitchAdjust <<
-    //        pitchRateInfo.pitchRatio <<
-    //        pitchRateInfo.pitchTweakRatio <<
-    //        pitchRateInfo.tempoRatio;
+    //        m_pitchRateInfo.pitchRatio <<
+    //        m_pitchRateInfo.pitchTweakRatio <<
+    //        m_pitchRateInfo.tempoRatio;
 
     double speedSliderPitchRatio = m_pitchRateInfo.pitchRatio / m_pitchRateInfo.pitchTweakRatio;
     // speedSliderPitchRatio must be unchanged
@@ -338,9 +338,9 @@ void KeyControl::updatePitchAdjust() {
     updateKeyCOs(dFileKey, KeyUtils::powerOf2ToOctaveChange(pitchKnobRatio));
 
     //qDebug() << "KeyControl::slotPitchAdjustChanged 2" << pitchAdjust <<
-    //        pitchRateInfo.pitchRatio <<
-    //        pitchRateInfo.pitchTweakRatio <<
-    //        pitchRateInfo.tempoRatio;
+    //        m_pitchRateInfo.pitchRatio <<
+    //        m_pitchRateInfo.pitchTweakRatio <<
+    //        m_pitchRateInfo.tempoRatio;
 }
 
 void KeyControl::slotSyncKey(double v) {

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -80,3 +80,18 @@ TEST_F(EngineBufferTest, PitchRoundtrip) {
     // pitch must reflect the pitch shift only
     ASSERT_DOUBLE_EQ(0.5, ControlObject::get(ConfigKey(m_sGroup1, "rate")));
 }
+
+TEST_F(EngineBufferTest, SlowRubberBand) {
+    // At very slow speeds, RubberBand needs to reallocate buffers and since this
+    // is done in the engine thread it can be a major party-stopper.
+    // Make sure slow speeds still use the linear scaler.
+    ControlObject::set(ConfigKey(m_sGroup1, "pitch"), 2.8);
+
+    // Hack to get a slow, non-scratching direct speed
+    ControlObject::set(ConfigKey(m_sGroup1, "rateSearch"), 0.0072);
+
+    ProcessBuffer();
+
+    // Scaler should still be linear
+    ASSERT_EQ(m_pMockScaleLinear1, m_pChannel1->getEngineBuffer()->m_pScale);
+}

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -100,5 +100,5 @@ TEST_F(EngineBufferTest, SlowRubberBand) {
     ControlObject::set(ConfigKey("[Master]", "keylock_engine"),
                        static_cast<double>(EngineBuffer::RUBBERBAND));
     ProcessBuffer();
-    EXPECT_EQ(m_pMockScaleLinear1, m_pChannel1->getEngineBuffer()->m_pScale);
+    EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
 }

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -90,8 +90,15 @@ TEST_F(EngineBufferTest, SlowRubberBand) {
     // Hack to get a slow, non-scratching direct speed
     ControlObject::set(ConfigKey(m_sGroup1, "rateSearch"), 0.0072);
 
+    // With Soundtouch, the scaler should still be the keylock scaler
+    ControlObject::set(ConfigKey("[Master]", "keylock_engine"),
+                       static_cast<double>(EngineBuffer::SOUNDTOUCH));
     ProcessBuffer();
+    EXPECT_EQ(m_pMockScaleKeylock1, m_pChannel1->getEngineBuffer()->m_pScale);
 
-    // Scaler should still be linear
-    ASSERT_EQ(m_pMockScaleLinear1, m_pChannel1->getEngineBuffer()->m_pScale);
+    // With Rubberband, the scaler should be linear
+    ControlObject::set(ConfigKey("[Master]", "keylock_engine"),
+                       static_cast<double>(EngineBuffer::RUBBERBAND));
+    ProcessBuffer();
+    EXPECT_EQ(m_pMockScaleLinear1, m_pChannel1->getEngineBuffer()->m_pScale);
 }

--- a/src/test/mockedenginebackendtest.h
+++ b/src/test/mockedenginebackendtest.h
@@ -79,12 +79,18 @@ class MockedEngineBackendTest : public MixxxTest {
 
         m_pEngineSync = m_pEngineMaster->getEngineSync();
 
-        m_pMockScaler1 = new MockScaler();
-        m_pMockScaler2 = new MockScaler();
-        m_pMockScaler3 = new MockScaler();
-        m_pChannel1->getEngineBuffer()->setScalerForTest(m_pMockScaler1);
-        m_pChannel2->getEngineBuffer()->setScalerForTest(m_pMockScaler2);
-        m_pChannel3->getEngineBuffer()->setScalerForTest(m_pMockScaler3);
+        m_pMockScaleLinear1 = new MockScaler();
+        m_pMockScaleKeylock1 = new MockScaler();
+        m_pMockScaleLinear2 = new MockScaler();
+        m_pMockScaleKeylock2 = new MockScaler();
+        m_pMockScaleLinear3 = new MockScaler();
+        m_pMockScaleKeylock3 = new MockScaler();
+        m_pChannel1->getEngineBuffer()->setScalerForTest(m_pMockScaleLinear1,
+                                                         m_pMockScaleKeylock1);
+        m_pChannel2->getEngineBuffer()->setScalerForTest(m_pMockScaleLinear2,
+                                                         m_pMockScaleKeylock2);
+        m_pChannel3->getEngineBuffer()->setScalerForTest(m_pMockScaleLinear3,
+                                                         m_pMockScaleKeylock3);
         m_pTrack1 = m_pChannel1->getEngineBuffer()->loadFakeTrack();
         m_pTrack2 = m_pChannel2->getEngineBuffer()->loadFakeTrack();
         m_pTrack3 = m_pChannel3->getEngineBuffer()->loadFakeTrack();
@@ -110,9 +116,10 @@ class MockedEngineBackendTest : public MixxxTest {
         // Deletes all EngineChannels added to it.
         delete m_pEngineMaster;
         delete m_pEffectsManager;
-        delete m_pMockScaler1;
-        delete m_pMockScaler2;
-        delete m_pMockScaler3;
+        // The Mock Linear Scalers will get deleted by the enginebuffer destructor.
+        delete m_pMockScaleKeylock1;
+        delete m_pMockScaleKeylock2;
+        delete m_pMockScaleKeylock3;
         delete m_pNumDecks;
     }
 
@@ -130,7 +137,8 @@ class MockedEngineBackendTest : public MixxxTest {
     EngineSync* m_pEngineSync;
     EngineMaster* m_pEngineMaster;
     EngineDeck *m_pChannel1, *m_pChannel2, *m_pChannel3;
-    MockScaler *m_pMockScaler1, *m_pMockScaler2, *m_pMockScaler3;
+    MockScaler *m_pMockScaleLinear1, *m_pMockScaleLinear2, *m_pMockScaleLinear3;
+    MockScaler *m_pMockScaleKeylock1, *m_pMockScaleKeylock2, *m_pMockScaleKeylock3;
     TrackPointer m_pTrack1, m_pTrack2, m_pTrack3;
     PreviewDeck *m_pPreview1;
     Sampler *m_pSampler1;

--- a/src/test/mockedenginebackendtest.h
+++ b/src/test/mockedenginebackendtest.h
@@ -79,17 +79,17 @@ class MockedEngineBackendTest : public MixxxTest {
 
         m_pEngineSync = m_pEngineMaster->getEngineSync();
 
-        m_pMockScaleLinear1 = new MockScaler();
+        m_pMockScaleVinyl1 = new MockScaler();
         m_pMockScaleKeylock1 = new MockScaler();
-        m_pMockScaleLinear2 = new MockScaler();
+        m_pMockScaleVinyl2 = new MockScaler();
         m_pMockScaleKeylock2 = new MockScaler();
-        m_pMockScaleLinear3 = new MockScaler();
+        m_pMockScaleVinyl3 = new MockScaler();
         m_pMockScaleKeylock3 = new MockScaler();
-        m_pChannel1->getEngineBuffer()->setScalerForTest(m_pMockScaleLinear1,
+        m_pChannel1->getEngineBuffer()->setScalerForTest(m_pMockScaleVinyl1,
                                                          m_pMockScaleKeylock1);
-        m_pChannel2->getEngineBuffer()->setScalerForTest(m_pMockScaleLinear2,
+        m_pChannel2->getEngineBuffer()->setScalerForTest(m_pMockScaleVinyl2,
                                                          m_pMockScaleKeylock2);
-        m_pChannel3->getEngineBuffer()->setScalerForTest(m_pMockScaleLinear3,
+        m_pChannel3->getEngineBuffer()->setScalerForTest(m_pMockScaleVinyl3,
                                                          m_pMockScaleKeylock3);
         m_pTrack1 = m_pChannel1->getEngineBuffer()->loadFakeTrack();
         m_pTrack2 = m_pChannel2->getEngineBuffer()->loadFakeTrack();
@@ -116,7 +116,9 @@ class MockedEngineBackendTest : public MixxxTest {
         // Deletes all EngineChannels added to it.
         delete m_pEngineMaster;
         delete m_pEffectsManager;
-        // The Mock Linear Scalers will get deleted by the enginebuffer destructor.
+        delete m_pMockScaleVinyl1;
+        delete m_pMockScaleVinyl2;
+        delete m_pMockScaleVinyl3;
         delete m_pMockScaleKeylock1;
         delete m_pMockScaleKeylock2;
         delete m_pMockScaleKeylock3;
@@ -137,7 +139,7 @@ class MockedEngineBackendTest : public MixxxTest {
     EngineSync* m_pEngineSync;
     EngineMaster* m_pEngineMaster;
     EngineDeck *m_pChannel1, *m_pChannel2, *m_pChannel3;
-    MockScaler *m_pMockScaleLinear1, *m_pMockScaleLinear2, *m_pMockScaleLinear3;
+    MockScaler *m_pMockScaleVinyl1, *m_pMockScaleVinyl2, *m_pMockScaleVinyl3;
     MockScaler *m_pMockScaleKeylock1, *m_pMockScaleKeylock2, *m_pMockScaleKeylock3;
     TrackPointer m_pTrack1, m_pTrack2, m_pTrack3;
     PreviewDeck *m_pPreview1;


### PR DESCRIPTION
Fixes lp:#1435340
Tested: a new test that mimics the original situation and checks that
the linear scaler is engaged.

This is a lot of code for what is actually a <1 line fix :).  But I had to make the enginebuffer testing apparatus more complete to actually confirm the behavior.
