### PR TITLE
QueryNode: Memory leak fix + refactoring

### DIFF
--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -393,7 +393,7 @@ void BaseTrackCache::filterAndSort(const QSet<int>& trackIds,
         }
     }
 
-    QScopedPointer<QueryNode> pQuery(parseQuery(
+    std::unique_ptr<QueryNode> pQuery(parseQuery(
         searchQuery, extraFilter, idStrings));
 
     QString filter = pQuery->toSql();
@@ -512,7 +512,7 @@ void BaseTrackCache::filterAndSort(const QSet<int>& trackIds,
     }
 }
 
-QueryNode* BaseTrackCache::parseQuery(QString query, QString extraFilter,
+std::unique_ptr<QueryNode> BaseTrackCache::parseQuery(QString query, QString extraFilter,
                                       QStringList idStrings) const {
     QStringList queryFragments;
     if (!extraFilter.isNull() && extraFilter != "") {

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -4,8 +4,6 @@
 #ifndef BASETRACKCACHE_H
 #define BASETRACKCACHE_H
 
-#include <memory>
-
 #include <QList>
 #include <QObject>
 #include <QSet>
@@ -19,6 +17,7 @@
 #include "library/columncache.h"
 #include "trackinfoobject.h"
 #include "util.h"
+#include "util/memory.h"
 
 class SearchQueryParser;
 class QueryNode;

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -4,6 +4,8 @@
 #ifndef BASETRACKCACHE_H
 #define BASETRACKCACHE_H
 
+#include <memory>
+
 #include <QList>
 #include <QObject>
 #include <QSet>
@@ -83,7 +85,7 @@ class BaseTrackCache : public QObject {
     void getTrackValueForColumn(TrackPointer pTrack, int column,
                                 QVariant& trackValue) const;
 
-    QueryNode* parseQuery(QString query, QString extraFilter,
+    std::unique_ptr<QueryNode> parseQuery(QString query, QString extraFilter,
                           QStringList idStrings) const;
     int findSortInsertionPoint(TrackPointer pTrack,
                                const int sortColumn,

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -107,6 +107,10 @@ NotNode::NotNode(QueryNode* pNode)
         : m_pNode(pNode) {
 }
 
+NotNode::~NotNode() {
+    delete m_pNode;
+}
+
 bool NotNode::match(const TrackPointer& pTrack) const {
     if (m_pNode != NULL) {
         return !m_pNode->match(pTrack);

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -57,11 +57,11 @@ QVariant getTrackValueForColumn(const TrackPointer& pTrack, const QString& colum
 }
 
 bool AndNode::match(const TrackPointer& pTrack) const {
-    if (m_nodes.isEmpty()) {
+    if (m_nodes.empty()) {
         return true;
     }
 
-    foreach (const QueryNode* pNode, m_nodes) {
+    for (const auto& pNode: m_nodes) {
         if (!pNode->match(pTrack)) {
             return false;
         }
@@ -71,7 +71,7 @@ bool AndNode::match(const TrackPointer& pTrack) const {
 
 QString AndNode::toSql() const {
     QStringList queryFragments;
-    foreach (const QueryNode* pNode, m_nodes) {
+    for (const auto& pNode: m_nodes) {
         QString sql = pNode->toSql();
         if (!sql.isEmpty()) {
             queryFragments << sql;
@@ -81,10 +81,10 @@ QString AndNode::toSql() const {
 }
 
 bool OrNode::match(const TrackPointer& pTrack) const {
-    if (m_nodes.isEmpty()) {
+    if (m_nodes.empty()) {
         return true;
     }
-    foreach (const QueryNode* pNode, m_nodes) {
+    for (const auto& pNode: m_nodes) {
         if (pNode->match(pTrack)) {
             return true;
         }
@@ -94,7 +94,7 @@ bool OrNode::match(const TrackPointer& pTrack) const {
 
 QString OrNode::toSql() const {
     QStringList queryFragments;
-    foreach (const QueryNode* pNode, m_nodes) {
+    for (const auto& pNode: m_nodes) {
         QString sql = pNode->toSql();
         if (!sql.isEmpty()) {
             queryFragments << sql;
@@ -103,19 +103,8 @@ QString OrNode::toSql() const {
     return queryFragments.join(" OR ");
 }
 
-NotNode::NotNode(QueryNode* pNode)
-        : m_pNode(pNode) {
-}
-
-NotNode::~NotNode() {
-    delete m_pNode;
-}
-
 bool NotNode::match(const TrackPointer& pTrack) const {
-    if (m_pNode != NULL) {
-        return !m_pNode->match(pTrack);
-    }
-    return false;
+    return !m_pNode->match(pTrack);
 }
 
 QString NotNode::toSql() const {

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -143,8 +143,7 @@ QString TextFilterNode::toSql() const {
             searchClauses.at(0);
 }
 
-NumericFilterNode::NumericFilterNode(const QStringList& sqlColumns,
-                                     QString argument)
+NumericFilterNode::NumericFilterNode(const QStringList& sqlColumns)
         : m_sqlColumns(sqlColumns),
           m_bOperatorQuery(false),
           m_operator("="),
@@ -152,6 +151,11 @@ NumericFilterNode::NumericFilterNode(const QStringList& sqlColumns,
           m_bRangeQuery(false),
           m_dRangeLow(0.0),
           m_dRangeHigh(0.0) {
+}
+
+NumericFilterNode::NumericFilterNode(
+        const QStringList& sqlColumns, const QString& argument)
+        : NumericFilterNode(sqlColumns) {
     init(argument);
 }
 
@@ -184,16 +188,6 @@ void NumericFilterNode::init(QString argument) {
 
 double NumericFilterNode::parse(const QString& arg, bool *ok) {
     return arg.toDouble(ok);
-}
-
-NumericFilterNode::NumericFilterNode(const QStringList& sqlColumns)
-        : m_sqlColumns(sqlColumns),
-          m_bOperatorQuery(false),
-          m_operator("="),
-          m_dOperatorArgument(0.0),
-          m_bRangeQuery(false),
-          m_dRangeLow(0.0),
-          m_dRangeHigh(0.0) {
 }
 
 bool NumericFilterNode::match(const TrackPointer& pTrack) const {
@@ -248,9 +242,11 @@ QString NumericFilterNode::toSql() const {
     return QString();
 }
 
-DurationFilterNode::DurationFilterNode(const QStringList& sqlColumns,
-                                       QString argument)
+DurationFilterNode::DurationFilterNode(
+        const QStringList& sqlColumns, const QString& argument)
         : NumericFilterNode(sqlColumns) {
+    // init() has to be called from this class directly to invoke
+    // the implementation of this and not that of the base class!
     init(argument);
 }
 

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -56,32 +56,52 @@ QVariant getTrackValueForColumn(const TrackPointer& pTrack, const QString& colum
     return QVariant();
 }
 
-bool AndNode::match(const TrackPointer& pTrack) const {
-    if (m_nodes.empty()) {
-        return true;
+//static
+QString QueryNode::concatSqlClauses(
+        const QStringList& sqlClauses, const QString& sqlConcatOp) {
+    switch (sqlClauses.size()) {
+    case 0:
+        return QString();
+    case 1:
+        return sqlClauses.front();
+    default:
+        // The component terms need to be wrapped into parantheses,
+        // but the whole expression does not. The composite node is
+        // always responsible for proper wrapping into parantheses!
+        return "(" % sqlClauses.join(") " % sqlConcatOp % " (") % ")";
     }
+}
 
+bool AndNode::match(const TrackPointer& pTrack) const {
     for (const auto& pNode: m_nodes) {
         if (!pNode->match(pTrack)) {
             return false;
         }
     }
+    // An empty AND node always evaluates to true! This
+    // is consistent with the generated SQL query.
     return true;
 }
 
 QString AndNode::toSql() const {
     QStringList queryFragments;
+    queryFragments.reserve(m_nodes.size());
     for (const auto& pNode: m_nodes) {
         QString sql = pNode->toSql();
         if (!sql.isEmpty()) {
             queryFragments << sql;
         }
     }
-    return queryFragments.join(" AND ");
+    return concatSqlClauses(queryFragments, "AND");
 }
 
 bool OrNode::match(const TrackPointer& pTrack) const {
-    if (m_nodes.empty()) {
+    // An empty OR node would always evaluate to false
+    // which is inconsistent with the generated SQL query!
+    DEBUG_ASSERT_AND_HANDLE(!m_nodes.empty()) {
+        // Evaluate to true even if the correct choice would
+        // be false to keep the evaluation consistent with
+        // the generated SQL query.
         return true;
     }
     for (const auto& pNode: m_nodes) {
@@ -94,13 +114,14 @@ bool OrNode::match(const TrackPointer& pTrack) const {
 
 QString OrNode::toSql() const {
     QStringList queryFragments;
+    queryFragments.reserve(m_nodes.size());
     for (const auto& pNode: m_nodes) {
         QString sql = pNode->toSql();
         if (!sql.isEmpty()) {
             queryFragments << sql;
         }
     }
-    return queryFragments.join(" OR ");
+    return concatSqlClauses(queryFragments, "OR");
 }
 
 bool NotNode::match(const TrackPointer& pTrack) const {
@@ -108,15 +129,19 @@ bool NotNode::match(const TrackPointer& pTrack) const {
 }
 
 QString NotNode::toSql() const {
-    QString sql = m_pNode->toSql();
-    if (!sql.isEmpty()) {
-        return sql.prepend("NOT ");
+    QString sql(m_pNode->toSql());
+    if (sql.isEmpty()) {
+        return QString();
+    } else {
+        // The component term needs to be wrapped into parantheses,
+        // but the whole expression does not. The composite node is
+        // always responsible for proper wrapping into parantheses!
+        return "NOT (" % sql % ")";
     }
-    return QString();
 }
 
 bool TextFilterNode::match(const TrackPointer& pTrack) const {
-    foreach (QString sqlColumn, m_sqlColumns) {
+    for (const auto& sqlColumn: m_sqlColumns) {
         QVariant value = getTrackValueForColumn(pTrack, sqlColumn);
         if (!value.isValid() || !qVariantCanConvert<QString>(value)) {
             continue;
@@ -134,13 +159,10 @@ QString TextFilterNode::toSql() const {
     QString escapedArgument = escaper.escapeString("%" + m_argument + "%");
 
     QStringList searchClauses;
-    foreach (QString sqlColumn, m_sqlColumns) {
-        searchClauses << QString("(%1 LIKE %2)").arg(sqlColumn, escapedArgument);
+    for (const auto& sqlColumn: m_sqlColumns) {
+        searchClauses << QString("%1 LIKE %2").arg(sqlColumn, escapedArgument);
     }
-
-    return searchClauses.length() > 1 ?
-            QString("(%1)").arg(searchClauses.join(" OR ")) :
-            searchClauses.at(0);
+    return concatSqlClauses(searchClauses, "OR");
 }
 
 NumericFilterNode::NumericFilterNode(const QStringList& sqlColumns)
@@ -191,7 +213,7 @@ double NumericFilterNode::parse(const QString& arg, bool *ok) {
 }
 
 bool NumericFilterNode::match(const TrackPointer& pTrack) const {
-    foreach (QString sqlColumn, m_sqlColumns) {
+    for (const auto& sqlColumn: m_sqlColumns) {
         QVariant value = getTrackValueForColumn(pTrack, sqlColumn);
         if (!value.isValid() || !qVariantCanConvert<double>(value)) {
             continue;
@@ -217,26 +239,24 @@ bool NumericFilterNode::match(const TrackPointer& pTrack) const {
 QString NumericFilterNode::toSql() const {
     if (m_bOperatorQuery) {
         QStringList searchClauses;
-        foreach (const QString& sqlColumn, m_sqlColumns) {
-            searchClauses << QString("(%1 %2 %3)").arg(
+        for (const auto& sqlColumn: m_sqlColumns) {
+            searchClauses << QString("%1 %2 %3").arg(
                 sqlColumn, m_operator, QString::number(m_dOperatorArgument));
         }
-        return searchClauses.length() > 1 ?
-                QString("(%1)").arg(searchClauses.join(" OR ")) :
-                searchClauses[0];
+        return concatSqlClauses(searchClauses, "OR");
     }
 
     if (m_bRangeQuery) {
         QStringList searchClauses;
-        foreach (const QString& sqlColumn, m_sqlColumns) {
-            searchClauses << QString("(%1 >= %2 AND %1 <= %3)")
-                    .arg(sqlColumn, QString::number(m_dRangeLow),
-                         QString::number(m_dRangeHigh));
+        for (const auto& sqlColumn: m_sqlColumns) {
+            QStringList rangeClauses;
+            rangeClauses << QString("%1 >= %2").arg(
+                    sqlColumn, QString::number(m_dRangeLow));
+            rangeClauses << QString("%1 <= %2").arg(
+                    sqlColumn, QString::number(m_dRangeHigh));
+            searchClauses << concatSqlClauses(rangeClauses, "AND");
         }
-
-        return searchClauses.length() > 1 ?
-                QString("(%1)").arg(searchClauses.join(" OR ")) :
-                searchClauses[0];
+        return concatSqlClauses(searchClauses, "OR");
     }
 
     return QString();
@@ -295,11 +315,8 @@ bool KeyFilterNode::match(const TrackPointer& pTrack) const {
 
 QString KeyFilterNode::toSql() const {
     QStringList searchClauses;
-    foreach (mixxx::track::io::key::ChromaticKey match, m_matchKeys) {
-        searchClauses << QString("(key_id IS %1)").arg(QString::number(match));
+    for (const auto& matchKey: m_matchKeys) {
+        searchClauses << QString("key_id IS %1").arg(QString::number(matchKey));
     }
-
-    return searchClauses.length() > 1 ?
-            QString("(%1)").arg(searchClauses.join(" OR ")) :
-            searchClauses[0];
+    return concatSqlClauses(searchClauses, "OR");
 }

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -26,6 +26,8 @@ class QueryNode {
 
   protected:
     QueryNode() {}
+
+    static QString concatSqlClauses(const QStringList& sqlClauses, const QString& sqlConcatOp);
 };
 
 class GroupNode : public QueryNode {
@@ -138,8 +140,10 @@ class KeyFilterNode : public QueryNode {
 class SqlNode : public QueryNode {
   public:
     explicit SqlNode(const QString& sqlExpression)
-            // Need to wrap it since we don't know if the caller wrapped it.
-            : m_sql(QString("(%1)").arg(sqlExpression)) {
+            // No need to wrap into parantheses here! This will be done
+            // later in toSql() if this node is a component of another
+            // composite node.
+            : m_sql(sqlExpression) {
     }
 
     bool match(const TrackPointer& pTrack) const override {

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -44,16 +44,12 @@ class GroupNode : public QueryNode {
 
 class OrNode : public GroupNode {
   public:
-    OrNode() {}
-
     bool match(const TrackPointer& pTrack) const;
     QString toSql() const;
 };
 
 class AndNode : public GroupNode {
   public:
-    AndNode() {}
-
     bool match(const TrackPointer& pTrack) const;
     QString toSql() const;
 };
@@ -135,7 +131,6 @@ class SqlNode : public QueryNode {
             // Need to wrap it since we don't know if the caller wrapped it.
             : m_sql(QString("(%1)").arg(sqlExpression)) {
     }
-    virtual ~SqlNode() {}
 
     bool match(const TrackPointer& pTrack) const {
         // We are usually embedded in an AND node so if we don't match

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -1,7 +1,6 @@
 #ifndef SEARCHQUERY_H
 #define SEARCHQUERY_H
 
-#include <memory>
 #include <vector>
 
 #include <QList>
@@ -13,6 +12,7 @@
 #include "trackinfoobject.h"
 #include "proto/keys.pb.h"
 #include "util/assert.h"
+#include "util/memory.h"
 
 QVariant getTrackValueForColumn(const TrackPointer& pTrack, const QString& column);
 

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -57,7 +57,7 @@ class AndNode : public GroupNode {
 class NotNode : public QueryNode {
   public:
     explicit NotNode(QueryNode* pNode);
-    ~NotNode();
+    virtual ~NotNode();
 
     bool match(const TrackPointer& pTrack) const;
     QString toSql() const;

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -89,14 +89,24 @@ class TextFilterNode : public QueryNode {
 
 class NumericFilterNode : public QueryNode {
   public:
-    NumericFilterNode(const QStringList& sqlColumns, QString argument);
-    NumericFilterNode(const QStringList& sqlColumns);
+    NumericFilterNode(const QStringList& sqlColumns, const QString& argument);
+
     bool match(const TrackPointer& pTrack) const override;
     QString toSql() const override;
 
   protected:
-    virtual void init(QString argument);
+    // Single argument constructor for that does not call init()
+    explicit NumericFilterNode(const QStringList& sqlColumns);
+
+    // init() must always be called in the constructor of the
+    // most derived class directly, because internally it calls
+    // the virtual function parse() that will be overridden by
+    // derived classes.
+    void init(QString argument);
+
+  private:
     virtual double parse(const QString& arg, bool *ok);
+
     QStringList m_sqlColumns;
     bool m_bOperatorQuery;
     QString m_operator;
@@ -108,7 +118,7 @@ class NumericFilterNode : public QueryNode {
 
 class DurationFilterNode : public NumericFilterNode {
   public:
-    DurationFilterNode(const QStringList& sqlColumns, QString argument);
+    DurationFilterNode(const QStringList& sqlColumns, const QString& argument);
 
   private:
     double parse(const QString& arg, bool* ok) override;

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -57,6 +57,7 @@ class AndNode : public GroupNode {
 class NotNode : public QueryNode {
   public:
     explicit NotNode(QueryNode* pNode);
+    ~NotNode();
 
     bool match(const TrackPointer& pTrack) const;
     QString toSql() const;

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -44,14 +44,14 @@ class GroupNode : public QueryNode {
 
 class OrNode : public GroupNode {
   public:
-    bool match(const TrackPointer& pTrack) const;
-    QString toSql() const;
+    bool match(const TrackPointer& pTrack) const override;
+    QString toSql() const override;
 };
 
 class AndNode : public GroupNode {
   public:
-    bool match(const TrackPointer& pTrack) const;
-    QString toSql() const;
+    bool match(const TrackPointer& pTrack) const override;
+    QString toSql() const override;
 };
 
 class NotNode : public QueryNode {
@@ -61,8 +61,8 @@ class NotNode : public QueryNode {
         DEBUG_ASSERT(m_pNode);
     }
 
-    bool match(const TrackPointer& pTrack) const;
-    QString toSql() const;
+    bool match(const TrackPointer& pTrack) const override;
+    QString toSql() const override;
 
   private:
     std::unique_ptr<QueryNode> m_pNode;
@@ -78,8 +78,8 @@ class TextFilterNode : public QueryNode {
               m_argument(argument) {
     }
 
-    bool match(const TrackPointer& pTrack) const;
-    QString toSql() const;
+    bool match(const TrackPointer& pTrack) const override;
+    QString toSql() const override;
 
   private:
     QSqlDatabase m_database;
@@ -91,8 +91,8 @@ class NumericFilterNode : public QueryNode {
   public:
     NumericFilterNode(const QStringList& sqlColumns, QString argument);
     NumericFilterNode(const QStringList& sqlColumns);
-    bool match(const TrackPointer& pTrack) const;
-    QString toSql() const;
+    bool match(const TrackPointer& pTrack) const override;
+    QString toSql() const override;
 
   protected:
     virtual void init(QString argument);
@@ -111,15 +111,15 @@ class DurationFilterNode : public NumericFilterNode {
     DurationFilterNode(const QStringList& sqlColumns, QString argument);
 
   private:
-    virtual double parse(const QString& arg, bool* ok);
+    double parse(const QString& arg, bool* ok) override;
 };
 
 class KeyFilterNode : public QueryNode {
   public:
     KeyFilterNode(mixxx::track::io::key::ChromaticKey key, bool fuzzy);
 
-    bool match(const TrackPointer& pTrack) const;
-    QString toSql() const;
+    bool match(const TrackPointer& pTrack) const override;
+    QString toSql() const override;
 
   private:
     QList<mixxx::track::io::key::ChromaticKey> m_matchKeys;
@@ -132,14 +132,14 @@ class SqlNode : public QueryNode {
             : m_sql(QString("(%1)").arg(sqlExpression)) {
     }
 
-    bool match(const TrackPointer& pTrack) const {
+    bool match(const TrackPointer& pTrack) const override {
         // We are usually embedded in an AND node so if we don't match
         // everything then we block everything.
         Q_UNUSED(pTrack);
         return true;
     }
 
-    QString toSql() const {
+    QString toSql() const override {
         return m_sql;
     }
 

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -192,7 +192,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
 std::unique_ptr<QueryNode> SearchQueryParser::parseQuery(const QString& query,
                                          const QStringList& searchColumns,
                                          const QString& extraFilter) const {
-    std::unique_ptr<QueryNode> pQuery(std::make_unique<AndNode>());
+    auto pQuery(std::make_unique<AndNode>());
 
     if (!extraFilter.isEmpty()) {
         pQuery->addNode(std::make_unique<SqlNode>(extraFilter));
@@ -203,5 +203,5 @@ std::unique_ptr<QueryNode> SearchQueryParser::parseQuery(const QString& query,
         parseTokens(tokens, searchColumns, pQuery.get());
     }
 
-    return pQuery;
+    return std::move(pQuery);
 }

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -118,11 +118,10 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                 m_textFilterMatcher.cap(2), &tokens).trimmed();
 
             if (!argument.isEmpty()) {
-                std::unique_ptr<QueryNode> pNode(new TextFilterNode(
+                std::unique_ptr<QueryNode> pNode(std::make_unique<TextFilterNode>(
                     m_database, m_fieldToSqlColumns[field], argument));
                 if (negate) {
-                    pNode = std::unique_ptr<QueryNode>(
-                            new NotNode(std::move(pNode)));
+                    pNode = std::make_unique<NotNode>(std::move(pNode));
                 }
                 pQuery->addNode(std::move(pNode));
             }
@@ -133,11 +132,11 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                 m_numericFilterMatcher.cap(2), &tokens).trimmed();
 
             if (!argument.isEmpty()) {
-                std::unique_ptr<QueryNode> pNode(new NumericFilterNode(
-                    m_fieldToSqlColumns[field], argument));
+                std::unique_ptr<QueryNode> pNode(
+                        std::make_unique<NumericFilterNode>(
+                                m_fieldToSqlColumns[field], argument));
                 if (negate) {
-                    pNode = std::unique_ptr<QueryNode>(
-                            new NotNode(std::move(pNode)));
+                    pNode = std::make_unique<NotNode>(std::move(pNode));
                 }
                 pQuery->addNode(std::move(pNode));
             }
@@ -153,23 +152,19 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                     mixxx::track::io::key::ChromaticKey key =
                             KeyUtils::guessKeyFromText(argument);
                     if (key == mixxx::track::io::key::INVALID) {
-                        pNode = std::unique_ptr<QueryNode>(
-                                new TextFilterNode(
-                                        m_database, m_fieldToSqlColumns[field], argument));
+                        pNode = std::make_unique<TextFilterNode>(
+                                m_database, m_fieldToSqlColumns[field], argument);
                     } else {
-                        pNode = std::unique_ptr<QueryNode>(
-                                new KeyFilterNode(key, fuzzy));
+                        pNode = std::make_unique<KeyFilterNode>(key, fuzzy);
                     }
                 } else if (field == "duration") {
-                    pNode = std::unique_ptr<QueryNode>(
-                            new DurationFilterNode(
-                                    m_fieldToSqlColumns[field], argument));
+                    pNode = std::make_unique<DurationFilterNode>(
+                            m_fieldToSqlColumns[field], argument);
                 }
             }
             if (pNode) {
                 if (negate) {
-                    pNode = std::unique_ptr<QueryNode>(
-                            new NotNode(std::move(pNode)));
+                    pNode = std::make_unique<NotNode>(std::move(pNode));
                 }
                 pQuery->addNode(std::move(pNode));
             }
@@ -182,11 +177,11 @@ void SearchQueryParser::parseTokens(QStringList tokens,
 
             // Don't trigger on a lone minus sign.
             if (!token.isEmpty()) {
-                std::unique_ptr<QueryNode> pNode(new TextFilterNode(
-                    m_database, searchColumns, token));
+                std::unique_ptr<QueryNode> pNode(
+                        std::make_unique<TextFilterNode>(
+                                m_database, searchColumns, token));
                 if (negate) {
-                    pNode = std::unique_ptr<QueryNode>(
-                            new NotNode(std::move(pNode)));
+                    pNode = std::make_unique<NotNode>(std::move(pNode));
                 }
                 pQuery->addNode(std::move(pNode));
             }
@@ -197,10 +192,10 @@ void SearchQueryParser::parseTokens(QStringList tokens,
 std::unique_ptr<QueryNode> SearchQueryParser::parseQuery(const QString& query,
                                          const QStringList& searchColumns,
                                          const QString& extraFilter) const {
-    std::unique_ptr<AndNode> pQuery(new AndNode());
+    auto pQuery(std::make_unique<AndNode>());
 
     if (!extraFilter.isEmpty()) {
-        pQuery->addNode(std::unique_ptr<QueryNode>(new SqlNode(extraFilter)));
+        pQuery->addNode(std::make_unique<SqlNode>(extraFilter));
     }
 
     if (!query.isEmpty()) {

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -192,7 +192,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
 std::unique_ptr<QueryNode> SearchQueryParser::parseQuery(const QString& query,
                                          const QStringList& searchColumns,
                                          const QString& extraFilter) const {
-    auto pQuery(std::make_unique<AndNode>());
+    std::unique_ptr<QueryNode> pQuery(std::make_unique<AndNode>());
 
     if (!extraFilter.isEmpty()) {
         pQuery->addNode(std::make_unique<SqlNode>(extraFilter));

--- a/src/library/searchqueryparser.h
+++ b/src/library/searchqueryparser.h
@@ -14,9 +14,10 @@ class SearchQueryParser {
     SearchQueryParser(QSqlDatabase& database);
     virtual ~SearchQueryParser();
 
-    QueryNode* parseQuery(const QString& query,
-                          const QStringList& searchColumns,
-                          const QString& extraFilter) const;
+    std::unique_ptr<QueryNode> parseQuery(
+            const QString& query,
+            const QStringList& searchColumns,
+            const QString& extraFilter) const;
 
   private:
     void parseTokens(QStringList tokens,

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -29,7 +29,7 @@ class SearchQueryParserTest : public testing::Test {
 };
 
 TEST_F(SearchQueryParserTest, EmptySearch) {
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("", QStringList(), ""));
 
     // An empty query matches all tracks.
@@ -44,7 +44,7 @@ TEST_F(SearchQueryParserTest, OneTermOneColumn) {
     QStringList searchColumns;
     searchColumns << "artist";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("asdf", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -63,7 +63,7 @@ TEST_F(SearchQueryParserTest, OneTermMultipleColumns) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("asdf", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -82,7 +82,7 @@ TEST_F(SearchQueryParserTest, OneTermMultipleColumnsNegation) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("-asdf", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -100,7 +100,7 @@ TEST_F(SearchQueryParserTest, MultipleTermsOneColumn) {
     QStringList searchColumns;
     searchColumns << "artist";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("asdf zxcv", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -119,7 +119,7 @@ TEST_F(SearchQueryParserTest, MultipleTermsMultipleColumns) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("asdf zxcv", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -144,7 +144,7 @@ TEST_F(SearchQueryParserTest, MultipleTermsMultipleColumnsNegation) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("asdf -zxcv", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -170,7 +170,7 @@ TEST_F(SearchQueryParserTest, TextFilter) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("comment:asdf", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -190,7 +190,7 @@ TEST_F(SearchQueryParserTest, TextFilterEmpty) {
                   << "album";
 
     // An empty argument should pass everything.
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("comment:", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -207,7 +207,7 @@ TEST_F(SearchQueryParserTest, TextFilterQuote) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("comment:\"asdf zxcv\"", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -226,7 +226,7 @@ TEST_F(SearchQueryParserTest, TextFilterQuote_NoEndQuoteTakesWholeQuery) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("comment:\"asdf zxcv qwer", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -245,7 +245,7 @@ TEST_F(SearchQueryParserTest, TextFilterAllowsSpace) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("comment: asdf", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -264,7 +264,7 @@ TEST_F(SearchQueryParserTest, TextFilterNegation) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("-comment: asdf", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -283,7 +283,7 @@ TEST_F(SearchQueryParserTest, NumericFilter) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("bpm:127.12", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -303,7 +303,7 @@ TEST_F(SearchQueryParserTest, NumericFilterEmpty) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("bpm:", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -321,7 +321,7 @@ TEST_F(SearchQueryParserTest, NumericFilterNegation) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("-bpm:127.12", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -341,7 +341,7 @@ TEST_F(SearchQueryParserTest, NumericFilterAllowsSpace) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("bpm: 127.12", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -361,7 +361,7 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("bpm:>127.12", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -375,7 +375,7 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
         qPrintable(pQuery->toSql()));
 
 
-    pQuery.reset(m_parser.parseQuery("bpm:>=127.12", searchColumns, ""));
+    pQuery = m_parser.parseQuery("bpm:>=127.12", searchColumns, "");
     pTrack->setBpm(127.11);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setBpm(127.12);
@@ -384,7 +384,7 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
         qPrintable(QString("(bpm >= 127.12)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("bpm:<127.12", searchColumns, ""));
+    pQuery = m_parser.parseQuery("bpm:<127.12", searchColumns, "");
     pTrack->setBpm(127.12);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setBpm(127.11);
@@ -393,7 +393,7 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
         qPrintable(QString("(bpm < 127.12)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("bpm:<=127.12", searchColumns, ""));
+    pQuery = m_parser.parseQuery("bpm:<=127.12", searchColumns, "");
     pTrack->setBpm(127.13);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setBpm(127.12);
@@ -408,7 +408,7 @@ TEST_F(SearchQueryParserTest, NumericRangeFilter) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("bpm:127.12-129", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -430,7 +430,7 @@ TEST_F(SearchQueryParserTest, MultipleFilters) {
     searchColumns << "artist"
                   << "title";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("bpm:127.12-129 artist:\"com truise\" Colorvision",
                             searchColumns, ""));
 
@@ -454,7 +454,7 @@ TEST_F(SearchQueryParserTest, ExtraFilterAppended) {
     QStringList searchColumns;
     searchColumns << "artist";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("asdf", searchColumns, "1 > 2"));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -473,7 +473,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearch) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("duration:1:30", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -487,7 +487,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearch) {
         qPrintable(QString("(duration = 90)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:1m30s", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:1m30s", searchColumns, "");
     pTrack->setDuration(91);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(90);
@@ -497,7 +497,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearch) {
         qPrintable(QString("(duration = 90)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:90", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:90", searchColumns, "");
     pTrack->setDuration(91);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(90);
@@ -513,7 +513,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("duration:>1:30", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -526,7 +526,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
         qPrintable(QString("(duration > 90)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:>=90", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:>=90", searchColumns, "");
     pTrack->setDuration(89);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(90);
@@ -535,7 +535,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
         qPrintable(QString("(duration >= 90)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:>=1:30", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:>=1:30", searchColumns, "");
     pTrack->setDuration(89);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(90);
@@ -544,7 +544,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
         qPrintable(QString("(duration >= 90)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:<2:30", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:<2:30", searchColumns, "");
     pTrack->setDuration(151);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(89);
@@ -553,7 +553,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
         qPrintable(QString("(duration < 150)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:<=2:30", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:<=2:30", searchColumns, "");
     pTrack->setDuration(191);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(150);
@@ -562,7 +562,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
         qPrintable(QString("(duration <= 150)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:<=150", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:<=150", searchColumns, "");
     pTrack->setDuration(191);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(150);
@@ -571,7 +571,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
         qPrintable(QString("(duration <= 150)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:<=2m30s", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:<=2m30s", searchColumns, "");
     pTrack->setDuration(191);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(150);
@@ -580,7 +580,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
         qPrintable(QString("(duration <= 150)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:<=2m", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:<=2m", searchColumns, "");
     pTrack->setDuration(191);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(110);
@@ -589,7 +589,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
         qPrintable(QString("(duration <= 120)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:<=2:", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:<=2:", searchColumns, "");
     pTrack->setDuration(191);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(110);
@@ -598,7 +598,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
         qPrintable(QString("(duration <= 120)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:>=1:3", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:>=1:3", searchColumns, "");
     pTrack->setDuration(60);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(150);
@@ -613,7 +613,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
     searchColumns << "artist"
                   << "album";
 
-    QScopedPointer<QueryNode> pQuery(
+    std::unique_ptr<QueryNode> pQuery(
         m_parser.parseQuery("duration:2:30-3:20", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -629,7 +629,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
         qPrintable(QString("(duration >= 150 AND duration <= 200)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:2:30-200", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:2:30-200", searchColumns, "");
     pTrack->setSampleRate(44100);
     pTrack->setDuration(80);
     EXPECT_FALSE(pQuery->match(pTrack));
@@ -642,7 +642,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
         qPrintable(QString("(duration >= 150 AND duration <= 200)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:150-200", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:150-200", searchColumns, "");
     pTrack->setSampleRate(44100);
     pTrack->setDuration(80);
     EXPECT_FALSE(pQuery->match(pTrack));
@@ -655,7 +655,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
         qPrintable(QString("(duration >= 150 AND duration <= 200)")),
         qPrintable(pQuery->toSql()));
 
-    pQuery.reset(m_parser.parseQuery("duration:2m30s-3m20s", searchColumns, ""));
+    pQuery = m_parser.parseQuery("duration:2m30s-3m20s", searchColumns, "");
     pTrack->setSampleRate(44100);
     pTrack->setDuration(80);
     EXPECT_FALSE(pQuery->match(pTrack));

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -54,7 +54,7 @@ TEST_F(SearchQueryParserTest, OneTermOneColumn) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(artist LIKE '%asdf%')")),
+        qPrintable(QString("artist LIKE '%asdf%'")),
         qPrintable(pQuery->toSql()));
 }
 
@@ -73,7 +73,7 @@ TEST_F(SearchQueryParserTest, OneTermMultipleColumns) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("((artist LIKE '%asdf%') OR (album LIKE '%asdf%'))")),
+        qPrintable(QString("(artist LIKE '%asdf%') OR (album LIKE '%asdf%')")),
         qPrintable(pQuery->toSql()));
 }
 
@@ -161,7 +161,7 @@ TEST_F(SearchQueryParserTest, MultipleTermsMultipleColumnsNegation) {
     EXPECT_STREQ(
         qPrintable(QString(
             "((artist LIKE '%asdf%') OR (album LIKE '%asdf%')) "
-            "AND NOT ((artist LIKE '%zxcv%') OR (album LIKE '%zxcv%'))")),
+            "AND (NOT ((artist LIKE '%zxcv%') OR (album LIKE '%zxcv%')))")),
         qPrintable(pQuery->toSql()));
 }
 
@@ -180,7 +180,7 @@ TEST_F(SearchQueryParserTest, TextFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(comment LIKE '%asdf%')")),
+        qPrintable(QString("comment LIKE '%asdf%'")),
         qPrintable(pQuery->toSql()));
 }
 
@@ -217,7 +217,7 @@ TEST_F(SearchQueryParserTest, TextFilterQuote) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(comment LIKE '%asdf zxcv%')")),
+        qPrintable(QString("comment LIKE '%asdf zxcv%'")),
         qPrintable(pQuery->toSql()));
 }
 
@@ -236,7 +236,7 @@ TEST_F(SearchQueryParserTest, TextFilterQuote_NoEndQuoteTakesWholeQuery) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(comment LIKE '%asdf zxcv qwer%')")),
+        qPrintable(QString("comment LIKE '%asdf zxcv qwer%'")),
         qPrintable(pQuery->toSql()));
 }
 
@@ -255,7 +255,7 @@ TEST_F(SearchQueryParserTest, TextFilterAllowsSpace) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(comment LIKE '%asdf%')")),
+        qPrintable(QString("comment LIKE '%asdf%'")),
         qPrintable(pQuery->toSql()));
 }
 
@@ -294,7 +294,7 @@ TEST_F(SearchQueryParserTest, NumericFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(bpm = 127.12)")),
+        qPrintable(QString("bpm = 127.12")),
         qPrintable(pQuery->toSql()));
 }
 
@@ -352,7 +352,7 @@ TEST_F(SearchQueryParserTest, NumericFilterAllowsSpace) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(bpm = 127.12)")),
+        qPrintable(QString("bpm = 127.12")),
         qPrintable(pQuery->toSql()));
 }
 
@@ -371,7 +371,7 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
     pTrack->setBpm(127.13);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(bpm > 127.12)")),
+        qPrintable(QString("bpm > 127.12")),
         qPrintable(pQuery->toSql()));
 
 
@@ -381,7 +381,7 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
     pTrack->setBpm(127.12);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(bpm >= 127.12)")),
+        qPrintable(QString("bpm >= 127.12")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("bpm:<127.12", searchColumns, "");
@@ -390,7 +390,7 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
     pTrack->setBpm(127.11);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(bpm < 127.12)")),
+        qPrintable(QString("bpm < 127.12")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("bpm:<=127.12", searchColumns, "");
@@ -399,7 +399,7 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
     pTrack->setBpm(127.12);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(bpm <= 127.12)")),
+        qPrintable(QString("bpm <= 127.12")),
         qPrintable(pQuery->toSql()));
 }
 
@@ -421,7 +421,7 @@ TEST_F(SearchQueryParserTest, NumericRangeFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(bpm >= 127.12 AND bpm <= 129)")),
+        qPrintable(QString("(bpm >= 127.12) AND (bpm <= 129)")),
         qPrintable(pQuery->toSql()));
 }
 
@@ -444,7 +444,7 @@ TEST_F(SearchQueryParserTest, MultipleFilters) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(bpm >= 127.12 AND bpm <= 129) AND "
+        qPrintable(QString("((bpm >= 127.12) AND (bpm <= 129)) AND "
                            "((artist LIKE '%com truise%') OR (album_artist LIKE '%com truise%')) AND "
                            "((artist LIKE '%Colorvision%') OR (title LIKE '%Colorvision%'))")),
         qPrintable(pQuery->toSql()));
@@ -484,7 +484,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearch) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(duration = 90)")),
+        qPrintable(QString("duration = 90")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:1m30s", searchColumns, "");
@@ -494,7 +494,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearch) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(duration = 90)")),
+        qPrintable(QString("duration = 90")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:90", searchColumns, "");
@@ -504,11 +504,11 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearch) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(duration = 90)")),
+        qPrintable(QString("duration = 90")),
         qPrintable(pQuery->toSql()));
 }
 
-TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
+TEST_F(SearchQueryParserTest, HumanReadableDurationSearchWithOperators) {
     QStringList searchColumns;
     searchColumns << "artist"
                   << "album";
@@ -523,7 +523,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     pTrack->setDuration(91);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(duration > 90)")),
+        qPrintable(QString("duration > 90")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:>=90", searchColumns, "");
@@ -532,7 +532,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     pTrack->setDuration(90);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(duration >= 90)")),
+        qPrintable(QString("duration >= 90")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:>=1:30", searchColumns, "");
@@ -541,7 +541,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     pTrack->setDuration(90);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(duration >= 90)")),
+        qPrintable(QString("duration >= 90")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:<2:30", searchColumns, "");
@@ -550,7 +550,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     pTrack->setDuration(89);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(duration < 150)")),
+        qPrintable(QString("duration < 150")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:<=2:30", searchColumns, "");
@@ -559,7 +559,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     pTrack->setDuration(150);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(duration <= 150)")),
+        qPrintable(QString("duration <= 150")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:<=150", searchColumns, "");
@@ -568,7 +568,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     pTrack->setDuration(150);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(duration <= 150)")),
+        qPrintable(QString("duration <= 150")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:<=2m30s", searchColumns, "");
@@ -577,7 +577,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     pTrack->setDuration(150);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(duration <= 150)")),
+        qPrintable(QString("duration <= 150")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:<=2m", searchColumns, "");
@@ -586,7 +586,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     pTrack->setDuration(110);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(duration <= 120)")),
+        qPrintable(QString("duration <= 120")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:<=2:", searchColumns, "");
@@ -595,7 +595,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     pTrack->setDuration(110);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(duration <= 120)")),
+        qPrintable(QString("duration <= 120")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:>=1:3", searchColumns, "");
@@ -604,7 +604,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithOperators) {
     pTrack->setDuration(150);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("(duration >= 63)")),
+        qPrintable(QString("duration >= 63")),
         qPrintable(pQuery->toSql()));
 }
 
@@ -626,7 +626,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(duration >= 150 AND duration <= 200)")),
+        qPrintable(QString("(duration >= 150) AND (duration <= 200)")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:2:30-200", searchColumns, "");
@@ -639,7 +639,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(duration >= 150 AND duration <= 200)")),
+        qPrintable(QString("(duration >= 150) AND (duration <= 200)")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:150-200", searchColumns, "");
@@ -652,7 +652,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(duration >= 150 AND duration <= 200)")),
+        qPrintable(QString("(duration >= 150) AND (duration <= 200)")),
         qPrintable(pQuery->toSql()));
 
     pQuery = m_parser.parseQuery("duration:2m30s-3m20s", searchColumns, "");
@@ -665,6 +665,6 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(duration >= 150 AND duration <= 200)")),
+        qPrintable(QString("(duration >= 150) AND (duration <= 200)")),
         qPrintable(pQuery->toSql()));
 }

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -29,7 +29,7 @@ class SearchQueryParserTest : public testing::Test {
 };
 
 TEST_F(SearchQueryParserTest, EmptySearch) {
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("", QStringList(), ""));
 
     // An empty query matches all tracks.
@@ -44,7 +44,7 @@ TEST_F(SearchQueryParserTest, OneTermOneColumn) {
     QStringList searchColumns;
     searchColumns << "artist";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("asdf", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -63,7 +63,7 @@ TEST_F(SearchQueryParserTest, OneTermMultipleColumns) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("asdf", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -82,7 +82,7 @@ TEST_F(SearchQueryParserTest, OneTermMultipleColumnsNegation) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("-asdf", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -100,7 +100,7 @@ TEST_F(SearchQueryParserTest, MultipleTermsOneColumn) {
     QStringList searchColumns;
     searchColumns << "artist";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("asdf zxcv", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -119,7 +119,7 @@ TEST_F(SearchQueryParserTest, MultipleTermsMultipleColumns) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("asdf zxcv", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -144,7 +144,7 @@ TEST_F(SearchQueryParserTest, MultipleTermsMultipleColumnsNegation) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("asdf -zxcv", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -170,7 +170,7 @@ TEST_F(SearchQueryParserTest, TextFilter) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("comment:asdf", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -190,7 +190,7 @@ TEST_F(SearchQueryParserTest, TextFilterEmpty) {
                   << "album";
 
     // An empty argument should pass everything.
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("comment:", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -207,7 +207,7 @@ TEST_F(SearchQueryParserTest, TextFilterQuote) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("comment:\"asdf zxcv\"", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -226,7 +226,7 @@ TEST_F(SearchQueryParserTest, TextFilterQuote_NoEndQuoteTakesWholeQuery) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("comment:\"asdf zxcv qwer", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -245,7 +245,7 @@ TEST_F(SearchQueryParserTest, TextFilterAllowsSpace) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("comment: asdf", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -264,7 +264,7 @@ TEST_F(SearchQueryParserTest, TextFilterNegation) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("-comment: asdf", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -283,7 +283,7 @@ TEST_F(SearchQueryParserTest, NumericFilter) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("bpm:127.12", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -303,7 +303,7 @@ TEST_F(SearchQueryParserTest, NumericFilterEmpty) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("bpm:", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -321,7 +321,7 @@ TEST_F(SearchQueryParserTest, NumericFilterNegation) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("-bpm:127.12", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -341,7 +341,7 @@ TEST_F(SearchQueryParserTest, NumericFilterAllowsSpace) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("bpm: 127.12", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -361,7 +361,7 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("bpm:>127.12", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -408,7 +408,7 @@ TEST_F(SearchQueryParserTest, NumericRangeFilter) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("bpm:127.12-129", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -430,7 +430,7 @@ TEST_F(SearchQueryParserTest, MultipleFilters) {
     searchColumns << "artist"
                   << "title";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("bpm:127.12-129 artist:\"com truise\" Colorvision",
                             searchColumns, ""));
 
@@ -454,7 +454,7 @@ TEST_F(SearchQueryParserTest, ExtraFilterAppended) {
     QStringList searchColumns;
     searchColumns << "artist";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("asdf", searchColumns, "1 > 2"));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -473,7 +473,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearch) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("duration:1:30", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -513,7 +513,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchWithOperators) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("duration:>1:30", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());
@@ -613,7 +613,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
     searchColumns << "artist"
                   << "album";
 
-    std::unique_ptr<QueryNode> pQuery(
+    auto pQuery(
         m_parser.parseQuery("duration:2:30-3:20", searchColumns, ""));
 
     TrackPointer pTrack(new TrackInfoObject());


### PR DESCRIPTION
- Cherry pick memory leak fix from 1.12 to avoid merge conflicts
- Replace plain pointers with std::unique_ptr to avoid memory leaks
- Delete obsolete constructors and destructors
- Add 'override' keyword to inherited virtual functions in derived classes
- Fix (or comment) fragile design of Numeric-/DurationFilterNode
- Consistent wrapping of SQL expressions into parantheses
- Improve readability using auto and std::make_unique
