### PR TITLE
ID3v2 BPM tag workaround for values higher than 500

### DIFF
--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "track/trackmetadatataglib.h"
-
+#include "util/memory.h"
 #include <QtDebug>
 
 namespace {
@@ -49,7 +49,7 @@ class MetadataTest : public testing::Test {
         mixxx::TrackMetadata trackMetadata;
         mixxx::taglib::readTrackMetadataFromID3v2Tag(&trackMetadata, tag);        
 
-        EXPECT_DOUBLE_EQ(trackMetadata.getBpm().getValue(), actualValue);
+        EXPECT_DOUBLE_EQ(trackMetadata.getBpm().getValue(), expectedValue);
     }
 };
 

--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -9,8 +9,6 @@
 
 namespace {
 
-const double kBpmValueMax = 300.0;
-
 class MetadataTest : public testing::Test {
   protected:
     double parseBpm(QString inputValue, bool expectedResult, double expectedValue) {
@@ -78,7 +76,7 @@ TEST_F(MetadataTest, ParseBpmPrecision) {
 }
 
 TEST_F(MetadataTest, ParseBpmValidRange) {
-    for (int bpm100 = int(mixxx::Bpm::kValueMin) * 100; kBpmValueMax * 100 >= bpm100; ++bpm100) {
+    for (int bpm100 = int(mixxx::Bpm::kValueMin) * 100; mixxx::Bpm::kValueMax * 100 >= bpm100; ++bpm100) {
         const double expectedValue = bpm100 / 100.0;
         const QString inputValues[] = {
                 QString("%1").arg(expectedValue),
@@ -102,10 +100,10 @@ TEST_F(MetadataTest, NormalizeBpm) {
     normalizeBpm(mixxx::Bpm::kValueMin - 1.0);
     normalizeBpm(mixxx::Bpm::kValueMin + 1.0);
     normalizeBpm(-mixxx::Bpm::kValueMin);
-    normalizeBpm(kBpmValueMax);
-    normalizeBpm(kBpmValueMax - 1.0);
-    normalizeBpm(kBpmValueMax + 1.0);
-    normalizeBpm(-kBpmValueMax);
+    normalizeBpm(mixxx::Bpm::kValueMax);
+    normalizeBpm(mixxx::Bpm::kValueMax - 1.0);
+    normalizeBpm(mixxx::Bpm::kValueMax + 1.0);
+    normalizeBpm(-mixxx::Bpm::kValueMax);
 }
 
 TEST_F(MetadataTest, ID3v2Year) {

--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -2,6 +2,9 @@
 
 #include "track/trackmetadatataglib.h"
 #include "util/memory.h"
+
+#include <taglib/tstring.h>
+#include <taglib/textidentificationframe.h>
 #include <QtDebug>
 
 namespace {

--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -50,7 +50,7 @@ class MetadataTest : public testing::Test {
         mixxx::TrackMetadata trackMetadata;
         mixxx::taglib::readTrackMetadataFromID3v2Tag(&trackMetadata, tag);        
 
-        EXPECT_DOUBLE_EQ(trackMetadata.getBpm().getValue(), expectedValue);
+        EXPECT_DOUBLE_EQ(expectedValue,trackMetadata.getBpm().getValue());
     }
 };
 

--- a/src/track/bpm.cpp
+++ b/src/track/bpm.cpp
@@ -38,6 +38,7 @@ double Bpm::valueFromString(const QString& str, bool* pValid) {
 
 QString Bpm::valueToString(double value) {
     if (isValidValue(value)) {
+        //TODO: Shouldn't this be formatted in some way, instead of letting it output in scientific notation?
         return QString::number(value);
     } else {
         return QString();

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -12,9 +12,7 @@ class Bpm final {
 public:
     static constexpr double kValueUndefined = 0.0;
     static constexpr double kValueMin = 0.0; // lower bound (exclusive)
-    //These define our BPM range to be from 30 to 299.99.
-    static constexpr double kValueMinForTwoDecimals = 3000.0;
-    static constexpr double kValueMinForOneDecimal = 300.0;
+    static constexpr double kValueMax = 300.0; // higher bound (inclusive)
 
     Bpm()
         : Bpm(kValueUndefined) {

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -12,6 +12,8 @@ class Bpm final {
 public:
     static constexpr double kValueUndefined = 0.0;
     static constexpr double kValueMin = 0.0; // lower bound (exclusive)
+    static constexpr double kValueMinForTwoDecimals = 5000.0;
+    static constexpr double kValueMinForOneDecimal = 500.0;
 
     Bpm()
         : Bpm(kValueUndefined) {

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -12,8 +12,9 @@ class Bpm final {
 public:
     static constexpr double kValueUndefined = 0.0;
     static constexpr double kValueMin = 0.0; // lower bound (exclusive)
-    static constexpr double kValueMinForTwoDecimals = 5000.0;
-    static constexpr double kValueMinForOneDecimal = 500.0;
+    //These define our BPM range to be from 30 to 299.99.
+    static constexpr double kValueMinForTwoDecimals = 3000.0;
+    static constexpr double kValueMinForOneDecimal = 300.0;
 
     Bpm()
         : Bpm(kValueUndefined) {

--- a/src/track/trackmetadata.h
+++ b/src/track/trackmetadata.h
@@ -130,7 +130,7 @@ public:
     }
 
     // beats / minute
-    Bpm getBpm() const {
+    const Bpm& getBpm() const {
         return m_bpm;
     }
     void setBpm(Bpm bpm) {

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -1029,14 +1029,13 @@ void readTrackMetadataFromID3v2Tag(TrackMetadata* pTrackMetadata,
         long bpmValue = pTrackMetadata->getBpm().getValue();
         //Some software uses (or used) to write decimated values without comma,
         //so the number reads as 1352 or 14525 when it is 135.2 or 145.25
-        if (bpmValue >= Bpm::kValueMinForTwoDecimals) {
+        long bpmValueOriginal = bpmValue;
+        while (bpmValue > Bpm::kValueMax) {
+            bpmValue /= 10.0;  
+        }
+        if (bpmValue != bpmValueOriginal) {
             qWarning() << " Changing BPM on " << pTrackMetadata->getArtist() << " - " << 
-                pTrackMetadata->getTitle() << " from " << bpmValue << " to " << bpmValue/100.0;
-            bpmValue /= 100.0;
-        } else if (bpmValue >= Bpm::kValueMinForOneDecimal) {
-            qWarning() << " Changing BPM on " << pTrackMetadata->getArtist() << " - " << 
-                pTrackMetadata->getTitle() << " from " << bpmValue << " to " << bpmValue/10.0;
-            bpmValue /= 10.0;
+                pTrackMetadata->getTitle() << " from " << bpmValueOriginal << " to " << bpmValue;
         }
         pTrackMetadata->getBpm().setValue(bpmValue);
     }

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -1026,10 +1026,10 @@ void readTrackMetadataFromID3v2Tag(TrackMetadata* pTrackMetadata,
     const TagLib::ID3v2::FrameList bpmFrame(tag.frameListMap()["TBPM"]);
     if (!bpmFrame.isEmpty()) {
         parseBpm(pTrackMetadata, toQStringFirstNotEmpty(bpmFrame));
-        long bpmValue = pTrackMetadata->getBpm().getValue();
+        double bpmValue = pTrackMetadata->getBpm().getValue();
         //Some software uses (or used) to write decimated values without comma,
         //so the number reads as 1352 or 14525 when it is 135.2 or 145.25
-        long bpmValueOriginal = bpmValue;
+        double bpmValueOriginal = bpmValue;
         while (bpmValue > Bpm::kValueMax) {
             bpmValue /= 10.0;  
         }

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -225,7 +225,7 @@ bool parseBpm(TrackMetadata* pTrackMetadata, QString sBpm) {
     DEBUG_ASSERT(pTrackMetadata);
 
     bool isBpmValid = false;
-    double bpmValue = Bpm::valueFromString(sBpm, &isBpmValid);
+    const double bpmValue = Bpm::valueFromString(sBpm, &isBpmValid);
     if (isBpmValid) {
         pTrackMetadata->setBpm(Bpm(bpmValue));
     }

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -1027,8 +1027,8 @@ void readTrackMetadataFromID3v2Tag(TrackMetadata* pTrackMetadata,
     if (!bpmFrame.isEmpty()) {
         parseBpm(pTrackMetadata, toQStringFirstNotEmpty(bpmFrame));
         double bpmValue = pTrackMetadata->getBpm().getValue();
-        //Some software uses (or used) to write decimated values without comma,
-        //so the number reads as 1352 or 14525 when it is 135.2 or 145.25
+        // Some software use (or used) to write decimated values without comma,
+        // so the number reads as 1352 or 14525 when it is 135.2 or 145.25
         double bpmValueOriginal = bpmValue;
         while (bpmValue > Bpm::kValueMax) {
             bpmValue /= 10.0;  
@@ -1037,7 +1037,7 @@ void readTrackMetadataFromID3v2Tag(TrackMetadata* pTrackMetadata,
             qWarning() << " Changing BPM on " << pTrackMetadata->getArtist() << " - " << 
                 pTrackMetadata->getTitle() << " from " << bpmValueOriginal << " to " << bpmValue;
         }
-        pTrackMetadata->getBpm().setValue(bpmValue);
+        pTrackMetadata->setBpm(Bpm(bpmValue));
     }
 
     const TagLib::ID3v2::FrameList keyFrame(tag.frameListMap()["TKEY"]);

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -225,8 +225,15 @@ bool parseBpm(TrackMetadata* pTrackMetadata, QString sBpm) {
     DEBUG_ASSERT(pTrackMetadata);
 
     bool isBpmValid = false;
-    const double bpmValue = Bpm::valueFromString(sBpm, &isBpmValid);
+    double bpmValue = Bpm::valueFromString(sBpm, &isBpmValid);
     if (isBpmValid) {
+        //Some software uses (or used) to write decimated values without comma,
+        //so the number reads as 1352 or 14525 when it is 135.2 or 145.25
+        if (bpmValue > 5000.0) {
+            bpmValue /= 100.0;
+        } else if (bpmValue > 500.0) {
+            bpmValue /= 10.0;
+        }
         pTrackMetadata->setBpm(Bpm(bpmValue));
     }
     return isBpmValid;


### PR DESCRIPTION
Workaround for a case where the BPM tag on ID3v2 has values that represent decimal values.
As the comment in the code says: Some software uses (or used) to write decimated values without comma,
so the number reads as 1352 or 14525 when it is 135.2 or 145.25.
