### PR TITLE
Add reading of rating tag for MP3, MP4, and FLAC

### DIFF
--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -48,7 +48,6 @@ Track::Track(
           m_qMutex(QMutex::Recursive),
           m_id(trackId),
           m_bDirty(false),
-          m_iRating(0),
           m_cuePoint(0.0),
           m_dateAdded(QDateTime::currentDateTime()),
           m_bHeaderParsed(false),
@@ -819,14 +818,15 @@ bool Track::isDirty() {
 
 int Track::getRating() const {
     QMutexLocker lock(&m_qMutex);
-    return m_iRating;
+    return m_metadata.getRating();
 }
 
 void Track::setRating (int rating) {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(&m_iRating, rating)) {
+    if (m_metadata.getRating() != rating) {
+        m_metadata.setRating(rating);
         markDirtyAndUnlock(&lock);
-    }
+	}
 }
 
 void Track::setKeys(const Keys& keys) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -826,7 +826,7 @@ void Track::setRating (int rating) {
     if (m_metadata.getRating() != rating) {
         m_metadata.setRating(rating);
         markDirtyAndUnlock(&lock);
-	}
+    }
 }
 
 void Track::setKeys(const Keys& keys) {

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -58,7 +58,7 @@ class Track : public QObject {
     Q_PROPERTY(int times_played READ getTimesPlayed)
     Q_PROPERTY(QString comment READ getComment WRITE setComment)
     Q_PROPERTY(double bpm READ getBpm WRITE setBpm)
-	Q_PROPERTY(int rating READ getRating WRITE setRating)
+    Q_PROPERTY(int rating READ getRating WRITE setRating)
     Q_PROPERTY(QString bpmFormatted READ getBpmText STORED false)
     Q_PROPERTY(QString key READ getKeyText WRITE setKeyText)
     Q_PROPERTY(double duration READ getDuration WRITE setDuration)
@@ -381,7 +381,7 @@ class Track : public QObject {
     QString m_sURL;
 
     // Cue point in samples
-    float m_cuePoint;
+    double m_cuePoint;
 
     // Date the track was added to the library
     QDateTime m_dateAdded;

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -58,6 +58,7 @@ class Track : public QObject {
     Q_PROPERTY(int times_played READ getTimesPlayed)
     Q_PROPERTY(QString comment READ getComment WRITE setComment)
     Q_PROPERTY(double bpm READ getBpm WRITE setBpm)
+	Q_PROPERTY(int rating READ getRating WRITE setRating)
     Q_PROPERTY(QString bpmFormatted READ getBpmText STORED false)
     Q_PROPERTY(QString key READ getKeyText WRITE setKeyText)
     Q_PROPERTY(double duration READ getDuration WRITE setDuration)
@@ -224,7 +225,7 @@ class Track : public QObject {
     // Returns rating
     int getRating() const;
     // Sets rating
-    void setRating(int);
+    void setRating(int rating);
 
     // Get URL for track
     QString getURL() const;
@@ -379,11 +380,8 @@ class Track : public QObject {
     // URL (used in promo track)
     QString m_sURL;
 
-    // Track rating
-    int m_iRating;
-
     // Cue point in samples
-    double m_cuePoint;
+    float m_cuePoint;
 
     // Date the track was added to the library
     QDateTime m_dateAdded;

--- a/src/track/trackmetadata.cpp
+++ b/src/track/trackmetadata.cpp
@@ -70,6 +70,7 @@ TrackMetadata::TrackMetadata()
     : m_duration(0.0),
       m_bitrate(0),
       m_channels(0),
+	  m_rating(0),
       m_sampleRate(0) {
 }
 
@@ -92,6 +93,7 @@ bool operator==(const TrackMetadata& lhs, const TrackMetadata& rhs) {
             (lhs.getGrouping() == rhs.getGrouping()) &&
             (lhs.getKey() == rhs.getKey()) &&
             (lhs.getBpm() == rhs.getBpm()) &&
+			(lhs.getRating() == rhs.getRating()) &&
             (lhs.getReplayGain() == rhs.getReplayGain());
 }
 

--- a/src/track/trackmetadata.cpp
+++ b/src/track/trackmetadata.cpp
@@ -70,7 +70,7 @@ TrackMetadata::TrackMetadata()
     : m_duration(0.0),
       m_bitrate(0),
       m_channels(0),
-	  m_rating(0),
+      m_rating(0),
       m_sampleRate(0) {
 }
 
@@ -93,7 +93,7 @@ bool operator==(const TrackMetadata& lhs, const TrackMetadata& rhs) {
             (lhs.getGrouping() == rhs.getGrouping()) &&
             (lhs.getKey() == rhs.getKey()) &&
             (lhs.getBpm() == rhs.getBpm()) &&
-			(lhs.getRating() == rhs.getRating()) &&
+            (lhs.getRating() == rhs.getRating()) &&
             (lhs.getReplayGain() == rhs.getReplayGain());
 }
 

--- a/src/track/trackmetadata.h
+++ b/src/track/trackmetadata.h
@@ -202,7 +202,7 @@ private:
     // Integer fields (in alphabetical order)
     int m_bitrate; // kbit/s
     int m_channels;
-	int m_rating;
+    int m_rating;
     int m_sampleRate; // Hz
 };
 

--- a/src/track/trackmetadata.h
+++ b/src/track/trackmetadata.h
@@ -140,6 +140,14 @@ public:
         m_bpm.resetValue();
     }
 
+	// rating
+    int getRating() const {
+        return m_rating;
+    }
+    void setRating(int rating) {
+        m_rating = rating;
+    }
+
     const ReplayGain& getReplayGain() const {
         return m_replayGain;
     }
@@ -195,6 +203,7 @@ private:
     // Integer fields (in alphabetical order)
     int m_bitrate; // kbit/s
     int m_channels;
+	int m_rating;
     int m_sampleRate; // Hz
 };
 

--- a/src/track/trackmetadata.h
+++ b/src/track/trackmetadata.h
@@ -140,7 +140,6 @@ public:
         m_bpm.resetValue();
     }
 
-	// rating
     int getRating() const {
         return m_rating;
     }

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -236,7 +236,7 @@ bool parseBpm(TrackMetadata* pTrackMetadata, QString sBpm) {
     return isBpmValid;
 }
 
-void parseFlacRating(int rating) {
+int parseFlacRating(int rating) {
 
         int starRatingValue;
 
@@ -256,10 +256,10 @@ void parseFlacRating(int rating) {
             starRatingValue = 0;
         }
 
-		return starRatingValue;
+        return starRatingValue;
 }
 
-void parseMp4Rating(int rating) {
+int parseMp4Rating(int rating) {
         int starRatingValue;
 
         if (rating <= 0) {
@@ -278,11 +278,10 @@ void parseMp4Rating(int rating) {
             starRatingValue = 0;
         }
 
-		return starRatingValue;
+        return starRatingValue;
 }
 
-void parseMp3Rating(QString sRating) {
-        int rating = sRating.toInt();
+int parseMp3Rating(int rating) {
         int starRatingValue;
 
         if (rating <= 0) {
@@ -301,7 +300,7 @@ void parseMp3Rating(QString sRating) {
             starRatingValue = 0;
         }
 
-		return starRatingValue;
+        return starRatingValue;
 }
 
 inline QString formatTrackGain(const TrackMetadata& trackMetadata) {
@@ -1127,26 +1126,16 @@ void readTrackMetadataFromID3v2Tag(TrackMetadata* pTrackMetadata,
         pTrackMetadata->setAlbumArtist(toQStringFirstNotEmpty(albumArtistFrame));
     }
 
-    int rating;
+    int rating = -1;
     const TagLib::ID3v2::FrameList popmRatingFrameList(tag.frameListMap()["POPM"]);
     if (!popmRatingFrameList.isEmpty()) {
-		//All elements of frameListMap() are normal Framelist classes. 
-		//You have to convert to a PopularimeterFrame to access the rating()
-		//and email() functions.
-		auto popmRatingFrame = dynamic_cast<TagLib::ID3v2::PopularimeterFrame*>(popmRatingFrameList.front());
+        //All elements of frameListMap() are normal Framelist classes. 
+        //You have to convert to a PopularimeterFrame to access the rating()
+        //and email() functions.
+        auto popmRatingFrame = dynamic_cast<TagLib::ID3v2::PopularimeterFrame*>(popmRatingFrameList.front());
         if (popmRatingFrame != nullptr){
-        	int  intRating = popmRatingFrame->rating();
-            for (TagLib::ID3v2::FrameList::ConstIterator it(popmRatingFrameList.begin());
-                it != popmRatingFrameList.end(); it++){
-                    auto popmFrame = dynamic_cast<TagLib::ID3v2::PopularimeterFrame*>(*it);
-                    if (popmFrame != nullptr){
-                        if (toQString(popmFrame->email()) == "mixxx@mixxx.org") {
-                            rating = popmFrame->rating();
-							break;
-                        }
-                    }
-            }
-            pTrackMetadata.setRating(parseMp3Rating(rating));
+            rating = popmRatingFrame->rating();
+            pTrackMetadata->setRating(parseMp3Rating(rating));
         }
     }
 
@@ -1372,8 +1361,8 @@ void readTrackMetadataFromVorbisCommentTag(TrackMetadata* pTrackMetadata,
 
     QString rating;
     if (readXiphCommentField(tag, "RATING", &rating)) {
-		int intRating = rating.toInt(); //readXiphCommentField reads all fields as strings
-        pTrackMetadata.setRating(parseFlacRating(intRating));
+        int intRating = rating.toInt(); //readXiphCommentField reads all fields as strings
+        pTrackMetadata->setRating(parseFlacRating(intRating));
     }
 
     // Only read track gain (not album gain)
@@ -1459,8 +1448,8 @@ void readTrackMetadataFromMP4Tag(TrackMetadata* pTrackMetadata, const TagLib::MP
 
     QString rating;
     if (readMP4Atom(tag, "rate", &rating)) {
-		int intRating = rating.toInt(); //readMP4Atom reads all atoms as strings
-		pTrackMetadata.setRating(parseMp4Rating(intRating));
+        int intRating = rating.toInt(); //readMP4Atom reads all atoms as strings
+        pTrackMetadata->setRating(parseMp4Rating(intRating));
     }
 
     // Only read track gain (not album gain)


### PR DESCRIPTION
So this is partly addressed in the open PR #924 but it seems to have stagnated so I have decided to jump on it. Current state is that for mp3 the rating is taken from a POPM tag with email "mixxx@mixxx.org" or the first available if there is none from mixxx. MP4 and FLAC both use a plain 0-100 integer scale. 

Values are then parsed into a 0-5 value before being added to the metadata object. For POPM, the same standard as Windows Media Player/Explorer is followed. 

To do:
-add support for APE tags I'm not familiar with it and don't use it. I can't seem to find the key for the rating tag. Does anyone know this off hand?
-add writing from database to file. Need some discussion here. As MP4, FLAC, and APE do no use POPM, there isn't the email feature. So I feel it would actually make little sense to use a designated email for mixxx. Some users claim that they need different rating option for different applications/people, but honestly I use a mixed library; format isn't so important to me. Like I said, discussion needed.
-add the option to not overwrite existing ratings in the database
-add the option to turn writing the rating to the file tag on or off

I'm not quite sure where in the code the writing part would be controlled. If someone could point me in the right direction I'm sure I can figure it out, but if someone wants to contribute that, that would be great too.