### PR TITLE
TagLib: Don't (re-)add legacy ID3v1 tag to MP3 files

### DIFF
--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -316,7 +316,7 @@ bool BrowseTableModel::setData(const QModelIndex &index, const QVariant &value,
 
     QStandardItem* item = itemFromIndex(index);
     QString track_location(getTrackLocation(index));
-    if (OK == writeTrackMetadataIntoFile(trackMetadata, track_location)) {
+    if (OK == mixxx::taglib::writeTrackMetadataIntoFile(trackMetadata, track_location)) {
         // Modify underlying interalPointer object
         item->setText(value.toString());
         item->setToolTip(item->text());

--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -43,12 +43,12 @@ SoundSource::OpenResult SoundSource::open(const AudioSourceConfig& audioSrcCfg) 
 Result SoundSource::parseTrackMetadataAndCoverArt(
         TrackMetadata* pTrackMetadata,
         QImage* pCoverArt) const {
-    return readTrackMetadataAndCoverArtFromFile(pTrackMetadata, pCoverArt, getLocalFileName());
+    return taglib::readTrackMetadataAndCoverArtFromFile(pTrackMetadata, pCoverArt, getLocalFileName());
 }
 
 Result SoundSource::writeTrackMetadata(
         const TrackMetadata& trackMetadata) const {
-    return writeTrackMetadataIntoFile(trackMetadata, getLocalFileName());
+    return taglib::writeTrackMetadataIntoFile(trackMetadata, getLocalFileName());
 }
 
 } //namespace mixxx

--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -101,10 +101,10 @@ TEST_F(MetadataTest, ID3v2Year) {
             {
                 mixxx::TrackMetadata trackMetadata;
                 trackMetadata.setYear(year);
-                writeTrackMetadataIntoID3v2Tag(&tag, trackMetadata);
+                mixxx::taglib::writeTrackMetadataIntoID3v2Tag(&tag, trackMetadata);
             }
             mixxx::TrackMetadata trackMetadata;
-            readTrackMetadataFromID3v2Tag(&trackMetadata, tag);
+            mixxx::taglib::readTrackMetadataFromID3v2Tag(&trackMetadata, tag);
             if (4 > majorVersion) {
                 // ID3v2.3.0: parsed + formatted
                 const QString actualYear(trackMetadata.getYear());

--- a/src/test/taglibtest.cpp
+++ b/src/test/taglibtest.cpp
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+
+#include <QDir>
+#include <QFile>
+#include <QTemporaryFile>
+#include <QtDebug>
+
+#include "track/trackmetadatataglib.h"
+
+namespace {
+
+const QDir kTestDir(QDir::current().absoluteFilePath("src/test/id3-test-data"));
+
+class TagLibTest : public testing::Test {
+  protected:
+
+    TagLibTest() {
+    }
+
+    virtual void SetUp() {
+    }
+
+    virtual void TearDown() {
+    }
+};
+
+TEST_F(TagLibTest, WriteID3v2Tag) {
+    QTemporaryFile tmpFile("no_id3v1_mp3");
+
+    // Generate file name
+    ASSERT_TRUE(tmpFile.open());
+    ASSERT_TRUE(tmpFile.exists());
+    const QString tmpFileName(tmpFile.fileName());
+    tmpFile.close(); // close before copying
+
+    // Delete empty temporary file
+    ASSERT_TRUE(QFile::remove(tmpFileName));
+
+    // Copy original to temporary file
+    QFile copiedFile(tmpFileName);
+    ASSERT_FALSE(copiedFile.exists());
+    {
+        const QString origFileName(kTestDir.absoluteFilePath("empty.mp3"));
+        QFile origFile(origFileName);
+        ASSERT_TRUE(origFile.exists());
+        qDebug() << "Copying file"
+                << origFileName
+                << "->"
+                <<tmpFileName;
+        ASSERT_TRUE(origFile.copy(tmpFileName));
+        ASSERT_TRUE(copiedFile.exists());
+        ASSERT_EQ(copiedFile.size(), origFile.size());
+    }
+
+    // Verify that the file has no tags
+    {
+        TagLib::MPEG::File mpegFile(
+                TAGLIB_FILENAME_FROM_QSTRING(tmpFileName));
+        EXPECT_FALSE(mixxx::taglib::hasID3v1Tag(mpegFile));
+        EXPECT_FALSE(mixxx::taglib::hasID3v2Tag(mpegFile));
+        EXPECT_FALSE(mixxx::taglib::hasAPETag(mpegFile));
+    }
+
+    // Write metadata -> only an ID3v2 tag should be added
+    mixxx::TrackMetadata trackMetadata;
+    trackMetadata.setTitle("title");
+    ASSERT_EQ(OK, mixxx::taglib::writeTrackMetadataIntoFile(
+            trackMetadata, tmpFileName, mixxx::taglib::FileType::MP3));
+
+    // Check that the file only has an ID3v2 tag after writing metadata
+    {
+        TagLib::MPEG::File mpegFile(
+                TAGLIB_FILENAME_FROM_QSTRING(tmpFileName));
+        EXPECT_FALSE(mixxx::taglib::hasID3v1Tag(mpegFile));
+        EXPECT_TRUE(mixxx::taglib::hasID3v2Tag(mpegFile));
+        EXPECT_FALSE(mixxx::taglib::hasAPETag(mpegFile));
+    }
+
+    // Write metadata again -> only the ID3v2 tag should be modified
+    trackMetadata.setTitle("title2");
+    ASSERT_EQ(OK, mixxx::taglib::writeTrackMetadataIntoFile(
+            trackMetadata, tmpFileName, mixxx::taglib::FileType::MP3));
+
+    // Check that the file (still) only has an ID3v2 tag after writing metadata
+    {
+        TagLib::MPEG::File mpegFile(
+                TAGLIB_FILENAME_FROM_QSTRING(tmpFileName));
+        EXPECT_FALSE(mixxx::taglib::hasID3v1Tag(mpegFile));
+        EXPECT_TRUE(mixxx::taglib::hasID3v2Tag(mpegFile));
+        EXPECT_FALSE(mixxx::taglib::hasAPETag(mpegFile));
+    }
+}
+
+}  // anonymous namespace

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -1762,7 +1762,7 @@ Result writeTrackMetadataIntoFile(const TrackMetadata& trackMetadata, QString fi
         if (tagsWritten != TagLib::MPEG::File::NoTags) {
             anyTagsModified = true;
             if (pMPEGFile->hasID3v1Tag()) {
-                // Save the file using the using the generic function (see below)
+                // Save the file using the generic function (see below)
                 pFile = std::move(pMPEGFile); // transfer ownership
             } else {
                 // NOTE(uklotzde, 2016-07-27): Special case handling for

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -63,6 +63,8 @@ static_assert(sizeof(wchar_t) == sizeof(QChar), "wchar_t is not the same size th
 
 namespace mixxx {
 
+namespace taglib {
+
 namespace {
 
 const QString kFileTypeAIFF("aiff");
@@ -1781,5 +1783,7 @@ Result writeTrackMetadataIntoFile(const TrackMetadata& trackMetadata, QString fi
 
     return OK;
 }
+
+} // namespace taglib
 
 } //namespace mixxx

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -37,12 +37,10 @@
 #include <taglib/tstringlist.h>
 
 #include <taglib/mp4file.h>
-#include <taglib/flacfile.h>
 #include <taglib/vorbisfile.h>
 #if (TAGLIB_HAS_OPUSFILE)
 #include <taglib/opusfile.h>
 #endif
-#include <taglib/wavpackfile.h>
 #include <taglib/wavfile.h>
 #include <taglib/aifffile.h>
 
@@ -83,6 +81,30 @@ bool hasAPETag(TagLib::MPEG::File& file) {
 #endif
 }
 
+bool hasID3v2Tag(TagLib::FLAC::File& file) {
+#if (TAGLIB_HAS_TAG_CHECK)
+    return file.hasID3v2Tag();
+#else
+    return nullptr != file.ID3v2Tag();
+#endif
+}
+
+bool hasXiphComment(TagLib::FLAC::File& file) {
+#if (TAGLIB_HAS_TAG_CHECK)
+    return file.hasXiphComment();
+#else
+    return nullptr != file.xiphComment();
+#endif
+}
+
+bool hasAPETag(TagLib::WavPack::File& file) {
+#if (TAGLIB_HAS_TAG_CHECK)
+    return file.hasAPETag();
+#else
+    return nullptr != file.APETag();
+#endif
+}
+
 namespace {
 
 // Preferred picture types for cover art sorted by priority
@@ -98,30 +120,6 @@ const std::array<TagLib::FLAC::Picture::Type, 4> kPreferredVorbisCommentPictureT
         TagLib::FLAC::Picture::Illustration, // Illustration related to the track
         TagLib::FLAC::Picture::Other
 };
-
-inline bool hasID3v2Tag(TagLib::FLAC::File& file) {
-#if (TAGLIB_HAS_TAG_CHECK)
-    return file.hasID3v2Tag();
-#else
-    return nullptr != file.ID3v2Tag();
-#endif
-}
-
-inline bool hasXiphComment(TagLib::FLAC::File& file) {
-#if (TAGLIB_HAS_TAG_CHECK)
-    return file.hasXiphComment();
-#else
-    return nullptr != file.xiphComment();
-#endif
-}
-
-inline bool hasAPETag(TagLib::WavPack::File& file) {
-#if (TAGLIB_HAS_TAG_CHECK)
-    return file.hasAPETag();
-#else
-    return nullptr != file.APETag();
-#endif
-}
 
 // Deduce the file type from the file name
 FileType getFileTypeFromFileName(QString fileName) {

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -32,20 +32,10 @@
 #define TAGLIB_HAS_VORBIS_COMMENT_PICTURES \
     (TAGLIB_MAJOR_VERSION > 1) || ((TAGLIB_MAJOR_VERSION == 1) && (TAGLIB_MINOR_VERSION >= 11))
 
-#ifdef _WIN32
-static_assert(sizeof(wchar_t) == sizeof(QChar), "wchar_t is not the same size than QChar");
-#define TAGLIB_FILENAME_FROM_QSTRING(fileName) (const wchar_t*)fileName.utf16()
-// Note: we cannot use QString::toStdWString since QT 4 is compiled with
-// '/Zc:wchar_t-' flag and QT 5 not
-#else
-#define TAGLIB_FILENAME_FROM_QSTRING(fileName) (fileName).toLocal8Bit().constData()
-#endif // _WIN32
-
 #include <taglib/tfile.h>
 #include <taglib/tmap.h>
 #include <taglib/tstringlist.h>
 
-#include <taglib/mpegfile.h>
 #include <taglib/mp4file.h>
 #include <taglib/flacfile.h>
 #include <taglib/vorbisfile.h>
@@ -69,6 +59,30 @@ QDebug operator<<(QDebug debug, FileType fileType) {
     return debug << static_cast<std::underlying_type<FileType>::type>(fileType);
 }
 
+bool hasID3v1Tag(TagLib::MPEG::File& file) {
+#if (TAGLIB_HAS_TAG_CHECK)
+    return file.hasID3v1Tag();
+#else
+    return nullptr != file.ID3v1Tag();
+#endif
+}
+
+bool hasID3v2Tag(TagLib::MPEG::File& file) {
+#if (TAGLIB_HAS_TAG_CHECK)
+    return file.hasID3v2Tag();
+#else
+    return nullptr != file.ID3v2Tag();
+#endif
+}
+
+bool hasAPETag(TagLib::MPEG::File& file) {
+#if (TAGLIB_HAS_TAG_CHECK)
+    return file.hasAPETag();
+#else
+    return nullptr != file.APETag();
+#endif
+}
+
 namespace {
 
 // Preferred picture types for cover art sorted by priority
@@ -84,22 +98,6 @@ const std::array<TagLib::FLAC::Picture::Type, 4> kPreferredVorbisCommentPictureT
         TagLib::FLAC::Picture::Illustration, // Illustration related to the track
         TagLib::FLAC::Picture::Other
 };
-
-inline bool hasID3v2Tag(TagLib::MPEG::File& file) {
-#if (TAGLIB_HAS_TAG_CHECK)
-    return file.hasID3v2Tag();
-#else
-    return nullptr != file.ID3v2Tag();
-#endif
-}
-
-inline bool hasAPETag(TagLib::MPEG::File& file) {
-#if (TAGLIB_HAS_TAG_CHECK)
-    return file.hasAPETag();
-#else
-    return nullptr != file.APETag();
-#endif
-}
 
 inline bool hasID3v2Tag(TagLib::FLAC::File& file) {
 #if (TAGLIB_HAS_TAG_CHECK)

--- a/src/track/trackmetadatataglib.h
+++ b/src/track/trackmetadatataglib.h
@@ -13,6 +13,8 @@
 
 namespace mixxx {
 
+namespace taglib {
+
 // Read both track metadata and cover art of supported file types.
 // Both parameters are optional and might be NULL.
 Result readTrackMetadataAndCoverArtFromFile(TrackMetadata* pTrackMetadata, QImage* pCoverArt, QString fileName);
@@ -33,6 +35,8 @@ bool writeTrackMetadataIntoXiphComment(TagLib::Ogg::XiphComment* pTag,
         const TrackMetadata& trackMetadata);
 bool writeTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& trackMetadata);
 
-} //namespace mixxx
+} // namespace taglib
+
+} // namespace mixxx
 
 #endif

--- a/src/track/trackmetadatataglib.h
+++ b/src/track/trackmetadatataglib.h
@@ -15,12 +15,26 @@ namespace mixxx {
 
 namespace taglib {
 
+enum class FileType {
+    UNKNOWN,
+    AIFF,
+    FLAC,
+    MP3,
+    MP4,
+    OGG,
+    OPUS,
+    WAV,
+    WV
+};
+
+QDebug operator<<(QDebug debug, FileType fileType);
+
 // Read both track metadata and cover art of supported file types.
 // Both parameters are optional and might be NULL.
-Result readTrackMetadataAndCoverArtFromFile(TrackMetadata* pTrackMetadata, QImage* pCoverArt, QString fileName);
+Result readTrackMetadataAndCoverArtFromFile(TrackMetadata* pTrackMetadata, QImage* pCoverArt, QString fileName, FileType fileType = FileType::UNKNOWN);
 
 // Write track metadata into the file with the given name
-Result writeTrackMetadataIntoFile(const TrackMetadata& trackMetadata, QString fileName);
+Result writeTrackMetadataIntoFile(const TrackMetadata& trackMetadata, QString fileName, FileType fileType = FileType::UNKNOWN);
 
 // Low-level tag read/write functions are exposed only for testing purposes!
 void readTrackMetadataFromID3v2Tag(TrackMetadata* pTrackMetadata, const TagLib::ID3v2::Tag& tag);

--- a/src/track/trackmetadatataglib.h
+++ b/src/track/trackmetadatataglib.h
@@ -5,7 +5,10 @@
 #include <taglib/id3v2tag.h>
 #include <taglib/xiphcomment.h>
 #include <taglib/mp4tag.h>
+
+#include <taglib/flacfile.h>
 #include <taglib/mpegfile.h>
+#include <taglib/wavpackfile.h>
 
 #include <QImage>
 
@@ -59,9 +62,15 @@ static_assert(sizeof(wchar_t) == sizeof(QChar), "wchar_t is not the same size th
 #define TAGLIB_FILENAME_FROM_QSTRING(fileName) (fileName).toLocal8Bit().constData()
 #endif // _WIN32
 
+// Some helper functions for backwards compatibility with older
+// TagLib version that don't provide the corresponding member
+// functions for files.
 bool hasID3v1Tag(TagLib::MPEG::File& file);
 bool hasID3v2Tag(TagLib::MPEG::File& file);
 bool hasAPETag(TagLib::MPEG::File& file);
+bool hasID3v2Tag(TagLib::FLAC::File& file);
+bool hasXiphComment(TagLib::FLAC::File& file);
+bool hasAPETag(TagLib::WavPack::File& file);
 
 } // namespace taglib
 

--- a/src/track/trackmetadatataglib.h
+++ b/src/track/trackmetadatataglib.h
@@ -5,6 +5,7 @@
 #include <taglib/id3v2tag.h>
 #include <taglib/xiphcomment.h>
 #include <taglib/mp4tag.h>
+#include <taglib/mpegfile.h>
 
 #include <QImage>
 
@@ -48,6 +49,19 @@ bool writeTrackMetadataIntoAPETag(TagLib::APE::Tag* pTag, const TrackMetadata& t
 bool writeTrackMetadataIntoXiphComment(TagLib::Ogg::XiphComment* pTag,
         const TrackMetadata& trackMetadata);
 bool writeTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& trackMetadata);
+
+#ifdef _WIN32
+static_assert(sizeof(wchar_t) == sizeof(QChar), "wchar_t is not the same size than QChar");
+#define TAGLIB_FILENAME_FROM_QSTRING(fileName) (const wchar_t*)fileName.utf16()
+// Note: we cannot use QString::toStdWString since QT 4 is compiled with
+// '/Zc:wchar_t-' flag and QT 5 not
+#else
+#define TAGLIB_FILENAME_FROM_QSTRING(fileName) (fileName).toLocal8Bit().constData()
+#endif // _WIN32
+
+bool hasID3v1Tag(TagLib::MPEG::File& file);
+bool hasID3v2Tag(TagLib::MPEG::File& file);
+bool hasAPETag(TagLib::MPEG::File& file);
 
 } // namespace taglib
 


### PR DESCRIPTION
This PR fixes an unwanted behavior of TagLib when saving tags of MPEG files in Mixxx. First I added a new regression test that fails before actually fixing the unwanted behavior.

If you invoke the generic implementation TagLib::File::save() ID3v1 tags will be added, regardless if the file contains ID3v1 tags or not. If a file contains only ID3v2 or APE tags, but no ID3v1 tags you usually don't want to add them again! This can be accomplished by using the specialized variants of TagLib::MPEG::File::save() that provide fine-grained control about which tags are saved.
