### PR TITLE
Library focus issue

### DIFF
--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -23,6 +23,7 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     m_place = true;
     showPlaceholder();
 
+    setFocusPolicy(Qt::ClickFocus);
     QShortcut *setFocusShortcut = new QShortcut(
         QKeySequence(tr("Ctrl+F", "Search|Focus")), this);
     connect(setFocusShortcut, SIGNAL(activated()),


### PR DESCRIPTION
This is the easiest solution to [Bug #1462061: LateNight: toggling big library view sometimes focuses search bar when small library display is showing](https://bugs.launchpad.net/mixxx/+bug/1462061).

This just disables tab focus for the line edit widget. Shouldn't we completely disable tab focus anyway in order to free the tab key for keyboard mappings?
