### PR TITLE
Define sample layout in AudioSignal

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -157,6 +157,7 @@ void MixxxMainWindow::initalize(QApplication* pApp, const CmdlineArgs& args) {
     qRegisterMetaType<TrackId>("TrackId");
     qRegisterMetaType<QSet<TrackId>>("QSet<TrackId>");
     qRegisterMetaType<TrackPointer>("TrackPointer");
+    qRegisterMetaType<Mixxx::ReplayGain>("Mixxx::ReplayGain");
 
     ScopedTimer t("MixxxMainWindow::MixxxMainWindow");
     m_runtime_timer.start();

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -21,6 +21,7 @@ void AudioSource::clampFrameInterval(
 
 AudioSource::AudioSource(const QUrl& url)
         : UrlResource(url),
+          AudioSignal(kSampleLayout),
           m_frameCount(kFrameCountDefault),
           m_bitrate(kBitrateDefault) {
 }

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -33,6 +33,8 @@ struct AudioSourceConfig;
 // closed upon destruction.
 class AudioSource: public UrlResource, public AudioSignal {
 public:
+    static const SampleLayout kSampleLayout = SampleLayout::Interleaved;
+
     // Returns the total number of sample frames.
     inline SINT getFrameCount() const {
         return m_frameCount;
@@ -216,14 +218,12 @@ private:
 // Parameters for configuring audio sources
 class AudioSourceConfig: public AudioSignal {
 public:
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-    // NOTE(uklotzde): Inheriting constructors are supported since VS2015.
-    AudioSourceConfig() {}
-    AudioSourceConfig(SINT channelCount, SINT samplingRate): AudioSignal(channelCount, samplingRate) {}
-#else
-    // Inherit constructors from base class
-    using AudioSignal::AudioSignal;
-#endif
+    AudioSourceConfig()
+        : AudioSignal(AudioSource::kSampleLayout) {
+    }
+    AudioSourceConfig(SINT channelCount, SINT samplingRate)
+        : AudioSignal(AudioSource::kSampleLayout, channelCount, samplingRate) {
+    }
 
     using AudioSignal::setChannelCount;
     using AudioSignal::resetChannelCount;

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -45,8 +45,6 @@ TrackInfoObject::TrackInfoObject(const QFileInfo& fileInfo,
     m_dateAdded = QDateTime::currentDateTime();
     m_Rating = 0;
 
-    qRegisterMetaType<Mixxx::ReplayGain>("Mixxx::ReplayGain");
-
     // Parse the metadata from file. This is not a quick operation!
     m_bHeaderParsed = false;
     if (parseHeader) {


### PR DESCRIPTION
Define the sample layout in AudioSignal to improve its versatility and to make implicit assumptions explicit. It is also beneficial for documentation puposes.

All audio sources in Mixxx produce an interleaved signal as indicated by the constant definition.

Minor change: I've moved the registration of the Qt meta type for Mixxx::ReplayGain out of the constructor to a place where other TIO types are registered to avoid repeated registration.
