### PR TITLE
show error text from PortAudio when there is an error setting up

### DIFF
--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -167,8 +167,6 @@ void SoundManager::closeDevices(bool sleepAfterClosing) {
 #endif
     }
 
-    m_pErrorDevice = NULL;
-
     // TODO(rryan): Should we do this before SoundDevice::close()? No! Because
     // then the callback may be running when we call
     // onInputDisconnected/onOutputDisconnected.
@@ -216,6 +214,7 @@ void SoundManager::clearDeviceList(bool sleepAfterClosing) {
         SoundDevice* dev = m_devices.takeLast();
         delete dev;
     }
+    m_pErrorDevice = NULL;
 
 #ifdef __PORTAUDIO__
     if (m_paInitialized) {


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/mixxx/+bug/1610551

DlgPrefSound::slotApply() relies on SoundManager's m_pErrorDevice being set for the error text shown when something goes wrong configuring the Sound Hardware Preferences. When an error occurrs, SoundManager::setupDevices() calls SoundManager::closeDevices(), which was setting m_pErrorDevice to NULL before DlgPrefSound::slotApply() could make use of it.
