### PR TITLE
Don't sync phase when latching a cue preview

### DIFF
--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -34,8 +34,6 @@ BpmControl::BpmControl(QString group,
         m_tapFilter(this, kFilterLength, kMaxInterval),
         m_sGroup(group) {
     m_pPlayButton = new ControlProxy(group, "play", this);
-    m_pPlayButton->connectValueChanged(SLOT(slotControlPlay(double)),
-            Qt::DirectConnection);
     m_pReverseButton = new ControlProxy(group, "reverse", this);
     m_pRateSlider = new ControlProxy(group, "rate", this);
     m_pRateSlider->connectValueChanged(SLOT(slotAdjustRateSlider()),
@@ -55,8 +53,6 @@ BpmControl::BpmControl(QString group,
     m_pLoopEnabled = new ControlProxy(group, "loop_enabled", this);
     m_pLoopStartPosition = new ControlProxy(group, "loop_start_position", this);
     m_pLoopEndPosition = new ControlProxy(group, "loop_end_position", this);
-
-    m_pVCEnabled = new ControlProxy(group, "vinylcontrol_enabled", this);
 
     m_pFileBpm = new ControlObject(ConfigKey(group, "file_bpm"));
     connect(m_pFileBpm, SIGNAL(valueChanged(double)),
@@ -239,14 +235,6 @@ void BpmControl::slotTapFilter(double averageLength, int numSamples) {
     double dRate = calcRateRatio();
     m_pFileBpm->set(averageBpm / dRate);
     slotAdjustRateSlider();
-}
-
-void BpmControl::slotControlPlay(double v) {
-    if (v > 0.0) {
-        if (m_pQuantize->get() > 0.0 && m_pVCEnabled->get() == 0) {
-            getEngineBuffer()->requestSyncPhase();
-        }
-    }
 }
 
 void BpmControl::slotControlBeatSyncPhase(double v) {

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -86,7 +86,6 @@ class BpmControl : public EngineControl {
     void slotAdjustBeatsSlower(double);
     void slotTranslateBeatsEarlier(double);
     void slotTranslateBeatsLater(double);
-    void slotControlPlay(double);
     void slotControlBeatSync(double);
     void slotControlBeatSyncPhase(double);
     void slotControlBeatSyncTempo(double);
@@ -109,6 +108,7 @@ class BpmControl : public EngineControl {
 
     // ControlObjects that come from EngineBuffer
     ControlProxy* m_pPlayButton;
+    QAtomicInt m_oldPlayButton;
     ControlProxy* m_pReverseButton;
     ControlProxy* m_pRateSlider;
     ControlObject* m_pQuantize;
@@ -124,8 +124,6 @@ class BpmControl : public EngineControl {
     ControlProxy* m_pLoopEnabled;
     ControlProxy* m_pLoopStartPosition;
     ControlProxy* m_pLoopEndPosition;
-
-    ControlProxy* m_pVCEnabled;
 
     // The current loaded file's detected BPM
     ControlObject* m_pFileBpm;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -641,7 +641,19 @@ void EngineBuffer::verifyPlay() {
 }
 
 void EngineBuffer::slotControlPlayRequest(double v) {
+    bool oldPlay = m_playButton->toBool();
     bool verifiedPlay = updateIndicatorsAndModifyPlay(v > 0.0);
+
+    if (!oldPlay && verifiedPlay) {
+        if (m_pQuantize->get() > 0.0
+#ifdef __VINYLCONTROL__
+                && m_pVinylControlControl && !m_pVinylControlControl->isEnabled()
+#endif
+        ) {
+            requestSyncPhase();
+        }
+    }
+
     // set and confirm must be called here in any case to update the widget toggle state
     m_playButton->setAndConfirm(verifiedPlay ? 1.0 : 0.0);
 }


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/mixxx/+bug/1564224

I have removed the phase syncing by play button when the track is already playing. 
