### PR TITLE
DlgTrackInfo: Fix reloading of metadata from file tags

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -611,17 +611,8 @@ void DlgTrackInfo::slotKeyTextChanged() {
 
 void DlgTrackInfo::reloadTrackMetadata() {
     if (m_pLoadedTrack) {
-        // Allocate a temporary track object for reading the metadata.
-        // We cannot reuse m_pLoadedTrack, because it might already been
-        // modified and we want to read fresh metadata directly from the
-        // file. Otherwise the changes in m_pLoadedTrack would be lost.
-        TrackPointer pTrack(Track::newTemporary(
-                m_pLoadedTrack->getFileInfo(),
-                m_pLoadedTrack->getSecurityToken()));
-        SoundSourceProxy(pTrack).loadTrackMetadata();
-        if (!pTrack.isNull()) {
-            populateFields(*pTrack);
-        }
+        SoundSourceProxy(m_pLoadedTrack).loadTrackMetadata(true);
+        populateFields(*m_pLoadedTrack);
     }
 }
 

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -170,8 +170,8 @@ void DlgTrackInfo::populateFields(const Track& track) {
     txtType->setText(track.getType());
     txtBitrate->setText(QString(track.getBitrateText()) + (" ") + tr("kbps"));
     txtBpm->setText(track.getBpmText());
-    m_keysClone = track.getKeys();
-    txtKey->setText(KeyUtils::getGlobalKeyText(m_keysClone));
+    m_keys = track.getKeys();
+    txtKey->setText(KeyUtils::getGlobalKeyText(m_keys));
     const mixxx::ReplayGain replayGain(track.getReplayGain());
     txtReplayGain->setText(mixxx::ReplayGain::ratioToString(replayGain.getRatio()));
 
@@ -383,7 +383,7 @@ void DlgTrackInfo::saveTrack() {
     // invalid then the change will be rejected.
     slotKeyTextChanged();
 
-    m_pLoadedTrack->setKeys(m_keysClone);
+    m_pLoadedTrack->setKeys(m_keys);
 
     QSet<int> updatedRows;
     for (int row = 0; row < cueTable->rowCount(); ++row) {
@@ -468,7 +468,7 @@ void DlgTrackInfo::clear() {
     txtComment->setPlainText("");
     spinBpm->setValue(0.0);
     m_pBeatsClone.clear();
-    m_keysClone = Keys();
+    m_keys = Keys();
 
     txtDuration->setText("");
     txtType->setText("");
@@ -596,17 +596,17 @@ void DlgTrackInfo::slotKeyTextChanged() {
 
     // If the new key string is invalid and not empty them reject the new key.
     if (globalKey == mixxx::track::io::key::INVALID && !newKeyText.isEmpty()) {
-        txtKey->setText(KeyUtils::getGlobalKeyText(m_keysClone));
+        txtKey->setText(KeyUtils::getGlobalKeyText(m_keys));
         return;
     }
 
     // If the new key is the same as the old key, reject the change.
-    if (globalKey == m_keysClone.getGlobalKey()) {
+    if (globalKey == m_keys.getGlobalKey()) {
         return;
     }
 
     // Otherwise, accept.
-    m_keysClone = newKeys;
+    m_keys = newKeys;
 }
 
 void DlgTrackInfo::reloadTrackMetadata() {

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -149,6 +149,17 @@ void DlgTrackInfo::cueDelete() {
     }
 }
 
+void DlgTrackInfo::cacheCoverArt() {
+    const TrackId trackId(m_pLoadedTrack->getId());
+    if (trackId.isValid()) {
+        CoverArtCache* const pCache = CoverArtCache::instance();
+        if (pCache != nullptr) {
+            // TODO(rryan) don't use track ID as a reference
+            pCache->requestCover(m_loadedCoverInfo, this, trackId.toInt());
+        }
+    }
+}
+
 void DlgTrackInfo::populateFields(const Track& track) {
     setWindowTitle(track.getArtist() % " - " % track.getTitle());
 
@@ -178,13 +189,10 @@ void DlgTrackInfo::populateFields(const Track& track) {
     reloadTrackBeats(track);
 
     m_loadedCoverInfo = track.getCoverInfo();
-    int reference = track.getId().toInt();
     m_loadedCoverInfo.trackLocation = track.getLocation();
     m_pWCoverArtLabel->setCoverArt(m_loadedCoverInfo.trackLocation, m_loadedCoverInfo, QPixmap());
-    CoverArtCache* pCache = CoverArtCache::instance();
-    if (pCache != NULL) {
-        pCache->requestCover(m_loadedCoverInfo, this, reference);
-    }
+
+    cacheCoverArt();
 }
 
 void DlgTrackInfo::reloadTrackBeats(const Track& track) {
@@ -253,16 +261,8 @@ void DlgTrackInfo::slotReloadCoverArt() {
 void DlgTrackInfo::slotCoverArtSelected(const CoverArt& art) {
     qDebug() << "DlgTrackInfo::slotCoverArtSelected" << art;
     m_loadedCoverInfo = art.info;
-    // TODO(rryan) don't use track ID as a reference
-    int reference = 0;
-    if (m_pLoadedTrack) {
-        reference = m_pLoadedTrack->getId().toInt();
-        m_loadedCoverInfo.trackLocation = m_pLoadedTrack->getLocation();
-    }
-    CoverArtCache* pCache = CoverArtCache::instance();
-    if (pCache != NULL) {
-        pCache->requestCover(m_loadedCoverInfo, this, reference);
-    }
+    m_loadedCoverInfo.trackLocation = m_pLoadedTrack->getLocation();
+    cacheCoverArt();
 }
 
 void DlgTrackInfo::slotOpenInFileBrowser() {

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -64,6 +64,8 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotReloadCoverArt();
 
   private:
+    void cacheCoverArt();
+
     void populateFields(const Track& track);
     void reloadTrackBeats(const Track& track);
     void populateCues(TrackPointer pTrack);

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -15,6 +15,15 @@
 #include "widget/wcoverartlabel.h"
 #include "widget/wcoverartmenu.h"
 
+// TODO(XXX): All unapplied edits in dialog fields are lost when
+// reloading metadata from file tags or when fetching metadata
+// from MusicBrainz. The reloaded/fetched metadata is applied
+// immediately to the actual track instead of only loaded into
+// the dialog's fields.
+// Fixing this unexpected behavior requires that the dialog and
+// all subtasks (reload, fetch) operate on a deep copy of the
+// actual track. A major refactoring is required to achieve this
+// goal.
 class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     Q_OBJECT
   public:

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -74,7 +74,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     QHash<int, CuePointer> m_cueMap;
     TrackPointer m_pLoadedTrack;
     BeatsPointer m_pBeatsClone;
-    Keys m_keysClone;
+    Keys m_keys;
     bool m_trackHasBeatMap;
 
     QScopedPointer<TapFilter> m_pTapFilter;

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -25,9 +25,6 @@
   <property name="windowTitle">
    <string>Track Editor</string>
   </property>
-  <property name="toolTip">
-   <string>Sets the BPM to 50% of the detected BPM.</string>
-  </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -124,12 +124,17 @@ void Track::setTrackMetadata(
 
     // Need to set BPM after sample rate since beat grid creation depends on
     // knowing the sample rate. Bug #1020438.
-    if (trackMetadata.getBpm().hasValue() &&
-            ((nullptr == m_pBeats) || !mixxx::Bpm::isValidValue(m_pBeats->getBpm()))) {
-        // Only (re-)set the BPM if the beat grid is not valid.
+    if (trackMetadata.getBpm().hasValue()) {
+        // NOTE(uklotzde): Only (re-)set the BPM if the beat grid is not valid.
         // Reason: The BPM value in the metadata might be normalized or rounded,
         // e.g. ID3v2 only supports integer values!
-        setBpm(trackMetadata.getBpm().getValue());
+        if ((m_pBeats == nullptr) || !mixxx::Bpm::isValidValue(m_pBeats->getBpm())) {
+            setBpm(trackMetadata.getBpm().getValue());
+        } else {
+            qDebug() << "Ignoring"
+                    << trackMetadata.getBpm().getValue()
+                    << "bpm from track metadata";
+        }
     }
 
     const QString key(trackMetadata.getKey());


### PR DESCRIPTION
Fixes some issues that have been reported in the forums:

http://www.mixxx.org/forums/viewtopic.php?f=1&t=8387

Please note that the track properties dialog still has some shortcomings. Fixing these would require a complete internal refactoring. I've added a TODO comment at the class definition that explains these issues.
