### PR TITLE
Remove impicit invert from LINK_LINKED_LEFT

### DIFF
--- a/src/effects/effectparameterslot.cpp
+++ b/src/effects/effectparameterslot.cpp
@@ -180,10 +180,9 @@ void EffectParameterSlot::onEffectMetaParameterChanged(double parameter, bool fo
                 break;
             case EffectManifestParameter::LINK_LINKED_LEFT:
                 if (parameter >= 0.5 && parameter <= 1.0) {
-                    parameter = 0;
+                    parameter = 1;
                 } else if (parameter >= 0.0 && parameter <= 0.5) {
                     parameter *= 2;
-                    parameter = 1.0 - parameter;
                 } else {
                     return;
                 }

--- a/src/effects/native/filtereffect.cpp
+++ b/src/effects/native/filtereffect.cpp
@@ -30,7 +30,6 @@ EffectManifest FilterEffect::getManifest() {
     lpf->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
     lpf->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
     lpf->setDefaultLinkType(EffectManifestParameter::LINK_LINKED_LEFT);
-    lpf->setDefaultLinkInversion(EffectManifestParameter::LinkInversion::INVERTED);
     lpf->setNeutralPointOnScale(1);
     lpf->setDefault(kMaxCorner);
     lpf->setMinimum(kMinCorner);

--- a/src/effects/native/moogladder4filtereffect.cpp
+++ b/src/effects/native/moogladder4filtereffect.cpp
@@ -32,7 +32,6 @@ EffectManifest MoogLadder4FilterEffect::getManifest() {
     lpf->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
     lpf->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
     lpf->setDefaultLinkType(EffectManifestParameter::LINK_LINKED_LEFT);
-    lpf->setDefaultLinkInversion(EffectManifestParameter::LinkInversion::INVERTED);
     lpf->setNeutralPointOnScale(1);
     lpf->setDefault(kMaxCorner);
     lpf->setMinimum(kMinCorner);

--- a/src/test/metaknob_link_test.cpp
+++ b/src/test/metaknob_link_test.cpp
@@ -211,7 +211,6 @@ TEST_F(MetaLinkTest, HalfLinkTakeover) {
     low->setControlHint(EffectManifestParameter::CONTROL_KNOB_LINEAR);
     low->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
     low->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
-    low->setDefaultLinkInversion(EffectManifestParameter::LinkInversion::INVERTED);
     low->setNeutralPointOnScale(1.0);
     low->setDefault(1.0);
     low->setMinimum(0);
@@ -252,5 +251,5 @@ TEST_F(MetaLinkTest, HalfLinkTakeover) {
     m_pEffectSlot->syncSofttakeover();
     newParam = 0.5 + SoftTakeover::kDefaultTakeoverThreshold * 1.5;
     m_pEffectSlot->slotEffectMetaParameter(newParam);
-    EXPECT_FLOAT_EQ(0.9296875, m_pControlValue->get());
+    EXPECT_FLOAT_EQ(0.0703125, m_pControlValue->get());
 }


### PR DESCRIPTION
This remove the need for invert the metaknob linking from the already inverted LPF knob of the filter effects. -1 * -1 = +1 ;-) 