### PR TITLE
Add tooltip for search bar

### DIFF
--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -22,6 +22,7 @@
 #define MIXXX_FEEDBACK_URL      "https://docs.google.com/a/mixxx.org/forms/d/1raQ0WnrdVJYSE5r2tsV4jIRd90oZVrF-TRKWeW2kfEU/viewform"
 #define MIXXX_TRANSLATION_URL   "https://www.transifex.com/projects/p/mixxxdj/"
 #define MIXXX_MANUAL_URL        "http://mixxx.org/manual/1.12"
+#define MIXXX_SHORTCUTS_URL     "http://mixxx.org/manual/1.12/chapters/appendix.html#keyboard-mapping-table"
 #define MIXXX_MANUAL_FILENAME   "Mixxx-Manual.pdf"
 
 #endif

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1229,6 +1229,13 @@ void MixxxMainWindow::initActions()
     m_pHelpManual->setWhatsThis(buildWhatsThis(manualTitle, manualText));
     connect(m_pHelpManual, SIGNAL(triggered()), this, SLOT(slotHelpManual()));
 
+    QString shortcutsTitle = tr("&Keyboard Shortcuts");
+    QString shortcutsText = tr("Speed up your workflow with keyboard shortcuts.");
+    m_pHelpShortcuts = new QAction(shortcutsTitle, this);
+    m_pHelpShortcuts->setStatusTip(shortcutsText);
+    m_pHelpShortcuts->setWhatsThis(buildWhatsThis(shortcutsTitle, shortcutsText));
+    connect(m_pHelpShortcuts, SIGNAL(triggered()), this, SLOT(slotHelpShortcuts()));
+    
     QString feedbackTitle = tr("Send Us &Feedback");
     QString feedbackText = tr("Send feedback to the Mixxx team.");
     m_pHelpFeedback = new QAction(feedbackTitle, this);
@@ -1621,6 +1628,7 @@ void MixxxMainWindow::initMenuBar() {
     // menuBar entry helpMenu
     m_pHelpMenu->addAction(m_pHelpSupport);
     m_pHelpMenu->addAction(m_pHelpManual);
+    m_pHelpMenu->addAction(m_pHelpShortcuts);
     m_pHelpMenu->addAction(m_pHelpFeedback);
     m_pHelpMenu->addAction(m_pHelpTranslation);
     m_pHelpMenu->addSeparator();
@@ -1996,6 +2004,12 @@ void MixxxMainWindow::slotHelpTranslation() {
     QUrl qTranslationUrl;
     qTranslationUrl.setUrl(MIXXX_TRANSLATION_URL);
     QDesktopServices::openUrl(qTranslationUrl);
+}
+
+void MixxxMainWindow::slotHelpShortcuts() {
+    QUrl qShortcutsUrl;
+    qShortcutsUrl.setUrl(MIXXX_SHORTCUTS_URL);
+    QDesktopServices::openUrl(qShortcutsUrl);
 }
 
 void MixxxMainWindow::slotHelpManual() {

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1207,6 +1207,8 @@ void MixxxMainWindow::initActions()
     connect(m_pOptionsPreferences, SIGNAL(triggered()),
             this, SLOT(slotOptionsPreferences()));
 
+    QString externalLinkSuffix = QChar(0x21D7);
+    
     QString aboutTitle = tr("&About");
     QString aboutText = tr("About the application");
     m_pHelpAboutApp = new QAction(aboutTitle, this);
@@ -1215,35 +1217,35 @@ void MixxxMainWindow::initActions()
     connect(m_pHelpAboutApp, SIGNAL(triggered()),
             this, SLOT(slotHelpAbout()));
 
-    QString supportTitle = tr("&Community Support");
+    QString supportTitle = tr("&Community Support") + externalLinkSuffix;
     QString supportText = tr("Get help with Mixxx");
     m_pHelpSupport = new QAction(supportTitle, this);
     m_pHelpSupport->setStatusTip(supportText);
     m_pHelpSupport->setWhatsThis(buildWhatsThis(supportTitle, supportText));
     connect(m_pHelpSupport, SIGNAL(triggered()), this, SLOT(slotHelpSupport()));
 
-    QString manualTitle = tr("&User Manual");
+    QString manualTitle = tr("&User Manual") + externalLinkSuffix;
     QString manualText = tr("Read the Mixxx user manual.");
     m_pHelpManual = new QAction(manualTitle, this);
     m_pHelpManual->setStatusTip(manualText);
     m_pHelpManual->setWhatsThis(buildWhatsThis(manualTitle, manualText));
     connect(m_pHelpManual, SIGNAL(triggered()), this, SLOT(slotHelpManual()));
 
-    QString shortcutsTitle = tr("&Keyboard Shortcuts");
+    QString shortcutsTitle = tr("&Keyboard Shortcuts") + externalLinkSuffix;
     QString shortcutsText = tr("Speed up your workflow with keyboard shortcuts.");
     m_pHelpShortcuts = new QAction(shortcutsTitle, this);
     m_pHelpShortcuts->setStatusTip(shortcutsText);
     m_pHelpShortcuts->setWhatsThis(buildWhatsThis(shortcutsTitle, shortcutsText));
     connect(m_pHelpShortcuts, SIGNAL(triggered()), this, SLOT(slotHelpShortcuts()));
     
-    QString feedbackTitle = tr("Send Us &Feedback");
+    QString feedbackTitle = tr("Send Us &Feedback") + externalLinkSuffix;
     QString feedbackText = tr("Send feedback to the Mixxx team.");
     m_pHelpFeedback = new QAction(feedbackTitle, this);
     m_pHelpFeedback->setStatusTip(feedbackText);
     m_pHelpFeedback->setWhatsThis(buildWhatsThis(feedbackTitle, feedbackText));
     connect(m_pHelpFeedback, SIGNAL(triggered()), this, SLOT(slotHelpFeedback()));
 
-    QString translateTitle = tr("&Translate This Application");
+    QString translateTitle = tr("&Translate This Application") + externalLinkSuffix;
     QString translateText = tr("Help translate this application into your language.");
     m_pHelpTranslation = new QAction(translateTitle, this);
     m_pHelpTranslation->setStatusTip(translateText);

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -104,7 +104,9 @@ class MixxxMainWindow : public QMainWindow {
     void slotHelpFeedback();
     // Open the manual.
     void slotHelpManual();
-    // Visits translation interface on launchpad.net
+    // Open the keyboard mapping table in the manual.
+    void slotHelpShortcuts();
+    // Visits translation interface on www.transifex.com
     void slotHelpTranslation();
     // Scan or rescan the music library directory
     void slotScanLibrary();
@@ -260,8 +262,9 @@ class MixxxMainWindow : public QMainWindow {
     QAction* m_pHelpAboutApp;
     QAction* m_pHelpSupport;
     QAction* m_pHelpFeedback;
-    QAction* m_pHelpTranslation;
     QAction* m_pHelpManual;
+    QAction* m_pHelpShortcuts;
+    QAction* m_pHelpTranslation;
 
     QAction* m_pDeveloperReloadSkin;
     QAction* m_pDeveloperTools;

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -173,6 +173,26 @@ void WSearchLineEdit::showPlaceholder() {
     //textChanged().
     blockSignals(true);
     setText(tr("Search..."));
+    setToolTip(tr("Search" ,"noun")
+                  + "\n"
+                  + tr("Searches for a match in the current selected list (e.g. a playlist, a crate or even the whole library.\n"
+                       "Search terms can include an artist’s name, a track title, BPM, etc.\n"
+                       "Supports search operators that allow you to form more complex search queries.")
+                  + "\n\n"
+                  + tr("Shortcut")
+                  + ": \n"
+                  + tr("Ctrl+F")
+                  + " "
+                  + tr("Focus" , "Give search bar input focus")
+                  + "\n"
+                  + tr("Ctrl+Backspace")
+                  + " "
+                  + tr("Clear input" , "Clear the search bar input field")
+                  + "\n"
+                  + tr("Esc")
+                  + " "
+                  + tr("Exit search" , "Exit search bar and leave focus")
+                  );
     blockSignals(false);
     QPalette pal = palette();
     pal.setColor(foregroundRole(), Qt::lightGray);

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -173,7 +173,7 @@ void WSearchLineEdit::showPlaceholder() {
     //textChanged().
     blockSignals(true);
     setText(tr("Search..." , "noun"));
-    setToolTip(tr("Search" , "noun") + "\n" + tr("Enter a string to seach for") + "\n\n"
+    setToolTip(tr("Search" , "noun") + "\n" + tr("Enter a string to search for") + "\n\n"
                   + tr("Shortcut")+ ": \n"
                   + tr("Ctrl+F") + "  " + tr("Focus" , "Give search bar input focus") + "\n"
                   + tr("Ctrl+Backspace") + "  "+ tr("Clear input" , "Clear the search bar input field") + "\n"

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -16,6 +16,7 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     m_clearButton->setIcon(QIcon(pixmap));
     m_clearButton->setIconSize(pixmap.size());
     m_clearButton->setCursor(Qt::ArrowCursor);
+    m_clearButton->setToolTip(tr("Clear input" , "Clear the search bar input field"));
     m_clearButton->setStyleSheet("QToolButton { border: none; padding: 0px; }");
     m_clearButton->hide();
 

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -172,26 +172,12 @@ void WSearchLineEdit::showPlaceholder() {
     //Must block signals here so that we don't emit a search() signal via
     //textChanged().
     blockSignals(true);
-    setText(tr("Search..."));
-    setToolTip(tr("Search" ,"noun")
-                  + "\n"
-                  + tr("Searches for a match in the current selected list (e.g. a playlist, a crate or even the whole library.\n"
-                       "Search terms can include an artist’s name, a track title, BPM, etc.\n"
-                       "Supports search operators that allow you to form more complex search queries.")
-                  + "\n\n"
-                  + tr("Shortcut")
-                  + ": \n"
-                  + tr("Ctrl+F")
-                  + " "
-                  + tr("Focus" , "Give search bar input focus")
-                  + "\n"
-                  + tr("Ctrl+Backspace")
-                  + " "
-                  + tr("Clear input" , "Clear the search bar input field")
-                  + "\n"
-                  + tr("Esc")
-                  + " "
-                  + tr("Exit search" , "Exit search bar and leave focus")
+    setText(tr("Search..." , "noun"));
+    setToolTip(tr("Search" , "noun") + "\n" + tr("Enter a string to seach for") + "\n\n"
+                  + tr("Shortcut")+ ": \n"
+                  + tr("Ctrl+F") + "  " + tr("Focus" , "Give search bar input focus") + "\n"
+                  + tr("Ctrl+Backspace") + "  "+ tr("Clear input" , "Clear the search bar input field") + "\n"
+                  + tr("Esc") + "  " + tr("Exit search" , "Exit search bar and leave focus")
                   );
     blockSignals(false);
     QPalette pal = palette();


### PR DESCRIPTION
Attempts to fix https://bugs.launchpad.net/mixxx/+bug/1457656 and https://bugs.launchpad.net/mixxx/+bug/1411471
Reused most of the text from the manual, so we may have the text already in the Translation memory, potentially saving time for translators.

Currently displays static key sequences in the tooltips. Could use some help to display native key sequences, e.g `CTRL+F` is `CMD+F` on OSX.
Thanks
