### PR TITLE
Invalid iterator use

### DIFF
--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -523,12 +523,13 @@ void BeatMap::translate(double dNumSamples) {
 
     double dNumFrames = samplesToFrames(dNumSamples);
     for (BeatList::iterator it = m_beats.begin();
-         it != m_beats.end(); ++it) {
+         it != m_beats.end(); ) {
         double newpos = it->frame_position() + dNumFrames;
         if (newpos >= 0) {
             it->set_frame_position(newpos);
+            ++it;
         } else {
-            m_beats.erase(it);
+            it = m_beats.erase(it);
         }
     }
     onBeatlistChanged();


### PR DESCRIPTION
Iterator it was used incase it has been erased.
This might lead to unexpected situations in rare cases.

You have to reassign the value after erasing it.

http://stackoverflow.com/questions/4645705/vector-erase-iterator states that it is better to count++ it in the loop body, if an iterator might be erased.
