### PR TITLE
WTrackProperty mouse click actions

### DIFF
--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1006,6 +1006,10 @@ QWidget* LegacySkinParser::parseTrackProperty(const QDomElement& node) {
             p, SLOT(slotTrackLoaded(TrackPointer)));
     connect(pPlayer, SIGNAL(loadingTrack(TrackPointer, TrackPointer)),
             p, SLOT(slotLoadingTrack(TrackPointer, TrackPointer)));
+
+    // Sending a null TrackPointer to slotLoadTrackToPlayer ejects the loaded track.
+    connect(p, SIGNAL(ejectTrack(TrackPointer, QString)),
+            m_pPlayerManager, SLOT(slotLoadTrackToPlayer(TrackPointer, QString)));
     connect(p, SIGNAL(trackDropped(QString,QString)),
             m_pPlayerManager, SLOT(slotLoadToPlayer(QString,QString)));
 

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -49,6 +49,12 @@ void WTrackProperty::updateLabel(Track* /*unused*/) {
     }
 }
 
+void WTrackProperty::mousePressEvent(QMouseEvent *event) {
+    if (event->button() != Qt::LeftButton) {
+        emit(ejectTrack(TrackPointer(), QString(m_pGroup)));
+    }
+}
+
 void WTrackProperty::mouseMoveEvent(QMouseEvent *event) {
     if ((event->buttons() & Qt::LeftButton) && m_pCurrentTrack) {
         DragAndDropHelper::dragTrack(m_pCurrentTrack, this, m_pGroup);

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -19,6 +19,7 @@ class WTrackProperty : public WLabel {
 
   signals:
     void trackDropped(QString filename, QString group);
+    void ejectTrack(TrackPointer track, QString group);
 
   public slots:
     void slotTrackLoaded(TrackPointer track);
@@ -30,6 +31,7 @@ class WTrackProperty : public WLabel {
   private:
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
 
     const char* m_pGroup;


### PR DESCRIPTION
This will allow the removal of the eject button from skins. Together with making the spinny toggling a global rather than per-deck state, a whole column can be removed from the grid of buttons next to the overview waveforms. That will feel less cluttered and allow more width for the overviews.