### PR TITLE
Bugfix #1668923: WAV/AIFF metadata in RIFF tag

### DIFF
--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -374,7 +374,7 @@ bool EngineRecord::openFile() {
                 qWarning("libsndfile error: %s", sf_error_number(ret));
             }
 
-            ret = sf_set_string(m_pSndfile, SF_STR_COMMENT, m_baAlbum.constData());
+            ret = sf_set_string(m_pSndfile, SF_STR_ALBUM, m_baAlbum.constData());
             if (ret != 0) {
                 qWarning("libsndfile error: %s", sf_error_number(ret));
             }

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -363,20 +363,31 @@ bool EngineRecord::openFile() {
             // Ensure CPU_CLIPS_NEGATIVE and CPU_CLIPS_POSITIVE is setup properly in the build.
             sf_command(m_pSndfile, SFC_SET_CLIPPING, NULL, SF_TRUE) ;
 
-            // Set meta data
-            int ret = sf_set_string(m_pSndfile, SF_STR_TITLE, m_baTitle.constData());
-            if (ret != 0) {
-                qWarning("libsndfile error: %s", sf_error_number(ret));
+            if (!m_baTitle.isEmpty()) {
+                int ret = sf_set_string(m_pSndfile, SF_STR_TITLE, m_baTitle.constData());
+                if (ret != 0) {
+                    qWarning("libsndfile error: %s", sf_error_number(ret));
+                }
             }
 
-            ret = sf_set_string(m_pSndfile, SF_STR_ARTIST, m_baAuthor.constData());
-            if (ret != 0) {
-                qWarning("libsndfile error: %s", sf_error_number(ret));
+            if (!m_baAuthor.isEmpty()) {
+                int ret = sf_set_string(m_pSndfile, SF_STR_ARTIST, m_baAuthor.constData());
+                if (ret != 0) {
+                    qWarning("libsndfile error: %s", sf_error_number(ret));
+                }
             }
 
-            ret = sf_set_string(m_pSndfile, SF_STR_ALBUM, m_baAlbum.constData());
-            if (ret != 0) {
-                qWarning("libsndfile error: %s", sf_error_number(ret));
+            if (!m_baAlbum.isEmpty()) {
+                int strType = SF_STR_ALBUM;
+                if (ENCODING_AIFF) {
+                    // There is no AIFF text chunk for "Album". But libsndfile is able to
+                    // write the SF_STR_COMMENT string into the text chunk with id "ANNO".
+                    strType = SF_STR_COMMENT;
+                }
+                int ret = sf_set_string(m_pSndfile, strType, m_baAlbum.constData());
+                if (ret != 0) {
+                    qWarning("libsndfile error: %s", sf_error_number(ret));
+                }
             }
         }
     } else {

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -323,6 +323,28 @@ bool readAudioProperties(TrackMetadata* pTrackMetadata,
     return true;
 }
 
+void readTrackMetadataFromRIFFTag(TrackMetadata* pTrackMetadata, const TagLib::RIFF::Info::Tag& tag) {
+    if (!pTrackMetadata) {
+        return; // nothing to do
+    }
+
+    pTrackMetadata->setTitle(toQString(tag.title()));
+    pTrackMetadata->setArtist(toQString(tag.artist()));
+    pTrackMetadata->setAlbum(toQString(tag.album()));
+    pTrackMetadata->setComment(toQString(tag.comment()));
+    pTrackMetadata->setGenre(toQString(tag.genre()));
+
+    int iYear = tag.year();
+    if (iYear > 0) {
+        pTrackMetadata->setYear(QString::number(iYear));
+    }
+
+    int iTrack = tag.track();
+    if (iTrack > 0) {
+        pTrackMetadata->setTrackNumber(QString::number(iTrack));
+    }
+}
+
 void readTrackMetadataFromTag(TrackMetadata* pTrackMetadata, const TagLib::Tag& tag) {
     if (!pTrackMetadata) {
         return; // nothing to do
@@ -1696,9 +1718,9 @@ Result readTrackMetadataAndCoverArtFromFile(TrackMetadata* pTrackMetadata, QImag
                 return OK;
             } else {
                 // fallback
-                const TagLib::Tag* pTag(file.tag());
+                const TagLib::RIFF::Info::Tag* pTag = file.InfoTag();
                 if (pTag) {
-                    readTrackMetadataFromTag(pTrackMetadata, *pTag);
+                    readTrackMetadataFromRIFFTag(pTrackMetadata, *pTag);
                     return OK;
                 }
             }


### PR DESCRIPTION
Again, targeted at both master and 2.1. I'm still unsure about our merging strategy, until now it was from master to 2.1.