### PR TITLE
remove unneeded SSE2 flag on x64 with msvs compiler

### DIFF
--- a/build/features.py
+++ b/build/features.py
@@ -1010,7 +1010,10 @@ class Optimize(Feature):
             if optimize_level == Optimize.LEVEL_PORTABLE:
                 # portable-binary: sse2 CPU (>= Pentium 4)
                 self.status = "portable: sse2 CPU (>= Pentium 4)"
-                build.env.Append(CCFLAGS='/arch:SSE2')
+                # SSE and SSE2 are core instructions on x64 
+                # and consequently raise a warning message from compiler with this flag on x64.
+                if not build.machine_is_64bit:
+                    build.env.Append(CCFLAGS='/arch:SSE2')
                 build.env.Append(CPPDEFINES=['__SSE__', '__SSE2__'])
             elif optimize_level == Optimize.LEVEL_NATIVE:
                 self.status = "native: tuned for this CPU (%s)" % build.machine


### PR DESCRIPTION
This PR removes a compiler warning with msvs toolchain on x64 and optimize=portable.
In this configuration, the compiler actually gets /arch:SSE2 parameter, which is unneeded on x64 because SSE2 are core instructions and raises a lot of warning messages during compilation.
We remove this parameter on 64 bits builds.
