### PR TITLE
Rename debug assertion macro

### DIFF
--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -139,7 +139,7 @@ MP4TrackId findFirstAudioTrackId(MP4FileHandle hFile, const QString& fileName) {
                     << fileName;
             continue;
         }
-        DEBUG_ASSERT_AND_HANDLE(!"unreachable code") {
+        VERIFY_OR_DEBUG_ASSERT(!"unreachable code") {
             qWarning() << "Skipping track"
                     << trackId
                     << "of"

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -53,7 +53,7 @@ SoundSourceMediaFoundation::~SoundSourceMediaFoundation() {
 }
 
 SoundSource::OpenResult SoundSourceMediaFoundation::tryOpen(const AudioSourceConfig& audioSrcCfg) {
-    DEBUG_ASSERT_AND_HANDLE(!SUCCEEDED(m_hrCoInitialize)) {
+    VERIFY_OR_DEBUG_ASSERT(!SUCCEEDED(m_hrCoInitialize)) {
         qWarning() << kLogPreamble
                 << "Cannot reopen file"
                 << getUrlString();
@@ -412,7 +412,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
                     pLockedSampleBuffer,
                     writableChunk.size());
             HRESULT hrUnlock = pMediaBuffer->Unlock();
-            DEBUG_ASSERT_AND_HANDLE(SUCCEEDED(hrUnlock)) {
+            VERIFY_OR_DEBUG_ASSERT(SUCCEEDED(hrUnlock)) {
                 qWarning() << kLogPreamble
                         << "IMFMediaBuffer::Unlock() failed"
                         << hrUnlock;

--- a/src/analyzer/analyzerebur128.cpp
+++ b/src/analyzer/analyzerebur128.cpp
@@ -58,7 +58,7 @@ void AnalyzerEbur128::process(const CSAMPLE *pIn, const int iLen) {
     ScopedTimer t("AnalyzerEbur128::process()");
     size_t frames = iLen / 2;
     int e = ebur128_add_frames_float(m_pState, pIn, frames);
-    DEBUG_ASSERT_AND_HANDLE(e == EBUR128_SUCCESS) {
+    VERIFY_OR_DEBUG_ASSERT(e == EBUR128_SUCCESS) {
         qWarning() << "AnalyzerEbur128::process() failed with" << e;
         return;
     }
@@ -71,7 +71,7 @@ void AnalyzerEbur128::finalize(TrackPointer tio) {
     double averageLufs;
     int e = ebur128_loudness_global(m_pState, &averageLufs);
     cleanup(tio);
-    DEBUG_ASSERT_AND_HANDLE(e == EBUR128_SUCCESS) {
+    VERIFY_OR_DEBUG_ASSERT(e == EBUR128_SUCCESS) {
         qWarning() << "AnalyzerEbur128::finalize() failed with" << e;
         return;
     }

--- a/src/effects/effectparameter.cpp
+++ b/src/effects/effectparameter.cpp
@@ -144,7 +144,7 @@ void EffectParameter::setMinimum(double minimum) {
     // value is currently below the manifest minimum. Since similar
     // guards exist in the setMaximum call, this should not be able to
     // happen.
-    DEBUG_ASSERT_AND_HANDLE(m_minimum >= m_parameter.getMinimum()) {
+    VERIFY_OR_DEBUG_ASSERT(m_minimum >= m_parameter.getMinimum()) {
         return;
     }
 
@@ -180,7 +180,7 @@ void EffectParameter::setMaximum(double maximum) {
     // value is currently above the manifest maximum. Since similar
     // guards exist in the setMinimum call, this should not be able to
     // happen.
-    DEBUG_ASSERT_AND_HANDLE(m_maximum <= m_parameter.getMaximum()) {
+    VERIFY_OR_DEBUG_ASSERT(m_maximum <= m_parameter.getMaximum()) {
         return;
     }
 

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -59,7 +59,7 @@ bool alphabetizeEffectManifests(const EffectManifest& manifest1,
 }
 
 void EffectsManager::addEffectsBackend(EffectsBackend* pBackend) {
-    DEBUG_ASSERT_AND_HANDLE(pBackend) {
+    VERIFY_OR_DEBUG_ASSERT(pBackend) {
         return;
     }
     m_effectsBackends.append(pBackend);

--- a/src/effects/native/echoeffect.cpp
+++ b/src/effects/native/echoeffect.cpp
@@ -105,7 +105,7 @@ void EchoEffect::processChannel(const ChannelHandle& handle, EchoGroupState* pGr
     double pingpong_frac = m_pPingPongParameter->value();
 
     int delay_samples = EchoGroupState::kChannelCount * delay_time * sampleRate;
-    DEBUG_ASSERT_AND_HANDLE(delay_samples <= gs.delay_buf.size()) {
+    VERIFY_OR_DEBUG_ASSERT(delay_samples <= gs.delay_buf.size()) {
         delay_samples = gs.delay_buf.size();
     }
 

--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -233,12 +233,12 @@ SINT CachingReader::read(SINT startSample, SINT numSamples, bool reverse, CSAMPL
     }
 
     // Check for bad inputs
-    DEBUG_ASSERT_AND_HANDLE(sample % CachingReaderChunk::kChannels == 0) {
+    VERIFY_OR_DEBUG_ASSERT(sample % CachingReaderChunk::kChannels == 0) {
         // This problem is easy to fix, but this type of call should be
         // complained about loudly.
         --sample;
     }
-    DEBUG_ASSERT_AND_HANDLE(numSamples % CachingReaderChunk::kChannels == 0) {
+    VERIFY_OR_DEBUG_ASSERT(numSamples % CachingReaderChunk::kChannels == 0) {
         --numSamples;
     }
     if (numSamples < 0 || !buffer) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -374,7 +374,7 @@ void EngineBuffer::queueNewPlaypos(double newpos, enum SeekRequest seekType) {
     // All seeks need to be done in the Engine thread so queue it up.
     // Write the position before the seek type, to reduce a possible race
     // condition effect
-    DEBUG_ASSERT_AND_HANDLE(seekType != SEEK_PHASE) {
+    VERIFY_OR_DEBUG_ASSERT(seekType != SEEK_PHASE) {
         // SEEK_PHASE with a position is not supported
         // use SEEK_STANDARD for that
         seekType = SEEK_STANDARD;
@@ -715,7 +715,7 @@ void EngineBuffer::slotKeylockEngineChanged(double dIndex) {
 
 void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
     // Bail if we receive a buffer size with incomplete sample frames. Assert in debug builds.
-    DEBUG_ASSERT_AND_HANDLE((iBufferSize % kSamplesPerFrame) == 0) {
+    VERIFY_OR_DEBUG_ASSERT((iBufferSize % kSamplesPerFrame) == 0) {
         return;
     }
     m_pReader->process();

--- a/src/engine/enginebufferscalelinear.cpp
+++ b/src/engine/enginebufferscalelinear.cpp
@@ -190,7 +190,7 @@ SINT EngineBufferScaleLinear::do_scale(CSAMPLE* buf, SINT buf_size) {
 
     // We special case direction change in the calling function, so this
     // shouldn't happen
-    DEBUG_ASSERT_AND_HANDLE(rate_new * rate_old >= 0) {
+    VERIFY_OR_DEBUG_ASSERT(rate_new * rate_old >= 0) {
         // We cannot change direction here.
         qDebug() << "EBSL::do_scale() can't change direction";
         rate_old = 0;

--- a/src/engine/enginedelay.cpp
+++ b/src/engine/enginedelay.cpp
@@ -63,10 +63,10 @@ void EngineDelay::process(CSAMPLE* pInOut, const int iBufferSize) {
     if (m_iDelay > 0) {
         int iDelaySourcePos = (m_iDelayPos + kiMaxDelay - m_iDelay) % kiMaxDelay;
 
-        DEBUG_ASSERT_AND_HANDLE(iDelaySourcePos >= 0) {
+        VERIFY_OR_DEBUG_ASSERT(iDelaySourcePos >= 0) {
             return;
         }
-        DEBUG_ASSERT_AND_HANDLE(iDelaySourcePos <= kiMaxDelay) {
+        VERIFY_OR_DEBUG_ASSERT(iDelaySourcePos <= kiMaxDelay) {
             return;
         }
 

--- a/src/engine/enginefilterdelay.h
+++ b/src/engine/enginefilterdelay.h
@@ -39,11 +39,11 @@ class EngineFilterDelay : public EngineObjectConstIn {
         if (!m_doRamping) {
             int delaySourcePos = (m_delayPos + SIZE - m_delaySamples) % SIZE;
 
-            DEBUG_ASSERT_AND_HANDLE(delaySourcePos >= 0) {
+            VERIFY_OR_DEBUG_ASSERT(delaySourcePos >= 0) {
                 SampleUtil::copy(pOutput, pIn, iBufferSize);
                 return;
             }
-            DEBUG_ASSERT_AND_HANDLE(delaySourcePos <= static_cast<int>(SIZE)) {
+            VERIFY_OR_DEBUG_ASSERT(delaySourcePos <= static_cast<int>(SIZE)) {
                 SampleUtil::copy(pOutput, pIn, iBufferSize);
                 return;
             }
@@ -61,19 +61,19 @@ class EngineFilterDelay : public EngineObjectConstIn {
             int delaySourcePos = (m_delayPos + SIZE - m_delaySamples + iBufferSize / 2) % SIZE;
             int oldDelaySourcePos = (m_delayPos + SIZE - m_oldDelaySamples) % SIZE;
 
-            DEBUG_ASSERT_AND_HANDLE(delaySourcePos >= 0) {
+            VERIFY_OR_DEBUG_ASSERT(delaySourcePos >= 0) {
                 SampleUtil::copy(pOutput, pIn, iBufferSize);
                 return;
             }
-            DEBUG_ASSERT_AND_HANDLE(delaySourcePos <= static_cast<int>(SIZE)) {
+            VERIFY_OR_DEBUG_ASSERT(delaySourcePos <= static_cast<int>(SIZE)) {
                 SampleUtil::copy(pOutput, pIn, iBufferSize);
                 return;
             }
-            DEBUG_ASSERT_AND_HANDLE(oldDelaySourcePos >= 0) {
+            VERIFY_OR_DEBUG_ASSERT(oldDelaySourcePos >= 0) {
                 SampleUtil::copy(pOutput, pIn, iBufferSize);
                 return;
             }
-            DEBUG_ASSERT_AND_HANDLE(oldDelaySourcePos <= static_cast<int>(SIZE)) {
+            VERIFY_OR_DEBUG_ASSERT(oldDelaySourcePos <= static_cast<int>(SIZE)) {
                 SampleUtil::copy(pOutput, pIn, iBufferSize);
                 return;
             }

--- a/src/engine/enginefilterpan.h
+++ b/src/engine/enginefilterpan.h
@@ -51,7 +51,7 @@ class EngineFilterPan : public EngineObjectConstIn {
             delayRightSourceFrame = m_delayFrame + SIZE + m_leftDelayFrames;
         }
 
-        DEBUG_ASSERT_AND_HANDLE(delayLeftSourceFrame >= 0 &&
+        VERIFY_OR_DEBUG_ASSERT(delayLeftSourceFrame >= 0 &&
                                 delayRightSourceFrame >= 0) {
             SampleUtil::copy(pOutput, pIn, iBufferSize);
             return;
@@ -81,7 +81,7 @@ class EngineFilterPan : public EngineObjectConstIn {
                 delayOldRightSourceFrame = m_delayFrame + SIZE + m_oldLeftDelayFrames;
             }
 
-            DEBUG_ASSERT_AND_HANDLE(delayOldLeftSourceFrame >= 0 &&
+            VERIFY_OR_DEBUG_ASSERT(delayOldLeftSourceFrame >= 0 &&
                                     delayOldRightSourceFrame >= 0) {
                 SampleUtil::copy(pOutput, pIn, iBufferSize);
                 return;

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -924,7 +924,7 @@ void LoopingControl::seekInsideAdjustedLoop(int old_loop_in, int old_loop_out,
     int adjusted_position = currentSample;
     while (adjusted_position > new_loop_out) {
         adjusted_position -= new_loop_size;
-        DEBUG_ASSERT_AND_HANDLE(adjusted_position > new_loop_in) {
+        VERIFY_OR_DEBUG_ASSERT(adjusted_position > new_loop_in) {
             // I'm not even sure this is possible.  The new loop would have to be bigger than the
             // old loop, and the playhead was somehow outside the old loop.
             qWarning() << "SHOULDN'T HAPPEN: seekInsideAdjustedLoop couldn't find a new position --"
@@ -935,7 +935,7 @@ void LoopingControl::seekInsideAdjustedLoop(int old_loop_in, int old_loop_out,
     }
     while (adjusted_position < new_loop_in) {
         adjusted_position += new_loop_size;
-        DEBUG_ASSERT_AND_HANDLE(adjusted_position < new_loop_out) {
+        VERIFY_OR_DEBUG_ASSERT(adjusted_position < new_loop_out) {
             qWarning() << "SHOULDN'T HAPPEN: seekInsideAdjustedLoop couldn't find a new position --"
                        << " seeking to in point";
             adjusted_position = new_loop_in;

--- a/src/engine/quantizecontrol.cpp
+++ b/src/engine/quantizecontrol.cpp
@@ -116,7 +116,7 @@ void QuantizeControl::updateClosestBeat(double dCurrentSample) {
         double currentClosestBeat =
                 (nextBeat - dCurrentSample > dCurrentSample - prevBeat) ?
                         prevBeat : nextBeat;
-        DEBUG_ASSERT_AND_HANDLE(even(static_cast<int>(currentClosestBeat))) {
+        VERIFY_OR_DEBUG_ASSERT(even(static_cast<int>(currentClosestBeat))) {
             currentClosestBeat--;
         }
         if (closestBeat != currentClosestBeat) {

--- a/src/engine/sidechain/enginebroadcast.cpp
+++ b/src/engine/sidechain/enginebroadcast.cpp
@@ -98,7 +98,7 @@ EngineBroadcast::~EngineBroadcast() {
     wait(4000);
 
     // Signal user if thread doesn't die
-    DEBUG_ASSERT_AND_HANDLE(!isRunning()) {
+    VERIFY_OR_DEBUG_ASSERT(!isRunning()) {
        qWarning() << "EngineBroadcast:~EngineBroadcast(): Thread didn't die.\
        Ignored but file a bug report if problems rise!";
     }
@@ -809,7 +809,7 @@ void EngineBroadcast::run() {
     ignoreSigpipe();
 #endif
 
-    DEBUG_ASSERT_AND_HANDLE(m_pOutputFifo) {
+    VERIFY_OR_DEBUG_ASSERT(m_pOutputFifo) {
         qDebug() << "EngineBroadcast::run: Broadcast FIFO handle is not available. Aborting";
         return;
     }

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -35,7 +35,7 @@ EngineSync::~EngineSync() {
 void EngineSync::requestSyncMode(Syncable* pSyncable, SyncMode mode) {
     //qDebug() << "EngineSync::requestSyncMode" << pSyncable->getGroup() << mode;
     // Based on the call hierarchy I don't think this is possible. (Famous last words.)
-    DEBUG_ASSERT_AND_HANDLE(pSyncable) {
+    VERIFY_OR_DEBUG_ASSERT(pSyncable) {
         return;
     }
 

--- a/src/errordialoghandler.cpp
+++ b/src/errordialoghandler.cpp
@@ -126,7 +126,7 @@ bool ErrorDialogHandler::requestErrorDialog(ErrorDialogProperties* props) {
 
     // Make sure the minimum items are set
     QString text = props->getText();
-    DEBUG_ASSERT_AND_HANDLE(!text.isEmpty()) {
+    VERIFY_OR_DEBUG_ASSERT(!text.isEmpty()) {
         delete props;
         return false;
     }

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -180,7 +180,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::shufflePlaylist(
 
 void AutoDJProcessor::fadeNow() {
     // Auto-DJ needs at least two decks
-    DEBUG_ASSERT_AND_HANDLE(m_decks.length() > 1) {
+    VERIFY_OR_DEBUG_ASSERT(m_decks.length() > 1) {
         return;
     }
     if (m_eState != ADJ_IDLE) {
@@ -221,7 +221,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::skipNext() {
     }
 
     // Auto-DJ needs at least two decks
-    DEBUG_ASSERT_AND_HANDLE(m_decks.length() > 1) {
+    VERIFY_OR_DEBUG_ASSERT(m_decks.length() > 1) {
         return ADJ_NOT_TWO_DECKS;
     }
 
@@ -405,7 +405,7 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
     }
 
     // Auto-DJ needs at least two decks
-    DEBUG_ASSERT_AND_HANDLE(m_decks.length() > 1) {
+    VERIFY_OR_DEBUG_ASSERT(m_decks.length() > 1) {
         return;
     }
 
@@ -830,7 +830,7 @@ void AutoDJProcessor::setTransitionTime(int time) {
     }
 
     // Auto-DJ needs at least two decks
-    DEBUG_ASSERT_AND_HANDLE(m_decks.length() > 1) {
+    VERIFY_OR_DEBUG_ASSERT(m_decks.length() > 1) {
         return;
     }
 

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -38,7 +38,7 @@ DlgAutoDJ::DlgAutoDJ(QWidget* parent,
 
 
     QBoxLayout* box = dynamic_cast<QBoxLayout*>(layout());
-    DEBUG_ASSERT_AND_HANDLE(box) { //Assumes the form layout is a QVBox/QHBoxLayout!
+    VERIFY_OR_DEBUG_ASSERT(box) { //Assumes the form layout is a QVBox/QHBoxLayout!
     } else {
         box->removeWidget(m_pTrackTablePlaceholder);
         m_pTrackTablePlaceholder->hide();

--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -324,7 +324,7 @@ void BasePlaylistFeature::slotDeletePlaylist() {
     }
 
     if (m_lastRightClickedIndex.isValid()) {
-        DEBUG_ASSERT_AND_HANDLE(playlistId >= 0) {
+        VERIFY_OR_DEBUG_ASSERT(playlistId >= 0) {
             return;
         }
 

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -542,7 +542,7 @@ void BaseSqlTableModel::setSort(int column, Qt::SortOrder order) {
                 int ccColumn = sc.m_column - m_tableColumns.size() + 1;
                 sort_field = m_trackSource->columnSortForFieldIndex(ccColumn);
             }
-            DEBUG_ASSERT_AND_HANDLE(!sort_field.isEmpty()) {
+            VERIFY_OR_DEBUG_ASSERT(!sort_field.isEmpty()) {
                 continue;
             }
 
@@ -953,7 +953,7 @@ void BaseSqlTableModel::setTrackValueForColumn(TrackPointer pTrack, int column,
         pTrack->setBpmLocked(value.toBool());
     } else {
         // We never should get up to this point!
-        DEBUG_ASSERT_AND_HANDLE(false) {
+        VERIFY_OR_DEBUG_ASSERT(false) {
             qWarning() << "Column"
                     << m_tableColumnCache.columnNameForFieldIndex(column)
                     << "is not editable!";

--- a/src/library/dao/cuedao.cpp
+++ b/src/library/dao/cuedao.cpp
@@ -143,7 +143,7 @@ bool CueDAO::deleteCuesForTracks(const QList<TrackId>& trackIds) {
 
 bool CueDAO::saveCue(Cue* cue) {
     //qDebug() << "CueDAO::saveCue" << QThread::currentThread() << m_database.connectionName();
-    DEBUG_ASSERT_AND_HANDLE(cue) {
+    VERIFY_OR_DEBUG_ASSERT(cue) {
         return false;
     }
     if (cue->getId() == -1) {

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -288,7 +288,7 @@ void TrackDAO::saveTrack(Track* pTrack) {
 
 void TrackDAO::slotTrackDirty(Track* pTrack) {
     // Should not be possible.
-    DEBUG_ASSERT_AND_HANDLE(pTrack != nullptr) {
+    VERIFY_OR_DEBUG_ASSERT(pTrack != nullptr) {
         return;
     }
 
@@ -308,7 +308,7 @@ void TrackDAO::slotTrackDirty(Track* pTrack) {
 
 void TrackDAO::slotTrackClean(Track* pTrack) {
     // Should not be possible.
-    DEBUG_ASSERT_AND_HANDLE(pTrack != nullptr) {
+    VERIFY_OR_DEBUG_ASSERT(pTrack != nullptr) {
         return;
     }
 
@@ -343,7 +343,7 @@ void TrackDAO::databaseTracksChanged(QSet<TrackId> tracksChanged) {
 
 void TrackDAO::slotTrackChanged(Track* pTrack) {
     // Should not be possible.
-    DEBUG_ASSERT_AND_HANDLE(pTrack != nullptr) {
+    VERIFY_OR_DEBUG_ASSERT(pTrack != nullptr) {
         return;
     }
 
@@ -553,7 +553,7 @@ namespace {
 
 TrackId TrackDAO::addTracksAddTrack(const TrackPointer& pTrack, bool unremove) {
     DEBUG_ASSERT(pTrack);
-    DEBUG_ASSERT_AND_HANDLE(m_pQueryLibraryInsert || m_pQueryTrackLocationInsert ||
+    VERIFY_OR_DEBUG_ASSERT(m_pQueryLibraryInsert || m_pQueryTrackLocationInsert ||
         m_pQueryLibrarySelect || m_pQueryTrackLocationSelect) {
         qDebug() << "TrackDAO::addTracksAddTrack: needed SqlQuerys have not "
                 "been prepared. Skipping track"
@@ -642,7 +642,7 @@ TrackId TrackDAO::addTracksAddTrack(const TrackPointer& pTrack, bool unremove) {
         // track location into the table AND we could not retrieve the id of
         // that track location from the same table. "It shouldn't
         // happen"... unless I screwed up - Albert :)
-        DEBUG_ASSERT_AND_HANDLE(trackLocationId.isValid()) {
+        VERIFY_OR_DEBUG_ASSERT(trackLocationId.isValid()) {
             return TrackId();
         }
 
@@ -650,7 +650,7 @@ TrackId TrackDAO::addTracksAddTrack(const TrackPointer& pTrack, bool unremove) {
             return TrackId();
         }
         trackId = TrackId(m_pQueryLibraryInsert->lastInsertId());
-        DEBUG_ASSERT_AND_HANDLE(trackId.isValid()) {
+        VERIFY_OR_DEBUG_ASSERT(trackId.isValid()) {
             return TrackId();
         }
 
@@ -984,7 +984,7 @@ void TrackDAO::purgeTracks(const QList<TrackId>& trackIds) {
 
 void TrackDAO::slotTrackReferenceExpired(Track* pTrack) {
     // Should not be possible.
-    DEBUG_ASSERT_AND_HANDLE(pTrack != nullptr) {
+    VERIFY_OR_DEBUG_ASSERT(pTrack != nullptr) {
         return;
     }
 
@@ -1341,7 +1341,7 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
 
     QSqlRecord queryRecord = query.record();
     int recordCount = queryRecord.count();
-    DEBUG_ASSERT_AND_HANDLE(recordCount == columnsCount) {
+    VERIFY_OR_DEBUG_ASSERT(recordCount == columnsCount) {
         recordCount = math_min(recordCount, columnsCount);
     }
 
@@ -1985,7 +1985,7 @@ void TrackDAO::detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
 
         CoverInfo::Source source = static_cast<CoverInfo::Source>(
             query.value(4).toInt());
-        DEBUG_ASSERT_AND_HANDLE(source != CoverInfo::USER_SELECTED) {
+        VERIFY_OR_DEBUG_ASSERT(source != CoverInfo::USER_SELECTED) {
             qWarning() << "PROGRAMMING ERROR! detectCoverArtForTracksWithoutCover()"
                        << "got a USER_SELECTED track. Skipping.";
             continue;

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -30,7 +30,7 @@ DlgAnalysis::DlgAnalysis(QWidget* parent,
             this, SIGNAL(trackSelected(TrackPointer)));
 
     QBoxLayout* box = dynamic_cast<QBoxLayout*>(layout());
-    DEBUG_ASSERT_AND_HANDLE(box) { // Assumes the form layout is a QVBox/QHBoxLayout!
+    VERIFY_OR_DEBUG_ASSERT(box) { // Assumes the form layout is a QVBox/QHBoxLayout!
     } else {
         box->removeWidget(m_pTrackTablePlaceholder);
         m_pTrackTablePlaceholder->hide();

--- a/src/library/dlghidden.cpp
+++ b/src/library/dlghidden.cpp
@@ -17,7 +17,7 @@ DlgHidden::DlgHidden(QWidget* parent, UserSettingsPointer pConfig,
 
     // Install our own trackTable
     QBoxLayout* box = dynamic_cast<QBoxLayout*>(layout());
-    DEBUG_ASSERT_AND_HANDLE(box) { //Assumes the form layout is a QVBox/QHBoxLayout!
+    VERIFY_OR_DEBUG_ASSERT(box) { //Assumes the form layout is a QVBox/QHBoxLayout!
     } else {
         box->removeWidget(m_pTrackTablePlaceholder);
         m_pTrackTablePlaceholder->hide();

--- a/src/library/dlgmissing.cpp
+++ b/src/library/dlgmissing.cpp
@@ -16,7 +16,7 @@ DlgMissing::DlgMissing(QWidget* parent, UserSettingsPointer pConfig,
 
     // Install our own trackTable
     QBoxLayout* box = dynamic_cast<QBoxLayout*>(layout());
-    DEBUG_ASSERT_AND_HANDLE(box) { //Assumes the form layout is a QVBox/QHBoxLayout!
+    VERIFY_OR_DEBUG_ASSERT(box) { //Assumes the form layout is a QVBox/QHBoxLayout!
     } else {
         box->removeWidget(m_pTrackTablePlaceholder);
         m_pTrackTablePlaceholder->hide();

--- a/src/library/export/trackexportdlg.cpp
+++ b/src/library/export/trackexportdlg.cpp
@@ -32,7 +32,7 @@ TrackExportDlg::TrackExportDlg(QWidget *parent,
 
 void TrackExportDlg::showEvent(QShowEvent* event) {
     QDialog::showEvent(event);
-    DEBUG_ASSERT_AND_HANDLE(m_worker) {
+    VERIFY_OR_DEBUG_ASSERT(m_worker) {
         // It's not worth checking for m_exporter != nullptr elsewhere in this
         // class... it'll be clear very quickly that someone screwed up and
         // forgot to call selectDestinationDirectory().

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -220,7 +220,7 @@ void Library::bindWidget(WLibrary* pLibraryWidget,
 }
 
 void Library::addFeature(LibraryFeature* feature) {
-    DEBUG_ASSERT_AND_HANDLE(feature) {
+    VERIFY_OR_DEBUG_ASSERT(feature) {
         return;
     }
     m_features.push_back(feature);
@@ -244,7 +244,7 @@ void Library::addFeature(LibraryFeature* feature) {
 void Library::slotShowTrackModel(QAbstractItemModel* model) {
     //qDebug() << "Library::slotShowTrackModel" << model;
     TrackModel* trackModel = dynamic_cast<TrackModel*>(model);
-    DEBUG_ASSERT_AND_HANDLE(trackModel) {
+    VERIFY_OR_DEBUG_ASSERT(trackModel) {
         return;
     }
     emit(showTrackModel(model));

--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -14,7 +14,7 @@ ProxyTrackModel::ProxyTrackModel(QAbstractItemModel* pTrackModel,
           m_pTrackModel(dynamic_cast<TrackModel*>(pTrackModel)),
           m_currentSearch(""),
           m_bHandleSearches(bHandleSearches) {
-    DEBUG_ASSERT_AND_HANDLE(m_pTrackModel && pTrackModel) {
+    VERIFY_OR_DEBUG_ASSERT(m_pTrackModel && pTrackModel) {
         return;
     }
     setSourceModel(pTrackModel);

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -40,7 +40,7 @@ DlgRecording::DlgRecording(QWidget* parent, UserSettingsPointer pConfig,
             this, SLOT(slotDurationRecorded(QString)));
 
     QBoxLayout* box = dynamic_cast<QBoxLayout*>(layout());
-    DEBUG_ASSERT_AND_HANDLE(box) { //Assumes the form layout is a QVBox/QHBoxLayout!
+    VERIFY_OR_DEBUG_ASSERT(box) { //Assumes the form layout is a QVBox/QHBoxLayout!
     } else {
         box->removeWidget(m_pTrackTablePlaceholder);
         m_pTrackTablePlaceholder->hide();

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -234,7 +234,7 @@ void LibraryScanner::slotStartScan() {
 // is called when all tasks of the first stage are done (threads are finished)
 void LibraryScanner::slotFinishHashedScan() {
     qDebug() << "LibraryScanner::slotFinishHashedScan";
-    DEBUG_ASSERT_AND_HANDLE(!m_scannerGlobal.isNull()) {
+    VERIFY_OR_DEBUG_ASSERT(!m_scannerGlobal.isNull()) {
         qWarning() << "No scanner global state exists in LibraryScanner::slotFinishHashedScan";
         return;
     }
@@ -348,7 +348,7 @@ void LibraryScanner::cleanUpScan() {
 // is called when all tasks of the second stage are done (threads are finished)
 void LibraryScanner::slotFinishUnhashedScan() {
     qDebug() << "LibraryScanner::slotFinishUnhashedScan";
-    DEBUG_ASSERT_AND_HANDLE(!m_scannerGlobal.isNull()) {
+    VERIFY_OR_DEBUG_ASSERT(!m_scannerGlobal.isNull()) {
         qWarning() << "No scanner global state exists in LibraryScanner::slotFinishUnhashedScan";
         return;
     }

--- a/src/library/schemamanager.cpp
+++ b/src/library/schemamanager.cpp
@@ -17,7 +17,7 @@ SchemaManager::Result SchemaManager::upgradeToSchemaVersion(
         QSqlDatabase& db, const int targetVersion) {
     SettingsDAO settings(db);
     int currentVersion = getCurrentSchemaVersion(settings);
-    DEBUG_ASSERT_AND_HANDLE(currentVersion >= 0) {
+    VERIFY_OR_DEBUG_ASSERT(currentVersion >= 0) {
         return RESULT_UPGRADE_FAILED;
     }
 
@@ -58,7 +58,7 @@ SchemaManager::Result SchemaManager::upgradeToSchemaVersion(
     for (int i = 0; i < revisions.count(); i++) {
         QDomElement revision = revisions.at(i).toElement();
         QString version = revision.attribute("version");
-        DEBUG_ASSERT_AND_HANDLE(!version.isNull()) {
+        VERIFY_OR_DEBUG_ASSERT(!version.isNull()) {
             // xml file is not valid
             return RESULT_SCHEMA_ERROR;
         }
@@ -92,7 +92,7 @@ SchemaManager::Result SchemaManager::upgradeToSchemaVersion(
             minCompatibleVersion = QString::number(thisTarget);
         }
 
-        DEBUG_ASSERT_AND_HANDLE(!eSql.isNull()) {
+        VERIFY_OR_DEBUG_ASSERT(!eSql.isNull()) {
             // xml file is not valid
             return RESULT_SCHEMA_ERROR;
         }

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -98,7 +98,7 @@ QString AndNode::toSql() const {
 bool OrNode::match(const TrackPointer& pTrack) const {
     // An empty OR node would always evaluate to false
     // which is inconsistent with the generated SQL query!
-    DEBUG_ASSERT_AND_HANDLE(!m_nodes.empty()) {
+    VERIFY_OR_DEBUG_ASSERT(!m_nodes.empty()) {
         // Evaluate to true even if the correct choice would
         // be false to keep the evaluation consistent with
         // the generated SQL query.

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -315,7 +315,7 @@ QModelIndex SidebarModel::translateSourceIndex(const QModelIndex& index) {
      */
 
     const QAbstractItemModel* model = dynamic_cast<QAbstractItemModel*>(sender());
-    DEBUG_ASSERT_AND_HANDLE(model != NULL) {
+    VERIFY_OR_DEBUG_ASSERT(model != NULL) {
         return QModelIndex();
     }
 

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -157,7 +157,7 @@ QSharedPointer<BaseTrackCache> TrackCollection::getTrackSource() {
 }
 
 void TrackCollection::setTrackSource(QSharedPointer<BaseTrackCache> trackSource) {
-    DEBUG_ASSERT_AND_HANDLE(m_defaultTrackSource.isNull()) {
+    VERIFY_OR_DEBUG_ASSERT(m_defaultTrackSource.isNull()) {
         return;
     }
     m_defaultTrackSource = trackSource;
@@ -254,7 +254,7 @@ int TrackCollection::sqliteLocaleAwareCompare(void* pArg,
 void TrackCollection::sqliteLike(sqlite3_context *context,
                                 int aArgc,
                                 sqlite3_value **aArgv) {
-    DEBUG_ASSERT_AND_HANDLE(aArgc == 2 || aArgc == 3) {
+    VERIFY_OR_DEBUG_ASSERT(aArgc == 2 || aArgc == 3) {
         return;
     }
 

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -326,7 +326,7 @@ void PlayerManager::addConfiguredDecks() {
 void PlayerManager::addDeckInner() {
     // Do not lock m_mutex here.
     QString group = groupForDeck(m_decks.count());
-    DEBUG_ASSERT_AND_HANDLE(!m_players.contains(group)) {
+    VERIFY_OR_DEBUG_ASSERT(!m_players.contains(group)) {
         return;
     }
 
@@ -389,7 +389,7 @@ void PlayerManager::addSamplerInner() {
     // Do not lock m_mutex here.
     QString group = groupForSampler(m_samplers.count());
 
-    DEBUG_ASSERT_AND_HANDLE(!m_players.contains(group)) {
+    VERIFY_OR_DEBUG_ASSERT(!m_players.contains(group)) {
         return;
     }
 
@@ -416,7 +416,7 @@ void PlayerManager::addPreviewDeck() {
 void PlayerManager::addPreviewDeckInner() {
     // Do not lock m_mutex here.
     QString group = groupForPreviewDeck(m_preview_decks.count());
-    DEBUG_ASSERT_AND_HANDLE(!m_players.contains(group)) {
+    VERIFY_OR_DEBUG_ASSERT(!m_players.contains(group)) {
         return;
     }
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -471,7 +471,7 @@ void MixxxMainWindow::finalize() {
         QCoreApplication::sendPostedEvents(pSkin, QEvent::DeferredDelete);
     }
     // Our central widget is now deleted.
-    DEBUG_ASSERT_AND_HANDLE(pSkin.isNull()) {
+    VERIFY_OR_DEBUG_ASSERT(pSkin.isNull()) {
         qWarning() << "Central widget was not deleted by our sendPostedEvents trick.";
     }
 
@@ -488,7 +488,7 @@ void MixxxMainWindow::finalize() {
         QCoreApplication::sendPostedEvents(pMenuBar, QEvent::DeferredDelete);
     }
     // Our main menu is now deleted.
-    DEBUG_ASSERT_AND_HANDLE(pMenuBar.isNull()) {
+    VERIFY_OR_DEBUG_ASSERT(pMenuBar.isNull()) {
         qWarning() << "WMainMenuBar was not deleted by our sendPostedEvents trick.";
     }
 

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -171,7 +171,7 @@ void DlgPrefBroadcast::slotResetToDefaults() {
     mountpoint->setText(m_settings.getDefaultMountpoint());
     host->setText(m_settings.getDefaultHost());
     int iPort = m_settings.getDefaultPort();
-    DEBUG_ASSERT_AND_HANDLE(iPort != 0 && iPort <= 0xffff) {
+    VERIFY_OR_DEBUG_ASSERT(iPort != 0 && iPort <= 0xffff) {
         port->setText(QString());
     } else {
         port->setText(QString::number(iPort));

--- a/src/preferences/settingsmanager.cpp
+++ b/src/preferences/settingsmanager.cpp
@@ -20,7 +20,7 @@ SettingsManager::SettingsManager(QObject* pParent,
     // after an upgrade and make any needed changes.
     Upgrade upgrader;
     m_pSettings = upgrader.versionUpgrade(settingsPath);
-    DEBUG_ASSERT_AND_HANDLE(!m_pSettings.isNull()) {
+    VERIFY_OR_DEBUG_ASSERT(!m_pSettings.isNull()) {
         m_pSettings = UserSettingsPointer(new UserSettings(""));
     }
     m_bShouldRescanLibrary = upgrader.rescanLibrary();

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -887,7 +887,7 @@ int SoundDevicePortAudio::callbackProcessClkRef(
         // verify if flush to zero or denormals to zero works
         // test passes if one of the two flag is set.
         volatile double doubleMin = DBL_MIN; // the smallest normalized double
-        DEBUG_ASSERT_AND_HANDLE(doubleMin / 2 == 0.0) {
+        VERIFY_OR_DEBUG_ASSERT(doubleMin / 2 == 0.0) {
             qWarning() << "Denormals to zero mode is not working. EQs and effects may suffer high CPU load";
         } else {
             qDebug() << "Denormals to zero mode is working";

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -253,7 +253,7 @@ unsigned int SoundManagerConfig::getAudioBufferSizeIndex() const {
 unsigned int SoundManagerConfig::getFramesPerBuffer() const {
     // endless loop otherwise
     unsigned int audioBufferSizeIndex = m_audioBufferSizeIndex;
-    DEBUG_ASSERT_AND_HANDLE(audioBufferSizeIndex > 0) {
+    VERIFY_OR_DEBUG_ASSERT(audioBufferSizeIndex > 0) {
         audioBufferSizeIndex = kDefaultAudioBufferSizeIndex;
     }
     unsigned int framesPerBuffer = 1;

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -105,7 +105,7 @@ SINT AudioSource::readSampleFramesStereo(
 bool AudioSource::verifyReadable() const {
     bool result = AudioSignal::verifyReadable();
     if (hasBitrate()) {
-        DEBUG_ASSERT_AND_HANDLE(isValidBitrate(m_bitrate)) {
+        VERIFY_OR_DEBUG_ASSERT(isValidBitrate(m_bitrate)) {
             qWarning() << "Invalid bitrate [kbps]:"
                     << getBitrate();
             // Don't set the result to false, because bitrate is only

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -78,7 +78,7 @@ bool getFrameCountOfStream(AVStream* pStream, SINT* pFrameCount) {
     }
     DEBUG_ASSERT(getSamplingRateOfStream(pStream) > 0);
     int64val *= getSamplingRateOfStream(pStream);
-    DEBUG_ASSERT_AND_HANDLE(int64val > 0) {
+    VERIFY_OR_DEBUG_ASSERT(int64val > 0) {
         // Integer overflow
         qWarning() << "[SoundSourceFFmpeg]"
                 << "Integer overflow during calculation of frame count";
@@ -86,7 +86,7 @@ bool getFrameCountOfStream(AVStream* pStream, SINT* pFrameCount) {
     }
     DEBUG_ASSERT(pStream->time_base.num > 0);
     int64val *= pStream->time_base.num;
-    DEBUG_ASSERT_AND_HANDLE(int64val > 0) {
+    VERIFY_OR_DEBUG_ASSERT(int64val > 0) {
         // Integer overflow
         qWarning() << "[SoundSourceFFmpeg]"
                 << "Integer overflow during calculation of frame count";
@@ -95,7 +95,7 @@ bool getFrameCountOfStream(AVStream* pStream, SINT* pFrameCount) {
     DEBUG_ASSERT(pStream->time_base.den > 0);
     int64val /= pStream->time_base.den;
     SINT frameCount = int64val;
-    DEBUG_ASSERT_AND_HANDLE(static_cast<int64_t>(frameCount) == int64val) {
+    VERIFY_OR_DEBUG_ASSERT(static_cast<int64_t>(frameCount) == int64val) {
         // Integer truncation
         qWarning() << "[SoundSourceFFmpeg]"
                 << "Integer truncation during calculation of frame count";

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -103,7 +103,7 @@ SINT SoundSourceSndFile::seekSampleFrame(
 
 SINT SoundSourceSndFile::readSampleFrames(
         SINT numberOfFrames, CSAMPLE* sampleBuffer) {
-    DEBUG_ASSERT_AND_HANDLE(numberOfFrames >= 0) {
+    VERIFY_OR_DEBUG_ASSERT(numberOfFrames >= 0) {
         return 0;
     }
     if (numberOfFrames == 0) {

--- a/src/track/playcounter.cpp
+++ b/src/track/playcounter.cpp
@@ -6,7 +6,7 @@ void PlayCounter::setPlayedAndUpdateTimesPlayed(bool bPlayed) {
     // as intended! But since this class provides independent
     // setters for both members we need to check and re-establish
     // the class invariant just in case.
-    DEBUG_ASSERT_AND_HANDLE(!m_bPlayed || (0 < m_iTimesPlayed)) {
+    VERIFY_OR_DEBUG_ASSERT(!m_bPlayed || (0 < m_iTimesPlayed)) {
         // Make sure that the number of times played does
         // not become negative!
         m_iTimesPlayed = 1;

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -82,7 +82,7 @@ TrackPointer Track::newDummy(
 
 // static
 void Track::onTrackReferenceExpired(Track* pTrack) {
-    DEBUG_ASSERT_AND_HANDLE(pTrack != nullptr) {
+    VERIFY_OR_DEBUG_ASSERT(pTrack != nullptr) {
         return;
     }
     //qDebug() << "Track::onTrackReferenceExpired"

--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -59,6 +59,6 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 #define DEBUG_ASSERT(cond)
 #endif
 
-#define DEBUG_ASSERT_AND_HANDLE(cond) if ((!(cond)) && mixxx_maybe_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
+#define VERIFY_OR_DEBUG_ASSERT(cond) if ((!(cond)) && mixxx_maybe_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
 
 #endif /* ASSERT_H */

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -201,10 +201,10 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel *model) {
 
     TrackModel* trackModel = dynamic_cast<TrackModel*>(model);
 
-    DEBUG_ASSERT_AND_HANDLE(model) {
+    VERIFY_OR_DEBUG_ASSERT(model) {
         return;
     }
-    DEBUG_ASSERT_AND_HANDLE(trackModel) {
+    VERIFY_OR_DEBUG_ASSERT(trackModel) {
         return;
     }
 


### PR DESCRIPTION
The DEBUG_ASSERT_AND_HANDLE macro is handy for handling unexpected runtime errors, e.g. malformed SQL commands and queries. Those errors are typically handled by aborting the invoked function through an early exit. Instead of only printing a warning log message the debug version should exit with an assertion. Otherwise those unexpected errors might slip into a release version without noticing during testing.

Evaluating the condition of a debug assertion should have no side effects. But in this case the side-effects are intended in contrast to the naming of the macro. Therefore I propose to rename this macro into VERIFY_OR_DEBUG_ASSERT. The debug assertion only kicks in if the condition evaluates to false.

See also: https://github.com/mixxxdj/mixxx/pull/1099
I'm using this macro extensively for checking the result of database operations. In accordance with @daschuer we came to the conclusion that the naming of this macro is inappropriate and misleading.