### PR TITLE
fix realtime scheduling notice overlapping other text

### DIFF
--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -282,7 +282,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="3" column="0" colspan="2">
        <widget class="QLabel" name="limitsHint">
         <property name="text">
          <string>Enable Real-Time scheduling (currently disabled), see the &lt;a href=&quot;http://mixxx.org/wiki/doku.php/adjusting_audio_latency&quot;&gt;Mixxx Wiki&lt;/a&gt;.</string>
@@ -295,7 +295,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="4" column="0" colspan="2">
        <widget class="QLabel" name="hardwareGuide">
         <property name="text">
          <string>The &lt;a href=&quot;http://mixxx.org/wiki/doku.php/hardware_compatibility&quot;&gt;Mixxx DJ Hardware Guide&lt;/a&gt; lists sound cards and controllers you may want to consider for using Mixxx.</string>
@@ -308,14 +308,14 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <widget class="Line" name="line">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="6" column="0">
         <widget class="QLabel" name="latencyLabel">
          <property name="text">
           <string>System Reported Latency</string>
@@ -325,14 +325,14 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="6" column="1">
         <widget class="QLabel" name="currentLatency">
          <property name="text">
           <string>20 ms</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="underflowLabel">
          <property name="text">
           <string>Buffer Underflow Count</string>
@@ -342,7 +342,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="7" column="1">
         <widget class="QLabel" name="bufferUnderflowCount">
          <property name="text">
           <string>0</string>


### PR DESCRIPTION
2.0 and master:
![realtime-text-overlapping](https://cloud.githubusercontent.com/assets/9455094/18452200/a30b1496-78ff-11e6-8148-c8907a7fd6c6.png)
This PR:
![realtime-text-fixed](https://cloud.githubusercontent.com/assets/9455094/18452205/a6df5ece-78ff-11e6-98ca-049f94fd4446.png)
Either with realtime priority:
![realtime-text-hidden](https://cloud.githubusercontent.com/assets/9455094/18452207/a802f19e-78ff-11e6-8280-fbb424c6167d.png)
