### PR TITLE
Add tests for isinf, isnan and denormal detection.

### DIFF
--- a/src/test/mathutiltest.cpp
+++ b/src/test/mathutiltest.cpp
@@ -75,17 +75,22 @@ TEST_F(MathUtilTest, Denormal) {
 
     float fDenormal = std::numeric_limits<float>::min() / 2.0f;
     EXPECT_TRUE(std::fpclassify(fDenormal) == FP_SUBNORMAL);
+    EXPECT_NE(0.0f, fDenormal);
 
     double dDenormal = std::numeric_limits<double>::min() / 2.0;
     EXPECT_TRUE(std::fpclassify(dDenormal) == FP_SUBNORMAL);
+    EXPECT_NE(0.0, dDenormal);
 
     _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
     _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 
     fDenormal = std::numeric_limits<float>::min() / 2.0f;
-    dDenormal = std::numeric_limits<double>::min() / 2.0;
     EXPECT_FALSE(std::fpclassify(fDenormal) == FP_SUBNORMAL);
+    EXPECT_EQ(0.0f, fDenormal);
+
+    dDenormal = std::numeric_limits<double>::min() / 2.0;
     EXPECT_FALSE(std::fpclassify(dDenormal) == FP_SUBNORMAL);
+    EXPECT_EQ(0.0, dDenormal);
 #endif
 }
 

--- a/src/test/mathutiltest.cpp
+++ b/src/test/mathutiltest.cpp
@@ -1,7 +1,9 @@
-#include <gtest/gtest.h>
-#include "util/math.h"
+#include <limits>
 
+#include <gtest/gtest.h>
 #include <QtDebug>
+
+#include "util/math.h"
 
 namespace {
 
@@ -28,7 +30,7 @@ const int MathUtilTest::MIN = -10;
 const int MathUtilTest::MAX = 10;
 
 const int MathUtilTest::VALUE_MIN = 2 * MathUtilTest::MIN;
-const int MathUtilTest::VALUE_MAX = 2  * MathUtilTest::MAX;
+const int MathUtilTest::VALUE_MAX = 2 * MathUtilTest::MAX;
 
 TEST_F(MathUtilTest, MathClampUnsafe) {
     for (int i = VALUE_MIN; i <= VALUE_MAX; ++i) {
@@ -44,5 +46,34 @@ TEST_F(MathUtilTest, MathClampUnsafe) {
         }
     }
 }
+
+TEST_F(MathUtilTest, IsNaN) {
+    // Test floats can be recognized as nan.
+    EXPECT_FALSE(isnan(0.0f));
+    EXPECT_TRUE(isnan(std::numeric_limits<float>::quiet_NaN()));
+
+    // Test doubles can be recognized as nan.
+    EXPECT_FALSE(isnan(0.0));
+    EXPECT_TRUE(isnan(std::numeric_limits<double>::quiet_NaN()));
+}
+
+TEST_F(MathUtilTest, IsInf) {
+    // Test floats can be recognized as infinity.
+    EXPECT_FALSE(isinf(0.0f));
+    EXPECT_TRUE(isinf(std::numeric_limits<float>::infinity()));
+
+    // Test doubles can be recognized as infinity.
+    EXPECT_FALSE(isinf(0.0f));
+    EXPECT_TRUE(isinf(std::numeric_limits<double>::infinity()));
+}
+
+TEST_F(MathUtilTest, Denormal) {
+    float fDenormal = std::numeric_limits<float>::min() / 2.0f;
+    EXPECT_TRUE(std::fpclassify(fDenormal) == FP_SUBNORMAL);
+
+    double dDenormal = std::numeric_limits<double>::min() / 2.0;
+    EXPECT_TRUE(std::fpclassify(dDenormal) == FP_SUBNORMAL);
+}
+
 
 }  // namespace

--- a/src/test/mathutiltest.cpp
+++ b/src/test/mathutiltest.cpp
@@ -4,6 +4,7 @@
 #include <QtDebug>
 
 #include "util/math.h"
+#include "util/denormalsarezero.h"
 
 namespace {
 
@@ -68,11 +69,24 @@ TEST_F(MathUtilTest, IsInf) {
 }
 
 TEST_F(MathUtilTest, Denormal) {
+#ifdef __SSE__
+    _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_OFF);
+    _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF);
+
     float fDenormal = std::numeric_limits<float>::min() / 2.0f;
     EXPECT_TRUE(std::fpclassify(fDenormal) == FP_SUBNORMAL);
 
     double dDenormal = std::numeric_limits<double>::min() / 2.0;
     EXPECT_TRUE(std::fpclassify(dDenormal) == FP_SUBNORMAL);
+
+    _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
+    _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+
+    fDenormal = std::numeric_limits<float>::min() / 2.0f;
+    dDenormal = std::numeric_limits<double>::min() / 2.0;
+    EXPECT_FALSE(std::fpclassify(fDenormal) == FP_SUBNORMAL);
+    EXPECT_FALSE(std::fpclassify(dDenormal) == FP_SUBNORMAL);
+#endif
 }
 
 


### PR DESCRIPTION
I built with optimize=portable -- why do these tests pass on my OS X machine?
