### PR TITLE
CachingReader: Reduce log spam for corrupt files

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -639,6 +639,7 @@ class MixxxCore(Feature):
                    "engine/readaheadmanager.cpp",
                    "engine/enginetalkoverducking.cpp",
                    "cachingreader.cpp",
+                   "cachingreaderchunk.cpp",
                    "cachingreaderworker.cpp",
 
                    "analyserrg.cpp",

--- a/src/cachingreader.cpp
+++ b/src/cachingreader.cpp
@@ -389,8 +389,7 @@ void CachingReader::hintAndMaybeWake(const HintVector& hintList) {
                     qDebug() << "ERROR: Couldn't allocate spare CachingReaderChunk to make CachingReaderChunkReadRequest.";
                     continue;
                 }
-                CachingReaderChunkReadRequest request;
-                request.chunk = pChunk;
+                CachingReaderChunkReadRequest request(pChunk);
                 pChunk->giveToWorker();
                 // qDebug() << "Requesting read of chunk" << current << "into" << pChunk;
                 // qDebug() << "Requesting read into " << request.chunk->data;

--- a/src/cachingreader.cpp
+++ b/src/cachingreader.cpp
@@ -13,6 +13,9 @@
 
 namespace {
 
+// NOTE(uklotzde): The following comment has been adopted without
+// modifications and should be rephrased.
+//
 // To prevent every bit of code having to guess how many samples
 // forward it makes sense to keep in memory, the hinter can provide
 // either 0 for a forward hint or -1 for a backward hint. We should

--- a/src/cachingreader.cpp
+++ b/src/cachingreader.cpp
@@ -55,8 +55,7 @@ CachingReader::CachingReader(QString group,
     for (int i = 0; i < maximumChunksInMemory; ++i) {
         Chunk* c = new Chunk;
         c->chunk_number = -1;
-        c->frameCountRead = 0;
-        c->frameCountTotal = 0;
+        c->frameCount = 0;
         c->stereoSamples = bufferStart;
         c->next_lru = NULL;
         c->prev_lru = NULL;
@@ -158,8 +157,7 @@ void CachingReader::freeChunk(Chunk* pChunk) {
     m_mruChunk = removeFromLRUList(pChunk, m_mruChunk);
     pChunk->state = Chunk::FREE;
     pChunk->chunk_number = -1;
-    pChunk->frameCountRead = 0;
-    pChunk->frameCountTotal = 0;
+    pChunk->frameCount = 0;
     m_freeChunks.push_back(pChunk);
 }
 
@@ -180,8 +178,7 @@ void CachingReader::freeAllChunks() {
         if (pChunk->state != Chunk::FREE) {
             pChunk->state = Chunk::FREE;
             pChunk->chunk_number = -1;
-            pChunk->frameCountRead = 0;
-            pChunk->frameCountTotal = 0;
+            pChunk->frameCount = 0;
             pChunk->next_lru = NULL;
             pChunk->prev_lru = NULL;
             m_freeChunks.append(pChunk);
@@ -391,7 +388,7 @@ int CachingReader::read(int sample, int numSamples, CSAMPLE* buffer) {
             const SINT chunkFrameOffset = frameIndex - chunkFrameIndex;
             DEBUG_ASSERT(chunkFrameOffset >= 0);
             const SINT chunkFrameCount = math_min(
-                    current->frameCountTotal,
+                    current->frameCount,
                     maxReadableFrameIndex - chunkFrameIndex);
 
             const SINT framesToCopy = chunkFrameCount - chunkFrameOffset;

--- a/src/cachingreader.h
+++ b/src/cachingreader.h
@@ -115,43 +115,43 @@ class CachingReader : public QObject {
     // Looks for the provided chunk number in the index of in-memory chunks and
     // returns it if it is present. If not, returns NULL. If it is present then
     // freshenChunk is called on the chunk to make it the MRU chunk.
-    CachingReaderChunk* lookupChunkAndFreshen(SINT chunkIndex);
+    CachingReaderChunkForOwner* lookupChunkAndFreshen(SINT chunkIndex);
 
     // Looks for the provided chunk number in the index of in-memory chunks and
     // returns it if it is present. If not, returns NULL.
-    CachingReaderChunk* lookupChunk(SINT chunkIndex);
+    CachingReaderChunkForOwner* lookupChunk(SINT chunkIndex);
 
     // Moves the provided chunk to the MRU position.
-    void freshenChunk(CachingReaderChunk* pChunk);
+    void freshenChunk(CachingReaderChunkForOwner* pChunk);
 
     // Returns a CachingReaderChunk to the free list
-    void freeChunk(CachingReaderChunk* pChunk);
+    void freeChunk(CachingReaderChunkForOwner* pChunk);
 
     // Returns all allocated chunks to the free list
     void freeAllChunks();
 
     // Gets a chunk from the free list. Returns NULL if none available.
-    CachingReaderChunk* allocateChunk(SINT chunkIndex);
+    CachingReaderChunkForOwner* allocateChunk(SINT chunkIndex);
 
     // Gets a chunk from the free list, frees the LRU CachingReaderChunk if none available.
-    CachingReaderChunk* allocateChunkExpireLRU(SINT chunkIndex);
+    CachingReaderChunkForOwner* allocateChunkExpireLRU(SINT chunkIndex);
 
     ReaderStatus m_readerStatus;
 
     // Keeps track of all CachingReaderChunks we've allocated.
-    QVector<CachingReaderChunk*> m_chunks;
+    QVector<CachingReaderChunkForOwner*> m_chunks;
 
     // List of free chunks. Linked list so that we have constant time insertions
     // and deletions. Iteration is not necessary.
-    QLinkedList<CachingReaderChunk*> m_freeChunks;
+    QLinkedList<CachingReaderChunkForOwner*> m_freeChunks;
 
     // Keeps track of what CachingReaderChunks we've allocated and indexes them based on what
     // chunk number they are allocated to.
-    QHash<int, CachingReaderChunk*> m_allocatedCachingReaderChunks;
+    QHash<int, CachingReaderChunkForOwner*> m_allocatedCachingReaderChunks;
 
     // The linked list of recently-used chunks.
-    CachingReaderChunk* m_mruCachingReaderChunk;
-    CachingReaderChunk* m_lruCachingReaderChunk;
+    CachingReaderChunkForOwner* m_mruCachingReaderChunk;
+    CachingReaderChunkForOwner* m_lruCachingReaderChunk;
 
     // The raw memory buffer which is divided up into chunks.
     SampleBuffer m_sampleBuffer;

--- a/src/cachingreader.h
+++ b/src/cachingreader.h
@@ -79,7 +79,7 @@ class CachingReader : public QObject {
 
     // Read num_samples from the SoundSource starting with sample into
     // buffer. Returns the total number of samples actually written to buffer.
-    virtual int read(int sample, int num_samples, CSAMPLE* buffer);
+    virtual int read(int sample, int numSamples, CSAMPLE* buffer);
 
     // Issue a list of hints, but check whether any of the hints request a chunk
     // that is not in the cache. If any hints do request a chunk not in cache,
@@ -166,10 +166,10 @@ class CachingReader : public QObject {
     // The raw memory buffer which is divided up into chunks.
     SampleBuffer m_sampleBuffer;
 
-    // The maximum valid frame index as reported by the worker.
+    // The maximum readable frame index as reported by the worker.
     // This frame index references the frame that follows the last
     // frame with sample data.
-    SINT m_maxFrameIndex;
+    SINT m_maxReadableFrameIndex;
 
     CachingReaderWorker m_worker;
 };

--- a/src/cachingreader.h
+++ b/src/cachingreader.h
@@ -166,7 +166,10 @@ class CachingReader : public QObject {
     // The raw memory buffer which is divided up into chunks.
     SampleBuffer m_sampleBuffer;
 
-    int m_iTrackNumFramesCallbackSafe;
+    // The maximum valid frame index as reported by the worker.
+    // This frame index references the frame that follows the last
+    // frame with sample data.
+    SINT m_maxFrameIndex;
 
     CachingReaderWorker m_worker;
 };

--- a/src/cachingreader.h
+++ b/src/cachingreader.h
@@ -113,12 +113,12 @@ class CachingReader : public QObject {
     FIFO<ReaderStatusUpdate> m_readerStatusFIFO;
 
     // Looks for the provided chunk number in the index of in-memory chunks and
-    // returns it if it is present. If not, returns NULL. If it is present then
+    // returns it if it is present. If not, returns nullptr. If it is present then
     // freshenChunk is called on the chunk to make it the MRU chunk.
     CachingReaderChunkForOwner* lookupChunkAndFreshen(SINT chunkIndex);
 
     // Looks for the provided chunk number in the index of in-memory chunks and
-    // returns it if it is present. If not, returns NULL.
+    // returns it if it is present. If not, returns nullptr.
     CachingReaderChunkForOwner* lookupChunk(SINT chunkIndex);
 
     // Moves the provided chunk to the MRU position.
@@ -130,7 +130,7 @@ class CachingReader : public QObject {
     // Returns all allocated chunks to the free list
     void freeAllChunks();
 
-    // Gets a chunk from the free list. Returns NULL if none available.
+    // Gets a chunk from the free list. Returns nullptr if none available.
     CachingReaderChunkForOwner* allocateChunk(SINT chunkIndex);
 
     // Gets a chunk from the free list, frees the LRU CachingReaderChunk if none available.

--- a/src/cachingreader.h
+++ b/src/cachingreader.h
@@ -111,8 +111,16 @@ class CachingReader : public QObject {
     static Chunk* insertIntoLRUList(Chunk* chunk, Chunk* head);
 
     // Given a sample number, return the chunk number corresponding to it.
-    inline static int chunkForFrame(int frame_number) {
-        return frame_number / CachingReaderWorker::kFramesPerChunk;
+    inline static SINT chunkForFrame(SINT frameIndex) {
+        return frameIndex / CachingReaderWorker::kFramesPerChunk;
+    }
+
+    inline static SINT frames2samples(SINT frames) {
+        return frames * CachingReaderWorker::kChunkChannels;
+    }
+    inline static SINT samples2frames(SINT samples) {
+        DEBUG_ASSERT(0 == (samples % CachingReaderWorker::kChunkChannels));
+        return samples / CachingReaderWorker::kChunkChannels;
     }
 
     const ConfigObject<ConfigValue>* m_pConfig;

--- a/src/cachingreader.h
+++ b/src/cachingreader.h
@@ -93,7 +93,7 @@ class CachingReader : public QObject {
     virtual void newTrack(TrackPointer pTrack);
 
     void setScheduler(EngineWorkerScheduler* pScheduler) {
-        m_pWorker->setScheduler(pScheduler);
+        m_worker.setScheduler(pScheduler);
     }
 
     const static int maximumChunksInMemory;
@@ -168,7 +168,7 @@ class CachingReader : public QObject {
 
     int m_iTrackNumFramesCallbackSafe;
 
-    CachingReaderWorker* m_pWorker;
+    CachingReaderWorker m_worker;
 };
 
 

--- a/src/cachingreaderchunk.cpp
+++ b/src/cachingreaderchunk.cpp
@@ -1,0 +1,165 @@
+#include <QtDebug>
+
+#include "cachingreaderchunk.h"
+
+#include "sampleutil.h"
+#include "util/math.h"
+
+
+const SINT CachingReaderChunk::kDefaultIndex = -1;
+
+// One chunk should contain 1/2 - 1/4th of a second of audio.
+// 8192 frames contain about 170 ms of audio at 48 kHz, which
+// is well above (hopefully) the latencies people are seeing.
+// At 10 ms latency one chunk is enough for 17 callbacks.
+// Additionally the chunk size should be a power of 2 for
+// easier memory alignment.
+// TODO(XXX): The optimum value of the "constant" kFrames depends
+// on the properties of the AudioSource as the remarks above suggest!
+const SINT CachingReaderChunk::kChannels = Mixxx::AudioSource::kChannelCountStereo;
+const SINT CachingReaderChunk::kFrames = 8192; // ~ 170 ms at 48 kHz
+const SINT CachingReaderChunk::kSamples =
+        CachingReaderChunk::frames2samples(CachingReaderChunk::kFrames);
+
+CachingReaderChunk::CachingReaderChunk(
+        CSAMPLE* sampleBuffer)
+        : m_index(kDefaultIndex),
+          m_pPrev(nullptr),
+          m_pNext(nullptr),
+          m_state(FREE),
+          m_sampleBuffer(sampleBuffer),
+          m_frameCount(0) {
+}
+
+CachingReaderChunk::~CachingReaderChunk() {
+    DEBUG_ASSERT(READ_PENDING != m_state);
+}
+
+void CachingReaderChunk::init(SINT index) {
+    DEBUG_ASSERT(kDefaultIndex == m_index);
+    DEBUG_ASSERT(FREE == m_state);
+    m_index = index;
+    m_state = READY;
+}
+
+void CachingReaderChunk::free() {
+    DEBUG_ASSERT(READ_PENDING != m_state);
+    m_index = kDefaultIndex;
+    m_state = FREE;
+    m_frameCount = 0;
+}
+
+void CachingReaderChunk::insertIntoListBefore(
+        CachingReaderChunk* pBefore) {
+    DEBUG_ASSERT(nullptr == m_pNext);
+    DEBUG_ASSERT(nullptr == m_pPrev);
+
+    m_pNext = pBefore;
+    if (pBefore) {
+        if (pBefore->m_pPrev) {
+            m_pPrev = pBefore->m_pPrev;
+            DEBUG_ASSERT(m_pPrev->m_pNext == pBefore);
+            m_pPrev->m_pNext = this;
+        }
+        pBefore->m_pPrev = this;
+    }
+}
+
+void CachingReaderChunk::removeFromList(
+        CachingReaderChunk** ppHead,
+        CachingReaderChunk** ppTail) {
+    // Remove this chunk from the doubly-linked list...
+    CachingReaderChunk* pNext = m_pNext;
+    CachingReaderChunk* pPrev = m_pPrev;
+    m_pNext = nullptr;
+    m_pPrev = nullptr;
+
+    // ...reconnect the remaining list elements...
+    if (pNext) {
+        DEBUG_ASSERT(this == pNext->m_pPrev);
+        pNext->m_pPrev = pPrev;
+    }
+    if (pPrev) {
+        DEBUG_ASSERT(this == pPrev->m_pNext);
+        pPrev->m_pNext = pNext;
+    }
+
+    // ...and adjust head/tail.
+    if (ppHead && (this == *ppHead)) {
+        *ppHead = pNext;
+    }
+    if (ppTail && (this == *ppTail)) {
+        *ppTail = pPrev;
+    }
+}
+
+bool CachingReaderChunk::isReadable(
+        const Mixxx::AudioSourcePointer& pAudioSource,
+        SINT maxReadableFrameIndex) const {
+    DEBUG_ASSERT(getState() != FREE);
+    DEBUG_ASSERT(Mixxx::AudioSource::getMinFrameIndex() <= maxReadableFrameIndex);
+
+    if (!isValid() || pAudioSource.isNull()) {
+        return false;
+    }
+    const SINT frameIndex = frameForIndex(getIndex());
+    const SINT maxFrameIndex = math_min(
+            maxReadableFrameIndex, pAudioSource->getMaxFrameIndex());
+    return frameIndex <= maxFrameIndex;
+}
+
+SINT CachingReaderChunk::readSampleFrames(
+        const Mixxx::AudioSourcePointer& pAudioSource,
+        SINT* pMaxReadableFrameIndex) {
+    DEBUG_ASSERT(getState() == READ_PENDING);
+    DEBUG_ASSERT(pMaxReadableFrameIndex);
+
+    const SINT frameIndex = frameForIndex(getIndex());
+    const SINT maxFrameIndex = math_min(
+            *pMaxReadableFrameIndex, pAudioSource->getMaxFrameIndex());
+    const SINT seekFrameIndex =
+            pAudioSource->seekSampleFrame(frameIndex);
+    if (seekFrameIndex != frameIndex) {
+        // Failed to seek to the requested index. The file might
+        // be corrupt and decoding should be aborted.
+        qWarning() << "Failed to seek chunk position:"
+                << "actual =" << seekFrameIndex
+                << ", expected =" << frameIndex
+                << ", maximum =" << maxFrameIndex;
+        if (seekFrameIndex <= frameIndex) {
+            // Unexpected/premature end of file -> prevent further
+            // seeks beyond the current seek position
+            *pMaxReadableFrameIndex = math_min(seekFrameIndex, *pMaxReadableFrameIndex);
+        }
+        // Don't read any sample on a seek failure
+        m_frameCount = 0;
+    } else {
+        const SINT framesRemaining =
+                *pMaxReadableFrameIndex - seekFrameIndex;
+        const SINT framesToRead =
+                math_min(kFrames, framesRemaining);
+        DEBUG_ASSERT(CachingReaderChunk::kChannels
+                == Mixxx::AudioSource::kChannelCountStereo);
+        m_frameCount = pAudioSource->readSampleFramesStereo(
+                framesToRead, m_sampleBuffer, kSamples);
+        if (m_frameCount < framesToRead) {
+            qWarning() << "Failed to read chunk samples:"
+                    << "actual =" << m_frameCount
+                    << ", expected =" << framesToRead;
+            // Adjust the max. readable frame index for future
+            // read requests to avoid repeated invalid reads.
+            *pMaxReadableFrameIndex = frameIndex + m_frameCount;
+        }
+    }
+
+    return m_frameCount;
+}
+
+void CachingReaderChunk::copySamples(
+        CSAMPLE* sampleBuffer, SINT sampleOffset, SINT sampleCount) const {
+    DEBUG_ASSERT(getState() == READY);
+    DEBUG_ASSERT(0 <= sampleOffset);
+    DEBUG_ASSERT(0 <= sampleCount);
+    DEBUG_ASSERT((sampleOffset + sampleCount) <= frames2samples(m_frameCount));
+    SampleUtil::copy(sampleBuffer, m_sampleBuffer + sampleOffset, sampleCount);
+}

--- a/src/cachingreaderchunk.cpp
+++ b/src/cachingreaderchunk.cpp
@@ -6,7 +6,7 @@
 #include "util/math.h"
 
 
-const SINT CachingReaderChunkWorker::kInvalidIndex = -1;
+const SINT CachingReaderChunkForWorker::kInvalidIndex = -1;
 
 // One chunk should contain 1/2 - 1/4th of a second of audio.
 // 8192 frames contain about 170 ms of audio at 48 kHz, which
@@ -16,27 +16,27 @@ const SINT CachingReaderChunkWorker::kInvalidIndex = -1;
 // easier memory alignment.
 // TODO(XXX): The optimum value of the "constant" kFrames depends
 // on the properties of the AudioSource as the remarks above suggest!
-const SINT CachingReaderChunkWorker::kChannels = Mixxx::AudioSource::kChannelCountStereo;
-const SINT CachingReaderChunkWorker::kFrames = 8192; // ~ 170 ms at 48 kHz
-const SINT CachingReaderChunkWorker::kSamples =
-        CachingReaderChunkWorker::frames2samples(CachingReaderChunkWorker::kFrames);
+const SINT CachingReaderChunkForWorker::kChannels = Mixxx::AudioSource::kChannelCountStereo;
+const SINT CachingReaderChunkForWorker::kFrames = 8192; // ~ 170 ms at 48 kHz
+const SINT CachingReaderChunkForWorker::kSamples =
+        CachingReaderChunkForWorker::frames2samples(CachingReaderChunkForWorker::kFrames);
 
-CachingReaderChunkWorker::CachingReaderChunkWorker(
+CachingReaderChunkForWorker::CachingReaderChunkForWorker(
         CSAMPLE* sampleBuffer)
         : m_index(kInvalidIndex),
           m_sampleBuffer(sampleBuffer),
           m_frameCount(0) {
 }
 
-CachingReaderChunkWorker::~CachingReaderChunkWorker() {
+CachingReaderChunkForWorker::~CachingReaderChunkForWorker() {
 }
 
-void CachingReaderChunkWorker::init(SINT index) {
+void CachingReaderChunkForWorker::init(SINT index) {
     m_index = index;
     m_frameCount = 0;
 }
 
-bool CachingReaderChunkWorker::isReadable(
+bool CachingReaderChunkForWorker::isReadable(
         const Mixxx::AudioSourcePointer& pAudioSource,
         SINT maxReadableFrameIndex) const {
     DEBUG_ASSERT(Mixxx::AudioSource::getMinFrameIndex() <= maxReadableFrameIndex);
@@ -50,7 +50,7 @@ bool CachingReaderChunkWorker::isReadable(
     return frameIndex <= maxFrameIndex;
 }
 
-SINT CachingReaderChunkWorker::readSampleFrames(
+SINT CachingReaderChunkForWorker::readSampleFrames(
         const Mixxx::AudioSourcePointer& pAudioSource,
         SINT* pMaxReadableFrameIndex) {
     DEBUG_ASSERT(pMaxReadableFrameIndex);
@@ -110,7 +110,7 @@ SINT CachingReaderChunkWorker::readSampleFrames(
     return m_frameCount;
 }
 
-void CachingReaderChunkWorker::copySamples(
+void CachingReaderChunkForWorker::copySamples(
         CSAMPLE* sampleBuffer, SINT sampleOffset, SINT sampleCount) const {
     DEBUG_ASSERT(0 <= sampleOffset);
     DEBUG_ASSERT(0 <= sampleCount);
@@ -120,7 +120,7 @@ void CachingReaderChunkWorker::copySamples(
 
 CachingReaderChunk::CachingReaderChunk(
         CSAMPLE* sampleBuffer)
-        : CachingReaderChunkWorker(sampleBuffer),
+        : CachingReaderChunkForWorker(sampleBuffer),
           m_state(FREE),
           m_pPrev(nullptr),
           m_pNext(nullptr) {
@@ -131,13 +131,13 @@ CachingReaderChunk::~CachingReaderChunk() {
 
 void CachingReaderChunk::init(SINT index) {
     DEBUG_ASSERT(READ_PENDING != m_state);
-    CachingReaderChunkWorker::init(index);
+    CachingReaderChunkForWorker::init(index);
     m_state = READY;
 }
 
 void CachingReaderChunk::free() {
     DEBUG_ASSERT(READ_PENDING != m_state);
-    CachingReaderChunkWorker::init(kInvalidIndex);
+    CachingReaderChunkForWorker::init(kInvalidIndex);
     m_state = FREE;
 }
 

--- a/src/cachingreaderchunk.cpp
+++ b/src/cachingreaderchunk.cpp
@@ -6,7 +6,7 @@
 #include "util/math.h"
 
 
-const SINT CachingReaderChunkWorker::kDefaultIndex = -1;
+const SINT CachingReaderChunkWorker::kInvalidIndex = -1;
 
 // One chunk should contain 1/2 - 1/4th of a second of audio.
 // 8192 frames contain about 170 ms of audio at 48 kHz, which
@@ -23,7 +23,7 @@ const SINT CachingReaderChunkWorker::kSamples =
 
 CachingReaderChunkWorker::CachingReaderChunkWorker(
         CSAMPLE* sampleBuffer)
-        : m_index(kDefaultIndex),
+        : m_index(kInvalidIndex),
           m_sampleBuffer(sampleBuffer),
           m_frameCount(0) {
 }
@@ -137,7 +137,7 @@ void CachingReaderChunk::init(SINT index) {
 
 void CachingReaderChunk::free() {
     DEBUG_ASSERT(READ_PENDING != m_state);
-    CachingReaderChunkWorker::init(kDefaultIndex);
+    CachingReaderChunkWorker::init(kInvalidIndex);
     m_state = FREE;
 }
 

--- a/src/cachingreaderchunk.h
+++ b/src/cachingreaderchunk.h
@@ -1,0 +1,130 @@
+#ifndef CACHINGREADERCHUNK_H
+#define CACHINGREADERCHUNK_H
+
+#include "sources/audiosource.h"
+
+
+// A Chunk is a memory-resident section of audio that has been cached.
+// Each chunk holds a fixed number kFrames of frames with samples for
+// kChannels.
+// The class is not thread-safe although it is shared between CachingReader
+// and CachingReaderWorker! A lock-free FIFO ensures that only a single
+// thread has exclusive access on each chunk. The state READ_PENDING
+// indicates that the worker thread is in control.
+class CachingReaderChunk {
+public:
+    static const SINT kDefaultIndex;
+    static const SINT kChannels;
+    static const SINT kFrames;
+    static const SINT kSamples;
+
+    // Returns the corresponding chunk index for a frame index
+    inline static SINT indexForFrame(SINT frameIndex) {
+        DEBUG_ASSERT(Mixxx::AudioSource::getMinFrameIndex() <= frameIndex);
+        const SINT chunkIndex = frameIndex / kFrames;
+        return chunkIndex;
+    }
+
+    // Returns the corresponding chunk index for a frame index
+    inline static SINT frameForIndex(SINT chunkIndex) {
+        DEBUG_ASSERT(0 <= chunkIndex);
+        return chunkIndex * kFrames;
+    }
+
+    // Converts frames to samples
+    inline static SINT frames2samples(SINT frames) {
+        return frames * kChannels;
+    }
+    // Converts samples to frames
+    inline static SINT samples2frames(SINT samples) {
+        DEBUG_ASSERT(0 == (samples % kChannels));
+        return samples / kChannels;
+    }
+
+    explicit CachingReaderChunk(CSAMPLE* sampleBuffer);
+    virtual ~CachingReaderChunk();
+
+    void init(SINT index);
+    void free();
+
+    enum State {
+        FREE,
+        READY,
+        READ_PENDING
+    };
+
+    State getState() const {
+        return m_state;
+    }
+
+    // Please note that the state must exclusively be controlled by the
+    // cache and not the worker thread!
+    void beginReading() {
+        DEBUG_ASSERT(READY == m_state);
+        m_state = READ_PENDING;
+    }
+    void finishReading() {
+        DEBUG_ASSERT(READ_PENDING == m_state);
+        m_state = READY;
+    }
+
+    // Inserts a chunk into the double-linked list before the
+    // given element
+    void insertIntoListBefore(
+            CachingReaderChunk* pBefore);
+    // Removes a chunk from the double-linked list and optionally
+    // adjusts head/tail pointers
+    void removeFromList(
+            CachingReaderChunk** ppHead,
+            CachingReaderChunk** ppTail);
+
+    SINT getIndex() const {
+        return m_index;
+    }
+
+    bool isValid() const {
+        return 0 <= getIndex();
+    }
+
+    SINT getFrameCount() const {
+        return m_frameCount;
+    }
+
+    // Check if the audio source has sample data available
+    // for this chunk.
+    bool isReadable(
+            const Mixxx::AudioSourcePointer& pAudioSource,
+            SINT maxReadableFrameIndex) const;
+
+    // Read sample frames from the audio source and return the
+    // number of frames that have been read. The in/out parameter
+    // pMaxReadableFrameIndex is adjusted if reading fails.
+    SINT readSampleFrames(
+            const Mixxx::AudioSourcePointer& pAudioSource,
+            SINT* pMaxReadableFrameIndex);
+
+    // Copy sampleCount samples starting at sampleOffset from
+    // the chunk's internal buffer into sampleBuffer.
+    void copySamples(
+            CSAMPLE* sampleBuffer,
+            SINT sampleOffset,
+            SINT sampleCount) const;
+
+private:
+    SINT m_index;
+
+    CachingReaderChunk* m_pPrev; // in double-linked list
+    CachingReaderChunk* m_pNext; // in double-linked list
+
+    // The state is read from both the cache and the worker thread.
+    // But only the cache is allowed to modify the state.
+    volatile State m_state;
+
+    // The worker thread will fill the sample buffer and
+    // set the frame count.
+    CSAMPLE* const m_sampleBuffer;
+    SINT m_frameCount;
+};
+
+
+#endif // CACHINGREADERCHUNK_H

--- a/src/cachingreaderchunk.h
+++ b/src/cachingreaderchunk.h
@@ -40,6 +40,7 @@ public:
         return samples / kChannels;
     }
 
+    CachingReaderChunkForWorker(const CachingReaderChunkForWorker&) = delete;
     virtual ~CachingReaderChunkForWorker();
 
     SINT getIndex() const {

--- a/src/cachingreaderchunk.h
+++ b/src/cachingreaderchunk.h
@@ -12,7 +12,7 @@
 // is available for both the worker thread and the cache.
 class CachingReaderChunkWorker {
 public:
-    static const SINT kDefaultIndex;
+    static const SINT kInvalidIndex;
     static const SINT kChannels;
     static const SINT kFrames;
     static const SINT kSamples;
@@ -121,11 +121,15 @@ public:
     }
 
     // Inserts a chunk into the double-linked list before the
-    // given element
+    // given chunk. If the list is currently empty simply pass
+    // pBefore = nullptr. Please note that if pBefore points to
+    // the head of the current list this chunk becomes the new
+    // head of the list.
     void insertIntoListBefore(
             CachingReaderChunk* pBefore);
     // Removes a chunk from the double-linked list and optionally
-    // adjusts head/tail pointers
+    // adjusts head/tail pointers. Pass ppHead/ppTail = nullptr if
+    // you prefer to adjust those pointers manually.
     void removeFromList(
             CachingReaderChunk** ppHead,
             CachingReaderChunk** ppTail);

--- a/src/cachingreaderchunk.h
+++ b/src/cachingreaderchunk.h
@@ -109,13 +109,12 @@ public:
         return m_state;
     }
 
-    // Please note that the state must exclusively be controlled by the
-    // cache and not the worker thread!
-    void beginReading() {
+    // The state is controlled by the cache as the owner of each chunk!
+    void giveToWorker() {
         DEBUG_ASSERT(READY == m_state);
         m_state = READ_PENDING;
     }
-    void finishReading() {
+    void takeFromWorker() {
         DEBUG_ASSERT(READ_PENDING == m_state);
         m_state = READY;
     }

--- a/src/cachingreaderchunk.h
+++ b/src/cachingreaderchunk.h
@@ -10,7 +10,7 @@
 // and CachingReaderWorker! A lock-free FIFO ensures that only a single
 // thread has exclusive access on each chunk. This abstract base class
 // is available for both the worker thread and the cache.
-class CachingReaderChunkWorker {
+class CachingReaderChunkForWorker {
 public:
     static const SINT kInvalidIndex;
     static const SINT kChannels;
@@ -40,7 +40,7 @@ public:
         return samples / kChannels;
     }
 
-    virtual ~CachingReaderChunkWorker();
+    virtual ~CachingReaderChunkForWorker();
 
     SINT getIndex() const {
         return m_index;
@@ -75,7 +75,7 @@ public:
             SINT sampleCount) const;
 
 protected:
-    explicit CachingReaderChunkWorker(CSAMPLE* sampleBuffer);
+    explicit CachingReaderChunkForWorker(CSAMPLE* sampleBuffer);
 
     void init(SINT index);
 
@@ -91,7 +91,7 @@ private:
 // The derived class is only accessible for the cache, but not the
 // worker thread. The state READ_PENDING indicates that the worker
 // thread is in control.
-class CachingReaderChunk: public CachingReaderChunkWorker {
+class CachingReaderChunk: public CachingReaderChunkForWorker {
 public:
     explicit CachingReaderChunk(CSAMPLE* sampleBuffer);
     virtual ~CachingReaderChunk();

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -1,33 +1,19 @@
 #include <QtDebug>
 #include <QFileInfo>
+#include <QMutexLocker>
 
 #include "controlobject.h"
 #include "controlobjectthread.h"
 
 #include "cachingreaderworker.h"
-#include "trackinfoobject.h"
-#include "sampleutil.h"
 #include "soundsourceproxy.h"
 #include "util/compatibility.h"
 #include "util/event.h"
-#include "util/math.h"
 
 
-// One chunk should contain 1/2 - 1/4th of a second of audio.
-// 8192 frames contain about 170 ms of audio at 48 kHz, which
-// is well above (hopefully) the latencies people are seeing.
-// At 10 ms latency one chunk is enough for 17 callbacks.
-// Additionally the chunk size should be a power of 2 for
-// easier memory alignment.
-// TODO(XXX): The optimum value of the "constant" kFramesPerChunk
-// depends on the properties of the AudioSource as the remarks
-// above suggest!
-const SINT CachingReaderWorker::kChunkChannels = Mixxx::AudioSource::kChannelCountStereo;
-const SINT CachingReaderWorker::kFramesPerChunk = 8192; // ~ 170 ms at 48 kHz
-const SINT CachingReaderWorker::kSamplesPerChunk = kFramesPerChunk * kChunkChannels;
-
-CachingReaderWorker::CachingReaderWorker(QString group,
-        FIFO<ChunkReadRequest>* pChunkReadRequestFIFO,
+CachingReaderWorker::CachingReaderWorker(
+        QString group,
+        FIFO<CachingReaderChunkReadRequest>* pChunkReadRequestFIFO,
         FIFO<ReaderStatusUpdate>* pReaderStatusFIFO)
         : m_group(group),
           m_tag(QString("CachingReaderWorker %1").arg(m_group)),
@@ -40,91 +26,41 @@ CachingReaderWorker::CachingReaderWorker(QString group,
 CachingReaderWorker::~CachingReaderWorker() {
 }
 
-void CachingReaderWorker::processChunkReadRequest(
-        ChunkReadRequest* request,
+void CachingReaderWorker::processCachingReaderChunkReadRequest(
+        CachingReaderChunkReadRequest* request,
         ReaderStatusUpdate* update) {
-    //qDebug() << "Processing ChunkReadRequest for" << chunk_number;
+    //qDebug() << "Processing CachingReaderChunkReadRequest for" << chunk_number;
 
+    // Initialize the output parameters
     update->maxReadableFrameIndex = m_maxReadableFrameIndex;
-
-    // Initialize the output parameter
     update->chunk = request->chunk;
-    update->chunk->frameCount = 0;
 
-    const int chunk_number = request->chunk->chunk_number;
-    if (!m_pAudioSource || chunk_number < 0) {
+    if (!update->chunk->isReadable(m_pAudioSource, m_maxReadableFrameIndex)) {
         update->status = CHUNK_READ_INVALID;
         return;
     }
 
-    const SINT chunkFrameIndex =
-            frameForChunk(chunk_number);
-    if (!m_pAudioSource->isValidFrameIndex(chunkFrameIndex)) {
-        // Frame index out of range
-        qWarning() << "Invalid chunk seek position"
-                << chunkFrameIndex;
-        update->status = CHUNK_READ_INVALID;
-        return;
-    }
-    if (chunkFrameIndex >= m_maxReadableFrameIndex) {
-        // No more data available for reading
-        update->status = CHUNK_READ_EOF;
-        return;
-    }
+    const SINT framesRead = request->chunk->readSampleFrames(
+            m_pAudioSource, &m_maxReadableFrameIndex);
 
-    const SINT seekFrameIndex =
-            m_pAudioSource->seekSampleFrame(chunkFrameIndex);
-    if (seekFrameIndex != chunkFrameIndex) {
-        // Failed to seek to the requested index. The file might
-        // be corrupt and decoding should be aborted.
-        qWarning() << "Failed to seek chunk position:"
-                << "actual =" << seekFrameIndex
-                << ", expected =" << chunkFrameIndex
-                << ", maximum =" << m_maxReadableFrameIndex;
-        if (seekFrameIndex <= chunkFrameIndex) {
-            // unexpected/premature end of file -> prevent further
-            // seeks beyond the current seek position
-            m_maxReadableFrameIndex = math_min(seekFrameIndex, m_maxReadableFrameIndex);
-            update->maxReadableFrameIndex = m_maxReadableFrameIndex;
+    if (0 < framesRead) {
+        update->status = CHUNK_READ_SUCCESS;
+    } else {
+        // The chunk might have become unreadable during the previous
+        // read attempt if no data is available. Otherwise we have simply
+        // reached the end of the track.
+        if (update->chunk->isReadable(m_pAudioSource, m_maxReadableFrameIndex)) {
             update->status = CHUNK_READ_EOF;
         } else {
             update->status = CHUNK_READ_INVALID;
         }
-        return;
-    }
-
-    const SINT framesRemaining =
-            m_maxReadableFrameIndex - seekFrameIndex;
-    const SINT framesToRead =
-            math_min(kFramesPerChunk, framesRemaining);
-    if (0 >= framesToRead) {
-        // No more data available for reading
-        update->status = CHUNK_READ_EOF;
-        return;
-    }
-
-    const SINT framesRead =
-            m_pAudioSource->readSampleFramesStereo(
-                    framesToRead, request->chunk->stereoSamples, kSamplesPerChunk);
-    DEBUG_ASSERT(framesRead <= framesToRead);
-    update->chunk->frameCount = framesRead;
-    if (framesRead < framesToRead) {
-        // Incomplete read! Corrupt file?
-        qWarning() << "Incomplete chunk read @" << seekFrameIndex
-                << "[" << Mixxx::AudioSource::getMinFrameIndex()
-                << "," << m_maxReadableFrameIndex
-                << "):" << framesRead << "<" << framesToRead;
-        update->status = CHUNK_READ_PARTIAL;
-    } else {
-        update->status = CHUNK_READ_SUCCESS;
     }
 }
 
 // WARNING: Always called from a different thread (GUI)
 void CachingReaderWorker::newTrack(TrackPointer pTrack) {
-    m_newTrackMutex.lock();
+    QMutexLocker locker(&m_newTrackMutex);
     m_newTrack = pTrack;
-    m_newTrackMutex.unlock();
 }
 
 void CachingReaderWorker::run() {
@@ -132,20 +68,21 @@ void CachingReaderWorker::run() {
     QThread::currentThread()->setObjectName(QString("CachingReaderWorker %1").arg(++id));
 
     TrackPointer pLoadTrack;
-    ChunkReadRequest request;
+    CachingReaderChunkReadRequest request;
     ReaderStatusUpdate status;
 
     Event::start(m_tag);
     while (!load_atomic(m_stop)) {
         if (m_newTrack) {
-            m_newTrackMutex.lock();
-            pLoadTrack = m_newTrack;
-            m_newTrack = TrackPointer();
-            m_newTrackMutex.unlock();
+            { // locking scope
+                QMutexLocker locker(&m_newTrackMutex);
+                pLoadTrack = m_newTrack;
+                m_newTrack = TrackPointer();
+            } // implicitly unlocks the mutex
             loadTrack(pLoadTrack);
         } else if (m_pChunkReadRequestFIFO->read(&request, 1) == 1) {
             // Read the requested chunks.
-            processChunkReadRequest(&request, &status);
+            processCachingReaderChunkReadRequest(&request, &status);
             m_pReaderStatusFIFO->writeBlocking(&status, 1);
         } else {
             Event::end(m_tag);
@@ -176,13 +113,13 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     emit(trackLoading());
 
     ReaderStatusUpdate status;
+    status.status = TRACK_NOT_LOADED;
 
     QString filename = pTrack->getLocation();
     if (filename.isEmpty() || !pTrack->exists()) {
         // Must unlock before emitting to avoid deadlock
         qDebug() << m_group << "CachingReaderWorker::loadTrack() load failed for\""
                  << filename << "\", unlocked reader lock";
-        status.status = TRACK_NOT_LOADED;
         m_pReaderStatusFIFO->writeBlocking(&status, 1);
         emit(trackLoadFailed(
             pTrack, QString("The file '%1' could not be found.").arg(filename)));
@@ -190,7 +127,7 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     }
 
     Mixxx::AudioSourceConfig audioSrcCfg;
-    audioSrcCfg.channelCountHint = kChunkChannels;
+    audioSrcCfg.channelCountHint = CachingReaderChunk::kChannels;
     m_pAudioSource = openAudioSourceForReading(pTrack, audioSrcCfg);
     if (m_pAudioSource.isNull()) {
         m_maxReadableFrameIndex = Mixxx::AudioSource::getMinFrameIndex();
@@ -209,9 +146,9 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     m_pReaderStatusFIFO->writeBlocking(&status, 1);
 
     // Clear the chunks to read list.
-    ChunkReadRequest request;
+    CachingReaderChunkReadRequest request;
     while (m_pChunkReadRequestFIFO->read(&request, 1) == 1) {
-        qDebug() << "Skipping read request for " << request.chunk->chunk_number;
+        qDebug() << "Skipping read request for " << request.chunk->getIndex();
         status.status = CHUNK_READ_INVALID;
         status.chunk = request.chunk;
         m_pReaderStatusFIFO->writeBlocking(&status, 1);
@@ -219,7 +156,8 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
 
     // Emit that the track is loaded.
     const SINT sampleCount =
-            m_pAudioSource->getFrameCount() * kChunkChannels;
+            CachingReaderChunk::frames2samples(
+                    m_pAudioSource->getFrameCount());
     emit(trackLoaded(pTrack, m_pAudioSource->getFrameRate(), sampleCount));
 }
 

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -49,8 +49,7 @@ void CachingReaderWorker::processChunkReadRequest(
 
     // Initialize the output parameter
     update->chunk = request->chunk;
-    update->chunk->frameCountRead = 0;
-    update->chunk->frameCountTotal = 0;
+    update->chunk->frameCount = 0;
 
     const int chunk_number = request->chunk->chunk_number;
     if (!m_pAudioSource || chunk_number < 0) {
@@ -108,17 +107,13 @@ void CachingReaderWorker::processChunkReadRequest(
             m_pAudioSource->readSampleFramesStereo(
                     framesToRead, request->chunk->stereoSamples, kSamplesPerChunk);
     DEBUG_ASSERT(framesRead <= framesToRead);
-    update->chunk->frameCountRead = framesRead;
-    update->chunk->frameCountTotal = framesToRead;
+    update->chunk->frameCount = framesRead;
     if (framesRead < framesToRead) {
         // Incomplete read! Corrupt file?
         qWarning() << "Incomplete chunk read @" << seekFrameIndex
                 << "[" << Mixxx::AudioSource::getMinFrameIndex()
                 << "," << m_maxReadableFrameIndex
                 << "):" << framesRead << "<" << framesToRead;
-        SampleUtil::clear(
-                request->chunk->stereoSamples + (framesRead * kChunkChannels),
-                (framesToRead - framesRead) * kChunkChannels);
         update->status = CHUNK_READ_PARTIAL;
     } else {
         update->status = CHUNK_READ_SUCCESS;

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -47,6 +47,9 @@ void CachingReaderWorker::processCachingReaderChunkReadRequest(
     // and adjust the max. readable frame index if decoding errors occur.
     const SINT framesRead = request->chunk->readSampleFrames(
             m_pAudioSource, &m_maxReadableFrameIndex);
+    // Re-adjust the max. readable frame index that might have been
+    // modified by the previous read operation.
+    update->maxReadableFrameIndex = m_maxReadableFrameIndex;
 
     if (0 < framesRead) {
         update->status = CHUNK_READ_SUCCESS;

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -55,11 +55,11 @@ enum ReaderStatus {
 typedef struct ReaderStatusUpdate {
     ReaderStatus status;
     Chunk* chunk;
-    SINT maxFrameIndex;
+    SINT maxReadableFrameIndex;
     ReaderStatusUpdate()
         : status(INVALID)
         , chunk(NULL)
-        , maxFrameIndex(0) {
+        , maxReadableFrameIndex(Mixxx::AudioSource::getMinFrameIndex()) {
     }
 } ReaderStatusUpdate;
 
@@ -125,12 +125,12 @@ class CachingReaderWorker : public EngineWorker {
     // The current audio source of the track loaded
     Mixxx::AudioSourcePointer m_pAudioSource;
 
-    // The maximum frame index of the AudioSource. Might be
-    // adjusted when decoding errors occur to prevent reading
+    // The maximum readable frame index of the AudioSource. Might
+    // be adjusted when decoding errors occur to prevent reading
     // the same chunk(s) over and over again.
     // This frame index references the frame that follows the
-    // last frame with sample data.
-    SINT m_maxFrameIndex;
+    // last frame with readable sample data.
+    SINT m_maxReadableFrameIndex;
 
     QAtomicInt m_stop;
 };

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -125,6 +125,15 @@ class CachingReaderWorker : public EngineWorker {
     // The current audio source of the track loaded
     Mixxx::AudioSourcePointer m_pAudioSource;
 
+    // The maximum frame index of the AudioSource. Might be
+    // adjusted when decoding errors occur to prevent reading
+    // the same chunk(s) over and over again.
+    SINT m_maxFrameIndex;
+
+    SINT getFrameCount() const {
+        return m_maxFrameIndex - m_pAudioSource->getMinFrameIndex();
+    }
+
     QAtomicInt m_stop;
 };
 

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -21,8 +21,7 @@ class AudioSourceProxy;
 // sampleForChunk()
 typedef struct Chunk {
     int chunk_number;
-    SINT frameCountRead;
-    SINT frameCountTotal;
+    SINT frameCount;
     CSAMPLE* stereoSamples;
     Chunk* prev_lru;
     Chunk* next_lru;

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -21,8 +21,8 @@ class AudioSourceProxy;
 // sampleForChunk()
 typedef struct Chunk {
     int chunk_number;
-    int frameCountRead;
-    int frameCountTotal;
+    SINT frameCountRead;
+    SINT frameCountTotal;
     CSAMPLE* stereoSamples;
     Chunk* prev_lru;
     Chunk* next_lru;
@@ -55,11 +55,11 @@ enum ReaderStatus {
 typedef struct ReaderStatusUpdate {
     ReaderStatus status;
     Chunk* chunk;
-    int trackFrameCount;
+    SINT maxFrameIndex;
     ReaderStatusUpdate()
         : status(INVALID)
         , chunk(NULL)
-        , trackFrameCount(0) {
+        , maxFrameIndex(0) {
     }
 } ReaderStatusUpdate;
 
@@ -128,11 +128,9 @@ class CachingReaderWorker : public EngineWorker {
     // The maximum frame index of the AudioSource. Might be
     // adjusted when decoding errors occur to prevent reading
     // the same chunk(s) over and over again.
+    // This frame index references the frame that follows the
+    // last frame with sample data.
     SINT m_maxFrameIndex;
-
-    SINT getFrameCount() const {
-        return m_maxFrameIndex - m_pAudioSource->getMinFrameIndex();
-    }
 
     QAtomicInt m_stop;
 };

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -13,9 +13,6 @@
 #include "util/fifo.h"
 
 
-// forward declaration(s)
-class AudioSourceProxy;
-
 // A Chunk is a section of audio that is being cached. The chunk_number can be
 // used to figure out the sample number of the first sample in data by using
 // sampleForChunk()

--- a/src/cachingreaderworker.h
+++ b/src/cachingreaderworker.h
@@ -17,7 +17,10 @@
 typedef struct CachingReaderChunkReadRequest {
     CachingReaderChunk* chunk;
 
-    CachingReaderChunkReadRequest() { chunk = NULL; }
+    explicit CachingReaderChunkReadRequest(
+            CachingReaderChunk* chunkArg = nullptr)
+        : chunk(chunkArg) {
+    }
 } CachingReaderChunkReadRequest;
 
 enum ReaderStatus {
@@ -35,8 +38,16 @@ typedef struct ReaderStatusUpdate {
     SINT maxReadableFrameIndex;
     ReaderStatusUpdate()
         : status(INVALID)
-        , chunk(NULL)
+        , chunk(nullptr)
         , maxReadableFrameIndex(Mixxx::AudioSource::getMinFrameIndex()) {
+    }
+    ReaderStatusUpdate(
+            ReaderStatus statusArg,
+            CachingReaderChunk* chunkArg,
+            SINT maxReadableFrameIndexArg)
+        : status(statusArg)
+        , chunk(chunkArg)
+        , maxReadableFrameIndex(maxReadableFrameIndexArg) {
     }
 } ReaderStatusUpdate;
 
@@ -82,10 +93,8 @@ class CachingReaderWorker : public EngineWorker {
     // Internal method to load a track. Emits trackLoaded when finished.
     void loadTrack(const TrackPointer& pTrack);
 
-    // Read the given chunk_number from the file into pChunk's data
-    // buffer. Fills length/sample information about CachingReaderChunk* as well.
-    void processCachingReaderChunkReadRequest(CachingReaderChunkReadRequest* request,
-                                 ReaderStatusUpdate* update);
+    ReaderStatusUpdate processReadRequest(
+            const CachingReaderChunkReadRequest& request);
 
     // The current audio source of the track loaded
     Mixxx::AudioSourcePointer m_pAudioSource;

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -151,7 +151,7 @@ void ReadAheadManager::hintReader(double dRate, HintVector* pHintList) {
 
     // SoundTouch can read up to 2 chunks ahead. Always keep 2 chunks ahead in
     // cache.
-    int length_to_cache = 2 * CachingReaderWorker::kSamplesPerChunk;
+    int length_to_cache = 2 * CachingReaderChunk::kSamples;
 
     current_position.length = length_to_cache;
     current_position.sample = in_reverse ?

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -4,6 +4,21 @@
 
 namespace Mixxx {
 
+void AudioSource::clampFrameInterval(
+        SINT* pMinFrameIndexOfInterval,
+        SINT* pMaxFrameIndexOfInterval,
+        SINT maxFrameIndexOfAudioSource) {
+    if (*pMinFrameIndexOfInterval < getMinFrameIndex()) {
+        *pMinFrameIndexOfInterval = getMinFrameIndex();
+    }
+    if (*pMaxFrameIndexOfInterval > maxFrameIndexOfAudioSource) {
+        *pMaxFrameIndexOfInterval = maxFrameIndexOfAudioSource;
+    }
+    if (*pMaxFrameIndexOfInterval < *pMinFrameIndexOfInterval) {
+        *pMaxFrameIndexOfInterval = *pMinFrameIndexOfInterval;
+    }
+}
+
 AudioSource::AudioSource(const QUrl& url)
         : UrlResource(url),
           m_channelCount(kChannelCountDefault),

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -209,6 +209,15 @@ public:
         }
     }
 
+    // Utility function to clamp the frame index interval
+    // [*pMinFrameIndexOfInterval, *pMaxFrameIndexOfInterval)
+    // to valid frame indexes. The lower bound is inclusive and
+    // the upper bound is exclusive!
+    static void clampFrameInterval(
+            SINT* pMinFrameIndexOfInterval,
+            SINT* pMaxFrameIndexOfInterval,
+            SINT maxFrameIndexOfAudioSource);
+
 protected:
     explicit AudioSource(const QUrl& url);
 


### PR DESCRIPTION
Partially fixes (decoding errors at the end of a file): https://bugs.launchpad.net/mixxx/+bug/1470010
- Shorten readable length of corrupt files to avoid repeated decoding
- Code cleanups: Consistent naming, remove unncessary checks and local variables, ...
