### PR TITLE
Replace 'constexpr' with 'const'

### DIFF
--- a/src/util/replaygain.cpp
+++ b/src/util/replaygain.cpp
@@ -4,13 +4,16 @@
 
 namespace Mixxx {
 
-/*static*/ constexpr double ReplayGain::kRatioUndefined;
-/*static*/ constexpr double ReplayGain::kRatioMin;
-/*static*/ constexpr double ReplayGain::kRatio0dB;
+// TODO(uklotzde): Replace 'const' with 'constexpr' and remove
+// initialization after switching to Visual Studio 2015.
 
-/*static*/ constexpr CSAMPLE ReplayGain::kPeakUndefined;
-/*static*/ constexpr CSAMPLE ReplayGain::kPeakMin;
-/*static*/ constexpr CSAMPLE ReplayGain::kPeakClip;
+/*static*/ const double ReplayGain::kRatioUndefined = 0.0;
+/*static*/ const double ReplayGain::kRatioMin = 0.0; // lower bound (exclusive)
+/*static*/ const double ReplayGain::kRatio0dB = 1.0;
+
+/*static*/ const CSAMPLE ReplayGain::kPeakUndefined = -CSAMPLE_PEAK;
+/*static*/ const CSAMPLE ReplayGain::kPeakMin = CSAMPLE_ZERO; // lower bound (inclusive)
+/*static*/ const CSAMPLE ReplayGain::kPeakClip = CSAMPLE_PEAK; // upper bound (inclusive) represents digital full scale without clipping;
 
 namespace {
 

--- a/src/util/replaygain.h
+++ b/src/util/replaygain.h
@@ -23,18 +23,24 @@ namespace Mixxx {
 // as a string into file tags.
 class ReplayGain final {
 public:
-    static constexpr double kRatioUndefined = 0.0;
-    static constexpr double kRatioMin = 0.0; // lower bound (exclusive)
-    static constexpr double kRatio0dB = 1.0;
+    // TODO(uklotzde): Replace 'const' with 'constexpr'
+    // (and copy initialization from .cpp file) after switching to
+    // Visual Studio 2015 on Windows.
+    static const double kRatioUndefined;
+    static const double kRatioMin; // lower bound (exclusive)
+    static const double kRatio0dB;
 
-    static constexpr CSAMPLE kPeakUndefined = -CSAMPLE_PEAK;
-    static constexpr CSAMPLE kPeakMin = CSAMPLE_ZERO; // lower bound (inclusive)
-    static constexpr CSAMPLE kPeakClip = CSAMPLE_PEAK; // upper bound (inclusive) represents digital full scale without clipping
+    static const CSAMPLE kPeakUndefined;
+    static const CSAMPLE kPeakMin; // lower bound (inclusive)
+    static const CSAMPLE kPeakClip; // upper bound (inclusive) represents digital full scale without clipping
 
-    static_assert(ReplayGain::kPeakClip == 1.0,
-            "http://wiki.hydrogenaud.io/index.php?title=ReplayGain_2.0_specification#Peak_amplitude: "
-            "The maximum peak amplitude value is stored as a floating number, "
-            "where 1.0 represents digital full scale");
+    // TODO(uklotzde): Uncomment after switching to Visual Studio 2015
+    // on Windows.
+    //static_assert(ReplayGain::kPeakClip == 1.0,
+    //        "http://wiki.hydrogenaud.io/index.php"
+    //        "?title=ReplayGain_2.0_specification#Peak_amplitude: "
+    //        "The maximum peak amplitude value is stored as a floating number, "
+    //        "where 1.0 represents digital full scale");
 
     ReplayGain()
         : ReplayGain(kRatioUndefined, kPeakUndefined) {

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -1,10 +1,13 @@
 #ifndef TYPES_H
 #define TYPES_H
 
-#include "util/math.h"
-
 #include <cstddef>
 #include <climits>
+
+#include "util/math.h"
+
+// TODO(uklotzde): Replace 'const' with 'constexpr' after
+// switching to Visual Studio 2015 on Windows.
 
 // Signed integer type for POT array indices, sizes and pointer
 // arithmetic. Its size (32-/64-bit) depends on the CPU architecture.
@@ -16,9 +19,9 @@ typedef std::ptrdiff_t SINT;
 // 16-bit integer sample data within the asymmetric
 // range [SHRT_MIN, SHRT_MAX].
 typedef short int SAMPLE;
-constexpr SAMPLE SAMPLE_ZERO = 0;
-constexpr SAMPLE SAMPLE_MIN = SHRT_MIN;
-constexpr SAMPLE SAMPLE_MAX = SHRT_MAX;
+const SAMPLE SAMPLE_ZERO = 0;
+const SAMPLE SAMPLE_MIN = SHRT_MIN;
+const SAMPLE SAMPLE_MAX = SHRT_MAX;
 
 // Limits the range of a SAMPLE value to [SAMPLE_MIN, SAMPLE_MAX].
 inline
@@ -38,9 +41,9 @@ SAMPLE SAMPLE_clampSymmetric(SAMPLE in) {
 // emphasize the symmetric value range of CSAMPLE
 // data!
 typedef float CSAMPLE;
-constexpr CSAMPLE CSAMPLE_ZERO = 0.0f;
-constexpr CSAMPLE CSAMPLE_ONE = 1.0f;
-constexpr CSAMPLE CSAMPLE_PEAK = CSAMPLE_ONE;
+const CSAMPLE CSAMPLE_ZERO = 0.0f;
+const CSAMPLE CSAMPLE_ONE = 1.0f;
+const CSAMPLE CSAMPLE_PEAK = CSAMPLE_ONE;
 
 // Limits the range of a CSAMPLE value to [-CSAMPLE_PEAK, CSAMPLE_PEAK].
 inline
@@ -52,10 +55,10 @@ CSAMPLE CSAMPLE_clamp(CSAMPLE in) {
 // data in the range [0.0, 1.0]. Same data type as
 // CSAMPLE to avoid type conversions in calculations.
 typedef CSAMPLE CSAMPLE_GAIN;
-constexpr float CSAMPLE_GAIN_ZERO = CSAMPLE_ZERO;
-constexpr float CSAMPLE_GAIN_ONE = CSAMPLE_ONE;
-constexpr float CSAMPLE_GAIN_MIN = CSAMPLE_GAIN_ZERO;
-constexpr float CSAMPLE_GAIN_MAX = CSAMPLE_GAIN_ONE;
+const float CSAMPLE_GAIN_ZERO = CSAMPLE_ZERO;
+const float CSAMPLE_GAIN_ONE = CSAMPLE_ONE;
+const float CSAMPLE_GAIN_MIN = CSAMPLE_GAIN_ZERO;
+const float CSAMPLE_GAIN_MAX = CSAMPLE_GAIN_ONE;
 
 // Limits the range of a CSAMPLE_GAIN value to [CSAMPLE_GAIN_MIN, CSAMPLE_GAIN_MAX].
 inline


### PR DESCRIPTION
Visual Studio 2013 does not support 'constexpr'.
