### PR TITLE
Bug #1545458: Drop tracks by location instead of canonical location

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1167,7 +1167,8 @@ void WTrackTableView::dropEvent(QDropEvent * event) {
 
         QList<QString> fileLocationList;
         foreach (const QFileInfo& fileInfo, fileList) {
-            fileLocationList.append(fileInfo.canonicalFilePath());
+            // TODO(uklotzde): Replace with TrackRef::location()
+            fileLocationList.append(fileInfo.absoluteFilePath());
         }
 
         // Drag-and-drop from an external application


### PR DESCRIPTION
...to preserve symbolic links.
