### PR TITLE
replace a few do-nothing destructors by default

### DIFF
--- a/src/effects/effectmanifest.h
+++ b/src/effects/effectmanifest.h
@@ -27,9 +27,6 @@ class EffectManifest {
           m_isForFilterKnob(false),
           m_effectRampsFromDry(false) {
     }
-    virtual ~EffectManifest() {
-        //qDebug() << debugString() << "deleted";
-    }
 
     virtual const QString& id() const {
         return m_id;

--- a/src/effects/effectmanifest.h
+++ b/src/effects/effectmanifest.h
@@ -19,7 +19,7 @@
 // the no-argument constructor be non-explicit. All methods are left virtual to
 // allow a backend to replace the entire functionality with its own (for
 // example, a database-backed manifest)
-class EffectManifest {
+class EffectManifest final {
   public:
     EffectManifest()
         : m_isMixingEQ(false),

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -33,10 +33,13 @@ class CoverInfoRelative {
 
     // all-default memory management
     CoverInfoRelative(const CoverInfoRelative&) = default;
-    CoverInfoRelative(CoverInfoRelative&&) = default;
     CoverInfoRelative& operator=(const CoverInfoRelative&) = default;
-    CoverInfoRelative& operator=(CoverInfoRelative&&) = default;
     virtual ~CoverInfoRelative() = default;
+// Visual Studio does not support default generated move constructors
+#if !defined(_MSC_VER)
+    CoverInfoRelative(CoverInfoRelative&&) = default;
+    CoverInfoRelative& operator=(CoverInfoRelative&&) = default;
+#endif
 
     Source source;
     Type type;
@@ -59,10 +62,13 @@ class CoverInfo : public CoverInfoRelative {
 
     // all-default memory management
     CoverInfo(const CoverInfo&) = default;
-    CoverInfo(CoverInfo&&) = default;
     CoverInfo& operator=(const CoverInfo&) = default;
-    CoverInfo& operator=(CoverInfo&&) = default;
     virtual ~CoverInfo() override = default;
+// Visual Studio does not support default generated move constructors
+#if !defined(_MSC_VER)
+    CoverInfo(CoverInfo&&) = default;
+    CoverInfo& operator=(CoverInfo&&) = default;
+#endif
 
     QString trackLocation;
 };
@@ -85,10 +91,13 @@ class CoverArt : public CoverInfo {
 
     // all-default memory management
     CoverArt(const CoverArt&) = default;
-    CoverArt(CoverArt&&) = default;
     CoverArt& operator=(const CoverArt&) = default;
-    CoverArt& operator=(CoverArt&&) = default;
     virtual ~CoverArt() override = default;
+// Visual Studio does not support default generated move constructors
+#if !defined(_MSC_VER)
+    CoverArt(CoverArt&&) = default;
+    CoverArt& operator=(CoverArt&&) = default;
+#endif
 
     // it is not a QPixmap, because it is not safe to use pixmaps 
     // outside the GUI thread

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -31,6 +31,13 @@ class CoverInfoRelative {
 
     CoverInfoRelative();
 
+    // all-default memory management
+    CoverInfoRelative(const CoverInfoRelative&) = default;
+    CoverInfoRelative(CoverInfoRelative&&) = default;
+    CoverInfoRelative& operator=(const CoverInfoRelative&) = default;
+    CoverInfoRelative& operator=(CoverInfoRelative&&) = default;
+    virtual ~CoverInfoRelative() = default;
+
     Source source;
     Type type;
     QString coverLocation; // relative path, from track location
@@ -50,6 +57,13 @@ class CoverInfo : public CoverInfoRelative {
           trackLocation(tl) {
     }
 
+    // all-default memory management
+    CoverInfo(const CoverInfo&) = default;
+    CoverInfo(CoverInfo&&) = default;
+    CoverInfo& operator=(const CoverInfo&) = default;
+    CoverInfo& operator=(CoverInfo&&) = default;
+    virtual ~CoverInfo() override = default;
+
     QString trackLocation;
 };
 
@@ -68,6 +82,13 @@ class CoverArt : public CoverInfo {
           image(img),
           resizedToWidth(rtw) {
     }
+
+    // all-default memory management
+    CoverArt(const CoverArt&) = default;
+    CoverArt(CoverArt&&) = default;
+    CoverArt& operator=(const CoverArt&) = default;
+    CoverArt& operator=(CoverArt&&) = default;
+    virtual ~CoverArt() override = default;
 
     // it is not a QPixmap, because it is not safe to use pixmaps 
     // outside the GUI thread

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -30,7 +30,6 @@ class CoverInfoRelative {
     };
 
     CoverInfoRelative();
-    virtual ~CoverInfoRelative() {};
 
     Source source;
     Type type;
@@ -51,8 +50,6 @@ class CoverInfo : public CoverInfoRelative {
           trackLocation(tl) {
     }
 
-    virtual ~CoverInfo() {};
-
     QString trackLocation;
 };
 
@@ -71,8 +68,6 @@ class CoverArt : public CoverInfo {
           image(img),
           resizedToWidth(rtw) {
     }
-
-    virtual ~CoverArt() {};
 
     // it is not a QPixmap, because it is not safe to use pixmaps 
     // outside the GUI thread

--- a/src/skin/pixmapsource.cpp
+++ b/src/skin/pixmapsource.cpp
@@ -10,9 +10,6 @@ PixmapSource::PixmapSource(const QString& filepath) {
     setPath(filepath);
 }
 
-PixmapSource::~PixmapSource() {
-}
-
 QByteArray PixmapSource::getData() const {
     return m_baData;
 }

--- a/src/skin/pixmapsource.h
+++ b/src/skin/pixmapsource.h
@@ -6,7 +6,7 @@
 
 // A class representing an image source for a pixmap
 // A bundle of a file path, raw data or inline svg
-class PixmapSource {
+class PixmapSource final {
   public:
     PixmapSource();
     PixmapSource(const QString& filepath);

--- a/src/skin/pixmapsource.h
+++ b/src/skin/pixmapsource.h
@@ -10,7 +10,6 @@ class PixmapSource {
   public:
     PixmapSource();
     PixmapSource(const QString& filepath);
-    virtual ~PixmapSource();
 
     bool isEmpty() const;
     bool isSVG() const;

--- a/src/util/audiosignal.h
+++ b/src/util/audiosignal.h
@@ -70,7 +70,6 @@ public:
         DEBUG_ASSERT(kChannelCountZero <= m_channelCount); // unsigned value
         DEBUG_ASSERT(kSamplingRateZero <= m_samplingRate); // unsigned value
     }
-    virtual ~AudioSignal() {}
 
     // Returns the ordering of samples in contiguous buffers
     SampleLayout getSampleLayout() const {

--- a/src/util/audiosignal.h
+++ b/src/util/audiosignal.h
@@ -71,6 +71,13 @@ public:
         DEBUG_ASSERT(kSamplingRateZero <= m_samplingRate); // unsigned value
     }
 
+    // all-default memory management
+    AudioSignal(const AudioSignal&) = default;
+    AudioSignal(AudioSignal&&) = default;
+    AudioSignal& operator=(const AudioSignal&) = default;
+    AudioSignal& operator=(AudioSignal&&) = default;
+    virtual ~AudioSignal() = default;
+
     // Returns the ordering of samples in contiguous buffers
     SampleLayout getSampleLayout() const {
         return m_sampleLayout;

--- a/src/util/audiosignal.h
+++ b/src/util/audiosignal.h
@@ -73,10 +73,13 @@ public:
 
     // all-default memory management
     AudioSignal(const AudioSignal&) = default;
-    AudioSignal(AudioSignal&&) = default;
     AudioSignal& operator=(const AudioSignal&) = default;
-    AudioSignal& operator=(AudioSignal&&) = default;
     virtual ~AudioSignal() = default;
+// Visual Studio does not support default generated move constructors
+#if !defined(_MSC_VER)
+    AudioSignal(AudioSignal&&) = default;
+    AudioSignal& operator=(AudioSignal&&) = default;
+#endif
 
     // Returns the ordering of samples in contiguous buffers
     SampleLayout getSampleLayout() const {


### PR DESCRIPTION
In C++11, special member functions (such as the move constructor) are only
created by the compiler is none of destructor, copy constructor, and copy
assignment operator are defined; see, e.g.,
<http://stackoverflow.com/a/4782927/353337>.

This PR removes a few destructors such that move constructors are automatically
generated.

Caught by Coverity <https://scan.coverity.com/projects/mixxxdj-mixxx>.