### PR TITLE
Fix move constructor of SampleBuffer

### DIFF
--- a/src/samplebuffer.h
+++ b/src/samplebuffer.h
@@ -31,7 +31,7 @@ class SampleBuffer {
     Q_DISABLE_COPY(SampleBuffer);
   public:
     SampleBuffer()
-            : m_data(NULL),
+            : m_data(nullptr),
               m_size(0) {
     }
     explicit SampleBuffer(SINT size);

--- a/src/samplebuffer.h
+++ b/src/samplebuffer.h
@@ -35,8 +35,11 @@ class SampleBuffer {
               m_size(0) {
     }
     explicit SampleBuffer(SINT size);
-    SampleBuffer(SampleBuffer&& other) {
-        swap(other);
+    SampleBuffer(SampleBuffer&& other)
+        : m_data(other.m_data),
+          m_size(other.m_size) {
+        other.m_data = nullptr;
+        other.m_size = 0;
     }
     virtual ~SampleBuffer();
 


### PR DESCRIPTION
An uninitialized pointer and integer value is swapped into the 'other' SampleBuffer.

Forgot to mention: YES, C++11 support finally!! But please be careful with the new features ;)
