### PR TITLE
Effect selector widget

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -844,6 +844,7 @@ class MixxxCore(Feature):
                    "widget/wstarrating.cpp",
                    "widget/weffectchain.cpp",
                    "widget/weffect.cpp",
+                   "widget/weffectselector.cpp",
                    "widget/weffectparameter.cpp",
                    "widget/weffectbuttonparameter.cpp",
                    "widget/weffectparameterbase.cpp",

--- a/src/effects/effectmanifest.h
+++ b/src/effects/effectmanifest.h
@@ -48,6 +48,14 @@ class EffectManifest final {
         m_shortName = shortName;
     }
 
+    virtual const QString& displayName() const {
+        if (!m_shortName.isEmpty()) {
+            return m_shortName;
+        } else {
+            return m_name;
+        }
+    }
+
     virtual const QString& author() const {
         return m_author;
     }

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -133,6 +133,33 @@ void EffectRack::loadPrevChain(const unsigned int iChainSlotNumber,
     m_effectChainSlots[iChainSlotNumber]->loadEffectChain(pPrevChain);
 }
 
+void EffectRack::maybeLoadEffect(const unsigned int iChainSlotNumber,
+                                 const unsigned int iEffectSlotNumber,
+                                 const QString& id) {
+    if (iChainSlotNumber >= static_cast<unsigned int>(m_effectChainSlots.size())) {
+        return;
+    }
+
+    EffectChainSlotPointer pChainSlot = m_effectChainSlots[iChainSlotNumber];
+    if (pChainSlot == nullptr) {
+        return;
+    }
+    EffectSlotPointer pEffectSlot = pChainSlot->getEffectSlot(iEffectSlotNumber);
+
+    bool loadNew = false;
+    if (pEffectSlot == nullptr || pEffectSlot->getEffect() == nullptr) {
+        loadNew = true;
+    } else if (id != pEffectSlot->getEffect()->getManifest().id()) {
+        loadNew = true;
+    }
+
+    if (loadNew) {
+        EffectChainPointer pChain = pChainSlot->getEffectChain();
+        EffectPointer pEffect = m_pEffectsManager->instantiateEffect(id);
+        pChain->replaceEffect(iEffectSlotNumber, pEffect);
+    }
+}
+
 void EffectRack::loadNextEffect(const unsigned int iChainSlotNumber,
                                 const unsigned int iEffectSlotNumber,
                                 EffectPointer pEffect) {

--- a/src/effects/effectrack.h
+++ b/src/effects/effectrack.h
@@ -40,6 +40,10 @@ class EffectRack : public QObject {
     int numEffectChainSlots() const;
     EffectChainSlotPointer getEffectChainSlot(int i);
 
+    void maybeLoadEffect(const unsigned int iChainSlotNumber,
+                         const unsigned int iEffectSlotNumber,
+                         const QString& id);
+
     unsigned int getRackNumber() const {
         return m_iRackNumber;
     }

--- a/src/effects/effectsbackend.cpp
+++ b/src/effects/effectsbackend.cpp
@@ -28,7 +28,7 @@ void EffectsBackend::registerEffect(const QString& id,
     m_registeredEffects[id] = QPair<EffectManifest, EffectInstantiatorPointer>(
             manifest, pInstantiator);
     m_effectIds.append(id);
-    emit(effectRegistered());
+    emit(effectRegistered(manifest));
 }
 
 const QList<QString>& EffectsBackend::getEffectIds() const {

--- a/src/effects/effectsbackend.h
+++ b/src/effects/effectsbackend.h
@@ -32,7 +32,7 @@ class EffectsBackend : public QObject {
             EffectsManager* pEffectsManager, const QString& effectId);
 
   signals:
-    void effectRegistered();
+    void effectRegistered(EffectManifest);
 
   protected:
     void registerEffect(const QString& id,

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -30,6 +30,10 @@ class EffectSlot : public QObject {
     // returns a null EffectPointer.
     EffectPointer getEffect() const;
 
+    inline int getEffectSlotNumber() const {
+        return m_iEffectNumber;
+    }
+
     unsigned int numParameterSlots() const;
     EffectParameterSlotPointer addEffectParameterSlot();
     EffectParameterSlotPointer getEffectParameterSlot(unsigned int slotNumber);

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -37,10 +37,16 @@ class EffectSlot : public QObject {
     unsigned int numParameterSlots() const;
     EffectParameterSlotPointer addEffectParameterSlot();
     EffectParameterSlotPointer getEffectParameterSlot(unsigned int slotNumber);
+    inline const QList<EffectParameterSlotPointer>& getEffectParameterSlots() const {
+        return m_parameters;
+    };
 
     unsigned int numButtonParameterSlots() const;
     EffectButtonParameterSlotPointer addEffectButtonParameterSlot();
     EffectButtonParameterSlotPointer getEffectButtonParameterSlot(unsigned int slotNumber);
+    inline const QList<EffectButtonParameterSlotPointer>& getEffectButtonParameterSlots() const {
+        return m_buttonParameters;
+    };
 
     double getMetaParameter() const;
 

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -142,40 +142,47 @@ bool EffectsManager::isEQ(const QString& effectId) const {
 }
 
 QString EffectsManager::getNextEffectId(const QString& effectId) {
-    const QList<QString> effects = getAvailableEffects();
+    const QList<QPair<QString, QString> > idNamePairs = getEffectShortNamesFiltered(nullptr);
 
-    if (effects.isEmpty()) {
+    if (idNamePairs.isEmpty()) {
         return QString();
     }
-
     if (effectId.isNull()) {
-        return effects.first();
+        return idNamePairs.first().first;
     }
 
-    int index = effects.indexOf(effectId);
-    if (++index >= effects.size()) {
+    int index;
+    for (index = 0; index < idNamePairs.size(); ++index) {
+        if (effectId == idNamePairs.at(index).first) {
+            break;
+        }
+    }
+    if (++index >= idNamePairs.size()) {
         index = 0;
     }
-    return effects.at(index);
+    return idNamePairs.at(index).first;
 }
 
 QString EffectsManager::getPrevEffectId(const QString& effectId) {
-    const QList<QString> effects = getAvailableEffects();
+    const QList<QPair<QString, QString> > idNamePairs = getEffectShortNamesFiltered(nullptr);
 
-    if (effects.isEmpty()) {
+    if (idNamePairs.isEmpty()) {
         return QString();
     }
-
     if (effectId.isNull()) {
-        return effects.last();
+        return idNamePairs.last().first;
     }
 
-    int index = effects.indexOf(effectId);
+    int index;
+    for (index = 0; index < idNamePairs.size(); ++index) {
+        if (effectId == idNamePairs.at(index).first) {
+            break;
+        }
+    }
     if (--index < 0) {
-        index = effects.size() - 1;
+        index = idNamePairs.size() - 1;
     }
-    return effects.at(index);
-
+    return idNamePairs.at(index).first;
 }
 
 QPair<EffectManifest, EffectsBackend*> EffectsManager::getEffectManifestAndBackend(

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -55,17 +55,7 @@ EffectsManager::~EffectsManager() {
 
 bool alphabetizeEffectManifests(const EffectManifest& manifest1,
                                 const EffectManifest& manifest2) {
-    QString displayName1 = manifest1.shortName();
-    if (displayName1.isEmpty()) {
-        displayName1 = manifest1.name();
-    }
-
-    QString displayName2 = manifest2.shortName();
-    if (displayName2.isEmpty()) {
-        displayName2 = manifest2.name();
-    }
-
-    return QString::localeAwareCompare(displayName1, displayName2) < 0;
+    return QString::localeAwareCompare(manifest1.displayName(), manifest2.displayName()) < 0;
 }
 
 void EffectsManager::addEffectsBackend(EffectsBackend* pBackend) {

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -80,9 +80,10 @@ void EffectsManager::addEffectsBackend(EffectsBackend* pBackend) {
 }
 
 void EffectsManager::slotBackendRegisteredEffect(EffectManifest manifest) {
-    m_availableEffectManifests.append(manifest);
-    qSort(m_availableEffectManifests.begin(), m_availableEffectManifests.end(),
-          alphabetizeEffectManifests);
+    auto insertion_point = qLowerBound(m_availableEffectManifests.begin(),
+                                       m_availableEffectManifests.end(),
+                                       manifest, alphabetizeEffectManifests);
+    m_availableEffectManifests.insert(insertion_point, manifest);
 }
 
 void EffectsManager::registerChannel(const ChannelHandleAndGroup& handle_group) {

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -103,32 +103,19 @@ const QSet<ChannelHandleAndGroup>& EffectsManager::registeredChannels() const {
     return m_pEffectChainManager->registeredChannels();
 }
 
-bool alphabetizeEffectNameIdPairs(const QPair<QString, QString>& pair1,
-                                  const QPair<QString, QString>& pair2) {
-    return pair1.second < pair2.second;
-}
-
-// Each returned QPair has the effect ID and full name.
-const QList<QPair<QString, QString> > EffectsManager::getEffectNamesFiltered(
+const QList<EffectManifest> EffectsManager::getAvailableEffectManifestsFiltered(
         EffectManifestFilterFnc filter) const {
-    QList<QPair<QString, QString> > filteredEffectNames;
-    QString currentEffectName;
-    for (const EffectsBackend* pBackend : m_effectsBackends) {
-        QList<QString> backendEffects = pBackend->getEffectIds();
-        for (const QString effectId : backendEffects) {
-            EffectManifest manifest = pBackend->getManifest(effectId);
-            if (filter && !filter(&manifest)) {
-                continue;
-            }
-            currentEffectName = manifest.name();
-            filteredEffectNames.append(qMakePair(effectId, currentEffectName));
-        }
+    if (filter == nullptr) {
+        return m_availableEffectManifests;
     }
 
-    qSort(filteredEffectNames.begin(), filteredEffectNames.end(),
-          alphabetizeEffectNameIdPairs);
-
-    return filteredEffectNames;
+    QList<EffectManifest> list;
+    for (const auto& manifest : m_availableEffectManifests) {
+        if (filter(manifest)) {
+            list.append(manifest);
+        }
+    }
+    return list;
 }
 
 bool EffectsManager::isEQ(const QString& effectId) const {

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -70,45 +70,32 @@ const QSet<ChannelHandleAndGroup>& EffectsManager::registeredChannels() const {
     return m_pEffectChainManager->registeredChannels();
 }
 
-const QList<QString> EffectsManager::getAvailableEffects() const {
-    QList<QString> availableEffects;
-
-    foreach (EffectsBackend* pBackend, m_effectsBackends) {
-        const QList<QString>& backendEffects = pBackend->getEffectIds();
-        foreach (QString effectId, backendEffects) {
-            if (availableEffects.contains(effectId)) {
-                qWarning() << "WARNING: Duplicate effect ID" << effectId;
-                continue;
-            }
-            availableEffects.append(effectId);
-        }
-    }
-
-    return availableEffects;
-}
-
 bool alphabetizeEffectNameIdPairs(const QPair<QString, QString>& pair1,
                                  const QPair<QString, QString>& pair2) {
     return pair1.second < pair2.second;
 }
 
+// Each returned QPair has the effect ID and full name.
 const QList<QPair<QString, QString> > EffectsManager::getEffectNamesFiltered(
         EffectManifestFilterFnc filter) const {
-    QList<QPair<QString, QString> > filteredEQEffectNames;
+    QList<QPair<QString, QString> > filteredEffectNames;
     QString currentEffectName;
-    foreach (EffectsBackend* pBackend, m_effectsBackends) {
+    for (const EffectsBackend* pBackend : m_effectsBackends) {
         QList<QString> backendEffects = pBackend->getEffectIds();
-        foreach (QString effectId, backendEffects) {
+        for (const QString effectId : backendEffects) {
             EffectManifest manifest = pBackend->getManifest(effectId);
             if (filter && !filter(&manifest)) {
                 continue;
             }
             currentEffectName = manifest.name();
-            filteredEQEffectNames.append(qMakePair(effectId, currentEffectName));
+            filteredEffectNames.append(qMakePair(effectId, currentEffectName));
         }
     }
 
-    return filteredEQEffectNames;
+    qSort(filteredEffectNames.begin(), filteredEffectNames.end(),
+          alphabetizeEffectNameIdPairs);
+
+    return filteredEffectNames;
 }
 
 // Each returned QPair has the effect ID and short name.

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -87,6 +87,11 @@ const QList<QString> EffectsManager::getAvailableEffects() const {
     return availableEffects;
 }
 
+bool alphabetizeEffectNameIdPairs(const QPair<QString, QString>& pair1,
+                                 const QPair<QString, QString>& pair2) {
+    return pair1.second < pair2.second;
+}
+
 const QList<QPair<QString, QString> > EffectsManager::getEffectNamesFiltered(
         EffectManifestFilterFnc filter) const {
     QList<QPair<QString, QString> > filteredEQEffectNames;
@@ -104,6 +109,32 @@ const QList<QPair<QString, QString> > EffectsManager::getEffectNamesFiltered(
     }
 
     return filteredEQEffectNames;
+}
+
+// Each returned QPair has the effect ID and short name.
+const QList<QPair<QString, QString> > EffectsManager::getEffectShortNamesFiltered(
+        EffectManifestFilterFnc filter) const {
+    QList<QPair<QString, QString> > filteredEffectShortNames;
+    QString currentEffectShortName;
+    for (const EffectsBackend* pBackend : m_effectsBackends) {
+        QList<QString> backendEffects = pBackend->getEffectIds();
+        for (const QString effectId : backendEffects) {
+            EffectManifest manifest = pBackend->getManifest(effectId);
+            if (filter != nullptr && !filter(&manifest)) {
+                continue;
+            }
+            currentEffectShortName = manifest.shortName();
+            if (currentEffectShortName.isEmpty()) {
+                currentEffectShortName = manifest.name();
+            }
+            filteredEffectShortNames.append(qMakePair(effectId, currentEffectShortName));
+        }
+    }
+
+    qSort(filteredEffectShortNames.begin(), filteredEffectShortNames.end(),
+          alphabetizeEffectNameIdPairs);
+
+    return filteredEffectShortNames;
 }
 
 bool EffectsManager::isEQ(const QString& effectId) const {

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -75,7 +75,7 @@ void EffectsManager::addEffectsBackend(EffectsBackend* pBackend) {
     m_effectsBackends.append(pBackend);
 
     QList<QString> backendEffects = pBackend->getEffectIds();
-    for (const QString effectId : backendEffects) {
+    for (const QString& effectId : backendEffects) {
         m_availableEffectManifests.append(pBackend->getManifest(effectId));
     }
 

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -64,6 +64,7 @@ class EffectsManager : public QObject {
     const QList<QString> getAvailableEffects() const;
     // Each entry of the set is a pair containing the effect id and its name
     const QList<QPair<QString, QString> > getEffectNamesFiltered(EffectManifestFilterFnc filter) const;
+    const QList<QPair<QString, QString> > getEffectShortNamesFiltered(EffectManifestFilterFnc filter) const;
     bool isEQ(const QString& effectId) const;
     QPair<EffectManifest, EffectsBackend*> getEffectManifestAndBackend(
             const QString& effectId) const;

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -27,7 +27,7 @@ class EngineEffectsManager;
 class EffectsManager : public QObject {
     Q_OBJECT
   public:
-    typedef bool (*EffectManifestFilterFnc)(EffectManifest* pManifest);
+    typedef bool (*EffectManifestFilterFnc)(const EffectManifest& pManifest);
 
     EffectsManager(QObject* pParent, UserSettingsPointer pConfig);
     virtual ~EffectsManager();
@@ -61,12 +61,11 @@ class EffectsManager : public QObject {
     QString getNextEffectId(const QString& effectId);
     QString getPrevEffectId(const QString& effectId);
 
-    // Each entry of the set is a pair containing the effect id and its name
-    const QList<QPair<QString, QString> > getEffectNamesFiltered(
-        EffectManifestFilterFnc filter) const;
     inline const QList<EffectManifest>& getAvailableEffectManifests() const {
         return m_availableEffectManifests;
     };
+    const QList<EffectManifest> getAvailableEffectManifestsFiltered(
+        EffectManifestFilterFnc filter) const;
     bool isEQ(const QString& effectId) const;
     QPair<EffectManifest, EffectsBackend*> getEffectManifestAndBackend(
             const QString& effectId) const;

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -62,8 +62,11 @@ class EffectsManager : public QObject {
     QString getPrevEffectId(const QString& effectId);
 
     // Each entry of the set is a pair containing the effect id and its name
-    const QList<QPair<QString, QString> > getEffectNamesFiltered(EffectManifestFilterFnc filter) const;
-    const QList<QPair<QString, QString> > getEffectShortNamesFiltered(EffectManifestFilterFnc filter) const;
+    const QList<QPair<QString, QString> > getEffectNamesFiltered(
+        EffectManifestFilterFnc filter) const;
+    inline const QList<EffectManifest>& getAvailableEffectManifests() const {
+        return m_availableEffectManifests;
+    };
     bool isEQ(const QString& effectId) const;
     QPair<EffectManifest, EffectsBackend*> getEffectManifestAndBackend(
             const QString& effectId) const;
@@ -78,7 +81,10 @@ class EffectsManager : public QObject {
     bool writeRequest(EffectsRequest* request);
 
   signals:
-    void availableEffectsUpdated();
+    void availableEffectsUpdated(EffectManifest);
+
+  private slots:
+    void slotBackendRegisteredEffect(EffectManifest manifest);
 
   private:
     QString debugString() const {
@@ -89,6 +95,7 @@ class EffectsManager : public QObject {
 
     EffectChainManager* m_pEffectChainManager;
     QList<EffectsBackend*> m_effectsBackends;
+    QList<EffectManifest> m_availableEffectManifests;
 
     EngineEffectsManager* m_pEngineEffectsManager;
 

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -61,7 +61,6 @@ class EffectsManager : public QObject {
     QString getNextEffectId(const QString& effectId);
     QString getPrevEffectId(const QString& effectId);
 
-    const QList<QString> getAvailableEffects() const;
     // Each entry of the set is a pair containing the effect id and its name
     const QList<QPair<QString, QString> > getEffectNamesFiltered(EffectManifestFilterFnc filter) const;
     const QList<QPair<QString, QString> > getEffectShortNamesFiltered(EffectManifestFilterFnc filter) const;

--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -23,12 +23,7 @@ void DlgPrefEffects::slotUpdate() {
     for (const auto& manifest : availableEffectManifests) {
         QListWidgetItem* pItem = new QListWidgetItem();
         pItem->setData(Qt::UserRole, manifest.id());
-        // Use short names to match order and appearance in WEffectSelector
-        if (!manifest.shortName().isEmpty()) {
-            pItem->setText(manifest.shortName());
-        } else {
-            pItem->setText(manifest.name());
-        }
+        pItem->setText(manifest.displayName());
         availableEffectsList->addItem(pItem);
     }
 

--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -18,25 +18,19 @@ DlgPrefEffects::DlgPrefEffects(QWidget* pParent,
 
 void DlgPrefEffects::slotUpdate() {
     clear();
-    QStringList effectIds = m_pEffectsManager->getAvailableEffects();
+    // Use short names to match order and appearance in WEffectSelector
+    QList<QPair<QString,QString> > effectIdsAndNames = m_pEffectsManager->getEffectShortNamesFiltered(nullptr);
 
-    foreach (QString id, effectIds) {
-        addEffectToList(id);
+    for (const auto& pair : effectIdsAndNames) {
+        QListWidgetItem* pItem = new QListWidgetItem();
+        pItem->setData(Qt::UserRole, pair.first);
+        pItem->setText(pair.second);
+        availableEffectsList->addItem(pItem);
     }
 
-    if (!effectIds.isEmpty()) {
+    if (!effectIdsAndNames.isEmpty()) {
         availableEffectsList->setCurrentRow(0);
     }
-}
-
-void DlgPrefEffects::addEffectToList(const QString& effectId) {
-    QPair<EffectManifest, EffectsBackend*> manifestAndBackend =
-            m_pEffectsManager->getEffectManifestAndBackend(effectId);
-
-    QListWidgetItem* pItem = new QListWidgetItem();
-    pItem->setText(manifestAndBackend.first.name());
-    pItem->setData(Qt::UserRole, effectId);
-    availableEffectsList->addItem(pItem);
 }
 
 void DlgPrefEffects::slotApply() {

--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -18,17 +18,21 @@ DlgPrefEffects::DlgPrefEffects(QWidget* pParent,
 
 void DlgPrefEffects::slotUpdate() {
     clear();
-    // Use short names to match order and appearance in WEffectSelector
-    QList<QPair<QString,QString> > effectIdsAndNames = m_pEffectsManager->getEffectShortNamesFiltered(nullptr);
+    const QList<EffectManifest> availableEffectManifests = m_pEffectsManager->getAvailableEffectManifests();
 
-    for (const auto& pair : effectIdsAndNames) {
+    for (const auto& manifest : availableEffectManifests) {
         QListWidgetItem* pItem = new QListWidgetItem();
-        pItem->setData(Qt::UserRole, pair.first);
-        pItem->setText(pair.second);
+        pItem->setData(Qt::UserRole, manifest.id());
+        // Use short names to match order and appearance in WEffectSelector
+        if (!manifest.shortName().isEmpty()) {
+            pItem->setText(manifest.shortName());
+        } else {
+            pItem->setText(manifest.name());
+        }
         availableEffectsList->addItem(pItem);
     }
 
-    if (!effectIdsAndNames.isEmpty()) {
+    if (!availableEffectManifests.isEmpty()) {
         availableEffectsList->setCurrentRow(0);
     }
 }

--- a/src/preferences/dialog/dlgprefeffects.h
+++ b/src/preferences/dialog/dlgprefeffects.h
@@ -24,7 +24,6 @@ class DlgPrefEffects : public DlgPreferencePage, public Ui::DlgPrefEffectsDlg {
                             QListWidgetItem* pPrevious);
 
   private:
-    void addEffectToList(const QString& id);
     void clear();
 
     UserSettingsPointer m_pConfig;

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -204,8 +204,8 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
         filterEQ = nullptr; // take all
     }
 
-    QList<EffectManifest> availableEQEffects = m_pEffectsManager->getAvailableEffectManifestsFiltered(filterEQ);
-    QList<EffectManifest> availableQuickEffects = m_pEffectsManager->getAvailableEffectManifestsFiltered(hasSuperKnobLinking);
+    const QList<EffectManifest> availableEQEffects = m_pEffectsManager->getAvailableEffectManifestsFiltered(filterEQ);
+    const QList<EffectManifest> availableQuickEffects = m_pEffectsManager->getAvailableEffectManifestsFiltered(hasSuperKnobLinking);
 
     for (QComboBox* box : m_deckEqEffectSelectors) {
         // Populate comboboxes with all available effects
@@ -217,7 +217,7 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
 
         int i;
         for (i = 0; i < availableEQEffects.size(); ++i) {
-            const EffectManifest& manifest = availableEQEffects[i];
+            const EffectManifest& manifest = availableEQEffects.at(i);
             box->addItem(manifest.name(), QVariant(manifest.id()));
             if (selectedEffectId == manifest.id()) {
                 currentIndex = i;
@@ -247,7 +247,7 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
 
         int i;
         for (i = 0; i < availableQuickEffects.size(); ++i) {
-            const EffectManifest& manifest = availableQuickEffects[i];
+            const EffectManifest& manifest = availableQuickEffects.at(i);
             box->addItem(manifest.name(), QVariant(manifest.id()));
             if (selectedEffectId == manifest.id()) {
                 currentIndex = i;
@@ -631,10 +631,10 @@ void DlgPrefEQ::setUpMasterEQ() {
     QString configuredEffect = m_pConfig->getValueString(ConfigKey(kConfigKey,
             "EffectForGroup_[Master]"), kDefaultMasterEqId);
 
-    QList<EffectManifest> availableMasterEQEffects = m_pEffectsManager->getAvailableEffectManifestsFiltered(isMasterEQ);
+    const QList<EffectManifest> availableMasterEQEffects = m_pEffectsManager->getAvailableEffectManifestsFiltered(isMasterEQ);
 
     for (int i = 0; i < availableMasterEQEffects.size(); ++i) {
-        const EffectManifest& manifest = availableMasterEQEffects[i];
+        const EffectManifest& manifest = availableMasterEQEffects.at(i);
         comboBoxMasterEq->addItem(manifest.name(), QVariant(manifest.id()));
         if (configuredEffect == manifest.id()) {
             comboBoxMasterEq->setCurrentIndex(i);

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -201,8 +201,10 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
         filterEQ = nullptr; // take all
     }
 
-    const QList<EffectManifest> availableEQEffects = m_pEffectsManager->getAvailableEffectManifestsFiltered(filterEQ);
-    const QList<EffectManifest> availableQuickEffects = m_pEffectsManager->getAvailableEffectManifestsFiltered(hasSuperKnobLinking);
+    const QList<EffectManifest> availableEQEffects =
+        m_pEffectsManager->getAvailableEffectManifestsFiltered(filterEQ);
+    const QList<EffectManifest> availableQuickEffects =
+        m_pEffectsManager->getAvailableEffectManifestsFiltered(hasSuperKnobLinking);
 
     for (QComboBox* box : m_deckEqEffectSelectors) {
         // Populate comboboxes with all available effects
@@ -628,7 +630,8 @@ void DlgPrefEQ::setUpMasterEQ() {
     QString configuredEffect = m_pConfig->getValue(ConfigKey(kConfigKey,
             "EffectForGroup_[Master]"), kDefaultMasterEqId);
 
-    const QList<EffectManifest> availableMasterEQEffects = m_pEffectsManager->getAvailableEffectManifestsFiltered(isMasterEQ);
+    const QList<EffectManifest> availableMasterEQEffects =
+        m_pEffectsManager->getAvailableEffectManifestsFiltered(isMasterEQ);
 
     for (const auto& manifest : availableMasterEQEffects) {
         comboBoxMasterEq->addItem(manifest.name(), QVariant(manifest.id()));

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -53,6 +53,7 @@
 #include "widget/wnumberrate.h"
 #include "widget/weffectchain.h"
 #include "widget/weffect.h"
+#include "widget/weffectselector.h"
 #include "widget/weffectparameter.h"
 #include "widget/weffectbuttonparameter.h"
 #include "widget/weffectparameterbase.h"
@@ -545,6 +546,8 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
         result = wrapWidget(parseEffectChainName(node));
     } else if (nodeName == "EffectName") {
         result = wrapWidget(parseEffectName(node));
+    } else if (nodeName == "EffectSelector") {
+        result = wrapWidget(parseEffectSelector(node));
     } else if (nodeName == "EffectParameterName") {
         result = wrapWidget(parseEffectParameterName(node));
     } else if (nodeName == "EffectButtonParameterName") {
@@ -1574,6 +1577,17 @@ QWidget* LegacySkinParser::parseEffectName(const QDomElement& node) {
     WEffect* pEffect = new WEffect(m_pParent, m_pEffectsManager);
     setupLabelWidget(node, pEffect);
     return pEffect;
+}
+
+QWidget* LegacySkinParser::parseEffectSelector(const QDomElement& node) {
+    WEffectSelector* pSelector = new WEffectSelector(m_pParent, m_pEffectsManager);
+    commonWidgetSetup(node, pSelector);
+    pSelector->setup(node, *m_pContext);
+    pSelector->installEventFilter(m_pKeyboard);
+    pSelector->installEventFilter(
+        m_pControllerManager->getControllerLearningEventFilter());
+    pSelector->Init();
+    return pSelector;
 }
 
 QWidget* LegacySkinParser::parseEffectPushButton(const QDomElement& element) {

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -79,6 +79,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     QWidget* parseEffectParameterName(const QDomElement& node);
     QWidget* parseEffectButtonParameterName(const QDomElement& node);
     QWidget* parseEffectPushButton(const QDomElement& node);
+    QWidget* parseEffectSelector(const QDomElement& node);
 
     // Legacy pre-1.12.0 skin support.
     QWidget* parseBackground(const QDomElement& node, QWidget* pOuterWidget, QWidget* pInnerWidget);

--- a/src/widget/weffect.cpp
+++ b/src/widget/weffect.cpp
@@ -44,14 +44,9 @@ void WEffect::effectUpdated() {
         EffectPointer pEffect = m_pEffectSlot->getEffect();
         if (pEffect) {
             const EffectManifest& manifest = pEffect->getManifest();
-            if (!manifest.shortName().isEmpty()) {
-                name = manifest.shortName();
-                //: %1 = effect name; %2 = effect description
-                description = tr("%1: %2").arg(manifest.name(), manifest.description());
-            } else {
-                name = manifest.name();
-                description = manifest.description();
-            }
+            name = manifest.displayName();
+            //: %1 = effect name; %2 = effect description
+            description = tr("%1: %2").arg(manifest.name(), manifest.description());
         }
     } else {
         name = tr("None");

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -16,13 +16,7 @@ WEffectSelector::WEffectSelector(QWidget* pParent, EffectsManager* pEffectsManag
     for (int i = 0; i < availableEffectManifests.size(); ++i) {
         const EffectManifest& manifest = availableEffectManifests.at(i);
 
-        QString displayName;
-        if (manifest.shortName().isEmpty()) {
-            displayName = manifest.name();
-        } else {
-            displayName = manifest.shortName();
-        }
-        addItem(displayName, QVariant(manifest.id()));
+        addItem(manifest.displayName(), QVariant(manifest.id()));
 
         //: %1 = effect name; %2 = effect description
         QString description = tr("%1: %2").arg(manifest.name(), manifest.description());

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -14,10 +14,14 @@ WEffectSelector::WEffectSelector(QWidget* pParent, EffectsManager* pEffectsManag
     // https://bugs.launchpad.net/mixxx/+bug/1653140
     const QList<EffectManifest> availableEffectManifests =
         m_pEffectsManager->getAvailableEffectManifests();
+    QFontMetrics metrics(font());
+
     for (int i = 0; i < availableEffectManifests.size(); ++i) {
         const EffectManifest& manifest = availableEffectManifests.at(i);
-
-        addItem(manifest.displayName(), QVariant(manifest.id()));
+        QString elidedDisplayName = metrics.elidedText(manifest.displayName(),
+                                                       Qt::ElideMiddle,
+                                                       width() - 2);
+        addItem(elidedDisplayName, QVariant(manifest.id()));
 
         //: %1 = effect name; %2 = effect description
         QString description = tr("%1: %2").arg(manifest.name(), manifest.description());

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -1,0 +1,94 @@
+#include <QtDebug>
+
+#include "widget/weffectselector.h"
+
+#include "effects/effectsmanager.h"
+#include "widget/effectwidgetutils.h"
+
+namespace {
+    const QString nullEffectId = "NULL";
+}
+
+WEffectSelector::WEffectSelector(QWidget* pParent, EffectsManager* pEffectsManager)
+        : QComboBox(pParent),
+          WBaseWidget(pParent),
+          m_pEffectsManager(pEffectsManager) {
+
+    setInsertPolicy(QComboBox::InsertAlphabetically);
+    // TODO(xxx): filter out blacklisted effects
+    // https://bugs.launchpad.net/mixxx/+bug/1653140
+    QList<QPair<QString,QString> > idNamePairs = m_pEffectsManager->getEffectShortNamesFiltered(nullptr);
+    for (const auto& effectPair : idNamePairs) {
+        addItem(effectPair.second, QVariant(effectPair.first));
+    }
+    //: Displayed when no effect is loaded
+    addItem(tr("None"), QVariant(nullEffectId));
+}
+
+void WEffectSelector::setup(const QDomNode& node, const SkinContext& context) {
+    // EffectWidgetUtils propagates NULLs so this is all safe.
+    m_pRack = EffectWidgetUtils::getEffectRackFromNode(
+            node, context, m_pEffectsManager);
+    m_pChainSlot = EffectWidgetUtils::getEffectChainSlotFromNode(
+            node, context, m_pRack);
+    m_pEffectSlot = EffectWidgetUtils::getEffectSlotFromNode(
+            node, context, m_pChainSlot);
+
+    if (m_pEffectSlot != nullptr) {
+        connect(m_pEffectSlot.data(), SIGNAL(updated()),
+                this, SLOT(slotEffectUpdated()));
+        connect(this, SIGNAL(currentIndexChanged(int)),
+                this, SLOT(slotEffectSelected(int)));
+        slotEffectUpdated();
+    } else {
+        SKIN_WARNING(node, context)
+                << "EffectSelector node could not attach to effect slot.";
+    }
+}
+
+void WEffectSelector::slotEffectSelected(int newIndex) {
+    const QString id = itemData(newIndex).toString();
+    EffectPointer pEffect;
+
+    bool loadNew = false;
+    if (m_pEffectSlot == nullptr || m_pEffectSlot->getEffect() == nullptr) {
+        loadNew = true;
+    } else if (id != m_pEffectSlot->getEffect()->getManifest().id()) {
+        loadNew = true;
+    }
+
+    if (loadNew) {
+        EffectChainPointer pChain = m_pChainSlot->getEffectChain();
+        if (id == nullEffectId) {
+            pEffect = EffectPointer();
+        } else {
+            pEffect = m_pEffectsManager->instantiateEffect(id);
+        }
+        pChain->replaceEffect(m_pEffectSlot->getEffectSlotNumber(), pEffect);
+    }
+}
+
+void WEffectSelector::slotEffectUpdated() {
+    QString description = tr("No effect loaded.");
+    int newIndex;
+
+    if (m_pEffectSlot != nullptr) {
+        EffectPointer pEffect = m_pEffectSlot->getEffect();
+        if (pEffect != nullptr) {
+            const EffectManifest& manifest = pEffect->getManifest();
+            newIndex = findData(QVariant(manifest.id()));
+
+            //: %1 = effect name; %2 = effect description
+            description = tr("%1: %2").arg(manifest.name(), manifest.description());
+        } else {
+            newIndex = findData(QVariant(nullEffectId));
+        }
+    } else {
+        newIndex = findData(QVariant(nullEffectId));
+    }
+
+    setBaseTooltip(description);
+    if (newIndex != -1 && newIndex != currentIndex()) {
+        setCurrentIndex(newIndex);
+    }
+}

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -14,7 +14,7 @@ WEffectSelector::WEffectSelector(QWidget* pParent, EffectsManager* pEffectsManag
     // https://bugs.launchpad.net/mixxx/+bug/1653140
     const QList<EffectManifest> availableEffectManifests = m_pEffectsManager->getAvailableEffectManifests();
     for (int i = 0; i < availableEffectManifests.size(); ++i) {
-        const EffectManifest& manifest = availableEffectManifests[i];
+        const EffectManifest& manifest = availableEffectManifests.at(i);
 
         QString displayName;
         if (manifest.shortName().isEmpty()) {

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -25,7 +25,9 @@ WEffectSelector::WEffectSelector(QWidget* pParent, EffectsManager* pEffectsManag
 
         //: %1 = effect name; %2 = effect description
         QString description = tr("%1: %2").arg(manifest.name(), manifest.description());
-        setItemData(i, QVariant(description), Qt::ToolTipRole);
+        // The <span/> is a hack to get Qt to treat the string as rich text so
+        // it automatically wraps long lines.
+        setItemData(i, QVariant("<span/>" + description), Qt::ToolTipRole);
     }
 
     //: Displayed when no effect is loaded

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -12,7 +12,8 @@ WEffectSelector::WEffectSelector(QWidget* pParent, EffectsManager* pEffectsManag
 
     // TODO(xxx): filter out blacklisted effects
     // https://bugs.launchpad.net/mixxx/+bug/1653140
-    const QList<EffectManifest> availableEffectManifests = m_pEffectsManager->getAvailableEffectManifests();
+    const QList<EffectManifest> availableEffectManifests =
+        m_pEffectsManager->getAvailableEffectManifests();
     for (int i = 0; i < availableEffectManifests.size(); ++i) {
         const EffectManifest& manifest = availableEffectManifests.at(i);
 

--- a/src/widget/weffectselector.h
+++ b/src/widget/weffectselector.h
@@ -1,0 +1,31 @@
+#ifndef WEFFECTSELECTOR_H
+#define WEFFECTSELECTOR_H
+
+#include <QDomNode>
+#include <QComboBox>
+#include "effects/effectrack.h"
+#include "effects/effectslot.h"
+#include "skin/skincontext.h"
+
+class EffectsManager;
+
+class WEffectSelector : public QComboBox, public WBaseWidget {
+    Q_OBJECT
+  public:
+    WEffectSelector(QWidget* pParent, EffectsManager* pEffectsManager);
+
+    void setup(const QDomNode& node, const SkinContext& context);
+
+  private slots:
+    void slotEffectUpdated();
+    void slotEffectSelected(int newIndex);
+
+  private:
+    EffectsManager* m_pEffectsManager;
+    EffectSlotPointer m_pEffectSlot;
+    EffectChainSlotPointer m_pChainSlot;
+    EffectRackPointer m_pRack;
+};
+
+
+#endif /* WEFFECTSELECTOR_H */


### PR DESCRIPTION
Add a new QComboBox widget to select an effect. This has several advantages:
* Next/previous effect and eject effect buttons can be removed from skins, freeing valuable space
* If the user wants to load a specific effect, they do not need to cycle through effects to do so.
* The list of available effects is visible to the user.
* The list of available effects is in predictable alphabetical order.

It is easy to replace EffectName elements in skin XML with the new EffectSelector element. All that is required is changing the element name. The skin will need to define styles for WEffectSelector to make the colors match the skin instead of the system Qt colors.