### PR TITLE
The level of verbosity of messages printed to the console can now be changed

### DIFF
--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -4,6 +4,7 @@
 #include "util/version.h"
 
 #include "sources/soundsourceproxy.h"
+#include "util/logging.h"
 
 
 CmdlineArgs::CmdlineArgs()
@@ -12,7 +13,7 @@ CmdlineArgs::CmdlineArgs()
       m_developer(false),
       m_safeMode(false),
       m_settingsPathSet(false),
-      m_debugLevel(1),
+      m_debugLevel(mixxx::kDebugLevelDefault),
 // We are not ready to switch to XDG folders under Linux, so keeping $HOME/.mixxx as preferences folder. see lp:1463273
 #ifdef __LINUX__
     m_settingsPath(QDir::homePath().append("/").append(SETTINGS_PATH)) {
@@ -53,16 +54,14 @@ bool CmdlineArgs::Parse(int &argc, char **argv) {
         } else if (argv[i] == QString("--timelinePath") && i+1 < argc) {
             m_timelinePath = QString::fromLocal8Bit(argv[i+1]);
             i++;
-        } else if (argv[i] == QString("--debugLevel") && i+1 < argc) { // Set cmdline message verbosity
-            bool isInt; // Scoped variable, will be destroyed at the end of this block @vhexs
-            m_debugLevel = QString::fromLocal8Bit(argv[i+1]).toInt(&isInt); // Try conversion, if it's not an int
-                                                                            // then the if statement below will
-                                                                            // set m_debugLevel back to its
-                                                                            // default value of 1
-            if (!isInt) {
+        } else if (argv[i] == QString("--debugLevel") && i+1 < argc) {
+            bool isInt = false;
+            int debugLevelRq = QString::fromLocal8Bit(argv[i+1]).toInt(&isInt);
+            if (isInt) {
+                m_debugLevel = debugLevelRq;
+            } else {
                 fputs("\ndebugLevel argument wasn't a number! Mixxx will only output\n\
 warnings and errors to the console unless this is set properly.\n", stdout);
-                m_debugLevel = 1;
             }
             i++;
         } else if (QString::fromLocal8Bit(argv[i]).contains("--midiDebug", Qt::CaseInsensitive) ||

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -12,6 +12,7 @@ CmdlineArgs::CmdlineArgs()
       m_developer(false),
       m_safeMode(false),
       m_settingsPathSet(false),
+      m_debugLevel(1),
 // We are not ready to switch to XDG folders under Linux, so keeping $HOME/.mixxx as preferences folder. see lp:1463273
 #ifdef __LINUX__
     m_settingsPath(QDir::homePath().append("/").append(SETTINGS_PATH)) {
@@ -52,12 +53,23 @@ bool CmdlineArgs::Parse(int &argc, char **argv) {
         } else if (argv[i] == QString("--timelinePath") && i+1 < argc) {
             m_timelinePath = QString::fromLocal8Bit(argv[i+1]);
             i++;
+        } else if (argv[i] == QString("--debugLevel") && i+1 < argc) { // Set cmdline message verbosity
+            bool isInt; // Scoped variable, will be destroyed at the end of this block @vhexs
+            m_debugLevel = QString::fromLocal8Bit(argv[i+1]).toInt(&isInt); // Try conversion, if it's not an int
+                                                                            // then the if statement below will
+                                                                            // set m_debugLevel back to its
+                                                                            // default value of 1
+            if (!isInt) {
+                fputs("\ndebugLevel argument wasn't a number! Mixxx will only output\n\
+warnings and errors to the console unless this is set properly.\n", stdout);
+                m_debugLevel = 1;
+            }
+            i++;
         } else if (QString::fromLocal8Bit(argv[i]).contains("--midiDebug", Qt::CaseInsensitive) ||
                    QString::fromLocal8Bit(argv[i]).contains("--controllerDebug", Qt::CaseInsensitive)) {
             m_midiDebug = true;
         } else if (QString::fromLocal8Bit(argv[i]).contains("--developer", Qt::CaseInsensitive)) {
             m_developer = true;
-
         } else if (QString::fromLocal8Bit(argv[i]).contains("--safeMode", Qt::CaseInsensitive)) {
             m_safeMode = true;
         } else {
@@ -112,6 +124,11 @@ void CmdlineArgs::printUsage() {
                         (e.g 'fr')\n\
 \n\
 -f, --fullScreen        Starts Mixxx in full-screen mode\n\
+\n\
+-debugLevel LEVEL       Sets the verbosity of command line debug messages\n\
+                        0 - Critical/Fatal only\n\
+                        1 - Above + Warnings\n\
+                        2 - Above + Debug/Developer messages\n\
 \n\
 -h, --help              Display this help message and exit", stdout);
 

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -43,7 +43,7 @@ class CmdlineArgs final {
     bool m_developer; // Developer Mode
     bool m_safeMode;
     bool m_settingsPathSet; // has --settingsPath been set on command line ?
-    int m_debugLevel; // Level of debug message verbosity (logging.cpp)
+    int m_debugLevel; // Level of debug message verbosity
     QString m_locale;
     QString m_settingsPath;
     QString m_resourcePath;

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -42,6 +42,7 @@ class CmdlineArgs final {
     bool m_developer; // Developer Mode
     bool m_safeMode;
     bool m_settingsPathSet; // has --settingsPath been set on command line ?
+    int m_debugLevel; // Level of debug message verbosity (logging.cpp)
     QString m_locale;
     QString m_settingsPath;
     QString m_resourcePath;

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -23,6 +23,7 @@ class CmdlineArgs final {
     bool getDeveloper() const { return m_developer; }
     bool getSafeMode() const { return m_safeMode; }
     bool getSettingsPathSet() const { return m_settingsPathSet; }
+    int getDebugLevel() const { return m_debugLevel; }
     bool getTimelineEnabled() const { return !m_timelinePath.isEmpty(); }
     const QString& getLocale() const { return m_locale; }
     const QString& getSettingsPath() const { return m_settingsPath; }

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -21,7 +21,7 @@ namespace {
 
 QFile Logfile;
 QMutex mutexLogfile;
-int debugLevel; // enum in cmdlineargs.h
+int debugLevel;
 
 // Debug message handler which outputs to both a logfile and prepends the thread
 // the message came from.

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -21,7 +21,7 @@ namespace {
 
 QFile Logfile;
 QMutex mutexLogfile;
-int debugLevel;
+int debugLevel; // enum in cmdlineargs.h
 
 // Debug message handler which outputs to both a logfile and prepends the thread
 // the message came from.
@@ -88,37 +88,34 @@ void MessageHandler(QtMsgType type,
         Logfile.open(QIODevice::WriteOnly | QIODevice::Text);
     }
 
-    debugLevel = CmdlineArgs::Instance().getDebugLevel(); // Get verbosity level
+    debugLevel = CmdlineArgs::Instance().getDebugLevel(); // Get message verbosity
 
     switch (type) {
-    // debugLevel is set to 1 by default, can be changed with the cmdline
-    // argument "--debugLevel". Items here are always written to the logfile,
-    // however only Fatal & Critical are displayed on the console by default.
     case QtDebugMsg: // debugLevel 2
-        if (debugLevel > 1)
-            fprintf(stderr, "Debug: %s", ba.constData());
+        if (debugLevel > kDebugLevelDefault)
+            fprintf(stderr, "Debug %s", ba.constData());
         if (Logfile.isOpen()) {
             Logfile.write("Debug ");
             Logfile.write(ba);
         }
         break;
     case QtWarningMsg: // debugLevel 1
-        if (debugLevel > 0)
-            fprintf(stderr, "Warning: %s", ba.constData());
+        if (debugLevel > kDebugLevelMin)
+            fprintf(stderr, "Warning %s", ba.constData());
         if (Logfile.isOpen()) {
             Logfile.write("Warning ");
             Logfile.write(ba);
         }
         break;
     case QtCriticalMsg: // debugLevel 0 (always shown)
-        fprintf(stderr, "Critical: %s", ba.constData());
+        fprintf(stderr, "Critical %s", ba.constData());
         if (Logfile.isOpen()) {
             Logfile.write("Critical ");
             Logfile.write(ba);
         }
         break; //NOTREACHED
     case QtFatalMsg: // debugLevel 0 (always shown)
-        fprintf(stderr, "Fatal: %s", ba.constData());
+        fprintf(stderr, "Fatal %s", ba.constData());
         if (Logfile.isOpen()) {
             Logfile.write("Fatal ");
             Logfile.write(ba);
@@ -126,7 +123,7 @@ void MessageHandler(QtMsgType type,
         break; //NOTREACHED
     default: // debugLevel unknown, we'll assume Warning
         if (debugLevel > 0)
-            fprintf(stderr, "Unknown: %s", ba.constData());
+            fprintf(stderr, "Unknown %s", ba.constData());
         if (Logfile.isOpen()) {
             Logfile.write("Unknown ");
             Logfile.write(ba);

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -88,6 +88,8 @@ void MessageHandler(QtMsgType type,
         Logfile.open(QIODevice::WriteOnly | QIODevice::Text);
     }
 
+    debugLevel = CmdlineArgs::Instance().getDebugLevel(); // Get verbosity level
+
     switch (type) {
     // debugLevel is set to 1 by default, can be changed with the cmdline
     // argument "--debugLevel". Items here are always written to the logfile,

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -21,6 +21,7 @@ namespace {
 
 QFile Logfile;
 QMutex mutexLogfile;
+int debugLevel;
 
 // Debug message handler which outputs to both a logfile and prepends the thread
 // the message came from.
@@ -88,36 +89,42 @@ void MessageHandler(QtMsgType type,
     }
 
     switch (type) {
-    case QtDebugMsg:
-        fprintf(stderr, "Debug %s", ba.constData());
+    // debugLevel is set to 1 by default, can be changed with the cmdline
+    // argument "--debugLevel". Items here are always written to the logfile,
+    // however only Fatal & Critical are displayed on the console by default.
+    case QtDebugMsg: // debugLevel 2
+        if (debugLevel > 1)
+            fprintf(stderr, "Debug: %s", ba.constData());
         if (Logfile.isOpen()) {
             Logfile.write("Debug ");
             Logfile.write(ba);
         }
         break;
-    case QtWarningMsg:
-        fprintf(stderr, "Warning %s", ba.constData());
+    case QtWarningMsg: // debugLevel 1
+        if (debugLevel > 0)
+            fprintf(stderr, "Warning: %s", ba.constData());
         if (Logfile.isOpen()) {
             Logfile.write("Warning ");
             Logfile.write(ba);
         }
         break;
-    case QtCriticalMsg:
-        fprintf(stderr, "Critical %s", ba.constData());
+    case QtCriticalMsg: // debugLevel 0 (always shown)
+        fprintf(stderr, "Critical: %s", ba.constData());
         if (Logfile.isOpen()) {
             Logfile.write("Critical ");
             Logfile.write(ba);
         }
         break; //NOTREACHED
-    case QtFatalMsg:
-        fprintf(stderr, "Fatal %s", ba.constData());
+    case QtFatalMsg: // debugLevel 0 (always shown)
+        fprintf(stderr, "Fatal: %s", ba.constData());
         if (Logfile.isOpen()) {
             Logfile.write("Fatal ");
             Logfile.write(ba);
         }
         break; //NOTREACHED
-    default:
-        fprintf(stderr, "Unknown %s", ba.constData());
+    default: // debugLevel unknown, we'll assume Warning
+        if (debugLevel > 0)
+            fprintf(stderr, "Unknown: %s", ba.constData());
         if (Logfile.isOpen()) {
             Logfile.write("Unknown ");
             Logfile.write(ba);

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -3,11 +3,13 @@
 
 namespace mixxx {
 
+static const int kDebugLevelMin = 0;
+static const int kDebugLevelDefault = 1;
+
 class Logging {
   public:
     static void initialize();
     static void shutdown();
-
   private:
     Logging() = delete;
 };


### PR DESCRIPTION
As suggested in bug #1636626, the level of verbosity for messages printed to the console can now be changed with the command line argument `--debugLevel <0-2>`.

* 0 - Show only Fatal and Critical messages. These are always shown.
* 1 - Show above + Warning messages. This is the default option chosen when `--debugLevel` isn't set or when it's set to a non-integer value.
* 2 - Show above + Debug messages.

Anything above 2 won't make a difference, as there are only 3 levels of debug messages. A negative integer will, in theory, set `debugLevel` to 0, as Fatal and Critical never need to check what the argument is set to.

This is my first PR on a large project so I hope I'm doing this right. I've tested it and it appears to be working as it should. Some logging messages may need updating to split them better between errors, warnings, etc.