### PR TITLE
Correct error of appearing % in waveform overview

### DIFF
--- a/src/waveform/renderers/waveformmarkproperties.h
+++ b/src/waveform/renderers/waveformmarkproperties.h
@@ -13,6 +13,7 @@ class WaveformMarkProperties final {
     WaveformMarkProperties(const QDomNode& node,
                            const SkinContext& context,
                            const WaveformSignalColors& signalColors);
+    void setHotCueNumber(int i) { m_text = m_text.arg(i); }
 
     QColor m_color;
     QColor m_textColor;

--- a/src/waveform/renderers/waveformmarkset.cpp
+++ b/src/waveform/renderers/waveformmarkset.cpp
@@ -71,6 +71,7 @@ void WaveformMarkSet::setup(const QString& group, const QDomNode& node,
                 //qDebug() << "WaveformRenderMark::setup - Automatic mark" << hotCueControlItem;
                 WaveformMarkPointer pMark(new WaveformMark(i));
                 WaveformMarkProperties defaultProperties = m_defaultMark.getProperties();
+                defaultProperties.setHotCueNumber(i);
                 pMark->setProperties(defaultProperties);
                 pMark->m_pPointCos = std::make_unique<ControlProxy>(pHotcue->getKey());
                 m_marks.push_back(pMark);


### PR DESCRIPTION
This is the bug at https://bugs.launchpad.net/mixxx/+bug/1650190 , which shows the %1 sign in the place of hotcue marks in the waveform overview, I hope this is right fix