### PR TITLE
Integrate Appveyor ci to add windows CI capabilities to the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ bug list][easybugs] and get started!
 ## Compiling
 
 * Linux / MacOS [![Build Status](https://travis-ci.org/mixxxdj/mixxx.svg)](https://travis-ci.org/mixxxdj/mixxx)
-* Windows [![Build status](https://ci.appveyor.com/api/projects/status/ADD_APPVEYOR_BADGE_ID_HERE?svg=true)](https://ci.appveyor.com/project/mixxxdj/mixxx)
+* Windows [![Build status](https://ci.appveyor.com/api/projects/status/j460rficblcaopwx?svg=true)](https://ci.appveyor.com/project/mixxxdj/mixxx)
 
 First, you must install all of Mixxx's dependencies. To compile Mixxx using
 [SCons], run:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ bug list][easybugs] and get started!
 
 ## Compiling
 
-[![Build Status](https://travis-ci.org/mixxxdj/mixxx.svg)](https://travis-ci.org/mixxxdj/mixxx)
+* Linux / MacOS [![Build Status](https://travis-ci.org/mixxxdj/mixxx.svg)](https://travis-ci.org/mixxxdj/mixxx)
+* Windows [![Build status](https://ci.appveyor.com/api/projects/status/ADD_APPVEYOR_BADGE_ID_HERE?svg=true)](https://ci.appveyor.com/project/mixxxdj/mixxx)
 
 First, you must install all of Mixxx's dependencies. To compile Mixxx using
 [SCons], run:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,9 +31,10 @@ install:
   - cd scons-2.5.1
   - python setup.py install
   - echo *** Downloading precompiled build environment if not in build-cache
+  - cd %APPVEYOR_BUILD_FOLDER%
   - build\appveyor\install_buildenv.bat %platform% %configuration%
 before_build:
-  - cd C:\projects\mixxx
+  - cd %APPVEYOR_BUILD_FOLDER%
 build_script:
   - build\appveyor\build_mixxx.bat %platform% %configuration%
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,12 +26,12 @@ install:
   - echo *** Downloading and installing scons
   # SF.net download currently broken from EC2 to some mirrors, so hosting scons myself
 #  - curl -fsS -L -o scons-2.5.1.zip http://prdownloads.sourceforge.net/scons/scons-2.5.1.zip
-  - curl -fsS -L -o scons-2.5.1.zip http://url_to_appveyor_build_env/scons-2.5.1.zip
+  - curl -fsS -L -o scons-2.5.1.zip http://downloads.mixxx.org/builds/appveyor/environments/2.0/scons-2.5.1.zip
   - 7z x scons-2.5.1.zip
   - cd scons-2.5.1
   - python setup.py install
   - echo *** Downloading precompiled build environment if not in build-cache
-  - curl -fsS -L -o install_buildenv.bat http://url_to_appveyor_build_env/install_buildenv.bat
+  - curl -fsS -L -o install_buildenv.bat http://downloads.mixxx.org/builds/appveyor/environments/2.0/install_buildenv.bat
   - .\install_buildenv.bat %platform% %configuration%
 before_build:
   - cd C:\projects\mixxx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,17 +26,16 @@ install:
   - echo *** Downloading and installing scons
   # SF.net download currently broken from EC2 to some mirrors, so hosting scons myself
 #  - curl -fsS -L -o scons-2.5.1.zip http://prdownloads.sourceforge.net/scons/scons-2.5.1.zip
-  - curl -fsS -L -o scons-2.5.1.zip http://downloads.mixxx.org/builds/appveyor/environments/2.0/scons-2.5.1.zip
+  - curl -fsS -L -o scons-2.5.1.zip https://downloads.mixxx.org/builds/appveyor/environments/2.0/scons-2.5.1.zip
   - 7z x scons-2.5.1.zip
   - cd scons-2.5.1
   - python setup.py install
   - echo *** Downloading precompiled build environment if not in build-cache
-  - curl -fsS -L -o install_buildenv.bat http://downloads.mixxx.org/builds/appveyor/environments/2.0/install_buildenv.bat
-  - .\install_buildenv.bat %platform% %configuration%
+  - build\appveyor\install_buildenv.bat %platform% %configuration%
 before_build:
   - cd C:\projects\mixxx
 build_script:
-  - C:\mixxx-buildserver\build_mixxx.bat %platform% %configuration%
+  - build\appveyor\build_mixxx.bat %platform% %configuration%
 test_script:
   - echo *** Testing
   # Calling mixxx-test under bash to have standard output

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,9 @@ configuration:
 environment:
   matrix:
     - platform: x64
-      bindir: dist64
+      distdir: dist64
     - platform: x86
-      bindir: dist32
+      distdir: dist32
 matrix:
   fast_finish: false     # set this flag to true to immediately finish build once one of the jobs fails.
 cache:
@@ -41,9 +41,9 @@ test_script:
   - echo *** Testing
   # Calling mixxx-test under bash to have standard output
   # and use stdbuf to unbuffer standard & error output
-  - bash -c "stdbuf -oL -eL %bindir%/mixxx-test.exe 2>&1"
+  - bash -c "stdbuf -oL -eL %distdir%/mixxx-test.exe 2>&1"
   - timeout 5 > NUL
-  - bash -c "stdbuf -oL -eL %bindir%/mixxx-test.exe --benchmark 2>&1"
+  - bash -c "stdbuf -oL -eL %distdir%/mixxx-test.exe --benchmark 2>&1"
   - timeout 5 > NUL
 artifacts:
   - path: '*.exe'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,60 @@
+---
+version: '{branch}-{build}'
+skip_tags: true
+max_jobs: 1
+image: Visual Studio 2013
+init:
+  - git config --global core.autocrlf input
+# Uncomment the following line to show RDP info at beginning of job
+#  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+clone_folder: c:\projects\mixxx
+configuration:
+  - release
+#  - debug
+environment:
+  matrix:
+    - platform: x64
+      bindir: dist64
+    - platform: x86
+      bindir: dist32
+matrix:
+  fast_finish: false     # set this flag to true to immediately finish build once one of the jobs fails.
+cache:
+  - C:\mixxx-buildserver
+install:
+  - cd %TEMP%
+  - echo *** Downloading and installing scons
+  # SF.net download currently broken from EC2 to some mirrors, so hosting scons myself
+#  - curl -fsS -L -o scons-2.5.1.zip http://prdownloads.sourceforge.net/scons/scons-2.5.1.zip
+  - curl -fsS -L -o scons-2.5.1.zip http://url_to_appveyor_build_env/scons-2.5.1.zip
+  - 7z x scons-2.5.1.zip
+  - cd scons-2.5.1
+  - python setup.py install
+  - echo *** Downloading precompiled build environment if not in build-cache
+  - curl -fsS -L -o install_buildenv.bat http://url_to_appveyor_build_env/install_buildenv.bat
+  - .\install_buildenv.bat %platform% %configuration%
+before_build:
+  - cd C:\projects\mixxx
+build_script:
+  - C:\mixxx-buildserver\build_mixxx.bat %platform% %configuration%
+test_script:
+  - echo *** Testing
+  # Calling mixxx-test under bash to have standard output
+  # and use stdbuf to unbuffer standard & error output
+  - bash -c "stdbuf -oL -eL %bindir%/mixxx-test.exe 2>&1"
+  - timeout 5 > NUL
+  - bash -c "stdbuf -oL -eL %bindir%/mixxx-test.exe --benchmark 2>&1"
+  - timeout 5 > NUL
+artifacts:
+  - path: '*.exe'
+  - path: '*.msi'
+on_success:
+  - echo "*** SUCCESS ***"
+on_failure:
+  - echo "*** FAILURE ***"
+on_finish:
+  # Uncomment the following line if you don't want the build VM to be destroyed
+  # and be able to RDP on it until a special “lock” file on VM desktop is deleted
+  # The RDP session is limited by overall build time (60 min).
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - echo "*** DONE ***"

--- a/build/appveyor/build_mixxx.bat
+++ b/build/appveyor/build_mixxx.bat
@@ -1,0 +1,61 @@
+@echo off
+
+REM set this to the folder where you build the dependencies
+set WINLIB_PATH64D=C:\mixxx-buildserver\2.0-x64-debug-minimal
+set WINLIB_PATH64R=C:\mixxx-buildserver\2.0-x64-release-minimal
+set WINLIB_PATH32D=C:\mixxx-buildserver\2.0-x86-debug-minimal
+set WINLIB_PATH32R=C:\mixxx-buildserver\2.0-x86-release-minimal
+
+REM XP Compatibility requires the v7.1A SDK
+set MSSDK_DIR="c:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A"
+
+IF "%2"=="" (
+echo "Usage: build_mixxx.bat <bitwidth> <buildtype>"
+echo.
+echo "For example : .\build.bat x64 release"
+exit /B 1
+)
+
+set ARCHITECTURE=%1
+set BUILD_TYPE=%2
+
+if "%ARCHITECTURE%" == "x86" set res32=T
+if "%ARCHITECTURE%" == "x32" set res32=T
+
+
+if "%res32%" == "T" (
+  set TARGET_MACHINE=x86
+  set VCVARS_ARCH=x86
+  set DISTDIR=dist32
+  if "%BUILD_TYPE%" == "release" (
+    set WINLIB_PATH=%WINLIB_PATH32R%
+  ) else (
+    set WINLIB_PATH=%WINLIB_PATH32D%
+  )
+  echo "****************************"
+  echo "** Building 32 bits Mixxx **"
+  echo "****************************"
+) else (
+  set TARGET_MACHINE=amd64
+  set VCVARS_ARCH=x86_amd64
+  set DISTDIR=dist64
+  if "%BUILD_TYPE%" == "release" (
+    set WINLIB_PATH=%WINLIB_PATH64R%
+  ) else (
+    set WINLIB_PATH=%WINLIB_PATH64D%
+  )
+  echo "****************************"
+  echo "** Building 64 bits Mixxx **"
+  echo "****************************"
+)
+
+REM Clean up after old builds.
+REM del /q /f *.exe *.msi 2>NUL
+REM rmdir /s /q %DISTDIR%
+
+call "c:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" %VCVARS_ARCH%
+
+REM set multiprocessor to build faster (together with scons -j4)
+set CL=/MP /FS /EHsc
+
+scons mixxx makerelease verbose=0 winlib=%WINLIB_PATH% qtdir=%WINLIB_PATH%\build\qt-everywhere-opensource-src-4.8.6 hss1394=1 mediafoundation=1 opus=1 localecompare=1 optimize=portable build=%BUILD_TYPE% machine=%TARGET_MACHINE% toolchain=msvs virtualize=0 test=1 qt_sqlite_plugin=0 mssdk_dir=%MSSDK_DIR% build_number_in_title_bar=0 bundle_pdbs=1

--- a/build/appveyor/install_buildenv.bat
+++ b/build/appveyor/install_buildenv.bat
@@ -1,0 +1,46 @@
+REM @ECHO OFF
+
+SET BUILDENVBASEDIR=C:\MIXXX-BUILDSERVER
+
+REM Build envs to install. You can specify more than one separated by spaces (no quotes)
+SET BUILDENVS=2.0-%1-%2-minimal
+
+REM precompiled compressed build env base URL
+SET BASEURL=https://downloads.mixxx.org/builds/appveyor/environments/2.0
+
+REM ---------------------------
+
+REM main()
+
+REM uncomment the following line if you want to empty cache and
+REM force buildenv (and build script) download
+REM RMDIR /S /Q %BUILDENVBASEDIR%
+
+REM Install build env base dir
+IF NOT EXIST %BUILDENVBASEDIR% MKDIR %BUILDENVBASEDIR%
+
+REM Install build envs
+FOR %%G IN (%BUILDENVS%) DO CALL :installbuildenv %%G
+
+REM End of main()
+GOTO:EOF
+
+REM ---------------------------
+
+REM FUNCTION installbuildenv(build_env_name)
+:installbuildenv
+SETLOCAL
+IF EXIST "%BUILDENVBASEDIR%\%1" GOTO BUILDENVEXISTS
+ECHO Installing build env %1
+CD %BUILDENVBASEDIR%
+echo ..Downloading %1.zip
+curl -fsS -L -o %1.zip %BASEURL%/%1.zip
+echo ..unzipping %1.zip
+7z x %1.zip
+DEL %1.zip
+GOTO ENDFUNC
+:BUILDENVEXISTS
+ECHO "Build env %1 seems to already exist. Leaving without doing anything"
+:ENDFUNC
+ENDLOCAL
+GOTO:EOF

--- a/build/util.py
+++ b/build/util.py
@@ -93,6 +93,10 @@ def get_git_branch_name():
     if branch_name == 'HEAD':
         # Use APPVEYOR_REPO_BRANCH variable if building on appveyor or (no branch) if unset
         branch_name = os.getenv("APPVEYOR_REPO_BRANCH", '(no branch)')
+    # Add PR# to branch name if building a PR in appveyor to avoid package naming collision
+    PRnum = os.getenv("APPVEYOR_PULL_REQUEST_NUMBER")
+    if PRnum != None:
+        branch_name += ("-PR" + PRnum)
     return branch_name
 
 

--- a/build/util.py
+++ b/build/util.py
@@ -91,7 +91,8 @@ def get_git_branch_name():
     branch_name = os.popen(
         "git rev-parse --abbrev-ref HEAD").readline().strip()
     if branch_name == 'HEAD':
-        branch_name = '(no branch)'
+        # Use APPVEYOR_REPO_BRANCH variable if building on appveyor or (no branch) if unset
+        branch_name = os.getenv("APPVEYOR_REPO_BRANCH", '(no branch)')
     return branch_name
 
 
@@ -127,7 +128,7 @@ def get_mixxx_version():
     versionMask = '^\d+\.\d+\.\d+([-~].+)?$'
     if not re.match(versionMask, version):
         raise ValueError("Version format mismatch. See src/defs_version.h comment")
-        
+
     return version
 
 
@@ -157,7 +158,7 @@ def CheckForPKGConfig(context, version='0.0.0'):
     context.Result(ret)
     return ret
 
-    
+
 # Uses pkg-config to check for a minimum version
 def CheckForPKG(context, name, version=""):
     if version == "":


### PR DESCRIPTION
This PR integrate with the appveyor service. Appveyor is a CI service for windows environment. This will add a build test on each commit and PR under windows env.
Appveyor also stores the resulting artifacts, allowing our coder to immediately get a testable build including their changes. This will ease the process to include a change for the windows env.

Thinks left to do before merging:

1) Host build env and scripts somewhere
download https://www.blaisot.org/mixxx-buildserver-windows/appveyor-build-env.tgz, extract it on some webserver and give me the URL where these files are downloadable to adjust scripts (more commits to follow)
/!\ you will have to update URL in install_buildenv.bat script to reflect the url it is hosted under.
see line SET BASEURL=http://url_to_appveyor_build_env

2) on appveyor site:
* create the mixxx appveyor project linked to the mixxxdj account/org on github (just log-in in appveyor with mixxxdj github account/org, then "new project"->github->mixxx
* Go to settings->badges and give me the SVG image URL to update URL in README (more commit to follow)

3) once all URL updated, merge & enjoy !

If you want to see what it will produce, here is an example:
https://ci.appveyor.com/project/sblaisot/mixxx/build/appveyor-test-65