### PR TITLE
make Button Component better able to handle different controllers

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -157,27 +157,21 @@
         onlyOnPress: true,
         on: 127,
         off: 0,
+        isPress: function (channel, control, value, status) {
+            return value > 0;
+        },
         inValueScale: function () { return ! this.inGetValue(); },
-        separateNoteOnOff: false,
         input: function (channel, control, value, status, group) {
             if (this.onlyOnPress) {
-                var pressed;
-                if (this.separateNoteOnOff) {
-                    // Does the first nybble of the first MIDI byte indicate a
-                    // note on or note off message?
-                    pressed = (status & 0xF0) === 0x90;
-                } else {
-                    pressed = value > 0;
-                }
-                if (pressed) {
+                if (this.isPress(channel, control, value, status)) {
                     this.inSetValue(this.inValueScale(value));
                 }
             } else {
                 this.inSetValue(this.inValueScale(value));
             }
         },
-        outValueScale: function() {
-            return (this.outGetValue()) ? this.on : this.off;
+        outValueScale: function (value) {
+            return (value > 0) ? this.on : this.off;
         },
     });
 
@@ -259,7 +253,7 @@
     SamplerButton.prototype = new Button({
         unshift: function () {
             this.input = function (channel, control, value, status, group) {
-                if (value > 0) {
+                if (this.isPress(channel, control, value, status)) {
                     if (engine.getValue(this.group, 'track_loaded') === 0) {
                         engine.setValue(this.group, 'LoadSelectedTrack', 1);
                     } else {
@@ -270,7 +264,7 @@
         },
         shift: function() {
             this.input = function (channel, control, value, status, group) {
-                if (value > 0) {
+                if (this.isPress(channel, control, value, status)) {
                     if (engine.getValue(this.group, 'play') === 1) {
                         engine.setValue(this.group, 'play', 0);
                     } else {
@@ -551,7 +545,7 @@
                 this.shift = function () {
                     this.isShifted = true;
                     this.input = function (channel, control, value, status, group) {
-                        if (value > 0) {
+                        if (this.isPress(channel, control, value, status)) {
                             if (engine.getValue(eu.group, "focused_effect") === this.number) {
                                 // unfocus and make knobs control metaknobs
                                 engine.setValue(eu.group, "focused_effect", 0);


### PR DESCRIPTION
Refactor the Button Component so script authors can override a default function if their controller uses unusual MIDI signals to differentiate a button press from a button release. For example, a user reported on the forum that the M-Audio Xponent [uses the MIDI channel](http://mixxx.org/forums/viewtopic.php?p=31709#p31709) to differentiate between button presses and releases. This will also allow script authors who have such controllers to use the library's SamplerButton and EffectUnit buttons without having to rewrite their input functions. I have tested with the Hercules P32 mapping and it still works.