### PR TITLE
Scale BeatMap

### DIFF
--- a/src/dlgtrackinfo.cpp
+++ b/src/dlgtrackinfo.cpp
@@ -160,7 +160,7 @@ void DlgTrackInfo::populateFields(TrackPointer pTrack) {
     txtBpm->setText(pTrack->getBpmStr());
     txtKey->setText(pTrack->getKeyText());
     BeatsPointer pBeats = pTrack->getBeats();
-    bool beatsSupportsSet = !pBeats || (pBeats->getCapabilities() & Beats::BEATSCAP_SET);
+    bool beatsSupportsSet = !pBeats || (pBeats->getCapabilities() & Beats::BEATSCAP_SETBPM);
     bool enableBpmEditing = !pTrack->hasBpmLock() && beatsSupportsSet;
     spinBpm->setEnabled(enableBpmEditing);
     bpmTap->setEnabled(enableBpmEditing);
@@ -444,19 +444,19 @@ void DlgTrackInfo::clear() {
 }
 
 void DlgTrackInfo::slotBpmDouble() {
-    spinBpm->setValue(spinBpm->value() * 2.0);
+    spinBpm->setValue(spinBpm->value() * 2);
 }
 
 void DlgTrackInfo::slotBpmHalve() {
-    spinBpm->setValue(spinBpm->value() / 2.0);
+    spinBpm->setValue(spinBpm->value() / 2);
 }
 
 void DlgTrackInfo::slotBpmTwoThirds() {
-    spinBpm->setValue(spinBpm->value() * (2./3.));
+    spinBpm->setValue(spinBpm->value() * 2 / 3);
 }
 
 void DlgTrackInfo::slotBpmThreeFourth() {
-    spinBpm->setValue(spinBpm->value() * (3./4.));
+    spinBpm->setValue(spinBpm->value() * 3 / 4);
 }
 
 void DlgTrackInfo::slotBpmTap(double averageLength, int numSamples) {

--- a/src/dlgtrackinfo.cpp
+++ b/src/dlgtrackinfo.cpp
@@ -469,19 +469,31 @@ void DlgTrackInfo::clear() {
 }
 
 void DlgTrackInfo::slotBpmDouble() {
-    spinBpm->setValue(spinBpm->value() * 2);
+    m_pBeatsClone->scale(Beats::DOUBLE);
+    // read back the actual value
+    double newValue = m_pBeatsClone->getBpm();
+    spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmHalve() {
-    spinBpm->setValue(spinBpm->value() / 2);
+    m_pBeatsClone->scale(Beats::HALVE);
+    // read back the actual value
+    double newValue = m_pBeatsClone->getBpm();
+    spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmTwoThirds() {
-    spinBpm->setValue(spinBpm->value() * 2 / 3);
+    m_pBeatsClone->scale(Beats::Beats::TWOTHIRDS);
+    // read back the actual value
+    double newValue = m_pBeatsClone->getBpm();
+    spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmThreeFourth() {
-    spinBpm->setValue(spinBpm->value() * 3 / 4);
+    m_pBeatsClone->scale(Beats::Beats::THREEFOURTHS);
+    // read back the actual value
+    double newValue = m_pBeatsClone->getBpm();
+    spinBpm->setValue(newValue);
 }
 
 void DlgTrackInfo::slotBpmClear() {

--- a/src/dlgtrackinfo.cpp
+++ b/src/dlgtrackinfo.cpp
@@ -186,7 +186,6 @@ void DlgTrackInfo::populateFields(TrackPointer pTrack) {
 void DlgTrackInfo::reloadTrackBeats(TrackPointer pTrack) {
     BeatsPointer pBeats = pTrack->getBeats();
     if (pBeats) {
-        // overwrite Track bpm with the average beats bpm from beats
         spinBpm->setValue(pBeats->getBpm());
         m_pBeatsClone = pBeats->clone();
     } else {
@@ -194,7 +193,6 @@ void DlgTrackInfo::reloadTrackBeats(TrackPointer pTrack) {
         spinBpm->setValue(0.0);
     }
     m_trackHasBeatMap = pBeats && !(pBeats->getCapabilities() & Beats::BEATSCAP_SETBPM);
-    //bool enableBpmEditing = !pTrack->hasBpmLock() && beatsSupportsSet;
     bpmConst->setChecked(!m_trackHasBeatMap);
     bpmConst->setEnabled(m_trackHasBeatMap); // We cannot make turn a BeatGrid to a BeatMap
     spinBpm->setEnabled(!m_trackHasBeatMap); // We cannot change bpm continuously or tab them
@@ -458,7 +456,6 @@ void DlgTrackInfo::clear() {
     txtLocation->setPlainText("");
     txtBitrate->setText("");
     txtBpm->setText("");
-    m_pBeatsClone.clear();
 
     m_cueMap.clear();
     cueTable->clearContents();

--- a/src/dlgtrackinfo.h
+++ b/src/dlgtrackinfo.h
@@ -49,6 +49,8 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotBpmHalve();
     void slotBpmTwoThirds();
     void slotBpmThreeFourth();
+    void slotBpmClear();
+    void slotBpmConstChanged(int state);
     void slotBpmTap(double averageLength, int numSamples);
 
     void reloadTrackMetadata();
@@ -62,6 +64,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
 
   private:
     void populateFields(TrackPointer pTrack);
+    void reloadTrackBeats(TrackPointer pTrack);
     void populateCues(TrackPointer pTrack);
     void saveTrack();
     void unloadTrack(bool save);
@@ -69,6 +72,8 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void init();
     QHash<int, Cue*> m_cueMap;
     TrackPointer m_pLoadedTrack;
+    BeatsPointer m_pBeatsClone;
+    bool m_trackHasBeatMap;
 
     QScopedPointer<TapFilter> m_pTapFilter;
     double m_dLastBpm;

--- a/src/dlgtrackinfo.h
+++ b/src/dlgtrackinfo.h
@@ -52,6 +52,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotBpmClear();
     void slotBpmConstChanged(int state);
     void slotBpmTap(double averageLength, int numSamples);
+    void slotSpinBpmValueChanged(double value);
 
     void reloadTrackMetadata();
     void updateTrackMetadata();
@@ -76,7 +77,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     bool m_trackHasBeatMap;
 
     QScopedPointer<TapFilter> m_pTapFilter;
-    double m_dLastBpm;
+    double m_dLastTapedBpm;
 
     DlgTagFetcher& m_DlgTagFetcher;
 

--- a/src/dlgtrackinfo.ui
+++ b/src/dlgtrackinfo.ui
@@ -47,7 +47,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab_1">
       <attribute name="title">
@@ -418,16 +418,7 @@
             <property name="sizeConstraint">
              <enum>QLayout::SetMinimumSize</enum>
             </property>
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
+            <property name="margin">
              <number>0</number>
             </property>
             <item>
@@ -683,6 +674,68 @@
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <layout class="QGridLayout" name="gridLayout">
+           <item row="0" column="1">
+            <widget class="QDoubleSpinBox" name="spinBpm">
+             <property name="toolTip">
+              <string>Displays the BPM of the selected track.</string>
+             </property>
+             <property name="decimals">
+              <number>8</number>
+             </property>
+             <property name="maximum">
+              <double>500.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>1.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="labelBpm">
+             <property name="text">
+              <string>Track BPM: </string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QCheckBox" name="bpmConst">
+             <property name="text">
+              <string>Assume constant tempo</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QPushButton" name="bpmTwoThirds">
+             <property name="minimumSize">
+              <size>
+               <width>125</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Sets the BPM to 66% of the current value.</string>
+             </property>
+             <property name="text">
+              <string>2/3 BPM</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QPushButton" name="bpmDouble">
+             <property name="minimumSize">
+              <size>
+               <width>125</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Sets the BPM to 200% of the current value.</string>
+             </property>
+             <property name="text">
+              <string>Double BPM</string>
+             </property>
+            </widget>
+           </item>
            <item row="2" column="1">
             <widget class="QPushButton" name="bpmThreeFourth">
              <property name="minimumSize">
@@ -715,58 +768,10 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
-            <widget class="QDoubleSpinBox" name="spinBpm">
-             <property name="toolTip">
-              <string>Displays the BPM of the selected track.</string>
-             </property>
-             <property name="decimals">
-              <number>8</number>
-             </property>
-             <property name="maximum">
-              <double>500.000000000000000</double>
-             </property>
-             <property name="singleStep">
-              <double>1.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QPushButton" name="bpmDouble">
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>Sets the BPM to 200% of the current value.</string>
-             </property>
+           <item row="1" column="2">
+            <widget class="QPushButton" name="bpmClear">
              <property name="text">
-              <string>Double BPM</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="labelBpm">
-             <property name="text">
-              <string>Track BPM: </string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QPushButton" name="bpmTwoThirds">
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>Sets the BPM to 66% of the current value.</string>
-             </property>
-             <property name="text">
-              <string>2/3 BPM</string>
+              <string>Clear Bpm and Beatgrid</string>
              </property>
             </widget>
            </item>

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -172,14 +172,14 @@ void BpmControl::slotFileBpmChanged(double bpm) {
 }
 
 void BpmControl::slotAdjustBeatsFaster(double v) {
-    if (v > 0 && m_pBeats && (m_pBeats->getCapabilities() & Beats::BEATSCAP_SET)) {
+    if (v > 0 && m_pBeats && (m_pBeats->getCapabilities() & Beats::BEATSCAP_SETBPM)) {
         double new_bpm = math_min(200.0, m_pBeats->getBpm() + .01);
         m_pBeats->setBpm(new_bpm);
     }
 }
 
 void BpmControl::slotAdjustBeatsSlower(double v) {
-    if (v > 0 && m_pBeats && (m_pBeats->getCapabilities() & Beats::BEATSCAP_SET)) {
+    if (v > 0 && m_pBeats && (m_pBeats->getCapabilities() & Beats::BEATSCAP_SETBPM)) {
         double new_bpm = math_max(10.0, m_pBeats->getBpm() - .01);
         m_pBeats->setBpm(new_bpm);
     }

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -30,14 +30,17 @@ TEST_F(BeatGridTest, Scale) {
     pGrid->setBpm(bpm);
 
     EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
-    pGrid->scale(2);
+    pGrid->scale(Beats::DOUBLE);
     EXPECT_DOUBLE_EQ(2 * bpm, pGrid->getBpm());
 
-    pGrid->scale(0.5);
+    pGrid->scale(Beats::HALVE);
     EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
 
-    pGrid->scale(0.25);
-    EXPECT_DOUBLE_EQ(0.25 * bpm, pGrid->getBpm());
+    pGrid->scale(Beats::TWOTHIRDS);
+    EXPECT_DOUBLE_EQ(bpm * 2 / 3, pGrid->getBpm());
+
+    pGrid->scale(Beats::THREEFOURTHS);
+    EXPECT_DOUBLE_EQ(bpm / 2, pGrid->getBpm());
 }
 
 TEST_F(BeatGridTest, TestNthBeatWhenOnBeat) {

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -56,12 +56,17 @@ TEST_F(BeatMapTest, Scale) {
     BeatMap* pMap = new BeatMap(m_pTrack, 0, beats);
 
     EXPECT_DOUBLE_EQ(bpm, pMap->getBpm());
-    pMap->scale(2);
+    pMap->scale(Beats::DOUBLE);
     EXPECT_DOUBLE_EQ(2 * bpm, pMap->getBpm());
-    pMap->scale(0.5);
+
+    pMap->scale(Beats::HALVE);
     EXPECT_DOUBLE_EQ(bpm, pMap->getBpm());
-    pMap->scale(0.25);
-    EXPECT_DOUBLE_EQ(0.25 * bpm, pMap->getBpm());
+
+    pMap->scale(Beats::TWOTHIRDS);
+    EXPECT_DOUBLE_EQ(bpm * 2 / 3, pMap->getBpm());
+
+    pMap->scale(Beats::THREEFOURTHS);
+    EXPECT_DOUBLE_EQ(bpm / 2, pMap->getBpm());
 }
 
 TEST_F(BeatMapTest, TestNthBeat) {

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -52,6 +52,16 @@ BeatGrid::BeatGrid(TrackInfoObject* pTrack, int iSampleRate,
     }
 }
 
+BeatGrid::BeatGrid(const BeatGrid& other)
+        : QObject(),
+          m_mutex(QMutex::Recursive) {
+    m_iSampleRate = other.m_iSampleRate;
+    m_dBeatLength = other.m_dBeatLength;
+    moveToThread(other.thread());
+    m_subVersion = other.m_subVersion;
+    m_grid = other.m_grid;
+}
+
 BeatGrid::~BeatGrid() {
 }
 
@@ -74,6 +84,12 @@ QByteArray* BeatGrid::toByteArray() const {
     QByteArray* pByteArray = new QByteArray(output.data(), output.length());
     // Caller is responsible for delete
     return pByteArray;
+}
+
+BeatsPointer BeatGrid::clone() const {
+    QMutexLocker locker(&m_mutex);
+    BeatsPointer other(new BeatGrid(*this));
+    return other;
 }
 
 void BeatGrid::readByteArray(const QByteArray* pByteArray) {

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -344,20 +344,34 @@ void BeatGrid::translate(double dNumSamples) {
     emit(updated());
 }
 
-void BeatGrid::scale(double dScalePercentage) {
-    QMutexLocker locker(&m_mutex);
-    if (!isValid()) {
+void BeatGrid::scale(enum BPMScale scale) {
+    double bpm = getBpm();
+
+    switch (scale) {
+    case DOUBLE:
+        bpm *= 2;
+        break;
+    case HALVE:
+        bpm *= 1.0 / 2;
+        break;
+    case TWOTHIRDS:
+        bpm *= 2.0 / 3;
+        break;
+    case THREEFOURTHS:
+        bpm *= 3.0 / 4;
+        break;
+    default:
+        DEBUG_ASSERT(!"scale value invalid");
         return;
     }
-    double newBpm = bpm() * dScalePercentage;
-    m_grid.mutable_bpm()->set_bpm(newBpm);
-    m_dBeatLength = (60.0 * m_iSampleRate / newBpm) * kFrameSize;
-    locker.unlock();
-    emit(updated());
+    setBpm(bpm);
 }
 
 void BeatGrid::setBpm(double dBpm) {
     QMutexLocker locker(&m_mutex);
+    if (dBpm > getMaxBpm()) {
+        dBpm = getMaxBpm();
+    }
     m_grid.mutable_bpm()->set_bpm(dBpm);
     m_dBeatLength = (60.0 * m_iSampleRate / dBpm) * kFrameSize;
     locker.unlock();

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -37,6 +37,7 @@ class BeatGrid : public QObject, public virtual Beats {
     }
 
     virtual QByteArray* toByteArray() const;
+    virtual BeatsPointer clone() const;
     virtual QString getVersion() const;
     virtual QString getSubVersion() const;
     virtual void setSubVersion(QString subVersion);
@@ -73,6 +74,7 @@ class BeatGrid : public QObject, public virtual Beats {
     void updated();
 
   private:
+    BeatGrid(const BeatGrid& other);
     double firstBeatSample() const;
     double bpm() const;
 

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -33,7 +33,7 @@ class BeatGrid : public QObject, public virtual Beats {
     // comments in beats.h
 
     virtual Beats::CapabilitiesFlags getCapabilities() const {
-        return BEATSCAP_TRANSLATE | BEATSCAP_SCALE | BEATSCAP_SET;
+        return BEATSCAP_TRANSLATE | BEATSCAP_SCALE | BEATSCAP_SETBPM;
     }
 
     virtual QByteArray* toByteArray() const;

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -67,7 +67,7 @@ class BeatGrid : public QObject, public virtual Beats {
     virtual void removeBeat(double dBeatSample);
     virtual void moveBeat(double dBeatSample, double dNewBeatSample);
     virtual void translate(double dNumSamples);
-    virtual void scale(double dScalePercentage);
+    virtual void scale(enum BPMScale scale);
     virtual void setBpm(double dBpm);
 
   signals:

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -90,6 +90,17 @@ void BeatMap::initialize(TrackPointer pTrack, int iSampleRate) {
     }
 }
 
+BeatMap::BeatMap (const BeatMap& other)
+        : QObject(),
+          m_mutex(QMutex::Recursive) {
+    m_iSampleRate = other.m_iSampleRate;
+    m_dCachedBpm = other.m_dCachedBpm;
+    m_dLastFrame = other.m_dLastFrame;
+    moveToThread(other.thread());
+    m_subVersion = other.m_subVersion;
+    m_beats = other.m_beats;
+}
+
 BeatMap::~BeatMap() {
 }
 
@@ -107,6 +118,12 @@ QByteArray* BeatMap::toByteArray() const {
     map.SerializeToString(&output);
     QByteArray* pByteArray = new QByteArray(output.data(), output.length());
     return pByteArray;
+}
+
+BeatsPointer BeatMap::clone() const {
+    QMutexLocker locker(&m_mutex);
+    BeatsPointer other(new BeatMap(*this));
+    return other;
 }
 
 void BeatMap::readByteArray(const QByteArray* pByteArray) {

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -577,6 +577,9 @@ void BeatMap::scale(double dScalePercentage) {
 }
 
 void BeatMap::setBpm(double dBpm) {
+    DEBUG_ASSERT(!"BeatMap::setBpm() not implemented");
+    return;
+
     /*
      * One of the problems of beattracking algorithms is the so called "octave error"
      * that is, calculated bpm is a power-of-two fraction of the bpm of the track.

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -40,7 +40,7 @@ class BeatMap : public QObject, public Beats {
 
     virtual Beats::CapabilitiesFlags getCapabilities() const {
         return BEATSCAP_TRANSLATE | BEATSCAP_SCALE | BEATSCAP_ADDREMOVE |
-                BEATSCAP_MOVEBEAT | BEATSCAP_SET;
+                BEATSCAP_MOVEBEAT;
     }
 
     virtual QByteArray* toByteArray() const;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -34,6 +34,7 @@ class BeatMap : public QObject, public Beats {
     // in audio frames may be provided.
     BeatMap(TrackPointer pTrack, int iSampleRate,
             const QVector<double>& beats);
+
     virtual ~BeatMap();
 
     // See method comments in beats.h
@@ -44,6 +45,7 @@ class BeatMap : public QObject, public Beats {
     }
 
     virtual QByteArray* toByteArray() const;
+    BeatsPointer clone() const;
     virtual QString getVersion() const;
     virtual QString getSubVersion() const;
     virtual void setSubVersion(QString subVersion);
@@ -81,6 +83,7 @@ class BeatMap : public QObject, public Beats {
     void updated();
 
   private:
+    BeatMap (const BeatMap& other);
     void initialize(TrackPointer pTrack, int iSampleRate);
     void readByteArray(const QByteArray* pByteArray);
     void createFromBeatVector(const QVector<double>& beats);

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -76,7 +76,7 @@ class BeatMap : public QObject, public Beats {
     virtual void removeBeat(double dBeatSample);
     virtual void moveBeat(double dBeatSample, double dNewBeatSample);
     virtual void translate(double dNumSamples);
-    virtual void scale(double dScalePercentage);
+    virtual void scale(enum BPMScale scale);
     virtual void setBpm(double dBpm);
 
   signals:
@@ -93,6 +93,12 @@ class BeatMap : public QObject, public Beats {
                         const mixxx::track::io::Beat& stopBeat) const;
     // For internal use only.
     bool isValid() const;
+
+    void scaleDouble();
+    void scaleTriple();
+    void scaleHalve();
+    void scaleThird();
+    void scaleFourth();
 
     mutable QMutex m_mutex;
     QString m_subVersion;

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -38,6 +38,7 @@ class Beats {
 
     // Serialization
     virtual QByteArray* toByteArray() const = 0;
+    virtual BeatsPointer clone() const = 0;
 
     // A string representing the version of the beat-processing code that
     // produced this Beats instance. Used by BeatsFactory for associating a

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -30,7 +30,7 @@ class Beats {
         BEATSCAP_TRANSLATE     = 0x0002, // Move all beat markers earlier or later
         BEATSCAP_SCALE         = 0x0004, // Scale beat distance of all beats
         BEATSCAP_MOVEBEAT      = 0x0008, // Move a single Beat
-        BEATSCAP_SET           = 0x0010  // Set new bpm, requires BEATSCAP_SCALE
+        BEATSCAP_SETBPM        = 0x0010  // Set new bpm, requires BEATSCAP_SCALE
     };
     typedef int CapabilitiesFlags; // Allows us to do ORing
 

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -26,11 +26,11 @@ class Beats {
 
     enum Capabilities {
         BEATSCAP_NONE          = 0x0000,
-        BEATSCAP_ADDREMOVE     = 0x0001,
-        BEATSCAP_TRANSLATE     = 0x0002,
-        BEATSCAP_SCALE         = 0x0004,
-        BEATSCAP_MOVEBEAT      = 0x0008,
-        BEATSCAP_SET           = 0x0010
+        BEATSCAP_ADDREMOVE     = 0x0001, // Add or remove a single beat
+        BEATSCAP_TRANSLATE     = 0x0002, // Move all beat markers earlier or later
+        BEATSCAP_SCALE         = 0x0004, // Scale beat distance of all beats
+        BEATSCAP_MOVEBEAT      = 0x0008, // Move a single Beat
+        BEATSCAP_SET           = 0x0010  // Set new bpm, requires BEATSCAP_SCALE
     };
     typedef int CapabilitiesFlags; // Allows us to do ORing
 

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -32,9 +32,9 @@ class Beats {
         BEATSCAP_NONE          = 0x0000,
         BEATSCAP_ADDREMOVE     = 0x0001, // Add or remove a single beat
         BEATSCAP_TRANSLATE     = 0x0002, // Move all beat markers earlier or later
-        BEATSCAP_SCALE         = 0x0004, // Scale beat distance of all beats
+        BEATSCAP_SCALE         = 0x0004, // Scale beat distance bay a fixed ratio
         BEATSCAP_MOVEBEAT      = 0x0008, // Move a single Beat
-        BEATSCAP_SETBPM        = 0x0010  // Set new bpm, requires BEATSCAP_SCALE
+        BEATSCAP_SETBPM        = 0x0010  // Set new bpm, beat grid only
     };
     typedef int CapabilitiesFlags; // Allows us to do ORing
 

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -6,6 +6,10 @@
 #include <QByteArray>
 #include <QSharedPointer>
 
+namespace {
+    double kMaxBpm = 500;
+}
+
 class Beats;
 typedef QSharedPointer<Beats> BeatsPointer;
 
@@ -33,6 +37,13 @@ class Beats {
         BEATSCAP_SETBPM        = 0x0010  // Set new bpm, requires BEATSCAP_SCALE
     };
     typedef int CapabilitiesFlags; // Allows us to do ORing
+
+    enum BPMScale {
+        DOUBLE,
+        HALVE,
+        TWOTHIRDS,
+        THREEFOURTHS,
+    };
 
     virtual Beats::CapabilitiesFlags getCapabilities() const = 0;
 
@@ -111,6 +122,10 @@ class Beats {
     // BPM returns -1.
     virtual double getBpmAroundPosition(double curSample, int n) const = 0;
 
+    virtual double getMaxBpm() const {
+        return kMaxBpm;
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
@@ -130,7 +145,7 @@ class Beats {
 
     // Scale the position of every beat in the song by dScalePercentage. Beats
     // class must have the capability BEATSCAP_SCALE.
-    virtual void scale(double dScalePercentage) = 0;
+    virtual void scale(enum BPMScale scale) = 0;
 
     // Adjust the beats so the global average BPM matches dBpm. Beats class must
     // have the capability BEATSCAP_SET.

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1548,7 +1548,7 @@ void WTrackTableView::slotScaleBpm(int scale) {
     for (int i = 0; i < selectedTrackIndices.size(); ++i) {
         QModelIndex index = selectedTrackIndices.at(i);
         TrackPointer track = trackModel->getTrack(index);
-        if (!track->hasBpmLock()) { //bpm is not locked
+        if (!track->hasBpmLock()) { // bpm is not locked
             BeatsPointer beats = track->getBeats();
             if (beats != NULL) {
                 beats->scale(scalingFactor);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1534,15 +1534,15 @@ void WTrackTableView::slotScaleBpm(int scale) {
         return;
     }
 
-    double scalingFactor=1;
+    double scalingFactor = 1.0;
     if (scale == DOUBLE)
-        scalingFactor = 2;
+        scalingFactor = 2.0;
     else if (scale == HALVE)
-        scalingFactor = 0.5;
+        scalingFactor = 1.0 / 2;
     else if (scale == TWOTHIRDS)
-        scalingFactor = 2./3.;
+        scalingFactor = 2.0 / 3;
     else if (scale == THREEFOURTHS)
-        scalingFactor = 3./4.;
+        scalingFactor = 3.0 / 4;
 
     QModelIndexList selectedTrackIndices = selectionModel()->selectedRows();
     for (int i = 0; i < selectedTrackIndices.size(); ++i) {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -432,10 +432,10 @@ void WTrackTableView::createActions() {
     m_pBpmTwoThirdsAction = new QAction(tr("2/3 BPM"), this);
     m_pBpmThreeFourthsAction = new QAction(tr("3/4 BPM"), this);
 
-    m_BpmMapper.setMapping(m_pBpmDoubleAction, DOUBLE);
-    m_BpmMapper.setMapping(m_pBpmHalveAction, HALVE);
-    m_BpmMapper.setMapping(m_pBpmTwoThirdsAction, TWOTHIRDS);
-    m_BpmMapper.setMapping(m_pBpmThreeFourthsAction, THREEFOURTHS);
+    m_BpmMapper.setMapping(m_pBpmDoubleAction, Beats::DOUBLE);
+    m_BpmMapper.setMapping(m_pBpmHalveAction, Beats::HALVE);
+    m_BpmMapper.setMapping(m_pBpmTwoThirdsAction, Beats::TWOTHIRDS);
+    m_BpmMapper.setMapping(m_pBpmThreeFourthsAction, Beats::THREEFOURTHS);
 
     connect(m_pBpmDoubleAction, SIGNAL(triggered()),
             &m_BpmMapper, SLOT(map()));
@@ -1534,16 +1534,6 @@ void WTrackTableView::slotScaleBpm(int scale) {
         return;
     }
 
-    double scalingFactor = 1.0;
-    if (scale == DOUBLE)
-        scalingFactor = 2.0;
-    else if (scale == HALVE)
-        scalingFactor = 1.0 / 2;
-    else if (scale == TWOTHIRDS)
-        scalingFactor = 2.0 / 3;
-    else if (scale == THREEFOURTHS)
-        scalingFactor = 3.0 / 4;
-
     QModelIndexList selectedTrackIndices = selectionModel()->selectedRows();
     for (int i = 0; i < selectedTrackIndices.size(); ++i) {
         QModelIndex index = selectedTrackIndices.at(i);
@@ -1551,7 +1541,7 @@ void WTrackTableView::slotScaleBpm(int scale) {
         if (!track->hasBpmLock()) { // bpm is not locked
             BeatsPointer beats = track->getBeats();
             if (beats != NULL) {
-                beats->scale(scalingFactor);
+                beats->scale((Beats::BPMScale)scale);
             } else {
                 continue;
             }

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -35,13 +35,6 @@ class WTrackTableView : public WLibraryTableView {
     virtual void loadSelectedTrack();
     virtual void loadSelectedTrackToGroup(QString group, bool play);
 
-    enum BPMScale {
-        DOUBLE,
-        HALVE,
-        TWOTHIRDS,
-        THREEFOURTHS,
-    };
-
   public slots:
     void loadTrackModel(QAbstractItemModel* model);
     void slotMouseDoubleClicked(const QModelIndex &);


### PR DESCRIPTION
Scaling the beatmap was heavily broken in 2.0.0 
https://bugs.launchpad.net/mixxx/+bug/1526075
https://bugs.launchpad.net/mixxx/+bug/1523286
https://bugs.launchpad.net/mixxx/+bug/1523179

This PR introduces a clear button and a const checkbox to the track preferences. 
The spinbox and the taping button is disabled if a beat map is available. 
Once you turn on the const check box both controls are enabled again. 

Scaling a beat map is now implemented by removing or adding beats. 
This fixes the issue that the second half of the track has no beats after you double the bpm.
It also guarantees that the beat remaining beat marks remains on the detected beat.  

I have also extended the test to check for 2/3 and 3/4 scaling.

I think if we offer a BeatMap feature, it is required that scaling works. 
If you try to scale a BeatMap with original 2.0.0 the beatmap becomes a mass. 
So this is not a situation that matches the desired quality. 

This PR is grown somehow bigger than original expected, but I think it is worth to include it into 
2.0.0. Other alternative is to disable scaling for beatmaps entirely. 
But that will put the whole BeatMap feature up for grabs 
