### PR TITLE
[OBSOLETE] Workaround: Simplified std::make_unique() function (from C++14)

### DIFF
--- a/src/util/memory.h
+++ b/src/util/memory.h
@@ -1,0 +1,16 @@
+#ifndef MIXXX_UTIL_MEMORY_H
+#define MIXXX_UTIL_MEMORY_H
+
+#include <memory>
+
+// Temporary workaround for the missing make_unique() template function
+// in C++11 that will be available in C++14. Please note that this
+// simplified version does not work for arrays!
+namespace std {
+    template<typename T, typename ...Args>
+    inline unique_ptr<T> make_unique(Args&& ...args) {
+        return unique_ptr<T>(new T(forward<Args>(args) ...));
+    }
+}
+
+#endif // MIXXX_UTIL_MEMORY_H


### PR DESCRIPTION
std::make_unique() is extremely helpful to improve the readability of the
code when working with std::unique_ptr. Unfortunately it is not available
in C+11, but will be introduced with C++14.

This is only a simplified workaround. Anyone who has more experience with the multi-platform build or other
system dependent workarounds in Mixxx might like to improve it. I'm even unsure if this prototype compiles
on all platform. I just need something quickly that is ready to use :)
