### PR TITLE
#1609270:  Disabled effect in chain should bypass instead of silence

### DIFF
--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -202,7 +202,7 @@ void EngineEffectChain::process(const ChannelHandle& handle,
                 if (pEffect == NULL || !pEffect->enabled()) {
                     continue;
                 }
-                const CSAMPLE* pIntermediateInput = (i == 0) ? pInOut : m_pBuffer;
+                const CSAMPLE* pIntermediateInput = (anyProcessed) ?  m_pBuffer : pInOut;
                 CSAMPLE* pIntermediateOutput = m_pBuffer;
                 pEffect->process(handle, pIntermediateInput, pIntermediateOutput,
                                  numSamples, sampleRate,


### PR DESCRIPTION
The original line would only chain effects if the first one was enabled
(compare with zero). Now, effects are properly chained for those effects
in the chain that are actually enabled.

Link to ticket: https://bugs.launchpad.net/mixxx/+bug/1609270
Link to forum: http://www.mixxx.org/forums/viewtopic.php?f=3&t=8477
