### PR TITLE
Blink sync

### DIFF
--- a/src/controlindicator.h
+++ b/src/controlindicator.h
@@ -3,7 +3,7 @@
 
 #include "controlobject.h"
 
-class ControlObjectThread;
+class ControlObjectSlave;
 
 class ControlIndicator : public ControlObject {
     Q_OBJECT
@@ -28,7 +28,7 @@ class ControlIndicator : public ControlObject {
     void slotBlinkValueChanged();
 
   private:
-    void toggle();
+    void toggle(double duartion);
     // set() is private, use setBlinkValue instead
     // it must be called from the GUI thread only to a void
     // race condition by toggle()
@@ -36,8 +36,8 @@ class ControlIndicator : public ControlObject {
 
     enum BlinkValue m_blinkValue;
     double m_nextSwitchTime;
-    ControlObjectThread* m_pCOTGuiTickTime;
-    ControlObjectThread* m_pCOTGuiTick50ms;
+    ControlObjectSlave* m_pCOTGuiTickTime;
+    ControlObjectSlave* m_pCOTGuiTick50ms;
 };
 
 #endif // CONTROLINDICATOR_H

--- a/src/controlindicator.h
+++ b/src/controlindicator.h
@@ -28,7 +28,7 @@ class ControlIndicator : public ControlObject {
     void slotBlinkValueChanged();
 
   private:
-    void toggle(double duartion);
+    void toggle(double duration);
     // set() is private, use setBlinkValue instead
     // it must be called from the GUI thread only to a void
     // race condition by toggle()

--- a/src/engine/cuecontrol.h
+++ b/src/engine/cuecontrol.h
@@ -89,7 +89,7 @@ class CueControl : public EngineControl {
     virtual ~CueControl();
 
     virtual void hintReader(HintVector* pHintList);
-    double updateIndicatorsAndModifyPlay(double play, bool playPossible);
+    bool updateIndicatorsAndModifyPlay(bool newPlay, bool playPossible);
     void updateIndicators();
     bool isTrackAtCue();
     bool getPlayFlashingAtPause();

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -632,7 +632,7 @@ void EngineBuffer::doSeekPlayPos(double new_playpos, enum SeekRequest seekType) 
     queueNewPlaypos(new_playpos, seekType);
 }
 
-double EngineBuffer::updateIndicatorsAndModifyPlay(double v) {
+bool EngineBuffer::updateIndicatorsAndModifyPlay(bool newPlay) {
     // If no track is currently loaded, turn play off. If a track is loading
     // allow the set since it might apply to a track we are loading due to the
     // asynchrony.
@@ -645,21 +645,21 @@ double EngineBuffer::updateIndicatorsAndModifyPlay(double v) {
         playPossible = false;
     }
 
-    return m_pCueControl->updateIndicatorsAndModifyPlay(v, playPossible);
+    return m_pCueControl->updateIndicatorsAndModifyPlay(newPlay, playPossible);
 }
 
 void EngineBuffer::verifyPlay() {
-    double play = m_playButton->get();
-    double verifiedPlay = updateIndicatorsAndModifyPlay(play);
+    bool play = m_playButton->toBool();
+    bool verifiedPlay = updateIndicatorsAndModifyPlay(play);
     if (play != verifiedPlay) {
-        m_playButton->setAndConfirm(verifiedPlay);
+        m_playButton->setAndConfirm(verifiedPlay ? 1.0 : 0.0);
     }
 }
 
 void EngineBuffer::slotControlPlayRequest(double v) {
-    double verifiedPlay = updateIndicatorsAndModifyPlay(v);
+    bool verifiedPlay = updateIndicatorsAndModifyPlay(v > 0.0);
     // set and confirm must be called here in any case to update the widget toggle state
-    m_playButton->setAndConfirm(verifiedPlay);
+    m_playButton->setAndConfirm(verifiedPlay ? 1.0 : 0.0);
 }
 
 void EngineBuffer::slotControlStart(double v)

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -235,7 +235,7 @@ class EngineBuffer : public EngineObject {
     void processSyncRequests();
     void processSeek();
 
-    double updateIndicatorsAndModifyPlay(double v);
+    bool updateIndicatorsAndModifyPlay(bool newPlay);
     void verifyPlay();
 
     // Holds the name of the control group


### PR DESCRIPTION
This branch syncs the phase of the button blinking.  https://bugs.launchpad.net/mixxx/+bug/1436505
It also fixes an issue with values other than 1.0 and 0.0 of the "play" CO 

There is a remaining, tiny off sync situation on heavy load. This is due to the asynchrony of the valueChanged slots transferring the current value too the widget . Fixing this requires to move the blinking generator into the button widget itself. But that requires a mayor refactoring and will not allow to sync the blinking on the controller buttons as well. 
