### PR TITLE
Reset slip mode on track load to prevent carry-over

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -546,6 +546,12 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
     m_trackSamplesOld = iTrackNumSamples;
     m_pTrackSamples->set(iTrackNumSamples);
     m_pTrackSampleRate->set(iTrackSampleRate);
+    // Reset slip mode
+    m_pSlipButton->set(0);
+    m_slipEnabled = 0;
+    m_bSlipEnabledProcessing = false;
+    m_dSlipPosition = 0.;
+    m_dSlipRate = 0;
     // Reset the pitch value for the new track.
     m_pause.unlock();
 


### PR DESCRIPTION
Posting to double-check -- doing this inside the m_pause mutex ought to prevent any race conditions, right?
