### PR TITLE
Add "stabilization read" to MP3 seeks in SoundSourceCoreAudio.

### DIFF
--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -50,6 +50,12 @@ public:
     static const SINT kBitrateZero = 0;
     static const SINT kBitrateDefault = kBitrateZero;
 
+    // In the worst case up to 29 MP3 frames need to be prefetched
+    // for accurate seeking:
+    // http://www.mars.org/mailman/public/mad-dev/2002-May/000634.html
+    // Used by both SoundSourceMp3 and SoundSourceCoreAudio.
+    static const SINT kMp3SeekFramePrefetchCount = 29;
+
     // Returns the number of channels. The number of channels
     // must be constant over time.
     inline SINT getChannelCount() const {

--- a/src/sources/soundsourcecoreaudio.h
+++ b/src/sources/soundsourcecoreaudio.h
@@ -37,6 +37,7 @@ public:
 private:
     Result tryOpen(const AudioSourceConfig& audioSrcCfg) /*override*/;
 
+    bool m_bFileIsMp3;
     ExtAudioFileRef m_audioFile;
     CAStreamBasicDescription m_inputFormat;
     CAStreamBasicDescription m_outputFormat;

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -8,12 +8,6 @@ namespace Mixxx {
 
 namespace {
 
-// In the worst case up to 29 MP3 frames need to be prefetched
-// for accurate seeking:
-// http://www.mars.org/mailman/public/mad-dev/2002-May/000634.html
-const SINT kSeekFramePrefetchCount = 29;
-
-
 // mp3 supports 9 different frame rates
 static const int kFrameRateCount = 9;
 
@@ -482,15 +476,15 @@ SINT SoundSourceMp3::seekSampleFrame(SINT frameIndex) {
     DEBUG_ASSERT((curSeekFrameIndex <= seekFrameIndex) || (m_curFrameIndex > frameIndex));
     if ((getFrameIndexMax() <= m_curFrameIndex) || // out of range
             (frameIndex < m_curFrameIndex) || // seek backward
-            (seekFrameIndex > (curSeekFrameIndex + kSeekFramePrefetchCount))) { // jump forward
+            (seekFrameIndex > (curSeekFrameIndex + kMp3SeekFramePrefetchCount))) { // jump forward
 
         // Adjust the seek frame index for prefetching
         // Implementation note: The type SINT is unsigned so
         // need to be careful when subtracting!
-        if (kSeekFramePrefetchCount < seekFrameIndex) {
-            // Restart decoding kSeekFramePrefetchCount seek frames
+        if (kMp3SeekFramePrefetchCount < seekFrameIndex) {
+            // Restart decoding kMp3SeekFramePrefetchCount seek frames
             // before the expected sync position
-            seekFrameIndex -= kSeekFramePrefetchCount;
+            seekFrameIndex -= kMp3SeekFramePrefetchCount;
         } else {
             // Restart decoding at the beginning of the audio stream
             seekFrameIndex = 0;


### PR DESCRIPTION
SoundSourceProxyTest.seekForward was failing on OSX due to
cover-test.mp3 not producing accurate samples on a seek. It seems this
is related to the MP3 decoder not being "primed" right after a seek. To
compensate for this, we seek backwards 29 MP3 frames (same as in
SoundSourceMp3) and read forward.

The test passes now but it would be ideal if we had a reliable way to
determine the right amount to read on a per-file basis from ExtAudioFile
directly (in case other formats need pre-fetching). I'm following up
with Apple support for help here.
