### PR TITLE
Don't start Appveyor CI on resource file changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,6 @@ clone_folder: c:\projects\mixxx
 skip_commits:
   files:
     - doc/
-    - res/
     - LICENCE
     - README
     - README.md

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,16 @@ init:
 # Uncomment the following line to show RDP info at beginning of job
 #  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 clone_folder: c:\projects\mixxx
+skip_commits:
+  files:
+    - doc/
+    - res/
+    - LICENCE
+    - README
+    - README.md
+    - COPYING
+    - CODE_OF_CONDUCT.md
+
 configuration:
   - release
 #  - debug


### PR DESCRIPTION
With this PR, AppVeyor will not start a build when a commit don't modify code.