### PR TITLE
Effect & effect parameter short names

### DIFF
--- a/src/effects/effectmanifest.h
+++ b/src/effects/effectmanifest.h
@@ -45,6 +45,13 @@ class EffectManifest {
         m_name = name;
     }
 
+    virtual const QString& shortName() const {
+        return m_shortName;
+    }
+    virtual void setShortName(const QString& shortName) {
+        m_shortName = shortName;
+    }
+
     virtual const QString& author() const {
         return m_author;
     }
@@ -114,6 +121,7 @@ class EffectManifest {
 
     QString m_id;
     QString m_name;
+    QString m_shortName;
     QString m_author;
     QString m_version;
     QString m_description;

--- a/src/effects/effectmanifestparameter.h
+++ b/src/effects/effectmanifestparameter.h
@@ -74,6 +74,13 @@ class EffectManifestParameter {
         m_name = name;
     }
 
+    virtual const QString& shortName() const {
+        return m_shortName;
+    }
+    virtual void setShortName(const QString& shortName) {
+        m_shortName = shortName;
+    }
+
     virtual const QString& description() const {
         return m_description;
     }
@@ -179,6 +186,7 @@ class EffectManifestParameter {
 
     QString m_id;
     QString m_name;
+    QString m_shortName;
     QString m_description;
 
     ControlHint m_controlHint;

--- a/src/effects/effectparameter.cpp
+++ b/src/effects/effectparameter.cpp
@@ -51,6 +51,10 @@ const QString EffectParameter::name() const {
     return m_parameter.name();
 }
 
+const QString EffectParameter::shortName() const {
+    return m_parameter.shortName();
+}
+
 const QString EffectParameter::description() const {
     return m_parameter.description();
 }

--- a/src/effects/effectparameter.h
+++ b/src/effects/effectparameter.h
@@ -32,6 +32,7 @@ class EffectParameter : public QObject {
     const EffectManifestParameter& manifest() const;
     const QString id() const;
     const QString name() const;
+    const QString shortName() const;
     const QString description() const;
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/effects/effectparameterslotbase.cpp
+++ b/src/effects/effectparameterslotbase.cpp
@@ -30,6 +30,13 @@ QString EffectParameterSlotBase::name() const {
     return QString();
 }
 
+QString EffectParameterSlotBase::shortName() const {
+    if (m_pEffectParameter) {
+        return m_pEffectParameter->shortName();
+    }
+    return QString();
+}
+
 QString EffectParameterSlotBase::description() const {
     if (m_pEffectParameter) {
         return m_pEffectParameter->description();

--- a/src/effects/effectparameterslotbase.h
+++ b/src/effects/effectparameterslotbase.h
@@ -22,6 +22,7 @@ class EffectParameterSlotBase : public QObject {
     virtual ~EffectParameterSlotBase();
 
     QString name() const;
+    QString shortName() const;
     QString description() const;
     const EffectManifestParameter getManifest();
 

--- a/src/effects/native/autopaneffect.cpp
+++ b/src/effects/native/autopaneffect.cpp
@@ -69,6 +69,7 @@ EffectManifest AutoPanEffect::getManifest() {
     EffectManifestParameter* smoothing = manifest.addParameter();
     smoothing->setId("smoothing");
     smoothing->setName(QObject::tr("Smoothing"));
+    smoothing->setShortName(QObject::tr("Smooth"));
     smoothing->setDescription(
             QObject::tr("How fast the signal goes from a channel to an other"));
     smoothing->setControlHint(EffectManifestParameter::CONTROL_KNOB_LOGARITHMIC);

--- a/src/effects/native/bessel4lvmixeqeffect.cpp
+++ b/src/effects/native/bessel4lvmixeqeffect.cpp
@@ -11,6 +11,7 @@ EffectManifest Bessel4LVMixEQEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
     manifest.setName(QObject::tr("Bessel4 LV-Mix EQ"));
+    manifest.setShortName(QObject::tr("Bessel4 EQ"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr(

--- a/src/effects/native/bessel8lvmixeqeffect.cpp
+++ b/src/effects/native/bessel8lvmixeqeffect.cpp
@@ -11,6 +11,7 @@ EffectManifest Bessel8LVMixEQEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
     manifest.setName(QObject::tr("Bessel8 LV-Mix EQ"));
+    manifest.setShortName(QObject::tr("Bessel8 EQ"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr(

--- a/src/effects/native/bitcrushereffect.cpp
+++ b/src/effects/native/bitcrushereffect.cpp
@@ -38,6 +38,7 @@ EffectManifest BitCrusherEffect::getManifest() {
     EffectManifestParameter* frequency = manifest.addParameter();
     frequency->setId("downsample");
     frequency->setName(QObject::tr("Downsampling"));
+    frequency->setShortName(QObject::tr("Down"));
     frequency->setDescription(QObject::tr("Adjusts the sample rate, to which the signal is downsampled."));
     frequency->setControlHint(EffectManifestParameter::CONTROL_KNOB_LOGARITHMIC);
     frequency->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);

--- a/src/effects/native/filtereffect.cpp
+++ b/src/effects/native/filtereffect.cpp
@@ -37,7 +37,8 @@ EffectManifest FilterEffect::getManifest() {
 
     EffectManifestParameter* q = manifest.addParameter();
     q->setId("q");
-    q->setName(QObject::tr("Q"));
+    q->setName(QObject::tr("Resonance"));
+    q->setShortName(QObject::tr("Q"));
     q->setDescription(QObject::tr("Resonance of the filters, default = Flat top"));
     q->setControlHint(EffectManifestParameter::CONTROL_KNOB_LOGARITHMIC);
     q->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);

--- a/src/effects/native/linkwitzriley8eqeffect.cpp
+++ b/src/effects/native/linkwitzriley8eqeffect.cpp
@@ -15,6 +15,7 @@ EffectManifest LinkwitzRiley8EQEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
     manifest.setName(QObject::tr("LinkwitzRiley8 EQ"));
+    manifest.setShortName(QObject::tr("LR8 EQ"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr(

--- a/src/effects/native/moogladder4filtereffect.cpp
+++ b/src/effects/native/moogladder4filtereffect.cpp
@@ -16,6 +16,7 @@ EffectManifest MoogLadder4FilterEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
     manifest.setName(QObject::tr("Moog Ladder 4 Filter"));
+    manifest.setShortName(QObject::tr("Moog Filter"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr(
@@ -39,6 +40,7 @@ EffectManifest MoogLadder4FilterEffect::getManifest() {
     EffectManifestParameter* q = manifest.addParameter();
     q->setId("resonance");
     q->setName(QObject::tr("Resonance"));
+    q->setShortName(QObject::tr("Res"));
     q->setDescription(QObject::tr("Resonance of the filters. 4 = self oscillating"));
     q->setControlHint(EffectManifestParameter::CONTROL_KNOB_LOGARITHMIC);
     q->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);

--- a/src/effects/native/reverbeffect.cpp
+++ b/src/effects/native/reverbeffect.cpp
@@ -26,6 +26,7 @@ EffectManifest ReverbEffect::getManifest() {
     EffectManifestParameter* time = manifest.addParameter();
     time->setId("bandwidth");
     time->setName(QObject::tr("Bandwidth"));
+    time->setName(QObject::tr("Band"));
     time->setDescription(QObject::tr("Higher bandwidth values cause more "
             "bright (high-frequency) tones to be included"));
     time->setControlHint(EffectManifestParameter::CONTROL_KNOB_LINEAR);

--- a/src/effects/native/reverbeffect.cpp
+++ b/src/effects/native/reverbeffect.cpp
@@ -26,7 +26,7 @@ EffectManifest ReverbEffect::getManifest() {
     EffectManifestParameter* time = manifest.addParameter();
     time->setId("bandwidth");
     time->setName(QObject::tr("Bandwidth"));
-    time->setName(QObject::tr("Band"));
+    time->setShortName(QObject::tr("BW"));
     time->setDescription(QObject::tr("Higher bandwidth values cause more "
             "bright (high-frequency) tones to be included"));
     time->setControlHint(EffectManifestParameter::CONTROL_KNOB_LINEAR);

--- a/src/widget/weffect.cpp
+++ b/src/widget/weffect.cpp
@@ -46,7 +46,9 @@ void WEffect::effectUpdated() {
             const EffectManifest& manifest = pEffect->getManifest();
             if (!manifest.shortName().isEmpty()) {
                 name = manifest.shortName();
-                description = manifest.name() + tr(": ") + manifest.description();
+                // %1 = effect name
+                // %2 = effect description
+                description = tr("%1: %2").arg(manifest.name(), manifest.description());
             } else {
                 name = manifest.name();
                 description = manifest.description();

--- a/src/widget/weffect.cpp
+++ b/src/widget/weffect.cpp
@@ -44,7 +44,11 @@ void WEffect::effectUpdated() {
         EffectPointer pEffect = m_pEffectSlot->getEffect();
         if (pEffect) {
             const EffectManifest& manifest = pEffect->getManifest();
-            name = manifest.name();
+            if (! manifest.shortName().isEmpty()) {
+                name = manifest.shortName();
+            } else {
+                name = manifest.name();
+            }
             description = manifest.description();
         }
     } else {

--- a/src/widget/weffect.cpp
+++ b/src/widget/weffect.cpp
@@ -44,12 +44,13 @@ void WEffect::effectUpdated() {
         EffectPointer pEffect = m_pEffectSlot->getEffect();
         if (pEffect) {
             const EffectManifest& manifest = pEffect->getManifest();
-            if (! manifest.shortName().isEmpty()) {
+            if (!manifest.shortName().isEmpty()) {
                 name = manifest.shortName();
+                description = manifest.name() + ": " + manifest.description();
             } else {
                 name = manifest.name();
+                description = manifest.description();
             }
-            description = manifest.description();
         }
     } else {
         name = tr("None");

--- a/src/widget/weffect.cpp
+++ b/src/widget/weffect.cpp
@@ -46,7 +46,7 @@ void WEffect::effectUpdated() {
             const EffectManifest& manifest = pEffect->getManifest();
             if (!manifest.shortName().isEmpty()) {
                 name = manifest.shortName();
-                description = manifest.name() + ": " + manifest.description();
+                description = manifest.name() + tr(": ") + manifest.description();
             } else {
                 name = manifest.name();
                 description = manifest.description();

--- a/src/widget/weffect.cpp
+++ b/src/widget/weffect.cpp
@@ -46,8 +46,7 @@ void WEffect::effectUpdated() {
             const EffectManifest& manifest = pEffect->getManifest();
             if (!manifest.shortName().isEmpty()) {
                 name = manifest.shortName();
-                // %1 = effect name
-                // %2 = effect description
+                //: %1 = effect name; %2 = effect description
                 description = tr("%1: %2").arg(manifest.name(), manifest.description());
             } else {
                 name = manifest.name();

--- a/src/widget/weffectparameterbase.cpp
+++ b/src/widget/weffectparameterbase.cpp
@@ -23,9 +23,11 @@ void WEffectParameterBase::parameterUpdated() {
     if (m_pEffectParameterSlot) {
         if (!m_pEffectParameterSlot->shortName().isEmpty()) {
             setText(m_pEffectParameterSlot->shortName());
-            setBaseTooltip(m_pEffectParameterSlot->name()
-                           + tr(": ") +
-                           m_pEffectParameterSlot->description());
+            // %1: effect name
+            // %2: effect description
+            setBaseTooltip(tr("%1: %2").arg(
+                              m_pEffectParameterSlot->name(),
+                              m_pEffectParameterSlot->description()));
         } else {
             setText(m_pEffectParameterSlot->name());
             setBaseTooltip(m_pEffectParameterSlot->description());

--- a/src/widget/weffectparameterbase.cpp
+++ b/src/widget/weffectparameterbase.cpp
@@ -24,7 +24,7 @@ void WEffectParameterBase::parameterUpdated() {
         if (!m_pEffectParameterSlot->shortName().isEmpty()) {
             setText(m_pEffectParameterSlot->shortName());
             setBaseTooltip(m_pEffectParameterSlot->name()
-                           + QString(": ") +
+                           + tr(": ") +
                            m_pEffectParameterSlot->description());
         } else {
             setText(m_pEffectParameterSlot->name());

--- a/src/widget/weffectparameterbase.cpp
+++ b/src/widget/weffectparameterbase.cpp
@@ -21,7 +21,11 @@ void WEffectParameterBase::setEffectParameterSlot(
 
 void WEffectParameterBase::parameterUpdated() {
     if (m_pEffectParameterSlot) {
-        setText(m_pEffectParameterSlot->name());
+        if (! m_pEffectParameterSlot->shortName().isEmpty()) {
+            setText(m_pEffectParameterSlot->shortName());
+        } else {
+            setText(m_pEffectParameterSlot->name());
+        }
         setBaseTooltip(m_pEffectParameterSlot->description());
     } else {
         setText(tr("None"));

--- a/src/widget/weffectparameterbase.cpp
+++ b/src/widget/weffectparameterbase.cpp
@@ -21,12 +21,15 @@ void WEffectParameterBase::setEffectParameterSlot(
 
 void WEffectParameterBase::parameterUpdated() {
     if (m_pEffectParameterSlot) {
-        if (! m_pEffectParameterSlot->shortName().isEmpty()) {
+        if (!m_pEffectParameterSlot->shortName().isEmpty()) {
             setText(m_pEffectParameterSlot->shortName());
+            setBaseTooltip(m_pEffectParameterSlot->name()
+                           + QString(": ") +
+                           m_pEffectParameterSlot->description());
         } else {
             setText(m_pEffectParameterSlot->name());
+            setBaseTooltip(m_pEffectParameterSlot->description());
         }
-        setBaseTooltip(m_pEffectParameterSlot->description());
     } else {
         setText(tr("None"));
         setBaseTooltip(tr("No effect loaded."));

--- a/src/widget/weffectparameterbase.cpp
+++ b/src/widget/weffectparameterbase.cpp
@@ -23,8 +23,7 @@ void WEffectParameterBase::parameterUpdated() {
     if (m_pEffectParameterSlot) {
         if (!m_pEffectParameterSlot->shortName().isEmpty()) {
             setText(m_pEffectParameterSlot->shortName());
-            // %1: effect name
-            // %2: effect description
+            //: %1 = effect name; %2 = effect description
             setBaseTooltip(tr("%1: %2").arg(
                               m_pEffectParameterSlot->name(),
                               m_pEffectParameterSlot->description()));


### PR DESCRIPTION
Allow effects and effect parameter manifests to define short names to be displayed in skins.
fixing https://bugs.launchpad.net/mixxx/+bug/1395245