### PR TITLE
Update parented_ptr

### DIFF
--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -1,14 +1,13 @@
-#ifndef UTIL_PARENTED_POINTER_H
-#define UTIL_PARENTED_POINTER_H
+#ifndef UTIL_PARENTED_PTR_H
+#define UTIL_PARENTED_PTR_H
 
-#include <memory>
+#include <QPointer>
 #include "util/assert.h"
 
-
 /**
- * Use this wrapper class to clearly represent a pointer that is owned by the QT object tree.
+ * Use this wrapper class to clearly represent a raw pointer that is owned by the QT object tree.
  * Objects which both derive from QObject AND have a parent object, have their lifetime governed by the QT object tree, 
- * and thus pointers to such objects do not need to be deleted when they go  out of scope.
+ * and thus such pointers do not require a manual delete to free the heap memory when they go out of scope.
 **/
 template <typename T>
 class parented_ptr {
@@ -19,10 +18,14 @@ class parented_ptr {
 
     /* If U* is convertible to T* then we also want parented_ptr<U> convertible to parented_ptr<T> */
     template <typename U>
-    parented_ptr(const parented_ptr<U>& u, typename std::enable_if<std::is_convertible<U*, T*>::value, void>::type * = 0) 
+    parented_ptr(parented_ptr<U>&& u, typename std::enable_if<std::is_convertible<U*, T*>::value, void>::type * = 0)
             : m_pObject(u.get()) {
         DEBUG_ASSERT(u->parent() != nullptr);
     }
+
+    // Delete copy constructor and copy assignment operator
+    parented_ptr(const parented_ptr<T>&) = delete;
+    parented_ptr& operator=(const parented_ptr<T>&) = delete;
 
     parented_ptr() : m_pObject(nullptr) {}
 
@@ -60,15 +63,19 @@ class parented_ptr {
         return m_pObject != nullptr;
     }
 
-    /* 
-     * If U* is convertible to T* then we also want parented_ptr<U> assignable to parented_ptr<T> 
+    /*
+     * If U* is convertible to T* then we also want parented_ptr<U> assignable to parented_ptr<T>
      * E.g. parented_ptr<Base> base = make_parented<Derived>(); should work as expected.
      */
     template <typename U>
     typename std::enable_if<std::is_convertible<U*, T*>::value, parented_ptr<T>&>::type
-            operator=(const parented_ptr<U>& p) {
+            operator=(parented_ptr<U>&& p) {
         m_pObject = p.get();
         return *this;
+    }
+
+    QPointer<T> toWeakRef() {
+        return m_pObject;
     }
 
   private:
@@ -82,7 +89,6 @@ inline parented_ptr<T> make_parented(Args&&... args) {
     return parented_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
-
 } // namespace
 
-#endif /* UTIL_PARENTED_POINTER_H */
+#endif // UTIL_PARENTED_PTR_H

--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -44,7 +44,7 @@ class parented_ptr {
     }
 
     bool operator== (const parented_ptr& other) const {
-        return m_pObject == other.m_ptr;
+        return m_pObject == other.m_pObject;
     }
 
     bool operator== (const T* other) const {


### PR DESCRIPTION
Following on from the discussion in #1142, having the copy constructor available in the `parented_ptr` class gives an incorrect feeling that it could be used in the same way as a `shared_ptr`, which would lead to dangling pointers if the pointer can outlive its parent.

To address this problem we introduce a second class `parented_weak_ptr` that wraps the raw pointer in a QPointer. Since @rryan pointed out that QPointer has some overhead, we keep the old `parented_ptr` which doesn't use QPointer, but change it so that it can only be used with move semantics, making it safer than the version in #1142 in that the compiler will detect some (but not all) possible abuses.

Basically the intention with this class is that the "owner" (of the `parented_ptr`) and the "parent" are the same object. In such cases the overhead of `QPointer` is unwarranted:

```c++
class ParentClass {
  private:
    parented_ptr<T> m_pChild = std::make_parented<T>(this);
};
```

The changes in this PR are working well in practice, as you can see in c9eaaf47d142d90cb538baedb27750e6eb31d71e.

Note that I [initially](https://gist.github.com/timrae/f6cca4af6a9ad8d9d45e76b0e23ab909) tried to make a version of `parented_ptr` that inherits from `unique_ptr` to minimize duplicated code, but I couldn't get that to work, as it was complaining about the deleted copy constructor when initializing `m_pLibraryControl` in c9eaaf47d142d90cb538baedb27750e6eb31d71e. If someone can figure out the trick how to get that to work, I think it would be worth changing to such an implementation.