### PR TITLE
move NetworkStreamWorker definition to cpp file

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -656,6 +656,7 @@ class MixxxCore(Feature):
                    "engine/enginevumeter.cpp",
                    "engine/enginesidechaincompressor.cpp",
                    "engine/sidechain/enginesidechain.cpp",
+                   "engine/sidechain/networkstreamworker.cpp",
                    "engine/enginexfader.cpp",
                    "engine/enginemicrophone.cpp",
                    "engine/enginedeck.cpp",

--- a/src/engine/sidechain/networkstreamworker.cpp
+++ b/src/engine/sidechain/networkstreamworker.cpp
@@ -1,0 +1,53 @@
+#include "networkstreamworker.h"
+
+int NetworkStreamWorker::s_networkStreamWorkerState;
+int NetworkStreamWorker::s_functionCode;
+int NetworkStreamWorker::s_runCount;
+
+NetworkStreamWorker::NetworkStreamWorker() {
+}
+
+NetworkStreamWorker::~NetworkStreamWorker() {
+}
+
+void NetworkStreamWorker::outputAvailable() {
+}
+
+void NetworkStreamWorker::setOutputFifo(FIFO<CSAMPLE>* pOutputFifo) {
+    Q_UNUSED(pOutputFifo);
+}
+
+bool NetworkStreamWorker::threadWaiting() {
+    return false;
+}
+
+int NetworkStreamWorker::getState() {
+    return s_networkStreamWorkerState;
+}
+
+int NetworkStreamWorker::getFunctionCode() {
+    return s_functionCode;
+}
+
+int NetworkStreamWorker::getRunCount() {
+    return s_runCount;
+}
+
+void NetworkStreamWorker::debugState() {
+    qDebug() << "NetworkStreamWorker state:"
+             << s_networkStreamWorkerState
+             << s_functionCode
+             << s_runCount;
+}
+
+void NetworkStreamWorker::setState(int state) {
+    s_networkStreamWorkerState = state;
+}
+
+void NetworkStreamWorker::setFunctionCode(int code) {
+    s_functionCode = code;
+}
+
+void NetworkStreamWorker::incRunCount() {
+    s_runCount++;
+}

--- a/src/engine/sidechain/networkstreamworker.h
+++ b/src/engine/sidechain/networkstreamworker.h
@@ -41,45 +41,28 @@ enum NetworkStreamWorkerStates {
 
 class NetworkStreamWorker {
   public:
-    NetworkStreamWorker() {
-    }
-    virtual ~NetworkStreamWorker() { }
+    NetworkStreamWorker();
+    virtual ~NetworkStreamWorker();
+
     virtual void process(const CSAMPLE* pBuffer, const int iBufferSize) = 0;
     virtual void shutdown() = 0;
-    virtual void outputAvailable() {
-    };
-    virtual void setOutputFifo(FIFO<CSAMPLE>* pOutputFifo) {
-        Q_UNUSED(pOutputFifo);
-    };
-    virtual bool threadWaiting() {
-        return false;
-    }
-    static int getState() {
-        return s_networkStreamWorkerState;
-    }
-    static int getFunctionCode() {
-        return s_functionCode;
-    }
-    static int getRunCount() {
-        return s_runCount;
-    }
-    static void debugState() {
-        qDebug() << "NetworkStreamWorker state:"
-                 << s_networkStreamWorkerState
-                 << s_functionCode
-                 << s_runCount;
-    }
+
+    virtual void outputAvailable();
+    virtual void setOutputFifo(FIFO<CSAMPLE>* pOutputFifo);
+
+    virtual bool threadWaiting();
+
+    static int getState();
+    static int getFunctionCode();
+    static int getRunCount();
+
+    static void debugState();
 
 protected:
-    void setState(int state) {
-        s_networkStreamWorkerState = state;
-    }
-    void setFunctionCode(int code) {
-        s_functionCode = code;
-    }
-    void incRunCount() {
-        s_runCount++;
-    }
+    void setState(int state);
+    void setFunctionCode(int code);
+    void incRunCount();
+    
 private:
     static int s_networkStreamWorkerState;
     static int s_functionCode;


### PR DESCRIPTION
Due to the missing initialization of the static members, the build
failed on g++ 5.3.0.
