### PR TITLE
Introduce new concept for audio signals

### DIFF
--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -236,10 +236,10 @@ Result SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSrcCfg) {
                 << "Continuing with default values.";
     }
 
-    SAMPLERATE_TYPE sampleRate;
+    SAMPLERATE_TYPE samplingRate;
     unsigned char channelCount;
     if (0 > NeAACDecInit2(m_hDecoder, configBuffer, configBufferSize,
-                    &sampleRate, &channelCount)) {
+                    &samplingRate, &channelCount)) {
         free(configBuffer);
         qWarning() << "Failed to initialize the AAC decoder!";
         return ERR;
@@ -254,7 +254,7 @@ Result SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSrcCfg) {
                                       (m_framesPerSampleBlock - 1)) / m_framesPerSampleBlock;
 
     setChannelCount(channelCount);
-    setFrameRate(sampleRate);
+    setSamplingRate(samplingRate);
     setFrameCount(((m_maxSampleBlockId - kSampleBlockIdMin) + 1) * m_framesPerSampleBlock);
 
     // Resize temporary buffer for decoded sample data
@@ -460,10 +460,10 @@ SINT SoundSourceM4A::readSampleFrames(
                     << "<>" << getChannelCount();
             break; // abort
         }
-        if (getFrameRate() != SINT(decFrameInfo.samplerate)) {
+        if (getSamplingRate() != SINT(decFrameInfo.samplerate)) {
             qWarning() << "Corrupt or unsupported AAC file:"
-                    << "Unexpected sample rate" << decFrameInfo.samplerate
-                    << "<>" << getFrameRate();
+                    << "Unexpected sampling rate" << decFrameInfo.samplerate
+                    << "<>" << getSamplingRate();
             break; // abort
         }
 

--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -212,8 +212,8 @@ Result SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSrcCfg) {
     NeAACDecConfigurationPtr pDecoderConfig = NeAACDecGetCurrentConfiguration(
             m_hDecoder);
     pDecoderConfig->outputFormat = FAAD_FMT_FLOAT;
-    if ((kChannelCountMono == audioSrcCfg.channelCountHint) ||
-            (kChannelCountStereo == audioSrcCfg.channelCountHint)) {
+    if ((kChannelCountMono == audioSrcCfg.getChannelCount()) ||
+            (kChannelCountStereo == audioSrcCfg.getChannelCount())) {
         pDecoderConfig->downMatrix = 1;
     } else {
         pDecoderConfig->downMatrix = 0;

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -495,8 +495,8 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     } else {
         qDebug() << "Number of channels in input stream" << numChannels;
     }
-    if (isValidChannelCount(audioSrcCfg.channelCountHint)) {
-        numChannels = audioSrcCfg.channelCountHint;
+    if (audioSrcCfg.hasChannelCount()) {
+        numChannels = audioSrcCfg.getChannelCount();
         hr = pAudioType->SetUINT32(
                 MF_MT_AUDIO_NUM_CHANNELS, numChannels);
         if (FAILED(hr)) {
@@ -519,8 +519,8 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     } else {
         qDebug() << "Samples per second in input stream" << samplesPerSecond;
     }
-    if (isValidFrameRate(audioSrcCfg.frameRateHint)) {
-        samplesPerSecond = audioSrcCfg.frameRateHint;
+    if (audioSrcCfg.hasSamplingRate()) {
+        samplesPerSecond = audioSrcCfg.getSamplingRate();
         hr = pAudioType->SetUINT32(
                 MF_MT_AUDIO_SAMPLES_PER_SECOND, samplesPerSecond);
         if (FAILED(hr)) {

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -162,7 +162,7 @@ SINT SoundSourceMediaFoundation::seekSampleFrame(
     if (sDebug) {
         qDebug() << "seekSampleFrame()" << frameIndex;
     }
-    qint64 mfSeekTarget(mfFromFrame(frameIndex, getFrameRate()) - 1);
+    qint64 mfSeekTarget(mfFromFrame(frameIndex, getSamplingRate()) - 1);
     // minus 1 here seems to make our seeking work properly, otherwise we will
     // (more often than not, maybe always) seek a bit too far (although not
     // enough for our calculatedFrameFromMF <= nextFrame assertion in ::read).
@@ -250,7 +250,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
 
         if (sDebug) {
             qDebug() << "ReadSample timestamp:" << timestamp << "frame:"
-                    << frameFromMF(timestamp, getFrameRate()) << "dwflags:" << dwFlags;
+                    << frameFromMF(timestamp, getSamplingRate()) << "dwflags:" << dwFlags;
         }
 
         if (dwFlags & MF_SOURCE_READERF_ERROR) {
@@ -290,7 +290,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
         SINT bufferLength = samples2frames(bufferLengthInBytes / sizeof(buffer[0]));
 
         if (m_seeking) {
-            qint64 bufferPosition(frameFromMF(timestamp, getFrameRate()));
+            qint64 bufferPosition(frameFromMF(timestamp, getSamplingRate()));
             if (sDebug) {
                 qDebug() << "While seeking to " << m_nextFrame
                         << "WMF put us at" << bufferPosition;
@@ -581,7 +581,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
             << "failed to get the actual sample rate";
         return false;
     }
-    setFrameRate(samplesPerSecond);
+    setSamplingRate(samplesPerSecond);
 
     UINT32 leftoverBufferSizeInBytes = 0;
     hr = pAudioType->GetUINT32(MF_MT_SAMPLE_SIZE, &leftoverBufferSizeInBytes);
@@ -612,14 +612,14 @@ bool SoundSourceMediaFoundation::readProperties() {
         return false;
     }
     m_mfDuration = prop.hVal.QuadPart;
-    setFrameCount(frameFromMF(m_mfDuration, getFrameRate()));
+    setFrameCount(frameFromMF(m_mfDuration, getSamplingRate()));
     qDebug() << "SSMF: Frame count" << getFrameCount();
     PropVariantClear(&prop);
 
     // presentation attribute MF_PD_AUDIO_ENCODING_BITRATE only exists for
     // presentation descriptors, one of which MFSourceReader is not.
     // Therefore, we calculate it ourselves.
-    setBitrate(kBitsPerSample * frames2samples(getFrameRate()));
+    setBitrate(kBitsPerSample * frames2samples(getSamplingRate()));
 
     return true;
 }

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -32,8 +32,8 @@ Result SoundSourceWV::tryOpen(const AudioSourceConfig& audioSrcCfg) {
     DEBUG_ASSERT(!m_wpc);
     char msg[80]; // hold possible error message
     int openFlags = OPEN_WVC | OPEN_NORMALIZE;
-    if ((kChannelCountMono == audioSrcCfg.channelCountHint) ||
-            (kChannelCountStereo == audioSrcCfg.channelCountHint)) {
+    if ((kChannelCountMono == audioSrcCfg.getChannelCount()) ||
+            (kChannelCountStereo == audioSrcCfg.getChannelCount())) {
         openFlags |= OPEN_2CH_MAX;
     }
 

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -56,7 +56,7 @@ Result SoundSourceWV::tryOpen(const AudioSourceConfig& audioSrcCfg) {
     }
 
     setChannelCount(WavpackGetReducedChannels(m_wpc));
-    setFrameRate(WavpackGetSampleRate(m_wpc));
+    setSamplingRate(WavpackGetSampleRate(m_wpc));
     setFrameCount(WavpackGetNumSamples(m_wpc));
 
     if (WavpackGetMode(m_wpc) & MODE_FLOAT) {

--- a/src/analyserqueue.cpp
+++ b/src/analyserqueue.cpp
@@ -330,7 +330,7 @@ void AnalyserQueue::run() {
         bool processTrack = false;
         while (it.hasNext()) {
             // Make sure not to short-circuit initialise(...)
-            if (it.next()->initialise(nextTrack, pAudioSource->getFrameRate(), pAudioSource->getFrameCount() * kAnalysisChannels)) {
+            if (it.next()->initialise(nextTrack, pAudioSource->getSamplingRate(), pAudioSource->getFrameCount() * kAnalysisChannels)) {
                 processTrack = true;
             }
         }

--- a/src/analyserqueue.cpp
+++ b/src/analyserqueue.cpp
@@ -318,7 +318,7 @@ void AnalyserQueue::run() {
         // Get the audio
         SoundSourceProxy soundSourceProxy(nextTrack);
         Mixxx::AudioSourceConfig audioSrcCfg;
-        audioSrcCfg.channelCountHint = kAnalysisChannels;
+        audioSrcCfg.setChannelCount(kAnalysisChannels);
         Mixxx::AudioSourcePointer pAudioSource(soundSourceProxy.openAudioSource(audioSrcCfg));
         if (!pAudioSource) {
             qWarning() << "Failed to open file for analyzing:" << nextTrack->getLocation();

--- a/src/audiosignal.h
+++ b/src/audiosignal.h
@@ -1,0 +1,121 @@
+#ifndef MIXXX_AUDIOSIGNAL_H
+#define MIXXX_AUDIOSIGNAL_H
+
+#include "util/assert.h"
+#include "util/types.h"
+
+namespace Mixxx {
+
+// Common properties of audio signals in Mixxx.
+//
+// An audio signal describes a stream of samples for multiple channels.
+// If there is more than one channel, the samples of each channel will
+// be interleaved. The samples from all channels that are coincident
+// in time are called a "frame". Consequently audio signals are streamed
+// frame by frame. With the knowledge about the number of channels sample
+// and frame offsets in the stream can be converted vice versa.
+//
+// Internally each sample is represented by a floating-point value.
+//
+// The properties of an audio signal are immutable and must be constant
+// over time. Therefore all functions for modifying individual properties
+// are declared as "protected" and only available from derived classes.
+class AudioSignal {
+public:
+    static const SINT kChannelCountZero    = 0;
+    static const SINT kChannelCountMono    = 1;
+    static const SINT kChannelCountStereo  = 2;
+    static const SINT kChannelCountDefault = kChannelCountZero;
+
+    static bool isValidChannelCount(SINT channelCount) {
+        return kChannelCountZero < channelCount;
+    }
+
+    static const SINT kSamplingRateZero    = 0;
+    static const SINT kSamplingRateCD      = 44100;
+    static const SINT kSamplingRate48kHz   = 48000;
+    static const SINT kSamplingRate96kHz   = 96000;
+    static const SINT kSamplingRateDefault = kSamplingRateZero;
+
+    static bool isValidSamplingRate(SINT samplingRate) {
+        return kSamplingRateZero < samplingRate;
+    }
+
+    AudioSignal()
+        : m_channelCount(kChannelCountDefault),
+          m_samplingRate(kSamplingRateDefault) {
+    }
+    AudioSignal(SINT channelCount, SINT samplingRate)
+        : m_channelCount(channelCount),
+          m_samplingRate(samplingRate) {
+        DEBUG_ASSERT(kChannelCountZero <= m_channelCount);
+        DEBUG_ASSERT(kSamplingRateZero <= m_samplingRate);
+    }
+    virtual ~AudioSignal() {}
+
+    // Returns the number of channels.
+    SINT getChannelCount() const {
+        return m_channelCount;
+    }
+    bool hasChannelCount() const {
+        return isValidChannelCount(getChannelCount());
+    }
+
+    // Returns the sampling rate in Hz. The sampling rate is defined as the
+    // number of samples per second for each channel. Please not that this
+    // does not equal the total number of samples per second in the stream!
+    SINT getSamplingRate() const {
+        return m_samplingRate;
+    }
+    bool hasSamplingRate() const {
+        return isValidSamplingRate(getSamplingRate());
+    }
+
+    // Check for valid properties. Subclasses may override this function
+    // to add more constraints. Derived functions should always call the
+    // implementation of the super class and concatenate the result with
+    // && (logical and).
+    virtual bool isValid() const {
+        return hasChannelCount() && hasSamplingRate();
+    }
+
+    // Conversion: #samples / sample offset -> #frames / frame offset
+    template<typename T>
+    inline T samples2frames(T samples) const {
+        DEBUG_ASSERT(hasChannelCount());
+        DEBUG_ASSERT(0 == (samples % getChannelCount()));
+        return samples / getChannelCount();
+    }
+
+    // Conversion: #frames / frame offset -> #samples / sample offset
+    template<typename T>
+    inline T frames2samples(T frames) const {
+        DEBUG_ASSERT(hasChannelCount());
+        return frames * getChannelCount();
+    }
+
+protected:
+    void setChannelCount(SINT channelCount) {
+        DEBUG_ASSERT(isValidChannelCount(channelCount));
+        m_channelCount = channelCount;
+    }
+    void resetChannelCount() {
+        m_channelCount = kChannelCountDefault;
+    }
+
+    void setSamplingRate(SINT samplingRate) {
+        DEBUG_ASSERT(isValidSamplingRate(samplingRate));
+        m_samplingRate = samplingRate;
+    }
+    void resetSamplingRate() {
+        m_samplingRate = kSamplingRateDefault;
+    }
+
+private:
+    SINT m_channelCount;
+    SINT m_samplingRate;
+};
+
+}
+
+#endif // MIXXX_AUDIOSIGNAL_H

--- a/src/audiosignal.h
+++ b/src/audiosignal.h
@@ -64,6 +64,10 @@ public:
     // Returns the sampling rate in Hz. The sampling rate is defined as the
     // number of samples per second for each channel. Please not that this
     // does not equal the total number of samples per second in the stream!
+    //
+    // NOTE(uklotzde): I consciously avoided the term "sample rate", because
+    // that sounds like "number of samples per second" which is wrong for
+    // signals with more than a single channel and might be misleading!
     SINT getSamplingRate() const {
         return m_samplingRate;
     }

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -166,7 +166,7 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     const SINT sampleCount =
             CachingReaderChunk::frames2samples(
                     m_pAudioSource->getFrameCount());
-    emit(trackLoaded(pTrack, m_pAudioSource->getFrameRate(), sampleCount));
+    emit(trackLoaded(pTrack, m_pAudioSource->getSamplingRate(), sampleCount));
 }
 
 void CachingReaderWorker::quitWait() {

--- a/src/cachingreaderworker.cpp
+++ b/src/cachingreaderworker.cpp
@@ -131,7 +131,7 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     }
 
     Mixxx::AudioSourceConfig audioSrcCfg;
-    audioSrcCfg.channelCountHint = CachingReaderChunk::kChannels;
+    audioSrcCfg.setChannelCount(CachingReaderChunk::kChannels);
     m_pAudioSource = openAudioSourceForReading(pTrack, audioSrcCfg);
     if (m_pAudioSource.isNull()) {
         m_maxReadableFrameIndex = Mixxx::AudioSource::getMinFrameIndex();

--- a/src/dlgprefmodplug.cpp
+++ b/src/dlgprefmodplug.cpp
@@ -129,7 +129,7 @@ void DlgPrefModplug::applySettings() {
     // Bits per sample - 8, 16, or 32
     settings.mBits = Mixxx::SoundSourceModPlug::kBitsPerSample;
     // Sampling rate - 11025, 22050, or 44100
-    settings.mFrequency = Mixxx::SoundSourceModPlug::kFrameRate;
+    settings.mFrequency = Mixxx::SoundSourceModPlug::kSamplingRate;
 
     // enabled features flags
     settings.mFlags = 0;

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -23,7 +23,7 @@ namespace
     QString calcFingerprint(const Mixxx::AudioSourcePointer& pAudioSource) {
 
         SINT numFrames =
-                kFingerprintDuration * pAudioSource->getFrameRate();
+                kFingerprintDuration * pAudioSource->getSamplingRate();
         // check that the song is actually longer then the amount of audio we use
         if (numFrames > pAudioSource->getFrameCount()) {
             numFrames = pAudioSource->getFrameCount();
@@ -56,7 +56,7 @@ namespace
         qDebug("reading file took: %d ms" , timerReadingFile.elapsed());
 
         ChromaprintContext* ctx = chromaprint_new(CHROMAPRINT_ALGORITHM_DEFAULT);
-        chromaprint_start(ctx, pAudioSource->getFrameRate(), kFingerprintChannels);
+        chromaprint_start(ctx, pAudioSource->getSamplingRate(), kFingerprintChannels);
 
         QTime timerGeneratingFingerprint;
         timerGeneratingFingerprint.start();

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -100,7 +100,7 @@ ChromaPrinter::ChromaPrinter(QObject* parent)
 QString ChromaPrinter::getFingerprint(TrackPointer pTrack) {
     SoundSourceProxy soundSourceProxy(pTrack);
     Mixxx::AudioSourceConfig audioSrcCfg;
-    audioSrcCfg.channelCountHint = kFingerprintChannels;
+    audioSrcCfg.setChannelCount(kFingerprintChannels);
     Mixxx::AudioSourcePointer pAudioSource(soundSourceProxy.openAudioSource(audioSrcCfg));
     if (pAudioSource.isNull()) {
         qDebug() << "Skipping invalid file:" << pTrack->getLocation();

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -158,6 +158,7 @@ Mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const Mixxx::AudioSo
         qWarning() << "Invalid file:" << m_pSoundSource->getUrlString()
                 << "channels" << m_pSoundSource->getChannelCount()
                 << "frame rate" << m_pSoundSource->getChannelCount();
+                << "sampling rate" << m_pSoundSource->getSamplingRate();
         return m_pAudioSource;
     }
     if (m_pSoundSource->isEmpty()) {
@@ -168,7 +169,7 @@ Mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const Mixxx::AudioSo
     // Overwrite metadata with actual audio properties
     if (m_pTrack) {
         m_pTrack->setChannels(m_pSoundSource->getChannelCount());
-        m_pTrack->setSampleRate(m_pSoundSource->getFrameRate());
+        m_pTrack->setSampleRate(m_pSoundSource->getSamplingRate());
         if (m_pSoundSource->hasDuration()) {
             m_pTrack->setDuration(m_pSoundSource->getDuration());
         }

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -157,7 +157,6 @@ Mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const Mixxx::AudioSo
     if (!m_pSoundSource->isValid()) {
         qWarning() << "Invalid file:" << m_pSoundSource->getUrlString()
                 << "channels" << m_pSoundSource->getChannelCount()
-                << "frame rate" << m_pSoundSource->getChannelCount();
                 << "sampling rate" << m_pSoundSource->getSamplingRate();
         return m_pAudioSource;
     }

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -21,20 +21,8 @@ void AudioSource::clampFrameInterval(
 
 AudioSource::AudioSource(const QUrl& url)
         : UrlResource(url),
-          m_channelCount(kChannelCountDefault),
-          m_frameRate(kFrameRateDefault),
           m_frameCount(kFrameCountDefault),
           m_bitrate(kBitrateDefault) {
-}
-
-void AudioSource::setChannelCount(SINT channelCount) {
-    DEBUG_ASSERT(isValidChannelCount(channelCount));
-    m_channelCount = channelCount;
-}
-
-void AudioSource::setFrameRate(SINT frameRate) {
-    DEBUG_ASSERT(isValidFrameRate(frameRate));
-    m_frameRate = frameRate;
 }
 
 void AudioSource::setFrameCount(SINT frameCount) {

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -232,14 +232,22 @@ private:
 };
 
 // Parameters for configuring audio sources
-struct AudioSourceConfig {
-    AudioSourceConfig()
-        : channelCountHint(AudioSignal::kChannelCountDefault),
-          frameRateHint(AudioSignal::kSamplingRateDefault){
-    }
+class AudioSourceConfig: public AudioSignal {
+public:
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+    // NOTE(uklotzde): Inheriting constructors are supported since VS2015.
+    AudioSourceConfig() {}
+    AudioSignal(SINT channelCount, SINT samplingRate): AudioSignal(channelCount, samplingRate) {}
+#else
+    // Inherit constructors from base class
+    using AudioSignal::AudioSignal;
+#endif
 
-    SINT channelCountHint;
-    SINT frameRateHint;
+    using AudioSignal::setChannelCount;
+    using AudioSignal::resetChannelCount;
+
+    using AudioSignal::setSamplingRate;
+    using AudioSignal::resetSamplingRate;
 };
 
 typedef QSharedPointer<AudioSource> AudioSourcePointer;

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -17,7 +17,7 @@ struct AudioSourceConfig;
 
 // Common interface and base class for audio sources.
 //
-// Both the number of channels and the frame rate must
+// Both the number of channels and the sampling rate must
 // be constant and are not allowed to change over time.
 //
 // The length of audio data is measured in frames. A frame
@@ -33,15 +33,7 @@ struct AudioSourceConfig;
 // closed upon destruction.
 class AudioSource: public UrlResource, public AudioSignal {
 public:
-    // Returns the number of frames per second. This equals
-    // the number samples for each channel per second, which
-    // must be uniform among all channels. The frame rate
-    // must be constant over time.
-    inline SINT getFrameRate() const {
-        return getSamplingRate();
-    }
-
-    // Returns the total number of frames.
+    // Returns the total number of sample frames.
     inline SINT getFrameCount() const {
         return m_frameCount;
     }
@@ -57,7 +49,7 @@ public:
     }
     inline SINT getDuration() const {
         DEBUG_ASSERT(hasDuration()); // prevents division by zero
-        return getFrameCount() / getFrameRate();
+        return getFrameCount() / getSamplingRate();
     }
 
     // The bitrate is measured in kbit/s (kbps).
@@ -97,7 +89,7 @@ public:
     // - Precondition: isValidFrameIndex(frameIndex) == true
     //   - Index of first frame: frameIndex = 0
     //   - Index of last frame: frameIndex = getFrameCount() - 1
-    // - The seek position in seconds is frameIndex / frameRate()
+    // - The seek position in seconds is frameIndex / getSamplingRate()
     // Returns the actual current frame index which may differ from the
     // requested index if the source does not support accurate seeking.
     virtual SINT seekSampleFrame(SINT frameIndex) = 0;
@@ -192,16 +184,6 @@ public:
 
 protected:
     explicit AudioSource(const QUrl& url);
-
-    inline static bool isValidFrameRate(SINT frameRate) {
-        return isValidSamplingRate(frameRate);
-    }
-    inline bool hasFrameRate() const {
-        return hasSamplingRate();
-    }
-    void setFrameRate(SINT frameRate) {
-        setSamplingRate(frameRate);
-    }
 
     inline static bool isValidFrameCount(SINT frameCount) {
         return kFrameCountZero <= frameCount;

--- a/src/sources/soundsource.h
+++ b/src/sources/soundsource.h
@@ -23,6 +23,11 @@ public:
     //
     // Since reopening is not supported close() will be called
     // implicitly before the AudioSource is actually opened.
+    //
+    // Optionally the caller may provide the desired properties
+    // of the decoded audio signal. Some decoders are able to reduce
+    // the number of channels or do resampling on the fly while decoding
+    // the input data.
     Result open(const AudioSourceConfig& audioSrcCfg = AudioSourceConfig());
 
     // Closes the AudioSource and frees all resources.

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -78,7 +78,7 @@ Result SoundSourceCoreAudio::tryOpen(const AudioSourceConfig& audioSrcCfg) {
 
     // create the output format
     const UInt32 numChannels =
-            isValidChannelCount(audioSrcCfg.channelCountHint) ? audioSrcCfg.channelCountHint : 2;
+            audioSrcCfg.hasChannelCount() ? audioSrcCfg.getChannelCount() : 2;
     m_outputFormat = CAStreamBasicDescription(m_inputFormat.mSampleRate,
             numChannels, CAStreamBasicDescription::kPCMFormatFloat32, true);
 

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -125,7 +125,7 @@ Result SoundSourceCoreAudio::tryOpen(const AudioSourceConfig& audioSrcCfg) {
     }
 
     setChannelCount(m_outputFormat.NumberChannels());
-    setFrameRate(m_inputFormat.mSampleRate);
+    setSamplingRate(m_inputFormat.mSampleRate);
     // NOTE(uklotzde): This is what I found when migrating
     // the code from SoundSource (sample-oriented) to the new
     // AudioSource (frame-oriented) API. It is not documented

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -154,11 +154,11 @@ Result SoundSourceFFmpeg::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
     m_pResample->openMixxx(m_pCodecCtx->sample_fmt, AV_SAMPLE_FMT_FLT);
 
     setChannelCount(m_pCodecCtx->channels);
-    setFrameRate(m_pCodecCtx->sample_rate);
+    setSamplingRate(m_pCodecCtx->sample_rate);
     setFrameCount((qint64)round((double)((double)m_pFormatCtx->duration *
                                          (double)m_pCodecCtx->sample_rate) / (double)AV_TIME_BASE));
 
-    qDebug() << "SoundSourceFFmpeg::tryOpen: Samplerate: " << getFrameRate() <<
+    qDebug() << "SoundSourceFFmpeg::tryOpen: Sampling rate: " << getSamplingRate() <<
              ", Channels: " <<
              getChannelCount() << "\n";
     if (getChannelCount() > 2) {

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -343,10 +343,10 @@ FLAC__StreamDecoderWriteStatus SoundSourceFLAC::flacWrite(
                 << frame->header.channels << "<>" << getChannelCount();
         return FLAC__STREAM_DECODER_WRITE_STATUS_ABORT;
     }
-    if (getFrameRate() != SINT(frame->header.sample_rate)) {
+    if (getSamplingRate() != SINT(frame->header.sample_rate)) {
         qWarning() << "Corrupt or unsupported FLAC file:"
                 << "Invalid sample rate in FLAC frame header"
-                << frame->header.sample_rate << "<>" << getFrameRate();
+                << frame->header.sample_rate << "<>" << getSamplingRate();
         return FLAC__STREAM_DECODER_WRITE_STATUS_ABORT;
     }
     const SINT numReadableFrames = frame->header.blocksize;
@@ -429,21 +429,21 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
             qWarning() << "Invalid channel count:"
                     << channelCount;
         }
-        const SINT frameRate = metadata->data.stream_info.sample_rate;
-        if (isValidFrameRate(frameRate)) {
-            if (hasFrameRate()) {
+        const SINT samplingRate = metadata->data.stream_info.sample_rate;
+        if (isValidSamplingRate(samplingRate)) {
+            if (hasSamplingRate()) {
                 // already set before -> check for consistency
-                if (getFrameRate() != frameRate) {
-                    qWarning() << "Unexpected frame/sample rate:"
-                            << frameRate << " <> " << getFrameRate();
+                if (getSamplingRate() != samplingRate) {
+                    qWarning() << "Unexpected sampling rate:"
+                            << samplingRate << " <> " << getSamplingRate();
                 }
             } else {
                 // not set before
-                setFrameRate(frameRate);
+                setSamplingRate(samplingRate);
             }
         } else {
-            qWarning() << "Invalid frame/sample rate:"
-                    << frameRate;
+            qWarning() << "Invalid sampling rate:"
+                    << samplingRate;
         }
         const SINT frameCount = metadata->data.stream_info.total_samples;
         DEBUG_ASSERT(isValidFrameCount(frameCount));

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -41,7 +41,7 @@ QString getModPlugTypeFromUrl(QUrl url) {
 
 const SINT SoundSourceModPlug::kChannelCount = AudioSource::kChannelCountStereo;
 const SINT SoundSourceModPlug::kBitsPerSample = 16;
-const SINT SoundSourceModPlug::kFrameRate = 44100; // 44.1 kHz
+const SINT SoundSourceModPlug::kSamplingRate = 44100; // 44.1 kHz
 
 unsigned int SoundSourceModPlug::s_bufferSizeLimit = 0;
 
@@ -117,7 +117,7 @@ Result SoundSourceModPlug::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
     const SampleBuffer::size_type estimateMilliseconds =
             ModPlug::ModPlug_GetLength(m_pModFile);
     const SampleBuffer::size_type estimateSamples =
-            estimateMilliseconds * kChannelCount * kFrameRate;
+            estimateMilliseconds * kChannelCount * kSamplingRate;
     const SampleBuffer::size_type estimateChunks =
             (estimateSamples + (chunkSizeInSamples - 1)) / chunkSizeInSamples;
     const SampleBuffer::size_type sampleBufferCapacity = math_min(
@@ -151,7 +151,7 @@ Result SoundSourceModPlug::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
             << " samples unused capacity.";
 
     setChannelCount(kChannelCount);
-    setFrameRate(kFrameRate);
+    setSamplingRate(kSamplingRate);
     setFrameCount(samples2frames(m_sampleBuf.size()));
     m_seekPos = 0;
 

--- a/src/sources/soundsourcemodplug.h
+++ b/src/sources/soundsourcemodplug.h
@@ -17,8 +17,8 @@ namespace Mixxx {
 class SoundSourceModPlug: public Mixxx::SoundSource {
 public:
     static const SINT kChannelCount;
+    static const SINT kSamplingRate;
     static const SINT kBitsPerSample;
-    static const SINT kFrameRate;
 
     // apply settings for decoding
     static void configure(unsigned int bufferSizeLimit,

--- a/src/sources/soundsourceoggvorbis.cpp
+++ b/src/sources/soundsourceoggvorbis.cpp
@@ -58,7 +58,7 @@ Result SoundSourceOggVorbis::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
         return ERR;
     }
     setChannelCount(vi->channels);
-    setFrameRate(vi->rate);
+    setSamplingRate(vi->rate);
     if (0 < vi->bitrate_nominal) {
         setBitrate(vi->bitrate_nominal / 1000);
     } else {

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -31,7 +31,7 @@ private:
 } // anonymous namespace
 
 // Decoded output of opusfile has a fixed sample rate of 48 kHz
-const SINT SoundSourceOpus::kFrameRate = 48000;
+const SINT SoundSourceOpus::kSamplingRate = 48000;
 
 SoundSourceOpus::SoundSourceOpus(QUrl url)
         : SoundSource(url, "opus"),
@@ -81,7 +81,7 @@ Result SoundSourceOpus::parseTrackMetadataAndCoverArt(
     const OpusTags *l_ptrOpusTags = op_tags(l_ptrOpusFile, -1);
 
     pTrackMetadata->setChannels(op_channel_count(l_ptrOpusFile, -1));
-    pTrackMetadata->setSampleRate(Mixxx::SoundSourceOpus::kFrameRate);
+    pTrackMetadata->setSampleRate(Mixxx::SoundSourceOpus::kSamplingRate);
     pTrackMetadata->setBitrate(op_bitrate(l_ptrOpusFile, -1) / 1000);
     pTrackMetadata->setDuration(
             op_pcm_total(l_ptrOpusFile, -1) / pTrackMetadata->getSampleRate());
@@ -184,7 +184,7 @@ Result SoundSourceOpus::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
         return ERR;
     }
 
-    setFrameRate(kFrameRate);
+    setSamplingRate(kSamplingRate);
 
     m_curFrameIndex = getMinFrameIndex();
 

--- a/src/sources/soundsourceopus.h
+++ b/src/sources/soundsourceopus.h
@@ -10,7 +10,7 @@ namespace Mixxx {
 
 class SoundSourceOpus: public Mixxx::SoundSource {
 public:
-    static const SINT kFrameRate;
+    static const SINT kSamplingRate;
 
     explicit SoundSourceOpus(QUrl url);
     ~SoundSourceOpus();

--- a/src/sources/soundsourcepluginapi.h
+++ b/src/sources/soundsourcepluginapi.h
@@ -1,18 +1,17 @@
 #ifndef MIXXX_SOUNDSOURCEPLUGINAPI_H
 #define MIXXX_SOUNDSOURCEPLUGINAPI_H
 
-#define MIXXX_SOUNDSOURCEPLUGINAPI_VERSION 8
-/** @note SoundSource API Version history:
- 1 - Mixxx 1.8.0 Beta 2
- 2 - Mixxx 1.9.0 Pre (added key code)
- 3 - Mixxx 1.10.0 Pre (added freeing function for extensions)
- 4 - Mixxx 1.11.0 Pre (added composer field to SoundSource)
- 5 - Mixxx 1.12.0 Pre (added album artist and grouping fields to SoundSource)
- 6 - Mixxx 1.12.0 Pre (added cover art suppport)
- 7 - Mixxx 1.13.0 New SoundSource/AudioSource API
- 8 - Mixxx 1.13.0 New SoundSource Plugin API
- 9 - Mixxx 1.13.0 New classes AudioSignal and ReplayGain
- */
+#define MIXXX_SOUNDSOURCEPLUGINAPI_VERSION 9
+// SoundSource Plugin API version history:
+//   9 - Mixxx 1.13.0 - New classes AudioSignal and ReplayGain
+//   8 - Mixxx 1.13.0 - New SoundSource Plugin API
+//   7 - Mixxx 1.13.0 - New SoundSource/AudioSource API
+//   6 - Mixxx 1.12.0 - Cover art support
+//   5 - Mixxx 1.12.0 - Add album artist and grouping fields to SoundSource
+//   4 - Mixxx 1.11.0 - Add composer field to SoundSource
+//   3 - Mixxx 1.10.0 - Add freeing function for extensions
+//   2 - Mixxx 1.9.0  - Add key code
+//   1 - Mixxx 1.8.0  - Beta 2
 
 #include <QtGlobal>
 

--- a/src/sources/soundsourcepluginapi.h
+++ b/src/sources/soundsourcepluginapi.h
@@ -11,6 +11,7 @@
  6 - Mixxx 1.12.0 Pre (added cover art suppport)
  7 - Mixxx 1.13.0 New SoundSource/AudioSource API
  8 - Mixxx 1.13.0 New SoundSource Plugin API
+ 9 - Mixxx 1.13.0 New classes AudioSignal and ReplayGain
  */
 
 #include <QtGlobal>

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -37,7 +37,7 @@ Result SoundSourceSndFile::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
     }
 
     setChannelCount(sfInfo.channels);
-    setFrameRate(sfInfo.samplerate);
+    setSamplingRate(sfInfo.samplerate);
     setFrameCount(sfInfo.frames);
 
     return OK;

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -65,7 +65,7 @@ TEST_F(SoundSourceProxyTest, open) {
         Mixxx::AudioSourcePointer pAudioSource(openAudioSource(filePath));
         ASSERT_TRUE(!pAudioSource.isNull());
         EXPECT_LT(0, pAudioSource->getChannelCount());
-        EXPECT_LT(0, pAudioSource->getFrameRate());
+        EXPECT_LT(0, pAudioSource->getSamplingRate());
         EXPECT_LT(0, pAudioSource->getFrameCount());
     }
 }


### PR DESCRIPTION
Mixxx is lacking a concept that explicitly represents the properties of an audio signal. Violation of implicit assumptions like the number of channels (usually 2) have already caused bugs in the effects framework. It is also needed for fixing "Support arbitrary bit-depth and sample-rate processing." (https://bugs.launchpad.net/mixxx/+bug/807511).

This PR adds a simple (base) class that encapsulates common properties of an audio signal. I'm demonstrating it's usefulness by reusing it for the AudioSource/SoundSource framework.

All changes are simple code refactorings, functionality should not be affected!
