### PR TITLE
VMS4: Disable vertical touch strips while deck is playing

### DIFF
--- a/res/controllers/American Audio VMS4.midi.xml
+++ b/res/controllers/American Audio VMS4.midi.xml
@@ -694,9 +694,12 @@
          </control>
          <control>
             <group>[Channel1]</group>
-            <key>playposition</key>
+            <key>VMS4.touch_strip</key>
             <status>0xB0</status>
             <midino>0x28</midino>
+            <options>
+               <Script-Binding/>
+            </options>
          </control>
 
          <!-- Deck B -->
@@ -1340,9 +1343,12 @@
          </control>
          <control>
             <group>[Channel2]</group>
-            <key>playposition</key>
+            <key>VMS4.touch_strip</key>
             <status>0xB0</status>
             <midino>0x2D</midino>
+            <options>
+               <Script-Binding/>
+            </options>
          </control>
 
          <!-- Mixer main-->

--- a/res/controllers/American-Audio-VMS4-scripts.js
+++ b/res/controllers/American-Audio-VMS4-scripts.js
@@ -392,6 +392,13 @@ VMS4.jog_move_msb = function(channel, control, value, status, group) {
    deck.jogMsb = value;
 }
 
+VMS4.touch_strip = function(channel, control, value, status, group) {
+   // Only modify the playposition if the deck is NOT playing!
+   if (engine.getValue(group, "play") === 0) {
+      engine.setValue(group, "playposition", value);
+   }
+}
+
 VMS4.vinyl = function(channel, control, value, status, group) {
     var deck = VMS4.GetDeck(group);
     deck.Buttons.Vinyl.handleEvent(value);


### PR DESCRIPTION
@Pegasus-RPG I'm not able to test this. I think it makes sense to prevent seeking to random positions inside a track while it is playing.

https://bugs.launchpad.net/mixxx/+bug/1663881