### PR TITLE
Make the overview-waveform darker for the played portion of the track

### DIFF
--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -105,7 +105,7 @@ class SkinContext {
 
         QColor color;
         QString sColorString = nodeToString(selectElement(node, nodeName));
-        if (sColorString.startsWith('#') && sColorString.length() == 9){
+        if (sColorString.startsWith('#') && sColorString.length() == 9) {
             // first extract the #RRGGBB part and parse the color from that
             QString sRgbHex = sColorString.mid(3, 6).prepend("#");
             color.setNamedColor(sRgbHex);
@@ -114,7 +114,7 @@ class SkinContext {
             QString sAlphaHex = sColorString.mid(1, 2);
             bool bAlphaValueTransformed;
             int iAlpha = sAlphaHex.toUInt(&bAlphaValueTransformed, 16);
-            if (bAlphaValueTransformed){
+            if (bAlphaValueTransformed) {
                 color.setAlpha(iAlpha);
             }
         } else {

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -98,6 +98,32 @@ class SkinContext {
             return ok ? conv : 0;
     }
 
+    inline QColor selectColor(const QDomNode& node, const QString& nodeName) const {
+        // Takes a string with format #AARRGGBB and returns the corresponding QColor with alpha-channel set
+        // QT5.2 parses such strings by default in QColor::setNamedColor()
+        // TODO(MK): remove that logic once QT > 5.2 is the default
+
+        QColor color;
+        QString sColorString = nodeToString(selectElement(node, nodeName));
+        if (sColorString.startsWith('#') && sColorString.length() == 9){
+            // first extract the #RRGGBB part and parse the color from that
+            QString sRgbHex = sColorString.mid(3, 6).prepend("#");
+            color.setNamedColor(sRgbHex);
+
+            // now extract the alpha-value
+            QString sAlphaHex = sColorString.mid(1, 2);
+            bool bAlphaValueTransformed;
+            int iAlpha = sAlphaHex.toUInt(&bAlphaValueTransformed, 16);
+            if (bAlphaValueTransformed){
+                color.setAlpha(iAlpha);
+            }
+        } else {
+            // if the given string is not in #AARRGGBB format, fall back to default QT behaviour
+            color.setNamedColor(sColorString);
+        }
+        return color;
+    }
+
     inline bool selectBool(const QDomNode& node, const QString& nodeName,
                            bool defaultValue) const {
         QDomNode child = selectNode(node, nodeName);

--- a/src/waveform/renderers/waveformsignalcolors.cpp
+++ b/src/waveform/renderers/waveformsignalcolors.cpp
@@ -64,7 +64,7 @@ bool WaveformSignalColors::setup(const QDomNode &node, const SkinContext& contex
 
     m_bgColor = context.selectColor(node, "BgColor");
     if (!m_bgColor.isValid()) {
-        m_bgColor = QColor(0, 0, 0);
+        m_bgColor = Qt::transparent;
     }
     m_bgColor = WSkinColor::getCorrectColor(m_bgColor).toRgb();
 

--- a/src/waveform/renderers/waveformsignalcolors.cpp
+++ b/src/waveform/renderers/waveformsignalcolors.cpp
@@ -43,13 +43,13 @@ bool WaveformSignalColors::setup(const QDomNode &node, const SkinContext& contex
     }
     m_rgbHighColor = WSkinColor::getCorrectColor(m_rgbHighColor).toRgb();
 
-    m_axesColor.setNamedColor(context.selectString(node, "AxesColor"));
+    m_axesColor = context.selectColor(node, "AxesColor");
     if (!m_axesColor.isValid()) {
         m_axesColor = QColor(245,245,245);
     }
     m_axesColor = WSkinColor::getCorrectColor(m_axesColor).toRgb();
 
-    m_playPosColor.setNamedColor(context.selectString(node, "PlayPosColor"));
+    m_playPosColor = context.selectColor(node, "PlayPosColor");
     m_playPosColor = WSkinColor::getCorrectColor(m_playPosColor).toRgb();
     if (!m_playPosColor.isValid()) {
         m_playPosColor = m_axesColor;
@@ -62,7 +62,7 @@ bool WaveformSignalColors::setup(const QDomNode &node, const SkinContext& contex
         m_playedOverlayColor = Qt::transparent;
     }
 
-    m_bgColor.setNamedColor(context.selectString(node, "BgColor"));
+    m_bgColor = context.selectColor(node, "BgColor");
     if (!m_bgColor.isValid()) {
         m_bgColor = QColor(0, 0, 0);
     }

--- a/src/waveform/renderers/waveformsignalcolors.cpp
+++ b/src/waveform/renderers/waveformsignalcolors.cpp
@@ -55,11 +55,12 @@ bool WaveformSignalColors::setup(const QDomNode &node, const SkinContext& contex
         m_playPosColor = m_axesColor;
     }
 
-    m_playedOverlayColor = rgbaColorFromString(context.selectString(node, "PlayedOverlayColor"));
-    if (!m_playedOverlayColor.isValid()) {
-        m_playedOverlayColor = QColor(0,0,0,200);
-    }
+    // This color is used to draw an overlay over the played part the overview-waveforms
+    m_playedOverlayColor = context.selectColor(node, "PlayedOverlayColor");
     m_playedOverlayColor = WSkinColor::getCorrectColor(m_playedOverlayColor).toRgb();
+    if (!m_playedOverlayColor.isValid()) {
+        m_playedOverlayColor = Qt::transparent;
+    }
 
     m_bgColor.setNamedColor(context.selectString(node, "BgColor"));
     if (!m_bgColor.isValid()) {
@@ -138,30 +139,6 @@ void WaveformSignalColors::fallBackDefaultColor() {
     m_signalColor = Qt::green;
     m_signalColor = m_signalColor.toRgb();
     fallBackFromSignalColor();
-}
-
-QColor WaveformSignalColors::rgbaColorFromString(QString sColorString) {
-    // Takes a string with format #AARRGGBBAA and returns the corresponding QColor with alpha-channel set
-    // QT5.2 parses such strings by default in QColor::setNamedColor()
-    // TODO(MK): remove that logic once QT > 5.2 is the default
-    QColor rgbaColor;
-    if (sColorString.startsWith('#') && sColorString.length() == 9){
-        // first extract the #RRGGBB part and parse the color from that
-        QString sRgbHex = sColorString.mid(3, 6);
-        sRgbHex.prepend("#");
-        rgbaColor.setNamedColor(sRgbHex);
-
-        QString sAlphaHex = sColorString.mid(1, 2);
-        bool bAlphaValueTransformed;
-        int iAlpha = sAlphaHex.toUInt(&bAlphaValueTransformed, 16);
-        if (bAlphaValueTransformed){
-            rgbaColor.setAlpha(iAlpha);
-        }
-    } else {
-        // if the given string is not in #AARRGGBB format, fall back to default QT behaviour
-        rgbaColor.setNamedColor(sColorString);
-    }
-    return rgbaColor;
 }
 
 //NOTE(vRince) this sabilise hue between -1.0 and 2.0 but not more !

--- a/src/waveform/renderers/waveformsignalcolors.cpp
+++ b/src/waveform/renderers/waveformsignalcolors.cpp
@@ -55,6 +55,12 @@ bool WaveformSignalColors::setup(const QDomNode &node, const SkinContext& contex
         m_playPosColor = m_axesColor;
     }
 
+    m_playedOverlayColor = rgbaColorFromString(context.selectString(node, "PlayedOverlayColor"));
+    if (!m_playedOverlayColor.isValid()) {
+        m_playedOverlayColor = QColor(0,0,0,200);
+    }
+    m_playedOverlayColor = WSkinColor::getCorrectColor(m_playedOverlayColor).toRgb();
+
     m_bgColor.setNamedColor(context.selectString(node, "BgColor"));
     if (!m_bgColor.isValid()) {
         m_bgColor = QColor(0, 0, 0);
@@ -132,6 +138,30 @@ void WaveformSignalColors::fallBackDefaultColor() {
     m_signalColor = Qt::green;
     m_signalColor = m_signalColor.toRgb();
     fallBackFromSignalColor();
+}
+
+QColor WaveformSignalColors::rgbaColorFromString(QString sColorString) {
+    // Takes a string with format #AARRGGBBAA and returns the corresponding QColor with alpha-channel set
+    // QT5.2 parses such strings by default in QColor::setNamedColor()
+    // TODO(MK): remove that logic once QT > 5.2 is the default
+    QColor rgbaColor;
+    if (sColorString.startsWith('#') && sColorString.length() == 9){
+        // first extract the #RRGGBB part and parse the color from that
+        QString sRgbHex = sColorString.mid(3, 6);
+        sRgbHex.prepend("#");
+        rgbaColor.setNamedColor(sRgbHex);
+
+        QString sAlphaHex = sColorString.mid(1, 2);
+        bool bAlphaValueTransformed;
+        int iAlpha = sAlphaHex.toUInt(&bAlphaValueTransformed, 16);
+        if (bAlphaValueTransformed){
+            rgbaColor.setAlpha(iAlpha);
+        }
+    } else {
+        // if the given string is not in #AARRGGBB format, fall back to default QT behaviour
+        rgbaColor.setNamedColor(sColorString);
+    }
+    return rgbaColor;
 }
 
 //NOTE(vRince) this sabilise hue between -1.0 and 2.0 but not more !

--- a/src/waveform/renderers/waveformsignalcolors.h
+++ b/src/waveform/renderers/waveformsignalcolors.h
@@ -22,11 +22,13 @@ class WaveformSignalColors {
     inline const QColor& getRgbHighColor() const { return m_rgbHighColor; }
     inline const QColor& getAxesColor() const { return m_axesColor; }
     inline const QColor& getPlayPosColor() const { return m_playPosColor; }
+    inline const QColor& getPlayedOverlayColor() const { return m_playedOverlayColor; }
     inline const QColor& getBgColor() const { return m_bgColor; }
 
   protected:
     void fallBackFromSignalColor();
     void fallBackDefaultColor();
+    QColor rgbaColorFromString(QString sColorString);
 
     float stableHue(float hue) const;
 
@@ -40,6 +42,7 @@ class WaveformSignalColors {
     QColor m_rgbHighColor;
     QColor m_axesColor;
     QColor m_playPosColor;
+    QColor m_playedOverlayColor;
     QColor m_bgColor;
 };
 

--- a/src/waveform/renderers/waveformsignalcolors.h
+++ b/src/waveform/renderers/waveformsignalcolors.h
@@ -28,7 +28,6 @@ class WaveformSignalColors {
   protected:
     void fallBackFromSignalColor();
     void fallBackDefaultColor();
-    QColor rgbaColorFromString(QString sColorString);
 
     float stableHue(float hue) const;
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -338,8 +338,8 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
 
             // Overlay the played part of the overview-waveform with a skin defined color
             QColor playedOverlayColor = m_signalColors.getPlayedOverlayColor();
-            if (playedOverlayColor.alpha() > 0){
-                if (m_orientation == Qt::Vertical){
+            if (playedOverlayColor.alpha() > 0) {
+                if (m_orientation == Qt::Vertical) {
                     painter.fillRect(0, 0, m_waveformImageScaled.width(),  m_iPos, playedOverlayColor);
                 } else {
                     painter.fillRect(0, 0, m_iPos, m_waveformImageScaled.height(), playedOverlayColor);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -338,8 +338,16 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
             }
 
             painter.drawImage(rect(), m_waveformImageScaled);
-            // desaturate the scaled waveform-image up to the current play-position by overdrawing semi-transparent black
-            painter.fillRect(0, 0, m_iPos, m_waveformImageScaled.height(), m_signalColors.getPlayedOverlayColor());
+
+            // Overlay the played part of the overview-waveform with a skin defined color
+            QColor playedOverlayColor = m_signalColors.getPlayedOverlayColor();
+            if (playedOverlayColor.alpha() > 0){
+                if (m_orientation == Qt::Vertical){
+                    painter.fillRect(0, 0, m_waveformImageScaled.width(),  m_iPos, playedOverlayColor);
+                } else {
+                    painter.fillRect(0, 0, m_iPos, m_waveformImageScaled.height(), playedOverlayColor);
+                }
+            }
         }
 
         if (m_dAnalyzerProgress < 1.0) {

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -339,7 +339,7 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
 
             painter.drawImage(rect(), m_waveformImageScaled);
             // desaturate the scaled waveform-image up to the current play-position by overdrawing semi-transparent black
-            painter.fillRect(0, 0, m_iPos, m_waveformImageScaled.height(), QColor(0,0,0,200));
+            painter.fillRect(0, 0, m_iPos, m_waveformImageScaled.height(), m_signalColors.getPlayedOverlayColor());
         }
 
         if (m_dAnalyzerProgress < 1.0) {

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -338,6 +338,8 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
             }
 
             painter.drawImage(rect(), m_waveformImageScaled);
+            // desaturate the scaled waveform-image up to the current play-position by overdrawing semi-transparent black
+            painter.fillRect(0, 0, m_iPos, m_waveformImageScaled.height(), QColor(0,0,0,200));
         }
 
         if (m_dAnalyzerProgress < 1.0) {


### PR DESCRIPTION
… as a stronger visual indicator of the current position

aiming to fix [lp:1328748](https://bugs.launchpad.net/mixxx/+bug/1328748)
Actually that change set is only one single line of code. I don't have any experience with qt painting and perfomance measures. So please feel free to comment.

I am thinking about making the color configurable for skin artists. What do you think about that?