### PR TITLE
MP3 channel and decoding fix

### DIFF
--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -274,7 +274,7 @@ Result SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
                 mad_timer_count(madDuration, madUnits);
 
         DEBUG_ASSERT(m_madStream.this_frame);
-        DEBUG_ASSERT(0 < (m_madStream.this_frame - m_pFileData));
+        DEBUG_ASSERT(0 <= (m_madStream.this_frame - m_pFileData));
     } while (quint64(m_madStream.this_frame - m_pFileData) < m_fileSize);
 
     mad_header_finish(&madHeader);


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/mixxx/+bug/1448224

SoundSourceMp3
- Accept MP3 files with varying number of channels (1 or 2)
- Last commit: Fix error handling for libMAD which was severely broken!
