### PR TITLE
(NSIS) correctly handle branches with space resulting in package name containing space

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -691,7 +691,7 @@ def BuildRelease(target, source, env):
             # Call the NSIS build
             buildwin64 = "/Dx64=1" if build.machine_is_64bit else ''
             staticdeps = "/DSTATICDEPS=1" if build.static_dependencies else ''
-            command = '%(path)s /DPACKAGE_NAME=%(package_name)s /DPRODUCT_VERSION=%(version)s /DQTDIR=%(qtpath)s /DWINLIB_PATH=%(winlibpath)s %(64bit)s %(staticdeps)s build\\nsis\\Mixxx.nsi' % \
+            command = '%(path)s /DPACKAGE_NAME=\"%(package_name)s\" /DPRODUCT_VERSION=%(version)s /DQTDIR=%(qtpath)s /DWINLIB_PATH=%(winlibpath)s %(64bit)s %(staticdeps)s build\\nsis\\Mixxx.nsi' % \
                 {'path': nsis_path,
                  'package_name': exe_name,
                  'version': mixxx_version,


### PR DESCRIPTION
This PR fixes lp:1643237

When you are in a detached HEAD state, https://github.com/mixxxdj/mixxx/blob/master/build/util.py#L94 returns "(no branch)" as branch name, resulting in a package name with a space.

`makensis` is called with parameter `/DPACKAGE_NAME=file name containing spaces`. This results in `PACKAGE_NAME=file` and unhandled parameters `name`, `containing` and `spaces`. The build fails.

This modification protect spaces within quotes resulting in `PACKAGE_NAME="file name containing spaces"`