### PR TITLE
Parse min|maj scales from the key definition

### DIFF
--- a/src/test/keyutilstest.cpp
+++ b/src/test/keyutilstest.cpp
@@ -23,6 +23,13 @@ TEST_F(KeyUtilsTest, OpenKeyNotation) {
               KeyUtils::guessKeyFromText("6d"));
     EXPECT_EQ(mixxx::track::io::key::B_MINOR,
               KeyUtils::guessKeyFromText("3m"));
+
+    // whitespace is ok
+    EXPECT_EQ(mixxx::track::io::key::B_MINOR,
+              KeyUtils::guessKeyFromText(" 3m\t\t"));
+    // but other stuff is not
+    EXPECT_EQ(mixxx::track::io::key::INVALID,
+              KeyUtils::guessKeyFromText(" 33m\t\t"));
 }
 
 TEST_F(KeyUtilsTest, LancelotNotation) {
@@ -36,6 +43,13 @@ TEST_F(KeyUtilsTest, LancelotNotation) {
               KeyUtils::guessKeyFromText("1b"));
     EXPECT_EQ(mixxx::track::io::key::B_MINOR,
               KeyUtils::guessKeyFromText("10a"));
+
+    // whitespace is ok
+    EXPECT_EQ(mixxx::track::io::key::B_MINOR,
+              KeyUtils::guessKeyFromText("\t10a  "));
+    // but other stuff is not
+    EXPECT_EQ(mixxx::track::io::key::INVALID,
+              KeyUtils::guessKeyFromText("\t10aa  "));
 }
 
 TEST_F(KeyUtilsTest, KeyNameNotation) {
@@ -44,6 +58,13 @@ TEST_F(KeyUtilsTest, KeyNameNotation) {
     //  everyone confused?)
     EXPECT_EQ(mixxx::track::io::key::INVALID,
               KeyUtils::guessKeyFromText("H"));
+
+    // whitespace is ok
+    EXPECT_EQ(mixxx::track::io::key::C_MAJOR,
+              KeyUtils::guessKeyFromText(" \tC   \t  "));
+    // but other crap is not
+    EXPECT_EQ(mixxx::track::io::key::INVALID,
+              KeyUtils::guessKeyFromText(" c\tC   c\t  "));
 
     // Major is upper-case, minor is lower-case.
     EXPECT_EQ(mixxx::track::io::key::C_MAJOR,

--- a/src/test/keyutilstest.cpp
+++ b/src/test/keyutilstest.cpp
@@ -51,6 +51,16 @@ TEST_F(KeyUtilsTest, KeyNameNotation) {
     EXPECT_EQ(mixxx::track::io::key::C_MINOR,
               KeyUtils::guessKeyFromText("c"));
 
+    // ... or explicitly written out
+    EXPECT_EQ(mixxx::track::io::key::C_MAJOR,
+              KeyUtils::guessKeyFromText("cmaj"));
+    EXPECT_EQ(mixxx::track::io::key::C_MINOR,
+              KeyUtils::guessKeyFromText("Cmin"));
+    EXPECT_EQ(mixxx::track::io::key::C_MAJOR,
+              KeyUtils::guessKeyFromText("cmajor"));
+    EXPECT_EQ(mixxx::track::io::key::C_MINOR,
+              KeyUtils::guessKeyFromText("Cminor"));
+
     // Sharps
     EXPECT_EQ(mixxx::track::io::key::D_FLAT_MAJOR,
               KeyUtils::guessKeyFromText("C#"));
@@ -74,6 +84,30 @@ TEST_F(KeyUtilsTest, KeyNameNotation) {
               KeyUtils::guessKeyFromText("Dbm"));
     EXPECT_EQ(mixxx::track::io::key::C_MINOR,
               KeyUtils::guessKeyFromText("C#bb#m"));
+
+    // ... as is min
+    EXPECT_EQ(mixxx::track::io::key::C_MINOR,
+              KeyUtils::guessKeyFromText("CMiN"));
+    EXPECT_EQ(mixxx::track::io::key::C_MINOR,
+              KeyUtils::guessKeyFromText("cmIn"));
+    EXPECT_EQ(mixxx::track::io::key::C_SHARP_MINOR,
+              KeyUtils::guessKeyFromText("C#mIN"));
+    EXPECT_EQ(mixxx::track::io::key::C_SHARP_MINOR,
+              KeyUtils::guessKeyFromText("Dbmin"));
+    EXPECT_EQ(mixxx::track::io::key::C_MINOR,
+              KeyUtils::guessKeyFromText("C#bb#miN"));
+
+    // but maj is major
+    EXPECT_EQ(mixxx::track::io::key::C_MAJOR,
+              KeyUtils::guessKeyFromText("CMaJ"));
+    EXPECT_EQ(mixxx::track::io::key::C_MAJOR,
+              KeyUtils::guessKeyFromText("cmAj"));
+    EXPECT_EQ(mixxx::track::io::key::D_FLAT_MAJOR,
+              KeyUtils::guessKeyFromText("C#mAJ"));
+    EXPECT_EQ(mixxx::track::io::key::D_FLAT_MAJOR,
+              KeyUtils::guessKeyFromText("Dbmaj"));
+    EXPECT_EQ(mixxx::track::io::key::C_MAJOR,
+              KeyUtils::guessKeyFromText("C#bb#maJ"));
 
     // Test going across the edges.
     EXPECT_EQ(mixxx::track::io::key::B_MAJOR,

--- a/src/test/keyutilstest.cpp
+++ b/src/test/keyutilstest.cpp
@@ -39,7 +39,9 @@ TEST_F(KeyUtilsTest, LancelotNotation) {
 }
 
 TEST_F(KeyUtilsTest, KeyNameNotation) {
-    // Invalid letter.
+    // Invalid letter
+    // (actually valid in traditional german notation where B is H and Bb is B -
+    //  everyone confused?)
     EXPECT_EQ(mixxx::track::io::key::INVALID,
               KeyUtils::guessKeyFromText("H"));
 

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -11,10 +11,10 @@ using mixxx::track::io::key::ChromaticKey;
 using mixxx::track::io::key::ChromaticKey_IsValid;
 
 // OpenKey notation, the numbers 1-12 followed by d (dur, major) or m (moll, minor).
-static const char* s_openKeyPattern = "(1[0-2]|[1-9])([dm])";
+static const char* s_openKeyPattern = "^\\s*(1[0-2]|[1-9])([dm])\\s*$";
 
 // Lancelot notation, the numbers 1-12 followed by a (minor) or b (major).
-static const char* s_lancelotKeyPattern = "(1[0-2]|[1-9])([ab])";
+static const char* s_lancelotKeyPattern = "^\\s*(1[0-2]|[1-9])([ab])\\s*$";
 
 // a-g followed by any number of sharps or flats, optionally followed by
 // a scale spec (m = minor, min, maj)

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -16,8 +16,12 @@ static const char* s_openKeyPattern = "(1[0-2]|[1-9])([dm])";
 // Lancelot notation, the numbers 1-12 followed by a (minor) or b (major).
 static const char* s_lancelotKeyPattern = "(1[0-2]|[1-9])([ab])";
 
-// a-g followed by any number of sharps or flats.
-static const char* s_keyPattern = "([a-g])([#♯b♭]*m?)";
+// a-g followed by any number of sharps or flats, optionally followed by
+// a scale spec (m = minor, min, maj)
+// anchor the pattern so we don't get accidental sub-string matches
+// (?:or)? allows unabbreviated major|minor without capturing
+static const char* s_keyPattern = "^\\s*([a-g])([#♯b♭]*)"
+    "(min(?:or)?|maj(?:or)?|m)?\\s*$";
 
 static const QString s_sharpSymbol = QString::fromUtf8("♯");
 static const QString s_flatSymbol = QString::fromUtf8("♭");
@@ -200,12 +204,22 @@ ChromaticKey KeyUtils::guessKeyFromText(const QString& text) {
         int steps = 0;
         for (QString::const_iterator it = adjustments.begin();
              it != adjustments.end(); ++it) {
-            // An m only comes at the end and
-            if (it->toLower() == 'm') {
-                major = false;
-                break;
-            }
             steps += (*it == '#' || *it == s_sharpSymbol[0]) ? 1 : -1;
+        }
+
+        QString scale = keyMatcher.cap(3);
+        // we override major if a scale definition exists
+        if (! scale.isEmpty()) {
+            if (scale.compare("m", Qt::CaseInsensitive) == 0) {
+                major = false;
+            } else if (scale.startsWith("min", Qt::CaseInsensitive)) {
+                major = false;
+            } else if (scale.startsWith("maj", Qt::CaseInsensitive)) {
+                major = true;
+            } else {
+                qDebug() << "WARNING: scale from regexp has unexpected value."
+                  " should never happen";
+            }
         }
 
         ChromaticKey letterKey = static_cast<ChromaticKey>(


### PR DESCRIPTION
Key definitions like A#maj or Cmin are used by beatport and possibly others.
