### PR TITLE
Treeitem(Model): Fixes & Optimizations

### DIFF
--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -56,13 +56,14 @@ AutoDJFeature::AutoDJFeature(Library* pLibrary,
 
 
     // Create the "Crates" tree-item under the root item.
-    TreeItem* root = m_childModel.getItem(QModelIndex());
-    m_pCratesTreeItem = new TreeItem(tr("Crates"), "", this, root);
+    TreeItem* root = new TreeItem(this);
+    m_pCratesTreeItem = root->appendChild(new TreeItem(this, tr("Crates")));
     m_pCratesTreeItem->setIcon(QIcon(":/images/library/ic_library_crates.png"));
-    root->appendChild(m_pCratesTreeItem);
 
     // Create tree-items under "Crates".
     constructCrateChildModel();
+
+    m_childModel.setRootItem(root);
 
     // Be notified when the status of crates changes.
     connect(&m_crateDao, SIGNAL(added(int)),
@@ -222,13 +223,9 @@ void AutoDJFeature::slotCrateAutoDjChanged(int crateId, bool added) {
         // Add our record of this crate-ID and name.
         m_crateList.append(qMakePair(crateId, strName));
 
-        // Create a tree-item for this crate.
-        TreeItem* item = new TreeItem(strName, strName, this,
-                                      m_pCratesTreeItem);
-
         // Prepare to add it to the "Crates" tree-item.
         QList<TreeItem*> lstItems;
-        lstItems.append(item);
+        lstItems.append(new TreeItem(this, strName));
 
         // Add it to the "Crates" tree-item.
         QModelIndex oCratesIndex = m_childModel.index(0, 0);
@@ -326,8 +323,7 @@ void AutoDJFeature::constructCrateChildModel() {
         m_crateList.append(qMakePair(id, name));
 
         // Create the TreeItem for this crate.
-        TreeItem* item = new TreeItem(name, name, this, m_pCratesTreeItem);
-        m_pCratesTreeItem->appendChild(item);
+        m_pCratesTreeItem->appendChild(new TreeItem(this, name));
     }
 }
 
@@ -337,7 +333,7 @@ void AutoDJFeature::onRightClickChild(const QPoint& globalPos,
     m_lastRightClickedIndex = index;
 
     TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
-    QString crateName = item->dataPath().toString();
+    QString crateName = item->getLabel();
     if (crateName.length() > 0) {
         // A crate was right-clicked.
         // Bring up the context menu.

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -56,14 +56,14 @@ AutoDJFeature::AutoDJFeature(Library* pLibrary,
 
 
     // Create the "Crates" tree-item under the root item.
-    TreeItem* root = new TreeItem(this);
-    m_pCratesTreeItem = root->appendChild(new TreeItem(this, tr("Crates")));
+    auto pRootItem = std::make_unique<TreeItem>(this);
+    m_pCratesTreeItem = pRootItem->appendChild(tr("Crates"));
     m_pCratesTreeItem->setIcon(QIcon(":/images/library/ic_library_crates.png"));
 
     // Create tree-items under "Crates".
     constructCrateChildModel();
 
-    m_childModel.setRootItem(root);
+    m_childModel.setRootItem(std::move(pRootItem));
 
     // Be notified when the status of crates changes.
     connect(&m_crateDao, SIGNAL(added(int)),
@@ -323,7 +323,7 @@ void AutoDJFeature::constructCrateChildModel() {
         m_crateList.append(qMakePair(id, name));
 
         // Create the TreeItem for this crate.
-        m_pCratesTreeItem->appendChild(new TreeItem(this, name));
+        m_pCratesTreeItem->appendChild(name);
     }
 }
 

--- a/src/library/banshee/bansheefeature.cpp
+++ b/src/library/banshee/bansheefeature.cpp
@@ -91,7 +91,7 @@ void BansheeFeature::activate() {
 
         m_isActivated =  true;
 
-        TreeItem* playlist_root = new TreeItem();
+        TreeItem* playlist_root = new TreeItem(this);
 
         QList<struct BansheeDbConnection::Playlist> list = m_connection.getPlaylists();
 
@@ -99,8 +99,8 @@ void BansheeFeature::activate() {
         foreach (playlist, list) {
             qDebug() << playlist.name;
             // append the playlist to the child model
-            TreeItem *item = new TreeItem(playlist.name, playlist.playlistId, this, playlist_root);
-            playlist_root->appendChild(item);
+            playlist_root->appendChild(
+                    new TreeItem(this, playlist.name, playlist.playlistId));
         }
 
         if (playlist_root) {
@@ -123,11 +123,9 @@ void BansheeFeature::activate() {
 
 void BansheeFeature::activateChild(const QModelIndex& index) {
     TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
-    //qDebug() << "BansheeFeature::activateChild " << item->data() << " " << item->dataPath();
-    QString playlist = item->dataPath().toString();
-    int playlistID = playlist.toInt();
+    int playlistID = item->getData().toInt();
     if (playlistID > 0) {
-        qDebug() << "Activating " << item->data().toString();
+        qDebug() << "Activating " << item->getLabel();
         m_pBansheePlaylistModel->setTableModel(playlistID);
         emit(showTrackModel(m_pBansheePlaylistModel));
         emit(enableCoverArtDisplay(false));
@@ -141,10 +139,9 @@ TreeItemModel* BansheeFeature::getChildModel() {
 void BansheeFeature::appendTrackIdsFromRightClickIndex(QList<TrackId>* trackIds, QString* pPlaylist) {
     if (m_lastRightClickedIndex.isValid()) {
         TreeItem *item = static_cast<TreeItem*>(m_lastRightClickedIndex.internalPointer());
-        *pPlaylist = item->data().toString();
-        QString playlistStId = item->dataPath().toString();
-        int playlistID = playlistStId.toInt();
-        qDebug() << "BansheeFeature::appendTrackIdsFromRightClickIndex " << *pPlaylist << " " << playlistStId;
+        *pPlaylist = item->getLabel();
+        int playlistID = item->getData().toInt();
+        qDebug() << "BansheeFeature::appendTrackIdsFromRightClickIndex " << *pPlaylist << " " << playlistID;
         if (playlistID > 0) {
             BansheePlaylistModel* pPlaylistModelToAdd = new BansheePlaylistModel(this, m_pTrackCollection, &m_connection);
             pPlaylistModelToAdd->setTableModel(playlistID);

--- a/src/library/banshee/bansheefeature.cpp
+++ b/src/library/banshee/bansheefeature.cpp
@@ -91,25 +91,19 @@ void BansheeFeature::activate() {
 
         m_isActivated =  true;
 
-        TreeItem* playlist_root = new TreeItem(this);
-
-        QList<struct BansheeDbConnection::Playlist> list = m_connection.getPlaylists();
-
-        struct BansheeDbConnection::Playlist playlist;
-        foreach (playlist, list) {
+        auto pRootItem = std::make_unique<TreeItem>(this);
+        QList<BansheeDbConnection::Playlist> playlists = m_connection.getPlaylists();
+        for (const BansheeDbConnection::Playlist& playlist: playlists) {
             qDebug() << playlist.name;
             // append the playlist to the child model
-            playlist_root->appendChild(
-                    new TreeItem(this, playlist.name, playlist.playlistId));
+            pRootItem->appendChild(playlist.name, playlist.playlistId);
         }
+        m_childModel.setRootItem(std::move(pRootItem));
 
-        if (playlist_root) {
-            m_childModel.setRootItem(playlist_root);
-            if (m_isActivated) {
-                activate();
-            }
-            qDebug() << "Banshee library loaded: success";
+        if (m_isActivated) {
+            activate();
         }
+        qDebug() << "Banshee library loaded: success";
 
         //calls a slot in the sidebarmodel such that 'isLoading' is removed from the feature title.
         m_title = tr("Banshee");

--- a/src/library/baseexternallibraryfeature.cpp
+++ b/src/library/baseexternallibraryfeature.cpp
@@ -101,8 +101,8 @@ void BaseExternalLibraryFeature::appendTrackIdsFromRightClickIndex(QList<TrackId
         return;
     }
 
-    // Qt::UserRole asks TreeItemModel for the TreeItem's dataPath. We need to
-    // use the dataPath because models with nested playlists need to use the
+    // Qt::UserRole asks TreeItemModel for the TreeItem's data. We need to
+    // use the data because models with nested playlists need to use the
     // full path/name of the playlist.
     *pPlaylist = m_lastRightClickedIndex.data(Qt::UserRole).toString();
     QScopedPointer<BaseSqlTableModel> pPlaylistModelToAdd(

--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -117,17 +117,17 @@ BasePlaylistFeature::~BasePlaylistFeature() {
 
 int BasePlaylistFeature::playlistIdFromIndex(QModelIndex index) {
     TreeItem* item = static_cast<TreeItem*>(index.internalPointer());
-    if (item == NULL) {
+    if (item == nullptr) {
         return -1;
     }
 
-    QString dataPath = item->dataPath().toString();
     bool ok = false;
-    int playlistId = dataPath.toInt(&ok);
-    if (!ok) {
+    int playlistId = item->getData().toInt(&ok);
+    if (ok) {
+        return playlistId;
+    } else {
         return -1;
     }
-    return playlistId;
 }
 
 void BasePlaylistFeature::activate() {
@@ -621,8 +621,6 @@ QModelIndex BasePlaylistFeature::constructChildModel(int selected_id) {
     buildPlaylistList();
     QList<TreeItem*> data_list;
     int selected_row = -1;
-    // Access the invisible root item
-    TreeItem* root = m_childModel.getItem(QModelIndex());
 
     int row = 0;
     for (QList<QPair<int, QString> >::const_iterator it = m_playlistList.begin();
@@ -637,7 +635,7 @@ QModelIndex BasePlaylistFeature::constructChildModel(int selected_id) {
         }
 
         // Create the TreeItem whose parent is the invisible root item
-        TreeItem* item = new TreeItem(playlist_name, QString::number(playlist_id), this, root);
+        TreeItem* item = new TreeItem(this, playlist_name, playlist_id);
         item->setBold(m_playlistsSelectedTrackIsIn.contains(playlist_id));
 
         decorateChild(item, playlist_id);
@@ -663,7 +661,8 @@ void BasePlaylistFeature::updateChildModel(int selected_id) {
 
         if (selected_id == playlist_id) {
             TreeItem* item = m_childModel.getItem(indexFromPlaylistId(playlist_id));
-            item->setData(playlist_name, QString::number(playlist_id));
+            item->setLabel(playlist_name);
+            item->setData(playlist_id);
             decorateChild(item, playlist_id);
         }
 

--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -700,7 +700,7 @@ void BasePlaylistFeature::slotTrackSelected(TrackPointer pTrack) {
     }
     m_playlistDao.getPlaylistsTrackIsIn(trackId, &m_playlistsSelectedTrackIsIn);
 
-    TreeItem* rootItem = m_childModel.getItem(QModelIndex());
+    TreeItem* rootItem = m_childModel.getRootItem();
     if (rootItem == nullptr) {
         return;
     }

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -54,16 +54,15 @@ BrowseFeature::BrowseFeature(QObject* parent,
     m_proxyModel.setDynamicSortFilter(true);
 
     // The invisible root item of the child model
-    TreeItem* rootItem = new TreeItem();
+    TreeItem* rootItem = new TreeItem(this);
 
-    m_pQuickLinkItem = new TreeItem(tr("Quick Links"), QUICK_LINK_NODE, this, rootItem);
-    rootItem->appendChild(m_pQuickLinkItem);
+    m_pQuickLinkItem = rootItem->appendChild(
+            new TreeItem(this, tr("Quick Links"), QUICK_LINK_NODE));
 
     // Create the 'devices' shortcut
 #if defined(__WINDOWS__)
-    TreeItem* devices_link = new TreeItem(
-        tr("Devices"), DEVICE_NODE, this, rootItem);
-    rootItem->appendChild(devices_link);
+    TreeItem* devices_link = rootItem->appendChild(
+            new TreeItem(this, tr("Devices"), DEVICE_NODE));
     // show drive letters
     QFileInfoList drives = QDir::drives();
     // show drive letters
@@ -81,28 +80,25 @@ BrowseFeature::BrowseFeature(QObject* parent,
         if (display_path.endsWith("/")) {
             display_path.chop(1);
         }
-        TreeItem* driveLetter = new TreeItem(
-            display_path,  // Displays C:
-            drive.filePath(),  // Displays C:/
-            this ,
-            devices_link);
-        devices_link->appendChild(driveLetter);
+        TreeItem* driveLetter =
+        devices_link->appendChild(
+                new TreeItem(
+                        this ,
+                        display_path, // Displays C:
+                        drive.filePath())); // Displays C:/
     }
 #elif defined(__APPLE__)
     // Apple hides the base Linux file structure But all devices are mounted at
     // /Volumes
-    TreeItem* devices_link = new TreeItem(
-        tr("Devices"), "/Volumes/", this, rootItem);
-    rootItem->appendChild(devices_link);
+    TreeItem* devices_link = rootItem->appendChild(
+        new TreeItem(this, tr("Devices"), "/Volumes/"));
 #else  // LINUX
-    TreeItem* devices_link = new TreeItem(
-        tr("Removable Devices"), "/media/", this, rootItem);
-    rootItem->appendChild(devices_link);
+    TreeItem* devices_link = rootItem->appendChild(
+        new TreeItem(this, tr("Removable Devices"), "/media/"));
 
     // show root directory on UNIX-based operating systems
-    TreeItem* root_folder_item = new TreeItem(
-        QDir::rootPath(), QDir::rootPath(), this, rootItem);
-    rootItem->appendChild(root_folder_item);
+    TreeItem* root_folder_item = rootItem->appendChild(
+        new TreeItem(this, QDir::rootPath(), QDir::rootPath()));
 #endif
 
     // Just a word about how the TreeItem objects are used for the BrowseFeature:
@@ -122,8 +118,8 @@ BrowseFeature::BrowseFeature(QObject* parent,
     foreach (QString quickLinkPath, m_quickLinkList) {
         QString name = extractNameFromPath(quickLinkPath);
         qDebug() << "Appending Quick Link: " << name << "---" << quickLinkPath;
-        TreeItem *item = new TreeItem(name, quickLinkPath, this, m_pQuickLinkItem);
-        m_pQuickLinkItem->appendChild(item);
+        m_pQuickLinkItem->appendChild(
+            new TreeItem(this, name, quickLinkPath));
     }
 
     // initialize the model
@@ -142,10 +138,10 @@ void BrowseFeature::slotAddQuickLink() {
         return;
     }
 
-    QString spath = m_pLastRightClickedItem->dataPath().toString();
+    QVariant vpath = m_pLastRightClickedItem->getData();
+    QString spath = vpath.toString();
     QString name = extractNameFromPath(spath);
-    TreeItem *item = new TreeItem(name, spath, this, m_pQuickLinkItem);
-    m_pQuickLinkItem->appendChild(item);
+    m_pQuickLinkItem->appendChild(new TreeItem(this, name, vpath));
     m_quickLinkList.append(spath);
     saveQuickLinks();
 }
@@ -154,7 +150,7 @@ void BrowseFeature::slotAddToLibrary() {
     if (!m_pLastRightClickedItem) {
         return;
     }
-    QString spath = m_pLastRightClickedItem->dataPath().toString();
+    QString spath = m_pLastRightClickedItem->getData().toString();
     emit(requestAddDir(spath));
 
     QMessageBox msgBox;
@@ -188,7 +184,7 @@ void BrowseFeature::slotRemoveQuickLink() {
         return;
     }
 
-    QString spath = m_pLastRightClickedItem->dataPath().toString();
+    QString spath = m_pLastRightClickedItem->getData().toString();
     int index = m_quickLinkList.indexOf(spath);
 
     if (index == -1) {
@@ -225,10 +221,10 @@ void BrowseFeature::activate() {
 // Single clicks will not populate sub folders
 void BrowseFeature::activateChild(const QModelIndex& index) {
     TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
-    qDebug() << "BrowseFeature::activateChild " << item->data() << " "
-             << item->dataPath();
+    qDebug() << "BrowseFeature::activateChild " << item->getLabel() << " "
+             << item->getData();
 
-    QString path = item->dataPath().toString();
+    QString path = item->getData().toString();
     if (path == QUICK_LINK_NODE || path == DEVICE_NODE) {
         m_browseModel.setPath(MDir());
     } else {
@@ -258,14 +254,14 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, QModelIndex index
         return;
     }
 
-    QString path = item->dataPath().toString();
+    QString path = item->getData().toString();
 
     if (path == QUICK_LINK_NODE || path == DEVICE_NODE) {
         return;
     }
 
     QMenu menu(NULL);
-    if (item->parent()->dataPath().toString() == QUICK_LINK_NODE) {
+    if (item->parent()->getData().toString() == QUICK_LINK_NODE) {
         menu.addAction(m_pRemoveQuickLinkAction);
         menu.exec(globalPos);
         onLazyChildExpandation(index);
@@ -292,10 +288,10 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
         return;
     }
 
-    qDebug() << "BrowseFeature::onLazyChildExpandation " << item->data()
-             << " " << item->dataPath();
+    qDebug() << "BrowseFeature::onLazyChildExpandation " << item->getLabel()
+             << " " << item->getData();
 
-    QString path = item->dataPath().toString();
+    QString path = item->getData().toString();
 
     // If the item is a build-in node, e.g., 'QuickLink' return
     if (path == QUICK_LINK_NODE) {
@@ -303,7 +299,7 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
     }
 
     // Before we populate the subtree, we need to delete old subtrees
-    m_childModel.removeRows(0, item->childCount(), index);
+    m_childModel.removeRows(0, item->childRows(), index);
 
     // List of subfolders or drive letters
     QList<TreeItem*> folders;
@@ -327,10 +323,9 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
                 display_path.chop(1);
             }
             TreeItem* driveLetter = new TreeItem(
-                display_path, // Displays C:
-                drive.filePath(), // Displays C:/
                 this,
-                item);
+                display_path, // Displays C:
+                drive.filePath()); // Displays C:/
             folders << driveLetter;
         }
     } else {
@@ -352,9 +347,9 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
             // Once the items are added to the TreeItemModel,
             // the models takes ownership of them and ensures their deletion
             TreeItem* folder = new TreeItem(
+                this,
                 one.fileName(),
-                one.absoluteFilePath() + "/",
-                this, item);
+                one.absoluteFilePath() + "/");
             folders << folder;
         }
     }

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -54,15 +54,13 @@ BrowseFeature::BrowseFeature(QObject* parent,
     m_proxyModel.setDynamicSortFilter(true);
 
     // The invisible root item of the child model
-    TreeItem* rootItem = new TreeItem(this);
+    auto pRootItem = std::make_unique<TreeItem>(this);
 
-    m_pQuickLinkItem = rootItem->appendChild(
-            new TreeItem(this, tr("Quick Links"), QUICK_LINK_NODE));
+    m_pQuickLinkItem = pRootItem->appendChild(tr("Quick Links"), QUICK_LINK_NODE);
 
     // Create the 'devices' shortcut
 #if defined(__WINDOWS__)
-    TreeItem* devices_link = rootItem->appendChild(
-            new TreeItem(this, tr("Devices"), DEVICE_NODE));
+    TreeItem* devices_link = pRootItem->appendChild(tr("Devices"), DEVICE_NODE);
     // show drive letters
     QFileInfoList drives = QDir::drives();
     // show drive letters
@@ -82,23 +80,18 @@ BrowseFeature::BrowseFeature(QObject* parent,
         }
         TreeItem* driveLetter =
         devices_link->appendChild(
-                new TreeItem(
-                        this ,
-                        display_path, // Displays C:
-                        drive.filePath())); // Displays C:/
+                display_path, // Displays C:
+                drive.filePath()); // Displays C:/
     }
 #elif defined(__APPLE__)
     // Apple hides the base Linux file structure But all devices are mounted at
     // /Volumes
-    TreeItem* devices_link = rootItem->appendChild(
-        new TreeItem(this, tr("Devices"), "/Volumes/"));
+    pRootItem->appendChild(tr("Devices"), "/Volumes/");
 #else  // LINUX
-    TreeItem* devices_link = rootItem->appendChild(
-        new TreeItem(this, tr("Removable Devices"), "/media/"));
+    pRootItem->appendChild(tr("Removable Devices"), "/media/");
 
     // show root directory on UNIX-based operating systems
-    TreeItem* root_folder_item = rootItem->appendChild(
-        new TreeItem(this, QDir::rootPath(), QDir::rootPath()));
+    pRootItem->appendChild(QDir::rootPath(), QDir::rootPath());
 #endif
 
     // Just a word about how the TreeItem objects are used for the BrowseFeature:
@@ -118,12 +111,11 @@ BrowseFeature::BrowseFeature(QObject* parent,
     foreach (QString quickLinkPath, m_quickLinkList) {
         QString name = extractNameFromPath(quickLinkPath);
         qDebug() << "Appending Quick Link: " << name << "---" << quickLinkPath;
-        m_pQuickLinkItem->appendChild(
-            new TreeItem(this, name, quickLinkPath));
+        m_pQuickLinkItem->appendChild(name, quickLinkPath);
     }
 
     // initialize the model
-    m_childModel.setRootItem(rootItem);
+    m_childModel.setRootItem(std::move(pRootItem));
 }
 
 BrowseFeature::~BrowseFeature() {
@@ -141,7 +133,7 @@ void BrowseFeature::slotAddQuickLink() {
     QVariant vpath = m_pLastRightClickedItem->getData();
     QString spath = vpath.toString();
     QString name = extractNameFromPath(spath);
-    m_pQuickLinkItem->appendChild(new TreeItem(this, name, vpath));
+    m_pQuickLinkItem->appendChild(name, vpath);
     m_quickLinkList.append(spath);
     saveQuickLinks();
 }

--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -38,14 +38,14 @@ bool FolderTreeModel::hasChildren(const QModelIndex& parent) const {
      * However, for, buid-in items such as 'Quick Links' there exist
      * child items at init time
      */
-    if(item->dataPath().toString() == QUICK_LINK_NODE)
+    if(item->getData().toString() == QUICK_LINK_NODE)
         return true;
     //Can only happen on Windows
-    if(item->dataPath().toString() == DEVICE_NODE)
+    if(item->getData().toString() == DEVICE_NODE)
         return true;
 
-    // In all other cases the dataPath() points to a folder
-    QString folder = item->dataPath().toString();
+    // In all other cases the getData() points to a folder
+    QString folder = item->getData().toString();
     return directoryHasChildren(folder);
 }
 
@@ -63,7 +63,7 @@ bool FolderTreeModel::directoryHasChildren(const QString& path) const {
      *  QDIR::EntryInfoList returns a full QFileInfolist
      *
      *
-     *  QDir dir(item->dataPath().toString());
+     *  QDir dir(item->getData().toString());
      *  QFileInfoList all = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
      *  return (all.count() > 0);
      *

--- a/src/library/cratefeature.cpp
+++ b/src/library/cratefeature.cpp
@@ -94,7 +94,7 @@ CrateFeature::CrateFeature(Library* pLibrary,
             this, SLOT(slotCrateTableChanged(int)));
 
     // construct child model
-    TreeItem *rootItem = new TreeItem();
+    TreeItem *rootItem = new TreeItem(this);
     m_childModel.setRootItem(rootItem);
     constructChildModel(-1);
 
@@ -131,9 +131,8 @@ int CrateFeature::crateIdFromIndex(QModelIndex index) {
         return -1;
     }
 
-    QString dataPath = item->dataPath().toString();
     bool ok = false;
-    int playlistId = dataPath.toInt(&ok);
+    int playlistId = item->getData().toInt(&ok);
     if (!ok) {
         return -1;
     }
@@ -512,8 +511,6 @@ QModelIndex CrateFeature::constructChildModel(int selected_id) {
     buildCrateList();
     QList<TreeItem*> data_list;
     int selected_row = -1;
-    // Access the invisible root item
-    TreeItem* root = m_childModel.getItem(QModelIndex());
 
     int row = 0;
     for (QList<QPair<int, QString> >::const_iterator it = m_crateList.begin();
@@ -528,8 +525,8 @@ QModelIndex CrateFeature::constructChildModel(int selected_id) {
         }
 
         // Create the TreeItem whose parent is the invisible root item
-        TreeItem* item = new TreeItem(crate_name, QString::number(crate_id), this, root);
         bool locked = m_crateDao.isCrateLocked(crate_id);
+        TreeItem* item = new TreeItem(this, crate_name, crate_id);
         item->setIcon(locked ? QIcon(":/images/library/ic_library_locked.png") : QIcon());
         item->setBold(m_cratesSelectedTrackIsIn.contains(crate_id));
         data_list.append(item);
@@ -554,7 +551,8 @@ void CrateFeature::updateChildModel(int selected_id) {
 
         if (selected_id == crate_id) {
             TreeItem* item = m_childModel.getItem(indexFromCrateId(crate_id));
-            item->setData(crate_name, QString::number(crate_id));
+            item->setLabel(crate_name);
+            item->setData(crate_id);
             bool locked = m_crateDao.isCrateLocked(crate_id);
             item->setIcon(locked ? QIcon(":/images/library/ic_library_locked.png") : QIcon());
 

--- a/src/library/cratefeature.cpp
+++ b/src/library/cratefeature.cpp
@@ -94,8 +94,8 @@ CrateFeature::CrateFeature(Library* pLibrary,
             this, SLOT(slotCrateTableChanged(int)));
 
     // construct child model
-    TreeItem *rootItem = new TreeItem(this);
-    m_childModel.setRootItem(rootItem);
+    auto pRootItem = std::make_unique<TreeItem>(this);
+    m_childModel.setRootItem(std::move(pRootItem));
     constructChildModel(-1);
 
     connect(pLibrary, SIGNAL(trackSelected(TrackPointer)),
@@ -823,7 +823,7 @@ void CrateFeature::slotTrackSelected(TrackPointer pTrack) {
     TrackId trackId(pTrack ? pTrack->getId() : TrackId());
     m_crateDao.getCratesTrackIsIn(trackId, &m_cratesSelectedTrackIsIn);
 
-    TreeItem* rootItem = m_childModel.getItem(QModelIndex());
+    TreeItem* rootItem = m_childModel.getRootItem();
     if (rootItem == nullptr) {
         return;
     }

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -587,7 +587,7 @@ void ITunesFeature::parseTrack(QXmlStreamReader &xml, QSqlQuery &query) {
 
 TreeItem* ITunesFeature::parsePlaylists(QXmlStreamReader &xml) {
     qDebug() << "Parse iTunes playlists";
-    TreeItem* rootItem = new TreeItem();
+    TreeItem* rootItem = new TreeItem(this);
     QSqlQuery query_insert_to_playlists(m_database);
     query_insert_to_playlists.prepare("INSERT INTO itunes_playlists (id, name) "
                                       "VALUES (:id, :name)");
@@ -684,9 +684,7 @@ void ITunesFeature::parsePlaylist(QXmlStreamReader &xml, QSqlQuery &query_insert
                         return;
                     }
                     //append the playlist to the child model
-                    TreeItem *item = new TreeItem(playlistname, playlistname, this, root);
-                    root->appendChild(item);
-
+                    root->appendChild(new TreeItem(this, playlistname));
                 }
                 // When processing playlist entries, playlist name and id have
                 // already been processed and persisted

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -684,7 +684,7 @@ void ITunesFeature::parsePlaylist(QXmlStreamReader &xml, QSqlQuery &query_insert
                         return;
                     }
                     //append the playlist to the child model
-                    root->appendChild(new TreeItem(this, playlistname));
+                    root->appendChild(playlistname);
                 }
                 // When processing playlist entries, playlist name and id have
                 // already been processed and persisted
@@ -732,9 +732,9 @@ void ITunesFeature::clearTable(QString table_name) {
 }
 
 void ITunesFeature::onTrackCollectionLoaded() {
-    TreeItem* root = m_future.result();
+    std::unique_ptr<TreeItem> root(m_future.result());
     if (root) {
-        m_childModel.setRootItem(root);
+        m_childModel.setRootItem(std::move(root));
 
         // Tell the rhythmbox track source that it should re-build its index.
         m_trackSource->buildIndex();

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -108,13 +108,9 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
     // These rely on the 'default' track source being present.
     m_pLibraryTableModel = new LibraryTableModel(this, pTrackCollection, "mixxx.db.model.library");
 
-    TreeItem* pRootItem = new TreeItem();
-    TreeItem* pmissingChildItem = new TreeItem(kMissingTitle, kMissingTitle,
-                                               this, pRootItem);
-    TreeItem* phiddenChildItem = new TreeItem(kHiddenTitle, kHiddenTitle,
-                                              this, pRootItem);
-    pRootItem->appendChild(pmissingChildItem);
-    pRootItem->appendChild(phiddenChildItem);
+    TreeItem* pRootItem = new TreeItem(this);
+    pRootItem->appendChild(new TreeItem(this, kMissingTitle));
+    pRootItem->appendChild(new TreeItem(this, kHiddenTitle));
 
     m_childModel.setRootItem(pRootItem);
 }

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -108,11 +108,11 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
     // These rely on the 'default' track source being present.
     m_pLibraryTableModel = new LibraryTableModel(this, pTrackCollection, "mixxx.db.model.library");
 
-    TreeItem* pRootItem = new TreeItem(this);
-    pRootItem->appendChild(new TreeItem(this, kMissingTitle));
-    pRootItem->appendChild(new TreeItem(this, kHiddenTitle));
+    auto pRootItem = std::make_unique<TreeItem>(this);
+    pRootItem->appendChild(kMissingTitle);
+    pRootItem->appendChild(kHiddenTitle);
 
-    m_childModel.setRootItem(pRootItem);
+    m_childModel.setRootItem(std::move(pRootItem));
 }
 
 MixxxLibraryFeature::~MixxxLibraryFeature() {

--- a/src/library/playlistfeature.cpp
+++ b/src/library/playlistfeature.cpp
@@ -27,7 +27,7 @@ PlaylistFeature::PlaylistFeature(QObject* parent,
                                                    "mixxx.db.model.playlist");
 
     //construct child model
-    TreeItem *rootItem = new TreeItem();
+    TreeItem *rootItem = new TreeItem(this);
     m_childModel.setRootItem(rootItem);
     constructChildModel(-1);
 }

--- a/src/library/playlistfeature.cpp
+++ b/src/library/playlistfeature.cpp
@@ -27,8 +27,8 @@ PlaylistFeature::PlaylistFeature(QObject* parent,
                                                    "mixxx.db.model.playlist");
 
     //construct child model
-    TreeItem *rootItem = new TreeItem(this);
-    m_childModel.setRootItem(rootItem);
+    auto pRootItem = std::make_unique<TreeItem>(this);
+    m_childModel.setRootItem(std::move(pRootItem));
     constructChildModel(-1);
 }
 

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -220,7 +220,7 @@ TreeItem* RhythmboxFeature::importPlaylists() {
             "INSERT INTO rhythmbox_playlist_tracks (playlist_id, track_id, position) "
             "VALUES (:playlist_id, :track_id, :position)");
     //The tree structure holding the playlists
-    TreeItem* rootItem = new TreeItem();
+    TreeItem* rootItem = new TreeItem(this);
 
     QXmlStreamReader xml(&db);
     while (!xml.atEnd() && !m_cancelImport) {
@@ -233,8 +233,7 @@ TreeItem* RhythmboxFeature::importPlaylists() {
                 QString playlist_name = attr.value("name").toString();
 
                 //Construct the childmodel
-                TreeItem * item = new TreeItem(playlist_name, playlist_name, this, rootItem);
-                rootItem->appendChild(item);
+                rootItem->appendChild(new TreeItem(this, playlist_name));
 
                 //Execute SQL statement
                 query_insert_to_playlists.bindValue(":name", playlist_name);

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -233,7 +233,7 @@ TreeItem* RhythmboxFeature::importPlaylists() {
                 QString playlist_name = attr.value("name").toString();
 
                 //Construct the childmodel
-                rootItem->appendChild(new TreeItem(this, playlist_name));
+                rootItem->appendChild(playlist_name);
 
                 //Execute SQL statement
                 query_insert_to_playlists.bindValue(":name", playlist_name);
@@ -434,9 +434,9 @@ void RhythmboxFeature::clearTable(QString table_name) {
 }
 
 void RhythmboxFeature::onTrackCollectionLoaded() {
-    TreeItem* root = m_track_future.result();
+    std::unique_ptr<TreeItem> root(m_track_future.result());
     if (root) {
-        m_childModel.setRootItem(root);
+        m_childModel.setRootItem(std::move(root));
 
         // Tell the rhythmbox track source that it should re-build its index.
         m_trackSource->buildIndex();

--- a/src/library/setlogfeature.cpp
+++ b/src/library/setlogfeature.cpp
@@ -19,6 +19,12 @@ SetlogFeature::SetlogFeature(QObject* parent,
     m_pPlaylistTableModel = new PlaylistTableModel(this, pTrackCollection,
                                                    "mixxx.db.model.setlog",
                                                    true); //show all tracks
+
+    //construct child model
+    TreeItem *rootItem = new TreeItem(this);
+    m_childModel.setRootItem(rootItem);
+    constructChildModel(-1);
+
     m_pJoinWithPreviousAction = new QAction(tr("Join with previous"), this);
     connect(m_pJoinWithPreviousAction, SIGNAL(triggered()),
             this, SLOT(slotJoinWithPrevious()));
@@ -28,11 +34,6 @@ SetlogFeature::SetlogFeature(QObject* parent,
 
     // initialized in a new generic slot(get new history playlist purpose)
     emit(slotGetNewPlaylist());
-
-    //construct child model
-    TreeItem *rootItem = new TreeItem();
-    m_childModel.setRootItem(rootItem);
-    constructChildModel(-1);
 }
 
 SetlogFeature::~SetlogFeature() {

--- a/src/library/setlogfeature.cpp
+++ b/src/library/setlogfeature.cpp
@@ -21,8 +21,8 @@ SetlogFeature::SetlogFeature(QObject* parent,
                                                    true); //show all tracks
 
     //construct child model
-    TreeItem *rootItem = new TreeItem(this);
-    m_childModel.setRootItem(rootItem);
+    auto pRootItem = std::make_unique<TreeItem>(this);
+    m_childModel.setRootItem(std::move(pRootItem));
     constructChildModel(-1);
 
     m_pJoinWithPreviousAction = new QAction(tr("Join with previous"), this);

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -66,7 +66,7 @@ void SidebarModel::activateDefaultSelection() {
 QModelIndex SidebarModel::index(int row, int column,
                                 const QModelIndex& parent) const {
     // qDebug() << "SidebarModel::index row=" << row
-      //       << "column=" << column << "parent=" << parent.data();
+      //       << "column=" << column << "parent=" << parent.getData();
     if (parent.isValid()) {
         /* If we have selected the root of a library feature at position 'row'
          * its internal pointer is the current sidebar object model
@@ -92,7 +92,7 @@ QModelIndex SidebarModel::index(int row, int column,
 }
 
 QModelIndex SidebarModel::parent(const QModelIndex& index) const {
-    //qDebug() << "SidebarModel::parent index=" << index.data();
+    //qDebug() << "SidebarModel::parent index=" << index.getData();
     if (index.isValid()) {
         // If we have selected the root of a library feature
         // its internal pointer is the current sidebar object model
@@ -108,8 +108,8 @@ QModelIndex SidebarModel::parent(const QModelIndex& index) const {
             // if we have selected an item at the first level of a childnode
 
             if (tree_item_parent) {
-                if (tree_item_parent->data() == "$root") {
-                    LibraryFeature* feature = tree_item->getFeature();
+                if (tree_item_parent->isRoot()) {
+                    LibraryFeature* feature = tree_item->feature();
                     for (int i = 0; i < m_sFeatures.size(); ++i) {
                         if (feature == m_sFeatures[i]) {
                             // create a ModelIndex for parent 'this' having a
@@ -119,7 +119,7 @@ QModelIndex SidebarModel::parent(const QModelIndex& index) const {
                     }
                 }
                 // if we have selected an item at some deeper level of a childnode
-                return createIndex(tree_item_parent->row(), 0 , tree_item_parent);
+                return createIndex(tree_item_parent->parentRow(), 0 , tree_item_parent);
             }
         }
     }
@@ -127,7 +127,7 @@ QModelIndex SidebarModel::parent(const QModelIndex& index) const {
 }
 
 int SidebarModel::rowCount(const QModelIndex& parent) const {
-    //qDebug() << "SidebarModel::rowCount parent=" << parent.data();
+    //qDebug() << "SidebarModel::rowCount parent=" << parent.getData();
     if (parent.isValid()) {
         if (parent.internalPointer() == this) {
             return m_sFeatures[parent.row()]->getChildModel()->rowCount();
@@ -135,7 +135,7 @@ int SidebarModel::rowCount(const QModelIndex& parent) const {
             // We support tree models deeper than 1 level
             TreeItem* tree_item = (TreeItem*)parent.internalPointer();
             if (tree_item) {
-                return tree_item->childCount();
+                return tree_item->childRows();
             }
             return 0;
         }
@@ -159,7 +159,7 @@ bool SidebarModel::hasChildren(const QModelIndex& parent) const {
         {
             TreeItem* tree_item = (TreeItem*)parent.internalPointer();
             if (tree_item) {
-                LibraryFeature* feature = tree_item->getFeature();
+                LibraryFeature* feature = tree_item->feature();
                 return feature->getChildModel()->hasChildren(parent);
             }
         }
@@ -189,17 +189,17 @@ QVariant SidebarModel::data(const QModelIndex& index, int role) const {
         TreeItem* tree_item = (TreeItem*)index.internalPointer();
         if (tree_item) {
             if (role == Qt::DisplayRole) {
-                return tree_item->data();
+                return tree_item->getLabel();
             } else if (role == Qt::ToolTipRole) {
                 // If it's the "Quick Links" node, display it's name
-                if (tree_item->dataPath() == QUICK_LINK_NODE) {
-                    return tree_item->data();
+                if (tree_item->getData().toString() == QUICK_LINK_NODE) {
+                    return tree_item->getLabel();
                 } else {
-                    return tree_item->dataPath();
+                    return tree_item->getData();
                 }
-            } else if (role == TreeItemModel::kDataPathRole) {
+            } else if (role == TreeItemModel::kDataRole) {
                 // We use Qt::UserRole to ask for the datapath.
-                return tree_item->dataPath();
+                return tree_item->getData();
             } else if (role == Qt::FontRole) {
                 QFont font;
                 font.setBold(tree_item->isBold());
@@ -228,7 +228,7 @@ void SidebarModel::clicked(const QModelIndex& index) {
         } else {
             TreeItem* tree_item = (TreeItem*)index.internalPointer();
             if (tree_item) {
-                LibraryFeature* feature = tree_item->getFeature();
+                LibraryFeature* feature = tree_item->feature();
                 feature->activateChild(index);
             }
         }
@@ -241,7 +241,7 @@ void SidebarModel::doubleClicked(const QModelIndex& index) {
         } else {
             TreeItem* tree_item = (TreeItem*)index.internalPointer();
             if (tree_item) {
-                LibraryFeature* feature = tree_item->getFeature();
+                LibraryFeature* feature = tree_item->feature();
                 feature->onLazyChildExpandation(index);
             }
         }
@@ -259,7 +259,7 @@ void SidebarModel::rightClicked(const QPoint& globalPos, const QModelIndex& inde
         {
             TreeItem* tree_item = (TreeItem*)index.internalPointer();
             if (tree_item) {
-                LibraryFeature* feature = tree_item->getFeature();
+                LibraryFeature* feature = tree_item->feature();
                 feature->activateChild(index);
                 feature->onRightClickChild(globalPos, index);
             }
@@ -277,7 +277,7 @@ bool SidebarModel::dropAccept(const QModelIndex& index, QList<QUrl> urls,
         } else {
             TreeItem* tree_item = (TreeItem*)index.internalPointer();
             if (tree_item) {
-                LibraryFeature* feature = tree_item->getFeature();
+                LibraryFeature* feature = tree_item->feature();
                 result = feature->dropAcceptChild(index, urls, pSource);
             }
         }
@@ -295,7 +295,7 @@ bool SidebarModel::dragMoveAccept(const QModelIndex& index, QUrl url) {
         } else {
             TreeItem* tree_item = (TreeItem*)index.internalPointer();
             if (tree_item) {
-                LibraryFeature* feature = tree_item->getFeature();
+                LibraryFeature* feature = tree_item->feature();
                 result = feature->dragMoveAcceptChild(index, url);
             }
         }

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -168,9 +168,9 @@ void TraktorFeature::activateChild(const QModelIndex& index) {
     //access underlying TreeItem object
     TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
 
-    if (item->isPlaylist()) {
-        qDebug() << "Activate Traktor Playlist: " << item->dataPath().toString();
-        m_pTraktorPlaylistModel->setPlaylist(item->dataPath().toString());
+    if (!item->hasChildren()) {
+        qDebug() << "Activate Traktor Playlist: " << item->getData().toString();
+        m_pTraktorPlaylistModel->setPlaylist(item->getData().toString());
         emit(showTrackModel(m_pTraktorPlaylistModel));
         emit(enableCoverArtDisplay(false));
     }
@@ -382,7 +382,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
 
     QString delimiter = "-->";
 
-    TreeItem *rootItem = new TreeItem();
+    TreeItem *rootItem = new TreeItem(this);
     TreeItem * parent = rootItem;
 
     QSqlQuery query_insert_to_playlists(m_database);
@@ -408,19 +408,16 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
                if (type == "FOLDER") {
                     current_path += delimiter;
                     current_path += name;
-                    //qDebug() << "Folder: " +current_path << " has parent " << parent->data().toString();
+                    //qDebug() << "Folder: " +current_path << " has parent " << parent->getData().toString();
                     map.insert(current_path, "FOLDER");
-                    TreeItem * item = new TreeItem(name,current_path, this, parent);
-                    parent->appendChild(item);
-                    parent = item;
+                    parent = parent->appendChild(new TreeItem(this, name, current_path));
                } else if (type == "PLAYLIST") {
                     current_path += delimiter;
                     current_path += name;
-                    //qDebug() << "Playlist: " +current_path << " has parent " << parent->data().toString();
+                    //qDebug() << "Playlist: " +current_path << " has parent " << parent->getData().toString();
                     map.insert(current_path, "PLAYLIST");
 
-                    TreeItem * item = new TreeItem(name,current_path, this, parent);
-                    parent->appendChild(item);
+                    parent->appendChild(new TreeItem(this, name, current_path));
                     // process all the entries within the playlist 'name' having path 'current_path'
                     parsePlaylistEntries(xml, current_path,
                                          query_insert_to_playlists,

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -410,14 +410,14 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
                     current_path += name;
                     //qDebug() << "Folder: " +current_path << " has parent " << parent->getData().toString();
                     map.insert(current_path, "FOLDER");
-                    parent = parent->appendChild(new TreeItem(this, name, current_path));
+                    parent = parent->appendChild(name, current_path);
                } else if (type == "PLAYLIST") {
                     current_path += delimiter;
                     current_path += name;
                     //qDebug() << "Playlist: " +current_path << " has parent " << parent->getData().toString();
                     map.insert(current_path, "PLAYLIST");
 
-                    parent->appendChild(new TreeItem(this, name, current_path));
+                    parent->appendChild(name, current_path);
                     // process all the entries within the playlist 'name' having path 'current_path'
                     parsePlaylistEntries(xml, current_path,
                                          query_insert_to_playlists,
@@ -598,9 +598,9 @@ QString TraktorFeature::getTraktorMusicDatabase() {
 }
 
 void TraktorFeature::onTrackCollectionLoaded() {
-    TreeItem* root = m_future.result();
+    std::unique_ptr<TreeItem> root(m_future.result());
     if (root) {
-        m_childModel.setRootItem(root);
+        m_childModel.setRootItem(std::move(root));
         // Tell the traktor track source that it should re-build its index.
         m_trackSource->buildIndex();
 

--- a/src/library/treeitem.cpp
+++ b/src/library/treeitem.cpp
@@ -1,8 +1,3 @@
-// TreeItem.cpp
-// Created 10/02/2010 by Tobias Rafreider
-
-#include <QStringList>
-
 #include "library/treeitem.h"
 
 /*
@@ -29,109 +24,80 @@
  * - cratefeature.cpp
  * - *feature.cpp
  */
-TreeItem::TreeItem(const QString &data, const QString &data_path,
-                   LibraryFeature* feature, TreeItem* parent) {
-    m_data = data;
-    m_dataPath = data_path;
-    m_parentItem = parent;
-    m_feature = feature;
-    m_bold = false;
+
+TreeItem::TreeItem()
+    : m_pFeature(nullptr),
+      m_pParent(nullptr),
+      m_bold(false) {
 }
 
-TreeItem::TreeItem() {
-    m_data = "$root";
-    m_dataPath = "$root";
-    m_parentItem = NULL;
-    m_feature = NULL;
-    m_bold = false;
+TreeItem::TreeItem(
+        LibraryFeature* pFeature,
+        const QString& label,
+        const QVariant& data)
+    : m_pFeature(pFeature),
+      m_pParent(nullptr),
+      m_label(label),
+      m_data(data),
+      m_bold(false) {
+    DEBUG_ASSERT(m_pFeature != nullptr);
 }
 
 TreeItem::~TreeItem() {
-    qDeleteAll(m_childItems);
+    qDeleteAll(m_children);
 }
 
-void TreeItem::appendChild(TreeItem *item) {
-    m_childItems.append(item);
-}
-
-void TreeItem::removeChild(int index) {
-    delete m_childItems.takeAt(index);
-}
-
-TreeItem *TreeItem::child(int row) {
-    return m_childItems.value(row);
-}
-
-int TreeItem::childCount() const {
-    return m_childItems.count();
-}
-
-QVariant TreeItem::data() const {
-    return m_data;
-}
-
-QVariant TreeItem::dataPath() const {
-    return m_dataPath;
-}
-
-bool TreeItem::isPlaylist() const {
-    return (m_childItems.count() == 0);
-}
-
-bool TreeItem::isFolder() const {
-    return (m_childItems.count() != 0);
-}
-
-TreeItem *TreeItem::parent() {
-    return m_parentItem;
-}
-
-int TreeItem::row() const {
-    if (m_parentItem) {
-        return m_parentItem->m_childItems.indexOf(const_cast<TreeItem*>(this));
+int TreeItem::parentRow() const {
+    if (m_pParent) {
+        return m_pParent->m_children.indexOf(const_cast<TreeItem*>(this));
+    } else {
+        return kInvalidRow;
     }
-
-    return 0;
 }
 
-LibraryFeature* TreeItem::getFeature() {
-    return m_feature;
+TreeItem* TreeItem::child(int row) const {
+    DEBUG_ASSERT(row >= 0);
+    DEBUG_ASSERT(row < m_children.size());
+    return m_children[row];
 }
 
-bool TreeItem::insertChildren(QList<TreeItem*> &data, int position, int count) {
-    if (position < 0 || position > m_childItems.size())
-        return false;
+TreeItem* TreeItem::appendChild(TreeItem* pChild) {
+    DEBUG_ASSERT(feature() != nullptr);
+    DEBUG_ASSERT(pChild != nullptr);
+    DEBUG_ASSERT(pChild->feature() == feature());
+    DEBUG_ASSERT(!pChild->hasParent());
+    m_children.append(pChild);
+    pChild->m_pParent = this;
+    return pChild;
+}
 
-    for (int row = 0; row < count; ++row) {
-        TreeItem* item = data.at(row);
-        m_childItems.insert(position + row, item);
+void TreeItem::removeChild(int row) {
+    DEBUG_ASSERT(row >= 0);
+    DEBUG_ASSERT(row < m_children.size());
+    delete m_children.takeAt(row);
+}
+
+void TreeItem::insertChildren(const QList<TreeItem*>& children, int row, int count) {
+    DEBUG_ASSERT(feature() != nullptr);
+    DEBUG_ASSERT(count >= 0);
+    DEBUG_ASSERT(count <= children.size());
+    DEBUG_ASSERT(row >= 0);
+    DEBUG_ASSERT(row <= m_children.size());
+    for (int offset = 0; offset < count; ++offset) {
+        TreeItem* pChild = children[offset];
+        DEBUG_ASSERT(pChild != nullptr);
+        DEBUG_ASSERT(pChild->feature() == feature());
+        DEBUG_ASSERT(!pChild->hasParent());
+        m_children.insert(row + offset, pChild);
+        pChild->m_pParent = this;
     }
-
-    return true;
 }
 
-bool TreeItem::removeChildren(int position, int count) {
-    if (position < 0 || position + count > m_childItems.size())
-        return false;
-
-    for (int row = 0; row < count; ++row) {
-        //Remove from list to avoid invalid pointers
-        TreeItem* item = m_childItems.takeAt(position);
-        if(item) delete item;
-    }
-    return true;
-}
-
-bool TreeItem::setData(const QVariant &data, const QVariant &data_path) {
-    m_data = data.toString();
-    m_dataPath = data_path.toString();
-    return true;
-}
-
-QIcon TreeItem::getIcon() {
-    return m_icon;
-}
-
-void TreeItem::setIcon(const QIcon& icon) {
-    m_icon = icon;
+void TreeItem::removeChildren(int row, int count) {
+    DEBUG_ASSERT(count >= 0);
+    DEBUG_ASSERT(count <= m_children.size());
+    DEBUG_ASSERT(row >= 0);
+    DEBUG_ASSERT(row <= (m_children.size() - count));
+    qDeleteAll(m_children.begin() + row, m_children.begin() + (row + count));
+    m_children.erase(m_children.begin() + row, m_children.begin() + (row + count));
 }

--- a/src/library/treeitem.cpp
+++ b/src/library/treeitem.cpp
@@ -61,13 +61,22 @@ TreeItem* TreeItem::child(int row) const {
     return m_children[row];
 }
 
-TreeItem* TreeItem::appendChild(TreeItem* pChild) {
+void TreeItem::appendChild(TreeItem* pChild) {
     DEBUG_ASSERT(feature() != nullptr);
     DEBUG_ASSERT(pChild != nullptr);
     DEBUG_ASSERT(pChild->feature() == feature());
     DEBUG_ASSERT(!pChild->hasParent());
     m_children.append(pChild);
     pChild->m_pParent = this;
+}
+
+TreeItem* TreeItem::appendChild(
+        const QString& label,
+        const QVariant& data) {
+    auto pNewChild = std::make_unique<TreeItem>(feature(), label, data);
+    TreeItem* pChild = pNewChild.get();
+    appendChild(pChild); // transfer ownership
+    pNewChild.release(); // release ownership (afterwards)
     return pChild;
 }
 
@@ -77,19 +86,17 @@ void TreeItem::removeChild(int row) {
     delete m_children.takeAt(row);
 }
 
-void TreeItem::insertChildren(const QList<TreeItem*>& children, int row, int count) {
+void TreeItem::insertChildren(QList<TreeItem*>& children, int row, int count) {
     DEBUG_ASSERT(feature() != nullptr);
     DEBUG_ASSERT(count >= 0);
     DEBUG_ASSERT(count <= children.size());
     DEBUG_ASSERT(row >= 0);
     DEBUG_ASSERT(row <= m_children.size());
-    for (int offset = 0; offset < count; ++offset) {
-        TreeItem* pChild = children[offset];
-        DEBUG_ASSERT(pChild != nullptr);
-        DEBUG_ASSERT(pChild->feature() == feature());
-        DEBUG_ASSERT(!pChild->hasParent());
-        m_children.insert(row + offset, pChild);
-        pChild->m_pParent = this;
+    for (int counter = 0; counter < count; ++counter) {
+        DEBUG_ASSERT(!children.empty());
+        TreeItem* pChild = children.front();
+        appendChild(pChild);
+        children.pop_front();
     }
 }
 

--- a/src/library/treeitem.cpp
+++ b/src/library/treeitem.cpp
@@ -55,7 +55,7 @@ void TreeItem::appendChild(TreeItem *item) {
 }
 
 void TreeItem::removeChild(int index) {
-    m_childItems.removeAt(index);
+    delete m_childItems.takeAt(index);
 }
 
 TreeItem *TreeItem::child(int row) {

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -7,6 +7,9 @@
 
 #include "library/libraryfeature.h"
 
+#include "util/memory.h"
+
+
 class TreeItem final {
   public:
     static const int kInvalidRow = -1;
@@ -58,14 +61,16 @@ class TreeItem final {
     }
     TreeItem* child(int row) const;
 
-    /** appends a child item to this object **/
-    TreeItem* appendChild(TreeItem* pChild);
-    /** remove a child item at the given index **/
+    // single child items
+    TreeItem* appendChild(
+            std::unique_ptr<TreeItem> pChild);
+    TreeItem* appendChild(
+            const QString& label,
+            const QVariant& data = QVariant());
     void removeChild(int row);
 
-    /** for dynamic resizing models **/
-    void insertChildren(const QList<TreeItem*>& children, int row, int count);
-    /** Removes <count> children from the child list starting at index <position> **/
+    // multiple child items
+    void insertChildren(QList<TreeItem*>& children, int row, int count); // take ownership
     void removeChildren(int row, int count);
 
 
@@ -102,6 +107,8 @@ class TreeItem final {
     }
 
   private:
+    void appendChild(TreeItem* pChild);
+
     LibraryFeature* m_pFeature;
 
     TreeItem* m_pParent;

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -1,8 +1,5 @@
-// treeitem.h
-// Created 10/02/2010 by Tobias Rafreider
-
-#ifndef TREEITEM_H
-#define TREEITEM_H
+#ifndef MIXXX_TREEITEM_H
+#define MIXXX_TREEITEM_H
 
 #include <QList>
 #include <QString>
@@ -10,44 +7,92 @@
 
 #include "library/libraryfeature.h"
 
-class TreeItem {
+class TreeItem final {
   public:
-    TreeItem(); //creates an invisible root item for the tree
-    TreeItem(const QString &data,
-             const QString &data_path,
-             LibraryFeature* feature,
-             TreeItem* parent);
+    static const int kInvalidRow = -1;
+
+    TreeItem();
+    explicit TreeItem(
+            LibraryFeature* pFeature,
+            const QString& label = QString(),
+            const QVariant& data = QVariant());
     ~TreeItem();
+
+
+    /////////////////////////////////////////////////////////////////////////
+    // Feature
+    /////////////////////////////////////////////////////////////////////////
+
+    LibraryFeature* feature() const {
+        return m_pFeature;
+    }
+
+
+    /////////////////////////////////////////////////////////////////////////
+    // Parent
+    /////////////////////////////////////////////////////////////////////////
+
+    TreeItem* parent() const {
+        return m_pParent;
+    }
+    bool hasParent() const {
+        return m_pParent != nullptr;
+    }
+    bool isRoot() const {
+        return !hasParent();
+    }
+    // Returns the position of this object within its parent
+    // or kInvalidRow if this is a root item without a parent.
+    int parentRow() const;
+
+
+    /////////////////////////////////////////////////////////////////////////
+    // Children
+    /////////////////////////////////////////////////////////////////////////
+
+    bool hasChildren() const {
+        return !m_children.empty();
+    }
+    int childRows() const {
+        return m_children.size();
+    }
+    TreeItem* child(int row) const;
+
     /** appends a child item to this object **/
-    void appendChild(TreeItem *child);
+    TreeItem* appendChild(TreeItem* pChild);
     /** remove a child item at the given index **/
-    void removeChild(int index);
-    /** returns the tree item at position 'row' in the childlist **/
-    TreeItem *child(int row);
-    /** returns the number of childs of this tree item **/
-    int childCount() const;
-    /** Returns the position of this object within its parent **/
-    int row() const;
-    /** returns the parent **/
-    TreeItem *parent();
+    void removeChild(int row);
 
     /** for dynamic resizing models **/
-    bool insertChildren(QList<TreeItem*> &data, int position, int count);
+    void insertChildren(const QList<TreeItem*>& children, int row, int count);
     /** Removes <count> children from the child list starting at index <position> **/
-    bool removeChildren(int position, int count);
+    void removeChildren(int row, int count);
 
-    /** sets data **/
-    bool setData(const QVariant &data, const QVariant &data_path);
-    /** simple name of the playlist **/
-    QVariant data() const;
-    /** Full path of the playlist **/
-    QVariant dataPath() const;
-    /** Returns true if we have a leaf node **/
-    bool isPlaylist() const;
-    /** returns true if we have an inner node **/
-    bool isFolder() const;
-    /* Returns the Library feature object to which an item belongs to */
-    LibraryFeature* getFeature();
+
+    /////////////////////////////////////////////////////////////////////////
+    // Payload
+    /////////////////////////////////////////////////////////////////////////
+
+    void setLabel(const QString& label) {
+        m_label = label;
+    }
+    const QString& getLabel() const {
+        return m_label;
+    }
+
+    void setData(const QVariant& data) {
+        m_data = data;
+    }
+    const QVariant& getData() const {
+        return m_data;
+    }
+
+    void setIcon(const QIcon& icon) {
+        m_icon = icon;
+    }
+    const QIcon& getIcon() {
+        return m_icon;
+    }
 
     void setBold(bool bold) {
         m_bold = bold;
@@ -56,19 +101,16 @@ class TreeItem {
         return m_bold;
     }
 
-
-    void setIcon(const QIcon& icon);
-    QIcon getIcon();
-
   private:
-    QList<TreeItem*> m_childItems;
-    QString m_dataPath;
-    QString m_data;
-    LibraryFeature* m_feature;
-    bool m_bold;
+    LibraryFeature* m_pFeature;
 
-    TreeItem *m_parentItem;
+    TreeItem* m_pParent;
+    QList<TreeItem*> m_children; // owned child items
+
+    QString m_label;
+    QVariant m_data;
     QIcon m_icon;
+    bool m_bold;
 };
 
-#endif
+#endif // MIXXX_TREEITEM_H

--- a/src/library/treeitemmodel.h
+++ b/src/library/treeitemmodel.h
@@ -11,7 +11,7 @@ class TreeItem;
 class TreeItemModel : public QAbstractItemModel {
     Q_OBJECT
   public:
-    static const int kDataPathRole = Qt::UserRole;
+    static const int kDataRole = Qt::UserRole;
     static const int kBoldRole = Qt::UserRole + 1;
 
     TreeItemModel(QObject *parent = 0);

--- a/src/library/treeitemmodel.h
+++ b/src/library/treeitemmodel.h
@@ -6,6 +6,8 @@
 #include <QVariant>
 #include <QList>
 
+#include "util/memory.h"
+
 class TreeItem;
 
 class TreeItemModel : public QAbstractItemModel {
@@ -14,23 +16,29 @@ class TreeItemModel : public QAbstractItemModel {
     static const int kDataRole = Qt::UserRole;
     static const int kBoldRole = Qt::UserRole + 1;
 
-    TreeItemModel(QObject *parent = 0);
-    virtual ~TreeItemModel();
+    explicit TreeItemModel(QObject *parent = 0);
+    ~TreeItemModel() override;
 
-    virtual QVariant data(const QModelIndex &index, int role) const;
-    virtual Qt::ItemFlags flags(const QModelIndex &index) const;
-    virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
-    virtual QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const;
-    virtual QModelIndex parent(const QModelIndex &index) const;
+    QVariant data(const QModelIndex &index, int role) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
+    QModelIndex parent(const QModelIndex &index) const override;
     // Tell the compiler we don't mean to shadow insertRows.
+    bool removeRows(int position, int rows, const QModelIndex &parent = QModelIndex()) override;
+    bool setData(const QModelIndex &a_rIndex, const QVariant &a_rValue,
+                         int a_iRole = Qt::EditRole) override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+
     using QAbstractItemModel::insertRows;
     virtual bool insertRows(QList<TreeItem*> &data, int position, int rows, const QModelIndex &parent = QModelIndex());
-    virtual bool removeRows(int position, int rows, const QModelIndex &parent = QModelIndex());
-    virtual bool setData(const QModelIndex &a_rIndex, const QVariant &a_rValue,
-                         int a_iRole = Qt::EditRole);
-    virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
-    virtual int columnCount(const QModelIndex &parent = QModelIndex()) const;
-    void setRootItem(TreeItem *item);
+
+    TreeItem* setRootItem(std::unique_ptr<TreeItem> pRootItem);
+    TreeItem* getRootItem() const {
+        return m_pRootItem.get();
+    }
+
     // Return the underlying TreeItem.
     // If the index is invalid, the root item is returned.
     TreeItem* getItem(const QModelIndex &index) const;
@@ -38,7 +46,7 @@ class TreeItemModel : public QAbstractItemModel {
     void triggerRepaint();
 
   private:
-    TreeItem *m_pRootItem;
+    std::unique_ptr<TreeItem> m_pRootItem;
 };
 
 #endif


### PR DESCRIPTION
...using std::unique_ptr for transfering ownership.

I also improved the distinction between a label (QString) and the data (QVariant) of a TreeItem. The code contained unnecessary QString <-> int conversions for the data of some tree items.

Still much room for improvements, but that should be enough for now. I just need this as a prerequisite for https://github.com/uklotzde/mixxx/tree/cratestorage.