### PR TITLE
allow win uninstaller to be run silently

### DIFF
--- a/build/nsis/Mixxx.nsi
+++ b/build/nsis/Mixxx.nsi
@@ -302,12 +302,12 @@ SectionEnd
 
 Function un.onUninstSuccess
   HideWindow
-  MessageBox MB_ICONINFORMATION|MB_OK "$(^Name) was successfully removed from your computer."
+  MessageBox MB_ICONINFORMATION|MB_OK "$(^Name) was successfully removed from your computer." /SD IDOK
 FunctionEnd
 
 Function un.onInit
     !insertmacro MUI_UNGETLANGUAGE
-    MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 "Are you sure you want to completely remove $(^Name) and all of its components?" IDYES +2
+    MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 "Are you sure you want to completely remove $(^Name) and all of its components?" /SD IDYES IDYES +2
     Abort
     !insertmacro MULTIUSER_UNINIT
 FunctionEnd


### PR DESCRIPTION
This PR adds defaults to windows uninstaller dialogs to allow it to run silently (if /S parameter is added)
