### PR TITLE
uninitialized variables

### DIFF
--- a/src/encoder/encodervorbis.cpp
+++ b/src/encoder/encodervorbis.cpp
@@ -37,39 +37,15 @@ http://svn.xiph.org/trunk/vorbis/examples/encoder_example.c
 
 EncoderVorbis::EncoderVorbis(EncoderCallback* pCallback)
         : m_bStreamInitialized(false),
+          m_vblock({}),
+          m_vdsp({}),
+          m_vinfo({}),
+          m_vcomment({}),
           m_header_write(false),
           m_pCallback(pCallback),
           m_metaDataTitle(NULL),
           m_metaDataArtist(NULL),
           m_metaDataAlbum(NULL){
-    m_vdsp.pcm_returned = 0;
-    m_vdsp.preextrapolate = 0;
-    m_vdsp.eofflag = 0;
-    m_vdsp.lW = 0;
-    m_vdsp.W = 0;
-    m_vdsp.nW = 0;
-    m_vdsp.centerW = 0;
-    m_vdsp.granulepos = 0;
-    m_vdsp.sequence = 0;
-    m_vdsp.glue_bits = 0;
-    m_vdsp.time_bits = 0;
-    m_vdsp.floor_bits = 0;
-    m_vdsp.res_bits = 0;
-    m_vdsp.backend_state = NULL;
-
-    m_vinfo.version = 0;
-    m_vinfo.channels = 0;
-    m_vinfo.rate = 0;
-    m_vinfo.bitrate_upper = 0;
-    m_vinfo.bitrate_nominal = 0;
-    m_vinfo.bitrate_lower = 0;
-    m_vinfo.bitrate_window = 0;
-    m_vinfo.codec_setup = NULL;
-
-    m_vcomment.user_comments = NULL;
-    m_vcomment.comment_lengths = NULL;
-    m_vcomment.comments = 0;
-    m_vcomment.vendor = NULL;
 }
 
 EncoderVorbis::~EncoderVorbis() {

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -40,7 +40,8 @@ RateControl::RateControl(QString group,
       m_dTempRateChange(0.0),
       m_dRateTemp(0.0),
       m_eRampBackMode(RATERAMP_RAMPBACK_NONE),
-      m_dRateTempRampbackChange(0.0) {
+      m_dRateTempRampbackChange(0.0),
+      m_reverseChanged(false) {
     m_pScratchController = new PositionScratchController(group);
 
     m_pRateDir = new ControlObject(ConfigKey(group, "rate_dir"));

--- a/src/util/movinginterquartilemean.cpp
+++ b/src/util/movinginterquartilemean.cpp
@@ -1,7 +1,8 @@
 #include "movinginterquartilemean.h"
 
 MovingInterquartileMean::MovingInterquartileMean(const unsigned int listMaxSize)
-        : m_iListMaxSize(listMaxSize),
+        : m_dMean(0.0),
+          m_iListMaxSize(listMaxSize),
           m_bChanged(true) {
 }
 

--- a/src/waveform/vsyncthread.cpp
+++ b/src/waveform/vsyncthread.cpp
@@ -24,8 +24,28 @@
 VSyncThread::VSyncThread(MixxxMainWindow* mixxxMainWindow)
         : QThread(mixxxMainWindow),
           m_bDoRendering(true),
+          m_glw(NULL),
+#if defined(__APPLE__)
+#elif defined(__WINDOWS__)
+#else
+          glXGetVideoSyncSGI(0),
+          glXWaitVideoSyncSGI(0),
+          glXSwapIntervalSGI(0),
+          glXSwapIntervalEXT(0),
+          glXGetSyncValuesOML(0),
+          glXGetMscRateOML(0),
+          glXSwapBuffersMscOML(0),
+          glXWaitForMscOML(0),
+          glXWaitForSbcOML(0),
+          glXSwapIntervalMESA(0),
+          m_counter(0),
+          m_target_msc(0),
+          m_dpy(NULL),
+          m_drawable({}),
+#endif
           m_vSyncTypeChanged(false),
           m_usSyncIntervalTime(33333),
+          m_usWaitToSwap(0),
           m_vSyncMode(ST_TIMER),
           m_syncOk(false),
           m_droppedFrames(0),


### PR DESCRIPTION
This small PR properly initializes some previously uninitialized variables. This is using C++11's struct initializer

```
a = {};
```

GCC < 5 shows the warning `- -Wmissing-field-initializers` here, but this is merely an overly careful compiler and has in fact been fixed; see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=36750.
