### PR TITLE
Add QT imageformats plugins in windows builds and installer

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -202,9 +202,12 @@ class Qt(Dependence):
 
     @staticmethod
     def enabled_imageformats(build):
+        qt5 = Qt.qt5_enabled(build)
         qt_imageformats = [
-            'qjpeg', 'qigf', 'qtiff'
+            'qgif', 'qico', 'qjpeg',  'qmng', 'qtga', 'qtiff', 'qsvg'
         ]
+        if qt5:
+            qt_imageformats.extend(['qdds', 'qicns', 'qjp2', 'qwbmp', 'qwebp'])
         return qt_imageformats
 
     def satisfy(self):

--- a/build/depends.py
+++ b/build/depends.py
@@ -200,7 +200,8 @@ class Qt(Dependence):
             qt_modules.extend(['QtWidgets', 'QtConcurrent'])
         return qt_modules
 
-    def enabled_imageformats(build):
+      @staticmethod
+      def enabled_imageformats(build):
         qt_imageformats = [
             'qjpeg', 'qigf', 'qtiff'
         ]

--- a/build/depends.py
+++ b/build/depends.py
@@ -200,6 +200,12 @@ class Qt(Dependence):
             qt_modules.extend(['QtWidgets', 'QtConcurrent'])
         return qt_modules
 
+    def enabled_imageformats(build):
+        qt_imageformats = [
+            'qjpeg', 'qigf', 'qtiff'
+        ]
+        return qt_imageformats
+
     def satisfy(self):
         pass
 

--- a/build/depends.py
+++ b/build/depends.py
@@ -200,8 +200,8 @@ class Qt(Dependence):
             qt_modules.extend(['QtWidgets', 'QtConcurrent'])
         return qt_modules
 
-      @staticmethod
-      def enabled_imageformats(build):
+    @staticmethod
+    def enabled_imageformats(build):
         qt_imageformats = [
             'qjpeg', 'qigf', 'qtiff'
         ]

--- a/build/nsis/Mixxx.nsi
+++ b/build/nsis/Mixxx.nsi
@@ -208,6 +208,9 @@ Section "Mixxx (required)" SecMixxx
   SetOutPath $INSTDIR\sqldrivers
   File /nonfatal /r "${BASE_BUILD_DIR}\dist${BITWIDTH}\sqldrivers\*"
 
+  SetOutPath $INSTDIR\imageformats
+  File /nonfatal /r "${BASE_BUILD_DIR}\dist${BITWIDTH}\imageformats\*"
+
   SetOutPath $INSTDIR\fonts
   File /nonfatal /r "${BASE_BUILD_DIR}\dist${BITWIDTH}\fonts\*"
 
@@ -315,6 +318,8 @@ Section "Uninstall"
   Delete $INSTDIR\COPYING
   Delete $INSTDIR\sqldrivers\*.dll
   RMDir "$INSTDIR\sqldrivers"
+  Delete $INSTDIR\imageformats\*.dll
+  RMDir "$INSTDIR\imageformats"
   Delete $INSTDIR\fonts\*
   RMDir "$INSTDIR\fonts"
   Delete $INSTDIR\plugins\soundsource\*

--- a/src/SConscript
+++ b/src/SConscript
@@ -244,6 +244,19 @@ else:
         qt_modules = ['$QTDIR/lib/' + module + suffix for module in qt_modules]
         dll_files.extend(qt_modules)
 
+# Qt imageformats plugin
+imgfmtdll_files = []
+qt_imagesformats = depends.Qt.enabled_imageformats(build)
+
+if qt5:
+        suffix = 'd.dll' if build.build_is_debug else '.dll'
+        qt_imagesformats = ['$QTDIR/plugins/imageformats/' + module + suffix for module in qt_imagesformats]
+        imgfmtdll_files.extend(qt_imagesformats)
+else:
+        suffix = 'd4.dll' if build.build_is_debug else '4.dll'
+        qt_imagesformats = ['$QTDIR/plugins/imageformats/' + module + suffix for module in qt_imagesformats]
+        imgfmtdll_files.extend(qt_imagesformats)
+
 sqldll_files = []
 if int(flags.get('qt_sqlite_plugin', 0)):
         if qt5:
@@ -475,6 +488,11 @@ if build.platform_is_windows:
         env.Alias('mixxx', vamp_plugins)
         #env.Alias('mixxx', icon)
         env.Alias('mixxx', binary)
+
+        # imageformats DLL
+        if imgfmtdll_files:
+                imageformats_dll = env.Install(os.path.join(base_dist_dir, "imageformats"), imgfmtdll_files)
+                env.Alias('mixxx', imageformats_dll)
 
         # QSQLite DLL
         if sqldll_files:


### PR DESCRIPTION
This is a fix for JPEG cover art bug on windows (lp:1448746)
QT's QImage can natively load PNG files, but needs additionnal imageformats plugins to be able to open other fileformats like JPEG or GIF under Windows.
The purpose of this PR is to install  the needed imageformats QT plugins and bundle them in windows installer.
