### PR TITLE
M4A/AAC: Fix seeking backwards

### DIFF
--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -158,12 +158,12 @@ SoundSourceM4A::SoundSourceM4A(const QUrl& url)
           m_hFile(MP4_INVALID_FILE_HANDLE),
           m_trackId(MP4_INVALID_TRACK_ID),
           m_framesPerSampleBlock(MP4_INVALID_DURATION),
-          m_numberOfPrefetchSampleBlocks(0),
           m_maxSampleBlockId(MP4_INVALID_SAMPLE_ID),
-          m_curSampleBlockId(MP4_INVALID_SAMPLE_ID),
           m_inputBufferLength(0),
           m_inputBufferOffset(0),
           m_hDecoder(nullptr),
+          m_numberOfPrefetchSampleBlocks(0),
+          m_curSampleBlockId(MP4_INVALID_SAMPLE_ID),
           m_curFrameIndex(getMinFrameIndex()) {
 }
 

--- a/plugins/soundsourcem4a/soundsourcem4a.h
+++ b/plugins/soundsourcem4a/soundsourcem4a.h
@@ -39,9 +39,7 @@ private:
     MP4FileHandle m_hFile;
     MP4TrackId m_trackId;
     MP4Duration m_framesPerSampleBlock;
-    SINT m_numberOfPrefetchSampleBlocks;
     MP4SampleId m_maxSampleBlockId;
-    MP4SampleId m_curSampleBlockId;
 
     typedef std::vector<u_int8_t> InputBuffer;
     InputBuffer m_inputBuffer;
@@ -49,6 +47,8 @@ private:
     SINT m_inputBufferOffset;
 
     NeAACDecHandle m_hDecoder;
+    SINT m_numberOfPrefetchSampleBlocks;
+    MP4SampleId m_curSampleBlockId;
 
     SingularSampleBuffer m_sampleBuffer;
 

--- a/plugins/soundsourcem4a/soundsourcem4a.h
+++ b/plugins/soundsourcem4a/soundsourcem4a.h
@@ -32,6 +32,10 @@ public:
 private:
     OpenResult tryOpen(const AudioSourceConfig& audioSrcCfg) override;
 
+    bool openDecoder();
+    void closeDecoder();
+    bool reopenDecoder();
+
     bool isValidSampleBlockId(MP4SampleId sampleBlockId) const;
 
     void restartDecoding(MP4SampleId sampleBlockId);
@@ -45,6 +49,8 @@ private:
     InputBuffer m_inputBuffer;
     SINT m_inputBufferLength;
     SINT m_inputBufferOffset;
+
+    AudioSourceConfig m_audioSrcCfg;
 
     NeAACDecHandle m_hDecoder;
     SINT m_numberOfPrefetchSampleBlocks;

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -173,7 +173,7 @@ SINT SoundSourceMediaFoundation::seekSampleFrame(
     // sample accurate decoding. The decoder needs to decode
     // some frames in advance to produce the same result at
     // each position in the stream.
-    SINT seekIndex = std::max(SINT(frameIndex - kNumberOfPrefetchFrames), SINT(0));
+    SINT seekIndex = std::max(SINT(frameIndex - kNumberOfPrefetchFrames), AudioSource::getMinFrameIndex());
 
     LONGLONG seekPos = m_streamUnitConverter.fromFrameIndex(seekIndex);
     DEBUG_ASSERT(seekPos >= 0);

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -194,22 +194,29 @@ SINT SoundSourceMediaFoundation::seekSampleFrame(
         //   "After seeking, the application should call IMFSourceReader::ReadSample
         //    and advance to the desired position.
         SINT skipFramesCount = frameIndex - seekIndex;
-        // We need to fetch at least 1 sample from the reader to obtain the
-        // current position!
-        DEBUG_ASSERT(skipFramesCount > 0);
-        skipSampleFrames(skipFramesCount);
-        // Now m_currentFrameIndex reflects the actual position of the reader
-        if (m_currentFrameIndex < frameIndex) {
-            // Skip more samples if frameIndex has not yet been reached
-            skipSampleFrames(frameIndex - m_currentFrameIndex);
-        }
-        if (m_currentFrameIndex != frameIndex) {
-            qWarning() << kLogPreamble
-                    << "Seek to frame"
-                    << frameIndex
-                    << "failed";
-            // Jump to end of stream (= invalidate current position)
-            m_currentFrameIndex = getMaxFrameIndex();
+        if (skipFramesCount > 0) {
+            // We need to fetch at least 1 sample from the reader to obtain the
+            // current position!
+            skipSampleFrames(skipFramesCount);
+            // Now m_currentFrameIndex reflects the actual position of the reader
+            if (m_currentFrameIndex < frameIndex) {
+                // Skip more samples if frameIndex has not yet been reached
+                skipSampleFrames(frameIndex - m_currentFrameIndex);
+            }
+            if (m_currentFrameIndex != frameIndex) {
+                qWarning() << kLogPreamble
+                        << "Seek to frame"
+                        << frameIndex
+                        << "failed";
+                // Jump to end of stream (= invalidate current position)
+                m_currentFrameIndex = getMaxFrameIndex();
+            }
+        } else {
+            // We are at the beginning of the stream and don't need
+            // to skip any frames. Calling IMFSourceReader::ReadSample
+            // is not necessary in this special case.
+            DEBUG_ASSERT(frameIndex == AudioSource::getMinFrameIndex());
+            m_currentFrameIndex = frameIndex;
         }
     } else {
         qWarning() << kLogPreamble

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
@@ -32,12 +32,13 @@ class StreamUnitConverter final {
         // Used for seeking, so we need to round down to hit the
         // corresponding stream unit where the given stream unit
         // starts
-        return floor(frameIndex * m_streamUnitsPerFrame);
+        return floor((frameIndex - AudioSource::getMinFrameIndex()) * m_streamUnitsPerFrame);
     }
 
     SINT toFrameIndex(LONGLONG streamPos) const {
         // NOTE(uklotzde): Add m_toFrameIndexBias to account for rounding errors
-        return floor((streamPos + m_toFrameIndexBias) / m_streamUnitsPerFrame);
+        return AudioSource::getMinFrameIndex() +
+                static_cast<SINT>(floor((streamPos + m_toFrameIndexBias) / m_streamUnitsPerFrame));
     }
 
   private:

--- a/src/util/audiosignal.h
+++ b/src/util/audiosignal.h
@@ -71,14 +71,7 @@ public:
         DEBUG_ASSERT(kSamplingRateZero <= m_samplingRate); // unsigned value
     }
 
-    // all-default memory management
-    AudioSignal(const AudioSignal&) = default;
     virtual ~AudioSignal() = default;
-// Visual Studio does not support default generated move constructors yet
-#if !defined(_MSC_VER) || _MSC_VER > 1900
-    AudioSignal(AudioSignal&&) = default;
-    AudioSignal& operator=(AudioSignal&&) = default;
-#endif
 
     // Returns the ordering of samples in contiguous buffers
     SampleLayout getSampleLayout() const {


### PR DESCRIPTION
While working on the SoundSourceMediaFoundation plugin I noticed that we don't have a test for seeking backwards. I extended the existing test and it turned out that FAAD2 is not sample accurate when seeking to a position near the beginning of the stream.

Workaround/Fix: Reopen the AAC decoder when seeking to a position near the beginning of the stream.

Update: Discovered and fixed a bug in SoundSourceMediaFoundation when seeking backwards to the beginning of the stream.