### PR TITLE
Double slash fix

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -1144,6 +1144,8 @@ class MixxxCore(Feature):
         if build.platform_is_linux or \
                 build.platform_is_bsd:
             mixxx_files = [
+                # TODO(XXX) Trailing slash not needed anymore as we switches from String::append
+                # to QDir::filePath elsewhere in the code. This is candidate for removal.
                 ('SETTINGS_PATH', '.mixxx/'),
                 ('SETTINGS_FILE', 'mixxx.cfg')]
         elif build.platform_is_osx:

--- a/src/analyserwaveform.cpp
+++ b/src/analyserwaveform.cpp
@@ -29,7 +29,7 @@ AnalyserWaveform::AnalyserWaveform(ConfigObject<ConfigValue>* pConfig) :
     m_database = QSqlDatabase::addDatabase("QSQLITE", "WAVEFORM_ANALYSIS" + QString::number(i++));
     if (!m_database.isOpen()) {
         m_database.setHostName("localhost");
-        m_database.setDatabaseName(pConfig->getSettingsPath().append("/mixxxdb.sqlite"));
+        m_database.setDatabaseName(QDir(pConfig->getSettingsPath()).filePath("mixxxdb.sqlite"));
         m_database.setUserName("mixxx");
         m_database.setPassword("mixxx");
 

--- a/src/dlgdevelopertools.cpp
+++ b/src/dlgdevelopertools.cpp
@@ -48,7 +48,7 @@ DlgDeveloperTools::DlgDeveloperTools(QWidget* pParent,
     m_statProxyModel.setSourceModel(&m_statModel);
     statsTable->setModel(&m_statProxyModel);
 
-    QString logFileName = CmdlineArgs::Instance().getSettingsPath() + "/mixxx.log";
+    QString logFileName = QDir(CmdlineArgs::Instance().getSettingsPath()).filePath("mixxx.log");
     m_logFile.setFileName(logFileName);
     if (!m_logFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
         qDebug() << "ERROR: Could not open log file";

--- a/src/library/parserm3u.cpp
+++ b/src/library/parserm3u.cpp
@@ -121,7 +121,7 @@ QString ParserM3u::getFilepath(QTextStream *stream, QString basepath)
                 return trackLocation;
             } else {
                 // Try relative to m3u dir
-                QString rel = basepath + "/" + trackLocation;
+                QString rel = QDir(basepath).filePath(trackLocation);
                 if (isFilepath(rel)) {
                     return rel;
                 }

--- a/src/library/parserpls.cpp
+++ b/src/library/parserpls.cpp
@@ -134,7 +134,7 @@ QString ParserPls::getFilepath(QTextStream *stream, QString basepath)
                 return trackLocation;
             } else {
                 // Try relative to m3u dir
-                QString rel = basepath + "/" + trackLocation;
+                QString rel = QDir(basepath).filePath(trackLocation);
                 if (isFilepath(rel)) {
                     return rel;
                 }

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -30,7 +30,7 @@ TrackCollection::TrackCollection(ConfigObject<ConfigValue>* pConfig)
     qDebug() << "Available QtSQL drivers:" << QSqlDatabase::drivers();
 
     m_db.setHostName("localhost");
-    m_db.setDatabaseName(QDir(pConfig->getSettingsPath()).filePath("/mixxxdb.sqlite"));
+    m_db.setDatabaseName(QDir(pConfig->getSettingsPath()).filePath("mixxxdb.sqlite"));
     m_db.setUserName("mixxx");
     m_db.setPassword("mixxx");
     bool ok = m_db.open();

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -30,7 +30,7 @@ TrackCollection::TrackCollection(ConfigObject<ConfigValue>* pConfig)
     qDebug() << "Available QtSQL drivers:" << QSqlDatabase::drivers();
 
     m_db.setHostName("localhost");
-    m_db.setDatabaseName(pConfig->getSettingsPath().append("/mixxxdb.sqlite"));
+    m_db.setDatabaseName(QDir(pConfig->getSettingsPath()).filePath("/mixxxdb.sqlite"));
     m_db.setUserName("mixxx");
     m_db.setPassword("mixxx");
     bool ok = m_db.open();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,14 +95,14 @@ void MessageHandler(QtMsgType type,
         //FIXME: cerr << doesn't get printed until after mixxx quits (???)
         for (int i = 9; i >= 0; --i) {
             if (i == 0) {
-                logFileName = QString("%1/mixxx.log").arg(logLocation);
+                logFileName = QDir(logLocation).filePath("mixxx.log");
             } else {
-                logFileName = QString("%1/mixxx.log.%2").arg(logLocation).arg(i);
+                logFileName = QDir(logLocation).filePath(QString("mixxx.log.%1").arg(i));
             }
             QFileInfo logbackup(logFileName);
             if (logbackup.exists()) {
                 QString olderlogname =
-                        QString("%1/mixxx.log.%2").arg(logLocation).arg(i + 1);
+                        QDir(logLocation).filePath(QString("mixxx.log.%1").arg(i + 1));
                 // This should only happen with number 10
                 if (QFileInfo(olderlogname).exists()) {
                     QFile::remove(olderlogname);

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -128,7 +128,7 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
     m_pConfig = upgrader.versionUpgrade(args.getSettingsPath());
     ControlDoublePrivate::setUserConfig(m_pConfig);
 
-    Sandbox::initialize(m_pConfig->getSettingsPath().append("/sandbox.cfg"));
+    Sandbox::initialize(QDir(m_pConfig->getSettingsPath()).filePath("sandbox.cfg"));
 
     // Only record stats in developer mode.
     if (m_cmdLineArgs.getDeveloper()) {
@@ -785,7 +785,7 @@ void MixxxMainWindow::initializeKeyboard() {
 
     // Read keyboard configuration and set kdbConfig object in WWidget
     // Check first in user's Mixxx directory
-    QString userKeyboard = m_cmdLineArgs.getSettingsPath() + "Custom.kbd.cfg";
+    QString userKeyboard = QDir(m_cmdLineArgs.getSettingsPath()).filePath("Custom.kbd.cfg");
 
     //Empty keyboard configuration
     m_pKbdConfigEmpty = new ConfigObject<ConfigValueKbd>("");

--- a/src/soundmanagerconfig.cpp
+++ b/src/soundmanagerconfig.cpp
@@ -38,7 +38,7 @@ SoundManagerConfig::SoundManagerConfig()
       m_deckCount(kDefaultDeckCount),
       m_audioBufferSizeIndex(kDefaultAudioBufferSizeIndex),
       m_syncBuffers(2) {
-    m_configFile = QFileInfo(CmdlineArgs::Instance().getSettingsPath() + SOUNDMANAGERCONFIG_FILENAME);
+    m_configFile = QFileInfo(QDir(CmdlineArgs::Instance().getSettingsPath()).filePath(SOUNDMANAGERCONFIG_FILENAME));
 }
 
 SoundManagerConfig::~SoundManagerConfig() {

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -68,7 +68,7 @@ TrackInfoObject::TrackInfoObject(const QDomNode &nodeHeader)
         : m_qMutex(QMutex::Recursive),
           m_analyserProgress(-1) {
     QString filename = XmlParse::selectNodeQString(nodeHeader, "Filename");
-    QString location = XmlParse::selectNodeQString(nodeHeader, "Filepath") + "/" +  filename;
+    QString location = QDir(XmlParse::selectNodeQString(nodeHeader, "Filepath")).filePath(filename);
     m_fileInfo = QFileInfo(location);
     m_pSecurityToken = Sandbox::openSecurityToken(m_fileInfo, true);
 

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -63,33 +63,32 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
 *   since we moved them in 1.7.0. This code takes care of moving them.
 */
 
-    QString oldLocation = QDir::homePath().append("/%1");
+    QDir oldLocation = QDir(QDir::homePath());
 #ifdef __WINDOWS__
-    QFileInfo* pre170Config = new QFileInfo(oldLocation.arg("mixxx.cfg"));
+    QFileInfo* pre170Config = new QFileInfo(oldLocation.filePath("mixxx.cfg"));
 #else
-    QFileInfo* pre170Config = new QFileInfo(oldLocation.arg(".mixxx.cfg"));
+    QFileInfo* pre170Config = new QFileInfo(oldLocation.filePath(".mixxx.cfg"));
 #endif
 
     if (pre170Config->exists()) {
 
         // Move the files to their new location
-        QString newLocation = settingsPath;
+        QDir newLocation = QDir(settingsPath);
 
-        if (!QDir(newLocation).exists()) {
-            qDebug() << "Creating new settings directory" << newLocation;
-            QDir().mkpath(newLocation);
+        if (!newLocation.exists()) {
+            qDebug() << "Creating new settings directory" << newLocation.absolutePath();
+            newLocation.mkpath(".");
         }
 
-        newLocation.append("%1");
         QString errorText = "Error moving your %1 file %2 to the new location %3: \n";
 
 #ifdef __WINDOWS__
-        QString oldFilePath = oldLocation.arg("mixxxtrack.xml");
+        QString oldFilePath = oldLocation.filePath("mixxxtrack.xml");
 #else
-        QString oldFilePath = oldLocation.arg(".mixxxtrack.xml");
+        QString oldFilePath = oldLocation.filePath(".mixxxtrack.xml");
 #endif
 
-        QString newFilePath = newLocation.arg("mixxxtrack.xml");
+        QString newFilePath = newLocation.filePath("mixxxtrack.xml");
         QFile* oldFile = new QFile(oldFilePath);
         if (oldFile->exists()) {
             if (oldFile->copy(newFilePath)) {
@@ -104,11 +103,11 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
         delete oldFile;
 
 #ifdef __WINDOWS__
-        oldFilePath = oldLocation.arg("mixxxbpmschemes.xml");
+        oldFilePath = oldLocation.filePath("mixxxbpmschemes.xml");
 #else
-        oldFilePath = oldLocation.arg(".mixxxbpmscheme.xml");
+        oldFilePath = oldLocation.filePath(".mixxxbpmscheme.xml");
 #endif
-        newFilePath = newLocation.arg("mixxxbpmscheme.xml");
+        newFilePath = newLocation.filePath("mixxxbpmscheme.xml");
         oldFile = new QFile(oldFilePath);
         if (oldFile->exists()) {
             if (oldFile->copy(newFilePath))
@@ -120,11 +119,11 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
         }
         delete oldFile;
 #ifdef __WINDOWS__
-        oldFilePath = oldLocation.arg("MixxxMIDIBindings.xml");
+        oldFilePath = oldLocation.filePath("MixxxMIDIBindings.xml");
 #else
-        oldFilePath = oldLocation.arg(".MixxxMIDIBindings.xml");
+        oldFilePath = oldLocation.filePath(".MixxxMIDIBindings.xml");
 #endif
-        newFilePath = newLocation.arg("MixxxMIDIBindings.xml");
+        newFilePath = newLocation.filePath("MixxxMIDIBindings.xml");
         oldFile = new QFile(oldFilePath);
         if (oldFile->exists()) {
             qWarning() << "The MIDI mapping file format has changed in this version of Mixxx. You will need to reconfigure your MIDI controller. See the Wiki for full details on the new format.";
@@ -137,15 +136,18 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
         }
         // Tidy up
         delete oldFile;
-
-        QFile::remove(oldLocation.arg(".MixxxMIDIDevice.xml")); // Obsolete file, so just delete it
+#ifdef __WINDOWS__
+        QFile::remove(oldLocation.filePath("MixxxMIDIDevice.xml")); // Obsolete file, so just delete it
+#else
+        QFile::remove(oldLocation.filePath(".MixxxMIDIDevice.xml")); // Obsolete file, so just delete it
+#endif
 
 #ifdef __WINDOWS__
-        oldFilePath = oldLocation.arg("mixxx.cfg");
+        oldFilePath = oldLocation.filePath("mixxx.cfg");
 #else
-        oldFilePath = oldLocation.arg(".mixxx.cfg");
+        oldFilePath = oldLocation.filePath(".mixxx.cfg");
 #endif
-        newFilePath = newLocation.arg(SETTINGS_FILE);
+        newFilePath = newLocation.filePath(SETTINGS_FILE);
         oldFile = new QFile(oldFilePath);
         if (oldFile->copy(newFilePath))
             oldFile->remove();
@@ -170,7 +172,7 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
 ****************************************************************************/
 
     // Read the config file from home directory
-    ConfigObject<ConfigValue> *config = new ConfigObject<ConfigValue>(settingsPath + "/" + SETTINGS_FILE);
+    ConfigObject<ConfigValue> *config = new ConfigObject<ConfigValue>(QDir(settingsPath).filePath(SETTINGS_FILE));
 
     QString configVersion = config->getValueString(ConfigKey("[Config]","Version"));
 
@@ -183,22 +185,22 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
         if (oldConfigFile->exists() && ! CmdlineArgs::Instance().getSettingsPathSet()) {
             qDebug() << "Found pre-1.9.0 config for OS X";
             // Note: We changed SETTINGS_PATH in 1.9.0 final on OS X so it must be hardcoded to ".mixxx" here for legacy.
-            config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append(".mixxx/mixxx.cfg"));
+            config = new ConfigObject<ConfigValue>(QDir::homePath().append("/.mixxx/mixxx.cfg"));
             // Just to be sure all files like logs and soundconfig go with mixxx.cfg
-            CmdlineArgs::Instance().setSettingsPath(QDir::homePath().append("/").append(".mixxx/"));
+            CmdlineArgs::Instance().setSettingsPath(QDir::homePath().append("/.mixxx/"));
             configVersion = config->getValueString(ConfigKey("[Config]","Version"));
         }
         else {
 #elif __WINDOWS__
         qDebug() << "Config version is empty, trying to read pre-1.12.0 config";
         // Try to read the config from the pre-1.12.0 final directory on Windows (we moved it in 1.12.0 final)
-        QScopedPointer<QFile> oldConfigFile(new QFile(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append("mixxx.cfg")));
+        QScopedPointer<QFile> oldConfigFile(new QFile(QDir::homePath().append("/Local Settings/Application Data/Mixxx/mixxx.cfg")));
         if (oldConfigFile->exists() && ! CmdlineArgs::Instance().getSettingsPathSet()) {
             qDebug() << "Found pre-1.12.0 config for Windows";
             // Note: We changed SETTINGS_PATH in 1.12.0 final on Windows so it must be hardcoded to "Local Settings/Application Data/Mixxx/" here for legacy.
-            config = new ConfigObject<ConfigValue>(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/").append("mixxx.cfg"));
+            config = new ConfigObject<ConfigValue>(QDir::homePath().append("/Local Settings/Application Data/Mixxx/mixxx.cfg"));
             // Just to be sure all files like logs and soundconfig go with mixxx.cfg
-            CmdlineArgs::Instance().setSettingsPath(QDir::homePath().append("/").append("Local Settings/Application Data/Mixxx/")); 
+            CmdlineArgs::Instance().setSettingsPath(QDir::homePath().append("/Local Settings/Application Data/Mixxx/")); 
             configVersion = config->getValueString(ConfigKey("[Config]","Version"));
         }
         else {
@@ -304,7 +306,7 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
         }
         // Reload the configuration file from the new location.
         // (We want to make sure we save to the new location...)
-        config = new ConfigObject<ConfigValue>(settingsPath + "/" + SETTINGS_FILE);
+        config = new ConfigObject<ConfigValue>(QDir(settingsPath).filePath(SETTINGS_FILE));
 #endif
         configVersion = "1.9.0";
         config->set(ConfigKey("[Config]","Version"), ConfigValue("1.9.0"));

--- a/src/upgrade.cpp
+++ b/src/upgrade.cpp
@@ -187,6 +187,8 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
             // Note: We changed SETTINGS_PATH in 1.9.0 final on OS X so it must be hardcoded to ".mixxx" here for legacy.
             config = new ConfigObject<ConfigValue>(QDir::homePath().append("/.mixxx/mixxx.cfg"));
             // Just to be sure all files like logs and soundconfig go with mixxx.cfg
+            // TODO(XXX) Trailing slash not needed anymore as we switches from String::append
+            // to QDir::filePath elsewhere in the code. This is candidate for removal.
             CmdlineArgs::Instance().setSettingsPath(QDir::homePath().append("/.mixxx/"));
             configVersion = config->getValueString(ConfigKey("[Config]","Version"));
         }
@@ -200,6 +202,8 @@ ConfigObject<ConfigValue>* Upgrade::versionUpgrade(const QString& settingsPath) 
             // Note: We changed SETTINGS_PATH in 1.12.0 final on Windows so it must be hardcoded to "Local Settings/Application Data/Mixxx/" here for legacy.
             config = new ConfigObject<ConfigValue>(QDir::homePath().append("/Local Settings/Application Data/Mixxx/mixxx.cfg"));
             // Just to be sure all files like logs and soundconfig go with mixxx.cfg
+            // TODO(XXX) Trailing slash not needed anymore as we switches from String::append
+            // to QDir::filePath elsewhere in the code. This is candidate for removal.
             CmdlineArgs::Instance().setSettingsPath(QDir::homePath().append("/Local Settings/Application Data/Mixxx/")); 
             configVersion = config->getValueString(ConfigKey("[Config]","Version"));
         }

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -64,7 +64,9 @@ class CmdlineArgs {
     bool getTimelineEnabled() const { return !m_timelinePath.isEmpty(); }
     const QString& getLocale() const { return m_locale; }
     const QString& getSettingsPath() const { return m_settingsPath; }
-    void setSettingsPath(QString newSettingsPath) { m_settingsPath=QString(newSettingsPath); return; }
+    void setSettingsPath(const QString& newSettingsPath) { 
+        m_settingsPath=newSettingsPath; 
+    }
     const QString& getResourcePath() const { return m_resourcePath; }
     const QString& getPluginPath() const { return m_pluginPath; }
     const QString& getTimelinePath() const { return m_timelinePath; }

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -28,6 +28,8 @@ class CmdlineArgs {
                 m_locale = argv[i+1];
             } else if (argv[i] == QString("--settingsPath") && i+1 < argc) {
                 m_settingsPath = QString::fromLocal8Bit(argv[i+1]);
+                // TODO(XXX) Trailing slash not needed anymore as we switches from String::append
+                // to QDir::filePath elsewhere in the code. This is candidate for removal.
                 if (!m_settingsPath.endsWith("/")) {
                     m_settingsPath.append("/");
                 }
@@ -82,6 +84,8 @@ class CmdlineArgs {
 #ifdef __LINUX__
         m_settingsPath(QDir::homePath().append("/").append(SETTINGS_PATH)) {
 #else
+        // TODO(XXX) Trailing slash not needed anymore as we switches from String::append
+        // to QDir::filePath elsewhere in the code. This is candidate for removal.
         m_settingsPath(QDesktopServices::storageLocation(QDesktopServices::DataLocation).append("/")) {
 #endif
     }

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -65,7 +65,7 @@ class CmdlineArgs {
     const QString& getLocale() const { return m_locale; }
     const QString& getSettingsPath() const { return m_settingsPath; }
     void setSettingsPath(const QString& newSettingsPath) { 
-        m_settingsPath=newSettingsPath; 
+        m_settingsPath = newSettingsPath; 
     }
     const QString& getResourcePath() const { return m_resourcePath; }
     const QString& getPluginPath() const { return m_pluginPath; }


### PR DESCRIPTION
This addresses lp:1464975
Replace all (at least most of) occurences of a manual path construction by string concatenation by the use of QDir::filePath.

This way, we avoid double-slahs and can handle properly settingsPath both with or without a trailing "/".
