### PR TITLE
search user's settings path for controller presets

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -630,6 +630,7 @@ class MixxxCore(Feature):
                    "controllers/controllermanager.cpp",
                    "controllers/controllerpresetfilehandler.cpp",
                    "controllers/controllerpresetinfo.cpp",
+                   "controllers/controllerpresetinfoenumerator.cpp",
                    "controllers/controlpickermenu.cpp",
                    "controllers/controllermappingtablemodel.cpp",
                    "controllers/controllerinputmappingtablemodel.cpp",

--- a/src/controllers/controllermanager.h
+++ b/src/controllers/controllermanager.h
@@ -12,6 +12,7 @@
 #include "controllers/controllerenumerator.h"
 #include "controllers/controllerpreset.h"
 #include "controllers/controllerpresetinfo.h"
+#include "controllers/controllerpresetinfoenumerator.h"
 
 //Forward declaration(s)
 class Controller;

--- a/src/controllers/controllerpresetinfo.cpp
+++ b/src/controllers/controllerpresetinfo.cpp
@@ -135,6 +135,7 @@ QHash<QString,QString> PresetInfo::parseOSCProduct(const QDomElement& element) c
 }
 
 PresetInfoEnumerator::PresetInfoEnumerator(ConfigObject<ConfigValue>* pConfig) {
+    controllerDirPaths.append(userPresetsPath(pConfig));
     controllerDirPaths.append(resourcePresetsPath(pConfig));
 
     // Static list of supported default extensions, sorted by popularity

--- a/src/controllers/controllerpresetinfo.cpp
+++ b/src/controllers/controllerpresetinfo.cpp
@@ -4,14 +4,13 @@
 * @date Wed May 15 2012
 * @brief Implement handling enumeration and parsing of preset info headers
 *
-* This class handles enumeration and parsing of controller XML description file
+* This class handles parsing of controller XML description file
 * <info> header tags. It can be used to match controllers automatically or to
 * show details for a mapping.
 */
 
-#include <QDirIterator>
-
 #include "controllers/controllerpresetinfo.h"
+#include "controllers/controllerpresetinfoenumerator.h"
 
 #include "controllers/defs_controllers.h"
 #include "util/xml.h"
@@ -30,40 +29,40 @@ PresetInfo::PresetInfo(const QString preset_path)
     // info.forums      Link to mixxx forum discussion for the preset
     // info.wiki        Link to mixxx wiki for the preset
     // info.devices.product List of device matches, specific to device type
-    path = QFileInfo(preset_path).absoluteFilePath();
-    name = "";
-    author = "";
-    description = "";
-    forumlink = "";
-    wikilink = "";
+    m_path = QFileInfo(preset_path).absoluteFilePath();
+    m_name = "";
+    m_author = "";
+    m_description = "";
+    m_forumlink = "";
+    m_wikilink = "";
 
-    QDomElement root = XmlParse::openXMLFile(path, "controller");
+    QDomElement root = XmlParse::openXMLFile(m_path, "controller");
     if (root.isNull()) {
-        qDebug() << "ERROR parsing" << path;
+        qDebug() << "ERROR parsing" << m_path;
         return;
     }
     QDomElement info = root.firstChildElement("info");
     if (info.isNull()) {
-        qDebug() << "MISSING <info> ELEMENT: " << path;
+        qDebug() << "MISSING <info> ELEMENT: " << m_path;
         return;
     }
 
     m_valid = true;
 
     QDomElement dom_name = info.firstChildElement("name");
-    if (!dom_name.isNull()) name = dom_name.text();
+    if (!dom_name.isNull()) m_name = dom_name.text();
 
     QDomElement dom_author = info.firstChildElement("author");
-    if (!dom_author.isNull()) author = dom_author.text();
+    if (!dom_author.isNull()) m_author = dom_author.text();
 
     QDomElement dom_description = info.firstChildElement("description");
-    if (!dom_description.isNull()) description = dom_description.text();
+    if (!dom_description.isNull()) m_description = dom_description.text();
 
     QDomElement dom_forums = info.firstChildElement("forums");
-    if (!dom_forums.isNull()) forumlink = dom_forums.text();
+    if (!dom_forums.isNull()) m_forumlink = dom_forums.text();
 
     QDomElement dom_wiki = info.firstChildElement("wiki");
-    if (!dom_wiki.isNull()) wikilink = dom_wiki.text();
+    if (!dom_wiki.isNull()) m_wikilink = dom_wiki.text();
 
     QDomElement devices = info.firstChildElement("devices");
     if (!devices.isNull()) {
@@ -71,15 +70,15 @@ PresetInfo::PresetInfo(const QString preset_path)
         while (!product.isNull()) {
             QString protocol = product.attribute("protocol","");
             if (protocol=="hid") {
-                products.append(parseHIDProduct(product));
+                m_products.append(parseHIDProduct(product));
             } else if (protocol=="bulk") {
-                products.append(parseBulkProduct(product));
+                m_products.append(parseBulkProduct(product));
             } else if (protocol=="midi") {
                 qDebug("MIDI product info parsing not yet implemented");
-                //products.append(parseMIDIProduct(product);
+                //m_products.append(parseMIDIProduct(product);
             } else if (protocol=="osc") {
                 qDebug("OSC product info parsing not yet implemented");
-                //products.append(parseOSCProduct(product);
+                //m_products.append(parseOSCProduct(product);
             } else {
                 qDebug("Product specification missing protocol attribute");
             }
@@ -132,131 +131,4 @@ QHash<QString,QString> PresetInfo::parseOSCProduct(const QDomElement& element) c
     QHash<QString,QString> product;
     product.insert("procotol",element.attribute("protocol",""));
     return product;
-}
-
-PresetInfoEnumerator::PresetInfoEnumerator(ConfigObject<ConfigValue>* pConfig) {
-    controllerDirPaths.append(userPresetsPath(pConfig));
-    controllerDirPaths.append(resourcePresetsPath(pConfig));
-
-    // Static list of supported default extensions, sorted by popularity
-    fileExtensions.append(QString(MIDI_PRESET_EXTENSION));
-    fileExtensions.append(QString(HID_PRESET_EXTENSION));
-    fileExtensions.append(QString(BULK_PRESET_EXTENSION));
-
-    loadSupportedPresets();
-}
-
-PresetInfoEnumerator::~PresetInfoEnumerator() {
-    for (QMap<QString, ControllerPresetFileHandler*>::iterator it =
-                 m_presetFileHandlersByExtension.begin();
-         it != m_presetFileHandlersByExtension.end(); ++it) {
-        delete it.value();
-        it = m_presetFileHandlersByExtension.erase(it);
-    }
-}
-
-bool PresetInfoEnumerator::isValidExtension(const QString extension) {
-    if (presetsByExtension.contains(extension))
-        return true;
-    return false;
-}
-
-bool PresetInfoEnumerator::hasPresetInfo(const QString extension, const QString name) {
-    // Check if preset info matching extension and preset name can be found
-    if (!isValidExtension(extension))
-        return false;
-
-    for (QMap<QString, QMap<QString, PresetInfo> >::const_iterator it =
-                 presetsByExtension.begin();
-         it != presetsByExtension.end(); ++it) {
-        for (QMap<QString, PresetInfo>::const_iterator it2 = it.value().begin();
-             it2 != it.value().end(); ++it2) {
-            if (name == it2.value().getName()) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-bool PresetInfoEnumerator::hasPresetInfo(const QString path) {
-    foreach (QString extension, presetsByExtension.keys()) {
-        QMap<QString, PresetInfo> presets = presetsByExtension[extension];
-        if (presets.contains(path))
-            return true;
-    }
-    return false;
-}
-
-PresetInfo PresetInfoEnumerator::getPresetInfo(const QString path) {
-    // Lookup and return controller script preset info by script path
-    // Return NULL if path is not found.
-    foreach (QString extension, presetsByExtension.keys()) {
-        QMap<QString, PresetInfo> presets = presetsByExtension[extension];
-        if (presets.contains(path))
-            return presets[path];
-    }
-    return PresetInfo();
-}
-
-QList<PresetInfo> PresetInfoEnumerator::getPresets(const QString extension) {
-    // Return list of PresetInfo items matching extension
-    // Returns empty list if no matching extension presets can be found
-    QList<PresetInfo> presets;
-    if (presetsByExtension.contains(extension)) {
-        presets = presetsByExtension[extension].values();
-        return presetsByExtension[extension].values();
-    }
-    qDebug() << "Extension not registered to presetinfo" << extension;
-    return presets;
-}
-
-void PresetInfoEnumerator::addExtension(const QString extension) {
-    if (presetsByExtension.contains(extension))
-        return;
-    QMap<QString,PresetInfo> presets;
-    presetsByExtension[extension] = presets;
-}
-
-void PresetInfoEnumerator::loadSupportedPresets() {
-    foreach (QString dirPath, controllerDirPaths) {
-        QDirIterator it(dirPath);
-        while (it.hasNext()) {
-            it.next();
-            const QString path = it.filePath();
-            foreach (QString extension, fileExtensions) {
-                if (!path.endsWith(extension))
-                    continue;
-                if (!presetsByExtension.contains(extension)) {
-                    addExtension(extension);
-                }
-                presetsByExtension[extension][path] = PresetInfo(path);
-            }
-        }
-    }
-
-    foreach (QString extension, presetsByExtension.keys()) {
-        QMap<QString,PresetInfo> presets = presetsByExtension[extension];
-        qDebug() << "Extension" << extension << "total" << presets.keys().length() << "presets";
-    }
-}
-
-void PresetInfoEnumerator::updatePresets(const QString extension) {
-    QMap<QString,PresetInfo> presets;
-
-    if (presetsByExtension.contains(extension))
-        presetsByExtension.remove(extension);
-
-    foreach (QString dirPath, controllerDirPaths) {
-        QDirIterator it(dirPath);
-        while (it.hasNext()) {
-            it.next();
-            const QString path = it.filePath();
-            if (!path.endsWith(extension))
-                continue;
-            presets[path] = PresetInfo(path);
-        }
-    }
-
-    presetsByExtension[extension] = presets;
 }

--- a/src/controllers/controllerpresetinfo.h
+++ b/src/controllers/controllerpresetinfo.h
@@ -32,15 +32,15 @@ class PresetInfo {
         return m_valid;
     }
 
-    inline const QString getPath() const { return path; };
+    inline const QString getPath() const { return m_path; };
 
-    inline const QString getName() const { return name; } ;
-    inline const QString getDescription() const { return description; };
-    inline const QString getForumLink() const { return forumlink; };
-    inline const QString getWikiLink() const { return wikilink; };
-    inline const QString getAuthor() const { return author; };
+    inline const QString getName() const { return m_name; } ;
+    inline const QString getDescription() const { return m_description; };
+    inline const QString getForumLink() const { return m_forumlink; };
+    inline const QString getWikiLink() const { return m_wikilink; };
+    inline const QString getAuthor() const { return m_author; };
 
-    inline const QList<QHash<QString,QString> > getProducts() const { return products; };
+    inline const QList<QHash<QString,QString> > getProducts() const { return m_products; };
 
   private:
     QHash<QString,QString> parseBulkProduct(const QDomElement& element) const;
@@ -50,47 +50,13 @@ class PresetInfo {
     QHash<QString,QString> parseOSCProduct(const QDomElement& element) const;
 
     bool m_valid;
-    QString path;
-    QString name;
-    QString author;
-    QString description;
-    QString forumlink;
-    QString wikilink;
-    QList<QHash<QString,QString> > products;
-};
-
-class PresetInfoEnumerator {
-  public:
-    PresetInfoEnumerator(ConfigObject<ConfigValue> *pConfig);
-    virtual ~PresetInfoEnumerator();
-
-    bool isValidExtension(const QString extension);
-
-    bool hasPresetInfo(const QString extension, const QString name);
-    bool hasPresetInfo(const QString path);
-
-    PresetInfo getPresetInfo(const QString path);
-
-    // Return cached list of presets for this extension
-    QList<PresetInfo> getPresets(const QString extension);
-
-    // Updates presets matching given extension
-    void updatePresets(const QString extension);
-
-  protected:
-    void addExtension(QString extension);
-    void loadSupportedPresets();
-
-  private:
-    QList<QString> fileExtensions;
-
-    // List of paths for controller presets
-    QList<QString> controllerDirPaths;
-
-    // Cached presets by extension. Map format is:
-    // [extension,[preset_path,preset]]
-    QMap<QString, QMap<QString, PresetInfo> > presetsByExtension;
-    QMap<QString, ControllerPresetFileHandler*> m_presetFileHandlersByExtension;
+    QString m_path;
+    QString m_name;
+    QString m_author;
+    QString m_description;
+    QString m_forumlink;
+    QString m_wikilink;
+    QList<QHash<QString,QString> > m_products;
 };
 
 #endif

--- a/src/controllers/controllerpresetinfoenumerator.cpp
+++ b/src/controllers/controllerpresetinfoenumerator.cpp
@@ -1,0 +1,139 @@
+/**
+* @file controllerpresetinfoenumerator.cpp
+* @author Be be.0@gmx.com
+* @date Sat Jul 18 2015
+* @brief Enumerate list of available controller mapping presets
+*/
+#include <QDirIterator>
+
+#include "controllers/controllerpresetinfo.h"
+#include "controllers/controllerpresetinfoenumerator.h"
+
+#include "controllers/defs_controllers.h"
+
+PresetInfoEnumerator::PresetInfoEnumerator(ConfigObject<ConfigValue>* pConfig) {
+    m_controllerDirPaths.append(userPresetsPath(pConfig));
+    m_controllerDirPaths.append(resourcePresetsPath(pConfig));
+
+    // Static list of supported default extensions, sorted by popularity
+    m_fileExtensions.append(QString(MIDI_PRESET_EXTENSION));
+    m_fileExtensions.append(QString(HID_PRESET_EXTENSION));
+    m_fileExtensions.append(QString(BULK_PRESET_EXTENSION));
+
+    loadSupportedPresets();
+}
+
+PresetInfoEnumerator::~PresetInfoEnumerator() {
+    for (QMap<QString, ControllerPresetFileHandler*>::iterator it =
+                 m_presetFileHandlersByExtension.begin();
+         it != m_presetFileHandlersByExtension.end(); ++it) {
+        delete it.value();
+        it = m_presetFileHandlersByExtension.erase(it);
+    }
+}
+
+bool PresetInfoEnumerator::isValidExtension(const QString extension) {
+    if (m_presetsByExtension.contains(extension))
+        return true;
+    return false;
+}
+
+bool PresetInfoEnumerator::hasPresetInfo(const QString extension, const QString name) {
+    // Check if preset info matching extension and preset name can be found
+    if (!isValidExtension(extension))
+        return false;
+
+    for (QMap<QString, QMap<QString, PresetInfo> >::const_iterator it =
+                 m_presetsByExtension.begin();
+         it != m_presetsByExtension.end(); ++it) {
+        for (QMap<QString, PresetInfo>::const_iterator it2 = it.value().begin();
+             it2 != it.value().end(); ++it2) {
+            if (name == it2.value().getName()) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool PresetInfoEnumerator::hasPresetInfo(const QString path) {
+    foreach (QString extension, m_presetsByExtension.keys()) {
+        QMap<QString, PresetInfo> presets = m_presetsByExtension[extension];
+        if (presets.contains(path))
+            return true;
+    }
+    return false;
+}
+
+PresetInfo PresetInfoEnumerator::getPresetInfo(const QString path) {
+    // Lookup and return controller script preset info by script path
+    // Return NULL if path is not found.
+    foreach (QString extension, m_presetsByExtension.keys()) {
+        QMap<QString, PresetInfo> presets = m_presetsByExtension[extension];
+        if (presets.contains(path))
+            return presets[path];
+    }
+    return PresetInfo();
+}
+
+QList<PresetInfo> PresetInfoEnumerator::getPresets(const QString extension) {
+    // Return list of PresetInfo items matching extension
+    // Returns empty list if no matching extension presets can be found
+    QList<PresetInfo> presets;
+    if (m_presetsByExtension.contains(extension)) {
+        presets = m_presetsByExtension[extension].values();
+        return m_presetsByExtension[extension].values();
+    }
+    qDebug() << "Extension not registered to presetinfo" << extension;
+    return presets;
+}
+
+void PresetInfoEnumerator::addExtension(const QString extension) {
+    if (m_presetsByExtension.contains(extension))
+        return;
+    QMap<QString,PresetInfo> presets;
+    m_presetsByExtension[extension] = presets;
+}
+
+void PresetInfoEnumerator::loadSupportedPresets() {
+    foreach (QString dirPath, m_controllerDirPaths) {
+        QDirIterator it(dirPath);
+        while (it.hasNext()) {
+            it.next();
+            const QString path = it.filePath();
+            foreach (QString extension, m_fileExtensions) {
+                if (!path.endsWith(extension))
+                    continue;
+                if (!m_presetsByExtension.contains(extension)) {
+                    addExtension(extension);
+                }
+                m_presetsByExtension[extension][path] = PresetInfo(path);
+            }
+        }
+    }
+
+    foreach (QString extension, m_presetsByExtension.keys()) {
+        QMap<QString,PresetInfo> presets = m_presetsByExtension[extension];
+        qDebug() << "Extension" << extension << "total" << presets.keys().length() << "presets";
+    }
+}
+
+void PresetInfoEnumerator::updatePresets(const QString extension) {
+    QMap<QString,PresetInfo> presets;
+
+    if (m_presetsByExtension.contains(extension))
+        m_presetsByExtension.remove(extension);
+
+    foreach (QString dirPath, m_controllerDirPaths) {
+        QDirIterator it(dirPath);
+        while (it.hasNext()) {
+            it.next();
+            const QString path = it.filePath();
+            if (!path.endsWith(extension))
+                continue;
+            presets[path] = PresetInfo(path);
+        }
+    }
+
+    m_presetsByExtension[extension] = presets;
+}

--- a/src/controllers/controllerpresetinfoenumerator.h
+++ b/src/controllers/controllerpresetinfoenumerator.h
@@ -1,0 +1,50 @@
+/**
+* @file controllerpresetinfoenumerator.h
+* @author Be be.0@gmx.com
+* @date Sat Jul 18 2015
+* @brief Enumerate list of available controller mapping presets
+*/
+#ifndef CONTROLLERPRESETINFOENUMERATOR_H
+#define CONTROLLERPRESETINFOENUMERATOR_H
+
+#include <QMap>
+#include <QList>
+#include <QString>
+
+#include "controllers/controllerpreset.h"
+
+class PresetInfoEnumerator {
+  public:
+    PresetInfoEnumerator(ConfigObject<ConfigValue> *pConfig);
+    virtual ~PresetInfoEnumerator();
+
+    bool isValidExtension(const QString extension);
+
+    bool hasPresetInfo(const QString extension, const QString name);
+    bool hasPresetInfo(const QString path);
+
+    PresetInfo getPresetInfo(const QString path);
+
+    // Return cached list of presets for this extension
+    QList<PresetInfo> getPresets(const QString extension);
+
+    // Updates presets matching given extension
+    void updatePresets(const QString extension);
+
+  protected:
+    void addExtension(QString extension);
+    void loadSupportedPresets();
+
+  private:
+    QList<QString> m_fileExtensions;
+
+    // List of paths for controller presets
+    QList<QString> m_controllerDirPaths;
+
+    // Cached presets by extension. Map format is:
+    // [extension,[preset_path,preset]]
+    QMap<QString, QMap<QString, PresetInfo> > m_presetsByExtension;
+    QMap<QString, ControllerPresetFileHandler*> m_presetFileHandlersByExtension;
+};
+
+#endif


### PR DESCRIPTION
Users should not need write access to their system's Mixxx resource directory to install controller presets. Note that autogenerated presets now show up in the available presets list, which may or may not be wanted.
