### PR TITLE
Fix compile-time test for support of std::make_unique

### DIFF
--- a/src/util/memory.h
+++ b/src/util/memory.h
@@ -52,6 +52,8 @@
    #elif defined(__GNUC__)
       // std::make_unique was added in gcc 4.9
       #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+      // Compiling with -std=c++11 sets __cplusplus=201103L and disables
+      // std::make_unique() from C++14! We need to take this into account.
       #if GCC_VERSION >= 40900 && __cplusplus > 201103L
          #define COMPILER_SUPPORTS_MAKE_UNIQUE
       #endif

--- a/src/util/memory.h
+++ b/src/util/memory.h
@@ -33,7 +33,7 @@
 
 // If user hasn't specified COMPILER_SUPPORTS_MAKE_UNIQUE then try to figure out
 // based on compiler version if std::make_unique is provided.
-#if defined(COMPILER_SUPPORTS_MAKE_UNIQUE)
+#if !defined(COMPILER_SUPPORTS_MAKE_UNIQUE)
    #if defined(_MSC_VER)
       // std::make_unique was added in MSVC 12.0
       #if _MSC_VER >= 1800 // MSVC 12.0 (Visual Studio 2013)
@@ -52,13 +52,13 @@
    #elif defined(__GNUC__)
       // std::make_unique was added in gcc 4.9
       #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-      #if GCC_VERSION >= 40900
+      #if GCC_VERSION >= 40900 && __cplusplus > 201103L
          #define COMPILER_SUPPORTS_MAKE_UNIQUE
       #endif
    #endif
 #endif
 
-#if COMPILER_SUPPORTS_MAKE_UNIQUE
+#if defined(COMPILER_SUPPORTS_MAKE_UNIQUE)
 
 // If the compiler supports std::make_unique, then pull in <memory> to get it.
 #include <memory>


### PR DESCRIPTION
I think I found a bug in our adopted util/memory.h by analyzing the VS2013 build errors:

http://builds.mixxx.org:8081/jenkins/job/master/architecture=amd64,platform=windows/378/console

Both of the following files are included and provide an ambiguous version of std::make_unique():
C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\INCLUDE\memory
C:\mixxx\workspace\master\architecture\amd64\platform\windows\src\util/memory.h

I also had to modify the detection for GCC and take the option -std=c++11 into account!
