### PR TITLE
CoverInfo cleanup

### DIFF
--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -328,7 +328,7 @@ void BaseTrackCache::getTrackValueForColumn(TrackPointer pTrack,
                fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART) == column) {
         // For sorting, we give COLUMN_LIBRARYTABLE_COVERART the same value as
         // the cover hash.
-        trackValue.setValue(pTrack->getCoverInfo().hash);
+        trackValue.setValue(pTrack->getCoverHash());
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART_SOURCE) == column) {
         trackValue.setValue(static_cast<int>(pTrack->getCoverInfo().source));
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART_TYPE) == column) {

--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -48,8 +48,8 @@ QString coverInfoToString(const CoverInfo& info) {
 bool operator==(const CoverInfoRelative& a, const CoverInfoRelative& b) {
     return a.source == b.source &&
             a.type == b.type &&
-            a.coverLocation == b.coverLocation &&
-            a.hash == b.hash;
+            a.hash == b.hash &&
+            a.coverLocation == b.coverLocation;
 }
 
 bool operator!=(const CoverInfoRelative& a, const CoverInfoRelative& b) {
@@ -74,18 +74,6 @@ bool operator!=(const CoverInfo& a, const CoverInfo& b) {
 QDebug operator<<(QDebug dbg, const CoverInfo& info) {
     return dbg.maybeSpace() << QString("CoverInfo(%1)")
             .arg(coverInfoToString(info));
-}
-
-bool operator==(const CoverArt& a, const CoverArt& b) {
-    // Only count image in the equality if both are non-null.
-    return static_cast<const CoverInfo&>(a) ==
-                    static_cast<const CoverInfo&>(b) &&
-            (a.image.isNull() || b.image.isNull() ||
-             a.image == b.image);
-}
-
-bool operator!=(const CoverArt& a, const CoverArt& b) {
-    return !(a == b);
 }
 
 QDebug operator<<(QDebug dbg, const CoverArt& art) {

--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -62,8 +62,8 @@ QDebug operator<<(QDebug dbg, const CoverInfoRelative& infoRelative) {
 }
 
 bool operator==(const CoverInfo& a, const CoverInfo& b) {
-    return static_cast<CoverInfoRelative>(a) ==
-                    static_cast<CoverInfoRelative>(b) &&
+    return static_cast<const CoverInfoRelative&>(a) ==
+                    static_cast<const CoverInfoRelative&>(b) &&
             a.trackLocation == b.trackLocation;
 }
 
@@ -78,8 +78,8 @@ QDebug operator<<(QDebug dbg, const CoverInfo& info) {
 
 bool operator==(const CoverArt& a, const CoverArt& b) {
     // Only count image in the equality if both are non-null.
-    return static_cast<CoverInfo>(a) ==
-                    static_cast<CoverInfo>(b) &&
+    return static_cast<const CoverInfo&>(a) ==
+                    static_cast<const CoverInfo&>(b) &&
             (a.image.isNull() || b.image.isNull() ||
              a.image == b.image);
 }

--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -44,14 +44,48 @@ QString coverInfoToString(const CoverInfo& info) {
 }
 } // anonymous namespace
 
+
+bool operator==(const CoverInfoRelative& a, const CoverInfoRelative& b) {
+    return a.source == b.source &&
+            a.type == b.type &&
+            a.coverLocation == b.coverLocation &&
+            a.hash == b.hash;
+}
+
+bool operator!=(const CoverInfoRelative& a, const CoverInfoRelative& b) {
+    return !(a == b);
+}
+
 QDebug operator<<(QDebug dbg, const CoverInfoRelative& infoRelative) {
     return dbg.maybeSpace() << QString("CoverInfoRelative(%1)")
             .arg(coverInfoRelativeToString(infoRelative));
 }
 
+bool operator==(const CoverInfo& a, const CoverInfo& b) {
+    return static_cast<CoverInfoRelative>(a) ==
+                    static_cast<CoverInfoRelative>(b) &&
+            a.trackLocation == b.trackLocation;
+}
+
+bool operator!=(const CoverInfo& a, const CoverInfo& b) {
+    return !(a == b);
+}
+
 QDebug operator<<(QDebug dbg, const CoverInfo& info) {
     return dbg.maybeSpace() << QString("CoverInfo(%1)")
             .arg(coverInfoToString(info));
+}
+
+bool operator==(const CoverArt& a, const CoverArt& b) {
+    // Only count image in the equality if both are non-null.
+    return static_cast<CoverInfo>(a) ==
+                    static_cast<CoverInfo>(b) &&
+            (a.image.isNull() || b.image.isNull() ||
+             a.image == b.image);
+}
+
+bool operator!=(const CoverArt& a, const CoverArt& b) {
+    return !(a == b);
 }
 
 QDebug operator<<(QDebug dbg, const CoverArt& art) {

--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -1,8 +1,11 @@
 #include <QtDebug>
+#include <QLatin1Literal>
 
 #include "library/coverart.h"
 #include "library/coverartutils.h"
 #include "util/debug.h"
+
+namespace {
 
 QString sourceToString(CoverInfo::Source source) {
     switch (source) {
@@ -28,24 +31,33 @@ QString typeToString(CoverInfo::Type type) {
     return "INVALID TYPE VALUE";
 }
 
-QDebug operator<<(QDebug dbg, const CoverInfoRelative& info) {
-    return dbg.maybeSpace() << QString("CoverInfo(%1,%2,%3,%4)")
-            .arg(typeToString(info.type),
-                 sourceToString(info.source),
-                 info.coverLocation,
-                 QString::number(info.hash));
+QString coverInfoRelativeToString(const CoverInfoRelative& infoRelative) {
+    return typeToString(infoRelative.type) % QLatin1Literal(",") %
+           sourceToString(infoRelative.source) % QLatin1Literal(",") %
+           infoRelative.coverLocation % QLatin1Literal(",") %
+           QLatin1Literal("0x") % QString::number(infoRelative.hash, 16);
+}
+
+QString coverInfoToString(const CoverInfo& info) {
+    return coverInfoRelativeToString(info) % QLatin1Literal(",") %
+           info.trackLocation % QLatin1Literal(",");
+}
+} // anonymous namespace
+
+QDebug operator<<(QDebug dbg, const CoverInfoRelative& infoRelative) {
+    return dbg.maybeSpace() << QString("CoverInfoRelative(%1)")
+            .arg(coverInfoRelativeToString(infoRelative));
 }
 
 QDebug operator<<(QDebug dbg, const CoverInfo& info) {
-    return dbg.maybeSpace() << QString("CoverInfo(%1,%2)")
-            .arg(toDebugString(static_cast<CoverInfoRelative>(info)),
-                 info.trackLocation);
+    return dbg.maybeSpace() << QString("CoverInfo(%1)")
+            .arg(coverInfoToString(info));
 }
 
 QDebug operator<<(QDebug dbg, const CoverArt& art) {
     return dbg.maybeSpace() << QString("CoverArt(%1,%2)")
-            .arg(toDebugString(art.image.size()),
-                 toDebugString(static_cast<CoverInfo>(art)));
+            .arg(coverInfoToString(art),
+                 toDebugString(art.image.size()));
 }
 
 const quint16 CoverInfoRelative::kNullImageHash = CoverArtUtils::calculateHash(QImage());

--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -55,9 +55,10 @@ QDebug operator<<(QDebug dbg, const CoverInfo& info) {
 }
 
 QDebug operator<<(QDebug dbg, const CoverArt& art) {
-    return dbg.maybeSpace() << QString("CoverArt(%1,%2)")
+    return dbg.maybeSpace() << QString("CoverArt(%1,%2,%3)")
             .arg(coverInfoToString(art),
-                 toDebugString(art.image.size()));
+                 toDebugString(art.image.size()),
+                 QString::number(art.resizedToWidth));
 }
 
 const quint16 CoverInfoRelative::kNullImageHash = CoverArtUtils::calculateHash(QImage());

--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -27,17 +27,22 @@ QString typeToString(CoverInfo::Type type) {
     return "INVALID TYPE VALUE";
 }
 
-QDebug operator<<(QDebug dbg, const CoverInfo& info) {
-    return dbg.maybeSpace() << QString("CoverInfo(%1,%2,%3,%4,%5)")
+QDebug operator<<(QDebug dbg, const CoverInfoRelative& info) {
+    return dbg.maybeSpace() << QString("CoverInfo(%1,%2,%3,%4)")
             .arg(typeToString(info.type),
                  sourceToString(info.source),
                  info.coverLocation,
-                 QString::number(info.hash), 
+                 QString::number(info.hash));
+}
+
+QDebug operator<<(QDebug dbg, const CoverInfo& info) {
+    return dbg.maybeSpace() << QString("CoverInfo(%1,%2)")
+            .arg(toDebugString(static_cast<CoverInfoRelative>(info)),
                  info.trackLocation);
 }
 
 QDebug operator<<(QDebug dbg, const CoverArt& art) {
     return dbg.maybeSpace() << QString("CoverArt(%1,%2)")
             .arg(toDebugString(art.image.size()),
-                 toDebugString(art.info));
+                 toDebugString(static_cast<CoverInfo>(art)));
 }

--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -44,6 +44,13 @@ QString coverInfoToString(const CoverInfo& info) {
 }
 } // anonymous namespace
 
+CoverInfoRelative::CoverInfoRelative()
+        : source(UNKNOWN),
+          type(NONE),
+          hash(0) {
+    // The default hash value should match the calculated hash for a null image
+    DEBUG_ASSERT(CoverArtUtils::calculateHash(QImage()) == hash);
+}
 
 bool operator==(const CoverInfoRelative& a, const CoverInfoRelative& b) {
     return a.source == b.source &&
@@ -82,6 +89,3 @@ QDebug operator<<(QDebug dbg, const CoverArt& art) {
                  toDebugString(art.image.size()),
                  QString::number(art.resizedToWidth));
 }
-
-const quint16 CoverInfoRelative::kNullImageHash = CoverArtUtils::calculateHash(QImage());
-

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -77,11 +77,14 @@ class CoverInfo : public CoverInfoRelative {
 
 class CoverArt : public CoverInfo {
   public:
-    CoverArt() {}
+    CoverArt()
+        : resizedToWidth(0) {
+    }
 
-    CoverArt(const CoverInfo& base, const QImage& img)
+    CoverArt(const CoverInfo& base, const QImage& img, int rtw)
         : CoverInfo(base),
-          image(img) {
+          image(img),
+          resizedToWidth(rtw) {
     }
 
     bool operator==(const CoverArt& other) const {
@@ -95,7 +98,10 @@ class CoverArt : public CoverInfo {
         return !(*this == other);
     }
 
-    QImage image;
+    // it is not a QPixmap, because it is not safe to use pixmaps 
+    // outside the GUI thread
+    QImage image; 
+    int resizedToWidth;
 };
 
 QDebug operator<<(QDebug dbg, const CoverInfoRelative& info);

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -7,7 +7,8 @@
 #include <QtDebug>
 #include <QtGlobal>
 
-struct CoverInfo {
+class CoverInfoRelative {
+  public:
     // DO NOT CHANGE THESE CONSTANT VALUES. THEY ARE STORED IN THE DATABASE.
     enum Source {
         // We don't know where we got this cover.
@@ -28,37 +29,63 @@ struct CoverInfo {
         FILE = 2
     };
 
-    CoverInfo() : source(UNKNOWN),
-                  type(NONE),
-                  coverLocation(QString()),
-                  trackLocation(QString()),
-                  // This default value is fine: qChecksum(NULL, 0) is 0.
-                  hash(0) {}
+    CoverInfoRelative()
+            : source(UNKNOWN),
+              type(NONE),
+              // This default value is fine: qChecksum(NULL, 0) is 0.
+              hash(0) {
+    }
 
-    bool operator==(const CoverInfo& other) const {
+    bool operator==(const CoverInfoRelative& other) const {
         return other.source == source &&
                 other.type == type &&
                 other.coverLocation == coverLocation &&
-                other.trackLocation == trackLocation &&
                 other.hash == hash;
     }
-    bool operator!=(const CoverInfo& other) const {
+    bool operator!=(const CoverInfoRelative& other) const {
         return !(*this == other);
     }
 
     Source source;
     Type type;
-    QString coverLocation; // Reative path, starting from trackLocation 
-    QString trackLocation;
+    QString coverLocation; // relative path, from track location
     quint16 hash;
 };
 
-struct CoverArt {
+class CoverInfo : public CoverInfoRelative {
+  public:
+    CoverInfo() {}
+
+    CoverInfo(const CoverInfoRelative& base, const QString& tl)
+        : CoverInfoRelative(base),
+          trackLocation(tl) {
+    }
+
+    bool operator==(const CoverInfo& other) const {
+        return static_cast<CoverInfoRelative>(other) == 
+                        static_cast<CoverInfoRelative>(*this) &&
+                other.trackLocation == trackLocation;
+    }
+    bool operator!=(const CoverInfo& other) const {
+        return !(*this == other);
+    }
+
+    QString trackLocation;
+};
+
+class CoverArt : public CoverInfo {
+  public:
     CoverArt() {}
+
+    CoverArt(const CoverInfo& base, const QImage& img)
+        : CoverInfo(base),
+          image(img) {
+    }
 
     bool operator==(const CoverArt& other) const {
         // Only count image in the equality if both are non-null.
-        return other.info == info &&
+        return static_cast<CoverInfo>(other) ==
+                        static_cast<CoverInfo>(*this) &&
                 (other.image.isNull() || image.isNull() ||
                  other.image == image);
     }
@@ -66,10 +93,10 @@ struct CoverArt {
         return !(*this == other);
     }
 
-    CoverInfo info;
     QImage image;
 };
 
+QDebug operator<<(QDebug dbg, const CoverInfoRelative& info);
 QDebug operator<<(QDebug dbg, const CoverInfo& info);
 QDebug operator<<(QDebug dbg, const CoverArt& art);
 

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -38,6 +38,8 @@ class CoverInfoRelative {
               hash(kNullImageHash) {
     }
 
+    virtual ~CoverInfoRelative() {};
+
     Source source;
     Type type;
     QString coverLocation; // relative path, from track location
@@ -57,6 +59,8 @@ class CoverInfo : public CoverInfoRelative {
           trackLocation(tl) {
     }
 
+    virtual ~CoverInfo() {};
+
     QString trackLocation;
 };
 
@@ -75,6 +79,8 @@ class CoverArt : public CoverInfo {
           image(img),
           resizedToWidth(rtw) {
     }
+
+    virtual ~CoverArt() {};
 
     // it is not a QPixmap, because it is not safe to use pixmaps 
     // outside the GUI thread

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -29,15 +29,7 @@ class CoverInfoRelative {
         FILE = 2
     };
 
-    static const quint16 kNullImageHash;
-
-    CoverInfoRelative()
-            : source(UNKNOWN),
-              type(NONE),
-              // This default value is fine: qChecksum(NULL, 0) is 0.
-              hash(kNullImageHash) {
-    }
-
+    CoverInfoRelative();
     virtual ~CoverInfoRelative() {};
 
     Source source;

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -88,8 +88,6 @@ class CoverArt : public CoverInfo {
     int resizedToWidth;
 };
 
-bool operator==(const CoverArt& a, const CoverArt& b);
-bool operator!=(const CoverArt& a, const CoverArt& b);
 QDebug operator<<(QDebug dbg, const CoverArt& art);
 
 #endif /* COVERART_H */

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -38,21 +38,15 @@ class CoverInfoRelative {
               hash(kNullImageHash) {
     }
 
-    bool operator==(const CoverInfoRelative& other) const {
-        return other.source == source &&
-                other.type == type &&
-                other.coverLocation == coverLocation &&
-                other.hash == hash;
-    }
-    bool operator!=(const CoverInfoRelative& other) const {
-        return !(*this == other);
-    }
-
     Source source;
     Type type;
     QString coverLocation; // relative path, from track location
     quint16 hash;
 };
+
+bool operator==(const CoverInfoRelative& a, const CoverInfoRelative& b);
+bool operator!=(const CoverInfoRelative& a, const CoverInfoRelative& b);
+QDebug operator<<(QDebug dbg, const CoverInfoRelative& info);
 
 class CoverInfo : public CoverInfoRelative {
   public:
@@ -63,17 +57,12 @@ class CoverInfo : public CoverInfoRelative {
           trackLocation(tl) {
     }
 
-    bool operator==(const CoverInfo& other) const {
-        return static_cast<CoverInfoRelative>(other) == 
-                        static_cast<CoverInfoRelative>(*this) &&
-                other.trackLocation == trackLocation;
-    }
-    bool operator!=(const CoverInfo& other) const {
-        return !(*this == other);
-    }
-
     QString trackLocation;
 };
+
+bool operator==(const CoverInfo& a, const CoverInfo& b);
+bool operator!=(const CoverInfo& a, const CoverInfo& b);
+QDebug operator<<(QDebug dbg, const CoverInfo& info);
 
 class CoverArt : public CoverInfo {
   public:
@@ -87,25 +76,14 @@ class CoverArt : public CoverInfo {
           resizedToWidth(rtw) {
     }
 
-    bool operator==(const CoverArt& other) const {
-        // Only count image in the equality if both are non-null.
-        return static_cast<CoverInfo>(other) ==
-                        static_cast<CoverInfo>(*this) &&
-                (other.image.isNull() || image.isNull() ||
-                 other.image == image);
-    }
-    bool operator!=(const CoverArt& other) const {
-        return !(*this == other);
-    }
-
     // it is not a QPixmap, because it is not safe to use pixmaps 
     // outside the GUI thread
     QImage image; 
     int resizedToWidth;
 };
 
-QDebug operator<<(QDebug dbg, const CoverInfoRelative& info);
-QDebug operator<<(QDebug dbg, const CoverInfo& info);
+bool operator==(const CoverArt& a, const CoverArt& b);
+bool operator!=(const CoverArt& a, const CoverArt& b);
 QDebug operator<<(QDebug dbg, const CoverArt& art);
 
 #endif /* COVERART_H */

--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -133,14 +133,15 @@ CoverArtCache::FutureResult CoverArtCache::loadCover(
                  << info << desiredWidth << signalWhenDone;
     }
 
+    QImage image = CoverArtUtils::loadCover(info);
+
     FutureResult res;
     res.pRequestor = pRequestor;
-    res.cover.info = info;
+    res.cover = CoverArt(info, image);
     res.desiredWidth = desiredWidth;
     res.signalWhenDone = signalWhenDone;
-    res.cover.image = CoverArtUtils::loadCover(res.cover.info);
 
-    if (res.cover.image.isNull()) {
+    if (image.isNull()) {
         return res;
     }
 
@@ -170,10 +171,10 @@ void CoverArtCache::coverLoaded() {
 
     QPixmap pixmap = cacheCover(res.cover, res.desiredWidth);
 
-    m_runningRequests.remove(qMakePair(res.pRequestor, res.cover.info.hash));
+    m_runningRequests.remove(qMakePair(res.pRequestor, res.cover.hash));
 
     if (res.signalWhenDone) {
-        emit(coverFound(res.pRequestor, res.cover.info, pixmap, false));
+        emit(coverFound(res.pRequestor, res.cover, pixmap, false));
     }
 }
 
@@ -188,7 +189,7 @@ void CoverArtCache::requestGuessCover(TrackPointer pTrack) {
 void CoverArtCache::guessCover(TrackPointer pTrack) {
     if (pTrack) {
         CoverArt cover = CoverArtUtils::guessCoverArt(pTrack);
-        pTrack->setCoverInfo(cover.info);
+        pTrack->setCoverInfo(cover);
     }
 }
 
@@ -203,7 +204,7 @@ void CoverArtCache::guessCovers(QList<TrackPointer> tracks) {
 QPixmap CoverArtCache::cacheCover(CoverArt cover, int width) {
     QPixmap pixmap;
     if (!cover.image.isNull()) {
-        QString cacheKey = pixmapCacheKey(cover.info.hash, width);
+        QString cacheKey = pixmapCacheKey(cover.hash, width);
         if (!QPixmapCache::find(cacheKey, &pixmap)) {
             pixmap.convertFromImage(cover.image);
             // Don't cache full size covers (Width = 0)

--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -133,16 +133,6 @@ CoverArtCache::FutureResult CoverArtCache::loadCover(
 
     QImage image = CoverArtUtils::loadCover(info);
 
-    FutureResult res;
-    res.pRequestor = pRequestor;
-    res.cover = CoverArt(info, image);
-    res.desiredWidth = desiredWidth;
-    res.signalWhenDone = signalWhenDone;
-
-    if (image.isNull()) {
-        return res;
-    }
-
     // TODO(XXX) Should we re-hash here? If the cover file (or track metadata)
     // has changed then info.hash may be incorrect. The fix
     // will also require noticing a hash mis-match at higher levels and
@@ -150,9 +140,14 @@ CoverArtCache::FutureResult CoverArtCache::loadCover(
 
     // Adjust the cover size according to the request or downsize the image for
     // efficiency.
-    if (res.desiredWidth > 0) {
-        res.cover.image = resizeImageWidth(res.cover.image, res.desiredWidth);
+    if (desiredWidth > 0 && !image.isNull()) {
+        image = resizeImageWidth(image, desiredWidth);
     }
+
+    FutureResult res;
+    res.pRequestor = pRequestor;
+    res.cover = CoverArt(info, image, desiredWidth);
+    res.signalWhenDone = signalWhenDone;
 
     return res;
 }
@@ -167,7 +162,23 @@ void CoverArtCache::coverLoaded() {
         qDebug() << "CoverArtCache::coverLoaded" << res.cover;
     }
 
-    QPixmap pixmap = cacheCover(res.cover, res.desiredWidth);
+    // Don't cache full size covers (resizedToWidth = 0)
+    // Large cover art wastes space in our cache and will likely
+    // uncache a lot of the small covers we need in the library
+    // table.
+    // Full size covers are used in the Skin Widgets, which are
+    // loaded with an artificial delay anyway and an additional
+    // re-load delay can be accepted.
+
+    // Create pixmap, GUI thread only 
+    QPixmap pixmap = QPixmap::fromImage(res.cover.image);
+    if (!pixmap.isNull() && res.cover.resizedToWidth != 0) {
+        // we have to be sure that res.cover.hash is unique
+        // because insert replaces the images with the same key
+        QString cacheKey = pixmapCacheKey(
+                res.cover.hash, res.cover.resizedToWidth);
+        QPixmapCache::insert(cacheKey, pixmap);
+    }
 
     m_runningRequests.remove(qMakePair(res.pRequestor, res.cover.hash));
 
@@ -199,23 +210,3 @@ void CoverArtCache::guessCovers(QList<TrackPointer> tracks) {
     }
 }
 
-QPixmap CoverArtCache::cacheCover(CoverArt cover, int width) {
-    QPixmap pixmap;
-    if (!cover.image.isNull()) {
-        QString cacheKey = pixmapCacheKey(cover.hash, width);
-        if (!QPixmapCache::find(cacheKey, &pixmap)) {
-            pixmap.convertFromImage(cover.image);
-            // Don't cache full size covers (Width = 0)
-            // Large cover art wastes space in our cache and will likely
-            // uncache a lot of the small covers we need in the library
-            // table.
-            // Full size covers are used in the Skin Widgets, which are
-            // loaded with an artificial delay anyway and an additional
-            // re-load delay can be accepted.
-            if (width > 0) {
-                QPixmapCache::insert(cacheKey, pixmap);
-            }
-        }
-    }
-    return pixmap;
-}

--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -140,7 +140,7 @@ CoverArtCache::FutureResult CoverArtCache::loadCover(
 
     // Adjust the cover size according to the request or downsize the image for
     // efficiency.
-    if (desiredWidth > 0 && !image.isNull()) {
+    if (!image.isNull() && desiredWidth > 0) {
         image = resizeImageWidth(image, desiredWidth);
     }
 

--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -197,7 +197,7 @@ void CoverArtCache::requestGuessCover(TrackPointer pTrack) {
 
 void CoverArtCache::guessCover(TrackPointer pTrack) {
     if (pTrack) {
-        CoverInfo cover = CoverArtUtils::guessCoverInfo(pTrack.data());
+        CoverInfo cover = CoverArtUtils::guessCoverInfo(*pTrack);
         pTrack->setCoverInfo(cover);
     }
 }

--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -118,8 +118,6 @@ void CoverArtCache::requestCover(const Track* pTrack,
     if (pCache == nullptr || pTrack == nullptr) return;
 
     CoverInfo info = pTrack->getCoverInfo();
-    // trackLocation is still empty here
-    info.trackLocation = pTrack->getLocation();
     pCache->requestCover(info, pRequestor, 0, false, true);
 }
 
@@ -188,7 +186,7 @@ void CoverArtCache::requestGuessCover(TrackPointer pTrack) {
 
 void CoverArtCache::guessCover(TrackPointer pTrack) {
     if (pTrack) {
-        CoverArt cover = CoverArtUtils::guessCoverArt(pTrack);
+        CoverInfo cover = CoverArtUtils::guessCoverInfo(pTrack.data());
         pTrack->setCoverInfo(cover);
     }
 }

--- a/src/library/coverartcache.h
+++ b/src/library/coverartcache.h
@@ -41,13 +41,11 @@ class CoverArtCache : public QObject, public Singleton<CoverArtCache> {
     struct FutureResult {
         FutureResult()
                 : pRequestor(NULL),
-                  desiredWidth(0),
                   signalWhenDone(false) {
         }
 
         CoverArt cover;
         const QObject* pRequestor;
-        int desiredWidth;
         bool signalWhenDone;
     };
 
@@ -74,7 +72,6 @@ class CoverArtCache : public QObject, public Singleton<CoverArtCache> {
     // Guesses the cover art for each track.
     void guessCovers(QList<TrackPointer> tracks);
     void guessCover(TrackPointer pTrack);
-    QPixmap cacheCover(CoverArt cover, int width);
 
   private:
     QSet<QPair<const QObject*, quint16> > m_runningRequests;

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -52,7 +52,7 @@ QImage CoverArtUtils::loadCover(const CoverInfo& info) {
             return QImage();
         }
         const QFileInfo fileInfo(info.trackLocation);
-        return CoverArtUtils::extractEmbeddedCover(fileInfo);
+        return extractEmbeddedCover(fileInfo);
     } else if (info.type == CoverInfo::FILE) {
         if (info.trackLocation.isEmpty()) {
             qDebug() << "CoverArtUtils::loadCover FILE cover with empty trackLocation."
@@ -215,7 +215,7 @@ CoverInfoRelative CoverArtUtils::selectCoverArtForTrack(
             coverInfoRelative.source = CoverInfo::GUESSED;
             coverInfoRelative.type = CoverInfo::FILE;
             // TODO() here we may introduce a duplicate hash code
-            coverInfoRelative.hash = CoverArtUtils::calculateHash(image);
+            coverInfoRelative.hash = calculateHash(image);
             coverInfoRelative.coverLocation = bestInfo->fileName();
             return coverInfoRelative;
         }

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -86,7 +86,7 @@ QImage CoverArtUtils::loadCover(const CoverInfo& info) {
 //static
 CoverArt CoverArtUtils::guessCoverArt(TrackPointer pTrack) {
     CoverArt art;
-    art.info.source = CoverInfo::GUESSED;
+    art.source = CoverInfo::GUESSED;
 
     if (pTrack.isNull()) {
         return art;
@@ -96,9 +96,9 @@ CoverArt CoverArtUtils::guessCoverArt(TrackPointer pTrack) {
     art.image = extractEmbeddedCover(fileInfo, pTrack->getSecurityToken());
     if (!art.image.isNull()) {
         // TODO() here we my introduce a duplicate hash code
-        art.info.hash = calculateHash(art.image);
-        art.info.coverLocation = QString();
-        art.info.type = CoverInfo::METADATA;
+        art.hash = calculateHash(art.image);
+        art.coverLocation = QString();
+        art.type = CoverInfo::METADATA;
         qDebug() << "CoverArtUtils::guessCoverArt found metadata art" << art;
         return art;
     }
@@ -106,7 +106,7 @@ CoverArt CoverArtUtils::guessCoverArt(TrackPointer pTrack) {
     QLinkedList<QFileInfo> possibleCovers = findPossibleCoversInFolder(
             fileInfo.absolutePath());
     art = selectCoverArtForTrack(pTrack.data(), possibleCovers);
-    if (art.info.type == CoverInfo::FILE) {
+    if (art.type == CoverInfo::FILE) {
         qDebug() << "CoverArtUtils::guessCoverArt found file art" << art;
     } else {
         qDebug() << "CoverArtUtils::guessCoverArt didn't find art" << art;
@@ -141,7 +141,7 @@ CoverArt CoverArtUtils::selectCoverArtForTrack(
         const QLinkedList<QFileInfo>& covers) {
     if (pTrack == NULL || covers.isEmpty()) {
         CoverArt art;
-        art.info.source = CoverInfo::GUESSED;
+        art.source = CoverInfo::GUESSED;
         return art;
     }
 
@@ -156,7 +156,7 @@ CoverArt CoverArtUtils::selectCoverArtForTrack(
         const QString& albumName,
         const QLinkedList<QFileInfo>& covers) {
     CoverArt art;
-    art.info.source = CoverInfo::GUESSED;
+    art.source = CoverInfo::GUESSED;
     if (covers.isEmpty()) {
         return art;
     }
@@ -216,11 +216,11 @@ CoverArt CoverArtUtils::selectCoverArtForTrack(
     if (bestInfo != NULL) {
         art.image = QImage(bestInfo->filePath());
         if (!art.image.isNull()) {
-            art.info.source = CoverInfo::GUESSED;
-            art.info.type = CoverInfo::FILE;
+            art.source = CoverInfo::GUESSED;
+            art.type = CoverInfo::FILE;
             // TODO() here we may introduce a duplicate hash code
-            art.info.hash = CoverArtUtils::calculateHash(art.image);
-            art.info.coverLocation = bestInfo->fileName();
+            art.hash = CoverArtUtils::calculateHash(art.image);
+            art.coverLocation = bestInfo->fileName();
             return art;
         }
     }

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -84,17 +84,14 @@ QImage CoverArtUtils::loadCover(const CoverInfo& info) {
 }
 
 //static
-CoverInfo CoverArtUtils::guessCoverInfo(const Track* pTrack) {
+CoverInfo CoverArtUtils::guessCoverInfo(const Track& track) {
     CoverInfo coverInfo;
-    DEBUG_ASSERT_AND_HANDLE(pTrack != nullptr){
-        return coverInfo;
-    }
 
-    coverInfo.trackLocation = pTrack->getLocation();
+    coverInfo.trackLocation = track.getLocation();
     coverInfo.source = CoverInfo::GUESSED;
 
-    const QFileInfo fileInfo(pTrack->getFileInfo());
-    QImage image = extractEmbeddedCover(fileInfo, pTrack->getSecurityToken());
+    const QFileInfo fileInfo(track.getFileInfo());
+    QImage image = extractEmbeddedCover(fileInfo, track.getSecurityToken());
     if (!image.isNull()) {
         // TODO() here we my introduce a duplicate hash code
         coverInfo.hash = calculateHash(image);
@@ -106,7 +103,7 @@ CoverInfo CoverArtUtils::guessCoverInfo(const Track* pTrack) {
 
     QLinkedList<QFileInfo> possibleCovers = findPossibleCoversInFolder(
             fileInfo.absolutePath());
-    coverInfo = selectCoverArtForTrack(pTrack, possibleCovers);
+    coverInfo = selectCoverArtForTrack(track, possibleCovers);
     if (coverInfo.type == CoverInfo::FILE) {
         qDebug() << "CoverArtUtils::guessCover found file art" << coverInfo;
     } else {
@@ -138,15 +135,12 @@ QLinkedList<QFileInfo> CoverArtUtils::findPossibleCoversInFolder(const QString& 
 
 //static
 CoverInfo CoverArtUtils::selectCoverArtForTrack(
-        const Track* pTrack,
+        const Track& track,
         const QLinkedList<QFileInfo>& covers) {
-    if (pTrack == NULL) {
-        return CoverInfo();
-    }
 
-    const QString trackBaseName = pTrack->getFileInfo().baseName();
-    const QString albumName = pTrack->getAlbum();
-    const QString trackLocation = pTrack->getLocation();
+    const QString trackBaseName = track.getFileInfo().baseName();
+    const QString albumName = track.getAlbum();
+    const QString trackLocation = track.getLocation();
     CoverInfoRelative coverInfoRelative =
             selectCoverArtForTrack(trackBaseName, albumName, covers);
     return CoverInfo(coverInfoRelative, trackLocation);

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -42,23 +42,21 @@ class CoverArtUtils {
         NONE
     };
 
-    // Guesses the cover art for the provided track. Does not modify the
-    // provided track.
-    static CoverArt guessCoverArt(
-            TrackPointer pTrack);
+    // Guesses the cover art for the provided track.
+    static CoverInfo guessCoverInfo(const Track* pTrack);
 
     static QLinkedList<QFileInfo> findPossibleCoversInFolder(
             const QString& folder);
 
     // Selects an appropriate cover file from provided list of image files.
-    static CoverArt selectCoverArtForTrack(
-            Track* pTrack,
+    static CoverInfo selectCoverArtForTrack(
+            const Track* pTrack,
             const QLinkedList<QFileInfo>& covers);
 
     // Selects an appropriate cover file from provided list of image
     // files. Assumes a SecurityTokenPointer is held by the caller for all files
     // in 'covers'.
-    static CoverArt selectCoverArtForTrack(
+    static CoverInfoRelative selectCoverArtForTrack(
             const QString& trackBaseName,
             const QString& albumName,
             const QLinkedList<QFileInfo>& covers);

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -43,14 +43,14 @@ class CoverArtUtils {
     };
 
     // Guesses the cover art for the provided track.
-    static CoverInfo guessCoverInfo(const Track* pTrack);
+    static CoverInfo guessCoverInfo(const Track& track);
 
     static QLinkedList<QFileInfo> findPossibleCoversInFolder(
             const QString& folder);
 
     // Selects an appropriate cover file from provided list of image files.
     static CoverInfo selectCoverArtForTrack(
-            const Track* pTrack,
+            const Track& track,
             const QLinkedList<QFileInfo>& covers);
 
     // Selects an appropriate cover file from provided list of image

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -11,6 +11,9 @@
 #include "track/track.h"
 #include "util/sandbox.h"
 
+class CoverInfo;
+class CoverInfoRelative;
+
 class CoverArtUtils {
   public:
     static QString defaultCoverLocation();

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -2054,11 +2054,11 @@ void TrackDAO::detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
             trackInfo.baseName(), track.trackAlbum, possibleCovers);
 
         updateQuery.bindValue(":coverart_type",
-                              static_cast<int>(art.info.type));
+                              static_cast<int>(art.type));
         updateQuery.bindValue(":coverart_source",
-                              static_cast<int>(art.info.source));
-        updateQuery.bindValue(":coverart_hash", art.info.hash);
-        updateQuery.bindValue(":coverart_location", art.info.coverLocation);
+                              static_cast<int>(art.source));
+        updateQuery.bindValue(":coverart_hash", art.hash);
+        updateQuery.bindValue(":coverart_location", art.coverLocation);
         updateQuery.bindValue(":track_id", track.trackId.toVariant());
         if (!updateQuery.exec()) {
             LOG_FAILED_QUERY(updateQuery) << "failed to write file or none cover";

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1215,7 +1215,7 @@ bool setTrackKey(const QSqlRecord& record, const int column,
 
 bool setTrackCoverInfo(const QSqlRecord& record, const int column,
                        TrackPointer pTrack) {
-    CoverInfo coverInfo;
+    CoverInfoRelative coverInfo;
     bool ok = false;
     coverInfo.source = static_cast<CoverInfo::Source>(
             record.value(column).toInt(&ok));
@@ -2050,15 +2050,15 @@ void TrackDAO::detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
                 currentDirectoryPath);
         }
 
-        CoverArt art = CoverArtUtils::selectCoverArtForTrack(
+        CoverInfoRelative coverInfo = CoverArtUtils::selectCoverArtForTrack(
             trackInfo.baseName(), track.trackAlbum, possibleCovers);
 
         updateQuery.bindValue(":coverart_type",
-                              static_cast<int>(art.type));
+                              static_cast<int>(coverInfo.type));
         updateQuery.bindValue(":coverart_source",
-                              static_cast<int>(art.source));
-        updateQuery.bindValue(":coverart_hash", art.hash);
-        updateQuery.bindValue(":coverart_location", art.coverLocation);
+                              static_cast<int>(coverInfo.source));
+        updateQuery.bindValue(":coverart_hash", coverInfo.hash);
+        updateQuery.bindValue(":coverart_location", coverInfo.coverLocation);
         updateQuery.bindValue(":track_id", track.trackId.toVariant());
         if (!updateQuery.exec()) {
             LOG_FAILED_QUERY(updateQuery) << "failed to write file or none cover";

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -251,7 +251,7 @@ void DlgTrackInfo::slotReloadCoverArt() {
 
 void DlgTrackInfo::slotCoverArtSelected(const CoverArt& art) {
     qDebug() << "DlgTrackInfo::slotCoverArtSelected" << art;
-    m_loadedCoverInfo = art.info;
+    m_loadedCoverInfo = art;
     if (m_pLoadedTrack) {
         m_loadedCoverInfo.trackLocation = m_pLoadedTrack->getLocation();
     }

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -240,7 +240,7 @@ void DlgTrackInfo::slotCoverFound(const QObject* pRequestor,
 void DlgTrackInfo::slotReloadCoverArt() {
     if (m_pLoadedTrack) {
         CoverInfo coverInfo =
-                CoverArtUtils::guessCoverInfo(m_pLoadedTrack.data());
+                CoverArtUtils::guessCoverInfo(*m_pLoadedTrack);
         slotCoverInfoSelected(coverInfo);
     }
 }

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -93,8 +93,8 @@ void DlgTrackInfo::init() {
         connect(pCache, SIGNAL(coverFound(const QObject*, const CoverInfo&, QPixmap, bool)),
                 this, SLOT(slotCoverFound(const QObject*, const CoverInfo&, QPixmap, bool)));
     }
-    connect(m_pWCoverArtLabel, SIGNAL(coverArtSelected(const CoverArt&)),
-            this, SLOT(slotCoverArtSelected(const CoverArt&)));
+    connect(m_pWCoverArtLabel, SIGNAL(coverInfoSelected(const CoverInfo&)),
+            this, SLOT(slotCoverInfoSelected(const CoverInfo&)));
     connect(m_pWCoverArtLabel, SIGNAL(reloadCoverArt()),
             this, SLOT(slotReloadCoverArt()));
 }
@@ -178,8 +178,7 @@ void DlgTrackInfo::populateFields(const Track& track) {
     reloadTrackBeats(track);
 
     m_loadedCoverInfo = track.getCoverInfo();
-    m_loadedCoverInfo.trackLocation = track.getLocation();
-    m_pWCoverArtLabel->setCoverArt(m_loadedCoverInfo.trackLocation, m_loadedCoverInfo, QPixmap());
+    m_pWCoverArtLabel->setCoverArt(m_loadedCoverInfo, QPixmap());
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache != NULL) {
         pCache->requestCover(m_loadedCoverInfo, this, 0, false, true);
@@ -234,27 +233,21 @@ void DlgTrackInfo::slotCoverFound(const QObject* pRequestor,
             m_loadedCoverInfo.hash == info.hash) {
         qDebug() << "DlgTrackInfo::slotPixmapFound" << pRequestor << info
                  << pixmap.size();
-        m_pWCoverArtLabel->setCoverArt(m_pLoadedTrack->getLocation(), m_loadedCoverInfo, pixmap);
+        m_pWCoverArtLabel->setCoverArt(m_loadedCoverInfo, pixmap);
     }
 }
 
 void DlgTrackInfo::slotReloadCoverArt() {
     if (m_pLoadedTrack) {
-        // TODO(rryan) move this out of the main thread. The issue is that
-        // CoverArtCache::requestGuessCover mutates the provided track whereas
-        // in DlgTrackInfo we delay changing the track until the user hits apply
-        // (or cancels the edit).
-        CoverArt art = CoverArtUtils::guessCoverArt(m_pLoadedTrack);
-        slotCoverArtSelected(art);
+        CoverInfo coverInfo =
+                CoverArtUtils::guessCoverInfo(m_pLoadedTrack.data());
+        slotCoverInfoSelected(coverInfo);
     }
 }
 
-void DlgTrackInfo::slotCoverArtSelected(const CoverArt& art) {
-    qDebug() << "DlgTrackInfo::slotCoverArtSelected" << art;
-    m_loadedCoverInfo = art;
-    if (m_pLoadedTrack) {
-        m_loadedCoverInfo.trackLocation = m_pLoadedTrack->getLocation();
-    }
+void DlgTrackInfo::slotCoverInfoSelected(const CoverInfo& coverInfo) {
+    qDebug() << "DlgTrackInfo::slotCoverInfoSelected" << coverInfo;
+    m_loadedCoverInfo = coverInfo;
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache != NULL) {
         pCache->requestCover(m_loadedCoverInfo, this, 0, false, true);
@@ -479,7 +472,7 @@ void DlgTrackInfo::clear() {
     cueTable->setRowCount(0);
 
     m_loadedCoverInfo = CoverInfo();
-    m_pWCoverArtLabel->setCoverArt(QString(), m_loadedCoverInfo, QPixmap());
+    m_pWCoverArtLabel->setCoverArt(m_loadedCoverInfo, QPixmap());
 }
 
 void DlgTrackInfo::slotBpmDouble() {

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -60,7 +60,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
 
     void slotCoverFound(const QObject* pRequestor,
                         const CoverInfo& info, QPixmap pixmap, bool fromCache);
-    void slotCoverArtSelected(const CoverArt& art);
+    void slotCoverInfoSelected(const CoverInfo& coverInfo);
     void slotReloadCoverArt();
 
   private:

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -466,10 +466,10 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
             // Cover image has been parsed from the file
             coverArt.image = coverImg;
             // TODO() here we may introduce a duplicate hash code
-            coverArt.info.hash = CoverArtUtils::calculateHash(coverArt.image);
-            coverArt.info.coverLocation = QString();
-            coverArt.info.type = CoverInfo::METADATA;
-            coverArt.info.source = CoverInfo::GUESSED;
+            coverArt.hash = CoverArtUtils::calculateHash(coverArt.image);
+            coverArt.coverLocation = QString();
+            coverArt.type = CoverInfo::METADATA;
+            coverArt.source = CoverInfo::GUESSED;
             parsedCoverArt = true;
         }
     } else {
@@ -492,7 +492,7 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
     // Dump the trackMetadata extracted from the file back into the track.
     m_pTrack->setTrackMetadata(trackMetadata, parsedFromFile);
     if (parsedCoverArt) {
-        m_pTrack->setCoverInfo(coverArt.info);
+        m_pTrack->setCoverInfo(coverArt);
     }
 }
 

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -452,7 +452,7 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
     // If parsing of the cover art image should be omitted the
     // 2nd output parameter must be set to nullptr. Cover art
     // is not reloaded from file once the metadata has been parsed!
-    CoverArt coverArt;
+    CoverInfoRelative coverInfoRelative;
     QImage coverImg;
     DEBUG_ASSERT(coverImg.isNull());
     QImage* pCoverImg = (withCoverArt && !parsedFromFile) ? &coverImg : nullptr;
@@ -464,12 +464,11 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
         parsedFromFile = true;
         if (!coverImg.isNull()) {
             // Cover image has been parsed from the file
-            coverArt.image = coverImg;
             // TODO() here we may introduce a duplicate hash code
-            coverArt.hash = CoverArtUtils::calculateHash(coverArt.image);
-            coverArt.coverLocation = QString();
-            coverArt.type = CoverInfo::METADATA;
-            coverArt.source = CoverInfo::GUESSED;
+            coverInfoRelative.hash = CoverArtUtils::calculateHash(coverImg);
+            coverInfoRelative.coverLocation = QString();
+            coverInfoRelative.type = CoverInfo::METADATA;
+            coverInfoRelative.source = CoverInfo::GUESSED;
             parsedCoverArt = true;
         }
     } else {
@@ -492,7 +491,7 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
     // Dump the trackMetadata extracted from the file back into the track.
     m_pTrack->setTrackMetadata(trackMetadata, parsedFromFile);
     if (parsedCoverArt) {
-        m_pTrack->setCoverInfo(coverArt);
+        m_pTrack->setCoverInfo(coverInfoRelative);
     }
 }
 

--- a/src/test/coverartcache_test.cpp
+++ b/src/test/coverartcache_test.cpp
@@ -27,8 +27,8 @@ class CoverArtCacheTest : public MixxxTest, public CoverArtCache {
 
         CoverArtCache::FutureResult res;
         res = CoverArtCache::loadCover(info, NULL, 0, false);
-        EXPECT_QSTRING_EQ(QString(), res.cover.info.coverLocation);
-        EXPECT_EQ(info.hash, res.cover.info.hash);
+        EXPECT_QSTRING_EQ(QString(), res.cover.coverLocation);
+        EXPECT_EQ(info.hash, res.cover.hash);
 
         SecurityTokenPointer securityToken = Sandbox::openSecurityToken(
             QDir(trackLocation), true);
@@ -51,8 +51,8 @@ class CoverArtCacheTest : public MixxxTest, public CoverArtCache {
 
         CoverArtCache::FutureResult res;
         res = CoverArtCache::loadCover(info, NULL, 0, false);
-        EXPECT_QSTRING_EQ(info.coverLocation, res.cover.info.coverLocation);
-        EXPECT_EQ(info.hash, res.cover.info.hash);
+        EXPECT_QSTRING_EQ(info.coverLocation, res.cover.coverLocation);
+        EXPECT_EQ(info.hash, res.cover.hash);
         EXPECT_FALSE(img.isNull());
         EXPECT_EQ(img, res.cover.image);
     }

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -136,7 +136,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
     EXPECT_EQ(result.type, CoverInfo::METADATA);
     EXPECT_EQ(result.source, CoverInfo::GUESSED);
     EXPECT_EQ(result.coverLocation, QString());
-    EXPECT_NE(result.hash, CoverInfoRelative::kNullImageHash);
+    EXPECT_NE(result.hash, CoverInfoRelative().hash);
 
     const char* format("jpg");
     const QString qFormat(format);
@@ -164,7 +164,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
 
     // All the following expect the same image/hash to be selected.
     CoverInfoRelative expected2;
-    expected2.hash = CoverInfoRelative::kNullImageHash;
+    expected2.hash = CoverInfoRelative().hash;
 
     // All the following expect FILE and GUESSED.
     expected2.type = CoverInfo::FILE;
@@ -244,7 +244,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
         if (cover.baseName() == "other1") {
             expected2.type = CoverInfo::NONE;
             expected2.coverLocation = QString();
-            expected2.hash = CoverInfoRelative::kNullImageHash;
+            expected2.hash = CoverInfoRelative().hash;
         } else {
             expected2.type = CoverInfo::FILE;
             expected2.coverLocation = cover.fileName();

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -126,7 +126,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
     res = CoverArtUtils::selectCoverArtForTrack(pTrack.data(), covers);
     CoverInfo expected1;
     expected1.source = CoverInfo::GUESSED;
-    EXPECT_EQ(expected1, res.info);
+    EXPECT_EQ(expected1, res);
 
     // Looking for a track with embedded cover.
     pTrack = TrackPointer(Track::newTemporary(kTrackLocationTest));
@@ -164,11 +164,11 @@ TEST_F(CoverArtUtilTest, searchImage) {
     // All the following expect the same image/hash to be selected.
     CoverArt expected2;
     expected2.image = img;
-    expected2.info.hash = CoverArtUtils::calculateHash(expected2.image);
+    expected2.hash = CoverArtUtils::calculateHash(expected2.image);
 
     // All the following expect FILE and GUESSED.
-    expected2.info.type = CoverInfo::FILE;
-    expected2.info.source = CoverInfo::GUESSED;
+    expected2.type = CoverInfo::FILE;
+    expected2.source = CoverInfo::GUESSED;
 
     // 0. saving just one cover in our temp track dir
     QString cLoc_foo = QString(trackdir % "/" % "foo." % qFormat);
@@ -176,8 +176,8 @@ TEST_F(CoverArtUtilTest, searchImage) {
 
     // looking for cover in an directory with one image will select that one.
     expected2.image = QImage(cLoc_foo);
-    expected2.info.coverLocation = "foo.jpg";
-    expected2.info.hash = CoverArtUtils::calculateHash(expected2.image);
+    expected2.coverLocation = "foo.jpg";
+    expected2.hash = CoverArtUtils::calculateHash(expected2.image);
     covers << QFileInfo(cLoc_foo);
     res = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
                                                 covers);
@@ -244,19 +244,19 @@ TEST_F(CoverArtUtilTest, searchImage) {
         // selected once we get to it since it is the only cover available.
         if (cover.baseName() == "other1") {
             expected2.image = QImage();
-            expected2.info.type = CoverInfo::NONE;
-            expected2.info.coverLocation = QString();
-            expected2.info.hash = 0;
+            expected2.type = CoverInfo::NONE;
+            expected2.coverLocation = QString();
+            expected2.hash = 0;
         } else {
             expected2.image = QImage(cover.filePath());
-            expected2.info.type = CoverInfo::FILE;
-            expected2.info.coverLocation = cover.fileName();
-            expected2.info.hash = CoverArtUtils::calculateHash(expected2.image);
+            expected2.type = CoverInfo::FILE;
+            expected2.coverLocation = cover.fileName();
+            expected2.hash = CoverArtUtils::calculateHash(expected2.image);
         }
         res = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
                                                     prefCovers);
-        EXPECT_QSTRING_EQ(expected2.info.coverLocation, res.info.coverLocation);
-        EXPECT_EQ(expected2.info.hash, res.info.hash);
+        EXPECT_QSTRING_EQ(expected2.coverLocation, res.coverLocation);
+        EXPECT_EQ(expected2.hash, res.hash);
         EXPECT_EQ(expected2, res);
 
         QFile::remove(cover.filePath());
@@ -280,8 +280,8 @@ TEST_F(CoverArtUtilTest, searchImage) {
     res = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
                                                 prefCovers);
     expected2.image = QImage(cLoc_coverJPG);
-    expected2.info.hash = CoverArtUtils::calculateHash(expected2.image);
-    expected2.info.coverLocation = "cover.JPG";
+    expected2.hash = CoverArtUtils::calculateHash(expected2.image);
+    expected2.coverLocation = "cover.JPG";
     EXPECT_EQ(expected2, res);
 
     // As we are looking for %album%.jpg and %base_track.jpg%,
@@ -298,8 +298,8 @@ TEST_F(CoverArtUtilTest, searchImage) {
     res = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
                                                 prefCovers);
     expected2.image = QImage(cLoc_albumName);
-    expected2.info.hash = CoverArtUtils::calculateHash(expected2.image);
-    expected2.info.coverLocation = trackAlbum % ".jpg";
+    expected2.hash = CoverArtUtils::calculateHash(expected2.image);
+    expected2.coverLocation = trackAlbum % ".jpg";
     EXPECT_EQ(expected2, res);
 
     // 1. track_filename.jpg
@@ -309,8 +309,8 @@ TEST_F(CoverArtUtilTest, searchImage) {
     res = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
                                                 prefCovers);
     expected2.image = QImage(cLoc_filename);
-    expected2.info.hash = CoverArtUtils::calculateHash(expected2.image);
-    expected2.info.coverLocation = trackBaseName % ".jpg";
+    expected2.hash = CoverArtUtils::calculateHash(expected2.image);
+    expected2.coverLocation = trackBaseName % ".jpg";
     EXPECT_EQ(expected2, res);
 
     QFile::remove(cLoc_filename);

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -121,11 +121,12 @@ TEST_F(CoverArtUtilTest, searchImage) {
     TrackPointer pTrack(Track::newTemporary(kTrackLocationTest));
     SoundSourceProxy(pTrack).loadTrackMetadata();
     QLinkedList<QFileInfo> covers;
-    CoverArt res;
+    CoverInfo res;
     // looking for cover in an empty directory
     res = CoverArtUtils::selectCoverArtForTrack(pTrack.data(), covers);
     CoverInfo expected1;
     expected1.source = CoverInfo::GUESSED;
+    expected1.trackLocation = pTrack->getLocation();
     EXPECT_EQ(expected1, res);
 
     // Looking for a track with embedded cover.
@@ -162,9 +163,8 @@ TEST_F(CoverArtUtilTest, searchImage) {
     // 7. if just one file exists take that otherwise none.
 
     // All the following expect the same image/hash to be selected.
-    CoverArt expected2;
-    expected2.image = img;
-    expected2.hash = CoverArtUtils::calculateHash(expected2.image);
+    CoverInfoRelative expected2;
+    expected2.hash = 0;
 
     // All the following expect FILE and GUESSED.
     expected2.type = CoverInfo::FILE;
@@ -175,13 +175,12 @@ TEST_F(CoverArtUtilTest, searchImage) {
     EXPECT_TRUE(img.save(cLoc_foo, format));
 
     // looking for cover in an directory with one image will select that one.
-    expected2.image = QImage(cLoc_foo);
     expected2.coverLocation = "foo.jpg";
-    expected2.hash = CoverArtUtils::calculateHash(expected2.image);
+    expected2.hash = CoverArtUtils::calculateHash(QImage(cLoc_foo));
     covers << QFileInfo(cLoc_foo);
-    res = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
-                                                covers);
-    EXPECT_EQ(expected2, res);
+    CoverInfoRelative res2 = CoverArtUtils::selectCoverArtForTrack(
+            trackBaseName, trackAlbum, covers);
+    EXPECT_EQ(expected2, res2);
     QFile::remove(cLoc_foo);
 
     QStringList extraCovers;
@@ -243,21 +242,19 @@ TEST_F(CoverArtUtilTest, searchImage) {
         // neither of which match our preferred cover names. other2 will be
         // selected once we get to it since it is the only cover available.
         if (cover.baseName() == "other1") {
-            expected2.image = QImage();
             expected2.type = CoverInfo::NONE;
             expected2.coverLocation = QString();
             expected2.hash = 0;
         } else {
-            expected2.image = QImage(cover.filePath());
             expected2.type = CoverInfo::FILE;
             expected2.coverLocation = cover.fileName();
-            expected2.hash = CoverArtUtils::calculateHash(expected2.image);
+            expected2.hash = CoverArtUtils::calculateHash(QImage(cover.filePath()));
         }
-        res = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
+        res2 = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
                                                     prefCovers);
-        EXPECT_QSTRING_EQ(expected2.coverLocation, res.coverLocation);
-        EXPECT_EQ(expected2.hash, res.hash);
-        EXPECT_EQ(expected2, res);
+        EXPECT_QSTRING_EQ(expected2.coverLocation, res2.coverLocation);
+        EXPECT_EQ(expected2.hash, res2.hash);
+        EXPECT_EQ(expected2, res2);
 
         QFile::remove(cover.filePath());
         prefCovers.pop_front();
@@ -277,12 +274,11 @@ TEST_F(CoverArtUtilTest, searchImage) {
     prefCovers.append(QFileInfo(cLoc_coverjpg));
     extraCovers << cLoc_coverJPG << cLoc_coverjpg;
 
-    res = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
+    res2 = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
                                                 prefCovers);
-    expected2.image = QImage(cLoc_coverJPG);
-    expected2.hash = CoverArtUtils::calculateHash(expected2.image);
+    expected2.hash = CoverArtUtils::calculateHash(QImage(cLoc_coverJPG));
     expected2.coverLocation = "cover.JPG";
-    EXPECT_EQ(expected2, res);
+    EXPECT_EQ(expected2, res2);
 
     // As we are looking for %album%.jpg and %base_track.jpg%,
     // we need to check if everything works with UTF8 chars.
@@ -295,23 +291,22 @@ TEST_F(CoverArtUtilTest, searchImage) {
     cLoc_albumName = QString(trackdir % "/" % trackAlbum % "." % qFormat);
     EXPECT_TRUE(img.save(cLoc_albumName, format));
     prefCovers.append(QFileInfo(cLoc_albumName));
-    res = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
+    res2 = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
                                                 prefCovers);
-    expected2.image = QImage(cLoc_albumName);
-    expected2.hash = CoverArtUtils::calculateHash(expected2.image);
+    expected2.hash = CoverArtUtils::calculateHash(QImage(cLoc_albumName));
     expected2.coverLocation = trackAlbum % ".jpg";
-    EXPECT_EQ(expected2, res);
+    EXPECT_EQ(expected2, res2);
 
     // 1. track_filename.jpg
     cLoc_filename = QString(trackdir % "/" % trackBaseName % "." % qFormat);
     EXPECT_TRUE(img.save(cLoc_filename, format));
     prefCovers.append(QFileInfo(cLoc_filename));
-    res = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
+    res2 = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
                                                 prefCovers);
-    expected2.image = QImage(cLoc_filename);
-    expected2.hash = CoverArtUtils::calculateHash(expected2.image);
+
+    expected2.hash = CoverArtUtils::calculateHash(QImage(cLoc_filename));
     expected2.coverLocation = trackBaseName % ".jpg";
-    EXPECT_EQ(expected2, res);
+    EXPECT_EQ(expected2, res2);
 
     QFile::remove(cLoc_filename);
     QFile::remove(cLoc_albumName);

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -123,7 +123,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
     QLinkedList<QFileInfo> covers;
     CoverInfo res;
     // looking for cover in an empty directory
-    res = CoverArtUtils::selectCoverArtForTrack(pTrack.data(), covers);
+    res = CoverArtUtils::selectCoverArtForTrack(*pTrack, covers);
     CoverInfo expected1;
     expected1.source = CoverInfo::GUESSED;
     expected1.trackLocation = pTrack->getLocation();

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -879,16 +879,37 @@ bool Track::isBpmLocked() const {
     return m_bBpmLocked;
 }
 
-void Track::setCoverInfo(const CoverInfo& info) {
+void Track::setCoverInfo(const CoverInfoRelative& coverInfoRelative) {
     QMutexLocker lock(&m_qMutex);
-    if (info != m_coverInfo) {
-        m_coverInfo = info;
+    if (coverInfoRelative != m_coverInfoRelative) {
+        m_coverInfoRelative = coverInfoRelative;
         markDirtyAndUnlock(&lock);
         emit(coverArtUpdated());
     }
 }
 
+void Track::setCoverInfo(const CoverInfo& coverInfo) {
+    QMutexLocker lock(&m_qMutex);
+    DEBUG_ASSERT(coverInfo.trackLocation == m_fileInfo.absoluteFilePath());
+    CoverInfoRelative coverInfoRelative =
+            static_cast<CoverInfoRelative>(coverInfo);
+    if (coverInfoRelative != m_coverInfoRelative) {
+        m_coverInfoRelative = coverInfoRelative;
+        markDirtyAndUnlock(&lock);
+        emit(coverArtUpdated());
+    }
+}
+
+void Track::setCoverInfo(const CoverArt& coverArt) {
+    setCoverInfo(static_cast<CoverInfo>(coverArt));
+}
+
 CoverInfo Track::getCoverInfo() const {
     QMutexLocker lock(&m_qMutex);
-    return m_coverInfo;
+    return CoverInfo(m_coverInfoRelative, m_fileInfo.absoluteFilePath());
+}
+
+quint16 Track::getCoverHash() const {
+    QMutexLocker lock(&m_qMutex);
+    return m_coverInfoRelative.hash;
 }

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -274,8 +274,13 @@ class Track : public QObject {
     mixxx::track::io::key::ChromaticKey getKey() const;
     QString getKeyText() const;
 
-    void setCoverInfo(const CoverInfo& cover);
+    void setCoverInfo(const CoverInfoRelative& coverInfoRelative);
+    void setCoverInfo(const CoverInfo& coverInfo);
+    void setCoverInfo(const CoverArt& coverArt);
+
     CoverInfo getCoverInfo() const;
+
+    quint16 getCoverHash() const;
 
     // Set/get track metadata and cover art (optional) all at once.
     void setTrackMetadata(
@@ -404,7 +409,7 @@ class Track : public QObject {
 
     QAtomicInt m_analyzerProgress; // in 0.1%
 
-    CoverInfo m_coverInfo;
+    CoverInfoRelative m_coverInfoRelative;
 
     friend class TrackDAO;
 };

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -96,7 +96,7 @@ void WCoverArt::slotReloadCoverArt() {
 void WCoverArt::slotCoverArtSelected(const CoverArt& art) {
     if (m_loadedTrack) {
         // Will trigger slotTrackCoverArtUpdated().
-        m_loadedTrack->setCoverInfo(art.info);
+        m_loadedTrack->setCoverInfo(art);
     }
 }
 

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -35,8 +35,8 @@ WCoverArt::WCoverArt(QWidget* parent,
                 this, SLOT(slotCoverFound(const QObject*,
                                           const CoverInfo&, QPixmap, bool)));
     }
-    connect(m_pMenu, SIGNAL(coverArtSelected(const CoverArt&)),
-            this, SLOT(slotCoverArtSelected(const CoverArt&)));
+    connect(m_pMenu, SIGNAL(coverInfoSelected(const CoverInfo&)),
+            this, SLOT(slotCoverInfoSelected(const CoverInfo&)));
     connect(m_pMenu, SIGNAL(reloadCoverArt()),
             this, SLOT(slotReloadCoverArt()));
 }
@@ -93,10 +93,10 @@ void WCoverArt::slotReloadCoverArt() {
     }
 }
 
-void WCoverArt::slotCoverArtSelected(const CoverArt& art) {
+void WCoverArt::slotCoverInfoSelected(const CoverInfo& coverInfo) {
     if (m_loadedTrack) {
         // Will trigger slotTrackCoverArtUpdated().
-        m_loadedTrack->setCoverInfo(art);
+        m_loadedTrack->setCoverInfo(coverInfo);
     }
 }
 
@@ -142,7 +142,7 @@ void WCoverArt::slotCoverFound(const QObject* pRequestor,
     }
 
     if (pRequestor == this && m_loadedTrack &&
-            m_loadedTrack->getCoverInfo().hash == info.hash) {
+            m_loadedTrack->getCoverHash() == info.hash) {
         qDebug() << "WCoverArt::slotCoverFound" << pRequestor << info
                  << pixmap.size();
         m_loadedCover = pixmap;
@@ -215,7 +215,7 @@ void WCoverArt::mousePressEvent(QMouseEvent* event) {
     }
 
     if (event->button() == Qt::RightButton && m_loadedTrack) { // show context-menu
-        m_pMenu->setCoverArt(m_loadedTrack->getLocation(), m_lastRequestedCover);
+        m_pMenu->setCoverArt(m_lastRequestedCover);
         m_pMenu->popup(event->globalPos());
     } else if (event->button() == Qt::LeftButton) { // init/close fullsize cover
         if (m_pDlgFullSize->isVisible()) {

--- a/src/widget/wcoverart.h
+++ b/src/widget/wcoverart.h
@@ -36,7 +36,7 @@ class WCoverArt : public QWidget, public WBaseWidget {
   private slots:
     void slotCoverFound(const QObject* pRequestor,
                         const CoverInfo& info, QPixmap pixmap, bool fromCache);
-    void slotCoverArtSelected(const CoverArt& art);
+    void slotCoverInfoSelected(const CoverInfo& coverInfo);
     void slotReloadCoverArt();
     void slotTrackCoverArtUpdated();
 

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -18,8 +18,8 @@ WCoverArtLabel::WCoverArtLabel(QWidget* parent)
     setContextMenuPolicy(Qt::CustomContextMenu);
     connect(this, SIGNAL(customContextMenuRequested(QPoint)),
             this, SLOT(slotCoverMenu(QPoint)));
-    connect(m_pCoverMenu, SIGNAL(coverArtSelected(const CoverArt&)),
-            this, SIGNAL(coverArtSelected(const CoverArt&)));
+    connect(m_pCoverMenu, SIGNAL(coverInfoSelected(const CoverInfo&)),
+            this, SIGNAL(coverInfoSelected(const CoverInfo&)));
     connect(m_pCoverMenu, SIGNAL(reloadCoverArt()),
             this, SIGNAL(reloadCoverArt()));
 
@@ -34,11 +34,12 @@ WCoverArtLabel::~WCoverArtLabel() {
     delete m_pDlgFullSize;
 }
 
-void WCoverArtLabel::setCoverArt(const QString& trackLocation, const CoverInfo& coverInfo, QPixmap px) {
+void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
+                                 QPixmap px) {
     qDebug() << "WCoverArtLabel::setCoverArt" << coverInfo << px.size();
 
     m_loadedCover = px;
-    m_pCoverMenu->setCoverArt(trackLocation, coverInfo);
+    m_pCoverMenu->setCoverArt(coverInfo);
 
 
     if (px.isNull()) {

--- a/src/widget/wcoverartlabel.h
+++ b/src/widget/wcoverartlabel.h
@@ -16,10 +16,10 @@ class WCoverArtLabel : public QLabel {
     explicit WCoverArtLabel(QWidget* parent = nullptr);
     ~WCoverArtLabel() override;
 
-    void setCoverArt(const QString& trackLocation, const CoverInfo& coverInfo, QPixmap px);
+    void setCoverArt(const CoverInfo& coverInfo, QPixmap px);
 
   signals:
-    void coverArtSelected(const CoverArt& art);
+    void coverInfoSelected(const CoverInfo& coverInfo);
     void reloadCoverArt();
 
   protected:

--- a/src/widget/wcoverartmenu.cpp
+++ b/src/widget/wcoverartmenu.cpp
@@ -82,19 +82,19 @@ void WCoverArtMenu::slotChange() {
         // TODO(rryan): feedback
         return;
     }
-    art.info.type = CoverInfo::FILE;
-    art.info.source = CoverInfo::USER_SELECTED;
-    art.info.coverLocation = selectedCoverPath;
+    art.type = CoverInfo::FILE;
+    art.source = CoverInfo::USER_SELECTED;
+    art.coverLocation = selectedCoverPath;
     // TODO() here we may introduce a duplicate hash code
-    art.info.hash = CoverArtUtils::calculateHash(art.image);
+    art.hash = CoverArtUtils::calculateHash(art.image);
     qDebug() << "WCoverArtMenu::slotChange emit" << art;
     emit(coverArtSelected(art));
 }
 
 void WCoverArtMenu::slotUnset() {
     CoverArt art;
-    art.info.type = CoverInfo::NONE;
-    art.info.source = CoverInfo::USER_SELECTED;
+    art.type = CoverInfo::NONE;
+    art.source = CoverInfo::USER_SELECTED;
     qDebug() << "WCoverArtMenu::slotUnset emit" << art;
     emit(coverArtSelected(art));
 }

--- a/src/widget/wcoverartmenu.cpp
+++ b/src/widget/wcoverartmenu.cpp
@@ -33,16 +33,13 @@ void WCoverArtMenu::createActions() {
     addAction(m_pReload);
 }
 
-void WCoverArtMenu::setCoverArt(const QString& trackLocation, const CoverInfo& coverInfo) {
-    m_trackLocation = trackLocation;
+void WCoverArtMenu::setCoverArt(const CoverInfo& coverInfo) {
     m_coverInfo = coverInfo;
 }
 
 void WCoverArtMenu::slotChange() {
     QFileInfo fileInfo;
-    if (!m_trackLocation.isEmpty()) {
-        fileInfo = QFileInfo(m_trackLocation);
-    } else if (!m_coverInfo.trackLocation.isEmpty()) {
+    if (!m_coverInfo.trackLocation.isEmpty()) {
         fileInfo = QFileInfo(m_coverInfo.trackLocation);
     }
 
@@ -72,29 +69,30 @@ void WCoverArtMenu::slotChange() {
 
     // TODO(rryan): Ask if user wants to copy the file.
 
-    CoverArt art;
+    CoverInfo coverInfo;
     // Create a security token for the file.
     QFileInfo selectedCover(selectedCoverPath);
     SecurityTokenPointer pToken = Sandbox::openSecurityToken(
         selectedCover, true);
-    art.image = QImage(selectedCoverPath);
-    if (art.image.isNull()) {
+    QImage image(selectedCoverPath);
+    if (image.isNull()) {
         // TODO(rryan): feedback
         return;
     }
-    art.type = CoverInfo::FILE;
-    art.source = CoverInfo::USER_SELECTED;
-    art.coverLocation = selectedCoverPath;
+    coverInfo.type = CoverInfo::FILE;
+    coverInfo.source = CoverInfo::USER_SELECTED;
+    coverInfo.coverLocation = selectedCoverPath;
     // TODO() here we may introduce a duplicate hash code
-    art.hash = CoverArtUtils::calculateHash(art.image);
-    qDebug() << "WCoverArtMenu::slotChange emit" << art;
-    emit(coverArtSelected(art));
+    coverInfo.hash = CoverArtUtils::calculateHash(image);
+    coverInfo.trackLocation = m_coverInfo.trackLocation;
+    qDebug() << "WCoverArtMenu::slotChange emit" << coverInfo;
+    emit(coverInfoSelected(coverInfo));
 }
 
 void WCoverArtMenu::slotUnset() {
-    CoverArt art;
-    art.type = CoverInfo::NONE;
-    art.source = CoverInfo::USER_SELECTED;
-    qDebug() << "WCoverArtMenu::slotUnset emit" << art;
-    emit(coverArtSelected(art));
+    CoverInfo coverInfo;
+    coverInfo.type = CoverInfo::NONE;
+    coverInfo.source = CoverInfo::USER_SELECTED;
+    qDebug() << "WCoverArtMenu::slotUnset emit" << coverInfo;
+    emit(coverInfoSelected(coverInfo));
 }

--- a/src/widget/wcoverartmenu.h
+++ b/src/widget/wcoverartmenu.h
@@ -20,10 +20,10 @@ class WCoverArtMenu : public QMenu {
     explicit WCoverArtMenu(QWidget *parent = nullptr);
     ~WCoverArtMenu() override;
 
-    void setCoverArt(const QString& trackLocation, const CoverInfo& coverInfo);
+    void setCoverArt(const CoverInfo& coverInfo);
 
   signals:
-    void coverArtSelected(const CoverArt& art);
+    void coverInfoSelected(const CoverInfo& coverInfo);
     void reloadCoverArt();
 
   private slots:
@@ -37,7 +37,6 @@ class WCoverArtMenu : public QMenu {
     QAction* m_pReload;
     QAction* m_pUnset;
 
-    QString m_trackLocation;
     CoverInfo m_coverInfo;
 };
 

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -265,7 +265,7 @@ void WSpinny::slotCoverFound(const QObject* pRequestor,
     Q_UNUSED(fromCache);
 
     if (pRequestor == this && m_loadedTrack &&
-            m_loadedTrack->getCoverInfo().hash == info.hash) {
+            m_loadedTrack->getCoverHash() == info.hash) {
         qDebug() << "WSpinny::slotCoverFound" << pRequestor << info
                  << pixmap.size();
         m_loadedCover = pixmap;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -73,8 +73,8 @@ WTrackTableView::WTrackTableView(QWidget * parent,
     m_pBPMMenu->setTitle(tr("BPM Options"));
     m_pCoverMenu = new WCoverArtMenu(this);
     m_pCoverMenu->setTitle(tr("Cover Art"));
-    connect(m_pCoverMenu, SIGNAL(coverArtSelected(const CoverArt&)),
-            this, SLOT(slotCoverArtSelected(const CoverArt&)));
+    connect(m_pCoverMenu, SIGNAL(coverInfoSelected(const CoverInfo&)),
+            this, SLOT(slotCoverInfoSelected(const CoverInfo&)));
     connect(m_pCoverMenu, SIGNAL(reloadCoverArt()),
             this, SLOT(slotReloadCoverArt()));
 
@@ -932,7 +932,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
             last.row(), m_iTrackLocationColumn).data().toString();
         info.coverLocation = last.sibling(
             last.row(), m_iCoverLocationColumn).data().toString();
-        m_pCoverMenu->setCoverArt(QString(), info);
+        m_pCoverMenu->setCoverArt(info);
         m_pMenu->addMenu(m_pCoverMenu);
     }
 
@@ -1626,7 +1626,7 @@ void WTrackTableView::slotReplayGainReset() {
     }
 }
 
-void WTrackTableView::slotCoverArtSelected(const CoverArt& art) {
+void WTrackTableView::slotCoverInfoSelected(const CoverInfo& coverInfo) {
     TrackModel* trackModel = getTrackModel();
     if (trackModel == nullptr) {
         return;
@@ -1635,7 +1635,7 @@ void WTrackTableView::slotCoverArtSelected(const CoverArt& art) {
     for (const QModelIndex& index : selection) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
-            pTrack->setCoverInfo(art);
+            pTrack->setCoverInfo(coverInfo);
         }
     }
 }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1635,7 +1635,7 @@ void WTrackTableView::slotCoverArtSelected(const CoverArt& art) {
     for (const QModelIndex& index : selection) {
         TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
-            pTrack->setCoverInfo(art.info);
+            pTrack->setCoverInfo(art);
         }
     }
 }

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -71,7 +71,7 @@ class WTrackTableView : public WLibraryTableView {
     // Signalled 20 times per second (every 50ms) by GuiTick.
     void slotGuiTick50ms(double);
     void slotScrollValueChanged(int);
-    void slotCoverArtSelected(const CoverArt& art);
+    void slotCoverInfoSelected(const CoverInfo& coverInfo);
     void slotReloadCoverArt();
 
     void slotTrackInfoClosed();


### PR DESCRIPTION
This is a follow up PR of #988

I have noticed that the image part of CoverArt is often unused. 
There where also some suspicious code parts with the redundant track locations. 

This is improved here by a new class hierarchy.
CoverArt - CoverInfo - CoverInfoRelative. 
