### PR TITLE
Optimize adding of selected tracks to crates/playlists/autodj

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1381,6 +1381,9 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
     // default value "//".
     // See also: Schema revision 26 in schema.xml
     if (pTrack->getTrackTotal() == "//") {
+        qDebug() << "Reloading value for 'tracktotal' once-only from file"
+                " to replace the default value introduced with a previous"
+                " schema upgrade";
         // Reload track total from file tags into a temporary
         // track object, if the special track total migration
         // value "//" indicates that the track total is missing
@@ -1407,7 +1410,7 @@ TrackPointer TrackDAO::getTrackFromDB(TrackId trackId) const {
                 pTrack->setTrackNumber(pTempTrack->getTrackNumber());
             }
         } else {
-            qWarning() << "Failed to reload track total from file tags:"
+            qWarning() << "Failed to reload value for 'tracktotal' from file tags:"
                     << trackLocation;
         }
     }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1409,34 +1409,34 @@ void WTrackTableView::addSelectionToPlaylist(int iPlaylistId) {
         return;
     }
 
-   if (iPlaylistId == -1) { // i.e. a new playlist is suppose to be created
-       QString name;
-       bool validNameGiven = false;
-
-       do {
-           bool ok = false;
-           name = QInputDialog::getText(nullptr,
-                                        tr("Create New Playlist"),
-                                        tr("Enter name for new playlist:"),
-                                        QLineEdit::Normal,
-                                        tr("New Playlist"),
-                                        &ok).trimmed();
-           if (!ok) {
-               return;
-           }
-           if (playlistDao.getPlaylistIdFromName(name) != -1) {
-               QMessageBox::warning(nullptr,
-                                    tr("Playlist Creation Failed"),
-                                    tr("A playlist by that name already exists."));
-           } else if (name.isEmpty()) {
-               QMessageBox::warning(nullptr,
-                                    tr("Playlist Creation Failed"),
-                                    tr("A playlist cannot have a blank name."));
-           } else {
-               validNameGiven = true;
-           }
     PlaylistDAO& playlistDao = m_pTrackCollection->getPlaylistDAO();
 
+    if (iPlaylistId == -1) { // i.e. a new playlist is suppose to be created
+        QString name;
+        bool validNameGiven = false;
+
+        do {
+            bool ok = false;
+            name = QInputDialog::getText(nullptr,
+                    tr("Create New Playlist"),
+                    tr("Enter name for new playlist:"),
+                    QLineEdit::Normal,
+                    tr("New Playlist"),
+                    &ok).trimmed();
+            if (!ok) {
+                return;
+            }
+            if (playlistDao.getPlaylistIdFromName(name) != -1) {
+                QMessageBox::warning(nullptr,
+                        tr("Playlist Creation Failed"),
+                        tr("A playlist by that name already exists."));
+            } else if (name.isEmpty()) {
+                QMessageBox::warning(nullptr,
+                        tr("Playlist Creation Failed"),
+                        tr("A playlist cannot have a blank name."));
+            } else {
+                validNameGiven = true;
+            }
        } while (!validNameGiven);
        iPlaylistId = playlistDao.createPlaylist(name);//-1 is changed to the new playlist ID return from the DAO
        if (iPlaylistId == -1) {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1271,12 +1271,12 @@ void WTrackTableView::dropEvent(QDropEvent * event) {
     restoreVScrollBarPos();
 }
 
-TrackModel* WTrackTableView::getTrackModel() {
+TrackModel* WTrackTableView::getTrackModel() const {
     TrackModel* trackModel = dynamic_cast<TrackModel*>(model());
     return trackModel;
 }
 
-bool WTrackTableView::modelHasCapabilities(TrackModel::CapabilitiesFlags capabilities) {
+bool WTrackTableView::modelHasCapabilities(TrackModel::CapabilitiesFlags capabilities) const {
     TrackModel* trackModel = getTrackModel();
     return trackModel &&
             (trackModel->getCapabilities() & capabilities) == capabilities;
@@ -1317,35 +1317,50 @@ void WTrackTableView::slotSendToAutoDJReplace() {
     sendToAutoDJ(PlaylistDAO::AutoDJSendLoc::REPLACE);
 }
 
+QList<TrackId> WTrackTableView::getSelectedTrackIds() const {
+    QList<TrackId> trackIds;
+
+    QItemSelectionModel* pSelectionModel = selectionModel();
+    VERIFY_OR_DEBUG_ASSERT(pSelectionModel != nullptr) {
+        qWarning() << "No selected tracks available";
+        return trackIds;
+    }
+
+    TrackModel* pTrackModel = getTrackModel();
+    VERIFY_OR_DEBUG_ASSERT(pTrackModel != nullptr) {
+        qWarning() << "No selected tracks available";
+        return trackIds;
+    }
+
+    const QModelIndexList rows = selectionModel()->selectedRows();
+    trackIds.reserve(rows.size());
+    for (const QModelIndex& row: rows) {
+        const TrackId trackId = pTrackModel->getTrackId(row);
+        VERIFY_OR_DEBUG_ASSERT(trackId.isValid()) {
+            qWarning() << "Skipping invalid track id @" << row;
+            continue;
+        }
+        trackIds.append(trackId);
+    }
+
+    return trackIds;
+}
+
 void WTrackTableView::sendToAutoDJ(PlaylistDAO::AutoDJSendLoc loc) {
     if (!modelHasCapabilities(TrackModel::TRACKMODELCAPS_ADDTOAUTODJ)) {
         return;
     }
 
-    PlaylistDAO& playlistDao = m_pTrackCollection->getPlaylistDAO();
-
-    QModelIndexList indices = selectionModel()->selectedRows();
-    QList<TrackId> trackIds;
-
-    TrackModel* trackModel = getTrackModel();
-    if (!trackModel) {
+    const QList<TrackId> trackIds = getSelectedTrackIds();
+    if (trackIds.isEmpty()) {
+        qWarning() << "No tracks selected for AutoDJ";
         return;
     }
 
-    for (const QModelIndex& index : indices) {
-        TrackPointer pTrack = trackModel->getTrack(index);
-        if (pTrack) {
-            TrackId trackId(pTrack->getId());
-            if (!trackId.isValid()) {
-                continue;
-            }
-            trackIds.append(trackId);
-        }
-    }
-
-    m_pTrackCollection->unhideTracks(trackIds);
+    PlaylistDAO& playlistDao = m_pTrackCollection->getPlaylistDAO();
 
     // TODO(XXX): Care whether the append succeeded.
+    m_pTrackCollection->unhideTracks(trackIds);
     playlistDao.sendToAutoDJ(trackIds, loc);
 }
 
@@ -1388,25 +1403,12 @@ void WTrackTableView::slotResetPlayed() {
 }
 
 void WTrackTableView::addSelectionToPlaylist(int iPlaylistId) {
-    PlaylistDAO& playlistDao = m_pTrackCollection->getPlaylistDAO();
-    TrackModel* trackModel = getTrackModel();
-
-    if (!trackModel) {
+    const QList<TrackId> trackIds = getSelectedTrackIds();
+    if (trackIds.isEmpty()) {
+        qWarning() << "No tracks selected for playlist";
         return;
     }
 
-    QModelIndexList indices = selectionModel()->selectedRows();
-    QList<TrackId> trackIds;
-    for (const QModelIndex& index : indices) {
-        TrackPointer pTrack = trackModel->getTrack(index);
-        if (!pTrack) {
-            continue;
-        }
-        TrackId trackId(pTrack->getId());
-        if (trackId.isValid()) {
-            trackIds.append(trackId);
-        }
-    }
    if (iPlaylistId == -1) { // i.e. a new playlist is suppose to be created
        QString name;
        bool validNameGiven = false;
@@ -1433,6 +1435,8 @@ void WTrackTableView::addSelectionToPlaylist(int iPlaylistId) {
            } else {
                validNameGiven = true;
            }
+    PlaylistDAO& playlistDao = m_pTrackCollection->getPlaylistDAO();
+
        } while (!validNameGiven);
        iPlaylistId = playlistDao.createPlaylist(name);//-1 is changed to the new playlist ID return from the DAO
        if (iPlaylistId == -1) {
@@ -1442,35 +1446,17 @@ void WTrackTableView::addSelectionToPlaylist(int iPlaylistId) {
                                  +name);
            return;
        }
-   }
-    if (trackIds.size() > 0) {
-        // TODO(XXX): Care whether the append succeeded.
-        m_pTrackCollection->unhideTracks(trackIds);
-        playlistDao.appendTracksToPlaylist(trackIds, iPlaylistId);
     }
+
+    // TODO(XXX): Care whether the append succeeded.
+    m_pTrackCollection->unhideTracks(trackIds);
+    playlistDao.appendTracksToPlaylist(trackIds, iPlaylistId);
 }
 
 void WTrackTableView::addSelectionToCrate(int iCrateId) {
-    TrackModel* trackModel = getTrackModel();
-
-    if (!trackModel) {
-        return;
-    }
-
-    QModelIndexList indices = selectionModel()->selectedRows();
-    QList<TrackId> trackIds;
-    for (const QModelIndex& index : indices) {
-        TrackPointer pTrack = trackModel->getTrack(index);
-        if (!pTrack) {
-            continue;
-        }
-        TrackId trackId(pTrack->getId());
-        if (trackId.isValid()) {
-            trackIds.append(trackId);
-        }
-    }
+    const QList<TrackId> trackIds = getSelectedTrackIds();
     if (trackIds.isEmpty()) {
-        qWarning() << "Cannot add empty track selection to crate";
+        qWarning() << "No tracks selected for crate";
         return;
     }
 
@@ -1494,11 +1480,7 @@ void WTrackTableView::doSortByColumn(int headerSection) {
     }
 
     // Save the selection
-    QModelIndexList selection = selectionModel()->selectedRows();
-    QSet<TrackId> trackIds;
-    for (const auto& index: selection) {
-        trackIds.insert(trackModel->getTrackId(index));
-    }
+    const QList<TrackId> trackIds = getSelectedTrackIds();
 
     sortByColumn(headerSection);
 

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -100,8 +100,10 @@ class WTrackTableView : public WLibraryTableView {
     void mouseMoveEvent(QMouseEvent *pEvent) override;
 
     // Returns the current TrackModel, or returns NULL if none is set.
-    TrackModel* getTrackModel();
-    bool modelHasCapabilities(TrackModel::CapabilitiesFlags capabilities);
+    TrackModel* getTrackModel() const;
+    bool modelHasCapabilities(TrackModel::CapabilitiesFlags capabilities) const;
+
+    QList<TrackId> getSelectedTrackIds() const;
 
     UserSettingsPointer m_pConfig;
     TrackCollection* m_pTrackCollection;


### PR DESCRIPTION
Ever tried to add hundreds or thousands of tracks to a crate or playlist? All the tracks will be loaded, just to get hold of their id. But the id is already available in the underlying table model. The tracks do not need to be loaded at all! Loading tracks from the DB might also trigger a reload of some tags from the corresponding file due to a delayed schema upgrade (see remark below).

The functionality for collecting the track ids of all selected tracks is now provided as a reusable private member function. This improves not only the runtime performance substantially, but also reduces code bloat and redundancies.

Edit: I added debug logs why reloading of file tags is sometimes necessary. The previous way of selecting tracks is affected by this delayed library update if the selection contains lots of tracks that have not been updated yet.

I propose to add this fix to both master and 2.1.