### PR TITLE
change default compiler optimization option to native

### DIFF
--- a/build/features.py
+++ b/build/features.py
@@ -961,7 +961,7 @@ class Optimize(Feature):
     LEVEL_NATIVE = 'native'
     LEVEL_LEGACY = 'legacy'
 
-    LEVEL_DEFAULT = LEVEL_PORTABLE
+    LEVEL_DEFAULT = LEVEL_NATIVE
 
     def description(self):
         return "Optimization and Tuning"


### PR DESCRIPTION
Most people compiling Mixxx are doing so to run it on the same computer they are compiling on. They shouldn't have to do anything extra to optimize for their computer. Packagers and others who are compiling to run on multiple types of CPUs should be expected to read the wiki (which had outdated info about optimization before I just updated it) and/or run scons -h.
