### PR TITLE
Bug 1316785 -- improve controller preset directory buttons 

### DIFF
--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -69,11 +69,6 @@ ControllerManager::ControllerManager(ConfigObject<ConfigValue>* pConfig)
         qDebug() << "Creating user controller presets directory:" << userPresets;
         QDir().mkpath(userPresets);
     }
-    QString localPresets = localPresetsPath(m_pConfig);
-    if (!QDir(localPresets).exists()) {
-        qDebug() << "Creating local controller presets directory:" << localPresets;
-        QDir().mkpath(localPresets);
-    }
 
     // Initialize preset info parsers. This object is only for use in the main
     // thread. Do not touch it from within ControllerManager.
@@ -375,7 +370,6 @@ void ControllerManager::slotSavePresets(bool onlyActive) {
 QList<QString> ControllerManager::getPresetPaths(ConfigObject<ConfigValue>* pConfig) {
     QList<QString> scriptPaths;
     scriptPaths.append(userPresetsPath(pConfig));
-    scriptPaths.append(localPresetsPath(pConfig));
     scriptPaths.append(resourcePresetsPath(pConfig));
     return scriptPaths;
 }

--- a/src/controllers/controllerpresetinfo.cpp
+++ b/src/controllers/controllerpresetinfo.cpp
@@ -135,7 +135,6 @@ QHash<QString,QString> PresetInfo::parseOSCProduct(const QDomElement& element) c
 }
 
 PresetInfoEnumerator::PresetInfoEnumerator(ConfigObject<ConfigValue>* pConfig) {
-    controllerDirPaths.append(localPresetsPath(pConfig));
     controllerDirPaths.append(resourcePresetsPath(pConfig));
 
     // Static list of supported default extensions, sorted by popularity

--- a/src/controllers/defs_controllers.h
+++ b/src/controllers/defs_controllers.h
@@ -27,12 +27,6 @@ inline QString userPresetsPath(ConfigObject<ConfigValue>* pConfig) {
     return dir.absolutePath().append("/");
 }
 
-inline QString localPresetsPath(ConfigObject<ConfigValue>* pConfig) {
-    QString presetsPath = pConfig->getSettingsPath();
-    QDir dir(presetsPath.append("/presets/"));
-    return dir.absolutePath().append("/");
-}
-
 #define HID_PRESET_EXTENSION ".hid.xml"
 #define MIDI_PRESET_EXTENSION ".midi.xml"
 #define BULK_PRESET_EXTENSION ".bulk.xml"

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -22,12 +22,9 @@ DlgPrefControllers::DlgPrefControllers(DlgPreferences* pPreferences,
     connect(&m_buttonMapper, SIGNAL(mapped(QString)),
             this, SLOT(slotOpenLocalFile(QString)));
 
-    connect(btnOpenSystemPresets, SIGNAL(clicked()),
-            &m_buttonMapper, SLOT(map()));
     connect(btnOpenUserPresets, SIGNAL(clicked()),
             &m_buttonMapper, SLOT(map()));
 
-    m_buttonMapper.setMapping(btnOpenSystemPresets, resourcePresetsPath(m_pConfig));
     m_buttonMapper.setMapping(btnOpenUserPresets, userPresetsPath(m_pConfig));
 
     // Connections

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -24,13 +24,10 @@ DlgPrefControllers::DlgPrefControllers(DlgPreferences* pPreferences,
 
     connect(btnOpenSystemPresets, SIGNAL(clicked()),
             &m_buttonMapper, SLOT(map()));
-    connect(btnOpenLocalPresets, SIGNAL(clicked()),
-            &m_buttonMapper, SLOT(map()));
     connect(btnOpenUserPresets, SIGNAL(clicked()),
             &m_buttonMapper, SLOT(map()));
 
     m_buttonMapper.setMapping(btnOpenSystemPresets, resourcePresetsPath(m_pConfig));
-    m_buttonMapper.setMapping(btnOpenLocalPresets, localPresetsPath(m_pConfig));
     m_buttonMapper.setMapping(btnOpenUserPresets, userPresetsPath(m_pConfig));
 
     // Connections

--- a/src/controllers/dlgprefcontrollersdlg.ui
+++ b/src/controllers/dlgprefcontrollersdlg.ui
@@ -96,6 +96,23 @@
        </widget>
       </item>
       <item row="1" column="0">
+       <widget class="QPushButton" name="btnOpenUserPresets">
+        <property name="text">
+         <string>Open User Preset Folder</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="txtOpenUserPresetFolderDescription">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save the preset file(s) in the &amp;quot;User Preset Folder&amp;quot; to make the preset available only for the current user. (Recommended)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
        <widget class="QPushButton" name="btnOpenSystemPresets">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -114,27 +131,10 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QLabel" name="txtOpenSystemPresetFolderDescription">
         <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save the preset file(s) in the &amp;quot;System Preset Folder&amp;quot; to make the preset available for all users.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QPushButton" name="btnOpenUserPresets">
-        <property name="text">
-         <string>Open User Preset Folder</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="txtOpenUserPresetFolderDescription">
-        <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save the preset file(s) in the &amp;quot;User Preset Folder&amp;quot; to make the preset available only for the current user.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save the preset file(s) in the &amp;quot;System Preset Folder&amp;quot; to make the preset available for all users. (Not recommended: this folder is subject to change when uninstalling/reinstalling the application, files could get overwritten or deleted)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/controllers/dlgprefcontrollersdlg.ui
+++ b/src/controllers/dlgprefcontrollersdlg.ui
@@ -88,7 +88,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Mixxx uses &quot;presets&quot; to connect messages from your controller to controls in Mixxx. If you do not see a preset for your controller, you can download one online from the Mixxx Forums or Mixxx Wiki. After downloading a preset, place the XML (.xml) and Javascript (.js) file(s) in one of these preset folders:</string>
+         <string>Mixxx uses &quot;presets&quot; to connect messages from your controller to controls in Mixxx. If you do not see a preset for your controller, you can download one online from the Mixxx Forums or Mixxx Wiki. After downloading a preset, place the XML (.xml) and Javascript (.js) file(s) in the &quot;User Preset Folder&quot;:</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -97,47 +97,14 @@
       </item>
       <item row="1" column="0">
        <widget class="QPushButton" name="btnOpenUserPresets">
-        <property name="text">
-         <string>Open User Preset Folder</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="txtOpenUserPresetFolderDescription">
-        <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save the preset file(s) in the &amp;quot;User Preset Folder&amp;quot; to make the preset available only for the current user. (Recommended)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QPushButton" name="btnOpenSystemPresets">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
         <property name="text">
-         <string>Open System Preset Folder</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="txtOpenSystemPresetFolderDescription">
-        <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save the preset file(s) in the &amp;quot;System Preset Folder&amp;quot; to make the preset available for all users. (Not recommended: this folder is subject to change when uninstalling/reinstalling the application, files could get overwritten or deleted)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
+         <string>Open User Preset Folder</string>
         </property>
        </widget>
       </item>

--- a/src/controllers/dlgprefcontrollersdlg.ui
+++ b/src/controllers/dlgprefcontrollersdlg.ui
@@ -13,8 +13,8 @@
   <property name="windowTitle">
    <string>Controller Preferences</string>
   </property>
-  <layout class="QVBoxLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Controllers</string>
@@ -73,7 +73,7 @@
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Presets</string>
@@ -95,10 +95,32 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="btnOpenLocalPresets">
+      <item row="1" column="0">
+       <widget class="QPushButton" name="btnOpenSystemPresets">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
         <property name="text">
-         <string>Open Local Preset Folder</string>
+         <string>Open System Preset Folder</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="txtOpenSystemPresetFolderDescription">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save the preset file(s) in the &amp;quot;System Preset Folder&amp;quot; to make the preset available for all users.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -109,17 +131,20 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QPushButton" name="btnOpenSystemPresets">
+      <item row="2" column="1">
+       <widget class="QLabel" name="txtOpenUserPresetFolderDescription">
         <property name="text">
-         <string>Open System Preset Folder</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save the preset file(s) in the &amp;quot;User Preset Folder&amp;quot; to make the preset available only for the current user.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>Resources</string>
@@ -168,7 +193,7 @@
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Pull request for 
https://bugs.launchpad.net/mixxx/+bug/1316785

I asked some questions in the bugtracker, they where not answered so I tried to use some common sense.

I created 2 commits, the first adds the requested description, removes the local preset button as afaik it serves the exact same function as the user preset button. However the code to read the presets is still intact in that commit. 
In the second commit I removed all references I could find to the local preset folder. The only issue I can see when doing this is that when a user uses 2 versions of mixxx, one with only the local presets folder and one with only the user presets folder, that he might have to put his presets in 2 distinct folders (the user could use the global preset folder in stead of course).
I've tried to look at the git log when these elements where introduced exactly, but that proved a more difficult exercise than expected, so I haven't gotten to the bottom of when which folder was introduced and why.
