### PR TITLE
Launchpad 1606054: Reject to load files with invalid sampling rates

### DIFF
--- a/src/util/audiosignal.h
+++ b/src/util/audiosignal.h
@@ -41,13 +41,15 @@ public:
     }
 
     static const SINT kSamplingRateZero    = 0;
+    static const SINT kSamplingRateMin     = 8000; // lower bound
+    static const SINT kSamplingRateMax     = 192000; // upper bound
     static const SINT kSamplingRateCD      = 44100;
     static const SINT kSamplingRate48kHz   = 48000;
     static const SINT kSamplingRate96kHz   = 96000;
     static const SINT kSamplingRateDefault = kSamplingRateZero;
 
     static bool isValidSamplingRate(SINT samplingRate) {
-        return kSamplingRateZero < samplingRate;
+        return (kSamplingRateMin <= samplingRate) && (kSamplingRateMax >= samplingRate);
     }
 
     explicit AudioSignal(SampleLayout sampleLayout)

--- a/src/util/audiosignal.h
+++ b/src/util/audiosignal.h
@@ -118,7 +118,6 @@ public:
 
 protected:
     void setChannelCount(SINT channelCount) {
-        DEBUG_ASSERT(isValidChannelCount(channelCount));
         m_channelCount = channelCount;
     }
     void resetChannelCount() {
@@ -126,7 +125,6 @@ protected:
     }
 
     void setSamplingRate(SINT samplingRate) {
-        DEBUG_ASSERT(isValidSamplingRate(samplingRate));
         m_samplingRate = samplingRate;
     }
     void resetSamplingRate() {


### PR DESCRIPTION
Limit the range of valid sampling rates to [8kHz, 192 kHz]

https://bugs.launchpad.net/mixxx/+bug/1606054
