### PR TITLE
Introduce "parented_ptr" wrapper class

### DIFF
--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -1,0 +1,88 @@
+#ifndef UTIL_PARENTED_POINTER_H
+#define UTIL_PARENTED_POINTER_H
+
+#include <memory>
+#include "util/assert.h"
+
+
+/**
+ * Use this wrapper class to clearly represent a pointer that is owned by the QT object tree.
+ * Objects which both derive from QObject AND have a parent object, have their lifetime governed by the QT object tree, 
+ * and thus pointers to such objects do not need to be deleted when they go  out of scope.
+**/
+template <typename T>
+class parented_ptr {
+  public:
+    explicit parented_ptr(T* t) : m_pObject(t) {
+        DEBUG_ASSERT(t->parent() != nullptr);
+    }
+
+    /* If U* is convertible to T* then we also want parented_ptr<U> convertible to parented_ptr<T> */
+    template <typename U>
+    parented_ptr(const parented_ptr<U>& u, typename std::enable_if<std::is_convertible<U*, T*>::value, void>::type * = 0) 
+            : m_pObject(u.get()) {
+        DEBUG_ASSERT(u->parent() != nullptr);
+    }
+
+    parented_ptr() : m_pObject(nullptr) {}
+
+    ~parented_ptr() = default;
+
+    T* get() const {
+        return m_pObject;
+    }
+
+    T& operator* () const {
+        return *m_pObject;
+    }
+
+    T* operator-> () const {
+        return m_pObject;
+    }
+
+    bool operator== (const parented_ptr& other) const {
+        return m_pObject == other.m_ptr;
+    }
+
+    bool operator== (const T* other) const {
+        return m_pObject == other;
+    }
+
+    bool operator!= (const parented_ptr& other) const {
+        return m_pObject != other.m_pObject;
+    }
+
+    bool operator!= (const T* other) const {
+        return m_pObject != other;
+    }
+
+    operator bool() const {
+        return m_pObject != nullptr;
+    }
+
+    /* 
+     * If U* is convertible to T* then we also want parented_ptr<U> assignable to parented_ptr<T> 
+     * E.g. parented_ptr<Base> base = make_parented<Derived>(); should work as expected.
+     */
+    template <typename U>
+    typename std::enable_if<std::is_convertible<U*, T*>::value, parented_ptr<T>&>::type
+            operator=(const parented_ptr<U>& p) {
+        m_pObject = p.get();
+        return *this;
+    }
+
+  private:
+    T* m_pObject;
+};
+
+namespace {
+
+template<typename T, typename... Args>
+inline parented_ptr<T> make_parented(Args&&... args) {
+    return parented_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+
+} // namespace
+
+#endif /* UTIL_PARENTED_POINTER_H */


### PR DESCRIPTION
**Proposed change to the coding guidelines:**

*No naked new statements.*

1) If a pointer is to be managed by the QT object tree, and has a known parent at the time of creation, use `make_parented<T>`
1) If a pointer is *not* to be managed by the QT object tree, use `std::make_unique<T>` to create the object, or `std::make_shared<T>` if shared ownership is really necessary.
1) If a pointer that will eventually be managed by the object tree needs to be created without a parent, create the object `p` with `std::make_unique<T>`, then later create a new variable using `parented_ptr(p.release())` once the underlying object gets a parent.
1) If a raw pointer is passed into or out of a function, it should be assumed that the pointer is being "borrowed". Keeping a pointer (or reference) to the underlying object violates this assumption and should be avoided. Instead use `std::move()` with a `unique_ptr` if ownership is to be transferred, or if shared ownership is really necessary then use `shared_ptr`.
1) As per the previous rule, in general we can say that a class should not have raw pointers as member variables. Always wrap pointer member variables in `parented_ptr<T>`, `unique_ptr<T>`, or `shared_ptr<T>`.
1) Any exceptions to these guidelines must be clearly documented inline in the code

**Reasons for the change**
It's currently extremely difficult to review new and existing mixxx code for memory leaks and dangling pointers because the code base is scattered with naked new calls, and ownership of pointers is almost never clear. Modern C++ [discourages](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r11-avoid-calling-new-and-delete-explicitly) using `new` and `delete`, so we should localize usage of these to a small number of places where the syntax makes ownership clear.