### PR TITLE
Audio Data Caching: Log warning instead of debug message

### DIFF
--- a/src/cachingreader.cpp
+++ b/src/cachingreader.cpp
@@ -130,7 +130,7 @@ CachingReaderChunkForOwner* CachingReader::allocateChunkExpireLRU(SINT chunkInde
     CachingReaderChunkForOwner* pChunk = allocateChunk(chunkIndex);
     if (pChunk == nullptr) {
         if (m_lruCachingReaderChunk == nullptr) {
-            qDebug() << "ERROR: No LRU chunk to free in allocateChunkExpireLRU.";
+            qWarning() << "ERROR: No LRU chunk to free in allocateChunkExpireLRU.";
             return nullptr;
         }
         freeChunk(m_lruCachingReaderChunk);


### PR DESCRIPTION
Follow up of my recent PR.

This helps to analyze audio issues that might be caused by a shortage of chunks for caching.
