### PR TITLE
Vestax VCI-100MKII: map "Rate by quantized BPM" to [shift + pitch fader]

### DIFF
--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -3,7 +3,7 @@
   <info>
     <name>Vestax VCI-100MKII</name>
     <author>Takeshi Soejima</author>
-    <description>2015-10-18</description>
+    <description>2015-11-1</description>
     <wiki>http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii</wiki>
   </info>
   <controller id="VCI-100MKII">
@@ -265,78 +265,74 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>playposition</key>
+        <key>VCI102.rateMSB2</key>
         <status>0xB0</status>
         <midino>0x1E</midino>
         <options>
-          <fourteen-bit-msb/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>playposition</key>
+        <key>VCI102.rateMSB2</key>
         <status>0xB1</status>
         <midino>0x1E</midino>
         <options>
-          <fourteen-bit-msb/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>playposition</key>
+        <key>VCI102.rateMSB2</key>
         <status>0xB2</status>
         <midino>0x1E</midino>
         <options>
-          <fourteen-bit-msb/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>playposition</key>
+        <key>VCI102.rateMSB2</key>
         <status>0xB3</status>
         <midino>0x1E</midino>
         <options>
-          <fourteen-bit-msb/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>playposition</key>
+        <key>VCI102.rateLSB2</key>
         <status>0xB0</status>
         <midino>0x2E</midino>
         <options>
-          <fourteen-bit-lsb/>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>playposition</key>
+        <key>VCI102.rateLSB2</key>
         <status>0xB1</status>
         <midino>0x2E</midino>
         <options>
-          <fourteen-bit-lsb/>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>playposition</key>
+        <key>VCI102.rateLSB2</key>
         <status>0xB2</status>
         <midino>0x2E</midino>
         <options>
-          <fourteen-bit-lsb/>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>playposition</key>
+        <key>VCI102.rateLSB2</key>
         <status>0xB3</status>
         <midino>0x2E</midino>
         <options>
-          <fourteen-bit-lsb/>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>

--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -265,7 +265,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>VCI102.rateMSB2</key>
+        <key>VCI102.rateQuantizedMSB</key>
         <status>0xB0</status>
         <midino>0x1E</midino>
         <options>
@@ -274,7 +274,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>VCI102.rateMSB2</key>
+        <key>VCI102.rateQuantizedMSB</key>
         <status>0xB1</status>
         <midino>0x1E</midino>
         <options>
@@ -283,7 +283,7 @@
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>VCI102.rateMSB2</key>
+        <key>VCI102.rateQuantizedMSB</key>
         <status>0xB2</status>
         <midino>0x1E</midino>
         <options>
@@ -292,7 +292,7 @@
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>VCI102.rateMSB2</key>
+        <key>VCI102.rateQuantizedMSB</key>
         <status>0xB3</status>
         <midino>0x1E</midino>
         <options>
@@ -301,7 +301,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>VCI102.rateLSB2</key>
+        <key>VCI102.rateQuantizedLSB</key>
         <status>0xB0</status>
         <midino>0x2E</midino>
         <options>
@@ -310,7 +310,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>VCI102.rateLSB2</key>
+        <key>VCI102.rateQuantizedLSB</key>
         <status>0xB1</status>
         <midino>0x2E</midino>
         <options>
@@ -319,7 +319,7 @@
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>VCI102.rateLSB2</key>
+        <key>VCI102.rateQuantizedLSB</key>
         <status>0xB2</status>
         <midino>0x2E</midino>
         <options>
@@ -328,7 +328,7 @@
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>VCI102.rateLSB2</key>
+        <key>VCI102.rateQuantizedLSB</key>
         <status>0xB3</status>
         <midino>0x2E</midino>
         <options>

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -127,30 +127,30 @@ VCI102.jog = function(ch, midino, value, status, group) {
     }
 };
 
-VCI102.rate7 = [64, 64, 64, 64];
+VCI102.rate7bit = [64, 64, 64, 64];
 
 VCI102.rateEnable = [true, true, true, true];
 
 VCI102.rateMSB = function(ch, midino, value, status, group) {
     if (!VCI102.rateEnable[ch]) {
-        if (Math.abs(value - VCI102.rate7[ch]) > 1) {
+        if (Math.abs(value - VCI102.rate7bit[ch]) > 1) {
             VCI102.rateEnable[ch] = true;
         } else {
             return;
         }
     }
-    VCI102.rate7[ch] = value;
+    VCI102.rate7bit[ch] = value;
 };
 
-VCI102.rateMSB2 = function(ch, midino, value, status, group) {
+VCI102.rateQuantizedMSB = function(ch, midino, value, status, group) {
     if (VCI102.rateEnable[ch]) {
         VCI102.rateEnable[ch] = false;
     }
-    VCI102.rate7[ch] = value;
+    VCI102.rate7bit[ch] = value;
 };
 
 VCI102.rate = function(ch, lsb) {
-    return ((64 - VCI102.rate7[ch]) * 128 - lsb) / 8192;
+    return ((64 - VCI102.rate7bit[ch]) * 128 - lsb) / 8192;
 };
 
 VCI102.rateLSB = function(ch, midino, value, status, group) {
@@ -159,7 +159,7 @@ VCI102.rateLSB = function(ch, midino, value, status, group) {
     }
 };
 
-VCI102.rateLSB2 = function(ch, midino, value, status, group) {
+VCI102.rateQuantizedLSB = function(ch, midino, value, status, group) {
     engine.setValue(
         group, "bpm", Math.round(
             (VCI102.rate(ch, value) * engine.getValue(group, "rateRange") + 1
@@ -255,7 +255,7 @@ VCI102.init = function() {
         [0x2C, 0x25, 0x27, 0x28],
         [0x28, 0x25, 0x27, 0x2C]
     ];
-    var LFX = [0x3A, 0x38];
+    var LEDfx = [0x3A, 0x38];
 
     function headMix(value, group, key) {
         var i;
@@ -289,9 +289,9 @@ VCI102.init = function() {
         };
     }
 
-    function makeLFX(ch, midino, fx) {
+    function makeLEDfx(ch, midino, button) {
         return function(value, group, key) {
-            if (group == VCI102.fxButton[ch % 2][fx]) {
+            if (group == VCI102.fxButton[ch % 2][button]) {
                 midi.sendShortMsg(0x90 + ch, midino, value * 127);
             }
         };
@@ -303,7 +303,7 @@ VCI102.init = function() {
         engine.connectControl(VCI102.deck[i], "pfl", headMix);
         enabled = "group_" + VCI102.deck[i] + "_enable";
         for (j = 0; j < 2; j++) {
-            led = makeLFX(i, LFX[j], j);
+            led = makeLEDfx(i, LEDfx[j], j);
             for (k = j + 1; k <= 4; k += 2) {
                 engine.connectControl(
                     "[EffectRack1_EffectUnit" + k + "]", enabled, led);

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -132,12 +132,13 @@ VCI102.rate7bit = [64, 64, 64, 64];
 VCI102.rateEnable = [true, true, true, true];
 
 VCI102.rateMSB = function(ch, midino, value, status, group) {
-    if (!VCI102.rateEnable[ch]) {
-        if (Math.abs(value - VCI102.rate7bit[ch]) > 1) {
-            VCI102.rateEnable[ch] = true;
-        } else {
-            return;
-        }
+    if (VCI102.rateEnable[ch]) {
+        engine.softTakeover(group, "rate", true);
+    } else if (Math.abs(value - VCI102.rate7bit[ch]) > 1) {
+        VCI102.rateEnable[ch] = true;
+        engine.softTakeover(group, "rate", false);
+    } else {
+        return;
     }
     VCI102.rate7bit[ch] = value;
 };
@@ -309,7 +310,6 @@ VCI102.init = function() {
                     "[EffectRack1_EffectUnit" + k + "]", enabled, led);
             }
         }
-        engine.softTakeover(VCI102.deck[i], "rate", true);
         engine.softTakeover(VCI102.deck[i], "pitch", true);
     }
     for (i = 1; i <= 4; i++) {

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -127,21 +127,21 @@ VCI102.jog = function(ch, midino, value, status, group) {
     }
 };
 
-VCI102.rate7bit = [64, 64, 64, 64];
-
 VCI102.rateEnable = [true, true, true, true];
+
+VCI102.rateValueMSB = [64, 64, 64, 64];  // defaults are at center
 
 VCI102.rateMSB = function(ch, midino, value, status, group) {
     // unlock rate control if the change is not caused by a mechanical drift
     if (VCI102.rateEnable[ch]) {
         engine.softTakeover(group, "rate", true);
-    } else if (Math.abs(value - VCI102.rate7bit[ch]) > 1) {
+    } else if (Math.abs(value - VCI102.rateValueMSB[ch]) > 1) {
         VCI102.rateEnable[ch] = true;
         engine.softTakeover(group, "rate", false);
     } else {
         return;
     }
-    VCI102.rate7bit[ch] = value;
+    VCI102.rateValueMSB[ch] = value;
 };
 
 VCI102.rateQuantizedMSB = function(ch, midino, value, status, group) {
@@ -149,11 +149,11 @@ VCI102.rateQuantizedMSB = function(ch, midino, value, status, group) {
     if (VCI102.rateEnable[ch]) {
         VCI102.rateEnable[ch] = false;
     }
-    VCI102.rate7bit[ch] = value;
+    VCI102.rateValueMSB[ch] = value;
 };
 
 VCI102.rate = function(ch, lsb) {
-    return ((64 - VCI102.rate7bit[ch]) * 128 - lsb) / 8192;
+    return ((64 - VCI102.rateValueMSB[ch]) * 128 - lsb) / 8192;
 };
 
 VCI102.rateLSB = function(ch, midino, value, status, group) {

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -132,6 +132,7 @@ VCI102.rate7bit = [64, 64, 64, 64];
 VCI102.rateEnable = [true, true, true, true];
 
 VCI102.rateMSB = function(ch, midino, value, status, group) {
+    // unlock rate control if the change is not caused by a mechanical drift
     if (VCI102.rateEnable[ch]) {
         engine.softTakeover(group, "rate", true);
     } else if (Math.abs(value - VCI102.rate7bit[ch]) > 1) {
@@ -144,6 +145,7 @@ VCI102.rateMSB = function(ch, midino, value, status, group) {
 };
 
 VCI102.rateQuantizedMSB = function(ch, midino, value, status, group) {
+    // lock rate control against a mechanical drift
     if (VCI102.rateEnable[ch]) {
         VCI102.rateEnable[ch] = false;
     }
@@ -155,6 +157,7 @@ VCI102.rate = function(ch, lsb) {
 };
 
 VCI102.rateLSB = function(ch, midino, value, status, group) {
+    // inhibit rate control after the change by quantized bpm until unlocked
     if (VCI102.rateEnable[ch]) {
         engine.setValue(group, "rate", VCI102.rate(ch, value));
     }


### PR DESCRIPTION
- Vestax VCI-100MKII: map "Rate by quantized BPM" to [shift + pitch fader]
  May be a nice companion of pitch fader for those who want exact BPM but don't want sync mode. It enables a user to set BPM of integer values. A drift of BPM, caused by mechanical weakness, may happen while playing for a long time after setting rate by quantized BPM. So I add an automatic lock: locked at any move of [shift + pitch fader] and unlocked at the move of [pitch fader] greater than 1 MIDI value of MSB (just as the inverse of soft-takeover).
- Vestax VCI-100MKII: clean up the code of exchanging fx display by shift
  Replace VCI102.shift/VCI102.setShift by VCI102.fxButton/VCI102.setFxButton. No change in the behavior.
