### PR TITLE
Post Visual Studio 2015 Upgrade

### DIFF
--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -4,15 +4,15 @@
 
 namespace mixxx {
 
-/*static*/ const AudioSignal::SampleLayout AudioSource::kSampleLayout;
+/*static*/ constexpr AudioSignal::SampleLayout AudioSource::kSampleLayout;
 
-/*static*/ const SINT AudioSource::kFrameCountZero;
-/*static*/ const SINT AudioSource::kFrameCountDefault;
+/*static*/ constexpr SINT AudioSource::kFrameCountZero;
+/*static*/ constexpr SINT AudioSource::kFrameCountDefault;
 
-/*static*/ const SINT AudioSource::kFrameIndexMin;
+/*static*/ constexpr SINT AudioSource::kFrameIndexMin;
 
-/*static*/ const SINT AudioSource::kBitrateZero;
-/*static*/ const SINT AudioSource::kBitrateDefault;
+/*static*/ constexpr SINT AudioSource::kBitrateZero;
+/*static*/ constexpr SINT AudioSource::kBitrateDefault;
 
 void AudioSource::clampFrameInterval(
         SINT* pMinFrameIndexOfInterval,

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -4,6 +4,16 @@
 
 namespace mixxx {
 
+/*static*/ const AudioSignal::SampleLayout AudioSource::kSampleLayout;
+
+/*static*/ const SINT AudioSource::kFrameCountZero;
+/*static*/ const SINT AudioSource::kFrameCountDefault;
+
+/*static*/ const SINT AudioSource::kFrameIndexMin;
+
+/*static*/ const SINT AudioSource::kBitrateZero;
+/*static*/ const SINT AudioSource::kBitrateDefault;
+
 void AudioSource::clampFrameInterval(
         SINT* pMinFrameIndexOfInterval,
         SINT* pMaxFrameIndexOfInterval,

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -30,7 +30,7 @@ class AudioSourceConfig;
 // closed upon destruction.
 class AudioSource: public UrlResource, public AudioSignal {
   public:
-    static const SampleLayout kSampleLayout = SampleLayout::Interleaved;
+    static constexpr SampleLayout kSampleLayout = SampleLayout::Interleaved;
 
     // Returns the total number of sample frames.
     inline SINT getFrameCount() const {
@@ -199,14 +199,14 @@ class AudioSource: public UrlResource, public AudioSignal {
   private:
     friend class AudioSourceConfig;
 
-    static const SINT kFrameCountZero = 0;
-    static const SINT kFrameCountDefault = kFrameCountZero;
+    static constexpr SINT kFrameCountZero = 0;
+    static constexpr SINT kFrameCountDefault = kFrameCountZero;
 
     // 0-based indexing of sample frames
-    static const SINT kFrameIndexMin = 0;
+    static constexpr SINT kFrameIndexMin = 0;
 
-    static const SINT kBitrateZero = 0;
-    static const SINT kBitrateDefault = kBitrateZero;
+    static constexpr SINT kBitrateZero = 0;
+    static constexpr SINT kBitrateDefault = kBitrateZero;
 
     SINT m_frameCount;
 

--- a/src/sources/mp3decoding.h
+++ b/src/sources/mp3decoding.h
@@ -9,7 +9,7 @@ namespace mixxx {
 // for accurate seeking:
 // http://www.mars.org/mailman/public/mad-dev/2002-May/000634.html
 // Used by both SoundSourceMp3 and SoundSourceCoreAudio.
-static const SINT kMp3SeekFramePrefetchCount = 29;
+constexpr SINT kMp3SeekFramePrefetchCount = 29;
 
 } // namespace mixxx
 

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -39,9 +39,9 @@ QString getModPlugTypeFromUrl(QUrl url) {
 
 } // anonymous namespace
 
-const SINT SoundSourceModPlug::kChannelCount = AudioSource::kChannelCountStereo;
-const SINT SoundSourceModPlug::kBitsPerSample = 16;
-const SINT SoundSourceModPlug::kSamplingRate = 44100; // 44.1 kHz
+/*static*/ constexpr SINT SoundSourceModPlug::kChannelCount;
+/*static*/ constexpr SINT SoundSourceModPlug::kBitsPerSample;
+/*static*/ constexpr SINT SoundSourceModPlug::kSamplingRate;
 
 unsigned int SoundSourceModPlug::s_bufferSizeLimit = 0;
 

--- a/src/sources/soundsourcemodplug.h
+++ b/src/sources/soundsourcemodplug.h
@@ -16,9 +16,9 @@ namespace mixxx {
 // in RAM to allow seeking and smooth operation in Mixxx.
 class SoundSourceModPlug: public mixxx::SoundSource {
 public:
-    static const SINT kChannelCount;
-    static const SINT kSamplingRate;
-    static const SINT kBitsPerSample;
+     static constexpr SINT kChannelCount = kChannelCountStereo;
+     static constexpr SINT kSamplingRate = 16;
+     static constexpr SINT kBitsPerSample = 44100;
 
     // apply settings for decoding
     static void configure(unsigned int bufferSizeLimit,

--- a/src/sources/soundsourcemodplug.h
+++ b/src/sources/soundsourcemodplug.h
@@ -17,8 +17,8 @@ namespace mixxx {
 class SoundSourceModPlug: public mixxx::SoundSource {
 public:
      static constexpr SINT kChannelCount = kChannelCountStereo;
-     static constexpr SINT kSamplingRate = 16;
-     static constexpr SINT kBitsPerSample = 44100;
+     static constexpr SINT kSamplingRate = 44100;
+     static constexpr SINT kBitsPerSample = 16;
 
     // apply settings for decoding
     static void configure(unsigned int bufferSizeLimit,

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -9,7 +9,7 @@ const CSAMPLE SoundSourceOpus::kMaxDecodingError = 0.01f;
 namespace {
 
 // Decoded output of opusfile has a fixed sample rate of 48 kHz (fullband)
-const SINT kSamplingRate = 48000;
+constexpr SINT kSamplingRate = 48000;
 
 // http://opus-codec.org
 //  - Sampling rate 48 kHz (fullband)
@@ -17,15 +17,15 @@ const SINT kSamplingRate = 48000;
 //   => Up to 48000 kHz * 0.06 s = 2880 sample frames per data frame
 // Prefetching 2 * 2880 sample frames while seeking limits the decoding
 // errors to kMaxDecodingError (see definition below) during our tests.
-const SINT kNumberOfPrefetchFrames = 2 * 2880;
+constexpr SINT kNumberOfPrefetchFrames = 2 * 2880;
 
 // Parameter for op_channel_count()
 // See also: https://mf4.xiph.org/jenkins/view/opus/job/opusfile-unix/ws/doc/html/group__stream__info.html
-const int kCurrentStreamLink = -1; // get ... of the current (stream) link
+constexpr int kCurrentStreamLink = -1; // get ... of the current (stream) link
 
 // Parameter for op_pcm_total() and op_bitrate()
 // See also: https://mf4.xiph.org/jenkins/view/opus/job/opusfile-unix/ws/doc/html/group__stream__info.html
-const int kEntireStreamLink  = -1; // get ... of the whole/entire stream
+constexpr int kEntireStreamLink  = -1; // get ... of the whole/entire stream
 
 class OggOpusFileOwner {
 public:

--- a/src/track/bpm.cpp
+++ b/src/track/bpm.cpp
@@ -2,11 +2,8 @@
 
 namespace mixxx {
 
-// TODO(uklotzde): Replace 'const' with 'constexpr' and remove
-// initialization after switching to Visual Studio 2015.
-
-/*static*/ const double Bpm::kValueUndefined = 0.0;
-/*static*/ const double Bpm::kValueMin = 0.0; // lower bound (exclusive)
+/*static*/ constexpr double Bpm::kValueUndefined;
+/*static*/ constexpr double Bpm::kValueMin;
 
 double Bpm::valueFromString(const QString& str, bool* pValid) {
     if (pValid) {

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -10,11 +10,8 @@ namespace mixxx {
 // DTO for storing BPM information.
 class Bpm final {
 public:
-    // TODO(uklotzde): Replace 'const' with 'constexpr'
-    // (and copy initialization from .cpp file) after switching to
-    // Visual Studio 2015 on Windows.
-    static const double kValueUndefined;
-    static const double kValueMin; // lower bound (exclusive)
+    static constexpr double kValueUndefined = 0.0;
+    static constexpr double kValueMin = 0.0; // lower bound (exclusive)
 
     Bpm()
         : Bpm(kValueUndefined) {

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -100,13 +100,7 @@ class KeyUtils {
     }
 
     static inline double powerOf2ToOctaveChange(const double& power_of_2) {
-        // log2 is in the C99 standard, MSVC only supports C90.
-#ifdef _MSC_VER
-        static const double lg2 = log(2.0);
-        return log(power_of_2) / lg2;
-#else
         return log2(power_of_2);
-#endif
     }
 
     static inline double powerOf2ToSemitoneChange(const double& power_of_2) {

--- a/src/track/replaygain.cpp
+++ b/src/track/replaygain.cpp
@@ -4,16 +4,13 @@
 
 namespace mixxx {
 
-// TODO(uklotzde): Replace 'const' with 'constexpr' and remove
-// initialization after switching to Visual Studio 2015.
+/*static*/ constexpr double ReplayGain::kRatioUndefined;
+/*static*/ constexpr double ReplayGain::kRatioMin;
+/*static*/ constexpr double ReplayGain::kRatio0dB;
 
-/*static*/ const double ReplayGain::kRatioUndefined = 0.0;
-/*static*/ const double ReplayGain::kRatioMin = 0.0; // lower bound (exclusive)
-/*static*/ const double ReplayGain::kRatio0dB = 1.0;
-
-/*static*/ const CSAMPLE ReplayGain::kPeakUndefined = -CSAMPLE_PEAK;
-/*static*/ const CSAMPLE ReplayGain::kPeakMin = CSAMPLE_ZERO; // lower bound (inclusive)
-/*static*/ const CSAMPLE ReplayGain::kPeakClip = CSAMPLE_PEAK; // upper bound (inclusive) represents digital full scale without clipping;
+/*static*/ constexpr CSAMPLE ReplayGain::kPeakUndefined;
+/*static*/ constexpr CSAMPLE ReplayGain::kPeakMin;
+/*static*/ constexpr CSAMPLE ReplayGain::kPeakClip;
 
 namespace {
 

--- a/src/track/replaygain.h
+++ b/src/track/replaygain.h
@@ -23,16 +23,13 @@ namespace mixxx {
 // as a string into file tags.
 class ReplayGain final {
 public:
-    // TODO(uklotzde): Replace 'const' with 'constexpr'
-    // (and copy initialization from .cpp file) after switching to
-    // Visual Studio 2015 on Windows.
-    static const double kRatioUndefined;
-    static const double kRatioMin; // lower bound (exclusive)
-    static const double kRatio0dB;
+    static constexpr double kRatioUndefined = 0.0;
+    static constexpr double kRatioMin = 0.0; // lower bound (exclusive)
+    static constexpr double kRatio0dB = 1.0;
 
-    static const CSAMPLE kPeakUndefined;
-    static const CSAMPLE kPeakMin; // lower bound (inclusive)
-    static const CSAMPLE kPeakClip; // upper bound (inclusive) represents digital full scale without clipping
+    static constexpr CSAMPLE kPeakUndefined = -CSAMPLE_PEAK;
+    static constexpr CSAMPLE kPeakMin = CSAMPLE_ZERO; // lower bound (inclusive)
+    static constexpr CSAMPLE kPeakClip = CSAMPLE_PEAK; // upper bound (inclusive) represents digital full scale without clipping
 
     // TODO(uklotzde): Uncomment after switching to Visual Studio 2015
     // on Windows.

--- a/src/track/replaygain.h
+++ b/src/track/replaygain.h
@@ -31,13 +31,11 @@ public:
     static constexpr CSAMPLE kPeakMin = CSAMPLE_ZERO; // lower bound (inclusive)
     static constexpr CSAMPLE kPeakClip = CSAMPLE_PEAK; // upper bound (inclusive) represents digital full scale without clipping
 
-    // TODO(uklotzde): Uncomment after switching to Visual Studio 2015
-    // on Windows.
-    //static_assert(ReplayGain::kPeakClip == 1.0,
-    //        "http://wiki.hydrogenaud.io/index.php"
-    //        "?title=ReplayGain_2.0_specification#Peak_amplitude: "
-    //        "The maximum peak amplitude value is stored as a floating number, "
-    //        "where 1.0 represents digital full scale");
+    static_assert(ReplayGain::kPeakClip == 1.0,
+            "http://wiki.hydrogenaud.io/index.php"
+            "?title=ReplayGain_2.0_specification#Peak_amplitude: "
+            "The maximum peak amplitude value is stored as a floating number, "
+            "where 1.0 represents digital full scale");
 
     ReplayGain()
         : ReplayGain(kRatioUndefined, kPeakUndefined) {

--- a/src/track/trackid.h
+++ b/src/track/trackid.h
@@ -7,17 +7,8 @@
 
 class TrackId: public DbId {
 public:
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-    // NOTE(uklotzde): Inheriting constructors are supported since VS2015.
-    // Use a default constructor and a single-argument constructor with
-    // perfect forwarding instead.
-    TrackId() {}
-    template<typename T>
-    explicit TrackId(T&& arg): DbId(std::forward<T>(arg)) {}
-#else
     // Inherit constructors from base class
     using DbId::DbId;
-#endif
 };
 
 Q_DECLARE_TYPEINFO(TrackId, Q_MOVABLE_TYPE);

--- a/src/track/trackmetadata.cpp
+++ b/src/track/trackmetadata.cpp
@@ -2,7 +2,7 @@
 
 namespace mixxx {
 
-/*static*/ const int TrackMetadata::kCalendarYearInvalid = 0;
+/*static*/ constexpr int TrackMetadata::kCalendarYearInvalid;
 
 int TrackMetadata::parseCalendarYear(QString year, bool* pValid) {
     const QDateTime dateTime(parseDateTime(year));

--- a/src/track/trackmetadata.h
+++ b/src/track/trackmetadata.h
@@ -9,7 +9,7 @@
 namespace mixxx {
 
 // DTO for track metadata properties. Must not be subclassed (no virtual destructor)!
-class TrackMetadata {
+class TrackMetadata final {
 public:
     TrackMetadata();
 
@@ -165,7 +165,7 @@ public:
     }
 
     // Parse and format the calendar year (for simplified display)
-    static const int kCalendarYearInvalid;
+    static constexpr int kCalendarYearInvalid = 0;
     static int parseCalendarYear(QString year, bool* pValid = 0);
     static QString formatCalendarYear(QString year, bool* pValid = 0);
 

--- a/src/track/tracknumbers.cpp
+++ b/src/track/tracknumbers.cpp
@@ -3,8 +3,8 @@
 #include "track/tracknumbers.h"
 #include "util/assert.h"
 
-/*static*/ const int TrackNumbers::kValueUndefined;
-/*static*/ const int TrackNumbers::kValueMin;
+/*static*/ constexpr int TrackNumbers::kValueUndefined;
+/*static*/ constexpr int TrackNumbers::kValueMin;
 
 /*static*/ const QString TrackNumbers::kSeparator("/");
 

--- a/src/track/tracknumbers.cpp
+++ b/src/track/tracknumbers.cpp
@@ -3,8 +3,10 @@
 #include "track/tracknumbers.h"
 #include "util/assert.h"
 
-// static
-const QString TrackNumbers::kSeparator("/");
+/*static*/ const int TrackNumbers::kValueUndefined;
+/*static*/ const int TrackNumbers::kValueMin;
+
+/*static*/ const QString TrackNumbers::kSeparator("/");
 
 //static
 bool TrackNumbers::parseValueFromString(

--- a/src/track/tracknumbers.h
+++ b/src/track/tracknumbers.h
@@ -9,9 +9,8 @@
 // Both numbers are 1-based and 0 indicates an undefined value.
 class TrackNumbers final {
 public:
-    // TODO(uklotzde): Replace 'const' with 'constexpr'
-    static const int kValueUndefined = 0;
-    static const int kValueMin = 1; // lower bound (inclusive)
+    static constexpr int kValueUndefined = 0;
+    static constexpr int kValueMin = 1; // lower bound (inclusive)
 
     // Separates the total number of tracks from the actual
     // track number in the textual format.

--- a/src/util/audiosignal.cpp
+++ b/src/util/audiosignal.cpp
@@ -4,10 +4,6 @@
 
 namespace mixxx {
 
-// Separate definitions of static class constants are only required
-// for LLVM CLang. Otherwise the linker complains about undefined
-// symbols!?
-#if defined(__clang__)
 const SINT AudioSignal::kChannelCountZero;
 const SINT AudioSignal::kChannelCountDefault;
 const SINT AudioSignal::kChannelCountMono;
@@ -23,7 +19,6 @@ const SINT AudioSignal::kSamplingRate48kHz;
 const SINT AudioSignal::kSamplingRate96kHz;
 const SINT AudioSignal::kSamplingRate192kHz;
 const SINT AudioSignal::kSamplingRateMax;
-#endif
 
 bool AudioSignal::verifyReadable() const {
     bool result = true;

--- a/src/util/audiosignal.cpp
+++ b/src/util/audiosignal.cpp
@@ -4,21 +4,22 @@
 
 namespace mixxx {
 
-const SINT AudioSignal::kChannelCountZero;
-const SINT AudioSignal::kChannelCountDefault;
-const SINT AudioSignal::kChannelCountMono;
-const SINT AudioSignal::kChannelCountMin;
-const SINT AudioSignal::kChannelCountStereo;
-const SINT AudioSignal::kChannelCountMax;
-const SINT AudioSignal::kSamplingRateZero;
-const SINT AudioSignal::kSamplingRateDefault;
-const SINT AudioSignal::kSamplingRateMin;
-const SINT AudioSignal::kSamplingRate32kHz;
-const SINT AudioSignal::kSamplingRateCD;
-const SINT AudioSignal::kSamplingRate48kHz;
-const SINT AudioSignal::kSamplingRate96kHz;
-const SINT AudioSignal::kSamplingRate192kHz;
-const SINT AudioSignal::kSamplingRateMax;
+/*static*/ constexpr SINT AudioSignal::kChannelCountZero;
+/*static*/ constexpr SINT AudioSignal::kChannelCountDefault;
+/*static*/ constexpr SINT AudioSignal::kChannelCountMono;
+/*static*/ constexpr SINT AudioSignal::kChannelCountMin;
+/*static*/ constexpr SINT AudioSignal::kChannelCountStereo;
+/*static*/ constexpr SINT AudioSignal::kChannelCountMax;
+
+/*static*/ constexpr SINT AudioSignal::kSamplingRateZero;
+/*static*/ constexpr SINT AudioSignal::kSamplingRateDefault;
+/*static*/ constexpr SINT AudioSignal::kSamplingRateMin;
+/*static*/ constexpr SINT AudioSignal::kSamplingRate32kHz;
+/*static*/ constexpr SINT AudioSignal::kSamplingRateCD;
+/*static*/ constexpr SINT AudioSignal::kSamplingRate48kHz;
+/*static*/ constexpr SINT AudioSignal::kSamplingRate96kHz;
+/*static*/ constexpr SINT AudioSignal::kSamplingRate192kHz;
+/*static*/ constexpr SINT AudioSignal::kSamplingRateMax;
 
 bool AudioSignal::verifyReadable() const {
     bool result = true;

--- a/src/util/audiosignal.h
+++ b/src/util/audiosignal.h
@@ -31,26 +31,26 @@ public:
         Interleaved
     };
 
-    static const SINT kChannelCountZero    = 0;
-    static const SINT kChannelCountDefault = kChannelCountZero;
-    static const SINT kChannelCountMono    = 1;
-    static const SINT kChannelCountMin     = kChannelCountMono; // lower bound
-    static const SINT kChannelCountStereo  = 2;
-    static const SINT kChannelCountMax     = 256; // upper bound (8-bit unsigned integer)
+    static constexpr SINT kChannelCountZero    = 0;
+    static constexpr SINT kChannelCountDefault = kChannelCountZero;
+    static constexpr SINT kChannelCountMono    = 1;
+    static constexpr SINT kChannelCountMin     = kChannelCountMono; // lower bound
+    static constexpr SINT kChannelCountStereo  = 2;
+    static constexpr SINT kChannelCountMax     = 256; // upper bound (8-bit unsigned integer)
 
     static bool isValidChannelCount(SINT channelCount) {
         return (kChannelCountMin <= channelCount) && (kChannelCountMax >= channelCount);
     }
 
-    static const SINT kSamplingRateZero    = 0;
-    static const SINT kSamplingRateDefault = kSamplingRateZero;
-    static const SINT kSamplingRateMin     = 8000; // lower bound (= minimum MP3 sampling rate)
-    static const SINT kSamplingRate32kHz   = 32000;
-    static const SINT kSamplingRateCD      = 44100;
-    static const SINT kSamplingRate48kHz   = 48000;
-    static const SINT kSamplingRate96kHz   = 96000;
-    static const SINT kSamplingRate192kHz  = 192000;
-    static const SINT kSamplingRateMax     = kSamplingRate192kHz; // upper bound
+    static constexpr SINT kSamplingRateZero    = 0;
+    static constexpr SINT kSamplingRateDefault = kSamplingRateZero;
+    static constexpr SINT kSamplingRateMin     = 8000; // lower bound (= minimum MP3 sampling rate)
+    static constexpr SINT kSamplingRate32kHz   = 32000;
+    static constexpr SINT kSamplingRateCD      = 44100;
+    static constexpr SINT kSamplingRate48kHz   = 48000;
+    static constexpr SINT kSamplingRate96kHz   = 96000;
+    static constexpr SINT kSamplingRate192kHz  = 192000;
+    static constexpr SINT kSamplingRateMax     = kSamplingRate192kHz; // upper bound
 
     static bool isValidSamplingRate(SINT samplingRate) {
         return (kSamplingRateMin <= samplingRate) && (kSamplingRateMax >= samplingRate);

--- a/src/util/math.h
+++ b/src/util/math.h
@@ -65,13 +65,6 @@ inline int roundUpToPowerOf2(int v) {
     return power;
 }
 
-// MSVS 2013 (_MSC_VER 1800) introduced C99 support.
-#if defined(__WINDOWS__) &&  _MSC_VER < 1800
-inline int round(double x) {
-    return x < 0.0 ? ceil(x - 0.5) : floor(x + 0.5);
-}
-#endif
-
 template <typename T>
 inline const T ratio2db(const T a) {
     return log10(a) * 20;

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -6,9 +6,6 @@
 
 #include "util/math.h"
 
-// TODO(uklotzde): Replace 'const' with 'constexpr' after
-// switching to Visual Studio 2015 on Windows.
-
 // Signed integer type for POT array indices, sizes and pointer
 // arithmetic. Its size (32-/64-bit) depends on the CPU architecture.
 // This should be used for all CSAMLE operations since it is fast and
@@ -19,9 +16,9 @@ typedef std::ptrdiff_t SINT;
 // 16-bit integer sample data within the asymmetric
 // range [SHRT_MIN, SHRT_MAX].
 typedef short int SAMPLE;
-const SAMPLE SAMPLE_ZERO = 0;
-const SAMPLE SAMPLE_MIN = SHRT_MIN;
-const SAMPLE SAMPLE_MAX = SHRT_MAX;
+constexpr SAMPLE SAMPLE_ZERO = 0;
+constexpr SAMPLE SAMPLE_MIN = SHRT_MIN;
+constexpr SAMPLE SAMPLE_MAX = SHRT_MAX;
 
 // Limits the range of a SAMPLE value to [SAMPLE_MIN, SAMPLE_MAX].
 inline
@@ -41,9 +38,9 @@ SAMPLE SAMPLE_clampSymmetric(SAMPLE in) {
 // emphasize the symmetric value range of CSAMPLE
 // data!
 typedef float CSAMPLE;
-const CSAMPLE CSAMPLE_ZERO = 0.0f;
-const CSAMPLE CSAMPLE_ONE = 1.0f;
-const CSAMPLE CSAMPLE_PEAK = CSAMPLE_ONE;
+constexpr CSAMPLE CSAMPLE_ZERO = 0.0f;
+constexpr CSAMPLE CSAMPLE_ONE = 1.0f;
+constexpr CSAMPLE CSAMPLE_PEAK = CSAMPLE_ONE;
 
 // Limits the range of a CSAMPLE value to [-CSAMPLE_PEAK, CSAMPLE_PEAK].
 inline
@@ -55,10 +52,10 @@ CSAMPLE CSAMPLE_clamp(CSAMPLE in) {
 // data in the range [0.0, 1.0]. Same data type as
 // CSAMPLE to avoid type conversions in calculations.
 typedef CSAMPLE CSAMPLE_GAIN;
-const float CSAMPLE_GAIN_ZERO = CSAMPLE_ZERO;
-const float CSAMPLE_GAIN_ONE = CSAMPLE_ONE;
-const float CSAMPLE_GAIN_MIN = CSAMPLE_GAIN_ZERO;
-const float CSAMPLE_GAIN_MAX = CSAMPLE_GAIN_ONE;
+constexpr float CSAMPLE_GAIN_ZERO = CSAMPLE_ZERO;
+constexpr float CSAMPLE_GAIN_ONE = CSAMPLE_ONE;
+constexpr float CSAMPLE_GAIN_MIN = CSAMPLE_GAIN_ZERO;
+constexpr float CSAMPLE_GAIN_MAX = CSAMPLE_GAIN_ONE;
 
 // Limits the range of a CSAMPLE_GAIN value to [CSAMPLE_GAIN_MIN, CSAMPLE_GAIN_MAX].
 inline


### PR DESCRIPTION
Visual Studio 2015 is now the minimum requirement for compiling Mixxx on Windows.

This PR includes the definition of missing static const/constexpr class constants detected with _optimize=off_. Visual Studio 2013 didn't like those.

I did **NOT** remove any version checks in external sources that we just copied!