### PR TITLE
Fix signal/slot connections of WStarRating and BaseTrackPlayer

### DIFF
--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1027,8 +1027,8 @@ QWidget* LegacySkinParser::parseStarRating(const QDomElement& node) {
 
     connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
             p, SLOT(slotTrackLoaded(TrackPointer)));
-    connect(pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
-            p, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
+    connect(pPlayer, SIGNAL(playerEmpty()),
+            p, SLOT(slotTrackLoaded()));
 
     TrackPointer pTrack = pPlayer->getLoadedTrack();
     if (pTrack) {

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -34,22 +34,19 @@ QSize WStarRating::sizeHint() const {
     return widgetSize;
 }
 
-void WStarRating::slotTrackLoaded(TrackPointer track) {
-    if (track) {
-        m_pCurrentTrack = track;
-        connect(track.data(), SIGNAL(changed(Track*)),
-                this, SLOT(updateRating(Track*)));
+void WStarRating::slotTrackLoaded(TrackPointer pTrack) {
+    if (m_pCurrentTrack != pTrack) {
+        if (m_pCurrentTrack) {
+            disconnect(&*m_pCurrentTrack, nullptr, this, nullptr);
+            m_pCurrentTrack = TrackPointer();
+        }
+        if (pTrack) {
+            connect(&*pTrack, SIGNAL(changed(Track*)),
+                    this, SLOT(updateRating(Track*)));
+            m_pCurrentTrack = pTrack;
+        }
         updateRating();
     }
-}
-
-void WStarRating::slotTrackUnloaded(TrackPointer track) {
-    Q_UNUSED(track);
-    if (m_pCurrentTrack) {
-        disconnect(m_pCurrentTrack.data(), nullptr, this, nullptr);
-    }
-    m_pCurrentTrack.clear();
-    updateRating();
 }
 
 void WStarRating::updateRating() {

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -20,8 +20,7 @@ class WStarRating : public WWidget {
     QSize sizeHint() const override;
 
   public slots:
-    void slotTrackLoaded(TrackPointer track);
-    void slotTrackUnloaded(TrackPointer track);
+    void slotTrackLoaded(TrackPointer pTrack = TrackPointer());
 
   private slots:
     void updateRating(Track*);


### PR DESCRIPTION
Fixes the following warning that occurs during startup:
Warning [Main]: Object::connect: No such slot WStarRating::slotLoadingTrack(TrackPointer, TrackPointer) in src/skin/legacyskinparser.cpp:1031
