### PR TITLE
update description (clarity, consistency, midi channel)

### DIFF
--- a/res/controllers/Xone K2.midi.xml
+++ b/res/controllers/Xone K2.midi.xml
@@ -4,7 +4,10 @@
     <info>
         <name>Allen&amp;Heath Xone K2</name>
         <author>Owen Williams</author>
-        <description>Set Xone:K2 latching mode to "Switching Matrix" -- mode 2.<br/> (See product manual for details)</description>
+        <description>For this mapping to work:
+- Set Xone:K2 midi channel to 16;
+- Set Xone:K2 Latching Layers state to "Switch Matrix" (state 2).
+(See product manual for details.)</description>
     </info>
     <controller id="XONE:K2">
         <scriptfiles>

--- a/scripts/make_xone.py
+++ b/scripts/make_xone.py
@@ -297,7 +297,10 @@ xml.append("""<?xml version='1.0' encoding='utf-8'?>
     <info>
         <name>Allen&amp;Heath Xone K2</name>
         <author>Owen Williams</author>
-        <description>Set Xone:K2 latching mode to "Switching Matrix" -- mode 2.<br/> (See product manual for details)</description>
+        <description>For this mapping to work:
+- Set Xone:K2 midi channel to 16;
+- Set Xone:K2 Latching Layers state to "Switch Matrix" (state 2).
+(See product manual for details.)</description>
     </info>
     <controller id="XONE:K2">
         <scriptfiles>


### PR DESCRIPTION
I updated the Xone:K2 mapping description so it is clearer, more consistent with the terms used in the [manual](http://www.allen-heath.com/media/Xone+K2_UG_AP8509_2.pdf), and so it includes the info about midi channel 16 being used (instead of the default 15 for this controller, which was mentioned [on the forum](http://www.mixxx.org/forums/viewtopic.php?f=7&t=3776#p24289)).

Should this also go to the 1.12 branch? Still not 100% sure how this works.
