### PR TITLE
persistent samplers

### DIFF
--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -23,6 +23,7 @@ class Library;
 class Microphone;
 class PreviewDeck;
 class Sampler;
+class SamplerBank;
 class SoundManager;
 class TrackCollection;
 
@@ -70,6 +71,9 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     // Add a sampler to the PlayerManager
     void addSampler();
 
+    // Load samplers from samplers.xml file in config directory
+    void loadSamplers();
+
     // Add a PreviewDeck to the PlayerManager
     void addPreviewDeck();
 
@@ -89,6 +93,10 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     // Returns true if the group is a deck group. If index is non-NULL,
     // populates it with the deck number (1-indexed).
     static bool isDeckGroup(const QString& group, int* number=NULL);
+
+    // Returns true if the group is a sampler group. If index is non-NULL,
+    // populates it with the deck number (1-indexed).
+    static bool isSamplerGroup(const QString& group, int* number=nullptr);
 
     // Returns true if the group is a preview deck group. If index is non-NULL,
     // populates it with the deck number (1-indexed).
@@ -228,9 +236,12 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     SoundManager* m_pSoundManager;
     EffectsManager* m_pEffectsManager;
     EngineMaster* m_pEngine;
+    SamplerBank* m_pSamplerBank;
     AnalyzerQueue* m_pAnalyzerQueue;
     ControlObject* m_pCONumDecks;
     ControlObject* m_pCONumSamplers;
+    ControlObject* m_pCOSamplerBankLoad;
+    ControlObject* m_pCOSamplerBankSave;
     ControlObject* m_pCONumPreviewDecks;
     ControlObject* m_pCONumMicrophones;
     ControlObject* m_pCONumAuxiliaries;

--- a/src/mixer/samplerbank.cpp
+++ b/src/mixer/samplerbank.cpp
@@ -13,54 +13,70 @@ SamplerBank::SamplerBank(PlayerManager* pPlayerManager)
         : QObject(pPlayerManager),
           m_pPlayerManager(pPlayerManager) {
     DEBUG_ASSERT(m_pPlayerManager);
-    m_pLoadControl = new ControlPushButton(ConfigKey("[Sampler]", "LoadSamplerBank"));
-    connect(m_pLoadControl, SIGNAL(valueChanged(double)),
+    m_pCOLoadBank = new ControlPushButton(ConfigKey("[Sampler]", "LoadSamplerBank"));
+    connect(m_pCOLoadBank, SIGNAL(valueChanged(double)),
             this, SLOT(slotLoadSamplerBank(double)));
-    m_pSaveControl = new ControlPushButton(ConfigKey("[Sampler]", "SaveSamplerBank"));
-    connect(m_pSaveControl, SIGNAL(valueChanged(double)),
+    m_pCOSaveBank = new ControlPushButton(ConfigKey("[Sampler]", "SaveSamplerBank"));
+    connect(m_pCOSaveBank, SIGNAL(valueChanged(double)),
             this, SLOT(slotSaveSamplerBank(double)));
+
+    m_pCONumSamplers = new ControlProxy(ConfigKey("[Master]", "num_samplers"));
 }
 
 SamplerBank::~SamplerBank() {
-    delete m_pLoadControl;
-    delete m_pSaveControl;
+    delete m_pCOLoadBank;
+    delete m_pCOSaveBank;
 }
 
 void SamplerBank::slotSaveSamplerBank(double v) {
-    if (v == 0.0 || m_pPlayerManager == NULL) {
+    if (v <= 0.0) {
         return;
     }
-    QString filefilter = tr("Mixxx Sampler Banks (*.xml)");
+
+    QString fileFilter = tr("Mixxx Sampler Banks (*.xml)");
     QString samplerBankPath = QFileDialog::getSaveFileName(
             NULL, tr("Save Sampler Bank"),
             QString(),
             tr("Mixxx Sampler Banks (*.xml)"),
-            &filefilter);
+            &fileFilter);
     if (samplerBankPath.isNull() || samplerBankPath.isEmpty()) {
         return;
     }
+
     // Manually add extension due to bug in QFileDialog
     // via https://bugreports.qt-project.org/browse/QTBUG-27186
     // Can be removed after switch to Qt5
     QFileInfo fileName(samplerBankPath);
     if (fileName.suffix().isEmpty()) {
-        QString ext = filefilter.section(".",1,1);
+        QString ext = fileFilter.section(".",1,1);
         ext.chop(1);
         samplerBankPath.append(".").append(ext);
     }
 
+    if (!saveSamplerBankToPath(samplerBankPath)) {
+        QMessageBox::warning(NULL,
+                        tr("Error Saving Sampler Bank"),
+                        tr("Could not write the sampler bank to '%1'.")
+                        .arg(samplerBankPath));
+    }
+}
+
+bool SamplerBank::saveSamplerBankToPath(const QString& samplerBankPath) {
     // The user has picked a new directory via a file dialog. This means the
     // system sandboxer (if we are sandboxed) has granted us permission to this
     // folder. We don't need access to this file on a regular basis so we do not
     // register a security bookmark.
 
+    if (m_pPlayerManager == nullptr) {
+        qWarning() << "SamplerBank::saveSamplerBankToPath called with no PlayerManager";
+        return false;
+    }
+
     QFile file(samplerBankPath);
     if (!file.open(QIODevice::WriteOnly)) {
-        QMessageBox::warning(NULL,
-                             tr("Error Saving Sampler Bank"),
-                             tr("Could not write the sampler bank to '%1'.")
-                             .arg(samplerBankPath));
-        return;
+        qWarning() << "Error saving sampler bank: Could not write to file"
+                   << samplerBankPath;
+        return false;
     }
 
     QDomDocument doc("SamplerBank");
@@ -89,10 +105,12 @@ void SamplerBank::slotSaveSamplerBank(double v) {
 
     file.write(docStr.toUtf8().constData());
     file.close();
+
+    return true;
 }
 
 void SamplerBank::slotLoadSamplerBank(double v) {
-    if (v == 0.0 || m_pPlayerManager == NULL) {
+    if (v <= 0.0) {
         return;
     }
 
@@ -105,37 +123,42 @@ void SamplerBank::slotLoadSamplerBank(double v) {
         return;
     }
 
+    if (!loadSamplerBankFromPath(samplerBankPath)) {
+        QMessageBox::warning(NULL,
+                      tr("Error Reading Sampler Bank"),
+                      tr("Could not open the sampler bank file '%1'.")
+                      .arg(samplerBankPath));
+    }
+}
+
+bool SamplerBank::loadSamplerBankFromPath(const QString& samplerBankPath) {
     // The user has picked a new directory via a file dialog. This means the
     // system sandboxer (if we are sandboxed) has granted us permission to this
     // folder. We don't need access to this file on a regular basis so we do not
     // register a security bookmark.
 
+    if (m_pPlayerManager == nullptr) {
+        qWarning() << "SamplerBank::loadSamplerBankFromPath called with no PlayerManager";
+        return false;
+    }
+
     QFile file(samplerBankPath);
     if (!file.open(QIODevice::ReadOnly)) {
-        QMessageBox::warning(NULL,
-                             tr("Error Reading Sampler Bank"),
-                             tr("Could not open the sampler bank file '%1'.")
-                             .arg(samplerBankPath));
-        return;
+        qWarning() << "Could not read sampler bank file" << samplerBankPath;
+        return false;
     }
 
     QDomDocument doc;
 
     if (!doc.setContent(file.readAll())) {
-        QMessageBox::warning(NULL,
-                             tr("Error Reading Sampler Bank"),
-                             tr("Could not read the sampler bank file '%1'.")
-                             .arg(samplerBankPath));
-        return;
+        qWarning() << "Could not read sampler bank file" << samplerBankPath;
+        return false;
     }
 
     QDomElement root = doc.documentElement();
-    if(root.tagName() != "samplerbank") {
-        QMessageBox::warning(NULL,
-                             tr("Error Reading Sampler Bank"),
-                             tr("Could not read the sampler bank file '%1'.")
-                             .arg(samplerBankPath));
-        return;
+    if (root.tagName() != "samplerbank") {
+        qWarning() << "Could not read sampler bank file" << samplerBankPath;
+        return false;
     }
 
     QDomNode n = root.firstChild();
@@ -147,8 +170,14 @@ void SamplerBank::slotLoadSamplerBank(double v) {
             if (e.tagName() == "sampler") {
                 QString group = e.attribute("group", "");
                 QString location = e.attribute("location", "");
+                int samplerNum;
 
-                if (!group.isEmpty()) {
+                if (!group.isEmpty()
+                        && m_pPlayerManager->isSamplerGroup(group, &samplerNum)) {
+                    if (m_pPlayerManager->numSamplers() < (unsigned) samplerNum) {
+                        m_pCONumSamplers->set(samplerNum);
+                    }
+
                     if (location.isEmpty()) {
                         m_pPlayerManager->slotLoadTrackToPlayer(TrackPointer(), group);
                     } else {
@@ -162,4 +191,5 @@ void SamplerBank::slotLoadSamplerBank(double v) {
     }
 
     file.close();
+    return true;
 }

--- a/src/mixer/samplerbank.cpp
+++ b/src/mixer/samplerbank.cpp
@@ -67,7 +67,7 @@ bool SamplerBank::saveSamplerBankToPath(const QString& samplerBankPath) {
     // folder. We don't need access to this file on a regular basis so we do not
     // register a security bookmark.
 
-    if (m_pPlayerManager == nullptr) {
+    VERIFY_OR_DEBUG_ASSERT(m_pPlayerManager != nullptr) {
         qWarning() << "SamplerBank::saveSamplerBankToPath called with no PlayerManager";
         return false;
     }
@@ -137,7 +137,7 @@ bool SamplerBank::loadSamplerBankFromPath(const QString& samplerBankPath) {
     // folder. We don't need access to this file on a regular basis so we do not
     // register a security bookmark.
 
-    if (m_pPlayerManager == nullptr) {
+    VERIFY_OR_DEBUG_ASSERT(m_pPlayerManager != nullptr) {
         qWarning() << "SamplerBank::loadSamplerBankFromPath called with no PlayerManager";
         return false;
     }

--- a/src/mixer/samplerbank.h
+++ b/src/mixer/samplerbank.h
@@ -4,6 +4,7 @@
 #include <QObject>
 
 class ControlObject;
+class ControlProxy;
 class PlayerManager;
 
 class SamplerBank : public QObject {
@@ -12,14 +13,18 @@ class SamplerBank : public QObject {
     SamplerBank(PlayerManager* pPlayerManager);
     virtual ~SamplerBank();
 
+    bool saveSamplerBankToPath(const QString& samplerBankPath);
+    bool loadSamplerBankFromPath(const QString& samplerBankPath);
+
   private slots:
     void slotSaveSamplerBank(double v);
     void slotLoadSamplerBank(double v);
 
   private:
     PlayerManager* m_pPlayerManager;
-    ControlObject* m_pLoadControl;
-    ControlObject* m_pSaveControl;
+    ControlObject* m_pCOLoadBank;
+    ControlObject* m_pCOSaveBank;
+    ControlProxy* m_pCONumSamplers;
 };
 
 #endif /* MIXER_SAMPLERBANK_H */

--- a/src/mixer/samplerbank.h
+++ b/src/mixer/samplerbank.h
@@ -7,6 +7,9 @@ class ControlObject;
 class ControlProxy;
 class PlayerManager;
 
+// TODO(Be): Replace saving/loading an XML file with saving/loading to the database.
+//           That should be part of a larger project to implement
+//           remix decks/sampler groups/whatever we end up calling them.
 class SamplerBank : public QObject {
     Q_OBJECT
   public:

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -434,6 +434,8 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
         }
     }
 
+    m_pPlayerManager->loadSamplers();
+
     connect(&PlayerInfo::instance(),
             SIGNAL(currentPlayingTrackChanged(TrackPointer)),
             this, SLOT(slotUpdateWindowTitle(TrackPointer)));


### PR DESCRIPTION
Make tracks loaded into samplers persistent across restarts. This is a quick hack involving a little refactoring of the existing functionality of saving/loading an XML file specifying file paths for samplers. Only Deere has implemented that functionality, but I'm doubtful it should be exposed to users. Saving file paths to an XML file and interrupting the flow of Mixxx with file selection dialogs feels like an ugly hack. I think in the future it would be better to save this information to the database and provide a new library GUI feature for managing samples and organizing them into groups. For 2.1, silently saving an XML file to the config directory and restoring it on startup will be a big step forward in the usability of samplers.