### PR TITLE
VCI-100MKII: improve fx super/mix knob and more

### DIFF
--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -3,7 +3,7 @@
   <info>
     <name>Vestax VCI-100MKII</name>
     <author>Takeshi Soejima</author>
-    <description>2016-9-2</description>
+    <description>2016-10-1</description>
     <wiki>http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii</wiki>
   </info>
   <controller id="VCI-100MKII">

--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -3,7 +3,7 @@
   <info>
     <name>Vestax VCI-100MKII</name>
     <author>Takeshi Soejima</author>
-    <description>2016-10-1</description>
+    <description>2016-10-9</description>
     <wiki>http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii</wiki>
   </info>
   <controller id="VCI-100MKII">

--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -3,7 +3,7 @@
   <info>
     <name>Vestax VCI-100MKII</name>
     <author>Takeshi Soejima</author>
-    <description>2016-11-3</description>
+    <description>2016-11-4</description>
     <wiki>http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii</wiki>
   </info>
   <controller id="VCI-100MKII">

--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -3,7 +3,7 @@
   <info>
     <name>Vestax VCI-100MKII</name>
     <author>Takeshi Soejima</author>
-    <description>2016-11-5</description>
+    <description>2016-12-1</description>
     <wiki>http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii</wiki>
   </info>
   <controller id="VCI-100MKII">

--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -3,7 +3,7 @@
   <info>
     <name>Vestax VCI-100MKII</name>
     <author>Takeshi Soejima</author>
-    <description>2016-10-9</description>
+    <description>2016-11-1</description>
     <wiki>http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii</wiki>
   </info>
   <controller id="VCI-100MKII">
@@ -721,51 +721,75 @@
       </control>
       <control>
         <group>[EffectRack1_EffectUnit1]</group>
-        <key>prev_chain</key>
+        <key>VCI102.prev_chain</key>
         <status>0x90</status>
         <midino>0x20</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit2]</group>
-        <key>prev_chain</key>
+        <key>VCI102.prev_chain</key>
         <status>0x91</status>
         <midino>0x20</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit3]</group>
-        <key>prev_chain</key>
+        <key>VCI102.prev_chain</key>
         <status>0x92</status>
         <midino>0x20</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit4]</group>
-        <key>prev_chain</key>
+        <key>VCI102.prev_chain</key>
         <status>0x93</status>
         <midino>0x20</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit1]</group>
-        <key>next_chain</key>
+        <key>VCI102.next_chain</key>
         <status>0x90</status>
         <midino>0x21</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit2]</group>
-        <key>next_chain</key>
+        <key>VCI102.next_chain</key>
         <status>0x91</status>
         <midino>0x21</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit3]</group>
-        <key>next_chain</key>
+        <key>VCI102.next_chain</key>
         <status>0x92</status>
         <midino>0x21</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[EffectRack1_EffectUnit4]</group>
-        <key>next_chain</key>
+        <key>VCI102.next_chain</key>
         <status>0x93</status>
         <midino>0x21</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[Channel1]</group>

--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -3,7 +3,7 @@
   <info>
     <name>Vestax VCI-100MKII</name>
     <author>Takeshi Soejima</author>
-    <description>2016-11-1</description>
+    <description>2016-11-3</description>
     <wiki>http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii</wiki>
   </info>
   <controller id="VCI-100MKII">

--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -3,7 +3,7 @@
   <info>
     <name>Vestax VCI-100MKII</name>
     <author>Takeshi Soejima</author>
-    <description>2016-4-1</description>
+    <description>2016-5-1</description>
     <wiki>http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii</wiki>
   </info>
   <controller id="VCI-100MKII">

--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -3,7 +3,7 @@
   <info>
     <name>Vestax VCI-100MKII</name>
     <author>Takeshi Soejima</author>
-    <description>2016-5-1</description>
+    <description>2016-9-2</description>
     <wiki>http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii</wiki>
   </info>
   <controller id="VCI-100MKII">
@@ -481,62 +481,74 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>pregain</key>
+        <key>VCI102.pitch</key>
         <status>0xB0</status>
         <midino>0x14</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>pregain</key>
+        <key>VCI102.pitch</key>
         <status>0xB1</status>
         <midino>0x12</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>pregain</key>
+        <key>VCI102.pitch</key>
         <status>0xB2</status>
         <midino>0x14</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>pregain</key>
+        <key>VCI102.pitch</key>
         <status>0xB3</status>
         <midino>0x12</midino>
+        <options>
+          <script-binding/>
+        </options>
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>VCI102.pitch</key>
+        <key>pregain</key>
         <status>0xB0</status>
         <midino>0x15</midino>
         <options>
-          <script-binding/>
+          <soft-takeover/>
         </options>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>VCI102.pitch</key>
+        <key>pregain</key>
         <status>0xB1</status>
         <midino>0x15</midino>
         <options>
-          <script-binding/>
+          <soft-takeover/>
         </options>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>VCI102.pitch</key>
+        <key>pregain</key>
         <status>0xB2</status>
         <midino>0x15</midino>
         <options>
-          <script-binding/>
+          <soft-takeover/>
         </options>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>VCI102.pitch</key>
+        <key>pregain</key>
         <status>0xB3</status>
         <midino>0x15</midino>
         <options>
-          <script-binding/>
+          <soft-takeover/>
         </options>
       </control>
       <control>

--- a/res/controllers/Vestax VCI-100MKII.midi.xml
+++ b/res/controllers/Vestax VCI-100MKII.midi.xml
@@ -3,7 +3,7 @@
   <info>
     <name>Vestax VCI-100MKII</name>
     <author>Takeshi Soejima</author>
-    <description>2016-11-4</description>
+    <description>2016-11-5</description>
     <wiki>http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii</wiki>
   </info>
   <controller id="VCI-100MKII">
@@ -913,25 +913,25 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>beats_translate_earlier</key>
+        <key>beats_translate_match_alignment</key>
         <status>0x90</status>
         <midino>0x4A</midino>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>beats_translate_earlier</key>
+        <key>beats_translate_match_alignment</key>
         <status>0x91</status>
         <midino>0x4A</midino>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>beats_translate_earlier</key>
+        <key>beats_translate_match_alignment</key>
         <status>0x92</status>
         <midino>0x4A</midino>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>beats_translate_earlier</key>
+        <key>beats_translate_match_alignment</key>
         <status>0x93</status>
         <midino>0x4A</midino>
       </control>
@@ -961,25 +961,25 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>beats_translate_later</key>
+        <key>sync_key</key>
         <status>0x90</status>
         <midino>0x4B</midino>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>beats_translate_later</key>
+        <key>sync_key</key>
         <status>0x91</status>
         <midino>0x4B</midino>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>beats_translate_later</key>
+        <key>sync_key</key>
         <status>0x92</status>
         <midino>0x4B</midino>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>beats_translate_later</key>
+        <key>sync_key</key>
         <status>0x93</status>
         <midino>0x4B</midino>
       </control>

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -1,6 +1,6 @@
 // name: Vestax VCI-100MKII
 // author: Takeshi Soejima
-// description: 2016-11-4
+// description: 2016-11-5
 // wiki: <http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii>
 
 // JSHint Configuration

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -236,28 +236,30 @@ VCI102.loop_double = function(ch, midino, value, status, group) {
 };
 
 VCI102.move = function(ch, group, dir) {
-    if (dir) {
-        if (engine.getValue(group, "loop_enabled")) {
-            // move the loop by the current length
-            engine.setValue(
-                group, "loop_move", dir * (
-                    engine.getValue(group, "loop_end_position")
-                        - engine.getValue(group, "loop_start_position"))
-                    / engine.getValue(group, "track_samplerate")
-                    * engine.getValue(group, "file_bpm") / 120);
-        } else {
-            // jump by the default length
-            engine.setValue(group, "beatjump", dir * VCI102.loopLength[ch]);
-        }
+    if (engine.getValue(group, "loop_enabled")) {
+        // move the loop by the current length
+        engine.setValue(
+            group, "loop_move", dir * (
+                engine.getValue(group, "loop_end_position")
+                    - engine.getValue(group, "loop_start_position"))
+                / engine.getValue(group, "track_samplerate")
+                * engine.getValue(group, "file_bpm") / 120);
+    } else {
+        // jump by the default length
+        engine.setValue(group, "beatjump", dir * VCI102.loopLength[ch]);
     }
 };
 
 VCI102.move_backward = function(ch, midino, value, status, group) {
-    VCI102.move(ch, group, value / -127);
+    if (value) {
+        VCI102.move(ch, group, -1);
+    }
 };
 
 VCI102.move_forward = function(ch, midino, value, status, group) {
-    VCI102.move(ch, group, value / 127);
+    if (value) {
+        VCI102.move(ch, group, 1);
+    }
 };
 
 VCI102.Deck = ["[Channel1]", "[Channel2]"];

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -1,6 +1,6 @@
 // name: Vestax VCI-100MKII
 // author: Takeshi Soejima
-// description: 2016-10-1
+// description: 2016-10-9
 // wiki: <http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii>
 
 // JSHint Configuration
@@ -153,13 +153,11 @@ VCI102.rateQuantizedLSB = function(ch, midino, value, status, group) {
 };
 
 VCI102.pitch = function(ch, midino, value, status, group) {
+    value = (value - 64) / 21;  // up and down to 3 semitones
     if (engine.getValue(group, "keylock")) {
-        // absolute discrete change up and down to 6 semitones
-        engine.setValue(group, "pitch", Math.round(value * 3 / 32) - 6);
-    } else {
-        // relative continuous change up and down to about whole tone
-        engine.setValue(group, "pitch_adjust", (value - 64) / 32);
+        value = Math.round(value);  // discrete change on keylock
     }
+    engine.setValue(group, "pitch_adjust", value);
 };
 
 ["parameter1", "parameter2", "parameter3"].forEach(function(key) {
@@ -360,7 +358,6 @@ VCI102.init = function(id, debug) {
             }
         }
         engine.softTakeover(VCI102.deck[i], "rate", true);
-        engine.softTakeover(VCI102.deck[i], "pitch", true);
         engine.softTakeover(VCI102.deck[i], "pitch_adjust", true);
         engine.softTakeover(VCI102.fx[i], "super1", true);
         engine.softTakeover(VCI102.fx[i], "mix", true);

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -1,6 +1,6 @@
 // name: Vestax VCI-100MKII
 // author: Takeshi Soejima
-// description: 2016-11-3
+// description: 2016-11-4
 // wiki: <http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii>
 
 // JSHint Configuration
@@ -105,7 +105,7 @@ VCI102.jog = function(ch, midino, value, status, group) {
     if (engine.isScratching(deck)) {
         engine.scratchTick(deck, value);
     } else if (!engine.getValue(group, "slip_enabled")) {
-        engine.setValue(group, "jog", value * value * value / 512);
+        engine.setValue(group, "jog", value * value * value / 1024);
     }
 };
 

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -1,6 +1,6 @@
 // name: Vestax VCI-100MKII
 // author: Takeshi Soejima
-// description: 2016-10-9
+// description: 2016-11-1
 // wiki: <http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii>
 
 // JSHint Configuration
@@ -160,8 +160,16 @@ VCI102.pitch = function(ch, midino, value, status, group) {
     engine.setValue(group, "pitch_adjust", value);
 };
 
+VCI102.fxKnob = [
+    "[EffectRack1_EffectUnit1_Effect1]",
+    "[EffectRack1_EffectUnit2_Effect1]",
+    "[EffectRack1_EffectUnit3_Effect1]",
+    "[EffectRack1_EffectUnit4_Effect1]"
+];
+
 ["parameter1", "parameter2", "parameter3"].forEach(function(key) {
     VCI102[key] = function(ch, midino, value, status, group) {
+        group = VCI102.fxKnob[ch];
         if (VCI102.shift[ch % 2]) {
             // link to super1, inverse variants -> none -> direct variants
             if (engine.getValue(group, key + "_loaded")) {
@@ -188,6 +196,32 @@ VCI102.super1 = function(ch, midino, value, status, group) {
     }
     VCI102.superKnobValue[ch] = value < 127 ? value / 128 : 1;
     engine.setValue(group, key, VCI102.superKnobValue[ch]);
+};
+
+VCI102.prev_chain = function(ch, midino, value, status, group) {
+    if (VCI102.shift[(ch + 1) % 2]) {
+        // select Effect1 of the EffectUnit if shift of the other Deck
+        if (value) {
+            VCI102.fxKnob[ch] = group.slice(0, -1) + "_Effect1]";
+        }
+    } else if (VCI102.fxKnob[ch].slice(-2, -1) > 1) {
+        engine.setValue(VCI102.fxKnob[ch], "prev_effect", value > 0);
+    } else {
+        engine.setValue(group, "prev_chain", value > 0);
+    }
+};
+
+VCI102.next_chain = function(ch, midino, value, status, group) {
+    if (VCI102.shift[(ch + 1) % 2]) {
+        // select Effect2 of the EffectUnit if shift of the other Deck
+        if (value) {
+            VCI102.fxKnob[ch] = group.slice(0, -1) + "_Effect2]";
+        }
+    } else if (VCI102.fxKnob[ch].slice(-2, -1) > 1) {
+        engine.setValue(VCI102.fxKnob[ch], "next_effect", value > 0);
+    } else {
+        engine.setValue(group, "next_chain", value > 0);
+    }
 };
 
 VCI102.loopLength = [4, 4, 4, 4];

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -1,6 +1,6 @@
 // name: Vestax VCI-100MKII
 // author: Takeshi Soejima
-// description: 2016-5-1
+// description: 2016-9-2
 // wiki: <http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii>
 
 // JSHint Configuration
@@ -166,7 +166,7 @@ VCI102.pitch = function(ch, midino, value, status, group) {
                 engine.setValue(group, key + "_link_inverse", value < 0);
             }
         } else {
-            engine.setParameter(group, key, value / 127);
+            engine.setParameter(group, key, value == 127 ? 1 : value / 128);
         }
     };
 });
@@ -182,7 +182,7 @@ VCI102.super1 = function(ch, midino, value, status, group) {
         engine.setValue(group, key, VCI102.superKnobValue[ch]);
         VCI102.superKnobKey[ch] = key;
     }
-    VCI102.superKnobValue[ch] = value / 127;
+    VCI102.superKnobValue[ch] = value == 127 ? 1 : value / 128;
     engine.setValue(group, key, VCI102.superKnobValue[ch]);
 };
 
@@ -213,7 +213,7 @@ VCI102.loop = function(ch, midino, value, status, group) {
 
 VCI102.reloop = function(ch, midino, value, status, group) {
     if (engine.getValue(group, "loop_enabled")) {
-        engine.setValue(group, "loop_out", value / 127);
+        engine.setValue(group, "loop_out", value > 0);
     } else {
         engine.setValue(group, "reloop_exit", 1);
     }
@@ -221,7 +221,7 @@ VCI102.reloop = function(ch, midino, value, status, group) {
 
 VCI102.loop_halve = function(ch, midino, value, status, group) {
     if (engine.getValue(group, "loop_enabled")) {
-        engine.setValue(group, "loop_halve", value / 127);
+        engine.setValue(group, "loop_halve", value > 0);
     } else if (value) {
         VCI102.setLoopLength(ch, status, VCI102.loopLength[ch] / 2);
     }
@@ -229,7 +229,7 @@ VCI102.loop_halve = function(ch, midino, value, status, group) {
 
 VCI102.loop_double = function(ch, midino, value, status, group) {
     if (engine.getValue(group, "loop_enabled")) {
-        engine.setValue(group, "loop_double", value / 127);
+        engine.setValue(group, "loop_double", value > 0);
     } else if (value) {
         VCI102.setLoopLength(ch, status, VCI102.loopLength[ch] * 2);
     }
@@ -316,7 +316,7 @@ VCI102.init = function(id, debug) {
 
     function makeButton(key) {
         VCI102[key] = function(ch, midino, value, status, group) {
-            engine.setValue(VCI102.Deck[ch % 2], key, value / 127);
+            engine.setValue(VCI102.Deck[ch % 2], key, value > 0);
         };
     }
 

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -171,14 +171,18 @@ VCI102.pitch = function(ch, midino, value, status, group) {
     };
 });
 
+VCI102.superKnobKey = ["super1", "super1", "super1", "super1"];
+VCI102.superKnobValue = [0, 0, 0, 0];
+
 VCI102.super1 = function(ch, midino, value, status, group) {
-    if (VCI102.shift[ch % 2]) {
-        engine.setValue(group, "mix", value / 127);
-        engine.softTakeoverIgnoreNextValue(group, "super1");
-    } else {
-        engine.setValue(group, "super1", value / 127);
-        engine.softTakeoverIgnoreNextValue(group, "mix");
+    var key = VCI102.shift[ch % 2] ? "mix" : "super1";
+    if (VCI102.superKnobKey[ch] != key) {
+        engine.softTakeoverIgnoreNextValue(group, key);
+        // set previous value again on key change to avoid slip
+        engine.setValue(group, key, VCI102.superKnobValue[ch]);
+        VCI102.superKnobKey[ch] = key;
     }
+    engine.setValue(group, key, VCI102.superKnobValue[ch] = value / 127);
 };
 
 VCI102.loopLength = [4, 4, 4, 4];

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -1,6 +1,6 @@
 // name: Vestax VCI-100MKII
 // author: Takeshi Soejima
-// description: 2016-11-5
+// description: 2016-12-1
 // wiki: <http://www.mixxx.org/wiki/doku.php/vestax_vci-100mkii>
 
 // JSHint Configuration
@@ -12,21 +12,20 @@ var VCI102 = {};
 VCI102.deck = ["[Channel1]", "[Channel2]", "[Channel3]", "[Channel4]"];
 VCI102.fx12 = ["[EffectRack1_EffectUnit1]", "[EffectRack1_EffectUnit2]"];
 VCI102.fx34 = ["[EffectRack1_EffectUnit3]", "[EffectRack1_EffectUnit4]"];
-
 VCI102.fxButton = [VCI102.fx12, VCI102.fx12];
 VCI102.shift = [0, 0];
 
 VCI102.setShift = function(ch, midino, value, status, group) {
-    var i, j, enabled;
     ch = VCI102.deck.indexOf(group);  // override channel by group
-    VCI102.fxButton[ch] = value ? VCI102.fx34 : VCI102.fx12;
-    for (i = ch; i < 4; i += 2) {
-        enabled = "group_" + VCI102.deck[i] + "_enable";
-        for (j = 0; j < 2; j++) {
-            engine.trigger(VCI102.fxButton[ch][j], enabled);
-        }
-    }
     VCI102.shift[ch] = value;
+    // if shift then show the state of fx3/4 else fx1/2
+    VCI102.fxButton[ch] = value ? VCI102.fx34 : VCI102.fx12;
+    [VCI102.deck[ch], VCI102.deck[ch + 2]].forEach(function(deck) {
+        var enable = "group_" + deck + "_enable";
+        VCI102.fxButton[ch].forEach(function(fx) {
+            engine.trigger(fx, enable);
+        });
+    });
 };
 
 VCI102.selectTimer = 0;
@@ -202,7 +201,7 @@ VCI102.super1 = function(ch, midino, value, status, group) {
 };
 
 VCI102.prev_chain = function(ch, midino, value, status, group) {
-    if (VCI102.shift[(ch + 1) % 2]) {
+    if (VCI102.shift[1 - ch % 2]) {
         // select Effect1 of the EffectUnit if shift of the other Deck
         if (value) {
             VCI102.fxKnob[ch] = group.slice(0, -1) + "_Effect1]";
@@ -215,7 +214,7 @@ VCI102.prev_chain = function(ch, midino, value, status, group) {
 };
 
 VCI102.next_chain = function(ch, midino, value, status, group) {
-    if (VCI102.shift[(ch + 1) % 2]) {
+    if (VCI102.shift[1 - ch % 2]) {
         // select Effect2 of the EffectUnit if shift of the other Deck
         if (value) {
             VCI102.fxKnob[ch] = group.slice(0, -1) + "_Effect2]";
@@ -304,23 +303,27 @@ VCI102.move_forward = function(ch, midino, value, status, group) {
 };
 
 VCI102.Deck = ["[Channel1]", "[Channel2]"];
+VCI102.hc = [
+    "hotcue_1_enabled",
+    "hotcue_2_enabled",
+    "hotcue_3_enabled",
+    "hotcue_4_enabled"
+];
 
 VCI102.setDeck = function(ch, midino, value, status, group) {
-    var i;
     if (value) {
         VCI102.Deck[ch] = group;
-        for (i = 1; i <= 4; i++) {
-            engine.trigger(group, "hotcue_" + i + "_enabled");
-        }
+        VCI102.hc.forEach(function(hc) {
+            engine.trigger(group, hc);
+        });
     }
 };
 
 VCI102.solo = function(ch, midino, value, status, group) {
-    var i;
     if (value) {
-        for (i = 0; i < 4; i++) {
-            engine.setValue(VCI102.deck[i], "pfl", i == ch);
-        }
+        VCI102.deck.forEach(function(deck, i) {
+            engine.setValue(deck, "pfl", i == ch);
+        });
     }
 };
 
@@ -334,79 +337,69 @@ VCI102.shutdown = function() {
 };
 
 VCI102.init = function(id, debug) {
-    var i, j, k, activate, enabled, led;
-    var LED = [
+    var LEDfx = [0x3A, 0x38];
+    var LEDhc = [
         [0x2C, 0x25, 0x27, 0x28],
         [0x28, 0x25, 0x27, 0x2C]
     ];
-    var LEDfx = [0x3A, 0x38];
 
     function headMix(value, group, key) {
-        var i;
         if (value) {
             if (engine.getValue("[Master]", "headMix") == 1) {
                 engine.setValue("[Master]", "headMix", -1);
             }
         } else if (engine.getValue("[Master]", "headMix") == -1) {
-            for (i = 0; i < 4; i++) {
-                if (engine.getValue(VCI102.deck[i], "pfl")) return;
+            if (VCI102.deck.every(function(deck) {
+                return !engine.getValue(deck, "pfl");
+            })) {
+                engine.setValue("[Master]", "headMix", 1);
             }
-            engine.setValue("[Master]", "headMix", 1);
         }
     }
 
-    function makeButton(key) {
-        VCI102[key] = function(ch, midino, value, status, group) {
-            engine.setValue(VCI102.Deck[ch % 2], key, value > 0);
+    function makeLEDfx(ch, i) {
+        return function(value, group, key) {
+            if (group == VCI102.fxButton[ch % 2][i]) {
+                midi.sendShortMsg(0x90 + ch, LEDfx[i], value * 127);
+            }
         };
     }
 
-    function makeLED(ch, midino) {
+    function makeLEDhc(ch, i) {
         return function(value, group, key) {
-            var i;
             if (group == VCI102.Deck[ch]) {
-                value *= 127;
-                for (i = 0x90 + ch; i < 0x94; i += 2) {
-                    midi.sendShortMsg(i, midino, value);
-                }
+                midi.sendShortMsg(0x90 + ch, LEDhc[ch][i], value * 127);
+                midi.sendShortMsg(0x92 + ch, LEDhc[ch][i], value * 127);
             }
         };
     }
 
-    function makeLEDfx(ch, midino, button) {
-        return function(value, group, key) {
-            if (group == VCI102.fxButton[ch % 2][button]) {
-                midi.sendShortMsg(0x90 + ch, midino, value * 127);
-            }
-        };
-    }
-
-    for (i = 0; i < 4; i++) {
-        engine.connectControl(VCI102.deck[i], "loop_enabled", VCI102.slip);
-        engine.connectControl(VCI102.deck[i], "reverse", VCI102.slip);
-        engine.connectControl(VCI102.deck[i], "play", VCI102.slip);
-        engine.connectControl(VCI102.deck[i], "pfl", headMix);
-        enabled = "group_" + VCI102.deck[i] + "_enable";
-        for (j = 0; j < 2; j++) {
-            led = makeLEDfx(i, LEDfx[j], j);
-            for (k = j + 1; k <= 4; k += 2) {
-                engine.connectControl(
-                    "[EffectRack1_EffectUnit" + k + "]", enabled, led);
-            }
-        }
-        engine.softTakeover(VCI102.deck[i], "rate", true);
-        engine.softTakeover(VCI102.deck[i], "pitch_adjust", true);
-    }
-    for (i = 1; i <= 4; i++) {
-        makeButton(activate = "hotcue_" + i + "_activate");
-        makeButton("hotcue_" + i + "_clear");
-        enabled = "hotcue_" + i + "_enabled";
-        for (j = 0; j < 2; j++) {
-            led = makeLED(j, LED[j][i - 1]);
-            for (k = j; k < 4; k += 2) {
-                engine.connectControl(VCI102.deck[k], activate, VCI102.slip);
-                engine.connectControl(VCI102.deck[k], enabled, led);
-            }
-        }
-    }
+    VCI102.deck.forEach(function(deck, i) {
+        var enable = "group_" + deck + "_enable";
+        [makeLEDfx(i, 0), makeLEDfx(i, 1)].forEach(function(led, j) {
+            engine.connectControl(VCI102.fx12[j], enable, led);
+            engine.connectControl(VCI102.fx34[j], enable, led);
+        });
+        ["loop_enabled", "play", "reverse"].forEach(function(key) {
+            engine.connectControl(deck, key, VCI102.slip);
+        });
+        engine.connectControl(deck, "pfl", headMix);
+        engine.softTakeover(deck, "rate", true);
+        engine.softTakeover(deck, "pitch_adjust", true);
+    });
+    // to use fx parameter buttons for hotcue
+    VCI102.hc.forEach(function(hc, i) {
+        var activate = hc.replace("enabled", "activate");
+        [makeLEDhc(0, i), makeLEDhc(1, i)].forEach(function(led, j) {
+            [VCI102.deck[j], VCI102.deck[j + 2]].forEach(function(deck) {
+                engine.connectControl(deck, activate, VCI102.slip);
+                engine.connectControl(deck, hc, led);
+            });
+        });
+        [activate, hc.replace("enabled", "clear")].forEach(function(key) {
+            VCI102[key] = function(ch, midino, value, status, group) {
+                engine.setValue(VCI102.Deck[ch % 2], key, value > 0);
+            };
+        });
+    });
 };

--- a/res/controllers/Vestax-VCI-100MKII-scripts.js
+++ b/res/controllers/Vestax-VCI-100MKII-scripts.js
@@ -182,7 +182,8 @@ VCI102.super1 = function(ch, midino, value, status, group) {
         engine.setValue(group, key, VCI102.superKnobValue[ch]);
         VCI102.superKnobKey[ch] = key;
     }
-    engine.setValue(group, key, VCI102.superKnobValue[ch] = value / 127);
+    VCI102.superKnobValue[ch] = value / 127;
+    engine.setValue(group, key, VCI102.superKnobValue[ch]);
 };
 
 VCI102.loopLength = [4, 4, 4, 4];


### PR DESCRIPTION
Two minor fixes.
- avoid slip of fx super/mix knob (obsolete after the recent commit 10/24)

When using one knob for fx super1 (without shift) and wet/dry mix (with shift) with soft takeover, slips at the edge (max or min position) occur in some cases. For example,
1. super1 is 0.0, mix is 1.0 and the knob is at min.
2. turn the knob to max without shift --> super1 is 1.0, mix is 1.0
3. turn the knob left with shift to diminish mix --> slip! fail to diminish mix, need back and forth again

The slip can be avoided when turning the knob extremely slow, because there is no midi value leap then. But I want to avoid it always, so I set the same value again on key change from super1 to mix (and mix to super1). Other controllers may need the same tweak.
- avoid possible conflicts between scratch and brake

Brake process is stopped when the wheel is released even without shift key.
