### PR TITLE
Remove adopting Meta knob after effect load

### DIFF
--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -163,11 +163,13 @@ void EffectSlot::loadEffect(EffectPointer pEffect) {
         connect(pEffect.data(), SIGNAL(enabledChanged(bool)),
                 this, SLOT(slotEffectEnabledChanged(bool)));
 
-        while (static_cast<unsigned int>(m_parameters.size()) < pEffect->numKnobParameters()) {
+        while (static_cast<unsigned int>(m_parameters.size())
+                < pEffect->numKnobParameters()) {
             addEffectParameterSlot();
         }
 
-        while (static_cast<unsigned int>(m_buttonParameters.size()) < pEffect->numButtonParameters()) {
+        while (static_cast<unsigned int>(m_buttonParameters.size())
+                < pEffect->numButtonParameters()) {
             addEffectButtonParameterSlot();
         }
 
@@ -178,8 +180,6 @@ void EffectSlot::loadEffect(EffectPointer pEffect) {
         for (const auto& pParameter : m_buttonParameters) {
             pParameter->loadEffect(pEffect);
         }
-
-        slotEffectMetaParameter(m_pControlMetaParameter->get(), true);
 
         emit(effectLoaded(pEffect, m_iEffectNumber));
     } else {
@@ -247,8 +247,8 @@ double EffectSlot::getMetaParameter() const {
 // slotEffectMetaParameter does not need to update m_pControlMetaParameter's value
 void EffectSlot::setMetaParameter(double v, bool force) {
     if (!m_pSoftTakeover->ignore(m_pControlMetaParameter, v)
-        || !m_pControlEnabled->toBool()
-        || force) {
+            || !m_pControlEnabled->toBool()
+            || force) {
         m_pControlMetaParameter->set(v);
         slotEffectMetaParameter(v, force);
     }


### PR DESCRIPTION
As discussed in https://github.com/mixxxdj/mixxx/pull/1118 with current master you do not get the default values of an effect after load, because the meta knob position is adopted. This is especially annoying if the user has no meta-knob on his controller and in case of the Filer effect which is silent in this case. 

This was originally introduces to avoid out of sync situations and the need for "snap in" when turning the meta-knob the first time. 

Now we have removed softtakover in when the effect is disabled which allows us the remove the initial meta-knob adoption.

It behaves now like this:

* Effect loads always with it's own default.
* If the effect is disabled, which is recommended when chaining effects, A touch at the meta-knob makes the parameter jump to the linked position 
* If the effect is enabled before touching the meta-knob, it plays with the well prepared defaults. When you touch the meta-knob nothing happens until you cross the current position of the mapped knobs. 
    

 