### PR TITLE
Fix Windows build on VS2013

### DIFF
--- a/src/track/trackid.h
+++ b/src/track/trackid.h
@@ -7,8 +7,17 @@
 
 class TrackId: public DbId {
 public:
+#if defined(_MSC_VER) && (_MSC_VER < 1500)
+    // NOTE(uklotzde): Inheriting constructors are supported since VS2015.
+    // Use a default constructor and a single-argument constructor with
+    // perfect forwarding instead.
+    TrackId() {}
+    template<typename T>
+    explicit TrackId(T&& arg): DbId(std::forward<T>(arg)) {}
+#else
     // Inherit constructors from base class
     using DbId::DbId;
+#endif
 };
 
 Q_DECLARE_METATYPE(TrackId)

--- a/src/util/dbid.h
+++ b/src/util/dbid.h
@@ -23,7 +23,7 @@
 // not add any additional state (= member variables). Inheritance is
 // only needed for type-safety.
 class DbId {
-private:
+protected:
     // Alias for the corresponding native type. This typedef
     // should actually not be needed by users of this class,
     // but it keeps the implementation of this class flexible


### PR DESCRIPTION
Inheriting constructors are supported since VS2015, but not in VS2013. Use a default constructor and a single-argument constructor with perfect forwarding instead.

Let's see what VS2013 thinks about this workaround ;)
