### PR TITLE
Trim mountpoint input in Broadcast Preferences.

### DIFF
--- a/src/dlgprefshoutcast.cpp
+++ b/src/dlgprefshoutcast.cpp
@@ -251,6 +251,7 @@ void DlgPrefShoutcast::slotApply()
             ConfigValue(comboBoxEncodingChannels->itemData(
                             comboBoxEncodingChannels->currentIndex()).toString()));
 
+    mountpoint->setText(mountpoint->text().trimmed());
     m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "mountpoint"),
             ConfigValue(mountpoint->text()));
     m_pConfig->set(ConfigKey(SHOUTCAST_PREF_KEY, "host"),


### PR DESCRIPTION
Strip whitespace from beginning and end of string after applying/saving
changes.
