### PR TITLE
Replace QSharedPointer with std::shared_ptr

### DIFF
--- a/src/library/dao/cue.h
+++ b/src/library/dao/cue.h
@@ -3,10 +3,10 @@
 
 #include <QObject>
 #include <QMutex>
-#include <QSharedPointer>
 #include <QColor>
 
 #include "track/trackid.h"
+#include "util/memory.h"
 
 class CueDAO;
 class Track;
@@ -74,20 +74,11 @@ class Cue : public QObject {
     friend class CueDAO;
 };
 
-class CuePointer: public QSharedPointer<Cue> {
+class CuePointer: public std::shared_ptr<Cue> {
   public:
     CuePointer() {}
     explicit CuePointer(Cue* pCue)
-          : QSharedPointer<Cue>(pCue, deleteLater) {
-    }
-
-    // TODO(uklotzde): Remove these functions after migration
-    // from QSharedPointer to std::shared_ptr
-    Cue* get() const {
-        return data();
-    }
-    void reset() {
-        clear();
+          : std::shared_ptr<Cue>(pCue, deleteLater) {
     }
 
   private:

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -1,10 +1,9 @@
 #ifndef MIXXX_AUDIOSOURCE_H
 #define MIXXX_AUDIOSOURCE_H
 
-#include <QSharedPointer>
-
 #include "sources/urlresource.h"
 #include "util/audiosignal.h"
+#include "util/memory.h"
 #include "util/result.h"
 #include "util/samplebuffer.h"
 
@@ -231,7 +230,7 @@ class AudioSourceConfig : public AudioSignal {
     using AudioSignal::resetSamplingRate;
 };
 
-typedef QSharedPointer<AudioSource> AudioSourcePointer;
+typedef std::shared_ptr<AudioSource> AudioSourcePointer;
 
 } // namespace mixxx
 

--- a/src/sources/soundsource.h
+++ b/src/sources/soundsource.h
@@ -75,11 +75,11 @@ private:
     const QString m_type;
 };
 
-typedef QSharedPointer<SoundSource> SoundSourcePointer;
+typedef std::shared_ptr<SoundSource> SoundSourcePointer;
 
 template<typename T>
 SoundSourcePointer newSoundSourceFromUrl(const QUrl& url) {
-    return SoundSourcePointer(new T(url));
+    return std::make_shared<T>(url);
 }
 
 } //namespace mixxx

--- a/src/sources/soundsourcepluginlibrary.cpp
+++ b/src/sources/soundsourcepluginlibrary.cpp
@@ -15,7 +15,7 @@ namespace mixxx {
         return s_loadedPluginLibraries.value(libFilePath);
     } else {
         SoundSourcePluginLibraryPointer pPluginLibrary(
-                new SoundSourcePluginLibrary(libFilePath));
+                std::make_shared<SoundSourcePluginLibrary>(libFilePath));
         if (pPluginLibrary->init()) {
             s_loadedPluginLibraries.insert(libFilePath, pPluginLibrary);
             return pPluginLibrary;

--- a/src/sources/soundsourcepluginlibrary.h
+++ b/src/sources/soundsourcepluginlibrary.h
@@ -12,13 +12,17 @@ namespace mixxx {
 
 class SoundSourcePluginLibrary;
 
-typedef QSharedPointer<SoundSourcePluginLibrary> SoundSourcePluginLibraryPointer;
+typedef std::shared_ptr<SoundSourcePluginLibrary> SoundSourcePluginLibraryPointer;
 
 
 // Wrapper class for a dynamic library that implements the SoundSource plugin API
 class SoundSourcePluginLibrary {
 public:
     static SoundSourcePluginLibraryPointer load(const QString& libFilePath);
+
+    // Use load() instead of this constructor!
+    // The constructor has been declared 'public' only for technical reasons.
+    explicit SoundSourcePluginLibrary(const QString& libFilePath);
 
     virtual ~SoundSourcePluginLibrary();
 
@@ -33,8 +37,6 @@ public:
     SoundSourceProviderPointer getSoundSourceProvider() const;
 
 protected:
-    explicit SoundSourcePluginLibrary(const QString& libFilePath);
-
     virtual bool init();
 
 private:

--- a/src/sources/soundsourceprovider.h
+++ b/src/sources/soundsourceprovider.h
@@ -55,11 +55,11 @@ public:
     virtual SoundSourcePointer newSoundSource(const QUrl& url) = 0;
 };
 
-typedef QSharedPointer<SoundSourceProvider> SoundSourceProviderPointer;
+typedef std::shared_ptr<SoundSourceProvider> SoundSourceProviderPointer;
 
 template<typename T>
 static SoundSourceProviderPointer newSoundSourceProvider() {
-    return SoundSourceProviderPointer(new T);
+    return std::make_shared<T>();
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -536,7 +536,7 @@ public:
         DEBUG_ASSERT(pTrack);
         DEBUG_ASSERT(pAudioSource);
         return mixxx::AudioSourcePointer(
-                new AudioSourceProxy(pTrack, pAudioSource));
+                std::make_shared<AudioSourceProxy>(pTrack, pAudioSource));
     }
 
     SINT seekSampleFrame(SINT frameIndex) override {

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -334,7 +334,7 @@ TEST_F(SoundSourceProxyTest, seekBoundaries) {
 
         // ...and verify read results
         mixxx::AudioSourcePointer pContReadSource(openAudioSource(filePath));
-        ASSERT_TRUE(pContReadSource);
+        ASSERT_FALSE(!pContReadSource);
         ASSERT_EQ(frameOffset, pContReadSource->skipSampleFrames(frameOffset));
         SampleBuffer contReadData(
                 pContReadSource->frames2samples(kReadFrameCount));


### PR DESCRIPTION
Replace some QSharedPointer types with std::shared_ptr from C++11.

Tested during the last months without any issues.