### PR TITLE
Decrease time taken to shuffle in the database

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -863,9 +863,9 @@ void PlaylistDAO::shuffleTracks(const int playlistId, const QList<int>& position
     qsrand(seed);
     QHash<int,TrackId> trackPositionIds = allIds;
     QList<int> newPositions = positions;
-    QList<int> tablePositionList, tableIDList;
+    QList<QPair<int, int> > tablePositionList;
     const int searchDistance = math_max(trackPositionIds.count() / 4, 1);
-    createTablePositionList(tablePositionList, tableIDList, playlistId);
+    createTablePositionList(tablePositionList, playlistId);
 
     qDebug() << "Shuffling Tracks";
     qDebug() << "*** Search Distance: " << searchDistance;
@@ -982,21 +982,27 @@ void PlaylistDAO::shuffleTracks(const int playlistId, const QList<int>& position
         trackPositionIds.insert(trackBPosition, trackAId);
         newPositions.swap(newPositions.indexOf(trackAPosition),
                           newPositions.indexOf(trackBPosition));
-        QList<int>::iterator posA = qFind(tablePositionList.begin(),
-                tablePositionList.end(), trackAPosition);
-        QList<int>::iterator posB = qFind(tablePositionList.begin(),
-                tablePositionList.end(), trackBPosition);
-        qSwap(*posA, *posB);
+        int posA, posB, tmp;
+        for(int i = 0; i < tablePositionList.size(); i++) {
+            if(tablePositionList[i].first == trackAPosition)
+                posA = i;
+            if(tablePositionList[i].first == trackBPosition)
+                posB = i;
+        }
+
+        tmp = tablePositionList[posA].first;
+        tablePositionList[posA].first = tablePositionList[posB].first;
+        tablePositionList[posB].first = tmp;
 
         if (query.lastError().isValid())
             qDebug() << query.lastError();
     }
     
     QString swapQuery = "UPDATE PlaylistTracks SET position=%1 "
-        "WHERE id=%2 AND playlist_id=%3";
+        "WHERE position=%2 AND playlist_id=%3";
     for(int i = 0; i < tablePositionList.size(); i++) {
-        query.exec(swapQuery.arg(QString::number(tablePositionList[i]),
-                    QString::number(tableIDList[i]),
+        query.exec(swapQuery.arg(QString::number(tablePositionList[i].first),
+                    QString::number(tablePositionList[i].second),
                     QString::number(playlistId)));
         if (query.lastError().isValid())
             qDebug() << query.lastError();
@@ -1049,19 +1055,17 @@ void PlaylistDAO::sendToAutoDJ(const QList<TrackId>& trackIds, AutoDJSendLoc loc
     }
 }
 
-void PlaylistDAO::createTablePositionList(QList<int> &positionsTable,
-        QList<int> &idTable, const int playList_ID) {
+void PlaylistDAO::createTablePositionList(QList<QPair<int, int> > &positionsTable,
+        const int playList_ID) {
     QSqlQuery query(m_database);
-    QString getPositionQuery = "SELECT position, id FROM PlaylistTracks \
+    QString getPositionQuery = "SELECT position FROM PlaylistTracks \
         WHERE playlist_id == %1";
     query.prepare(getPositionQuery.arg(QString::number(playList_ID)));
     query.exec();
     while(query.next())
     {
         int position = query.value(0).toInt();
-        int id = query.value(1).toInt();
-        positionsTable.append(position);
-        idTable.append(id);
+        positionsTable.append(qMakePair(position, position));
     }
 }
 

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -865,8 +865,7 @@ void PlaylistDAO::shuffleTracks(const int playlistId, const QList<int>& position
     QList<int> newPositions = positions;
     QList<int> tablePositionList, tableIDList;
     const int searchDistance = math_max(trackPositionIds.count() / 4, 1);
-    createTablePositionList(tablePositionList, playlistId);
-    createTableIDList(tableIDList, playlistId);
+    createTablePositionList(tablePositionList, tableIDList, playlistId);
 
     qDebug() << "Shuffling Tracks";
     qDebug() << "*** Search Distance: " << searchDistance;
@@ -1050,32 +1049,19 @@ void PlaylistDAO::sendToAutoDJ(const QList<TrackId>& trackIds, AutoDJSendLoc loc
     }
 }
 
-void PlaylistDAO::createTablePositionList(QList<int> &positionsTable, const int playList_ID) {
+void PlaylistDAO::createTablePositionList(QList<int> &positionsTable,
+        QList<int> &idTable, const int playList_ID) {
     QSqlQuery query(m_database);
-    QString getPositionQuery = "SELECT position from PlaylistTracks \
+    QString getPositionQuery = "SELECT position, id FROM PlaylistTracks \
         WHERE playlist_id == %1";
     query.prepare(getPositionQuery.arg(QString::number(playList_ID)));
     query.exec();
     while(query.next())
     {
         int position = query.value(0).toInt();
+        int id = query.value(1).toInt();
         positionsTable.append(position);
-
+        idTable.append(id);
     }
-}
-
-void PlaylistDAO::createTableIDList(QList<int> &idList, const int playList_ID) {
-    QSqlQuery query(m_database);
-    QString getPositionQuery = "SELECT id from PlaylistTracks \
-        WHERE playlist_id == %1";
-    query.prepare(getPositionQuery.arg(QString::number(playList_ID)));
-    query.exec();
-    while(query.next())
-    {
-        int position = query.value(0).toInt();
-        idList.append(position);
-
-    }
-
 }
 

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -863,9 +863,9 @@ void PlaylistDAO::shuffleTracks(const int playlistId, const QList<int>& position
     qsrand(seed);
     QHash<int,TrackId> trackPositionIds = allIds;
     QList<int> newPositions = positions;
-    QList<int> playListTrackIds;
+    QList<int> playListTracksRowIds;
     const int searchDistance = math_max(trackPositionIds.count() / 4, 1);
-    playListTrackIds = getPlaylistTrackIds(playlistId);
+    playListTracksRowIds = getPlaylistTracksRowIds(playlistId);
 
     qDebug() << "Shuffling Tracks";
     qDebug() << "*** Search Distance: " << searchDistance;
@@ -983,15 +983,15 @@ void PlaylistDAO::shuffleTracks(const int playlistId, const QList<int>& position
         newPositions.swap(newPositions.indexOf(trackAPosition),
                           newPositions.indexOf(trackBPosition));
 
-        qSwap(playListTrackIds[trackAPosition - 1],
-              playListTrackIds[trackBPosition - 1]);
+        qSwap(playListTracksRowIds[trackAPosition - 1],
+              playListTracksRowIds[trackBPosition - 1]);
     }
     
     QString changePositionQuery = "UPDATE PlaylistTracks SET position=%1 "
         "WHERE id=%2";
-    for(int i = 0; i < playListTrackIds.size(); i++) {
+    for(int i = 0; i < playListTracksRowIds.size(); i++) {
         query.exec(changePositionQuery.arg(QString::number(i + 1),
-                                           QString::number(playListTrackIds[i])));
+                                           QString::number(playListTracksRowIds[i])));
         if (query.lastError().isValid())
             qDebug() << query.lastError();
     }
@@ -1044,7 +1044,7 @@ void PlaylistDAO::sendToAutoDJ(const QList<TrackId>& trackIds, AutoDJSendLoc loc
 }
 
 
-QList<int> PlaylistDAO::getPlaylistTrackIds(int playlistID) {
+QList<int> PlaylistDAO::getPlaylistTracksRowIds(int playlistID) {
     QList<int> idList;
     QSqlQuery query(m_database);
     QString getIdsQuery = "SELECT id FROM PlaylistTracks WHERE playlist_id=%1 "

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -144,8 +144,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     QMultiHash<TrackId, int> m_playlistsTrackIsIn;
     AutoDJProcessor* m_pAutoDJProcessor;
     DISALLOW_COPY_AND_ASSIGN(PlaylistDAO);
-    void createTablePositionList(QList<int> &, const int);
-    void createTableIDList(QList<int> &, const int);
+    void createTablePositionList(QList<int> &, QList<int> &, const int);
 };
 
 #endif //PLAYLISTDAO_H

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -144,7 +144,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     QMultiHash<TrackId, int> m_playlistsTrackIsIn;
     AutoDJProcessor* m_pAutoDJProcessor;
     DISALLOW_COPY_AND_ASSIGN(PlaylistDAO);
-    QList<int> getPlaylistTrackIds(int playListID);
+    QList<int> getPlaylistTracksRowIds(int playListID);
 };
 
 #endif //PLAYLISTDAO_H

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -144,6 +144,8 @@ class PlaylistDAO : public QObject, public virtual DAO {
     QMultiHash<TrackId, int> m_playlistsTrackIsIn;
     AutoDJProcessor* m_pAutoDJProcessor;
     DISALLOW_COPY_AND_ASSIGN(PlaylistDAO);
+    void createTablePositionList(QList<int> &, const int);
+    void createTableIDList(QList<int> &, const int);
 };
 
 #endif //PLAYLISTDAO_H

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -144,7 +144,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     QMultiHash<TrackId, int> m_playlistsTrackIsIn;
     AutoDJProcessor* m_pAutoDJProcessor;
     DISALLOW_COPY_AND_ASSIGN(PlaylistDAO);
-    void createTableIDList(QList<int>* pIdList, int playListID);
+    QList<int> getPlaylistTrackIds(int playListID);
 };
 
 #endif //PLAYLISTDAO_H

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -144,7 +144,12 @@ class PlaylistDAO : public QObject, public virtual DAO {
     QMultiHash<TrackId, int> m_playlistsTrackIsIn;
     AutoDJProcessor* m_pAutoDJProcessor;
     DISALLOW_COPY_AND_ASSIGN(PlaylistDAO);
-    QList<QPair<int, int> > getPlaylistTracksPositionRowIds(int playListID);
+    struct PlaylistPosition
+    {
+        int position;
+        int id;
+    };
+    QList<PlaylistPosition> getTracksPositionRowIds(int playListID);
 };
 
 #endif //PLAYLISTDAO_H

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -144,7 +144,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     QMultiHash<TrackId, int> m_playlistsTrackIsIn;
     AutoDJProcessor* m_pAutoDJProcessor;
     DISALLOW_COPY_AND_ASSIGN(PlaylistDAO);
-    QList<int> getPlaylistTracksRowIds(int playListID);
+    QList<QPair<int, int> > getPlaylistTracksPositionRowIds(int playListID);
 };
 
 #endif //PLAYLISTDAO_H

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -144,7 +144,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     QMultiHash<TrackId, int> m_playlistsTrackIsIn;
     AutoDJProcessor* m_pAutoDJProcessor;
     DISALLOW_COPY_AND_ASSIGN(PlaylistDAO);
-    void createTablePositionList(QList<QPair<int, int> > &, const int);
+    void createTablePositionList(QList<int> &, QList<int> &, const int);
 };
 
 #endif //PLAYLISTDAO_H

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -144,7 +144,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     QMultiHash<TrackId, int> m_playlistsTrackIsIn;
     AutoDJProcessor* m_pAutoDJProcessor;
     DISALLOW_COPY_AND_ASSIGN(PlaylistDAO);
-    void createTablePositionList(QList<int> &, QList<int> &, const int);
+    void createTableIDList(QList<int>* pIdList, int playListID);
 };
 
 #endif //PLAYLISTDAO_H

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -144,7 +144,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     QMultiHash<TrackId, int> m_playlistsTrackIsIn;
     AutoDJProcessor* m_pAutoDJProcessor;
     DISALLOW_COPY_AND_ASSIGN(PlaylistDAO);
-    void createTablePositionList(QList<int> &, QList<int> &, const int);
+    void createTablePositionList(QList<QPair<int, int> > &, const int);
 };
 
 #endif //PLAYLISTDAO_H


### PR DESCRIPTION
With reference to https://bugs.launchpad.net/mixxx/+bug/1665284 , I make the pull request, the time will now naturally reduced as the swapping will first be done in the data structure, in the ram first, then the output will be just copied to the database so reduces time.