### PR TITLE
Fix double-processing of realtime midi messages

### DIFF
--- a/src/controllers/midi/portmidicontroller.cpp
+++ b/src/controllers/midi/portmidicontroller.cpp
@@ -172,6 +172,7 @@ bool PortMidiController::poll() {
         if ((status & 0xF8) == 0xF8) {
             // Handle real-time MIDI messages at any time
             receive(status, 0, 0);
+            continue;
         }
 
         reprocessMessage:


### PR DESCRIPTION
In developing midi clock input, I noticed that realtime midi messages were getting processed twice.  This patch fixes that behavior.

I think this fix is correct, although there are scary gotos in this loop so I'm not totally sure.
