### PR TITLE
Fix Windows build

### DIFF
--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -109,9 +109,12 @@ Result SoundSourceMediaFoundation::tryOpen(const AudioSourceConfig& audioSrcCfg)
     }
 
     // Create the source reader to read the input file.
-    static_assert(sizeof(wchar_t) == sizeof(QChar), "wchar_t is not the same size than QChar");
-    hr = MFCreateSourceReaderFromURL(
-            (wchar_t*)getFilename().utf16(),
+    // Note: we cannot use QString::toStdWString since QT 4 is compiled with
+    // '/Zc:wchar_t-' flag and QT 5 not
+    const ushort* const fileNameUtf16 = fileName.utf16();
+    static_assert(sizeof(wchar_t) == sizeof(ushort), "QString::utf16(): wchar_t and ushort have different sizes");
+    HRESULT hr = MFCreateSourceReaderFromURL(
+            reinterpret_cast<const wchar_t*>(fileNameUtf16),
             NULL,
             &m_pReader);
 
@@ -139,8 +142,6 @@ Result SoundSourceMediaFoundation::tryOpen(const AudioSourceConfig& audioSrcCfg)
 }
 
 void SoundSourceMediaFoundation::close() {
-    delete[] m_wcFilename;
-    m_wcFilename = NULL;
     delete[] m_leftoverBuffer;
     m_leftoverBuffer = NULL;
 

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -219,7 +219,7 @@ public:
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
     // NOTE(uklotzde): Inheriting constructors are supported since VS2015.
     AudioSourceConfig() {}
-    AudioSignal(SINT channelCount, SINT samplingRate): AudioSignal(channelCount, samplingRate) {}
+    AudioSourceConfig(SINT channelCount, SINT samplingRate): AudioSignal(channelCount, samplingRate) {}
 #else
     // Inherit constructors from base class
     using AudioSignal::AudioSignal;

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -16,10 +16,14 @@ Result SoundSourceSndFile::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
     SF_INFO sfInfo;
     memset(&sfInfo, 0, sizeof(sfInfo));
 #ifdef __WINDOWS__
-    static_assert(sizeof(wchar_t) == sizeof(QChar), "wchar_t is not the same size than QChar");
-    m_pSndFile = sf_wchar_open(fileName.utf16(), SFM_READ, &sfInfo);
     // Note: we cannot use QString::toStdWString since QT 4 is compiled with
     // '/Zc:wchar_t-' flag and QT 5 not
+    const ushort* const fileNameUtf16 = getLocalFileName().utf16();
+    static_assert(sizeof(wchar_t) == sizeof(ushort), "QString::utf16(): wchar_t and ushort have different sizes");
+    m_pSndFile = sf_wchar_open(
+		reinterpret_cast<wchar_t*>(const_cast<ushort*>(fileNameUtf16)),
+		SFM_READ,
+		&sfInfo);
 #else
     m_pSndFile = sf_open(getLocalFileName().toLocal8Bit(), SFM_READ, &sfInfo);
 #endif


### PR DESCRIPTION
Fix Windows build after merging 1.12. There was also a mispelled constructor name that is only relevant for the Windows build.
