### PR TITLE
[Fix] Parented pointer comparison

### DIFF
--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -104,6 +104,11 @@ inline parented_ptr<T> make_parented(Args&&... args) {
     return parented_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
+template<typename T, typename U>
+bool operator== (const T* pLeft, const parented_ptr<U>& pRight) {
+    return pRight == pLeft;
+}
+
 } // namespace
 
 #endif // UTIL_PARENTED_PTR_H

--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -88,34 +88,35 @@ inline parented_ptr<T> make_parented(Args&&... args) {
     return parented_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
+// Comparison operator definitions
 template<typename T, typename U>
 inline bool operator== (const T* lhs, const parented_ptr<U>& rhs) {
     return lhs == rhs.get();
 }
 
 template<typename T, typename U>
-inline bool operator== (const parented_ptr<T>& lhs, const T* rhs) {
+inline bool operator== (const parented_ptr<T>& lhs, const U* rhs) {
     return lhs.get() == rhs;
 }
 
-template<typename T>
-inline bool operator== (const parented_ptr<T>& lhs, const parented_ptr<T>& rhs) const {
+template<typename T, typename U>
+inline bool operator== (const parented_ptr<T>& lhs, const parented_ptr<U>& rhs) const {
     return lhs.get() == rhs.get();
 }
 
 template<typename T, typename U>
 inline bool operator!= (const T* lhs, const parented_ptr<U>& rhs) {
-    return lhs != rhs.get();
+    return !(lhs == rhs.get());
 }
 
 template<typename T, typename U>
-inline bool operator!= (const parented_ptr<T>& lhs, const T* rhs) {
-    return lhs.get() != rhs;
+inline bool operator!= (const parented_ptr<T>& lhs, const U* rhs) {
+    return !(lhs.get() == rhs);
 }
 
-template<typename T>
-inline bool operator!= (const parented_ptr<T>& lhs, const parented_ptr<T>& rhs) const {
-    return lhs.get() != rhs.get();
+template<typename T, typename U>
+inline bool operator!= (const parented_ptr<T>& lhs, const parented_ptr<U>& rhs) const {
+    return !(lhs.get() == rhs.get());
 }
 
 } // namespace

--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -58,22 +58,6 @@ class parented_ptr {
         return m_pObject;
     }
 
-    bool operator== (const parented_ptr& other) const {
-        return m_pObject == other.m_pObject;
-    }
-
-    bool operator== (const T* other) const {
-        return m_pObject == other;
-    }
-
-    bool operator!= (const parented_ptr& other) const {
-        return m_pObject != other.m_pObject;
-    }
-
-    bool operator!= (const T* other) const {
-        return m_pObject != other;
-    }
-
     operator bool() const {
         return m_pObject != nullptr;
     }
@@ -105,8 +89,33 @@ inline parented_ptr<T> make_parented(Args&&... args) {
 }
 
 template<typename T, typename U>
-bool operator== (const T* pLeft, const parented_ptr<U>& pRight) {
-    return pRight == pLeft;
+inline bool operator== (const T* lhs, const parented_ptr<U>& rhs) {
+    return lhs == rhs.get();
+}
+
+template<typename T, typename U>
+inline bool operator== (const parented_ptr<T>& lhs, const T* rhs) {
+    return lhs.get() == rhs;
+}
+
+template<typename T>
+inline bool operator== (const parented_ptr<T>& lhs, const parented_ptr<T>& rhs) const {
+    return lhs.get() == rhs.get();
+}
+
+template<typename T, typename U>
+inline bool operator!= (const T* lhs, const parented_ptr<U>& rhs) {
+    return lhs != rhs.get();
+}
+
+template<typename T, typename U>
+inline bool operator!= (const parented_ptr<T>& lhs, const T* rhs) {
+    return lhs.get() != rhs;
+}
+
+template<typename T>
+inline bool operator!= (const parented_ptr<T>& lhs, const parented_ptr<T>& rhs) const {
+    return lhs.get() != rhs.get();
 }
 
 } // namespace


### PR DESCRIPTION
In `parented_ptr` comparison with other pointers if the left operand is a raw pointer and the right operand is a `parented_ptr` it gives a compilation error.