### PR TITLE
LateNight: Shouldn't use widget stacks for show/hide operations

### DIFF
--- a/res/skins/LateNight/fx_samplers_container_full.xml
+++ b/res/skins/LateNight/fx_samplers_container_full.xml
@@ -4,61 +4,45 @@
         <SizePolicy>me,max</SizePolicy>
         <MinimumSize>0,0</MinimumSize>
         <Children>
-            <WidgetStack currentpage="[Library],show_big_current" persist="true">
-                <Children>
-                    <WidgetGroup trigger="[Master],maximize_library">
-                        <Layout>vertical</Layout>
-                        <Children>
-                            <WidgetStack currentpage="[MicrophoneRack],current" persist="true">
-                                <Children>
-                                    <WidgetGroup trigger="[MicrophoneRack],show" persist="true">
-                                        <Layout>vertical</Layout>
-                                        <Children>
-                                            <Template src="skin:microphone_rack.xml"/>
-                                        </Children>
-                                    </WidgetGroup>
-                                    <WidgetGroup>
-                                        <SizePolicy>me,min</SizePolicy>
-                                        <Children/>
-                                    </WidgetGroup>
-                                </Children>
-                            </WidgetStack>
-                            <WidgetStack currentpage="[Samplers],current" persist="true">
-                                <Children>
-                                    <WidgetGroup trigger="[Samplers],show_samplers" persist="true">
-                                        <Layout>vertical</Layout>
-                                        <Children>
-                                            <Template src="skin:sampler_decks.xml"/>
-                                        </Children>
-                                    </WidgetGroup>
-                                    <WidgetGroup>
-                                        <SizePolicy>me,min</SizePolicy>
-                                        <Children/>
-                                    </WidgetGroup>
-                                </Children>
-                            </WidgetStack>
-                            <WidgetStack currentpage="[EffectRack1],current" persist="true">
-                                <Children>
-                                    <WidgetGroup trigger="[EffectRack1],show" persist="true">
-                                        <Layout>vertical</Layout>
-                                        <Children>
-                                            <Template src="skin:effect_rack.xml"/>
-                                        </Children>
-                                    </WidgetGroup>
-                                    <WidgetGroup>
-                                        <SizePolicy>me,min</SizePolicy>
-                                        <Children/>
-                                    </WidgetGroup>
-                                </Children>
-                            </WidgetStack>
-                        </Children>
-                    </WidgetGroup>
-                    <WidgetGroup>
-                        <Layout>horizontal</Layout>
-                        <Children/>
-                    </WidgetGroup>
-                </Children>
-            </WidgetStack>
+          <WidgetGroup trigger="">
+              <Layout>vertical</Layout>
+              <Children>
+                  <WidgetGroup>
+                      <Layout>vertical</Layout>
+                      <Children>
+                          <Template src="skin:microphone_rack.xml"/>
+                      </Children>
+                      <Connection>
+                          <ConfigKey persist="true">[MicrophoneRack],show</ConfigKey>
+                          <BindProperty>visible</BindProperty>
+                      </Connection>
+                  </WidgetGroup>
+                  <WidgetGroup>
+                      <Layout>vertical</Layout>
+                      <Children>
+                          <Template src="skin:sampler_decks.xml"/>
+                      </Children>
+                      <Connection>
+                          <ConfigKey persist="true">[Samplers],show_samplers</ConfigKey>
+                          <BindProperty>visible</BindProperty>
+                      </Connection>
+                  </WidgetGroup>
+                  <WidgetGroup>
+                      <Layout>vertical</Layout>
+                      <Children>
+                          <Template src="skin:effect_rack.xml"/>
+                      </Children>
+                      <Connection>
+                          <ConfigKey persist="true">[EffectRack1],show</ConfigKey>
+                          <BindProperty>visible</BindProperty>
+                      </Connection>
+                  </WidgetGroup>
+              </Children>
+              <Connection>
+                  <ConfigKey persist="true">[Master],maximize_library</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+              </Connection>
+          </WidgetGroup>
         </Children>
     </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/fx_samplers_container_full.xml
+++ b/res/skins/LateNight/fx_samplers_container_full.xml
@@ -4,7 +4,7 @@
         <SizePolicy>me,max</SizePolicy>
         <MinimumSize>0,0</MinimumSize>
         <Children>
-          <WidgetGroup trigger="">
+          <WidgetGroup>
               <Layout>vertical</Layout>
               <Children>
                   <WidgetGroup>

--- a/res/skins/LateNight/fx_samplers_container_med.xml
+++ b/res/skins/LateNight/fx_samplers_container_med.xml
@@ -4,7 +4,7 @@
         <SizePolicy>me,max</SizePolicy>
         <MinimumSize>0,0</MinimumSize>
         <Children>
-            <WidgetStack currentpage="[Master],med_view_curpage" persist="true">
+            <WidgetStack currentpage="[Master],view_curpage" persist="true">
                 <SizePolicy>me,min</SizePolicy>
                 <Children>
                     <!-- First page is blank for when the user just wants the library. -->
@@ -14,21 +14,21 @@
                         <Children/>
                     </WidgetGroup>
                     <!-- When any tab is hidden, go back to the first (empty) page. -->
-                    <WidgetGroup trigger="[MicrophoneRack],show_microphones_tab" on_hide_select="0">
+                    <WidgetGroup trigger="[MicrophoneRack],show" on_hide_select="0">
                         <Layout>vertical</Layout>
                         <SizePolicy>me,min</SizePolicy>
                         <Children>
                             <Template src="skin:microphone_rack.xml"/>
                         </Children>
                     </WidgetGroup>
-                    <WidgetGroup trigger="[EffectRack1],show_tab" on_hide_select="0">
+                    <WidgetGroup trigger="[EffectRack1],show" on_hide_select="0">
                         <Layout>vertical</Layout>
                         <SizePolicy>me,min</SizePolicy>
                         <Children>
                             <Template src="skin:effect_rack.xml"/>
                         </Children>
                     </WidgetGroup>
-                    <WidgetGroup trigger="[Samplers],show_samplers_tab" on_hide_select="0">
+                    <WidgetGroup trigger="[Samplers],show_samplers" on_hide_select="0">
                         <Layout>vertical</Layout>
                         <SizePolicy>me,min</SizePolicy>
                         <Children>

--- a/res/skins/LateNight/fx_samplers_container_small.xml
+++ b/res/skins/LateNight/fx_samplers_container_small.xml
@@ -4,7 +4,7 @@
         <SizePolicy>me,max</SizePolicy>
         <MinimumSize>0,0</MinimumSize>
         <Children>
-            <WidgetStack currentpage="[Master],small_view_curpage" persist="true">
+            <WidgetStack currentpage="[Master],view_curpage" persist="true">
                 <Children>
                     <WidgetGroup trigger="[Library],show_library_tab_small" persist="true">
                         <Layout>vertical</Layout>
@@ -14,22 +14,22 @@
                             </SingletonContainer>
                         </Children>
                     </WidgetGroup>
-                    <WidgetGroup trigger="[EffectRack1],show_tab_small" persist="true">
+                    <WidgetGroup trigger="[MicrophoneRack],show" persist="true">
+                        <Layout>vertical</Layout>
+                        <Children>
+                            <Template src="skin:microphone_rack.xml"/>
+                        </Children>
+                    </WidgetGroup>
+                    <WidgetGroup trigger="[EffectRack1],show" persist="true">
                         <Layout>vertical</Layout>
                         <Children>
                             <Template src="skin:effect_rack.xml"/>
                         </Children>
                     </WidgetGroup>
-                    <WidgetGroup trigger="[Samplers],show_samplers_tab_small" persist="true">
+                    <WidgetGroup trigger="[Samplers],show_samplers" persist="true">
                         <Layout>vertical</Layout>
                         <Children>
                             <Template src="skin:sampler_decks.xml"/>
-                        </Children>
-                    </WidgetGroup>
-                    <WidgetGroup trigger="[MicrophoneRack],show_mics_tab_small" persist="true">
-                        <Layout>vertical</Layout>
-                        <Children>
-                            <Template src="skin:microphone_rack.xml"/>
                         </Children>
                     </WidgetGroup>
                 </Children>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -45,18 +45,13 @@
       <attribute persist="true" config_key="[Spinny4],show_spinny">1</attribute>
       <attribute persist="true" config_key="[Microphone],show_microphone">0</attribute>
       <attribute persist="true" config_key="[MicrophoneRack],show">0</attribute>
-      <attribute persist="true" config_key="[MicrophoneRack],show_microphones_tab">0</attribute>
-      <attribute persist="true" config_key="[MicrophoneRack],show_mics_tab_small">0</attribute>
       <attribute persist="true" config_key="[EffectRack1],show">0</attribute>
-      <attribute persist="true" config_key="[EffectRack1],show_tab">0</attribute>
-      <attribute persist="true" config_key="[EffectRack1],show_tab_small">0</attribute>
       <attribute persist="true" config_key="[Samplers],show_samplers">0</attribute>
-      <attribute persist="true" config_key="[Samplers],show_samplers_tab">0</attribute>
-      <attribute persist="true" config_key="[Samplers],show_samplers_tab_small">0</attribute>
       <attribute persist="true" config_key="[Vinylcontrol],show_vinylcontrol">0</attribute>
       <attribute persist="true" config_key="[PreviewDeck],show_previewdeck">0</attribute>
       <attribute persist="true" config_key="[Master],show_mixer">1</attribute>
       <attribute persist="true" config_key="[Master],show_mics">0</attribute>
+      <attribute persist="true" config_key="[Master],view_curpage">2</attribute>
       <attribute persist="true" config_key="[Library],show_coverart">1</attribute>
       <attribute config_key="[Library],show_library">1</attribute>
       <attribute persist="true" config_key="[Library],show_current">1</attribute>

--- a/res/skins/LateNight/toolbar_full.xml
+++ b/res/skins/LateNight/toolbar_full.xml
@@ -38,6 +38,33 @@
                 <SizePolicy>min,min</SizePolicy>
                 <Children>
                     <PushButton>
+                        <Size>85f,20f</Size>
+                        <ObjectName>GuiToggleButton</ObjectName>
+                        <NumberStates>2</NumberStates>
+                        <State>
+                          <Number>0</Number>
+                          <Text>MICROPHONES</Text>
+                        </State>
+                        <State>
+                          <Number>1</Number>
+                          <Text>MICROPHONES</Text>
+                        </State>
+                        <Connection>
+                          <ConfigKey persist="true">[MicrophoneRack],show</ConfigKey>
+                          <ButtonState>LeftButton</ButtonState>
+                        </Connection>
+                        <Connection>
+                          <ConfigKey persist="true">[MicrophoneRack],show</ConfigKey>
+                        </Connection>
+                    </PushButton>
+                </Children>
+            </WidgetGroup>
+            <WidgetGroup>
+                <ObjectName>GuiToggleContainer</ObjectName>
+                <Layout>vertical</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                    <PushButton>
                         <Size>55f,20f</Size>
                         <TooltipId>show_effects</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
@@ -84,34 +111,6 @@
                         </Connection>
                         <Connection>
                           <ConfigKey persist="true">[Samplers],show_samplers</ConfigKey>
-                        </Connection>
-                    </PushButton>
-                </Children>
-            </WidgetGroup>
-            <WidgetGroup>
-                <ObjectName>GuiToggleContainer</ObjectName>
-                <Layout>vertical</Layout>
-                <SizePolicy>min,min</SizePolicy>
-                <Children>
-                    <PushButton>
-                        <Size>85f,20f</Size>
-                        <TooltipId>show_samplers</TooltipId>
-                        <ObjectName>GuiToggleButton</ObjectName>
-                        <NumberStates>2</NumberStates>
-                        <State>
-                          <Number>0</Number>
-                          <Text>MICROPHONES</Text>
-                        </State>
-                        <State>
-                          <Number>1</Number>
-                          <Text>MICROPHONES</Text>
-                        </State>
-                        <Connection>
-                          <ConfigKey persist="true">[MicrophoneRack],show</ConfigKey>
-                          <ButtonState>LeftButton</ButtonState>
-                        </Connection>
-                        <Connection>
-                          <ConfigKey persist="true">[MicrophoneRack],show</ConfigKey>
                         </Connection>
                     </PushButton>
                 </Children>

--- a/res/skins/LateNight/toolbar_med.xml
+++ b/res/skins/LateNight/toolbar_med.xml
@@ -38,6 +38,33 @@
                 <SizePolicy>min,min</SizePolicy>
                 <Children>
                     <PushButton>
+                        <Size>85f,20f</Size>
+                        <ObjectName>GuiToggleButton</ObjectName>
+                        <NumberStates>2</NumberStates>
+                        <State>
+                          <Number>0</Number>
+                          <Text>MICROPHONES</Text>
+                        </State>
+                        <State>
+                          <Number>1</Number>
+                          <Text>MICROPHONES</Text>
+                        </State>
+                        <Connection>
+                          <ConfigKey persist="true">[MicrophoneRack],show</ConfigKey>
+                          <ButtonState>LeftButton</ButtonState>
+                        </Connection>
+                        <Connection>
+                          <ConfigKey persist="true">[MicrophoneRack],show</ConfigKey>
+                        </Connection>
+                    </PushButton>
+                </Children>
+            </WidgetGroup>
+            <WidgetGroup>
+                <ObjectName>GuiToggleContainer</ObjectName>
+                <Layout>vertical</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                    <PushButton>
                         <Size>55f,20f</Size>
                         <TooltipId>show_effects</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
@@ -51,11 +78,11 @@
                           <Text>EFFECTS</Text>
                         </State>
                         <Connection>
-                          <ConfigKey persist="true">[EffectRack1],show_tab</ConfigKey>
+                          <ConfigKey persist="true">[EffectRack1],show</ConfigKey>
                           <ButtonState>LeftButton</ButtonState>
                         </Connection>
                         <Connection>
-                          <ConfigKey persist="true">[EffectRack1],show_tab</ConfigKey>
+                          <ConfigKey persist="true">[EffectRack1],show</ConfigKey>
                         </Connection>
                     </PushButton>
                 </Children>
@@ -79,38 +106,11 @@
                           <Text>SAMPLERS</Text>
                         </State>
                         <Connection>
-                          <ConfigKey persist="true">[Samplers],show_samplers_tab</ConfigKey>
+                          <ConfigKey persist="true">[Samplers],show_samplers</ConfigKey>
                           <ButtonState>LeftButton</ButtonState>
                         </Connection>
                         <Connection>
-                          <ConfigKey persist="true">[Samplers],show_samplers_tab</ConfigKey>
-                        </Connection>
-                    </PushButton>
-                </Children>
-            </WidgetGroup>
-            <WidgetGroup>
-                <ObjectName>GuiToggleContainer</ObjectName>
-                <Layout>vertical</Layout>
-                <SizePolicy>min,min</SizePolicy>
-                <Children>
-                    <PushButton>
-                        <Size>85f,20f</Size>
-                        <ObjectName>GuiToggleButton</ObjectName>
-                        <NumberStates>2</NumberStates>
-                        <State>
-                          <Number>0</Number>
-                          <Text>MICROPHONES</Text>
-                        </State>
-                        <State>
-                          <Number>1</Number>
-                          <Text>MICROPHONES</Text>
-                        </State>
-                        <Connection>
-                          <ConfigKey persist="true">[MicrophoneRack],show_microphones_tab</ConfigKey>
-                          <ButtonState>LeftButton</ButtonState>
-                        </Connection>
-                        <Connection>
-                          <ConfigKey persist="true">[MicrophoneRack],show_microphones_tab</ConfigKey>
+                          <ConfigKey persist="true">[Samplers],show_samplers</ConfigKey>
                         </Connection>
                     </PushButton>
                 </Children>

--- a/res/skins/LateNight/toolbar_small.xml
+++ b/res/skins/LateNight/toolbar_small.xml
@@ -42,6 +42,33 @@
                 <SizePolicy>min,min</SizePolicy>
                 <Children>
                     <PushButton>
+                        <Size>85f,20f</Size>
+                        <ObjectName>GuiToggleButton</ObjectName>
+                        <NumberStates>2</NumberStates>
+                        <State>
+                          <Number>0</Number>
+                          <Text>MICROPHONES</Text>
+                        </State>
+                        <State>
+                          <Number>1</Number>
+                          <Text>MICROPHONES</Text>
+                        </State>
+                        <Connection>
+                          <ConfigKey persist="true">[MicrophoneRack],show</ConfigKey>
+                          <ButtonState>LeftButton</ButtonState>
+                        </Connection>
+                        <Connection>
+                          <ConfigKey persist="true">[MicrophoneRack],show</ConfigKey>
+                        </Connection>
+                    </PushButton>
+                </Children>
+            </WidgetGroup>
+            <WidgetGroup>
+                <ObjectName>GuiToggleContainer</ObjectName>
+                <Layout>vertical</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                    <PushButton>
                         <Size>55f,20f</Size>
                         <TooltipId>show_effects</TooltipId>
                         <ObjectName>GuiToggleButton</ObjectName>
@@ -55,11 +82,11 @@
                           <Text>EFFECTS</Text>
                         </State>
                         <Connection>
-                          <ConfigKey persist="true">[EffectRack1],show_tab_small</ConfigKey>
+                          <ConfigKey persist="true">[EffectRack1],show</ConfigKey>
                           <ButtonState>LeftButton</ButtonState>
                         </Connection>
                         <Connection>
-                          <ConfigKey persist="true">[EffectRack1],show_tab_small</ConfigKey>
+                          <ConfigKey persist="true">[EffectRack1],show</ConfigKey>
                         </Connection>
                     </PushButton>
                 </Children>
@@ -83,38 +110,11 @@
                           <Text>SAMPLERS</Text>
                         </State>
                         <Connection>
-                          <ConfigKey persist="true">[Samplers],show_samplers_tab_small</ConfigKey>
+                          <ConfigKey persist="true">[Samplers],show_samplers</ConfigKey>
                           <ButtonState>LeftButton</ButtonState>
                         </Connection>
                         <Connection>
-                          <ConfigKey persist="true">[Samplers],show_samplers_tab_small</ConfigKey>
-                        </Connection>
-                    </PushButton>
-                </Children>
-            </WidgetGroup>
-            <WidgetGroup>
-                <ObjectName>GuiToggleContainer</ObjectName>
-                <Layout>vertical</Layout>
-                <SizePolicy>min,min</SizePolicy>
-                <Children>
-                    <PushButton>
-                        <Size>85f,20f</Size>
-                        <ObjectName>GuiToggleButton</ObjectName>
-                        <NumberStates>2</NumberStates>
-                        <State>
-                          <Number>0</Number>
-                          <Text>MICROPHONES</Text>
-                        </State>
-                        <State>
-                          <Number>1</Number>
-                          <Text>MICROPHONES</Text>
-                        </State>
-                        <Connection>
-                          <ConfigKey persist="true">[MicrophoneRack],show_mics_tab_small</ConfigKey>
-                          <ButtonState>LeftButton</ButtonState>
-                        </Connection>
-                        <Connection>
-                          <ConfigKey persist="true">[MicrophoneRack],show_mics_tab_small</ConfigKey>
+                          <ConfigKey persist="true">[Samplers],show_samplers</ConfigKey>
                         </Connection>
                     </PushButton>
                 </Children>

--- a/src/test/wwidgetstack_test.cpp
+++ b/src/test/wwidgetstack_test.cpp
@@ -1,0 +1,152 @@
+// A series of unit tests for the widget stack, which has lots of different
+// ways to control its state.
+#include "widget/wwidgetstack.h"
+
+#include <gtest/gtest.h>
+#include <QScopedPointer>
+
+#include "mixxxtest.h"
+#include "controlobject.h"
+#include "controlpushbutton.h"
+#include "controlobjectslave.h"
+
+class WWidgetStackTest : public MixxxTest {
+  public:
+    WWidgetStackTest()
+          : m_pGroup("[Channel1]") {
+    }
+
+  protected:
+    virtual void SetUp() {
+        // Create a widget stack with three pages, and *before* the pages
+        // are added, set the current page control to the second page.
+        m_pPrevControl.reset(
+                new ControlPushButton(ConfigKey(m_pGroup, "prev")));
+        m_pNextControl.reset(
+                new ControlPushButton(ConfigKey(m_pGroup, "next")));
+        m_pCurPageControl.reset(
+                new ControlObject(ConfigKey(m_pGroup, "page")));
+        m_pStack.reset(new WWidgetStack(NULL, m_pNextControl.data(),
+                                        m_pPrevControl.data(),
+                                        m_pCurPageControl.data()));
+
+        // 0-based index
+        m_pCurPageControl->set(1);
+
+        m_pPage0Widget.reset(new QWidget());
+        m_pPage0Control.reset(new ControlObject(ConfigKey(m_pGroup, "page0")));
+        m_pPage1Widget.reset(new QWidget());
+        m_pPage1Control.reset(new ControlObject(ConfigKey(m_pGroup, "page1")));
+        m_pPage2Widget.reset(new QWidget());
+        m_pPage2Control.reset(new ControlObject(ConfigKey(m_pGroup, "page2")));
+
+        m_pStack->addWidgetWithControl(m_pPage0Widget.data(),
+                                       m_pPage0Control.data(),
+                                       2);
+        m_pStack->addWidgetWithControl(m_pPage1Widget.data(),
+                                       m_pPage1Control.data(),
+                                       -1);
+        m_pStack->addWidgetWithControl(m_pPage2Widget.data(),
+                                       m_pPage2Control.data(),
+                                       -1);
+        m_pStack->Init();
+    }
+
+    void ExpectPageSelected(int index) {
+        EXPECT_EQ(index, m_pCurPageControl->get());
+        EXPECT_EQ(index == 0 ? 1 : 0, m_pPage0Control->get());
+        EXPECT_EQ(index == 1 ? 1 : 0, m_pPage1Control->get());
+        EXPECT_EQ(index == 2 ? 1 : 0, m_pPage2Control->get());
+        switch (index) {
+        case 0:
+            EXPECT_FALSE(m_pPage0Widget->isHidden());
+            EXPECT_TRUE(m_pPage1Widget->isHidden());
+            EXPECT_TRUE(m_pPage2Widget->isHidden());
+            break;
+        case 1:
+            EXPECT_TRUE(m_pPage0Widget->isHidden());
+            EXPECT_FALSE(m_pPage1Widget->isHidden());
+            EXPECT_TRUE(m_pPage2Widget->isHidden());
+            break;
+        case 2:
+            EXPECT_TRUE(m_pPage0Widget->isHidden());
+            EXPECT_TRUE(m_pPage1Widget->isHidden());
+            EXPECT_FALSE(m_pPage2Widget->isHidden());
+            break;
+        }
+    }
+
+    QScopedPointer<WWidgetStack> m_pStack;
+    QScopedPointer<ControlObject> m_pPrevControl;
+    QScopedPointer<ControlObject> m_pNextControl;
+    QScopedPointer<ControlObject> m_pCurPageControl;
+    QScopedPointer<QWidget> m_pPage0Widget;
+    QScopedPointer<QWidget> m_pPage1Widget;
+    QScopedPointer<QWidget> m_pPage2Widget;
+    QScopedPointer<ControlObject> m_pPage0Control;
+    QScopedPointer<ControlObject> m_pPage1Control;
+    QScopedPointer<ControlObject> m_pPage2Control;
+    const char* m_pGroup;
+};
+
+TEST_F(WWidgetStackTest, MaintainPageSelected) {
+    // As a widget stack is created, if the current page control object
+    // is already set, that setting should remain the same and the final stack
+    // should be consistent.  Since we set the control in SetUp, that part
+    // is already done.  We just need to test the current state.
+    ExpectPageSelected(1);
+}
+
+TEST_F(WWidgetStackTest, ChangePageSelection) {
+    // Changing the page via the current page control should work.
+    m_pCurPageControl->set(2);
+    ExpectPageSelected(2);
+    m_pCurPageControl->set(0);
+    ExpectPageSelected(0);
+}
+
+TEST_F(WWidgetStackTest, ChangeChildControls) {
+    // Changing the page via the individual page controls should work.
+    m_pPage0Control->set(1);
+    ExpectPageSelected(0);
+    m_pPage2Control->set(1);
+    ExpectPageSelected(2);
+}
+
+TEST_F(WWidgetStackTest, OnHideBehavior) {
+    // When hiding a page, if the on_hide_select value is -1, the next
+    // page is selected.  Otherwise, the page given by on_hide_select is
+    // selected.  The on-hide values are set in SetUp.
+    m_pPage1Control->set(0);
+    ExpectPageSelected(2);
+
+    m_pPage2Control->set(0);
+    ExpectPageSelected(0);
+
+    m_pPage0Control->set(0);
+    ExpectPageSelected(2);
+}
+
+TEST_F(WWidgetStackTest, NextPrevControls) {
+    // The next / prev controls should work, and wrap around.
+    m_pNextControl->set(1);
+    m_pNextControl->set(0);
+    ExpectPageSelected(2);
+
+    m_pNextControl->set(1);
+    m_pNextControl->set(0);
+    ExpectPageSelected(0);
+
+    m_pNextControl->set(1);
+    m_pNextControl->set(0);
+    ExpectPageSelected(1);
+
+    m_pPrevControl->set(1);
+    m_pPrevControl->set(0);
+    ExpectPageSelected(0);
+
+    m_pPrevControl->set(1);
+    m_pPrevControl->set(0);
+    ExpectPageSelected(2);
+}
+

--- a/src/test/wwidgetstack_test.cpp
+++ b/src/test/wwidgetstack_test.cpp
@@ -97,6 +97,34 @@ TEST_F(WWidgetStackTest, MaintainPageSelected) {
     ExpectPageSelected(1);
 }
 
+TEST_F(WWidgetStackTest, MaintainPageControlValue) {
+    // The current page control overrides whatever values the individual
+    // page triggers may already have.  This is what caused the bug with the
+    // LateNight skin -- The page trigger was set to off, but the current page
+    // control was defaulted to 0, so that overrode the page trigger and
+    // showed the first page.
+    m_pCurPageControl.reset(
+            new ControlObject(ConfigKey(m_pGroup,
+                                        "MaintainPageControlValue-page")));
+    QScopedPointer<WWidgetStack> stack(
+            new WWidgetStack(NULL, m_pNextControl.data(),
+                             m_pPrevControl.data(),
+                             m_pCurPageControl.data()));
+
+    QWidget page0;
+    QWidget page1;
+
+    // We don't set the current page control.  All we know is that page0
+    // is supposed to be off.
+    m_pPage0Control->set(0);
+
+    stack->addWidgetWithControl(&page0, m_pPage0Control.data(), -1);
+    stack->addWidgetWithControl(&page1, NULL, -1);
+    stack->Init();
+
+    ExpectPageSelected(0);
+}
+
 TEST_F(WWidgetStackTest, ChangePageSelection) {
     // Changing the page via the current page control should work.
     m_pCurPageControl->set(2);

--- a/src/test/wwidgetstack_test.cpp
+++ b/src/test/wwidgetstack_test.cpp
@@ -50,6 +50,7 @@ class WWidgetStackTest : public MixxxTest {
                                        m_pPage2Control.data(),
                                        -1);
         m_pStack->Init();
+        m_pStack->show();
     }
 
     void ExpectPageSelected(int index) {
@@ -179,6 +180,28 @@ TEST_F(WWidgetStackTest, NextPrevControls) {
 
     m_pPrevControl->set(1);
     m_pPrevControl->set(0);
+    ExpectPageSelected(2);
+}
+
+TEST_F(WWidgetStackTest, HiddenStackNoChanges) {
+    // When the widgetstack is hidden, it does not respond to outside changes.
+    // This helps LateNight use the same triggers in multiple views.
+    ExpectPageSelected(1);
+    m_pStack->hide();
+    m_pPage2Control->set(1);
+
+    EXPECT_EQ(1, m_pCurPageControl->get());
+    EXPECT_EQ(0, m_pPage0Control->get());
+    EXPECT_EQ(1, m_pPage1Control->get());
+    EXPECT_EQ(1, m_pPage2Control->get());
+    EXPECT_TRUE(m_pPage0Widget->isHidden());
+    EXPECT_FALSE(m_pPage1Widget->isHidden());
+    EXPECT_TRUE(m_pPage2Widget->isHidden());
+
+    // As soon as we show, the states return to being consistent, based on
+    // whatever the current page control is set to.
+    m_pCurPageControl->set(2);
+    m_pStack->show();
     ExpectPageSelected(2);
 }
 

--- a/src/test/wwidgetstack_test.cpp
+++ b/src/test/wwidgetstack_test.cpp
@@ -150,12 +150,17 @@ TEST_F(WWidgetStackTest, OnHideBehavior) {
     // When hiding a page, if the on_hide_select value is -1, the next
     // page is selected.  Otherwise, the page given by on_hide_select is
     // selected.  The on-hide values are set in SetUp.
+
+    // When the second page is hidden, show the third.
     m_pPage1Control->set(0);
     ExpectPageSelected(2);
 
+    // When the last page is hidden, show the first.
     m_pPage2Control->set(0);
     ExpectPageSelected(0);
 
+    // The first page has an override, so when it is hidden the third
+    // is shown instead of the second.
     m_pPage0Control->set(0);
     ExpectPageSelected(2);
 }

--- a/src/test/wwidgetstack_test.cpp
+++ b/src/test/wwidgetstack_test.cpp
@@ -103,6 +103,8 @@ TEST_F(WWidgetStackTest, MaintainPageControlValue) {
     // LateNight skin -- The page trigger was set to off, but the current page
     // control was defaulted to 0, so that overrode the page trigger and
     // showed the first page.
+
+    // This test is set up to reproduce the original LateNight skin case.
     m_pCurPageControl.reset(
             new ControlObject(ConfigKey(m_pGroup,
                                         "MaintainPageControlValue-page")));
@@ -122,6 +124,8 @@ TEST_F(WWidgetStackTest, MaintainPageControlValue) {
     stack->addWidgetWithControl(&page1, NULL, -1);
     stack->Init();
 
+    // The off state above is overridden by the default value of curpagecontrol,
+    // which is set to 0 on creation.
     ExpectPageSelected(0);
 }
 

--- a/src/widget/wwidgetstack.cpp
+++ b/src/widget/wwidgetstack.cpp
@@ -131,6 +131,8 @@ void WWidgetStack::addWidgetWithControl(QWidget* pWidget, ControlObject* pContro
     }
 
     if (m_currentPageControl.get() == index) {
+        // The value in the curren page control overrides whatever initial
+        // values the individual page triggers may have.
         setCurrentIndex(index);
     }
     if (on_hide_select != -1) {

--- a/src/widget/wwidgetstack.cpp
+++ b/src/widget/wwidgetstack.cpp
@@ -42,7 +42,7 @@ WWidgetStack::WWidgetStack(QWidget* pParent,
           m_currentPageControl(
                   pCurrentPageControl ?
                   pCurrentPageControl->getKey() : ConfigKey()),
-          m_bRespondToChanges(true) {
+          m_bRespondToChanges(false) {
     connect(&m_nextControl, SIGNAL(valueChanged(double)),
             this, SLOT(onNextControlChanged(double)));
     connect(&m_prevControl, SIGNAL(valueChanged(double)),

--- a/src/widget/wwidgetstack.cpp
+++ b/src/widget/wwidgetstack.cpp
@@ -91,6 +91,9 @@ void WWidgetStack::hideIndex(int index) {
         if (it != m_hideMap.end()) {
             setCurrentIndex(*it);
         } else {
+            // TODO: This default behavior is a little odd, is it really what
+            // we want?  Or should we save the previously-selected page and then
+            // switch to that.
             setCurrentIndex((index + 1) % count());
         }
     }

--- a/src/widget/wwidgetstack.h
+++ b/src/widget/wwidgetstack.h
@@ -17,6 +17,9 @@ class WidgetStackControlListener : public QObject {
     WidgetStackControlListener(QObject* pParent, ControlObject* pControl,
                                int index);
     virtual ~WidgetStackControlListener();
+    void setControl(double val) {
+        m_control.set(val);
+    }
 
   signals:
     void switchToWidget();
@@ -72,7 +75,6 @@ class WWidgetStack : public QStackedWidget, public WBaseWidget {
     void showIndex(int index);
     void hideIndex(int index);
     void showEvent(QShowEvent* event);
-    void hideEvent(QHideEvent* event);
 
   private:
     QSignalMapper m_showMapper;
@@ -85,8 +87,7 @@ class WWidgetStack : public QStackedWidget, public WBaseWidget {
     // signal.
     QMap<int, int> m_hideMap;
     // A map of the individual page triggers so we can rectify state if needed.
-    QMap<int, ControlObject*> m_triggers;
-    bool m_bRespondToChanges;
+    QMap<int, WidgetStackControlListener*> m_listeners;
 };
 
 #endif /* WWIDGETSTACK_H */

--- a/src/widget/wwidgetstack.h
+++ b/src/widget/wwidgetstack.h
@@ -72,6 +72,7 @@ class WWidgetStack : public QStackedWidget, public WBaseWidget {
     void showIndex(int index);
     void hideIndex(int index);
     void showEvent(QShowEvent* event);
+    void hideEvent(QHideEvent* event);
 
   private:
     QSignalMapper m_showMapper;
@@ -85,6 +86,7 @@ class WWidgetStack : public QStackedWidget, public WBaseWidget {
     QMap<int, int> m_hideMap;
     // A map of the individual page triggers so we can rectify state if needed.
     QMap<int, ControlObject*> m_triggers;
+    bool m_bRespondToChanges;
 };
 
 #endif /* WWIDGETSTACK_H */

--- a/src/widget/wwidgetstack.h
+++ b/src/widget/wwidgetstack.h
@@ -69,7 +69,9 @@ class WWidgetStack : public QStackedWidget, public WBaseWidget {
     void onCurrentPageControlChanged(double v);
     // Fired when we change pages.
     void onCurrentPageChanged(int);
+    void showIndex(int index);
     void hideIndex(int index);
+    void showEvent(QShowEvent* event);
 
   private:
     QSignalMapper m_showMapper;
@@ -81,6 +83,8 @@ class WWidgetStack : public QStackedWidget, public WBaseWidget {
     // Optional map that defines which page to select if a page gets a hide
     // signal.
     QMap<int, int> m_hideMap;
+    // A map of the individual page triggers so we can rectify state if needed.
+    QMap<int, ControlObject*> m_triggers;
 };
 
 #endif /* WWIDGETSTACK_H */


### PR DESCRIPTION
This is regarding this bug: https://bugs.launchpad.net/mixxx/+bug/1451187

On first launch, if the user deselects "mixer", all of the sampler / mic / effect racks shouldn't suddenly appear.  

This PR doesn't solve the larger problem of the panels being inconsistent between sizeaware sizes, but it at least establishes that all the panels start off.

I think it works ok but I'd like others to test it to make sure I didn't break anything else.
