### PR TITLE
EngineBuffe rate == 0 fixes 

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -780,6 +780,8 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
 
         bool useIndependentPitchAndTempoScaling = false;
 
+        qDebug() << "slow rubberband 1" << is_scratching  << speed << m_group;
+
         // TODO(owen): Maybe change this so that rubberband doesn't disable
         // keylock on scratch. (just check m_pScaleKeylock == m_pScaleST)
         if (is_scratching || fabs(speed) > 1.9) {
@@ -793,10 +795,11 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
             // Force pitchRatio to the linear pitch set by speed
             pitchRatio = speed;
             // This is for the natural speed pitch found on turn tables
-        } else if (m_pScaleKeylock == m_pScaleRB && fabs(speed) < 0.1) {
+        } else if (fabs(speed) < 0.1 && m_pKeylockEngine->get() == RUBBERBAND) {
             // At very slow speeds, Rubberband performs memory allocations which
             // can cause underruns.  Disable keylock under these conditions.
 
+            qDebug() << "slow rubberband";
             // Force pitchRatio to the linear pitch set by speed
             pitchRatio = speed;
         } else if (keylock_enabled) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1348,6 +1348,7 @@ void EngineBuffer::setScalerForTest(EngineBufferScale* pScaleVinyl,
     m_pScaleKeylock = pScaleKeylock;
     m_pScale = m_pScaleVinyl;
     m_pScale->clear();
+    m_bScalerChanged = true;
     // This bool is permanently set and can't be undone.
     m_bScalerOverride = true;
 }

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -446,8 +446,6 @@ void EngineBuffer::readToCrossfadeBuffer(const int iBufferSize) {
 
     // Restore the original position that was lost due to getScaled() above
     m_pReadAheadManager->notifySeek(m_filepos_play);
-    // Clear the current scale information
-    m_pScale->clear();
 
     m_bCrossfadeReady = true;
 }
@@ -461,6 +459,8 @@ void EngineBuffer::setNewPlaypos(double newpos) {
 
     // Before seeking, read extra buffer for crossfading
     readToCrossfadeBuffer(m_iLastBufferSize);
+    // Clear the scale information
+    m_pScale->clear();
 
     // Ensures that the playpos slider gets updated in next process call
     m_iSamplesCalculated = 1000000;
@@ -812,8 +812,6 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
         // need to use pitch and time scaling.
         // Note: we have still click issue when changing the scaler
 
-        // const double kLinearScalerElipsis = 1.00058;
-
         bool useIndependentPitchAndTempoScaling = false;
         if (keylock_enabled) {
             // always use IndependentPitchAndTempoScaling
@@ -893,6 +891,8 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
                 if ((m_speed_old <= 0 && speed > 0) ||
                     (m_speed_old >= 0 && speed < 0)) {
                     readToCrossfadeBuffer(iBufferSize);
+                    // Clear the scaler information
+                    m_pScale->clear();
                 }
             }
 
@@ -969,6 +969,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
         }
 
         if (m_bCrossfadeReady) {
+            qDebug() << "m_bCrossfadeReady";
             SampleUtil::linearCrossfadeBuffers(
                 pOutput, m_pCrossfadeBuffer, pOutput, iBufferSize);
             m_bCrossfadeReady = false;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -456,7 +456,7 @@ void EngineBuffer::setNewPlaypos(double newpos) {
 
     m_filepos_play = newpos;
 
-    if (m_rate_old) {
+    if (m_rate_old != 0.0) {
         // Before seeking, read extra buffer for crossfading
         // (calls notifySeek())
         readToCrossfadeBuffer(m_iLastBufferSize);
@@ -820,7 +820,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
 
             // Check if we are off-linear (the pitch is tweaked) to enable
             // the keylock scaler even though keylock is disabled
-            if (speed) {
+            if (speed != 0.0) {
                 double offlinear = pitchRatio / speed;
                 if (offlinear > kLinearScalerElipsis ||
                         offlinear < 1 / kLinearScalerElipsis) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -754,7 +754,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
             baserate = ((double)m_trackSampleRateOld / sample_rate);
         }
 
-
+        // Note: play is also active during cue preview
         bool paused = m_playButton->get() == 0.0;
         KeyControl::PitchTempoRatio pitchTempoRatio = m_pKeyControl->getPitchTempoRatio();
 
@@ -793,7 +793,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
             // Force pitchRatio to the linear pitch set by speed
             pitchRatio = speed;
             // This is for the natural speed pitch found on turn tables
-        } else if (fabs(speed) < 0.1 && m_pKeylockEngine->get() == RUBBERBAND) {
+        } else if (m_pScaleKeylock == m_pScaleRB && fabs(speed) < 0.1) {
             // At very slow speeds, Rubberband performs memory allocations which
             // can cause underruns.  Disable keylock under these conditions.
 
@@ -826,8 +826,11 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
             }
         }
 
-        enableIndependentPitchTempoScaling(useIndependentPitchAndTempoScaling,
-                                           iBufferSize);
+        if (speed) {
+            // Do not switch scaler when we have no transport
+            enableIndependentPitchTempoScaling(useIndependentPitchAndTempoScaling,
+                                               iBufferSize);
+        }
 
         // How speed/tempo/pitch are related:
         // Processing is done in two parts, the first part is calculated inside

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -782,8 +782,6 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
         double speed = m_pRateControl->calculateSpeed(
                 baserate, tempoRatio, paused, iBufferSize, &is_scratching);
 
-        qDebug() << "EngineBuffer::process" << speed << is_scratching << tempoRatio;
-
         bool useIndependentPitchAndTempoScaling = false;
 
         // TODO(owen): Maybe change this so that rubberband doesn't disable
@@ -985,7 +983,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
                 m_filepos_play += samplesRead;
             } else {
                 // Adjust filepos_play by the amount we processed. TODO(XXX) what
-                // happens if samplesRead is a fraction?
+                // happens if samplesRead is a fraction ?
                 m_filepos_play =
                         m_pReadAheadManager->getEffectiveVirtualPlaypositionFromLog(
                                 static_cast<int>(m_filepos_play), samplesRead);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -456,9 +456,14 @@ void EngineBuffer::setNewPlaypos(double newpos) {
 
     m_filepos_play = newpos;
 
-    // Before seeking, read extra buffer for crossfading
-    readToCrossfadeBuffer(m_iLastBufferSize);
-    // Clear the scale information
+    if (m_rate_old) {
+        // Before seeking, read extra buffer for crossfading
+        // (calls notifySeek())
+        readToCrossfadeBuffer(m_iLastBufferSize);
+        // Clear the scale information
+    } else {
+        m_pReadAheadManager->notifySeek(m_filepos_play);
+    }
     m_pScale->clear();
 
     // Ensures that the playpos slider gets updated in next process call
@@ -989,6 +994,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
         }
 
         if (m_bCrossfadeReady) {
+            qDebug() << "m_bCrossfadeReady";
             SampleUtil::linearCrossfadeBuffers(
                     pOutput, m_pCrossfadeBuffer, pOutput, iBufferSize);
         }

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -460,7 +460,6 @@ void EngineBuffer::setNewPlaypos(double newpos) {
         // Before seeking, read extra buffer for crossfading
         // (calls notifySeek())
         readToCrossfadeBuffer(m_iLastBufferSize);
-        // Clear the scale information
     } else {
         m_pReadAheadManager->notifySeek(m_filepos_play);
     }

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -782,6 +782,8 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
         double speed = m_pRateControl->calculateSpeed(
                 baserate, tempoRatio, paused, iBufferSize, &is_scratching);
 
+        qDebug() << "EngineBuffer::process" << speed << is_scratching << tempoRatio;
+
         bool useIndependentPitchAndTempoScaling = false;
 
         // TODO(owen): Maybe change this so that rubberband doesn't disable

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -368,13 +368,13 @@ void EngineBuffer::enableIndependentPitchTempoScaling(bool bEnable,
         m_pScale = keylock_scale;
         m_pScale->clear();
         m_bScalerChanged = true;
-        qDebug() << "keylock_scale";
+        //qDebug() << "keylock_scale";
     } else if (!bEnable && m_pScale != vinyl_scale) {
         readToCrossfadeBuffer(iBufferSize);
         m_pScale = vinyl_scale;
         m_pScale->clear();
         m_bScalerChanged = true;
-        qDebug() << "vinyl_scale";
+        //qDebug() << "vinyl_scale";
     }
 }
 
@@ -452,7 +452,7 @@ void EngineBuffer::readToCrossfadeBuffer(const int iBufferSize) {
 // WARNING: This method is not thread safe and must not be called from outside
 // the engine callback!
 void EngineBuffer::setNewPlaypos(double newpos) {
-    qDebug() << m_group << "engine new pos " << newpos;
+    //qDebug() << m_group << "engine new pos " << newpos;
 
     m_filepos_play = newpos;
 
@@ -780,8 +780,6 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
 
         bool useIndependentPitchAndTempoScaling = false;
 
-        qDebug() << "slow rubberband 1" << is_scratching  << speed << m_group;
-
         // TODO(owen): Maybe change this so that rubberband doesn't disable
         // keylock on scratch. (just check m_pScaleKeylock == m_pScaleST)
         if (is_scratching || fabs(speed) > 1.9) {
@@ -799,7 +797,6 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
             // At very slow speeds, Rubberband performs memory allocations which
             // can cause underruns.  Disable keylock under these conditions.
 
-            qDebug() << "slow rubberband";
             // Force pitchRatio to the linear pitch set by speed
             pitchRatio = speed;
         } else if (keylock_enabled) {
@@ -898,7 +895,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
                 //XXX: Trying to force RAMAN to read from correct
                 //     playpos when rate changes direction - Albert
                 if (m_speed_old * speed < 0) {
-                    qDebug() << "direction changed";
+                    //qDebug() << "direction changed";
                     readToCrossfadeBuffer(iBufferSize);
                     // Clear the scaler information
                     m_pScale->clear();
@@ -968,11 +965,11 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
             CSAMPLE* output = m_pScale->getScaled(iBufferSize);
             double samplesRead = m_pScale->getSamplesRead();
 
-            // qDebug() << "sourceSamples used " << iSourceSamples
-            //          <<" samplesRead " << samplesRead
-            //          << ", buffer pos " << iBufferStartSample
-            //          << ", play " << filepos_play
-            //          << " bufferlen " << iBufferSize;
+            //qDebug() << "sourceSamples used " << iSourceSamples
+            //         <<" samplesRead " << samplesRead
+            //         << ", buffer pos " << iBufferStartSample
+            //         << ", play " << filepos_play
+            //         << " bufferlen " << iBufferSize;
 
             // Copy scaled audio into pOutput
             SampleUtil::copy(pOutput, output, iBufferSize);
@@ -992,7 +989,6 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
         }
 
         if (m_bCrossfadeReady) {
-            qDebug() << "m_bCrossfadeReady";
             SampleUtil::linearCrossfadeBuffers(
                     pOutput, m_pCrossfadeBuffer, pOutput, iBufferSize);
         }
@@ -1077,7 +1073,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
 
         for (int i=0; i < iBufferSize; i += 2) {
             if (bCurBufferPaused && !m_bCrossfadeReady) {
-                // qDebug() << "ramp dither";
+                //qDebug() << "ramp dither";
                 CSAMPLE dither = m_pDitherBuffer[m_iDitherBufferReadIndex];
                 m_iDitherBufferReadIndex = (m_iDitherBufferReadIndex + 1) % MAX_BUFFER_LEN;
                 pOutput[i] = m_fLastSampleValue[0] * m_fRampValue + dither;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -90,8 +90,6 @@ EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
           m_pRepeat(NULL),
           m_startButton(NULL),
           m_endButton(NULL),
-          m_pScale(NULL),
-          m_bScalerChanged(false),
           m_bScalerOverride(false),
           m_iSeekQueued(NO_SEEK),
           m_iEnableSyncQueued(SYNC_REQUEST_NONE),
@@ -282,7 +280,9 @@ EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
         m_pScaleKeylock = m_pScaleRB;
     }
     m_pScaleVinyl = m_pScaleLinear;
-    enableIndependentPitchTempoScaling(false, 0);
+    m_pScale = m_pScaleVinyl;
+    m_pScale->clear();
+    m_bScalerChanged = true;
 
     m_pPassthroughEnabled.reset(new ControlObjectSlave(group, "passthrough", this));
     m_pPassthroughEnabled->connectValueChanged(this, SLOT(slotPassthroughChanged(double)),
@@ -440,10 +440,6 @@ void EngineBuffer::requestSyncMode(SyncMode mode) {
 }
 
 void EngineBuffer::readToCrossfadeBuffer(const int iBufferSize) {
-    // During startup, scaler is null.
-    if (m_pScale == NULL) {
-        return;
-    }
     CSAMPLE* fadeout = m_pScale->getScaled(iBufferSize);
     SampleUtil::copy(m_pCrossfadeBuffer, fadeout, iBufferSize);
 

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -154,7 +154,7 @@ class EngineBuffer : public EngineObject {
     //void setReader(CachingReader* pReader);
 
     // For dependency injection of scalers.
-    void setScalerForTest(EngineBufferScale* pScale,
+    void setScalerForTest(EngineBufferScale* pScaleVinyl,
                           EngineBufferScale* pScaleKeylock);
 
     // For dependency injection of fake tracks, with an optional filebpm value.

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -249,6 +249,7 @@ class EngineBuffer : public EngineObject {
     FRIEND_TEST(EngineSyncTest, HalfDoubleBpmTest);
     FRIEND_TEST(EngineSyncTest, HalfDoubleThenPlay);
     FRIEND_TEST(EngineSyncTest, UserTweakBeatDistance);
+    FRIEND_TEST(EngineBufferTest, ScalerNoTransport);
     EngineSync* m_pEngineSync;
     SyncControl* m_pSyncControl;
     VinylControlControl* m_pVinylControlControl;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -349,6 +349,8 @@ class EngineBuffer : public EngineObject {
     // three pointers may be reassigned depending on configuration and tests.
     EngineBufferScale* m_pScale;
     FRIEND_TEST(EngineBufferTest, SlowRubberBand);
+    FRIEND_TEST(EngineBufferTest, VinylScalerRampZero);
+    FRIEND_TEST(EngineBufferTest, ReadFadeOut);
     EngineBufferScale* m_pScaleVinyl;
     // The keylock engine is configurable, so it could flip flop between
     // ScaleST and ScaleRB during a single callback.

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -481,7 +481,7 @@ double RateControl::calculateSpeed(double baserate, double speed, bool paused,
         } else {
             // If master sync is on, respond to it -- but vinyl and scratch mode always override.
             if (getSyncMode() == SYNC_FOLLOWER && !paused &&
-                !bVinylControlEnabled && !useScratch2Value) {
+                    !bVinylControlEnabled && !useScratch2Value) {
                 if (m_pBpmControl == NULL) {
                     qDebug() << "ERROR: calculateRate m_pBpmControl is null during master sync";
                     return 1.0;
@@ -506,7 +506,6 @@ double RateControl::calculateSpeed(double baserate, double speed, bool paused,
             }
         }
     }
-
     return rate;
 }
 

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -99,12 +99,10 @@ TEST_F(EngineBufferTest, SlowRubberBand) {
     // With Rubberband, and transport stopped it should be still keylock 
     ControlObject::set(ConfigKey("[Master]", "keylock_engine"),
                        static_cast<double>(EngineBuffer::RUBBERBAND));
-    // Hack to get a slow, non-scratching direct speed
     ControlObject::set(ConfigKey(m_sGroup1, "rateSearch"), 0.0);
     ProcessBuffer();
     EXPECT_EQ(m_pMockScaleKeylock1, m_pChannel1->getEngineBuffer()->m_pScale);
 
-    // Hack to get a slow, non-scratching direct speed
     ControlObject::set(ConfigKey(m_sGroup1, "rateSearch"), 0.0072);
 
     // Paying at low rate, the vinyl scaler should be used

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -99,7 +99,7 @@ TEST_F(EngineBufferTest, SlowRubberBand) {
     // With Rubberband, and transport stopped it should be still keylock 
     ControlObject::set(ConfigKey("[Master]", "keylock_engine"),
                        static_cast<double>(EngineBuffer::RUBBERBAND));
-        // Hack to get a slow, non-scratching direct speed
+    // Hack to get a slow, non-scratching direct speed
     ControlObject::set(ConfigKey(m_sGroup1, "rateSearch"), 0.0);
     ProcessBuffer();
     EXPECT_EQ(m_pMockScaleKeylock1, m_pChannel1->getEngineBuffer()->m_pScale);
@@ -115,7 +115,6 @@ TEST_F(EngineBufferTest, SlowRubberBand) {
 
 
 TEST_F(EngineBufferTest, ScalerNoTransport) {
-
     // normaly use the Vinyl scaler
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     ProcessBuffer();
@@ -139,21 +138,20 @@ TEST_F(EngineBufferTest, ScalerNoTransport) {
 }
 
 TEST_F(EngineBufferTest, VinylScalerRampZero) {
-
     // scratch in play mode
     ControlObject::set(ConfigKey(m_sGroup1, "scratch2_enable"), 1.0);
     ControlObject::set(ConfigKey(m_sGroup1, "scratch2"), 1.0);
 
     ProcessBuffer();
     EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
-    EXPECT_EQ(m_pMockScaleVinyl1->getProcessesTempo(), 1.0);
+    EXPECT_EQ(m_pMockScaleVinyl1->getProcessedTempo(), 1.0);
 
     ControlObject::set(ConfigKey(m_sGroup1, "scratch2"), 0.0);
 
     // we are in scratching mode so a zero rate has to be processed
     ProcessBuffer();
     EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
-    EXPECT_EQ(m_pMockScaleVinyl1->getProcessesTempo(), 0.0);
+    EXPECT_EQ(m_pMockScaleVinyl1->getProcessedTempo(), 0.0);
 }
 
 TEST_F(EngineBufferTest, ReadFadeOut) {
@@ -162,7 +160,7 @@ TEST_F(EngineBufferTest, ReadFadeOut) {
 
     ProcessBuffer();
     EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
-    EXPECT_EQ(m_pMockScaleVinyl1->getProcessesTempo(), 1.0);
+    EXPECT_EQ(m_pMockScaleVinyl1->getProcessedTempo(), 1.0);
 
     // pause
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 0.0);
@@ -171,7 +169,7 @@ TEST_F(EngineBufferTest, ReadFadeOut) {
     // prepare the crossfade buffer
     ProcessBuffer();
     EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
-    EXPECT_EQ(m_pMockScaleVinyl1->getProcessesTempo(), 1.0);
+    EXPECT_EQ(m_pMockScaleVinyl1->getProcessedTempo(), 1.0);
 }
 
 TEST_F(EngineBufferTest, ResetPitchAdjustUsesLinear) {

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -137,3 +137,39 @@ TEST_F(EngineBufferTest, ScalerNoTransport) {
     ProcessBuffer();
     EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
 }
+
+TEST_F(EngineBufferTest, VinylScalerRampZero) {
+
+    // scratch in play mode
+    ControlObject::set(ConfigKey(m_sGroup1, "scratch2_enable"), 1.0);
+    ControlObject::set(ConfigKey(m_sGroup1, "scratch2"), 1.0);
+
+    ProcessBuffer();
+    EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
+    EXPECT_EQ(m_pMockScaleVinyl1->getProcessesTempo(), 1.0);
+
+    ControlObject::set(ConfigKey(m_sGroup1, "scratch2"), 0.0);
+
+    // we are in scratching mode so a zero rate has to be processed
+    ProcessBuffer();
+    EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
+    EXPECT_EQ(m_pMockScaleVinyl1->getProcessesTempo(), 0.0);
+}
+
+TEST_F(EngineBufferTest, ReadFadeOut) {
+    // Start playing
+    ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
+
+    ProcessBuffer();
+    EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
+    EXPECT_EQ(m_pMockScaleVinyl1->getProcessesTempo(), 1.0);
+
+    // pause
+    ControlObject::set(ConfigKey(m_sGroup1, "play"), 0.0);
+
+    // The scaler need to be processed with the old rate to
+    // prepare the crossfade buffer
+    ProcessBuffer();
+    EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
+    EXPECT_EQ(m_pMockScaleVinyl1->getProcessesTempo(), 1.0);
+}

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -112,3 +112,28 @@ TEST_F(EngineBufferTest, SlowRubberBand) {
     ProcessBuffer();
     EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
 }
+
+
+TEST_F(EngineBufferTest, ScalerNoTransport) {
+
+    // normaly use the Vinyl scaler
+    ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
+    ProcessBuffer();
+    EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
+
+    // switch to keylock scaler
+    ControlObject::set(ConfigKey(m_sGroup1, "keylock"), 1.0);
+    ProcessBuffer();
+    EXPECT_EQ(m_pMockScaleKeylock1, m_pChannel1->getEngineBuffer()->m_pScale);
+
+    // Stop and disable keylock: do not change scaler
+    ControlObject::set(ConfigKey(m_sGroup1, "play"), 0.0);
+    ControlObject::set(ConfigKey(m_sGroup1, "keylock"), 0.0);
+    ProcessBuffer();
+    EXPECT_EQ(m_pMockScaleKeylock1, m_pChannel1->getEngineBuffer()->m_pScale);
+
+    // play: we need to use vinyl scaler
+    ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
+    ProcessBuffer();
+    EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
+}

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -104,7 +104,6 @@ TEST_F(EngineBufferTest, SlowRubberBand) {
     ProcessBuffer();
     EXPECT_EQ(m_pMockScaleKeylock1, m_pChannel1->getEngineBuffer()->m_pScale);
 
-
     // Hack to get a slow, non-scratching direct speed
     ControlObject::set(ConfigKey(m_sGroup1, "rateSearch"), 0.0072);
 

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -96,9 +96,19 @@ TEST_F(EngineBufferTest, SlowRubberBand) {
     ProcessBuffer();
     EXPECT_EQ(m_pMockScaleKeylock1, m_pChannel1->getEngineBuffer()->m_pScale);
 
-    // With Rubberband, the scaler should be linear
+    // With Rubberband, and transport stopped it should be still keylock 
     ControlObject::set(ConfigKey("[Master]", "keylock_engine"),
                        static_cast<double>(EngineBuffer::RUBBERBAND));
+        // Hack to get a slow, non-scratching direct speed
+    ControlObject::set(ConfigKey(m_sGroup1, "rateSearch"), 0.0);
+    ProcessBuffer();
+    EXPECT_EQ(m_pMockScaleKeylock1, m_pChannel1->getEngineBuffer()->m_pScale);
+
+
+    // Hack to get a slow, non-scratching direct speed
+    ControlObject::set(ConfigKey(m_sGroup1, "rateSearch"), 0.0072);
+
+    // Paying at low rate, the vinyl scaler should be used
     ProcessBuffer();
     EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
 }

--- a/src/test/mockedenginebackendtest.h
+++ b/src/test/mockedenginebackendtest.h
@@ -30,15 +30,32 @@ using ::testing::_;
 
 class MockScaler : public EngineBufferScale {
   public:
-    MockScaler() : EngineBufferScale() {
+    MockScaler()
+            : EngineBufferScale(),
+              m_processedTempo(-1),
+              m_processedPitch(-1) {
         SampleUtil::clear(m_buffer, MAX_BUFFER_LEN);
     }
     void clear() { }
     CSAMPLE *getScaled(unsigned long buf_size) {
+        m_processedTempo = m_dTempo;
+        m_processedPitch = m_dPitch;
         m_samplesRead = round(buf_size * m_dTempo);
         if (static_cast<int>(m_samplesRead) % 2) { m_samplesRead--; }
         return m_buffer;
     }
+
+    double getProcessesTempo() {
+        return m_processedTempo;
+    }
+
+    double getProcessedPitch() {
+        return m_processedPitch;
+    }
+
+  private:
+    double m_processedTempo;
+    double m_processedPitch;
 };
 
 

--- a/src/test/mockedenginebackendtest.h
+++ b/src/test/mockedenginebackendtest.h
@@ -45,7 +45,7 @@ class MockScaler : public EngineBufferScale {
         return m_buffer;
     }
 
-    double getProcessesTempo() {
+    double getProcessedTempo() {
         return m_processedTempo;
     }
 


### PR DESCRIPTION
This fixes some issues when changing to or from zero rate. 
It allows to spin down to zero with th Vinyl Scaler
It avoids Scaler changes when pressing pause
It uses real samples to fade out after stop
