### PR TITLE
Vestax VCI-100MKII: improve the drift lock of "Rate by quantized BPM"

### DIFF
--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -3,7 +3,7 @@
   <info>
     <name>Vestax VCI-100MKII</name>
     <author>Takeshi Soejima</author>
-    <description>2015-11-1</description>
+    <description>2015-12-1</description>
     <wiki>http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii</wiki>
   </info>
   <controller id="VCI-100MKII">
@@ -31,11 +31,11 @@
       </control>
       <control>
         <group>[Master]</group>
-        <key>VCI102.headVolume</key>
+        <key>headVolume</key>
         <status>0xB4</status>
         <midino>0x12</midino>
         <options>
-          <script-binding/>
+          <soft-takeover/>
         </options>
       </control>
       <control>
@@ -46,11 +46,11 @@
       </control>
       <control>
         <group>[Master]</group>
-        <key>VCI102.volume</key>
+        <key>volume</key>
         <status>0xB4</status>
         <midino>0x14</midino>
         <options>
-          <script-binding/>
+          <soft-takeover/>
         </options>
       </control>
       <control>
@@ -544,72 +544,108 @@
         <key>parameter1</key>
         <status>0xB0</status>
         <midino>0x16</midino>
+        <options>
+          <soft-takeover/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit2_Effect1]</group>
         <key>parameter1</key>
         <status>0xB1</status>
         <midino>0x17</midino>
+        <options>
+          <soft-takeover/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit3_Effect1]</group>
         <key>parameter1</key>
         <status>0xB2</status>
         <midino>0x16</midino>
+        <options>
+          <soft-takeover/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit4_Effect1]</group>
         <key>parameter1</key>
         <status>0xB3</status>
         <midino>0x17</midino>
+        <options>
+          <soft-takeover/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit1_Effect1]</group>
         <key>parameter2</key>
         <status>0xB0</status>
         <midino>0x17</midino>
+        <options>
+          <soft-takeover/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit2_Effect1]</group>
         <key>parameter2</key>
         <status>0xB1</status>
         <midino>0x18</midino>
+        <options>
+          <soft-takeover/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit3_Effect1]</group>
         <key>parameter2</key>
         <status>0xB2</status>
         <midino>0x17</midino>
+        <options>
+          <soft-takeover/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit4_Effect1]</group>
         <key>parameter2</key>
         <status>0xB3</status>
         <midino>0x18</midino>
+        <options>
+          <soft-takeover/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit1_Effect1]</group>
         <key>parameter3</key>
         <status>0xB0</status>
         <midino>0x18</midino>
+        <options>
+          <soft-takeover/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit2_Effect1]</group>
         <key>parameter3</key>
         <status>0xB1</status>
         <midino>0x19</midino>
+        <options>
+          <soft-takeover/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit3_Effect1]</group>
         <key>parameter3</key>
         <status>0xB2</status>
         <midino>0x18</midino>
+        <options>
+          <soft-takeover/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit4_Effect1]</group>
         <key>parameter3</key>
         <status>0xB3</status>
         <midino>0x19</midino>
+        <options>
+          <soft-takeover/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit1]</group>

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -124,10 +124,9 @@ VCI102.rateEnable = [true, true, true, true];
 VCI102.rateValueMSB = [64, 64, 64, 64];  // defaults are at center
 
 VCI102.rateMSB = function(ch, midino, value, status, group) {
-    // unlock rate control if sync_enabled or not caused by a mechanical drift
+    // unlock rate control if the change is not caused by a mechanical drift
     if (!VCI102.rateEnable[ch]) {
-        if (engine.getValue(group, "sync_enabled")
-            || Math.abs(value - VCI102.rateValueMSB[ch]) > 1) {
+        if (Math.abs(value - VCI102.rateValueMSB[ch]) > 1) {
             VCI102.rateEnable[ch] = true;
         } else {
             return;
@@ -156,10 +155,12 @@ VCI102.rateLSB = function(ch, midino, value, status, group) {
 };
 
 VCI102.rateQuantizedLSB = function(ch, midino, value, status, group) {
+    // not change "bpm" direct but by "rate" to go through soft takeover
+    var bpm = engine.getValue(group, "file_bpm");
+    var range = engine.getValue(group, "rateRange") * bpm;
     engine.setValue(
-        group, "bpm", Math.round(
-            (VCI102.rate(ch, value) * engine.getValue(group, "rateRange") + 1
-            ) * engine.getValue(group, "file_bpm")));
+        group, "rate",
+        (Math.round(VCI102.rate(ch, value) * range + bpm) - bpm) / range);
 };
 
 VCI102.pitch = function(ch, midino, value, status, group) {
@@ -267,10 +268,6 @@ VCI102.init = function() {
         }
     }
 
-    function rateTakeover(value, group, key) {
-        engine.softTakeover(group, "rate", value);
-    }
-
     function makeButton(key) {
         VCI102[key] = function(ch, midino, value, status, group) {
             engine.setValue(VCI102.Deck[ch % 2], key, value / 127);
@@ -309,8 +306,7 @@ VCI102.init = function() {
                     "[EffectRack1_EffectUnit" + k + "]", enabled, led);
             }
         }
-        // enable soft takeover for rate if and only if sync_enabled
-        engine.connectControl(VCI102.deck[i], "sync_enabled", rateTakeover);
+        engine.softTakeover(VCI102.deck[i], "rate", true);
         engine.softTakeover(VCI102.deck[i], "pitch", true);
     }
     for (i = 1; i <= 4; i++) {

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -157,10 +157,9 @@ VCI102.rateLSB = function(ch, midino, value, status, group) {
 VCI102.rateQuantizedLSB = function(ch, midino, value, status, group) {
     // not change "bpm" direct but by "rate" to go through soft takeover
     var bpm = engine.getValue(group, "file_bpm");
-    var range = engine.getValue(group, "rateRange") * bpm;
-    engine.setValue(
-        group, "rate",
-        (Math.round(VCI102.rate(ch, value) * range + bpm) - bpm) / range);
+    var range = engine.getValue(group, "rateRange");
+    engine.setValue(group, "rate", (Math.round(
+        (VCI102.rate(ch, value) * range + 1) * bpm) / bpm - 1) / range);
 };
 
 VCI102.pitch = function(ch, midino, value, status, group) {

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -1,16 +1,11 @@
-////////////////////////////////////////////////////////////////////////
-// JSHint configuration                                               //
-////////////////////////////////////////////////////////////////////////
-/* global engine                                                      */
-/* global script                                                      */
-/* global print                                                       */
-/* global midi                                                        */
-////////////////////////////////////////////////////////////////////////
-
 // name: Vestax VCI-100MKII
 // author: Takeshi Soejima
 // description: 2015-12-1
 // wiki: <http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii>
+
+// JSHint Configuration
+// global engine
+// global midi
 
 var VCI102 = {};
 


### PR DESCRIPTION
(urgency is low, but hope to be merged in 2.0)
- After the last update I noticed that unlocking and changing rate after the change by quantized BPM with the "fast" move of the fader occasionally stopped at the following MIDI message. It seems that switching soft takeover must be avoided while the fader is moving. The script is improved as below.
  1. Enable soft takeover of rate if and only if sync mode is enabled.
  2. In sync mode (so with soft takeover), the drift lock is canceled.
  3. Out of sync mode (so without soft takeover), the lock is valid as before.
- I also drop master and headphone volume functions keeping values under 1.0. I thought that the front side knobs were too thin to treat safely. But a bit more gain is usefull in some cases, so I decide to map them as usual with the safeguard of soft takeover.
- Enable soft takeover for parameters of effects.
