### PR TITLE
Fix pulse config issues

### DIFF
--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -528,7 +528,7 @@ void DlgPrefSound::settingChanged() {
  */
 void DlgPrefSound::queryClicked() {
     ScopedWaitCursor cursor;
-    m_pSoundManager->queryDevices(true);
+    m_pSoundManager->clearAndQueryDevices();
     updateAPIs();
 }
 

--- a/src/dlgprefsound.cpp
+++ b/src/dlgprefsound.cpp
@@ -191,6 +191,9 @@ void DlgPrefSound::slotApply() {
         return;
     }
 
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+    QApplication::processEvents();
+
     m_pKeylockEngine->set(keylockComboBox->currentIndex());
     m_pConfig->set(ConfigKey("[Master]", "keylock_engine"),
                    ConfigValue(keylockComboBox->currentIndex()));
@@ -199,6 +202,7 @@ void DlgPrefSound::slotApply() {
     m_config.clearOutputs();
     emit(writePaths(&m_config));
     int err = m_pSoundManager->setConfig(m_config);
+    QApplication::restoreOverrideCursor();
     if (err != OK) {
         QString error;
         QString deviceName(tr("a device"));
@@ -522,8 +526,11 @@ void DlgPrefSound::settingChanged() {
  * Slot called when the "Query Devices" button is clicked.
  */
 void DlgPrefSound::queryClicked() {
-    m_pSoundManager->queryDevices();
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+    QApplication::processEvents();
+    m_pSoundManager->queryDevices(true);
     updateAPIs();
+    QApplication::restoreOverrideCursor();
 }
 
 /**

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1055,7 +1055,7 @@ int MixxxMainWindow::noSoundDlg(void)
         msgBox.exec();
 
         if (msgBox.clickedButton() == retryButton) {
-            m_pSoundManager->queryDevices(true);
+            m_pSoundManager->clearAndQueryDevices();
             return 0;
         } else if (msgBox.clickedButton() == wikiButton) {
             QDesktopServices::openUrl(QUrl(

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1055,7 +1055,7 @@ int MixxxMainWindow::noSoundDlg(void)
         msgBox.exec();
 
         if (msgBox.clickedButton() == retryButton) {
-            m_pSoundManager->queryDevices();
+            m_pSoundManager->queryDevices(true);
             return 0;
         } else if (msgBox.clickedButton() == wikiButton) {
             QDesktopServices::openUrl(QUrl(
@@ -1064,13 +1064,11 @@ int MixxxMainWindow::noSoundDlg(void)
             wikiButton->setEnabled(false);
         } else if (msgBox.clickedButton() == reconfigureButton) {
             msgBox.hide();
-            m_pSoundManager->queryDevices();
 
             // This way of opening the dialog allows us to use it synchronously
             m_pPrefDlg->setWindowModality(Qt::ApplicationModal);
             m_pPrefDlg->exec();
             if (m_pPrefDlg->result() == QDialog::Accepted) {
-                m_pSoundManager->queryDevices();
                 return 0;
             }
 
@@ -1115,7 +1113,6 @@ int MixxxMainWindow::noOutputDlg(bool *continueClicked)
             return 0;
         } else if (msgBox.clickedButton() == reconfigureButton) {
             msgBox.hide();
-            m_pSoundManager->queryDevices();
 
             // This way of opening the dialog allows us to use it synchronously
             m_pPrefDlg->setWindowModality(Qt::ApplicationModal);

--- a/src/sounddevice.h
+++ b/src/sounddevice.h
@@ -56,6 +56,7 @@ class SoundDevice {
     void setSampleRate(double sampleRate);
     void setFramesPerBuffer(unsigned int framesPerBuffer);
     virtual Result open(bool isClkRefDevice, int syncBuffers) = 0;
+    virtual bool isOpen() = 0;
     virtual Result close() = 0;
     virtual void readProcess() = 0;
     virtual void writeProcess() = 0;

--- a/src/sounddevice.h
+++ b/src/sounddevice.h
@@ -56,7 +56,7 @@ class SoundDevice {
     void setSampleRate(double sampleRate);
     void setFramesPerBuffer(unsigned int framesPerBuffer);
     virtual Result open(bool isClkRefDevice, int syncBuffers) = 0;
-    virtual bool isOpen() = 0;
+    virtual bool isOpen() const = 0;
     virtual Result close() = 0;
     virtual void readProcess() = 0;
     virtual void writeProcess() = 0;

--- a/src/sounddevicenetwork.cpp
+++ b/src/sounddevicenetwork.cpp
@@ -94,7 +94,7 @@ Result SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers) {
     return OK;
 }
 
-bool SoundDeviceNetwork::isOpen() {
+bool SoundDeviceNetwork::isOpen() const {
     return (m_outputFifo != NULL || m_outputFifo != NULL);
 }
 

--- a/src/sounddevicenetwork.cpp
+++ b/src/sounddevicenetwork.cpp
@@ -94,6 +94,10 @@ Result SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers) {
     return OK;
 }
 
+bool SoundDeviceNetwork::isOpen() {
+    return (m_outputFifo || m_outputFifo);
+}
+
 Result SoundDeviceNetwork::close() {
     //qDebug() << "SoundDeviceNetwork::close()" << getInternalName();
     m_pNetworkStream->stopStream();

--- a/src/sounddevicenetwork.cpp
+++ b/src/sounddevicenetwork.cpp
@@ -95,7 +95,7 @@ Result SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers) {
 }
 
 bool SoundDeviceNetwork::isOpen() {
-    return (m_outputFifo || m_outputFifo);
+    return (m_outputFifo != NULL || m_outputFifo != NULL);
 }
 
 Result SoundDeviceNetwork::close() {

--- a/src/sounddevicenetwork.cpp
+++ b/src/sounddevicenetwork.cpp
@@ -95,7 +95,7 @@ Result SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers) {
 }
 
 bool SoundDeviceNetwork::isOpen() const {
-    return (m_outputFifo != NULL || m_outputFifo != NULL);
+    return (m_inputFifo != NULL || m_outputFifo != NULL);
 }
 
 Result SoundDeviceNetwork::close() {

--- a/src/sounddevicenetwork.h
+++ b/src/sounddevicenetwork.h
@@ -20,7 +20,7 @@ class SoundDeviceNetwork : public SoundDevice {
     virtual ~SoundDeviceNetwork();
 
     virtual Result open(bool isClkRefDevice, int syncBuffers);
-    virtual bool isOpen();
+    virtual bool isOpen() const;
     virtual Result close();
     virtual void readProcess();
     virtual void writeProcess();

--- a/src/sounddevicenetwork.h
+++ b/src/sounddevicenetwork.h
@@ -20,6 +20,7 @@ class SoundDeviceNetwork : public SoundDevice {
     virtual ~SoundDeviceNetwork();
 
     virtual Result open(bool isClkRefDevice, int syncBuffers);
+    virtual bool isOpen();
     virtual Result close();
     virtual void readProcess();
     virtual void writeProcess();

--- a/src/sounddeviceportaudio.cpp
+++ b/src/sounddeviceportaudio.cpp
@@ -335,7 +335,7 @@ Result SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers) {
 }
 
 bool SoundDevicePortAudio::isOpen() {
-    return m_pStream ? true : false;
+    return m_pStream != NULL;
 }
 
 Result SoundDevicePortAudio::close() {

--- a/src/sounddeviceportaudio.cpp
+++ b/src/sounddeviceportaudio.cpp
@@ -334,6 +334,10 @@ Result SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers) {
     return OK;
 }
 
+bool SoundDevicePortAudio::isOpen() {
+    return m_pStream ? true : false;
+}
+
 Result SoundDevicePortAudio::close() {
     //qDebug() << "SoundDevicePortAudio::close()" << getInternalName();
     PaStream* pStream = m_pStream;

--- a/src/sounddeviceportaudio.cpp
+++ b/src/sounddeviceportaudio.cpp
@@ -334,7 +334,7 @@ Result SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers) {
     return OK;
 }
 
-bool SoundDevicePortAudio::isOpen() {
+bool SoundDevicePortAudio::isOpen() const {
     return m_pStream != NULL;
 }
 

--- a/src/sounddeviceportaudio.h
+++ b/src/sounddeviceportaudio.h
@@ -43,7 +43,7 @@ class SoundDevicePortAudio : public SoundDevice {
     virtual ~SoundDevicePortAudio();
 
     virtual Result open(bool isClkRefDevice, int syncBuffers);
-    virtual bool isOpen();
+    virtual bool isOpen() const;
     virtual Result close();
     virtual void readProcess();
     virtual void writeProcess();

--- a/src/sounddeviceportaudio.h
+++ b/src/sounddeviceportaudio.h
@@ -43,6 +43,7 @@ class SoundDevicePortAudio : public SoundDevice {
     virtual ~SoundDevicePortAudio();
 
     virtual Result open(bool isClkRefDevice, int syncBuffers);
+    virtual bool isOpen();
     virtual Result close();
     virtual void readProcess();
     virtual void writeProcess();

--- a/src/soundmanager.cpp
+++ b/src/soundmanager.cpp
@@ -84,7 +84,8 @@ SoundManager::SoundManager(ConfigObject<ConfigValue> *pConfig,
 
 SoundManager::~SoundManager() {
     // Clean up devices.
-    clearDeviceList(false);
+    const bool sleepAfterClosing = false;
+    clearDeviceList(sleepAfterClosing);
 
 #ifdef __PORTAUDIO__
     if (m_paInitialized) {
@@ -245,7 +246,7 @@ void SoundManager::queryDevices() {
 }
 
 void SoundManager::clearAndQueryDevices() {
-    bool sleepAfterClosing = true;
+    const bool sleepAfterClosing = true;
     clearDeviceList(sleepAfterClosing);
     queryDevices();
 }
@@ -476,8 +477,10 @@ Result SoundManager::setupDevices() {
     }
     m_pErrorDevice = NULL;
     return ERR;
+
 closeAndError:
-    closeDevices(false);
+    const bool sleepAfterClosing = false;
+    closeDevices(sleepAfterClosing);
     return err;
 }
 
@@ -497,7 +500,8 @@ Result SoundManager::setConfig(SoundManagerConfig config) {
     // Close open devices. After this call we will not get any more
     // onDeviceOutputCallback() or pushBuffer() calls because all the
     // SoundDevices are closed. closeDevices() blocks and can take a while.
-    closeDevices(true);
+    const bool sleepAfterClosing = true;
+    closeDevices(sleepAfterClosing);
 
     // certain parts of mixxx rely on this being here, for the time being, just
     // letting those be -- bkgood

--- a/src/soundmanager.cpp
+++ b/src/soundmanager.cpp
@@ -73,7 +73,7 @@ SoundManager::SoundManager(ConfigObject<ConfigValue> *pConfig,
     m_pNetworkStream = QSharedPointer<EngineNetworkStream>(
             new EngineNetworkStream(2, 0));
 
-    queryDevices(false);
+    queryDevices();
 
     if (!m_config.readFromDisk()) {
         m_config.loadDefaults(this, SoundManagerConfig::ALL);
@@ -235,18 +235,19 @@ QList<unsigned int> SoundManager::getSampleRates() const {
     return getSampleRates("");
 }
 
-void SoundManager::queryDevices(bool clearFirst) {
+void SoundManager::queryDevices() {
     //qDebug() << "SoundManager::queryDevices()";
-
-    if (clearFirst) {
-        clearDeviceList(true);
-    }
-
     queryDevicesPortaudio();
     queryDevicesMixxx();
 
     // now tell the prefs that we updated the device list -- bkgood
     emit(devicesUpdated());
+}
+
+void SoundManager::clearAndQueryDevices() {
+    bool sleepAfterClosing = true;
+    clearDeviceList(sleepAfterClosing);
+    queryDevices();
 }
 
 void SoundManager::queryDevicesPortaudio() {

--- a/src/soundmanager.cpp
+++ b/src/soundmanager.cpp
@@ -40,9 +40,11 @@
 typedef PaError (*SetJackClientName)(const char *name);
 #endif
 
+namespace {
 #ifdef __LINUX__
 const unsigned int kSleepSecondsAfterClosingDevice = 5;
 #endif
+} // anonymous namespace
 
 SoundManager::SoundManager(ConfigObject<ConfigValue> *pConfig,
                            EngineMaster *pMaster)

--- a/src/soundmanager.h
+++ b/src/soundmanager.h
@@ -62,13 +62,13 @@ class SoundManager : public QObject {
     // open, this method simply runs through the list of all known soundcards
     // (from PortAudio) and attempts to close them all. Closing a soundcard that
     // isn't open is safe.
-    void closeDevices();
+    void closeDevices(bool wait);
 
     // Closes all the devices and empties the list of devices we have.
-    void clearDeviceList();
+    void clearDeviceList(bool wait);
 
     // Creates a list of sound devices
-    void queryDevices();
+    void queryDevices(bool clearFirst);
     void queryDevicesPortaudio();
     void queryDevicesMixxx();
 

--- a/src/soundmanager.h
+++ b/src/soundmanager.h
@@ -62,10 +62,10 @@ class SoundManager : public QObject {
     // open, this method simply runs through the list of all known soundcards
     // (from PortAudio) and attempts to close them all. Closing a soundcard that
     // isn't open is safe.
-    void closeDevices(bool wait);
+    void closeDevices(bool sleepAfterClosing);
 
     // Closes all the devices and empties the list of devices we have.
-    void clearDeviceList(bool wait);
+    void clearDeviceList(bool sleepAfterClosing);
 
     // Creates a list of sound devices
     void queryDevices(bool clearFirst);

--- a/src/soundmanager.h
+++ b/src/soundmanager.h
@@ -68,7 +68,8 @@ class SoundManager : public QObject {
     void clearDeviceList(bool sleepAfterClosing);
 
     // Creates a list of sound devices
-    void queryDevices(bool clearFirst);
+    void clearAndQueryDevices();
+    void queryDevices();
     void queryDevicesPortaudio();
     void queryDevicesMixxx();
 

--- a/src/soundmanager.h
+++ b/src/soundmanager.h
@@ -58,15 +58,6 @@ class SoundManager : public QObject {
     // bOutputDevices or bInputDevices are set, respectively.
     QList<SoundDevice*> getDeviceList(QString filterAPI, bool bOutputDevices, bool bInputDevices);
 
-    // Closes all the open sound devices. Because multiple soundcards might be
-    // open, this method simply runs through the list of all known soundcards
-    // (from PortAudio) and attempts to close them all. Closing a soundcard that
-    // isn't open is safe.
-    void closeDevices(bool sleepAfterClosing);
-
-    // Closes all the devices and empties the list of devices we have.
-    void clearDeviceList(bool sleepAfterClosing);
-
     // Creates a list of sound devices
     void clearAndQueryDevices();
     void queryDevices();
@@ -122,6 +113,15 @@ class SoundManager : public QObject {
     void inputRegistered(AudioInput input, AudioDestination *dest);
 
   private:
+    // Closes all the devices and empties the list of devices we have.
+    void clearDeviceList(bool sleepAfterClosing);
+
+    // Closes all the open sound devices. Because multiple soundcards might be
+    // open, this method simply runs through the list of all known soundcards
+    // (from PortAudio) and attempts to close them all. Closing a soundcard that
+    // isn't open is safe.
+    void closeDevices(bool sleepAfterClosing);
+
     void setJACKName() const;
 
     EngineMaster *m_pMaster;

--- a/src/util/scopedoverridecursor.h
+++ b/src/util/scopedoverridecursor.h
@@ -1,0 +1,26 @@
+#ifndef SCOPEDOVERRIDECURSOR_H
+#define SCOPEDOVERRIDECURSOR_H
+
+#include <QApplication>
+
+class ScopedOverrideCursor {
+  public:
+    inline explicit ScopedOverrideCursor(const QCursor& cursor) {
+        QApplication::setOverrideCursor(cursor);
+        QApplication::processEvents();
+    }
+
+    inline virtual ~ScopedOverrideCursor() {
+        QApplication::restoreOverrideCursor();
+    }
+};
+
+class ScopedWaitCursor : public ScopedOverrideCursor {
+  public:
+    ScopedWaitCursor()
+        : ScopedOverrideCursor(Qt::WaitCursor)
+    {
+    }
+};
+
+#endif // SCOPEDOVERRIDECURSOR_H


### PR DESCRIPTION
This branch introduces a 5 sec sleep after closing a device and enumerate the devices again. 
This fixes the issue, when pulse is in use, that the native Alsa devices are not shown. 
Bug https://github.com/mixxxdj/mixxx/issues/8284
