### PR TITLE
Add missing null check before invoking deleteLater()

### DIFF
--- a/src/library/dao/cue.h
+++ b/src/library/dao/cue.h
@@ -1,8 +1,6 @@
 #ifndef MIXXX_CUE_H
 #define MIXXX_CUE_H
 
-#include <functional>
-
 #include <QObject>
 #include <QMutex>
 #include <QSharedPointer>
@@ -80,7 +78,7 @@ class CuePointer: public QSharedPointer<Cue> {
   public:
     CuePointer() {}
     explicit CuePointer(Cue* pCue)
-          : QSharedPointer<Cue>(pCue, std::bind(&Cue::deleteLater, pCue)) {
+          : QSharedPointer<Cue>(pCue, deleteLater) {
     }
 
     // TODO(uklotzde): Remove these functions after migration
@@ -90,6 +88,13 @@ class CuePointer: public QSharedPointer<Cue> {
     }
     void reset() {
         clear();
+    }
+
+  private:
+    static void deleteLater(Cue* pCue) {
+        if (pCue != nullptr) {
+            pCue->deleteLater();
+        }
     }
 };
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -1,8 +1,6 @@
 #ifndef MIXXX_TRACK_H
 #define MIXXX_TRACK_H
 
-#include <functional>
-
 #include <QAtomicInt>
 #include <QFileInfo>
 #include <QList>
@@ -423,7 +421,7 @@ class TrackPointer: public QSharedPointer<Track> {
         : QSharedPointer<Track>(pTrack) {
     }
     explicit TrackPointer(Track* pTrack)
-        : QSharedPointer<Track>(pTrack, std::bind(&Track::deleteLater, pTrack)) {
+        : QSharedPointer<Track>(pTrack, deleteLater) {
     }
     TrackPointer(Track* pTrack, void (*deleter)(Track*))
         : QSharedPointer<Track>(pTrack, deleter) {
@@ -436,6 +434,13 @@ class TrackPointer: public QSharedPointer<Track> {
     }
     void reset() {
         clear();
+    }
+
+  private:
+    static void deleteLater(Track* pTrack) {
+        if (pTrack != nullptr) {
+            pTrack->deleteLater();
+        }
     }
 };
 


### PR DESCRIPTION
Otherwise Mixxx logs many warnings on shutdown:
QCoreApplication::postEvent: Unexpected null receiver