### PR TITLE
Implement the preview cue

### DIFF
--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -219,6 +219,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
             Qt::DirectConnection);
 
     CuePointer pLoadCue;
+    CuePointer pPreviewCue;
     for (const CuePointer& pCue: m_pLoadedTrack->getCuePoints()) {
         if (pCue->getType() == Cue::CUE) {
             continue; // skip
@@ -227,17 +228,26 @@ void CueControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
             DEBUG_ASSERT(!pLoadCue);
             pLoadCue = pCue;
         }
+        if (pCue->getType() == Cue::PREVIEW) {
+            pPreviewCue = pCue;
+        }
         int hotcue = pCue->getHotCue();
         if (hotcue != -1) {
             attachCue(pCue, hotcue);
         }
     }
     double cuePoint;
+    double previewCuePoint;
+    bool onPreviewDeck = false;
     if (pLoadCue) {
         cuePoint = pLoadCue->getPosition();
     } else {
         // If no load cue point is stored, read from track
         cuePoint = m_pLoadedTrack->getCuePoint();
+    }
+    if(pPreviewCue) {
+        previewCuePoint = pPreviewCue->getPosition();
+        onPreviewDeck = true;
     }
     m_pCuePoint->set(cuePoint);
 
@@ -260,6 +270,10 @@ void CueControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
         // vinylcontrol is on and set to absolute.  This allows users to
         // load tracks and have the needle-drop be maintained.
         seekExact(0.0);
+    }
+
+    if(onPreviewDeck) {
+        seekExact(previewCuePoint);
     }
 
     trackCuesUpdated();

--- a/src/library/dao/cue.h
+++ b/src/library/dao/cue.h
@@ -21,6 +21,7 @@ class Cue : public QObject {
         BEAT    = 3,
         LOOP    = 4,
         JUMP    = 5,
+        PREVIEW = 6,
     };
 
     ~Cue() override;


### PR DESCRIPTION
This is the first commit for making the preview cue control, this just adds the PREVIEW to the src/library/dao/cue.h as an enum constant, and adds the mechanism to check for the preview cue in the src/engine/cuecontrol.cpp . The next commits will implement the feature to its full.