### PR TITLE
modplug: check for nullptr when reading track metadata.

### DIFF
--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -67,6 +67,11 @@ Result SoundSourceModPlug::parseTrackMetadataAndCoverArt(
         QImage* /*pCoverArt*/) const {
     // The modplug library currently does not support reading cover-art from
     // modplug files -- kain88 (Oct 2014)
+
+    if (pTrackMetadata == nullptr) {
+        return ERR;
+    }
+
     QFile modFile(getLocalFileName());
     modFile.open(QIODevice::ReadOnly);
     const QByteArray fileBuf(modFile.readAll());
@@ -74,6 +79,7 @@ Result SoundSourceModPlug::parseTrackMetadataAndCoverArt(
 
     ModPlug::ModPlugFile* pModFile = ModPlug::ModPlug_Load(fileBuf.constData(),
             fileBuf.length());
+
     if (nullptr != pModFile) {
         pTrackMetadata->setComment(QString(ModPlug::ModPlug_GetMessage(pModFile)));
         pTrackMetadata->setTitle(QString(ModPlug::ModPlug_GetName(pModFile)));


### PR DESCRIPTION
The `parseTrackMetadataAndCoverArt` method is sometimes called with a `nullptr` argument for the track metadata pointer. This PR adds a simple check that immediately returns from the function in that case.

The ModPlug support is not built by default, but I still use it a lot in my personal setup ;-)
