### PR TITLE
reload only effect being updated instead of each effect in chain

### DIFF
--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -95,9 +95,6 @@ EffectChainPointer EffectChain::clone(EffectChainPointer pChain) {
     pClone->setEnabled(pChain->enabled());
     pClone->setName(pChain->name());
     pClone->setMix(pChain->mix());
-    foreach (const ChannelHandleAndGroup& handle_group, pChain->enabledChannels()) {
-        pClone->enableForChannel(handle_group);
-    }
     foreach (EffectPointer pEffect, pChain->effects()) {
         EffectPointer pClonedEffect = pChain->m_pEffectsManager
                 ->instantiateEffect(pEffect->getManifest().id());
@@ -212,7 +209,7 @@ void EffectChain::addEffect(EffectPointer pEffect) {
     if (m_bAddedToEngine) {
         pEffect->addToEngine(m_pEngineEffectChain, m_effects.size() - 1);
     }
-    emit(effectsChanged());
+    emit(effectChanged(m_effects.size() - 1));
 }
 
 void EffectChain::replaceEffect(unsigned int effectSlotNumber,
@@ -240,7 +237,7 @@ void EffectChain::replaceEffect(unsigned int effectSlotNumber,
         }
     }
 
-    emit(effectsChanged());
+    emit(effectChanged(effectSlotNumber));
 }
 
 void EffectChain::removeEffect(unsigned int effectSlotNumber) {

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -92,10 +92,10 @@ EffectChainPointer EffectChain::clone(EffectChainPointer pChain) {
 
     EffectChain* pClone = new EffectChain(
         pChain->m_pEffectsManager, pChain->id(), pChain);
-    pClone->setEnabled(pChain->enabled());
     pClone->setName(pChain->name());
-    pClone->setMix(pChain->mix());
-    foreach (EffectPointer pEffect, pChain->effects()) {
+    // Do not set the state of the chain because that information belongs
+    // to the EffectChainSlot. Leave that to EffectChainSlot::loadEffectChain.
+    for (const auto& pEffect : pChain->effects()) {
         EffectPointer pClonedEffect = pChain->m_pEffectsManager
                 ->instantiateEffect(pEffect->getManifest().id());
         pClone->addEffect(pClonedEffect);

--- a/src/effects/effectchain.h
+++ b/src/effects/effectchain.h
@@ -100,7 +100,7 @@ class EffectChain : public QObject {
 
   signals:
     // Signal that indicates that an effect has been added or removed.
-    void effectsChanged();
+    void effectChanged(unsigned int effectSlotNumber);
     void nameChanged(const QString& name);
     void descriptionChanged(const QString& name);
     void enabledChanged(bool enabled);

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -162,21 +162,28 @@ void EffectChainSlot::slotChainEffectChanged(unsigned int effectSlotNumber,
                                              bool shouldEmit) {
     //qDebug() << debugString() << "slotChainEffectChanged" << effectSlotNumber;
     if (m_pEffectChain) {
-        QList<EffectPointer> effects = m_pEffectChain->effects();
+        const QList<EffectPointer> effects = m_pEffectChain->effects();
+        EffectSlotPointer pSlot;
+        EffectPointer pEffect;
+
         if (effects.size() > m_slots.size()) {
             qWarning() << debugString() << "has too few slots for effect";
         }
-        EffectSlotPointer pSlot = m_slots[effectSlotNumber];
-        EffectPointer pEffect;
-        if (effectSlotNumber < (unsigned) effects.size()) {
-            pEffect = effects[effectSlotNumber];
+
+        if (effectSlotNumber < (unsigned) m_slots.size()) {
+            pSlot = m_slots.at(effectSlotNumber);
         }
-        if (pSlot) {
+        if (effectSlotNumber < (unsigned) effects.size()) {
+            pEffect = effects.at(effectSlotNumber);
+        }
+        if (pSlot != nullptr) {
             pSlot->loadEffect(pEffect);
         }
+
         m_pControlNumEffects->forceSet(math_min(
             static_cast<unsigned int>(m_slots.size()),
             m_pEffectChain->numEffects()));
+
         if (shouldEmit) {
             emit(updated());
         }

--- a/src/effects/effectchainslot.h
+++ b/src/effects/effectchainslot.h
@@ -93,7 +93,7 @@ class EffectChainSlot : public QObject {
 
 
   private slots:
-    void slotChainEffectsChanged(bool shouldEmit=true);
+    void slotChainEffectChanged(unsigned int effectSlotNumber, bool shouldEmit=true);
     void slotChainNameChanged(const QString& name);
     void slotChainEnabledChanged(bool enabled);
     void slotChainMixChanged(double mix);


### PR DESCRIPTION
Before, metaknob linkings of every effect in a chain would be reset to default when loading a different effect to any position in the chain. Also, the parameter name labels of effects that were not being replaced would flicker on screen.

fixes
https://bugs.launchpad.net/mixxx/+bug/1655523