### PR TITLE
Components: change shift behavior of CueButton and PlayButton

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -182,10 +182,20 @@
         unshift: function () {
             this.inKey = 'play';
             this.onlyOnPress = true;
+            this.inValueScale = Button.prototype.inValueScale;
+            // Stop reversing playback if the user releases the shift button before this PlayButton.
+            if (engine.getValue(this.group, 'reverse') === 1) {
+                engine.setValue(this.group, 'reverse', 0);
+            }
         },
         shift: function () {
             this.inKey = 'reverse';
             this.onlyOnPress = false;
+            // The prototype inValueScale function would not work properly if the deck was already
+            // playing in reverse.
+            this.inValueScale = function (value) {
+                return value > 0;
+            };
         },
         outKey: 'play_indicator',
     });
@@ -199,6 +209,11 @@
         },
         shift: function () {
             this.inKey = 'start_stop';
+        },
+        // The prototype inValueScale function would not work properly if the cue button was already
+        // pressed with the GUI or another controller.
+        inValueScale: function (value) {
+            return value > 0;
         },
         onlyOnPress: false,
         outKey: 'cue_indicator',

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -181,9 +181,11 @@
     PlayButton.prototype = new Button({
         unshift: function () {
             this.inKey = 'play';
+            this.onlyOnPress = true;
         },
         shift: function () {
-            this.inKey = 'start_stop';
+            this.inKey = 'reverse';
+            this.onlyOnPress = false;
         },
         outKey: 'play_indicator',
     });
@@ -192,7 +194,12 @@
         Button.call(this, options);
     };
     CueButton.prototype = new Button({
-        inKey: 'cue_default',
+        unshift: function () {
+            this.inKey = 'cue_default';
+        },
+        shift: function () {
+            this.inKey = 'start_stop';
+        },
         outKey: 'cue_indicator',
         onlyOnPress: false,
     });

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -181,20 +181,15 @@
     PlayButton.prototype = new Button({
         unshift: function () {
             this.inKey = 'play';
-            this.onlyOnPress = true;
-            this.inValueScale = Button.prototype.inValueScale;
-            // Stop reversing playback if the user releases the shift button before this PlayButton.
+            this.input = Button.prototype.input;
+            // Stop reversing playback if the user releases the shift button before releasing this PlayButton.
             if (engine.getValue(this.group, 'reverse') === 1) {
                 engine.setValue(this.group, 'reverse', 0);
             }
         },
         shift: function () {
-            this.inKey = 'reverse';
-            this.onlyOnPress = false;
-            // The prototype inValueScale function would not work properly if the deck was already
-            // playing in reverse.
-            this.inValueScale = function (value) {
-                return value > 0;
+            this.input = function (channel, control, value, status, group) {
+                engine.setValue(this.group, 'reverse', this.isPress(channel, control, value, status));
             };
         },
         outKey: 'play_indicator',
@@ -210,12 +205,9 @@
         shift: function () {
             this.inKey = 'start_stop';
         },
-        // The prototype inValueScale function would not work properly if the cue button was already
-        // pressed with the GUI or another controller.
-        inValueScale: function (value) {
-            return value > 0;
+        input: function (channel, control, value, status, group) {
+            this.inSetValue(this.isPress(channel, control, value, status));
         },
-        onlyOnPress: false,
         outKey: 'cue_indicator',
     });
 

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -200,8 +200,8 @@
         shift: function () {
             this.inKey = 'start_stop';
         },
-        outKey: 'cue_indicator',
         onlyOnPress: false,
+        outKey: 'cue_indicator',
     });
 
     var SyncButton = function (options) {
@@ -226,9 +226,6 @@
             return 1;
         },
         outKey: 'loop_enabled',
-        outValueScale: function (value) {
-            return (value) ? this.on : this.off;
-        },
     });
 
     var HotcueButton = function (options) {


### PR DESCRIPTION
shift + PlayButton: play in reverse while held
shift + CueButton: jump to beginning of track and stop

Previously shift + CueButton was unused. Looking at the documentation for other mappings, I see that many people want a reverse button. I think this is an intuitive way to map these behaviors.