### PR TITLE
Safeguards for TrackModel inheritance hierarchy

### DIFF
--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -33,7 +33,6 @@
 
 BansheePlaylistModel::BansheePlaylistModel(QObject* pParent, TrackCollection* pTrackCollection, BansheeDbConnection* pConnection)
         : BaseSqlTableModel(pParent, pTrackCollection, "mixxx.db.model.banshee_playlist"),
-          m_pTrackCollection(pTrackCollection),
           m_pConnection(pConnection),
           m_playlistId(-1) {
 }

--- a/src/library/banshee/bansheeplaylistmodel.h
+++ b/src/library/banshee/bansheeplaylistmodel.h
@@ -42,7 +42,6 @@ class BansheePlaylistModel : public BaseSqlTableModel {
     QString getFieldString(const QModelIndex& index, const QString& fieldName) const;
     QVariant getFieldVariant(const QModelIndex& index, const QString& fieldName) const;
 
-    TrackCollection* m_pTrackCollection;
     BansheeDbConnection* m_pConnection;
     int m_playlistId;
 };

--- a/src/library/banshee/bansheeplaylistmodel.h
+++ b/src/library/banshee/bansheeplaylistmodel.h
@@ -15,29 +15,28 @@ class BansheePlaylistModel : public BaseSqlTableModel {
     Q_OBJECT
   public:
     BansheePlaylistModel(QObject* pParent, TrackCollection* pTrackCollection, BansheeDbConnection* pConnection);
-    virtual ~BansheePlaylistModel();
+    ~BansheePlaylistModel() final;
 
     void setTableModel(int playlistId);
 
-    virtual TrackPointer getTrack(const QModelIndex& index) const;
-    virtual QString getTrackLocation(const QModelIndex& index) const;
-    virtual bool isColumnInternal(int column);
+    TrackPointer getTrack(const QModelIndex& index) const final;
+    QString getTrackLocation(const QModelIndex& index) const final;
+    bool isColumnInternal(int column) final;
 
-    virtual Qt::ItemFlags flags(const QModelIndex &index) const;
-    TrackModel::CapabilitiesFlags getCapabilities() const;
+    Qt::ItemFlags flags(const QModelIndex &index) const final;
+    CapabilitiesFlags getCapabilities() const final;
 
-    virtual bool setData(const QModelIndex& index, const QVariant& value, int role=Qt::EditRole);
-
+    bool setData(const QModelIndex& index, const QVariant& value, int role=Qt::EditRole) final;
 
   protected:
     // Use this if you want a model that is read-only.
-    virtual Qt::ItemFlags readOnlyFlags(const QModelIndex &index) const;
+    Qt::ItemFlags readOnlyFlags(const QModelIndex &index) const final;
     // Use this if you want a model that can be changed
-    virtual Qt::ItemFlags readWriteFlags(const QModelIndex &index) const;
+    Qt::ItemFlags readWriteFlags(const QModelIndex &index) const final;
 
   private slots:
-    virtual void tracksChanged(QSet<TrackId> trackIds);
-    virtual void trackLoaded(QString group, TrackPointer pTrack);
+    void tracksChanged(QSet<TrackId> trackIds);
+    void trackLoaded(QString group, TrackPointer pTrack);
 
   private:
     QString getFieldString(const QModelIndex& index, const QString& fieldName) const;

--- a/src/library/baseexternalplaylistmodel.h
+++ b/src/library/baseexternalplaylistmodel.h
@@ -20,14 +20,15 @@ class BaseExternalPlaylistModel : public BaseSqlTableModel {
                               const char* settingsNamespace, const QString& playlistsTable,
                               const QString& playlistTracksTable, QSharedPointer<BaseTrackCache> trackSource);
 
-    virtual ~BaseExternalPlaylistModel();
+    ~BaseExternalPlaylistModel() override;
 
-    virtual TrackPointer getTrack(const QModelIndex& index) const;
-    virtual bool isColumnInternal(int column);
-    Qt::ItemFlags flags(const QModelIndex &index) const;
     void setPlaylist(QString path_name);
-    virtual void trackLoaded(QString group, TrackPointer pTrack);
-    virtual TrackModel::CapabilitiesFlags getCapabilities() const;
+
+    TrackPointer getTrack(const QModelIndex& index) const override;
+    bool isColumnInternal(int column) override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    void trackLoaded(QString group, TrackPointer pTrack) override;
+    CapabilitiesFlags getCapabilities() const override;
 
   private:
     QString m_playlistsTable;

--- a/src/library/baseexternaltrackmodel.h
+++ b/src/library/baseexternaltrackmodel.h
@@ -19,13 +19,13 @@ class BaseExternalTrackModel : public BaseSqlTableModel {
                            const char* settingsNamespace,
                            const QString& trackTable,
                            QSharedPointer<BaseTrackCache> trackSource);
-    virtual ~BaseExternalTrackModel();
+    ~BaseExternalTrackModel() override;
 
-    virtual TrackModel::CapabilitiesFlags getCapabilities() const;
-    TrackPointer getTrack(const QModelIndex& index) const;
-    virtual void trackLoaded(QString group, TrackPointer pTrack);
-    virtual bool isColumnInternal(int column);
-    Qt::ItemFlags flags(const QModelIndex &index) const;
+    CapabilitiesFlags getCapabilities() const override;
+    TrackPointer getTrack(const QModelIndex& index) const override;
+    void trackLoaded(QString group, TrackPointer pTrack) override;
+    bool isColumnInternal(int column) override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
 };
 
 #endif /* BASEEXTERNALTRACKMODEL_H */

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -20,57 +20,64 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     BaseSqlTableModel(QObject* pParent,
                       TrackCollection* pTrackCollection,
                       const char* settingsNamespace);
-    virtual ~BaseSqlTableModel();
-
-    ///////////////////////////////////////////////////////////////////////////
-    //  Functions that have to/can be reimplemented
-    ///////////////////////////////////////////////////////////////////////////
-    //  This class also has protected variables that should be used in children
-    //  m_database, m_pTrackCollection, m_trackDAO
-
-    virtual bool isColumnInternal(int column) = 0;
-    virtual bool isColumnHiddenByDefault(int column);
-    virtual TrackModel::CapabilitiesFlags getCapabilities() const = 0;
-
-    // functions that can be implemented
-    // function to reimplement for external libraries
-    virtual TrackPointer getTrack(const QModelIndex& index) const;
-    // calls readWriteFlags() by default, reimplement this if the child calls
-    // should be readOnly
-    virtual Qt::ItemFlags flags(const QModelIndex &index) const;
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Other public methods
-    ////////////////////////////////////////////////////////////////////////////
+    ~BaseSqlTableModel() override;
 
     // Returns true if the BaseSqlTableModel has been initialized. Calling data
     // access methods on a BaseSqlTableModel which is not initialized is likely
     // to cause instability / crashes.
-    bool initialized() const { return m_bInitialized; }
-    TrackId getTrackId(const QModelIndex& index) const;
-    void search(const QString& searchText, const QString& extraFilter = QString());
+    bool initialized() const {
+        return m_bInitialized;
+    }
+
     void setSearch(const QString& searchText, const QString& extraFilter = QString());
-    const QString currentSearch() const;
     void setSort(int column, Qt::SortOrder order);
-    void hideTracks(const QModelIndexList& indices);
 
     int fieldIndex(ColumnCache::Column column) const;
-    int fieldIndex(const QString& fieldName) const;
 
-    QString getTrackLocation(const QModelIndex& index) const;
-    QAbstractItemDelegate* delegateForColumn(const int i, QObject* pParent);
+    ///////////////////////////////////////////////////////////////////////////
+    // Inherited from TrackModel
+    ///////////////////////////////////////////////////////////////////////////
+    int fieldIndex(const QString& fieldName) const final;
 
-    // Methods reimplemented from QAbstractItemModel
-    void sort(int column, Qt::SortOrder order);
-    int rowCount(const QModelIndex& parent=QModelIndex()) const;
-    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
-    bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole);
-    int columnCount(const QModelIndex& parent = QModelIndex()) const;
+    ///////////////////////////////////////////////////////////////////////////
+    // Inherited from QAbstractItemModel
+    ///////////////////////////////////////////////////////////////////////////
+    void sort(int column, Qt::SortOrder order) final;
+    int rowCount(const QModelIndex& parent=QModelIndex()) const final;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const final;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const final;
     bool setHeaderData(int section, Qt::Orientation orientation,
-                       const QVariant &value, int role = Qt::DisplayRole);
+                       const QVariant &value, int role = Qt::DisplayRole) final;
     QVariant headerData(int section, Qt::Orientation orientation,
-                        int role=Qt::DisplayRole) const;
-    virtual QMimeData* mimeData(const QModelIndexList &indexes) const;
+                        int role=Qt::DisplayRole) const final;
+    QMimeData* mimeData(const QModelIndexList &indexes) const final;
+
+    ///////////////////////////////////////////////////////////////////////////
+    //  Functions that might be reimplemented/overridden in derived classes
+    ///////////////////////////////////////////////////////////////////////////
+    //  This class also has protected variables that should be used in children
+    //  m_database, m_pTrackCollection, m_trackDAO
+
+    // calls readWriteFlags() by default, reimplement this if the child calls
+    // should be readOnly
+    virtual Qt::ItemFlags flags(const QModelIndex &index) const;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Inherited from TrackModel
+    ///////////////////////////////////////////////////////////////////////////
+    bool isColumnHiddenByDefault(int column) override;
+    TrackPointer getTrack(const QModelIndex& index) const override;
+    TrackId getTrackId(const QModelIndex& index) const override;
+    QString getTrackLocation(const QModelIndex& index) const override;
+    void hideTracks(const QModelIndexList& indices) override;
+    void search(const QString& searchText, const QString& extraFilter = QString()) override;
+    const QString currentSearch() const override;
+    QAbstractItemDelegate* delegateForColumn(const int i, QObject* pParent) override;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Inherited from QAbstractItemModel
+    ///////////////////////////////////////////////////////////////////////////
+    bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
 
   public slots:
     void select();
@@ -85,9 +92,9 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     void initHeaderData();
 
     // Use this if you want a model that is read-only.
-    Qt::ItemFlags readOnlyFlags(const QModelIndex &index) const;
+    virtual Qt::ItemFlags readOnlyFlags(const QModelIndex &index) const;
     // Use this if you want a model that can be changed
-    Qt::ItemFlags readWriteFlags(const QModelIndex &index) const;
+    virtual Qt::ItemFlags readWriteFlags(const QModelIndex &index) const;
 
     TrackCollection* m_pTrackCollection;
     TrackDAO& m_trackDAO;

--- a/src/library/cratetablemodel.cpp
+++ b/src/library/cratetablemodel.cpp
@@ -13,8 +13,7 @@ CrateTableModel::CrateTableModel(QObject* pParent,
                                  TrackCollection* pTrackCollection)
         : BaseSqlTableModel(pParent, pTrackCollection,
                             "mixxx.db.model.crate"),
-          m_iCrateId(-1),
-          m_crateDAO(pTrackCollection->getCrateDAO()) {
+          m_iCrateId(-1) {
 }
 
 CrateTableModel::~CrateTableModel() {
@@ -126,7 +125,7 @@ int CrateTableModel::addTracks(const QModelIndex& index,
 
     QList<TrackId> trackIds(m_trackDAO.addMultipleTracks(fileInfoList, true));
 
-    int tracksAdded = m_crateDAO.addTracksToCrate(m_iCrateId, &trackIds);
+    int tracksAdded = m_pTrackCollection->getCrateDAO().addTracksToCrate(m_iCrateId, &trackIds);
     if (tracksAdded > 0) {
         select();
     }
@@ -140,14 +139,14 @@ int CrateTableModel::addTracks(const QModelIndex& index,
 }
 
 void CrateTableModel::removeTracks(const QModelIndexList& indices) {
-    bool locked = m_crateDAO.isCrateLocked(m_iCrateId);
+    bool locked = m_pTrackCollection->getCrateDAO().isCrateLocked(m_iCrateId);
 
     if (!locked) {
         QList<TrackId> trackIds;
         foreach (QModelIndex index, indices) {
             trackIds.append(getTrackId(index));
         }
-        m_crateDAO.removeTracksFromCrate(trackIds, m_iCrateId);
+        m_pTrackCollection->getCrateDAO().removeTracksFromCrate(trackIds, m_iCrateId);
         select();
     }
 }
@@ -186,7 +185,7 @@ TrackModel::CapabilitiesFlags CrateTableModel::getCapabilities() const {
             | TRACKMODELCAPS_CLEAR_BEATS
             | TRACKMODELCAPS_RESETPLAYED;
 
-    bool locked = m_crateDAO.isCrateLocked(m_iCrateId);
+    bool locked = m_pTrackCollection->getCrateDAO().isCrateLocked(m_iCrateId);
     if (locked) {
         caps |= TRACKMODELCAPS_LOCKED;
     }

--- a/src/library/cratetablemodel.h
+++ b/src/library/cratetablemodel.h
@@ -29,7 +29,6 @@ class CrateTableModel : public BaseSqlTableModel {
 
   private:
     int m_iCrateId;
-    CrateDAO& m_crateDAO;
 };
 
 #endif /* CRATETABLEMODEL_H */

--- a/src/library/cratetablemodel.h
+++ b/src/library/cratetablemodel.h
@@ -11,20 +11,21 @@ class CrateTableModel : public BaseSqlTableModel {
     Q_OBJECT
   public:
     CrateTableModel(QObject* parent, TrackCollection* pTrackCollection);
-    virtual ~CrateTableModel();
+    ~CrateTableModel() final;
 
     void setTableModel(int crateId=-1);
     int getCrate() const {
         return m_iCrateId;
     }
 
-    // From TrackModel
-    bool isColumnInternal(int column);
-    void removeTracks(const QModelIndexList& indices);
     bool addTrack(const QModelIndex &index, QString location);
+
+    // From TrackModel
+    bool isColumnInternal(int column) final;
+    void removeTracks(const QModelIndexList& indices) final;
     // Returns the number of unsuccessful track additions
-    int addTracks(const QModelIndex& index, const QList<QString>& locations);
-    TrackModel::CapabilitiesFlags getCapabilities() const;
+    int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
+    CapabilitiesFlags getCapabilities() const final;
 
   private:
     int m_iCrateId;

--- a/src/library/hiddentablemodel.h
+++ b/src/library/hiddentablemodel.h
@@ -7,14 +7,15 @@ class HiddenTableModel : public BaseSqlTableModel {
     Q_OBJECT
   public:
     HiddenTableModel(QObject* parent, TrackCollection* pTrackCollection);
-    virtual ~HiddenTableModel();
+    ~HiddenTableModel() final;
 
     void setTableModel(int id = -1);
-    bool isColumnInternal(int column);
-    void purgeTracks(const QModelIndexList& indices);
-    void unhideTracks(const QModelIndexList& indices);
-    Qt::ItemFlags flags(const QModelIndex &index) const;
-    TrackModel::CapabilitiesFlags getCapabilities() const;
+
+    bool isColumnInternal(int column) final;
+    void purgeTracks(const QModelIndexList& indices) final;
+    void unhideTracks(const QModelIndexList& indices) final;
+    Qt::ItemFlags flags(const QModelIndex &index) const final;
+    CapabilitiesFlags getCapabilities() const final;
 };
 
 #endif

--- a/src/library/librarytablemodel.cpp
+++ b/src/library/librarytablemodel.cpp
@@ -3,8 +3,12 @@
 #include "library/queryutil.h"
 #include "mixer/playermanager.h"
 
-const QString LibraryTableModel::DEFAULT_LIBRARYFILTER =
+namespace {
+
+const QString kDefaultLibraryFilter =
         "mixxx_deleted=0 AND fs_deleted=0";
+
+} // anonymous namespace
 
 LibraryTableModel::LibraryTableModel(QObject* parent,
                                      TrackCollection* pTrackCollection,
@@ -32,7 +36,7 @@ void LibraryTableModel::setTableModel(int id) {
             "SELECT " + columns.join(", ") +
             " FROM library INNER JOIN track_locations "
             "ON library.location = track_locations.id "
-            "WHERE (" + LibraryTableModel::DEFAULT_LIBRARYFILTER + ")";
+            "WHERE (" + kDefaultLibraryFilter + ")";
     query.prepare(queryString);
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);

--- a/src/library/librarytablemodel.h
+++ b/src/library/librarytablemodel.h
@@ -6,8 +6,6 @@
 class LibraryTableModel : public BaseSqlTableModel {
     Q_OBJECT
   public:
-    static const QString DEFAULT_LIBRARYFILTER;
-
     LibraryTableModel(QObject* parent, TrackCollection* pTrackCollection,
                       const char* settingsNamespace);
     ~LibraryTableModel() override;

--- a/src/library/librarytablemodel.h
+++ b/src/library/librarytablemodel.h
@@ -6,16 +6,19 @@
 class LibraryTableModel : public BaseSqlTableModel {
     Q_OBJECT
   public:
+    static const QString DEFAULT_LIBRARYFILTER;
+
     LibraryTableModel(QObject* parent, TrackCollection* pTrackCollection,
                       const char* settingsNamespace);
-    virtual ~LibraryTableModel();
+    ~LibraryTableModel() override;
+
     void setTableModel(int id =-1);
-    bool isColumnInternal(int column);
+
+    bool isColumnInternal(int column) final;
     // Takes a list of locations and add the tracks to the library. Returns the
     // number of successful additions.
-    int addTracks(const QModelIndex& index, const QList<QString>& locations);
-    TrackModel::CapabilitiesFlags getCapabilities() const;
-    static const QString DEFAULT_LIBRARYFILTER;
+    int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
+    TrackModel::CapabilitiesFlags getCapabilities() const final;
 };
 
 #endif

--- a/src/library/missingtablemodel.cpp
+++ b/src/library/missingtablemodel.cpp
@@ -6,7 +6,7 @@
 
 namespace {
 
-const QString kMissinbgFilter = "mixxx_deleted=0 AND fs_deleted=1";
+const QString kMissingFilter = "mixxx_deleted=0 AND fs_deleted=1";
 
 } // anonymous namespace
 
@@ -33,7 +33,7 @@ void MissingTableModel::setTableModel(int id) {
                   " FROM library "
                   "INNER JOIN track_locations "
                   "ON library.location=track_locations.id "
-                  "WHERE " + kMissinbgFilter);
+                  "WHERE " + kMissingFilter);
     if (!query.exec()) {
         qDebug() << query.executedQuery() << query.lastError();
     }

--- a/src/library/missingtablemodel.cpp
+++ b/src/library/missingtablemodel.cpp
@@ -4,7 +4,11 @@
 #include "library/missingtablemodel.h"
 #include "library/librarytablemodel.h"
 
-const QString MissingTableModel::MISSINGFILTER = "mixxx_deleted=0 AND fs_deleted=1";
+namespace {
+
+const QString kMissinbgFilter = "mixxx_deleted=0 AND fs_deleted=1";
+
+} // anonymous namespace
 
 MissingTableModel::MissingTableModel(QObject* parent,
                                      TrackCollection* pTrackCollection)
@@ -29,7 +33,7 @@ void MissingTableModel::setTableModel(int id) {
                   " FROM library "
                   "INNER JOIN track_locations "
                   "ON library.location=track_locations.id "
-                  "WHERE " + MissingTableModel::MISSINGFILTER);
+                  "WHERE " + kMissinbgFilter);
     if (!query.exec()) {
         qDebug() << query.executedQuery() << query.lastError();
     }

--- a/src/library/missingtablemodel.h
+++ b/src/library/missingtablemodel.h
@@ -15,16 +15,14 @@ class MissingTableModel : public BaseSqlTableModel {
     Q_OBJECT
   public:
     MissingTableModel(QObject* parent, TrackCollection* pTrackCollection);
-    virtual ~MissingTableModel();
+    ~MissingTableModel() final;
 
     void setTableModel(int id = -1);
-    bool isColumnInternal(int column);
-    void purgeTracks(const QModelIndexList& indices);
-    Qt::ItemFlags flags(const QModelIndex &index) const;
-    TrackModel::CapabilitiesFlags getCapabilities() const;
 
-  private:
-    static const QString MISSINGFILTER;
+    bool isColumnInternal(int column) final;
+    void purgeTracks(const QModelIndexList& indices) final;
+    Qt::ItemFlags flags(const QModelIndex &index) const final;
+    CapabilitiesFlags getCapabilities() const final;
 };
 
 #endif

--- a/src/library/playlisttablemodel.h
+++ b/src/library/playlisttablemodel.h
@@ -9,27 +9,28 @@ class PlaylistTableModel : public BaseSqlTableModel {
   public:
     PlaylistTableModel(QObject* parent, TrackCollection* pTrackCollection,
                        const char* settingsNamespace, bool showAll = false);
-    virtual ~PlaylistTableModel();
-    void setTableModel(int playlistId = -1);
+    ~PlaylistTableModel() final;
 
+    void setTableModel(int playlistId = -1);
     int getPlaylist() const {
         return m_iPlaylistId;
     }
 
-    bool isColumnInternal(int column);
-    bool isColumnHiddenByDefault(int column);
-    // This function should only be used by AUTODJ
-    void removeTrack(const QModelIndex& index);
-    void removeTracks(const QModelIndexList& indices);
-    // Adding multiple tracks at one to a playlist. Returns the number of
-    // successful additions.
-    int addTracks(const QModelIndex& index, const QList<QString>& locations);
     bool appendTrack(TrackId trackId);
     void moveTrack(const QModelIndex& sourceIndex,
                    const QModelIndex& destIndex);
-    bool isLocked();
+    void removeTrack(const QModelIndex& index);
     void shuffleTracks(const QModelIndexList& shuffle, const QModelIndex& exclude);
-    TrackModel::CapabilitiesFlags getCapabilities() const;
+
+    bool isColumnInternal(int column) final;
+    bool isColumnHiddenByDefault(int column) final;
+    // This function should only be used by AUTODJ
+    void removeTracks(const QModelIndexList& indices) final;
+    // Adding multiple tracks at one to a playlist. Returns the number of
+    // successful additions.
+    int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
+    bool isLocked() final;
+    CapabilitiesFlags getCapabilities() const final;
 
   private slots:
     void playlistChanged(int playlistId);

--- a/src/library/playlisttablemodel.h
+++ b/src/library/playlisttablemodel.h
@@ -36,7 +36,6 @@ class PlaylistTableModel : public BaseSqlTableModel {
     void playlistChanged(int playlistId);
 
   private:
-    PlaylistDAO& m_playlistDao;
     int m_iPlaylistId;
     bool m_showAll;
 };

--- a/src/library/proxytrackmodel.h
+++ b/src/library/proxytrackmodel.h
@@ -1,8 +1,5 @@
-// proxytrackmodel.h
-// Created 10/22/2009 by RJ Ryan (rryan@mit.edu)
-
-#ifndef PROXYTRACKMODEL_H
-#define PROXYTRACKMODEL_H
+#ifndef MIXXX_PROXYTRACKMODEL_H
+#define MIXXX_PROXYTRACKMODEL_H
 
 #include <QSortFilterProxyModel>
 #include <QAbstractItemModel>
@@ -22,30 +19,30 @@ class ProxyTrackModel : public QSortFilterProxyModel, public TrackModel {
     // composes. If bHandleSearches is true, then search signals will not be
     // delivered to pTrackModel -- instead the ProxyTrackModel will do its own
     // filtering.
-    ProxyTrackModel(QAbstractItemModel* pTrackModel, bool bHandleSearches=true);
-    virtual ~ProxyTrackModel();
+    explicit ProxyTrackModel(QAbstractItemModel* pTrackModel, bool bHandleSearches = true);
+    ~ProxyTrackModel() override;
 
-    virtual TrackPointer getTrack(const QModelIndex& index) const;
-    virtual QString getTrackLocation(const QModelIndex& index) const;
-    virtual TrackId getTrackId(const QModelIndex& index) const;
-    virtual const QLinkedList<int> getTrackRows(TrackId trackId) const;
-    virtual void search(const QString& searchText,const QString& extraFilter=QString());
-    virtual const QString currentSearch() const;
-    virtual bool isColumnInternal(int column);
-    virtual bool isColumnHiddenByDefault(int column);
-    virtual void removeTracks(const QModelIndexList& indices);
-    virtual void moveTrack(const QModelIndex& sourceIndex,
-                           const QModelIndex& destIndex);
-    void deleteTracks(const QModelIndexList& indices);
-    virtual QAbstractItemDelegate* delegateForColumn(const int i, QObject* pParent);
-    virtual TrackModel::CapabilitiesFlags getCapabilities() const;
+    // Inherited from TrackModel
+    CapabilitiesFlags getCapabilities() const final;
+    TrackPointer getTrack(const QModelIndex& index) const final;
+    QString getTrackLocation(const QModelIndex& index) const final;
+    TrackId getTrackId(const QModelIndex& index) const final;
+    const QLinkedList<int> getTrackRows(TrackId trackId) const final;
+    void search(const QString& searchText,const QString& extraFilter = QString()) final;
+    const QString currentSearch() const final;
+    bool isColumnInternal(int column) final;
+    bool isColumnHiddenByDefault(int column) final;
+    void removeTracks(const QModelIndexList& indices) final;
+    void moveTrack(const QModelIndex& sourceIndex, const QModelIndex& destIndex) final;
+    QAbstractItemDelegate* delegateForColumn(const int i, QObject* pParent) final;
+    QString getModelSetting(QString name) final;
+    bool setModelSetting(QString name, QVariant value) final;
 
-    bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const;
+    // Inherited from QSortFilterProxyModel
+    bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const final;
 
-    virtual QString getModelSetting(QString name);
-    virtual bool setModelSetting(QString name, QVariant value);
-
-    void sort(int column, Qt::SortOrder order = Qt::AscendingOrder);
+    // Inherited from QAbstractItemModel
+    void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) final;
 
   private:
     TrackModel* m_pTrackModel;
@@ -53,4 +50,4 @@ class ProxyTrackModel : public QSortFilterProxyModel, public TrackModel {
     bool m_bHandleSearches;
 };
 
-#endif /* PROXYTRACKMODEL_H */
+#endif // MIXXX_PROXYTRACKMODEL_H


### PR DESCRIPTION
Just minor syntactic stuff, no functional changes (yet):
* Decorate inherited functions with override/final keywords
* Remove redundant class members
* Hide internal constants