### PR TITLE
Fix tree selection during playlist interaction

### DIFF
--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -124,8 +124,23 @@ void BasePlaylistFeature::activateChild(const QModelIndex& index) {
     int playlistId = playlistIdFromIndex(index);
     if (playlistId != -1 && m_pPlaylistTableModel) {
         m_pPlaylistTableModel->setTableModel(playlistId);
+        // Update selection
+        emit(featureSelect(this, index));
         emit(showTrackModel(m_pPlaylistTableModel));
         emit(enableCoverArtDisplay(true));
+    }
+}
+
+void BasePlaylistFeature::activatePlaylist(int playlistId) {
+    //qDebug() << "BasePlaylistFeature::activatePlaylist()" << playlistId;
+    QModelIndex index = indexFromPlaylistId(playlistId);
+    if (playlistId != -1 && index != QModelIndex() && m_pPlaylistTableModel) {
+        m_pPlaylistTableModel->setTableModel(playlistId);
+        emit(showTrackModel(m_pPlaylistTableModel));
+        emit(enableCoverArtDisplay(true));
+        // Update selection
+        emit(featureSelect(this, m_lastRightClickedIndex));
+        activateChild(m_lastRightClickedIndex);
     }
 }
 
@@ -223,7 +238,7 @@ void BasePlaylistFeature::slotDuplicatePlaylist() {
 
     if (newPlaylistId != -1 &&
         m_playlistDao.copyPlaylistTracks(oldPlaylistId, newPlaylistId)) {
-        emit(showTrackModel(m_pPlaylistTableModel));
+        activatePlaylist(newPlaylistId);
     }
 }
 
@@ -276,7 +291,7 @@ void BasePlaylistFeature::slotCreatePlaylist() {
     int playlistId = m_playlistDao.createPlaylist(name);
 
     if (playlistId != -1) {
-        emit(showTrackModel(m_pPlaylistTableModel));
+        activatePlaylist(playlistId);
     } else {
         QMessageBox::warning(NULL,
                              tr("Playlist Creation Failed"),
@@ -310,7 +325,7 @@ void BasePlaylistFeature::slotDeletePlaylist() {
 
 
 void BasePlaylistFeature::slotImportPlaylist() {
-    qDebug() << "slotImportPlaylist() row:" ; //<< m_lastRightClickedIndex.data();
+    //qDebug() << "slotImportPlaylist() row:" << m_lastRightClickedIndex.data();
 
     if (!m_pPlaylistTableModel) {
         return;
@@ -358,6 +373,7 @@ void BasePlaylistFeature::slotImportPlaylist() {
 
       // Iterate over the List that holds URLs of playlist entires
       m_pPlaylistTableModel->addTracks(QModelIndex(), entries);
+      activateChild(m_lastRightClickedIndex);
 
       // delete the parser object
       delete playlist_parser;
@@ -559,4 +575,18 @@ QModelIndex BasePlaylistFeature::constructChildModel(int selected_id) {
   */
 void BasePlaylistFeature::clearChildModel() {
     m_childModel.removeRows(0, m_playlistList.size());
+}
+
+QModelIndex BasePlaylistFeature::indexFromPlaylistId(int playlistId) {
+    int row = 0;
+    for (QList<QPair<int, QString> >::const_iterator it = m_playlistList.begin();
+         it != m_playlistList.end(); ++it, ++row) {
+        int current_id = it->first;
+        QString playlist_name = it->second;
+
+        if (playlistId == current_id) {
+            return m_childModel.index(row, 0);
+        }
+    }
+    return QModelIndex();
 }

--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -134,7 +134,7 @@ void BasePlaylistFeature::activateChild(const QModelIndex& index) {
 void BasePlaylistFeature::activatePlaylist(int playlistId) {
     //qDebug() << "BasePlaylistFeature::activatePlaylist()" << playlistId;
     QModelIndex index = indexFromPlaylistId(playlistId);
-    if (playlistId != -1 && index != QModelIndex() && m_pPlaylistTableModel) {
+    if (playlistId != -1 && index.isValid() && m_pPlaylistTableModel) {
         m_pPlaylistTableModel->setTableModel(playlistId);
         emit(showTrackModel(m_pPlaylistTableModel));
         emit(enableCoverArtDisplay(true));
@@ -188,11 +188,6 @@ void BasePlaylistFeature::slotRenamePlaylist() {
     }
 
     m_playlistDao.renamePlaylist(playlistId, newName);
-}
-
-void BasePlaylistFeature::slotPlaylistTableRenamed(int playlistId,
-                                                   QString /* a_strName */) {
-    slotPlaylistTableChanged(playlistId);
 }
 
 void BasePlaylistFeature::slotDuplicatePlaylist() {

--- a/src/library/baseplaylistfeature.h
+++ b/src/library/baseplaylistfeature.h
@@ -45,7 +45,7 @@ class BasePlaylistFeature : public LibraryFeature {
     virtual void htmlLinkClicked(const QUrl& link);
 
     virtual void slotPlaylistTableChanged(int playlistId) = 0;
-    virtual void slotPlaylistTableRenamed(int playlistId, QString a_strName);
+    virtual void slotPlaylistTableRenamed(int playlistId, QString a_strName) = 0;
     void slotCreatePlaylist();
 
   protected slots:

--- a/src/library/baseplaylistfeature.h
+++ b/src/library/baseplaylistfeature.h
@@ -41,10 +41,11 @@ class BasePlaylistFeature : public LibraryFeature {
   public slots:
     virtual void activate();
     virtual void activateChild(const QModelIndex& index);
+    virtual void activatePlaylist(int playlistId);
     virtual void htmlLinkClicked(const QUrl& link);
 
     virtual void slotPlaylistTableChanged(int playlistId) = 0;
-    void slotPlaylistTableRenamed(int playlistId, QString a_strName);
+    virtual void slotPlaylistTableRenamed(int playlistId, QString a_strName);
     void slotCreatePlaylist();
 
   protected slots:
@@ -66,6 +67,9 @@ class BasePlaylistFeature : public LibraryFeature {
     virtual void addToAutoDJ(bool bTop);
 
     int playlistIdFromIndex(QModelIndex index);
+    // Get the QModelIndex of a playlist based on its id.  Returns QModelIndex()
+    // on failure.
+    QModelIndex indexFromPlaylistId(int playlistId);
 
     ConfigObject<ConfigValue>* m_pConfig;
     TrackCollection* m_pTrackCollection;

--- a/src/library/playlistfeature.cpp
+++ b/src/library/playlistfeature.cpp
@@ -189,15 +189,31 @@ void PlaylistFeature::slotPlaylistTableChanged(int playlistId) {
     enum PlaylistDAO::HiddenType type = m_playlistDao.getHiddenType(playlistId);
     if (type == PlaylistDAO::PLHT_NOT_HIDDEN ||
         type == PlaylistDAO::PLHT_UNKNOWN) { // In case of a deleted Playlist
+        // TODO: Is this even necessary?
         clearChildModel();
         m_lastRightClickedIndex = constructChildModel(playlistId);
+    }
+}
 
+void PlaylistFeature::slotPlaylistTableRenamed(int playlistId,
+                                               QString /* a_strName */) {
+    if (!m_pPlaylistTableModel) {
+        return;
+    }
+
+    //qDebug() << "slotPlaylistTableChanged() playlistId:" << playlistId;
+    enum PlaylistDAO::HiddenType type = m_playlistDao.getHiddenType(playlistId);
+    if (type == PlaylistDAO::PLHT_NOT_HIDDEN ||
+        type == PlaylistDAO::PLHT_UNKNOWN) { // In case of a deleted Playlist
+        clearChildModel();
+        m_lastRightClickedIndex = constructChildModel(playlistId);
         if (type != PlaylistDAO::PLHT_UNKNOWN) {
             // Switch the view to the playlist.
             m_pPlaylistTableModel->setTableModel(playlistId);
             // Update selection
             emit(featureSelect(this, m_lastRightClickedIndex));
-            activateChild(m_lastRightClickedIndex);
+            emit(showTrackModel(m_pPlaylistTableModel));
+            emit(enableCoverArtDisplay(true));
         }
     }
 }

--- a/src/library/playlistfeature.cpp
+++ b/src/library/playlistfeature.cpp
@@ -189,7 +189,6 @@ void PlaylistFeature::slotPlaylistTableChanged(int playlistId) {
     enum PlaylistDAO::HiddenType type = m_playlistDao.getHiddenType(playlistId);
     if (type == PlaylistDAO::PLHT_NOT_HIDDEN ||
         type == PlaylistDAO::PLHT_UNKNOWN) { // In case of a deleted Playlist
-        // TODO: Is this even necessary?
         clearChildModel();
         m_lastRightClickedIndex = constructChildModel(playlistId);
     }
@@ -208,12 +207,7 @@ void PlaylistFeature::slotPlaylistTableRenamed(int playlistId,
         clearChildModel();
         m_lastRightClickedIndex = constructChildModel(playlistId);
         if (type != PlaylistDAO::PLHT_UNKNOWN) {
-            // Switch the view to the playlist.
-            m_pPlaylistTableModel->setTableModel(playlistId);
-            // Update selection
-            emit(featureSelect(this, m_lastRightClickedIndex));
-            emit(showTrackModel(m_pPlaylistTableModel));
-            emit(enableCoverArtDisplay(true));
+            activatePlaylist(playlistId);
         }
     }
 }

--- a/src/library/playlistfeature.h
+++ b/src/library/playlistfeature.h
@@ -36,6 +36,7 @@ class PlaylistFeature : public BasePlaylistFeature {
 
   private slots:
     void slotPlaylistTableChanged(int playlistId);
+    void slotPlaylistTableRenamed(int playlistId, QString a_strName);
 
  protected:
     void buildPlaylistList();

--- a/src/library/setlogfeature.cpp
+++ b/src/library/setlogfeature.cpp
@@ -301,12 +301,7 @@ void SetlogFeature::slotPlaylistTableRenamed(int playlistId,
         clearChildModel();
         m_lastRightClickedIndex = constructChildModel(playlistId);
         if (type != PlaylistDAO::PLHT_UNKNOWN) {
-            // Switch the view to the playlist.
-            m_pPlaylistTableModel->setTableModel(playlistId);
-            // Update selection
-            emit(featureSelect(this, m_lastRightClickedIndex));
-            emit(showTrackModel(m_pPlaylistTableModel));
-            emit(enableCoverArtDisplay(true));
+            activatePlaylist(playlistId);
         }
     }
 }

--- a/src/library/setlogfeature.cpp
+++ b/src/library/setlogfeature.cpp
@@ -288,6 +288,28 @@ void SetlogFeature::slotPlaylistTableChanged(int playlistId) {
     }
 }
 
+void SetlogFeature::slotPlaylistTableRenamed(int playlistId,
+                                             QString /* a_strName */) {
+    if (!m_pPlaylistTableModel) {
+        return;
+    }
+
+    //qDebug() << "slotPlaylistTableChanged() playlistId:" << playlistId;
+    enum PlaylistDAO::HiddenType type = m_playlistDao.getHiddenType(playlistId);
+    if (type == PlaylistDAO::PLHT_SET_LOG ||
+        type == PlaylistDAO::PLHT_UNKNOWN) { // In case of a deleted Playlist
+        clearChildModel();
+        m_lastRightClickedIndex = constructChildModel(playlistId);
+        if (type != PlaylistDAO::PLHT_UNKNOWN) {
+            // Switch the view to the playlist.
+            m_pPlaylistTableModel->setTableModel(playlistId);
+            // Update selection
+            emit(featureSelect(this, m_lastRightClickedIndex));
+            emit(showTrackModel(m_pPlaylistTableModel));
+            emit(enableCoverArtDisplay(true));
+        }
+    }
+}
 
 QString SetlogFeature::getRootViewHtml() const {
     QString playlistsTitle = tr("History");

--- a/src/library/setlogfeature.h
+++ b/src/library/setlogfeature.h
@@ -39,6 +39,7 @@ public:
   private slots:
     void slotPlayingTrackChanged(TrackPointer currentPlayingTrack);
     void slotPlaylistTableChanged(int playlistId);
+    void slotPlaylistTableRenamed(int playlistId, QString a_strName);
 
   private:
     QString getRootViewHtml() const;


### PR DESCRIPTION
- adding tracks to a playlist should not switch to that playlist
- renaming a playlist should keep that playlist highlighted
- adding a playlist should select that playlist
- duplicating a playlist should select the new playlist

tested by manually performing playlist functions:
Add, Remove, Rename, Import, Export.  Also did renaming setlog playlists.
Also adding tracks to a playlist.
