### PR TITLE
Show native separators in user visible strings (GUI)

### DIFF
--- a/src/engine/cachingreaderworker.cpp
+++ b/src/engine/cachingreaderworker.cpp
@@ -134,7 +134,8 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
                  << filename << "\", unlocked reader lock";
         m_pReaderStatusFIFO->writeBlocking(&status, 1);
         emit(trackLoadFailed(
-            pTrack, QString("The file '%1' could not be found.").arg(filename)));
+            pTrack, QString("The file '%1' could not be found.")
+                    .arg(QDir::toNativeSeparators(filename))));
         return;
     }
 

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -302,7 +302,7 @@ void BaseTrackCache::getTrackValueForColumn(TrackPointer pTrack,
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER) == column) {
         trackValue.setValue(pTrack->getTrackNumber());
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_LOCATION) == column) {
-        trackValue.setValue(pTrack->getLocation());
+        trackValue.setValue(QDir::toNativeSeparators(pTrack->getLocation()));
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COMMENT) == column) {
         trackValue.setValue(pTrack->getComment());
     } else if (fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DURATION) == column) {

--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -238,9 +238,11 @@ void BrowseThread::populateModel() {
         item->setData(pTrack->getBitrate(), Qt::UserRole);
         row_data.insert(COLUMN_BITRATE, item);
 
-        item = new QStandardItem(pTrack->getLocation());
-        item->setToolTip(item->text());
-        item->setData(item->text(), Qt::UserRole);
+        QString location = pTrack->getLocation();
+        QString locationNative = QDir::toNativeSeparators(location);
+        item = new QStandardItem(locationNative);
+        item->setToolTip(locationNative);
+        item->setData(location, Qt::UserRole);
         row_data.insert(COLUMN_LOCATION, item);
 
         QDateTime modifiedTime = pTrack->getFileModifiedTime().toLocalTime();

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -170,7 +170,7 @@ void DlgTrackInfo::populateFields(const Track& track) {
 
     // Non-editable fields
     txtDuration->setText(track.getDurationText(mixxx::Duration::Precision::SECONDS));
-    txtLocation->setPlainText(track.getLocation());
+    txtLocation->setPlainText(QDir::toNativeSeparators(track.getLocation()));
     txtType->setText(track.getType());
     txtBitrate->setText(QString(track.getBitrateText()) + (" ") + tr("kbps"));
     txtBpm->setText(track.getBpmText());

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -31,7 +31,7 @@ QVariant getTrackValueForColumn(const TrackPointer& pTrack, const QString& colum
     } else if (column == LIBRARYTABLE_TRACKNUMBER) {
         return pTrack->getTrackNumber();
     } else if (column == LIBRARYTABLE_LOCATION) {
-        return pTrack->getLocation();
+        return QDir::toNativeSeparators(pTrack->getLocation());
     } else if (column == LIBRARYTABLE_COMMENT) {
         return pTrack->getComment();
     } else if (column == LIBRARYTABLE_DURATION) {


### PR DESCRIPTION
This was found during investigation of:  
https://bugs.launchpad.net/mixxx/+bug/1672002

I think it is less confusing if we show "\" as separator on windows. 
This is especially helpful if the user copies the location and than tries to paste it in a third party application.  