### PR TITLE
Constant power crossfader

### DIFF
--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -401,7 +401,7 @@ void EngineMaster::process(const int iBufferSize) {
     double c1_gain, c2_gain;
     EngineXfader::getXfadeGains(m_pCrossfader->get(), m_pXFaderCurve->get(),
                                 m_pXFaderCalibration->get(),
-                                m_pXFaderMode->get() == MIXXX_XFADER_CONSTPWR,
+                                m_pXFaderMode->get(),
                                 m_pXFaderReverse->toBool(),
                                 &c1_gain, &c2_gain);
 

--- a/src/engine/enginexfader.cpp
+++ b/src/engine/enginexfader.cpp
@@ -14,7 +14,7 @@ double EngineXfader::getPowerCalibration(double transform) {
 
 void EngineXfader::getXfadeGains(
         double xfadePosition, double transform, double powerCalibration,
-        bool constPower, bool reverse, double* gain1, double* gain2) {
+        double curve, bool reverse, double* gain1, double* gain2) {
     if (gain1 == NULL || gain2 == NULL) {
         return;
     }
@@ -23,7 +23,7 @@ void EngineXfader::getXfadeGains(
     double xfadePositionLeft = xfadePosition;
     double xfadePositionRight = xfadePosition;
 
-    if (constPower) {
+    if (curve == MIXXX_XFADER_CONSTPWR) {
         // Apply Calibration
         xfadePosition *= powerCalibration;
         xfadePositionLeft = xfadePosition - powerCalibration;
@@ -51,12 +51,17 @@ void EngineXfader::getXfadeGains(
         *gain2 = 0.0;
     }
 
-    if (constPower) {
+    if (curve == MIXXX_XFADER_CONSTPWR) {
         if (*gain1 > *gain2) {
             *gain2 = 1 - *gain1;
         } else {
             *gain1 = 1 - *gain2;
         }
+
+        // normalize the gain
+        double gain = sqrt(*gain1 * *gain1 + *gain2 * *gain2);
+        *gain1 = *gain1 / gain;
+        *gain2 = *gain2 / gain;
     }
 
     if (reverse) {

--- a/src/engine/enginexfader.cpp
+++ b/src/engine/enginexfader.cpp
@@ -58,7 +58,14 @@ void EngineXfader::getXfadeGains(
             *gain1 = 1 - *gain2;
         }
 
-        // normalize the gain
+        // The resulting power at the crossover point depends on the correlation of the input signals
+        // In theory the gain ratio varies from 0.5 for two equal signals to sqrt(0.5) = 0.707 for totally
+        // uncorrelated signals.
+        // Since the underlying requirement for this curve is constant loudness, we did a test with 30 s
+        // snippets of various genres and ReplayGain 2.0 analysis. Allmost all results where near 0.707 
+        // with one exception of mixing two parts of the same track, which resulted in 0.66.
+        // Based on the testing, we normalize the gain as if the signals were uncorrelated. The
+        // correction on the following lines ensures that  gain1^2 + gain2^2 == 1.
         double gain = sqrt(*gain1 * *gain1 + *gain2 * *gain2);
         *gain1 = *gain1 / gain;
         *gain2 = *gain2 / gain;

--- a/src/engine/enginexfader.h
+++ b/src/engine/enginexfader.h
@@ -10,7 +10,7 @@ class EngineXfader {
     static double getPowerCalibration(double transform);
     static void getXfadeGains(
         double xfadePosition, double transform, double powerCalibration,
-        bool constPower, bool reverse, double* gain1, double* gain2);
+        double curve, bool reverse, double* gain1, double* gain2);
 
     static const char* kXfaderConfigKey;
     static const double kTransformMax;

--- a/src/mixer/playerinfo.cpp
+++ b/src/mixer/playerinfo.cpp
@@ -129,7 +129,7 @@ void PlayerInfo::updateCurrentPlayingDeck() {
         }
 
         double xfl, xfr;
-        EngineXfader::getXfadeGains(m_pCOxfader->get(), 1.0, 0.0, false, false,
+        EngineXfader::getXfadeGains(m_pCOxfader->get(), 1.0, 0.0, MIXXX_XFADER_ADDITIVE, false,
                                     &xfl, &xfr);
 
         int orient = pDc->m_orientation.get();

--- a/src/mixer/playerinfo.cpp
+++ b/src/mixer/playerinfo.cpp
@@ -129,6 +129,8 @@ void PlayerInfo::updateCurrentPlayingDeck() {
         }
 
         double xfl, xfr;
+        // TODO: supply correct parameters to the function. If the hamster style
+        // for the crossfader is enabled, the result is currently wrong.
         EngineXfader::getXfadeGains(m_pCOxfader->get(), 1.0, 0.0, MIXXX_XFADER_ADDITIVE, false,
                                     &xfl, &xfr);
 

--- a/src/preferences/dialog/dlgprefcrossfader.cpp
+++ b/src/preferences/dialog/dlgprefcrossfader.cpp
@@ -165,28 +165,22 @@ void DlgPrefCrossfader::drawXfaderDisplay()
                                     checkBoxReverse->isChecked(),
                                     &gain1, &gain2);
 
-        double sum = gain1 + gain2;
+        double gain = sqrt(gain1 * gain1 + gain2 * gain2);
         // scale for graph
-        gain1 *= 0.80;
-        gain2 *= 0.80;
-        sum *= 0.80;
+        gain1 *= 0.71;
+        gain2 *= 0.71;
+        gain *= 0.71;
 
         // draw it
-        pointTotal = QPointF(i + 1, (1. - sum) * (sizeY) - 3);
+        pointTotal = QPointF(i + 1, (1. - gain) * (sizeY) - 3);
         point1 = QPointF(i + 1, (1. - gain1) * (sizeY) - 3);
         point2 = QPointF(i + 1, (1. - gain2) * (sizeY) - 3);
 
-        if(i == 0) {
-            pointTotalPrev = pointTotal;
-            point1Prev = point1;
-            point2Prev = point2;
-        }
-
-        if(pointTotal != point1)
+        if (i > 0) {
+            m_pxfScene->addLine(QLineF(pointTotal, pointTotalPrev), QPen(Qt::red));
             m_pxfScene->addLine(QLineF(point1, point1Prev), graphLinePen);
-        if(pointTotal != point2)
             m_pxfScene->addLine(QLineF(point2, point2Prev), graphLinePen);
-        m_pxfScene->addLine(QLineF(pointTotal, pointTotalPrev), QPen(Qt::red));
+        }
 
         // Save old values
         pointTotalPrev = pointTotal;

--- a/src/preferences/dialog/dlgprefcrossfader.cpp
+++ b/src/preferences/dialog/dlgprefcrossfader.cpp
@@ -161,7 +161,7 @@ void DlgPrefCrossfader::drawXfaderDisplay()
         double gain1, gain2;
         EngineXfader::getXfadeGains((-1. + (xfadeStep * i)),
                                     m_transform, m_cal,
-                                    (m_xFaderMode == MIXXX_XFADER_CONSTPWR),
+                                    m_xFaderMode,
                                     checkBoxReverse->isChecked(),
                                     &gain1, &gain2);
 

--- a/src/preferences/dialog/dlgprefcrossfaderdlg.ui
+++ b/src/preferences/dialog/dlgprefcrossfaderdlg.ui
@@ -162,7 +162,7 @@
           <property name="minimumSize">
            <size>
             <width>125</width>
-            <height>70</height>
+            <height>80</height>
            </size>
           </property>
           <property name="maximumSize">


### PR DESCRIPTION
Add a new Constant power crossfader (which is constant power for uncorrelated signals, a²+b²=1 for gains a,b). The crossfader previously known as Constant power is renamed to Linear. At least for my music, this new crossfader gives more constant-powery crossfades than either of the previously available ones.
