### PR TITLE
invert Cue Select led states to match behaviour

### DIFF
--- a/res/controllers/Hercules-DJ-Console-RMX-scripts.js
+++ b/res/controllers/Hercules-DJ-Console-RMX-scripts.js
@@ -442,10 +442,10 @@ HerculesRMX.Deck.prototype.cueSelectHandler = function(value) {
       var filterStatus = engine.getValue(this.group, "pfl");
       if(filterStatus) {
          engine.setValue(this.group, "pfl", 0);
-         this.Buttons.CueSelect.setLed(LedState.on);
+         this.Buttons.CueSelect.setLed(LedState.off);
       } else {
          engine.setValue(this.group, "pfl", 1);
-         this.Buttons.CueSelect.setLed(LedState.off);
+         this.Buttons.CueSelect.setLed(LedState.on);
       }
    }
 };


### PR DESCRIPTION
This fixes the unexpected behaviour of the Hercules RMX controller having the Cue Select backlight off when the sound goes to the headphones, and on when it does not. Was not the case in 1.11.

Tested on 1.12.0-beta1-git5504-ppa1~trusty1 on KXStudio 14.04.1g.
