### PR TITLE
New version of DJ console 4mx mapping

### DIFF
--- a/res/controllers/Hercules DJ Console 4-Mx.midi.xml
+++ b/res/controllers/Hercules DJ Console 4-Mx.midi.xml
@@ -83,14 +83,11 @@
                 </options>
             </control>
             <control>
-                <group>[Microphone]</group>
-                <key>talkover</key>
+                <group></group>
+                <key></key>
                 <description>Button Mic On/Off (state)</description>
                 <status>0x90</status>
                 <midino>0x47</midino>
-                <options>
-                    <switch/>
-                </options>
             </control>
             <control>
                 <group>[Channel2]</group>

--- a/res/controllers/Hercules DJ Console 4-Mx.midi.xml
+++ b/res/controllers/Hercules DJ Console 4-Mx.midi.xml
@@ -63,23 +63,23 @@
                 </options>
             </control>
             <control>
-                <group></group>
-                <key></key>
+                <group>[Master]</group>
+                <key>Hercules4Mx.deckDStateChange</key>
                 <description>Button Deck D (State)</description>
                 <status>0x90</status>
                 <midino>0x49</midino>
                 <options>
-                    <switch/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
-                <group></group>
-                <key></key>
+                <group>[Master]</group>
+                <key>Hercules4Mx.deckCStateChange</key>
                 <description>Button Deck C (State)</description>
                 <status>0x90</status>
                 <midino>0x48</midino>
                 <options>
-                    <switch/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -94,82 +94,82 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>fwd</key>
+                <key>Hercules4Mx.forwardButton</key>
                 <description>Right Forward</description>
                 <status>0x90</status>
                 <midino>0x46</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>fwd</key>
+                <key>Hercules4Mx.forwardButton</key>
                 <description>Right Forward</description>
                 <status>0x91</status>
                 <midino>0x46</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>back</key>
+                <key>Hercules4Mx.rewindButton</key>
                 <description>Right Rewind</description>
                 <status>0x90</status>
                 <midino>0x45</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>back</key>
+                <key>Hercules4Mx.rewindButton</key>
                 <description>Right Rewind</description>
                 <status>0x91</status>
                 <midino>0x45</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>rate_temp_up</key>
+                <key>Hercules4Mx.pBendUpButton</key>
                 <description>Right P. Bend +</description>
                 <status>0x90</status>
                 <midino>0x44</midino>
                 <options>
-                    <button/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>rate_temp_down</key>
+                <key>Hercules4Mx.pBendDownButton</key>
                 <description>Right P. Bend -</description>
                 <status>0x90</status>
                 <midino>0x43</midino>
                 <options>
-                    <button/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>rate_temp_up</key>
+                <key>Hercules4Mx.pBendUpButton</key>
                 <description>Right P. Bend +</description>
                 <status>0x91</status>
                 <midino>0x44</midino>
                 <options>
-                    <button/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>rate_temp_down</key>
+                <key>Hercules4Mx.pBendDownButton</key>
                 <description>Right P. Bend -</description>
                 <status>0x91</status>
                 <midino>0x43</midino>
                 <options>
-                    <button/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -214,7 +214,7 @@
             </control>
             <control>
                 <group>[Playlist]</group>
-                <key>Hercules4Mx.navigation</key>
+                <key>Hercules4Mx.navigationFolders</key>
                 <description>Button Nav Folder</description>
                 <status>0x90</status>
                 <midino>0x3F</midino>
@@ -224,7 +224,7 @@
             </control>
             <control>
                 <group>[Playlist]</group>
-                <key>Hercules4Mx.navigation</key>
+                <key>Hercules4Mx.navigationFiles</key>
                 <description>Button Nav Files</description>
                 <status>0x90</status>
                 <midino>0x3E</midino>
@@ -394,42 +394,42 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>pitch_adjust_down_small</key>
+                <key>Hercules4Mx.pScaleDownButton</key>
                 <description>Right Pitch scale-</description>
                 <status>0x90</status>
                 <midino>0x34</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>pitch_adjust_down_small</key>
+                <key>Hercules4Mx.pScaleDownButton</key>
                 <description>Right Pitch scale-</description>
                 <status>0x91</status>
                 <midino>0x34</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>pitch_adjust_up_small</key>
+                <key>Hercules4Mx.pScaleUpButton</key>
                 <description>Right Pitch scale+</description>
                 <status>0x90</status>
                 <midino>0x33</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>pitch_adjust_up_small</key>
+                <key>Hercules4Mx.pScaleUpButton</key>
                 <description>Right Pitch scale+</description>
                 <status>0x91</status>
                 <midino>0x33</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -444,22 +444,22 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>sync_enabled</key>
+                <key>Hercules4Mx.syncButton</key>
                 <description>Right Sync button</description>
                 <status>0x90</status>
                 <midino>0x31</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>sync_enabled</key>
+                <key>Hercules4Mx.syncButton</key>
                 <description>Right Sync button</description>
                 <status>0x91</status>
                 <midino>0x31</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -504,22 +504,22 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>play</key>
+                <key>Hercules4Mx.playButton</key>
                 <description>Right Play</description>
                 <status>0x90</status>
                 <midino>0x2E</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>play</key>
+                <key>Hercules4Mx.playButton</key>
                 <description>Right Play</description>
                 <status>0x91</status>
                 <midino>0x2E</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -794,82 +794,82 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>fwd</key>
+                <key>Hercules4Mx.forwardButton</key>
                 <description>Left Forward</description>
                 <status>0x90</status>
                 <midino>0x20</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>fwd</key>
+                <key>Hercules4Mx.forwardButton</key>
                 <description>Left Forward</description>
                 <status>0x91</status>
                 <midino>0x20</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>back</key>
+                <key>Hercules4Mx.rewindButton</key>
                 <description>Left Rewind</description>
                 <status>0x90</status>
                 <midino>0x1F</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>back</key>
+                <key>Hercules4Mx.rewindButton</key>
                 <description>Left Rewind</description>
                 <status>0x91</status>
                 <midino>0x1F</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>rate_temp_up</key>
+                <key>Hercules4Mx.pBendUpButton</key>
                 <description>Left P.Bend +</description>
                 <status>0x90</status>
                 <midino>0x1E</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>rate_temp_up</key>
+                <key>Hercules4Mx.pBendUpButton</key>
                 <description>Left P.Bend +</description>
                 <status>0x91</status>
                 <midino>0x1E</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>rate_temp_down</key>
+                <key>Hercules4Mx.pBendDownButton</key>
                 <description>Left P.Bend -</description>
                 <status>0x90</status>
                 <midino>0x1D</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>rate_temp_down</key>
+                <key>Hercules4Mx.pBendDownButton</key>
                 <description>Left P.Bend -</description>
                 <status>0x91</status>
                 <midino>0x1D</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -1034,42 +1034,42 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>pitch_adjust_down_small</key>
+                <key>Hercules4Mx.pScaleDownButton</key>
                 <description>Left Pitch scale-</description>
                 <status>0x90</status>
                 <midino>0x14</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>pitch_adjust_down_small</key>
+                <key>Hercules4Mx.pScaleDownButton</key>
                 <description>Left Pitch scale-</description>
                 <status>0x91</status>
                 <midino>0x14</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>pitch_adjust_up_small</key>
+                <key>Hercules4Mx.pScaleUpButton</key>
                 <description>Left Pitch scale+</description>
                 <status>0x90</status>
                 <midino>0x13</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>pitch_adjust_up_small</key>
+                <key>Hercules4Mx.pScaleUpButton</key>
                 <description>Left Pitch scale+</description>
                 <status>0x91</status>
                 <midino>0x13</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -1084,22 +1084,22 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>sync_enabled</key>
+                <key>Hercules4Mx.syncButton</key>
                 <description>Left Sync button</description>
                 <status>0x90</status>
                 <midino>0x11</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>sync_enabled</key>
+                <key>Hercules4Mx.syncButton</key>
                 <description>Left Sync button</description>
                 <status>0x91</status>
                 <midino>0x11</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -1144,22 +1144,22 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>play</key>
+                <key>Hercules4Mx.playButton</key>
                 <description>Left Play</description>
                 <status>0x90</status>
                 <midino>0x0E</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>play</key>
+                <key>Hercules4Mx.playButton</key>
                 <description>Left Play</description>
                 <status>0x91</status>
                 <midino>0x0E</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -1194,7 +1194,7 @@
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>Hercules4Mx.rateLsb</key>
+                <key>Hercules4Mx.deckRateLsb</key>
                 <description>Right Pitch (14bits LSB).</description>
                 <status>0xB0</status>
                 <midino>0x2B</midino>
@@ -1224,7 +1224,7 @@
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>Hercules4Mx.rateLsb</key>
+                <key>Hercules4Mx.deckRateLsb</key>
                 <description>Left Pitch (14bits LSB).</description>
                 <status>0xB0</status>
                 <midino>0x2A</midino>
@@ -1254,7 +1254,7 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>Hercules4Mx.rateLsb</key>
+                <key>Hercules4Mx.deckRateLsb</key>
                 <description>Right Pitch (14bits LSB).</description>
                 <status>0xB0</status>
                 <midino>0x29</midino>
@@ -1284,7 +1284,7 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>Hercules4Mx.rateLsb</key>
+                <key>Hercules4Mx.deckRateLsb</key>
                 <description>Right Pitch (14bits LSB).</description>
                 <status>0xB0</status>
                 <midino>0x28</midino>
@@ -1484,12 +1484,12 @@
             </control>
             <control>
                 <group>[Master]</group>
-                <key>crossfader</key>
+                <key>Hercules4Mx.crossfader</key>
                 <description>Crossfader</description>
                 <status>0xB0</status>
                 <midino>0x22</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -1534,37 +1534,37 @@
             </control>
             <control>
                 <group>[EqualizerRack1_[Channel4]_Effect1]</group>
-                <key>parameter1</key>
+                <key>Hercules4Mx.deckBass</key>
                 <description>Right Bass</description>
                 <status>0xB0</status>
                 <midino>0x20</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[EqualizerRack1_[Channel4]_Effect1]</group>
-                <key>parameter2</key>
+                <key>Hercules4Mx.deckMids</key>
                 <description>Right Mid</description>
                 <status>0xB0</status>
                 <midino>0x1F</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[EqualizerRack1_[Channel4]_Effect1]</group>
-                <key>parameter3</key>
+                <key>Hercules4Mx.deckTreble</key>
                 <description>Right Treble</description>
                 <status>0xB0</status>
                 <midino>0x1E</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>Hercules4Mx.rateMsb</key>
+                <key>Hercules4Mx.deckRateMsb</key>
                 <description>Right Pitch (MSB)</description>
                 <status>0xB0</status>
                 <midino>0x1D</midino>
@@ -1574,22 +1574,22 @@
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>pregain</key>
+                <key>Hercules4Mx.deckGain</key>
                 <description>Right Gain</description>
                 <status>0xB0</status>
                 <midino>0x1C</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>volume</key>
+                <key>Hercules4Mx.deckVolume</key>
                 <description>Right Volume Fader</description>
                 <status>0xB0</status>
                 <midino>0x1B</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -1614,37 +1614,37 @@
             </control>
             <control>
                 <group>[EqualizerRack1_[Channel3]_Effect1]</group>
-                <key>parameter1</key>
+                <key>Hercules4Mx.deckBass</key>
                 <description>Left Bass</description>
                 <status>0xB0</status>
                 <midino>0x18</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[EqualizerRack1_[Channel3]_Effect1]</group>
-                <key>parameter2</key>
+                <key>Hercules4Mx.deckMids</key>
                 <description>Left Mid</description>
                 <status>0xB0</status>
                 <midino>0x17</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[EqualizerRack1_[Channel3]_Effect1]</group>
-                <key>parameter3</key>
+                <key>Hercules4Mx.deckTreble</key>
                 <description>Left Treble</description>
                 <status>0xB0</status>
                 <midino>0x16</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>Hercules4Mx.rateMsb</key>
+                <key>Hercules4Mx.deckRateMsb</key>
                 <description>Left Pitch (MSB)</description>
                 <status>0xB0</status>
                 <midino>0x15</midino>
@@ -1654,22 +1654,22 @@
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>pregain</key>
+                <key>Hercules4Mx.deckGain</key>
                 <description>Left Gain</description>
                 <status>0xB0</status>
                 <midino>0x14</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>volume</key>
+                <key>Hercules4Mx.deckVolume</key>
                 <description>Left Volume Fader</description>
                 <status>0xB0</status>
                 <midino>0x13</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -1694,37 +1694,37 @@
             </control>
             <control>
                 <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-                <key>parameter1</key>
+                <key>Hercules4Mx.deckBass</key>
                 <description>Right Bass</description>
                 <status>0xB0</status>
                 <midino>0x10</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-                <key>parameter2</key>
+                <key>Hercules4Mx.deckMids</key>
                 <description>Right Mid</description>
                 <status>0xB0</status>
                 <midino>0x0F</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-                <key>parameter3</key>
+                <key>Hercules4Mx.deckTreble</key>
                 <description>Right Treble</description>
                 <status>0xB0</status>
                 <midino>0x0E</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>Hercules4Mx.rateMsb</key>
+                <key>Hercules4Mx.deckRateMsb</key>
                 <description>Right Pitch (MSB)</description>
                 <status>0xB0</status>
                 <midino>0x0D</midino>
@@ -1734,22 +1734,22 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>pregain</key>
+                <key>Hercules4Mx.deckGain</key>
                 <description>Right Gain</description>
                 <status>0xB0</status>
                 <midino>0x0C</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>volume</key>
+                <key>Hercules4Mx.deckVolume</key>
                 <description>Right Volume Fader</description>
                 <status>0xB0</status>
                 <midino>0x0B</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -1774,37 +1774,37 @@
             </control>
             <control>
                 <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>parameter1</key>
+                <key>Hercules4Mx.deckBass</key>
                 <description>Left Bass</description>
                 <status>0xB0</status>
                 <midino>0x08</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>parameter2</key>
+                <key>Hercules4Mx.deckMids</key>
                 <description>Left Mid</description>
                 <status>0xB0</status>
                 <midino>0x07</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>parameter3</key>
+                <key>Hercules4Mx.deckTreble</key>
                 <description>Left Treble</description>
                 <status>0xB0</status>
                 <midino>0x06</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>Hercules4Mx.rateMsb</key>
+                <key>Hercules4Mx.deckRateMsb</key>
                 <description>Left Pitch (MSB)</description>
                 <status>0xB0</status>
                 <midino>0x05</midino>
@@ -1814,22 +1814,22 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>pregain</key>
+                <key>Hercules4Mx.deckGain</key>
                 <description>Left Gain</description>
                 <status>0xB0</status>
                 <midino>0x04</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>volume</key>
+                <key>Hercules4Mx.deckVolume</key>
                 <description>Left Volume Fader</description>
                 <status>0xB0</status>
                 <midino>0x03</midino>
                 <options>
-                    <soft-takeover/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -1855,179 +1855,11 @@
         </controls>
         <outputs>
             <output>
-                <group>[Channel1]</group>
-                <key>cue_indicator</key>
-                <description>Left Cue button</description>
-                <status>0x90</status>
-                <midino>0x0D</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel4]</group>
-                <key>hotcue_4_enabled</key>
-                <description>Right Effect 10 led</description>
-                <status>0x91</status>
-                <midino>0x2A</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>hotcue_2_enabled</key>
-                <description>Left Effect 8 led</description>
-                <status>0x90</status>
-                <midino>0x08</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel3]</group>
-                <key>play_indicator</key>
-                <description>Left Play button</description>
-                <status>0x91</status>
-                <midino>0x0E</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel4]</group>
-                <key>hotcue_1_enabled</key>
-                <description>Right Effect 7 led</description>
-                <status>0x91</status>
-                <midino>0x27</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel3]</group>
-                <key>stop</key>
-                <description>Left Stop button</description>
-                <status>0x91</status>
-                <midino>0x10</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel4]</group>
-                <key>keylock</key>
-                <description>Right pitch reset led</description>
-                <status>0x91</status>
-                <midino>0x35</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>button_parameter1</key>
-                <description>Left Kill Bass</description>
-                <status>0x90</status>
-                <midino>0x19</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
                 <group>[Channel2]</group>
-                <key>pfl</key>
-                <description>Right Deck Cue Select (PFL headphones)</description>
-                <status>0x90</status>
-                <midino>0x2F</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>button_parameter3</key>
-                <description>Left Kill Treble</description>
-                <status>0x90</status>
-                <midino>0x17</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel4]</group>
-                <key>hotcue_2_enabled</key>
-                <description>Right Effect 8 led</description>
-                <status>0x91</status>
-                <midino>0x28</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>button_parameter2</key>
-                <description>Left Kill Mid</description>
-                <status>0x90</status>
-                <midino>0x18</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel3]</group>
-                <key>hotcue_3_enabled</key>
-                <description>Left Effect 9 led</description>
-                <status>0x91</status>
-                <midino>0x09</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel2]</group>
-                <key>passthrough</key>
-                <description>Right Source 2 Button</description>
-                <status>0x90</status>
-                <midino>0x36</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[EffectRack1_EffectUnit1]</group>
-                <key>group_[Channel2]_enable</key>
-                <description>Right Effect 11 led</description>
-                <status>0x90</status>
-                <midino>0x2B</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel2]</group>
-                <key>cue_indicator</key>
-                <description>Right Cue button</description>
-                <status>0x90</status>
-                <midino>0x2D</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel3]</group>
-                <key>hotcue_4_enabled</key>
-                <description>Left Effect 10 led</description>
-                <status>0x91</status>
-                <midino>0x0A</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel4]</group>
                 <key>play_indicator</key>
                 <description>Right Play button</description>
-                <status>0x91</status>
+                <status>0x90</status>
                 <midino>0x2E</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[EffectRack1_EffectUnit1]</group>
-                <key>group_[Channel4]_enable</key>
-                <description>Right Effect 11 led</description>
-                <status>0x91</status>
-                <midino>0x2B</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel3]</group>
-                <key>hotcue_1_enabled</key>
-                <description>Left Effect 7 led</description>
-                <status>0x91</status>
-                <midino>0x07</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel4]</group>
-                <key>stop</key>
-                <description>Right Stop button</description>
-                <status>0x91</status>
-                <midino>0x30</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel3]</group>
-                <key>keylock</key>
-                <description>Left pitch reset led</description>
-                <status>0x91</status>
-                <midino>0x15</midino>
                 <minimum>0.5</minimum>
             </output>
             <output>
@@ -2039,19 +1871,27 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Channel3]</group>
-                <key>hotcue_2_enabled</key>
-                <description>Left Effect 8 led</description>
+                <group>[Channel4]</group>
+                <key>passthrough</key>
+                <description>Right Source 2 Button</description>
                 <status>0x91</status>
-                <midino>0x08</midino>
+                <midino>0x36</midino>
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[EqualizerRack1_[Channel4]_Effect1]</group>
-                <key>button_parameter1</key>
-                <description>Right Kill Bass</description>
+                <group>[Channel3]</group>
+                <key>stop</key>
+                <description>Left Stop button</description>
                 <status>0x91</status>
-                <midino>0x39</midino>
+                <midino>0x10</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel4]</group>
+                <key>play_indicator</key>
+                <description>Right Play button</description>
+                <status>0x91</status>
+                <midino>0x2E</midino>
                 <minimum>0.5</minimum>
             </output>
             <output>
@@ -2063,147 +1903,11 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[EffectRack1_EffectUnit2]</group>
-                <key>group_[Channel2]_enable</key>
-                <description>Right Effect 12 led</description>
-                <status>0x90</status>
-                <midino>0x2C</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[EqualizerRack1_[Channel4]_Effect1]</group>
-                <key>button_parameter3</key>
-                <description>Right Kill Treble</description>
-                <status>0x91</status>
-                <midino>0x37</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[EqualizerRack1_[Channel4]_Effect1]</group>
-                <key>button_parameter2</key>
-                <description>Right Kill Mid</description>
-                <status>0x91</status>
-                <midino>0x38</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
                 <group>[Channel1]</group>
-                <key>stop</key>
-                <description>Left Stop button</description>
-                <status>0x90</status>
-                <midino>0x10</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>play_indicator</key>
-                <description>Left Play button</description>
-                <status>0x90</status>
-                <midino>0x0E</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel2]</group>
-                <key>keylock</key>
-                <description>Right pitch reset led</description>
-                <status>0x90</status>
-                <midino>0x35</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[EffectRack1_EffectUnit1]</group>
-                <key>group_[Channel1]_enable</key>
-                <description>Left Effect 11 led</description>
-                <status>0x90</status>
-                <midino>0x0B</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel2]</group>
-                <key>hotcue_3_enabled</key>
-                <description>Right Effect 9 led</description>
-                <status>0x90</status>
-                <midino>0x29</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[EffectRack1_EffectUnit2]</group>
-                <key>group_[Channel4]_enable</key>
-                <description>Right Effect 12 led</description>
-                <status>0x91</status>
-                <midino>0x2C</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel4]</group>
-                <key>passthrough</key>
-                <description>Right Source 2 Button</description>
-                <status>0x91</status>
-                <midino>0x36</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel4]</group>
                 <key>pfl</key>
-                <description>Right Deck Cue Select (PFL headphones)</description>
-                <status>0x91</status>
-                <midino>0x2F</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel2]</group>
-                <key>hotcue_4_enabled</key>
-                <description>Right Effect 10 led</description>
+                <description>Left Deck Cue Select (PFL headphones)</description>
                 <status>0x90</status>
-                <midino>0x2A</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel3]</group>
-                <key>cue_indicator</key>
-                <description>Left Cue button</description>
-                <status>0x91</status>
-                <midino>0x0D</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[EffectRack1_EffectUnit1]</group>
-                <key>group_[Channel3]_enable</key>
-                <description>Left Effect 11 led</description>
-                <status>0x91</status>
-                <midino>0x0B</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel2]</group>
-                <key>hotcue_1_enabled</key>
-                <description>Right Effect 7 led</description>
-                <status>0x90</status>
-                <midino>0x27</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[EqualizerRack1_[Channel3]_Effect1]</group>
-                <key>button_parameter1</key>
-                <description>Left Kill Bass</description>
-                <status>0x91</status>
-                <midino>0x19</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel2]</group>
-                <key>stop</key>
-                <description>Right Stop button</description>
-                <status>0x90</status>
-                <midino>0x30</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel2]</group>
-                <key>play_indicator</key>
-                <description>Right Play button</description>
-                <status>0x90</status>
-                <midino>0x2E</midino>
+                <midino>0x0F</midino>
                 <minimum>0.5</minimum>
             </output>
             <output>
@@ -2216,6 +1920,22 @@
             </output>
             <output>
                 <group>[EqualizerRack1_[Channel3]_Effect1]</group>
+                <key>button_parameter1</key>
+                <description>Left Kill Bass</description>
+                <status>0x91</status>
+                <midino>0x19</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>button_parameter1</key>
+                <description>Left Kill Bass</description>
+                <status>0x90</status>
+                <midino>0x19</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[EqualizerRack1_[Channel3]_Effect1]</group>
                 <key>button_parameter3</key>
                 <description>Left Kill Treble</description>
                 <status>0x91</status>
@@ -2223,19 +1943,19 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[EffectRack1_EffectUnit2]</group>
-                <key>group_[Channel1]_enable</key>
-                <description>Left Effect 12 led</description>
+                <group>[Channel1]</group>
+                <key>stop</key>
+                <description>Left Stop button</description>
                 <status>0x90</status>
-                <midino>0x0C</midino>
+                <midino>0x10</midino>
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Channel2]</group>
-                <key>hotcue_2_enabled</key>
-                <description>Right Effect 8 led</description>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>button_parameter3</key>
+                <description>Left Kill Treble</description>
                 <status>0x90</status>
-                <midino>0x28</midino>
+                <midino>0x17</midino>
                 <minimum>0.5</minimum>
             </output>
             <output>
@@ -2247,11 +1967,51 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Channel1]</group>
-                <key>hotcue_3_enabled</key>
-                <description>Left Effect 9 led</description>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>button_parameter2</key>
+                <description>Left Kill Mid</description>
                 <status>0x90</status>
-                <midino>0x09</midino>
+                <midino>0x18</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel3]</group>
+                <key>cue_indicator</key>
+                <description>Left Cue button</description>
+                <status>0x91</status>
+                <midino>0x0D</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel4]</group>
+                <key>keylock</key>
+                <description>Right pitch reset led</description>
+                <status>0x91</status>
+                <midino>0x35</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>cue_indicator</key>
+                <description>Left Cue button</description>
+                <status>0x90</status>
+                <midino>0x0D</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel4]</group>
+                <key>stop</key>
+                <description>Right Stop button</description>
+                <status>0x91</status>
+                <midino>0x30</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel4]</group>
+                <key>pfl</key>
+                <description>Right Deck Cue Select (PFL headphones)</description>
+                <status>0x91</status>
+                <midino>0x2F</midino>
                 <minimum>0.5</minimum>
             </output>
             <output>
@@ -2263,6 +2023,62 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
+                <group>[Channel1]</group>
+                <key>play_indicator</key>
+                <description>Left Play button</description>
+                <status>0x90</status>
+                <midino>0x0E</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>pfl</key>
+                <description>Right Deck Cue Select (PFL headphones)</description>
+                <status>0x90</status>
+                <midino>0x2F</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel3]</group>
+                <key>play_indicator</key>
+                <description>Left Play button</description>
+                <status>0x91</status>
+                <midino>0x0E</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>passthrough</key>
+                <description>Right Source 2 Button</description>
+                <status>0x90</status>
+                <midino>0x36</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>keylock</key>
+                <description>Right pitch reset led</description>
+                <status>0x90</status>
+                <midino>0x35</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[EqualizerRack1_[Channel4]_Effect1]</group>
+                <key>button_parameter1</key>
+                <description>Right Kill Bass</description>
+                <status>0x91</status>
+                <midino>0x39</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>stop</key>
+                <description>Right Stop button</description>
+                <status>0x90</status>
+                <midino>0x30</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
                 <group>[EqualizerRack1_[Channel2]_Effect1]</group>
                 <key>button_parameter1</key>
                 <description>Right Kill Bass</description>
@@ -2271,11 +2087,43 @@
                 <minimum>0.5</minimum>
             </output>
             <output>
-                <group>[Channel1]</group>
-                <key>hotcue_4_enabled</key>
-                <description>Left Effect 10 led</description>
+                <group>[Channel4]</group>
+                <key>cue_indicator</key>
+                <description>Right Cue button</description>
+                <status>0x91</status>
+                <midino>0x2D</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel3]</group>
+                <key>keylock</key>
+                <description>Left pitch reset led</description>
+                <status>0x91</status>
+                <midino>0x15</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[EqualizerRack1_[Channel4]_Effect1]</group>
+                <key>button_parameter3</key>
+                <description>Right Kill Treble</description>
+                <status>0x91</status>
+                <midino>0x37</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>cue_indicator</key>
+                <description>Right Cue button</description>
                 <status>0x90</status>
-                <midino>0x0A</midino>
+                <midino>0x2D</midino>
+                <minimum>0.5</minimum>
+            </output>
+            <output>
+                <group>[EqualizerRack1_[Channel4]_Effect1]</group>
+                <key>button_parameter2</key>
+                <description>Right Kill Mid</description>
+                <status>0x91</status>
+                <midino>0x38</midino>
                 <minimum>0.5</minimum>
             </output>
             <output>
@@ -2292,46 +2140,6 @@
                 <description>Right Kill Mid</description>
                 <status>0x90</status>
                 <midino>0x38</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel4]</group>
-                <key>cue_indicator</key>
-                <description>Right Cue button</description>
-                <status>0x91</status>
-                <midino>0x2D</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>pfl</key>
-                <description>Left Deck Cue Select (PFL headphones)</description>
-                <status>0x90</status>
-                <midino>0x0F</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[EffectRack1_EffectUnit2]</group>
-                <key>group_[Channel3]_enable</key>
-                <description>Left Effect 12 led</description>
-                <status>0x91</status>
-                <midino>0x0C</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel4]</group>
-                <key>hotcue_3_enabled</key>
-                <description>Right Effect 9 led</description>
-                <status>0x91</status>
-                <midino>0x29</midino>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>hotcue_1_enabled</key>
-                <description>Left Effect 7 led</description>
-                <status>0x90</status>
-                <midino>0x07</midino>
                 <minimum>0.5</minimum>
             </output>
         </outputs>

--- a/res/controllers/Hercules DJ Console 4-Mx.midi.xml
+++ b/res/controllers/Hercules DJ Console 4-Mx.midi.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <MixxxControllerPreset mixxxVersion="2.0.0+" schemaVersion="1">
     <info>
-        <name>Hercules DJ Console 4-Mx (2.0)</name>
+        <name>Hercules DJ Console 4-Mx (2.1)</name>
         <author>josepma</author>
-        <description>Hercules DJ Console 4-Mx (2.0)</description>
+        <description>Hercules DJ Console 4-Mx (2.1) 2016-11-06</description>
         <forums>http://www.mixxx.org/forums/viewtopic.php?f=7&amp;t=3023</forums>
         <wiki>http://mixxx.org/wiki/doku.php/hercules_dj_console_4-mx</wiki>
     </info>
@@ -24,42 +24,42 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>LoadSelectedTrack</key>
+                <key>Hercules4Mx.LoadSelectedTrack</key>
                 <description>Button Load on Right Deck</description>
                 <status>0x90</status>
                 <midino>0x4B</midino>
                 <options>
-                    <button/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>LoadSelectedTrack</key>
+                <key>Hercules4Mx.LoadSelectedTrack</key>
                 <description>Button Load on Right Deck</description>
                 <status>0x91</status>
                 <midino>0x4B</midino>
                 <options>
-                    <button/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>LoadSelectedTrack</key>
+                <key>Hercules4Mx.LoadSelectedTrack</key>
                 <description>Button Load on Left Deck</description>
                 <status>0x90</status>
                 <midino>0x4A</midino>
                 <options>
-                    <button/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>LoadSelectedTrack</key>
+                <key>Hercules4Mx.LoadSelectedTrack</key>
                 <description>Button Load on Left Deck</description>
                 <status>0x91</status>
                 <midino>0x4A</midino>
                 <options>
-                    <button/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -88,6 +88,9 @@
                 <description>Button Mic On/Off (state)</description>
                 <status>0x90</status>
                 <midino>0x47</midino>
+                <options>
+                    <normal/>
+                </options>
             </control>
             <control>
                 <group>[Channel2]</group>
@@ -481,22 +484,22 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>pfl</key>
+                <key>Hercules4Mx.deckheadphones</key>
                 <description>Right Cue Select Deck (PFL headphones)</description>
                 <status>0x90</status>
                 <midino>0x2F</midino>
                 <options>
-                    <button/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>pfl</key>
+                <key>Hercules4Mx.deckheadphones</key>
                 <description>Right Cue Select Deck (PFL headphones)</description>
                 <status>0x91</status>
                 <midino>0x2F</midino>
                 <options>
-                    <button/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -521,22 +524,22 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>cue_default</key>
+                <key>Hercules4Mx.cueButton</key>
                 <description>Right Cue</description>
                 <status>0x90</status>
                 <midino>0x2D</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>cue_default</key>
+                <key>Hercules4Mx.cueButton</key>
                 <description>Right Cue</description>
                 <status>0x91</status>
                 <midino>0x2D</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -1121,22 +1124,22 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>pfl</key>
+                <key>Hercules4Mx.deckheadphones</key>
                 <description>Left Deck Cue Select (PFL headphones)</description>
                 <status>0x90</status>
                 <midino>0x0F</midino>
                 <options>
-                    <button/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>pfl</key>
+                <key>Hercules4Mx.deckheadphones</key>
                 <description>Left Deck Cue Select (PFL headphones)</description>
                 <status>0x91</status>
                 <midino>0x0F</midino>
                 <options>
-                    <button/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -1161,22 +1164,22 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>cue_default</key>
+                <key>Hercules4Mx.cueButton</key>
                 <description>Left Cue</description>
                 <status>0x90</status>
                 <midino>0x0D</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>cue_default</key>
+                <key>Hercules4Mx.cueButton</key>
                 <description>Left Cue</description>
                 <status>0x91</status>
                 <midino>0x0D</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>

--- a/res/controllers/Hercules DJ Console 4-Mx.midi.xml
+++ b/res/controllers/Hercules DJ Console 4-Mx.midi.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <MixxxControllerPreset mixxxVersion="2.0.0+" schemaVersion="1">
     <info>
-        <name>Hercules DJ Console 4-Mx (2.1)</name>
+        <name>Hercules DJ Console 4-Mx</name>
         <author>josepma</author>
-        <description>Hercules DJ Console 4-Mx (2.1) 2016-11-06</description>
+        <description>Hercules DJ Console 4-Mx 2016-11-06</description>
         <forums>http://www.mixxx.org/forums/viewtopic.php?f=7&amp;t=3023</forums>
         <wiki>http://mixxx.org/wiki/doku.php/hercules_dj_console_4-mx</wiki>
     </info>

--- a/res/controllers/Hercules-DJ-Console-4-Mx-scripts.js
+++ b/res/controllers/Hercules-DJ-Console-4-Mx-scripts.js
@@ -17,7 +17,21 @@
 //        Removed midi channel configuration. It also required modifying the mapping, so it didn't really work.
 //        Automatically setup some internal values, like 4 decks mode
 //        Support speed sensor on jog wheel and Fx knob. They need to be moved really fast, so it's rarely useful.
-//
+// Version 2016-09-22
+//        Beatgrid editing mode enabled with shift+sync. Allows to correct the beatgrid from the controller. 
+//        (For when you're in the middle of a mix and something is not properly aligned)
+//        Brake effect (power unplug) with shift+stop, backward playing moved to shift+play and forward and rewind by beats.
+//        Keylock, quantize and master sync (shift pitch scale up, shift pitch scale down and sync pressed for 400ms respectively).
+//        Improvements and fixes on sync button and navigation.
+//        Corrections in soft takeover, and initialization of control values from their physical positions on Mixxx startup.
+//        Audio vu meters on the kill/source buttons that switches between master and decks on pfl. Can be switched 
+//          off on userSettings. If kill or source buttons are activated, the vu on that channel is deactivated.
+//        Reimplemented the actions for Fx buttons. It now allows to have personalized mappings, and comes already with three:
+//          Manual/VirtualDJ setup, Mixxx 2.0 setup and a new setup that adds more functionality, like playing 4 samplers.
+//        New loop edit mode. It allows for a random length loop as well as more beatloop sizes. It is also possible to modify
+//          a loop size with the fx knob. See the updated wiki for a detailed explanation.
+//        The FX "super" knob can be controlled from the controller now. Maintain the fx button pressed and move the knob.
+//        
 // Usage:
 // ------
 // Check the dedicated controller wiki page at: 
@@ -30,10 +44,10 @@ var Hercules4Mx = function() {};
 
 // The 4 possible values for the beatFlashLed option below.
 Hercules4Mx.Leds = {
-    "none" : 0,
-    "syncLed" : 0x11,
-    "pitchResetLed" : 0x15,
-    "JogLed" : 0x1A
+    "none": 0,
+    "syncLed": 0x11,
+    "pitchResetLed": 0x15,
+    "JogLed": 0x1A
 };
 // --- Personal preferences configuration ---
 Hercules4Mx.userSettings = {
@@ -44,13 +58,15 @@ Hercules4Mx.userSettings = {
     // Flashing at the rythm of the beat on the led. Use the Leds map above.
     // Note: if using sync button, then the button will not show sync master state.
     'beatFlashLed': Hercules4Mx.Leds.JogLed,
-    // KeyRepeat speed for navigating up/down, in milliseconds. 125 is a good value. Lower values make it scroll faster.
-    'naviScrollSpeed': 125,
+    // Simulate vuMeters using the kill and source buttons. If enabled, shows master vus, or deck vu depending if prefader listen button is enabled or not.
+    'useVuMeters': true,
+    // KeyRepeat speed for navigating up/down, in milliseconds. 100 is a good value. Lower values make it scroll faster.
+    'naviScrollSpeed': 100,
     // The controller has two modes to report the crossfader position. The default/beatmix curve, and the scratch curve.
     // The default curve reports the real position of the control. The scratch curve just crossfades on the edges.
     // Setting this setting to true, the curve will change to scratch curve when the scratch mode is on (scratch button).
     // Setting it to false will not change it, so it will use the setting configured in the DJHercules Tray-icon configuration.
-    'crossfaderScratchCurve' : false,
+    'crossfaderScratchCurve': false,
     // _Scratching_ Playback speed of the virtual vinyl that is being scratched. 45.00 and 33.33 are the common speeeds. (Lower number equals faster scratch)
     'vinylSpeed': 45,
     // _Scratching_ You should configure this setting to the same value than in the DJHercules tray icon configuration. (Normal means 1/1).
@@ -60,13 +76,22 @@ Hercules4Mx.userSettings = {
     'alpha': 1 / 8,
     // _Scratching_ beta value for the filter (start with alpha/32 and tune from there)
     'beta': (1 / 8) / 32,
-     // This controls the function of the deck C/deck D buttons (changes the setting in the tray-icon configuration, avanced tab)
-     // Deck button mode: deckmode=0 2 Decks only, deckmode=1 2 Decks with deck switch button command, deckmode=2 4 decks.
-     // Since Mixxx supports 4 decks and this mapping is configured for all four decks, the default value is 2.
-     'deckButtonMode': 2
+    // This controls the function of the deck C/deck D buttons (changes the setting in the tray-icon configuration, avanced tab)
+    // Deck button mode: deckmode=0 2 Decks only, deckmode=1 2 Decks with deck switch button command, deckmode=2 4 decks.
+    // Since Mixxx supports 4 decks and this mapping is configured for all four decks, the default value is 2.
+    'deckButtonMode': 2,
+    // This indicates which mapping for the FX buttons should Mixxx use.
+    // The possible values are:
+    // original : As they are in the Hercules Manual and the default setup in Virtual DJ 7 LE.
+    // mixxx20 : As they were initially defined with the release of Mixxx 2.0
+    // mixxx21 : AS they were defined with the release of Mixxx 2.1
+    // With a little caution, you can modify them at the bottom of this file
+    'FXbuttonsSetup': 'mixxx21'
 };
 
-
+//
+// End of User configurable options
+//
 ////////////////////////////////////////////////////////////////////////
 // JSHint configuration                                               //
 ////////////////////////////////////////////////////////////////////////
@@ -86,17 +111,85 @@ Hercules4Mx.navigationStatus = {
     //Indicates if navigating in the sidebar, or in the library
     'sidebar': false,
     //Holds the timeout event id that does the key-repeat action for moving up or down holding only the key.
+    'timeoutId': null,
+    //Indicates if it is the first execution of the timer for this timer instance. We use this to have a longer start time when pressing the button than for keyrepeat.
+    'isSingleShotTimer': false
+};
+
+Hercules4Mx.forwardRewindStatus = {
+    //Navigation direction 1 forward, -1 backward, 0 do not move
+    'direction': 0,
+    'group': null,
+    //Holds the timeout event id that starts the forward/backward seeking.
     'timeoutId': null
 };
 
+Hercules4Mx.syncEnabledStatus = {
+    //Holds the timeout event id that starts the forward/backward seeking.
+    'timeoutId': null,
+    //Indicates if the timeout has been reached
+    'triggered': 0
+};
+
+Hercules4Mx.editModes = {
+    'disabled': -1,
+    'beatgrid': 0,
+    'effects': 1,
+    'loop': 2,
+    'effectknob': 3
+};
+Hercules4Mx.editModeStatus = {
+    'mode': Hercules4Mx.editModes.disabled,
+    'effect': -1
+};
+Hercules4Mx.shiftStatus = {
+    'pressed': false,
+    'used': false,
+    'braking': false,
+    'reversing': false,
+    'loopsizing': false,
+    'effectsuperknob': false
+};
+Hercules4Mx.VuMeterL = {
+    'initchan': 1, // This is used internally to know that this is VuMeterL
+    'clip': 0x16,
+    'vu3': 0x17,
+    'vu2': 0x18,
+    'vu1': 0x19,
+    'source': '[Master]',
+    'midichan': 0x90,
+    'lastvalue': 0
+};
+Hercules4Mx.VuMeterR = {
+    'initchan': 2, // This is used internally to know that this is VuMeterR
+    'clip': 0x36,
+    'vu3': 0x37,
+    'vu2': 0x38,
+    'vu1': 0x39,
+    'source': '[Master]',
+    'midichan': 0x90,
+    'lastvalue': 0
+};
+
+Hercules4Mx.KeyHoldTime = 500;
 Hercules4Mx.scratchEnabled = false;
 Hercules4Mx.previousHeadMix = 0;
 Hercules4Mx.autoDJfadingId = null;
-Hercules4Mx.shiftPressed = false;
-Hercules4Mx.shiftUsed = false;
 //Assume 14bit mode is disabled by default, and enable it on the first lsb detected.
 Hercules4Mx.pitch14bitMode = false;
-Hercules4Mx.pitchMsbValue = [0x40,0x40,0x40,0x40];
+Hercules4Mx.pitchMsbValue = [0x40, 0x40, 0x40, 0x40];
+Hercules4Mx.noActionButtonMap = {
+    'buttonPressAction': Hercules4Mx.FxActionNoOp,
+    'buttonReleaseAction': null,
+    'extraParameter': null,
+    'ledToConnect': null
+};
+Hercules4Mx.buttonMappings = [Hercules4Mx.noActionButtonMap];
+Hercules4Mx.beatLoopEditButtons = [];
+Hercules4Mx.beatLoopReloopPos = -1;
+Hercules4Mx.LoopEnabledPos = -1;
+Hercules4Mx.samplerLedIdx = [];
+Hercules4Mx.FxLedIdx = [];
 
 // The Hercules Tray Icon configuration allows to configure a different midi channel for the
 // controller. You will need to change all the status codes in the xml mapping and these three
@@ -113,7 +206,7 @@ Hercules4Mx.init = function(id, debugging) {
     Hercules4Mx.allLedsOff();
     //Activate Files led.
     midi.sendShortMsg(Hercules4Mx.NOnC1, 0x3E, 0x7F);
-    
+
     var i;
     //Shift and deck buttons set to default
     for (i = 0x72; i <= 0x77; i++) {
@@ -125,6 +218,7 @@ Hercules4Mx.init = function(id, debugging) {
     if (Hercules4Mx.userSettings.crossfaderScratchCurve) {
         midi.sendShortMsg(Hercules4Mx.CC, 0x7E, 0x00);
     }
+
     // Tell the controller to report all current values to Mixxx (update_all_controls message)
     // Concretely it reports crossfader, master volume, master headmix, and EQ knobs, gain, pitch slider and vol fader of each channel.
     midi.sendShortMsg(Hercules4Mx.CC, 0x7F, 0x7F);
@@ -137,26 +231,26 @@ Hercules4Mx.init = function(id, debugging) {
     // midi.sendShortMsg(Hercules4Mx.CC, 0x7A, enable); enable = 0 obey movement, enable = 0x7F ignore movement
 
     // Connect several signals to javascript events, like song load, pre-fader-listen, loops or effects
-    engine.connectControl("[AutoDJ]","enabled","Hercules4Mx.onAutoDJ");
-    engine.connectControl("[AutoDJ]","fade_now","Hercules4Mx.onAutoDJFade");
+    engine.connectControl("[AutoDJ]", "enabled", "Hercules4Mx.onAutoDJ");
+    engine.connectControl("[AutoDJ]", "fade_now", "Hercules4Mx.onAutoDJFade");
+    engine.trigger("[AutoDJ]", "enabled");
     for (i = 1; i <= 4; i++) {
         engine.connectControl("[Channel" + i + "]", "pfl", "Hercules4Mx.onPreFaderListen");
         engine.connectControl("[Channel" + i + "]", "loop_enabled", "Hercules4Mx.onLoopStateChange");
         engine.connectControl("[Channel" + i + "]", "loop_start_position", "Hercules4Mx.onLoopStateChange");
         engine.connectControl("[Channel" + i + "]", "loop_end_position", "Hercules4Mx.onLoopStateChange");
-//        TODO: control when they are enabled, so that FX knob can move the effect unit knob.
-//        engine.connectControl("[EffectRack1_EffectUnit1]", "group_[Channel" + i + "]_enable", "Hercules4Mx.onEffectStateChange");
-//        engine.connectControl("[EffectRack1_EffectUnit2]", "group_[Channel" + i + "]_enable", "Hercules4Mx.onEffectStateChange");
+        engine.trigger("[Channel" + i + "]", "pfl");
     }
     if (Hercules4Mx.userSettings.autoHeadcueOnLoad) {
         for (i = 1; i <= 4; i++) {
             engine.connectControl("[Channel" + i + "]", "LoadSelectedTrack", "Hercules4Mx.onSongLoaded");
         }
     }
-    if (Hercules4Mx.userSettings.beatFlashLed !== Hercules4Mx.Leds.syncLed ){
+    if (Hercules4Mx.userSettings.beatFlashLed !== Hercules4Mx.Leds.syncLed) {
         //Set sync master led indicator
         for (i = 1; i <= 4; i++) {
             engine.connectControl("[Channel" + i + "]", "sync_enabled", "Hercules4Mx.onSyncLed");
+            engine.trigger("[Channel" + i + "]", "sync_enabled");
         }
     }
     if (Hercules4Mx.userSettings.beatFlashLed !== Hercules4Mx.Leds.none) {
@@ -165,16 +259,51 @@ Hercules4Mx.init = function(id, debugging) {
             engine.connectControl("[Channel" + i + "]", "beat_active", "Hercules4Mx.onBeatFlash");
         }
     }
-    
-    // Activate soft takeover for the rate sliders. The other sliders and knobs have softtakeover set in the xml mapping.
-    for (i = 1; i <= 4; i++) {
-        engine.softTakeover("[Channel" + i + "]","rate",true);
-        engine.softTakeover("[Channel" + i + "]","rate",true);
+    if (Hercules4Mx.userSettings.useVuMeters) {
+        engine.connectControl("[Master]", "VuMeterL", "Hercules4Mx.onVuMeterMasterL");
+        engine.connectControl("[Master]", "VuMeterR", "Hercules4Mx.onVuMeterMasterR");
+        for (i = 1; i <= 4; i++) {
+            engine.connectControl("[Channel" + i + "]", "VuMeter", "Hercules4Mx.onVuMeterDeck" + i);
+            engine.connectControl("[Channel" + i + "]", "passthrough", "Hercules4Mx.onKillOrSourceChange" + i);
+            engine.connectControl("[EqualizerRack1_[Channel" + i + "]_Effect1]", "button_parameter3", "Hercules4Mx.onKillOrSourceChange" + i);
+            engine.connectControl("[EqualizerRack1_[Channel" + i + "]_Effect1]", "button_parameter2", "Hercules4Mx.onKillOrSourceChange" + i);
+            engine.connectControl("[EqualizerRack1_[Channel" + i + "]_Effect1]", "button_parameter1", "Hercules4Mx.onKillOrSourceChange" + i);
+        }
     }
+    if (Hercules4Mx.userSettings.FXbuttonsSetup === "original") {
+        Hercules4Mx.setupFXButtonsLikeManual();
+    } else if (Hercules4Mx.userSettings.FXbuttonsSetup === "mixxx20") {
+        Hercules4Mx.setupFXButtonsCustomMixx20();
+    } else /* if (Hercules4Mx.userSettings.FXbuttonsSetup === "mixxx21" ) */ {
+        Hercules4Mx.setupFXButtonsCustomMixx21();
+    }
+
+    engine.beginTimer(3000, "Hercules4Mx.doDelayedSetup", true);
 };
+//timer-called (delayed) setup.
+Hercules4Mx.doDelayedSetup = function() {
+    var i;
+    // Activate soft takeover for the relevant controls. Important: engine.softTakeover only works when scripted with setValue !!
+    for (i = 1; i <= 4; i++) {
+        engine.softTakeover("[Channel" + i + "]", "rate", true);
+        engine.softTakeover("[Channel" + i + "]", "volume", true);
+        engine.softTakeover("[Channel" + i + "]", "pregain", true);
+        engine.softTakeover("[EqualizerRack1_[Channel" + i + "]_Effect1]", "parameter3", true);
+        engine.softTakeover("[EqualizerRack1_[Channel" + i + "]_Effect1]", "parameter2", true);
+        engine.softTakeover("[EqualizerRack1_[Channel" + i + "]_Effect1]", "parameter1", true);
+    }
+    engine.softTakeover("[Master]", "crossfader", true);
+};
+
 Hercules4Mx.shutdown = function() {
     if (Hercules4Mx.navigationStatus.timeoutId !== null) {
         engine.stopTimer(Hercules4Mx.navigationStatus.timeoutId);
+    }
+    if (Hercules4Mx.forwardRewindStatus.timeoutId !== null) {
+        engine.stopTimer(Hercules4Mx.forwardRewindStatus.timeoutId);
+    }
+    if (Hercules4Mx.syncEnabledStatus.timeoutId !== null) {
+        engine.stopTimer(Hercules4Mx.syncEnabledStatus.timeoutId);
     }
     if (Hercules4Mx.autoDJfadingId !== null) {
         engine.stopTimer(Hercules4Mx.autoDJfadingId);
@@ -189,10 +318,13 @@ Hercules4Mx.shutdown = function() {
 
 //Set all leds to off
 Hercules4Mx.allLedsOff = function() {
-    engine.log("Hercules4Mx.allLedsOff: switching leds off");
+    if (Hercules4Mx.debuglog) {
+        engine.log("Hercules4Mx.allLedsOff: switching leds off");
+    }
     // Switch off all LEDs
     // +0x20 -> the other deck
     // +0x40 -> blinking.
+    // NOnC2 : Decks C/D
     var i;
     for (i = 0x3C; i <= 0x3F; i++) { //auto, scratch, files, folders
         midi.sendShortMsg(Hercules4Mx.NOnC1, i, 0x00);
@@ -200,39 +332,40 @@ Hercules4Mx.allLedsOff = function() {
     }
     for (i = 0x1; i <= 0x11; i++) { // Fx, cue, play, cuesel,stop, sync
         midi.sendShortMsg(Hercules4Mx.NOnC1, i, 0x00);
-        midi.sendShortMsg(Hercules4Mx.NOnC2, i, 0x00);
         midi.sendShortMsg(Hercules4Mx.NOnC1, i + 0x20, 0x00);
-        midi.sendShortMsg(Hercules4Mx.NOnC2, i + 0x20, 0x00);
     }
     for (i = 0x15; i <= 0x1A; i++) { //pitch led, source, kill,jog touch
         midi.sendShortMsg(Hercules4Mx.NOnC1, i, 0x00);
-        midi.sendShortMsg(Hercules4Mx.NOnC2, i, 0x00);
         midi.sendShortMsg(Hercules4Mx.NOnC1, i + 0x20, 0x00);
-        midi.sendShortMsg(Hercules4Mx.NOnC2, i + 0x20, 0x00);
     }
     // I've put these on a separate loop so that there are more chances for decks A/B leds to light off when shutdown,
     // since there is a strange problem where not all messages are delivered.
     for (i = 0x1; i <= 0x11; i++) { // Fx, cue, play, cuesel,stop, sync
         midi.sendShortMsg(Hercules4Mx.NOnC1, i + 0x40, 0x00);
-        midi.sendShortMsg(Hercules4Mx.NOnC2, i + 0x40, 0x00);
         midi.sendShortMsg(Hercules4Mx.NOnC1, i + 0x60, 0x00);
+        midi.sendShortMsg(Hercules4Mx.NOnC2, i, 0x00);
+        midi.sendShortMsg(Hercules4Mx.NOnC2, i + 0x20, 0x00);
+        midi.sendShortMsg(Hercules4Mx.NOnC2, i + 0x40, 0x00);
         midi.sendShortMsg(Hercules4Mx.NOnC2, i + 0x60, 0x00);
     }
     for (i = 0x15; i <= 0x1A; i++) { //pitch led, source, kill,jog touch
         midi.sendShortMsg(Hercules4Mx.NOnC1, i + 0x40, 0x00);
-        midi.sendShortMsg(Hercules4Mx.NOnC2, i + 0x40, 0x00);
         midi.sendShortMsg(Hercules4Mx.NOnC1, i + 0x60, 0x00);
+        midi.sendShortMsg(Hercules4Mx.NOnC2, i, 0x00);
+        midi.sendShortMsg(Hercules4Mx.NOnC2, i + 0x20, 0x00);
+        midi.sendShortMsg(Hercules4Mx.NOnC2, i + 0x40, 0x00);
         midi.sendShortMsg(Hercules4Mx.NOnC2, i + 0x60, 0x00);
     }
 };
+
 ///////////////////////////////////////////////////////////////////
 // --- Events ----
 
 // The jog wheel sensitivity setting has changed. This is reported in two scenarios:
 // when the setting is changed in the tray icon, and when the crossfader curve is changed to beatmix.
 Hercules4Mx.onSensitivityChange = function(value, group, control) {
-    Hercules4Mx.userSettings.sensitivity = 1/value;    
-}
+    Hercules4Mx.userSettings.sensitivity = 1 / value;
+};
 
 //Action to do when a song is loaded in a deck. virtualDJ automatically enables the headphone cue (PFL)
 Hercules4Mx.onSongLoaded = function(value, group, control) {
@@ -253,28 +386,67 @@ Hercules4Mx.onSongLoaded = function(value, group, control) {
     }
 };
 
-//A change in the loop position or loop state has happened.
-Hercules4Mx.onLoopStateChange = function(value, group, control) {
-    engine.log("Hercules4Mx.onLoopStateChange: value, group, control: " + value + ", " + group + ", " + control);
-    var finalvalue = (value == -1) ? 0 : value;
+Hercules4Mx.onEnableLed = function(value, group, control) {
     var deck = script.deckFromGroup(group);
-    var messageto = (deck === 1 || deck == 2) ? Hercules4Mx.NOnC1 : Hercules4Mx.NOnC2;
-    var offset = (deck === 1 || deck == 3) ? 0x00 : 0x20;
-    var b1 = engine.getParameter("[Channel" + deck + "]", "beatloop_0.5_enabled");
-    var b2 = engine.getParameter("[Channel" + deck + "]", "beatloop_1_enabled");
-    var b3 = engine.getParameter("[Channel" + deck + "]", "beatloop_2_enabled");
-    var b4 = engine.getParameter("[Channel" + deck + "]", "beatloop_4_enabled");
-    if (!b1 && !b2 && !b3 && !b4) {
-        //If no beatloops set but loop is enabled, light up buttons 3 and 4
-        b3 = (finalvalue) ? 1 : 0;
-        b4 = b3;
+    var messageto = (deck === 1 || deck === 2) ? Hercules4Mx.NOnC1 : Hercules4Mx.NOnC2;
+    var offset = (deck === 1 || deck === 3) ? 0x00 : 0x20;
+    for (var i = 0; i < 12; i++) {
+        var led = Hercules4Mx.buttonMappings[i].ledToConnect;
+        if (led !== null && led === control) {
+            midi.sendShortMsg(messageto, i + 1 + offset, value);
+        }
     }
-    midi.sendShortMsg(messageto, 0x01 + offset, b1);
-    midi.sendShortMsg(messageto, 0x02 + offset, b2);
-    midi.sendShortMsg(messageto, 0x03 + offset, b3);
-    midi.sendShortMsg(messageto, 0x04 + offset, b4);
 };
 
+//A change in the loop position or loop state has happened.
+Hercules4Mx.onLoopStateChange = function(value, group, control) {
+    if (Hercules4Mx.debuglog) {
+        engine.log("Hercules4Mx.onLoopStateChange: value, group, control: " + value + ", " + group + ", " + control);
+    }
+    var deck = script.deckFromGroup(group);
+    var messageto = (deck === 1 || deck === 2) ? Hercules4Mx.NOnC1 : Hercules4Mx.NOnC2;
+    var offset = (deck === 1 || deck === 3) ? 0x00 : 0x20;
+    var chandeck = "[Channel" + deck + "]";
+    var loopenabled = parseInt(engine.getParameter(chandeck, "loop_enabled"));
+    var beatenabled = 0;
+    if (loopenabled !== 0) {
+        for (var i = 0; i < 12; i++) {
+            var led = Hercules4Mx.buttonMappings[i].ledToConnect;
+            if (led !== null && led.indexOf("beatloop") !== -1) {
+                beatenabled = beatenabled + parseInt(engine.getParameter(chandeck, led));
+            }
+        }
+    }
+    var newval;
+    if (Hercules4Mx.LoopEnabledPos !== -1) {
+        newval = (loopenabled > 0 && beatenabled === 0) ? 0x7F : 0;
+        midi.sendShortMsg(messageto, Hercules4Mx.LoopEnabledPos + offset, newval);
+    }
+    if (Hercules4Mx.beatLoopReloopPos !== -1) {
+        newval = (parseInt(engine.getParameter(chandeck, "loop_start_position")) > -1) ? 0x7F : 0;
+        midi.sendShortMsg(messageto, Hercules4Mx.beatLoopReloopPos + offset, newval);
+    }
+};
+//A change in an effect channel status has happened
+Hercules4Mx.onEffectStateChange = function(value, group, control) {
+    var fxidx = parseInt(group.slice(-2).substr(0, 1)); // "[EffectRack1_EffectUnit1]"
+    if (fxidx > 0 && fxidx <= Hercules4Mx.FxLedIdx.length) {
+        var newval = (value > 0) ? 0x7F : 0x0;
+        var deck = parseInt(control.slice(-9).substr(0, 1)); // "group_[Channel1]_enable"
+        var offset = (deck === 1 || deck === 3) ? 0x00 : 0x20;
+        midi.sendShortMsg(Hercules4Mx.NOnC1, Hercules4Mx.FxLedIdx[fxidx - 1] + offset, newval);
+    }
+};
+//A change in a sampler playback state has happened
+Hercules4Mx.onSamplerStateChange = function(value, group, control) {
+    //This slice only works for up to 9 samplers. Since we only support 4 buttons, that's enough.
+    var sampleidx = parseInt(group.slice(-2).substr(0, 1));
+    if (sampleidx > 0 && sampleidx <= Hercules4Mx.samplerLedIdx.length) {
+        var newval = (value > 0) ? 0x7F : 0x0;
+        midi.sendShortMsg(Hercules4Mx.NOnC1, Hercules4Mx.samplerLedIdx[sampleidx - 1], newval);
+        midi.sendShortMsg(Hercules4Mx.NOnC2, Hercules4Mx.samplerLedIdx[sampleidx - 1], newval);
+    }
+};
 // Controls the action to do when the headphone cue (pre-fader-listen) buttons are pressed.
 Hercules4Mx.onPreFaderListen = function(value, group, control) {
     if (Hercules4Mx.userSettings.autoHeadMix) {
@@ -292,6 +464,14 @@ Hercules4Mx.onPreFaderListen = function(value, group, control) {
         } else if (currentHeadMix == 1) {
             // If at least one is enabled and headmix is set to master, restore previous headmix.
             engine.setParameter("[Master]", "headMix", Hercules4Mx.previousHeadMix);
+        }
+    }
+    if (Hercules4Mx.userSettings.useVuMeters) {
+        var deck = script.deckFromGroup(group);
+        if (deck === 1 || deck === 3) {
+            Hercules4Mx.updateVumeterSourceAction(Hercules4Mx.VuMeterL, deck);
+        } else {
+            Hercules4Mx.updateVumeterSourceAction(Hercules4Mx.VuMeterR, deck);
         }
     }
 };
@@ -315,9 +495,9 @@ Hercules4Mx.onAutoDJFade = function(value, group, control) {
     //After 5 seconds, restore non-flashing led. It would be perfect if autoDJFade was triggered also
     //when the fading ends, but right now it seems this is not possible. Also, it doesn't seem to be
     //an option to get the duration of the fading, that's why i simply put there 5 seconds.
-    Hercules4Mx.autoDJfadingId = engine.beginTimer(5000, "Hercules4Mx.onAutoDJFadeOff", true);
+    Hercules4Mx.autoDJfadingId = engine.beginTimer(5000, "Hercules4Mx.doEndAutoDJFadeOffAction", true);
 };
-Hercules4Mx.onAutoDJFadeOff = function() {
+Hercules4Mx.doEndAutoDJFadeOffAction = function() {
     midi.sendShortMsg(Hercules4Mx.NOnC1, 0x7C, 0x00);
 };
 
@@ -326,27 +506,145 @@ Hercules4Mx.onBeatFlash = function(value, group, control) {
     var deck = script.deckFromGroup(group);
     var val = (value) ? 0x7F : 0x00;
     var led = Hercules4Mx.userSettings.beatFlashLed;
-    switch(deck){
-        case 1: midi.sendShortMsg(Hercules4Mx.NOnC1, led, val); break;
-        case 2: midi.sendShortMsg(Hercules4Mx.NOnC1, led+0x20, val); break;
-        case 3: midi.sendShortMsg(Hercules4Mx.NOnC2, led, val); break;
-        case 4: midi.sendShortMsg(Hercules4Mx.NOnC2, led+0x20, val); break;
+    switch (deck) {
+        case 1:
+            midi.sendShortMsg(Hercules4Mx.NOnC1, led, val);
+            break;
+        case 2:
+            midi.sendShortMsg(Hercules4Mx.NOnC1, led + 0x20, val);
+            break;
+        case 3:
+            midi.sendShortMsg(Hercules4Mx.NOnC2, led, val);
+            break;
+        case 4:
+            midi.sendShortMsg(Hercules4Mx.NOnC2, led + 0x20, val);
+            break;
     }
 };
 // Deck's Sync led changed state
 Hercules4Mx.onSyncLed = function(value, group, control) {
     var deck = script.deckFromGroup(group);
-    var val = (value) ? 0x7F : 0x00;
-    switch(deck){
-        case 1: midi.sendShortMsg(Hercules4Mx.NOnC1, 0x11, val); break;
-        case 2: midi.sendShortMsg(Hercules4Mx.NOnC1, 0x31, val); break;
-        case 3: midi.sendShortMsg(Hercules4Mx.NOnC2, 0x11, val); break;
-        case 4: midi.sendShortMsg(Hercules4Mx.NOnC2, 0x31, val); break;
+    if (Hercules4Mx.editModeStatus.mode === Hercules4Mx.editModes.beatgrid) {
+        //beatgrid mode is activated for all decks (i.e. it is not needed to activate and deactivate one by one)
+        switch (deck) {
+            case 1:
+                midi.sendShortMsg(Hercules4Mx.NOnC1, 0x51, 1);
+                break;
+            case 2:
+                midi.sendShortMsg(Hercules4Mx.NOnC1, 0x71, 1);
+                break;
+            case 3:
+                midi.sendShortMsg(Hercules4Mx.NOnC2, 0x51, 1);
+                break;
+            case 4:
+                midi.sendShortMsg(Hercules4Mx.NOnC2, 0x71, 1);
+                break;
+        }
+    } else {
+        var val = (value) ? 0x7F : 0x00;
+        switch (deck) {
+            case 1:
+                midi.sendShortMsg(Hercules4Mx.NOnC1, 0x11, val);
+                midi.sendShortMsg(Hercules4Mx.NOnC1, 0x51, 0);
+                break;
+            case 2:
+                midi.sendShortMsg(Hercules4Mx.NOnC1, 0x31, val);
+                midi.sendShortMsg(Hercules4Mx.NOnC1, 0x71, 0);
+                break;
+            case 3:
+                midi.sendShortMsg(Hercules4Mx.NOnC2, 0x11, val);
+                midi.sendShortMsg(Hercules4Mx.NOnC2, 0x51, 0);
+                break;
+            case 4:
+                midi.sendShortMsg(Hercules4Mx.NOnC2, 0x31, val);
+                midi.sendShortMsg(Hercules4Mx.NOnC2, 0x71, 0);
+                break;
+        }
     }
 };
 
+// only feed the correct levels to each channel of the vumeter
+Hercules4Mx.onVuMeterMasterL = function(value) {
+    if (Hercules4Mx.VuMeterL.source === '[Master]') {
+        Hercules4Mx.updateVumeterEvent(Hercules4Mx.VuMeterL, value);
+    }
+};
+Hercules4Mx.onVuMeterMasterR = function(value) {
+    if (Hercules4Mx.VuMeterR.source === '[Master]') {
+        Hercules4Mx.updateVumeterEvent(Hercules4Mx.VuMeterR, value);
+    }
+};
+Hercules4Mx.onVuMeterDeck1 = function(value) {
+    if (Hercules4Mx.VuMeterL.source === '[Channel1]') {
+        Hercules4Mx.updateVumeterEvent(Hercules4Mx.VuMeterL, value);
+    }
+};
+Hercules4Mx.onVuMeterDeck2 = function(value) {
+    if (Hercules4Mx.VuMeterR.source === '[Channel2]') {
+        Hercules4Mx.updateVumeterEvent(Hercules4Mx.VuMeterR, value);
+    }
+};
+Hercules4Mx.onVuMeterDeck3 = function(value) {
+    if (Hercules4Mx.VuMeterL.source === '[Channel3]') {
+        Hercules4Mx.updateVumeterEvent(Hercules4Mx.VuMeterL, value);
+    }
+};
+Hercules4Mx.onVuMeterDeck4 = function(value) {
+    if (Hercules4Mx.VuMeterR.source === '[Channel4]') {
+        Hercules4Mx.updateVumeterEvent(Hercules4Mx.VuMeterR, value);
+    }
+};
+// update a vumeter channel
+Hercules4Mx.updateVumeterEvent = function(vumeter, value) {
+    var newval = parseInt(value * 0x80);
+    if (vumeter.lastvalue !== newval) {
+        vumeter.lastvalue = newval;
+        if (engine.getValue(vumeter.source, "PeakIndicator") > 0) {
+            // IF it clips, we put the top led on and the rest off, which gives a "flash" effect.
+            midi.sendShortMsg(vumeter.midichan, vumeter.clip, 0x7F);
+            newval = 0;
+        }
+        midi.sendShortMsg(vumeter.midichan, vumeter.clip, newval > 0x70 ? 0x7F : 0x00);
+        midi.sendShortMsg(vumeter.midichan, vumeter.vu3, newval > 0x60 ? 0x7F : 0x00);
+        midi.sendShortMsg(vumeter.midichan, vumeter.vu2, newval > 0x45 ? 0x7F : 0x00);
+        midi.sendShortMsg(vumeter.midichan, vumeter.vu1, newval > 0x15 ? 0x7F : 0x00);
+    }
+};
+
+// Duplicating for each deck because script.deckFromGroup does not work for equalizer controls.
+Hercules4Mx.onKillOrSourceChange1 = function(value, group, control) {
+    Hercules4Mx.updateVumeterSourceAction(Hercules4Mx.VuMeterL, 1);
+};
+Hercules4Mx.onKillOrSourceChange2 = function(value, group, control) {
+    Hercules4Mx.updateVumeterSourceAction(Hercules4Mx.VuMeterR, 2);
+};
+Hercules4Mx.onKillOrSourceChange3 = function(value, group, control) {
+    Hercules4Mx.updateVumeterSourceAction(Hercules4Mx.VuMeterL, 3);
+};
+Hercules4Mx.onKillOrSourceChange4 = function(value, group, control) {
+    Hercules4Mx.updateVumeterSourceAction(Hercules4Mx.VuMeterR, 4);
+};
+
+
 ///////////////////////////////////////////////////////////////////
 // --- Actions ----
+//Any of the shift buttons for effects has been pressed. This button simply changes
+//the controller internal state, but we can use it for other reasons while the user maintains it pressed.
+Hercules4Mx.pressEffectShift = function(midichan, control, value) {
+    // I don't diferentiate between decks. I don't expect two shift buttons being pressed at the same time.
+    Hercules4Mx.shiftStatus.pressed = (value) ? true : false;
+};
+//Indicator of the shift effect state change. This happens always after shift is released
+//We control if we let it change or not
+Hercules4Mx.stateEffectShift = function(midichan, control, value, status, group) {
+    if (Hercules4Mx.shiftStatus.used) {
+        //If shift state was changed because of the alternate shift usage, restore its state.
+        Hercules4Mx.shiftStatus.used = false;
+        var deck = script.deckFromGroup(group) - 1;
+        midi.sendShortMsg(Hercules4Mx.CC, 0x72 + deck, !value);
+    }
+};
+
 //Auto DJ button is pressed. Two functions: enable autoDJ, and Fade to next track.
 //The virtualDJ function is to do a fade to next in interactive mode (Mixxx fade to next requires autoDJ)
 //The would then be determined by the beats per minute.
@@ -364,7 +662,13 @@ Hercules4Mx.autoDJButton = function(midichan, control, value) {
 
 //Stop button is pressed in a deck.
 Hercules4Mx.stopButton = function(midichan, control, value, status, group) {
-    if (value) {
+    if (Hercules4Mx.shiftStatus.pressed || Hercules4Mx.shiftStatus.braking) { //Shifting: Do brake effect.
+        var deck = script.deckFromGroup(group);
+        engine.brake(deck, value ? true : false);
+        Hercules4Mx.shiftStatus.braking = value ? true : false;
+        //Tell shift button not to change state.
+        Hercules4Mx.shiftStatus.used = true;
+    } else if (value) { //Not shifting and pressed
         engine.setParameter(group, "cue_gotoandstop", 1);
 
         var stop1 = engine.getParameter("[Channel1]", "stop");
@@ -378,45 +682,295 @@ Hercules4Mx.stopButton = function(midichan, control, value, status, group) {
     }
 };
 
+//Play button is pressed in a deck.
+Hercules4Mx.playButton = function(midichan, control, value, status, group) {
+    if (Hercules4Mx.shiftStatus.pressed || Hercules4Mx.shiftStatus.reversing) { //Shifting: Do backward playback effect.
+        if (engine.getValue(group, "slip_enabled") !== 0) {
+            engine.setValue(group, "reverseroll", (value) ? 1 : 0);
+        } else {
+            engine.setValue(group, "reverse", (value) ? 1 : 0);
+        }
+        Hercules4Mx.shiftStatus.reversing = value ? true : false;
+        //Tell shift button not to change state.
+        Hercules4Mx.shiftStatus.used = true;
+    } else if (value) { //Not shifting and pressed
+        engine.setParameter(group, "play", !engine.getParameter(group, "play"));
+    }
+};
+
+Hercules4Mx.forwardButton = function(midichan, control, value, status, group) {
+    if (Hercules4Mx.shiftStatus.pressed) { //Shifting: Jump 1 beat forward.
+        if (value) {
+            engine.setValue(group, "beatjump_1_forward", 1);
+        }
+        //Tell shift button not to change state.
+        Hercules4Mx.shiftStatus.used = true;
+    } else {
+        //Jump 4 beats and enable Timer: if timer elapsed do "fwd"
+        if (value) {
+            engine.setValue(group, "beatjump_4_forward", 1);
+            if (Hercules4Mx.forwardRewindStatus.timeoutId !== null) {
+                //Safety measure, ensure timer is off
+                engine.stopTimer(Hercules4Mx.forwardRewindStatus.timeoutId);
+            }
+            Hercules4Mx.forwardRewindStatus.direction = 1;
+            Hercules4Mx.forwardRewindStatus.group = group;
+            Hercules4Mx.forwardRewindStatus.timeoutId = engine.beginTimer(Hercules4Mx.KeyHoldTime, Hercules4Mx.doForwardRewindAction, true);
+        } else {
+            engine.stopTimer(Hercules4Mx.forwardRewindStatus.timeoutId);
+            Hercules4Mx.forwardRewindStatus.timeoutId = null;
+            engine.setParameter(group, "fwd", 0);
+        }
+    }
+};
+
+Hercules4Mx.rewindButton = function(midichan, control, value, status, group) {
+    if (Hercules4Mx.shiftStatus.pressed) { //Shifting: Jump 1 beat backwards.
+        if (value) {
+            engine.setValue(group, "beatjump_1_backward", 1);
+        }
+        //Tell shift button not to change state.
+        Hercules4Mx.shiftStatus.used = true;
+    } else {
+        //Jump 4 beats and enable Timer: if timer elapsed do "back"
+        if (value) {
+            engine.setValue(group, "beatjump_4_backward", 1);
+            if (Hercules4Mx.forwardRewindStatus.timeoutId !== null) {
+                //Safety measure, ensure timer is off
+                engine.stopTimer(Hercules4Mx.forwardRewindStatus.timeoutId);
+            }
+            Hercules4Mx.forwardRewindStatus.direction = -1;
+            Hercules4Mx.forwardRewindStatus.group = group;
+            Hercules4Mx.forwardRewindStatus.timeoutId = engine.beginTimer(Hercules4Mx.KeyHoldTime, Hercules4Mx.doForwardRewindAction, true);
+        } else {
+            engine.stopTimer(Hercules4Mx.forwardRewindStatus.timeoutId);
+            Hercules4Mx.forwardRewindStatus.timeoutId = null;
+            engine.setParameter(group, "back", 0);
+        }
+    }
+};
+//Internal timer-called forward and rewind action.
+Hercules4Mx.doForwardRewindAction = function() {
+    if (Hercules4Mx.forwardRewindStatus.direction === 1) {
+        engine.setParameter(Hercules4Mx.forwardRewindStatus.group, "fwd", "1");
+    } else if (Hercules4Mx.forwardRewindStatus.direction === -1) {
+        engine.setParameter(Hercules4Mx.forwardRewindStatus.group, "back", "1");
+    }
+};
+
+
+Hercules4Mx.pScaleDownButton = function(midichan, control, value, status, group) {
+    if (Hercules4Mx.editModeStatus.mode === Hercules4Mx.editModes.beatgrid) { //Edit mode. Move the beatgrid to the left.
+        engine.setParameter(group, "beats_translate_earlier", value);
+    } else if (Hercules4Mx.shiftStatus.pressed && value) { // Shift mode: enable/disable keylock
+        engine.setParameter(group, "keylock", !engine.getParameter(group, "keylock"));
+        //Tell shift button not to change state.
+        Hercules4Mx.shiftStatus.used = true;
+    } else {
+        //Possible improvement: Add also timer to do repeat
+        engine.setParameter(group, "pitch_adjust_down_small", value);
+    }
+};
+
+Hercules4Mx.pScaleUpButton = function(midichan, control, value, status, group) {
+    if (Hercules4Mx.editModeStatus.mode === Hercules4Mx.editModes.beatgrid) { //Edit mode. Move the beatgrid to the right.
+        engine.setParameter(group, "beats_translate_later", value);
+    } else if (Hercules4Mx.shiftStatus.pressed && value) { // Shift mode: enable/disable quantize
+        engine.setParameter(group, "quantize", !engine.getParameter(group, "quantize"));
+        //Tell shift button not to change state.
+        Hercules4Mx.shiftStatus.used = true;
+    } else {
+        //Possible improvement: Add also timer to do repeat
+        engine.setParameter(group, "pitch_adjust_up_small", value);
+    }
+};
+
+Hercules4Mx.pBendDownButton = function(midichan, control, value, status, group) {
+    if (Hercules4Mx.editModeStatus.mode === Hercules4Mx.editModes.beatgrid) { //Edit mode. Reduce the BPM.
+        engine.setParameter(group, "beats_adjust_slower", value);
+    } else { //Normal mode: pitch bend down (change the rate down temporarily)
+        engine.setParameter(group, "rate_temp_down", value);
+    }
+};
+
+Hercules4Mx.pBendUpButton = function(midichan, control, value, status, group) {
+    if (Hercules4Mx.editModeStatus.mode === Hercules4Mx.editModes.beatgrid) { //Edit mode. Increase the BPM
+        engine.setParameter(group, "beats_adjust_faster", value);
+    } else { //Normal mode: pitch bend up (change the rate up temporarily)
+        engine.setParameter(group, "rate_temp_up", value);
+    }
+};
+
+Hercules4Mx.syncButton = function(midichan, control, value, status, group) {
+    if (Hercules4Mx.shiftStatus.pressed) { //Shifting: Enable beatgrid editing mode.
+        if (value) {
+            if (Hercules4Mx.editModeStatus.mode === Hercules4Mx.editModes.beatgrid) {
+                Hercules4Mx.deactivateEditModeAction();
+            } else if (Hercules4Mx.editModeStatus.mode !== Hercules4Mx.editModes.disabled) {
+                Hercules4Mx.deactivateEditModeAction();
+                Hercules4Mx.activateEditModeAction(Hercules4Mx.editModes.beatgrid, -1);
+            } else {
+                Hercules4Mx.activateEditModeAction(Hercules4Mx.editModes.beatgrid, -1);
+            }
+            //Tell shift button not to change state.
+            Hercules4Mx.shiftStatus.used = true;
+        }
+    } else if (Hercules4Mx.editModeStatus.mode === Hercules4Mx.editModes.beatgrid) { //Edit mode. Align the beatgrid to cursor or to other deck
+        if (value) {
+            if (engine.getParameter(group, "play") === 1) {
+                engine.setParameter(group, "beats_translate_match_alignment", 1);
+            } else {
+                engine.setParameter(group, "beats_translate_curpos", 1);
+            }
+        }
+    } else {
+        if (value) {
+            // sync_enabled acts as a switch so we set the opposite of the value that it has.
+            var newval;
+            if (engine.getValue(group, "sync_enabled") > 0) {
+                newval = 0;
+            } else {
+                newval = 1;
+            }
+            engine.setValue(group, "sync_enabled", newval);
+            if (newval === 1) {
+                // if it has been enabled by the above step, start the timer to see if we maintain the value or not when releasing the button.
+                if (Hercules4Mx.syncEnabledStatus.timeoutId !== null) {
+                    //Safety measure, ensure timer is off
+                    engine.stopTimer(Hercules4Mx.syncEnabledStatus.timeoutId);
+                }
+                //If pressed for 400 ms, activate master sync (sync_enabled), like it happens in the UI.
+                Hercules4Mx.syncEnabledStatus.triggered = 0;
+                Hercules4Mx.syncEnabledStatus.timeoutId = engine.beginTimer(Hercules4Mx.KeyHoldTime, Hercules4Mx.doSyncHoldAction, true);
+            }
+        } else {
+            if (Hercules4Mx.syncEnabledStatus.timeoutId !== null) {
+                if (Hercules4Mx.syncEnabledStatus.triggered === 0 && engine.getValue(group, "sync_enabled") === 1) {
+                    // only if the timer has not triggered, disable it
+                    engine.stopTimer(Hercules4Mx.syncEnabledStatus.timeoutId);
+                    engine.setValue(group, "sync_enabled", 0);
+                }
+                Hercules4Mx.syncEnabledStatus.timeoutId = null;
+            }
+        }
+    }
+};
+//Enter into/Exit the edit mode, which changes the functionality of several buttons to edit the beatgrid
+Hercules4Mx.activateEditModeAction = function(editMode, effect) {
+    if (editMode === Hercules4Mx.editModes.loop) {
+        var offset = (effect === 2 || effect === 4) ? 0x20 : 0x0;
+        var cccode = (effect > 2) ? Hercules4Mx.NOnC2 : Hercules4Mx.NOnC1;
+        midi.sendShortMsg(cccode, 0x41 + offset, 0x7F);
+        midi.sendShortMsg(cccode, 0x42 + offset, 0x7F);
+        midi.sendShortMsg(cccode, 0x43 + offset, 0x7F);
+        midi.sendShortMsg(cccode, 0x44 + offset, 0x7F);
+        midi.sendShortMsg(cccode, 0x45 + offset, 0x7F);
+        midi.sendShortMsg(cccode, 0x46 + offset, 0x7F);
+    } else {
+        //Activate blinking led
+        for (var i = 1; i <= 4; i++) {
+            var midicode = (i > 2) ? Hercules4Mx.NOnC2 : Hercules4Mx.NOnC1;
+            var side = (i === 2 || i === 4) ? 0x20 : 0x0;
+            //Todo: convert effect led changes to trigger
+            switch (editMode) {
+                case Hercules4Mx.editModes.beatgrid:
+                    engine.trigger("[Channel" + i + "]", "sync_enabled");
+                    break;
+                case Hercules4Mx.editModes.effects:
+                    midi.sendShortMsg(midicode, 0x40 + side + effect, 1);
+                    break;
+            }
+        }
+    }
+    Hercules4Mx.editModeStatus.mode = editMode;
+    Hercules4Mx.editModeStatus.effect = effect;
+};
+Hercules4Mx.deactivateEditModeAction = function() {
+    var effect;
+    if (Hercules4Mx.editModeStatus.mode === Hercules4Mx.editModes.loop) {
+        effect = Hercules4Mx.editModeStatus.effect;
+        var offset = (effect === 2 || effect === 4) ? 0x20 : 0x0;
+        var cccode = (effect > 2) ? Hercules4Mx.NOnC2 : Hercules4Mx.NOnC1;
+        midi.sendShortMsg(cccode, 0x41 + offset, 0x0);
+        midi.sendShortMsg(cccode, 0x42 + offset, 0x0);
+        midi.sendShortMsg(cccode, 0x43 + offset, 0x0);
+        midi.sendShortMsg(cccode, 0x44 + offset, 0x0);
+        midi.sendShortMsg(cccode, 0x45 + offset, 0x0);
+        midi.sendShortMsg(cccode, 0x46 + offset, 0x0);
+    } else {
+        effect = Hercules4Mx.editModeStatus.effect;
+        //Deactivate blinking led
+        for (var i = 1; i <= 4; i++) {
+            var midicode = (i > 2) ? Hercules4Mx.NOnC2 : Hercules4Mx.NOnC1;
+            var side = (i === 2 || i === 4) ? 0x20 : 0x0;
+            //Todo: convert effect led changes to trigger
+            switch (Hercules4Mx.editModeStatus.mode) {
+                case Hercules4Mx.editModes.beatgrid:
+                    engine.trigger("[Channel" + i + "]", "sync_enabled");
+                    break;
+                case Hercules4Mx.editModes.effects:
+                    midi.sendShortMsg(midicode, 0x40 + side + effect, 0);
+                    break;
+            }
+        }
+    }
+    Hercules4Mx.editModeStatus.mode = Hercules4Mx.editModes.disabled;
+    Hercules4Mx.editModeStatus.effect = -1;
+};
+//Internal timer called sync
+Hercules4Mx.doSyncHoldAction = function() {
+    Hercules4Mx.syncEnabledStatus.triggered = 1;
+};
+
 //Advanced navigation mode. 
+Hercules4Mx.navigationFiles = function(midichan, control, value, status, group) {
+    if (value) {
+        if (Hercules4Mx.navigationStatus.sidebar === false &&
+            engine.getParameter("[AutoDJ]", "enabled") === 1) {
+            // if autoDJ enabled and we are already at "files", skip next file
+            engine.setParameter("[AutoDJ]", "skip_next", 1);
+        } else {
+            Hercules4Mx.navigationStatus.sidebar = false;
+            midi.sendShortMsg(Hercules4Mx.NOnC1, 0x3E, 0x7F);
+            midi.sendShortMsg(Hercules4Mx.NOnC1, 0x3F, 0x00);
+            //When changing from another library folder, the cursor is not set on the list
+            //This forces it to be set and shouldn't affect if it hasn't changed.
+            engine.setParameter("[Playlist]", "SelectNextTrack", "1");
+            engine.setParameter("[Playlist]", "SelectPrevTrack", "1");
+        }
+    }
+};
+Hercules4Mx.navigationFolders = function(midichan, control, value, status, group) {
+    if (value) {
+        if (Hercules4Mx.navigationStatus.sidebar) {
+            //if we are already on sidebar, open/close group
+            engine.setParameter('[Playlist]', 'ToggleSelectedSidebarItem', 1);
+        }
+        Hercules4Mx.navigationStatus.sidebar = true;
+        midi.sendShortMsg(Hercules4Mx.NOnC1, 0x3E, 0x00);
+        midi.sendShortMsg(Hercules4Mx.NOnC1, 0x3F, 0x7F);
+    }
+};
 Hercules4Mx.navigation = function(midichan, control, value, status, group) {
     if (value) {
-        if (control === 0x3E) {
-            //FILES
-            if (Hercules4Mx.navigationStatus.sidebar === false && 
-                    engine.getParameter("[AutoDJ]", "enabled") === 1) {
-                // if autoDJ enabled and we are already at "files", skip next file
-                engine.setParameter("[AutoDJ]", "skip_next", 1);
-            } else {
-                Hercules4Mx.navigationStatus.sidebar = false;
-                midi.sendShortMsg(Hercules4Mx.NOnC1, 0x3E, 0x7F);
-                midi.sendShortMsg(Hercules4Mx.NOnC1, 0x3F, 0x00);
-            }
-        } else if (control === 0x3F) {
-            //FOLDERS
-            if (Hercules4Mx.navigationStatus.sidebar ) {
-                //if we are already on sidebar, open/close group
-                engine.setParameter('[Playlist]', 'ToggleSelectedSidebarItem', 1);
-            }
-            Hercules4Mx.navigationStatus.sidebar = true;
-            midi.sendShortMsg(Hercules4Mx.NOnC1, 0x3E, 0x00);
-            midi.sendShortMsg(Hercules4Mx.NOnC1, 0x3F, 0x7F);
-        } else if (control === 0x40) {
+        if (control === 0x40) {
             //UP
             Hercules4Mx.navigationStatus.direction = -1;
-            Hercules4Mx.navigationStatus.enabled = true;
-            Hercules4Mx.doNavigate();
-        } else if (control === 0x41) {
+        } else /*if (control === 0x41)*/ {
             //DOWN
             Hercules4Mx.navigationStatus.direction = 1;
-            Hercules4Mx.navigationStatus.enabled = true;
-            Hercules4Mx.doNavigate();
         }
-        if (Hercules4Mx.navigationStatus.enabled &&
-                Hercules4Mx.navigationStatus.timeoutId === null) {
-            //Enable key-repeat mode. Cursor will continue moving until button is released.
-            Hercules4Mx.navigationStatus.timeoutId = engine.beginTimer(Hercules4Mx.userSettings.naviScrollSpeed, Hercules4Mx.doNavigate);
+        if (Hercules4Mx.navigationStatus.timeoutId !== null) {
+            //Safety measure.
+            engine.stopTimer(Hercules4Mx.navigationStatus.timeoutId);
+            Hercules4Mx.navigationStatus.timeoutId = null;
         }
+        Hercules4Mx.navigationStatus.enabled = true;
+        Hercules4Mx.navigationStatus.isSingleShotTimer = false;
+        Hercules4Mx.doNavigateAction();
+        //Enable key-repeat mode. Cursor will continue moving until button is released.
+        Hercules4Mx.navigationStatus.isSingleShotTimer = true;
+        Hercules4Mx.navigationStatus.timeoutId = engine.beginTimer(Hercules4Mx.KeyHoldTime, Hercules4Mx.doNavigateAction, true);
     } else {
         //On key release disable navigation mode and stop key-repeat.
         Hercules4Mx.navigationStatus.direction = 0;
@@ -427,9 +981,13 @@ Hercules4Mx.navigation = function(midichan, control, value, status, group) {
         }
     }
 };
-
-// Internal navigate action.
-Hercules4Mx.doNavigate = function() {
+// Internal timer-called navigate action.
+Hercules4Mx.doNavigateAction = function() {
+    if (Hercules4Mx.navigationStatus.isSingleShotTimer) {
+        //Start the key-repeat timer.
+        Hercules4Mx.navigationStatus.timeoutId = engine.beginTimer(Hercules4Mx.userSettings.naviScrollSpeed, Hercules4Mx.doNavigateAction);
+        Hercules4Mx.navigationStatus.isSingleShotTimer = false;
+    }
     if (Hercules4Mx.navigationStatus.sidebar === false) {
         if (Hercules4Mx.navigationStatus.direction === 1) {
             engine.setParameter("[Playlist]", "SelectNextTrack", "1");
@@ -444,35 +1002,199 @@ Hercules4Mx.doNavigate = function() {
         }
     }
 };
-//Any of the shift buttons for effects has been pressed. This button simply changes
-//the controller internal state, but we can use it for other reasons while the user maintains it pressed.
-Hercules4Mx.pressEffectShift = function(midichan, control, value) {
-    // I don't diferentiate between decks. I don't expect two shift buttons being pressed at the same time.
-    Hercules4Mx.shiftPressed = (value) ? true : false;
-};
-//Indicator of the shift effect state change. This happens always after shift is released
-//We control if we let it change or not
-Hercules4Mx.stateEffectShift = function(midichan, control, value, status, group) {
-    if (Hercules4Mx.shiftUsed) {
-        //If shift state was changed because of the alternate shift usage, restore its state.
-        Hercules4Mx.shiftUsed = false;
-        var deck = script.deckFromGroup(group) - 1;
-        midi.sendShortMsg(Hercules4Mx.CC, 0x72 + deck, !value);
-    }
-};
 
-//The effect knob granularity is very coarse, so we compensate it here so that it behaves like an analog one.
+
+
 Hercules4Mx.effectKnob = function(midichan, control, value, status, group) {
+    var fxGroup;
     //It has a speed sensor, but you have to move it really fast for it to send something different.
-    var direction = (value < 0x40) ? value : value-0x80;
-    var step = 1 / 20;
-    if (Hercules4Mx.shiftPressed) {
+    var direction = (value < 0x40) ? value : value - 0x80;
+    //The effect knob granularity is very coarse, so we compensate it here so that it behaves like an analog one.
+    var step = 1 / 32;
+    if (Hercules4Mx.shiftStatus.pressed) {
         //If pressing shift, let's move it slowly.
         step = 1 / 127;
         //Tell shift button not to change state.
-        Hercules4Mx.shiftUsed = true;
+        Hercules4Mx.shiftStatus.used = true;
     }
-    engine.setParameter(group, "super1", engine.getParameter(group, "super1") + step * direction);
+    if (Hercules4Mx.shiftStatus.loopsizing) {
+        fxGroup = "[Channel" + group.slice(-3).substr(0, 1) + "]";
+        var action = (direction > 0) ? "loop_double" : "loop_halve";
+        engine.setValue(fxGroup, action, 1);
+        //"Releasing" the button.
+        engine.setValue(fxGroup, action, 0);
+        //TODO: do not use shifstatus.used
+        Hercules4Mx.shiftStatus.used = true;
+    } else if (Hercules4Mx.editModeStatus.mode === Hercules4Mx.editModes.effectknob) {
+        fxGroup = "[EffectRack1_EffectUnit" + Hercules4Mx.editModeStatus.effect + "]";
+        engine.setParameter(fxGroup, "super1", engine.getParameter(fxGroup, "super1") + step * direction);
+        //TODO: do not use shifstatus.used
+        Hercules4Mx.shiftStatus.used = true;
+    } else if (Hercules4Mx.editModeStatus.mode === Hercules4Mx.editModes.beatgrid) {
+        var Fxgroup = "[Channel" + group.slice(-3).substr(0, 1) + "]";
+        if (direction < 0) {
+            engine.setParameter(Fxgroup, "beats_translate_earlier", direction * -1);
+        } else {
+            engine.setParameter(Fxgroup, "beats_translate_later", direction);
+        }
+    } else {
+        engine.setParameter(group, "super1", engine.getParameter(group, "super1") + step * direction);
+    }
+};
+
+Hercules4Mx.FxActionNoOp = function(group, fxbutton, value, extraparam) {
+    if (Hercules4Mx.debuglog) {
+        engine.log("entering Hercules4Mx.FxActionNoOp");
+    }
+};
+Hercules4Mx.buttonPush = function(group, fxbutton, value, extraparam) {
+    if (Hercules4Mx.debuglog) {
+        engine.log("entering Hercules4Mx.buttonPush");
+    }
+    engine.setValue(group, extraparam, value);
+};
+Hercules4Mx.FxSwitchDown = function(group, fxbutton, value, extraparam) {
+    if (Hercules4Mx.debuglog) {
+        engine.log("entering Hercules4Mx.FxSwitchDown");
+    }
+    if (Hercules4Mx.editModeStatus.mode !== Hercules4Mx.editModes.disabled) {
+        Hercules4Mx.deactivateEditModeAction();
+    }
+    Hercules4Mx.activateEditModeAction(Hercules4Mx.editModes.effectknob, extraparam);
+    //TODO: do not use shifstatus.used
+    Hercules4Mx.shiftStatus.used = false;
+};
+Hercules4Mx.FxSwitchUp = function(group, fxbutton, value, extraparam) {
+    if (Hercules4Mx.debuglog) {
+        engine.log("entering Hercules4Mx.FxSwitchUp");
+    }
+    //TODO: do not use shifstatus.used
+    if (Hercules4Mx.shiftStatus.used === false) {
+        var deck = script.deckFromGroup(group);
+        var state = engine.getParameter("[EffectRack1_EffectUnit" + extraparam + "]", "group_[Channel" + deck + "]_enable");
+        engine.setParameter("[EffectRack1_EffectUnit" + extraparam + "]", "group_[Channel" + deck + "]_enable", !state);
+    }
+    Hercules4Mx.deactivateEditModeAction();
+};
+Hercules4Mx.FxSamplerPush = function(group, fxbutton, value, extraparam) {
+    if (Hercules4Mx.debuglog) {
+        engine.log("entering Hercules4Mx.FxSamplerPush");
+    }
+    var deck = script.deckFromGroup(group);
+    //Since the sampler does not depend on the deck, buttons on deck
+    // A/C are for samples 1/2 and buttons on deck B/D are for samples 3/4.
+    var newgroup;
+    if (deck === 1 || deck === 3) {
+        newgroup = "[Sampler" + extraparam + "]";
+    }
+    if (deck === 2 || deck === 4) {
+        newgroup = "[Sampler" + (2 + parseInt(extraparam)) + "]";
+    }
+    if (engine.getValue(newgroup, "play")) {
+        engine.setValue(newgroup, "start_stop", 1);
+    } else {
+        engine.setValue(newgroup, "start_play", 1);
+    }
+};
+/*
+ button 1: loop start and loop editing functionality -> 
+		loop enabled and is not one of the two preconfigured: button led is on
+		click: sets loop start (all 6 buttons start blinking). 
+		    If loop was already enabled, moves the start to the current position but does not disable the playing loop
+		click on button 2: set loop end and enable looping (stops blinking and sets led on buttons 1 and 2 to on).
+		click on any of the other 4 buttons: set loop to 2, 8, 16, 32 beats (stops blinking and sets led on button 1 to on).
+		click on button 1: forget start pos (discard loop) (stops blinking and no led is on).
+		click again release loop. 
+		click with shift pressed: Same as clic, but this will be a rolling loop
+		"mousedown" while loop is on and move knob: double or halve the loop. 
+
+ button 2: loop end, reloop functionality ->
+		loop present: button led is on.
+        click without a loop present: nothing
+		click with a loop present but not active: activate the loop (reloop)
+		click with shift pressed with a loop present but not active: Same as clic, but this will be a rolling loop
+		click when a loop is present and active: release loop
+		click when configuring a loop (see button 1): set loop end and enable looping.
+
+ buttons 3 and 4: predefined beat loops  -> (maybe user configurable which two he wants. by default could be 1 and 4 beats
+		click when this beatloop is not active: set a loop with specified beats and enable it. (button led is set to on).
+		click when this beatloop is active: release loop.
+        click with shift pressed:  Same as clic, but this will be a rolling loop
+
+ buttons 3 to 6: additional beat loops ->
+        click when loop editing has been enabled (see button 1): set beatloop of defined size and enable looping.
+
+*/
+Hercules4Mx.LoopEditPress = function(group, fxbutton, value, extraparam) {
+    if (Hercules4Mx.debuglog) {
+        engine.log("entering Hercules4Mx.LoopEditPress");
+    }
+    Hercules4Mx.shiftStatus.loopsizing = true;
+    //TODO: do not use shifstatus.used
+    Hercules4Mx.shiftStatus.used = false;
+};
+Hercules4Mx.LoopEditRelease = function(group, fxbutton, value, extraparam) {
+    if (Hercules4Mx.debuglog) {
+        engine.log("entering Hercules4Mx.LoopEditRelease");
+    }
+    //TODO: do not use shifstatus.used
+    if (Hercules4Mx.shiftStatus.used === false) {
+        var deck = script.deckFromGroup(group);
+        if (engine.getValue(group, "loop_enabled") === 0) {
+            if (Hercules4Mx.editModeStatus.mode !== Hercules4Mx.editModes.disabled) {
+                Hercules4Mx.deactivateEditModeAction();
+            }
+            Hercules4Mx.activateEditModeAction(Hercules4Mx.editModes.loop, deck);
+            engine.setValue(group, "loop_in", 1);
+            //"Releasing" the button.
+            engine.setValue(group, "loop_in", 0);
+        } else {
+            engine.setValue(group, "reloop_exit", 1);
+        }
+    }
+    Hercules4Mx.shiftStatus.loopsizing = false;
+};
+Hercules4Mx.LoopEditComplete = function(group, button) {
+    if (Hercules4Mx.debuglog) {
+        engine.log("Hercules4Mx.LoopEditComplete");
+    }
+    switch (button) {
+        case 1:
+            break;
+        case 2:
+            {
+                engine.setValue(group, "loop_out", 1);
+                //"Releasing" the button.
+                engine.setValue(group, "loop_out", 0);
+                break;
+            }
+        case 3:
+            engine.setValue(group, Hercules4Mx.beatLoopEditButtons[0], 1);
+            break;
+        case 4:
+            engine.setValue(group, Hercules4Mx.beatLoopEditButtons[1], 1);
+            break;
+        case 5:
+            engine.setValue(group, Hercules4Mx.beatLoopEditButtons[2], 1);
+            break;
+        case 6:
+            engine.setValue(group, Hercules4Mx.beatLoopEditButtons[3], 1);
+            break;
+    }
+};
+Hercules4Mx.LoopButtonPush = function(group, fxbutton, value, extraparam) {
+    if (Hercules4Mx.debuglog) {
+        engine.log("Hercules4Mx.LoopButtonPush");
+    }
+    var splitted = extraparam.split(";");
+    if (splitted[0] === "roll" && splitted.length === 2) {
+        if (engine.setValue(group, "loop_enabled") === 0 && value > 0) {
+            engine.setValue(group, "slip_enabled", value);
+        }
+        Hercules4Mx.buttonPush(group, fxbutton, value, splitted[1]);
+    } else if (splitted.length === 1) {
+        Hercules4Mx.buttonPush(group, fxbutton, value, extraparam);
+    }
 };
 
 // Any of the FX buttons has been pressed
@@ -481,131 +1203,37 @@ Hercules4Mx.effectKnob = function(midichan, control, value, status, group) {
 // Since the shift button also sends a message when it is pressed and when it is released,
 // I've been able to setup up to 24 different actions per deck.
 // I call these additional 12 messages the "shift-pressed" mode.
+// Some buttons have default actions if the button is maintained pressed (like play a hotcue), and others
+// have additional functionality (like editing the loop length , or using the effect superknob)
 Hercules4Mx.FXButton = function(midichan, control, value, status, group) {
-    var deck = script.deckFromGroup(group);
-    if (Hercules4Mx.shiftPressed) {
+    var fxbutton = (control > 0x20) ? control - 0x20 : control;
+    if (Hercules4Mx.shiftStatus.pressed) {
         //Tell shift not to change state.
-        Hercules4Mx.shiftUsed = true;
+        Hercules4Mx.shiftStatus.used = true;
+        fxbutton = fxbutton + 0x0C;
     }
-    switch (control) {
-        // 1 to 6 and 0x21 to 0x26 are the 6 left deck and right deck buttons respectively, with shift disabled.
-        // Loop buttons
-        case 0x01:
-        case 0x21: // K1, beatloop 1/ Loop in
-            if (value) {
-                //beatloop 0.125 in "shift-pressed" mode, beatloop of 0.5 beat otherwise
-                if (Hercules4Mx.shiftPressed) {
-                    engine.setValue(group, "beatloop_0.125_toggle", 1);
-                } else {
-                    engine.setValue(group, "beatloop_0.5_toggle", 1);
-                }
-            }
-            break;
-        case 0x02:
-        case 0x22: // K2, beatloop 2/ Loop out
-            if (value) {
-                //beatlook 0.25 in "shift-pressed" mode, beatloop of 1 beat otherwise
-                if (Hercules4Mx.shiftPressed) {
-                    engine.setValue(group, "beatloop_0.25_toggle", 1);
-                } else {
-                    engine.setValue(group, "beatloop_1_toggle", 1);
-                }
-            }
-            break;
-        case 0x03:
-        case 0x23: // K3, beatloop 4/ Reloop/Exit
-            if (value) {
-                //enable/disable loop in "shift-pressed" mode, beatloop of 2 beat otherwise
-                if (Hercules4Mx.shiftPressed) {
-                    engine.setValue(group, "reloop_exit", 1);
-                } else {
-                    engine.setValue(group, "beatloop_2_toggle", 1);
-                }
-            }
-            break;
-        case 0x04:
-        case 0x24: // K4, beatloop 8/ Reloop/Exit
-            if (value) {
-                //enable/disable loop in "shift-pressed" mode, beatloop of 4 beat otherwise
-                if (Hercules4Mx.shiftPressed) {
-                    engine.setValue(group, "reloop_exit", 1);
-                } else {
-                    engine.setValue(group, "beatloop_4_toggle", 1);
-                }
-            }
-            break;
-            // Reverse play buttons
-        case 0x05:
-        case 0x25: // K5, reverse play
-            engine.setValue(group, "reverse", (value) ? 1 : 0);
-            break;
-        case 0x06:
-        case 0x26: // K6, reverse roll play
-            engine.setValue(group, "reverseroll", (value) ? 1 : 0);
-            break;
-
-            // 7 to 0xC and 0x27 to 0x3C are the 6 left deck and right deck buttons respectively, with shift enabled.
-            // Hotcue buttons:
-        case 0x07:
-        case 0x27: // K7 Hotcue 1 activate/ clear
-            if (Hercules4Mx.shiftPressed) {
-                if (value) {
-                    engine.setValue(group, "hotcue_1_clear", 1);
-                }
-            } else {
-                engine.setValue(group, "hotcue_1_activate", (value) ? 1 : 0);
-            }
-            break;
-        case 0x08:
-        case 0x28: // K8 Hotcue 2 activate/ clear
-            if (Hercules4Mx.shiftPressed) {
-                if (value) {
-                    engine.setValue(group, "hotcue_2_clear", 1);
-                }
-            } else {
-                engine.setValue(group, "hotcue_2_activate", (value) ? 1 : 0);
-            }
-            break;
-        case 0x09:
-        case 0x29: // K9 Hotcue 3 activate/ clear
-            if (Hercules4Mx.shiftPressed) {
-                if (value) {
-                    engine.setValue(group, "hotcue_3_clear", 1);
-                }
-            } else {
-                engine.setValue(group, "hotcue_3_activate", (value) ? 1 : 0);
-            }
-            break;
-        case 0x0A:
-        case 0x2A: // K10 Hotcue 4 activate/ clear
-            if (Hercules4Mx.shiftPressed) {
-                if (value) {
-                    engine.setValue(group, "hotcue_4_clear", 1);
-                }
-            } else {
-                engine.setValue(group, "hotcue_4_activate", (value) ? 1 : 0);
-            }
-            break;
-            //Effects
-        case 0x0B:
-        case 0x2B: // K11. Effect Unit 1
-                if (value) {
-                    engine.setParameter("[EffectRack1_EffectUnit1]", "group_[Channel" + deck + "]_enable", !engine.getParameter("[EffectRack1_EffectUnit1]", "group_[Channel" + deck + "]_enable"));
-                }
-            break;
-        case 0x0C:
-        case 0x2C: // K12. Effect Unit 2
-                if (value) {
-                    engine.setParameter("[EffectRack1_EffectUnit2]", "group_[Channel" + deck + "]_enable", !engine.getParameter("[EffectRack1_EffectUnit2]", "group_[Channel" + deck + "]_enable"));
-                }
-            break;
+    // the array is zero based.
+    var mapping = Hercules4Mx.buttonMappings[fxbutton - 1];
+    var deck = script.deckFromGroup(group);
+    if (Hercules4Mx.editModeStatus.mode === Hercules4Mx.editModes.loop &&
+        Hercules4Mx.editModeStatus.effect === deck) {
+        if (value) {
+            //truncate the button pressed to the 6 physical positions.
+            Hercules4Mx.LoopEditComplete(group, ((fxbutton - 1) % 6) + 1);
+        } else {
+            Hercules4Mx.deactivateEditModeAction();
+        }
+    } else if (value) {
+        mapping.buttonPressAction(group, fxbutton, 1, mapping.extraParameter);
+    } else if (mapping.buttonReleaseAction !== null) {
+        mapping.buttonReleaseAction(group, fxbutton, 0, mapping.extraParameter);
     }
 };
 
 //Jog wheel moved without pressure (for seeking, speeding or slowing down, or navigating)
 Hercules4Mx.jogWheel = function(midichan, control, value, status, group) {
     //It has a speed sensor, but you have to move it really fast for it to send something different.
-    var direction = (value < 0x40) ? value : value-0x80;
+    var direction = (value < 0x40) ? value : value - 0x80;
     if (Hercules4Mx.navigationStatus.enabled) {
         if (Hercules4Mx.navigationStatus.timeoutId !== null) {
             //Stop key-repeat mode. From now on, obey only jog movement until button is released.
@@ -613,7 +1241,7 @@ Hercules4Mx.jogWheel = function(midichan, control, value, status, group) {
             Hercules4Mx.navigationStatus.timeoutId = null;
         }
         Hercules4Mx.navigationStatus.direction = direction;
-        Hercules4Mx.doNavigate();
+        Hercules4Mx.doNavigateAction();
     } else {
         engine.setValue(group, "jog", direction + engine.getValue(group, "jog"));
     }
@@ -623,15 +1251,15 @@ Hercules4Mx.jogWheel = function(midichan, control, value, status, group) {
 // Concretely, it tells if it has to ignore or not the pressure sensor in the jog wheel.
 Hercules4Mx.scratchButton = function(midichan, control, value, status, group) {
     if (value) {
-        if (Hercules4Mx.scratchEnabled ) {
+        if (Hercules4Mx.scratchEnabled) {
             Hercules4Mx.scratchEnabled = false;
-            midi.sendShortMsg(Hercules4Mx.NOnC1, 0x7D, 0x00);
+            midi.sendShortMsg(Hercules4Mx.NOnC1, 0x3D, 0x00);
             if (Hercules4Mx.userSettings.crossfaderScratchCurve) {
                 midi.sendShortMsg(Hercules4Mx.CC, 0x7E, 0x00);
             }
         } else {
             Hercules4Mx.scratchEnabled = true;
-            midi.sendShortMsg(Hercules4Mx.NOnC1, 0x7D, 0x7F);
+            midi.sendShortMsg(Hercules4Mx.NOnC1, 0x3D, 0x7F);
             if (Hercules4Mx.userSettings.crossfaderScratchCurve) {
                 midi.sendShortMsg(Hercules4Mx.CC, 0x7E, 0x7F);
             }
@@ -660,25 +1288,258 @@ Hercules4Mx.scratchWheel = function(midichan, control, value, status, group) {
         Hercules4Mx.jogWheel(midichan, control, value, status, group);
     } else {
         //It has a speed sensor, but you have to move it really fast for it to send something different.
-        var direction = (value < 0x40) ? value : value-0x80;
+        var direction = (value < 0x40) ? value : value - 0x80;
         engine.scratchTick(script.deckFromGroup(group), direction);
     }
 };
 
 // Pitch slider rate change, MSB (Most significant bits in 14bit mode, or directly the value in 7bit)
-Hercules4Mx.rateMsb = function(midichan, control, value, status, group) {
-    if (Hercules4Mx.pitch14bitMode) {
-        var deck = script.deckFromGroup(group);
-        Hercules4Mx.pitchMsbValue[deck-1]=value*0x80;
-    }
-    else {
-        engine.setParameter(group, "rate", value/0x7F);
+Hercules4Mx.deckRateMsb = function(midichan, control, value, status, group) {
+    var deck = script.deckFromGroup(group);
+    //Calculating this always, or else the first time will not work
+    //(which is precisely when the controller reports the initial positions)
+    Hercules4Mx.pitchMsbValue[deck - 1] = value * 0x80;
+    if (Hercules4Mx.pitch14bitMode === false) {
+        engine.setParameter(group, "rate", value / 0x7F);
     }
 };
 // Pitch slider rate change, LSB (Least significant bits in 14bit mode, not called in 7bit)
-Hercules4Mx.rateLsb = function(midichan, control, value, status, group) {
+Hercules4Mx.deckRateLsb = function(midichan, control, value, status, group) {
     var deck = script.deckFromGroup(group);
-    var msbval = Hercules4Mx.pitchMsbValue[deck-1];
+    var msbval = Hercules4Mx.pitchMsbValue[deck - 1];
     Hercules4Mx.pitch14bitMode = true;
-    engine.setParameter(group, "rate", (msbval+value)/0x3FFF);
+    engine.setValue(group, "rate", script.absoluteLin(msbval + value, -1, 1, 0, 0x3FFF));
+    //TODO: how to use script.midiPitch() instead?
+};
+
+//These are mapped with javascript so that engine.softTakeover can be enabled programatically.
+Hercules4Mx.deckGain = function(midichan, control, value, status, group) {
+    engine.setValue(group, "pregain", script.absoluteNonLin(value, 0, 1, 4));
+};
+Hercules4Mx.deckTreble = function(midichan, control, value, status, group) {
+    engine.setValue(group, "parameter3", script.absoluteNonLin(value, 0, 1, 4));
+};
+Hercules4Mx.deckMids = function(midichan, control, value, status, group) {
+    engine.setValue(group, "parameter2", script.absoluteNonLin(value, 0, 1, 4));
+};
+Hercules4Mx.deckBass = function(midichan, control, value, status, group) {
+    engine.setValue(group, "parameter1", script.absoluteNonLin(value, 0, 1, 4));
+};
+Hercules4Mx.deckVolume = function(midichan, control, value, status, group) {
+    engine.setValue(group, "volume", script.absoluteLin(value, 0, 1));
+};
+Hercules4Mx.crossfader = function(midichan, control, value, status, group) {
+    engine.setValue(group, "crossfader", script.absoluteLin(value, -1, 1));
+};
+
+// Deck C/D have been pressed.
+Hercules4Mx.deckCStateChange = function(midichan, control, value, status, group) {
+    Hercules4Mx.VuMeterL.midichan = (value > 0) ? 0x91 : 0x90;
+    Hercules4Mx.updateVumeterSourceAction(Hercules4Mx.VuMeterL, (value > 0) ? 3 : 1);
+};
+Hercules4Mx.deckDStateChange = function(midichan, control, value, status, group) {
+    Hercules4Mx.VuMeterR.midichan = (value > 0) ? 0x91 : 0x90;
+    Hercules4Mx.updateVumeterSourceAction(Hercules4Mx.VuMeterR, (value > 0) ? 4 : 2);
+};
+
+// Internal select what data is sent to the vumeter
+Hercules4Mx.updateVumeterSourceAction = function(vumeter, deck) {
+    var returnarray;
+    if (vumeter.midichan === 0x90) {
+        returnarray = Hercules4Mx.getNewDestinationChannel(vumeter.initchan);
+    } else /*if (vumeter.midichan === 0x91)*/ {
+        returnarray = Hercules4Mx.getNewDestinationChannel(vumeter.initchan + 2);
+    }
+    vumeter.source = returnarray[0];
+    if (vumeter.source === "[Disabled]") {
+        //If disabled, we have to ensure the kill leds are properly shown.
+        midi.sendShortMsg(vumeter.midichan, vumeter.clip, returnarray[2] > 0 ? 0x7F : 0x00);
+        midi.sendShortMsg(vumeter.midichan, vumeter.vu3, returnarray[3] > 0 ? 0x7F : 0x00);
+        midi.sendShortMsg(vumeter.midichan, vumeter.vu2, returnarray[4] > 0 ? 0x7F : 0x00);
+        midi.sendShortMsg(vumeter.midichan, vumeter.vu1, returnarray[5] > 0 ? 0x7F : 0x00);
+    } else {
+        //Forcing a refresh, because if the vumeter is at 0, Mixxx doesn't send the event.
+        vumeter.lastvalue = 0xFF;
+        Hercules4Mx.updateVumeterEvent(vumeter, 0);
+    }
+};
+//Internal function that returns what the vumeter should show for this deck
+Hercules4Mx.getNewDestinationChannel = function(chan) {
+    var pfl = engine.getParameter("[Channel" + chan + "]", "pfl");
+    var source = engine.getParameter("[Channel" + chan + "]", "passthrough");
+    var treble = engine.getParameter("[EqualizerRack1_[Channel" + chan + "]_Effect1]", "button_parameter3");
+    var mids = engine.getParameter("[EqualizerRack1_[Channel" + chan + "]_Effect1]", "button_parameter2");
+    var bass = engine.getParameter("[EqualizerRack1_[Channel" + chan + "]_Effect1]", "button_parameter1");
+    var returnarray = ["", pfl, source, treble, mids, bass];
+    if (bass > 0 || mids > 0 || treble > 0 || source > 0) {
+        returnarray[0] = "[Disabled]";
+    } else if (pfl > 0) {
+        returnarray[0] = "[Channel" + chan + "]";
+    } else {
+        returnarray[0] = "[Master]";
+    }
+    return returnarray;
+};
+
+//////////////////////////////////////////
+// FX button presets configuration.
+Hercules4Mx.reinitButtonsMap = function() {
+    Hercules4Mx.buttonMappings = Hercules4Mx.buttonMappings.slice(Hercules4Mx.buttonMappings.length);
+};
+Hercules4Mx.mapNewButton = function(pushAction, releaseAction, extraParameter, signalLed) {
+    var i;
+    var mapping = {};
+    mapping.buttonPressAction = pushAction;
+    mapping.buttonReleaseAction = releaseAction;
+    mapping.extraParameter = extraParameter;
+    mapping.ledToConnect = signalLed;
+    Hercules4Mx.buttonMappings.push(mapping);
+    if (Hercules4Mx.buttonMappings.length <= 12) { // The "shift" buttons do not have a differentiated led.
+        if (extraParameter === "reloop_exit") {
+            Hercules4Mx.beatLoopReloopPos = Hercules4Mx.buttonMappings.length;
+        }
+        if (pushAction === Hercules4Mx.LoopEditPress) {
+            Hercules4Mx.LoopEnabledPos = Hercules4Mx.buttonMappings.length;
+        }
+        if (signalLed !== null) {
+            for (i = 1; i <= 4; i++) {
+                engine.connectControl("[Channel" + i + "]", signalLed, "Hercules4Mx.onEnableLed");
+                engine.trigger("[Channel" + i + "]", signalLed);
+            }
+        }
+        if (pushAction === Hercules4Mx.FxSamplerPush) {
+            var curlen = Hercules4Mx.buttonMappings.length;
+            Hercules4Mx.samplerLedIdx.push(curlen);
+            Hercules4Mx.samplerLedIdx.push(0x20 + curlen);
+
+            engine.connectControl("[Sampler" + extraParameter + "]", "play_indicator", "Hercules4Mx.onSamplerStateChange");
+            engine.connectControl("[Sampler" + (2 + parseInt(extraParameter)) + "]", "play_indicator", "Hercules4Mx.onSamplerStateChange");
+            engine.trigger("[Sampler" + extraParameter + "]", "play_indicator");
+            engine.trigger("[Sampler" + (2 + parseInt(extraParameter)) + "]", "play_indicator");
+        }
+        if (pushAction === Hercules4Mx.FxSwitchDown) {
+            Hercules4Mx.FxLedIdx.push(Hercules4Mx.buttonMappings.length);
+            for (i = 1; i <= 4; i++) {
+                engine.connectControl("[EffectRack1_EffectUnit" + extraParameter + "]", "group_[Channel" + i + "]_enable", "Hercules4Mx.onEffectStateChange");
+                engine.trigger("[EffectRack1_EffectUnit" + extraParameter + "]", "group_[Channel" + i + "]_enable");
+            }
+        }
+    }
+};
+Hercules4Mx.completeButtonsMap = function() {
+    while (Hercules4Mx.buttonMappings.length < 24) {
+        Hercules4Mx.buttonMappings.push(Hercules4Mx.noActionButtonMap);
+    }
+    if (Hercules4Mx.LoopEnabledPos !== -1 || Hercules4Mx.beatLoopReloopPos !== -1) {
+        for (var i = 1; i <= 4; i++) {
+            engine.trigger("[Channel" + i + "]", "loop_enabled");
+        }
+    }
+};
+
+//Mappings of the buttons as described in the DJ Console Manual for Virtual DJ 7 LE.
+Hercules4Mx.setupFXButtonsLikeManual = function() {
+    Hercules4Mx.reinitButtonsMap();
+    Hercules4Mx.mapNewButton(Hercules4Mx.LoopEditPress, Hercules4Mx.LoopEditRelease, null, null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.ButtonPush, null, "reloop_exit", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "hotcue_1_activate", "hotcue_1_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "hotcue_2_activate", "hotcue_2_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "hotcue_3_activate", "hotcue_3_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "hotcue_4_activate", "hotcue_4_enabled");
+    //In VirtualDJ there is a recorder, which is not an option in Mixxx. So we simply play the samplers.
+    //Note: the implementation doubles the number of samples: Buttons on left deck use the value here, and buttons on right deck use "2 + value".
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxSamplerPush, null, "1", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxSamplerPush, null, "2", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxSwitchDown, Hercules4Mx.FxSwitchUp, "1", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxSwitchDown, Hercules4Mx.FxSwitchUp, "2", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxSwitchDown, Hercules4Mx.FxSwitchUp, "3", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxSwitchDown, Hercules4Mx.FxSwitchUp, "4", null);
+    //Shift-pressed actions. These do not exist on the original mapping, but having the hotcue clear options here is useful.
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxActionNoOp, null, null, null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxActionNoOp, null, null, null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "hotcue_1_clear", null, null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "hotcue_2_clear", null, null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "hotcue_3_clear", null, null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "hotcue_4_clear", null, null);
+
+    Hercules4Mx.completeButtonsMap();
+    // It is possible to configure the loop sizes of the buttons 3 to 6 when the loop editing mode has been activated.
+    // (activated by the "LoopEditPress" action, which is button 1 on original and mixxx21 mappings).
+    Hercules4Mx.beatLoopEditButtons.push("beatloop_1_toggle"); // loop edit mode, button 3
+    Hercules4Mx.beatLoopEditButtons.push("beatloop_4_toggle"); // loop edit mode, button 4
+    Hercules4Mx.beatLoopEditButtons.push("beatloop_8_toggle"); // loop edit mode, button 5
+    Hercules4Mx.beatLoopEditButtons.push("beatloop_16_toggle"); // loop edit mode, button 6
+};
+
+//Custom mapping adapted to the features of Mixxx. Version 2015-12-19 as published in 2.0.
+Hercules4Mx.setupFXButtonsCustomMixx20 = function() {
+    var beatloop1 = "beatloop_0.5";
+    var beatloop2 = "beatloop_1";
+    var beatloop3 = "beatloop_2";
+    var beatloop4 = "beatloop_4";
+    Hercules4Mx.reinitButtonsMap();
+    //Direct actions
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, beatloop1 + "_toggle", beatloop1 + "_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, beatloop2 + "_toggle", beatloop2 + "_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, beatloop3 + "_toggle", beatloop3 + "_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, beatloop4 + "_toggle", beatloop4 + "_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "reverse", "reverse");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "reverseroll", "reverseroll");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "hotcue_1_activate", "hotcue_1_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "hotcue_2_activate", "hotcue_2_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "hotcue_3_activate", "hotcue_3_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "hotcue_4_activate", "hotcue_4_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxSwitchDown, Hercules4Mx.FxSwitchUp, "1", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxSwitchDown, Hercules4Mx.FxSwitchUp, "2", null);
+    //Shift-pressed actions
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "beatloop_0.125_toggle", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "beatloop_0.25_toggle", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "reloop_exit", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "reloop_exit", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxActionNoOp, null, null, null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxActionNoOp, null, null, null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "hotcue_1_clear", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "hotcue_2_clear", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "hotcue_3_clear", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "hotcue_4_clear", null);
+    Hercules4Mx.completeButtonsMap();
+};
+
+//Custom mapping adapted to the features of Mixxx. Version 2016-08-xx for publishing in 2.1.
+Hercules4Mx.setupFXButtonsCustomMixx21 = function() {
+    var beatloop1 = "4";
+    var beatloop2 = "16";
+    Hercules4Mx.reinitButtonsMap();
+    //Direct actions
+    Hercules4Mx.mapNewButton(Hercules4Mx.LoopEditPress, Hercules4Mx.LoopEditRelease, null, null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.LoopButtonPush, null, "reloop_exit", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.LoopButtonPush, null, "beatloop_" + beatloop1 + "_toggle", "beatloop_" + beatloop1 + "_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.LoopButtonPush, null, "beatloop_" + beatloop2 + "_toggle", "beatloop_" + beatloop2 + "_enabled");
+    //Note: the implementation doubles the number of samples: Buttons on left deck use the value here, and buttons on right deck use "2 + value".
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxSamplerPush, null, "1", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxSamplerPush, null, "2", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "hotcue_1_activate", "hotcue_1_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "hotcue_2_activate", "hotcue_2_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "hotcue_3_activate", "hotcue_3_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, Hercules4Mx.buttonPush, "hotcue_4_activate", "hotcue_4_enabled");
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxSwitchDown, Hercules4Mx.FxSwitchUp, "1", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxSwitchDown, Hercules4Mx.FxSwitchUp, "2", null);
+    //Shift-pressed actions
+    Hercules4Mx.mapNewButton(Hercules4Mx.LoopEditPress, Hercules4Mx.LoopEditRelease, "roll", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.LoopButtonPush, null, "roll;reloop_exit", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.LoopButtonPush, null, "roll;beatloop_" + beatloop1 + "_toggle", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.LoopButtonPush, null, "roll;beatloop_" + beatloop2 + "_toggle", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxActionNoOp, null, null, null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.FxActionNoOp, null, null, null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "hotcue_1_clear", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "hotcue_2_clear", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "hotcue_3_clear", null);
+    Hercules4Mx.mapNewButton(Hercules4Mx.buttonPush, null, "hotcue_4_clear", null);
+    Hercules4Mx.completeButtonsMap();
+    // It is possible to configure the loop sizes of the buttons 3 to 6 when the loop editing mode has been activated.
+    // (activated by the "LoopEditPress" action, which is button 1 on original and mixxx21 mappings).
+    Hercules4Mx.beatLoopEditButtons.push("beatloop_1_toggle"); // loop edit mode, button 3
+    Hercules4Mx.beatLoopEditButtons.push("beatloop_2_toggle"); // loop edit mode, button 4
+    Hercules4Mx.beatLoopEditButtons.push("beatloop_8_toggle"); // loop edit mode, button 5
+    Hercules4Mx.beatLoopEditButtons.push("beatloop_32_toggle"); // loop edit mode, button 6
 };


### PR DESCRIPTION
New version of the mapping for the Hercules DJ Console 4-Mx. 
 Version 2016-09-22
        Beatgrid editing mode enabled with shift+sync. Allows to correct the beatgrid from the controller. 
        (For when you're in the middle of a mix and something is not properly aligned)
        Brake effect (power unplug) with shift+stop, backward playing moved to shift+play and forward and rewind by beats.
        Keylock, quantize and master sync (shift pitch scale up, shift pitch scale down and sync pressed for 400ms respectively).
        Improvements and fixes on sync button and navigation.
        Corrections in soft takeover, and initialization of control values from their physical positions on Mixxx startup.
        Audio vu meters on the kill/source buttons that switches between master and decks on PFL. Can be switched 
          off on userSettings. If kill or source buttons are activated, the vu on that channel is deactivated.
        Reimplemented the actions for Fx buttons. It now allows to have personalized mappings, and comes already with three:
          Manual/VirtualDJ setup, Mixxx 2.0 setup and a new setup that adds more functionality, like playing 4 samplers.
        New loop edit mode. It allows for a random length loop as well as more beatloop sizes. It is also possible to modify
          a loop size with the fx knob. See the updated wiki for a detailed explanation.
        The FX "super" knob can be controlled from the controller now. Maintain the fx button pressed and move the knob.
