### PR TITLE
fix retrieval of "this" object in ControllerEngine::beginTimer

### DIFF
--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -132,6 +132,16 @@ QScriptValue ControllerEngine::wrapFunctionCode(const QString& codeSnippet,
     return wrappedFunction;
 }
 
+QScriptValue ControllerEngine::getThisObjectInFunctionCall() {
+    QScriptContext *ctxt = m_pEngine->currentContext();
+    // Our current context is a function call. We want to grab the 'this'
+    // from the caller's context, so we walk up the stack.
+    if (ctxt) {
+        ctxt = ctxt->parentContext();
+    }
+    return ctxt ? ctxt->thisObject() : QScriptValue();
+}
+
 /* -------- ------------------------------------------------------
 Purpose: Shuts down scripts in an orderly fashion
             (stops timers then executes shutdown functions)
@@ -780,14 +790,7 @@ QScriptValue ControllerEngine::connectControl(
             return QScriptValue(true);
         }
 
-        QScriptContext *ctxt = m_pEngine->currentContext();
-        // Our current context is a function call to engine.connectControl. We
-        // want to grab the 'this' from the caller's context, so we walk up the
-        // stack.
-        if (ctxt) {
-            ctxt = ctxt->parentContext();
-            conn.context = ctxt ? ctxt->thisObject() : QScriptValue();
-        }
+        conn.context = getThisObjectInFunctionCall();
 
         if (callback.isString()) {
             conn.id = callback.toString();
@@ -971,8 +974,7 @@ int ControllerEngine::beginTimer(int interval, QScriptValue timerCallback,
     int timerId = startTimer(interval);
     TimerInfo info;
     info.callback = timerCallback;
-    QScriptContext *ctxt = m_pEngine->currentContext();
-    info.context = ctxt ? ctxt->thisObject() : QScriptValue();
+    info.context = getThisObjectInFunctionCall();
     info.oneShot = oneShot;
     m_timers[timerId] = info;
     if (timerId == 0) {

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -81,6 +81,7 @@ class ControllerEngine : public QObject {
 
     // Wrap a snippet of JS code in an anonymous function
     QScriptValue wrapFunctionCode(const QString& codeSnippet, int numberOfArgs);
+    QScriptValue getThisObjectInFunctionCall();
 
     // Look up registered script function prefixes
     const QList<QString>& getScriptFunctionPrefixes() { return m_scriptFunctionPrefixes; };


### PR DESCRIPTION
This will facilitate using timers in Components, for example to implement alternate actions on double button presses or long presses.