### PR TITLE
Fix the reverb effect

### DIFF
--- a/lib/reverb/basics.h
+++ b/lib/reverb/basics.h
@@ -29,8 +29,8 @@
 	02111-1307, USA or point your web browser to http://www.gnu.org.
 */
 
-#ifndef _BASICS_H_
-#define _BASICS_H_
+#ifndef BASICS_H
+#define BASICS_H
 
 // NOTE(rryan): 3/2014 Added for MSVC support. (missing M_PI)
 #define _USE_MATH_DEFINES
@@ -59,9 +59,9 @@ typedef quint32 uint32;
 typedef qint64 int64;
 typedef quint64 uint64;
 
-#define MIN_GAIN .000001 /* -120 dB */
+#define MIN_GAIN 1e-6 /* -120 dB */
 /* smallest non-denormal 32 bit IEEE float is 1.18e-38 */
-#define NOISE_FLOOR .00000000000005 /* -266 dB */
+#define NOISE_FLOOR 1e-20 /* -400 dB */
 
 /* //////////////////////////////////////////////////////////////////////// */
 
@@ -71,29 +71,9 @@ typedef unsigned long ulong;
 /* prototype that takes a sample and yields a sample */
 typedef CSAMPLE (*clip_func_t) (CSAMPLE);
 
-/* flavours for sample store functions run() and run_adding() */
-typedef void (*yield_func_t) (CSAMPLE *, uint, CSAMPLE, CSAMPLE);
-
-inline void
-adding_func (CSAMPLE * s, uint i, CSAMPLE x, CSAMPLE gain)
-{
-	s[i] += gain * x;
-}
-
 #ifndef max
-
-template <class X, class Y>
-X min (X x, Y y)
-{
-	return x < y ? x : (X) y;
-}
-
-template <class X, class Y>
-X max (X x, Y y)
-{
-	return x > y ? x : (X) y;
-}
-
+template <class X, class Y> X min (X x, Y y) { return x < (X)y ? x : (X)y; }
+template <class X, class Y> X max (X x, Y y) { return x > (X)y ? x : (X)y; }
 #endif /* ! max */
 
 template <class T>
@@ -104,11 +84,8 @@ T clamp (T value, T lower, T upper)
 	return value;
 }
 
-static inline float
-frandom()
-{
-	return (float) rand() / (float) RAND_MAX;
-}
+// (timrae) change random() to rand() for MSVC support
+static inline float frandom() { return (float) rand() / (float) RAND_MAX; }
 
 /* NB: also true if 0  */
 inline bool
@@ -144,18 +121,9 @@ next_power_of_2 (uint n)
 	return ++n;
 }
 
-inline double
-db2lin (double db)
-{
-	return pow(10, db*.05);
-}
-
-inline double
-lin2db (double lin)
-{
-	return 20*log10(lin);
-}
+inline double db2lin (double db) { return pow(10, .05*db); }
+inline double lin2db (double lin) { return 20*log10(lin); }
 
 /* //////////////////////////////////////////////////////////////////////// */
 
-#endif /* _BASICS_H_ */
+#endif /* BASICS_H */

--- a/lib/reverb/dsp/IIR1.h
+++ b/lib/reverb/dsp/IIR1.h
@@ -1,11 +1,11 @@
 /*
 	dsp/OnePole.h
-	
-	Copyright 2003-13 Tim Goetze <tim@quitte.de>
-	
+
+	Copyright 2003-14 Tim Goetze <tim@quitte.de>
+
 	http://quitte.de/dsp/
 
-	one pole (or one zero, or one zero, one pole) hi- and lo-pass filters.
+	first-order IIR hi- and lo-pass filters.
 
 */
 /*
@@ -25,62 +25,58 @@
 	02111-1307, USA or point your web browser to http://www.gnu.org.
 */
 
-#ifndef _ONE_POLE_H_
-#define _ONE_POLE_H_
+#ifndef IIR1_H
+#define IIR1_H
 
 namespace DSP {
-	
+
 template <class T>
-class OnePoleLP
+class LP1
 {
 	public:
 		T a0, b1, y1;
 
-		OnePoleLP (double d = 1.)
+		LP1 (double d = 1.)
 			{
 				set (d);
 				y1 = 0.;
 			}
 
-		inline void reset()
+		sample_t last() {return y1;}
+		inline void reset() { y1 = 0.; }
+
+		inline void decay (T d)
 			{
-				y1 = 0.;
+				a0 *= d;
+				b1 = 1. - a0;
 			}
 
 		inline void set_f (T fc)
 			{
 				set (1 - exp(-2*M_PI*fc));
 			}
-
 		inline void set (T d)
 			{
 				a0 = d;
 				b1 = 1 - d;
 			}
 
-		inline T process (T x)
-			{
-				return y1 = a0*x + b1*y1;
-			}
-		
-		inline void decay (T d)
-			{
-				a0 *= d;
-				b1 = 1. - a0;
-			}
+		inline T process (T x) { return y1 = a0*x + b1*y1; }
 };
 
 template <class T>
-class OnePoleHP
+class HP1
 {
 	public:
 		T a0, a1, b1, x1, y1;
 
-		OnePoleHP (T d = 1.)
+		HP1 (T d = 1.)
 			{
 				set (d);
-				x1 = y1 = 0.;
+				reset();
 			}
+
+		sample_t last() {return y1;}
 
 		void set_f (T f)
 			{
@@ -115,4 +111,4 @@ class OnePoleHP
 
 } /* namespace DSP */
 
-#endif /* _ONE_POLE_H_ */
+#endif /* IIR1 */

--- a/lib/reverb/dsp/Sine.h
+++ b/lib/reverb/dsp/Sine.h
@@ -1,11 +1,11 @@
 /*
 	dsp/Sine.h
-	
-	Copyright 2003-13 Tim Goetze <tim@quitte.de>
-	
+
+	Copyright 2003-14 Tim Goetze <tim@quitte.de>
+
 	http://quitte.de/dsp/
 
-	Direct form I recursive sin() generator.  Utilising doubles 
+	Direct form I recursive sin() generator.  Utilising doubles
 	for stability.
 
 */
@@ -26,11 +26,11 @@
 	02111-1307, USA or point your web browser to http://www.gnu.org.
 */
 
-#ifndef _DSP_SINE_H_
-#define _DSP_SINE_H_
+#ifndef DSP_SINE_H
+#define DSP_SINE_H
 
 namespace DSP {
-	
+
 class Sine
 {
 	public:
@@ -40,7 +40,7 @@ class Sine
 
 	public:
 		Sine()
-			{ 
+			{
 				b = 0;
 				y[0] = y[1] = 0;
 				z = 0;
@@ -63,16 +63,16 @@ class Sine
 
 		inline void set_f (double w, double phase)
 			{
-				b = 2 * cos (w);
+				b = 2*cos(w);
 				y[0] = sin (phase - w);
-				y[1] = sin (phase - w * 2);
+				y[1] = sin (phase - 2*w);
 				z = 0;
 			}
 
 		/* advance and return 1 sample */
 		inline double get()
 			{
-				register double s = b * y[z]; 
+				register double s = b*y[z];
 				z ^= 1;
 				s -= y[z];
 				return y[z] = s;
@@ -80,14 +80,11 @@ class Sine
 
 		double get_phase()
 			{
-				double x0 = y[z], x1 = b * y[z] - y[z^1];
-				double phi = asin (x0);
-				
-				/* slope is falling, we're into the 2nd half. */
-				if (x1 < x0)
-					return M_PI - phi;
+				double x0 = y[z], x1 = b*y[z] - y[z^1];
+				double phi = asin(x0);
 
-				return phi;
+				/* slope is falling: into the 2nd half. */
+				return x1 < x0 ? M_PI - phi : phi;
 			}
 };
 
@@ -104,7 +101,7 @@ class DampedSine
 
 		inline double get()
 			{
-				register double s = b * y[z]; 
+				register double s = b * y[z];
 				z ^= 1;
 				s -= d * y[z];
 				return y[z] = d * s;
@@ -113,4 +110,4 @@ class DampedSine
 
 } /* namespace DSP */
 
-#endif /* _DSP_SINE_H_ */
+#endif /* DSP_SINE_H */

--- a/src/effects/native/reverbeffect.cpp
+++ b/src/effects/native/reverbeffect.cpp
@@ -23,40 +23,63 @@ EffectManifest ReverbEffect::getManifest() {
             "reverberators, which use networks of simple allpass and comb"
             "delay filters.");
 
-    EffectManifestParameter* time = manifest.addParameter();
-    time->setId("bandwidth");
-    time->setName(QObject::tr("Bandwidth"));
-    time->setShortName(QObject::tr("BW"));
-    time->setDescription(QObject::tr("Higher bandwidth values cause more "
-            "bright (high-frequency) tones to be included"));
-    time->setControlHint(EffectManifestParameter::CONTROL_KNOB_LINEAR);
-    time->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
-    time->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
-    time->setDefaultLinkType(EffectManifestParameter::LINK_LINKED);
-    time->setDefaultLinkInversion(EffectManifestParameter::LinkInversion::INVERTED);
-    time->setMinimum(0.0005);
-    time->setDefault(0.5);
-    time->setMaximum(1.0);
+    EffectManifestParameter* decay = manifest.addParameter();
+    decay->setId("decay");
+    decay->setName(QObject::tr("Decay"));
+    decay->setDescription(QObject::tr("Lower decay values cause reverberations to die out more quickly."));
+    decay->setControlHint(EffectManifestParameter::CONTROL_KNOB_LINEAR);
+    decay->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
+    decay->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
+    decay->setMinimum(0);
+    decay->setDefault(0.5);
+    decay->setMaximum(1);
+
+    EffectManifestParameter* bandwidth = manifest.addParameter();
+    bandwidth->setId("bandwidth");
+    bandwidth->setName(QObject::tr("Bandwidth"));
+    bandwidth->setShortName(QObject::tr("BW"));
+    bandwidth->setDescription(QObject::tr("Bandwidth of the low pass filter at the input. "
+            "Higher values result in less attenuation of high frequencies."));
+    bandwidth->setControlHint(EffectManifestParameter::CONTROL_KNOB_LINEAR);
+    bandwidth->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
+    bandwidth->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
+    bandwidth->setMinimum(0);
+    bandwidth->setDefault(1);
+    bandwidth->setMaximum(1);
 
     EffectManifestParameter* damping = manifest.addParameter();
     damping->setId("damping");
     damping->setName(QObject::tr("Damping"));
     damping->setDescription(QObject::tr("Higher damping values cause "
-            "reverberations to die out more quickly."));
+            "high frequencies to decay more quickly than low frequencies."));
     damping->setControlHint(EffectManifestParameter::CONTROL_KNOB_LINEAR);
     damping->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
     damping->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
-    damping->setMinimum(0.005);
-    damping->setDefault(0.5);
-    damping->setMaximum(1.0);
+    damping->setMinimum(0);
+    damping->setDefault(0);
+    damping->setMaximum(1);
 
+    EffectManifestParameter* send = manifest.addParameter();
+    send->setId("send_amount");
+    send->setName(QObject::tr("Send"));
+    send->setDescription(QObject::tr("How much of the signal to send to the effect"));
+    send->setControlHint(EffectManifestParameter::CONTROL_KNOB_LINEAR);
+    send->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
+    send->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
+    send->setDefaultLinkType(EffectManifestParameter::LINK_LINKED);
+    send->setDefaultLinkInversion(EffectManifestParameter::LinkInversion::NOT_INVERTED);
+    send->setMinimum(0);
+    send->setDefault(0);
+    send->setMaximum(1);
     return manifest;
 }
 
 ReverbEffect::ReverbEffect(EngineEffect* pEffect,
                              const EffectManifest& manifest)
-        : m_pBandWidthParameter(pEffect->getParameterById("bandwidth")),
-          m_pDampingParameter(pEffect->getParameterById("damping")) {
+        : m_pDecayParameter(pEffect->getParameterById("decay")),
+          m_pBandWidthParameter(pEffect->getParameterById("bandwidth")),
+          m_pDampingParameter(pEffect->getParameterById("damping")),
+          m_pSendParameter(pEffect->getParameterById("send_amount")) {
     Q_UNUSED(manifest);
 }
 
@@ -74,48 +97,21 @@ void ReverbEffect::processChannel(const ChannelHandle& handle,
     Q_UNUSED(handle);
     Q_UNUSED(enableState);
     Q_UNUSED(groupFeatures);
-    Q_UNUSED(sampleRate);
-    CSAMPLE bandwidth = m_pBandWidthParameter->value();
-    CSAMPLE damping = m_pDampingParameter->value();
 
-    // Flip value around.  Assumes max allowable is 1.0.
-    damping = 1.0 - damping;
-
-    bool params_changed = (damping != pState->prev_damping ||
-                           bandwidth != pState->prev_bandwidth);
-
-    pState->reverb.setBandwidth(bandwidth);
-    pState->reverb.setDecay(damping);
-
-    for (uint i = 0; i + 1 < numSamples; i += 2) {
-        CSAMPLE mono_sample = (pInput[i] + pInput[i + 1]) / 2;
-        CSAMPLE xl, xr;
-
-        // sample_t is typedefed to be the same as CSAMPLE, so no cast needed.
-        pState->reverb.process(mono_sample, damping, &xl, &xr);
-
-        pOutput[i] = xl;
-        pOutput[i + 1] = xr;
+    if (!pState || !m_pDecayParameter || !m_pBandWidthParameter || !m_pDampingParameter || !m_pSendParameter) {
+        qWarning() << "Could not retrieve all effect parameters";
+        return;
     }
 
-    if (params_changed) {
-        pState->reverb.setBandwidth(pState->prev_bandwidth);
-        pState->reverb.setDecay(pState->prev_damping);
+    const auto decay = m_pDecayParameter->value();
+    const auto bandwidth = m_pBandWidthParameter->value();
+    const auto damping = m_pDampingParameter->value();
+    const auto send = m_pSendParameter->value();
 
-        for (uint i = 0; i + 1 < numSamples; i += 2) {
-            CSAMPLE mono_sample = (pInput[i] + pInput[i + 1]) / 2;
-            CSAMPLE xl, xr;
-
-            pState->reverb.process(mono_sample, pState->prev_damping, &xl, &xr);
-
-            pState->crossfade_buffer[i] = xl;
-            pState->crossfade_buffer[i + 1] = xr;
-        }
-
-        pState->prev_bandwidth = bandwidth;
-        pState->prev_damping = damping;
-
-        SampleUtil::linearCrossfadeBuffers(
-                pOutput, pOutput, pState->crossfade_buffer, numSamples);
+    if (pState->sampleRate != sampleRate) {
+        // update the sample rate if it's changed
+        pState->reverb.init(sampleRate);
+        pState->sampleRate = sampleRate;
     }
+    pState->reverb.processBuffer(pInput, pOutput, numSamples, bandwidth, decay, damping, send);
 }

--- a/src/effects/native/reverbeffect.h
+++ b/src/effects/native/reverbeffect.h
@@ -17,23 +17,8 @@
 #include "util/types.h"
 
 struct ReverbGroupState {
-    ReverbGroupState() {
-        // Default damping value.
-        prev_bandwidth = 0.5;
-        prev_damping = 0.5;
-        reverb.init();
-        reverb.activate();
-        crossfade_buffer = SampleUtil::alloc(MAX_BUFFER_LEN);
-    }
-
-    ~ReverbGroupState() {
-        SampleUtil::free(crossfade_buffer);
-    }
-
-    MixxxPlateX2 reverb;
-    CSAMPLE* crossfade_buffer;
-    double prev_bandwidth;
-    double prev_damping;
+    float sampleRate  = 0;
+    MixxxPlateX2 reverb{};
 };
 
 class ReverbEffect : public PerChannelEffectProcessor<ReverbGroupState> {
@@ -58,8 +43,10 @@ class ReverbEffect : public PerChannelEffectProcessor<ReverbGroupState> {
         return getId();
     }
 
+    EngineEffectParameter* m_pDecayParameter;
     EngineEffectParameter* m_pBandWidthParameter;
     EngineEffectParameter* m_pDampingParameter;
+    EngineEffectParameter* m_pSendParameter;
 
     DISALLOW_COPY_AND_ASSIGN(ReverbEffect);
 };


### PR DESCRIPTION
The previous implementation of the reverb effect was suffering from serious artifacts in terms of feedback / distortion that the original LADSPA plugin doesn't suffer from:
https://bugs.launchpad.net/mixxx/+bug/1647568

I updated the code base to use the latest version (0.9.24) from the original author (http://quitte.de/dsp/caps.html), and in doing this I disabled the unused code with preprocessor directives instead of deleting it, in order to make it easier to update in the future.

Next I tried to track down where the bug was. It turns out that the `SampleUtil::linearCrossfadeBuffers()` call was causing all the feedback problems, and it seems to be safe to remove this.

This commit also adds the missing two controls for damping and blend, and remaps the meta knob from bandwidth to blend, which fixes the following bug:
https://bugs.launchpad.net/mixxx/+bug/1647775