### PR TITLE
version-guard default move constructors for MSVC

### DIFF
--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -32,6 +32,8 @@ class CoverInfoRelative {
     CoverInfoRelative();
 
     // all-default memory management
+    CoverInfoRelative(const CoverInfoRelative&) = default;
+    CoverInfoRelative& operator=(const CoverInfoRelative&) = default;
     virtual ~CoverInfoRelative() = default;
 // Visual Studio does not support default generated move constructors yet
 #if !defined(_MSC_VER) || _MSC_VER > 1900
@@ -59,6 +61,8 @@ class CoverInfo : public CoverInfoRelative {
     }
 
     // all-default memory management
+    CoverInfo(const CoverInfo&) = default;
+    CoverInfo& operator=(const CoverInfo&) = default;
     virtual ~CoverInfo() override = default;
 // Visual Studio does not support default generated move constructors yet
 #if !defined(_MSC_VER) || _MSC_VER > 1900
@@ -86,6 +90,7 @@ class CoverArt : public CoverInfo {
     }
 
     // all-default memory management
+    CoverArt(const CoverArt&) = default;
     virtual ~CoverArt() override = default;
 // Visual Studio does not support default generated move constructors yet
 #if !defined(_MSC_VER) || _MSC_VER > 1900

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -35,8 +35,8 @@ class CoverInfoRelative {
     CoverInfoRelative(const CoverInfoRelative&) = default;
     CoverInfoRelative& operator=(const CoverInfoRelative&) = default;
     virtual ~CoverInfoRelative() = default;
-// Visual Studio does not support default generated move constructors
-#if !defined(_MSC_VER)
+// Visual Studio does not support default generated move constructors yet
+#if !defined(_MSC_VER) || _MSC_VER > 1900
     CoverInfoRelative(CoverInfoRelative&&) = default;
     CoverInfoRelative& operator=(CoverInfoRelative&&) = default;
 #endif
@@ -64,8 +64,8 @@ class CoverInfo : public CoverInfoRelative {
     CoverInfo(const CoverInfo&) = default;
     CoverInfo& operator=(const CoverInfo&) = default;
     virtual ~CoverInfo() override = default;
-// Visual Studio does not support default generated move constructors
-#if !defined(_MSC_VER)
+// Visual Studio does not support default generated move constructors yet
+#if !defined(_MSC_VER) || _MSC_VER > 1900
     CoverInfo(CoverInfo&&) = default;
     CoverInfo& operator=(CoverInfo&&) = default;
 #endif
@@ -93,8 +93,8 @@ class CoverArt : public CoverInfo {
     CoverArt(const CoverArt&) = default;
     CoverArt& operator=(const CoverArt&) = default;
     virtual ~CoverArt() override = default;
-// Visual Studio does not support default generated move constructors
-#if !defined(_MSC_VER)
+// Visual Studio does not support default generated move constructors yet
+#if !defined(_MSC_VER) || _MSC_VER > 1900
     CoverArt(CoverArt&&) = default;
     CoverArt& operator=(CoverArt&&) = default;
 #endif

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -32,8 +32,6 @@ class CoverInfoRelative {
     CoverInfoRelative();
 
     // all-default memory management
-    CoverInfoRelative(const CoverInfoRelative&) = default;
-    CoverInfoRelative& operator=(const CoverInfoRelative&) = default;
     virtual ~CoverInfoRelative() = default;
 // Visual Studio does not support default generated move constructors yet
 #if !defined(_MSC_VER) || _MSC_VER > 1900
@@ -61,8 +59,6 @@ class CoverInfo : public CoverInfoRelative {
     }
 
     // all-default memory management
-    CoverInfo(const CoverInfo&) = default;
-    CoverInfo& operator=(const CoverInfo&) = default;
     virtual ~CoverInfo() override = default;
 // Visual Studio does not support default generated move constructors yet
 #if !defined(_MSC_VER) || _MSC_VER > 1900
@@ -90,8 +86,6 @@ class CoverArt : public CoverInfo {
     }
 
     // all-default memory management
-    CoverArt(const CoverArt&) = default;
-    CoverArt& operator=(const CoverArt&) = default;
     virtual ~CoverArt() override = default;
 // Visual Studio does not support default generated move constructors yet
 #if !defined(_MSC_VER) || _MSC_VER > 1900

--- a/src/util/audiosignal.h
+++ b/src/util/audiosignal.h
@@ -72,8 +72,6 @@ public:
     }
 
     // all-default memory management
-    AudioSignal(const AudioSignal&) = default;
-    AudioSignal& operator=(const AudioSignal&) = default;
     virtual ~AudioSignal() = default;
 // Visual Studio does not support default generated move constructors yet
 #if !defined(_MSC_VER) || _MSC_VER > 1900

--- a/src/util/audiosignal.h
+++ b/src/util/audiosignal.h
@@ -72,6 +72,7 @@ public:
     }
 
     // all-default memory management
+    AudioSignal(const AudioSignal&) = default;
     virtual ~AudioSignal() = default;
 // Visual Studio does not support default generated move constructors yet
 #if !defined(_MSC_VER) || _MSC_VER > 1900

--- a/src/util/audiosignal.h
+++ b/src/util/audiosignal.h
@@ -75,8 +75,8 @@ public:
     AudioSignal(const AudioSignal&) = default;
     AudioSignal& operator=(const AudioSignal&) = default;
     virtual ~AudioSignal() = default;
-// Visual Studio does not support default generated move constructors
-#if !defined(_MSC_VER)
+// Visual Studio does not support default generated move constructors yet
+#if !defined(_MSC_VER) || _MSC_VER > 1900
     AudioSignal(AudioSignal&&) = default;
     AudioSignal& operator=(AudioSignal&&) = default;
 #endif


### PR DESCRIPTION
Follow-up on PR #1100.