### PR TITLE
Fix cover hash amgigious issue

### DIFF
--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -49,7 +49,7 @@ CoverInfoRelative::CoverInfoRelative()
           type(NONE),
           hash(0) {
     // The default hash value should match the calculated hash for a null image
-    DEBUG_ASSERT(CoverArtUtils::calculateHash(QImage()) == hash);
+    DEBUG_ASSERT(CoverArtUtils::calculateProvisionalHash(QImage()) == hash);
 }
 
 bool operator==(const CoverInfoRelative& a, const CoverInfoRelative& b) {
@@ -91,3 +91,8 @@ QDebug operator<<(QDebug dbg, const CoverArt& art) {
 }
 
 const int CoverInfoRelative::kNoHash = -1;
+// Mixxx 2.0 16 bit hashes are treated as provisional, since
+// it has no guarantee to be unique. From 2.1 we use the
+// 8 additional bits to distinguish duplicates hashes.
+const int CoverInfoRelative::kMaxProvisionalHash = 0xFFFF;
+

--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -89,3 +89,5 @@ QDebug operator<<(QDebug dbg, const CoverArt& art) {
                  toDebugString(art.image.size()),
                  QString::number(art.resizedToWidth));
 }
+
+const int CoverInfoRelative::kNoHash = -1;

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -29,13 +29,15 @@ class CoverInfoRelative {
         FILE = 2
     };
 
+    static const int kNoHash;
+
     CoverInfoRelative();
     virtual ~CoverInfoRelative() {};
 
     Source source;
     Type type;
     QString coverLocation; // relative path, from track location
-    quint16 hash;
+    int hash;
 };
 
 bool operator==(const CoverInfoRelative& a, const CoverInfoRelative& b);

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -30,6 +30,7 @@ class CoverInfoRelative {
     };
 
     static const int kNoHash;
+    static const int kMaxProvisionalHash;
 
     CoverInfoRelative();
     virtual ~CoverInfoRelative() {};

--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -9,7 +9,7 @@
 
 
 namespace {
-    QString pixmapCacheKey(quint16 hash, int width) {
+    QString pixmapCacheKey(int hash, int width) {
         return QString("CoverArtCache_%1_%2")
                 .arg(QString::number(hash)).arg(width);
     }
@@ -74,7 +74,7 @@ QPixmap CoverArtCache::requestCover(const CoverInfo& requestInfo,
 
     // keep a list of trackIds for which a future is currently running
     // to avoid loading the same picture again while we are loading it
-    QPair<const QObject*, quint16> requestId = qMakePair(pRequestor, requestInfo.hash);
+    QPair<const QObject*, int> requestId = qMakePair(pRequestor, requestInfo.hash);
     if (m_runningRequests.contains(requestId)) {
         return QPixmap();
     }

--- a/src/library/coverartcache.h
+++ b/src/library/coverartcache.h
@@ -74,7 +74,7 @@ class CoverArtCache : public QObject, public Singleton<CoverArtCache> {
     void guessCover(TrackPointer pTrack);
 
   private:
-    QSet<QPair<const QObject*, quint16> > m_runningRequests;
+    QSet<QPair<const QObject*, int> > m_runningRequests;
 };
 
 #endif // COVERARTCACHE_H

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -94,7 +94,7 @@ CoverInfo CoverArtUtils::guessCoverInfo(const Track& track) {
     QImage image = extractEmbeddedCover(fileInfo, track.getSecurityToken());
     if (!image.isNull()) {
         // TODO() here we my introduce a duplicate hash code
-        coverInfo.hash = calculateHash(image);
+        coverInfo.hash = calculateProvisionalHash(image);
         coverInfo.coverLocation = QString();
         coverInfo.type = CoverInfo::METADATA;
         qDebug() << "CoverArtUtils::guessCover found metadata art" << coverInfo;
@@ -215,7 +215,7 @@ CoverInfoRelative CoverArtUtils::selectCoverArtForTrack(
             coverInfoRelative.source = CoverInfo::GUESSED;
             coverInfoRelative.type = CoverInfo::FILE;
             // TODO() here we may introduce a duplicate hash code
-            coverInfoRelative.hash = calculateHash(image);
+            coverInfoRelative.hash = calculateProvisionalHash(image);
             coverInfoRelative.coverLocation = bestInfo->fileName();
             return coverInfoRelative;
         }

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -143,23 +143,17 @@ CoverInfo CoverArtUtils::selectCoverArtForTrack(
     const QString trackLocation = track.getLocation();
     CoverInfoRelative coverInfoRelative =
             selectCoverArtForTrack(trackBaseName, albumName, covers);
+
+
     return CoverInfo(coverInfoRelative, trackLocation);
 }
 
-//static
-CoverInfoRelative CoverArtUtils::selectCoverArtForTrack(
+const QFileInfo* CoverArtUtils::selectBestCoverFile(
+        const QLinkedList<QFileInfo>& covers,
         const QString& trackBaseName,
-        const QString& albumName,
-        const QLinkedList<QFileInfo>& covers) {
-    CoverInfoRelative coverInfoRelative;
-    coverInfoRelative.source = CoverInfo::GUESSED;
-    if (covers.isEmpty()) {
-        return coverInfoRelative;
-    }
-
+        const QString& albumName) {
     PreferredCoverType bestType = NONE;
     const QFileInfo* bestInfo = NULL;
-
     // If there is a single image then we use it unconditionally. Otherwise
     // we use the priority order described in PreferredCoverType. Notably,
     // if there are multiple image files in the folder we require they match
@@ -174,40 +168,53 @@ CoverInfoRelative CoverArtUtils::selectCoverArtForTrack(
         foreach (const QFileInfo& file, covers) {
             const QString coverBaseName = file.baseName();
             if (bestType > TRACK_BASENAME &&
-                coverBaseName.compare(trackBaseName,
-                                      Qt::CaseInsensitive) == 0) {
+                    coverBaseName.compare(trackBaseName,
+                            Qt::CaseInsensitive) == 0) {
                 bestType = TRACK_BASENAME;
                 bestInfo = &file;
                 // This is the best type so we know we're done.
                 break;
             } else if (bestType > ALBUM_NAME &&
-                       coverBaseName.compare(albumName,
-                                             Qt::CaseInsensitive) == 0) {
+                    coverBaseName.compare(albumName,
+                            Qt::CaseInsensitive) == 0) {
                 bestType = ALBUM_NAME;
                 bestInfo = &file;
             } else if (bestType > COVER &&
-                       coverBaseName.compare(QLatin1String("cover"),
-                                             Qt::CaseInsensitive) == 0) {
+                    coverBaseName.compare(QLatin1String("cover"),
+                            Qt::CaseInsensitive) == 0) {
                 bestType = COVER;
                 bestInfo = &file;
             } else if (bestType > FRONT &&
-                       coverBaseName.compare(QLatin1String("front"),
-                                             Qt::CaseInsensitive) == 0) {
+                    coverBaseName.compare(QLatin1String("front"),
+                            Qt::CaseInsensitive) == 0) {
                 bestType = FRONT;
                 bestInfo = &file;
             } else if (bestType > ALBUM &&
-                       coverBaseName.compare(QLatin1String("album"),
-                                             Qt::CaseInsensitive) == 0) {
+                    coverBaseName.compare(QLatin1String("album"),
+                            Qt::CaseInsensitive) == 0) {
                 bestType = ALBUM;
                 bestInfo = &file;
             } else if (bestType > FOLDER &&
-                       coverBaseName.compare(QLatin1String("folder"),
-                                             Qt::CaseInsensitive) == 0) {
+                    coverBaseName.compare(QLatin1String("folder"),
+                            Qt::CaseInsensitive) == 0) {
                 bestType = FOLDER;
                 bestInfo = &file;
             }
         }
     }
+    return bestInfo;
+}
+
+//static
+CoverInfoRelative CoverArtUtils::selectCoverArtForTrack(
+        const QString& trackBaseName,
+        const QString& albumName,
+        const QLinkedList<QFileInfo>& covers) {
+    CoverInfoRelative coverInfoRelative;
+    coverInfoRelative.source = CoverInfo::GUESSED;
+
+    const QFileInfo* bestInfo = selectBestCoverFile(
+            covers, trackBaseName, albumName);
 
     if (bestInfo != NULL) {
         QImage image(bestInfo->filePath());

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -56,17 +56,11 @@ class CoverArtUtils {
     static QLinkedList<QFileInfo> findPossibleCoversInFolder(
             const QString& folder);
 
-    // Selects an appropriate cover file from provided list of image files.
-    static CoverInfo selectCoverArtForTrack(
-            const Track& track,
-            const QLinkedList<QFileInfo>& covers);
-
     // Selects an appropriate cover file from provided list of image
     // files. Assumes a SecurityTokenPointer is held by the caller for all files
     // in 'covers'.
-    static CoverInfoRelative selectCoverArtForTrack(
-            const QString& trackBaseName,
-            const QString& albumName,
+    static CoverInfo selectCoverArtForTrack(
+            const Track& track,
             const QLinkedList<QFileInfo>& covers);
 
     static const QFileInfo* selectBestCoverFile(const QLinkedList<QFileInfo>& covers,

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -27,9 +27,14 @@ class CoverArtUtils {
             SecurityTokenPointer pToken);
 
     static QImage loadCover(const CoverInfo& info);
-    static quint16 calculateHash(const QImage& image) {
+
+    static quint16 calculateProvisionalHash(const QImage& image) {
         return qChecksum(reinterpret_cast<const char*>(image.constBits()),
                          image.byteCount());
+    }
+
+    static bool isHashProvisional(int hash) {
+        return hash <= CoverInfo::kMaxProvisionalHash;
     }
 
     static QStringList supportedCoverArtExtensions();

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -69,6 +69,8 @@ class CoverArtUtils {
             const QString& albumName,
             const QLinkedList<QFileInfo>& covers);
 
+    static const QFileInfo* selectBestCoverFile(const QLinkedList<QFileInfo>& covers,
+            const QString& trackBaseName, const QString& albumName);
 
   private:
     CoverArtUtils() {}

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1224,7 +1224,7 @@ bool setTrackCoverInfo(const QSqlRecord& record, const int column,
             record.value(column + 1).toInt(&ok));
     if (!ok) coverInfo.type = CoverInfo::NONE;
     coverInfo.coverLocation = record.value(column + 2).toString();
-    coverInfo.hash = record.value(column + 3).toUInt();
+    coverInfo.hash = record.value(column + 3).toInt();
     pTrack->setCoverInfo(coverInfo);
     return false;
 }
@@ -2155,7 +2155,7 @@ int TrackDAO::calculateUniqueCoverHash(const QImage& image) {
     while (!verifyCoverHashUnique(image, hash)) {
        hash += 0x10000;
        if (hash > 0xF0000) {
-           return -1;
+           return CoverInfo::kNoHash;
        }
     }
     return hash;

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -174,6 +174,7 @@ class TrackDAO : public QObject, public virtual DAO {
 
     bool verifyCoverHashUnique(const QImage& image, int hash);
     int calculateUniqueCoverHash(const QImage& image);
+    void makeTrackCoverHashUnique(Track* pTrack);
 
   signals:
     void trackDirty(TrackId trackId) const;

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -169,6 +169,9 @@ class TrackDAO : public QObject, public virtual DAO {
     void detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
                                         QSet<TrackId>* pTracksChanged);
 
+    bool verifyCoverHashUnique(const QImage& image, int hash);
+    int calculateUniqueCoverHash(const QImage& image);
+
   signals:
     void trackDirty(TrackId trackId) const;
     void trackClean(TrackId trackId) const;

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -166,8 +166,11 @@ class TrackDAO : public QObject, public virtual DAO {
             const QStringList& libraryRootDirs,
             volatile const bool* pCancel);
 
-    void detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
-                                        QSet<TrackId>* pTracksChanged);
+    void detectCoverArtForTracksUnknownCover(volatile const bool* pCancel,
+            QSet<TrackId>* pTracksChanged);
+
+    void makeAllCoverArtHashesUnique(volatile const bool* pCancel,
+            QSet<TrackId>* pTracksChanged);
 
     bool verifyCoverHashUnique(const QImage& image, int hash);
     int calculateUniqueCoverHash(const QImage& image);

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -336,7 +336,11 @@ void LibraryScanner::cleanUpScan() {
 
     qDebug() << "Detecting cover art for unscanned files.";
     QSet<TrackId> coverArtTracksChanged;
-    m_trackDao.detectCoverArtForTracksWithoutCover(
+    m_trackDao.detectCoverArtForTracksUnknownCover(
+            m_scannerGlobal->shouldCancelPointer(), &coverArtTracksChanged);
+
+    qDebug() << "Detecting cover art with provisional hashes.";
+    m_trackDao.makeAllCoverArtHashesUnique(
             m_scannerGlobal->shouldCancelPointer(), &coverArtTracksChanged);
 
     // Update BaseTrackCache via signals connected to the main TrackDAO.

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -465,7 +465,7 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
         if (!coverImg.isNull()) {
             // Cover image has been parsed from the file
             // TODO() here we may introduce a duplicate hash code
-            coverInfoRelative.hash = CoverArtUtils::calculateHash(coverImg);
+            coverInfoRelative.hash = CoverArtUtils::calculateProvisionalHash(coverImg);
             coverInfoRelative.coverLocation = QString();
             coverInfoRelative.type = CoverInfo::METADATA;
             coverInfoRelative.source = CoverInfo::GUESSED;

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -176,7 +176,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
 
     // looking for cover in an directory with one image will select that one.
     expected2.coverLocation = "foo.jpg";
-    expected2.hash = CoverArtUtils::calculateHash(QImage(cLoc_foo));
+    expected2.hash = CoverArtUtils::calculateProvisionalHash(QImage(cLoc_foo));
     covers << QFileInfo(cLoc_foo);
     CoverInfoRelative res2 = CoverArtUtils::selectCoverArtForTrack(
             trackBaseName, trackAlbum, covers);
@@ -248,7 +248,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
         } else {
             expected2.type = CoverInfo::FILE;
             expected2.coverLocation = cover.fileName();
-            expected2.hash = CoverArtUtils::calculateHash(QImage(cover.filePath()));
+            expected2.hash = CoverArtUtils::calculateProvisionalHash(QImage(cover.filePath()));
         }
         res2 = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
                                                     prefCovers);
@@ -276,7 +276,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
 
     res2 = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
                                                 prefCovers);
-    expected2.hash = CoverArtUtils::calculateHash(QImage(cLoc_coverJPG));
+    expected2.hash = CoverArtUtils::calculateProvisionalHash(QImage(cLoc_coverJPG));
     expected2.coverLocation = "cover.JPG";
     EXPECT_EQ(expected2, res2);
 
@@ -293,7 +293,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
     prefCovers.append(QFileInfo(cLoc_albumName));
     res2 = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
                                                 prefCovers);
-    expected2.hash = CoverArtUtils::calculateHash(QImage(cLoc_albumName));
+    expected2.hash = CoverArtUtils::calculateProvisionalHash(QImage(cLoc_albumName));
     expected2.coverLocation = trackAlbum % ".jpg";
     EXPECT_EQ(expected2, res2);
 
@@ -304,7 +304,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
     res2 = CoverArtUtils::selectCoverArtForTrack(trackBaseName, trackAlbum,
                                                 prefCovers);
 
-    expected2.hash = CoverArtUtils::calculateHash(QImage(cLoc_filename));
+    expected2.hash = CoverArtUtils::calculateProvisionalHash(QImage(cLoc_filename));
     expected2.coverLocation = trackBaseName % ".jpg";
     EXPECT_EQ(expected2, res2);
 

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -909,7 +909,7 @@ CoverInfo Track::getCoverInfo() const {
     return CoverInfo(m_coverInfoRelative, m_fileInfo.absoluteFilePath());
 }
 
-quint16 Track::getCoverHash() const {
+int Track::getCoverHash() const {
     QMutexLocker lock(&m_qMutex);
     return m_coverInfoRelative.hash;
 }

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -280,7 +280,7 @@ class Track : public QObject {
 
     CoverInfo getCoverInfo() const;
 
-    quint16 getCoverHash() const;
+    int getCoverHash() const;
 
     // Set/get track metadata and cover art (optional) all at once.
     void setTrackMetadata(

--- a/src/widget/wcoverartmenu.cpp
+++ b/src/widget/wcoverartmenu.cpp
@@ -83,7 +83,7 @@ void WCoverArtMenu::slotChange() {
     coverInfo.source = CoverInfo::USER_SELECTED;
     coverInfo.coverLocation = selectedCoverPath;
     // TODO() here we may introduce a duplicate hash code
-    coverInfo.hash = CoverArtUtils::calculateHash(image);
+    coverInfo.hash = CoverArtUtils::calculateProvisionalHash(image);
     coverInfo.trackLocation = m_coverInfo.trackLocation;
     qDebug() << "WCoverArtMenu::slotChange emit" << coverInfo;
     emit(coverInfoSelected(coverInfo));

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -927,7 +927,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
             last.sibling(last.row(), m_iCoverSourceColumn).data().toInt());
         info.type = static_cast<CoverInfo::Type>(
             last.sibling(last.row(), m_iCoverTypeColumn).data().toInt());
-        info.hash = last.sibling(last.row(), m_iCoverHashColumn).data().toUInt();
+        info.hash = last.sibling(last.row(), m_iCoverHashColumn).data().toInt();
         info.trackLocation = last.sibling(
             last.row(), m_iTrackLocationColumn).data().toString();
         info.coverLocation = last.sibling(


### PR DESCRIPTION
This is a fix for https://bugs.launchpad.net/mixxx/+bug/1607097

The cover swapping issue was caused by two cover arts with the same 16 bit hash code. 

This PR expands the has code to a 32 bit integer. The lower 16 bit are equal to the 16 bit hash of the old Mixxx, to maintain compatibility. 
The old hash <= 0xFFFF is now called provisional hash, the new >= 0x10000 one is the unique hash. 
The new TrackDAO::calculateUniqueCoverHash() function generates an provisional hash and increments the high word until there is no different cover in the database that uses the same hash. 
After 255 iteration it gives up, to avoid too long loops. 

During a library scan all provisional hashes are replaced by unique hashes.  

Since calculation the unique hash requires database and disk access, it cannot be done in any case from any thread. As a workaround covers for tracks in the track cache can uses the provisional hash for changed covers. The provisional hash is replaced by a unique hash before storing in the DB. 
I think that is OK for now, because there is only a theoretical risk for an ambiguous hash code among the view cashed tracks.  This remaining issue can be solved once we have an own DB thread. 

This PR is on top of the https://github.com/mixxxdj/mixxx/pull/990 branch 
we should merge it before to have less changes to review here, 
