### PR TITLE
SoundSourceFFmpeg: Cleanup/Extensions/Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
+      - libavformat-dev
       - libchromaprint-dev
       - libfaad-dev
       - libfftw3-dev
@@ -46,14 +47,14 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0         ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install scons portaudio libsndfile libogg libvorbis portmidi taglib libshout protobuf flac libjpeg qt chromaprint rubberband fftw libmodplug libid3tag libmad mp4v2 faad2 wavpack opusfile; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install scons portaudio libsndfile libogg libvorbis portmidi taglib libshout protobuf flac ffmpeg libjpeg qt chromaprint rubberband fftw libmodplug libid3tag libmad mp4v2 faad2 wavpack opusfile; fi
 
 install:
   ####
   # Common
 
   # Build flags common to OS X and Linux.
-  - export COMMON="test=1 localecompare=1 mad=1 faad=1 opus=1 modplug=1 wv=1 hss1394=0 virtualize=0 debug_assertions_fatal=1"
+  - export COMMON="test=1 localecompare=1 mad=1 faad=1 ffmpeg=1 opus=1 modplug=1 wv=1 hss1394=0 virtualize=0 debug_assertions_fatal=1"
 
   #####
   # Ubuntu Trusty Build

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -67,7 +67,9 @@ SINT getSamplingRate(AVStream* pStream) {
 inline
 SINT getFrameCount(AVStream* pStream) {
     // NOTE(uklotzde): Use 64-bit integer calculation to minimize rounding errors
-    return (static_cast<uint64_t>(pStream->time_base.num) * static_cast<uint64_t>(pStream->duration) * static_cast<uint64_t>(getSamplingRate(pStream))) /
+    return (static_cast<uint64_t>(pStream->time_base.num) *
+            pStream->duration *
+            static_cast<uint64_t>(getSamplingRate(pStream))) /
             static_cast<uint64_t>(pStream->time_base.den);
 }
 

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -39,7 +39,14 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileExtensions() const {
 
         qDebug() << "FFmpeg input format:" << l_SInputFmt->name;
 
-        if (!strcmp(l_SInputFmt->name, "flac")) {
+        if (!strcmp(l_SInputFmt->name, "ac3")) {
+            list.append("ac3");
+        } else if (!strcmp(l_SInputFmt->name, "aiff")) {
+                list.append("aif");
+                list.append("aiff");
+        } else if (!strcmp(l_SInputFmt->name, "caf")) {
+            list.append("caf");
+        } else if (!strcmp(l_SInputFmt->name, "flac")) {
             list.append("flac");
         } else if (!strcmp(l_SInputFmt->name, "ogg")) {
             list.append("ogg");
@@ -55,9 +62,17 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileExtensions() const {
         } else if (!strcmp(l_SInputFmt->name, "opus") ||
                    !strcmp(l_SInputFmt->name, "libopus")) {
             list.append("opus");
+        } else if (!strcmp(l_SInputFmt->name, "tak")) {
+            list.append("tak");
+        } else if (!strcmp(l_SInputFmt->name, "tta")) {
+            list.append("tta");
+        } else if (!strcmp(l_SInputFmt->name, "wav")) {
+            list.append("wav");
         } else if (!strcmp(l_SInputFmt->name, "wma") or
                    !strcmp(l_SInputFmt->name, "xwma")) {
             list.append("wma");
+        } else if (!strcmp(l_SInputFmt->name, "wv")) {
+            list.append("wv");
         }
     }
 

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -172,7 +172,6 @@ void SoundSourceFFmpeg::ClosableAVStreamPtr::close() {
 SoundSourceFFmpeg::SoundSourceFFmpeg(const QUrl& url)
     : SoundSource(url),
       m_pFormatCtx(nullptr),
-      m_pAudioStream(nullptr),
       m_pResample(nullptr),
       m_currentMixxxFrameIndex(0),
       m_bIsSeeked(false),

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -211,7 +211,7 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(const AudioSourceConfig& /*au
         return OpenResult::FAILED;
     }
     // TODO() why is this required, should't it be a runtime check
-#if LIBAVCODEC_VERSION_INT < 3622144 // 55.69.0
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55, 69, 0)
     m_pFormatCtx->max_analyze_duration = 999999999;
 #endif
 
@@ -332,11 +332,11 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
     while (l_iCount > 0) {
         if (l_pFrame != nullptr) {
             l_iFrameCount--;
-// FFMPEG 2.2 3561060 and beyond
-#if LIBAVCODEC_VERSION_INT >= 3561060
+// FFMPEG 2.2 and beyond
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(54, 86, 100)
             av_frame_free(&l_pFrame);
 // FFMPEG 0.11 and below
-#elif LIBAVCODEC_VERSION_INT <= 3544932
+#elif LIBAVCODEC_VERSION_INT <= AV_VERSION_INT(54, 23, 100)
             av_free(l_pFrame);
 // FFMPEG 1.0 - 2.1
 #else
@@ -351,7 +351,7 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
         }
         l_iFrameCount++;
         av_init_packet(&l_SPacket);
-#if LIBAVCODEC_VERSION_INT < 3617792
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55, 52, 0)
         l_pFrame = avcodec_alloc_frame();
 #else
         l_pFrame = av_frame_alloc();
@@ -506,12 +506,12 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
 
     if (l_pFrame != nullptr) {
         l_iFrameCount--;
-// FFMPEG 2.2 3561060 anb beyond
-#if LIBAVCODEC_VERSION_INT >= 3561060
+// FFMPEG 2.2 and beyond
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(54, 86, 100)
         av_frame_unref(l_pFrame);
         av_frame_free(&l_pFrame);
 // FFMPEG 0.11 and below
-#elif LIBAVCODEC_VERSION_INT <= 3544932
+#elif LIBAVCODEC_VERSION_INT <= AV_VERSION_INT(54, 23, 100)
         av_free(l_pFrame);
 // FFMPEG 1.0 - 2.1
 #else

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -33,18 +33,10 @@ AVMediaType getMediaType(AVStream* pStream) {
     return pStream->codec->codec_type;
 }
 
-AVStream* findNextAudioStream(AVFormatContext* pFormatCtx, AVStream* pStream = nullptr) {
+AVStream* findFirstAudioStream(AVFormatContext* pFormatCtx) {
     DEBUG_ASSERT(pFormatCtx != nullptr);
-    DEBUG_ASSERT((pStream == nullptr) || (static_cast<unsigned int>(pStream->index) < pFormatCtx->nb_streams));
-    DEBUG_ASSERT((pStream == nullptr) || (pStream == pFormatCtx->streams[pStream->index]));
-    unsigned int iNextStream;
-    if (pStream == nullptr) {
-        // Start search at the first stream
-        iNextStream = 0;
-    } else {
-        // Restart search at the following stream
-        iNextStream = pStream->index + 1;
-    }
+    // Start search at the first stream
+    unsigned int iNextStream = 0;
     while (iNextStream < pFormatCtx->nb_streams) {
         AVStream* pNextStream = pFormatCtx->streams[iNextStream];
         if (getMediaType(pNextStream) == AVMEDIA_TYPE_AUDIO) {
@@ -55,11 +47,6 @@ AVStream* findNextAudioStream(AVFormatContext* pFormatCtx, AVStream* pStream = n
         }
     }
     return nullptr;
-}
-
-inline
-AVStream* findFirstAudioStream(AVFormatContext* pFormatCtx) {
-    return findNextAudioStream(pFormatCtx);
 }
 
 inline

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -5,6 +5,9 @@
 #include <mutex>
 #include <vector>
 
+#define LIBAVCODEC_HAS_AV_PACKET_UNREF \
+    (LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 8, 0))
+
 #define AUDIOSOURCEFFMPEG_CACHESIZE 1000
 #define AUDIOSOURCEFFMPEG_MIXXXFRAME_TO_BYTEOFFSET(numFrames) (frames2samples(numFrames) * sizeof(CSAMPLE))
 #define AUDIOSOURCEFFMPEG_BYTEOFFSET_TO_MIXXXFRAME(byteOffset) (samples2frames(byteOffset / sizeof(CSAMPLE)))
@@ -351,7 +354,11 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
 
                     // Seek for correct jump point
                     if (m_lStoredSeekPoint > l_SPacket.pos) {
+#if (LIBAVCODEC_HAS_AV_PACKET_UNREF)
+                        av_packet_unref(&l_SPacket);
+#else
                         av_free_packet(&l_SPacket);
+#endif
                         l_SPacket.data = nullptr;
                         l_SPacket.size = 0;
                         continue;
@@ -445,7 +452,11 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
                     }
                 }
 
+#if (LIBAVCODEC_HAS_AV_PACKET_UNREF)
+                av_packet_unref(&l_SPacket);
+#else
                 av_free_packet(&l_SPacket);
+#endif
                 l_SPacket.data = nullptr;
                 l_SPacket.size = 0;
 

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -78,6 +78,8 @@ class SoundSourceFFmpeg : public SoundSource {
             close();
         }
 
+        void take(AVFormatContext** ppClosableInputFormatContext);
+
         void close();
 
         friend void swap(ClosableInputAVFormatContextPtr& lhs, ClosableInputAVFormatContextPtr& rhs) {
@@ -118,6 +120,7 @@ class SoundSourceFFmpeg : public SoundSource {
             close();
         }
 
+        void take(AVStream** ppClosableStream);
         void close();
 
         friend void swap(ClosableAVStreamPtr& lhs, ClosableAVStreamPtr& rhs) {

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -66,7 +66,7 @@ class SoundSourceFFmpeg : public SoundSource {
 
     // Takes ownership of an opened (audio) stream and ensures that
     // the corresponding AVStream is closed, either explicitly or
-    // implicitly by the destructor. The object can only be moved,
+    // implicitly by the destructor. The wrapper can only be moved,
     // copying is disabled.
     class ClosableAVStreamPtr final {
     public:
@@ -84,10 +84,13 @@ class SoundSourceFFmpeg : public SoundSource {
 
         void close();
 
+        friend void swap(ClosableAVStreamPtr& lhs, ClosableAVStreamPtr& rhs) {
+            std::swap(lhs.m_pClosableStream, rhs.m_pClosableStream);
+        }
+
         ClosableAVStreamPtr& operator=(const ClosableAVStreamPtr&) = delete;
         ClosableAVStreamPtr& operator=(ClosableAVStreamPtr&& that) {
-            m_pClosableStream = that.m_pClosableStream;
-            that.m_pClosableStream = nullptr;
+            swap(*this, that);
             return *this;
         }
 

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -3,7 +3,6 @@
 
 extern "C" {
 
-#include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 
 #ifndef __FFMPEGOLDAPI__
@@ -61,10 +60,12 @@ class SoundSourceFFmpeg : public SoundSource {
 
     unsigned int read(unsigned long size, SAMPLE*);
 
-    AVFormatContext *m_pFormatCtx;
-    int m_iAudioStream;
-    AVCodecContext *m_pCodecCtx;
-    AVCodec *m_pCodec;
+    AVFormatContext* m_pFormatCtx;
+
+    AVStream* m_pAudioStream;
+
+    static OpenResult openAudioStream(AVStream* pAudioStream);
+    static void closeAudioStream(AVStream** ppAudioStream);
 
     std::unique_ptr<EncoderFfmpegResample> m_pResample;
 

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -60,6 +60,8 @@ class SoundSourceFFmpeg : public SoundSource {
 
     unsigned int read(unsigned long size, SAMPLE*);
 
+    static AVFormatContext* openInputFile(const QString& fileName);
+
     // Takes ownership of an input format context and ensures that
     // the corresponding AVFormatContext is closed, either explicitly
     // or implicitly by the destructor. The wrapper can only be

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -87,10 +87,7 @@ class SoundSourceFFmpeg : public SoundSource {
         }
 
         ClosableInputAVFormatContextPtr& operator=(const ClosableInputAVFormatContextPtr&) = delete;
-        ClosableInputAVFormatContextPtr& operator=(ClosableInputAVFormatContextPtr&& that) {
-            swap(*this, that);
-            return *this;
-        }
+        ClosableInputAVFormatContextPtr& operator=(ClosableInputAVFormatContextPtr&& that) = delete;
 
         AVFormatContext* operator->() { return m_pClosableInputFormatContext; }
         operator AVFormatContext*() { return m_pClosableInputFormatContext; }
@@ -128,10 +125,7 @@ class SoundSourceFFmpeg : public SoundSource {
         }
 
         ClosableAVStreamPtr& operator=(const ClosableAVStreamPtr&) = delete;
-        ClosableAVStreamPtr& operator=(ClosableAVStreamPtr&& that) {
-            swap(*this, that);
-            return *this;
-        }
+        ClosableAVStreamPtr& operator=(ClosableAVStreamPtr&& that) = delete;
 
         AVStream* operator->() { return m_pClosableStream; }
         operator AVStream*() { return m_pClosableStream; }

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -2,23 +2,11 @@
 
 #include "sources/soundsourceproxy.h"
 
-#ifdef __FFMPEGFILE__
-extern "C" {
-#include <libavcodec/avcodec.h>
-#include <libavformat/avformat.h>
-}
-#endif
-
 // Static initialization
 QScopedPointer<MixxxApplication> MixxxTest::s_pApplication;
 
 MixxxTest::ApplicationScope::ApplicationScope(int& argc, char** argv) {
     DEBUG_ASSERT(!s_pApplication);
-
-#ifdef __FFMPEGFILE__
-    av_register_all();
-    avcodec_register_all();
-#endif
 
     s_pApplication.reset(new MixxxApplication(argc, argv));
 

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -131,15 +131,6 @@ TEST_F(SoundSourceProxyTest, seekForward) {
         SampleBuffer contReadData(readSampleCount);
         SampleBuffer seekReadData(readSampleCount);
 
-#ifdef __FFMPEGFILE__
-        if (dynamic_cast<mixxx::SoundSourceFFmpeg*>(&*pContReadSource)) {
-            if (filePath.endsWith(".mp3")) {
-                qDebug() << "Skip test since it will fail using SoundSourceFFmpeg";
-                continue;
-            }
-        }
-#endif
-
         for (SINT contFrameIndex = 0;
                 pContReadSource->isValidFrameIndex(contFrameIndex);
                 contFrameIndex += kReadFrameCount) {


### PR DESCRIPTION
Please refer to the individual commits for a summary.

The main work is around opening and closing of FFmpeg audio streams in SoundSourceFFmpeg. I also improved the error handling and reporting. No more TODO comments with open questions in the code. SoundSourceFFmpeg now has fewer class members with obvious dependencies among each other and a simplified lifecycle.

[2016-09-10] I've enabled FFmpeg on Travis by setting ffmpeg=1 . Unfortunately the ancient version of libav in Ubuntu 14.04 fails to deocde our .m4a test file.

[2016-09-11] Tests for Ubuntu Trusty on Travis fixed.
[2016-09-11] Tests for OS X on Travis stalled as before.
