### PR TITLE
Fix build for FFmpeg 3.0.x

### DIFF
--- a/src/encoder/encoderffmpegcore.h
+++ b/src/encoder/encoderffmpegcore.h
@@ -25,7 +25,6 @@ extern "C" {
 #include <libavutil/opt.h>
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
-#include <libavutil/audioconvert.h>
 #include <libavutil/common.h>
 #include <libavutil/mathematics.h>
 #include <libavutil/samplefmt.h>


### PR DESCRIPTION
The Travis build should reveal if the removal of an include directive is backwards compatible with FFmpeg 2.x.
