### PR TITLE
Encapsulate BPM values in new class

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -933,6 +933,7 @@ class MixxxCore(Feature):
                    "track/keyutils.cpp",
                    "track/playcounter.cpp",
                    "track/replaygain.cpp",
+                   "track/bpm.cpp",
                    "track/trackmetadata.cpp",
                    "track/trackmetadatataglib.cpp",
                    "track/audiotagger.cpp",

--- a/plugins/soundsourcem4a/SConscript
+++ b/plugins/soundsourcem4a/SConscript
@@ -20,7 +20,8 @@ m4a_sources = [
     "util/sample.cpp",
     "track/trackmetadata.cpp",
     "track/trackmetadatataglib.cpp",
-    "track/replaygain.cpp"
+    "track/replaygain.cpp",
+    "track/bpm.cpp"
 ]
 
 #Tell SCons to build the SoundSourceM4A plugin

--- a/plugins/soundsourcemediafoundation/SConscript
+++ b/plugins/soundsourcemediafoundation/SConscript
@@ -18,7 +18,7 @@ if int(build.flags['mediafoundation']):
     else:
         env["LINKFLAGS"].remove("/subsystem:windows,5.01")
     ssmediafoundation_bin = env.SharedLibrary('soundsourcemediafoundation',
-        ['soundsourcemediafoundation.cpp', 'sources/soundsourceplugin.cpp', 'sources/soundsource.cpp', 'sources/audiosource.cpp', 'util/samplebuffer.cpp', 'util/sample.cpp', 'track/trackmetadata.cpp', 'track/trackmetadatataglib.cpp', 'track/replaygain.cpp' ],
+        ['soundsourcemediafoundation.cpp', 'sources/soundsourceplugin.cpp', 'sources/soundsource.cpp', 'sources/audiosource.cpp', 'util/samplebuffer.cpp', 'util/sample.cpp', 'track/trackmetadata.cpp', 'track/trackmetadatataglib.cpp', 'track/replaygain.cpp', 'track/bpm.cpp' ],
         LINKCOM  = [env['LINKCOM'],
             'mt.exe -nologo -manifest ${TARGET}.manifest -outputresource:$TARGET;1'])
     Return("ssmediafoundation_bin")

--- a/plugins/soundsourcewv/SConscript
+++ b/plugins/soundsourcewv/SConscript
@@ -17,7 +17,8 @@ wv_sources = [
     "sources/audiosource.cpp",
     "track/trackmetadata.cpp",
     "track/trackmetadatataglib.cpp",
-    "track/replaygain.cpp"
+    "track/replaygain.cpp",
+    "track/bpm.cpp"
 ]
 
 

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -46,7 +46,7 @@ bool AnalyzerBeats::initialize(TrackPointer tio, int sampleRate, int totalSample
         return false;
     }
 
-    bool bpmLock = tio->hasBpmLock();
+    bool bpmLock = tio->isBpmLocked();
     if (bpmLock) {
         qDebug() << "Track is BpmLocked: Beat calculation will not start";
         return false;
@@ -120,7 +120,7 @@ bool AnalyzerBeats::loadStored(TrackPointer tio) const {
         iMaxBpm = m_pConfig->getValueString(ConfigKey(BPM_CONFIG_KEY, BPM_RANGE_END)).toInt();
     }
 
-    bool bpmLock = tio->hasBpmLock();
+    bool bpmLock = tio->isBpmLocked();
     if (bpmLock) {
         qDebug() << "Track is BpmLocked: Beat calculation will not start";
         return true;
@@ -231,7 +231,7 @@ void AnalyzerBeats::finalize(TrackPointer tio) {
 
     // If the track received the beat lock while we were analyzing it then we
     // abort setting it.
-    if (tio->hasBpmLock()) {
+    if (tio->isBpmLocked()) {
         qDebug() << "Track was BPM-locked as we were analysing it. Aborting analysis.";
         return;
     }

--- a/src/dlgtrackinfo.cpp
+++ b/src/dlgtrackinfo.cpp
@@ -163,7 +163,7 @@ void DlgTrackInfo::populateFields(TrackPointer pTrack) {
     txtReplayGain->setText(Mixxx::ReplayGain::ratioToString(replayGain.getRatio()));
     BeatsPointer pBeats = pTrack->getBeats();
     bool beatsSupportsSet = !pBeats || (pBeats->getCapabilities() & Beats::BEATSCAP_SET);
-    bool enableBpmEditing = !pTrack->hasBpmLock() && beatsSupportsSet;
+    bool enableBpmEditing = !pTrack->isBpmLocked() && beatsSupportsSet;
     spinBpm->setEnabled(enableBpmEditing);
     bpmTap->setEnabled(enableBpmEditing);
     bpmDouble->setEnabled(enableBpmEditing);
@@ -345,7 +345,7 @@ void DlgTrackInfo::saveTrack() {
     m_pLoadedTrack->setTrackNumber(txtTrackNumber->text());
     m_pLoadedTrack->setComment(txtComment->toPlainText());
 
-    if (!m_pLoadedTrack->hasBpmLock()) {
+    if (!m_pLoadedTrack->isBpmLocked()) {
         m_pLoadedTrack->setBpm(spinBpm->value());
     }
 

--- a/src/dlgtrackinfo.cpp
+++ b/src/dlgtrackinfo.cpp
@@ -153,11 +153,11 @@ void DlgTrackInfo::populateFields(TrackPointer pTrack) {
     txtComment->setPlainText(pTrack->getComment());
     spinBpm->setValue(pTrack->getBpm());
     // Non-editable fields
-    txtDuration->setText(pTrack->getDurationStr());
+    txtDuration->setText(pTrack->getDurationText());
     txtLocation->setPlainText(pTrack->getLocation());
     txtType->setText(pTrack->getType());
-    txtBitrate->setText(QString(pTrack->getBitrateStr()) + (" ") + tr("kbps"));
-    txtBpm->setText(pTrack->getBpmStr());
+    txtBitrate->setText(QString(pTrack->getBitrateText()) + (" ") + tr("kbps"));
+    txtBpm->setText(pTrack->getBpmText());
     txtKey->setText(pTrack->getKeyText());
     const Mixxx::ReplayGain replayGain(pTrack->getReplayGain());
     txtReplayGain->setText(Mixxx::ReplayGain::ratioToString(replayGain.getRatio()));

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -507,8 +507,8 @@ TrackPointer EngineBuffer::loadFakeTrack(double filebpm) {
     // 10 seconds
     pTrack->setDuration(10);
     if (filebpm > 0) {
-        pTrack->setBpm(filebpm);
-        BeatsPointer pBeats = BeatFactory::makeBeatGrid(pTrack.data(), filebpm, 0.0);
+        double bpm = pTrack->setBpm(filebpm);
+        BeatsPointer pBeats = BeatFactory::makeBeatGrid(pTrack.data(), bpm, 0.0);
         pTrack->setBeats(pBeats);
     }
     slotTrackLoaded(pTrack, 44100, 44100 * 10);

--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -315,7 +315,7 @@ TrackPointer BansheePlaylistModel::getTrack(const QModelIndex& index) const {
         pTrack->setRating(getFieldString(index, CLM_RATING).toInt());
         pTrack->setTrackNumber(getFieldString(index, CLM_TRACKNUMBER));
         double bpm = getFieldString(index, CLM_BPM).toDouble();
-        pTrack->setBpm(bpm);
+        bpm = pTrack->setBpm(bpm);
         pTrack->setBitrate(getFieldString(index, CLM_BITRATE).toInt());
         pTrack->setComment(getFieldString(index, CLM_COMMENT));
         pTrack->setComposer(getFieldString(index, CLM_COMPOSER));

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -868,7 +868,7 @@ void BaseSqlTableModel::setTrackValueForColumn(TrackPointer pTrack, int column,
         pTrack->setKeyText(value.toString(),
                            mixxx::track::io::key::USER);
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK) == column) {
-        pTrack->setBpmLock(value.toBool());
+        pTrack->setBpmLocked(value.toBool());
     } else {
         // We never should get up to this point!
         DEBUG_ASSERT_AND_HANDLE(false) {

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -320,7 +320,7 @@ void BaseTrackCache::getTrackValueForColumn(TrackPointer pTrack,
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID) == column) {
         trackValue.setValue(static_cast<int>(pTrack->getKey()));
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK) == column) {
-        trackValue.setValue(pTrack->hasBpmLock());
+        trackValue.setValue(pTrack->isBpmLocked());
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART_LOCATION) == column) {
         trackValue.setValue(pTrack->getCoverInfo().coverLocation);
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART_HASH) == column ||

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -345,7 +345,7 @@ bool BrowseTableModel::setData(const QModelIndex &index, const QVariant &value,
     trackMetadata.setTitle(this->index(row, COLUMN_TITLE).data().toString());
     trackMetadata.setAlbum(this->index(row, COLUMN_ALBUM).data().toString());
     trackMetadata.setKey(this->index(row, COLUMN_KEY).data().toString());
-    trackMetadata.setBpm(this->index(row, COLUMN_BPM).data().toDouble());
+    trackMetadata.setBpm(Mixxx::Bpm(this->index(row, COLUMN_BPM).data().toDouble()));
     trackMetadata.setComment(this->index(row, COLUMN_COMMENT).data().toString());
     trackMetadata.setTrackNumber(this->index(row, COLUMN_TRACK_NUMBER).data().toString());
     trackMetadata.setYear(this->index(row, COLUMN_YEAR).data().toString());
@@ -362,7 +362,7 @@ bool BrowseTableModel::setData(const QModelIndex &index, const QVariant &value,
     } else if (col == COLUMN_ALBUM) {
         trackMetadata.setAlbum(value.toString());
     } else if (col == COLUMN_BPM) {
-        trackMetadata.setBpm(value.toDouble());
+        trackMetadata.setBpm(Mixxx::Bpm(value.toDouble()));
     } else if (col == COLUMN_KEY) {
         trackMetadata.setKey(value.toString());
     } else if (col == COLUMN_TRACK_NUMBER) {

--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -218,7 +218,7 @@ void BrowseThread::populateModel() {
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_DURATION, item);
 
-        item = new QStandardItem(tio.getBpmStr());
+        item = new QStandardItem(tio.getBpmText());
         item->setToolTip(item->text());
         item->setData(tio.getBpm(), Qt::UserRole);
         row_data.insert(COLUMN_BPM, item);
@@ -233,7 +233,7 @@ void BrowseThread::populateModel() {
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_TYPE, item);
 
-        item = new QStandardItem(tio.getBitrateStr());
+        item = new QStandardItem(tio.getBitrateText());
         item->setToolTip(item->text());
         item->setData(tio.getBitrate(), Qt::UserRole);
         row_data.insert(COLUMN_BITRATE, item);

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -401,7 +401,7 @@ void TrackDAO::bindTrackToLibraryInsert(TrackInfoObject* pTrack, int trackLocati
     m_pQueryLibraryInsert->bindValue(":bitrate", pTrack->getBitrate());
     m_pQueryLibraryInsert->bindValue(":samplerate", pTrack->getSampleRate());
     m_pQueryLibraryInsert->bindValue(":cuepoint", pTrack->getCuePoint());
-    m_pQueryLibraryInsert->bindValue(":bpm_lock", pTrack->hasBpmLock()? 1 : 0);
+    m_pQueryLibraryInsert->bindValue(":bpm_lock", pTrack->isBpmLocked()? 1 : 0);
     m_pQueryLibraryInsert->bindValue(":replaygain", pTrack->getReplayGain().getRatio());
     m_pQueryLibraryInsert->bindValue(":replaygain_peak", pTrack->getReplayGain().getPeak());
 
@@ -1133,7 +1133,7 @@ bool setTrackBeats(const QSqlRecord& record, const int column,
     } else {
         pTrack->setBpm(bpm);
     }
-    pTrack->setBpmLock(bpmLocked);
+    pTrack->setBpmLocked(bpmLocked);
     return false;
 }
 
@@ -1481,7 +1481,7 @@ void TrackDAO::updateTrack(TrackInfoObject* pTrack) {
     //query.bindValue(":location", pTrack->getLocation());
     query.bindValue(":track_id", trackId.toVariant());
 
-    query.bindValue(":bpm_lock", pTrack->hasBpmLock() ? 1 : 0);
+    query.bindValue(":bpm_lock", pTrack->isBpmLocked() ? 1 : 0);
 
     BeatsPointer pBeats = pTrack->getBeats();
     QByteArray* pBeatsBlob = NULL;

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -50,7 +50,7 @@ QVariant getTrackValueForColumn(const TrackPointer& pTrack, const QString& colum
     } else if (column == LIBRARYTABLE_KEY_ID) {
         return static_cast<int>(pTrack->getKey());
     } else if (column == LIBRARYTABLE_BPM_LOCK) {
-        return pTrack->hasBpmLock();
+        return pTrack->isBpmLocked();
     }
 
     return QVariant();

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -158,6 +158,7 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
     qRegisterMetaType<QSet<TrackId>>("QSet<TrackId>");
     qRegisterMetaType<TrackPointer>("TrackPointer");
     qRegisterMetaType<Mixxx::ReplayGain>("Mixxx::ReplayGain");
+    qRegisterMetaType<Mixxx::Bpm>("Mixxx::Bpm");
 
     ScopedTimer t("MixxxMainWindow::MixxxMainWindow");
     m_runtime_timer.start();

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -97,7 +97,7 @@ Result SoundSourceOpus::parseTrackMetadataAndCoverArt(
         } else if (!l_STag.compare("ALBUM")) {
             pTrackMetadata->setAlbum(l_SPayload);
         } else if (!l_STag.compare("BPM")) {
-            pTrackMetadata->setBpm(l_SPayload.toFloat());
+            pTrackMetadata->setBpm(Bpm(l_SPayload.toDouble()));
         } else if (!l_STag.compare("DATE")) {
             // Prefer "DATE" over "YEAR"
             pTrackMetadata->setYear(l_SPayload.trimmed());

--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -6,6 +6,8 @@
 
 namespace {
 
+const double kBpmValueMax = Mixxx::Bpm::kValueMax;
+
 class MetadataTest : public testing::Test {
   protected:
 
@@ -22,21 +24,24 @@ class MetadataTest : public testing::Test {
         //qDebug() << "parseBpm" << inputValue << expectedResult << expectedValue;
 
         bool actualResult;
-        const double actualValue = Mixxx::TrackMetadata::parseBpm(inputValue, &actualResult);
+        const double actualValue = Mixxx::Bpm::valueFromString(inputValue, &actualResult);
 
         EXPECT_EQ(expectedResult, actualResult);
         EXPECT_DOUBLE_EQ(expectedValue, actualValue);
 
 //        if (actualResult) {
-//            qDebug() << "BPM:" << inputValue << "->" << Mixxx::TrackMetadata::formatBpm(actualValue);
+//            qDebug() << "BPM:" << inputValue << "->" << Mixxx::Bpm::valueToString(actualValue);
 //        }
 
         return actualResult;
     }
 
-    void normalizeBpm(double expectedResult) {
-        const double actualResult = Mixxx::TrackMetadata::normalizeBpm(expectedResult);
-        EXPECT_EQ(expectedResult, actualResult);
+    void normalizeBpm(double normalizedValue) {
+        Mixxx::Bpm normalizedBpm(normalizedValue);
+        normalizedBpm.normalizeValue(); // re-normalize
+        // Expected: Re-normalization does not change the value
+        // that should already be normalized.
+        EXPECT_EQ(normalizedBpm.getValue(), normalizedValue);
     }
 };
 
@@ -45,7 +50,7 @@ TEST_F(MetadataTest, ParseBpmPrecision) {
 }
 
 TEST_F(MetadataTest, ParseBpmValidRange) {
-    for (int bpm100 = int(Mixxx::TrackMetadata::kBpmMin) * 100; int(Mixxx::TrackMetadata::kBpmMax) * 100 >= bpm100; ++bpm100) {
+    for (int bpm100 = int(Mixxx::Bpm::kValueMin) * 100; kBpmValueMax * 100 >= bpm100; ++bpm100) {
         const double expectedValue = bpm100 / 100.0;
         const QString inputValues[] = {
                 QString("%1").arg(expectedValue),
@@ -63,21 +68,21 @@ TEST_F(MetadataTest, ParseBpmDecimalScaling) {
 }
 
 TEST_F(MetadataTest, ParseBpmInvalid) {
-    parseBpm("", false, Mixxx::TrackMetadata::kBpmUndefined);
-    parseBpm("abcde", false, Mixxx::TrackMetadata::kBpmUndefined);
-    parseBpm("0 dBA", false, Mixxx::TrackMetadata::kBpmUndefined);
+    parseBpm("", false, Mixxx::Bpm::kValueUndefined);
+    parseBpm("abcde", false, Mixxx::Bpm::kValueUndefined);
+    parseBpm("0 dBA", false, Mixxx::Bpm::kValueUndefined);
 }
 
 TEST_F(MetadataTest, NormalizeBpm) {
-    normalizeBpm(Mixxx::TrackMetadata::kBpmUndefined);
-    normalizeBpm(Mixxx::TrackMetadata::kBpmMin);
-    normalizeBpm(Mixxx::TrackMetadata::kBpmMin - 1.0);
-    normalizeBpm(Mixxx::TrackMetadata::kBpmMin + 1.0);
-    normalizeBpm(-Mixxx::TrackMetadata::kBpmMin);
-    normalizeBpm(Mixxx::TrackMetadata::kBpmMax);
-    normalizeBpm(Mixxx::TrackMetadata::kBpmMax - 1.0);
-    normalizeBpm(Mixxx::TrackMetadata::kBpmMax + 1.0);
-    normalizeBpm(-Mixxx::TrackMetadata::kBpmMax);
+    normalizeBpm(Mixxx::Bpm::kValueUndefined);
+    normalizeBpm(Mixxx::Bpm::kValueMin);
+    normalizeBpm(Mixxx::Bpm::kValueMin - 1.0);
+    normalizeBpm(Mixxx::Bpm::kValueMin + 1.0);
+    normalizeBpm(-Mixxx::Bpm::kValueMin);
+    normalizeBpm(kBpmValueMax);
+    normalizeBpm(kBpmValueMax - 1.0);
+    normalizeBpm(kBpmValueMax + 1.0);
+    normalizeBpm(-kBpmValueMax);
 }
 
 TEST_F(MetadataTest, ID3v2Year) {

--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -6,7 +6,7 @@
 
 namespace {
 
-const double kBpmValueMax = Mixxx::Bpm::kValueMax;
+const double kBpmValueMax = 300.0;
 
 class MetadataTest : public testing::Test {
   protected:
@@ -60,11 +60,6 @@ TEST_F(MetadataTest, ParseBpmValidRange) {
             parseBpm(inputValues[i], true, expectedValue);
         }
     }
-}
-
-TEST_F(MetadataTest, ParseBpmDecimalScaling) {
-    parseBpm("345678", true, 34.5678);
-    parseBpm("2345678", true, 234.5678);
 }
 
 TEST_F(MetadataTest, ParseBpmInvalid) {

--- a/src/track/bpm.cpp
+++ b/src/track/bpm.cpp
@@ -7,7 +7,6 @@ namespace Mixxx {
 
 /*static*/ const double Bpm::kValueUndefined = 0.0;
 /*static*/ const double Bpm::kValueMin = 0.0; // lower bound (exclusive)
-/*static*/ const double Bpm::kValueMax = 300.0; // upper bound (inclusive)
 
 double Bpm::valueFromString(const QString& str, bool* pValid) {
     if (pValid) {
@@ -25,13 +24,6 @@ double Bpm::valueFromString(const QString& str, bool* pValid) {
                 *pValid = true;
             }
             return value;
-        }
-        while (kValueMax < value) {
-            // Some applications might store the BPM as an
-            // integer scaled by a factor of 10 or 100 to
-            // preserve fractional digits.
-            qDebug() << "Scaling BPM value:" << value;
-            value /= 10.0;
         }
         if (isValidValue(value)) {
             if (pValid) {

--- a/src/track/bpm.cpp
+++ b/src/track/bpm.cpp
@@ -1,0 +1,68 @@
+#include "track/bpm.h"
+
+namespace Mixxx {
+
+// TODO(uklotzde): Replace 'const' with 'constexpr' and remove
+// initialization after switching to Visual Studio 2015.
+
+/*static*/ const double Bpm::kValueUndefined = 0.0;
+/*static*/ const double Bpm::kValueMin = 0.0; // lower bound (exclusive)
+/*static*/ const double Bpm::kValueMax = 300.0; // upper bound (inclusive)
+
+double Bpm::valueFromString(const QString& str, bool* pValid) {
+    if (pValid) {
+        *pValid = false;
+    }
+    if (str.trimmed().isEmpty()) {
+        return kValueUndefined;
+    }
+    bool valueValid = false;
+    double value = str.toDouble(&valueValid);
+    if (valueValid) {
+        if (kValueUndefined == value) {
+            // special case
+            if (pValid) {
+                *pValid = true;
+            }
+            return value;
+        }
+        while (kValueMax < value) {
+            // Some applications might store the BPM as an
+            // integer scaled by a factor of 10 or 100 to
+            // preserve fractional digits.
+            qDebug() << "Scaling BPM value:" << value;
+            value /= 10.0;
+        }
+        if (isValidValue(value)) {
+            if (pValid) {
+                *pValid = true;
+            }
+            return value;
+        } else {
+            qDebug() << "Invalid BPM value:" << str << "->" << value;
+        }
+    } else {
+        qDebug() << "Failed to parse BPM:" << str;
+    }
+    return kValueUndefined;
+}
+
+QString Bpm::valueToString(double value) {
+    if (isValidValue(value)) {
+        return QString::number(value);
+    } else {
+        return QString();
+    }
+}
+
+void Bpm::normalizeValue() {
+    if (isValidValue(m_value)) {
+        const double normalizedValue = valueFromString(valueToString(m_value));
+        // NOTE(uklotzde): Subsequently formatting and parsing the
+        // normalized value should not alter it anymore!
+        DEBUG_ASSERT(normalizedValue == valueFromString(valueToString(normalizedValue)));
+        m_value = normalizedValue;
+    }
+}
+
+} //namespace Mixxx

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -1,0 +1,69 @@
+#ifndef MIXXX_BPM_H
+#define MIXXX_BPM_H
+
+#include <QtDebug>
+
+#include "util/math.h"
+
+namespace Mixxx {
+
+// DTO for storing BPM information.
+class Bpm final {
+public:
+    // TODO(uklotzde): Replace 'const' with 'constexpr'
+    // (and copy initialization from .cpp file) after switching to
+    // Visual Studio 2015 on Windows.
+    static const double kValueUndefined;
+    static const double kValueMin; // lower bound (exclusive)
+    static const double kValueMax; // upper bound (inclusive)
+
+    Bpm()
+        : Bpm(kValueUndefined) {
+    }
+    explicit Bpm(double value)
+        : m_value(value) {
+    }
+
+    static bool isValidValue(double value) {
+        return (kValueMin < value) && (kValueMax >= value);
+    }
+
+    bool hasValue() const {
+        return isValidValue(m_value);
+    }
+    double getValue() const {
+        return m_value;
+    }
+    void setValue(double value) {
+        m_value = value;
+    }
+    void resetValue() {
+        m_value = kValueUndefined;
+    }
+    void normalizeValue();
+
+    static double valueFromString(const QString& str, bool* pValid = nullptr);
+    static QString valueToString(double value);
+    static int valueToInteger(double value) {
+        return std::round(value);
+    }
+
+private:
+    double m_value;
+};
+
+inline
+bool operator==(const Bpm& lhs, const Bpm& rhs) {
+    return lhs.getValue() == rhs.getValue();
+}
+
+inline
+bool operator!=(const Bpm& lhs, const Bpm& rhs) {
+    return !(lhs == rhs);
+}
+
+}
+
+Q_DECLARE_METATYPE(Mixxx::Bpm)
+
+#endif // MIXXX_BPM_H

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -15,7 +15,6 @@ public:
     // Visual Studio 2015 on Windows.
     static const double kValueUndefined;
     static const double kValueMin; // lower bound (exclusive)
-    static const double kValueMax; // upper bound (inclusive)
 
     Bpm()
         : Bpm(kValueUndefined) {
@@ -25,7 +24,7 @@ public:
     }
 
     static bool isValidValue(double value) {
-        return (kValueMin < value) && (kValueMax >= value);
+        return kValueMin < value;
     }
 
     bool hasValue() const {

--- a/src/track/trackmetadata.cpp
+++ b/src/track/trackmetadata.cpp
@@ -4,77 +4,7 @@
 
 namespace Mixxx {
 
-/*static*/ const double TrackMetadata::kBpmUndefined = 0.0;
-/*static*/ const double TrackMetadata::kBpmMin = 0.0; // lower bound (exclusive)
-/*static*/ const double TrackMetadata::kBpmMax = 300.0; // upper bound (inclusive)
-
 /*static*/ const int TrackMetadata::kCalendarYearInvalid = 0;
-
-double TrackMetadata::parseBpm(const QString& sBpm, bool* pValid) {
-    if (pValid) {
-        *pValid = false;
-    }
-    if (sBpm.trimmed().isEmpty()) {
-        return kBpmUndefined;
-    }
-    bool bpmValid = false;
-    double bpm = sBpm.toDouble(&bpmValid);
-    if (bpmValid) {
-        if (kBpmUndefined == bpm) {
-            // special case
-            if (pValid) {
-                *pValid = true;
-            }
-            return bpm;
-        }
-        while (kBpmMax < bpm) {
-            // Some applications might store the BPM as an
-            // integer scaled by a factor of 10 or 100 to
-            // preserve fractional digits.
-            qDebug() << "Scaling BPM value:" << bpm;
-            bpm /= 10.0;
-        }
-        if (isBpmValid(bpm)) {
-            if (pValid) {
-                *pValid = true;
-            }
-            return bpm;
-        } else {
-            qDebug() << "Invalid BPM value:" << sBpm << "->" << bpm;
-        }
-    } else {
-        qDebug() << "Failed to parse BPM:" << sBpm;
-    }
-    return kBpmUndefined;
-}
-
-QString TrackMetadata::formatBpm(double bpm) {
-    if (isBpmValid(bpm)) {
-        return QString::number(bpm);
-    } else {
-        return QString();
-    }
-}
-
-QString TrackMetadata::formatBpm(int bpm) {
-    if (isBpmValid(bpm)) {
-        return QString::number(bpm);
-    } else {
-        return QString();
-    }
-}
-
-double TrackMetadata::normalizeBpm(double bpm) {
-    if (isBpmValid(bpm)) {
-        const double normalizedBpm = parseBpm(formatBpm(bpm));
-        // NOTE(uklotzde): Subsequently formatting and parsing the
-        // normalized value should not alter it anymore!
-        DEBUG_ASSERT(normalizedBpm == parseBpm(formatBpm(normalizedBpm)));
-        return normalizedBpm;
-    } else {
-        return bpm;
-    }
-}
 
 int TrackMetadata::parseCalendarYear(QString year, bool* pValid) {
     const QDateTime dateTime(parseDateTime(year));
@@ -143,8 +73,7 @@ QString TrackMetadata::formatDuration(int duration) {
 }
 
 TrackMetadata::TrackMetadata()
-    : m_bpm(kBpmUndefined),
-      m_bitrate(0),
+    : m_bitrate(0),
       m_channels(0),
       m_duration(0),
       m_sampleRate(0) {

--- a/src/track/trackmetadata.h
+++ b/src/track/trackmetadata.h
@@ -3,6 +3,7 @@
 
 #include <QDateTime>
 
+#include "track/bpm.h"
 #include "track/replaygain.h"
 
 namespace Mixxx {
@@ -125,26 +126,14 @@ public:
     static QString formatDuration(int duration);
 
     // beats / minute
-    static const double kBpmUndefined;
-    static const double kBpmMin; // lower bound (exclusive)
-    static const double kBpmMax; // upper bound (inclusive)
-    inline double getBpm() const {
+    Bpm getBpm() const {
         return m_bpm;
     }
-    inline int getBpmAsInteger() const {
-        return round(getBpm());
-    }
-    inline static bool isBpmValid(double bpm) {
-        return (kBpmMin < bpm) && (kBpmMax >= bpm);
-    }
-    inline bool isBpmValid() const {
-        return isBpmValid(getBpm());
-    }
-    inline void setBpm(double bpm) {
+    void setBpm(Bpm bpm) {
         m_bpm = bpm;
     }
-    inline void resetBpm() {
-        m_bpm = kBpmUndefined;
+    void resetBpm() {
+        m_bpm.resetValue();
     }
 
     const ReplayGain& getReplayGain() const {
@@ -156,12 +145,6 @@ public:
     void resetReplayGain() {
         m_replayGain = ReplayGain();
     }
-
-    // Parse and format BPM metadata
-    static double parseBpm(const QString& sBpm, bool* pValid = 0);
-    static QString formatBpm(double bpm);
-    static QString formatBpm(int bpm);
-    static double normalizeBpm(double bpm);
 
     // Parse an format date/time values according to ISO 8601
     inline static QDate parseDate(QString str) {
@@ -198,10 +181,8 @@ private:
     QString m_trackNumber;
     QString m_year;
 
+    Bpm m_bpm;
     ReplayGain m_replayGain;
-
-    // Floating-point fields (in alphabetical order)
-    double m_bpm;
 
     // Integer fields (in alphabetical order)
     int m_bitrate; // kbit/s

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -305,16 +305,18 @@ void TrackInfoObject::setReplayGain(const Mixxx::ReplayGain& replayGain) {
 }
 
 double TrackInfoObject::getBpm() const {
+    double bpm = Mixxx::Bpm::kValueUndefined;
     QMutexLocker lock(&m_qMutex);
-    if (!m_pBeats) {
-        return 0;
+    if (m_pBeats) {
+        // BPM from beat grid overrides BPM from metadata
+        // Reason: The BPM value in the metadata might be imprecise,
+        // e.g. ID3v2 only supports integer values!
+        double beatsBpm = m_pBeats->getBpm();
+        if (Mixxx::Bpm::isValidValue(beatsBpm)) {
+            bpm = beatsBpm;
+        }
     }
-    // getBpm() returns -1 when invalid.
-    double bpm = m_pBeats->getBpm();
-    if (bpm >= 0.0) {
-        return bpm;
-    }
-    return 0;
+    return bpm;
 }
 
 double TrackInfoObject::setBpm(double bpmValue) {

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -213,7 +213,7 @@ void TrackInfoObject::parse(bool parseCoverArt) {
     }
 }
 
-QString TrackInfoObject::getDurationStr() const {
+QString TrackInfoObject::getDurationText() const {
     QMutexLocker lock(&m_qMutex);
     int iDuration = m_iDuration;
     lock.unlock();
@@ -348,7 +348,7 @@ double TrackInfoObject::setBpm(double bpmValue) {
     return bpmValue;
 }
 
-QString TrackInfoObject::getBpmStr() const {
+QString TrackInfoObject::getBpmText() const {
     return QString("%1").arg(getBpm(), 3,'f',1);
 }
 
@@ -660,7 +660,7 @@ int TrackInfoObject::getBitrate() const {
     return m_iBitrate;
 }
 
-QString TrackInfoObject::getBitrateStr() const {
+QString TrackInfoObject::getBitrateText() const {
     return QString("%1").arg(getBitrate());
 }
 

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -57,10 +57,10 @@ class TrackInfoObject : public QObject {
     Q_PROPERTY(int times_played READ getTimesPlayed)
     Q_PROPERTY(QString comment READ getComment WRITE setComment)
     Q_PROPERTY(double bpm READ getBpm WRITE setBpm)
-    Q_PROPERTY(QString bpmFormatted READ getBpmStr STORED false)
+    Q_PROPERTY(QString bpmFormatted READ getBpmText STORED false)
     Q_PROPERTY(QString key READ getKeyText WRITE setKeyText)
     Q_PROPERTY(int duration READ getDuration WRITE setDuration)
-    Q_PROPERTY(QString durationFormatted READ getDurationStr STORED false)
+    Q_PROPERTY(QString durationFormatted READ getDurationText STORED false)
 
     TrackId getId() const;
 
@@ -112,21 +112,21 @@ class TrackInfoObject : public QObject {
     // Returns the bitrate
     int getBitrate() const;
     // Returns the bitrate as a string
-    QString getBitrateStr() const;
+    QString getBitrateText() const;
 
     // Set duration in seconds
     void setDuration(int);
     // Returns the duration in seconds
     int getDuration() const;
     // Returns the duration as a string: H:MM:SS
-    QString getDurationStr() const;
+    QString getDurationText() const;
 
     // Set BPM
     double setBpm(double);
     // Returns BPM
     double getBpm() const;
     // Returns BPM as a string
-    QString getBpmStr() const;
+    QString getBpmText() const;
 
     // A track with a locked BPM will not be re-analyzed by the beats or bpm
     // analyzer.

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -122,7 +122,7 @@ class TrackInfoObject : public QObject {
     QString getDurationStr() const;
 
     // Set BPM
-    void setBpm(double);
+    double setBpm(double);
     // Returns BPM
     double getBpm() const;
     // Returns BPM as a string
@@ -130,8 +130,8 @@ class TrackInfoObject : public QObject {
 
     // A track with a locked BPM will not be re-analyzed by the beats or bpm
     // analyzer.
-    void setBpmLock(bool hasLock);
-    bool hasBpmLock() const;
+    void setBpmLocked(bool bpmLocked = true);
+    bool isBpmLocked() const;
 
     // Set ReplayGain
     void setReplayGain(const Mixxx::ReplayGain&);
@@ -295,6 +295,8 @@ class TrackInfoObject : public QObject {
     // TIO local methods or the TrackDAO.
     void setDirty(bool bDirty);
 
+    void setBeatsAndUnlock(QMutexLocker* pLock, BeatsPointer pBeats);
+
     // Set a unique identifier for the track. Only used by services like
     // TrackDAO
     void setId(TrackId id);
@@ -368,8 +370,7 @@ class TrackInfoObject : public QObject {
 
     Keys m_keys;
 
-    // BPM lock
-    bool m_bBpmLock;
+    bool m_bBpmLocked;
 
     // The list of cue points for the track
     QList<Cue*> m_cuePoints;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1554,7 +1554,7 @@ void WTrackTableView::slotScaleBpm(int scale) {
     for (int i = 0; i < selectedTrackIndices.size(); ++i) {
         QModelIndex index = selectedTrackIndices.at(i);
         TrackPointer track = trackModel->getTrack(index);
-        if (!track->hasBpmLock()) { //bpm is not locked
+        if (!track->isBpmLocked()) { //bpm is not locked
             BeatsPointer beats = track->getBeats();
             if (beats != NULL) {
                 beats->scale(scalingFactor);
@@ -1576,7 +1576,7 @@ void WTrackTableView::lockBpm(bool lock) {
     for (int i = 0; i < selectedTrackIndices.size(); ++i) {
         QModelIndex index = selectedTrackIndices.at(i);
         TrackPointer track = trackModel->getTrack(index);
-        track->setBpmLock(lock);
+        track->setBpmLocked(lock);
     }
 }
 
@@ -1591,7 +1591,7 @@ void WTrackTableView::slotClearBeats() {
     for (int i = 0; i < selectedTrackIndices.size(); ++i) {
         QModelIndex index = selectedTrackIndices.at(i);
         TrackPointer track = trackModel->getTrack(index);
-        if (!track->hasBpmLock()) {
+        if (!track->isBpmLocked()) {
             track->setBeats(BeatsPointer());
         }
     }


### PR DESCRIPTION
A similar strategy that we have already applied for ReplayGain. This refactoring removes unnecessary complexity from TrackInfoObject and TagLib code.

Both classes ReplayGain and Bpm are located in the "Mixxx" namespace to avoid naming conflicts. Currently this is only necessary for ReplayGain, but for consistency both classes are placed in a namespace.

Extensions/improvements/fixes of the actual TagLib related code ("total tracks") will follow in a separate PR.
