### PR TITLE
simplify ControllerEngine::connectControl

### DIFF
--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -783,69 +783,78 @@ void ControllerEngine::trigger(QString group, QString name) {
    Output:  true if successful
    -------- ------------------------------------------------------ */
 QScriptValue ControllerEngine::connectControl(QString group, QString name,
-                                              QScriptValue callback, bool disconnect) {
-    ControlObjectThread* cot = getControlObjectThread(group, name);
-    ControllerEngineConnection conn;
-    conn.key = ConfigKey(group, name);
-    conn.ce = this;
+                                              QScriptValue callback, bool remove) {
+    QScriptContext *scriptContext = m_pEngine->currentContext();
+    // Our current context is a function call to engine.connectControl. We
+    // want to grab the 'this' from the caller's context, so we walk up the
+    // stack.
+    scriptContext = scriptContext->parentContext();
+    QScriptContextInfo scriptContextInfo = QScriptContextInfo(scriptContext);
+    QString errorMessage = QString("Error in %1 at line %2\n")
+                                   .arg(scriptContextInfo.fileName())
+                                   .arg(scriptContextInfo.lineNumber());
 
+    ControlObjectThread* cot = getControlObjectThread(group, name);
     if (cot == NULL) {
-        qWarning() << "ControllerEngine: script connecting [" << group << "," << name
+        qWarning() << errorMessage
+                   << "ControllerEngine: script connecting [" << group << "," << name
                    << "], which is non-existent. ignoring.";
         return QScriptValue(false);
-    }
-
-    if (m_pEngine == NULL) {
+    } else if (m_pEngine == NULL) {
         return QScriptValue(false);
     }
+    
+    ControllerEngineConnection conn;
+    conn.key = ConfigKey(group, name);
+    conn.controllerEngine = this;
+    conn.context = scriptContext ? scriptContext->thisObject() : QScriptValue();
 
     if (callback.isString()) {
         conn.id = callback.toString();
 
         conn.function = m_pEngine->evaluate(conn.id);
         if (checkException() || !conn.function.isFunction()) {
-            qWarning() << "Cannot make connection to" << conn.key
-                       << ": no such callback function" << conn.id;
+            if (remove) {
+                qWarning() << errorMessage
+                           << "Cannot disconnect from" << conn.key
+                           << ": no such callback function" << conn.id;
+            } else {
+                qWarning() << errorMessage
+                           << "Cannot make connection to" << conn.key
+                           << ": no such callback function" << conn.id;
+            }
             return QScriptValue(false);
         }
     } else if (callback.isFunction()) {
+        conn.id = callback.toString();
         conn.function = callback;
-    } else if (callback.isQObject()) {
-        // Assume a ControllerEngineConnection
-        QObject *qobject = callback.toQObject();
-        const QMetaObject *qmeta = qobject->metaObject();
-
-        if (!strcmp(qmeta->className(), "ControllerEngineConnectionScriptValue")) {
-            ControllerEngineConnectionScriptValue *proxy =
-                (ControllerEngineConnectionScriptValue *)qobject;
-            proxy->disconnect();
-        }
     } else {
-        qWarning() << "Cannot make connection to" << group << name
+        qWarning() << errorMessage
+                   << "Cannot make connection to" << group << name
                    << ": no such callback function";
         return QScriptValue(false);
     }
-
-    QScriptContext *ctxt = m_pEngine->currentContext();
-    // Our current context is a function call to engine.connectControl. We
-    // want to grab the 'this' from the caller's context, so we walk up the
-    // stack.
-    if (ctxt) {
-        ctxt = ctxt->parentContext();
-        conn.context = ctxt ? ctxt->thisObject() : QScriptValue();
-    }
     
-    if (!callback.isString()) {
-        QUuid uuid = QUuid::createUuid();
-        conn.id = uuid.toString();
-    }
-    
-    if (disconnect) {
-        return QScriptValue(disconnectControl(conn));
+    if (remove) {
+        if (m_connectedControls.contains(conn.key, conn)) {
+            m_connectedControls.remove(conn.key, conn);
+            qDebug() << "Disconnection: function" << conn.id
+                     << "disconnected from" << conn.key;
+            disconnect(cot, SIGNAL(valueChanged(double)),
+                    this, SLOT(slotValueChanged(double)));
+            disconnect(cot, SIGNAL(valueChangedByThis(double)),
+                    this, SLOT(slotValueChanged(double)));
+            return QScriptValue(true);
+        } else {
+            qWarning() << errorMessage
+                       << "Could not Disconnect function" << conn.id
+                       << "from" << conn.key << ": no such connection";
+        }
     } else {
         if (m_connectedControls.contains(conn.key, conn)) {
-            qWarning() << "Cannot connect" << conn.key << "to"
-                        << conn.id << ": already connected";
+            qWarning() << errorMessage
+                       << "Cannot connect" << conn.key << "to"
+                       << conn.id << ": already connected";
             return QScriptValue(false);
         }
         
@@ -857,56 +866,11 @@ QScriptValue ControllerEngine::connectControl(QString group, QString name,
                 Qt::QueuedConnection);
         m_connectedControls.insert(conn.key, conn);
 
-        if (m_connectedControls.contains(conn.key, conn)) {
-            qDebug() << "Connection: function" << conn.id
-                     << "connected to" << conn.key;
-            // Return a wrapper to the conn
-            QHash<ConfigKey, ControllerEngineConnection>::iterator i =
-                m_connectedControls.find(conn.key);
-
-            conn = i.value();
-            return m_pEngine->newQObject(
-                new ControllerEngineConnectionScriptValue(conn),
-                QScriptEngine::ScriptOwnership);
-        }
+        qDebug() << "Connection: function" << conn.id
+                 << "connected to" << conn.key;
+        return QScriptValue(true);
     }
     return QScriptValue(false);
-}
-
-/* -------- ------------------------------------------------------
-   Purpose: (Dis)connects a ControlObject valueChanged() signal to/from a script function
-   Input:   Control group (e.g. [Channel1]), Key name (e.g. [filterHigh]),
-                script function name, true if you want to disconnect
-   Output:  true if successful
-   -------- ------------------------------------------------------ */
-QScriptValue ControllerEngine::disconnectControl(const ControllerEngineConnection conn) {
-    ControlObjectThread* cot = getControlObjectThread(conn.key.group, conn.key.item);
-
-    if (m_pEngine == NULL) {
-        return QScriptValue(false);
-    }
-
-    if (m_connectedControls.contains(conn.key, conn)) {
-        m_connectedControls.remove(conn.key, conn);
-        // Only disconnect the signal if there are no other instances of this control using it
-        if (!m_connectedControls.contains(conn.key)) {
-            qDebug() << "Disconnection: function" << conn.id
-                     << "disconnected from" << conn.key;
-            disconnect(cot, SIGNAL(valueChanged(double)),
-                       this, SLOT(slotValueChanged(double)));
-            disconnect(cot, SIGNAL(valueChangedByThis(double)),
-                       this, SLOT(slotValueChanged(double)));
-            return QScriptValue(true);
-        }
-    } else {
-        qWarning() << "Could not Disconnect function" << conn.id
-                   << "from" << conn.key << ": no such connection";
-    }
-    return QScriptValue(false);
-}
-
-void ControllerEngineConnectionScriptValue::disconnect() {
-    conn.ce->disconnectControl(conn);
 }
 
 /**-------- ------------------------------------------------------

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -30,7 +30,7 @@ class ControllerEngineConnection {
     ConfigKey key;
     QString id;
     QScriptValue function;
-    ControllerEngine *ce;
+    ControllerEngine *controllerEngine;
     QScriptValue context;
 };
 
@@ -47,7 +47,6 @@ class ControllerEngineConnectionScriptValue : public QObject {
         this->conn = conn;
     }
     QString readId() const { return this->conn.id; }
-    Q_INVOKABLE void disconnect();
 
   private:
    ControllerEngineConnection conn;
@@ -83,7 +82,6 @@ class ControllerEngine : public QObject {
     /** Look up registered script function prefixes */
     QList<QString>& getScriptFunctionPrefixes() { return m_scriptFunctionPrefixes; };
     /** Disconnect a ControllerEngineConnection */
-    QScriptValue disconnectControl(const ControllerEngineConnection conn);
 
   protected:
     Q_INVOKABLE double getValue(QString group, QString name);
@@ -95,7 +93,7 @@ class ControllerEngine : public QObject {
     Q_INVOKABLE double getDefaultValue(QString group, QString name);
     Q_INVOKABLE double getDefaultParameter(QString group, QString name);
     Q_INVOKABLE QScriptValue connectControl(QString group, QString name,
-                                    QScriptValue function, bool disconnect = false);
+                                    QScriptValue function, bool remove = false);
     // Called indirectly by the objects returned by connectControl
     Q_INVOKABLE void trigger(QString group, QString name);
     Q_INVOKABLE void log(QString message);

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -83,7 +83,7 @@ class ControllerEngine : public QObject {
     /** Look up registered script function prefixes */
     QList<QString>& getScriptFunctionPrefixes() { return m_scriptFunctionPrefixes; };
     /** Disconnect a ControllerEngineConnection */
-    void disconnectControl(const ControllerEngineConnection conn);
+    QScriptValue disconnectControl(const ControllerEngineConnection conn);
 
   protected:
     Q_INVOKABLE double getValue(QString group, QString name);


### PR DESCRIPTION
also make debugging and error messages more descriptive

This fixes https://bugs.launchpad.net/mixxx/+bug/1458264:
engine.connectionControl(group, control, function, true) connects control to a function rather than removes connection)

I tried writing a test to demonstrate the above bug but couldn't get the test to fail (on a branch without this commit of course). I did see that the bug was there because the test output showed the connection being made twice, but the logic of the test did not fail when this happened.
