### PR TITLE
Reuse TrackMetadata in TrackInfoObject

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -475,7 +475,7 @@ namespace {
         pTrackLibraryQuery->bindValue(":replaygain_peak", track.getReplayGain().getPeak());
         pTrackLibraryQuery->bindValue(":channels", track.getChannels());
 
-        pTrackLibraryQuery->bindValue(":header_parsed", track.getHeaderParsed() ? 1 : 0);
+        pTrackLibraryQuery->bindValue(":header_parsed", track.isHeaderParsed() ? 1 : 0);
 
         const PlayCounter playCounter(track.getPlayCounter());
         pTrackLibraryQuery->bindValue(":timesplayed", playCounter.getTimesPlayed());
@@ -703,7 +703,7 @@ TrackPointer TrackDAO::addTracksAddFile(const QFileInfo& fileInfo, bool unremove
     // the track is already in the library. A refactoring is
     // needed to detect this before calling addTracksAddTrack().
     SoundSourceProxy(pTrack).loadTrackMetadata();
-    if (!pTrack->getHeaderParsed()) {
+    if (!pTrack->isHeaderParsed()) {
         qWarning() << "TrackDAO::addTracksAddFile:"
                 << "Failed to parse track metadata from file"
                 << pTrack->getLocation();
@@ -1386,9 +1386,9 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
         // The metadata for the newly created track object has
         // not been parsed from the file, until we explicitly
         // (re-)load it through the SoundSourceProxy.
-        DEBUG_ASSERT(!pTempTrack->getHeaderParsed());
+        DEBUG_ASSERT(!pTempTrack->isHeaderParsed());
         proxy.loadTrackMetadata();
-        if (pTempTrack->getHeaderParsed()) {
+        if (pTempTrack->isHeaderParsed()) {
             // Copy the track total from the temporary track object
             pTrack->setTrackTotal(pTempTrack->getTrackTotal());
             // Also set the track number if it is still empty due
@@ -1457,7 +1457,7 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
     // We could (re-)load the metadata here, but this would risk to
     // overwrite the metadata that is currently stored in the library.
     // Instead prefer to log an informational warning for the user.
-    if (!pTrack->getHeaderParsed()) {
+    if (!pTrack->isHeaderParsed()) {
         qWarning() << "Metadata of the track" << pTrack->getLocation()
                 << "has never been loaded from this file."
                 << "Please consider reloading it manually if you prefer"

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -421,17 +421,28 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
         return; // do not reload from file
     }
 
-    CoverArt coverArt(m_pTrack->getCoverArt());
-
     // If parsing of the cover art image should be omitted the
     // 2nd output parameter must be set to nullptr. Cover art
     // is not reloaded from file once the metadata has been parsed!
-    QImage* pCoverImg = (withCoverArt && !parsedFromFile) ? &coverArt.image : nullptr;
+    CoverArt coverArt;
+    QImage coverImg;
+    DEBUG_ASSERT(coverImg.isNull());
+    QImage* pCoverImg = (withCoverArt && !parsedFromFile) ? &coverImg : nullptr;
+    bool parsedCoverArt = false;
 
     // Parse the tags stored in the audio file.
     if (!m_pSoundSource.isNull() &&
             (m_pSoundSource->parseTrackMetadataAndCoverArt(&trackMetadata, pCoverImg) == OK)) {
         parsedFromFile = true;
+        if (!coverImg.isNull()) {
+            // Cover image has been parsed from the file
+            coverArt.image = coverImg;
+            coverArt.info.hash = CoverArtUtils::calculateHash(coverArt.image);
+            coverArt.info.coverLocation = QString();
+            coverArt.info.type = CoverInfo::METADATA;
+            coverArt.info.source = CoverInfo::GUESSED;
+            parsedCoverArt = true;
+        }
     } else {
         qWarning() << "Failed to parse track metadata from file"
                  << getUrl();
@@ -450,7 +461,10 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
     }
 
     // Dump the trackMetadata extracted from the file back into the track.
-    m_pTrack->setTrackMetadata(trackMetadata, pCoverImg, parsedFromFile);
+    m_pTrack->setTrackMetadata(trackMetadata, parsedFromFile);
+    if (parsedCoverArt) {
+        m_pTrack->setCoverArt(coverArt);
+    }
 }
 
 Result SoundSourceProxy::parseTrackMetadata(Mixxx::TrackMetadata* pTrackMetadata) const {

--- a/src/soundsourceproxy.cpp
+++ b/src/soundsourceproxy.cpp
@@ -273,8 +273,8 @@ SoundSourceProxy::SaveTrackMetadataResult SoundSourceProxy::saveTrackMetadata(
     SoundSourceProxy proxy(pTrack);
     if (!proxy.m_pSoundSource.isNull()) {
         Mixxx::TrackMetadata trackMetadata;
-        bool parsedFromFile = pTrack->getHeaderParsed();
-        pTrack->getMetadata(&trackMetadata);
+        bool parsedFromFile = false;
+        pTrack->getTrackMetadata(&trackMetadata, &parsedFromFile);
         if (parsedFromFile || evenIfNeverParsedFromFileBefore) {
             switch (proxy.m_pSoundSource->writeTrackMetadata(trackMetadata)) {
             case OK:
@@ -407,20 +407,20 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
         return;
     }
 
-    bool parsedFromFile = m_pTrack->getHeaderParsed();
+    // Use the existing trackMetadata as default values. Otherwise
+    // existing values in the library will be overwritten with
+    // empty values if the corresponding file tags are missing.
+    // Depending on the file type some kind of tags might even
+    // not be supported at all and those would get lost!
+    bool parsedFromFile = false;
+    Mixxx::TrackMetadata trackMetadata;
+    m_pTrack->getTrackMetadata(&trackMetadata, &parsedFromFile);
     if (parsedFromFile && !reloadFromFile) {
         qDebug() << "Skip parsing of track metadata from file"
                 << getUrl();
         return; // do not reload from file
     }
 
-    // Use the existing trackMetadata as default values. Otherwise
-    // existing values in the library will be overwritten with
-    // empty values if the corresponding file tags are missing.
-    // Depending on the file type some kind of tags might even
-    // not be supported at all and those would get lost!
-    Mixxx::TrackMetadata trackMetadata;
-    m_pTrack->getMetadata(&trackMetadata);
     CoverArt coverArt(m_pTrack->getCoverArt());
 
     // If parsing of the cover art image should be omitted the
@@ -450,18 +450,7 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
     }
 
     // Dump the trackMetadata extracted from the file back into the track.
-    m_pTrack->setMetadata(trackMetadata);
-    m_pTrack->setHeaderParsed(parsedFromFile);
-    if (parsedFromFile && (nullptr != pCoverImg) && !pCoverImg->isNull()) {
-        CoverArt coverArt;
-        coverArt.image = *pCoverImg;
-        coverArt.info.hash = CoverArtUtils::calculateHash(
-                coverArt.image);
-        coverArt.info.coverLocation = QString();
-        coverArt.info.type = CoverInfo::METADATA;
-        coverArt.info.source = CoverInfo::GUESSED;
-        m_pTrack->setCoverArt(coverArt);
-    }
+    m_pTrack->setTrackMetadata(trackMetadata, pCoverImg, parsedFromFile);
 }
 
 Result SoundSourceProxy::parseTrackMetadata(Mixxx::TrackMetadata* pTrackMetadata) const {

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -111,7 +111,7 @@ void TrackInfoObject::setTrackMetadata(
         bool modified = compareAndSet(&m_bHeaderParsed, parsedFromFile);
         bool modifiedReplayGain = false;
         if (m_metadata != trackMetadata) {
-            bool modifiedReplayGain =
+            modifiedReplayGain =
                     (m_metadata.getReplayGain() != trackMetadata.getReplayGain());
             m_metadata = trackMetadata;
             modified = true;

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -371,7 +371,7 @@ void TrackInfoObject::setHeaderParsed(bool parsedFromFile) {
     }
 }
 
-bool TrackInfoObject::getHeaderParsed() const {
+bool TrackInfoObject::isHeaderParsed() const {
     QMutexLocker lock(&m_qMutex);
     return m_bHeaderParsed;
 }

--- a/src/trackinfoobject.cpp
+++ b/src/trackinfoobject.cpp
@@ -161,10 +161,12 @@ void TrackInfoObject::setTrackMetadata(
     }
 }
 
-void TrackInfoObject::getTrackMetadata(Mixxx::TrackMetadata* pTrackMetadata, bool* pParsedFromFile) const {
+void TrackInfoObject::getTrackMetadata(
+        Mixxx::TrackMetadata* pTrackMetadata,
+        bool* pHeaderParsed) const {
     QMutexLocker lock(&m_qMutex);
     *pTrackMetadata = m_metadata;
-    *pParsedFromFile = m_bHeaderParsed;
+    *pHeaderParsed = m_bHeaderParsed;
 }
 
 QString TrackInfoObject::getLocation() const {
@@ -364,9 +366,9 @@ void TrackInfoObject::slotBeatsUpdated() {
     emit(beatsUpdated());
 }
 
-void TrackInfoObject::setHeaderParsed(bool parsedFromFile) {
+void TrackInfoObject::setHeaderParsed(bool headerParsed) {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(&m_bHeaderParsed, parsedFromFile)) {
+    if (compareAndSet(&m_bHeaderParsed, headerParsed)) {
         markDirtyAndUnlock(&lock);
     }
 }

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -138,8 +138,10 @@ class TrackInfoObject : public QObject {
     // Returns ReplayGain
     Mixxx::ReplayGain getReplayGain() const;
 
-    void setHeaderParsed(bool parsed = true);
+    // Indicates if the metadata has been parsed from file tags.
     bool isHeaderParsed() const;
+    // Only used by TrackDAO!
+    void setHeaderParsed(bool headerParsed);
 
     void setDateAdded(const QDateTime& dateAdded);
     QDateTime getDateAdded() const;
@@ -262,8 +264,15 @@ class TrackInfoObject : public QObject {
 
     // Set/get track trackMetadata all at once.
     // When setting metadata the cover art image is optional and might be NULL.
-    void setTrackMetadata(const Mixxx::TrackMetadata& trackMetadata, QImage *pCoverArt, bool parsedFromFile);
-    void getTrackMetadata(Mixxx::TrackMetadata* pTrackMetadata, bool* pParsedFromFile) const;
+    // fileTimeStamp.isNull() indicates that the metadata has not
+    // been parsed from the file.
+    void setTrackMetadata(
+            const Mixxx::TrackMetadata& trackMetadata,
+            QImage *pCoverArt,
+            bool parsedFromFile);
+    void getTrackMetadata(
+            Mixxx::TrackMetadata* pTrackMetadata,
+            bool* pHeaderParsed) const;
 
     // Mark the track dirty if it isn't already.
     void markDirty();
@@ -316,7 +325,8 @@ class TrackInfoObject : public QObject {
     void setBeatsAndUnlock(QMutexLocker* pLock, BeatsPointer pBeats);
     void setKeysAndUnlock(QMutexLocker* pLock, const Keys& keys);
 
-    // Set a unique identifier for the track. Only used by TrackDAO!
+    // Set a unique identifier for the track.
+    // Only used by TrackDAO!
     void setId(TrackId id);
 
     // The file

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -259,16 +259,12 @@ class TrackInfoObject : public QObject {
     void setCoverInfo(const CoverInfo& cover);
     CoverInfo getCoverInfo() const;
 
-    void setCoverArt(const CoverArt& cover);
+    void setCoverArt(const CoverArt& coverArt);
     CoverArt getCoverArt() const;
 
-    // Set/get track trackMetadata all at once.
-    // When setting metadata the cover art image is optional and might be NULL.
-    // fileTimeStamp.isNull() indicates that the metadata has not
-    // been parsed from the file.
+    // Set/get track metadata and cover art (optional) all at once.
     void setTrackMetadata(
             const Mixxx::TrackMetadata& trackMetadata,
-            QImage *pCoverArt,
             bool parsedFromFile);
     void getTrackMetadata(
             Mixxx::TrackMetadata* pTrackMetadata,

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -139,7 +139,7 @@ class TrackInfoObject : public QObject {
     Mixxx::ReplayGain getReplayGain() const;
 
     void setHeaderParsed(bool parsed = true);
-    bool getHeaderParsed() const;
+    bool isHeaderParsed() const;
 
     void setDateAdded(const QDateTime& dateAdded);
     QDateTime getDateAdded() const;

--- a/src/trackinfoobject.h
+++ b/src/trackinfoobject.h
@@ -2,7 +2,6 @@
 #define TRACKINFOOBJECT_H
 
 #include <QAtomicInt>
-#include <QDateTime>
 #include <QFileInfo>
 #include <QList>
 #include <QMutex>
@@ -11,22 +10,18 @@
 
 #include "library/dao/cue.h"
 #include "library/coverart.h"
-#include "track/replaygain.h"
 #include "proto/keys.pb.h"
 #include "track/beats.h"
 #include "track/keys.h"
 #include "track/trackid.h"
 #include "track/playcounter.h"
+#include "track/trackmetadata.h"
 #include "util/sandbox.h"
 #include "waveform/waveform.h"
 
 class TrackInfoObject;
 typedef QSharedPointer<TrackInfoObject> TrackPointer;
 typedef QWeakPointer<TrackInfoObject> TrackWeakPointer;
-
-namespace Mixxx {
-    class TrackMetadata;
-}
 
 class TrackInfoObject : public QObject {
     Q_OBJECT
@@ -265,8 +260,10 @@ class TrackInfoObject : public QObject {
     void setCoverArt(const CoverArt& cover);
     CoverArt getCoverArt() const;
 
-    void setMetadata(const Mixxx::TrackMetadata& trackMetadata);
-    void getMetadata(Mixxx::TrackMetadata* pTrackMetadata) const;
+    // Set/get track trackMetadata all at once.
+    // When setting metadata the cover art image is optional and might be NULL.
+    void setTrackMetadata(const Mixxx::TrackMetadata& trackMetadata, QImage *pCoverArt, bool parsedFromFile);
+    void getTrackMetadata(Mixxx::TrackMetadata* pTrackMetadata, bool* pParsedFromFile) const;
 
     // Mark the track dirty if it isn't already.
     void markDirty();
@@ -319,8 +316,7 @@ class TrackInfoObject : public QObject {
     void setBeatsAndUnlock(QMutexLocker* pLock, BeatsPointer pBeats);
     void setKeysAndUnlock(QMutexLocker* pLock, const Keys& keys);
 
-    // Set a unique identifier for the track. Only used by services like
-    // TrackDAO
+    // Set a unique identifier for the track. Only used by TrackDAO!
     void setId(TrackId id);
 
     // The file
@@ -343,47 +339,18 @@ class TrackInfoObject : public QObject {
     // TrackDAO to determine whether or not to write the Track back.
     bool m_bDirty;
 
-    // Metadata
-    // Album
-    QString m_sAlbum;
-    // Artist
-    QString m_sArtist;
-    // Album Artist
-    QString m_sAlbumArtist;
-    // Title
-    QString m_sTitle;
-    // Genre
-    QString m_sGenre;
-    // Composer
-    QString m_sComposer;
-    // Grouping
-    QString m_sGrouping;
-    // Year
-    QString m_sYear;
-    // Track number/total
-    QString m_sTrackNumber;
-    QString m_sTrackTotal;
-
     // File type
     QString m_sType;
-    // User comment
-    QString m_sComment;
+
+    // Track metadata
+    Mixxx::TrackMetadata m_metadata;
+
     // URL (used in promo track)
     QString m_sURL;
-    // Duration of track in seconds
-    int m_iDuration;
-    // Sample rate
-    int m_iSampleRate;
-    // Number of channels
-    int m_iChannels;
+
     // Track rating
     int m_iRating;
-    // Bitrate, number of kilobits per second of audio in the track
-    int m_iBitrate;
-    // Replay Gain volume
-    Mixxx::ReplayGain m_replayGain;
-    // True if header was parsed
-    bool m_bHeaderParsed;
+
     // Cue point in samples or something
     float m_fCuePoint;
     // Date the track was added to the library
@@ -393,6 +360,10 @@ class TrackInfoObject : public QObject {
 
     Keys m_keys;
 
+    // Various boolean flags. Please refer to the corresponding
+    // setter/getter functions for detailed information about
+    // their usage.
+    bool m_bHeaderParsed;
     bool m_bBpmLocked;
 
     // The list of cue points for the track


### PR DESCRIPTION
Get rid of many redundant member variables in TrackInfoObject by replacing them with TrackMetadata.
