### PR TITLE
Add a ControlObject::setReadOnly method.

### DIFF
--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -135,3 +135,12 @@ bool ControlObject::connectValueChangeRequest(const QObject* receiver,
     }
     return ret;
 }
+
+void ControlObject::setReadOnly() {
+    connectValueChangeRequest(this, SLOT(readOnlyHandler(double)),
+                              Qt::DirectConnection);
+}
+
+void ControlObject::readOnlyHandler(double v) {
+    qWarning() << m_key << "is read-only. Ignoring set of value:" << v;
+}

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -144,6 +144,9 @@ class ControlObject : public QObject {
     bool connectValueChangeRequest(const QObject* receiver,
                                    const char* method, Qt::ConnectionType type = Qt::AutoConnection);
 
+    // Installs a value-change request handler that ignores all sets.
+    void setReadOnly();
+
   signals:
     void valueChanged(double);
     void valueChangedFromEngine(double);
@@ -161,6 +164,7 @@ class ControlObject : public QObject {
 
   private slots:
     void privateValueChanged(double value, QObject* pSetter);
+    void readOnlyHandler(double v);
 
   private:
     void initialize(ConfigKey key, bool bIgnoreNops, bool bTrack,

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -94,12 +94,20 @@ class ControlObject : public QObject {
             m_pControl->set(value, this);
         }
     }
+
     // Sets the ControlObject value and confirms it.
     inline void setAndConfirm(double value) {
         if (m_pControl) {
             m_pControl->setAndConfirm(value, this);
         }
     }
+
+    // Forces the control to 'value', regardless of whether it has a change
+    // request handler attached (identical to setAndConfirm).
+    inline void forceSet(double value) {
+        setAndConfirm(value);
+    }
+
     // Instantly sets the value of the ControlObject
     static void set(const ConfigKey& key, const double& value);
 

--- a/src/effects/effectbuttonparameterslot.cpp
+++ b/src/effects/effectbuttonparameterslot.cpp
@@ -71,9 +71,9 @@ void EffectButtonParameterSlot::loadEffect(EffectPointer pEffect) {
             m_pControlValue->setDefaultValue(dDefault);
             EffectManifestParameter::ControlHint type = m_pEffectParameter->getControlHint();
             // TODO(rryan) expose this from EffectParameter
-            m_pControlType->setAndConfirm(static_cast<double>(type));
+            m_pControlType->forceSet(static_cast<double>(type));
             // Default loaded parameters to loaded and unlinked
-            m_pControlLoaded->setAndConfirm(1.0);
+            m_pControlLoaded->forceSet(1.0);
 
             connect(m_pEffectParameter, SIGNAL(valueChanged(double)),
                     this, SLOT(slotParameterValueChanged(double)));
@@ -90,10 +90,10 @@ void EffectButtonParameterSlot::clear() {
     }
 
     m_pEffect.clear();
-    m_pControlLoaded->setAndConfirm(0.0);
+    m_pControlLoaded->forceSet(0.0);
     m_pControlValue->set(0.0);
     m_pControlValue->setDefaultValue(0.0);
-    m_pControlType->setAndConfirm(0.0);
+    m_pControlType->forceSet(0.0);
     emit(updated());
 }
 

--- a/src/effects/effectbuttonparameterslot.cpp
+++ b/src/effects/effectbuttonparameterslot.cpp
@@ -23,10 +23,8 @@ EffectButtonParameterSlot::EffectButtonParameterSlot(const QString& group,
             this, SLOT(slotValueChanged(double)));
 
     // Read-only controls.
-    m_pControlType->connectValueChangeRequest(
-            this, SLOT(slotValueType(double)));
-    m_pControlLoaded->connectValueChangeRequest(
-            this, SLOT(slotLoaded(double)));
+    m_pControlType->setReadOnly();
+    m_pControlLoaded->setReadOnly();
 
     clear();
 }

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -17,16 +17,13 @@ EffectChainSlot::EffectChainSlot(EffectRack* pRack, const QString& group,
             this, SLOT(slotControlClear(double)));
 
     m_pControlNumEffects = new ControlObject(ConfigKey(m_group, "num_effects"));
-    m_pControlNumEffects->connectValueChangeRequest(
-        this, SLOT(slotControlNumEffects(double)));
+    m_pControlNumEffects->setReadOnly();
 
     m_pControlNumEffectSlots = new ControlObject(ConfigKey(m_group, "num_effectslots"));
-    m_pControlNumEffectSlots->connectValueChangeRequest(
-        this, SLOT(slotControlNumEffectSlots(double)));
+    m_pControlNumEffectSlots->setReadOnly();
 
     m_pControlChainLoaded = new ControlObject(ConfigKey(m_group, "loaded"));
-    m_pControlChainLoaded->connectValueChangeRequest(
-        this, SLOT(slotControlChainLoaded(double)));
+    m_pControlChainLoaded->setReadOnly();
 
     m_pControlChainEnabled = new ControlPushButton(ConfigKey(m_group, "enabled"));
     m_pControlChainEnabled->setButtonMode(ControlPushButton::POWERWINDOW);
@@ -306,27 +303,6 @@ void EffectChainSlot::slotControlClear(double v) {
     if (v > 0) {
         clear();
     }
-}
-
-void EffectChainSlot::slotControlNumEffects(double v) {
-    // Ignore sets to num_effects.
-    Q_UNUSED(v);
-    //qDebug() << debugString() << "slotControlNumEffects" << v;
-    qWarning() << "WARNING: num_effects is a read-only control.";
-}
-
-void EffectChainSlot::slotControlNumEffectSlots(double v) {
-    // Ignore sets to num_effectslots.
-    Q_UNUSED(v);
-    //qDebug() << debugString() << "slotControlNumEffectSlots" << v;
-    qWarning() << "WARNING: num_effectslots is a read-only control.";
-}
-
-void EffectChainSlot::slotControlChainLoaded(double v) {
-    // Ignore sets to loaded.
-    Q_UNUSED(v);
-    //qDebug() << debugString() << "slotControlChainLoaded" << v;
-    qWarning() << "WARNING: loaded is a read-only control.";
 }
 
 void EffectChainSlot::slotControlChainEnabled(double v) {

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -159,7 +159,7 @@ void EffectChainSlot::slotChainEffectsChanged(bool shouldEmit) {
             if (pSlot)
                 pSlot->loadEffect(pEffect);
         }
-        m_pControlNumEffects->setAndConfirm(math_min(
+        m_pControlNumEffects->forceSet(math_min(
             static_cast<unsigned int>(m_slots.size()),
             m_pEffectChain->numEffects()));
         if (shouldEmit) {
@@ -191,7 +191,7 @@ void EffectChainSlot::loadEffectChain(EffectChainPointer pEffectChain) {
         connect(m_pEffectChain.data(), SIGNAL(channelStatusChanged(const QString&, bool)),
                 this, SLOT(slotChainChannelStatusChanged(const QString&, bool)));
 
-        m_pControlChainLoaded->setAndConfirm(true);
+        m_pControlChainLoaded->forceSet(true);
         m_pControlChainInsertionType->set(m_pEffectChain->insertionType());
 
         // Mix and enabled channels are persistent properties of the chain slot,
@@ -229,8 +229,8 @@ void EffectChainSlot::clear() {
         m_pEffectChain->disconnect(this);
         m_pEffectChain.clear();
     }
-    m_pControlNumEffects->setAndConfirm(0.0);
-    m_pControlChainLoaded->setAndConfirm(0.0);
+    m_pControlNumEffects->forceSet(0.0);
+    m_pControlChainLoaded->forceSet(0.0);
     m_pControlChainInsertionType->set(EffectChain::INSERT);
     emit(updated());
 }
@@ -257,7 +257,7 @@ EffectSlotPointer EffectChainSlot::addEffectSlot(const QString& group) {
 
     EffectSlotPointer pSlot(pEffectSlot);
     m_slots.append(pSlot);
-    m_pControlNumEffectSlots->setAndConfirm(m_pControlNumEffectSlots->get() + 1);
+    m_pControlNumEffectSlots->forceSet(m_pControlNumEffectSlots->get() + 1);
     return pSlot;
 }
 

--- a/src/effects/effectchainslot.h
+++ b/src/effects/effectchainslot.h
@@ -106,9 +106,6 @@ class EffectChainSlot : public QObject {
     void slotClearEffect(unsigned int iEffectSlotNumber);
 
     void slotControlClear(double v);
-    void slotControlNumEffects(double v);
-    void slotControlNumEffectSlots(double v);
-    void slotControlChainLoaded(double v);
     void slotControlChainEnabled(double v);
     void slotControlChainMix(double v);
     void slotControlChainSuperParameter(double v);

--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -78,9 +78,9 @@ void EffectParameterSlot::loadEffect(EffectPointer pEffect) {
             m_pControlValue->setDefaultValue(dDefault);
             m_pControlValue->set(dValue);
             // TODO(rryan) expose this from EffectParameter
-            m_pControlType->setAndConfirm(static_cast<double>(type));
+            m_pControlType->forceSet(static_cast<double>(type));
             // Default loaded parameters to loaded and unlinked
-            m_pControlLoaded->setAndConfirm(1.0);
+            m_pControlLoaded->forceSet(1.0);
 
             m_pControlLinkType->set(m_pEffectParameter->getDefaultLinkType());
             m_pControlLinkInverse->set(
@@ -100,10 +100,10 @@ void EffectParameterSlot::clear() {
         m_pEffectParameter = NULL;
     }
 
-    m_pControlLoaded->setAndConfirm(0.0);
+    m_pControlLoaded->forceSet(0.0);
     m_pControlValue->set(0.0);
     m_pControlValue->setDefaultValue(0.0);
-    m_pControlType->setAndConfirm(0.0);
+    m_pControlType->forceSet(0.0);
     m_pControlLinkType->setAndConfirm(EffectManifestParameter::LINK_NONE);
     m_pSoftTakeover->setThreshold(SoftTakeover::kDefaultTakeoverThreshold);
     m_pControlLinkInverse->set(0.0);

--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -31,11 +31,8 @@ EffectParameterSlot::EffectParameterSlot(const QString& group, const unsigned in
             this, SLOT(slotValueChanged(double)));
 
     // Read-only controls.
-    m_pControlType->connectValueChangeRequest(
-            this, SLOT(slotValueType(double)));
-    m_pControlLoaded->connectValueChangeRequest(
-            this, SLOT(slotLoaded(double)));
-
+    m_pControlType->setReadOnly();
+    m_pControlLoaded->setReadOnly();
 
     m_pSoftTakeover = new SoftTakeover();
 

--- a/src/effects/effectparameterslotbase.cpp
+++ b/src/effects/effectparameterslotbase.cpp
@@ -44,18 +44,6 @@ QString EffectParameterSlotBase::description() const {
     return tr("No effect loaded.");
 }
 
-void EffectParameterSlotBase::slotLoaded(double v) {
-    Q_UNUSED(v);
-    //qDebug() << debugString() << "slotLoaded" << v;
-    qWarning() << "WARNING: loaded is a read-only control.";
-}
-
-void EffectParameterSlotBase::slotValueType(double v) {
-    Q_UNUSED(v);
-    //qDebug() << debugString() << "slotValueType" << v;
-    qWarning() << "WARNING: value_type is a read-only control.";
-}
-
 const EffectManifestParameter EffectParameterSlotBase::getManifest() {
     if (m_pEffectParameter) {
         return m_pEffectParameter->manifest();

--- a/src/effects/effectparameterslotbase.h
+++ b/src/effects/effectparameterslotbase.h
@@ -30,11 +30,6 @@ class EffectParameterSlotBase : public QObject {
     // Signal that indicates that the EffectParameterSlotBase has been updated.
     void updated();
 
-  protected slots:
-    // Solely for handling control changes
-    void slotLoaded(double v);
-    void slotValueType(double v);
-
   protected:
     const unsigned int m_iParameterSlotNumber;
     QString m_group;

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -94,7 +94,7 @@ int EffectRack::numEffectChainSlots() const {
 
 void EffectRack::addEffectChainSlotInternal(EffectChainSlotPointer pChainSlot) {
     m_effectChainSlots.append(pChainSlot);
-    m_controlNumEffectChainSlots.setAndConfirm(
+    m_controlNumEffectChainSlots.forceSet(
         m_controlNumEffectChainSlots.get() + 1);
 }
 

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -17,8 +17,7 @@ EffectRack::EffectRack(EffectsManager* pEffectsManager,
           m_pEngineEffectRack(NULL) {
     connect(&m_controlClearRack, SIGNAL(valueChanged(double)),
             this, SLOT(slotClearRack(double)));
-    m_controlNumEffectChainSlots.connectValueChangeRequest(
-            this, SLOT(slotNumEffectChainSlots(double)));
+    m_controlNumEffectChainSlots.setReadOnly();
     addToEngine();
 }
 
@@ -72,13 +71,6 @@ void EffectRack::registerChannel(const ChannelHandleAndGroup& handle_group) {
     foreach (EffectChainSlotPointer pChainSlot, m_effectChainSlots) {
         pChainSlot->registerChannel(handle_group);
     }
-}
-
-void EffectRack::slotNumEffectChainSlots(double v) {
-    // Ignore sets to num_effectchain_slots
-    Q_UNUSED(v);
-    //qDebug() << debugString() << "slotNumEffectChainSlots" << v;
-    qWarning() << "WARNING: num_effectchain_slots is a read-only control.";
 }
 
 void EffectRack::slotClearRack(double v) {

--- a/src/effects/effectrack.h
+++ b/src/effects/effectrack.h
@@ -50,7 +50,6 @@ class EffectRack : public QObject {
 
   public slots:
     void slotClearRack(double v);
-    void slotNumEffectChainSlots(double v);
 
   private slots:
     void loadNextChain(const unsigned int iChainSlotNumber,

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -15,24 +15,19 @@ EffectSlot::EffectSlot(const QString& group,
           m_iEffectNumber(iEffectnumber),
           m_group(group) {
     m_pControlLoaded = new ControlObject(ConfigKey(m_group, "loaded"));
-    m_pControlLoaded->connectValueChangeRequest(
-        this, SLOT(slotLoaded(double)));
+    m_pControlLoaded->setReadOnly();
 
     m_pControlNumParameters = new ControlObject(ConfigKey(m_group, "num_parameters"));
-    m_pControlNumParameters->connectValueChangeRequest(
-        this, SLOT(slotNumParameters(double)));
+    m_pControlNumParameters->setReadOnly();
 
     m_pControlNumParameterSlots = new ControlObject(ConfigKey(m_group, "num_parameterslots"));
-    m_pControlNumParameterSlots->connectValueChangeRequest(
-        this, SLOT(slotNumParameterSlots(double)));
+    m_pControlNumParameterSlots->setReadOnly();
 
     m_pControlNumButtonParameters = new ControlObject(ConfigKey(m_group, "num_button_parameters"));
-    m_pControlNumButtonParameters->connectValueChangeRequest(
-        this, SLOT(slotNumParameters(double)));
+    m_pControlNumButtonParameters->setReadOnly();
 
     m_pControlNumButtonParameterSlots = new ControlObject(ConfigKey(m_group, "num_button_parameterslots"));
-    m_pControlNumButtonParameterSlots->connectValueChangeRequest(
-        this, SLOT(slotNumParameterSlots(double)));
+    m_pControlNumButtonParameterSlots->setReadOnly();
 
     m_pControlEnabled = new ControlPushButton(ConfigKey(m_group, "enabled"));
     m_pControlEnabled->setButtonMode(ControlPushButton::POWERWINDOW);
@@ -111,24 +106,6 @@ unsigned int EffectSlot::numParameterSlots() const {
 
 unsigned int EffectSlot::numButtonParameterSlots() const {
     return m_buttonParameters.size();
-}
-
-void EffectSlot::slotLoaded(double v) {
-    Q_UNUSED(v);
-    //qDebug() << debugString() << "slotLoaded" << v;
-    qWarning() << "WARNING: loaded is a read-only control.";
-}
-
-void EffectSlot::slotNumParameters(double v) {
-    Q_UNUSED(v);
-    //qDebug() << debugString() << "slotNumParameters" << v;
-    qWarning() << "WARNING: num_parameters is a read-only control.";
-}
-
-void EffectSlot::slotNumParameterSlots(double v) {
-    Q_UNUSED(v);
-    //qDebug() << debugString() << "slotNumParameterSlots" << v;
-    qWarning() << "WARNING: num_parameterslots is a read-only control.";
 }
 
 void EffectSlot::slotEnabled(double v) {

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -82,7 +82,7 @@ EffectParameterSlotPointer EffectSlot::addEffectParameterSlot() {
     EffectParameterSlotPointer pParameter = EffectParameterSlotPointer(
             new EffectParameterSlot(m_group, m_parameters.size()));
     m_parameters.append(pParameter);
-    m_pControlNumParameterSlots->setAndConfirm(
+    m_pControlNumParameterSlots->forceSet(
             m_pControlNumParameterSlots->get() + 1);
     return pParameter;
 }
@@ -91,7 +91,7 @@ EffectButtonParameterSlotPointer EffectSlot::addEffectButtonParameterSlot() {
     EffectButtonParameterSlotPointer pParameter = EffectButtonParameterSlotPointer(
             new EffectButtonParameterSlot(m_group, m_buttonParameters.size()));
     m_buttonParameters.append(pParameter);
-    m_pControlNumButtonParameterSlots->setAndConfirm(
+    m_pControlNumButtonParameterSlots->forceSet(
             m_pControlNumButtonParameterSlots->get() + 1);
     return pParameter;
 }
@@ -142,9 +142,9 @@ void EffectSlot::loadEffect(EffectPointer pEffect) {
     //         << (pEffect ? pEffect->getManifest().name() : "(null)");
     if (pEffect) {
         m_pEffect = pEffect;
-        m_pControlLoaded->setAndConfirm(1.0);
-        m_pControlNumParameters->setAndConfirm(pEffect->numKnobParameters());
-        m_pControlNumButtonParameters->setAndConfirm(pEffect->numButtonParameters());
+        m_pControlLoaded->forceSet(1.0);
+        m_pControlNumParameters->forceSet(pEffect->numKnobParameters());
+        m_pControlNumButtonParameters->forceSet(pEffect->numButtonParameters());
 
         // Enabled is a persistent property of the effect slot, not of the
         // effect. Propagate the current setting to the effect.
@@ -182,9 +182,9 @@ void EffectSlot::clear() {
     if (m_pEffect) {
         m_pEffect->disconnect(this);
     }
-    m_pControlLoaded->setAndConfirm(0.0);
-    m_pControlNumParameters->setAndConfirm(0.0);
-    m_pControlNumButtonParameters->setAndConfirm(0.0);
+    m_pControlLoaded->forceSet(0.0);
+    m_pControlNumParameters->forceSet(0.0);
+    m_pControlNumButtonParameters->forceSet(0.0);
     foreach (EffectParameterSlotPointer pParameter, m_parameters) {
         pParameter->clear();
     }

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -53,9 +53,6 @@ class EffectSlot : public QObject {
     // Request that this EffectSlot load the given Effect
     void loadEffect(EffectPointer pEffect);
 
-    void slotLoaded(double v);
-    void slotNumParameters(double v);
-    void slotNumParameterSlots(double v);
     void slotEnabled(double v);
     void slotNextEffect(double v);
     void slotPrevEffect(double v);

--- a/src/engine/engineaux.cpp
+++ b/src/engine/engineaux.cpp
@@ -26,9 +26,7 @@ EngineAux::EngineAux(const ChannelHandleAndGroup& handle_group, EffectsManager* 
     }
 
     // Make input_configured read-only.
-    m_pInputConfigured->connectValueChangeRequest(
-        this, SLOT(slotInputConfiguredChangeRequest(double)),
-        Qt::DirectConnection);
+    m_pInputConfigured->setReadOnly();
     ControlDoublePrivate::insertAlias(ConfigKey(getGroup(), "enabled"),
                                       ConfigKey(getGroup(), "input_configured"));
 

--- a/src/engine/engineaux.cpp
+++ b/src/engine/engineaux.cpp
@@ -60,7 +60,7 @@ void EngineAux::onInputConfigured(AudioInput input) {
         return;
     }
     m_sampleBuffer = NULL;
-    m_pInputConfigured->setAndConfirm(1.0);
+    m_pInputConfigured->forceSet(1.0);
 }
 
 void EngineAux::onInputUnconfigured(AudioInput input) {
@@ -70,7 +70,7 @@ void EngineAux::onInputUnconfigured(AudioInput input) {
         return;
     }
     m_sampleBuffer = NULL;
-    m_pInputConfigured->setAndConfirm(0.0);
+    m_pInputConfigured->forceSet(0.0);
 }
 
 void EngineAux::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,

--- a/src/engine/engineaux.h
+++ b/src/engine/engineaux.h
@@ -48,10 +48,6 @@ class EngineAux : public EngineChannel, public AudioDestination {
     // a soundcard input.
     virtual void onInputUnconfigured(AudioInput input);
 
-  private slots:
-    // Reject all change requests for input configured.
-    void slotInputConfiguredChangeRequest(double) {}
-
   private:
     EngineEffectsManager* m_pEngineEffectsManager;
     EngineVuMeter m_vuMeter;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -186,7 +186,7 @@ EngineBuffer::EngineBuffer(QString group, UserSettingsPointer pConfig,
             Qt::DirectConnection);
 
     m_pTrackLoaded = new ControlObject(ConfigKey(m_group, "track_loaded"));
-    m_pTrackLoaded->connectValueChangeRequest(this, SLOT(slotTrackLoadedCO(double)));
+    m_pTrackLoaded->setReadOnly();
 
     // Quantization Controller for enabling and disabling the
     // quantization (alignment) of loop in/out positions and (hot)cues with
@@ -487,12 +487,6 @@ void EngineBuffer::slotTrackLoading() {
     // Set play here, to signal the user that the play command is adopted
     m_playButton->set((double)m_bPlayAfterLoading);
     m_pTrackSamples->set(0); // Stop renderer
-}
-
-void EngineBuffer::slotTrackLoadedCO(double v) {
-    Q_UNUSED(v);
-    qWarning() << "WARNING:" << m_group << "\"track_loaded\""
-               << "is a read-only control, ignoring.";
 }
 
 TrackPointer EngineBuffer::loadFakeTrack(double filebpm) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -525,7 +525,7 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
     m_bSlipEnabledProcessing = false;
     m_dSlipPosition = 0.;
     m_dSlipRate = 0;
-    m_pTrackLoaded->setAndConfirm(1);
+    m_pTrackLoaded->forceSet(1);
     // Reset the pitch value for the new track.
     m_pause.unlock();
 
@@ -555,7 +555,7 @@ void EngineBuffer::ejectTrack() {
     //qDebug() << "EngineBuffer::ejectTrack()";
     m_pause.lock();
     m_iTrackLoading = 0;
-    m_pTrackLoaded->setAndConfirm(0);
+    m_pTrackLoaded->forceSet(0);
     m_pTrackSamples->set(0);
     m_pTrackSampleRate->set(0);
     TrackPointer pTrack = m_pCurrentTrack;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -186,7 +186,6 @@ class EngineBuffer : public EngineObject {
 
   private slots:
     void slotTrackLoading();
-    void slotTrackLoadedCO(double v);
     void slotTrackLoaded(TrackPointer pTrack,
                          int iSampleRate, int iNumSamples);
     void slotTrackLoadFailed(TrackPointer pTrack,

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -45,9 +45,7 @@ EngineDeck::EngineDeck(const ChannelHandleAndGroup& handle_group,
     }
 
     // Make input_configured read-only.
-    m_pInputConfigured->connectValueChangeRequest(
-        this, SLOT(slotInputConfiguredChangeRequest(double)),
-        Qt::DirectConnection);
+    m_pInputConfigured->setReadOnly();
 
     // Set up passthrough utilities and fields
     m_pPassing->setButtonMode(ControlPushButton::POWERWINDOW);

--- a/src/engine/enginedeck.cpp
+++ b/src/engine/enginedeck.cpp
@@ -156,7 +156,7 @@ void EngineDeck::onInputConfigured(AudioInput input) {
         qDebug() << "WARNING: EngineDeck connected to AudioInput for a non-vinylcontrol type!";
         return;
     }
-    m_pInputConfigured->setAndConfirm(1.0);
+    m_pInputConfigured->forceSet(1.0);
     m_sampleBuffer =  NULL;
 }
 
@@ -166,7 +166,7 @@ void EngineDeck::onInputUnconfigured(AudioInput input) {
         qDebug() << "WARNING: EngineDeck connected to AudioInput for a non-vinylcontrol type!";
         return;
     }
-    m_pInputConfigured->setAndConfirm(0.0);
+    m_pInputConfigured->forceSet(0.0);
     m_sampleBuffer = NULL;
 }
 

--- a/src/engine/enginedeck.h
+++ b/src/engine/enginedeck.h
@@ -76,10 +76,6 @@ class EngineDeck : public EngineChannel, public AudioDestination {
   public slots:
     void slotPassingToggle(double v);
 
-  private slots:
-    // Reject all change requests for input configured.
-    void slotInputConfiguredChangeRequest(double) {}
-
   private:
     UserSettingsPointer m_pConfig;
     EngineBuffer* m_pBuffer;

--- a/src/engine/enginemicrophone.cpp
+++ b/src/engine/enginemicrophone.cpp
@@ -26,9 +26,7 @@ EngineMicrophone::EngineMicrophone(const ChannelHandleAndGroup& handle_group,
     }
 
     // Make input_configured read-only.
-    m_pInputConfigured->connectValueChangeRequest(
-        this, SLOT(slotInputConfiguredChangeRequest(double)),
-        Qt::DirectConnection);
+    m_pInputConfigured->setReadOnly();
     ControlDoublePrivate::insertAlias(ConfigKey(getGroup(), "enabled"),
                                       ConfigKey(getGroup(), "input_configured"));
 

--- a/src/engine/enginemicrophone.cpp
+++ b/src/engine/enginemicrophone.cpp
@@ -58,7 +58,7 @@ void EngineMicrophone::onInputConfigured(AudioInput input) {
         return;
     }
     m_sampleBuffer = NULL;
-    m_pInputConfigured->setAndConfirm(1.0);
+    m_pInputConfigured->forceSet(1.0);
 }
 
 void EngineMicrophone::onInputUnconfigured(AudioInput input) {
@@ -68,7 +68,7 @@ void EngineMicrophone::onInputUnconfigured(AudioInput input) {
         return;
     }
     m_sampleBuffer = NULL;
-    m_pInputConfigured->setAndConfirm(0.0);
+    m_pInputConfigured->forceSet(0.0);
 }
 
 void EngineMicrophone::receiveBuffer(AudioInput input, const CSAMPLE* pBuffer,

--- a/src/engine/enginemicrophone.h
+++ b/src/engine/enginemicrophone.h
@@ -52,10 +52,6 @@ class EngineMicrophone : public EngineChannel, public AudioDestination {
     bool isSolo();
     double getSoloDamping();
 
-  private slots:
-    // Reject all change requests for input configured.
-    void slotInputConfiguredChangeRequest(double) {}
-
   private:
     EngineEffectsManager* m_pEngineEffectsManager;
     EngineVuMeter m_vuMeter;

--- a/src/engine/sidechain/enginebroadcast.cpp
+++ b/src/engine/sidechain/enginebroadcast.cpp
@@ -57,8 +57,7 @@ EngineBroadcast::EngineBroadcast(UserSettingsPointer pConfig)
             this, SLOT(slotEnableCO(double)));
 
     m_pStatusCO = new ControlObject(ConfigKey(BROADCAST_PREF_KEY, "status"));
-    m_pStatusCO->connectValueChangeRequest(
-            this, SLOT(slotStatusCO(double)));
+    m_pStatusCO->setReadOnly();
     m_pStatusCO->setAndConfirm(STATUSCO_UNCONNECTED);
 
     setState(NETWORKSTREAMWORKER_STATE_INIT);
@@ -897,12 +896,6 @@ void EngineBroadcast::ignoreSigpipe() {
 }
 #endif
 
-void EngineBroadcast::slotStatusCO(double v) {
-    // Ignore external sets "status"
-    Q_UNUSED(v);
-    qWarning() << "WARNING:"
-            << BROADCAST_PREF_KEY << "\"status\" is a read-only control, ignoring";
-}
 
 void EngineBroadcast::slotEnableCO(double v) {
     if (v > 1.0) {

--- a/src/engine/sidechain/enginebroadcast.cpp
+++ b/src/engine/sidechain/enginebroadcast.cpp
@@ -58,7 +58,7 @@ EngineBroadcast::EngineBroadcast(UserSettingsPointer pConfig)
 
     m_pStatusCO = new ControlObject(ConfigKey(BROADCAST_PREF_KEY, "status"));
     m_pStatusCO->setReadOnly();
-    m_pStatusCO->setAndConfirm(STATUSCO_UNCONNECTED);
+    m_pStatusCO->forceSet(STATUSCO_UNCONNECTED);
 
     setState(NETWORKSTREAMWORKER_STATE_INIT);
 
@@ -407,13 +407,13 @@ bool EngineBroadcast::processConnect() {
 
     if (!m_encoder) {
         // updateFromPreferences failed
-        m_pStatusCO->setAndConfirm(STATUSCO_FAILURE);
+        m_pStatusCO->forceSet(STATUSCO_FAILURE);
         m_pBroadcastEnabled->set(0);
         qDebug() << "EngineBroadcast::processConnect() returning false";
         return false;
     }
 
-    m_pStatusCO->setAndConfirm(STATUSCO_CONNECTING);
+    m_pStatusCO->forceSet(STATUSCO_CONNECTING);
     m_iShoutFailures = 0;
     m_lastErrorStr.clear();
     // set to a high number to automatically update the metadata
@@ -502,7 +502,7 @@ bool EngineBroadcast::processConnect() {
                 m_pOutputFifo->flushReadData(m_pOutputFifo->readAvailable());
             }
             m_threadWaiting = true;
-            m_pStatusCO->setAndConfirm(STATUSCO_CONNECTED);
+            m_pStatusCO->forceSet(STATUSCO_CONNECTED);
             emit(broadcastConnected());
             qDebug() << "EngineBroadcast::processConnect() returning true";
             return true;
@@ -526,10 +526,10 @@ bool EngineBroadcast::processConnect() {
         m_encoder = nullptr;
     }
     if (m_pBroadcastEnabled->toBool()) {
-        m_pStatusCO->setAndConfirm(STATUSCO_FAILURE);
+        m_pStatusCO->forceSet(STATUSCO_FAILURE);
         m_pBroadcastEnabled->set(0);
     } else {
-        m_pStatusCO->setAndConfirm(STATUSCO_UNCONNECTED);
+        m_pStatusCO->forceSet(STATUSCO_UNCONNECTED);
     }
     qDebug() << "EngineBroadcast::processConnect() returning false";
     return false;
@@ -577,7 +577,7 @@ void EngineBroadcast::write(unsigned char *header, unsigned char *body,
             qDebug() << "shout_queuelen" << queuelen;
             NetworkStreamWorker::debugState();
             if (queuelen > kMaxNetworkCache) {
-                m_pStatusCO->setAndConfirm(STATUSCO_FAILURE);
+                m_pStatusCO->forceSet(STATUSCO_FAILURE);
                 processDisconnect();
                 if (!processConnect()) {
                     errorDialog(tr("Lost connection to streaming server and the attempt to reconnect failed"),
@@ -599,7 +599,7 @@ bool EngineBroadcast::writeSingle(const unsigned char* data, size_t len) {
                  << ret << shout_get_error(m_pShout);
         NetworkStreamWorker::debugState();
         if (m_iShoutFailures > kMaxShoutFailures) {
-            m_pStatusCO->setAndConfirm(STATUSCO_FAILURE);
+            m_pStatusCO->forceSet(STATUSCO_FAILURE);
             processDisconnect();
             if (!processConnect()) {
                 errorDialog(tr("Lost connection to streaming server and the attempt to reconnect failed"),
@@ -842,7 +842,7 @@ void EngineBroadcast::run() {
         // broadcast if necessary.
         if (!m_pBroadcastEnabled->toBool()) {
             m_threadWaiting = false;
-            m_pStatusCO->setAndConfirm(STATUSCO_UNCONNECTED);
+            m_pStatusCO->forceSet(STATUSCO_UNCONNECTED);
             processDisconnect();
             setFunctionCode(2);
             return;

--- a/src/engine/sidechain/enginebroadcast.h
+++ b/src/engine/sidechain/enginebroadcast.h
@@ -66,7 +66,6 @@ class EngineBroadcast
     virtual void run();
 
   private slots:
-    void slotStatusCO(double v);
     void slotEnableCO(double v);
 
   signals:


### PR DESCRIPTION
Supports the common use-case of setting a control read-only by attaching a no-op change request handler.