### PR TITLE
Move Library menu to subsection of File menu

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1101,18 +1101,6 @@ void MixxxMainWindow::initActions()
         buildWhatsThis(openText, player2LoadStatusText));
     connect(m_pFileLoadSongPlayer2, SIGNAL(triggered()),
             this, SLOT(slotFileLoadSongPlayer2()));
-
-    QString quitTitle = tr("&Exit");
-    QString quitText = tr("Quits Mixxx");
-    m_pFileQuit = new QAction(quitTitle, this);
-    m_pFileQuit->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "FileMenu_Quit"),
-                                                  tr("Ctrl+q"))));
-    m_pFileQuit->setShortcutContext(Qt::ApplicationShortcut);
-    m_pFileQuit->setStatusTip(quitText);
-    m_pFileQuit->setWhatsThis(buildWhatsThis(quitTitle, quitText));
-    connect(m_pFileQuit, SIGNAL(triggered()), this, SLOT(slotFileQuit()));
-
     
     QString player3LoadStatusText = loadTrackStatusText.arg(QString::number(3));
     m_pFileLoadSongPlayer3 = new QAction(loadTrackText.arg(QString::number(3)), this);
@@ -1140,32 +1128,43 @@ void MixxxMainWindow::initActions()
     m_pLibraryRescan->setCheckable(false);
     connect(m_pLibraryRescan, SIGNAL(triggered()),
             this, SLOT(slotScanLibrary()));
-
+    
     QString createPlaylistTitle = tr("Create &New Playlist");
     QString createPlaylistText = tr("Create a new playlist");
     m_pPlaylistsNew = new QAction(createPlaylistTitle, this);
     m_pPlaylistsNew->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
-                                                  "LibraryMenu_NewPlaylist"),
-                                                  tr("Ctrl+n"))));
+            QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                                "FileMenu_NewPlaylist"),
+                                                      tr("Ctrl+n"))));
     m_pPlaylistsNew->setShortcutContext(Qt::ApplicationShortcut);
     m_pPlaylistsNew->setStatusTip(createPlaylistText);
     m_pPlaylistsNew->setWhatsThis(buildWhatsThis(createPlaylistTitle, createPlaylistText));
     connect(m_pPlaylistsNew, SIGNAL(triggered()),
             m_pLibrary, SLOT(slotCreatePlaylist()));
-
+    
     QString createCrateTitle = tr("Create New &Crate");
     QString createCrateText = tr("Create a new crate");
     m_pCratesNew = new QAction(createCrateTitle, this);
     m_pCratesNew->setShortcut(
-        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
-                                                  "LibraryMenu_NewCrate"),
-                                                  tr("Ctrl+Shift+N"))));
+            QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
+                                                                "FileMenu_NewCrate"),
+                                                      tr("Ctrl+Shift+N"))));
     m_pCratesNew->setShortcutContext(Qt::ApplicationShortcut);
     m_pCratesNew->setStatusTip(createCrateText);
     m_pCratesNew->setWhatsThis(buildWhatsThis(createCrateTitle, createCrateText));
     connect(m_pCratesNew, SIGNAL(triggered()),
             m_pLibrary, SLOT(slotCreateCrate()));
+
+    QString quitTitle = tr("&Exit");
+    QString quitText = tr("Quits Mixxx");
+    m_pFileQuit = new QAction(quitTitle, this);
+    m_pFileQuit->setShortcut(
+        QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "FileMenu_Quit"),
+                                                  tr("Ctrl+q"))));
+    m_pFileQuit->setShortcutContext(Qt::ApplicationShortcut);
+    m_pFileQuit->setStatusTip(quitText);
+    m_pFileQuit->setWhatsThis(buildWhatsThis(quitTitle, quitText));
+    connect(m_pFileQuit, SIGNAL(triggered()), this, SLOT(slotFileQuit()));
 
     QString fullScreenTitle = tr("&Full Screen");
     QString fullScreenText = tr("Display Mixxx using the full screen");
@@ -1587,7 +1586,6 @@ void MixxxMainWindow::initMenuBar() {
     // MENUBAR
     m_pFileMenu = new QMenu(tr("&File"), menuBar());
     m_pOptionsMenu = new QMenu(tr("&Options"), menuBar());
-    m_pLibraryMenu = new QMenu(tr("&Library"),menuBar());
     m_pViewMenu = new QMenu(tr("&View"), menuBar());
     m_pHelpMenu = new QMenu(tr("&Help"), menuBar());
     m_pDeveloperMenu = new QMenu(tr("&Developer"), menuBar());
@@ -1598,6 +1596,10 @@ void MixxxMainWindow::initMenuBar() {
     m_pFileMenu->addAction(m_pFileLoadSongPlayer2);
     m_pFileMenu->addAction(m_pFileLoadSongPlayer3);
     m_pFileMenu->addAction(m_pFileLoadSongPlayer4);
+    m_pFileMenu->addSeparator();
+    m_pFileMenu->addAction(m_pLibraryRescan);
+    m_pFileMenu->addAction(m_pPlaylistsNew);
+    m_pFileMenu->addAction(m_pCratesNew);
     m_pFileMenu->addSeparator();
     m_pFileMenu->addAction(m_pFileQuit);
 
@@ -1621,11 +1623,6 @@ void MixxxMainWindow::initMenuBar() {
     m_pOptionsMenu->addAction(m_pOptionsKeyboard);
     m_pOptionsMenu->addSeparator();
     m_pOptionsMenu->addAction(m_pOptionsPreferences);
-
-    m_pLibraryMenu->addAction(m_pLibraryRescan);
-    m_pLibraryMenu->addSeparator();
-    m_pLibraryMenu->addAction(m_pPlaylistsNew);
-    m_pLibraryMenu->addAction(m_pCratesNew);
 
     // menuBar entry viewMenu
     //viewMenu->setCheckable(true);
@@ -1658,7 +1655,6 @@ void MixxxMainWindow::initMenuBar() {
     m_pHelpMenu->addAction(m_pHelpAboutApp);
 
     menuBar()->addMenu(m_pFileMenu);
-    menuBar()->addMenu(m_pLibraryMenu);
     menuBar()->addMenu(m_pViewMenu);
     menuBar()->addMenu(m_pOptionsMenu);
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1113,6 +1113,25 @@ void MixxxMainWindow::initActions()
     m_pFileQuit->setWhatsThis(buildWhatsThis(quitTitle, quitText));
     connect(m_pFileQuit, SIGNAL(triggered()), this, SLOT(slotFileQuit()));
 
+    
+    QString player3LoadStatusText = loadTrackStatusText.arg(QString::number(3));
+    m_pFileLoadSongPlayer3 = new QAction(loadTrackText.arg(QString::number(3)), this);
+    m_pFileLoadSongPlayer3->setShortcutContext(Qt::ApplicationShortcut);
+    m_pFileLoadSongPlayer3->setStatusTip(player3LoadStatusText);
+    m_pFileLoadSongPlayer3->setWhatsThis(
+        buildWhatsThis(openText, player3LoadStatusText));
+    connect(m_pFileLoadSongPlayer3, SIGNAL(triggered()),
+            this, SLOT(slotFileLoadSongPlayer3()));
+    
+    QString player4LoadStatusText = loadTrackStatusText.arg(QString::number(4));
+    m_pFileLoadSongPlayer4 = new QAction(loadTrackText.arg(QString::number(4)), this);
+    m_pFileLoadSongPlayer4->setShortcutContext(Qt::ApplicationShortcut);
+    m_pFileLoadSongPlayer4->setStatusTip(player4LoadStatusText);
+    m_pFileLoadSongPlayer4->setWhatsThis(
+        buildWhatsThis(openText, player4LoadStatusText));
+    connect(m_pFileLoadSongPlayer4, SIGNAL(triggered()),
+            this, SLOT(slotFileLoadSongPlayer4()));
+    
     QString rescanTitle = tr("&Rescan Library");
     QString rescanText = tr("Rescans library folders for changes to tracks.");
     m_pLibraryRescan = new QAction(rescanTitle, this);
@@ -1577,6 +1596,8 @@ void MixxxMainWindow::initMenuBar() {
     // menuBar entry fileMenu
     m_pFileMenu->addAction(m_pFileLoadSongPlayer1);
     m_pFileMenu->addAction(m_pFileLoadSongPlayer2);
+    m_pFileMenu->addAction(m_pFileLoadSongPlayer3);
+    m_pFileMenu->addAction(m_pFileLoadSongPlayer4);
     m_pFileMenu->addSeparator();
     m_pFileMenu->addAction(m_pFileQuit);
 
@@ -1695,6 +1716,14 @@ void MixxxMainWindow::slotFileLoadSongPlayer1() {
 
 void MixxxMainWindow::slotFileLoadSongPlayer2() {
     slotFileLoadSongPlayer(2);
+}
+
+void MixxxMainWindow::slotFileLoadSongPlayer3() {
+    slotFileLoadSongPlayer(3);
+}
+
+void MixxxMainWindow::slotFileLoadSongPlayer4() {
+    slotFileLoadSongPlayer(4);
 }
 
 void MixxxMainWindow::slotFileQuit()

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -84,6 +84,10 @@ class MixxxMainWindow : public QMainWindow {
     void slotFileLoadSongPlayer1();
     // Opens a file in player 2
     void slotFileLoadSongPlayer2();
+    // Opens a file in player 3
+    void slotFileLoadSongPlayer3();
+    // Opens a file in player 4
+    void slotFileLoadSongPlayer4();
     // exits the application
     void slotFileQuit();
 
@@ -223,8 +227,6 @@ class MixxxMainWindow : public QMainWindow {
     QMenu* m_pFileMenu;
     // edit_menu contains all items of the menubar entry "Edit"
     QMenu* m_pEditMenu;
-    // library menu
-    QMenu* m_pLibraryMenu;
     // options_menu contains all items of the menubar entry "Options"
     QMenu* m_pOptionsMenu;
     // view_menu contains all items of the menubar entry "View"
@@ -236,6 +238,8 @@ class MixxxMainWindow : public QMainWindow {
 
     QAction* m_pFileLoadSongPlayer1;
     QAction* m_pFileLoadSongPlayer2;
+    QAction* m_pFileLoadSongPlayer3;
+    QAction* m_pFileLoadSongPlayer4;
     QAction* m_pFileQuit;
     QAction* m_pPlaylistsNew;
     QAction* m_pCratesNew;


### PR DESCRIPTION
The Library menu was kinda awkward with just 3 lonely menu items. The file menu also only had a few menu items. I think it makes sense to consolidate them into one menu. This begins to implement https://blueprints.launchpad.net/mixxx/+spec/library-scan-analyze-reorganization
Screenshot:
![mixxx-new-file-menu](https://cloud.githubusercontent.com/assets/9455094/8728334/26bffc1a-2baa-11e5-92d3-451826154187.png)
