### PR TITLE
add slip_cancel control

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -715,7 +715,7 @@ void EngineBuffer::slotControlSlip(double v)
 
 void EngineBuffer::slotControlSlipCancel(double v)
 {
-    if (m_slipEnabled.fetchAndStoreAcquire(0)) {
+    if (m_slipEnabled.fetchAndAddAcquire(0)) {
         m_slipCancelled = static_cast<int>(v > 0.0);
     }
 }
@@ -1154,7 +1154,6 @@ void EngineBuffer::processSlip(int iBufferSize) {
         if (enabled || m_slipCancelled.fetchAndStoreAcquire(0)) {
             m_dSlipPosition = m_filepos_play;
             m_dSlipRate = m_rate_old;
-            m_slipCancelled = 0;
         } else {
             // TODO(owen) assuming that looping will get canceled properly
             double newPlayFrame = m_dSlipPosition / kSamplesPerFrame;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -715,7 +715,7 @@ void EngineBuffer::slotControlSlip(double v)
 
 void EngineBuffer::slotControlSlipCancel(double v)
 {
-    if (m_slipEnabled.fetchAndAddAcquire(0)) {
+    if (load_atomic(m_slipEnabled)) {
         m_slipCancelled = static_cast<int>(v > 0.0);
     }
 }

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -182,6 +182,7 @@ class EngineBuffer : public EngineObject {
     void slotControlSeekAbs(double);
     void slotControlSeekExact(double);
     void slotControlSlip(double);
+    void slotControlSlipCancel(double);
     void slotKeylockEngineChanged(double);
 
     // Request that the EngineBuffer load a track. Since the process is
@@ -311,8 +312,9 @@ class EngineBuffer : public EngineObject {
     double m_dSlipPosition;
     // Saved value of rate for slip mode
     double m_dSlipRate;
-    // m_slipEnabled is a boolean accessed from multiple threads, so we use an atomic int.
+    // m_slipEnabled and m_slipCancelled are booleans accessed from multiple threads, so we use atomic ints.
     QAtomicInt m_slipEnabled;
+    QAtomicInt m_slipCancelled;
     // m_bSlipEnabledProcessing is only used by the engine processing thread.
     bool m_bSlipEnabledProcessing;
 
@@ -327,6 +329,7 @@ class EngineBuffer : public EngineObject {
     ControlObject* m_fwdButton;
     ControlObject* m_backButton;
     ControlPushButton* m_pSlipButton;
+    ControlPushButton* m_pSlipCancelButton;
 
     ControlObject* m_visualBpm;
     ControlObject* m_visualKey;


### PR DESCRIPTION
Setting slip_cancel to 1 prevents setting slip_enabled to 0 from seeking to where the track would have been. This address https://bugs.launchpad.net/mixxx/+bug/1159247 and is necessary for PR #638. Without being able to cancel slip mode, the Electrix Tweaker mapping (PR #638) will not jump back to the slip point when a hotcue is pressed, slip mode is released before the hotcue button, the hotcue button is released, then slip mode is enabled again, and a hotcue is pressed & released.
