### PR TITLE
(appveyor) switch to new 2.0.1 build env including libshout fix

### DIFF
--- a/build/appveyor/build_mixxx.bat
+++ b/build/appveyor/build_mixxx.bat
@@ -1,10 +1,10 @@
 @echo off
 
 REM set this to the folder where you build the dependencies
-set WINLIB_PATH64D=C:\mixxx-buildserver\2.0-x64-debug-minimal
-set WINLIB_PATH64R=C:\mixxx-buildserver\2.0-x64-release-minimal
-set WINLIB_PATH32D=C:\mixxx-buildserver\2.0-x86-debug-minimal
-set WINLIB_PATH32R=C:\mixxx-buildserver\2.0-x86-release-minimal
+set WINLIB_PATH64D=C:\mixxx-buildserver\2.0.1-x64-debug-minimal
+set WINLIB_PATH64R=C:\mixxx-buildserver\2.0.1-x64-release-minimal
+set WINLIB_PATH32D=C:\mixxx-buildserver\2.0.1-x86-debug-minimal
+set WINLIB_PATH32R=C:\mixxx-buildserver\2.0.1-x86-release-minimal
 
 REM XP Compatibility requires the v7.1A SDK
 set MSSDK_DIR="c:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A"

--- a/build/appveyor/install_buildenv.bat
+++ b/build/appveyor/install_buildenv.bat
@@ -3,7 +3,7 @@ REM @ECHO OFF
 SET BUILDENVBASEDIR=C:\MIXXX-BUILDSERVER
 
 REM Build envs to install. You can specify more than one separated by spaces (no quotes)
-SET BUILDENVS=2.0-%1-%2-minimal
+SET BUILDENVS=2.0.1-%1-%2-minimal
 
 REM precompiled compressed build env base URL
 SET BASEURL=https://downloads.mixxx.org/builds/appveyor/environments/2.0
@@ -14,7 +14,7 @@ REM main()
 
 REM uncomment the following line if you want to empty cache and
 REM force buildenv (and build script) download
-REM RMDIR /S /Q %BUILDENVBASEDIR%
+RMDIR /S /Q %BUILDENVBASEDIR%
 
 REM Install build env base dir
 IF NOT EXIST %BUILDENVBASEDIR% MKDIR %BUILDENVBASEDIR%


### PR DESCRIPTION
This should fix lp:1544739 in the event of a 2.0.1 hotfix

Please drop the following two files in http://downloads.mixxx.org/builds/appveyor/environments/2.0/
  * https://www.blaisot.org/mixxx-buildserver-windows/2.0.1-x64-release-minimal.zip
  * https://www.blaisot.org/mixxx-buildserver-windows/2.0.1-x86-release-minimal.zip

sb