### PR TITLE
HiDPI Skin Scaling 

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -1117,6 +1117,7 @@ class MixxxCore(Feature):
                    "util/logging.cpp",
                    "util/cmdlineargs.cpp",
                    "util/audiosignal.cpp",
+                   "util/autohidpi.cpp",
 
                    '#res/mixxx.qrc'
                    ]

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -176,8 +176,7 @@ QHeaderView {
 }
 
 QHeaderView::section {
-  height: 18px;
-  font-size: 13px/15px;
+  font-size: 10pt;
   font-weight: normal;
   padding: 2px;
   background: #1A1A1A;
@@ -188,7 +187,7 @@ QHeaderView::section {
 }
 
 QHeaderView::section:selected {
-  font-size: 13px/15px;
+  font-size: 10pt;
   font-weight: bold;
   padding: 2px;
   background: #1A1A1A;

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -860,6 +860,8 @@ WEffectSelector {
   /* The 3D frame on the combo box becomes flat when you give it a border */
   border: 1px solid #444342;
   border-radius: 3px;
+  
+  font: 12px;
 }
 
   WEffectSelector:hover {

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -1199,12 +1199,11 @@ QPushButton#LibraryPreviewButton:!checked{ image: url(skin:/style/style_library_
 QPushButton#LibraryPreviewButton:checked{ image: url(skin:/style/style_library_preview_pause.png); }
 
 QHeaderView {
-  font: 13px/15px;
+  font: 10pt;
   color: #cfb32c;
   background-color: #0f0f0f;
 }
 QHeaderView::section {
-  height: 18px;
   border: 1px solid #585858;
   border-left: 0px;
   background-color:qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #585858, stop:1 #0f0f0f);

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -380,8 +380,6 @@
 
 					QTableView, QTextBrowser, QTreeView {
 						border: 1px solid #656565;
-						font: 12px/14px sans-serif;
-						font-family: "Open Sans";
 						background: transparent; color: #ACACAC;
 						<!--we use  "background: transparent" as workaround, else "alternate-background-color" wont work, QT 4.7.x bug?-->
 						alternate-background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 rgba(43, 43, 43, 255), stop:0.049 rgba(43, 43, 43, 255), stop:0.050 rgba(43, 43, 43, 100), stop:0.949 rgba(43, 43, 43, 100), stop:0.95 rgba(43, 43, 43, 255), stop:1 rgba(43, 43, 43, 255));}
@@ -403,8 +401,7 @@
 					QPushButton#LibraryBPMButton::checked {image: url(:/images/library/ic_library_checked.png);}
 					QPushButton#LibraryBPMButton::!checked {image: url(:/images/library/ic_library_unchecked.png);}
 
-					QHeaderView { font: 11px/13px sans-serif;
-						      font-family: "Open Sans";}
+					QHeaderView { font-size: 10pt; }
 
 					<!--Styling a QSpinbox is complex and it took ages to figure out how to remove the surrounding frame and make the background transparent without affecting the subcontrols (up/down-buttons).
 					You could easily style a subcontrol like in the QT-Docs, but if you want to have the OS-native subcontrols, this is the only way i found ( there are probably others ).
@@ -413,8 +410,7 @@
 					-->
 					<!--transition time in Auto DJ tab-->
 					QSpinBox:editable {
-							font: 12px/14px sans-serif;
-							font-family: "Open Sans";
+							font-size: 10pt;
 							background: transparent;
 							color: #ACACAC; }
 					QSpinBox { min-height: 20px; max-height: 20px;min-width: 40px; max-width: 40px;}
@@ -424,7 +420,7 @@
 						margin: 0px 0px 5px 5px;
 						padding: 2px;
 						border: 1px solid #656565;
-						font: 12px/14px sans-serif;
+						font-size: 10pt;
 						font-family: "Open Sans";
 						background: transparent;
 						color: #ACACAC;
@@ -432,14 +428,14 @@
 					WSearchLineEdit:focus {
 						padding: 2px;
 						border: 2px solid #FF6600;
-						font: 12px/14px sans-serif;
+						font-size: 10pt;
 						font-family: "Open Sans";
 						background: rgba(255, 102, 0,50);
 						color: #D6D6D6;}
 
 					<!--Cover Art-->
 					WCoverArt {
-						font: 13px/15px sans-serif;
+						font: 11px/15px sans-serif;
 						font-family: "Open Sans";
 						background: transparent;
 						color: #ACACAC;
@@ -451,12 +447,11 @@
 					QSplitter::handle:horizontal { width: 6px; }
 					QSplitter::handle:vertical { height: 6px;}
 
-					QPushButton { font: 12px/14px sans-serif;
+					QPushButton { font-size: 10pt;
 						      font-family: "Open Sans";}
 					<!--Extra declaration for QRadionButton otherwise it shows up with wrong colors in Linux with Gnome -->
 					QLabel, QRadioButton {
-						font: 12px/14px sans-serif;
-						font-family: "Open Sans";
+						font-size: 10pt;
 						background: transparent;
 						color: #C1C1C1;}
 

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -301,15 +301,42 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     double scaleFactor = m_pConfig->getValue(
             ConfigKey("[Config]", "ScaleFactor"), 1.0);
 
-    if (scaleFactor == 1.0) {
-        checkBoxDoubleWidgetSize->setCheckState(Qt::Unchecked);
-    } else if (scaleFactor == 2.0) {
-        checkBoxDoubleWidgetSize->setCheckState(Qt::Checked);
-    } else {
-        checkBoxDoubleWidgetSize->setCheckState(Qt::PartiallyChecked);
+    //: Entry of the HiDPI scale combo box. %1 is the scale factor-
+    comboBoxScaleFactor->addItem(QString(tr("x %1")).arg(0.5), 0.5);
+    comboBoxScaleFactor->addItem(QString(tr("x %1")).arg(1), 1);
+    comboBoxScaleFactor->addItem(QString(tr("x %1")).arg(2), 2);
+    comboBoxScaleFactor->addItem(QString(tr("x %1")).arg(3), 3);
+    comboBoxScaleFactor->addItem(QString(tr("x %1")).arg(4), 4);
+    int i;
+    for (i = 0; i < comboBoxScaleFactor->count(); ++i) {
+        if (scaleFactor == comboBoxScaleFactor->itemData(i)) {
+            comboBoxScaleFactor->setCurrentIndex(i);
+            break;
+        }
     }
-    connect(checkBoxDoubleWidgetSize, SIGNAL(stateChanged(int)),
-            this, SLOT(slotSetDoubleWidgetSize(int)));
+    if (i == comboBoxScaleFactor->count()) {
+        // no default scale, add custom scale
+        comboBoxScaleFactor->addItem(
+                QString(tr("x %1")).arg(scaleFactor), scaleFactor);
+        comboBoxScaleFactor->setCurrentIndex(i);
+    }
+    connect(comboBoxScaleFactor, SIGNAL(activated(int)),
+            this, SLOT(slotSetScaleFactor(int)));
+
+
+    bool autoValueAvalable = false;
+    if (autoValueAvalable) {
+        bool scaleFactorAuto = m_pConfig->getValue(
+                ConfigKey("[Config]", "ScaleFactorAuto"), true);
+        checkBoxScaleFactorAuto->setChecked(scaleFactorAuto);
+        if (scaleFactorAuto) {
+            comboBoxScaleFactor->setEnabled(false);
+        }
+        connect(checkBoxScaleFactorAuto, SIGNAL(toggled(bool)),
+                this, SLOT(slotSetScaleFactorAuto(bool)));
+    } else {
+        checkBoxScaleFactorAuto->setEnabled(false);
+    }
 
     //
     // Start in fullscreen mode
@@ -467,7 +494,8 @@ void DlgPrefControls::slotResetToDefaults() {
     checkBoxSeekToCue->setChecked(true);
 
     // Default to normal size widgets
-    checkBoxDoubleWidgetSize->setChecked(false);
+    comboBoxScaleFactor->setCurrentIndex(1);
+    checkBoxScaleFactorAuto->setChecked(true);
 
     // Don't start in full screen.
     checkBoxStartFullScreen->setChecked(false);
@@ -580,13 +608,17 @@ void DlgPrefControls::slotSetCueRecall(bool b)
     m_pConfig->set(ConfigKey("[Controls]", "CueRecall"), ConfigValue(b?0:1));
 }
 
-void DlgPrefControls::slotSetDoubleWidgetSize(int state) {
-    Q_UNUSED(state);
-    checkBoxDoubleWidgetSize->setTristate(false);
-    bool b = checkBoxDoubleWidgetSize->isChecked();
-    m_pConfig->setValue(ConfigKey("[Config]", "ScaleFactor"), b ? 2.0 : 1.0);
+
+void DlgPrefControls::slotSetScaleFactor(int index) {
+    double scaleFactor = comboBoxScaleFactor->itemData(index).toDouble();
+    m_pConfig->setValue(ConfigKey("[Config]", "ScaleFactor"), scaleFactor);
     // reload the skin when the button is toggled
     m_mixxx->rebootMixxxView();
+}
+
+void DlgPrefControls::slotSetScaleFactorAuto(bool checked) {
+    Q_UNUSED(checked);
+   // DODO
 }
 
 void DlgPrefControls::slotSetStartInFullScreen(bool b) {

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -298,8 +298,16 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
 
     slotUpdateSchemes();
 
-    checkBoxDoubleWidgetSize->setChecked(m_pConfig->getValueString(
-                       ConfigKey("[Config]", "DoubleWidgetSize")).toInt()==1);
+    double scaleFactor = m_pConfig->getValue(
+            ConfigKey("[Config]", "ScaleFactor"), 1.0);
+
+    if (scaleFactor == 1.0) {
+        checkBoxDoubleWidgetSize->setCheckState(Qt::Unchecked);
+    } else if (scaleFactor == 2.0) {
+        checkBoxDoubleWidgetSize->setCheckState(Qt::Checked);
+    } else {
+        checkBoxDoubleWidgetSize->setCheckState(Qt::PartiallyChecked);
+    }
     connect(checkBoxDoubleWidgetSize, SIGNAL(toggled(bool)),
             this, SLOT(slotSetDoubleWidgetSize(bool)));
 
@@ -573,7 +581,8 @@ void DlgPrefControls::slotSetCueRecall(bool b)
 }
 
 void DlgPrefControls::slotSetDoubleWidgetSize(bool b) {
-    m_pConfig->set(ConfigKey("[Config]", "DoubleWidgetSize"), ConfigValue(b?1:0));
+    checkBoxDoubleWidgetSize->setTristate(false);
+    m_pConfig->setValue(ConfigKey("[Config]", "ScaleFactor"), b ? 2.0 : 1.0);
     // reload the skin when the button is toggled
     m_mixxx->rebootMixxxView();
 }

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -328,7 +328,7 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     slotUpdateSchemes();
 
 
-#if QT_VERSION > QT_VERSION_CHECK(5, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     AutoHiDpi autoHiDpi;
     m_autoScaleFactor = autoHiDpi.getScaleFactor();
     double scaleFactor = m_autoScaleFactor;
@@ -339,6 +339,8 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
         checkBoxScaleFactorAuto->setChecked(scaleFactorAuto);
         if (scaleFactorAuto) {
             comboBoxScaleFactor->setEnabled(false);
+            m_pConfig->setValue(
+                    ConfigKey("[Config]", "ScaleFactor"), m_autoScaleFactor);
         } else {
             scaleFactor = m_pConfig->getValue(
                         ConfigKey("[Config]", "ScaleFactor"), 1.0);

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -301,12 +301,12 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     double scaleFactor = m_pConfig->getValue(
             ConfigKey("[Config]", "ScaleFactor"), 1.0);
 
-    //: Entry of the HiDPI scale combo box. %1 is the scale factor-
-    comboBoxScaleFactor->addItem(QString(tr("x %1")).arg(0.5), 0.5);
-    comboBoxScaleFactor->addItem(QString(tr("x %1")).arg(1), 1);
-    comboBoxScaleFactor->addItem(QString(tr("x %1")).arg(2), 2);
-    comboBoxScaleFactor->addItem(QString(tr("x %1")).arg(3), 3);
-    comboBoxScaleFactor->addItem(QString(tr("x %1")).arg(4), 4);
+    //: Entry of the HiDPI scale combo box. %1 is the scale factor in percent
+    comboBoxScaleFactor->addItem(QString(tr("%1 % (Experimental)")).arg(50), 0.5);
+    comboBoxScaleFactor->addItem(QString(tr("%1 %")).arg(100), 1);
+    comboBoxScaleFactor->addItem(QString(tr("%1 % (Experimental)")).arg(200), 2);
+    comboBoxScaleFactor->addItem(QString(tr("%1 % (Experimental)")).arg(300), 3);
+    comboBoxScaleFactor->addItem(QString(tr("%1 % (Experimental)")).arg(400), 4);
     int i;
     for (i = 0; i < comboBoxScaleFactor->count(); ++i) {
         if (scaleFactor == comboBoxScaleFactor->itemData(i)) {

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -308,8 +308,8 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     } else {
         checkBoxDoubleWidgetSize->setCheckState(Qt::PartiallyChecked);
     }
-    connect(checkBoxDoubleWidgetSize, SIGNAL(toggled(bool)),
-            this, SLOT(slotSetDoubleWidgetSize(bool)));
+    connect(checkBoxDoubleWidgetSize, SIGNAL(stateChanged(int)),
+            this, SLOT(slotSetDoubleWidgetSize(int)));
 
     //
     // Start in fullscreen mode
@@ -580,8 +580,10 @@ void DlgPrefControls::slotSetCueRecall(bool b)
     m_pConfig->set(ConfigKey("[Controls]", "CueRecall"), ConfigValue(b?0:1));
 }
 
-void DlgPrefControls::slotSetDoubleWidgetSize(bool b) {
+void DlgPrefControls::slotSetDoubleWidgetSize(int state) {
+    Q_UNUSED(state);
     checkBoxDoubleWidgetSize->setTristate(false);
+    bool b = checkBoxDoubleWidgetSize->isChecked();
     m_pConfig->setValue(ConfigKey("[Config]", "ScaleFactor"), b ? 2.0 : 1.0);
     // reload the skin when the button is toggled
     m_mixxx->rebootMixxxView();

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -298,6 +298,11 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
 
     slotUpdateSchemes();
 
+    checkBoxDoubleWidgetSize->setChecked(m_pConfig->getValueString(
+                       ConfigKey("[Config]", "DoubleWidgetSize")).toInt()==1);
+    connect(checkBoxDoubleWidgetSize, SIGNAL(toggled(bool)),
+            this, SLOT(slotSetDoubleWidgetSize(bool)));
+
     //
     // Start in fullscreen mode
     //
@@ -453,6 +458,9 @@ void DlgPrefControls::slotResetToDefaults() {
     // Cue recall on.
     checkBoxSeekToCue->setChecked(true);
 
+    // Default to normal size widgets
+    checkBoxDoubleWidgetSize->setChecked(false);
+
     // Don't start in full screen.
     checkBoxStartFullScreen->setChecked(false);
 
@@ -562,6 +570,10 @@ void DlgPrefControls::slotSetCueDefault(int index)
 void DlgPrefControls::slotSetCueRecall(bool b)
 {
     m_pConfig->set(ConfigKey("[Controls]", "CueRecall"), ConfigValue(b?0:1));
+}
+
+void DlgPrefControls::slotSetDoubleWidgetSize(bool b) {
+    m_pConfig->set(ConfigKey("[Config]", "DoubleWidgetSize"), ConfigValue(b?1:0));
 }
 
 void DlgPrefControls::slotSetStartInFullScreen(bool b) {

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -328,6 +328,7 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     slotUpdateSchemes();
 
 
+#if QT_VERSION > QT_VERSION_CHECK(5, 0, 0)
     AutoHiDpi autoHiDpi;
     m_autoScaleFactor = autoHiDpi.getScaleFactor();
     double scaleFactor = m_autoScaleFactor;
@@ -373,6 +374,12 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     }
     connect(comboBoxScaleFactor, SIGNAL(activated(int)),
             this, SLOT(slotSetScaleFactor(int)));
+#else
+    checkBoxScaleFactorAuto->hide();
+    comboBoxScaleFactor->hide();
+    labelScaleFactor->hide();
+#endif
+
 
     //
     // Start in fullscreen mode

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -574,6 +574,8 @@ void DlgPrefControls::slotSetCueRecall(bool b)
 
 void DlgPrefControls::slotSetDoubleWidgetSize(bool b) {
     m_pConfig->set(ConfigKey("[Config]", "DoubleWidgetSize"), ConfigValue(b?1:0));
+    // reload the skin when the button is toggled
+    m_mixxx->rebootMixxxView();
 }
 
 void DlgPrefControls::slotSetStartInFullScreen(bool b) {

--- a/src/preferences/dialog/dlgprefcontrols.h
+++ b/src/preferences/dialog/dlgprefcontrols.h
@@ -69,7 +69,7 @@ class DlgPrefControls : public DlgPreferencePage, public Ui::DlgPrefControlsDlg 
     void slotSetRateRamp(bool);
     void slotSetRateRampSensitivity(int);
     void slotSetLocale(int);
-    void slotSetDoubleWidgetSize(bool b);
+    void slotSetDoubleWidgetSize(int state);
     void slotSetStartInFullScreen(bool b);
 
     void slotNumDecksChanged(double);

--- a/src/preferences/dialog/dlgprefcontrols.h
+++ b/src/preferences/dialog/dlgprefcontrols.h
@@ -69,7 +69,8 @@ class DlgPrefControls : public DlgPreferencePage, public Ui::DlgPrefControlsDlg 
     void slotSetRateRamp(bool);
     void slotSetRateRampSensitivity(int);
     void slotSetLocale(int);
-    void slotSetDoubleWidgetSize(int state);
+    void slotSetScaleFactor(int index);
+    void slotSetScaleFactorAuto(bool checked);
     void slotSetStartInFullScreen(bool b);
 
     void slotNumDecksChanged(double);

--- a/src/preferences/dialog/dlgprefcontrols.h
+++ b/src/preferences/dialog/dlgprefcontrols.h
@@ -69,6 +69,7 @@ class DlgPrefControls : public DlgPreferencePage, public Ui::DlgPrefControlsDlg 
     void slotSetRateRamp(bool);
     void slotSetRateRampSensitivity(int);
     void slotSetLocale(int);
+    void slotSetDoubleWidgetSize(bool b);
     void slotSetStartInFullScreen(bool b);
 
     void slotNumDecksChanged(double);

--- a/src/preferences/dialog/dlgprefcontrols.h
+++ b/src/preferences/dialog/dlgprefcontrols.h
@@ -108,6 +108,7 @@ class DlgPrefControls : public DlgPreferencePage, public Ui::DlgPrefControlsDlg 
     bool m_speedAutoReset;
     bool m_pitchAutoReset;
     int m_keylockMode;
+    double m_autoScaleFactor;
 };
 
 #endif

--- a/src/preferences/dialog/dlgprefcontrolsdlg.ui
+++ b/src/preferences/dialog/dlgprefcontrolsdlg.ui
@@ -489,6 +489,23 @@
        </property>
       </widget>
      </item>
+     <item row="12" column="1" colspan="2">
+      <widget class="QCheckBox" name="checkBoxDoubleWidgetSize">
+       <property name="text">
+        <string>Use 2x larger widgets for HiDPI displays</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="0">
+      <widget class="QLabel" name="labelDoubleWidgetOption">
+       <property name="text">
+        <string>Double Widget Sizes</string>
+       </property>
+       <property name="buddy">
+        <cstring>checkBoxDoubleWidgetSize</cstring>
+       </property>
+      </widget>
+     </item>
      <item row="9" column="0">
       <widget class="QLabel" name="labelPositionDisplay">
        <property name="enabled">

--- a/src/preferences/dialog/dlgprefcontrolsdlg.ui
+++ b/src/preferences/dialog/dlgprefcontrolsdlg.ui
@@ -6,15 +6,332 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>485</width>
-    <height>554</height>
+    <width>490</width>
+    <height>677</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Interface Preferences</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBoxSkinOptions">
+     <property name="title">
+      <string>Skin options</string>
+     </property>
+     <layout class="QGridLayout" name="GridLayout1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="lableSkin_2">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="text">
+         <string>Skin</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="buddy">
+         <cstring>ComboBoxSkinconf</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QComboBox" name="ComboBoxSkinconf">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <widget class="QLabel" name="warningLabel">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignJustify|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" rowspan="2">
+       <widget class="QLabel" name="lableColorScheme">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="text">
+         <string>Color scheme</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="buddy">
+         <cstring>ComboBoxSchemeconf</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" rowspan="2" colspan="2">
+       <widget class="QComboBox" name="ComboBoxSchemeconf">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="toolTip">
+         <string>Select from different color schemes of a skin if available.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="labelDoubleWidgetOption">
+        <property name="text">
+         <string>HiDPI / Retina scaling</string>
+        </property>
+        <property name="buddy">
+         <cstring>checkBoxScaleFactorAuto</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QComboBox" name="comboBoxScaleFactor"/>
+      </item>
+      <item row="4" column="2">
+       <widget class="QCheckBox" name="checkBoxScaleFactorAuto">
+        <property name="text">
+         <string>Auto Scaling</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="textLabelLocale">
+        <property name="text">
+         <string>Locale</string>
+        </property>
+        <property name="buddy">
+         <cstring>ComboBoxLocale</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1" colspan="2">
+       <widget class="QComboBox" name="ComboBoxLocale">
+        <property name="toolTip">
+         <string>Locales determine country and language specific settings.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="labelFullscreenOption">
+        <property name="text">
+         <string>Full-screen mode</string>
+        </property>
+        <property name="buddy">
+         <cstring>checkBoxStartFullScreen</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1" colspan="2">
+       <widget class="QCheckBox" name="checkBoxStartFullScreen">
+        <property name="text">
+         <string>Start in full-screen mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="labelTooltips">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="text">
+         <string>Tool tips</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="buddy">
+         <cstring>radioButtonTooltipsOff</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QRadioButton" name="radioButtonTooltipsOff">
+          <property name="text">
+           <string>Off</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupTooltips</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioButtonTooltipsLibrary">
+          <property name="text">
+           <string>Library only</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupTooltips</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioButtonTooltipsLibraryAndSkin">
+          <property name="text">
+           <string>Library and Skin</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupTooltips</string>
+          </attribute>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBoxDeckOptions">
+     <property name="title">
+      <string>Deck option</string>
+     </property>
+     <layout class="QGridLayout" name="GridLayout1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelCueMode">
+        <property name="text">
+         <string>Cue mode</string>
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
+        <property name="buddy">
+         <cstring>ComboBoxCueDefault</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QComboBox" name="ComboBoxCueDefault">
+        <property name="toolTip">
+         <string>Mixxx mode:
+- Cue button while pause at cue point = preview
+- Cue button while pause not at cue point = set cue point
+- Cue button while playing = pause at cue point
+Mixxx mode (no blinking):
+- Same as Mixxx mode but with no blinking indicators
+Pioneer mode:
+- Same as Mixxx mode with a flashing play button
+Denon mode:
+- Cue button at cue point = preview
+- Cue button not at cue point = pause at cue point
+- Play = set cue point
+Numark mode:
+- Same as Denon mode, but without a flashing play button
+CUP mode:
+- Cue button while pause at cue point = play after release
+- Cue button while pause not at cue point = set cue point and play after release
+- Cue button while playing = go to cue point and play after release
+</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelPositionDisplay">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="text">
+         <string>Track time display</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="buddy">
+         <cstring>radioButtonElapsed</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QRadioButton" name="radioButtonElapsed">
+        <property name="text">
+         <string>Elapsed</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroupTrackTime</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QRadioButton" name="radioButtonRemaining">
+        <property name="text">
+         <string>Remaining</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroupTrackTime</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelAutoCue">
+        <property name="text">
+         <string>Auto cue</string>
+        </property>
+        <property name="buddy">
+         <cstring>checkBoxSeekToCue</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="2">
+       <widget class="QCheckBox" name="checkBoxSeekToCue">
+        <property name="toolTip">
+         <string>Automatically seeks to the first saved cue point on track load.
+            If none exists, seeks to the beginning of the track.</string>
+        </property>
+        <property name="text">
+         <string>Jump to main cue point on track load</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="labelPlayingTrackProtection">
+        <property name="text">
+         <string>Playing track protection</string>
+        </property>
+        <property name="buddy">
+         <cstring>checkBoxDisallowLoadToPlayingDeck</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1" colspan="2">
+       <widget class="QCheckBox" name="checkBoxDisallowLoadToPlayingDeck">
+        <property name="text">
+         <string>Do not load tracks into playing decks</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
     <widget class="QGroupBox" name="groupBoxSpeedPitchOptions">
      <property name="title">
       <string>Speed (Tempo) and Key (Pitch) options</string>
@@ -418,314 +735,7 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="0">
-    <layout class="QGridLayout" name="GridLayout1">
-     <item row="0" column="1" colspan="2">
-      <widget class="QComboBox" name="ComboBoxSkinconf">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font/>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="textLabelLocale">
-       <property name="text">
-        <string>Locale</string>
-       </property>
-       <property name="buddy">
-        <cstring>ComboBoxLocale</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0" rowspan="2">
-      <widget class="QLabel" name="lableColorScheme">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="font">
-        <font/>
-       </property>
-       <property name="text">
-        <string>Color scheme</string>
-       </property>
-       <property name="wordWrap">
-        <bool>false</bool>
-       </property>
-       <property name="buddy">
-        <cstring>ComboBoxSchemeconf</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="2">
-      <widget class="QRadioButton" name="radioButtonRemaining">
-       <property name="text">
-        <string>Remaining</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">buttonGroupTrackTime</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <widget class="QRadioButton" name="radioButtonElapsed">
-       <property name="text">
-        <string>Elapsed</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">buttonGroupTrackTime</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="5" column="1" colspan="2">
-      <widget class="QCheckBox" name="checkBoxStartFullScreen">
-       <property name="text">
-        <string>Start in full-screen mode</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="1" colspan="2">
-      <widget class="QCheckBox" name="checkBoxDoubleWidgetSize">
-       <property name="text">
-        <string>Use 2x larger widgets for HiDPI displays</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="0">
-      <widget class="QLabel" name="labelDoubleWidgetOption">
-       <property name="text">
-        <string>Double Widget Sizes</string>
-       </property>
-       <property name="buddy">
-        <cstring>checkBoxDoubleWidgetSize</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="labelPositionDisplay">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="font">
-        <font/>
-       </property>
-       <property name="text">
-        <string>Track time display</string>
-       </property>
-       <property name="wordWrap">
-        <bool>false</bool>
-       </property>
-       <property name="buddy">
-        <cstring>radioButtonElapsed</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="labelFullscreenOption">
-       <property name="text">
-        <string>Full-screen mode</string>
-       </property>
-       <property name="buddy">
-        <cstring>checkBoxStartFullScreen</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1" colspan="2">
-      <widget class="QLabel" name="warningLabel">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignJustify|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0" colspan="3">
-      <widget class="Line" name="line">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="lableSkin_2">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="font">
-        <font/>
-       </property>
-       <property name="text">
-        <string>Skin</string>
-       </property>
-       <property name="wordWrap">
-        <bool>false</bool>
-       </property>
-       <property name="buddy">
-        <cstring>ComboBoxSkinconf</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1" colspan="2">
-      <widget class="QComboBox" name="ComboBoxLocale">
-       <property name="toolTip">
-        <string>Locales determine country and language specific settings.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1" rowspan="2" colspan="2">
-      <widget class="QComboBox" name="ComboBoxSchemeconf">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font/>
-       </property>
-       <property name="toolTip">
-        <string>Select from different color schemes of a skin if available.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="0">
-      <widget class="QLabel" name="labelPlayingTrackProtection">
-       <property name="text">
-        <string>Playing track protection</string>
-       </property>
-       <property name="buddy">
-        <cstring>checkBoxDisallowLoadToPlayingDeck</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="1" colspan="2">
-      <widget class="QCheckBox" name="checkBoxDisallowLoadToPlayingDeck">
-       <property name="text">
-        <string>Do not load tracks into playing decks</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="labelCueMode">
-       <property name="text">
-        <string>Cue mode</string>
-       </property>
-       <property name="openExternalLinks">
-        <bool>true</bool>
-       </property>
-       <property name="buddy">
-        <cstring>ComboBoxCueDefault</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1" colspan="2">
-      <widget class="QComboBox" name="ComboBoxCueDefault">
-       <property name="toolTip">
-        <string>Mixxx mode:
-- Cue button while pause at cue point = preview
-- Cue button while pause not at cue point = set cue point
-- Cue button while playing = pause at cue point
-Mixxx mode (no blinking):
-- Same as Mixxx mode but with no blinking indicators
-Pioneer mode:
-- Same as Mixxx mode with a flashing play button
-Denon mode:
-- Cue button at cue point = preview
-- Cue button not at cue point = pause at cue point
-- Play = set cue point
-Numark mode:
-- Same as Denon mode, but without a flashing play button
-CUP mode:
-- Cue button while pause at cue point = play after release
-- Cue button while pause not at cue point = set cue point and play after release
-- Cue button while playing = go to cue point and play after release
-</string>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="1" colspan="2">
-      <widget class="QCheckBox" name="checkBoxSeekToCue">
-       <property name="toolTip">
-        <string>Automatically seeks to the first saved cue point on track load.
-            If none exists, seeks to the beginning of the track.</string>
-       </property>
-       <property name="text">
-        <string>Jump to main cue point on track load</string>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="labelAutoCue">
-       <property name="text">
-        <string>Auto cue</string>
-       </property>
-       <property name="buddy">
-        <cstring>checkBoxSeekToCue</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1" colspan="2">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QRadioButton" name="radioButtonTooltipsOff">
-         <property name="text">
-          <string>Off</string>
-         </property>
-         <attribute name="buttonGroup">
-          <string notr="true">buttonGroupTooltips</string>
-         </attribute>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="radioButtonTooltipsLibrary">
-         <property name="text">
-          <string>Library only</string>
-         </property>
-         <attribute name="buttonGroup">
-          <string notr="true">buttonGroupTooltips</string>
-         </attribute>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="radioButtonTooltipsLibraryAndSkin">
-         <property name="text">
-          <string>Library and Skin</string>
-         </property>
-         <attribute name="buttonGroup">
-          <string notr="true">buttonGroupTooltips</string>
-         </attribute>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="labelTooltips">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="font">
-        <font/>
-       </property>
-       <property name="text">
-        <string>Tool tips</string>
-       </property>
-       <property name="wordWrap">
-        <bool>false</bool>
-       </property>
-       <property name="buddy">
-        <cstring>radioButtonTooltipsOff</cstring>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/preferences/dialog/dlgprefcontrolsdlg.ui
+++ b/src/preferences/dialog/dlgprefcontrolsdlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>490</width>
-    <height>677</height>
+    <height>682</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -97,26 +97,6 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="labelDoubleWidgetOption">
-        <property name="text">
-         <string>HiDPI / Retina scaling</string>
-        </property>
-        <property name="buddy">
-         <cstring>checkBoxScaleFactorAuto</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QComboBox" name="comboBoxScaleFactor"/>
-      </item>
-      <item row="4" column="2">
-       <widget class="QCheckBox" name="checkBoxScaleFactorAuto">
-        <property name="text">
-         <string>Auto Scaling</string>
-        </property>
-       </widget>
-      </item>
       <item row="5" column="0">
        <widget class="QLabel" name="textLabelLocale">
         <property name="text">
@@ -134,7 +114,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="labelFullscreenOption">
         <property name="text">
          <string>Full-screen mode</string>
@@ -144,14 +124,14 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1" colspan="2">
+      <item row="7" column="1" colspan="2">
        <widget class="QCheckBox" name="checkBoxStartFullScreen">
         <property name="text">
          <string>Start in full-screen mode</string>
         </property>
        </widget>
       </item>
-      <item row="8" column="0">
+      <item row="9" column="0">
        <widget class="QLabel" name="labelTooltips">
         <property name="enabled">
          <bool>true</bool>
@@ -170,7 +150,7 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="1" colspan="2">
+      <item row="9" column="1" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QRadioButton" name="radioButtonTooltipsOff">
@@ -203,6 +183,33 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="labelDoubleWidgetOption">
+        <property name="text">
+         <string>HiDPI / Retina scaling</string>
+        </property>
+        <property name="buddy">
+         <cstring>checkBoxScaleFactorAuto</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QComboBox" name="comboBoxScaleFactor">
+        <property name="toolTip">
+         <string>Change the size of text, buttons, and other items.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2">
+       <widget class="QCheckBox" name="checkBoxScaleFactorAuto">
+        <property name="toolTip">
+         <string>Adopt scale factor from the Os </string>
+        </property>
+        <property name="text">
+         <string>Auto Scaling</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/preferences/dialog/dlgprefcontrolsdlg.ui
+++ b/src/preferences/dialog/dlgprefcontrolsdlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>562</width>
-    <height>632</height>
+    <height>711</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -185,7 +185,7 @@
        </layout>
       </item>
       <item row="6" column="0">
-       <widget class="QLabel" name="labelDoubleWidgetOption">
+       <widget class="QLabel" name="labelScaleFactor">
         <property name="text">
          <string>HiDPI / Retina scaling</string>
         </property>
@@ -278,39 +278,39 @@ CUP mode:
        </widget>
       </item>
       <item row="1" column="1" colspan="2">
-        <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-            <widget class="QRadioButton" name="radioButtonElapsed">
-            <property name="text">
-              <string>Elapsed</string>
-            </property>
-            <attribute name="buttonGroup">
-              <string notr="true">buttonGroupTrackTime</string>
-            </attribute>
-            </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="radioButtonRemaining">
-             <property name="text">
-             <string>Remaining</string>
-           </property>
-           <attribute name="buttonGroup">
-             <string notr="true">buttonGroupTrackTime</string>
-           </attribute>
-           </widget>
-          </item>
-          <item>
-            <widget class="QRadioButton" name="radioButtonElapsedAndRemaining">
-              <property name="text">
-            <string>Elapsed and Remaining</string>
-            </property>
-              <attribute name="buttonGroup">
-                <string notr="true">buttonGroupTrackTime</string>
-              </attribute>
-          </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QRadioButton" name="radioButtonElapsed">
+          <property name="text">
+           <string>Elapsed</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupTrackTime</string>
+          </attribute>
+         </widget>
         </item>
-      </layout>
-     </item>
+        <item>
+         <widget class="QRadioButton" name="radioButtonRemaining">
+          <property name="text">
+           <string>Remaining</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupTrackTime</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioButtonElapsedAndRemaining">
+          <property name="text">
+           <string>Elapsed and Remaining</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupTrackTime</string>
+          </attribute>
+         </widget>
+        </item>
+       </layout>
+      </item>
       <item row="2" column="0">
        <widget class="QLabel" name="labelAutoCue">
         <property name="text">

--- a/src/skin/colorschemeparser.cpp
+++ b/src/skin/colorschemeparser.cpp
@@ -41,15 +41,7 @@ void ColorSchemeParser::setupLegacyColorSchemes(QDomElement docElem,
             WPixmapStore::setLoader(imsrc);
             WImageStore::setLoader(imsrc);
             WSkinColor::setLoader(imsrc);
-        } else {
-            WPixmapStore::setLoader(QSharedPointer<ImgSource>());
-            WImageStore::setLoader(QSharedPointer<ImgSource>());
-            WSkinColor::setLoader(QSharedPointer<ImgSource>());
         }
-    } else {
-        WPixmapStore::setLoader(QSharedPointer<ImgSource>());
-        WImageStore::setLoader(QSharedPointer<ImgSource>());
-        WSkinColor::setLoader(QSharedPointer<ImgSource>());
     }
 }
 

--- a/src/skin/colorschemeparser.cpp
+++ b/src/skin/colorschemeparser.cpp
@@ -53,13 +53,11 @@ void ColorSchemeParser::setupLegacyColorSchemes(QDomElement docElem,
 }
 
 ImgSource* ColorSchemeParser::parseFilters(QDomNode filt) {
+    ImgSource* ret = new ImgLoader();
 
-    // TODO: Move this code into ImgSource
     if (!filt.hasChildNodes()) {
-        return 0;
+        return ret;
     }
-
-    ImgSource * ret = new ImgLoader();
 
     QDomNode f = filt.firstChild();
 

--- a/src/skin/colorschemeparser.cpp
+++ b/src/skin/colorschemeparser.cpp
@@ -15,11 +15,11 @@ void ColorSchemeParser::setupLegacyColorSchemes(QDomElement docElem,
                                                 UserSettingsPointer pConfig) {
     QDomNode colsch = docElem.namedItem("Schemes");
 
+    bool found = false;
+
     if (!colsch.isNull() && colsch.isElement()) {
         QString schname = pConfig->getValueString(ConfigKey("[Config]","Scheme"));
         QDomNode sch = colsch.firstChild();
-
-        bool found = false;
 
         if (schname.isEmpty()) {
             // If no scheme stored, accept the first one in the file
@@ -42,6 +42,13 @@ void ColorSchemeParser::setupLegacyColorSchemes(QDomElement docElem,
             WImageStore::setLoader(imsrc);
             WSkinColor::setLoader(imsrc);
         }
+    }
+    if (!found) {
+        QSharedPointer<ImgSource> imsrc =
+                QSharedPointer<ImgSource>(new ImgLoader());
+        WPixmapStore::setLoader(imsrc);
+        WImageStore::setLoader(imsrc);
+        WSkinColor::setLoader(imsrc);
     }
 }
 

--- a/src/skin/imgcolor.cpp
+++ b/src/skin/imgcolor.cpp
@@ -1,33 +1,29 @@
 #include "imgcolor.h"
 
-QColor ImgHueInv::doColorCorrection(QColor c) {
-    int h, s, v, a;
-    c.getHsv(&h, &s, &v, &a);
-    int r, g, b;
-    c.getRgb(&r, &g, &b);
-    c.setRgb(0xff - r, 0xff - g, 0xff - b);
-    int hi, si, vi;
-    c.getHsv(&hi, &si, &vi);
-    c.setHsv(hi, s, v, a);
-    return c;
+QColor ImgHueInv::doColorCorrection(const QColor& c) const {
+    int r, g, b, a;
+    c.getRgb(&r, &g, &b, &a);
+    return QColor(0xff - r, 0xff - g, 0xff - b, a);
 }
 
-QColor ImgHueRot::doColorCorrection(QColor c) {
+QColor ImgHueRot::doColorCorrection(const QColor& c) const {
     int h, s, v, a;
     c.getHsv(&h, &s, &v, &a);
     h = (h + m_amt) % 256;
     if (h < 0) { h += 256; }
-    c.setHsv(h, s, v, a);
-    return c;
+    QColor ret;
+    ret.setHsv(h, s, v, a);
+    return ret;
 }
 
-QColor ImgScaleWhite::doColorCorrection(QColor c) {
+QColor ImgScaleWhite::doColorCorrection(const QColor& c) const {
     int h, s, v, a;
     c.getHsv(&h, &s, &v, &a);
     if (s < 50) { v *= m_amt; }
     if (v > 255) { v = 255; }
-    c.setHsv(h, s, v, a);
-    return c;
+    QColor ret;
+    ret.setHsv(h, s, v, a);
+    return ret;
 }
 
 ImgAdd::ImgAdd(ImgSource * parent, int amt)
@@ -35,7 +31,7 @@ ImgAdd::ImgAdd(ImgSource * parent, int amt)
     // Nothing left to do
 }
 
-QColor ImgAdd::doColorCorrection(QColor c) {
+QColor ImgAdd::doColorCorrection(const QColor& c) const {
     int r = c.red() + m_amt;
     int g = c.green() + m_amt;
     int b = c.blue() + m_amt;
@@ -52,7 +48,7 @@ ImgMax::ImgMax(ImgSource * parent, int amt)
     : ImgColorProcessor(parent), m_amt(amt) {
 }
 
-QColor ImgMax::doColorCorrection(QColor c) {
+QColor ImgMax::doColorCorrection(const QColor& c) const {
     int r = c.red();
     int g = c.green();
     int b = c.blue();
@@ -63,7 +59,7 @@ QColor ImgMax::doColorCorrection(QColor c) {
 }
 
 
-QColor ImgHSVTweak::doColorCorrection(QColor c) {
+QColor ImgHSVTweak::doColorCorrection(const QColor& c) const {
     int h, s, v, a;
     c.getHsv(&h, &s, &v, &a);
 
@@ -83,7 +79,9 @@ QColor ImgHSVTweak::doColorCorrection(QColor c) {
         if (v < 0) { v = 0; }
         if (v > 255) { v = 255; }
 
-        c.setHsv(h, s, v, a);
+        QColor ret;
+        ret.setHsv(h, s, v, a);
+        return ret;
     }
     return c;
 }

--- a/src/skin/imgcolor.h
+++ b/src/skin/imgcolor.h
@@ -24,7 +24,7 @@ class ImgAdd : public ImgColorProcessor {
 
 public:
     ImgAdd(ImgSource* parent, int amt);
-    virtual QColor doColorCorrection(QColor c);
+    QColor doColorCorrection(const QColor& c) const override;
 
 private:
     int m_amt;
@@ -34,7 +34,7 @@ class ImgMax : public ImgColorProcessor {
 
 public:
     ImgMax(ImgSource* parent, int amt);
-    virtual QColor doColorCorrection(QColor c);
+    QColor doColorCorrection(const QColor& c) const override;
 
 private:
     int m_amt;
@@ -45,7 +45,7 @@ class ImgScaleWhite : public ImgColorProcessor {
 public:
     inline ImgScaleWhite(ImgSource* parent, float amt)
         : ImgColorProcessor(parent), m_amt(amt) {}
-    virtual QColor doColorCorrection(QColor c);
+    QColor doColorCorrection(const QColor& c) const override;
 private:
     float m_amt;
 };
@@ -55,7 +55,7 @@ class ImgHueRot : public ImgColorProcessor {
 public:
     inline ImgHueRot(ImgSource* parent, int amt)
         : ImgColorProcessor(parent), m_amt(amt) {}
-    virtual QColor doColorCorrection(QColor c);
+    QColor doColorCorrection(const QColor& c) const override;
 
 private:
     int m_amt;
@@ -65,7 +65,7 @@ class ImgHueInv : public ImgColorProcessor {
 
 public:
     inline ImgHueInv(ImgSource* parent) : ImgColorProcessor(parent) {}
-    virtual QColor doColorCorrection(QColor c);
+    QColor doColorCorrection(const QColor& c) const override;
 };
 
 class ImgHSVTweak : public ImgColorProcessor {
@@ -79,7 +79,7 @@ class ImgHSVTweak : public ImgColorProcessor {
               m_vmin(vmin), m_vmax(vmax),
               m_hconst(hconst), m_sconst(sconst), m_vconst(vconst),
               m_hfact(hfact), m_sfact(sfact), m_vfact(vfact) {}
-    virtual QColor doColorCorrection(QColor c);
+    QColor doColorCorrection(const QColor& c) const override;
 
   private:
     int m_hmin, m_hmax,

--- a/src/skin/imginvert.cpp
+++ b/src/skin/imginvert.cpp
@@ -1,6 +1,6 @@
 #include "imginvert.h"
 
-QColor ImgInvert::doColorCorrection(QColor c) {
+QColor ImgInvert::doColorCorrection(const QColor& c) const {
     return QColor(0xff - c.red(),
                   0xff - c.green(),
                   0xff - c.blue(),

--- a/src/skin/imginvert.h
+++ b/src/skin/imginvert.h
@@ -24,7 +24,7 @@ class ImgInvert : public ImgColorProcessor {
 
 public:
     inline ImgInvert(ImgSource* parent) : ImgColorProcessor(parent) {}
-    virtual QColor doColorCorrection(QColor c);
+    QColor doColorCorrection(const QColor& c) const override;
 };
 
 #endif

--- a/src/skin/imgloader.cpp
+++ b/src/skin/imgloader.cpp
@@ -4,7 +4,7 @@
 ImgLoader::ImgLoader() {
 }
 
-QImage * ImgLoader::getImage(QString img) {
+QImage* ImgLoader::getImage(QString img) {
     return new QImage(img);
 }
 

--- a/src/skin/imgloader.cpp
+++ b/src/skin/imgloader.cpp
@@ -38,13 +38,46 @@ QImage* ImgLoader::getImage(const QString& fileName, double scaleFactor) const {
         }
     }
 
-    QImageReader reader(fileName);
-    QSize originalSize = reader.size();
-    if (originalSize.isValid()) {
-        QSize scale = originalSize * scaleFactor;
-        reader.setScaledSize(scale);
-        reader.read(pImage);
-        return pImage;
+    {
+        QImageReader reader(fileName);
+        QSize originalSize = reader.size();
+        if (originalSize.isValid()) {
+            QSize scale = originalSize * scaleFactor;
+            reader.setScaledSize(scale);
+            reader.read(pImage);
+            return pImage;
+        }
+    }
+
+    // No Image found, matching the desired resolution or lower.
+    // try to load a bigger Images.
+
+    {
+        // Try to load with @2x suffix
+        QString strNewName = info.path() + "/" + info.baseName() + "@2x."
+                + info.completeSuffix();
+        QImageReader reader(info.fileName());
+        QSize originalSize = reader.size();
+        if (originalSize.isValid()) {
+            QSize scale = originalSize * (scaleFactor / 2.0);
+            reader.setScaledSize(scale);
+            reader.read(pImage);
+            return pImage;
+        }
+    }
+
+    {
+        // Try to load with @3x suffix
+        QString strNewName = info.path() + "/" + info.baseName() + "@3x."
+                + info.completeSuffix();
+        QImageReader reader(info.fileName());
+        QSize originalSize = reader.size();
+        if (originalSize.isValid()) {
+            QSize scale = originalSize * (scaleFactor / 3.0);
+            reader.setScaledSize(scale);
+            reader.read(pImage);
+            return pImage;
+        }
     }
 
     return pImage;

--- a/src/skin/imgloader.cpp
+++ b/src/skin/imgloader.cpp
@@ -1,10 +1,52 @@
+
+#include <QImageReader>
+#include <QFileInfo>
+
 #include "imgloader.h"
 #include "widget/wwidget.h"
 
 ImgLoader::ImgLoader() {
 }
 
-QImage* ImgLoader::getImage(const QString& fileName) const {
-    return new QImage(fileName);
+QImage* ImgLoader::getImage(const QString& fileName, double scaleFactor) const {
+    QImage* pImage = new QImage();
+    QFileInfo info(fileName);
+    if (scaleFactor > 2.0) {
+        // Try to load with @3x suffix
+        QString strNewName = info.path() + "/" + info.baseName() + "@3x."
+                + info.completeSuffix();
+        QImageReader reader(info.fileName());
+        QSize originalSize = reader.size();
+        if (originalSize.isValid()) {
+            QSize scale = originalSize * (scaleFactor / 3.0);
+            reader.setScaledSize(scale);
+            reader.read(pImage);
+            return pImage;
+        }
+    }
+    if (scaleFactor > 1.0) {
+        // Try to load with @2x suffix
+        QString strNewName = info.path() + "/" + info.baseName() + "@2x."
+                + info.completeSuffix();
+        QImageReader reader(info.fileName());
+        QSize originalSize = reader.size();
+        if (originalSize.isValid()) {
+            QSize scale = originalSize * (scaleFactor / 2.0);
+            reader.setScaledSize(scale);
+            reader.read(pImage);
+            return pImage;
+        }
+    }
+
+    QImageReader reader(fileName);
+    QSize originalSize = reader.size();
+    if (originalSize.isValid()) {
+        QSize scale = originalSize * scaleFactor;
+        reader.setScaledSize(scale);
+        reader.read(pImage);
+        return pImage;
+    }
+
+    return pImage;
 }
 

--- a/src/skin/imgloader.cpp
+++ b/src/skin/imgloader.cpp
@@ -4,7 +4,7 @@
 ImgLoader::ImgLoader() {
 }
 
-QImage* ImgLoader::getImage(QString img) {
-    return new QImage(img);
+QImage* ImgLoader::getImage(const QString& fileName) const {
+    return new QImage(fileName);
 }
 

--- a/src/skin/imgloader.h
+++ b/src/skin/imgloader.h
@@ -24,7 +24,7 @@ class ImgLoader : public ImgSource {
 
 public:
     ImgLoader();
-    virtual QImage* getImage(QString img);
+    QImage* getImage(const QString &fileName) const override;
 };
 
 #endif

--- a/src/skin/imgloader.h
+++ b/src/skin/imgloader.h
@@ -24,7 +24,7 @@ class ImgLoader : public ImgSource {
 
 public:
     ImgLoader();
-    QImage* getImage(const QString &fileName) const override;
+    QImage* getImage(const QString &fileName, double scaleFactor) const override;
 };
 
 #endif

--- a/src/skin/imgsource.h
+++ b/src/skin/imgsource.h
@@ -27,7 +27,7 @@
 class ImgSource {
   public:
     virtual ~ImgSource() {};
-    virtual QImage* getImage(const QString& fileName) const = 0;
+    virtual QImage* getImage(const QString& fileName, double scaleFactor) const = 0;
     virtual QColor getCorrectColor(const QColor& c) const { return c; }
     virtual void correctImageColors(QImage* p) const { (void)p; };
 };
@@ -54,8 +54,8 @@ public:
 
     inline ImgColorProcessor(ImgSource* parent) : ImgProcessor(parent) {}
 
-    QImage* getImage(const QString& fileName) const override {
-        QImage* i = m_parent->getImage(fileName);
+    QImage* getImage(const QString& fileName, double scaleFactor) const override {
+        QImage* i = m_parent->getImage(fileName, scaleFactor);
         correctImageColors(i);
         return i;
     }

--- a/src/skin/imgsource.h
+++ b/src/skin/imgsource.h
@@ -27,21 +27,21 @@
 class ImgSource {
   public:
     virtual ~ImgSource() {};
-    virtual QImage* getImage(QString img) = 0;
-    virtual inline QColor getCorrectColor(QColor c) { return c; }
-    virtual void correctImageColors(QImage* p) { (void)p; };
+    virtual QImage* getImage(const QString& fileName) const = 0;
+    virtual QColor getCorrectColor(const QColor& c) const { return c; }
+    virtual void correctImageColors(QImage* p) const { (void)p; };
 };
 
 class ImgProcessor : public ImgSource {
 
   public:
-    virtual ~ImgProcessor() {};
+    ~ImgProcessor() override {};
     inline ImgProcessor(ImgSource* parent) : m_parent(parent) {}
-    virtual QColor doColorCorrection(QColor c) = 0;
-    inline QColor getCorrectColor(QColor c) {
+    virtual QColor doColorCorrection(const QColor& c) const = 0;
+    QColor getCorrectColor(const QColor& c) const override {
         return doColorCorrection(m_parent->getCorrectColor(c));
     }
-    virtual void correctImageColors(QImage* p) { (void)p; };
+    void correctImageColors(QImage* p) const override { (void)p; };
 
   protected:
     ImgSource* m_parent;
@@ -54,13 +54,13 @@ public:
 
     inline ImgColorProcessor(ImgSource* parent) : ImgProcessor(parent) {}
 
-    inline virtual QImage* getImage(QString img) {
-        QImage* i = m_parent->getImage(img);
+    QImage* getImage(const QString& fileName) const override {
+        QImage* i = m_parent->getImage(fileName);
         correctImageColors(i);
         return i;
     }
 
-    virtual void correctImageColors(QImage* i) {
+    void correctImageColors(QImage* i) const override {
         if (i == NULL || i->isNull()) {
             return;
         }

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -143,7 +143,8 @@ LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig)
           m_pLibrary(NULL),
           m_pVCManager(NULL),
           m_pEffectsManager(NULL),
-          m_pParent(NULL) {
+          m_pParent(NULL),
+          m_scaleFactor(1.0) {
 }
 
 LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig,
@@ -160,7 +161,8 @@ LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig,
           m_pLibrary(pLibrary),
           m_pVCManager(pVCMan),
           m_pEffectsManager(pEffectsManager),
-          m_pParent(NULL) {
+          m_pParent(NULL),
+          m_scaleFactor(1.0) {
 }
 
 LegacySkinParser::~LegacySkinParser() {
@@ -366,8 +368,7 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
     ColorSchemeParser::setupLegacyColorSchemes(skinDocument, m_pConfig);
 
     // Load the config option once, here, rather than in setupSize.
-    // DoubleWidgetSize is boolean, so we add 1 to get the multiplier 1 or 2
-    m_scaleFactor = m_pConfig->getValueString(ConfigKey("[Config]","DoubleWidgetSize"), "0").toInt() + 1;
+    m_scaleFactor = m_pConfig->getValue(ConfigKey("[Config]","ScaleFactor"), 1.0);
 
     QStringList skinPaths(skinPath);
     QDir::setSearchPaths("skin", skinPaths);

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1653,10 +1653,10 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
         QString ys = size.mid(comma+1);
 
         bool widthOk = false;
-        int x = xs.toInt(&widthOk);
+        int x = xs.toInt(&widthOk) * 2;
 
         bool heightOk = false;
-        int y = ys.toInt(&heightOk);
+        int y = ys.toInt(&heightOk) * 2;
 
         // -1 means do not set.
         if (widthOk && heightOk && x >= 0 && y >= 0) {
@@ -1678,10 +1678,10 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
         QString ys = size.mid(comma+1);
 
         bool widthOk = false;
-        int x = xs.toInt(&widthOk);
+        int x = xs.toInt(&widthOk) * 2;
 
         bool heightOk = false;
-        int y = ys.toInt(&heightOk);
+        int y = ys.toInt(&heightOk) * 2;
 
         // -1 means do not set.
         if (widthOk && heightOk && x >= 0 && y >= 0) {
@@ -1746,7 +1746,7 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
         }
 
         bool widthOk = false;
-        int x = xs.toInt(&widthOk);
+        int x = xs.toInt(&widthOk) * 2;
         if (widthOk && x >= 0) {
             if (hasHorizontalPolicy &&
                     sizePolicy.horizontalPolicy() == QSizePolicy::Fixed) {
@@ -1759,7 +1759,7 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
         }
 
         bool heightOk = false;
-        int y = ys.toInt(&heightOk);
+        int y = ys.toInt(&heightOk) * 2;
         if (heightOk && y >= 0) {
             if (hasVerticalPolicy &&
                     sizePolicy.verticalPolicy() == QSizePolicy::Fixed) {

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1789,6 +1789,31 @@ QString LegacySkinParser::getStyleFromNode(const QDomNode& node) {
             style = QString::fromLocal8Bit(fileBytes.constData(),
                                            fileBytes.length());
         }
+
+        double scaleFactor = m_pContext->getScaleFactor();
+        if (scaleFactor >= 3) {
+            // Try to load with @3x suffix
+            QFileInfo info(file);
+            QString strNewName = info.path() + "/" + info.baseName() + "@3x."
+                    + info.completeSuffix();
+            QFile file(strNewName);
+            if (file.open(QIODevice::ReadOnly)) {
+                QByteArray fileBytes = file.readAll();
+                style.prepend(QString::fromLocal8Bit(fileBytes.constData(),
+                                               fileBytes.length()));
+            }
+        } else if (scaleFactor >= 2) {
+            // Try to load with @3x suffix
+            QFileInfo info(file);
+            QString strNewName = info.path() + "/" + info.baseName() + "@2x."
+                    + info.completeSuffix();
+            QFile file(strNewName);
+            if (file.open(QIODevice::ReadOnly)) {
+                QByteArray fileBytes = file.readAll();
+                style.prepend(QString::fromLocal8Bit(fileBytes.constData(),
+                                               fileBytes.length()));
+            }
+        }
     } else {
         // If no src attribute, use the node data as text.
         style = styleElement.text();

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1611,8 +1611,10 @@ QWidget* LegacySkinParser::parseEffectButtonParameterName(const QDomElement& nod
 void LegacySkinParser::setupPosition(const QDomNode& node, QWidget* pWidget) {
     QString pos;
     if (m_pContext->hasNodeSelectString(node, "Pos", &pos)) {
-        int x = pos.left(pos.indexOf(",")).toInt();
-        int y = pos.mid(pos.indexOf(",")+1).toInt();
+        QString xs = pos.left(pos.indexOf(","));
+        QString ys = pos.mid(pos.indexOf(",") + 1);
+        int x = m_pContext->scaleToWidgetSize(xs);
+        int y = m_pContext->scaleToWidgetSize(ys);
         pWidget->move(x,y);
     }
 }

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -365,6 +365,10 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
 
     ColorSchemeParser::setupLegacyColorSchemes(skinDocument, m_pConfig);
 
+    // Load the config option once, here, rather than in setupSize.
+    // DoubleWidgetSize is boolean, so we add 1 to get the multiplier 1 or 2
+    m_scaleFactor = m_pConfig->getValueString(ConfigKey("[Config]","DoubleWidgetSize"), "0").toInt() + 1;
+
     QStringList skinPaths(skinPath);
     QDir::setSearchPaths("skin", skinPaths);
 
@@ -1653,10 +1657,10 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
         QString ys = size.mid(comma+1);
 
         bool widthOk = false;
-        int x = xs.toInt(&widthOk) * 2;
+        int x = xs.toInt(&widthOk) * m_scaleFactor;
 
         bool heightOk = false;
-        int y = ys.toInt(&heightOk) * 2;
+        int y = ys.toInt(&heightOk) * m_scaleFactor;
 
         // -1 means do not set.
         if (widthOk && heightOk && x >= 0 && y >= 0) {
@@ -1678,10 +1682,10 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
         QString ys = size.mid(comma+1);
 
         bool widthOk = false;
-        int x = xs.toInt(&widthOk) * 2;
+        int x = xs.toInt(&widthOk) * m_scaleFactor;
 
         bool heightOk = false;
-        int y = ys.toInt(&heightOk) * 2;
+        int y = ys.toInt(&heightOk) * m_scaleFactor;
 
         // -1 means do not set.
         if (widthOk && heightOk && x >= 0 && y >= 0) {
@@ -1746,7 +1750,7 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
         }
 
         bool widthOk = false;
-        int x = xs.toInt(&widthOk) * 2;
+        int x = xs.toInt(&widthOk) * m_scaleFactor;
         if (widthOk && x >= 0) {
             if (hasHorizontalPolicy &&
                     sizePolicy.horizontalPolicy() == QSizePolicy::Fixed) {
@@ -1759,7 +1763,7 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
         }
 
         bool heightOk = false;
-        int y = ys.toInt(&heightOk) * 2;
+        int y = ys.toInt(&heightOk) * m_scaleFactor;
         if (heightOk && y >= 0) {
             if (hasVerticalPolicy &&
                     sizePolicy.verticalPolicy() == QSizePolicy::Fixed) {

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1790,6 +1790,10 @@ QString LegacySkinParser::getStyleFromNode(const QDomNode& node) {
                                            fileBytes.length());
         }
 
+// This section can be enabled on demand. It is useful to tweak
+// pixel sized values for different scalings. But we should know if this is
+// actually used when migrating to Qt5
+#if 0
         // now load style files with suffix for HiDPI scaling.
         // We follow here the Gnome/Unity scaling slider approach, where
         // the widgets are scaled by an integer value once the slider is
@@ -1820,6 +1824,7 @@ QString LegacySkinParser::getStyleFromNode(const QDomNode& node) {
                                                fileBytes.length()));
             }
         }
+#endif
     } else {
         // If no src attribute, use the node data as text.
         style = styleElement.text();

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1790,6 +1790,12 @@ QString LegacySkinParser::getStyleFromNode(const QDomNode& node) {
                                            fileBytes.length());
         }
 
+        // now load style files with suffix for HiDPI scaling.
+        // We follow here the Gnome/Unity scaling slider approach, where
+        // the widgets are scaled by an integer value once the slider is
+        // greater or equal to the next integer step.
+        // This should help to scale the GUI along with the native widgets once
+        // we are on Qt 5.
         double scaleFactor = m_pContext->getScaleFactor();
         if (scaleFactor >= 3) {
             // Try to load with @3x suffix
@@ -1803,7 +1809,7 @@ QString LegacySkinParser::getStyleFromNode(const QDomNode& node) {
                                                fileBytes.length()));
             }
         } else if (scaleFactor >= 2) {
-            // Try to load with @3x suffix
+            // Try to load with @2x suffix
             QFileInfo info(file);
             QString strNewName = info.path() + "/" + info.baseName() + "@2x."
                     + info.completeSuffix();

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -809,7 +809,7 @@ QWidget* LegacySkinParser::parseBackground(const QDomElement& node,
 
     QString filename = m_pContext->selectString(node, "Path");
     QPixmap* background = WPixmapStore::getPixmapNoCache(
-        m_pContext->getSkinPath(filename));
+        m_pContext->getSkinPath(filename), m_pContext->getScaleFactor());
 
     bg->move(0, 0);
     if (background != NULL && !background->isNull()) {

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -143,8 +143,7 @@ LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig)
           m_pLibrary(NULL),
           m_pVCManager(NULL),
           m_pEffectsManager(NULL),
-          m_pParent(NULL),
-          m_scaleFactor(1.0) {
+          m_pParent(NULL) {
 }
 
 LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig,
@@ -161,8 +160,7 @@ LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig,
           m_pLibrary(pLibrary),
           m_pVCManager(pVCMan),
           m_pEffectsManager(pEffectsManager),
-          m_pParent(NULL),
-          m_scaleFactor(1.0) {
+          m_pParent(NULL) {
 }
 
 LegacySkinParser::~LegacySkinParser() {
@@ -366,9 +364,6 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
     }
 
     ColorSchemeParser::setupLegacyColorSchemes(skinDocument, m_pConfig);
-
-    // Load the config option once, here, rather than in setupSize.
-    m_scaleFactor = m_pConfig->getValue(ConfigKey("[Config]","ScaleFactor"), 1.0);
 
     QStringList skinPaths(skinPath);
     QDir::setSearchPaths("skin", skinPaths);
@@ -1625,25 +1620,25 @@ void LegacySkinParser::setupPosition(const QDomNode& node, QWidget* pWidget) {
 bool parseSizePolicy(QString* input, QSizePolicy::Policy* policy) {
     if (input->endsWith("me")) {
         *policy = QSizePolicy::MinimumExpanding;
-        *input = input->left(input->size()-2);
+        *input = input->left(input->size() - 2);
     } else if (input->endsWith("e")) {
         *policy = QSizePolicy::Expanding;
-        *input = input->left(input->size()-1);
+        *input = input->left(input->size() - 1);
     } else if (input->endsWith("i")) {
         *policy = QSizePolicy::Ignored;
-        *input = input->left(input->size()-1);
+        *input = input->left(input->size() - 1);
     } else if (input->endsWith("min")) {
         *policy = QSizePolicy::Minimum;
-        *input = input->left(input->size()-3);
+        *input = input->left(input->size() - 3);
     } else if (input->endsWith("max")) {
         *policy = QSizePolicy::Maximum;
-        *input = input->left(input->size()-3);
+        *input = input->left(input->size() - 3);
     } else if (input->endsWith("p")) {
         *policy = QSizePolicy::Preferred;
-        *input = input->left(input->size()-1);
+        *input = input->left(input->size() - 1);
     } else if (input->endsWith("f")) {
         *policy = QSizePolicy::Fixed;
-        *input = input->left(input->size()-1);
+        *input = input->left(input->size() - 1);
     } else {
         return false;
     }
@@ -1655,22 +1650,19 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
     if (m_pContext->hasNodeSelectString(node, "MinimumSize", &size)) {
         int comma = size.indexOf(",");
         QString xs = size.left(comma);
-        QString ys = size.mid(comma+1);
+        QString ys = size.mid(comma + 1);
 
-        bool widthOk = false;
-        int x = xs.toInt(&widthOk) * m_scaleFactor;
-
-        bool heightOk = false;
-        int y = ys.toInt(&heightOk) * m_scaleFactor;
+        int x = m_pContext->scaleToWidgetSize(xs);
+        int y = m_pContext->scaleToWidgetSize(ys);
 
         // -1 means do not set.
-        if (widthOk && heightOk && x >= 0 && y >= 0) {
+        if (x >= 0 && y >= 0) {
             pWidget->setMinimumSize(x, y);
-        } else if (widthOk && x >= 0) {
+        } else if (x >= 0) {
             pWidget->setMinimumWidth(x);
-        } else if (heightOk && y >= 0) {
+        } else if (y >= 0) {
             pWidget->setMinimumHeight(y);
-        } else if (!widthOk && !heightOk) {
+        } else {
             SKIN_WARNING(node, *m_pContext)
                     << "Could not parse widget MinimumSize:" << size;
         }
@@ -1682,20 +1674,17 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
         QString xs = size.left(comma);
         QString ys = size.mid(comma+1);
 
-        bool widthOk = false;
-        int x = xs.toInt(&widthOk) * m_scaleFactor;
-
-        bool heightOk = false;
-        int y = ys.toInt(&heightOk) * m_scaleFactor;
+        int x = m_pContext->scaleToWidgetSize(xs);
+        int y = m_pContext->scaleToWidgetSize(ys);
 
         // -1 means do not set.
-        if (widthOk && heightOk && x >= 0 && y >= 0) {
+        if (x >= 0 && y >= 0) {
             pWidget->setMaximumSize(x, y);
-        } else if (widthOk && x >= 0) {
+        } else if (x >= 0) {
             pWidget->setMaximumWidth(x);
-        } else if (heightOk && y >= 0) {
+        } else if (y >= 0) {
             pWidget->setMaximumHeight(y);
-        } else if (!widthOk && !heightOk) {
+        } else {
             SKIN_WARNING(node, *m_pContext)
                     << "Could not parse widget MaximumSize:" << size;
         }
@@ -1750,9 +1739,8 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
             hasVerticalPolicy = true;
         }
 
-        bool widthOk = false;
-        int x = xs.toInt(&widthOk) * m_scaleFactor;
-        if (widthOk && x >= 0) {
+        int x = m_pContext->scaleToWidgetSize(xs);
+        if (x >= 0) {
             if (hasHorizontalPolicy &&
                     sizePolicy.horizontalPolicy() == QSizePolicy::Fixed) {
                 //qDebug() << "setting width fixed to" << x;
@@ -1763,9 +1751,8 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
             }
         }
 
-        bool heightOk = false;
-        int y = ys.toInt(&heightOk) * m_scaleFactor;
-        if (heightOk && y >= 0) {
+        int y = m_pContext->scaleToWidgetSize(ys);
+        if (y >= 0) {
             if (hasVerticalPolicy &&
                     sizePolicy.verticalPolicy() == QSizePolicy::Fixed) {
                 //qDebug() << "setting height fixed to" << x;

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -144,7 +144,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     static QList<const char*> s_channelStrs;
     static QMutex s_safeStringMutex;
 
-    int m_scaleFactor = 1;
+    double m_scaleFactor;
 };
 
 

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -143,6 +143,8 @@ class LegacySkinParser : public QObject, public SkinParser {
     QHash<QString, QDomElement> m_templateCache;
     static QList<const char*> s_channelStrs;
     static QMutex s_safeStringMutex;
+
+    int m_scaleFactor = 1;
 };
 
 

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -143,8 +143,6 @@ class LegacySkinParser : public QObject, public SkinParser {
     QHash<QString, QDomElement> m_templateCache;
     static QList<const char*> s_channelStrs;
     static QMutex s_safeStringMutex;
-
-    double m_scaleFactor;
 };
 
 

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -30,6 +30,9 @@ SkinContext::SkinContext(UserSettingsPointer pConfig,
     if (!hooksPattern.isNull()) {
         m_hookRx.setPattern(hooksPattern.toString());
     }
+
+    // Load the config option once, here, rather than in setupSize.
+    m_scaleFactor = m_pConfig->getValue(ConfigKey("[Config]","ScaleFactor"), 1.0);
 }
 
 SkinContext::SkinContext(const SkinContext& parent)
@@ -42,7 +45,8 @@ SkinContext::SkinContext(const SkinContext& parent)
           m_parentGlobal(m_pScriptEngine->globalObject()),
           m_hookRx(parent.m_hookRx),
           m_pSvgCache(parent.m_pSvgCache),
-          m_pSingletons(parent.m_pSingletons) {
+          m_pSingletons(parent.m_pSingletons),
+          m_scaleFactor(parent.m_scaleFactor) {
     // we generate a new global object to preserve the scope between
     // a context and its children
     QScriptValue context = m_pScriptEngine->pushContext()->activationObject();
@@ -167,7 +171,7 @@ PixmapSource SkinContext::getPixmapSource(const QDomNode& pixmapNode) const {
         if (!svgNode.isNull()) {
             // inline svg
             const QByteArray rslt = svgParser.saveToQByteArray(
-                svgParser.parseSvgTree(svgNode, m_xmlPath));
+                    svgParser.parseSvgTree(svgNode, m_xmlPath));
             source.setSVG(rslt);
         } else {
             // filename.
@@ -255,4 +259,13 @@ QDebug SkinContext::logWarning(const char* file, const int line,
                                   node.nodeName())
                              .toUtf8()
                              .constData();
+}
+
+int SkinContext::scaleToWidgetSize(QString& size) const {
+    bool widthOk = false;
+    double dSize = size.toDouble(&widthOk);
+    if (widthOk && dSize >= 0) {
+        return static_cast<int>(std::round(dSize * m_scaleFactor));
+    }
+    return -1;
 }

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -32,8 +32,12 @@ SkinContext::SkinContext(UserSettingsPointer pConfig,
         m_hookRx.setPattern(hooksPattern.toString());
     }
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     // Load the config option once, here, rather than in setupSize.
     m_scaleFactor = m_pConfig->getValue(ConfigKey("[Config]","ScaleFactor"), 1.0);
+#else
+    m_scaleFactor = 1.0;
+#endif
 }
 
 SkinContext::SkinContext(const SkinContext& parent)

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -265,7 +265,7 @@ int SkinContext::scaleToWidgetSize(QString& size) const {
     bool widthOk = false;
     double dSize = size.toDouble(&widthOk);
     if (widthOk && dSize >= 0) {
-        return static_cast<int>(std::round(dSize * m_scaleFactor));
+        return static_cast<int>(round(dSize * m_scaleFactor));
     }
     return -1;
 }

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -7,6 +7,7 @@
 #include "skin/skincontext.h"
 #include "skin/svgparser.h"
 #include "util/cmdlineargs.h"
+#include "util/math.h"
 
 SkinContext::SkinContext(UserSettingsPointer pConfig,
                          const QString& xmlPath)

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -188,8 +188,9 @@ class SkinContext {
     PixmapSource getPixmapSource(const QDomNode& pixmapNode) const;
     PixmapSource getPixmapSource(const QString& filename) const;
 
-    inline Paintable::DrawMode selectScaleMode(const QDomElement& element,
-                                               Paintable::DrawMode defaultDrawMode) const {
+    inline Paintable::DrawMode selectScaleMode(
+            const QDomElement& element,
+            Paintable::DrawMode defaultDrawMode) const {
         QString drawModeStr;
         if (hasAttributeSelectString(element, "scalemode", &drawModeStr)) {
             return Paintable::DrawModeFromString(drawModeStr);
@@ -216,6 +217,12 @@ class SkinContext {
 
     const QRegExp& getHookRegex() const {
         return m_hookRx;
+    }
+
+    int scaleToWidgetSize(QString& size) const;
+
+    double getScaleFactor() const {
+        return m_scaleFactor;
     }
 
   private:
@@ -245,6 +252,7 @@ class SkinContext {
     // The SingletonContainer map is passed to child SkinContexts, so that all
     // templates in the tree can share a single map.
     QSharedPointer<SingletonMap> m_pSingletons;
+    double m_scaleFactor;
 };
 
 #endif /* SKINCONTEXT_H */

--- a/src/util/autohidpi.cpp
+++ b/src/util/autohidpi.cpp
@@ -1,0 +1,38 @@
+
+#include <QProcess>
+
+#include "util/autohidpi.h"
+
+#ifdef __WINDOWS__
+
+double AutoHiDpi::getScaleFactor() {
+    return -1;
+}
+
+#elif __APPLE__
+
+double AutoHiDpi::getScaleFactor() {
+    return -1;
+}
+
+#else
+
+double AutoHiDpi::getScaleFactor() {
+    QProcess gsettingsProcess;
+    QStringList args;
+    args.append("get");
+    args.append("org.gnome.desktop.interface");
+    args.append("scaling-factor");
+    gsettingsProcess.start("gsettings", args);
+    gsettingsProcess.waitForFinished();
+    QString output = gsettingsProcess.readAllStandardOutput();
+    // output is now "uint32 1" or "" if gsettings is not installed
+    bool ok;
+    double value = output.remove(0, 7).toDouble(&ok);
+    if (ok && value > 0) {
+        return value;
+    }
+    return 0;
+}
+
+#endif // __LINUX__

--- a/src/util/autohidpi.cpp
+++ b/src/util/autohidpi.cpp
@@ -1,11 +1,36 @@
 
 #include <QProcess>
+#include <QApplication>
+#include <QDesktopWidget>
+#include <QDebug>
 
 #include "util/autohidpi.h"
 
 #ifdef __WINDOWS__
 
 double AutoHiDpi::getScaleFactor() {
+    // Windows 10 has a percentage setting in preferences, which
+    // finally changes the screen DPI setting
+    // 96 dpi = 100%
+    // 120 dpi = 125%
+    // 144 dpi = 150%
+    // 192 dpi = 200%
+    // 240 dpi = 250%
+    // 288 dpi = 300%
+    int dpiX = QApplication::desktop()->logicalDpiX();
+    qDebug() << "AutoHiDpi::getScaleFactor()" << dpiX;
+    // This follows the strategy used in Gnome/Unity
+    // that the widget size is doubled once the font size
+    // reaches the double vale threshold
+    if (dpiX < 96) {
+        return -1;
+    } else if (dpiX < 192) {
+        return 1;
+    } else if (dpiX < 288) {
+        return 2;
+    } else if (dpiX == 288) {
+        return 3;
+    }
     return -1;
 }
 

--- a/src/util/autohidpi.h
+++ b/src/util/autohidpi.h
@@ -1,0 +1,10 @@
+
+#ifndef AUTOHIDPI_H_
+#define AUTOHIDPI_H_
+
+class AutoHiDpi {
+  public:
+    double getScaleFactor();
+};
+
+#endif /*AUTOHIDPI_H_ */

--- a/src/waveform/renderers/waveformrenderbackground.cpp
+++ b/src/waveform/renderers/waveformrenderbackground.cpp
@@ -3,6 +3,7 @@
 
 #include "widget/wskincolor.h"
 #include "widget/wwidget.h"
+#include "widget/wimagestore.h"
 
 WaveformRenderBackground::WaveformRenderBackground(
     WaveformWidgetRenderer* waveformWidgetRenderer)
@@ -16,12 +17,9 @@ WaveformRenderBackground::~WaveformRenderBackground() {
 void WaveformRenderBackground::setup(const QDomNode& node,
                                      const SkinContext& context) {
     m_backgroundColor = m_waveformRenderer->getWaveformSignalColors()->getBgColor();
-    m_backgroundPixmapPath = context.selectString(node, "BgPixmap");
-    if (m_backgroundPixmapPath.isEmpty()) {
-        //qWarning() << "WaveformRenderBackground::generatePixmap - no background file";
-        m_backgroundPixmapPath = QString();
-    } else {
-        m_backgroundPixmapPath = context.getSkinPath(m_backgroundPixmapPath);
+    QString backgroundPixmapPath = context.selectString(node, "BgPixmap");
+    if (!backgroundPixmapPath.isEmpty()) {
+        m_backgroundPixmapPath = context.getSkinPath(backgroundPixmapPath);
     }
     setDirty(true);
 }
@@ -51,7 +49,9 @@ void WaveformRenderBackground::draw(QPainter* painter,
 void WaveformRenderBackground::generateImage() {
     m_backgroundImage = QImage();
     if (!m_backgroundPixmapPath.isEmpty()) {
-        QImage backgroundImage(m_backgroundPixmapPath);
+        QImage backgroundImage = *WImageStore::getImage(
+                m_backgroundPixmapPath,
+                scaleFactor());
 
         if (!backgroundImage.isNull()) {
             if (backgroundImage.width() == m_waveformRenderer->getWidth() &&

--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -42,15 +42,18 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
         return;
     }
 
-    const double firstDisplayedPosition = m_waveformRenderer->getFirstDisplayedPosition();
-    const double lastDisplayedPosition = m_waveformRenderer->getLastDisplayedPosition();
+    const double firstDisplayedPosition =
+            m_waveformRenderer->getFirstDisplayedPosition();
+    const double lastDisplayedPosition =
+            m_waveformRenderer->getLastDisplayedPosition();
 
     // qDebug() << "trackSamples" << trackSamples
     //          << "firstDisplayedPosition" << firstDisplayedPosition
     //          << "lastDisplayedPosition" << lastDisplayedPosition;
 
     std::unique_ptr<BeatIterator> it(trackBeats->findBeats(
-            firstDisplayedPosition * trackSamples, lastDisplayedPosition * trackSamples));
+            firstDisplayedPosition * trackSamples,
+            lastDisplayedPosition * trackSamples));
 
     // if no beat do not waste time saving/restoring painter
     if (!it || !it->hasNext()) {
@@ -61,7 +64,7 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     painter->setRenderHint(QPainter::Antialiasing);
 
     QPen beatPen(m_beatColor);
-    beatPen.setWidthF(1);
+    beatPen.setWidthF(std::max(1.0, scaleFactor()));
     painter->setPen(beatPen);
 
     const Qt::Orientation orientation = m_waveformRenderer->getOrientation();

--- a/src/waveform/renderers/waveformrendererabstract.cpp
+++ b/src/waveform/renderers/waveformrendererabstract.cpp
@@ -2,7 +2,8 @@
 
 WaveformRendererAbstract::WaveformRendererAbstract(WaveformWidgetRenderer* waveformWidgetRenderer)
         : m_waveformRenderer(waveformWidgetRenderer),
-          m_dirty(true) {
+          m_dirty(true),
+          m_scaleFactor(1.0) {
 }
 
 WaveformRendererAbstract::~WaveformRendererAbstract() {

--- a/src/waveform/renderers/waveformrendererabstract.h
+++ b/src/waveform/renderers/waveformrendererabstract.h
@@ -11,7 +11,8 @@ class WaveformWidgetRenderer;
 
 class WaveformRendererAbstract {
   public:
-    explicit WaveformRendererAbstract(WaveformWidgetRenderer* waveformWidgetRenderer);
+    explicit WaveformRendererAbstract(
+            WaveformWidgetRenderer* waveformWidgetRenderer);
     virtual ~WaveformRendererAbstract();
 
     virtual bool init() {return true; }
@@ -28,8 +29,20 @@ class WaveformRendererAbstract {
     void setDirty(bool dirty = true) {
         m_dirty = dirty;
     }
+
+    double scaleFactor() const {
+        return m_scaleFactor;
+    }
+    void setScaleFactor(double scaleFactor) {
+        m_scaleFactor = scaleFactor;
+    }
+
     WaveformWidgetRenderer* m_waveformRenderer;
+
+  private:
+
     bool m_dirty;
+    double m_scaleFactor;
 
     friend class WaveformWidgetRenderer;
 };

--- a/src/waveform/renderers/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/waveformrendererendoftrack.cpp
@@ -57,7 +57,7 @@ void WaveformRendererEndOfTrack::setup(const QDomNode& node, const SkinContext& 
         m_color.setNamedColor(endOfTrackColorName);
         m_color = WSkinColor::getCorrectColor(m_color);
     }
-    m_pen = QPen(QBrush(m_color), 2.5);
+    m_pen = QPen(QBrush(m_color), 2.5 * scaleFactor());
     generateBackRects();
 }
 

--- a/src/waveform/renderers/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/waveformrendererpreroll.cpp
@@ -17,7 +17,8 @@ WaveformRendererPreroll::WaveformRendererPreroll(WaveformWidgetRenderer* wavefor
 WaveformRendererPreroll::~WaveformRendererPreroll() {
 }
 
-void WaveformRendererPreroll::setup(const QDomNode& node, const SkinContext& context) {
+void WaveformRendererPreroll::setup(
+        const QDomNode& node, const SkinContext& context) {
     m_color.setNamedColor(context.selectString(node, "SignalColor"));
     m_color = WSkinColor::getCorrectColor(m_color);
 }
@@ -42,15 +43,15 @@ void WaveformRendererPreroll::draw(QPainter* painter, QPaintEvent* event) {
     if (currentPosition < numberOfSamples / 2.0) {
         int index = static_cast<int>(numberOfSamples / 2.0 - currentPosition);
         const int polyLength = static_cast<int>(40.0 / samplesPerPixel);
-        const float halfBreadth = m_waveformRenderer->getBreadth()/2.0;
-        const float halfPolyBreadth = m_waveformRenderer->getBreadth()/5.0;
+        const float halfBreadth = m_waveformRenderer->getBreadth() / 2.0;
+        const float halfPolyBreadth = m_waveformRenderer->getBreadth() / 5.0;
 
         painter->save();
         painter->setRenderHint(QPainter::Antialiasing);
         //painter->setRenderHint(QPainter::HighQualityAntialiasing);
         //painter->setBackgroundMode(Qt::TransparentMode);
         painter->setWorldMatrixEnabled(false);
-        painter->setPen(QPen(QBrush(m_color), 1));
+        painter->setPen(QPen(QBrush(m_color), std::max(1.0, scaleFactor())));
 
         // Rotate if drawing vertical waveforms
         if (m_waveformRenderer->getOrientation() == Qt::Vertical) {

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -16,7 +16,8 @@ namespace {
     const int kMaxCueLabelLength = 23;
 }
 
-WaveformRenderMark::WaveformRenderMark(WaveformWidgetRenderer* waveformWidgetRenderer) :
+WaveformRenderMark::WaveformRenderMark(
+        WaveformWidgetRenderer* waveformWidgetRenderer) :
     WaveformRendererAbstract(waveformWidgetRenderer) {
 }
 
@@ -116,7 +117,7 @@ void WaveformRenderMark::slotCuesUpdated() {
         WaveformMark* pMark = m_marks.getHotCueMark(hotCue).data();
         WaveformMarkProperties markProperties = pMark->getProperties();
         if (markProperties.m_text.isNull() || newLabel != markProperties.m_text ||
-            !markProperties.m_color.isValid() || newColor != markProperties.m_color) {
+                !markProperties.m_color.isValid() || newColor != markProperties.m_color) {
             markProperties.m_text = newLabel;
             markProperties.m_color = newColor;
             pMark->setProperties(markProperties);
@@ -131,12 +132,13 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
     // Load the pixmap from file -- takes precedence over text.
     if (!markProperties.m_pixmapPath.isEmpty()) {
         QString path = markProperties.m_pixmapPath;
-        QImage image = QImage(path);
+        QImage image = *WImageStore::getImage(path, scaleFactor());
+        //QImage image = QImage(path);
         // If loading the image didn't fail, then we're done. Otherwise fall
         // through and render a label.
         if (!image.isNull()) {
             pMark->m_image = image.convertToFormat(QImage::Format_ARGB32_Premultiplied);
-            WImageStore::correctImageColors(&pMark->m_image);
+            //WImageStore::correctImageColors(&pMark->m_image);
             return;
         }
     }
@@ -160,7 +162,7 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
         //QFont font("Bitstream Vera Sans");
         //QFont font("Helvetica");
         QFont font; // Uses the application default
-        font.setPointSize(10);
+        font.setPointSizeF(10 * scaleFactor());
         font.setStretch(100);
         font.setWeight(75);
 

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -40,7 +40,8 @@ WaveformWidgetRenderer::WaveformWidgetRenderer(const char* group)
       m_pGainControlObject(NULL),
       m_gain(1.0),
       m_pTrackSamplesControlObject(NULL),
-      m_trackSamples(0.0) {
+      m_trackSamples(0.0),
+      m_scaleFactor(1.0) {
 
     //qDebug() << "WaveformWidgetRenderer";
 
@@ -120,7 +121,7 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
     //rate adjust may have change sampling per
     //vRince for the moment only more than one sample per pixel is supported
     //due to the fact we play the visual play pos modulo floor m_visualSamplePerPixel ...
-    double visualSamplePerPixel = m_zoomFactor * (1.0 + m_rateAdjust);
+    double visualSamplePerPixel = m_zoomFactor * (1.0 + m_rateAdjust) / m_scaleFactor;
     m_visualSamplePerPixel = math_max(1.0, visualSamplePerPixel);
 
     TrackPointer pTrack(m_pTrack);
@@ -250,7 +251,9 @@ void WaveformWidgetRenderer::resize(int width, int height) {
     }
 }
 
-void WaveformWidgetRenderer::setup(const QDomNode& node, const SkinContext& context) {
+void WaveformWidgetRenderer::setup(
+        const QDomNode& node, const SkinContext& context) {
+    m_scaleFactor = context.getScaleFactor();
     QString orientationString = context.selectString(node, "Orientation").toLower();
     if (orientationString == "vertical") {
         m_orientation = Qt::Vertical;
@@ -260,6 +263,7 @@ void WaveformWidgetRenderer::setup(const QDomNode& node, const SkinContext& cont
 
     m_colors.setup(node, context);
     for (int i = 0; i < m_rendererStack.size(); ++i) {
+        m_rendererStack[i]->setScaleFactor(m_scaleFactor);
         m_rendererStack[i]->setup(node, context);
     }
 }

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -120,6 +120,7 @@ class WaveformWidgetRenderer {
     double m_gain;
     ControlProxy* m_pTrackSamplesControlObject;
     int m_trackSamples;
+    double m_scaleFactor;
 
 #ifdef WAVEFORMWIDGETRENDERER_DEBUG
     PerformanceTimer* m_timer;

--- a/src/widget/wbattery.cpp
+++ b/src/widget/wbattery.cpp
@@ -19,21 +19,24 @@ void WBattery::setup(const QDomNode& node, const SkinContext& context) {
     if (!backPath.isNull()) {
         setPixmap(&m_pPixmapBack,
                   context.getPixmapSource(backPath),
-                  context.selectScaleMode(backPath, Paintable::TILE));
+                  context.selectScaleMode(backPath, Paintable::TILE),
+                  context.getScaleFactor());
     }
 
     QDomElement unknownPath = context.selectElement(node, "PixmapUnknown");
     if (!unknownPath.isNull()) {
         setPixmap(&m_pPixmapUnknown,
                   context.getPixmapSource(unknownPath),
-                  context.selectScaleMode(unknownPath, Paintable::TILE));
+                  context.selectScaleMode(unknownPath, Paintable::TILE),
+                  context.getScaleFactor());
     }
 
     QDomElement chargedPath = context.selectElement(node, "PixmapCharged");
     if (!chargedPath.isNull()) {
         setPixmap(&m_pPixmapCharged,
                   context.getPixmapSource(chargedPath),
-                  context.selectScaleMode(chargedPath, Paintable::TILE));
+                  context.selectScaleMode(chargedPath, Paintable::TILE),
+                  context.getScaleFactor());
     }
 
     int numberStates = context.selectInt(node, "NumberStates");
@@ -52,7 +55,7 @@ void WBattery::setup(const QDomNode& node, const SkinContext& context) {
                                                            Paintable::TILE);
         for (int i = 0; i < m_chargingPixmaps.size(); ++i) {
             PixmapSource source = context.getPixmapSource(chargingPath.arg(i));
-            setPixmap(&m_chargingPixmaps[i], source, mode);
+            setPixmap(&m_chargingPixmaps[i], source, mode, context.getScaleFactor());
         }
     }
 
@@ -64,7 +67,7 @@ void WBattery::setup(const QDomNode& node, const SkinContext& context) {
                                                            Paintable::TILE);
         for (int i = 0; i < m_dischargingPixmaps.size(); ++i) {
             PixmapSource source = context.getPixmapSource(dischargingPath.arg(i));
-            setPixmap(&m_dischargingPixmaps[i], source, mode);
+            setPixmap(&m_dischargingPixmaps[i], source, mode, context.getScaleFactor());
         }
     }
 
@@ -139,8 +142,8 @@ void WBattery::update() {
 }
 
 void WBattery::setPixmap(PaintablePointer* ppPixmap, const PixmapSource& source,
-                         Paintable::DrawMode mode) {
-    PaintablePointer pPixmap = WPixmapStore::getPaintable(source, mode);
+                         Paintable::DrawMode mode, double scaleFactor) {
+    PaintablePointer pPixmap = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (pPixmap.isNull() || pPixmap->isNull()) {
         qDebug() << this << "Error loading pixmap:" << source.getPath();
     } else {

--- a/src/widget/wbattery.h
+++ b/src/widget/wbattery.h
@@ -28,7 +28,7 @@ class WBattery : public WWidget {
 
   private:
     void setPixmap(PaintablePointer* ppPixmap, const PixmapSource& source,
-                   Paintable::DrawMode mode);
+                   Paintable::DrawMode mode, double scaleFactor);
 
     QScopedPointer<Battery> m_pBattery;
     PaintablePointer m_pCurrentPixmap;

--- a/src/widget/wdisplay.cpp
+++ b/src/widget/wdisplay.cpp
@@ -43,7 +43,8 @@ void WDisplay::setup(const QDomNode& node, const SkinContext& context) {
     QDomElement backPathNode = context.selectElement(node, "BackPath");
     if (!backPathNode.isNull()) {
         setPixmapBackground(context.getPixmapSource(backPathNode),
-                            context.selectScaleMode(backPathNode, Paintable::TILE));
+                            context.selectScaleMode(backPathNode, Paintable::TILE),
+                            context.getScaleFactor());
     }
 
     // Number of states
@@ -57,7 +58,8 @@ void WDisplay::setup(const QDomNode& node, const SkinContext& context) {
     Paintable::DrawMode pathMode =
             context.selectScaleMode(pathNode, Paintable::FIXED);
     for (int i = 0; i < m_pixmaps.size(); ++i) {
-        setPixmap(&m_pixmaps, i, context.getSkinPath(path.arg(i)), pathMode);
+        setPixmap(&m_pixmaps, i, context.getSkinPath(path.arg(i)),
+                  pathMode, context.getScaleFactor());
     }
 
     // See if disabled images is defined, and load them...
@@ -70,7 +72,8 @@ void WDisplay::setup(const QDomNode& node, const SkinContext& context) {
             context.selectScaleMode(disabledNode, Paintable::FIXED);
         for (int i = 0; i < m_disabledPixmaps.size(); ++i) {
             setPixmap(&m_disabledPixmaps, i,
-                      context.getSkinPath(disabledPath.arg(i)), disabledMode);
+                      context.getSkinPath(disabledPath.arg(i)),
+                      disabledMode, context.getScaleFactor());
         }
         m_bDisabledLoaded = true;
     }
@@ -96,22 +99,27 @@ void WDisplay::resetPositions() {
 }
 
 void WDisplay::setPixmapBackground(PixmapSource source,
-                                   Paintable::DrawMode mode) {
-    m_pPixmapBack = WPixmapStore::getPaintable(source, mode);
+                                   Paintable::DrawMode mode,
+                                   double scaleFactor) {
+    m_pPixmapBack = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (m_pPixmapBack.isNull() || m_pPixmapBack->isNull()) {
         qDebug() << metaObject()->className()
                  << "Error loading background pixmap:" << source.getPath();
     }
 }
 
-void WDisplay::setPixmap(QVector<PaintablePointer>* pPixmaps, int iPos,
-                         const QString& filename, Paintable::DrawMode mode) {
+void WDisplay::setPixmap(
+        QVector<PaintablePointer>* pPixmaps,
+        int iPos,
+        const QString& filename,
+        Paintable::DrawMode mode,
+        double scaleFactor) {
     if (iPos < 0 || iPos >= pPixmaps->size()) {
         return;
     }
 
     PixmapSource source(filename);
-    PaintablePointer pPixmap = WPixmapStore::getPaintable(source, mode);
+    PaintablePointer pPixmap = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (pPixmap.isNull() || pPixmap->isNull()) {
         qDebug() << metaObject()->className()
                  << "Error loading pixmap:" << filename;

--- a/src/widget/wdisplay.h
+++ b/src/widget/wdisplay.h
@@ -45,10 +45,17 @@ class WDisplay : public WWidget {
     }
 
   private:
-    void setPixmap(QVector<PaintablePointer>* pPixmaps, int iPos,
-                   const QString& filename, Paintable::DrawMode mode);
+    void setPixmap(
+            QVector<PaintablePointer>* pPixmaps,
+            int iPos,
+            const QString& filename,
+            Paintable::DrawMode mode,
+            double scaleFactor);
 
-    void setPixmapBackground(PixmapSource source, Paintable::DrawMode mode);
+    void setPixmapBackground(
+            PixmapSource source,
+            Paintable::DrawMode mode,
+            double scaleFactor);
 
     void setPositions(int iNoPos);
 

--- a/src/widget/weffectbuttonparameter.cpp
+++ b/src/widget/weffectbuttonparameter.cpp
@@ -9,6 +9,7 @@ WEffectButtonParameter::WEffectButtonParameter(QWidget* pParent, EffectsManager*
 }
 
 void WEffectButtonParameter::setup(const QDomNode& node, const SkinContext& context) {
+    WLabel::setup(node, context);
     // EffectWidgetUtils propagates NULLs so this is all safe.
     EffectRackPointer pRack = EffectWidgetUtils::getEffectRackFromNode(
             node, context, m_pEffectsManager);

--- a/src/widget/weffectparameter.cpp
+++ b/src/widget/weffectparameter.cpp
@@ -9,6 +9,7 @@ WEffectParameter::WEffectParameter(QWidget* pParent, EffectsManager* pEffectsMan
 }
 
 void WEffectParameter::setup(const QDomNode& node, const SkinContext& context) {
+    WLabel::setup(node, context);
     // EffectWidgetUtils propagates NULLs so this is all safe.
     EffectRackPointer pRack = EffectWidgetUtils::getEffectRackFromNode(
             node, context, m_pEffectsManager);

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -106,12 +106,10 @@ bool WEffectSelector::event(QEvent* pEvent) {
         updateTooltip();
     } else if (pEvent->type() == QEvent::FontChange) {
         const QFont& fonti = font();
-        // Change the new font on the fly by casting away its constness
+        // Change the new font on the fly by casting away its constancy
         // using setFont() here, would results into a recursive loop
         // resetting the font to the original css values.
-        if (fonti.pointSizeF() > 0) {
-            const_cast<QFont&>(fonti).setPointSizeF(fonti.pointSizeF() * m_scaleFactor);
-        }
+        // Only scale pixel size fonts, point size fonts are scaled by the OS
         if (fonti.pixelSize() > 0) {
             const_cast<QFont&>(fonti).setPixelSize(fonti.pixelSize() * m_scaleFactor);
         }

--- a/src/widget/weffectselector.h
+++ b/src/widget/weffectselector.h
@@ -16,9 +16,13 @@ class WEffectSelector : public QComboBox, public WBaseWidget {
 
     void setup(const QDomNode& node, const SkinContext& context);
 
+  protected:
+    bool event(QEvent* pEvent) override;
+
   private slots:
     void slotEffectUpdated();
     void slotEffectSelected(int newIndex);
+    void populate();
 
   private:
     EffectsManager* m_pEffectsManager;

--- a/src/widget/weffectselector.h
+++ b/src/widget/weffectselector.h
@@ -29,6 +29,7 @@ class WEffectSelector : public QComboBox, public WBaseWidget {
     EffectSlotPointer m_pEffectSlot;
     EffectChainSlotPointer m_pChainSlot;
     EffectRackPointer m_pRack;
+    double m_scaleFactor;
 };
 
 

--- a/src/widget/wimagestore.cpp
+++ b/src/widget/wimagestore.cpp
@@ -67,7 +67,8 @@ QImage* WImageStore::getImageNoCache(const PixmapSource& source, double scaleFac
             renderer.load(source.getData());
         }
 
-        pImage = new QImage(renderer.defaultSize(), QImage::Format_ARGB32);
+        pImage = new QImage(renderer.defaultSize() * scaleFactor,
+                            QImage::Format_ARGB32);
         pImage->fill(0x00000000);  // Transparent black.
         QPainter painter(pImage);
         renderer.render(&painter);

--- a/src/widget/wimagestore.cpp
+++ b/src/widget/wimagestore.cpp
@@ -25,8 +25,9 @@ QImage* WImageStore::getImage(const QString& fileName, double scaleFactor) {
 QImage* WImageStore::getImage(const PixmapSource& source, double scaleFactor) {
     // Search for Image in list
     ImageInfoType* info = nullptr;
+    QString key = source.getId() + QString::number(scaleFactor);
 
-    QHash<QString, ImageInfoType*>::iterator it = m_dictionary.find(source.getId());
+    QHash<QString, ImageInfoType*>::iterator it = m_dictionary.find(key);
     if (it != m_dictionary.end()) {
         info = it.value();
         info->instCount++;
@@ -52,7 +53,7 @@ QImage* WImageStore::getImage(const PixmapSource& source, double scaleFactor) {
     info = new ImageInfoType;
     info->image = loadedImage;
     info->instCount = 1;
-    m_dictionary.insert(source.getId(), info);
+    m_dictionary.insert(key, info);
     return info->image;
 }
 

--- a/src/widget/wimagestore.cpp
+++ b/src/widget/wimagestore.cpp
@@ -12,17 +12,17 @@ QSharedPointer<ImgSource> WImageStore::m_loader
         = QSharedPointer<ImgSource>(new ImgLoader());
 
 // static
-QImage* WImageStore::getImageNoCache(const QString& fileName) {
-    return getImageNoCache(PixmapSource(fileName));
+QImage* WImageStore::getImageNoCache(const QString& fileName, double scaleFactor) {
+    return getImageNoCache(PixmapSource(fileName), scaleFactor);
 }
 
 // static
-QImage* WImageStore::getImage(const QString& fileName) {
-    return getImage(PixmapSource(fileName));
+QImage* WImageStore::getImage(const QString& fileName, double scaleFactor) {
+    return getImage(PixmapSource(fileName), scaleFactor);
 }
 
 // static
-QImage* WImageStore::getImage(const PixmapSource& source) {
+QImage* WImageStore::getImage(const PixmapSource& source, double scaleFactor) {
     // Search for Image in list
     ImageInfoType* info = nullptr;
 
@@ -37,7 +37,7 @@ QImage* WImageStore::getImage(const PixmapSource& source) {
     // Image wasn't found, construct it
     //qDebug() << "WImageStore Loading Image from file" << source.getPath();
 
-    QImage* loadedImage = getImageNoCache(source);
+    QImage* loadedImage = getImageNoCache(source, scaleFactor);
 
     if (loadedImage == nullptr) {
         return nullptr;
@@ -57,7 +57,7 @@ QImage* WImageStore::getImage(const PixmapSource& source) {
 }
 
 // static
-QImage* WImageStore::getImageNoCache(const PixmapSource& source) {
+QImage* WImageStore::getImageNoCache(const PixmapSource& source, double scaleFactor) {
     QImage* pImage;
     if (source.isSVG()) {
         QSvgRenderer renderer;
@@ -72,13 +72,13 @@ QImage* WImageStore::getImageNoCache(const PixmapSource& source) {
         QPainter painter(pImage);
         renderer.render(&painter);
     } else {
-        pImage = m_loader->getImage(source.getPath());
+        pImage = m_loader->getImage(source.getPath(), scaleFactor);
     }
     return pImage;
 }
 
 // static
-void WImageStore::deleteImage(QImage * p)
+void WImageStore::deleteImage(QImage* p)
 {
     // Search for Image in list
     ImageInfoType *info = nullptr;

--- a/src/widget/wimagestore.cpp
+++ b/src/widget/wimagestore.cpp
@@ -4,9 +4,12 @@
 #include <QSvgRenderer>
 #include <QPainter>
 
+#include "skin/imgloader.h"
+
 // static
 QHash<QString, WImageStore::ImageInfoType*> WImageStore::m_dictionary;
-QSharedPointer<ImgSource> WImageStore::m_loader = QSharedPointer<ImgSource>();
+QSharedPointer<ImgSource> WImageStore::m_loader
+        = QSharedPointer<ImgSource>(new ImgLoader());
 
 // static
 QImage* WImageStore::getImageNoCache(const QString& fileName) {
@@ -69,11 +72,7 @@ QImage* WImageStore::getImageNoCache(const PixmapSource& source) {
         QPainter painter(pImage);
         renderer.render(&painter);
     } else {
-        if (m_loader) {
-            pImage = m_loader->getImage(source.getPath());
-        } else {
-            pImage = new QImage(source.getPath());
-        }
+        pImage = m_loader->getImage(source.getPath());
     }
     return pImage;
 }
@@ -104,9 +103,7 @@ void WImageStore::deleteImage(QImage * p)
 
 // static
 void WImageStore::correctImageColors(QImage* p) {
-    if (m_loader) {
-        m_loader->correctImageColors(p);
-    }
+    m_loader->correctImageColors(p);
 }
 
 // static

--- a/src/widget/wimagestore.h
+++ b/src/widget/wimagestore.h
@@ -12,10 +12,10 @@ class QImage;
 
 class WImageStore {
   public:
-    static QImage* getImage(const QString &fileName);
-    static QImage* getImageNoCache(const QString &fileName);
-    static QImage* getImage(const PixmapSource& source);
-    static QImage* getImageNoCache(const PixmapSource& source);
+    static QImage* getImage(const QString& fileName, double scaleFactor);
+    static QImage* getImageNoCache(const QString& fileName, double scaleFactor);
+    static QImage* getImage(const PixmapSource& source, double scaleFactor);
+    static QImage* getImageNoCache(const PixmapSource& source, double scaleFactor);
     static void deleteImage(QImage* p);
     static void setLoader(QSharedPointer<ImgSource> ld);
     // For external owned images like software generated ones.

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -16,13 +16,15 @@ WKnobComposed::WKnobComposed(QWidget* pParent)
 void WKnobComposed::setup(const QDomNode& node, const SkinContext& context) {
     clear();
 
+    double scaleFactor = context.getScaleFactor();
+
     // Set background pixmap if available
     QDomElement backPathElement = context.selectElement(node, "BackPath");
     if (!backPathElement.isNull()) {
         setPixmapBackground(
                 context.getPixmapSource(backPathElement),
                 context.selectScaleMode(backPathElement, Paintable::STRETCH),
-                context.getScaleFactor());
+                scaleFactor);
     }
 
     // Set knob pixmap if available
@@ -31,13 +33,16 @@ void WKnobComposed::setup(const QDomNode& node, const SkinContext& context) {
         setPixmapKnob(
                 context.getPixmapSource(knobNode),
                 context.selectScaleMode(knobNode, Paintable::STRETCH),
-                context.getScaleFactor());
+                scaleFactor);
     }
 
     context.hasNodeSelectDouble(node, "MinAngle", &m_dMinAngle);
     context.hasNodeSelectDouble(node, "MaxAngle", &m_dMaxAngle);
     context.hasNodeSelectDouble(node, "KnobCenterXOffset", &m_dKnobCenterXOffset);
     context.hasNodeSelectDouble(node, "KnobCenterYOffset", &m_dKnobCenterYOffset);
+
+    m_dKnobCenterXOffset *= scaleFactor;
+    m_dKnobCenterYOffset *= scaleFactor;
 }
 
 void WKnobComposed::clear() {

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -19,15 +19,19 @@ void WKnobComposed::setup(const QDomNode& node, const SkinContext& context) {
     // Set background pixmap if available
     QDomElement backPathElement = context.selectElement(node, "BackPath");
     if (!backPathElement.isNull()) {
-        setPixmapBackground(context.getPixmapSource(backPathElement),
-                            context.selectScaleMode(backPathElement, Paintable::STRETCH));
+        setPixmapBackground(
+                context.getPixmapSource(backPathElement),
+                context.selectScaleMode(backPathElement, Paintable::STRETCH),
+                context.getScaleFactor());
     }
 
     // Set knob pixmap if available
     QDomElement knobNode = context.selectElement(node, "Knob");
     if (!knobNode.isNull()) {
-        setPixmapKnob(context.getPixmapSource(knobNode),
-                      context.selectScaleMode(knobNode, Paintable::STRETCH));
+        setPixmapKnob(
+                context.getPixmapSource(knobNode),
+                context.selectScaleMode(knobNode, Paintable::STRETCH),
+                context.getScaleFactor());
     }
 
     context.hasNodeSelectDouble(node, "MinAngle", &m_dMinAngle);
@@ -42,8 +46,9 @@ void WKnobComposed::clear() {
 }
 
 void WKnobComposed::setPixmapBackground(PixmapSource source,
-                                        Paintable::DrawMode mode) {
-    m_pPixmapBack = WPixmapStore::getPaintable(source, mode);
+                                        Paintable::DrawMode mode,
+                                        double scaleFactor) {
+    m_pPixmapBack = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (m_pPixmapBack.isNull() || m_pPixmapBack->isNull()) {
         qDebug() << metaObject()->className()
                  << "Error loading background pixmap:" << source.getPath();
@@ -51,8 +56,9 @@ void WKnobComposed::setPixmapBackground(PixmapSource source,
 }
 
 void WKnobComposed::setPixmapKnob(PixmapSource source,
-                                  Paintable::DrawMode mode) {
-    m_pKnob = WPixmapStore::getPaintable(source, mode);
+                                  Paintable::DrawMode mode,
+                                  double scaleFactor) {
+    m_pKnob = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (m_pKnob.isNull() || m_pKnob->isNull()) {
         qDebug() << metaObject()->className()
                  << "Error loading knob pixmap:" << source.getPath();

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -30,8 +30,14 @@ class WKnobComposed : public WWidget {
 
   private:
     void clear();
-    void setPixmapBackground(PixmapSource source, Paintable::DrawMode mode);
-    void setPixmapKnob(PixmapSource source, Paintable::DrawMode mode);
+    void setPixmapBackground(
+            PixmapSource source,
+            Paintable::DrawMode mode,
+            double scaleFactor);
+    void setPixmapKnob(
+            PixmapSource source,
+            Paintable::DrawMode mode,
+            double scaleFactor);
 
     double m_dCurrentAngle;
     PaintablePointer m_pKnob;

--- a/src/widget/wlabel.cpp
+++ b/src/widget/wlabel.cpp
@@ -126,12 +126,10 @@ bool WLabel::event(QEvent* pEvent) {
         updateTooltip();
     } else if (pEvent->type() == QEvent::FontChange) {
         const QFont& fonti = font();
-        // Change the new font on the fly by casting away its constness
+        // Change the new font on the fly by casting away its constancy
         // using setFont() here, would results into a recursive loop
         // resetting the font to the original css values.
-        if (fonti.pointSizeF() > 0) {
-            const_cast<QFont&>(fonti).setPointSizeF(fonti.pointSizeF() * m_scaleFactor);
-        }
+        // Only scale pixel size fonts, point size fonts are scaled by the OS
         if (fonti.pixelSize() > 0) {
             const_cast<QFont&>(fonti).setPixelSize(fonti.pixelSize() * m_scaleFactor);
         }

--- a/src/widget/wlabel.cpp
+++ b/src/widget/wlabel.cpp
@@ -26,13 +26,15 @@ WLabel::WLabel(QWidget* pParent)
           WBaseWidget(this),
           m_skinText(),
           m_longText(),
-          m_elideMode(Qt::ElideNone) {
+          m_elideMode(Qt::ElideNone),
+          m_scaleFactor(1.0) {
 }
 
 void WLabel::setup(const QDomNode& node, const SkinContext& context) {
-    // Colors
-    QPalette pal = palette(); //we have to copy out the palette to edit it since it's const (probably for threadsafety)
+    m_scaleFactor = context.getScaleFactor();
 
+    // Colors
+    QPalette pal = palette(); // we have to copy out the palette to edit it since it's const (probably for threadsafety)
 
     QDomElement bgColor = context.selectElement(node, "BgColor");
     if (!bgColor.isNull()) {
@@ -45,17 +47,23 @@ void WLabel::setup(const QDomNode& node, const SkinContext& context) {
     pal.setColor(this->foregroundRole(), WSkinColor::getCorrectColor(m_qFgColor));
     setPalette(pal);
 
-    // Text
-    if (context.hasNodeSelectString(node, "Text", &m_skinText)) {
-        setText(m_skinText);
-    }
-
     // Font size
     QString strFontSize;
     if (context.hasNodeSelectString(node, "FontSize", &strFontSize)) {
-        int fontsize = strFontSize.toInt();
-        // TODO(XXX) "Helvetica" should retrain the Qt default font matching, verify that.
-        setFont(QFont("Helvetica", fontsize, QFont::Normal));
+        bool widthOk = false;
+        double dFontSize = strFontSize.toDouble(&widthOk);
+        if (widthOk && dFontSize >= 0) {
+            QFont fonti = font();
+            // We do not scale the font here, because in most cases
+            // this is overridden by the style sheet font size
+            fonti.setPointSizeF(dFontSize);
+            setFont(fonti);
+        }
+    }
+
+    // Text
+    if (context.hasNodeSelectString(node, "Text", &m_skinText)) {
+        setText(m_skinText);
     }
 
     // Alignment
@@ -116,6 +124,19 @@ void WLabel::setText(const QString& text) {
 bool WLabel::event(QEvent* pEvent) {
     if (pEvent->type() == QEvent::ToolTip) {
         updateTooltip();
+    } else if (pEvent->type() == QEvent::FontChange) {
+        const QFont& fonti = font();
+        // Change the new font on the fly by casting away its constness
+        // using setFont() here, would results into a recursive loop
+        // resetting the font to the original css values.
+        if (fonti.pointSizeF() > 0) {
+            const_cast<QFont&>(fonti).setPointSizeF(fonti.pointSizeF() * m_scaleFactor);
+        }
+        if (fonti.pixelSize() > 0) {
+            const_cast<QFont&>(fonti).setPixelSize(fonti.pixelSize() * m_scaleFactor);
+        }
+        // measure text with the new font
+        setText(m_longText);
     }
     return QLabel::event(pEvent);
 }

--- a/src/widget/wlabel.h
+++ b/src/widget/wlabel.h
@@ -45,6 +45,7 @@ class WLabel : public QLabel, public WBaseWidget {
   private:
     QString m_longText;
     Qt::TextElideMode m_elideMode;
+    double m_scaleFactor;
 };
 
 #endif

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -133,7 +133,7 @@ class WOverview : public WWidget {
     double m_dAnalyzerProgress;
     bool m_bAnalyzerFinalizing;
     bool m_trackLoaded;
-    bool m_scaleFactor;
+    double m_scaleFactor;
 };
 
 #endif

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -133,6 +133,7 @@ class WOverview : public WWidget {
     double m_dAnalyzerProgress;
     bool m_bAnalyzerFinalizing;
     bool m_trackLoaded;
+    bool m_scaleFactor;
 };
 
 #endif

--- a/src/widget/wpixmapstore.cpp
+++ b/src/widget/wpixmapstore.cpp
@@ -269,9 +269,12 @@ QString Paintable::getAltFileName(const QString& fileName) {
 
 // static
 PaintablePointer WPixmapStore::getPaintable(PixmapSource source,
-                                            Paintable::DrawMode mode) {
+                                            Paintable::DrawMode mode,
+                                            double scaleFactor) {
     // See if we have a cached value for the pixmap.
-    PaintablePointer pPaintable = m_paintableCache.value(source.getId(), PaintablePointer());
+    PaintablePointer pPaintable = m_paintableCache.value(
+            source.getId(),
+            PaintablePointer());
     if (pPaintable) {
         return pPaintable;
     }
@@ -279,10 +282,10 @@ PaintablePointer WPixmapStore::getPaintable(PixmapSource source,
     // Otherwise, construct it with the pixmap loader.
     //qDebug() << "WPixmapStore Loading pixmap from file" << source.getPath();
 
-    QImage* pImage = m_loader->getImage(source.getPath());
+    QImage* pImage = m_loader->getImage(source.getPath(), scaleFactor);
     pPaintable = PaintablePointer(new Paintable(pImage, mode));
 
-    if (pPaintable.isNull() || pPaintable->isNull()) {
+    if (pPaintable->isNull()) {
         // Only log if it looks like the user tried to specify a
         // pixmap. Otherwise we probably just have a widget that is calling
         // getPaintable without checking that the skinner actually wanted one.
@@ -298,9 +301,11 @@ PaintablePointer WPixmapStore::getPaintable(PixmapSource source,
 }
 
 // static
-QPixmap* WPixmapStore::getPixmapNoCache(const QString& fileName) {
+QPixmap* WPixmapStore::getPixmapNoCache(
+        const QString& fileName,
+        double scaleFactor) {
     QPixmap* pPixmap = nullptr;
-    QImage* img = m_loader->getImage(fileName);
+    QImage* img = m_loader->getImage(fileName, scaleFactor);
 #if QT_VERSION >= 0x040700
     pPixmap = new QPixmap();
     pPixmap->convertFromImage(*img);

--- a/src/widget/wpixmapstore.cpp
+++ b/src/widget/wpixmapstore.cpp
@@ -90,7 +90,8 @@ Paintable::Paintable(const QString& fileName, DrawMode mode)
             m_pSvg.reset(new QSvgRenderer(fileName));
         }
     } else {
-        m_pPixmap.reset(new QPixmap(fileName));
+        // TODO: this should detect DoubleWidgetSize setting
+        m_pPixmap.reset(new QPixmap(getAltFileName(fileName)));
     }
 }
 
@@ -121,7 +122,8 @@ Paintable::Paintable(const PixmapSource& source, DrawMode mode)
         if (!source.getData().isEmpty()) {
             pPixmap->loadFromData(source.getData());
         } else {
-            pPixmap->load(source.getPath());
+            // TODO: this should detect DoubleWidgetSize setting
+            pPixmap->load(getAltFileName(source.getPath()));
         }
         m_pPixmap.reset(pPixmap);
     }
@@ -299,6 +301,14 @@ void Paintable::drawInternal(const QRectF& targetRect, QPainter* pPainter,
         }
     }
 }
+
+// static
+QString Paintable::getAltFileName(const QString& fileName) {
+    QStringList temp = fileName.split('.');
+    QString newFileName = temp[0] + QString::fromAscii("@2x.") + temp[1];
+    return newFileName;
+}
+
 
 // static
 PaintablePointer WPixmapStore::getPaintable(PixmapSource source,

--- a/src/widget/wpixmapstore.cpp
+++ b/src/widget/wpixmapstore.cpp
@@ -17,6 +17,7 @@
 
 #include "widget/wpixmapstore.h"
 
+#include <QDir>
 #include <QString>
 #include <QtDebug>
 
@@ -304,9 +305,20 @@ void Paintable::drawInternal(const QRectF& targetRect, QPainter* pPainter,
 
 // static
 QString Paintable::getAltFileName(const QString& fileName) {
+    // Detect if the alternate image file exists and, if it does,
+    // return its path instead
     QStringList temp = fileName.split('.');
+    if (temp.length() != 2) {
+        return fileName;
+    }
+
     QString newFileName = temp[0] + QString::fromAscii("@2x.") + temp[1];
-    return newFileName;
+    QFile file(newFileName);
+    if (QFileInfo(file).exists()) {
+        return newFileName;
+    } else {
+        return fileName;
+    }
 }
 
 

--- a/src/widget/wpixmapstore.cpp
+++ b/src/widget/wpixmapstore.cpp
@@ -271,9 +271,11 @@ QString Paintable::getAltFileName(const QString& fileName) {
 PaintablePointer WPixmapStore::getPaintable(PixmapSource source,
                                             Paintable::DrawMode mode,
                                             double scaleFactor) {
+    QString key = source.getId() + QString::number(scaleFactor);
+
     // See if we have a cached value for the pixmap.
     PaintablePointer pPaintable = m_paintableCache.value(
-            source.getId(),
+            key,
             PaintablePointer());
     if (pPaintable) {
         return pPaintable;
@@ -296,7 +298,7 @@ PaintablePointer WPixmapStore::getPaintable(PixmapSource source,
         return PaintablePointer();
     }
 
-    m_paintableCache[source.getId()] = pPaintable;
+    m_paintableCache.insert(key, pPaintable);
     return pPaintable;
 }
 

--- a/src/widget/wpixmapstore.h
+++ b/src/widget/wpixmapstore.h
@@ -48,8 +48,6 @@ class Paintable {
 
     // Takes ownership of QImage.
     Paintable(QImage* pImage, DrawMode mode);
-    Paintable(const QString& fileName, DrawMode mode);
-    Paintable(const PixmapSource& source, DrawMode mode);
 
     QSize size() const;
     int width() const;

--- a/src/widget/wpixmapstore.h
+++ b/src/widget/wpixmapstore.h
@@ -48,6 +48,7 @@ class Paintable {
 
     // Takes ownership of QImage.
     Paintable(QImage* pImage, DrawMode mode);
+    Paintable(const PixmapSource& source, DrawMode mode);
 
     QSize size() const;
     int width() const;

--- a/src/widget/wpixmapstore.h
+++ b/src/widget/wpixmapstore.h
@@ -85,9 +85,11 @@ typedef QWeakPointer<Paintable> WeakPaintablePointer;
 
 class WPixmapStore {
   public:
-    static PaintablePointer getPaintable(PixmapSource source,
-                                            Paintable::DrawMode mode);
-    static QPixmap* getPixmapNoCache(const QString& fileName);
+    static PaintablePointer getPaintable(
+            PixmapSource source,
+            Paintable::DrawMode mode,
+            double scaleFactor);
+    static QPixmap* getPixmapNoCache(const QString& fileName, double scaleFactor);
     static void setLoader(QSharedPointer<ImgSource> ld);
 
   private:

--- a/src/widget/wpixmapstore.h
+++ b/src/widget/wpixmapstore.h
@@ -71,6 +71,7 @@ class Paintable {
 
     static DrawMode DrawModeFromString(const QString& str);
     static QString DrawModeToString(DrawMode mode);
+    static QString getAltFileName(const QString& fileName);
 
   private:
     void drawInternal(const QRectF& targetRect, QPainter* pPainter,

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -61,8 +61,10 @@ void WPushButton::setup(const QDomNode& node, const SkinContext& context) {
         if (!backgroundSource.isEmpty()) {
             // The implicit default in <1.12.0 was FIXED so we keep it for
             // backwards compatibility.
-            setPixmapBackground(backgroundSource,
-                                context.selectScaleMode(backPathNode, Paintable::FIXED));
+            setPixmapBackground(
+                    backgroundSource,
+                    context.selectScaleMode(backPathNode, Paintable::FIXED),
+                    context.getScaleFactor());
         }
     }
 
@@ -95,7 +97,8 @@ void WPushButton::setup(const QDomNode& node, const SkinContext& context) {
                 Paintable::DrawMode unpressedMode =
                         stateContext->selectScaleMode(unpressedNode, Paintable::FIXED);
                 if (!pixmapSource.isEmpty()) {
-                    setPixmap(iState, false, pixmapSource, unpressedMode);
+                    setPixmap(iState, false, pixmapSource,
+                              unpressedMode, context.getScaleFactor());
                 }
 
                 QDomElement pressedNode = stateContext->selectElement(state, "Pressed");
@@ -105,7 +108,8 @@ void WPushButton::setup(const QDomNode& node, const SkinContext& context) {
                 Paintable::DrawMode pressedMode =
                         stateContext->selectScaleMode(pressedNode, Paintable::FIXED);
                 if (!pixmapSource.isEmpty()) {
-                    setPixmap(iState, true, pixmapSource, pressedMode);
+                    setPixmap(iState, true, pixmapSource,
+                              pressedMode, context.getScaleFactor());
                 }
 
                 m_text.replace(iState, stateContext->selectString(state, "Text"));
@@ -229,7 +233,7 @@ void WPushButton::setStates(int iStates) {
 }
 
 void WPushButton::setPixmap(int iState, bool bPressed, PixmapSource source,
-                            Paintable::DrawMode mode) {
+                            Paintable::DrawMode mode, double scaleFactor) {
     QVector<PaintablePointer>& pixmaps = bPressed ?
             m_pressedPixmaps : m_unpressedPixmaps;
 
@@ -237,7 +241,7 @@ void WPushButton::setPixmap(int iState, bool bPressed, PixmapSource source,
         return;
     }
 
-    PaintablePointer pPixmap = WPixmapStore::getPaintable(source, mode);
+    PaintablePointer pPixmap = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (pPixmap.isNull() || pPixmap->isNull()) {
         // Only log if it looks like the user tried to specify a pixmap.
         if (!source.isEmpty()) {
@@ -251,9 +255,10 @@ void WPushButton::setPixmap(int iState, bool bPressed, PixmapSource source,
 }
 
 void WPushButton::setPixmapBackground(PixmapSource source,
-                                      Paintable::DrawMode mode) {
+                                      Paintable::DrawMode mode,
+                                      double scaleFactor) {
     // Load background pixmap
-    m_pPixmapBack = WPixmapStore::getPaintable(source, mode);
+    m_pPixmapBack = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (!source.isEmpty() &&
             (m_pPixmapBack.isNull() || m_pPixmapBack->isNull())) {
         // Only log if it looks like the user tried to specify a pixmap.

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -49,6 +49,8 @@ WPushButton::WPushButton(QWidget* pParent, ControlPushButton::ButtonMode leftBut
 }
 
 void WPushButton::setup(const QDomNode& node, const SkinContext& context) {
+    setScaleFactor(context.getScaleFactor());
+
     // Number of states
     int iNumStates = context.selectInt(node, "NumberStates");
     setStates(iNumStates);

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -86,12 +86,14 @@ class WPushButton : public WWidget {
 
     // Associates a pixmap of a given state of the button with the widget
     void setPixmap(int iState, bool bPressed, PixmapSource source,
-                   Paintable::DrawMode mode);
+                   Paintable::DrawMode mode, double scaleFactor);
 
     // Associates a background pixmap with the widget. This is only needed if
     // the button pixmaps contains alpha channel values.
-    void setPixmapBackground(PixmapSource source,
-                            Paintable::DrawMode mode);
+    void setPixmapBackground(
+            PixmapSource source,
+            Paintable::DrawMode mode,
+            double scaleFactor);
 
     // True, if the button is currently pressed
     bool m_bPressed;

--- a/src/widget/wskincolor.cpp
+++ b/src/widget/wskincolor.cpp
@@ -1,16 +1,15 @@
 #include "wskincolor.h"
 
-QSharedPointer<ImgSource> WSkinColor::loader = QSharedPointer<ImgSource>();
+#include "skin/imgloader.h"
+
+QSharedPointer<ImgSource> WSkinColor::loader
+    = QSharedPointer<ImgSource>(new ImgLoader());
 
 void WSkinColor::setLoader(QSharedPointer<ImgSource> ld) {
     loader = ld;
 }
 
 QColor WSkinColor::getCorrectColor(QColor c) {
-    if (loader) {
-        return loader->getCorrectColor(c);
-    } else {
-        return c;
-    }
+    return loader->getCorrectColor(c);
 }
 

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -49,7 +49,10 @@ void WSliderComposed::setup(const QDomNode& node, const SkinContext& context) {
         // The implicit default in <1.12.0 was FIXED so we keep it for backwards
         // compatibility.
         PixmapSource sourceSlider = context.getPixmapSource(slider);
-        setSliderPixmap(sourceSlider, context.selectScaleMode(slider, Paintable::FIXED));
+        setSliderPixmap(
+                sourceSlider,
+                context.selectScaleMode(slider, Paintable::FIXED),
+                context.getScaleFactor());
     }
 
     m_dSliderLength = m_bHorizontal ? width() : height();
@@ -61,7 +64,8 @@ void WSliderComposed::setup(const QDomNode& node, const SkinContext& context) {
     // The implicit default in <1.12.0 was FIXED so we keep it for backwards
     // compatibility.
     setHandlePixmap(h, sourceHandle,
-                    context.selectScaleMode(handle, Paintable::FIXED));
+                    context.selectScaleMode(handle, Paintable::FIXED),
+                    context.getScaleFactor());
 
     QString eventWhileDrag;
     if (context.hasNodeSelectString(node, "EventWhileDrag", &eventWhileDrag)) {
@@ -83,8 +87,9 @@ void WSliderComposed::setup(const QDomNode& node, const SkinContext& context) {
 }
 
 void WSliderComposed::setSliderPixmap(PixmapSource sourceSlider,
-                                      Paintable::DrawMode drawMode) {
-    m_pSlider = WPixmapStore::getPaintable(sourceSlider, drawMode);
+                                      Paintable::DrawMode drawMode,
+                                      double scaleFactor) {
+    m_pSlider = WPixmapStore::getPaintable(sourceSlider, drawMode, scaleFactor);
     if (!m_pSlider) {
         qDebug() << "WSliderComposed: Error loading slider pixmap:" << sourceSlider.getPath();
     } else if (drawMode == Paintable::FIXED) {
@@ -95,10 +100,11 @@ void WSliderComposed::setSliderPixmap(PixmapSource sourceSlider,
 
 void WSliderComposed::setHandlePixmap(bool bHorizontal,
                                       PixmapSource sourceHandle,
-                                      Paintable::DrawMode mode) {
+                                      Paintable::DrawMode mode,
+                                      double scaleFactor) {
     m_bHorizontal = bHorizontal;
     m_handler.setHorizontal(m_bHorizontal);
-    m_pHandle = WPixmapStore::getPaintable(sourceHandle, mode);
+    m_pHandle = WPixmapStore::getPaintable(sourceHandle, mode, scaleFactor);
     m_dHandleLength = calculateHandleLength();
     m_handler.setHandleLength(m_dHandleLength);
     if (!m_pHandle) {

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -44,9 +44,15 @@ class WSliderComposed : public WWidget  {
     ~WSliderComposed() override;
 
     void setup(const QDomNode& node, const SkinContext& context);
-    void setSliderPixmap(PixmapSource sourceSlider, Paintable::DrawMode drawMode);
-    void setHandlePixmap(bool bHorizontal, PixmapSource sourceHandle,
-                         Paintable::DrawMode mode);
+    void setSliderPixmap(
+            PixmapSource sourceSlider,
+            Paintable::DrawMode drawMode,
+            double scaleFactor);
+    void setHandlePixmap(
+            bool bHorizontal,
+            PixmapSource sourceHandle,
+            Paintable::DrawMode mode,
+            double scaleFactor);
     inline bool isHorizontal() const { return m_bHorizontal; };
 
   public slots:

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -127,7 +127,8 @@ void WSpinny::onVinylSignalQualityUpdate(const VinylSignalQualityReport& report)
 void WSpinny::setup(const QDomNode& node, const SkinContext& context) {
     // Set images
     QDomElement backPathElement = context.selectElement(node, "PathBackground");
-    m_pBgImage = WImageStore::getImage(context.getPixmapSource(backPathElement));
+    m_pBgImage = WImageStore::getImage(context.getPixmapSource(backPathElement),
+                                       context.getScaleFactor());
     Paintable::DrawMode bgmode = context.selectScaleMode(backPathElement,
                                                          Paintable::FIXED);
     if (m_pBgImage && !m_pBgImage->isNull() && bgmode == Paintable::FIXED) {
@@ -135,16 +136,19 @@ void WSpinny::setup(const QDomNode& node, const SkinContext& context) {
     } else {
         setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
     }
-    m_pMaskImage = WImageStore::getImage(context.getPixmapSource(
-                        context.selectNode(node, "PathMask")));
-    m_pFgImage = WImageStore::getImage(context.getPixmapSource(
-                        context.selectNode(node,"PathForeground")));
+    m_pMaskImage = WImageStore::getImage(
+            context.getPixmapSource(context.selectNode(node, "PathMask")),
+            context.getScaleFactor());
+    m_pFgImage = WImageStore::getImage(
+            context.getPixmapSource(context.selectNode(node,"PathForeground")),
+            context.getScaleFactor());
     if (m_pFgImage && !m_pFgImage->isNull()) {
         m_fgImageScaled = m_pFgImage->scaled(
                 size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
     }
-    m_pGhostImage = WImageStore::getImage(context.getPixmapSource(
-                        context.selectNode(node,"PathGhost")));
+    m_pGhostImage = WImageStore::getImage(
+            context.getPixmapSource(context.selectNode(node,"PathGhost")),
+            context.getScaleFactor());
     if (m_pGhostImage && !m_pGhostImage->isNull()) {
         m_ghostImageScaled = m_pGhostImage->scaled(
                 size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);

--- a/src/widget/wstatuslight.cpp
+++ b/src/widget/wstatuslight.cpp
@@ -58,7 +58,10 @@ void WStatusLight::setup(const QDomNode& node, const SkinContext& context) {
                 (i == 0 && context.hasNodeSelectElement(node, "PathBack", &statusLightNode)) ||
                 (i == 1 && context.hasNodeSelectElement(node, "PathStatusLight", &statusLightNode))) {
             setPixmap(i, context.getPixmapSource(statusLightNode),
-                      context.selectScaleMode(statusLightNode, Paintable::FIXED));
+                      context.selectScaleMode(
+                              statusLightNode,
+                              Paintable::FIXED),
+                              context.getScaleFactor());
         } else {
             m_pixmaps[i].clear();
         }
@@ -66,12 +69,13 @@ void WStatusLight::setup(const QDomNode& node, const SkinContext& context) {
 }
 
 void WStatusLight::setPixmap(int iState, PixmapSource source,
-                             Paintable::DrawMode mode) {
+                             Paintable::DrawMode mode,
+                             double scaleFactor) {
     if (iState < 0 || iState >= m_pixmaps.size()) {
         return;
     }
 
-    PaintablePointer pPixmap = WPixmapStore::getPaintable(source, mode);
+    PaintablePointer pPixmap = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (!pPixmap.isNull() && !pPixmap->isNull()) {
         m_pixmaps[iState] = pPixmap;
         if (mode == Paintable::FIXED) {

--- a/src/widget/wstatuslight.h
+++ b/src/widget/wstatuslight.h
@@ -45,7 +45,8 @@ class WStatusLight : public WWidget  {
     void paintEvent(QPaintEvent * /*unused*/) override;
 
   private:
-    void setPixmap(int iState, PixmapSource source, Paintable::DrawMode mode);
+    void setPixmap(int iState, PixmapSource source,
+                   Paintable::DrawMode mode, double scaleFactor);
     void setNoPos(int iNoPos);
 
     // Current position

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -58,15 +58,18 @@ void WVuMeter::setup(const QDomNode& node, const SkinContext& context) {
     if (!backPathNode.isNull()) {
         // The implicit default in <1.12.0 was FIXED so we keep it for backwards
         // compatibility.
-        setPixmapBackground(context.getPixmapSource(backPathNode),
-                            context.selectScaleMode(backPathNode, Paintable::FIXED));
+        setPixmapBackground(
+                context.getPixmapSource(backPathNode),
+                context.selectScaleMode(backPathNode, Paintable::FIXED),
+                context.getScaleFactor());
     }
 
     QDomElement vuNode = context.selectElement(node, "PathVu");
     // The implicit default in <1.12.0 was FIXED so we keep it for backwards
     // compatibility.
     setPixmaps(context.getPixmapSource(vuNode), bHorizontal,
-               context.selectScaleMode(vuNode, Paintable::FIXED));
+               context.selectScaleMode(vuNode, Paintable::FIXED),
+               context.getScaleFactor());
 
     m_iPeakHoldSize = context.selectInt(node, "PeakHoldSize");
     if (m_iPeakHoldSize < 0 || m_iPeakHoldSize > 100) {
@@ -89,8 +92,11 @@ void WVuMeter::setup(const QDomNode& node, const SkinContext& context) {
     }
 }
 
-void WVuMeter::setPixmapBackground(PixmapSource source, Paintable::DrawMode mode) {
-    m_pPixmapBack = WPixmapStore::getPaintable(source, mode);
+void WVuMeter::setPixmapBackground(
+        PixmapSource source,
+        Paintable::DrawMode mode,
+        double scaleFactor) {
+    m_pPixmapBack = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (m_pPixmapBack.isNull() || m_pPixmapBack->isNull()) {
         qDebug() << metaObject()->className()
                  << "Error loading background pixmap:" << source.getPath();
@@ -99,9 +105,9 @@ void WVuMeter::setPixmapBackground(PixmapSource source, Paintable::DrawMode mode
     }
 }
 
-void WVuMeter::setPixmaps(PixmapSource source,
-                          bool bHorizontal, Paintable::DrawMode mode) {
-    m_pPixmapVu = WPixmapStore::getPaintable(source, mode);
+void WVuMeter::setPixmaps(PixmapSource source, bool bHorizontal,
+                          Paintable::DrawMode mode, double scaleFactor ) {
+    m_pPixmapVu = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (m_pPixmapVu.isNull() || m_pPixmapVu->isNull()) {
         qDebug() << "WVuMeter: Error loading vu pixmap" << source.getPath();
     } else {

--- a/src/widget/wvumeter.h
+++ b/src/widget/wvumeter.h
@@ -35,10 +35,15 @@ class WVuMeter : public WWidget  {
     explicit WVuMeter(QWidget *parent=nullptr);
 
     void setup(const QDomNode& node, const SkinContext& context);
-    void setPixmapBackground(PixmapSource source, Paintable::DrawMode mode);
-    void setPixmaps(PixmapSource source,
-                    bool bHorizontal,
-                    Paintable::DrawMode mode);
+    void setPixmapBackground(
+            PixmapSource source,
+            Paintable::DrawMode mode,
+            double scaleFactor);
+    void setPixmaps(
+            PixmapSource source,
+            bool bHorizontal,
+            Paintable::DrawMode mode,
+            double scaleFactor);
     void onConnectedControlChanged(double dParameter, double dValue) override;
 
   protected slots:

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -44,7 +44,6 @@ WWaveformViewer::~WWaveformViewer() {
 }
 
 void WWaveformViewer::setup(const QDomNode& node, const SkinContext& context) {
-    Q_UNUSED(context);
     if (m_waveformWidget) {
         m_waveformWidget->setup(node, context);
     }

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -46,12 +46,10 @@ bool WWidget::event(QEvent* e) {
         updateTooltip();
     } if (e->type() == QEvent::FontChange) {
         const QFont& fonti = font();
-        // Change the new font on the fly by casting away its constness
+        // Change the new font on the fly by casting away its constancy
         // using setFont() here, would results into a recursive loop
         // resetting the font to the original css values.
-        if (fonti.pointSizeF() > 0) {
-            const_cast<QFont&>(fonti).setPointSizeF(fonti.pointSizeF() * m_scaleFactor);
-        }
+        // Only scale pixel size fonts, point size fonts are scaled by the OS
         if (fonti.pixelSize() > 0) {
             const_cast<QFont&>(fonti).setPixelSize(fonti.pixelSize() * m_scaleFactor);
         }

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -25,7 +25,8 @@
 WWidget::WWidget(QWidget* parent, Qt::WindowFlags flags)
         : QWidget(parent, flags),
           WBaseWidget(this),
-          m_activeTouchButton(Qt::NoButton) {
+          m_activeTouchButton(Qt::NoButton),
+          m_scaleFactor(1.0) {
     m_pTouchShift = new ControlProxy("[Controls]", "touch_shift");
     setAttribute(Qt::WA_StaticContents);
     setAttribute(Qt::WA_AcceptTouchEvents);
@@ -43,6 +44,17 @@ bool WWidget::touchIsRightButton() {
 bool WWidget::event(QEvent* e) {
     if (e->type() == QEvent::ToolTip) {
         updateTooltip();
+    } if (e->type() == QEvent::FontChange) {
+        const QFont& fonti = font();
+        // Change the new font on the fly by casting away its constness
+        // using setFont() here, would results into a recursive loop
+        // resetting the font to the original css values.
+        if (fonti.pointSizeF() > 0) {
+            const_cast<QFont&>(fonti).setPointSizeF(fonti.pointSizeF() * m_scaleFactor);
+        }
+        if (fonti.pixelSize() > 0) {
+            const_cast<QFont&>(fonti).setPixelSize(fonti.pixelSize() * m_scaleFactor);
+        }
     } else if (isEnabled()) {
         switch(e->type()) {
         case QEvent::TouchBegin:

--- a/src/widget/wwidget.h
+++ b/src/widget/wwidget.h
@@ -48,11 +48,18 @@ class WWidget : public QWidget, public WBaseWidget {
   protected:
     bool touchIsRightButton();
     bool event(QEvent* e) override;
+    void setScaleFactor(double value) {
+        m_scaleFactor = value;
+    }
+    double scaleFactor() {
+        return m_scaleFactor;
+    }
 
     enum Qt::MouseButton m_activeTouchButton;
 
   private:
     ControlProxy* m_pTouchShift;
+    double m_scaleFactor;
 };
 
 #endif

--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -103,7 +103,8 @@ void WWidgetGroup::setup(const QDomNode& node, const SkinContext& context) {
     if (!backPathNode.isNull()) {
         setPixmapBackground(
                 context.getPixmapSource(backPathNode),
-                context.selectScaleMode(backPathNode, Paintable::TILE));
+                context.selectScaleMode(backPathNode, Paintable::TILE),
+                context.getScaleFactor());
     }
 
     // Set background pixmap for the highlighted state
@@ -112,7 +113,8 @@ void WWidgetGroup::setup(const QDomNode& node, const SkinContext& context) {
     if (!backPathNodeHighlighted.isNull()) {
         setPixmapBackgroundHighlighted(
                 context.getPixmapSource(backPathNodeHighlighted),
-                context.selectScaleMode(backPathNodeHighlighted, Paintable::TILE));
+                context.selectScaleMode(backPathNodeHighlighted, Paintable::TILE),
+                context.getScaleFactor());
     }
 
     QLayout* pLayout = nullptr;
@@ -147,9 +149,11 @@ void WWidgetGroup::setup(const QDomNode& node, const SkinContext& context) {
 }
 
 void WWidgetGroup::setPixmapBackground(
-        PixmapSource source, Paintable::DrawMode mode) {
+        PixmapSource source,
+        Paintable::DrawMode mode,
+        double scaleFactor) {
     // Load background pixmap
-    m_pPixmapBack = WPixmapStore::getPaintable(source, mode);
+    m_pPixmapBack = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (!m_pPixmapBack) {
         qWarning() << "WWidgetGroup: Error loading background pixmap:"
                  << source.getPath();
@@ -157,9 +161,11 @@ void WWidgetGroup::setPixmapBackground(
 }
 
 void WWidgetGroup::setPixmapBackgroundHighlighted(
-        PixmapSource source, Paintable::DrawMode mode) {
+        PixmapSource source,
+        Paintable::DrawMode mode,
+        double scaleFactor) {
     // Load background pixmap for the highlighted state
-    m_pPixmapBackHighlighted = WPixmapStore::getPaintable(source, mode);
+    m_pPixmapBackHighlighted = WPixmapStore::getPaintable(source, mode, scaleFactor);
     if (!m_pPixmapBackHighlighted) {
         qWarning() << "WWidgetGroup: Error loading background highlighted pixmap:"
                  << source.getPath();

--- a/src/widget/wwidgetgroup.h
+++ b/src/widget/wwidgetgroup.h
@@ -66,8 +66,14 @@ class WWidgetGroup : public QFrame, public WBaseWidget {
     void setHighlight(int highlight);
 
     virtual void setup(const QDomNode& node, const SkinContext& context);
-    void setPixmapBackground(PixmapSource source, Paintable::DrawMode mode);
-    void setPixmapBackgroundHighlighted(PixmapSource source, Paintable::DrawMode mode);
+    void setPixmapBackground(
+            PixmapSource source,
+            Paintable::DrawMode mode,
+            double scaleFactor);
+    void setPixmapBackgroundHighlighted(
+            PixmapSource source,
+            Paintable::DrawMode mode,
+            double scaleFactor);
     void addWidget(QWidget* pChild);
 
   signals:


### PR DESCRIPTION
This is the PR original started by @devananda to allow to build skins using @2x suffixed images for HiDpi screens. 

I have picked it up, because we have an increasing amount of reports complaining about missing HiDPI support on Win and Linux. Mac has already "some" HiDpi support by the OS, for font rendering, and upscaling. so there seams to be less pressure.  

I have now completed his work with floating point scaling for almost all skin widgets.
For now, I have kept the checkbox in preferences for double only. I consider fractional scaling as an experimental option, that can be enabled by editing the cfg file. `ScaleFactor 0.5`
This is usefull for example to test big skins on small displays. 
It is fun to test exotic scaling values B-)

I have failed to scale the combobox which is heavy styled by a style sheet. 
Qt4 has no nice interface to hock between style sheet ans widget painting. 
So other styled elements are effected as well. 
I think a complete solution for this requires Qt5. 

I have no HiDPI screen, so I cannot decide if this is already usable. 
Assuming this does not break 1x scaling, this is a candidate to include it into 2.1 marked as experimental.

In any case this is a step in a right direction, because it allows high resolution cover arts and waveforms.

  

 