### PR TITLE
Update ControlDoublePrivate <-> ControlObjectSlave to avoid a race conditon. Improves Bug #1406124.

### DIFF
--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -65,10 +65,10 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
             this, SLOT(slotUnloadTrack(TrackPointer)));
 
     // Get loop point control objects
-    m_pLoopInPoint = new ControlObjectThread(
-            getGroup(),"loop_start_position");
-    m_pLoopOutPoint = new ControlObjectThread(
-            getGroup(),"loop_end_position");
+    m_pLoopInPoint = new ControlObjectSlave(
+            getGroup(),"loop_start_position", this);
+    m_pLoopOutPoint = new ControlObjectSlave(
+            getGroup(),"loop_end_position", this);
 
     // Duration of the current song, we create this one because nothing else does.
     m_pDuration = new ControlObject(ConfigKey(getGroup(), "duration"));
@@ -86,14 +86,14 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
     m_pEndOfTrack = new ControlObject(ConfigKey(group, "end_of_track"));
     m_pEndOfTrack->set(0.);
 
-    m_pPreGain = new ControlObjectSlave(ConfigKey(group, "pregain"));
+    m_pPreGain = new ControlObjectSlave(group, "pregain", this);
     //BPM of the current song
     m_pBPM = new ControlObjectThread(group, "file_bpm");
     m_pKey = new ControlObjectThread(group, "file_key");
-    m_pReplayGain = new ControlObjectThread(group, "replaygain");
-    m_pPlay = new ControlObjectThread(group, "play");
-    connect(m_pPlay, SIGNAL(valueChanged(double)),
-            this, SLOT(slotPlayToggled(double)));
+
+    m_pReplayGain = new ControlObjectSlave(group, "replaygain", this);
+    m_pPlay = new ControlObjectSlave(group, "play", this);
+    m_pPlay->connectValueChanged(SLOT(slotPlayToggled(double)));
 }
 
 BaseTrackPlayerImpl::~BaseTrackPlayerImpl() {
@@ -108,21 +108,8 @@ BaseTrackPlayerImpl::~BaseTrackPlayerImpl() {
     delete m_pDuration;
     delete m_pWaveformZoom;
     delete m_pEndOfTrack;
-    delete m_pLoopInPoint;
-    delete m_pLoopOutPoint;
     delete m_pBPM;
     delete m_pKey;
-    delete m_pReplayGain;
-    delete m_pPlay;
-    delete m_pLowFilter;
-    delete m_pMidFilter;
-    delete m_pHighFilter;
-    delete m_pLowFilterKill;
-    delete m_pMidFilterKill;
-    delete m_pHighFilterKill;
-    delete m_pPreGain;
-    delete m_pSpeed;
-    delete m_pPitchAdjust;
 }
 
 void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer track, bool bPlay) {
@@ -166,7 +153,7 @@ void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer track, bool bPlay) {
         disconnect(m_pLoadedTrack.data(), 0, this, 0);
         disconnect(m_pLoadedTrack.data(), 0, m_pKey, 0);
 
-        m_pReplayGain->slotSet(0);
+        m_pReplayGain->set(0);
 
         // Causes the track's data to be saved back to the library database.
         emit(unloadingTrack(m_pLoadedTrack));
@@ -221,9 +208,9 @@ void BaseTrackPlayerImpl::slotUnloadTrack(TrackPointer) {
     m_pDuration->set(0);
     m_pBPM->slotSet(0);
     m_pKey->slotSet(0);
-    m_pReplayGain->slotSet(0);
-    m_pLoopInPoint->slotSet(-1);
-    m_pLoopOutPoint->slotSet(-1);
+    m_pReplayGain->set(0);
+    m_pLoopInPoint->set(-1);
+    m_pLoopOutPoint->set(-1);
     m_pLoadedTrack.clear();
 
     // Update the PlayerInfo class that is used in EngineShoutcast to replace
@@ -245,15 +232,15 @@ void BaseTrackPlayerImpl::slotFinishLoading(TrackPointer pTrackInfoObject)
     m_pDuration->set(m_pLoadedTrack->getDuration());
     m_pBPM->slotSet(m_pLoadedTrack->getBpm());
     m_pKey->slotSet(m_pLoadedTrack->getKey());
-    m_pReplayGain->slotSet(m_pLoadedTrack->getReplayGain());
+    m_pReplayGain->set(m_pLoadedTrack->getReplayGain());
 
     // Update the PlayerInfo class that is used in EngineShoutcast to replace
     // the metadata of a stream
     PlayerInfo::instance().setTrackInfo(getGroup(), m_pLoadedTrack);
 
     // Reset the loop points.
-    m_pLoopInPoint->slotSet(-1);
-    m_pLoopOutPoint->slotSet(-1);
+    m_pLoopInPoint->set(-1);
+    m_pLoopOutPoint->set(-1);
 
     const QList<Cue*> trackCues = pTrackInfoObject->getCuePoints();
     QListIterator<Cue*> it(trackCues);
@@ -263,8 +250,8 @@ void BaseTrackPlayerImpl::slotFinishLoading(TrackPointer pTrackInfoObject)
             int loopStart = pCue->getPosition();
             int loopEnd = loopStart + pCue->getLength();
             if (loopStart != -1 && loopEnd != -1 && even(loopStart) && even(loopEnd)) {
-                m_pLoopInPoint->slotSet(loopStart);
-                m_pLoopOutPoint->slotSet(loopEnd);
+                m_pLoopInPoint->set(loopStart);
+                m_pLoopOutPoint->set(loopEnd);
                 break;
             }
         }
@@ -316,7 +303,7 @@ void BaseTrackPlayerImpl::slotSetReplayGain(double replayGain) {
     // Do not change replay gain when track is playing because
     // this may lead to an unexpected volume change
     if (m_pPlay->get() == 0.0) {
-        m_pReplayGain->slotSet(replayGain);
+        m_pReplayGain->set(replayGain);
     } else {
         m_replaygainPending = true;
     }
@@ -324,7 +311,7 @@ void BaseTrackPlayerImpl::slotSetReplayGain(double replayGain) {
 
 void BaseTrackPlayerImpl::slotPlayToggled(double v) {
     if (!v && m_replaygainPending) {
-        m_pReplayGain->slotSet(m_pLoadedTrack->getReplayGain());
+        m_pReplayGain->set(m_pLoadedTrack->getReplayGain());
         m_replaygainPending = false;
     }
 }
@@ -335,12 +322,12 @@ EngineDeck* BaseTrackPlayerImpl::getEngineDeck() const {
 
 void BaseTrackPlayerImpl::setupEqControls() {
     const QString group = getGroup();
-    m_pLowFilter = new ControlObjectSlave(group, "filterLow");
-    m_pMidFilter = new ControlObjectSlave(group, "filterMid");
-    m_pHighFilter = new ControlObjectSlave(group, "filterHigh");
-    m_pLowFilterKill = new ControlObjectSlave(group, "filterLowKill");
-    m_pMidFilterKill = new ControlObjectSlave(group, "filterMidKill");
-    m_pHighFilterKill = new ControlObjectSlave(group, "filterHighKill");
-    m_pSpeed = new ControlObjectSlave(group, "rate");
-    m_pPitchAdjust = new ControlObjectSlave(group, "pitch_adjust");
+    m_pLowFilter = new ControlObjectSlave(group, "filterLow", this);
+    m_pMidFilter = new ControlObjectSlave(group, "filterMid", this);
+    m_pHighFilter = new ControlObjectSlave(group, "filterHigh", this);
+    m_pLowFilterKill = new ControlObjectSlave(group, "filterLowKill", this);
+    m_pMidFilterKill = new ControlObjectSlave(group, "filterMidKill", this);
+    m_pHighFilterKill = new ControlObjectSlave(group, "filterHighKill", this);
+    m_pSpeed = new ControlObjectSlave(group, "rate", this);
+    m_pPitchAdjust = new ControlObjectSlave(group, "pitch_adjust", this);
 }

--- a/src/basetrackplayer.h
+++ b/src/basetrackplayer.h
@@ -79,13 +79,17 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     ControlPotmeter* m_pWaveformZoom;
     ControlObject* m_pEndOfTrack;
 
-    ControlObjectThread* m_pLoopInPoint;
-    ControlObjectThread* m_pLoopOutPoint;
+    ControlObjectSlave* m_pLoopInPoint;
+    ControlObjectSlave* m_pLoopOutPoint;
     ControlObject* m_pDuration;
+
+    // TODO() these COs are reconnected during runtime
+    // This may lock the engine
     ControlObjectThread* m_pBPM;
     ControlObjectThread* m_pKey;
-    ControlObjectThread* m_pReplayGain;
-    ControlObjectThread* m_pPlay;
+
+    ControlObjectSlave* m_pReplayGain;
+    ControlObjectSlave* m_pPlay;
     ControlObjectSlave* m_pLowFilter;
     ControlObjectSlave* m_pMidFilter;
     ControlObjectSlave* m_pHighFilter;

--- a/src/controlobjectslave.cpp
+++ b/src/controlobjectslave.cpp
@@ -69,7 +69,7 @@ bool ControlObjectSlave::connectValueChanged(const QObject* receiver,
                                                          Qt::UniqueConnection));
             } else {
                 connect(m_pControl.data(), SIGNAL(valueChanged(double, QObject*)),
-                        this, SLOT(slotValueChangedDirect(double, QObject*)),
+                        this, SLOT(slotValueChangedAuto(double, QObject*)),
                         static_cast<Qt::ConnectionType>(Qt::AutoConnection |
                                                         Qt::UniqueConnection));
             }

--- a/src/controlobjectslave.cpp
+++ b/src/controlobjectslave.cpp
@@ -36,18 +36,43 @@ ControlObjectSlave::~ControlObjectSlave() {
 }
 
 bool ControlObjectSlave::connectValueChanged(const QObject* receiver,
-        const char* method, Qt::ConnectionType type) {
+        const char* method, Qt::ConnectionType requestedConnectionType) {
+
+    // We connect to the
+    // ControlObjectPrivate only once and in a way that
+    // the requested ConnectionType is working as desired.
+    // We try to avoid direct connections if not requested
+    // since you cannot safely delete an object with a pending
+    // direct connection. This fixes bug Bug #1406124
+    // requested: Auto -> COP = Auto / SCO = Auto
+    // requested: Direct -> COP = Direct / SCO = Direct
+    // requested: Queued -> COP = Auto / SCO = Queued
+    // requested: BlockingQueued -> Assert(false)
+
+
     bool ret = false;
     if (m_pControl) {
+        // We must not block the signal source by a blocking connection
+        DEBUG_ASSERT(requestedConnectionType != Qt::BlockingQueuedConnection);
         ret = connect((QObject*)this, SIGNAL(valueChanged(double)),
-                      receiver, method, type);
+                      receiver, method, requestedConnectionType);
         if (ret) {
             // Connect to ControlObjectPrivate only if required. Do not allow
             // duplicate connections.
-            connect(m_pControl.data(), SIGNAL(valueChanged(double, QObject*)),
-                    this, SLOT(slotValueChanged(double, QObject*)),
-                    static_cast<Qt::ConnectionType>(Qt::DirectConnection |
-                                                    Qt::UniqueConnection));
+            if (requestedConnectionType == Qt::DirectConnection) {
+                // use only explicit direct connection if requested
+                // the caller must not delete this until the all signals are
+                // processed to avoid segfaults
+                connect(m_pControl.data(), SIGNAL(valueChanged(double, QObject*)),
+                         this, SLOT(slotValueChangedDirect(double, QObject*)),
+                         static_cast<Qt::ConnectionType>(Qt::DirectConnection |
+                                                         Qt::UniqueConnection));
+            } else {
+                connect(m_pControl.data(), SIGNAL(valueChanged(double, QObject*)),
+                        this, SLOT(slotValueChangedDirect(double, QObject*)),
+                        static_cast<Qt::ConnectionType>(Qt::AutoConnection |
+                                                        Qt::UniqueConnection));
+            }
         }
     }
     return ret;

--- a/src/controlobjectslave.h
+++ b/src/controlobjectslave.h
@@ -95,9 +95,16 @@ class ControlObjectSlave : public QObject {
     void valueChanged(double);
 
   protected slots:
-    // Receives the value from the master control and re-emits either
-    // valueChanged(double) or valueChangedByThis(double) based on pSetter.
-    inline void slotValueChanged(double v, QObject* pSetter) {
+    // Receives the value from the master control by a unique direct connection
+    void slotValueChangedDirect(double v, QObject* pSetter) {
+        if (pSetter != this) {
+            // This is base implementation of this function without scaling
+            emit(valueChanged(v));
+        }
+    }
+
+    // Receives the value from the master control by a unique auto connection
+    void slotValueChangedAuto(double v, QObject* pSetter) {
         if (pSetter != this) {
             // This is base implementation of this function without scaling
             emit(valueChanged(v));

--- a/src/controlobjectslave.h
+++ b/src/controlobjectslave.h
@@ -8,11 +8,13 @@
 #include "control/control.h"
 #include "configobject.h"
 
-// This class is the successor of ControlObjectThread. It should be used for new
-// code. It is better named and may save some CPU time because it is connected
-// only on demand. There are many ControlObjectThread instances where the changed
-// signal is not needed. This change will save the set() caller for doing
-// unnecessary checks for possible connections.
+// This class is the successor of ControlObjectThread. It should be used for
+// new code to avoid unnecessary locking during send if no slot is connected.
+// Do not (re-)connect slots during runtime, since this locks the mutex in
+// QMetaObject::activate().
+// Be sure that the ControlObjectSlave is created and deleted from the same
+// thread, otherwise a pending signal may lead to a segfault (Bug #1406124).
+// Parent it to the the creating object to achieve this.
 class ControlObjectSlave : public QObject {
     Q_OBJECT
   public:

--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -125,7 +125,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     masterMixComboBox->setCurrentIndex(m_pMasterEnabled->get() ? 1 : 0);
     connect(masterMixComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(masterMixChanged(int)));
-    m_pMasterEnabled->connectValueChanged(this, SLOT(masterEnabledChanged(double)));
+    m_pMasterEnabled->connectValueChanged(SLOT(masterEnabledChanged(double)));
 
     m_pMasterMonoMixdown = new ControlObjectSlave("[Master]", "mono_mixdown", this);
     masterOutputModeComboBox->addItem(tr("Stereo"));
@@ -133,7 +133,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     masterOutputModeComboBox->setCurrentIndex(m_pMasterMonoMixdown->get() ? 1 : 0);
     connect(masterOutputModeComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(masterOutputModeComboBoxChanged(int)));
-    m_pMasterMonoMixdown->connectValueChanged(this, SLOT(masterMonoMixdownChanged(double)));
+    m_pMasterMonoMixdown->connectValueChanged(SLOT(masterMonoMixdownChanged(double)));
 
     m_pMasterTalkoverMix = new ControlObjectSlave("[Master]", "talkover_mix", this);
     micMixComboBox->addItem(tr("Master output"));
@@ -141,7 +141,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     micMixComboBox->setCurrentIndex((int)m_pMasterTalkoverMix->get());
     connect(micMixComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(talkoverMixComboBoxChanged(int)));
-    m_pMasterTalkoverMix->connectValueChanged(this, SLOT(talkoverMixChanged(double)));
+    m_pMasterTalkoverMix->connectValueChanged(SLOT(talkoverMixChanged(double)));
 
 
     m_pKeylockEngine =

--- a/src/dlgprefvinyl.cpp
+++ b/src/dlgprefvinyl.cpp
@@ -345,9 +345,9 @@ void DlgPrefVinyl::VinylTypeSlotApply()
     switch (m_COSpeeds.length()) {
     case 4:
         if (ComboBoxVinylSpeed4->currentText() == MIXXX_VINYL_SPEED_33) {
-            m_COSpeeds[3]->slotSet(MIXXX_VINYL_SPEED_33_NUM);
+            m_COSpeeds[3]->set(MIXXX_VINYL_SPEED_33_NUM);
         } else if (ComboBoxVinylSpeed4->currentText() == MIXXX_VINYL_SPEED_45) {
-            m_COSpeeds[3]->slotSet(MIXXX_VINYL_SPEED_45_NUM);
+            m_COSpeeds[3]->set(MIXXX_VINYL_SPEED_45_NUM);
         }
         // fallthrough intended
     case 3:

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -32,15 +32,19 @@ BpmControl::BpmControl(QString group,
         m_tapFilter(this, filterLength, maxInterval),
         m_sGroup(group) {
     m_pPlayButton = new ControlObjectSlave(group, "play", this);
-    m_pPlayButton->connectValueChanged(SLOT(slotControlPlay(double)), Qt::DirectConnection);
+    m_pPlayButton->connectValueChanged(SLOT(slotControlPlay(double)),
+            Qt::DirectConnection);
     m_pReverseButton = new ControlObjectSlave(group, "reverse", this);
     m_pRateSlider = new ControlObjectSlave(group, "rate", this);
-    m_pRateSlider->connectValueChanged(SLOT(slotAdjustRateSlider()), Qt::DirectConnection);
+    m_pRateSlider->connectValueChanged(SLOT(slotAdjustRateSlider()),
+            Qt::DirectConnection);
     m_pQuantize = ControlObject::getControl(group, "quantize");
     m_pRateRange = new ControlObjectSlave(group, "rateRange", this);
-    m_pRateRange->connectValueChanged(SLOT(slotAdjustRateSlider()), Qt::DirectConnection);
+    m_pRateRange->connectValueChanged(SLOT(slotAdjustRateSlider()),
+            Qt::DirectConnection);
     m_pRateDir = new ControlObjectSlave(group, "rate_dir", this);
-    m_pRateDir->connectValueChanged(SLOT(slotAdjustRateSlider()), Qt::DirectConnection);
+    m_pRateDir->connectValueChanged(SLOT(slotAdjustRateSlider()),
+            Qt::DirectConnection);
 
     m_pPrevBeat.reset(new ControlObjectSlave(group, "beat_prev"));
     m_pNextBeat.reset(new ControlObjectSlave(group, "beat_next"));
@@ -125,14 +129,6 @@ BpmControl::BpmControl(QString group,
 }
 
 BpmControl::~BpmControl() {
-    delete m_pPlayButton;
-    delete m_pRateSlider;
-    delete m_pRateRange;
-    delete m_pRateDir;
-    delete m_pLoopEnabled;
-    delete m_pLoopStartPosition;
-    delete m_pLoopEndPosition;
-    delete m_pVCEnabled;
     delete m_pFileBpm;
     delete m_pLocalBpm;
     delete m_pEngineBpm;
@@ -144,7 +140,6 @@ BpmControl::~BpmControl() {
     delete m_pBeatsTranslateMatchAlignment;
     delete m_pTranslateBeatsEarlier;
     delete m_pTranslateBeatsLater;
-    delete m_pThisBeatDistance;
     delete m_pAdjustBeatsFaster;
     delete m_pAdjustBeatsSlower;
 }

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -281,8 +281,8 @@ EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
     m_pScale->clear();
     m_bScalerChanged = true;
 
-    m_pPassthroughEnabled.reset(new ControlObjectSlave(group, "passthrough", this));
-    m_pPassthroughEnabled->connectValueChanged(this, SLOT(slotPassthroughChanged(double)),
+    m_pPassthroughEnabled = new ControlObjectSlave(group, "passthrough", this);
+    m_pPassthroughEnabled->connectValueChanged(SLOT(slotPassthroughChanged(double)),
                                                Qt::DirectConnection);
 
     //m_iRampIter = 0;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -200,8 +200,7 @@ EngineBuffer::EngineBuffer(QString group, ConfigObject<ConfigValue>* _config,
     m_pSampleRate = new ControlObjectSlave("[Master]", "samplerate", this);
 
     m_pKeylockEngine = new ControlObjectSlave("[Master]", "keylock_engine", this);
-    m_pKeylockEngine->connectValueChanged(this,
-                                          SLOT(slotKeylockEngineChanged(double)),
+    m_pKeylockEngine->connectValueChanged(SLOT(slotKeylockEngineChanged(double)),
                                           Qt::DirectConnection);
 
     m_pTrackSamples = new ControlObject(ConfigKey(m_group, "track_samples"));

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -336,7 +336,7 @@ class EngineBuffer : public EngineObject {
     ControlObjectSlave* m_pSampleRate;
     ControlObjectSlave* m_pKeylockEngine;
     ControlPushButton* m_pKeylock;
-    QScopedPointer<ControlObjectSlave> m_pPassthroughEnabled;
+    ControlObjectSlave* m_pPassthroughEnabled;
 
     ControlPushButton* m_pEject;
 

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -336,6 +336,10 @@ class EngineBuffer : public EngineObject {
     ControlObjectSlave* m_pSampleRate;
     ControlObjectSlave* m_pKeylockEngine;
     ControlPushButton* m_pKeylock;
+
+    // This ControlObjectSlaves is created as parent to this and deleted by
+    // the Qt object tree. This helps that they are deleted by the creating
+    // thread, which is required to avoid segfaults.
     ControlObjectSlave* m_pPassthroughEnabled;
 
     ControlPushButton* m_pEject;

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -170,7 +170,7 @@ void EngineRecord::process(const CSAMPLE* pBuffer, const int iBufferSize) {
         if (openFile()) {
             Event::start("EngineRecord recording");
             qDebug("Setting record flag to: ON");
-            m_pRecReady->slotSet(RECORD_ON);
+            m_pRecReady->set(RECORD_ON);
             emit(isRecording(true));  // will notify the RecordingManager
 
             // Since we just started recording, timeout and clear the metadata.

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -31,8 +31,8 @@ SyncControl::SyncControl(const QString& group, ConfigObject<ConfigValue>* pConfi
           m_prevLocalBpm(0.0) {
     // Play button.  We only listen to this to disable master if the deck is
     // stopped.
-    m_pPlayButton.reset(new ControlObjectSlave(group, "play", this));
-    m_pPlayButton->connectValueChanged(this, SLOT(slotControlPlay(double)),
+    m_pPlayButton = new ControlObjectSlave(group, "play", this);
+    m_pPlayButton->connectValueChanged(SLOT(slotControlPlay(double)),
                                        Qt::DirectConnection);
 
     m_pSyncMode.reset(new ControlPushButton(ConfigKey(group, "sync_mode")));
@@ -56,13 +56,13 @@ SyncControl::SyncControl(const QString& group, ConfigObject<ConfigValue>* pConfi
     m_pSyncBeatDistance.reset(
             new ControlObject(ConfigKey(group, "beat_distance")));
 
-    m_pPassthroughEnabled.reset(new ControlObjectSlave(group, "passthrough", this));
-    m_pPassthroughEnabled->connectValueChanged(this, SLOT(slotPassthroughChanged(double)),
-                                               Qt::DirectConnection);
+    m_pPassthroughEnabled = new ControlObjectSlave(group, "passthrough", this);
+    m_pPassthroughEnabled->connectValueChanged(
+            SLOT(slotPassthroughChanged(double)), Qt::DirectConnection);
 
-    m_pEjectButton.reset(new ControlObjectSlave(group, "eject", this));
-    m_pEjectButton->connectValueChanged(this, SLOT(slotEjectPushed(double)),
-                                        Qt::DirectConnection);
+    m_pEjectButton = new ControlObjectSlave(group, "eject", this);
+    m_pEjectButton->connectValueChanged(
+            SLOT(slotEjectPushed(double)), Qt::DirectConnection);
 
     // BPMControl and RateControl will be initialized later.
 }
@@ -78,37 +78,37 @@ void SyncControl::setEngineControls(RateControl* pRateControl,
     // We set this to change the effective BPM in BpmControl. We do not listen
     // to changes from this control because changes in rate, rate_dir, rateRange
     // and file_bpm result in changes to this control.
-    m_pBpm.reset(new ControlObjectSlave(getGroup(), "bpm", this));
+    m_pBpm = new ControlObjectSlave(getGroup(), "bpm", this);
 
-    m_pLocalBpm.reset(new ControlObjectSlave(getGroup(), "local_bpm", this));
+    m_pLocalBpm = new ControlObjectSlave(getGroup(), "local_bpm", this);
 
-    m_pFileBpm.reset(new ControlObjectSlave(getGroup(), "file_bpm", this));
-    m_pFileBpm->connectValueChanged(this, SLOT(slotFileBpmChanged()),
+    m_pFileBpm = new ControlObjectSlave(getGroup(), "file_bpm", this);
+    m_pFileBpm->connectValueChanged(SLOT(slotFileBpmChanged()),
                                     Qt::DirectConnection);
 
-    m_pRateSlider.reset(new ControlObjectSlave(getGroup(), "rate", this));
-    m_pRateSlider->connectValueChanged(this, SLOT(slotRateChanged()),
+    m_pRateSlider = new ControlObjectSlave(getGroup(), "rate", this);
+    m_pRateSlider->connectValueChanged(SLOT(slotRateChanged()),
                                        Qt::DirectConnection);
 
-    m_pRateDirection.reset(new ControlObjectSlave(getGroup(), "rate_dir", this));
-    m_pRateDirection->connectValueChanged(this, SLOT(slotRateChanged()),
+    m_pRateDirection = new ControlObjectSlave(getGroup(), "rate_dir", this);
+    m_pRateDirection->connectValueChanged(SLOT(slotRateChanged()),
                                           Qt::DirectConnection);
 
-    m_pRateRange.reset(new ControlObjectSlave(getGroup(), "rateRange", this));
-    m_pRateRange->connectValueChanged(this, SLOT(slotRateChanged()),
+    m_pRateRange = new ControlObjectSlave(getGroup(), "rateRange", this);
+    m_pRateRange->connectValueChanged(SLOT(slotRateChanged()),
                                       Qt::DirectConnection);
 
-    m_pSyncPhaseButton.reset(new ControlObjectSlave(getGroup(), "beatsync_phase", this));
+    m_pSyncPhaseButton = new ControlObjectSlave(getGroup(), "beatsync_phase", this);
 
 #ifdef __VINYLCONTROL__
-    m_pVCEnabled.reset(new ControlObjectSlave(
-        getGroup(), "vinylcontrol_enabled", this));
+    m_pVCEnabled = new ControlObjectSlave(
+            getGroup(), "vinylcontrol_enabled", this);
 
     // Throw a hissy fit if somebody moved us such that the vinylcontrol_enabled
     // control doesn't exist yet. This will blow up immediately, won't go unnoticed.
     DEBUG_ASSERT(m_pVCEnabled->valid());
 
-    m_pVCEnabled->connectValueChanged(this, SLOT(slotVinylControlChanged(double)),
+    m_pVCEnabled->connectValueChanged(SLOT(slotVinylControlChanged(double)),
                                       Qt::DirectConnection);
 #endif
 }

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -122,17 +122,17 @@ class SyncControl : public EngineControl, public Syncable {
     QScopedPointer<ControlPushButton> m_pSyncEnabled;
     QScopedPointer<ControlObject> m_pSyncBeatDistance;
 
-    QScopedPointer<ControlObjectSlave> m_pPlayButton;
-    QScopedPointer<ControlObjectSlave> m_pBpm;
-    QScopedPointer<ControlObjectSlave> m_pLocalBpm;
-    QScopedPointer<ControlObjectSlave> m_pFileBpm;
-    QScopedPointer<ControlObjectSlave> m_pRateSlider;
-    QScopedPointer<ControlObjectSlave> m_pRateDirection;
-    QScopedPointer<ControlObjectSlave> m_pRateRange;
-    QScopedPointer<ControlObjectSlave> m_pVCEnabled;
-    QScopedPointer<ControlObjectSlave> m_pPassthroughEnabled;
-    QScopedPointer<ControlObjectSlave> m_pEjectButton;
-    QScopedPointer<ControlObjectSlave> m_pSyncPhaseButton;
+    ControlObjectSlave* m_pPlayButton;
+    ControlObjectSlave* m_pBpm;
+    ControlObjectSlave* m_pLocalBpm;
+    ControlObjectSlave* m_pFileBpm;
+    ControlObjectSlave* m_pRateSlider;
+    ControlObjectSlave* m_pRateDirection;
+    ControlObjectSlave* m_pRateRange;
+    ControlObjectSlave* m_pVCEnabled;
+    ControlObjectSlave* m_pPassthroughEnabled;
+    ControlObjectSlave* m_pEjectButton;
+    ControlObjectSlave* m_pSyncPhaseButton;
 };
 
 

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -122,6 +122,9 @@ class SyncControl : public EngineControl, public Syncable {
     QScopedPointer<ControlPushButton> m_pSyncEnabled;
     QScopedPointer<ControlObject> m_pSyncBeatDistance;
 
+    // These ControlObjectSlaves are created as parent to this and deleted by
+    // the Qt object tree. This helps that they are deleted by the creating
+    // thread, which is required to avoid segfaults.
     ControlObjectSlave* m_pPlayButton;
     ControlObjectSlave* m_pBpm;
     ControlObjectSlave* m_pLocalBpm;

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -960,8 +960,7 @@ void MixxxMainWindow::linkSkinWidget(ControlObjectSlave** pCOS,
                                      ConfigKey key, const char* slot) {
     if (!*pCOS) {
         *pCOS = new ControlObjectSlave(key, this);
-        (*pCOS)->connectValueChanged(
-            this, slot, Qt::DirectConnection);
+        (*pCOS)->connectValueChanged(slot);
     }
 }
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1599,8 +1599,8 @@ void MixxxMainWindow::initActions()
         if (i > 0) {
             group = QString("[Microphone%1]").arg(i + 1);
         }
-        ControlObjectSlave* talkover_button(new ControlObjectSlave(
-                group, "talkover", this));
+        ControlObjectSlave* talkover_button = new ControlObjectSlave(
+                group, "talkover");
         m_TalkoverMapper->setMapping(talkover_button, i);
         talkover_button->connectValueChanged(m_TalkoverMapper, SLOT(map()));
         m_micTalkoverControls.push_back(talkover_button);

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1871,12 +1871,8 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
             QString property = m_pContext->selectString(con, "BindProperty");
             //qDebug() << "Making property connection for" << property;
 
-            ControlObjectSlave* pControlWidget =
-                    new ControlObjectSlave(control->getKey(),
-                                           pWidget->toQWidget());
-
             ControlWidgetPropertyConnection* pConnection =
-                    new ControlWidgetPropertyConnection(pWidget, pControlWidget,
+                    new ControlWidgetPropertyConnection(pWidget, control->getKey(),
                                                         pTransformer, property);
             pWidget->addPropertyConnection(pConnection);
 
@@ -1943,12 +1939,8 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
                 emitOption |= ControlParameterWidgetConnection::EMIT_DEFAULT;
             }
 
-            // Connect control proxy to widget. Parented to pWidget so it is not
-            // leaked.
-            ControlObjectSlave* pControlWidget = new ControlObjectSlave(
-                    control->getKey(), pWidget->toQWidget());
             ControlParameterWidgetConnection* pConnection = new ControlParameterWidgetConnection(
-                    pWidget, pControlWidget, pTransformer,
+                    pWidget, control->getKey(), pTransformer,
                     static_cast<ControlParameterWidgetConnection::DirectionOption>(directionOption),
                     static_cast<ControlParameterWidgetConnection::EmitOption>(emitOption));
 
@@ -1976,6 +1968,8 @@ void LegacySkinParser::setupConnections(QDomNode node, WBaseWidget* pWidget) {
                 pWidget->addRightConnection(pConnection);
                 break;
             default:
+                // can't happen. Nothing else is returned by parseButtonState();
+                DEBUG_ASSERT(false);
                 break;
             }
 

--- a/src/test/wpushbutton_test.cpp
+++ b/src/test/wpushbutton_test.cpp
@@ -38,7 +38,7 @@ TEST_F(WPushButtonTest, QuickPressNoLatchTest) {
     m_pButton->addLeftConnection(
         new ControlParameterWidgetConnection(
             m_pButton.data(),
-            new ControlObjectSlave(pPushControl->getKey()), NULL,
+            pPushControl->getKey(), NULL,
             ControlParameterWidgetConnection::DIR_FROM_AND_TO_WIDGET,
             ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE));
 
@@ -63,7 +63,7 @@ TEST_F(WPushButtonTest, LongPressLatchTest) {
     m_pButton->addLeftConnection(
         new ControlParameterWidgetConnection(
             m_pButton.data(),
-            new ControlObjectSlave(pPushControl->getKey()), NULL,
+            pPushControl->getKey(), NULL,
             ControlParameterWidgetConnection::DIR_FROM_AND_TO_WIDGET,
             ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE));
 

--- a/src/visualplayposition.cpp
+++ b/src/visualplayposition.cpp
@@ -15,15 +15,15 @@ VisualPlayPosition::VisualPlayPosition(const QString& key)
         : m_valid(false),
           m_key(key),
           m_invalidTimeInfoWarned(false) {
-    m_audioBufferSize = new ControlObjectSlave("[Master]", "audio_buffer_size");
+    m_audioBufferSize = new ControlObjectSlave(
+            "[Master]", "audio_buffer_size", this);
     m_audioBufferSize->connectValueChanged(
-            this, SLOT(slotAudioBufferSizeChanged(double)));
+            SLOT(slotAudioBufferSizeChanged(double)));
     m_dAudioBufferSize = m_audioBufferSize->get();
 }
 
 VisualPlayPosition::~VisualPlayPosition() {
     m_listVisualPlayPosition.remove(m_key);
-    delete m_audioBufferSize;
 }
 
 void VisualPlayPosition::set(double playPos, double rate,

--- a/src/waveform/renderers/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/waveformrendererendoftrack.cpp
@@ -6,7 +6,7 @@
 #include "waveformwidgetrenderer.h"
 
 #include "controlobject.h"
-#include "controlobjectthread.h"
+#include "controlobjectslave.h"
 
 #include "widget/wskincolor.h"
 #include "widget/wwidget.h"
@@ -36,16 +36,16 @@ WaveformRendererEndOfTrack::~WaveformRendererEndOfTrack() {
 bool WaveformRendererEndOfTrack::init() {
     m_timer.restart();
 
-    m_pEndOfTrackControl = new ControlObjectThread(
+    m_pEndOfTrackControl = new ControlObjectSlave(
             m_waveformRenderer->getGroup(), "end_of_track");
     m_pEndOfTrackControl->slotSet(0.);
     m_endOfTrackEnabled = false;
 
-    m_pTrackSampleRate = new ControlObjectThread(
+    m_pTrackSampleRate = new ControlObjectSlave(
             m_waveformRenderer->getGroup(), "track_samplerate");
-    m_pPlayControl = new ControlObjectThread(
+    m_pPlayControl = new ControlObjectSlave(
             m_waveformRenderer->getGroup(), "play");
-    m_pLoopControl = new ControlObjectThread(
+    m_pLoopControl = new ControlObjectSlave(
             m_waveformRenderer->getGroup(), "loop_enabled");
     return true;
 }
@@ -99,7 +99,7 @@ void WaveformRendererEndOfTrack::draw(QPainter* painter,
             || trackLength <= m_remainingTimeTriggerSeconds //track too short
             ) {
         if (m_endOfTrackEnabled) {
-            m_pEndOfTrackControl->slotSet(0.0);
+            m_pEndOfTrackControl->set(0.0);
             m_endOfTrackEnabled = false;
         }
         return;
@@ -111,7 +111,7 @@ void WaveformRendererEndOfTrack::draw(QPainter* painter,
 
     if (remainingTime > m_remainingTimeTriggerSeconds) {
         if (m_endOfTrackEnabled) {
-            m_pEndOfTrackControl->slotSet(0.);
+            m_pEndOfTrackControl->set(0.);
             m_endOfTrackEnabled = false;
         }
         return;

--- a/src/waveform/renderers/waveformrendererendoftrack.h
+++ b/src/waveform/renderers/waveformrendererendoftrack.h
@@ -11,7 +11,7 @@
 #include "waveform/waveformwidgetfactory.h"
 
 class ControlObject;
-class ControlObjectThread;
+class ControlObjectSlave;
 
 class WaveformRendererEndOfTrack : public WaveformRendererAbstract {
   public:
@@ -26,11 +26,11 @@ class WaveformRendererEndOfTrack : public WaveformRendererAbstract {
     virtual void draw(QPainter* painter, QPaintEvent* event);
 
   private:
-    ControlObjectThread*  m_pEndOfTrackControl;
+    ControlObjectSlave* m_pEndOfTrackControl;
     bool m_endOfTrackEnabled;
-    ControlObjectThread* m_pTrackSampleRate;
-    ControlObjectThread* m_pPlayControl;
-    ControlObjectThread* m_pLoopControl;
+    ControlObjectSlave* m_pTrackSampleRate;
+    ControlObjectSlave* m_pPlayControl;
+    ControlObjectSlave* m_pLoopControl;
 
     QColor m_color;
     QTime m_timer;

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -4,7 +4,7 @@
 #include "waveform/waveform.h"
 #include "widget/wwidget.h"
 #include "controlobject.h"
-#include "controlobjectthread.h"
+#include "controlobjectslave.h"
 #include "visualplayposition.h"
 #include "util/math.h"
 #include "util/performancetimer.h"
@@ -77,15 +77,15 @@ bool WaveformWidgetRenderer::init() {
     //qDebug() << "WaveformWidgetRenderer::init";
     m_visualPlayPosition = VisualPlayPosition::getVisualPlayPosition(m_group);
 
-    m_pRateControlObject = new ControlObjectThread(
+    m_pRateControlObject = new ControlObjectSlave(
             m_group, "rate");
-    m_pRateRangeControlObject = new ControlObjectThread(
+    m_pRateRangeControlObject = new ControlObjectSlave(
             m_group, "rateRange");
-    m_pRateDirControlObject = new ControlObjectThread(
+    m_pRateDirControlObject = new ControlObjectSlave(
             m_group, "rate_dir");
-    m_pGainControlObject = new ControlObjectThread(
+    m_pGainControlObject = new ControlObjectSlave(
             m_group, "total_gain");
-    m_pTrackSamplesControlObject = new ControlObjectThread(
+    m_pTrackSamplesControlObject = new ControlObjectSlave(
             m_group, "track_samples");
 
     for (int i = 0; i < m_rendererStack.size(); ++i) {

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -14,7 +14,7 @@
 //#define WAVEFORMWIDGETRENDERER_DEBUG
 
 class TrackInfoObject;
-class ControlObjectThread;
+class ControlObjectSlave;
 class VisualPlayPosition;
 class VSyncThread;
 
@@ -105,15 +105,15 @@ class WaveformWidgetRenderer {
     QSharedPointer<VisualPlayPosition> m_visualPlayPosition;
     double m_playPos;
     int m_playPosVSample;
-    ControlObjectThread* m_pRateControlObject;
+    ControlObjectSlave* m_pRateControlObject;
     double m_rate;
-    ControlObjectThread* m_pRateRangeControlObject;
+    ControlObjectSlave* m_pRateRangeControlObject;
     double m_rateRange;
-    ControlObjectThread* m_pRateDirControlObject;
+    ControlObjectSlave* m_pRateDirControlObject;
     double m_rateDir;
-    ControlObjectThread* m_pGainControlObject;
+    ControlObjectSlave* m_pGainControlObject;
     double m_gain;
-    ControlObjectThread* m_pTrackSamplesControlObject;
+    ControlObjectSlave* m_pTrackSamplesControlObject;
     int m_trackSamples;
 
 #ifdef WAVEFORMWIDGETRENDERER_DEBUG

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -7,18 +7,12 @@
 #include "util/assert.h"
 
 ControlWidgetConnection::ControlWidgetConnection(WBaseWidget* pBaseWidget,
-                                                 ControlObjectSlave* pControl,
+                                                 const ConfigKey& key,
                                                  ValueTransformer* pTransformer)
         : m_pWidget(pBaseWidget),
-          m_pControl(pControl),
           m_pValueTransformer(pTransformer) {
-    // If m_pControl is NULL then the creator of ControlWidgetConnection has
-    // screwed up badly. Assert in development mode. In release mode the
-    // connection will be defunct.
-    DEBUG_ASSERT_AND_HANDLE(!m_pControl.isNull()) {
-        m_pControl.reset(new ControlObjectSlave());
-    }
-    m_pControl->connectValueChanged(this, SLOT(slotControlValueChanged(double)));
+    m_pControl = new ControlObjectSlave(key, this);
+    m_pControl->connectValueChanged(SLOT(slotControlValueChanged(double)));
 }
 
 ControlWidgetConnection::~ControlWidgetConnection() {
@@ -48,11 +42,11 @@ double ControlWidgetConnection::getControlParameterForValue(double value) const 
 }
 
 ControlParameterWidgetConnection::ControlParameterWidgetConnection(WBaseWidget* pBaseWidget,
-                                                                   ControlObjectSlave* pControl,
+                                                                   const ConfigKey& key,
                                                                    ValueTransformer* pTransformer,
                                                                    DirectionOption directionOption,
                                                                    EmitOption emitOption)
-        : ControlWidgetConnection(pBaseWidget, pControl, pTransformer),
+        : ControlWidgetConnection(pBaseWidget, key, pTransformer),
           m_directionOption(directionOption),
           m_emitOption(emitOption) {
 }
@@ -105,10 +99,10 @@ void ControlParameterWidgetConnection::setControlParameterUp(double v) {
 }
 
 ControlWidgetPropertyConnection::ControlWidgetPropertyConnection(WBaseWidget* pBaseWidget,
-                                                                 ControlObjectSlave* pControl,
+                                                                 const ConfigKey& key,
                                                                  ValueTransformer* pTransformer,
                                                                  const QString& propertyName)
-        : ControlWidgetConnection(pBaseWidget, pControl, pTransformer),
+        : ControlWidgetConnection(pBaseWidget, key, pTransformer),
           m_propertyName(propertyName.toAscii()) {
     slotControlValueChanged(m_pControl->get());
 }

--- a/src/widget/controlwidgetconnection.h
+++ b/src/widget/controlwidgetconnection.h
@@ -36,6 +36,10 @@ class ControlWidgetConnection : public QObject {
     void setControlParameter(double v);
 
     WBaseWidget* m_pWidget;
+
+    // This ControlObjectSlaves is created as parent to this and deleted by
+    // the Qt object tree. This helps that they are deleted by the creating
+    // thread, which is required to avoid segfaults.
     ControlObjectSlave* m_pControl;
 
   private:

--- a/src/widget/controlwidgetconnection.h
+++ b/src/widget/controlwidgetconnection.h
@@ -16,7 +16,7 @@ class ControlWidgetConnection : public QObject {
   public:
     // Takes ownership of pControl and pTransformer.
     ControlWidgetConnection(WBaseWidget* pBaseWidget,
-                            ControlObjectSlave* pControl,
+                            const ConfigKey& key,
                             ValueTransformer* pTransformer);
     virtual ~ControlWidgetConnection();
 
@@ -36,7 +36,7 @@ class ControlWidgetConnection : public QObject {
     void setControlParameter(double v);
 
     WBaseWidget* m_pWidget;
-    QScopedPointer<ControlObjectSlave> m_pControl;
+    ControlObjectSlave* m_pControl;
 
   private:
     QScopedPointer<ValueTransformer> m_pValueTransformer;
@@ -92,7 +92,7 @@ class ControlParameterWidgetConnection : public ControlWidgetConnection {
     }
 
     ControlParameterWidgetConnection(WBaseWidget* pBaseWidget,
-                                     ControlObjectSlave* pControl,
+                                     const ConfigKey& key,
                                      ValueTransformer* pTransformer,
                                      DirectionOption directionOption,
                                      EmitOption emitOption);
@@ -125,7 +125,7 @@ class ControlWidgetPropertyConnection : public ControlWidgetConnection {
     Q_OBJECT
   public:
     ControlWidgetPropertyConnection(WBaseWidget* pBaseWidget,
-                                    ControlObjectSlave* pControl,
+                                    const ConfigKey& key,
                                     ValueTransformer* pTransformer,
                                     const QString& property);
     virtual ~ControlWidgetPropertyConnection();

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -4,7 +4,7 @@
 
 #include "widget/wnumberpos.h"
 #include "controlobject.h"
-#include "controlobjectthread.h"
+#include "controlobjectslave.h"
 #include "util/math.h"
 #include "util/time.h"
 
@@ -14,10 +14,10 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
           m_dTrackSamples(0.0),
           m_dTrackSampleRate(0.0),
           m_bRemain(false) {
-    m_pShowTrackTimeRemaining = new ControlObjectThread(
-            "[Controls]", "ShowDurationRemaining");
+    m_pShowTrackTimeRemaining = new ControlObjectSlave(
+            "[Controls]", "ShowDurationRemaining", this);
     m_pShowTrackTimeRemaining->connectValueChanged(
-            this, SLOT(slotSetRemain(double)));
+            SLOT(slotSetRemain(double)));
     slotSetRemain(m_pShowTrackTimeRemaining->get());
 
     // We use the engine's playposition value directly because the parameter
@@ -25,22 +25,21 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
     // because the range of playposition was -0.14 to 1.14 in 1.11.x. As a
     // result, the <Connection> parameter is no longer necessary in skin
     // definitions, but leaving it in is harmless.
-    m_pVisualPlaypos = new ControlObjectThread(group, "playposition");
-    m_pVisualPlaypos->connectValueChanged(this, SLOT(slotSetValue(double)));
+    m_pVisualPlaypos = new ControlObjectSlave(group, "playposition", this);
+    m_pVisualPlaypos->connectValueChanged(SLOT(slotSetValue(double)));
 
-    m_pTrackSamples = new ControlObjectThread(
-            group, "track_samples");
-    m_pTrackSamples->connectValueChanged(
-            this, SLOT(slotSetTrackSamples(double)));
+    m_pTrackSamples = new ControlObjectSlave(
+            group, "track_samples", this);
+    m_pTrackSamples->connectValueChanged(SLOT(slotSetTrackSamples(double)));
 
     // Tell the CO to re-emit its value since we could be created after it was
     // set to a valid value.
     m_pTrackSamples->emitValueChanged();
 
-    m_pTrackSampleRate = new ControlObjectThread(
-            group, "track_samplerate");
+    m_pTrackSampleRate = new ControlObjectSlave(
+            group, "track_samplerate", this);
     m_pTrackSampleRate->connectValueChanged(
-            this, SLOT(slotSetTrackSampleRate(double)));
+            SLOT(slotSetTrackSampleRate(double)));
 
     // Tell the CO to re-emit its value since we could be created after it was
     // set to a valid value.
@@ -50,10 +49,6 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
 }
 
 WNumberPos::~WNumberPos() {
-    delete m_pTrackSampleRate;
-    delete m_pTrackSamples;
-    delete m_pVisualPlaypos;
-    delete m_pShowTrackTimeRemaining;
 }
 
 void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {
@@ -61,7 +56,7 @@ void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {
 
     if (leftClick) {
         setRemain(!m_bRemain);
-        m_pShowTrackTimeRemaining->slotSet(m_bRemain ? 1.0 : 0.0);
+        m_pShowTrackTimeRemaining->set(m_bRemain ? 1.0 : 0.0);
     }
 }
 

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -7,7 +7,7 @@
 
 #include "wnumber.h"
 
-class ControlObjectThread;
+class ControlObjectSlave;
 
 class WNumberPos : public WNumber {
     Q_OBJECT
@@ -35,11 +35,11 @@ class WNumberPos : public WNumber {
     double m_dTrackSampleRate;
     // True if remaining content is being shown
     bool m_bRemain;
-    ControlObjectThread* m_pShowTrackTimeRemaining;
+    ControlObjectSlave* m_pShowTrackTimeRemaining;
     // Pointer to control object for position, rate, and track info
-    ControlObjectThread* m_pVisualPlaypos;
-    ControlObjectThread* m_pTrackSamples;
-    ControlObjectThread* m_pTrackSampleRate;
+    ControlObjectSlave* m_pVisualPlaypos;
+    ControlObjectSlave* m_pTrackSamples;
+    ControlObjectSlave* m_pTrackSampleRate;
 };
 
 #endif

--- a/src/widget/wnumberrate.cpp
+++ b/src/widget/wnumberrate.cpp
@@ -13,28 +13,22 @@
 #include "widget/wnumberrate.h"
 
 #include "controlobject.h"
-#include "controlobjectthread.h"
+#include "controlobjectslave.h"
 #include "util/math.h"
 
 WNumberRate::WNumberRate(const char * group, QWidget * parent)
         : WNumber(parent) {
-    m_pRateRangeControl = new ControlObjectThread(group, "rateRange");
-    connect(m_pRateRangeControl, SIGNAL(valueChanged(double)),
-            this, SLOT(setValue(double)));
-    m_pRateDirControl = new ControlObjectThread(group, "rate_dir");
-    connect(m_pRateDirControl, SIGNAL(valueChanged(double)),
-            this, SLOT(setValue(double)));
-    m_pRateControl = new ControlObjectThread(group, "rate");
-    connect(m_pRateControl, SIGNAL(valueChanged(double)),
-            this, SLOT(setValue(double)));
+    m_pRateRangeControl = new ControlObjectSlave(group, "rateRange", this);
+    m_pRateRangeControl->connectValueChanged(SLOT(setValue(double)));
+    m_pRateDirControl = new ControlObjectSlave(group, "rate_dir", this);
+    m_pRateDirControl->connectValueChanged(SLOT(setValue(double)));
+    m_pRateControl = new ControlObjectSlave(group, "rate", this);
+    m_pRateControl->connectValueChanged(SLOT(setValue(double)));
     // Initialize the widget.
     setValue(0);
 }
 
 WNumberRate::~WNumberRate() {
-    delete m_pRateControl;
-    delete m_pRateDirControl;
-    delete m_pRateRangeControl;
 }
 
 void WNumberRate::setValue(double) {

--- a/src/widget/wnumberrate.h
+++ b/src/widget/wnumberrate.h
@@ -14,7 +14,7 @@
 
 #include "widget/wnumber.h"
 
-class ControlObjectThread;
+class ControlObjectSlave;
 
 class WNumberRate : public WNumber {
     Q_OBJECT
@@ -27,9 +27,9 @@ class WNumberRate : public WNumber {
 
   private:
     // Pointer to control objects for rate.
-    ControlObjectThread* m_pRateControl;
-    ControlObjectThread* m_pRateRangeControl;
-    ControlObjectThread* m_pRateDirControl;
+    ControlObjectSlave* m_pRateControl;
+    ControlObjectSlave* m_pRateRangeControl;
+    ControlObjectSlave* m_pRateDirControl;
 };
 
 #endif

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -50,19 +50,17 @@ WOverview::WOverview(const char *pGroup, ConfigObject<ConfigValue>* pConfig, QWi
         m_dAnalyserProgress(-1.0),
         m_bAnalyserFinalizing(false),
         m_trackLoaded(false) {
-    m_endOfTrackControl = new ControlObjectThread(
-            m_group, "end_of_track");
-    connect(m_endOfTrackControl, SIGNAL(valueChanged(double)),
-             this, SLOT(onEndOfTrackChange(double)));
-    m_trackSamplesControl = new ControlObjectThread(m_group, "track_samples");
-    m_playControl = new ControlObjectThread(m_group, "play");
+    m_endOfTrackControl = new ControlObjectSlave(
+            m_group, "end_of_track", this);
+    m_endOfTrackControl->connectValueChanged(
+             SLOT(onEndOfTrackChange(double)));
+    m_trackSamplesControl =
+            new ControlObjectSlave(m_group, "track_samples", this);
+    m_playControl = new ControlObjectSlave(m_group, "play", this);
     setAcceptDrops(true);
 }
 
 WOverview::~WOverview() {
-    delete m_endOfTrackControl;
-    delete m_trackSamplesControl;
-    delete m_playControl;
     if (m_pWaveformSourceImage) {
         delete m_pWaveformSourceImage;
     }

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -95,10 +95,10 @@ class WOverview : public WWidget {
 
     const QString m_group;
     ConfigObject<ConfigValue>* m_pConfig;
-    ControlObjectThread* m_endOfTrackControl;
+    ControlObjectSlave* m_endOfTrackControl;
     double m_endOfTrack;
-    ControlObjectThread* m_trackSamplesControl;
-    ControlObjectThread* m_playControl;
+    ControlObjectSlave* m_trackSamplesControl;
+    ControlObjectSlave* m_playControl;
 
     // Current active track
     TrackPointer m_pCurrentTrack;

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -5,7 +5,7 @@
 #include <QStylePainter>
 
 #include "controlobject.h"
-#include "controlobjectthread.h"
+#include "controlobjectslave.h"
 #include "library/coverartcache.h"
 #include "sharedglcontext.h"
 #include "util/dnd.h"
@@ -87,18 +87,6 @@ WSpinny::~WSpinny() {
     WImageStore::deleteImage(m_pMaskImage);
     WImageStore::deleteImage(m_pFgImage);
     WImageStore::deleteImage(m_pGhostImage);
-    delete m_pPlay;
-    delete m_pPlayPos;
-    delete m_pTrackSamples;
-    delete m_pTrackSampleRate;
-    delete m_pScratchToggle;
-    delete m_pScratchPos;
-    delete m_pSlipEnabled;
-#ifdef __VINYLCONTROL__
-    delete m_pVinylControlSpeedType;
-    delete m_pVinylControlEnabled;
-    delete m_pSignalEnabled;
-#endif
 }
 
 void WSpinny::onVinylSignalQualityUpdate(const VinylSignalQualityReport& report) {
@@ -175,50 +163,46 @@ void WSpinny::setup(QDomNode node, const SkinContext& context) {
     m_qImage.fill(qRgba(0,0,0,0));
 #endif
 
-    m_pPlay = new ControlObjectThread(
-            m_group, "play");
-    m_pPlayPos = new ControlObjectThread(
-            m_group, "playposition");
+    m_pPlay = new ControlObjectSlave(
+            m_group, "play", this);
+    m_pPlayPos = new ControlObjectSlave(
+            m_group, "playposition", this);
     m_pVisualPlayPos = VisualPlayPosition::getVisualPlayPosition(m_group);
-    m_pTrackSamples = new ControlObjectThread(
-            m_group, "track_samples");
-    m_pTrackSampleRate = new ControlObjectThread(
-            m_group, "track_samplerate");
+    m_pTrackSamples = new ControlObjectSlave(
+            m_group, "track_samples", this);
+    m_pTrackSampleRate = new ControlObjectSlave(
+            m_group, "track_samplerate", this);
 
-    m_pScratchToggle = new ControlObjectThread(
-            m_group, "scratch_position_enable");
-    m_pScratchPos = new ControlObjectThread(
-            m_group, "scratch_position");
+    m_pScratchToggle = new ControlObjectSlave(
+            m_group, "scratch_position_enable", this);
+    m_pScratchPos = new ControlObjectSlave(
+            m_group, "scratch_position", this);
 
-    m_pSlipEnabled = new ControlObjectThread(
-            m_group, "slip_enabled");
-    connect(m_pSlipEnabled, SIGNAL(valueChanged(double)),
-            this, SLOT(updateSlipEnabled(double)));
+    m_pSlipEnabled = new ControlObjectSlave(
+            m_group, "slip_enabled", this);
+    m_pSlipEnabled->connectValueChanged(
+            SLOT(updateSlipEnabled(double)));
 
 #ifdef __VINYLCONTROL__
-    m_pVinylControlSpeedType = new ControlObjectThread(
-            m_group, "vinylcontrol_speed_type");
-    if (m_pVinylControlSpeedType)
-    {
-        //Initialize the rotational speed.
-        this->updateVinylControlSpeed(m_pVinylControlSpeedType->get());
-    }
+    m_pVinylControlSpeedType = new ControlObjectSlave(
+            m_group, "vinylcontrol_speed_type", this);
+    // Initialize the rotational speed.
+    updateVinylControlSpeed(m_pVinylControlSpeedType->get());
 
-    m_pVinylControlEnabled = new ControlObjectThread(
-            m_group, "vinylcontrol_enabled");
-    connect(m_pVinylControlEnabled, SIGNAL(valueChanged(double)),
-            this, SLOT(updateVinylControlEnabled(double)));
+    m_pVinylControlEnabled = new ControlObjectSlave(
+            m_group, "vinylcontrol_enabled", this);
+    m_pVinylControlEnabled->connectValueChanged(
+            SLOT(updateVinylControlEnabled(double)));
 
-    m_pSignalEnabled = new ControlObjectThread(
-            m_group, "vinylcontrol_signal_enabled");
-    connect(m_pSignalEnabled, SIGNAL(valueChanged(double)),
-            this, SLOT(updateVinylControlSignalEnabled(double)));
+    m_pSignalEnabled = new ControlObjectSlave(
+            m_group, "vinylcontrol_signal_enabled", this);
+    m_pSignalEnabled->connectValueChanged(
+            SLOT(updateVinylControlSignalEnabled(double)));
 
-    //Match the vinyl control's set RPM so that the spinny widget rotates at the same
-    //speed as your physical decks, if you're using vinyl control.
-    connect(m_pVinylControlSpeedType, SIGNAL(valueChanged(double)),
-            this, SLOT(updateVinylControlSpeed(double)));
-
+    // Match the vinyl control's set RPM so that the spinny widget rotates at
+    // the same speed as your physical decks, if you're using vinyl control.
+    m_pVinylControlSpeedType->connectValueChanged(
+            SLOT(updateVinylControlSpeed(double)));
 
 
 #else
@@ -552,7 +536,7 @@ void WSpinny::mouseMoveEvent(QMouseEvent * e) {
         //Convert deltaTheta into a percentage of song length.
         double absPos = calculatePositionFromAngle(theta);
         double absPosInSamples = absPos * m_pTrackSamples->get();
-        m_pScratchPos->slotSet(absPosInSamples - m_dInitialPos);
+        m_pScratchPos->set(absPosInSamples - m_dInitialPos);
     } else if (e->buttons() & Qt::MidButton) {
     } else if (e->buttons() & Qt::NoButton) {
         setCursor(QCursor(Qt::OpenHandCursor));
@@ -583,11 +567,11 @@ void WSpinny::mousePressEvent(QMouseEvent * e)
         theta += m_iFullRotations * 360.0;
         m_dInitialPos = calculatePositionFromAngle(theta) * m_pTrackSamples->get();
 
-        m_pScratchPos->slotSet(0);
-        m_pScratchToggle->slotSet(1.0);
+        m_pScratchPos->set(0);
+        m_pScratchToggle->set(1.0);
 
         if (e->button() == Qt::RightButton) {
-            m_pSlipEnabled->slotSet(1.0);
+            m_pSlipEnabled->set(1.0);
         }
 
         // Trigger a mouse move to immediately line up the vinyl with the cursor
@@ -599,10 +583,10 @@ void WSpinny::mouseReleaseEvent(QMouseEvent * e)
 {
     if (e->button() == Qt::LeftButton || e->button() == Qt::RightButton) {
         QApplication::restoreOverrideCursor();
-        m_pScratchToggle->slotSet(0.0);
+        m_pScratchToggle->set(0.0);
         m_iFullRotations = 0;
         if (e->button() == Qt::RightButton) {
-            m_pSlipEnabled->slotSet(0.0);
+            m_pSlipEnabled->set(0.0);
         }
     }
 }

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -14,7 +14,7 @@
 #include "widget/wbasewidget.h"
 #include "widget/wwidget.h"
 
-class ControlObjectThread;
+class ControlObjectSlave;
 class VisualPlayPosition;
 class VinylControlManager;
 
@@ -75,17 +75,17 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
     QImage m_fgImageScaled;
     QImage* m_pGhostImage;
     QImage m_ghostImageScaled;
-    ControlObjectThread* m_pPlay;
-    ControlObjectThread* m_pPlayPos;
+    ControlObjectSlave* m_pPlay;
+    ControlObjectSlave* m_pPlayPos;
     QSharedPointer<VisualPlayPosition> m_pVisualPlayPos;
-    ControlObjectThread* m_pTrackSamples;
-    ControlObjectThread* m_pTrackSampleRate;
-    ControlObjectThread* m_pScratchToggle;
-    ControlObjectThread* m_pScratchPos;
-    ControlObjectThread* m_pVinylControlSpeedType;
-    ControlObjectThread* m_pVinylControlEnabled;
-    ControlObjectThread* m_pSignalEnabled;
-    ControlObjectThread* m_pSlipEnabled;
+    ControlObjectSlave* m_pTrackSamples;
+    ControlObjectSlave* m_pTrackSampleRate;
+    ControlObjectSlave* m_pScratchToggle;
+    ControlObjectSlave* m_pScratchPos;
+    ControlObjectSlave* m_pVinylControlSpeedType;
+    ControlObjectSlave* m_pVinylControlEnabled;
+    ControlObjectSlave* m_pSignalEnabled;
+    ControlObjectSlave* m_pSlipEnabled;
 
     TrackPointer m_loadedTrack;
     QPixmap m_loadedCover;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -13,7 +13,7 @@
 #include "library/trackcollection.h"
 #include "trackinfoobject.h"
 #include "controlobject.h"
-#include "controlobjectthread.h"
+#include "controlobjectslave.h"
 #include "widget/wtracktableview.h"
 #include "dlgtrackinfo.h"
 #include "soundsourceproxy.h"
@@ -65,12 +65,12 @@ WTrackTableView::WTrackTableView(QWidget * parent,
     connect(&m_BpmMapper, SIGNAL(mapped(int)),
             this, SLOT(slotScaleBpm(int)));
 
-    m_pNumSamplers = new ControlObjectThread(
-            "[Master]", "num_samplers");
-    m_pNumDecks = new ControlObjectThread(
-            "[Master]", "num_decks");
-    m_pNumPreviewDecks = new ControlObjectThread(
-            "[Master]", "num_preview_decks");
+    m_pNumSamplers = new ControlObjectSlave(
+            "[Master]", "num_samplers", this);
+    m_pNumDecks = new ControlObjectSlave(
+            "[Master]", "num_decks", this);
+    m_pNumPreviewDecks = new ControlObjectSlave(
+            "[Master]", "num_preview_decks", this);
 
     m_pMenu = new QMenu(this);
 
@@ -139,10 +139,6 @@ WTrackTableView::~WTrackTableView() {
     delete m_pMenu;
     delete m_pPlaylistMenu;
     delete m_pCrateMenu;
-    //delete m_pRenamePlaylistAct;
-    delete m_pNumSamplers;
-    delete m_pNumDecks;
-    delete m_pNumPreviewDecks;
     delete m_pBpmLockAction;
     delete m_pBpmUnlockAction;
     delete m_pBpmDoubleAction;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -106,8 +106,8 @@ WTrackTableView::WTrackTableView(QWidget * parent,
     connect(&m_crateMapper, SIGNAL(mapped(int)),
             this, SLOT(addSelectionToCrate(int)));
 
-    m_pCOTGuiTick = new ControlObjectSlave("[Master]", "guiTick50ms");
-    m_pCOTGuiTick->connectValueChanged(this, SLOT(slotGuiTick50ms(double)));
+    m_pCOTGuiTick = new ControlObjectSlave("[Master]", "guiTick50ms", this);
+    m_pCOTGuiTick->connectValueChanged(SLOT(slotGuiTick50ms(double)));
 
     connect(this, SIGNAL(scrollValueChanged(int)),
             this, SLOT(slotScrollValueChanged(int)));
@@ -154,7 +154,6 @@ WTrackTableView::~WTrackTableView() {
     delete m_pFileBrowserAct;
     delete m_pResetPlayedAct;
     delete m_pSamplerMenu;
-    delete m_pCOTGuiTick;
 }
 
 void WTrackTableView::enableCachedOnly() {

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -13,7 +13,7 @@
 #include "widget/wlibrarytableview.h"
 #include "dlgtagfetcher.h"
 
-class ControlObjectThread;
+class ControlObjectSlave;
 class DlgTrackInfo;
 class TrackCollection;
 class WCoverArtMenu;
@@ -110,9 +110,9 @@ class WTrackTableView : public WLibraryTableView {
     QModelIndex currentTrackInfoIndex;
 
 
-    ControlObjectThread* m_pNumSamplers;
-    ControlObjectThread* m_pNumDecks;
-    ControlObjectThread* m_pNumPreviewDecks;
+    ControlObjectSlave* m_pNumSamplers;
+    ControlObjectSlave* m_pNumDecks;
+    ControlObjectSlave* m_pNumPreviewDecks;
 
     // Context menu machinery
     QMenu *m_pMenu, *m_pPlaylistMenu, *m_pCrateMenu, *m_pSamplerMenu, *m_pBPMMenu;

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -69,7 +69,7 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
         m_bScratching = true;
         double audioSamplePerPixel = m_waveformWidget->getAudioSamplePerPixel();
         double targetPosition = -1.0 * event->pos().x() * audioSamplePerPixel * 2;
-        m_pScratchPosition->slotSet(targetPosition);
+        m_pScratchPosition->set(targetPosition);
         m_pScratchPositionEnable->slotSet(1.0);
     } else if (event->button() == Qt::RightButton) {
         // If we are scratching then disable and reset because the two shouldn't
@@ -93,7 +93,7 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
         double audioSamplePerPixel = m_waveformWidget->getAudioSamplePerPixel();
         double targetPosition = -1.0 * event->pos().x() * audioSamplePerPixel * 2;
         //qDebug() << "Target:" << targetPosition;
-        m_pScratchPosition->slotSet(targetPosition);
+        m_pScratchPosition->set(targetPosition);
     } else if (m_bBending) {
         QPoint diff = event->pos() - m_mouseAnchor;
         // Start at the middle of [0.0, 1.0], and emit values based on how far
@@ -112,7 +112,7 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
 
 void WWaveformViewer::mouseReleaseEvent(QMouseEvent* /*event*/) {
     if (m_bScratching) {
-        m_pScratchPositionEnable->slotSet(0.0);
+        m_pScratchPositionEnable->set(0.0);
         m_bScratching = false;
     }
     if (m_bBending) {

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -26,26 +26,21 @@ WWaveformViewer::WWaveformViewer(const char *group, ConfigObject<ConfigValue>* p
           m_waveformWidget(NULL) {
     setAcceptDrops(true);
 
-    m_pZoom = new ControlObjectSlave(group, "waveform_zoom");
-    m_pZoom->connectValueChanged(this, SLOT(onZoomChange(double)));
+    m_pZoom = new ControlObjectSlave(group, "waveform_zoom", this);
+    m_pZoom->connectValueChanged(SLOT(onZoomChange(double)));
 
     m_pScratchPositionEnable = new ControlObjectSlave(
-            group, "scratch_position_enable");
+            group, "scratch_position_enable", this);
     m_pScratchPosition = new ControlObjectSlave(
-            group, "scratch_position");
+            group, "scratch_position", this);
     m_pWheel = new ControlObjectSlave(
-            group, "wheel");
+            group, "wheel", this);
 
     setAttribute(Qt::WA_OpaquePaintEvent);
 }
 
 WWaveformViewer::~WWaveformViewer() {
     //qDebug() << "~WWaveformViewer";
-
-    delete m_pZoom;
-    delete m_pScratchPositionEnable;
-    delete m_pScratchPosition;
-    delete m_pWheel;
 }
 
 void WWaveformViewer::setup(QDomNode node, const SkinContext& context) {


### PR DESCRIPTION
This should Fix Bug https://bugs.launchpad.net/mixxx/+bug/1406124

I have changed the internal signal/slot connection according to the requested connection, like that:

```
connectValueChanged Auto -> COP = Auto / SCO = Auto
connectValueChanged Direct -> COP = Direct / SCO = Direct
connectValueChanged Queued -> COP = Auto / SCO = Queued
connectValueChanged BlockingQueued -> Assert(false)
```

I have also reviewed all occurrence of ControlObjectSlave and it should work now.

I have removed most manual deletes and scoped pointer in favour of the Qt Object tree delete feature. This offers the best safety since the COS is deleted by its parent object, from which it usually inherits the event queue as well.

TODO: The deprecated ControlObjectThread suffers the same issue. I think we need to replace it with ControlObjectSlaves.
