### PR TITLE
Added additional scanner cancel points ..

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1622,14 +1622,16 @@ void TrackDAO::markTrackLocationsAsDeleted(const QString& directory) {
     }
 }
 
-// Look for moved files. Look for files that have been marked as "deleted on disk"
-// and see if another "file" with the same name and filesize exists in the track_locations
-// table. That means the file has moved instead of being deleted outright, and so
-// we can salvage your existing metadata that you have in your DB (like cue points, etc.).
-void TrackDAO::detectMovedFiles(QSet<int>* pTracksMovedSetOld, QSet<int>* pTracksMovedSetNew) {
-    //This function should not start a transaction on it's own!
-    //When it's called from libraryscanner.cpp, there already is a transaction
-    //started!
+// Look for moved files. Look for files that have been marked as
+// "deleted on disk" and see if another "file" with the same name and
+// files size exists in the track_locations table. That means the file has
+// moved instead of being deleted outright, and so we can salvage your
+// existing metadata that you have in your DB (like cue points, etc.).
+bool TrackDAO::detectMovedFiles(QSet<int>* pTracksMovedSetOld,
+        QSet<int>* pTracksMovedSetNew, volatile const bool* pCancel) {
+    // This function should not start a transaction on it's own!
+    // When it's called from libraryscanner.cpp, there already is a transaction
+    // started!
     QSqlQuery query(m_database);
     QSqlQuery query2(m_database);
     QSqlQuery query3(m_database);
@@ -1659,8 +1661,11 @@ void TrackDAO::detectMovedFiles(QSet<int>* pTracksMovedSetOld, QSet<int>* pTrack
     const int filenameColumn = queryRecord.indexOf("filename");
     const int durationColumn = queryRecord.indexOf("duration");
 
-    //For each track that's been "deleted" on disk...
+    // For each track that's been "deleted" on disk...
     while (query.next()) {
+        if (*pCancel) {
+            return false;
+        }
         newTrackLocationId = -1; //Reset this var
         oldTrackLocationId = query.value(idColumn).toInt();
         filename = query.value(filenameColumn).toString();
@@ -1750,6 +1755,7 @@ void TrackDAO::detectMovedFiles(QSet<int>* pTracksMovedSetOld, QSet<int>* pTrack
             }
         }
     }
+    return true;
 }
 
 void TrackDAO::clearCache() {
@@ -1819,7 +1825,7 @@ bool TrackDAO::isTrackFormatSupported(TrackInfoObject* pTrack) const {
     return false;
 }
 
-void TrackDAO::verifyRemainingTracks() {
+bool TrackDAO::verifyRemainingTracks(volatile const bool* pCancel) {
     // This function is called from the LibraryScanner Thread, which also has a
     // transaction running, so we do NOT NEED to use one here
     QSqlQuery query(m_database);
@@ -1835,7 +1841,7 @@ void TrackDAO::verifyRemainingTracks() {
                   "WHERE needs_verification = 1");
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
-        return;
+        return false;
     }
 
     query2.prepare("UPDATE track_locations "
@@ -1852,7 +1858,11 @@ void TrackDAO::verifyRemainingTracks() {
             LOG_FAILED_QUERY(query2);
         }
         emit(progressVerifyTracksOutside(trackLocation));
+        if (*pCancel) {
+            return false;
+        }
     }
+    return true;
 }
 
 namespace

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -150,8 +150,9 @@ class TrackDAO : public QObject, public virtual DAO {
     void invalidateTrackLocationsInLibrary();
     void markUnverifiedTracksAsDeleted();
     void markTrackLocationsAsDeleted(const QString& directory);
-    void detectMovedFiles(QSet<int>* tracksMovedSetNew, QSet<int>* tracksMovedSetOld);
-    void verifyRemainingTracks();
+    bool detectMovedFiles(QSet<int>* pTracksMovedSetOld,
+            QSet<int>* pTracksMovedSetNew, volatile const bool* pCancel);
+    bool verifyRemainingTracks(volatile const bool* pCancel);
     void detectCoverArtForUnknownTracks(volatile const bool* pCancel,
                                         QSet<int>* pTracksChanged);
 

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -289,9 +289,9 @@ void LibraryScanner::cleanUpScan( const QStringList& verifiedTracks,
     qDebug() << "Marking unverified directories as deleted.";
     m_libraryHashDao.markUnverifiedDirectoriesAsDeleted();
 
-    // For making the scanner slow
-   qDebug() << "Burn CPU";
-   for (int i = 0;i < 1000000000; i++) asm("nop");
+    // For making the scanner slow, during debugging
+    //qDebug() << "Burn CPU";
+    //for (int i = 0;i < 1000000000; i++) asm("nop");
 
 
 

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -251,6 +251,81 @@ void LibraryScanner::slotStartScan() {
     }
 }
 
+void LibraryScanner::cleanUpScan( const QStringList& verifiedTracks,
+        const QStringList& verifiedDirectories) {
+    // At the end of a scan, mark all tracks and directories that weren't
+    // "verified" as "deleted" (as long as the scan wasn't canceled half way
+    // through). This condition is important because our rescanning algorithm
+    // starts by marking all tracks and dirs as unverified, so a canceled scan
+    // might leave half of your library as unverified. Don't want to mark those
+    // tracks/dirs as deleted in that case) :)
+
+    // Start a transaction for all the library hashing (moved file
+    // detection) stuff.
+    ScopedTransaction transaction(m_database);
+
+    qDebug() << "Marking tracks in changed directories as verified";
+    m_trackDao.markTrackLocationsAsVerified(verifiedTracks);
+
+    qDebug() << "Marking unchanged directories and tracks as verified";
+    m_libraryHashDao.updateDirectoryStatuses(verifiedDirectories, false,
+            true);
+    m_trackDao.markTracksInDirectoriesAsVerified(verifiedDirectories);
+
+    // After verifying tracks and directories via recursive scanning of the
+    // library directories the only unverified tracks will be files that are
+    // outside of the library directories and files that have been
+    // moved/deleted/renamed.
+    qDebug() << "Checking remaining unverified tracks.";
+    if (!m_trackDao.verifyRemainingTracks(
+            m_scannerGlobal->shouldCancelPointer())) {
+        // canceled
+        return;
+    }
+
+    qDebug() << "Marking unverified tracks as deleted.";
+    m_trackDao.markUnverifiedTracksAsDeleted();
+
+    qDebug() << "Marking unverified directories as deleted.";
+    m_libraryHashDao.markUnverifiedDirectoriesAsDeleted();
+
+    // For making the scanner slow
+   qDebug() << "Burn CPU";
+   for (int i = 0;i < 1000000000; i++) asm("nop");
+
+
+
+    // Check to see if the "deleted" tracks showed up in another location,
+    // and if so, do some magic to update all our tables.
+    qDebug() << "Detecting moved files.";
+    QSet<int> tracksMovedSetOld;
+    QSet<int> tracksMovedSetNew;
+    if (!m_trackDao.detectMovedFiles(&tracksMovedSetOld,
+            &tracksMovedSetNew,
+            m_scannerGlobal->shouldCancelPointer())) {
+        // canceled
+        return;
+    }
+
+    // Remove the hashes for any directories that have been marked as
+    // deleted to clean up. We need to do this otherwise we can skip over
+    // songs if you move a set of songs from directory A to B, then back to
+    // A.
+    m_libraryHashDao.removeDeletedDirectoryHashes();
+
+    transaction.commit();
+
+    qDebug() << "Detecting cover art for unscanned files.";
+    QSet<int> coverArtTracksChanged;
+    m_trackDao.detectCoverArtForUnknownTracks(
+            m_scannerGlobal->shouldCancelPointer(), &coverArtTracksChanged);
+
+    // Update BaseTrackCache via signals connected to the main TrackDAO.
+    emit(tracksMoved(tracksMovedSetOld, tracksMovedSetNew));
+    emit(tracksChanged(coverArtTracksChanged));
+}
+
+// is called when all tasks are done (threads are finished)
 void LibraryScanner::slotFinishScan() {
     qDebug() << "LibraryScanner::slotFinishScan";
     if (m_scannerGlobal.isNull()) {
@@ -274,62 +349,11 @@ void LibraryScanner::slotFinishScan() {
     QStringList verifiedTracks = m_scannerGlobal->verifiedTracks();
     QStringList verifiedDirectories = m_scannerGlobal->verifiedDirectories();
 
-    // At the end of a scan, mark all tracks and directories that weren't
-    // "verified" as "deleted" (as long as the scan wasn't canceled half way
-    // through). This condition is important because our rescanning algorithm
-    // starts by marking all tracks and dirs as unverified, so a canceled scan
-    // might leave half of your library as unverified. Don't want to mark those
-    // tracks/dirs as deleted in that case) :)
-    if (bScanFinishedCleanly) {
-        QSet<int> tracksMovedSetOld;
-        QSet<int> tracksMovedSetNew;
-        QSet<int> coverArtTracksChanged;
+    if (!m_scannerGlobal->shouldCancel() && bScanFinishedCleanly) {
+        cleanUpScan(verifiedTracks, verifiedDirectories);
+    }
 
-        // Start a transaction for all the library hashing (moved file
-        // detection) stuff.
-        ScopedTransaction transaction(m_database);
-
-        qDebug() << "Marking tracks in changed directories as verified";
-        m_trackDao.markTrackLocationsAsVerified(verifiedTracks);
-
-        qDebug() << "Marking unchanged directories and tracks as verified";
-        m_libraryHashDao.updateDirectoryStatuses(verifiedDirectories, false, true);
-        m_trackDao.markTracksInDirectoriesAsVerified(verifiedDirectories);
-
-        // After verifying tracks and directories via recursive scanning of the
-        // library directories the only unverified tracks will be files that are
-        // outside of the library directories and files that have been
-        // moved/deleted/renamed.
-        qDebug() << "Checking remaining unverified tracks.";
-        m_trackDao.verifyRemainingTracks();
-
-        qDebug() << "Marking unverified tracks as deleted.";
-        m_trackDao.markUnverifiedTracksAsDeleted();
-
-        qDebug() << "Marking unverified directories as deleted.";
-        m_libraryHashDao.markUnverifiedDirectoriesAsDeleted();
-
-        // Check to see if the "deleted" tracks showed up in another location,
-        // and if so, do some magic to update all our tables.
-        qDebug() << "Detecting moved files.";
-        m_trackDao.detectMovedFiles(&tracksMovedSetOld, &tracksMovedSetNew);
-
-        // Remove the hashes for any directories that have been marked as
-        // deleted to clean up. We need to do this otherwise we can skip over
-        // songs if you move a set of songs from directory A to B, then back to
-        // A.
-        m_libraryHashDao.removeDeletedDirectoryHashes();
-
-        transaction.commit();
-
-        qDebug() << "Detecting cover art for unscanned files.";
-        m_trackDao.detectCoverArtForUnknownTracks(
-            m_scannerGlobal->shouldCancelPointer(), &coverArtTracksChanged);
-
-        // Update BaseTrackCache via signals connected to the main TrackDAO.
-        emit(tracksMoved(tracksMovedSetOld, tracksMovedSetNew));
-        emit(tracksChanged(coverArtTracksChanged));
-
+    if (!m_scannerGlobal->shouldCancel() && bScanFinishedCleanly) {
         qDebug() << "Scan finished cleanly";
     } else {
         qDebug() << "Scan cancelled";
@@ -369,7 +393,7 @@ void LibraryScanner::taskDone(bool success) {
     //qDebug() << "LibraryScanner::taskDone" << success;
     ScopedTimer timer("LibraryScanner::taskDone");
     if (!success && m_scannerGlobal) {
-        m_scannerGlobal->setScanFinishedCleanly(false);
+        m_scannerGlobal->clearScanFinishedCleanly();
     }
 }
 

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -91,6 +91,9 @@ class LibraryScanner : public QThread {
     void addNewTrack(TrackPointer pTrack);
 
   private:
+    void cleanUpScan(const QStringList& verifiedTracks,
+            const QStringList& verifiedDirectories);
+
     // The library trackcollection. Do not touch this from the library scanner
     // thread.
     TrackCollection* m_pCollection;

--- a/src/library/scanner/scannerglobal.h
+++ b/src/library/scanner/scannerglobal.h
@@ -85,8 +85,8 @@ class ScannerGlobal {
         return m_scanFinishedCleanly;
     }
 
-    void setScanFinishedCleanly(bool scanFinishedCleanly) {
-        m_scanFinishedCleanly = scanFinishedCleanly;
+    void clearScanFinishedCleanly() {
+        m_scanFinishedCleanly = false;
     }
 
     void addVerifiedDirectory(const QString& directory) {


### PR DESCRIPTION
... during the library clean up time. 

This is required, since the clean up time task may take significant > 20 s time, which may delay the Mixxx shutdown. 

Breaking the clean up should be save, since we use a transaction. 
A "cancel" during the clean up period will have the same effect as a "cancel" before this region.

In the original code the clean up tasks where skipped by a "cancel", but the found tracks where stored. 
This means with and without the patch we are facing situations where the library clean up is not run.
I think this is OK. but if not, we have to fix the upstream as well
