### PR TITLE
add language property to windows exe

### DIFF
--- a/src/mixxx.rc
+++ b/src/mixxx.rc
@@ -59,10 +59,10 @@ BEGIN
         END
     END
 
-    //BLOCK "VarFileInfo"
-    //BEGIN
-        // English language (0x409) Unicode (1200).
-    //    VALUE "Translation", 0x409, 1200
+    BLOCK "VarFileInfo"
+    BEGIN
+        // Neutral Language (0x0) Unicode (1200).
+        VALUE "Translation", 0x0, 1200
 
-    //END
+    END
 END


### PR DESCRIPTION
This PR add language property to windows executable.
This property is mandatory for wix/MSI installer to avoid unwanted warning.

I used a neutral language value because the same executable (mixxx.exe) can show different languages depending of the loaded translation, so the exe itself is language neutral (the same exe is installed whatever language is show)
