### PR TITLE
rename Hercules DJ Control MP3 e2 mapping to indicate MP3 LE and Glow support

### DIFF
--- a/res/controllers/Hercules DJ Control MP3 e2.bulk.xml
+++ b/res/controllers/Hercules DJ Control MP3 e2.bulk.xml
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <MixxxControllerPreset mixxxVersion="1.11+" schemaVersion="1">
     <info>
-        <name>Hercules DJ Control MP3 e2</name>
+        <name>Hercules DJ Control MP3 e2 / MP3 LE / Glow</name>
         <author>Neale Pickett</author>
-        <description>Hercules DJ Control MP3 e2</description>
+        <description>Hercules DJ Control MP3 e2 / MP3 LE / Glow mapping. These three controllers have identical controls and share the same mapping.</description>
         <devices>
             <product protocol="bulk" vendor_id="0x06f8" product_id="0x0b105" in_epaddr="0x82" out_epaddr="0x03" />
+            <product protocol="bulk" vendor_id="0x06f8" product_id="0x0b120" in_epaddr="0x82" out_epaddr="0x03" />
         </devices>
     </info>
     <controller id="Hercules DJ Control MP3 e2">

--- a/res/controllers/Hercules DJ Control MP3 e2.midi.xml
+++ b/res/controllers/Hercules DJ Control MP3 e2.midi.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <MixxxMIDIPreset schemaVersion="1" mixxxVersion="2.0.0+">
   <info>
-    <name>Hercules DJ Control MP3 e2</name>
+    <name>Hercules DJ Control MP3 e2 / MP3 LE / Glow</name>
     <author>Gianfe, Taucher and SBlaisot</author>
-    <description>This is a complete mapping for Hercules DJ Control MP3 e2 controller. Requires scripting.</description>
+    <description>Hercules DJ Control MP3 e2 / MP3 LE / Glow mapping. These three controllers have identical controls and share the same mapping.</description>
      <wiki>http://www.mixxx.org/wiki/doku.php/hercules_dj_control_mp3_e2</wiki>
     <forums>http://mixxx.org/forums/viewtopic.php?f=7&amp;t=7173</forums>
   </info>


### PR DESCRIPTION
Thanks again to appendix on the forum: http://mixxx.org/forums/viewtopic.php?p=30384#p30384

Should the mapping files be renamed?
Does anyone know if the Hercules DJ Console Mk4 works with this mapping too? It also seems to have identical controls and is in the list of supported USB Bulk devices.
