### PR TITLE
Fix decoding of the last MP3 frame

### DIFF
--- a/src/sources/soundsourcemp3.h
+++ b/src/sources/soundsourcemp3.h
@@ -76,6 +76,8 @@ private:
     mad_synth m_madSynth;
 
     SINT m_madSynthCount; // left overs from the previous read
+
+    std::vector<unsigned char> m_leftoverBuffer;
 };
 
 class SoundSourceProviderMp3: public SoundSourceProvider {

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -309,20 +309,8 @@ TEST_F(SoundSourceProxyTest, seekBoundaries) {
         // Seek to boundaries (alternating)
         EXPECT_EQ(pSeekReadSource->getMinFrameIndex(),
                 pSeekReadSource->seekSampleFrame(pSeekReadSource->getMinFrameIndex()));
-#ifdef __MAD__
-        // TODO(XXX): Seeking near the end of an MP3 stream
-        // is currently broken for SoundSourceMP3 (libmad)
-        if (filePath.endsWith(".mp3")) {
-            qWarning()
-                    << "TODO(XXX): Fix seeking near end of stream for MP3 files"
-                    << "and re-enable this test!";
-        } else {
-#endif // __MAD__
-            EXPECT_EQ(pSeekReadSource->getMaxFrameIndex() - 1,
-                    pSeekReadSource->seekSampleFrame(pSeekReadSource->getMaxFrameIndex() - 1));
-#ifdef __MAD__
-        }
-#endif // __MAD__
+        EXPECT_EQ(pSeekReadSource->getMaxFrameIndex() - 1,
+                pSeekReadSource->seekSampleFrame(pSeekReadSource->getMaxFrameIndex() - 1));
         EXPECT_EQ(pSeekReadSource->getMinFrameIndex() + 1,
                 pSeekReadSource->seekSampleFrame(pSeekReadSource->getMinFrameIndex() + 1));
         EXPECT_EQ(pSeekReadSource->getMaxFrameIndex(),


### PR DESCRIPTION
Another fix for the upcoming release.

The code of SoundSourceMp3 is still ugly, but I don't want to rewrite this once again, even if mpg123 is more popular than libmad nowadays.