### PR TITLE
update documentation links

### DIFF
--- a/src/controllers/dlgprefcontrollersdlg.ui
+++ b/src/controllers/dlgprefcontrollersdlg.ui
@@ -88,7 +88,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Mixxx uses &quot;presets&quot; to connect messages from your controller to controls in Mixxx. If you do not see a preset for your controller in the "Load Preset" menu when you click on your controller on the left sidebar, you may be able to download one online from the &lt;a href=&quot;http://www.mixxx.org/forums/viewforum.php?f=7&quot;&gt;Mixxx Forum&lt;/a&gt;. Place the XML (.xml) and Javascript (.js) file(s) in the &quot;User Preset Folder&quot;. If you download a mapping in a ZIP file, extract the ZIP file first and copy the XML and Javascript file(s) from the ZIP file to your &quot;User Preset Folder&quot;:</string>
+         <string>Mixxx uses &quot;presets&quot; to connect messages from your controller to controls in Mixxx. If you do not see a preset for your controller in the "Load Preset" menu when you click on your controller on the left sidebar, you may be able to download one online from the &lt;a href=&quot;http://www.mixxx.org/forums/viewforum.php?f=7&quot;&gt;Mixxx Forum&lt;/a&gt;. Place the XML (.xml) and Javascript (.js) file(s) in the &quot;User Preset Folder&quot; then restart Mixxx. If you download a mapping in a ZIP file, extract the XML and Javascript file(s) from the ZIP file to your &quot;User Preset Folder&quot; then restart Mixxx:</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/controllers/dlgprefcontrollersdlg.ui
+++ b/src/controllers/dlgprefcontrollersdlg.ui
@@ -88,7 +88,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Mixxx uses &quot;presets&quot; to connect messages from your controller to controls in Mixxx. If you do not see a preset for your controller, you can download one online from the Mixxx Forums or Mixxx Wiki. After downloading a preset, place the XML (.xml) and Javascript (.js) file(s) in the &quot;User Preset Folder&quot;:</string>
+         <string>Mixxx uses &quot;presets&quot; to connect messages from your controller to controls in Mixxx. If you do not see a preset for your controller in the "Load Preset" menu when you click on your controller on the left sidebar, you may be able to download one online from the &lt;a href=&quot;http://www.mixxx.org/forums/viewforum.php?f=7&quot;&gt;Mixxx Forum&lt;/a&gt;. Place the XML (.xml) and Javascript (.js) file(s) in the &quot;User Preset Folder&quot;. If you download a mapping in a ZIP file, extract the ZIP file first and copy the XML and Javascript file(s) from the ZIP file to your &quot;User Preset Folder&quot;:</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/controllers/dlgprefcontrollersdlg.ui
+++ b/src/controllers/dlgprefcontrollersdlg.ui
@@ -93,6 +93,9 @@
         <property name="wordWrap">
          <bool>true</bool>
         </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item row="1" column="0">

--- a/src/controllers/dlgprefcontrollersdlg.ui
+++ b/src/controllers/dlgprefcontrollersdlg.ui
@@ -111,6 +111,22 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QLabel" name="createMapping">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>You can create your own mapping by using the MIDI Learning Wizard when you select your controller in the sidebar. You can edit mappings by selecting the &quot;Input Mappings&quot; and &quot;Output Mappings&quot; tabs in the preference page for your controller. See the Resources below for more details on making mappings.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/controllers/dlgprefcontrollersdlg.ui
+++ b/src/controllers/dlgprefcontrollersdlg.ui
@@ -29,7 +29,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Controllers allow you to control Mixxx with physical devices (for example USB MIDI or HID controllers). Controllers that Mixxx recognizes are shown in the &quot;Controllers&quot; section in the sidebar.</string>
+         <string>Controllers are physical devices that send MIDI or HID signals to your computer over a USB connection. These allow you to control Mixxx in a more hands-on way than a keyboard and mouse. Attached controllers that Mixxx recognizes are shown in the &quot;Controllers&quot; section in the sidebar.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/controllers/dlgprefcontrollersdlg.ui
+++ b/src/controllers/dlgprefcontrollersdlg.ui
@@ -120,7 +120,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="txtHardwareCompatibility">
         <property name="text">
-         <string>&lt;a href=&quot;http://mixxx.org/wiki/doku.php/hardware_compatibility&quot;&gt;Mixxx Wiki: Hardware Compatibility&lt;/a&gt;</string>
+         <string>&lt;a href=&quot;http://mixxx.org/wiki/doku.php/hardware_compatibility&quot;&gt;Mixxx DJ Hardware Guide&lt;/a&gt;</string>
         </property>
         <property name="openExternalLinks">
          <bool>true</bool>

--- a/src/dlgprefsounddlg.ui
+++ b/src/dlgprefsounddlg.ui
@@ -285,7 +285,20 @@
       <item row="2" column="0" colspan="2">
        <widget class="QLabel" name="limitsHint">
         <property name="text">
-         <string>Enable Real-Time scheduling (currently disabled), see the &lt;a href=&quot;http://www.mixxx.org/wiki/doku.php/troubleshooting?s[]=limits&quot;&gt;Mixxx Wiki&lt;/a&gt;.</string>
+         <string>Enable Real-Time scheduling (currently disabled), see the &lt;a href=&quot;http://mixxx.org/wiki/doku.php/adjusting_audio_latency&quot;&gt;Mixxx Wiki&lt;/a&gt;.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QLabel" name="hardwareGuide">
+        <property name="text">
+         <string>The &lt;a href=&quot;http://mixxx.org/wiki/doku.php/hardware_compatibility&quot;&gt;Mixxx DJ Hardware Guide&lt;/a&gt; lists sound cards and controllers you may want to consider for using Mixxx.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/dlgprefvinyl.cpp
+++ b/src/dlgprefvinyl.cpp
@@ -26,6 +26,7 @@
 #include "playermanager.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
 #include "vinylcontrol/vinylcontrolmanager.h"
+#include "defs_urls.h"
 
 DlgPrefVinyl::DlgPrefVinyl(QWidget * parent, VinylControlManager *pVCMan,
                            ConfigObject<ConfigValue> * _config)
@@ -88,6 +89,10 @@ DlgPrefVinyl::DlgPrefVinyl(QWidget * parent, VinylControlManager *pVCMan,
     ComboBoxVinylSpeed3->addItem(MIXXX_VINYL_SPEED_45);
     ComboBoxVinylSpeed4->addItem(MIXXX_VINYL_SPEED_33);
     ComboBoxVinylSpeed4->addItem(MIXXX_VINYL_SPEED_45);
+
+    TroubleshootingLink->setText(QString("<a href='%1%2'>Troubleshooting</a>")
+                                         .arg(MIXXX_MANUAL_URL)
+                                         .arg("/chapters/vinyl_control.html#troubleshooting"));
 
     connect(VinylGain, SIGNAL(sliderReleased()),
             this, SLOT(slotVinylGainApply()));

--- a/src/dlgprefvinyldlg.ui
+++ b/src/dlgprefvinyldlg.ui
@@ -732,10 +732,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_6">
       <item row="4" column="0">
-       <widget class="QLabel" name="label_12">
-        <property name="text">
-         <string>&lt;a href=&quot;http://mixxx.org/manual/latest/chapters/vinyl_control.html#troubleshooting&lt;/a&gt;</string>
-        </property>
+       <widget class="QLabel" name="TroubleshootingLink">
         <property name="wordWrap">
          <bool>true</bool>
         </property>

--- a/src/dlgprefvinyldlg.ui
+++ b/src/dlgprefvinyldlg.ui
@@ -734,7 +734,7 @@
       <item row="4" column="0">
        <widget class="QLabel" name="label_12">
         <property name="text">
-         <string>&lt;a href=&quot;http://www.mixxx.org/wiki/doku.php/vinyl_control#troubleshooting&quot;&gt;Troubleshooting&lt;/a&gt;</string>
+         <string>&lt;a href=&quot;http://mixxx.org/manual/latest/chapters/vinyl_control.html#troubleshooting&lt;/a&gt;</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -991,7 +991,7 @@ int MixxxMainWindow::noSoundDlg(void)
         } else if (msgBox.clickedButton() == wikiButton) {
             QDesktopServices::openUrl(QUrl(
                 "http://mixxx.org/wiki/doku.php/troubleshooting"
-                "#no_or_too_few_sound_cards_appear_in_the_preferences_dialog"));
+                "#i_can_t_select_my_sound_card_in_the_sound_hardware_preferences"));
             wikiButton->setEnabled(false);
         } else if (msgBox.clickedButton() == reconfigureButton) {
             msgBox.hide();

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -2019,8 +2019,8 @@ void MixxxMainWindow::slotHelpManual() {
     // Default to the mixxx.org hosted version of the manual.
     QUrl qManualUrl(MIXXX_MANUAL_URL);
 #if defined(__APPLE__)
-    // We don't include the PDF manual in the bundle on OSX. Default to the
-    // web-hosted version.
+    // FIXME: We don't include the PDF manual in the bundle on OSX.
+    // Default to the web-hosted version.
 #elif defined(__WINDOWS__)
     // On Windows, the manual PDF sits in the same folder as the 'skins' folder.
     if (resourceDir.exists(MIXXX_MANUAL_FILENAME)) {
@@ -2029,7 +2029,7 @@ void MixxxMainWindow::slotHelpManual() {
     }
 #elif defined(__LINUX__)
     // On GNU/Linux, the manual is installed to e.g. /usr/share/mixxx/doc/
-    if (resourceDir.cd("doc") && resourceDir.exists(MIXXX_MANUAL_FILENAME)) {
+    if (resourceDir.cd("../doc/mixxx") && resourceDir.exists(MIXXX_MANUAL_FILENAME)) {
         qManualUrl = QUrl::fromLocalFile(
                 resourceDir.absoluteFilePath(MIXXX_MANUAL_FILENAME));
     }


### PR DESCRIPTION
Update links in Mixxx to reflect current state of wiki. Also fix loading of PDF manual on GNU/Linux and reword some text on the Controllers preference page.

This partially fixes https://bugs.launchpad.net/mixxx/+bug/1343113 , but to fully fix it the PDF manual should be included in OS X builds.
