### PR TITLE
Establish dependency from SoundSourceProxy to TrackInfoObject

### DIFF
--- a/src/dlgtrackinfo.cpp
+++ b/src/dlgtrackinfo.cpp
@@ -3,6 +3,7 @@
 
 #include "dlgtrackinfo.h"
 #include "trackinfoobject.h"
+#include "soundsourceproxy.h"
 #include "library/coverartcache.h"
 #include "library/coverartutils.h"
 
@@ -478,6 +479,7 @@ void DlgTrackInfo::reloadTrackMetadata() {
     if (m_pLoadedTrack) {
         TrackPointer pTrack(new TrackInfoObject(m_pLoadedTrack->getLocation(),
                                                 m_pLoadedTrack->getSecurityToken()));
+        SoundSourceProxy(pTrack).loadTrackMetadata();
         populateFields(pTrack);
     }
 }

--- a/src/dlgtrackinfo.cpp
+++ b/src/dlgtrackinfo.cpp
@@ -477,6 +477,10 @@ void DlgTrackInfo::slotBpmTap(double averageLength, int numSamples) {
 
 void DlgTrackInfo::reloadTrackMetadata() {
     if (m_pLoadedTrack) {
+        // Allocate a temporary track object for reading the metadata.
+        // We cannot reuse m_pLoadedTrack, because it might already been
+        // modified and we want to read fresh metadata directly from the
+        // file. Otherwise the changes in m_pLoadedTrack would be lost.
         TrackPointer pTrack(new TrackInfoObject(m_pLoadedTrack->getLocation(),
                                                 m_pLoadedTrack->getSecurityToken()));
         SoundSourceProxy(pTrack).loadTrackMetadata();

--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -147,114 +147,116 @@ void BrowseThread::populateModel() {
         }
 
         QString filepath = fileIt.next();
-        TrackInfoObject tio(filepath, thisPath.token());
+        TrackPointer pTrack(new TrackInfoObject(filepath, thisPath.token()));
+        SoundSourceProxy(pTrack).loadTrackMetadata();
+
         QList<QStandardItem*> row_data;
 
         QStandardItem* item = new QStandardItem("0");
         item->setData("0", Qt::UserRole);
         row_data.insert(COLUMN_PREVIEW, item);
 
-        item = new QStandardItem(tio.getFileName());
+        item = new QStandardItem(pTrack->getFileName());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_FILENAME, item);
 
-        item = new QStandardItem(tio.getArtist());
+        item = new QStandardItem(pTrack->getArtist());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_ARTIST, item);
 
-        item = new QStandardItem(tio.getTitle());
+        item = new QStandardItem(pTrack->getTitle());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_TITLE, item);
 
-        item = new QStandardItem(tio.getAlbum());
+        item = new QStandardItem(pTrack->getAlbum());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_ALBUM, item);
 
-        item = new QStandardItem(tio.getAlbumArtist());
+        item = new QStandardItem(pTrack->getAlbumArtist());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_ALBUMARTIST, item);
 
-        item = new QStandardItem(tio.getTrackNumber());
+        item = new QStandardItem(pTrack->getTrackNumber());
         item->setToolTip(item->text());
         item->setData(item->text().toInt(), Qt::UserRole);
         row_data.insert(COLUMN_TRACK_NUMBER, item);
 
-        const QString year(tio.getYear());
+        const QString year(pTrack->getYear());
         item = new YearItem(year);
         item->setToolTip(year);
         // The year column is sorted according to the numeric calendar year
         item->setData(Mixxx::TrackMetadata::parseCalendarYear(year), Qt::UserRole);
         row_data.insert(COLUMN_YEAR, item);
 
-        item = new QStandardItem(tio.getGenre());
+        item = new QStandardItem(pTrack->getGenre());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_GENRE, item);
 
-        item = new QStandardItem(tio.getComposer());
+        item = new QStandardItem(pTrack->getComposer());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_COMPOSER, item);
 
-        item = new QStandardItem(tio.getGrouping());
+        item = new QStandardItem(pTrack->getGrouping());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_GROUPING, item);
 
-        item = new QStandardItem(tio.getComment());
+        item = new QStandardItem(pTrack->getComment());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_COMMENT, item);
 
-        QString duration = Time::formatSeconds(tio.getDuration());
+        QString duration = Time::formatSeconds(pTrack->getDuration());
         item = new QStandardItem(duration);
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_DURATION, item);
 
-        item = new QStandardItem(tio.getBpmText());
+        item = new QStandardItem(pTrack->getBpmText());
         item->setToolTip(item->text());
-        item->setData(tio.getBpm(), Qt::UserRole);
+        item->setData(pTrack->getBpm(), Qt::UserRole);
         row_data.insert(COLUMN_BPM, item);
 
-        item = new QStandardItem(tio.getKeyText());
+        item = new QStandardItem(pTrack->getKeyText());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_KEY, item);
 
-        item = new QStandardItem(tio.getType());
+        item = new QStandardItem(pTrack->getType());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_TYPE, item);
 
-        item = new QStandardItem(tio.getBitrateText());
+        item = new QStandardItem(pTrack->getBitrateText());
         item->setToolTip(item->text());
-        item->setData(tio.getBitrate(), Qt::UserRole);
+        item->setData(pTrack->getBitrate(), Qt::UserRole);
         row_data.insert(COLUMN_BITRATE, item);
 
-        item = new QStandardItem(tio.getLocation());
+        item = new QStandardItem(pTrack->getLocation());
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_LOCATION, item);
 
-        QDateTime modifiedTime = tio.getFileModifiedTime().toLocalTime();
+        QDateTime modifiedTime = pTrack->getFileModifiedTime().toLocalTime();
         item = new QStandardItem(modifiedTime.toString(Qt::DefaultLocaleShortDate));
         item->setToolTip(item->text());
         item->setData(modifiedTime, Qt::UserRole);
         row_data.insert(COLUMN_FILE_MODIFIED_TIME, item);
 
-        QDateTime creationTime = tio.getFileCreationTime().toLocalTime();
+        QDateTime creationTime = pTrack->getFileCreationTime().toLocalTime();
         item = new QStandardItem(creationTime.toString(Qt::DefaultLocaleShortDate));
         item->setToolTip(item->text());
         item->setData(creationTime, Qt::UserRole);
         row_data.insert(COLUMN_FILE_CREATION_TIME, item);
 
-        const Mixxx::ReplayGain replayGain(tio.getReplayGain());
+        const Mixxx::ReplayGain replayGain(pTrack->getReplayGain());
         item = new QStandardItem(
                 Mixxx::ReplayGain::ratioToString(replayGain.getRatio()));
         item->setToolTip(item->text());

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -30,13 +30,7 @@ QImage CoverArtUtils::extractEmbeddedCover(
         const QString& trackLocation,
         SecurityTokenPointer pToken) {
     TrackPointer pTrack(new TrackInfoObject(trackLocation, pToken));
-    SoundSourceProxy proxy(pTrack);
-    QImage coverArt;
-    if (OK == proxy.parseTrackMetadataAndCoverArt(nullptr, &coverArt)) {
-        return coverArt;
-    } else {
-        return QImage();
-    }
+    return SoundSourceProxy(pTrack).parseCoverImage();
 }
 
 //static

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -29,7 +29,8 @@ QString CoverArtUtils::supportedCoverArtExtensionsRegex() {
 QImage CoverArtUtils::extractEmbeddedCover(
         const QString& trackLocation,
         SecurityTokenPointer pToken) {
-    SoundSourceProxy proxy(trackLocation, pToken);
+    TrackPointer pTrack(new TrackInfoObject(trackLocation, pToken));
+    SoundSourceProxy proxy(pTrack);
     QImage coverArt;
     if (OK == proxy.parseTrackMetadataAndCoverArt(nullptr, &coverArt)) {
         return coverArt;

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -27,9 +27,11 @@ QString CoverArtUtils::supportedCoverArtExtensionsRegex() {
 
 //static
 QImage CoverArtUtils::extractEmbeddedCover(
-        const QString& trackLocation,
+        const QFileInfo& fileInfo,
         SecurityTokenPointer pToken) {
-    TrackPointer pTrack(new TrackInfoObject(trackLocation, pToken));
+    // TODO(uklotzde): Resolve the TrackPointer from the track cache
+    // to avoid accessing reading the file while it is written.
+    TrackPointer pTrack(new TrackInfoObject(fileInfo, pToken));
     return SoundSourceProxy(pTrack).parseCoverImage();
 }
 

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -16,10 +16,10 @@ class CoverArtUtils {
     static QString defaultCoverLocation();
 
     // Extracts the first cover art image embedded within the file at
-    // trackLocation. You must provide a security token for accessing
-    // trackLocation.
+    // fileInfo. You must provide a security token for accessing
+    // fileInfo.
     static QImage extractEmbeddedCover(
-            const QString& trackLocation,
+            const QFileInfo& fileInfo,
             SecurityTokenPointer pToken);
 
     static QImage loadCover(const CoverInfo& info);

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -648,15 +648,11 @@ bool TrackDAO::addTracksAdd(TrackInfoObject* pTrack, bool unremove) {
 }
 
 TrackId TrackDAO::addTrack(const QFileInfo& fileInfo, bool unremove) {
-    TrackId trackId;
-    TrackInfoObject * pTrack = new TrackInfoObject(fileInfo);
-    if (pTrack) {
-        // Add the song to the database.
-        addTrack(pTrack, unremove);
-        trackId = pTrack->getId();
-        delete pTrack;
-    }
-    return trackId;
+    TrackPointer pTrack(new TrackInfoObject(fileInfo));
+    SoundSourceProxy(pTrack).loadTrackMetadata();
+    // Add the song to the database.
+    addTrack(pTrack.data(), unremove);
+    return pTrack->getId();
 }
 
 void TrackDAO::addTrack(TrackInfoObject* pTrack, bool unremove) {
@@ -749,13 +745,13 @@ QList<TrackId> TrackDAO::addTracks(const QList<QFileInfo>& fileInfoList,
         int addIndex = query.value(addIndexColumn).toInt();
         QString filePath = query.value(locationColumn).toString();
         const QFileInfo& fileInfo = fileInfoList.at(addIndex);
-        TrackInfoObject* pTrack = new TrackInfoObject(fileInfo);
-        addTracksAdd(pTrack, unremove);
+        TrackPointer pTrack(new TrackInfoObject(fileInfo));
+        SoundSourceProxy(pTrack).loadTrackMetadata();
+        addTracksAdd(pTrack.data(), unremove);
         TrackId trackId = pTrack->getId();
         if (trackId.isValid()) {
             trackIds.append(trackId);
         }
-        delete pTrack;
     }
 
     // Now that we have imported any tracks that were not already in the
@@ -1288,9 +1284,8 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
     // Location is the first column.
     QString location = queryRecord.value(0).toString();
 
-    TrackPointer pTrack = TrackPointer(
-            new TrackInfoObject(location, SecurityTokenPointer(),
-                                false),
+    TrackPointer pTrack(
+            new TrackInfoObject(location),
             TrackInfoObject::onTrackReferenceExpired);
     pTrack->setId(trackId);
 
@@ -1382,9 +1377,7 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
     // If the header hasn't been parsed, parse it but only after we set the
     // track clean and hooked it up to the track cache, because this will
     // dirty it.
-    if (!pTrack->getHeaderParsed()) {
-         pTrack->parse(false);
-    }
+    SoundSourceProxy(pTrack).loadTrackMetadata();
 
     return pTrack;
 }
@@ -2101,8 +2094,8 @@ TrackPointer TrackDAO::getOrAddTrack(const QString& trackLocation,
     // TrackPointer. We explicitly do not process cover art while creating the
     // TrackInfoObject since we want to do it asynchronously (see below).
     if (pTrack.isNull()) {
-        pTrack = TrackPointer(new TrackInfoObject(
-                trackLocation, SecurityTokenPointer(), true, false));
+        pTrack = TrackPointer(new TrackInfoObject(trackLocation));
+        SoundSourceProxy(pTrack).loadTrackMetadata();
     }
 
     // If the track wasn't in the library already then it has not yet been

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1933,7 +1933,7 @@ bool TrackDAO::verifyRemainingTracks(
 namespace {
     QImage parseCoverArt(const QFileInfo& fileInfo) {
         SecurityTokenPointer pToken = Sandbox::openSecurityToken(fileInfo, true);
-        return CoverArtUtils::extractEmbeddedCover(fileInfo.filePath(), pToken);
+        return CoverArtUtils::extractEmbeddedCover(fileInfo, pToken);
     }
 }
 

--- a/src/library/scanner/importfilestask.cpp
+++ b/src/library/scanner/importfilestask.cpp
@@ -1,5 +1,6 @@
 #include "library/scanner/importfilestask.h"
 
+#include "soundsourceproxy.h"
 #include "library/scanner/libraryscanner.h"
 #include "library/coverartutils.h"
 #include "util/timer.h"
@@ -48,11 +49,16 @@ void ImportFilesTask::run() {
             // without checking if we have cover art that is USER_SELECTED. If
             // this changes in the future you MUST check that the cover art is
             // not USER_SELECTED first.
-            TrackPointer pTrack = TrackPointer(
-                new TrackInfoObject(filePath, m_pToken, true, true));
+            TrackPointer pTrack(
+                new TrackInfoObject(filePath, m_pToken));
+            SoundSourceProxy(pTrack).loadTrackMetadataAndCoverArt();
 
             // If cover art is not found in the track metadata, populate from
             // possibleCovers.
+            // This is a new (never before seen) track so it is safe
+            // to parse cover art without checking if we have cover art
+            // that is USER_SELECTED. If this changes in the future you
+            // MUST check that the cover art is not USER_SELECTED first.
             if (pTrack->getCoverArt().image.isNull()) {
                 CoverArt art = CoverArtUtils::selectCoverArtForTrack(
                     pTrack.data(), m_possibleCovers);

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -6,6 +6,7 @@
 #include "controlobject.h"
 #include "controlpotmeter.h"
 #include "trackinfoobject.h"
+#include "soundsourceproxy.h"
 #include "engine/enginebuffer.h"
 #include "engine/enginedeck.h"
 #include "engine/enginemaster.h"
@@ -215,15 +216,14 @@ void BaseTrackPlayerImpl::slotUnloadTrack(TrackPointer) {
     PlayerInfo::instance().setTrackInfo(getGroup(), m_pLoadedTrack);
 }
 
-void BaseTrackPlayerImpl::slotFinishLoading(TrackPointer pTrackInfoObject)
-{
+void BaseTrackPlayerImpl::slotFinishLoading(TrackPointer pTrackInfoObject) {
+    DEBUG_ASSERT(m_pLoadedTrack == pTrackInfoObject);
     m_replaygainPending = false;
-    // Read the tags if required
-    if (!m_pLoadedTrack->getHeaderParsed()) {
-        m_pLoadedTrack->parse(false);
-    }
 
-    // m_pLoadedTrack->setPlayedAndUpdatePlaycount(true); // Actually the song is loaded but not played
+    // Reload metadata from file, but only if required
+    SoundSourceProxy(m_pLoadedTrack).loadTrackMetadata();
+
+    // m_pLoadedTrack->setPlayedAndUpdatePlayCount(); // Actually the song is loaded but not played
 
     // Update the BPM and duration values that are stored in ControlObjects
     m_pDuration->set(m_pLoadedTrack->getDuration());

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -115,8 +115,7 @@ void TagFetcher::tagsFetched(int index, const MusicBrainzClient::ResultList& res
 
     foreach (const MusicBrainzClient::Result& result, results) {
         TrackPointer track(new TrackInfoObject(originalTrack->getLocation(),
-                                               originalTrack->getSecurityToken(),
-                                               false),
+                                               originalTrack->getSecurityToken()),
                            &QObject::deleteLater);
         track->setTitle(result.m_title);
         track->setArtist(result.m_artist);

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -283,19 +283,6 @@ SoundSourceProxy::findSoundSourceProviderRegistrations(
     return registrationsForFileExtension;
 }
 
-//Constructor
-SoundSourceProxy::SoundSourceProxy(
-        const QString& filePath,
-        SecurityTokenPointer pSecurityToken)
-        : m_filePath(filePath),
-          m_url(QUrl::fromLocalFile(m_filePath)),
-          m_pSecurityToken(openSecurityToken(m_filePath, pSecurityToken)),
-          m_soundSourceProviderRegistrations(findSoundSourceProviderRegistrations(m_url)),
-          m_soundSourceProviderRegistrationIndex(0) {
-    initSoundSource();
-}
-
-//Other constructor
 SoundSourceProxy::SoundSourceProxy(
         const TrackPointer& pTrack)
         : m_filePath(pTrack->getCanonicalLocation()),

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -42,25 +42,6 @@ const QStringList SOUND_SOURCE_PLUGIN_FILENAME_PATTERN("libsoundsource*");
 const QStringList SOUND_SOURCE_PLUGIN_FILENAME_PATTERN; // empty
 #endif
 
-inline
-SecurityTokenPointer openSecurityToken(
-        const QString& fileName,
-        const SecurityTokenPointer& pSecurityToken) {
-    if (pSecurityToken.isNull()) {
-        // Open a security token for the file if we are in a sandbox.
-        return Sandbox::openSecurityToken(QFileInfo(fileName), true);
-    } else {
-        return pSecurityToken;
-    }
-}
-
-inline
-SecurityTokenPointer openSecurityToken(const TrackPointer& pTrack) {
-    return openSecurityToken(
-            pTrack->getCanonicalLocation(),
-            pTrack->getSecurityToken());
-}
-
 QList<QDir> getSoundSourcePluginDirectories() {
     QList<QDir> pluginDirs;
 
@@ -283,14 +264,12 @@ SoundSourceProxy::findSoundSourceProviderRegistrations(
     return registrationsForFileExtension;
 }
 
-SoundSourceProxy::SoundSourceProxy(
-        const TrackPointer& pTrack)
-        : m_filePath(pTrack->getCanonicalLocation()),
-          m_url(QUrl::fromLocalFile(m_filePath)),
-          m_pTrack(pTrack),
-          m_pSecurityToken(openSecurityToken(pTrack)),
-          m_soundSourceProviderRegistrations(findSoundSourceProviderRegistrations(m_url)),
-          m_soundSourceProviderRegistrationIndex(0) {
+SoundSourceProxy::SoundSourceProxy(const TrackPointer& pTrack)
+    : m_pTrack(pTrack),
+      m_filePath(pTrack->getCanonicalLocation()),
+      m_url(QUrl::fromLocalFile(m_filePath)),
+      m_soundSourceProviderRegistrations(findSoundSourceProviderRegistrations(m_url)),
+      m_soundSourceProviderRegistrationIndex(0) {
     initSoundSource();
 }
 

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -131,7 +131,7 @@ QList<QDir> getSoundSourcePluginDirectories() {
     return pluginDirs;
 }
 
-}
+} // anonymous namespace
 
 // static
 void SoundSourceProxy::loadPlugins() {

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -294,17 +294,13 @@ void SoundSourceProxy::nextSoundSourceProvider() {
 void SoundSourceProxy::initSoundSource() {
     DEBUG_ASSERT(m_pSoundSource.isNull());
     DEBUG_ASSERT(m_pAudioSource.isNull());
-    QString trackType;
-    if (!m_pTrack.isNull()) {
-        trackType = m_pTrack->getType();
-    }
     while (m_pSoundSource.isNull()) {
         Mixxx::SoundSourceProviderPointer pProvider(getSoundSourceProvider());
         if (pProvider.isNull()) {
             qWarning() << "No SoundSourceProvider for file"
                     << getUrl();
-            // Failure -> exit loop
-            break;
+            // Failure
+            return;
         }
         m_pSoundSource = pProvider->newSoundSource(m_url);
         if (m_pSoundSource.isNull()) {
@@ -317,19 +313,17 @@ void SoundSourceProxy::initSoundSource() {
             // ...and continue loop
             DEBUG_ASSERT(m_pSoundSource.isNull());
         } else {
-            trackType = m_pSoundSource->getType();
+            QString trackType(m_pSoundSource->getType());
             qDebug() << "SoundSourceProvider"
                     << pProvider->getName()
                     << "created a SoundSource for file"
                     << getUrl()
                     << "of type"
                     << trackType;
-            // Success -> exit loop
-            break;
+            if (!m_pTrack.isNull()) {
+                m_pTrack->setType(trackType);
+            }
         }
-    }
-    if (!m_pTrack.isNull()) {
-        m_pTrack->setType(trackType);
     }
 }
 

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -6,8 +6,8 @@
 #include "sources/soundsourceproviderregistry.h"
 
 // Creates sound sources for tracks. Only intended to be used
-// in a narrow scope and not shareable between multiple threads!
-class SoundSourceProxy: public Mixxx::MetadataSource {
+// in a narrow scope and not sharable between multiple threads!
+class SoundSourceProxy {
 public:
     // Initially registers all built-in SoundSource providers and
     // loads all SoundSource plugins with additional providers. This
@@ -47,31 +47,25 @@ public:
     // metadata and cover art will be reloaded from the file regardless
     // if it has already been parsed before or not.
     void loadTrackMetadata(bool reloadFromFile = false) const {
-        return m_pTrack->parseTrackMetadata(*this, false, reloadFromFile);
+        return loadTrackMetadataAndCoverArt(false, reloadFromFile);
     }
     void loadTrackMetadataAndCoverArt(bool reloadFromFile = false) const {
-        return m_pTrack->parseTrackMetadata(*this, true, reloadFromFile);
+        return loadTrackMetadataAndCoverArt(true, reloadFromFile);
     }
 
-    // Low-level function for parsing track metadata and cover art
-    // embedded in the audio file into the corresponding objects.
-    // The track referenced by this proxy is not modified! Both
-    // parameters are optional and can be set to nullptr/NULL.
-    Result parseTrackMetadataAndCoverArt(
-            Mixxx::TrackMetadata* pTrackMetadata,
-            QImage* pCoverArt) const override {
-        if (m_pSoundSource) {
-            return m_pSoundSource->parseTrackMetadataAndCoverArt(
-                    pTrackMetadata, pCoverArt);
-        } else {
-            return ERR;
-        }
-    }
+    // Parse only the metadata from the file without modifying
+    // the referenced track.
+    Result parseTrackMetadata(Mixxx::TrackMetadata* pTrackMetadata) const;
+
+    // Parse only the cover image from the file without modifying
+    // the referenced track.
+    QImage parseCoverImage() const;
 
     // Opening the audio data through the proxy will
     // update the some metadata of the track object.
     // Returns a null pointer on failure.
-    Mixxx::AudioSourcePointer openAudioSource(const Mixxx::AudioSourceConfig& audioSrcCfg = Mixxx::AudioSourceConfig());
+    Mixxx::AudioSourcePointer openAudioSource(
+            const Mixxx::AudioSourceConfig& audioSrcCfg = Mixxx::AudioSourceConfig());
 
     void closeAudioSource();
 
@@ -93,6 +87,8 @@ private:
     void nextSoundSourceProvider();
 
     void initSoundSource();
+
+    void loadTrackMetadataAndCoverArt(bool withCoverArt, bool reloadFromFile) const;
 
     Mixxx::SoundSourcePointer m_pSoundSource;
 

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -42,14 +42,6 @@ public:
         return m_url;
     }
 
-    QString getType() const {
-        if (m_pSoundSource) {
-            return m_pSoundSource->getType();
-        } else {
-            return QString();
-        }
-    }
-
     // Load track metadata and (optionally) cover art from the file
     // if it has not already been parsed. With reloadFromFile = true
     // metadata and cover art will be reloaded from the file regardless

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -34,6 +34,10 @@ public:
     explicit SoundSourceProxy(
             const TrackPointer& pTrack);
 
+    const TrackPointer& getTrack() const {
+        return m_pTrack;
+    }
+
     const QString& getFilePath() const {
         return m_filePath;
     }
@@ -50,6 +54,21 @@ public:
         }
     }
 
+    // Load track metadata and (optionally) cover art from the file
+    // if it has not already been parsed. With reloadFromFile = true
+    // metadata and cover art will be reloaded from the file regardless
+    // if it has already been parsed before or not.
+    void loadTrackMetadata(bool reloadFromFile = false) const {
+        return m_pTrack->parseTrackMetadata(*this, false, reloadFromFile);
+    }
+    void loadTrackMetadataAndCoverArt(bool reloadFromFile = false) const {
+        return m_pTrack->parseTrackMetadata(*this, true, reloadFromFile);
+    }
+
+    // Low-level function for parsing track metadata and cover art
+    // embedded in the audio file into the corresponding objects.
+    // The track referenced by this proxy is not modified! Both
+    // parameters are optional and can be set to nullptr/NULL.
     Result parseTrackMetadataAndCoverArt(
             Mixxx::TrackMetadata* pTrackMetadata,
             QImage* pCoverArt) const override {

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -38,10 +38,6 @@ public:
         return m_pTrack;
     }
 
-    const QString& getFilePath() const {
-        return m_filePath;
-    }
-
     const QUrl& getUrl() const {
         return m_url;
     }
@@ -94,7 +90,6 @@ private:
 
     const TrackPointer m_pTrack;
 
-    const QString m_filePath;
     const QUrl m_url;
 
     static QList<Mixxx::SoundSourceProviderRegistration> findSoundSourceProviderRegistrations(const QUrl& url);

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -5,8 +5,6 @@
 
 #include "sources/soundsourceproviderregistry.h"
 
-#include "util/sandbox.h"
-
 // Creates sound sources for tracks. Only intended to be used
 // in a narrow scope and not shareable between multiple threads!
 class SoundSourceProxy: public Mixxx::MetadataSource {
@@ -79,8 +77,6 @@ private:
 
     const QString m_filePath;
     const QUrl m_url;
-
-    const SecurityTokenPointer m_pSecurityToken;
 
     static QList<Mixxx::SoundSourceProviderRegistration> findSoundSourceProviderRegistrations(const QUrl& url);
 

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -7,7 +7,7 @@
 
 #include "util/sandbox.h"
 
-// Creates sound sources for plain files or tracks. Only intended to be used
+// Creates sound sources for tracks. Only intended to be used
 // in a narrow scope and not shareable between multiple threads!
 class SoundSourceProxy: public Mixxx::MetadataSource {
 public:
@@ -33,9 +33,6 @@ public:
     static bool isFileNameSupported(const QString& fileName);
     static bool isFileExtensionSupported(const QString& fileExtension);
 
-    explicit SoundSourceProxy(
-            const QString& filePath,
-            SecurityTokenPointer pSecurityToken = SecurityTokenPointer());
     explicit SoundSourceProxy(
             const TrackPointer& pTrack);
 
@@ -78,10 +75,11 @@ private:
     static QStringList s_supportedFileNamePatterns;
     static QRegExp s_supportedFileNamesRegex;
 
+    const TrackPointer m_pTrack;
+
     const QString m_filePath;
     const QUrl m_url;
 
-    const TrackPointer m_pTrack;
     const SecurityTokenPointer m_pSecurityToken;
 
     static QList<Mixxx::SoundSourceProviderRegistration> findSoundSourceProviderRegistrations(const QUrl& url);

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -11,6 +11,8 @@
 #include "controllinpotmeter.h"
 #include "mixer/playermanager.h"
 #include "mixer/basetrackplayer.h"
+#include "trackinfoobject.h"
+#include "soundsourceproxy.h"
 
 using ::testing::_;
 using ::testing::Return;
@@ -135,6 +137,16 @@ class MockAutoDJProcessor : public AutoDJProcessor {
 
 class AutoDJProcessorTest : public LibraryTest {
   protected:
+    static TrackId nextTrackId(TrackId trackId) {
+        return TrackId(trackId.toInt() + 1);
+    }
+    static TrackPointer newTestTrack(TrackId trackId) {
+        TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
+        pTrack->setId(trackId);
+        SoundSourceProxy(pTrack).loadTrackMetadata();
+        return pTrack;
+    }
+
     AutoDJProcessorTest()
             :  deck1("[Channel1]"),
                deck2("[Channel2]"),
@@ -312,8 +324,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFails) {
 
     // Load the track and mark it playing (as the loadTrackToPlayer signal would
     // have connected to this eventually).
-    TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
-    setTrackId(pTrack, testId);
+    TrackPointer pTrack(newTestTrack(testId));
     deck1.slotLoadTrack(pTrack, true);
 
     // Signal that the request to load pTrack failed.
@@ -379,8 +390,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFailsRightDeck)
 
     // Load the track and mark it playing (as the loadTrackToPlayer signal would
     // have connected to this eventually).
-    TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
-    setTrackId(pTrack, testId);
+    TrackPointer pTrack(newTestTrack(testId));
     deck1.slotLoadTrack(pTrack, true);
 
     // Signal that the request to load pTrack to deck1 succeeded.
@@ -427,8 +437,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1) {
     ASSERT_TRUE(testId.isValid());
 
     // Pretend a track is playing on deck 1.
-    TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
-    setTrackId(pTrack, TrackId(testId.toInt() + 1));
+    TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
     deck1.slotLoadTrack(pTrack, true);
     // Indicate the track loaded successfully.
@@ -468,8 +477,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1_TrackLoadFailed) {
     ASSERT_TRUE(testId.isValid());
 
     // Pretend a track is playing on deck 1.
-    TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
-    setTrackId(pTrack, TrackId(testId.toInt() + 1));
+    TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
     deck1.slotLoadTrack(pTrack, true);
     // Indicate the track loaded successfully.
@@ -525,8 +533,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2) {
     ASSERT_TRUE(testId.isValid());
 
     // Pretend a track is playing on deck 2.
-    TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
-    setTrackId(pTrack, TrackId(testId.toInt() + 1));
+    TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
     deck2.slotLoadTrack(pTrack, true);
     // Indicate the track loaded successfully.
@@ -566,8 +573,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2_TrackLoadFailed) {
     ASSERT_TRUE(testId.isValid());
 
     // Pretend a track is playing on deck 2.
-    TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
-    setTrackId(pTrack, TrackId(testId.toInt() + 1));
+    TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
     deck2.slotLoadTrack(pTrack, true);
     // Indicate the track loaded successfully.
@@ -625,8 +631,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadSuccess) {
     // Crossfader starts on the right.
     master.crossfader.set(1.0);
     // Pretend a track is playing on deck 2.
-    TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
-    setTrackId(pTrack, TrackId(testId.toInt() + 1));
+    TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
     deck2.slotLoadTrack(pTrack, true);
     // Indicate the track loaded successfully.
@@ -706,8 +711,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
     // Crossfader starts on the right.
     master.crossfader.set(1.0);
     // Pretend a track is playing on deck 2.
-    TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
-    setTrackId(pTrack, TrackId(testId.toInt() + 1));
+    TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
     deck2.slotLoadTrack(pTrack, true);
     // Indicate the track loaded successfully.
@@ -803,8 +807,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadSuccess) {
     // Crossfader starts on the left.
     master.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
-    TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
-    setTrackId(pTrack, TrackId(testId.toInt() + 1));
+    TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
     deck1.slotLoadTrack(pTrack, true);
     // Indicate the track loaded successfully.
@@ -884,8 +887,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
     // Crossfader starts on the left.
     master.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
-    TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
-    setTrackId(pTrack, TrackId(testId.toInt() + 1));
+    TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
     deck1.slotLoadTrack(pTrack, true);
     // Indicate the track loaded successfully.
@@ -982,8 +984,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_Long_Transition) {
     // Crossfader starts on the left.
     master.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
-    TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
-    setTrackId(pTrack, TrackId(testId.toInt() + 1));
+    TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
     deck1.slotLoadTrack(pTrack, true);
     // Indicate the track loaded successfully.
@@ -1063,8 +1064,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_SeekEnd) {
     // Crossfader starts on the left.
     master.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
-    TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
-    setTrackId(pTrack, TrackId(testId.toInt() + 1));
+    TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
     deck1.slotLoadTrack(pTrack, true);
     // Indicate the track loaded successfully.

--- a/src/test/coverartcache_test.cpp
+++ b/src/test/coverartcache_test.cpp
@@ -34,9 +34,7 @@ class CoverArtCacheTest : public MixxxTest, public CoverArtCache {
         SecurityTokenPointer securityToken = Sandbox::openSecurityToken(
             QDir(trackLocation), true);
         TrackPointer pTrack(new TrackInfoObject(trackLocation, securityToken));
-        SoundSourceProxy proxy(pTrack);
-        QImage img;
-        EXPECT_EQ(OK, proxy.parseTrackMetadataAndCoverArt(nullptr, &img));
+        QImage img(SoundSourceProxy(pTrack).parseCoverImage());
         EXPECT_FALSE(img.isNull());
         EXPECT_EQ(img, res.cover.image);
     }

--- a/src/test/coverartcache_test.cpp
+++ b/src/test/coverartcache_test.cpp
@@ -33,7 +33,8 @@ class CoverArtCacheTest : public MixxxTest, public CoverArtCache {
 
         SecurityTokenPointer securityToken = Sandbox::openSecurityToken(
             QDir(trackLocation), true);
-        SoundSourceProxy proxy(trackLocation, securityToken);
+        TrackPointer pTrack(new TrackInfoObject(trackLocation, securityToken));
+        SoundSourceProxy proxy(pTrack);
         QImage img;
         EXPECT_EQ(OK, proxy.parseTrackMetadataAndCoverArt(nullptr, &img));
         EXPECT_FALSE(img.isNull());

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -51,39 +51,39 @@ TEST_F(CoverArtUtilTest, extractEmbeddedCover) {
 	
     SecurityTokenPointer pToken;
     // aiff
-    cover = CoverArtUtils::extractEmbeddedCover(kTestPath % "cover-test.aiff",
+    cover = CoverArtUtils::extractEmbeddedCover(kTestPath + "cover-test.aiff",
                                                 pToken);
     EXPECT_FALSE(cover.isNull());
     EXPECT_EQ(referencePNGImage, cover);
     // flac
-    cover = CoverArtUtils::extractEmbeddedCover(kTestPath % "cover-test.flac",
+    cover = CoverArtUtils::extractEmbeddedCover(kTestPath + "cover-test.flac",
                                                 pToken);
     EXPECT_FALSE(cover.isNull());
     EXPECT_EQ(referencePNGImage, cover);
     // mp3 - PNG
-    cover = CoverArtUtils::extractEmbeddedCover(kTestPath % "cover-test-png.mp3",
+    cover = CoverArtUtils::extractEmbeddedCover(kTestPath + "cover-test-png.mp3",
                                                 pToken);
     EXPECT_FALSE(cover.isNull());
     EXPECT_EQ(referencePNGImage, cover);
     // mp3 - JPEG
-    cover = CoverArtUtils::extractEmbeddedCover(kTestPath % "cover-test-jpg.mp3",
+    cover = CoverArtUtils::extractEmbeddedCover(kTestPath + "cover-test-jpg.mp3",
                                                 pToken);
     EXPECT_FALSE(cover.isNull());
     EXPECT_EQ(referenceJPGImage, cover);
     // ogg
-    cover = CoverArtUtils::extractEmbeddedCover(kTestPath % "cover-test.ogg",
+    cover = CoverArtUtils::extractEmbeddedCover(kTestPath + "cover-test.ogg",
                                                 pToken);
     EXPECT_FALSE(cover.isNull());
     EXPECT_EQ(referencePNGImage, cover);
     // wav
-    cover = CoverArtUtils::extractEmbeddedCover(kTestPath % "cover-test.wav",
+    cover = CoverArtUtils::extractEmbeddedCover(kTestPath + "cover-test.wav",
                                                 pToken);
     EXPECT_FALSE(cover.isNull());
     EXPECT_EQ(referencePNGImage, cover);
 
 #ifdef __OPUS__
     // opus
-    cover = CoverArtUtils::extractEmbeddedCover(kTestPath % "cover-test.opus",
+    cover = CoverArtUtils::extractEmbeddedCover(kTestPath + "cover-test.opus",
                                                 pToken);
     EXPECT_FALSE(cover.isNull());
     EXPECT_EQ(referencePNGImage, cover);

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -2,6 +2,7 @@
 #include <QStringBuilder>
 #include <QFileInfo>
 
+#include "soundsourceproxy.h"
 #include "library/coverartcache.h"
 #include "library/coverartutils.h"
 #include "library/trackcollection.h"
@@ -96,6 +97,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
     ASSERT_TRUE(QDir().mkpath(trackdir));
 
     TrackPointer pTrack(new TrackInfoObject(kTrackLocationTest));
+    SoundSourceProxy(pTrack).loadTrackMetadata();
     QLinkedList<QFileInfo> covers;
     CoverArt res;
     // looking for cover in an empty directory
@@ -105,9 +107,8 @@ TEST_F(CoverArtUtilTest, searchImage) {
     EXPECT_EQ(expected, res);
 
     // Looking for a track with embedded cover.
-    pTrack = TrackPointer(new TrackInfoObject(kTrackLocationTest,
-                                              SecurityTokenPointer(),
-                                              true, true));
+    pTrack = TrackPointer(new TrackInfoObject(kTrackLocationTest));
+    SoundSourceProxy(pTrack).loadTrackMetadataAndCoverArt();
     expected = CoverArt();
     expected.image = pTrack->getCoverArt().image;
     expected.info.type = CoverInfo::METADATA;

--- a/src/test/directorydoatest.cpp
+++ b/src/test/directorydoatest.cpp
@@ -142,13 +142,13 @@ TEST_F(DirectoryDAOTest, relocateDirTest) {
     // ok now lets create some tracks here
     trackDAO.addTracksPrepare();
     trackDAO.addTracksAdd(new TrackInfoObject(
-            testdir + "/a", SecurityTokenPointer(), false), false);
+            testdir + "/a"), false);
     trackDAO.addTracksAdd(new TrackInfoObject(
-            testdir + "/b", SecurityTokenPointer(), false), false);
+            testdir + "/b"), false);
     trackDAO.addTracksAdd(new TrackInfoObject(
-            test2 + "/c", SecurityTokenPointer(), false), false);
+            test2 + "/c"), false);
     trackDAO.addTracksAdd(new TrackInfoObject(
-            test2 + "/d", SecurityTokenPointer(), false), false);
+            test2 + "/d"), false);
     trackDAO.addTracksFinish(false);
 
     QSet<TrackId> ids = directoryDao.relocateDirectory(testdir, testnew);

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -52,7 +52,8 @@ class SoundSourceProxyTest: public MixxxTest {
     }
 
     static Mixxx::AudioSourcePointer openAudioSource(const QString& filePath) {
-        return SoundSourceProxy(filePath).openAudioSource();
+        TrackPointer pTrack(new TrackInfoObject(filePath));
+        return SoundSourceProxy(pTrack).openAudioSource();
     }
 };
 
@@ -70,16 +71,18 @@ TEST_F(SoundSourceProxyTest, open) {
 }
 
 TEST_F(SoundSourceProxyTest, readArtist) {
-    SoundSourceProxy proxy(
-            QDir::currentPath().append("/src/test/id3-test-data/artist.mp3"));
+    TrackPointer pTrack(new TrackInfoObject(
+            QDir::currentPath().append("/src/test/id3-test-data/artist.mp3")));
+    SoundSourceProxy proxy(pTrack);
     Mixxx::TrackMetadata trackMetadata;
     EXPECT_EQ(OK, proxy.parseTrackMetadataAndCoverArt(&trackMetadata, NULL));
     EXPECT_EQ("Test Artist", trackMetadata.getArtist());
 }
 
 TEST_F(SoundSourceProxyTest, TOAL_TPE2) {
-    SoundSourceProxy proxy(
-        QDir::currentPath().append("/src/test/id3-test-data/TOAL_TPE2.mp3"));
+    TrackPointer pTrack(new TrackInfoObject(
+            QDir::currentPath().append("/src/test/id3-test-data/TOAL_TPE2.mp3")));
+    SoundSourceProxy proxy(pTrack);
     Mixxx::TrackMetadata trackMetadata;
     EXPECT_EQ(OK, proxy.parseTrackMetadataAndCoverArt(&trackMetadata, NULL));
     EXPECT_EQ("TITLE2", trackMetadata.getArtist());

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -75,7 +75,7 @@ TEST_F(SoundSourceProxyTest, readArtist) {
             QDir::currentPath().append("/src/test/id3-test-data/artist.mp3")));
     SoundSourceProxy proxy(pTrack);
     Mixxx::TrackMetadata trackMetadata;
-    EXPECT_EQ(OK, proxy.parseTrackMetadataAndCoverArt(&trackMetadata, NULL));
+    EXPECT_EQ(OK, proxy.parseTrackMetadata(&trackMetadata));
     EXPECT_EQ("Test Artist", trackMetadata.getArtist());
 }
 
@@ -84,7 +84,7 @@ TEST_F(SoundSourceProxyTest, TOAL_TPE2) {
             QDir::currentPath().append("/src/test/id3-test-data/TOAL_TPE2.mp3")));
     SoundSourceProxy proxy(pTrack);
     Mixxx::TrackMetadata trackMetadata;
-    EXPECT_EQ(OK, proxy.parseTrackMetadataAndCoverArt(&trackMetadata, NULL));
+    EXPECT_EQ(OK, proxy.parseTrackMetadata(&trackMetadata));
     EXPECT_EQ("TITLE2", trackMetadata.getArtist());
     EXPECT_EQ("ARTIST", trackMetadata.getAlbum());
     EXPECT_EQ("TITLE", trackMetadata.getAlbumArtist());

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -167,20 +167,6 @@ void TrackInfoObject::parseTrackMetadata(
         bool reloadFromFile) {
     DEBUG_ASSERT(this == proxy.getTrack().data());
 
-    // NOTE(uklotzde): The type must not be set before parsing
-    // the metadata from the file! Otherwise the TIO is marked
-    // as dirty and incomplete metadata might be written back
-    // into the file.
-    const QString trackType(proxy.getType());
-    if (trackType.isEmpty()) {
-        qWarning() << "Failed to parse track metadata from file"
-                << getLocation()
-                << ": Unsupported file type";
-        setHeaderParsed(false);
-        return;
-    }
-    setType(trackType);
-
     bool parsedFromFile = getHeaderParsed();
     if (parsedFromFile && !reloadFromFile) {
         qDebug() << "Skip parsing of track metadata from file"

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -35,9 +35,9 @@ inline bool compareAndSet(T* pField, const T& value) {
 
 } // anonymous namespace
 
-TrackInfoObject::TrackInfoObject(const QFileInfo& fileInfo,
-                                 SecurityTokenPointer pToken,
-                                 bool parseHeader, bool parseCoverArt)
+TrackInfoObject::TrackInfoObject(
+        const QFileInfo& fileInfo,
+        SecurityTokenPointer pToken)
         : m_fileInfo(fileInfo),
           m_pSecurityToken(pToken.isNull() ? Sandbox::openSecurityToken(
                   m_fileInfo, true) : pToken),
@@ -57,11 +57,6 @@ TrackInfoObject::TrackInfoObject(const QFileInfo& fileInfo,
     m_iChannels = 0;
     m_fCuePoint = 0.0f;
     m_dateAdded = QDateTime::currentDateTime();
-
-    // Parse the metadata from file. This is not a quick operation!
-    if (parseHeader) {
-        parse(parseCoverArt);
-    }
 }
 
 // static
@@ -166,67 +161,85 @@ void TrackInfoObject::getMetadata(Mixxx::TrackMetadata* pTrackMetadata) {
     pTrackMetadata->setKey(getKeyText());
 }
 
-void TrackInfoObject::parse(bool parseCoverArt) {
-    // Log parsing of header information in developer mode. This is useful for
-    // tracking down corrupt files.
-    const QString canonicalLocation(getCanonicalLocation());
-    if (CmdlineArgs::Instance().getDeveloper()) {
-        qDebug() << "TrackInfoObject::parse()" << canonicalLocation;
-    }
+void TrackInfoObject::parseTrackMetadata(
+        const SoundSourceProxy& proxy,
+        bool parseCoverArt,
+        bool reloadFromFile) {
+    DEBUG_ASSERT(this == proxy.getTrack().data());
 
-    // TODO(uklotzde): Move parsing of metadata to SoundSourceProxy
-    SoundSourceProxy proxy(canonicalLocation, m_pSecurityToken);
-    if (!proxy.getType().isEmpty()) {
-        setType(proxy.getType());
-
-        // Parse the information stored in the sound file.
-        Mixxx::TrackMetadata trackMetadata;
-        QImage coverArt;
-        // If parsing of the cover art image should be omitted the
-        // 2nd output parameter must be set to NULL.
-        QImage* pCoverArt = parseCoverArt ? &coverArt : NULL;
-        if (proxy.parseTrackMetadataAndCoverArt(&trackMetadata, pCoverArt) == OK) {
-            // If Artist, Title and Type fields are not blank, modify them.
-            // Otherwise, keep their current values.
-            // TODO(rryan): Should we re-visit this decision?
-            if (trackMetadata.getArtist().isEmpty() || trackMetadata.getTitle().isEmpty()) {
-                Mixxx::TrackMetadata fileNameMetadata;
-                parseMetadataFromFileName(fileNameMetadata, getFileName());
-                if (trackMetadata.getArtist().isEmpty()) {
-                    trackMetadata.setArtist(fileNameMetadata.getArtist());
-                }
-                if (trackMetadata.getTitle().isEmpty()) {
-                    trackMetadata.setTitle(fileNameMetadata.getTitle());
-                }
-            }
-
-            if (pCoverArt && !pCoverArt->isNull()) {
-                QMutexLocker lock(&m_qMutex);
-                m_coverArt.image = *pCoverArt;
-                m_coverArt.info.hash = CoverArtUtils::calculateHash(
-                    m_coverArt.image);
-                m_coverArt.info.coverLocation = QString();
-                m_coverArt.info.type = CoverInfo::METADATA;
-                m_coverArt.info.source = CoverInfo::GUESSED;
-            }
-
-            setHeaderParsed(true);
-        } else {
-            qDebug() << "TrackInfoObject::parse() error at file"
-                     << canonicalLocation;
-
-            // Add basic information derived from the filename
-            parseMetadataFromFileName(trackMetadata, getFileName());
-
-            setHeaderParsed(false);
-        }
-        // Dump the metadata extracted from the file into the track.
-        setMetadata(trackMetadata);
-    } else {
-        qDebug() << "TrackInfoObject::parse() error at file"
-                 << canonicalLocation;
+    if (proxy.getFilePath().isEmpty()) {
+        qWarning() << "Failed to parse track metadata from file"
+                << getLocation()
+                << ": File is inaccessible or missing";
         setHeaderParsed(false);
+        return;
     }
+
+    const QString canonicalLocation(getCanonicalLocation());
+    DEBUG_ASSERT_AND_HANDLE(proxy.getFilePath() == canonicalLocation) {
+            qWarning() << "Failed to parse track metadata from file"
+                    << getLocation()
+                    << ": Mismatching file paths"
+                    << proxy.getFilePath()
+                    << "<>"
+                    << canonicalLocation;
+        setHeaderParsed(false);
+        return;
+    }
+
+    if (proxy.getType().isEmpty()) {
+        qWarning() << "Failed to parse track metadata from file"
+                << getLocation()
+                << ": Unsupported file type";
+        setHeaderParsed(false);
+        return;
+    }
+    setType(proxy.getType());
+
+    bool parsedFromFile = getHeaderParsed();
+    if (parsedFromFile && !reloadFromFile) {
+        return; // do not reload from file
+    }
+    Mixxx::TrackMetadata trackMetadata;
+    // Use the existing trackMetadata as default values. Otherwise
+    // existing values in the library will be overwritten with
+    // empty values if the corresponding file tags are missing.
+    // Depending on the file type some kind of tags might even
+    // not be supported at all and those would get lost!
+    getMetadata(&trackMetadata);
+    QImage coverArt;
+    // If parsing of the cover art image should be omitted the
+    // 2nd output parameter must be set to nullptr. Cover art
+    // is not reloaded from file once the metadata has been parsed!
+    QImage* pCoverArt = (parseCoverArt && !parsedFromFile) ? &coverArt : nullptr;
+    // Parse the tags stored in the audio file.
+    if (proxy.parseTrackMetadataAndCoverArt(&trackMetadata, pCoverArt) == OK) {
+        parsedFromFile = true;
+    } else {
+        qWarning() << "Failed to parse tags from file"
+                 << getLocation();
+    }
+
+    // If Artist or title fields are blank try to parse them
+    // from the file name.
+    // TODO(rryan): Should we re-visit this decision?
+    if (trackMetadata.getArtist().isEmpty() || trackMetadata.getTitle().isEmpty()) {
+        parseMetadataFromFileName(trackMetadata, m_fileInfo.fileName());
+    }
+
+    // Dump the trackMetadata extracted from the file back into the track.
+    setMetadata(trackMetadata);
+    if (pCoverArt && !pCoverArt->isNull()) {
+        CoverArt coverArt;
+        coverArt.image = *pCoverArt;
+        coverArt.info.hash = CoverArtUtils::calculateHash(
+                coverArt.image);
+        coverArt.info.coverLocation = QString();
+        coverArt.info.type = CoverInfo::METADATA;
+        coverArt.info.source = CoverInfo::GUESSED;
+        setCoverArt(coverArt);
+    }
+    setHeaderParsed(parsedFromFile);
 }
 
 QString TrackInfoObject::getLocation() const {

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -174,6 +174,7 @@ void TrackInfoObject::parse(bool parseCoverArt) {
         qDebug() << "TrackInfoObject::parse()" << canonicalLocation;
     }
 
+    // TODO(uklotzde): Move parsing of metadata to SoundSourceProxy
     SoundSourceProxy proxy(canonicalLocation, m_pSecurityToken);
     if (!proxy.getType().isEmpty()) {
         setType(proxy.getType());

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -167,39 +167,27 @@ void TrackInfoObject::parseTrackMetadata(
         bool reloadFromFile) {
     DEBUG_ASSERT(this == proxy.getTrack().data());
 
-    if (proxy.getFilePath().isEmpty()) {
-        qWarning() << "Failed to parse track metadata from file"
-                << getLocation()
-                << ": File is inaccessible or missing";
-        setHeaderParsed(false);
-        return;
-    }
-
-    const QString canonicalLocation(getCanonicalLocation());
-    DEBUG_ASSERT_AND_HANDLE(proxy.getFilePath() == canonicalLocation) {
-            qWarning() << "Failed to parse track metadata from file"
-                    << getLocation()
-                    << ": Mismatching file paths"
-                    << proxy.getFilePath()
-                    << "<>"
-                    << canonicalLocation;
-        setHeaderParsed(false);
-        return;
-    }
-
-    if (proxy.getType().isEmpty()) {
+    // NOTE(uklotzde): The type must not be set before parsing
+    // the metadata from the file! Otherwise the TIO is marked
+    // as dirty and incomplete metadata might be written back
+    // into the file.
+    const QString trackType(proxy.getType());
+    if (trackType.isEmpty()) {
         qWarning() << "Failed to parse track metadata from file"
                 << getLocation()
                 << ": Unsupported file type";
         setHeaderParsed(false);
         return;
     }
-    setType(proxy.getType());
+    setType(trackType);
 
     bool parsedFromFile = getHeaderParsed();
     if (parsedFromFile && !reloadFromFile) {
+        qDebug() << "Skip parsing of track metadata from file"
+                << getLocation();
         return; // do not reload from file
     }
+
     Mixxx::TrackMetadata trackMetadata;
     // Use the existing trackMetadata as default values. Otherwise
     // existing values in the library will be overwritten with

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -87,10 +87,10 @@ class TrackInfoObject : public QObject {
     // Returns whether the file exists on disk or not.
     bool exists() const;
 
-    // Sets the type of the string
-    void setType(const QString&);
     // Returns the file type
     QString getType() const;
+    // Sets the file type. Only used by TrackDAO and SoundSourceProxy!
+    void setType(const QString&);
 
     void setChannels(int iChannels);
     // Get number of channels

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -8,7 +8,6 @@
 #include <QMutex>
 #include <QObject>
 #include <QSharedPointer>
-#include <QWeakPointer>
 
 #include "library/dao/cue.h"
 #include "library/coverart.h"
@@ -20,6 +19,8 @@
 #include "track/playcounter.h"
 #include "util/sandbox.h"
 #include "waveform/waveform.h"
+
+class SoundSourceProxy;
 
 class TrackInfoObject;
 typedef QSharedPointer<TrackInfoObject> TrackPointer;
@@ -34,14 +35,9 @@ class TrackInfoObject : public QObject {
 
   public:
     // Initialize track with a QFileInfo class
-    explicit TrackInfoObject(const QFileInfo& fileInfo = QFileInfo(),
-                    SecurityTokenPointer pToken = SecurityTokenPointer(),
-                    bool parseHeader = true,
-                    bool parseCoverArt = false);
-
-    // Parse file metadata. If no file metadata is present, attempts to extract
-    // artist and title information from the filename.
-    void parse(bool parseCoverArt);
+    explicit TrackInfoObject(
+            const QFileInfo& fileInfo = QFileInfo(),
+            SecurityTokenPointer pToken = SecurityTokenPointer());
 
     Q_PROPERTY(QString artist READ getArtist WRITE setArtist)
     Q_PROPERTY(QString title READ getTitle WRITE setTitle)
@@ -305,6 +301,12 @@ class TrackInfoObject : public QObject {
     // while the TIO is locked.
     bool markDirtyAndUnlock(QMutexLocker* pLock, bool bDirty = true);
     void setDirtyAndUnlock(QMutexLocker* pLock, bool bDirty);
+
+    friend class SoundSourceProxy;
+    void parseTrackMetadata(
+            const SoundSourceProxy& proxy,
+            bool parseCoverArt,
+            bool reloadFromFile);
 
     void setBeatsAndUnlock(QMutexLocker* pLock, BeatsPointer pBeats);
     void setKeysAndUnlock(QMutexLocker* pLock, const Keys& keys);

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -20,8 +20,6 @@
 #include "util/sandbox.h"
 #include "waveform/waveform.h"
 
-class SoundSourceProxy;
-
 class TrackInfoObject;
 typedef QSharedPointer<TrackInfoObject> TrackPointer;
 typedef QWeakPointer<TrackInfoObject> TrackWeakPointer;
@@ -255,6 +253,9 @@ class TrackInfoObject : public QObject {
     void setCoverArt(const CoverArt& cover);
     CoverArt getCoverArt() const;
 
+    void setMetadata(const Mixxx::TrackMetadata& trackMetadata);
+    void getMetadata(Mixxx::TrackMetadata* pTrackMetadata);
+
     // markDirty(false) = current value of dirty flag (unchanged)
     // markDirty(true) = true = new value of dirty flag
     bool markDirty(bool bDirty = true);
@@ -291,9 +292,6 @@ class TrackInfoObject : public QObject {
     void slotBeatsUpdated();
 
   private:
-    void setMetadata(const Mixxx::TrackMetadata& trackMetadata);
-    void getMetadata(Mixxx::TrackMetadata* pTrackMetadata);
-
     void resetDirty();
 
     // Set whether the TIO is dirty or not and unlock before emitting
@@ -301,12 +299,6 @@ class TrackInfoObject : public QObject {
     // while the TIO is locked.
     bool markDirtyAndUnlock(QMutexLocker* pLock, bool bDirty = true);
     void setDirtyAndUnlock(QMutexLocker* pLock, bool bDirty);
-
-    friend class SoundSourceProxy;
-    void parseTrackMetadata(
-            const SoundSourceProxy& proxy,
-            bool parseCoverArt,
-            bool reloadFromFile);
 
     void setBeatsAndUnlock(QMutexLocker* pLock, BeatsPointer pBeats);
     void setKeysAndUnlock(QMutexLocker* pLock, const Keys& keys);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1317,7 +1317,7 @@ void WTrackTableView::slotReloadTrackMetadata() {
     foreach (QModelIndex index, indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
-            pTrack->parse(false);
+            SoundSourceProxy(pTrack).loadTrackMetadata(true);
         }
     }
 }


### PR DESCRIPTION
Establish dependency from SoundSourceProxy to TrackInfoObject, move around the code for metadata parsing, and delete obsolete class members of SoundSourceProxy.

**1st step: Establish dependency from SoundSourceProxy to TrackInfoObject**
- SoundSourceProxy now holds a TrackPointer
- SoundSourceProxy can only be constructed from a TrackPointer
- Delete obsolete SecurityToken from SoundSourceProxy

**2nd step: Move parsing of metadata from TrackInfoObject to SoundSourceProxy**
- Fixing compile errors introduced by the 1st step

**3rd step: Cleanup/Refactoring**
- Delete another obsolete member from SoundSourceProxy
## Background

A prerequisite for writing back metadata into files is to keep track who is currently reading from a file. Writing to files requires exclusive access, i.e. no other Mixxx component must be reading from the same file. External applications that might access files concurrently are out of scope.

This PR establishes TrackInfoObject as the central authority for keeping track of file access. All read operations (both metadata/cover art and audio) must ensure that the TrackInfoObject instance for the corresponding file exists. It is no longer allowed to access a file without a TrackInfoObject instance.

All read operations are now routed through SoundSourceProxy which holds a reference of the TrackInfoObject instance. SoundSourceProxy ensures that its TrackInfoObject instance is kept alive while read operations are pending, even if it is destroyed before the corresponding SoundSource is closed.

Currently multiple instances of TrackInfoObject for the same file might exist. Another PR will establish the required 1:1 relationship between TrackInfoObjects and their corresponding files by introducing a TrackCache.
