### PR TITLE
Setting the presets in sorted order

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -22,7 +22,16 @@
 #include "util/version.h"
 
 namespace {
-QString nameForPreset(const PresetInfo& preset);
+
+QString nameForPreset(const PresetInfo& preset) {
+    QString name = preset.getName();
+    if (name.length() == 0) {
+        QFileInfo file(preset.getPath());
+        name = file.baseName();
+    }
+    return name;
+}
+
 bool presetInfoNameComparator(const PresetInfo &a, const PresetInfo &b) {
     // the comparison function for PresetInfo objects
     // this function is used to sort the list of
@@ -238,15 +247,6 @@ QString DlgPrefController::presetWikiLink(const ControllerPresetPointer pPreset)
 
 void DlgPrefController::slotDirty() {
     m_bDirty = true;
-}
-
-QString nameForPreset(const PresetInfo& preset) {
-    QString name = preset.getName();
-    if (name.length() == 0) {
-        QFileInfo file(preset.getPath());
-        name = file.baseName();
-    }
-    return name;
 }
 
 void DlgPrefController::enumeratePresets() {

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -248,7 +248,6 @@ void DlgPrefController::enumeratePresets() {
     // user has their controller plugged in)
     m_ui.comboBoxPreset->addItem("...");
 
-    m_ui.comboBoxPreset->setInsertPolicy(QComboBox::InsertAlphabetically);
     // Ask the controller manager for a list of applicable presets
     QSharedPointer<PresetInfoEnumerator> pie =
             m_pControllerManager->getMainThreadPresetEnumerator();
@@ -259,8 +258,10 @@ void DlgPrefController::enumeratePresets() {
         return;
     }
 
-    const QList<PresetInfo> presets = pie->getPresetsByExtension(
+    //Making the list of presets in the alphabetical order
+    QList<PresetInfo> presets = pie->getPresetsByExtension(
         m_pController->presetExtension());
+    qSort(presets.begin(), presets.end(), DlgPrefController::presetInfoLessThan);
 
     PresetInfo match;
     for (const PresetInfo& preset : presets) {
@@ -748,4 +749,12 @@ void DlgPrefController::openScript() {
             QDesktopServices::openUrl(QUrl::fromLocalFile(scriptPath));
         }
     }
+}
+
+
+bool DlgPrefController::presetInfoLessThan(const PresetInfo &a, const PresetInfo &b) {
+    //the compartion function for PresetInfo objects
+    //this function is used to sort the list of 
+    //presets in the combo box
+    return nameForPreset(a) < nameForPreset(b);
 }

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -21,6 +21,17 @@
 #include "preferences/usersettings.h"
 #include "util/version.h"
 
+QString nameForPreset(const PresetInfo& preset);
+namespace {
+    bool presetInfoNameComparator(const PresetInfo &a, const PresetInfo &b) {
+        // the comparison function for PresetInfo objects
+        // this function is used to sort the list of
+        // presets in the combo box
+        return nameForPreset(a) < nameForPreset(b);
+    }
+
+}
+
 DlgPrefController::DlgPrefController(QWidget* parent, Controller* controller,
                                      ControllerManager* controllerManager,
                                      UserSettingsPointer pConfig)
@@ -258,10 +269,10 @@ void DlgPrefController::enumeratePresets() {
         return;
     }
 
-    //Making the list of presets in the alphabetical order
+    // Making the list of presets in the alphabetical order
     QList<PresetInfo> presets = pie->getPresetsByExtension(
         m_pController->presetExtension());
-    qSort(presets.begin(), presets.end(), DlgPrefController::presetInfoLessThan);
+    qSort(presets.begin(), presets.end(), presetInfoNameComparator);
 
     PresetInfo match;
     for (const PresetInfo& preset : presets) {
@@ -752,9 +763,3 @@ void DlgPrefController::openScript() {
 }
 
 
-bool DlgPrefController::presetInfoLessThan(const PresetInfo &a, const PresetInfo &b) {
-    //the compartion function for PresetInfo objects
-    //this function is used to sort the list of 
-    //presets in the combo box
-    return nameForPreset(a) < nameForPreset(b);
-}

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -23,14 +23,14 @@
 
 QString nameForPreset(const PresetInfo& preset);
 namespace {
-    bool presetInfoNameComparator(const PresetInfo &a, const PresetInfo &b) {
-        // the comparison function for PresetInfo objects
-        // this function is used to sort the list of
-        // presets in the combo box
-        return nameForPreset(a) < nameForPreset(b);
-    }
-
+bool presetInfoNameComparator(const PresetInfo &a, const PresetInfo &b) {
+    // the comparison function for PresetInfo objects
+    // this function is used to sort the list of
+    // presets in the combo box
+    return nameForPreset(a) < nameForPreset(b);
 }
+
+} // The anonymous namespace
 
 DlgPrefController::DlgPrefController(QWidget* parent, Controller* controller,
                                      ControllerManager* controllerManager,

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -21,8 +21,8 @@
 #include "preferences/usersettings.h"
 #include "util/version.h"
 
-QString nameForPreset(const PresetInfo& preset);
 namespace {
+QString nameForPreset(const PresetInfo& preset);
 bool presetInfoNameComparator(const PresetInfo &a, const PresetInfo &b) {
     // the comparison function for PresetInfo objects
     // this function is used to sort the list of

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -103,7 +103,6 @@ class DlgPrefController : public DlgPreferencePage {
     ControllerOutputMappingTableModel* m_pOutputTableModel;
     QSortFilterProxyModel* m_pOutputProxyModel;
     bool m_bDirty;
-    static bool presetInfoLessThan(const PresetInfo &, const PresetInfo &);
 };
 
 #endif /*DLGPREFCONTROLLER_H*/

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -103,6 +103,7 @@ class DlgPrefController : public DlgPreferencePage {
     ControllerOutputMappingTableModel* m_pOutputTableModel;
     QSortFilterProxyModel* m_pOutputProxyModel;
     bool m_bDirty;
+    static bool presetInfoLessThan(const PresetInfo &, const PresetInfo &);
 };
 
 #endif /*DLGPREFCONTROLLER_H*/


### PR DESCRIPTION
The logic to convert the list of presets are sorted in the combobox, may be there was a fault with the previous logic so it was not able to set them in alphabetical order, now this time I used the qSort function of the QtAlgorithms, bug reference: https://bugs.launchpad.net/mixxx/+bug/1649724