### PR TITLE
pitch_set_default should revert to linear scaler if keylock is off

### DIFF
--- a/src/controlpotmeter.cpp
+++ b/src/controlpotmeter.cpp
@@ -32,7 +32,8 @@ ControlPotmeter::ControlPotmeter(ConfigKey key, double dMinValue, double dMaxVal
     if (!bPersist) {
         set(default_value);
     }
-    //qDebug() << "" << this << ", min " << m_dMinValue << ", max " << m_dMaxValue << ", range " << m_dValueRange << ", val " << m_dValue;
+    //qDebug() << "" << this << key << ", min " << dMinValue << ", max " << dMaxValue << ", default"
+    //        << default_value;
 }
 
 ControlPotmeter::~ControlPotmeter() {

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -348,6 +348,7 @@ class EngineBuffer : public EngineObject {
     // Object used to perform waveform scaling (sample rate conversion)
     EngineBufferScale* m_pScale;
     FRIEND_TEST(EngineBufferTest, SlowRubberBand);
+    FRIEND_TEST(EngineBufferTest, ResetPitchUsesLinear);
     // Object used for linear interpolation scaling of the audio
     EngineBufferScale* m_pScaleLinear;
     // Object used for pitch-indep time stretch (key lock) scaling of the audio

--- a/src/engine/keycontrol.cpp
+++ b/src/engine/keycontrol.cpp
@@ -287,18 +287,26 @@ void KeyControl::slotPitchChanged(double pitch) {
 
 void KeyControl::updatePitch() {
     double pitch = m_pPitch->get();
+    double pitchKnobRatio = KeyUtils::semitoneChangeToPowerOf2(pitch);
 
     //qDebug() << "KeyControl::slotPitchChanged 1" << pitch <<
     //        m_pitchRateInfo.pitchRatio <<
     //        m_pitchRateInfo.pitchTweakRatio <<
     //        m_pitchRateInfo.tempoRatio;
 
-    double speedSliderPitchRatio =
-            m_pitchRateInfo.pitchRatio / m_pitchRateInfo.pitchTweakRatio;
-    // speedSliderPitchRatio must be unchanged
-    double pitchKnobRatio = KeyUtils::semitoneChangeToPowerOf2(pitch);
-    m_pitchRateInfo.pitchRatio = pitchKnobRatio;
-    m_pitchRateInfo.pitchTweakRatio = pitchKnobRatio / speedSliderPitchRatio;
+
+    // If keylock is not on, and the new pitch is 0.0, then reset the tweak
+    // ratio so we stop using the keylock scaler.
+    if (!m_pitchRateInfo.keylock && pitch == 0.0) {
+        m_pitchRateInfo.pitchRatio = m_pitchRateInfo.tempoRatio;
+        m_pitchRateInfo.pitchTweakRatio = 1.0;
+    } else {
+        double speedSliderPitchRatio =
+                m_pitchRateInfo.pitchRatio / m_pitchRateInfo.pitchTweakRatio;
+        // speedSliderPitchRatio must be unchanged
+        m_pitchRateInfo.pitchRatio = pitchKnobRatio;
+        m_pitchRateInfo.pitchTweakRatio = pitchKnobRatio / speedSliderPitchRatio;
+    }
 
     double dFileKey = m_pFileKey->get();
     m_pPitchAdjust->set(

--- a/src/engine/keycontrol.cpp
+++ b/src/engine/keycontrol.cpp
@@ -287,16 +287,14 @@ void KeyControl::slotPitchChanged(double pitch) {
 
 void KeyControl::updatePitch() {
     double pitch = m_pPitch->get();
-    double pitchKnobRatio = KeyUtils::semitoneChangeToPowerOf2(pitch);
-
     //qDebug() << "KeyControl::slotPitchChanged 1" << pitch <<
     //        m_pitchRateInfo.pitchRatio <<
     //        m_pitchRateInfo.pitchTweakRatio <<
     //        m_pitchRateInfo.tempoRatio;
 
-
     // If keylock is not on, and the new pitch is 0.0, then reset the tweak
     // ratio so we stop using the keylock scaler.
+    double pitchKnobRatio = KeyUtils::semitoneChangeToPowerOf2(pitch);
     if (!m_pitchRateInfo.keylock && pitch == 0.0) {
         m_pitchRateInfo.pitchRatio = m_pitchRateInfo.tempoRatio;
         m_pitchRateInfo.pitchTweakRatio = 1.0;

--- a/src/engine/keycontrol.h
+++ b/src/engine/keycontrol.h
@@ -20,7 +20,7 @@ class KeyControl : public EngineControl {
         // this is the value of the speed slider and speed slider
         // effecting controls at the moment of calculation
         double tempoRatio;
-        // the offeset factor to the natural pitch set by the rate slider
+        // the offset factor to the natural pitch set by the rate slider
         double pitchTweakRatio;
         bool keylock;
     };

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -95,3 +95,22 @@ TEST_F(EngineBufferTest, SlowRubberBand) {
     // Scaler should still be linear
     ASSERT_EQ(m_pMockScaleLinear1, m_pChannel1->getEngineBuffer()->m_pScale);
 }
+
+TEST_F(EngineBufferTest, ResetPitchUsesLinear) {
+    // If the key was adjusted, but keylock is off, and then the key is
+    // reset, then the engine should be using the linear scaler.
+
+    // First, we should be using the keylock scaler here.
+    ControlObject::set(ConfigKey(m_sGroup1, "pitch"), 1.2);
+    // Remember that a rate of "0" is "regular playback speed".
+    ControlObject::set(ConfigKey(m_sGroup1, "rate"), 0.05);
+    ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
+    ProcessBuffer();
+    EXPECT_EQ(m_pMockScaleKeylock1, m_pChannel1->getEngineBuffer()->m_pScale);
+
+    // Reset pitch, and we should be back to the linear scaler.
+    ControlObject::set(ConfigKey(m_sGroup1, "pitch_set_default"), 1.0);
+    ProcessBuffer();
+    // Now we should be back to the linear scaler.
+    EXPECT_EQ(m_pMockScaleLinear1, m_pChannel1->getEngineBuffer()->m_pScale);
+}

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -119,5 +119,5 @@ TEST_F(EngineBufferTest, ResetPitchUsesLinear) {
     ControlObject::set(ConfigKey(m_sGroup1, "pitch_set_default"), 1.0);
     ProcessBuffer();
     // Now we should be back to the linear scaler.
-    EXPECT_EQ(m_pMockScaleLinear1, m_pChannel1->getEngineBuffer()->m_pScale);
+    EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
 }


### PR DESCRIPTION
If keylock is off, and the rate slider has been moved, pitch_set_default should cause the engine to go back to the linear scaler.  Otherwise if the user does a pitch change and then tries to reset it, they are stuck with the keylock engine until they load a new track.

https://bugs.launchpad.net/mixxx/+bug/1435124
