### PR TITLE
Components: fix deck toggling

### DIFF
--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -366,11 +366,10 @@ bpm.tapButton = function(deck) {
 }
 
 // ----------------- Common regular expressions --------------------------
-script.samplerRegEx = /\[Sampler(\d+)\]/ ;
-script.channelRegEx = /\[Channel(\d+)\]/ ;
-script.channelRegExExact = /^\[Channel(\d+)\]$/ ;
-script.eqRegEx = /\[EqualizerRack1_\[(.*)\]_Effect1\]/ ;
-script.quickEffectRegEx = /\[QuickEffectRack1_\[(.*)\]\]/ ;
+script.samplerRegEx = /^\[Sampler(\d+)\]$/ ;
+script.channelRegEx = /^\[Channel(\d+)\]$/ ;
+script.eqRegEx = /^\[EqualizerRack1_(\[.*\])_Effect1\]$/ ;
+script.quickEffectRegEx = /^\[QuickEffectRack1_(\[.*\])\]$/ ;
 
 // ----------------- Object definitions --------------------------
 

--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -368,6 +368,7 @@ bpm.tapButton = function(deck) {
 // ----------------- Common regular expressions --------------------------
 script.samplerRegEx = /\[Sampler(\d+)\]/ ;
 script.channelRegEx = /\[Channel(\d+)\]/ ;
+script.channelRegExExact = /^\[Channel(\d+)\]$/ ;
 script.eqRegEx = /\[EqualizerRack1_\[(.*)\]_Effect1\]/ ;
 script.quickEffectRegEx = /\[QuickEffectRack1_\[(.*)\]\]/ ;
 

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -435,7 +435,7 @@
         setCurrentDeck: function (newGroup) {
             this.currentDeck = newGroup;
             this.reconnectComponents(function (component) {
-                if (component.group.search(script.channelRegExExact) !== -1) {
+                if (component.group.search(script.channelRegEx) !== -1) {
                     component.group = this.currentDeck;
                 } else if (component.group.search(script.eqRegEx) !== -1) {
                     component.group = '[EqualizerRack1_' + this.currentDeck + '_Effect1]';

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -435,7 +435,7 @@
         setCurrentDeck: function (newGroup) {
             this.currentDeck = newGroup;
             this.reconnectComponents(function (component) {
-                if (component.group.search(script.channelRegEx) !== -1) {
+                if (component.group.search(script.channelRegExExact) !== -1) {
                     component.group = this.currentDeck;
                 } else if (component.group.search(script.eqRegEx) !== -1) {
                     component.group = '[EqualizerRack1_' + this.currentDeck + '_Effect1]';


### PR DESCRIPTION
script.channelRegEx was matching EQ knob groups, causing their group to be set to [ChannelX] when Deck.setCurrentDeck was called