### PR TITLE
Spring cleaning: Apply clang-tidy to src/widget.

### DIFF
--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -15,11 +15,10 @@ ControlWidgetConnection::ControlWidgetConnection(WBaseWidget* pBaseWidget,
     m_pControl->connectValueChanged(SLOT(slotControlValueChanged(double)));
 }
 
-ControlWidgetConnection::~ControlWidgetConnection() {
-}
+ControlWidgetConnection::~ControlWidgetConnection() = default;
 
 void ControlWidgetConnection::setControlParameter(double parameter) {
-    if (m_pValueTransformer != NULL) {
+    if (m_pValueTransformer != nullptr) {
         parameter = m_pValueTransformer->transformInverse(parameter);
     }
     m_pControl->setParameter(parameter);
@@ -27,7 +26,7 @@ void ControlWidgetConnection::setControlParameter(double parameter) {
 
 double ControlWidgetConnection::getControlParameter() const {
     double parameter = m_pControl->getParameter();
-    if (m_pValueTransformer != NULL) {
+    if (m_pValueTransformer != nullptr) {
         parameter = m_pValueTransformer->transform(parameter);
     }
     return parameter;
@@ -35,7 +34,7 @@ double ControlWidgetConnection::getControlParameter() const {
 
 double ControlWidgetConnection::getControlParameterForValue(double value) const {
     double parameter = m_pControl->getParameterForValue(value);
-    if (m_pValueTransformer != NULL) {
+    if (m_pValueTransformer != nullptr) {
         parameter = m_pValueTransformer->transform(parameter);
     }
     return parameter;
@@ -51,8 +50,7 @@ ControlParameterWidgetConnection::ControlParameterWidgetConnection(WBaseWidget* 
           m_emitOption(emitOption) {
 }
 
-ControlParameterWidgetConnection::~ControlParameterWidgetConnection() {
-}
+ControlParameterWidgetConnection::~ControlParameterWidgetConnection() = default;
 
 void ControlParameterWidgetConnection::Init() {
     slotControlValueChanged(m_pControl->get());
@@ -107,8 +105,7 @@ ControlWidgetPropertyConnection::ControlWidgetPropertyConnection(WBaseWidget* pB
     slotControlValueChanged(m_pControl->get());
 }
 
-ControlWidgetPropertyConnection::~ControlWidgetPropertyConnection() {
-}
+ControlWidgetPropertyConnection::~ControlWidgetPropertyConnection() = default;
 
 QString ControlWidgetPropertyConnection::toDebugString() const {
     const ConfigKey& key = getKey();

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -15,8 +15,6 @@ ControlWidgetConnection::ControlWidgetConnection(WBaseWidget* pBaseWidget,
     m_pControl->connectValueChanged(SLOT(slotControlValueChanged(double)));
 }
 
-ControlWidgetConnection::~ControlWidgetConnection() = default;
-
 void ControlWidgetConnection::setControlParameter(double parameter) {
     if (m_pValueTransformer != nullptr) {
         parameter = m_pValueTransformer->transformInverse(parameter);
@@ -49,8 +47,6 @@ ControlParameterWidgetConnection::ControlParameterWidgetConnection(WBaseWidget* 
           m_directionOption(directionOption),
           m_emitOption(emitOption) {
 }
-
-ControlParameterWidgetConnection::~ControlParameterWidgetConnection() = default;
 
 void ControlParameterWidgetConnection::Init() {
     slotControlValueChanged(m_pControl->get());
@@ -104,8 +100,6 @@ ControlWidgetPropertyConnection::ControlWidgetPropertyConnection(WBaseWidget* pB
           m_propertyName(propertyName.toAscii()) {
     slotControlValueChanged(m_pControl->get());
 }
-
-ControlWidgetPropertyConnection::~ControlWidgetPropertyConnection() = default;
 
 QString ControlWidgetPropertyConnection::toDebugString() const {
     const ConfigKey& key = getKey();

--- a/src/widget/controlwidgetconnection.h
+++ b/src/widget/controlwidgetconnection.h
@@ -7,6 +7,7 @@
 #include <QByteArray>
 
 #include "controlobjectslave.h"
+#include "util/valuetransformer.h"
 
 class WBaseWidget;
 class ValueTransformer;
@@ -18,7 +19,6 @@ class ControlWidgetConnection : public QObject {
     ControlWidgetConnection(WBaseWidget* pBaseWidget,
                             const ConfigKey& key,
                             ValueTransformer* pTransformer);
-    ~ControlWidgetConnection() override;
 
     double getControlParameter() const;
     double getControlParameterForValue(double value) const;
@@ -100,7 +100,6 @@ class ControlParameterWidgetConnection : public ControlWidgetConnection {
                                      ValueTransformer* pTransformer,
                                      DirectionOption directionOption,
                                      EmitOption emitOption);
-    ~ControlParameterWidgetConnection() override;
 
     void Init();
 
@@ -132,7 +131,6 @@ class ControlWidgetPropertyConnection : public ControlWidgetConnection {
                                     const ConfigKey& key,
                                     ValueTransformer* pTransformer,
                                     const QString& propertyName);
-    ~ControlWidgetPropertyConnection() override;
 
     QString toDebugString() const override;
 

--- a/src/widget/controlwidgetconnection.h
+++ b/src/widget/controlwidgetconnection.h
@@ -18,7 +18,7 @@ class ControlWidgetConnection : public QObject {
     ControlWidgetConnection(WBaseWidget* pBaseWidget,
                             const ConfigKey& key,
                             ValueTransformer* pTransformer);
-    virtual ~ControlWidgetConnection();
+    ~ControlWidgetConnection() override;
 
     double getControlParameter() const;
     double getControlParameterForValue(double value) const;
@@ -33,7 +33,7 @@ class ControlWidgetConnection : public QObject {
     virtual void slotControlValueChanged(double v) = 0;
 
   protected:
-    void setControlParameter(double v);
+    void setControlParameter(double parameter);
 
     WBaseWidget* m_pWidget;
 
@@ -100,11 +100,11 @@ class ControlParameterWidgetConnection : public ControlWidgetConnection {
                                      ValueTransformer* pTransformer,
                                      DirectionOption directionOption,
                                      EmitOption emitOption);
-    virtual ~ControlParameterWidgetConnection();
+    ~ControlParameterWidgetConnection() override;
 
     void Init();
 
-    QString toDebugString() const;
+    QString toDebugString() const override;
 
     int getDirectionOption() const { return m_directionOption; };
     int getEmitOption() const { return m_emitOption; };
@@ -118,7 +118,7 @@ class ControlParameterWidgetConnection : public ControlWidgetConnection {
     void setControlParameterUp(double v);
 
   private slots:
-    virtual void slotControlValueChanged(double v);
+    void slotControlValueChanged(double value) override;
 
   private:
     DirectionOption m_directionOption;
@@ -131,13 +131,13 @@ class ControlWidgetPropertyConnection : public ControlWidgetConnection {
     ControlWidgetPropertyConnection(WBaseWidget* pBaseWidget,
                                     const ConfigKey& key,
                                     ValueTransformer* pTransformer,
-                                    const QString& property);
-    virtual ~ControlWidgetPropertyConnection();
+                                    const QString& propertyName);
+    ~ControlWidgetPropertyConnection() override;
 
-    QString toDebugString() const;
+    QString toDebugString() const override;
 
   private slots:
-    virtual void slotControlValueChanged(double v);
+    void slotControlValueChanged(double v) override;
 
   private:
     QByteArray m_propertyName;

--- a/src/widget/effectwidgetutils.h
+++ b/src/widget/effectwidgetutils.h
@@ -12,7 +12,7 @@ class EffectWidgetUtils {
             const QDomNode& node,
             const SkinContext& context,
             EffectsManager* pEffectsManager) {
-        if (pEffectsManager == NULL) {
+        if (pEffectsManager == nullptr) {
             return EffectRackPointer();
         }
 
@@ -116,7 +116,7 @@ class EffectWidgetUtils {
     }
 
   private:
-    EffectWidgetUtils() {};
+    EffectWidgetUtils() = default;;
 };
 
 #endif /* EFFECTWIDGETUTILS_H */

--- a/src/widget/effectwidgetutils.h
+++ b/src/widget/effectwidgetutils.h
@@ -116,7 +116,7 @@ class EffectWidgetUtils {
     }
 
   private:
-    EffectWidgetUtils() = default;;
+    EffectWidgetUtils() = default;
 };
 
 #endif /* EFFECTWIDGETUTILS_H */

--- a/src/widget/hexspinbox.cpp
+++ b/src/widget/hexspinbox.cpp
@@ -5,8 +5,7 @@ HexSpinBox::HexSpinBox(QWidget* pParent)
     setRange(0, 255);
 }
 
-HexSpinBox::~HexSpinBox() {
-}
+HexSpinBox::~HexSpinBox() = default;
 
 QString HexSpinBox::textFromValue(int value) const {
     // Construct a hex string formatted like 0xFF.
@@ -21,6 +20,6 @@ int HexSpinBox::valueFromText(const QString& text) const {
 
 QValidator::State HexSpinBox::validate(QString& input, int& pos) const {
     const QRegExp regExp("^0(x|X)[0-9A-Fa-f]+");
-    QRegExpValidator validator(regExp, NULL);
+    QRegExpValidator validator(regExp, nullptr);
     return validator.validate(input, pos);
 }

--- a/src/widget/hexspinbox.cpp
+++ b/src/widget/hexspinbox.cpp
@@ -5,8 +5,6 @@ HexSpinBox::HexSpinBox(QWidget* pParent)
     setRange(0, 255);
 }
 
-HexSpinBox::~HexSpinBox() = default;
-
 QString HexSpinBox::textFromValue(int value) const {
     // Construct a hex string formatted like 0xFF.
     return QString("0x") + QString("%1")

--- a/src/widget/hexspinbox.h
+++ b/src/widget/hexspinbox.h
@@ -7,7 +7,6 @@
 class HexSpinBox : public QSpinBox {
   public:
     explicit HexSpinBox(QWidget *pParent);
-    ~HexSpinBox() override;
 
   protected:
     QString textFromValue(int value) const override;

--- a/src/widget/hexspinbox.h
+++ b/src/widget/hexspinbox.h
@@ -6,13 +6,13 @@
 
 class HexSpinBox : public QSpinBox {
   public:
-    HexSpinBox(QWidget *parent);
-    virtual ~HexSpinBox();
+    explicit HexSpinBox(QWidget *pParent);
+    ~HexSpinBox() override;
 
   protected:
-    QString textFromValue(int value) const;
-    int valueFromText(const QString& text) const;
-    QValidator::State validate(QString& input, int& pos) const;
+    QString textFromValue(int value) const override;
+    int valueFromText(const QString& text) const override;
+    QValidator::State validate(QString& input, int& pos) const override;
 };
 
 #endif /* HEXSPINBOX_H */

--- a/src/widget/slidereventhandler.h
+++ b/src/widget/slidereventhandler.h
@@ -105,7 +105,7 @@ class SliderEventHandler {
 
     void wheelEvent(T* pWidget, QWheelEvent* e) {
         // For legacy (MIDI) reasons this is tuned to 127.
-        double wheelAdjustment = ((QWheelEvent *)e)->delta() / (120.0 * 127.0);
+        double wheelAdjustment = (e)->delta() / (120.0 * 127.0);
         double newParameter = pWidget->getControlParameter() + wheelAdjustment;
 
         // Clamp to [0.0, 1.0]

--- a/src/widget/wanalysislibrarytableview.cpp
+++ b/src/widget/wanalysislibrarytableview.cpp
@@ -9,8 +9,7 @@ WAnalysisLibraryTableView::WAnalysisLibraryTableView(QWidget* parent,
     setDragEnabled(true); //Always enable drag for now (until we have a model that doesn't support this.)
 }
 
-WAnalysisLibraryTableView::~WAnalysisLibraryTableView() {
-}
+WAnalysisLibraryTableView::~WAnalysisLibraryTableView() = default;
 
 void WAnalysisLibraryTableView::onSearchStarting() {
 }

--- a/src/widget/wanalysislibrarytableview.cpp
+++ b/src/widget/wanalysislibrarytableview.cpp
@@ -9,8 +9,6 @@ WAnalysisLibraryTableView::WAnalysisLibraryTableView(QWidget* parent,
     setDragEnabled(true); //Always enable drag for now (until we have a model that doesn't support this.)
 }
 
-WAnalysisLibraryTableView::~WAnalysisLibraryTableView() = default;
-
 void WAnalysisLibraryTableView::onSearchStarting() {
 }
 

--- a/src/widget/wanalysislibrarytableview.h
+++ b/src/widget/wanalysislibrarytableview.h
@@ -13,11 +13,11 @@ class WAnalysisLibraryTableView : public WTrackTableView
     public:
         WAnalysisLibraryTableView(QWidget* parent, UserSettingsPointer pConfig,
                                  TrackCollection* pTrackCollection);
-        ~WAnalysisLibraryTableView();
+        ~WAnalysisLibraryTableView() override;
 
         virtual void onSearchStarting();
         virtual void onSearchCleared();
-        virtual void onSearch(const QString& text);
+        void onSearch(const QString& text) override;
 };
 
 #endif

--- a/src/widget/wanalysislibrarytableview.h
+++ b/src/widget/wanalysislibrarytableview.h
@@ -13,7 +13,6 @@ class WAnalysisLibraryTableView : public WTrackTableView
     public:
         WAnalysisLibraryTableView(QWidget* parent, UserSettingsPointer pConfig,
                                  TrackCollection* pTrackCollection);
-        ~WAnalysisLibraryTableView() override;
 
         virtual void onSearchStarting();
         virtual void onSearchCleared();

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -7,12 +7,12 @@
 #include "util/debug.h"
 
 WBaseWidget::WBaseWidget(QWidget* pWidget)
-        : m_pDisplayConnection(NULL),
+        : m_pDisplayConnection(nullptr),
           m_pWidget(pWidget) {
 }
 
 WBaseWidget::~WBaseWidget() {
-    m_pDisplayConnection = NULL;
+    m_pDisplayConnection = nullptr;
     while (!m_leftConnections.isEmpty()) {
         delete m_leftConnections.takeLast();
     }
@@ -79,7 +79,7 @@ double WBaseWidget::getControlParameterRight() const {
 }
 
 double WBaseWidget::getControlParameterDisplay() const {
-    if (m_pDisplayConnection != NULL) {
+    if (m_pDisplayConnection != nullptr) {
         return m_pDisplayConnection->getControlParameter();
     }
     return 0.0;

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -86,36 +86,36 @@ double WBaseWidget::getControlParameterDisplay() const {
 }
 
 void WBaseWidget::resetControlParameter() {
-    foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
+    for (ControlParameterWidgetConnection* pControlConnection : m_connections) {
         pControlConnection->resetControl();
     }
 }
 
 void WBaseWidget::setControlParameter(double v) {
-    foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
+    for (ControlParameterWidgetConnection* pControlConnection : m_connections) {
         pControlConnection->setControlParameter(v);
     }
 }
 
 void WBaseWidget::setControlParameterUp(double v) {
-    foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
+    for (ControlParameterWidgetConnection* pControlConnection : m_connections) {
         pControlConnection->setControlParameterUp(v);
     }
 }
 
 void WBaseWidget::setControlParameterDown(double v) {
-    foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
+    for (ControlParameterWidgetConnection* pControlConnection : m_connections) {
         pControlConnection->setControlParameterDown(v);
     }
 }
 
 void WBaseWidget::setControlParameterLeftDown(double v) {
     if (!m_leftConnections.isEmpty()) {
-        foreach (ControlParameterWidgetConnection* pControlConnection, m_leftConnections) {
+        for (ControlParameterWidgetConnection* pControlConnection : m_leftConnections) {
             pControlConnection->setControlParameterDown(v);
         }
     } else {
-        foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
+        for (ControlParameterWidgetConnection* pControlConnection : m_connections) {
             pControlConnection->setControlParameterDown(v);
         }
     }
@@ -123,24 +123,24 @@ void WBaseWidget::setControlParameterLeftDown(double v) {
 
 void WBaseWidget::setControlParameterLeftUp(double v) {
     if (!m_leftConnections.isEmpty()) {
-        foreach (ControlParameterWidgetConnection* pControlConnection, m_leftConnections) {
+        for (ControlParameterWidgetConnection* pControlConnection : m_leftConnections) {
             pControlConnection->setControlParameterUp(v);
         }
     } else {
-        foreach (ControlParameterWidgetConnection* pControlConnection, m_connections) {
+        for (ControlParameterWidgetConnection* pControlConnection : m_connections) {
             pControlConnection->setControlParameterUp(v);
         }
     }
 }
 
 void WBaseWidget::setControlParameterRightDown(double v) {
-    foreach (ControlParameterWidgetConnection* pControlConnection, m_rightConnections) {
+    for (ControlParameterWidgetConnection* pControlConnection : m_rightConnections) {
         pControlConnection->setControlParameterDown(v);
     }
 }
 
 void WBaseWidget::setControlParameterRightUp(double v) {
-    foreach (ControlParameterWidgetConnection* pControlConnection, m_rightConnections) {
+    for (ControlParameterWidgetConnection* pControlConnection : m_rightConnections) {
         pControlConnection->setControlParameterUp(v);
     }
 }
@@ -193,13 +193,13 @@ void WBaseWidget::fillDebugTooltip(QStringList* debug) {
            << QString("SizeHint: %1").arg(toDebugString(m_pWidget->sizeHint()))
            << QString("MinimumSizeHint: %1").arg(toDebugString(m_pWidget->minimumSizeHint()));
 
-    foreach (ControlWidgetConnection* pControlConnection, m_leftConnections) {
+    for (ControlParameterWidgetConnection* pControlConnection : m_leftConnections) {
         *debug << QString("LeftConnection: %1").arg(pControlConnection->toDebugString());
     }
-    foreach (ControlWidgetConnection* pControlConnection, m_rightConnections) {
+    for (ControlParameterWidgetConnection* pControlConnection : m_rightConnections) {
         *debug << QString("RightConnection: %1").arg(pControlConnection->toDebugString());
     }
-    foreach (ControlWidgetConnection* pControlConnection, m_connections) {
+    for (ControlParameterWidgetConnection* pControlConnection : m_connections) {
         *debug << QString("Connection: %1").arg(pControlConnection->toDebugString());
     }
     if (m_pDisplayConnection) {

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -10,7 +10,7 @@ class ControlParameterWidgetConnection;
 
 class WBaseWidget {
   public:
-    WBaseWidget(QWidget* pWidget);
+    explicit WBaseWidget(QWidget* pWidget);
     virtual ~WBaseWidget();
 
     virtual void Init();

--- a/src/widget/wbattery.cpp
+++ b/src/widget/wbattery.cpp
@@ -14,8 +14,6 @@ WBattery::WBattery(QWidget* parent)
     }
 }
 
-WBattery::~WBattery() = default;
-
 void WBattery::setup(QDomNode node, const SkinContext& context) {
     if (context.hasNode(node, "BackPath")) {
         QString mode_str = context.selectAttributeString(

--- a/src/widget/wbattery.cpp
+++ b/src/widget/wbattery.cpp
@@ -14,8 +14,7 @@ WBattery::WBattery(QWidget* parent)
     }
 }
 
-WBattery::~WBattery() {
-}
+WBattery::~WBattery() = default;
 
 void WBattery::setup(QDomNode node, const SkinContext& context) {
     if (context.hasNode(node, "BackPath")) {
@@ -157,7 +156,7 @@ void WBattery::setPixmap(PaintablePointer* ppPixmap, const PixmapSource& source,
     }
 }
 
-void WBattery::paintEvent(QPaintEvent*) {
+void WBattery::paintEvent(QPaintEvent* /*unused*/) {
     QStyleOption option;
     option.initFrom(this);
     QStylePainter p(this);

--- a/src/widget/wbattery.h
+++ b/src/widget/wbattery.h
@@ -10,14 +10,12 @@
 #include "widget/wlabel.h"
 #include "widget/wpixmapstore.h"
 #include "widget/wwidget.h"
-
-class Battery;
+#include "util/battery/battery.h"
 
 class WBattery : public WWidget {
     Q_OBJECT
   public:
     explicit WBattery(QWidget* parent=nullptr);
-    ~WBattery() override;
 
     void setup(QDomNode node, const SkinContext& context);
 

--- a/src/widget/wbattery.h
+++ b/src/widget/wbattery.h
@@ -16,8 +16,8 @@ class Battery;
 class WBattery : public WWidget {
     Q_OBJECT
   public:
-    WBattery(QWidget* parent=NULL);
-    virtual ~WBattery();
+    explicit WBattery(QWidget* parent=nullptr);
+    ~WBattery() override;
 
     void setup(QDomNode node, const SkinContext& context);
 
@@ -26,7 +26,7 @@ class WBattery : public WWidget {
     void update();
 
   protected:
-    void paintEvent(QPaintEvent *);
+    void paintEvent(QPaintEvent * /*unused*/) override;
 
   private:
     void setPixmap(PaintablePointer* ppPixmap, const PixmapSource& source,

--- a/src/widget/wcombobox.cpp
+++ b/src/widget/wcombobox.cpp
@@ -10,8 +10,7 @@ WComboBox::WComboBox(QWidget* pParent)
             this, SLOT(slotCurrentIndexChanged(int)));
 }
 
-WComboBox::~WComboBox() {
-}
+WComboBox::~WComboBox() = default;
 
 void WComboBox::setup(QDomNode node, const SkinContext& context) {
     // Load pixmaps for associated states

--- a/src/widget/wcombobox.cpp
+++ b/src/widget/wcombobox.cpp
@@ -10,8 +10,6 @@ WComboBox::WComboBox(QWidget* pParent)
             this, SLOT(slotCurrentIndexChanged(int)));
 }
 
-WComboBox::~WComboBox() = default;
-
 void WComboBox::setup(QDomNode node, const SkinContext& context) {
     // Load pixmaps for associated states
     QDomNode state = context.selectNode(node, "State");

--- a/src/widget/wcombobox.h
+++ b/src/widget/wcombobox.h
@@ -12,7 +12,6 @@ class WComboBox : public QComboBox, public WBaseWidget {
     Q_OBJECT
   public:
     explicit WComboBox(QWidget* pParent);
-    ~WComboBox() override;
 
     void setup(QDomNode node, const SkinContext& context);
 

--- a/src/widget/wcombobox.h
+++ b/src/widget/wcombobox.h
@@ -11,15 +11,15 @@
 class WComboBox : public QComboBox, public WBaseWidget {
     Q_OBJECT
   public:
-    WComboBox(QWidget* pParent);
-    virtual ~WComboBox();
+    explicit WComboBox(QWidget* pParent);
+    ~WComboBox() override;
 
     void setup(QDomNode node, const SkinContext& context);
 
-    void onConnectedControlChanged(double dParameter, double dValue);
+    void onConnectedControlChanged(double dParameter, double dValue) override;
 
   protected:
-    bool event(QEvent* pEvent);
+    bool event(QEvent* pEvent) override;
 
   private slots:
     void slotCurrentIndexChanged(int index);

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -12,8 +12,8 @@
 #include "library/coverartcache.h"
 #include "library/coverartutils.h"
 #include "library/dlgcoverartfullsize.h"
-#include "util/math.h"
 #include "util/dnd.h"
+#include "util/math.h"
 
 WCoverArt::WCoverArt(QWidget* parent,
                      UserSettingsPointer pConfig,
@@ -29,7 +29,7 @@ WCoverArt::WCoverArt(QWidget* parent,
     setAcceptDrops(!m_group.isEmpty());
 
     CoverArtCache* pCache = CoverArtCache::instance();
-    if (pCache != NULL) {
+    if (pCache != nullptr) {
         connect(pCache, SIGNAL(coverFound(const QObject*, const int,
                                           const CoverInfo&, QPixmap, bool)),
                 this, SLOT(slotCoverFound(const QObject*, const int,
@@ -149,7 +149,7 @@ void WCoverArt::slotTrackCoverArtUpdated() {
         m_lastRequestedCover = m_loadedTrack->getCoverInfo();
         m_lastRequestedCover.trackLocation = m_loadedTrack->getLocation();
         CoverArtCache* pCache = CoverArtCache::instance();
-        if (pCache != NULL) {
+        if (pCache != nullptr) {
             // TODO(rryan): Don't use track id.
             pCache->requestCover(m_lastRequestedCover, this, m_loadedTrack->getId().toInt());
         }
@@ -184,7 +184,7 @@ QPixmap WCoverArt::scaledCoverArt(const QPixmap& normal) {
     return normal.scaled(size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
 }
 
-void WCoverArt::paintEvent(QPaintEvent*) {
+void WCoverArt::paintEvent(QPaintEvent* /*unused*/) {
     QStyleOption option;
     option.initFrom(this);
     QStylePainter painter(this);
@@ -209,7 +209,7 @@ void WCoverArt::paintEvent(QPaintEvent*) {
     }
 }
 
-void WCoverArt::resizeEvent(QResizeEvent*) {
+void WCoverArt::resizeEvent(QResizeEvent* /*unused*/) {
     m_loadedCoverScaled = scaledCoverArt(m_loadedCover);
     m_defaultCoverScaled = scaledCoverArt(m_defaultCover);
 }
@@ -231,7 +231,7 @@ void WCoverArt::mousePressEvent(QMouseEvent* event) {
     }
 }
 
-void WCoverArt::leaveEvent(QEvent*) {
+void WCoverArt::leaveEvent(QEvent* /*unused*/) {
     m_pDlgFullSize->close();
 }
 

--- a/src/widget/wcoverart.h
+++ b/src/widget/wcoverart.h
@@ -20,7 +20,7 @@ class WCoverArt : public QWidget, public WBaseWidget {
   public:
     WCoverArt(QWidget* parent, UserSettingsPointer pConfig,
               const QString& group);
-    virtual ~WCoverArt();
+    ~WCoverArt() override;
 
     void setup(QDomNode node, const SkinContext& context);
 
@@ -41,14 +41,14 @@ class WCoverArt : public QWidget, public WBaseWidget {
     void slotTrackCoverArtUpdated();
 
   protected:
-    void paintEvent(QPaintEvent*);
-    void resizeEvent(QResizeEvent*);
-    void mousePressEvent(QMouseEvent*);
-    void leaveEvent(QEvent*);
+    void paintEvent(QPaintEvent* /*unused*/) override;
+    void resizeEvent(QResizeEvent* /*unused*/) override;
+    void mousePressEvent(QMouseEvent* /*unused*/) override;
+    void leaveEvent(QEvent* /*unused*/) override;
 
-    void dragEnterEvent(QDragEnterEvent *event);
-    void dropEvent(QDropEvent *event);
-    void mouseMoveEvent(QMouseEvent *event);
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
 
   private:
     QPixmap scaledCoverArt(const QPixmap& normal);

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -71,6 +71,6 @@ void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
     }
 }
 
-void WCoverArtLabel::leaveEvent(QEvent*) {
+void WCoverArtLabel::leaveEvent(QEvent* /*unused*/) {
     m_pDlgFullSize->close();
 }

--- a/src/widget/wcoverartlabel.h
+++ b/src/widget/wcoverartlabel.h
@@ -13,8 +13,8 @@ class DlgCoverArtFullSize;
 class WCoverArtLabel : public QLabel {
     Q_OBJECT
   public:
-    WCoverArtLabel(QWidget* parent = 0);
-    virtual ~WCoverArtLabel();
+    explicit WCoverArtLabel(QWidget* parent = nullptr);
+    ~WCoverArtLabel() override;
 
     void setCoverArt(const QString& trackLocation, const CoverInfo& coverInfo, QPixmap px);
 
@@ -23,8 +23,8 @@ class WCoverArtLabel : public QLabel {
     void reloadCoverArt();
 
   protected:
-    void leaveEvent(QEvent*);
-    void mousePressEvent(QMouseEvent* event);
+    void leaveEvent(QEvent* /*unused*/) override;
+    void mousePressEvent(QMouseEvent* event) override;
 
   private slots:
       void slotCoverMenu(const QPoint& pos);

--- a/src/widget/wcoverartmenu.cpp
+++ b/src/widget/wcoverartmenu.cpp
@@ -57,7 +57,7 @@ void WCoverArtMenu::slotChange() {
     }
 
     QStringList extensions = CoverArtUtils::supportedCoverArtExtensions();
-    for (auto & extension : extensions) {
+    for (auto&& extension : extensions) {
         extension.prepend("*.");
     }
     QString supportedText = QString("%1 (%2)").arg(tr("Image Files"))

--- a/src/widget/wcoverartmenu.cpp
+++ b/src/widget/wcoverartmenu.cpp
@@ -57,8 +57,8 @@ void WCoverArtMenu::slotChange() {
     }
 
     QStringList extensions = CoverArtUtils::supportedCoverArtExtensions();
-    for (QStringList::iterator it = extensions.begin(); it != extensions.end(); ++it) {
-        it->prepend("*.");
+    for (auto & extension : extensions) {
+        extension.prepend("*.");
     }
     QString supportedText = QString("%1 (%2)").arg(tr("Image Files"))
             .arg(extensions.join(" "));

--- a/src/widget/wcoverartmenu.h
+++ b/src/widget/wcoverartmenu.h
@@ -17,8 +17,8 @@
 class WCoverArtMenu : public QMenu {
     Q_OBJECT
   public:
-    WCoverArtMenu(QWidget *parent = 0);
-    virtual ~WCoverArtMenu();
+    explicit WCoverArtMenu(QWidget *parent = nullptr);
+    ~WCoverArtMenu() override;
 
     void setCoverArt(const QString& trackLocation, const CoverInfo& coverInfo);
 

--- a/src/widget/wdisplay.cpp
+++ b/src/widget/wdisplay.cpp
@@ -28,7 +28,7 @@
 WDisplay::WDisplay(QWidget * parent)
         : WWidget(parent),
           m_iCurrentPixmap(0),
-          m_pPixmapBack(NULL),
+          m_pPixmapBack(nullptr),
           m_bDisabledLoaded(false) {
     setPositions(0);
 }
@@ -171,7 +171,7 @@ void WDisplay::onConnectedControlChanged(double dParameter, double dValue) {
     }
 }
 
-void WDisplay::paintEvent(QPaintEvent*) {
+void WDisplay::paintEvent(QPaintEvent* /*unused*/) {
     QStyleOption option;
     option.initFrom(this);
     QStylePainter p(this);

--- a/src/widget/wdisplay.h
+++ b/src/widget/wdisplay.h
@@ -30,15 +30,15 @@
 class WDisplay : public WWidget {
    Q_OBJECT
   public:
-    WDisplay(QWidget *parent=NULL);
-    virtual ~WDisplay();
+    explicit WDisplay(QWidget *parent=nullptr);
+    ~WDisplay() override;
 
     void setup(QDomNode node, const SkinContext& context);
 
-    void onConnectedControlChanged(double dParameter, double dValue);
+    void onConnectedControlChanged(double dParameter, double dValue) override;
 
   protected:
-    void paintEvent(QPaintEvent*);
+    void paintEvent(QPaintEvent* /*unused*/) override;
 
     int numPixmaps() const {
         return m_pixmaps.size();

--- a/src/widget/weffect.cpp
+++ b/src/widget/weffect.cpp
@@ -11,8 +11,6 @@ WEffect::WEffect(QWidget* pParent, EffectsManager* pEffectsManager)
     effectUpdated();
 }
 
-WEffect::~WEffect() = default;
-
 void WEffect::setup(QDomNode node, const SkinContext& context) {
     WLabel::setup(node, context);
     // EffectWidgetUtils propagates NULLs so this is all safe.

--- a/src/widget/weffect.cpp
+++ b/src/widget/weffect.cpp
@@ -11,8 +11,7 @@ WEffect::WEffect(QWidget* pParent, EffectsManager* pEffectsManager)
     effectUpdated();
 }
 
-WEffect::~WEffect() {
-}
+WEffect::~WEffect() = default;
 
 void WEffect::setup(QDomNode node, const SkinContext& context) {
     WLabel::setup(node, context);

--- a/src/widget/weffect.h
+++ b/src/widget/weffect.h
@@ -13,9 +13,9 @@ class WEffect : public WLabel {
     Q_OBJECT
   public:
     WEffect(QWidget* pParent, EffectsManager* pEffectsManager);
-    virtual ~WEffect();
+    ~WEffect() override;
 
-    void setup(QDomNode node, const SkinContext& context);
+    void setup(QDomNode node, const SkinContext& context) override;
 
   private slots:
     void effectUpdated();

--- a/src/widget/weffect.h
+++ b/src/widget/weffect.h
@@ -13,7 +13,6 @@ class WEffect : public WLabel {
     Q_OBJECT
   public:
     WEffect(QWidget* pParent, EffectsManager* pEffectsManager);
-    ~WEffect() override;
 
     void setup(QDomNode node, const SkinContext& context) override;
 

--- a/src/widget/weffectbuttonparameter.cpp
+++ b/src/widget/weffectbuttonparameter.cpp
@@ -8,8 +8,6 @@ WEffectButtonParameter::WEffectButtonParameter(QWidget* pParent, EffectsManager*
         : WEffectParameterBase(pParent, pEffectsManager) {
 }
 
-WEffectButtonParameter::~WEffectButtonParameter() = default;
-
 void WEffectButtonParameter::setup(QDomNode node, const SkinContext& context) {
     // EffectWidgetUtils propagates NULLs so this is all safe.
     EffectRackPointer pRack = EffectWidgetUtils::getEffectRackFromNode(

--- a/src/widget/weffectbuttonparameter.cpp
+++ b/src/widget/weffectbuttonparameter.cpp
@@ -8,8 +8,7 @@ WEffectButtonParameter::WEffectButtonParameter(QWidget* pParent, EffectsManager*
         : WEffectParameterBase(pParent, pEffectsManager) {
 }
 
-WEffectButtonParameter::~WEffectButtonParameter() {
-}
+WEffectButtonParameter::~WEffectButtonParameter() = default;
 
 void WEffectButtonParameter::setup(QDomNode node, const SkinContext& context) {
     // EffectWidgetUtils propagates NULLs so this is all safe.

--- a/src/widget/weffectbuttonparameter.h
+++ b/src/widget/weffectbuttonparameter.h
@@ -13,7 +13,6 @@ class WEffectButtonParameter : public WEffectParameterBase {
     Q_OBJECT
   public:
     WEffectButtonParameter(QWidget* pParent, EffectsManager* pEffectsManager);
-    ~WEffectButtonParameter() override;
 
     void setup(QDomNode node, const SkinContext& context) override;
 };

--- a/src/widget/weffectbuttonparameter.h
+++ b/src/widget/weffectbuttonparameter.h
@@ -13,9 +13,9 @@ class WEffectButtonParameter : public WEffectParameterBase {
     Q_OBJECT
   public:
     WEffectButtonParameter(QWidget* pParent, EffectsManager* pEffectsManager);
-    virtual ~WEffectButtonParameter();
+    ~WEffectButtonParameter() override;
 
-    void setup(QDomNode node, const SkinContext& context);
+    void setup(QDomNode node, const SkinContext& context) override;
 };
 
 

--- a/src/widget/weffectchain.cpp
+++ b/src/widget/weffectchain.cpp
@@ -10,8 +10,7 @@ WEffectChain::WEffectChain(QWidget* pParent, EffectsManager* pEffectsManager)
     chainUpdated();
 }
 
-WEffectChain::~WEffectChain() {
-}
+WEffectChain::~WEffectChain() = default;
 
 void WEffectChain::setup(QDomNode node, const SkinContext& context) {
     WLabel::setup(node, context);

--- a/src/widget/weffectchain.cpp
+++ b/src/widget/weffectchain.cpp
@@ -10,8 +10,6 @@ WEffectChain::WEffectChain(QWidget* pParent, EffectsManager* pEffectsManager)
     chainUpdated();
 }
 
-WEffectChain::~WEffectChain() = default;
-
 void WEffectChain::setup(QDomNode node, const SkinContext& context) {
     WLabel::setup(node, context);
     // EffectWidgetUtils propagates NULLs so this is all safe.

--- a/src/widget/weffectchain.h
+++ b/src/widget/weffectchain.h
@@ -15,9 +15,9 @@ class WEffectChain : public WLabel {
     Q_OBJECT
   public:
     WEffectChain(QWidget* pParent, EffectsManager* pEffectsManager);
-    virtual ~WEffectChain();
+    ~WEffectChain() override;
 
-    void setup(QDomNode node, const SkinContext& context);
+    void setup(QDomNode node, const SkinContext& context) override;
 
   private slots:
     void chainUpdated();

--- a/src/widget/weffectchain.h
+++ b/src/widget/weffectchain.h
@@ -15,7 +15,6 @@ class WEffectChain : public WLabel {
     Q_OBJECT
   public:
     WEffectChain(QWidget* pParent, EffectsManager* pEffectsManager);
-    ~WEffectChain() override;
 
     void setup(QDomNode node, const SkinContext& context) override;
 

--- a/src/widget/weffectparameter.cpp
+++ b/src/widget/weffectparameter.cpp
@@ -8,8 +8,7 @@ WEffectParameter::WEffectParameter(QWidget* pParent, EffectsManager* pEffectsMan
         : WEffectParameterBase(pParent, pEffectsManager) {
 }
 
-WEffectParameter::~WEffectParameter() {
-}
+WEffectParameter::~WEffectParameter() = default;
 
 void WEffectParameter::setup(QDomNode node, const SkinContext& context) {
     // EffectWidgetUtils propagates NULLs so this is all safe.

--- a/src/widget/weffectparameter.cpp
+++ b/src/widget/weffectparameter.cpp
@@ -8,8 +8,6 @@ WEffectParameter::WEffectParameter(QWidget* pParent, EffectsManager* pEffectsMan
         : WEffectParameterBase(pParent, pEffectsManager) {
 }
 
-WEffectParameter::~WEffectParameter() = default;
-
 void WEffectParameter::setup(QDomNode node, const SkinContext& context) {
     // EffectWidgetUtils propagates NULLs so this is all safe.
     EffectRackPointer pRack = EffectWidgetUtils::getEffectRackFromNode(

--- a/src/widget/weffectparameter.h
+++ b/src/widget/weffectparameter.h
@@ -13,9 +13,9 @@ class WEffectParameter : public WEffectParameterBase {
     Q_OBJECT
   public:
     WEffectParameter(QWidget* pParent, EffectsManager* pEffectsManager);
-    virtual ~WEffectParameter();
+    ~WEffectParameter() override;
 
-    void setup(QDomNode node, const SkinContext& context);
+    void setup(QDomNode node, const SkinContext& context) override;
 };
 
 

--- a/src/widget/weffectparameter.h
+++ b/src/widget/weffectparameter.h
@@ -13,7 +13,6 @@ class WEffectParameter : public WEffectParameterBase {
     Q_OBJECT
   public:
     WEffectParameter(QWidget* pParent, EffectsManager* pEffectsManager);
-    ~WEffectParameter() override;
 
     void setup(QDomNode node, const SkinContext& context) override;
 };

--- a/src/widget/weffectparameterbase.cpp
+++ b/src/widget/weffectparameterbase.cpp
@@ -9,8 +9,7 @@ WEffectParameterBase::WEffectParameterBase(QWidget* pParent, EffectsManager* pEf
     parameterUpdated();
 }
 
-WEffectParameterBase::~WEffectParameterBase() {
-}
+WEffectParameterBase::~WEffectParameterBase() = default;
 
 void WEffectParameterBase::setEffectParameterSlot(
         EffectParameterSlotBasePointer pEffectParameterSlot) {

--- a/src/widget/weffectparameterbase.cpp
+++ b/src/widget/weffectparameterbase.cpp
@@ -9,8 +9,6 @@ WEffectParameterBase::WEffectParameterBase(QWidget* pParent, EffectsManager* pEf
     parameterUpdated();
 }
 
-WEffectParameterBase::~WEffectParameterBase() = default;
-
 void WEffectParameterBase::setEffectParameterSlot(
         EffectParameterSlotBasePointer pEffectParameterSlot) {
     m_pEffectParameterSlot = pEffectParameterSlot;

--- a/src/widget/weffectparameterbase.h
+++ b/src/widget/weffectparameterbase.h
@@ -13,7 +13,6 @@ class WEffectParameterBase : public WLabel {
     Q_OBJECT
   public:
     WEffectParameterBase(QWidget* pParent, EffectsManager* pEffectsManager);
-    ~WEffectParameterBase() override;
 
     void setup(QDomNode node, const SkinContext& context) override = 0;
 

--- a/src/widget/weffectparameterbase.h
+++ b/src/widget/weffectparameterbase.h
@@ -13,9 +13,9 @@ class WEffectParameterBase : public WLabel {
     Q_OBJECT
   public:
     WEffectParameterBase(QWidget* pParent, EffectsManager* pEffectsManager);
-    virtual ~WEffectParameterBase();
+    ~WEffectParameterBase() override;
 
-    virtual void setup(QDomNode node, const SkinContext& context) = 0;
+    void setup(QDomNode node, const SkinContext& context) override = 0;
 
   protected slots:
     void parameterUpdated();

--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -7,11 +7,10 @@
 WEffectPushButton::WEffectPushButton(QWidget* pParent, EffectsManager* pEffectsManager)
         : WPushButton(pParent),
           m_pEffectsManager(pEffectsManager),
-          m_pButtonMenu(NULL) {
+          m_pButtonMenu(nullptr) {
 }
 
-WEffectPushButton::~WEffectPushButton() {
-}
+WEffectPushButton::~WEffectPushButton() = default;
 
 void WEffectPushButton::setup(QDomNode node, const SkinContext& context) {
     // Setup parent class.
@@ -100,17 +99,17 @@ void WEffectPushButton::parameterUpdated() {
     }
     double value = getControlParameterLeft();
 
-    QActionGroup* actionGroup = new QActionGroup(m_pButtonMenu);
+    auto  actionGroup = new QActionGroup(m_pButtonMenu);
     actionGroup->setExclusive(true);
-    for (int i = 0; i < options.size(); i++) {
+    for (const auto & option : options) {
         // action is added automatically to actionGroup
-        QAction* action = new QAction(actionGroup);
+        auto  action = new QAction(actionGroup);
         // qDebug() << options[i].first;
-        action->setText(options[i].first);
-        action->setData(options[i].second);
+        action->setText(option.first);
+        action->setData(option.second);
         action->setCheckable(true);
 
-        if (options[i].second == value) {
+        if (option.second == value) {
             action->setChecked(true);
         }
         m_pButtonMenu->addAction(action);

--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -79,7 +79,7 @@ void WEffectPushButton::mouseReleaseEvent(QMouseEvent* e) {
     // The release handler may have set the left value. Check the corresponding
     // QAction.
     double leftValue = getControlParameterLeft();
-    for (const auto& action : m_pButtonMenu->actions()) {
+    for (QAction* action : m_pButtonMenu->actions()) {
         if (action->data().toDouble() == leftValue) {
             action->setChecked(true);
             break;

--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -42,7 +42,7 @@ void WEffectPushButton::setup(QDomNode node, const SkinContext& context) {
 }
 
 void WEffectPushButton::onConnectedControlChanged(double dParameter, double dValue) {
-    foreach (QAction* action, m_pButtonMenu->actions()) {
+    for (const auto& action : m_pButtonMenu->actions()) {
         if (action->data().toDouble() == dValue) {
             action->setChecked(true);
             break;
@@ -64,7 +64,7 @@ void WEffectPushButton::mousePressEvent(QMouseEvent* e) {
     // The push handler may have set the left value. Check the corresponding
     // QAction.
     double leftValue = getControlParameterLeft();
-    foreach (QAction* action, m_pButtonMenu->actions()) {
+    for (const auto& action : m_pButtonMenu->actions()) {
         if (action->data().toDouble() == leftValue) {
             action->setChecked(true);
             break;
@@ -79,7 +79,7 @@ void WEffectPushButton::mouseReleaseEvent(QMouseEvent* e) {
     // The release handler may have set the left value. Check the corresponding
     // QAction.
     double leftValue = getControlParameterLeft();
-    foreach (QAction* action, m_pButtonMenu->actions()) {
+    for (const auto& action : m_pButtonMenu->actions()) {
         if (action->data().toDouble() == leftValue) {
             action->setChecked(true);
             break;
@@ -99,11 +99,11 @@ void WEffectPushButton::parameterUpdated() {
     }
     double value = getControlParameterLeft();
 
-    auto  actionGroup = new QActionGroup(m_pButtonMenu);
+    auto actionGroup = new QActionGroup(m_pButtonMenu);
     actionGroup->setExclusive(true);
-    for (const auto & option : options) {
+    for (const auto& option : options) {
         // action is added automatically to actionGroup
-        auto  action = new QAction(actionGroup);
+        auto action = new QAction(actionGroup);
         // qDebug() << options[i].first;
         action->setText(option.first);
         action->setData(option.second);

--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -10,8 +10,6 @@ WEffectPushButton::WEffectPushButton(QWidget* pParent, EffectsManager* pEffectsM
           m_pButtonMenu(nullptr) {
 }
 
-WEffectPushButton::~WEffectPushButton() = default;
-
 void WEffectPushButton::setup(QDomNode node, const SkinContext& context) {
     // Setup parent class.
     WPushButton::setup(node, context);

--- a/src/widget/weffectpushbutton.h
+++ b/src/widget/weffectpushbutton.h
@@ -15,7 +15,6 @@ class WEffectPushButton : public WPushButton {
     Q_OBJECT
   public:
     WEffectPushButton(QWidget* pParent, EffectsManager* pEffectsManager);
-    ~WEffectPushButton() override;
 
     void setup(QDomNode node, const SkinContext& context) override;
 

--- a/src/widget/weffectpushbutton.h
+++ b/src/widget/weffectpushbutton.h
@@ -8,23 +8,23 @@
 #include <QWidget>
 
 #include "widget/wpushbutton.h"
-#include "skin/skincontext.h"
 #include "effects/effectsmanager.h"
+#include "skin/skincontext.h"
 
 class WEffectPushButton : public WPushButton {
     Q_OBJECT
   public:
     WEffectPushButton(QWidget* pParent, EffectsManager* pEffectsManager);
-    virtual ~WEffectPushButton();
+    ~WEffectPushButton() override;
 
-    virtual void setup(QDomNode node, const SkinContext& context);
+    void setup(QDomNode node, const SkinContext& context) override;
 
   public slots:
-    virtual void onConnectedControlChanged(double dParameter, double dValue);
+    void onConnectedControlChanged(double dParameter, double dValue) override;
 
   protected:
-    virtual void mousePressEvent(QMouseEvent* e);
-    virtual void mouseReleaseEvent(QMouseEvent* e);
+    void mousePressEvent(QMouseEvent* e) override;
+    void mouseReleaseEvent(QMouseEvent* e) override;
 
   private slots:
     void parameterUpdated();

--- a/src/widget/wimagestore.cpp
+++ b/src/widget/wimagestore.cpp
@@ -21,7 +21,7 @@ QImage* WImageStore::getImage(const QString& fileName) {
 // static
 QImage* WImageStore::getImage(const PixmapSource& source) {
     // Search for Image in list
-    ImageInfoType* info = NULL;
+    ImageInfoType* info = nullptr;
 
     QHash<QString, ImageInfoType*>::iterator it = m_dictionary.find(source.getId());
     if (it != m_dictionary.end()) {
@@ -36,14 +36,14 @@ QImage* WImageStore::getImage(const PixmapSource& source) {
 
     QImage* loadedImage = getImageNoCache(source);
 
-    if (loadedImage == NULL) {
-        return NULL;
+    if (loadedImage == nullptr) {
+        return nullptr;
     }
 
     if (loadedImage->isNull()) {
-        qDebug() << "WImageStore couldn't load:" << source.getPath() << (loadedImage == NULL);
+        qDebug() << "WImageStore couldn't load:" << source.getPath() << (loadedImage == nullptr);
         delete loadedImage;
-        return NULL;
+        return nullptr;
     }
 
     info = new ImageInfoType;
@@ -82,7 +82,7 @@ QImage* WImageStore::getImageNoCache(const PixmapSource& source) {
 void WImageStore::deleteImage(QImage * p)
 {
     // Search for Image in list
-    ImageInfoType *info = NULL;
+    ImageInfoType *info = nullptr;
     QMutableHashIterator<QString, ImageInfoType*> it(m_dictionary);
 
     while (it.hasNext())

--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -12,8 +12,7 @@ WKey::WKey(const char* group, QWidget* pParent)
     m_engineKeyDistance.connectValueChanged(SLOT(setCents()));
 }
 
-WKey::~WKey() {
-}
+WKey::~WKey() = default;
 
 void WKey::onConnectedControlChanged(double dParameter, double dValue) {
     Q_UNUSED(dParameter);

--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -12,8 +12,6 @@ WKey::WKey(const char* group, QWidget* pParent)
     m_engineKeyDistance.connectValueChanged(SLOT(setCents()));
 }
 
-WKey::~WKey() = default;
-
 void WKey::onConnectedControlChanged(double dParameter, double dValue) {
     Q_UNUSED(dParameter);
     // Enums are not currently represented using parameter space so it doesn't

--- a/src/widget/wkey.h
+++ b/src/widget/wkey.h
@@ -9,11 +9,11 @@
 class WKey : public WLabel  {
     Q_OBJECT
   public:
-    WKey(const char* group, QWidget* pParent=NULL);
-    virtual ~WKey();
+    explicit WKey(const char* group, QWidget* pParent=nullptr);
+    ~WKey() override;
 
-    virtual void onConnectedControlChanged(double dParameter, double dValue);
-    void setup(QDomNode node, const SkinContext& context);
+    void onConnectedControlChanged(double dParameter, double dValue) override;
+    void setup(QDomNode node, const SkinContext& context) override;
 
   private slots:
     void setValue(double dValue);

--- a/src/widget/wkey.h
+++ b/src/widget/wkey.h
@@ -10,7 +10,6 @@ class WKey : public WLabel  {
     Q_OBJECT
   public:
     explicit WKey(const char* group, QWidget* pParent=nullptr);
-    ~WKey() override;
 
     void onConnectedControlChanged(double dParameter, double dValue) override;
     void setup(QDomNode node, const SkinContext& context) override;

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -25,8 +25,6 @@ WKnob::WKnob(QWidget* pParent)
         : WDisplay(pParent) {
 }
 
-WKnob::~WKnob() = default;
-
 void WKnob::mouseMoveEvent(QMouseEvent* e) {
     m_handler.mouseMoveEvent(this, e);
 }

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -25,8 +25,7 @@ WKnob::WKnob(QWidget* pParent)
         : WDisplay(pParent) {
 }
 
-WKnob::~WKnob() {
-}
+WKnob::~WKnob() = default;
 
 void WKnob::mouseMoveEvent(QMouseEvent* e) {
     m_handler.mouseMoveEvent(this, e);

--- a/src/widget/wknob.h
+++ b/src/widget/wknob.h
@@ -30,14 +30,14 @@
 class WKnob : public WDisplay {
    Q_OBJECT
   public:
-    WKnob(QWidget* pParent=NULL);
-    virtual ~WKnob();
+    explicit WKnob(QWidget* pParent=nullptr);
+    ~WKnob() override;
 
   protected:
-    void wheelEvent(QWheelEvent *e);
-    void mouseMoveEvent(QMouseEvent *e);
-    void mousePressEvent(QMouseEvent *e);
-    void mouseReleaseEvent(QMouseEvent *e);
+    void wheelEvent(QWheelEvent *e) override;
+    void mouseMoveEvent(QMouseEvent *e) override;
+    void mousePressEvent(QMouseEvent *e) override;
+    void mouseReleaseEvent(QMouseEvent *e) override;
 
   private:
     KnobEventHandler<WKnob> m_handler;

--- a/src/widget/wknob.h
+++ b/src/widget/wknob.h
@@ -31,7 +31,6 @@ class WKnob : public WDisplay {
    Q_OBJECT
   public:
     explicit WKnob(QWidget* pParent=nullptr);
-    ~WKnob() override;
 
   protected:
     void wheelEvent(QWheelEvent *e) override;

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -13,8 +13,7 @@ WKnobComposed::WKnobComposed(QWidget* pParent)
           m_dKnobCenterYOffset(0) {
 }
 
-WKnobComposed::~WKnobComposed() {
-}
+WKnobComposed::~WKnobComposed() = default;
 
 void WKnobComposed::setup(QDomNode node, const SkinContext& context) {
     clear();

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -13,8 +13,6 @@ WKnobComposed::WKnobComposed(QWidget* pParent)
           m_dKnobCenterYOffset(0) {
 }
 
-WKnobComposed::~WKnobComposed() = default;
-
 void WKnobComposed::setup(QDomNode node, const SkinContext& context) {
     clear();
 

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -16,7 +16,6 @@ class WKnobComposed : public WWidget {
     Q_OBJECT
   public:
     explicit WKnobComposed(QWidget* pParent=nullptr);
-    ~WKnobComposed() override;
 
     void setup(QDomNode node, const SkinContext& context);
 

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -15,19 +15,19 @@
 class WKnobComposed : public WWidget {
     Q_OBJECT
   public:
-    WKnobComposed(QWidget* pParent=NULL);
-    virtual ~WKnobComposed();
+    explicit WKnobComposed(QWidget* pParent=nullptr);
+    ~WKnobComposed() override;
 
     void setup(QDomNode node, const SkinContext& context);
 
-    void onConnectedControlChanged(double dParameter, double dValue);
+    void onConnectedControlChanged(double dParameter, double dValue) override;
 
   protected:
-    void wheelEvent(QWheelEvent *e);
-    void mouseMoveEvent(QMouseEvent *e);
-    void mousePressEvent(QMouseEvent *e);
-    void mouseReleaseEvent(QMouseEvent *e);
-    void paintEvent(QPaintEvent*);
+    void wheelEvent(QWheelEvent *e) override;
+    void mouseMoveEvent(QMouseEvent *e) override;
+    void mousePressEvent(QMouseEvent *e) override;
+    void mouseReleaseEvent(QMouseEvent *e) override;
+    void paintEvent(QPaintEvent* /*unused*/) override;
 
   private:
     void clear();

--- a/src/widget/wlabel.cpp
+++ b/src/widget/wlabel.cpp
@@ -29,8 +29,7 @@ WLabel::WLabel(QWidget* pParent)
           m_elideMode(Qt::ElideNone) {
 }
 
-WLabel::~WLabel() {
-}
+WLabel::~WLabel() = default;
 
 void WLabel::setup(QDomNode node, const SkinContext& context) {
     // Colors

--- a/src/widget/wlabel.cpp
+++ b/src/widget/wlabel.cpp
@@ -29,8 +29,6 @@ WLabel::WLabel(QWidget* pParent)
           m_elideMode(Qt::ElideNone) {
 }
 
-WLabel::~WLabel() = default;
-
 void WLabel::setup(QDomNode node, const SkinContext& context) {
     // Colors
     QPalette pal = palette(); //we have to copy out the palette to edit it since it's const (probably for threadsafety)

--- a/src/widget/wlabel.h
+++ b/src/widget/wlabel.h
@@ -27,8 +27,8 @@
 class WLabel : public QLabel, public WBaseWidget {
     Q_OBJECT
   public:
-    WLabel(QWidget* pParent=NULL);
-    virtual ~WLabel();
+    explicit WLabel(QWidget* pParent=nullptr);
+    ~WLabel() override;
 
     virtual void setup(QDomNode node, const SkinContext& context);
 
@@ -36,9 +36,9 @@ class WLabel : public QLabel, public WBaseWidget {
     void setText(const QString& text);
 
   protected:
-    virtual bool event(QEvent* pEvent);
-    virtual void resizeEvent(QResizeEvent* event);
-    void fillDebugTooltip(QStringList* debug);
+    bool event(QEvent* pEvent) override;
+    void resizeEvent(QResizeEvent* event) override;
+    void fillDebugTooltip(QStringList* debug) override;
     QString m_skinText;
     // Foreground and background colors.
     QColor m_qFgColor;

--- a/src/widget/wlabel.h
+++ b/src/widget/wlabel.h
@@ -28,7 +28,6 @@ class WLabel : public QLabel, public WBaseWidget {
     Q_OBJECT
   public:
     explicit WLabel(QWidget* pParent=nullptr);
-    ~WLabel() override;
 
     virtual void setup(QDomNode node, const SkinContext& context);
 
@@ -43,7 +42,7 @@ class WLabel : public QLabel, public WBaseWidget {
     // Foreground and background colors.
     QColor m_qFgColor;
     QColor m_qBgColor;
-  private: 
+  private:
     QString m_longText;
     Qt::TextElideMode m_elideMode;
 };

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -14,15 +14,14 @@ WLibrary::WLibrary(QWidget* parent)
           m_mutex(QMutex::Recursive) {
 }
 
-WLibrary::~WLibrary() {
-}
+WLibrary::~WLibrary() = default;
 
 bool WLibrary::registerView(QString name, QWidget* view) {
     QMutexLocker lock(&m_mutex);
     if (m_viewMap.contains(name)) {
         return false;
     }
-    if (dynamic_cast<LibraryView*>(view) == NULL) {
+    if (dynamic_cast<LibraryView*>(view) == nullptr) {
         qDebug() << "WARNING: Attempted to register a view with WLibrary "
                  << "that does not implement the LibraryView interface. "
                  << "Ignoring.";
@@ -36,10 +35,10 @@ bool WLibrary::registerView(QString name, QWidget* view) {
 void WLibrary::switchToView(const QString& name) {
     QMutexLocker lock(&m_mutex);
     //qDebug() << "WLibrary::switchToView" << name;
-    QWidget* widget = m_viewMap.value(name, NULL);
-    if (widget != NULL) {
+    QWidget* widget = m_viewMap.value(name, nullptr);
+    if (widget != nullptr) {
         LibraryView * lview = dynamic_cast<LibraryView*>(widget);
-        if (lview == NULL) {
+        if (lview == nullptr) {
             qDebug() << "WARNING: Attempted to register a view with WLibrary "
                      << "that does not implement the LibraryView interface. "
                      << "Ignoring.";
@@ -57,7 +56,7 @@ void WLibrary::search(const QString& name) {
     QMutexLocker lock(&m_mutex);
     QWidget* current = currentWidget();
     LibraryView* view = dynamic_cast<LibraryView*>(current);
-    if (view == NULL) {
+    if (view == nullptr) {
         qDebug() << "WARNING: Attempted to register a view with WLibrary "
           << "that does not implement the LibraryView interface. Ignoring.";
         return;

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -14,8 +14,6 @@ WLibrary::WLibrary(QWidget* parent)
           m_mutex(QMutex::Recursive) {
 }
 
-WLibrary::~WLibrary() = default;
-
 bool WLibrary::registerView(QString name, QWidget* view) {
     QMutexLocker lock(&m_mutex);
     if (m_viewMap.contains(name)) {

--- a/src/widget/wlibrary.h
+++ b/src/widget/wlibrary.h
@@ -19,7 +19,6 @@ class WLibrary : public QStackedWidget, public WBaseWidget {
     Q_OBJECT
   public:
     explicit WLibrary(QWidget* parent);
-    ~WLibrary() override;
 
     // registerView is used to add a view to the LibraryWidget which the widget
     // can disply on request via showView(). To switch to a given view, call

--- a/src/widget/wlibrary.h
+++ b/src/widget/wlibrary.h
@@ -18,8 +18,8 @@ class MixxxKeyboard;
 class WLibrary : public QStackedWidget, public WBaseWidget {
     Q_OBJECT
   public:
-    WLibrary(QWidget* parent);
-    virtual ~WLibrary();
+    explicit WLibrary(QWidget* parent);
+    ~WLibrary() override;
 
     // registerView is used to add a view to the LibraryWidget which the widget
     // can disply on request via showView(). To switch to a given view, call
@@ -40,7 +40,7 @@ class WLibrary : public QStackedWidget, public WBaseWidget {
     void search(const QString&);
 
   protected:
-    bool event(QEvent* pEvent);
+    bool event(QEvent* pEvent) override;
 
   private:
     QMutex m_mutex;

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -29,8 +29,7 @@ WLibrarySidebar::WLibrarySidebar(QWidget* parent)
     header()->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
 }
 
-WLibrarySidebar::~WLibrarySidebar() {
-}
+WLibrarySidebar::~WLibrarySidebar() = default;
 
 
 void WLibrarySidebar::contextMenuEvent(QContextMenuEvent *event) {
@@ -196,7 +195,7 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
 }
 
 void WLibrarySidebar::selectIndex(const QModelIndex& index) {
-    QItemSelectionModel* pModel = new QItemSelectionModel(model());
+    auto  pModel = new QItemSelectionModel(model());
     pModel->select(index, QItemSelectionModel::Select);
     setSelectionModel(pModel);
 

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -84,7 +84,7 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
             bool accepted = true;
             if (sidebarModel) {
                 accepted = false;
-                foreach (QUrl url, urls) {
+                for (const QUrl& url : urls) {
                     QModelIndex destIndex = this->indexAt(event->pos());
                     if (sidebarModel->dragMoveAccept(destIndex, url)) {
                         // We only need one URL to be valid for us
@@ -195,7 +195,7 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
 }
 
 void WLibrarySidebar::selectIndex(const QModelIndex& index) {
-    auto  pModel = new QItemSelectionModel(model());
+    auto pModel = new QItemSelectionModel(model());
     pModel->select(index, QItemSelectionModel::Select);
     setSelectionModel(pModel);
 

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -29,9 +29,6 @@ WLibrarySidebar::WLibrarySidebar(QWidget* parent)
     header()->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
 }
 
-WLibrarySidebar::~WLibrarySidebar() = default;
-
-
 void WLibrarySidebar::contextMenuEvent(QContextMenuEvent *event) {
     //if (event->state() & Qt::RightButton) { //Dis shiz don werk on windowze
     QModelIndex clickedItem = indexAt(event->pos());

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -18,7 +18,6 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     Q_OBJECT
   public:
     explicit WLibrarySidebar(QWidget* parent = nullptr);
-    ~WLibrarySidebar() override;
 
     void contextMenuEvent(QContextMenuEvent * event) override;
     void dragMoveEvent(QDragMoveEvent * event) override;

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -17,15 +17,15 @@
 class WLibrarySidebar : public QTreeView, public WBaseWidget {
     Q_OBJECT
   public:
-    WLibrarySidebar(QWidget* parent = 0);
-    virtual ~WLibrarySidebar();
+    explicit WLibrarySidebar(QWidget* parent = nullptr);
+    ~WLibrarySidebar() override;
 
-    void contextMenuEvent(QContextMenuEvent * event);
-    void dragMoveEvent(QDragMoveEvent * event);
-    void dragEnterEvent(QDragEnterEvent * event);
-    void dropEvent(QDropEvent * event);
-    void keyPressEvent(QKeyEvent* event);
-    void timerEvent(QTimerEvent* event);
+    void contextMenuEvent(QContextMenuEvent * event) override;
+    void dragMoveEvent(QDragMoveEvent * event) override;
+    void dragEnterEvent(QDragEnterEvent * event) override;
+    void dropEvent(QDropEvent * event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+    void timerEvent(QTimerEvent* event) override;
     void toggleSelectedItem();
 
   public slots:
@@ -36,7 +36,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void rightClicked(const QPoint&, const QModelIndex&);
 
   protected:
-    bool event(QEvent* pEvent);
+    bool event(QEvent* pEvent) override;
 
   private:
     QBasicTimer m_expandTimer;

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -85,7 +85,7 @@ void WLibraryTableView::saveVScrollBarPosState() {
 void WLibraryTableView::moveSelection(int delta) {
     QAbstractItemModel* pModel = model();
 
-    if (pModel == NULL) {
+    if (pModel == nullptr) {
         return;
     }
 
@@ -95,15 +95,17 @@ void WLibraryTableView::moveSelection(int delta) {
         if(delta > 0) {
             // i is positive, so we want to move the highlight down
             int row = current.row();
-            if (row + 1 < pModel->rowCount())
+            if (row + 1 < pModel->rowCount()) {
                 selectRow(row + 1);
+            }
 
             delta--;
         } else {
             // i is negative, so we want to move the highlight up
             int row = current.row();
-            if (row - 1 >= 0)
+            if (row - 1 >= 0) {
                 selectRow(row - 1);
+            }
 
             delta++;
         }

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -21,8 +21,8 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
     WLibraryTableView(QWidget* parent,
                       UserSettingsPointer pConfig,
                       ConfigKey vScrollBarPosKey);
-    virtual ~WLibraryTableView();
-    virtual void moveSelection(int delta);
+    ~WLibraryTableView() override;
+    void moveSelection(int delta) override;
 
   signals:
     void loadTrack(TrackPointer pTrack);

--- a/src/widget/wlibrarytextbrowser.cpp
+++ b/src/widget/wlibrarytextbrowser.cpp
@@ -7,5 +7,4 @@ WLibraryTextBrowser::WLibraryTextBrowser(QWidget* parent)
         : QTextBrowser(parent) {
 }
 
-WLibraryTextBrowser::~WLibraryTextBrowser() {
-}
+WLibraryTextBrowser::~WLibraryTextBrowser() = default;

--- a/src/widget/wlibrarytextbrowser.cpp
+++ b/src/widget/wlibrarytextbrowser.cpp
@@ -6,5 +6,3 @@
 WLibraryTextBrowser::WLibraryTextBrowser(QWidget* parent)
         : QTextBrowser(parent) {
 }
-
-WLibraryTextBrowser::~WLibraryTextBrowser() = default;

--- a/src/widget/wlibrarytextbrowser.h
+++ b/src/widget/wlibrarytextbrowser.h
@@ -12,7 +12,6 @@ class WLibraryTextBrowser : public QTextBrowser, public LibraryView {
     Q_OBJECT
   public:
     explicit WLibraryTextBrowser(QWidget* parent = nullptr);
-    ~WLibraryTextBrowser() override;
 
     void onShow() override {}
 };

--- a/src/widget/wlibrarytextbrowser.h
+++ b/src/widget/wlibrarytextbrowser.h
@@ -11,10 +11,10 @@
 class WLibraryTextBrowser : public QTextBrowser, public LibraryView {
     Q_OBJECT
   public:
-    WLibraryTextBrowser(QWidget* parent = NULL);
-    virtual ~WLibraryTextBrowser();
+    explicit WLibraryTextBrowser(QWidget* parent = nullptr);
+    ~WLibraryTextBrowser() override;
 
-    virtual void onShow() {}
+    void onShow() override {}
 };
 
 #endif /* WLIBRARYTEXTBROWSER_H */

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -72,8 +72,7 @@ WMainMenuBar::WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
             this, SIGNAL(toggleVinylControl(int)));
 }
 
-WMainMenuBar::~WMainMenuBar() {
-}
+WMainMenuBar::~WMainMenuBar() = default;
 
 void WMainMenuBar::initialize() {
     // FILE MENU
@@ -111,7 +110,7 @@ void WMainMenuBar::initialize() {
 
     QString quitTitle = tr("&Exit");
     QString quitText = tr("Quits Mixxx");
-    QAction* pFileQuit = new QAction(quitTitle, this);
+    auto  pFileQuit = new QAction(quitTitle, this);
     pFileQuit->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "FileMenu_Quit"),
                                                   tr("Ctrl+q"))));
@@ -129,7 +128,7 @@ void WMainMenuBar::initialize() {
 
     QString rescanTitle = tr("&Rescan Library");
     QString rescanText = tr("Rescans library folders for changes to tracks.");
-    QAction* pLibraryRescan = new QAction(rescanTitle, this);
+    auto  pLibraryRescan = new QAction(rescanTitle, this);
     pLibraryRescan->setStatusTip(rescanText);
     pLibraryRescan->setWhatsThis(buildWhatsThis(rescanTitle, rescanText));
     pLibraryRescan->setCheckable(false);
@@ -144,7 +143,7 @@ void WMainMenuBar::initialize() {
 
     QString createPlaylistTitle = tr("Create &New Playlist");
     QString createPlaylistText = tr("Create a new playlist");
-    QAction* pLibraryCreatePlaylist = new QAction(createPlaylistTitle, this);
+    auto  pLibraryCreatePlaylist = new QAction(createPlaylistTitle, this);
     pLibraryCreatePlaylist->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                   "LibraryMenu_NewPlaylist"),
@@ -158,7 +157,7 @@ void WMainMenuBar::initialize() {
 
     QString createCrateTitle = tr("Create New &Crate");
     QString createCrateText = tr("Create a new crate");
-    QAction* pLibraryCreateCrate = new QAction(createCrateTitle, this);
+    auto  pLibraryCreateCrate = new QAction(createCrateTitle, this);
     pLibraryCreateCrate->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                   "LibraryMenu_NewCrate"),
@@ -179,7 +178,7 @@ void WMainMenuBar::initialize() {
     QString showSamplersTitle = tr("Show Samplers");
     QString showSamplersText = tr("Show the sample deck section of the Mixxx interface.") +
             " " + mayNotBeSupported;
-    QAction* pViewShowSamplers = new QAction(showSamplersTitle, this);
+    auto  pViewShowSamplers = new QAction(showSamplersTitle, this);
     pViewShowSamplers->setCheckable(true);
     pViewShowSamplers->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
@@ -193,7 +192,7 @@ void WMainMenuBar::initialize() {
     QString showMicrophoneTitle = tr("Show Microphone Section");
     QString showMicrophoneText = tr("Show the microphone section of the Mixxx interface.") +
             " " + mayNotBeSupported;
-    QAction* pViewShowMicrophone = new QAction(showMicrophoneTitle, this);
+    auto  pViewShowMicrophone = new QAction(showMicrophoneTitle, this);
     pViewShowMicrophone->setCheckable(true);
     pViewShowMicrophone->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(
@@ -208,7 +207,7 @@ void WMainMenuBar::initialize() {
     QString showVinylControlTitle = tr("Show Vinyl Control Section");
     QString showVinylControlText = tr("Show the vinyl control section of the Mixxx interface.") +
             " " + mayNotBeSupported;
-    QAction* pViewVinylControl = new QAction(showVinylControlTitle, this);
+    auto  pViewVinylControl = new QAction(showVinylControlTitle, this);
     pViewVinylControl->setCheckable(true);
     pViewVinylControl->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(
@@ -223,7 +222,7 @@ void WMainMenuBar::initialize() {
     QString showPreviewDeckTitle = tr("Show Preview Deck");
     QString showPreviewDeckText = tr("Show the preview deck in the Mixxx interface.") +
             " " + mayNotBeSupported;
-    QAction* pViewShowPreviewDeck = new QAction(showPreviewDeckTitle, this);
+    auto  pViewShowPreviewDeck = new QAction(showPreviewDeckTitle, this);
     pViewShowPreviewDeck->setCheckable(true);
     pViewShowPreviewDeck->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
@@ -237,7 +236,7 @@ void WMainMenuBar::initialize() {
     QString showEffectsTitle = tr("Show Effect Rack");
     QString showEffectsText = tr("Show the effect rack in the Mixxx interface.") +
     " " + mayNotBeSupported;
-    QAction* pViewShowEffects = new QAction(showEffectsTitle, this);
+    auto  pViewShowEffects = new QAction(showEffectsTitle, this);
     pViewShowEffects->setCheckable(true);
     pViewShowEffects->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
@@ -252,7 +251,7 @@ void WMainMenuBar::initialize() {
     QString showCoverArtTitle = tr("Show Cover Art");
     QString showCoverArtText = tr("Show cover art in the Mixxx interface.") +
             " " + mayNotBeSupported;
-    QAction* pViewShowCoverArt = new QAction(showCoverArtTitle, this);
+    auto  pViewShowCoverArt = new QAction(showCoverArtTitle, this);
     pViewShowCoverArt->setCheckable(true);
     pViewShowCoverArt->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
@@ -267,7 +266,7 @@ void WMainMenuBar::initialize() {
     QString maximizeLibraryTitle = tr("Maximize Library");
     QString maximizeLibraryText = tr("Maximize the track library to take up all the available screen space.") +
             " " + mayNotBeSupported;
-    QAction* pViewMaximizeLibrary = new QAction(maximizeLibraryTitle, this);
+    auto  pViewMaximizeLibrary = new QAction(maximizeLibraryTitle, this);
     pViewMaximizeLibrary->setCheckable(true);
     pViewMaximizeLibrary->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
@@ -284,7 +283,7 @@ void WMainMenuBar::initialize() {
 
     QString fullScreenTitle = tr("&Full Screen");
     QString fullScreenText = tr("Display Mixxx using the full screen");
-    QAction* pViewFullScreen = new QAction(fullScreenTitle, this);
+    auto  pViewFullScreen = new QAction(fullScreenTitle, this);
     pViewFullScreen->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                   "ViewMenu_Fullscreen"),
@@ -312,7 +311,7 @@ void WMainMenuBar::initialize() {
 
     for (int i = 0; i < kMaximumVinylControlInputs; ++i) {
         QString vinylControlTitle = tr("Enable Vinyl Control &%1").arg(i + 1);
-        QAction* vc_checkbox = new QAction(vinylControlTitle, this);
+        auto  vc_checkbox = new QAction(vinylControlTitle, this);
         m_vinylControlEnabledActions.push_back(vc_checkbox);
 
         QString binding = m_pKbdConfig->getValueString(
@@ -346,7 +345,7 @@ void WMainMenuBar::initialize() {
 
     QString recordTitle = tr("&Record Mix");
     QString recordText = tr("Record your mix to a file");
-    QAction* pOptionsRecord = new QAction(recordTitle, this);
+    auto  pOptionsRecord = new QAction(recordTitle, this);
     pOptionsRecord->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                   "OptionsMenu_RecordMix"),
@@ -364,7 +363,7 @@ void WMainMenuBar::initialize() {
 #ifdef __SHOUTCAST__
     QString broadcastingTitle = tr("Enable Live &Broadcasting");
     QString broadcastingText = tr("Stream your mixes to a shoutcast or icecast server");
-    QAction* pOptionsBroadcasting = new QAction(broadcastingTitle, this);
+    auto  pOptionsBroadcasting = new QAction(broadcastingTitle, this);
     pOptionsBroadcasting->setShortcut(
             QKeySequence(m_pKbdConfig->getValueString(
                     ConfigKey("[KeyboardShortcuts]",
@@ -388,7 +387,7 @@ void WMainMenuBar::initialize() {
     QString keyboardShortcutText = tr("Toggles keyboard shortcuts on or off");
     bool keyboardShortcutsEnabled = m_pConfig->getValueString(
         ConfigKey("[Keyboard]", "Enabled")) == "1";
-    QAction* pOptionsKeyboard = new QAction(keyboardShortcutTitle, this);
+    auto  pOptionsKeyboard = new QAction(keyboardShortcutTitle, this);
     pOptionsKeyboard->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                   "OptionsMenu_EnableShortcuts"),
@@ -407,7 +406,7 @@ void WMainMenuBar::initialize() {
 
     QString preferencesTitle = tr("&Preferences");
     QString preferencesText = tr("Change Mixxx settings (e.g. playback, MIDI, controls)");
-    QAction* pOptionsPreferences = new QAction(preferencesTitle, this);
+    auto  pOptionsPreferences = new QAction(preferencesTitle, this);
     pOptionsPreferences->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                   "OptionsMenu_Preferences"),
@@ -428,7 +427,7 @@ void WMainMenuBar::initialize() {
 
         QString reloadSkinTitle = tr("&Reload Skin");
         QString reloadSkinText = tr("Reload the skin");
-        QAction* pDeveloperReloadSkin = new QAction(reloadSkinTitle, this);
+        auto  pDeveloperReloadSkin = new QAction(reloadSkinTitle, this);
         pDeveloperReloadSkin->setShortcut(
             QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                                 "OptionsMenu_ReloadSkin"),
@@ -442,7 +441,7 @@ void WMainMenuBar::initialize() {
 
         QString developerToolsTitle = tr("Developer &Tools");
         QString developerToolsText = tr("Opens the developer tools dialog");
-        QAction* pDeveloperTools = new QAction(developerToolsTitle, this);
+        auto  pDeveloperTools = new QAction(developerToolsTitle, this);
         pDeveloperTools->setShortcut(
             QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                                 "OptionsMenu_DeveloperTools"),
@@ -461,7 +460,7 @@ void WMainMenuBar::initialize() {
         QString enableExperimentTitle = tr("Stats: &Experiment Bucket");
         QString enableExperimentToolsText = tr(
             "Enables experiment mode. Collects stats in the EXPERIMENT tracking bucket.");
-        QAction* pDeveloperStatsExperiment = new QAction(enableExperimentTitle, this);
+        auto  pDeveloperStatsExperiment = new QAction(enableExperimentTitle, this);
         pDeveloperStatsExperiment->setShortcut(
             QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                                 "OptionsMenu_DeveloperStatsExperiment"),
@@ -479,7 +478,7 @@ void WMainMenuBar::initialize() {
         QString enableBaseTitle = tr("Stats: &Base Bucket");
         QString enableBaseToolsText = tr(
             "Enables base mode. Collects stats in the BASE tracking bucket.");
-        QAction* pDeveloperStatsBase = new QAction(enableBaseTitle, this);
+        auto  pDeveloperStatsBase = new QAction(enableBaseTitle, this);
         pDeveloperStatsBase->setShortcut(
             QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                                 "OptionsMenu_DeveloperStatsBase"),
@@ -499,7 +498,7 @@ void WMainMenuBar::initialize() {
         QString scriptDebuggerText = tr("Enables the debugger during skin parsing");
         bool scriptDebuggerEnabled = m_pConfig->getValueString(
             ConfigKey("[ScriptDebugger]", "Enabled")) == "1";
-        QAction* pDeveloperDebugger = new QAction(scriptDebuggerTitle, this);
+        auto  pDeveloperDebugger = new QAction(scriptDebuggerTitle, this);
         pDeveloperDebugger->setShortcut(
             QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                                 "DeveloperMenu_EnableDebugger"),
@@ -525,7 +524,7 @@ void WMainMenuBar::initialize() {
 
     QString supportTitle = tr("&Community Support") + externalLinkSuffix;
     QString supportText = tr("Get help with Mixxx");
-    QAction* pHelpSupport = new QAction(supportTitle, this);
+    auto  pHelpSupport = new QAction(supportTitle, this);
     pHelpSupport->setStatusTip(supportText);
     pHelpSupport->setWhatsThis(buildWhatsThis(supportTitle, supportText));
     m_visitUrlMapper.setMapping(pHelpSupport, MIXXX_SUPPORT_URL);
@@ -556,7 +555,7 @@ void WMainMenuBar::initialize() {
 
     QString manualTitle = tr("&User Manual") + externalLinkSuffix;
     QString manualText = tr("Read the Mixxx user manual.");
-    QAction* pHelpManual = new QAction(manualTitle, this);
+    auto  pHelpManual = new QAction(manualTitle, this);
     pHelpManual->setStatusTip(manualText);
     pHelpManual->setWhatsThis(buildWhatsThis(manualTitle, manualText));
     m_visitUrlMapper.setMapping(pHelpManual, qManualUrl.toString());
@@ -565,7 +564,7 @@ void WMainMenuBar::initialize() {
 
     QString shortcutsTitle = tr("&Keyboard Shortcuts") + externalLinkSuffix;
     QString shortcutsText = tr("Speed up your workflow with keyboard shortcuts.");
-    QAction* pHelpShortcuts = new QAction(shortcutsTitle, this);
+    auto  pHelpShortcuts = new QAction(shortcutsTitle, this);
     pHelpShortcuts->setStatusTip(shortcutsText);
     pHelpShortcuts->setWhatsThis(buildWhatsThis(shortcutsTitle, shortcutsText));
     m_visitUrlMapper.setMapping(pHelpShortcuts, MIXXX_SHORTCUTS_URL);
@@ -574,7 +573,7 @@ void WMainMenuBar::initialize() {
 
     QString feedbackTitle = tr("Send Us &Feedback") + externalLinkSuffix;
     QString feedbackText = tr("Send feedback to the Mixxx team.");
-    QAction* pHelpFeedback = new QAction(feedbackTitle, this);
+    auto  pHelpFeedback = new QAction(feedbackTitle, this);
     pHelpFeedback->setStatusTip(feedbackText);
     pHelpFeedback->setWhatsThis(buildWhatsThis(feedbackTitle, feedbackText));
     m_visitUrlMapper.setMapping(pHelpFeedback, MIXXX_FEEDBACK_URL);
@@ -583,7 +582,7 @@ void WMainMenuBar::initialize() {
 
     QString translateTitle = tr("&Translate This Application") + externalLinkSuffix;
     QString translateText = tr("Help translate this application into your language.");
-    QAction* pHelpTranslation = new QAction(translateTitle, this);
+    auto  pHelpTranslation = new QAction(translateTitle, this);
     pHelpTranslation->setStatusTip(translateText);
     pHelpTranslation->setWhatsThis(buildWhatsThis(translateTitle, translateText));
     m_visitUrlMapper.setMapping(pHelpTranslation, MIXXX_TRANSLATION_URL);
@@ -594,7 +593,7 @@ void WMainMenuBar::initialize() {
 
     QString aboutTitle = tr("&About");
     QString aboutText = tr("About the application");
-    QAction* pHelpAboutApp = new QAction(aboutTitle, this);
+    auto  pHelpAboutApp = new QAction(aboutTitle, this);
     pHelpAboutApp->setStatusTip(aboutText);
     pHelpAboutApp->setWhatsThis(buildWhatsThis(aboutTitle, aboutText));
     pHelpAboutApp->setMenuRole(QAction::AboutRole);
@@ -676,7 +675,7 @@ void WMainMenuBar::slotVisitUrl(const QString& url) {
 
 void WMainMenuBar::createVisibilityControl(QAction* pAction,
                                            const ConfigKey& key) {
-    VisibilityControlConnection* pConnection =
+    auto  pConnection =
             new VisibilityControlConnection(this, pAction, key);
     connect(this, SIGNAL(internalOnNewSkinLoaded()),
             pConnection, SLOT(slotReconnectControl()));
@@ -705,8 +704,7 @@ VisibilityControlConnection::VisibilityControlConnection(
             this, SLOT(slotActionToggled(bool)));
 }
 
-VisibilityControlConnection::~VisibilityControlConnection() {
-}
+VisibilityControlConnection::~VisibilityControlConnection() = default;
 
 void VisibilityControlConnection::slotClearControl() {
     m_pControl.reset();

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -72,8 +72,6 @@ WMainMenuBar::WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
             this, SIGNAL(toggleVinylControl(int)));
 }
 
-WMainMenuBar::~WMainMenuBar() = default;
-
 void WMainMenuBar::initialize() {
     // FILE MENU
     QMenu* pFileMenu = new QMenu(tr("&File"));
@@ -702,8 +700,6 @@ VisibilityControlConnection::VisibilityControlConnection(
     connect(m_pAction, SIGNAL(triggered(bool)),
             this, SLOT(slotActionToggled(bool)));
 }
-
-VisibilityControlConnection::~VisibilityControlConnection() = default;
 
 void VisibilityControlConnection::slotClearControl() {
     m_pControl.reset();

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -110,7 +110,7 @@ void WMainMenuBar::initialize() {
 
     QString quitTitle = tr("&Exit");
     QString quitText = tr("Quits Mixxx");
-    auto  pFileQuit = new QAction(quitTitle, this);
+    auto pFileQuit = new QAction(quitTitle, this);
     pFileQuit->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]", "FileMenu_Quit"),
                                                   tr("Ctrl+q"))));
@@ -128,7 +128,7 @@ void WMainMenuBar::initialize() {
 
     QString rescanTitle = tr("&Rescan Library");
     QString rescanText = tr("Rescans library folders for changes to tracks.");
-    auto  pLibraryRescan = new QAction(rescanTitle, this);
+    auto pLibraryRescan = new QAction(rescanTitle, this);
     pLibraryRescan->setStatusTip(rescanText);
     pLibraryRescan->setWhatsThis(buildWhatsThis(rescanTitle, rescanText));
     pLibraryRescan->setCheckable(false);
@@ -143,7 +143,7 @@ void WMainMenuBar::initialize() {
 
     QString createPlaylistTitle = tr("Create &New Playlist");
     QString createPlaylistText = tr("Create a new playlist");
-    auto  pLibraryCreatePlaylist = new QAction(createPlaylistTitle, this);
+    auto pLibraryCreatePlaylist = new QAction(createPlaylistTitle, this);
     pLibraryCreatePlaylist->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                   "LibraryMenu_NewPlaylist"),
@@ -157,7 +157,7 @@ void WMainMenuBar::initialize() {
 
     QString createCrateTitle = tr("Create New &Crate");
     QString createCrateText = tr("Create a new crate");
-    auto  pLibraryCreateCrate = new QAction(createCrateTitle, this);
+    auto pLibraryCreateCrate = new QAction(createCrateTitle, this);
     pLibraryCreateCrate->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                   "LibraryMenu_NewCrate"),
@@ -178,7 +178,7 @@ void WMainMenuBar::initialize() {
     QString showSamplersTitle = tr("Show Samplers");
     QString showSamplersText = tr("Show the sample deck section of the Mixxx interface.") +
             " " + mayNotBeSupported;
-    auto  pViewShowSamplers = new QAction(showSamplersTitle, this);
+    auto pViewShowSamplers = new QAction(showSamplersTitle, this);
     pViewShowSamplers->setCheckable(true);
     pViewShowSamplers->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
@@ -192,7 +192,7 @@ void WMainMenuBar::initialize() {
     QString showMicrophoneTitle = tr("Show Microphone Section");
     QString showMicrophoneText = tr("Show the microphone section of the Mixxx interface.") +
             " " + mayNotBeSupported;
-    auto  pViewShowMicrophone = new QAction(showMicrophoneTitle, this);
+    auto pViewShowMicrophone = new QAction(showMicrophoneTitle, this);
     pViewShowMicrophone->setCheckable(true);
     pViewShowMicrophone->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(
@@ -207,7 +207,7 @@ void WMainMenuBar::initialize() {
     QString showVinylControlTitle = tr("Show Vinyl Control Section");
     QString showVinylControlText = tr("Show the vinyl control section of the Mixxx interface.") +
             " " + mayNotBeSupported;
-    auto  pViewVinylControl = new QAction(showVinylControlTitle, this);
+    auto pViewVinylControl = new QAction(showVinylControlTitle, this);
     pViewVinylControl->setCheckable(true);
     pViewVinylControl->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(
@@ -222,7 +222,7 @@ void WMainMenuBar::initialize() {
     QString showPreviewDeckTitle = tr("Show Preview Deck");
     QString showPreviewDeckText = tr("Show the preview deck in the Mixxx interface.") +
             " " + mayNotBeSupported;
-    auto  pViewShowPreviewDeck = new QAction(showPreviewDeckTitle, this);
+    auto pViewShowPreviewDeck = new QAction(showPreviewDeckTitle, this);
     pViewShowPreviewDeck->setCheckable(true);
     pViewShowPreviewDeck->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
@@ -236,7 +236,7 @@ void WMainMenuBar::initialize() {
     QString showEffectsTitle = tr("Show Effect Rack");
     QString showEffectsText = tr("Show the effect rack in the Mixxx interface.") +
     " " + mayNotBeSupported;
-    auto  pViewShowEffects = new QAction(showEffectsTitle, this);
+    auto pViewShowEffects = new QAction(showEffectsTitle, this);
     pViewShowEffects->setCheckable(true);
     pViewShowEffects->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
@@ -251,7 +251,7 @@ void WMainMenuBar::initialize() {
     QString showCoverArtTitle = tr("Show Cover Art");
     QString showCoverArtText = tr("Show cover art in the Mixxx interface.") +
             " " + mayNotBeSupported;
-    auto  pViewShowCoverArt = new QAction(showCoverArtTitle, this);
+    auto pViewShowCoverArt = new QAction(showCoverArtTitle, this);
     pViewShowCoverArt->setCheckable(true);
     pViewShowCoverArt->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
@@ -266,7 +266,7 @@ void WMainMenuBar::initialize() {
     QString maximizeLibraryTitle = tr("Maximize Library");
     QString maximizeLibraryText = tr("Maximize the track library to take up all the available screen space.") +
             " " + mayNotBeSupported;
-    auto  pViewMaximizeLibrary = new QAction(maximizeLibraryTitle, this);
+    auto pViewMaximizeLibrary = new QAction(maximizeLibraryTitle, this);
     pViewMaximizeLibrary->setCheckable(true);
     pViewMaximizeLibrary->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
@@ -283,7 +283,7 @@ void WMainMenuBar::initialize() {
 
     QString fullScreenTitle = tr("&Full Screen");
     QString fullScreenText = tr("Display Mixxx using the full screen");
-    auto  pViewFullScreen = new QAction(fullScreenTitle, this);
+    auto pViewFullScreen = new QAction(fullScreenTitle, this);
     pViewFullScreen->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                   "ViewMenu_Fullscreen"),
@@ -311,7 +311,7 @@ void WMainMenuBar::initialize() {
 
     for (int i = 0; i < kMaximumVinylControlInputs; ++i) {
         QString vinylControlTitle = tr("Enable Vinyl Control &%1").arg(i + 1);
-        auto  vc_checkbox = new QAction(vinylControlTitle, this);
+        auto vc_checkbox = new QAction(vinylControlTitle, this);
         m_vinylControlEnabledActions.push_back(vc_checkbox);
 
         QString binding = m_pKbdConfig->getValueString(
@@ -345,7 +345,7 @@ void WMainMenuBar::initialize() {
 
     QString recordTitle = tr("&Record Mix");
     QString recordText = tr("Record your mix to a file");
-    auto  pOptionsRecord = new QAction(recordTitle, this);
+    auto pOptionsRecord = new QAction(recordTitle, this);
     pOptionsRecord->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                   "OptionsMenu_RecordMix"),
@@ -363,7 +363,7 @@ void WMainMenuBar::initialize() {
 #ifdef __SHOUTCAST__
     QString broadcastingTitle = tr("Enable Live &Broadcasting");
     QString broadcastingText = tr("Stream your mixes to a shoutcast or icecast server");
-    auto  pOptionsBroadcasting = new QAction(broadcastingTitle, this);
+    auto pOptionsBroadcasting = new QAction(broadcastingTitle, this);
     pOptionsBroadcasting->setShortcut(
             QKeySequence(m_pKbdConfig->getValueString(
                     ConfigKey("[KeyboardShortcuts]",
@@ -387,7 +387,7 @@ void WMainMenuBar::initialize() {
     QString keyboardShortcutText = tr("Toggles keyboard shortcuts on or off");
     bool keyboardShortcutsEnabled = m_pConfig->getValueString(
         ConfigKey("[Keyboard]", "Enabled")) == "1";
-    auto  pOptionsKeyboard = new QAction(keyboardShortcutTitle, this);
+    auto pOptionsKeyboard = new QAction(keyboardShortcutTitle, this);
     pOptionsKeyboard->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                   "OptionsMenu_EnableShortcuts"),
@@ -406,7 +406,7 @@ void WMainMenuBar::initialize() {
 
     QString preferencesTitle = tr("&Preferences");
     QString preferencesText = tr("Change Mixxx settings (e.g. playback, MIDI, controls)");
-    auto  pOptionsPreferences = new QAction(preferencesTitle, this);
+    auto pOptionsPreferences = new QAction(preferencesTitle, this);
     pOptionsPreferences->setShortcut(
         QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                   "OptionsMenu_Preferences"),
@@ -427,7 +427,7 @@ void WMainMenuBar::initialize() {
 
         QString reloadSkinTitle = tr("&Reload Skin");
         QString reloadSkinText = tr("Reload the skin");
-        auto  pDeveloperReloadSkin = new QAction(reloadSkinTitle, this);
+        auto pDeveloperReloadSkin = new QAction(reloadSkinTitle, this);
         pDeveloperReloadSkin->setShortcut(
             QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                                 "OptionsMenu_ReloadSkin"),
@@ -441,7 +441,7 @@ void WMainMenuBar::initialize() {
 
         QString developerToolsTitle = tr("Developer &Tools");
         QString developerToolsText = tr("Opens the developer tools dialog");
-        auto  pDeveloperTools = new QAction(developerToolsTitle, this);
+        auto pDeveloperTools = new QAction(developerToolsTitle, this);
         pDeveloperTools->setShortcut(
             QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                                 "OptionsMenu_DeveloperTools"),
@@ -460,7 +460,7 @@ void WMainMenuBar::initialize() {
         QString enableExperimentTitle = tr("Stats: &Experiment Bucket");
         QString enableExperimentToolsText = tr(
             "Enables experiment mode. Collects stats in the EXPERIMENT tracking bucket.");
-        auto  pDeveloperStatsExperiment = new QAction(enableExperimentTitle, this);
+        auto pDeveloperStatsExperiment = new QAction(enableExperimentTitle, this);
         pDeveloperStatsExperiment->setShortcut(
             QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                                 "OptionsMenu_DeveloperStatsExperiment"),
@@ -478,7 +478,7 @@ void WMainMenuBar::initialize() {
         QString enableBaseTitle = tr("Stats: &Base Bucket");
         QString enableBaseToolsText = tr(
             "Enables base mode. Collects stats in the BASE tracking bucket.");
-        auto  pDeveloperStatsBase = new QAction(enableBaseTitle, this);
+        auto pDeveloperStatsBase = new QAction(enableBaseTitle, this);
         pDeveloperStatsBase->setShortcut(
             QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                                 "OptionsMenu_DeveloperStatsBase"),
@@ -498,7 +498,7 @@ void WMainMenuBar::initialize() {
         QString scriptDebuggerText = tr("Enables the debugger during skin parsing");
         bool scriptDebuggerEnabled = m_pConfig->getValueString(
             ConfigKey("[ScriptDebugger]", "Enabled")) == "1";
-        auto  pDeveloperDebugger = new QAction(scriptDebuggerTitle, this);
+        auto pDeveloperDebugger = new QAction(scriptDebuggerTitle, this);
         pDeveloperDebugger->setShortcut(
             QKeySequence(m_pKbdConfig->getValueString(ConfigKey("[KeyboardShortcuts]",
                                                                 "DeveloperMenu_EnableDebugger"),
@@ -524,7 +524,7 @@ void WMainMenuBar::initialize() {
 
     QString supportTitle = tr("&Community Support") + externalLinkSuffix;
     QString supportText = tr("Get help with Mixxx");
-    auto  pHelpSupport = new QAction(supportTitle, this);
+    auto pHelpSupport = new QAction(supportTitle, this);
     pHelpSupport->setStatusTip(supportText);
     pHelpSupport->setWhatsThis(buildWhatsThis(supportTitle, supportText));
     m_visitUrlMapper.setMapping(pHelpSupport, MIXXX_SUPPORT_URL);
@@ -555,7 +555,7 @@ void WMainMenuBar::initialize() {
 
     QString manualTitle = tr("&User Manual") + externalLinkSuffix;
     QString manualText = tr("Read the Mixxx user manual.");
-    auto  pHelpManual = new QAction(manualTitle, this);
+    auto pHelpManual = new QAction(manualTitle, this);
     pHelpManual->setStatusTip(manualText);
     pHelpManual->setWhatsThis(buildWhatsThis(manualTitle, manualText));
     m_visitUrlMapper.setMapping(pHelpManual, qManualUrl.toString());
@@ -564,7 +564,7 @@ void WMainMenuBar::initialize() {
 
     QString shortcutsTitle = tr("&Keyboard Shortcuts") + externalLinkSuffix;
     QString shortcutsText = tr("Speed up your workflow with keyboard shortcuts.");
-    auto  pHelpShortcuts = new QAction(shortcutsTitle, this);
+    auto pHelpShortcuts = new QAction(shortcutsTitle, this);
     pHelpShortcuts->setStatusTip(shortcutsText);
     pHelpShortcuts->setWhatsThis(buildWhatsThis(shortcutsTitle, shortcutsText));
     m_visitUrlMapper.setMapping(pHelpShortcuts, MIXXX_SHORTCUTS_URL);
@@ -573,7 +573,7 @@ void WMainMenuBar::initialize() {
 
     QString feedbackTitle = tr("Send Us &Feedback") + externalLinkSuffix;
     QString feedbackText = tr("Send feedback to the Mixxx team.");
-    auto  pHelpFeedback = new QAction(feedbackTitle, this);
+    auto pHelpFeedback = new QAction(feedbackTitle, this);
     pHelpFeedback->setStatusTip(feedbackText);
     pHelpFeedback->setWhatsThis(buildWhatsThis(feedbackTitle, feedbackText));
     m_visitUrlMapper.setMapping(pHelpFeedback, MIXXX_FEEDBACK_URL);
@@ -582,7 +582,7 @@ void WMainMenuBar::initialize() {
 
     QString translateTitle = tr("&Translate This Application") + externalLinkSuffix;
     QString translateText = tr("Help translate this application into your language.");
-    auto  pHelpTranslation = new QAction(translateTitle, this);
+    auto pHelpTranslation = new QAction(translateTitle, this);
     pHelpTranslation->setStatusTip(translateText);
     pHelpTranslation->setWhatsThis(buildWhatsThis(translateTitle, translateText));
     m_visitUrlMapper.setMapping(pHelpTranslation, MIXXX_TRANSLATION_URL);
@@ -593,7 +593,7 @@ void WMainMenuBar::initialize() {
 
     QString aboutTitle = tr("&About");
     QString aboutText = tr("About the application");
-    auto  pHelpAboutApp = new QAction(aboutTitle, this);
+    auto pHelpAboutApp = new QAction(aboutTitle, this);
     pHelpAboutApp->setStatusTip(aboutText);
     pHelpAboutApp->setWhatsThis(buildWhatsThis(aboutTitle, aboutText));
     pHelpAboutApp->setMenuRole(QAction::AboutRole);
@@ -675,8 +675,7 @@ void WMainMenuBar::slotVisitUrl(const QString& url) {
 
 void WMainMenuBar::createVisibilityControl(QAction* pAction,
                                            const ConfigKey& key) {
-    auto  pConnection =
-            new VisibilityControlConnection(this, pAction, key);
+    auto pConnection = new VisibilityControlConnection(this, pAction, key);
     connect(this, SIGNAL(internalOnNewSkinLoaded()),
             pConnection, SLOT(slotReconnectControl()));
     connect(this, SIGNAL(internalOnNewSkinAboutToLoad()),

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -17,7 +17,7 @@ class VisibilityControlConnection : public QObject {
   public:
     VisibilityControlConnection(QObject* pParent, QAction* pAction,
                                 const ConfigKey& key);
-    virtual ~VisibilityControlConnection();
+    ~VisibilityControlConnection() override;
 
   private slots:
     void slotClearControl();
@@ -34,9 +34,9 @@ class VisibilityControlConnection : public QObject {
 class WMainMenuBar : public QMenuBar {
     Q_OBJECT
   public:
-    WMainMenuBar(QWidget* pParent, UserSettingsPointer pSettings,
+    WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
                  ConfigObject<ConfigValueKbd>* pKbdConfig);
-    virtual ~WMainMenuBar();
+    ~WMainMenuBar() override;
 
   public slots:
     void onLibraryScanStarted();
@@ -79,7 +79,7 @@ class WMainMenuBar : public QMenuBar {
   private slots:
     void slotDeveloperStatsExperiment(bool enable);
     void slotDeveloperStatsBase(bool enable);
-    void slotDeveloperDebugger(bool enable);
+    void slotDeveloperDebugger(bool toggle);
     void slotVisitUrl(const QString& url);
 
   private:

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -17,7 +17,6 @@ class VisibilityControlConnection : public QObject {
   public:
     VisibilityControlConnection(QObject* pParent, QAction* pAction,
                                 const ConfigKey& key);
-    ~VisibilityControlConnection() override;
 
   private slots:
     void slotClearControl();
@@ -36,7 +35,6 @@ class WMainMenuBar : public QMenuBar {
   public:
     WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
                  ConfigObject<ConfigValueKbd>* pKbdConfig);
-    ~WMainMenuBar() override;
 
   public slots:
     void onLibraryScanStarted();

--- a/src/widget/wnumber.cpp
+++ b/src/widget/wnumber.cpp
@@ -22,8 +22,6 @@ WNumber::WNumber(QWidget* pParent)
           m_iNoDigits(2) {
 }
 
-WNumber::~WNumber() = default;
-
 void WNumber::setup(QDomNode node, const SkinContext& context) {
     WLabel::setup(node, context);
 

--- a/src/widget/wnumber.cpp
+++ b/src/widget/wnumber.cpp
@@ -22,8 +22,7 @@ WNumber::WNumber(QWidget* pParent)
           m_iNoDigits(2) {
 }
 
-WNumber::~WNumber() {
-}
+WNumber::~WNumber() = default;
 
 void WNumber::setup(QDomNode node, const SkinContext& context) {
     WLabel::setup(node, context);

--- a/src/widget/wnumber.h
+++ b/src/widget/wnumber.h
@@ -27,7 +27,6 @@ class WNumber : public WLabel  {
     Q_OBJECT
   public:
     explicit WNumber(QWidget* pParent = nullptr);
-    ~WNumber() override;
 
     void setup(QDomNode node, const SkinContext& context) override;
 

--- a/src/widget/wnumber.h
+++ b/src/widget/wnumber.h
@@ -26,12 +26,12 @@
 class WNumber : public WLabel  {
     Q_OBJECT
   public:
-    WNumber(QWidget* pParent = NULL);
-    virtual ~WNumber();
+    explicit WNumber(QWidget* pParent = nullptr);
+    ~WNumber() override;
 
-    virtual void setup(QDomNode node, const SkinContext& context);
+    void setup(QDomNode node, const SkinContext& context) override;
 
-    virtual void onConnectedControlChanged(double dParameter, double dValue);
+    void onConnectedControlChanged(double dParameter, double dValue) override;
 
   public slots:
     virtual void setValue(double dValue);

--- a/src/widget/wnumberdb.cpp
+++ b/src/widget/wnumberdb.cpp
@@ -10,8 +10,7 @@ WNumberDb::WNumberDb(QWidget* pParent)
         : WNumber(pParent) {
 }
 
-WNumberDb::~WNumberDb() {
-}
+WNumberDb::~WNumberDb() = default;
 
 
 void WNumberDb::setValue(double dValue) {

--- a/src/widget/wnumberdb.cpp
+++ b/src/widget/wnumberdb.cpp
@@ -10,9 +10,6 @@ WNumberDb::WNumberDb(QWidget* pParent)
         : WNumber(pParent) {
 }
 
-WNumberDb::~WNumberDb() = default;
-
-
 void WNumberDb::setValue(double dValue) {
     QString strDb;
     if (dValue != 0.0) {

--- a/src/widget/wnumberdb.h
+++ b/src/widget/wnumberdb.h
@@ -10,11 +10,11 @@
 class WNumberDb : public WNumber {
     Q_OBJECT
   public:
-    WNumberDb(QWidget* pParent = NULL);
-    virtual ~WNumberDb();
+    explicit WNumberDb(QWidget* pParent = nullptr);
+    ~WNumberDb() override;
 
   public slots:
-    virtual void setValue(double dValue);
+    void setValue(double dValue) override;
 };
 
 #endif // WNUMBERDB_H

--- a/src/widget/wnumberdb.h
+++ b/src/widget/wnumberdb.h
@@ -11,7 +11,6 @@ class WNumberDb : public WNumber {
     Q_OBJECT
   public:
     explicit WNumberDb(QWidget* pParent = nullptr);
-    ~WNumberDb() override;
 
   public slots:
     void setValue(double dValue) override;

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -48,8 +48,6 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
     slotSetValue(m_pVisualPlaypos->get());
 }
 
-WNumberPos::~WNumberPos() = default;
-
 void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {
     bool leftClick = pEvent->buttons() & Qt::LeftButton;
 

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -48,8 +48,7 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
     slotSetValue(m_pVisualPlaypos->get());
 }
 
-WNumberPos::~WNumberPos() {
-}
+WNumberPos::~WNumberPos() = default;
 
 void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {
     bool leftClick = pEvent->buttons() & Qt::LeftButton;
@@ -85,8 +84,9 @@ void WNumberPos::slotSetValue(double dValue) {
         double dDuration = m_dTrackSamples / m_dTrackSampleRate / 2.0;
         valueMillis = dValue * 500.0 * m_dTrackSamples / m_dTrackSampleRate;
         double durationMillis = dDuration * Time::kMillisPerSecond;
-        if (m_bRemain)
+        if (m_bRemain) {
             valueMillis = math_max(durationMillis - valueMillis, 0.0);
+        }
     }
 
     QString valueString;

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -12,19 +12,19 @@ class ControlObjectSlave;
 class WNumberPos : public WNumber {
     Q_OBJECT
   public:
-    WNumberPos(const char *group, QWidget *parent=0);
-    virtual ~WNumberPos();
+    explicit WNumberPos(const char *group, QWidget *parent=nullptr);
+    ~WNumberPos() override;
 
     // Set if the display shows remaining time (true) or position (false)
     void setRemain(bool bRemain);
 
   protected:
-    void mousePressEvent(QMouseEvent* pEvent);
+    void mousePressEvent(QMouseEvent* pEvent) override;
 
   private slots:
-    void setValue(double dValue);
+    void setValue(double dValue) override;
     void slotSetValue(double);
-    void slotSetRemain(double dRemain);
+    void slotSetRemain(double remain);
     void slotSetTrackSampleRate(double dSampleRate);
     void slotSetTrackSamples(double dSamples);
 

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -13,7 +13,6 @@ class WNumberPos : public WNumber {
     Q_OBJECT
   public:
     explicit WNumberPos(const char *group, QWidget *parent=nullptr);
-    ~WNumberPos() override;
 
     // Set if the display shows remaining time (true) or position (false)
     void setRemain(bool bRemain);

--- a/src/widget/wnumberrate.cpp
+++ b/src/widget/wnumberrate.cpp
@@ -28,8 +28,6 @@ WNumberRate::WNumberRate(const char * group, QWidget * parent)
     setValue(0);
 }
 
-WNumberRate::~WNumberRate() = default;
-
 void WNumberRate::setValue(double /*dValue*/) {
     double vsign = m_pRateControl->get() *
             m_pRateRangeControl->get() *

--- a/src/widget/wnumberrate.cpp
+++ b/src/widget/wnumberrate.cpp
@@ -28,10 +28,9 @@ WNumberRate::WNumberRate(const char * group, QWidget * parent)
     setValue(0);
 }
 
-WNumberRate::~WNumberRate() {
-}
+WNumberRate::~WNumberRate() = default;
 
-void WNumberRate::setValue(double) {
+void WNumberRate::setValue(double /*dValue*/) {
     double vsign = m_pRateControl->get() *
             m_pRateRangeControl->get() *
             m_pRateDirControl->get();

--- a/src/widget/wnumberrate.h
+++ b/src/widget/wnumberrate.h
@@ -19,11 +19,11 @@ class ControlObjectSlave;
 class WNumberRate : public WNumber {
     Q_OBJECT
   public:
-    WNumberRate(const char *group, QWidget *parent=0);
-    virtual ~WNumberRate();
+    explicit WNumberRate(const char *group, QWidget *parent=nullptr);
+    ~WNumberRate() override;
 
   private slots:
-    void setValue(double dValue);
+    void setValue(double dValue) override;
 
   private:
     // Pointer to control objects for rate.

--- a/src/widget/wnumberrate.h
+++ b/src/widget/wnumberrate.h
@@ -20,7 +20,6 @@ class WNumberRate : public WNumber {
     Q_OBJECT
   public:
     explicit WNumberRate(const char *group, QWidget *parent=nullptr);
-    ~WNumberRate() override;
 
   private slots:
     void setValue(double dValue) override;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -35,7 +35,7 @@
 
 WOverview::WOverview(const char *pGroup, UserSettingsPointer pConfig, QWidget* parent) :
         WWidget(parent),
-        m_pWaveformSourceImage(NULL),
+        m_pWaveformSourceImage(nullptr),
         m_actualCompletion(0),
         m_pixmapDone(false),
         m_waveformPeak(-1.0),
@@ -196,7 +196,7 @@ void WOverview::slotTrackLoaded(TrackPointer pTrack) {
 
 void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     qDebug() << "WOverview::slotLoadingTrack" << pNewTrack << pOldTrack;
-    if (m_pCurrentTrack != NULL && pOldTrack == m_pCurrentTrack) {
+    if (m_pCurrentTrack != nullptr && pOldTrack == m_pCurrentTrack) {
         disconnect(m_pCurrentTrack.data(), SIGNAL(waveformSummaryUpdated()),
                    this, SLOT(slotWaveformSummaryUpdated()));
         disconnect(m_pCurrentTrack.data(), SIGNAL(analyzerProgress(int)),
@@ -205,7 +205,7 @@ void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack)
 
     if (m_pWaveformSourceImage) {
         delete m_pWaveformSourceImage;
-        m_pWaveformSourceImage = NULL;
+        m_pWaveformSourceImage = nullptr;
     }
 
     m_dAnalyzerProgress = 1.0;
@@ -269,7 +269,7 @@ void WOverview::mousePressEvent(QMouseEvent* e) {
     m_bDrag = true;
 }
 
-void WOverview::paintEvent(QPaintEvent *) {
+void WOverview::paintEvent(QPaintEvent * /*unused*/) {
     //qDebug() << "WOverview::paintEvent";
     ScopedTimer t("WOverview::paintEvent");
 
@@ -343,12 +343,10 @@ void WOverview::paintEvent(QPaintEvent *) {
         if (m_trackLoaded && trackSamples > 0) {
             //qDebug() << "WOverview::paintEvent trackSamples > 0";
             const float offset = 1.0f;
-            const float gain = (float)(width()-2) / trackSamples;
+            const float gain = static_cast<float>(width()-2) / trackSamples;
 
             // Draw range (loop)
-            for (unsigned int i = 0; i < m_markRanges.size(); ++i) {
-                WaveformMarkRange& currentMarkRange = m_markRanges[i];
-
+            for (auto & currentMarkRange : m_markRanges) {
                 // If the mark range is not active we should not draw it.
                 if (!currentMarkRange.active()) {
                     continue;
@@ -400,7 +398,7 @@ void WOverview::paintEvent(QPaintEvent *) {
                     //        (currentMark.m_pointControl->get() / (float)m_trackSamplesControl->get()) * (float)(width()-2);
                     const float markPosition = offset + currentMark.m_pPointCos->get() * gain;
 
-                    const QLineF line(markPosition, 0.0, markPosition, (float)height());
+                    const QLineF line(markPosition, 0.0, markPosition, static_cast<float>(height()));
                     painter.setPen(shadowPen);
                     painter.drawLine(line);
 
@@ -471,7 +469,7 @@ void WOverview::paintText(const QString &text, QPainter *painter) {
     painter->drawText(10, 12, text);
 }
 
-void WOverview::resizeEvent(QResizeEvent *) {
+void WOverview::resizeEvent(QResizeEvent * /*unused*/) {
     // Play-position potmeters range from 0 to 1 but they allow out-of-range
     // sets. This is to give VC access to the pre-roll area.
     const double kMaxPlayposRange = 1.0;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -346,7 +346,7 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
             const float gain = static_cast<float>(width()-2) / trackSamples;
 
             // Draw range (loop)
-            for (auto & currentMarkRange : m_markRanges) {
+            for (auto&& currentMarkRange : m_markRanges) {
                 // If the mark range is not active we should not draw it.
                 if (!currentMarkRange.active()) {
                     continue;

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -33,13 +33,13 @@ class Waveform;
 class WOverview : public WWidget {
     Q_OBJECT
   public:
-    WOverview(const char* pGroup, UserSettingsPointer pConfig, QWidget* parent=NULL);
-    virtual ~WOverview();
+    WOverview(const char* pGroup, UserSettingsPointer pConfig, QWidget* parent=nullptr);
+    ~WOverview() override;
 
     void setup(QDomNode node, const SkinContext& context);
 
   public slots:
-    void onConnectedControlChanged(double dParameter, double dValue);
+    void onConnectedControlChanged(double dParameter, double dValue) override;
     void slotTrackLoaded(TrackPointer pTrack);
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
@@ -47,13 +47,13 @@ class WOverview : public WWidget {
     void trackDropped(QString filename, QString group);
 
   protected:
-    void mouseMoveEvent(QMouseEvent *e);
-    void mouseReleaseEvent(QMouseEvent *e);
-    void mousePressEvent(QMouseEvent *e);
-    void paintEvent(QPaintEvent *);
-    void resizeEvent(QResizeEvent *);
-    virtual void dragEnterEvent(QDragEnterEvent* event);
-    virtual void dropEvent(QDropEvent* event);
+    void mouseMoveEvent(QMouseEvent *e) override;
+    void mouseReleaseEvent(QMouseEvent *e) override;
+    void mousePressEvent(QMouseEvent *e) override;
+    void paintEvent(QPaintEvent * /*unused*/) override;
+    void resizeEvent(QResizeEvent * /*unused*/) override;
+    void dragEnterEvent(QDragEnterEvent* event) override;
+    void dropEvent(QDropEvent* event) override;
 
     ConstWaveformPointer getWaveform() const {
         return m_pWaveform;

--- a/src/widget/woverviewhsv.cpp
+++ b/src/widget/woverviewhsv.cpp
@@ -58,7 +58,7 @@ bool WOverviewHSV::drawNextPixmapPart() {
 
 
     QPainter painter(m_pWaveformSourceImage);
-    painter.translate(0.0,(double)m_pWaveformSourceImage->height()/2.0);
+    painter.translate(0.0,static_cast<double>(m_pWaveformSourceImage->height())/2.0);
 
     // Get HSV of low color. NOTE(rryan): On ARM, qreal is float so it's
     // important we use qreal here and not double or float or else we will get

--- a/src/widget/woverviewhsv.h
+++ b/src/widget/woverviewhsv.h
@@ -8,7 +8,7 @@ class WOverviewHSV : public WOverview {
     WOverviewHSV(const char *pGroup, UserSettingsPointer pConfig, QWidget* parent);
 
   private:
-    virtual bool drawNextPixmapPart();
+    bool drawNextPixmapPart() override;
 };
 
 #endif // WOVERVIEWHSV_H

--- a/src/widget/woverviewlmh.cpp
+++ b/src/widget/woverviewlmh.cpp
@@ -60,7 +60,7 @@ bool WOverviewLMH::drawNextPixmapPart() {
 
 
     QPainter painter(m_pWaveformSourceImage);
-    painter.translate(0.0,(double)m_pWaveformSourceImage->height()/2.0);
+    painter.translate(0.0,static_cast<double>(m_pWaveformSourceImage->height())/2.0);
 
     QColor lowColor = m_signalColors.getLowColor();
     QPen lowColorPen(QBrush(lowColor), 1);

--- a/src/widget/woverviewlmh.h
+++ b/src/widget/woverviewlmh.h
@@ -8,7 +8,7 @@ class WOverviewLMH : public WOverview {
     WOverviewLMH(const char *pGroup, UserSettingsPointer pConfig, QWidget* parent);
 
   private:
-    virtual bool drawNextPixmapPart();
+    bool drawNextPixmapPart() override;
 };
 
 #endif // WOVERVIEWLMH_H

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -56,7 +56,7 @@ bool WOverviewRGB::drawNextPixmapPart() {
     //         << "completionIncrement:" << completionIncrement;
 
     QPainter painter(m_pWaveformSourceImage);
-    painter.translate(0.0,(double)m_pWaveformSourceImage->height()/2.0);
+    painter.translate(0.0,static_cast<double>(m_pWaveformSourceImage->height())/2.0);
 
     QColor color;
 

--- a/src/widget/woverviewrgb.h
+++ b/src/widget/woverviewrgb.h
@@ -8,7 +8,7 @@ class WOverviewRGB : public WOverview {
     WOverviewRGB(const char *pGroup, UserSettingsPointer pConfig, QWidget* parent);
 
   private:
-    virtual bool drawNextPixmapPart();
+    bool drawNextPixmapPart() override;
 };
 
 #endif // WOVERVIEWRGB_H

--- a/src/widget/wpixmapstore.cpp
+++ b/src/widget/wpixmapstore.cpp
@@ -117,7 +117,7 @@ Paintable::Paintable(const PixmapSource& source, DrawMode mode)
             m_pSvg.reset(pSvgRenderer.take());
         }
     } else {
-        QPixmap * pPixmap = new QPixmap();
+        auto  pPixmap = new QPixmap();
         if (!source.getData().isEmpty()) {
             pPixmap->loadFromData(source.getData());
         } else {
@@ -339,7 +339,7 @@ PaintablePointer WPixmapStore::getPaintable(PixmapSource source,
 
 // static
 QPixmap* WPixmapStore::getPixmapNoCache(const QString& fileName) {
-    QPixmap* pPixmap = NULL;
+    QPixmap* pPixmap = nullptr;
     if (m_loader) {
         QImage* img = m_loader->getImage(fileName);
 #if QT_VERSION >= 0x040700

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -48,8 +48,6 @@ WPushButton::WPushButton(QWidget* pParent, ControlPushButton::ButtonMode leftBut
     setStates(0);
 }
 
-WPushButton::~WPushButton() = default;
-
 void WPushButton::setup(QDomNode node, const SkinContext& context) {
     // Number of states
     int iNumStates = context.selectInt(node, "NumberStates");

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -26,12 +26,12 @@
 #include <QPaintEvent>
 #include <QApplication>
 
-#include "widget/wpixmapstore.h"
+#include "control/controlbehavior.h"
 #include "controlobject.h"
 #include "controlpushbutton.h"
-#include "control/controlbehavior.h"
 #include "util/debug.h"
 #include "util/math.h"
+#include "widget/wpixmapstore.h"
 
 WPushButton::WPushButton(QWidget* pParent)
         : WWidget(pParent),
@@ -48,8 +48,7 @@ WPushButton::WPushButton(QWidget* pParent, ControlPushButton::ButtonMode leftBut
     setStates(0);
 }
 
-WPushButton::~WPushButton() {
-}
+WPushButton::~WPushButton() = default;
 
 void WPushButton::setup(QDomNode node, const SkinContext& context) {
     // Number of states
@@ -114,7 +113,7 @@ void WPushButton::setup(QDomNode node, const SkinContext& context) {
         state = state.nextSibling();
     }
 
-    ControlParameterWidgetConnection* leftConnection = NULL;
+    ControlParameterWidgetConnection* leftConnection = nullptr;
     if (m_leftConnections.isEmpty()) {
         if (!m_connections.isEmpty()) {
             // If no left connection is set, the this is the left connection

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -41,7 +41,6 @@ class WPushButton : public WWidget {
     // Used by WPushButtonTest.
     WPushButton(QWidget* pParent, ControlPushButton::ButtonMode leftButtonMode,
                 ControlPushButton::ButtonMode rightButtonMode);
-    ~WPushButton() override;
 
     Q_PROPERTY(bool pressed READ isPressed);
 

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -37,11 +37,11 @@
 class WPushButton : public WWidget {
     Q_OBJECT
   public:
-    WPushButton(QWidget* pParent = NULL);
+    explicit WPushButton(QWidget* pParent = nullptr);
     // Used by WPushButtonTest.
     WPushButton(QWidget* pParent, ControlPushButton::ButtonMode leftButtonMode,
                 ControlPushButton::ButtonMode rightButtonMode);
-    virtual ~WPushButton();
+    ~WPushButton() override;
 
     Q_PROPERTY(bool pressed READ isPressed);
 
@@ -67,20 +67,20 @@ class WPushButton : public WWidget {
 
     // Sets the number of states associated with this button, and removes
     // associated pixmaps.
-    void setStates(int iStatesW);
+    void setStates(int iStates);
 
   signals:
     void displayValueChanged(int value);
 
   public slots:
-    virtual void onConnectedControlChanged(double dParameter, double dValue);
+    void onConnectedControlChanged(double dParameter, double dValue) override;
 
   protected:
-    virtual void paintEvent(QPaintEvent*);
-    virtual void mousePressEvent(QMouseEvent* e);
-    virtual void mouseReleaseEvent(QMouseEvent* e);
-    virtual void focusOutEvent(QFocusEvent* e);
-    void fillDebugTooltip(QStringList* debug);
+    void paintEvent(QPaintEvent* /*unused*/) override;
+    void mousePressEvent(QMouseEvent* e) override;
+    void mouseReleaseEvent(QMouseEvent* e) override;
+    void focusOutEvent(QFocusEvent* e) override;
+    void fillDebugTooltip(QStringList* debug) override;
 
   protected:
     void restyleAndRepaint();

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -62,8 +62,7 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
                   arg(m_clearButton->sizeHint().width() + frameWidth + 1));
 }
 
-WSearchLineEdit::~WSearchLineEdit() {
-}
+WSearchLineEdit::~WSearchLineEdit() = default;
 
 void WSearchLineEdit::setup(QDomNode node, const SkinContext& context) {
     // Background color

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -62,8 +62,6 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
                   arg(m_clearButton->sizeHint().width() + frameWidth + 1));
 }
 
-WSearchLineEdit::~WSearchLineEdit() = default;
-
 void WSearchLineEdit::setup(QDomNode node, const SkinContext& context) {
     // Background color
     QColor bgc(255,255,255);

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -17,7 +17,6 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     Q_OBJECT
   public:
     explicit WSearchLineEdit(QWidget* pParent);
-    ~WSearchLineEdit() override;
 
     void setup(QDomNode node, const SkinContext& context);
 

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -16,16 +16,16 @@
 class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     Q_OBJECT
   public:
-    WSearchLineEdit(QWidget* pParent);
-    virtual ~WSearchLineEdit();
+    explicit WSearchLineEdit(QWidget* pParent);
+    ~WSearchLineEdit() override;
 
     void setup(QDomNode node, const SkinContext& context);
 
   protected:
-    void resizeEvent(QResizeEvent*);
-    virtual void focusInEvent(QFocusEvent*);
-    virtual void focusOutEvent(QFocusEvent*);
-    bool event(QEvent* pEvent);
+    void resizeEvent(QResizeEvent* /*unused*/) override;
+    void focusInEvent(QFocusEvent* /*unused*/) override;
+    void focusOutEvent(QFocusEvent* /*unused*/) override;
+    bool event(QEvent* pEvent) override;
 
   signals:
     void search(const QString& text);

--- a/src/widget/wsingletoncontainer.cpp
+++ b/src/widget/wsingletoncontainer.cpp
@@ -8,7 +8,7 @@
 
 
 WSingletonContainer::WSingletonContainer(QWidget* pParent)
-        : WWidgetGroup(pParent), m_pWidget(NULL), m_pLayout(NULL) { }
+        : WWidgetGroup(pParent), m_pWidget(nullptr), m_pLayout(nullptr) { }
 
 void WSingletonContainer::setup(QDomNode node, const SkinContext& context) {
     setContentsMargins(0, 0, 0, 0);
@@ -30,7 +30,7 @@ void WSingletonContainer::setup(QDomNode node, const SkinContext& context) {
         return;
     }
     m_pWidget = context.getSingletonWidget(objectName);
-    if (m_pWidget == NULL) {
+    if (m_pWidget == nullptr) {
         SKIN_WARNING(node, context)
                 << "Asked for an unknown singleton widget:" << objectName;
     }
@@ -68,5 +68,5 @@ void SingletonMap::insertSingleton(QString objectName, QWidget* widget) {
 }
 
 QWidget* SingletonMap::getSingletonWidget(QString objectName) const {
-    return m_singletons.value(objectName, NULL);
+    return m_singletons.value(objectName, nullptr);
 }

--- a/src/widget/wsingletoncontainer.h
+++ b/src/widget/wsingletoncontainer.h
@@ -56,12 +56,12 @@ class WSingletonContainer : public WWidgetGroup {
   public:
     // Prepares the container and remembers the widget, but does not add the
     // widget to the container.
-    WSingletonContainer(QWidget* pParent=NULL);
+    explicit WSingletonContainer(QWidget* pParent=nullptr);
 
     virtual void setup(QDomNode node, const SkinContext& context);
 
   public slots:
-    virtual void showEvent(QShowEvent* event);
+    void showEvent(QShowEvent* event) override;
 
   private:
     QPointer<QWidget> m_pWidget;

--- a/src/widget/wsizeawarestack.cpp
+++ b/src/widget/wsizeawarestack.cpp
@@ -7,7 +7,7 @@
 class SizeAwareLayout : public QStackedLayout
 {
   public:
-    QSize minimumSize() const
+    QSize minimumSize() const override
     {
         QSize s(0, 0) ;
         QWidget *w = widget(0);
@@ -77,8 +77,7 @@ WSizeAwareStack::WSizeAwareStack(QWidget* parent)
     setLayout(m_layout);
 }
 
-WSizeAwareStack::~WSizeAwareStack() {
-}
+WSizeAwareStack::~WSizeAwareStack() = default;
 
 int WSizeAwareStack::addWidget(QWidget *widget) {
     // smallest widgets should be added first

--- a/src/widget/wsizeawarestack.cpp
+++ b/src/widget/wsizeawarestack.cpp
@@ -77,8 +77,6 @@ WSizeAwareStack::WSizeAwareStack(QWidget* parent)
     setLayout(m_layout);
 }
 
-WSizeAwareStack::~WSizeAwareStack() = default;
-
 int WSizeAwareStack::addWidget(QWidget *widget) {
     // smallest widgets should be added first
     return m_layout->addWidget(widget);

--- a/src/widget/wsizeawarestack.h
+++ b/src/widget/wsizeawarestack.h
@@ -11,14 +11,14 @@ class SizeAwareLayout;
 class WSizeAwareStack : public QWidget, public WBaseWidget {
     Q_OBJECT
   public:
-    WSizeAwareStack(QWidget* pParent = NULL);
-    virtual ~WSizeAwareStack();
+    explicit WSizeAwareStack(QWidget* parent = nullptr);
+    ~WSizeAwareStack() override;
 
-    int addWidget(QWidget* pWidget);
+    int addWidget(QWidget* widget);
 
   protected:
-    virtual void resizeEvent(QResizeEvent* event);
-    bool event(QEvent* pEvent);
+    void resizeEvent(QResizeEvent* event) override;
+    bool event(QEvent* pEvent) override;
 
   private:
     SizeAwareLayout* m_layout;

--- a/src/widget/wsizeawarestack.h
+++ b/src/widget/wsizeawarestack.h
@@ -12,7 +12,6 @@ class WSizeAwareStack : public QWidget, public WBaseWidget {
     Q_OBJECT
   public:
     explicit WSizeAwareStack(QWidget* parent = nullptr);
-    ~WSizeAwareStack() override;
 
     int addWidget(QWidget* widget);
 

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -21,8 +21,8 @@
 #include <QStylePainter>
 #include <QStyleOption>
 
-#include "widget/wpixmapstore.h"
 #include "widget/controlwidgetconnection.h"
+#include "widget/wpixmapstore.h"
 #include "util/debug.h"
 #include "util/math.h"
 
@@ -32,8 +32,8 @@ WSliderComposed::WSliderComposed(QWidget * parent)
       m_dHandleLength(0.0),
       m_dSliderLength(0.0),
       m_bHorizontal(false),
-      m_pSlider(NULL),
-      m_pHandle(NULL) {
+      m_pSlider(nullptr),
+      m_pHandle(nullptr) {
 }
 
 WSliderComposed::~WSliderComposed() {
@@ -130,7 +130,7 @@ void WSliderComposed::mousePressEvent(QMouseEvent * e) {
     m_handler.mousePressEvent(this, e);
 }
 
-void WSliderComposed::paintEvent(QPaintEvent *) {
+void WSliderComposed::paintEvent(QPaintEvent * /*unused*/) {
     QStyleOption option;
     option.initFrom(this);
     QStylePainter p(this);
@@ -168,7 +168,7 @@ void WSliderComposed::resizeEvent(QResizeEvent* pEvent) {
     onConnectedControlChanged(getControlParameter(), 0);
 }
 
-void WSliderComposed::onConnectedControlChanged(double dParameter, double) {
+void WSliderComposed::onConnectedControlChanged(double dParameter, double /*dValue*/) {
     m_handler.onConnectedControlChanged(this, dParameter);
 }
 

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -40,26 +40,26 @@
 class WSliderComposed : public WWidget  {
     Q_OBJECT
   public:
-    WSliderComposed(QWidget* parent = 0);
-    virtual ~WSliderComposed();
+    explicit WSliderComposed(QWidget* parent = nullptr);
+    ~WSliderComposed() override;
 
     void setup(QDomNode node, const SkinContext& context);
-    void setSliderPixmap(PixmapSource sourceSlider, Paintable::DrawMode mode);
+    void setSliderPixmap(PixmapSource sourceSlider, Paintable::DrawMode drawMode);
     void setHandlePixmap(bool bHorizontal, PixmapSource sourceHandle,
                          Paintable::DrawMode mode);
     inline bool isHorizontal() const { return m_bHorizontal; };
 
   public slots:
-    void onConnectedControlChanged(double dParameter, double dValue);
-    void fillDebugTooltip(QStringList* debug);
+    void onConnectedControlChanged(double dParameter, double dValue) override;
+    void fillDebugTooltip(QStringList* debug) override;
 
   protected:
-    virtual void mouseMoveEvent(QMouseEvent* e);
-    virtual void mouseReleaseEvent(QMouseEvent* e);
-    virtual void mousePressEvent(QMouseEvent* e);
-    virtual void paintEvent(QPaintEvent* e);
-    virtual void wheelEvent(QWheelEvent* e);
-    virtual void resizeEvent(QResizeEvent* e);
+    void mouseMoveEvent(QMouseEvent* e) override;
+    void mouseReleaseEvent(QMouseEvent* e) override;
+    void mousePressEvent(QMouseEvent* e) override;
+    void paintEvent(QPaintEvent* e) override;
+    void wheelEvent(QWheelEvent* e) override;
+    void resizeEvent(QResizeEvent* pEvent) override;
 
   private:
     double calculateHandleLength();

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -7,8 +7,8 @@
 #include "controlobject.h"
 #include "controlobjectslave.h"
 #include "library/coverartcache.h"
-#include "waveform/sharedglcontext.h"
 #include "util/dnd.h"
+#include "waveform/sharedglcontext.h"
 #include "util/math.h"
 #include "waveform/visualplayposition.h"
 #include "vinylcontrol/vinylcontrol.h"
@@ -24,21 +24,21 @@ WSpinny::WSpinny(QWidget* parent, const QString& group,
           WBaseWidget(this),
           m_group(group),
           m_pConfig(pConfig),
-          m_pBgImage(NULL),
-          m_pMaskImage(NULL),
-          m_pFgImage(NULL),
-          m_pGhostImage(NULL),
-          m_pPlay(NULL),
-          m_pPlayPos(NULL),
-          m_pVisualPlayPos(NULL),
-          m_pTrackSamples(NULL),
-          m_pTrackSampleRate(NULL),
-          m_pScratchToggle(NULL),
-          m_pScratchPos(NULL),
-          m_pVinylControlSpeedType(NULL),
-          m_pVinylControlEnabled(NULL),
-          m_pSignalEnabled(NULL),
-          m_pSlipEnabled(NULL),
+          m_pBgImage(nullptr),
+          m_pMaskImage(nullptr),
+          m_pFgImage(nullptr),
+          m_pGhostImage(nullptr),
+          m_pPlay(nullptr),
+          m_pPlayPos(nullptr),
+          m_pVisualPlayPos(nullptr),
+          m_pTrackSamples(nullptr),
+          m_pTrackSampleRate(nullptr),
+          m_pScratchToggle(nullptr),
+          m_pScratchPos(nullptr),
+          m_pVinylControlSpeedType(nullptr),
+          m_pVinylControlEnabled(nullptr),
+          m_pSignalEnabled(nullptr),
+          m_pSlipEnabled(nullptr),
           m_bShowCover(true),
           m_dInitialPos(0.),
           m_iVinylInput(-1),
@@ -70,7 +70,7 @@ WSpinny::WSpinny(QWidget* parent, const QString& group,
              << "Sharing:" << context()->isSharing();
 
     CoverArtCache* pCache = CoverArtCache::instance();
-    if (pCache != NULL) {
+    if (pCache != nullptr) {
         connect(pCache, SIGNAL(coverFound(const QObject*, const int,
                                           const CoverInfo&, QPixmap, bool)),
                 this, SLOT(slotCoverFound(const QObject*, const int,
@@ -106,17 +106,17 @@ void WSpinny::onVinylSignalQualityUpdate(const VinylSignalQualityReport& report)
     // hsv:  s=1, v=1
     // h is the only variable.
     // h=0 is red, h=120 is green
-    qual_color.setHsv((int)(120.0 * signalQuality), 255, 255);
+    qual_color.setHsv(static_cast<int>(120.0 * signalQuality), 255, 255);
     qual_color.getRgb(&r, &g, &b);
 
     for (int y = 0; y < m_iVinylScopeSize; ++y) {
-        QRgb *line = (QRgb *)m_qImage.scanLine(y);
+        QRgb *line = reinterpret_cast<QRgb *>(m_qImage.scanLine(y));
         for (int x = 0; x < m_iVinylScopeSize; ++x) {
             // use xwax's bitmap to set alpha data only
             // adjust alpha by 3/4 so it's not quite so distracting
             // setpixel is slow, use scanlines instead
             //m_qImage.setPixel(x, y, qRgba(r,g,b,(int)buf[x+m_iVinylScopeSize*y] * .75));
-            *line = qRgba(r,g,b,(int)(report.scope[x+m_iVinylScopeSize*y] * .75));
+            *line = qRgba(r,g,b,static_cast<int>(report.scope[x+m_iVinylScopeSize*y] * .75));
             line++;
         }
     }
@@ -259,7 +259,7 @@ void WSpinny::slotTrackCoverArtUpdated() {
         m_lastRequestedCover = m_loadedTrack->getCoverInfo();
         m_lastRequestedCover.trackLocation = m_loadedTrack->getLocation();
         CoverArtCache* pCache = CoverArtCache::instance();
-        if (pCache != NULL) {
+        if (pCache != nullptr) {
             // TODO(rryan): Don't use track id.
             pCache->requestCover(m_lastRequestedCover, this, m_loadedTrack->getId().toInt());
         }
@@ -366,7 +366,7 @@ QPixmap WSpinny::scaledCoverArt(const QPixmap& normal) {
     return normal.scaled(size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
 }
 
-void WSpinny::resizeEvent(QResizeEvent*) {
+void WSpinny::resizeEvent(QResizeEvent* /*unused*/) {
     m_loadedCoverScaled = scaledCoverArt(m_loadedCover);
     if (m_pFgImage && !m_pFgImage->isNull()) {
         m_fgImageScaled = m_pFgImage->scaled(
@@ -431,8 +431,9 @@ double WSpinny::calculateAngle(double playpos) {
     that it would take to wind the vinyl to that position. */
 int WSpinny::calculateFullRotations(double playpos)
 {
-    if (isnan(playpos))
+    if (isnan(playpos)) {
         return 0;
+    }
     //Convert playpos to seconds.
     double t = playpos * (m_pTrackSamples->get() / 2 /  // Stereo audio!
                           m_pTrackSampleRate->get());
@@ -441,7 +442,7 @@ int WSpinny::calculateFullRotations(double playpos)
     //qDebug() << t;
     double angle = 360 * m_dRotationsPerSecond * t;
 
-    return (((int)angle + 180) / 360);
+    return ((static_cast<int>(angle) + 180) / 360);
 }
 
 //Inverse of calculateAngle()
@@ -475,7 +476,7 @@ void WSpinny::updateVinylControlSpeed(double rpm) {
 
 void WSpinny::updateVinylControlSignalEnabled(double enabled) {
 #ifdef __VINYLCONTROL__
-    if (m_pVCManager == NULL) {
+    if (m_pVCManager == nullptr) {
         return;
     }
     m_bSignalActive = enabled;
@@ -554,8 +555,9 @@ void WSpinny::mousePressEvent(QMouseEvent * e)
     m_iStartMouseY = y;
 
     //don't do anything if vinyl control is active
-    if (m_bVinylActive)
+    if (m_bVinylActive) {
         return;
+    }
 
     if (e->button() == Qt::LeftButton || e->button() == Qt::RightButton) {
         QApplication::setOverrideCursor(QCursor(Qt::ClosedHandCursor));

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -24,13 +24,13 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
     WSpinny(QWidget* parent, const QString& group,
             UserSettingsPointer pConfig,
             VinylControlManager* pVCMan);
-    virtual ~WSpinny();
+    ~WSpinny() override;
 
-    void onVinylSignalQualityUpdate(const VinylSignalQualityReport& report);
+    void onVinylSignalQualityUpdate(const VinylSignalQualityReport& report) override;
 
     void setup(QDomNode node, const SkinContext& context);
-    void dragEnterEvent(QDragEnterEvent *event);
-    void dropEvent(QDropEvent *event);
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
 
   public slots:
     void slotLoadTrack(TrackPointer);
@@ -52,14 +52,14 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
 
   protected:
     //QWidget:
-    void paintEvent(QPaintEvent*);
-    void mouseMoveEvent(QMouseEvent * e);
-    void mousePressEvent(QMouseEvent * e);
-    void mouseReleaseEvent(QMouseEvent * e);
-    void resizeEvent(QResizeEvent*);
-    void showEvent(QShowEvent* event);
-    void hideEvent(QHideEvent* event);
-    bool event(QEvent* pEvent);
+    void paintEvent(QPaintEvent* /*unused*/) override;
+    void mouseMoveEvent(QMouseEvent * e) override;
+    void mousePressEvent(QMouseEvent * e) override;
+    void mouseReleaseEvent(QMouseEvent * e) override;
+    void resizeEvent(QResizeEvent* /*unused*/) override;
+    void showEvent(QShowEvent* event) override;
+    void hideEvent(QHideEvent* event) override;
+    bool event(QEvent* pEvent) override;
 
     double calculateAngle(double playpos);
     int calculateFullRotations(double playpos);

--- a/src/widget/wsplitter.cpp
+++ b/src/widget/wsplitter.cpp
@@ -10,8 +10,6 @@ WSplitter::WSplitter(QWidget* pParent, UserSettingsPointer pConfig)
             this, SLOT(slotSplitterMoved()));
 }
 
-WSplitter::~WSplitter() = default;
-
 void WSplitter::setup(QDomNode node, const SkinContext& context) {
     // Load split sizes
     QString sizesJoined;

--- a/src/widget/wsplitter.cpp
+++ b/src/widget/wsplitter.cpp
@@ -46,7 +46,7 @@ void WSplitter::setup(QDomNode node, const SkinContext& context) {
         QStringList sizesSplit = sizesJoined.split(",");
         QList<int> sizesList;
         ok = false;
-        foreach (const QString& sizeStr, sizesSplit) {
+        for (const QString& sizeStr : sizesSplit) {
             sizesList.push_back(sizeStr.toInt(&ok));
             if (!ok) {
                 break;
@@ -77,7 +77,7 @@ void WSplitter::setup(QDomNode node, const SkinContext& context) {
         QStringList collapsibleSplit = collapsibleJoined.split(",");
         QList<bool> collapsibleList;
         ok = false;
-        foreach (const QString& collapsibleStr, collapsibleSplit) {
+        for (const QString& collapsibleStr : collapsibleSplit) {
             collapsibleList.push_back(collapsibleStr.toInt(&ok)>0);
             if (!ok) {
                 break;
@@ -105,7 +105,7 @@ void WSplitter::setup(QDomNode node, const SkinContext& context) {
 void WSplitter::slotSplitterMoved() {
     if (!m_configKey.group.isEmpty() && !m_configKey.item.isEmpty()) {
         QStringList sizeStrList;
-        foreach (const int& sizeInt, sizes()) {
+        for (const int& sizeInt : sizes()) {
             sizeStrList.push_back(QString::number(sizeInt));
         }
         QString sizesStr = sizeStrList.join(",");

--- a/src/widget/wsplitter.cpp
+++ b/src/widget/wsplitter.cpp
@@ -10,8 +10,7 @@ WSplitter::WSplitter(QWidget* pParent, UserSettingsPointer pConfig)
             this, SLOT(slotSplitterMoved()));
 }
 
-WSplitter::~WSplitter() {
-}
+WSplitter::~WSplitter() = default;
 
 void WSplitter::setup(QDomNode node, const SkinContext& context) {
     // Load split sizes
@@ -43,7 +42,7 @@ void WSplitter::setup(QDomNode node, const SkinContext& context) {
                 + QString::number(this->count());
     }
     // found some value for splitsizes?
-    if (sizesJoined != NULL) {
+    if (sizesJoined != nullptr) {
         QStringList sizesSplit = sizesJoined.split(",");
         QList<int> sizesList;
         ok = false;

--- a/src/widget/wsplitter.h
+++ b/src/widget/wsplitter.h
@@ -13,12 +13,12 @@ class WSplitter : public QSplitter, public WBaseWidget {
     Q_OBJECT
   public:
     WSplitter(QWidget* pParent, UserSettingsPointer pConfig);
-    virtual ~WSplitter();
+    ~WSplitter() override;
 
     void setup(QDomNode node, const SkinContext& context);
 
   protected:
-    bool event(QEvent* pEvent);
+    bool event(QEvent* pEvent) override;
 
   private slots:
     void slotSplitterMoved();

--- a/src/widget/wsplitter.h
+++ b/src/widget/wsplitter.h
@@ -13,7 +13,6 @@ class WSplitter : public QSplitter, public WBaseWidget {
     Q_OBJECT
   public:
     WSplitter(QWidget* pParent, UserSettingsPointer pConfig);
-    ~WSplitter() override;
 
     void setup(QDomNode node, const SkinContext& context);
 

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -12,8 +12,7 @@ WStarRating::WStarRating(QString group, QWidget* pParent)
           m_focused(false) {
 }
 
-WStarRating::~WStarRating() {
-}
+WStarRating::~WStarRating() = default;
 
 void WStarRating::setup(QDomNode node, const SkinContext& context) {
     Q_UNUSED(node);
@@ -49,7 +48,7 @@ void WStarRating::slotTrackLoaded(TrackPointer track) {
 void WStarRating::slotTrackUnloaded(TrackPointer track) {
     Q_UNUSED(track);
     if (m_pCurrentTrack) {
-        disconnect(m_pCurrentTrack.data(), 0, this, 0);
+        disconnect(m_pCurrentTrack.data(), nullptr, this, nullptr);
     }
     m_pCurrentTrack.clear();
     updateRating();
@@ -64,11 +63,11 @@ void WStarRating::updateRating() {
     update();
 }
 
-void WStarRating::updateRating(TrackInfoObject*) {
+void WStarRating::updateRating(TrackInfoObject* /*unused*/) {
     updateRating();
 }
 
-void WStarRating::paintEvent(QPaintEvent *) {
+void WStarRating::paintEvent(QPaintEvent * /*unused*/) {
     QStyleOption option;
     option.initFrom(this);
     QStylePainter painter(this);
@@ -80,8 +79,9 @@ void WStarRating::paintEvent(QPaintEvent *) {
 }
 
 void WStarRating::mouseMoveEvent(QMouseEvent *event) {
-    if (!m_pCurrentTrack)
+    if (!m_pCurrentTrack) {
         return;
+    }
 
     m_focused = true;
     int star = starAtPosition(event->x());
@@ -92,7 +92,7 @@ void WStarRating::mouseMoveEvent(QMouseEvent *event) {
     }
 }
 
-void WStarRating::leaveEvent(QEvent*) {
+void WStarRating::leaveEvent(QEvent* /*unused*/) {
     m_focused = false;
     updateRating();
 }
@@ -112,9 +112,10 @@ int WStarRating::starAtPosition(int x) {
     return star;
 }
 
-void WStarRating::mouseReleaseEvent(QMouseEvent*) {
-    if (!m_pCurrentTrack)
+void WStarRating::mouseReleaseEvent(QMouseEvent* /*unused*/) {
+    if (!m_pCurrentTrack) {
         return;
+    }
 
     m_pCurrentTrack->setRating(m_starRating.starCount());
 }

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -12,8 +12,6 @@ WStarRating::WStarRating(QString group, QWidget* pParent)
           m_focused(false) {
 }
 
-WStarRating::~WStarRating() = default;
-
 void WStarRating::setup(QDomNode node, const SkinContext& context) {
     Q_UNUSED(node);
     Q_UNUSED(context);

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -15,7 +15,6 @@ class WStarRating : public WWidget {
     Q_OBJECT
   public:
     WStarRating(QString group, QWidget* pParent);
-    ~WStarRating() override;
 
     virtual void setup(QDomNode node, const SkinContext& context);
     QSize sizeHint() const override;

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -15,10 +15,10 @@ class WStarRating : public WWidget {
     Q_OBJECT
   public:
     WStarRating(QString group, QWidget* pParent);
-    virtual ~WStarRating();
+    ~WStarRating() override;
 
     virtual void setup(QDomNode node, const SkinContext& context);
-    QSize sizeHint() const;
+    QSize sizeHint() const override;
 
   public slots:
     void slotTrackLoaded(TrackPointer track);
@@ -31,7 +31,7 @@ class WStarRating : public WWidget {
     void paintEvent(QPaintEvent* e) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
-    void leaveEvent(QEvent *) override;
+    void leaveEvent(QEvent * /*unused*/) override;
     void fillDebugTooltip(QStringList* debug) override;
 
     StarRating m_starRating;

--- a/src/widget/wstatuslight.cpp
+++ b/src/widget/wstatuslight.cpp
@@ -30,8 +30,7 @@ WStatusLight::WStatusLight(QWidget * parent)
     setNoPos(0);
 }
 
-WStatusLight::~WStatusLight() {
-}
+WStatusLight::~WStatusLight() = default;
 
 void WStatusLight::setNoPos(int iNoPos) {
     // If pixmap array is already allocated, delete it.
@@ -114,7 +113,7 @@ void WStatusLight::onConnectedControlChanged(double dParameter, double dValue) {
     }
 }
 
-void WStatusLight::paintEvent(QPaintEvent *) {
+void WStatusLight::paintEvent(QPaintEvent * /*unused*/) {
     QStyleOption option;
     option.initFrom(this);
     QStylePainter p(this);

--- a/src/widget/wstatuslight.cpp
+++ b/src/widget/wstatuslight.cpp
@@ -30,8 +30,6 @@ WStatusLight::WStatusLight(QWidget * parent)
     setNoPos(0);
 }
 
-WStatusLight::~WStatusLight() = default;
-
 void WStatusLight::setNoPos(int iNoPos) {
     // If pixmap array is already allocated, delete it.
     if (!m_pixmaps.empty()) {

--- a/src/widget/wstatuslight.h
+++ b/src/widget/wstatuslight.h
@@ -34,16 +34,16 @@
 class WStatusLight : public WWidget  {
    Q_OBJECT
   public:
-    WStatusLight(QWidget *parent=0);
-    virtual ~WStatusLight();
+    explicit WStatusLight(QWidget *parent=nullptr);
+    ~WStatusLight() override;
 
     void setup(QDomNode node, const SkinContext& context);
 
   public slots:
-    void onConnectedControlChanged(double dParameter, double dValue);
+    void onConnectedControlChanged(double dParameter, double dValue) override;
 
   protected:
-    void paintEvent(QPaintEvent *);
+    void paintEvent(QPaintEvent * /*unused*/) override;
 
   private:
     void setPixmap(int iState, PixmapSource source, Paintable::DrawMode mode);

--- a/src/widget/wstatuslight.h
+++ b/src/widget/wstatuslight.h
@@ -35,7 +35,6 @@ class WStatusLight : public WWidget  {
    Q_OBJECT
   public:
     explicit WStatusLight(QWidget *parent=nullptr);
-    ~WStatusLight() override;
 
     void setup(QDomNode node, const SkinContext& context);
 

--- a/src/widget/wtime.h
+++ b/src/widget/wtime.h
@@ -13,10 +13,10 @@
 class WTime: public WLabel {
     Q_OBJECT
   public:
-    WTime(QWidget *parent=0);
-    virtual ~WTime();
+    explicit WTime(QWidget *parent=nullptr);
+    ~WTime() override;
 
-    void setup(QDomNode node, const SkinContext& context);
+    void setup(QDomNode node, const SkinContext& context) override;
 
   private slots:
     void refreshTime();

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -15,8 +15,6 @@ WTrackProperty::WTrackProperty(const char* group,
     setAcceptDrops(true);
 }
 
-WTrackProperty::~WTrackProperty() = default;
-
 void WTrackProperty::setup(QDomNode node, const SkinContext& context) {
     WLabel::setup(node, context);
 

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -15,8 +15,7 @@ WTrackProperty::WTrackProperty(const char* group,
     setAcceptDrops(true);
 }
 
-WTrackProperty::~WTrackProperty() {
-}
+WTrackProperty::~WTrackProperty() = default;
 
 void WTrackProperty::setup(QDomNode node, const SkinContext& context) {
     WLabel::setup(node, context);
@@ -37,13 +36,13 @@ void WTrackProperty::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldT
     Q_UNUSED(pNewTrack);
     Q_UNUSED(pOldTrack);
     if (m_pCurrentTrack) {
-        disconnect(m_pCurrentTrack.data(), 0, this, 0);
+        disconnect(m_pCurrentTrack.data(), nullptr, this, nullptr);
     }
     m_pCurrentTrack.clear();
     setText("");
 }
 
-void WTrackProperty::updateLabel(TrackInfoObject*) {
+void WTrackProperty::updateLabel(TrackInfoObject* /*unused*/) {
     if (m_pCurrentTrack) {
         QVariant property = m_pCurrentTrack->property(m_property.toAscii().constData());
         if (property.isValid() && qVariantCanConvert<QString>(property)) {

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -14,9 +14,9 @@ class WTrackProperty : public WLabel {
     Q_OBJECT
   public:
     WTrackProperty(const char* group, UserSettingsPointer pConfig, QWidget* pParent);
-    virtual ~WTrackProperty();
+    ~WTrackProperty() override;
 
-    void setup(QDomNode node, const SkinContext& context);
+    void setup(QDomNode node, const SkinContext& context) override;
 
   signals:
     void trackDropped(QString filename, QString group);
@@ -29,9 +29,9 @@ class WTrackProperty : public WLabel {
     void updateLabel(TrackInfoObject*);
 
   private:
-    void dragEnterEvent(QDragEnterEvent *event);
-    void dropEvent(QDropEvent *event);
-    void mouseMoveEvent(QMouseEvent *event);
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
 
     const char* m_pGroup;
     UserSettingsPointer m_pConfig;

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -14,7 +14,6 @@ class WTrackProperty : public WLabel {
     Q_OBJECT
   public:
     WTrackProperty(const char* group, UserSettingsPointer pConfig, QWidget* pParent);
-    ~WTrackProperty() override;
 
     void setup(QDomNode node, const SkinContext& context) override;
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -10,9 +10,9 @@
 #include "widget/wtracktableviewheader.h"
 #include "library/coverartcache.h"
 #include "library/librarytablemodel.h"
+#include "controlobject.h"
 #include "library/trackcollection.h"
 #include "trackinfoobject.h"
-#include "controlobject.h"
 #include "controlobjectslave.h"
 #include "widget/wtracktableview.h"
 #include "library/dlgtrackinfo.h"
@@ -22,8 +22,8 @@
 #include "util/time.h"
 #include "preferences/dialog/dlgpreflibrary.h"
 #include "waveform/guitick.h"
-#include "widget/wcoverartmenu.h"
 #include "util/assert.h"
+#include "widget/wcoverartmenu.h"
 
 WTrackTableView::WTrackTableView(QWidget * parent,
                                  UserSettingsPointer pConfig,
@@ -33,7 +33,7 @@ WTrackTableView::WTrackTableView(QWidget * parent,
                                       WTRACKTABLEVIEW_VSCROLLBARPOS_KEY)),
           m_pConfig(pConfig),
           m_pTrackCollection(pTrackCollection),
-          m_DlgTagFetcher(NULL),
+          m_DlgTagFetcher(nullptr),
           m_sorting(sorting),
           m_iCoverSourceColumn(-1),
           m_iCoverTypeColumn(-1),
@@ -44,7 +44,7 @@ WTrackTableView::WTrackTableView(QWidget * parent,
           m_loadCachedOnly(false) {
     // Give a NULL parent because otherwise it inherits our style which can make
     // it unreadable. Bug #673411
-    m_pTrackInfo = new DlgTrackInfo(NULL, m_DlgTagFetcher);
+    m_pTrackInfo = new DlgTrackInfo(nullptr, m_DlgTagFetcher);
     connect(m_pTrackInfo, SIGNAL(next()),
             this, SLOT(slotNextTrackInfo()));
     connect(m_pTrackInfo, SIGNAL(previous()),
@@ -161,7 +161,7 @@ void WTrackTableView::enableCachedOnly() {
     m_lastUserAction = Time::elapsed();
 }
 
-void WTrackTableView::slotScrollValueChanged(int) {
+void WTrackTableView::slotScrollValueChanged(int /*unused*/) {
     enableCachedOnly();
 }
 
@@ -172,7 +172,7 @@ void WTrackTableView::selectionChanged(const QItemSelection& selected,
     QTableView::selectionChanged(selected, deselected);
 }
 
-void WTrackTableView::slotGuiTick50ms(double) {
+void WTrackTableView::slotGuiTick50ms(double /*unused*/) {
     // if the user is stopped in the same row for more than 0.1 s,
     // we load un-cached cover arts as well.
     mixxx::Duration timeDelta = Time::elapsed() - m_lastUserAction;
@@ -253,7 +253,7 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel *model) {
     // header. Also, for some reason the WTrackTableView has to be hidden or
     // else problems occur. Since we parent the WtrackTableViewHeader's to the
     // WTrackTableView, they are automatically deleted.
-    WTrackTableViewHeader* header = new WTrackTableViewHeader(Qt::Horizontal, this);
+    auto  header = new WTrackTableViewHeader(Qt::Horizontal, this);
 
     // WTF(rryan) The following saves on unnecessary work on the part of
     // WTrackTableHeaderView. setHorizontalHeader() calls setModel() on the
@@ -263,7 +263,7 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel *model) {
     // WTrackTableViewHeader, so this is wasteful. Setting a temporary
     // QHeaderView here saves on setModel() calls. Since we parent the
     // QHeaderView to the WTrackTableView, it is automatically deleted.
-    QHeaderView* tempHeader = new QHeaderView(Qt::Horizontal, this);
+    auto  tempHeader = new QHeaderView(Qt::Horizontal, this);
     /* Tobias Rafreider: DO NOT SET SORTING TO TRUE during header replacement
      * Otherwise, setSortingEnabled(1) will immediately trigger sortByColumn()
      * For some reason this will cause 4 select statements in series
@@ -526,8 +526,9 @@ void WTrackTableView::slotPurge() {
 
 void WTrackTableView::slotOpenInFileBrowser() {
     TrackModel* trackModel = getTrackModel();
-    if (!trackModel)
+    if (!trackModel) {
         return;
+    }
 
     QModelIndexList indices = selectionModel()->selectedRows();
 
@@ -748,7 +749,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
             if (!playlistDao.isHidden(it.value())) {
                 // No leak because making the menu the parent means they will be
                 // auto-deleted
-                QAction* pAction = new QAction(it.key(), m_pPlaylistMenu);
+                auto  pAction = new QAction(it.key(), m_pPlaylistMenu);
                 bool locked = playlistDao.isPlaylistLocked(it.value());
                 pAction->setEnabled(!locked);
                 m_pPlaylistMenu->addAction(pAction);
@@ -779,7 +780,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
             it.next();
             // No leak because making the menu the parent means they will be
             // auto-deleted
-            QAction* pAction = new QAction(it.key(), m_pCrateMenu);
+            auto  pAction = new QAction(it.key(), m_pCrateMenu);
             bool locked = crateDao.isCrateLocked(it.value());
             pAction->setEnabled(!locked);
             m_pCrateMenu->addAction(pAction);
@@ -807,7 +808,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
         m_pBPMMenu->addAction(m_pBpmUnlockAction);
         m_pBPMMenu->addSeparator();
         if (oneSongSelected) {
-            if (trackModel == NULL) {
+            if (trackModel == nullptr) {
                 return;
             }
             int column = trackModel->fieldIndex("bpm_lock");
@@ -857,7 +858,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
     //end of BPM section of menu
 
     if (modelHasCapabilities(TrackModel::TRACKMODELCAPS_CLEAR_BEATS)) {
-        if (trackModel == NULL) {
+        if (trackModel == nullptr) {
             return;
         }
         bool allowClear = true;
@@ -967,8 +968,9 @@ void WTrackTableView::mouseMoveEvent(QMouseEvent* pEvent) {
     }
 
     TrackModel* trackModel = getTrackModel();
-    if (!trackModel)
+    if (!trackModel) {
         return;
+    }
     //qDebug() << "MouseMoveEvent";
     // Iterate over selected rows and append each item's location url to a list.
     QList<QString> locations;
@@ -1309,7 +1311,7 @@ void WTrackTableView::slotReloadTrackMetadata() {
 
     TrackModel* trackModel = getTrackModel();
 
-    if (trackModel == NULL) {
+    if (trackModel == nullptr) {
         return;
     }
 
@@ -1326,7 +1328,7 @@ void WTrackTableView::slotResetPlayed() {
     QModelIndexList indices = selectionModel()->selectedRows();
     TrackModel* trackModel = getTrackModel();
 
-    if (trackModel == NULL) {
+    if (trackModel == nullptr) {
         return;
     }
 
@@ -1364,20 +1366,21 @@ void WTrackTableView::addSelectionToPlaylist(int iPlaylistId) {
 
        do {
            bool ok = false;
-           name = QInputDialog::getText(NULL,
+           name = QInputDialog::getText(nullptr,
                                         tr("Create New Playlist"),
                                         tr("Enter name for new playlist:"),
                                         QLineEdit::Normal,
                                         tr("New Playlist"),
                                         &ok).trimmed();
-           if (!ok)
+           if (!ok) {
                return;
+           }
            if (playlistDao.getPlaylistIdFromName(name) != -1) {
-               QMessageBox::warning(NULL,
+               QMessageBox::warning(nullptr,
                                     tr("Playlist Creation Failed"),
                                     tr("A playlist by that name already exists."));
            } else if (name.isEmpty()) {
-               QMessageBox::warning(NULL,
+               QMessageBox::warning(nullptr,
                                     tr("Playlist Creation Failed"),
                                     tr("A playlist cannot have a blank name."));
            } else {
@@ -1386,7 +1389,7 @@ void WTrackTableView::addSelectionToPlaylist(int iPlaylistId) {
        } while (!validNameGiven);
        iPlaylistId = playlistDao.createPlaylist(name);//-1 is changed to the new playlist ID return from the DAO
        if (iPlaylistId == -1) {
-           QMessageBox::warning(NULL,
+           QMessageBox::warning(nullptr,
                                 tr("Playlist Creation Failed"),
                                 tr("An unknown error occurred while creating playlist: ")
                                  +name);
@@ -1425,21 +1428,22 @@ void WTrackTableView::addSelectionToCrate(int iCrateId) {
         bool validNameGiven = false;
         do {
             bool ok = false;
-            name = QInputDialog::getText(NULL,
+            name = QInputDialog::getText(nullptr,
                                          tr("Create New Crate"),
                                          tr("Enter name for new crate:"),
                                          QLineEdit::Normal, tr("New Crate"),
                                          &ok).trimmed();
-            if (!ok)
+            if (!ok) {
                 return;
+            }
             int existingId = crateDao.getCrateIdByName(name);
             if (existingId != -1) {
-                QMessageBox::warning(NULL,
+                QMessageBox::warning(nullptr,
                                      tr("Creating Crate Failed"),
                                      tr("A crate by that name already exists."));
             }
             else if (name.isEmpty()) {
-                QMessageBox::warning(NULL,
+                QMessageBox::warning(nullptr,
                                      tr("Creating Crate Failed"),
                                      tr("A crate cannot have a blank name."));
             }
@@ -1450,7 +1454,7 @@ void WTrackTableView::addSelectionToCrate(int iCrateId) {
         iCrateId = crateDao.createCrate(name);// -1 is changed to the new crate ID returned by the DAO
         if (iCrateId == -1) {
             qDebug() << "Error creating crate with name " << name;
-            QMessageBox::warning(NULL,
+            QMessageBox::warning(nullptr,
                                  tr("Creating Crate Failed"),
                                  tr("An unknown error occurred while creating crate: ")
                                  + name);
@@ -1467,8 +1471,9 @@ void WTrackTableView::doSortByColumn(int headerSection) {
     TrackModel* trackModel = getTrackModel();
     QAbstractItemModel* itemModel = model();
 
-    if (trackModel == NULL || itemModel == NULL || m_sorting == false)
+    if (trackModel == nullptr || itemModel == nullptr || !m_sorting) {
         return;
+    }
 
     // Save the selection
     QModelIndexList selection = selectionModel()->selectedRows();
@@ -1535,18 +1540,17 @@ void WTrackTableView::slotUnlockBpm() {
 
 void WTrackTableView::slotScaleBpm(int scale) {
     TrackModel* trackModel = getTrackModel();
-    if (trackModel == NULL) {
+    if (trackModel == nullptr) {
         return;
     }
 
     QModelIndexList selectedTrackIndices = selectionModel()->selectedRows();
-    for (int i = 0; i < selectedTrackIndices.size(); ++i) {
-        QModelIndex index = selectedTrackIndices.at(i);
+    for (auto index : selectedTrackIndices) {
         TrackPointer track = trackModel->getTrack(index);
         if (!track->isBpmLocked()) { // bpm is not locked
             BeatsPointer beats = track->getBeats();
-            if (beats != NULL) {
-                beats->scale((Beats::BPMScale)scale);
+            if (beats != nullptr) {
+                beats->scale(static_cast<Beats::BPMScale>(scale));
             } else {
                 continue;
             }
@@ -1556,14 +1560,13 @@ void WTrackTableView::slotScaleBpm(int scale) {
 
 void WTrackTableView::lockBpm(bool lock) {
     TrackModel* trackModel = getTrackModel();
-    if (trackModel == NULL) {
+    if (trackModel == nullptr) {
         return;
     }
 
     QModelIndexList selectedTrackIndices = selectionModel()->selectedRows();
     // TODO: This should be done in a thread for large selections
-    for (int i = 0; i < selectedTrackIndices.size(); ++i) {
-        QModelIndex index = selectedTrackIndices.at(i);
+    for (auto index : selectedTrackIndices) {
         TrackPointer track = trackModel->getTrack(index);
         track->setBpmLocked(lock);
     }
@@ -1571,14 +1574,13 @@ void WTrackTableView::lockBpm(bool lock) {
 
 void WTrackTableView::slotClearBeats() {
     TrackModel* trackModel = getTrackModel();
-    if (trackModel == NULL) {
+    if (trackModel == nullptr) {
         return;
     }
 
     QModelIndexList selectedTrackIndices = selectionModel()->selectedRows();
     // TODO: This should be done in a thread for large selections
-    for (int i = 0; i < selectedTrackIndices.size(); ++i) {
-        QModelIndex index = selectedTrackIndices.at(i);
+    for (auto index : selectedTrackIndices) {
         TrackPointer track = trackModel->getTrack(index);
         if (!track->isBpmLocked()) {
             track->setBeats(BeatsPointer());
@@ -1590,7 +1592,7 @@ void WTrackTableView::slotReplayGainReset() {
     QModelIndexList indices = selectionModel()->selectedRows();
     TrackModel* trackModel = getTrackModel();
 
-    if (trackModel == NULL) {
+    if (trackModel == nullptr) {
         return;
     }
 
@@ -1604,7 +1606,7 @@ void WTrackTableView::slotReplayGainReset() {
 
 void WTrackTableView::slotCoverArtSelected(const CoverArt& art) {
     TrackModel* trackModel = getTrackModel();
-    if (trackModel == NULL) {
+    if (trackModel == nullptr) {
         return;
     }
     QModelIndexList selection = selectionModel()->selectedRows();
@@ -1618,7 +1620,7 @@ void WTrackTableView::slotCoverArtSelected(const CoverArt& art) {
 
 void WTrackTableView::slotReloadCoverArt() {
     TrackModel* trackModel = getTrackModel();
-    if (trackModel == NULL) {
+    if (trackModel == nullptr) {
         return;
     }
     QList<TrackPointer> selectedTracks;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -253,7 +253,7 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel *model) {
     // header. Also, for some reason the WTrackTableView has to be hidden or
     // else problems occur. Since we parent the WtrackTableViewHeader's to the
     // WTrackTableView, they are automatically deleted.
-    auto  header = new WTrackTableViewHeader(Qt::Horizontal, this);
+    auto header = new WTrackTableViewHeader(Qt::Horizontal, this);
 
     // WTF(rryan) The following saves on unnecessary work on the part of
     // WTrackTableHeaderView. setHorizontalHeader() calls setModel() on the
@@ -263,7 +263,7 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel *model) {
     // WTrackTableViewHeader, so this is wasteful. Setting a temporary
     // QHeaderView here saves on setModel() calls. Since we parent the
     // QHeaderView to the WTrackTableView, it is automatically deleted.
-    auto  tempHeader = new QHeaderView(Qt::Horizontal, this);
+    auto tempHeader = new QHeaderView(Qt::Horizontal, this);
     /* Tobias Rafreider: DO NOT SET SORTING TO TRUE during header replacement
      * Otherwise, setSortingEnabled(1) will immediately trigger sortByColumn()
      * For some reason this will cause 4 select statements in series
@@ -533,7 +533,7 @@ void WTrackTableView::slotOpenInFileBrowser() {
     QModelIndexList indices = selectionModel()->selectedRows();
 
     QSet<QString> sDirs;
-    foreach (QModelIndex index, indices) {
+    for (const QModelIndex& index : indices) {
         if (!index.isValid()) {
             continue;
         }
@@ -749,7 +749,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
             if (!playlistDao.isHidden(it.value())) {
                 // No leak because making the menu the parent means they will be
                 // auto-deleted
-                auto  pAction = new QAction(it.key(), m_pPlaylistMenu);
+                auto pAction = new QAction(it.key(), m_pPlaylistMenu);
                 bool locked = playlistDao.isPlaylistLocked(it.value());
                 pAction->setEnabled(!locked);
                 m_pPlaylistMenu->addAction(pAction);
@@ -780,7 +780,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
             it.next();
             // No leak because making the menu the parent means they will be
             // auto-deleted
-            auto  pAction = new QAction(it.key(), m_pCrateMenu);
+            auto pAction = new QAction(it.key(), m_pCrateMenu);
             bool locked = crateDao.isCrateLocked(it.value());
             pAction->setEnabled(!locked);
             m_pCrateMenu->addAction(pAction);
@@ -976,7 +976,7 @@ void WTrackTableView::mouseMoveEvent(QMouseEvent* pEvent) {
     QList<QString> locations;
     QModelIndexList indices = selectionModel()->selectedRows();
 
-    foreach (QModelIndex index, indices) {
+    for (const QModelIndex& index : indices) {
         if (!index.isValid()) {
             continue;
         }
@@ -1076,8 +1076,7 @@ void WTrackTableView::dropEvent(QDropEvent * event) {
         QModelIndexList indices = selectionModel()->selectedRows();
 
         QList<int> selectedRows;
-        QModelIndex idx;
-        foreach (idx, indices) {
+        for (const QModelIndex& idx : indices) {
             selectedRows.append(idx.row());
         }
 
@@ -1168,7 +1167,7 @@ void WTrackTableView::dropEvent(QDropEvent * event) {
             event->mimeData()->urls(), false, true);
 
         QList<QString> fileLocationList;
-        foreach (const QFileInfo& fileInfo, fileList) {
+        for (const QFileInfo& fileInfo : fileList) {
             // TODO(uklotzde): Replace with TrackRef::location()
             fileLocationList.append(fileInfo.absoluteFilePath());
         }
@@ -1278,7 +1277,7 @@ void WTrackTableView::sendToAutoDJ(bool bTop) {
         return;
     }
 
-    foreach (QModelIndex index, indices) {
+    for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
             TrackId trackId(pTrack->getId());
@@ -1315,7 +1314,7 @@ void WTrackTableView::slotReloadTrackMetadata() {
         return;
     }
 
-    foreach (QModelIndex index, indices) {
+    for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
             SoundSourceProxy(pTrack).loadTrackMetadata(true);
@@ -1332,7 +1331,7 @@ void WTrackTableView::slotResetPlayed() {
         return;
     }
 
-    foreach (QModelIndex index, indices) {
+    for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
             pTrack->resetPlayCounter();
@@ -1350,7 +1349,7 @@ void WTrackTableView::addSelectionToPlaylist(int iPlaylistId) {
 
     QModelIndexList indices = selectionModel()->selectedRows();
     QList<TrackId> trackIds;
-    foreach (QModelIndex index, indices) {
+    for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (!pTrack) {
             continue;
@@ -1413,7 +1412,7 @@ void WTrackTableView::addSelectionToCrate(int iCrateId) {
 
     QModelIndexList indices = selectionModel()->selectedRows();
     QList<TrackId> trackIds;
-    foreach (QModelIndex index, indices) {
+    for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (!pTrack) {
             continue;
@@ -1495,7 +1494,7 @@ void WTrackTableView::doSortByColumn(int headerSection) {
     currentSelection->reset(); // remove current selection
 
     QMap<int,int> selectedRows;
-    for (auto  const& trackId: trackIds) {
+    for (const auto& trackId : trackIds) {
 
         // TODO(rryan) slowly fixing the issues with BaseSqlTableModel. This
         // code is broken for playlists because it assumes each trackid is in
@@ -1506,7 +1505,7 @@ void WTrackTableView::doSortByColumn(int headerSection) {
         // table index as the unique id instead of this code stupidly using
         // trackid.
         QLinkedList<int> rows = trackModel->getTrackRows(trackId);
-        foreach (int row, rows) {
+        for (int row : rows) {
             // Restore sort order by rows, so the following commands will act as expected
             selectedRows.insert(row,0);
         }
@@ -1545,7 +1544,7 @@ void WTrackTableView::slotScaleBpm(int scale) {
     }
 
     QModelIndexList selectedTrackIndices = selectionModel()->selectedRows();
-    for (auto index : selectedTrackIndices) {
+    for (const auto& index : selectedTrackIndices) {
         TrackPointer track = trackModel->getTrack(index);
         if (!track->isBpmLocked()) { // bpm is not locked
             BeatsPointer beats = track->getBeats();
@@ -1566,7 +1565,7 @@ void WTrackTableView::lockBpm(bool lock) {
 
     QModelIndexList selectedTrackIndices = selectionModel()->selectedRows();
     // TODO: This should be done in a thread for large selections
-    for (auto index : selectedTrackIndices) {
+    for (const auto& index : selectedTrackIndices) {
         TrackPointer track = trackModel->getTrack(index);
         track->setBpmLocked(lock);
     }
@@ -1580,7 +1579,7 @@ void WTrackTableView::slotClearBeats() {
 
     QModelIndexList selectedTrackIndices = selectionModel()->selectedRows();
     // TODO: This should be done in a thread for large selections
-    for (auto index : selectedTrackIndices) {
+    for (const auto& index : selectedTrackIndices) {
         TrackPointer track = trackModel->getTrack(index);
         if (!track->isBpmLocked()) {
             track->setBeats(BeatsPointer());
@@ -1596,7 +1595,7 @@ void WTrackTableView::slotReplayGainReset() {
         return;
     }
 
-    foreach (QModelIndex index, indices) {
+    for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
             pTrack->setReplayGain(Mixxx::ReplayGain());
@@ -1610,7 +1609,7 @@ void WTrackTableView::slotCoverArtSelected(const CoverArt& art) {
         return;
     }
     QModelIndexList selection = selectionModel()->selectedRows();
-    foreach (QModelIndex index, selection) {
+    for (const QModelIndex& index : selection) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
             pTrack->setCoverArt(art);
@@ -1625,7 +1624,7 @@ void WTrackTableView::slotReloadCoverArt() {
     }
     QList<TrackPointer> selectedTracks;
     QModelIndexList selection = selectionModel()->selectedRows();
-    foreach (QModelIndex index, selection) {
+    for (const QModelIndex& index : selection) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
             selectedTracks.append(pTrack);

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -28,13 +28,13 @@ class WTrackTableView : public WLibraryTableView {
   public:
     WTrackTableView(QWidget* parent, UserSettingsPointer pConfig,
                     TrackCollection* pTrackCollection, bool sorting = true);
-    virtual ~WTrackTableView();
-    void contextMenuEvent(QContextMenuEvent * event);
-    void onSearch(const QString& text);
-    void onShow();
-    virtual void keyPressEvent(QKeyEvent* event);
-    virtual void loadSelectedTrack();
-    virtual void loadSelectedTrackToGroup(QString group, bool play);
+    ~WTrackTableView() override;
+    void contextMenuEvent(QContextMenuEvent * event) override;
+    void onSearch(const QString& text) override;
+    void onShow() override;
+    void keyPressEvent(QKeyEvent* event) override;
+    void loadSelectedTrack() override;
+    void loadSelectedTrackToGroup(QString group, bool play) override;
 
   public slots:
     void loadTrackModel(QAbstractItemModel* model);
@@ -43,8 +43,8 @@ class WTrackTableView : public WLibraryTableView {
     void slotPurge();
     void onSearchStarting();
     void onSearchCleared();
-    void slotSendToAutoDJ();
-    void slotSendToAutoDJTop();
+    void slotSendToAutoDJ() override;
+    void slotSendToAutoDJTop() override;
 
   private slots:
     void slotRemove();
@@ -78,22 +78,22 @@ class WTrackTableView : public WLibraryTableView {
     void showTrackInfo(QModelIndex index);
     void showDlgTagFetcher(QModelIndex index);
     void createActions();
-    void dragMoveEvent(QDragMoveEvent * event);
-    void dragEnterEvent(QDragEnterEvent * event);
-    void dropEvent(QDropEvent * event);
+    void dragMoveEvent(QDragMoveEvent * event) override;
+    void dragEnterEvent(QDragEnterEvent * event) override;
+    void dropEvent(QDropEvent * event) override;
     void lockBpm(bool lock);
 
     void enableCachedOnly();
     void selectionChanged(const QItemSelection &selected,
-                          const QItemSelection &deselected);
+                          const QItemSelection &deselected) override;
 
     // Mouse move event, implemented to hide the text and show an icon instead
     // when dragging.
-    void mouseMoveEvent(QMouseEvent *pEvent);
+    void mouseMoveEvent(QMouseEvent *pEvent) override;
 
     // Returns the current TrackModel, or returns NULL if none is set.
     TrackModel* getTrackModel();
-    bool modelHasCapabilities(TrackModel::CapabilitiesFlags capability);
+    bool modelHasCapabilities(TrackModel::CapabilitiesFlags capabilities);
 
     UserSettingsPointer m_pConfig;
     TrackCollection* m_pTrackCollection;

--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -155,7 +155,7 @@ void WTrackTableViewHeader::setModel(QAbstractItemModel* model) {
         }
 
         QString title = model->headerData(i, orientation()).toString();
-        auto  action = new QAction(title, &m_menu);
+        auto action = new QAction(title, &m_menu);
         action->setCheckable(true);
 
         /* If Mixxx starts the first time or the header states have been cleared
@@ -283,7 +283,7 @@ void WTrackTableViewHeader::showOrHideColumn(int column) {
 
 int WTrackTableViewHeader::hiddenCount() {
     int count = 0;
-    for (auto pAction : m_columnActions) {
+    for (const auto& pAction : m_columnActions) {
         if (!pAction->isChecked()) {
             count += 1;
         }

--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -103,8 +103,6 @@ WTrackTableViewHeader::WTrackTableViewHeader(Qt::Orientation orientation,
             this, SLOT(showOrHideColumn(int)));
 }
 
-WTrackTableViewHeader::~WTrackTableViewHeader() = default;
-
 void WTrackTableViewHeader::contextMenuEvent(QContextMenuEvent* event) {
     m_menu.popup(event->globalPos());
 }

--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -103,8 +103,7 @@ WTrackTableViewHeader::WTrackTableViewHeader(Qt::Orientation orientation,
             this, SLOT(showOrHideColumn(int)));
 }
 
-WTrackTableViewHeader::~WTrackTableViewHeader() {
-}
+WTrackTableViewHeader::~WTrackTableViewHeader() = default;
 
 void WTrackTableViewHeader::contextMenuEvent(QContextMenuEvent* event) {
     m_menu.popup(event->globalPos());
@@ -156,7 +155,7 @@ void WTrackTableViewHeader::setModel(QAbstractItemModel* model) {
         }
 
         QString title = model->headerData(i, orientation()).toString();
-        QAction* action = new QAction(title, &m_menu);
+        auto  action = new QAction(title, &m_menu);
         action->setCheckable(true);
 
         /* If Mixxx starts the first time or the header states have been cleared
@@ -248,10 +247,7 @@ bool WTrackTableViewHeader::hasPersistedHeaderState() {
         return false;
     }
     QString headerStateString = track_model->getModelSetting("header_state_pb");
-    if (!headerStateString.isNull()) {
-        return true;
-    }
-    return false;
+    return !headerStateString.isNull();
 }
 
 void WTrackTableViewHeader::clearActions() {
@@ -287,11 +283,10 @@ void WTrackTableViewHeader::showOrHideColumn(int column) {
 
 int WTrackTableViewHeader::hiddenCount() {
     int count = 0;
-    for (QMap<int, QAction*>::iterator it = m_columnActions.begin();
-         it != m_columnActions.end(); ++it) {
-        QAction* pAction = *it;
-        if (!pAction->isChecked())
+    for (auto pAction : m_columnActions) {
+        if (!pAction->isChecked()) {
             count += 1;
+        }
     }
     return count;
 }

--- a/src/widget/wtracktableviewheader.h
+++ b/src/widget/wtracktableviewheader.h
@@ -30,7 +30,7 @@ public:
             : m_view_state(pb) { }
 
     // Populate the object with the serialized protobuf data provided.
-    HeaderViewState(const QString& serialized);
+    explicit HeaderViewState(const QString& base64serialized);
 
     // Returns a serialized protobuf of the current state.
     QString saveState() const;
@@ -59,11 +59,11 @@ private:
 class WTrackTableViewHeader : public QHeaderView {
     Q_OBJECT
   public:
-    WTrackTableViewHeader(Qt::Orientation orientation, QWidget* parent = 0);
-    virtual ~WTrackTableViewHeader();
+    explicit WTrackTableViewHeader(Qt::Orientation orientation, QWidget* parent = nullptr);
+    ~WTrackTableViewHeader() override;
 
-    void contextMenuEvent(QContextMenuEvent* event);
-    virtual void setModel(QAbstractItemModel* model);
+    void contextMenuEvent(QContextMenuEvent* event) override;
+    void setModel(QAbstractItemModel* model) override;
 
     void saveHeaderState();
     void restoreHeaderState();

--- a/src/widget/wtracktableviewheader.h
+++ b/src/widget/wtracktableviewheader.h
@@ -60,7 +60,6 @@ class WTrackTableViewHeader : public QHeaderView {
     Q_OBJECT
   public:
     explicit WTrackTableViewHeader(Qt::Orientation orientation, QWidget* parent = nullptr);
-    ~WTrackTableViewHeader() override;
 
     void contextMenuEvent(QContextMenuEvent* event) override;
     void setModel(QAbstractItemModel* model) override;

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -13,8 +13,6 @@ WTrackText::WTrackText(const char *group, UserSettingsPointer pConfig, QWidget* 
     setAcceptDrops(true);
 }
 
-WTrackText::~WTrackText() = default;
-
 void WTrackText::slotTrackLoaded(TrackPointer track) {
     if (track) {
         m_pCurrentTrack = track;

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -13,8 +13,7 @@ WTrackText::WTrackText(const char *group, UserSettingsPointer pConfig, QWidget* 
     setAcceptDrops(true);
 }
 
-WTrackText::~WTrackText() {
-}
+WTrackText::~WTrackText() = default;
 
 void WTrackText::slotTrackLoaded(TrackPointer track) {
     if (track) {
@@ -29,13 +28,13 @@ void WTrackText::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack
     Q_UNUSED(pNewTrack);
     Q_UNUSED(pOldTrack);
     if (m_pCurrentTrack) {
-        disconnect(m_pCurrentTrack.data(), 0, this, 0);
+        disconnect(m_pCurrentTrack.data(), nullptr, this, nullptr);
     }
     m_pCurrentTrack.clear();
     setText("");
 }
 
-void WTrackText::updateLabel(TrackInfoObject*) {
+void WTrackText::updateLabel(TrackInfoObject* /*unused*/) {
     if (m_pCurrentTrack) {
         setText(m_pCurrentTrack->getInfo());
     }

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -12,8 +12,8 @@
 class WTrackText : public WLabel {
     Q_OBJECT
   public:
-    WTrackText(const char* group, UserSettingsPointer pConfig, QWidget *parent);
-    virtual ~WTrackText();
+    WTrackText(const char* group, UserSettingsPointer pConfig, QWidget *pParent);
+    ~WTrackText() override;
 
   signals:
     void trackDropped(QString fileName, QString group);
@@ -26,9 +26,9 @@ class WTrackText : public WLabel {
     void updateLabel(TrackInfoObject*);
 
   private:
-    void dragEnterEvent(QDragEnterEvent *event);
-    void dropEvent(QDropEvent *event);
-    void mouseMoveEvent(QMouseEvent *event);
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
 
     const char* m_pGroup;
     UserSettingsPointer m_pConfig;

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -13,7 +13,6 @@ class WTrackText : public WLabel {
     Q_OBJECT
   public:
     WTrackText(const char* group, UserSettingsPointer pConfig, QWidget *pParent);
-    ~WTrackText() override;
 
   signals:
     void trackDropped(QString fileName, QString group);

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -48,8 +48,6 @@ WVuMeter::WVuMeter(QWidget* parent)
     m_timer.start();
 }
 
-WVuMeter::~WVuMeter() = default;
-
 void WVuMeter::setup(QDomNode node, const SkinContext& context) {
     // Set pixmaps
     bool bHorizontal = context.hasNode(node, "Horizontal") &&

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -23,8 +23,8 @@
 #include <QtDebug>
 #include <QPixmap>
 
-#include "widget/wpixmapstore.h"
 #include "util/timer.h"
+#include "widget/wpixmapstore.h"
 #include "util/math.h"
 
 #define DEFAULT_FALLTIME 20
@@ -48,8 +48,7 @@ WVuMeter::WVuMeter(QWidget* parent)
     m_timer.start();
 }
 
-WVuMeter::~WVuMeter() {
-}
+WVuMeter::~WVuMeter() = default;
 
 void WVuMeter::setup(QDomNode node, const SkinContext& context) {
     // Set pixmaps
@@ -72,20 +71,24 @@ void WVuMeter::setup(QDomNode node, const SkinContext& context) {
                context.selectScaleMode(vuNode, Paintable::FIXED));
 
     m_iPeakHoldSize = context.selectInt(node, "PeakHoldSize");
-    if (m_iPeakHoldSize < 0 || m_iPeakHoldSize > 100)
+    if (m_iPeakHoldSize < 0 || m_iPeakHoldSize > 100) {
         m_iPeakHoldSize = DEFAULT_HOLDSIZE;
+    }
 
     m_iPeakFallStep = context.selectInt(node, "PeakFallStep");
-    if (m_iPeakFallStep < 1 || m_iPeakFallStep > 1000)
+    if (m_iPeakFallStep < 1 || m_iPeakFallStep > 1000) {
         m_iPeakFallStep = DEFAULT_FALLSTEP;
+    }
 
     m_iPeakHoldTime = context.selectInt(node, "PeakHoldTime");
-    if (m_iPeakHoldTime < 1 || m_iPeakHoldTime > 3000)
+    if (m_iPeakHoldTime < 1 || m_iPeakHoldTime > 3000) {
         m_iPeakHoldTime = DEFAULT_HOLDTIME;
+    }
 
     m_iPeakFallTime = context.selectInt(node, "PeakFallTime");
-    if (m_iPeakFallTime < 1 || m_iPeakFallTime > 1000)
+    if (m_iPeakFallTime < 1 || m_iPeakFallTime > 1000) {
         m_iPeakFallTime = DEFAULT_FALLTIME;
+    }
 }
 
 void WVuMeter::setPixmapBackground(PixmapSource source, Paintable::DrawMode mode) {
@@ -159,7 +162,7 @@ void WVuMeter::maybeUpdate() {
     }
 }
 
-void WVuMeter::paintEvent(QPaintEvent *) {
+void WVuMeter::paintEvent(QPaintEvent * /*unused*/) {
     ScopedTimer t("WVuMeter::paintEvent");
 
     QStyleOption option;

--- a/src/widget/wvumeter.h
+++ b/src/widget/wvumeter.h
@@ -32,22 +32,22 @@
 class WVuMeter : public WWidget  {
    Q_OBJECT
   public:
-    WVuMeter(QWidget *parent=0);
-    virtual ~WVuMeter();
+    explicit WVuMeter(QWidget *parent=nullptr);
+    ~WVuMeter() override;
 
     void setup(QDomNode node, const SkinContext& context);
     void setPixmapBackground(PixmapSource source, Paintable::DrawMode mode);
     void setPixmaps(PixmapSource source,
                     bool bHorizontal,
                     Paintable::DrawMode mode);
-    void onConnectedControlChanged(double dParameter, double dValue);
+    void onConnectedControlChanged(double dParameter, double dValue) override;
 
   protected slots:
     void updateState(mixxx::Duration elapsed);
     void maybeUpdate();
 
   private:
-    void paintEvent(QPaintEvent *);
+    void paintEvent(QPaintEvent * /*unused*/) override;
     void setPeak(double parameter);
 
     // Current parameter and peak parameter.

--- a/src/widget/wvumeter.h
+++ b/src/widget/wvumeter.h
@@ -33,7 +33,6 @@ class WVuMeter : public WWidget  {
    Q_OBJECT
   public:
     explicit WVuMeter(QWidget *parent=nullptr);
-    ~WVuMeter() override;
 
     void setup(QDomNode node, const SkinContext& context);
     void setPixmapBackground(PixmapSource source, Paintable::DrawMode mode);

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -23,7 +23,7 @@ WWaveformViewer::WWaveformViewer(const char *group, UserSettingsPointer pConfig,
           m_zoomZoneWidth(20),
           m_bScratching(false),
           m_bBending(false),
-          m_waveformWidget(NULL) {
+          m_waveformWidget(nullptr) {
     setAcceptDrops(true);
 
     m_pZoom = new ControlObjectSlave(group, "waveform_zoom", this);

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -19,18 +19,18 @@ class ControlPotmeter;
 class WWaveformViewer : public WWidget {
     Q_OBJECT
   public:
-    WWaveformViewer(const char *group, UserSettingsPointer pConfig, QWidget *parent=0);
-    virtual ~WWaveformViewer();
+    WWaveformViewer(const char *group, UserSettingsPointer pConfig, QWidget *parent=nullptr);
+    ~WWaveformViewer() override;
 
     const char* getGroup() const { return m_pGroup;}
     void setup(QDomNode node, const SkinContext& context);
 
-    void dragEnterEvent(QDragEnterEvent *event);
-    void dropEvent(QDropEvent *event);
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
 
-    void mousePressEvent(QMouseEvent *);
-    void mouseMoveEvent(QMouseEvent *);
-    void mouseReleaseEvent(QMouseEvent *);
+    void mousePressEvent(QMouseEvent * /*unused*/) override;
+    void mouseMoveEvent(QMouseEvent * /*unused*/) override;
+    void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
 
 signals:
     void trackDropped(QString filename, QString group);
@@ -40,13 +40,13 @@ public slots:
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
 protected:
-    virtual void resizeEvent(QResizeEvent *event);
-    virtual void wheelEvent(QWheelEvent *event);
+    void resizeEvent(QResizeEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
 
 private slots:
     void onZoomChange(double zoom);
     void slotWidgetDead() {
-        m_waveformWidget = NULL;
+        m_waveformWidget = nullptr;
     }
 
 private:

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -49,7 +49,7 @@ bool WWidget::event(QEvent* e) {
         case QEvent::TouchUpdate:
         case QEvent::TouchEnd:
         {
-            QTouchEvent* touchEvent = static_cast<QTouchEvent*>(e);
+            QTouchEvent* touchEvent = dynamic_cast<QTouchEvent*>(e);
             if (touchEvent->deviceType() !=  QTouchEvent::TouchScreen) {
                 break;
             }

--- a/src/widget/wwidget.h
+++ b/src/widget/wwidget.h
@@ -40,14 +40,14 @@ class ControlObjectSlave;
 class WWidget : public QWidget, public WBaseWidget {
    Q_OBJECT
   public:
-    WWidget(QWidget *parent=0, Qt::WindowFlags flags=0);
-    virtual ~WWidget();
+    explicit WWidget(QWidget *parent=nullptr, Qt::WindowFlags flags=nullptr);
+    ~WWidget() override;
 
     Q_PROPERTY(double value READ getControlParameterDisplay);
 
   protected:
     bool touchIsRightButton();
-    bool event(QEvent* e);
+    bool event(QEvent* e) override;
 
     enum Qt::MouseButton m_activeTouchButton;
 

--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -17,8 +17,6 @@ WWidgetGroup::WWidgetGroup(QWidget* pParent)
     setObjectName("WidgetGroup");
 }
 
-WWidgetGroup::~WWidgetGroup() = default;
-
 int WWidgetGroup::layoutSpacing() const {
     QLayout* pLayout = layout();
     return pLayout ? pLayout->spacing() : 0;

--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -96,7 +96,7 @@ void WWidgetGroup::setup(QDomNode node, const SkinContext& context) {
         } else if (layout == "horizontal") {
             pLayout = new QHBoxLayout();
         } else if (layout == "stacked") {
-            auto  pStackedLayout = new QStackedLayout();
+            auto pStackedLayout = new QStackedLayout();
             pStackedLayout->setStackingMode(QStackedLayout::StackAll);
             pLayout = pStackedLayout;
         }

--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -7,18 +7,17 @@
 
 #include "skin/skincontext.h"
 #include "widget/wwidget.h"
-#include "widget/wpixmapstore.h"
 #include "util/debug.h"
+#include "widget/wpixmapstore.h"
 
 WWidgetGroup::WWidgetGroup(QWidget* pParent)
         : QFrame(pParent),
           WBaseWidget(this),
-          m_pPixmapBack(NULL) {
+          m_pPixmapBack(nullptr) {
     setObjectName("WidgetGroup");
 }
 
-WWidgetGroup::~WWidgetGroup() {
-}
+WWidgetGroup::~WWidgetGroup() = default;
 
 int WWidgetGroup::layoutSpacing() const {
     QLayout* pLayout = layout();
@@ -89,7 +88,7 @@ void WWidgetGroup::setup(QDomNode node, const SkinContext& context) {
                             context.selectScaleMode(backPathNode, Paintable::TILE));
     }
 
-    QLayout* pLayout = NULL;
+    QLayout* pLayout = nullptr;
     if (context.hasNode(node, "Layout")) {
         QString layout = context.selectString(node, "Layout");
         if (layout == "vertical") {
@@ -97,13 +96,13 @@ void WWidgetGroup::setup(QDomNode node, const SkinContext& context) {
         } else if (layout == "horizontal") {
             pLayout = new QHBoxLayout();
         } else if (layout == "stacked") {
-            QStackedLayout* pStackedLayout = new QStackedLayout();
+            auto  pStackedLayout = new QStackedLayout();
             pStackedLayout->setStackingMode(QStackedLayout::StackAll);
             pLayout = pStackedLayout;
         }
 
         // Set common layout parameters.
-        if (pLayout != NULL) {
+        if (pLayout != nullptr) {
             pLayout->setSpacing(0);
             pLayout->setContentsMargins(0, 0, 0, 0);
             pLayout->setAlignment(Qt::AlignCenter);

--- a/src/widget/wwidgetgroup.h
+++ b/src/widget/wwidgetgroup.h
@@ -18,8 +18,8 @@ class SkinContext;
 class WWidgetGroup : public QFrame, public WBaseWidget {
     Q_OBJECT
   public:
-    WWidgetGroup(QWidget* pParent=NULL);
-    virtual ~WWidgetGroup();
+    explicit WWidgetGroup(QWidget* pParent=nullptr);
+    ~WWidgetGroup() override;
 
     // QLayouts are not stylable using Qt style sheets. These properties let us
     // style the layout properties using the QProperty support in Qt style
@@ -39,7 +39,7 @@ class WWidgetGroup : public QFrame, public WBaseWidget {
     int layoutSpacing() const;
     void setLayoutSpacing(int spacing);
     QRect layoutContentsMargins() const;
-    void setLayoutContentsMargins(QRect margins);
+    void setLayoutContentsMargins(QRect rectMargins);
     Qt::Alignment layoutAlignment() const;
     void setLayoutAlignment(int alignment);
 
@@ -48,10 +48,10 @@ class WWidgetGroup : public QFrame, public WBaseWidget {
     void addWidget(QWidget* pChild);
 
   protected:
-    virtual void paintEvent(QPaintEvent* pe);
-    virtual void resizeEvent(QResizeEvent* re);
-    bool event(QEvent* pEvent);
-    void fillDebugTooltip(QStringList* debug);
+    void paintEvent(QPaintEvent* pe) override;
+    void resizeEvent(QResizeEvent* re) override;
+    bool event(QEvent* pEvent) override;
+    void fillDebugTooltip(QStringList* debug) override;
 
   private:
     // Associated background pixmap

--- a/src/widget/wwidgetgroup.h
+++ b/src/widget/wwidgetgroup.h
@@ -19,7 +19,6 @@ class WWidgetGroup : public QFrame, public WBaseWidget {
     Q_OBJECT
   public:
     explicit WWidgetGroup(QWidget* pParent=nullptr);
-    ~WWidgetGroup() override;
 
     // QLayouts are not stylable using Qt style sheets. These properties let us
     // style the layout properties using the QProperty support in Qt style

--- a/src/widget/wwidgetstack.cpp
+++ b/src/widget/wwidgetstack.cpp
@@ -11,8 +11,7 @@ WidgetStackControlListener::WidgetStackControlListener(QObject* pParent,
     m_control.connectValueChanged(SLOT(slotValueChanged(double)));
 }
 
-WidgetStackControlListener::~WidgetStackControlListener() {
-}
+WidgetStackControlListener::~WidgetStackControlListener() = default;
 
 void WidgetStackControlListener::slotValueChanged(double v) {
     if (v > 0.0) {
@@ -62,8 +61,7 @@ void WWidgetStack::Init() {
             this, SLOT(onCurrentPageChanged(int)));
 }
 
-WWidgetStack::~WWidgetStack() {
-}
+WWidgetStack::~WWidgetStack() = default;
 
 QSize WWidgetStack::sizeHint() const {
     QWidget* pWidget = currentWidget();
@@ -100,7 +98,7 @@ void WWidgetStack::hideIndex(int index) {
     }
 }
 
-void WWidgetStack::showEvent(QShowEvent*) {
+void WWidgetStack::showEvent(QShowEvent* /*unused*/) {
     int index = static_cast<int>(m_currentPageControl.get());
 
     // Set the page triggers to match the current index.
@@ -153,7 +151,7 @@ void WWidgetStack::addWidgetWithControl(QWidget* pWidget, ControlObject* pContro
                                         int on_hide_select) {
     int index = addWidget(pWidget);
     if (pControl) {
-        WidgetStackControlListener* pListener = new WidgetStackControlListener(
+        auto  pListener = new WidgetStackControlListener(
             this, pControl, index);
         m_showMapper.setMapping(pListener, index);
         m_hideMapper.setMapping(pListener, index);

--- a/src/widget/wwidgetstack.cpp
+++ b/src/widget/wwidgetstack.cpp
@@ -11,8 +11,6 @@ WidgetStackControlListener::WidgetStackControlListener(QObject* pParent,
     m_control.connectValueChanged(SLOT(slotValueChanged(double)));
 }
 
-WidgetStackControlListener::~WidgetStackControlListener() = default;
-
 void WidgetStackControlListener::slotValueChanged(double v) {
     if (v > 0.0) {
         emit(switchToWidget());
@@ -60,8 +58,6 @@ void WWidgetStack::Init() {
     connect(this, SIGNAL(currentChanged(int)),
             this, SLOT(onCurrentPageChanged(int)));
 }
-
-WWidgetStack::~WWidgetStack() = default;
 
 QSize WWidgetStack::sizeHint() const {
     QWidget* pWidget = currentWidget();

--- a/src/widget/wwidgetstack.cpp
+++ b/src/widget/wwidgetstack.cpp
@@ -151,8 +151,7 @@ void WWidgetStack::addWidgetWithControl(QWidget* pWidget, ControlObject* pContro
                                         int on_hide_select) {
     int index = addWidget(pWidget);
     if (pControl) {
-        auto  pListener = new WidgetStackControlListener(
-            this, pControl, index);
+        auto pListener = new WidgetStackControlListener(this, pControl, index);
         m_showMapper.setMapping(pListener, index);
         m_hideMapper.setMapping(pListener, index);
         m_listeners[index] = pListener;

--- a/src/widget/wwidgetstack.h
+++ b/src/widget/wwidgetstack.h
@@ -16,7 +16,7 @@ class WidgetStackControlListener : public QObject {
   public:
     WidgetStackControlListener(QObject* pParent, ControlObject* pControl,
                                int index);
-    ~WidgetStackControlListener() override;
+
     void setControl(double val) {
         m_control.set(val);
     }
@@ -43,7 +43,6 @@ class WWidgetStack : public QStackedWidget, public WBaseWidget {
                  ControlObject* pNextControl,
                  ControlObject* pPrevControl,
                  ControlObject* pCurrentPageControl);
-    ~WWidgetStack() override;
 
     // We don't want to change pages until all the pages have been added,
     // so we override Init and hook up the connection there.

--- a/src/widget/wwidgetstack.h
+++ b/src/widget/wwidgetstack.h
@@ -16,7 +16,7 @@ class WidgetStackControlListener : public QObject {
   public:
     WidgetStackControlListener(QObject* pParent, ControlObject* pControl,
                                int index);
-    virtual ~WidgetStackControlListener();
+    ~WidgetStackControlListener() override;
     void setControl(double val) {
         m_control.set(val);
     }
@@ -43,18 +43,18 @@ class WWidgetStack : public QStackedWidget, public WBaseWidget {
                  ControlObject* pNextControl,
                  ControlObject* pPrevControl,
                  ControlObject* pCurrentPageControl);
-    virtual ~WWidgetStack();
+    ~WWidgetStack() override;
 
     // We don't want to change pages until all the pages have been added,
     // so we override Init and hook up the connection there.
-    virtual void Init();
+    void Init() override;
 
     // QStackedWidget sizeHint and minimumSizeHint are the largest of all the
     // widgets in the stack. This is presumably to prevent UI resizes when the
     // stack changes. We explicitly want the UI to change when the stack changes
     // (potentially grow or shrink).
-    QSize sizeHint() const;
-    QSize minimumSizeHint() const;
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
 
     // Adds a page to the stack.  If this page is hidden, the the page with the
     // 0-based index given by on_hide_select will be shown.  If this value is
@@ -63,7 +63,7 @@ class WWidgetStack : public QStackedWidget, public WBaseWidget {
                               int on_hide_select);
 
   protected:
-    bool event(QEvent* pEvent);
+    bool event(QEvent* pEvent) override;
 
   private slots:
     void onNextControlChanged(double v);
@@ -74,7 +74,7 @@ class WWidgetStack : public QStackedWidget, public WBaseWidget {
     void onCurrentPageChanged(int);
     void showIndex(int index);
     void hideIndex(int index);
-    void showEvent(QShowEvent* event);
+    void showEvent(QShowEvent* event) override;
 
   private:
     QSignalMapper m_showMapper;


### PR DESCRIPTION
Using LLVM 3.8.0:

$ clang-tidy --fix --checks="*,-llvm-header-guard,-readability-implicit-bool-cast,-readability-else-after-return,-google-readability-todo" $(git ls src/widget | xargs) -- (flags to compile)
