### PR TITLE
Fix plugin build scripts after renaming source files

### DIFF
--- a/plugins/soundsourcem4a/SConscript
+++ b/plugins/soundsourcem4a/SConscript
@@ -15,9 +15,9 @@ m4a_sources = [
     "sources/soundsource.cpp",
     "sources/soundsourceplugin.cpp",
     "sources/audiosource.cpp",
-    "samplebuffer.cpp",
-    "singularsamplebuffer.cpp",
-    "sampleutil.cpp",
+    "util/samplebuffer.cpp",
+    "util/singularsamplebuffer.cpp",
+    "util/sample.cpp",
     "metadata/trackmetadata.cpp",
     "metadata/trackmetadatataglib.cpp",
     "util/replaygain.cpp"

--- a/plugins/soundsourcemediafoundation/SConscript
+++ b/plugins/soundsourcemediafoundation/SConscript
@@ -18,7 +18,7 @@ if int(build.flags['mediafoundation']):
     else:
         env["LINKFLAGS"].remove("/subsystem:windows,5.01")
     ssmediafoundation_bin = env.SharedLibrary('soundsourcemediafoundation',
-        ['soundsourcemediafoundation.cpp', 'sources/soundsourceplugin.cpp', 'sources/soundsource.cpp', 'sources/audiosource.cpp', 'metadata/trackmetadata.cpp', 'metadata/trackmetadatataglib.cpp', 'samplebuffer.cpp', 'sampleutil.cpp', 'util/replaygain.cpp' ],
+        ['soundsourcemediafoundation.cpp', 'sources/soundsourceplugin.cpp', 'sources/soundsource.cpp', 'sources/audiosource.cpp', 'metadata/trackmetadata.cpp', 'metadata/trackmetadatataglib.cpp', 'util/samplebuffer.cpp', 'util/sample.cpp', 'util/replaygain.cpp' ],
         LINKCOM  = [env['LINKCOM'],
             'mt.exe -nologo -manifest ${TARGET}.manifest -outputresource:$TARGET;1'])
     Return("ssmediafoundation_bin")


### PR DESCRIPTION
Plugin builds are broken after moving renaming sampleutil.h/.cpp to util/sample.h/.cpp
