### PR TITLE
Fix windows Build: activate QT initializer lists

### DIFF
--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -1,3 +1,11 @@
+// Horrible Hack to workaround QT 4.8 bug with MSVC compiler. lp:1627826
+// QT 4.8 explicitely disable Initializer list, but initializer list is
+// supported with MSVC 2012 SP2 +
+// http://code.qt.io/cgit/qt/qt.git/tree/src/corelib/global/qglobal.h#n910
+// TODO(XXX): Remove after QT4 deprecation, unneeded with QT5
+#ifdef __WINDOWS__
+  #define Q_COMPILER_INITIALIZER_LISTS
+#endif
 #include <QtDebug>
 #include <QMap>
 #include <QMutexLocker>

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -1,11 +1,11 @@
 // Horrible Hack to workaround QT 4.8 bug with MSVC compiler. lp:1627826
-// QT 4.8 explicitely disable Initializer list, but initializer list is
+// QT 4.8 explicitely disable Initializer lists, but initializer lists is
 // supported with MSVC 2012 SP2 +
 // http://code.qt.io/cgit/qt/qt.git/tree/src/corelib/global/qglobal.h#n910
 // TODO(XXX): Remove after QT4 deprecation, unneeded with QT5
-#ifdef __WINDOWS__
+#if _MSC_FULL_VER >= 180030324 // VC 12 SP 2 RC
   #define Q_COMPILER_INITIALIZER_LISTS
-#endif
+#endif /* VC 12 SP 2 RC */
 #include <QtDebug>
 #include <QMap>
 #include <QMutexLocker>

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -3,9 +3,9 @@
 // supported with MSVC 2012 SP2 +
 // http://code.qt.io/cgit/qt/qt.git/tree/src/corelib/global/qglobal.h#n910
 // TODO(XXX): Remove after QT4 deprecation, unneeded with QT5
-#if _MSC_FULL_VER >= 180030324 // VC 12 SP 2 RC
+#if _MSC_VER >= 1800 /* MSVS 2013 */
   #define Q_COMPILER_INITIALIZER_LISTS
-#endif /* VC 12 SP 2 RC */
+#endif /* MSVS 2013 */
 #include <QtDebug>
 #include <QMap>
 #include <QMutexLocker>

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -1,6 +1,6 @@
 // Horrible Hack to workaround QT 4.8 bug with MSVC compiler. lp:1627826
 // QT 4.8 explicitely disable Initializer lists, but initializer lists is
-// supported with MSVC 2012 SP2 +
+// supported with MSVC 2013 SP2 +
 // http://code.qt.io/cgit/qt/qt.git/tree/src/corelib/global/qglobal.h#n910
 // TODO(XXX): Remove after QT4 deprecation, unneeded with QT5
 #if _MSC_VER >= 1800 /* MSVS 2013 */


### PR DESCRIPTION
This PR fixes windows build lp:1627826

For the record: 
even if MSVC 2013 compiler supports initializer lists, QT 4.8 explicitly disables initializer lists with MSVC due to old MSVC 2012 bug.
http://code.qt.io/cgit/qt/qt.git/tree/src/corelib/global/qglobal.h#n910
