### PR TITLE
Browse view: Prevent creation of duplicate tracks

### DIFF
--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -212,7 +212,7 @@ void BrowseThread::populateModel() {
         item->setData(tio.getBitrate(), Qt::UserRole);
         row_data.insert(COLUMN_BITRATE, item);
 
-        item = new QStandardItem(filepath);
+        item = new QStandardItem(tio.getLocation());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_LOCATION, item);


### PR DESCRIPTION
I discovered another issue in the browse view that might cause duplicate tracks: After a TrackInfoObject has been created its location has to be used instead of the raw file path.

Related bugs:
https://bugs.launchpad.net/mixxx/+bug/1480791
https://bugs.launchpad.net/mixxx/+bug/1451778
