### PR TITLE
modplug: set channel count and other track info on open

### DIFF
--- a/src/soundsourcemodplug.cpp
+++ b/src/soundsourcemodplug.cpp
@@ -125,7 +125,9 @@ Result SoundSourceModPlug::open() {
     setSampleRate(44100); // ModPlug always uses 44.1kHz
     m_opened = true;
     m_seekPos = 0;
-    return OK;
+
+    // read all other track information
+    return parseHeader();
 }
 
 long SoundSourceModPlug::seek(long filePos)


### PR DESCRIPTION
This fixes an "invalid channel count" (0) on loading mod files in the 1.12 branch.
Somehow parseHeader() must have been called directly in the past or the check for channels is new.
