### PR TITLE
Windows build: Fix extern "C" linkage of SoundSource plugin API (2nd attempt)

### DIFF
--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -74,6 +74,8 @@ template<class T> static void safeRelease(T **ppT) {
 
 } // anonymous namespace
 
+namespace Mixxx {
+
 SoundSourceMediaFoundation::SoundSourceMediaFoundation(QUrl url)
         : SoundSourcePlugin(url, "m4a"),
           m_hrCoInitialize(E_FAIL),
@@ -106,7 +108,7 @@ SoundSourceMediaFoundation::~SoundSourceMediaFoundation() {
     close();
 }
 
-Result SoundSourceMediaFoundation::tryOpen(const Mixxx::AudioSourceConfig& audioSrcCfg) {
+Result SoundSourceMediaFoundation::tryOpen(const AudioSourceConfig& audioSrcCfg) {
     if (SUCCEEDED(m_hrCoInitialize)) {
         qWarning() << "Cannot reopen MediaFoundation file" << getUrlString();
         return ERR;
@@ -425,7 +427,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
  If anything in here fails, just bail. I'm not going to decode HRESULTS.
  -- Bill
  */
-bool SoundSourceMediaFoundation::configureAudioStream(const Mixxx::AudioSourceConfig& audioSrcCfg) {
+bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& audioSrcCfg) {
     HRESULT hr(S_OK);
 
     // deselect all streams, we only want the first
@@ -596,15 +598,17 @@ QStringList SoundSourceProviderMediaFoundation::getSupportedFileExtensions() con
     return supportedFileExtensions;
 }
 
-Mixxx::SoundSourcePointer SoundSourceProviderMediaFoundation::newSoundSource(const QUrl& url) {
-    return Mixxx::exportSoundSourcePlugin(new SoundSourceMediaFoundation(url));
+SoundSourcePointer SoundSourceProviderMediaFoundation::newSoundSource(const QUrl& url) {
+    return exportSoundSourcePlugin(new SoundSourceMediaFoundation(url));
 }
+
+} // namespace Mixxx
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
 Mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider() {
     // SoundSourceProviderMediaFoundation is stateless and a single instance
     // can safely be shared
-    static SoundSourceProviderMediaFoundation singleton;
+    static Mixxx::SoundSourceProviderMediaFoundation singleton;
     return &singleton;
 }
 

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
@@ -28,6 +28,8 @@ class IMFSourceReader;
 class IMFMediaType;
 class IMFMediaSource;
 
+namespace Mixxx {
+
 class SoundSourceMediaFoundation : public Mixxx::SoundSourcePlugin {
 public:
     explicit SoundSourceMediaFoundation(QUrl url);
@@ -63,14 +65,16 @@ private:
     bool m_seeking;
 };
 
-class SoundSourceProviderMediaFoundation: public Mixxx::SoundSourceProvider {
+class SoundSourceProviderMediaFoundation: public SoundSourceProvider {
 public:
     QString getName() const override;
 
     QStringList getSupportedFileExtensions() const override;
 
-    Mixxx::SoundSourcePointer newSoundSource(const QUrl& url) override;
+    SoundSourcePointer newSoundSource(const QUrl& url) override;
 };
+
+} // namespace Mixxx
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
 Mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider();

--- a/src/sources/soundsourcepluginapi.h
+++ b/src/sources/soundsourcepluginapi.h
@@ -13,7 +13,10 @@
  8 - Mixxx 1.13.0 New SoundSource Plugin API
  */
 
-//As per QLibrary docs: http://doc.trolltech.com/4.6/qlibrary.html#resolve
+#include <QtGlobal>
+
+// Q_OS_WIN from <QtGlobal> should be defined when compiling on any
+// Windows platform
 #ifdef Q_OS_WIN
 #define MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT __declspec(dllexport)
 #else

--- a/src/sources/soundsourcepluginlibrary.h
+++ b/src/sources/soundsourcepluginlibrary.h
@@ -13,6 +13,8 @@ class SoundSourcePluginLibrary;
 
 typedef QSharedPointer<SoundSourcePluginLibrary> SoundSourcePluginLibraryPointer;
 
+typedef QSharedPointer<SoundSourceProvider> SoundSourceProviderPointer;
+
 // Wrapper class for a dynamic library that implements the SoundSource plugin API
 class SoundSourcePluginLibrary {
 public:

--- a/src/sources/soundsourceprovider.h
+++ b/src/sources/soundsourceprovider.h
@@ -1,7 +1,6 @@
 #ifndef MIXXX_SOUNDSOURCEPROVIDER_H
 #define MIXXX_SOUNDSOURCEPROVIDER_H
 
-#include <QSharedPointer>
 #include <QString>
 #include <QStringList>
 #include <QUrl>
@@ -21,8 +20,6 @@ public:
 
     virtual SoundSourcePointer newSoundSource(const QUrl& url) = 0;
 };
-
-typedef QSharedPointer<SoundSourceProvider> SoundSourceProviderPointer;
 
 } // namespace Mixxx
 


### PR DESCRIPTION
An #include directive was missing before the macro definition! I also enclosed the class in namespace "Mixxx" like the other plugins.
