### PR TITLE
Backport signal11/hidapi@b5b2e17 into mixxx

### DIFF
--- a/lib/hidapi-0.8.0-rc1/windows/hid.c
+++ b/lib/hidapi-0.8.0-rc1/windows/hid.c
@@ -219,9 +219,7 @@ static HANDLE open_device(const char *path, BOOL enumerate)
 {
 	HANDLE handle;
 	DWORD desired_access = (enumerate)? 0: (GENERIC_WRITE | GENERIC_READ);
-	DWORD share_mode = (enumerate)?
-	                      FILE_SHARE_READ|FILE_SHARE_WRITE:
-	                      FILE_SHARE_READ;
+	DWORD share_mode = FILE_SHARE_READ|FILE_SHARE_WRITE;
 
 	handle = CreateFileA(path,
 		desired_access,


### PR DESCRIPTION
Backport signal11/hidapi@b5b2e17 into mixxx

Some user reported on the forums he has problems with a Traktor S2 MK2 HID Controller in Windows 10.
http://mixxx.org/forums/viewtopic.php?f=3&t=8744&p=31021

Backporting a fix from upstream hidapi master into hid lib/hipapi-0.8.0-rc1 we have in mixxx.