### PR TITLE
VCI-100MKII: add variable beatjump, loop_move and fx super/mix knob

### DIFF
--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -54,8 +54,8 @@
         </options>
       </control>
       <control>
-        <group>[Master]</group>
-        <key>VCI102.shiftL</key>
+        <group>[Channel1]</group>
+        <key>VCI102.shift</key>
         <status>0x94</status>
         <midino>0x24</midino>
         <options>
@@ -63,8 +63,8 @@
         </options>
       </control>
       <control>
-        <group>[Master]</group>
-        <key>VCI102.shiftR</key>
+        <group>[Channel2]</group>
+        <key>VCI102.shift</key>
         <status>0x94</status>
         <midino>0x34</midino>
         <options>
@@ -649,27 +649,39 @@
       </control>
       <control>
         <group>[EffectRack1_EffectUnit1]</group>
-        <key>mix</key>
+        <key>VCI102.super_mix</key>
         <status>0xB0</status>
         <midino>0x19</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit2]</group>
-        <key>mix</key>
+        <key>VCI102.super_mix</key>
         <status>0xB1</status>
         <midino>0x1A</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit3]</group>
-        <key>mix</key>
+        <key>VCI102.super_mix</key>
         <status>0xB2</status>
         <midino>0x19</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit4]</group>
-        <key>mix</key>
+        <key>VCI102.super_mix</key>
         <status>0xB3</status>
         <midino>0x1A</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[QuickEffectRack1_[Channel1]_Effect1]</group>

--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -55,7 +55,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>VCI102.shift</key>
+        <key>VCI102.setShift</key>
         <status>0x94</status>
         <midino>0x24</midino>
         <options>
@@ -64,7 +64,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>VCI102.shift</key>
+        <key>VCI102.setShift</key>
         <status>0x94</status>
         <midino>0x34</midino>
         <options>
@@ -541,115 +541,115 @@
       </control>
       <control>
         <group>[EffectRack1_EffectUnit1_Effect1]</group>
-        <key>parameter1</key>
+        <key>VCI102.parameter1</key>
         <status>0xB0</status>
         <midino>0x16</midino>
         <options>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit2_Effect1]</group>
-        <key>parameter1</key>
+        <key>VCI102.parameter1</key>
         <status>0xB1</status>
         <midino>0x17</midino>
         <options>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit3_Effect1]</group>
-        <key>parameter1</key>
+        <key>VCI102.parameter1</key>
         <status>0xB2</status>
         <midino>0x16</midino>
         <options>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit4_Effect1]</group>
-        <key>parameter1</key>
+        <key>VCI102.parameter1</key>
         <status>0xB3</status>
         <midino>0x17</midino>
         <options>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit1_Effect1]</group>
-        <key>parameter2</key>
+        <key>VCI102.parameter2</key>
         <status>0xB0</status>
         <midino>0x17</midino>
         <options>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit2_Effect1]</group>
-        <key>parameter2</key>
+        <key>VCI102.parameter2</key>
         <status>0xB1</status>
         <midino>0x18</midino>
         <options>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit3_Effect1]</group>
-        <key>parameter2</key>
+        <key>VCI102.parameter2</key>
         <status>0xB2</status>
         <midino>0x17</midino>
         <options>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit4_Effect1]</group>
-        <key>parameter2</key>
+        <key>VCI102.parameter2</key>
         <status>0xB3</status>
         <midino>0x18</midino>
         <options>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit1_Effect1]</group>
-        <key>parameter3</key>
+        <key>VCI102.parameter3</key>
         <status>0xB0</status>
         <midino>0x18</midino>
         <options>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit2_Effect1]</group>
-        <key>parameter3</key>
+        <key>VCI102.parameter3</key>
         <status>0xB1</status>
         <midino>0x19</midino>
         <options>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit3_Effect1]</group>
-        <key>parameter3</key>
+        <key>VCI102.parameter3</key>
         <status>0xB2</status>
         <midino>0x18</midino>
         <options>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit4_Effect1]</group>
-        <key>parameter3</key>
+        <key>VCI102.parameter3</key>
         <status>0xB3</status>
         <midino>0x19</midino>
         <options>
-          <soft-takeover/>
+          <script-binding/>
         </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit1]</group>
-        <key>VCI102.super_mix</key>
+        <key>VCI102.super1</key>
         <status>0xB0</status>
         <midino>0x19</midino>
         <options>
@@ -658,7 +658,7 @@
       </control>
       <control>
         <group>[EffectRack1_EffectUnit2]</group>
-        <key>VCI102.super_mix</key>
+        <key>VCI102.super1</key>
         <status>0xB1</status>
         <midino>0x1A</midino>
         <options>
@@ -667,7 +667,7 @@
       </control>
       <control>
         <group>[EffectRack1_EffectUnit3]</group>
-        <key>VCI102.super_mix</key>
+        <key>VCI102.super1</key>
         <status>0xB2</status>
         <midino>0x19</midino>
         <options>
@@ -676,7 +676,7 @@
       </control>
       <control>
         <group>[EffectRack1_EffectUnit4]</group>
-        <key>VCI102.super_mix</key>
+        <key>VCI102.super1</key>
         <status>0xB3</status>
         <midino>0x1A</midino>
         <options>

--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -1033,7 +1033,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>VCI102.beatloop_exit</key>
+        <key>VCI102.loop</key>
         <status>0x90</status>
         <midino>0x26</midino>
         <options>
@@ -1042,7 +1042,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>VCI102.beatloop_exit</key>
+        <key>VCI102.loop</key>
         <status>0x91</status>
         <midino>0x33</midino>
         <options>
@@ -1051,7 +1051,7 @@
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>VCI102.beatloop_exit</key>
+        <key>VCI102.loop</key>
         <status>0x92</status>
         <midino>0x26</midino>
         <options>
@@ -1060,7 +1060,7 @@
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>VCI102.beatloop_exit</key>
+        <key>VCI102.loop</key>
         <status>0x93</status>
         <midino>0x33</midino>
         <options>
@@ -1069,7 +1069,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>VCI102.reloop_out</key>
+        <key>VCI102.reloop</key>
         <status>0x90</status>
         <midino>0x46</midino>
         <options>
@@ -1078,7 +1078,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>VCI102.reloop_out</key>
+        <key>VCI102.reloop</key>
         <status>0x91</status>
         <midino>0x53</midino>
         <options>
@@ -1087,7 +1087,7 @@
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>VCI102.reloop_out</key>
+        <key>VCI102.reloop</key>
         <status>0x92</status>
         <midino>0x46</midino>
         <options>
@@ -1096,7 +1096,7 @@
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>VCI102.reloop_out</key>
+        <key>VCI102.reloop</key>
         <status>0x93</status>
         <midino>0x53</midino>
         <options>
@@ -1141,27 +1141,39 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>loop_move_0.5_backward</key>
+        <key>VCI102.move_backward</key>
         <status>0x90</status>
         <midino>0x53</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>loop_move_0.5_backward</key>
+        <key>VCI102.move_backward</key>
         <status>0x91</status>
         <midino>0x49</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>loop_move_0.5_backward</key>
+        <key>VCI102.move_backward</key>
         <status>0x92</status>
         <midino>0x53</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>loop_move_0.5_backward</key>
+        <key>VCI102.move_backward</key>
         <status>0x93</status>
         <midino>0x49</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[Channel1]</group>
@@ -1201,27 +1213,39 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>loop_move_0.5_forward</key>
+        <key>VCI102.move_forward</key>
         <status>0x90</status>
         <midino>0x49</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>loop_move_0.5_forward</key>
+        <key>VCI102.move_forward</key>
         <status>0x91</status>
         <midino>0x46</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>loop_move_0.5_forward</key>
+        <key>VCI102.move_forward</key>
         <status>0x92</status>
         <midino>0x49</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>loop_move_0.5_forward</key>
+        <key>VCI102.move_forward</key>
         <status>0x93</status>
         <midino>0x46</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[Channel1]</group>

--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -3,7 +3,7 @@
   <info>
     <name>Vestax VCI-100MKII</name>
     <author>Takeshi Soejima</author>
-    <description>2016-3-1</description>
+    <description>2016-4-1</description>
     <wiki>http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii</wiki>
   </info>
   <controller id="VCI-100MKII">
@@ -781,25 +781,25 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>beats_translate_curpos</key>
+        <key>reverse</key>
         <status>0x90</status>
         <midino>0x42</midino>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>beats_translate_curpos</key>
+        <key>reverse</key>
         <status>0x91</status>
         <midino>0x42</midino>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>beats_translate_curpos</key>
+        <key>reverse</key>
         <status>0x92</status>
         <midino>0x42</midino>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>beats_translate_curpos</key>
+        <key>reverse</key>
         <status>0x93</status>
         <midino>0x42</midino>
       </control>
@@ -829,25 +829,25 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>beats_translate_earlier</key>
+        <key>beats_translate_curpos</key>
         <status>0x90</status>
         <midino>0x43</midino>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>beats_translate_earlier</key>
+        <key>beats_translate_curpos</key>
         <status>0x91</status>
         <midino>0x43</midino>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>beats_translate_earlier</key>
+        <key>beats_translate_curpos</key>
         <status>0x92</status>
         <midino>0x43</midino>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>beats_translate_earlier</key>
+        <key>beats_translate_curpos</key>
         <status>0x93</status>
         <midino>0x43</midino>
       </control>
@@ -877,25 +877,25 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>beats_translate_later</key>
+        <key>beats_translate_earlier</key>
         <status>0x90</status>
         <midino>0x4A</midino>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>beats_translate_later</key>
+        <key>beats_translate_earlier</key>
         <status>0x91</status>
         <midino>0x4A</midino>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>beats_translate_later</key>
+        <key>beats_translate_earlier</key>
         <status>0x92</status>
         <midino>0x4A</midino>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>beats_translate_later</key>
+        <key>beats_translate_earlier</key>
         <status>0x93</status>
         <midino>0x4A</midino>
       </control>
@@ -925,25 +925,25 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>beats_translate_match_alignment</key>
+        <key>beats_translate_later</key>
         <status>0x90</status>
         <midino>0x4B</midino>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>beats_translate_match_alignment</key>
+        <key>beats_translate_later</key>
         <status>0x91</status>
         <midino>0x4B</midino>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>beats_translate_match_alignment</key>
+        <key>beats_translate_later</key>
         <status>0x92</status>
         <midino>0x4B</midino>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>beats_translate_match_alignment</key>
+        <key>beats_translate_later</key>
         <status>0x93</status>
         <midino>0x4B</midino>
       </control>

--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -3,7 +3,7 @@
   <info>
     <name>Vestax VCI-100MKII</name>
     <author>Takeshi Soejima</author>
-    <description>2015-12-1</description>
+    <description>2016-3-1</description>
     <wiki>http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii</wiki>
   </info>
   <controller id="VCI-100MKII">
@@ -72,8 +72,8 @@
         </options>
       </control>
       <control>
-        <group>[Playlist]</group>
-        <key>LoadSelectedIntoFirstStopped</key>
+        <group>[Master]</group>
+        <key>maximize_library</key>
         <status>0x94</status>
         <midino>0x36</midino>
       </control>
@@ -829,25 +829,25 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>beats_translate_match_alignment</key>
+        <key>beats_translate_earlier</key>
         <status>0x90</status>
         <midino>0x43</midino>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>beats_translate_match_alignment</key>
+        <key>beats_translate_earlier</key>
         <status>0x91</status>
         <midino>0x43</midino>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>beats_translate_match_alignment</key>
+        <key>beats_translate_earlier</key>
         <status>0x92</status>
         <midino>0x43</midino>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>beats_translate_match_alignment</key>
+        <key>beats_translate_earlier</key>
         <status>0x93</status>
         <midino>0x43</midino>
       </control>
@@ -877,25 +877,25 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>beats_translate_earlier</key>
+        <key>beats_translate_later</key>
         <status>0x90</status>
         <midino>0x4A</midino>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>beats_translate_earlier</key>
+        <key>beats_translate_later</key>
         <status>0x91</status>
         <midino>0x4A</midino>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>beats_translate_earlier</key>
+        <key>beats_translate_later</key>
         <status>0x92</status>
         <midino>0x4A</midino>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>beats_translate_earlier</key>
+        <key>beats_translate_later</key>
         <status>0x93</status>
         <midino>0x4A</midino>
       </control>
@@ -925,25 +925,25 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>beats_translate_later</key>
+        <key>beats_translate_match_alignment</key>
         <status>0x90</status>
         <midino>0x4B</midino>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>beats_translate_later</key>
+        <key>beats_translate_match_alignment</key>
         <status>0x91</status>
         <midino>0x4B</midino>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>beats_translate_later</key>
+        <key>beats_translate_match_alignment</key>
         <status>0x92</status>
         <midino>0x4B</midino>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>beats_translate_later</key>
+        <key>beats_translate_match_alignment</key>
         <status>0x93</status>
         <midino>0x4B</midino>
       </control>
@@ -970,76 +970,76 @@
         <key>quantize</key>
         <status>0x93</status>
         <midino>0x24</midino>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>waveform_zoom_down</key>
-        <status>0x90</status>
-        <midino>0x44</midino>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>waveform_zoom_down</key>
-        <status>0x91</status>
-        <midino>0x44</midino>
-      </control>
-      <control>
-        <group>[Channel3]</group>
-        <key>waveform_zoom_down</key>
-        <status>0x92</status>
-        <midino>0x44</midino>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>waveform_zoom_down</key>
-        <status>0x93</status>
-        <midino>0x44</midino>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>keylock</key>
-        <status>0x90</status>
-        <midino>0x2D</midino>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>keylock</key>
-        <status>0x91</status>
-        <midino>0x2D</midino>
-      </control>
-      <control>
-        <group>[Channel3]</group>
-        <key>keylock</key>
-        <status>0x92</status>
-        <midino>0x2D</midino>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>keylock</key>
-        <status>0x93</status>
-        <midino>0x2D</midino>
       </control>
       <control>
         <group>[Channel1]</group>
         <key>waveform_zoom_up</key>
+        <status>0x90</status>
+        <midino>0x44</midino>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>waveform_zoom_up</key>
+        <status>0x91</status>
+        <midino>0x44</midino>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>waveform_zoom_up</key>
+        <status>0x92</status>
+        <midino>0x44</midino>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>waveform_zoom_up</key>
+        <status>0x93</status>
+        <midino>0x44</midino>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>keylock</key>
+        <status>0x90</status>
+        <midino>0x2D</midino>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>keylock</key>
+        <status>0x91</status>
+        <midino>0x2D</midino>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>keylock</key>
+        <status>0x92</status>
+        <midino>0x2D</midino>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>keylock</key>
+        <status>0x93</status>
+        <midino>0x2D</midino>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>waveform_zoom_down</key>
         <status>0x90</status>
         <midino>0x4D</midino>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>waveform_zoom_up</key>
+        <key>waveform_zoom_down</key>
         <status>0x91</status>
         <midino>0x4D</midino>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>waveform_zoom_up</key>
+        <key>waveform_zoom_down</key>
         <status>0x92</status>
         <midino>0x4D</midino>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>waveform_zoom_up</key>
+        <key>waveform_zoom_down</key>
         <status>0x93</status>
         <midino>0x4D</midino>
       </control>

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -176,7 +176,7 @@ VCI102.setLoopLength = function(ch, status, value) {
     midi.sendShortMsg(status, LED[ch][1], (value > 4 || value * 4 < 1) * 127);
 };
 
-VCI102.beatloop_exit = function(ch, midino, value, status, group) {
+VCI102.loop = function(ch, midino, value, status, group) {
     if (value) {
         if (engine.getValue(group, "loop_enabled")) {
             engine.setValue(group, "reloop_exit", 1);
@@ -186,9 +186,9 @@ VCI102.beatloop_exit = function(ch, midino, value, status, group) {
     }
 };
 
-VCI102.reloop_out = function(ch, midino, value, status, group) {
+VCI102.reloop = function(ch, midino, value, status, group) {
     if (engine.getValue(group, "loop_enabled")) {
-        engine.setValue(group, "loop_out", value);
+        engine.setValue(group, "loop_out", value / 127);
     } else {
         engine.setValue(group, "reloop_exit", 1);
     }
@@ -208,6 +208,31 @@ VCI102.loop_double = function(ch, midino, value, status, group) {
     } else if (value) {
         VCI102.setLoopLength(ch, status, VCI102.loopLength[ch] * 2);
     }
+};
+
+VCI102.move = function(ch, group, dir) {
+    if (dir) {
+        if (engine.getValue(group, "loop_enabled")) {
+            // move the loop by the current length
+            engine.setValue(
+                group, "loop_move", dir * (
+                    engine.getValue(group, "loop_end_position")
+                        - engine.getValue(group, "loop_start_position"))
+                    / engine.getValue(group, "track_samplerate")
+                    * engine.getValue(group, "file_bpm") / 120);
+        } else {
+            // jump by the default length
+            engine.setValue(group, "beatjump", dir * VCI102.loopLength[ch]);
+        }
+    }
+};
+
+VCI102.move_backward = function(ch, midino, value, status, group) {
+    VCI102.move(ch, group, value / -127);
+};
+
+VCI102.move_forward = function(ch, midino, value, status, group) {
+    VCI102.move(ch, group, value / 127);
 };
 
 VCI102.Deck = ["[Channel1]", "[Channel2]"];

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -1,6 +1,6 @@
 // name: Vestax VCI-100MKII
 // author: Takeshi Soejima
-// description: 2015-12-1
+// description: 2016-3-1
 // wiki: <http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii>
 
 // JSHint Configuration
@@ -264,7 +264,7 @@ VCI102.shutdown = function() {
     }
 };
 
-VCI102.init = function() {
+VCI102.init = function(id, debug) {
     var i, j, k, activate, enabled, led;
     var LED = [
         [0x2C, 0x25, 0x27, 0x28],
@@ -312,7 +312,6 @@ VCI102.init = function() {
         };
     }
 
-    VCI102.shutdown();
     for (i = 0; i < 4; i++) {
         engine.connectControl(VCI102.deck[i], "loop_enabled", VCI102.slip);
         engine.connectControl(VCI102.deck[i], "pfl", headMix);
@@ -330,8 +329,7 @@ VCI102.init = function() {
         engine.softTakeover(VCI102.fx[i], "mix", true);
     }
     for (i = 1; i <= 4; i++) {
-        activate = "hotcue_" + i + "_activate";
-        makeButton(activate);
+        makeButton(activate = "hotcue_" + i + "_activate");
         makeButton("hotcue_" + i + "_clear");
         enabled = "hotcue_" + i + "_enabled";
         for (j = 0; j < 2; j++) {


### PR DESCRIPTION
- Fixed length loop_move -> beatjump by the default length, or _in loop_ loop_move by the current loop length
- Only fx wet/dry mix -> super1, or _on shift_ mix with soft takeover
- Map super knob link setting of fx parameters
- LoadSelectedIntoFirstStopped -> maixmize_library (push selector)
- Exchange up and down of waveform_zoom (following Deere skin)
- Map brake and reverse (drop beats_translate_match_alignment)

http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii#mapping_for_mixxx_development
