### PR TITLE
Follow-up: Workaround for libmp4v2 2.0.0

### DIFF
--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -211,6 +211,11 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSr
     // sample block for the selected track.
     const u_int32_t maxSampleBlockInputSize = MP4GetTrackMaxSampleSize(m_hFile,
             m_trackId);
+    if (maxSampleBlockInputSize == 0) {
+        qWarning() << "Failed to read MP4 DecoderConfigDescriptor.bufferSizeDB:"
+                << getUrlString();
+        return OpenResult::FAILED;
+    }
     if (maxSampleBlockInputSize > kMaxSampleBlockInputSizeLimit) {
         // Workaround for a possible bug in libmp4v2 2.0.0 (Ubuntu 16.04)
         // that returns 4278190742 when opening a corrupt file.

--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -23,17 +23,19 @@ SoundSource::SoundSource(const QUrl& url, const QString& type)
 
 SoundSource::OpenResult SoundSource::open(const AudioSourceConfig& audioSrcCfg) {
     close(); // reopening is not supported
+
     OpenResult result;
     try {
         result = tryOpen(audioSrcCfg);
     } catch (const std::exception& e) {
-        qWarning() << "tryOpen failed" << getLocalFileName() << e.what();
-        close();
-        return OpenResult::FAILED;
+        qWarning() << "Caught unexpected exception from SoundSource::tryOpen():" << e.what();
+        result = OpenResult::FAILED;
+    } catch (...) {
+        qWarning() << "Caught unknown exception from SoundSource::tryOpen()";
+        result = OpenResult::FAILED;
     }
-
     if (OpenResult::SUCCEEDED != result) {
-        close();
+        close(); // rollback
     }
     return result;
 }

--- a/src/sources/soundsource.h
+++ b/src/sources/soundsource.h
@@ -56,13 +56,20 @@ protected:
     SoundSource(const QUrl& url, const QString& type);
 
 private:
-    // Tries to open the AudioSource for reading audio data
-    // according to the "Template Method" design pattern. If
-    // tryOpen() fails all (partially) allocated resources
-    // will be freed by close(). Implementing classes do not
-    // need to free resources in tryOpen() themselves, but
-    // should instead be prepared for the following invocation
-    // of close().
+    // Tries to open the AudioSource for reading audio data according
+    // to the "Template Method" design pattern.
+    //
+    // The invocation of tryOpen() is enclosed in invocations of close():
+    //   - Before: Always
+    //   - After: Upon failure
+    // If tryOpen() throws an exception or returns a result other than
+    // OpenResult::SUCCEEDED an invocation of close() will follow.
+    // Implementations do not need to free internal resources twice in
+    // both tryOpen() upon failure and close(). All internal resources
+    // should be freed in close() instead.
+    //
+    // Exceptions should be handled internally by implementations to
+    // avoid warning messages about unexpected or unknown exceptions.
     virtual OpenResult tryOpen(const AudioSourceConfig& audioSrcCfg) = 0;
 
     const QString m_type;


### PR DESCRIPTION
Some improvements and additional documentation as a follow up for Daniel's bug report and fix:
https://bugs.launchpad.net/mixxx/+bug/1594169
