### PR TITLE
correctly destroy ValueTransformer

### DIFF
--- a/src/util/valuetransformer.cpp
+++ b/src/util/valuetransformer.cpp
@@ -56,3 +56,9 @@ ValueTransformer* ValueTransformer::parseFromXml(QDomElement transformElement,
 
     return pTransformer;
 }
+
+ValueTransformer::~ValueTransformer() {
+    foreach (TransformNode* node, m_transformers) {
+        delete node;
+    }
+}

--- a/src/util/valuetransformer.h
+++ b/src/util/valuetransformer.h
@@ -9,6 +9,7 @@
 class TransformNode {
   public:
     TransformNode() {}
+    virtual ~TransformNode() {}
 
     virtual double transform(double argument) const = 0;
     virtual double transformInverse(double argument) const = 0;
@@ -58,6 +59,7 @@ class TransformNot : public TransformNode {
 
 class ValueTransformer {
   public:
+    ~ValueTransformer();
     double transform(double argument) const;
     double transformInverse(double argument) const;
 


### PR DESCRIPTION
I tried to have a look at [1459419](https://bugs.launchpad.net/mixxx/+bug/1459419). This is a bit tricky since mixxx crashes inside valgrind when I want to change a skin. Most of the leaks I see in the trace are due to the libraries we use (about half is in the graphics stack for me). 

But from what I saw in the future we can get rid of some warning switching to std::shared_ptr and std::unique_ptr.

valgrind complained that we lost a few bytes here because the
allocated transformers were never released.

Valgrind Error Message

==14766== 16 bytes in 2 blocks are definitely lost in loss record 8,831 of 108,745
==14766==    at 0x4C29180: operator new(unsigned long) (vg_replace_malloc.c:324)
==14766==    by 0xB86505: ValueTransformer::parseFromXml(QDomElement, SkinContext const&) (valuetransformer.cpp:53)
==14766==    by 0xACB946: LegacySkinParser::setupConnections(QDomNode, WBaseWidget_) (legacyskinparser.cpp:1830)
==14766==    by 0xAD05C3: LegacySkinParser::commonWidgetSetup(QDomNode, WBaseWidget_, bool) [clone .constprop.70](legacyskinparser.cpp:1760)
==14766==    by 0xAD578E: LegacySkinParser::parseWidgetGroup(QDomElement) (legacyskinparser.cpp:579)
==14766==    by 0xAD4935: LegacySkinParser::parseNode(QDomElement) (legacyskinparser.cpp:501)
==14766==    by 0xAD58BA: LegacySkinParser::parseWidgetGroup(QDomElement) (legacyskinparser.cpp:594)
==14766==    by 0xAD4935: LegacySkinParser::parseNode(QDomElement) (legacyskinparser.cpp:501)
==14766==    by 0xAD6B54: LegacySkinParser::parseSizeAwareStack(QDomElement) (legacyskinparser.cpp:737)
==14766==    by 0xAD4A6B: LegacySkinParser::parseNode(QDomElement) (legacyskinparser.cpp:505)
==14766==    by 0xAD7778: LegacySkinParser::parseTemplate(QDomElement) (legacyskinparser.cpp:1462)
==14766==    by 0xAD519F: LegacySkinParser::parseNode(QDomElement) (legacyskinparser.cpp:529)
