### PR TITLE
Track Export: Sync tags for exported tracks before copying

### DIFF
--- a/src/library/export/trackexportdlg.cpp
+++ b/src/library/export/trackexportdlg.cpp
@@ -23,6 +23,7 @@ TrackExportDlg::TrackExportDlg(QWidget *parent,
 
     connect(m_worker, SIGNAL(progress(QString, int, int)), this,
             SLOT(slotProgress(QString, int, int)));
+    connect(m_worker, SIGNAL(finished()), this, SLOT(slotFinished()));
     connect(m_worker,
             SIGNAL(askOverwriteMode(QString, std::promise<TrackExportWorker::OverwriteAnswer>*)),
             this,
@@ -42,13 +43,8 @@ void TrackExportDlg::showEvent(QShowEvent* event) {
     m_worker->start();
 }
 
-void TrackExportDlg::slotProgress(QString filename, int progress, int count) {
-    if (progress == count) {
-        statusLabel->setText(tr("Export finished"));
-        finish();
-    } else {
-        statusLabel->setText(tr("Exporting %1").arg(filename));
-    }
+void TrackExportDlg::slotProgress(QString message, int progress, int count) {
+    statusLabel->setText(message);
     exportProgress->setMinimum(0);
     exportProgress->setMaximum(count);
     exportProgress->setValue(progress);
@@ -89,6 +85,12 @@ void TrackExportDlg::slotAskOverwriteMode(
 }
 
 void TrackExportDlg::cancelButtonClicked() {
+    statusLabel->setText(tr("Export canceled"));
+    finish();
+}
+
+void TrackExportDlg::slotFinished() {
+    statusLabel->setText(tr("Export finished"));
     finish();
 }
 

--- a/src/library/export/trackexportdlg.h
+++ b/src/library/export/trackexportdlg.h
@@ -31,6 +31,7 @@ class TrackExportDlg : public QDialog, public Ui::DlgTrackExport {
 
   public slots:
     void slotProgress(QString filename, int progress, int count);
+    void slotFinished();
     void slotAskOverwriteMode(
             QString filename,
             std::promise<TrackExportWorker::OverwriteAnswer>* promise);

--- a/src/library/export/trackexportwizard.cpp
+++ b/src/library/export/trackexportwizard.cpp
@@ -28,7 +28,7 @@ bool TrackExportWizard::selectDestinationDirectory() {
     m_pConfig->set(ConfigKey("[Library]", "LastTrackCopyDirectory"),
                    ConfigValue(destDir));
 
-    m_worker.reset(new TrackExportWorker(destDir, m_tracks));
+    m_worker.reset(new TrackExportWorker(m_pConfig, destDir, m_tracks));
     m_dialog.reset(new TrackExportDlg(m_parent, m_pConfig, m_worker.data()));
     return true;
 }

--- a/src/library/export/trackexportworker.h
+++ b/src/library/export/trackexportworker.h
@@ -7,6 +7,7 @@
 #include <QThread>
 #include <future>
 
+#include "preferences/usersettings.h"
 #include "track/track.h"
 
 // A QThread class for copying a list of files to a single destination directory.
@@ -34,8 +35,9 @@ class TrackExportWorker : public QThread {
 
     // Constructor does not validate the destination directory.  Calling classes
     // should do that.
-    TrackExportWorker(QString destDir, QList<TrackPointer> tracks)
-            : m_destDir(destDir), m_tracks(tracks) { }
+    TrackExportWorker(UserSettingsPointer pConfig, QString destDir,
+                      QList<TrackPointer> tracks)
+            : m_pConfig(pConfig), m_destDir(destDir), m_tracks(tracks) { }
     virtual ~TrackExportWorker() { };
 
     // exports ALL the tracks.  Thread joins on success or failure.
@@ -60,7 +62,11 @@ class TrackExportWorker : public QThread {
     void askOverwriteMode(
             QString filename,
             std::promise<TrackExportWorker::OverwriteAnswer>* promise);
-    void progress(QString filename, int progress, int count);
+    // Outgoing messages should already be i18n.
+    void progress(QString message, int progress, int count);
+    // The finished signal indicates a successful copy.
+    void finished();
+    // The canceled signal indicates a canceled (non-error) copy.
     void canceled();
 
   private:
@@ -80,6 +86,7 @@ class TrackExportWorker : public QThread {
     QString m_errorMessage;
 
     OverwriteMode m_overwriteMode = OverwriteMode::ASK;
+    UserSettingsPointer m_pConfig;
     const QString m_destDir;
     const QList<TrackPointer> m_tracks;
 };

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -39,7 +39,7 @@ DlgPrefLibrary::DlgPrefLibrary(QWidget * parent,
           m_iOriginalTrackTableRowHeight(Library::kDefaultRowHeightPx) {
     setupUi(this);
     slotUpdate();
-    checkbox_ID3_sync->setVisible(false);
+    checkbox_ID3_sync->setVisible(true);
 
     connect(this, SIGNAL(requestAddDir(QString)),
             m_pLibrary, SLOT(slotRequestAddDir(QString)));

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -188,9 +188,6 @@
       </item>
       <item row="1" column="0" colspan="2">
        <widget class="QCheckBox" name="checkbox_ID3_sync">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
         <property name="text">
          <string>Synchronize ID3 tags on track modifications</string>
         </property>

--- a/src/test/trackexport_test.cpp
+++ b/src/test/trackexport_test.cpp
@@ -50,7 +50,7 @@ TEST_F(TrackExporterTest, SimpleListExport) {
     tracks.append(track1);
     tracks.append(track2);
     tracks.append(track3);
-    TrackExportWorker worker(m_exportDir.canonicalPath(), tracks);
+    TrackExportWorker worker(nullptr, m_exportDir.canonicalPath(), tracks);
     m_answerer.reset(new FakeOverwriteAnswerer(&worker));
 
     worker.run();
@@ -86,7 +86,7 @@ TEST_F(TrackExporterTest, OverwriteSkip) {
     QList<TrackPointer> tracks;
     tracks.append(track1);
     tracks.append(track2);
-    TrackExportWorker worker(m_exportDir.canonicalPath(), tracks);
+    TrackExportWorker worker(nullptr, m_exportDir.canonicalPath(), tracks);
     m_answerer.reset(new FakeOverwriteAnswerer(&worker));
     m_answerer->setAnswer(QFileInfo(file1).canonicalFilePath(),
                            TrackExportWorker::OverwriteAnswer::OVERWRITE);
@@ -130,7 +130,7 @@ TEST_F(TrackExporterTest, OverwriteAll) {
     QList<TrackPointer> tracks;
     tracks.append(track1);
     tracks.append(track2);
-    TrackExportWorker worker(m_exportDir.canonicalPath(), tracks);
+    TrackExportWorker worker(nullptr, m_exportDir.canonicalPath(), tracks);
     m_answerer.reset(new FakeOverwriteAnswerer(&worker));
     m_answerer->setAnswer(QFileInfo(file2).canonicalFilePath(),
                            TrackExportWorker::OverwriteAnswer::OVERWRITE_ALL);
@@ -171,7 +171,7 @@ TEST_F(TrackExporterTest, SkipAll) {
     QList<TrackPointer> tracks;
     tracks.append(track1);
     tracks.append(track2);
-    TrackExportWorker worker(m_exportDir.canonicalPath(), tracks);
+    TrackExportWorker worker(nullptr, m_exportDir.canonicalPath(), tracks);
     m_answerer.reset(new FakeOverwriteAnswerer(&worker));
     m_answerer->setAnswer(QFileInfo(file2).canonicalFilePath(),
                            TrackExportWorker::OverwriteAnswer::SKIP_ALL);
@@ -210,7 +210,7 @@ TEST_F(TrackExporterTest, Cancel) {
     QList<TrackPointer> tracks;
     tracks.append(track1);
     tracks.append(track2);
-    TrackExportWorker worker(m_exportDir.canonicalPath(), tracks);
+    TrackExportWorker worker(nullptr, m_exportDir.canonicalPath(), tracks);
     m_answerer.reset(new FakeOverwriteAnswerer(&worker));
     m_answerer->setAnswer(QFileInfo(file2).canonicalFilePath(),
                            TrackExportWorker::OverwriteAnswer::CANCEL);
@@ -241,7 +241,7 @@ TEST_F(TrackExporterTest, DedupeList) {
     QList<TrackPointer> tracks;
     tracks.append(track1);
     tracks.append(track2);
-    TrackExportWorker worker(m_exportDir.canonicalPath(), tracks);
+    TrackExportWorker worker(nullptr, m_exportDir.canonicalPath(), tracks);
     m_answerer.reset(new FakeOverwriteAnswerer(&worker));
 
     worker.run();
@@ -278,7 +278,7 @@ TEST_F(TrackExporterTest, MungeFilename) {
     QList<TrackPointer> tracks;
     tracks.append(track1);
     tracks.append(track2);
-    TrackExportWorker worker(m_exportDir.canonicalPath(), tracks);
+    TrackExportWorker worker(nullptr, m_exportDir.canonicalPath(), tracks);
     m_answerer.reset(new FakeOverwriteAnswerer(&worker));
 
     worker.run();


### PR DESCRIPTION
Note that I re-enabled id3 sync to make this easier to test, the final merge will revert that change.

Testing: I did an export, the tags synced just fine
