### PR TITLE
Improve DAC timing plausibility and add a CPU timer fallback

### DIFF
--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -368,6 +368,9 @@ Result SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers) {
         if (m_pMasterAudioLatencyOverloadCount) {
             m_pMasterAudioLatencyOverloadCount->set(0);
         }
+
+        m_clkRefTimer.start();
+        m_invalidTimeInfoWarned = false;
     }
     m_pStream = pStream;
     return OK;

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -1011,7 +1011,7 @@ void SoundDevicePortAudio::updateCallbackEntryToDacTime(
 
         if (!m_invalidTimeInfoWarned) {
             qWarning() << "SoundDevicePortAudio: Audio API provides invalid time stamps,"
-                       << "waveform by CPU Timer"
+                       << "syncing waveforms with a CPU Timer"
                        << "DacTime:" << timeInfo->outputBufferDacTime
                        << "EntrytoDac:" << callbackEntrytoDacSecs;
             m_invalidTimeInfoWarned = true;

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -76,6 +76,7 @@ class SoundDevicePortAudio : public SoundDevice {
 
   private:
     void updateCallbackEntryToDacTime(const PaStreamCallbackTimeInfo* timeInfo);
+    void updateAudioLatencyUsage(const unsigned int framesPerBuffer);
 
     // PortAudio stream for this device.
     PaStream* volatile m_pStream;

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -106,9 +106,10 @@ class SoundDevicePortAudio : public SoundDevice {
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
     int m_syncBuffers;
-    bool m_invalidTimeInfoWarned;
+    int m_invalidTimeInfoCount;
     PerformanceTimer m_clkRefTimer;
     PaTime m_lastCallbackEntrytoDacSecs;
+
 };
 
 #endif

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -108,6 +108,7 @@ class SoundDevicePortAudio : public SoundDevice {
     int m_syncBuffers;
     bool m_invalidTimeInfoWarned;
     PerformanceTimer m_clkRefTimer;
+    PaTime m_lastCallbackEntrytoDacSecs;
 };
 
 #endif


### PR DESCRIPTION
Here it is. 
It works surprisingly well with the pulse ALSA device. Even if we have a 47 ms cycle for a 43 ms buffer and two callbacks without a gap if the buffer is consumed. 
