### PR TITLE
Make translation of "Empty Chain" consistent

### DIFF
--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -92,7 +92,7 @@ void EffectRack::slotClearRack(double v) {
 EffectChainPointer EffectRack::makeEmptyChain() {
     EffectChainPointer pChain(new EffectChain(m_pEffectsManager, QString(),
                                               EffectChainPointer()));
-    pChain->setName("Empty Chain");
+    pChain->setName(tr("Empty Chain"));
     return pChain;
 }
 

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -92,7 +92,7 @@ void EffectRack::slotClearRack(double v) {
 EffectChainPointer EffectRack::makeEmptyChain() {
     EffectChainPointer pChain(new EffectChain(m_pEffectsManager, QString(),
                                               EffectChainPointer()));
-    pChain->setName("Empty Chain");
+    pChain->setName(QObject::tr("Empty Chain"));
     return pChain;
 }
 

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -92,7 +92,7 @@ void EffectRack::slotClearRack(double v) {
 EffectChainPointer EffectRack::makeEmptyChain() {
     EffectChainPointer pChain(new EffectChain(m_pEffectsManager, QString(),
                                               EffectChainPointer()));
-    pChain->setName(QObject::tr("Empty Chain"));
+    pChain->setName("Empty Chain");
     return pChain;
 }
 

--- a/src/widget/weffectchain.cpp
+++ b/src/widget/weffectchain.cpp
@@ -38,7 +38,7 @@ void WEffectChain::setEffectChainSlot(EffectChainSlotPointer pEffectChainSlot) {
 }
 
 void WEffectChain::chainUpdated() {
-    QString name = QObject::tr("Empty Chain");
+    QString name = tr("None");
     QString description = tr("No effect chain loaded.");
     if (m_pEffectChainSlot) {
         EffectChainPointer pChain = m_pEffectChainSlot->getEffectChain();

--- a/src/widget/weffectchain.cpp
+++ b/src/widget/weffectchain.cpp
@@ -38,7 +38,7 @@ void WEffectChain::setEffectChainSlot(EffectChainSlotPointer pEffectChainSlot) {
 }
 
 void WEffectChain::chainUpdated() {
-    QString name = tr("None");
+    QString name = QObject::tr("Empty Chain");
     QString description = tr("No effect chain loaded.");
     if (m_pEffectChainSlot) {
         EffectChainPointer pChain = m_pEffectChainSlot->getEffectChain();

--- a/src/widget/weffectchain.cpp
+++ b/src/widget/weffectchain.cpp
@@ -38,7 +38,7 @@ void WEffectChain::setEffectChainSlot(EffectChainSlotPointer pEffectChainSlot) {
 }
 
 void WEffectChain::chainUpdated() {
-    QString name = tr("None");
+    QString name = tr("Empty Chain");
     QString description = tr("No effect chain loaded.");
     if (m_pEffectChainSlot) {
         EffectChainPointer pChain = m_pEffectChainSlot->getEffectChain();


### PR DESCRIPTION
I don't really know much about mixxxs translation system, so shame on me if I did it wrong.

using QObject::tr() was the only way to get the same string out of it in effectrack and weffectchain. So i used that.

How do I use plain tr() right in effectRack?

Edit:
https://bugs.launchpad.net/mixxx/+bug/1463927
