### PR TITLE
Fixing wait() issue on destructor and change sleep() to shorter non-blocking one in EngineShoutcast

### DIFF
--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -96,9 +96,26 @@ EngineShoutcast::EngineShoutcast(ConfigObject<ConfigValue>* _config)
 }
 
 EngineShoutcast::~EngineShoutcast() {
+    int l_iTime = 0;
     m_pShoutcastEnabled->set(0);
     m_readSema.release();
-    wait(); // until the thread ends.
+
+    // Because Thread QThread msec doesn't blocking
+    // If we can believe this:
+    // http://stackoverflow.com/questions/1950160/what-can-i-use-to-replace-sleep-and-usleep-in-my-qt-app
+    while(l_iTime < 100) {
+        // If Thread has exited then just break out
+        if(!isRunning()) {
+            break;
+        }
+        l_iTime ++;
+        QThread::msleep(100);
+    }
+
+    // Signal user if thread doesn't die
+    if(isRunning()) {
+        qDebug() << "EngineShoutcast::~EngineShoutcast(): Thread didn't die. Ignored but add this to bug report if problems rise!";
+    }
 
     delete m_pStatusCO;
     delete m_pMasterSamplerate;

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -101,9 +101,9 @@ EngineShoutcast::~EngineShoutcast() {
     m_readSema.release();
 
     // Because Thread QThread msec doesn't blocking
-    // If we can believe this:
-    // http://stackoverflow.com/questions/1950160/what-can-i-use-to-replace-sleep-and-usleep-in-my-qt-app
-    while(l_iTime < 100) {
+    // Wait 20 * 100 msec which is ~2 seconds for disconnection. If anything ain't happening
+    // it's not going to happen!
+    while(l_iTime < 20) {
         // If Thread has exited then just break out
         if(!isRunning()) {
             break;

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -96,25 +96,16 @@ EngineShoutcast::EngineShoutcast(ConfigObject<ConfigValue>* _config)
 }
 
 EngineShoutcast::~EngineShoutcast() {
-    int l_iTime = 0;
     m_pShoutcastEnabled->set(0);
     m_readSema.release();
 
-    // Because Thread QThread msec doesn't blocking
-    // Wait 20 * 100 msec which is ~2 seconds for disconnection. If anything ain't happening
-    // it's not going to happen!
-    while (l_iTime < 20) {
-        // If Thread has exited then just break out
-        if (!isRunning()) {
-            break;
-        }
-        l_iTime ++;
-        QThread::msleep(100);
-    }
+    // Wait maximum ~4 seconds. User will get annoyed but
+    // if there is some network problems we let them settle
+    wait(4000);
 
     // Signal user if thread doesn't die
     if (isRunning()) {
-        qDebug() << "EngineShoutcast::~EngineShoutcast(): Thread didn't die. Ignored but add this to bug report if problems rise!";
+        qDebug() << "EngineShoutcast:~EngineShoutcast(): Thread didn't die. Ignored but add this to bug report if problems rise!";
     }
 
     delete m_pStatusCO;

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -418,7 +418,7 @@ bool EngineShoutcast::processConnect() {
 
         m_iShoutFailures++;
         qDebug() << "Streaming server failed connect. Failures:" << shout_get_error(m_pShout);
-        sleep(1);
+        QThread::msleep(100);
     }
 
     if (m_iShoutFailures < kMaxShoutFailures) {
@@ -429,7 +429,7 @@ bool EngineShoutcast::processConnect() {
                 m_pShoutcastEnabled->toBool()) {
             setState(NETWORKSTREAMWORKER_STATE_WAITING);
             qDebug() << "Connection pending. Sleeping...";
-            sleep(1);
+            QThread::msleep(100);
             m_iShoutStatus = shout_get_connected(m_pShout);
             ++ timeout;
         }

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -104,8 +104,9 @@ EngineShoutcast::~EngineShoutcast() {
     wait(4000);
 
     // Signal user if thread doesn't die
-    if (isRunning()) {
-        qDebug() << "EngineShoutcast:~EngineShoutcast(): Thread didn't die. Ignored but add this to bug report if problems rise!";
+    DEBUG_ASSERT_AND_HANDLE(isRunning()) {
+       qWarning() << "EngineShoutcast:~EngineShoutcast(): Thread didn't die.\
+       Ignored but add this to bug report if problems rise!";
     }
 
     delete m_pStatusCO;

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -437,9 +437,16 @@ bool EngineShoutcast::processConnect() {
             qDebug() << "Connection pending. Waiting...";
             m_iShoutStatus = shout_get_connected(m_pShout);
 
-            if (m_iShoutStatus != SHOUTERR_BUSY ||
-                m_iShoutStatus != SHOUTERR_SUCCESS) {
+            if (m_iShoutStatus != SHOUTERR_BUSY &&
+                m_iShoutStatus != SHOUTERR_SUCCESS &&
+                m_iShoutStatus != SHOUTERR_CONNECTED) {
                 qDebug() << "Streaming server made error:" << shout_get_error(m_pShout);
+            }
+
+            // If socket is busy then we wait half second
+            if(m_iShoutStatus == SHOUTERR_BUSY)
+            {
+               QThread::msleep(500);
             }
 
             ++ timeout;

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -434,9 +434,14 @@ bool EngineShoutcast::processConnect() {
                 timeout < kConnectRetries &&
                 m_pShoutcastEnabled->toBool()) {
             setState(NETWORKSTREAMWORKER_STATE_WAITING);
-            qDebug() << "Connection pending. Sleeping...";
-            QThread::msleep(100);
+            qDebug() << "Connection pending. Waiting...";
             m_iShoutStatus = shout_get_connected(m_pShout);
+
+            if (m_iShoutStatus != SHOUTERR_BUSY ||
+                m_iShoutStatus != SHOUTERR_SUCCESS) {
+                qDebug() << "Streaming server made error:" << shout_get_error(m_pShout);
+            }
+
             ++ timeout;
         }
         if (m_iShoutStatus == SHOUTERR_CONNECTED) {

--- a/src/engine/sidechain/engineshoutcast.cpp
+++ b/src/engine/sidechain/engineshoutcast.cpp
@@ -103,9 +103,9 @@ EngineShoutcast::~EngineShoutcast() {
     // Because Thread QThread msec doesn't blocking
     // Wait 20 * 100 msec which is ~2 seconds for disconnection. If anything ain't happening
     // it's not going to happen!
-    while(l_iTime < 20) {
+    while (l_iTime < 20) {
         // If Thread has exited then just break out
-        if(!isRunning()) {
+        if (!isRunning()) {
             break;
         }
         l_iTime ++;
@@ -113,7 +113,7 @@ EngineShoutcast::~EngineShoutcast() {
     }
 
     // Signal user if thread doesn't die
-    if(isRunning()) {
+    if (isRunning()) {
         qDebug() << "EngineShoutcast::~EngineShoutcast(): Thread didn't die. Ignored but add this to bug report if problems rise!";
     }
 


### PR DESCRIPTION
There is possible deadlock in destructor of EngineShoutcast if network drops and 'wait()' never exit. Change it non-blocking waiting 'while()' system so others can exit while we wait. Change sleep to use QThread::msleep which should be non-blocking and make waiting very short.
