### PR TITLE
Print duration of selected tracks in AutoDJ

### DIFF
--- a/res/translations/mixxx.ts
+++ b/res/translations/mixxx.ts
@@ -2848,6 +2848,11 @@
         </translation>
     </message>
     <message>
+        <location filename="../../src/dlgautodj.cpp" line="253"/>
+        <source>%1h%2m%3s in selection</source>
+        <translation>%1h%2m%3s in selection</translation>
+    </message>
+    <message>
         <location filename="../../src/dlgautodj.ui" line="14"/>
         <source>Auto DJ</source>
         <translation type="unfinished"></translation>

--- a/res/translations/mixxx.ts
+++ b/res/translations/mixxx.ts
@@ -2806,52 +2806,6 @@
         <source>Disable Auto DJ</source>
         <translation type="unfinished"></translation>
     </message>
-    <message numerus="yes">
-        <location filename="../../src/dlgautodj.cpp" line="228"/>
-        <source>%Ln hour(s)</source>
-        <comment>duration_hours</comment>
-        <translation>
-            <numerusform>1 hour</numerusform>
-            <numerusform>%n hours</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../../src/dlgautodj.cpp" line="235"/>
-        <source>%Ln minute(s)</source>
-        <comment>duration_minutes</comment>
-        <translation>
-            <numerusform>1 minute</numerusform>
-            <numerusform>%n minutes</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../../src/dlgautodj.cpp" line="242"/>
-        <source>%Ln second(s)</source>
-        <comment>duration_seconds</comment>
-        <translation>
-            <numerusform>1 second</numerusform>
-            <numerusform>%n seconds</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../../src/dlgautodj.cpp" line="246"/>
-        <source>0 seconds</source>
-        <translation>less than a second</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../../src/dlgautodj.cpp" line="250"/>
-        <source>(%Ln track(s))</source>
-        <comment>track_count</comment>
-        <translation>
-            <numerusform>(1 track)</numerusform>
-            <numerusform>(%n tracks)</numerusform>
-        </translation>
-    </message>
-    <message>
-        <location filename="../../src/dlgautodj.cpp" line="253"/>
-        <source>%1h%2m%3s in selection</source>
-        <translation>%1h%2m%3s in selection</translation>
-    </message>
     <message>
         <location filename="../../src/dlgautodj.ui" line="14"/>
         <source>Auto DJ</source>
@@ -2914,14 +2868,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/dlgautodj.ui" line="137"/>
+        <location filename="../../src/dlgautodj.ui" line="144"/>
         <source>Turn Auto DJ on or off.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/dlgautodj.ui" line="140"/>
-        <location filename="../../src/dlgautodj.cpp" line="169"/>
-        <location filename="../../src/dlgautodj.cpp" line="170"/>
+        <location filename="../../src/dlgautodj.ui" line="147"/>
+        <location filename="../../src/dlgautodj.cpp" line="175"/>
+        <location filename="../../src/dlgautodj.cpp" line="176"/>
         <source>Enable Auto DJ</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3200,17 +3154,27 @@ You tried to learn: %1,%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/dlgdevelopertoolsdlg.ui" line="75"/>
+        <location filename="../../src/dlgdevelopertoolsdlg.ui" line="46"/>
+        <source>Dumps all ControlObject values to a csv-file saved in the settings path (e.g. ~/.mixxx)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/dlgdevelopertoolsdlg.ui" line="49"/>
+        <source>Dump to csv</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/dlgdevelopertoolsdlg.ui" line="85"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/dlgdevelopertoolsdlg.ui" line="97"/>
+        <location filename="../../src/dlgdevelopertoolsdlg.ui" line="94"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/dlgdevelopertoolsdlg.ui" line="125"/>
+        <location filename="../../src/dlgdevelopertoolsdlg.ui" line="135"/>
         <source>Stats</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3592,11 +3556,6 @@ Apply settings and continue?</source>
     <message>
         <location filename="../../src/controllers/dlgprefcontrollersdlg.ui" line="20"/>
         <source>Controllers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../src/controllers/dlgprefcontrollersdlg.ui" line="32"/>
-        <source>Controllers allow you to control Mixxx with physical devices (for example USB MIDI or HID controllers). Controllers that Mixxx recognizes are shown in the &quot;Controllers&quot; section in the sidebar.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/res/translations/mixxx.ts
+++ b/res/translations/mixxx.ts
@@ -2806,6 +2806,47 @@
         <source>Disable Auto DJ</source>
         <translation type="unfinished"></translation>
     </message>
+    <message numerus="yes">
+        <location filename="../../src/dlgautodj.cpp" line="228"/>
+        <source>%Ln hour(s)</source>
+        <comment>duration_hours</comment>
+        <translation>
+            <numerusform>1 hour</numerusform>
+            <numerusform>%n hours</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/dlgautodj.cpp" line="235"/>
+        <source>%Ln minute(s)</source>
+        <comment>duration_minutes</comment>
+        <translation>
+            <numerusform>1 minute</numerusform>
+            <numerusform>%n minutes</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/dlgautodj.cpp" line="242"/>
+        <source>%Ln second(s)</source>
+        <comment>duration_seconds</comment>
+        <translation>
+            <numerusform>1 second</numerusform>
+            <numerusform>%n seconds</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../../src/dlgautodj.cpp" line="246"/>
+        <source>0 seconds</source>
+        <translation>less than a second</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/dlgautodj.cpp" line="250"/>
+        <source>(%Ln track(s))</source>
+        <comment>track_count</comment>
+        <translation>
+            <numerusform>(1 track)</numerusform>
+            <numerusform>(%n tracks)</numerusform>
+        </translation>
+    </message>
     <message>
         <location filename="../../src/dlgautodj.ui" line="14"/>
         <source>Auto DJ</source>

--- a/src/dlgautodj.cpp
+++ b/src/dlgautodj.cpp
@@ -217,6 +217,7 @@ void DlgAutoDJ::updateSelectionInfo()
     }
 
     QString label = QString();
+    QString tooltip = QString();
     
     if (!indices.isEmpty()) {
     	
@@ -248,7 +249,13 @@ void DlgAutoDJ::updateSelectionInfo()
 	
 	label.append(" ");
 	label.append(tr("(%Ln track(s))","track_count", indices.size()));
+	
+	tooltip = QString(tr("%1h%2m%3s in selection")).arg(hours)
+	.arg(minutes,2,10,QChar('0'))
+	.arg(seconds,2,10,QChar('0'));
+	
     }
     
+    labelSelectionInfo->setToolTip(tooltip);
     labelSelectionInfo->setText(label);
 }

--- a/src/dlgautodj.cpp
+++ b/src/dlgautodj.cpp
@@ -5,6 +5,7 @@
 #include "library/playlisttablemodel.h"
 #include "widget/wtracktableview.h"
 #include "util/assert.h"
+#include "util/time.h"
 
 DlgAutoDJ::DlgAutoDJ(QWidget* parent,
                      ConfigObject<ConfigValue>* pConfig,
@@ -206,56 +207,22 @@ void DlgAutoDJ::setTrackTableRowHeight(int rowHeight) {
 void DlgAutoDJ::updateSelectionInfo()
 {
     int duration = 0;
-    
+
     QModelIndexList indices = m_pTrackTableView->selectionModel()->selectedRows();
 
-    for(int i=0;i!= indices.size();i++) {
-      TrackPointer pTrack = m_pAutoDJTableModel->getTrack(indices.at(i));
+    for (int i = 0; i < indices.size(); ++i) {
+        TrackPointer pTrack = m_pAutoDJTableModel->getTrack(indices.at(i));
       if (pTrack) {
         duration += pTrack->getDuration();
       }
     }
 
-    QString label = QString();
-    QString tooltip = QString();
-    
-    if (!indices.isEmpty()) {
-    	
-      	int hours = duration / 3600;
-	int minutes = (duration - (hours*3600)) / 60;
-	int seconds = duration - (hours * 3600) - (minutes*60);
+    QString label;
 
-	if (hours > 0) {
-	  label.append(tr("%Ln hour(s)", "duration_hours", hours));
-	}
-	
-	if (minutes > 0) {
-	  if (hours > 0) { 
-	    label.append(", ");
-	  }
-	  label.append(tr("%Ln minute(s)","duration_minutes", minutes));
-	}
-	
-	if (hours == 0 && seconds > 0) {
-	  if (minutes > 0) {
-	    label.append(", ");
-	  }
-	  label.append(tr("%Ln second(s)","duration_seconds", seconds));
-	}
-	
-	if (hours == 0 && minutes == 0 && seconds == 0) {
-	  label.append(tr("0 seconds"));
-	}
-	
-	label.append(" ");
-	label.append(tr("(%Ln track(s))","track_count", indices.size()));
-	
-	tooltip = QString(tr("%1h%2m%3s in selection")).arg(hours)
-	.arg(minutes,2,10,QChar('0'))
-	.arg(seconds,2,10,QChar('0'));
-	
+    if (!indices.isEmpty()) {
+        label.append(Time::formatSeconds(duration, false));
+        label.append(QString(" (%1)").arg(indices.size()));           
     }
     
-    labelSelectionInfo->setToolTip(tooltip);
     labelSelectionInfo->setText(label);
 }

--- a/src/dlgautodj.h
+++ b/src/dlgautodj.h
@@ -41,6 +41,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void autoDJStateChanged(AutoDJProcessor::AutoDJState state);
     void setTrackTableFont(const QFont& font);
     void setTrackTableRowHeight(int rowHeight);
+    void updateSelectionInfo();
 
   signals:
     void addRandomButton(bool buttonChecked);

--- a/src/dlgautodj.ui
+++ b/src/dlgautodj.ui
@@ -132,6 +132,13 @@
       </spacer>
      </item>
      <item>
+      <widget class="QLabel" name="labelSelectionInfo">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="pushButtonAutoDJ">
        <property name="toolTip">
         <string>Turn Auto DJ on or off.</string>


### PR DESCRIPTION
Relates to https://bugs.launchpad.net/mixxx/+bug/1505408 and possibly offers a fix.

Adds a human friendly duration of the selected tracks in AutoDJ next to the "Enable AutoDJ" button:

```
1 hour, 34 seconds (24 tracks)
```

The exact time is available as a tooltip.

NOTE: I'm not a C++ programmer, so I may have overlooked something. :smile:

I ran _lupdate_ to update the mixxx.ts file. It made a truckload of changes to the file (mostly line number changes), but I've tried to only include the relevant lines in this pull request.

(I'd love it if this could make the next 1.12 beta.)
