### PR TITLE
Added multi import for crates and playlists

### DIFF
--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -351,7 +351,7 @@ void BasePlaylistFeature::slotImportPlaylist() {
     slotImportPlaylistFile(playlist_file);
 }
 
-void BasePlaylistFeature::slotImportPlaylistFile(QString &playlist_file) {
+void BasePlaylistFeature::slotImportPlaylistFile(const QString &playlist_file) {
     // The user has picked a new directory via a file dialog. This means the
     // system sandboxer (if we are sandboxed) has granted us permission to this
     // folder. We don't need access to this file on a regular basis so we do not
@@ -383,20 +383,25 @@ void BasePlaylistFeature::slotImportPlaylistFile(QString &playlist_file) {
 }
 
 void BasePlaylistFeature::slotCreateImportPlaylist() {
-    if (!m_pPlaylistTableModel) return;
+    if (!m_pPlaylistTableModel) {
+        return;
+    }
 
     // Get file to read
     QStringList playlist_files = LibraryFeature::getPlaylistFiles();
-    if (playlist_files.isEmpty()) return;
+    if (playlist_files.isEmpty()) {
+        return;
+    }
     
     // Set last import directory
     QFileInfo fileName(playlist_files.first());
     m_pConfig->set(ConfigKey("[Library]","LastImportExportPlaylistDirectory"),
                 ConfigValue(fileName.dir().absolutePath()));
-
-    // For each selected element create a different playlist.
-    for (QString &playlistFile : playlist_files) {
     
+    int playlistId = -1;
+    
+    // For each selected element create a different playlist.
+    for (const QString &playlistFile : playlist_files) {
         fileName = QFileInfo(playlistFile);
     
         // Get a valid name
@@ -407,7 +412,9 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
         int i = 0;
         while (!validNameGiven) {
             name = baseName;
-            if (i != 0) name += QString::number(i);
+            if (i != 0) {
+                name += QString::number(i);
+            }
     
             // Check name
             int existingId = m_playlistDao.getPlaylistIdFromName(name);
@@ -416,8 +423,9 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
             ++i;
         }
     
-        int playlistId = m_playlistDao.createPlaylist(name);
+        playlistId = m_playlistDao.createPlaylist(name);
         if (playlistId != -1) {
+            //m_pPlaylistTableModel->setTableModel(playlistId);
             activatePlaylist(playlistId);
         }
         else {
@@ -430,8 +438,6 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
         
         slotImportPlaylistFile(playlistFile);
     }
-
-
 }
 
 void BasePlaylistFeature::slotExportPlaylist() {

--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -349,6 +349,7 @@ void BasePlaylistFeature::slotImportPlaylist() {
                 ConfigValue(fileName.dir().absolutePath()));
 
     slotImportPlaylistFile(playlist_file);
+    activateChild(m_lastRightClickedIndex);
 }
 
 void BasePlaylistFeature::slotImportPlaylistFile(const QString &playlist_file) {
@@ -375,7 +376,6 @@ void BasePlaylistFeature::slotImportPlaylistFile(const QString &playlist_file) {
 
       // Iterate over the List that holds URLs of playlist entires
       m_pPlaylistTableModel->addTracks(QModelIndex(), entries);
-      activateChild(m_lastRightClickedIndex);
 
       // delete the parser object
       delete playlist_parser;
@@ -398,7 +398,7 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
     m_pConfig->set(ConfigKey("[Library]","LastImportExportPlaylistDirectory"),
                 ConfigValue(fileName.dir().absolutePath()));
     
-    int playlistId = -1;
+    int lastPlaylistId = -1;
     
     // For each selected element create a different playlist.
     for (const QString &playlistFile : playlist_files) {
@@ -423,10 +423,9 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
             ++i;
         }
     
-        playlistId = m_playlistDao.createPlaylist(name);
-        if (playlistId != -1) {
-            //m_pPlaylistTableModel->setTableModel(playlistId);
-            activatePlaylist(playlistId);
+        lastPlaylistId = m_playlistDao.createPlaylist(name);
+        if (lastPlaylistId != -1 && m_pPlaylistTableModel) {
+            m_pPlaylistTableModel->setTableModel(lastPlaylistId);
         }
         else {
                 QMessageBox::warning(NULL,
@@ -438,6 +437,7 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
         
         slotImportPlaylistFile(playlistFile);
     }
+    activatePlaylist(lastPlaylistId);
 }
 
 void BasePlaylistFeature::slotExportPlaylist() {

--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -401,7 +401,7 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
     int lastPlaylistId = -1;
     
     // For each selected element create a different playlist.
-    for (const QString &playlistFile : playlist_files) {
+    for (const QString& playlistFile : playlist_files) {
         fileName = QFileInfo(playlistFile);
     
         // Get a valid name

--- a/src/library/baseplaylistfeature.h
+++ b/src/library/baseplaylistfeature.h
@@ -59,7 +59,7 @@ class BasePlaylistFeature : public LibraryFeature {
     void slotRenamePlaylist();
     void slotTogglePlaylistLock();
     void slotImportPlaylist();
-    void slotImportPlaylistFile(QString &playlist_file);
+    void slotImportPlaylistFile(const QString &playlist_file);
     void slotCreateImportPlaylist();
     void slotExportPlaylist();
     // Copy all of the tracks in a playlist to a new directory.

--- a/src/library/cratefeature.cpp
+++ b/src/library/cratefeature.cpp
@@ -634,7 +634,7 @@ void CrateFeature::slotCreateImportCrate() {
     int lastCrateId = -1;
     
     // For each selected file
-    for (const QString &playlistFile : playlist_files) {
+    for (const QString& playlistFile : playlist_files) {
         fileName = QFileInfo(playlistFile);
 
         // Get a valid name

--- a/src/library/cratefeature.cpp
+++ b/src/library/cratefeature.cpp
@@ -584,7 +584,7 @@ void CrateFeature::slotImportPlaylist() {
     slotImportPlaylistFile(playlist_file);
 }
 
-void CrateFeature::slotImportPlaylistFile(QString &playlist_file) {
+void CrateFeature::slotImportPlaylistFile(const QString &playlist_file) {
     // The user has picked a new directory via a file dialog. This means the
     // system sandboxer (if we are sandboxed) has granted us permission to this
     // folder. We don't need access to this file on a regular basis so we do not
@@ -620,9 +620,10 @@ void CrateFeature::slotImportPlaylistFile(QString &playlist_file) {
 void CrateFeature::slotCreateImportPlaylist() {
 
     // Get file to read
-    // Get file to read
     QStringList playlist_files = LibraryFeature::getPlaylistFiles();
-    if (playlist_files.isEmpty()) return;
+    if (playlist_files.isEmpty()) {
+        return;
+    }
     
     
     // Set last import directory
@@ -631,7 +632,7 @@ void CrateFeature::slotCreateImportPlaylist() {
                 ConfigValue(fileName.dir().absolutePath()));
     
     // For each selected file
-    for (QString &playlistFile : playlist_files) {
+    for (const QString &playlistFile : playlist_files) {
         fileName = QFileInfo(playlistFile);
 
         // Get a valid name
@@ -641,7 +642,9 @@ void CrateFeature::slotCreateImportPlaylist() {
         int i = 0;
         while (!validNameGiven) {
             name = baseName;
-            if (i != 0) name += QString::number(i);
+            if (i != 0) {
+                name += QString::number(i);
+            }
     
             // Check name
             int existingId = m_crateDao.getCrateIdByName(name);
@@ -655,8 +658,8 @@ void CrateFeature::slotCreateImportPlaylist() {
         if (playlistId != -1) activateCrate(playlistId);
         else {
                 QMessageBox::warning(NULL,
-                                     tr("Playlist Creation Failed"),
-                                     tr("An unknown error occurred while creating playlist: ")
+                                     tr("Crate Creation Failed"),
+                                     tr("An unknown error occurred while creating crate: ")
                                       + name);
                 return;
         }

--- a/src/library/cratefeature.cpp
+++ b/src/library/cratefeature.cpp
@@ -624,6 +624,7 @@ void CrateFeature::slotCreateImportPlaylist() {
     QStringList playlist_files = LibraryFeature::getPlaylistFiles();
     if (playlist_files.isEmpty()) return;
     
+    
     // Set last import directory
     QFileInfo fileName(playlist_files.first());
     m_pConfig->set(ConfigKey("[Library]","LastImportExportCrateDirectory"),

--- a/src/library/cratefeature.h
+++ b/src/library/cratefeature.h
@@ -59,7 +59,7 @@ class CrateFeature : public LibraryFeature {
     void slotToggleCrateLock();
     void slotImportPlaylist();
     void slotImportPlaylistFile(const QString &playlist_file);
-    void slotCreateImportPlaylist();
+    void slotCreateImportCrate();
     void slotExportPlaylist();
     // Copy all of the tracks in a crate to a new directory (like a thumbdrive).
     void slotExportTrackFiles();

--- a/src/library/cratefeature.h
+++ b/src/library/cratefeature.h
@@ -58,7 +58,7 @@ class CrateFeature : public LibraryFeature {
     void slotAutoDjTrackSourceChanged();
     void slotToggleCrateLock();
     void slotImportPlaylist();
-    void slotImportPlaylistFile(QString &playlist_file);
+    void slotImportPlaylistFile(const QString &playlist_file);
     void slotCreateImportPlaylist();
     void slotExportPlaylist();
     // Copy all of the tracks in a crate to a new directory (like a thumbdrive).

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -20,7 +20,8 @@ LibraryFeature::~LibraryFeature() {
     
 }
 
-QString LibraryFeature::getPlaylistFile() {    
+QStringList LibraryFeature::getPlaylistFiles(QFileDialog::FileMode mode)
+{
     QString lastPlaylistDirectory = m_pConfig->getValueString(
             ConfigKey("[Library]", "LastImportExportPlaylistDirectory"),
             QDesktopServices::storageLocation(QDesktopServices::MusicLocation));
@@ -30,10 +31,10 @@ QString LibraryFeature::getPlaylistFile() {
                      lastPlaylistDirectory,
                      tr("Playlist Files (*.m3u *.m3u8 *.pls *.csv)"));
     dialogg.setAcceptMode(QFileDialog::AcceptOpen);
-    dialogg.setFileMode(QFileDialog::ExistingFile);
+    dialogg.setFileMode(mode);
     dialogg.setModal(true);
     
     // If the user refuses return
-    if (! dialogg.exec()) return QString();
-    return dialogg.selectedFiles().first();
+    if (! dialogg.exec()) return QStringList();
+    return dialogg.selectedFiles();
 }

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -20,8 +20,7 @@ LibraryFeature::~LibraryFeature() {
     
 }
 
-QStringList LibraryFeature::getPlaylistFiles(QFileDialog::FileMode mode)
-{
+QStringList LibraryFeature::getPlaylistFiles(QFileDialog::FileMode mode) {
     QString lastPlaylistDirectory = m_pConfig->getValueString(
             ConfigKey("[Library]", "LastImportExportPlaylistDirectory"),
             QDesktopServices::storageLocation(QDesktopServices::MusicLocation));

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -65,7 +65,7 @@ class LibraryFeature : public QObject {
                             KeyboardEventFilter* /* keyboard */) {}
     virtual TreeItemModel* getChildModel() = 0;
 
-protected:
+  protected:
     inline QStringList getPlaylistFiles() { return getPlaylistFiles(QFileDialog::ExistingFiles); }
     inline QString getPlaylistFile() { return getPlaylistFiles(QFileDialog::ExistingFile).first(); }
     UserSettingsPointer m_pConfig;
@@ -108,7 +108,7 @@ protected:
     void enableCoverArtDisplay(bool);
     void trackSelected(TrackPointer pTrack);
 
-private: 
+  private: 
     QStringList getPlaylistFiles(QFileDialog::FileMode mode);
 
 };

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -66,7 +66,8 @@ class LibraryFeature : public QObject {
     virtual TreeItemModel* getChildModel() = 0;
 
 protected:
-    QString getPlaylistFile();
+    inline QStringList getPlaylistFiles() { return getPlaylistFiles(QFileDialog::ExistingFiles); }
+    inline QString getPlaylistFile() { return getPlaylistFiles(QFileDialog::ExistingFile).first(); }
     UserSettingsPointer m_pConfig;
 
   public slots:
@@ -107,6 +108,8 @@ protected:
     void enableCoverArtDisplay(bool);
     void trackSelected(TrackPointer pTrack);
 
+private: 
+    QStringList getPlaylistFiles(QFileDialog::FileMode mode);
 
 };
 


### PR DESCRIPTION
As discussed in https://bugs.launchpad.net/mixxx/+bug/1108371 now there's the option to import multiple playlists / crates at once
