### PR TITLE
Auto DJ short track

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -490,7 +490,8 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
                 // For negative fade durations, jump back to insert a pause
                 // between the tracks.
                 if (thisFadeDuration < 0.0) {
-                    // TODO(rryan) why otherDeck.fadeDuration?
+                    // Note: since the fade duration is relative to the track
+                    // length, we need to user here the other deck fade duration
                     otherDeck.setPlayPosition(otherDeck.fadeDuration);
                 }
             }
@@ -674,9 +675,9 @@ void AutoDJProcessor::calculateFadeThresholds(DeckAttributes* pAttributes) {
 
             // The track might be shorter than the transition period. Use a
             // sensible cap.
-            int autoDjTransition = math_min(m_iTransitionTime, TrackDuration/2);
+            int autoDjTransition = math_min(m_iTransitionTime, TrackDuration / 2);
 
-            if (TrackDuration > autoDjTransition && TrackDuration > 0) {
+            if (TrackDuration > 0) {
                 pAttributes->fadeDuration = static_cast<double>(autoDjTransition) /
                         static_cast<double>(TrackDuration);
             } else {

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -187,22 +187,29 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::fadeNow() {
         DeckAttributes& leftDeck = *m_decks[0];
         DeckAttributes& rightDeck = *m_decks[1];
         if (crossfader <= 0.3 && leftDeck.isPlaying()) {
-            // Make sure leftDeck.fadeDuration is up to date.
-            calculateTransition(&leftDeck);
+            // left deck is playing and the crossfader is on the left
 
+            // Make sure leftDeck.fadeDuration is up to date.
+            calculateTransition(&leftDeck, &rightDeck);
+
+            // override posThreshold to start fade now
             leftDeck.posThreshold = leftDeck.playPosition() -
                     ((crossfader + 1.0) / 2 * (leftDeck.fadeDuration));
             // Repeat is disabled by FadeNow but disables auto Fade
             leftDeck.setRepeat(false);
         } else if (crossfader >= -0.3 && rightDeck.isPlaying()) {
-            // Make sure rightDeck.fadeDuration is up to date.
-            calculateTransition(&rightDeck);
+            // right deck is playing and the crossfader is on the right
 
+            // Make sure rightDeck.fadeDuration is up to date.
+            calculateTransition(&rightDeck, &leftDeck);
+
+            // override posThreshold to start fade now
             rightDeck.posThreshold = rightDeck.playPosition() -
                     ((1.0 - crossfader) / 2 * (rightDeck.fadeDuration));
             // Repeat is disabled by FadeNow but disables auto Fade
             rightDeck.setRepeat(false);
         }
+        // else { // do not know what to do  }
     }
     return ADJ_OK;
 }
@@ -391,11 +398,12 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
 
     // qDebug() << "player" << pAttributes->group << "PositionChanged(" << value << ")";
     if (m_eState == ADJ_DISABLED) {
-        //nothing to do
+        // nothing to do
         return;
     }
 
     DeckAttributes& thisDeck = *pAttributes;
+    // prefer to fade to deck 0
     int otherDeckIndex = 0;
     if (thisDeck.index == 0) {
         otherDeckIndex = 1;

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -665,9 +665,8 @@ void AutoDJProcessor::playerPlayChanged(DeckAttributes* pAttributes, bool playin
     calculateTransition(pAttributes, getToDeck(pAttributes));
 }
 
-void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck, DeckAttributes* pToDeck) {
-    Q_UNUSED(pToDeck);
-
+void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
+                                          DeckAttributes* pToDeck) {
     bool playing = pFromDeck->isPlaying();
     if (sDebug) {
         qDebug() << this << "calculateFadeThresholds" << pFromDeck->group << playing;
@@ -681,20 +680,32 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck, DeckAttribu
     // is loaded we should be able to calculate the fadeDuration and
     // posThreshold regardless of the rest of the ADJ.
     if (playing && m_eState == ADJ_IDLE) {
-        TrackPointer loadedTrack = pFromDeck->getLoadedTrack();
-        if (loadedTrack) {
+        TrackPointer fromTrack = pFromDeck->getLoadedTrack();
+        if (fromTrack) {
             // TODO(rryan): Duration is super inaccurate! We should be using
             // track_samples / track_samplerate instead.
-            int TrackDuration = loadedTrack->getDuration();
-            qDebug() << "TrackDuration = " << TrackDuration;
+            int fromTrackDuration = fromTrack->getDuration();
+            qDebug() << "fromTrackDuration = " << fromTrackDuration;
 
             // The track might be shorter than the transition period. Use a
             // sensible cap.
-            m_nextTransitionTime = math_min(m_iTransitionTime, TrackDuration / 2);
+            m_nextTransitionTime = math_min(m_iTransitionTime,
+                                            fromTrackDuration / 2);
 
-            if (TrackDuration > 0) {
-                pFromDeck->fadeDuration = static_cast<double>(m_nextTransitionTime) /
-                        static_cast<double>(TrackDuration);
+            TrackPointer toTrack = pToDeck->getLoadedTrack();
+            if (toTrack) {
+                // TODO(rryan): Duration is super inaccurate! We should be using
+                // track_samples / track_samplerate instead.
+                int toTrackDuration = toTrack->getDuration();
+                qDebug() << "toTrackDuration = " << toTrackDuration;
+                m_nextTransitionTime = math_min(m_nextTransitionTime,
+                                                toTrackDuration / 2);
+            }
+
+            if (fromTrackDuration > 0) {
+                pFromDeck->fadeDuration =
+                        static_cast<double>(m_nextTransitionTime) /
+                        static_cast<double>(fromTrackDuration);
             } else {
                 pFromDeck->fadeDuration = 0;
             }

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -168,7 +168,8 @@ class AutoDJProcessor : public QObject {
 
     TrackPointer getNextTrackFromQueue();
     bool loadNextTrackFromQueue(const DeckAttributes& pDeck, bool play = false);
-    void calculateTransition(DeckAttributes* pFromDeck, DeckAttributes* pToDeck = NULL);
+    void calculateTransition(DeckAttributes* pFromDeck, DeckAttributes* pToDeck);
+    DeckAttributes* getToDeck(DeckAttributes* pFromDeck);
 
     // Removes the track loaded to the player group from the top of the AutoDJ
     // queue if it is present.

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -168,7 +168,7 @@ class AutoDJProcessor : public QObject {
 
     TrackPointer getNextTrackFromQueue();
     bool loadNextTrackFromQueue(const DeckAttributes& pDeck, bool play = false);
-    void calculateFadeThresholds(DeckAttributes* pAttributes);
+    void calculateTransition(DeckAttributes* pFromDeck, DeckAttributes* pToDeck = NULL);
 
     // Removes the track loaded to the player group from the top of the AutoDJ
     // queue if it is present.
@@ -183,7 +183,8 @@ class AutoDJProcessor : public QObject {
     PlaylistTableModel* m_pAutoDJTableModel;
 
     AutoDJState m_eState;
-    int m_iTransitionTime;
+    int m_iTransitionTime; // the desired value set by the user
+    int m_nextTransitionTime; // the tweaked value actually used
 
     QList<DeckAttributes*> m_decks;
 

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -168,7 +168,8 @@ class AutoDJProcessor : public QObject {
 
     TrackPointer getNextTrackFromQueue();
     bool loadNextTrackFromQueue(const DeckAttributes& pDeck, bool play = false);
-    void calculateTransition(DeckAttributes* pFromDeck, DeckAttributes* pToDeck);
+    void calculateTransition(DeckAttributes* pFromDeck,
+                             DeckAttributes* pToDeck);
     DeckAttributes* getToDeck(DeckAttributes* pFromDeck);
 
     // Removes the track loaded to the player group from the top of the AutoDJ

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -170,7 +170,8 @@ class AutoDJProcessor : public QObject {
     bool loadNextTrackFromQueue(const DeckAttributes& pDeck, bool play = false);
     void calculateTransition(DeckAttributes* pFromDeck,
                              DeckAttributes* pToDeck);
-    DeckAttributes* getToDeck(DeckAttributes* pFromDeck);
+    DeckAttributes* getOtherDeck(DeckAttributes* pFromDeck,
+                                 bool playing = false);
 
     // Removes the track loaded to the player group from the top of the AutoDJ
     // queue if it is present.


### PR DESCRIPTION
This fixes: 
https://bugs.launchpad.net/mixxx/+bug/1396385

Now, tracks shorter than transition time do not stop AutoDJ anymore. 
