### PR TITLE
ID3v2: Add workaround to improve compatibility with ffmpeg

### DIFF
--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -622,8 +622,10 @@ TagLib::ID3v2::CommentsFrame* findFirstCommentsFrame(
         const TagLib::ID3v2::Tag& tag,
         const QString& description = QString(),
         bool preferNotEmpty = true) {
-    TagLib::ID3v2::FrameList commentsFrames(tag.frameListMap()["COMM"]);
     TagLib::ID3v2::CommentsFrame* pFirstFrame = nullptr;
+    // Bind the const-ref result to avoid a local copy
+    const TagLib::ID3v2::FrameList& commentsFrames =
+            tag.frameListMap()["COMM"];
     for (TagLib::ID3v2::FrameList::ConstIterator it(commentsFrames.begin());
             it != commentsFrames.end(); ++it) {
         auto pFrame =
@@ -650,16 +652,18 @@ TagLib::ID3v2::CommentsFrame* findFirstCommentsFrame(
     return pFirstFrame;
 }
 
-// Finds the first text frame that with a matching description.
-// If multiple comments frames with matching descriptions exist
-// prefer the first with a non-empty content if requested.
+// Finds the first text frame that with a matching description (case-insensitive).
+// If multiple comments frames with matching descriptions exist prefer the first
+// with a non-empty content if requested.
 TagLib::ID3v2::UserTextIdentificationFrame* findFirstUserTextIdentificationFrame(
         const TagLib::ID3v2::Tag& tag,
         const QString& description,
         bool preferNotEmpty = true) {
     DEBUG_ASSERT(!description.isEmpty());
-    TagLib::ID3v2::FrameList textFrames(tag.frameListMap()["TXXX"]);
     TagLib::ID3v2::UserTextIdentificationFrame* pFirstFrame = nullptr;
+    // Bind the const-ref result to avoid a local copy
+    const TagLib::ID3v2::FrameList& textFrames =
+            tag.frameListMap()["TXXX"];
     for (TagLib::ID3v2::FrameList::ConstIterator it(textFrames.begin());
             it != textFrames.end(); ++it) {
         auto pFrame =


### PR DESCRIPTION
After converting archived FLAC files to MP3 using ffmpeg (3.1.x) I noticed that Mixxx did not read the comment tags, although puddletag displayed them correctly. A short analysis revealed that ffmpeg is writing arbitrary TXXX frames labeled "comment" instead of dedicated comment frames as proposed by the standard: http://id3.org/id3v2.3.0#Comments

Taglib closely follows the standard and doesn't pick up those non-standard comment tags as puddletag does. The implemented workaround is only a fallback in case no standard comment tags are found.

Again, should be merged into both master and 2.1!