### PR TITLE
Add building files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 *.pyc
 *.rej
 *_build
+dist32
+dist64
+src/mixxx.rc.include
+src/mixxx.res
 *~
 .#*
 .sconf_temp


### PR DESCRIPTION
This will make the life easier for windows developers.
