### PR TITLE
SoundSourceM4A: Log properties of unsupported MP4 files

### DIFF
--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -37,31 +37,93 @@ const MP4SampleId kSampleBlockIdMin = 1;
 // playback from any point in the bistream."
 const SINT kNumberOfPrefetchFrames = 2112;
 
+const u_int32_t kMinTrackId = 1;
+
+inline
+u_int32_t getMaxTrackId(MP4FileHandle hFile) {
+    return MP4GetNumberOfTracks(hFile, nullptr, 0);
+}
+
+inline
+bool isValidTrackType(const char* trackType) {
+    return (nullptr != trackType) &&
+            MP4_IS_AUDIO_TRACK_TYPE(trackType);
+}
+
+inline
+bool isValidMediaDataName(const char* mediaDataName) {
+    return (nullptr != mediaDataName) &&
+            (0 == strcasecmp(mediaDataName, "mp4a"));
+}
+
 // Searches for the first audio track in the MP4 file that
 // suits our needs.
-MP4TrackId findFirstAudioTrackId(MP4FileHandle hFile) {
-    const MP4TrackId maxTrackId = MP4GetNumberOfTracks(hFile, nullptr, 0);
-    for (MP4TrackId trackId = 1; trackId <= maxTrackId; ++trackId) {
+MP4TrackId findFirstAudioTrackId(MP4FileHandle hFile, const QString& fileName) {
+    const u_int32_t maxTrackId = getMaxTrackId(hFile);
+    for (u_int32_t trackId = kMinTrackId; trackId <= maxTrackId; ++trackId) {
         const char* trackType = MP4GetTrackType(hFile, trackId);
-        if ((nullptr == trackType) || !MP4_IS_AUDIO_TRACK_TYPE(trackType)) {
+        if (!isValidTrackType(trackType)) {
+            qWarning() << "Unsupported track type"
+                    << QString((trackType == nullptr) ? "" : trackType);
+            qWarning() << "Skipping track"
+                    << trackId
+                    << "of"
+                    << maxTrackId
+                    << "in file"
+                    << fileName;
             continue;
         }
         const char* mediaDataName = MP4GetTrackMediaDataName(hFile, trackId);
-        if ((nullptr == mediaDataName) || (0 != strcasecmp(mediaDataName, "mp4a"))) {
+        if (!isValidMediaDataName(mediaDataName)) {
+            qWarning() << "Unsupported media data name"
+                    << QString((mediaDataName == nullptr) ? "" : mediaDataName);
+            qWarning() << "Skipping track"
+                    << trackId
+                    << "of"
+                    << maxTrackId
+                    << "in file"
+                    << fileName;
             continue;
         }
         const u_int8_t audioType = MP4GetTrackEsdsObjectTypeId(hFile, trackId);
-        if (MP4_INVALID_AUDIO_TYPE == audioType) {
-            continue;
-        }
-        if (MP4_MPEG4_AUDIO_TYPE == audioType) {
-            const u_int8_t audioMpeg4Type = MP4GetTrackAudioMpeg4Type(hFile,
-                    trackId);
-            if (MP4_IS_MPEG4_AAC_AUDIO_TYPE(audioMpeg4Type)) {
+        if (MP4_IS_AAC_AUDIO_TYPE(audioType)) {
+            if (MP4_MPEG4_AUDIO_TYPE == audioType) {
+                const u_int8_t mpeg4AudioType =
+                        MP4GetTrackAudioMpeg4Type(hFile, trackId);
+                if (MP4_IS_MPEG4_AAC_AUDIO_TYPE(mpeg4AudioType)) {
+                    return trackId;
+                } else {
+                    qWarning() << "Unsupported MPEG4 audio type"
+                            << int(mpeg4AudioType);
+                    qWarning() << "Skipping track"
+                            << trackId
+                            << "of"
+                            << maxTrackId
+                            << "in file"
+                            << fileName;
+                    continue;
+                }
+            } else {
                 return trackId;
             }
-        } else if (MP4_IS_AAC_AUDIO_TYPE(audioType)) {
-            return trackId;
+        } else {
+            qWarning() << "Unsupported audio type"
+                    << int(audioType);
+            qWarning() << "Skipping track"
+                    << trackId
+                    << "of"
+                    << maxTrackId
+                    << "in file"
+                    << fileName;
+            continue;
+        }
+        DEBUG_ASSERT_AND_HANDLE(!"unreachable code") {
+            qWarning() << "Skipping track"
+                    << trackId
+                    << "of"
+                    << maxTrackId
+                    << "in file"
+                    << fileName;
         }
     }
     return MP4_INVALID_TRACK_ID;
@@ -105,7 +167,7 @@ Result SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSrcCfg) {
         return ERR;
     }
 
-    m_trackId = findFirstAudioTrackId(m_hFile);
+    m_trackId = findFirstAudioTrackId(m_hFile, getLocalFileName());
     if (MP4_INVALID_TRACK_ID == m_trackId) {
         qWarning() << "No AAC track found:" << getUrlString();
         return ERR;

--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -37,10 +37,16 @@ const MP4SampleId kSampleBlockIdMin = 1;
 // playback from any point in the bistream."
 const SINT kNumberOfPrefetchFrames = 2112;
 
+// The TrackId is a 1-based index of the tracks in an MP4 file
 const u_int32_t kMinTrackId = 1;
 
 inline
 u_int32_t getMaxTrackId(MP4FileHandle hFile) {
+    // The maximum TrackId equals the number of all tracks
+    // in an MP4 file. We pass nullptr and 0 as arguments
+    // to avoid any type/subtype filtering at this point!
+    // Otherwise the previous assumption would no longer
+    // be valid!
     return MP4GetNumberOfTracks(hFile, nullptr, 0);
 }
 

--- a/src/util/dbid.h
+++ b/src/util/dbid.h
@@ -95,8 +95,8 @@ public:
         return os << dbId.m_value;
     }
 
-    friend QDebug operator<<(QDebug qDebug, const DbId& dbId) {
-        return qDebug << dbId.m_value;
+    friend QDebug operator<<(QDebug debug, const DbId& dbId) {
+        return debug << dbId.m_value;
     }
 
     friend uint qHash(const DbId& dbId) {


### PR DESCRIPTION
Some minor improvements when opening and verbose logging of unsupported MP4 files.
