### PR TITLE
Cleanup and refactoring of TrackDAO: Adding tracks [rebased and consolidated]

### DIFF
--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -174,7 +174,7 @@ bool AnalysisFeature::dropAccept(QList<QUrl> urls, QObject* pSource) {
     Q_UNUSED(pSource);
     QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
     // Adds track, does not insert duplicates, handles unremoving logic.
-    QList<TrackId> trackIds = m_pTrackCollection->getTrackDAO().addTracks(files, true);
+    QList<TrackId> trackIds = m_pTrackCollection->getTrackDAO().addMultipleTracks(files, true);
     analyzeTracks(trackIds);
     return trackIds.size() > 0;
 }

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -155,7 +155,7 @@ bool AutoDJFeature::dropAccept(QList<QUrl> urls, QObject* pSource) {
         trackIds = trackDao.getTrackIds(files);
         trackDao.unhideTracks(trackIds);
     } else {
-        trackIds = trackDao.addTracks(files, true);
+        trackIds = trackDao.addMultipleTracks(files, true);
     }
 
     // remove tracks that could not be added

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -697,7 +697,6 @@ bool BaseSqlTableModel::setData(
     // Do not save the track here. Changing the track dirties it and the caching
     // system will automatically save the track once it is unloaded from
     // memory. rryan 10/2010
-    //m_trackDAO.saveTrack(pTrack);
 
     return true;
 }

--- a/src/library/cratefeature.cpp
+++ b/src/library/cratefeature.cpp
@@ -154,7 +154,7 @@ bool CrateFeature::dropAcceptChild(const QModelIndex& index, QList<QUrl> urls,
         m_pTrackCollection->getTrackDAO().unhideTracks(trackIds);
     } else {
         // Adds track, does not insert duplicates, handles unremoving logic.
-        trackIds = m_pTrackCollection->getTrackDAO().addTracks(files, true);
+        trackIds = m_pTrackCollection->getTrackDAO().addMultipleTracks(files, true);
     }
     qDebug() << "CrateFeature::dropAcceptChild adding tracks"
             << trackIds.size() << " to crate "<< crateId;

--- a/src/library/cratetablemodel.cpp
+++ b/src/library/cratetablemodel.cpp
@@ -87,8 +87,8 @@ bool CrateTableModel::addTrack(const QModelIndex& index, QString location) {
     // If the track is already contained in the library it will not insert
     // a duplicate. It also handles unremoving logic if the track has been
     // removed from the library recently and re-adds it.
-    const TrackId trackId(trackDao.addSingleTrack(fileInfo, true));
-    if (!trackId.isValid()) {
+    const TrackPointer pTrack(trackDao.addSingleTrack(fileInfo, true));
+    if (pTrack.isNull()) {
         qDebug() << "CrateTableModel::addTrack:"
                 << "Failed to add track"
                 << location
@@ -96,6 +96,7 @@ bool CrateTableModel::addTrack(const QModelIndex& index, QString location) {
         return false;
     }
 
+    const TrackId trackId(pTrack->getId());
     if (m_pTrackCollection->getCrateDAO().addTrackToCrate(trackId, m_iCrateId)) {
         // TODO(rryan) just add the track dont select
         select();

--- a/src/library/cratetablemodel.cpp
+++ b/src/library/cratetablemodel.cpp
@@ -70,30 +70,42 @@ void CrateTableModel::setTableModel(int crateId) {
 
 bool CrateTableModel::addTrack(const QModelIndex& index, QString location) {
     Q_UNUSED(index);
-    // If a track is dropped but it isn't in the library, then add it because
-    // the user probably dropped a file from outside Mixxx into this playlist.
+
+    // This will only succeed if the file actually exist.
     QFileInfo fileInfo(location);
     if (!fileInfo.exists()) {
+        qDebug() << "CrateTableModel::addTrack:"
+                << "File"
+                << location
+                << "not found";
         return false;
     }
 
     TrackDAO& trackDao = m_pTrackCollection->getTrackDAO();
-
-    // Adds track, does not insert duplicates, handles unremoving logic.
-    TrackId trackId(trackDao.addTrack(fileInfo, true));
-
-    bool success = false;
-    if (trackId.isValid()) {
-        success = m_pTrackCollection->getCrateDAO().addTrackToCrate(trackId, m_iCrateId);
+    // If a track is dropped but it isn't in the library, then add it because
+    // the user probably dropped a file from outside Mixxx into this crate.
+    // If the track is already contained in the library it will not insert
+    // a duplicate. It also handles unremoving logic if the track has been
+    // removed from the library recently and re-adds it.
+    const TrackId trackId(trackDao.addSingleTrack(fileInfo, true));
+    if (!trackId.isValid()) {
+        qDebug() << "CrateTableModel::addTrack:"
+                << "Failed to add track"
+                << location
+                << "to library";
+        return false;
     }
 
-    if (success) {
+    if (m_pTrackCollection->getCrateDAO().addTrackToCrate(trackId, m_iCrateId)) {
         // TODO(rryan) just add the track dont select
         select();
         return true;
     } else {
-        qDebug() << "CrateTableModel::addTrack could not add track"
-                 << fileInfo.absoluteFilePath() << "to crate" << m_iCrateId;
+        qDebug() << "CrateTableModel::addTrack:"
+                << "Failed to add track"
+                << location
+                << "to crate"
+                << m_iCrateId;
         return false;
     }
 }
@@ -111,7 +123,7 @@ int CrateTableModel::addTracks(const QModelIndex& index,
         }
     }
 
-    QList<TrackId> trackIds(m_trackDAO.addTracks(fileInfoList, true));
+    QList<TrackId> trackIds(m_trackDAO.addMultipleTracks(fileInfoList, true));
 
     int tracksAdded = m_crateDAO.addTracksToCrate(m_iCrateId, &trackIds);
     if (tracksAdded > 0) {

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1424,12 +1424,14 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
     // Insert the loaded track into the recent tracks cache
     cacheRecentTrack(trackId, pTrack);
 
-    // If the track is dirty send dirty notifications after we inserted
-    // it in the cache. BaseTrackCache cares about dirty notifications
-    // and the markDirty() call above happens before we connect to the
-    // track's signals.
-    if (shouldDirty) {
+    // BaseTrackCache cares about track trackDirty/trackClean notifications
+    // from TrackDAO that are triggered by the track itself. But the preceding
+    // track modifications above have been sent before the TrackDAO has been
+    // connected to the track's signals and need to be replayed manually.
+    if (pTrack->isDirty()) {
         emit(trackDirty(trackId));
+    } else {
+        emit(trackClean(trackId));
     }
 
     // NOTE(uklotz): Loading of metadata from the corresponding file

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -679,13 +679,15 @@ TrackPointer TrackDAO::addTracksAddFile(const QFileInfo& fileInfo, bool unremove
         return TrackPointer();
     }
 
+    // Initially load the metadata for the newly created track
+    // from the file.
     SoundSourceProxy(pTrack).loadTrackMetadata();
     if (!pTrack->getHeaderParsed()) {
         qWarning() << "TrackDAO::addTracksAddFile:"
                 << "Failed to parse track metadata from file"
                 << pTrack->getLocation();
-        // Add the track to the library no matter if parsing
-        // the metadata from file succeeded or failed.
+        // Copntinue with adding the track to the library, no matter
+        // if parsing the metadata from file succeeded or failed.
     }
 
     const TrackId trackId(addTracksAddTrack(pTrack, unremove));

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -679,6 +679,9 @@ TrackPointer TrackDAO::addTracksAddFile(const QFileInfo& fileInfo, bool unremove
     TrackPointer pTrack(new TrackInfoObject(fileInfo));
 
     // Check that track is a supported extension.
+    // TODO(uklotzde): The following check can be skipped if
+    // the track is already in the library. A refactoring is
+    // needed to detect this before calling addTracksAddTrack().
     if (!SoundSourceProxy::isFileSupported(fileInfo)) {
         qWarning() << "TrackDAO::addTracksAddFile:"
                 << "Unsupported file type"
@@ -688,12 +691,15 @@ TrackPointer TrackDAO::addTracksAddFile(const QFileInfo& fileInfo, bool unremove
 
     // Initially load the metadata for the newly created track
     // from the file.
+    // TODO(uklotzde): Loading of metadata can be skipped if
+    // the track is already in the library. A refactoring is
+    // needed to detect this before calling addTracksAddTrack().
     SoundSourceProxy(pTrack).loadTrackMetadata();
     if (!pTrack->getHeaderParsed()) {
         qWarning() << "TrackDAO::addTracksAddFile:"
                 << "Failed to parse track metadata from file"
                 << pTrack->getLocation();
-        // Copntinue with adding the track to the library, no matter
+        // Continue with adding the track to the library, no matter
         // if parsing the metadata from file succeeded or failed.
     }
 

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -719,6 +719,9 @@ TrackPointer TrackDAO::addSingleTrack(const QFileInfo& fileInfo, bool unremove) 
     addTracksPrepare();
     TrackPointer pTrack(addTracksAddFile(fileInfo, unremove));
     addTracksFinish(pTrack.isNull());
+    if (!pTrack.isNull()) {
+        cacheRecentTrack(pTrack->getId(), pTrack);
+    }
     return pTrack;
 }
 

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1222,8 +1222,8 @@ struct ColumnPopulator {
 #define ARRAYLENGTH(x) (sizeof(x) / sizeof(*x))
 
 void TrackDAO::cacheRecentTrack(
-    TrackId trackId,
-    const TrackPointer& pTrack) const {
+        TrackId trackId,
+        const TrackPointer& pTrack) const {
     RecentTrackCacheItem* pCacheItem = new RecentTrackCacheItem(pTrack);
     m_recentTracksCache.insert(trackId, pCacheItem);
 

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -265,8 +265,15 @@ void TrackDAO::saveTrack(TrackInfoObject* pTrack) {
 
     if (pTrack->isDirty()) {
         // Only update the database if the track has already been added!
-        if (pTrack->getId().isValid()) {
+        const TrackId trackId(pTrack->getId());
+        if (trackId.isValid()) {
             updateTrack(pTrack);
+            // BaseTrackCache must be informed separately, because the
+            // track has already been disconnected and TrackDAO does
+            // not receive any signals that are usually forwarded to
+            // BaseTrackCache.
+            DEBUG_ASSERT(!pTrack->isDirty());
+            emit(trackClean(trackId));
         }
 
         // Write audio meta data, if enabled in the preferences.

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -79,12 +79,12 @@ TrackDAO::TrackDAO(QSqlDatabase& database,
           m_libraryHashDao(libraryHashDao),
           m_pConfig(pConfig),
           m_recentTracksCache(kRecentTracksCacheSize),
-          m_pQueryTrackLocationInsert(NULL),
-          m_pQueryTrackLocationSelect(NULL),
-          m_pQueryLibraryInsert(NULL),
-          m_pQueryLibraryUpdate(NULL),
-          m_pQueryLibrarySelect(NULL),
-          m_pTransaction(NULL),
+          m_pQueryTrackLocationInsert(nullptr),
+          m_pQueryTrackLocationSelect(nullptr),
+          m_pQueryLibraryInsert(nullptr),
+          m_pQueryLibraryUpdate(nullptr),
+          m_pQueryLibrarySelect(nullptr),
+          m_pTransaction(nullptr),
           m_trackLocationIdColumn(UndefinedRecordIndex),
           m_queryLibraryIdColumn(UndefinedRecordIndex),
           m_queryLibraryMixxxDeletedColumn(UndefinedRecordIndex) {
@@ -103,7 +103,7 @@ void TrackDAO::finish() {
     while (it.hasNext()) {
         it.next();
         // Cast from TrackWeakPointer to TrackPointer. If the track still exists
-        // then pTrack will be non-NULL. If the track is dirty then save it.
+        // then pTrack will be non-nullptr. If the track is dirty then save it.
         TrackPointer pTrack = it.value();
         if (!pTrack.isNull()) {
             if (pTrack->isDirty()) {
@@ -150,7 +150,7 @@ void TrackDAO::finish() {
     // And mark the corresponding tracks in track_locations in the deleted
     // directories as deleted.
     // TODO(XXX) This doesn't handle sub-directories of deleted directories.
-    foreach (QString dir, deletedHashDirs) {
+    for (const auto& dir: deletedHashDirs) {
         markTrackLocationsAsDeleted(dir);
     }
     transaction.commit();
@@ -289,7 +289,7 @@ void TrackDAO::saveTrack(TrackInfoObject* pTrack) {
 
 void TrackDAO::slotTrackDirty(TrackInfoObject* pTrack) {
     // Should not be possible.
-    DEBUG_ASSERT_AND_HANDLE(pTrack != NULL) {
+    DEBUG_ASSERT_AND_HANDLE(pTrack != nullptr) {
         return;
     }
 
@@ -309,7 +309,7 @@ void TrackDAO::slotTrackDirty(TrackInfoObject* pTrack) {
 
 void TrackDAO::slotTrackClean(TrackInfoObject* pTrack) {
     // Should not be possible.
-    DEBUG_ASSERT_AND_HANDLE(pTrack != NULL) {
+    DEBUG_ASSERT_AND_HANDLE(pTrack != nullptr) {
         return;
     }
 
@@ -344,7 +344,7 @@ void TrackDAO::databaseTracksChanged(QSet<TrackId> tracksChanged) {
 
 void TrackDAO::slotTrackChanged(TrackInfoObject* pTrack) {
     // Should not be possible.
-    DEBUG_ASSERT_AND_HANDLE(pTrack != NULL) {
+    DEBUG_ASSERT_AND_HANDLE(pTrack != nullptr) {
         return;
     }
 
@@ -416,7 +416,7 @@ void TrackDAO::bindTrackToLibraryInsert(TrackInfoObject* pTrack, int trackLocati
     m_pQueryLibraryInsert->bindValue(":coverart_location", coverInfo.coverLocation);
     m_pQueryLibraryInsert->bindValue(":coverart_hash", coverInfo.hash);
 
-    const QByteArray* pBeatsBlob = NULL;
+    const QByteArray* pBeatsBlob = nullptr;
     QString beatsVersion = "";
     QString beatsSubVersion = "";
     BeatsPointer pBeats = pTrack->getBeats();
@@ -437,7 +437,7 @@ void TrackDAO::bindTrackToLibraryInsert(TrackInfoObject* pTrack, int trackLocati
     delete pBeatsBlob;
 
     const Keys& keys = pTrack->getKeys();
-    QByteArray* pKeysBlob = NULL;
+    QByteArray* pKeysBlob = nullptr;
     QString keysVersion = "";
     QString keysSubVersion = "";
     QString keyText = "";
@@ -523,11 +523,11 @@ void TrackDAO::addTracksFinish(bool rollback) {
     delete m_pQueryLibraryInsert;
     delete m_pQueryLibrarySelect;
     delete m_pTransaction;
-    m_pQueryTrackLocationInsert = NULL;
-    m_pQueryTrackLocationSelect = NULL;
-    m_pQueryLibraryInsert = NULL;
-    m_pQueryLibrarySelect = NULL;
-    m_pTransaction = NULL;
+    m_pQueryTrackLocationInsert = nullptr;
+    m_pQueryTrackLocationSelect = nullptr;
+    m_pQueryLibraryInsert = nullptr;
+    m_pQueryLibrarySelect = nullptr;
+    m_pTransaction = nullptr;
 
     emit(tracksAdded(m_tracksAddedSet));
     m_tracksAddedSet.clear();
@@ -651,7 +651,7 @@ TrackId TrackDAO::addTrack(const QFileInfo& fileInfo, bool unremove) {
 void TrackDAO::addTrack(TrackInfoObject* pTrack, bool unremove) {
     //qDebug() << "TrackDAO::addTrack" << QThread::currentThread() << m_database.connectionName();
     //qDebug() << "TrackCollection::addTrack(), inserting into DB";
-    // Why you be giving me NULL pTracks
+    // Why you be giving me nullptr pTracks
     DEBUG_ASSERT_AND_HANDLE(pTrack) {
         return;
     }
@@ -689,9 +689,9 @@ QList<TrackId> TrackDAO::addTracks(const QList<QFileInfo>& fileInfoList,
     query.prepare("INSERT INTO playlist_import (add_index, location) "
                   "VALUES (:add_index, :location)");
     int index = 0;
-    foreach (const QFileInfo& rFileInfo, fileInfoList) {
+    for (const auto& fileInfo: fileInfoList) {
         query.bindValue(":add_index", index);
-        query.bindValue(":location", rFileInfo.absoluteFilePath());
+        query.bindValue(":location", fileInfo.absoluteFilePath());
         if (!query.exec()) {
             LOG_FAILED_QUERY(query);
         }
@@ -929,7 +929,7 @@ void TrackDAO::purgeTracks(const QList<TrackId>& trackIds) {
 
 void TrackDAO::slotTrackReferenceExpired(TrackInfoObject* pTrack) {
     // Should not be possible.
-    DEBUG_ASSERT_AND_HANDLE(pTrack != NULL) {
+    DEBUG_ASSERT_AND_HANDLE(pTrack != nullptr) {
         return;
     }
 
@@ -1193,7 +1193,7 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
 
     ColumnPopulator columns[] = {
         // Location must be first.
-        { "track_locations.location", NULL },
+        { "track_locations.location", nullptr },
         { "artist", setTrackArtist },
         { "title", setTrackTitle },
         { "album", setTrackAlbum },
@@ -1223,24 +1223,24 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
         // Beat detection columns are handled by setTrackBeats. Do not change
         // the ordering of these columns or put other columns in between them!
         { "bpm", setTrackBeats },
-        { "beats_version", NULL },
-        { "beats_sub_version", NULL },
-        { "beats", NULL },
-        { "bpm_lock", NULL },
+        { "beats_version", nullptr },
+        { "beats_sub_version", nullptr },
+        { "beats", nullptr },
+        { "bpm_lock", nullptr },
 
         // Beat detection columns are handled by setTrackKey. Do not change the
         // ordering of these columns or put other columns in between them!
         { "key", setTrackKey },
-        { "keys_version", NULL },
-        { "keys_sub_version", NULL },
-        { "keys", NULL },
+        { "keys_version", nullptr },
+        { "keys_sub_version", nullptr },
+        { "keys", nullptr },
 
         // Cover art columns are handled by setTrackCoverInfo. Do not change the
         // ordering of these columns or put other columns in between them!
         { "coverart_source", setTrackCoverInfo },
-        { "coverart_type", NULL },
-        { "coverart_location", NULL },
-        { "coverart_hash", NULL }
+        { "coverart_type", nullptr },
+        { "coverart_location", nullptr },
+        { "coverart_hash", nullptr }
     };
 
     QString columnsStr;
@@ -1289,7 +1289,7 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
     bool shouldDirty = false;
     for (int i = 0; i < recordCount; ++i) {
         TrackPopulatorFn populator = columns[i].populator;
-        if (populator != NULL) {
+        if (populator != nullptr) {
             // If any populator says the track should be dirty then we dirty it.
             shouldDirty = (*populator)(queryRecord, i, pTrack) || shouldDirty;
         }
@@ -1387,7 +1387,7 @@ TrackPointer TrackDAO::getTrack(TrackId trackId, const bool cacheOnly) const {
     // reference to the track. We do this first so that the QCache keeps track
     // of the least-recently-used track so that it expires them intelligently.
     RecentTrackCacheItem* pRecentTrackCacheItem = m_recentTracksCache.object(trackId);
-    if (pRecentTrackCacheItem != NULL) {
+    if (pRecentTrackCacheItem != nullptr) {
         pTrack = pRecentTrackCacheItem->getTrack();
         // If the strong reference is still valid (it should be), then return
         // it.
@@ -1511,7 +1511,7 @@ void TrackDAO::updateTrack(TrackInfoObject* pTrack) {
     query.bindValue(":bpm_lock", pTrack->isBpmLocked() ? 1 : 0);
 
     BeatsPointer pBeats = pTrack->getBeats();
-    QByteArray* pBeatsBlob = NULL;
+    QByteArray* pBeatsBlob = nullptr;
     QString beatsVersion = "";
     QString beatsSubVersion = "";
     double dBpm = pTrack->getBpm();
@@ -1529,7 +1529,7 @@ void TrackDAO::updateTrack(TrackInfoObject* pTrack) {
     delete pBeatsBlob;
 
     const Keys& keys = pTrack->getKeys();
-    QByteArray* pKeysBlob = NULL;
+    QByteArray* pKeysBlob = nullptr;
     QString keysVersion = "";
     QString keysSubVersion = "";
     QString keyText = "";
@@ -1885,7 +1885,7 @@ bool TrackDAO::verifyRemainingTracks(
     while (query.next()) {
         trackLocation = query.value(locationColumn).toString();
         int fs_deleted = 0;
-        foreach(const QString dir, libraryRootDirs) {
+        for (const auto& dir: libraryRootDirs) {
             if (trackLocation.startsWith(dir)) {
                 // Track is under the library root,
                 // but was not verified.
@@ -1949,7 +1949,7 @@ void TrackDAO::detectCoverArtForUnknownTracks(volatile const bool* pCancel,
                   "INNER JOIN track_locations "
                   "ON library.location = track_locations.id "
                   // CoverInfo::Source 0 is UNKNOWN
-                  "WHERE coverart_source is NULL or coverart_source = 0 "
+                  "WHERE coverart_source IS NULL or coverart_source = 0 "
                   "ORDER BY track_locations.directory");
 
     QList<TrackWithoutCover> tracksWithoutCover;
@@ -2000,7 +2000,7 @@ void TrackDAO::detectCoverArtForUnknownTracks(volatile const bool* pCancel,
     MDir currentDirectory;
     QLinkedList<QFileInfo> possibleCovers;
 
-    foreach (const TrackWithoutCover& track, tracksWithoutCover) {
+    for (const auto& track: tracksWithoutCover) {
         if (*pCancel) {
             return;
         }
@@ -2087,12 +2087,12 @@ TrackPointer TrackDAO::getOrAddTrack(const QString& trackLocation,
     // cover processing via CoverArtCache asynchronously.
     if (processCoverArt && pTrack && !track_already_in_library) {
         CoverArtCache* pCache = CoverArtCache::instance();
-        if (pCache != NULL) {
+        if (pCache != nullptr) {
             pCache->requestGuessCover(pTrack);
         }
     }
 
-    if (pAlreadyInLibrary != NULL) {
+    if (pAlreadyInLibrary != nullptr) {
         *pAlreadyInLibrary = track_already_in_library;
     }
 

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -79,13 +79,14 @@ class LibraryHashDAO;
 // TrackPointers themselves within the QCache by holding a strong reference to
 // TrackPointer (and thereby serving it out of the weak pointer track cache) up
 // until the track has been saved to the database.
-class TrackCacheItem : public QObject {
+class RecentTrackCacheItem final : public QObject {
     Q_OBJECT
   public:
-    TrackCacheItem(TrackPointer pTrack);
-    virtual ~TrackCacheItem();
+    explicit RecentTrackCacheItem(
+            const TrackPointer& pTrack);
+    virtual ~RecentTrackCacheItem();
 
-    TrackPointer getTrack() {
+    const TrackPointer& getTrack() const {
         return m_pTrack;
     }
 
@@ -221,7 +222,7 @@ class TrackDAO : public QObject, public virtual DAO {
     // getTrack calls made by BaseSqlTableModel return null and serve stale
     // results from BaseTrackCache before the newly expired TrackPointer has
     // been saved to the database.
-    mutable QCache<TrackId, TrackCacheItem> m_recentTracksCache;
+    mutable QCache<TrackId, RecentTrackCacheItem> m_recentTracksCache;
 
     QSqlQuery* m_pQueryTrackLocationInsert;
     QSqlQuery* m_pQueryTrackLocationSelect;

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -221,6 +221,11 @@ class TrackDAO : public QObject, public virtual DAO {
     static QMutex m_sTracksMutex;
     // Weak pointer cache of active tracks.
     static QHash<TrackId, TrackWeakPointer> m_sTracks;
+
+    void cacheRecentTrack(
+            TrackId trackId,
+            const TrackPointer& pTrack) const;
+
     // "Recent tracks" cache -- holds strong references to recently used
     // tracks. When a track is expired, calls saveTrack(TrackPointer) without
     // dropping the strong reference to the track. This prevents a race

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -208,7 +208,7 @@ class TrackDAO : public QObject, public virtual DAO {
     void updateTrack(TrackInfoObject* pTrack);
 
     void bindTrackToTrackLocationsInsert(TrackInfoObject* pTrack);
-    void bindTrackToLibraryInsert(TrackInfoObject* pTrack, int trackLocationId);
+    void bindTrackToLibraryInsert(TrackInfoObject* pTrack, DbId trackLocationId);
 
     QSqlDatabase& m_database;
     CueDAO& m_cueDao;

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -125,11 +125,11 @@ class TrackDAO : public QObject, public virtual DAO {
     QSet<QString> getTrackLocations();
     QString getTrackLocation(TrackId trackId);
 
-    TrackId addSingleTrack(const QFileInfo& fileInfo, bool unremove);
+    TrackPointer addSingleTrack(const QFileInfo& fileInfo, bool unremove);
     QList<TrackId> addMultipleTracks(const QList<QFileInfo>& fileInfoList, bool unremove);
 
     void addTracksPrepare();
-    TrackId addTracksAddFile(const QFileInfo& fileInfo, bool unremove);
+    TrackPointer addTracksAddFile(const QFileInfo& fileInfo, bool unremove);
     TrackId addTracksAddTrack(const TrackPointer& pTrack, bool unremove);
     void addTracksFinish(bool rollback = false);
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -344,20 +344,8 @@ void Library::slotRequestRemoveDir(QString dir, RemovalType removalType) {
 }
 
 void Library::slotRequestRelocateDir(QString oldDir, QString newDir) {
-    // We only call this method if the user has picked a relocated directory via
-    // a file dialog. This means the system sandboxer (if we are sandboxed) has
-    // granted us permission to this folder. Create a security bookmark while we
-    // have permission so that we can access the folder on future runs. We need
-    // to canonicalize the path so we first wrap the directory string with a
-    // QDir.
-    QDir directory(newDir);
-    Sandbox::createSecurityToken(directory);
+    m_pTrackCollection->relocateDirectory(oldDir, newDir);
 
-    QSet<TrackId> movedIds = m_pTrackCollection->getDirectoryDAO().relocateDirectory(oldDir, newDir);
-
-    // Clear cache to that all TIO with the old dir information get updated
-    m_pTrackCollection->getTrackDAO().clearCache();
-    m_pTrackCollection->getTrackDAO().databaseTracksMoved(movedIds, QSet<TrackId>());
     // also update the config file if necessary so that downgrading is still
     // possible
     QString conDir = m_pConfig->getValueString(PREF_LEGACY_LIBRARY_DIR);

--- a/src/library/librarytablemodel.cpp
+++ b/src/library/librarytablemodel.cpp
@@ -56,7 +56,7 @@ int LibraryTableModel::addTracks(const QModelIndex& index,
     foreach (QString fileLocation, locations) {
         fileInfoList.append(QFileInfo(fileLocation));
     }
-    QList<TrackId> trackIds = m_trackDAO.addTracks(fileInfoList, true);
+    QList<TrackId> trackIds = m_trackDAO.addMultipleTracks(fileInfoList, true);
     select();
     return trackIds.size();
 }

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -181,7 +181,7 @@ bool MixxxLibraryFeature::dropAccept(QList<QUrl> urls, QObject* pSource) {
         QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
 
         // Adds track, does not insert duplicates, handles unremoving logic.
-        QList<TrackId> trackIds = m_trackDao.addTracks(files, true);
+        QList<TrackId> trackIds = m_trackDao.addMultipleTracks(files, true);
         return trackIds.size() > 0;
     }
 }

--- a/src/library/playlistfeature.cpp
+++ b/src/library/playlistfeature.cpp
@@ -99,7 +99,7 @@ bool PlaylistFeature::dropAcceptChild(const QModelIndex& index, QList<QUrl> urls
         // library, then add the track to the library before adding it to the
         // playlist.
         // Adds track, does not insert duplicates, handles unremoving logic.
-        trackIds = m_pTrackCollection->getTrackDAO().addTracks(files, true);
+        trackIds = m_pTrackCollection->getTrackDAO().addMultipleTracks(files, true);
     }
 
     // remove tracks that could not be added

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -92,7 +92,7 @@ int PlaylistTableModel::addTracks(const QModelIndex& index,
         }
     }
 
-    QList<TrackId> trackIds = m_trackDAO.addTracks(fileInfoList, true);
+    QList<TrackId> trackIds = m_trackDAO.addMultipleTracks(fileInfoList, true);
 
     int tracksAdded = m_playlistDao.insertTracksIntoPlaylist(
         trackIds, m_iPlaylistId, position);

--- a/src/library/scanner/importfilestask.cpp
+++ b/src/library/scanner/importfilestask.cpp
@@ -1,8 +1,6 @@
 #include "library/scanner/importfilestask.h"
 
-#include "soundsourceproxy.h"
 #include "library/scanner/libraryscanner.h"
-#include "library/coverartutils.h"
 #include "util/timer.h"
 
 ImportFilesTask::ImportFilesTask(LibraryScanner* pScanner,
@@ -24,14 +22,14 @@ ImportFilesTask::ImportFilesTask(LibraryScanner* pScanner,
 
 void ImportFilesTask::run() {
     ScopedTimer timer("ImportFilesTask::run");
-    foreach (const QFileInfo& file, m_filesToImport) {
+    for (const QFileInfo& fileInfo: m_filesToImport) {
         // If a flag was raised telling us to cancel the library scan then stop.
         if (m_scannerGlobal->shouldCancel()) {
             setSuccess(false);
             return;
         }
 
-        QString filePath = file.filePath();
+        const QString filePath(fileInfo.filePath());
         //qDebug() << "ImportFilesTask::run" << filePath;
 
         // If the file does not exist in the database then add it. If it
@@ -44,30 +42,14 @@ void ImportFilesTask::run() {
             // directory hash has changed).
             emit(trackExists(filePath));
         } else {
-            // Parse the track including cover art from metadata. This is a new
-            // (never before seen) track so it is safe to parse cover art
-            // without checking if we have cover art that is USER_SELECTED. If
-            // this changes in the future you MUST check that the cover art is
-            // not USER_SELECTED first.
-            TrackPointer pTrack(
-                new TrackInfoObject(filePath, m_pToken));
-            SoundSourceProxy(pTrack).loadTrackMetadataAndCoverArt();
-
-            // If cover art is not found in the track metadata, populate from
-            // possibleCovers.
-            // This is a new (never before seen) track so it is safe
-            // to parse cover art without checking if we have cover art
-            // that is USER_SELECTED. If this changes in the future you
-            // MUST check that the cover art is not USER_SELECTED first.
-            if (pTrack->getCoverArt().image.isNull()) {
-                CoverArt art = CoverArtUtils::selectCoverArtForTrack(
-                    pTrack.data(), m_possibleCovers);
-                if (!art.image.isNull()) {
-                    pTrack->setCoverArt(art);
-                }
+            if (!fileInfo.exists()) {
+                qWarning() << "ImportFilesTask: Skipping inaccessible file"
+                        << filePath;
+                continue;
             }
+            qDebug() << "Importing track" << filePath;
 
-            emit(addNewTrack(pTrack));
+            emit(addNewTrack(filePath));
         }
     }
     // Insert or update the hash in the database.

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -515,7 +515,8 @@ void LibraryScanner::slotAddNewTrack(TrackPointer pTrack) {
     if (m_scannerGlobal) {
         m_scannerGlobal->trackAdded(pTrack->getLocation());
     }
-    if (m_trackDao.addTracksAdd(pTrack.data(), false)) {
+    TrackId trackId(m_trackDao.addTracksAddTrack(pTrack, false));
+    if (trackId.isValid()) {
         // Successfully added. Signal the main instance of TrackDAO,
         // that there is a new track in the database.
         emit(trackAdded(pTrack));

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -515,6 +515,8 @@ void LibraryScanner::slotAddNewTrack(const QString& trackPath) {
     TrackPointer pTrack(m_trackDao.addTracksAddFile(trackPath, false));
     if (pTrack.isNull()) {
         // Acknowledge failed track addition
+        // TODO(XXX): Is it really intended to acknowledge a failed
+        // track addition with a trackAdded() signal??
         if (m_scannerGlobal) {
             m_scannerGlobal->trackAdded(trackPath);
         }

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -458,8 +458,8 @@ void LibraryScanner::queueTask(ScannerTask* pTask) {
             this, SLOT(slotDirectoryUnchanged(QString)));
     connect(pTask, SIGNAL(trackExists(QString)),
             this, SLOT(slotTrackExists(QString)));
-    connect(pTask, SIGNAL(addNewTrack(TrackPointer)),
-            this, SLOT(slotAddNewTrack(TrackPointer)));
+    connect(pTask, SIGNAL(addNewTrack(QString)),
+            this, SLOT(slotAddNewTrack(QString)));
 
     // Progress signals.
     // Pass directly to the main thread
@@ -508,22 +508,31 @@ void LibraryScanner::slotTrackExists(const QString& trackPath) {
     }
 }
 
-void LibraryScanner::slotAddNewTrack(TrackPointer pTrack) {
-    //qDebug() << "LibraryScanner::slotAddNewTrack" << pTrack;
+void LibraryScanner::slotAddNewTrack(const QString& trackPath) {
+    //qDebug() << "LibraryScanner::slotAddNewTrack" << trackPath;
     ScopedTimer timer("LibraryScanner::addNewTrack");
     // For statistics tracking and to detect moved tracks
-    if (m_scannerGlobal) {
-        m_scannerGlobal->trackAdded(pTrack->getLocation());
-    }
-    TrackId trackId(m_trackDao.addTracksAddTrack(pTrack, false));
-    if (trackId.isValid()) {
-        // Successfully added. Signal the main instance of TrackDAO,
-        // that there is a new track in the database.
-        emit(trackAdded(pTrack));
-        emit(progressLoading(pTrack->getLocation()));
-    } else {
+    TrackPointer pTrack(m_trackDao.addTracksAddFile(trackPath, false));
+    if (pTrack.isNull()) {
+        // Acknowledge failed track addition
+        if (m_scannerGlobal) {
+            m_scannerGlobal->trackAdded(trackPath);
+        }
         qWarning()
-                << "Track (" + pTrack->getLocation() + ") could not be added";
+                << "Failed to add track to library:"
+                << trackPath;
+    } else {
+        // The track's actual location might differ from the
+        // given trackPath
+        const QString trackLocation(pTrack->getLocation());
+        // Acknowledge successful track addition
+        if (m_scannerGlobal) {
+            m_scannerGlobal->trackAdded(trackLocation);
+        }
+        // Signal the main instance of TrackDAO, that there is
+        // a new track in the database.
+        emit(trackAdded(pTrack));
+        emit(progressLoading(trackLocation));
     }
 }
 

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -95,7 +95,7 @@ class LibraryScanner : public QThread {
                                    bool newDirectory, int hash);
     void slotDirectoryUnchanged(const QString& directoryPath);
     void slotTrackExists(const QString& trackPath);
-    void slotAddNewTrack(TrackPointer pTrack);
+    void slotAddNewTrack(const QString& trackPath);
 
   private:
     enum ScannerState {

--- a/src/library/scanner/scannertask.h
+++ b/src/library/scanner/scannertask.h
@@ -25,7 +25,7 @@ class ScannerTask : public QObject, public QRunnable {
                                    bool newDirectory, int hash);
     void directoryUnchanged(const QString& directoryPath);
     void trackExists(const QString& filePath);
-    void addNewTrack(TrackPointer pTrack);
+    void addNewTrack(const QString& filePath);
 
     // Feedback to GUI
     void progressLoading(const QString& fileName);

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -163,6 +163,24 @@ void TrackCollection::setTrackSource(QSharedPointer<BaseTrackCache> trackSource)
     m_defaultTrackSource = trackSource;
 }
 
+void TrackCollection::relocateDirectory(QString oldDir, QString newDir) {
+    // We only call this method if the user has picked a relocated directory via
+    // a file dialog. This means the system sandboxer (if we are sandboxed) has
+    // granted us permission to this folder. Create a security bookmark while we
+    // have permission so that we can access the folder on future runs. We need
+    // to canonicalize the path so we first wrap the directory string with a
+    // QDir.
+    QDir directory(newDir);
+    Sandbox::createSecurityToken(directory);
+
+    QSet<TrackId> movedIds(
+            m_directoryDao.relocateDirectory(oldDir, newDir));
+
+    // Clear cache to that all TIO with the old dir information get updated
+    m_trackDao.clearCache();
+    m_trackDao.databaseTracksMoved(std::move(movedIds), QSet<TrackId>());
+}
+
 #ifdef __SQLITE3__
 // from public domain code
 // http://www.archivum.info/qt-interest@trolltech.com/2008-12/00584/Re-%28Qt-interest%29-Qt-Sqlite-UserDefinedFunction.html
@@ -376,7 +394,6 @@ int TrackCollection::likeCompareInner(
     }
     return iString == stringSize;
 }
-
 
 
 /*

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -71,6 +71,8 @@ class TrackCollection : public QObject {
         return m_pConfig;
     }
 
+    void relocateDirectory(QString oldDir, QString newDir);
+
   protected:
 #ifdef __SQLITE3__
     void installSorting(QSqlDatabase &db);

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -422,10 +422,11 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
     QImage* pCoverImg = (withCoverArt && !parsedFromFile) ? &coverArt.image : nullptr;
 
     // Parse the tags stored in the audio file.
-    if (m_pSoundSource->parseTrackMetadataAndCoverArt(&trackMetadata, pCoverImg) == OK) {
+    if (!m_pSoundSource.isNull() &&
+            (m_pSoundSource->parseTrackMetadataAndCoverArt(&trackMetadata, pCoverImg) == OK)) {
         parsedFromFile = true;
     } else {
-        qWarning() << "Failed to parse metadata from file"
+        qWarning() << "Failed to parse track metadata from file"
                  << getUrl();
         if (parsedFromFile) {
             // Don't overwrite any existing metadata that once has

--- a/src/soundsourceproxy.h
+++ b/src/soundsourceproxy.h
@@ -31,8 +31,7 @@ public:
     static bool isFileNameSupported(const QString& fileName);
     static bool isFileExtensionSupported(const QString& fileExtension);
 
-    explicit SoundSourceProxy(
-            const TrackPointer& pTrack);
+    explicit SoundSourceProxy(const TrackPointer& pTrack);
 
     const TrackPointer& getTrack() const {
         return m_pTrack;

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -241,7 +241,7 @@ TEST_F(AutoDJProcessorTest, QueueEmpty) {
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();
@@ -292,7 +292,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped) {
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFails) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();
@@ -362,7 +362,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFails) {
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFailsRightDeck) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();
@@ -433,7 +433,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFailsRightDeck)
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     // Pretend a track is playing on deck 1.
@@ -473,7 +473,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1) {
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1_TrackLoadFailed) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     // Pretend a track is playing on deck 1.
@@ -529,7 +529,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1_TrackLoadFailed) {
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     // Pretend a track is playing on deck 2.
@@ -569,7 +569,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2) {
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2_TrackLoadFailed) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     // Pretend a track is playing on deck 2.
@@ -625,7 +625,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2_TrackLoadFailed) {
 }
 
 TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadSuccess) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the right.
@@ -705,7 +705,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadSuccess) {
 }
 
 TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the right.
@@ -801,7 +801,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
 }
 
 TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadSuccess) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
@@ -881,7 +881,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadSuccess) {
 }
 
 TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
@@ -978,7 +978,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
 
 
 TEST_F(AutoDJProcessorTest, FadeToDeck2_Long_Transition) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
@@ -1058,7 +1058,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_Long_Transition) {
 }
 
 TEST_F(AutoDJProcessorTest, FadeToDeck2_SeekEnd) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
@@ -1113,7 +1113,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_SeekEnd) {
 }
 
 TEST_F(AutoDJProcessorTest, TrackZeroLength) {
-    TrackId testId = collection()->getTrackDAO().addTrack(kTrackLocationTest, false);
+    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
     ASSERT_TRUE(testId.isValid());
 
     PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -192,6 +192,11 @@ class AutoDJProcessorTest : public LibraryTest {
         pTrack->setId(trackId);
     }
 
+    TrackId addTrackToCollection(const QString& trackLocation) {
+        TrackPointer pTrack(collection()->getTrackDAO().addSingleTrack(trackLocation, false));
+        return pTrack.isNull() ? TrackId() : pTrack->getId();
+    }
+
     FakeMaster master;
     FakeDeck deck1;
     FakeDeck deck2;
@@ -241,7 +246,7 @@ TEST_F(AutoDJProcessorTest, QueueEmpty) {
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();
@@ -292,7 +297,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped) {
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFails) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();
@@ -362,7 +367,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFails) {
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFailsRightDeck) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();
@@ -433,7 +438,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFailsRightDeck)
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     // Pretend a track is playing on deck 1.
@@ -473,7 +478,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1) {
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1_TrackLoadFailed) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     // Pretend a track is playing on deck 1.
@@ -529,7 +534,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1_TrackLoadFailed) {
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     // Pretend a track is playing on deck 2.
@@ -569,7 +574,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2) {
 }
 
 TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2_TrackLoadFailed) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     // Pretend a track is playing on deck 2.
@@ -625,7 +630,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2_TrackLoadFailed) {
 }
 
 TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadSuccess) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the right.
@@ -705,7 +710,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadSuccess) {
 }
 
 TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the right.
@@ -801,7 +806,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
 }
 
 TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadSuccess) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
@@ -881,7 +886,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadSuccess) {
 }
 
 TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
@@ -978,7 +983,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
 
 
 TEST_F(AutoDJProcessorTest, FadeToDeck2_Long_Transition) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
@@ -1058,7 +1063,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_Long_Transition) {
 }
 
 TEST_F(AutoDJProcessorTest, FadeToDeck2_SeekEnd) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
@@ -1113,7 +1118,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_SeekEnd) {
 }
 
 TEST_F(AutoDJProcessorTest, TrackZeroLength) {
-    TrackId testId = collection()->getTrackDAO().addSingleTrack(kTrackLocationTest, false);
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
     ASSERT_TRUE(testId.isValid());
 
     PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();

--- a/src/test/directorydoatest.cpp
+++ b/src/test/directorydoatest.cpp
@@ -9,6 +9,7 @@
 #include <QFileInfo>
 #include <QtAlgorithms>
 
+#include "soundsourceproxy.h"
 #include "preferences/usersettings.h"
 #include "library/dao/directorydao.h"
 #include "library/dao/trackdao.h"
@@ -23,6 +24,7 @@ class DirectoryDAOTest : public MixxxTest {
   protected:
     virtual void SetUp() {
         m_pTrackCollection = new TrackCollection(config());
+        m_supportedFileExt = "." % SoundSourceProxy::getSupportedFileExtensions().first();
     }
 
     virtual void TearDown() {
@@ -39,6 +41,7 @@ class DirectoryDAOTest : public MixxxTest {
     }
 
     TrackCollection* m_pTrackCollection;
+    QString m_supportedFileExt;
 };
 
 TEST_F(DirectoryDAOTest, addDirTest) {
@@ -141,14 +144,10 @@ TEST_F(DirectoryDAOTest, relocateDirTest) {
     TrackDAO &trackDAO = m_pTrackCollection->getTrackDAO();
     // ok now lets create some tracks here
     trackDAO.addTracksPrepare();
-    trackDAO.addTracksAdd(new TrackInfoObject(
-            testdir + "/a"), false);
-    trackDAO.addTracksAdd(new TrackInfoObject(
-            testdir + "/b"), false);
-    trackDAO.addTracksAdd(new TrackInfoObject(
-            test2 + "/c"), false);
-    trackDAO.addTracksAdd(new TrackInfoObject(
-            test2 + "/d"), false);
+    trackDAO.addTracksAddFile(testdir + "/a" + m_supportedFileExt, false);
+    trackDAO.addTracksAddFile(testdir + "/b" + m_supportedFileExt, false);
+    trackDAO.addTracksAddFile(test2 + "/c" + m_supportedFileExt, false);
+    trackDAO.addTracksAddFile(test2 + "/d" + m_supportedFileExt, false);
     trackDAO.addTracksFinish(false);
 
     QSet<TrackId> ids = directoryDao.relocateDirectory(testdir, testnew);


### PR DESCRIPTION
TrackDAO has too many responsibilities, a multitude of hardly testable code paths, and subtle assumptions about how various member functions are supposed to interact.

As a first attempt this PR tries to straighten the code paths when adding single/multiple tracks, which is needed for the introduction of TrackCache.
