### PR TITLE
Track metadata improvements and fixes

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -969,6 +969,7 @@ class MixxxCore(Feature):
                    "util/movinginterquartilemean.cpp",
                    "util/console.cpp",
                    "util/dbid.cpp",
+                   "util/replaygain.cpp",
 
                    '#res/mixxx.qrc'
                    ]

--- a/src/metadata/trackmetadata.cpp
+++ b/src/metadata/trackmetadata.cpp
@@ -1,6 +1,7 @@
 #include "metadata/trackmetadata.h"
 
 #include "util/math.h"
+#include "util/time.h"
 
 namespace Mixxx {
 
@@ -216,6 +217,10 @@ QString TrackMetadata::reformatYear(QString year) {
     }
     // just trim and simplify whitespaces
     return year.simplified();
+}
+
+QString TrackMetadata::formatDuration(int duration) {
+    return Time::formatSeconds(duration, false);
 }
 
 TrackMetadata::TrackMetadata()

--- a/src/metadata/trackmetadata.cpp
+++ b/src/metadata/trackmetadata.cpp
@@ -38,7 +38,7 @@ double TrackMetadata::parseBpm(const QString& sBpm, bool* pValid) {
             qDebug() << "Scaling BPM value:" << bpm;
             bpm /= 10.0;
         }
-        if (TrackMetadata::isBpmValid(bpm)) {
+        if (isBpmValid(bpm)) {
             if (pValid) {
                 *pValid = true;
             }
@@ -53,7 +53,7 @@ double TrackMetadata::parseBpm(const QString& sBpm, bool* pValid) {
 }
 
 QString TrackMetadata::formatBpm(double bpm) {
-    if (TrackMetadata::isBpmValid(bpm)) {
+    if (isBpmValid(bpm)) {
         return QString::number(bpm);
     } else {
         return QString();
@@ -61,7 +61,7 @@ QString TrackMetadata::formatBpm(double bpm) {
 }
 
 QString TrackMetadata::formatBpm(int bpm) {
-    if (TrackMetadata::isBpmValid(bpm)) {
+    if (isBpmValid(bpm)) {
         return QString::number(bpm);
     } else {
         return QString();
@@ -194,13 +194,13 @@ QString TrackMetadata::reformatYear(QString year) {
     return year.simplified();
 }
 
-TrackMetadata::TrackMetadata() :
-        m_channels(0),
-        m_sampleRate(0),
-        m_bitrate(0),
-        m_duration(0),
-        m_bpm(kBpmUndefined),
-        m_replayGain(kReplayGainUndefined) {
+TrackMetadata::TrackMetadata()
+    : m_bpm(kBpmUndefined),
+      m_replayGain(kReplayGainUndefined),
+      m_bitrate(0),
+      m_channels(0),
+      m_duration(0),
+      m_sampleRate(0) {
 }
 
 } //namespace Mixxx

--- a/src/metadata/trackmetadata.cpp
+++ b/src/metadata/trackmetadata.cpp
@@ -203,4 +203,24 @@ TrackMetadata::TrackMetadata()
       m_sampleRate(0) {
 }
 
+bool operator==(const TrackMetadata& lhs, const TrackMetadata& rhs) {
+    return (lhs.getArtist() == rhs.getArtist()) &&
+            (lhs.getTitle() == rhs.getTitle()) &&
+            (lhs.getAlbum() == rhs.getAlbum()) &&
+            (lhs.getAlbumArtist() == rhs.getAlbumArtist()) &&
+            (lhs.getGenre() == rhs.getGenre()) &&
+            (lhs.getComment() == rhs.getComment()) &&
+            (lhs.getYear() == rhs.getYear()) &&
+            (lhs.getTrackNumber() == rhs.getTrackNumber()) &&
+            (lhs.getComposer() == rhs.getComposer()) &&
+            (lhs.getGrouping() == rhs.getGrouping()) &&
+            (lhs.getKey() == rhs.getKey()) &&
+            (lhs.getChannels() == rhs.getChannels()) &&
+            (lhs.getSampleRate() == rhs.getSampleRate()) &&
+            (lhs.getBitrate() == rhs.getBitrate()) &&
+            (lhs.getDuration() == rhs.getDuration()) &&
+            (lhs.getBpm() == rhs.getBpm()) &&
+            (lhs.getReplayGain() == rhs.getReplayGain());
+}
+
 } //namespace Mixxx

--- a/src/metadata/trackmetadata.cpp
+++ b/src/metadata/trackmetadata.cpp
@@ -68,6 +68,18 @@ QString TrackMetadata::formatBpm(int bpm) {
     }
 }
 
+double TrackMetadata::normalizeBpm(double bpm) {
+    if (isBpmValid(bpm)) {
+        const double normalizedBpm = parseBpm(formatBpm(bpm));
+        // NOTE(uklotzde): Subsequently formatting and parsing the
+        // normalized value should not alter it anymore!
+        DEBUG_ASSERT(normalizedBpm == parseBpm(formatBpm(normalizedBpm)));
+        return normalizedBpm;
+    } else {
+        return bpm;
+    }
+}
+
 namespace {
 
 const QString kReplayGainUnit("dB");
@@ -129,6 +141,18 @@ QString TrackMetadata::formatReplayGain(double replayGain) {
         return QString::number(ratio2db(replayGain)) + kReplayGainSuffix;
     } else {
         return QString();
+    }
+}
+
+double TrackMetadata::normalizeReplayGain(double replayGain) {
+    if (isReplayGainValid(replayGain) && (kReplayGain0dB != replayGain)) {
+        const double normalizedReplayGain = parseReplayGain(formatReplayGain(replayGain));
+        // NOTE(uklotzde): Subsequently formatting and parsing the
+        // normalized value should not alter it anymore!
+        DEBUG_ASSERT(normalizedReplayGain == parseReplayGain(formatReplayGain(normalizedReplayGain)));
+        return normalizedReplayGain;
+    } else {
+        return replayGain;
     }
 }
 

--- a/src/metadata/trackmetadata.h
+++ b/src/metadata/trackmetadata.h
@@ -1,5 +1,5 @@
-#ifndef TRACKMETADATA_H
-#define TRACKMETADATA_H
+#ifndef MIXXX_TRACKMETADATA_H
+#define MIXXX_TRACKMETADATA_H
 
 #include <QDateTime>
 
@@ -197,29 +197,30 @@ public:
     static QString reformatYear(QString year);
 
 private:
-    QString m_artist;
-    QString m_title;
+    // String fields (in alphabetical order)
     QString m_album;
     QString m_albumArtist;
-    QString m_genre;
+    QString m_artist;
     QString m_comment;
-    QString m_year;
-    QString m_trackNumber;
     QString m_composer;
+    QString m_genre;
     QString m_grouping;
     QString m_key;
+    QString m_title;
+    QString m_trackNumber;
+    QString m_year;
 
-    // The following members need to be initialized
-    // explicitly in the constructor! Otherwise their
-    // value is undefined.
-    int m_channels;
-    int m_sampleRate;
-    int m_bitrate;
-    int m_duration;
+    // Floating-point fields (in alphabetical order)
     double m_bpm;
     double m_replayGain;
+
+    // Integer fields (in alphabetical order)
+    int m_bitrate; // kbit/s
+    int m_channels;
+    int m_duration; // seconds
+    int m_sampleRate; // Hz
 };
 
 }
 
-#endif
+#endif // MIXXX_TRACKMETADATA_H

--- a/src/metadata/trackmetadata.h
+++ b/src/metadata/trackmetadata.h
@@ -168,12 +168,14 @@ public:
     static double parseBpm(const QString& sBpm, bool* pValid = 0);
     static QString formatBpm(double bpm);
     static QString formatBpm(int bpm);
+    static double normalizeBpm(double bpm);
 
     // Parse and format replay gain metadata according to the
     // ReplayGain 1.0 specification.
     // http://wiki.hydrogenaud.io/index.php?title=ReplayGain_1.0_specification
     static double parseReplayGain(QString sReplayGain, bool* pValid = 0);
     static QString formatReplayGain(double replayGain);
+    static double normalizeReplayGain(double replayGain);
 
     // Parse an format date/time values according to ISO 8601
     inline static QDate parseDate(QString str) {

--- a/src/metadata/trackmetadata.h
+++ b/src/metadata/trackmetadata.h
@@ -221,6 +221,13 @@ private:
     int m_sampleRate; // Hz
 };
 
+bool operator==(const TrackMetadata& lhs, const TrackMetadata& rhs);
+
+inline
+bool operator!=(const TrackMetadata& lhs, const TrackMetadata& rhs) {
+    return !(lhs == rhs);
+}
+
 }
 
 #endif // MIXXX_TRACKMETADATA_H

--- a/src/metadata/trackmetadata.h
+++ b/src/metadata/trackmetadata.h
@@ -3,7 +3,7 @@
 
 #include <QDateTime>
 
-#include <cmath>
+#include "util/replaygain.h"
 
 namespace Mixxx {
 
@@ -147,23 +147,14 @@ public:
         m_bpm = kBpmUndefined;
     }
 
-    static const double kReplayGainUndefined;
-    static const double kReplayGainMin; // lower bound (exclusive)
-    static const double kReplayGain0dB;
-    inline double getReplayGain() const {
+    const ReplayGain& getReplayGain() const {
         return m_replayGain;
     }
-    inline static bool isReplayGainValid(double replayGain) {
-        return kReplayGainMin < replayGain;
-    }
-    inline bool isReplayGainValid() const {
-        return isReplayGainValid(getReplayGain());
-    }
-    inline void setReplayGain(double replayGain) {
+    void setReplayGain(const ReplayGain& replayGain) {
         m_replayGain = replayGain;
     }
-    inline void resetReplayGain() {
-        m_replayGain = kReplayGainUndefined;
+    void resetReplayGain() {
+        m_replayGain = ReplayGain();
     }
 
     // Parse and format BPM metadata
@@ -171,13 +162,6 @@ public:
     static QString formatBpm(double bpm);
     static QString formatBpm(int bpm);
     static double normalizeBpm(double bpm);
-
-    // Parse and format replay gain metadata according to the
-    // ReplayGain 1.0 specification.
-    // http://wiki.hydrogenaud.io/index.php?title=ReplayGain_1.0_specification
-    static double parseReplayGain(QString sReplayGain, bool* pValid = 0);
-    static QString formatReplayGain(double replayGain);
-    static double normalizeReplayGain(double replayGain);
 
     // Parse an format date/time values according to ISO 8601
     inline static QDate parseDate(QString str) {
@@ -214,9 +198,10 @@ private:
     QString m_trackNumber;
     QString m_year;
 
+    ReplayGain m_replayGain;
+
     // Floating-point fields (in alphabetical order)
     double m_bpm;
-    double m_replayGain;
 
     // Integer fields (in alphabetical order)
     int m_bitrate; // kbit/s

--- a/src/metadata/trackmetadata.h
+++ b/src/metadata/trackmetadata.h
@@ -121,6 +121,8 @@ public:
     inline void setDuration(int duration) {
         m_duration = duration;
     }
+    // Returns the duration as a string: H:MM:SS
+    static QString formatDuration(int duration);
 
     // beats / minute
     static const double kBpmUndefined;

--- a/src/metadata/trackmetadatataglib.cpp
+++ b/src/metadata/trackmetadatataglib.cpp
@@ -202,6 +202,15 @@ bool parseTrackGain(TrackMetadata* pTrackMetadata, QString dbGain) {
     bool trackGainRatioValid = false;
     double trackGainRatio = ReplayGain::parseGain2Ratio(dbGain, &trackGainRatioValid);
     if (trackGainRatioValid) {
+        // Some applications (e.g. Rapid Evolution 3) write a replay gain
+        // of 0 dB even if the replay gain is undefined. To be safe we
+        // ignore this special value and instead prefer to recalculate
+        // the replay gain.
+        if (trackGainRatio == ReplayGain::kRatio0dB) {
+            // special case
+            qDebug() << "Ignoring possibly undefined gain:" << ReplayGain::formatRatio2Gain(trackGainRatio);
+            trackGainRatio = ReplayGain::kRatioUndefined;
+        }
         ReplayGain trackGain(pTrackMetadata->getReplayGain());
         trackGain.setRatio(trackGainRatio);
         pTrackMetadata->setReplayGain(trackGain);

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -116,7 +116,13 @@ Result SoundSourceOpus::parseTrackMetadataAndCoverArt(
         } else if (!l_STag.compare("TITLE")) {
             pTrackMetadata->setTitle(l_SPayload);
         } else if (!l_STag.compare("REPLAYGAIN_TRACK_GAIN")) {
-            pTrackMetadata->setReplayGain(Mixxx::TrackMetadata::parseReplayGain(l_SPayload));
+            bool trackGainRatioValid = false;
+            double trackGainRatio = ReplayGain::parseGain2Ratio(l_SPayload, &trackGainRatioValid);
+            if (trackGainRatioValid) {
+                ReplayGain trackGain(pTrackMetadata->getReplayGain());
+                trackGain.setRatio(trackGainRatio);
+                pTrackMetadata->setReplayGain(trackGain);
+            }
         }
 
         // This is left fot debug reasons!!

--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -35,6 +35,11 @@ class MetadataTest : public testing::Test {
         return actualResult;
     }
 
+    void normalizeBpm(double expectedResult) {
+        const double actualResult = Mixxx::TrackMetadata::normalizeBpm(expectedResult);
+        EXPECT_EQ(expectedResult, actualResult);
+    }
+
     double parseReplayGain(QString inputValue, bool expectedResult, float expectedValue) {
         //qDebug() << "parseReplayGain" << inputValue << expectedResult << expectedValue;
 
@@ -49,6 +54,11 @@ class MetadataTest : public testing::Test {
 //        }
 
         return actualResult;
+    }
+
+    void normalizeReplayGain(double expectedResult) {
+        const double actualResult = Mixxx::TrackMetadata::normalizeReplayGain(expectedResult);
+        EXPECT_EQ(expectedResult, actualResult);
     }
 };
 
@@ -80,6 +90,18 @@ TEST_F(MetadataTest, ParseBpmInvalid) {
     parseBpm("0 dBA", false, Mixxx::TrackMetadata::kBpmUndefined);
 }
 
+TEST_F(MetadataTest, NormalizeBpm) {
+    normalizeBpm(Mixxx::TrackMetadata::kBpmUndefined);
+    normalizeBpm(Mixxx::TrackMetadata::kBpmMin);
+    normalizeBpm(Mixxx::TrackMetadata::kBpmMin - 1.0);
+    normalizeBpm(Mixxx::TrackMetadata::kBpmMin + 1.0);
+    normalizeBpm(-Mixxx::TrackMetadata::kBpmMin);
+    normalizeBpm(Mixxx::TrackMetadata::kBpmMax);
+    normalizeBpm(Mixxx::TrackMetadata::kBpmMax - 1.0);
+    normalizeBpm(Mixxx::TrackMetadata::kBpmMax + 1.0);
+    normalizeBpm(-Mixxx::TrackMetadata::kBpmMax);
+}
+
 TEST_F(MetadataTest, ParseReplayGainDbValidRange) {
     for (int replayGainDb = -100; 100 >= replayGainDb; ++replayGainDb) {
         const QString inputValues[] = {
@@ -109,6 +131,14 @@ TEST_F(MetadataTest, ParseReplayGainDbInvalid) {
     parseReplayGain("", false, Mixxx::TrackMetadata::kReplayGainUndefined);
     parseReplayGain("abcde", false, Mixxx::TrackMetadata::kReplayGainUndefined);
     parseReplayGain("0 dBA", false, Mixxx::TrackMetadata::kReplayGainUndefined);
+}
+
+TEST_F(MetadataTest, NormalizeReplayGain) {
+    normalizeReplayGain(Mixxx::TrackMetadata::kReplayGainUndefined);
+    normalizeReplayGain(Mixxx::TrackMetadata::kReplayGainMin);
+    normalizeReplayGain(-Mixxx::TrackMetadata::kReplayGainMin);
+    normalizeReplayGain(Mixxx::TrackMetadata::kReplayGain0dB);
+    normalizeReplayGain(-Mixxx::TrackMetadata::kReplayGain0dB);
 }
 
 TEST_F(MetadataTest, ID3v2Year) {

--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include "metadata/trackmetadatataglib.h"
-#include "util/math.h"
 
 #include <QtDebug>
 
@@ -37,27 +36,6 @@ class MetadataTest : public testing::Test {
 
     void normalizeBpm(double expectedResult) {
         const double actualResult = Mixxx::TrackMetadata::normalizeBpm(expectedResult);
-        EXPECT_EQ(expectedResult, actualResult);
-    }
-
-    double parseReplayGain(QString inputValue, bool expectedResult, float expectedValue) {
-        //qDebug() << "parseReplayGain" << inputValue << expectedResult << expectedValue;
-
-        bool actualResult;
-        const double actualValue = Mixxx::TrackMetadata::parseReplayGain(inputValue, &actualResult);
-
-        EXPECT_EQ(expectedResult, actualResult);
-        EXPECT_FLOAT_EQ(expectedValue, actualValue);
-
-//        if (actualResult) {
-//            qDebug() << "ReplayGain:" << inputValue << "->" << Mixxx::TrackMetadata::formatReplayGain(actualValue);
-//        }
-
-        return actualResult;
-    }
-
-    void normalizeReplayGain(double expectedResult) {
-        const double actualResult = Mixxx::TrackMetadata::normalizeReplayGain(expectedResult);
         EXPECT_EQ(expectedResult, actualResult);
     }
 };
@@ -100,45 +78,6 @@ TEST_F(MetadataTest, NormalizeBpm) {
     normalizeBpm(Mixxx::TrackMetadata::kBpmMax - 1.0);
     normalizeBpm(Mixxx::TrackMetadata::kBpmMax + 1.0);
     normalizeBpm(-Mixxx::TrackMetadata::kBpmMax);
-}
-
-TEST_F(MetadataTest, ParseReplayGainDbValidRange) {
-    for (int replayGainDb = -100; 100 >= replayGainDb; ++replayGainDb) {
-        const QString inputValues[] = {
-                QString("%1 ").arg(replayGainDb),
-                QString("  %1dB ").arg(replayGainDb),
-                QString("  %1 DB ").arg(replayGainDb),
-                QString("  %1db ").arg(replayGainDb)
-        };
-        float expectedValue;
-        if (0 != replayGainDb) {
-            // regular case
-            expectedValue = db2ratio(double(replayGainDb));
-        } else {
-            // special case: 0 dB -> undefined
-            expectedValue = Mixxx::TrackMetadata::kReplayGainUndefined;
-        }
-        for (size_t i = 0; i < sizeof(inputValues) / sizeof(inputValues[0]); ++i) {
-            parseReplayGain(inputValues[i], true, expectedValue);
-            if (0 <= replayGainDb) {
-                parseReplayGain(QString("  + ") + inputValues[i], true, expectedValue);
-            }
-        }
-    }
-}
-
-TEST_F(MetadataTest, ParseReplayGainDbInvalid) {
-    parseReplayGain("", false, Mixxx::TrackMetadata::kReplayGainUndefined);
-    parseReplayGain("abcde", false, Mixxx::TrackMetadata::kReplayGainUndefined);
-    parseReplayGain("0 dBA", false, Mixxx::TrackMetadata::kReplayGainUndefined);
-}
-
-TEST_F(MetadataTest, NormalizeReplayGain) {
-    normalizeReplayGain(Mixxx::TrackMetadata::kReplayGainUndefined);
-    normalizeReplayGain(Mixxx::TrackMetadata::kReplayGainMin);
-    normalizeReplayGain(-Mixxx::TrackMetadata::kReplayGainMin);
-    normalizeReplayGain(Mixxx::TrackMetadata::kReplayGain0dB);
-    normalizeReplayGain(-Mixxx::TrackMetadata::kReplayGain0dB);
 }
 
 TEST_F(MetadataTest, ID3v2Year) {

--- a/src/test/replaygaintest.cpp
+++ b/src/test/replaygaintest.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+
+#include "util/replaygain.h"
+
+#include <QtDebug>
+
+namespace {
+
+class ReplayGainTest : public testing::Test {
+  protected:
+
+    ReplayGainTest() {
+    }
+
+    virtual void SetUp() {
+    }
+
+    virtual void TearDown() {
+    }
+
+    double parseGain2Ratio(QString inputValue, bool expectedResult, float expectedValue) {
+        //qDebug() << "parseGain2Ratio" << inputValue << expectedResult << expectedValue;
+
+        bool actualResult;
+        const double actualValue = Mixxx::ReplayGain::parseGain2Ratio(inputValue, &actualResult);
+
+        EXPECT_EQ(expectedResult, actualResult);
+        EXPECT_FLOAT_EQ(expectedValue, actualValue);
+
+        return actualResult;
+    }
+
+    void normalizeRatio(double expectedResult) {
+        const double actualResult = Mixxx::ReplayGain::normalizeRatio(expectedResult);
+        EXPECT_EQ(expectedResult, actualResult);
+    }
+};
+
+TEST_F(ReplayGainTest, ParseReplayGainDbValidRange) {
+    for (int replayGainDb = -100; 100 >= replayGainDb; ++replayGainDb) {
+        const QString inputValues[] = {
+                QString("%1 ").arg(replayGainDb),
+                QString("  %1dB ").arg(replayGainDb),
+                QString("  %1 DB ").arg(replayGainDb),
+                QString("  %1db ").arg(replayGainDb)
+        };
+        float expectedValue;
+        if (0 != replayGainDb) {
+            // regular case
+            expectedValue = db2ratio(double(replayGainDb));
+        } else {
+            // special case: 0 dB -> undefined
+            expectedValue = Mixxx::ReplayGain::kRatioUndefined;
+        }
+        for (size_t i = 0; i < sizeof(inputValues) / sizeof(inputValues[0]); ++i) {
+            parseGain2Ratio(inputValues[i], true, expectedValue);
+            if (0 <= replayGainDb) {
+                parseGain2Ratio(QString("  + ") + inputValues[i], true, expectedValue);
+            }
+        }
+    }
+}
+
+TEST_F(ReplayGainTest, ParseReplayGainDbInvalid) {
+    parseGain2Ratio("", false, Mixxx::ReplayGain::kRatioUndefined);
+    parseGain2Ratio("abcde", false, Mixxx::ReplayGain::kRatioUndefined);
+    parseGain2Ratio("0 dBA", false, Mixxx::ReplayGain::kRatioUndefined);
+}
+
+TEST_F(ReplayGainTest, NormalizeReplayGain) {
+    normalizeRatio(Mixxx::ReplayGain::kRatioUndefined);
+    normalizeRatio(Mixxx::ReplayGain::kRatioMin);
+    normalizeRatio(-Mixxx::ReplayGain::kRatioMin);
+    normalizeRatio(Mixxx::ReplayGain::kRatio0dB);
+    normalizeRatio(-Mixxx::ReplayGain::kRatio0dB);
+}
+
+} // anonymous namespace

--- a/src/test/replaygaintest.cpp
+++ b/src/test/replaygaintest.cpp
@@ -45,13 +45,7 @@ TEST_F(ReplayGainTest, ParseReplayGainDbValidRange) {
                 QString("  %1db ").arg(replayGainDb)
         };
         float expectedValue;
-        if (0 != replayGainDb) {
-            // regular case
-            expectedValue = db2ratio(double(replayGainDb));
-        } else {
-            // special case: 0 dB -> undefined
-            expectedValue = Mixxx::ReplayGain::kRatioUndefined;
-        }
+        expectedValue = db2ratio(double(replayGainDb));
         for (size_t i = 0; i < sizeof(inputValues) / sizeof(inputValues[0]); ++i) {
             parseGain2Ratio(inputValues[i], true, expectedValue);
             if (0 <= replayGainDb) {

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -113,8 +113,8 @@ void TrackInfoObject::setMetadata(const Mixxx::TrackMetadata& trackMetadata) {
     setDuration(trackMetadata.getDuration());
     setBitrate(trackMetadata.getBitrate());
 
-    if (trackMetadata.isReplayGainValid()) {
-        setReplayGain(trackMetadata.getReplayGain());
+    if (trackMetadata.getReplayGain().hasRatio()) {
+        setReplayGain(trackMetadata.getReplayGain().getRatio());
     }
 
     // Need to set BPM after sample rate since beat grid creation depends on
@@ -147,7 +147,9 @@ void TrackInfoObject::getMetadata(Mixxx::TrackMetadata* pTrackMetadata) {
     pTrackMetadata->setSampleRate(getSampleRate());
     pTrackMetadata->setDuration(getDuration());
     pTrackMetadata->setBitrate(getBitrate());
-    pTrackMetadata->setReplayGain(getReplayGain());
+    Mixxx::ReplayGain trackGain(pTrackMetadata->getReplayGain());
+    trackGain.setRatio(getReplayGain());
+    pTrackMetadata->setReplayGain(trackGain);
     pTrackMetadata->setBpm(getBpm());
     pTrackMetadata->setKey(getKeyText());
 }

--- a/src/util/replaygain.cpp
+++ b/src/util/replaygain.cpp
@@ -38,18 +38,6 @@ double ReplayGain::parseGain2Ratio(QString dbGain, bool* pValid) {
     if (isValid) {
         const double ratio = db2ratio(replayGainDb);
         DEBUG_ASSERT(kRatioUndefined != ratio);
-        // Some applications (e.g. Rapid Evolution 3) write a replay gain
-        // of 0 dB even if the replay gain is undefined. To be safe we
-        // ignore this special value and instead prefer to recalculate
-        // the replay gain.
-        if (kRatio0dB == ratio) {
-            // special case
-            qDebug() << "ReplayGain: Ignoring possibly undefined gain:" << formatRatio2Gain(ratio);
-            if (pValid) {
-                *pValid = true;
-            }
-            return kRatioUndefined;
-        }
         if (isValidRatio(ratio)) {
             if (pValid) {
                 *pValid = true;
@@ -73,7 +61,7 @@ QString ReplayGain::formatRatio2Gain(double ratio) {
 }
 
 double ReplayGain::normalizeRatio(double ratio) {
-    if (isValidRatio(ratio) && (kRatio0dB != ratio)) {
+    if (isValidRatio(ratio)) {
         const double normalizedRatio = parseGain2Ratio(formatRatio2Gain(ratio));
         // NOTE(uklotzde): Subsequently formatting and parsing the
         // normalized value should not alter it anymore!

--- a/src/util/replaygain.cpp
+++ b/src/util/replaygain.cpp
@@ -1,0 +1,87 @@
+#include "util/replaygain.h"
+
+#include "util/math.h"
+
+namespace Mixxx {
+
+/*static*/ const double ReplayGain::kRatioUndefined = 0.0;
+/*static*/ const double ReplayGain::kRatioMin = 0.0; // lower bound (inclusive)
+/*static*/ const double ReplayGain::kRatio0dB = 1.0;
+
+namespace {
+
+const QString kGainUnit("dB");
+const QString kGainSuffix(" " + kGainUnit);
+
+} // anonymous namespace
+
+double ReplayGain::parseGain2Ratio(QString dbGain, bool* pValid) {
+    if (pValid) {
+        *pValid = false;
+    }
+    QString trimmedGain(dbGain.trimmed());
+    const int plusIndex = trimmedGain.indexOf('+');
+    if (0 == plusIndex) {
+        // strip leading "+"
+        trimmedGain = trimmedGain.mid(plusIndex + 1).trimmed();
+    }
+    const int unitIndex = trimmedGain.lastIndexOf(kGainUnit, -1, Qt::CaseInsensitive);
+    if ((0 <= unitIndex) && ((trimmedGain.length() - 2) == unitIndex)) {
+        // strip trailing unit suffix
+        trimmedGain = trimmedGain.left(unitIndex).trimmed();
+    }
+    if (trimmedGain.isEmpty()) {
+        return kRatioUndefined;
+    }
+    bool isValid = false;
+    const double replayGainDb = trimmedGain.toDouble(&isValid);
+    if (isValid) {
+        const double ratio = db2ratio(replayGainDb);
+        DEBUG_ASSERT(kRatioUndefined != ratio);
+        // Some applications (e.g. Rapid Evolution 3) write a replay gain
+        // of 0 dB even if the replay gain is undefined. To be safe we
+        // ignore this special value and instead prefer to recalculate
+        // the replay gain.
+        if (kRatio0dB == ratio) {
+            // special case
+            qDebug() << "ReplayGain: Ignoring possibly undefined gain:" << formatRatio2Gain(ratio);
+            if (pValid) {
+                *pValid = true;
+            }
+            return kRatioUndefined;
+        }
+        if (isValidRatio(ratio)) {
+            if (pValid) {
+                *pValid = true;
+            }
+            return ratio;
+        } else {
+            qDebug() << "ReplayGain: Invalid gain value:" << dbGain << " -> "<< ratio;
+        }
+    } else {
+        qDebug() << "ReplayGain: Failed to parse gain:" << dbGain;
+    }
+    return kRatioUndefined;
+}
+
+QString ReplayGain::formatRatio2Gain(double ratio) {
+    if (isValidRatio(ratio)) {
+        return QString::number(ratio2db(ratio)) + kGainSuffix;
+    } else {
+        return QString();
+    }
+}
+
+double ReplayGain::normalizeRatio(double ratio) {
+    if (isValidRatio(ratio) && (kRatio0dB != ratio)) {
+        const double normalizedRatio = parseGain2Ratio(formatRatio2Gain(ratio));
+        // NOTE(uklotzde): Subsequently formatting and parsing the
+        // normalized value should not alter it anymore!
+        DEBUG_ASSERT(normalizedRatio == parseGain2Ratio(formatRatio2Gain(normalizedRatio)));
+        return normalizedRatio;
+    } else {
+        return ratio;
+    }
+}
+
+} //namespace Mixxx

--- a/src/util/replaygain.h
+++ b/src/util/replaygain.h
@@ -1,0 +1,76 @@
+#ifndef MIXXX_REPLAYGAIN_H
+#define MIXXX_REPLAYGAIN_H
+
+#include "util/types.h"
+
+namespace Mixxx {
+
+// DTO for replay gain. Must not be subclassed (no virtual destructor)!
+class ReplayGain {
+public:
+    static const double kRatioUndefined;
+    static const double kRatioMin; // lower bound (exclusive)
+    static const double kRatio0dB;
+
+    ReplayGain()
+        : m_ratio(kRatioUndefined)
+        , m_peak(CSAMPLE_PEAK) {
+    }
+
+    static bool isValidRatio(double ratio) {
+        return kRatioMin < ratio;
+    }
+    bool hasRatio() const {
+        return isValidRatio(m_ratio);
+    }
+    double getRatio() const {
+        return m_ratio;
+    }
+    void setRatio(double ratio) {
+        m_ratio = ratio;
+    }
+    void resetRatio() {
+        m_ratio = kRatioUndefined;
+    }
+
+    // Parse and format replay gain metadata according to the ReplayGain
+    // 1.0/2.0 specification.
+    // http://wiki.hydrogenaud.io/index.php?title=ReplayGain_1.0_specification
+    // http://wiki.hydrogenaud.io/index.php?title=ReplayGain_2.0_specification
+    static double parseGain2Ratio(QString dBGain, bool* pValid = 0);
+    static QString formatRatio2Gain(double ratio);
+
+    // After normalization formatting and parsing the ratio repeatedly will
+    // always lead to the same value. This is required to reliably store the
+    // dB gain as a string in track metadata.
+    static double normalizeRatio(double ratio);
+
+    // The peak amplitude of the track or signal.
+    CSAMPLE getPeak() const {
+        return m_ratio;
+    }
+    void setPeak(CSAMPLE peak) {
+        m_peak = peak;
+    }
+    void resetPeak() {
+        m_peak = CSAMPLE_PEAK;
+    }
+
+private:
+    double m_ratio;
+    CSAMPLE m_peak;
+};
+
+inline
+bool operator==(const ReplayGain& lhs, const ReplayGain& rhs) {
+    return (lhs.getRatio() == rhs.getRatio()) && (lhs.getPeak() == rhs.getPeak());
+}
+
+inline
+bool operator!=(const ReplayGain& lhs, const ReplayGain& rhs) {
+    return !(lhs == rhs);
+}
+
+}
+
+#endif // MIXXX_REPLAYGAIN_H


### PR DESCRIPTION
The harvest from the tag writing branch with some lessons learned. Especially the handling of ID3 tags is always tricky. I already use this stuff heavily to keep the tags of my files (mostly MP3/M4A/FLAC) in sync with the Mixxx library, including bpm, key, and replay gain.

iTunes still doesn't recognize the ID3v2 comment tag in MP3 files written by TagLib. Give me a hint if you know what's missing ;)
