### PR TITLE
Declare data types with trivial ctor/dtor as Q_MOVABLE_TYPE

### DIFF
--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -63,6 +63,7 @@ bool operator!=(const Bpm& lhs, const Bpm& rhs) {
 
 }
 
+Q_DECLARE_TYPEINFO(mixxx::Bpm, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(mixxx::Bpm)
 
 #endif // MIXXX_BPM_H

--- a/src/track/replaygain.h
+++ b/src/track/replaygain.h
@@ -114,6 +114,7 @@ bool operator!=(const ReplayGain& lhs, const ReplayGain& rhs) {
 
 }
 
+Q_DECLARE_TYPEINFO(mixxx::ReplayGain, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(mixxx::ReplayGain)
 
 #endif // MIXXX_REPLAYGAIN_H

--- a/src/track/trackid.h
+++ b/src/track/trackid.h
@@ -20,6 +20,7 @@ public:
 #endif
 };
 
+Q_DECLARE_TYPEINFO(TrackId, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(TrackId)
 
 

--- a/src/track/tracknumbers.h
+++ b/src/track/tracknumbers.h
@@ -122,6 +122,7 @@ bool operator!=(const TrackNumbers& lhs, const TrackNumbers& rhs) {
     return !(lhs == rhs);
 }
 
+Q_DECLARE_TYPEINFO(TrackNumbers, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(TrackNumbers)
 
 #endif // TRACKNUMBERS_H

--- a/src/util/dbid.h
+++ b/src/util/dbid.h
@@ -117,6 +117,7 @@ private:
     value_type m_value;
 };
 
+Q_DECLARE_TYPEINFO(DbId, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(DbId)
 
 

--- a/src/util/duration.h
+++ b/src/util/duration.h
@@ -271,6 +271,7 @@ class Duration : public DurationBase {
 
 }  // namespace mixxx
 
+Q_DECLARE_TYPEINFO(mixxx::Duration, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(mixxx::Duration)
 
 #endif /* MIXXX_UTIL_DURATION_H */


### PR DESCRIPTION
...to improve the efficiency when used as elements of Qt container classes like QList.