### PR TITLE
Make all effect short names translatable

### DIFF
--- a/src/effects/effectmanifest.h
+++ b/src/effects/effectmanifest.h
@@ -48,14 +48,6 @@ class EffectManifest final {
         m_shortName = shortName;
     }
 
-    virtual const QString& displayName() const {
-        if (!m_shortName.isEmpty()) {
-            return m_shortName;
-        } else {
-            return m_name;
-        }
-    }
-
     virtual const QString& author() const {
         return m_author;
     }
@@ -129,3 +121,5 @@ class EffectManifest final {
 };
 
 #endif /* EFFECTMANIFEST_H */
+
+

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -55,7 +55,7 @@ EffectsManager::~EffectsManager() {
 
 bool alphabetizeEffectManifests(const EffectManifest& manifest1,
                                 const EffectManifest& manifest2) {
-    return QString::localeAwareCompare(manifest1.displayName(), manifest2.displayName()) < 0;
+    return QString::localeAwareCompare(manifest1.shortName(), manifest2.shortName()) < 0;
 }
 
 void EffectsManager::addEffectsBackend(EffectsBackend* pBackend) {

--- a/src/effects/native/autopaneffect.cpp
+++ b/src/effects/native/autopaneffect.cpp
@@ -18,7 +18,10 @@ QString AutoPanEffect::getId() {
 EffectManifest AutoPanEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("AutoPan"));
+    //: Short name
+    manifest.setShortName(QObject::tr("AutoPan"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr("Bounce the sound from a channel "

--- a/src/effects/native/bessel4lvmixeqeffect.cpp
+++ b/src/effects/native/bessel4lvmixeqeffect.cpp
@@ -10,7 +10,9 @@ QString Bessel4LVMixEQEffect::getId() {
 EffectManifest Bessel4LVMixEQEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("Bessel4 LV-Mix Isolator"));
+    //: Short name
     manifest.setShortName(QObject::tr("Bessel4 ISO"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");

--- a/src/effects/native/bessel8lvmixeqeffect.cpp
+++ b/src/effects/native/bessel8lvmixeqeffect.cpp
@@ -10,7 +10,9 @@ QString Bessel8LVMixEQEffect::getId() {
 EffectManifest Bessel8LVMixEQEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("Bessel8 LV-Mix Isolator"));
+    //: Short name
     manifest.setShortName(QObject::tr("Bessel8 ISO"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");

--- a/src/effects/native/bitcrushereffect.cpp
+++ b/src/effects/native/bitcrushereffect.cpp
@@ -11,7 +11,10 @@ QString BitCrusherEffect::getId() {
 EffectManifest BitCrusherEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("BitCrusher"));
+    //: Short name
+    manifest.setShortName(QObject::tr("BitCrusher"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr(

--- a/src/effects/native/echoeffect.cpp
+++ b/src/effects/native/echoeffect.cpp
@@ -19,7 +19,10 @@ QString EchoEffect::getId() {
 EffectManifest EchoEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("Echo"));
+    //: Short name
+    manifest.setShortName(QObject::tr("Echo"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr("Simple Echo with pingpong"));

--- a/src/effects/native/filtereffect.cpp
+++ b/src/effects/native/filtereffect.cpp
@@ -13,7 +13,10 @@ QString FilterEffect::getId() {
 EffectManifest FilterEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("Filter"));
+    //: Short name
+    manifest.setShortName(QObject::tr("Filter"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr("The filter changes the tone of the "

--- a/src/effects/native/flangereffect.cpp
+++ b/src/effects/native/flangereffect.cpp
@@ -17,7 +17,10 @@ QString FlangerEffect::getId() {
 EffectManifest FlangerEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("Flanger"));
+    //: Short name
+    manifest.setShortName(QObject::tr("Flanger"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr(

--- a/src/effects/native/graphiceqeffect.cpp
+++ b/src/effects/native/graphiceqeffect.cpp
@@ -12,7 +12,9 @@ QString GraphicEQEffect::getId() {
 EffectManifest GraphicEQEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("Graphic Equalizer"));
+    //: Short name
     manifest.setShortName(QObject::tr("Graphic EQ"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");

--- a/src/effects/native/linkwitzriley8eqeffect.cpp
+++ b/src/effects/native/linkwitzriley8eqeffect.cpp
@@ -14,7 +14,9 @@ QString LinkwitzRiley8EQEffect::getId() {
 EffectManifest LinkwitzRiley8EQEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("LinkwitzRiley8 Isolator"));
+    //: Short name
     manifest.setShortName(QObject::tr("LR8 ISO"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");

--- a/src/effects/native/loudnesscontoureffect.cpp
+++ b/src/effects/native/loudnesscontoureffect.cpp
@@ -24,7 +24,9 @@ QString LoudnessContourEffect::getId() {
 EffectManifest LoudnessContourEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("Loudness Contour"));
+    //: Short name
     manifest.setShortName(QObject::tr("Loudness"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");

--- a/src/effects/native/moogladder4filtereffect.cpp
+++ b/src/effects/native/moogladder4filtereffect.cpp
@@ -15,7 +15,9 @@ QString MoogLadder4FilterEffect::getId() {
 EffectManifest MoogLadder4FilterEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("Moog Ladder 4 Filter"));
+    //: Short name
     manifest.setShortName(QObject::tr("Moog Filter"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");

--- a/src/effects/native/phasereffect.cpp
+++ b/src/effects/native/phasereffect.cpp
@@ -15,7 +15,10 @@ QString PhaserEffect::getId() {
 EffectManifest PhaserEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("Phaser"));
+    //: Short name
+    manifest.setShortName(QObject::tr("Phaser"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr(

--- a/src/effects/native/reverbeffect.cpp
+++ b/src/effects/native/reverbeffect.cpp
@@ -13,7 +13,10 @@ QString ReverbEffect::getId() {
 EffectManifest ReverbEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("Reverb"));
+    //: Short name
+    manifest.setShortName(QObject::tr("Reverb"));
     manifest.setAuthor("The Mixxx Team, CAPS Plugins");
     manifest.setVersion("1.0");
     manifest.setDescription("This is a port of the GPL'ed CAPS Reverb plugin, "

--- a/src/effects/native/threebandbiquadeqeffect.cpp
+++ b/src/effects/native/threebandbiquadeqeffect.cpp
@@ -38,8 +38,10 @@ QString ThreeBandBiquadEQEffect::getId() {
 EffectManifest ThreeBandBiquadEQEffect::getManifest() {
     EffectManifest manifest;
     manifest.setId(getId());
+    //: Long name
     manifest.setName(QObject::tr("Biquad Equalizer"));
-    manifest.setShortName(QObject::tr("BQ EQ"));
+    //: Short name
+    manifest.setShortName(QObject::tr("Biquad EQ"));
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr(

--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -23,7 +23,7 @@ void DlgPrefEffects::slotUpdate() {
     for (const auto& manifest : availableEffectManifests) {
         QListWidgetItem* pItem = new QListWidgetItem();
         pItem->setData(Qt::UserRole, manifest.id());
-        pItem->setText(manifest.displayName());
+        pItem->setText(manifest.shortName());
         availableEffectsList->addItem(pItem);
     }
 

--- a/src/widget/weffect.cpp
+++ b/src/widget/weffect.cpp
@@ -44,7 +44,7 @@ void WEffect::effectUpdated() {
         EffectPointer pEffect = m_pEffectSlot->getEffect();
         if (pEffect) {
             const EffectManifest& manifest = pEffect->getManifest();
-            name = manifest.displayName();
+            name = manifest.shortName();
             //: %1 = effect name; %2 = effect description
             description = tr("%1: %2").arg(manifest.name(), manifest.description());
         }

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -18,7 +18,7 @@ WEffectSelector::WEffectSelector(QWidget* pParent, EffectsManager* pEffectsManag
 
     for (int i = 0; i < availableEffectManifests.size(); ++i) {
         const EffectManifest& manifest = availableEffectManifests.at(i);
-        QString elidedDisplayName = metrics.elidedText(manifest.displayName(),
+        QString elidedDisplayName = metrics.elidedText(manifest.shortName(),
                                                        Qt::ElideMiddle,
                                                        width() - 2);
         addItem(elidedDisplayName, QVariant(manifest.id()));


### PR DESCRIPTION
This PR gives every effect a short name, even if they are not needed in English, in case a separate short name is needed for other languages.