### PR TITLE
Build fix: openSUSE fails due to -Wreturn-type [1.12 branch].

### DIFF
--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -11,9 +11,8 @@ QString sourceToString(CoverInfo::Source source) {
             return "GUESSED";
         case CoverInfo::USER_SELECTED:
             return "USER_SELECTED";
-        default:
-            return "INVALID INFO VALUE";
     }
+    return "INVALID INFO VALUE";
 }
 
 QString typeToString(CoverInfo::Type type) {
@@ -24,9 +23,8 @@ QString typeToString(CoverInfo::Type type) {
             return "METADATA";
         case CoverInfo::FILE:
             return "FILE";
-        default:
-            return "INVALID TYPE VALUE";
     }
+    return "INVALID TYPE VALUE";
 }
 
 QDebug operator<<(QDebug dbg, const CoverInfo& info) {


### PR DESCRIPTION
-Wreturn-type is part of -Wall:

build/depends.py:1055:            build.env.Append(CCFLAGS='-Wall')

openSUSE doesn't allow to build packages with such warnings.
