### PR TITLE
Workaround for missing 'constexpr' in Visual Studio 2013

### DIFF
--- a/src/util/defs.h
+++ b/src/util/defs.h
@@ -1,6 +1,18 @@
 #ifndef DEFS_H
 #define DEFS_H
 
+// Support for 'constexpr' is available since Visual Studio 2015
+// NOTE(uklotzde) This workaround is ugly, but could easily be
+// removed as soon as Visual Studio 2015 is required for building
+// Mixxx on Windows.
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#undef MIXXX_HAS_CONSTEXPR
+#define mixxx_constexpr const
+#else
+#define MIXXX_HAS_CONSTEXPR 1
+#define mixxx_constexpr constexpr
+#endif
+
 // Used for returning errors from functions.
 enum Result {
     OK = 0,

--- a/src/util/replaygain.cpp
+++ b/src/util/replaygain.cpp
@@ -4,6 +4,7 @@
 
 namespace Mixxx {
 
+#if MIXXX_HAS_CONSTEXPR
 /*static*/ constexpr double ReplayGain::kRatioUndefined;
 /*static*/ constexpr double ReplayGain::kRatioMin;
 /*static*/ constexpr double ReplayGain::kRatio0dB;
@@ -11,6 +12,15 @@ namespace Mixxx {
 /*static*/ constexpr CSAMPLE ReplayGain::kPeakUndefined;
 /*static*/ constexpr CSAMPLE ReplayGain::kPeakMin;
 /*static*/ constexpr CSAMPLE ReplayGain::kPeakClip;
+#else
+/*static*/ const double ReplayGain::kRatioUndefined = 0.0;
+/*static*/ const double ReplayGain::kRatioMin = 0.0;
+/*static*/ const double ReplayGain::kRatio0dB = 1.0;
+
+/*static*/ const CSAMPLE ReplayGain::kPeakUndefined = -CSAMPLE_PEAK;
+/*static*/ const CSAMPLE ReplayGain::kPeakMin = CSAMPLE_ZERO;
+/*static*/ const CSAMPLE ReplayGain::kPeakClip = CSAMPLE_PEAK;
+#endif
 
 namespace {
 

--- a/src/util/replaygain.h
+++ b/src/util/replaygain.h
@@ -23,6 +23,7 @@ namespace Mixxx {
 // as a string into file tags.
 class ReplayGain final {
 public:
+#if MIXXX_HAS_CONSTEXPR
     static constexpr double kRatioUndefined = 0.0;
     static constexpr double kRatioMin = 0.0; // lower bound (exclusive)
     static constexpr double kRatio0dB = 1.0;
@@ -35,6 +36,15 @@ public:
             "http://wiki.hydrogenaud.io/index.php?title=ReplayGain_2.0_specification#Peak_amplitude: "
             "The maximum peak amplitude value is stored as a floating number, "
             "where 1.0 represents digital full scale");
+#else
+    static const double kRatioUndefined;
+    static const double kRatioMin; // lower bound (exclusive)
+    static const double kRatio0dB;
+
+    static const CSAMPLE kPeakUndefined;
+    static const CSAMPLE kPeakMin; // lower bound (inclusive)
+    static const CSAMPLE kPeakClip; // upper bound (inclusive) represents digital full scale without clipping
+#endif
 
     ReplayGain()
         : ReplayGain(kRatioUndefined, kPeakUndefined) {

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -1,10 +1,11 @@
 #ifndef TYPES_H
 #define TYPES_H
 
-#include "util/math.h"
-
 #include <cstddef>
 #include <climits>
+
+#include "util/defs.h"
+#include "util/math.h"
 
 // Signed integer type for POT array indices, sizes and pointer
 // arithmetic. Its size (32-/64-bit) depends on the CPU architecture.
@@ -16,9 +17,9 @@ typedef std::ptrdiff_t SINT;
 // 16-bit integer sample data within the asymmetric
 // range [SHRT_MIN, SHRT_MAX].
 typedef short int SAMPLE;
-constexpr SAMPLE SAMPLE_ZERO = 0;
-constexpr SAMPLE SAMPLE_MIN = SHRT_MIN;
-constexpr SAMPLE SAMPLE_MAX = SHRT_MAX;
+mixxx_constexpr SAMPLE SAMPLE_ZERO = 0;
+mixxx_constexpr SAMPLE SAMPLE_MIN = SHRT_MIN;
+mixxx_constexpr SAMPLE SAMPLE_MAX = SHRT_MAX;
 
 // Limits the range of a SAMPLE value to [SAMPLE_MIN, SAMPLE_MAX].
 inline
@@ -38,9 +39,9 @@ SAMPLE SAMPLE_clampSymmetric(SAMPLE in) {
 // emphasize the symmetric value range of CSAMPLE
 // data!
 typedef float CSAMPLE;
-constexpr CSAMPLE CSAMPLE_ZERO = 0.0f;
-constexpr CSAMPLE CSAMPLE_ONE = 1.0f;
-constexpr CSAMPLE CSAMPLE_PEAK = CSAMPLE_ONE;
+mixxx_constexpr CSAMPLE CSAMPLE_ZERO = 0.0f;
+mixxx_constexpr CSAMPLE CSAMPLE_ONE = 1.0f;
+mixxx_constexpr CSAMPLE CSAMPLE_PEAK = CSAMPLE_ONE;
 
 // Limits the range of a CSAMPLE value to [-CSAMPLE_PEAK, CSAMPLE_PEAK].
 inline
@@ -52,10 +53,10 @@ CSAMPLE CSAMPLE_clamp(CSAMPLE in) {
 // data in the range [0.0, 1.0]. Same data type as
 // CSAMPLE to avoid type conversions in calculations.
 typedef CSAMPLE CSAMPLE_GAIN;
-constexpr float CSAMPLE_GAIN_ZERO = CSAMPLE_ZERO;
-constexpr float CSAMPLE_GAIN_ONE = CSAMPLE_ONE;
-constexpr float CSAMPLE_GAIN_MIN = CSAMPLE_GAIN_ZERO;
-constexpr float CSAMPLE_GAIN_MAX = CSAMPLE_GAIN_ONE;
+mixxx_constexpr float CSAMPLE_GAIN_ZERO = CSAMPLE_ZERO;
+mixxx_constexpr float CSAMPLE_GAIN_ONE = CSAMPLE_ONE;
+mixxx_constexpr float CSAMPLE_GAIN_MIN = CSAMPLE_GAIN_ZERO;
+mixxx_constexpr float CSAMPLE_GAIN_MAX = CSAMPLE_GAIN_ONE;
 
 // Limits the range of a CSAMPLE_GAIN value to [CSAMPLE_GAIN_MIN, CSAMPLE_GAIN_MAX].
 inline


### PR DESCRIPTION
A workaround for the missing support of 'constexpr' in Visual Studio 2013. It introduces a #define and some redundant constant definitions, but the migration to a C++11 code base with the switch to Visual Studio 2015 will be safe and is straightforward. Compile errors will guide you when deleting the #define of 'mixxx_constexpr'.
