### PR TITLE
Add missing includes for std::move

### DIFF
--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -2,6 +2,7 @@
 #define SEARCHQUERY_H
 
 #include <vector>
+#include <utility>
 
 #include <QList>
 #include <QSqlDatabase>

--- a/src/util/dbid.h
+++ b/src/util/dbid.h
@@ -3,6 +3,7 @@
 
 
 #include <ostream>
+#include <utility>
 
 #include <QString>
 #include <QVariant>


### PR DESCRIPTION
...to fix the OS X build.

Afterwards the build will still fail (again) because of the missing type_traits include.
