### PR TITLE
SELECTMULTI ControlPushButtonBehavior

### DIFF
--- a/src/control/controlbehavior.h
+++ b/src/control/controlbehavior.h
@@ -110,7 +110,8 @@ class ControlPushButtonBehavior : public ControlNumericBehavior {
          TOGGLE,
          POWERWINDOW,
          LONGPRESSLATCHING,
-         TRIGGER
+         TRIGGER,
+         SELECTMULTI,
     };
 
     ControlPushButtonBehavior(ButtonMode buttonMode, int iNumStates);

--- a/src/control/controlpushbutton.h
+++ b/src/control/controlpushbutton.h
@@ -33,6 +33,7 @@ class ControlPushButton : public ControlObject {
          POWERWINDOW,
          LONGPRESSLATCHING,
          TRIGGER,
+         SELECTMULTI,
     };
 
     static QString buttonModeToString(int mode) {
@@ -47,6 +48,8 @@ class ControlPushButton : public ControlObject {
                 return "LONGPRESSLATCHING";
             case ControlPushButton::TRIGGER:
                 return "TRIGGER";
+            case ControlPushButton::SELECTMULTI:
+                return "SELECTMULTI";
             default:
                 return "UNKNOWN";
         }

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -79,9 +79,10 @@ EffectChainSlot::EffectChainSlot(EffectRack* pRack, const QString& group,
                                         true);
     m_pControlChainShowParameters->setButtonMode(ControlPushButton::TOGGLE);
 
-    m_pControlChainFocusedEffect = new ControlObject(
+    m_pControlChainFocusedEffect = new ControlPushButton(
                                        ConfigKey(m_group, "focused_effect"),
-                                       true, false, true);
+                                       true);
+    m_pControlChainFocusedEffect->setButtonMode(ControlPushButton::SELECTMULTI);
 }
 
 EffectChainSlot::~EffectChainSlot() {

--- a/src/effects/effectchainslot.h
+++ b/src/effects/effectchainslot.h
@@ -147,7 +147,7 @@ class EffectChainSlot : public QObject {
     **/
     ControlPushButton* m_pControlChainShowFocus;
     ControlPushButton* m_pControlChainShowParameters;
-    ControlObject* m_pControlChainFocusedEffect;
+    ControlPushButton* m_pControlChainFocusedEffect;
 
     struct ChannelInfo {
         // Takes ownership of pEnabled.

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -52,7 +52,7 @@ class WBaseWidget {
     double getControlParameter() const;
     double getControlParameterLeft() const;
     double getControlParameterRight() const;
-    double getControlParameterDisplay() const;
+    virtual double getControlParameterDisplay() const;
 
   protected:
     // Whenever a connected control is changed, onConnectedControlChanged is

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -265,8 +265,6 @@ void WPushButton::setPixmapBackground(PixmapSource source,
 }
 
 void WPushButton::restyleAndRepaint() {
-    emit(displayValueChanged(readDisplayValue()));
-
     // According to http://stackoverflow.com/a/3822243 this is the least
     // expensive way to restyle just this widget.
     // Since we expect button connections to not change at high frequency we

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -61,6 +61,7 @@ class WPushButton : public WWidget {
         }
         return 0;
     }
+    double getControlParameterDisplay() const override;
 
     virtual void setup(const QDomNode& node, const SkinContext& context);
 
@@ -98,6 +99,7 @@ class WPushButton : public WWidget {
 
     // Array of associated pixmaps
     int m_iNoStates;
+    int m_iSelectionIndex;
     QVector<QString> m_text;
     QVector<PaintablePointer> m_pressedPixmaps;
     QVector<PaintablePointer> m_unpressedPixmaps;

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -48,19 +48,6 @@ class WPushButton : public WWidget {
         return m_bPressed;
     }
 
-    // The displayValue property is used to restyle the pushbutton with CSS.
-    // The declaration #MyButton[displayValue="0"] { } will define the style
-    // when the widget is in state 0.  This allows for effects like reversing
-    // background and foreground colors to indicate enabled/disabled state.
-    Q_PROPERTY(int displayValue READ readDisplayValue NOTIFY displayValueChanged)
-
-    int readDisplayValue() const {
-        double value = getControlParameterDisplay();
-        if (!isnan(value) && m_iNoStates > 0) {
-            return static_cast<int>(value) % m_iNoStates;
-        }
-        return 0;
-    }
     double getControlParameterDisplay() const override;
 
     virtual void setup(const QDomNode& node, const SkinContext& context);
@@ -68,9 +55,6 @@ class WPushButton : public WWidget {
     // Sets the number of states associated with this button, and removes
     // associated pixmaps.
     void setStates(int iStates);
-
-  signals:
-    void displayValueChanged(int value);
 
   public slots:
     void onConnectedControlChanged(double dParameter, double dValue) override;


### PR DESCRIPTION
Add a new ControlPushButtonBehavior for the new focused_effect CO. This is similar to radio buttons, but having no option selected (ControlPushButton value of 0) is a valid option. Clicking an unselected button selects that option for the ControlPushButton's value. Clicking a selected button again unselects (sets the ControlPushButton value back to 0).