### PR TITLE
Keep TIO alive while reading audio data

### DIFF
--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -434,8 +434,9 @@ QImage SoundSourceProxy::parseCoverImage() const {
 }
 
 Mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const Mixxx::AudioSourceConfig& audioSrcCfg) {
-    while (!m_pAudioSource) {
-        if (!m_pSoundSource) {
+    DEBUG_ASSERT(!m_pTrack.isNull());
+    while (m_pAudioSource.isNull()) {
+        if (m_pSoundSource.isNull()) {
             qWarning() << "Failed to open AudioSource for file"
                     << getUrl();
             return m_pAudioSource; // failure -> exit loop
@@ -452,7 +453,7 @@ Mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const Mixxx::AudioSo
                             << getUrl();
                 }
                 // Overwrite metadata with actual audio properties
-                if (m_pTrack) {
+                if (!m_pTrack.isNull()) {
                     m_pTrack->setChannels(m_pAudioSource->getChannelCount());
                     m_pTrack->setSampleRate(m_pAudioSource->getSamplingRate());
                     if (m_pAudioSource->hasDuration()) {
@@ -487,8 +488,8 @@ Mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const Mixxx::AudioSo
 }
 
 void SoundSourceProxy::closeAudioSource() {
-    if (m_pAudioSource) {
-        DEBUG_ASSERT(m_pSoundSource);
+    if (!m_pAudioSource.isNull()) {
+        DEBUG_ASSERT(!m_pSoundSource.isNull());
         m_pSoundSource->close();
         m_pAudioSource.clear();
         qDebug() << "Closed AudioSource for file"

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -482,8 +482,8 @@ private:
             const TrackPointer& pTrack,
             const Mixxx::AudioSourcePointer& pAudioSource)
         : Mixxx::AudioSource(*pAudioSource),
-          m_pTrack(std::move(pTrack)),
-          m_pAudioSource(std::move(pAudioSource)) {
+          m_pTrack(pTrack),
+          m_pAudioSource(pAudioSource) {
     }
 
     const TrackPointer m_pTrack;

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -454,14 +454,6 @@ public:
                 new AudioSourceProxy(pTrack, pAudioSource));
     }
 
-    AudioSourceProxy(
-            const TrackPointer& pTrack,
-            const Mixxx::AudioSourcePointer& pAudioSource)
-        : Mixxx::AudioSource(*pAudioSource),
-          m_pTrack(std::move(pTrack)),
-          m_pAudioSource(std::move(pAudioSource)) {
-    }
-
     SINT seekSampleFrame(SINT frameIndex) override {
         return m_pAudioSource->seekSampleFrame(
                 frameIndex);
@@ -486,6 +478,14 @@ public:
     }
 
 private:
+    AudioSourceProxy(
+            const TrackPointer& pTrack,
+            const Mixxx::AudioSourcePointer& pAudioSource)
+        : Mixxx::AudioSource(*pAudioSource),
+          m_pTrack(std::move(pTrack)),
+          m_pAudioSource(std::move(pAudioSource)) {
+    }
+
     const TrackPointer m_pTrack;
     const Mixxx::AudioSourcePointer m_pAudioSource;
 };

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -90,10 +90,14 @@ private:
 
     void loadTrackMetadataAndCoverArt(bool withCoverArt, bool reloadFromFile) const;
 
+    // This pointer must stay in this class together with
+    // the corresponding track pointer. Don't pass it around!!
     Mixxx::SoundSourcePointer m_pSoundSource;
 
-    // Just an alias that keeps track of opening and closing
-    // the corresponding SoundSource.
+    // Keeps track of opening and closing the corresponding
+    // SoundSource. This pointer can safely be passed around,
+    // because internally it contains a reference to the TIO
+    // that keeps it alive.
     Mixxx::AudioSourcePointer m_pAudioSource;
 };
 


### PR DESCRIPTION
The lifecycle of the SoundSourceProxy and the AudioSource pointers it creates are decoupled! AudioSource pointers that have been handed out by a SoundSourceProxy must keep the TIO alive even if the SoundSourceProxy has already been destroyed.

The SoundSourceProxy is usually allocated on the stack and will most likely be destroyed before the AudioSource while reading audio data from the file.
## Background

A prerequisite for writing back metadata into files is to keep track who is currently reading from a file. Writing to files requires exclusive access, i.e. no other Mixxx component must be reading from the same file. External applications that might access files concurrently are out of scope.

All read operations are routed through SoundSourceProxy which holds a reference of the TrackInfoObject instance. SoundSourceProxy must ensure that its TrackInfoObject instance is kept alive while read operations are pending, even if it is destroyed before the corresponding SoundSource/AudioSource is closed.

Currently multiple instances of TrackInfoObject for the same file might exist. Another PR will establish the required 1:1 relationship between TrackInfoObjects and their corresponding files by introducing a TrackCache.
