### PR TITLE
Patch gmock-1.7.0 to avoid segfaults with GCC 6 during tests

### DIFF
--- a/lib/gmock-1.7.0/include/gmock/gmock-spec-builders.h
+++ b/lib/gmock-1.7.0/include/gmock/gmock-spec-builders.h
@@ -1381,7 +1381,7 @@ class ActionResultHolder<void> : public UntypedActionResultHolderBase {
       const typename Function<F>::ArgumentTuple& args,
       const string& call_description) {
     func_mocker->PerformDefaultAction(args, call_description);
-    return NULL;
+    return new ActionResultHolder();
   }
 
   // Performs the given action and returns NULL.
@@ -1390,7 +1390,7 @@ class ActionResultHolder<void> : public UntypedActionResultHolderBase {
       const Action<F>& action,
       const typename Function<F>::ArgumentTuple& args) {
     action.Perform(args);
-    return NULL;
+    return new ActionResultHolder();
   }
 };
 


### PR DESCRIPTION
With this simple patch the complete test suite passes when compiled with GCC 6.

As suggested here:
https://github.com/google/googletest/issues/705#issuecomment-235067917

Reported here:
https://bugs.launchpad.net/mixxx/+bug/1600578