### PR TITLE
Move mic/aux creation out of MixxxMainWindow.

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -938,9 +938,11 @@ class MixxxCore(Feature):
                    "track/trackmetadatataglib.cpp",
                    "track/audiotagger.cpp",
 
+                   "mixer/auxiliary.cpp",
                    "mixer/baseplayer.cpp",
                    "mixer/basetrackplayer.cpp",
                    "mixer/deck.cpp",
+                   "mixer/microphone.cpp",
                    "mixer/playerinfo.cpp",
                    "mixer/playermanager.cpp",
                    "mixer/previewdeck.cpp",

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -529,10 +529,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                 ConfigKey("[Master]", "num_microphones"));
             for (int iMicrophoneNumber = 1; iMicrophoneNumber <= iNumMicrophones;
                  ++iMicrophoneNumber) {
-                QString micGroup = "[Microphone]";
-                if (iMicrophoneNumber > 1) {
-                    micGroup = QString("[Microphone%1]").arg(iMicrophoneNumber);
-                }
+                QString micGroup = PlayerManager::groupForMicrophone(iMicrophoneNumber - 1);
                 // TODO(owen): Fix bad i18n here.
                 addPrefixedControl(effectUnitGroup,
                                    QString("group_%1_enable").arg(micGroup),
@@ -546,7 +543,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                     ConfigKey("[Master]", "num_auxiliaries"));
             for (int iAuxiliaryNumber = 1; iAuxiliaryNumber <= iNumAuxiliaries;
                  ++iAuxiliaryNumber) {
-                QString auxGroup = QString("[Auxiliary%1]").arg(iAuxiliaryNumber);
+                QString auxGroup = PlayerManager::groupForAuxiliary(iAuxiliaryNumber - 1);
                 // TODO(owen): Fix bad i18n here.
                 addPrefixedControl(effectUnitGroup,
                                    QString("group_%1_enable").arg(auxGroup),
@@ -886,7 +883,7 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
                                                    QString controlTitle,
                                                    QString controlDescription,
                                                    QMenu* pMenu,
-                                                   bool microhoneControls,
+                                                   bool microphoneControls,
                                                    bool auxControls,
                                                    bool addReset) {
     QMenu* controlMenu = new QMenu(controlTitle, pMenu);
@@ -900,14 +897,10 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
         pMenu->addMenu(resetControlMenu);
     }
 
-    if (microhoneControls) {
+    if (microphoneControls) {
         const int kNumMicrophones = ControlObject::get(ConfigKey("[Master]", "num_microphones"));
         for (int i = 1; i <= kNumMicrophones; ++i) {
-            QString group = "[Microphone]";
-            if (i > 1) {
-                group = QString("[Microphone%1]").arg(i);
-            }
-
+            QString group = PlayerManager::groupForMicrophone(i - 1);
             QString title = QString("%1: %2").arg(
                 m_microphoneStr.arg(QString::number(i)), controlTitle);
             QString description = QString("%1: %2").arg(
@@ -931,7 +924,7 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
     const int kNumAuxiliaries = ControlObject::get(ConfigKey("[Master]", "num_auxiliaries"));
     if (auxControls) {
         for (int i = 1; i <= kNumAuxiliaries; ++i) {
-            QString group = QString("[Auxiliary%1]").arg(i);
+            QString group = PlayerManager::groupForAuxiliary(i - 1);
             QString title = QString("%1: %2").arg(
                 m_auxStr.arg(QString::number(i)), controlTitle);
             QString description = QString("%1: %2").arg(

--- a/src/controllers/controlpickermenu.h
+++ b/src/controllers/controlpickermenu.h
@@ -53,7 +53,7 @@ class ControlPickerMenu : public QMenu {
                                QMenu* pMenu, bool addReset=false);
     void addMicrophoneAndAuxControl(QString control, QString title,
                                     QString helpText, QMenu* pMenu,
-                                    bool microhoneControls, bool auxControls,
+                                    bool microphoneControls, bool auxControls,
                                     bool addReset=false);
     void addPrefixedControl(QString group, QString control, QString title,
                             QString menuDescription, QString descriptionPrefix,

--- a/src/mixer/auxiliary.cpp
+++ b/src/mixer/auxiliary.cpp
@@ -1,0 +1,20 @@
+#include "mixer/auxiliary.h"
+
+#include "engine/engineaux.h"
+#include "engine/enginemaster.h"
+#include "soundio/soundmanager.h"
+#include "soundio/soundmanagerutil.h"
+
+Auxiliary::Auxiliary(QObject* pParent, const QString& group, int index,
+                     SoundManager* pSoundManager, EngineMaster* pEngine,
+                     EffectsManager* pEffectsManager)
+        : BasePlayer(pParent, group) {
+    ChannelHandleAndGroup channelGroup = pEngine->registerChannelGroup(group);
+    EngineAux* pAuxiliary = new EngineAux(channelGroup, pEffectsManager);
+    pEngine->addChannel(pAuxiliary);
+    AudioInput auxInput = AudioInput(AudioPath::AUXILIARY, 0, 0, index);
+    pSoundManager->registerInput(auxInput, pAuxiliary);
+}
+
+Auxiliary::~Auxiliary() {
+}

--- a/src/mixer/auxiliary.h
+++ b/src/mixer/auxiliary.h
@@ -1,0 +1,25 @@
+#ifndef MIXER_AUXILIARY_H
+#define MIXER_AUXILIARY_H
+
+#include <QObject>
+#include <QString>
+
+#include "mixer/baseplayer.h"
+
+class EffectsManager;
+class EngineMaster;
+class SoundManager;
+
+class Auxiliary : public BasePlayer {
+    Q_OBJECT
+  public:
+    Auxiliary(QObject* pParent,
+              const QString& group,
+              int index,
+              SoundManager* pSoundManager,
+              EngineMaster* pMixingEngine,
+              EffectsManager* pEffectsManager);
+    virtual ~Auxiliary();
+};
+
+#endif /* MIXER_AUXILIARY_H */

--- a/src/mixer/microphone.cpp
+++ b/src/mixer/microphone.cpp
@@ -1,0 +1,21 @@
+#include "mixer/microphone.h"
+
+#include "engine/enginemaster.h"
+#include "engine/enginemicrophone.h"
+#include "soundio/soundmanager.h"
+#include "soundio/soundmanagerutil.h"
+
+Microphone::Microphone(QObject* pParent, const QString& group, int index,
+                       SoundManager* pSoundManager, EngineMaster* pEngine,
+                       EffectsManager* pEffectsManager)
+        : BasePlayer(pParent, group) {
+    ChannelHandleAndGroup channelGroup = pEngine->registerChannelGroup(group);
+    EngineMicrophone* pMicrophone =
+            new EngineMicrophone(channelGroup, pEffectsManager);
+    pEngine->addChannel(pMicrophone);
+    AudioInput micInput = AudioInput(AudioPath::MICROPHONE, 0, 0, index);
+    pSoundManager->registerInput(micInput, pMicrophone);
+}
+
+Microphone::~Microphone() {
+}

--- a/src/mixer/microphone.h
+++ b/src/mixer/microphone.h
@@ -1,0 +1,26 @@
+#ifndef MIXER_MICROPHONE_H
+#define MIXER_MICROPHONE_H
+
+#include <QObject>
+#include <QString>
+
+#include "mixer/baseplayer.h"
+
+class EffectsManager;
+class EngineMaster;
+class SoundManager;
+
+class Microphone : public BasePlayer {
+    Q_OBJECT
+  public:
+    Microphone(QObject* pParent,
+               const QString& group,
+               int index,
+               SoundManager* pSoundManager,
+               EngineMaster* pMixingEngine,
+               EffectsManager* pEffectsManager);
+    virtual ~Microphone();
+
+};
+
+#endif /* MIXER_MICROPHONE_H */

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -12,7 +12,9 @@
 #include "engine/enginemaster.h"
 #include "library/library.h"
 #include "library/trackcollection.h"
+#include "mixer/auxiliary.h"
 #include "mixer/deck.h"
+#include "mixer/microphone.h"
 #include "mixer/previewdeck.h"
 #include "mixer/sampler.h"
 #include "mixer/samplerbank.h"
@@ -33,10 +35,16 @@ PlayerManager::PlayerManager(ConfigObject<ConfigValue>* pConfig,
         // NOTE(XXX) LegacySkinParser relies on these controls being COs and
         // not COTMs listening to a CO.
         m_pAnalyzerQueue(NULL),
-        m_pCONumDecks(new ControlObject(ConfigKey("[Master]", "num_decks"), true, true)),
-        m_pCONumSamplers(new ControlObject(ConfigKey("[Master]", "num_samplers"), true, true)),
-        m_pCONumPreviewDecks(new ControlObject(ConfigKey("[Master]", "num_preview_decks"), true, true)) {
-
+        m_pCONumDecks(new ControlObject(
+            ConfigKey("[Master]", "num_decks"), true, true)),
+        m_pCONumSamplers(new ControlObject(
+            ConfigKey("[Master]", "num_samplers"), true, true)),
+        m_pCONumPreviewDecks(new ControlObject(
+            ConfigKey("[Master]", "num_preview_decks"), true, true)),
+        m_pCONumMicrophones(new ControlObject(
+            ConfigKey("[Master]", "num_microphones"), true, true)),
+        m_pCONumAuxiliaries(new ControlObject(
+            ConfigKey("[Master]", "num_auxiliaries"), true, true)){
     connect(m_pCONumDecks, SIGNAL(valueChanged(double)),
             this, SLOT(slotNumDecksControlChanged(double)),
             Qt::DirectConnection);
@@ -55,15 +63,22 @@ PlayerManager::PlayerManager(ConfigObject<ConfigValue>* pConfig,
     connect(m_pCONumPreviewDecks, SIGNAL(valueChangedFromEngine(double)),
             this, SLOT(slotNumPreviewDecksControlChanged(double)),
             Qt::DirectConnection);
+    connect(m_pCONumMicrophones, SIGNAL(valueChanged(double)),
+            this, SLOT(slotNumMicrophonesControlChanged(double)),
+            Qt::DirectConnection);
+    connect(m_pCONumMicrophones, SIGNAL(valueChangedFromEngine(double)),
+            this, SLOT(slotNumMicrophonesControlChanged(double)),
+            Qt::DirectConnection);
+    connect(m_pCONumAuxiliaries, SIGNAL(valueChanged(double)),
+            this, SLOT(slotNumAuxiliariesControlChanged(double)),
+            Qt::DirectConnection);
+    connect(m_pCONumAuxiliaries, SIGNAL(valueChangedFromEngine(double)),
+            this, SLOT(slotNumAuxiliariesControlChanged(double)),
+            Qt::DirectConnection);
 
     // This is parented to the PlayerManager so does not need to be deleted
     SamplerBank* pSamplerBank = new SamplerBank(this);
     Q_UNUSED(pSamplerBank);
-
-    // Redundant
-    m_pCONumDecks->set(0);
-    m_pCONumSamplers->set(0);
-    m_pCONumPreviewDecks->set(0);
 
     // register the engine's outputs
     m_pSoundManager->registerOutput(AudioOutput(AudioOutput::MASTER),
@@ -85,10 +100,14 @@ PlayerManager::~PlayerManager() {
     m_players.clear();
     m_decks.clear();
     m_samplers.clear();
+    m_microphones.clear();
+    m_auxiliaries.clear();
 
     delete m_pCONumSamplers;
     delete m_pCONumDecks;
     delete m_pCONumPreviewDecks;
+    delete m_pCONumMicrophones;
+    delete m_pCONumAuxiliaries;
     if (m_pAnalyzerQueue) {
         delete m_pAnalyzerQueue;
     }
@@ -258,6 +277,36 @@ void PlayerManager::slotNumPreviewDecksControlChanged(double v) {
     }
 }
 
+void PlayerManager::slotNumMicrophonesControlChanged(double v) {
+    QMutexLocker locker(&m_mutex);
+    int num = (int)v;
+    if (num < m_microphones.size()) {
+        // The request was invalid -- reset the value.
+        m_pCONumMicrophones->set(m_microphones.size());
+        qDebug() << "Ignoring request to reduce the number of microphones to" << num;
+        return;
+    }
+
+    while (m_microphones.size() < num) {
+        addMicrophoneInner();
+    }
+}
+
+void PlayerManager::slotNumAuxiliariesControlChanged(double v) {
+    QMutexLocker locker(&m_mutex);
+    int num = (int)v;
+    if (num < m_auxiliaries.size()) {
+        // The request was invalid -- reset the value.
+        m_pCONumAuxiliaries->set(m_auxiliaries.size());
+        qDebug() << "Ignoring request to reduce the number of auxiliaries to" << num;
+        return;
+    }
+
+    while (m_auxiliaries.size() < num) {
+        addAuxiliaryInner();
+    }
+}
+
 void PlayerManager::addDeck() {
     QMutexLocker locker(&m_mutex);
     addDeckInner();
@@ -379,6 +428,37 @@ void PlayerManager::addPreviewDeckInner() {
     m_preview_decks.append(pPreviewDeck);
 }
 
+void PlayerManager::addMicrophone() {
+    QMutexLocker locker(&m_mutex);
+    addMicrophoneInner();
+    m_pCONumMicrophones->set(m_microphones.count());
+}
+
+void PlayerManager::addMicrophoneInner() {
+    // Do not lock m_mutex here.
+    int index = m_microphones.count();
+    QString group = groupForMicrophone(index);
+    Microphone* pMicrophone = new Microphone(this, group, index, m_pSoundManager,
+                                             m_pEngine, m_pEffectsManager);
+    m_microphones.append(pMicrophone);
+}
+
+void PlayerManager::addAuxiliary() {
+    QMutexLocker locker(&m_mutex);
+    addAuxiliaryInner();
+    m_pCONumAuxiliaries->set(m_auxiliaries.count());
+}
+
+void PlayerManager::addAuxiliaryInner() {
+    // Do not lock m_mutex here.
+    int index = m_auxiliaries.count();
+    QString group = groupForAuxiliary(index);
+
+    Auxiliary* pAuxiliary = new Auxiliary(this, group, index, m_pSoundManager,
+                                          m_pEngine, m_pEffectsManager);
+    m_auxiliaries.append(pAuxiliary);
+}
+
 BaseTrackPlayer* PlayerManager::getPlayer(QString group) const {
     QMutexLocker locker(&m_mutex);
     if (m_players.contains(group)) {
@@ -415,6 +495,26 @@ Sampler* PlayerManager::getSampler(unsigned int sampler) const {
         return NULL;
     }
     return m_samplers[sampler - 1];
+}
+
+Microphone* PlayerManager::getMicrophone(unsigned int microphone) const {
+    QMutexLocker locker(&m_mutex);
+    if (microphone < 1 || microphone >= static_cast<unsigned int>(m_microphones.size())) {
+        qWarning() << "Warning PlayerManager::getMicrophone() called with invalid index: "
+                   << microphone;
+        return NULL;
+    }
+    return m_microphones[microphone - 1];
+}
+
+Auxiliary* PlayerManager::getAuxiliary(unsigned int auxiliary) const {
+    QMutexLocker locker(&m_mutex);
+    if (auxiliary < 1 || auxiliary > static_cast<unsigned int>(m_auxiliaries.size())) {
+        qWarning() << "Warning PlayerManager::getAuxiliary() called with invalid index: "
+                   << auxiliary;
+        return NULL;
+    }
+    return m_auxiliaries[auxiliary - 1];
 }
 
 bool PlayerManager::hasVinylInput(int inputnum) const {

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -12,17 +12,18 @@
 #include "configobject.h"
 #include "trackinfoobject.h"
 
+class AnalyzerQueue;
+class Auxiliary;
+class BaseTrackPlayer;
 class ControlObject;
 class Deck;
-class Sampler;
-class PreviewDeck;
-class BaseTrackPlayer;
-
-class Library;
-class EngineMaster;
-class AnalyzerQueue;
-class SoundManager;
 class EffectsManager;
+class EngineMaster;
+class Library;
+class Microphone;
+class PreviewDeck;
+class Sampler;
+class SoundManager;
 class TrackCollection;
 
 // For mocking PlayerManager.
@@ -72,6 +73,12 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     // Add a PreviewDeck to the PlayerManager
     void addPreviewDeck();
 
+    // Add a microphone to the PlayerManager
+    void addMicrophone();
+
+    // Add an auxiliary input to the PlayerManager
+    void addAuxiliary();
+
     // Return the number of players. Thread-safe.
     static unsigned int numDecks();
 
@@ -101,7 +108,8 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
         return numPreviewDecks();
     }
 
-    // Get a BaseTrackPlayer (i.e. a Deck or a Sampler) by its group
+    // Get a BaseTrackPlayer (i.e. a Deck, Sampler or PreviewDeck) by its
+    // group. Auxiliaries and microphones are not players.
     BaseTrackPlayer* getPlayer(QString group) const;
 
     // Get the deck by its deck number. Decks are numbered starting with 1.
@@ -111,6 +119,12 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
 
     // Get the sampler by its number. Samplers are numbered starting with 1.
     Sampler* getSampler(unsigned int sampler) const;
+
+    // Get the microphone by its number. Microphones are numbered starting with 1.
+    Microphone* getMicrophone(unsigned int microphone) const;
+
+    // Get the auxiliary by its number. Auxiliaries are numbered starting with 1.
+    Auxiliary* getAuxiliary(unsigned int auxiliary) const;
 
     // Binds signals between PlayerManager and Library. Does not store a pointer
     // to the Library.
@@ -129,6 +143,23 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     // Returns the group for the ith PreviewDeck where i is zero indexed
     static QString groupForPreviewDeck(int i) {
         return QString("[PreviewDeck%1]").arg(i+1);
+    }
+
+    // Returns the group for the ith Microphone where i is zero indexed
+    static QString groupForMicrophone(int i) {
+        // Before Mixxx had multiple microphone support the first microphone had
+        // the group [Microphone]. For backwards compatibility we keep it that
+        // way.
+        QString group("[Microphone]");
+        if (i > 0) {
+            group = QString("[Microphone%1]").arg(i + 1);
+        }
+        return group;
+    }
+
+    // Returns the group for the ith Auxiliary where i is zero indexed
+    static QString groupForAuxiliary(int i) {
+        return QString("[Auxiliary%1]").arg(i + 1);
     }
 
     // Used to determine if the user has configured an input for the given vinyl deck.
@@ -154,6 +185,8 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     void slotNumDecksControlChanged(double v);
     void slotNumSamplersControlChanged(double v);
     void slotNumPreviewDecksControlChanged(double v);
+    void slotNumMicrophonesControlChanged(double v);
+    void slotNumAuxiliariesControlChanged(double v);
 
   signals:
     void loadLocationToPlayer(QString location, QString group);
@@ -169,6 +202,12 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     // Must hold m_mutex before calling this method. Internal method that
     // creates a new preview deck.
     void addPreviewDeckInner();
+    // Must hold m_mutex before calling this method. Internal method that
+    // creates a new microphone.
+    void addMicrophoneInner();
+    // Must hold m_mutex before calling this method. Internal method that
+    // creates a new auxiliary.
+    void addAuxiliaryInner();
 
     // Used to protect access to PlayerManager state across threads.
     mutable QMutex m_mutex;
@@ -181,10 +220,14 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     ControlObject* m_pCONumDecks;
     ControlObject* m_pCONumSamplers;
     ControlObject* m_pCONumPreviewDecks;
+    ControlObject* m_pCONumMicrophones;
+    ControlObject* m_pCONumAuxiliaries;
 
     QList<Deck*> m_decks;
     QList<Sampler*> m_samplers;
     QList<PreviewDeck*> m_preview_decks;
+    QList<Microphone*> m_microphones;
+    QList<Auxiliary*> m_auxiliaries;
     QMap<QString, BaseTrackPlayer*> m_players;
 };
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1398,10 +1398,7 @@ void MixxxMainWindow::initActions() {
     connect(m_TalkoverMapper, SIGNAL(mapped(int)),
             this, SLOT(slotTalkoverChanged(int)));
     for (int i = 0; i < kMicrophoneCount; ++i) {
-        QString group("[Microphone]");
-        if (i > 0) {
-            group = QString("[Microphone%1]").arg(i + 1);
-        }
+        QString group = PlayerManager::groupForMicrophone(i);
         ControlObjectSlave* talkover_button = new ControlObjectSlave(
                 group, "talkover");
         m_TalkoverMapper->setMapping(talkover_button, i);

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -28,7 +28,6 @@
 #include "analyzer/analyzerqueue.h"
 #include "controlpotmeter.h"
 #include "controlobjectslave.h"
-#include "mixer/deck.h"
 #include "defs_urls.h"
 #include "dlgabout.h"
 #include "dlgpreferences.h"
@@ -53,7 +52,6 @@
 #include "skin/legacyskinparser.h"
 #include "skin/skinloader.h"
 #include "soundio/soundmanager.h"
-#include "soundio/soundmanagerutil.h"
 #include "soundsourceproxy.h"
 #include "trackinfoobject.h"
 #include "waveform/waveformwidgetfactory.h"
@@ -213,30 +211,6 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
 #endif
 
     launchProgress(11);
-    // TODO(rryan): Fold microphone and aux creation into a manager
-    // (e.g. PlayerManager, though they aren't players).
-
-    ControlObject* pNumMicrophones = new ControlObject(ConfigKey("[Master]", "num_microphones"));
-    pNumMicrophones->setParent(this);
-
-    for (int i = 0; i < kMicrophoneCount; ++i) {
-        QString group("[Microphone]");
-        if (i > 0) {
-            group = QString("[Microphone%1]").arg(i + 1);
-        }
-        ChannelHandleAndGroup channelGroup =
-                m_pEngine->registerChannelGroup(group);
-        EngineMicrophone* pMicrophone =
-                new EngineMicrophone(channelGroup, m_pEffectsManager);
-
-        // What should channelbase be?
-        AudioInput micInput = AudioInput(AudioPath::MICROPHONE, 0, 0, i);
-        m_pEngine->addChannel(pMicrophone);
-        m_pSoundManager->registerInput(micInput, pMicrophone);
-        pNumMicrophones->set(pNumMicrophones->get() + 1);
-    }
-
-    m_pNumAuxiliaries = new ControlObject(ConfigKey("[Master]", "num_auxiliaries"));
 
     m_PassthroughMapper = new QSignalMapper(this);
     connect(m_PassthroughMapper, SIGNAL(mapped(int)),
@@ -245,29 +219,6 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
     m_AuxiliaryMapper = new QSignalMapper(this);
     connect(m_AuxiliaryMapper, SIGNAL(mapped(int)),
             this, SLOT(slotControlAuxiliary(int)));
-
-    for (int i = 0; i < kAuxiliaryCount; ++i) {
-        QString group = QString("[Auxiliary%1]").arg(i + 1);
-        ChannelHandleAndGroup channelGroup = m_pEngine->registerChannelGroup(group);
-        EngineAux* pAux = new EngineAux(channelGroup, m_pEffectsManager);
-
-        // What should channelbase be?
-        AudioInput auxInput = AudioInput(AudioPath::AUXILIARY, 0, 0, i);
-        m_pEngine->addChannel(pAux);
-        m_pSoundManager->registerInput(auxInput, pAux);
-        m_pNumAuxiliaries->set(m_pNumAuxiliaries->get() + 1);
-
-        m_pAuxiliaryPassthrough.push_back(
-                new ControlObjectSlave(group, "passthrough"));
-        ControlObjectSlave* auxiliary_passthrough =
-                m_pAuxiliaryPassthrough.back();
-
-        // These non-vinyl passthrough COs have their index offset by the max
-        // number of vinyl inputs.
-        m_AuxiliaryMapper->setMapping(auxiliary_passthrough, i);
-        auxiliary_passthrough->connectValueChanged(m_AuxiliaryMapper,
-                                                   SLOT(map()));
-    }
 
     m_pGuiTick = new GuiTick();
 
@@ -280,6 +231,25 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
     // Create the player manager. (long)
     m_pPlayerManager = new PlayerManager(pConfig.data(), m_pSoundManager,
                                          m_pEffectsManager, m_pEngine);
+    for (int i = 0; i < kMicrophoneCount; ++i) {
+        m_pPlayerManager->addMicrophone();
+    }
+
+    for (int i = 0; i < kAuxiliaryCount; ++i) {
+        m_pPlayerManager->addAuxiliary();
+        QString group = PlayerManager::groupForAuxiliary(i);
+        m_pAuxiliaryPassthrough.push_back(
+                new ControlObjectSlave(group, "passthrough"));
+        ControlObjectSlave* auxiliary_passthrough =
+                m_pAuxiliaryPassthrough.back();
+
+        // These non-vinyl passthrough COs have their index offset by the max
+        // number of vinyl inputs.
+        m_AuxiliaryMapper->setMapping(auxiliary_passthrough, i);
+        auxiliary_passthrough->connectValueChanged(m_AuxiliaryMapper,
+                                                   SLOT(map()));
+    }
+
     m_pPlayerManager->addConfiguredDecks();
     m_pPlayerManager->addSampler();
     m_pPlayerManager->addSampler();
@@ -593,7 +563,6 @@ void MixxxMainWindow::finalize() {
     delete m_pShowPreviewDeck;
     delete m_pShowEffects;
     delete m_pShowCoverArt;
-    delete m_pNumAuxiliaries;
     delete m_pNumDecks;
 
     // Check for leaked ControlObjects and give warnings.


### PR DESCRIPTION
Adds PlayerManager-managed classes to represent microphones and
auxiliary inputs.

Fixes a long-term TODO of mine :). Hopefully I didn't break anything.
