### PR TITLE
fix WriteID3v2Tag test

### DIFF
--- a/src/test/taglibtest.cpp
+++ b/src/test/taglibtest.cpp
@@ -34,7 +34,7 @@ TEST_F(TagLibTest, WriteID3v2Tag) {
     tmpFile.close(); // close before copying
 
     // Delete empty temporary file
-    ASSERT_TRUE(QFile::remove(tmpFileName));
+    ASSERT_TRUE(tmpFile.remove());
 
     // Copy original to temporary file
     QFile copiedFile(tmpFileName);


### PR DESCRIPTION
This PR fixes the TagLibTest.WriteID3v2Tag test on windows/MSVS

https://bugs.launchpad.net/mixxx/+bug/1628780
