### PR TITLE
Follow-up: Shared pointers in SoundSource framework

### DIFF
--- a/src/sources/soundsourcepluginlibrary.cpp
+++ b/src/sources/soundsourcepluginlibrary.cpp
@@ -27,9 +27,7 @@ namespace mixxx {
 
 SoundSourcePluginLibrary::SoundSourcePluginLibrary(const QString& libFilePath)
     : m_library(libFilePath),
-      m_apiVersion(0),
-      m_createSoundSourceProviderFunc(nullptr),
-      m_destroySoundSourceProviderFunc(nullptr){
+      m_apiVersion(0) {
 }
 
 SoundSourcePluginLibrary::~SoundSourcePluginLibrary() {
@@ -48,50 +46,62 @@ bool SoundSourcePluginLibrary::init() {
 
     SoundSourcePluginAPI_getVersionFunc getVersionFunc = (SoundSourcePluginAPI_getVersionFunc)
             m_library.resolve(SoundSourcePluginAPI_getVersionFuncName);
-    if (!getVersionFunc) {
+    if (getVersionFunc == nullptr) {
         // Try to resolve the legacy plugin API function name
         getVersionFunc = (SoundSourcePluginAPI_getVersionFunc)
                     m_library.resolve("getSoundSourceAPIVersion");
     }
-    if (getVersionFunc) {
-        m_apiVersion = getVersionFunc();
-        if (m_apiVersion == MIXXX_SOUNDSOURCEPLUGINAPI_VERSION) {
-            m_createSoundSourceProviderFunc = (SoundSourcePluginAPI_createSoundSourceProviderFunc)
-                    m_library.resolve(SoundSourcePluginAPI_createSoundSourceProviderFuncName);
-            if (nullptr == m_createSoundSourceProviderFunc) {
-                qWarning() << "Failed to resolve SoundSource plugin API function"
-                        << SoundSourcePluginAPI_createSoundSourceProviderFuncName;
-            }
-            m_destroySoundSourceProviderFunc = (SoundSourcePluginAPI_destroySoundSourceProviderFunc)
-                    m_library.resolve(SoundSourcePluginAPI_destroySoundSourceProviderFuncName);
-            if (nullptr == m_destroySoundSourceProviderFunc) {
-                qWarning() << "Failed to resolve SoundSource plugin API function"
-                        << SoundSourcePluginAPI_destroySoundSourceProviderFuncName;
-            }
-        } else {
-            qWarning() << "Incompatible SoundSource plugin API version"
-                    << m_apiVersion << "<>" << MIXXX_SOUNDSOURCEPLUGINAPI_VERSION;
-        }
-    } else {
+    if (getVersionFunc == nullptr) {
         qWarning() << "Failed to resolve SoundSource plugin API function"
                 << SoundSourcePluginAPI_getVersionFuncName;
+        return initFailedForIncompatiblePlugin();
     }
 
-    if (getVersionFunc && m_createSoundSourceProviderFunc && m_destroySoundSourceProviderFunc) {
+    m_apiVersion = getVersionFunc();
+    if (m_apiVersion != MIXXX_SOUNDSOURCEPLUGINAPI_VERSION) {
+        qWarning() << "Incompatible SoundSource plugin API version"
+                << m_apiVersion << "<>" << MIXXX_SOUNDSOURCEPLUGINAPI_VERSION;
+        return initFailedForIncompatiblePlugin();
+    }
+
+    auto const createSoundSourceProviderFunc =
+            reinterpret_cast<SoundSourcePluginAPI_createSoundSourceProviderFunc>(
+                    m_library.resolve(SoundSourcePluginAPI_createSoundSourceProviderFuncName));
+    if (createSoundSourceProviderFunc == nullptr) {
+        qWarning() << "Failed to resolve SoundSource plugin API function"
+                << SoundSourcePluginAPI_createSoundSourceProviderFuncName;
+        return initFailedForIncompatiblePlugin();
+    }
+
+    auto const destroySoundSourceProviderFunc =
+            reinterpret_cast<SoundSourcePluginAPI_destroySoundSourceProviderFunc>(
+                m_library.resolve(SoundSourcePluginAPI_destroySoundSourceProviderFuncName));
+    if (destroySoundSourceProviderFunc == nullptr) {
+        qWarning() << "Failed to resolve SoundSource plugin API function"
+                << SoundSourcePluginAPI_destroySoundSourceProviderFuncName;
+        return initFailedForIncompatiblePlugin();
+    }
+
+    m_pSoundSourceProvider = SoundSourceProviderPointer(
+            (*createSoundSourceProviderFunc)(),
+            destroySoundSourceProviderFunc);
+    if (m_pSoundSourceProvider) {
         return true;
     } else {
-        qWarning() << "Incompatible SoundSource plugin"
+        qWarning() << "Failed to create SoundSource provider for plugin library"
                 << m_library.fileName();
         return false;
     }
 }
 
+bool SoundSourcePluginLibrary::initFailedForIncompatiblePlugin() const {
+    qWarning() << "Incompatible SoundSource plugin"
+            << m_library.fileName();
+    return false;
+}
+
 SoundSourceProviderPointer SoundSourcePluginLibrary::getSoundSourceProvider() const {
-    DEBUG_ASSERT(m_createSoundSourceProviderFunc);
-    DEBUG_ASSERT(m_destroySoundSourceProviderFunc);
-    return SoundSourceProviderPointer(
-            (*m_createSoundSourceProviderFunc)(),
-            m_destroySoundSourceProviderFunc);
+    return m_pSoundSourceProvider;
 }
 
 } // Mixxx

--- a/src/sources/soundsourcepluginlibrary.cpp
+++ b/src/sources/soundsourcepluginlibrary.cpp
@@ -86,7 +86,7 @@ bool SoundSourcePluginLibrary::init() {
     }
 }
 
-SoundSourceProviderPointer SoundSourcePluginLibrary::createSoundSourceProvider() const {
+SoundSourceProviderPointer SoundSourcePluginLibrary::getSoundSourceProvider() const {
     DEBUG_ASSERT(m_createSoundSourceProviderFunc);
     DEBUG_ASSERT(m_destroySoundSourceProviderFunc);
     return SoundSourceProviderPointer(

--- a/src/sources/soundsourcepluginlibrary.h
+++ b/src/sources/soundsourcepluginlibrary.h
@@ -2,6 +2,7 @@
 #define MIXXX_SOUNDSOURCEPLUGINLIBRARY_H
 
 #include "sources/soundsourcepluginapi.h"
+#include "sources/soundsourceprovider.h"
 
 #include <QMap>
 #include <QMutex>
@@ -13,7 +14,6 @@ class SoundSourcePluginLibrary;
 
 typedef QSharedPointer<SoundSourcePluginLibrary> SoundSourcePluginLibraryPointer;
 
-typedef QSharedPointer<SoundSourceProvider> SoundSourceProviderPointer;
 
 // Wrapper class for a dynamic library that implements the SoundSource plugin API
 class SoundSourcePluginLibrary {

--- a/src/sources/soundsourcepluginlibrary.h
+++ b/src/sources/soundsourcepluginlibrary.h
@@ -30,7 +30,7 @@ public:
         return m_apiVersion;
     }
 
-    SoundSourceProviderPointer createSoundSourceProvider() const;
+    SoundSourceProviderPointer getSoundSourceProvider() const;
 
 protected:
     explicit SoundSourcePluginLibrary(const QString& libFilePath);

--- a/src/sources/soundsourcepluginlibrary.h
+++ b/src/sources/soundsourcepluginlibrary.h
@@ -41,13 +41,14 @@ private:
     static QMutex s_loadedPluginLibrariesMutex;
     static QMap<QString, mixxx::SoundSourcePluginLibraryPointer> s_loadedPluginLibraries;
 
+    bool initFailedForIncompatiblePlugin() const;
+
     QLibrary m_library;
 
     int m_apiVersion;
     QStringList m_supportedFileExtensions;
 
-    SoundSourcePluginAPI_createSoundSourceProviderFunc m_createSoundSourceProviderFunc;
-    SoundSourcePluginAPI_destroySoundSourceProviderFunc m_destroySoundSourceProviderFunc;
+    SoundSourceProviderPointer m_pSoundSourceProvider;
 };
 
 } // namespace mixxx

--- a/src/sources/soundsourceprovider.h
+++ b/src/sources/soundsourceprovider.h
@@ -53,6 +53,12 @@ public:
 };
 
 typedef QSharedPointer<SoundSourceProvider> SoundSourceProviderPointer;
+
+template<typename T>
+static SoundSourceProviderPointer newSoundSourceProvider() {
+    return SoundSourceProviderPointer(new T);
+}
+
 } // namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCEPROVIDER_H

--- a/src/sources/soundsourceprovider.h
+++ b/src/sources/soundsourceprovider.h
@@ -22,6 +22,9 @@ enum class SoundSourceProviderPriority {
 };
 
 // Factory interface for SoundSources
+//
+// The implementation of a SoundSourceProvider must be thread-safe, because
+// a single instance might be accessed concurrently from different threads.
 class SoundSourceProvider {
 public:
     virtual ~SoundSourceProvider() {}

--- a/src/sources/soundsourceprovider.h
+++ b/src/sources/soundsourceprovider.h
@@ -52,6 +52,7 @@ public:
     virtual SoundSourcePointer newSoundSource(const QUrl& url) = 0;
 };
 
+typedef QSharedPointer<SoundSourceProvider> SoundSourceProviderPointer;
 } // namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCEPROVIDER_H

--- a/src/sources/soundsourceproviderregistry.cpp
+++ b/src/sources/soundsourceproviderregistry.cpp
@@ -25,7 +25,7 @@ void SoundSourceProviderRegistry::registerProvider(
 void SoundSourceProviderRegistry::registerPluginLibrary(
         const SoundSourcePluginLibraryPointer& pPluginLibrary) {
     SoundSourceProviderPointer pProvider(
-            pPluginLibrary->createSoundSourceProvider());
+            pPluginLibrary->getSoundSourceProvider());
     if (!pProvider) {
         qWarning() << "Failed to obtain SoundSource provider from plugin library"
                 << pPluginLibrary->getFilePath();

--- a/src/sources/soundsourceproviderregistry.cpp
+++ b/src/sources/soundsourceproviderregistry.cpp
@@ -26,11 +26,7 @@ void SoundSourceProviderRegistry::registerPluginLibrary(
         const SoundSourcePluginLibraryPointer& pPluginLibrary) {
     SoundSourceProviderPointer pProvider(
             pPluginLibrary->getSoundSourceProvider());
-    if (!pProvider) {
-        qWarning() << "Failed to obtain SoundSource provider from plugin library"
-                << pPluginLibrary->getFilePath();
-        return; // abort registration
-    }
+    DEBUG_ASSERT(pProvider);
     const QStringList supportedFileExtensions(
             pProvider->getSupportedFileExtensions());
     if (supportedFileExtensions.isEmpty()) {

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -146,33 +146,33 @@ void SoundSourceProxy::loadPlugins() {
     // only matters among providers with equal priority.
 #ifdef __FFMPEGFILE__
     // Use FFmpeg as the last resort.
-    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
-            new mixxx::SoundSourceProviderFFmpeg));
+    s_soundSourceProviders.registerProvider(
+            mixxx::newSoundSourceProvider<mixxx::SoundSourceProviderFFmpeg>());
 #endif
 #ifdef __SNDFILE__
     // libsndfile is another fallback
-    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
-            new mixxx::SoundSourceProviderSndFile));
+    s_soundSourceProviders.registerProvider(
+            mixxx::newSoundSourceProvider<mixxx::SoundSourceProviderSndFile>());
 #endif
-    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
-            new mixxx::SoundSourceProviderFLAC));
-    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
-            new mixxx::SoundSourceProviderOggVorbis));
+    s_soundSourceProviders.registerProvider(
+            mixxx::newSoundSourceProvider<mixxx::SoundSourceProviderFLAC>());
+    s_soundSourceProviders.registerProvider(
+            mixxx::newSoundSourceProvider<mixxx::SoundSourceProviderOggVorbis>());
 #ifdef __OPUS__
-    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
-            new mixxx::SoundSourceProviderOpus));
+    s_soundSourceProviders.registerProvider(
+            mixxx::newSoundSourceProvider<mixxx::SoundSourceProviderOpus>());
 #endif
 #ifdef __MAD__
-    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
-            new mixxx::SoundSourceProviderMp3));
+    s_soundSourceProviders.registerProvider(
+            mixxx::newSoundSourceProvider<mixxx::SoundSourceProviderMp3>());
 #endif
 #ifdef __MODPLUG__
-    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
-            new mixxx::SoundSourceProviderModPlug));
+    s_soundSourceProviders.registerProvider(
+            mixxx::newSoundSourceProvider<mixxx::SoundSourceProviderModPlug>());
 #endif
 #ifdef __COREAUDIO__
-    s_soundSourceProviders.registerProvider(mixxx::SoundSourceProviderPointer(
-            new mixxx::SoundSourceProviderCoreAudio));
+    s_soundSourceProviders.registerProvider(
+            mixxx::newSoundSourceProvider<mixxx::SoundSourceProviderCoreAudio>());
 #endif
 
     // Scan for and initialize all plugins.


### PR DESCRIPTION
Afterwards I found some quirks in the current implementation. And I missed some allocations that should be encapsulated in factory functions.

Now replacing QSharedPointer with std::shared_ptr becomes even easier without the need for _operator new_ anymore: https://github.com/uklotzde/mixxx/tree/std_shared_ptr

I will post a proposal on the mailing list after this PR has been merged with the above branch as a show case. Since C++11 has first class support for managed pointers we should use this feature at least for new code. We are already recommending to use std::unqiue_ptr instead of QScopedPointer.
