### PR TITLE
Prepare to switch from QSharedPointer to std::shared_ptr

### DIFF
--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -215,7 +215,7 @@ void AnalyzerBeats::finalize(TrackPointer tio) {
     QHash<QString, QString> extraVersionInfo = getExtraVersionInfo(
         m_pluginId, m_bPreferencesFastAnalysis);
     BeatsPointer pBeats = BeatFactory::makePreferredBeats(
-        tio, beats, extraVersionInfo,
+        *tio, beats, extraVersionInfo,
         m_bPreferencesFixedTempo, m_bPreferencesOffsetCorrection,
         m_iSampleRate, m_iTotalSamples,
         m_iMinBpm, m_iMaxBpm);

--- a/src/analyzer/analyzerqueue.cpp
+++ b/src/analyzer/analyzerqueue.cpp
@@ -294,7 +294,7 @@ void AnalyzerQueue::run() {
     if (m_aq.size() == 0)
         return;
 
-    m_progressInfo.current_track = TrackPointer();
+    m_progressInfo.current_track.reset();
     m_progressInfo.track_progress = 0;
     m_progressInfo.queue_size = 0;
     m_progressInfo.sema.release(); // Initialize with one
@@ -409,7 +409,7 @@ void AnalyzerQueue::slotUpdateProgress() {
     if (m_progressInfo.current_track) {
         m_progressInfo.current_track->setAnalyzerProgress(
         		m_progressInfo.track_progress);
-        m_progressInfo.current_track = TrackPointer();
+        m_progressInfo.current_track.reset();
     }
     emit(trackProgress(m_progressInfo.track_progress / 10));
     if (m_progressInfo.track_progress == 1000) {

--- a/src/analyzer/analyzerqueue.cpp
+++ b/src/analyzer/analyzerqueue.cpp
@@ -294,7 +294,7 @@ void AnalyzerQueue::run() {
     if (m_aq.size() == 0)
         return;
 
-    m_progressInfo.current_track.clear();
+    m_progressInfo.current_track = TrackPointer();
     m_progressInfo.track_progress = 0;
     m_progressInfo.queue_size = 0;
     m_progressInfo.sema.release(); // Initialize with one
@@ -409,7 +409,7 @@ void AnalyzerQueue::slotUpdateProgress() {
     if (m_progressInfo.current_track) {
         m_progressInfo.current_track->setAnalyzerProgress(
         		m_progressInfo.track_progress);
-        m_progressInfo.current_track.clear();
+        m_progressInfo.current_track = TrackPointer();
     }
     emit(trackProgress(m_progressInfo.track_progress / 10));
     if (m_progressInfo.track_progress == 1000) {

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -739,7 +739,7 @@ void BpmControl::slotAdjustRateSlider() {
 void BpmControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     Q_UNUSED(pOldTrack);
     if (m_pTrack) {
-        disconnect(&*m_pTrack, SIGNAL(beatsUpdated()),
+        disconnect(m_pTrack.get(), SIGNAL(beatsUpdated()),
                    this, SLOT(slotUpdatedTrackBeats()));
     }
 
@@ -749,7 +749,7 @@ void BpmControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     if (pNewTrack) {
         m_pTrack = pNewTrack;
         m_pBeats = m_pTrack->getBeats();
-        connect(&*m_pTrack, SIGNAL(beatsUpdated()),
+        connect(m_pTrack.get(), SIGNAL(beatsUpdated()),
                 this, SLOT(slotUpdatedTrackBeats()));
     } else {
         m_pTrack = TrackPointer();

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -739,7 +739,7 @@ void BpmControl::slotAdjustRateSlider() {
 void BpmControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     Q_UNUSED(pOldTrack);
     if (m_pTrack) {
-        disconnect(m_pTrack.data(), SIGNAL(beatsUpdated()),
+        disconnect(&*m_pTrack, SIGNAL(beatsUpdated()),
                    this, SLOT(slotUpdatedTrackBeats()));
     }
 
@@ -749,10 +749,10 @@ void BpmControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     if (pNewTrack) {
         m_pTrack = pNewTrack;
         m_pBeats = m_pTrack->getBeats();
-        connect(m_pTrack.data(), SIGNAL(beatsUpdated()),
+        connect(&*m_pTrack, SIGNAL(beatsUpdated()),
                 this, SLOT(slotUpdatedTrackBeats()));
     } else {
-        m_pTrack.clear();
+        m_pTrack = TrackPointer();
         m_pBeats.clear();
     }
 }

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -752,7 +752,7 @@ void BpmControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
         connect(m_pTrack.get(), SIGNAL(beatsUpdated()),
                 this, SLOT(slotUpdatedTrackBeats()));
     } else {
-        m_pTrack = TrackPointer();
+        m_pTrack.reset();
         m_pBeats.clear();
     }
 }

--- a/src/engine/cachingreaderworker.cpp
+++ b/src/engine/cachingreaderworker.cpp
@@ -80,7 +80,7 @@ void CachingReaderWorker::run() {
             { // locking scope
                 QMutexLocker locker(&m_newTrackMutex);
                 pLoadTrack = m_newTrack;
-                m_newTrack = TrackPointer();
+                m_newTrack.reset();
             } // implicitly unlocks the mutex
             loadTrack(pLoadTrack);
         } else if (m_pChunkReadRequestFIFO->read(&request, 1) == 1) {

--- a/src/engine/clockcontrol.cpp
+++ b/src/engine/clockcontrol.cpp
@@ -35,7 +35,7 @@ void ClockControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
                 this, SLOT(slotBeatsUpdated()));
     } else {
         m_pBeats.clear();
-        m_pTrack = TrackPointer();
+        m_pTrack.reset();
     }
 
 }

--- a/src/engine/clockcontrol.cpp
+++ b/src/engine/clockcontrol.cpp
@@ -25,13 +25,13 @@ void ClockControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
 
     // Disconnect any previously loaded track/beats
     if (m_pTrack) {
-        disconnect(&*m_pTrack, SIGNAL(beatsUpdated()),
+        disconnect(m_pTrack.get(), SIGNAL(beatsUpdated()),
                    this, SLOT(slotBeatsUpdated()));
     }
     if (pNewTrack) {
         m_pTrack = pNewTrack;
         m_pBeats = m_pTrack->getBeats();
-        connect(&*m_pTrack, SIGNAL(beatsUpdated()),
+        connect(m_pTrack.get(), SIGNAL(beatsUpdated()),
                 this, SLOT(slotBeatsUpdated()));
     } else {
         m_pBeats.clear();

--- a/src/engine/clockcontrol.cpp
+++ b/src/engine/clockcontrol.cpp
@@ -25,17 +25,17 @@ void ClockControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
 
     // Disconnect any previously loaded track/beats
     if (m_pTrack) {
-        disconnect(m_pTrack.data(), SIGNAL(beatsUpdated()),
+        disconnect(&*m_pTrack, SIGNAL(beatsUpdated()),
                    this, SLOT(slotBeatsUpdated()));
     }
     if (pNewTrack) {
         m_pTrack = pNewTrack;
         m_pBeats = m_pTrack->getBeats();
-        connect(m_pTrack.data(), SIGNAL(beatsUpdated()),
+        connect(&*m_pTrack, SIGNAL(beatsUpdated()),
                 this, SLOT(slotBeatsUpdated()));
     } else {
         m_pBeats.clear();
-        m_pTrack.clear();
+        m_pTrack = TrackPointer();
     }
 
 }

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -225,7 +225,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
 
         m_pCueIndicator->setBlinkValue(ControlIndicator::OFF);
         m_pCuePoint->set(-1.0);
-        m_pLoadedTrack = TrackPointer();
+        m_pLoadedTrack.reset();
     }
 
 

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -163,7 +163,7 @@ void CueControl::attachCue(CuePointer pCue, int hotCue) {
     if (pControl->getCue() != NULL) {
         detachCue(pControl->getHotcueNumber());
     }
-    connect(pCue.data(), SIGNAL(updated()),
+    connect(&*pCue, SIGNAL(updated()),
             this, SLOT(cueUpdated()),
             Qt::DirectConnection);
 
@@ -183,7 +183,7 @@ void CueControl::detachCue(int hotCue) {
     CuePointer pCue(pControl->getCue());
     if (!pCue)
         return;
-    disconnect(pCue.data(), 0, this, 0);
+    disconnect(&*pCue, 0, this, 0);
     // clear pCue first because we have a null check for valid data else where
     // in the code
     pControl->setCue(CuePointer());
@@ -196,7 +196,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     QMutexLocker lock(&m_mutex);
 
     if (m_pLoadedTrack) {
-        disconnect(m_pLoadedTrack.data(), 0, this, 0);
+        disconnect(&*m_pLoadedTrack, 0, this, 0);
         for (int i = 0; i < m_iNumHotCues; ++i) {
             detachCue(i);
         }
@@ -225,16 +225,16 @@ void CueControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
 
         m_pCueIndicator->setBlinkValue(ControlIndicator::OFF);
         m_pCuePoint->set(-1.0);
-        m_pLoadedTrack.clear();
+        m_pLoadedTrack = TrackPointer();
     }
 
 
-    if (pNewTrack.isNull()) {
+    if (!pNewTrack) {
         return;
     }
 
     m_pLoadedTrack = pNewTrack;
-    connect(pNewTrack.data(), SIGNAL(cuesUpdated()),
+    connect(&*pNewTrack, SIGNAL(cuesUpdated()),
             this, SLOT(trackCuesUpdated()),
             Qt::DirectConnection);
 

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -163,7 +163,7 @@ void CueControl::attachCue(CuePointer pCue, int hotCue) {
     if (pControl->getCue() != NULL) {
         detachCue(pControl->getHotcueNumber());
     }
-    connect(&*pCue, SIGNAL(updated()),
+    connect(pCue.get(), SIGNAL(updated()),
             this, SLOT(cueUpdated()),
             Qt::DirectConnection);
 
@@ -183,7 +183,7 @@ void CueControl::detachCue(int hotCue) {
     CuePointer pCue(pControl->getCue());
     if (!pCue)
         return;
-    disconnect(&*pCue, 0, this, 0);
+    disconnect(pCue.get(), 0, this, 0);
     // clear pCue first because we have a null check for valid data else where
     // in the code
     pControl->setCue(CuePointer());
@@ -196,7 +196,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     QMutexLocker lock(&m_mutex);
 
     if (m_pLoadedTrack) {
-        disconnect(&*m_pLoadedTrack, 0, this, 0);
+        disconnect(m_pLoadedTrack.get(), 0, this, 0);
         for (int i = 0; i < m_iNumHotCues; ++i) {
             detachCue(i);
         }
@@ -234,7 +234,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     }
 
     m_pLoadedTrack = pNewTrack;
-    connect(&*pNewTrack, SIGNAL(cuesUpdated()),
+    connect(pNewTrack.get(), SIGNAL(cuesUpdated()),
             this, SLOT(trackCuesUpdated()),
             Qt::DirectConnection);
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -492,7 +492,7 @@ TrackPointer EngineBuffer::loadFakeTrack(double filebpm) {
     pTrack->setDuration(10);
     if (filebpm > 0) {
         double bpm = pTrack->setBpm(filebpm);
-        BeatsPointer pBeats = BeatFactory::makeBeatGrid(pTrack.data(), bpm, 0.0);
+        BeatsPointer pBeats = BeatFactory::makeBeatGrid(*pTrack, bpm, 0.0);
         pTrack->setBeats(pBeats);
     }
     slotTrackLoaded(pTrack, 44100, 44100 * 10);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -553,7 +553,7 @@ void EngineBuffer::ejectTrack() {
     m_pTrackSamples->set(0);
     m_pTrackSampleRate->set(0);
     TrackPointer pTrack = m_pCurrentTrack;
-    m_pCurrentTrack = TrackPointer();
+    m_pCurrentTrack.reset();
     m_trackSampleRateOld = 0;
     m_trackSamplesOld = 0;
     m_playButton->set(0.0);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -553,7 +553,7 @@ void EngineBuffer::ejectTrack() {
     m_pTrackSamples->set(0);
     m_pTrackSampleRate->set(0);
     TrackPointer pTrack = m_pCurrentTrack;
-    m_pCurrentTrack.clear();
+    m_pCurrentTrack = TrackPointer();
     m_trackSampleRateOld = 0;
     m_trackSamplesOld = 0;
     m_playButton->set(0.0);
@@ -1245,14 +1245,14 @@ void EngineBuffer::hintReader(const double dRate) {
 
 // WARNING: This method runs in the GUI thread
 void EngineBuffer::loadTrack(TrackPointer pTrack, bool play) {
-    if (pTrack.isNull()) {
-        // Loading a null track means "eject"
-        ejectTrack();
-    } else {
+    if (pTrack) {
         // Signal to the reader to load the track. The reader will respond with
         // trackLoading and then either with trackLoaded or trackLoadFailed signals.
         m_bPlayAfterLoading = play;
         m_pReader->newTrack(pTrack);
+    } else {
+        // Loading a null track means "eject"
+        ejectTrack();
     }
 }
 

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -657,7 +657,7 @@ void LoopingControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack)
         connect(m_pTrack.get(), SIGNAL(beatsUpdated()),
                 this, SLOT(slotUpdatedTrackBeats()));
     } else {
-        m_pTrack = TrackPointer();
+        m_pTrack.reset();
         m_pBeats.clear();
     }
 }

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -645,7 +645,7 @@ void LoopingControl::setLoopingEnabled(bool enabled) {
 void LoopingControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     Q_UNUSED(pOldTrack);
     if (m_pTrack) {
-        disconnect(&*m_pTrack, SIGNAL(beatsUpdated()),
+        disconnect(m_pTrack.get(), SIGNAL(beatsUpdated()),
                    this, SLOT(slotUpdatedTrackBeats()));
     }
 
@@ -654,7 +654,7 @@ void LoopingControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack)
     if (pNewTrack) {
         m_pTrack = pNewTrack;
         m_pBeats = m_pTrack->getBeats();
-        connect(&*m_pTrack, SIGNAL(beatsUpdated()),
+        connect(m_pTrack.get(), SIGNAL(beatsUpdated()),
                 this, SLOT(slotUpdatedTrackBeats()));
     } else {
         m_pTrack = TrackPointer();

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -645,7 +645,7 @@ void LoopingControl::setLoopingEnabled(bool enabled) {
 void LoopingControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     Q_UNUSED(pOldTrack);
     if (m_pTrack) {
-        disconnect(m_pTrack.data(), SIGNAL(beatsUpdated()),
+        disconnect(&*m_pTrack, SIGNAL(beatsUpdated()),
                    this, SLOT(slotUpdatedTrackBeats()));
     }
 
@@ -654,10 +654,10 @@ void LoopingControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack)
     if (pNewTrack) {
         m_pTrack = pNewTrack;
         m_pBeats = m_pTrack->getBeats();
-        connect(m_pTrack.data(), SIGNAL(beatsUpdated()),
+        connect(&*m_pTrack, SIGNAL(beatsUpdated()),
                 this, SLOT(slotUpdatedTrackBeats()));
     } else {
-        m_pTrack.clear();
+        m_pTrack = TrackPointer();
         m_pBeats.clear();
     }
 }

--- a/src/engine/quantizecontrol.cpp
+++ b/src/engine/quantizecontrol.cpp
@@ -35,21 +35,21 @@ QuantizeControl::~QuantizeControl() {
 void QuantizeControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     Q_UNUSED(pOldTrack);
     if (m_pTrack) {
-        disconnect(m_pTrack.data(), SIGNAL(beatsUpdated()),
+        disconnect(&*m_pTrack, SIGNAL(beatsUpdated()),
                        this, SLOT(slotBeatsUpdated()));
     }
 
     if (pNewTrack) {
         m_pTrack = pNewTrack;
         m_pBeats = m_pTrack->getBeats();
-        connect(m_pTrack.data(), SIGNAL(beatsUpdated()),
+        connect(&*m_pTrack, SIGNAL(beatsUpdated()),
                 this, SLOT(slotBeatsUpdated()));
         // Initialize prev and next beat as if current position was zero.
         // If there is a cue point, the value will be updated.
         lookupBeatPositions(0.0);
         updateClosestBeat(0.0);
     } else {
-        m_pTrack.clear();
+        m_pTrack = TrackPointer();
         m_pBeats.clear();
         m_pCOPrevBeat->set(-1);
         m_pCONextBeat->set(-1);

--- a/src/engine/quantizecontrol.cpp
+++ b/src/engine/quantizecontrol.cpp
@@ -35,14 +35,14 @@ QuantizeControl::~QuantizeControl() {
 void QuantizeControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     Q_UNUSED(pOldTrack);
     if (m_pTrack) {
-        disconnect(&*m_pTrack, SIGNAL(beatsUpdated()),
-                       this, SLOT(slotBeatsUpdated()));
+        disconnect(m_pTrack.get(), SIGNAL(beatsUpdated()),
+                this, SLOT(slotBeatsUpdated()));
     }
 
     if (pNewTrack) {
         m_pTrack = pNewTrack;
         m_pBeats = m_pTrack->getBeats();
-        connect(&*m_pTrack, SIGNAL(beatsUpdated()),
+        connect(m_pTrack.get(), SIGNAL(beatsUpdated()),
                 this, SLOT(slotBeatsUpdated()));
         // Initialize prev and next beat as if current position was zero.
         // If there is a cue point, the value will be updated.

--- a/src/engine/quantizecontrol.cpp
+++ b/src/engine/quantizecontrol.cpp
@@ -49,7 +49,7 @@ void QuantizeControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack
         lookupBeatPositions(0.0);
         updateClosestBeat(0.0);
     } else {
-        m_pTrack = TrackPointer();
+        m_pTrack.reset();
         m_pBeats.clear();
         m_pCOPrevBeat->set(-1);
         m_pCONextBeat->set(-1);

--- a/src/engine/sidechain/enginebroadcast.cpp
+++ b/src/engine/sidechain/enginebroadcast.cpp
@@ -423,7 +423,7 @@ bool EngineBroadcast::processConnect() {
     // clear metadata, to make sure the first track is not skipped
     // because it was sent via an previous connection (see metaDataHasChanged)
     if(m_pMetaData) {
-        m_pMetaData.clear();
+        m_pMetaData = TrackPointer();
     }
     // If static metadata is available, we only need to send metadata one time
     m_firstCall = false;

--- a/src/engine/sidechain/enginebroadcast.cpp
+++ b/src/engine/sidechain/enginebroadcast.cpp
@@ -423,7 +423,7 @@ bool EngineBroadcast::processConnect() {
     // clear metadata, to make sure the first track is not skipped
     // because it was sent via an previous connection (see metaDataHasChanged)
     if(m_pMetaData) {
-        m_pMetaData = TrackPointer();
+        m_pMetaData.reset();
     }
     // If static metadata is available, we only need to send metadata one time
     m_firstCall = false;

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -187,7 +187,7 @@ void EngineRecord::process(const CSAMPLE* pBuffer, const int iBufferSize) {
 
             // Since we just started recording, timeout and clear the metadata.
             m_iMetaDataLife = kMetaDataLifeTimeout;
-            m_pCurrentTrack = TrackPointer();
+            m_pCurrentTrack.reset();
 
             // clean frames couting and get current sample rate.
             m_frames = 0;
@@ -219,7 +219,7 @@ void EngineRecord::process(const CSAMPLE* pBuffer, const int iBufferSize) {
 
             // Since we just started recording, timeout and clear the metadata.
             m_iMetaDataLife = kMetaDataLifeTimeout;
-            m_pCurrentTrack = TrackPointer();
+            m_pCurrentTrack.reset();
 
             // clean frames counting and get current sample rate.
             m_frames = 0;

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -314,7 +314,7 @@ void SyncControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
         // If we change or remove a new track while master, hand off.
         m_pChannel->getEngineBuffer()->requestSyncMode(SYNC_NONE);
     }
-    if (!pNewTrack.isNull()) {
+    if (pNewTrack) {
         m_masterBpmAdjustFactor = kBpmUnity;
         if (getSyncMode() != SYNC_NONE) {
             // Because of the order signals get processed, the file/local_bpm COs and

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -630,20 +630,12 @@ bool AutoDJProcessor::loadNextTrackFromQueue(const DeckAttributes& deck, bool pl
 }
 
 bool AutoDJProcessor::removeLoadedTrackFromTopOfQueue(const DeckAttributes& deck) {
-    // Get loaded track for this group.
-    TrackPointer loadedTrack = deck.getLoadedTrack();
-
-    // No loaded track in this group.
-    if (loadedTrack.isNull()) {
-        return false;
-    }
-
-    return removeTrackFromTopOfQueue(loadedTrack);
+    return removeTrackFromTopOfQueue(deck.getLoadedTrack());
 }
 
 bool AutoDJProcessor::removeTrackFromTopOfQueue(TrackPointer pTrack) {
     // No track to test for.
-    if (pTrack.isNull()) {
+    if (!pTrack) {
         return false;
     }
 
@@ -769,7 +761,7 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
 void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTrack) {
     if (sDebug) {
         qDebug() << this << "playerTrackLoaded" << pDeck->group
-                 << (pTrack.isNull() ? "(null)" : pTrack->getLocation());
+                 << (pTrack ? pTrack->getLocation() : "(null)");
     }
 
     double duration = pTrack->getDuration();
@@ -791,8 +783,8 @@ void AutoDJProcessor::playerLoadingTrack(DeckAttributes* pDeck,
         TrackPointer pNewTrack, TrackPointer pOldTrack) {
     if (sDebug) {
         qDebug() << this << "playerLoadingTrack" << pDeck->group
-                 << "new:"<< (pNewTrack.isNull() ? "(null)" : pNewTrack->getLocation())
-                 << "old:"<< (pOldTrack.isNull() ? "(null)" : pOldTrack->getLocation());
+                 << "new:"<< (pNewTrack ? pNewTrack->getLocation() : "(null)")
+                 << "old:"<< (pOldTrack ? pOldTrack->getLocation() : "(null)");
     }
 
     // The Deck is loading an new track
@@ -805,7 +797,7 @@ void AutoDJProcessor::playerLoadingTrack(DeckAttributes* pDeck,
     // 4) We have just completed fading from one deck to another. Mode is
     //    ADJ_IDLE.
 
-    if (pNewTrack.isNull()) {
+    if (!pNewTrack) {
         // If a track is ejected because of a manual eject command or a load failure
         // this track seams to be undesired. Remove the bad track from the queue.
         removeTrackFromTopOfQueue(pOldTrack);

--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -320,7 +320,7 @@ TrackPointer BansheePlaylistModel::getTrack(const QModelIndex& index) const {
         pTrack->setComposer(getFieldString(index, CLM_COMPOSER));
         // If the track has a BPM, then give it a static beatgrid.
         if (bpm > 0) {
-            BeatsPointer pBeats = BeatFactory::makeBeatGrid(pTrack.data(), bpm, 0.0);
+            BeatsPointer pBeats = BeatFactory::makeBeatGrid(*pTrack, bpm, 0.0);
             pTrack->setBeats(pBeats);
         }
 

--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -696,7 +696,7 @@ QModelIndex BasePlaylistFeature::indexFromPlaylistId(int playlistId) {
 void BasePlaylistFeature::slotTrackSelected(TrackPointer pTrack) {
     m_pSelectedTrack = pTrack;
     TrackId trackId;
-    if (!pTrack.isNull()) {
+    if (pTrack) {
         trackId = pTrack->getId();
     }
     m_playlistDao.getPlaylistsTrackIsIn(trackId, &m_playlistsSelectedTrackIsIn);

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -157,7 +157,7 @@ bool BaseTrackCache::updateIndexWithTrackpointer(TrackPointer pTrack) {
         qDebug() << "updateIndexWithTrackpointer:" << pTrack->getLocation();
     }
 
-    if (pTrack.isNull()) {
+    if (!pTrack) {
         return false;
     }
 

--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -112,12 +112,12 @@ QPixmap CoverArtCache::requestCover(const CoverInfo& requestInfo,
 }
 
 //static
-void CoverArtCache::requestCover(const Track* pTrack,
+void CoverArtCache::requestCover(const Track& track,
                          const QObject* pRequestor) {
     CoverArtCache* pCache = CoverArtCache::instance();
-    if (pCache == nullptr || pTrack == nullptr) return;
+    if (pCache == nullptr) return;
 
-    CoverInfo info = pTrack->getCoverInfo();
+    CoverInfo info = track.getCoverInfo();
     pCache->requestCover(info, pRequestor, 0, false, true);
 }
 

--- a/src/library/coverartcache.h
+++ b/src/library/coverartcache.h
@@ -29,7 +29,7 @@ class CoverArtCache : public QObject, public Singleton<CoverArtCache> {
                          const bool onlyCached,
                          const bool signalWhenDone);
 
-    static void requestCover(const Track* pTrack,
+    static void requestCover(const Track& track,
                              const QObject* pRequestor);
 
     // Guesses the cover art for the provided tracks by searching the tracks'

--- a/src/library/cratefeature.cpp
+++ b/src/library/cratefeature.cpp
@@ -822,7 +822,7 @@ QString CrateFeature::getRootViewHtml() const {
 
 void CrateFeature::slotTrackSelected(TrackPointer pTrack) {
     m_pSelectedTrack = pTrack;
-    TrackId trackId(pTrack.isNull() ? TrackId() : pTrack->getId());
+    TrackId trackId(pTrack ? pTrack->getId() : TrackId());
     m_crateDao.getCratesTrackIsIn(trackId, &m_cratesSelectedTrackIsIn);
 
     TreeItem* rootItem = m_childModel.getItem(QModelIndex());

--- a/src/library/cratetablemodel.cpp
+++ b/src/library/cratetablemodel.cpp
@@ -88,7 +88,7 @@ bool CrateTableModel::addTrack(const QModelIndex& index, QString location) {
     // a duplicate. It also handles unremoving logic if the track has been
     // removed from the library recently and re-adds it.
     const TrackPointer pTrack(trackDao.addSingleTrack(fileInfo, true));
-    if (pTrack.isNull()) {
+    if (!pTrack) {
         qDebug() << "CrateTableModel::addTrack:"
                 << "Failed to add track"
                 << location

--- a/src/library/dao/analysisdao.cpp
+++ b/src/library/dao/analysisdao.cpp
@@ -316,11 +316,7 @@ bool AnalysisDao::saveDataToFile(const QString& fileName, const QByteArray& data
     return true;
 }
 
-void AnalysisDao::saveTrackAnalyses(Track* pTrack) {
-    if (!pTrack) {
-        return;
-    }
-
+void AnalysisDao::saveTrackAnalyses(const Track& track) {
     // The only analyses we have at the moment are waveform analyses so we have
     // nothing to do if it is disabled.
     WaveformSettings waveformSettings(m_pConfig);
@@ -328,8 +324,8 @@ void AnalysisDao::saveTrackAnalyses(Track* pTrack) {
         return;
     }
 
-    ConstWaveformPointer pWaveform = pTrack->getWaveform();
-    ConstWaveformPointer pWaveSummary = pTrack->getWaveformSummary();
+    ConstWaveformPointer pWaveform = track.getWaveform();
+    ConstWaveformPointer pWaveSummary = track.getWaveformSummary();
 
     // Don't try to save invalid or non-dirty waveforms.
     if (!pWaveform || pWaveform->getDataSize() == 0 || !pWaveform->isDirty() ||
@@ -337,7 +333,7 @@ void AnalysisDao::saveTrackAnalyses(Track* pTrack) {
         return;
     }
 
-    TrackId trackId(pTrack->getId());
+    TrackId trackId(track.getId());
 
     AnalysisDao::AnalysisInfo analysis;
     analysis.trackId = trackId;

--- a/src/library/dao/analysisdao.h
+++ b/src/library/dao/analysisdao.h
@@ -49,7 +49,7 @@ class AnalysisDao : public DAO {
     bool deleteAnalysesForTrack(TrackId trackId);
     bool deleteAnalysesByType(AnalysisType type);
 
-    void saveTrackAnalyses(Track* pTrack);
+    void saveTrackAnalyses(const Track& track);
 
     size_t getDiskUsageInBytes(AnalysisType type);
 

--- a/src/library/dao/cue.h
+++ b/src/library/dao/cue.h
@@ -1,8 +1,7 @@
-// cue.h
-// Created 10/26/2009 by RJ Ryan (rryan@mit.edu)
+#ifndef MIXXX_CUE_H
+#define MIXXX_CUE_H
 
-#ifndef CUE_H
-#define CUE_H
+#include <functional>
 
 #include <QObject>
 #include <QMutex>
@@ -77,6 +76,12 @@ class Cue : public QObject {
     friend class CueDAO;
 };
 
-typedef QSharedPointer<Cue> CuePointer;
+class CuePointer: public QSharedPointer<Cue> {
+  public:
+    CuePointer() {}
+    explicit CuePointer(Cue* pCue)
+          : QSharedPointer<Cue>(pCue, std::bind(&Cue::deleteLater, pCue)) {
+    }
+};
 
-#endif /* CUE_H */
+#endif // MIXXX_CUE_H

--- a/src/library/dao/cue.h
+++ b/src/library/dao/cue.h
@@ -82,6 +82,12 @@ class CuePointer: public QSharedPointer<Cue> {
     explicit CuePointer(Cue* pCue)
           : QSharedPointer<Cue>(pCue, std::bind(&Cue::deleteLater, pCue)) {
     }
+
+    // TODO(uklotzde): Remove this function after migration
+    // from QSharedPointer to std::shared_ptr
+    Cue* get() const {
+        return data();
+    }
 };
 
 #endif // MIXXX_CUE_H

--- a/src/library/dao/cue.h
+++ b/src/library/dao/cue.h
@@ -83,10 +83,13 @@ class CuePointer: public QSharedPointer<Cue> {
           : QSharedPointer<Cue>(pCue, std::bind(&Cue::deleteLater, pCue)) {
     }
 
-    // TODO(uklotzde): Remove this function after migration
+    // TODO(uklotzde): Remove these functions after migration
     // from QSharedPointer to std::shared_ptr
     Cue* get() const {
         return data();
+    }
+    void reset() {
+        clear();
     }
 };
 

--- a/src/library/dao/cuedao.cpp
+++ b/src/library/dao/cuedao.cpp
@@ -213,13 +213,11 @@ bool CueDAO::deleteCue(Cue* cue) {
     return false;
 }
 
-void CueDAO::saveTrackCues(TrackId trackId, Track* pTrack) {
+void CueDAO::saveTrackCues(TrackId trackId, const QList<CuePointer>& cueList) {
     //qDebug() << "CueDAO::saveTrackCues" << QThread::currentThread() << m_database.connectionName();
     // TODO(XXX) transaction, but people who are already in a transaction call
     // this.
     PerformanceTimer time;
-
-    const QList<CuePointer> cueList(pTrack->getCuePoints());
 
     // qDebug() << "CueDAO::saveTrackCues old size:" << oldCueList.size()
     //          << "new size:" << cueList.size();

--- a/src/library/dao/cuedao.cpp
+++ b/src/library/dao/cuedao.cpp
@@ -240,7 +240,7 @@ void CueDAO::saveTrackCues(TrackId trackId, const QList<CuePointer>& cueList) {
         }
         // Update or save cue
         if (pCue->isDirty()) {
-            saveCue(pCue.data());
+            saveCue(&*pCue);
 
             // Since this cue didn't have an id until now, add it to the list of
             // cues not to delete.

--- a/src/library/dao/cuedao.cpp
+++ b/src/library/dao/cuedao.cpp
@@ -240,7 +240,7 @@ void CueDAO::saveTrackCues(TrackId trackId, const QList<CuePointer>& cueList) {
         }
         // Update or save cue
         if (pCue->isDirty()) {
-            saveCue(&*pCue);
+            saveCue(pCue.get());
 
             // Since this cue didn't have an id until now, add it to the list of
             // cues not to delete.

--- a/src/library/dao/cuedao.h
+++ b/src/library/dao/cuedao.h
@@ -30,7 +30,7 @@ class CueDAO : public DAO {
     bool deleteCue(Cue* cue);
     // TODO(XXX) once we refer to all tracks by their id and TIO has a getId()
     // method the first parameter here won't be necessary.
-    void saveTrackCues(TrackId trackId, Track*);
+    void saveTrackCues(TrackId trackId, const QList<CuePointer>& cueList);
   private:
     CuePointer cueFromRow(const QSqlQuery& query) const;
 

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -250,7 +250,7 @@ bool TrackDAO::trackExistsInDatabase(const QString& absoluteFilePath) {
 
 void TrackDAO::saveTrack(const TrackPointer& pTrack) {
     if (pTrack) {
-        saveTrack(&*pTrack);
+        saveTrack(pTrack.get());
     }
 }
 
@@ -1416,19 +1416,19 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
     }
 
     // Listen to dirty and changed signals
-    connect(&*pTrack, SIGNAL(dirty(Track*)),
+    connect(pTrack.get(), SIGNAL(dirty(Track*)),
             this, SLOT(slotTrackDirty(Track*)),
             Qt::DirectConnection);
-    connect(&*pTrack, SIGNAL(clean(Track*)),
+    connect(pTrack.get(), SIGNAL(clean(Track*)),
             this, SLOT(slotTrackClean(Track*)),
             Qt::DirectConnection);
-    connect(&*pTrack, SIGNAL(changed(Track*)),
+    connect(pTrack.get(), SIGNAL(changed(Track*)),
             this, SLOT(slotTrackChanged(Track*)),
             Qt::DirectConnection);
     // Queued connection. We are not in a rush to process reference
     // count expirations and it can produce dangerous signal loops.
     // See: https://bugs.launchpad.net/mixxx/+bug/1365708
-    connect(&*pTrack, SIGNAL(referenceExpired(Track*)),
+    connect(pTrack.get(), SIGNAL(referenceExpired(Track*)),
             this, SLOT(slotTrackReferenceExpired(Track*)),
             Qt::QueuedConnection);
 

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -248,9 +248,9 @@ bool TrackDAO::trackExistsInDatabase(const QString& absoluteFilePath) {
     return getTrackId(absoluteFilePath).isValid();
 }
 
-void TrackDAO::saveTrack(TrackPointer track) {
-    if (track) {
-        saveTrack(track.data());
+void TrackDAO::saveTrack(const TrackPointer& pTrack) {
+    if (pTrack) {
+        saveTrack(&*pTrack);
     }
 }
 
@@ -654,8 +654,8 @@ TrackId TrackDAO::addTracksAddTrack(const TrackPointer& pTrack, bool unremove) {
             return TrackId();
         }
 
-        m_analysisDao.saveTrackAnalyses(pTrack.data());
-        m_cueDao.saveTrackCues(trackId, pTrack.data());
+        m_analysisDao.saveTrackAnalyses(*pTrack);
+        m_cueDao.saveTrackCues(trackId, pTrack->getCuePoints());
 
         DEBUG_ASSERT(!m_tracksAddedSet.contains(trackId));
         m_tracksAddedSet.insert(trackId);
@@ -1180,7 +1180,7 @@ bool setTrackBeats(const QSqlRecord& record, const int column,
     QByteArray beatsBlob = record.value(column + 3).toByteArray();
     bool bpmLocked = record.value(column + 4).toBool();
     BeatsPointer pBeats = BeatFactory::loadBeatsFromByteArray(
-            pTrack, beatsVersion, beatsSubVersion, &beatsBlob);
+            *pTrack, beatsVersion, beatsSubVersion, beatsBlob);
     if (pBeats) {
         pTrack->setBeats(pBeats);
     } else {
@@ -1583,8 +1583,8 @@ bool TrackDAO::updateTrack(Track* pTrack) {
 
     //qDebug() << "Update track took : " << time.elapsed().formatMillisWithUnit() << "Now updating cues";
     //time.start();
-    m_analysisDao.saveTrackAnalyses(pTrack);
-    m_cueDao.saveTrackCues(trackId, pTrack);
+    m_analysisDao.saveTrackAnalyses(*pTrack);
+    m_cueDao.saveTrackCues(trackId, pTrack->getCuePoints());
     transaction.commit();
 
     //qDebug() << "Update track in database took: " << time.elapsed().formatMillisWithUnit();

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -97,7 +97,7 @@ void TrackDAO::finish() {
         it.next();
         // Cast from TrackWeakPointer to TrackPointer. If the track still exists
         // then pTrack will be non-nullptr. If the track is dirty then save it.
-        TrackPointer pTrack = it.value();
+        TrackPointer pTrack = TrackPointer(it.value());
         if (pTrack) {
             if (pTrack->isDirty()) {
                 saveTrack(pTrack);
@@ -1489,7 +1489,7 @@ TrackPointer TrackDAO::getTrack(TrackId trackId, const bool cacheOnly) const {
     QHash<TrackId, TrackWeakPointer>::iterator it = m_sTracks.find(trackId);
     if (it != m_sTracks.end()) {
         //qDebug() << "Returning cached TIO for track" << id;
-        pTrack = it.value();
+        pTrack = TrackPointer(it.value());
     }
     // Unlock the track cache mutex. Otherwise we can deadlock.
     locker.unlock();

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -185,7 +185,7 @@ class TrackDAO : public QObject, public virtual DAO {
     // have a guarantee that the track will not be deleted while we are working
     // on it. However, private parts of TrackDAO can use the raw saveTrack(TIO*)
     // call.
-    void saveTrack(TrackPointer pTrack);
+    void saveTrack(const TrackPointer& pTrack);
 
     // Clears the cached Tracks, which can be useful when the
     // underlying database tables change (eg. during a library rescan,

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -54,7 +54,7 @@ void DlgTagFetcher::loadTrack(const TrackPointer track) {
     m_TagFetcher.startFetch(m_track);
 
     disconnect(this, SLOT(updateTrackMetadata(Track*)));
-    connect(track.data(), SIGNAL(changed(Track*)),
+    connect(&*track, SIGNAL(changed(Track*)),
             this, SLOT(updateTrackMetadata(Track*)));
 
     updateStack();

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -54,7 +54,7 @@ void DlgTagFetcher::loadTrack(const TrackPointer track) {
     m_TagFetcher.startFetch(m_track);
 
     disconnect(this, SLOT(updateTrackMetadata(Track*)));
-    connect(&*track, SIGNAL(changed(Track*)),
+    connect(track.get(), SIGNAL(changed(Track*)),
             this, SLOT(updateTrackMetadata(Track*)));
 
     updateStack();

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -221,7 +221,7 @@ void DlgTrackInfo::loadTrack(TrackPointer pTrack) {
 
     // We already listen to changed() so we don't need to listen to individual
     // signals such as cuesUpdates, coverArtUpdated(), etc.
-    connect(&*pTrack, SIGNAL(changed(Track*)),
+    connect(pTrack.get(), SIGNAL(changed(Track*)),
             this, SLOT(updateTrackMetadata()));
 }
 
@@ -347,7 +347,7 @@ void DlgTrackInfo::saveTrack() {
 
     // First, disconnect the track changed signal. Otherwise we signal ourselves
     // and repopulate all these fields.
-    disconnect(&*m_pLoadedTrack, SIGNAL(changed(Track*)),
+    disconnect(m_pLoadedTrack.get(), SIGNAL(changed(Track*)),
                this, SLOT(updateTrackMetadata()));
 
     m_pLoadedTrack->setTitle(txtTrackName->text());
@@ -425,7 +425,7 @@ void DlgTrackInfo::saveTrack() {
     m_pLoadedTrack->setCoverInfo(m_loadedCoverInfo);
 
     // Reconnect changed signals now.
-    connect(&*m_pLoadedTrack, SIGNAL(changed(Track*)),
+    connect(m_pLoadedTrack.get(), SIGNAL(changed(Track*)),
             this, SLOT(updateTrackMetadata()));
 }
 

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -443,7 +443,7 @@ void DlgTrackInfo::unloadTrack(bool save) {
 void DlgTrackInfo::clear() {
 
     disconnect(this, SLOT(updateTrackMetadata()));
-    m_pLoadedTrack = TrackPointer();
+    m_pLoadedTrack.reset();
 
     txtTrackName->setText("");
     txtArtist->setText("");

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -524,8 +524,8 @@ void DlgTrackInfo::slotBpmConstChanged(int state) {
             // The cue point should be set on a beat, so this seams
             // to be a good alternative
             double cue = m_pLoadedTrack->getCuePoint();
-            m_pBeatsClone = BeatFactory::makeBeatGrid(m_pLoadedTrack.data(),
-                    spinBpm->value(), cue);
+            m_pBeatsClone = BeatFactory::makeBeatGrid(
+                    *m_pLoadedTrack, spinBpm->value(), cue);
         } else {
             m_pBeatsClone.clear();
         }
@@ -558,8 +558,8 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
 
     if (!m_pBeatsClone) {
         double cue = m_pLoadedTrack->getCuePoint();
-        m_pBeatsClone = BeatFactory::makeBeatGrid(m_pLoadedTrack.data(),
-                value, cue);
+        m_pBeatsClone = BeatFactory::makeBeatGrid(
+                *m_pLoadedTrack, value, cue);
     }
 
     double oldValue = m_pBeatsClone->getBpm();

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -210,7 +210,7 @@ void DlgTrackInfo::reloadTrackBeats(const Track& track) {
 void DlgTrackInfo::loadTrack(TrackPointer pTrack) {
     clear();
 
-    if (pTrack.isNull()) {
+    if (!pTrack) {
         return;
     }
 
@@ -221,7 +221,7 @@ void DlgTrackInfo::loadTrack(TrackPointer pTrack) {
 
     // We already listen to changed() so we don't need to listen to individual
     // signals such as cuesUpdates, coverArtUpdated(), etc.
-    connect(pTrack.data(), SIGNAL(changed(Track*)),
+    connect(&*pTrack, SIGNAL(changed(Track*)),
             this, SLOT(updateTrackMetadata()));
 }
 
@@ -255,7 +255,7 @@ void DlgTrackInfo::slotCoverInfoSelected(const CoverInfo& coverInfo) {
 }
 
 void DlgTrackInfo::slotOpenInFileBrowser() {
-    if (m_pLoadedTrack.isNull()) {
+    if (!m_pLoadedTrack) {
         return;
     }
 
@@ -347,7 +347,7 @@ void DlgTrackInfo::saveTrack() {
 
     // First, disconnect the track changed signal. Otherwise we signal ourselves
     // and repopulate all these fields.
-    disconnect(m_pLoadedTrack.data(), SIGNAL(changed(Track*)),
+    disconnect(&*m_pLoadedTrack, SIGNAL(changed(Track*)),
                this, SLOT(updateTrackMetadata()));
 
     m_pLoadedTrack->setTitle(txtTrackName->text());
@@ -425,7 +425,7 @@ void DlgTrackInfo::saveTrack() {
     m_pLoadedTrack->setCoverInfo(m_loadedCoverInfo);
 
     // Reconnect changed signals now.
-    connect(m_pLoadedTrack.data(), SIGNAL(changed(Track*)),
+    connect(&*m_pLoadedTrack, SIGNAL(changed(Track*)),
             this, SLOT(updateTrackMetadata()));
 }
 
@@ -443,7 +443,7 @@ void DlgTrackInfo::unloadTrack(bool save) {
 void DlgTrackInfo::clear() {
 
     disconnect(this, SLOT(updateTrackMetadata()));
-    m_pLoadedTrack.clear();
+    m_pLoadedTrack = TrackPointer();
 
     txtTrackName->setText("");
     txtArtist->setText("");
@@ -608,14 +608,14 @@ void DlgTrackInfo::reloadTrackMetadata() {
                 m_pLoadedTrack->getFileInfo(),
                 m_pLoadedTrack->getSecurityToken()));
         SoundSourceProxy(pTrack).loadTrackMetadata();
-        if (!pTrack.isNull()) {
+        if (pTrack) {
             populateFields(*pTrack);
         }
     }
 }
 
 void DlgTrackInfo::updateTrackMetadata() {
-    if (!m_pLoadedTrack.isNull()) {
+    if (m_pLoadedTrack) {
         populateFields(*m_pLoadedTrack);
     }
 }

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -265,7 +265,7 @@ void Library::slotLoadTrack(TrackPointer pTrack) {
 void Library::slotLoadLocationToPlayer(QString location, QString group) {
     TrackPointer pTrack = m_pTrackCollection->getTrackDAO()
             .getOrAddTrack(location, true, NULL);
-    if (!pTrack.isNull()) {
+    if (pTrack) {
         emit(loadTrackToPlayer(pTrack, group));
     }
 }

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -511,17 +511,7 @@ void LibraryScanner::slotAddNewTrack(const QString& trackPath) {
     ScopedTimer timer("LibraryScanner::addNewTrack");
     // For statistics tracking and to detect moved tracks
     TrackPointer pTrack(m_trackDao.addTracksAddFile(trackPath, false));
-    if (pTrack.isNull()) {
-        // Acknowledge failed track addition
-        // TODO(XXX): Is it really intended to acknowledge a failed
-        // track addition with a trackAdded() signal??
-        if (m_scannerGlobal) {
-            m_scannerGlobal->trackAdded(trackPath);
-        }
-        qWarning()
-                << "Failed to add track to library:"
-                << trackPath;
-    } else {
+    if (pTrack) {
         // The track's actual location might differ from the
         // given trackPath
         const QString trackLocation(pTrack->getLocation());
@@ -533,6 +523,16 @@ void LibraryScanner::slotAddNewTrack(const QString& trackPath) {
         // a new track in the database.
         emit(trackAdded(pTrack));
         emit(progressLoading(trackLocation));
+    } else {
+        // Acknowledge failed track addition
+        // TODO(XXX): Is it really intended to acknowledge a failed
+        // track addition with a trackAdded() signal??
+        if (m_scannerGlobal) {
+            m_scannerGlobal->trackAdded(trackPath);
+        }
+        qWarning()
+                << "Failed to add track to library:"
+                << trackPath;
     }
 }
 

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -108,9 +108,9 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
 BaseTrackPlayerImpl::~BaseTrackPlayerImpl() {
     if (m_pLoadedTrack) {
         emit(loadingTrack(TrackPointer(), m_pLoadedTrack));
-        disconnect(&*m_pLoadedTrack, 0, m_pBPM, 0);
-        disconnect(&*m_pLoadedTrack, 0, this, 0);
-        disconnect(&*m_pLoadedTrack, 0, m_pKey, 0);
+        disconnect(m_pLoadedTrack.get(), 0, m_pBPM, 0);
+        disconnect(m_pLoadedTrack.get(), 0, this, 0);
+        disconnect(m_pLoadedTrack.get(), 0, m_pKey, 0);
         m_pLoadedTrack = TrackPointer();
     }
 
@@ -158,9 +158,9 @@ void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer pNewTrack, bool bPlay) {
         // WARNING: Never. Ever. call bare disconnect() on an object. Mixxx
         // relies on signals and slots to get tons of things done. Don't
         // randomly disconnect things.
-        disconnect(&*m_pLoadedTrack, 0, m_pBPM, 0);
-        disconnect(&*m_pLoadedTrack, 0, this, 0);
-        disconnect(&*m_pLoadedTrack, 0, m_pKey, 0);
+        disconnect(m_pLoadedTrack.get(), 0, m_pBPM, 0);
+        disconnect(m_pLoadedTrack.get(), 0, this, 0);
+        disconnect(m_pLoadedTrack.get(), 0, m_pKey, 0);
 
         // Do not reset m_pReplayGain here, because the track might be still
         // playing and the last buffer will be processed.
@@ -171,14 +171,14 @@ void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer pNewTrack, bool bPlay) {
     m_pLoadedTrack = pNewTrack;
     if (m_pLoadedTrack) {
         // Listen for updates to the file's BPM
-        connect(&*m_pLoadedTrack, SIGNAL(bpmUpdated(double)),
+        connect(m_pLoadedTrack.get(), SIGNAL(bpmUpdated(double)),
                 m_pBPM, SLOT(set(double)));
 
-        connect(&*m_pLoadedTrack, SIGNAL(keyUpdated(double)),
+        connect(m_pLoadedTrack.get(), SIGNAL(keyUpdated(double)),
                 m_pKey, SLOT(set(double)));
 
         // Listen for updates to the file's Replay Gain
-        connect(&*m_pLoadedTrack, SIGNAL(ReplayGainUpdated(mixxx::ReplayGain)),
+        connect(m_pLoadedTrack.get(), SIGNAL(ReplayGainUpdated(mixxx::ReplayGain)),
                 this, SLOT(slotSetReplayGain(mixxx::ReplayGain)));
     }
 
@@ -220,9 +220,9 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
         // relies on signals and slots to get tons of things done. Don't
         // randomly disconnect things.
         // m_pLoadedTrack->disconnect();
-        disconnect(&*m_pLoadedTrack, 0, m_pBPM, 0);
-        disconnect(&*m_pLoadedTrack, 0, this, 0);
-        disconnect(&*m_pLoadedTrack, 0, m_pKey, 0);
+        disconnect(m_pLoadedTrack.get(), 0, m_pBPM, 0);
+        disconnect(m_pLoadedTrack.get(), 0, this, 0);
+        disconnect(m_pLoadedTrack.get(), 0, m_pKey, 0);
 
         // Causes the track's data to be saved back to the library database and
         // for all the widgets to change the track and update themselves.

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -108,10 +108,10 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
 BaseTrackPlayerImpl::~BaseTrackPlayerImpl() {
     if (m_pLoadedTrack) {
         emit(loadingTrack(TrackPointer(), m_pLoadedTrack));
-        disconnect(m_pLoadedTrack.data(), 0, m_pBPM, 0);
-        disconnect(m_pLoadedTrack.data(), 0, this, 0);
-        disconnect(m_pLoadedTrack.data(), 0, m_pKey, 0);
-        m_pLoadedTrack.clear();
+        disconnect(&*m_pLoadedTrack, 0, m_pBPM, 0);
+        disconnect(&*m_pLoadedTrack, 0, this, 0);
+        disconnect(&*m_pLoadedTrack, 0, m_pKey, 0);
+        m_pLoadedTrack = TrackPointer();
     }
 
     delete m_pDuration;
@@ -123,7 +123,7 @@ void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer pNewTrack, bool bPlay) {
     qDebug() << "BaseTrackPlayerImpl::slotLoadTrack";
     // Before loading the track, ensure we have access. This uses lazy
     // evaluation to make sure track isn't NULL before we dereference it.
-    if (!pNewTrack.isNull() && !Sandbox::askForAccess(pNewTrack->getCanonicalLocation())) {
+    if (pNewTrack && !Sandbox::askForAccess(pNewTrack->getCanonicalLocation())) {
         // We don't have access.
         return;
     }
@@ -158,9 +158,9 @@ void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer pNewTrack, bool bPlay) {
         // WARNING: Never. Ever. call bare disconnect() on an object. Mixxx
         // relies on signals and slots to get tons of things done. Don't
         // randomly disconnect things.
-        disconnect(m_pLoadedTrack.data(), 0, m_pBPM, 0);
-        disconnect(m_pLoadedTrack.data(), 0, this, 0);
-        disconnect(m_pLoadedTrack.data(), 0, m_pKey, 0);
+        disconnect(&*m_pLoadedTrack, 0, m_pBPM, 0);
+        disconnect(&*m_pLoadedTrack, 0, this, 0);
+        disconnect(&*m_pLoadedTrack, 0, m_pKey, 0);
 
         // Do not reset m_pReplayGain here, because the track might be still
         // playing and the last buffer will be processed.
@@ -171,14 +171,14 @@ void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer pNewTrack, bool bPlay) {
     m_pLoadedTrack = pNewTrack;
     if (m_pLoadedTrack) {
         // Listen for updates to the file's BPM
-        connect(m_pLoadedTrack.data(), SIGNAL(bpmUpdated(double)),
+        connect(&*m_pLoadedTrack, SIGNAL(bpmUpdated(double)),
                 m_pBPM, SLOT(set(double)));
 
-        connect(m_pLoadedTrack.data(), SIGNAL(keyUpdated(double)),
+        connect(&*m_pLoadedTrack, SIGNAL(keyUpdated(double)),
                 m_pKey, SLOT(set(double)));
 
         // Listen for updates to the file's Replay Gain
-        connect(m_pLoadedTrack.data(), SIGNAL(ReplayGainUpdated(mixxx::ReplayGain)),
+        connect(&*m_pLoadedTrack, SIGNAL(ReplayGainUpdated(mixxx::ReplayGain)),
                 this, SLOT(slotSetReplayGain(mixxx::ReplayGain)));
     }
 
@@ -191,17 +191,17 @@ void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer pNewTrack, bool bPlay) {
     emit(loadingTrack(pNewTrack, pOldTrack));
 }
 
-void BaseTrackPlayerImpl::slotLoadFailed(TrackPointer track, QString reason) {
+void BaseTrackPlayerImpl::slotLoadFailed(TrackPointer pTrack, QString reason) {
     // Note: This slot can be a load failure from the current track or a
     // a delayed signal from a previous load.
     // We have probably received a slotTrackLoaded signal, of an old track that
     // was loaded before. Here we must unload the
     // We must unload the track m_pLoadedTrack as well
-    if (track == m_pLoadedTrack) {
-        qDebug() << "Failed to load track" << track->getLocation() << reason;
-        slotTrackLoaded(TrackPointer(), track);
-    } else if (!track.isNull()) {
-        qDebug() << "Stray failed to load track" << track->getLocation() << reason;
+    if (pTrack == m_pLoadedTrack) {
+        qDebug() << "Failed to load track" << pTrack->getLocation() << reason;
+        slotTrackLoaded(TrackPointer(), pTrack);
+    } else if (pTrack) {
+        qDebug() << "Stray failed to load track" << pTrack->getLocation() << reason;
     } else {
         qDebug() << "Failed to load track (NULL track object)" << reason;
     }
@@ -212,17 +212,17 @@ void BaseTrackPlayerImpl::slotLoadFailed(TrackPointer track, QString reason) {
 void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
                                           TrackPointer pOldTrack) {
     qDebug() << "BaseTrackPlayerImpl::slotTrackLoaded";
-    if (pNewTrack.isNull() &&
-            !pOldTrack.isNull() &&
+    if (!pNewTrack &&
+            pOldTrack &&
             pOldTrack == m_pLoadedTrack) {
         // eject Track
         // WARNING: Never. Ever. call bare disconnect() on an object. Mixxx
         // relies on signals and slots to get tons of things done. Don't
         // randomly disconnect things.
         // m_pLoadedTrack->disconnect();
-        disconnect(m_pLoadedTrack.data(), 0, m_pBPM, 0);
-        disconnect(m_pLoadedTrack.data(), 0, this, 0);
-        disconnect(m_pLoadedTrack.data(), 0, m_pKey, 0);
+        disconnect(&*m_pLoadedTrack, 0, m_pBPM, 0);
+        disconnect(&*m_pLoadedTrack, 0, this, 0);
+        disconnect(&*m_pLoadedTrack, 0, m_pKey, 0);
 
         // Causes the track's data to be saved back to the library database and
         // for all the widgets to change the track and update themselves.
@@ -233,9 +233,9 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
         setReplayGain(0);
         m_pLoopInPoint->set(-1);
         m_pLoopOutPoint->set(-1);
-        m_pLoadedTrack.clear();
+        m_pLoadedTrack = TrackPointer();
         emit(playerEmpty());
-    } else if (!pNewTrack.isNull() && pNewTrack == m_pLoadedTrack) {
+    } else if (pNewTrack && pNewTrack == m_pLoadedTrack) {
         // Successful loaded a new track
         // Reload metadata from file, but only if required
         SoundSourceProxy(m_pLoadedTrack).loadTrackMetadata();

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -111,7 +111,7 @@ BaseTrackPlayerImpl::~BaseTrackPlayerImpl() {
         disconnect(m_pLoadedTrack.get(), 0, m_pBPM, 0);
         disconnect(m_pLoadedTrack.get(), 0, this, 0);
         disconnect(m_pLoadedTrack.get(), 0, m_pKey, 0);
-        m_pLoadedTrack = TrackPointer();
+        m_pLoadedTrack.reset();
     }
 
     delete m_pDuration;
@@ -233,7 +233,7 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
         setReplayGain(0);
         m_pLoopInPoint->set(-1);
         m_pLoopOutPoint->set(-1);
-        m_pLoadedTrack = TrackPointer();
+        m_pLoadedTrack.reset();
         emit(playerEmpty());
     } else if (pNewTrack && pNewTrack == m_pLoadedTrack) {
         // Successful loaded a new track

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -325,7 +325,7 @@ SoundSourceProxy::SaveTrackMetadataResult SoundSourceProxy::saveTrackMetadata(
 
 SoundSourceProxy::SoundSourceProxy(const TrackPointer& pTrack)
     : m_pTrack(pTrack),
-      m_url(getCanonicalUrlForTrack(&*pTrack)),
+      m_url(getCanonicalUrlForTrack(pTrack.get())),
       m_soundSourceProviderRegistrations(findSoundSourceProviderRegistrations(m_url)),
       m_soundSourceProviderRegistrationIndex(0) {
     initSoundSource();

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -325,7 +325,7 @@ SoundSourceProxy::SaveTrackMetadataResult SoundSourceProxy::saveTrackMetadata(
 
 SoundSourceProxy::SoundSourceProxy(const TrackPointer& pTrack)
     : m_pTrack(pTrack),
-      m_url(getCanonicalUrlForTrack(pTrack.data())),
+      m_url(getCanonicalUrlForTrack(&*pTrack)),
       m_soundSourceProviderRegistrations(findSoundSourceProviderRegistrations(m_url)),
       m_soundSourceProviderRegistrationIndex(0) {
     initSoundSource();
@@ -520,6 +520,13 @@ namespace {
 // is still in use.
 class AudioSourceProxy: public mixxx::AudioSource {
 public:
+    AudioSourceProxy(
+            const TrackPointer& pTrack,
+            const mixxx::AudioSourcePointer& pAudioSource)
+        : mixxx::AudioSource(*pAudioSource),
+          m_pTrack(pTrack),
+          m_pAudioSource(pAudioSource) {
+    }
     AudioSourceProxy(const AudioSourceProxy&) = delete;
     AudioSourceProxy(AudioSourceProxy&&) = delete;
 
@@ -556,14 +563,6 @@ public:
     }
 
 private:
-    AudioSourceProxy(
-            const TrackPointer& pTrack,
-            const mixxx::AudioSourcePointer& pAudioSource)
-        : mixxx::AudioSource(*pAudioSource),
-          m_pTrack(pTrack),
-          m_pAudioSource(pAudioSource) {
-    }
-
     const TrackPointer m_pTrack;
     const mixxx::AudioSourcePointer m_pAudioSource;
 };

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -59,7 +59,7 @@ class FakeDeck : public BaseTrackPlayer {
     void fakeUnloadingTrackEvent(TrackPointer pTrack) {
         play.set(0.0);
         emit(loadingTrack(TrackPointer(), pTrack));
-        loadedTrack.clear();
+        loadedTrack = TrackPointer();
         emit(playerEmpty());
     }
 
@@ -190,7 +190,7 @@ class AutoDJProcessorTest : public LibraryTest {
 
     TrackId addTrackToCollection(const QString& trackLocation) {
         TrackPointer pTrack(collection()->getTrackDAO().addSingleTrack(trackLocation, false));
-        return pTrack.isNull() ? TrackId() : pTrack->getId();
+        return pTrack ? pTrack->getId() : TrackId();
     }
 
     FakeMaster master;

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -59,7 +59,7 @@ class FakeDeck : public BaseTrackPlayer {
     void fakeUnloadingTrackEvent(TrackPointer pTrack) {
         play.set(0.0);
         emit(loadingTrack(TrackPointer(), pTrack));
-        loadedTrack = TrackPointer();
+        loadedTrack.reset();
         emit(playerEmpty());
     }
 

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -26,7 +26,7 @@ TEST_F(BeatGridTest, Scale) {
     pTrack->setBpm(bpm);
     pTrack->setSampleRate(sampleRate);
 
-    BeatGrid* pGrid = new BeatGrid(pTrack.data(), 0);
+    BeatGrid* pGrid = new BeatGrid(*pTrack, 0);
     pGrid->setBpm(bpm);
 
     EXPECT_DOUBLE_EQ(bpm, pGrid->getBpm());
@@ -53,7 +53,7 @@ TEST_F(BeatGridTest, TestNthBeatWhenOnBeat) {
     pTrack->setSampleRate(sampleRate);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    BeatGrid* pGrid = new BeatGrid(pTrack.data(), 0);
+    BeatGrid* pGrid = new BeatGrid(*pTrack, 0);
     pGrid->setBpm(bpm);
     // Pretend we're on the 20th beat;
     double position = beatLength * 20;
@@ -89,7 +89,7 @@ TEST_F(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     pTrack->setSampleRate(sampleRate);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    BeatGrid* pGrid = new BeatGrid(pTrack.data(), 0);
+    BeatGrid* pGrid = new BeatGrid(*pTrack, 0);
     pGrid->setBpm(bpm);
 
     // Pretend we're just before the 20th beat.
@@ -127,7 +127,7 @@ TEST_F(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     pTrack->setSampleRate(sampleRate);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    BeatGrid* pGrid = new BeatGrid(pTrack.data(), 0);
+    BeatGrid* pGrid = new BeatGrid(*pTrack, 0);
     pGrid->setBpm(bpm);
 
     // Pretend we're just before the 20th beat.
@@ -164,7 +164,7 @@ TEST_F(BeatGridTest, TestNthBeatWhenNotOnBeat) {
     pTrack->setSampleRate(sampleRate);
     double beatLength = (60.0 * sampleRate / bpm) * kFrameSize;
 
-    BeatGrid* pGrid = new BeatGrid(pTrack.data(), 0);
+    BeatGrid* pGrid = new BeatGrid(*pTrack, 0);
     pGrid->setBpm(bpm);
 
     // Pretend we're half way between the 20th and 21st beat

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -53,7 +53,7 @@ TEST_F(BeatMapTest, Scale) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    BeatMap* pMap = new BeatMap(m_pTrack, 0, beats);
+    BeatMap* pMap = new BeatMap(*m_pTrack, 0, beats);
 
     EXPECT_DOUBLE_EQ(bpm, pMap->getBpm());
     pMap->scale(Beats::DOUBLE);
@@ -80,7 +80,7 @@ TEST_F(BeatMapTest, TestNthBeat) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    BeatMap* pMap = new BeatMap(m_pTrack, 0, beats);
+    BeatMap* pMap = new BeatMap(*m_pTrack, 0, beats);
 
     // Check edge cases
     double firstBeat = startOffsetSamples + beatLengthSamples * 0;
@@ -113,7 +113,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    BeatMap* pMap = new BeatMap(m_pTrack, 0, beats);
+    BeatMap* pMap = new BeatMap(*m_pTrack, 0, beats);
 
     // Pretend we're on the 20th beat;
     const int curBeat = 20;
@@ -151,7 +151,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    BeatMap* pMap = new BeatMap(m_pTrack, 0, beats);
+    BeatMap* pMap = new BeatMap(*m_pTrack, 0, beats);
 
     // Pretend we're just before the 20th beat;
     const int curBeat = 20;
@@ -191,7 +191,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    BeatMap* pMap = new BeatMap(m_pTrack, 0, beats);
+    BeatMap* pMap = new BeatMap(*m_pTrack, 0, beats);
 
     // Pretend we're just after the 20th beat;
     const int curBeat = 20;
@@ -232,7 +232,7 @@ TEST_F(BeatMapTest, TestNthBeatWhenNotOnBeat) {
     const int numBeats = 100;
     // Note beats must be in frames, not samples.
     QVector<double> beats = createBeatVector(startOffsetFrames, numBeats, beatLengthFrames);
-    BeatMap* pMap = new BeatMap(m_pTrack, 0, beats);
+    BeatMap* pMap = new BeatMap(*m_pTrack, 0, beats);
 
     // Pretend we're half way between the 20th and 21st beat
     double previousBeat = startOffsetSamples + beatLengthSamples * 20.0;
@@ -273,7 +273,7 @@ TEST_F(BeatMapTest, TestBpmAround) {
         beat_pos += beat_length;
     }
 
-    BeatMap* pMap = new BeatMap(m_pTrack, 0, beats);
+    BeatMap* pMap = new BeatMap(*m_pTrack, 0, beats);
 
     // The average of the first 8 beats should be different than the average
     // of the last 8 beats.
@@ -290,7 +290,7 @@ TEST_F(BeatMapTest, TestBpmAround) {
 
     // Try a really, really short track
     beats = createBeatVector(10, 3, getBeatLengthFrames(filebpm));
-    pMap = new BeatMap(m_pTrack, 0, beats);
+    pMap = new BeatMap(*m_pTrack, 0, beats);
 
     EXPECT_DOUBLE_EQ(filebpm, pMap->getBpmAroundPosition(1 * approx_beat_length, 4));
     delete pMap;

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -9,12 +9,12 @@ TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
     // Set up BeatGrids for decks 1 and 2.
     const double bpm = 60.0;
     const double firstBeat = 0.0;
-    BeatGrid grid1(m_pTrack1.data(), m_pTrack1->getSampleRate());
+    BeatGrid grid1(*m_pTrack1, m_pTrack1->getSampleRate());
     grid1.setGrid(bpm, firstBeat);
     m_pTrack1->setBeats(QSharedPointer<Beats>(&grid1));
     ASSERT_DOUBLE_EQ(firstBeat, grid1.findClosestBeat(0));
 
-    BeatGrid grid2(m_pTrack2.data(), m_pTrack2->getSampleRate());
+    BeatGrid grid2(*m_pTrack2, m_pTrack2->getSampleRate());
     grid2.setGrid(bpm, firstBeat);
     m_pTrack2->setBeats(QSharedPointer<Beats>(&grid2));
     ASSERT_DOUBLE_EQ(firstBeat, grid2.findClosestBeat(0));

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -32,7 +32,7 @@ TEST_F(BpmControlTest, BeatContext_BeatGrid) {
     TrackPointer pTrack = Track::newTemporary();
     pTrack->setSampleRate(sampleRate);
 
-    BeatsPointer pBeats = BeatFactory::makeBeatGrid(pTrack.data(), bpm, 0);
+    BeatsPointer pBeats = BeatFactory::makeBeatGrid(*pTrack, bpm, 0);
 
     // On a beat.
     double prevBeat, nextBeat, beatLength, beatPercentage;

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1205,9 +1205,9 @@ TEST_F(EngineSyncTest, ZeroLatencyRateChange) {
         ConfigKey(m_sGroup2, "file_bpm")));
     pFileBpm1->set(128.0);
     pFileBpm2->set(128.0);
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1.data(), 128, 0.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2.data(), 128, 0.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 128, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1240,12 +1240,12 @@ TEST_F(EngineSyncTest, HalfDoubleBpmTest) {
     QScopedPointer<ControlProxy> pFileBpm1(getControlProxy(
         ConfigKey(m_sGroup1, "file_bpm")));
     pFileBpm1->set(70);
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1.data(), 70, 0.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 70, 0.0);
     m_pTrack1->setBeats(pBeats1);
     QScopedPointer<ControlProxy> pFileBpm2(getControlProxy(
         ConfigKey(m_sGroup2, "file_bpm")));
     pFileBpm2->set(140);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2.data(), 140, 0.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1309,9 +1309,9 @@ TEST_F(EngineSyncTest, HalfDoubleThenPlay) {
     QScopedPointer<ControlProxy> pFileBpm2(getControlProxy(
         ConfigKey(m_sGroup2, "file_bpm")));
     pFileBpm2->set(175.0);
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1.data(), 80, 0.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 80, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2.data(), 175, 0.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 175, 0.0);
     m_pTrack2->setBeats(pBeats2);
     ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->set(getRateSliderValue(1.0));
 
@@ -1368,9 +1368,9 @@ TEST_F(EngineSyncTest, HalfDoubleInternalClockTest) {
     QScopedPointer<ControlProxy> pFileBpm2(getControlProxy(
         ConfigKey(m_sGroup2, "file_bpm")));
     pFileBpm2->set(140.0);
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1.data(), 70, 0.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 70, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2.data(), 140, 0.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 140, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1399,7 +1399,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
         ConfigKey(m_sGroup1, "file_bpm")));
     ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->set(0.2);
     pFileBpm1->set(130.0);
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1.data(), 130, 0.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
     m_pTrack1->setBeats(pBeats1);
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
 
@@ -1409,7 +1409,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
         ConfigKey(m_sGroup2, "file_bpm")));
     ControlObject::getControl(ConfigKey(m_sGroup2, "beat_distance"))->set(0.8);
     ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->set(getRateSliderValue(1.0));
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2.data(), 100, 0.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 100, 0.0);
     m_pTrack2->setBeats(pBeats2);
     pFileBpm2->set(100.0);
 
@@ -1448,7 +1448,7 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
         ConfigKey(m_sGroup3, "file_bpm")));
     ControlObject::getControl(ConfigKey(m_sGroup3, "beat_distance"))->set(0.6);
     ControlObject::getControl(ConfigKey(m_sGroup3, "rate"))->set(getRateSliderValue(1.0));
-    BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(m_pTrack3.data(), 140, 0.0);
+    BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(*m_pTrack3, 140, 0.0);
     m_pTrack3->setBeats(pBeats3);
     pFileBpm3->set(140.0);
     pButtonSyncEnabled1->set(0.0);
@@ -1481,9 +1481,9 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
     QScopedPointer<ControlProxy> pFileBpm2(getControlProxy(
         ConfigKey(m_sGroup2, "file_bpm")));
     pFileBpm2->set(128.0);
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1.data(), 128, 0.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 128, 0.0);
     m_pTrack1->setBeats(pBeats1);
-    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(m_pTrack2.data(), 128, 0.0);
+    BeatsPointer pBeats2 = BeatFactory::makeBeatGrid(*m_pTrack2, 128, 0.0);
     m_pTrack2->setBeats(pBeats2);
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "quantize"))->set(1.0);
@@ -1542,7 +1542,7 @@ TEST_F(EngineSyncTest, ZeroBpmNaturalRate) {
         ConfigKey(m_sGroup1, "file_bpm")));
     pFileBpm1->set(0.0);
     // Maybe the beatgrid ended up at zero also.
-    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(m_pTrack1.data(), 0.0, 0.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 0.0, 0.0);
     m_pTrack1->setBeats(pBeats1);
 
     QScopedPointer<ControlProxy> pButtonSyncEnabled1(getControlProxy(

--- a/src/track/beatfactory.cpp
+++ b/src/track/beatfactory.cpp
@@ -6,18 +6,18 @@
 #include "track/beatfactory.h"
 #include "track/beatutils.h"
 
-BeatsPointer BeatFactory::loadBeatsFromByteArray(TrackPointer pTrack,
+BeatsPointer BeatFactory::loadBeatsFromByteArray(const Track& track,
                                                  QString beatsVersion,
                                                  QString beatsSubVersion,
-                                                 QByteArray* beatsSerialized) {
+                                                 const QByteArray& beatsSerialized) {
     if (beatsVersion == BEAT_GRID_1_VERSION ||
         beatsVersion == BEAT_GRID_2_VERSION) {
-        BeatGrid* pGrid = new BeatGrid(pTrack.data(), 0, beatsSerialized);
+        BeatGrid* pGrid = new BeatGrid(track, 0, beatsSerialized);
         pGrid->setSubVersion(beatsSubVersion);
         qDebug() << "Successfully deserialized BeatGrid";
         return BeatsPointer(pGrid, &BeatFactory::deleteBeats);
     } else if (beatsVersion == BEAT_MAP_VERSION) {
-        BeatMap* pMap = new BeatMap(pTrack, 0, beatsSerialized);
+        BeatMap* pMap = new BeatMap(track, 0, beatsSerialized);
         pMap->setSubVersion(beatsSubVersion);
         qDebug() << "Successfully deserialized BeatMap";
         return BeatsPointer(pMap, &BeatFactory::deleteBeats);
@@ -26,9 +26,9 @@ BeatsPointer BeatFactory::loadBeatsFromByteArray(TrackPointer pTrack,
     return BeatsPointer();
 }
 
-BeatsPointer BeatFactory::makeBeatGrid(Track* pTrack, double dBpm,
+BeatsPointer BeatFactory::makeBeatGrid(const Track& track, double dBpm,
                                        double dFirstBeatSample) {
-    BeatGrid* pGrid = new BeatGrid(pTrack, 0);
+    BeatGrid* pGrid = new BeatGrid(track, 0);
     pGrid->setGrid(dBpm, dFirstBeatSample);
     return BeatsPointer(pGrid, &BeatFactory::deleteBeats);
 }
@@ -86,7 +86,7 @@ QString BeatFactory::getPreferredSubVersion(
 
 
 BeatsPointer BeatFactory::makePreferredBeats(
-    TrackPointer pTrack, QVector<double> beats,
+    const Track& track, QVector<double> beats,
     const QHash<QString, QString> extraVersionInfo,
     const bool bEnableFixedTempoCorrection, const bool bEnableOffsetCorrection,
     const int iSampleRate, const int iTotalSamples,
@@ -103,13 +103,13 @@ BeatsPointer BeatFactory::makePreferredBeats(
         double firstBeat = BeatUtils::calculateFixedTempoFirstBeat(
             bEnableOffsetCorrection,
             beats, iSampleRate, iTotalSamples, globalBpm);
-        BeatGrid* pGrid = new BeatGrid(pTrack.data(), iSampleRate);
+        BeatGrid* pGrid = new BeatGrid(track, iSampleRate);
         // firstBeat is in frames here and setGrid() takes samples.
         pGrid->setGrid(globalBpm, firstBeat * 2);
         pGrid->setSubVersion(subVersion);
         return BeatsPointer(pGrid, &BeatFactory::deleteBeats);
     } else if (version == BEAT_MAP_VERSION) {
-        BeatMap* pBeatMap = new BeatMap(pTrack, iSampleRate, beats);
+        BeatMap* pBeatMap = new BeatMap(track, iSampleRate, beats);
         pBeatMap->setSubVersion(subVersion);
         return BeatsPointer(pBeatMap, &BeatFactory::deleteBeats);
     } else {

--- a/src/track/beatfactory.h
+++ b/src/track/beatfactory.h
@@ -7,11 +7,11 @@
 
 class BeatFactory {
   public:
-    static BeatsPointer loadBeatsFromByteArray(TrackPointer pTrack,
+    static BeatsPointer loadBeatsFromByteArray(const Track& track,
                                                QString beatsVersion,
                                                QString beatsSubVersion,
-                                               QByteArray* beatsSerialized);
-    static BeatsPointer makeBeatGrid(Track* pTrack,
+                                               const QByteArray& beatsSerialized);
+    static BeatsPointer makeBeatGrid(const Track& track,
                                      double dBpm, double dFirstBeatSample);
 
     static QString getPreferredVersion(const bool bEnableFixedTempoCorrection);
@@ -23,7 +23,7 @@ class BeatFactory {
         const QHash<QString, QString> extraVersionInfo);
 
     static BeatsPointer makePreferredBeats(
-        TrackPointer pTrack, QVector<double> beats,
+        const Track& track, QVector<double> beats,
         const QHash<QString, QString> extraVersionInfo,
         const bool bEnableFixedTempoCorrection,
         const bool bEnableOffsetCorrection,

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -35,34 +35,33 @@ class BeatGridIterator : public BeatIterator {
     double m_dEndSample;
 };
 
-BeatGrid::BeatGrid(Track* pTrack, int iSampleRate,
-                   const QByteArray* pByteArray)
-        : QObject(),
-          m_mutex(QMutex::Recursive),
-          m_iSampleRate(iSampleRate > 0 ? iSampleRate :
-                        pTrack->getSampleRate()),
+BeatGrid::BeatGrid(
+        const Track& track,
+        SINT iSampleRate)
+        : m_mutex(QMutex::Recursive),
+          m_iSampleRate(iSampleRate > 0 ? iSampleRate : track.getSampleRate()),
           m_dBeatLength(0.0) {
-    if (pTrack != nullptr) {
-        // BeatGrid should live in the same thread as the track it is associated
-        // with.
-        moveToThread(pTrack->thread());
-    }
-    if (pByteArray != nullptr) {
-        readByteArray(*pByteArray);
-    }
+    // BeatGrid should live in the same thread as the track it is associated
+    // with.
+    moveToThread(track.thread());
+}
+
+BeatGrid::BeatGrid(
+        const Track& track,
+        SINT iSampleRate,
+        const QByteArray& byteArray)
+        : BeatGrid(track, iSampleRate) {
+    readByteArray(byteArray);
 }
 
 BeatGrid::BeatGrid(const BeatGrid& other)
         : QObject(),
-          m_mutex(QMutex::Recursive) {
-    m_iSampleRate = other.m_iSampleRate;
-    m_dBeatLength = other.m_dBeatLength;
+          m_mutex(QMutex::Recursive),
+          m_subVersion(other.m_subVersion),
+          m_iSampleRate(other.m_iSampleRate),
+          m_grid(other.m_grid),
+          m_dBeatLength(other.m_dBeatLength) {
     moveToThread(other.thread());
-    m_subVersion = other.m_subVersion;
-    m_grid = other.m_grid;
-}
-
-BeatGrid::~BeatGrid() {
 }
 
 void BeatGrid::setGrid(double dBpm, double dFirstBeatSample) {

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -18,11 +18,14 @@ class BeatGrid : public QObject, public virtual Beats {
     Q_OBJECT
   public:
     // Construct a BeatGrid. If a more accurate sample rate is known, provide it
-    // in the iSampleRate parameter -- otherwise pass 0. If pByteArray is
-    // non-NULL, the BeatGrid will be deserialized from the byte array.
-    BeatGrid(Track* pTrack, int iSampleRate,
-             const QByteArray* pByteArray = nullptr);
-    virtual ~BeatGrid();
+    // in the iSampleRate parameter -- otherwise pass 0.
+    BeatGrid(const Track& track, SINT iSampleRate);
+    // Construct a BeatGrid. If a more accurate sample rate is known, provide it
+    // in the iSampleRate parameter -- otherwise pass 0. The BeatGrid will be
+    // deserialized from the byte array.
+    BeatGrid(const Track& track, SINT iSampleRate,
+             const QByteArray& byteArray);
+    ~BeatGrid() override = default;
 
     // Initializes the BeatGrid to have a BPM of dBpm and the first beat offset
     // of dFirstBeatSample. Does not generate an updated() signal, since it is
@@ -86,7 +89,7 @@ class BeatGrid : public QObject, public virtual Beats {
     // The sub-version of this beatgrid.
     QString m_subVersion;
     // The number of samples per second
-    int m_iSampleRate;
+    SINT m_iSampleRate;
     // Data storage for BeatGrid
     mixxx::track::io::BeatGrid m_grid;
     // The length of a beat in samples

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -23,19 +23,22 @@ class BeatMap : public QObject, public Beats {
     Q_OBJECT
   public:
     // Construct a BeatMap. iSampleRate may be provided if a more accurate
+    // sample rate is known than the one associated with the Track.
+    BeatMap(const Track& track, SINT iSampleRate);
+    // Construct a BeatMap. iSampleRate may be provided if a more accurate
     // sample rate is known than the one associated with the Track. If it is
-    // zero then the track's sample rate will be used. If a byte array is
-    // provided then the BeatMap will be deserialized from the byte array.
-    BeatMap(TrackPointer pTrack, int iSampleRate,
-            const QByteArray* pByteArray = nullptr);
+    // zero then the track's sample rate will be used. The BeatMap will be
+    // deserialized from the byte array.
+    BeatMap(const Track& track, SINT iSampleRate,
+            const QByteArray& byteArray);
     // Construct a BeatMap. iSampleRate may be provided if a more accurate
     // sample rate is known than the one associated with the Track. If it is
     // zero then the track's sample rate will be used. A list of beat locations
     // in audio frames may be provided.
-    BeatMap(TrackPointer pTrack, int iSampleRate,
+    BeatMap(const Track& track, SINT iSampleRate,
             const QVector<double>& beats);
 
-    virtual ~BeatMap();
+    ~BeatMap() override = default;
 
     // See method comments in beats.h
 
@@ -83,8 +86,7 @@ class BeatMap : public QObject, public Beats {
     void updated();
 
   private:
-    BeatMap (const BeatMap& other);
-    void initialize(TrackPointer pTrack, int iSampleRate);
+    BeatMap(const BeatMap& other);
     bool readByteArray(const QByteArray& byteArray);
     void createFromBeatVector(const QVector<double>& beats);
     void onBeatlistChanged();
@@ -102,8 +104,8 @@ class BeatMap : public QObject, public Beats {
 
     mutable QMutex m_mutex;
     QString m_subVersion;
+    SINT m_iSampleRate;
     double m_dCachedBpm;
-    int m_iSampleRate;
     double m_dLastFrame;
     BeatList m_beats;
 };

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -25,14 +25,6 @@ SecurityTokenPointer openSecurityToken(
     }
 }
 
-struct TrackDeleter {
-    void operator()(Track* pTrack) {
-        if (pTrack != nullptr) {
-            pTrack->deleteLater();
-        }
-    }
-};
-
 template<typename T>
 inline
 bool compareAndSet(T* pField, const T& value) {
@@ -73,7 +65,7 @@ TrackPointer Track::newTemporary(
                     fileInfo,
                     pSecurityToken,
                     TrackId());
-    return TrackPointer(pTrack, TrackDeleter());
+    return TrackPointer(pTrack);
 }
 
 //static
@@ -85,7 +77,7 @@ TrackPointer Track::newDummy(
                     fileInfo,
                     SecurityTokenPointer(),
                     trackId);
-    return TrackPointer(pTrack, TrackDeleter());
+    return TrackPointer(pTrack);
 }
 
 // static

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -717,7 +717,7 @@ void Track::slotCueUpdated() {
 CuePointer Track::addCue() {
     QMutexLocker lock(&m_qMutex);
     CuePointer pCue(new Cue(m_id));
-    connect(&*pCue, SIGNAL(updated()),
+    connect(pCue.get(), SIGNAL(updated()),
             this, SLOT(slotCueUpdated()));
     m_cuePoints.push_back(pCue);
     markDirtyAndUnlock(&lock);
@@ -727,7 +727,7 @@ CuePointer Track::addCue() {
 
 void Track::removeCue(const CuePointer& pCue) {
     QMutexLocker lock(&m_qMutex);
-    disconnect(&*pCue, 0, this, 0);
+    disconnect(pCue.get(), 0, this, 0);
     m_cuePoints.removeOne(pCue);
     markDirtyAndUnlock(&lock);
     emit(cuesUpdated());
@@ -743,12 +743,12 @@ void Track::setCuePoints(const QList<CuePointer>& cuePoints) {
     QMutexLocker lock(&m_qMutex);
     // disconnect existing cue points
     for (const auto& pCue: m_cuePoints) {
-        disconnect(&*pCue, 0, this, 0);
+        disconnect(pCue.get(), 0, this, 0);
     }
     m_cuePoints = cuePoints;
     // connect new cue points
     for (const auto& pCue: m_cuePoints) {
-        connect(&*pCue, SIGNAL(updated()),
+        connect(pCue.get(), SIGNAL(updated()),
                 this, SLOT(slotCueUpdated()));
     }
     markDirtyAndUnlock(&lock);

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -725,7 +725,7 @@ void Track::slotCueUpdated() {
 CuePointer Track::addCue() {
     QMutexLocker lock(&m_qMutex);
     CuePointer pCue(new Cue(m_id));
-    connect(pCue.data(), SIGNAL(updated()),
+    connect(&*pCue, SIGNAL(updated()),
             this, SLOT(slotCueUpdated()));
     m_cuePoints.push_back(pCue);
     markDirtyAndUnlock(&lock);
@@ -735,7 +735,7 @@ CuePointer Track::addCue() {
 
 void Track::removeCue(const CuePointer& pCue) {
     QMutexLocker lock(&m_qMutex);
-    disconnect(pCue.data(), 0, this, 0);
+    disconnect(&*pCue, 0, this, 0);
     m_cuePoints.removeOne(pCue);
     markDirtyAndUnlock(&lock);
     emit(cuesUpdated());
@@ -751,12 +751,12 @@ void Track::setCuePoints(const QList<CuePointer>& cuePoints) {
     QMutexLocker lock(&m_qMutex);
     // disconnect existing cue points
     for (const auto& pCue: m_cuePoints) {
-        disconnect(pCue.data(), 0, this, 0);
+        disconnect(&*pCue, 0, this, 0);
     }
     m_cuePoints = cuePoints;
     // connect new cue points
     for (const auto& pCue: m_cuePoints) {
-        connect(pCue.data(), SIGNAL(updated()),
+        connect(&*pCue, SIGNAL(updated()),
                 this, SLOT(slotCueUpdated()));
     }
     markDirtyAndUnlock(&lock);

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -267,7 +267,7 @@ double Track::setBpm(double bpmValue) {
     if (!m_pBeats) {
         // No beat grid available -> create and initialize
         double cue = getCuePoint();
-        BeatsPointer pBeats(BeatFactory::makeBeatGrid(this, bpmValue, cue));
+        BeatsPointer pBeats(BeatFactory::makeBeatGrid(*this, bpmValue, cue));
         setBeatsAndUnlock(&lock, pBeats);
         return bpmValue;
     }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -665,7 +665,7 @@ QString Track::getURL() const {
     return m_sURL;
 }
 
-ConstWaveformPointer Track::getWaveform() {
+ConstWaveformPointer Track::getWaveform() const {
     return m_waveform;
 }
 

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -25,8 +25,17 @@ SecurityTokenPointer openSecurityToken(
     }
 }
 
+struct TrackDeleter {
+    void operator()(Track* pTrack) {
+        if (pTrack != nullptr) {
+            pTrack->deleteLater();
+        }
+    }
+};
+
 template<typename T>
-inline bool compareAndSet(T* pField, const T& value) {
+inline
+bool compareAndSet(T* pField, const T& value) {
     if (*pField != value) {
         *pField = value;
         return true;
@@ -59,24 +68,24 @@ Track::Track(
 TrackPointer Track::newTemporary(
         const QFileInfo& fileInfo,
         const SecurityTokenPointer& pSecurityToken) {
-    return TrackPointer(
+    Track* pTrack =
             new Track(
                     fileInfo,
                     pSecurityToken,
-                    TrackId()),
-            &QObject::deleteLater);
+                    TrackId());
+    return TrackPointer(pTrack, TrackDeleter());
 }
 
 //static
 TrackPointer Track::newDummy(
         const QFileInfo& fileInfo,
         TrackId trackId) {
-    return TrackPointer(
+    Track* pTrack =
             new Track(
                     fileInfo,
                     SecurityTokenPointer(),
-                    trackId),
-            &QObject::deleteLater);
+                    trackId);
+    return TrackPointer(pTrack, TrackDeleter());
 }
 
 // static

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -428,6 +428,12 @@ class TrackPointer: public QSharedPointer<Track> {
     TrackPointer(Track* pTrack, void (*deleter)(Track*))
         : QSharedPointer<Track>(pTrack, deleter) {
     }
+
+    // TODO(uklotzde): Remove this function after migration
+    // from QSharedPointer to std::shared_ptr
+    Track* get() const {
+        return data();
+    }
 };
 
 #endif // MIXXX_TRACK_H

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -1,5 +1,7 @@
-#ifndef TRACK_TRACK_H
-#define TRACK_TRACK_H
+#ifndef MIXXX_TRACK_H
+#define MIXXX_TRACK_H
+
+#include <functional>
 
 #include <QAtomicInt>
 #include <QFileInfo>
@@ -21,7 +23,7 @@
 #include "waveform/waveform.h"
 
 class Track;
-typedef QSharedPointer<Track> TrackPointer;
+class TrackPointer;
 typedef QWeakPointer<Track> TrackWeakPointer;
 
 class Track : public QObject {
@@ -414,4 +416,18 @@ class Track : public QObject {
     friend class TrackDAO;
 };
 
-#endif // TRACK_TRACK_H
+class TrackPointer: public QSharedPointer<Track> {
+  public:
+    TrackPointer() {}
+    explicit TrackPointer(const TrackWeakPointer& pTrack)
+        : QSharedPointer<Track>(pTrack) {
+    }
+    explicit TrackPointer(Track* pTrack)
+        : QSharedPointer<Track>(pTrack, std::bind(&Track::deleteLater, pTrack)) {
+    }
+    TrackPointer(Track* pTrack, void (*deleter)(Track*))
+        : QSharedPointer<Track>(pTrack, deleter) {
+    }
+};
+
+#endif // MIXXX_TRACK_H

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -429,10 +429,13 @@ class TrackPointer: public QSharedPointer<Track> {
         : QSharedPointer<Track>(pTrack, deleter) {
     }
 
-    // TODO(uklotzde): Remove this function after migration
+    // TODO(uklotzde): Remove these functions after migration
     // from QSharedPointer to std::shared_ptr
     Track* get() const {
         return data();
+    }
+    void reset() {
+        clear();
     }
 };
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -234,7 +234,7 @@ class Track : public QObject {
     // Output a formatted string with artist and title.
     QString getInfo() const;
 
-    ConstWaveformPointer getWaveform();
+    ConstWaveformPointer getWaveform() const;
     void setWaveform(ConstWaveformPointer pWaveform);
 
     ConstWaveformPointer getWaveformSummary() const;

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -90,7 +90,7 @@ void WaveformRenderMark::onSetTrack() {
     if (!trackInfo) {
         return;
     }
-    connect(trackInfo.data(), SIGNAL(cuesUpdated(void)),
+    connect(&*trackInfo, SIGNAL(cuesUpdated(void)),
                   this, SLOT(slotCuesUpdated(void)));
 }
 

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -90,7 +90,7 @@ void WaveformRenderMark::onSetTrack() {
     if (!trackInfo) {
         return;
     }
-    connect(&*trackInfo, SIGNAL(cuesUpdated(void)),
+    connect(trackInfo.get(), SIGNAL(cuesUpdated(void)),
                   this, SLOT(slotCuesUpdated(void)));
 }
 

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -121,7 +121,7 @@ void WCoverArt::slotReset() {
         disconnect(m_loadedTrack.get(), SIGNAL(coverArtUpdated()),
                    this, SLOT(slotTrackCoverArtUpdated()));
     }
-    m_loadedTrack = TrackPointer();
+    m_loadedTrack.reset();
     m_lastRequestedCover = CoverInfo();
     m_loadedCover = QPixmap();
     m_loadedCoverScaled = QPixmap();

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -129,7 +129,9 @@ void WCoverArt::slotReset() {
 }
 
 void WCoverArt::slotTrackCoverArtUpdated() {
-    CoverArtCache::requestCover(m_loadedTrack.data(), this);
+    if (m_loadedTrack) {
+        CoverArtCache::requestCover(*m_loadedTrack, this);
+    }
 }
 
 void WCoverArt::slotCoverFound(const QObject* pRequestor,

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -118,7 +118,7 @@ void WCoverArt::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack)
 
 void WCoverArt::slotReset() {
     if (m_loadedTrack) {
-        disconnect(m_loadedTrack.data(), SIGNAL(coverArtUpdated()),
+        disconnect(&*m_loadedTrack, SIGNAL(coverArtUpdated()),
                    this, SLOT(slotTrackCoverArtUpdated()));
     }
     m_loadedTrack = TrackPointer();
@@ -155,7 +155,7 @@ void WCoverArt::slotCoverFound(const QObject* pRequestor,
 
 void WCoverArt::slotLoadTrack(TrackPointer pTrack) {
     if (m_loadedTrack) {
-        disconnect(m_loadedTrack.data(), SIGNAL(coverArtUpdated()),
+        disconnect(&*m_loadedTrack, SIGNAL(coverArtUpdated()),
                    this, SLOT(slotTrackCoverArtUpdated()));
     }
     m_lastRequestedCover = CoverInfo();
@@ -163,7 +163,7 @@ void WCoverArt::slotLoadTrack(TrackPointer pTrack) {
     m_loadedCoverScaled = QPixmap();
     m_loadedTrack = pTrack;
     if (m_loadedTrack) {
-        connect(m_loadedTrack.data(), SIGNAL(coverArtUpdated()),
+        connect(&*m_loadedTrack, SIGNAL(coverArtUpdated()),
                 this, SLOT(slotTrackCoverArtUpdated()));
     }
 

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -118,7 +118,7 @@ void WCoverArt::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack)
 
 void WCoverArt::slotReset() {
     if (m_loadedTrack) {
-        disconnect(&*m_loadedTrack, SIGNAL(coverArtUpdated()),
+        disconnect(m_loadedTrack.get(), SIGNAL(coverArtUpdated()),
                    this, SLOT(slotTrackCoverArtUpdated()));
     }
     m_loadedTrack = TrackPointer();
@@ -155,7 +155,7 @@ void WCoverArt::slotCoverFound(const QObject* pRequestor,
 
 void WCoverArt::slotLoadTrack(TrackPointer pTrack) {
     if (m_loadedTrack) {
-        disconnect(&*m_loadedTrack, SIGNAL(coverArtUpdated()),
+        disconnect(m_loadedTrack.get(), SIGNAL(coverArtUpdated()),
                    this, SLOT(slotTrackCoverArtUpdated()));
     }
     m_lastRequestedCover = CoverInfo();
@@ -163,7 +163,7 @@ void WCoverArt::slotLoadTrack(TrackPointer pTrack) {
     m_loadedCoverScaled = QPixmap();
     m_loadedTrack = pTrack;
     if (m_loadedTrack) {
-        connect(&*m_loadedTrack, SIGNAL(coverArtUpdated()),
+        connect(m_loadedTrack.get(), SIGNAL(coverArtUpdated()),
                 this, SLOT(slotTrackCoverArtUpdated()));
     }
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -204,9 +204,9 @@ void WOverview::slotTrackLoaded(TrackPointer pTrack) {
 void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     //qDebug() << this << "WOverview::slotLoadingTrack" << pNewTrack << pOldTrack;
     if (m_pCurrentTrack != nullptr && pOldTrack == m_pCurrentTrack) {
-        disconnect(&*m_pCurrentTrack, SIGNAL(waveformSummaryUpdated()),
+        disconnect(m_pCurrentTrack.get(), SIGNAL(waveformSummaryUpdated()),
                    this, SLOT(slotWaveformSummaryUpdated()));
-        disconnect(&*m_pCurrentTrack, SIGNAL(analyzerProgress(int)),
+        disconnect(m_pCurrentTrack.get(), SIGNAL(analyzerProgress(int)),
                    this, SLOT(slotAnalyzerProgress(int)));
     }
 
@@ -226,9 +226,9 @@ void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack)
         m_pCurrentTrack = pNewTrack;
         m_pWaveform = pNewTrack->getWaveformSummary();
 
-        connect(&*pNewTrack, SIGNAL(waveformSummaryUpdated()),
+        connect(pNewTrack.get(), SIGNAL(waveformSummaryUpdated()),
                 this, SLOT(slotWaveformSummaryUpdated()));
-        connect(&*pNewTrack, SIGNAL(analyzerProgress(int)),
+        connect(pNewTrack.get(), SIGNAL(analyzerProgress(int)),
                 this, SLOT(slotAnalyzerProgress(int)));
 
         slotAnalyzerProgress(pNewTrack->getAnalyzerProgress());

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -202,11 +202,11 @@ void WOverview::slotTrackLoaded(TrackPointer pTrack) {
 }
 
 void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
-    qDebug() << this << "WOverview::slotLoadingTrack" << pNewTrack << pOldTrack;
+    //qDebug() << this << "WOverview::slotLoadingTrack" << pNewTrack << pOldTrack;
     if (m_pCurrentTrack != nullptr && pOldTrack == m_pCurrentTrack) {
-        disconnect(m_pCurrentTrack.data(), SIGNAL(waveformSummaryUpdated()),
+        disconnect(&*m_pCurrentTrack, SIGNAL(waveformSummaryUpdated()),
                    this, SLOT(slotWaveformSummaryUpdated()));
-        disconnect(m_pCurrentTrack.data(), SIGNAL(analyzerProgress(int)),
+        disconnect(&*m_pCurrentTrack, SIGNAL(analyzerProgress(int)),
                    this, SLOT(slotAnalyzerProgress(int)));
     }
 
@@ -226,14 +226,14 @@ void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack)
         m_pCurrentTrack = pNewTrack;
         m_pWaveform = pNewTrack->getWaveformSummary();
 
-        connect(pNewTrack.data(), SIGNAL(waveformSummaryUpdated()),
+        connect(&*pNewTrack, SIGNAL(waveformSummaryUpdated()),
                 this, SLOT(slotWaveformSummaryUpdated()));
-        connect(pNewTrack.data(), SIGNAL(analyzerProgress(int)),
+        connect(&*pNewTrack, SIGNAL(analyzerProgress(int)),
                 this, SLOT(slotAnalyzerProgress(int)));
 
         slotAnalyzerProgress(pNewTrack->getAnalyzerProgress());
     } else {
-        m_pCurrentTrack.clear();
+        m_pCurrentTrack = TrackPointer();
         m_pWaveform.clear();
     }
     update();

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -233,7 +233,7 @@ void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack)
 
         slotAnalyzerProgress(pNewTrack->getAnalyzerProgress());
     } else {
-        m_pCurrentTrack = TrackPointer();
+        m_pCurrentTrack.reset();
         m_pWaveform.clear();
     }
     update();

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -226,7 +226,7 @@ void WSpinny::maybeUpdate() {
 
 void WSpinny::slotLoadTrack(TrackPointer pTrack) {
     if (m_loadedTrack) {
-        disconnect(&*m_loadedTrack, SIGNAL(coverArtUpdated()),
+        disconnect(m_loadedTrack.get(), SIGNAL(coverArtUpdated()),
                    this, SLOT(slotTrackCoverArtUpdated()));
     }
     m_lastRequestedCover = CoverInfo();
@@ -234,7 +234,7 @@ void WSpinny::slotLoadTrack(TrackPointer pTrack) {
     m_loadedCoverScaled = QPixmap();
     m_loadedTrack = pTrack;
     if (m_loadedTrack) {
-        connect(&*m_loadedTrack, SIGNAL(coverArtUpdated()),
+        connect(m_loadedTrack.get(), SIGNAL(coverArtUpdated()),
                 this, SLOT(slotTrackCoverArtUpdated()));
     }
 
@@ -244,7 +244,7 @@ void WSpinny::slotLoadTrack(TrackPointer pTrack) {
 void WSpinny::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     Q_UNUSED(pNewTrack);
     if (m_loadedTrack && pOldTrack == m_loadedTrack) {
-        disconnect(&*m_loadedTrack, SIGNAL(coverArtUpdated()),
+        disconnect(m_loadedTrack.get(), SIGNAL(coverArtUpdated()),
                    this, SLOT(slotTrackCoverArtUpdated()));
     }
     m_loadedTrack = TrackPointer();

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -226,7 +226,7 @@ void WSpinny::maybeUpdate() {
 
 void WSpinny::slotLoadTrack(TrackPointer pTrack) {
     if (m_loadedTrack) {
-        disconnect(m_loadedTrack.data(), SIGNAL(coverArtUpdated()),
+        disconnect(&*m_loadedTrack, SIGNAL(coverArtUpdated()),
                    this, SLOT(slotTrackCoverArtUpdated()));
     }
     m_lastRequestedCover = CoverInfo();
@@ -234,7 +234,7 @@ void WSpinny::slotLoadTrack(TrackPointer pTrack) {
     m_loadedCoverScaled = QPixmap();
     m_loadedTrack = pTrack;
     if (m_loadedTrack) {
-        connect(m_loadedTrack.data(), SIGNAL(coverArtUpdated()),
+        connect(&*m_loadedTrack, SIGNAL(coverArtUpdated()),
                 this, SLOT(slotTrackCoverArtUpdated()));
     }
 
@@ -244,7 +244,7 @@ void WSpinny::slotLoadTrack(TrackPointer pTrack) {
 void WSpinny::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     Q_UNUSED(pNewTrack);
     if (m_loadedTrack && pOldTrack == m_loadedTrack) {
-        disconnect(m_loadedTrack.data(), SIGNAL(coverArtUpdated()),
+        disconnect(&*m_loadedTrack, SIGNAL(coverArtUpdated()),
                    this, SLOT(slotTrackCoverArtUpdated()));
     }
     m_loadedTrack = TrackPointer();

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -255,7 +255,9 @@ void WSpinny::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
 }
 
 void WSpinny::slotTrackCoverArtUpdated() {
-    CoverArtCache::requestCover(m_loadedTrack.data(), this);
+    if (m_loadedTrack) {
+        CoverArtCache::requestCover(*m_loadedTrack, this);
+    }
 }
 
 void WSpinny::slotCoverFound(const QObject* pRequestor,

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -247,7 +247,7 @@ void WSpinny::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
         disconnect(m_loadedTrack.get(), SIGNAL(coverArtUpdated()),
                    this, SLOT(slotTrackCoverArtUpdated()));
     }
-    m_loadedTrack = TrackPointer();
+    m_loadedTrack.reset();
     m_lastRequestedCover = CoverInfo();
     m_loadedCover = QPixmap();
     m_loadedCoverScaled = QPixmap();

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -37,11 +37,11 @@ QSize WStarRating::sizeHint() const {
 void WStarRating::slotTrackLoaded(TrackPointer pTrack) {
     if (m_pCurrentTrack != pTrack) {
         if (m_pCurrentTrack) {
-            disconnect(&*m_pCurrentTrack, nullptr, this, nullptr);
+            disconnect(m_pCurrentTrack.get(), nullptr, this, nullptr);
             m_pCurrentTrack = TrackPointer();
         }
         if (pTrack) {
-            connect(&*pTrack, SIGNAL(changed(Track*)),
+            connect(pTrack.get(), SIGNAL(changed(Track*)),
                     this, SLOT(updateRating(Track*)));
             m_pCurrentTrack = pTrack;
         }

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -38,7 +38,7 @@ void WStarRating::slotTrackLoaded(TrackPointer pTrack) {
     if (m_pCurrentTrack != pTrack) {
         if (m_pCurrentTrack) {
             disconnect(m_pCurrentTrack.get(), nullptr, this, nullptr);
-            m_pCurrentTrack = TrackPointer();
+            m_pCurrentTrack.reset();
         }
         if (pTrack) {
             connect(pTrack.get(), SIGNAL(changed(Track*)),

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -24,9 +24,9 @@ void WTrackProperty::setup(const QDomNode& node, const SkinContext& context) {
 void WTrackProperty::slotTrackLoaded(TrackPointer track) {
     if (track) {
         m_pCurrentTrack = track;
-        connect(&*track, SIGNAL(changed(Track*)),
+        connect(track.get(), SIGNAL(changed(Track*)),
                 this, SLOT(updateLabel(Track*)));
-        updateLabel(&*track);
+        updateLabel(track.get());
     }
 }
 
@@ -34,7 +34,7 @@ void WTrackProperty::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldT
     Q_UNUSED(pNewTrack);
     Q_UNUSED(pOldTrack);
     if (m_pCurrentTrack) {
-        disconnect(&*m_pCurrentTrack, nullptr, this, nullptr);
+        disconnect(m_pCurrentTrack.get(), nullptr, this, nullptr);
     }
     m_pCurrentTrack = TrackPointer();
     setText("");

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -24,9 +24,9 @@ void WTrackProperty::setup(const QDomNode& node, const SkinContext& context) {
 void WTrackProperty::slotTrackLoaded(TrackPointer track) {
     if (track) {
         m_pCurrentTrack = track;
-        connect(track.data(), SIGNAL(changed(Track*)),
+        connect(&*track, SIGNAL(changed(Track*)),
                 this, SLOT(updateLabel(Track*)));
-        updateLabel(track.data());
+        updateLabel(&*track);
     }
 }
 
@@ -34,9 +34,9 @@ void WTrackProperty::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldT
     Q_UNUSED(pNewTrack);
     Q_UNUSED(pOldTrack);
     if (m_pCurrentTrack) {
-        disconnect(m_pCurrentTrack.data(), nullptr, this, nullptr);
+        disconnect(&*m_pCurrentTrack, nullptr, this, nullptr);
     }
-    m_pCurrentTrack.clear();
+    m_pCurrentTrack = TrackPointer();
     setText("");
 }
 

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -36,7 +36,7 @@ void WTrackProperty::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldT
     if (m_pCurrentTrack) {
         disconnect(m_pCurrentTrack.get(), nullptr, this, nullptr);
     }
-    m_pCurrentTrack = TrackPointer();
+    m_pCurrentTrack.reset();
     setText("");
 }
 

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -16,9 +16,9 @@ WTrackText::WTrackText(const char *group, UserSettingsPointer pConfig, QWidget* 
 void WTrackText::slotTrackLoaded(TrackPointer track) {
     if (track) {
         m_pCurrentTrack = track;
-        connect(&*track, SIGNAL(changed(Track*)),
+        connect(track.get(), SIGNAL(changed(Track*)),
                 this, SLOT(updateLabel(Track*)));
-        updateLabel(&*track);
+        updateLabel(track.get());
     }
 }
 
@@ -26,7 +26,7 @@ void WTrackText::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack
     Q_UNUSED(pNewTrack);
     Q_UNUSED(pOldTrack);
     if (m_pCurrentTrack) {
-        disconnect(&*m_pCurrentTrack, nullptr, this, nullptr);
+        disconnect(m_pCurrentTrack.get(), nullptr, this, nullptr);
     }
     m_pCurrentTrack = TrackPointer();
     setText("");

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -16,9 +16,9 @@ WTrackText::WTrackText(const char *group, UserSettingsPointer pConfig, QWidget* 
 void WTrackText::slotTrackLoaded(TrackPointer track) {
     if (track) {
         m_pCurrentTrack = track;
-        connect(track.data(), SIGNAL(changed(Track*)),
+        connect(&*track, SIGNAL(changed(Track*)),
                 this, SLOT(updateLabel(Track*)));
-        updateLabel(track.data());
+        updateLabel(&*track);
     }
 }
 
@@ -26,9 +26,9 @@ void WTrackText::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack
     Q_UNUSED(pNewTrack);
     Q_UNUSED(pOldTrack);
     if (m_pCurrentTrack) {
-        disconnect(m_pCurrentTrack.data(), nullptr, this, nullptr);
+        disconnect(&*m_pCurrentTrack, nullptr, this, nullptr);
     }
-    m_pCurrentTrack.clear();
+    m_pCurrentTrack = TrackPointer();
     setText("");
 }
 

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -28,7 +28,7 @@ void WTrackText::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack
     if (m_pCurrentTrack) {
         disconnect(m_pCurrentTrack.get(), nullptr, this, nullptr);
     }
-    m_pCurrentTrack = TrackPointer();
+    m_pCurrentTrack.reset();
     setText("");
 }
 


### PR DESCRIPTION
Some refactorings around the usage of Track/TrackPointer that lay the ground for replacing QSharedPointer with std::shared_ptr eventually.

The design of std::shared_ptr allows more efficient allocation of reference-counted objects by allocating the managing count object together with the managed object in a single memory allocation on the heap. But even more important: It's the standard! We already propose to use std::unqiue_ptr instead of QScopedPointer since upgrading to C++11.

The remaining changes to actually perform this switch are very simple. I've already prepared another branch for demonstration purposes: https://github.com/uklotzde/mixxx/tree/std_shared_ptr