### PR TITLE
clockref improvements

### DIFF
--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -44,6 +44,13 @@ typedef PaError (*SetJackClientName)(const char *name);
 #endif
 
 namespace {
+
+struct DeviceMode {
+    SoundDevice* device;
+    bool isInput;
+    bool isOutput;
+};
+
 #ifdef __LINUX__
 const unsigned int kSleepSecondsAfterClosingDevice = 5;
 #endif
@@ -432,7 +439,6 @@ Result SoundManager::setupDevices() {
         m_pErrorDevice = device;
         // If we have not yet set a clock source then we use the first
         // output device
-        qDebug() << haveOutput << mode.isOutput;
         if (device->getInternalName() != kNetworkDeviceInternalName &&
                 pNewMasterClockRef == NULL &&
                 (!haveOutput || mode.isOutput)) {

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -113,6 +113,12 @@ class SoundManager : public QObject {
     void inputRegistered(AudioInput input, AudioDestination *dest);
 
   private:
+
+    struct DeviceMode {
+        bool isInput;
+        bool isOutput;
+    };
+
     // Closes all the devices and empties the list of devices we have.
     void clearDeviceList(bool sleepAfterClosing);
 

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -113,13 +113,6 @@ class SoundManager : public QObject {
     void inputRegistered(AudioInput input, AudioDestination *dest);
 
   private:
-
-    struct DeviceMode {
-        SoundDevice* device;
-        bool isInput;
-        bool isOutput;
-    };
-
     // Closes all the devices and empties the list of devices we have.
     void clearDeviceList(bool sleepAfterClosing);
 

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -115,6 +115,7 @@ class SoundManager : public QObject {
   private:
 
     struct DeviceMode {
+        SoundDevice* device;
         bool isInput;
         bool isOutput;
     };


### PR DESCRIPTION
This is a bandaid for:
https://bugs.launchpad.net/mixxx/+bug/1535746

If you use a mic and headphones only, it can happen that Mixxx picks the mic soundcard as clock reference which leads to noise. 
Now Mixxx picks only an input only soundcard if there is no output at all. 
