### PR TITLE
Restore window geometry from last session instead of centering

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -134,8 +134,6 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
     m_pLaunchImage = m_pSkinLoader->loadLaunchImage(this);
     m_pWidgetParent = (QWidget*)m_pLaunchImage;
     setCentralWidget(m_pWidgetParent);
-    // move the app in the center of the primary screen
-    slotToCenterOfPrimaryScreen();
 
     show();
 #if defined(Q_WS_X11)
@@ -446,6 +444,12 @@ void MixxxMainWindow::finalize() {
     Timer t("MixxxMainWindow::~finalize");
     t.start();
 
+    // Save the current window state (position, maximized, etc)
+    m_pSettingsManager->settings()->set(ConfigKey("[MainWindow]", "geometry"),
+        QString(saveGeometry().toBase64()));
+    m_pSettingsManager->settings()->set(ConfigKey("[MainWindow]", "state"),
+        QString(saveState().toBase64()));
+
     setCentralWidget(NULL);
 
     // TODO(rryan): WMainMenuBar holds references to controls so we need to delete it
@@ -597,6 +601,12 @@ void MixxxMainWindow::initializeWindow() {
     // restore default QMenuBar background
     Pal.setColor(QPalette::Background, MenuBarBackground);
     m_pMenuBar->setPalette(Pal);
+
+    // Restore the current window state (position, maximized, etc)
+    restoreGeometry(QByteArray::fromBase64(m_pSettingsManager->settings()->getValueString(
+        ConfigKey("[MainWindow]", "geometry")).toUtf8()));
+    restoreState(QByteArray::fromBase64(m_pSettingsManager->settings()->getValueString(
+        ConfigKey("[MainWindow]", "state")).toUtf8()));
 
     setWindowIcon(QIcon(":/images/ic_mixxx_window.png"));
     slotUpdateWindowTitle(TrackPointer());
@@ -792,8 +802,7 @@ void MixxxMainWindow::connectMenuBar() {
             m_pMenuBar, SLOT(onNewSkinLoaded()));
 
     // Misc
-    connect(m_pMenuBar, SIGNAL(quit()),
-            this, SLOT(slotFileQuit()));
+    connect(m_pMenuBar, SIGNAL(quit()), this, SLOT(close()));
     connect(m_pMenuBar, SIGNAL(showPreferences()),
             this, SLOT(slotOptionsPreferences()));
     connect(m_pMenuBar, SIGNAL(loadTrackToDeck(int)),
@@ -908,13 +917,6 @@ void MixxxMainWindow::slotFileLoadSongPlayer(int deck) {
     }
 }
 
-void MixxxMainWindow::slotFileQuit() {
-    if (!confirmExit()) {
-        return;
-    }
-    hide();
-    qApp->quit();
-}
 
 void MixxxMainWindow::slotOptionsKeyboard(bool toggle) {
     UserSettingsPointer pConfig = m_pSettingsManager->settings();
@@ -1129,20 +1131,12 @@ bool MixxxMainWindow::event(QEvent* e) {
 void MixxxMainWindow::closeEvent(QCloseEvent *event) {
     if (!confirmExit()) {
         event->ignore();
-    }
-}
-
-void MixxxMainWindow::slotToCenterOfPrimaryScreen() {
-    if (!m_pWidgetParent)
         return;
-
-    QDesktopWidget* desktop = QApplication::desktop();
-    int primaryScreen = desktop->primaryScreen();
-    QRect primaryScreenRect = desktop->availableGeometry(primaryScreen);
-
-    move(primaryScreenRect.left() + (primaryScreenRect.width() - m_pWidgetParent->width()) / 2,
-         primaryScreenRect.top() + (primaryScreenRect.height() - m_pWidgetParent->height()) / 2);
+    }
+    finalize();
+    QMainWindow::closeEvent(event);
 }
+
 
 void MixxxMainWindow::checkDirectRendering() {
     // IF
@@ -1226,8 +1220,6 @@ bool MixxxMainWindow::confirmExit() {
             m_pPrefDlg->close();
         }
     }
-
-    finalize();
 
     return true;
 }

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -73,10 +73,7 @@ class MixxxMainWindow : public QMainWindow {
   public slots:
     void rebootMixxxView();
 
-    //void slotQuitFullScreen();
     void slotFileLoadSongPlayer(int deck);
-    // exits the application
-    void slotFileQuit();
     // toogle keyboard on-off
     void slotOptionsKeyboard(bool toggle);
     // Preference dialog
@@ -88,8 +85,6 @@ class MixxxMainWindow : public QMainWindow {
     // Open the developer tools dialog.
     void slotDeveloperTools(bool enable);
     void slotDeveloperToolsClosed();
-
-    void slotToCenterOfPrimaryScreen();
 
     void slotUpdateWindowTitle(TrackPointer pTrack);
 


### PR DESCRIPTION
Mixxx currently sets the window to the center of the screen without remembering the adjustments made to the window dimensions, which is super annoying. This PR makes it so that the sizes are saved / restored during app shutdown / startup, and removes the `slotToCenterOfPrimaryScreen()` method.

The very first time the app is started, the window will be located with its bottom left corner aligned flush with the bottom left corner of the display (this is the default QT geometry state). On subsequent app restarts, the window will be in whatever state the user last put it in.
