### PR TITLE
Build fix: "s:qDebug:qdebug" since it is already a macro.

### DIFF
--- a/src/util/dbid.h
+++ b/src/util/dbid.h
@@ -95,8 +95,8 @@ public:
         return os << dbId.m_value;
     }
 
-    friend QDebug& operator<<(QDebug& qDebug, const DbId& dbId) {
-        return qDebug << dbId.m_value;
+    friend QDebug& operator<<(QDebug& qdebug, const DbId& dbId) {
+        return qdebug << dbId.m_value;
     }
 
     friend uint qHash(const DbId& dbId) {


### PR DESCRIPTION
Fixes:
scons -j1 prefix=/usr optimize=9 vinylcontrol=1 ffmpeg=0 flac=1 m4a=1
mad=1 modplug=1 ogg=1 opus=1 sndfile=1 faad=1 shoutcast=1 ipod=0
hss1394=0 hid=1 bulk=1 vamp=1 wv=1 asmlib=1 qdebug=0 verbose=0
perftools=1

[CXX] src/analyserbeats.cpp
In file included from /usr/include/QtCore/qalgorithms.h:45:0,
                 from /usr/include/QtCore/qdebug.h:45,
                 from /usr/include/QtCore/QtDebug:1,
                 from src/analyserbeats.cpp:8:
/usr/include/QtCore/qdebug.h:284:16: error: expected ',' or '...' before
'while'
 #define qDebug QT_NO_QDEBUG_MACRO
                ^
src/util/dbid.h:98:39: note: in expansion of macro 'qDebug'
     friend QDebug& operator<<(QDebug& qDebug, const DbId& dbId) {
                                       ^
In file included from src/track/trackid.h:5:0,
                 from src/library/dao/cue.h:10,
                 from src/trackinfoobject.h:32,
                 from src/analyserbeats.cpp:13:
src/util/dbid.h:98:63: error: 'QDebug& operator<<(QDebug&)' must take
exactly two arguments
     friend QDebug& operator<<(QDebug& qDebug, const DbId& dbId) {
                                                               ^
scons: **\* [lin64_build/analyserbeats.o] Error 1
