### PR TITLE
Changed RateRange to RateRangeDecimal

### DIFF
--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -102,10 +102,10 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
             this, SLOT(slotSetRateRange(int)));
 
     // Set default range as stored in config file
-    if (m_pConfig->getValueString(ConfigKey("[Controls]", "RateRangeDecimal")).length() == 0){
+    if (m_pConfig->getValueString(ConfigKey("[Controls]", "RateRangePercent")).length() == 0){
         //fallback to old [Controls]RateRange
         if (m_pConfig->getValueString(ConfigKey("[Controls]", "RateRange")).length() == 0){
-            m_pConfig->set(ConfigKey("[Controls]", "RateRangeDecimal"),ConfigValue(8));
+            m_pConfig->set(ConfigKey("[Controls]", "RateRangePercent"),ConfigValue(8));
         } else {
             int oldIdx = m_pConfig->getValueString(ConfigKey("[Controls]", "RateRange")).toInt();
             double oldRange = static_cast<double>(oldIdx-1) / 10.0;
@@ -113,8 +113,8 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
                 oldRange = 0.06;
             if (oldIdx == 1)
                 oldRange = 0.08;
-            m_pConfig->set(ConfigKey("[Controls]", "RateRangeDecimal"),ConfigValue((int)(oldRange * 100.)));
-            slotSetRateRangeDecimal(oldRange * 100.);
+            m_pConfig->set(ConfigKey("[Controls]", "RateRangePercent"),ConfigValue((int)(oldRange * 100.)));
+            slotSetRateRangePercent(oldRange * 100.);
         }
     }
 
@@ -460,18 +460,18 @@ void DlgPrefControls::slotSetLocale(int pos) {
 }
 
 void DlgPrefControls::slotSetRateRange(int pos) {
-    slotSetRateRangeDecimal(ComboBoxRateRange->itemData(pos).toInt());
+    slotSetRateRangePercent(ComboBoxRateRange->itemData(pos).toInt());
 }
 
 
-void DlgPrefControls::slotSetRateRangeDecimal (int rate) {
-    double range = rate / 100.;
+void DlgPrefControls::slotSetRateRangePercent (int rateRangePercent) {
+    double rateRange = rateRangePercent / 100.;
 
-    qDebug() << "slotSetRateRange" << range;
+    qDebug() << "slotSetRateRangePercent" << rateRange;
 
     // Set rate range for every group
     foreach (ControlObjectThread* pControl, m_rateRangeControls) {
-        pControl->slotSet(range);
+        pControl->slotSet(rateRange);
     }
 
     // Reset rate for every group
@@ -617,7 +617,7 @@ void DlgPrefControls::slotApply() {
     double deck1RateRange = m_rateRangeControls[0]->get();
     double deck1RateDir = m_rateDirControls[0]->get();
 
-    m_pConfig->set(ConfigKey("[Controls]", "RateRangeDecimal"), ConfigValue((int)(deck1RateRange * 100)));
+    m_pConfig->set(ConfigKey("[Controls]", "RateRangePercent"), ConfigValue((int)(deck1RateRange * 100)));
 
     // Write rate direction to config file
     if (deck1RateDir == 1) {
@@ -693,7 +693,7 @@ void DlgPrefControls::slotNumDecksChanged(double new_count) {
 
     m_iNumConfiguredDecks = numdecks;
     slotSetRateDir(m_pConfig->getValueString(ConfigKey("[Controls]", "RateDir")).toInt());
-    slotSetRateRangeDecimal(m_pConfig->getValueString(ConfigKey("[Controls]", "RateRangeDecimal")).toInt());
+    slotSetRateRangePercent(m_pConfig->getValueString(ConfigKey("[Controls]", "RateRangePercent")).toInt());
 }
 
 void DlgPrefControls::slotNumSamplersChanged(double new_count) {
@@ -719,7 +719,7 @@ void DlgPrefControls::slotNumSamplersChanged(double new_count) {
 
     m_iNumConfiguredSamplers = numsamplers;
     slotSetRateDir(m_pConfig->getValueString(ConfigKey("[Controls]", "RateDir")).toInt());
-    slotSetRateRangeDecimal(m_pConfig->getValueString(ConfigKey("[Controls]", "RateRangeDecimal")).toInt());
+    slotSetRateRangePercent(m_pConfig->getValueString(ConfigKey("[Controls]", "RateRangePercent")).toInt());
 }
 
 void DlgPrefControls::slotUpdateSpeedAutoReset(int i) {

--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -90,14 +90,14 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
             this, SLOT(slotSetRateDir(int)));
 
     ComboBoxRateRange->clear();
-    ComboBoxRateRange->addItem(tr("4% (Denon DN-D4500)"), 4);
-    ComboBoxRateRange->addItem(tr("6% (Pioneer CDJ/DDJ-S1)"), 6);
-    ComboBoxRateRange->addItem(tr("8% (Technics SL-1210, Pioneer DDJ-SX)"), 8);
-    ComboBoxRateRange->addItem(tr("10% (Pioneer CDJ/DDJ-S1, Denon DN-D4500)"), 10);
-    ComboBoxRateRange->addItem(tr("16% (Pioneer CDJ/DDJ-SX/DDJ-S1, Denon DN-D4500)"), 16);
-    ComboBoxRateRange->addItem(tr("24% (Denon DN-D4500)"), 24);
-    ComboBoxRateRange->addItem(tr("50% (Pioneer DDJ-SX, Denon DN-D4500)"), 50);
-    ComboBoxRateRange->addItem(tr("100% (Denon DN-D4500)"), 100);
+    ComboBoxRateRange->addItem(tr("4%"), 4);
+    ComboBoxRateRange->addItem(tr("6% (Halftone)"), 6);
+    ComboBoxRateRange->addItem(tr("8% (Technics SL-1210)"), 8);
+    ComboBoxRateRange->addItem(tr("10%"), 10);
+    ComboBoxRateRange->addItem(tr("16%"), 16);
+    ComboBoxRateRange->addItem(tr("24%"), 24);
+    ComboBoxRateRange->addItem(tr("50%"), 50);
+    ComboBoxRateRange->addItem(tr("90%"), 90);
     connect(ComboBoxRateRange, SIGNAL(activated(int)),
             this, SLOT(slotSetRateRange(int)));
 

--- a/src/dlgprefcontrols.cpp
+++ b/src/dlgprefcontrols.cpp
@@ -113,8 +113,8 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
                 oldRange = 0.06;
             if (oldIdx == 1)
                 oldRange = 0.08;
-            m_pConfig->set(ConfigKey("[Controls]", "RateRangeDecimal"),ConfigValue((int)(oldRange*100.)));
-            slotSetRateRangeDecimal(oldRange*100.);
+            m_pConfig->set(ConfigKey("[Controls]", "RateRangeDecimal"),ConfigValue((int)(oldRange * 100.)));
+            slotSetRateRangeDecimal(oldRange * 100.);
         }
     }
 
@@ -388,9 +388,9 @@ void DlgPrefControls::slotUpdate() {
     double deck1RateRange = m_rateRangeControls[0]->get();
     double deck1RateDir = m_rateDirControls[0]->get();
 
-    int idx = ComboBoxRateRange->findData((int)(deck1RateRange*100));
+    int idx = ComboBoxRateRange->findData((int)(deck1RateRange * 100));
     if (idx == -1){
-        ComboBoxRateRange->addItem(QString::number(deck1RateRange*100.).append("%"), deck1RateRange*100.);
+        ComboBoxRateRange->addItem(QString::number(deck1RateRange * 100.).append("%"), deck1RateRange * 100.);
     }
 
     ComboBoxRateRange->setCurrentIndex(idx);
@@ -465,7 +465,7 @@ void DlgPrefControls::slotSetRateRange(int pos) {
 
 
 void DlgPrefControls::slotSetRateRangeDecimal (int rate) {
-    double range = rate/100.;
+    double range = rate / 100.;
 
     qDebug() << "slotSetRateRange" << range;
 
@@ -617,7 +617,7 @@ void DlgPrefControls::slotApply() {
     double deck1RateRange = m_rateRangeControls[0]->get();
     double deck1RateDir = m_rateDirControls[0]->get();
 
-    m_pConfig->set(ConfigKey("[Controls]", "RateRangeDecimal"), ConfigValue((int)(deck1RateRange*100)));
+    m_pConfig->set(ConfigKey("[Controls]", "RateRangeDecimal"), ConfigValue((int)(deck1RateRange * 100)));
 
     // Write rate direction to config file
     if (deck1RateDir == 1) {

--- a/src/dlgprefcontrols.h
+++ b/src/dlgprefcontrols.h
@@ -49,7 +49,7 @@ class DlgPrefControls : public DlgPreferencePage, public Ui::DlgPrefControlsDlg 
     void slotApply();
     void slotResetToDefaults();
 
-    void slotSetRateRange(int pos);
+    void slotSetRateRangeDecimal(int range);
     void slotSetRateDir(int pos);
     void slotKeylockMode(int pos);
     void slotSetRateTempLeft(double);

--- a/src/dlgprefcontrols.h
+++ b/src/dlgprefcontrols.h
@@ -49,7 +49,8 @@ class DlgPrefControls : public DlgPreferencePage, public Ui::DlgPrefControlsDlg 
     void slotApply();
     void slotResetToDefaults();
 
-    void slotSetRateRangeDecimal(int range);
+    void slotSetRateRange(int pos);
+    void slotSetRateRangeDecimal(int rate);
     void slotSetRateDir(int pos);
     void slotKeylockMode(int pos);
     void slotSetRateTempLeft(double);

--- a/src/dlgprefcontrols.h
+++ b/src/dlgprefcontrols.h
@@ -50,7 +50,7 @@ class DlgPrefControls : public DlgPreferencePage, public Ui::DlgPrefControlsDlg 
     void slotResetToDefaults();
 
     void slotSetRateRange(int pos);
-    void slotSetRateRangeDecimal(int rate);
+    void slotSetRateRangePercent(int rateRangePercent);
     void slotSetRateDir(int pos);
     void slotKeylockMode(int pos);
     void slotSetRateTempLeft(double);

--- a/src/dlgprefcontrolsdlg.ui
+++ b/src/dlgprefcontrolsdlg.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>576</width>
+    <width>561</width>
     <height>690</height>
    </rect>
   </property>
@@ -448,6 +448,9 @@
        <property name="wordWrap">
         <bool>false</bool>
        </property>
+       <property name="buddy">
+        <cstring>ComboBoxRateRange</cstring>
+       </property>
       </widget>
      </item>
      <item row="6" column="1" colspan="2">
@@ -479,6 +482,22 @@
        </property>
        <property name="toolTip">
         <string>Select from different color schemes of a skin if available.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="1" colspan="2">
+      <widget class="QComboBox" name="ComboBoxRateRange">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font/>
+       </property>
+       <property name="toolTip">
+        <string>Adjusts the range of the speed (Vinyl &quot;Pitch&quot;) slider.</string>
        </property>
       </widget>
      </item>
@@ -641,13 +660,6 @@ Numark mode:
      <item row="10" column="1" colspan="2">
       <widget class="QComboBox" name="ComboBoxResetSpeedAndPitch"/>
      </item>
-     <item row="12" column="1" colspan="2">
-      <widget class="QSpinBox" name="spinBoxRateRangeDecimal">
-       <property name="maximum">
-        <number>100</number>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
   </layout>
@@ -657,16 +669,10 @@ Numark mode:
   <tabstop>ComboBoxSkinconf</tabstop>
   <tabstop>ComboBoxSchemeconf</tabstop>
   <tabstop>ComboBoxStartInFullscreen</tabstop>
-  <tabstop>ComboBoxLocale</tabstop>
   <tabstop>ComboBoxTooltips</tabstop>
   <tabstop>ComboBoxPosition</tabstop>
-  <tabstop>ComboBoxCueDefault</tabstop>
-  <tabstop>ComboBoxSeekToCue</tabstop>
-  <tabstop>ComboBoxResetSpeedAndPitch</tabstop>
-  <tabstop>ComboBoxAllowTrackLoadToPlayingDeck</tabstop>
-  <tabstop>spinBoxRateRangeDecimal</tabstop>
+  <tabstop>ComboBoxRateRange</tabstop>
   <tabstop>ComboBoxRateDir</tabstop>
-  <tabstop>ComboBoxKeylockMode</tabstop>
   <tabstop>spinBoxPermRateLeft</tabstop>
   <tabstop>spinBoxPermRateRight</tabstop>
   <tabstop>spinBoxTempRateLeft</tabstop>

--- a/src/dlgprefcontrolsdlg.ui
+++ b/src/dlgprefcontrolsdlg.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>561</width>
+    <width>576</width>
     <height>690</height>
    </rect>
   </property>
@@ -448,9 +448,6 @@
        <property name="wordWrap">
         <bool>false</bool>
        </property>
-       <property name="buddy">
-        <cstring>ComboBoxRateRange</cstring>
-       </property>
       </widget>
      </item>
      <item row="6" column="1" colspan="2">
@@ -482,22 +479,6 @@
        </property>
        <property name="toolTip">
         <string>Select from different color schemes of a skin if available.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="1" colspan="2">
-      <widget class="QComboBox" name="ComboBoxRateRange">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font/>
-       </property>
-       <property name="toolTip">
-        <string>Adjusts the range of the speed (Vinyl &quot;Pitch&quot;) slider.</string>
        </property>
       </widget>
      </item>
@@ -660,6 +641,13 @@ Numark mode:
      <item row="10" column="1" colspan="2">
       <widget class="QComboBox" name="ComboBoxResetSpeedAndPitch"/>
      </item>
+     <item row="12" column="1" colspan="2">
+      <widget class="QSpinBox" name="spinBoxRateRangeDecimal">
+       <property name="maximum">
+        <number>100</number>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>
@@ -669,10 +657,16 @@ Numark mode:
   <tabstop>ComboBoxSkinconf</tabstop>
   <tabstop>ComboBoxSchemeconf</tabstop>
   <tabstop>ComboBoxStartInFullscreen</tabstop>
+  <tabstop>ComboBoxLocale</tabstop>
   <tabstop>ComboBoxTooltips</tabstop>
   <tabstop>ComboBoxPosition</tabstop>
-  <tabstop>ComboBoxRateRange</tabstop>
+  <tabstop>ComboBoxCueDefault</tabstop>
+  <tabstop>ComboBoxSeekToCue</tabstop>
+  <tabstop>ComboBoxResetSpeedAndPitch</tabstop>
+  <tabstop>ComboBoxAllowTrackLoadToPlayingDeck</tabstop>
+  <tabstop>spinBoxRateRangeDecimal</tabstop>
   <tabstop>ComboBoxRateDir</tabstop>
+  <tabstop>ComboBoxKeylockMode</tabstop>
   <tabstop>spinBoxPermRateLeft</tabstop>
   <tabstop>spinBoxPermRateRight</tabstop>
   <tabstop>spinBoxTempRateLeft</tabstop>


### PR DESCRIPTION
The RateRange is now a int-Setting, allowing the user to set any rateRange.
Removes the ComboBox from Setting replacing it with a spinner.
A new setting-key is added and if not present filled with the according values from the old setting for smooth migration.

fixes lp:#1441161

This would apply cleanly to 1.12 also, but I think feature freeze is over for 1.12?
