### PR TITLE
Metaknob soft takeover

### DIFF
--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -122,8 +122,9 @@ double EffectChainSlot::getSuperParameter() const {
     return m_pControlChainSuperParameter->get();
 }
 
-void EffectChainSlot::setSuperParameter(double value) {
+void EffectChainSlot::setSuperParameter(double value, bool force) {
     m_pControlChainSuperParameter->set(value);
+    slotControlChainSuperParameter(value, force);
 }
 
 void EffectChainSlot::setSuperParameterDefaultValue(double value) {
@@ -357,7 +358,7 @@ void EffectChainSlot::slotControlChainMix(double v) {
     }
 }
 
-void EffectChainSlot::slotControlChainSuperParameter(double v) {
+void EffectChainSlot::slotControlChainSuperParameter(double v, bool force) {
     //qDebug() << debugString() << "slotControlChainSuperParameter" << v;
 
     // Clamp to [0.0, 1.0]
@@ -367,7 +368,7 @@ void EffectChainSlot::slotControlChainSuperParameter(double v) {
         m_pControlChainSuperParameter->set(v);
     }
     for (const auto& pSlot : m_slots) {
-        pSlot->setMetaParameter(v);
+        pSlot->setMetaParameter(v, force);
     }
 }
 

--- a/src/effects/effectchainslot.h
+++ b/src/effects/effectchainslot.h
@@ -39,7 +39,7 @@ class EffectChainSlot : public QObject {
     void registerChannel(const ChannelHandleAndGroup& handle_group);
 
     double getSuperParameter() const;
-    void setSuperParameter(double value);
+    void setSuperParameter(double value, bool force = false);
     void setSuperParameterDefaultValue(double value);
 
     // Unload the loaded EffectChain.
@@ -107,7 +107,7 @@ class EffectChainSlot : public QObject {
     void slotControlClear(double v);
     void slotControlChainEnabled(double v);
     void slotControlChainMix(double v);
-    void slotControlChainSuperParameter(double v);
+    void slotControlChainSuperParameter(double v, bool force = false);
     void slotControlChainInsertionType(double v);
     void slotControlChainSelector(double v);
     void slotControlChainNextPreset(double v);

--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -218,7 +218,7 @@ void EffectParameterSlot::onEffectMetaParameterChanged(double parameter, bool fo
             parameter = 1.0 - parameter;
         }
 
-        // qDebug() << "onEffectMetaParameterChanged" << parameter;
+        //qDebug() << "onEffectMetaParameterChanged" << debugString() << parameter << "force?" << force;
         if (force) {
             m_pControlValue->setParameterFrom(parameter, NULL);
             // This ensures that softtakover is in sync for following updates

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -327,12 +327,8 @@ bool QuickEffectRack::loadEffectToGroup(const QString& groupName,
 
     pChain->replaceEffect(0, pEffect);
 
-    // Force update the new effect to match the current superknob position.
-    EffectSlotPointer pEffectSlot = pChainSlot->getEffectSlot(0);
-    if (pEffectSlot) {
-        pEffectSlot->slotEffectMetaParameter(
-                pChainSlot->getSuperParameter(), true);
-    }
+    // Force update metaknobs and parameters to match state of superknob
+    pChainSlot->setSuperParameter(pChainSlot->getSuperParameter(), true);
 
     if (pEffect != nullptr) {
         pEffect->setEnabled(true);

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -239,13 +239,18 @@ void EffectSlot::syncSofttakeover() {
     }
 }
 
+double EffectSlot::getMetaParameter() const {
+    return m_pControlMetaParameter->get();
+}
+
 // This function is for the superknob to update individual effects' meta knobs
 // slotEffectMetaParameter does not need to update m_pControlMetaParameter's value
-void EffectSlot::setMetaParameter(double v) {
-    if (!m_pSoftTakeover->ignore(m_pControlMetaParameter, v) ||
-        !m_pControlEnabled->toBool()) {
+void EffectSlot::setMetaParameter(double v, bool force) {
+    if (!m_pSoftTakeover->ignore(m_pControlMetaParameter, v)
+        || !m_pControlEnabled->toBool()
+        || force) {
         m_pControlMetaParameter->set(v);
-        slotEffectMetaParameter(v);
+        slotEffectMetaParameter(v, force);
     }
 }
 

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -8,6 +8,7 @@
 #include "control/controlobject.h"
 #include "control/controlpotmeter.h"
 #include "control/controlpushbutton.h"
+#include "controllers/softtakeover.h"
 #include "effects/effect.h"
 #include "effects/effectparameterslot.h"
 #include "effects/effectbuttonparameterslot.h"
@@ -107,6 +108,8 @@ class EffectSlot : public QObject {
     ControlPotmeter* m_pControlMetaParameter;
     QList<EffectParameterSlotPointer> m_parameters;
     QList<EffectButtonParameterSlotPointer> m_buttonParameters;
+
+    SoftTakeover* m_pSoftTakeover;
 
     DISALLOW_COPY_AND_ASSIGN(EffectSlot);
 };

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -38,6 +38,8 @@ class EffectSlot : public QObject {
     EffectButtonParameterSlotPointer addEffectButtonParameterSlot();
     EffectButtonParameterSlotPointer getEffectButtonParameterSlot(unsigned int slotNumber);
 
+    double getMetaParameter() const;
+
     // ensures that Softtakover is bypassed for the following
     // ChainParameterChange. Uses for testing only
     void syncSofttakeover();
@@ -52,7 +54,7 @@ class EffectSlot : public QObject {
   public slots:
     // Request that this EffectSlot load the given Effect
     void loadEffect(EffectPointer pEffect);
-    void setMetaParameter(double v);
+    void setMetaParameter(double v, bool force = false);
 
     void slotEnabled(double v);
     void slotNextEffect(double v);


### PR DESCRIPTION
Follow-up from discussion on #1062:
* When an effect is on, do not make parameters audibly jump when metaknob changes. If the superknob is turned, do not make metaknobs jump for effects that are on.
* When an effect is off, do not do any automatic soft takeover. Snap parameters to position of metaknob when the metaknob turns (either directly or by the superknob). With #1103, this does not interfere with loading initial states of knobs from controllers when Mixxx starts. It also makes it easier to experiment with different metaknob linkings.