### PR TITLE
Bug 1337505 - adjust rate slider when rateRange changes in GUI

### DIFF
--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -40,7 +40,7 @@ BpmControl::BpmControl(QString group,
             Qt::DirectConnection);
     m_pQuantize = ControlObject::getControl(group, "quantize");
     m_pRateRange = new ControlObjectSlave(group, "rateRange", this);
-    m_pRateRange->connectValueChanged(SLOT(slotAdjustRateSlider()),
+    m_pRateRange->connectValueChanged(SLOT(slotAdjustRateRange()),
             Qt::DirectConnection);
     m_pRateDir = new ControlObjectSlave(group, "rate_dir", this);
     m_pRateDir->connectValueChanged(SLOT(slotAdjustRateSlider()),
@@ -726,6 +726,13 @@ void BpmControl::slotAdjustRateSlider() {
     // Adjust playback bpm in response to a change in the rate slider.
     double dRate = 1.0 + m_pRateDir->get() * m_pRateRange->get() * m_pRateSlider->get();
     m_pEngineBpm->set(m_pLocalBpm->get() * dRate);
+}
+
+void BpmControl::slotAdjustRateRange() {
+    // Adjust rate slider position to reflect change in rate range.
+    double dRateSlider = (m_pEngineBpm->get() / m_pLocalBpm->get() - 1.0) /
+            (m_pRateDir->get() * m_pRateRange->get());
+    m_pRateSlider->set(dRateSlider);
 }
 
 void BpmControl::trackLoaded(TrackPointer pTrack) {

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -94,6 +94,7 @@ class BpmControl : public EngineControl {
     void slotTapFilter(double,int);
     void slotBpmTap(double);
     void slotAdjustRateSlider();
+    void slotAdjustRateRange();
     void slotUpdatedTrackBeats();
     void slotBeatsTranslate(double);
     void slotBeatsTranslateMatchAlignment(double);


### PR DESCRIPTION
Create separate slot in BpmControl constructor for changes to
m_pRateRange.  Use new function slotAdjustRateRange() for m_pRateRange
and retain old slotAdjustRateSlider for other rate slider components.

slotAdjustRateRange calculates the new pitch slider direction and
magnitude after the range is changed.
