### PR TITLE
Initial value for persistent ControlObjects

### DIFF
--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -32,7 +32,7 @@ ControlDoublePrivate::ControlDoublePrivate()
 ControlDoublePrivate::ControlDoublePrivate(ConfigKey key,
                                            ControlObject* pCreatorCO,
                                            bool bIgnoreNops, bool bTrack,
-                                           bool bPersist, double initialValue)
+                                           bool bPersist, double defaultValue)
         : m_key(key),
           m_bPersistInConfiguration(bPersist),
           m_bIgnoreNops(bIgnoreNops),
@@ -42,22 +42,18 @@ ControlDoublePrivate::ControlDoublePrivate(ConfigKey key,
                        Stat::SAMPLE_VARIANCE | Stat::MIN | Stat::MAX),
           m_confirmRequired(false),
           m_pCreatorCO(pCreatorCO) {
-    initialize(initialValue);
+    initialize(defaultValue);
 }
 
-void ControlDoublePrivate::initialize(double initialValue) {
-    double value = 0;
+void ControlDoublePrivate::initialize(double defaultValue) {
+    double value = defaultValue;
     if (m_bPersistInConfiguration) {
         UserSettingsPointer pConfig = ControlDoublePrivate::s_pUserConfig;
         if (pConfig != nullptr) {
-            bool conversionWorked;
-            value = pConfig->getValueString(m_key).toDouble(&conversionWorked);
-            if (!conversionWorked) {
-                value = initialValue;
-            }
+            value = pConfig->getValue(m_key, defaultValue);
         }
     }
-    m_defaultValue.setValue(0);
+    m_defaultValue.setValue(defaultValue);
     m_value.setValue(value);
 
     //qDebug() << "Creating:" << m_trackKey << "at" << &m_value << sizeof(m_value);
@@ -109,7 +105,7 @@ void ControlDoublePrivate::insertAlias(const ConfigKey& alias, const ConfigKey& 
 // static
 QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getControl(
         const ConfigKey& key, bool warn, ControlObject* pCreatorCO,
-        bool bIgnoreNops, bool bTrack, bool bPersist, double initialValue) {
+        bool bIgnoreNops, bool bTrack, bool bPersist, double defaultValue) {
     if (key.isEmpty()) {
         if (warn) {
             qWarning() << "ControlDoublePrivate::getControl returning NULL"
@@ -140,7 +136,7 @@ QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getControl(
         if (pCreatorCO) {
             pControl = QSharedPointer<ControlDoublePrivate>(
                     new ControlDoublePrivate(key, pCreatorCO, bIgnoreNops,
-                                             bTrack, bPersist, initialValue));
+                                             bTrack, bPersist, defaultValue));
             MMutexLocker locker(&s_qCOHashMutex);
             //qDebug() << "ControlDoublePrivate::s_qCOHash.insert(" << key.group << "," << key.item << ")";
             s_qCOHash.insert(key, pControl);

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -36,7 +36,7 @@ class ControlDoublePrivate : public QObject {
     static QSharedPointer<ControlDoublePrivate> getControl(
             const ConfigKey& key, bool warn = true,
             ControlObject* pCreatorCO = NULL, bool bIgnoreNops = true, bool bTrack = false,
-            bool bPersist = false, double initialValue = 0.0);
+            bool bPersist = false, double defaultValue = 0.0);
 
     // Adds all ControlDoublePrivate that currently exist to pControlList
     static void getControls(QList<QSharedPointer<ControlDoublePrivate> >* pControlsList);
@@ -127,8 +127,8 @@ class ControlDoublePrivate : public QObject {
   private:
     ControlDoublePrivate(ConfigKey key, ControlObject* pCreatorCO,
                          bool bIgnoreNops, bool bTrack, bool bPersist,
-                         double initialValue);
-    void initialize(double initialValue);
+                         double defaultValue);
+    void initialize(double defaultValue);
     void setInner(double value, QObject* pSender);
 
     ConfigKey m_key;

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -36,7 +36,7 @@ class ControlDoublePrivate : public QObject {
     static QSharedPointer<ControlDoublePrivate> getControl(
             const ConfigKey& key, bool warn = true,
             ControlObject* pCreatorCO = NULL, bool bIgnoreNops = true, bool bTrack = false,
-            bool bPersist = false);
+            bool bPersist = false, double initialValue = 0.0);
 
     // Adds all ControlDoublePrivate that currently exist to pControlList
     static void getControls(QList<QSharedPointer<ControlDoublePrivate> >* pControlsList);
@@ -126,8 +126,9 @@ class ControlDoublePrivate : public QObject {
 
   private:
     ControlDoublePrivate(ConfigKey key, ControlObject* pCreatorCO,
-                         bool bIgnoreNops, bool bTrack, bool bPersist);
-    void initialize();
+                         bool bIgnoreNops, bool bTrack, bool bPersist,
+                         double initialValue);
+    void initialize(double initialValue);
     void setInner(double value, QObject* pSender);
 
     ConfigKey m_key;

--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -29,8 +29,8 @@ ControlObject::ControlObject() {
 }
 
 ControlObject::ControlObject(ConfigKey key, bool bIgnoreNops, bool bTrack,
-                             bool bPersist, double initialValue) {
-    initialize(key, bIgnoreNops, bTrack, bPersist, initialValue);
+                             bool bPersist, double defaultValue) {
+    initialize(key, bIgnoreNops, bTrack, bPersist, defaultValue);
 }
 
 ControlObject::~ControlObject() {
@@ -40,14 +40,14 @@ ControlObject::~ControlObject() {
 }
 
 void ControlObject::initialize(ConfigKey key, bool bIgnoreNops, bool bTrack,
-                               bool bPersist, double initialValue) {
+                               bool bPersist, double defaultValue) {
     m_key = key;
 
     // Don't bother looking up the control if key is NULL. Prevents log spew.
     if (!m_key.isNull()) {
         m_pControl = ControlDoublePrivate::getControl(m_key, true, this,
                                                       bIgnoreNops, bTrack,
-                                                      bPersist, initialValue);
+                                                      bPersist, defaultValue);
     }
 
     // getControl can fail and return a NULL control even with the create flag.

--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -29,8 +29,8 @@ ControlObject::ControlObject() {
 }
 
 ControlObject::ControlObject(ConfigKey key, bool bIgnoreNops, bool bTrack,
-                             bool bPersist) {
-    initialize(key, bIgnoreNops, bTrack, bPersist);
+                             bool bPersist, double initialValue) {
+    initialize(key, bIgnoreNops, bTrack, bPersist, initialValue);
 }
 
 ControlObject::~ControlObject() {
@@ -40,14 +40,14 @@ ControlObject::~ControlObject() {
 }
 
 void ControlObject::initialize(ConfigKey key, bool bIgnoreNops, bool bTrack,
-                               bool bPersist) {
+                               bool bPersist, double initialValue) {
     m_key = key;
 
     // Don't bother looking up the control if key is NULL. Prevents log spew.
     if (!m_key.isNull()) {
         m_pControl = ControlDoublePrivate::getControl(m_key, true, this,
                                                       bIgnoreNops, bTrack,
-                                                      bPersist);
+                                                      bPersist, initialValue);
     }
 
     // getControl can fail and return a NULL control even with the create flag.

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -34,9 +34,11 @@ class ControlObject : public QObject {
     // bIgnoreNops: Don't emit a signal if the CO is set to its current value.
     // bTrack: Record statistics about this control.
     // bPersist: Store value on exit, load on startup.
+    // initialValue: value to set if bPersist is true but there is no value
+    //               stored in the config file
     ControlObject(ConfigKey key,
-                  bool bIgnoreNops=true, bool bTrack=false,
-                  bool bPersist=false);
+                  bool bIgnoreNops = true, bool bTrack = false,
+                  bool bPersist = false, double initialValue = 0.0);
     virtual ~ControlObject();
 
     // Returns a pointer to the ControlObject matching the given ConfigKey
@@ -176,7 +178,7 @@ class ControlObject : public QObject {
 
   private:
     void initialize(ConfigKey key, bool bIgnoreNops, bool bTrack,
-                    bool bPersist);
+                    bool bPersist, double initialValue);
     inline bool ignoreNops() const {
         return m_pControl ? m_pControl->ignoreNops() : true;
     }

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -34,11 +34,11 @@ class ControlObject : public QObject {
     // bIgnoreNops: Don't emit a signal if the CO is set to its current value.
     // bTrack: Record statistics about this control.
     // bPersist: Store value on exit, load on startup.
-    // initialValue: value to set if bPersist is true but there is no value
-    //               stored in the config file
+    // defaultValue: default value of CO. If CO is persistent and there is no valid
+    //               value found in the config, this is also the initial value.
     ControlObject(ConfigKey key,
                   bool bIgnoreNops = true, bool bTrack = false,
-                  bool bPersist = false, double initialValue = 0.0);
+                  bool bPersist = false, double defaultValue = 0.0);
     virtual ~ControlObject();
 
     // Returns a pointer to the ControlObject matching the given ConfigKey
@@ -178,7 +178,7 @@ class ControlObject : public QObject {
 
   private:
     void initialize(ConfigKey key, bool bIgnoreNops, bool bTrack,
-                    bool bPersist, double initialValue);
+                    bool bPersist, double defaultValue);
     inline bool ignoreNops() const {
         return m_pControl ? m_pControl->ignoreNops() : true;
     }

--- a/src/control/controlpushbutton.cpp
+++ b/src/control/controlpushbutton.cpp
@@ -21,8 +21,8 @@
    Purpose: Creates a new simulated latching push-button.
    Input:   key - Key for the configuration file
    -------- ------------------------------------------------------ */
-ControlPushButton::ControlPushButton(ConfigKey key, bool bPersist, double initialValue)
-        : ControlObject(key, false, false, bPersist, initialValue),
+ControlPushButton::ControlPushButton(ConfigKey key, bool bPersist, double defaultValue)
+        : ControlObject(key, false, false, bPersist, defaultValue),
           m_buttonMode(PUSH),
           m_iNoStates(2) {
     if (m_pControl) {

--- a/src/control/controlpushbutton.cpp
+++ b/src/control/controlpushbutton.cpp
@@ -21,8 +21,8 @@
    Purpose: Creates a new simulated latching push-button.
    Input:   key - Key for the configuration file
    -------- ------------------------------------------------------ */
-ControlPushButton::ControlPushButton(ConfigKey key, bool bPersist)
-        : ControlObject(key, false, false, bPersist),
+ControlPushButton::ControlPushButton(ConfigKey key, bool bPersist, double initialValue)
+        : ControlObject(key, false, false, bPersist, initialValue),
           m_buttonMode(PUSH),
           m_iNoStates(2) {
     if (m_pControl) {

--- a/src/control/controlpushbutton.h
+++ b/src/control/controlpushbutton.h
@@ -53,7 +53,7 @@ class ControlPushButton : public ControlObject {
         }
     }
 
-    ControlPushButton(ConfigKey key, bool bPersist = false, double initialValue = 0.0);
+    ControlPushButton(ConfigKey key, bool bPersist = false, double defaultValue = 0.0);
     virtual ~ControlPushButton();
 
     inline ButtonMode getButtonMode() const {

--- a/src/control/controlpushbutton.h
+++ b/src/control/controlpushbutton.h
@@ -53,7 +53,7 @@ class ControlPushButton : public ControlObject {
         }
     }
 
-    ControlPushButton(ConfigKey key, bool bPersist=false);
+    ControlPushButton(ConfigKey key, bool bPersist = false, double initialValue = 0.0);
     virtual ~ControlPushButton();
 
     inline ButtonMode getButtonMode() const {

--- a/src/test/controlobjecttest.cpp
+++ b/src/test/controlobjecttest.cpp
@@ -56,9 +56,29 @@ TEST_F(ControlObjectTest, persistence) {
     EXPECT_DOUBLE_EQ(3.0, testCo1->get());
 
     testCo1->set(5.0);
+
+    // simulate restarting Mixxx
     delete testCo1;
+    m_pConfig->save();
+    m_pConfig.clear();
+    m_pConfig = UserSettingsPointer(
+                    new UserSettings(getTestDataDir().filePath("test.cfg")));
+    ControlDoublePrivate::setUserConfig(m_pConfig);
+
     ControlObject* testCo2 = new ControlObject(ck, true, false, true, 3.0);
     EXPECT_DOUBLE_EQ(5.0, testCo2->get());
+
+    // simulate restarting Mixxx and
+    // a user editing the stored CO value to an invalid value
+    delete testCo2;
+    m_pConfig->set(ck, QString("NotANumber"));
+    m_pConfig->save();
+    m_pConfig.clear();
+    m_pConfig = UserSettingsPointer(
+                    new UserSettings(getTestDataDir().filePath("test.cfg")));
+    ControlDoublePrivate::setUserConfig(m_pConfig);
+    ControlObject* testCo3 = new ControlObject(ck, true, false, true, 3.0);
+    EXPECT_DOUBLE_EQ(3.0, testCo3->get());
 }
 
 }

--- a/src/test/controlobjecttest.cpp
+++ b/src/test/controlobjecttest.cpp
@@ -49,4 +49,16 @@ TEST_F(ControlObjectTest, aliasRetrieval) {
     EXPECT_EQ(ControlObject::getControl(ckAlias), co.get());
 }
 
+TEST_F(ControlObjectTest, persistence) {
+    ConfigKey ck("[Test]", "key");
+    ControlObject* testCo1 = new ControlObject(ck, true, false, true, 3.0);
+    // Should be initialized to default value with no valid value in config
+    EXPECT_DOUBLE_EQ(3.0, testCo1->get());
+
+    testCo1->set(5.0);
+    delete testCo1;
+    ControlObject* testCo2 = new ControlObject(ck, true, false, true, 3.0);
+    EXPECT_DOUBLE_EQ(5.0, testCo2->get());
+}
+
 }

--- a/src/test/controlobjecttest.cpp
+++ b/src/test/controlobjecttest.cpp
@@ -79,6 +79,7 @@ TEST_F(ControlObjectTest, persistence) {
     ControlDoublePrivate::setUserConfig(m_pConfig);
     ControlObject* testCo3 = new ControlObject(ck, true, false, true, 3.0);
     EXPECT_DOUBLE_EQ(3.0, testCo3->get());
+    delete testCo3;
 }
 
 }

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -65,6 +65,7 @@ MixxxTest::MixxxTest()
         : m_testDataDir(makeTestDir()),
           m_pConfig(new UserSettings(makeTestConfigFile(
               m_testDataDir.filePath("test.cfg")))) {
+    ControlDoublePrivate::setUserConfig(m_pConfig);
 }
 
 MixxxTest::~MixxxTest() {


### PR DESCRIPTION
This lets constructors specify an initial value for persistent ControlObjects when there is not a valid value found in mixxx.cfg. I have added support for this to ControlPushButton. Should I add it for other ControlObject subclasses too? If so, which ones?

The first planned use of this is for the EffectUnit deck assignment switches in #1103.