### PR TITLE
Launchpad 1658243: Increment plugin API version (std::shared_ptr)

### DIFF
--- a/src/sources/soundsourcepluginapi.h
+++ b/src/sources/soundsourcepluginapi.h
@@ -1,8 +1,9 @@
 #ifndef MIXXX_SOUNDSOURCEPLUGINAPI_H
 #define MIXXX_SOUNDSOURCEPLUGINAPI_H
 
-#define MIXXX_SOUNDSOURCEPLUGINAPI_VERSION 13
+#define MIXXX_SOUNDSOURCEPLUGINAPI_VERSION 14
 // SoundSource Plugin API version history:
+//  14 - Mixxx 2.1.0 - Replace QSharedPointer with std::shared_ptr
 //  13 - Mixxx 2.1.0 - New function in base class for verifying audio properties
 //  12 - Mixxx 2.1.0 - New result codes for opening files
 //  11 - Mixxx 2.1.0 - Add function for writing metadata to SoundSource


### PR DESCRIPTION
After recompiling the plugins the reported crash should be fixed. I forgot that the change from QSharedPointer to std::shared_pointer leaks into the plugin API.