### PR TITLE
remember skin splitter size for vertical splitters

### DIFF
--- a/src/widget/wsplitter.cpp
+++ b/src/widget/wsplitter.cpp
@@ -16,6 +16,16 @@ void WSplitter::setup(const QDomNode& node, const SkinContext& context) {
     QString msg;
     bool ok = false;
 
+    // Default orientation is horizontal.
+    QString layout;
+    if (context.hasNodeSelectString(node, "Orientation", &layout)) {
+        if (layout == "vertical") {
+            setOrientation(Qt::Vertical);
+        } else if (layout == "horizontal") {
+            setOrientation(Qt::Horizontal);
+        }
+    }
+
     // Try to load last values stored in mixxx.cfg
     QString splitSizesConfigKey;
     if (context.hasNodeSelectString(node, "SplitSizesConfigKey", &splitSizesConfigKey)) {
@@ -58,16 +68,6 @@ void WSplitter::setup(const QDomNode& node, const SkinContext& context) {
         }
         if (ok) {
             this->setSizes(sizesList);
-        }
-    }
-
-    // Default orientation is horizontal.
-    QString layout;
-    if (context.hasNodeSelectString(node, "Orientation", &layout)) {
-        if (layout == "vertical") {
-            setOrientation(Qt::Vertical);
-        } else if (layout == "horizontal") {
-            setOrientation(Qt::Horizontal);
         }
     }
 


### PR DESCRIPTION
The splitter has to be set to the vertical orientation before setSize() is called. This is necessary for PR #940 to remember the sizes of the different parts of the interface across restart.

It would be cool to see more skins start making use of vertical splitters.