### PR TITLE
Fractional Frame Loops 

### DIFF
--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -222,11 +222,11 @@ void CachingReader::process() {
     }
 }
 
-SINT CachingReader::read(SINT start_sample, bool reverse, SINT numSamples, CSAMPLE* buffer) {
+SINT CachingReader::read(SINT startSample, SINT numSamples, bool reverse, CSAMPLE* buffer) {
     // the samples are always read in forward direction
     // If reverse = true, the frames are copied in reverse order to the
     // destination buffer
-    SINT sample = start_sample;
+    SINT sample = startSample;
     if (reverse) {
         // Start with the last sample in buffer
         sample -= numSamples;

--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -222,7 +222,16 @@ void CachingReader::process() {
     }
 }
 
-SINT CachingReader::read(SINT sample, bool reverse, SINT numSamples, CSAMPLE* buffer) {
+SINT CachingReader::read(SINT start_sample, bool reverse, SINT numSamples, CSAMPLE* buffer) {
+    // the samples are always read in forward direction
+    // If reverse = true, the frames are copied in reverse order to the
+    // destination buffer
+    SINT sample = start_sample;
+    if (reverse) {
+        // Start with the last sample in buffer
+        sample -= numSamples;
+    }
+
     // Check for bad inputs
     DEBUG_ASSERT_AND_HANDLE(sample % CachingReaderChunk::kChannels == 0) {
         // This problem is easy to fix, but this type of call should be

--- a/src/engine/cachingreader.h
+++ b/src/engine/cachingreader.h
@@ -80,7 +80,7 @@ class CachingReader : public QObject {
     // Read numSamples from the SoundSource starting with sample into
     // buffer. Returns the total number of samples actually written to buffer
     // support reading stereo samples in reverse (backward) order
-    virtual SINT read(SINT sample, bool reverse, SINT numSamples, CSAMPLE* buffer);
+    virtual SINT read(SINT startSample, SINT numSamples, bool reverse, CSAMPLE* buffer);
 
     // Issue a list of hints, but check whether any of the hints request a chunk
     // that is not in the cache. If any hints do request a chunk not in cache,

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -968,7 +968,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
             } else {
                 // Adjust filepos_play by the amount we processed.
                 m_filepos_play =
-                        m_pReadAheadManager->getEffectiveVirtualPlaypositionFromLog(
+                        m_pReadAheadManager->getFilePlaypositionFromLog(
                                 m_filepos_play, samplesRead);
             }
             if (m_bCrossfadeReady) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -948,10 +948,6 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
 
         // If the buffer is not paused, then scale the audio.
         if (!bCurBufferPaused) {
-            //if (rate == 0) {
-            //    qDebug() << "ramp to rate 0";
-            //}
-
             // Perform scaling of Reader buffer into buffer.
             double framesRead =
                     m_pScale->scaleBuffer(pOutput, iBufferSize);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -439,7 +439,7 @@ void EngineBuffer::setNewPlaypos(double newpos) {
 
     if (m_rate_old != 0.0) {
         // Before seeking, read extra buffer for crossfading
-        // (calls notifySeek())
+        // this also sets m_pReadAheadManager to newpos
         readToCrossfadeBuffer(m_iLastBufferSize);
     } else {
         m_pReadAheadManager->notifySeek(m_filepos_play);

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -19,24 +19,36 @@ EngineControl::EngineControl(QString group,
 EngineControl::~EngineControl() {
 }
 
-double EngineControl::process(const double,
-                              const double,
-                              const double,
-                              const int) {
+double EngineControl::process(const double dRate,
+                           const double dCurrentSample,
+                           const double dTotalSamples,
+                           const int iBufferSize) {
+    Q_UNUSED(dRate);
+    Q_UNUSED(dCurrentSample);
+    Q_UNUSED(dTotalSamples);
+    Q_UNUSED(iBufferSize);
     return kNoTrigger;
 }
 
-double EngineControl::nextTrigger(const double,
-                                  const double,
-                                  const double,
-                                  const int) {
+double EngineControl::nextTrigger(const double dRate,
+                                  const double currentSample,
+                                  const double totalSamples,
+                                  const int iBufferSize) {
+    Q_UNUSED(dRate);
+    Q_UNUSED(currentSample);
+    Q_UNUSED(totalSamples);
+    Q_UNUSED(iBufferSize);
     return kNoTrigger;
 }
 
-double EngineControl::getTrigger(const double,
-                                 const double,
-                                 const double,
-                                 const int) {
+double EngineControl::getTrigger(const double dRate,
+                                 const double currentSample,
+                                 const double totalSamples,
+                                 const int iBufferSize) {
+    Q_UNUSED(dRate);
+    Q_UNUSED(currentSample);
+    Q_UNUSED(totalSamples);
+    Q_UNUSED(iBufferSize);
     return kNoTrigger;
 }
 

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -115,6 +115,7 @@ class LoopingControl : public EngineControl {
 
     bool m_bLoopingEnabled;
     bool m_bLoopRollActive;
+    // TODO(DSC) Make the following values double
     ControlValueAtomic<LoopSamples> m_loopSamples;
     QAtomicInt m_iCurrentSample;
     ControlObject* m_pQuantizeEnabled;

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -74,23 +74,17 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
         }
     }
 
-    SINT start_sample;
-    if (in_reverse) {
-        start_sample = SampleUtil::roundPlayPosToFrameStart(
-                m_currentPosition, kNumChannels) - samples_from_reader;
-    } else {
-        start_sample = SampleUtil::roundPlayPosToFrameStart(
-                m_currentPosition, kNumChannels);
-    }
-
     // Sanity checks.
     if (samples_from_reader < 0) {
         qDebug() << "Need negative samples in ReadAheadManager::getNextSamples. Ignoring read";
         return 0;
     }
 
-    SINT samples_read = m_pReader->read(start_sample, in_reverse, samples_from_reader,
-                                       pOutput);
+    SINT start_sample = SampleUtil::roundPlayPosToFrameStart(
+            m_currentPosition, kNumChannels);
+
+    SINT samples_read = m_pReader->read(
+            start_sample, in_reverse, samples_from_reader, pOutput);
 
     if (samples_read != samples_from_reader) {
         qDebug() << "didn't get what we wanted" << samples_read << samples_from_reader;

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -74,7 +74,7 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
         }
     }
 
-    int start_sample;
+    SINT start_sample;
     if (in_reverse) {
         start_sample = SampleUtil::roundPlayPosToFrameStart(
                 m_currentPosition, kNumChannels) - samples_from_reader;

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -10,6 +10,8 @@
 #include "util/math.h"
 #include "util/sample.h"
 
+static const int kNumChannels = 2;
+
 ReadAheadManager::ReadAheadManager()
         : m_pLoopingControl(NULL),
           m_pRateControl(NULL),
@@ -28,7 +30,6 @@ ReadAheadManager::ReadAheadManager(CachingReader* pReader,
           m_pCrossFadeBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)) {
     DEBUG_ASSERT(m_pLoopingControl != NULL);
     DEBUG_ASSERT(m_pReader != NULL);
-    SampleUtil::clear(m_pCrossFadeBuffer, MAX_BUFFER_LEN);
 }
 
 ReadAheadManager::~ReadAheadManager() {

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -84,7 +84,7 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
             m_currentPosition, kNumChannels);
 
     SINT samples_read = m_pReader->read(
-            start_sample, in_reverse, samples_from_reader, pOutput);
+            start_sample, samples_from_reader, in_reverse, pOutput);
 
     if (samples_read != samples_from_reader) {
         qDebug() << "didn't get what we wanted" << samples_read << samples_from_reader;
@@ -134,7 +134,7 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
                     m_currentPosition + (in_reverse ? preloop_samples : -preloop_samples), kNumChannels);
 
             int looping_samples_read = m_pReader->read(
-                    loop_read_position, in_reverse, samples_read, m_pCrossFadeBuffer);
+                    loop_read_position, samples_read, in_reverse, m_pCrossFadeBuffer);
 
             if (looping_samples_read != samples_read) {
                 qDebug() << "ERROR: Couldn't get all needed samples for crossfade.";

--- a/src/engine/readaheadmanager.h
+++ b/src/engine/readaheadmanager.h
@@ -56,7 +56,7 @@ class ReadAheadManager {
     // indicate that the given portion of a song is about to be read.
     virtual void hintReader(double dRate, HintVector* hintList);
 
-    virtual SINT getEffectiveVirtualPlaypositionFromLog(double currentVirtualPlayposition,
+    virtual double getFilePlaypositionFromLog(double currentFilePlayposition,
                                                        double numConsumedSamples);
 
     virtual void setReader(CachingReader* pReader) {
@@ -91,13 +91,14 @@ class ReadAheadManager {
         }
 
         // Moves the start position forward or backward (depending on
-        // direction()) by numSamples. Returns the total number of samples
-        // consumed. Caller should check if length() is 0 after consumption in
+        // direction()) by numSamples.
+        // Caller should check if length() is 0 after consumption in
         // order to expire the ReadLogEntry.
-        double consume(double numSamples) {
-            double available = math_min(numSamples, length());
+        double advancePlayposition(double* pNumConsumedSamples) {
+            double available = math_min(*pNumConsumedSamples, length());
             virtualPlaypositionStart += (direction() ? 1 : -1) * available;
-            return available;
+            *pNumConsumedSamples -= available;
+            return virtualPlaypositionStart;
         }
 
         bool merge(const ReadLogEntry& other) {

--- a/src/engine/readaheadmanager.h
+++ b/src/engine/readaheadmanager.h
@@ -27,7 +27,7 @@ class RateControl;
 class ReadAheadManager {
   public:
     ReadAheadManager(); // Only for testing: ReadAheadManagerMock
-     ReadAheadManager(CachingReader* reader,
+    ReadAheadManager(CachingReader* reader,
                               LoopingControl* pLoopingControl);
     virtual ~ReadAheadManager();
 
@@ -45,11 +45,12 @@ class ReadAheadManager {
     void addRateControl(RateControl* pRateControl);
 
     // Get the current read-ahead position in samples.
-    virtual inline SINT getPlaypos() const {
-        return m_iCurrentPosition;
+    // unused in Mixxx, but needed for testing 
+    virtual inline double getPlaypos() const {
+        return m_currentPosition;
     }
 
-    virtual void notifySeek(SINT iSeekPosition);
+    virtual void notifySeek(double seekPosition);
 
     // hintReader allows the ReadAheadManager to provide hints to the reader to
     // indicate that the given portion of a song is about to be read.
@@ -120,7 +121,7 @@ class ReadAheadManager {
     LoopingControl* m_pLoopingControl;
     RateControl* m_pRateControl;
     QLinkedList<ReadLogEntry> m_readAheadLog;
-    SINT m_iCurrentPosition;
+    double m_currentPosition;
     CachingReader* m_pReader;
     CSAMPLE* m_pCrossFadeBuffer;
 };

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -17,12 +17,12 @@ class StubReader : public CachingReader {
     StubReader()
             : CachingReader("[test]", UserSettingsPointer()) { }
 
-    SINT read(SINT sample, bool reverse, SINT num_samples,
+    SINT read(SINT startSample, SINT numSamples, bool reverse,
              CSAMPLE* buffer) override {
-        Q_UNUSED(sample);
+        Q_UNUSED(startSample);
         Q_UNUSED(reverse);
-        SampleUtil::clear(buffer, num_samples);
-        return num_samples;
+        SampleUtil::clear(buffer, numSamples);
+        return numSamples;
     }
 };
 

--- a/src/util/sample.cpp
+++ b/src/util/sample.cpp
@@ -151,7 +151,8 @@ void SampleUtil::applyAlternatingGain(CSAMPLE* pBuffer, CSAMPLE gain1,
 }
 
 // static
-void SampleUtil::addWithGain(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRICT pSrc,
+void SampleUtil::addWithGain(CSAMPLE* M_RESTRICT pDest,
+        const CSAMPLE* M_RESTRICT pSrc,
         CSAMPLE_GAIN gain, int iNumSamples) {
     if (gain == CSAMPLE_GAIN_ZERO) {
         return;
@@ -163,7 +164,8 @@ void SampleUtil::addWithGain(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRIC
     }
 }
 
-void SampleUtil::addWithRampingGain(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRICT pSrc,
+void SampleUtil::addWithRampingGain(CSAMPLE* M_RESTRICT pDest,
+        const CSAMPLE* M_RESTRICT pSrc,
         CSAMPLE_GAIN old_gain, CSAMPLE_GAIN new_gain,
         int iNumSamples) {
     if (old_gain == CSAMPLE_GAIN_ZERO && new_gain == CSAMPLE_GAIN_ZERO) {
@@ -189,8 +191,9 @@ void SampleUtil::addWithRampingGain(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_
 }
 
 // static
-void SampleUtil::add2WithGain(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRICT pSrc1,
-        CSAMPLE_GAIN gain1, const CSAMPLE* M_RESTRICT pSrc2, CSAMPLE_GAIN gain2,
+void SampleUtil::add2WithGain(CSAMPLE* M_RESTRICT pDest,
+        const CSAMPLE* M_RESTRICT pSrc1, CSAMPLE_GAIN gain1,
+        const CSAMPLE* M_RESTRICT pSrc2, CSAMPLE_GAIN gain2,
         int iNumSamples) {
     if (gain1 == CSAMPLE_GAIN_ZERO) {
         return addWithGain(pDest, pSrc2, gain2, iNumSamples);
@@ -205,9 +208,11 @@ void SampleUtil::add2WithGain(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRI
 }
 
 // static
-void SampleUtil::add3WithGain(CSAMPLE* pDest, const CSAMPLE* M_RESTRICT pSrc1,
-        CSAMPLE_GAIN gain1, const CSAMPLE* M_RESTRICT pSrc2, CSAMPLE_GAIN gain2,
-        const CSAMPLE* M_RESTRICT pSrc3, CSAMPLE_GAIN gain3, int iNumSamples) {
+void SampleUtil::add3WithGain(CSAMPLE* pDest,
+        const CSAMPLE* M_RESTRICT pSrc1, CSAMPLE_GAIN gain1,
+        const CSAMPLE* M_RESTRICT pSrc2, CSAMPLE_GAIN gain2,
+        const CSAMPLE* M_RESTRICT pSrc3, CSAMPLE_GAIN gain3,
+        int iNumSamples) {
     if (gain1 == CSAMPLE_GAIN_ZERO) {
         return add2WithGain(pDest, pSrc2, gain2, pSrc3, gain3, iNumSamples);
     } else if (gain2 == CSAMPLE_GAIN_ZERO) {
@@ -223,7 +228,8 @@ void SampleUtil::add3WithGain(CSAMPLE* pDest, const CSAMPLE* M_RESTRICT pSrc1,
 }
 
 // static
-void SampleUtil::copyWithGain(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRICT pSrc,
+void SampleUtil::copyWithGain(CSAMPLE* M_RESTRICT pDest,
+        const CSAMPLE* M_RESTRICT pSrc,
         CSAMPLE_GAIN gain, int iNumSamples) {
     if (gain == CSAMPLE_GAIN_ONE) {
         copy(pDest, pSrc, iNumSamples);
@@ -245,8 +251,11 @@ void SampleUtil::copyWithGain(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRI
 }
 
 // static
-void SampleUtil::copyWithRampingGain(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRICT pSrc,
-        CSAMPLE_GAIN old_gain, CSAMPLE_GAIN new_gain, int iNumSamples) {
+void SampleUtil::copyWithRampingGain(CSAMPLE* M_RESTRICT pDest,
+        const CSAMPLE* M_RESTRICT pSrc,
+        CSAMPLE_GAIN old_gain,
+        CSAMPLE_GAIN new_gain,
+        int iNumSamples) {
     if (old_gain == CSAMPLE_GAIN_ONE && new_gain == CSAMPLE_GAIN_ONE) {
         copy(pDest, pSrc, iNumSamples);
         return;
@@ -279,8 +288,8 @@ void SampleUtil::copyWithRampingGain(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M
 }
 
 // static
-void SampleUtil::convertS16ToFloat32(CSAMPLE* M_RESTRICT pDest, const SAMPLE* M_RESTRICT pSrc,
-        int iNumSamples) {
+void SampleUtil::convertS16ToFloat32(CSAMPLE* M_RESTRICT pDest,
+        const SAMPLE* M_RESTRICT pSrc, int iNumSamples) {
     // SAMPLE_MIN = -32768 is a valid low sample, whereas SAMPLE_MAX = 32767
     // is the highest valid sample. Note that this means that although some
     // sample values convert to -1.0, none will convert to +1.0.
@@ -303,8 +312,8 @@ void SampleUtil::convertFloat32ToS16(SAMPLE* pDest, const CSAMPLE* pSrc,
 }
 
 // static
-SampleUtil::CLIP_STATUS SampleUtil::sumAbsPerChannel(CSAMPLE* pfAbsL, CSAMPLE* pfAbsR,
-        const CSAMPLE* pBuffer, int iNumSamples) {
+SampleUtil::CLIP_STATUS SampleUtil::sumAbsPerChannel(CSAMPLE* pfAbsL,
+        CSAMPLE* pfAbsR, const CSAMPLE* pBuffer, int iNumSamples) {
     CSAMPLE fAbsL = CSAMPLE_ZERO;
     CSAMPLE fAbsR = CSAMPLE_ZERO;
     CSAMPLE clippedL = 0;
@@ -334,8 +343,8 @@ SampleUtil::CLIP_STATUS SampleUtil::sumAbsPerChannel(CSAMPLE* pfAbsL, CSAMPLE* p
 }
 
 // static
-void SampleUtil::copyClampBuffer(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRICT pSrc,
-        int iNumSamples) {
+void SampleUtil::copyClampBuffer(CSAMPLE* M_RESTRICT pDest,
+        const CSAMPLE* M_RESTRICT pSrc, int iNumSamples) {
     // note: LOOP VECTORIZED.
     for (int i = 0; i < iNumSamples; ++i) {
         pDest[i] = clampSample(pSrc[i]);
@@ -343,20 +352,24 @@ void SampleUtil::copyClampBuffer(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RES
 }
 
 // static
-void SampleUtil::interleaveBuffer(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRICT pSrc1,
-        const CSAMPLE* M_RESTRICT pSrc2, int iNumSamples) {
+void SampleUtil::interleaveBuffer(CSAMPLE* M_RESTRICT pDest,
+        const CSAMPLE* M_RESTRICT pSrc1,
+        const CSAMPLE* M_RESTRICT pSrc2,
+        int iNumFrames) {
     // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumSamples; ++i) {
+    for (int i = 0; i < iNumFrames; ++i) {
         pDest[2 * i] = pSrc1[i];
         pDest[2 * i + 1] = pSrc2[i];
     }
 }
 
 // static
-void SampleUtil::deinterleaveBuffer(CSAMPLE* pDest1, CSAMPLE* pDest2,
-        const CSAMPLE* pSrc, int iNumSamples) {
+void SampleUtil::deinterleaveBuffer(CSAMPLE* M_RESTRICT pDest1,
+        CSAMPLE* M_RESTRICT pDest2,
+        const CSAMPLE* M_RESTRICT pSrc,
+        int iNumFrames) {
     // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumSamples; ++i) {
+    for (int i = 0; i < iNumFrames; ++i) {
         pDest1[i] = pSrc[i * 2];
         pDest2[i] = pSrc[i * 2 + 1];
     }
@@ -404,8 +417,8 @@ void SampleUtil::doubleMonoToDualMono(CSAMPLE* pBuffer, int numFrames) {
 }
 
 // static
-void SampleUtil::copyMonoToDualMono(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRICT pSrc,
-        int numFrames) {
+void SampleUtil::copyMonoToDualMono(CSAMPLE* M_RESTRICT pDest,
+        const CSAMPLE* M_RESTRICT pSrc, int numFrames) {
     // forward loop
     // note: LOOP VECTORIZED
     for (int i = 0; i < numFrames; ++i) {
@@ -426,7 +439,8 @@ void SampleUtil::stripMultiToStereo(CSAMPLE* pBuffer, int numFrames,
 }
 
 // static
-void SampleUtil::copyMultiToStereo(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRICT pSrc,
+void SampleUtil::copyMultiToStereo(CSAMPLE* M_RESTRICT pDest,
+        const CSAMPLE* M_RESTRICT pSrc,
         int numFrames, int numChannels) {
     // forward loop
     for (int i = 0; i < numFrames; ++i) {
@@ -450,8 +464,8 @@ void SampleUtil::reverse(CSAMPLE* pBuffer, int iNumSamples) {
 }
 
 // static
-void SampleUtil::copyReverse(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRICT pSrc,
-        int iNumSamples) {
+void SampleUtil::copyReverse(CSAMPLE* M_RESTRICT pDest,
+        const CSAMPLE* M_RESTRICT pSrc, int iNumSamples) {
     for (int j = 0; j < iNumSamples / 2; ++j) {
         const int endpos = (iNumSamples - 1) - j * 2;
         pDest[j * 2] = pSrc[endpos - 1];

--- a/src/util/sample.cpp
+++ b/src/util/sample.cpp
@@ -27,7 +27,7 @@ static inline bool useAlignedAlloc() {
 }
 
 // static
-CSAMPLE* SampleUtil::alloc(int size) {
+CSAMPLE* SampleUtil::alloc(SINT size) {
     // To speed up vectorization we align our sample buffers to 16-byte (128
     // bit) boundaries so that vectorized loops doesn't have to do a serial
     // ramp-up before going parallel.
@@ -46,7 +46,7 @@ CSAMPLE* SampleUtil::alloc(int size) {
     // TODO(XXX): consider 32 byte alignement to optimize for AVX builds
     if (useAlignedAlloc()) {
 #ifdef _MSC_VER
-        return static_cast<CSAMPLE*>(_aligned_malloc(sizeof(CSAMPLE)*size, 16));
+        return static_cast<CSAMPLE*>(_aligned_malloc(sizeof(CSAMPLE) * size, 16));
 #else
         // This block will be only used on non-Windows platforms that don't
         // produce 16-byte aligned pointers via malloc. We allocate 16 bytes of
@@ -91,37 +91,37 @@ void SampleUtil::free(CSAMPLE* pBuffer) {
 
 // static
 void SampleUtil::applyGain(CSAMPLE* pBuffer, CSAMPLE_GAIN gain,
-        int iNumSamples) {
+        SINT numSamples) {
     if (gain == CSAMPLE_GAIN_ONE)
         return;
     if (gain == CSAMPLE_GAIN_ZERO) {
-        clear(pBuffer, iNumSamples);
+        clear(pBuffer, numSamples);
         return;
     }
 
     // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumSamples; ++i) {
+    for (SINT i = 0; i < numSamples; ++i) {
         pBuffer[i] *= gain;
     }
 }
 
 // static
 void SampleUtil::applyRampingGain(CSAMPLE* pBuffer, CSAMPLE_GAIN old_gain,
-        CSAMPLE_GAIN new_gain, int iNumSamples) {
+        CSAMPLE_GAIN new_gain, SINT numSamples) {
     if (old_gain == CSAMPLE_GAIN_ONE && new_gain == CSAMPLE_GAIN_ONE) {
         return;
     }
     if (old_gain == CSAMPLE_GAIN_ZERO && new_gain == CSAMPLE_GAIN_ZERO) {
-        clear(pBuffer, iNumSamples);
+        clear(pBuffer, numSamples);
         return;
     }
 
     const CSAMPLE_GAIN gain_delta = (new_gain - old_gain)
-            / CSAMPLE_GAIN(iNumSamples / 2);
+            / CSAMPLE_GAIN(numSamples / 2);
     if (gain_delta) {
         const CSAMPLE_GAIN start_gain = old_gain + gain_delta;
         // note: LOOP VECTORIZED.
-        for (int i = 0; i < iNumSamples / 2; ++i) {
+        for (int i = 0; i < numSamples / 2; ++i) {
             const CSAMPLE_GAIN gain = start_gain + gain_delta * i;
             // a loop counter i += 2 prevents vectorizing.
             pBuffer[i * 2] *= gain;
@@ -129,7 +129,7 @@ void SampleUtil::applyRampingGain(CSAMPLE* pBuffer, CSAMPLE_GAIN old_gain,
         }
     } else {
         // note: LOOP VECTORIZED.
-        for (int i = 0; i < iNumSamples; ++i) {
+        for (int i = 0; i < numSamples; ++i) {
             pBuffer[i] *= old_gain;
         }
     }
@@ -137,14 +137,14 @@ void SampleUtil::applyRampingGain(CSAMPLE* pBuffer, CSAMPLE_GAIN old_gain,
 
 // static
 void SampleUtil::applyAlternatingGain(CSAMPLE* pBuffer, CSAMPLE gain1,
-        CSAMPLE gain2, int iNumSamples) {
+        CSAMPLE gain2, SINT numSamples) {
     // This handles gain1 == CSAMPLE_GAIN_ONE && gain2 == CSAMPLE_GAIN_ONE as well.
     if (gain1 == gain2) {
-        return applyGain(pBuffer, gain1, iNumSamples);
+        return applyGain(pBuffer, gain1, numSamples);
     }
 
     // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumSamples / 2; ++i) {
+    for (SINT i = 0; i < numSamples / 2; ++i) {
         pBuffer[i * 2] *= gain1;
         pBuffer[i * 2 + 1] *= gain2;
     }
@@ -153,13 +153,13 @@ void SampleUtil::applyAlternatingGain(CSAMPLE* pBuffer, CSAMPLE gain1,
 // static
 void SampleUtil::addWithGain(CSAMPLE* M_RESTRICT pDest,
         const CSAMPLE* M_RESTRICT pSrc,
-        CSAMPLE_GAIN gain, int iNumSamples) {
+        CSAMPLE_GAIN gain, SINT numSamples) {
     if (gain == CSAMPLE_GAIN_ZERO) {
         return;
     }
 
     // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumSamples; ++i) {
+    for (SINT i = 0; i < numSamples; ++i) {
         pDest[i] += pSrc[i] * gain;
     }
 }
@@ -167,24 +167,24 @@ void SampleUtil::addWithGain(CSAMPLE* M_RESTRICT pDest,
 void SampleUtil::addWithRampingGain(CSAMPLE* M_RESTRICT pDest,
         const CSAMPLE* M_RESTRICT pSrc,
         CSAMPLE_GAIN old_gain, CSAMPLE_GAIN new_gain,
-        int iNumSamples) {
+        SINT numSamples) {
     if (old_gain == CSAMPLE_GAIN_ZERO && new_gain == CSAMPLE_GAIN_ZERO) {
         return;
     }
 
     const CSAMPLE_GAIN gain_delta = (new_gain - old_gain)
-            / CSAMPLE_GAIN(iNumSamples / 2);
+            / CSAMPLE_GAIN(numSamples / 2);
     if (gain_delta) {
         const CSAMPLE_GAIN start_gain = old_gain + gain_delta;
         // note: LOOP VECTORIZED.
-        for (int i = 0; i < iNumSamples / 2; ++i) {
+        for (int i = 0; i < numSamples / 2; ++i) {
             const CSAMPLE_GAIN gain = start_gain + gain_delta * i;
             pDest[i * 2] += pSrc[i * 2] * gain;
             pDest[i * 2 + 1] += pSrc[i * 2 + 1] * gain;
         }
     } else {
         // note: LOOP VECTORIZED.
-        for (int i = 0; i < iNumSamples; ++i) {
+        for (int i = 0; i < numSamples; ++i) {
             pDest[i] += pSrc[i] * old_gain;
         }
     }
@@ -194,15 +194,15 @@ void SampleUtil::addWithRampingGain(CSAMPLE* M_RESTRICT pDest,
 void SampleUtil::add2WithGain(CSAMPLE* M_RESTRICT pDest,
         const CSAMPLE* M_RESTRICT pSrc1, CSAMPLE_GAIN gain1,
         const CSAMPLE* M_RESTRICT pSrc2, CSAMPLE_GAIN gain2,
-        int iNumSamples) {
+        SINT numSamples) {
     if (gain1 == CSAMPLE_GAIN_ZERO) {
-        return addWithGain(pDest, pSrc2, gain2, iNumSamples);
+        return addWithGain(pDest, pSrc2, gain2, numSamples);
     } else if (gain2 == CSAMPLE_GAIN_ZERO) {
-        return addWithGain(pDest, pSrc1, gain1, iNumSamples);
+        return addWithGain(pDest, pSrc1, gain1, numSamples);
     }
 
     // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumSamples; ++i) {
+    for (int i = 0; i < numSamples; ++i) {
         pDest[i] += pSrc1[i] * gain1 + pSrc2[i] * gain2;
     }
 }
@@ -212,17 +212,17 @@ void SampleUtil::add3WithGain(CSAMPLE* pDest,
         const CSAMPLE* M_RESTRICT pSrc1, CSAMPLE_GAIN gain1,
         const CSAMPLE* M_RESTRICT pSrc2, CSAMPLE_GAIN gain2,
         const CSAMPLE* M_RESTRICT pSrc3, CSAMPLE_GAIN gain3,
-        int iNumSamples) {
+        SINT numSamples) {
     if (gain1 == CSAMPLE_GAIN_ZERO) {
-        return add2WithGain(pDest, pSrc2, gain2, pSrc3, gain3, iNumSamples);
+        return add2WithGain(pDest, pSrc2, gain2, pSrc3, gain3, numSamples);
     } else if (gain2 == CSAMPLE_GAIN_ZERO) {
-        return add2WithGain(pDest, pSrc1, gain1, pSrc3, gain3, iNumSamples);
+        return add2WithGain(pDest, pSrc1, gain1, pSrc3, gain3, numSamples);
     } else if (gain3 == CSAMPLE_GAIN_ZERO) {
-        return add2WithGain(pDest, pSrc1, gain1, pSrc2, gain2, iNumSamples);
+        return add2WithGain(pDest, pSrc1, gain1, pSrc2, gain2, numSamples);
     }
 
     // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumSamples; ++i) {
+    for (SINT i = 0; i < numSamples; ++i) {
         pDest[i] += pSrc1[i] * gain1 + pSrc2[i] * gain2 + pSrc3[i] * gain3;
     }
 }
@@ -230,18 +230,18 @@ void SampleUtil::add3WithGain(CSAMPLE* pDest,
 // static
 void SampleUtil::copyWithGain(CSAMPLE* M_RESTRICT pDest,
         const CSAMPLE* M_RESTRICT pSrc,
-        CSAMPLE_GAIN gain, int iNumSamples) {
+        CSAMPLE_GAIN gain, SINT numSamples) {
     if (gain == CSAMPLE_GAIN_ONE) {
-        copy(pDest, pSrc, iNumSamples);
+        copy(pDest, pSrc, numSamples);
         return;
     }
     if (gain == CSAMPLE_GAIN_ZERO) {
-        clear(pDest, iNumSamples);
+        clear(pDest, numSamples);
         return;
     }
 
     // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumSamples; ++i) {
+    for (SINT i = 0; i < numSamples; ++i) {
         pDest[i] = pSrc[i] * gain;
     }
 
@@ -255,29 +255,29 @@ void SampleUtil::copyWithRampingGain(CSAMPLE* M_RESTRICT pDest,
         const CSAMPLE* M_RESTRICT pSrc,
         CSAMPLE_GAIN old_gain,
         CSAMPLE_GAIN new_gain,
-        int iNumSamples) {
+        SINT numSamples) {
     if (old_gain == CSAMPLE_GAIN_ONE && new_gain == CSAMPLE_GAIN_ONE) {
-        copy(pDest, pSrc, iNumSamples);
+        copy(pDest, pSrc, numSamples);
         return;
     }
     if (old_gain == CSAMPLE_GAIN_ZERO && new_gain == CSAMPLE_GAIN_ZERO) {
-        clear(pDest, iNumSamples);
+        clear(pDest, numSamples);
         return;
     }
 
     const CSAMPLE_GAIN gain_delta = (new_gain - old_gain)
-            / CSAMPLE_GAIN(iNumSamples / 2);
+            / CSAMPLE_GAIN(numSamples / 2);
     if (gain_delta) {
         const CSAMPLE_GAIN start_gain = old_gain + gain_delta;
-        // note: LOOP VECTORIZED.
-        for (int i = 0; i < iNumSamples / 2; ++i) {
+        // note: LOOP VECTORIZED only with "int i"
+        for (int i = 0; i < numSamples / 2; ++i) {
             const CSAMPLE_GAIN gain = start_gain + gain_delta * i;
             pDest[i * 2] = pSrc[i * 2] * gain;
             pDest[i * 2 + 1] = pSrc[i * 2 + 1] * gain;
         }
     } else {
         // note: LOOP VECTORIZED.
-        for (int i = 0; i < iNumSamples; ++i) {
+        for (SINT i = 0; i < numSamples; ++i) {
             pDest[i] = pSrc[i] * old_gain;
         }
     }
@@ -289,38 +289,39 @@ void SampleUtil::copyWithRampingGain(CSAMPLE* M_RESTRICT pDest,
 
 // static
 void SampleUtil::convertS16ToFloat32(CSAMPLE* M_RESTRICT pDest,
-        const SAMPLE* M_RESTRICT pSrc, int iNumSamples) {
+        const SAMPLE* M_RESTRICT pSrc, SINT numSamples) {
     // SAMPLE_MIN = -32768 is a valid low sample, whereas SAMPLE_MAX = 32767
     // is the highest valid sample. Note that this means that although some
     // sample values convert to -1.0, none will convert to +1.0.
     DEBUG_ASSERT(-SAMPLE_MIN >= SAMPLE_MAX);
     const CSAMPLE kConversionFactor = -SAMPLE_MIN;
     // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumSamples; ++i) {
+    for (SINT i = 0; i < numSamples; ++i) {
         pDest[i] = CSAMPLE(pSrc[i]) / kConversionFactor;
     }
 }
 
 //static
 void SampleUtil::convertFloat32ToS16(SAMPLE* pDest, const CSAMPLE* pSrc,
-        unsigned int iNumSamples) {
+        SINT numSamples) {
     DEBUG_ASSERT(-SAMPLE_MIN >= SAMPLE_MAX);
     const CSAMPLE kConversionFactor = -SAMPLE_MIN;
-    for (unsigned int i = 0; i < iNumSamples; ++i) {
+    // note: LOOP VECTORIZED only with "int i"
+    for (int i = 0; i < numSamples; ++i) {
         pDest[i] = SAMPLE(pSrc[i] * kConversionFactor);
     }
 }
 
 // static
 SampleUtil::CLIP_STATUS SampleUtil::sumAbsPerChannel(CSAMPLE* pfAbsL,
-        CSAMPLE* pfAbsR, const CSAMPLE* pBuffer, int iNumSamples) {
+        CSAMPLE* pfAbsR, const CSAMPLE* pBuffer, SINT numSamples) {
     CSAMPLE fAbsL = CSAMPLE_ZERO;
     CSAMPLE fAbsR = CSAMPLE_ZERO;
     CSAMPLE clippedL = 0;
     CSAMPLE clippedR = 0;
 
     // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumSamples / 2; ++i) {
+    for (SINT i = 0; i < numSamples / 2; ++i) {
         CSAMPLE absl = fabs(pBuffer[i * 2]);
         fAbsL += absl;
         clippedL += absl > CSAMPLE_PEAK ? 1 : 0;
@@ -344,9 +345,9 @@ SampleUtil::CLIP_STATUS SampleUtil::sumAbsPerChannel(CSAMPLE* pfAbsL,
 
 // static
 void SampleUtil::copyClampBuffer(CSAMPLE* M_RESTRICT pDest,
-        const CSAMPLE* M_RESTRICT pSrc, int iNumSamples) {
+        const CSAMPLE* M_RESTRICT pSrc, SINT iNumSamples) {
     // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumSamples; ++i) {
+    for (SINT i = 0; i < iNumSamples; ++i) {
         pDest[i] = clampSample(pSrc[i]);
     }
 }
@@ -355,9 +356,9 @@ void SampleUtil::copyClampBuffer(CSAMPLE* M_RESTRICT pDest,
 void SampleUtil::interleaveBuffer(CSAMPLE* M_RESTRICT pDest,
         const CSAMPLE* M_RESTRICT pSrc1,
         const CSAMPLE* M_RESTRICT pSrc2,
-        int iNumFrames) {
+        SINT numFrames) {
     // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumFrames; ++i) {
+    for (SINT i = 0; i < numFrames; ++i) {
         pDest[2 * i] = pSrc1[i];
         pDest[2 * i + 1] = pSrc2[i];
     }
@@ -367,9 +368,9 @@ void SampleUtil::interleaveBuffer(CSAMPLE* M_RESTRICT pDest,
 void SampleUtil::deinterleaveBuffer(CSAMPLE* M_RESTRICT pDest1,
         CSAMPLE* M_RESTRICT pDest2,
         const CSAMPLE* M_RESTRICT pSrc,
-        int iNumFrames) {
+        SINT numFrames) {
     // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumFrames; ++i) {
+    for (SINT i = 0; i < numFrames; ++i) {
         pDest1[i] = pSrc[i * 2];
         pDest2[i] = pSrc[i * 2 + 1];
     }
@@ -378,11 +379,11 @@ void SampleUtil::deinterleaveBuffer(CSAMPLE* M_RESTRICT pDest1,
 // static
 void SampleUtil::linearCrossfadeBuffers(CSAMPLE* pDest,
         const CSAMPLE* pSrcFadeOut, const CSAMPLE* pSrcFadeIn,
-        int iNumSamples) {
+        SINT numSamples) {
     const CSAMPLE_GAIN cross_inc = CSAMPLE_GAIN_ONE
-            / CSAMPLE_GAIN(iNumSamples / 2);
-    // note: LOOP VECTORIZED.
-    for (int i = 0; i < iNumSamples / 2; ++i) {
+            / CSAMPLE_GAIN(numSamples / 2);
+    // note: LOOP VECTORIZED. only with "int i"
+    for (int i = 0; i < numSamples / 2; ++i) {
         const CSAMPLE_GAIN cross_mix = cross_inc * i;
         pDest[i * 2] = pSrcFadeIn[i * 2] * cross_mix
                 + pSrcFadeOut[i * 2] * (CSAMPLE_GAIN_ONE - cross_mix);
@@ -394,20 +395,20 @@ void SampleUtil::linearCrossfadeBuffers(CSAMPLE* pDest,
 
 // static
 void SampleUtil::mixStereoToMono(CSAMPLE* pDest, const CSAMPLE* pSrc,
-        int iNumSamples) {
+        SINT numSamples) {
     const CSAMPLE_GAIN mixScale = CSAMPLE_GAIN_ONE
             / (CSAMPLE_GAIN_ONE + CSAMPLE_GAIN_ONE);
     // note: LOOP VECTORIZED
-    for (int i = 0; i < iNumSamples / 2; ++i) {
+    for (SINT i = 0; i < numSamples / 2; ++i) {
         pDest[i * 2] = (pSrc[i * 2] + pSrc[i * 2 + 1]) * mixScale;
         pDest[i * 2 + 1] = pDest[i * 2];
     }
 }
 
 // static
-void SampleUtil::doubleMonoToDualMono(CSAMPLE* pBuffer, int numFrames) {
+void SampleUtil::doubleMonoToDualMono(CSAMPLE* pBuffer, SINT numFrames) {
     // backward loop
-    int i = numFrames;
+    SINT i = numFrames;
     // Unvectorizable Loop
     while (0 < i--) {
         const CSAMPLE s = pBuffer[i];
@@ -418,10 +419,10 @@ void SampleUtil::doubleMonoToDualMono(CSAMPLE* pBuffer, int numFrames) {
 
 // static
 void SampleUtil::copyMonoToDualMono(CSAMPLE* M_RESTRICT pDest,
-        const CSAMPLE* M_RESTRICT pSrc, int numFrames) {
+        const CSAMPLE* M_RESTRICT pSrc, SINT numFrames) {
     // forward loop
     // note: LOOP VECTORIZED
-    for (int i = 0; i < numFrames; ++i) {
+    for (SINT i = 0; i < numFrames; ++i) {
         const CSAMPLE s = pSrc[i];
         pDest[i * 2] = s;
         pDest[i * 2 + 1] = s;
@@ -429,10 +430,10 @@ void SampleUtil::copyMonoToDualMono(CSAMPLE* M_RESTRICT pDest,
 }
 
 // static
-void SampleUtil::stripMultiToStereo(CSAMPLE* pBuffer, int numFrames,
+void SampleUtil::stripMultiToStereo(CSAMPLE* pBuffer, SINT numFrames,
         int numChannels) {
     // forward loop
-    for (int i = 0; i < numFrames; ++i) {
+    for (SINT i = 0; i < numFrames; ++i) {
         pBuffer[i * 2] = pBuffer[i * numChannels];
         pBuffer[i * 2 + 1] = pBuffer[i * numChannels + 1];
     }
@@ -441,9 +442,9 @@ void SampleUtil::stripMultiToStereo(CSAMPLE* pBuffer, int numFrames,
 // static
 void SampleUtil::copyMultiToStereo(CSAMPLE* M_RESTRICT pDest,
         const CSAMPLE* M_RESTRICT pSrc,
-        int numFrames, int numChannels) {
+        SINT numFrames, int numChannels) {
     // forward loop
-    for (int i = 0; i < numFrames; ++i) {
+    for (SINT i = 0; i < numFrames; ++i) {
         pDest[i * 2] = pSrc[i * numChannels];
         pDest[i * 2 + 1] = pSrc[i * numChannels + 1];
     }
@@ -451,9 +452,9 @@ void SampleUtil::copyMultiToStereo(CSAMPLE* M_RESTRICT pDest,
 
 
 // static
-void SampleUtil::reverse(CSAMPLE* pBuffer, int iNumSamples) {
-    for (int j = 0; j < iNumSamples / 4; ++j) {
-        const int endpos = (iNumSamples - 1) - j * 2 ;
+void SampleUtil::reverse(CSAMPLE* pBuffer, SINT numSamples) {
+    for (SINT j = 0; j < numSamples / 4; ++j) {
+        const SINT endpos = (numSamples - 1) - j * 2 ;
         CSAMPLE temp1 = pBuffer[j * 2];
         CSAMPLE temp2 = pBuffer[j * 2 + 1];
         pBuffer[j * 2] = pBuffer[endpos - 1];
@@ -465,9 +466,9 @@ void SampleUtil::reverse(CSAMPLE* pBuffer, int iNumSamples) {
 
 // static
 void SampleUtil::copyReverse(CSAMPLE* M_RESTRICT pDest,
-        const CSAMPLE* M_RESTRICT pSrc, int iNumSamples) {
-    for (int j = 0; j < iNumSamples / 2; ++j) {
-        const int endpos = (iNumSamples - 1) - j * 2;
+        const CSAMPLE* M_RESTRICT pSrc, SINT numSamples) {
+    for (SINT j = 0; j < numSamples / 2; ++j) {
+        const int endpos = (numSamples - 1) - j * 2;
         pDest[j * 2] = pSrc[endpos - 1];
         pDest[j * 2 + 1] = pSrc[endpos];
     }

--- a/src/util/sample.h
+++ b/src/util/sample.h
@@ -23,31 +23,31 @@ class SampleUtil {
 
     // Allocated a buffer of CSAMPLE's with length size. Ensures that the buffer
     // is 16-byte aligned for SSE enhancement.
-    static CSAMPLE* alloc(int size);
+    static CSAMPLE* alloc(SINT size);
 
     // Frees a 16-byte aligned buffer allocated by SampleUtil::alloc()
     static void free(CSAMPLE* pBuffer);
 
     // Sets every sample in pBuffer to zero
     inline
-    static void clear(CSAMPLE* pBuffer, int iNumSamples) {
+    static void clear(CSAMPLE* pBuffer, SINT numSamples) {
         // Special case: This works, because the binary representation
         // of 0.0f is 0!
-        memset(pBuffer, 0, sizeof(*pBuffer) * iNumSamples);
+        memset(pBuffer, 0, sizeof(*pBuffer) * numSamples);
         //fill(pBuffer, CSAMPLE_ZERO, iNumSamples);
     }
 
     // Sets every sample in pBuffer to value
     inline
     static void fill(CSAMPLE* pBuffer, CSAMPLE value,
-            int iNumSamples) {
-        std::fill(pBuffer, pBuffer + iNumSamples, value);
+            SINT numSamples) {
+        std::fill(pBuffer, pBuffer + numSamples, value);
     }
 
     // Copies every sample from pSrc to pDest
     inline
     static void copy(CSAMPLE* M_RESTRICT pDest, const CSAMPLE* M_RESTRICT pSrc,
-            int iNumSamples) {
+            SINT iNumSamples) {
         // Benchmark results on 32 bit SSE2 Atom Cpu (Linux)
         // memcpy 7263 ns
         // std::copy 9289 ns
@@ -68,7 +68,7 @@ class SampleUtil {
 #ifdef __SSE__
         if (sizeof(void*) == 4) { // 32 bit
             // note: LOOP VECTORIZED.
-            for (int i = 0; i < iNumSamples; ++i) { // 571 ns
+            for (SINT i = 0; i < iNumSamples; ++i) { // 571 ns
                 pDest[i] = pSrc[i];
             }
         } else
@@ -88,115 +88,111 @@ class SampleUtil {
         return CSAMPLE_GAIN_clamp(in);
     }
 
-    // static
-    inline static int roundPlayPosToFrameStart(double playPos, int numChannels) {
-        int playPosFrames = static_cast<int>(round(playPos / numChannels));
+    inline static SINT roundPlayPosToFrameStart(double playPos, int numChannels) {
+        SINT playPosFrames = static_cast<SINT>(round(playPos / numChannels));
         return playPosFrames * numChannels;
     }
 
-    // static
-    inline static int truncPlayPosToFrameStart(double playPos, int numChannels) {
-        int playPosFrames = static_cast<int>(playPos / numChannels);
+    inline static SINT truncPlayPosToFrameStart(double playPos, int numChannels) {
+        SINT playPosFrames = static_cast<SINT>(playPos / numChannels);
         return playPosFrames * numChannels;
     }
 
-    // static
-    inline static int floorPlayPosToFrameStart(double playPos, int numChannels) {
-        int playPosFrames = static_cast<int>(floor(playPos / numChannels));
+    inline static SINT floorPlayPosToFrameStart(double playPos, int numChannels) {
+        SINT playPosFrames = static_cast<SINT>(floor(playPos / numChannels));
         return playPosFrames * numChannels;
     }
 
-    // static
-    inline static int ceilPlayPosToFrameStart(double playPos, int numChannels) {
-        int playPosFrames = static_cast<int>(ceil(playPos / numChannels));
+    inline static SINT ceilPlayPosToFrameStart(double playPos, int numChannels) {
+        SINT playPosFrames = static_cast<SINT>(ceil(playPos / numChannels));
         return playPosFrames * numChannels;
     }
 
     // Multiply every sample in pBuffer by gain
     static void applyGain(CSAMPLE* pBuffer, CSAMPLE gain,
-            int iNumSamples);
+            SINT numSamples);
 
     // Copy pSrc to pDest and multiply each sample by a factor of gain.
     // For optimum performance use the in-place function applyGain()
     // if pDest == pSrc!
     static void copyWithGain(CSAMPLE* pDest, const CSAMPLE* pSrc,
-            CSAMPLE_GAIN gain, int iNumSamples);
+            CSAMPLE_GAIN gain, SINT numSamples);
 
     // Apply a different gain to every other sample.
     static void applyAlternatingGain(CSAMPLE* pBuffer, CSAMPLE_GAIN gain1,
-            CSAMPLE_GAIN gain2, int iNumSamples);
+            CSAMPLE_GAIN gain2, SINT numSamples);
 
     // Multiply every sample in pBuffer ramping from gain1 to gain2.
     // We use ramping as often as possible to prevent soundwave discontinuities
     // which can cause audible clicks and pops.
     static void applyRampingGain(CSAMPLE* pBuffer, CSAMPLE_GAIN old_gain,
-            CSAMPLE_GAIN new_gain, int iNumSamples);
+            CSAMPLE_GAIN new_gain, SINT numSamples);
 
     // Copy pSrc to pDest and ramp gain
     // For optimum performance use the in-place function applyRampingGain()
     // if pDest == pSrc!
     static void copyWithRampingGain(CSAMPLE* pDest, const CSAMPLE* pSrc,
             CSAMPLE_GAIN old_gain, CSAMPLE_GAIN new_gain,
-            int iNumSamples);
+            SINT numSamples);
 
     // Add each sample of pSrc, multiplied by the gain, to pDest
     static void addWithGain(CSAMPLE* pDest, const CSAMPLE* pSrc,
-            CSAMPLE_GAIN gain, int iNumSamples);
+            CSAMPLE_GAIN gain, SINT numSamples);
 
     // Add each sample of pSrc, multiplied by the gain, to pDest
     static void addWithRampingGain(CSAMPLE* pDest, const CSAMPLE* pSrc,
             CSAMPLE_GAIN old_gain, CSAMPLE_GAIN new_gain,
-            int iNumSamples);
+            SINT numSamples);
 
     // Add to each sample of pDest, pSrc1 multiplied by gain1 plus pSrc2
     // multiplied by gain2
     static void add2WithGain(CSAMPLE* pDest, const CSAMPLE* pSrc1,
             CSAMPLE_GAIN gain1, const CSAMPLE* pSrc2, CSAMPLE_GAIN gain2,
-            int iNumSamples);
+            SINT numSamples);
 
     // Add to each sample of pDest, pSrc1 multiplied by gain1 plus pSrc2
     // multiplied by gain2 plus pSrc3 multiplied by gain3
     static void add3WithGain(CSAMPLE* pDest, const CSAMPLE* pSrc1,
             CSAMPLE_GAIN gain1, const CSAMPLE* pSrc2, CSAMPLE_GAIN gain2,
-            const CSAMPLE* pSrc3, CSAMPLE_GAIN gain3, int iNumSamples);
+            const CSAMPLE* pSrc3, CSAMPLE_GAIN gain3, SINT numSamples);
 
     // Convert and normalize a buffer of SAMPLEs in the range [-SAMPLE_MAX, SAMPLE_MAX]
     // to a buffer of CSAMPLEs in the range [-1.0, 1.0].
     static void convertS16ToFloat32(CSAMPLE* pDest, const SAMPLE* pSrc,
-            int iNumSamples);
+            SINT numSamples);
 
     // Convert and normalize a buffer of CSAMPLEs in the range [-1.0, 1.0]
     // to a buffer of SAMPLEs in the range [-SAMPLE_MAX, SAMPLE_MAX].
     static void convertFloat32ToS16(SAMPLE* pDest, const CSAMPLE* pSrc,
-            unsigned int iNumSamples);
+            SINT numSamples);
 
     // For each pair of samples in pBuffer (l,r) -- stores the sum of the
     // absolute values of l in pfAbsL, and the sum of the absolute values of r
     // in pfAbsR.
     // The return value tells whether there is clipping in pBuffer or not.
     static CLIP_STATUS sumAbsPerChannel(CSAMPLE* pfAbsL, CSAMPLE* pfAbsR,
-            const CSAMPLE* pBuffer, int iNumSamples);
+            const CSAMPLE* pBuffer, SINT numSamples);
 
     // Copies every sample in pSrc to pDest, limiting the values in pDest
     // to the valid range of CSAMPLE. If pDest and pSrc are aliases, will
     // not copy will only clamp. Returns true if any samples in pSrc were
     // outside the valid range of CSAMPLE.
     static void copyClampBuffer(CSAMPLE* pDest, const CSAMPLE* pSrc,
-            int iNumSamples);
+            SINT numSamples);
 
     // Interleave the samples in pSrc1 and pSrc2 into pDest. iNumSamples must be
     // the number of samples in pSrc1 and pSrc2, and pDest must have at least
     // space for iNumSamples*2 samples. pDest must not be an alias of pSrc1 or
     // pSrc2.
     static void interleaveBuffer(CSAMPLE* pDest, const CSAMPLE* pSrc1,
-            const CSAMPLE* pSrc2, int iNumSamples);
+            const CSAMPLE* pSrc2, SINT numSamples);
 
     // Deinterleave the samples in pSrc alternately into pDest1 and
     // pDest2. iNumSamples must be the number of samples in pDest1 and pDest2,
     // and pSrc must have at least iNumSamples*2 samples. Neither pDest1 or
     // pDest2 can be aliases of pSrc.
     static void deinterleaveBuffer(CSAMPLE* pDest1, CSAMPLE* pDest2,
-            const CSAMPLE* pSrc, int iNumSamples);
+            const CSAMPLE* pSrc, SINT numSamples);
 
     // Crossfade two buffers together and put the result in pDest.  All the
     // buffers must be the same length.  pDest may be an alias of the source
@@ -204,25 +200,25 @@ class SampleUtil {
     // sometimes this function is necessary.
     static void linearCrossfadeBuffers(CSAMPLE* pDest,
             const CSAMPLE* pSrcFadeOut, const CSAMPLE* pSrcFadeIn,
-            int iNumSamples);
+            SINT numSamples);
 
     // Mix a buffer down to mono, putting the result in both of the channels.
     // This uses a simple (L+R)/2 method, which assumes that the audio is
     // "mono-compatible", ie there are no major out-of-phase parts of the signal.
     static void mixStereoToMono(CSAMPLE* pDest, const CSAMPLE* pSrc,
-            int iNumSamples);
+            SINT numSamples);
 
     // In-place doubles the mono samples in pBuffer to dual mono samples.
     // (numFrames) samples will be read from pBuffer
     // (numFrames * 2) samples will be written into pBuffer
-    static void doubleMonoToDualMono(CSAMPLE* pBuffer, int numFrames);
+    static void doubleMonoToDualMono(CSAMPLE* pBuffer, SINT numFrames);
 
     // Copies and doubles the mono samples in pSrc to dual mono samples
     // into pDest.
     // (numFrames) samples will be read from pSrc
     // (numFrames * 2) samples will be written into pDest
     static void copyMonoToDualMono(CSAMPLE* pDest, const CSAMPLE* pSrc,
-            int numFrames);
+            SINT numFrames);
 
     // In-place strips interleaved multi-channel samples in pBuffer with
     // numChannels >= 2 down to stereo samples. Only samples from the first
@@ -230,7 +226,7 @@ class SampleUtil {
     // channels are discarded.
     // pBuffer must contain (numFrames * numChannels) samples
     // (numFrames * 2) samples will be written into pBuffer
-    static void stripMultiToStereo(CSAMPLE* pBuffer, int numFrames,
+    static void stripMultiToStereo(CSAMPLE* pBuffer, SINT numFrames,
             int numChannels);
 
     // Copies and strips interleaved multi-channel sample data in pSrc with
@@ -240,14 +236,14 @@ class SampleUtil {
     // pSrc must contain (numFrames * numChannels) samples
     // (numFrames * 2) samples will be written into pDest
     static void copyMultiToStereo(CSAMPLE* pDest, const CSAMPLE* pSrc,
-            int numFrames, int numChannels);
+            SINT numFrames, int numChannels);
 
     // reverses stereo sample in place
-    static void reverse(CSAMPLE* pBuffer, int iNumSamples);
+    static void reverse(CSAMPLE* pBuffer, SINT numSamples);
 
     // copy pSrc to pDest and reverses stereo sample order (backward)
     static void copyReverse(CSAMPLE* M_RESTRICT pDest,
-            const CSAMPLE* M_RESTRICT pSrc, int iNumSamples);
+            const CSAMPLE* M_RESTRICT pSrc, SINT numSamples);
 
 
     // Include auto-generated methods (e.g. copyXWithGain, copyXWithRampingGain,

--- a/src/util/sample.h
+++ b/src/util/sample.h
@@ -88,6 +88,30 @@ class SampleUtil {
         return CSAMPLE_GAIN_clamp(in);
     }
 
+    // static
+    inline static int roundPlayPosToFrameStart(double playPos, int numChannels) {
+        int playPosFrames = static_cast<int>(round(playPos / numChannels));
+        return playPosFrames * numChannels;
+    }
+
+    // static
+    inline static int truncPlayPosToFrameStart(double playPos, int numChannels) {
+        int playPosFrames = static_cast<int>(playPos / numChannels);
+        return playPosFrames * numChannels;
+    }
+
+    // static
+    inline static int floorPlayPosToFrameStart(double playPos, int numChannels) {
+        int playPosFrames = static_cast<int>(floor(playPos / numChannels));
+        return playPosFrames * numChannels;
+    }
+
+    // static
+    inline static int ceilPlayPosToFrameStart(double playPos, int numChannels) {
+        int playPosFrames = static_cast<int>(ceil(playPos / numChannels));
+        return playPosFrames * numChannels;
+    }
+
     // Multiply every sample in pBuffer by gain
     static void applyGain(CSAMPLE* pBuffer, CSAMPLE gain,
             int iNumSamples);


### PR DESCRIPTION
This allows to set loop start and end somewhere in the middle of two frames. 
This can happen if yo play the track at other rates than 1. 
Before, the positions where rounded to a full frame, which changes the size of the original loop. 
After a great amount of loop cycles, these errors could be summed to a significant error. 

A unittest is in place to demonstrate the issue. 

Still open: Allow to store loops at fractional frames.
