### PR TITLE
Fix for the showing false presence of song

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -261,6 +261,7 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
                              m_pRecordingManager);
     m_pPlayerManager->bindToLibrary(m_pLibrary);
 
+    m_pLibrary->scan();
     launchProgress(35);
 
     // Get Music dir


### PR DESCRIPTION
With reference to https://bugs.launchpad.net/mixxx/+bug/1662302 , when we add the new song or deleted any of the previous song in the directory for the songs, and after the starting of the program, it didn't show the change, we only had to Rescan the Library in order to see the change, so to remove this I  added a line in src/mixxx.cpp, so  now after the every start of application it will be scanned every time if any change of the song has taken place in the Music directory