### PR TITLE
Fix skipSampleFrames() for various AudioSource implementations

### DIFF
--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -21,7 +21,8 @@ SoundSourceWV::SoundSourceWV(const QUrl& url)
           m_wpc(nullptr),
           m_sampleScaleFactor(CSAMPLE_ZERO), 
           m_pWVFile(nullptr),
-          m_pWVCFile(nullptr) {
+          m_pWVCFile(nullptr),
+          m_curFrameIndex(getMinFrameIndex()) {
 }
 
 SoundSourceWV::~SoundSourceWV() {
@@ -86,11 +87,13 @@ void SoundSourceWV::close() {
         delete m_pWVCFile;
         m_pWVCFile = nullptr;
     }
+    m_curFrameIndex = getMinFrameIndex();
 }
 
 SINT SoundSourceWV::seekSampleFrame(SINT frameIndex) {
     DEBUG_ASSERT(isValidFrameIndex(frameIndex));
     if (WavpackSeekSample(m_wpc, frameIndex) == true) {
+        m_curFrameIndex = frameIndex;
         return frameIndex;
     } else {
         qDebug() << "SSWV::seek : could not seek to frame #" << frameIndex;
@@ -100,9 +103,23 @@ SINT SoundSourceWV::seekSampleFrame(SINT frameIndex) {
 
 SINT SoundSourceWV::readSampleFrames(
         SINT numberOfFrames, CSAMPLE* sampleBuffer) {
+    if (sampleBuffer == nullptr) {
+        // NOTE(uklotzde): The WavPack API does not provide any
+        // functions for skipping samples in the audio stream. Calling
+        // API functions with a nullptr buffer does not return. Since
+        // we don't want to read samples into a temporary buffer that
+        // has to be allocated we are seeking to the position after
+        // the skipped samples.
+        SINT curFrameIndexBefore = m_curFrameIndex;
+        SINT curFrameIndexAfter = seekSampleFrame(m_curFrameIndex + numberOfFrames);
+        DEBUG_ASSERT(curFrameIndexBefore <= curFrameIndexAfter);
+        DEBUG_ASSERT(m_curFrameIndex == curFrameIndexAfter);
+        return curFrameIndexAfter - curFrameIndexBefore;
+    }
     // static assert: sizeof(CSAMPLE) == sizeof(int32_t)
     SINT unpackCount = WavpackUnpackSamples(m_wpc,
             reinterpret_cast<int32_t*>(sampleBuffer), numberOfFrames);
+    DEBUG_ASSERT(unpackCount >= 0);
     if (!(WavpackGetMode(m_wpc) & MODE_FLOAT)) {
         // signed integer -> float
         const SINT sampleCount = frames2samples(unpackCount);
@@ -112,6 +129,7 @@ SINT SoundSourceWV::readSampleFrames(
             sampleBuffer[i] = CSAMPLE(sampleValue) * m_sampleScaleFactor;
         }
     }
+    m_curFrameIndex += unpackCount;
     return unpackCount;
 }
 

--- a/plugins/soundsourcewv/soundsourcewv.h
+++ b/plugins/soundsourcewv/soundsourcewv.h
@@ -38,6 +38,8 @@ class SoundSourceWV: public SoundSourcePlugin {
     CSAMPLE m_sampleScaleFactor;
     QFile* m_pWVFile;
     QFile* m_pWVCFile;
+
+    SINT m_curFrameIndex;
 };
 
 class SoundSourceProviderWV: public SoundSourceProvider {

--- a/src/sources/soundsourceoggvorbis.cpp
+++ b/src/sources/soundsourceoggvorbis.cpp
@@ -166,26 +166,28 @@ SINT SoundSourceOggVorbis::readSampleFrames(
                 numberOfFramesRemaining, &currentSection);
         if (0 < readResult) {
             m_curFrameIndex += readResult;
-            if (kChannelCountMono == getChannelCount()) {
-                if (readStereoSamples) {
+            if (pSampleBuffer != nullptr) {
+                if (kChannelCountMono == getChannelCount()) {
+                    if (readStereoSamples) {
+                        for (long i = 0; i < readResult; ++i) {
+                            *pSampleBuffer++ = pcmChannels[0][i];
+                            *pSampleBuffer++ = pcmChannels[0][i];
+                        }
+                    } else {
+                        for (long i = 0; i < readResult; ++i) {
+                            *pSampleBuffer++ = pcmChannels[0][i];
+                        }
+                    }
+                } else if (readStereoSamples || (kChannelCountStereo == getChannelCount())) {
                     for (long i = 0; i < readResult; ++i) {
                         *pSampleBuffer++ = pcmChannels[0][i];
-                        *pSampleBuffer++ = pcmChannels[0][i];
+                        *pSampleBuffer++ = pcmChannels[1][i];
                     }
                 } else {
                     for (long i = 0; i < readResult; ++i) {
-                        *pSampleBuffer++ = pcmChannels[0][i];
-                    }
-                }
-            } else if (readStereoSamples || (kChannelCountStereo == getChannelCount())) {
-                for (long i = 0; i < readResult; ++i) {
-                    *pSampleBuffer++ = pcmChannels[0][i];
-                    *pSampleBuffer++ = pcmChannels[1][i];
-                }
-            } else {
-                for (long i = 0; i < readResult; ++i) {
-                    for (SINT j = 0; j < getChannelCount(); ++j) {
-                        *pSampleBuffer++ = pcmChannels[j][i];
+                        for (SINT j = 0; j < getChannelCount(); ++j) {
+                            *pSampleBuffer++ = pcmChannels[j][i];
+                        }
                     }
                 }
             }

--- a/src/sources/soundsourceopus.h
+++ b/src/sources/soundsourceopus.h
@@ -1,15 +1,27 @@
 #ifndef MIXXX_SOUNDSOURCEOPUS_H
 #define MIXXX_SOUNDSOURCEOPUS_H
 
-#include "sources/soundsourceprovider.h"
-
 #define OV_EXCLUDE_STATIC_CALLBACKS
 #include <opus/opusfile.h>
+
+#include "sources/soundsourceprovider.h"
+#include "util/samplebuffer.h"
 
 namespace mixxx {
 
 class SoundSourceOpus: public mixxx::SoundSource {
 public:
+    // According to the API documentation of op_pcm_seek():
+    // "...decoding after seeking may not return exactly the same
+    // values as would be obtained by decoding the stream straight
+    // through. However, such differences are expected to be smaller
+    // than the loss introduced by Opus's lossy compression."
+    // This implementation internally uses prefetching to compensate
+    // those differences, although not completely. The following
+    // constant indicates the maximum expected difference for
+    // testing purposes.
+    static const CSAMPLE kMaxDecodingError;
+
     explicit SoundSourceOpus(const QUrl& url);
     ~SoundSourceOpus() override;
 
@@ -31,6 +43,8 @@ private:
 
     OggOpusFile *m_pOggOpusFile;
     bool m_downmixToStereo;
+
+    SampleBuffer m_prefetchSampleBuffer;
 
     SINT m_curFrameIndex;
 };

--- a/src/sources/soundsourceopus.h
+++ b/src/sources/soundsourceopus.h
@@ -30,6 +30,7 @@ private:
     OpenResult tryOpen(const AudioSourceConfig& audioSrcCfg) override;
 
     OggOpusFile *m_pOggOpusFile;
+    bool m_downmixToStereo;
 
     SINT m_curFrameIndex;
 };

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -6,7 +6,8 @@ namespace mixxx {
 
 SoundSourceSndFile::SoundSourceSndFile(const QUrl& url)
         : SoundSource(url),
-          m_pSndFile(nullptr) {
+          m_pSndFile(nullptr),
+          m_curFrameIndex(getMinFrameIndex()) {
 }
 
 SoundSourceSndFile::~SoundSourceSndFile() {
@@ -56,14 +57,17 @@ SoundSource::OpenResult SoundSourceSndFile::tryOpen(const AudioSourceConfig& /*a
     setSamplingRate(sfInfo.samplerate);
     setFrameCount(sfInfo.frames);
 
+    m_curFrameIndex = getMinFrameIndex();
+
     return OpenResult::SUCCEEDED;
 }
 
 void SoundSourceSndFile::close() {
-    if (m_pSndFile) {
+    if (m_pSndFile != nullptr) {
         const int closeResult = sf_close(m_pSndFile);
         if (0 == closeResult) {
             m_pSndFile = nullptr;
+            m_curFrameIndex = getMinFrameIndex();
         } else {
             qWarning() << "Failed to close file:" << closeResult
                     << sf_strerror(m_pSndFile)
@@ -78,6 +82,7 @@ SINT SoundSourceSndFile::seekSampleFrame(
 
     const sf_count_t seekResult = sf_seek(m_pSndFile, frameIndex, SEEK_SET);
     if (0 <= seekResult) {
+        m_curFrameIndex = seekResult;
         return seekResult;
     } else {
         qWarning() << "Failed to seek libsnd file:" << seekResult
@@ -88,9 +93,29 @@ SINT SoundSourceSndFile::seekSampleFrame(
 
 SINT SoundSourceSndFile::readSampleFrames(
         SINT numberOfFrames, CSAMPLE* sampleBuffer) {
+    DEBUG_ASSERT_AND_HANDLE(numberOfFrames >= 0) {
+        return 0;
+    }
+    if (numberOfFrames == 0) {
+        return 0;
+    }
+    if (sampleBuffer == nullptr) {
+        // NOTE(uklotzde): The libsndfile API does not provide any
+        // functions for skipping samples in the audio stream. Calling
+        // API functions with a nullptr buffer does not return. Since
+        // we don't want to read samples into a temporary buffer that
+        // has to be allocated we are seeking to the position after
+        // the skipped samples.
+        SINT curFrameIndexBefore = m_curFrameIndex;
+        SINT curFrameIndexAfter = seekSampleFrame(m_curFrameIndex + numberOfFrames);
+        DEBUG_ASSERT(curFrameIndexBefore <= curFrameIndexAfter);
+        DEBUG_ASSERT(m_curFrameIndex == curFrameIndexAfter);
+        return curFrameIndexAfter - curFrameIndexBefore;
+    }
     const sf_count_t readCount =
             sf_readf_float(m_pSndFile, sampleBuffer, numberOfFrames);
     if (0 <= readCount) {
+        m_curFrameIndex += readCount;
         return readCount;
     } else {
         qWarning() << "Failed to read from libsnd file:" << readCount

--- a/src/sources/soundsourcesndfile.h
+++ b/src/sources/soundsourcesndfile.h
@@ -29,6 +29,8 @@ private:
     OpenResult tryOpen(const AudioSourceConfig& audioSrcCfg) override;
 
     SNDFILE* m_pSndFile;
+
+    SINT m_curFrameIndex;
 };
 
 class SoundSourceProviderSndFile: public SoundSourceProvider {

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -4,6 +4,7 @@
 
 #include "track/trackmetadata.h"
 #include "sources/soundsourceproxy.h"
+#include "sources/soundsourceopus.h"
 #include "test/mixxxtest.h"
 #include "util/samplebuffer.h"
 
@@ -76,15 +77,9 @@ class SoundSourceProxyTest: public MixxxTest {
             const CSAMPLE* expected,
             const CSAMPLE* actual,
             const char* errorMessage) {
-        // According to API documentation of op_pcm_seek():
-        // "...decoding after seeking may not return exactly the same
-        // values as would be obtained by decoding the stream straight
-        // through. However, such differences are expected to be smaller
-        // than the loss introduced by Opus's lossy compression."
-        const CSAMPLE kAcceptableOpusSeekDecodingError = 0.2f;
-
         for (SINT i = 0; i < size; ++i) {
-            EXPECT_NEAR(expected[i], actual[i], kAcceptableOpusSeekDecodingError) << errorMessage;
+            EXPECT_NEAR(expected[i], actual[i],
+                    mixxx::SoundSourceOpus::kMaxDecodingError) << errorMessage;
         }
     }
 };

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -134,7 +134,7 @@ TEST_F(SoundSourceProxyTest, seekForwardBackward) {
     for (const auto& filePath: getFilePaths()) {
         ASSERT_TRUE(SoundSourceProxy::isFileNameSupported(filePath));
 
-        qDebug() << "Seek forward test:" << filePath;
+        qDebug() << "Seek forward/backward test:" << filePath;
 
         mixxx::AudioSourcePointer pContReadSource(openAudioSource(filePath));
         // Obtaining an AudioSource may fail for unsupported file formats,
@@ -208,6 +208,83 @@ TEST_F(SoundSourceProxyTest, seekForwardBackward) {
                         &seekReadData[0],
                         "Decoding mismatch after seeking backward");
             }
+        }
+    }
+}
+
+TEST_F(SoundSourceProxyTest, skipAndRead) {
+    const SINT kReadFrameCount = 1000;
+
+    for (const auto& filePath: getFilePaths()) {
+        ASSERT_TRUE(SoundSourceProxy::isFileNameSupported(filePath));
+
+        qDebug() << "Skip and read test:" << filePath;
+
+        mixxx::AudioSourcePointer pContReadSource(openAudioSource(filePath));
+        // Obtaining an AudioSource may fail for unsupported file formats,
+        // even if the corresponding file extension is supported, e.g.
+        // AAC vs. ALAC in .m4a files
+        if (!pContReadSource) {
+            // skip test file
+            continue;
+        }
+
+        mixxx::AudioSourcePointer pSkipReadSource(openAudioSource(filePath));
+        ASSERT_FALSE(!pSkipReadSource);
+        ASSERT_EQ(pContReadSource->getChannelCount(), pSkipReadSource->getChannelCount());
+        ASSERT_EQ(pContReadSource->getFrameCount(), pSkipReadSource->getFrameCount());
+
+        const SINT readSampleCount = pContReadSource->frames2samples(kReadFrameCount);
+        SampleBuffer contReadData(readSampleCount);
+        SampleBuffer skipReadData(readSampleCount);
+
+        SINT frameIndex = mixxx::AudioSource::getMinFrameIndex();
+        SINT contFrameIndex = mixxx::AudioSource::getMinFrameIndex();
+        SINT skipFrameIndex = mixxx::AudioSource::getMinFrameIndex();
+        SINT skipCount = 1;
+        while (pContReadSource->isValidFrameIndex(frameIndex += skipCount)) {
+            skipCount = frameIndex / 4 + 1;
+
+            qDebug() << "Skipping to:" << frameIndex;
+
+            // Read (and discard samples) until reaching the frame index
+            // and read next chunk
+            ASSERT_LE(contFrameIndex, frameIndex);
+            while (contFrameIndex < frameIndex) {
+                SINT readCount = std::min(frameIndex - contFrameIndex, kReadFrameCount);
+                contFrameIndex += pContReadSource->readSampleFrames(readCount, &contReadData[0]);
+            }
+            ASSERT_EQ(contFrameIndex, frameIndex);
+            const SINT contReadFrameCount =
+                    pContReadSource->readSampleFrames(kReadFrameCount, &contReadData[0]);
+            contFrameIndex += contReadFrameCount;
+
+            // Skip until reaching the frame index and read next chunk
+            ASSERT_LE(skipFrameIndex, frameIndex);
+            skipFrameIndex +=
+                    pSkipReadSource->skipSampleFrames(frameIndex - skipFrameIndex);
+            ASSERT_EQ(skipFrameIndex, frameIndex);
+            SINT skipReadFrameCount =
+                    pSkipReadSource->readSampleFrames(kReadFrameCount, &skipReadData[0]);
+            skipFrameIndex += skipReadFrameCount;
+
+            // Both buffers should be equal
+            ASSERT_EQ(contReadFrameCount, skipReadFrameCount);
+            if (filePath.endsWith(".opus")) {
+                expectDecodedSamplesEqualOpus(
+                        pContReadSource->frames2samples(contReadFrameCount),
+                        &contReadData[0],
+                        &skipReadData[0],
+                        "Decoding mismatch after skipping");
+            } else {
+                expectDecodedSamplesEqual(
+                        pContReadSource->frames2samples(contReadFrameCount),
+                        &contReadData[0],
+                        &skipReadData[0],
+                        "Decoding mismatch after skipping");
+            }
+
+            frameIndex = contFrameIndex;
         }
     }
 }


### PR DESCRIPTION
After adding a new test case for skipping and reading sample frames it became obvious that many AudioSource implementations are broken.

The fix for SoundSourceOpus is the biggest one, because opusfile neither implements skipping nor provides sample accurate seeking and decoding. By prefetching sample frames while seeking the accuracy can be improved substantially. All tunable parameters that affect the sample accuracy are now defined in SoundSourceOpus and are available as constants for verifying the test results.