### PR TITLE
SoundSource: Improve compatibility with std::shared_ptr (C++11)

### DIFF
--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -543,7 +543,7 @@ QStringList SoundSourceProviderM4A::getSupportedFileExtensions() const {
 }
 
 SoundSourcePointer SoundSourceProviderM4A::newSoundSource(const QUrl& url) {
-    return exportSoundSourcePlugin(new SoundSourceM4A(url));
+    return newSoundSourcePluginFromUrl<SoundSourceM4A>(url);
 }
 
 } // namespace mixxx

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -662,7 +662,7 @@ QStringList SoundSourceProviderMediaFoundation::getSupportedFileExtensions() con
 }
 
 SoundSourcePointer SoundSourceProviderMediaFoundation::newSoundSource(const QUrl& url) {
-    return exportSoundSourcePlugin(new SoundSourceMediaFoundation(url));
+    return newSoundSourcePluginFromUrl<SoundSourceMediaFoundation>(url);
 }
 
 } // namespace mixxx

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -126,7 +126,7 @@ QStringList SoundSourceProviderWV::getSupportedFileExtensions() const {
 }
 
 SoundSourcePointer SoundSourceProviderWV::newSoundSource(const QUrl& url) {
-    return exportSoundSourcePlugin(new SoundSourceWV(url));
+    return newSoundSourcePluginFromUrl<SoundSourceWV>(url);
 }
 
 //static

--- a/src/engine/cachingreaderchunk.cpp
+++ b/src/engine/cachingreaderchunk.cpp
@@ -40,7 +40,7 @@ bool CachingReaderChunk::isReadable(
         SINT maxReadableFrameIndex) const {
     DEBUG_ASSERT(mixxx::AudioSource::getMinFrameIndex() <= maxReadableFrameIndex);
 
-    if (!isValid() || pAudioSource.isNull()) {
+    if (!isValid() || !pAudioSource) {
         return false;
     }
     const SINT frameIndex = frameForIndex(getIndex());

--- a/src/engine/cachingreaderworker.cpp
+++ b/src/engine/cachingreaderworker.cpp
@@ -100,7 +100,7 @@ namespace
     mixxx::AudioSourcePointer openAudioSourceForReading(const TrackPointer& pTrack, const mixxx::AudioSourceConfig& audioSrcCfg) {
         SoundSourceProxy soundSourceProxy(pTrack);
         mixxx::AudioSourcePointer pAudioSource(soundSourceProxy.openAudioSource(audioSrcCfg));
-        if (pAudioSource.isNull()) {
+        if (!pAudioSource) {
             qWarning() << "Failed to open file:" << pTrack->getLocation();
             return mixxx::AudioSourcePointer();
         }
@@ -132,7 +132,7 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     mixxx::AudioSourceConfig audioSrcCfg;
     audioSrcCfg.setChannelCount(CachingReaderChunk::kChannels);
     m_pAudioSource = openAudioSourceForReading(pTrack, audioSrcCfg);
-    if (m_pAudioSource.isNull()) {
+    if (!m_pAudioSource) {
         m_maxReadableFrameIndex = mixxx::AudioSource::getMinFrameIndex();
         // Must unlock before emitting to avoid deadlock
         qDebug() << m_group << "CachingReaderWorker::loadTrack() load failed for\""

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -102,7 +102,7 @@ QString ChromaPrinter::getFingerprint(TrackPointer pTrack) {
     mixxx::AudioSourceConfig audioSrcCfg;
     audioSrcCfg.setChannelCount(kFingerprintChannels);
     mixxx::AudioSourcePointer pAudioSource(soundSourceProxy.openAudioSource(audioSrcCfg));
-    if (pAudioSource.isNull()) {
+    if (!pAudioSource) {
         qDebug() << "Skipping invalid file:" << pTrack->getLocation();
         return QString();
     }

--- a/src/sources/soundsource.h
+++ b/src/sources/soundsource.h
@@ -77,6 +77,11 @@ private:
 
 typedef QSharedPointer<SoundSource> SoundSourcePointer;
 
+template<typename T>
+SoundSourcePointer newSoundSourceFromUrl(const QUrl& url) {
+    return SoundSourcePointer(new T(url));
+}
+
 } //namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCE_H

--- a/src/sources/soundsourcecoreaudio.h
+++ b/src/sources/soundsourcecoreaudio.h
@@ -49,7 +49,7 @@ public:
     QStringList getSupportedFileExtensions() const override;
 
     SoundSourcePointer newSoundSource(const QUrl& url) override {
-        return SoundSourcePointer(new SoundSourceCoreAudio(url));
+        return newSoundSourceFromUrl<SoundSourceCoreAudio>(url);
     }
 };
 

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -102,7 +102,7 @@ class SoundSourceProviderFFmpeg: public SoundSourceProvider {
     QStringList getSupportedFileExtensions() const override;
 
     SoundSourcePointer newSoundSource(const QUrl& url) override {
-        return SoundSourcePointer(new SoundSourceFFmpeg(url));
+        return newSoundSourceFromUrl<SoundSourceFFmpeg>(url);
     }
 };
 

--- a/src/sources/soundsourceflac.h
+++ b/src/sources/soundsourceflac.h
@@ -68,7 +68,7 @@ public:
     QStringList getSupportedFileExtensions() const override;
 
     SoundSourcePointer newSoundSource(const QUrl& url) override {
-        return SoundSourcePointer(new SoundSourceFLAC(url));
+        return newSoundSourceFromUrl<SoundSourceFLAC>(url);
     }
 };
 

--- a/src/sources/soundsourcemodplug.h
+++ b/src/sources/soundsourcemodplug.h
@@ -59,7 +59,7 @@ public:
     QStringList getSupportedFileExtensions() const override;
 
     SoundSourcePointer newSoundSource(const QUrl& url) override {
-        return SoundSourcePointer(new SoundSourceModPlug(url));
+        return newSoundSourceFromUrl<SoundSourceModPlug>(url);
     }
 };
 

--- a/src/sources/soundsourcemp3.h
+++ b/src/sources/soundsourcemp3.h
@@ -88,7 +88,7 @@ public:
     QStringList getSupportedFileExtensions() const override;
 
     SoundSourcePointer newSoundSource(const QUrl& url) override {
-        return SoundSourcePointer(new SoundSourceMp3(url));
+        return newSoundSourceFromUrl<SoundSourceMp3>(url);
     }
 };
 

--- a/src/sources/soundsourceoggvorbis.h
+++ b/src/sources/soundsourceoggvorbis.h
@@ -53,7 +53,7 @@ public:
     QStringList getSupportedFileExtensions() const override;
 
     SoundSourcePointer newSoundSource(const QUrl& url) override {
-        return SoundSourcePointer(new SoundSourceOggVorbis(url));
+        return newSoundSourceFromUrl<SoundSourceOggVorbis>(url);
     }
 };
 

--- a/src/sources/soundsourceopus.h
+++ b/src/sources/soundsourceopus.h
@@ -41,7 +41,7 @@ public:
     QStringList getSupportedFileExtensions() const override;
 
     SoundSourcePointer newSoundSource(const QUrl& url) override {
-        return SoundSourcePointer(new SoundSourceOpus(url));
+        return newSoundSourceFromUrl<SoundSourceOpus>(url);
     }
 };
 

--- a/src/sources/soundsourceplugin.cpp
+++ b/src/sources/soundsourceplugin.cpp
@@ -4,19 +4,10 @@
 
 namespace mixxx {
 
-namespace {
-
-void deleteSoundSource(SoundSource* pSoundSource) {
-    // The SoundSource must be deleted from within the external library
-    // that has allocated it.
+void deleteSoundSourcePlugin(SoundSource* pSoundSource) {
+    // The SoundSource must be deleted from within the external
+    // library that has allocated it.
     delete pSoundSource;
-}
-
-} // anonymous namespace
-
-SoundSourcePointer exportSoundSourcePlugin(
-        SoundSourcePlugin* pSoundSourcePlugin) {
-    return SoundSourcePointer(pSoundSourcePlugin, deleteSoundSource);
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourceplugin.h
+++ b/src/sources/soundsourceplugin.h
@@ -16,12 +16,14 @@ protected:
     }
 };
 
-// Wraps the SoundSourcePlugin allocated with operator new
-// into a SoundSourcePointer that ensures that the managed
-// object will deleted from within the external library (DLL)
-// eventually.
-SoundSourcePointer exportSoundSourcePlugin(
-        SoundSourcePlugin* pSoundSourcePlugin);
+void deleteSoundSourcePlugin(SoundSource* pSoundSource);
+
+template<typename T>
+SoundSourcePointer newSoundSourcePluginFromUrl(const QUrl& url) {
+    // Ensures that the managed object will deleted from within the external
+    // library (DLL) eventually.
+    return SoundSourcePointer(new T(url), deleteSoundSourcePlugin);
+}
 
 } // namespace mixxx
 

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -352,7 +352,7 @@ void SoundSourceProxy::nextSoundSourceProvider() {
         ++m_soundSourceProviderRegistrationIndex;
         // Discard SoundSource and AudioSource from previous provider
         closeAudioSource();
-        m_pSoundSource.clear();
+        m_pSoundSource = mixxx::SoundSourcePointer();
     }
 }
 
@@ -631,7 +631,7 @@ void SoundSourceProxy::closeAudioSource() {
     if (m_pAudioSource) {
         DEBUG_ASSERT(m_pSoundSource);
         m_pSoundSource->close();
-        m_pAudioSource.clear();
+        m_pAudioSource = mixxx::AudioSourcePointer();
         qDebug() << "Closed AudioSource for file"
                  << getUrl().toString();
     }

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -297,7 +297,7 @@ SoundSourceProxy::SaveTrackMetadataResult SoundSourceProxy::saveTrackMetadata(
         bool evenIfNeverParsedFromFileBefore) {
     DEBUG_ASSERT(nullptr != pTrack);
     SoundSourceProxy proxy(pTrack);
-    if (!proxy.m_pSoundSource.isNull()) {
+    if (proxy.m_pSoundSource) {
         mixxx::TrackMetadata trackMetadata;
         bool parsedFromFile = false;
         pTrack->getTrackMetadata(&trackMetadata, &parsedFromFile);
@@ -357,11 +357,11 @@ void SoundSourceProxy::nextSoundSourceProvider() {
 }
 
 void SoundSourceProxy::initSoundSource() {
-    DEBUG_ASSERT(m_pSoundSource.isNull());
-    DEBUG_ASSERT(m_pAudioSource.isNull());
-    while (m_pSoundSource.isNull()) {
+    DEBUG_ASSERT(!m_pSoundSource);
+    DEBUG_ASSERT(!m_pAudioSource);
+    while (!m_pSoundSource) {
         mixxx::SoundSourceProviderPointer pProvider(getSoundSourceProvider());
-        if (pProvider.isNull()) {
+        if (!pProvider) {
             if (!getUrl().isEmpty()) {
                 qWarning() << "No SoundSourceProvider for file"
                            << getUrl().toString();
@@ -370,7 +370,7 @@ void SoundSourceProxy::initSoundSource() {
             return;
         }
         m_pSoundSource = pProvider->newSoundSource(m_url);
-        if (m_pSoundSource.isNull()) {
+        if (!m_pSoundSource) {
             qWarning() << "SoundSourceProvider"
                        << pProvider->getName()
                        << "failed to create a SoundSource for file"
@@ -378,7 +378,7 @@ void SoundSourceProxy::initSoundSource() {
             // Switch to next provider...
             nextSoundSourceProvider();
             // ...and continue loop
-            DEBUG_ASSERT(m_pSoundSource.isNull());
+            DEBUG_ASSERT(!m_pSoundSource);
         } else {
             QString trackType(m_pSoundSource->getType());
             qDebug() << "SoundSourceProvider"
@@ -387,7 +387,7 @@ void SoundSourceProxy::initSoundSource() {
                      << getUrl().toString()
                      << "of type"
                      << trackType;
-            if (!m_pTrack.isNull()) {
+            if (m_pTrack) {
                 m_pTrack->setType(trackType);
             }
         }
@@ -426,9 +426,9 @@ namespace {
 void SoundSourceProxy::loadTrackMetadataAndCoverArt(
         bool withCoverArt,
         bool reloadFromFile) const {
-    DEBUG_ASSERT(!m_pTrack.isNull());
+    DEBUG_ASSERT(m_pTrack);
 
-    if (m_pSoundSource.isNull()) {
+    if (!m_pSoundSource) {
         // Silently ignore requests for unsupported files
         qDebug() << "Unable to parse file tags without a SoundSource"
                  << getUrl().toString();
@@ -459,7 +459,7 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
     bool parsedCoverArt = false;
 
     // Parse the tags stored in the audio file.
-    if (!m_pSoundSource.isNull() &&
+    if (m_pSoundSource &&
             (m_pSoundSource->parseTrackMetadataAndCoverArt(&trackMetadata, pCoverImg) == OK)) {
         parsedFromFile = true;
         if (!coverImg.isNull()) {
@@ -497,7 +497,7 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
 }
 
 Result SoundSourceProxy::parseTrackMetadata(mixxx::TrackMetadata* pTrackMetadata) const {
-    if (!m_pSoundSource.isNull()) {
+    if (m_pSoundSource) {
         return m_pSoundSource->parseTrackMetadataAndCoverArt(pTrackMetadata, nullptr);
     } else {
         return ERR;
@@ -506,7 +506,7 @@ Result SoundSourceProxy::parseTrackMetadata(mixxx::TrackMetadata* pTrackMetadata
 
 QImage SoundSourceProxy::parseCoverImage() const {
     QImage coverImg;
-    if (!m_pSoundSource.isNull()) {
+    if (m_pSoundSource) {
         m_pSoundSource->parseTrackMetadataAndCoverArt(nullptr, &coverImg);
     }
     return coverImg;
@@ -527,8 +527,8 @@ public:
     static mixxx::AudioSourcePointer create(
             const TrackPointer& pTrack,
             const mixxx::AudioSourcePointer& pAudioSource) {
-        DEBUG_ASSERT(!pTrack.isNull());
-        DEBUG_ASSERT(!pAudioSource.isNull());
+        DEBUG_ASSERT(pTrack);
+        DEBUG_ASSERT(pAudioSource);
         return mixxx::AudioSourcePointer(
                 new AudioSourceProxy(pTrack, pAudioSource));
     }
@@ -572,9 +572,9 @@ private:
 } // anonymous namespace
 
 mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSourceConfig& audioSrcCfg) {
-    DEBUG_ASSERT(!m_pTrack.isNull());
-    while (m_pAudioSource.isNull()) {
-        if (m_pSoundSource.isNull()) {
+    DEBUG_ASSERT(m_pTrack);
+    while (!m_pAudioSource) {
+        if (!m_pSoundSource) {
             qWarning() << "Failed to open AudioSource for file"
                        << getUrl().toString();
             return m_pAudioSource; // failure -> exit loop
@@ -593,7 +593,7 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSo
                                << getUrl().toString();
                 }
                 // Overwrite metadata with actual audio properties
-                if (!m_pTrack.isNull()) {
+                if (m_pTrack) {
                     m_pTrack->setChannels(m_pAudioSource->getChannelCount());
                     m_pTrack->setSampleRate(m_pAudioSource->getSamplingRate());
                     if (m_pAudioSource->hasDuration()) {
@@ -628,8 +628,8 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSo
 }
 
 void SoundSourceProxy::closeAudioSource() {
-    if (!m_pAudioSource.isNull()) {
-        DEBUG_ASSERT(!m_pSoundSource.isNull());
+    if (m_pAudioSource) {
+        DEBUG_ASSERT(m_pSoundSource);
         m_pSoundSource->close();
         m_pAudioSource.clear();
         qDebug() << "Closed AudioSource for file"

--- a/src/sources/soundsourcesndfile.h
+++ b/src/sources/soundsourcesndfile.h
@@ -45,7 +45,7 @@ public:
     QStringList getSupportedFileExtensions() const override;
 
     SoundSourcePointer newSoundSource(const QUrl& url) override {
-        return SoundSourcePointer(new SoundSourceSndFile(url));
+        return newSoundSourceFromUrl<SoundSourceSndFile>(url);
     }
 };
 

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -132,7 +132,7 @@ TEST_F(SoundSourceProxyTest, seekForward) {
         SampleBuffer seekReadData(readSampleCount);
 
 #ifdef __FFMPEGFILE__
-        if (dynamic_cast<mixxx::SoundSourceFFmpeg*>(pContReadSource.data())) {
+        if (dynamic_cast<mixxx::SoundSourceFFmpeg*>(&*pContReadSource)) {
             if (filePath.endsWith(".mp3")) {
                 qDebug() << "Skip test since it will fail using SoundSourceFFmpeg";
                 continue;

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -70,7 +70,7 @@ TEST_F(SoundSourceProxyTest, open) {
         // Obtaining an AudioSource may fail for unsupported file formats,
         // even if the corresponding file extension is supported, e.g.
         // AAC vs. ALAC in .m4a files
-        if (pAudioSource.isNull()) {
+        if (!pAudioSource) {
             // skip test file
             continue;
         }
@@ -123,7 +123,7 @@ TEST_F(SoundSourceProxyTest, seekForward) {
         // Obtaining an AudioSource may fail for unsupported file formats,
         // even if the corresponding file extension is supported, e.g.
         // AAC vs. ALAC in .m4a files
-        if (pContReadSource.isNull()) {
+        if (!pContReadSource) {
             // skip test file
             continue;
         }
@@ -149,7 +149,7 @@ TEST_F(SoundSourceProxyTest, seekForward) {
                     pContReadSource->readSampleFrames(kReadFrameCount, &contReadData[0]);
 
             mixxx::AudioSourcePointer pSeekReadSource(openAudioSource(filePath));
-            ASSERT_FALSE(pSeekReadSource.isNull());
+            ASSERT_FALSE(!pSeekReadSource);
             ASSERT_EQ(pContReadSource->getChannelCount(), pSeekReadSource->getChannelCount());
             ASSERT_EQ(pContReadSource->getFrameCount(), pSeekReadSource->getFrameCount());
 


### PR DESCRIPTION
Lay the grounds for switching from QSharedPointer to std::shared_ptr some day.

With these modifications using std::shared_ptr instead of the proprietary QSharedPointer becomes very easy. Only very few lines of code need to be changed. The details are hidden behind typedefs and encapsulated in factory functions. If you are interested how this will look like I will publish the final commit in a separate PR afterwards. Preview branch: https://github.com/uklotzde/mixxx/tree/std_shared_ptr

Hint: std::shared_ptr is accompanied by std::make_shared() that might be more efficient by allocating the reference count together with the managed object in a single allocation on the heap. Efficiency does not matter for SoundSource, my motivation was mainly being standard compliant.
