### PR TITLE
Three fixes related to waveform generation, splitted from the multithreaded-analysis branch

### DIFF
--- a/src/analyzer/analyzerwaveform.cpp
+++ b/src/analyzer/analyzerwaveform.cpp
@@ -204,6 +204,8 @@ void AnalyzerWaveform::process(const CSAMPLE* buffer, const int bufferLength) {
     m_filter[Mid]->process(buffer, &m_buffers[Mid][0], bufferLength);
     m_filter[High]->process(buffer, &m_buffers[High][0], bufferLength);
 
+    m_waveform->setSaveState(Waveform::SaveState::NotSaved);
+    m_waveformSummary->setSaveState(Waveform::SaveState::NotSaved);
 
     for (int i = 0; i < bufferLength; i+=2) {
         // Take max value, not average of data

--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -175,7 +175,7 @@ class AnalyzerWaveform : public Analyzer {
     PerformanceTimer m_timer;
     QSqlDatabase m_database;
     std::unique_ptr<AnalysisDao> m_pAnalysisDao;
-    static QMutex s_mutex;
+
 #ifdef TEST_HEAT_MAP
     QImage* test_heatMap;
 #endif

--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -175,7 +175,7 @@ class AnalyzerWaveform : public Analyzer {
     PerformanceTimer m_timer;
     QSqlDatabase m_database;
     std::unique_ptr<AnalysisDao> m_pAnalysisDao;
-
+    static QMutex s_mutex;
 #ifdef TEST_HEAT_MAP
     QImage* test_heatMap;
 #endif

--- a/src/library/dao/analysisdao.cpp
+++ b/src/library/dao/analysisdao.cpp
@@ -328,8 +328,8 @@ void AnalysisDao::saveTrackAnalyses(const Track& track) {
     ConstWaveformPointer pWaveSummary = track.getWaveformSummary();
 
     // Don't try to save invalid or non-dirty waveforms.
-    if (!pWaveform || pWaveform->getDataSize() == 0 || !pWaveform->isDirty() ||
-        !pWaveSummary || pWaveSummary->getDataSize() == 0 || !pWaveSummary->isDirty()) {
+    if (!pWaveform || pWaveform->saveState() != Waveform::SaveState::SavePending ||
+        !pWaveSummary || pWaveSummary->saveState() != Waveform::SaveState::SavePending) {
         return;
     }
 
@@ -346,7 +346,7 @@ void AnalysisDao::saveTrackAnalyses(const Track& track) {
     analysis.data = pWaveform->toByteArray();
     bool success = saveAnalysis(&analysis);
     if (success) {
-        pWaveform->setDirty(false);
+        pWaveform->setSaveState(Waveform::SaveState::Saved);
     }
 
     qDebug() << (success ? "Saved" : "Failed to save")
@@ -362,7 +362,7 @@ void AnalysisDao::saveTrackAnalyses(const Track& track) {
 
     success = saveAnalysis(&analysis);
     if (success) {
-        pWaveSummary->setDirty(false);
+        pWaveSummary->setSaveState(Waveform::SaveState::Saved);
     }
     qDebug() << (success ? "Saved" : "Failed to save")
              << "waveform summary analysis for trackId" << trackId

--- a/src/library/dao/analysisdao.cpp
+++ b/src/library/dao/analysisdao.cpp
@@ -407,5 +407,11 @@ bool AnalysisDao::deleteAnalysesByType(AnalysisType type) {
         QString dataPath = analysisPath.absoluteFilePath(query.value(idColumn).toString());
         deleteFile(dataPath);
     }
+    query.prepare(QString("DELETE FROM %1 WHERE type=:type").arg(s_analysisTableName));
+    query.bindValue(":type", type);
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query) << "couldn't delete analysis";
+    }
+
     return true;
 }

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -188,7 +188,7 @@
        <item row="0" column="3">
         <widget class="QLabel" name="visualGainLabel_5">
          <property name="text">
-          <string>Low</string>
+          <string>High</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -265,7 +265,7 @@
        <item row="0" column="1">
         <widget class="QLabel" name="visualGainLabel_3">
          <property name="text">
-          <string>High</string>
+          <string>Low</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>

--- a/src/waveform/waveform.cpp
+++ b/src/waveform/waveform.cpp
@@ -19,7 +19,7 @@ int computeTextureStride(int size) {
 
 Waveform::Waveform(const QByteArray data)
         : m_id(-1),
-          m_saveState(SaveState::Virgin),
+          m_saveState(SaveState::NotSaved),
           m_dataSize(0),
           m_visualSampleRate(0),
           m_audioVisualRatio(0),
@@ -31,7 +31,7 @@ Waveform::Waveform(const QByteArray data)
 Waveform::Waveform(int audioSampleRate, int audioSamples,
                    int desiredVisualSampleRate, int maxVisualSamples)
         : m_id(-1),
-          m_saveState(SaveState::Virgin),
+          m_saveState(SaveState::NotSaved),
           m_dataSize(0),
           m_visualSampleRate(0),
           m_audioVisualRatio(0),
@@ -167,7 +167,7 @@ void Waveform::readByteArray(const QByteArray& data) {
         qDebug() << "ERROR: Couldn't resize Waveform to" << all.value_size()
                  << "while reading.";
         resize(0);
-        m_saveState = SaveState::Virgin;
+        m_saveState = SaveState::NotSaved;
         return;
     }
 

--- a/src/waveform/waveform.cpp
+++ b/src/waveform/waveform.cpp
@@ -167,6 +167,7 @@ void Waveform::readByteArray(const QByteArray& data) {
         qDebug() << "ERROR: Couldn't resize Waveform to" << all.value_size()
                  << "while reading.";
         resize(0);
+        m_saveState = SaveState::Virgin;
         return;
     }
 
@@ -200,7 +201,6 @@ void Waveform::resize(int size) {
     m_dataSize = size;
     m_textureStride = computeTextureStride(size);
     m_data.resize(m_textureStride * m_textureStride);
-    m_saveState = SaveState::SavePending;
 }
 
 void Waveform::assign(int size, int value) {

--- a/src/waveform/waveform.cpp
+++ b/src/waveform/waveform.cpp
@@ -19,7 +19,7 @@ int computeTextureStride(int size) {
 
 Waveform::Waveform(const QByteArray data)
         : m_id(-1),
-          m_bDirty(true),
+          m_saveState(SaveState::Virgin),
           m_dataSize(0),
           m_visualSampleRate(0),
           m_audioVisualRatio(0),
@@ -31,7 +31,7 @@ Waveform::Waveform(const QByteArray data)
 Waveform::Waveform(int audioSampleRate, int audioSamples,
                    int desiredVisualSampleRate, int maxVisualSamples)
         : m_id(-1),
-          m_bDirty(true),
+          m_saveState(SaveState::Virgin),
           m_dataSize(0),
           m_visualSampleRate(0),
           m_audioVisualRatio(0),
@@ -193,21 +193,21 @@ void Waveform::readByteArray(const QByteArray& data) {
         m_data[i].filtered.high = use_high ? static_cast<unsigned char>(high.value(i)) : 0;
     }
     m_completion = dataSize;
-    m_bDirty = false;
+    m_saveState = SaveState::Saved;
 }
 
 void Waveform::resize(int size) {
     m_dataSize = size;
     m_textureStride = computeTextureStride(size);
     m_data.resize(m_textureStride * m_textureStride);
-    m_bDirty = true;
+    m_saveState = SaveState::SavePending;
 }
 
 void Waveform::assign(int size, int value) {
     m_dataSize = size;
     m_textureStride = computeTextureStride(size);
     m_data.assign(m_textureStride * m_textureStride, value);
-    m_bDirty = true;
+    m_saveState = SaveState::SavePending;
 }
 
 void Waveform::dump() const {

--- a/src/waveform/waveform.h
+++ b/src/waveform/waveform.h
@@ -32,8 +32,7 @@ union WaveformData {
 class Waveform {
   public:
     enum class SaveState {
-        Virgin = 0,
-        Changing, 
+        NotSaved = 0,
         SavePending, 
         Saved
     };
@@ -86,8 +85,8 @@ class Waveform {
         return m_saveState;
     }
 
-    // AnalysisDAO needs to be able to set the waveform as clean so we mark this
-    // as const and m_saveState mutable.
+    // AnalysisDAO needs to be able to change the state to savePending when finished 
+    // so we mark this as const and m_saveState mutable.
     void setSaveState(SaveState eState) const {
         m_saveState = eState;
     }
@@ -105,7 +104,6 @@ class Waveform {
     }
     void setCompletion(int completion) {
         m_completion = completion;
-        m_saveState = Waveform::SaveState::Changing;
     }
 
     // We do not lock the mutex since m_textureStride is not changed after


### PR DESCRIPTION
Fix clear waveform cache not deleting database entries.
Fixed waveform analysis not storing the waveform analysis if the waveform analysis was the only analyzer, like when reanalyzing after enabling waveform analysis generation.
Fix waveform generation not being correctly stored on bbdd sometimes: caused by Main thread saving an incomplete analysis scan