### PR TITLE
gracefull handle Midi overflow

### DIFF
--- a/src/controllers/midi/portmidicontroller.cpp
+++ b/src/controllers/midi/portmidicontroller.cpp
@@ -125,16 +125,6 @@ bool PortMidiController::poll() {
         return false;
     }
 
-    // Returns true if events are available or an error code.
-    PmError gotEvents = m_pInputDevice->poll();
-    if (gotEvents == FALSE) {
-        return false;
-    }
-    if (gotEvents < 0) {
-        qWarning() << "PortMidi error:" << Pm_GetErrorText(gotEvents);
-        return false;
-    }
-
     int numEvents = m_pInputDevice->read(m_midiBuffer, MIXXX_PORTMIDI_BUFFER_LEN);
 
     //qDebug() << "PortMidiController::poll()" << numEvents;

--- a/src/test/portmidicontroller_test.cpp
+++ b/src/test/portmidicontroller_test.cpp
@@ -196,23 +196,6 @@ TEST_F(PortMidiControllerTest, WriteSysex_Malformed) {
     m_pController->sendSysexMsg(sysex, sysex.length());
 };
 
-TEST_F(PortMidiControllerTest, Poll_Read_NoInput) {
-    Sequence poll;
-    EXPECT_CALL(*m_mockInput, isOpen())
-            .WillRepeatedly(Return(true));
-    EXPECT_CALL(*m_mockInput, poll())
-            .InSequence(poll)
-            .WillOnce(Return((PmError)FALSE));
-    EXPECT_CALL(*m_mockInput, poll())
-            .InSequence(poll)
-            .WillOnce(Return((PmError)TRUE));
-    EXPECT_CALL(*m_mockInput, read(_, _))
-            .InSequence(poll)
-            .WillOnce(Return(0));
-
-    pollDevice();
-    pollDevice();
-};
 
 TEST_F(PortMidiControllerTest, Poll_Read_Basic) {
     std::vector<PmEvent> messages;
@@ -222,9 +205,6 @@ TEST_F(PortMidiControllerTest, Poll_Read_Basic) {
     Sequence read;
     EXPECT_CALL(*m_mockInput, isOpen())
             .WillRepeatedly(Return(true));
-    EXPECT_CALL(*m_mockInput, poll())
-            .InSequence(read)
-            .WillOnce(Return((PmError)TRUE));
     EXPECT_CALL(*m_mockInput, read(NotNull(), _))
             .InSequence(read)
             .WillOnce(DoAll(SetArrayArgument<0>(messages.begin(), messages.end()),
@@ -260,9 +240,6 @@ TEST_F(PortMidiControllerTest, Poll_Read_SysExWithRealtime) {
     Sequence read;
     EXPECT_CALL(*m_mockInput, isOpen())
             .WillRepeatedly(Return(true));
-    EXPECT_CALL(*m_mockInput, poll())
-            .InSequence(read)
-            .WillOnce(Return((PmError)TRUE));
     EXPECT_CALL(*m_mockInput, read(NotNull(), _))
             .InSequence(read)
             .WillOnce(DoAll(SetArrayArgument<0>(messages.begin(), messages.end()),
@@ -295,9 +272,6 @@ TEST_F(PortMidiControllerTest, Poll_Read_SysEx) {
     Sequence read;
     EXPECT_CALL(*m_mockInput, isOpen())
             .WillRepeatedly(Return(true));
-    EXPECT_CALL(*m_mockInput, poll())
-            .InSequence(read)
-            .WillOnce(Return((PmError)TRUE));
     EXPECT_CALL(*m_mockInput, read(NotNull(), _))
             .InSequence(read)
             .WillOnce(DoAll(SetArrayArgument<0>(messages.begin(), messages.end()),
@@ -332,9 +306,6 @@ TEST_F(PortMidiControllerTest,
     Sequence read;
     EXPECT_CALL(*m_mockInput, isOpen())
             .WillRepeatedly(Return(true));
-    EXPECT_CALL(*m_mockInput, poll())
-            .InSequence(read)
-            .WillOnce(Return((PmError)TRUE));
     EXPECT_CALL(*m_mockInput, read(NotNull(), _))
             .InSequence(read)
             .WillOnce(DoAll(SetArrayArgument<0>(messages.begin(), messages.end()),
@@ -358,9 +329,6 @@ TEST_F(PortMidiControllerTest, Poll_Read_SysExInterrupted_FollowedByNormalMessag
     Sequence read;
     EXPECT_CALL(*m_mockInput, isOpen())
             .WillRepeatedly(Return(true));
-    EXPECT_CALL(*m_mockInput, poll())
-            .InSequence(read)
-            .WillOnce(Return((PmError)TRUE));
     EXPECT_CALL(*m_mockInput, read(NotNull(), _))
             .InSequence(read)
             .WillOnce(DoAll(SetArrayArgument<0>(messages.begin(), messages.end()),
@@ -396,9 +364,6 @@ TEST_F(PortMidiControllerTest, Poll_Read_SysExInterrupted_FollowedBySysExMessage
     Sequence read;
     EXPECT_CALL(*m_mockInput, isOpen())
             .WillRepeatedly(Return(true));
-    EXPECT_CALL(*m_mockInput, poll())
-            .InSequence(read)
-            .WillOnce(Return((PmError)TRUE));
     EXPECT_CALL(*m_mockInput, read(NotNull(), _))
             .InSequence(read)
             .WillOnce(DoAll(SetArrayArgument<0>(messages.begin(), messages.end()),
@@ -441,35 +406,23 @@ TEST_F(PortMidiControllerTest, Poll_Read_SysEx_BufferOverflow) {
             .WillRepeatedly(Return(true));
 
     // Poll 1 -- returns messages1.
-    EXPECT_CALL(*m_mockInput, poll())
-            .InSequence(read)
-            .WillOnce(Return((PmError)TRUE));
     EXPECT_CALL(*m_mockInput, read(NotNull(), _))
             .InSequence(read)
             .WillOnce(DoAll(SetArrayArgument<0>(messages1.begin(), messages1.end()),
                             Return(messages1.size())));
 
     // Poll 2 -- buffer overflow.
-    EXPECT_CALL(*m_mockInput, poll())
-            .InSequence(read)
-            .WillOnce(Return((PmError)TRUE));
     EXPECT_CALL(*m_mockInput, read(NotNull(), _))
             .InSequence(read)
             .WillOnce(Return(pmBufferOverflow));
 
     // Poll 3 -- returns messages2.
-    EXPECT_CALL(*m_mockInput, poll())
-            .InSequence(read)
-            .WillOnce(Return((PmError)TRUE));
     EXPECT_CALL(*m_mockInput, read(NotNull(), _))
             .InSequence(read)
             .WillOnce(DoAll(SetArrayArgument<0>(messages2.begin(), messages2.end()),
                             Return(messages2.size())));
 
     // Poll 4 -- returns messages3.
-    EXPECT_CALL(*m_mockInput, poll())
-            .InSequence(read)
-            .WillOnce(Return((PmError)TRUE));
     EXPECT_CALL(*m_mockInput, read(NotNull(), _))
             .InSequence(read)
             .WillOnce(DoAll(SetArrayArgument<0>(messages3.begin(), messages3.end()),


### PR DESCRIPTION
This is a simple fix to handle midi overflows gracefully. 
Details see: https://bugs.launchpad.net/mixxx/+bug/1527410

This fixes the issue that the midi fix stops after an overflow on nearly all platforms. 
Unfortunately in Ubuntu the thing becomes worse due to and exit call. 
This is why I change the required potmidi version to > the problematic one. 

https://bugs.launchpad.net/mixxx/+bug/1527888
https://bugs.launchpad.net/mixxx/+bug/1097286

IMHO This is merge-able once we have a portmidi version for Ubnutu in our ppa 
