### PR TITLE
Cover art UX improvements

### DIFF
--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -1,49 +1,161 @@
 #include <QDesktopWidget>
+#include <QWheelEvent>
 
 #include "library/dlgcoverartfullsize.h"
 #include "library/coverartutils.h"
+#include "library/coverartcache.h"
 
-DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent)
-        : QDialog(parent) {
+DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlayer)
+        : QDialog(parent),
+          m_pPlayer(pPlayer),
+          m_pCoverMenu(new WCoverArtMenu(this)) {
+    CoverArtCache* pCache = CoverArtCache::instance();
+    if (pCache != nullptr) {
+        connect(pCache, SIGNAL(coverFound(const QObject*,
+                                          const CoverInfo&, QPixmap, bool)),
+                this, SLOT(slotCoverFound(const QObject*,
+                                          const CoverInfo&, QPixmap, bool)));
+    }
+
+    setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(this, SIGNAL(customContextMenuRequested(QPoint)),
+            this, SLOT(slotCoverMenu(QPoint)));
+    connect(m_pCoverMenu, SIGNAL(coverInfoSelected(const CoverInfo&)),
+            this, SLOT(slotCoverInfoSelected(const CoverInfo&)));
+    connect(m_pCoverMenu, SIGNAL(reloadCoverArt()),
+            this, SLOT(slotReloadCoverArt()));
+
+    if (m_pPlayer != nullptr) {
+        connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
+                this, SLOT(slotLoadTrack(TrackPointer)));
+    }
+
     setupUi(this);
-    setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
 }
 
 DlgCoverArtFullSize::~DlgCoverArtFullSize() {
 }
 
-void DlgCoverArtFullSize::init(QPixmap pixmap) {
-    if (pixmap.isNull()) {
+void DlgCoverArtFullSize::init(TrackPointer pTrack) {
+    if (pTrack == nullptr) {
         return;
     }
-
-    QWidgetList windows = QApplication::topLevelWidgets();
-    QSize largestWindowSize;
-    foreach (QWidget* pWidget, windows) {
-        largestWindowSize = largestWindowSize.expandedTo(pWidget->size());
-    }
-
-    // If cover is bigger than Mixxx, it must be resized!
-    // In this case, it need to do a small adjust to make
-    // this dlg a bit smaller than the Mixxx window.
-    QSize mixxxSize = largestWindowSize / qreal(1.2);
-    if (pixmap.height() > mixxxSize.height()
-            || pixmap.width() > mixxxSize.width()) {
-        pixmap = pixmap.scaled(
-            mixxxSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    }
-    resize(pixmap.size());
-    coverArt->setPixmap(pixmap);
+    slotLoadTrack(pTrack);
 
     show();
-    move(QApplication::desktop()->screenGeometry().center() - rect().center());
     raise();
     activateWindow();
 }
 
+void DlgCoverArtFullSize::slotLoadTrack(TrackPointer pTrack) {
+    if (m_pLoadedTrack) {
+        disconnect(m_pLoadedTrack.get(), SIGNAL(coverArtUpdated()),
+                   this, SLOT(slotTrackCoverArtUpdated()));
+    }
+    m_pLoadedTrack = pTrack;
+    if (m_pLoadedTrack) {
+        QString windowTitle;
+        const QString albumArtist = m_pLoadedTrack->getAlbumArtist();
+        const QString artist = m_pLoadedTrack->getArtist();
+        const QString album = m_pLoadedTrack->getAlbum();
+        const QString year = m_pLoadedTrack->getYear();
+        if (!albumArtist.isEmpty()) {
+            windowTitle = albumArtist;
+        } else if (!artist.isEmpty()) {
+            windowTitle += artist;
+        }
+        if (!album.isEmpty()) {
+            if (!windowTitle.isEmpty()) {
+                windowTitle += " - ";
+            }
+            windowTitle += album;
+        }
+        if (!year.isEmpty()) {
+            if (!windowTitle.isEmpty()) {
+                windowTitle += " ";
+            }
+            windowTitle += QString("(%1)").arg(year);
+        }
+        setWindowTitle(windowTitle);
+
+        connect(m_pLoadedTrack.get(), SIGNAL(coverArtUpdated()),
+                this, SLOT(slotTrackCoverArtUpdated()));
+    }
+
+    slotTrackCoverArtUpdated();
+}
+
+void DlgCoverArtFullSize::slotTrackCoverArtUpdated() {
+    if (m_pLoadedTrack != nullptr) {
+        CoverArtCache::requestCover(*m_pLoadedTrack, this);
+    }
+}
+
+void DlgCoverArtFullSize::slotCoverFound(const QObject* pRequestor,
+                                         const CoverInfo& info, QPixmap pixmap,
+                                         bool fromCache) {
+    Q_UNUSED(info);
+    Q_UNUSED(fromCache);
+
+    if (pRequestor == this && m_pLoadedTrack != nullptr &&
+            m_pLoadedTrack->getCoverHash() == info.hash) {
+        // qDebug() << "DlgCoverArtFullSize::slotCoverFound" << pRequestor << info
+        //          << pixmap.size();
+        m_pixmap = pixmap;
+        move(QApplication::desktop()->screenGeometry().center() - rect().center());
+        if (m_pixmap.isNull()) {
+            close();
+        } else {
+            resize(pixmap.size());
+        }
+    }
+}
+
+// slots to handle signals from the context menu
+void DlgCoverArtFullSize::slotReloadCoverArt() {
+    if (m_pLoadedTrack) {
+        CoverInfo coverInfo =
+                CoverArtUtils::guessCoverInfo(*m_pLoadedTrack);
+        slotCoverInfoSelected(coverInfo);
+    }
+}
+
+void DlgCoverArtFullSize::slotCoverInfoSelected(const CoverInfo& coverInfo) {
+    qDebug() << "DlgCoverArtFullSize::slotCoverInfoSelected" << coverInfo;
+    if (m_pLoadedTrack != nullptr) {
+        m_pLoadedTrack->setCoverInfo(coverInfo);
+    }
+}
+
 void DlgCoverArtFullSize::mousePressEvent(QMouseEvent* event) {
     Q_UNUSED(event);
-    if (isVisible()) {
+
+    if (m_pCoverMenu->isVisible()) {
+        return;
+    }
+
+    if (event->button() == Qt::LeftButton && isVisible()) {
         close();
     }
+}
+
+void DlgCoverArtFullSize::slotCoverMenu(const QPoint& pos) {
+    m_pCoverMenu->popup(mapToGlobal(pos));
+}
+
+void DlgCoverArtFullSize::resizeEvent(QResizeEvent* event) {
+    Q_UNUSED(event);
+    qDebug() << "DlgCoverArtFullSize::resizeEvent" << size();
+    QPixmap resizedPixmap = m_pixmap.scaled(size(),
+        Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    coverArt->setPixmap(resizedPixmap);
+}
+
+void DlgCoverArtFullSize::wheelEvent(QWheelEvent* event) {
+    int newWidth = width() + (0.2 * event->delta());
+    int newHeight = height() + (0.2 * event->delta());
+    QSize newSize = size();
+    newSize.scale(newWidth, newHeight, Qt::KeepAspectRatio);
+    resize(newSize);
+    event->accept();
 }

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -40,3 +40,10 @@ void DlgCoverArtFullSize::init(QPixmap pixmap) {
     raise();
     activateWindow();
 }
+
+void DlgCoverArtFullSize::mousePressEvent(QMouseEvent* event) {
+    Q_UNUSED(event);
+    if (isVisible()) {
+        close();
+    }
+}

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -48,12 +48,12 @@ void DlgCoverArtFullSize::init(TrackPointer pTrack) {
 }
 
 void DlgCoverArtFullSize::slotLoadTrack(TrackPointer pTrack) {
-    if (m_pLoadedTrack) {
+    if (m_pLoadedTrack != nullptr) {
         disconnect(m_pLoadedTrack.get(), SIGNAL(coverArtUpdated()),
                    this, SLOT(slotTrackCoverArtUpdated()));
     }
     m_pLoadedTrack = pTrack;
-    if (m_pLoadedTrack) {
+    if (m_pLoadedTrack != nullptr) {
         QString windowTitle;
         const QString albumArtist = m_pLoadedTrack->getAlbumArtist();
         const QString artist = m_pLoadedTrack->getArtist();
@@ -113,7 +113,7 @@ void DlgCoverArtFullSize::slotCoverFound(const QObject* pRequestor,
 
 // slots to handle signals from the context menu
 void DlgCoverArtFullSize::slotReloadCoverArt() {
-    if (m_pLoadedTrack) {
+    if (m_pLoadedTrack != nullptr) {
         CoverInfo coverInfo =
                 CoverArtUtils::guessCoverInfo(*m_pLoadedTrack);
         slotCoverInfoSelected(coverInfo);

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -107,10 +107,13 @@ void DlgCoverArtFullSize::slotCoverFound(const QObject* pRequestor,
         if (m_pixmap.isNull()) {
             close();
         } else {
-            // Scale down dialog to screen size if the pixmap is larger than the screen
+            // Scale down dialog if the pixmap is larger than the screen.
+            // Use 90% of screen size instead of 100% to prevent an issue with
+            // whitespace appearing on the side when resizing a window whose
+            // borders touch the edges of the screen.
             QSize dialogSize = m_pixmap.size();
             const QSize availableScreenSpace =
-                QApplication::desktop()->availableGeometry().size();
+                QApplication::desktop()->availableGeometry().size() * 0.9;
             if (dialogSize.height() > availableScreenSpace.height()) {
                 dialogSize.scale(dialogSize.width(), availableScreenSpace.height(),
                                  Qt::KeepAspectRatio);

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -120,7 +120,9 @@ void DlgCoverArtFullSize::slotCoverFound(const QObject* pRequestor,
                 dialogSize.scale(availableScreenSpace.width(), dialogSize.height(),
                                  Qt::KeepAspectRatio);
             }
-            coverArt->setPixmap(m_pixmap);
+            QPixmap resizedPixmap = m_pixmap.scaled(size(),
+                Qt::KeepAspectRatio, Qt::SmoothTransformation);
+            coverArt->setPixmap(resizedPixmap);
             // center the window
             setGeometry(QStyle::alignedRect(
                     Qt::LeftToRight,

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -133,7 +133,7 @@ void DlgCoverArtFullSize::slotReloadCoverArt() {
 }
 
 void DlgCoverArtFullSize::slotCoverInfoSelected(const CoverInfo& coverInfo) {
-    qDebug() << "DlgCoverArtFullSize::slotCoverInfoSelected" << coverInfo;
+    // qDebug() << "DlgCoverArtFullSize::slotCoverInfoSelected" << coverInfo;
     if (m_pLoadedTrack != nullptr) {
         m_pLoadedTrack->setCoverInfo(coverInfo);
     }
@@ -160,7 +160,7 @@ void DlgCoverArtFullSize::resizeEvent(QResizeEvent* event) {
     if (m_pixmap.isNull()) {
         return;
     }
-    qDebug() << "DlgCoverArtFullSize::resizeEvent" << size();
+    // qDebug() << "DlgCoverArtFullSize::resizeEvent" << size();
     QPixmap resizedPixmap = m_pixmap.scaled(size(),
         Qt::KeepAspectRatio, Qt::SmoothTransformation);
     coverArt->setPixmap(resizedPixmap);

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -167,16 +167,27 @@ void DlgCoverArtFullSize::resizeEvent(QResizeEvent* event) {
 }
 
 void DlgCoverArtFullSize::wheelEvent(QWheelEvent* event) {
-    QPoint oldOrigin = frameGeometry().topLeft();
-    int oldWidth = frameGeometry().width();
-    int oldHeight = frameGeometry().height();
+    // Scale the image size
+    int oldWidth = width();
+    int oldHeight = height();
     int newWidth = oldWidth + (0.2 * event->delta());
     int newHeight = oldHeight + (0.2 * event->delta());
     QSize newSize = size();
     newSize.scale(newWidth, newHeight, Qt::KeepAspectRatio);
-    resize(newSize);
-    QPoint newOrigin = QPoint(oldOrigin.x() + (oldWidth - frameGeometry().width()) / 2,
-                              oldOrigin.y() + (oldHeight - frameGeometry().height()) / 2 );
-    move(newOrigin);
+
+    // To keep the same part of the image under the cursor, shift the
+    // origin (top left point) by the distance the point moves under the cursor.
+    QPoint oldOrigin = geometry().topLeft();
+    QPoint oldPointUnderCursor = event->pos();
+    int newPointX = (double) oldPointUnderCursor.x() / oldWidth * newSize.width();
+    int newPointY = (double) oldPointUnderCursor.y() / oldHeight * newSize.height();
+    QPoint newOrigin = QPoint(
+        oldOrigin.x() + (oldPointUnderCursor.x() - newPointX),
+        oldOrigin.y() + (oldPointUnderCursor.y() - newPointY));
+
+    // Calling resize() then move() causes flickering, so resize and move the window
+    // simultaneously with setGeometry().
+    setGeometry(QRect(newOrigin, newSize));
+
     event->accept();
 }

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -167,10 +167,16 @@ void DlgCoverArtFullSize::resizeEvent(QResizeEvent* event) {
 }
 
 void DlgCoverArtFullSize::wheelEvent(QWheelEvent* event) {
-    int newWidth = width() + (0.2 * event->delta());
-    int newHeight = height() + (0.2 * event->delta());
+    QPoint oldOrigin = frameGeometry().topLeft();
+    int oldWidth = frameGeometry().width();
+    int oldHeight = frameGeometry().height();
+    int newWidth = oldWidth + (0.2 * event->delta());
+    int newHeight = oldHeight + (0.2 * event->delta());
     QSize newSize = size();
     newSize.scale(newWidth, newHeight, Qt::KeepAspectRatio);
     resize(newSize);
+    QPoint newOrigin = QPoint(oldOrigin.x() + (oldWidth - frameGeometry().width()) / 2,
+                              oldOrigin.y() + (oldHeight - frameGeometry().height()) / 2 );
+    move(newOrigin);
     event->accept();
 }

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -34,6 +34,7 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlay
 }
 
 DlgCoverArtFullSize::~DlgCoverArtFullSize() {
+    delete m_pCoverMenu;
 }
 
 void DlgCoverArtFullSize::init(TrackPointer pTrack) {

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -106,7 +106,18 @@ void DlgCoverArtFullSize::slotCoverFound(const QObject* pRequestor,
         if (m_pixmap.isNull()) {
             close();
         } else {
-            resize(pixmap.size());
+            // Scale down dialog to screen size if the pixmap is larger than the screen
+            QSize dialogSize = m_pixmap.size();
+            const QSize availableScreenSpace =
+                QApplication::desktop()->availableGeometry().size();
+            if (dialogSize.height() > availableScreenSpace.height()) {
+                dialogSize.scale(dialogSize.width(), availableScreenSpace.height(),
+                                 Qt::KeepAspectRatio);
+            } else if (dialogSize.width() > availableScreenSpace.width()) {
+                dialogSize.scale(availableScreenSpace.width(), dialogSize.height(),
+                                 Qt::KeepAspectRatio);
+            }
+            resize(dialogSize);
         }
     }
 }

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -157,6 +157,9 @@ void DlgCoverArtFullSize::slotCoverMenu(const QPoint& pos) {
 
 void DlgCoverArtFullSize::resizeEvent(QResizeEvent* event) {
     Q_UNUSED(event);
+    if (m_pixmap.isNull()) {
+        return;
+    }
     qDebug() << "DlgCoverArtFullSize::resizeEvent" << size();
     QPixmap resizedPixmap = m_pixmap.scaled(size(),
         Qt::KeepAspectRatio, Qt::SmoothTransformation);

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -103,7 +103,6 @@ void DlgCoverArtFullSize::slotCoverFound(const QObject* pRequestor,
         // qDebug() << "DlgCoverArtFullSize::slotCoverFound" << pRequestor << info
         //          << pixmap.size();
         m_pixmap = pixmap;
-        move(QApplication::desktop()->screenGeometry().center() - rect().center());
         if (m_pixmap.isNull()) {
             close();
         } else {
@@ -121,7 +120,13 @@ void DlgCoverArtFullSize::slotCoverFound(const QObject* pRequestor,
                 dialogSize.scale(availableScreenSpace.width(), dialogSize.height(),
                                  Qt::KeepAspectRatio);
             }
-            resize(dialogSize);
+            coverArt->setPixmap(m_pixmap);
+            // center the window
+            setGeometry(QStyle::alignedRect(
+                    Qt::LeftToRight,
+                    Qt::AlignCenter,
+                    dialogSize,
+                    QApplication::desktop()->availableGeometry()));
         }
     }
 }

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -5,17 +5,39 @@
 
 #include "library/ui_dlgcoverartfullsize.h"
 #include "library/coverart.h"
+#include "mixer/basetrackplayer.h"
+#include "track/track.h"
+#include "widget/wcoverartmenu.h"
 
 class DlgCoverArtFullSize
         : public QDialog,
           public Ui::DlgCoverArtFullSize {
     Q_OBJECT
   public:
-    DlgCoverArtFullSize(QWidget* parent=0);
+    DlgCoverArtFullSize(QWidget* parent = nullptr, BaseTrackPlayer* pPlayer = nullptr);
     virtual ~DlgCoverArtFullSize();
 
-    void init(QPixmap pixmap);
+    void init(TrackPointer pTrack);
     void mousePressEvent(QMouseEvent* /* unused */) override;
+    void resizeEvent(QResizeEvent* event) override;
+    void wheelEvent(QWheelEvent* event) override;
+
+  public slots:
+    void slotLoadTrack(TrackPointer);
+    void slotCoverFound(const QObject* pRequestor,
+            const CoverInfo& info, QPixmap pixmap, bool fromCache);
+    void slotTrackCoverArtUpdated();
+
+    // slots that handle signals from WCoverArtMenu
+    void slotCoverMenu(const QPoint& pos);
+    void slotCoverInfoSelected(const CoverInfo& coverInfo);
+    void slotReloadCoverArt();
+
+  private:
+    QPixmap m_pixmap;
+    TrackPointer m_pLoadedTrack;
+    BaseTrackPlayer* m_pPlayer;
+    WCoverArtMenu* m_pCoverMenu;
 };
 
 #endif // DLGCOVERARTFULLSIZE_H

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -15,6 +15,7 @@ class DlgCoverArtFullSize
     virtual ~DlgCoverArtFullSize();
 
     void init(QPixmap pixmap);
+    void mousePressEvent(QMouseEvent* /* unused */) override;
 };
 
 #endif // DLGCOVERARTFULLSIZE_H

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -222,6 +222,7 @@ void DlgTrackInfo::loadTrack(TrackPointer pTrack) {
 
     populateFields(*m_pLoadedTrack);
     populateCues(m_pLoadedTrack);
+    m_pWCoverArtLabel->loadTrack(m_pLoadedTrack);
 
     // We already listen to changed() so we don't need to listen to individual
     // signals such as cuesUpdates, coverArtUpdated(), etc.

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1107,8 +1107,10 @@ QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
         dummy->setText(tr("Safe Mode Enabled"));
         return dummy;
     }
+
+    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
     WSpinny* spinny = new WSpinny(m_pParent, channelStr, m_pConfig,
-                                  m_pVCManager);
+                                  m_pVCManager, pPlayer);
     if (!spinny->isValid()) {
         delete spinny;
         WLabel* dummy = new WLabel(m_pParent);
@@ -1121,16 +1123,6 @@ QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
     WaveformWidgetFactory::instance()->addTimerListener(spinny);
     connect(spinny, SIGNAL(trackDropped(QString, QString)),
             m_pPlayerManager, SLOT(slotLoadToPlayer(QString, QString)));
-
-    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channelStr);
-    if (pPlayer != NULL) {
-        connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
-                spinny, SLOT(slotLoadTrack(TrackPointer)));
-        connect(pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
-                spinny, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
-        // just in case a track is already loaded
-        spinny->slotLoadTrack(pPlayer->getLoadedTrack());
-    }
 
     spinny->setup(node, *m_pContext);
     spinny->installEventFilter(m_pKeyboard);
@@ -1161,7 +1153,7 @@ QWidget* LegacySkinParser::parseCoverArt(const QDomElement& node) {
     QString channel = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(channel);
 
-    WCoverArt* pCoverArt = new WCoverArt(m_pParent, m_pConfig, channel);
+    WCoverArt* pCoverArt = new WCoverArt(m_pParent, m_pConfig, channel, pPlayer);
     commonWidgetSetup(node, pCoverArt);
     pCoverArt->setup(node, *m_pContext);
 
@@ -1174,16 +1166,9 @@ QWidget* LegacySkinParser::parseCoverArt(const QDomElement& node) {
                 pCoverArt, SLOT(slotEnable(bool)));
         connect(m_pLibrary, SIGNAL(trackSelected(TrackPointer)),
                 pCoverArt, SLOT(slotLoadTrack(TrackPointer)));
-    } else if (pPlayer != NULL) {
-        connect(pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
-                pCoverArt, SLOT(slotLoadTrack(TrackPointer)));
-        connect(pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
-                pCoverArt, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
+    } else if (pPlayer != nullptr) {
         connect(pCoverArt, SIGNAL(trackDropped(QString, QString)),
                 m_pPlayerManager, SLOT(slotLoadToPlayer(QString, QString)));
-
-        // just in case a track is already loaded
-        pCoverArt->slotLoadTrack(pPlayer->getLoadedTrack());
     }
 
     return pCoverArt;

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -60,6 +60,7 @@ void Tooltips::addStandardTooltips() {
             << tr("Spinning Vinyl")
             << tr("Rotates during playback and shows the position of a track.")
             << scratchMouse
+            << tr("Right click to show cover art of loaded track.")
             << dropTracksHere
             << tr("If Vinyl control is enabled, displays time-coded vinyl signal quality (see Preferences -> Vinyl Control).");
 

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -17,14 +17,16 @@
 
 WCoverArt::WCoverArt(QWidget* parent,
                      UserSettingsPointer pConfig,
-                     const QString& group)
+                     const QString& group,
+                     BaseTrackPlayer* pPlayer)
         : QWidget(parent),
           WBaseWidget(this),
           m_group(group),
           m_pConfig(pConfig),
           m_bEnable(true),
           m_pMenu(new WCoverArtMenu(this)),
-          m_pDlgFullSize(new DlgCoverArtFullSize()) {
+          m_pPlayer(pPlayer),
+          m_pDlgFullSize(new DlgCoverArtFullSize(parent, pPlayer)) {
     // Accept drops if we have a group to load tracks into.
     setAcceptDrops(!m_group.isEmpty());
 
@@ -39,6 +41,16 @@ WCoverArt::WCoverArt(QWidget* parent,
             this, SLOT(slotCoverInfoSelected(const CoverInfo&)));
     connect(m_pMenu, SIGNAL(reloadCoverArt()),
             this, SLOT(slotReloadCoverArt()));
+
+    if (m_pPlayer != nullptr) {
+        connect(m_pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
+                this, SLOT(slotLoadTrack(TrackPointer)));
+        connect(m_pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
+                this, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
+
+        // just in case a track is already loaded
+        slotLoadTrack(m_pPlayer->getLoadedTrack());
+    }
 }
 
 WCoverArt::~WCoverArt() {
@@ -223,7 +235,7 @@ void WCoverArt::mousePressEvent(QMouseEvent* event) {
         if (m_pDlgFullSize->isVisible()) {
             m_pDlgFullSize->close();
         } else {
-            m_pDlgFullSize->init(m_loadedCover);
+            m_pDlgFullSize->init(m_loadedTrack);
         }
     }
 }

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -228,10 +228,6 @@ void WCoverArt::mousePressEvent(QMouseEvent* event) {
     }
 }
 
-void WCoverArt::leaveEvent(QEvent* /*unused*/) {
-    m_pDlgFullSize->close();
-}
-
 void WCoverArt::mouseMoveEvent(QMouseEvent* event) {
     if ((event->buttons() & Qt::LeftButton) && m_loadedTrack) {
         DragAndDropHelper::dragTrack(m_loadedTrack, this, m_group);

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -26,7 +26,7 @@ WCoverArt::WCoverArt(QWidget* parent,
           m_bEnable(true),
           m_pMenu(new WCoverArtMenu(this)),
           m_pPlayer(pPlayer),
-          m_pDlgFullSize(new DlgCoverArtFullSize(parent, pPlayer)) {
+          m_pDlgFullSize(new DlgCoverArtFullSize(this, pPlayer)) {
     // Accept drops if we have a group to load tracks into.
     setAcceptDrops(!m_group.isEmpty());
 

--- a/src/widget/wcoverart.h
+++ b/src/widget/wcoverart.h
@@ -6,6 +6,7 @@
 #include <QMouseEvent>
 #include <QWidget>
 
+#include "mixer/basetrackplayer.h"
 #include "preferences/usersettings.h"
 #include "track/track.h"
 #include "library/coverartcache.h"
@@ -19,7 +20,7 @@ class WCoverArt : public QWidget, public WBaseWidget {
     Q_OBJECT
   public:
     WCoverArt(QWidget* parent, UserSettingsPointer pConfig,
-              const QString& group);
+              const QString& group, BaseTrackPlayer* pPlayer);
     ~WCoverArt() override;
 
     void setup(const QDomNode& node, const SkinContext& context);
@@ -62,6 +63,7 @@ class WCoverArt : public QWidget, public WBaseWidget {
     QPixmap m_defaultCover;
     QPixmap m_defaultCoverScaled;
     CoverInfo m_lastRequestedCover;
+    BaseTrackPlayer* m_pPlayer;
     DlgCoverArtFullSize* m_pDlgFullSize;
 };
 

--- a/src/widget/wcoverart.h
+++ b/src/widget/wcoverart.h
@@ -44,7 +44,6 @@ class WCoverArt : public QWidget, public WBaseWidget {
     void paintEvent(QPaintEvent* /*unused*/) override;
     void resizeEvent(QResizeEvent* /*unused*/) override;
     void mousePressEvent(QMouseEvent* /*unused*/) override;
-    void leaveEvent(QEvent* /*unused*/) override;
 
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -10,7 +10,7 @@ static const QSize s_labelDisplaySize = QSize(100, 100);
 WCoverArtLabel::WCoverArtLabel(QWidget* parent)
         : QLabel(parent),
           m_pCoverMenu(new WCoverArtMenu(this)),
-          m_pDlgFullSize(new DlgCoverArtFullSize()),
+          m_pDlgFullSize(new DlgCoverArtFullSize(this, nullptr)),
           m_defaultCover(CoverArtUtils::defaultCoverLocation()) {
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
     setFrameShape(QFrame::Box);
@@ -59,6 +59,10 @@ void WCoverArtLabel::slotCoverMenu(const QPoint& pos) {
     m_pCoverMenu->popup(mapToGlobal(pos));
 }
 
+void WCoverArtLabel::loadTrack(TrackPointer pTrack) {
+    m_pLoadedTrack = pTrack;
+}
+
 void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
     if (m_pCoverMenu->isVisible()) {
         return;
@@ -68,11 +72,8 @@ void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
         if (m_pDlgFullSize->isVisible()) {
             m_pDlgFullSize->close();
         } else {
-            m_pDlgFullSize->init(m_loadedCover);
+            m_pDlgFullSize->init(m_pLoadedTrack);
         }
     }
 }
 
-void WCoverArtLabel::leaveEvent(QEvent* /*unused*/) {
-    m_pDlgFullSize->close();
-}

--- a/src/widget/wcoverartlabel.h
+++ b/src/widget/wcoverartlabel.h
@@ -6,6 +6,7 @@
 #include <QWidget>
 #include <QPixmap>
 
+#include "track/track.h"
 #include "widget/wcoverartmenu.h"
 
 class DlgCoverArtFullSize;
@@ -17,13 +18,13 @@ class WCoverArtLabel : public QLabel {
     ~WCoverArtLabel() override;
 
     void setCoverArt(const CoverInfo& coverInfo, QPixmap px);
+    void loadTrack(TrackPointer pTrack);
 
   signals:
     void coverInfoSelected(const CoverInfo& coverInfo);
     void reloadCoverArt();
 
   protected:
-    void leaveEvent(QEvent* /*unused*/) override;
     void mousePressEvent(QMouseEvent* event) override;
 
   private slots:
@@ -31,6 +32,7 @@ class WCoverArtLabel : public QLabel {
 
   private:
     QPixmap m_loadedCover;
+    TrackPointer m_pLoadedTrack;
     WCoverArtMenu* m_pCoverMenu;
     DlgCoverArtFullSize* m_pDlgFullSize;
     QPixmap m_defaultCover;

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -19,7 +19,8 @@
 // The SampleBuffers format enables antialiasing.
 WSpinny::WSpinny(QWidget* parent, const QString& group,
                  UserSettingsPointer pConfig,
-                 VinylControlManager* pVCMan)
+                 VinylControlManager* pVCMan,
+                 BaseTrackPlayer* pPlayer)
         : QGLWidget(QGLFormat(QGL::SampleBuffers), parent, SharedGLContext::getWidget()),
           WBaseWidget(this),
           m_group(group),
@@ -60,7 +61,9 @@ WSpinny::WSpinny(QWidget* parent, const QString& group,
           m_bClampFailedWarning(false),
           m_bGhostPlayback(false),
           m_bWidgetDirty(false),
-          m_pDlgCoverArt(new DlgCoverArtFullSize()) {
+          m_pPlayer(pPlayer),
+          m_pDlgCoverArt(new DlgCoverArtFullSize(parent, pPlayer)),
+          m_pCoverMenu(new WCoverArtMenu(this)) {
 #ifdef __VINYLCONTROL__
     m_pVCManager = pVCMan;
 #endif
@@ -78,6 +81,19 @@ WSpinny::WSpinny(QWidget* parent, const QString& group,
                                           const CoverInfo&, QPixmap, bool)));
     }
 
+    if (m_pPlayer != nullptr) {
+        connect(m_pPlayer, SIGNAL(newTrackLoaded(TrackPointer)),
+                this, SLOT(slotLoadTrack(TrackPointer)));
+        connect(m_pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
+                this, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
+        // just in case a track is already loaded
+        slotLoadTrack(m_pPlayer->getLoadedTrack());
+    }
+
+    connect(m_pCoverMenu, SIGNAL(coverInfoSelected(const CoverInfo&)),
+        this, SLOT(slotCoverInfoSelected(const CoverInfo&)));
+    connect(m_pCoverMenu, SIGNAL(reloadCoverArt()),
+        this, SLOT(slotReloadCoverArt()));
 }
 
 WSpinny::~WSpinny() {
@@ -277,6 +293,21 @@ void WSpinny::slotCoverFound(const QObject* pRequestor,
     }
 }
 
+void WSpinny::slotCoverInfoSelected(const CoverInfo& coverInfo) {
+    if (m_loadedTrack) {
+        // Will trigger slotTrackCoverArtUpdated().
+        m_loadedTrack->setCoverInfo(coverInfo);
+    }
+}
+
+void WSpinny::slotReloadCoverArt() {
+    if (m_loadedTrack) {
+        CoverArtCache* pCache = CoverArtCache::instance();
+        if (pCache) {
+            pCache->requestGuessCover(m_loadedTrack);
+        }
+    }
+}
 
 void WSpinny::paintEvent(QPaintEvent *e) {
     Q_UNUSED(e); //ditch unused param warning
@@ -541,8 +572,17 @@ void WSpinny::mouseMoveEvent(QMouseEvent * e) {
 }
 
 void WSpinny::mousePressEvent(QMouseEvent * e) {
+    if (m_loadedTrack == nullptr) {
+        return;
+    }
+
     if (m_pDlgCoverArt->isVisible()) {
         m_pDlgCoverArt->close();
+        return;
+    }
+
+    if (m_pCoverMenu->isVisible()) {
+        m_pCoverMenu->close();
         return;
     }
 
@@ -576,8 +616,12 @@ void WSpinny::mousePressEvent(QMouseEvent * e) {
             // Trigger a mouse move to immediately line up the vinyl with the cursor
             mouseMoveEvent(e);
         }
-    } else if (m_bShowCover) {
-        m_pDlgCoverArt->init(m_loadedCover);
+    } else {
+        if (!m_loadedCover.isNull()) {
+            m_pDlgCoverArt->init(m_loadedTrack);
+        } else if (!m_pDlgCoverArt->isVisible()) {
+            m_pCoverMenu->popup(e->pos());
+        }
     }
 }
 
@@ -587,9 +631,6 @@ void WSpinny::mouseReleaseEvent(QMouseEvent * e)
         QApplication::restoreOverrideCursor();
         m_pScratchToggle->set(0.0);
         m_iFullRotations = 0;
-        if (e->button() == Qt::RightButton) {
-            m_pSlipEnabled->set(0.0);
-        }
     }
 }
 

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -59,7 +59,8 @@ WSpinny::WSpinny(QWidget* parent, const QString& group,
           m_dRotationsPerSecond(0.),
           m_bClampFailedWarning(false),
           m_bGhostPlayback(false),
-          m_bWidgetDirty(false) {
+          m_bWidgetDirty(false),
+          m_pDlgCoverArt(new DlgCoverArtFullSize()) {
 #ifdef __VINYLCONTROL__
     m_pVCManager = pVCMan;
 #endif
@@ -540,38 +541,43 @@ void WSpinny::mouseMoveEvent(QMouseEvent * e) {
 }
 
 void WSpinny::mousePressEvent(QMouseEvent * e) {
-    int y = e->y();
-    int x = e->x();
-
-    m_iStartMouseX = x;
-    m_iStartMouseY = y;
-
-    //don't do anything if vinyl control is active
-    if (m_bVinylActive) {
+    if (m_pDlgCoverArt->isVisible()) {
+        m_pDlgCoverArt->close();
         return;
     }
 
-    if (e->button() == Qt::LeftButton || e->button() == Qt::RightButton) {
-        QApplication::setOverrideCursor(QCursor(Qt::ClosedHandCursor));
+    if (e->button() == Qt::LeftButton) {
+        int y = e->y();
+        int x = e->x();
 
-        // Coordinates from center of widget
-        double c_x = x - width()/2;
-        double c_y = y - height()/2;
-        double theta = (180.0/M_PI)*atan2(c_x, -c_y);
-        m_dPrevTheta = theta;
-        m_iFullRotations = calculateFullRotations(m_pPlayPos->get());
-        theta += m_iFullRotations * 360.0;
-        m_dInitialPos = calculatePositionFromAngle(theta) * m_pTrackSamples->get();
+        m_iStartMouseX = x;
+        m_iStartMouseY = y;
 
-        m_pScratchPos->set(0);
-        m_pScratchToggle->set(1.0);
-
-        if (e->button() == Qt::RightButton) {
-            m_pSlipEnabled->set(1.0);
+        //don't do anything if vinyl control is active
+        if (m_bVinylActive) {
+            return;
         }
 
-        // Trigger a mouse move to immediately line up the vinyl with the cursor
-        mouseMoveEvent(e);
+        if (e->button() == Qt::LeftButton || e->button() == Qt::RightButton) {
+            QApplication::setOverrideCursor(QCursor(Qt::ClosedHandCursor));
+
+            // Coordinates from center of widget
+            double c_x = x - width()/2;
+            double c_y = y - height()/2;
+            double theta = (180.0/M_PI)*atan2(c_x, -c_y);
+            m_dPrevTheta = theta;
+            m_iFullRotations = calculateFullRotations(m_pPlayPos->get());
+            theta += m_iFullRotations * 360.0;
+            m_dInitialPos = calculatePositionFromAngle(theta) * m_pTrackSamples->get();
+
+            m_pScratchPos->set(0);
+            m_pScratchToggle->set(1.0);
+
+            // Trigger a mouse move to immediately line up the vinyl with the cursor
+            mouseMoveEvent(e);
+        }
+    } else if (m_bShowCover) {
+        m_pDlgCoverArt->init(m_loadedCover);
     }
 }
 

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -294,14 +294,14 @@ void WSpinny::slotCoverFound(const QObject* pRequestor,
 }
 
 void WSpinny::slotCoverInfoSelected(const CoverInfo& coverInfo) {
-    if (m_loadedTrack) {
+    if (m_loadedTrack != nullptr) {
         // Will trigger slotTrackCoverArtUpdated().
         m_loadedTrack->setCoverInfo(coverInfo);
     }
 }
 
 void WSpinny::slotReloadCoverArt() {
-    if (m_loadedTrack) {
+    if (m_loadedTrack != nullptr) {
         CoverArtCache* pCache = CoverArtCache::instance();
         if (pCache) {
             pCache->requestGuessCover(m_loadedTrack);

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -7,6 +7,7 @@
 #include <QHideEvent>
 #include <QEvent>
 
+#include "library/dlgcoverartfullsize.h"
 #include "preferences/usersettings.h"
 #include "skin/skincontext.h"
 #include "track/track.h"
@@ -119,6 +120,8 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
     bool m_bClampFailedWarning;
     bool m_bGhostPlayback;
     bool m_bWidgetDirty;
+
+    DlgCoverArtFullSize* m_pDlgCoverArt;
 };
 
 #endif //_WSPINNY_H

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -8,11 +8,13 @@
 #include <QEvent>
 
 #include "library/dlgcoverartfullsize.h"
+#include "mixer/basetrackplayer.h"
 #include "preferences/usersettings.h"
 #include "skin/skincontext.h"
 #include "track/track.h"
 #include "vinylcontrol/vinylsignalquality.h"
 #include "widget/wbasewidget.h"
+#include "widget/wcoverartmenu.h"
 #include "widget/wwidget.h"
 
 class ControlProxy;
@@ -24,7 +26,8 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
   public:
     WSpinny(QWidget* parent, const QString& group,
             UserSettingsPointer pConfig,
-            VinylControlManager* pVCMan);
+            VinylControlManager* pVCMan,
+            BaseTrackPlayer* pPlayer);
     ~WSpinny() override;
 
     void onVinylSignalQualityUpdate(const VinylSignalQualityReport& report) override;
@@ -45,6 +48,8 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
     void maybeUpdate();
     void slotCoverFound(const QObject* pRequestor,
                         const CoverInfo& info, QPixmap pixmap, bool fromCache);
+    void slotCoverInfoSelected(const CoverInfo& coverInfo);
+    void slotReloadCoverArt();
     void slotTrackCoverArtUpdated();
 
 
@@ -121,7 +126,9 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
     bool m_bGhostPlayback;
     bool m_bWidgetDirty;
 
+    BaseTrackPlayer* m_pPlayer;
     DlgCoverArtFullSize* m_pDlgCoverArt;
+    WCoverArtMenu* m_pCoverMenu;
 };
 
 #endif //_WSPINNY_H


### PR DESCRIPTION
Rework the UX for showing DlgCoverArtFullSize:
  * don't close DlgCoverArtFullSize when moving cursor off WCoverArt. IMO this was surprising and confusing.
  * close DlgCoverArtFullSize when clicked
  * show DlgCoverArtFullSize when right clicking WSpinny. Before, right clicking on WSpinny paused the track and enabled slip mode. I can't think of a use case for that behavior. The change allows skins to show only WSpinny with cover art but without taking space with a redundant WCoverArt and still make DlgCoverArtFullSize available.