### PR TITLE
mp4 crash fix 

### DIFF
--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -205,7 +205,7 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSr
         // Limit to an insane high value of 1 MB,
         // we got 4278190742 in https://bugs.launchpad.net/mixxx/+bug/1594169
         // TODO() set this to the mp4 maximum allowed block size, if there is one   
-        qWarning() << "maxSampleBlockInputSize is to big:" << maxSampleBlockInputSize << getUrlString();
+        qWarning() << "maxSampleBlockInputSize is too big:" << maxSampleBlockInputSize << getUrlString();
         return OpenResult::FAILED;    
     }
     m_inputBuffer.resize(maxSampleBlockInputSize, 0);

--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -201,6 +201,13 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSr
     // sample block for the selected track.
     const u_int32_t maxSampleBlockInputSize = MP4GetTrackMaxSampleSize(m_hFile,
             m_trackId);
+    if (maxSampleBlockInputSize > 1048576) { 
+        // Limit to an insane high value of 1 MB,
+        // we got 4278190742 in https://bugs.launchpad.net/mixxx/+bug/1594169
+        // TODO() set this to the mp4 maximum allowed block size, if there is one   
+        qWarning() << "maxSampleBlockInputSize is to big:" << maxSampleBlockInputSize << getUrlString();
+        return OpenResult::FAILED;    
+    }
     m_inputBuffer.resize(maxSampleBlockInputSize, 0);
 
     DEBUG_ASSERT(nullptr == m_hDecoder); // not already opened

--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -26,10 +26,12 @@ SoundSource::OpenResult SoundSource::open(const AudioSourceConfig& audioSrcCfg) 
     OpenResult result;
     try {
         result = tryOpen(audioSrcCfg);
-    } catch (...) {
+    } catch (const std::exception& e) {
+        qWarning() << "tryOpen failed" << getLocalFileName() << e.what();
         close();
-        throw;
+        return OpenResult::FAILED;
     }
+
     if (OpenResult::SUCCEEDED != result) {
         close();
     }


### PR DESCRIPTION
This is a fix for https://bugs.launchpad.net/mixxx/+bug/1594169

It turns out that Mixxx crashes, because of a rethrowed exception. 

I think it is better to consume the exception in this case, since crashing is not a good alternative here. The exception is most likely caused by an faulty file (like int this case). If the system is unstable, it can crash later ;-)

I have also added a plausibility check that completely avoid the bad_alloc exception from this bug. 
I have not found  a limit for SampleBlockSize in the mp4 docs, so I pick an insane value of 1 MB 
