### PR TITLE
Take into account platter when detecting if stopped

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -780,6 +780,11 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
         double speed = m_pRateControl->calculateSpeed(
                 baserate, tempoRatio, paused, iBufferSize, &is_scratching, &is_reverse);
 
+        // The cue indicator may change when scratch state is changed
+        if (is_scratching != m_scratching_old) {
+            m_pCueControl->updateIndicators();
+        }
+
         bool useIndependentPitchAndTempoScaling = false;
 
         // TODO(owen): Maybe change this so that rubberband doesn't disable


### PR DESCRIPTION
In the case of CDJs, pressing the cue button while playing but with your hand on the platter is equivalent to pressing the cue button while stopped. Before this fix, the behavior was super unintuitive when you try to set a cue point using the platter to navigate like you would with vinyl.

I don't have experience with the other cue modes, so I don't know what the correct behavior is supposed to be there, and thus have left them alone.