### PR TITLE
Small formatting issue at the end of the file

### DIFF
--- a/res/controllers/Vestax VCI-300.midi.xml
+++ b/res/controllers/Vestax VCI-300.midi.xml
@@ -1195,6 +1195,6 @@
 				<off>0x00</off>
 				<minimum>0.5</minimum>
 			</output>
-		</outputs>outputs>
+		</outputs>
 	</controller>
 </MixxxControllerPreset>


### PR DESCRIPTION
Vestax VCI-300 preset bad xml file format line 1198 :
https://github.com/mixxxdj/mixxx/blob/1.12/res/controllers/Vestax%20VCI-300.midi.xml#L1198

Address bug report assigned to myself :  
https://bugs.launchpad.net/mixxx/+bug/1511147
