### PR TITLE
user pkg-config for portaudio to obtain build flags

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -12,6 +12,8 @@ class PortAudio(Dependence):
         if not conf.CheckLib('portaudio'):
             raise Exception(
                 'Did not find libportaudio.a, portaudio.lib, or the PortAudio-v19 development header files.')
+        else:
+            build.env.ParseConfig('pkg-config portaudio-2.0 --silence-errors --cflags --libs')
 
         # Turn on PortAudio support in Mixxx
         build.env.Append(CPPDEFINES='__PORTAUDIO__')

--- a/build/depends.py
+++ b/build/depends.py
@@ -12,7 +12,7 @@ class PortAudio(Dependence):
         if not conf.CheckLib('portaudio'):
             raise Exception(
                 'Did not find libportaudio.a, portaudio.lib, or the PortAudio-v19 development header files.')
-        else:
+        elif build.platform_is_linux:
             build.env.ParseConfig('pkg-config portaudio-2.0 --silence-errors --cflags --libs')
 
         # Turn on PortAudio support in Mixxx


### PR DESCRIPTION
Ubuntu Trusty:
This works with the system provided portaudio library and the current release candidate. 
