### PR TITLE
Biquad EQ with full kill feature

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -704,6 +704,7 @@ class MixxxCore(Feature):
                    "effects/native/bessel4lvmixeqeffect.cpp",
                    "effects/native/bessel8lvmixeqeffect.cpp",
                    "effects/native/threebandbiquadeqeffect.cpp",
+                   "effects/native/biquadfullkilleqeffect.cpp",
                    "effects/native/loudnesscontoureffect.cpp",
                    "effects/native/graphiceqeffect.cpp",
                    "effects/native/flangereffect.cpp",

--- a/src/control/controlbehavior.cpp
+++ b/src/control/controlbehavior.cpp
@@ -195,10 +195,12 @@ double ControlAudioTaperPotBehavior::parameterToValue(double dParam) {
         }
     } else if (dParam == m_neutralParameter) {
         dValue = 1.0;
-    } else if (dParam <= 1.0) {
+    } else if (dParam < 1.0) {
         // m_maxDB = 1
         // 0 dB = m_neutralParame;
         dValue = db2ratio((dParam - m_neutralParameter) * m_maxDB / (1 - m_neutralParameter));
+    } else {
+        dValue = db2ratio(m_maxDB);
     }
     //qDebug() << "ControlAudioTaperPotBehavior::parameterToValue" << "dValue =" << dValue << "dParam =" << dParam;
     return dValue;

--- a/src/effects/native/bessel4lvmixeqeffect.cpp
+++ b/src/effects/native/bessel4lvmixeqeffect.cpp
@@ -121,15 +121,13 @@ void Bessel4LVMixEQEffect::processChannel(const ChannelHandle& handle,
     Q_UNUSED(handle);
     Q_UNUSED(groupFeatures);
 
-    double fLow;
-    double fMid;
-    double fHigh;
     if (enableState == EffectProcessor::DISABLING) {
         // Ramp to dry, when disabling, this will ramp from dry when enabling as well
-        fLow = 1.0;
-        fMid = 1.0;
-        fHigh = 1.0;
+        pState->processChannelAndPause(pInput, pOutput, numSamples);
     } else {
+        double fLow;
+        double fMid;
+        double fHigh;
         if (!m_pKillLow->toBool()) {
             fLow = m_pPotLow->value();
         } else {
@@ -145,9 +143,8 @@ void Bessel4LVMixEQEffect::processChannel(const ChannelHandle& handle,
         } else {
             fHigh = 0;
         }
+        pState->processChannel(pInput, pOutput, numSamples, sampleRate,
+                               fLow, fMid, fHigh,
+                               m_pLoFreqCorner->get(), m_pHiFreqCorner->get());
     }
-
-    pState->processChannel(pInput, pOutput, numSamples, sampleRate,
-                           fLow, fMid, fHigh,
-                           m_pLoFreqCorner->get(), m_pHiFreqCorner->get());
 }

--- a/src/effects/native/bessel8lvmixeqeffect.cpp
+++ b/src/effects/native/bessel8lvmixeqeffect.cpp
@@ -121,15 +121,14 @@ void Bessel8LVMixEQEffect::processChannel(const ChannelHandle& handle,
     Q_UNUSED(handle);
     Q_UNUSED(groupFeatures);
 
-    double fLow;
-    double fMid;
-    double fHigh;
+
     if (enableState == EffectProcessor::DISABLING) {
         // Ramp to dry, when disabling, this will ramp from dry when enabling as well
-        fLow = 1.0;
-        fMid = 1.0;
-        fHigh = 1.0;
+        pState->processChannelAndPause(pInput, pOutput, numSamples);
     } else {
+        double fLow;
+        double fMid;
+        double fHigh;
         if (!m_pKillLow->toBool()) {
             fLow = m_pPotLow->value();
         } else {
@@ -145,9 +144,8 @@ void Bessel8LVMixEQEffect::processChannel(const ChannelHandle& handle,
         } else {
             fHigh = 0;
         }
+        pState->processChannel(
+                pInput, pOutput, numSamples, sampleRate, fLow, fMid, fHigh,
+                m_pLoFreqCorner->get(), m_pHiFreqCorner->get());
     }
-
-    pState->processChannel(pInput, pOutput, numSamples, sampleRate,
-                           fLow, fMid, fHigh,
-                           m_pLoFreqCorner->get(), m_pHiFreqCorner->get());
 }

--- a/src/effects/native/biquadfullkilleqeffect.cpp
+++ b/src/effects/native/biquadfullkilleqeffect.cpp
@@ -1,0 +1,492 @@
+#include <effects/native/biquadfullkilleqeffect.h>
+#include "util/math.h"
+
+namespace {
+
+static const int kStartupSamplerate = 44100;
+static const double kMinimumFrequency = 10.0;
+static const double kMaximumFrequency = kStartupSamplerate / 2;
+static const double kStartupLoFreq = 50.0;
+static const double kStartupMidFreq = 1100.0;
+static const double kStartupHiFreq = 12000.0;
+static const double kQBoost = 0.3;
+static const double kQKill = 0.9;
+static const double kQLowKillShelve = 0.4;
+static const double kQHighKillShelve = 0.4;
+static const double kKillGain = -23;
+static const int kMaxDelay = 3300; // allows a 30 Hz filter at 97346;
+static const int kRampDone = -1;
+static const int kBesselStartRatio = 0.4;
+
+
+double getCenterFrequency(double low, double high) {
+    double scaleLow = log10(low);
+    double scaleHigh = log10(high);
+
+    double scaleCenter = (scaleHigh - scaleLow) / 2 + scaleLow;
+    return pow(10, scaleCenter);
+}
+
+double knobValueToBiquadGainDb (double value, bool kill) {
+    if (kill) {
+        return kKillGain;
+    }
+    double clampedValue = math_max(value, 0.07);
+    return ratio2db(clampedValue);
+}
+
+double knobValueToBesselRatio (double value, bool kill) {
+    if (kill) {
+        return 0.0;
+    }
+    return math_min(value / 0.4, 1.0);
+}
+
+} // anonymous namesspace
+
+
+// static
+QString BiquadFullKillEQEffect::getId() {
+    return "org.mixxx.effects.dbiquadquadeq";
+}
+
+// static
+EffectManifest BiquadFullKillEQEffect::getManifest() {
+    EffectManifest manifest;
+    manifest.setId(getId());
+    manifest.setName(QObject::tr("Biquad Full Kill Equalizer"));
+    manifest.setShortName(QObject::tr("BQ EQ/ISO"));
+    manifest.setAuthor("The Mixxx Team");
+    manifest.setVersion("1.0");
+    manifest.setDescription(QObject::tr(
+        "A 3-band Equalizer that combines an Equalizer and an Isolator circuit to offer gentle slopes and full kill.") +
+        " " +  QObject::tr(
+        "To adjust frequency shelves see the Equalizer preferences."));
+    manifest.setEffectRampsFromDry(true);
+    manifest.setIsMixingEQ(true);
+
+    EffectManifestParameter* low = manifest.addParameter();
+    low->setId("low");
+    low->setName(QObject::tr("Low"));
+    low->setDescription(QObject::tr("Gain for Low Filter"));
+    low->setControlHint(EffectManifestParameter::CONTROL_KNOB_LOGARITHMIC);
+    low->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
+    low->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
+    low->setNeutralPointOnScale(0.5);
+    low->setDefault(1.0);
+    low->setMinimum(0);
+    low->setMaximum(4.0);
+
+    EffectManifestParameter* killLow = manifest.addParameter();
+    killLow->setId("killLow");
+    killLow->setName(QObject::tr("Kill Low"));
+    killLow->setDescription(QObject::tr("Kill the Low Filter"));
+    killLow->setControlHint(EffectManifestParameter::CONTROL_TOGGLE_STEPPING);
+    killLow->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
+    killLow->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
+    killLow->setDefault(0);
+    killLow->setMinimum(0);
+    killLow->setMaximum(1);
+
+    EffectManifestParameter* mid = manifest.addParameter();
+    mid->setId("mid");
+    mid->setName(QObject::tr("Mid"));
+    mid->setDescription(QObject::tr("Gain for Mid Filter"));
+    mid->setControlHint(EffectManifestParameter::CONTROL_KNOB_LOGARITHMIC);
+    mid->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
+    mid->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
+    mid->setNeutralPointOnScale(0.5);
+    mid->setDefault(1.0);
+    mid->setMinimum(0);
+    mid->setMaximum(4.0);
+
+    EffectManifestParameter* killMid = manifest.addParameter();
+    killMid->setId("killMid");
+    killMid->setName(QObject::tr("Kill Mid"));
+    killMid->setDescription(QObject::tr("Kill the Mid Filter"));
+    killMid->setControlHint(EffectManifestParameter::CONTROL_TOGGLE_STEPPING);
+    killMid->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
+    killMid->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
+    killMid->setDefault(0);
+    killMid->setMinimum(0);
+    killMid->setMaximum(1);
+
+    EffectManifestParameter* high = manifest.addParameter();
+    high->setId("high");
+    high->setName(QObject::tr("High"));
+    high->setDescription(QObject::tr("Gain for High Filter"));
+    high->setControlHint(EffectManifestParameter::CONTROL_KNOB_LOGARITHMIC);
+    high->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
+    high->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
+    high->setNeutralPointOnScale(0.5);
+    high->setDefault(1.0);
+    high->setMinimum(0);
+    high->setMaximum(4.0);
+
+    EffectManifestParameter* killHigh = manifest.addParameter();
+    killHigh->setId("killHigh");
+    killHigh->setName(QObject::tr("Kill High"));
+    killHigh->setDescription(QObject::tr("Kill the High Filter"));
+    killHigh->setControlHint(EffectManifestParameter::CONTROL_TOGGLE_STEPPING);
+    killHigh->setSemanticHint(EffectManifestParameter::SEMANTIC_UNKNOWN);
+    killHigh->setUnitsHint(EffectManifestParameter::UNITS_UNKNOWN);
+    killHigh->setDefault(0);
+    killHigh->setMinimum(0);
+    killHigh->setMaximum(1);
+
+    return manifest;
+}
+
+BiquadFullKillEQEffectGroupState::BiquadFullKillEQEffectGroupState()
+        : m_oldLowBoost(0),
+          m_oldMidBoost(0),
+          m_oldHighBoost(0),
+          m_oldLowKill(0),
+          m_oldMidKill(0),
+          m_oldHighKill(0),
+          m_oldLow(1.0),
+          m_oldMid(1.0),
+          m_oldHigh(1.0),
+          m_loFreqCorner(0),
+          m_highFreqCorner(0),
+          m_rampHoldOff(kRampDone),
+          m_oldSampleRate(kStartupSamplerate) {
+
+    m_pLowBuf = SampleUtil::alloc(MAX_BUFFER_LEN);
+    m_pBandBuf = SampleUtil::alloc(MAX_BUFFER_LEN);
+    m_pHighBuf = SampleUtil::alloc(MAX_BUFFER_LEN);
+    m_pTempBuf = SampleUtil::alloc(MAX_BUFFER_LEN);
+
+    // Initialize the filters with default parameters
+
+    m_lowBoost = std::make_unique<EngineFilterBiquad1Peaking>(
+            kStartupSamplerate, kStartupLoFreq, kQBoost);
+    m_midBoost = std::make_unique<EngineFilterBiquad1Peaking>(
+            kStartupSamplerate, kStartupMidFreq, kQBoost);
+    m_highBoost = std::make_unique<EngineFilterBiquad1Peaking>(
+            kStartupSamplerate, kStartupHiFreq, kQBoost);
+    m_lowKill = std::make_unique<EngineFilterBiquad1LowShelving>(
+            kStartupSamplerate, kStartupLoFreq * 2, kQLowKillShelve);
+    m_midKill = std::make_unique<EngineFilterBiquad1Peaking>(
+            kStartupSamplerate, kStartupMidFreq, kQKill);
+    m_highKill = std::make_unique<EngineFilterBiquad1HighShelving>(
+            kStartupSamplerate, kStartupHiFreq / 2, kQHighKillShelve);
+    m_low1 = std::make_unique<EngineFilterBessel4Low>(
+            kStartupSamplerate, kStartupLoFreq);
+    m_low2 = std::make_unique<EngineFilterBessel4Low>(
+            kStartupSamplerate, kStartupHiFreq);
+    m_delay2 = std::make_unique<EngineFilterDelay<kMaxDelay2>>();
+    m_delay3 = std::make_unique<EngineFilterDelay<kMaxDelay2>>();
+
+    setFilters(kStartupSamplerate, kStartupLoFreq, kStartupHiFreq);
+}
+
+BiquadFullKillEQEffectGroupState::~BiquadFullKillEQEffectGroupState() {
+    SampleUtil::free(m_pLowBuf);
+    SampleUtil::free(m_pBandBuf);
+    SampleUtil::free(m_pHighBuf);
+    SampleUtil::free(m_pTempBuf);
+}
+
+void BiquadFullKillEQEffectGroupState::setFilters(
+        int sampleRate, double lowFreqCorner, double highFreqCorner) {
+
+    double lowCenter = getCenterFrequency(kMinimumFrequency, lowFreqCorner);
+    double midCenter = getCenterFrequency(lowFreqCorner, highFreqCorner);
+    double highCenter = getCenterFrequency(highFreqCorner, kMaximumFrequency);
+
+
+    m_lowBoost->setFrequencyCorners(
+            sampleRate, lowCenter, kQBoost, m_oldLowBoost);
+    m_midBoost->setFrequencyCorners(
+            sampleRate, midCenter, kQBoost, m_oldMidBoost);
+    m_highBoost->setFrequencyCorners(
+            sampleRate, highCenter, kQBoost, m_oldHighBoost);
+    m_lowKill->setFrequencyCorners(
+            sampleRate, lowCenter * 2, kQLowKillShelve, m_oldLowKill);
+    m_midKill->setFrequencyCorners(
+            sampleRate, midCenter, kQKill, m_oldMidKill);
+    m_highKill->setFrequencyCorners(
+            sampleRate, highCenter / 2, kQHighKillShelve, m_oldHighKill);
+
+
+    int delayLow1 = m_low1->setFrequencyCornersForIntDelay(
+            lowFreqCorner / sampleRate, kMaxDelay);
+    int delayLow2 = m_low2->setFrequencyCornersForIntDelay(
+            highFreqCorner / sampleRate, kMaxDelay);
+
+    m_delay2->setDelay((delayLow1 - delayLow2) * 2);
+    m_delay3->setDelay(delayLow1 * 2);
+}
+
+BiquadFullKillEQEffect::BiquadFullKillEQEffect(EngineEffect* pEffect,
+                                             const EffectManifest& manifest)
+        : m_pPotLow(pEffect->getParameterById("low")),
+          m_pPotMid(pEffect->getParameterById("mid")),
+          m_pPotHigh(pEffect->getParameterById("high")),
+          m_pKillLow(pEffect->getParameterById("killLow")),
+          m_pKillMid(pEffect->getParameterById("killMid")),
+          m_pKillHigh(pEffect->getParameterById("killHigh")) {
+    Q_UNUSED(manifest);
+    m_pLoFreqCorner = std::make_unique<ControlProxy>("[Mixer Profile]", "LoEQFrequency");
+    m_pHiFreqCorner = std::make_unique<ControlProxy>("[Mixer Profile]", "HiEQFrequency");
+}
+
+BiquadFullKillEQEffect::~BiquadFullKillEQEffect() {
+}
+
+void BiquadFullKillEQEffect::processChannel(
+        const ChannelHandle& handle,
+        BiquadFullKillEQEffectGroupState* pState,
+        const CSAMPLE* pInput,
+        CSAMPLE* pOutput,
+        const unsigned int numSamples,
+        const unsigned int sampleRate,
+        const EffectProcessor::EnableState enableState,
+        const GroupFeatureState& groupFeatures) {
+    Q_UNUSED(handle);
+    Q_UNUSED(groupFeatures);
+
+    if (pState->m_oldSampleRate != sampleRate ||
+            (pState->m_loFreqCorner != m_pLoFreqCorner->get()) ||
+            (pState->m_highFreqCorner != m_pHiFreqCorner->get())) {
+        pState->m_loFreqCorner = m_pLoFreqCorner->get();
+        pState->m_highFreqCorner = m_pHiFreqCorner->get();
+        pState->m_oldSampleRate = sampleRate;
+        pState->setFilters(sampleRate, pState->m_loFreqCorner, pState->m_highFreqCorner);
+    }
+
+    // Ramp to dry, when disabling, this will ramp from dry when enabling as well
+    double bqGainLow = 0;
+    double bqGainMid = 0;
+    double bqGainHigh = 0;
+    if (enableState != EffectProcessor::DISABLING) {
+        bqGainLow = knobValueToBiquadGainDb(
+                m_pPotLow->value(), m_pKillLow->toBool());
+        bqGainMid = knobValueToBiquadGainDb(
+                m_pPotMid->value(), m_pKillMid->toBool());
+        bqGainHigh = knobValueToBiquadGainDb(
+                m_pPotHigh->value(), m_pKillHigh->toBool());
+    }
+
+    int activeFilters = 0;
+
+    if (bqGainLow != 0.0) {
+        ++activeFilters;
+    }
+    if (bqGainMid != 0.0) {
+        ++activeFilters;
+    }
+    if (bqGainHigh != 0.0) {
+        ++activeFilters;
+    }
+
+    QVarLengthArray<const CSAMPLE*, 3> inBuffer;
+    QVarLengthArray<CSAMPLE*, 3> outBuffer;
+
+    if (activeFilters == 2) {
+        inBuffer.append(pInput);
+        outBuffer.append(pState->m_pTempBuf);
+        inBuffer.append(pState->m_pTempBuf);
+        outBuffer.append(pOutput);
+    }
+    else
+    {
+        inBuffer.append(pInput);
+        outBuffer.append(pOutput);
+        inBuffer.append(pOutput);
+        outBuffer.append(pState->m_pTempBuf);
+        inBuffer.append(pState->m_pTempBuf);
+        outBuffer.append(pOutput);
+    }
+
+    int bufIndex = 0;
+
+    if (bqGainLow > 0.0) {
+        if (bqGainLow != pState->m_oldLowBoost) {
+            double lowCenter = getCenterFrequency(
+                    kMinimumFrequency, pState->m_loFreqCorner);
+            pState->m_lowBoost->setFrequencyCorners(
+                    sampleRate, lowCenter, kQBoost, bqGainLow);
+            pState->m_oldLowBoost = bqGainLow;
+        }
+        pState->m_lowBoost->process(
+                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        pState->m_lowKill->pauseFilter();
+        ++bufIndex;
+    } else if (bqGainLow < 0.0) {
+        if (bqGainLow != pState->m_oldLowKill) {
+            double lowCenter = getCenterFrequency(
+                    kMinimumFrequency, pState->m_loFreqCorner);
+            pState->m_lowKill->setFrequencyCorners(
+                    sampleRate, lowCenter * 2, kQLowKillShelve, bqGainLow);
+            pState->m_oldLowKill = bqGainLow;
+        }
+        pState->m_lowBoost->pauseFilter();
+        pState->m_lowKill->process(
+                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        ++bufIndex;
+    } else {
+        pState->m_lowBoost->pauseFilter();
+        pState->m_lowKill->pauseFilter();
+    }
+
+    if (bqGainMid > 0.0) {
+        if (bqGainMid != pState->m_oldMidBoost) {
+            double midCenter = getCenterFrequency(
+                    pState->m_loFreqCorner, pState->m_highFreqCorner);
+            pState->m_midBoost->setFrequencyCorners(
+                    sampleRate, midCenter, kQBoost, bqGainMid);
+            pState->m_oldMidBoost = bqGainMid;
+        }
+        pState->m_midBoost->process(
+                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        pState->m_midKill->pauseFilter();
+        ++bufIndex;
+    } else if (bqGainMid < 0.0) {
+        if (bqGainMid != pState->m_oldMidKill) {
+            double midCenter = getCenterFrequency(
+                    pState->m_loFreqCorner, pState->m_highFreqCorner);
+            pState->m_midKill->setFrequencyCorners(
+                    sampleRate, midCenter, kQKill, bqGainMid);
+            pState->m_oldMidKill = bqGainMid;
+        }
+        pState->m_midBoost->pauseFilter();
+        pState->m_midKill->process(
+                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        ++bufIndex;
+    } else {
+        pState->m_midBoost->pauseFilter();
+        pState->m_midKill->pauseFilter();
+    }
+
+    if (bqGainHigh > 0.0) {
+        if (bqGainHigh != pState->m_oldHighBoost) {
+            double highCenter = getCenterFrequency(
+                    pState->m_highFreqCorner, kMaximumFrequency);
+            pState->m_highBoost->setFrequencyCorners(
+                    sampleRate, highCenter, kQBoost, bqGainHigh);
+            pState->m_oldHighBoost = bqGainHigh;
+        }
+        pState->m_highBoost->process(
+                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        pState->m_highKill->pauseFilter();
+        ++bufIndex;
+    } else if (bqGainHigh < 0.0) {
+        if (bqGainHigh != pState->m_oldHighKill) {
+            double highCenter = getCenterFrequency(
+                    pState->m_highFreqCorner, kMaximumFrequency);
+            pState->m_highKill->setFrequencyCorners(
+                    sampleRate, highCenter / 2, kQHighKillShelve, bqGainHigh);
+            pState->m_oldHighKill = bqGainHigh;
+        }
+        pState->m_highBoost->pauseFilter();
+        pState->m_highKill->process(
+                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        ++bufIndex;
+    } else {
+        pState->m_highBoost->pauseFilter();
+        pState->m_highKill->pauseFilter();
+    }
+
+    if (activeFilters == 0) {
+        SampleUtil::copy(pOutput, pInput, numSamples);
+    }
+
+    if (enableState == EffectProcessor::DISABLING) {
+        pState->m_lowBoost->pauseFilter();
+        pState->m_midBoost->pauseFilter();
+        pState->m_highBoost->pauseFilter();
+        pState->m_lowKill->pauseFilter();
+        pState->m_midKill->pauseFilter();
+        pState->m_highKill->pauseFilter();
+    }
+
+    // Since a Bessel Low pass Filter has a constant group delay in the pass band,
+    // we can subtract or add the filtered signal to the dry signal if we compensate this delay
+    // The dry signal represents the high gain
+    // Then the higher low pass is added and at least the lower low pass result.
+    double fLow = knobValueToBesselRatio(
+            m_pPotLow->value(), m_pKillLow->toBool());
+    double fMid = knobValueToBesselRatio(
+            m_pPotMid->value(), m_pKillMid->toBool());
+    double fHigh = knobValueToBesselRatio(
+            m_pPotHigh->value(), m_pKillHigh->toBool());
+    fLow = fLow - fMid;
+    fMid = fMid - fHigh;
+
+
+    // Note: We do not call pauseFilter() here because this will introduce a
+    // buffer size-dependent start delay. During such start delay some unwanted
+    // frequencies are slipping though or wanted frequencies are damped.
+    // We know the exact group delay here so we can just hold off the ramping.
+    if (fHigh || pState->m_oldHigh) {
+        pState->m_delay3->process(pOutput, pState->m_pHighBuf, numSamples);
+    }
+
+    if (fMid || pState->m_oldMid) {
+        pState->m_delay2->process(pOutput, pState->m_pBandBuf, numSamples);
+        pState->m_low2->process(pState->m_pBandBuf, pState->m_pBandBuf, numSamples);
+    }
+
+    if (fLow || pState->m_oldLow) {
+        pState->m_low1->process(pOutput, pState->m_pLowBuf, numSamples);
+    }
+
+    if (fLow == pState->m_oldLow &&
+            fMid == pState->m_oldMid &&
+            fHigh == pState->m_oldHigh) {
+        SampleUtil::copy3WithGain(pOutput,
+                pState->m_pLowBuf, fLow,
+                pState->m_pBandBuf, fMid,
+                pState->m_pHighBuf, fHigh,
+                numSamples);
+    } else {
+        int copySamples = 0;
+        int rampingSamples = numSamples;
+        if ((fLow && !pState->m_oldLow) ||
+                (fMid && !pState->m_oldMid) ||
+                (fHigh && !pState->m_oldHigh)) {
+            // we have just switched at least one filter on
+            // Hold off ramping for the group delay
+            if (pState->m_rampHoldOff == kRampDone) {
+                // multiply the group delay * 2 to ensure that the filter is
+                // settled it is actually at a factor of 1,8 at default setting
+                pState->m_rampHoldOff = pState->m_groupDelay * 2;
+                // ensure that we have at least 128 samples for ramping
+                // (the smallest buffer, that suits for de-clicking)
+                int rampingSamples = numSamples - (pState->m_rampHoldOff % numSamples);
+                if (rampingSamples < 128) {
+                    pState->m_rampHoldOff += rampingSamples;
+                }
+            }
+
+            // ramping is done in one of the following calls if
+            // pState->m_rampHoldOff >= numSamples;
+            copySamples = math_min<int>(pState->m_rampHoldOff, numSamples);
+            pState->m_rampHoldOff -= copySamples;
+            rampingSamples = numSamples - copySamples;
+
+            SampleUtil::copy3WithGain(pOutput,
+                    pState->m_pLowBuf, pState->m_oldLow,
+                    pState->m_pBandBuf, pState->m_oldMid,
+                    pState->m_pHighBuf, pState->m_oldHigh,
+                    copySamples);
+        }
+
+        if (rampingSamples) {
+            SampleUtil::copy3WithRampingGain(&pOutput[copySamples],
+                    &pState->m_pLowBuf[copySamples], pState->m_oldLow, fLow,
+                    &pState->m_pBandBuf[copySamples], pState->m_oldMid, fMid,
+                    &pState->m_pHighBuf[copySamples], pState->m_oldHigh, fHigh,
+                    rampingSamples);
+
+            pState->m_oldLow = fLow;
+            pState->m_oldMid = fMid;
+            pState->m_oldHigh = fHigh;
+            pState->m_rampHoldOff = kRampDone;
+
+        }
+    }
+}
+

--- a/src/effects/native/biquadfullkilleqeffect.cpp
+++ b/src/effects/native/biquadfullkilleqeffect.cpp
@@ -328,8 +328,13 @@ void BiquadFullKillEQEffect::processChannel(
                     sampleRate, lowCenter, kQBoost, bqGainLow);
             pState->m_oldLowBoost = bqGainLow;
         }
-        pState->m_lowBoost->process(
-                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        if (bqGainLow > 0.0) {
+            pState->m_lowBoost->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        } else {
+            pState->m_lowBoost->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        }
         ++bufIndex;
     } else {
         pState->m_lowBoost->pauseFilter();
@@ -344,8 +349,13 @@ void BiquadFullKillEQEffect::processChannel(
                     sampleRate, lowCenter * 2, kQLowKillShelve, bqGainLow);
             pState->m_oldLowKill = bqGainLow;
         }
-        pState->m_lowKill->process(
-                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        if (bqGainLow < 0.0) {
+            pState->m_lowKill->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        } else {
+            pState->m_lowKill->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        }
         ++bufIndex;
     } else {
         pState->m_lowKill->pauseFilter();
@@ -360,8 +370,13 @@ void BiquadFullKillEQEffect::processChannel(
                     sampleRate, midCenter, kQBoost, bqGainMid);
             pState->m_oldMidBoost = bqGainMid;
         }
-        pState->m_midBoost->process(
-                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        if (bqGainMid > 0.0) {
+            pState->m_midBoost->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        } else {
+            pState->m_midBoost->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        }
         ++bufIndex;
     } else {
         pState->m_midBoost->pauseFilter();
@@ -375,8 +390,13 @@ void BiquadFullKillEQEffect::processChannel(
                     sampleRate, midCenter, kQKill, bqGainMid);
             pState->m_oldMidKill = bqGainMid;
         }
-        pState->m_midKill->process(
-                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        if (bqGainMid < 0.0) {
+            pState->m_midKill->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        } else {
+            pState->m_midKill->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        }
         ++bufIndex;
     } else {
         pState->m_midKill->pauseFilter();
@@ -390,8 +410,13 @@ void BiquadFullKillEQEffect::processChannel(
                     sampleRate, highCenter, kQBoost, bqGainHigh);
             pState->m_oldHighBoost = bqGainHigh;
         }
-        pState->m_highBoost->process(
-                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        if (bqGainHigh > 0.0) {
+            pState->m_highBoost->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        } else {
+            pState->m_highBoost->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        }
         ++bufIndex;
     } else {
         pState->m_highBoost->pauseFilter();
@@ -405,8 +430,13 @@ void BiquadFullKillEQEffect::processChannel(
                     sampleRate, highCenter / 2, kQHighKillShelve, bqGainHigh);
             pState->m_oldHighKill = bqGainHigh;
         }
-        pState->m_highKill->process(
-                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        if (bqGainHigh < 0.0) {
+            pState->m_highKill->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        } else {
+            pState->m_highKill->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        }
         ++bufIndex;
     } else {
         pState->m_highKill->pauseFilter();

--- a/src/effects/native/biquadfullkilleqeffect.cpp
+++ b/src/effects/native/biquadfullkilleqeffect.cpp
@@ -14,7 +14,7 @@ static const double kQKill = 0.9;
 static const double kQLowKillShelve = 0.4;
 static const double kQHighKillShelve = 0.4;
 static const double kKillGain = -23;
-static const double kBesselStartRatio = 0.4;
+static const double kBesselStartRatio = 0.25;
 static const int kMaxDelay = 3300; // allows a 30 Hz filter at 97346;
 static const int kRampDone = -1;
 
@@ -32,8 +32,13 @@ double knobValueToBiquadGainDb (double value, bool kill) {
     if (kill) {
         return kKillGain;
     }
-    double clampedValue = math_max(value, 0.07); // limit at kKillGain
-    return ratio2db(clampedValue);
+    if (value > kBesselStartRatio) {
+        return ratio2db(value);
+    }
+    double startDB = ratio2db(kBesselStartRatio);
+    value = 1 - (value / kBesselStartRatio);
+    return (kKillGain - startDB) * value + startDB;
+
 }
 
 double knobValueToBesselRatio (double value, bool kill) {

--- a/src/effects/native/biquadfullkilleqeffect.h
+++ b/src/effects/native/biquadfullkilleqeffect.h
@@ -14,6 +14,7 @@
 #include "util/sample.h"
 #include "util/types.h"
 #include "util/memory.h"
+#include "util/samplebuffer.h"
 
 static const int kMaxDelay2 = 3300; // allows a 30 Hz filter at 97346;
 
@@ -35,11 +36,11 @@ class BiquadFullKillEQEffectGroupState final {
     std::unique_ptr<EngineFilterBessel4Low> m_low2;
     std::unique_ptr<EngineFilterDelay<kMaxDelay2>> m_delay2;
     std::unique_ptr<EngineFilterDelay<kMaxDelay2>> m_delay3;
-    CSAMPLE* m_pLowBuf;
-    CSAMPLE* m_pBandBuf;
-    CSAMPLE* m_pHighBuf;
+    std::unique_ptr<SampleBuffer> m_pLowBuf;
+    std::unique_ptr<SampleBuffer> m_pBandBuf;
+    std::unique_ptr<SampleBuffer> m_pHighBuf;
+    std::unique_ptr<SampleBuffer> m_pTempBuf;
 
-    CSAMPLE* m_pTempBuf;
     double m_oldLowBoost;
     double m_oldMidBoost;
     double m_oldHighBoost;

--- a/src/effects/native/biquadfullkilleqeffect.h
+++ b/src/effects/native/biquadfullkilleqeffect.h
@@ -8,6 +8,7 @@
 #include "engine/effects/engineeffectparameter.h"
 #include "engine/enginefilterbiquad1.h"
 #include "engine/enginefilterbessel4.h"
+#include "effects/native/lvmixeqbase.h"
 #include "engine/enginefilterdelay.h"
 #include "util/class.h"
 #include "util/defs.h"
@@ -32,14 +33,12 @@ class BiquadFullKillEQEffectGroupState final {
     std::unique_ptr<EngineFilterBiquad1LowShelving> m_lowKill;
     std::unique_ptr<EngineFilterBiquad1Peaking> m_midKill;
     std::unique_ptr<EngineFilterBiquad1HighShelving> m_highKill;
-    std::unique_ptr<EngineFilterBessel4Low> m_low1;
-    std::unique_ptr<EngineFilterBessel4Low> m_low2;
-    std::unique_ptr<EngineFilterDelay<kMaxDelay2>> m_delay2;
-    std::unique_ptr<EngineFilterDelay<kMaxDelay2>> m_delay3;
+    std::unique_ptr<LVMixEQEffectGroupState<EngineFilterBessel4Low>> m_lvMixIso;
     std::unique_ptr<SampleBuffer> m_pLowBuf;
     std::unique_ptr<SampleBuffer> m_pBandBuf;
     std::unique_ptr<SampleBuffer> m_pHighBuf;
     std::unique_ptr<SampleBuffer> m_pTempBuf;
+
 
     double m_oldLowBoost;
     double m_oldMidBoost;

--- a/src/effects/native/biquadfullkilleqeffect.h
+++ b/src/effects/native/biquadfullkilleqeffect.h
@@ -1,0 +1,101 @@
+#ifndef BIQUADFULLKILLEQEFFECT_H
+#define BIQUADFULLKILLEQEFFECT_H
+
+#include "control/controlproxy.h"
+#include "effects/effect.h"
+#include "effects/effectprocessor.h"
+#include "engine/effects/engineeffect.h"
+#include "engine/effects/engineeffectparameter.h"
+#include "engine/enginefilterbiquad1.h"
+#include "engine/enginefilterbessel4.h"
+#include "engine/enginefilterdelay.h"
+#include "util/class.h"
+#include "util/defs.h"
+#include "util/sample.h"
+#include "util/types.h"
+#include "util/memory.h"
+
+static const int kMaxDelay2 = 3300; // allows a 30 Hz filter at 97346;
+
+class BiquadFullKillEQEffectGroupState final {
+  public:
+    BiquadFullKillEQEffectGroupState();
+    ~BiquadFullKillEQEffectGroupState();
+
+    void setFilters(
+            int sampleRate, double lowFreqCorner, double highFreqCorner);
+
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_lowBoost;
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_midBoost;
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_highBoost;
+    std::unique_ptr<EngineFilterBiquad1LowShelving> m_lowKill;
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_midKill;
+    std::unique_ptr<EngineFilterBiquad1HighShelving> m_highKill;
+    std::unique_ptr<EngineFilterBessel4Low> m_low1;
+    std::unique_ptr<EngineFilterBessel4Low> m_low2;
+    std::unique_ptr<EngineFilterDelay<kMaxDelay2>> m_delay2;
+    std::unique_ptr<EngineFilterDelay<kMaxDelay2>> m_delay3;
+    CSAMPLE* m_pLowBuf;
+    CSAMPLE* m_pBandBuf;
+    CSAMPLE* m_pHighBuf;
+
+    CSAMPLE* m_pTempBuf;
+    double m_oldLowBoost;
+    double m_oldMidBoost;
+    double m_oldHighBoost;
+    double m_oldLowKill;
+    double m_oldMidKill;
+    double m_oldHighKill;
+    double m_oldLow;
+    double m_oldMid;
+    double m_oldHigh;
+
+    double m_loFreqCorner;
+    double m_highFreqCorner;
+
+    int m_rampHoldOff;
+    int m_groupDelay;
+
+    unsigned int m_oldSampleRate;
+};
+
+class BiquadFullKillEQEffect : public PerChannelEffectProcessor<BiquadFullKillEQEffectGroupState> {
+  public:
+    BiquadFullKillEQEffect(EngineEffect* pEffect, const EffectManifest& manifest);
+    ~BiquadFullKillEQEffect() override;
+
+    static QString getId();
+    static EffectManifest getManifest();
+
+    void setFilters(int sampleRate, double lowFreqCorner, double highFreqCorner);
+
+    // See effectprocessor.h
+    void processChannel(const ChannelHandle& handle,
+                        BiquadFullKillEQEffectGroupState* pState,
+                        const CSAMPLE* pInput, CSAMPLE *pOutput,
+                        const unsigned int numSamples,
+                        const unsigned int sampleRate,
+                        const EffectProcessor::EnableState enableState,
+                        const GroupFeatureState& groupFeatureState);
+
+  private:
+    BiquadFullKillEQEffect(const BiquadFullKillEQEffect&) = delete;
+    void operator=(const BiquadFullKillEQEffect&) = delete;
+
+    QString debugString() const {
+        return getId();
+    }
+
+    EngineEffectParameter* m_pPotLow;
+    EngineEffectParameter* m_pPotMid;
+    EngineEffectParameter* m_pPotHigh;
+
+    EngineEffectParameter* m_pKillLow;
+    EngineEffectParameter* m_pKillMid;
+    EngineEffectParameter* m_pKillHigh;
+
+    std::unique_ptr<ControlProxy> m_pLoFreqCorner;
+    std::unique_ptr<ControlProxy> m_pHiFreqCorner;
+};
+
+#endif // BIQUADFULLKILLEQEFFECT_H

--- a/src/effects/native/lvmixeqbase.h
+++ b/src/effects/native/lvmixeqbase.h
@@ -160,8 +160,6 @@ class LVMixEQEffectGroupState {
 
     void processChannelAndPause(
             const CSAMPLE* pInput, CSAMPLE* pOutput, const int numSamples) {
-        DEBUG_ASSERT(pInput != pOutput); // Fade to dry only works if pInput is not touched by pOutput
-
 
         // Note: We do not call pauseFilter() here because this will introduce a
         // buffer size-dependent start delay. During such start delay some unwanted

--- a/src/effects/native/lvmixeqbase.h
+++ b/src/effects/native/lvmixeqbase.h
@@ -158,6 +158,84 @@ class LVMixEQEffectGroupState {
         }
     }
 
+    void processChannelAndPause(
+            const CSAMPLE* pInput, CSAMPLE* pOutput, const int numSamples) {
+        DEBUG_ASSERT(pInput != pOutput); // Fade to dry only works if pInput is not touched by pOutput
+
+
+        // Note: We do not call pauseFilter() here because this will introduce a
+        // buffer size-dependent start delay. During such start delay some unwanted
+        // frequencies are slipping though or wanted frequencies are damped.
+        // We know the exact group delay here so we can just hold off the ramping.
+        m_delay3->processAndPauseFilter(pInput, m_pHighBuf, numSamples);
+
+        if (m_oldMid) {
+            m_delay2->processAndPauseFilter(pInput, m_pBandBuf, numSamples);
+            m_low2->processAndPauseFilter(m_pBandBuf, m_pBandBuf, numSamples);
+        }
+
+        if (m_oldLow) {
+            m_low1->processAndPauseFilter(pInput, m_pLowBuf, numSamples);
+        }
+
+        SampleUtil::copy3WithRampingGain(pOutput,
+                m_pLowBuf, m_oldLow, 0.0,
+                m_pBandBuf, m_oldMid, 0.0,
+                m_pHighBuf, m_oldHigh, 1.0,
+                numSamples);
+    }
+
+    /*
+
+        int copySamples = 0;
+        int rampingSamples = numSamples;
+        if ((fLow && !m_oldLow) ||
+                (fMid && !m_oldMid) ||
+                (fHigh && !m_oldHigh)) {
+            // we have just switched at least one filter on
+            // Hold off ramping for the group delay
+            if (m_rampHoldOff == kRampDone) {
+                // multiply the group delay * 2 to ensure that the filter is
+                // settled it is actually at a factor of 1,8 at default setting
+                m_rampHoldOff = m_groupDelay * 2;
+                // ensure that we have at least 128 samples for ramping
+                // (the smallest buffer, that suits for de-clicking)
+                int rampingSamples = numSamples - (m_rampHoldOff % numSamples);
+                if (rampingSamples < 128) {
+                    m_rampHoldOff += rampingSamples;
+                }
+            }
+
+            // ramping is done in one of the following calls if
+            // pState->m_rampHoldOff >= numSamples;
+            copySamples = math_min<int>(m_rampHoldOff, numSamples);
+            m_rampHoldOff -= copySamples;
+            rampingSamples = numSamples - copySamples;
+
+            SampleUtil::copy3WithGain(pOutput,
+                    m_pLowBuf, m_oldLow,
+                    m_pBandBuf, m_oldMid,
+                    m_pHighBuf, m_oldHigh,
+                    copySamples);
+        }
+
+        if (rampingSamples) {
+            SampleUtil::copy3WithRampingGain(&pOutput[copySamples],
+                    &m_pLowBuf[copySamples], m_oldLow, fLow,
+                    &m_pBandBuf[copySamples], m_oldMid, fMid,
+                    &m_pHighBuf[copySamples], m_oldHigh, fHigh,
+                    rampingSamples);
+
+            m_oldLow = fLow;
+            m_oldMid = fMid;
+            m_oldHigh = fHigh;
+            m_rampHoldOff = kRampDone;
+
+        }
+    }
+
+*/
+
   private:
     LPF* m_low1;
     LPF* m_low2;

--- a/src/effects/native/nativebackend.cpp
+++ b/src/effects/native/nativebackend.cpp
@@ -1,4 +1,4 @@
-#include <effects/native/threebandbiquadeqeffect.h>
+
 #include <QtDebug>
 
 #include "effects/native/nativebackend.h"
@@ -7,6 +7,8 @@
 #include "effects/native/linkwitzriley8eqeffect.h"
 #include "effects/native/bessel8lvmixeqeffect.h"
 #include "effects/native/bessel4lvmixeqeffect.h"
+#include <effects/native/threebandbiquadeqeffect.h>
+#include <effects/native/biquadfullkilleqeffect.h>
 #include "effects/native/graphiceqeffect.h"
 #include "effects/native/filtereffect.h"
 #include "effects/native/moogladder4filtereffect.h"
@@ -26,6 +28,7 @@ NativeBackend::NativeBackend(QObject* pParent)
     registerEffect<Bessel8LVMixEQEffect>();
     registerEffect<LinkwitzRiley8EQEffect>();
     registerEffect<ThreeBandBiquadEQEffect>();
+    registerEffect<BiquadFullKillEQEffect>();
     // Compensations EQs    
     registerEffect<GraphicEQEffect>();
     registerEffect<LoudnessContourEffect>();

--- a/src/effects/native/threebandbiquadeqeffect.cpp
+++ b/src/effects/native/threebandbiquadeqeffect.cpp
@@ -136,12 +136,18 @@ ThreeBandBiquadEQEffectGroupState::ThreeBandBiquadEQEffectGroupState()
 
     // Initialize the filters with default parameters
 
-    m_lowBoost = std::make_unique<EngineFilterBiquad1Peaking>(kStartupSamplerate , kStartupLoFreq, kQBoost);
-    m_midBoost = std::make_unique<EngineFilterBiquad1Peaking>(kStartupSamplerate , kStartupMidFreq, kQBoost);
-    m_highBoost = std::make_unique<EngineFilterBiquad1Peaking>(kStartupSamplerate , kStartupHiFreq, kQBoost);
-    m_lowCut = std::make_unique<EngineFilterBiquad1Peaking>(kStartupSamplerate , kStartupLoFreq, kQKill);
-    m_midCut = std::make_unique<EngineFilterBiquad1Peaking>(kStartupSamplerate , kStartupMidFreq, kQKill);
-    m_highCut = std::make_unique<EngineFilterBiquad1HighShelving>(kStartupSamplerate , kStartupHiFreq / 2, kQKillShelve);
+    m_lowBoost = std::make_unique<EngineFilterBiquad1Peaking>(
+            kStartupSamplerate , kStartupLoFreq, kQBoost);
+    m_midBoost = std::make_unique<EngineFilterBiquad1Peaking>(
+            kStartupSamplerate , kStartupMidFreq, kQBoost);
+    m_highBoost = std::make_unique<EngineFilterBiquad1Peaking>(
+            kStartupSamplerate , kStartupHiFreq, kQBoost);
+    m_lowCut = std::make_unique<EngineFilterBiquad1Peaking>(
+            kStartupSamplerate , kStartupLoFreq, kQKill);
+    m_midCut = std::make_unique<EngineFilterBiquad1Peaking>(
+            kStartupSamplerate , kStartupMidFreq, kQKill);
+    m_highCut = std::make_unique<EngineFilterBiquad1HighShelving>(
+            kStartupSamplerate , kStartupHiFreq / 2, kQKillShelve);
 }
 
 ThreeBandBiquadEQEffectGroupState::~ThreeBandBiquadEQEffectGroupState() {

--- a/src/effects/native/threebandbiquadeqeffect.cpp
+++ b/src/effects/native/threebandbiquadeqeffect.cpp
@@ -315,13 +315,17 @@ void ThreeBandBiquadEQEffect::processChannel(
                     sampleRate, lowCenter, kQBoost, bqGainLow);
             pState->m_oldLowBoost = bqGainLow;
         }
-        pState->m_lowBoost->process(
-                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        if (bqGainLow > 0.0) {
+            pState->m_lowBoost->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        } else {
+            pState->m_lowBoost->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        }
         ++bufIndex;
     } else {
         pState->m_lowBoost->pauseFilter();
     }
-
 
     if (bqGainLow < 0.0 || pState->m_oldLowCut < 0.0) {
         if (bqGainLow != pState->m_oldLowCut) {
@@ -331,12 +335,16 @@ void ThreeBandBiquadEQEffect::processChannel(
                     sampleRate, lowCenter, kQKill, bqGainLow);
             pState->m_oldLowCut = bqGainLow;
         }
-        pState->m_lowCut->process(
-                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        if (bqGainLow < 0.0) {
+            pState->m_lowCut->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        } else {
+            pState->m_lowCut->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        }
         ++bufIndex;
     } else {
         pState->m_lowCut->pauseFilter();
-
     }
 
     if (bqGainMid > 0.0 || pState->m_oldMidBoost > 0.0) {
@@ -347,12 +355,18 @@ void ThreeBandBiquadEQEffect::processChannel(
                     sampleRate, midCenter, kQBoost, bqGainMid);
             pState->m_oldMidBoost = bqGainMid;
         }
-        pState->m_midBoost->process(
-                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        if (bqGainMid > 0.0) {
+            pState->m_midBoost->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        } else {
+            pState->m_midBoost->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        }
         ++bufIndex;
     } else {
         pState->m_midBoost->pauseFilter();
     }
+
 
     if (bqGainMid < 0.0 || pState->m_oldMidCut < 0.0) {
         if (bqGainMid != pState->m_oldMidCut) {
@@ -362,8 +376,13 @@ void ThreeBandBiquadEQEffect::processChannel(
                     sampleRate, midCenter, kQKill, bqGainMid);
             pState->m_oldMidCut = bqGainMid;
         }
-        pState->m_midCut->process(
-                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        if (bqGainMid < 0.0) {
+            pState->m_midCut->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        } else {
+            pState->m_midCut->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        }
         ++bufIndex;
     } else {
         pState->m_midCut->pauseFilter();
@@ -377,8 +396,13 @@ void ThreeBandBiquadEQEffect::processChannel(
                     sampleRate, highCenter, kQBoost, bqGainHigh);
             pState->m_oldHighBoost = bqGainHigh;
         }
-        pState->m_highBoost->process(
-                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        if (bqGainHigh > 0.0) {
+            pState->m_highBoost->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        } else {
+            pState->m_highBoost->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        }
         ++bufIndex;
     } else {
         pState->m_highBoost->pauseFilter();
@@ -392,8 +416,13 @@ void ThreeBandBiquadEQEffect::processChannel(
                     sampleRate, highCenter / 2, kQKillShelve, bqGainHigh);
             pState->m_oldHighCut = bqGainHigh;
         }
-        pState->m_highCut->process(
-                inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        if (bqGainHigh < 0.0) {
+            pState->m_highCut->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        } else {
+            pState->m_highCut->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], numSamples);
+        }
         ++bufIndex;
     } else {
         pState->m_highCut->pauseFilter();

--- a/src/effects/native/threebandbiquadeqeffect.h
+++ b/src/effects/native/threebandbiquadeqeffect.h
@@ -1,8 +1,6 @@
 #ifndef THREEBANDBIQUADEQEFFECT_H
 #define THREEBANDBIQUADEQEFFECT_H
 
-#include <QMap>
-
 #include "control/controlproxy.h"
 #include "effects/effect.h"
 #include "effects/effectprocessor.h"
@@ -14,6 +12,7 @@
 #include "util/sample.h"
 #include "util/types.h"
 #include "util/memory.h"
+#include "util/samplebuffer.h"
 
 class ThreeBandBiquadEQEffectGroupState final {
   public:
@@ -29,7 +28,7 @@ class ThreeBandBiquadEQEffectGroupState final {
     std::unique_ptr<EngineFilterBiquad1Peaking> m_lowCut;
     std::unique_ptr<EngineFilterBiquad1Peaking> m_midCut;
     std::unique_ptr<EngineFilterBiquad1HighShelving> m_highCut;
-    CSAMPLE* m_pBuf;
+    std::unique_ptr<SampleBuffer> m_pTempBuf;
     double m_oldLowBoost;
     double m_oldMidBoost;
     double m_oldHighBoost;

--- a/src/engine/enginefilterdelay.h
+++ b/src/engine/enginefilterdelay.h
@@ -102,6 +102,19 @@ class EngineFilterDelay : public EngineObjectConstIn {
         m_doStart = false;
     }
 
+
+    // this is can be used instead off a final process() call before pause
+    // It fades to dry or 0 according to the m_startFromDry parameter
+    // it is an alternative for using pauseFillter() calls
+    void processAndPauseFilter(const CSAMPLE* pIn, CSAMPLE* pOutput,
+                       const int iBufferSize) {
+        double oldDelay = m_delaySamples;
+        m_delaySamples = 0;
+        process(pIn, pOutput, iBufferSize);
+        m_delaySamples = oldDelay;
+        pauseFilter();
+    }
+
   protected:
     int m_delaySamples;
     int m_oldDelaySamples;

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -31,7 +31,7 @@ const QString kConfigKey = "[Mixer Profile]";
 const QString kEnableEqs = "EnableEQs";
 const QString kEqsOnly = "EQsOnly";
 const QString kSingleEq = "SingleEQEffect";
-const QString kDefaultEqId = "org.mixxx.effects.bessel8lvmixeq";
+const QString kDefaultEqId = "org.mixxx.effects.dbiquadquadeq";
 const QString kDefaultMasterEqId = QString();
 const QString kDefaultQuickEffectId = "org.mixxx.effects.filter";
 


### PR DESCRIPTION
This is an attempt to build a new default EQ for Mixxx. It combines an standard Biquad Equalizer with an Isolator to reach full kill. This should suite to gentle tweak the sound around unity and It allows to full kill a band when doing a transition.

Features:
* Boost: +12 dB
* Kill: -Infinity 
* Bit perfect at unity  
* No CPU load at unity 
* Up medium CPU load when killing Mid 
* Gentle rounded cut-off

I am curious to read your results from listening. 


 

