### PR TITLE
Script connection object trigger method

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -123,13 +123,17 @@
         },
         disconnect: function () {
             if (this.connections[0] !== undefined) {
-                this.connections.forEach(function (connection) {
-                    connection.disconnect();
+                this.connections.forEach(function (conn) {
+                    conn.disconnect();
                 });
             }
         },
         trigger: function() {
-            engine.trigger(this.group, this.outKey);
+            if (this.connections[0] !== undefined) {
+                this.connections.forEach(function (conn) {
+                    conn.trigger();
+                });
+            }
         },
         shiftOffset: 0,
         sendShifted: false,

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -808,10 +808,8 @@ QScriptValue ControllerEngine::connectControl(
 }
 
 /* -------- ------------------------------------------------------
-   Purpose: (Dis)connects a ControlObject valueChanged() signal to/from a script function
-   Input:   Control group (e.g. [Channel1]), Key name (e.g. [filterHigh]),
-                script function name, true if you want to disconnect
-   Output:  true if successful
+   Purpose: (Dis)connects a ControllerEngineConnection
+   Input:   the ControllerEngineConnection to disconnect
    -------- ------------------------------------------------------ */
 void ControllerEngine::disconnectControl(const ControllerEngineConnection conn) {
     ControlObjectScript* coScript = getControlObjectScript(conn.key.group, conn.key.item);
@@ -832,6 +830,23 @@ void ControllerEngineConnectionScriptValue::disconnect() {
     m_conn.ce->disconnectControl(m_conn);
 }
 
+/* -------- ------------------------------------------------------
+   Purpose: Triggers the callback function of a ControllerEngineConnection
+   Input:   the ControllerEngineConnection to trigger
+   -------- ------------------------------------------------------ */
+void ControllerEngine::triggerControl(const ControllerEngineConnection conn) {
+    ControlObjectScript* coScript = getControlObjectScript(conn.key.group, conn.key.item);
+
+    if (m_pEngine == nullptr || coScript == nullptr) {
+        return;
+    }
+
+    coScript->emitValueChanged();
+}
+
+void ControllerEngineConnectionScriptValue::trigger() {
+    m_conn.ce->triggerControl(m_conn);
+}
 
 /* -------- ------------------------------------------------------
    Purpose: Evaluate a script file

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -49,6 +49,7 @@ class ControllerEngineConnectionScriptValue : public QObject {
     }
     const QString& readId() const { return m_conn.id; }
     Q_INVOKABLE void disconnect();
+    Q_INVOKABLE void trigger();
 
   private:
     ControllerEngineConnection m_conn;
@@ -87,6 +88,7 @@ class ControllerEngine : public QObject {
 
     // Disconnect a ControllerEngineConnection
     void disconnectControl(const ControllerEngineConnection conn);
+    void triggerControl(const ControllerEngineConnection conn);
 
   protected:
     Q_INVOKABLE double getValue(QString group, QString name);


### PR DESCRIPTION
Previously, engine.trigger(group, key) had to be called by scripts, which would trigger all callbacks connected to that ConfigKey. This new method allows more fine-grained control by scripts.