### PR TITLE
Fix formatting of time durations (Follow-up)

### DIFF
--- a/src/dlgautodj.cpp
+++ b/src/dlgautodj.cpp
@@ -219,7 +219,7 @@ void DlgAutoDJ::updateSelectionInfo() {
     QString label;
 
     if (!indices.isEmpty()) {
-        label.append(Time::formatSeconds(duration, false));
+        label.append(Time::formatSeconds(duration));
         label.append(QString(" (%1)").arg(indices.size()));           
     }
 

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -562,7 +562,7 @@ QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
             if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DURATION)) {
                 int duration = value.toInt();
                 if (duration > 0) {
-                    value = Time::formatSeconds(duration, false);
+                    value = Time::formatSeconds(duration);
                 } else {
                     value = QString();
                 }

--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -211,8 +211,7 @@ void BrowseThread::populateModel() {
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_COMMENT, item);
 
-        QString duration = Time::formatSeconds(qVariantValue<int>(
-                tio.getDuration()), false);
+        QString duration = Time::formatSeconds(tio.getDuration());
         item = new QStandardItem(duration);
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);

--- a/src/library/cratefeature.cpp
+++ b/src/library/cratefeature.cpp
@@ -496,7 +496,7 @@ void CrateFeature::buildCrateList() {
             crateListTableModel.index(row, durationColumn)).toInt();
         m_crateList.append(qMakePair(id, QString("%1 (%2) %3")
                                      .arg(name, QString::number(count),
-                                          Time::formatSeconds(duration, false))));
+                                          Time::formatSeconds(duration))));
     }
 }
 

--- a/src/library/playlistfeature.cpp
+++ b/src/library/playlistfeature.cpp
@@ -167,7 +167,7 @@ void PlaylistFeature::buildPlaylistList() {
             playlistTableModel.index(row, durationColumn)).toInt();
         m_playlistList.append(qMakePair(id, QString("%1 (%2) %3")
                                         .arg(name, QString::number(count),
-                                             Time::formatSeconds(duration, false))));
+                                             Time::formatSeconds(duration))));
     }
 }
 

--- a/src/test/timeutiltest.cpp
+++ b/src/test/timeutiltest.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+
+#include "util/time.h"
+
+#include <QtDebug>
+
+namespace {
+
+class TimeUtilTest : public testing::Test {
+  protected:
+
+    TimeUtilTest() {
+    }
+
+    virtual void SetUp() {
+    }
+
+    virtual void TearDown() {
+    }
+    
+    static QString adjustPrecision(
+        QString withMilliseconds,
+        Time::Precision precision) {
+        switch (precision) {
+        case Time::Precision::SECONDS:
+        {
+            return withMilliseconds.left(withMilliseconds.length() - 4);
+        }
+        case Time::Precision::CENTISECONDS:
+        {
+            return withMilliseconds.left(withMilliseconds.length() - 1);
+        }
+        default:
+            return withMilliseconds;
+        }
+    }
+    
+    void formatSeconds(QString expectedMilliseconds, double dSeconds) {
+        ASSERT_LE(4, expectedMilliseconds.length()); // 3 digits + 1 decimal point
+        const QString actualSeconds =
+            Time::formatSeconds(dSeconds, Time::Precision::SECONDS);
+        const QString expectedSeconds =
+                adjustPrecision(expectedMilliseconds, Time::Precision::SECONDS);
+        EXPECT_EQ(expectedSeconds, actualSeconds);
+        const QString expectedCentiseconds =
+                adjustPrecision(expectedMilliseconds, Time::Precision::CENTISECONDS);
+        const QString actualCentiseconds =
+            Time::formatSeconds(dSeconds, Time::Precision::CENTISECONDS);
+        EXPECT_EQ(expectedCentiseconds, actualCentiseconds);
+        const QString actualMilliseconds =
+            Time::formatSeconds(dSeconds, Time::Precision::MILLISECONDS);
+        EXPECT_EQ(actualMilliseconds, actualMilliseconds);
+    }
+};
+
+TEST_F(TimeUtilTest, FormatSecondsNegative) {
+    EXPECT_EQ("?", Time::formatSeconds(-1, Time::Precision::SECONDS));
+    EXPECT_EQ("?", Time::formatSeconds(-1, Time::Precision::CENTISECONDS));
+    EXPECT_EQ("?", Time::formatSeconds(-1, Time::Precision::MILLISECONDS));
+}
+
+TEST_F(TimeUtilTest, FormatSeconds) {
+    formatSeconds("00:00.000", 0);
+    formatSeconds("00:01.000", 1);
+    formatSeconds("00:59.000", 59);
+    formatSeconds("01:00.000", 60);
+    formatSeconds("01:01.123", 61.1234);
+    formatSeconds("59:59.999", 3599.999);
+    formatSeconds("01:00:00.000", 3600);
+    formatSeconds("23:59:59.000", 24 * 3600 - 1);
+    formatSeconds("1d, 00:00:00.000", 24 * 3600);
+}
+
+} // anonymous namespace

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -220,7 +220,7 @@ QString TrackInfoObject::getDurationText() const {
     int iDuration = m_iDuration;
     lock.unlock();
 
-    return Time::formatSeconds(iDuration, false);
+    return Time::formatSeconds(iDuration);
 }
 
 QString TrackInfoObject::getLocation() const {

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -1,5 +1,7 @@
 #include "util/time.h"
 
+#include "util/assert.h"
+
 // static
 LLTIMER Time::s_timer;
 // static
@@ -8,7 +10,7 @@ bool Time::s_testMode = false;
 qint64 Time::s_testElapsed_nsecs = 0;
 
 // static
-QString Time::formatSeconds(double dSeconds, bool showCentis) {
+QString Time::formatSeconds(double dSeconds, Precision precision) {
     if (dSeconds < 0) {
         return "?";
     }
@@ -24,13 +26,14 @@ QString Time::formatSeconds(double dSeconds, bool showCentis) {
             (days > 0 ? (QString::number(days) %
                          QLatin1String("'d', ")) : QString()) %
             QLatin1String(days > 0 || t.hour() > 0 ? "hh:mm:ss" : "mm:ss") %
-            QLatin1String(showCentis ? ".zzz" : "");
+            QLatin1String(Precision::SECONDS == precision ? "" : ".zzz");
 
     QString timeString = t.toString(formatString);
 
     // The format string gives us milliseconds but we want
     // centiseconds. Slice one character off.
-    if (showCentis) {
+    if (Precision::CENTISECONDS == precision) {
+        DEBUG_ASSERT(1 <= timeString.length());
         timeString = timeString.left(timeString.length() - 1);
     }
 

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -64,10 +64,17 @@ class Time {
         s_testElapsed_nsecs = elapsed * 1000000;
     }
 
-    // The standard way of formatting a time in seconds. Used for display of
-    // track duration, etc. showCentis indicates whether to include
-    // centisecond-precision or to round to the nearest second.
-    static QString formatSeconds(double dSeconds, bool showCentis);
+    enum class Precision {
+        SECONDS,
+        CENTISECONDS,
+        MILLISECONDS
+    };
+
+    // The standard way of formatting a time in seconds. Used for display
+    // of track duration, etc.
+    static QString formatSeconds(
+            double dSeconds,
+            Precision precision = Time::Precision::SECONDS);
 
   private:
     static LLTIMER s_timer;

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -92,10 +92,10 @@ void WNumberPos::slotSetValue(double dValue) {
     QString valueString;
     if (valueMillis >= 0) {
         valueString = m_skinText % Time::formatSeconds(
-                valueMillis / Time::kMillisPerSecond, true);
+                valueMillis / Time::kMillisPerSecond, Time::Precision::MILLISECONDS);
     } else {
         valueString = m_skinText % QLatin1String("-") % Time::formatSeconds(
-                -valueMillis / Time::kMillisPerSecond, true);
+                -valueMillis / Time::kMillisPerSecond, Time::Precision::CENTISECONDS);
     }
     setText(valueString);
 }


### PR DESCRIPTION
Fix formatting of time durations with consistent precision handling.

Handling of the decimal point according to the current locale is still open. I would leave this to someone else. But now we have at least a consistent algorithm with tests ;)
