### PR TITLE
Provide Mixxx version to MusicBrainz to don't be considered as anonymous

### DIFF
--- a/src/musicbrainz/acoustidclient.cpp
+++ b/src/musicbrainz/acoustidclient.cpp
@@ -21,7 +21,6 @@
 // see API-KEY site here http://acoustid.org/application/496
 // I registered the KEY for version 1.12 -- kain88 (may 2013)
 const QString CLIENT_APIKEY = "czKxnkyO";
-const QString CLIENT_NAME = "Mixxx1.12";
 const QString ACOUSTID_URL = "http://api.acoustid.org/v2/lookup";
 const int AcoustidClient::m_DefaultTimeout = 5000; // msec
 
@@ -47,7 +46,6 @@ void AcoustidClient::start(int id, const QString& fingerprint, int duration) {
     QNetworkRequest req(QUrl::fromEncoded(ACOUSTID_URL.toAscii()));
     req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
     req.setRawHeader("Content-Encoding", "gzip");
-    req.setRawHeader("User-Agent", CLIENT_NAME.toAscii());
 
     qDebug() << "AcoustIdClient POST request:" << ACOUSTID_URL
              << "body:" << body;

--- a/src/musicbrainz/musicbrainzclient.cpp
+++ b/src/musicbrainz/musicbrainzclient.cpp
@@ -16,6 +16,8 @@
 #include <QUrl>
 
 #include "musicbrainz/musicbrainzclient.h"
+#include "util/version.h"
+#include "defs_urls.h"
 
 const QString MusicBrainzClient::m_TrackUrl = "http://musicbrainz.org/ws/2/recording/";
 const QString MusicBrainzClient::m_DateRegex = "^[12]\\d{3}";
@@ -37,6 +39,9 @@ void MusicBrainzClient::start(int id, const QString& mbid) {
     url.setQueryItems(parameters);
     qDebug() << "MusicBrainzClient GET request:" << url.toString();
     QNetworkRequest req(url);
+    // http://musicbrainz.org/doc/XML_Web_Service/Rate_Limiting#Provide_meaningful_User-Agent_strings
+    QString mixxxMusicBrainzId(Version::applicationName() + "/" + Version::version() + " ( " + MIXXX_WEBSITE_URL + " )");
+    req.setRawHeader("User-Agent", mixxxMusicBrainzId.toAscii());
     QNetworkReply* reply = m_network.get(req);
     connect(reply, SIGNAL(finished()), SLOT(requestFinished()));
     m_requests[reply] = id;


### PR DESCRIPTION
When I opened this bug https://bugs.launchpad.net/mixxx/+bug/1510550 I tried a bit to resolve it (before @rryan fixed it) and, reading the doc of Musicbrainz I found this : 
http://musicbrainz.org/doc/XML_Web_Service/Rate_Limiting#Provide_meaningful_User-Agent_strings

This PR simply provides the version of Mixxx to Musicbrainz to fit to their best practices.
