### PR TITLE
Player signals rework

### DIFF
--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -736,36 +736,28 @@ void BpmControl::slotAdjustRateSlider() {
     m_pEngineBpm->set(m_pLocalBpm->get() * dRate);
 }
 
-void BpmControl::trackLoaded(TrackPointer pTrack) {
-    if (m_pTrack) {
-        trackUnloaded(m_pTrack);
-    }
-
-    // reset for new track
-    resetSyncAdjustment();
-
-    if (pTrack) {
-        m_pTrack = pTrack;
-        m_pBeats = m_pTrack->getBeats();
-        connect(m_pTrack.data(), SIGNAL(beatsUpdated()),
-                this, SLOT(slotUpdatedTrackBeats()));
-    }
-}
-
-void BpmControl::trackUnloaded(TrackPointer pTrack) {
-    Q_UNUSED(pTrack);
+void BpmControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack);
     if (m_pTrack) {
         disconnect(m_pTrack.data(), SIGNAL(beatsUpdated()),
                    this, SLOT(slotUpdatedTrackBeats()));
+    }
+
+    // reset for a new track
+    resetSyncAdjustment();
+
+    if (pNewTrack) {
+        m_pTrack = pNewTrack;
+        m_pBeats = m_pTrack->getBeats();
+        connect(m_pTrack.data(), SIGNAL(beatsUpdated()),
+                this, SLOT(slotUpdatedTrackBeats()));
+    } else {
         m_pTrack.clear();
         m_pBeats.clear();
     }
-    m_dUserOffset = 0.0;
-    m_dLastSyncAdjustment = 1.0;
 }
 
-void BpmControl::slotUpdatedTrackBeats()
-{
+void BpmControl::slotUpdatedTrackBeats() {
     if (m_pTrack) {
         resetSyncAdjustment();
         m_pBeats = m_pTrack->getBeats();

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -642,7 +642,7 @@ double BpmControl::getPhaseOffset(double dThisPosition) {
         }
 
         double dOtherLength = ControlObject::getControl(
-            ConfigKey(pOtherEngineBuffer->getGroup(), "track_samples"))->get();
+                ConfigKey(pOtherEngineBuffer->getGroup(), "track_samples"))->get();
         double dOtherEnginePlayPos = pOtherEngineBuffer->getVisualPlayPos();
         double dOtherPosition = dOtherLength * dOtherEnginePlayPos;
 

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -77,8 +77,7 @@ class BpmControl : public EngineControl {
                                            const double& target_percentage);
 
   public slots:
-    virtual void trackLoaded(TrackPointer pTrack);
-    virtual void trackUnloaded(TrackPointer pTrack);
+    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
 
   private slots:
     void slotSetEngineBpm(double);

--- a/src/engine/clockcontrol.cpp
+++ b/src/engine/clockcontrol.cpp
@@ -18,7 +18,9 @@ ClockControl::~ClockControl() {
     delete m_pCOSampleRate;
 }
 
-void ClockControl::trackLoaded(TrackPointer pTrack) {
+void ClockControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack);
+
     // Clear on-beat control
     m_pCOBeatActive->set(0.0);
 
@@ -27,20 +29,16 @@ void ClockControl::trackLoaded(TrackPointer pTrack) {
         disconnect(m_pTrack.data(), SIGNAL(beatsUpdated()),
                    this, SLOT(slotBeatsUpdated()));
     }
-    m_pBeats.clear();
-    m_pTrack.clear();
-
-    if (pTrack) {
-        m_pTrack = pTrack;
+    if (pNewTrack) {
+        m_pTrack = pNewTrack;
         m_pBeats = m_pTrack->getBeats();
         connect(m_pTrack.data(), SIGNAL(beatsUpdated()),
                 this, SLOT(slotBeatsUpdated()));
+    } else {
+        m_pBeats.clear();
+        m_pTrack.clear();
     }
-}
 
-void ClockControl::trackUnloaded(TrackPointer pTrack) {
-    Q_UNUSED(pTrack)
-    trackLoaded(TrackPointer());
 }
 
 void ClockControl::slotBeatsUpdated() {

--- a/src/engine/clockcontrol.h
+++ b/src/engine/clockcontrol.h
@@ -22,8 +22,7 @@ class ClockControl: public EngineControl {
                    const double totalSamples, const int iBufferSize);
 
   public slots:
-    virtual void trackLoaded(TrackPointer pTrack);
-    virtual void trackUnloaded(TrackPointer pTrack);
+    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
     void slotBeatsUpdated();
 
   private:

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -183,22 +183,55 @@ void CueControl::detachCue(int hotCue) {
     pControl->getEnabled()->set(0);
 }
 
-void CueControl::trackLoaded(TrackPointer pTrack) {
+void CueControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack);
     QMutexLocker lock(&m_mutex);
-    if (m_pLoadedTrack)
-        trackUnloaded(m_pLoadedTrack);
 
-    if (!pTrack) {
+    if (m_pLoadedTrack) {
+        disconnect(m_pLoadedTrack.data(), 0, this, 0);
+        for (int i = 0; i < m_iNumHotCues; ++i) {
+            detachCue(i);
+        }
+
+        // Store the cue point in a load cue.
+        double cuePoint = m_pCuePoint->get();
+
+        if (cuePoint != -1 && cuePoint != 0.0) {
+            CuePointer loadCue;
+            const QList<CuePointer> cuePoints(m_pLoadedTrack->getCuePoints());
+            QListIterator<CuePointer> it(cuePoints);
+            while (it.hasNext()) {
+                CuePointer pCue(it.next());
+                if (pCue->getType() == Cue::LOAD) {
+                    loadCue = pCue;
+                    break;
+                }
+            }
+            if (!loadCue) {
+                loadCue = m_pLoadedTrack->addCue();
+                loadCue->setType(Cue::LOAD);
+                loadCue->setLength(0);
+            }
+            loadCue->setPosition(cuePoint);
+        }
+
+        m_pCueIndicator->setBlinkValue(ControlIndicator::OFF);
+        m_pCuePoint->set(-1.0);
+        m_pLoadedTrack.clear();
+    }
+
+
+    if (pNewTrack.isNull()) {
         return;
     }
 
-    m_pLoadedTrack = pTrack;
-    connect(pTrack.data(), SIGNAL(cuesUpdated()),
+    m_pLoadedTrack = pNewTrack;
+    connect(pNewTrack.data(), SIGNAL(cuesUpdated()),
             this, SLOT(trackCuesUpdated()),
             Qt::DirectConnection);
 
     CuePointer loadCue;
-    const QList<CuePointer> cuePoints(pTrack->getCuePoints());
+    const QList<CuePointer> cuePoints(pNewTrack->getCuePoints());
     QListIterator<CuePointer> it(cuePoints);
     while (it.hasNext()) {
         CuePointer pCue(it.next());
@@ -240,40 +273,6 @@ void CueControl::trackLoaded(TrackPointer pTrack) {
         // load tracks and have the needle-drop be maintained.
         seekExact(0.0);
     }
-}
-
-void CueControl::trackUnloaded(TrackPointer pTrack) {
-    QMutexLocker lock(&m_mutex);
-    disconnect(pTrack.data(), 0, this, 0);
-    for (int i = 0; i < m_iNumHotCues; ++i) {
-        detachCue(i);
-    }
-
-    // Store the cue point in a load cue.
-    double cuePoint = m_pCuePoint->get();
-
-    if (cuePoint != -1 && cuePoint != 0.0) {
-        CuePointer loadCue;
-        const QList<CuePointer> cuePoints(pTrack->getCuePoints());
-        QListIterator<CuePointer> it(cuePoints);
-        while (it.hasNext()) {
-            CuePointer pCue(it.next());
-            if (pCue->getType() == Cue::LOAD) {
-                loadCue = pCue;
-                break;
-            }
-        }
-        if (!loadCue) {
-            loadCue = pTrack->addCue();
-            loadCue->setType(Cue::LOAD);
-            loadCue->setLength(0);
-        }
-        loadCue->setPosition(cuePoint);
-    }
-
-    m_pCueIndicator->setBlinkValue(ControlIndicator::OFF);
-    m_pCuePoint->set(-1.0);
-    m_pLoadedTrack.clear();
 }
 
 void CueControl::cueUpdated() {

--- a/src/engine/cuecontrol.h
+++ b/src/engine/cuecontrol.h
@@ -94,8 +94,7 @@ class CueControl : public EngineControl {
     bool getPlayFlashingAtPause();
 
   public slots:
-    void trackLoaded(TrackPointer pTrack);
-    void trackUnloaded(TrackPointer pTrack);
+    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
 
   private slots:
     void cueUpdated();

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1305,7 +1305,7 @@ void EngineBuffer::hintReader(const double dRate) {
 }
 
 // WARNING: This method runs in the GUI thread
-void EngineBuffer::slotLoadTrack(TrackPointer pTrack, bool play) {
+void EngineBuffer::loadTrack(TrackPointer pTrack, bool play) {
     // Signal to the reader to load the track. The reader will respond with
     // trackLoading and then either with trackLoaded or trackLoadFailed signals.
     m_bPlayAfterLoading = play;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -510,7 +510,7 @@ TrackPointer EngineBuffer::loadFakeTrack(double filebpm) {
     }
     slotTrackLoaded(pTrack, 44100, 44100 * 10);
     m_pSyncControl->setLocalBpm(filebpm);
-    m_pSyncControl->trackLoaded(pTrack);
+    m_pSyncControl->trackLoaded(pTrack, TrackPointer());
     return pTrack;
 }
 
@@ -519,6 +519,8 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
                                    int iTrackSampleRate,
                                    int iTrackNumSamples) {
     //qDebug() << getGroup() << "EngineBuffer::slotTrackLoaded";
+    TrackPointer pOldTrack = m_pCurrentTrack;
+
     m_pause.lock();
     m_visualPlayPos->setInvalid();
     m_pCurrentTrack = pTrack;
@@ -536,7 +538,7 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
     m_pause.unlock();
 
     // All EngineControls are connected directly
-    emit(trackLoaded(pTrack));
+    emit(trackLoaded(pTrack, pOldTrack));
     // Start buffer processing after all EngineContols are up to date
     // with the current track e.g track is seeked to Cue
     m_iTrackLoading = 0;
@@ -571,7 +573,7 @@ void EngineBuffer::ejectTrack() {
     m_pause.unlock();
 
     if (pTrack) {
-        emit(trackUnloaded(pTrack));
+        emit(trackLoaded(TrackPointer(), pTrack));
     }
 }
 
@@ -1314,11 +1316,8 @@ void EngineBuffer::addControl(EngineControl* pControl) {
     // Connect to signals from EngineControl here...
     m_engineControls.push_back(pControl);
     pControl->setEngineBuffer(this);
-    connect(this, SIGNAL(trackLoaded(TrackPointer)),
-            pControl, SLOT(trackLoaded(TrackPointer)),
-            Qt::DirectConnection);
-    connect(this, SIGNAL(trackUnloaded(TrackPointer)),
-            pControl, SLOT(trackUnloaded(TrackPointer)),
+    connect(this, SIGNAL(trackLoaded(TrackPointer, TrackPointer)),
+            pControl, SLOT(trackLoaded(TrackPointer, TrackPointer)),
             Qt::DirectConnection);
 }
 

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -194,9 +194,8 @@ class EngineBuffer : public EngineObject {
     void slotEjectTrack(double);
 
   signals:
-    void trackLoaded(TrackPointer pTrack);
+    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void trackLoadFailed(TrackPointer pTrack, QString reason);
-    void trackUnloaded(TrackPointer pTrack);
 
   private slots:
     void slotTrackLoading();

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -173,6 +173,11 @@ class EngineBuffer : public EngineObject {
         }
     }
 
+    // Request that the EngineBuffer load a track. Since the process is
+    // asynchronous, EngineBuffer will emit a trackLoaded signal when the load
+    // has completed.
+    void loadTrack(TrackPointer pTrack, bool play);
+
   public slots:
     void slotControlPlayRequest(double);
     void slotControlPlayFromStart(double);
@@ -185,11 +190,6 @@ class EngineBuffer : public EngineObject {
     void slotControlSeekExact(double);
     void slotControlSlip(double);
     void slotKeylockEngineChanged(double);
-
-    // Request that the EngineBuffer load a track. Since the process is
-    // asynchronous, EngineBuffer will emit a trackLoaded signal when the load
-    // has completed.
-    void slotLoadTrack(TrackPointer pTrack, bool play);
 
     void slotEjectTrack(double);
 

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -189,7 +189,7 @@ class EngineBuffer : public EngineObject {
     // Request that the EngineBuffer load a track. Since the process is
     // asynchronous, EngineBuffer will emit a trackLoaded signal when the load
     // has completed.
-    void slotLoadTrack(TrackPointer pTrack, bool play = false);
+    void slotLoadTrack(TrackPointer pTrack, bool play);
 
     void slotEjectTrack(double);
 

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -40,10 +40,9 @@ double EngineControl::getTrigger(const double,
     return kNoTrigger;
 }
 
-void EngineControl::trackLoaded(TrackPointer) {
-}
-
-void EngineControl::trackUnloaded(TrackPointer) {
+void EngineControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pNewTrack);
+    Q_UNUSED(pOldTrack);
 }
 
 void EngineControl::hintReader(HintVector*) {

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -81,8 +81,7 @@ class EngineControl : public QObject {
     virtual void notifySeek(double dNewPlaypo);
 
   public slots:
-    virtual void trackLoaded(TrackPointer pTrack);
-    virtual void trackUnloaded(TrackPointer pTrack);
+    virtual void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
   protected:
     void seek(double fractionalPosition);

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -607,30 +607,24 @@ void LoopingControl::setLoopingEnabled(bool enabled) {
     }
 }
 
-void LoopingControl::trackLoaded(TrackPointer pTrack) {
-    if (m_pTrack) {
-        trackUnloaded(m_pTrack);
-    }
-
-    clearActiveBeatLoop();
-
-    if (pTrack) {
-        m_pTrack = pTrack;
-        m_pBeats = m_pTrack->getBeats();
-        connect(m_pTrack.data(), SIGNAL(beatsUpdated()),
-                this, SLOT(slotUpdatedTrackBeats()));
-    }
-}
-
-void LoopingControl::trackUnloaded(TrackPointer pTrack) {
-    Q_UNUSED(pTrack);
+void LoopingControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack);
     if (m_pTrack) {
         disconnect(m_pTrack.data(), SIGNAL(beatsUpdated()),
                    this, SLOT(slotUpdatedTrackBeats()));
     }
-    m_pTrack.clear();
-    m_pBeats.clear();
+
     clearActiveBeatLoop();
+
+    if (pNewTrack) {
+        m_pTrack = pNewTrack;
+        m_pBeats = m_pTrack->getBeats();
+        connect(m_pTrack.data(), SIGNAL(beatsUpdated()),
+                this, SLOT(slotUpdatedTrackBeats()));
+    } else {
+        m_pTrack.clear();
+        m_pBeats.clear();
+    }
 }
 
 void LoopingControl::slotUpdatedTrackBeats()

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -64,8 +64,7 @@ class LoopingControl : public EngineControl {
     void slotReloopExit(double);
     void slotLoopStartPos(double);
     void slotLoopEndPos(double);
-    virtual void trackLoaded(TrackPointer pTrack);
-    virtual void trackUnloaded(TrackPointer pTrack);
+    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
     void slotUpdatedTrackBeats();
 
     // Generate a loop of 'beats' length. It can also do fractions for a

--- a/src/engine/quantizecontrol.h
+++ b/src/engine/quantizecontrol.h
@@ -22,8 +22,7 @@ class QuantizeControl : public EngineControl {
                                   const double dTotalSamples);
 
   public slots:
-    virtual void trackLoaded(TrackPointer pTrack);
-    virtual void trackUnloaded(TrackPointer pTrack);
+    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
 
   private slots:
     void slotBeatsUpdated();

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -372,16 +372,9 @@ void RateControl::slotControlRateTempUpSmall(double)
     }
 }
 
-void RateControl::trackLoaded(TrackPointer pTrack) {
-    if (m_pTrack) {
-        trackUnloaded(m_pTrack);
-    }
-    m_pTrack = pTrack;
-}
-
-void RateControl::trackUnloaded(TrackPointer pTrack) {
-    Q_UNUSED(pTrack);
-    m_pTrack.clear();
+void RateControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack);
+    m_pTrack = pNewTrack;
 }
 
 double RateControl::calcRateRatio() const {

--- a/src/engine/ratecontrol.h
+++ b/src/engine/ratecontrol.h
@@ -75,8 +75,7 @@ public:
     void slotControlRateTempUpSmall(double);
     void slotControlFastForward(double);
     void slotControlFastBack(double);
-    virtual void trackLoaded(TrackPointer pTrack);
-    virtual void trackUnloaded(TrackPointer pTrack);
+    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
 
   private:
     double getJogFactor() const;

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -308,6 +308,7 @@ void SyncControl::reportTrackPosition(double fractionalPlaypos) {
 }
 
 void SyncControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack);
     //qDebug() << getGroup() << "SyncControl::trackLoaded";
     if (getSyncMode() == SYNC_MASTER) {
         // If we change or remove a new track while master, hand off.

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -307,34 +307,26 @@ void SyncControl::reportTrackPosition(double fractionalPlaypos) {
     }
 }
 
-void SyncControl::trackLoaded(TrackPointer pTrack) {
+void SyncControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     //qDebug() << getGroup() << "SyncControl::trackLoaded";
-    Q_UNUSED(pTrack);
-    m_masterBpmAdjustFactor = kBpmUnity;
     if (getSyncMode() == SYNC_MASTER) {
-        // If we loaded a new track while master, hand off.
+        // If we change or remove a new track while master, hand off.
         m_pChannel->getEngineBuffer()->requestSyncMode(SYNC_NONE);
     }
-
-    if (getSyncMode() != SYNC_NONE) {
-        // Because of the order signals get processed, the file/local_bpm COs and
-        // rate slider are not updated as soon as we need them, so do that now.
-        m_pFileBpm->set(pTrack->getBpm());
-        m_pLocalBpm->set(pTrack->getBpm());
-        double dRate = calcRateRatio();
-        // We used to set the m_pBpm here, but that causes a signal loop whereby
-        // that was interpretted as a rate slider tweak, and the master bpm
-        // was changed.  Instead, now we pass the suggested bpm to enginesync
-        // explicitly, and it can decide what to do with it.
-        m_pEngineSync->notifyTrackLoaded(this, m_pLocalBpm->get() * dRate);
-    }
-}
-
-void SyncControl::trackUnloaded(TrackPointer pTrack) {
-    Q_UNUSED(pTrack);
-    if (getSyncMode() == SYNC_MASTER) {
-        // If we unloaded a new track while master, hand off.
-        m_pChannel->getEngineBuffer()->requestSyncMode(SYNC_NONE);
+    if (!pNewTrack.isNull()) {
+        m_masterBpmAdjustFactor = kBpmUnity;
+        if (getSyncMode() != SYNC_NONE) {
+            // Because of the order signals get processed, the file/local_bpm COs and
+            // rate slider are not updated as soon as we need them, so do that now.
+            m_pFileBpm->set(pNewTrack->getBpm());
+            m_pLocalBpm->set(pNewTrack->getBpm());
+            double dRate = calcRateRatio();
+            // We used to set the m_pBpm here, but that causes a signal loop whereby
+            // that was interpretted as a rate slider tweak, and the master bpm
+            // was changed.  Instead, now we pass the suggested bpm to enginesync
+            // explicitly, and it can decide what to do with it.
+            m_pEngineSync->notifyTrackLoaded(this, m_pLocalBpm->get() * dRate);
+        }
     }
 }
 

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -59,8 +59,7 @@ class SyncControl : public EngineControl, public Syncable {
     void reportPlayerSpeed(double speed, bool scratching);
 
   public slots:
-    virtual void trackLoaded(TrackPointer pTrack);
-    virtual void trackUnloaded(TrackPointer pTrack);
+    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
 
   private slots:
     // Fired by changes in play.

--- a/src/engine/vinylcontrolcontrol.cpp
+++ b/src/engine/vinylcontrolcontrol.cpp
@@ -62,13 +62,9 @@ VinylControlControl::~VinylControlControl() {
     delete m_pControlVinylStatus;
 }
 
-void VinylControlControl::trackLoaded(TrackPointer pTrack) {
-    m_pCurrentTrack = pTrack;
-}
-
-void VinylControlControl::trackUnloaded(TrackPointer pTrack) {
-    Q_UNUSED(pTrack);
-    m_pCurrentTrack.clear();
+void VinylControlControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack);
+    m_pCurrentTrack = pNewTrack;
 }
 
 void VinylControlControl::notifySeekQueued() {

--- a/src/engine/vinylcontrolcontrol.h
+++ b/src/engine/vinylcontrolcontrol.h
@@ -14,9 +14,6 @@ class VinylControlControl : public EngineControl {
     VinylControlControl(QString group, UserSettingsPointer pConfig);
     virtual ~VinylControlControl();
 
-    void trackLoaded(TrackPointer pTrack);
-    void trackUnloaded(TrackPointer pTrack);
-
     // If the engine asks for a seek, we may need to disable absolute mode.
     void notifySeekQueued();
     bool isEnabled();
@@ -24,6 +21,7 @@ class VinylControlControl : public EngineControl {
 
   private slots:
     void slotControlVinylSeek(double fractionalPos);
+    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
 
   private:
     ControlObject* m_pControlVinylRate;

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -27,10 +27,10 @@ DeckAttributes::DeckAttributes(int index,
           m_pPlayer(pPlayer) {
     connect(m_pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
             this, SLOT(slotTrackLoaded(TrackPointer)));
-    connect(m_pPlayer, SIGNAL(loadTrackFailed(TrackPointer)),
-            this, SLOT(slotTrackLoadFailed(TrackPointer)));
-    connect(m_pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
-            this, SLOT(slotTrackUnloaded(TrackPointer)));
+    connect(m_pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
+            this, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
+    connect(m_pPlayer, SIGNAL(playerEmpty()),
+            this, SLOT(slotPlayerEmpty()));
     m_playPos.connectValueChanged(this, SLOT(slotPlayPosChanged(double)));
     m_play.connectValueChanged(this, SLOT(slotPlayChanged(double)));
 }
@@ -50,12 +50,13 @@ void DeckAttributes::slotTrackLoaded(TrackPointer pTrack) {
     emit(trackLoaded(this, pTrack));
 }
 
-void DeckAttributes::slotTrackLoadFailed(TrackPointer pTrack) {
-    emit(trackLoadFailed(this, pTrack));
+void DeckAttributes::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    //qDebug() << "DeckAttributes::slotLoadingTrack";
+    emit(loadingTrack(this, pNewTrack, pOldTrack));
 }
 
-void DeckAttributes::slotTrackUnloaded(TrackPointer pTrack) {
-    emit(trackUnloaded(this, pTrack));
+void DeckAttributes::slotPlayerEmpty() {
+    emit(playerEmpty(this));
 }
 
 TrackPointer DeckAttributes::getLoadedTrack() const {
@@ -298,16 +299,15 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         connect(&rightDeck, SIGNAL(trackLoaded(DeckAttributes*, TrackPointer)),
                 this, SLOT(playerTrackLoaded(DeckAttributes*, TrackPointer)));
 
-        connect(&leftDeck, SIGNAL(trackUnloaded(DeckAttributes*, TrackPointer)),
-                this, SLOT(playerTrackUnloaded(DeckAttributes*, TrackPointer)));
-        connect(&rightDeck, SIGNAL(trackUnloaded(DeckAttributes*, TrackPointer)),
-                this, SLOT(playerTrackUnloaded(DeckAttributes*, TrackPointer)));
+        connect(&leftDeck, SIGNAL(loadingTrack(DeckAttributes*, TrackPointer, TrackPointer)),
+                this, SLOT(playerLoadingTrack(DeckAttributes*, TrackPointer, TrackPointer)));
+        connect(&rightDeck, SIGNAL(loadingTrack(DeckAttributes*, TrackPointer, TrackPointer)),
+                this, SLOT(playerLoadingTrack(DeckAttributes*, TrackPointer, TrackPointer)));
 
-        connect(&leftDeck, SIGNAL(trackLoadFailed(DeckAttributes*, TrackPointer)),
-                this, SLOT(playerTrackLoadFailed(DeckAttributes*, TrackPointer)));
-        connect(&rightDeck, SIGNAL(trackLoadFailed(DeckAttributes*, TrackPointer)),
-                this, SLOT(playerTrackLoadFailed(DeckAttributes*, TrackPointer)));
-
+        connect(&leftDeck, SIGNAL(playerEmpty(DeckAttributes*)),
+                this, SLOT(playerEmpty(DeckAttributes*)));
+        connect(&rightDeck, SIGNAL(playerEmpty(DeckAttributes*)),
+                this, SLOT(playerEmpty(DeckAttributes*)));
 
         if (!deck1Playing && !deck2Playing) {
             // Both decks are stopped. Load a track into deck 1 and start it
@@ -766,11 +766,15 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
     }
 }
 
-void AutoDJProcessor::playerTrackLoadFailed(DeckAttributes* pDeck, TrackPointer pTrack) {
+void AutoDJProcessor::playerLoadingTrack(DeckAttributes* pDeck,
+        TrackPointer pNewTrack, TrackPointer pOldTrack) {
     if (sDebug) {
-        qDebug() << this << "playerTrackLoadFailed" << pDeck->group
-                 << (pTrack.isNull() ? "(null)" : pTrack->getLocation());
+        qDebug() << this << "playerLoadingTrack" << pDeck->group
+                 << "new:"<< (pNewTrack.isNull() ? "(null)" : pNewTrack->getLocation())
+                 << "old:"<< (pOldTrack.isNull() ? "(null)" : pOldTrack->getLocation());
     }
+
+    // The Deck is loading an new track
 
     // There are four conditions under which we load a track.
     // 1) We are enabling AutoDJ and no decks are playing. Mode is
@@ -779,24 +783,32 @@ void AutoDJProcessor::playerTrackLoadFailed(DeckAttributes* pDeck, TrackPointer 
     // 3) We are enabling AutoDJ and a single deck is playing. Mode is ADJ_IDLE.
     // 4) We have just completed fading from one deck to another. Mode is
     //    ADJ_IDLE.
-    // In all of these cases, it should be safe to skip the bad track in the
-    // queue and re-request a track load for the next track. The only case where
+
+    if (pNewTrack.isNull()) {
+        // If a track is ejected because of a manual eject command or a load failure
+        // this track seams to be undesired. Remove the bad track from the queue.
+        removeTrackFromTopOfQueue(pOldTrack);
+
+        // wait until the track is fully unloaded and the playerEmpty()
+        // slot is called before load an alternative track.
+    }
+}
+
+void AutoDJProcessor::playerEmpty(DeckAttributes* pDeck) {
+    if (sDebug) {
+        qDebug() << this << "playerEmpty()" << pDeck->group;
+    }
+
+    // The Deck has ejected a track and no new one is loaded 
+    // This happens if loading fails or the user manually ejected the track
+    // and would normally stopp the AutoDJ flow, which is not desired.
+    // It should be safe to load a load a new track from the queue. The only case where
     // we request a load-and-play is case #1 currently so we can easily test for
     // this based on the mode.
-
-    // Remove the bad track from the queue.
-    removeTrackFromTopOfQueue(pTrack);
 
     // Load the next track. If we are the first AutoDJ track
     // (ADJ_ENABLE_P1LOADED state) then play the track.
     loadNextTrackFromQueue(*pDeck, m_eState == ADJ_ENABLE_P1LOADED);
-}
-
-void AutoDJProcessor::playerTrackUnloaded(DeckAttributes* pDeck, TrackPointer pTrack) {
-    if (sDebug) {
-        qDebug() << this << "playerTrackUnloaded" << pDeck->group
-                 << (pTrack.isNull() ? "(null)" : pTrack->getLocation());
-    }
 }
 
 void AutoDJProcessor::setTransitionTime(int time) {

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -64,18 +64,18 @@ class DeckAttributes : public QObject {
     TrackPointer getLoadedTrack() const;
 
   signals:
-    void playChanged(DeckAttributes* deck, bool playing);
-    void playPositionChanged(DeckAttributes* deck, double playPosition);
-    void trackLoaded(DeckAttributes* deck, TrackPointer pTrack);
-    void trackLoadFailed(DeckAttributes* deck, TrackPointer pTrack);
-    void trackUnloaded(DeckAttributes* deck, TrackPointer pTrack);
+    void playChanged(DeckAttributes* pDeck, bool playing);
+    void playPositionChanged(DeckAttributes* pDeck, double playPosition);
+    void trackLoaded(DeckAttributes* pDeck, TrackPointer pTrack);
+    void loadingTrack(DeckAttributes* pDeck, TrackPointer pNewTrack, TrackPointer pOldTrack);
+    void playerEmpty(DeckAttributes* pDeck);
 
   private slots:
     void slotPlayPosChanged(double v);
     void slotPlayChanged(double v);
     void slotTrackLoaded(TrackPointer pTrack);
-    void slotTrackLoadFailed(TrackPointer pTrack);
-    void slotTrackUnloaded(TrackPointer pTrack);
+    void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
+    void slotPlayerEmpty();
 
   public:
     int index;
@@ -159,8 +159,8 @@ class AutoDJProcessor : public QObject {
     void playerPositionChanged(DeckAttributes* pDeck, double position);
     void playerPlayChanged(DeckAttributes* pDeck, bool playing);
     void playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTrack);
-    void playerTrackLoadFailed(DeckAttributes* pDeck, TrackPointer pTrack);
-    void playerTrackUnloaded(DeckAttributes* pDeck, TrackPointer pTrack);
+    void playerLoadingTrack(DeckAttributes* pDeck, TrackPointer pNewTrack, TrackPointer pOldTrack);
+    void playerEmpty(DeckAttributes* pDeck);
 
     void controlEnable(double value);
     void controlFadeNow(double value);

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -67,12 +67,10 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
     // let us request that the reader load a track.
     connect(this, SIGNAL(loadTrack(TrackPointer, bool)),
             pEngineBuffer, SLOT(slotLoadTrack(TrackPointer, bool)));
-    connect(pEngineBuffer, SIGNAL(trackLoaded(TrackPointer)),
-            this, SLOT(slotFinishLoading(TrackPointer)));
+    connect(pEngineBuffer, SIGNAL(trackLoaded(TrackPointer, TrackPointer)),
+            this, SLOT(slotTrackLoaded(TrackPointer, TrackPointer)));
     connect(pEngineBuffer, SIGNAL(trackLoadFailed(TrackPointer, QString)),
             this, SLOT(slotLoadFailed(TrackPointer, QString)));
-    connect(pEngineBuffer, SIGNAL(trackUnloaded(TrackPointer)),
-            this, SLOT(slotUnloadTrack(TrackPointer)));
 
     // Get loop point control objects
     m_pLoopInPoint = new ControlObjectSlave(
@@ -128,7 +126,7 @@ void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer track, bool bPlay) {
         return;
     }
 
-    //Disconnect the old track's signals.
+    // Disconnect the old track's signals.
     if (m_pLoadedTrack) {
         // Save the loops that are currently set in a loop cue. If no loop cue is
         // currently on the track, then create a new one.
@@ -198,115 +196,113 @@ void BaseTrackPlayerImpl::slotLoadFailed(TrackPointer track, QString reason) {
     QMessageBox::warning(NULL, tr("Couldn't load track."), reason);
 }
 
-void BaseTrackPlayerImpl::slotUnloadTrack(TrackPointer) {
-    if (m_pLoadedTrack) {
-        // WARNING: Never. Ever. call bare disconnect() on an object. Mixxx
-        // relies on signals and slots to get tons of things done. Don't
-        // randomly disconnect things.
-        // m_pLoadedTrack->disconnect();
-        disconnect(m_pLoadedTrack.data(), 0, m_pBPM, 0);
-        disconnect(m_pLoadedTrack.data(), 0, this, 0);
-        disconnect(m_pLoadedTrack.data(), 0, m_pKey, 0);
-
-        // Causes the track's data to be saved back to the library database and
-        // for all the widgets to unload the track and blank themselves.
-        emit(unloadingTrack(m_pLoadedTrack));
-    }
+void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
+                                          TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack);
     m_replaygainPending = false;
-    m_pDuration->set(0);
-    m_pBPM->set(0);
-    m_pKey->set(0);
-    m_pReplayGain->set(0);
-    m_pLoopInPoint->set(-1);
-    m_pLoopOutPoint->set(-1);
-    m_pLoadedTrack.clear();
-
-    // Update the PlayerInfo class that is used in EngineShoutcast to replace
-    // the metadata of a stream
-    PlayerInfo::instance().setTrackInfo(getGroup(), m_pLoadedTrack);
-}
-
-void BaseTrackPlayerImpl::slotFinishLoading(TrackPointer pTrackInfoObject) {
-    DEBUG_ASSERT(m_pLoadedTrack == pTrackInfoObject);
-    m_replaygainPending = false;
-
-    // Reload metadata from file, but only if required
-    SoundSourceProxy(m_pLoadedTrack).loadTrackMetadata();
-
-    // m_pLoadedTrack->setPlayedAndUpdatePlayCount(); // Actually the song is loaded but not played
-
-    // Update the BPM and duration values that are stored in ControlObjects
-    m_pDuration->set(m_pLoadedTrack->getDuration());
-    m_pBPM->set(m_pLoadedTrack->getBpm());
-    m_pKey->set(m_pLoadedTrack->getKey());
-    m_pReplayGain->set(m_pLoadedTrack->getReplayGain().getRatio());
-
-    // Update the PlayerInfo class that is used in EngineShoutcast to replace
-    // the metadata of a stream
-    PlayerInfo::instance().setTrackInfo(getGroup(), m_pLoadedTrack);
 
     // Reset the loop points.
     m_pLoopInPoint->set(-1);
     m_pLoopOutPoint->set(-1);
 
-    const QList<CuePointer> trackCues(pTrackInfoObject->getCuePoints());
-    QListIterator<CuePointer> it(trackCues);
-    while (it.hasNext()) {
-        CuePointer pCue(it.next());
-        if (pCue->getType() == Cue::LOOP) {
-            int loopStart = pCue->getPosition();
-            int loopEnd = loopStart + pCue->getLength();
-            if (loopStart != -1 && loopEnd != -1 && even(loopStart) && even(loopEnd)) {
-                m_pLoopInPoint->set(loopStart);
-                m_pLoopOutPoint->set(loopEnd);
-                break;
+    if (pNewTrack.isNull()) {
+        // Unload track 
+        if (m_pLoadedTrack) {
+            // WARNING: Never. Ever. call bare disconnect() on an object. Mixxx
+            // relies on signals and slots to get tons of things done. Don't
+            // randomly disconnect things.
+            // m_pLoadedTrack->disconnect();
+            disconnect(m_pLoadedTrack.data(), 0, m_pBPM, 0);
+            disconnect(m_pLoadedTrack.data(), 0, this, 0);
+            disconnect(m_pLoadedTrack.data(), 0, m_pKey, 0);
+
+            // Causes the track's data to be saved back to the library database and
+            // for all the widgets to unload the track and blank themselves.
+            emit(unloadingTrack(m_pLoadedTrack));
+        }
+        m_pDuration->set(0);
+        m_pBPM->set(0);
+        m_pKey->set(0);
+        m_pReplayGain->set(0);
+        m_pLoopInPoint->set(-1);
+        m_pLoopOutPoint->set(-1);
+        m_pLoadedTrack.clear();
+    } else {
+        DEBUG_ASSERT(m_pLoadedTrack == pNewTrack);
+
+        // Reload metadata from file, but only if required
+        SoundSourceProxy(m_pLoadedTrack).loadTrackMetadata();
+
+        // m_pLoadedTrack->setPlayedAndUpdatePlayCount(); // Actually the song is loaded but not played
+
+        // Update the BPM and duration values that are stored in ControlObjects
+        m_pDuration->set(m_pLoadedTrack->getDuration());
+        m_pBPM->set(m_pLoadedTrack->getBpm());
+        m_pKey->set(m_pLoadedTrack->getKey());
+        m_pReplayGain->set(m_pLoadedTrack->getReplayGain().getRatio());
+
+        const QList<CuePointer> trackCues(pNewTrack->getCuePoints());
+        QListIterator<CuePointer> it(trackCues);
+        while (it.hasNext()) {
+            CuePointer pCue(it.next());
+            if (pCue->getType() == Cue::LOOP) {
+                int loopStart = pCue->getPosition();
+                int loopEnd = loopStart + pCue->getLength();
+                if (loopStart != -1 && loopEnd != -1 && even(loopStart) && even(loopEnd)) {
+                    m_pLoopInPoint->set(loopStart);
+                    m_pLoopOutPoint->set(loopEnd);
+                    break;
+                }
             }
         }
+        if(m_pConfig->getValueString(ConfigKey("[Mixer Profile]", "EqAutoReset"), 0).toInt()) {
+            if (m_pLowFilter != NULL) {
+                m_pLowFilter->set(1.0);
+            }
+            if (m_pMidFilter != NULL) {
+                m_pMidFilter->set(1.0);
+            }
+            if (m_pHighFilter != NULL) {
+                m_pHighFilter->set(1.0);
+            }
+            if (m_pLowFilterKill != NULL) {
+                m_pLowFilterKill->set(0.0);
+            }
+            if (m_pMidFilterKill != NULL) {
+                m_pMidFilterKill->set(0.0);
+            }
+            if (m_pHighFilterKill != NULL) {
+                m_pHighFilterKill->set(0.0);
+            }
+            m_pPreGain->set(1.0);
+        }
+        int reset = m_pConfig->getValueString(ConfigKey(
+                "[Controls]", "SpeedAutoReset"),
+                QString("%1").arg(RESET_PITCH)).toInt();
+        switch (reset) {
+          case RESET_PITCH_AND_SPEED:
+            // Note: speed may affect pitch
+            if (m_pRateSlider != NULL) {
+                m_pRateSlider->set(0.0);
+            }
+            // Fallthrough intended
+          case RESET_PITCH:
+            if (m_pPitchAdjust != NULL) {
+                m_pPitchAdjust->set(0.0);
+            }
+            break;
+          case RESET_SPEED:
+            // Note: speed may affect pitch
+            if (m_pRateSlider != NULL) {
+                m_pRateSlider->set(0.0);
+            }
+            break;
+        }
+        emit(newTrackLoaded(m_pLoadedTrack));
     }
-    if(m_pConfig->getValueString(ConfigKey("[Mixer Profile]", "EqAutoReset"), 0).toInt()) {
-        if (m_pLowFilter != NULL) {
-            m_pLowFilter->set(1.0);
-        }
-        if (m_pMidFilter != NULL) {
-            m_pMidFilter->set(1.0);
-        }
-        if (m_pHighFilter != NULL) {
-            m_pHighFilter->set(1.0);
-        }
-        if (m_pLowFilterKill != NULL) {
-            m_pLowFilterKill->set(0.0);
-        }
-        if (m_pMidFilterKill != NULL) {
-            m_pMidFilterKill->set(0.0);
-        }
-        if (m_pHighFilterKill != NULL) {
-            m_pHighFilterKill->set(0.0);
-        }
-        m_pPreGain->set(1.0);
-    }
-    int reset = m_pConfig->getValueString(ConfigKey(
-            "[Controls]", "SpeedAutoReset"),
-            QString("%1").arg(RESET_PITCH)).toInt();
-    switch (reset) {
-      case RESET_PITCH_AND_SPEED:
-        // Note: speed may affect pitch
-        if (m_pRateSlider != NULL) {
-            m_pRateSlider->set(0.0);
-        }
-        // Fallthrough intended
-      case RESET_PITCH:
-        if (m_pPitchAdjust != NULL) {
-            m_pPitchAdjust->set(0.0);
-        }
-        break;
-      case RESET_SPEED:
-        // Note: speed may affect pitch
-        if (m_pRateSlider != NULL) {
-            m_pRateSlider->set(0.0);
-        }
-        break;
-    }
-    emit(newTrackLoaded(m_pLoadedTrack));
+    // Update the PlayerInfo class that is used in EngineShoutcast to replace
+    // the metadata of a stream
+    PlayerInfo::instance().setTrackInfo(getGroup(), m_pLoadedTrack);
 }
 
 TrackPointer BaseTrackPlayerImpl::getLoadedTrack() const {

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -179,7 +179,7 @@ void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer track, bool bPlay) {
                 this, SLOT(slotSetReplayGain(Mixxx::ReplayGain)));
     }
 
-    // Request a new track from the reader
+    // Request a new track from EngineBuffer
     emit(loadTrack(track, bPlay));
 }
 

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -65,8 +65,6 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
     // Connect our signals and slots with the EngineBuffer's signals and
     // slots. This will let us know when the reader is done loading a track, and
     // let us request that the reader load a track.
-    connect(this, SIGNAL(loadTrack(TrackPointer, bool)),
-            pEngineBuffer, SLOT(slotLoadTrack(TrackPointer, bool)));
     connect(pEngineBuffer, SIGNAL(trackLoaded(TrackPointer, TrackPointer)),
             this, SLOT(slotTrackLoaded(TrackPointer, TrackPointer)));
     connect(pEngineBuffer, SIGNAL(trackLoadFailed(TrackPointer, QString)),
@@ -180,7 +178,8 @@ void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer track, bool bPlay) {
     }
 
     // Request a new track from EngineBuffer
-    emit(loadTrack(track, bPlay));
+    EngineBuffer* pEngineBuffer = m_pChannel->getEngineBuffer();
+    pEngineBuffer->loadTrack(track, bPlay);
 }
 
 void BaseTrackPlayerImpl::slotLoadFailed(TrackPointer track, QString reason) {

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -68,7 +68,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     void setupEqControls();
 
   public slots:
-    void slotLoadTrack(TrackPointer track, bool bPlay=false);
+    void slotLoadTrack(TrackPointer track, bool bPlay) override;
     void slotTrackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void slotLoadFailed(TrackPointer pTrackInfoObject, QString reason);
     void slotSetReplayGain(Mixxx::ReplayGain replayGain);

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -38,10 +38,9 @@ class BaseTrackPlayer : public BasePlayer {
     virtual void slotLoadTrack(TrackPointer pTrack, bool bPlay=false) = 0;
 
   signals:
-    void loadTrack(TrackPointer pTrack, bool bPlay=false);
-    void loadTrackFailed(TrackPointer pTrack);
     void newTrackLoaded(TrackPointer pLoadedTrack);
-    void unloadingTrack(TrackPointer pAboutToBeUnloaded);
+    void loadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
+    void playerEmpty();
     void noPassthroughInputConfigured();
     void noVinylControlInputConfigured();
 };
@@ -79,6 +78,8 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     void slotVinylControlEnabled(double v);
 
   private:
+    void setReplayGain(double value);
+
     UserSettingsPointer m_pConfig;
     TrackPointer m_pLoadedTrack;
 

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -69,9 +69,8 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
 
   public slots:
     void slotLoadTrack(TrackPointer track, bool bPlay=false);
-    void slotFinishLoading(TrackPointer pTrackInfoObject);
+    void slotTrackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void slotLoadFailed(TrackPointer pTrackInfoObject, QString reason);
-    void slotUnloadTrack(TrackPointer track);
     void slotSetReplayGain(Mixxx::ReplayGain replayGain);
     void slotPlayToggled(double);
 

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -22,6 +22,7 @@
 #include "trackinfoobject.h"
 #include "util/assert.h"
 #include "util/stat.h"
+#include "util/sleepableqthread.h"
 
 PlayerManager::PlayerManager(UserSettingsPointer pConfig,
                              SoundManager* pSoundManager,
@@ -571,6 +572,9 @@ void PlayerManager::slotLoadTrackIntoNextAvailableDeck(TrackPointer pTrack) {
         if (playControl && playControl->get() != 1.) {
             locker.unlock();
             pDeck->slotLoadTrack(pTrack, false);
+            // Test for a fixed race condition with fast loads
+            //SleepableQThread::sleep(1);
+            //pDeck->slotLoadTrack(TrackPointer(), false);
             return;
         }
         ++it;

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -904,17 +904,14 @@ QWidget* LegacySkinParser::parseOverview(QDomElement node) {
     overviewWidget->Init();
 
     // Connect the player's load and unload signals to the overview widget.
-    connect(pPlayer, SIGNAL(loadTrack(TrackPointer)),
-            overviewWidget, SLOT(slotLoadNewTrack(TrackPointer)));
     connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
             overviewWidget, SLOT(slotTrackLoaded(TrackPointer)));
-    connect(pPlayer, SIGNAL(loadTrackFailed(TrackPointer)),
-            overviewWidget, SLOT(slotUnloadTrack(TrackPointer)));
-    connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
-            overviewWidget, SLOT(slotUnloadTrack(TrackPointer)));
+    connect(pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
+            overviewWidget, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
 
-    //just in case track already loaded
-    overviewWidget->slotLoadNewTrack(pPlayer->getLoadedTrack());
+    // just in case track already loaded
+    overviewWidget->slotLoadingTrack(pPlayer->getLoadedTrack(), TrackPointer());
+    overviewWidget->slotTrackLoaded(pPlayer->getLoadedTrack());
 
     return overviewWidget;
 }
@@ -943,15 +940,15 @@ QWidget* LegacySkinParser::parseVisual(QDomElement node) {
 
     // connect display with loading/unloading of tracks
     QObject::connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
-                     viewer, SLOT(onTrackLoaded(TrackPointer)));
-    QObject::connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
-                     viewer, SLOT(onTrackUnloaded(TrackPointer)));
+                     viewer, SLOT(slotTrackLoaded(TrackPointer)));
+    QObject::connect(pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
+                     viewer, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
 
     connect(viewer, SIGNAL(trackDropped(QString, QString)),
             m_pPlayerManager, SLOT(slotLoadToPlayer(QString, QString)));
 
     // if any already loaded
-    viewer->onTrackLoaded(pPlayer->getLoadedTrack());
+    viewer->slotTrackLoaded(pPlayer->getLoadedTrack());
 
     return viewer;
 }
@@ -970,8 +967,8 @@ QWidget* LegacySkinParser::parseText(QDomElement node) {
 
     connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
             p, SLOT(slotTrackLoaded(TrackPointer)));
-    connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
-            p, SLOT(slotTrackUnloaded(TrackPointer)));
+    connect(pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
+            p, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
     connect(p, SIGNAL(trackDropped(QString,QString)),
             m_pPlayerManager, SLOT(slotLoadToPlayer(QString,QString)));
 
@@ -997,8 +994,8 @@ QWidget* LegacySkinParser::parseTrackProperty(QDomElement node) {
 
     connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
             p, SLOT(slotTrackLoaded(TrackPointer)));
-    connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
-            p, SLOT(slotTrackUnloaded(TrackPointer)));
+    connect(pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
+            p, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
     connect(p, SIGNAL(trackDropped(QString,QString)),
             m_pPlayerManager, SLOT(slotLoadToPlayer(QString,QString)));
 
@@ -1025,8 +1022,8 @@ QWidget* LegacySkinParser::parseStarRating(QDomElement node) {
 
     connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
             p, SLOT(slotTrackLoaded(TrackPointer)));
-    connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
-            p, SLOT(slotTrackUnloaded(TrackPointer)));
+    connect(pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
+            p, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
 
     TrackPointer pTrack = pPlayer->getLoadedTrack();
     if (pTrack) {
@@ -1107,8 +1104,8 @@ QWidget* LegacySkinParser::parseSpinny(QDomElement node) {
     if (pPlayer != NULL) {
         connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
                 spinny, SLOT(slotLoadTrack(TrackPointer)));
-        connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
-                spinny, SLOT(slotReset()));
+        connect(pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
+                spinny, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
         // just in case a track is already loaded
         spinny->slotLoadTrack(pPlayer->getLoadedTrack());
     }
@@ -1158,8 +1155,8 @@ QWidget* LegacySkinParser::parseCoverArt(QDomElement node) {
     } else if (pPlayer != NULL) {
         connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
                 pCoverArt, SLOT(slotLoadTrack(TrackPointer)));
-        connect(pPlayer, SIGNAL(unloadingTrack(TrackPointer)),
-                pCoverArt, SLOT(slotReset()));
+        connect(pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
+                pCoverArt, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
         connect(pCoverArt, SIGNAL(trackDropped(QString, QString)),
                 m_pPlayerManager, SLOT(slotLoadToPlayer(QString, QString)));
 

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -54,13 +54,13 @@ class FakeDeck : public BaseTrackPlayer {
         // of controls (play, track_samples, track_samplerate, playposition,
         // etc.).
         fakeUnloadingTrackEvent(pTrack);
-        emit(loadTrackFailed(pTrack));
     }
 
     void fakeUnloadingTrackEvent(TrackPointer pTrack) {
         play.set(0.0);
-        emit(unloadingTrack(pTrack));
+        emit(loadingTrack(TrackPointer(), pTrack));
         loadedTrack.clear();
+        emit(playerEmpty());
     }
 
     TrackPointer getLoadedTrack() const {

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -72,7 +72,7 @@ class FakeDeck : public BaseTrackPlayer {
     // a success or failure signal. To simulate a load success, call
     // fakeTrackLoadedEvent. To simulate a failure, call
     // fakeTrackLoadFailedEvent.
-    void slotLoadTrack(TrackPointer pTrack, bool bPlay) {
+    void slotLoadTrack(TrackPointer pTrack, bool bPlay) override {
         loadedTrack = pTrack;
         play.set(bPlay);
     }

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -99,7 +99,7 @@ class SignalPathTest : public MixxxTest {
     void loadTrack(EngineDeck* pDeck, QString path) {
         const QString kTrackLocationTest(path);
         TrackPointer pTrack(TrackInfoObject::newTemporary(kTrackLocationTest));
-        pDeck->getEngineBuffer()->slotLoadTrack(pTrack, true);
+        pDeck->getEngineBuffer()->loadTrack(pTrack, true);
 
         // Wait for the track to load.
         ProcessBuffer();

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -104,8 +104,13 @@ void WCoverArt::slotEnable(bool enable) {
     if (wasDisabled) {
         slotLoadTrack(m_loadedTrack);
     }
-
     update();
+}
+
+void WCoverArt::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pNewTrack);
+    Q_UNUSED(pOldTrack);
+    slotReset();
 }
 
 void WCoverArt::slotReset() {

--- a/src/widget/wcoverart.h
+++ b/src/widget/wcoverart.h
@@ -26,6 +26,7 @@ class WCoverArt : public QWidget, public WBaseWidget {
 
   public slots:
     void slotLoadTrack(TrackPointer);
+    void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void slotReset();
     void slotEnable(bool);
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -42,12 +42,12 @@ WOverview::WOverview(const char *pGroup, UserSettingsPointer pConfig, QWidget* p
         m_diffGain(0),
         m_group(pGroup),
         m_pConfig(pConfig),
-        m_endOfTrack(0),
+        m_endOfTrack(false),
         m_bDrag(false),
         m_iPos(0),
         m_a(1.0),
         m_b(0.0),
-        m_dAnalyzerProgress(-1.0),
+        m_dAnalyzerProgress(1.0),
         m_bAnalyzerFinalizing(false),
         m_trackLoaded(false) {
     m_endOfTrackControl = new ControlObjectSlave(
@@ -187,9 +187,16 @@ void WOverview::slotAnalyzerProgress(int progress) {
     }
 }
 
-void WOverview::slotLoadNewTrack(TrackPointer pTrack) {
-    // qDebug() << "WOverview::slotLoadNewTrack(TrackPointer pTrack)";
-    if (m_pCurrentTrack) {
+void WOverview::slotTrackLoaded(TrackPointer pTrack) {
+    if (m_pCurrentTrack == pTrack) {
+        m_trackLoaded = true;
+        update();
+    }
+}
+
+void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    qDebug() << "WOverview::slotLoadingTrack" << pNewTrack << pOldTrack;
+    if (m_pCurrentTrack != NULL && pOldTrack == m_pCurrentTrack) {
         disconnect(m_pCurrentTrack.data(), SIGNAL(waveformSummaryUpdated()),
                    this, SLOT(slotWaveformSummaryUpdated()));
         disconnect(m_pCurrentTrack.data(), SIGNAL(analyzerProgress(int)),
@@ -201,55 +208,33 @@ void WOverview::slotLoadNewTrack(TrackPointer pTrack) {
         m_pWaveformSourceImage = NULL;
     }
 
-    m_dAnalyzerProgress = -1;
+    m_dAnalyzerProgress = 1.0;
     m_actualCompletion = 0;
     m_waveformPeak = -1.0;
     m_pixmapDone = false;
     m_trackLoaded = false;
+    m_endOfTrack = false;
 
-    if (pTrack) {
-        m_pCurrentTrack = pTrack;
-        m_pWaveform = pTrack->getWaveformSummary();
+    if (pNewTrack) {
+        m_pCurrentTrack = pNewTrack;
+        m_pWaveform = pNewTrack->getWaveformSummary();
 
-        connect(pTrack.data(), SIGNAL(waveformSummaryUpdated()),
+        connect(pNewTrack.data(), SIGNAL(waveformSummaryUpdated()),
                 this, SLOT(slotWaveformSummaryUpdated()));
-        connect(pTrack.data(), SIGNAL(analyzerProgress(int)),
+        connect(pNewTrack.data(), SIGNAL(analyzerProgress(int)),
                 this, SLOT(slotAnalyzerProgress(int)));
 
-        slotAnalyzerProgress(pTrack->getAnalyzerProgress());
-    }
-}
-
-void WOverview::slotTrackLoaded(TrackPointer pTrack) {
-    if (m_pCurrentTrack == pTrack) {
-        m_trackLoaded = true;
-        update();
-    }
-}
-
-void WOverview::slotUnloadTrack(TrackPointer pTrack) {
-    // it may happen that this call is a delayed call
-    // of a track that was already replaced
-    //qDebug() << "WOverview::slotUnloadTrack(TrackPointer pTrack)";
-    if (pTrack != NULL && pTrack == m_pCurrentTrack) {
-        disconnect(m_pCurrentTrack.data(), SIGNAL(waveformSummaryUpdated()),
-                   this, SLOT(slotWaveformSummaryUpdated()));
-        disconnect(m_pCurrentTrack.data(), SIGNAL(analyzerProgress(int)),
-                   this, SLOT(slotAnalyzerProgress(int)));
-
+        slotAnalyzerProgress(pNewTrack->getAnalyzerProgress());
+    } else {
         m_pCurrentTrack.clear();
         m_pWaveform.clear();
-        m_actualCompletion = 0;
-        m_waveformPeak = -1.0;
-        m_pixmapDone = false;
-        m_trackLoaded = false;
-        update();
     }
+    update();
 }
 
 void WOverview::onEndOfTrackChange(double v) {
     //qDebug() << "WOverview::onEndOfTrackChange()" << v;
-    m_endOfTrack = v > 0.5;
+    m_endOfTrack = v > 0.0;
     update();
 }
 
@@ -285,6 +270,7 @@ void WOverview::mousePressEvent(QMouseEvent* e) {
 }
 
 void WOverview::paintEvent(QPaintEvent *) {
+    //qDebug() << "WOverview::paintEvent";
     ScopedTimer t("WOverview::paintEvent");
 
     QPainter painter(this);
@@ -293,25 +279,25 @@ void WOverview::paintEvent(QPaintEvent *) {
         painter.drawPixmap(rect(), m_backgroundPixmap);
     }
 
-    //Display viewer contour if end of track
-    if (m_endOfTrack) {
-        painter.setOpacity(0.8);
-        painter.setPen(QPen(QBrush(m_endOfTrackColor),1.5));
-        painter.setBrush(QColor(0,0,0,0));
-        painter.drawRect(rect().adjusted(0,0,-1,-1));
-        painter.setOpacity(0.3);
-        painter.setBrush(m_endOfTrackColor);
-        painter.drawRect(rect().adjusted(1,1,-2,-2));
-        painter.setOpacity(1);
-    }
+    if (m_pCurrentTrack) {
+        // Display viewer contour if end of track
+        if (m_endOfTrack) {
+            painter.setOpacity(0.8);
+            painter.setPen(QPen(QBrush(m_endOfTrackColor),1.5));
+            painter.setBrush(QColor(0,0,0,0));
+            painter.drawRect(rect().adjusted(0,0,-1,-1));
+            painter.setOpacity(0.3);
+            painter.setBrush(m_endOfTrackColor);
+            painter.drawRect(rect().adjusted(1,1,-2,-2));
+            painter.setOpacity(1);
+        }
 
-    //Draw waveform pixmap
-    WaveformWidgetFactory* widgetFactory = WaveformWidgetFactory::instance();
-    if (m_pWaveform) {
         // Draw Axis
         painter.setPen(QPen(m_signalColors.getAxesColor(), 1));
         painter.drawLine(0, height()/2, width(), height()/2);
 
+        // Draw waveform pixmap
+        WaveformWidgetFactory* widgetFactory = WaveformWidgetFactory::instance();
         if (m_pWaveformSourceImage) {
             int diffGain;
             bool normalize = widgetFactory->isOverviewNormalized();
@@ -333,11 +319,11 @@ void WOverview::paintEvent(QPaintEvent *) {
             painter.drawImage(rect(), m_waveformImageScaled);
         }
 
-        if (m_dAnalyzerProgress != 1.0) {
+        if (m_dAnalyzerProgress < 1.0) {
             // Paint analyzer Progress
             painter.setPen(QPen(m_signalColors.getAxesColor(), 3));
-            painter.drawLine(m_dAnalyzerProgress * width(), height()/2,
-                             width(), height()/2);
+            painter.drawLine(m_dAnalyzerProgress * width(), height() / 2,
+                             width(), height() / 2);
         }
 
         if (m_dAnalyzerProgress <= 0.5) { // remove text after progress by wf is recognizable
@@ -352,114 +338,115 @@ void WOverview::paintEvent(QPaintEvent *) {
             //: Text on waveform overview during finalizing of waveform analysis
             paintText(tr("Finalizing .."), &painter);
         }
-    }
 
-    double trackSamples = m_trackSamplesControl->get();
-    if (trackSamples > 0) {
-        const float offset = 1.0f;
-        const float gain = (float)(width()-2) / trackSamples;
+        double trackSamples = m_trackSamplesControl->get();
+        if (m_trackLoaded && trackSamples > 0) {
+            //qDebug() << "WOverview::paintEvent trackSamples > 0";
+            const float offset = 1.0f;
+            const float gain = (float)(width()-2) / trackSamples;
 
-        // Draw range (loop)
-        for (unsigned int i = 0; i < m_markRanges.size(); ++i) {
-            WaveformMarkRange& currentMarkRange = m_markRanges[i];
+            // Draw range (loop)
+            for (unsigned int i = 0; i < m_markRanges.size(); ++i) {
+                WaveformMarkRange& currentMarkRange = m_markRanges[i];
 
-            // If the mark range is not active we should not draw it.
-            if (!currentMarkRange.active()) {
-                continue;
+                // If the mark range is not active we should not draw it.
+                if (!currentMarkRange.active()) {
+                    continue;
+                }
+
+                // Active mark ranges by definition have starts/ends that are not
+                // disabled.
+                const double startValue = currentMarkRange.start();
+                const double endValue = currentMarkRange.end();
+
+                const float startPosition = offset + startValue * gain;
+                const float endPosition = offset + endValue * gain;
+
+                if (startPosition < 0.0 && endPosition < 0.0) {
+                    continue;
+                }
+
+                if (currentMarkRange.enabled()) {
+                    painter.setOpacity(0.4);
+                    painter.setPen(currentMarkRange.m_activeColor);
+                    painter.setBrush(currentMarkRange.m_activeColor);
+                } else {
+                    painter.setOpacity(0.2);
+                    painter.setPen(currentMarkRange.m_disabledColor);
+                    painter.setBrush(currentMarkRange.m_disabledColor);
+                }
+
+                // let top and bottom of the rect out of the widget
+                painter.drawRect(QRectF(QPointF(startPosition, -2.0),
+                                        QPointF(endPosition,height() + 1.0)));
             }
 
-            // Active mark ranges by definition have starts/ends that are not
-            // disabled.
-            const double startValue = currentMarkRange.start();
-            const double endValue = currentMarkRange.end();
+            // Draw markers (Cue & hotcues)
+            QPen shadowPen(QBrush(m_qColorBackground), 2.5);
 
-            const float startPosition = offset + startValue * gain;
-            const float endPosition = offset + endValue * gain;
+            QFont markerFont = painter.font();
+            markerFont.setPixelSize(10);
 
-            if (startPosition < 0.0 && endPosition < 0.0) {
-                continue;
-            }
+            QFont shadowFont = painter.font();
+            shadowFont.setWeight(99);
+            shadowFont.setPixelSize(10);
 
-            if (currentMarkRange.enabled()) {
-                painter.setOpacity(0.4);
-                painter.setPen(currentMarkRange.m_activeColor);
-                painter.setBrush(currentMarkRange.m_activeColor);
-            } else {
-                painter.setOpacity(0.2);
-                painter.setPen(currentMarkRange.m_disabledColor);
-                painter.setBrush(currentMarkRange.m_disabledColor);
-            }
+            painter.setOpacity(0.9);
 
-            //let top and bottom of the rect out of the widget
-            painter.drawRect(QRectF(QPointF(startPosition, -2.0),
-                                    QPointF(endPosition,height() + 1.0)));
-        }
+            for (int i = 0; i < m_marks.size(); ++i) {
+                WaveformMark& currentMark = m_marks[i];
+                if (currentMark.m_pPointCos && currentMark.m_pPointCos->get() >= 0.0) {
+                    //const float markPosition = 1.0 +
+                    //        (currentMark.m_pointControl->get() / (float)m_trackSamplesControl->get()) * (float)(width()-2);
+                    const float markPosition = offset + currentMark.m_pPointCos->get() * gain;
 
-        //Draw markers (Cue & hotcues)
-        QPen shadowPen(QBrush(m_qColorBackground), 2.5);
-
-        QFont markerFont = painter.font();
-        markerFont.setPixelSize(10);
-
-        QFont shadowFont = painter.font();
-        shadowFont.setWeight(99);
-        shadowFont.setPixelSize(10);
-
-        painter.setOpacity(0.9);
-
-        for (int i = 0; i < m_marks.size(); ++i) {
-            WaveformMark& currentMark = m_marks[i];
-            if (currentMark.m_pPointCos && currentMark.m_pPointCos->get() >= 0.0) {
-                //const float markPosition = 1.0 +
-                //        (currentMark.m_pointControl->get() / (float)m_trackSamplesControl->get()) * (float)(width()-2);
-                const float markPosition = offset + currentMark.m_pPointCos->get() * gain;
-
-                const QLineF line(markPosition, 0.0, markPosition, (float)height());
-                painter.setPen(shadowPen);
-                painter.drawLine(line);
-
-                painter.setPen(currentMark.m_color);
-                painter.drawLine(line);
-
-                if (!currentMark.m_text.isEmpty()) {
-                    QPointF textPoint;
-                    textPoint.setX(markPosition+0.5f);
-
-                    if (currentMark.m_align == Qt::AlignTop) {
-                        QFontMetricsF metric(markerFont);
-                        textPoint.setY(metric.tightBoundingRect(currentMark.m_text).height()+0.5f);
-                    } else {
-                        textPoint.setY(float(height())-0.5f);
-                    }
-
+                    const QLineF line(markPosition, 0.0, markPosition, (float)height());
                     painter.setPen(shadowPen);
-                    painter.setFont(shadowFont);
-                    painter.drawText(textPoint,currentMark.m_text);
+                    painter.drawLine(line);
 
-                    painter.setPen(currentMark.m_textColor);
-                    painter.setFont(markerFont);
-                    painter.drawText(textPoint,currentMark.m_text);
+                    painter.setPen(currentMark.m_color);
+                    painter.drawLine(line);
+
+                    if (!currentMark.m_text.isEmpty()) {
+                        QPointF textPoint;
+                        textPoint.setX(markPosition + 0.5f);
+
+                        if (currentMark.m_align == Qt::AlignTop) {
+                            QFontMetricsF metric(markerFont);
+                            textPoint.setY(metric.tightBoundingRect(currentMark.m_text).height()+0.5f);
+                        } else {
+                            textPoint.setY(float(height())-0.5f);
+                        }
+
+                        painter.setPen(shadowPen);
+                        painter.setFont(shadowFont);
+                        painter.drawText(textPoint,currentMark.m_text);
+
+                        painter.setPen(currentMark.m_textColor);
+                        painter.setFont(markerFont);
+                        painter.drawText(textPoint,currentMark.m_text);
+                    }
                 }
             }
+
+            // draw current position
+            painter.setPen(QPen(QBrush(m_qColorBackground),1));
+            painter.setOpacity(0.5);
+            painter.drawLine(m_iPos + 1, 0, m_iPos + 1, height());
+            painter.drawLine(m_iPos - 1, 0, m_iPos - 1, height());
+
+            painter.setPen(QPen(m_signalColors.getPlayPosColor(),1));
+            painter.setOpacity(1.0);
+            painter.drawLine(m_iPos, 0, m_iPos, height());
+
+            painter.drawLine(m_iPos - 2, 0, m_iPos, 2);
+            painter.drawLine(m_iPos, 2, m_iPos + 2, 0);
+            painter.drawLine(m_iPos - 2, 0, m_iPos + 2, 0);
+
+            painter.drawLine(m_iPos - 2, height() - 1, m_iPos, height() - 3);
+            painter.drawLine(m_iPos, height() - 3, m_iPos + 2, height() - 1);
+            painter.drawLine(m_iPos - 2, height() - 1, m_iPos + 2, height() - 1);
         }
-
-        //draw current position
-        painter.setPen(QPen(QBrush(m_qColorBackground),1));
-        painter.setOpacity(0.5);
-        painter.drawLine(m_iPos + 1, 0, m_iPos + 1, height());
-        painter.drawLine(m_iPos - 1, 0, m_iPos - 1, height());
-
-        painter.setPen(QPen(m_signalColors.getPlayPosColor(),1));
-        painter.setOpacity(1.0);
-        painter.drawLine(m_iPos, 0, m_iPos, height());
-
-        painter.drawLine(m_iPos - 2, 0, m_iPos, 2);
-        painter.drawLine(m_iPos, 2, m_iPos + 2, 0);
-        painter.drawLine(m_iPos - 2, 0, m_iPos + 2, 0);
-
-        painter.drawLine(m_iPos - 2, height() - 1, m_iPos, height() - 3);
-        painter.drawLine(m_iPos, height() - 3, m_iPos + 2, height() - 1);
-        painter.drawLine(m_iPos - 2, height() - 1, m_iPos + 2, height() - 1);
     }
     painter.end();
 }

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -40,9 +40,8 @@ class WOverview : public WWidget {
 
   public slots:
     void onConnectedControlChanged(double dParameter, double dValue);
-    void slotLoadNewTrack(TrackPointer pTrack);
     void slotTrackLoaded(TrackPointer pTrack);
-    void slotUnloadTrack(TrackPointer pTrack);
+    void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
   signals:
     void trackDropped(QString filename, QString group);
@@ -96,7 +95,7 @@ class WOverview : public WWidget {
     const QString m_group;
     UserSettingsPointer m_pConfig;
     ControlObjectSlave* m_endOfTrackControl;
-    double m_endOfTrack;
+    bool m_endOfTrack;
     ControlObjectSlave* m_trackSamplesControl;
     ControlObjectSlave* m_playControl;
 

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -241,8 +241,9 @@ void WSpinny::slotLoadTrack(TrackPointer pTrack) {
     slotTrackCoverArtUpdated();
 }
 
-void WSpinny::slotReset() {
-    if (m_loadedTrack) {
+void WSpinny::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pNewTrack);
+    if (m_loadedTrack && pOldTrack == m_loadedTrack) {
         disconnect(m_loadedTrack.data(), SIGNAL(coverArtUpdated()),
                    this, SLOT(slotTrackCoverArtUpdated()));
     }

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -34,7 +34,7 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
 
   public slots:
     void slotLoadTrack(TrackPointer);
-    void slotReset();
+    void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void updateVinylControlSpeed(double rpm);
     void updateVinylControlEnabled(double enabled);
     void updateVinylControlSignalEnabled(double enabled);

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -33,8 +33,9 @@ void WTrackProperty::slotTrackLoaded(TrackPointer track) {
     }
 }
 
-void WTrackProperty::slotTrackUnloaded(TrackPointer track) {
-    Q_UNUSED(track);
+void WTrackProperty::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pNewTrack);
+    Q_UNUSED(pOldTrack);
     if (m_pCurrentTrack) {
         disconnect(m_pCurrentTrack.data(), 0, this, 0);
     }

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -23,7 +23,7 @@ class WTrackProperty : public WLabel {
 
   public slots:
     void slotTrackLoaded(TrackPointer track);
-    void slotTrackUnloaded(TrackPointer track);
+    void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
   private slots:
     void updateLabel(TrackInfoObject*);

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -25,8 +25,9 @@ void WTrackText::slotTrackLoaded(TrackPointer track) {
     }
 }
 
-void WTrackText::slotTrackUnloaded(TrackPointer track) {
-    Q_UNUSED(track);
+void WTrackText::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pNewTrack);
+    Q_UNUSED(pOldTrack);
     if (m_pCurrentTrack) {
         disconnect(m_pCurrentTrack.data(), 0, this, 0);
     }

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -20,7 +20,7 @@ class WTrackText : public WLabel {
 
   public slots:
     void slotTrackLoaded(TrackPointer track);
-    void slotTrackUnloaded(TrackPointer track);
+    void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
   private slots:
     void updateLabel(TrackInfoObject*);

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -163,13 +163,15 @@ void WWaveformViewer::dropEvent(QDropEvent* event) {
     event->ignore();
 }
 
-void WWaveformViewer::onTrackLoaded(TrackPointer track) {
+void WWaveformViewer::slotTrackLoaded(TrackPointer track) {
     if (m_waveformWidget) {
         m_waveformWidget->setTrack(track);
     }
 }
 
-void WWaveformViewer::onTrackUnloaded(TrackPointer /*track*/) {
+void WWaveformViewer::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pNewTrack);
+    Q_UNUSED(pOldTrack);
     if (m_waveformWidget) {
         m_waveformWidget->setTrack(TrackPointer());
     }

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -36,8 +36,8 @@ signals:
     void trackDropped(QString filename, QString group);
 
 public slots:
-    void onTrackLoaded(TrackPointer track);
-    void onTrackUnloaded(TrackPointer track);
+    void slotTrackLoaded(TrackPointer track);
+    void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
 protected:
     virtual void resizeEvent(QResizeEvent *event);


### PR DESCRIPTION
During fixing Bug #1551019 (Auto DJ stops after eject) I hit a clutter or signals between Player CachingReader Enginebuffer and engine controls. 
There were signals named in continues from received by slots perfect form and some race conditions caused by that, which leads to things like a lit cue button when now track was loaded. 
The difficult part where the load and unload transitions and stray signals that are possible when the  buffer has still the old track but the player already the new one. 

I have fixes this by a loading signal, that transfers the old and the new track.  
The same signals are also used with null tracks in case of failure, ejecting and starting new.
This way we have no extra state between removing and loading a track when it is just replaced.

This is now the normal signal flow when loading a track: 

Enter player loading state: 
- BaseTrackPlayerImpl::slotLoadTrack()
  - EngineBuffer::loadTrack()
    - m_pReader->newTrack(pTrack);
  - BaseTrackPlayerImpl::loadingTrack(pNewTrack, pOldTrack);

Enter player loaded state:
- EngineBuffer::slotTrackLoaded
  - EngineBuffer::trackLoaded(pTrack, pOldTrack));
    - BaseTrackPlayerImpl::slotTrackLoaded(pTrack, pOldTrack));

The original unload and load failure signals are now gone.
Fixing Bug #1551019 requires a new playerEmpty() signal to avoid loading a new track in the middle of ejecting the track before. 
