### PR TITLE
fix for BPM becoming Inf (https://bugs.launchpad.net/mixxx/+bug/1631393)

### DIFF
--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -231,10 +231,11 @@ void SyncControl::setMasterBpm(double bpm) {
     }
 
     double localBpm = m_pLocalBpm->get();
-    if (localBpm > 0.0) {
+    double rateRange = m_pRateRange->get();
+    if (localBpm > 0.0 && rateRange > 0.0) {
         double newRate = m_pRateDirection->get() *
                 ((bpm * m_masterBpmAdjustFactor / localBpm) - 1.0) /
-                m_pRateRange->get();
+                rateRange;
         m_pRateSlider->set(newRate);
     } else {
         m_pRateSlider->set(0);


### PR DESCRIPTION
m_pRateRange->get() is zero and not checked.
This results in division through zero. This change checks if the rateRange is zero and sets the pitch change accordingly.

This PR fixes a filed bug for the 2.1.0 release.
https://bugs.launchpad.net/mixxx/+bug/1631393

I don't know why the range is zero. On a fresh startup the config file is created with the value 8, but the value is not used on the first start. With this fix the value is read on the second startup after being shut down gracefully. Without the fix neither the config file not the analyzed songs are written to disk. I think fixing the loading of th config-file belongs to another pull request.