### PR TITLE
let any effect with a default superknob linking be a QuickEffect

### DIFF
--- a/src/effects/effectmanifest.h
+++ b/src/effects/effectmanifest.h
@@ -24,7 +24,6 @@ class EffectManifest final {
     EffectManifest()
         : m_isMixingEQ(false),
           m_isMasterEQ(false),
-          m_isForFilterKnob(false),
           m_effectRampsFromDry(false) {
     }
 
@@ -83,14 +82,6 @@ class EffectManifest final {
         m_isMasterEQ = value;
     }
 
-    virtual const bool& isForFilterKnob() const {
-        return m_isForFilterKnob;
-    }
-
-    virtual void setIsForFilterKnob(const bool value) {
-        m_isForFilterKnob = value;
-    }
-
     virtual void setDescription(const QString& description) {
         m_description = description;
     }
@@ -125,8 +116,6 @@ class EffectManifest final {
     // This helps us at DlgPrefEQ's basic selection of Equalizers
     bool m_isMixingEQ;
     bool m_isMasterEQ;
-    // This helps us at DlgPrefEQ's basic selection of Filter knob effects
-    bool m_isForFilterKnob;
     QList<EffectManifestParameter> m_parameters;
     bool m_effectRampsFromDry;
 };

--- a/src/effects/native/bitcrushereffect.cpp
+++ b/src/effects/native/bitcrushereffect.cpp
@@ -17,7 +17,6 @@ EffectManifest BitCrusherEffect::getManifest() {
     manifest.setDescription(QObject::tr(
         "The BitCrusher is an effect that adds quantisation noise to the signal "
         "by the reduction of the resolution or bandwidth of the samples."));
-    manifest.setIsForFilterKnob(true);
     manifest.setEffectRampsFromDry(true);
 
     EffectManifestParameter* depth = manifest.addParameter();

--- a/src/effects/native/filtereffect.cpp
+++ b/src/effects/native/filtereffect.cpp
@@ -20,7 +20,6 @@ EffectManifest FilterEffect::getManifest() {
                                         "music by allowing only high or low "
                                         "frequencies to pass through."));
     manifest.setEffectRampsFromDry(true);
-    manifest.setIsForFilterKnob(true);
 
     EffectManifestParameter* lpf = manifest.addParameter();
     lpf->setId("lpf");

--- a/src/effects/native/moogladder4filtereffect.cpp
+++ b/src/effects/native/moogladder4filtereffect.cpp
@@ -22,7 +22,6 @@ EffectManifest MoogLadder4FilterEffect::getManifest() {
     manifest.setDescription(QObject::tr(
             "A 4-pole Moog ladder filter, based on Antti Houvilainen's non linear digital implementation"));
     manifest.setEffectRampsFromDry(true);
-    manifest.setIsForFilterKnob(true);
 
     EffectManifestParameter* lpf = manifest.addParameter();
     lpf->setId("lpf");

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -180,8 +180,13 @@ static bool isMasterEQ(EffectManifest* pManifest) {
     return pManifest->isMasterEQ();
 }
 
-static bool isForFilterKnob(EffectManifest* pManifest) {
-    return pManifest->isForFilterKnob();
+static bool hasSuperKnobLinking(EffectManifest* pManifest) {
+    for (const auto& pParameterManifest : pManifest->parameters()) {
+        if (pParameterManifest.defaultLinkType() != EffectManifestParameter::LINK_NONE) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
@@ -190,21 +195,21 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
     QList<QPair<QString, QString> > availableEQEffectNames;
     QList<QPair<QString, QString> > availableQuickEffectNames;
     EffectsManager::EffectManifestFilterFnc filterEQ;
-    EffectsManager::EffectManifestFilterFnc filterFilter;
+    EffectsManager::EffectManifestFilterFnc filterHasSuperKnobLinking;
     if (CheckBoxEqOnly->isChecked()) {
         m_pConfig->set(ConfigKey(kConfigKey, kEqsOnly), QString("yes"));
         filterEQ = isMixingEQ;
-        filterFilter = isForFilterKnob;
+        filterHasSuperKnobLinking = hasSuperKnobLinking;
     } else {
         m_pConfig->set(ConfigKey(kConfigKey, kEqsOnly), QString("no"));
-        filterEQ = NULL; // take all;
-        filterFilter = NULL;
+        filterEQ = nullptr; // take all;
+        filterHasSuperKnobLinking = nullptr;
     }
     availableEQEffectNames =
             m_pEffectsManager->getEffectNamesFiltered(filterEQ);
     availableEQEffectNames.append(QPair<QString,QString>("none", tr("None")));
     availableQuickEffectNames =
-            m_pEffectsManager->getEffectNamesFiltered(filterFilter);
+            m_pEffectsManager->getEffectNamesFiltered(filterHasSuperKnobLinking);
     availableQuickEffectNames.append(QPair<QString,QString>("none", tr("None")));
 
     foreach (QComboBox* box, m_deckEqEffectSelectors) {

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -195,20 +195,18 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
     QList<QPair<QString, QString> > availableEQEffectNames;
     QList<QPair<QString, QString> > availableQuickEffectNames;
     EffectsManager::EffectManifestFilterFnc filterEQ;
-    EffectsManager::EffectManifestFilterFnc filterHasSuperKnobLinking;
-    filterHasSuperKnobLinking = hasSuperKnobLinking;
     if (CheckBoxEqOnly->isChecked()) {
         m_pConfig->set(ConfigKey(kConfigKey, kEqsOnly), QString("yes"));
         filterEQ = isMixingEQ;
     } else {
         m_pConfig->set(ConfigKey(kConfigKey, kEqsOnly), QString("no"));
-        filterEQ = nullptr; // take all;
+        filterEQ = nullptr; // take all
     }
     availableEQEffectNames =
             m_pEffectsManager->getEffectNamesFiltered(filterEQ);
     availableEQEffectNames.append(QPair<QString,QString>("none", tr("None")));
     availableQuickEffectNames =
-            m_pEffectsManager->getEffectNamesFiltered(filterHasSuperKnobLinking);
+            m_pEffectsManager->getEffectNamesFiltered(hasSuperKnobLinking);
     availableQuickEffectNames.append(QPair<QString,QString>("none", tr("None")));
 
     foreach (QComboBox* box, m_deckEqEffectSelectors) {

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -196,14 +196,13 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
     QList<QPair<QString, QString> > availableQuickEffectNames;
     EffectsManager::EffectManifestFilterFnc filterEQ;
     EffectsManager::EffectManifestFilterFnc filterHasSuperKnobLinking;
+    filterHasSuperKnobLinking = hasSuperKnobLinking;
     if (CheckBoxEqOnly->isChecked()) {
         m_pConfig->set(ConfigKey(kConfigKey, kEqsOnly), QString("yes"));
         filterEQ = isMixingEQ;
-        filterHasSuperKnobLinking = hasSuperKnobLinking;
     } else {
         m_pConfig->set(ConfigKey(kConfigKey, kEqsOnly), QString("no"));
         filterEQ = nullptr; // take all;
-        filterHasSuperKnobLinking = nullptr;
     }
     availableEQEffectNames =
             m_pEffectsManager->getEffectNamesFiltered(filterEQ);


### PR DESCRIPTION
Before, only Filter, Moog Filter, and Bitcrusher were able to be loaded as QuickEffects. This was arbitrary and artificially limiting the capability of the QuickEffect knob. In the future, when exporting/importing effects chains is implemented, it will be cool to let users import whatever custom effect chain they want as a QuickEffect.