### PR TITLE
Library navigation controls

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -354,46 +354,53 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
     // Library Controls
     QMenu* libraryMenu = addSubmenu(tr("Library"));
-    addPrefixedControl("[Playlist]", "ToggleSelectedSidebarItem",
-                       tr("Expand/Collapse View"),
-                       tr("Expand/collapse the selected view (library, playlist..)"),
+    addPrefixedControl("[Library]", "MoveUp",
+                       tr("Move up"),
+                       tr("Equivalent to pressing the UP key on the keyboard"),
                        m_libraryStr, libraryMenu);
-
-    addPrefixedControl("[Playlist]", "SelectPlaylist",
-                       tr("Switch Next/Previous View"),
-                       tr("Switch to the next or previous view (library, playlist..)"),
+    addPrefixedControl("[Library]", "MoveDown",
+                       tr("Move down"),
+                       tr("Equivalent to pressing the DOWN key on the keyboard"),
                        m_libraryStr, libraryMenu);
-    addPrefixedControl("[Playlist]", "SelectNextPlaylist",
-                       tr("Switch To Next View"),
-                       tr("Switch to the next view (library, playlist..)"),
+    addPrefixedControl("[Library]", "MoveVertical",
+                       tr("Move up/down"),
+                       tr("Move vertically in either direction using a knob, as if pressing UP/DOWN keys"),
                        m_libraryStr, libraryMenu);
-    addPrefixedControl("[Playlist]", "SelectPrevPlaylist",
-                       tr("Switch To Previous View"),
-                       tr("Switch to the previous view (library, playlist..)"),
+    addPrefixedControl("[Library]", "ScrollUp",
+                       tr("Scroll Up"),
+                       tr("Equivalent to pressing the PAGE UP key on the keyboard"),
                        m_libraryStr, libraryMenu);
-    addPrefixedControl("[Playlist]", "SelectTrackKnob",
-                       tr("Scroll To Next/Previous Track"),
-                       tr("Scroll up or down in library/playlist"),
+    addPrefixedControl("[Library]", "ScrollDown",
+                       tr("Scroll Down"),
+                       tr("Equivalent to pressing the PAGE DOWN key on the keyboard"),
                        m_libraryStr, libraryMenu);
-    addPrefixedControl("[Playlist]", "SelectNextTrack",
-                       tr("Scroll To Next Track"),
-                       tr("Scroll to next track in library/playlist"),
+    addPrefixedControl("[Library]", "ScrollVertical",
+                       tr("Scroll up/down"),
+                       tr("Scroll vertically in either direction using a knob, as if pressing PGUP/PGDOWN keys"),
                        m_libraryStr, libraryMenu);
-    addPrefixedControl("[Playlist]", "SelectPrevTrack",
-                       tr("Scroll To Previous Track"),
-                       tr("Scroll to previous track in library/playlist"),
+    addPrefixedControl("[Library]", "MoveLeft",
+                       tr("Move left"),
+                       tr("Equivalent to pressing the LEFT key on the keyboard"),
                        m_libraryStr, libraryMenu);
-    addPrefixedControl("[Playlist]", "LoadSelectedIntoFirstStopped",
-                       tr("Load Track Into Stopped Deck"),
-                       tr("Load selected track into first stopped deck"),
+    addPrefixedControl("[Library]", "MoveRight",
+                       tr("Move right"),
+                       tr("Equivalent to pressing the RIGHT key on the keyboard"),
                        m_libraryStr, libraryMenu);
-    addPrefixedControl("[Playlist]", "AutoDjAddBottom",
-                       tr("Add to Auto DJ Queue (bottom)"),
-                       tr("Append the selected track to the Auto DJ Queue"),
+    addPrefixedControl("[Library]", "MoveHorizontal",
+                       tr("Move left/right"),
+                       tr("Move horizontall in either direction using a knob, as if pressing LEFT/RIGHT keys"),
                        m_libraryStr, libraryMenu);
-    addPrefixedControl("[Playlist]", "AutoDjAddTop",
-                       tr("Add to Auto DJ Queue (top)"),
-                       tr("Prepend selected track to the Auto DJ Queue"),
+    addPrefixedControl("[Library]", "MoveFocusForward",
+                       tr("Move focus to right pane"),
+                       tr("Equivalent to pressing the TAB key on the keyboard"),
+                       m_libraryStr, libraryMenu);
+    addPrefixedControl("[Library]", "MoveFocusBackward",
+                       tr("Move focus to left pane"),
+                       tr("Equivalent to pressing the SHIFT+TAB key on the keyboard"),
+                       m_libraryStr, libraryMenu);
+    addPrefixedControl("[Library]", "MoveFocus",
+                       tr("Move focus to right/left pane"),
+                       tr("Move focus one pane to right or left using a knob, as if pressing TAB/SHIFT+TAB keys"),
                        m_libraryStr, libraryMenu);
     addDeckAndSamplerControl("LoadSelectedTrack",
                              tr("Load Track"),

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -402,6 +402,16 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                        tr("Move focus to right/left pane"),
                        tr("Move focus one pane to right or left using a knob, as if pressing TAB/SHIFT+TAB keys"),
                        m_libraryStr, libraryMenu);
+    addPrefixedControl("[Library]", "AutoDjAddBottom",
+                       tr("Add to Auto DJ Queue (bottom)"),
+                       tr("Append the selected track to the Auto DJ Queue"),
+                       m_libraryStr, libraryMenu);
+    addPrefixedControl("[Library]", "AutoDjAddTop",
+                       tr("Add to Auto DJ Queue (top)"),
+                       tr("Prepend selected track to the Auto DJ Queue"),
+                       m_libraryStr, libraryMenu);
+
+    // Load track (these can be loaded into any channel)
     addDeckAndSamplerControl("LoadSelectedTrack",
                              tr("Load Track"),
                              tr("Load selected track"), libraryMenu);

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -223,3 +223,7 @@ void DlgAutoDJ::updateSelectionInfo() {
         labelSelectionInfo->setEnabled(false);
     }
 }
+
+bool DlgAutoDJ::hasFocus() const {
+    return QWidget::hasFocus();
+}

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -23,14 +23,14 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
               Library* pLibrary,
               AutoDJProcessor* pProcessor, TrackCollection* pTrackCollection,
               KeyboardEventFilter* pKeyboard);
-    virtual ~DlgAutoDJ();
+    ~DlgAutoDJ() override;
 
-    void onShow();
-    bool hasFocus() const;
-    void onSearch(const QString& text);
-    void loadSelectedTrack();
-    void loadSelectedTrackToGroup(QString group, bool play);
-    void moveSelection(int delta);
+    void onShow() override;
+    bool hasFocus() const override;
+    void onSearch(const QString& text) override;
+    void loadSelectedTrack() override;
+    void loadSelectedTrackToGroup(QString group, bool play) override;
+    void moveSelection(int delta) override;
 
   public slots:
     void shufflePlaylistButton(bool buttonChecked);

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -26,6 +26,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     virtual ~DlgAutoDJ();
 
     void onShow();
+    bool hasFocus() const;
     void onSearch(const QString& text);
     void loadSelectedTrack();
     void loadSelectedTrackToGroup(QString group, bool play);

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -72,6 +72,10 @@ void DlgAnalysis::onShow() {
     m_pAnalysisLibraryTableModel->select();
 }
 
+bool DlgAnalysis::hasFocus() const {
+    return QWidget::hasFocus();
+}
+
 void DlgAnalysis::onSearch(const QString& text) {
     m_pAnalysisLibraryTableModel->search(text);
 }

--- a/src/library/dlganalysis.h
+++ b/src/library/dlganalysis.h
@@ -18,16 +18,16 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
     DlgAnalysis(QWidget *parent,
                UserSettingsPointer pConfig,
                TrackCollection* pTrackCollection);
-    virtual ~DlgAnalysis();
+    ~DlgAnalysis() override;
 
-    virtual void onSearch(const QString& text);
-    virtual void onShow();
-    virtual bool hasFocus() const;
-    virtual void loadSelectedTrack();
-    virtual void loadSelectedTrackToGroup(QString group, bool play);
-    virtual void slotSendToAutoDJ();
-    virtual void slotSendToAutoDJTop();
-    virtual void moveSelection(int delta);
+    void onSearch(const QString& text) override;
+    void onShow() override;
+    bool hasFocus() const override;
+    void loadSelectedTrack() override;
+    void loadSelectedTrackToGroup(QString group, bool play) override;
+    void slotSendToAutoDJ() override;
+    void slotSendToAutoDJTop() override;
+    void moveSelection(int delta) override;
     inline const QString currentSearch() {
         return m_pAnalysisLibraryTableModel->currentSearch();
     }

--- a/src/library/dlganalysis.h
+++ b/src/library/dlganalysis.h
@@ -22,6 +22,7 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
 
     virtual void onSearch(const QString& text);
     virtual void onShow();
+    virtual bool hasFocus() const;
     virtual void loadSelectedTrack();
     virtual void loadSelectedTrackToGroup(QString group, bool play);
     virtual void slotSendToAutoDJ();

--- a/src/library/dlghidden.cpp
+++ b/src/library/dlghidden.cpp
@@ -94,3 +94,7 @@ void DlgHidden::setTrackTableFont(const QFont& font) {
 void DlgHidden::setTrackTableRowHeight(int rowHeight) {
     m_pTrackTableView->setTrackTableRowHeight(rowHeight);
 }
+
+bool DlgHidden::hasFocus() const {
+    return QWidget::hasFocus();
+}

--- a/src/library/dlghidden.h
+++ b/src/library/dlghidden.h
@@ -18,11 +18,11 @@ class DlgHidden : public QWidget, public Ui::DlgHidden, public LibraryView {
     DlgHidden(QWidget* parent, UserSettingsPointer pConfig,
               Library* pLibrary, TrackCollection* pTrackCollection,
               KeyboardEventFilter* pKeyboard);
-    virtual ~DlgHidden();
+    ~DlgHidden() override;
 
-    void onShow();
-    bool hasFocus() const;
-    void onSearch(const QString& text);
+    void onShow() override;
+    bool hasFocus() const override;
+    void onSearch(const QString& text) override;
 
   public slots:
     void clicked();

--- a/src/library/dlghidden.h
+++ b/src/library/dlghidden.h
@@ -21,6 +21,7 @@ class DlgHidden : public QWidget, public Ui::DlgHidden, public LibraryView {
     virtual ~DlgHidden();
 
     void onShow();
+    bool hasFocus() const;
     void onSearch(const QString& text);
 
   public slots:

--- a/src/library/dlgmissing.cpp
+++ b/src/library/dlgmissing.cpp
@@ -87,3 +87,7 @@ void DlgMissing::setTrackTableFont(const QFont& font) {
 void DlgMissing::setTrackTableRowHeight(int rowHeight) {
     m_pTrackTableView->setTrackTableRowHeight(rowHeight);
 }
+
+bool DlgMissing::hasFocus() const {
+    return QWidget::hasFocus();
+}

--- a/src/library/dlgmissing.h
+++ b/src/library/dlgmissing.h
@@ -20,6 +20,7 @@ class DlgMissing : public QWidget, public Ui::DlgMissing, public LibraryView {
     virtual ~DlgMissing();
 
     void onShow();
+    bool hasFocus() const;
     void onSearch(const QString& text);
 
   public slots:

--- a/src/library/dlgmissing.h
+++ b/src/library/dlgmissing.h
@@ -17,11 +17,11 @@ class DlgMissing : public QWidget, public Ui::DlgMissing, public LibraryView {
     DlgMissing(QWidget* parent, UserSettingsPointer pConfig,
                Library* pLibrary, TrackCollection* pTrackCollection,
                KeyboardEventFilter* pKeyboard);
-    virtual ~DlgMissing();
+    ~DlgMissing() override;
 
-    void onShow();
-    bool hasFocus() const;
-    void onSearch(const QString& text);
+    void onShow() override;
+    bool hasFocus() const override;
+    void onSearch(const QString& text) override;
 
   public slots:
     void clicked();

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -61,62 +61,36 @@ LibraryControl::LibraryControl(Library* pLibrary)
     m_numSamplers.connectValueChanged(SLOT(slotNumSamplersChanged(double)));
     m_numPreviewDecks.connectValueChanged(SLOT(slotNumPreviewDecksChanged(double)));
 
-    // Make controls for library navigation and track loading.
+    // Controls to navigate vertically within currently focussed widget (up/down buttons)
+    m_pMoveUp = new ControlPushButton(ConfigKey("[Playlist]", "MoveUp"));
+    m_pMoveDown = new ControlPushButton(ConfigKey("[Playlist]", "MoveDown"));
+    m_pMoveVertical = new ControlObject(ConfigKey("[Playlist]", "MoveVertical"), false);
+    connect(m_pMoveUp, SIGNAL(valueChanged(double)),this, SLOT(slotMoveUp(double)));
+    connect(m_pMoveDown, SIGNAL(valueChanged(double)),this, SLOT(slotMoveDown(double)));
+    connect(m_pMoveVertical, SIGNAL(valueChanged(double)),this, SLOT(slotMoveVertical(double)));
 
-    m_pSelectNextTrack = new ControlPushButton(ConfigKey("[Playlist]", "SelectNextTrack"));
-    connect(m_pSelectNextTrack, SIGNAL(valueChanged(double)),
-            this, SLOT(slotSelectNextTrack(double)));
+    // Controls to navigate horizontally within currently selected item (left/right buttons)
+    m_pMoveLeft = new ControlPushButton(ConfigKey("[Playlist]", "MoveLeft"));
+    m_pMoveRight = new ControlPushButton(ConfigKey("[Playlist]", "MoveRight"));
+    m_pMoveHorizontal = new ControlObject(ConfigKey("[Playlist]", "MoveHorizontal"), false);
+    connect(m_pMoveLeft, SIGNAL(valueChanged(double)),this, SLOT(slotMoveLeft(double)));
+    connect(m_pMoveRight, SIGNAL(valueChanged(double)),this, SLOT(slotMoveRight(double)));
+    connect(m_pMoveHorizontal, SIGNAL(valueChanged(double)),this, SLOT(slotMoveHorizontal(double)));
 
-    m_pSelectPrevTrack = new ControlPushButton(ConfigKey("[Playlist]", "SelectPrevTrack"));
-    connect(m_pSelectPrevTrack, SIGNAL(valueChanged(double)),
-            this, SLOT(slotSelectPrevTrack(double)));
+    // Control to navigate between widgets (tab/shit+tab button)
+    m_pMoveFocusForward = new ControlPushButton(ConfigKey("[Playlist]", "MoveFocusForward"));
+    m_pMoveFocusBackward = new ControlPushButton(ConfigKey("[Playlist]", "MoveFocusBackward"));
+    m_pMoveFocus = new ControlObject(ConfigKey("[Playlist]", "MoveFocus"), false);
+    connect(m_pMoveFocusForward, SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocusForward(double)));
+    connect(m_pMoveFocusBackward, SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocusBackward(double)));
+    connect(m_pMoveFocus, SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocus(double)));
 
-    // Ignoring no-ops is important since this is for +/- tickers.
-    m_pSelectTrack = new ControlObject(ConfigKey("[Playlist]","SelectTrackKnob"), false);
-    connect(m_pSelectTrack, SIGNAL(valueChanged(double)),
-            this, SLOT(slotSelectTrack(double)));
-
-    // Ignoring no-ops is important since this is for +/- tickers.
-    m_pSelectItem = new ControlObject(ConfigKey("[Playlist]","SelectItemKnob"), false);
-    connect(m_pSelectItem, SIGNAL(valueChanged(double)),
-            this, SLOT(slotSelectItem(double)));
-
-    m_pSelectNextSidebarItem = new ControlPushButton(ConfigKey("[Playlist]", "SelectNextPlaylist"));
-    connect(m_pSelectNextSidebarItem, SIGNAL(valueChanged(double)),
-            this, SLOT(slotSelectNextSidebarItem(double)));
-
-    m_pSelectPrevSidebarItem = new ControlPushButton(ConfigKey("[Playlist]", "SelectPrevPlaylist"));
-    connect(m_pSelectPrevSidebarItem, SIGNAL(valueChanged(double)),
-            this, SLOT(slotSelectPrevSidebarItem(double)));
-
-    // Ignoring no-ops is important since this is for +/- tickers.
-    m_pSelectSidebarItem = new ControlObject(ConfigKey("[Playlist]", "SelectPlaylist"), false);
-    connect(m_pSelectSidebarItem, SIGNAL(valueChanged(double)),
-            this, SLOT(slotSelectSidebarItem(double)));
-
-    m_pToggleFocusWidget = new ControlPushButton(ConfigKey("[Playlist]", "ToggleFocusWidget"));
-    connect(m_pToggleFocusWidget, SIGNAL(valueChanged(double)),this, SLOT(slotToggleFocusWidget(double)));
-
-    m_pToggleSidebarItem = new ControlPushButton(ConfigKey("[Playlist]", "ToggleSelectedSidebarItem"));
-    connect(m_pToggleSidebarItem, SIGNAL(valueChanged(double)),
-            this, SLOT(slotToggleSelectedSidebarItem(double)));
-
+    // Control to choose the currently selected item in focussed widget (double click)
     m_pChooseItem = new ControlPushButton(ConfigKey("[Playlist]", "ChooseItem"));
     connect(m_pChooseItem, SIGNAL(valueChanged(double)), this, SLOT(slotChooseItem(double)));
 
-    m_pLoadSelectedIntoFirstStopped = new ControlPushButton(ConfigKey("[Playlist]","LoadSelectedIntoFirstStopped"));
-    connect(m_pLoadSelectedIntoFirstStopped, SIGNAL(valueChanged(double)),
-            this, SLOT(slotLoadSelectedIntoFirstStopped(double)));
 
-    m_pAutoDjAddTop = new ControlPushButton(ConfigKey("[Playlist]","AutoDjAddTop"));
-    connect(m_pAutoDjAddTop, SIGNAL(valueChanged(double)),
-            this, SLOT(slotAutoDjAddTop(double)));
-
-    m_pAutoDjAddBottom = new ControlPushButton(ConfigKey("[Playlist]","AutoDjAddBottom"));
-    connect(m_pAutoDjAddBottom, SIGNAL(valueChanged(double)),
-            this, SLOT(slotAutoDjAddBottom(double)));
-
-    // Ignoring no-ops is important since this is for +/- tickers.
+    // Font sizes
     m_pFontSizeKnob = new ControlObject(
             ConfigKey("[Library]", "font_size_knob"), false);
     connect(m_pFontSizeKnob, SIGNAL(valueChanged(double)),
@@ -131,6 +105,53 @@ LibraryControl::LibraryControl(Library* pLibrary)
             ConfigKey("[Library]", "font_size_increment"));
     connect(m_pFontSizeIncrement, SIGNAL(valueChanged(double)),
             this, SLOT(slotIncrementFontSize(double)));
+
+
+    /// Deprecated controls
+    m_pSelectNextTrack = new ControlPushButton(ConfigKey("[Playlist]", "SelectNextTrack"));
+    connect(m_pSelectNextTrack, SIGNAL(valueChanged(double)),
+            this, SLOT(slotSelectNextTrack(double)));
+
+
+    m_pSelectPrevTrack = new ControlPushButton(ConfigKey("[Playlist]", "SelectPrevTrack"));
+    connect(m_pSelectPrevTrack, SIGNAL(valueChanged(double)),
+            this, SLOT(slotSelectPrevTrack(double)));
+
+    // Ignoring no-ops is important since this is for +/- tickers.
+    m_pSelectTrack = new ControlObject(ConfigKey("[Playlist]","SelectTrackKnob"), false);
+    connect(m_pSelectTrack, SIGNAL(valueChanged(double)),
+            this, SLOT(slotSelectTrack(double)));
+
+
+    m_pSelectNextSidebarItem = new ControlPushButton(ConfigKey("[Playlist]", "SelectNextPlaylist"));
+    connect(m_pSelectNextSidebarItem, SIGNAL(valueChanged(double)),
+            this, SLOT(slotSelectNextSidebarItem(double)));
+
+    m_pSelectPrevSidebarItem = new ControlPushButton(ConfigKey("[Playlist]", "SelectPrevPlaylist"));
+    connect(m_pSelectPrevSidebarItem, SIGNAL(valueChanged(double)),
+            this, SLOT(slotSelectPrevSidebarItem(double)));
+
+    // Ignoring no-ops is important since this is for +/- tickers.
+    m_pSelectSidebarItem = new ControlObject(ConfigKey("[Playlist]", "SelectPlaylist"), false);
+    connect(m_pSelectSidebarItem, SIGNAL(valueChanged(double)),
+            this, SLOT(slotSelectSidebarItem(double)));
+
+    m_pToggleSidebarItem = new ControlPushButton(ConfigKey("[Playlist]", "ToggleSelectedSidebarItem"));
+    connect(m_pToggleSidebarItem, SIGNAL(valueChanged(double)),
+            this, SLOT(slotToggleSelectedSidebarItem(double)));
+
+    m_pLoadSelectedIntoFirstStopped = new ControlPushButton(ConfigKey("[Playlist]","LoadSelectedIntoFirstStopped"));
+    connect(m_pLoadSelectedIntoFirstStopped, SIGNAL(valueChanged(double)),
+            this, SLOT(slotLoadSelectedIntoFirstStopped(double)));
+
+    m_pAutoDjAddTop = new ControlPushButton(ConfigKey("[Playlist]","AutoDjAddTop"));
+    connect(m_pAutoDjAddTop, SIGNAL(valueChanged(double)),
+            this, SLOT(slotAutoDjAddTop(double)));
+
+    m_pAutoDjAddBottom = new ControlPushButton(ConfigKey("[Playlist]","AutoDjAddBottom"));
+    connect(m_pAutoDjAddBottom, SIGNAL(valueChanged(double)),
+            this, SLOT(slotAutoDjAddBottom(double)));
+
 }
 
 LibraryControl::~LibraryControl() {
@@ -301,36 +322,76 @@ void LibraryControl::slotSelectTrack(double v) {
     activeView->moveSelection(i);
 }
 
-void LibraryControl::slotSelectItem(double v) {
-    if (!m_pLibraryWidget || !m_pSidebarWidget) {
+
+
+void LibraryControl::slotMoveUp(double v) {
+    if (v > 0) {
+        emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Up, Qt::NoModifier});
+    }
+}
+
+void LibraryControl::slotMoveDown(double v) {
+    if (v > 0) {
+        emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Down, Qt::NoModifier});
+    }
+}
+
+void LibraryControl::slotMoveVertical(double v) {
+    const auto key = (v < 0) ? Qt::Key_Up: Qt::Key_Down;
+    const auto times = static_cast<unsigned short>(v);
+    emitKeyEvent(QKeyEvent{QEvent::KeyPress, key, Qt::NoModifier, QString(), false, times});
+}
+
+void LibraryControl::slotMoveLeft(double v) {
+    if (v > 0) {
+        emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Left, Qt::NoModifier});
+    }
+}
+
+void LibraryControl::slotMoveRight(double v) {
+    if (v > 0) {
+        emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Right, Qt::NoModifier});
+    }
+}
+
+void LibraryControl::slotMoveHorizontal(double v) {
+    const auto key = (v < 0) ? Qt::Key_Left: Qt::Key_Right;
+    const auto times = static_cast<unsigned short>(v);
+    emitKeyEvent(QKeyEvent{QEvent::KeyPress, key, Qt::NoModifier, QString(), false, times});
+}
+
+void LibraryControl::slotMoveFocusForward(double v) {
+    if (v > 0) {
+        emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier});
+    }
+}
+
+void LibraryControl::slotMoveFocusBackward(double v) {
+    if (v > 0) {
+        emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier});
+    }
+}
+
+void LibraryControl::slotMoveFocus(double v) {
+    const auto shift = (v < 0) ? Qt::ShiftModifier: Qt::NoModifier;
+    const auto times = static_cast<unsigned short>(v);
+    emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Tab, shift, QString(), false, times});
+}
+
+void LibraryControl::emitKeyEvent(QKeyEvent&& event) {
+    auto focusWidget = QApplication::focusWidget();
+    if (!focusWidget) {
+        qWarning() << "LibraryControl::emitKeyPress() failed due to no widget having focus";
         return;
     }
-    // Select track if a LibraryView object has focus, otherwise select sidebar item
-    const auto activeView = m_pLibraryWidget->getActiveView();
-    if (activeView && activeView->hasFocus()) {
-        return slotSelectTrack(v);
-    }
-    slotSelectSidebarItem(v);
+    QApplication::sendEvent(focusWidget, &event);
 }
 
 void LibraryControl::slotSelectSidebarItem(double v) {
-    if (!m_pSidebarWidget) {
-        return;
-    }
-    if (v > 0) {
-        QApplication::postEvent(m_pSidebarWidget, new QKeyEvent(
-            QEvent::KeyPress,
-            (int)Qt::Key_Down, Qt::NoModifier, QString(), true));
-        QApplication::postEvent(m_pSidebarWidget, new QKeyEvent(
-            QEvent::KeyRelease,
-            (int)Qt::Key_Down, Qt::NoModifier, QString(), true));
-    } else if (v < 0) {
-        QApplication::postEvent(m_pSidebarWidget, new QKeyEvent(
-            QEvent::KeyPress,
-            (int)Qt::Key_Up, Qt::NoModifier, QString(), true));
-        QApplication::postEvent(m_pSidebarWidget, new QKeyEvent(
-            QEvent::KeyRelease,
-            (int)Qt::Key_Up, Qt::NoModifier, QString(), true));
+    if (v != 0) {
+        const auto key = (v < 0) ? Qt::Key_Up : Qt::Key_Down;
+        emitKeyEvent(QKeyEvent{QEvent::KeyPress, key, Qt::NoModifier});
+        emitKeyEvent(QKeyEvent{QEvent::KeyRelease, key, Qt::NoModifier});
     }
 }
 
@@ -346,14 +407,6 @@ void LibraryControl::slotSelectPrevSidebarItem(double v) {
     }
 }
 
-void LibraryControl::slotToggleFocusWidget(double v) {
-    if (v <= 0 || !m_pSidebarWidget) {
-        return;
-    }
-    QApplication::postEvent(m_pSidebarWidget, new QKeyEvent(
-        QEvent::KeyPress, (int)Qt::Key_Tab, Qt::NoModifier, QString(), true));
-}
-
 void LibraryControl::slotToggleSelectedSidebarItem(double v) {
     if (m_pSidebarWidget && v > 0) {
         m_pSidebarWidget->toggleSelectedItem();
@@ -361,6 +414,7 @@ void LibraryControl::slotToggleSelectedSidebarItem(double v) {
 }
 
 void LibraryControl::slotChooseItem(double v) {
+    // XXX: Make this more generic? If Enter key is mapped correctly maybe we can use that
     if (!m_pLibraryWidget) {
         return;
     }

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -78,6 +78,11 @@ LibraryControl::LibraryControl(Library* pLibrary)
     connect(m_pSelectTrack, SIGNAL(valueChanged(double)),
             this, SLOT(slotSelectTrack(double)));
 
+    // Ignoring no-ops is important since this is for +/- tickers.
+    m_pSelectItem = new ControlObject(ConfigKey("[Playlist]","SelectItemKnob"), false);
+    connect(m_pSelectItem, SIGNAL(valueChanged(double)),
+            this, SLOT(slotSelectItem(double)));
+
     m_pSelectNextSidebarItem = new ControlPushButton(ConfigKey("[Playlist]", "SelectNextPlaylist"));
     connect(m_pSelectNextSidebarItem, SIGNAL(valueChanged(double)),
             this, SLOT(slotSelectNextSidebarItem(double)));
@@ -290,6 +295,17 @@ void LibraryControl::slotSelectTrack(double v) {
         return;
     }
     activeView->moveSelection(i);
+}
+
+void LibraryControl::slotSelectItem(double v) {
+    if (m_pLibraryWidget == NULL || m_pSidebarWidget == NULL) {
+        return;
+    }
+    // Select track if a LibraryView object has focus, otherwise select sidebar item
+    if (m_pLibraryWidget->getActiveView()->hasFocus()) {
+        return slotSelectTrack(v);
+    }
+    slotSelectSidebarItem(v);
 }
 
 void LibraryControl::slotSelectSidebarItem(double v) {

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -103,6 +103,9 @@ LibraryControl::LibraryControl(Library* pLibrary)
     connect(m_pToggleSidebarItem, SIGNAL(valueChanged(double)),
             this, SLOT(slotToggleSelectedSidebarItem(double)));
 
+    m_pChooseItem = new ControlPushButton(ConfigKey("[Playlist]", "ChooseItem"));
+    connect(m_pChooseItem, SIGNAL(valueChanged(double)), this, SLOT(slotChooseItem(double)));
+
     m_pLoadSelectedIntoFirstStopped = new ControlPushButton(ConfigKey("[Playlist]","LoadSelectedIntoFirstStopped"));
     connect(m_pLoadSelectedIntoFirstStopped, SIGNAL(valueChanged(double)),
             this, SLOT(slotLoadSelectedIntoFirstStopped(double)));
@@ -356,6 +359,18 @@ void LibraryControl::slotToggleSelectedSidebarItem(double v) {
     if (m_pSidebarWidget != NULL && v > 0) {
         m_pSidebarWidget->toggleSelectedItem();
     }
+}
+
+void LibraryControl::slotChooseItem(double v) {
+    if (m_pLibraryWidget == NULL) {
+        return;
+    }
+    // Load current track if a LibraryView object has focus
+    if (m_pLibraryWidget->getActiveView()->hasFocus()) {
+        return slotLoadSelectedIntoFirstStopped(v);
+    }
+    // Otherwise toggle the sidebar item expanded state (like a double-click)
+    slotToggleSelectedSidebarItem(v);
 }
 
 void LibraryControl::slotFontSize(double v) {

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -50,6 +50,8 @@ void LoadToGroupController::slotLoadToGroupAndPlay(double v) {
 LibraryControl::LibraryControl(Library* pLibrary)
         : QObject(pLibrary),
           m_pLibrary(pLibrary),
+          m_pLibraryWidget(nullptr),
+          m_pSidebarWidget(nullptr),
           m_numDecks("[Master]", "num_decks", this),
           m_numSamplers("[Master]", "num_samplers", this),
           m_numPreviewDecks("[Master]", "num_preview_decks", this) {

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -50,8 +50,6 @@ void LoadToGroupController::slotLoadToGroupAndPlay(double v) {
 LibraryControl::LibraryControl(Library* pLibrary)
         : QObject(pLibrary),
           m_pLibrary(pLibrary),
-          m_pLibraryWidget(nullptr),
-          m_pSidebarWidget(nullptr),
           m_numDecks("[Master]", "num_decks", this),
           m_numSamplers("[Master]", "num_samplers", this),
           m_numPreviewDecks("[Master]", "num_preview_decks", this) {
@@ -154,7 +152,7 @@ LibraryControl::~LibraryControl() {
 
 void LibraryControl::maybeCreateGroupController(const QString& group) {
     LoadToGroupController* pGroup = m_loadToGroupControllers.value(group, nullptr);
-    if (pGroup == nullptr) {
+    if (!pGroup) {
         pGroup = new LoadToGroupController(this, group);
         m_loadToGroupControllers[group] = pGroup;
     }
@@ -197,7 +195,7 @@ void LibraryControl::slotNumPreviewDecksChanged(double v) {
 }
 
 void LibraryControl::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
-    if (m_pSidebarWidget != nullptr) {
+    if (m_pSidebarWidget) {
         disconnect(m_pSidebarWidget, 0, this, 0);
     }
     m_pSidebarWidget = pSidebarWidget;
@@ -207,7 +205,7 @@ void LibraryControl::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
 
 void LibraryControl::bindWidget(WLibrary* pLibraryWidget, KeyboardEventFilter* pKeyboard) {
     Q_UNUSED(pKeyboard);
-    if (m_pLibraryWidget != nullptr) {
+    if (m_pLibraryWidget) {
         disconnect(m_pLibraryWidget, 0, this, 0);
     }
     m_pLibraryWidget = pLibraryWidget;
@@ -224,7 +222,7 @@ void LibraryControl::sidebarWidgetDeleted() {
 }
 
 void LibraryControl::slotLoadSelectedTrackToGroup(QString group, bool play) {
-    if (m_pLibraryWidget == nullptr) {
+    if (!m_pLibraryWidget) {
         return;
     }
 
@@ -236,7 +234,7 @@ void LibraryControl::slotLoadSelectedTrackToGroup(QString group, bool play) {
 }
 
 void LibraryControl::slotLoadSelectedIntoFirstStopped(double v) {
-    if (m_pLibraryWidget == nullptr) {
+    if (!m_pLibraryWidget) {
         return;
     }
 
@@ -250,7 +248,7 @@ void LibraryControl::slotLoadSelectedIntoFirstStopped(double v) {
 }
 
 void LibraryControl::slotAutoDjAddTop(double v) {
-    if (m_pLibraryWidget == nullptr) {
+    if (!m_pLibraryWidget) {
         return;
     }
 
@@ -264,7 +262,7 @@ void LibraryControl::slotAutoDjAddTop(double v) {
 }
 
 void LibraryControl::slotAutoDjAddBottom(double v) {
-    if (m_pLibraryWidget == nullptr) {
+    if (!m_pLibraryWidget) {
         return;
     }
 
@@ -290,7 +288,7 @@ void LibraryControl::slotSelectPrevTrack(double v) {
 }
 
 void LibraryControl::slotSelectTrack(double v) {
-    if (m_pLibraryWidget == nullptr) {
+    if (!m_pLibraryWidget) {
         return;
     }
 
@@ -304,19 +302,19 @@ void LibraryControl::slotSelectTrack(double v) {
 }
 
 void LibraryControl::slotSelectItem(double v) {
-    if (m_pLibraryWidget == nullptr || m_pSidebarWidget == nullptr) {
+    if (!m_pLibraryWidget || !m_pSidebarWidget) {
         return;
     }
     // Select track if a LibraryView object has focus, otherwise select sidebar item
-    LibraryView* activeView = m_pLibraryWidget->getActiveView();
-    if (activeView != nullptr && activeView->hasFocus()) {
+    const auto activeView = m_pLibraryWidget->getActiveView();
+    if (activeView && activeView->hasFocus()) {
         return slotSelectTrack(v);
     }
     slotSelectSidebarItem(v);
 }
 
 void LibraryControl::slotSelectSidebarItem(double v) {
-    if (m_pSidebarWidget == nullptr) {
+    if (!m_pSidebarWidget) {
         return;
     }
     if (v > 0) {
@@ -349,7 +347,7 @@ void LibraryControl::slotSelectPrevSidebarItem(double v) {
 }
 
 void LibraryControl::slotToggleFocusWidget(double v) {
-    if (v <= 0 || m_pSidebarWidget == nullptr) {
+    if (v <= 0 || !m_pSidebarWidget) {
         return;
     }
     QApplication::postEvent(m_pSidebarWidget, new QKeyEvent(
@@ -357,18 +355,18 @@ void LibraryControl::slotToggleFocusWidget(double v) {
 }
 
 void LibraryControl::slotToggleSelectedSidebarItem(double v) {
-    if (m_pSidebarWidget != nullptr && v > 0) {
+    if (m_pSidebarWidget && v > 0) {
         m_pSidebarWidget->toggleSelectedItem();
     }
 }
 
 void LibraryControl::slotChooseItem(double v) {
-    if (m_pLibraryWidget == nullptr) {
+    if (!m_pLibraryWidget) {
         return;
     }
     // Load current track if a LibraryView object has focus
-    LibraryView* activeView = m_pLibraryWidget->getActiveView();
-    if (activeView != nullptr && activeView->hasFocus()) {
+    const auto activeView = m_pLibraryWidget->getActiveView();
+    if (activeView && activeView->hasFocus()) {
         return slotLoadSelectedIntoFirstStopped(v);
     }
     // Otherwise toggle the sidebar item expanded state (like a double-click)

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -61,39 +61,39 @@ LibraryControl::LibraryControl(Library* pLibrary)
     m_numPreviewDecks.connectValueChanged(SLOT(slotNumPreviewDecksChanged(double)));
 
     // Controls to navigate vertically within currently focussed widget (up/down buttons)
-    m_pMoveUp = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveUp"));
-    m_pMoveDown = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveDown"));
-    m_pMoveVertical = std::make_unique<ControlObject>(ConfigKey("[Playlist]", "MoveVertical"), false);
+    m_pMoveUp = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveUp"));
+    m_pMoveDown = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveDown"));
+    m_pMoveVertical = std::make_unique<ControlObject>(ConfigKey("[Library]", "MoveVertical"), false);
     connect(m_pMoveUp.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveUp(double)));
     connect(m_pMoveDown.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveDown(double)));
     connect(m_pMoveVertical.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveVertical(double)));
 
     // Controls to navigate vertically within currently focussed widget (up/down buttons)
-    m_pScrollUp = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "ScrollUp"));
-    m_pScrollDown = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "ScrollDown"));
-    m_pScrollVertical = std::make_unique<ControlObject>(ConfigKey("[Playlist]", "ScrollVertical"), false);
+    m_pScrollUp = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "ScrollUp"));
+    m_pScrollDown = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "ScrollDown"));
+    m_pScrollVertical = std::make_unique<ControlObject>(ConfigKey("[Library]", "ScrollVertical"), false);
     connect(m_pScrollUp.get(), SIGNAL(valueChanged(double)),this, SLOT(slotScrollUp(double)));
     connect(m_pScrollDown.get(), SIGNAL(valueChanged(double)),this, SLOT(slotScrollDown(double)));
     connect(m_pScrollVertical.get(), SIGNAL(valueChanged(double)),this, SLOT(slotScrollVertical(double)));
 
     // Controls to navigate horizontally within currently selected item (left/right buttons)
-    m_pMoveLeft = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveLeft"));
-    m_pMoveRight = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveRight"));
-    m_pMoveHorizontal = std::make_unique<ControlObject>(ConfigKey("[Playlist]", "MoveHorizontal"), false);
+    m_pMoveLeft = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveLeft"));
+    m_pMoveRight = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveRight"));
+    m_pMoveHorizontal = std::make_unique<ControlObject>(ConfigKey("[Library]", "MoveHorizontal"), false);
     connect(m_pMoveLeft.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveLeft(double)));
     connect(m_pMoveRight.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveRight(double)));
     connect(m_pMoveHorizontal.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveHorizontal(double)));
 
     // Control to navigate between widgets (tab/shit+tab button)
-    m_pMoveFocusForward = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveFocusForward"));
-    m_pMoveFocusBackward = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveFocusBackward"));
-    m_pMoveFocus = std::make_unique<ControlObject>(ConfigKey("[Playlist]", "MoveFocus"), false);
+    m_pMoveFocusForward = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveFocusForward"));
+    m_pMoveFocusBackward = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveFocusBackward"));
+    m_pMoveFocus = std::make_unique<ControlObject>(ConfigKey("[Library]", "MoveFocus"), false);
     connect(m_pMoveFocusForward.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocusForward(double)));
     connect(m_pMoveFocusBackward.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocusBackward(double)));
     connect(m_pMoveFocus.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocus(double)));
 
     // Control to choose the currently selected item in focussed widget (double click)
-    m_pChooseItem = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "ChooseItem"));
+    m_pChooseItem = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "ChooseItem"));
     connect(m_pChooseItem.get(), SIGNAL(valueChanged(double)), this, SLOT(slotChooseItem(double)));
 
 

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -18,22 +18,19 @@
 LoadToGroupController::LoadToGroupController(QObject* pParent, const QString& group)
         : QObject(pParent),
           m_group(group) {
-    m_pLoadControl = new ControlPushButton(ConfigKey(group, "LoadSelectedTrack"));
-    connect(m_pLoadControl, SIGNAL(valueChanged(double)),
+    m_pLoadControl = std::make_unique<ControlPushButton>(ConfigKey(group, "LoadSelectedTrack"));
+    connect(m_pLoadControl.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotLoadToGroup(double)));
 
-    m_pLoadAndPlayControl = new ControlPushButton(ConfigKey(group, "LoadSelectedTrackAndPlay"));
-    connect(m_pLoadAndPlayControl, SIGNAL(valueChanged(double)),
+    m_pLoadAndPlayControl = std::make_unique<ControlPushButton>(ConfigKey(group, "LoadSelectedTrackAndPlay"));
+    connect(m_pLoadAndPlayControl.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotLoadToGroupAndPlay(double)));
 
     connect(this, SIGNAL(loadToGroup(QString, bool)),
             pParent, SLOT(slotLoadSelectedTrackToGroup(QString, bool)));
 }
 
-LoadToGroupController::~LoadToGroupController() {
-    delete m_pLoadControl;
-    delete m_pLoadAndPlayControl;
-}
+LoadToGroupController::~LoadToGroupController() = default;
 
 void LoadToGroupController::slotLoadToGroup(double v) {
     if (v > 0) {
@@ -64,120 +61,103 @@ LibraryControl::LibraryControl(Library* pLibrary)
     m_numPreviewDecks.connectValueChanged(SLOT(slotNumPreviewDecksChanged(double)));
 
     // Controls to navigate vertically within currently focussed widget (up/down buttons)
-    m_pMoveUp = new ControlPushButton(ConfigKey("[Playlist]", "MoveUp"));
-    m_pMoveDown = new ControlPushButton(ConfigKey("[Playlist]", "MoveDown"));
-    m_pMoveVertical = new ControlObject(ConfigKey("[Playlist]", "MoveVertical"), false);
-    connect(m_pMoveUp, SIGNAL(valueChanged(double)),this, SLOT(slotMoveUp(double)));
-    connect(m_pMoveDown, SIGNAL(valueChanged(double)),this, SLOT(slotMoveDown(double)));
-    connect(m_pMoveVertical, SIGNAL(valueChanged(double)),this, SLOT(slotMoveVertical(double)));
+    m_pMoveUp = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveUp"));
+    m_pMoveDown = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveDown"));
+    m_pMoveVertical = std::make_unique<ControlObject>(ConfigKey("[Playlist]", "MoveVertical"), false);
+    connect(m_pMoveUp.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveUp(double)));
+    connect(m_pMoveDown.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveDown(double)));
+    connect(m_pMoveVertical.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveVertical(double)));
 
     // Controls to navigate horizontally within currently selected item (left/right buttons)
-    m_pMoveLeft = new ControlPushButton(ConfigKey("[Playlist]", "MoveLeft"));
-    m_pMoveRight = new ControlPushButton(ConfigKey("[Playlist]", "MoveRight"));
-    m_pMoveHorizontal = new ControlObject(ConfigKey("[Playlist]", "MoveHorizontal"), false);
-    connect(m_pMoveLeft, SIGNAL(valueChanged(double)),this, SLOT(slotMoveLeft(double)));
-    connect(m_pMoveRight, SIGNAL(valueChanged(double)),this, SLOT(slotMoveRight(double)));
-    connect(m_pMoveHorizontal, SIGNAL(valueChanged(double)),this, SLOT(slotMoveHorizontal(double)));
+    m_pMoveLeft = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveLeft"));
+    m_pMoveRight = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveRight"));
+    m_pMoveHorizontal = std::make_unique<ControlObject>(ConfigKey("[Playlist]", "MoveHorizontal"), false);
+    connect(m_pMoveLeft.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveLeft(double)));
+    connect(m_pMoveRight.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveRight(double)));
+    connect(m_pMoveHorizontal.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveHorizontal(double)));
 
     // Control to navigate between widgets (tab/shit+tab button)
-    m_pMoveFocusForward = new ControlPushButton(ConfigKey("[Playlist]", "MoveFocusForward"));
-    m_pMoveFocusBackward = new ControlPushButton(ConfigKey("[Playlist]", "MoveFocusBackward"));
-    m_pMoveFocus = new ControlObject(ConfigKey("[Playlist]", "MoveFocus"), false);
-    connect(m_pMoveFocusForward, SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocusForward(double)));
-    connect(m_pMoveFocusBackward, SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocusBackward(double)));
-    connect(m_pMoveFocus, SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocus(double)));
+    m_pMoveFocusForward = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveFocusForward"));
+    m_pMoveFocusBackward = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveFocusBackward"));
+    m_pMoveFocus = std::make_unique<ControlObject>(ConfigKey("[Playlist]", "MoveFocus"), false);
+    connect(m_pMoveFocusForward.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocusForward(double)));
+    connect(m_pMoveFocusBackward.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocusBackward(double)));
+    connect(m_pMoveFocus.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocus(double)));
 
     // Control to choose the currently selected item in focussed widget (double click)
-    m_pChooseItem = new ControlPushButton(ConfigKey("[Playlist]", "ChooseItem"));
-    connect(m_pChooseItem, SIGNAL(valueChanged(double)), this, SLOT(slotChooseItem(double)));
+    m_pChooseItem = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "ChooseItem"));
+    connect(m_pChooseItem.get(), SIGNAL(valueChanged(double)), this, SLOT(slotChooseItem(double)));
 
 
     // Font sizes
-    m_pFontSizeKnob = new ControlObject(
+    m_pFontSizeKnob = std::make_unique<ControlObject>(
             ConfigKey("[Library]", "font_size_knob"), false);
-    connect(m_pFontSizeKnob, SIGNAL(valueChanged(double)),
+    connect(m_pFontSizeKnob.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotFontSize(double)));
 
-    m_pFontSizeDecrement = new ControlPushButton(
+    m_pFontSizeDecrement = std::make_unique<ControlPushButton>(
             ConfigKey("[Library]", "font_size_decrement"));
-    connect(m_pFontSizeDecrement, SIGNAL(valueChanged(double)),
+    connect(m_pFontSizeDecrement.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotDecrementFontSize(double)));
 
-    m_pFontSizeIncrement = new ControlPushButton(
+    m_pFontSizeIncrement = std::make_unique<ControlPushButton>(
             ConfigKey("[Library]", "font_size_increment"));
-    connect(m_pFontSizeIncrement, SIGNAL(valueChanged(double)),
+    connect(m_pFontSizeIncrement.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotIncrementFontSize(double)));
 
 
     /// Deprecated controls
-    m_pSelectNextTrack = new ControlPushButton(ConfigKey("[Playlist]", "SelectNextTrack"));
-    connect(m_pSelectNextTrack, SIGNAL(valueChanged(double)),
+    m_pSelectNextTrack = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "SelectNextTrack"));
+    connect(m_pSelectNextTrack.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotSelectNextTrack(double)));
 
 
-    m_pSelectPrevTrack = new ControlPushButton(ConfigKey("[Playlist]", "SelectPrevTrack"));
-    connect(m_pSelectPrevTrack, SIGNAL(valueChanged(double)),
+    m_pSelectPrevTrack = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "SelectPrevTrack"));
+    connect(m_pSelectPrevTrack.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotSelectPrevTrack(double)));
 
     // Ignoring no-ops is important since this is for +/- tickers.
-    m_pSelectTrack = new ControlObject(ConfigKey("[Playlist]","SelectTrackKnob"), false);
-    connect(m_pSelectTrack, SIGNAL(valueChanged(double)),
+    m_pSelectTrack = std::make_unique<ControlObject>(ConfigKey("[Playlist]","SelectTrackKnob"), false);
+    connect(m_pSelectTrack.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotSelectTrack(double)));
 
 
-    m_pSelectNextSidebarItem = new ControlPushButton(ConfigKey("[Playlist]", "SelectNextPlaylist"));
-    connect(m_pSelectNextSidebarItem, SIGNAL(valueChanged(double)),
+    m_pSelectNextSidebarItem = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "SelectNextPlaylist"));
+    connect(m_pSelectNextSidebarItem.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotSelectNextSidebarItem(double)));
 
-    m_pSelectPrevSidebarItem = new ControlPushButton(ConfigKey("[Playlist]", "SelectPrevPlaylist"));
-    connect(m_pSelectPrevSidebarItem, SIGNAL(valueChanged(double)),
+    m_pSelectPrevSidebarItem = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "SelectPrevPlaylist"));
+    connect(m_pSelectPrevSidebarItem.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotSelectPrevSidebarItem(double)));
 
     // Ignoring no-ops is important since this is for +/- tickers.
-    m_pSelectSidebarItem = new ControlObject(ConfigKey("[Playlist]", "SelectPlaylist"), false);
-    connect(m_pSelectSidebarItem, SIGNAL(valueChanged(double)),
+    m_pSelectSidebarItem = std::make_unique<ControlObject>(ConfigKey("[Playlist]", "SelectPlaylist"), false);
+    connect(m_pSelectSidebarItem.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotSelectSidebarItem(double)));
 
-    m_pToggleSidebarItem = new ControlPushButton(ConfigKey("[Playlist]", "ToggleSelectedSidebarItem"));
-    connect(m_pToggleSidebarItem, SIGNAL(valueChanged(double)),
+    m_pToggleSidebarItem = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "ToggleSelectedSidebarItem"));
+    connect(m_pToggleSidebarItem.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotToggleSelectedSidebarItem(double)));
 
-    m_pLoadSelectedIntoFirstStopped = new ControlPushButton(ConfigKey("[Playlist]","LoadSelectedIntoFirstStopped"));
-    connect(m_pLoadSelectedIntoFirstStopped, SIGNAL(valueChanged(double)),
+    m_pLoadSelectedIntoFirstStopped = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]","LoadSelectedIntoFirstStopped"));
+    connect(m_pLoadSelectedIntoFirstStopped.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotLoadSelectedIntoFirstStopped(double)));
 
-    m_pAutoDjAddTop = new ControlPushButton(ConfigKey("[Playlist]","AutoDjAddTop"));
-    connect(m_pAutoDjAddTop, SIGNAL(valueChanged(double)),
+    m_pAutoDjAddTop = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]","AutoDjAddTop"));
+    connect(m_pAutoDjAddTop.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotAutoDjAddTop(double)));
 
-    m_pAutoDjAddBottom = new ControlPushButton(ConfigKey("[Playlist]","AutoDjAddBottom"));
-    connect(m_pAutoDjAddBottom, SIGNAL(valueChanged(double)),
+    m_pAutoDjAddBottom = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]","AutoDjAddBottom"));
+    connect(m_pAutoDjAddBottom.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotAutoDjAddBottom(double)));
 
 }
 
-LibraryControl::~LibraryControl() {
-   delete m_pSelectNextTrack;
-   delete m_pSelectPrevTrack;
-   delete m_pSelectTrack;
-   delete m_pSelectNextSidebarItem;
-   delete m_pSelectPrevSidebarItem;
-   delete m_pSelectSidebarItem;
-   delete m_pToggleSidebarItem;
-   delete m_pLoadSelectedIntoFirstStopped;
-   delete m_pAutoDjAddTop;
-   delete m_pAutoDjAddBottom;
-   delete m_pFontSizeKnob;
-   delete m_pFontSizeDecrement;
-   delete m_pFontSizeIncrement;
-   deleteMapValues(&m_loadToGroupControllers);
-}
+LibraryControl::~LibraryControl() = default;
 
 void LibraryControl::maybeCreateGroupController(const QString& group) {
-    LoadToGroupController* pGroup = m_loadToGroupControllers.value(group, nullptr);
-    if (!pGroup) {
-        pGroup = new LoadToGroupController(this, group);
-        m_loadToGroupControllers[group] = pGroup;
+    if (m_loadToGroupControllers.find(group) == m_loadToGroupControllers.end()) {
+        m_loadToGroupControllers.emplace(group, std::make_unique<LoadToGroupController>(this, group));
     }
 }
 
@@ -204,6 +184,7 @@ void LibraryControl::slotNumSamplersChanged(double v) {
         maybeCreateGroupController(PlayerManager::groupForSampler(i));
     }
 }
+
 
 void LibraryControl::slotNumPreviewDecksChanged(double v) {
     int iNumPreviewDecks = v;
@@ -276,7 +257,7 @@ void LibraryControl::slotAutoDjAddTop(double v) {
     }
 
     if (v > 0) {
-        LibraryView* activeView = m_pLibraryWidget->getActiveView();
+        auto activeView = m_pLibraryWidget->getActiveView();
         if (!activeView) {
             return;
         }
@@ -290,7 +271,7 @@ void LibraryControl::slotAutoDjAddBottom(double v) {
     }
 
     if (v > 0) {
-        LibraryView* activeView = m_pLibraryWidget->getActiveView();
+        auto activeView = m_pLibraryWidget->getActiveView();
         if (!activeView) {
             return;
         }
@@ -317,7 +298,7 @@ void LibraryControl::slotSelectTrack(double v) {
 
     int i = (int)v;
 
-    LibraryView* activeView = m_pLibraryWidget->getActiveView();
+    auto activeView = m_pLibraryWidget->getActiveView();
     if (!activeView) {
         return;
     }

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -329,7 +329,7 @@ void LibraryControl::slotMoveDown(double v) {
 
 void LibraryControl::slotMoveVertical(double v) {
     const auto key = (v < 0) ? Qt::Key_Up: Qt::Key_Down;
-    const auto times = static_cast<unsigned short>(v);
+    const auto times = static_cast<unsigned short>(std::abs(v));
     emitKeyEvent(QKeyEvent{QEvent::KeyPress, key, Qt::NoModifier, QString(), false, times});
 }
 
@@ -347,7 +347,7 @@ void LibraryControl::slotScrollDown(double v) {
 
 void LibraryControl::slotScrollVertical(double v) {
     const auto key = (v < 0) ? Qt::Key_PageUp: Qt::Key_PageDown;
-    const auto times = static_cast<unsigned short>(v);
+    const auto times = static_cast<unsigned short>(std::abs(v));
     emitKeyEvent(QKeyEvent{QEvent::KeyPress, key, Qt::NoModifier, QString(), false, times});
 }
 
@@ -365,7 +365,7 @@ void LibraryControl::slotMoveRight(double v) {
 
 void LibraryControl::slotMoveHorizontal(double v) {
     const auto key = (v < 0) ? Qt::Key_Left: Qt::Key_Right;
-    const auto times = static_cast<unsigned short>(v);
+    const auto times = static_cast<unsigned short>(std::abs(v));
     emitKeyEvent(QKeyEvent{QEvent::KeyPress, key, Qt::NoModifier, QString(), false, times});
 }
 
@@ -383,7 +383,7 @@ void LibraryControl::slotMoveFocusBackward(double v) {
 
 void LibraryControl::slotMoveFocus(double v) {
     const auto shift = (v < 0) ? Qt::ShiftModifier: Qt::NoModifier;
-    const auto times = static_cast<unsigned short>(v);
+    const auto times = static_cast<unsigned short>(std::abs(v));
     emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Tab, shift, QString(), false, times});
 }
 
@@ -398,7 +398,9 @@ void LibraryControl::emitKeyEvent(QKeyEvent&& event) {
         }
     }
     // Send the event pointer to the currently focused widget
-    QApplication::sendEvent(focusWidget, &event);
+    for (auto i = 0; i < event.count(); ++i) {
+        QApplication::sendEvent(focusWidget, &event);
+    }
 }
 
 void LibraryControl::setLibraryFocus() {

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -96,6 +96,14 @@ LibraryControl::LibraryControl(Library* pLibrary)
     m_pChooseItem = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "ChooseItem"));
     connect(m_pChooseItem.get(), SIGNAL(valueChanged(double)), this, SLOT(slotChooseItem(double)));
 
+    // Auto DJ controls
+    m_pAutoDjAddTop = std::make_unique<ControlPushButton>(ConfigKey("[Library]","AutoDjAddTop"));
+    connect(m_pAutoDjAddTop.get(), SIGNAL(valueChanged(double)),
+            this, SLOT(slotAutoDjAddTop(double)));
+
+    m_pAutoDjAddBottom = std::make_unique<ControlPushButton>(ConfigKey("[Library]","AutoDjAddBottom"));
+    connect(m_pAutoDjAddBottom.get(), SIGNAL(valueChanged(double)),
+            this, SLOT(slotAutoDjAddBottom(double)));
 
     // Font sizes
     m_pFontSizeKnob = std::make_unique<ControlObject>(
@@ -151,14 +159,8 @@ LibraryControl::LibraryControl(Library* pLibrary)
     connect(m_pLoadSelectedIntoFirstStopped.get(), SIGNAL(valueChanged(double)),
             this, SLOT(slotLoadSelectedIntoFirstStopped(double)));
 
-    m_pAutoDjAddTop = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]","AutoDjAddTop"));
-    connect(m_pAutoDjAddTop.get(), SIGNAL(valueChanged(double)),
-            this, SLOT(slotAutoDjAddTop(double)));
-
-    m_pAutoDjAddBottom = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]","AutoDjAddBottom"));
-    connect(m_pAutoDjAddBottom.get(), SIGNAL(valueChanged(double)),
-            this, SLOT(slotAutoDjAddBottom(double)));
-
+    ControlDoublePrivate::insertAlias(ConfigKey("[Playlist]", "AutoDjAddTop"), ConfigKey("[Library]", "AutoDjAddTop"));
+    ControlDoublePrivate::insertAlias(ConfigKey("[Playlist]", "AutoDjAddBottom"), ConfigKey("[Library]", "AutoDjAddBottom"));
 }
 
 LibraryControl::~LibraryControl() = default;

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -68,6 +68,14 @@ LibraryControl::LibraryControl(Library* pLibrary)
     connect(m_pMoveDown.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveDown(double)));
     connect(m_pMoveVertical.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveVertical(double)));
 
+    // Controls to navigate vertically within currently focussed widget (up/down buttons)
+    m_pScrollUp = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "ScrollUp"));
+    m_pScrollDown = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "ScrollDown"));
+    m_pScrollVertical = std::make_unique<ControlObject>(ConfigKey("[Playlist]", "ScrollVertical"), false);
+    connect(m_pScrollUp.get(), SIGNAL(valueChanged(double)),this, SLOT(slotScrollUp(double)));
+    connect(m_pScrollDown.get(), SIGNAL(valueChanged(double)),this, SLOT(slotScrollDown(double)));
+    connect(m_pScrollVertical.get(), SIGNAL(valueChanged(double)),this, SLOT(slotScrollVertical(double)));
+
     // Controls to navigate horizontally within currently selected item (left/right buttons)
     m_pMoveLeft = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveLeft"));
     m_pMoveRight = std::make_unique<ControlPushButton>(ConfigKey("[Playlist]", "MoveRight"));
@@ -321,6 +329,24 @@ void LibraryControl::slotMoveDown(double v) {
 
 void LibraryControl::slotMoveVertical(double v) {
     const auto key = (v < 0) ? Qt::Key_Up: Qt::Key_Down;
+    const auto times = static_cast<unsigned short>(v);
+    emitKeyEvent(QKeyEvent{QEvent::KeyPress, key, Qt::NoModifier, QString(), false, times});
+}
+
+void LibraryControl::slotScrollUp(double v) {
+    if (v > 0) {
+        emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_PageUp, Qt::NoModifier});
+    }
+}
+
+void LibraryControl::slotScrollDown(double v) {
+    if (v > 0) {
+        emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_PageDown, Qt::NoModifier});
+    }
+}
+
+void LibraryControl::slotScrollVertical(double v) {
+    const auto key = (v < 0) ? Qt::Key_PageUp: Qt::Key_PageDown;
     const auto times = static_cast<unsigned short>(v);
     emitKeyEvent(QKeyEvent{QEvent::KeyPress, key, Qt::NoModifier, QString(), false, times});
 }

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -96,6 +96,9 @@ LibraryControl::LibraryControl(Library* pLibrary)
     connect(m_pSelectSidebarItem, SIGNAL(valueChanged(double)),
             this, SLOT(slotSelectSidebarItem(double)));
 
+    m_pToggleFocusWidget = new ControlPushButton(ConfigKey("[Playlist]", "ToggleFocusWidget"));
+    connect(m_pToggleFocusWidget, SIGNAL(valueChanged(double)),this, SLOT(slotToggleFocusWidget(double)));
+
     m_pToggleSidebarItem = new ControlPushButton(ConfigKey("[Playlist]", "ToggleSelectedSidebarItem"));
     connect(m_pToggleSidebarItem, SIGNAL(valueChanged(double)),
             this, SLOT(slotToggleSelectedSidebarItem(double)));
@@ -339,6 +342,14 @@ void LibraryControl::slotSelectPrevSidebarItem(double v) {
     if (v > 0) {
         slotSelectSidebarItem(-1);
     }
+}
+
+void LibraryControl::slotToggleFocusWidget(double v) {
+    if (v <= 0 || m_pSidebarWidget == NULL) {
+        return;
+    }
+    QApplication::postEvent(m_pSidebarWidget, new QKeyEvent(
+        QEvent::KeyPress, (int)Qt::Key_Tab, Qt::NoModifier, QString(), true));
 }
 
 void LibraryControl::slotToggleSelectedSidebarItem(double v) {

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -380,10 +380,15 @@ void LibraryControl::slotMoveFocus(double v) {
 
 void LibraryControl::emitKeyEvent(QKeyEvent&& event) {
     auto focusWidget = QApplication::focusWidget();
+    // Set the sidebar as the default focused widget
     if (!focusWidget) {
-        qWarning() << "LibraryControl::emitKeyPress() failed due to no widget having focus";
-        return;
+        if (!m_pSidebarWidget) {
+            return;
+        }
+        m_pSidebarWidget->setFocus();
+        focusWidget = m_pSidebarWidget;
     }
+    // Send a pointer to the event to focused widget
     QApplication::sendEvent(focusWidget, &event);
 }
 

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -308,7 +308,8 @@ void LibraryControl::slotSelectItem(double v) {
         return;
     }
     // Select track if a LibraryView object has focus, otherwise select sidebar item
-    if (m_pLibraryWidget->getActiveView()->hasFocus()) {
+    LibraryView* activeView = m_pLibraryWidget->getActiveView();
+    if (activeView != nullptr && activeView->hasFocus()) {
         return slotSelectTrack(v);
     }
     slotSelectSidebarItem(v);
@@ -366,7 +367,8 @@ void LibraryControl::slotChooseItem(double v) {
         return;
     }
     // Load current track if a LibraryView object has focus
-    if (m_pLibraryWidget->getActiveView()->hasFocus()) {
+    LibraryView* activeView = m_pLibraryWidget->getActiveView();
+    if (activeView != nullptr && activeView->hasFocus()) {
         return slotLoadSelectedIntoFirstStopped(v);
     }
     // Otherwise toggle the sidebar item expanded state (like a double-click)

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -388,17 +388,26 @@ void LibraryControl::slotMoveFocus(double v) {
 }
 
 void LibraryControl::emitKeyEvent(QKeyEvent&& event) {
+    // Ensure a valid widget has the keyboard focus
     auto focusWidget = QApplication::focusWidget();
-    // Set the sidebar as the default focused widget
     if (!focusWidget) {
-        if (!m_pSidebarWidget) {
+        setLibraryFocus();
+        focusWidget = QApplication::focusWidget();
+        if (!focusWidget) {
             return;
         }
-        m_pSidebarWidget->setFocus();
-        focusWidget = m_pSidebarWidget;
     }
-    // Send a pointer to the event to focused widget
+    // Send the event pointer to the currently focused widget
     QApplication::sendEvent(focusWidget, &event);
+}
+
+void LibraryControl::setLibraryFocus() {
+    if (m_pSidebarWidget) {
+        // XXX: Set the focus of the library panel directly instead of sending tab from sidebar
+        m_pSidebarWidget->setFocus();
+        QKeyEvent event(QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier);
+        QApplication::sendEvent(m_pSidebarWidget, &event);
+    }
 }
 
 void LibraryControl::slotSelectSidebarItem(double v) {

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -50,8 +50,8 @@ void LoadToGroupController::slotLoadToGroupAndPlay(double v) {
 LibraryControl::LibraryControl(Library* pLibrary)
         : QObject(pLibrary),
           m_pLibrary(pLibrary),
-          m_pLibraryWidget(NULL),
-          m_pSidebarWidget(NULL),
+          m_pLibraryWidget(nullptr),
+          m_pSidebarWidget(nullptr),
           m_numDecks("[Master]", "num_decks", this),
           m_numSamplers("[Master]", "num_samplers", this),
           m_numPreviewDecks("[Master]", "num_preview_decks", this) {
@@ -153,8 +153,8 @@ LibraryControl::~LibraryControl() {
 }
 
 void LibraryControl::maybeCreateGroupController(const QString& group) {
-    LoadToGroupController* pGroup = m_loadToGroupControllers.value(group, NULL);
-    if (pGroup == NULL) {
+    LoadToGroupController* pGroup = m_loadToGroupControllers.value(group, nullptr);
+    if (pGroup == nullptr) {
         pGroup = new LoadToGroupController(this, group);
         m_loadToGroupControllers[group] = pGroup;
     }
@@ -197,7 +197,7 @@ void LibraryControl::slotNumPreviewDecksChanged(double v) {
 }
 
 void LibraryControl::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
-    if (m_pSidebarWidget != NULL) {
+    if (m_pSidebarWidget != nullptr) {
         disconnect(m_pSidebarWidget, 0, this, 0);
     }
     m_pSidebarWidget = pSidebarWidget;
@@ -207,7 +207,7 @@ void LibraryControl::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
 
 void LibraryControl::bindWidget(WLibrary* pLibraryWidget, KeyboardEventFilter* pKeyboard) {
     Q_UNUSED(pKeyboard);
-    if (m_pLibraryWidget != NULL) {
+    if (m_pLibraryWidget != nullptr) {
         disconnect(m_pLibraryWidget, 0, this, 0);
     }
     m_pLibraryWidget = pLibraryWidget;
@@ -216,15 +216,15 @@ void LibraryControl::bindWidget(WLibrary* pLibraryWidget, KeyboardEventFilter* p
 }
 
 void LibraryControl::libraryWidgetDeleted() {
-    m_pLibraryWidget = NULL;
+    m_pLibraryWidget = nullptr;
 }
 
 void LibraryControl::sidebarWidgetDeleted() {
-    m_pSidebarWidget = NULL;
+    m_pSidebarWidget = nullptr;
 }
 
 void LibraryControl::slotLoadSelectedTrackToGroup(QString group, bool play) {
-    if (m_pLibraryWidget == NULL) {
+    if (m_pLibraryWidget == nullptr) {
         return;
     }
 
@@ -236,7 +236,7 @@ void LibraryControl::slotLoadSelectedTrackToGroup(QString group, bool play) {
 }
 
 void LibraryControl::slotLoadSelectedIntoFirstStopped(double v) {
-    if (m_pLibraryWidget == NULL) {
+    if (m_pLibraryWidget == nullptr) {
         return;
     }
 
@@ -250,7 +250,7 @@ void LibraryControl::slotLoadSelectedIntoFirstStopped(double v) {
 }
 
 void LibraryControl::slotAutoDjAddTop(double v) {
-    if (m_pLibraryWidget == NULL) {
+    if (m_pLibraryWidget == nullptr) {
         return;
     }
 
@@ -264,7 +264,7 @@ void LibraryControl::slotAutoDjAddTop(double v) {
 }
 
 void LibraryControl::slotAutoDjAddBottom(double v) {
-    if (m_pLibraryWidget == NULL) {
+    if (m_pLibraryWidget == nullptr) {
         return;
     }
 
@@ -290,7 +290,7 @@ void LibraryControl::slotSelectPrevTrack(double v) {
 }
 
 void LibraryControl::slotSelectTrack(double v) {
-    if (m_pLibraryWidget == NULL) {
+    if (m_pLibraryWidget == nullptr) {
         return;
     }
 
@@ -304,7 +304,7 @@ void LibraryControl::slotSelectTrack(double v) {
 }
 
 void LibraryControl::slotSelectItem(double v) {
-    if (m_pLibraryWidget == NULL || m_pSidebarWidget == NULL) {
+    if (m_pLibraryWidget == nullptr || m_pSidebarWidget == nullptr) {
         return;
     }
     // Select track if a LibraryView object has focus, otherwise select sidebar item
@@ -315,7 +315,7 @@ void LibraryControl::slotSelectItem(double v) {
 }
 
 void LibraryControl::slotSelectSidebarItem(double v) {
-    if (m_pSidebarWidget == NULL) {
+    if (m_pSidebarWidget == nullptr) {
         return;
     }
     if (v > 0) {
@@ -348,7 +348,7 @@ void LibraryControl::slotSelectPrevSidebarItem(double v) {
 }
 
 void LibraryControl::slotToggleFocusWidget(double v) {
-    if (v <= 0 || m_pSidebarWidget == NULL) {
+    if (v <= 0 || m_pSidebarWidget == nullptr) {
         return;
     }
     QApplication::postEvent(m_pSidebarWidget, new QKeyEvent(
@@ -356,13 +356,13 @@ void LibraryControl::slotToggleFocusWidget(double v) {
 }
 
 void LibraryControl::slotToggleSelectedSidebarItem(double v) {
-    if (m_pSidebarWidget != NULL && v > 0) {
+    if (m_pSidebarWidget != nullptr && v > 0) {
         m_pSidebarWidget->toggleSelectedItem();
     }
 }
 
 void LibraryControl::slotChooseItem(double v) {
-    if (m_pLibraryWidget == NULL) {
+    if (m_pLibraryWidget == nullptr) {
         return;
     }
     // Load current track if a LibraryView object has focus

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -89,12 +89,12 @@ class LibraryControl : public QObject {
     // Give the keyboard focus to the main library pane
     void setLibraryFocus();
 
-    // Controls to navigate vertically within currently focussed widget (up/down buttons)
+    // Controls to navigate vertically within currently focused widget (up/down buttons)
     std::unique_ptr<ControlPushButton> m_pMoveUp;
     std::unique_ptr<ControlPushButton> m_pMoveDown;
     std::unique_ptr<ControlObject> m_pMoveVertical;
 
-    // Controls to QUICKLY navigate vertically within currently focussed widget (pageup/pagedown buttons)
+    // Controls to QUICKLY navigate vertically within currently focused widget (pageup/pagedown buttons)
     std::unique_ptr<ControlPushButton> m_pScrollUp;
     std::unique_ptr<ControlPushButton> m_pScrollDown;
     std::unique_ptr<ControlObject> m_pScrollVertical;
@@ -109,7 +109,7 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlPushButton> m_pMoveFocusBackward;
     std::unique_ptr<ControlObject> m_pMoveFocus;
 
-    // Control to choose the currently selected item in focussed widget (double click)
+    // Control to choose the currently selected item in focused widget (double click)
     std::unique_ptr<ControlObject> m_pChooseItem;
 
     // Font sizes

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -78,49 +78,49 @@ class LibraryControl : public QObject {
     void slotDecrementFontSize(double v);
 
   private:
-    Library* m_pLibrary = nullptr;
+    Library* m_pLibrary;
 
     // Simulate pressing a key on the keyboard
     void emitKeyEvent(QKeyEvent&& event);
 
     // Controls to navigate vertically within currently focussed widget (up/down buttons)
-    ControlPushButton* m_pMoveUp = nullptr;
-    ControlPushButton* m_pMoveDown = nullptr;
-    ControlObject* m_pMoveVertical = nullptr;
+    ControlPushButton* m_pMoveUp;
+    ControlPushButton* m_pMoveDown;
+    ControlObject* m_pMoveVertical;
 
     // Controls to navigate horizontally within currently selected item (left/right buttons)
-    ControlPushButton* m_pMoveLeft = nullptr;
-    ControlPushButton* m_pMoveRight = nullptr;
-    ControlObject* m_pMoveHorizontal = nullptr;
+    ControlPushButton* m_pMoveLeft;
+    ControlPushButton* m_pMoveRight;
+    ControlObject* m_pMoveHorizontal;
 
     // Controls to navigate between widgets (tab/shit+tab button)
-    ControlPushButton* m_pMoveFocusForward = nullptr;
-    ControlPushButton* m_pMoveFocusBackward = nullptr;
-    ControlObject* m_pMoveFocus = nullptr;
+    ControlPushButton* m_pMoveFocusForward;
+    ControlPushButton* m_pMoveFocusBackward;
+    ControlObject* m_pMoveFocus;
 
     // Control to choose the currently selected item in focussed widget (double click)
-    ControlObject* m_pChooseItem = nullptr;
+    ControlObject* m_pChooseItem;
 
     // Font sizes
-    ControlPushButton* m_pFontSizeIncrement = nullptr;
-    ControlPushButton* m_pFontSizeDecrement = nullptr;
-    ControlObject* m_pFontSizeKnob = nullptr;
+    ControlPushButton* m_pFontSizeIncrement;
+    ControlPushButton* m_pFontSizeDecrement;
+    ControlObject* m_pFontSizeKnob;
 
     // Direct navigation controls for specific widgets (deprecated)
-    ControlObject* m_pSelectNextTrack = nullptr;
-    ControlObject* m_pSelectPrevTrack = nullptr;
-    ControlObject* m_pSelectTrack = nullptr;
-    ControlObject* m_pSelectSidebarItem = nullptr;
-    ControlObject* m_pSelectPrevSidebarItem = nullptr;
-    ControlObject* m_pSelectNextSidebarItem = nullptr;
-    ControlObject* m_pToggleSidebarItem = nullptr;
-    ControlObject* m_pLoadSelectedIntoFirstStopped = nullptr;
-    ControlObject* m_pAutoDjAddTop = nullptr;
-    ControlObject* m_pAutoDjAddBottom = nullptr;
+    ControlObject* m_pSelectNextTrack;
+    ControlObject* m_pSelectPrevTrack;
+    ControlObject* m_pSelectTrack;
+    ControlObject* m_pSelectSidebarItem;
+    ControlObject* m_pSelectPrevSidebarItem;
+    ControlObject* m_pSelectNextSidebarItem;
+    ControlObject* m_pToggleSidebarItem;
+    ControlObject* m_pLoadSelectedIntoFirstStopped;
+    ControlObject* m_pAutoDjAddTop;
+    ControlObject* m_pAutoDjAddBottom;
 
     // Library widgets
-    WLibrary* m_pLibraryWidget = nullptr;
-    WLibrarySidebar* m_pSidebarWidget = nullptr;
+    WLibrary* m_pLibraryWidget;
+    WLibrarySidebar* m_pSidebarWidget;
 
     // Other variables
     ControlProxy m_numDecks;

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -52,6 +52,7 @@ class LibraryControl : public QObject {
     void slotSelectNextSidebarItem(double v);
     void slotSelectPrevSidebarItem(double v);
     void slotToggleSelectedSidebarItem(double v);
+    void slotToggleFocusWidget(double v);
     void slotLoadSelectedIntoFirstStopped(double v);
     void slotAutoDjAddTop(double v);
     void slotAutoDjAddBottom(double v);
@@ -73,6 +74,7 @@ class LibraryControl : public QObject {
     ControlObject* m_pSelectTrack;
 
     ControlObject* m_pSelectSidebarItem;
+    ControlObject* m_pToggleFocusWidget;
     ControlObject* m_pSelectItem;
     ControlObject* m_pSelectPrevSidebarItem;
     ControlObject* m_pSelectNextSidebarItem;

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -112,6 +112,10 @@ class LibraryControl : public QObject {
     // Control to choose the currently selected item in focused widget (double click)
     std::unique_ptr<ControlObject> m_pChooseItem;
 
+    // Add to Auto-Dj Cueue
+    std::unique_ptr<ControlObject> m_pAutoDjAddTop;
+    std::unique_ptr<ControlObject> m_pAutoDjAddBottom;
+
     // Font sizes
     std::unique_ptr<ControlPushButton> m_pFontSizeIncrement;
     std::unique_ptr<ControlPushButton> m_pFontSizeDecrement;
@@ -126,8 +130,6 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlObject> m_pSelectNextSidebarItem;
     std::unique_ptr<ControlObject> m_pToggleSidebarItem;
     std::unique_ptr<ControlObject> m_pLoadSelectedIntoFirstStopped;
-    std::unique_ptr<ControlObject> m_pAutoDjAddTop;
-    std::unique_ptr<ControlObject> m_pAutoDjAddBottom;
 
     // Library widgets
     WLibrary* m_pLibraryWidget;

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -1,10 +1,10 @@
 #ifndef LIBRARYMIDICONTROL_H
 #define LIBRARYMIDICONTROL_H
 
-#include <memory>
 #include <QObject>
 
 #include "control/controlproxy.h"
+#include "util/memory.h"
 
 class ControlObject;
 class ControlPushButton;

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -48,6 +48,7 @@ class LibraryControl : public QObject {
     void slotSelectPrevTrack(double v);
     void slotSelectTrack(double v);
     void slotSelectSidebarItem(double v);
+    void slotSelectItem(double v);
     void slotSelectNextSidebarItem(double v);
     void slotSelectPrevSidebarItem(double v);
     void slotToggleSelectedSidebarItem(double v);
@@ -72,6 +73,7 @@ class LibraryControl : public QObject {
     ControlObject* m_pSelectTrack;
 
     ControlObject* m_pSelectSidebarItem;
+    ControlObject* m_pSelectItem;
     ControlObject* m_pSelectPrevSidebarItem;
     ControlObject* m_pSelectNextSidebarItem;
 

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -68,30 +68,30 @@ class LibraryControl : public QObject {
     void slotDecrementFontSize(double v);
 
   private:
-    Library* m_pLibrary;
+    Library* m_pLibrary = nullptr;
 
-    ControlObject* m_pSelectNextTrack;
-    ControlObject* m_pSelectPrevTrack;
-    ControlObject* m_pSelectTrack;
+    ControlObject* m_pSelectNextTrack = nullptr;
+    ControlObject* m_pSelectPrevTrack = nullptr;
+    ControlObject* m_pSelectTrack = nullptr;
 
-    ControlObject* m_pSelectSidebarItem;
-    ControlObject* m_pToggleFocusWidget;
-    ControlObject* m_pSelectItem;
-    ControlObject* m_pSelectPrevSidebarItem;
-    ControlObject* m_pSelectNextSidebarItem;
+    ControlObject* m_pSelectSidebarItem = nullptr;
+    ControlObject* m_pToggleFocusWidget = nullptr;
+    ControlObject* m_pSelectItem = nullptr;
+    ControlObject* m_pSelectPrevSidebarItem = nullptr;
+    ControlObject* m_pSelectNextSidebarItem = nullptr;
 
-    ControlObject* m_pToggleSidebarItem;
-    ControlObject* m_pChooseItem;
-    ControlObject* m_pLoadSelectedIntoFirstStopped;
-    ControlObject* m_pAutoDjAddTop;
-    ControlObject* m_pAutoDjAddBottom;
+    ControlObject* m_pToggleSidebarItem = nullptr;
+    ControlObject* m_pChooseItem = nullptr;
+    ControlObject* m_pLoadSelectedIntoFirstStopped = nullptr;
+    ControlObject* m_pAutoDjAddTop = nullptr;
+    ControlObject* m_pAutoDjAddBottom = nullptr;
 
-    ControlObject* m_pFontSizeKnob;
-    ControlPushButton* m_pFontSizeIncrement;
-    ControlPushButton* m_pFontSizeDecrement;
+    ControlObject* m_pFontSizeKnob = nullptr;
+    ControlPushButton* m_pFontSizeIncrement = nullptr;
+    ControlPushButton* m_pFontSizeDecrement = nullptr;
 
-    WLibrary* m_pLibraryWidget;
-    WLibrarySidebar* m_pSidebarWidget;
+    WLibrary* m_pLibraryWidget = nullptr;
+    WLibrarySidebar* m_pSidebarWidget = nullptr;
     ControlProxy m_numDecks;
     ControlProxy m_numSamplers;
     ControlProxy m_numPreviewDecks;

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -53,6 +53,7 @@ class LibraryControl : public QObject {
     void slotSelectPrevSidebarItem(double v);
     void slotToggleSelectedSidebarItem(double v);
     void slotToggleFocusWidget(double v);
+    void slotChooseItem(double v);
     void slotLoadSelectedIntoFirstStopped(double v);
     void slotAutoDjAddTop(double v);
     void slotAutoDjAddBottom(double v);
@@ -80,6 +81,7 @@ class LibraryControl : public QObject {
     ControlObject* m_pSelectNextSidebarItem;
 
     ControlObject* m_pToggleSidebarItem;
+    ControlObject* m_pChooseItem;
     ControlObject* m_pLoadSelectedIntoFirstStopped;
     ControlObject* m_pAutoDjAddTop;
     ControlObject* m_pAutoDjAddBottom;

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -43,17 +43,27 @@ class LibraryControl : public QObject {
   private slots:
     void libraryWidgetDeleted();
     void sidebarWidgetDeleted();
+
+    void slotMoveUp(double);
+    void slotMoveDown(double);
+    void slotMoveVertical(double);
+    void slotMoveLeft(double);
+    void slotMoveRight(double);
+    void slotMoveHorizontal(double);
+    void slotMoveFocusForward(double);
+    void slotMoveFocusBackward(double);
+    void slotMoveFocus(double);
+    void slotChooseItem(double v);
+
+    // Deprecated navigation slots
     void slotLoadSelectedTrackToGroup(QString group, bool play);
     void slotSelectNextTrack(double v);
     void slotSelectPrevTrack(double v);
     void slotSelectTrack(double v);
     void slotSelectSidebarItem(double v);
-    void slotSelectItem(double v);
     void slotSelectNextSidebarItem(double v);
     void slotSelectPrevSidebarItem(double v);
     void slotToggleSelectedSidebarItem(double v);
-    void slotToggleFocusWidget(double v);
-    void slotChooseItem(double v);
     void slotLoadSelectedIntoFirstStopped(double v);
     void slotAutoDjAddTop(double v);
     void slotAutoDjAddBottom(double v);
@@ -70,28 +80,49 @@ class LibraryControl : public QObject {
   private:
     Library* m_pLibrary = nullptr;
 
+    // Simulate pressing a key on the keyboard
+    void emitKeyEvent(QKeyEvent&& event);
+
+    // Controls to navigate vertically within currently focussed widget (up/down buttons)
+    ControlPushButton* m_pMoveUp = nullptr;
+    ControlPushButton* m_pMoveDown = nullptr;
+    ControlObject* m_pMoveVertical = nullptr;
+
+    // Controls to navigate horizontally within currently selected item (left/right buttons)
+    ControlPushButton* m_pMoveLeft = nullptr;
+    ControlPushButton* m_pMoveRight = nullptr;
+    ControlObject* m_pMoveHorizontal = nullptr;
+
+    // Controls to navigate between widgets (tab/shit+tab button)
+    ControlPushButton* m_pMoveFocusForward = nullptr;
+    ControlPushButton* m_pMoveFocusBackward = nullptr;
+    ControlObject* m_pMoveFocus = nullptr;
+
+    // Control to choose the currently selected item in focussed widget (double click)
+    ControlObject* m_pChooseItem = nullptr;
+
+    // Font sizes
+    ControlPushButton* m_pFontSizeIncrement = nullptr;
+    ControlPushButton* m_pFontSizeDecrement = nullptr;
+    ControlObject* m_pFontSizeKnob = nullptr;
+
+    // Direct navigation controls for specific widgets (deprecated)
     ControlObject* m_pSelectNextTrack = nullptr;
     ControlObject* m_pSelectPrevTrack = nullptr;
     ControlObject* m_pSelectTrack = nullptr;
-
     ControlObject* m_pSelectSidebarItem = nullptr;
-    ControlObject* m_pToggleFocusWidget = nullptr;
-    ControlObject* m_pSelectItem = nullptr;
     ControlObject* m_pSelectPrevSidebarItem = nullptr;
     ControlObject* m_pSelectNextSidebarItem = nullptr;
-
     ControlObject* m_pToggleSidebarItem = nullptr;
-    ControlObject* m_pChooseItem = nullptr;
     ControlObject* m_pLoadSelectedIntoFirstStopped = nullptr;
     ControlObject* m_pAutoDjAddTop = nullptr;
     ControlObject* m_pAutoDjAddBottom = nullptr;
 
-    ControlObject* m_pFontSizeKnob = nullptr;
-    ControlPushButton* m_pFontSizeIncrement = nullptr;
-    ControlPushButton* m_pFontSizeDecrement = nullptr;
-
+    // Library widgets
     WLibrary* m_pLibraryWidget = nullptr;
     WLibrarySidebar* m_pSidebarWidget = nullptr;
+
+    // Other variables
     ControlProxy m_numDecks;
     ControlProxy m_numSamplers;
     ControlProxy m_numPreviewDecks;

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -1,6 +1,7 @@
 #ifndef LIBRARYMIDICONTROL_H
 #define LIBRARYMIDICONTROL_H
 
+#include <memory>
 #include <QObject>
 
 #include "control/controlproxy.h"
@@ -27,8 +28,8 @@ class LoadToGroupController : public QObject {
 
   private:
     QString m_group;
-    ControlObject* m_pLoadControl;
-    ControlObject* m_pLoadAndPlayControl;
+    std::unique_ptr<ControlObject> m_pLoadControl;
+    std::unique_ptr<ControlObject> m_pLoadAndPlayControl;
 };
 
 class LibraryControl : public QObject {
@@ -84,39 +85,39 @@ class LibraryControl : public QObject {
     void emitKeyEvent(QKeyEvent&& event);
 
     // Controls to navigate vertically within currently focussed widget (up/down buttons)
-    ControlPushButton* m_pMoveUp;
-    ControlPushButton* m_pMoveDown;
-    ControlObject* m_pMoveVertical;
+    std::unique_ptr<ControlPushButton> m_pMoveUp;
+    std::unique_ptr<ControlPushButton> m_pMoveDown;
+    std::unique_ptr<ControlObject> m_pMoveVertical;
 
     // Controls to navigate horizontally within currently selected item (left/right buttons)
-    ControlPushButton* m_pMoveLeft;
-    ControlPushButton* m_pMoveRight;
-    ControlObject* m_pMoveHorizontal;
+    std::unique_ptr<ControlPushButton> m_pMoveLeft;
+    std::unique_ptr<ControlPushButton> m_pMoveRight;
+    std::unique_ptr<ControlObject> m_pMoveHorizontal;
 
     // Controls to navigate between widgets (tab/shit+tab button)
-    ControlPushButton* m_pMoveFocusForward;
-    ControlPushButton* m_pMoveFocusBackward;
-    ControlObject* m_pMoveFocus;
+    std::unique_ptr<ControlPushButton> m_pMoveFocusForward;
+    std::unique_ptr<ControlPushButton> m_pMoveFocusBackward;
+    std::unique_ptr<ControlObject> m_pMoveFocus;
 
     // Control to choose the currently selected item in focussed widget (double click)
-    ControlObject* m_pChooseItem;
+    std::unique_ptr<ControlObject> m_pChooseItem;
 
     // Font sizes
-    ControlPushButton* m_pFontSizeIncrement;
-    ControlPushButton* m_pFontSizeDecrement;
-    ControlObject* m_pFontSizeKnob;
+    std::unique_ptr<ControlPushButton> m_pFontSizeIncrement;
+    std::unique_ptr<ControlPushButton> m_pFontSizeDecrement;
+    std::unique_ptr<ControlObject> m_pFontSizeKnob;
 
     // Direct navigation controls for specific widgets (deprecated)
-    ControlObject* m_pSelectNextTrack;
-    ControlObject* m_pSelectPrevTrack;
-    ControlObject* m_pSelectTrack;
-    ControlObject* m_pSelectSidebarItem;
-    ControlObject* m_pSelectPrevSidebarItem;
-    ControlObject* m_pSelectNextSidebarItem;
-    ControlObject* m_pToggleSidebarItem;
-    ControlObject* m_pLoadSelectedIntoFirstStopped;
-    ControlObject* m_pAutoDjAddTop;
-    ControlObject* m_pAutoDjAddBottom;
+    std::unique_ptr<ControlObject> m_pSelectNextTrack;
+    std::unique_ptr<ControlObject> m_pSelectPrevTrack;
+    std::unique_ptr<ControlObject> m_pSelectTrack;
+    std::unique_ptr<ControlObject> m_pSelectSidebarItem;
+    std::unique_ptr<ControlObject> m_pSelectPrevSidebarItem;
+    std::unique_ptr<ControlObject> m_pSelectNextSidebarItem;
+    std::unique_ptr<ControlObject> m_pToggleSidebarItem;
+    std::unique_ptr<ControlObject> m_pLoadSelectedIntoFirstStopped;
+    std::unique_ptr<ControlObject> m_pAutoDjAddTop;
+    std::unique_ptr<ControlObject> m_pAutoDjAddBottom;
 
     // Library widgets
     WLibrary* m_pLibraryWidget;
@@ -126,7 +127,7 @@ class LibraryControl : public QObject {
     ControlProxy m_numDecks;
     ControlProxy m_numSamplers;
     ControlProxy m_numPreviewDecks;
-    QMap<QString, LoadToGroupController*> m_loadToGroupControllers;
+    std::map<QString, std::unique_ptr<LoadToGroupController>> m_loadToGroupControllers;
 };
 
 #endif //LIBRARYMIDICONTROL_H

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -86,6 +86,8 @@ class LibraryControl : public QObject {
 
     // Simulate pressing a key on the keyboard
     void emitKeyEvent(QKeyEvent&& event);
+    // Give the keyboard focus to the main library pane
+    void setLibraryFocus();
 
     // Controls to navigate vertically within currently focussed widget (up/down buttons)
     std::unique_ptr<ControlPushButton> m_pMoveUp;

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -48,6 +48,9 @@ class LibraryControl : public QObject {
     void slotMoveUp(double);
     void slotMoveDown(double);
     void slotMoveVertical(double);
+    void slotScrollUp(double);
+    void slotScrollDown(double);
+    void slotScrollVertical(double);
     void slotMoveLeft(double);
     void slotMoveRight(double);
     void slotMoveHorizontal(double);
@@ -88,6 +91,11 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlPushButton> m_pMoveUp;
     std::unique_ptr<ControlPushButton> m_pMoveDown;
     std::unique_ptr<ControlObject> m_pMoveVertical;
+
+    // Controls to QUICKLY navigate vertically within currently focussed widget (pageup/pagedown buttons)
+    std::unique_ptr<ControlPushButton> m_pScrollUp;
+    std::unique_ptr<ControlPushButton> m_pScrollDown;
+    std::unique_ptr<ControlObject> m_pScrollVertical;
 
     // Controls to navigate horizontally within currently selected item (left/right buttons)
     std::unique_ptr<ControlPushButton> m_pMoveLeft;

--- a/src/library/libraryview.h
+++ b/src/library/libraryview.h
@@ -14,6 +14,7 @@ class LibraryView {
     virtual ~LibraryView() {};
 
     virtual void onShow() = 0;
+    virtual bool hasFocus() const = 0;
     // reimplement if LibraryView should be able to search
     virtual void onSearch(const QString& text) {Q_UNUSED(text);}
 

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -69,6 +69,10 @@ void DlgRecording::onShow() {
     m_browseModel.setPath(m_recordingDir);
 }
 
+bool DlgRecording::hasFocus() const {
+    return QWidget::hasFocus();
+}
+
 void DlgRecording::refreshBrowseModel() {
      m_browseModel.setPath(m_recordingDir);
 }

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -22,16 +22,16 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
     DlgRecording(QWidget *parent, UserSettingsPointer pConfig,
                  Library* pLibrary, TrackCollection* pTrackCollection,
                  RecordingManager* pRecManager, KeyboardEventFilter* pKeyboard);
-    virtual ~DlgRecording();
+    ~DlgRecording() override;
 
-    virtual void onSearch(const QString& text);
-    virtual void onShow();
-    virtual bool hasFocus() const;
-    virtual void loadSelectedTrack();
-    virtual void slotSendToAutoDJ();
-    virtual void slotSendToAutoDJTop();
-    virtual void loadSelectedTrackToGroup(QString group, bool play);
-    virtual void moveSelection(int delta);
+    void onSearch(const QString& text) override;
+    void onShow() override;
+    bool hasFocus() const override;
+    void loadSelectedTrack() override;
+    void slotSendToAutoDJ() override;
+    void slotSendToAutoDJTop() override;
+    void loadSelectedTrackToGroup(QString group, bool play) override;
+    void moveSelection(int delta) override;
     inline const QString currentSearch() { return m_proxyModel.currentSearch(); }
 
   public slots:

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -26,6 +26,7 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
 
     virtual void onSearch(const QString& text);
     virtual void onShow();
+    virtual bool hasFocus() const;
     virtual void loadSelectedTrack();
     virtual void slotSendToAutoDJ();
     virtual void slotSendToAutoDJTop();

--- a/src/widget/wlibrarytextbrowser.cpp
+++ b/src/widget/wlibrarytextbrowser.cpp
@@ -6,3 +6,7 @@
 WLibraryTextBrowser::WLibraryTextBrowser(QWidget* parent)
         : QTextBrowser(parent) {
 }
+
+bool WLibraryTextBrowser::hasFocus() const {
+    return QWidget::hasFocus();
+}

--- a/src/widget/wlibrarytextbrowser.h
+++ b/src/widget/wlibrarytextbrowser.h
@@ -12,8 +12,8 @@ class WLibraryTextBrowser : public QTextBrowser, public LibraryView {
     Q_OBJECT
   public:
     explicit WLibraryTextBrowser(QWidget* parent = nullptr);
-
     void onShow() override {}
+    bool hasFocus() const override;
 };
 
 #endif /* WLIBRARYTEXTBROWSER_H */

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1680,3 +1680,7 @@ void WTrackTableView::slotReloadCoverArt() {
         pCache->requestGuessCovers(selectedTracks);
     }
 }
+
+bool WTrackTableView::hasFocus() const {
+    return QWidget::hasFocus();
+}

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -32,6 +32,7 @@ class WTrackTableView : public WLibraryTableView {
     void contextMenuEvent(QContextMenuEvent * event) override;
     void onSearch(const QString& text) override;
     void onShow() override;
+    bool hasFocus() const override;
     void keyPressEvent(QKeyEvent* event) override;
     void loadSelectedTrack() override;
     void loadSelectedTrackToGroup(QString group, bool play) override;


### PR DESCRIPTION
Added three new controls that make it a lot easier to use the library encoder on DJ controllers by allowing the following functionality:
- `SelectItemKnob` allows the library encoder to scroll through sidebar items when the sidebar has focus, as opposed to `SelectTrackKnob` which only scans through the library and `SelectPlaylist` which only scans through the sidebar items.
- `ToggleFocusWidget` allows users to toggle the focus between the sidebar and the library.
- `ChooseItem` allows the library encoder push button to either expand a sidebar item if sidebar has focus, or load a track into first stopped deck if library has focus. This is intuitive as it's the same behavior as a double click.
