### PR TITLE
Appveyor: only upload test results when test have run

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,8 @@ test_script:
   - timeout 5 > NUL
   - bash -c "stdbuf -oL -eL %distdir%/mixxx-test.exe --benchmark 2>&1"
   - timeout 5 > NUL
+after_test:
+  - ps: (new-object net.webclient).UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\test_results.xml))
 artifacts:
   - path: '*.exe'
   - path: '*.msi'
@@ -53,7 +55,6 @@ on_success:
 on_failure:
   - echo "*** FAILURE ***"
 on_finish:
-  - ps: (new-object net.webclient).UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\test_results.xml))
   # Uncomment the following line if you don't want the build VM to be destroyed
   # and be able to RDP on it until a special “lock” file on VM desktop is deleted
   # The RDP session is limited by overall build time (60 min).


### PR DESCRIPTION
Move test results upload to `after_test` section to avoid trying to upload test results when no test have run (build failure for example)