### PR TITLE
add libqt4-opengl-dev pkg to fix travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ addons:
       - libportmidi-dev
       - libprotobuf-dev
       - libqt4-dev
+      - libqt4-opengl-dev
       - libqt4-sql-sqlite
       - librubberband-dev
       - libshout3-dev


### PR DESCRIPTION
This will fix travis-ci builds broken by some change on travis-ci side.