### PR TITLE
Correct settings path on windows seven+

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -1140,12 +1140,15 @@ class MixxxCore(Feature):
         build.env.Append(CPPPATH=['.'])
 
         # Set up flags for config/track listing files
+        # SETTINGS_PATH not needed for windows because we now use QDesktopServices::storageLocation(QDesktopServices::DataLocation)
         if build.platform_is_linux or \
                 build.platform_is_bsd:
             mixxx_files = [
+                ('SETTINGS_PATH', '.mixxx/'),
                 ('SETTINGS_FILE', 'mixxx.cfg')]
         elif build.platform_is_osx:
             mixxx_files = [
+                ('SETTINGS_PATH', 'Library/Application Support/Mixxx/'),
                 ('SETTINGS_FILE', 'mixxx.cfg')]
         elif build.platform_is_windows:
             mixxx_files = [

--- a/build/depends.py
+++ b/build/depends.py
@@ -1143,15 +1143,12 @@ class MixxxCore(Feature):
         if build.platform_is_linux or \
                 build.platform_is_bsd:
             mixxx_files = [
-                ('SETTINGS_PATH', '.mixxx/'),
                 ('SETTINGS_FILE', 'mixxx.cfg')]
         elif build.platform_is_osx:
             mixxx_files = [
-                ('SETTINGS_PATH', 'Library/Application Support/Mixxx/'),
                 ('SETTINGS_FILE', 'mixxx.cfg')]
         elif build.platform_is_windows:
             mixxx_files = [
-                ('SETTINGS_PATH', 'Local Settings/Application Data/Mixxx/'),
                 ('SETTINGS_FILE', 'mixxx.cfg')]
 
         # Escape the filenames so they don't end up getting screwed up in the

--- a/build/depends.py
+++ b/build/depends.py
@@ -1140,15 +1140,19 @@ class MixxxCore(Feature):
         build.env.Append(CPPPATH=['.'])
 
         # Set up flags for config/track listing files
+        # SETTINGS_DIR is relative to QDesktopServices::storageLocation(QDesktopServices::DataLocation)
         if build.platform_is_linux or \
                 build.platform_is_bsd:
             mixxx_files = [
+                ('SETTINGS_DIR', '.mixxx/'),
                 ('SETTINGS_FILE', 'mixxx.cfg')]
         elif build.platform_is_osx:
             mixxx_files = [
+                ('SETTINGS_DIR', 'Mixxx/'),
                 ('SETTINGS_FILE', 'mixxx.cfg')]
         elif build.platform_is_windows:
             mixxx_files = [
+                ('SETTINGS_DIR', 'Mixxx/'),
                 ('SETTINGS_FILE', 'mixxx.cfg')]
 
         # Escape the filenames so they don't end up getting screwed up in the

--- a/build/depends.py
+++ b/build/depends.py
@@ -1140,19 +1140,15 @@ class MixxxCore(Feature):
         build.env.Append(CPPPATH=['.'])
 
         # Set up flags for config/track listing files
-        # SETTINGS_DIR is relative to QDesktopServices::storageLocation(QDesktopServices::DataLocation)
         if build.platform_is_linux or \
                 build.platform_is_bsd:
             mixxx_files = [
-                ('SETTINGS_DIR', '.mixxx/'),
                 ('SETTINGS_FILE', 'mixxx.cfg')]
         elif build.platform_is_osx:
             mixxx_files = [
-                ('SETTINGS_DIR', 'Mixxx/'),
                 ('SETTINGS_FILE', 'mixxx.cfg')]
         elif build.platform_is_windows:
             mixxx_files = [
-                ('SETTINGS_DIR', 'Mixxx/'),
                 ('SETTINGS_FILE', 'mixxx.cfg')]
 
         # Escape the filenames so they don't end up getting screwed up in the

--- a/build/depends.py
+++ b/build/depends.py
@@ -1140,7 +1140,7 @@ class MixxxCore(Feature):
         build.env.Append(CPPPATH=['.'])
 
         # Set up flags for config/track listing files
-        # SETTINGS_PATH not needed for windows because we now use QDesktopServices::storageLocation(QDesktopServices::DataLocation)
+        # SETTINGS_PATH not needed for windows and MacOSX because we now use QDesktopServices::storageLocation(QDesktopServices::DataLocation)
         if build.platform_is_linux or \
                 build.platform_is_bsd:
             mixxx_files = [
@@ -1148,7 +1148,6 @@ class MixxxCore(Feature):
                 ('SETTINGS_FILE', 'mixxx.cfg')]
         elif build.platform_is_osx:
             mixxx_files = [
-                ('SETTINGS_PATH', 'Library/Application Support/Mixxx/'),
                 ('SETTINGS_FILE', 'mixxx.cfg')]
         elif build.platform_is_windows:
             mixxx_files = [

--- a/src/dlgabout.cpp
+++ b/src/dlgabout.cpp
@@ -106,7 +106,8 @@ DlgAbout::DlgAbout(QWidget* parent) :  QDialog(parent), Ui::DlgAboutDlg() {
             << "Nils Goroll"
             << "Marco Angerer"
             << "Ferran Pujol Camins"
-            << "Markus Kl&ouml;sges";
+            << "Markus Kl&ouml;sges"
+            << "S&eacute;bastien Blaisot";
 
     QStringList specialThanks;
     specialThanks

--- a/src/library/legacylibraryimporter.cpp
+++ b/src/library/legacylibraryimporter.cpp
@@ -34,15 +34,8 @@ LegacyLibraryImporter::LegacyLibraryImporter(TrackDAO& trackDao,
 
 /** Upgrade from <= 1.7 library to 1.8 DB format */
 void LegacyLibraryImporter::import() {
-    //Here we need the SETTINGS_PATH from Mixxx V <= 1.7
-#ifdef __LINUX__
-    QString settingPath17 = QDir::homePath().append("/").append(".mixxx/");
-#elif __WINDOWS__
-    QString settingPath17 = QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/");
-#elif __APPLE__
-    QString settingPath17 = QDir::homePath().append("/").append(".mixxx/");
-#endif
-
+    // Here we need the SETTINGS_PATH from Mixxx V <= 1.7
+    QString settingPath17 = Upgrade::mixxx17HomePath();
 
     QString trackXML = settingPath17.append("mixxxtrack.xml");
     QFile file(trackXML);

--- a/src/library/legacylibraryimporter.cpp
+++ b/src/library/legacylibraryimporter.cpp
@@ -34,9 +34,16 @@ LegacyLibraryImporter::LegacyLibraryImporter(TrackDAO& trackDao,
 
 /** Upgrade from <= 1.7 library to 1.8 DB format */
 void LegacyLibraryImporter::import() {
-    // TODO(XXX) SETTINGS_PATH may change in new Mixxx Versions. Here we need
-    // the SETTINGS_PATH from Mixxx V <= 1.7
-    QString settingPath17 = QDir::homePath().append("/").append(SETTINGS_PATH);
+    //Here we need the SETTINGS_PATH from Mixxx V <= 1.7
+#ifdef __LINUX__
+    QString settingPath17 = QDir::homePath().append("/").append(".mixxx/");
+#elif __WINDOWS__
+    QString settingPath17 = QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/");
+#elif __APPLE__
+    QString settingPath17 = QDir::homePath().append("/").append(".mixxx/");
+#endif
+
+
     QString trackXML = settingPath17.append("mixxxtrack.xml");
     QFile file(trackXML);
 

--- a/src/library/legacylibraryimporter.cpp
+++ b/src/library/legacylibraryimporter.cpp
@@ -17,6 +17,7 @@
 #include "trackinfoobject.h" //needed for importing 1.7.x library
 #include "util/xml.h" //needed for importing 1.7.x library
 #include "legacylibraryimporter.h"
+#include "upgrade.h"
 
 struct LegacyPlaylist {
     QString name;

--- a/src/library/legacylibraryimporter.cpp
+++ b/src/library/legacylibraryimporter.cpp
@@ -14,8 +14,8 @@
 #include <QDir>
 #include <QFile>
 #include <QtDebug>
-#include "trackinfoobject.h" //needed for importing 1.7.x library
-#include "util/xml.h" //needed for importing 1.7.x library
+#include "trackinfoobject.h" // needed for importing 1.7.x library
+#include "util/xml.h" // needed for importing 1.7.x library
 #include "legacylibraryimporter.h"
 #include "upgrade.h"
 
@@ -54,7 +54,7 @@ void LegacyLibraryImporter::import() {
 
     qDebug() << "Starting upgrade from 1.7 library...";
 
-    QHash<int, QString> playlistHashTable; //Maps track indices onto track locations
+    QHash<int, QString> playlistHashTable; // Maps track indices onto track locations
     QList<LegacyPlaylist> legacyPlaylists; // <= 1.7 playlists
 
     if (doc.setContent(&file, false, errorMsg, errorLine, errorColumn)) {
@@ -69,17 +69,17 @@ void LegacyLibraryImporter::import() {
 
             legPlaylist.name = name;
 
-            //Store the IDs in the hash table so we can map them to track locations later,
-            //and also store them in-order in a temporary playlist struct.
+            // Store the IDs in the hash table so we can map them to track locations later,
+            // and also store them in-order in a temporary playlist struct.
             QDomElement listNode = playlist.firstChildElement("List").toElement();
             QDomNodeList trackIDs = listNode.elementsByTagName("Id");
             for (int j = 0; j < trackIDs.size(); j++) {
                 int id = trackIDs.at(j).toElement().text().toInt();
                 if (!playlistHashTable.contains(id))
                     playlistHashTable.insert(id, "");
-                legPlaylist.indexes.push_back(id); //Save this track id.
+                legPlaylist.indexes.push_back(id); // Save this track id.
             }
-            //Save this playlist in our list.
+            // Save this playlist in our list.
             legacyPlaylists.push_back(legPlaylist);
         }
 
@@ -87,23 +87,23 @@ void LegacyLibraryImporter::import() {
         QDomNode track;
 
         for (int i = 0; i < trackList.size(); i++) {
-            //blah, can't figure out how to use an iterator with QDomNodeList
+            // blah, can't figure out how to use an iterator with QDomNodeList
             track = trackList.at(i);
             TrackInfoObject trackInfo17(track);
-            //Only add the track to the DB if the file exists on disk,
-            //because Mixxx <= 1.7 had no logic to deal with detecting deleted
-            //files.
+            // Only add the track to the DB if the file exists on disk,
+            // because Mixxx <= 1.7 had no logic to deal with detecting deleted
+            // files.
 
             if (trackInfo17.exists()) {
-                //Create a TrackInfoObject by directly parsing
-                //the actual MP3/OGG/whatever because 1.7 didn't parse
-                //genre and album tags (so the imported TIO doesn't have
-                //those fields).
+                // Create a TrackInfoObject by directly parsing
+                // the actual MP3/OGG/whatever because 1.7 didn't parse
+                // genre and album tags (so the imported TIO doesn't have
+                // those fields).
                 emit(progress("Upgrading Mixxx 1.7 Library: " + trackInfo17.getTitle()));
 
                 // Read the metadata we couldn't support in <1.8 from file.
                 QFileInfo fileInfo(trackInfo17.getLocation());
-                //Ensure we have the absolute file path stored
+                // Ensure we have the absolute file path stored
                 trackInfo17.setLocation(fileInfo.absoluteFilePath());
                 TrackInfoObject trackInfoNew(trackInfo17.getLocation());
                 trackInfo17.setGenre(trackInfoNew.getGenre());
@@ -126,9 +126,9 @@ void LegacyLibraryImporter::import() {
                 TrackPointer pTrack(&trackInfo17, &doNothing);
                 m_trackDao.saveTrack(pTrack);
 
-                //Check if this track is used in a playlist anywhere. If it is, save the
-                //track location. (The "id" of a track in 1.8 is a database index, so it's totally
-                //different. Using the track location is the best way for us to identify the song.)
+                // Check if this track is used in a playlist anywhere. If it is, save the
+                // track location. (The "id" of a track in 1.8 is a database index, so it's totally
+                // different. Using the track location is the best way for us to identify the song.)
                 int id = trackInfo17.getId();
                 if (playlistHashTable.contains(id))
                     playlistHashTable[id] = trackInfo17.getLocation();
@@ -136,18 +136,18 @@ void LegacyLibraryImporter::import() {
         }
 
 
-        //Create the imported playlists
+        // Create the imported playlists
         QListIterator<LegacyPlaylist> it(legacyPlaylists);
         LegacyPlaylist current;
         while (it.hasNext()) {
             current = it.next();
             emit(progress("Upgrading Mixxx 1.7 Playlists: " + current.name));
 
-            //Create the playlist with the imported name.
+            // Create the playlist with the imported name.
             //qDebug() << "Importing playlist:" << current.name;
             int playlistId = m_playlistDao.createPlaylist(current.name);
 
-            //For each track ID in the XML...
+            // For each track ID in the XML...
             QList<int> trackIDs = current.indexes;
             for (int i = 0; i < trackIDs.size(); i++)
             {
@@ -155,13 +155,13 @@ void LegacyLibraryImporter::import() {
                 int id = trackIDs[i];
                 //qDebug() << "track ID:" << id;
 
-                //Try to resolve the (XML's) track ID to a track location.
+                // Try to resolve the (XML's) track ID to a track location.
                 if (playlistHashTable.contains(id)) {
                     trackLocation = playlistHashTable[id];
                     //qDebug() << "Resolved to:" << trackLocation;
                 }
 
-                //Get the database's track ID (NOT the XML's track ID!)
+                // Get the database's track ID (NOT the XML's track ID!)
                 int dbTrackId = m_trackDao.getTrackId(trackLocation);
 
                 if (dbTrackId >= 0) {
@@ -173,7 +173,7 @@ void LegacyLibraryImporter::import() {
         }
 
         QString upgrade_filename = settingPath17.append("DBUPGRADED");
-        //now create stub so that the library is not readded next time program loads
+        // now create stub so that the library is not readded next time program loads
         QFile upgradefile(upgrade_filename);
         if (!upgradefile.open(QIODevice::WriteOnly | QIODevice::Text))
             qDebug() << "Couldn't open" << upgrade_filename << "for writing";

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -189,9 +189,14 @@ void LibraryScanner::slotStartScan() {
     // Try to upgrade the library from 1.7 (XML) to 1.8+ (DB) if needed. If the
     // upgrade_filename already exists, then do not try to upgrade since we have
     // already done it.
-    // TODO(XXX) SETTINGS_PATH may change in new Mixxx Versions. Here we need
-    // the SETTINGS_PATH from Mixxx V <= 1.7
-    QString upgrade_filename = QDir::homePath().append("/").append(SETTINGS_PATH).append("DBUPGRADED");
+    //  Here we need the SETTINGS_PATH from Mixxx V <= 1.7
+#ifdef __LINUX__
+    QString upgrade_filename = QDir::homePath().append("/").append(".mixxx/").append("DBUPGRADED");
+#elif __WINDOWS__
+    QString upgrade_filename = QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append("DBUPGRADED");
+#elif __APPLE__
+    QString upgrade_filename = QDir::homePath().append("/").append(".mixxx/").append("DBUPGRADED");
+#endif
     qDebug() << "upgrade filename is " << upgrade_filename;
     QFile upgradefile(upgrade_filename);
     if (!upgradefile.exists()) {

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -405,7 +405,7 @@ void LibraryScanner::queueTask(ScannerTask* pTask) {
 void LibraryScanner::directoryHashedAndScanned(const QString& directoryPath,
                                                bool newDirectory, int hash) {
     ScopedTimer timer("LibraryScanner::directoryHashedAndScanned");
-    // qDebug() << "LibraryScanner::directoryHashedAndScanned" << directoryPath
+    //qDebug() << "LibraryScanner::directoryHashedAndScanned" << directoryPath
     //          << newDirectory << hash;
 
     // For statistics tracking -- if we hashed a directory then we scanned it

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -30,6 +30,7 @@
 #include "util/file.h"
 #include "util/timer.h"
 #include "library/scanner/scannerutil.h"
+#include "upgrade.h"
 
 // TODO(rryan) make configurable
 const int kScannerThreadPoolSize = 1;

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -190,13 +190,7 @@ void LibraryScanner::slotStartScan() {
     // upgrade_filename already exists, then do not try to upgrade since we have
     // already done it.
     //  Here we need the SETTINGS_PATH from Mixxx V <= 1.7
-#ifdef __LINUX__
-    QString upgrade_filename = QDir::homePath().append("/").append(".mixxx/").append("DBUPGRADED");
-#elif __WINDOWS__
-    QString upgrade_filename = QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append("DBUPGRADED");
-#elif __APPLE__
-    QString upgrade_filename = QDir::homePath().append("/").append(".mixxx/").append("DBUPGRADED");
-#endif
+    QString upgrade_filename = Upgrade::mixxx17HomePath().append("DBUPGRADED");
     qDebug() << "upgrade filename is " << upgrade_filename;
     QFile upgradefile(upgrade_filename);
     if (!upgradefile.exists()) {

--- a/src/soundmanagerconfig.cpp
+++ b/src/soundmanagerconfig.cpp
@@ -38,7 +38,7 @@ SoundManagerConfig::SoundManagerConfig()
       m_deckCount(kDefaultDeckCount),
       m_audioBufferSizeIndex(kDefaultAudioBufferSizeIndex),
       m_syncBuffers(2) {
-    m_configFile = QFileInfo(CmdlineArgs::Instance().getSettingsPath() + SOUNDMANAGERCONFIG_FILENAME);
+    m_configFile = QFileInfo(CmdlineArgs::Instance().getSettingsPath() + "/" + SOUNDMANAGERCONFIG_FILENAME);
 }
 
 SoundManagerConfig::~SoundManagerConfig() {

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -180,7 +180,7 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
         qDebug() << "Config version is empty, trying to read pre-1.9.0 config";
         // Try to read the config from the pre-1.9.0 final directory on OS X (we moved it in 1.9.0 final)
         QScopedPointer<QFile> oldConfigFile(new QFile(QDir::homePath().append("/").append(".mixxx/mixxx.cfg")));
-        if (oldConfigFile->exists()) {
+        if (oldConfigFile->exists() && ! CmdlineArgs::Instance().getSettingsPathSet()) {
             qDebug() << "Found pre-1.9.0 config for OS X";
             // Note: We changed SETTINGS_PATH in 1.9.0 final on OS X so it must be hardcoded to ".mixxx" here for legacy.
             config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append(".mixxx/mixxx.cfg"));
@@ -193,7 +193,7 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
         qDebug() << "Config version is empty, trying to read pre-1.12.0 config";
         // Try to read the config from the pre-1.12.0 final directory on Windows (we moved it in 1.12.0 final)
         QScopedPointer<QFile> oldConfigFile(new QFile(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE)));
-        if (oldConfigFile->exists()) {
+        if (oldConfigFile->exists() && ! CmdlineArgs::Instance().getSettingsPathSet()) {
             qDebug() << "Found pre-1.12.0 config for Windows";
             // Note: We changed SETTINGS_PATH in 1.12.0 final on Windows so it must be hardcoded to "Local Settings/Application Data/Mixxx/" here for legacy.
             config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE));

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -27,8 +27,8 @@
 #include "library/trackcollection.h"
 #include "library/library_preferences.h"
 #include "util/math.h"
-#include "util/cmdlineargs.h"
 #include "configobject.h"
+#include "upgrade.h"
 
 
 Upgrade::Upgrade()

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -177,25 +177,25 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
 #ifdef __APPLE__
         qDebug() << "Config version is empty, trying to read pre-1.9.0 config";
         //Try to read the config from the pre-1.9.0 final directory on OS X (we moved it in 1.9.0 final)
-        QFile* oldFile = new QFile(QDir::homePath().append("/").append(".mixxx/mixxx.cfg"));
-        if (oldFile->exists()) {
+        QScopedPointer<QFile> oldConfigFile(new QFile(QDir::homePath().append("/").append(".mixxx/mixxx.cfg")));
+        if (oldConfigFile->exists()) {
             qDebug() << "Found pre-1.9.0 config for OS X";
             config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append(".mixxx/mixxx.cfg"));
             //Note: We changed SETTINGS_PATH in 1.9.0 final on OS X so it must be hardcoded to ".mixxx" here for legacy.
             configVersion = config->getValueString(ConfigKey("[Config]","Version"));
-            delete oldFile;
         }
         else {
 #elif __WINDOWS__
         qDebug() << "Config version is empty, trying to read pre-1.12.0 config";
         //Try to read the config from the pre-1.12.0 final directory on Windows (we moved it in 1.12.0 final)
-        QFile* oldFile = new QFile(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE));
-        if (oldFile->exists()) {
+        QScopedPointer<QFile> oldConfigFile(new QFile(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE)));
+        if (oldConfigFile->exists()) {
             qDebug() << "Found pre-1.12.0 config for Windows";
             config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE));
             //Note: We changed SETTINGS_PATH in 1.12.0 final on Windows so it must be hardcoded to "Local Settings/Application Data/Mixxx/" here for legacy.
             configVersion = config->getValueString(ConfigKey("[Config]","Version"));
-            delete oldFile;
+        }
+        else {
 #endif
             //This must have been the first run... right? :)
             qDebug() << "No version number in configuration file. Setting to" << VERSION;

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -177,28 +177,28 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
 
 #ifdef __APPLE__
         qDebug() << "Config version is empty, trying to read pre-1.9.0 config";
-        //Try to read the config from the pre-1.9.0 final directory on OS X (we moved it in 1.9.0 final)
+        // Try to read the config from the pre-1.9.0 final directory on OS X (we moved it in 1.9.0 final)
         QScopedPointer<QFile> oldConfigFile(new QFile(QDir::homePath().append("/").append(".mixxx/mixxx.cfg")));
         if (oldConfigFile->exists()) {
             qDebug() << "Found pre-1.9.0 config for OS X";
             config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append(".mixxx/mixxx.cfg"));
-            //Note: We changed SETTINGS_PATH in 1.9.0 final on OS X so it must be hardcoded to ".mixxx" here for legacy.
+            // Note: We changed SETTINGS_PATH in 1.9.0 final on OS X so it must be hardcoded to ".mixxx" here for legacy.
             configVersion = config->getValueString(ConfigKey("[Config]","Version"));
         }
         else {
 #elif __WINDOWS__
         qDebug() << "Config version is empty, trying to read pre-1.12.0 config";
-        //Try to read the config from the pre-1.12.0 final directory on Windows (we moved it in 1.12.0 final)
+        // Try to read the config from the pre-1.12.0 final directory on Windows (we moved it in 1.12.0 final)
         QScopedPointer<QFile> oldConfigFile(new QFile(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE)));
         if (oldConfigFile->exists()) {
             qDebug() << "Found pre-1.12.0 config for Windows";
             config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE));
-            //Note: We changed SETTINGS_PATH in 1.12.0 final on Windows so it must be hardcoded to "Local Settings/Application Data/Mixxx/" here for legacy.
+            // Note: We changed SETTINGS_PATH in 1.12.0 final on Windows so it must be hardcoded to "Local Settings/Application Data/Mixxx/" here for legacy.
             configVersion = config->getValueString(ConfigKey("[Config]","Version"));
         }
         else {
 #endif
-            //This must have been the first run... right? :)
+            // This must have been the first run... right? :)
             qDebug() << "No version number in configuration file. Setting to" << VERSION;
             config->set(ConfigKey("[Config]","Version"), ConfigValue(VERSION));
             m_bFirstRun = true;
@@ -234,10 +234,10 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
     }
     */
 
-    //We use the following blocks to detect if this is the first time
-    //you've run the latest version of Mixxx. This lets us show
-    //the promo tracks stats agreement stuff for all users that are
-    //upgrading Mixxx.
+    // We use the following blocks to detect if this is the first time
+    // you've run the latest version of Mixxx. This lets us show
+    // the promo tracks stats agreement stuff for all users that are
+    // upgrading Mixxx.
 
     if (configVersion.startsWith("1.7")) {
         qDebug() << "Upgrading from v1.7.x...";
@@ -276,12 +276,12 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
             qDebug() << "Moving" << curPair.first << "to" << curPair.second;
             QDir oldSubDir(curPair.first);
             QDir newSubDir(curPair.second);
-            newSubDir.mkpath(curPair.second); //Create the new destination directory
+            newSubDir.mkpath(curPair.second); // Create the new destination directory
 
             QStringList contents = oldSubDir.entryList(QDir::Files | QDir::NoDotAndDotDot);
             QStringListIterator it(contents);
             QString cur;
-            //Iterate over all the files in the source directory and copy them to the dest dir.
+            // Iterate over all the files in the source directory and copy them to the dest dir.
             while (it.hasNext())
             {
                 cur = it.next();
@@ -294,11 +294,11 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
                 }
             }
 
-            //Rename the old directory.
+            // Rename the old directory.
             newOSXDir.rename(OSXLocation180, OSXLocation180 + "-1.8");
         }
-        //Reload the configuration file from the new location.
-        //(We want to make sure we save to the new location...)
+        // Reload the configuration file from the new location.
+        // (We want to make sure we save to the new location...)
         config = new ConfigObject<ConfigValue>(settingsPath + SETTINGS_FILE);
 #endif
         configVersion = "1.9.0";
@@ -319,7 +319,7 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
         QStringList contents = oldDir.entryList(QDir::Files | QDir::NoDotAndDotDot);
         QStringListIterator it(contents);
         QString cur;
-        //Iterate over all the files in the source directory and copy them to the dest dir.
+        // Iterate over all the files in the source directory and copy them to the dest dir.
         while (it.hasNext()) {
             cur = it.next();
             if (newDir.exists(cur)) {

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -39,6 +39,17 @@ Upgrade::Upgrade()
 Upgrade::~Upgrade() {
 }
 
+// static 
+QString Upgrade::mixxx17HomePath() {
+#ifdef __LINUX__
+    return QDir::homePath().append("/").append(".mixxx/");
+#elif __WINDOWS__
+    return QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/");
+#elif __APPLE__
+    return QDir::homePath().append("/").append(".mixxx/");
+#endif
+}
+
 // We return the ConfigObject here because we have to make changes to the
 // configuration and the location of the file may change between releases.
 ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) {

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -27,6 +27,7 @@
 #include "library/trackcollection.h"
 #include "library/library_preferences.h"
 #include "util/math.h"
+#include "util/cmdlineargs.h"
 #include "configobject.h"
 #include "upgrade.h"
 
@@ -194,6 +195,7 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
             qDebug() << "Found pre-1.12.0 config for Windows";
             config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE));
             // Note: We changed SETTINGS_PATH in 1.12.0 final on Windows so it must be hardcoded to "Local Settings/Application Data/Mixxx/" here for legacy.
+            CmdlineArgs::setSettingsPath(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/")); // Just to have mixxx.log and soundconfig.xml in the right directory
             configVersion = config->getValueString(ConfigKey("[Config]","Version"));
         }
         else {

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -19,6 +19,7 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QTranslator>
+#include <QScopedPointer>
 
 #include "defs_version.h"
 #include "controllers/defs_controllers.h"

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -29,7 +29,6 @@
 #include "util/math.h"
 #include "util/cmdlineargs.h"
 #include "configobject.h"
-#include "upgrade.h"
 
 
 Upgrade::Upgrade()
@@ -195,7 +194,6 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
             qDebug() << "Found pre-1.12.0 config for Windows";
             config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE));
             // Note: We changed SETTINGS_PATH in 1.12.0 final on Windows so it must be hardcoded to "Local Settings/Application Data/Mixxx/" here for legacy.
-            CmdlineArgs::setSettingsPath(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/")); // Just to have mixxx.log and soundconfig.xml in the right directory
             configVersion = config->getValueString(ConfigKey("[Config]","Version"));
         }
         else {

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -169,7 +169,7 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
 ****************************************************************************/
 
     // Read the config file from home directory
-    ConfigObject<ConfigValue> *config = new ConfigObject<ConfigValue>(settingsPath + SETTINGS_FILE);
+    ConfigObject<ConfigValue> *config = new ConfigObject<ConfigValue>(settingsPath + "/" + SETTINGS_FILE);
 
     QString configVersion = config->getValueString(ConfigKey("[Config]","Version"));
 

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -175,6 +175,16 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
             delete oldFile;
         }
         else {
+#elif __WINDOWS__
+        qDebug() << "Config version is empty, trying to read pre-1.12.0 config";
+        //Try to read the config from the pre-1.12.0 final directory on Windows (we moved it in 1.12.0 final)
+        QFile* oldFile = new QFile(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE));
+        if (oldFile->exists()) {
+            qDebug() << "Found pre-1.12.0 config for Windows";
+            config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE));
+            //Note: We changed SETTINGS_PATH in 1.12.0 final on Windows so it must be hardcoded to "Local Settings/Application Data/Mixxx/" here for legacy.
+            configVersion = config->getValueString(ConfigKey("[Config]","Version"));
+            delete oldFile;
 #endif
             //This must have been the first run... right? :)
             qDebug() << "No version number in configuration file. Setting to" << VERSION;
@@ -182,6 +192,8 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
             m_bFirstRun = true;
             return config;
 #ifdef __APPLE__
+        }
+#elif __WINDOWS__
         }
 #endif
     }

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -27,6 +27,7 @@
 #include "library/trackcollection.h"
 #include "library/library_preferences.h"
 #include "util/math.h"
+#include "util/cmdlineargs.h"
 #include "configobject.h"
 #include "upgrade.h"
 
@@ -181,8 +182,10 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
         QScopedPointer<QFile> oldConfigFile(new QFile(QDir::homePath().append("/").append(".mixxx/mixxx.cfg")));
         if (oldConfigFile->exists()) {
             qDebug() << "Found pre-1.9.0 config for OS X";
-            config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append(".mixxx/mixxx.cfg"));
             // Note: We changed SETTINGS_PATH in 1.9.0 final on OS X so it must be hardcoded to ".mixxx" here for legacy.
+            config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append(".mixxx/mixxx.cfg"));
+            // Just to be sure all files like logs and soundconfig go with mixxx.cfg
+            CmdlineArgs::Instance().setSettingsPath(QDir::homePath().append("/").append(".mixxx/mixxx.cfg"));
             configVersion = config->getValueString(ConfigKey("[Config]","Version"));
         }
         else {
@@ -192,8 +195,10 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
         QScopedPointer<QFile> oldConfigFile(new QFile(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE)));
         if (oldConfigFile->exists()) {
             qDebug() << "Found pre-1.12.0 config for Windows";
-            config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE));
             // Note: We changed SETTINGS_PATH in 1.12.0 final on Windows so it must be hardcoded to "Local Settings/Application Data/Mixxx/" here for legacy.
+            config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append(SETTINGS_FILE));
+            // Just to be sure all files like logs and soundconfig go with mixxx.cfg
+            CmdlineArgs::Instance().setSettingsPath(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/")); 
             configVersion = config->getValueString(ConfigKey("[Config]","Version"));
         }
         else {

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -299,7 +299,7 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
         }
         // Reload the configuration file from the new location.
         // (We want to make sure we save to the new location...)
-        config = new ConfigObject<ConfigValue>(settingsPath + SETTINGS_FILE);
+        config = new ConfigObject<ConfigValue>(settingsPath + "/" + SETTINGS_FILE);
 #endif
         configVersion = "1.9.0";
         config->set(ConfigKey("[Config]","Version"), ConfigValue("1.9.0"));

--- a/src/upgrade.h
+++ b/src/upgrade.h
@@ -24,6 +24,7 @@ class Upgrade
         Upgrade();
         ~Upgrade();
         ConfigObject<ConfigValue>* versionUpgrade(const QString& settingsPath);
+        static QString mixxx17HomePath();
         bool isFirstRun() { return m_bFirstRun; };
         bool isUpgraded() { return m_bUpgraded; };
         bool rescanLibrary() {return m_bRescanLibrary; };

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -72,7 +72,7 @@ class CmdlineArgs {
         m_midiDebug(false),
         m_developer(false),
         m_safeMode(false),
-        m_settingsPath(QDesktopServices::storageLocation(QDesktopServices::DataLocation)) {
+        m_settingsPath(QDesktopServices::storageLocation(QDesktopServices::DataLocation).append("/")) {
     }
     ~CmdlineArgs() { };
 

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -62,7 +62,6 @@ class CmdlineArgs {
     bool getTimelineEnabled() const { return !m_timelinePath.isEmpty(); }
     const QString& getLocale() const { return m_locale; }
     const QString& getSettingsPath() const { return m_settingsPath; }
-    const QString& setSettingsPath(QString newSettingsPath) const { return m_settingsPath=newSettingsPath; }
     const QString& getResourcePath() const { return m_resourcePath; }
     const QString& getPluginPath() const { return m_pluginPath; }
     const QString& getTimelinePath() const { return m_timelinePath; }

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -68,7 +68,7 @@ class CmdlineArgs {
 
   private:
     CmdlineArgs() :
-        m_startInFullscreen(false), //Initialize vars
+        m_startInFullscreen(false), // Initialize vars
         m_midiDebug(false),
         m_developer(false),
         m_safeMode(false),
@@ -76,8 +76,8 @@ class CmdlineArgs {
     }
     ~CmdlineArgs() { };
 
-    QList<QString> m_musicFiles;    /* List of files to load into players at startup */
-    bool m_startInFullscreen;       /* Start in fullscreen mode */
+    QList<QString> m_musicFiles;    // List of files to load into players at startup
+    bool m_startInFullscreen;       // Start in fullscreen mode
     bool m_midiDebug;
     bool m_developer; // Developer Mode
     bool m_safeMode;

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -71,7 +71,7 @@ class CmdlineArgs {
         m_midiDebug(false),
         m_developer(false),
         m_safeMode(false),
-        m_settingsPath(QDir::homePath().append("/").append(SETTINGS_PATH)) {
+        m_settingsPath(QDesktopServices::storageLocation(QDesktopServices::DataLocation)) {
     }
     ~CmdlineArgs() { };
 

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -72,10 +72,11 @@ class CmdlineArgs {
         m_midiDebug(false),
         m_developer(false),
         m_safeMode(false),
-#ifdef __WINDOWS__
-        m_settingsPath(QDesktopServices::storageLocation(QDesktopServices::DataLocation).append("/")) {
-#else
+// We are not ready to switch to XDG folders under Linux, so keeping $HOME/.mixxx as preferences folder. see lp:1463273
+#ifdef __LINUX__
         m_settingsPath(QDir::homePath().append("/").append(SETTINGS_PATH)) {
+#else
+        m_settingsPath(QDesktopServices::storageLocation(QDesktopServices::DataLocation).append("/")) {
 #endif
     }
     ~CmdlineArgs() { };

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -62,6 +62,7 @@ class CmdlineArgs {
     bool getTimelineEnabled() const { return !m_timelinePath.isEmpty(); }
     const QString& getLocale() const { return m_locale; }
     const QString& getSettingsPath() const { return m_settingsPath; }
+    void setSettingsPath(QString newSettingsPath) { m_settingsPath=QString(newSettingsPath); return; }
     const QString& getResourcePath() const { return m_resourcePath; }
     const QString& getPluginPath() const { return m_pluginPath; }
     const QString& getTimelinePath() const { return m_timelinePath; }

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -72,8 +72,8 @@ class CmdlineArgs {
         m_midiDebug(false),
         m_developer(false),
         m_safeMode(false),
-        m_settingsPath(QDesktopServices::storageLocation(QDesktopServices::DataLocation)) {
-    }
+        m_settingsPath(QDesktopServices::storageLocation(QDesktopServices::DataLocation).append("/").append(SETTINGS_DIR)) {
+        }
     ~CmdlineArgs() { };
 
     QList<QString> m_musicFiles;    // List of files to load into players at startup

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -30,6 +30,7 @@ class CmdlineArgs {
                 m_settingsPath = QString::fromLocal8Bit(argv[i+1]);
                 if (!m_settingsPath.endsWith("/")) {
                     m_settingsPath.append("/");
+                    m_settingsPathSet=true;
                 }
             } else if (argv[i] == QString("--resourcePath") && i+1 < argc) {
                 m_resourcePath = QString::fromLocal8Bit(argv[i+1]);
@@ -59,6 +60,7 @@ class CmdlineArgs {
     bool getMidiDebug() const { return m_midiDebug; }
     bool getDeveloper() const { return m_developer; }
     bool getSafeMode() const { return m_safeMode; }
+    bool getSettingsPathSet() const { return m_settingsPathSet; }
     bool getTimelineEnabled() const { return !m_timelinePath.isEmpty(); }
     const QString& getLocale() const { return m_locale; }
     const QString& getSettingsPath() const { return m_settingsPath; }
@@ -73,6 +75,7 @@ class CmdlineArgs {
         m_midiDebug(false),
         m_developer(false),
         m_safeMode(false),
+        m_settingsPathSet(false),
 // We are not ready to switch to XDG folders under Linux, so keeping $HOME/.mixxx as preferences folder. see lp:1463273
 #ifdef __LINUX__
         m_settingsPath(QDir::homePath().append("/").append(SETTINGS_PATH)) {
@@ -87,6 +90,7 @@ class CmdlineArgs {
     bool m_midiDebug;
     bool m_developer; // Developer Mode
     bool m_safeMode;
+    bool m_settingsPathSet; // has --settingsPath been set on command line ?
     QString m_locale;
     QString m_settingsPath;
     QString m_resourcePath;

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -4,6 +4,7 @@
 #include <QList>
 #include <QString>
 #include <QDir>
+#include <QDesktopServices>
 
 // A structure to store the parsed command-line arguments
 class CmdlineArgs {

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -30,8 +30,8 @@ class CmdlineArgs {
                 m_settingsPath = QString::fromLocal8Bit(argv[i+1]);
                 if (!m_settingsPath.endsWith("/")) {
                     m_settingsPath.append("/");
-                    m_settingsPathSet=true;
                 }
+                m_settingsPathSet=true;
             } else if (argv[i] == QString("--resourcePath") && i+1 < argc) {
                 m_resourcePath = QString::fromLocal8Bit(argv[i+1]);
                 i++;

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -72,8 +72,8 @@ class CmdlineArgs {
         m_midiDebug(false),
         m_developer(false),
         m_safeMode(false),
-        m_settingsPath(QDesktopServices::storageLocation(QDesktopServices::DataLocation).append("/").append(SETTINGS_DIR)) {
-        }
+        m_settingsPath(QDesktopServices::storageLocation(QDesktopServices::DataLocation)) {
+    }
     ~CmdlineArgs() { };
 
     QList<QString> m_musicFiles;    // List of files to load into players at startup

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -62,6 +62,7 @@ class CmdlineArgs {
     bool getTimelineEnabled() const { return !m_timelinePath.isEmpty(); }
     const QString& getLocale() const { return m_locale; }
     const QString& getSettingsPath() const { return m_settingsPath; }
+    const QString& setSettingsPath(QString newSettingsPath) const { return m_settingsPath=newSettingsPath; }
     const QString& getResourcePath() const { return m_resourcePath; }
     const QString& getPluginPath() const { return m_pluginPath; }
     const QString& getTimelinePath() const { return m_timelinePath; }
@@ -72,7 +73,11 @@ class CmdlineArgs {
         m_midiDebug(false),
         m_developer(false),
         m_safeMode(false),
+#ifdef __WINDOWS__
         m_settingsPath(QDesktopServices::storageLocation(QDesktopServices::DataLocation).append("/")) {
+#else
+        m_settingsPath(QDir::homePath().append("/").append(SETTINGS_PATH)) {
+#endif
     }
     ~CmdlineArgs() { };
 


### PR DESCRIPTION
This PR is to address bugs https://bugs.launchpad.net/mixxx/+bug/695235 and https://bugs.launchpad.net/mixxx/+bug/907192

It uses QT's QDesktopServices::storageLocation(QDesktopServices::DataLocation) on Mac OSX and Windows. Linux is treated as a special case, using old $HOME/.mixxx location.

It works the following way:
- If --settingsPath is provided on the command line, use the provided path regardless if there is a preference folder elsewhere
- If there is a preference folder at the new location, use this one
- If there is no preference folder at the new location, but we find one at the old location, use the one at the old location (no change for former users)
- If we can't find a preference folder at all, create a new one at the new location

Manually tested on:
- French Windows seven 64 bits: @sblaisot
- German Windows XP 32 bits: @daschuer 
- US English Windows XP 64 bits: @Pegasus-RPG (to be confirmed)
- Mac OSX: @rryan (to be confirmed)

I also corrected an old TODO for pre-1.7 library compatibility.
