### PR TITLE
LateNight: make right clicking on KEY button reset key

### DIFF
--- a/res/skins/LateNight/deck.xml
+++ b/res/skins/LateNight/deck.xml
@@ -59,6 +59,10 @@
                                       <Connection>
                                         <ConfigKey persist="true">[Channel<Variable name="channum"/>],pitch_adjust_set_default</ConfigKey>
                                       </Connection>
+                                      <Connection>
+                                        <ConfigKey persist="true">[Channel<Variable name="channum"/>],reset_key</ConfigKey>
+                                        <ButtonState>RightButton</ButtonState>
+                                      </Connection>
                                    </PushButton>
                                    <PushButton>
                                       <Size>16f,16f</Size>


### PR DESCRIPTION
Right clicking on many elements in the GUI resets them to their default value. This makes the KEY button do that in LateNight, as it already does in Shade.
