### PR TITLE
Fix various signal/slot connections

### DIFF
--- a/src/library/dao/autodjcratesdao.cpp
+++ b/src/library/dao/autodjcratesdao.cpp
@@ -165,8 +165,8 @@ void AutoDJCratesDAO::createAutoDjCratesDatabase() {
 
     // Be notified when a track is modified.
     // We only care when the number of times it's been played changes.
-    connect(&m_rTrackDAO, SIGNAL(trackDirty(int)),
-            this, SLOT(slotTrackDirty(int)));
+    connect(&m_rTrackDAO, SIGNAL(trackDirty(TrackId)),
+            this, SLOT(slotTrackDirty(TrackId)));
 
     // Be notified when the status of crates changes.
     // We only care about the crates labeled as auto-DJ, and tracks added to,

--- a/src/library/dao/autodjcratesdao.cpp
+++ b/src/library/dao/autodjcratesdao.cpp
@@ -177,10 +177,10 @@ void AutoDJCratesDAO::createAutoDjCratesDatabase() {
             this, SLOT(slotCrateDeleted(int)));
     connect(&m_rCrateDAO, SIGNAL(autoDjChanged(int,bool)),
             this, SLOT(slotCrateAutoDjChanged(int,bool)));
-    connect(&m_rCrateDAO, SIGNAL(trackAdded(int,int)),
-            this, SLOT(slotCrateTrackAdded(int,int)));
-    connect(&m_rCrateDAO, SIGNAL(trackRemoved(int,int)),
-            this, SLOT(slotCrateTrackRemoved(int,int)));
+    connect(&m_rCrateDAO, SIGNAL(trackAdded(int,TrackId)),
+            this, SLOT(slotCrateTrackAdded(int,TrackId)));
+    connect(&m_rCrateDAO, SIGNAL(trackRemoved(int,TrackId)),
+            this, SLOT(slotCrateTrackRemoved(int,TrackId)));
 
     // Be notified when playlists are added/removed.
     // We only care about set-log playlists.

--- a/src/library/dao/autodjcratesdao.cpp
+++ b/src/library/dao/autodjcratesdao.cpp
@@ -191,10 +191,10 @@ void AutoDJCratesDAO::createAutoDjCratesDatabase() {
 
     // Be notified when tracks are added/removed from playlists.
     // We only care about the auto-DJ playlist and the set-log playlists.
-    connect(&m_rPlaylistDAO, SIGNAL(trackAdded(int,int,int)),
-            this, SLOT(slotPlaylistTrackAdded(int,int,int)));
-    connect(&m_rPlaylistDAO, SIGNAL(trackRemoved(int,int,int)),
-            this, SLOT(slotPlaylistTrackRemoved(int,int,int)));
+    connect(&m_rPlaylistDAO, SIGNAL(trackAdded(int,TrackId,int)),
+            this, SLOT(slotPlaylistTrackAdded(int,TrackId,int)));
+    connect(&m_rPlaylistDAO, SIGNAL(trackRemoved(int,TrackId,int)),
+            this, SLOT(slotPlaylistTrackRemoved(int,TrackId,int)));
 
     // Be notified when tracks are loaded to, or unloaded from, a deck.
     // These count as auto-DJ references, i.e. prevent the track from being

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1027,8 +1027,8 @@ QWidget* LegacySkinParser::parseStarRating(const QDomElement& node) {
 
     connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
             p, SLOT(slotTrackLoaded(TrackPointer)));
-    connect(pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
-            p, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
+    connect(pPlayer, SIGNAL(playerEmpty()),
+            p, SLOT(slotTrackLoaded()));
 
     TrackPointer pTrack = pPlayer->getLoadedTrack();
     if (pTrack) {

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -34,22 +34,19 @@ QSize WStarRating::sizeHint() const {
     return widgetSize;
 }
 
-void WStarRating::slotTrackLoaded(TrackPointer track) {
-    if (track) {
-        m_pCurrentTrack = track;
-        connect(track.data(), SIGNAL(changed(Track*)),
-                this, SLOT(updateRating(Track*)));
+void WStarRating::slotTrackLoaded(TrackPointer pTrack) {
+    if (m_pCurrentTrack != pTrack) {
+        if (m_pCurrentTrack) {
+            disconnect(&*m_pCurrentTrack, nullptr, this, nullptr);
+            m_pCurrentTrack = TrackPointer();
+        }
+        if (pTrack) {
+            connect(&*pTrack, SIGNAL(changed(Track*)),
+                    this, SLOT(updateRating(Track*)));
+            m_pCurrentTrack = pTrack;
+        }
         updateRating();
     }
-}
-
-void WStarRating::slotTrackUnloaded(TrackPointer track) {
-    Q_UNUSED(track);
-    if (m_pCurrentTrack) {
-        disconnect(m_pCurrentTrack.data(), nullptr, this, nullptr);
-    }
-    m_pCurrentTrack.clear();
-    updateRating();
 }
 
 void WStarRating::updateRating() {

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -20,8 +20,7 @@ class WStarRating : public WWidget {
     QSize sizeHint() const override;
 
   public slots:
-    void slotTrackLoaded(TrackPointer track);
-    void slotTrackUnloaded(TrackPointer track);
+    void slotTrackLoaded(TrackPointer pTrack = TrackPointer());
 
   private slots:
     void updateRating(Track*);


### PR DESCRIPTION
Some signal/slot connections got broken with the introduction of TrackId.

I wasn't aware that these type and naming mismatches are only detected at runtime in Qt 4. Another good reason for the migration to Qt 5!!
