### PR TITLE
Split TrackRef from TrackInfoObject

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -916,6 +916,7 @@ class MixxxCore(Feature):
                    "track/keys.cpp",
                    "track/keyfactory.cpp",
                    "track/keyutils.cpp",
+                   "track/trackref.cpp",
 
                    "baseplayer.cpp",
                    "basetrackplayer.cpp",

--- a/src/analyserqueue.cpp
+++ b/src/analyserqueue.cpp
@@ -218,7 +218,7 @@ bool AnalyserQueue::doAnalysis(TrackPointer tio, Mixxx::AudioSourcePointer pAudi
             if (frameIndex < pAudioSource->getMaxFrameIndex()) {
                 // EOF not reached -> Maybe a corrupt file?
                 qWarning() << "Failed to read sample data from file:"
-                        << tio->getFilename()
+                        << tio->getTrackRef().getLocation()
                         << "@" << frameIndex;
                 if (0 >= framesRead) {
                     // If no frames have been read then abort the analysis.

--- a/src/basetrackplayer.cpp
+++ b/src/basetrackplayer.cpp
@@ -114,7 +114,8 @@ BaseTrackPlayerImpl::~BaseTrackPlayerImpl() {
 void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer track, bool bPlay) {
     // Before loading the track, ensure we have access. This uses lazy
     // evaluation to make sure track isn't NULL before we dereference it.
-    if (!track.isNull() && !Sandbox::askForAccess(track->getCanonicalLocation())) {
+    const TrackRef trackRef(track->getTrackRef());
+    if (!track.isNull() && !Sandbox::askForAccess(trackRef.getCanonicalLocation())) {
         // We don't have access.
         return;
     }

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -119,14 +119,14 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     ReaderStatusUpdate status;
     status.status = TRACK_NOT_LOADED;
 
-    QString filename = pTrack->getLocation();
-    if (filename.isEmpty() || !pTrack->exists()) {
+    const TrackRef trackRef(pTrack->getTrackRef());
+    if (trackRef.getLocation().isEmpty() || !trackRef.createFileInfo().exists()) {
         // Must unlock before emitting to avoid deadlock
         qDebug() << m_group << "CachingReaderWorker::loadTrack() load failed for\""
-                 << filename << "\", unlocked reader lock";
+                 << trackRef.getLocation() << "\", unlocked reader lock";
         m_pReaderStatusFIFO->writeBlocking(&status, 1);
         emit(trackLoadFailed(
-            pTrack, QString("The file '%1' could not be found.").arg(filename)));
+            pTrack, QString("The file '%1' could not be found.").arg(trackRef.getLocation())));
         return;
     }
 
@@ -137,10 +137,10 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
         m_maxReadableFrameIndex = Mixxx::AudioSource::getMinFrameIndex();
         // Must unlock before emitting to avoid deadlock
         qDebug() << m_group << "CachingReaderWorker::loadTrack() load failed for\""
-                 << filename << "\", file invalid, unlocked reader lock";
+                 << trackRef.getLocation() << "\", file invalid, unlocked reader lock";
         m_pReaderStatusFIFO->writeBlocking(&status, 1);
         emit(trackLoadFailed(
-            pTrack, QString("The file '%1' could not be loaded.").arg(filename)));
+            pTrack, QString("The file '%1' could not be loaded.").arg(trackRef.getLocation())));
         return;
     }
 

--- a/src/dlgtrackinfo.cpp
+++ b/src/dlgtrackinfo.cpp
@@ -243,11 +243,13 @@ void DlgTrackInfo::slotOpenInFileBrowser() {
     }
 
     QDir dir;
-    QStringList splittedPath = m_pLoadedTrack->getDirectory().split("/");
+    const TrackRef trackRef(m_pLoadedTrack->getTrackRef());
+    const QFileInfo fileInfo(trackRef.createFileInfo());
+    QStringList splittedPath = TrackRef::toDirectory(fileInfo).split("/");
     do {
         dir = QDir(splittedPath.join("/"));
         splittedPath.removeLast();
-    } while (!dir.exists() && splittedPath.size());
+    } while (!dir.exists() && !splittedPath.isEmpty());
 
     // This function does not work for a non-existent directory!
     // so it is essential that in the worst case it try opening

--- a/src/dlgtrackinfo.cpp
+++ b/src/dlgtrackinfo.cpp
@@ -170,9 +170,10 @@ void DlgTrackInfo::populateFields(TrackPointer pTrack) {
     bpmThreeFourth->setEnabled(enableBpmEditing);
 
     m_loadedCoverInfo = pTrack->getCoverInfo();
-    int reference = pTrack->getId().toInt();
-    m_loadedCoverInfo.trackLocation = pTrack->getLocation();
-    m_pWCoverArtLabel->setCoverArt(pTrack, m_loadedCoverInfo, QPixmap());
+    const TrackRef trackRef(pTrack->getTrackRef());
+    int reference = trackRef.getId().toInt();
+    m_loadedCoverInfo.trackLocation = trackRef.getLocation();
+    m_pWCoverArtLabel->setCoverArt(trackRef, m_loadedCoverInfo, QPixmap());
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache != NULL) {
         pCache->requestCover(m_loadedCoverInfo, this, reference);
@@ -206,7 +207,7 @@ void DlgTrackInfo::slotCoverFound(const QObject* pRequestor,
             m_pLoadedTrack->getId().toInt() == requestReference) {
         qDebug() << "DlgTrackInfo::slotPixmapFound" << pRequestor << info
                  << pixmap.size();
-        m_pWCoverArtLabel->setCoverArt(m_pLoadedTrack, m_loadedCoverInfo, pixmap);
+        m_pWCoverArtLabel->setCoverArt(m_pLoadedTrack->getTrackRef(), m_loadedCoverInfo, pixmap);
     }
 }
 
@@ -440,7 +441,7 @@ void DlgTrackInfo::clear() {
     cueTable->setRowCount(0);
 
     m_loadedCoverInfo = CoverInfo();
-    m_pWCoverArtLabel->setCoverArt(TrackPointer(), m_loadedCoverInfo, QPixmap());
+    m_pWCoverArtLabel->setCoverArt(TrackRef(), m_loadedCoverInfo, QPixmap());
 }
 
 void DlgTrackInfo::slotBpmDouble() {

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -287,13 +287,14 @@ void AutoDJFeature::slotAddRandomTrack(bool) {
             if (trackId.isValid()) {
                 // Get Track Information
                 TrackPointer addedTrack = (m_pTrackCollection->getTrackDAO()).getTrack(trackId);
-                if(addedTrack->exists()) {
+                const TrackRef trackRef(addedTrack->getTrackRef());
+                if(trackRef.createFileInfo().exists()) {
                     playlistDao.appendTrackToPlaylist(trackId, m_iAutoDJPlaylistId);
                     m_pAutoDJView->onShow();
                     return;
                 } else {
                     qDebug() << "Track does not exist: "<< addedTrack->getInfo()
-                             << " " << addedTrack->getDirectory();
+                             << " " << trackRef.getLocation();
                 }
             }
             failedRetrieveAttempts += 1;
@@ -305,7 +306,8 @@ void AutoDJFeature::slotAddRandomTrack(bool) {
             TrackId trackId(m_autoDjCratesDao.getRandomTrackIdFromLibrary(m_iAutoDJPlaylistId));
             if (trackId.isValid()) {
                 TrackPointer addedTrack = m_pTrackCollection->getTrackDAO().getTrack(trackId);
-                if(addedTrack->exists()) {
+                const TrackRef trackRef(addedTrack->getTrackRef());
+                if(trackRef.createFileInfo().exists()) {
                     if(!addedTrack->getPlayed()) {
                         playlistDao.appendTrackToPlaylist(trackId, m_iAutoDJPlaylistId);
                         m_pAutoDJView->onShow();
@@ -313,7 +315,7 @@ void AutoDJFeature::slotAddRandomTrack(bool) {
                     }
                 } else {
                     qDebug() << "Track does not exist:"<< addedTrack->getInfo()
-                             << addedTrack->getDirectory();
+                             << trackRef;
                 }
             }
             failedRetrieveAttempts += 1;

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -577,7 +577,8 @@ TrackPointer AutoDJProcessor::getNextTrackFromQueue() {
             m_pAutoDJTableModel->index(0, 0));
 
         if (nextTrack) {
-            if (nextTrack->exists()) {
+            const TrackRef trackRef(nextTrack->getTrackRef());
+            if(trackRef.createFileInfo().exists()) {
                 return nextTrack;
             } else {
                 // Remove missing song from auto DJ playlist.

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -842,7 +842,12 @@ void BaseSqlTableModel::setTrackValueForColumn(TrackPointer pTrack, int column,
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER) == column) {
         pTrack->setTrackNumber(value.toString());
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_LOCATION) == column) {
-        pTrack->setLocation(value.toString());
+        DEBUG_ASSERT_AND_HANDLE(pTrack->getLocation() == value.toString()) {
+            qWarning() << "The location of track cannot be modified from"
+                    << pTrack->getLocation()
+                    << "to"
+                    << value.toString();
+        }
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMMENT) == column) {
         pTrack->setComment(value.toString());
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DURATION) == column) {

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -150,7 +150,7 @@ TrackPointer BaseTrackCache::lookupCachedTrack(TrackId trackId) const {
 
 bool BaseTrackCache::updateIndexWithTrackpointer(TrackPointer pTrack) {
     if (sDebug) {
-        qDebug() << "updateIndexWithTrackpointer:" << pTrack->getFilename();
+        qDebug() << "updateIndexWithTrackpointer:" << pTrack->getTrackRef();
     }
 
     if (pTrack.isNull()) {

--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -146,15 +146,17 @@ void BrowseThread::populateModel() {
             return populateModel();
         }
 
-        QString filepath = fileIt.next();
-        TrackInfoObject tio(filepath, thisPath.token());
+        TrackInfoObject tio(fileIt.next(), thisPath.token());
+        const TrackRef trackRef(tio.getTrackRef());
+        const QFileInfo fileInfo(trackRef.createFileInfo());
+
         QList<QStandardItem*> row_data;
 
         QStandardItem* item = new QStandardItem("0");
         item->setData("0", Qt::UserRole);
         row_data.insert(COLUMN_PREVIEW, item);
 
-        item = new QStandardItem(tio.getFilename());
+        item = new QStandardItem(TrackRef::toFileName(fileInfo));
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_FILENAME, item);
@@ -238,18 +240,18 @@ void BrowseThread::populateModel() {
         item->setData(tio.getBitrate(), Qt::UserRole);
         row_data.insert(COLUMN_BITRATE, item);
 
-        item = new QStandardItem(filepath);
+        item = new QStandardItem(trackRef.getLocation());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_LOCATION, item);
 
-        QDateTime modifiedTime = tio.getFileModifiedTime().toLocalTime();
+        QDateTime modifiedTime = TrackRef::toFileLastModifiedAt(fileInfo).toLocalTime();
         item = new QStandardItem(modifiedTime.toString(Qt::DefaultLocaleShortDate));
         item->setToolTip(item->text());
         item->setData(modifiedTime, Qt::UserRole);
         row_data.insert(COLUMN_FILE_MODIFIED_TIME, item);
 
-        QDateTime creationTime = tio.getFileCreationTime().toLocalTime();
+        QDateTime creationTime = TrackRef::toFileCreatedAt(fileInfo).toLocalTime();
         item = new QStandardItem(creationTime.toString(Qt::DefaultLocaleShortDate));
         item->setToolTip(item->text());
         item->setData(creationTime, Qt::UserRole);
@@ -262,7 +264,7 @@ void BrowseThread::populateModel() {
         if (row % 10 == 0) {
             // this is a blocking operation
             emit(rowsAppended(rows, thisModelObserver));
-            qDebug() << "Append " << rows.count() << " from " << filepath;
+            qDebug() << "Append " << rows.count() << " from " << trackRef.getLocation();
             rows.clear();
         }
         // Sleep additionally for 10ms which prevents us from GUI freezes

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -85,10 +85,8 @@ CoverArt CoverArtUtils::guessCoverArt(TrackPointer pTrack) {
         return art;
     }
 
-    const QFileInfo trackInfo = pTrack->getFileInfo();
-    const QString trackLocation = trackInfo.absoluteFilePath();
-
-    art.image = extractEmbeddedCover(trackLocation, pTrack->getSecurityToken());
+    const TrackRef trackRef(pTrack->getTrackRef());
+    art.image = extractEmbeddedCover(trackRef.getLocation(), pTrack->getSecurityToken());
     if (!art.image.isNull()) {
         art.info.hash = calculateHash(art.image);
         art.info.coverLocation = QString();
@@ -97,8 +95,9 @@ CoverArt CoverArtUtils::guessCoverArt(TrackPointer pTrack) {
         return art;
     }
 
+    const QFileInfo fileInfo(trackRef.createFileInfo());
     QLinkedList<QFileInfo> possibleCovers = findPossibleCoversInFolder(
-        trackInfo.absolutePath());
+            TrackRef::toDirectory(fileInfo));
     art = selectCoverArtForTrack(pTrack.data(), possibleCovers);
     if (art.info.type == CoverInfo::FILE) {
         qDebug() << "CoverArtUtils::guessCoverArt found file art" << art;
@@ -139,7 +138,7 @@ CoverArt CoverArtUtils::selectCoverArtForTrack(
         return art;
     }
 
-    const QString trackBaseName = pTrack->getFileInfo().baseName();
+    const QString trackBaseName = pTrack->getTrackRef().createFileInfo().baseName();
     const QString albumName = pTrack->getAlbum();
     return selectCoverArtForTrack(trackBaseName, albumName, covers);
 }

--- a/src/library/legacylibraryimporter.cpp
+++ b/src/library/legacylibraryimporter.cpp
@@ -94,7 +94,10 @@ void LegacyLibraryImporter::import() {
             // because Mixxx <= 1.7 had no logic to deal with detecting deleted
             // files.
 
-            if (trackInfo17.exists()) {
+            const TrackRef trackRef(trackInfo17.getTrackRef());
+            const QFileInfo fileInfo(trackRef.createFileInfo());
+
+            if (fileInfo.exists()) {
                 // Create a TrackInfoObject by directly parsing
                 // the actual MP3/OGG/whatever because 1.7 didn't parse
                 // genre and album tags (so the imported TIO doesn't have
@@ -102,10 +105,7 @@ void LegacyLibraryImporter::import() {
                 emit(progress("Upgrading Mixxx 1.7 Library: " + trackInfo17.getTitle()));
 
                 // Read the metadata we couldn't support in <1.8 from file.
-                QFileInfo fileInfo(trackInfo17.getLocation());
-                // Ensure we have the absolute file path stored
-                trackInfo17.setLocation(fileInfo.absoluteFilePath());
-                TrackInfoObject trackInfoNew(trackInfo17.getLocation());
+                TrackInfoObject trackInfoNew(fileInfo);
                 trackInfo17.setGenre(trackInfoNew.getGenre());
                 trackInfo17.setAlbum(trackInfoNew.getAlbum());
                 trackInfo17.setYear(trackInfoNew.getYear());
@@ -131,7 +131,7 @@ void LegacyLibraryImporter::import() {
                 // different. Using the track location is the best way for us to identify the song.)
                 TrackId trackId(pTrack->getId());
                 if (playlistHashTable.contains(trackId)) {
-                    playlistHashTable[trackId] = pTrack->getLocation();
+                    playlistHashTable[trackId] = trackRef.getLocation();
                 }
             }
         }

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -1141,8 +1141,9 @@ TEST_F(AutoDJProcessorTest, TrackZeroLength) {
 
     // Load the track and mark it playing (as the loadTrackToPlayer signal would
     // have connected to this eventually).
-    TrackPointer pTrack(new TrackInfoObject());
+    TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
     setTrackId(pTrack, testId);
+    pTrack->setDuration(0);
     deck1.slotLoadTrack(pTrack, true);
 
     // Expect that the track is rejected an a new one is loaded

--- a/src/test/trackreftest.cpp
+++ b/src/test/trackreftest.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+
+#include <QDir>
+#include <QTemporaryFile>
+#include <QtDebug>
+
+#include "track/trackref.h"
+
+namespace {
+
+class TrackRefTest : public testing::Test {
+  protected:
+
+    TrackRefTest()
+      : m_tempFile("TrackRefTest.tmp"),
+        m_tempFileDir(QDir::tempPath()),
+        m_tempFileName(m_tempFile.fileName()),
+        m_tempFileInfo(m_tempFileDir, m_tempFileName),
+        m_validTrackId(123) {
+    }
+
+    virtual void SetUp() {
+        ASSERT_TRUE(m_validTrackId.isValid());
+        ASSERT_FALSE(m_invalidTrackId.isValid());
+    }
+
+    virtual void TearDown() {
+    }
+
+    static void verifyFileInfo(const TrackRef& actual, const QFileInfo& fileInfo) {
+        EXPECT_TRUE(actual.hasLocation());
+        EXPECT_EQ(TrackRef::toLocation(fileInfo), actual.getLocation());
+        EXPECT_TRUE(actual.hasCanonicalLocation());
+        EXPECT_EQ(TrackRef::toCanonicalLocation(fileInfo), actual.getCanonicalLocation());
+        EXPECT_EQ(fileInfo, actual.createFileInfo());
+    }
+
+    const QTemporaryFile m_tempFile;
+    const QDir m_tempFileDir;
+    const QString m_tempFileName;
+    const QFileInfo m_tempFileInfo;
+    const TrackId m_validTrackId;
+    const TrackId m_invalidTrackId;
+};
+
+TEST_F(TrackRefTest, DefaultConstructor) {
+    TrackRef actual;
+
+    EXPECT_FALSE(actual.hasLocation());
+    EXPECT_FALSE(actual.hasCanonicalLocation());
+    EXPECT_FALSE(actual.hasId());
+}
+
+TEST_F(TrackRefTest, FromFileInfoWithId) {
+    const TrackRef actual(m_tempFileInfo, m_validTrackId);
+
+    verifyFileInfo(actual, m_tempFileInfo);
+    EXPECT_TRUE(actual.hasId());
+    EXPECT_EQ(m_validTrackId, actual.getId());
+}
+
+TEST_F(TrackRefTest, FromFileInfoWithoutId) {
+    const TrackRef actual(m_tempFileInfo);
+
+    verifyFileInfo(actual, m_tempFileInfo);
+    EXPECT_FALSE(actual.hasId());
+    EXPECT_EQ(m_invalidTrackId, actual.getId());
+}
+
+TEST_F(TrackRefTest, CopyAndSetId) {
+    const TrackRef withoutId(m_tempFileInfo);
+
+    const TrackRef actual(withoutId, m_validTrackId);
+
+    verifyFileInfo(actual, m_tempFileInfo);
+    EXPECT_TRUE(actual.hasId());
+    EXPECT_EQ(m_validTrackId, actual.getId());
+}
+
+}  // namespace

--- a/src/track/trackref.cpp
+++ b/src/track/trackref.cpp
@@ -1,0 +1,43 @@
+#include "track/trackref.h"
+
+
+bool TrackRef::verifyConsistency() const {
+    DEBUG_ASSERT_AND_HANDLE(hasLocation() || !hasCanonicalLocation()) {
+        return false;
+    }
+    DEBUG_ASSERT_AND_HANDLE(hasLocation() || !hasId()) {
+        return false;
+    }
+    return true;
+}
+
+QFileInfo TrackRef::createFileInfo() const {
+    QFileInfo fileInfo(getLocation());
+    DEBUG_ASSERT(toLocation(fileInfo) == getLocation());
+    DEBUG_ASSERT_AND_HANDLE(toCanonicalLocation(fileInfo) == getCanonicalLocation()) {
+        qWarning() << "Inconsistent canonical locations detected for file"
+                << getLocation()
+                << ":"
+                << getCanonicalLocation()
+                << "<>"
+                << toCanonicalLocation(fileInfo);
+
+    }
+    return fileInfo;
+}
+
+std::ostream& operator<<(std::ostream& os, const TrackRef& trackRef) {
+    return os << '[' << trackRef.getLocation().toStdString()
+            << " | " << trackRef.getCanonicalLocation().toStdString()
+            << " | " << trackRef.getId().toString().toStdString()
+            << ']';
+
+}
+
+QDebug operator<<(QDebug qDebug, const TrackRef& trackRef) {
+    qDebug.nospace() << '[' << trackRef.getLocation()
+                    << " | " << trackRef.getCanonicalLocation()
+                    << " | " << trackRef.getId()
+                    << ']';
+    return qDebug.space();
+}

--- a/src/track/trackref.h
+++ b/src/track/trackref.h
@@ -1,0 +1,146 @@
+#ifndef TRACKREF_H
+#define TRACKREF_H
+
+
+#include <ostream>
+#include <utility>
+
+#include <QDateTime>
+#include <QFileInfo>
+#include <QString>
+#include <QtDebug>
+
+#include "track/trackid.h"
+#include "util/assert.h"
+
+
+// A track in the library is identified by a location and an id.
+// The location is mandatory to identify the file, whereas the id
+// only exists after the track has been inserted into the database.
+//
+// The logical reference to the track's file is referred to as its
+// "location". The location of each track must be unique inside the
+// library, i.e. each location identifies a single track. The location
+// contains an absolute path to the file.
+//
+// Different locations might reference the same file on disk. In order
+// to track which files are in use at runtime we also need to reference
+// tracks by their "canonical location". Each file has a unique canonical
+// location that is determined at runtime. The canonical location is
+// a transient property that may vary between different executions of the
+// application, but must not change during a single execution. It is
+// obtained by removing all redundancies from and resolving all symbolic
+// links in the location.
+//
+// NOTE(uklotzde): I've decided not to add any comparison operators for
+// this class, because technical and logical equality differs depending
+// on the use case!
+class TrackRef {
+public:
+    // Functions for extracting commonly used information from QFileInfo.
+    static QString toLocation(const QFileInfo& fileInfo) {
+        return fileInfo.absoluteFilePath();
+    }
+    static QString toCanonicalLocation(const QFileInfo& fileInfo) {
+        return fileInfo.canonicalFilePath();
+    }
+    static QString toDirectory(const QFileInfo& fileInfo) {
+        return fileInfo.absolutePath();
+    }
+    static QString toFileName(const QFileInfo& fileInfo) {
+        return fileInfo.fileName();
+    }
+    static quint64 toFileSize(const QFileInfo& fileInfo) {
+        return fileInfo.size();
+    }
+    static QDateTime toFileCreatedAt(const QFileInfo& fileInfo) {
+        return fileInfo.created();
+    }
+    static QDateTime toFileLastModifiedAt(const QFileInfo& fileInfo) {
+        return fileInfo.lastModified();
+    }
+
+    TrackRef() {
+        DEBUG_ASSERT(verifyConsistency());
+    }
+    // Conversion from QFileInfo
+    explicit TrackRef(
+            const QFileInfo& fileInfo,
+            TrackId id = TrackId())
+        : m_location(toLocation(fileInfo)),
+          m_canonicalLocation(toCanonicalLocation(fileInfo)),
+          m_id(std::move(id)) {
+        DEBUG_ASSERT(verifyConsistency());
+    }
+    // Create a copy of an existing TrackRef and set the TrackId.
+    // This is equivalent to invoking the regular copy constructor
+    // followed by a call to setId().
+    TrackRef(
+            const TrackRef& other,
+            TrackId id)
+        : m_location(other.m_location),
+          m_canonicalLocation(other.m_canonicalLocation),
+          m_id(std::move(id)) {
+        DEBUG_ASSERT(!other.hasId() || (other.getId() == id));
+        DEBUG_ASSERT(verifyConsistency());
+    }
+
+    // The human-readable identifier of a track in Mixxx. The location is
+    // immutable and the starting point for accessing a track's file.
+    const QString& getLocation() const {
+        return m_location;
+    }
+    bool hasLocation() const {
+        return !getLocation().isEmpty();
+    }
+
+    // The unique identifier of a track's file at runtime and used
+    // for caching. The canonical location is empty for inexistent
+    // files. Like the id it can only be set once.
+    const QString& getCanonicalLocation() const {
+        return m_canonicalLocation;
+    }
+    bool hasCanonicalLocation() const {
+        return !getCanonicalLocation().isEmpty();
+    }
+    void setCanonicalLocation(QString canonicalLocation) {
+        DEBUG_ASSERT(!hasCanonicalLocation() ||
+                (getCanonicalLocation() == getCanonicalLocation()));
+        m_canonicalLocation = std::move(canonicalLocation);
+        DEBUG_ASSERT(verifyConsistency());
+    }
+
+    // The primary key of a track in the Mixxx library. The id must only
+    // be set once after inserting into or after loading from the database.
+    // Tracks that have not been stored in the database don't have an id.
+    const TrackId& getId() const {
+        return m_id;
+    }
+    bool hasId() const {
+        return getId().isValid();
+    }
+    void setId(TrackId id) {
+        DEBUG_ASSERT(!hasId() || (getId() == id));
+        m_id = std::move(id);
+        DEBUG_ASSERT(verifyConsistency());
+    }
+
+    // Conversion of a TrackRef into the corresponding QFileInfo.
+    QFileInfo createFileInfo() const;
+
+private:
+    bool verifyConsistency() const;
+
+    QString m_location;
+    QString m_canonicalLocation;
+    TrackId m_id;
+};
+
+Q_DECLARE_METATYPE(TrackRef)
+
+std::ostream& operator<<(std::ostream& os, const TrackRef& trackRef);
+
+QDebug operator<<(QDebug qDebug, const TrackRef& trackRef);
+
+
+#endif // TRACKREF_H

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -107,13 +107,11 @@ TrackInfoObject::TrackInfoObject(const QDomNode &nodeHeader)
     m_bPlayed = false;
     m_bDeleteOnReferenceExpiration = false;
     m_bDirty = false;
-    m_bLocationChanged = false;
 }
 
 void TrackInfoObject::initialize(bool parseHeader, bool parseCoverArt) {
     m_bDeleteOnReferenceExpiration = false;
     m_bDirty = false;
-    m_bLocationChanged = false;
 
     m_sArtist = "";
     m_sTitle = "";
@@ -312,15 +310,6 @@ QString TrackInfoObject::getDurationStr() const {
     lock.unlock();
 
     return Time::formatSeconds(iDuration, false);
-}
-
-void TrackInfoObject::setLocation(const QString& location) {
-    QMutexLocker lock(&m_qMutex);
-    if (m_trackRef.getLocation() != location) {
-        m_trackRef = TrackRef(location, m_trackRef.getId());
-        m_bLocationChanged = true;
-        setDirty(true);
-    }
 }
 
 SecurityTokenPointer TrackInfoObject::getSecurityToken() {
@@ -886,11 +875,6 @@ void TrackInfoObject::setDirty(bool bDirty) {
 bool TrackInfoObject::isDirty() {
     QMutexLocker lock(&m_qMutex);
     return m_bDirty;
-}
-
-bool TrackInfoObject::locationChanged() {
-    QMutexLocker lock(&m_qMutex);
-    return m_bLocationChanged;
 }
 
 int TrackInfoObject::getRating() const {

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -79,7 +79,7 @@ class TrackInfoObject : public QObject {
     QString getDurationStr() const;
 
     // Accessors for various stats of the file on disk. These are auto-populated
-    // when the TIO is constructed, or when setLocation() is called.
+    // when the TIO is constructed.
 
     Q_PROPERTY(QString artist READ getArtist WRITE setArtist)
     Q_PROPERTY(QString title READ getTitle WRITE setTitle)
@@ -97,7 +97,6 @@ class TrackInfoObject : public QObject {
     Q_PROPERTY(QString key READ getKeyText WRITE setKeyText)
     Q_PROPERTY(int duration READ getDuration WRITE setDuration)
     Q_PROPERTY(QString durationFormatted READ getDurationStr STORED false)
-
 
 
     TrackRef getTrackRef() const;
@@ -239,12 +238,6 @@ class TrackInfoObject : public QObject {
 
     bool isDirty();
 
-    // Returns true if the track location has changed
-    bool locationChanged();
-
-    // Set the track's full file path
-    void setLocation(const QString& location);
-
     // Get the track's Beats list
     BeatsPointer getBeats() const;
 
@@ -320,9 +313,6 @@ class TrackInfoObject : public QObject {
     // Flag that indicates whether or not the TIO has changed. This is used by
     // TrackDAO to determine whether or not to write the Track back.
     bool m_bDirty;
-
-    // Special flag for telling if the track location was changed.
-    bool m_bLocationChanged;
 
     // The track's reference
     TrackRef m_trackRef;

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -99,36 +99,19 @@ class TrackInfoObject : public QObject {
     Q_PROPERTY(QString durationFormatted READ getDurationStr STORED false)
 
 
-    // Returns absolute path to the file, including the filename.
+
+    TrackRef getTrackRef() const;
+
+    // Some convenience functions for backward compatibility
+    // that return TrackRef properties.
+    TrackId getId() const {
+        return getTrackRef().getId();
+    }
     QString getLocation() const {
         return getTrackRef().getLocation();
     }
-    QString getCanonicalLocation() const {
-        return getTrackRef().getCanonicalLocation();
-    }
-    QFileInfo getFileInfo() const {
-        return getTrackRef().createFileInfo();
-    }
 
     SecurityTokenPointer getSecurityToken();
-
-    // Returns the absolute path to the directory containing the file
-    QString getDirectory() const {
-        return TrackRef::toDirectory(getFileInfo());
-    }
-    // Returns the filename of the file.
-    QString getFilename() const {
-        return TrackRef::toFileName(getFileInfo());
-    }
-    // Returns the length of the file in bytes
-    int getLength() const {
-        return TrackRef::toFileSize(getFileInfo());
-    }
-    // Returns whether the file exists on disk or not. Updated as of the time
-    // the TrackInfoObject is created, or when setLocation() is called.
-    bool exists() const {
-        return getFileInfo().exists();
-    }
 
     // Returns ReplayGain
     float getReplayGain() const;
@@ -173,18 +156,6 @@ class TrackInfoObject : public QObject {
 
     QDateTime getDateAdded() const;
     void setDateAdded(const QDateTime& dateAdded);
-
-    // Returns file modified datetime. Limited by the accuracy of what Qt
-    // QFileInfo gives us.
-    QDateTime getFileModifiedTime() const {
-        return TrackRef::toFileLastModifiedAt(getFileInfo());
-    }
-
-    // Returns file creation datetime. Limited by the accuracy of what Qt
-    // QFileInfo gives us.
-    QDateTime getFileCreationTime() const {
-        return TrackRef::toFileCreatedAt(getFileInfo());
-    }
 
     // Getter/Setter methods for metadata
     // Return title
@@ -235,12 +206,6 @@ class TrackInfoObject : public QObject {
     void setPlayedAndUpdatePlaycount(bool);
     // Set played status without affecting the playcount
     void setPlayed(bool bPlayed);
-
-    TrackRef getTrackRef() const;
-
-    TrackId getId() const {
-        return getTrackRef().getId();
-    }
 
     // Returns rating
     int getRating() const;

--- a/src/util/dbid.h
+++ b/src/util/dbid.h
@@ -95,7 +95,7 @@ public:
         return os << dbId.m_value;
     }
 
-    friend QDebug& operator<<(QDebug& qDebug, const DbId& dbId) {
+    friend QDebug operator<<(QDebug qDebug, const DbId& dbId) {
         return qDebug << dbId.m_value;
     }
 

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -214,7 +214,7 @@ void WCoverArt::mousePressEvent(QMouseEvent* event) {
     }
 
     if (event->button() == Qt::RightButton && m_loadedTrack) { // show context-menu
-        m_pMenu->setCoverArt(m_loadedTrack, m_lastRequestedCover);
+        m_pMenu->setCoverArt(m_loadedTrack->getTrackRef(), m_lastRequestedCover);
         m_pMenu->popup(event->globalPos());
     } else if (event->button() == Qt::LeftButton) { // init/close fullsize cover
         if (m_pDlgFullSize->isVisible()) {

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -33,12 +33,12 @@ WCoverArtLabel::~WCoverArtLabel() {
     delete m_pDlgFullSize;
 }
 
-void WCoverArtLabel::setCoverArt(TrackPointer pTrack, const CoverInfo& info, QPixmap px) {
+void WCoverArtLabel::setCoverArt(const TrackRef& trackRef, const CoverInfo& info, QPixmap px) {
     qDebug() << "WCoverArtLabel::setCoverArt" << info << px.size();
-    m_pCoverMenu->setCoverArt(pTrack, info);
+    m_pCoverMenu->setCoverArt(trackRef, info);
 
+    m_trackRef = trackRef;
     m_coverInfo = info;
-    m_pTrack = pTrack;
 
     if (px.isNull()) {
         setPixmap(m_defaultCover);

--- a/src/widget/wcoverartlabel.h
+++ b/src/widget/wcoverartlabel.h
@@ -15,7 +15,7 @@ class WCoverArtLabel : public QLabel {
     WCoverArtLabel(QWidget* parent = 0);
     virtual ~WCoverArtLabel();
 
-    void setCoverArt(TrackPointer pTrack, const CoverInfo& info, QPixmap px);
+    void setCoverArt(const TrackRef& trackRef, const CoverInfo& info, QPixmap px);
 
   signals:
     void coverArtSelected(const CoverArt& art);
@@ -29,7 +29,7 @@ class WCoverArtLabel : public QLabel {
       void slotCoverMenu(const QPoint& pos);
 
   private:
-    TrackPointer m_pTrack;
+    TrackRef m_trackRef;
     CoverInfo m_coverInfo;
     WCoverArtMenu* m_pCoverMenu;
     DlgCoverArtFullSize* m_pDlgFullSize;

--- a/src/widget/wcoverartmenu.cpp
+++ b/src/widget/wcoverartmenu.cpp
@@ -27,14 +27,14 @@ void WCoverArtMenu::createActions() {
     connect(m_pUnset, SIGNAL(triggered()), this, SLOT(slotUnset()));
     addAction(m_pUnset);
 
-    m_pReload = new QAction(tr("Reload from track/folder",
-            "reload cover art from track metadata or folder"), this);
+    m_pReload = new QAction(tr("Reload from file/folder",
+            "reload cover art from file metadata or folder"), this);
     connect(m_pReload, SIGNAL(triggered()), this, SIGNAL(reloadCoverArt()));
     addAction(m_pReload);
 }
 
-void WCoverArtMenu::setCoverArt(TrackPointer pTrack, const CoverInfo& info) {
-    m_pTrack = pTrack;
+void WCoverArtMenu::setCoverArt(const TrackRef& trackRef, const CoverInfo& info) {
+    m_trackRef = trackRef;
     m_coverInfo = info;
 }
 
@@ -43,8 +43,8 @@ void WCoverArtMenu::slotChange() {
     QString initialDir;
 
     QFileInfo track;
-    if (m_pTrack) {
-        track = m_pTrack->getFileInfo();
+    if (m_trackRef.hasLocation()) {
+        track = m_trackRef.createFileInfo();
     } else if (!m_coverInfo.trackLocation.isEmpty()) {
         track = QFileInfo(m_coverInfo.trackLocation);
     }

--- a/src/widget/wcoverartmenu.h
+++ b/src/widget/wcoverartmenu.h
@@ -20,7 +20,7 @@ class WCoverArtMenu : public QMenu {
     WCoverArtMenu(QWidget *parent = 0);
     virtual ~WCoverArtMenu();
 
-    void setCoverArt(TrackPointer pTrack, const CoverInfo& info);
+    void setCoverArt(const TrackRef& trackRef, const CoverInfo& info);
 
   signals:
     void coverArtSelected(const CoverArt& art);
@@ -37,7 +37,7 @@ class WCoverArtMenu : public QMenu {
     QAction* m_pReload;
     QAction* m_pUnset;
 
-    TrackPointer m_pTrack;
+    TrackRef m_trackRef;
     CoverInfo m_coverInfo;
 };
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -893,7 +893,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
             last.row(), m_iTrackLocationColumn).data().toString();
         info.coverLocation = last.sibling(
             last.row(), m_iCoverLocationColumn).data().toString();
-        m_pCoverMenu->setCoverArt(TrackPointer(), info);
+        m_pCoverMenu->setCoverArt(TrackRef(), info);
         m_pMenu->addMenu(m_pCoverMenu);
     }
 


### PR DESCRIPTION
My next attempt to reduce the complexity of TrackInfoObject and a prerequisite for caching. TrackRef encapsulates all identifying properties of TrackInfoObject:

TrackRef = Track Location (absolute + canonical) + TrackId

The implementation contains lots of DEBUG_ASSERTs to verify that the properties are always consistent and are never modified in an uncontrolled way.

From the class header:
// A track in the library is identified by a location and an id.
// The location is mandatory to identify the file, whereas the id
// only exists after the track has been inserted into the database.
//
// The logical reference to the track's file is referred to as its
// "location". The location of each track must be unique inside the
// library, i.e. each location identifies a single track. The location
// contains an absolute path to the file.
//
// Different locations might reference the same file on disk. In order
// to track which files are in use at runtime we also need to reference
// tracks by their "canonical location". Each file has a unique canonical
// location that is determined at runtime. The canonical location is
// a transient property that may vary between different executions of the
// application, but must not change during a single execution. It is
// obtained by removing all redundancies from and resolving all symbolic
// links in the location.
