### PR TITLE
Use a cross-platform sleep to fix a compile error on Windows

### DIFF
--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -4,6 +4,7 @@
 #include <gmock/gmock.h>
 
 #include <QtDebug>
+#include <QTest>
 
 #include "basetrackplayer.h"
 #include "configobject.h"
@@ -213,7 +214,7 @@ TEST_F(EngineBufferTest, SoundTouchCrashTest) {
     ProcessBuffer();
     for (int i = 0; i < 10 && !channel4->getEngineBuffer()->isTrackLoaded();
             ++i) {
-        sleep(1);
+        QTest::qSleep(1000); // millis
     }
     ASSERT_TRUE(channel4->getEngineBuffer()->isTrackLoaded());
 


### PR DESCRIPTION
I am assuming that the original author is calling the POSIX sleep() here, so using 1000 millis preserves his intent.
