### PR TITLE
Added if-else preproccesor directives to declare fprint/encoded point…

### DIFF
--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -10,6 +10,16 @@
 #include "util/samplebuffer.h"
 #include "util/performancetimer.h"
 
+// Types of fprint/encoded pointers take into account Chromaprint API version
+// (void* -> uint32_t*) and (void* -> char*) changed in v1.4.0 -- alyptik 12/2016
+#if (CHROMAPRINT_VERSION_MINOR > 3)
+	typedef uint32_t* uint32_p;
+	typedef char* char_p;
+#else
+	typedef void* uint32_p;
+	typedef void* char_p;
+#endif
+
 namespace
 {
     // this is worth 2min of audio
@@ -67,12 +77,12 @@ namespace
             return QString();
         }
 
-        void* fprint = NULL;
+	uint32_p fprint = NULL;
         int size = 0;
         int ret = chromaprint_get_raw_fingerprint(ctx, &fprint, &size);
         QByteArray fingerprint;
         if (ret == 1) {
-            void* encoded = NULL;
+	    char_p encoded = NULL;
             int encoded_size = 0;
             chromaprint_encode_fingerprint(fprint, size,
                                            CHROMAPRINT_ALGORITHM_DEFAULT,

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -10,18 +10,18 @@
 #include "util/samplebuffer.h"
 #include "util/performancetimer.h"
 
-// Types of fprint/encoded pointers take into account Chromaprint API version
-// (void* -> uint32_t*) and (void* -> char*) changed in v1.4.0 -- alyptik 12/2016
-#if (CHROMAPRINT_VERSION_MINOR > 3)
-	typedef uint32_t* uint32_p;
-	typedef char* char_p;
-#else
-	typedef void* uint32_p;
-	typedef void* char_p;
-#endif
-
 namespace
 {
+// Type declarations of *fprint and *encoded pointers need to account for Chromaprint API version
+// (void* -> uint32_t*) and (void* -> char*) changed in versions v1.4.0 or later -- alyptik 12/2016
+#if (CHROMAPRINT_VERSION_MINOR > 3) || (CHROMAPRINT_VERSION_MAJOR > 1)
+    typedef uint32_t* uint32_p;
+    typedef char* char_p;
+#else
+    typedef void* uint32_p;
+    typedef void* char_p;
+#endif
+
     // this is worth 2min of audio
     // AcoustID only stores a fingerprint for the first two minutes of a song
     // on their server so we need only a fingerprint of the first two minutes

--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -12,15 +12,15 @@
 
 namespace
 {
-// Type declarations of *fprint and *encoded pointers need to account for Chromaprint API version
-// (void* -> uint32_t*) and (void* -> char*) changed in versions v1.4.0 or later -- alyptik 12/2016
-#if (CHROMAPRINT_VERSION_MINOR > 3) || (CHROMAPRINT_VERSION_MAJOR > 1)
-    typedef uint32_t* uint32_p;
-    typedef char* char_p;
-#else
-    typedef void* uint32_p;
-    typedef void* char_p;
-#endif
+    // Type declarations of *fprint and *encoded pointers need to account for Chromaprint API version
+    // (void* -> uint32_t*) and (void* -> char*) changed in versions v1.4.0 or later -- alyptik 12/2016
+    #if (CHROMAPRINT_VERSION_MINOR > 3) || (CHROMAPRINT_VERSION_MAJOR > 1)
+        typedef uint32_t* uint32_p;
+        typedef char* char_p;
+    #else
+        typedef void* uint32_p;
+        typedef void* char_p;
+    #endif
 
     // this is worth 2min of audio
     // AcoustID only stores a fingerprint for the first two minutes of a song
@@ -77,12 +77,12 @@ namespace
             return QString();
         }
 
-	uint32_p fprint = NULL;
+        uint32_p fprint = NULL;
         int size = 0;
         int ret = chromaprint_get_raw_fingerprint(ctx, &fprint, &size);
         QByteArray fingerprint;
         if (ret == 1) {
-	    char_p encoded = NULL;
+            char_p encoded = NULL;
             int encoded_size = 0;
             chromaprint_encode_fingerprint(fprint, size,
                                            CHROMAPRINT_ALGORITHM_DEFAULT,


### PR DESCRIPTION
Added if-else preproccesor directives to declare **fprint/encoded** pointers as desired type for the installed API. This seemed like the cleanest way to do it without using the memory overhead of declaring a new structure/class or duplicating code inside if/switch statements.

Chromaprint API has changed between 1.3.1 and 1.4.
See: https://bitbucket.org/acoustid/chromaprint/commits/2c85a1d88d197b8107039a57b6f3811b0b4308b0