### PR TITLE
add option to generate waveforms on analysis

### DIFF
--- a/src/analyzer/analyzerqueue.cpp
+++ b/src/analyzer/analyzerqueue.cpp
@@ -457,7 +457,7 @@ AnalyzerQueue* AnalyzerQueue::createAnalysisFeatureAnalyzerQueue(
         UserSettingsPointer pConfig, TrackCollection* pTrackCollection) {
     AnalyzerQueue* ret = new AnalyzerQueue(pTrackCollection);
 
-    if (pConfig->getValue<bool>(ConfigKey("[Library]", "GenerateWaveformsWithAnalysis"))) {
+    if (pConfig->getValue<bool>(ConfigKey("[Library]", "EnableWaveformGenerationWithAnalysis"))) {
         ret->addAnalyzer(new AnalyzerWaveform(pConfig));
     }
     ret->addAnalyzer(new AnalyzerGain(pConfig));

--- a/src/analyzer/analyzerqueue.cpp
+++ b/src/analyzer/analyzerqueue.cpp
@@ -457,6 +457,9 @@ AnalyzerQueue* AnalyzerQueue::createAnalysisFeatureAnalyzerQueue(
         UserSettingsPointer pConfig, TrackCollection* pTrackCollection) {
     AnalyzerQueue* ret = new AnalyzerQueue(pTrackCollection);
 
+    if (pConfig->getValue<bool>(ConfigKey("[Library]", "GenerateWaveformsWithAnalysis"))) {
+        ret->addAnalyzer(new AnalyzerWaveform(pConfig));
+    }
     ret->addAnalyzer(new AnalyzerGain(pConfig));
     ret->addAnalyzer(new AnalyzerEbur128(pConfig));
 #ifdef __VAMP__

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -112,12 +112,14 @@ void DlgPrefWaveform::slotUpdate() {
 
     WaveformSettings waveformSettings(m_pConfig);
     enableWaveformCaching->setChecked(waveformSettings.waveformCachingEnabled());
+    generateWaveformsWithAnalysis->setChecked(waveformSettings.waveformGenerateWithAnalysisEnabled());
     calculateCachedWaveformDiskUsage();
 }
 
 void DlgPrefWaveform::slotApply() {
     WaveformSettings waveformSettings(m_pConfig);
     waveformSettings.setWaveformCachingEnabled(enableWaveformCaching->isChecked());
+    waveformSettings.setWaveformGenerateWithAnalysisEnabled(generateWaveformsWithAnalysis->isChecked());
 }
 
 void DlgPrefWaveform::slotResetToDefaults() {

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -112,14 +112,16 @@ void DlgPrefWaveform::slotUpdate() {
 
     WaveformSettings waveformSettings(m_pConfig);
     enableWaveformCaching->setChecked(waveformSettings.waveformCachingEnabled());
-    generateWaveformsWithAnalysis->setChecked(waveformSettings.waveformGenerateWithAnalysisEnabled());
+    enableWaveformGenerationWithAnalysis->setChecked(
+        waveformSettings.waveformGenerationWithAnalysisEnabled());
     calculateCachedWaveformDiskUsage();
 }
 
 void DlgPrefWaveform::slotApply() {
     WaveformSettings waveformSettings(m_pConfig);
     waveformSettings.setWaveformCachingEnabled(enableWaveformCaching->isChecked());
-    waveformSettings.setWaveformGenerateWithAnalysisEnabled(generateWaveformsWithAnalysis->isChecked());
+    waveformSettings.setWaveformGenerationWithAnalysisEnabled(
+        enableWaveformGenerationWithAnalysis->isChecked());
 }
 
 void DlgPrefWaveform::slotResetToDefaults() {
@@ -156,6 +158,7 @@ void DlgPrefWaveform::slotResetToDefaults() {
 
     // Waveform caching enabled.
     enableWaveformCaching->setChecked(true);
+    enableWaveformGenerationWithAnalysis->setChecked(false);
 }
 
 void DlgPrefWaveform::slotSetFrameRate(int frameRate) {

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -452,7 +452,7 @@
        <item row="0" column="0" colspan="2">
         <widget class="QCheckBox" name="enableWaveformCaching">
          <property name="text">
-          <string>Enable Waveform Caching</string>
+          <string>Enable waveform caching</string>
          </property>
         </widget>
        </item>

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>536</width>
-    <height>390</height>
+    <height>445</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -422,7 +422,14 @@
      </item>
      <item row="8" column="1" colspan="3">
       <layout class="QGridLayout" name="cachingGridLayout">
-       <item row="1" column="0" colspan="2">
+       <item row="3" column="1">
+        <widget class="QPushButton" name="clearCachedWaveforms">
+         <property name="text">
+          <string>Clear Cached Waveforms</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
         <widget class="QLabel" name="waveformCachingInfo">
          <property name="text">
           <string>Mixxx caches the waveforms of your tracks on disk the first time you load a track. This reduces CPU usage when you are playing live but requires extra disk space.</string>
@@ -432,10 +439,13 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
-        <widget class="QPushButton" name="clearCachedWaveforms">
+       <item row="3" column="0">
+        <widget class="QLabel" name="waveformDiskUsage">
          <property name="text">
-          <string>Clear Cached Waveforms</string>
+          <string notr="true">PLACEHOLDER FOR DISK USAGE</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -446,13 +456,10 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="waveformDiskUsage">
+       <item row="1" column="0" colspan="2">
+        <widget class="QCheckBox" name="generateWaveformsWithAnalysis">
          <property name="text">
-          <string notr="true">PLACEHOLDER FOR DISK USAGE</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
+          <string>Generate waveforms when analyzing library</string>
          </property>
         </widget>
        </item>

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -457,7 +457,7 @@
         </widget>
        </item>
        <item row="1" column="0" colspan="2">
-        <widget class="QCheckBox" name="generateWaveformsWithAnalysis">
+        <widget class="QCheckBox" name="enableWaveformGenerationWithAnalysis">
          <property name="text">
           <string>Generate waveforms when analyzing library</string>
          </property>

--- a/src/preferences/waveformsettings.h
+++ b/src/preferences/waveformsettings.h
@@ -15,14 +15,14 @@ class WaveformSettings {
                 ConfigKey("[Library]", "EnableWaveformCaching"), enabled);
     }
 
-    bool waveformGenerateWithAnalysisEnabled() const {
+    bool waveformGenerationWithAnalysisEnabled() const {
         return m_pConfig->getValue<bool>(
-                ConfigKey("[Library]", "GenerateWaveformsWithAnalysis"), true);
+                ConfigKey("[Library]", "EnableWaveformGenerationWithAnalysis"), true);
     }
 
-    void setWaveformGenerateWithAnalysisEnabled(bool enabled) {
+    void setWaveformGenerationWithAnalysisEnabled(bool enabled) {
         m_pConfig->setValue<bool>(
-                ConfigKey("[Library]", "GenerateWaveformsWithAnalysis"), enabled);
+                ConfigKey("[Library]", "EnableWaveformGenerationWithAnalysis"), enabled);
     }
 
   private:

--- a/src/preferences/waveformsettings.h
+++ b/src/preferences/waveformsettings.h
@@ -15,6 +15,16 @@ class WaveformSettings {
                 ConfigKey("[Library]", "EnableWaveformCaching"), enabled);
     }
 
+    bool waveformGenerateWithAnalysisEnabled() const {
+        return m_pConfig->getValue<bool>(
+                ConfigKey("[Library]", "GenerateWaveformsWithAnalysis"), true);
+    }
+
+    void setWaveformGenerateWithAnalysisEnabled(bool enabled) {
+        m_pConfig->setValue<bool>(
+                ConfigKey("[Library]", "GenerateWaveformsWithAnalysis"), enabled);
+    }
+
   private:
     UserSettingsPointer m_pConfig;
 };


### PR DESCRIPTION
Taking care of https://bugs.launchpad.net/mixxx/+bug/1617589

Adds a new checkbox to Preferences > Interface > Waveforms > Caching:
![waveform-option](https://cloud.githubusercontent.com/assets/9455094/18210170/df3862ee-70fc-11e6-81c3-66a79b001906.png)
