### PR TITLE
add [ChannelX],loaded ControlObject

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -185,7 +185,7 @@ EngineBuffer::EngineBuffer(QString group, UserSettingsPointer pConfig,
             this, SLOT(slotEjectTrack(double)),
             Qt::DirectConnection);
 
-    m_pTrackLoaded = new ControlObject(ConfigKey(m_group, "track_loaded"), 0, 1);
+    m_pTrackLoaded = new ControlObject(ConfigKey(m_group, "track_loaded"));
     m_pTrackLoaded->connectValueChangeRequest(this, SLOT(slotTrackLoadedCO(double)));
 
     // Quantization Controller for enabling and disabling the
@@ -531,9 +531,9 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
     m_bSlipEnabledProcessing = false;
     m_dSlipPosition = 0.;
     m_dSlipRate = 0;
+    m_pTrackLoaded->setAndConfirm(1);
     // Reset the pitch value for the new track.
     m_pause.unlock();
-    m_pTrackLoaded->setAndConfirm(1);
 
     // All EngineControls are connected directly
     emit(trackLoaded(pTrack, pOldTrack));

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -185,6 +185,8 @@ EngineBuffer::EngineBuffer(QString group, UserSettingsPointer pConfig,
             this, SLOT(slotEjectTrack(double)),
             Qt::DirectConnection);
 
+    m_pTrackLoaded = new ControlPushButton(ConfigKey(m_group, "loaded"));
+
     // Quantization Controller for enabling and disabling the
     // quantization (alignment) of loop in/out positions and (hot)cues with
     // beats.
@@ -483,6 +485,7 @@ void EngineBuffer::slotTrackLoading() {
     // Set play here, to signal the user that the play command is adopted
     m_playButton->set((double)m_bPlayAfterLoading);
     m_pTrackSamples->set(0); // Stop renderer
+    m_pTrackLoaded->set(1);
 }
 
 TrackPointer EngineBuffer::loadFakeTrack(double filebpm) {
@@ -550,6 +553,7 @@ void EngineBuffer::ejectTrack() {
     //qDebug() << "EngineBuffer::ejectTrack()";
     m_pause.lock();
     m_iTrackLoading = 0;
+    m_pTrackLoaded->set(0);
     m_pTrackSamples->set(0);
     m_pTrackSampleRate->set(0);
     TrackPointer pTrack = m_pCurrentTrack;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -485,7 +485,6 @@ void EngineBuffer::slotTrackLoading() {
     // Set play here, to signal the user that the play command is adopted
     m_playButton->set((double)m_bPlayAfterLoading);
     m_pTrackSamples->set(0); // Stop renderer
-    m_pTrackLoaded->set(1);
 }
 
 TrackPointer EngineBuffer::loadFakeTrack(double filebpm) {
@@ -512,6 +511,7 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
     TrackPointer pOldTrack = m_pCurrentTrack;
 
     m_pause.lock();
+    m_pTrackLoaded->set(1);
     m_visualPlayPos->setInvalid();
     m_pCurrentTrack = pTrack;
     m_trackSampleRateOld = iTrackSampleRate;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -185,7 +185,7 @@ EngineBuffer::EngineBuffer(QString group, UserSettingsPointer pConfig,
             this, SLOT(slotEjectTrack(double)),
             Qt::DirectConnection);
 
-    m_pTrackLoaded = new ControlPushButton(ConfigKey(m_group, "loaded"));
+    m_pTrackLoaded = new ControlPushButton(ConfigKey(m_group, "track_loaded"));
 
     // Quantization Controller for enabling and disabling the
     // quantization (alignment) of loop in/out positions and (hot)cues with

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -186,6 +186,7 @@ class EngineBuffer : public EngineObject {
 
   private slots:
     void slotTrackLoading();
+    void slotTrackLoadedCO(double v);
     void slotTrackLoaded(TrackPointer pTrack,
                          int iSampleRate, int iNumSamples);
     void slotTrackLoadFailed(TrackPointer pTrack,
@@ -332,7 +333,7 @@ class EngineBuffer : public EngineObject {
     ControlProxy* m_pPassthroughEnabled;
 
     ControlPushButton* m_pEject;
-    ControlPushButton* m_pTrackLoaded;
+    ControlObject* m_pTrackLoaded;
 
     // Whether or not to repeat the track when at the end
     ControlPushButton* m_pRepeat;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -332,6 +332,7 @@ class EngineBuffer : public EngineObject {
     ControlProxy* m_pPassthroughEnabled;
 
     ControlPushButton* m_pEject;
+    ControlPushButton* m_pTrackLoaded;
 
     // Whether or not to repeat the track when at the end
     ControlPushButton* m_pRepeat;


### PR DESCRIPTION
Previously, controller mappings and skins had to use track_samples to detect if a deck was loaded. This is not obvious and was often a point of confusion for people new to Mixxx.