### PR TITLE
VS 2013 Compile Error: Fix wrong usage of std::unique_ptr

### DIFF
--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -5,10 +5,6 @@
 
 #include "waveformmark.h"
 
-WaveformMark::WaveformMark()
-    : m_iHotCue(-1) {
-}
-
 WaveformMark::WaveformMark(int hotCue)
     : m_iHotCue(hotCue) {
 }

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -9,6 +9,10 @@ WaveformMark::WaveformMark(int hotCue)
     : m_iHotCue(hotCue) {
 }
 
+void WaveformMark::reset(int hotCue) {
+    WaveformMark(hotCue).swap(*this);
+}
+
 void WaveformMark::setup(const QString& group, const QDomNode& node,
                          const SkinContext& context,
                          const WaveformSignalColors& signalColors) {

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -18,6 +18,21 @@ class WaveformMark {
 
     explicit WaveformMark(int hotCue = kDefaultHotCue);
 
+    // Disable copying
+    WaveformMark(const WaveformMark&) = delete;
+    WaveformMark& operator=(const WaveformMark&) = delete;
+
+    // Enable swapping
+    void swap(WaveformMark& that) {
+        std::swap(m_pPointCos, that.m_pPointCos);
+        std::swap(m_properties, that.m_properties);
+        std::swap(m_iHotCue, that.m_iHotCue);
+        std::swap(m_image, that.m_image);
+    }
+    friend void swap(WaveformMark& lhs, WaveformMark& rhs) {
+        lhs.swap(rhs);
+    }
+
     void setup(const QString& group, const QDomNode& node,
                const SkinContext& context,
                const WaveformSignalColors& signalColors);

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -33,6 +33,8 @@ class WaveformMark {
         lhs.swap(rhs);
     }
 
+    void reset(int hotCue = kDefaultHotCue);
+
     void setup(const QString& group, const QDomNode& node,
                const SkinContext& context,
                const WaveformSignalColors& signalColors);

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -14,8 +14,9 @@ class WaveformSignalColors;
 
 class WaveformMark {
   public:
-    WaveformMark();
-    WaveformMark(int hotCue);
+    static const int kDefaultHotCue = -1;
+
+    explicit WaveformMark(int hotCue = kDefaultHotCue);
 
     void setup(const QString& group, const QDomNode& node,
                const SkinContext& context,

--- a/src/waveform/renderers/waveformmarkset.cpp
+++ b/src/waveform/renderers/waveformmarkset.cpp
@@ -80,7 +80,7 @@ void WaveformMarkSet::setup(const QString& group, const QDomNode& node,
 }
 
 void WaveformMarkSet::clear() {
-    m_defaultMark = WaveformMark();
+    m_defaultMark.reset();
     m_marks.clear();
 }
 


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1623128

Allowing direct access of the public member m_pPointCos is still unsafe.
