### PR TITLE
Bugfix 1478412 to LateNight deck_buttons.xml

### DIFF
--- a/res/skins/LateNight/deck_buttons.xml
+++ b/res/skins/LateNight/deck_buttons.xml
@@ -449,6 +449,9 @@
 							<ConfigKey>[Channel<Variable name="channum" />],cue_gotoandstop</ConfigKey>
 							<ButtonState>RightButton</ButtonState>
 						</Connection>
+						<Connection>
+							<ConfigKey>[Channel<Variable name="channum" />],cue_indicator</ConfigKey>
+						</Connection>
 					</PushButton>
 					<PushButton>
 						<TooltipId>play_cue_set</TooltipId>
@@ -467,6 +470,9 @@
 						<Connection>
 							<ConfigKey>[Channel<Variable name="channum" />],play</ConfigKey>
 							<ButtonState>LeftButton</ButtonState>
+						</Connection>
+						<Connection>
+							<ConfigKey>[Channel<Variable name="channum" />],play_indicator</ConfigKey>
 						</Connection>
 					</PushButton>
 				</Children>


### PR DESCRIPTION
Added the indicator connection for play and cue buttons in the LateNight skin. The Deere skin (ha! - that's funny!) still does not work, but I'll mess around with that one later. :)
