### PR TITLE
increase maximum waveform zoom out level

### DIFF
--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -79,6 +79,10 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
   private slots:
     void slotPassthroughEnabled(double v);
     void slotVinylControlEnabled(double v);
+    void slotWaveformZoomValueChangeRequest(double pressed);
+    void slotWaveformZoomUp(double pressed);
+    void slotWaveformZoomDown(double pressed);
+    void slotWaveformZoomSetDefault(double pressed);
 
   private:
     void setReplayGain(double value);
@@ -88,7 +92,10 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     TrackPointer m_pLoadedTrack;
 
     // Waveform display related controls
-    ControlPotmeter* m_pWaveformZoom;
+    ControlObject* m_pWaveformZoom;
+    ControlPushButton* m_pWaveformZoomUp;
+    ControlPushButton* m_pWaveformZoomDown;
+    ControlPushButton* m_pWaveformZoomSetDefault;
     ControlObject* m_pEndOfTrack;
 
     ControlProxy* m_pLoopInPoint;

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -11,6 +11,7 @@
 
 const int WaveformWidgetRenderer::s_waveformMinZoom = 1;
 const int WaveformWidgetRenderer::s_waveformMaxZoom = 10;
+const int WaveformWidgetRenderer::s_waveformDefaultZoom = 3;
 
 WaveformWidgetRenderer::WaveformWidgetRenderer(const char* group)
     : m_group(group),

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -10,7 +10,7 @@
 #include "util/performancetimer.h"
 
 const int WaveformWidgetRenderer::s_waveformMinZoom = 1;
-const int WaveformWidgetRenderer::s_waveformMaxZoom = 6;
+const int WaveformWidgetRenderer::s_waveformMaxZoom = 10;
 
 WaveformWidgetRenderer::WaveformWidgetRenderer(const char* group)
     : m_group(group),

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -23,6 +23,7 @@ class WaveformWidgetRenderer {
   public:
     static const int s_waveformMinZoom;
     static const int s_waveformMaxZoom;
+    static const int s_waveformDefaultZoom;
 
   public:
     explicit WaveformWidgetRenderer(const char* group);

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -62,7 +62,7 @@ WaveformWidgetFactory::WaveformWidgetFactory() :
         m_skipRender(false),
         m_frameRate(30),
         m_endOfTrackWarningTime(30),
-        m_defaultZoom(3),
+        m_defaultZoom(WaveformWidgetRenderer::s_waveformDefaultZoom),
         m_zoomSync(false),
         m_overviewNormalized(false),
         m_openGLAvailable(false),


### PR DESCRIPTION
As requested by [a user](https://bugs.launchpad.net/mixxx/+bug/1656209). I have found myself staring at overview waveforms to know when a transition is coming, which is not what the overviews are for. Zooming the waveforms out further should help with that.

It would also be nice if the current play position relative to the widget's length could be adjusted. It is more important to see what is coming than what has already played, so it would be good to set this 1/4 or 1/3 from the left. There is a [Launchpad ticket](https://bugs.launchpad.net/mixxx/+bug/1308643) for that.