### PR TITLE
Remove WaveformMarkProperties::setHotCueNumber(int i)

### DIFF
--- a/src/waveform/renderers/waveformmarkproperties.h
+++ b/src/waveform/renderers/waveformmarkproperties.h
@@ -13,7 +13,6 @@ class WaveformMarkProperties final {
     WaveformMarkProperties(const QDomNode& node,
                            const SkinContext& context,
                            const WaveformSignalColors& signalColors);
-    void setHotCueNumber(int i) { m_text = m_text.arg(i); }
 
     QColor m_color;
     QColor m_textColor;


### PR DESCRIPTION
Method introduced here: https://github.com/mixxxdj/mixxx/pull/1083

The method is not used. It is unneeded because there's an analogous method in WaveformMark