### PR TITLE
Contrl object slave direct

### DIFF
--- a/src/controlobjectslave.cpp
+++ b/src/controlobjectslave.cpp
@@ -36,18 +36,43 @@ ControlObjectSlave::~ControlObjectSlave() {
 }
 
 bool ControlObjectSlave::connectValueChanged(const QObject* receiver,
-        const char* method, Qt::ConnectionType type) {
+        const char* method, Qt::ConnectionType requestedConnectionType) {
+
+    // We connect to the
+    // ControlObjectPrivate only once and in a way that
+    // the requested ConnectionType is working as desired.
+    // We try to avoid direct connections if not requested
+    // since you cannot safely delete an object with a pending
+    // direct connection. This fixes bug Bug #1406124
+    // requested: Auto -> COP = Auto / SCO = Auto
+    // requested: Direct -> COP = Direct / SCO = Direct
+    // requested: Queued -> COP = Auto / SCO = Queued
+    // requested: BlockingQueued -> Assert(false)
+
+
     bool ret = false;
     if (m_pControl) {
+        // We must not block the signal source by a blocking connection
+        DEBUG_ASSERT(requestedConnectionType != Qt::BlockingQueuedConnection);
         ret = connect((QObject*)this, SIGNAL(valueChanged(double)),
-                      receiver, method, type);
+                      receiver, method, requestedConnectionType);
         if (ret) {
             // Connect to ControlObjectPrivate only if required. Do not allow
             // duplicate connections.
-            connect(m_pControl.data(), SIGNAL(valueChanged(double, QObject*)),
-                    this, SLOT(slotValueChanged(double, QObject*)),
-                    static_cast<Qt::ConnectionType>(Qt::DirectConnection |
-                                                    Qt::UniqueConnection));
+            if (requestedConnectionType == Qt::DirectConnection) {
+                // use only explicit direct connection if requested
+                // the caller must not delete this until the all signals are
+                // processed to avoid segfaults
+                connect(m_pControl.data(), SIGNAL(valueChanged(double, QObject*)),
+                         this, SLOT(slotValueChangedDirect(double, QObject*)),
+                         static_cast<Qt::ConnectionType>(Qt::DirectConnection |
+                                                         Qt::UniqueConnection));
+            } else {
+                connect(m_pControl.data(), SIGNAL(valueChanged(double, QObject*)),
+                        this, SLOT(slotValueChangedDirect(double, QObject*)),
+                        static_cast<Qt::ConnectionType>(Qt::AutoConnection |
+                                                        Qt::UniqueConnection));
+            }
         }
     }
     return ret;

--- a/src/controlobjectslave.h
+++ b/src/controlobjectslave.h
@@ -95,9 +95,16 @@ class ControlObjectSlave : public QObject {
     void valueChanged(double);
 
   protected slots:
-    // Receives the value from the master control and re-emits either
-    // valueChanged(double) or valueChangedByThis(double) based on pSetter.
-    inline void slotValueChanged(double v, QObject* pSetter) {
+    // Receives the value from the master control by a unique direct connection
+    void slotValueChangedDirect(double v, QObject* pSetter) {
+        if (pSetter != this) {
+            // This is base implementation of this function without scaling
+            emit(valueChanged(v));
+        }
+    }
+
+    // Receives the value from the master control by a unique auto connection
+    void slotValueChangedAuto(double v, QObject* pSetter) {
         if (pSetter != this) {
             // This is base implementation of this function without scaling
             emit(valueChanged(v));

--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -125,7 +125,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     masterMixComboBox->setCurrentIndex(m_pMasterEnabled->get() ? 1 : 0);
     connect(masterMixComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(masterMixChanged(int)));
-    m_pMasterEnabled->connectValueChanged(this, SLOT(masterEnabledChanged(double)));
+    m_pMasterEnabled->connectValueChanged(SLOT(masterEnabledChanged(double)));
 
     m_pMasterMonoMixdown = new ControlObjectSlave("[Master]", "mono_mixdown", this);
     masterOutputModeComboBox->addItem(tr("Stereo"));
@@ -133,7 +133,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     masterOutputModeComboBox->setCurrentIndex(m_pMasterMonoMixdown->get() ? 1 : 0);
     connect(masterOutputModeComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(masterOutputModeComboBoxChanged(int)));
-    m_pMasterMonoMixdown->connectValueChanged(this, SLOT(masterMonoMixdownChanged(double)));
+    m_pMasterMonoMixdown->connectValueChanged(SLOT(masterMonoMixdownChanged(double)));
 
     m_pMasterTalkoverMix = new ControlObjectSlave("[Master]", "talkover_mix", this);
     micMixComboBox->addItem(tr("Master output"));
@@ -141,7 +141,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     micMixComboBox->setCurrentIndex((int)m_pMasterTalkoverMix->get());
     connect(micMixComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(talkoverMixComboBoxChanged(int)));
-    m_pMasterTalkoverMix->connectValueChanged(this, SLOT(talkoverMixChanged(double)));
+    m_pMasterTalkoverMix->connectValueChanged(SLOT(talkoverMixChanged(double)));
 
 
     m_pKeylockEngine =

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -32,15 +32,19 @@ BpmControl::BpmControl(QString group,
         m_tapFilter(this, filterLength, maxInterval),
         m_sGroup(group) {
     m_pPlayButton = new ControlObjectSlave(group, "play", this);
-    m_pPlayButton->connectValueChanged(SLOT(slotControlPlay(double)), Qt::DirectConnection);
+    m_pPlayButton->connectValueChanged(SLOT(slotControlPlay(double)),
+            Qt::DirectConnection);
     m_pReverseButton = new ControlObjectSlave(group, "reverse", this);
     m_pRateSlider = new ControlObjectSlave(group, "rate", this);
-    m_pRateSlider->connectValueChanged(SLOT(slotAdjustRateSlider()), Qt::DirectConnection);
+    m_pRateSlider->connectValueChanged(SLOT(slotAdjustRateSlider()),
+            Qt::DirectConnection);
     m_pQuantize = ControlObject::getControl(group, "quantize");
     m_pRateRange = new ControlObjectSlave(group, "rateRange", this);
-    m_pRateRange->connectValueChanged(SLOT(slotAdjustRateSlider()), Qt::DirectConnection);
+    m_pRateRange->connectValueChanged(SLOT(slotAdjustRateSlider()),
+            Qt::DirectConnection);
     m_pRateDir = new ControlObjectSlave(group, "rate_dir", this);
-    m_pRateDir->connectValueChanged(SLOT(slotAdjustRateSlider()), Qt::DirectConnection);
+    m_pRateDir->connectValueChanged(SLOT(slotAdjustRateSlider()),
+            Qt::DirectConnection);
 
     m_pPrevBeat.reset(new ControlObjectSlave(group, "beat_prev"));
     m_pNextBeat.reset(new ControlObjectSlave(group, "beat_next"));
@@ -125,14 +129,6 @@ BpmControl::BpmControl(QString group,
 }
 
 BpmControl::~BpmControl() {
-    delete m_pPlayButton;
-    delete m_pRateSlider;
-    delete m_pRateRange;
-    delete m_pRateDir;
-    delete m_pLoopEnabled;
-    delete m_pLoopStartPosition;
-    delete m_pLoopEndPosition;
-    delete m_pVCEnabled;
     delete m_pFileBpm;
     delete m_pLocalBpm;
     delete m_pEngineBpm;
@@ -144,7 +140,6 @@ BpmControl::~BpmControl() {
     delete m_pBeatsTranslateMatchAlignment;
     delete m_pTranslateBeatsEarlier;
     delete m_pTranslateBeatsLater;
-    delete m_pThisBeatDistance;
     delete m_pAdjustBeatsFaster;
     delete m_pAdjustBeatsSlower;
 }

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -281,8 +281,8 @@ EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
     m_pScale->clear();
     m_bScalerChanged = true;
 
-    m_pPassthroughEnabled.reset(new ControlObjectSlave(group, "passthrough", this));
-    m_pPassthroughEnabled->connectValueChanged(this, SLOT(slotPassthroughChanged(double)),
+    m_pPassthroughEnabled = new ControlObjectSlave(group, "passthrough", this);
+    m_pPassthroughEnabled->connectValueChanged(SLOT(slotPassthroughChanged(double)),
                                                Qt::DirectConnection);
 
     //m_iRampIter = 0;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -200,8 +200,7 @@ EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
     m_pSampleRate = new ControlObjectSlave("[Master]", "samplerate", this);
 
     m_pKeylockEngine = new ControlObjectSlave("[Master]", "keylock_engine", this);
-    m_pKeylockEngine->connectValueChanged(this,
-                                          SLOT(slotKeylockEngineChanged(double)),
+    m_pKeylockEngine->connectValueChanged(SLOT(slotKeylockEngineChanged(double)),
                                           Qt::DirectConnection);
 
     m_pTrackSamples = new ControlObject(ConfigKey(m_group, "track_samples"));

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -336,7 +336,7 @@ class EngineBuffer : public EngineObject {
     ControlObjectSlave* m_pSampleRate;
     ControlObjectSlave* m_pKeylockEngine;
     ControlPushButton* m_pKeylock;
-    QScopedPointer<ControlObjectSlave> m_pPassthroughEnabled;
+    ControlObjectSlave* m_pPassthroughEnabled;
 
     ControlPushButton* m_pEject;
 

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -31,8 +31,8 @@ SyncControl::SyncControl(const QString& group, ConfigObject<ConfigValue>* pConfi
           m_prevLocalBpm(0.0) {
     // Play button.  We only listen to this to disable master if the deck is
     // stopped.
-    m_pPlayButton.reset(new ControlObjectSlave(group, "play", this));
-    m_pPlayButton->connectValueChanged(this, SLOT(slotControlPlay(double)),
+    m_pPlayButton = new ControlObjectSlave(group, "play", this);
+    m_pPlayButton->connectValueChanged(SLOT(slotControlPlay(double)),
                                        Qt::DirectConnection);
 
     m_pSyncMode.reset(new ControlPushButton(ConfigKey(group, "sync_mode")));
@@ -56,13 +56,13 @@ SyncControl::SyncControl(const QString& group, ConfigObject<ConfigValue>* pConfi
     m_pSyncBeatDistance.reset(
             new ControlObject(ConfigKey(group, "beat_distance")));
 
-    m_pPassthroughEnabled.reset(new ControlObjectSlave(group, "passthrough", this));
-    m_pPassthroughEnabled->connectValueChanged(this, SLOT(slotPassthroughChanged(double)),
-                                               Qt::DirectConnection);
+    m_pPassthroughEnabled = new ControlObjectSlave(group, "passthrough", this);
+    m_pPassthroughEnabled->connectValueChanged(
+            SLOT(slotPassthroughChanged(double)), Qt::DirectConnection);
 
-    m_pEjectButton.reset(new ControlObjectSlave(group, "eject", this));
-    m_pEjectButton->connectValueChanged(this, SLOT(slotEjectPushed(double)),
-                                        Qt::DirectConnection);
+    m_pEjectButton = new ControlObjectSlave(group, "eject", this);
+    m_pEjectButton->connectValueChanged(
+            SLOT(slotEjectPushed(double)), Qt::DirectConnection);
 
     // BPMControl and RateControl will be initialized later.
 }
@@ -78,37 +78,37 @@ void SyncControl::setEngineControls(RateControl* pRateControl,
     // We set this to change the effective BPM in BpmControl. We do not listen
     // to changes from this control because changes in rate, rate_dir, rateRange
     // and file_bpm result in changes to this control.
-    m_pBpm.reset(new ControlObjectSlave(getGroup(), "bpm", this));
+    m_pBpm = new ControlObjectSlave(getGroup(), "bpm", this);
 
-    m_pLocalBpm.reset(new ControlObjectSlave(getGroup(), "local_bpm", this));
+    m_pLocalBpm = new ControlObjectSlave(getGroup(), "local_bpm", this);
 
-    m_pFileBpm.reset(new ControlObjectSlave(getGroup(), "file_bpm", this));
-    m_pFileBpm->connectValueChanged(this, SLOT(slotFileBpmChanged()),
+    m_pFileBpm = new ControlObjectSlave(getGroup(), "file_bpm", this);
+    m_pFileBpm->connectValueChanged(SLOT(slotFileBpmChanged()),
                                     Qt::DirectConnection);
 
-    m_pRateSlider.reset(new ControlObjectSlave(getGroup(), "rate", this));
-    m_pRateSlider->connectValueChanged(this, SLOT(slotRateChanged()),
+    m_pRateSlider = new ControlObjectSlave(getGroup(), "rate", this);
+    m_pRateSlider->connectValueChanged(SLOT(slotRateChanged()),
                                        Qt::DirectConnection);
 
-    m_pRateDirection.reset(new ControlObjectSlave(getGroup(), "rate_dir", this));
-    m_pRateDirection->connectValueChanged(this, SLOT(slotRateChanged()),
+    m_pRateDirection = new ControlObjectSlave(getGroup(), "rate_dir", this);
+    m_pRateDirection->connectValueChanged(SLOT(slotRateChanged()),
                                           Qt::DirectConnection);
 
-    m_pRateRange.reset(new ControlObjectSlave(getGroup(), "rateRange", this));
-    m_pRateRange->connectValueChanged(this, SLOT(slotRateChanged()),
+    m_pRateRange = new ControlObjectSlave(getGroup(), "rateRange", this);
+    m_pRateRange->connectValueChanged(SLOT(slotRateChanged()),
                                       Qt::DirectConnection);
 
-    m_pSyncPhaseButton.reset(new ControlObjectSlave(getGroup(), "beatsync_phase", this));
+    m_pSyncPhaseButton = new ControlObjectSlave(getGroup(), "beatsync_phase", this);
 
 #ifdef __VINYLCONTROL__
-    m_pVCEnabled.reset(new ControlObjectSlave(
-        getGroup(), "vinylcontrol_enabled", this));
+    m_pVCEnabled = new ControlObjectSlave(
+            getGroup(), "vinylcontrol_enabled", this);
 
     // Throw a hissy fit if somebody moved us such that the vinylcontrol_enabled
     // control doesn't exist yet. This will blow up immediately, won't go unnoticed.
     DEBUG_ASSERT(m_pVCEnabled->valid());
 
-    m_pVCEnabled->connectValueChanged(this, SLOT(slotVinylControlChanged(double)),
+    m_pVCEnabled->connectValueChanged(SLOT(slotVinylControlChanged(double)),
                                       Qt::DirectConnection);
 #endif
 }

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -122,17 +122,17 @@ class SyncControl : public EngineControl, public Syncable {
     QScopedPointer<ControlPushButton> m_pSyncEnabled;
     QScopedPointer<ControlObject> m_pSyncBeatDistance;
 
-    QScopedPointer<ControlObjectSlave> m_pPlayButton;
-    QScopedPointer<ControlObjectSlave> m_pBpm;
-    QScopedPointer<ControlObjectSlave> m_pLocalBpm;
-    QScopedPointer<ControlObjectSlave> m_pFileBpm;
-    QScopedPointer<ControlObjectSlave> m_pRateSlider;
-    QScopedPointer<ControlObjectSlave> m_pRateDirection;
-    QScopedPointer<ControlObjectSlave> m_pRateRange;
-    QScopedPointer<ControlObjectSlave> m_pVCEnabled;
-    QScopedPointer<ControlObjectSlave> m_pPassthroughEnabled;
-    QScopedPointer<ControlObjectSlave> m_pEjectButton;
-    QScopedPointer<ControlObjectSlave> m_pSyncPhaseButton;
+    ControlObjectSlave* m_pPlayButton;
+    ControlObjectSlave* m_pBpm;
+    ControlObjectSlave* m_pLocalBpm;
+    ControlObjectSlave* m_pFileBpm;
+    ControlObjectSlave* m_pRateSlider;
+    ControlObjectSlave* m_pRateDirection;
+    ControlObjectSlave* m_pRateRange;
+    ControlObjectSlave* m_pVCEnabled;
+    ControlObjectSlave* m_pPassthroughEnabled;
+    ControlObjectSlave* m_pEjectButton;
+    ControlObjectSlave* m_pSyncPhaseButton;
 };
 
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -960,8 +960,7 @@ void MixxxMainWindow::linkSkinWidget(ControlObjectSlave** pCOS,
                                      ConfigKey key, const char* slot) {
     if (!*pCOS) {
         *pCOS = new ControlObjectSlave(key, this);
-        (*pCOS)->connectValueChanged(
-            this, slot, Qt::DirectConnection);
+        (*pCOS)->connectValueChanged(slot);
     }
 }
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1599,8 +1599,8 @@ void MixxxMainWindow::initActions()
         if (i > 0) {
             group = QString("[Microphone%1]").arg(i + 1);
         }
-        ControlObjectSlave* talkover_button(new ControlObjectSlave(
-                group, "talkover", this));
+        ControlObjectSlave* talkover_button = new ControlObjectSlave(
+                group, "talkover");
         m_TalkoverMapper->setMapping(talkover_button, i);
         talkover_button->connectValueChanged(m_TalkoverMapper, SLOT(map()));
         m_micTalkoverControls.push_back(talkover_button);

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1871,12 +1871,8 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
             QString property = m_pContext->selectString(con, "BindProperty");
             //qDebug() << "Making property connection for" << property;
 
-            ControlObjectSlave* pControlWidget =
-                    new ControlObjectSlave(control->getKey(),
-                                           pWidget->toQWidget());
-
             ControlWidgetPropertyConnection* pConnection =
-                    new ControlWidgetPropertyConnection(pWidget, pControlWidget,
+                    new ControlWidgetPropertyConnection(pWidget, control->getKey(),
                                                         pTransformer, property);
             pWidget->addPropertyConnection(pConnection);
 
@@ -1943,12 +1939,8 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
                 emitOption |= ControlParameterWidgetConnection::EMIT_DEFAULT;
             }
 
-            // Connect control proxy to widget. Parented to pWidget so it is not
-            // leaked.
-            ControlObjectSlave* pControlWidget = new ControlObjectSlave(
-                    control->getKey(), pWidget->toQWidget());
             ControlParameterWidgetConnection* pConnection = new ControlParameterWidgetConnection(
-                    pWidget, pControlWidget, pTransformer,
+                    pWidget, control->getKey(), pTransformer,
                     static_cast<ControlParameterWidgetConnection::DirectionOption>(directionOption),
                     static_cast<ControlParameterWidgetConnection::EmitOption>(emitOption));
 
@@ -1976,6 +1968,8 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
                 pWidget->addRightConnection(pConnection);
                 break;
             default:
+                // can't happen. Nothing else is returned by parseButtonState();
+                DEBUG_ASSERT(false);
                 break;
             }
 

--- a/src/test/wpushbutton_test.cpp
+++ b/src/test/wpushbutton_test.cpp
@@ -38,7 +38,7 @@ TEST_F(WPushButtonTest, QuickPressNoLatchTest) {
     m_pButton->addLeftConnection(
         new ControlParameterWidgetConnection(
             m_pButton.data(),
-            new ControlObjectSlave(pPushControl->getKey()), NULL,
+            pPushControl->getKey(), NULL,
             ControlParameterWidgetConnection::DIR_FROM_AND_TO_WIDGET,
             ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE));
 
@@ -63,7 +63,7 @@ TEST_F(WPushButtonTest, LongPressLatchTest) {
     m_pButton->addLeftConnection(
         new ControlParameterWidgetConnection(
             m_pButton.data(),
-            new ControlObjectSlave(pPushControl->getKey()), NULL,
+            pPushControl->getKey(), NULL,
             ControlParameterWidgetConnection::DIR_FROM_AND_TO_WIDGET,
             ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE));
 

--- a/src/visualplayposition.cpp
+++ b/src/visualplayposition.cpp
@@ -15,15 +15,15 @@ VisualPlayPosition::VisualPlayPosition(const QString& key)
         : m_valid(false),
           m_key(key),
           m_invalidTimeInfoWarned(false) {
-    m_audioBufferSize = new ControlObjectSlave("[Master]", "audio_buffer_size");
+    m_audioBufferSize = new ControlObjectSlave(
+            "[Master]", "audio_buffer_size", this);
     m_audioBufferSize->connectValueChanged(
-            this, SLOT(slotAudioBufferSizeChanged(double)));
+            SLOT(slotAudioBufferSizeChanged(double)));
     m_dAudioBufferSize = m_audioBufferSize->get();
 }
 
 VisualPlayPosition::~VisualPlayPosition() {
     m_listVisualPlayPosition.remove(m_key);
-    delete m_audioBufferSize;
 }
 
 void VisualPlayPosition::set(double playPos, double rate,

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -7,18 +7,12 @@
 #include "util/assert.h"
 
 ControlWidgetConnection::ControlWidgetConnection(WBaseWidget* pBaseWidget,
-                                                 ControlObjectSlave* pControl,
+                                                 const ConfigKey& key,
                                                  ValueTransformer* pTransformer)
         : m_pWidget(pBaseWidget),
-          m_pControl(pControl),
           m_pValueTransformer(pTransformer) {
-    // If m_pControl is NULL then the creator of ControlWidgetConnection has
-    // screwed up badly. Assert in development mode. In release mode the
-    // connection will be defunct.
-    DEBUG_ASSERT_AND_HANDLE(!m_pControl.isNull()) {
-        m_pControl.reset(new ControlObjectSlave());
-    }
-    m_pControl->connectValueChanged(this, SLOT(slotControlValueChanged(double)));
+    m_pControl = new ControlObjectSlave(key, this);
+    m_pControl->connectValueChanged(SLOT(slotControlValueChanged(double)));
 }
 
 ControlWidgetConnection::~ControlWidgetConnection() {
@@ -48,11 +42,11 @@ double ControlWidgetConnection::getControlParameterForValue(double value) const 
 }
 
 ControlParameterWidgetConnection::ControlParameterWidgetConnection(WBaseWidget* pBaseWidget,
-                                                                   ControlObjectSlave* pControl,
+                                                                   const ConfigKey& key,
                                                                    ValueTransformer* pTransformer,
                                                                    DirectionOption directionOption,
                                                                    EmitOption emitOption)
-        : ControlWidgetConnection(pBaseWidget, pControl, pTransformer),
+        : ControlWidgetConnection(pBaseWidget, key, pTransformer),
           m_directionOption(directionOption),
           m_emitOption(emitOption) {
 }
@@ -105,10 +99,10 @@ void ControlParameterWidgetConnection::setControlParameterUp(double v) {
 }
 
 ControlWidgetPropertyConnection::ControlWidgetPropertyConnection(WBaseWidget* pBaseWidget,
-                                                                 ControlObjectSlave* pControl,
+                                                                 const ConfigKey& key,
                                                                  ValueTransformer* pTransformer,
                                                                  const QString& propertyName)
-        : ControlWidgetConnection(pBaseWidget, pControl, pTransformer),
+        : ControlWidgetConnection(pBaseWidget, key, pTransformer),
           m_propertyName(propertyName.toAscii()) {
     slotControlValueChanged(m_pControl->get());
 }

--- a/src/widget/controlwidgetconnection.h
+++ b/src/widget/controlwidgetconnection.h
@@ -16,7 +16,7 @@ class ControlWidgetConnection : public QObject {
   public:
     // Takes ownership of pControl and pTransformer.
     ControlWidgetConnection(WBaseWidget* pBaseWidget,
-                            ControlObjectSlave* pControl,
+                            const ConfigKey& key,
                             ValueTransformer* pTransformer);
     virtual ~ControlWidgetConnection();
 
@@ -36,7 +36,7 @@ class ControlWidgetConnection : public QObject {
     void setControlParameter(double v);
 
     WBaseWidget* m_pWidget;
-    QScopedPointer<ControlObjectSlave> m_pControl;
+    ControlObjectSlave* m_pControl;
 
   private:
     QScopedPointer<ValueTransformer> m_pValueTransformer;
@@ -92,7 +92,7 @@ class ControlParameterWidgetConnection : public ControlWidgetConnection {
     }
 
     ControlParameterWidgetConnection(WBaseWidget* pBaseWidget,
-                                     ControlObjectSlave* pControl,
+                                     const ConfigKey& key,
                                      ValueTransformer* pTransformer,
                                      DirectionOption directionOption,
                                      EmitOption emitOption);
@@ -125,7 +125,7 @@ class ControlWidgetPropertyConnection : public ControlWidgetConnection {
     Q_OBJECT
   public:
     ControlWidgetPropertyConnection(WBaseWidget* pBaseWidget,
-                                    ControlObjectSlave* pControl,
+                                    const ConfigKey& key,
                                     ValueTransformer* pTransformer,
                                     const QString& property);
     virtual ~ControlWidgetPropertyConnection();

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -106,8 +106,8 @@ WTrackTableView::WTrackTableView(QWidget * parent,
     connect(&m_crateMapper, SIGNAL(mapped(int)),
             this, SLOT(addSelectionToCrate(int)));
 
-    m_pCOTGuiTick = new ControlObjectSlave("[Master]", "guiTick50ms");
-    m_pCOTGuiTick->connectValueChanged(this, SLOT(slotGuiTick50ms(double)));
+    m_pCOTGuiTick = new ControlObjectSlave("[Master]", "guiTick50ms", this);
+    m_pCOTGuiTick->connectValueChanged(SLOT(slotGuiTick50ms(double)));
 
     connect(this, SIGNAL(scrollValueChanged(int)),
             this, SLOT(slotScrollValueChanged(int)));
@@ -154,7 +154,6 @@ WTrackTableView::~WTrackTableView() {
     delete m_pFileBrowserAct;
     delete m_pResetPlayedAct;
     delete m_pSamplerMenu;
-    delete m_pCOTGuiTick;
 }
 
 void WTrackTableView::enableCachedOnly() {

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -26,26 +26,21 @@ WWaveformViewer::WWaveformViewer(const char *group, ConfigObject<ConfigValue>* p
           m_waveformWidget(NULL) {
     setAcceptDrops(true);
 
-    m_pZoom = new ControlObjectSlave(group, "waveform_zoom");
-    m_pZoom->connectValueChanged(this, SLOT(onZoomChange(double)));
+    m_pZoom = new ControlObjectSlave(group, "waveform_zoom", this);
+    m_pZoom->connectValueChanged(SLOT(onZoomChange(double)));
 
     m_pScratchPositionEnable = new ControlObjectSlave(
-            group, "scratch_position_enable");
+            group, "scratch_position_enable", this);
     m_pScratchPosition = new ControlObjectSlave(
-            group, "scratch_position");
+            group, "scratch_position", this);
     m_pWheel = new ControlObjectSlave(
-            group, "wheel");
+            group, "wheel", this);
 
     setAttribute(Qt::WA_OpaquePaintEvent);
 }
 
 WWaveformViewer::~WWaveformViewer() {
     //qDebug() << "~WWaveformViewer";
-
-    delete m_pZoom;
-    delete m_pScratchPositionEnable;
-    delete m_pScratchPosition;
-    delete m_pWheel;
 }
 
 void WWaveformViewer::setup(QDomNode node, const SkinContext& context) {


### PR DESCRIPTION
This should Fix Bug https://bugs.launchpad.net/mixxx/+bug/1406124

I have changed the internal signal/slot connection according to the requested connection, like that: 
- connectValueChanged Auto -> COP = Auto / SCO = Auto
- connectValueChanged Direct -> COP = Direct / SCO = Direct
- connectValueChanged Queued -> COP = Auto / SCO = Queued
- connectValueChanged BlockingQueued -> Assert(false)

I have also reviewed all occurrence of ControlObjectSlave and it should work now. 

I have removed  most manual deletes and scoped pointer in favour of the Qt Object tree delete feature. This offers the best safety since the COS is deleted by its parent object, from which it usually inherits the event queue as well. 

TODO: The deprecated ControlObjectThread suffers the same issue. I think we need to replace it with ControlObjectSlaves.
