### PR TITLE
coverart.cpp: fix build

### DIFF
--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -1,5 +1,5 @@
 #include <QtDebug>
-#include <QLatin1Literal>
+#include <QStringBuilder>
 
 #include "library/coverart.h"
 #include "library/coverartutils.h"
@@ -32,15 +32,15 @@ QString typeToString(CoverInfo::Type type) {
 }
 
 QString coverInfoRelativeToString(const CoverInfoRelative& infoRelative) {
-    return typeToString(infoRelative.type) % QLatin1Literal(",") %
-           sourceToString(infoRelative.source) % QLatin1Literal(",") %
-           infoRelative.coverLocation % QLatin1Literal(",") %
-           QLatin1Literal("0x") % QString::number(infoRelative.hash, 16);
+    return typeToString(infoRelative.type) % "," %
+           sourceToString(infoRelative.source) % "," %
+           infoRelative.coverLocation % "," %
+           "0x" % QString::number(infoRelative.hash, 16);
 }
 
 QString coverInfoToString(const CoverInfo& info) {
-    return coverInfoRelativeToString(info) % QLatin1Literal(",") %
-           info.trackLocation % QLatin1Literal(",");
+    return coverInfoRelativeToString(info) % "," %
+           info.trackLocation % ",";
 }
 } // anonymous namespace
 


### PR DESCRIPTION
fixes build for Qt5.7:

src/library/coverart.cpp:35:44: error: no match for 'operator%' (operand types are 'QString' and 'QLatin1Literal {aka QLatin1String}')
     return typeToString(infoRelative.type) % QLatin1Literal(",") %
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
src/library/coverart.cpp: In function 'QString {anonymous}::coverInfoToString(const CoverInfo&)':
src/library/coverart.cpp:42:44: error: no match for 'operator%' (operand types are 'QString' and 'QLatin1Literal {aka QLatin1String}')
     return coverInfoRelativeToString(info) % QLatin1Literal(",") %
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~

Thanks Daniel Schürmann for review and helpful hints to get this patch into
correct shape [1].

[1] https://sourceforge.net/p/mixxx/mailman/message/35384430/

Signed-off-by: Andreas Müller schnitzeltony@googlemail.com
