### PR TITLE
Replace QLinkedList with QVector

### DIFF
--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -255,9 +255,9 @@ void BansheePlaylistModel::trackLoaded(QString group, TrackPointer pTrack) {
         // preview state will update.
         if (m_previewDeckTrackId.isValid()) {
             const int numColumns = columnCount();
-            QLinkedList<int> rows = getTrackRows(m_previewDeckTrackId);
+            QVector<int> rows = getTrackRows(m_previewDeckTrackId);
             m_previewDeckTrackId = TrackId(); // invalidate
-            foreach (int row, rows) {
+            for (int row: rows) {
                 QModelIndex left = index(row, 0);
                 QModelIndex right = index(row, numColumns);
                 emit(dataChanged(left, right));

--- a/src/library/baseexternalplaylistmodel.cpp
+++ b/src/library/baseexternalplaylistmodel.cpp
@@ -137,9 +137,9 @@ void BaseExternalPlaylistModel::trackLoaded(QString group, TrackPointer pTrack) 
         // preview state will update.
         if (m_previewDeckTrackId.isValid()) {
             const int numColumns = columnCount();
-            QLinkedList<int> rows = getTrackRows(m_previewDeckTrackId);
+            QVector<int> rows = getTrackRows(m_previewDeckTrackId);
             m_previewDeckTrackId = TrackId(); // invalidate
-            foreach (int row, rows) {
+            for (int row: rows) {
                 QModelIndex left = index(row, 0);
                 QModelIndex right = index(row, numColumns);
                 emit(dataChanged(left, right));

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -77,9 +77,9 @@ void BaseExternalTrackModel::trackLoaded(QString group, TrackPointer pTrack) {
         // preview state will update.
         if (m_previewDeckTrackId.isValid()) {
             const int numColumns = columnCount();
-            QLinkedList<int> rows = getTrackRows(m_previewDeckTrackId);
+            QVector<int> rows = getTrackRows(m_previewDeckTrackId);
             m_previewDeckTrackId = TrackId(); // invalidate
-            foreach (int row, rows) {
+            for (int row: rows) {
                 QModelIndex left = index(row, 0);
                 QModelIndex right = index(row, numColumns);
                 emit(dataChanged(left, right));

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -314,6 +314,9 @@ void BaseSqlTableModel::select() {
         endInsertRows();
     }
 
+    DEBUG_ASSERT(m_rowInfo.empty() == m_trackIdToRows.empty());
+    DEBUG_ASSERT(m_rowInfo.size() >= m_trackIdToRows.size());
+
     qDebug() << this << "select() took" << time.elapsed().debugMillisWithUnit()
              << rowInfo.size();
 }

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -293,7 +293,7 @@ void BaseSqlTableModel::select() {
     // should not disturb that if we are only removing tracks.
     qStableSort(rowInfo.begin(), rowInfo.end());
 
-    m_trackIdToRows.clear();
+    QHash<TrackId, QVector<int> > trackIdToRows;
     for (int i = 0; i < rowInfo.size(); ++i) {
         const RowInfo& row = rowInfo[i];
 
@@ -303,13 +303,14 @@ void BaseSqlTableModel::select() {
             rowInfo.resize(i);
             break;
         }
-        m_trackIdToRows[row.trackId].push_back(i);
+        trackIdToRows[row.trackId].push_back(i);
     }
 
     // We're done! Issue the update signals and replace the master maps.
     if (!rowInfo.isEmpty()) {
         beginInsertRows(QModelIndex(), 0, rowInfo.size() - 1);
         m_rowInfo = rowInfo;
+        m_trackIdToRows = trackIdToRows;
         endInsertRows();
     }
 

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -68,7 +68,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     bool isColumnHiddenByDefault(int column) override;
     TrackPointer getTrack(const QModelIndex& index) const override;
     TrackId getTrackId(const QModelIndex& index) const override;
-    const QLinkedList<int> getTrackRows(TrackId trackId) const;
+    QVector<int> getTrackRows(TrackId trackId) const;
     QString getTrackLocation(const QModelIndex& index) const override;
     void hideTracks(const QModelIndexList& indices) override;
     void search(const QString& searchText, const QString& extraFilter = QString()) override;
@@ -150,7 +150,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     bool m_bInitialized;
     QSqlRecord m_queryRecord;
     QHash<TrackId, int> m_trackSortOrder;
-    QHash<TrackId, QLinkedList<int> > m_trackIdToRows;
+    QHash<TrackId, QVector<int> > m_trackIdToRows;
     QString m_currentSearch;
     QString m_currentSearchFilter;
     QVector<QHash<int, QVariant> > m_headerInfo;

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -68,6 +68,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     bool isColumnHiddenByDefault(int column) override;
     TrackPointer getTrack(const QModelIndex& index) const override;
     TrackId getTrackId(const QModelIndex& index) const override;
+    const QLinkedList<int> getTrackRows(TrackId trackId) const;
     QString getTrackLocation(const QModelIndex& index) const override;
     void hideTracks(const QModelIndexList& indices) override;
     void search(const QString& searchText, const QString& extraFilter = QString()) override;
@@ -85,7 +86,6 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
   protected:
     // Returns the row of trackId in this result set. If trackId is not present,
     // returns -1.
-    const QLinkedList<int> getTrackRows(TrackId trackId) const;
     void setTable(const QString& tableName, const QString& trackIdColumn,
                   const QStringList& tableColumns,
                   QSharedPointer<BaseTrackCache> trackSource);

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -126,10 +126,10 @@ TrackId BrowseTableModel::getTrackId(const QModelIndex& index) const {
     return TrackId();
 }
 
-const QLinkedList<int> BrowseTableModel::getTrackRows(TrackId trackId) const {
+QVector<int> BrowseTableModel::getTrackRows(TrackId trackId) const {
     Q_UNUSED(trackId);
     // We can't implement this as it stands.
-    return QLinkedList<int>();
+    return QVector<int>();
 }
 
 void BrowseTableModel::search(const QString& searchText, const QString& extraFilter) {

--- a/src/library/browse/browsetablemodel.h
+++ b/src/library/browse/browsetablemodel.h
@@ -51,7 +51,7 @@ class BrowseTableModel : public QStandardItemModel, public virtual TrackModel {
 
     QString getTrackLocation(const QModelIndex& index) const override;
     TrackId getTrackId(const QModelIndex& index) const override;
-    const QLinkedList<int> getTrackRows(TrackId trackId) const override;
+    QVector<int> getTrackRows(TrackId trackId) const override;
     void search(const QString& searchText,const QString& extraFilter = QString()) override;
     void removeTracks(const QModelIndexList& indices) override;
     QMimeData* mimeData(const QModelIndexList &indexes) const override;

--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -28,8 +28,8 @@ TrackId ProxyTrackModel::getTrackId(const QModelIndex& index) const {
     return m_pTrackModel ? m_pTrackModel->getTrackId(indexSource) : TrackId();
 }
 
-const QLinkedList<int> ProxyTrackModel::getTrackRows(TrackId trackId) const {
-    return m_pTrackModel ? m_pTrackModel->getTrackRows(trackId) : QLinkedList<int>();
+QVector<int> ProxyTrackModel::getTrackRows(TrackId trackId) const {
+    return m_pTrackModel ? m_pTrackModel->getTrackRows(trackId) : QVector<int>();
 }
 
 TrackPointer ProxyTrackModel::getTrack(const QModelIndex& index) const {

--- a/src/library/proxytrackmodel.h
+++ b/src/library/proxytrackmodel.h
@@ -27,7 +27,7 @@ class ProxyTrackModel : public QSortFilterProxyModel, public TrackModel {
     TrackPointer getTrack(const QModelIndex& index) const final;
     QString getTrackLocation(const QModelIndex& index) const final;
     TrackId getTrackId(const QModelIndex& index) const final;
-    const QLinkedList<int> getTrackRows(TrackId trackId) const final;
+    QVector<int> getTrackRows(TrackId trackId) const final;
     void search(const QString& searchText,const QString& extraFilter = QString()) final;
     const QString currentSearch() const final;
     bool isColumnInternal(int column) final;

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -2,7 +2,7 @@
 #define TRACKMODEL_H
 
 #include <QList>
-#include <QLinkedList>
+#include <QVector>
 #include <QItemDelegate>
 #include <QtSql>
 
@@ -59,9 +59,8 @@ class TrackModel {
     // Gets the track ID of the track at the given QModelIndex
     virtual TrackId getTrackId(const QModelIndex& index) const = 0;
 
-    // Gets the row of the track in the current result set. Returns -1 if the
-    // track ID is not present in the result set.
-    virtual const QLinkedList<int> getTrackRows(TrackId trackId) const = 0;
+    // Gets the row of the track in the current result set.
+    virtual QVector<int> getTrackRows(TrackId trackId) const = 0;
 
     bool isTrackModel() { return true;}
     virtual void search(const QString& searchText, const QString& extraFilter=QString()) = 0;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1527,8 +1527,8 @@ void WTrackTableView::doSortByColumn(int headerSection) {
         // the TrackModel. This will allow the playlist table model to use the
         // table index as the unique id instead of this code stupidly using
         // trackid.
-        QLinkedList<int> rows = trackModel->getTrackRows(trackId);
-        for (int row : rows) {
+        QVector<int> rows = trackModel->getTrackRows(trackId);
+        for (int row: rows) {
             // Restore sort order by rows, so the following commands will act as expected
             selectedRows.insert(row,0);
         }


### PR DESCRIPTION
Just some minor changes:
- Switch collection type
- Fix some design issues

This PR keeps the QHash instead of replacing it with QMultiHash.