### PR TITLE
use RGB overview waveforms by default

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -103,9 +103,9 @@ void DlgPrefWaveform::slotUpdate() {
     normalizeOverviewCheckBox->setChecked(factory->isOverviewNormalized());
     defaultZoomComboBox->setCurrentIndex(factory->getDefaultZoom() - 1);
 
-    // By default we set filtered woverview = "0"
+    // By default we set RGB woverview = "2"
     int overviewType = m_pConfig->getValueString(
-            ConfigKey("[Waveform]","WaveformOverviewType"), "0").toInt();
+            ConfigKey("[Waveform]","WaveformOverviewType"), "2").toInt();
     if (overviewType != waveformOverviewComboBox->currentIndex()) {
         waveformOverviewComboBox->setCurrentIndex(overviewType);
     }
@@ -146,8 +146,8 @@ void DlgPrefWaveform::slotResetToDefaults() {
     // Don't synchronize zoom by default.
     synchronizeZoomCheckBox->setChecked(false);
 
-    // Filtered overview.
-    waveformOverviewComboBox->setCurrentIndex(0);
+    // RGB overview.
+    waveformOverviewComboBox->setCurrentIndex(2);
 
     // Don't normalize overview.
     normalizeOverviewCheckBox->setChecked(false);

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -896,7 +896,7 @@ QWidget* LegacySkinParser::parseOverview(const QDomElement& node) {
     WOverview* overviewWidget = NULL;
 
     // "RGB" = "2", "HSV" = "1" or "Filtered" = "0" (LMH) waveform overview type
-    int type = m_pConfig->getValueString(ConfigKey("[Waveform]","WaveformOverviewType"), "0").toInt();
+    int type = m_pConfig->getValueString(ConfigKey("[Waveform]","WaveformOverviewType"), "2").toInt();
     if (type == 0) {
         overviewWidget = new WOverviewLMH(pSafeChannelStr, m_pConfig, m_pParent);
     } else if (type == 1) {


### PR DESCRIPTION
RGB waveforms look cool and convey useful information. They are already the default for zoomed waveforms. Let's make them the default for overview waveforms too.