### PR TITLE
Rename namespace 'Mixxx' to 'mixxx'

### DIFF
--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -19,7 +19,7 @@ typedef uint32_t SAMPLERATE_TYPE;
 typedef unsigned long SAMPLERATE_TYPE;
 #endif
 
-namespace Mixxx {
+namespace mixxx {
 
 namespace {
 
@@ -546,17 +546,17 @@ SoundSourcePointer SoundSourceProviderM4A::newSoundSource(const QUrl& url) {
     return exportSoundSourcePlugin(new SoundSourceM4A(url));
 }
 
-} // namespace Mixxx
+} // namespace mixxx
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
-Mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider() {
+mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider() {
     // SoundSourceProviderM4A is stateless and a single instance
     // can safely be shared
-    static Mixxx::SoundSourceProviderM4A singleton;
+    static mixxx::SoundSourceProviderM4A singleton;
     return &singleton;
 }
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
-void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(Mixxx::SoundSourceProvider*) {
+void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(mixxx::SoundSourceProvider*) {
     // The statically allocated instance must not be deleted!
 }

--- a/plugins/soundsourcem4a/soundsourcem4a.h
+++ b/plugins/soundsourcem4a/soundsourcem4a.h
@@ -15,7 +15,7 @@
 
 #include <vector>
 
-namespace Mixxx {
+namespace mixxx {
 
 class SoundSourceM4A: public SoundSourcePlugin {
 public:
@@ -64,12 +64,12 @@ public:
     SoundSourcePointer newSoundSource(const QUrl& url) override;
 };
 
-} // namespace Mixxx
+} // namespace mixxx
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
-Mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider();
+mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider();
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
-void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(Mixxx::SoundSourceProvider*);
+void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(mixxx::SoundSourceProvider*);
 
 #endif // MIXXX_SOUNDSOURCEM4A_H

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -60,7 +60,7 @@ template<class T> static void safeRelease(T **ppT) {
 
 } // anonymous namespace
 
-namespace Mixxx {
+namespace mixxx {
 
 SoundSourceMediaFoundation::SoundSourceMediaFoundation(const QUrl& url)
         : SoundSourcePlugin(url, "m4a"),
@@ -665,17 +665,17 @@ SoundSourcePointer SoundSourceProviderMediaFoundation::newSoundSource(const QUrl
     return exportSoundSourcePlugin(new SoundSourceMediaFoundation(url));
 }
 
-} // namespace Mixxx
+} // namespace mixxx
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
-Mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider() {
+mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider() {
     // SoundSourceProviderMediaFoundation is stateless and a single instance
     // can safely be shared
-    static Mixxx::SoundSourceProviderMediaFoundation singleton;
+    static mixxx::SoundSourceProviderMediaFoundation singleton;
     return &singleton;
 }
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
-void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(Mixxx::SoundSourceProvider*) {
+void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(mixxx::SoundSourceProvider*) {
     // The statically allocated instance must not be deleted!
 }

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
@@ -28,9 +28,9 @@ class IMFSourceReader;
 class IMFMediaType;
 class IMFMediaSource;
 
-namespace Mixxx {
+namespace mixxx {
 
-class SoundSourceMediaFoundation : public Mixxx::SoundSourcePlugin {
+class SoundSourceMediaFoundation : public mixxx::SoundSourcePlugin {
 public:
     explicit SoundSourceMediaFoundation(const QUrl& url);
     ~SoundSourceMediaFoundation() override;
@@ -42,9 +42,9 @@ public:
     SINT readSampleFrames(SINT numberOfFrames, CSAMPLE* sampleBuffer) override;
 
 private:
-    OpenResult tryOpen(const Mixxx::AudioSourceConfig& audioSrcCfg) override;
+    OpenResult tryOpen(const mixxx::AudioSourceConfig& audioSrcCfg) override;
 
-    bool configureAudioStream(const Mixxx::AudioSourceConfig& audioSrcCfg);
+    bool configureAudioStream(const mixxx::AudioSourceConfig& audioSrcCfg);
     bool readProperties();
 
     void copyFrames(CSAMPLE *dest, SINT *destFrames, const CSAMPLE *src,
@@ -73,12 +73,12 @@ public:
     SoundSourcePointer newSoundSource(const QUrl& url) override;
 };
 
-} // namespace Mixxx
+} // namespace mixxx
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
-Mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider();
+mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider();
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
-void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(Mixxx::SoundSourceProvider*);
+void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(mixxx::SoundSourceProvider*);
 
 #endif // SOUNDSOURCEMEDIAFOUNDATION_H

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -2,7 +2,7 @@
 
 #include <QFile>
 
-namespace Mixxx {
+namespace mixxx {
 
 //static
 WavpackStreamReader SoundSourceWV::s_streamReader = {
@@ -221,17 +221,17 @@ int32_t SoundSourceWV::WriteBytesCallback(void* id, void* data, int32_t bcount)
     return (int32_t)pFile->write((char*)data, bcount);
 }
 
-} // namespace Mixxx
+} // namespace mixxx
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
-Mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider() {
+mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider() {
     // SoundSourceProviderWV is stateless and a single instance
     // can safely be shared
-    static Mixxx::SoundSourceProviderWV singleton;
+    static mixxx::SoundSourceProviderWV singleton;
     return &singleton;
 }
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
-void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(Mixxx::SoundSourceProvider*) {
+void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(mixxx::SoundSourceProvider*) {
     // The statically allocated instance must not be deleted!
 }

--- a/plugins/soundsourcewv/soundsourcewv.h
+++ b/plugins/soundsourcewv/soundsourcewv.h
@@ -7,7 +7,7 @@
 
 class QFile;
 
-namespace Mixxx {
+namespace mixxx {
 
 class SoundSourceWV: public SoundSourcePlugin {
   public:
@@ -49,12 +49,12 @@ public:
     SoundSourcePointer newSoundSource(const QUrl& url) override;
 };
 
-}  // namespace Mixxx
+}  // namespace mixxx
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
-Mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider();
+mixxx::SoundSourceProvider* Mixxx_SoundSourcePluginAPI_createSoundSourceProvider();
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT
-void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(Mixxx::SoundSourceProvider*);
+void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(mixxx::SoundSourceProvider*);
 
 #endif // MIXXX_SOUNDSOURCEWV_H

--- a/src/analyzer/analyzerebur128.cpp
+++ b/src/analyzer/analyzerebur128.cpp
@@ -82,7 +82,7 @@ void AnalyzerEbur128::finalize(TrackPointer tio) {
     }
 
     const double fReplayGain2 = kReplayGain2ReferenceLUFS - averageLufs;
-    Mixxx::ReplayGain replayGain(tio->getReplayGain());
+    mixxx::ReplayGain replayGain(tio->getReplayGain());
     replayGain.setRatio(db2ratio(fReplayGain2));
     tio->setReplayGain(replayGain);
     qDebug() << "ReplayGain 2.0 (libebur128) result is" << fReplayGain2 << "dB for" << tio->getLocation();

--- a/src/analyzer/analyzergain.cpp
+++ b/src/analyzer/analyzergain.cpp
@@ -75,7 +75,7 @@ void AnalyzerGain::finalize(TrackPointer tio) {
         return;
     }
 
-    Mixxx::ReplayGain replayGain(tio->getReplayGain());
+    mixxx::ReplayGain replayGain(tio->getReplayGain());
     replayGain.setRatio(db2ratio(fReplayGainOutput));
     tio->setReplayGain(replayGain);
     qDebug() << "ReplayGain 1.0 result is" << fReplayGainOutput << "dB for" << tio->getLocation();

--- a/src/analyzer/analyzerqueue.cpp
+++ b/src/analyzer/analyzerqueue.cpp
@@ -33,7 +33,7 @@ namespace {
     // We need to use a smaller block size, because on Linux the AnalyzerQueue
     // can starve the CPU of its resources, resulting in xruns. A block size
     // of 4096 frames per block seems to do fine.
-    const SINT kAnalysisChannels = Mixxx::AudioSource::kChannelCountStereo;
+    const SINT kAnalysisChannels = mixxx::AudioSource::kChannelCountStereo;
     const SINT kAnalysisFramesPerBlock = 4096;
     const SINT kAnalysisSamplesPerBlock =
             kAnalysisFramesPerBlock * kAnalysisChannels;
@@ -177,7 +177,7 @@ TrackPointer AnalyzerQueue::dequeueNextBlocking() {
 }
 
 // This is called from the AnalyzerQueue thread
-bool AnalyzerQueue::doAnalysis(TrackPointer tio, Mixxx::AudioSourcePointer pAudioSource) {
+bool AnalyzerQueue::doAnalysis(TrackPointer tio, mixxx::AudioSourcePointer pAudioSource) {
 
     QTime progressUpdateInhibitTimer;
     progressUpdateInhibitTimer.start(); // Inhibit Updates for 60 milliseconds
@@ -320,9 +320,9 @@ void AnalyzerQueue::run() {
 
         // Get the audio
         SoundSourceProxy soundSourceProxy(nextTrack);
-        Mixxx::AudioSourceConfig audioSrcCfg;
+        mixxx::AudioSourceConfig audioSrcCfg;
         audioSrcCfg.setChannelCount(kAnalysisChannels);
-        Mixxx::AudioSourcePointer pAudioSource(soundSourceProxy.openAudioSource(audioSrcCfg));
+        mixxx::AudioSourcePointer pAudioSource(soundSourceProxy.openAudioSource(audioSrcCfg));
         if (!pAudioSource) {
             qWarning() << "Failed to open file for analyzing:" << nextTrack->getLocation();
             emptyCheck();

--- a/src/analyzer/analyzerqueue.h
+++ b/src/analyzer/analyzerqueue.h
@@ -61,7 +61,7 @@ class AnalyzerQueue : public QThread {
 
     bool isLoadedTrackWaiting(TrackPointer analysingTrack);
     TrackPointer dequeueNextBlocking();
-    bool doAnalysis(TrackPointer tio, Mixxx::AudioSourcePointer pAudioSource);
+    bool doAnalysis(TrackPointer tio, mixxx::AudioSourcePointer pAudioSource);
     void emitUpdateProgress(TrackPointer tio, int progress);
     void emptyCheck();
 

--- a/src/controllers/bulk/bulkcontroller.cpp
+++ b/src/controllers/bulk/bulkcontroller.cpp
@@ -53,7 +53,7 @@ void BulkReader::run() {
             Trace process("BulkReader process packet");
             //qDebug() << "Read" << result << "bytes, pointer:" << data;
             QByteArray outData((char*)data, transferred);
-            emit(incomingData(outData, Time::elapsed()));
+            emit(incomingData(outData, mixxx::Time::elapsed()));
         }
     }
     qDebug() << "Stopped Reader";

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -1160,7 +1160,7 @@ void ControllerEngine::scratchEnable(int deck, int intervalsPerRev, double rpm,
     Output:  -
     -------- ------------------------------------------------------ */
 void ControllerEngine::scratchTick(int deck, int interval) {
-    m_lastMovement[deck] = Time::elapsed();
+    m_lastMovement[deck] = mixxx::Time::elapsed();
     m_intervalAccumulator[deck] += interval;
 }
 
@@ -1186,7 +1186,7 @@ void ControllerEngine::scratchProcess(int timerId) {
     // If we're ramping to end scratching and the wheel hasn't been turned very
     // recently (spinback after lift-off,) feed fixed data
     if (m_ramp[deck] &&
-        ((Time::elapsed() - m_lastMovement[deck]) >= mixxx::Duration::fromMillis(1))) {
+        ((mixxx::Time::elapsed() - m_lastMovement[deck]) >= mixxx::Duration::fromMillis(1))) {
         filter->observation(m_rampTo[deck] * m_rampFactor[deck]);
         // Once this code path is run, latch so it always runs until reset
         //m_lastMovement[deck] += mixxx::Duration::fromSeconds(1);
@@ -1269,7 +1269,7 @@ void ControllerEngine::scratchDisable(int deck, bool ramp) {
         m_rampTo[deck] = getDeckRate(group);
     }
 
-    m_lastMovement[deck] = Time::elapsed();
+    m_lastMovement[deck] = mixxx::Time::elapsed();
     m_ramp[deck] = true;    // Activate the ramping in scratchProcess()
 }
 

--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -320,14 +320,14 @@ void ControllerManager::pollDevices() {
         return;
     }
 
-    mixxx::Duration start = Time::elapsed();
+    mixxx::Duration start = mixxx::Time::elapsed();
     foreach (Controller* pDevice, m_controllers) {
         if (pDevice->isOpen() && pDevice->isPolling()) {
             pDevice->poll();
         }
     }
 
-    mixxx::Duration duration = Time::elapsed() - start;
+    mixxx::Duration duration = mixxx::Time::elapsed() - start;
     if (duration > mixxx::Duration::fromMillis(kPollIntervalMillis)) {
         m_skipPoll = true;
     }

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -42,7 +42,7 @@ void HidReader::run() {
             Trace process("HidReader process packet");
             //qDebug() << "Read" << result << "bytes, pointer:" << data;
             QByteArray outData(reinterpret_cast<char*>(data), result);
-            emit(incomingData(outData, Time::elapsed()));
+            emit(incomingData(outData, mixxx::Time::elapsed()));
         }
     }
     delete [] data;

--- a/src/controllers/midi/hss1394controller.cpp
+++ b/src/controllers/midi/hss1394controller.cpp
@@ -21,7 +21,7 @@ DeviceChannelListener::~DeviceChannelListener() {
 void DeviceChannelListener::Process(const hss1394::uint8 *pBuffer, hss1394::uint uBufferSize) {
     unsigned int i = 0;
 
-    mixxx::Duration timestamp = Time::elapsed();
+    mixxx::Duration timestamp = mixxx::Time::elapsed();
 
     // If multiple three-byte messages arrive right next to each other, handle them all
     while (i < uBufferSize) {

--- a/src/controllers/softtakeover.cpp
+++ b/src/controllers/softtakeover.cpp
@@ -116,7 +116,7 @@ bool SoftTakeover::ignore(ControlObject* control, double newParameter) {
      *      Don't ignore in every other case.
      */
 
-    mixxx::Duration currentTime = Time::elapsed();
+    mixxx::Duration currentTime = mixxx::Time::elapsed();
     // We will get a sudden jump if we don't ignore the first value.
     if (m_time == mixxx::Duration::fromMillis(0)) {
         ignore = true;

--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -40,7 +40,7 @@ CachingReader::CachingReader(QString group,
           m_mruCachingReaderChunk(nullptr),
           m_lruCachingReaderChunk(nullptr),
           m_sampleBuffer(CachingReaderChunk::kSamples * maximumCachingReaderChunksInMemory),
-          m_maxReadableFrameIndex(Mixxx::AudioSource::getMinFrameIndex()),
+          m_maxReadableFrameIndex(mixxx::AudioSource::getMinFrameIndex()),
           m_worker(group, &m_chunkReadRequestFIFO, &m_readerStatusFIFO) {
 
     m_allocatedCachingReaderChunks.reserve(maximumCachingReaderChunksInMemory);
@@ -217,7 +217,7 @@ void CachingReader::process() {
         if (m_readerStatus == TRACK_LOADED) {
             m_maxReadableFrameIndex = math_min(status.maxReadableFrameIndex, m_maxReadableFrameIndex);
         } else {
-            m_maxReadableFrameIndex = Mixxx::AudioSource::getMinFrameIndex();
+            m_maxReadableFrameIndex = mixxx::AudioSource::getMinFrameIndex();
         }
     }
 }
@@ -258,9 +258,9 @@ int CachingReader::read(int sample, bool reverse, int numSamples, CSAMPLE* buffe
     // silence. This may happen when the engine is in preroll,
     // i.e. if the frame index points a region before the first
     // track sample.
-    if (Mixxx::AudioSource::getMinFrameIndex() > frameIndex) {
+    if (mixxx::AudioSource::getMinFrameIndex() > frameIndex) {
         const SINT prerollFrames = math_min(numFrames,
-                Mixxx::AudioSource::getMinFrameIndex() - frameIndex);
+                mixxx::AudioSource::getMinFrameIndex() - frameIndex);
         const SINT prerollSamples = CachingReaderChunk::frames2samples(prerollFrames);
         if (reverse) {
             SampleUtil::clear(&buffer[numSamples - prerollSamples], prerollSamples);
@@ -281,7 +281,7 @@ int CachingReader::read(int sample, bool reverse, int numSamples, CSAMPLE* buffe
     if (numSamples > samplesRead) {
         // If any unread samples from the track are left the current
         // frame index must be at or beyond the first track sample.
-        DEBUG_ASSERT(Mixxx::AudioSource::getMinFrameIndex() <= frameIndex);
+        DEBUG_ASSERT(mixxx::AudioSource::getMinFrameIndex() <= frameIndex);
 
         SINT maxReadableFrameIndex = math_min(frameIndex + numFrames, m_maxReadableFrameIndex);
         if (maxReadableFrameIndex > frameIndex) {
@@ -389,7 +389,7 @@ void CachingReader::hintAndMaybeWake(const HintVector& hintList) {
 
         SINT minReadableFrameIndex = hintFrame;
         SINT maxReadableFrameIndex = hintFrame + hintFrameCount;
-        Mixxx::AudioSource::clampFrameInterval(&minReadableFrameIndex, &maxReadableFrameIndex, m_maxReadableFrameIndex);
+        mixxx::AudioSource::clampFrameInterval(&minReadableFrameIndex, &maxReadableFrameIndex, m_maxReadableFrameIndex);
         if (minReadableFrameIndex >= maxReadableFrameIndex) {
             // skip empty frame interval silently
             continue;

--- a/src/engine/cachingreaderchunk.cpp
+++ b/src/engine/cachingreaderchunk.cpp
@@ -15,7 +15,7 @@ const SINT CachingReaderChunk::kInvalidIndex = -1;
 // easier memory alignment.
 // TODO(XXX): The optimum value of the "constant" kFrames depends
 // on the properties of the AudioSource as the remarks above suggest!
-const SINT CachingReaderChunk::kChannels = Mixxx::AudioSource::kChannelCountStereo;
+const SINT CachingReaderChunk::kChannels = mixxx::AudioSource::kChannelCountStereo;
 const SINT CachingReaderChunk::kFrames = 8192; // ~ 170 ms at 48 kHz
 const SINT CachingReaderChunk::kSamples =
         CachingReaderChunk::frames2samples(CachingReaderChunk::kFrames);
@@ -36,9 +36,9 @@ void CachingReaderChunk::init(SINT index) {
 }
 
 bool CachingReaderChunk::isReadable(
-        const Mixxx::AudioSourcePointer& pAudioSource,
+        const mixxx::AudioSourcePointer& pAudioSource,
         SINT maxReadableFrameIndex) const {
-    DEBUG_ASSERT(Mixxx::AudioSource::getMinFrameIndex() <= maxReadableFrameIndex);
+    DEBUG_ASSERT(mixxx::AudioSource::getMinFrameIndex() <= maxReadableFrameIndex);
 
     if (!isValid() || pAudioSource.isNull()) {
         return false;
@@ -50,7 +50,7 @@ bool CachingReaderChunk::isReadable(
 }
 
 SINT CachingReaderChunk::readSampleFrames(
-        const Mixxx::AudioSourcePointer& pAudioSource,
+        const mixxx::AudioSourcePointer& pAudioSource,
         SINT* pMaxReadableFrameIndex) {
     DEBUG_ASSERT(pMaxReadableFrameIndex);
 
@@ -94,7 +94,7 @@ SINT CachingReaderChunk::readSampleFrames(
 
     DEBUG_ASSERT(frameIndex == seekFrameIndex);
     DEBUG_ASSERT(CachingReaderChunk::kChannels
-            == Mixxx::AudioSource::kChannelCountStereo);
+            == mixxx::AudioSource::kChannelCountStereo);
     m_frameCount = pAudioSource->readSampleFramesStereo(
             framesToRead, m_sampleBuffer, kSamples);
     if (m_frameCount < framesToRead) {

--- a/src/engine/cachingreaderchunk.h
+++ b/src/engine/cachingreaderchunk.h
@@ -23,7 +23,7 @@ public:
 
     // Returns the corresponding chunk index for a frame index
     inline static SINT indexForFrame(SINT frameIndex) {
-        DEBUG_ASSERT(Mixxx::AudioSource::getMinFrameIndex() <= frameIndex);
+        DEBUG_ASSERT(mixxx::AudioSource::getMinFrameIndex() <= frameIndex);
         const SINT chunkIndex = frameIndex / kFrames;
         return chunkIndex;
     }
@@ -63,14 +63,14 @@ public:
     // Check if the audio source has sample data available
     // for this chunk.
     bool isReadable(
-            const Mixxx::AudioSourcePointer& pAudioSource,
+            const mixxx::AudioSourcePointer& pAudioSource,
             SINT maxReadableFrameIndex) const;
 
     // Read sample frames from the audio source and return the
     // number of frames that have been read. The in/out parameter
     // pMaxReadableFrameIndex is adjusted if reading fails.
     SINT readSampleFrames(
-            const Mixxx::AudioSourcePointer& pAudioSource,
+            const mixxx::AudioSourcePointer& pAudioSource,
             SINT* pMaxReadableFrameIndex);
 
     // Copy sampleCount samples starting at sampleOffset from

--- a/src/engine/cachingreaderworker.cpp
+++ b/src/engine/cachingreaderworker.cpp
@@ -18,7 +18,7 @@ CachingReaderWorker::CachingReaderWorker(
           m_tag(QString("CachingReaderWorker %1").arg(m_group)),
           m_pChunkReadRequestFIFO(pChunkReadRequestFIFO),
           m_pReaderStatusFIFO(pReaderStatusFIFO),
-          m_maxReadableFrameIndex(Mixxx::AudioSource::getMinFrameIndex()),
+          m_maxReadableFrameIndex(mixxx::AudioSource::getMinFrameIndex()),
           m_stop(0) {
 }
 
@@ -97,12 +97,12 @@ void CachingReaderWorker::run() {
 
 namespace
 {
-    Mixxx::AudioSourcePointer openAudioSourceForReading(const TrackPointer& pTrack, const Mixxx::AudioSourceConfig& audioSrcCfg) {
+    mixxx::AudioSourcePointer openAudioSourceForReading(const TrackPointer& pTrack, const mixxx::AudioSourceConfig& audioSrcCfg) {
         SoundSourceProxy soundSourceProxy(pTrack);
-        Mixxx::AudioSourcePointer pAudioSource(soundSourceProxy.openAudioSource(audioSrcCfg));
+        mixxx::AudioSourcePointer pAudioSource(soundSourceProxy.openAudioSource(audioSrcCfg));
         if (pAudioSource.isNull()) {
             qWarning() << "Failed to open file:" << pTrack->getLocation();
-            return Mixxx::AudioSourcePointer();
+            return mixxx::AudioSourcePointer();
         }
         // successfully opened and readable
         return pAudioSource;
@@ -129,11 +129,11 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
         return;
     }
 
-    Mixxx::AudioSourceConfig audioSrcCfg;
+    mixxx::AudioSourceConfig audioSrcCfg;
     audioSrcCfg.setChannelCount(CachingReaderChunk::kChannels);
     m_pAudioSource = openAudioSourceForReading(pTrack, audioSrcCfg);
     if (m_pAudioSource.isNull()) {
-        m_maxReadableFrameIndex = Mixxx::AudioSource::getMinFrameIndex();
+        m_maxReadableFrameIndex = mixxx::AudioSource::getMinFrameIndex();
         // Must unlock before emitting to avoid deadlock
         qDebug() << m_group << "CachingReaderWorker::loadTrack() load failed for\""
                  << filename << "\", file invalid, unlocked reader lock";

--- a/src/engine/cachingreaderworker.h
+++ b/src/engine/cachingreaderworker.h
@@ -39,7 +39,7 @@ typedef struct ReaderStatusUpdate {
     ReaderStatusUpdate()
         : status(INVALID)
         , chunk(nullptr)
-        , maxReadableFrameIndex(Mixxx::AudioSource::getMinFrameIndex()) {
+        , maxReadableFrameIndex(mixxx::AudioSource::getMinFrameIndex()) {
     }
     ReaderStatusUpdate(
             ReaderStatus statusArg,
@@ -97,7 +97,7 @@ class CachingReaderWorker : public EngineWorker {
             const CachingReaderChunkReadRequest& request);
 
     // The current audio source of the track loaded
-    Mixxx::AudioSourcePointer m_pAudioSource;
+    mixxx::AudioSourcePointer m_pAudioSource;
 
     // The maximum readable frame index of the AudioSource. Might
     // be adjusted when decoding errors occur to prevent reading

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -638,7 +638,7 @@ QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
             } else if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK)) {
                 value = value.toBool();
             } else if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_YEAR)) {
-                value = Mixxx::TrackMetadata::formatCalendarYear(value.toString());
+                value = mixxx::TrackMetadata::formatCalendarYear(value.toString());
             } else if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER)) {
                 int track_number = value.toInt();
                 if (track_number <= 0) {
@@ -668,7 +668,7 @@ QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
                     }
                 }
             } else if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN)) {
-                value = Mixxx::ReplayGain::ratioToString(value.toDouble());
+                value = mixxx::ReplayGain::ratioToString(value.toDouble());
             } // Otherwise, just use the column value.
 
             break;

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -268,14 +268,14 @@ bool BrowseTableModel::setData(const QModelIndex &index, const QVariant &value,
     int row = index.row();
     int col = index.column();
 
-    Mixxx::TrackMetadata trackMetadata;
+    mixxx::TrackMetadata trackMetadata;
 
     // set tagger information
     trackMetadata.setArtist(this->index(row, COLUMN_ARTIST).data().toString());
     trackMetadata.setTitle(this->index(row, COLUMN_TITLE).data().toString());
     trackMetadata.setAlbum(this->index(row, COLUMN_ALBUM).data().toString());
     trackMetadata.setKey(this->index(row, COLUMN_KEY).data().toString());
-    trackMetadata.setBpm(Mixxx::Bpm(this->index(row, COLUMN_BPM).data().toDouble()));
+    trackMetadata.setBpm(mixxx::Bpm(this->index(row, COLUMN_BPM).data().toDouble()));
     trackMetadata.setComment(this->index(row, COLUMN_COMMENT).data().toString());
     trackMetadata.setTrackNumber(this->index(row, COLUMN_TRACK_NUMBER).data().toString());
     trackMetadata.setYear(this->index(row, COLUMN_YEAR).data().toString());
@@ -292,7 +292,7 @@ bool BrowseTableModel::setData(const QModelIndex &index, const QVariant &value,
     } else if (col == COLUMN_ALBUM) {
         trackMetadata.setAlbum(value.toString());
     } else if (col == COLUMN_BPM) {
-        trackMetadata.setBpm(Mixxx::Bpm(value.toDouble()));
+        trackMetadata.setBpm(mixxx::Bpm(value.toDouble()));
     } else if (col == COLUMN_KEY) {
         trackMetadata.setKey(value.toString());
     } else if (col == COLUMN_TRACK_NUMBER) {

--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -102,7 +102,7 @@ public:
         case Qt::DisplayRole:
         {
             const QString year(QStandardItem::data(role).toString());
-            return Mixxx::TrackMetadata::formatCalendarYear(year);
+            return mixxx::TrackMetadata::formatCalendarYear(year);
         }
         default:
             return QStandardItem::data(role);
@@ -189,7 +189,7 @@ void BrowseThread::populateModel() {
         item = new YearItem(year);
         item->setToolTip(year);
         // The year column is sorted according to the numeric calendar year
-        item->setData(Mixxx::TrackMetadata::parseCalendarYear(year), Qt::UserRole);
+        item->setData(mixxx::TrackMetadata::parseCalendarYear(year), Qt::UserRole);
         row_data.insert(COLUMN_YEAR, item);
 
         item = new QStandardItem(pTrack->getGenre());
@@ -255,9 +255,9 @@ void BrowseThread::populateModel() {
         item->setData(creationTime, Qt::UserRole);
         row_data.insert(COLUMN_FILE_CREATION_TIME, item);
 
-        const Mixxx::ReplayGain replayGain(pTrack->getReplayGain());
+        const mixxx::ReplayGain replayGain(pTrack->getReplayGain());
         item = new QStandardItem(
-                Mixxx::ReplayGain::ratioToString(replayGain.getRatio()));
+                mixxx::ReplayGain::ratioToString(replayGain.getRatio()));
         item->setToolTip(item->text());
         item->setData(item->text(), Qt::UserRole);
         row_data.insert(COLUMN_REPLAYGAIN, item);

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1118,7 +1118,7 @@ bool setTrackCuePoint(const QSqlRecord& record, const int column,
 
 bool setTrackReplayGainRatio(const QSqlRecord& record, const int column,
                         TrackPointer pTrack) {
-    Mixxx::ReplayGain replayGain(pTrack->getReplayGain());
+    mixxx::ReplayGain replayGain(pTrack->getReplayGain());
     replayGain.setRatio(record.value(column).toDouble());
     pTrack->setReplayGain(replayGain);
     return false;
@@ -1126,7 +1126,7 @@ bool setTrackReplayGainRatio(const QSqlRecord& record, const int column,
 
 bool setTrackReplayGainPeak(const QSqlRecord& record, const int column,
                         TrackPointer pTrack) {
-    Mixxx::ReplayGain replayGain(pTrack->getReplayGain());
+    mixxx::ReplayGain replayGain(pTrack->getReplayGain());
     replayGain.setPeak(record.value(column).toDouble());
     pTrack->setReplayGain(replayGain);
     return false;

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -172,8 +172,8 @@ void DlgTrackInfo::populateFields(const Track& track) {
     txtBpm->setText(track.getBpmText());
     m_keysClone = track.getKeys();
     txtKey->setText(KeyUtils::getGlobalKeyText(m_keysClone));
-    const Mixxx::ReplayGain replayGain(track.getReplayGain());
-    txtReplayGain->setText(Mixxx::ReplayGain::ratioToString(replayGain.getRatio()));
+    const mixxx::ReplayGain replayGain(track.getReplayGain());
+    txtReplayGain->setText(mixxx::ReplayGain::ratioToString(replayGain.getRatio()));
 
     reloadTrackBeats(track);
 

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -174,8 +174,8 @@ void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer pNewTrack, bool bPlay) {
                 m_pKey, SLOT(set(double)));
 
         // Listen for updates to the file's Replay Gain
-        connect(m_pLoadedTrack.data(), SIGNAL(ReplayGainUpdated(Mixxx::ReplayGain)),
-                this, SLOT(slotSetReplayGain(Mixxx::ReplayGain)));
+        connect(m_pLoadedTrack.data(), SIGNAL(ReplayGainUpdated(mixxx::ReplayGain)),
+                this, SLOT(slotSetReplayGain(mixxx::ReplayGain)));
     }
 
     // Request a new track from EngineBuffer and wait for slotTrackLoaded()
@@ -316,7 +316,7 @@ TrackPointer BaseTrackPlayerImpl::getLoadedTrack() const {
     return m_pLoadedTrack;
 }
 
-void BaseTrackPlayerImpl::slotSetReplayGain(Mixxx::ReplayGain replayGain) {
+void BaseTrackPlayerImpl::slotSetReplayGain(mixxx::ReplayGain replayGain) {
     // Do not change replay gain when track is playing because
     // this may lead to an unexpected volume change
     if (m_pPlay->get() == 0.0) {

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -70,7 +70,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     void slotLoadTrack(TrackPointer track, bool bPlay) override;
     void slotTrackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void slotLoadFailed(TrackPointer pTrack, QString reason);
-    void slotSetReplayGain(Mixxx::ReplayGain replayGain);
+    void slotSetReplayGain(mixxx::ReplayGain replayGain);
     void slotPlayToggled(double);
 
   private slots:

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -159,8 +159,8 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
     qRegisterMetaType<TrackId>("TrackId");
     qRegisterMetaType<QSet<TrackId>>("QSet<TrackId>");
     qRegisterMetaType<TrackPointer>("TrackPointer");
-    qRegisterMetaType<Mixxx::ReplayGain>("Mixxx::ReplayGain");
-    qRegisterMetaType<Mixxx::Bpm>("Mixxx::Bpm");
+    qRegisterMetaType<mixxx::ReplayGain>("mixxx::ReplayGain");
+    qRegisterMetaType<mixxx::Bpm>("mixxx::Bpm");
     qRegisterMetaType<mixxx::Duration>("mixxx::Duration");
 
     UserSettingsPointer pConfig = m_pSettingsManager->settings();

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -108,7 +108,7 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
           m_cmdLineArgs(args),
           m_pTouchShift(nullptr) {
     m_runtime_timer.start();
-    Time::start();
+    mixxx::Time::start();
 
     Version::logBuildDetails();
 

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -17,9 +17,9 @@ namespace
     // on their server so we need only a fingerprint of the first two minutes
     // --kain88 July 2012
     const SINT kFingerprintDuration = 120; // in seconds
-    const SINT kFingerprintChannels = Mixxx::AudioSource::kChannelCountStereo;
+    const SINT kFingerprintChannels = mixxx::AudioSource::kChannelCountStereo;
 
-    QString calcFingerprint(const Mixxx::AudioSourcePointer& pAudioSource) {
+    QString calcFingerprint(const mixxx::AudioSourcePointer& pAudioSource) {
 
         SINT numFrames =
                 kFingerprintDuration * pAudioSource->getSamplingRate();
@@ -99,9 +99,9 @@ ChromaPrinter::ChromaPrinter(QObject* parent)
 
 QString ChromaPrinter::getFingerprint(TrackPointer pTrack) {
     SoundSourceProxy soundSourceProxy(pTrack);
-    Mixxx::AudioSourceConfig audioSrcCfg;
+    mixxx::AudioSourceConfig audioSrcCfg;
     audioSrcCfg.setChannelCount(kFingerprintChannels);
-    Mixxx::AudioSourcePointer pAudioSource(soundSourceProxy.openAudioSource(audioSrcCfg));
+    mixxx::AudioSourcePointer pAudioSource(soundSourceProxy.openAudioSource(audioSrcCfg));
     if (pAudioSource.isNull()) {
         qDebug() << "Skipping invalid file:" << pTrack->getLocation();
         return QString();

--- a/src/preferences/dialog/dlgprefmodplug.cpp
+++ b/src/preferences/dialog/dlgprefmodplug.cpp
@@ -125,11 +125,11 @@ void DlgPrefModplug::applySettings() {
     // Currently this is fixed to 16bit 44.1kHz stereo
 
     // Number of channels - 1 for mono or 2 for stereo
-    settings.mChannels = Mixxx::SoundSourceModPlug::kChannelCount;
+    settings.mChannels = mixxx::SoundSourceModPlug::kChannelCount;
     // Bits per sample - 8, 16, or 32
-    settings.mBits = Mixxx::SoundSourceModPlug::kBitsPerSample;
+    settings.mBits = mixxx::SoundSourceModPlug::kBitsPerSample;
     // Sampling rate - 11025, 22050, or 44100
-    settings.mFrequency = Mixxx::SoundSourceModPlug::kSamplingRate;
+    settings.mFrequency = mixxx::SoundSourceModPlug::kSamplingRate;
 
     // enabled features flags
     settings.mFlags = 0;
@@ -180,5 +180,5 @@ void DlgPrefModplug::applySettings() {
     settings.mLoopCount = 0;
 
     // apply modplug settings
-    Mixxx::SoundSourceModPlug::configure(bufferSizeLimit, settings);
+    mixxx::SoundSourceModPlug::configure(bufferSizeLimit, settings);
 }

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -2,7 +2,7 @@
 
 #include "util/sample.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 void AudioSource::clampFrameInterval(
         SINT* pMinFrameIndexOfInterval,

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -8,7 +8,7 @@
 #include "util/result.h"
 #include "util/samplebuffer.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 // forward declaration(s)
 class AudioSourceConfig;
@@ -233,6 +233,6 @@ class AudioSourceConfig : public AudioSignal {
 
 typedef QSharedPointer<AudioSource> AudioSourcePointer;
 
-} // namespace Mixxx
+} // namespace mixxx
 
 #endif // MIXXX_AUDIOSOURCE_H

--- a/src/sources/metadatasource.h
+++ b/src/sources/metadatasource.h
@@ -6,7 +6,7 @@
 #include "track/trackmetadata.h"
 #include "util/result.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 // Interface for parsing track metadata and cover art.
 class MetadataSource {
@@ -27,6 +27,6 @@ protected:
     virtual ~MetadataSource() {}
 };
 
-} //namespace Mixxx
+} //namespace mixxx
 
 #endif // MIXXX_METADATASOURCE_H

--- a/src/sources/mp3decoding.h
+++ b/src/sources/mp3decoding.h
@@ -3,7 +3,7 @@
 
 #include "util/types.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 // In the worst case up to 29 MP3 frames need to be prefetched
 // for accurate seeking:
@@ -11,6 +11,6 @@ namespace Mixxx {
 // Used by both SoundSourceMp3 and SoundSourceCoreAudio.
 static const SINT kMp3SeekFramePrefetchCount = 29;
 
-} // namespace Mixxx
+} // namespace mixxx
 
 #endif // MIXXX_MP3DECODING_H

--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -2,7 +2,7 @@
 
 #include "track/trackmetadatataglib.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 /*static*/ QString SoundSource::getFileExtensionFromUrl(const QUrl& url) {
     return url.toString().section(".", -1).toLower().trimmed();
@@ -51,4 +51,4 @@ Result SoundSource::writeTrackMetadata(
     return writeTrackMetadataIntoFile(trackMetadata, getLocalFileName());
 }
 
-} //namespace Mixxx
+} //namespace mixxx

--- a/src/sources/soundsource.h
+++ b/src/sources/soundsource.h
@@ -4,7 +4,7 @@
 #include "sources/metadatasource.h"
 #include "sources/audiosource.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 // Base class for sound sources.
 class SoundSource: public MetadataSource, public AudioSource {
@@ -77,6 +77,6 @@ private:
 
 typedef QSharedPointer<SoundSource> SoundSourcePointer;
 
-} //namespace Mixxx
+} //namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCE_H

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -3,7 +3,7 @@
 
 #include "util/math.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 namespace {
 
@@ -210,4 +210,4 @@ QStringList SoundSourceProviderCoreAudio::getSupportedFileExtensions() const {
     return supportedFileExtensions;
 }
 
-}  // namespace Mixxx
+}  // namespace mixxx

--- a/src/sources/soundsourcecoreaudio.h
+++ b/src/sources/soundsourcecoreaudio.h
@@ -18,9 +18,9 @@
 #include "AudioFormat.h"
 #endif
 
-namespace Mixxx {
+namespace mixxx {
 
-class SoundSourceCoreAudio : public Mixxx::SoundSource {
+class SoundSourceCoreAudio : public mixxx::SoundSource {
 public:
     explicit SoundSourceCoreAudio(QUrl url);
     ~SoundSourceCoreAudio() override;
@@ -53,6 +53,6 @@ public:
     }
 };
 
-}  // namespace Mixxx
+}  // namespace mixxx
 
 #endif // SOUNDSOURCECOREAUDIO_H

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -10,7 +10,7 @@
 #define AUDIOSOURCEFFMPEG_BYTEOFFSET_TO_MIXXXFRAME(byteOffset) (samples2frames(byteOffset / sizeof(CSAMPLE)))
 #define AUDIOSOURCEFFMPEG_FILL_FROM_CURRENTPOS -1
 
-namespace Mixxx {
+namespace mixxx {
 
 namespace {
 
@@ -712,4 +712,4 @@ SINT SoundSourceFFmpeg::readSampleFrames(SINT numberOfFrames,
     return numberOfFrames;
 }
 
-} // namespace Mixxx
+} // namespace mixxx

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -26,7 +26,7 @@ extern "C" {
 // forward declaration
 class EncoderFfmpegResample;
 
-namespace Mixxx {
+namespace mixxx {
 
 struct ffmpegLocationObject {
     SINT pos;
@@ -106,6 +106,6 @@ class SoundSourceProviderFFmpeg: public SoundSourceProvider {
     }
 };
 
-} // namespace Mixxx
+} // namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCEFFMPEG_H

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -3,7 +3,7 @@
 #include "util/math.h"
 #include "util/sample.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 namespace {
 
@@ -521,4 +521,4 @@ QStringList SoundSourceProviderFLAC::getSupportedFileExtensions() const {
     return supportedFileExtensions;
 }
 
-} // namespace Mixxx
+} // namespace mixxx

--- a/src/sources/soundsourceflac.h
+++ b/src/sources/soundsourceflac.h
@@ -9,7 +9,7 @@
 
 #include <QFile>
 
-namespace Mixxx {
+namespace mixxx {
 
 class SoundSourceFLAC: public SoundSource {
 public:
@@ -72,6 +72,6 @@ public:
     }
 };
 
-} // namespace Mixxx
+} // namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCEFLAC_H

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-namespace Mixxx {
+namespace mixxx {
 
 namespace {
 
@@ -204,4 +204,4 @@ QStringList SoundSourceProviderModPlug::getSupportedFileExtensions() const {
     return supportedFileExtensions;
 }
 
-} // namespace Mixxx
+} // namespace mixxx

--- a/src/sources/soundsourcemodplug.h
+++ b/src/sources/soundsourcemodplug.h
@@ -9,12 +9,12 @@ namespace ModPlug {
 
 #include <vector>
 
-namespace Mixxx {
+namespace mixxx {
 
 // Class for reading tracker files using libmodplug.
 // The whole file is decoded at once and saved
 // in RAM to allow seeking and smooth operation in Mixxx.
-class SoundSourceModPlug: public Mixxx::SoundSource {
+class SoundSourceModPlug: public mixxx::SoundSource {
 public:
     static const SINT kChannelCount;
     static const SINT kSamplingRate;
@@ -63,6 +63,6 @@ public:
     }
 };
 
-} // namespace Mixxx
+} // namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCEMODPLUG_H

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -5,7 +5,7 @@
 
 #include <id3tag.h>
 
-namespace Mixxx {
+namespace mixxx {
 
 namespace {
 
@@ -718,4 +718,4 @@ QStringList SoundSourceProviderMp3::getSupportedFileExtensions() const {
     return supportedFileExtensions;
 }
 
-} // namespace Mixxx
+} // namespace mixxx

--- a/src/sources/soundsourcemp3.h
+++ b/src/sources/soundsourcemp3.h
@@ -15,7 +15,7 @@
 
 #include <vector>
 
-namespace Mixxx {
+namespace mixxx {
 
 class SoundSourceMp3: public SoundSource {
 public:
@@ -92,6 +92,6 @@ public:
     }
 };
 
-} // namespace Mixxx
+} // namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCEMP3_H

--- a/src/sources/soundsourceoggvorbis.cpp
+++ b/src/sources/soundsourceoggvorbis.cpp
@@ -2,7 +2,7 @@
 
 #include <QFile>
 
-namespace Mixxx {
+namespace mixxx {
 
 namespace {
 
@@ -267,4 +267,4 @@ QStringList SoundSourceProviderOggVorbis::getSupportedFileExtensions() const {
     return supportedFileExtensions;
 }
 
-} // namespace Mixxx
+} // namespace mixxx

--- a/src/sources/soundsourceoggvorbis.h
+++ b/src/sources/soundsourceoggvorbis.h
@@ -9,7 +9,7 @@
 
 class QFile;
 
-namespace Mixxx {
+namespace mixxx {
 
 class SoundSourceOggVorbis: public SoundSource {
 public:
@@ -57,6 +57,6 @@ public:
     }
 };
 
-} // namespace Mixxx
+} // namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCEOGGVORBIS_H

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -1,6 +1,6 @@
 #include "sources/soundsourceopus.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 namespace {
 
@@ -294,4 +294,4 @@ QStringList SoundSourceProviderOpus::getSupportedFileExtensions() const {
     return supportedFileExtensions;
 }
 
-} // namespace Mixxx
+} // namespace mixxx

--- a/src/sources/soundsourceopus.h
+++ b/src/sources/soundsourceopus.h
@@ -6,9 +6,9 @@
 #define OV_EXCLUDE_STATIC_CALLBACKS
 #include <opus/opusfile.h>
 
-namespace Mixxx {
+namespace mixxx {
 
-class SoundSourceOpus: public Mixxx::SoundSource {
+class SoundSourceOpus: public mixxx::SoundSource {
 public:
     explicit SoundSourceOpus(const QUrl& url);
     ~SoundSourceOpus() override;
@@ -45,6 +45,6 @@ public:
     }
 };
 
-} // namespace Mixxx
+} // namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCEOPUS_H

--- a/src/sources/soundsourceplugin.cpp
+++ b/src/sources/soundsourceplugin.cpp
@@ -2,7 +2,7 @@
 #include "defs_version.h"
 
 
-namespace Mixxx {
+namespace mixxx {
 
 namespace {
 
@@ -19,7 +19,7 @@ SoundSourcePointer exportSoundSourcePlugin(
     return SoundSourcePointer(pSoundSourcePlugin, deleteSoundSource);
 }
 
-} // namespace Mixxx
+} // namespace mixxx
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT const char* Mixxx_getVersion() {
     return VERSION;

--- a/src/sources/soundsourceplugin.h
+++ b/src/sources/soundsourceplugin.h
@@ -3,7 +3,7 @@
 
 #include "sources/soundsourcepluginapi.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 // Common base class for SoundSource plugins
 class SoundSourcePlugin: public SoundSource {
@@ -23,7 +23,7 @@ protected:
 SoundSourcePointer exportSoundSourcePlugin(
         SoundSourcePlugin* pSoundSourcePlugin);
 
-} // namespace Mixxx
+} // namespace mixxx
 
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT const char* Mixxx_getVersion();
 extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT int Mixxx_SoundSourcePluginAPI_getVersion();

--- a/src/sources/soundsourcepluginapi.h
+++ b/src/sources/soundsourcepluginapi.h
@@ -30,7 +30,7 @@
 
 // Function types and names of the public SoundSource plugin API
 
-namespace Mixxx {
+namespace mixxx {
 
 // extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT const char* Mixxx_getVersion()
 
@@ -42,7 +42,7 @@ const char * const SoundSourcePluginAPI_getVersionFuncName = "Mixxx_SoundSourceP
 typedef SoundSourceProvider* (*SoundSourcePluginAPI_createSoundSourceProviderFunc)();
 const char* const SoundSourcePluginAPI_createSoundSourceProviderFuncName = "Mixxx_SoundSourcePluginAPI_createSoundSourceProvider";
 
-// extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(Mixxx::SoundSourceProvider*)
+// extern "C" MIXXX_SOUNDSOURCEPLUGINAPI_EXPORT void Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider(mixxx::SoundSourceProvider*)
 typedef void (*SoundSourcePluginAPI_destroySoundSourceProviderFunc)(SoundSourceProvider*);
 const char* const SoundSourcePluginAPI_destroySoundSourceProviderFuncName = "Mixxx_SoundSourcePluginAPI_destroySoundSourceProvider";
 

--- a/src/sources/soundsourcepluginlibrary.cpp
+++ b/src/sources/soundsourcepluginlibrary.cpp
@@ -2,7 +2,7 @@
 
 #include <QMutexLocker>
 
-namespace Mixxx {
+namespace mixxx {
 
 /*static*/ QMutex SoundSourcePluginLibrary::s_loadedPluginLibrariesMutex;
 /*static*/ QMap<QString, SoundSourcePluginLibraryPointer> SoundSourcePluginLibrary::s_loadedPluginLibraries;

--- a/src/sources/soundsourcepluginlibrary.h
+++ b/src/sources/soundsourcepluginlibrary.h
@@ -7,7 +7,7 @@
 #include <QMutex>
 #include <QLibrary>
 
-namespace Mixxx {
+namespace mixxx {
 
 class SoundSourcePluginLibrary;
 
@@ -39,7 +39,7 @@ protected:
 
 private:
     static QMutex s_loadedPluginLibrariesMutex;
-    static QMap<QString, Mixxx::SoundSourcePluginLibraryPointer> s_loadedPluginLibraries;
+    static QMap<QString, mixxx::SoundSourcePluginLibraryPointer> s_loadedPluginLibraries;
 
     QLibrary m_library;
 
@@ -50,6 +50,6 @@ private:
     SoundSourcePluginAPI_destroySoundSourceProviderFunc m_destroySoundSourceProviderFunc;
 };
 
-} // namespace Mixxx
+} // namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCEPLUGINLIBRARY_H

--- a/src/sources/soundsourceprovider.h
+++ b/src/sources/soundsourceprovider.h
@@ -7,7 +7,7 @@
 
 #include "sources/soundsource.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 // Providers for the same file extension are selected according
 // to the priority for which they have been registered. Only
@@ -52,6 +52,6 @@ public:
     virtual SoundSourcePointer newSoundSource(const QUrl& url) = 0;
 };
 
-} // namespace Mixxx
+} // namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCEPROVIDER_H

--- a/src/sources/soundsourceproviderregistry.cpp
+++ b/src/sources/soundsourceproviderregistry.cpp
@@ -1,6 +1,6 @@
 #include "soundsourceproviderregistry.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 void SoundSourceProviderRegistry::registerProvider(
         const SoundSourceProviderPointer& pProvider) {

--- a/src/sources/soundsourceproviderregistry.h
+++ b/src/sources/soundsourceproviderregistry.h
@@ -5,7 +5,7 @@
 
 #include <QMap>
 
-namespace Mixxx {
+namespace mixxx {
 
 class SoundSourceProviderRegistration {
 public:
@@ -99,6 +99,6 @@ private:
     FileExtension2RegistrationList m_registry;
 };
 
-} // namespace Mixxx
+} // namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCEPROVIDERREGISTRY_H

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -29,7 +29,7 @@
 #include "util/regex.h"
 
 //Static memory allocation
-/*static*/ Mixxx::SoundSourceProviderRegistry SoundSourceProxy::s_soundSourceProviders;
+/*static*/ mixxx::SoundSourceProviderRegistry SoundSourceProxy::s_soundSourceProviders;
 /*static*/ QStringList SoundSourceProxy::s_supportedFileNamePatterns;
 /*static*/ QRegExp SoundSourceProxy::s_supportedFileNamesRegex;
 
@@ -145,33 +145,33 @@ void SoundSourceProxy::loadPlugins() {
     // only matters among providers with equal priority.
 #ifdef __FFMPEGFILE__
     // Use FFmpeg as the last resort.
-    s_soundSourceProviders.registerProvider(Mixxx::SoundSourceProviderPointer(
-            new Mixxx::SoundSourceProviderFFmpeg));
+    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
+            new mixxx::SoundSourceProviderFFmpeg));
 #endif
 #ifdef __SNDFILE__
     // libsndfile is another fallback
-    s_soundSourceProviders.registerProvider(Mixxx::SoundSourceProviderPointer(
-            new Mixxx::SoundSourceProviderSndFile));
+    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
+            new mixxx::SoundSourceProviderSndFile));
 #endif
-    s_soundSourceProviders.registerProvider(Mixxx::SoundSourceProviderPointer(
-            new Mixxx::SoundSourceProviderFLAC));
-    s_soundSourceProviders.registerProvider(Mixxx::SoundSourceProviderPointer(
-            new Mixxx::SoundSourceProviderOggVorbis));
+    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
+            new mixxx::SoundSourceProviderFLAC));
+    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
+            new mixxx::SoundSourceProviderOggVorbis));
 #ifdef __OPUS__
-    s_soundSourceProviders.registerProvider(Mixxx::SoundSourceProviderPointer(
-            new Mixxx::SoundSourceProviderOpus));
+    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
+            new mixxx::SoundSourceProviderOpus));
 #endif
 #ifdef __MAD__
-    s_soundSourceProviders.registerProvider(Mixxx::SoundSourceProviderPointer(
-            new Mixxx::SoundSourceProviderMp3));
+    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
+            new mixxx::SoundSourceProviderMp3));
 #endif
 #ifdef __MODPLUG__
-    s_soundSourceProviders.registerProvider(Mixxx::SoundSourceProviderPointer(
-            new Mixxx::SoundSourceProviderModPlug));
+    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
+            new mixxx::SoundSourceProviderModPlug));
 #endif
 #ifdef __COREAUDIO__
-    s_soundSourceProviders.registerProvider(Mixxx::SoundSourceProviderPointer(
-            new Mixxx::SoundSourceProviderCoreAudio));
+    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
+            new mixxx::SoundSourceProviderCoreAudio));
 #endif
 
     // Scan for and initialize all plugins.
@@ -185,8 +185,8 @@ void SoundSourceProxy::loadPlugins() {
                 QDir::Files | QDir::NoDotAndDotDot));
         for (const auto& file: files) {
             const QString libFilePath(pluginDir.filePath(file));
-            Mixxx::SoundSourcePluginLibraryPointer pPluginLibrary(
-                    Mixxx::SoundSourcePluginLibrary::load(libFilePath));
+            mixxx::SoundSourcePluginLibraryPointer pPluginLibrary(
+                    mixxx::SoundSourcePluginLibrary::load(libFilePath));
             if (pPluginLibrary) {
                 s_soundSourceProviders.registerPluginLibrary(pPluginLibrary);
             } else {
@@ -200,7 +200,7 @@ void SoundSourceProxy::loadPlugins() {
             s_soundSourceProviders.getRegisteredFileExtensions());
     for (const auto &supportedFileExtension: supportedFileExtensions) {
         qDebug() << "SoundSource providers for file extension" << supportedFileExtension;
-        const QList<Mixxx::SoundSourceProviderRegistration> registrationsForFileExtension(
+        const QList<mixxx::SoundSourceProviderRegistration> registrationsForFileExtension(
                 s_soundSourceProviders.getRegistrationsForFileExtension(
                         supportedFileExtension));
         for (const auto& registration: registrationsForFileExtension) {
@@ -233,7 +233,7 @@ QStringList SoundSourceProxy::getSupportedFileExtensionsByPlugins() {
     QStringList supportedFileExtensionsByPlugins;
     const QStringList supportedFileExtensions(getSupportedFileExtensions());
     for (const auto &supportedFileExtension: supportedFileExtensions) {
-        const QList<Mixxx::SoundSourceProviderRegistration> registrationsForFileExtension(
+        const QList<mixxx::SoundSourceProviderRegistration> registrationsForFileExtension(
                 s_soundSourceProviders.getRegistrationsForFileExtension(
                         supportedFileExtension));
         for (const auto& registration: registrationsForFileExtension) {
@@ -267,20 +267,20 @@ bool SoundSourceProxy::isFileExtensionSupported(const QString& fileExtension) {
 }
 
 // static
-QList<Mixxx::SoundSourceProviderRegistration>
+QList<mixxx::SoundSourceProviderRegistration>
 SoundSourceProxy::findSoundSourceProviderRegistrations(
         const QUrl& url) {
     if (url.isEmpty()) {
         // silently ignore empty URLs
-        return QList<Mixxx::SoundSourceProviderRegistration>();
+        return QList<mixxx::SoundSourceProviderRegistration>();
     }
-    QString fileExtension(Mixxx::SoundSource::getFileExtensionFromUrl(url));
+    QString fileExtension(mixxx::SoundSource::getFileExtensionFromUrl(url));
     if (fileExtension.isEmpty()) {
         qWarning() << "Unknown file type:" << url.toString();
-        return QList<Mixxx::SoundSourceProviderRegistration>();
+        return QList<mixxx::SoundSourceProviderRegistration>();
     }
 
-    QList<Mixxx::SoundSourceProviderRegistration> registrationsForFileExtension(
+    QList<mixxx::SoundSourceProviderRegistration> registrationsForFileExtension(
             s_soundSourceProviders.getRegistrationsForFileExtension(
                     fileExtension));
     if (registrationsForFileExtension.isEmpty()) {
@@ -297,7 +297,7 @@ SoundSourceProxy::SaveTrackMetadataResult SoundSourceProxy::saveTrackMetadata(
     DEBUG_ASSERT(nullptr != pTrack);
     SoundSourceProxy proxy(pTrack);
     if (!proxy.m_pSoundSource.isNull()) {
-        Mixxx::TrackMetadata trackMetadata;
+        mixxx::TrackMetadata trackMetadata;
         bool parsedFromFile = false;
         pTrack->getTrackMetadata(&trackMetadata, &parsedFromFile);
         if (parsedFromFile || evenIfNeverParsedFromFileBefore) {
@@ -337,12 +337,12 @@ SoundSourceProxy::SoundSourceProxy(const Track* pTrack)
     initSoundSource();
 }
 
-Mixxx::SoundSourceProviderPointer SoundSourceProxy::getSoundSourceProvider() const {
+mixxx::SoundSourceProviderPointer SoundSourceProxy::getSoundSourceProvider() const {
     DEBUG_ASSERT(0 <= m_soundSourceProviderRegistrationIndex);
     if (m_soundSourceProviderRegistrations.size() > m_soundSourceProviderRegistrationIndex) {
         return m_soundSourceProviderRegistrations[m_soundSourceProviderRegistrationIndex].getProvider();
     } else {
-        return Mixxx::SoundSourceProviderPointer();
+        return mixxx::SoundSourceProviderPointer();
     }
 }
 
@@ -359,7 +359,7 @@ void SoundSourceProxy::initSoundSource() {
     DEBUG_ASSERT(m_pSoundSource.isNull());
     DEBUG_ASSERT(m_pAudioSource.isNull());
     while (m_pSoundSource.isNull()) {
-        Mixxx::SoundSourceProviderPointer pProvider(getSoundSourceProvider());
+        mixxx::SoundSourceProviderPointer pProvider(getSoundSourceProvider());
         if (pProvider.isNull()) {
             if (!getUrl().isEmpty()) {
                 qWarning() << "No SoundSourceProvider for file"
@@ -399,7 +399,7 @@ namespace {
     // or "artist_-_title.xxx".
     // This function does not overwrite any existing (non-empty) artist
     // and title fields!
-    void parseMetadataFromFileName(Mixxx::TrackMetadata* pTrackMetadata, QString fileName) {
+    void parseMetadataFromFileName(mixxx::TrackMetadata* pTrackMetadata, QString fileName) {
         fileName.replace("_", " ");
         QString titleWithFileType;
         if (fileName.count('-') == 1) {
@@ -440,7 +440,7 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
     // Depending on the file type some kind of tags might even
     // not be supported at all and those would get lost!
     bool parsedFromFile = false;
-    Mixxx::TrackMetadata trackMetadata;
+    mixxx::TrackMetadata trackMetadata;
     m_pTrack->getTrackMetadata(&trackMetadata, &parsedFromFile);
     if (parsedFromFile && !reloadFromFile) {
         qDebug() << "Skip parsing of track metadata from file"
@@ -494,7 +494,7 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
     }
 }
 
-Result SoundSourceProxy::parseTrackMetadata(Mixxx::TrackMetadata* pTrackMetadata) const {
+Result SoundSourceProxy::parseTrackMetadata(mixxx::TrackMetadata* pTrackMetadata) const {
     if (!m_pSoundSource.isNull()) {
         return m_pSoundSource->parseTrackMetadataAndCoverArt(pTrackMetadata, nullptr);
     } else {
@@ -517,17 +517,17 @@ namespace {
 // accessing the corresponding file to avoid file
 // corruption when writing metadata while the file
 // is still in use.
-class AudioSourceProxy: public Mixxx::AudioSource {
+class AudioSourceProxy: public mixxx::AudioSource {
 public:
     AudioSourceProxy(const AudioSourceProxy&) = delete;
     AudioSourceProxy(AudioSourceProxy&&) = delete;
 
-    static Mixxx::AudioSourcePointer create(
+    static mixxx::AudioSourcePointer create(
             const TrackPointer& pTrack,
-            const Mixxx::AudioSourcePointer& pAudioSource) {
+            const mixxx::AudioSourcePointer& pAudioSource) {
         DEBUG_ASSERT(!pTrack.isNull());
         DEBUG_ASSERT(!pAudioSource.isNull());
-        return Mixxx::AudioSourcePointer(
+        return mixxx::AudioSourcePointer(
                 new AudioSourceProxy(pTrack, pAudioSource));
     }
 
@@ -557,19 +557,19 @@ public:
 private:
     AudioSourceProxy(
             const TrackPointer& pTrack,
-            const Mixxx::AudioSourcePointer& pAudioSource)
-        : Mixxx::AudioSource(*pAudioSource),
+            const mixxx::AudioSourcePointer& pAudioSource)
+        : mixxx::AudioSource(*pAudioSource),
           m_pTrack(pTrack),
           m_pAudioSource(pAudioSource) {
     }
 
     const TrackPointer m_pTrack;
-    const Mixxx::AudioSourcePointer m_pAudioSource;
+    const mixxx::AudioSourcePointer m_pAudioSource;
 };
 
 } // anonymous namespace
 
-Mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const Mixxx::AudioSourceConfig& audioSrcCfg) {
+mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSourceConfig& audioSrcCfg) {
     DEBUG_ASSERT(!m_pTrack.isNull());
     while (m_pAudioSource.isNull()) {
         if (m_pSoundSource.isNull()) {
@@ -577,13 +577,13 @@ Mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const Mixxx::AudioSo
                        << getUrl().toString();
             return m_pAudioSource; // failure -> exit loop
         }
-        const Mixxx::SoundSource::OpenResult openResult = m_pSoundSource->open(audioSrcCfg);
-        if (Mixxx::SoundSource::OpenResult::UNSUPPORTED_FORMAT != openResult) {
+        const mixxx::SoundSource::OpenResult openResult = m_pSoundSource->open(audioSrcCfg);
+        if (mixxx::SoundSource::OpenResult::UNSUPPORTED_FORMAT != openResult) {
             qDebug() << "Opened AudioSource for file"
                      << getUrl().toString()
                      << "with provider"
                      << getSoundSourceProvider()->getName();
-            if (Mixxx::SoundSource::OpenResult::FAILED == openResult) {
+            if (mixxx::SoundSource::OpenResult::FAILED == openResult) {
                 qWarning() << "Invalid audio data in file"
                            << getUrl().toString();
                 // Do NOT retry with the next SoundSource provider if
@@ -591,7 +591,7 @@ Mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const Mixxx::AudioSo
                 m_pSoundSource->close();
                 break; // exit loop
             } else {
-                DEBUG_ASSERT(Mixxx::SoundSource::OpenResult::SUCCEEDED == openResult);
+                DEBUG_ASSERT(mixxx::SoundSource::OpenResult::SUCCEEDED == openResult);
                 if (m_pSoundSource->isValid()) {
                     m_pAudioSource =
                             AudioSourceProxy::create(m_pTrack, m_pSoundSource);

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -54,7 +54,7 @@ class SoundSourceProxy {
 
     // Parse only the metadata from the file without modifying
     // the referenced track.
-    Result parseTrackMetadata(Mixxx::TrackMetadata* pTrackMetadata) const;
+    Result parseTrackMetadata(mixxx::TrackMetadata* pTrackMetadata) const;
 
     // Parse only the cover image from the file without modifying
     // the referenced track.
@@ -72,13 +72,13 @@ class SoundSourceProxy {
     // Opening the audio data through the proxy will
     // update the some metadata of the track object.
     // Returns a null pointer on failure.
-    Mixxx::AudioSourcePointer openAudioSource(
-            const Mixxx::AudioSourceConfig& audioSrcCfg = Mixxx::AudioSourceConfig());
+    mixxx::AudioSourcePointer openAudioSource(
+            const mixxx::AudioSourceConfig& audioSrcCfg = mixxx::AudioSourceConfig());
 
     void closeAudioSource();
 
   private:
-    static Mixxx::SoundSourceProviderRegistry s_soundSourceProviders;
+    static mixxx::SoundSourceProviderRegistry s_soundSourceProviders;
     static QStringList s_supportedFileNamePatterns;
     static QRegExp s_supportedFileNamesRegex;
 
@@ -91,12 +91,12 @@ class SoundSourceProxy {
 
     const QUrl m_url;
 
-    static QList<Mixxx::SoundSourceProviderRegistration> findSoundSourceProviderRegistrations(const QUrl& url);
+    static QList<mixxx::SoundSourceProviderRegistration> findSoundSourceProviderRegistrations(const QUrl& url);
 
-    const QList<Mixxx::SoundSourceProviderRegistration> m_soundSourceProviderRegistrations;
+    const QList<mixxx::SoundSourceProviderRegistration> m_soundSourceProviderRegistrations;
     int m_soundSourceProviderRegistrationIndex;
 
-    Mixxx::SoundSourceProviderPointer getSoundSourceProvider() const;
+    mixxx::SoundSourceProviderPointer getSoundSourceProvider() const;
     void nextSoundSourceProvider();
 
     void initSoundSource();
@@ -105,13 +105,13 @@ class SoundSourceProxy {
 
     // This pointer must stay in this class together with
     // the corresponding track pointer. Don't pass it around!!
-    Mixxx::SoundSourcePointer m_pSoundSource;
+    mixxx::SoundSourcePointer m_pSoundSource;
 
     // Keeps track of opening and closing the corresponding
     // SoundSource. This pointer can safely be passed around,
     // because internally it contains a reference to the TIO
     // that keeps it alive.
-    Mixxx::AudioSourcePointer m_pAudioSource;
+    mixxx::AudioSourcePointer m_pAudioSource;
 };
 
 #endif // MIXXX_SOURCES_SOUNDSOURCEPROXY_H

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -2,7 +2,7 @@
 
 #include "sources/soundsourcesndfile.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 SoundSourceSndFile::SoundSourceSndFile(const QUrl& url)
         : SoundSource(url),
@@ -117,4 +117,4 @@ QStringList SoundSourceProviderSndFile::getSupportedFileExtensions() const {
     return supportedFileExtensions;
 }
 
-} // namespace Mixxx
+} // namespace mixxx

--- a/src/sources/soundsourcesndfile.h
+++ b/src/sources/soundsourcesndfile.h
@@ -11,9 +11,9 @@
 #endif
 #include <sndfile.h>
 
-namespace Mixxx {
+namespace mixxx {
 
-class SoundSourceSndFile: public Mixxx::SoundSource {
+class SoundSourceSndFile: public mixxx::SoundSource {
 public:
     explicit SoundSourceSndFile(const QUrl& url);
     ~SoundSourceSndFile() override;
@@ -49,6 +49,6 @@ public:
     }
 };
 
-} // namespace Mixxx
+} // namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCESNDFILE_H

--- a/src/sources/urlresource.h
+++ b/src/sources/urlresource.h
@@ -5,7 +5,7 @@
 
 #include <QUrl>
 
-namespace Mixxx {
+namespace mixxx {
 
 class UrlResource {
 public:
@@ -40,6 +40,6 @@ private:
     const QUrl m_url;
 };
 
-} // namespace Mixxx
+} // namespace mixxx
 
 #endif // MIXXX_URLRESOURCE_H

--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -24,20 +24,20 @@ class MetadataTest : public testing::Test {
         //qDebug() << "parseBpm" << inputValue << expectedResult << expectedValue;
 
         bool actualResult;
-        const double actualValue = Mixxx::Bpm::valueFromString(inputValue, &actualResult);
+        const double actualValue = mixxx::Bpm::valueFromString(inputValue, &actualResult);
 
         EXPECT_EQ(expectedResult, actualResult);
         EXPECT_DOUBLE_EQ(expectedValue, actualValue);
 
 //        if (actualResult) {
-//            qDebug() << "BPM:" << inputValue << "->" << Mixxx::Bpm::valueToString(actualValue);
+//            qDebug() << "BPM:" << inputValue << "->" << mixxx::Bpm::valueToString(actualValue);
 //        }
 
         return actualResult;
     }
 
     void normalizeBpm(double normalizedValue) {
-        Mixxx::Bpm normalizedBpm(normalizedValue);
+        mixxx::Bpm normalizedBpm(normalizedValue);
         normalizedBpm.normalizeValue(); // re-normalize
         // Expected: Re-normalization does not change the value
         // that should already be normalized.
@@ -50,7 +50,7 @@ TEST_F(MetadataTest, ParseBpmPrecision) {
 }
 
 TEST_F(MetadataTest, ParseBpmValidRange) {
-    for (int bpm100 = int(Mixxx::Bpm::kValueMin) * 100; kBpmValueMax * 100 >= bpm100; ++bpm100) {
+    for (int bpm100 = int(mixxx::Bpm::kValueMin) * 100; kBpmValueMax * 100 >= bpm100; ++bpm100) {
         const double expectedValue = bpm100 / 100.0;
         const QString inputValues[] = {
                 QString("%1").arg(expectedValue),
@@ -63,17 +63,17 @@ TEST_F(MetadataTest, ParseBpmValidRange) {
 }
 
 TEST_F(MetadataTest, ParseBpmInvalid) {
-    parseBpm("", false, Mixxx::Bpm::kValueUndefined);
-    parseBpm("abcde", false, Mixxx::Bpm::kValueUndefined);
-    parseBpm("0 dBA", false, Mixxx::Bpm::kValueUndefined);
+    parseBpm("", false, mixxx::Bpm::kValueUndefined);
+    parseBpm("abcde", false, mixxx::Bpm::kValueUndefined);
+    parseBpm("0 dBA", false, mixxx::Bpm::kValueUndefined);
 }
 
 TEST_F(MetadataTest, NormalizeBpm) {
-    normalizeBpm(Mixxx::Bpm::kValueUndefined);
-    normalizeBpm(Mixxx::Bpm::kValueMin);
-    normalizeBpm(Mixxx::Bpm::kValueMin - 1.0);
-    normalizeBpm(Mixxx::Bpm::kValueMin + 1.0);
-    normalizeBpm(-Mixxx::Bpm::kValueMin);
+    normalizeBpm(mixxx::Bpm::kValueUndefined);
+    normalizeBpm(mixxx::Bpm::kValueMin);
+    normalizeBpm(mixxx::Bpm::kValueMin - 1.0);
+    normalizeBpm(mixxx::Bpm::kValueMin + 1.0);
+    normalizeBpm(-mixxx::Bpm::kValueMin);
     normalizeBpm(kBpmValueMax);
     normalizeBpm(kBpmValueMax - 1.0);
     normalizeBpm(kBpmValueMax + 1.0);
@@ -99,22 +99,22 @@ TEST_F(MetadataTest, ID3v2Year) {
             TagLib::ID3v2::Tag tag;
             tag.header()->setMajorVersion(majorVersion);
             {
-                Mixxx::TrackMetadata trackMetadata;
+                mixxx::TrackMetadata trackMetadata;
                 trackMetadata.setYear(year);
                 writeTrackMetadataIntoID3v2Tag(&tag, trackMetadata);
             }
-            Mixxx::TrackMetadata trackMetadata;
+            mixxx::TrackMetadata trackMetadata;
             readTrackMetadataFromID3v2Tag(&trackMetadata, tag);
             if (4 > majorVersion) {
                 // ID3v2.3.0: parsed + formatted
                 const QString actualYear(trackMetadata.getYear());
-                const QDate expectedDate(Mixxx::TrackMetadata::parseDate(year));
+                const QDate expectedDate(mixxx::TrackMetadata::parseDate(year));
                 if (expectedDate.isValid()) {
                     // Only the date part can be stored in an ID3v2.3.0 tag
-                    EXPECT_EQ(Mixxx::TrackMetadata::formatDate(expectedDate), actualYear);
+                    EXPECT_EQ(mixxx::TrackMetadata::formatDate(expectedDate), actualYear);
                 } else {
                     // numeric year (without month/day)
-                    EXPECT_EQ(Mixxx::TrackMetadata::reformatYear(year), actualYear);
+                    EXPECT_EQ(mixxx::TrackMetadata::reformatYear(year), actualYear);
                 }
             } else {
                 // ID3v2.4.0: currently unverified/unmodified
@@ -126,25 +126,25 @@ TEST_F(MetadataTest, ID3v2Year) {
 
 TEST_F(MetadataTest, CalendarYear) {
     // Parsing
-    EXPECT_EQ(2014, Mixxx::TrackMetadata::parseCalendarYear("2014-04-29T07:00:00Z"));
-    EXPECT_EQ(2014, Mixxx::TrackMetadata::parseCalendarYear("2014-04-29"));
-    EXPECT_EQ(2014, Mixxx::TrackMetadata::parseCalendarYear("2014"));
-    EXPECT_EQ(2015, Mixxx::TrackMetadata::parseCalendarYear("2015-02"));
-    EXPECT_EQ(1997, Mixxx::TrackMetadata::parseCalendarYear("1997-W43"));
-    EXPECT_EQ(1, Mixxx::TrackMetadata::parseCalendarYear("1"));
-    EXPECT_EQ(Mixxx::TrackMetadata::kCalendarYearInvalid, Mixxx::TrackMetadata::parseCalendarYear("0"));
-    EXPECT_EQ(Mixxx::TrackMetadata::kCalendarYearInvalid, Mixxx::TrackMetadata::parseCalendarYear("-1"));
-    EXPECT_EQ(Mixxx::TrackMetadata::kCalendarYearInvalid, Mixxx::TrackMetadata::parseCalendarYear("year"));
+    EXPECT_EQ(2014, mixxx::TrackMetadata::parseCalendarYear("2014-04-29T07:00:00Z"));
+    EXPECT_EQ(2014, mixxx::TrackMetadata::parseCalendarYear("2014-04-29"));
+    EXPECT_EQ(2014, mixxx::TrackMetadata::parseCalendarYear("2014"));
+    EXPECT_EQ(2015, mixxx::TrackMetadata::parseCalendarYear("2015-02"));
+    EXPECT_EQ(1997, mixxx::TrackMetadata::parseCalendarYear("1997-W43"));
+    EXPECT_EQ(1, mixxx::TrackMetadata::parseCalendarYear("1"));
+    EXPECT_EQ(mixxx::TrackMetadata::kCalendarYearInvalid, mixxx::TrackMetadata::parseCalendarYear("0"));
+    EXPECT_EQ(mixxx::TrackMetadata::kCalendarYearInvalid, mixxx::TrackMetadata::parseCalendarYear("-1"));
+    EXPECT_EQ(mixxx::TrackMetadata::kCalendarYearInvalid, mixxx::TrackMetadata::parseCalendarYear("year"));
 
     // Formatting
-    EXPECT_EQ("2014", Mixxx::TrackMetadata::formatCalendarYear("2014-04-29T07:00:00Z"));
-    EXPECT_EQ("2014", Mixxx::TrackMetadata::formatCalendarYear("2014-04-29"));
-    EXPECT_EQ("2014", Mixxx::TrackMetadata::formatCalendarYear("2014"));
-    EXPECT_EQ("2015", Mixxx::TrackMetadata::formatCalendarYear("2015-02"));
-    EXPECT_EQ("1997", Mixxx::TrackMetadata::formatCalendarYear("1997-W43"));
-    EXPECT_EQ("", Mixxx::TrackMetadata::formatCalendarYear("0"));
-    EXPECT_EQ("", Mixxx::TrackMetadata::formatCalendarYear("-1"));
-    EXPECT_EQ("", Mixxx::TrackMetadata::formatCalendarYear("year"));
+    EXPECT_EQ("2014", mixxx::TrackMetadata::formatCalendarYear("2014-04-29T07:00:00Z"));
+    EXPECT_EQ("2014", mixxx::TrackMetadata::formatCalendarYear("2014-04-29"));
+    EXPECT_EQ("2014", mixxx::TrackMetadata::formatCalendarYear("2014"));
+    EXPECT_EQ("2015", mixxx::TrackMetadata::formatCalendarYear("2015-02"));
+    EXPECT_EQ("1997", mixxx::TrackMetadata::formatCalendarYear("1997-W43"));
+    EXPECT_EQ("", mixxx::TrackMetadata::formatCalendarYear("0"));
+    EXPECT_EQ("", mixxx::TrackMetadata::formatCalendarYear("-1"));
+    EXPECT_EQ("", mixxx::TrackMetadata::formatCalendarYear("year"));
 }
 
 }  // namespace

--- a/src/test/midicontrollertest.cpp
+++ b/src/test/midicontrollertest.cpp
@@ -42,7 +42,7 @@ class MidiControllerTest : public MixxxTest {
     void receive(unsigned char status, unsigned char control,
                  unsigned char value) {
         // TODO(rryan): This test doesn't care about timestamps.
-        m_pController->receive(status, control, value, Time::elapsed());
+        m_pController->receive(status, control, value, mixxx::Time::elapsed());
     }
 
     MidiControllerPreset m_preset;

--- a/src/test/replaygaintest.cpp
+++ b/src/test/replaygaintest.cpp
@@ -22,7 +22,7 @@ class ReplayGainTest : public testing::Test {
         //qDebug() << "ratioFromString" << inputValue << expectedResult << expectedValue;
 
         bool actualResult;
-        const double actualValue = Mixxx::ReplayGain::ratioFromString(inputValue, &actualResult);
+        const double actualValue = mixxx::ReplayGain::ratioFromString(inputValue, &actualResult);
 
         EXPECT_EQ(expectedResult, actualResult);
         EXPECT_FLOAT_EQ(expectedValue, actualValue);
@@ -31,11 +31,11 @@ class ReplayGainTest : public testing::Test {
     }
 
     void normalizeRatio(double expectedResult) {
-        const double actualResult = Mixxx::ReplayGain::normalizeRatio(expectedResult);
-        if (Mixxx::ReplayGain::isValidRatio(expectedResult)) {
+        const double actualResult = mixxx::ReplayGain::normalizeRatio(expectedResult);
+        if (mixxx::ReplayGain::isValidRatio(expectedResult)) {
             EXPECT_EQ(expectedResult, actualResult);
         } else {
-            EXPECT_EQ(Mixxx::ReplayGain::kRatioUndefined, actualResult);
+            EXPECT_EQ(mixxx::ReplayGain::kRatioUndefined, actualResult);
         }
     }
 
@@ -43,7 +43,7 @@ class ReplayGainTest : public testing::Test {
         //qDebug() << "peakFromString" << inputValue << expectedResult << expectedValue;
 
         bool actualResult;
-        const CSAMPLE actualValue = Mixxx::ReplayGain::peakFromString(inputValue, &actualResult);
+        const CSAMPLE actualValue = mixxx::ReplayGain::peakFromString(inputValue, &actualResult);
 
         EXPECT_EQ(expectedResult, actualResult);
         EXPECT_FLOAT_EQ(expectedValue, actualValue);
@@ -52,21 +52,21 @@ class ReplayGainTest : public testing::Test {
     }
 
     void normalizePeak(CSAMPLE expectedResult) {
-        const CSAMPLE actualResult = Mixxx::ReplayGain::normalizePeak(expectedResult);
-        if (Mixxx::ReplayGain::isValidPeak(expectedResult)) {
+        const CSAMPLE actualResult = mixxx::ReplayGain::normalizePeak(expectedResult);
+        if (mixxx::ReplayGain::isValidPeak(expectedResult)) {
             EXPECT_EQ(expectedResult, actualResult);
         } else {
-            EXPECT_EQ(Mixxx::ReplayGain::kPeakUndefined, actualResult);
+            EXPECT_EQ(mixxx::ReplayGain::kPeakUndefined, actualResult);
         }
     }
 };
 
 TEST_F(ReplayGainTest, RatioFromString0dB) {
-    ratioFromString("0 dB", true, Mixxx::ReplayGain::kRatio0dB);
-    ratioFromString("0.0dB", true, Mixxx::ReplayGain::kRatio0dB);
-    ratioFromString("0 DB", true, Mixxx::ReplayGain::kRatio0dB);
-    ratioFromString("-0 Db", true, Mixxx::ReplayGain::kRatio0dB);
-    ratioFromString("+0db", true, Mixxx::ReplayGain::kRatio0dB);
+    ratioFromString("0 dB", true, mixxx::ReplayGain::kRatio0dB);
+    ratioFromString("0.0dB", true, mixxx::ReplayGain::kRatio0dB);
+    ratioFromString("0 DB", true, mixxx::ReplayGain::kRatio0dB);
+    ratioFromString("-0 Db", true, mixxx::ReplayGain::kRatio0dB);
+    ratioFromString("+0db", true, mixxx::ReplayGain::kRatio0dB);
 }
 
 TEST_F(ReplayGainTest, RatioFromStringValidRange) {
@@ -89,56 +89,56 @@ TEST_F(ReplayGainTest, RatioFromStringValidRange) {
 }
 
 TEST_F(ReplayGainTest, RatioFromStringInvalid) {
-    ratioFromString("", false, Mixxx::ReplayGain::kRatioUndefined);
-    ratioFromString("abcde", false, Mixxx::ReplayGain::kRatioUndefined);
-    ratioFromString("0 dBA", false, Mixxx::ReplayGain::kRatioUndefined);
-    ratioFromString("--2 dB", false, Mixxx::ReplayGain::kRatioUndefined);
-    ratioFromString("+-2 dB", false, Mixxx::ReplayGain::kRatioUndefined);
-    ratioFromString("-+2 dB", false, Mixxx::ReplayGain::kRatioUndefined);
-    ratioFromString("++2 dB", false, Mixxx::ReplayGain::kRatioUndefined);
+    ratioFromString("", false, mixxx::ReplayGain::kRatioUndefined);
+    ratioFromString("abcde", false, mixxx::ReplayGain::kRatioUndefined);
+    ratioFromString("0 dBA", false, mixxx::ReplayGain::kRatioUndefined);
+    ratioFromString("--2 dB", false, mixxx::ReplayGain::kRatioUndefined);
+    ratioFromString("+-2 dB", false, mixxx::ReplayGain::kRatioUndefined);
+    ratioFromString("-+2 dB", false, mixxx::ReplayGain::kRatioUndefined);
+    ratioFromString("++2 dB", false, mixxx::ReplayGain::kRatioUndefined);
 }
 
 TEST_F(ReplayGainTest, NormalizeRatio) {
-    normalizeRatio(Mixxx::ReplayGain::kRatioUndefined);
-    normalizeRatio(Mixxx::ReplayGain::kRatioMin);
-    normalizeRatio(-Mixxx::ReplayGain::kRatioMin);
-    normalizeRatio(Mixxx::ReplayGain::kRatio0dB);
-    normalizeRatio(-Mixxx::ReplayGain::kRatio0dB);
+    normalizeRatio(mixxx::ReplayGain::kRatioUndefined);
+    normalizeRatio(mixxx::ReplayGain::kRatioMin);
+    normalizeRatio(-mixxx::ReplayGain::kRatioMin);
+    normalizeRatio(mixxx::ReplayGain::kRatio0dB);
+    normalizeRatio(-mixxx::ReplayGain::kRatio0dB);
 }
 
 TEST_F(ReplayGainTest, PeakFromStringValid) {
-    peakFromString("0", true, Mixxx::ReplayGain::kPeakMin);
-    peakFromString("+0", true, Mixxx::ReplayGain::kPeakMin);
-    peakFromString("-0", true, Mixxx::ReplayGain::kPeakMin);
-    peakFromString("0.0", true, Mixxx::ReplayGain::kPeakMin);
-    peakFromString("+0.0", true, Mixxx::ReplayGain::kPeakMin);
-    peakFromString("-0.0", true, Mixxx::ReplayGain::kPeakMin);
-    peakFromString("1", true, Mixxx::ReplayGain::kPeakClip);
-    peakFromString("+1", true, Mixxx::ReplayGain::kPeakClip);
-    peakFromString("1.0", true, Mixxx::ReplayGain::kPeakClip);
-    peakFromString("+1.0", true, Mixxx::ReplayGain::kPeakClip);
+    peakFromString("0", true, mixxx::ReplayGain::kPeakMin);
+    peakFromString("+0", true, mixxx::ReplayGain::kPeakMin);
+    peakFromString("-0", true, mixxx::ReplayGain::kPeakMin);
+    peakFromString("0.0", true, mixxx::ReplayGain::kPeakMin);
+    peakFromString("+0.0", true, mixxx::ReplayGain::kPeakMin);
+    peakFromString("-0.0", true, mixxx::ReplayGain::kPeakMin);
+    peakFromString("1", true, mixxx::ReplayGain::kPeakClip);
+    peakFromString("+1", true, mixxx::ReplayGain::kPeakClip);
+    peakFromString("1.0", true, mixxx::ReplayGain::kPeakClip);
+    peakFromString("+1.0", true, mixxx::ReplayGain::kPeakClip);
     peakFromString("  0.12345  ", true, 0.12345);
     peakFromString("  1.2345", true, 1.2345);
 }
 
 TEST_F(ReplayGainTest, PeakFromStringInvalid) {
-    peakFromString("", false, Mixxx::ReplayGain::kPeakUndefined);
-    peakFromString("-1", false, Mixxx::ReplayGain::kPeakUndefined);
-    peakFromString("-0.12345", false, Mixxx::ReplayGain::kPeakUndefined);
-    peakFromString("--1.0", false, Mixxx::ReplayGain::kPeakUndefined);
-    peakFromString("+-1.0", false, Mixxx::ReplayGain::kPeakUndefined);
-    peakFromString("-+1.0", false, Mixxx::ReplayGain::kPeakUndefined);
-    peakFromString("++1.0", false, Mixxx::ReplayGain::kPeakUndefined);
-    peakFromString("+abcde", false, Mixxx::ReplayGain::kPeakUndefined);
+    peakFromString("", false, mixxx::ReplayGain::kPeakUndefined);
+    peakFromString("-1", false, mixxx::ReplayGain::kPeakUndefined);
+    peakFromString("-0.12345", false, mixxx::ReplayGain::kPeakUndefined);
+    peakFromString("--1.0", false, mixxx::ReplayGain::kPeakUndefined);
+    peakFromString("+-1.0", false, mixxx::ReplayGain::kPeakUndefined);
+    peakFromString("-+1.0", false, mixxx::ReplayGain::kPeakUndefined);
+    peakFromString("++1.0", false, mixxx::ReplayGain::kPeakUndefined);
+    peakFromString("+abcde", false, mixxx::ReplayGain::kPeakUndefined);
 }
 
 TEST_F(ReplayGainTest, NormalizePeak) {
-    normalizePeak(Mixxx::ReplayGain::kPeakUndefined);
-    normalizePeak(Mixxx::ReplayGain::kPeakMin);
-    normalizePeak(-Mixxx::ReplayGain::kPeakMin);
-    normalizePeak(Mixxx::ReplayGain::kPeakClip);
-    normalizePeak(-Mixxx::ReplayGain::kPeakClip);
-    normalizePeak(Mixxx::ReplayGain::kPeakClip + Mixxx::ReplayGain::kPeakClip);
+    normalizePeak(mixxx::ReplayGain::kPeakUndefined);
+    normalizePeak(mixxx::ReplayGain::kPeakMin);
+    normalizePeak(-mixxx::ReplayGain::kPeakMin);
+    normalizePeak(mixxx::ReplayGain::kPeakClip);
+    normalizePeak(-mixxx::ReplayGain::kPeakClip);
+    normalizePeak(mixxx::ReplayGain::kPeakClip + mixxx::ReplayGain::kPeakClip);
 }
 
 } // anonymous namespace

--- a/src/test/softtakeover_test.cpp
+++ b/src/test/softtakeover_test.cpp
@@ -14,12 +14,12 @@ namespace {
 class SoftTakeoverTest : public MixxxTest {
   protected:
     virtual void SetUp() {
-        Time::setTestMode(true);
-        Time::setTestElapsedTime(mixxx::Duration::fromMillis(10));
+        mixxx::Time::setTestMode(true);
+        mixxx::Time::setTestElapsedTime(mixxx::Duration::fromMillis(10));
     }
 
     virtual void TearDown() {
-        Time::setTestMode(false);
+        mixxx::Time::setTestMode(false);
     }
 };
 
@@ -81,14 +81,14 @@ TEST_F(SoftTakeoverTest, SuperFastPrevEqCurrent) {
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(-250)));
     // This can happen any time afterwards, so we test 10 seconds
-    Time::setTestElapsedTime(mixxx::Duration::fromSeconds(10));
+    mixxx::Time::setTestElapsedTime(mixxx::Duration::fromSeconds(10));
     EXPECT_FALSE(st_control.ignore(co.data(), co->getParameterForValue(200)));
 
     // From the top
     co->set(250);
     EXPECT_FALSE(st_control.ignore(co.data(), co->getParameterForValue(250)));
     // This can happen any time afterwards, so we test 10 seconds
-    Time::setTestElapsedTime(mixxx::Duration::fromSeconds(10));
+    mixxx::Time::setTestElapsedTime(mixxx::Duration::fromSeconds(10));
     EXPECT_FALSE(st_control.ignore(co.data(), co->getParameterForValue(-200)));
 }
 
@@ -105,7 +105,7 @@ TEST_F(SoftTakeoverTest, DISABLED_SuperFastNotSame) {
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(249)));
     // This can happen any time afterwards, so we test 10 seconds
-    Time::setTestElapsedTime(mixxx::Duration::fromSeconds(10));
+    mixxx::Time::setTestElapsedTime(mixxx::Duration::fromSeconds(10));
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(-200)));
 }
 
@@ -185,7 +185,7 @@ TEST_F(SoftTakeoverTest, PrevNearLess_NewNearLess_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(40)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_FALSE(st_control.ignore(co.data(), co->getParameterForValue(45)));
 }
 
@@ -199,7 +199,7 @@ TEST_F(SoftTakeoverTest, PrevNearLess_NewNearMore_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(40)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_FALSE(st_control.ignore(co.data(), co->getParameterForValue(60)));
 }
 
@@ -217,7 +217,7 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevNearLess_NewFarLess_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(40)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(1)));
 }
 
@@ -235,7 +235,7 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevNearLess_NewFarMore_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(40)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(100)));
 }
 
@@ -303,7 +303,7 @@ TEST_F(SoftTakeoverTest, PrevNearMore_NewNearLess_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(55)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_FALSE(st_control.ignore(co.data(), co->getParameterForValue(45)));
 }
 
@@ -317,7 +317,7 @@ TEST_F(SoftTakeoverTest, PrevNearMore_NewNearMore_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(55)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_FALSE(st_control.ignore(co.data(), co->getParameterForValue(60)));
 }
 
@@ -335,7 +335,7 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevNearMore_NewFarLess_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(55)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(1)));
 }
 
@@ -353,7 +353,7 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevNearMore_NewFarMore_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(55)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(100)));
 }
 
@@ -425,7 +425,7 @@ TEST_F(SoftTakeoverTest, PrevFarLess_NewNearLess_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(-50)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_FALSE(st_control.ignore(co.data(), co->getParameterForValue(45)));
 }
 
@@ -439,7 +439,7 @@ TEST_F(SoftTakeoverTest, PrevFarLess_NewNearMore_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(-50)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_FALSE(st_control.ignore(co.data(), co->getParameterForValue(60)));
 }
 
@@ -456,7 +456,7 @@ TEST_F(SoftTakeoverTest, PrevFarLess_NewFarLess_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(-50)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(1)));
 }
 
@@ -474,7 +474,7 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevFarLess_NewFarMore_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(-50)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(100)));
 }
 
@@ -546,7 +546,7 @@ TEST_F(SoftTakeoverTest, PrevFarMore_NewNearLess_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(120)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_FALSE(st_control.ignore(co.data(), co->getParameterForValue(45)));
 }
 
@@ -560,7 +560,7 @@ TEST_F(SoftTakeoverTest, PrevFarMore_NewNearMore_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(120)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_FALSE(st_control.ignore(co.data(), co->getParameterForValue(60)));
 }
 
@@ -578,7 +578,7 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevFarMore_NewFarLess_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(120)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(1)));
 }
 
@@ -595,7 +595,7 @@ TEST_F(SoftTakeoverTest, PrevFarMore_NewFarMore_Late) {
 
     // First is always ignored.
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(120)));
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     EXPECT_TRUE(st_control.ignore(co.data(), co->getParameterForValue(100)));
 }
 

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -55,7 +55,7 @@ class SoundSourceProxyTest: public MixxxTest {
         return filePaths;
     }
 
-    static Mixxx::AudioSourcePointer openAudioSource(const QString& filePath) {
+    static mixxx::AudioSourcePointer openAudioSource(const QString& filePath) {
         TrackPointer pTrack(Track::newTemporary(filePath));
         return SoundSourceProxy(pTrack).openAudioSource();
     }
@@ -66,7 +66,7 @@ TEST_F(SoundSourceProxyTest, open) {
     for (const auto& filePath: getFilePaths()) {
         ASSERT_TRUE(SoundSourceProxy::isFileNameSupported(filePath));
 
-        Mixxx::AudioSourcePointer pAudioSource(openAudioSource(filePath));
+        mixxx::AudioSourcePointer pAudioSource(openAudioSource(filePath));
         // Obtaining an AudioSource may fail for unsupported file formats,
         // even if the corresponding file extension is supported, e.g.
         // AAC vs. ALAC in .m4a files
@@ -84,7 +84,7 @@ TEST_F(SoundSourceProxyTest, readArtist) {
     TrackPointer pTrack(Track::newTemporary(
             kTestDir.absoluteFilePath("artist.mp3")));
     SoundSourceProxy proxy(pTrack);
-    Mixxx::TrackMetadata trackMetadata;
+    mixxx::TrackMetadata trackMetadata;
     EXPECT_EQ(OK, proxy.parseTrackMetadata(&trackMetadata));
     EXPECT_EQ("Test Artist", trackMetadata.getArtist());
 }
@@ -93,7 +93,7 @@ TEST_F(SoundSourceProxyTest, TOAL_TPE2) {
     TrackPointer pTrack(Track::newTemporary(
             kTestDir.absoluteFilePath("TOAL_TPE2.mp3")));
     SoundSourceProxy proxy(pTrack);
-    Mixxx::TrackMetadata trackMetadata;
+    mixxx::TrackMetadata trackMetadata;
     EXPECT_EQ(OK, proxy.parseTrackMetadata(&trackMetadata));
     EXPECT_EQ("TITLE2", trackMetadata.getArtist());
     EXPECT_EQ("ARTIST", trackMetadata.getAlbum());
@@ -119,7 +119,7 @@ TEST_F(SoundSourceProxyTest, seekForward) {
 
         qDebug() << "Seek forward test:" << filePath;
 
-        Mixxx::AudioSourcePointer pContReadSource(openAudioSource(filePath));
+        mixxx::AudioSourcePointer pContReadSource(openAudioSource(filePath));
         // Obtaining an AudioSource may fail for unsupported file formats,
         // even if the corresponding file extension is supported, e.g.
         // AAC vs. ALAC in .m4a files
@@ -132,7 +132,7 @@ TEST_F(SoundSourceProxyTest, seekForward) {
         SampleBuffer seekReadData(readSampleCount);
 
 #ifdef __FFMPEGFILE__
-        if (dynamic_cast<Mixxx::SoundSourceFFmpeg*>(pContReadSource.data())) {
+        if (dynamic_cast<mixxx::SoundSourceFFmpeg*>(pContReadSource.data())) {
             if (filePath.endsWith(".mp3")) {
                 qDebug() << "Skip test since it will fail using SoundSourceFFmpeg";
                 continue;
@@ -148,7 +148,7 @@ TEST_F(SoundSourceProxyTest, seekForward) {
             const SINT contReadFrameCount =
                     pContReadSource->readSampleFrames(kReadFrameCount, &contReadData[0]);
 
-            Mixxx::AudioSourcePointer pSeekReadSource(openAudioSource(filePath));
+            mixxx::AudioSourcePointer pSeekReadSource(openAudioSource(filePath));
             ASSERT_FALSE(pSeekReadSource.isNull());
             ASSERT_EQ(pContReadSource->getChannelCount(), pSeekReadSource->getChannelCount());
             ASSERT_EQ(pContReadSource->getFrameCount(), pSeekReadSource->getFrameCount());

--- a/src/test/soundsourceproviderregistrytest.cpp
+++ b/src/test/soundsourceproviderregistrytest.cpp
@@ -4,7 +4,7 @@
 
 #include "sources/soundsourceproviderregistry.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 namespace {
 
@@ -161,4 +161,4 @@ TEST_F(SoundSourceProviderRegistryTest, registerProviders) {
 
 }  // anonymous namespace
 
-}  // namespace Mixxx
+}  // namespace mixxx

--- a/src/test/super_link_test.cpp
+++ b/src/test/super_link_test.cpp
@@ -16,8 +16,8 @@ class SuperLinkTest : public BaseEffectTest {
     SuperLinkTest()
             : m_master(m_factory.getOrCreateHandle("[Master]"), "[Master]"),
               m_headphone(m_factory.getOrCreateHandle("[Headphone]"), "[Headphone]") {
-        Time::setTestMode(true);
-        Time::setTestElapsedTime(mixxx::Duration::fromNanos(0));
+        mixxx::Time::setTestMode(true);
+        mixxx::Time::setTestElapsedTime(mixxx::Duration::fromNanos(0));
         m_pEffectsManager->registerChannel(m_master);
         m_pEffectsManager->registerChannel(m_headphone);
         registerTestBackend();
@@ -120,7 +120,7 @@ TEST_F(SuperLinkTest, Softtakeover) {
     EXPECT_EQ(1.0, m_pControlValue->get());
     m_pControlValue->set(0.1);
     // Let enough time pass by to exceed soft-takeover's override interval.
-    Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() +
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() +
                              mixxx::Duration::fromMillis(2));
     // Ignored by SoftTakeover since it is too far from the current value of
     // 0.1.

--- a/src/track/bpm.cpp
+++ b/src/track/bpm.cpp
@@ -1,6 +1,6 @@
 #include "track/bpm.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 // TODO(uklotzde): Replace 'const' with 'constexpr' and remove
 // initialization after switching to Visual Studio 2015.
@@ -57,4 +57,4 @@ void Bpm::normalizeValue() {
     }
 }
 
-} //namespace Mixxx
+} //namespace mixxx

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -5,7 +5,7 @@
 
 #include "util/math.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 // DTO for storing BPM information.
 class Bpm final {
@@ -63,6 +63,6 @@ bool operator!=(const Bpm& lhs, const Bpm& rhs) {
 
 }
 
-Q_DECLARE_METATYPE(Mixxx::Bpm)
+Q_DECLARE_METATYPE(mixxx::Bpm)
 
 #endif // MIXXX_BPM_H

--- a/src/track/replaygain.cpp
+++ b/src/track/replaygain.cpp
@@ -2,7 +2,7 @@
 
 #include "util/math.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 // TODO(uklotzde): Replace 'const' with 'constexpr' and remove
 // initialization after switching to Visual Studio 2015.
@@ -159,4 +159,4 @@ CSAMPLE ReplayGain::normalizePeak(CSAMPLE peak) {
     }
 }
 
-} //namespace Mixxx
+} //namespace mixxx

--- a/src/track/replaygain.h
+++ b/src/track/replaygain.h
@@ -3,7 +3,7 @@
 
 #include "util/types.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 // DTO for storing replay gain information.
 //
@@ -114,6 +114,6 @@ bool operator!=(const ReplayGain& lhs, const ReplayGain& rhs) {
 
 }
 
-Q_DECLARE_METATYPE(Mixxx::ReplayGain)
+Q_DECLARE_METATYPE(mixxx::ReplayGain)
 
 #endif // MIXXX_REPLAYGAIN_H

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -98,7 +98,7 @@ void Track::setDeleteOnReferenceExpiration(bool deleteOnReferenceExpiration) {
 }
 
 void Track::setTrackMetadata(
-        const Mixxx::TrackMetadata& trackMetadata,
+        const mixxx::TrackMetadata& trackMetadata,
         bool parsedFromFile) {
     {
         // enter locking scope
@@ -125,7 +125,7 @@ void Track::setTrackMetadata(
     // Need to set BPM after sample rate since beat grid creation depends on
     // knowing the sample rate. Bug #1020438.
     if (trackMetadata.getBpm().hasValue() &&
-            ((nullptr == m_pBeats) || !Mixxx::Bpm::isValidValue(m_pBeats->getBpm()))) {
+            ((nullptr == m_pBeats) || !mixxx::Bpm::isValidValue(m_pBeats->getBpm()))) {
         // Only (re-)set the BPM if the beat grid is not valid.
         // Reason: The BPM value in the metadata might be normalized or rounded,
         // e.g. ID3v2 only supports integer values!
@@ -139,7 +139,7 @@ void Track::setTrackMetadata(
 }
 
 void Track::getTrackMetadata(
-        Mixxx::TrackMetadata* pTrackMetadata,
+        mixxx::TrackMetadata* pTrackMetadata,
         bool* pHeaderParsed) const {
     QMutexLocker lock(&m_qMutex);
     *pTrackMetadata = m_metadata;
@@ -213,12 +213,12 @@ bool Track::exists() const {
     return QFile::exists(m_fileInfo.absoluteFilePath());
 }
 
-Mixxx::ReplayGain Track::getReplayGain() const {
+mixxx::ReplayGain Track::getReplayGain() const {
     QMutexLocker lock(&m_qMutex);
     return m_metadata.getReplayGain();
 }
 
-void Track::setReplayGain(const Mixxx::ReplayGain& replayGain) {
+void Track::setReplayGain(const mixxx::ReplayGain& replayGain) {
     QMutexLocker lock(&m_qMutex);
     if (m_metadata.getReplayGain() != replayGain) {
         m_metadata.setReplayGain(replayGain);
@@ -228,14 +228,14 @@ void Track::setReplayGain(const Mixxx::ReplayGain& replayGain) {
 }
 
 double Track::getBpm() const {
-    double bpm = Mixxx::Bpm::kValueUndefined;
+    double bpm = mixxx::Bpm::kValueUndefined;
     QMutexLocker lock(&m_qMutex);
     if (m_pBeats) {
         // BPM from beat grid overrides BPM from metadata
         // Reason: The BPM value in the metadata might be imprecise,
         // e.g. ID3v2 only supports integer values!
         double beatsBpm = m_pBeats->getBpm();
-        if (Mixxx::Bpm::isValidValue(beatsBpm)) {
+        if (mixxx::Bpm::isValidValue(beatsBpm)) {
             bpm = beatsBpm;
         }
     }
@@ -243,14 +243,14 @@ double Track::getBpm() const {
 }
 
 double Track::setBpm(double bpmValue) {
-    if (!Mixxx::Bpm::isValidValue(bpmValue)) {
+    if (!mixxx::Bpm::isValidValue(bpmValue)) {
         // If the user sets the BPM to an invalid value, we assume
         // they want to clear the beatgrid.
         setBeats(BeatsPointer());
         return bpmValue;
     }
 
-    Mixxx::Bpm normalizedBpm(bpmValue);
+    mixxx::Bpm normalizedBpm(bpmValue);
     normalizedBpm.normalizeValue();
 
     QMutexLocker lock(&m_qMutex);
@@ -303,7 +303,7 @@ void Track::setBeatsAndUnlock(QMutexLocker* pLock, BeatsPointer pBeats) {
         }
     }
 
-    Mixxx::Bpm bpm;
+    mixxx::Bpm bpm;
     double bpmValue = bpm.getValue();
 
     m_pBeats = pBeats;
@@ -333,7 +333,7 @@ BeatsPointer Track::getBeats() const {
 void Track::slotBeatsUpdated() {
     QMutexLocker lock(&m_qMutex);
     double bpmValue = m_pBeats->getBpm();
-    Mixxx::Bpm bpm(bpmValue);
+    mixxx::Bpm bpm(bpmValue);
     bpm.normalizeValue();
     m_metadata.setBpm(bpm);
     markDirtyAndUnlock(&lock);

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -152,9 +152,9 @@ class Track : public QObject {
     bool isBpmLocked() const;
 
     // Set ReplayGain
-    void setReplayGain(const Mixxx::ReplayGain&);
+    void setReplayGain(const mixxx::ReplayGain&);
     // Returns ReplayGain
-    Mixxx::ReplayGain getReplayGain() const;
+    mixxx::ReplayGain getReplayGain() const;
 
     // Indicates if the metadata has been parsed from file tags.
     bool isHeaderParsed() const;
@@ -282,10 +282,10 @@ class Track : public QObject {
 
     // Set/get track metadata and cover art (optional) all at once.
     void setTrackMetadata(
-            const Mixxx::TrackMetadata& trackMetadata,
+            const mixxx::TrackMetadata& trackMetadata,
             bool parsedFromFile);
     void getTrackMetadata(
-            Mixxx::TrackMetadata* pTrackMetadata,
+            mixxx::TrackMetadata* pTrackMetadata,
             bool* pHeaderParsed) const;
 
     // Mark the track dirty if it isn't already.
@@ -314,7 +314,7 @@ class Track : public QObject {
     void beatsUpdated();
     void keyUpdated(double key);
     void keysUpdated();
-    void ReplayGainUpdated(Mixxx::ReplayGain replayGain);
+    void ReplayGainUpdated(mixxx::ReplayGain replayGain);
     void cuesUpdated();
     void changed(Track* pTrack);
     void dirty(Track* pTrack);
@@ -372,7 +372,7 @@ class Track : public QObject {
     QString m_sType;
 
     // Track metadata
-    Mixxx::TrackMetadata m_metadata;
+    mixxx::TrackMetadata m_metadata;
 
     // URL (used in promo track)
     QString m_sURL;

--- a/src/track/trackmetadata.cpp
+++ b/src/track/trackmetadata.cpp
@@ -1,6 +1,6 @@
 #include "track/trackmetadata.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 /*static*/ const int TrackMetadata::kCalendarYearInvalid = 0;
 
@@ -95,4 +95,4 @@ bool operator==(const TrackMetadata& lhs, const TrackMetadata& rhs) {
             (lhs.getReplayGain() == rhs.getReplayGain());
 }
 
-} //namespace Mixxx
+} //namespace mixxx

--- a/src/track/trackmetadata.h
+++ b/src/track/trackmetadata.h
@@ -6,7 +6,7 @@
 #include "track/bpm.h"
 #include "track/replaygain.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 // DTO for track metadata properties. Must not be subclassed (no virtual destructor)!
 class TrackMetadata {

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -55,7 +55,7 @@ static_assert(sizeof(wchar_t) == sizeof(QChar), "wchar_t is not the same size th
 #include <taglib/attachedpictureframe.h>
 #include <taglib/flacpicture.h>
 
-namespace Mixxx {
+namespace mixxx {
 
 namespace {
 
@@ -1287,7 +1287,7 @@ bool writeTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& t
     if (trackMetadata.getBpm().hasValue()) {
         // 16-bit integer value
         const int tmpoValue =
-                Mixxx::Bpm::valueToInteger(trackMetadata.getBpm().getValue());
+                mixxx::Bpm::valueToInteger(trackMetadata.getBpm().getValue());
         pTag->itemListMap()["tmpo"] = tmpoValue;
     } else {
         pTag->itemListMap().erase("tmpo");
@@ -1601,4 +1601,4 @@ Result writeTrackMetadataIntoFile(const TrackMetadata& trackMetadata, QString fi
     return OK;
 }
 
-} //namespace Mixxx
+} //namespace mixxx

--- a/src/track/trackmetadatataglib.h
+++ b/src/track/trackmetadatataglib.h
@@ -11,7 +11,7 @@
 #include "track/trackmetadata.h"
 #include "util/result.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 // Read both track metadata and cover art of supported file types.
 // Both parameters are optional and might be NULL.
@@ -33,6 +33,6 @@ bool writeTrackMetadataIntoXiphComment(TagLib::Ogg::XiphComment* pTag,
         const TrackMetadata& trackMetadata);
 bool writeTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& trackMetadata);
 
-} //namespace Mixxx
+} //namespace mixxx
 
 #endif

--- a/src/util/audiosignal.h
+++ b/src/util/audiosignal.h
@@ -4,7 +4,7 @@
 #include "util/assert.h"
 #include "util/types.h"
 
-namespace Mixxx {
+namespace mixxx {
 
 // Common properties of audio signals in Mixxx.
 //

--- a/src/util/duration.h
+++ b/src/util/duration.h
@@ -1,5 +1,5 @@
-#ifndef UTIL_DURATION_H
-#define UTIL_DURATION_H
+#ifndef MIXXX_UTIL_DURATION_H
+#define MIXXX_UTIL_DURATION_H
 
 #include <QMetaType>
 #include <QString>
@@ -273,4 +273,4 @@ class Duration : public DurationBase {
 
 Q_DECLARE_METATYPE(mixxx::Duration)
 
-#endif /* UTIL_DURATION_H */
+#endif /* MIXXX_UTIL_DURATION_H */

--- a/src/util/stat.cpp
+++ b/src/util/stat.cpp
@@ -148,7 +148,7 @@ bool Stat::track(const QString& tag,
     report.tag = strdup(tag.toAscii().constData());
     report.type = type;
     report.compute = compute;
-    report.time = Time::elapsed().toIntegerNanos();
+    report.time = mixxx::Time::elapsed().toIntegerNanos();
     report.value = value;
     StatsManager* pManager = StatsManager::instance();
     return pManager && pManager->maybeWriteReport(report);

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -1,5 +1,7 @@
 #include "util/time.h"
 
+namespace mixxx {
+
 // static
 LLTIMER Time::s_timer;
 
@@ -7,4 +9,6 @@ LLTIMER Time::s_timer;
 bool Time::s_testMode = false;
 
 // static
-mixxx::Duration Time::s_testElapsed = mixxx::Duration::fromNanos(0);
+Duration Time::s_testElapsed = Duration::fromNanos(0);
+
+} // namespace mixxx

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -1,10 +1,12 @@
-#ifndef UTIL_TIME_H
-#define UTIL_TIME_H
+#ifndef MIXXX_UTIL_TIME_H
+#define MIXXX_UTIL_TIME_H
 
 #include "util/performancetimer.h"
 #include "util/threadcputimer.h"
 #include "util/timer.h"
 #include "util/duration.h"
+
+namespace mixxx {
 
 #define LLTIMER PerformanceTimer
 //#define LLTIMER ThreadCpuTimer
@@ -41,4 +43,6 @@ class Time {
     static mixxx::Duration s_testElapsed;
 };
 
-#endif /* UTIL_TIME_H */
+} // namespace mixxx
+
+#endif /* MIXXX_UTIL_TIME_H */

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -147,7 +147,7 @@ void WTrackTableView::enableCachedOnly() {
         emit(onlyCachedCoverArt(true));
         m_loadCachedOnly = true;
     }
-    m_lastUserAction = Time::elapsed();
+    m_lastUserAction = mixxx::Time::elapsed();
 }
 
 void WTrackTableView::slotScrollValueChanged(int /*unused*/) {
@@ -164,7 +164,7 @@ void WTrackTableView::selectionChanged(const QItemSelection& selected,
 void WTrackTableView::slotGuiTick50ms(double /*unused*/) {
     // if the user is stopped in the same row for more than 0.1 s,
     // we load un-cached cover arts as well.
-    mixxx::Duration timeDelta = Time::elapsed() - m_lastUserAction;
+    mixxx::Duration timeDelta = mixxx::Time::elapsed() - m_lastUserAction;
     if (m_loadCachedOnly && timeDelta > mixxx::Duration::fromMillis(100)) {
 
         // Show the currently selected track in the large cover art view. Doing

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1621,7 +1621,7 @@ void WTrackTableView::slotReplayGainReset() {
     for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
-            pTrack->setReplayGain(Mixxx::ReplayGain());
+            pTrack->setReplayGain(mixxx::ReplayGain());
         }
     }
 }


### PR DESCRIPTION
This PR fixes a naming inconsistency: I once introduced the namespace 'Mixxx', but we already have 'mixxx'. Since lowercase names are more common for namespaces in C++ and provide a better distinction from class names I changed the name.

I also moved the util class with the very common name 'Time' into this namespace.

No code changes, just search & replace!

I decided to leave the plugin API version unchanged. Please let me know if you disagree ;)
