### PR TITLE
Fix coverity warnings for new SoundSources

### DIFF
--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -164,6 +164,9 @@ SoundSourceMp3::SoundSourceMp3(QUrl url)
           m_curFrameIndex(kFrameIndexMin),
           m_madSynthCount(0) {
     m_seekFrameList.reserve(kSeekFrameListCapacity);
+    mad_stream_init(&m_madStream);
+    mad_frame_init(&m_madFrame);
+    mad_synth_init(&m_madSynth);
 }
 
 SoundSourceMp3::~SoundSourceMp3() {
@@ -185,12 +188,9 @@ Result SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
     m_pFileData = m_file.map(0, m_fileSize);
 
     // Transfer it to the mad stream-buffer:
-    mad_stream_init(&m_madStream);
     mad_stream_options(&m_madStream, MAD_OPTION_IGNORECRC);
     mad_stream_buffer(&m_madStream, m_pFileData, m_fileSize);
     DEBUG_ASSERT(m_pFileData == m_madStream.this_frame);
-    mad_frame_init(&m_madFrame);
-    mad_synth_init(&m_madSynth);
 
     DEBUG_ASSERT(m_seekFrameList.empty());
     m_avgSeekFrameCount = 0;
@@ -370,10 +370,11 @@ Result SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
 }
 
 void SoundSourceMp3::close() {
+    mad_synth_finish(&m_madSynth);
+    mad_frame_finish(&m_madFrame);
+    mad_stream_finish(&m_madStream);
+
     if (m_pFileData) {
-        mad_synth_finish(&m_madSynth);
-        mad_frame_finish(&m_madFrame);
-        mad_stream_finish(&m_madStream);
         m_file.unmap(m_pFileData);
         m_pFileData = NULL;
     }

--- a/src/sources/soundsourcemp3.h
+++ b/src/sources/soundsourcemp3.h
@@ -66,7 +66,14 @@ private:
 
     SINT m_curFrameIndex;
 
+    // NOTE(uklotzde): Each invocation of initDecoding() must be
+    // followed by an invocation of finishDecoding(). In between
+    // 2 matching invocations restartDecoding() might invoked any
+    // number of times, but only if the files has been opened
+    // successfully.
+    void initDecoding();
     SINT restartDecoding(const SeekFrameType& seekFrame);
+    void finishDecoding();
 
     // MAD decoder
     mad_stream m_madStream;

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -14,7 +14,6 @@ QList<QString> SoundSourceSndFile::supportedFileExtensions() {
 SoundSourceSndFile::SoundSourceSndFile(QUrl url)
         : SoundSource(url),
           m_pSndFile(NULL) {
-    memset(&m_sfInfo, 0, sizeof(m_sfInfo));
 }
 
 SoundSourceSndFile::~SoundSourceSndFile() {
@@ -29,8 +28,9 @@ Result SoundSourceSndFile::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
     LPCWSTR lpcwFilename = (LPCWSTR) fileName.utf16();
     m_pSndFile = sf_wchar_open(lpcwFilename, SFM_READ, &m_sfInfo);
 #else
-    m_pSndFile = sf_open(getLocalFileNameBytes().constData(), SFM_READ,
-            &m_sfInfo);
+    SF_INFO sfInfo;
+    memset(&sfInfo, 0, sizeof(sfInfo));
+    m_pSndFile = sf_open(getLocalFileNameBytes().constData(), SFM_READ, &sfInfo);
 #endif
 
     if (!m_pSndFile) {   // sf_format_check is only for writes
@@ -45,9 +45,9 @@ Result SoundSourceSndFile::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
         return ERR;
     }
 
-    setChannelCount(m_sfInfo.channels);
-    setFrameRate(m_sfInfo.samplerate);
-    setFrameCount(m_sfInfo.frames);
+    setChannelCount(sfInfo.channels);
+    setFrameRate(sfInfo.samplerate);
+    setFrameCount(sfInfo.frames);
 
     return OK;
 }

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -14,6 +14,7 @@ QList<QString> SoundSourceSndFile::supportedFileExtensions() {
 SoundSourceSndFile::SoundSourceSndFile(QUrl url)
         : SoundSource(url),
           m_pSndFile(NULL) {
+    memset(&m_sfInfo, 0, sizeof(m_sfInfo));
 }
 
 SoundSourceSndFile::~SoundSourceSndFile() {
@@ -22,7 +23,6 @@ SoundSourceSndFile::~SoundSourceSndFile() {
 
 Result SoundSourceSndFile::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
     DEBUG_ASSERT(!m_pSndFile);
-    memset(&m_sfInfo, 0, sizeof(m_sfInfo));
 #ifdef __WINDOWS__
     // Pointer valid until string changed
     const QString fileName(getLocalFileName());

--- a/src/sources/soundsourcesndfile.h
+++ b/src/sources/soundsourcesndfile.h
@@ -31,7 +31,6 @@ private:
     Result tryOpen(const AudioSourceConfig& audioSrcCfg) /*override*/;
 
     SNDFILE* m_pSndFile;
-    SF_INFO m_sfInfo;
 };
 
 } // namespace Mixxx


### PR DESCRIPTION
Try to fix some minor Coverity warnings for 2 SoundSources by moving the initialization from tryOpen() into the constructor.

For details please refer to the individual commit messages that contain the Coverity warnings.
