### PR TITLE
Enable utf16 files on windows

### DIFF
--- a/build/features.py
+++ b/build/features.py
@@ -486,7 +486,7 @@ class WavPack(Feature):
     def configure(self, build, conf):
         if not self.enabled(build):
             return
-        have_wv = conf.CheckLib(['wavpack', 'wv'], autoadd=False)
+        have_wv = conf.CheckLib(['wavpack', 'wv'], autoadd=True)
         if not have_wv:
             raise Exception(
                 'Could not find libwavpack, libwv or its development headers.')

--- a/plugins/soundsourcem4a/m4a/ip.h
+++ b/plugins/soundsourcem4a/m4a/ip.h
@@ -69,7 +69,7 @@ struct input_plugin_data {
 struct input_plugin_data {
 	// filled by ip-layer
 //	QString filename;
-	char *filename;
+	char *filenameUtf8;
 	int fd;
 
 	unsigned int remote : 1;

--- a/plugins/soundsourcem4a/m4a/mp4-mixxx.cpp
+++ b/plugins/soundsourcem4a/m4a/mp4-mixxx.cpp
@@ -207,7 +207,7 @@ static int mp4_open(struct input_plugin_data *ip_data)
 
     /* init decoder according to mpeg-4 audio config */
     if (faacDecInit2(priv->decoder, buf, buf_size,
-            (SAMPLERATE_TYPE*)&priv->sample_rate, &priv->channels) < 0) {
+            &priv->sample_rate, &priv->channels) < 0) {
         free(buf);
         goto out;
     }

--- a/plugins/soundsourcem4a/m4a/mp4-mixxx.cpp
+++ b/plugins/soundsourcem4a/m4a/mp4-mixxx.cpp
@@ -170,9 +170,9 @@ static int mp4_open(struct input_plugin_data *ip_data)
 
     /* open mpeg-4 file, check for >= ver 1.9.1 */
 #if MP4V2_PROJECT_version_hex <= 0x00010901
-    priv->mp4.handle = MP4Read(ip_data->filename, 0);
+    priv->mp4.handle = MP4Read(ip_data->filenameUtf8, 0);
 #else
-    priv->mp4.handle = MP4Read(ip_data->filename);
+    priv->mp4.handle = MP4Read(ip_data->filenameUtf8);
 #endif
     if (!priv->mp4.handle) {
         qDebug() << "MP4Read failed";

--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -48,10 +48,8 @@ SoundSourceM4A::SoundSourceM4A(QString qFileName)
 }
 
 SoundSourceM4A::~SoundSourceM4A() {
-    if (ipd.filename) {
-        delete [] ipd.filename;
-        ipd.filename = NULL;
-    }
+    delete [] ipd.filenameUtf8;
+    ipd.filenameUtf8 = NULL;
 
     if (mp4file != MP4_INVALID_FILE_HANDLE) {
         mp4_close(&ipd);
@@ -73,11 +71,16 @@ Result SoundSourceM4A::open()
 int SoundSourceM4A::initializeDecoder()
 {
     // Copy QString to char[] buffer for mp4_open to read from later
-    const QByteArray qbaFileName(getFilename().toLocal8Bit());
+    // From mp4v2/file.h:
+    //  * On Windows, this should be a UTF-8 encoded string.
+    //  * On other platforms, it should be an 8-bit encoding that is
+    //  * appropriate for the platform, locale, file system, etc.
+    //  * (prefer to use UTF-8 when possible).
+    const QByteArray qbaFileName(getFilename().toUtf8());
     int bytes = qbaFileName.length() + 1;
-    ipd.filename = new char[bytes];
-    strncpy(ipd.filename, qbaFileName.constData(), bytes);
-    ipd.filename[bytes-1] = '\0';
+    ipd.filenameUtf8 = new char[bytes];
+    strncpy(ipd.filenameUtf8, qbaFileName.constData(), bytes);
+    ipd.filenameUtf8[bytes-1] = '\0';
     ipd.remote = false; // File is not an stream
     // The file was loading and failing erratically because
     // ipd.remote was an in an uninitialized state, it needed to be

--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -178,8 +178,11 @@ inline long unsigned SoundSourceM4A::length(){
 }
 
 Result SoundSourceM4A::parseHeader(){
+#ifdef _WIN32
+    TagLib::MP4::File f(getFilename().toStdWString().data());
+#else
     TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
-
+#endif
     if (!readFileHeader(this, f)) {
         return ERR;
     }
@@ -201,7 +204,11 @@ Result SoundSourceM4A::parseHeader(){
 }
 
 QImage SoundSourceM4A::parseCoverArt() {
+#ifdef _WIN32
+    TagLib::MP4::File f(getFilename().toStdWString().data());
+#else
     TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
+#endif
     TagLib::MP4::Tag *mp4(f.tag());
     if (mp4) {
         return getCoverInMP4Tag(*mp4);

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -92,7 +92,6 @@ Result SoundSourceMediaFoundation::open()
         qDebug() << "open()" << getFilename();
     }
 
-    QString qurlStr(getFilename());
     int wcFilenameLength(getFilename().toWCharArray(m_wcFilename));
     // toWCharArray does not append a null terminator to the string!
     m_wcFilename[wcFilenameLength] = '\0';
@@ -376,9 +375,7 @@ inline unsigned long SoundSourceMediaFoundation::length()
 
 Result SoundSourceMediaFoundation::parseHeader()
 {
-    // Must be toLocal8Bit since Windows fopen does not do UTF-8
-    TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
-
+    TagLib::MP4::File f(getFilename().toStdWString().data());
     if (!readFileHeader(this, f)) {
         return ERR;
     }
@@ -401,7 +398,7 @@ Result SoundSourceMediaFoundation::parseHeader()
 
 QImage SoundSourceMediaFoundation::parseCoverArt() {
     setType("m4a");
-    TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
+    TagLib::MP4::File f(getFilename().toStdWString().data());
     TagLib::MP4::Tag *mp4(f.tag());
     if (mp4) {
         return Mixxx::getCoverInMP4Tag(*mp4);

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -4,6 +4,7 @@
 //format_samples adapted from cmus (Peter Lemenkov)
 
 #include <QtDebug>
+#include <QFile>
 
 #include "soundsourcewv.h"
 #include "soundsourcetaglib.h"
@@ -12,19 +13,42 @@
 #include <taglib/wavpackfile.h>
 namespace Mixxx {
 
+//static
+WavpackStreamReader SoundSourceWV::s_streamReader = {
+    SoundSourceWV::ReadBytesCallback,
+    SoundSourceWV::GetPosCallback,
+    SoundSourceWV::SetPosAbsCallback,
+    SoundSourceWV::SetPosRelCallback,
+    SoundSourceWV::PushBackByteCallback,
+    SoundSourceWV::GetlengthCallback,
+    SoundSourceWV::CanSeekCallback,
+    SoundSourceWV::WriteBytesCallback
+};
+
 SoundSourceWV::SoundSourceWV(QString qFilename)
     : SoundSource(qFilename),
     filewvc(NULL),
     Bps(0),
-    filelength(0) {
+    filelength(0),
+    m_pWVFile(NULL),
+    m_pWVCFile(NULL) {
     setType("wv");
 }
-
 
 SoundSourceWV::~SoundSourceWV(){
    if (filewvc) {
     WavpackCloseFile(filewvc);
-    filewvc=NULL;
+    filewvc = NULL;
+   }
+   if (m_pWVFile) {
+       m_pWVFile->close();
+       delete m_pWVFile;
+       m_pWVFile = NULL;
+   }
+   if (m_pWVCFile) {
+       m_pWVCFile->close();
+       delete m_pWVCFile;
+       m_pWVCFile = NULL;
    }
 }
 
@@ -39,9 +63,20 @@ QList<QString> SoundSourceWV::supportedFileExtensions()
 Result SoundSourceWV::open()
 {
     QByteArray qBAFilename(getFilename().toLocal8Bit());
-    char msg[80];   //hold possible error message
+    char msg[80];   // hold possible error message
 
-    filewvc = WavpackOpenFileInput(qBAFilename.constData(), msg, OPEN_2CH_MAX | OPEN_WVC,0);
+    // We use WavpackOpenFileInputEx to support Unicode paths on windows
+    // http://www.wavpack.com/lib_use.txt
+    m_pWVFile = new QFile(getFilename());
+    m_pWVFile->open(QFile::ReadOnly);
+    QString correctionfileName(getFilename() + "c");
+    if (QFile::exists(correctionfileName)) {
+        // If there is a correction file, open it as well
+        m_pWVCFile = new QFile(correctionfileName);
+        m_pWVCFile->open(QFile::ReadOnly);
+    }
+    filewvc = WavpackOpenFileInputEx(&s_streamReader, m_pWVFile, m_pWVCFile, msg,
+             OPEN_2CH_MAX | OPEN_WVC, 0);
     if (!filewvc) {
         qDebug() << "SSWV::open: failed to open file : "<< msg;
         return ERR;
@@ -49,7 +84,10 @@ Result SoundSourceWV::open()
     if (WavpackGetMode(filewvc) & MODE_FLOAT) {
         qDebug() << "SSWV::open: cannot load 32bit float files";
         WavpackCloseFile(filewvc);
-        filewvc=NULL;
+        filewvc = NULL;
+        m_pWVFile->close();
+        delete m_pWVFile;
+        m_pWVFile = NULL;
         return ERR;
     }
     // wavpack_open succeeded -> populate variables
@@ -57,8 +95,9 @@ Result SoundSourceWV::open()
     setSampleRate(WavpackGetSampleRate(filewvc));
     setChannels(WavpackGetReducedChannels(filewvc));
     Bps=WavpackGetBytesPerSample(filewvc);
-    qDebug () << "SSWV::open: opened filewvc with filelength: "<<filelength<<" SampleRate: " << getSampleRate()
-        << " channels: " << getChannels() << " bytes per samp: "<<Bps;
+    qDebug() << "SSWV::open: opened filewvc with filelength: " << filelength
+            << " SampleRate: " << getSampleRate() << " channels: "
+            << getChannels() << " bytes per samp: " << Bps;
     if (Bps>2) {
         qDebug() << "SSWV::open: warning: input file has > 2 bytes per sample, will be truncated to 16bits";
     }
@@ -83,13 +122,13 @@ unsigned SoundSourceWV::read(volatile unsigned long size, const SAMPLE* destinat
 
     //tempbuffer is fixed size : WV_BUF_LENGTH of uint32
     while (sampsread != size) {
-        timesamps=(size-sampsread)>>1;      //timesamps still remaining
-        if (timesamps > (WV_BUF_LENGTH / getChannels())) {  //if requested size requires more than one buffer filling
-            timesamps=(WV_BUF_LENGTH / getChannels());      //tempbuffer must hold (timesamps * channels) samples
+        timesamps = (size-sampsread) >> 1; // timesamps still remaining
+        if (timesamps > (unsigned long)(WV_BUF_LENGTH / getChannels())) {  //if requested size requires more than one buffer filling
+            timesamps = (WV_BUF_LENGTH / getChannels());      //tempbuffer must hold (timesamps * channels) samples
             qDebug() << "SSWV::read : performance warning, size requested > buffer size !";
         }
 
-        tsdone=WavpackUnpackSamples(filewvc, tempbuffer, timesamps);    //fill temp buffer with timesamps*4bytes*channels
+        tsdone = WavpackUnpackSamples(filewvc, tempbuffer, timesamps);    //fill temp buffer with timesamps*4bytes*channels
                 //data is right justified, format_samples() fixes that.
 
         SoundSourceWV::format_samples(Bps, (char *) (dest + (sampsread>>1) * getChannels()), tempbuffer, tsdone*getChannels());
@@ -197,6 +236,102 @@ void SoundSourceWV::format_samples(int Bps, char *dst, int32_t *src, uint32_t co
     }
 
     return;
+}
+
+//static
+int32_t SoundSourceWV::ReadBytesCallback(void* id, void* data, int bcount)
+{
+    QFile* pFile = static_cast<QFile*>(id);
+    if (!pFile) {
+        return 0;
+    }
+    return pFile->read((char*)data, bcount);
+}
+
+
+// static
+uint32_t SoundSourceWV::GetPosCallback(void *id)
+{
+    QFile* pFile = static_cast<QFile*>(id);
+    if (!pFile) {
+        return 0;
+    }
+    pFile->reset();
+    return pFile->pos();
+}
+
+//static
+int SoundSourceWV::SetPosAbsCallback(void* id, unsigned int pos)
+{
+    QFile* pFile = static_cast<QFile*>(id);
+    if (!pFile) {
+        return 0;
+    }
+    pFile->reset();
+    return pFile->seek(pos) ? 0 : -1;
+}
+
+//static
+int SoundSourceWV::SetPosRelCallback(void *id, int delta, int mode)
+{
+    QFile* pFile = static_cast<QFile*>(id);
+    if (!pFile) {
+        return 0;
+    }
+
+    switch(mode) {
+    case SEEK_SET:
+        pFile->reset();
+        return pFile->seek(delta) ? 0 : -1;
+    case SEEK_CUR:
+        return pFile->seek(delta) ? 0 : -1;
+    case SEEK_END:
+        pFile->reset();
+        return pFile->seek(pFile->size() + delta) ? 0 : -1;
+    default:
+        return -1;
+    }
+}
+
+//static
+int SoundSourceWV::PushBackByteCallback(void* id, int c)
+{
+    QFile* pFile = static_cast<QFile*>(id);
+    if (!pFile) {
+        return 0;
+    }
+    pFile->ungetChar((char)c);
+    return 1;
+}
+
+//static
+uint32_t SoundSourceWV::GetlengthCallback(void* id)
+{
+    QFile* pFile = static_cast<QFile*>(id);
+    if (!pFile) {
+        return 0;
+    }
+    return pFile->size();
+}
+
+//static
+int SoundSourceWV::CanSeekCallback(void *id)
+{
+    QFile* pFile = static_cast<QFile*>(id);
+    if (!pFile) {
+        return 0;
+    }
+    return pFile->isSequential() ? 0 : 1;
+}
+
+//static
+int32_t SoundSourceWV::WriteBytesCallback(void* id, void* data, int32_t bcount)
+{
+    QFile* pFile = static_cast<QFile*>(id);
+    if (!pFile) {
+        return 0;
+    }
+    return (int32_t)pFile->write((char*)data, bcount);
 }
 
 }  // namespace Mixxx

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -256,7 +256,6 @@ uint32_t SoundSourceWV::GetPosCallback(void *id)
     if (!pFile) {
         return 0;
     }
-    pFile->reset();
     return pFile->pos();
 }
 

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -121,9 +121,11 @@ inline long unsigned SoundSourceWV::length(){
 
 
 Result SoundSourceWV::parseHeader() {
-    const QByteArray qBAFilename(getFilename().toLocal8Bit());
-    TagLib::WavPack::File f(qBAFilename.constData());
-
+#ifdef _WIN32
+    TagLib::WavPack::File f(getFilename().toStdWString().data());
+#else
+    TagLib::WavPack::File f(getFilename().toLocal8Bit().constData());
+#endif
     if (!readFileHeader(this, f)) {
         return ERR;
     }
@@ -145,7 +147,11 @@ Result SoundSourceWV::parseHeader() {
 }
 
 QImage SoundSourceWV::parseCoverArt() {
+#ifdef _WIN32
+    TagLib::WavPack::File f(getFilename().toStdWString().data());
+#else
     TagLib::WavPack::File f(getFilename().toLocal8Bit().constData());
+#endif
     TagLib::APE::Tag *ape = f.APETag();
     if (ape) {
         return Mixxx::getCoverInAPETag(*ape);

--- a/plugins/soundsourcewv/soundsourcewv.h
+++ b/plugins/soundsourcewv/soundsourcewv.h
@@ -19,6 +19,8 @@
 #define MY_EXPORT
 #endif
 
+class QFile;
+
 #define WV_BUF_LENGTH 65536
 
 namespace Mixxx {
@@ -35,11 +37,23 @@ class SoundSourceWV : public SoundSource {
   QImage parseCoverArt();
   static QList<QString> supportedFileExtensions();
  private:
-  WavpackContext * filewvc; //works as a file handle to access the wv file.
+  static int32_t ReadBytesCallback(void* id, void* data, int bcount);
+  static uint32_t GetPosCallback(void* id);
+  static int SetPosAbsCallback(void* id, unsigned int pos);
+  static int SetPosRelCallback(void* id, int delta, int mode);
+  static int PushBackByteCallback(void* id, int c);
+  static uint32_t GetlengthCallback(void* id);
+  static int CanSeekCallback(void* id);
+  static int32_t WriteBytesCallback(void* id, void* data, int32_t bcount);
+  static WavpackStreamReader s_streamReader;
+
+  WavpackContext* filewvc; // works as a file handle to access the wv file.
   int Bps;
   unsigned long filelength;
-  int32_t tempbuffer[WV_BUF_LENGTH];	//hax ! legacy from cmus. this is 64k*4bytes.
-  void format_samples(int, char *, int32_t *, uint32_t);
+  int32_t tempbuffer[WV_BUF_LENGTH];	// hax ! legacy from cmus. this is 64k*4bytes.
+  void format_samples(int, char*, int32_t*, uint32_t);
+  QFile* m_pWVFile;
+  QFile* m_pWVCFile;
 };
 
 

--- a/src/soundsourceffmpeg.cpp
+++ b/src/soundsourceffmpeg.cpp
@@ -554,7 +554,11 @@ Result SoundSourceFFmpeg::parseHeader() {
     bool is_aiff = location.endsWith("aiff", Qt::CaseInsensitive);
 
     if (is_flac) {
+#ifdef _WIN32
+        TagLib::FLAC::File f(getFilename().toStdWString().data());
+#else
         TagLib::FLAC::File f(qBAFilename.constData());
+#endif
         if (!readFileHeader(this, f)) {
             return ERR;
         }
@@ -577,7 +581,11 @@ Result SoundSourceFFmpeg::parseHeader() {
             }
         }
     } else if (is_wav) {
+#ifdef _WIN32
+        TagLib::RIFF::WAV::File f(getFilename().toStdWString().data());
+#else
         TagLib::RIFF::WAV::File f(qBAFilename.constData());
+#endif
         if (!readFileHeader(this, f)) {
             return ERR;
         }
@@ -605,7 +613,11 @@ Result SoundSourceFFmpeg::parseHeader() {
 
     } else if (is_aiff) {
         // Try AIFF
+#ifdef _WIN32
+        TagLib::RIFF::AIFF::File f(getFilename().toStdWString().data());
+#else
         TagLib::RIFF::AIFF::File f(qBAFilename.constData());
+#endif
         if (!readFileHeader(this, f)) {
             return ERR;
         }
@@ -616,8 +628,11 @@ Result SoundSourceFFmpeg::parseHeader() {
             return ERR;
         }
     } else if (is_mp3) {
+#ifdef _WIN32
+        TagLib::MPEG::File f(getFilename().toStdWString().data());
+#else
         TagLib::MPEG::File f(qBAFilename.constData());
-
+#endif
         if (!readFileHeader(this, f)) {
             return ERR;
         }
@@ -641,8 +656,11 @@ Result SoundSourceFFmpeg::parseHeader() {
             }
         }
     } else if (is_ogg) {
+#ifdef _WIN32
+        TagLib::Ogg::Vorbis::File f(getFilename().toStdWString().data());
+#else
         TagLib::Ogg::Vorbis::File f(qBAFilename.constData());
-
+#endif
         if (!readFileHeader(this, f)) {
             return ERR;
         }
@@ -660,8 +678,11 @@ Result SoundSourceFFmpeg::parseHeader() {
             }
         }
     } else if (is_mp4) {
-        TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
-
+#ifdef _WIN32
+        TagLib::MP4::File f(getFilename().toStdWString().data());
+#else
+        TagLib::MP4::File f(qBAFilename.constData());
+#endif
         if (!readFileHeader(this, f)) {
            return ERR;
         }
@@ -764,7 +785,11 @@ QImage SoundSourceFFmpeg::parseCoverArt() {
             coverArt = Mixxx::getCoverInXiphComment(*xiph);
         }
    } else if (getType() == "mp4" || getType() == "m4a") {
-        TagLib::MP4::File f(getFilename().toLocal8Bit().constData());
+#ifdef _WIN32
+        TagLib::MP4::File f(getFilename().toStdWString().data());
+#else
+        TagLib::MP4::File f(qBAFilename.constData());
+#endif
         TagLib::MP4::Tag *mp4(f.tag());
         if (mp4) {
             coverArt = Mixxx::getCoverInMP4Tag(*mp4);

--- a/src/soundsourceffmpeg.cpp
+++ b/src/soundsourceffmpeg.cpp
@@ -378,7 +378,7 @@ Result SoundSourceFFmpeg::open() {
 
     QByteArray qBAFilename = getFilename().toLocal8Bit();
 
-    qDebug() << "New SoundSourceFFmpeg :" << qBAFilename;
+    qDebug() << "New SoundSourceFFmpeg :" << getFilename();
 
     m_pFormatCtx = avformat_alloc_context();
 
@@ -386,10 +386,17 @@ Result SoundSourceFFmpeg::open() {
     m_pFormatCtx->max_analyze_duration = 999999999;
 #endif
 
+#ifdef _WIN32
+#warning No Unicode filnames supported
+// Solution: use register register_protocol(&ufile_protocol); from:
+// https://github.com/lalinsky/picard-debian/blob/9be0dfeec7da9af5d01bc11aa530f873511a59b0/picard/musicdns/avcodec.c
+#endif
+
     // Open file and make m_pFormatCtx
-    if (avformat_open_input(&m_pFormatCtx, qBAFilename.constData(), NULL,
-                            &l_iFormatOpts)!=0) {
-        qDebug() << "av_open_input_file: cannot open" << qBAFilename;
+    if (avformat_open_input(&m_pFormatCtx,
+            getFilename().toLocal8Bit().constData(), NULL, &l_iFormatOpts)
+            != 0) {
+        qDebug() << "av_open_input_file: cannot open" << getFilename();
         return ERR;
     }
 
@@ -401,7 +408,7 @@ Result SoundSourceFFmpeg::open() {
 
     // Retrieve stream information
     if (avformat_find_stream_info(m_pFormatCtx, NULL)<0) {
-        qDebug() << "av_find_stream_info: cannot open" << qBAFilename;
+        qDebug() << "av_find_stream_info: cannot open" << getFilename();
         return ERR;
     }
 
@@ -419,7 +426,7 @@ Result SoundSourceFFmpeg::open() {
         }
     if (m_iAudioStream==-1) {
         qDebug() << "ffmpeg: cannot find an audio stream: cannot open"
-                 << qBAFilename;
+                 << getFilename();
         return ERR;
     }
 
@@ -428,12 +435,12 @@ Result SoundSourceFFmpeg::open() {
 
     // Find the decoder for the audio stream
     if (!(m_pCodec=avcodec_find_decoder(m_pCodecCtx->codec_id))) {
-        qDebug() << "ffmpeg: cannot find a decoder for" << qBAFilename;
+        qDebug() << "ffmpeg: cannot find a decoder for" << getFilename();
         return ERR;
     }
 
     if (avcodec_open2(m_pCodecCtx, m_pCodec, NULL)<0) {
-        qDebug() << "ffmpeg:  cannot open" << qBAFilename;
+        qDebug() << "ffmpeg:  cannot open" << getFilename();
         return ERR;
     }
 
@@ -702,7 +709,11 @@ Result SoundSourceFFmpeg::parseHeader() {
         }
     } else if (is_opus) {
         // If some have too old Taglib it's his own pain
+#ifdef _WIN32
+        TagLib::Ogg::Opus::File f(getFilename().toStdWString().data());
+#else
         TagLib::Ogg::Opus::File f(qBAFilename.constData());
+#endif
 
         if (!readFileHeader(this, f)) {
             return ERR;
@@ -733,7 +744,11 @@ QImage SoundSourceFFmpeg::parseCoverArt() {
     QImage coverArt;
 
     if (getType() == "flac") {
+#ifdef _WIN32
+        TagLib::FLAC::File f(getFilename().toStdWString().data());
+#else
         TagLib::FLAC::File f(qBAFilename.constData());
+#endif
         TagLib::ID3v2::Tag* id3v2 = f.ID3v2Tag();
         if (id3v2) {
             coverArt = Mixxx::getCoverInID3v2Tag(*id3v2);
@@ -754,19 +769,32 @@ QImage SoundSourceFFmpeg::parseCoverArt() {
             }
         }
     } else if (getType() == "wav") {
+#ifdef _WIN32
+        TagLib::RIFF::WAV::File f(getFilename().toStdWString().data());
+#else
         TagLib::RIFF::WAV::File f(qBAFilename.constData());
+#endif
         TagLib::ID3v2::Tag* id3v2 = f.tag();
         if (id3v2) {
             coverArt = Mixxx::getCoverInID3v2Tag(*id3v2);
         }
     } else if (getType() == "aiff") {
         // Try AIFF
+#ifdef _WIN32
+        TagLib::RIFF::AIFF::File f(getFilename().toStdWString().data());
+#else
         TagLib::RIFF::AIFF::File f(qBAFilename.constData());
+#endif
         TagLib::ID3v2::Tag* id3v2 = f.tag();
         if (id3v2) {
             coverArt = Mixxx::getCoverInID3v2Tag(*id3v2);
         }
     } else if (getType() == "mp3") {
+#ifdef _WIN32
+        TagLib::MPEG::File f(getFilename().toStdWString().data());
+#else
+        TagLib::MPEG::File f(qBAFilename.constData());
+#endif
         TagLib::MPEG::File f(getFilename().toLocal8Bit().constData());
         TagLib::ID3v2::Tag* id3v2 = f.ID3v2Tag();
         if (id3v2) {
@@ -779,7 +807,11 @@ QImage SoundSourceFFmpeg::parseCoverArt() {
             }
         }
     } else if (getType() == "ogg" || getType() == "opus") {
-        TagLib::Ogg::Vorbis::File f(getFilename().toLocal8Bit().constData());
+#ifdef _WIN32
+        TagLib::Ogg::Vorbis::File f(getFilename().toStdWString().data());
+#else
+        TagLib::Ogg::Vorbis::File f(qBAFilename.constData());
+#endif
         TagLib::Ogg::XiphComment *xiph = f.tag();
         if (xiph) {
             coverArt = Mixxx::getCoverInXiphComment(*xiph);

--- a/src/soundsourceflac.cpp
+++ b/src/soundsourceflac.cpp
@@ -126,7 +126,8 @@ unsigned int SoundSourceFLAC::read(unsigned long size, const SAMPLE *destination
         if (m_flacBufferLength == 0) {
             i = 0;
             if (!FLAC__stream_decoder_process_single(m_decoder)) {
-                qWarning() << "SSFLAC: decoder_process_single returned false (" << getFilename() << ")";
+                qWarning() << "SSFLAC: decoder_process_single returned false ("
+                           << getFilename() << ")";
                 break;
             } else if (m_flacBufferLength == 0) {
                 // EOF
@@ -155,9 +156,11 @@ inline unsigned long SoundSourceFLAC::length() {
 }
 
 Result SoundSourceFLAC::parseHeader() {
-    const QByteArray qBAFilename(getFilename().toLocal8Bit());
-    TagLib::FLAC::File f(qBAFilename.constData());
-
+#ifdef _WIN32
+    TagLib::FLAC::File f(getFilename().toStdWString().data());
+#else
+    TagLib::FLAC::File f(getFilename().toLocal8Bit().constData());
+#endif
     if (!readFileHeader(this, f)) {
         return ERR;
     }
@@ -184,8 +187,11 @@ Result SoundSourceFLAC::parseHeader() {
 }
 
 QImage SoundSourceFLAC::parseCoverArt() {
-    const QByteArray qBAFilename(getFilename().toLocal8Bit());
-    TagLib::FLAC::File f(qBAFilename.constData());
+#ifdef _WIN32
+    TagLib::FLAC::File f(getFilename().toStdWString().data());
+#else
+    TagLib::FLAC::File f(getFilename().toLocal8Bit().constData());
+#endif
     QImage coverArt;
     TagLib::Ogg::XiphComment *xiph(f.xiphComment());
     if (xiph) {
@@ -258,7 +264,8 @@ FLAC__StreamDecoderSeekStatus SoundSourceFLAC::flacSeek(FLAC__uint64 offset) {
     if (m_file.seek(offset)) {
         return FLAC__STREAM_DECODER_SEEK_STATUS_OK;
     } else {
-        qWarning() << "SSFLAC: An unrecoverable error occurred (" << getFilename() << ")";
+        qWarning() << "SSFLAC: An unrecoverable error occurred ("
+                   << getFilename() << ")";
         return FLAC__STREAM_DECODER_SEEK_STATUS_ERROR;
     }
 }
@@ -359,7 +366,7 @@ void SoundSourceFLAC::flacError(FLAC__StreamDecoderErrorStatus status) {
         break;
     }
     qWarning() << "SSFLAC got error" << error << "from libFLAC for file"
-        << getFilename();
+               << getFilename();
     // not much else to do here... whatever function that initiated whatever
     // decoder method resulted in this error will return an error, and the caller
     // will bail. libFLAC docs say to not close the decoder here -- bkgood

--- a/src/soundsourcemp3.cpp
+++ b/src/soundsourcemp3.cpp
@@ -563,9 +563,11 @@ unsigned SoundSourceMp3::read(unsigned long samples_wanted, const SAMPLE * _dest
 }
 
 Result SoundSourceMp3::parseHeader() {
-    QByteArray qBAFilename(getFilename().toLocal8Bit());
-    TagLib::MPEG::File f(qBAFilename.constData());
-
+#ifdef _WIN32
+    TagLib::MPEG::File f(getFilename().toStdWString().data());
+#else
+    TagLib::MPEG::File f(getFilename().toLocal8Bit().constData());
+#endif
     if (!readFileHeader(this, f)) {
         return ERR;
     }
@@ -594,7 +596,11 @@ Result SoundSourceMp3::parseHeader() {
 
 QImage SoundSourceMp3::parseCoverArt() {
     QImage coverArt;
+#ifdef _WIN32
+    TagLib::MPEG::File f(getFilename().toStdWString().data());
+#else
     TagLib::MPEG::File f(getFilename().toLocal8Bit().constData());
+#endif
     TagLib::ID3v2::Tag* id3v2 = f.ID3v2Tag();
     if (id3v2) {
         coverArt = Mixxx::getCoverInID3v2Tag(*id3v2);

--- a/src/soundsourceoggvorbis.cpp
+++ b/src/soundsourceoggvorbis.cpp
@@ -17,12 +17,15 @@
 #include "soundsourceoggvorbis.h"
 #include "soundsourcetaglib.h"
 #include "sampleutil.h"
+#include "util/math.h"
 
 #include <taglib/vorbisfile.h>
 
 #include <vorbis/codec.h>
 
 #include <QtDebug>
+#include <QFile>
+
 
 #ifdef __WINDOWS__
 #include <io.h>
@@ -50,11 +53,21 @@ inline int getByteOrder() {
    Class for reading Ogg Vorbis
  */
 
+
+//static
+ov_callbacks SoundSourceOggVorbis::s_callbacks = {
+    SoundSourceOggVorbis::ReadCallback,
+    SoundSourceOggVorbis::SeekCallback,
+    SoundSourceOggVorbis::CloseCallback,
+    SoundSourceOggVorbis::TellCallback
+};
+
 SoundSourceOggVorbis::SoundSourceOggVorbis(QString qFilename)
         : Mixxx::SoundSource(qFilename),
           channels(0),
           filelength(0),
-          current_section(0) {
+          current_section(0),
+          m_pFile(NULL) {
     setType("ogg");
     vf.datasource = NULL;
     vf.seekable = 0;
@@ -85,30 +98,21 @@ SoundSourceOggVorbis::~SoundSourceOggVorbis()
     if (filelength > 0) {
         ov_clear(&vf);
     }
+    delete m_pFile;
 }
 
 Result SoundSourceOggVorbis::open() {
-    const QByteArray qBAFilename(getFilename().toLocal8Bit());
-#ifdef __WINDOWS__
-    if(ov_fopen(qBAFilename.constData(), &vf) < 0) {
-        qDebug() << "oggvorbis: Input does not appear to be an Ogg bitstream.";
-        filelength = 0;
-        return ERR;
-    }
-#else
-    FILE *vorbisfile =  fopen(qBAFilename.constData(), "r");
-
-    if (!vorbisfile) {
+    m_pFile = new QFile(getFilename());
+    if(!m_pFile->open(QFile::ReadOnly)) {
         qDebug() << "oggvorbis: cannot open" << getFilename();
+        filelength = 0;
         return ERR;
     }
-
-    if(ov_open(vorbisfile, &vf, NULL, 0) < 0) {
+    if (ov_open_callbacks(m_pFile, &vf, NULL, 0, s_callbacks) < 0) {
         qDebug() << "oggvorbis: Input does not appear to be an Ogg bitstream.";
         filelength = 0;
         return ERR;
     }
-#endif
 
     // lookup the ogg's channels and samplerate
     vorbis_info * vi = ov_info(&vf, -1);
@@ -299,3 +303,61 @@ QList<QString> SoundSourceOggVorbis::supportedFileExtensions()
     list.push_back("ogg");
     return list;
 }
+
+//static
+size_t SoundSourceOggVorbis::ReadCallback(void *ptr, size_t size, size_t nmemb,
+        void *datasource) {
+    if (!size || !nmemb) {
+        return 0;
+    }
+    QFile* pFile = static_cast<QFile*>(datasource);
+    if (!pFile) {
+        return 0;
+    }
+
+    nmemb = math_min<size_t>((pFile->size() - pFile->pos()) / size, nmemb);
+    pFile->read((char*)ptr, nmemb * size);
+    return nmemb;
+}
+
+//static
+int SoundSourceOggVorbis::SeekCallback(void *datasource, ogg_int64_t offset,
+        int whence) {
+    QFile* pFile = static_cast<QFile*>(datasource);
+    if (!pFile) {
+        return 0;
+    }
+
+    switch(whence) {
+    case SEEK_SET:
+        pFile->reset();
+        return pFile->seek(offset) ? 0 : -1;
+    case SEEK_CUR:
+        return pFile->seek(offset) ? 0 : -1;
+    case SEEK_END:
+        pFile->reset();
+        return pFile->seek(pFile->size() + offset) ? 0 : -1;
+    default:
+        return -1;
+    }
+}
+
+//static
+int SoundSourceOggVorbis::CloseCallback(void* datasource) {
+    QFile* pFile = static_cast<QFile*>(datasource);
+    if (!pFile) {
+        return 0;
+    }
+    pFile->close();
+    return 0;
+}
+
+//static
+long SoundSourceOggVorbis::TellCallback(void* datasource) {
+    QFile* pFile = static_cast<QFile*>(datasource);
+    if (!pFile) {
+        return 0;
+    }
+    return pFile->pos();
+}
+

--- a/src/soundsourceoggvorbis.cpp
+++ b/src/soundsourceoggvorbis.cpp
@@ -245,9 +245,11 @@ unsigned SoundSourceOggVorbis::read(volatile unsigned long size, const SAMPLE * 
    Parse the the file to get metadata
  */
 Result SoundSourceOggVorbis::parseHeader() {
-    QByteArray qBAFilename = getFilename().toLocal8Bit();
-    TagLib::Ogg::Vorbis::File f(qBAFilename.constData());
-
+#ifdef _WIN32
+    TagLib::Ogg::Vorbis::File f(getFilename().toStdWString().data());
+#else
+    TagLib::Ogg::Vorbis::File f(getFilename().toLocal8Bit().constData());
+#endif
     if (!readFileHeader(this, f)) {
         return ERR;
     }
@@ -269,7 +271,11 @@ Result SoundSourceOggVorbis::parseHeader() {
 }
 
 QImage SoundSourceOggVorbis::parseCoverArt() {
+#ifdef _WIN32
+    TagLib::Ogg::Vorbis::File f(getFilename().toStdWString().data());
+#else
     TagLib::Ogg::Vorbis::File f(getFilename().toLocal8Bit().constData());
+#endif
     TagLib::Ogg::XiphComment *xiph = f.tag();
     if (xiph) {
         return Mixxx::getCoverInXiphComment(*xiph);

--- a/src/soundsourceoggvorbis.h
+++ b/src/soundsourceoggvorbis.h
@@ -23,6 +23,8 @@
 
 #include "soundsource.h"
 
+class QFile;
+
 class SoundSourceOggVorbis : public Mixxx::SoundSource {
  public:
   explicit SoundSourceOggVorbis(QString qFilename);
@@ -35,10 +37,18 @@ class SoundSourceOggVorbis : public Mixxx::SoundSource {
   QImage parseCoverArt();
   static QList<QString> supportedFileExtensions();
  private:
+  static size_t ReadCallback(void *ptr,
+          size_t size, size_t nmemb, void *datasource);
+  static int SeekCallback(void *datasource, ogg_int64_t offset, int whence);
+  static int CloseCallback(void *datasource);
+  static long TellCallback(void *datasource);
+  static ov_callbacks s_callbacks;
+
   int channels;
   unsigned long filelength;
   OggVorbis_File vf;
   int current_section;
+  QFile* m_pFile;
 };
 
 #endif

--- a/src/soundsourceopus.cpp
+++ b/src/soundsourceopus.cpp
@@ -53,8 +53,17 @@ SoundSourceOpus::~SoundSourceOpus() {
 
 Result SoundSourceOpus::open() {
     int error = 0;
-    const QByteArray qBAFilename(getFilename().toLocal8Bit());
 
+    // From opus/opusfile.h
+    // On Windows, this string must be UTF-8 (to allow access to
+    // files whose names cannot be represented in the current
+    // MBCS code page).
+    // All other systems use the native character encoding.
+#ifdef _WIN32
+    QByteArray qBAFilename = getFilename().toUtf8();
+#else
+    QByteArray qBAFilename = getFilename().toLocal8Bit();
+#endif
     m_ptrOpusFile = op_open_file(qBAFilename.constData(), &error);
     if (m_ptrOpusFile == NULL) {
         qDebug() << "opus: Input does not appear to be an Opus bitstream.";
@@ -176,9 +185,16 @@ unsigned SoundSourceOpus::read(volatile unsigned long size, const SAMPLE * desti
  */
 Result SoundSourceOpus::parseHeader() {
     int error = 0;
-
+    // From opus/opusfile.h
+    // On Windows, this string must be UTF-8 (to allow access to
+    // files whose names cannot be represented in the current
+    // MBCS code page).
+    // All other systems use the native character encoding.
+#ifdef _WIN32
+    QByteArray qBAFilename = getFilename().toUtf8();
+#else
     QByteArray qBAFilename = getFilename().toLocal8Bit();
-
+#endif
     OggOpusFile *l_ptrOpusFile = op_open_file(qBAFilename.constData(), &error);
     this->setBitrate((int)op_bitrate(l_ptrOpusFile, -1) / 1000);
     this->setSampleRate(48000);

--- a/src/soundsourceopus.cpp
+++ b/src/soundsourceopus.cpp
@@ -188,8 +188,11 @@ Result SoundSourceOpus::parseHeader() {
 
 // If we don't have new enough Taglib we use libopusfile parser!
 #if (TAGLIB_MAJOR_VERSION > 1) || ((TAGLIB_MAJOR_VERSION == 1) && (TAGLIB_MINOR_VERSION >= 9))
+#ifdef _WIN32
+    TagLib::Ogg::Opus::File f(getFilename().toStdWString().data());
+#else
     TagLib::Ogg::Opus::File f(qBAFilename.constData());
-
+#endif
     if (!readFileHeader(this, f)) {
         return ERR;
     }
@@ -272,7 +275,11 @@ QList<QString> SoundSourceOpus::supportedFileExtensions() {
 
 QImage SoundSourceOpus::parseCoverArt() {
 #if (TAGLIB_MAJOR_VERSION > 1) || ((TAGLIB_MAJOR_VERSION == 1) && (TAGLIB_MINOR_VERSION >= 9))
+#ifdef _WIN32
+    TagLib::Ogg::Opus::File f(getFilename().toStdWString().data());
+#else
     TagLib::Ogg::Opus::File f(getFilename().toLocal8Bit().constData());
+#endif
     TagLib::Ogg::XiphComment *xiph = f.tag();
     if (xiph) {
         return Mixxx::getCoverInXiphComment(*xiph);

--- a/src/soundsourcesndfile.cpp
+++ b/src/soundsourcesndfile.cpp
@@ -70,7 +70,8 @@ Result SoundSourceSndFile::open() {
     }
 
     if (sf_error(fh)>0) {
-        qWarning() << "libsndfile: Error opening file" << getFilename() << sf_strerror(fh);
+        qWarning() << "libsndfile: Error opening file"
+                   << getFilename() << sf_strerror(fh);
         return ERR;
     }
 
@@ -157,7 +158,11 @@ Result SoundSourceSndFile::parseHeader()
     QByteArray qBAFilename = getFilename().toLocal8Bit();
 
     if (is_flac) {
+#ifdef _WIN32
+        TagLib::FLAC::File f(getFilename().toStdWString().data());
+#else
         TagLib::FLAC::File f(qBAFilename.constData());
+#endif
         if (!readFileHeader(this, f)) {
             return ERR;
         }
@@ -248,7 +253,11 @@ QImage SoundSourceSndFile::parseCoverArt() {
     const QByteArray qBAFilename(getFilename().toLocal8Bit());
 
     if (getType() == "flac") {
+#ifdef _WIN32
+        TagLib::FLAC::File f(getFilename().toStdWString().data());
+#else
         TagLib::FLAC::File f(qBAFilename.constData());
+#endif
         TagLib::ID3v2::Tag* id3v2 = f.ID3v2Tag();
         if (id3v2) {
             coverArt = Mixxx::getCoverInID3v2Tag(*id3v2);
@@ -269,14 +278,22 @@ QImage SoundSourceSndFile::parseCoverArt() {
             }
         }
     } else if (getType() == "wav") {
+#ifdef _WIN32
+        TagLib::RIFF::WAV::File f(getFilename().toStdWString().data());
+#else
         TagLib::RIFF::WAV::File f(qBAFilename.constData());
+#endif
         TagLib::ID3v2::Tag* id3v2 = f.tag();
         if (id3v2) {
             coverArt = Mixxx::getCoverInID3v2Tag(*id3v2);
         }
     } else {
         // Try AIFF
+#ifdef _WIN32
+        TagLib::RIFF::AIFF::File f(getFilename().toStdWString().data());
+#else
         TagLib::RIFF::AIFF::File f(qBAFilename.constData());
+#endif
         TagLib::ID3v2::Tag* id3v2 = f.tag();
         if (id3v2) {
             coverArt = Mixxx::getCoverInID3v2Tag(*id3v2);


### PR DESCRIPTION
This should fix bug https://bugs.launchpad.net/mixxx/+bug/1498213

I have used the "right" method to access files on windows according to the libraries docu.  

Before this patch we use often toLocal8bit() to encode the file path. This strips all characters not part of the selected code page.

This fixes also the wavpack plugin, which had broken link options. Since no one has noticed it, this seams to be unused. :-/
