### PR TITLE
Clear loop when loading track

### DIFF
--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -242,6 +242,10 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
         m_pKey->set(m_pLoadedTrack->getKey());
         setReplayGain(m_pLoadedTrack->getReplayGain().getRatio());
 
+        // Clear loop
+        m_pLoopOutPoint->set(-1);
+        m_pLoopInPoint->set(-1);
+
         const QList<CuePointer> trackCues(pNewTrack->getCuePoints());
         QListIterator<CuePointer> it(trackCues);
         while (it.hasNext()) {

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -243,6 +243,9 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
         setReplayGain(m_pLoadedTrack->getReplayGain().getRatio());
 
         // Clear loop
+        // It seems that the trick is to first clear the loop out point, and then
+        // the loop in point. If we first clear the loop in point, the loop out point
+        // does not get cleared.
         m_pLoopOutPoint->set(-1);
         m_pLoopInPoint->set(-1);
 


### PR DESCRIPTION
This PR fixes:
- https://bugs.launchpad.net/mixxx/+bug/1306323
- https://bugs.launchpad.net/mixxx/+bug/1532360

It seems that the trick is to first clear the loop out point, and then the loop in point. If we first clear the loop in point, the loop out point does not get cleared.
