### PR TITLE
Keep row members of BaseSqlTableModel in sync

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -254,8 +254,10 @@ void BaseSqlTableModel::select() {
     // This causes a memory savings since QSqlCachedResult (what QtSQLite uses)
     // won't allocate a giant in-memory table that we won't use at all.
     query.setForwardOnly(true);
-    query.prepare(queryString);
-
+    if (!query.prepare(queryString)) {
+        LOG_FAILED_QUERY(query);
+        return;
+    }
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
         return;

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -185,6 +185,41 @@ bool BaseSqlTableModel::isColumnHiddenByDefault(int column) {
     return false;
 }
 
+void BaseSqlTableModel::clearRows() {
+    DEBUG_ASSERT(m_rowInfo.empty() == m_trackIdToRows.empty());
+    DEBUG_ASSERT(m_rowInfo.size() >= m_trackIdToRows.size());
+    if (!m_rowInfo.isEmpty()) {
+        beginRemoveRows(QModelIndex(), 0, m_rowInfo.size() - 1);
+        m_rowInfo.clear();
+        m_trackIdToRows.clear();
+        endRemoveRows();
+    }
+    DEBUG_ASSERT(m_rowInfo.isEmpty());
+    DEBUG_ASSERT(m_trackIdToRows.isEmpty());
+}
+
+void BaseSqlTableModel::replaceRows(
+            QVector<RowInfo>&& rows,
+            TrackId2Rows&& trackIdToRows) {
+    // NOTE(uklotzde): Use r-value references for parameters here, because
+    // conceptually those parameters should replace the corresponding internal
+    // member variables. Currently Qt4/5 doesn't support move semantics and
+    // instead prevents unnecessary deep copying by implicit sharing (COW)
+    // behind the scenes. Moving would be more efficient, although implicit
+    // sharing meets all requirements. If Qt will ever add move support for
+    // its container types in the future this code becomes even more efficient.
+    DEBUG_ASSERT(rows.empty() == trackIdToRows.empty());
+    DEBUG_ASSERT(rows.size() >= trackIdToRows.size());
+    if (rows.isEmpty()) {
+        clearRows();
+    } else {
+        beginInsertRows(QModelIndex(), 0, rows.size() - 1);
+        m_rowInfo = rows;
+        m_trackIdToRows = trackIdToRows;
+        endInsertRows();
+    }
+}
+
 void BaseSqlTableModel::select() {
     if (!m_bInitialized) {
         return;
@@ -226,20 +261,14 @@ void BaseSqlTableModel::select() {
         return;
     }
 
-    // Remove all the rows from the table. We wait to do this until after the
-    // table query has succeeded. See Bug #1090888.
+    // Remove all the rows from the table after(!) the query has been
+    // executed successfully. See Bug #1090888.
     // TODO(rryan) we could edit the table in place instead of clearing it?
-    if (!m_rowInfo.isEmpty()) {
-        beginRemoveRows(QModelIndex(), 0, m_rowInfo.size() - 1);
-        m_rowInfo.clear();
-        m_trackIdToRows.clear();
-        endRemoveRows();
-    }
-    // sqlite does not set size and m_rowInfo was just cleared
-    //if (sDebug) {
-    //    qDebug() << "Rows returned" << rows << m_rowInfo.size();
-    //}
+    clearRows();
 
+    // The size of the result set is not known in advance for a
+    // forward-only query, so we cannot reserve memory for rows
+    // in advance.
     QVector<RowInfo> rowInfo;
     QSet<TrackId> trackIds;
     while (query.next()) {
@@ -293,7 +322,7 @@ void BaseSqlTableModel::select() {
     // should not disturb that if we are only removing tracks.
     qStableSort(rowInfo.begin(), rowInfo.end());
 
-    m_trackIdToRows.clear();
+    TrackId2Rows trackIdToRows;
     for (int i = 0; i < rowInfo.size(); ++i) {
         const RowInfo& row = rowInfo[i];
 
@@ -303,19 +332,18 @@ void BaseSqlTableModel::select() {
             rowInfo.resize(i);
             break;
         }
-        QLinkedList<int>& rows = m_trackIdToRows[row.trackId];
-        rows.push_back(i);
+        trackIdToRows[row.trackId].push_back(i);
     }
 
     // We're done! Issue the update signals and replace the master maps.
-    if (!rowInfo.isEmpty()) {
-        beginInsertRows(QModelIndex(), 0, rowInfo.size() - 1);
-        m_rowInfo = rowInfo;
-        endInsertRows();
-    }
+    replaceRows(
+            std::move(rowInfo),
+            std::move(trackIdToRows));
+    // Both rowInfo and trackIdToRows (might) have been moved and
+    // must not be used afterwards!
 
     qDebug() << this << "select() took" << time.elapsed().debugMillisWithUnit()
-             << rowInfo.size();
+             << m_rowInfo.size();
 }
 
 void BaseSqlTableModel::setTable(const QString& tableName,

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -84,8 +84,6 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     void select();
 
   protected:
-    // Returns the row of trackId in this result set. If trackId is not present,
-    // returns -1.
     void setTable(const QString& tableName, const QString& trackIdColumn,
                   const QStringList& tableColumns,
                   QSharedPointer<BaseTrackCache> trackSource);

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -138,6 +138,13 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
         }
     };
 
+    typedef QHash<TrackId, QLinkedList<int>> TrackId2Rows;
+
+    void clearRows();
+    void replaceRows(
+            QVector<RowInfo>&& rows,
+            TrackId2Rows&& trackIdToRows);
+
     QVector<RowInfo> m_rowInfo;
 
     QString m_tableName;
@@ -150,7 +157,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     bool m_bInitialized;
     QSqlRecord m_queryRecord;
     QHash<TrackId, int> m_trackSortOrder;
-    QHash<TrackId, QLinkedList<int> > m_trackIdToRows;
+    TrackId2Rows m_trackIdToRows;
     QString m_currentSearch;
     QString m_currentSearchFilter;
     QVector<QHash<int, QVariant> > m_headerInfo;

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -68,7 +68,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     bool isColumnHiddenByDefault(int column) override;
     TrackPointer getTrack(const QModelIndex& index) const override;
     TrackId getTrackId(const QModelIndex& index) const override;
-    const QLinkedList<int> getTrackRows(TrackId trackId) const;
+    const QLinkedList<int> getTrackRows(TrackId trackId) const override;
     QString getTrackLocation(const QModelIndex& index) const override;
     void hideTracks(const QModelIndexList& indices) override;
     void search(const QString& searchText, const QString& extraFilter = QString()) override;

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -68,6 +68,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     bool isColumnHiddenByDefault(int column) override;
     TrackPointer getTrack(const QModelIndex& index) const override;
     TrackId getTrackId(const QModelIndex& index) const override;
+    const QLinkedList<int> getTrackRows(TrackId trackId) const;
     QString getTrackLocation(const QModelIndex& index) const override;
     void hideTracks(const QModelIndexList& indices) override;
     void search(const QString& searchText, const QString& extraFilter = QString()) override;
@@ -85,7 +86,6 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
   protected:
     // Returns the row of trackId in this result set. If trackId is not present,
     // returns -1.
-    const QLinkedList<int> getTrackRows(TrackId trackId) const;
     void setTable(const QString& tableName, const QString& trackIdColumn,
                   const QStringList& tableColumns,
                   QSharedPointer<BaseTrackCache> trackSource);

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -59,8 +59,8 @@ class TrackModel {
     // Gets the track ID of the track at the given QModelIndex
     virtual TrackId getTrackId(const QModelIndex& index) const = 0;
 
-    // Gets the row of the track in the current result set. Returns -1 if the
-    // track ID is not present in the result set.
+    // Gets the rows of the track in the current result set. Returns an
+    // empty list if the track ID is not present in the result set.
     virtual const QLinkedList<int> getTrackRows(TrackId trackId) const = 0;
 
     bool isTrackModel() { return true;}


### PR DESCRIPTION
This PR fixes some findings from the closed PR ["Replace QLinkedList with QVector"](https://github.com/mixxxdj/mixxx/pull/1056).

Both members m_rowInfo and m_trackIdToRow of BaseSqlTableModel are closely related and should always be modified together. Those operations were scattered in the select() function and have now been wrapped into two dedicated member functions clearRows()/replaceRows().