### PR TITLE
rework keySortSQL to work with columnSortForFieldIndex() without a warning

### DIFF
--- a/src/library/columncache.cpp
+++ b/src/library/columncache.cpp
@@ -187,7 +187,7 @@ void ColumnCache::slotSetKeySortOrder(double notationValue) {
     QString keySortSQL("CASE %1_id WHEN NULL THEN 0 ");
     for (int i = 0; i <= 24; ++i) {
             keySortSQL.append(QString("WHEN %1 THEN %2 ")
-                .arg(sortOrder[i]).arg(i));
+                .arg(QString::number(sortOrder[i]), QString::number(i)));
     }
     keySortSQL.append("END");
 

--- a/src/library/columncache.cpp
+++ b/src/library/columncache.cpp
@@ -181,7 +181,7 @@ void ColumnCache::slotSetKeySortOrder(double notation) {
     // A custom COLLATE function was tested, but using CASE ... WHEN was found to be faster
     // see GitHub PR#649
     // https://github.com/mixxxdj/mixxx/pull/649#discussion_r34863809
-    QString keySortSQL("CASE key_id ");
+    QString keySortSQL("CASE %1_id WHEN NULL THEN 0 ");
     for (int i = 0; i <= 24; ++i) {
             keySortSQL.append(QString("WHEN %1 THEN %2 ")
                 .arg(sortOrder[i]).arg(i));

--- a/src/library/columncache.cpp
+++ b/src/library/columncache.cpp
@@ -94,12 +94,9 @@ void ColumnCache::setColumns(const QStringList& columns) {
     m_columnSortByIndex.insert(m_columnIndexByEnum[COLUMN_PLAYLISTTRACKSTABLE_TITLE], sortNoCase);
 }
 
-void ColumnCache::slotSetKeySortOrder(double notationValue) {
-    // MSVC++ 2013 requires casting to int before enum
-    KeyUtils::KeyNotation notation = static_cast<KeyUtils::KeyNotation>(
-                                       static_cast<int>(notationValue));
+void ColumnCache::slotSetKeySortOrder(double notation) {
     std::vector<mixxx::track::io::key::ChromaticKey> sortOrder;
-    if (notation != KeyUtils::LANCELOT) {
+    if (notation != static_cast<double>(KeyUtils::LANCELOT)) {
         sortOrder = {
             mixxx::track::io::key::INVALID,
 

--- a/src/library/columncache.cpp
+++ b/src/library/columncache.cpp
@@ -94,9 +94,12 @@ void ColumnCache::setColumns(const QStringList& columns) {
     m_columnSortByIndex.insert(m_columnIndexByEnum[COLUMN_PLAYLISTTRACKSTABLE_TITLE], sortNoCase);
 }
 
-void ColumnCache::slotSetKeySortOrder(double notation) {
+void ColumnCache::slotSetKeySortOrder(double notationValue) {
+    // MSVC++ 2013 requires casting to int before enum
+    KeyUtils::KeyNotation notation = static_cast<KeyUtils::KeyNotation>(
+                                       static_cast<int>(notationValue));
     std::vector<mixxx::track::io::key::ChromaticKey> sortOrder;
-    if (static_cast<KeyUtils::KeyNotation>(notation) != KeyUtils::LANCELOT) {
+    if (notation != KeyUtils::LANCELOT) {
         sortOrder = {
             mixxx::track::io::key::INVALID,
 


### PR DESCRIPTION
Takes care of log warning reported at https://github.com/mixxxdj/mixxx/pull/1000#issuecomment-245708557
