### PR TITLE
fix a compile error using the gcc 6.1.1 header

### DIFF
--- a/src/util/math.h
+++ b/src/util/math.h
@@ -9,7 +9,10 @@
 #define _USE_MATH_DEFINES
 #endif
 #endif
-#include <cmath>
+
+#include <math.h>
+// Note: #include <cmath> does not work with GCC 6.1.1 because of our fpclassify hack 
+
 #include <algorithm>
 
 #include "util/assert.h"

--- a/src/util/math.h
+++ b/src/util/math.h
@@ -11,7 +11,11 @@
 #endif
 
 #include <math.h>
-// Note: #include <cmath> does not work with GCC 6.1.1 because of our fpclassify hack 
+#include <cmath> 
+// Note: Because of our fpclassify hack, we actualy need to inlude both, 
+// the c and the c++ version of the math header.  
+// From GCC 6.1.1 math.h depends on cmath, which failes to compile if included 
+// after our fpclassify hack 
 
 #include <algorithm>
 


### PR DESCRIPTION
This should fix the compile error reported in:  
https://github.com/mixxxdj/mixxx/commit/7e9bba7e88842b5bbb5e7b4ee602b410c455892d#commitcomment-17448450

and tracked in: 
https://bugs.launchpad.net/bugs/1586808
