### PR TITLE
re-enable waveform generation on analysis by default

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -158,7 +158,7 @@ void DlgPrefWaveform::slotResetToDefaults() {
 
     // Waveform caching enabled.
     enableWaveformCaching->setChecked(true);
-    enableWaveformGenerationWithAnalysis->setChecked(false);
+    enableWaveformGenerationWithAnalysis->setChecked(true);
 }
 
 void DlgPrefWaveform::slotSetFrameRate(int frameRate) {


### PR DESCRIPTION
I have about 4000 tracks in my library and all my waveform data takes 2.5 GB. I used to run Mixxx with a 23.2 ms audio buffer because the load would spike when I loaded tracks from the waveform generation. Now I can now run Mixxx with a 1.45 ms buffer with Soundtouch. Using Rubberband I can use a 2.9 ms buffer with an occasional xrun or 5.8 ms without xruns. This is with a Core i5 2410M running Linux with the realtime patch set. I'm kinda surprised we haven't gotten more complaints about audible dropouts on track load since 2.0 was released.

IMO trading off a bit of disk space for lower latency and better reliability of the audio is well worth it. I think turning this option off only makes sense for storage constrained systems with powerful processors, which I don't think is a very common situation. Storage is cheap, so I think CPUs are more often the bottleneck.
