### PR TITLE
AudioSource API Code Cleanup

### DIFF
--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -33,7 +33,7 @@ const MP4SampleId kSampleBlockIdMin = 1;
 
 inline SINT getFrameIndexForSampleBlockId(
         MP4SampleId sampleBlockId) {
-    return AudioSource::kFrameIndexMin +
+    return AudioSource::getMinFrameIndex() +
         (sampleBlockId - kSampleBlockIdMin) * kFramesPerSampleBlock;
 }
 
@@ -107,7 +107,7 @@ SoundSourceM4A::SoundSourceM4A(QUrl url)
           m_inputBufferLength(0),
           m_inputBufferOffset(0),
           m_hDecoder(NULL),
-          m_curFrameIndex(kFrameIndexMin) {
+          m_curFrameIndex(getMinFrameIndex()) {
 }
 
 SoundSourceM4A::~SoundSourceM4A() {
@@ -205,7 +205,7 @@ Result SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSrcCfg) {
     m_curFrameIndex = getMaxFrameIndex();
 
     // (Re-)Start decoding at the beginning of the file
-    seekSampleFrame(kFrameIndexMin);
+    seekSampleFrame(getMinFrameIndex());
 
     return OK;
 }

--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -156,8 +156,8 @@ Result SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSrcCfg) {
     NeAACDecConfigurationPtr pDecoderConfig = NeAACDecGetCurrentConfiguration(
             m_hDecoder);
     pDecoderConfig->outputFormat = FAAD_FMT_FLOAT;
-    if ((1 == audioSrcCfg.channelCountHint) || (2 == audioSrcCfg.channelCountHint)) {
-        // mono or stereo requested
+    if ((kChannelCountMono == audioSrcCfg.channelCountHint) ||
+            (kChannelCountStereo == audioSrcCfg.channelCountHint)) {
         pDecoderConfig->downMatrix = 1;
     } else {
         pDecoderConfig->downMatrix = 0;

--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -287,8 +287,8 @@ SINT SoundSourceM4A::readSampleFrames(
         SINT numberOfFrames, CSAMPLE* sampleBuffer) {
     DEBUG_ASSERT(isValidFrameIndex(m_curFrameIndex));
 
-    const SINT numberOfFramesTotal = math_min(numberOfFrames,
-            SINT(getMaxFrameIndex() - m_curFrameIndex));
+    const SINT numberOfFramesTotal = math_min(
+            numberOfFrames, getMaxFrameIndex() - m_curFrameIndex);
     const SINT numberOfSamplesTotal = frames2samples(numberOfFramesTotal);
 
     CSAMPLE* pSampleBuffer = sampleBuffer;

--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -202,7 +202,7 @@ Result SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSrcCfg) {
 
     // Invalidate current position to enforce the following
     // seek operation
-    m_curFrameIndex = getFrameIndexMax();
+    m_curFrameIndex = getMaxFrameIndex();
 
     // (Re-)Start decoding at the beginning of the file
     seekSampleFrame(kFrameIndexMin);
@@ -288,7 +288,7 @@ SINT SoundSourceM4A::readSampleFrames(
     DEBUG_ASSERT(isValidFrameIndex(m_curFrameIndex));
 
     const SINT numberOfFramesTotal = math_min(numberOfFrames,
-            SINT(getFrameIndexMax() - m_curFrameIndex));
+            SINT(getMaxFrameIndex() - m_curFrameIndex));
     const SINT numberOfSamplesTotal = frames2samples(numberOfFramesTotal);
 
     CSAMPLE* pSampleBuffer = sampleBuffer;

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -500,7 +500,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const Mixxx::AudioSourceCo
         return false;
     }
 
-    if (kChannelCountZero < audioSrcCfg.channelCountHint) {
+    if (isValidChannelCount(audioSrcCfg.channelCountHint)) {
         hr = m_pAudioType->SetUINT32(MF_MT_AUDIO_NUM_CHANNELS, audioSrcCfg.channelCountHint);
         if (FAILED(hr)) {
             qWarning() << "SSMF: failed to set number of channels";

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -22,8 +22,8 @@ Result SoundSourceWV::tryOpen(const AudioSourceConfig& audioSrcCfg) {
     DEBUG_ASSERT(!m_wpc);
     char msg[80]; // hold possible error message
     int openFlags = OPEN_WVC | OPEN_NORMALIZE;
-    if ((1 == audioSrcCfg.channelCountHint) || (2 == audioSrcCfg.channelCountHint)) {
-        // mono or stereo requested
+    if ((kChannelCountMono == audioSrcCfg.channelCountHint) ||
+            (kChannelCountStereo == audioSrcCfg.channelCountHint)) {
         openFlags |= OPEN_2CH_MAX;
     }
     m_wpc = WavpackOpenFileInput(

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -11,7 +11,7 @@ QList<QString> SoundSourceWV::supportedFileExtensions() {
 SoundSourceWV::SoundSourceWV(QUrl url)
         : SoundSourcePlugin(url, "wv"),
           m_wpc(NULL),
-          m_sampleScaleFactor(kSampleValueZero) {
+          m_sampleScaleFactor(CSAMPLE_ZERO) {
 }
 
 SoundSourceWV::~SoundSourceWV() {
@@ -38,12 +38,12 @@ Result SoundSourceWV::tryOpen(const AudioSourceConfig& audioSrcCfg) {
     setFrameCount(WavpackGetNumSamples(m_wpc));
 
     if (WavpackGetMode(m_wpc) & MODE_FLOAT) {
-        m_sampleScaleFactor = kSampleValuePeak;
+        m_sampleScaleFactor = CSAMPLE_PEAK;
     } else {
         const int bitsPerSample = WavpackGetBitsPerSample(m_wpc);
         const uint32_t wavpackPeakSampleValue = uint32_t(1)
                 << (bitsPerSample - 1);
-        m_sampleScaleFactor = kSampleValuePeak / CSAMPLE(wavpackPeakSampleValue);
+        m_sampleScaleFactor = CSAMPLE_PEAK / CSAMPLE(wavpackPeakSampleValue);
     }
 
     return OK;

--- a/src/analyserqueue.cpp
+++ b/src/analyserqueue.cpp
@@ -15,7 +15,6 @@
 #include "analyserbeats.h"
 #include "analyserkey.h"
 #include "vamp/vampanalyser.h"
-#include "util/assert.h"
 #include "util/compatibility.h"
 #include "util/event.h"
 #include "util/trace.h"
@@ -31,7 +30,7 @@ namespace {
     // We need to use a smaller block size, because on Linux the AnalyserQueue
     // can starve the CPU of its resources, resulting in xruns. A block size
     // of 4096 frames per block seems to do fine.
-    const SINT kAnalysisChannels = 2; // stereo
+    const SINT kAnalysisChannels = Mixxx::AudioSource::kChannelCountStereo;
     const SINT kAnalysisFramesPerBlock = 4096;
     const SINT kAnalysisSamplesPerBlock =
             kAnalysisFramesPerBlock * kAnalysisChannels;

--- a/src/analyserqueue.cpp
+++ b/src/analyserqueue.cpp
@@ -166,15 +166,15 @@ bool AnalyserQueue::doAnalysis(TrackPointer tio, Mixxx::AudioSourcePointer pAudi
     QTime progressUpdateInhibitTimer;
     progressUpdateInhibitTimer.start(); // Inhibit Updates for 60 milliseconds
 
-    SINT frameIndex = pAudioSource->getFrameIndexMin();
+    SINT frameIndex = pAudioSource->getMinFrameIndex();
     bool dieflag = false;
     bool cancelled = false;
     do {
         ScopedTimer t("AnalyserQueue::doAnalysis block");
 
-        DEBUG_ASSERT(frameIndex < pAudioSource->getFrameIndexMax());
+        DEBUG_ASSERT(frameIndex < pAudioSource->getMaxFrameIndex());
         const SINT framesRemaining =
-                pAudioSource->getFrameIndexMax() - frameIndex;
+                pAudioSource->getMaxFrameIndex() - frameIndex;
         const SINT framesToRead =
                 math_min(kAnalysisFramesPerBlock, framesRemaining);
         DEBUG_ASSERT(0 < framesToRead);
@@ -202,7 +202,7 @@ bool AnalyserQueue::doAnalysis(TrackPointer tio, Mixxx::AudioSourcePointer pAudi
             // Partial analysis block of audio samples has been read.
             // This should only happen at the end of an audio stream,
             // otherwise a decoding error must have occurred.
-            if (frameIndex < pAudioSource->getFrameIndexMax()) {
+            if (frameIndex < pAudioSource->getMaxFrameIndex()) {
                 // EOF not reached -> Maybe a corrupt file?
                 qWarning() << "Failed to read sample data from file:"
                         << tio->getFilename()
@@ -222,7 +222,7 @@ bool AnalyserQueue::doAnalysis(TrackPointer tio, Mixxx::AudioSourcePointer pAudi
         //fp div here prevents insane signed overflow
         DEBUG_ASSERT(pAudioSource->isValidFrameIndex(frameIndex));
         const double frameProgress =
-                double(frameIndex) / double(pAudioSource->getFrameIndexMax());
+                double(frameIndex) / double(pAudioSource->getMaxFrameIndex());
         int progressPromille = frameProgress * (1000 - FINALIZE_PROMILLE);
 
         if (m_progressInfo.track_progress != progressPromille) {
@@ -259,7 +259,7 @@ bool AnalyserQueue::doAnalysis(TrackPointer tio, Mixxx::AudioSourcePointer pAudi
         if (dieflag || cancelled) {
             t.cancel();
         }
-    } while (!dieflag && (frameIndex < pAudioSource->getFrameIndexMax()));
+    } while (!dieflag && (frameIndex < pAudioSource->getMaxFrameIndex()));
 
     return !cancelled; //don't return !dieflag or we might reanalyze over and over
 }

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -21,7 +21,7 @@
 // TODO(XXX): The optimum value of the "constant" kFramesPerChunk
 // depends on the properties of the AudioSource as the remarks
 // above suggest!
-const SINT CachingReaderWorker::kChunkChannels = 2; // stereo
+const SINT CachingReaderWorker::kChunkChannels = Mixxx::AudioSource::kChannelCountStereo;
 const SINT CachingReaderWorker::kFramesPerChunk = 8192; // ~ 170 ms at 48 kHz
 const SINT CachingReaderWorker::kSamplesPerChunk = kFramesPerChunk * kChunkChannels;
 

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -72,7 +72,7 @@ void CachingReaderWorker::processChunkReadRequest(
     }
 
     const SINT framesRemaining =
-            m_pAudioSource->getFrameIndexMax() - seekFrameIndex;
+            m_pAudioSource->getMaxFrameIndex() - seekFrameIndex;
     const SINT framesToRead =
             math_min(kFramesPerChunk, framesRemaining);
     if (0 >= framesToRead) {

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -18,7 +18,7 @@ namespace
     // on their server so we need only a fingerprint of the first two minutes
     // --kain88 July 2012
     const SINT kFingerprintDuration = 120; // in seconds
-    const SINT kFingerprintChannels = 2; // stereo
+    const SINT kFingerprintChannels = Mixxx::AudioSource::kChannelCountStereo;
 
     QString calcFingerprint(const Mixxx::AudioSourcePointer& pAudioSource) {
 

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -4,9 +4,9 @@
 
 namespace Mixxx {
 
-/*static*/const CSAMPLE AudioSource::kSampleValueZero =
+/*static*/ const CSAMPLE AudioSource::kSampleValueZero =
         CSAMPLE_ZERO;
-/*static*/const CSAMPLE AudioSource::kSampleValuePeak =
+/*static*/ const CSAMPLE AudioSource::kSampleValuePeak =
         CSAMPLE_PEAK;
 
 AudioSource::AudioSource(QUrl url)
@@ -18,13 +18,23 @@ AudioSource::AudioSource(QUrl url)
 }
 
 void AudioSource::setChannelCount(SINT channelCount) {
+    DEBUG_ASSERT(isValidChannelCount(channelCount));
     m_channelCount = channelCount;
 }
+
 void AudioSource::setFrameRate(SINT frameRate) {
+    DEBUG_ASSERT(isValidFrameRate(frameRate));
     m_frameRate = frameRate;
 }
+
 void AudioSource::setFrameCount(SINT frameCount) {
+    DEBUG_ASSERT(isValidFrameCount(frameCount));
     m_frameCount = frameCount;
+}
+
+void AudioSource::setBitrate(SINT bitrate) {
+    DEBUG_ASSERT(isValidBitrate(bitrate));
+    m_bitrate = bitrate;
 }
 
 SINT AudioSource::getSampleBufferSize(

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -4,11 +4,6 @@
 
 namespace Mixxx {
 
-/*static*/ const CSAMPLE AudioSource::kSampleValueZero =
-        CSAMPLE_ZERO;
-/*static*/ const CSAMPLE AudioSource::kSampleValuePeak =
-        CSAMPLE_PEAK;
-
 AudioSource::AudioSource(QUrl url)
         : UrlResource(url),
           m_channelCount(kChannelCountDefault),

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -36,7 +36,7 @@ SINT AudioSource::getSampleBufferSize(
         SINT numberOfFrames,
         bool readStereoSamples) const {
     if (readStereoSamples) {
-        return numberOfFrames * 2;
+        return numberOfFrames * kChannelCountStereo;
     } else {
         return frames2samples(numberOfFrames);
     }

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -36,12 +36,6 @@ public:
     static const SINT kChannelCountMono = 1;
     static const SINT kChannelCountStereo = 2;
 
-    // In the worst case up to 29 MP3 frames need to be prefetched
-    // for accurate seeking:
-    // http://www.mars.org/mailman/public/mad-dev/2002-May/000634.html
-    // Used by both SoundSourceMp3 and SoundSourceCoreAudio.
-    static const SINT kMp3SeekFramePrefetchCount = 29;
-
     // Returns the number of channels. The number of channels
     // must be constant over time.
     inline SINT getChannelCount() const {

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -134,21 +134,21 @@ public:
     }
 
     // Index of the first sample frame.
-    SINT getFrameIndexMin() const {
+    inline SINT getMinFrameIndex() const {
         return kFrameIndexMin;
     }
 
     // Index of the sample frame following the last
     // sample frame.
-    SINT getFrameIndexMax() const {
-        return kFrameIndexMin + getFrameCount();
+    inline SINT getMaxFrameIndex() const {
+        return getMinFrameIndex() + getFrameCount();
     }
 
     // The sample frame index is valid in the range
-    // [getFrameIndexMin(), getFrameIndexMax()].
+    // [getMinFrameIndex(), getMaxFrameIndex()].
     inline bool isValidFrameIndex(SINT frameIndex) const {
-        return (getFrameIndexMin() <= frameIndex) &&
-                (getFrameIndexMax() >= frameIndex);
+        return (getMinFrameIndex() <= frameIndex) &&
+                (getMaxFrameIndex() >= frameIndex);
     }
 
     // Adjusts the current frame seek index:

--- a/src/sources/mp3decoding.h
+++ b/src/sources/mp3decoding.h
@@ -1,0 +1,16 @@
+#ifndef MIXXX_MP3DECODING_H
+#define MIXXX_MP3DECODING_H
+
+#include "util/types.h"
+
+namespace Mixxx {
+
+// In the worst case up to 29 MP3 frames need to be prefetched
+// for accurate seeking:
+// http://www.mars.org/mailman/public/mad-dev/2002-May/000634.html
+// Used by both SoundSourceMp3 and SoundSourceCoreAudio.
+static const SINT kMp3SeekFramePrefetchCount = 29;
+
+} // namespace Mixxx
+
+#endif // MIXXX_MP3DECODING_H

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -86,7 +86,7 @@ Result SoundSourceCoreAudio::tryOpen(const AudioSourceConfig& audioSrcCfg) {
 
     // create the output format
     const UInt32 numChannels =
-            (kChannelCountZero < audioSrcCfg.channelCountHint) ? audioSrcCfg.channelCountHint : 2;
+            isValidChannelCount(audioSrcCfg.channelCountHint) ? audioSrcCfg.channelCountHint : 2;
     m_outputFormat = CAStreamBasicDescription(m_inputFormat.mSampleRate,
             numChannels, CAStreamBasicDescription::kPCMFormatFloat32, true);
 

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -156,8 +156,8 @@ SINT SoundSourceCoreAudio::seekSampleFrame(SINT frameIndex) {
     DEBUG_ASSERT(isValidFrameIndex(frameIndex));
 
     // See comments above on kMp3StabilizationFrames.
-    const SINT stabilization_frames = m_bFileIsMp3 ? math_min<SINT>(
-            kMp3StabilizationFrames, frameIndex + m_headerFrames) : 0;
+    const SINT stabilization_frames = m_bFileIsMp3 ? math_min(
+            kMp3StabilizationFrames, SINT(frameIndex + m_headerFrames)) : 0;
     OSStatus err = ExtAudioFileSeek(
             m_audioFile, frameIndex + m_headerFrames - stabilization_frames);
     if (stabilization_frames > 0) {

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -1,4 +1,5 @@
 #include "sources/soundsourcecoreaudio.h"
+#include "sources/mp3decoding.h"
 
 #include "util/math.h"
 
@@ -17,7 +18,7 @@ const SINT kMp3MaxFrameSize = 1152;
 // information -- which AIUI is supposed to tell us this information -- is zero
 // for this file. We use the same frame pre-fetch count from SoundSourceMp3.
 const SINT kMp3StabilizationFrames =
-        AudioSource::kMp3SeekFramePrefetchCount * kMp3MaxFrameSize;
+        kMp3SeekFramePrefetchCount * kMp3MaxFrameSize;
 
 static CSAMPLE kMp3StabilizationScratchBuffer[kMp3StabilizationFrames *
                                               AudioSource::kChannelCountStereo];

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -13,7 +13,7 @@ namespace {
 // appropriate amount to pre-fetch from the ExtAudioFile API. Oddly, the "prime"
 // information -- which AIUI is supposed to tell us this information -- is zero
 // for this file. We use the same frame pre-fetch count from SoundSourceMp3.
-static const int kMp3StabilizationFrames =
+const SINT kMp3StabilizationFrames =
         AudioSource::kMp3SeekFramePrefetchCount * 1152;
 static CSAMPLE kMp3StabilizationScratchBuffer[kMp3StabilizationFrames *
                                               AudioSource::kChannelCountStereo];

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -6,6 +6,9 @@ namespace Mixxx {
 
 namespace {
 
+// The maximum number of samples per MP3 frame
+const SINT kMp3MaxFrameSize = 1152;
+
 // NOTE(rryan): For every MP3 seek we jump back kStabilizationFrames frames from
 // the seek position and read forward to allow the decoder to stabilize. The
 // cover-test.mp3 file needs this otherwise SoundSourceProxyTest.seekForward
@@ -14,7 +17,8 @@ namespace {
 // information -- which AIUI is supposed to tell us this information -- is zero
 // for this file. We use the same frame pre-fetch count from SoundSourceMp3.
 const SINT kMp3StabilizationFrames =
-        AudioSource::kMp3SeekFramePrefetchCount * 1152;
+        AudioSource::kMp3SeekFramePrefetchCount * kMp3MaxFrameSize;
+
 static CSAMPLE kMp3StabilizationScratchBuffer[kMp3StabilizationFrames *
                                               AudioSource::kChannelCountStereo];
 

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -144,7 +144,7 @@ SINT SoundSourceFLAC::seekSampleFrame(SINT frameIndex) {
     } else {
         qWarning() << "Seek error at" << frameIndex << "in" << m_file.fileName();
         // Invalidate the current position
-        m_curFrameIndex = getFrameIndexMax();
+        m_curFrameIndex = getMaxFrameIndex();
         if (FLAC__STREAM_DECODER_SEEK_ERROR == FLAC__stream_decoder_get_state(m_decoder)) {
             // Flush the input stream of the decoder according to the
             // documentation of FLAC__stream_decoder_seek_absolute()
@@ -152,7 +152,7 @@ SINT SoundSourceFLAC::seekSampleFrame(SINT frameIndex) {
                 qWarning() << "Failed to flush input buffer of the FLAC decoder after seeking in"
                         << m_file.fileName();
                 // Invalidate the current position...
-                m_curFrameIndex = getFrameIndexMax();
+                m_curFrameIndex = getMaxFrameIndex();
                 // ...and abort
                 return m_curFrameIndex;
             }
@@ -164,7 +164,7 @@ SINT SoundSourceFLAC::seekSampleFrame(SINT frameIndex) {
                 qWarning() << "Failed to resync FLAC decoder after seeking in"
                         << m_file.fileName();
                 // Invalidate the current position...
-                m_curFrameIndex = getFrameIndexMax();
+                m_curFrameIndex = getMaxFrameIndex();
                 // ...and abort
                 return m_curFrameIndex;
             }
@@ -200,7 +200,7 @@ SINT SoundSourceFLAC::readSampleFrames(
     DEBUG_ASSERT(getSampleBufferSize(numberOfFrames, readStereoSamples) <= sampleBufferSize);
 
     const SINT numberOfFramesTotal =
-            math_min(numberOfFrames, getFrameIndexMax() - m_curFrameIndex);
+            math_min(numberOfFrames, getMaxFrameIndex() - m_curFrameIndex);
     const SINT numberOfSamplesTotal = frames2samples(numberOfFramesTotal);
 
     CSAMPLE* outBuffer = sampleBuffer;

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -247,8 +247,8 @@ SINT SoundSourceFLAC::readSampleFrames(
                 m_sampleBuffer.readFromHead(numberOfSamplesRemaining));
         const SINT framesToCopy = samples2frames(readableChunk.size());
         if (outBuffer) {
-            if (readStereoSamples && !isChannelCountStereo()) {
-                if (isChannelCountMono()) {
+            if (readStereoSamples && (kChannelCountStereo != getChannelCount())) {
+                if (kChannelCountMono == getChannelCount()) {
                     SampleUtil::copyMonoToDualMono(outBuffer,
                             readableChunk.data(),
                             framesToCopy);

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -257,7 +257,7 @@ SINT SoundSourceFLAC::readSampleFrames(
                             readableChunk.data(),
                             framesToCopy, getChannelCount());
                 }
-                outBuffer += framesToCopy * 2; // copied 2 samples per frame
+                outBuffer += framesToCopy * kChannelCountStereo;
             } else {
                 SampleUtil::copy(outBuffer, readableChunk.data(), readableChunk.size());
                 outBuffer += readableChunk.size();

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -72,8 +72,8 @@ SoundSourceFLAC::SoundSourceFLAC(QUrl url)
           m_minFramesize(0),
           m_maxFramesize(0),
           m_bitsPerSample(kBitsPerSampleDefault),
-          m_sampleScaleFactor(kSampleValueZero),
-          m_curFrameIndex(kFrameIndexMin) {
+          m_sampleScaleFactor(CSAMPLE_ZERO),
+          m_curFrameIndex(getMinFrameIndex()) {
 }
 
 SoundSourceFLAC::~SoundSourceFLAC() {
@@ -107,7 +107,7 @@ Result SoundSourceFLAC::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
         return ERR;
     }
 
-    m_curFrameIndex = kFrameIndexMin;
+    m_curFrameIndex = getMinFrameIndex();
 
     return OK;
 }
@@ -410,32 +410,40 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
     case FLAC__METADATA_TYPE_STREAMINFO:
     {
         const SINT channelCount = metadata->data.stream_info.channels;
-        DEBUG_ASSERT(kChannelCountDefault != channelCount);
-        if (getChannelCount() == kChannelCountDefault) {
-            // not set before
-            setChannelCount(channelCount);
-        } else {
-            // already set before -> check for consistency
-            if (getChannelCount() != channelCount) {
-                qWarning() << "Unexpected channel count:"
-                        << channelCount << " <> " << getChannelCount();
+        if (isValidChannelCount(channelCount)) {
+            if (hasChannelCount()) {
+                // already set before -> check for consistency
+                if (getChannelCount() != channelCount) {
+                    qWarning() << "Unexpected channel count:"
+                            << channelCount << " <> " << getChannelCount();
+                }
+            } else {
+                // not set before
+                setChannelCount(channelCount);
             }
+        } else {
+            qWarning() << "Invalid channel count:"
+                    << channelCount;
         }
         const SINT frameRate = metadata->data.stream_info.sample_rate;
-        DEBUG_ASSERT(kFrameRateDefault != frameRate);
-        if (getFrameRate() == kFrameRateDefault) {
-            // not set before
-            setFrameRate(frameRate);
-        } else {
-            // already set before -> check for consistency
-            if (getFrameRate() != frameRate) {
-                qWarning() << "Unexpected frame/sample rate:"
-                        << frameRate << " <> " << getFrameRate();
+        if (isValidFrameRate(frameRate)) {
+            if (hasFrameRate()) {
+                // already set before -> check for consistency
+                if (getFrameRate() != frameRate) {
+                    qWarning() << "Unexpected frame/sample rate:"
+                            << frameRate << " <> " << getFrameRate();
+                }
+            } else {
+                // not set before
+                setFrameRate(frameRate);
             }
+        } else {
+            qWarning() << "Invalid frame/sample rate:"
+                    << frameRate;
         }
         const SINT frameCount = metadata->data.stream_info.total_samples;
-        DEBUG_ASSERT(kFrameCountDefault != frameCount);
-        if (getFrameCount() == kFrameCountDefault) {
+        DEBUG_ASSERT(isValidFrameCount(frameCount));
+        if (isEmpty()) {
             // not set before
             setFrameCount(frameCount);
         } else {
@@ -450,7 +458,7 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
         if (kBitsPerSampleDefault == m_bitsPerSample) {
             // not set before
             m_bitsPerSample = bitsPerSample;
-            m_sampleScaleFactor = kSampleValuePeak
+            m_sampleScaleFactor = CSAMPLE_PEAK
                     / CSAMPLE(FLAC__int32(1) << bitsPerSample);
         } else {
             // already set before -> check for consistency

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -39,7 +39,7 @@ QString getModPlugTypeFromUrl(QUrl url) {
 
 } // anonymous namespace
 
-const SINT SoundSourceModPlug::kChannelCount = 2; // stereo
+const SINT SoundSourceModPlug::kChannelCount = AudioSource::kChannelCountStereo;
 const SINT SoundSourceModPlug::kBitsPerSample = 16;
 const SINT SoundSourceModPlug::kFrameRate = 44100; // 44.1 kHz
 

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -1,4 +1,5 @@
 #include "sources/soundsourcemp3.h"
+#include "sources/mp3decoding.h"
 
 #include "util/math.h"
 

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -186,8 +186,8 @@ void SoundSourceMp3::finishDecoding() {
 }
 
 Result SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
-    DEBUG_ASSERT(!isChannelCountValid());
-    DEBUG_ASSERT(!isFrameRateValid());
+    DEBUG_ASSERT(!hasChannelCount());
+    DEBUG_ASSERT(!hasFrameRate());
 
     DEBUG_ASSERT(!m_file.isOpen());
     if (!m_file.open(QIODevice::ReadOnly)) {
@@ -249,7 +249,7 @@ Result SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
         }
 
         const SINT madChannelCount = MAD_NCHANNELS(&madHeader);
-        if ((0 < maxChannelCount) && (madChannelCount != maxChannelCount)) {
+        if (isValidChannelCount(maxChannelCount) && (madChannelCount != maxChannelCount)) {
             qWarning() << "Differing number of channels"
                     << madChannelCount << "<>" << maxChannelCount
                     << "in some MP3 frame headers:"
@@ -646,9 +646,9 @@ SINT SoundSourceMp3::readSampleFrames(
                         << madSynthChannelCount << "<>" << getChannelCount();
             }
 #endif
-            if (1 == madSynthChannelCount) {
+            if (kChannelCountMono == madSynthChannelCount) {
                 // MP3 frame contains a mono signal
-                if (readStereoSamples || isChannelCountStereo()) {
+                if (readStereoSamples || (kChannelCountStereo == getChannelCount())) {
                     // The reader explicitly requested a stereo signal
                     // or the AudioSource itself provides a stereo signal.
                     // Mono -> Stereo: Copy 1st channel twice
@@ -671,11 +671,11 @@ SINT SoundSourceMp3::readSampleFrames(
                 }
             } else {
                 // MP3 frame contains a stereo signal
-                DEBUG_ASSERT(2 == madSynthChannelCount);
+                DEBUG_ASSERT(kChannelCountStereo == madSynthChannelCount);
                 // If the MP3 frame contains a stereo signal then the whole
                 // AudioSource must also provide 2 channels, because the
                 // maximum channel count of all MP3 frames is used.
-                DEBUG_ASSERT(2 == getChannelCount());
+                DEBUG_ASSERT(kChannelCountStereo == getChannelCount());
                 // Stereo -> Stereo: Copy 1st+2nd channel
                 for (SINT i = 0; i < synthReadCount; ++i) {
                     *pSampleBuffer = madScaleSampleValue(

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -444,7 +444,7 @@ SINT SoundSourceMp3::findSeekFrameIndex(
     DEBUG_ASSERT(0 < m_avgSeekFrameCount);
     DEBUG_ASSERT(!m_seekFrameList.empty());
     DEBUG_ASSERT(kFrameIndexMin == m_seekFrameList.front().frameIndex);
-    DEBUG_ASSERT(SINT(kFrameIndexMin + getFrameIndexMax()) == m_seekFrameList.back().frameIndex);
+    DEBUG_ASSERT(SINT(kFrameIndexMin + getMaxFrameIndex()) == m_seekFrameList.back().frameIndex);
 
     SINT lowerBound =
             0;
@@ -495,7 +495,7 @@ SINT SoundSourceMp3::seekSampleFrame(SINT frameIndex) {
     // some consistency checks
     DEBUG_ASSERT((curSeekFrameIndex >= seekFrameIndex) || (m_curFrameIndex < frameIndex));
     DEBUG_ASSERT((curSeekFrameIndex <= seekFrameIndex) || (m_curFrameIndex > frameIndex));
-    if ((getFrameIndexMax() <= m_curFrameIndex) || // out of range
+    if ((getMaxFrameIndex() <= m_curFrameIndex) || // out of range
             (frameIndex < m_curFrameIndex) || // seek backward
             (seekFrameIndex > (curSeekFrameIndex + kMp3SeekFramePrefetchCount))) { // jump forward
 
@@ -512,7 +512,7 @@ SINT SoundSourceMp3::seekSampleFrame(SINT frameIndex) {
         }
 
         m_curFrameIndex = restartDecoding(m_seekFrameList[seekFrameIndex]);
-        if (getFrameIndexMax() <= m_curFrameIndex) {
+        if (getMaxFrameIndex() <= m_curFrameIndex) {
             // out of range -> abort
             return m_curFrameIndex;
         }
@@ -553,7 +553,7 @@ SINT SoundSourceMp3::readSampleFrames(
     DEBUG_ASSERT(getSampleBufferSize(numberOfFrames, readStereoSamples) <= sampleBufferSize);
 
     const SINT numberOfFramesTotal = math_min(numberOfFrames,
-            SINT(getFrameIndexMax() - m_curFrameIndex));
+            SINT(getMaxFrameIndex() - m_curFrameIndex));
 
     CSAMPLE* pSampleBuffer = sampleBuffer;
     SINT numberOfFramesRemaining = numberOfFramesTotal;

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -198,6 +198,12 @@ Result SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
     // Get a pointer to the file using memory mapped IO
     m_fileSize = m_file.size();
     m_pFileData = m_file.map(0, m_fileSize);
+    // NOTE(uklotzde): If the file disappears unexpectedly while mapped
+    // a SIGBUS error might occur that is not handled and will terminate
+    // Mixxx immediately. This behavior is documented in the manpage of
+    // mmap(). It has already appeared due to hardware errors and is
+    // described in the following bug report:
+    // https://bugs.launchpad.net/mixxx/+bug/1452005
 
     // Transfer it to the mad stream-buffer:
     mad_stream_options(&m_madStream, MAD_OPTION_IGNORECRC);

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -9,7 +9,7 @@ namespace Mixxx {
 namespace {
 
 // MP3 does only support 1 or 2 channels
-const SINT kChannelCountMax = 2;
+const SINT kChannelCountMax = AudioSource::kChannelCountStereo;
 
 // mp3 supports 9 different frame rates
 const int kFrameRateCount = 9;
@@ -661,18 +661,15 @@ SINT SoundSourceMp3::readSampleFrames(
                     for (SINT i = 0; i < synthReadCount; ++i) {
                         const CSAMPLE sampleValue = madScaleSampleValue(
                                 m_madSynth.pcm.samples[0][madSynthOffset + i]);
-                        *pSampleBuffer = sampleValue;
-                        ++pSampleBuffer;
-                        *pSampleBuffer = sampleValue;
-                        ++pSampleBuffer;
+                        *pSampleBuffer++ = sampleValue;
+                        *pSampleBuffer++ = sampleValue;
                     }
                 } else {
                     // Mono -> Mono: Copy 1st channel
                     for (SINT i = 0; i < synthReadCount; ++i) {
                         const CSAMPLE sampleValue = madScaleSampleValue(
                                 m_madSynth.pcm.samples[0][madSynthOffset + i]);
-                        *pSampleBuffer = sampleValue;
-                        ++pSampleBuffer;
+                        *pSampleBuffer++ = sampleValue;
                     }
                 }
             } else {
@@ -682,14 +679,12 @@ SINT SoundSourceMp3::readSampleFrames(
                 // AudioSource must also provide 2 channels, because the
                 // maximum channel count of all MP3 frames is used.
                 DEBUG_ASSERT(kChannelCountStereo == getChannelCount());
-                // Stereo -> Stereo: Copy 1st+2nd channel
+                // Stereo -> Stereo: Copy 1st + 2nd channel
                 for (SINT i = 0; i < synthReadCount; ++i) {
-                    *pSampleBuffer = madScaleSampleValue(
+                    *pSampleBuffer++ = madScaleSampleValue(
                             m_madSynth.pcm.samples[0][madSynthOffset + i]);
-                    ++pSampleBuffer;
-                    *pSampleBuffer = madScaleSampleValue(
+                    *pSampleBuffer++ = madScaleSampleValue(
                             m_madSynth.pcm.samples[1][madSynthOffset + i]);
-                    ++pSampleBuffer;
                 }
             }
         }

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -558,8 +558,8 @@ SINT SoundSourceMp3::readSampleFrames(
     DEBUG_ASSERT(isValidFrameIndex(m_curFrameIndex));
     DEBUG_ASSERT(getSampleBufferSize(numberOfFrames, readStereoSamples) <= sampleBufferSize);
 
-    const SINT numberOfFramesTotal = math_min(numberOfFrames,
-            SINT(getMaxFrameIndex() - m_curFrameIndex));
+    const SINT numberOfFramesTotal = math_min(
+            numberOfFrames, getMaxFrameIndex() - m_curFrameIndex);
 
     CSAMPLE* pSampleBuffer = sampleBuffer;
     SINT numberOfFramesRemaining = numberOfFramesTotal;

--- a/src/sources/soundsourceoggvorbis.cpp
+++ b/src/sources/soundsourceoggvorbis.cpp
@@ -134,7 +134,7 @@ SINT SoundSourceOggVorbis::readSampleFrames(
                 numberOfFramesRemaining, &currentSection);
         if (0 < readResult) {
             m_curFrameIndex += readResult;
-            if (isChannelCountMono()) {
+            if (kChannelCountMono == getChannelCount()) {
                 if (readStereoSamples) {
                     for (long i = 0; i < readResult; ++i) {
                         *pSampleBuffer++ = pcmChannels[0][i];
@@ -145,7 +145,7 @@ SINT SoundSourceOggVorbis::readSampleFrames(
                         *pSampleBuffer++ = pcmChannels[0][i];
                     }
                 }
-            } else if (isChannelCountStereo() || readStereoSamples) {
+            } else if (readStereoSamples || (kChannelCountStereo == getChannelCount())) {
                 for (long i = 0; i < readResult; ++i) {
                     *pSampleBuffer++ = pcmChannels[0][i];
                     *pSampleBuffer++ = pcmChannels[1][i];

--- a/src/sources/soundsourceoggvorbis.cpp
+++ b/src/sources/soundsourceoggvorbis.cpp
@@ -91,7 +91,7 @@ SINT SoundSourceOggVorbis::seekSampleFrame(
             m_curFrameIndex = pcmOffset;
         } else {
             // Reset to EOF
-            m_curFrameIndex = getFrameIndexMax();
+            m_curFrameIndex = getMaxFrameIndex();
         }
     }
 
@@ -119,7 +119,7 @@ SINT SoundSourceOggVorbis::readSampleFrames(
     DEBUG_ASSERT(getSampleBufferSize(numberOfFrames, readStereoSamples) <= sampleBufferSize);
 
     const SINT numberOfFramesTotal = math_min(numberOfFrames,
-            SINT(getFrameIndexMax() - m_curFrameIndex));
+            SINT(getMaxFrameIndex() - m_curFrameIndex));
 
     CSAMPLE* pSampleBuffer = sampleBuffer;
     SINT numberOfFramesRemaining = numberOfFramesTotal;

--- a/src/sources/soundsourceoggvorbis.cpp
+++ b/src/sources/soundsourceoggvorbis.cpp
@@ -118,8 +118,8 @@ SINT SoundSourceOggVorbis::readSampleFrames(
     DEBUG_ASSERT(isValidFrameIndex(m_curFrameIndex));
     DEBUG_ASSERT(getSampleBufferSize(numberOfFrames, readStereoSamples) <= sampleBufferSize);
 
-    const SINT numberOfFramesTotal = math_min(numberOfFrames,
-            SINT(getMaxFrameIndex() - m_curFrameIndex));
+    const SINT numberOfFramesTotal = math_min(
+            numberOfFrames, getMaxFrameIndex() - m_curFrameIndex);
 
     CSAMPLE* pSampleBuffer = sampleBuffer;
     SINT numberOfFramesRemaining = numberOfFramesTotal;

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -188,7 +188,7 @@ SINT SoundSourceOpus::seekSampleFrame(SINT frameIndex) {
             m_curFrameIndex = pcmOffset;
         } else {
             // Reset to EOF
-            m_curFrameIndex = getFrameIndexMax();
+            m_curFrameIndex = getMaxFrameIndex();
         }
     }
 
@@ -201,7 +201,7 @@ SINT SoundSourceOpus::readSampleFrames(
     DEBUG_ASSERT(isValidFrameIndex(m_curFrameIndex));
 
     const SINT numberOfFramesTotal = math_min(numberOfFrames,
-            SINT(getFrameIndexMax() - m_curFrameIndex));
+            SINT(getMaxFrameIndex() - m_curFrameIndex));
 
     CSAMPLE* pSampleBuffer = sampleBuffer;
     SINT numberOfFramesRemaining = numberOfFramesTotal;
@@ -232,7 +232,7 @@ SINT SoundSourceOpus::readSampleFramesStereo(
     DEBUG_ASSERT(getSampleBufferSize(numberOfFrames, true) <= sampleBufferSize);
 
     const SINT numberOfFramesTotal = math_min(numberOfFrames,
-            SINT(getFrameIndexMax() - m_curFrameIndex));
+            SINT(getMaxFrameIndex() - m_curFrameIndex));
 
     CSAMPLE* pSampleBuffer = sampleBuffer;
     SINT numberOfFramesRemaining = numberOfFramesTotal;

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -42,7 +42,7 @@ QList<QString> SoundSourceOpus::supportedFileExtensions() {
 SoundSourceOpus::SoundSourceOpus(QUrl url)
         : SoundSource(url, "opus"),
           m_pOggOpusFile(NULL),
-          m_curFrameIndex(kFrameIndexMin) {
+          m_curFrameIndex(getMinFrameIndex()) {
 }
 
 SoundSourceOpus::~SoundSourceOpus() {
@@ -162,7 +162,7 @@ Result SoundSourceOpus::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
 
     setFrameRate(kFrameRate);
 
-    m_curFrameIndex = kFrameIndexMin;
+    m_curFrameIndex = getMinFrameIndex();
 
     return OK;
 }

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -200,8 +200,8 @@ SINT SoundSourceOpus::readSampleFrames(
         SINT numberOfFrames, CSAMPLE* sampleBuffer) {
     DEBUG_ASSERT(isValidFrameIndex(m_curFrameIndex));
 
-    const SINT numberOfFramesTotal = math_min(numberOfFrames,
-            SINT(getMaxFrameIndex() - m_curFrameIndex));
+    const SINT numberOfFramesTotal = math_min(
+            numberOfFrames, getMaxFrameIndex() - m_curFrameIndex);
 
     CSAMPLE* pSampleBuffer = sampleBuffer;
     SINT numberOfFramesRemaining = numberOfFramesTotal;
@@ -231,8 +231,8 @@ SINT SoundSourceOpus::readSampleFramesStereo(
     DEBUG_ASSERT(isValidFrameIndex(m_curFrameIndex));
     DEBUG_ASSERT(getSampleBufferSize(numberOfFrames, true) <= sampleBufferSize);
 
-    const SINT numberOfFramesTotal = math_min(numberOfFrames,
-            SINT(getMaxFrameIndex() - m_curFrameIndex));
+    const SINT numberOfFramesTotal = math_min(
+            numberOfFrames, getMaxFrameIndex() - m_curFrameIndex);
 
     CSAMPLE* pSampleBuffer = sampleBuffer;
     SINT numberOfFramesRemaining = numberOfFramesTotal;


### PR DESCRIPTION
Some minor technical refactorings, mainly to keep the public interface of AudioSource concise and readable. Please refer to the individual commit message for the actual modifications that I did. No bugfixes or new features, just cleaner code.

I also added a note in SoundSourceMp3 about potential SIGBUS errors if the memory-mapped file is modified concurrently or disappears unexpectedly due to technical issues.
