### PR TITLE
remove Midi spam with fast changing controls

### DIFF
--- a/src/controllers/midi/midioutputhandler.h
+++ b/src/controllers/midi/midioutputhandler.h
@@ -33,7 +33,7 @@ class MidiOutputHandler : QObject {
     MidiController* m_pController;
     const MidiOutputMapping m_mapping;
     ControlObjectThread m_cot;
-    double m_lastVal;
+    int m_lastVal;
 };
 
 #endif


### PR DESCRIPTION
This uses the midi value as guard against redundant messages.
It fixes also the issue that the very first value can be discharged.
