### PR TITLE
Print duration of selected tracks in AutoDJ

### DIFF
--- a/res/translations/mixxx.ts
+++ b/res/translations/mixxx.ts
@@ -2806,6 +2806,47 @@
         <source>Disable Auto DJ</source>
         <translation type="unfinished"></translation>
     </message>
+    <message numerus="yes">
+        <location filename="../../src/dlgautodj.cpp" line="228"/>
+        <source>%Ln hour(s)</source>
+        <comment>duration_hours</comment>
+        <translation>
+            <numerusform>1 hour</numerusform>
+            <numerusform>%n hours</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/dlgautodj.cpp" line="235"/>
+        <source>%Ln minute(s)</source>
+        <comment>duration_minutes</comment>
+        <translation>
+            <numerusform>1 minute</numerusform>
+            <numerusform>%n minutes</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/dlgautodj.cpp" line="242"/>
+        <source>%Ln second(s)</source>
+        <comment>duration_seconds</comment>
+        <translation>
+            <numerusform>1 second</numerusform>
+            <numerusform>%n seconds</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../../src/dlgautodj.cpp" line="246"/>
+        <source>0 seconds</source>
+        <translation>less than a second</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/dlgautodj.cpp" line="250"/>
+        <source>(%Ln track(s))</source>
+        <comment>track_count</comment>
+        <translation>
+            <numerusform>(1 track)</numerusform>
+            <numerusform>(%n tracks)</numerusform>
+        </translation>
+    </message>
     <message>
         <location filename="../../src/dlgautodj.ui" line="14"/>
         <source>Auto DJ</source>

--- a/src/dlgautodj.h
+++ b/src/dlgautodj.h
@@ -41,6 +41,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void autoDJStateChanged(AutoDJProcessor::AutoDJState state);
     void setTrackTableFont(const QFont& font);
     void setTrackTableRowHeight(int rowHeight);
+    void updateSelectionInfo();
 
   signals:
     void addRandomButton(bool buttonChecked);

--- a/src/dlgautodj.ui
+++ b/src/dlgautodj.ui
@@ -132,6 +132,13 @@
       </spacer>
      </item>
      <item>
+      <widget class="QLabel" name="labelSelectionInfo">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="pushButtonAutoDJ">
        <property name="toolTip">
         <string>Turn Auto DJ on or off.</string>


### PR DESCRIPTION
This pull request will print something like:

   1 hour, 3 minutes (5 tracks) 

next to the "Enable AutoDJ" button based on how many tracks are selected by the user.

NOTE: I'm not a C++ programmer, so all feedback is welcome! :smile: 
