### PR TITLE
Add support for resetting just the key on track load

### DIFF
--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -38,7 +38,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
           m_pMidFilterKill(NULL),
           m_pHighFilterKill(NULL),
           m_pSpeed(NULL),
-          m_pPitch(NULL),
+          m_pPitchAdjust(NULL),
           m_replaygainPending(false) {
     ChannelHandleAndGroup channelGroup =
             pMixingEngine->registerChannelGroup(group);
@@ -122,7 +122,7 @@ BaseTrackPlayerImpl::~BaseTrackPlayerImpl() {
     delete m_pHighFilterKill;
     delete m_pPreGain;
     delete m_pSpeed;
-    delete m_pPitch;
+    delete m_pPitchAdjust;
 }
 
 void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer track, bool bPlay) {
@@ -290,13 +290,17 @@ void BaseTrackPlayerImpl::slotFinishLoading(TrackPointer pTrackInfoObject)
         }
         m_pPreGain->set(1.0);
     }
-    if(m_pConfig->getValueString(ConfigKey("[Controls]", "SpeedAutoReset"), 0).toInt()) {
+    int reset = m_pConfig->getValueString(ConfigKey("[Controls]", "SpeedAutoReset"), 0).toInt();
+    switch (reset) {
+      case 2:
+        // Note: speed may effect pitch
         if (m_pSpeed != NULL) {
             m_pSpeed->set(0.0);
         }
-        // Note: speed may effect pitch
-        if (m_pPitch != NULL) {
-            m_pPitch->set(0.0);
+        // Fallthrough intended
+      case 1:
+        if (m_pPitchAdjust != NULL) {
+            m_pPitchAdjust->set(0.0);
         }
     }
     emit(newTrackLoaded(m_pLoadedTrack));
@@ -336,5 +340,5 @@ void BaseTrackPlayerImpl::setupEqControls() {
     m_pMidFilterKill = new ControlObjectSlave(group, "filterMidKill");
     m_pHighFilterKill = new ControlObjectSlave(group, "filterHighKill");
     m_pSpeed = new ControlObjectSlave(group, "rate");
-    m_pPitch = new ControlObjectSlave(group, "pitch");
+    m_pPitchAdjust = new ControlObjectSlave(group, "pitch_adjust");
 }

--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -290,15 +290,17 @@ void BaseTrackPlayerImpl::slotFinishLoading(TrackPointer pTrackInfoObject)
         }
         m_pPreGain->set(1.0);
     }
-    int reset = m_pConfig->getValueString(ConfigKey("[Controls]", "SpeedAutoReset"), 0).toInt();
+    int reset = m_pConfig->getValueString(ConfigKey(
+            "[Controls]", "SpeedAutoReset"),
+            QString("%1").arg(RESET_PITCH)).toInt();
     switch (reset) {
-      case 2:
+      case RESET_PITCH_AND_SPEED:
         // Note: speed may affect pitch
         if (m_pSpeed != NULL) {
             m_pSpeed->set(0.0);
         }
         // Fallthrough intended
-      case 1:
+      case RESET_PITCH:
         if (m_pPitchAdjust != NULL) {
             m_pPitchAdjust->set(0.0);
         }

--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -293,7 +293,7 @@ void BaseTrackPlayerImpl::slotFinishLoading(TrackPointer pTrackInfoObject)
     int reset = m_pConfig->getValueString(ConfigKey("[Controls]", "SpeedAutoReset"), 0).toInt();
     switch (reset) {
       case 2:
-        // Note: speed may effect pitch
+        // Note: speed may affect pitch
         if (m_pSpeed != NULL) {
             m_pSpeed->set(0.0);
         }

--- a/src/basetrackplayer.h
+++ b/src/basetrackplayer.h
@@ -20,6 +20,13 @@ class EffectsManager;
 class BaseTrackPlayer : public BasePlayer {
     Q_OBJECT
   public:
+    // The ordering here corresponds to the ordering of the preferences combo box.
+    enum TrackLoadReset {
+        RESET_NONE,
+        RESET_PITCH,
+        RESET_PITCH_AND_SPEED,
+    };
+
     BaseTrackPlayer(QObject* pParent, const QString& group);
     virtual ~BaseTrackPlayer() {}
 

--- a/src/basetrackplayer.h
+++ b/src/basetrackplayer.h
@@ -87,7 +87,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     ControlObjectSlave* m_pHighFilterKill;
     ControlObjectSlave* m_pPreGain;
     ControlObjectSlave* m_pSpeed;
-    ControlObjectSlave* m_pPitch;
+    ControlObjectSlave* m_pPitchAdjust;
     EngineDeck* m_pChannel;
 
     bool m_replaygainPending;

--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -327,8 +327,9 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
 
     // Update Speed Auto Reset Slider Box
     // Cue recall
-    ComboBoxResetSpeedAndPitch->addItem(tr("On track load"));
     ComboBoxResetSpeedAndPitch->addItem(tr("Off"));
+    ComboBoxResetSpeedAndPitch->addItem(tr("Reset key adjustment on track load"));
+    ComboBoxResetSpeedAndPitch->addItem(tr("Reset key and speed on track load"));
     connect(ComboBoxResetSpeedAndPitch, SIGNAL(activated(int)),
             this, SLOT(slotUpdateSpeedAutoReset(int)));
     m_speedAutoReset = static_cast<bool>(m_pConfig->getValueString(
@@ -389,7 +390,7 @@ void DlgPrefControls::slotUpdate() {
 
     ComboBoxKeylockMode->setCurrentIndex(m_keylockMode);
 
-    ComboBoxResetSpeedAndPitch->setCurrentIndex(1 - m_speedAutoReset);
+    ComboBoxResetSpeedAndPitch->setCurrentIndex(m_speedAutoReset);
 }
 
 void DlgPrefControls::slotResetToDefaults() {
@@ -432,9 +433,9 @@ void DlgPrefControls::slotResetToDefaults() {
     spinBoxPermRateLeft->setValue(0.50);
     spinBoxPermRateRight->setValue(0.05);
 
-    // Speed auto reset combobox 1 = off
+    // Speed auto reset combobox 0 = off
     m_speedAutoReset = 0;
-    ComboBoxResetSpeedAndPitch->setCurrentIndex(1);
+    ComboBoxResetSpeedAndPitch->setCurrentIndex(0);
 
     m_keylockMode = 0;
     ComboBoxKeylockMode->setCurrentIndex(m_keylockMode);
@@ -716,6 +717,6 @@ void DlgPrefControls::slotNumSamplersChanged(double new_count) {
 }
 
 void DlgPrefControls::slotUpdateSpeedAutoReset(int i) {
-    // 1 = off
-    m_speedAutoReset = 1 - i;
+    // 0 = off
+    m_speedAutoReset = i;
 }

--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -326,14 +326,14 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
             ConfigKey("[Controls]", "RateRampSensitivity")).toInt());
 
     // Update Speed Auto Reset Slider Box
-    // Cue recall
+    // TODO: Use an enum for the various options so it's easier to maintain.
     ComboBoxResetSpeedAndPitch->addItem(tr("Off"));
     ComboBoxResetSpeedAndPitch->addItem(tr("Reset key adjustment on track load"));
     ComboBoxResetSpeedAndPitch->addItem(tr("Reset key and speed on track load"));
     connect(ComboBoxResetSpeedAndPitch, SIGNAL(activated(int)),
             this, SLOT(slotUpdateSpeedAutoReset(int)));
-    m_speedAutoReset = static_cast<bool>(m_pConfig->getValueString(
-                    ConfigKey("[Controls]", "SpeedAutoReset")).toInt());
+    m_speedAutoReset = m_pConfig->getValueString(
+                    ConfigKey("[Controls]", "SpeedAutoReset")).toInt();
 
     slotUpdate();
 }
@@ -433,9 +433,9 @@ void DlgPrefControls::slotResetToDefaults() {
     spinBoxPermRateLeft->setValue(0.50);
     spinBoxPermRateRight->setValue(0.05);
 
-    // Speed auto reset combobox 0 = off
-    m_speedAutoReset = 0;
-    ComboBoxResetSpeedAndPitch->setCurrentIndex(0);
+    // Speed auto reset combobox 0 = off, 1 = pitch-only, 2 = pitch and speed.
+    m_speedAutoReset = 1;
+    ComboBoxResetSpeedAndPitch->setCurrentIndex(1);
 
     m_keylockMode = 0;
     ComboBoxKeylockMode->setCurrentIndex(m_keylockMode);
@@ -717,6 +717,6 @@ void DlgPrefControls::slotNumSamplersChanged(double new_count) {
 }
 
 void DlgPrefControls::slotUpdateSpeedAutoReset(int i) {
-    // 0 = off
+    // 0 = off, 1 = pitch-only, 2 = pitch and speed
     m_speedAutoReset = i;
 }

--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -332,8 +332,9 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     ComboBoxResetSpeedAndPitch->addItem(tr("Reset key and speed on track load"));
     connect(ComboBoxResetSpeedAndPitch, SIGNAL(activated(int)),
             this, SLOT(slotUpdateSpeedAutoReset(int)));
+    // TODO: All defaults should only be set in slotResetToDefaults.
     m_speedAutoReset = m_pConfig->getValueString(
-                    ConfigKey("[Controls]", "SpeedAutoReset")).toInt();
+                    ConfigKey("[Controls]", "SpeedAutoReset"), "1").toInt();
 
     slotUpdate();
 }

--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -23,6 +23,7 @@
 #include <QLocale>
 #include <QDesktopWidget>
 
+#include "basetrackplayer.h"
 #include "dlgprefcontrols.h"
 #include "configobject.h"
 #include "controlobject.h"
@@ -326,7 +327,7 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
             ConfigKey("[Controls]", "RateRampSensitivity")).toInt());
 
     // Update Speed Auto Reset Slider Box
-    // TODO: Use an enum for the various options so it's easier to maintain.
+    // This corresponds to the enum in basetrackplayer.h TrackLoadReset.
     ComboBoxResetSpeedAndPitch->addItem(tr("Off"));
     ComboBoxResetSpeedAndPitch->addItem(tr("Reset key adjustment on track load"));
     ComboBoxResetSpeedAndPitch->addItem(tr("Reset key and speed on track load"));
@@ -334,7 +335,8 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
             this, SLOT(slotUpdateSpeedAutoReset(int)));
     // TODO: All defaults should only be set in slotResetToDefaults.
     m_speedAutoReset = m_pConfig->getValueString(
-                    ConfigKey("[Controls]", "SpeedAutoReset"), "1").toInt();
+                    ConfigKey("[Controls]", "SpeedAutoReset"),
+                    QString("%1").arg(BaseTrackPlayer::RESET_PITCH)).toInt();
 
     slotUpdate();
 }
@@ -434,9 +436,9 @@ void DlgPrefControls::slotResetToDefaults() {
     spinBoxPermRateLeft->setValue(0.50);
     spinBoxPermRateRight->setValue(0.05);
 
-    // Speed auto reset combobox 0 = off, 1 = pitch-only, 2 = pitch and speed.
-    m_speedAutoReset = 1;
-    ComboBoxResetSpeedAndPitch->setCurrentIndex(1);
+    // Speed auto reset combobox
+    m_speedAutoReset = BaseTrackPlayer::RESET_PITCH;
+    ComboBoxResetSpeedAndPitch->setCurrentIndex(BaseTrackPlayer::RESET_PITCH);
 
     m_keylockMode = 0;
     ComboBoxKeylockMode->setCurrentIndex(m_keylockMode);
@@ -718,6 +720,5 @@ void DlgPrefControls::slotNumSamplersChanged(double new_count) {
 }
 
 void DlgPrefControls::slotUpdateSpeedAutoReset(int i) {
-    // 0 = off, 1 = pitch-only, 2 = pitch and speed
     m_speedAutoReset = i;
 }

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -5,6 +5,7 @@
 
 #include <QtDebug>
 
+#include "basetrackplayer.h"
 #include "configobject.h"
 #include "controlobject.h"
 #include "test/mockedenginebackendtest.h"
@@ -33,7 +34,8 @@ TEST_F(EngineBufferTest, DisableKeylockResetsPitch) {
 /* Does not work yet because we have no BaseTrackPlayerImpl in this test
 TEST_F(EngineBufferTest, TrackLoadResetsPitch) {
     // When a new track is loaded, the pitch value should be reset.
-    config()->set(ConfigKey("[Controls]","SpeedAutoReset"), ConfigValue(1));
+    config()->set(ConfigKey("[Controls]","SpeedAutoReset"),
+            ConfigValue(BaseTrackPlayer::RESET_PITCH));
     ControlObject::set(ConfigKey(m_sGroup1, "file_bpm"), 128.0);
     ControlObject::set(ConfigKey(m_sGroup1, "pitch"), 0.5);
     ProcessBuffer();
@@ -43,7 +45,6 @@ TEST_F(EngineBufferTest, TrackLoadResetsPitch) {
     ASSERT_EQ(0.0, ControlObject::get(ConfigKey(m_sGroup1, "pitch")));
 }
 */
-
 
 TEST_F(EngineBufferTest, PitchRoundtrip) {
     ControlObject::set(ConfigKey(m_sGroup1, "keylock"), 0.0);


### PR DESCRIPTION
My controller, like many, doesn't have a dedicated slider or knob for key adjustment, just an encoder.  So I'd prefer to reset the key adjustment on track load, but not the speed slider.  This PR adds an option to do that, preserving the other options.

This will break old preferences since I've fixed the whacky ordering, but in general we're going to be breaking some people's preferences with the new version anyway so I think that's better than the alternative of keeping 1 for "off".
