### PR TITLE
Fix PDB bundling for mixxx, VAMP, and SoundSource plugins.

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -1263,7 +1263,7 @@ class MixxxCore(Feature):
             # executables linked regardless of whether we are creating a debug
             # build. Having PDB files for our releases is helpful for debugging.
             build.env.Append(LINKFLAGS='/DEBUG')
-            build.env.Append(CCFLAGS='/Zi')
+            build.env.Append(CCFLAGS='/Zi /Fd${TARGET}.pdb')
 
             if build.build_is_debug:
                 # Important: We always build Mixxx with the Multi-Threaded DLL

--- a/build/mixxx.py
+++ b/build/mixxx.py
@@ -115,6 +115,9 @@ class MixxxBuild(object):
         self.static_dependencies = int(Script.ARGUMENTS.get('staticlibs', 0))
         self.static_qt = int(Script.ARGUMENTS.get('staticqt', 0))
 
+        self.bundle_pdbs = self.platform_is_windows and (
+            self.build_is_debug or Script.ARGUMENTS.get('bundle_pdbs', '') in ('yes', 'y', '1'))
+
         logging.info("Target Platform: %s" % self.platform)
         logging.info("Target Machine: %s" % self.machine)
         logging.info("Build: %s" % self.build)

--- a/plugins/soundsourcem4a/SConscript
+++ b/plugins/soundsourcem4a/SConscript
@@ -61,6 +61,7 @@ if int(build.flags['faad']):
         env.Append(CPPDEFINES = '__MP4V2__')
 
     env = conf.Finish()
+    results = []
     SHLIBPREFIX='lib' #Makes the filename "libsoundsourcem4a" consistently across platforms to make our lives easier.
     if build.platform_is_windows:
         env["LINKFLAGS"].remove("/entry:mainCRTStartup")
@@ -70,13 +71,15 @@ if int(build.flags['faad']):
         else:
             env["LINKFLAGS"].remove("/subsystem:windows,5.01")
         ssm4a_bin = env.SharedLibrary('soundsourcem4a', m4a_sources, LINKCOM  = [env['LINKCOM'], 'mt.exe -nologo -manifest ${TARGET}.manifest -outputresource:$TARGET;1'])
+        results.append('ssm4a_bin')
+        if build.bundle_pdbs:
+            ssm4a_pdb = env.SideEffect('soundsourcem4a.pdb', ssm4a_bin)
+            results.append('ssm4a_pdb')
     else:
         ssm4a_bin = env.SharedLibrary('soundsourcem4a', m4a_sources)
+        results.append('ssm4a_bin')
 
     #Pass this soundsourcem4a library object file back to the SConscript above us.
-    Return("ssm4a_bin")
+    Return(results)
 else:
     Return("")
-
-
-

--- a/plugins/soundsourcemediafoundation/SConscript
+++ b/plugins/soundsourcemediafoundation/SConscript
@@ -17,6 +17,7 @@ if int(build.flags['mediafoundation']):
         env["LINKFLAGS"].remove("/subsystem:windows,5.02")
     else:
         env["LINKFLAGS"].remove("/subsystem:windows,5.01")
+    results = ["ssmediafoundation_bin"]
     ssmediafoundation_bin = env.SharedLibrary('soundsourcemediafoundation',
         ['soundsourcemediafoundation.cpp',
          'sources/soundsourceplugin.cpp',
@@ -33,6 +34,9 @@ if int(build.flags['mediafoundation']):
          'track/bpm.cpp' ],
         LINKCOM  = [env['LINKCOM'],
             'mt.exe -nologo -manifest ${TARGET}.manifest -outputresource:$TARGET;1'])
-    Return("ssmediafoundation_bin")
+    if build.bundle_pdbs:
+        ssmediafoundation_pdb = env.SideEffect('soundsourcemediafoundation.pdb', ssmediafoundation_bin)
+        results.append("ssmediafoundation_pdb")
+    Return(results)
 else:
     Return("")

--- a/plugins/soundsourcewv/SConscript
+++ b/plugins/soundsourcewv/SConscript
@@ -37,6 +37,7 @@ if int(build.flags['wv']):
     have_wv = conf.CheckLib(['wavpack', 'wv'])
     env = conf.Finish()
 
+    results = []
     if build.platform_is_windows:
         env["LINKFLAGS"].remove("/entry:mainCRTStartup")
         # TODO(rryan): Why do we do this?
@@ -45,10 +46,15 @@ if int(build.flags['wv']):
         else:
             env["LINKFLAGS"].remove("/subsystem:windows,5.01")
         sswv_bin = env.SharedLibrary('soundsourcewv', wv_sources, LINKCOM  = [env['LINKCOM'], 'mt.exe -nologo -manifest ${TARGET}.manifest -outputresource:$TARGET;1'])
+        results.append('sswv_bin')
+        if build.bundle_pdbs:
+            sswv_pdb = env.SideEffect('soundsourcewv.pdb', sswv_bin)
+            results.append('sswv_pdb')
     else:
         sswv_bin = env.SharedLibrary('soundsourcewv', wv_sources)
+        results.append('sswv_bin')
 
     #Pass this soundsourcewv library object file back to the SConscript above us.
-    Return("sswv_bin")
+    Return(results)
 else:
     Return("")

--- a/src/SConscript
+++ b/src/SConscript
@@ -238,21 +238,13 @@ def ubuntu_construct_version(build, mixxx_version, branch_name, vcs_revision,
 #        unix_share_path = flags['prefix'] + "/share"
 #        unix_bin_path   = flags['prefix'] + "/bin"
 
-bundle_pdbs = build.platform_is_windows and (
-        build.build_is_debug or
-        SCons.ARGUMENTS.get('bundle_pdbs', '') in ('yes', 'y', '1'))
-
 #Mixxx binary
 binary_files = [mixxx_bin];
 if test_bin is not None:
         binary_files.append(test_bin)
-        if bundle_pdbs:
-                binary_files.append(
-                        Glob('#' + os.path.join(build.build_dir, 'mixxx-test.pdb')))
 
-if bundle_pdbs:
-        binary_files.append(
-                Glob('#' + os.path.join(build.build_dir, 'mixxx.pdb')))
+if build.bundle_pdbs:
+        binary_files.append(env.SideEffect('mixxx.pdb', mixxx_bin))
 
 #Soundsource plugins
 soundsource_plugin_files = soundsource_plugins
@@ -305,7 +297,7 @@ if build.toolchain_is_msvs and not build.static_dependencies:
         dll_files.extend(Glob('%s/*.dll' % build.winlib_path))
         dll_files.extend(Glob('%s/lib/*.dll' % build.winlib_path))
 
-        if bundle_pdbs:
+        if build.bundle_pdbs:
                 dll_files.extend(Glob('%s/*.pdb' % build.winlib_path))
                 dll_files.extend(Glob('%s/lib/*.pdb' % build.winlib_path))
 elif build.crosscompile and build.platform_is_windows and build.toolchain_is_gnu and not build.static_dependencies:
@@ -336,7 +328,7 @@ if qt5:
         if not build.static_qt:
             imgfmtdll_files.extend(['$QTDIR/plugins/imageformats/' + module + suffix for module in qt_imagesformats])
         # We don't have Qt's dll pdb files in our release build environements, so only if build is debug
-        pdbSuffix = 'd.pdb' if (bundle_pdbs and build.build_is_debug) else ''
+        pdbSuffix = 'd.pdb' if (build.bundle_pdbs and build.build_is_debug) else ''
         if pdbSuffix:
                  imgfmtdll_files.extend(['$QTDIR/plugins/imageformats/' + module + pdbSuffix for module in qt_imagesformats])
 else:
@@ -344,7 +336,7 @@ else:
         if not build.static_qt:
             imgfmtdll_files.extend(['$QTDIR/plugins/imageformats/' + module + suffix for module in qt_imagesformats])
         # We don't have Qt's dll pdb files in our release build environements, so only if build is debug
-        pdbSuffix = 'd4.pdb' if (bundle_pdbs and build.build_is_debug) else ''
+        pdbSuffix = 'd4.pdb' if (build.bundle_pdbs and build.build_is_debug) else ''
         if pdbSuffix:
                 imgfmtdll_files.extend(['$QTDIR/plugins/imageformats/' + module + pdbSuffix for module in qt_imagesformats])
 
@@ -761,7 +753,7 @@ def BuildRelease(target, source, env):
 
         # Harvest main PDB from install dir if they exist
         isPdb = "no"
-        if bundle_pdbs and glob.glob(os.path.join(dist_dir, "*.pdb")):
+        if build.bundle_pdbs and glob.glob(os.path.join(dist_dir, "*.pdb")):
             isPdb = "yes"
             command = '"%(wix)s\\heat.exe" dir %(distdir)s -nologo -sfrag -suid -ag -srd -cg mainPDBCompGroup -dr INSTALLDIR -out build\wix\subdirs\mainPDB.wxs -sw5150 -var var.SourceDir -t build\wix\only-pdb.xslt' % \
             {'wix': wix_path,

--- a/vamp-plugins/SConscript
+++ b/vamp-plugins/SConscript
@@ -67,6 +67,7 @@ if int(build.flags['vamp']):
         mixxxminimal_sources.extend(depend_source)
 
     env = conf.Finish()
+    results = []
     if build.platform_is_linux:
         env["LINKFLAGS"].append("-Wl,--version-script=vamp-plugins/vamp-plugin.map")
     if build.platform_is_windows:
@@ -79,9 +80,15 @@ if int(build.flags['vamp']):
         #env["LINKFLAGS"].append("/DEFAULTLIB:LIBCMT.lib")
         #env["LINKFLAGS"].append("/DEFAULTLIB:LIBCPMT.lib")
         mixxxminimal_bin = env.SharedLibrary('libmixxxminimal', mixxxminimal_sources)
+        results.append("mixxxminimal_bin")
+        if build.bundle_pdbs:
+            mixxxminimal_pdb = env.SideEffect('libmixxxminimal.pdb', mixxxminimal_bin)
+            results.append("mixxxminimal_pdb")
+
     else:
-    	mixxxminimal_bin = env.SharedLibrary('mixxxminimal', mixxxminimal_sources)
+        mixxxminimal_bin = env.SharedLibrary('mixxxminimal', mixxxminimal_sources)
+        results.append("mixxxminimal_bin")
     #Pass this library object file back to the SConscript above us.
-    Return("mixxxminimal_bin")
+    Return(results)
 else:
     Return("")


### PR DESCRIPTION
Also avoids concurrent writing issues with ```/Zi``` by writing a separate PDB for each object file. The final link step aggregates them all into one PDB.