### PR TITLE
option to show both elapsed and remaining time simultaneously

### DIFF
--- a/res/skins/Deere/deck_text_row.xml
+++ b/res/skins/Deere/deck_text_row.xml
@@ -494,7 +494,7 @@
                     <Layout>horizontal</Layout>
                     <SizePolicy>min,max</SizePolicy>
                     <MinimumSize>70,20</MinimumSize>
-                    <MaximumSize>100,30</MaximumSize>
+                    <MaximumSize>190,30</MaximumSize>
                     <Children>
                       <NumberPos>
                         <TooltipId>track_time</TooltipId>

--- a/res/skins/LateNight/deck_row_2_3_4.xml
+++ b/res/skins/LateNight/deck_row_2_3_4.xml
@@ -34,9 +34,9 @@
                     <WidgetGroup>
                         <ObjectName>AlignRightTop</ObjectName>
                         <Layout>horizontal</Layout>
-                        <SizePolicy>f,min</SizePolicy>
+                        <SizePolicy>max,min</SizePolicy>
                         <MinimumSize>100,</MinimumSize>
-                        <MaximumSize>100,</MaximumSize>
+                        <MaximumSize>220,</MaximumSize>
                         <Children>
                             <NumberPos>
                                 <ObjectName>TextColor<Variable name="channum" /></ObjectName>

--- a/res/skins/Shade/deck.xml
+++ b/res/skins/Shade/deck.xml
@@ -149,18 +149,18 @@
 								<!-- Spinning Vinyl & VinylControl -->
 								<WidgetGroup>
 									<Style>
-                                        QGroupBox { 
-                                            border: 0px solid yellow;
-                                        } 
-                                        QWidget { margin: 0; padding: 0; }
-                                    </Style>
+										QGroupBox {
+											border: 0px solid yellow;
+										}
+										QWidget { margin: 0; padding: 0; }
+									</Style>
 									<Layout>vertical</Layout>
 									<Children>
-                                        <WidgetGroup>
-											<Style>QGroupBox { border: 0px solid green; } QWidget { margin: 0; padding: 0;}                                         
-                                            </Style>
+										<WidgetGroup>
+											<Style>QGroupBox { border: 0px solid green; } QWidget { margin: 0; padding: 0;}
+											</Style>
 											<Size>f,e</Size>
-                                         </WidgetGroup>
+										 </WidgetGroup>
 										<!-- Spinning Vinyl sub-widget -->
 										<WidgetGroup>
 											<!--<Pos>296,0</Pos>-->
@@ -188,14 +188,14 @@
 												<BindProperty>visible</BindProperty>
 											</Connection>
 										</WidgetGroup>
-                                        <WidgetGroup>
-											<Style>QGroupBox { border: 0px solid green; } QWidget { margin: 0; padding: 0;}                                         
-                                            </Style>
+										<WidgetGroup>
+											<Style>QGroupBox { border: 0px solid green; } QWidget { margin: 0; padding: 0;}
+											</Style>
 											<Size>f,e</Size>
-                                         </WidgetGroup>
-                 						<Template src="skin:vinylcontrol.xml">
-							                <SetVariable name="channum"><Variable name="channum"/></SetVariable>
-						                </Template>	
+										 </WidgetGroup>
+				 						<Template src="skin:vinylcontrol.xml">
+											<SetVariable name="channum"><Variable name="channum"/></SetVariable>
+										</Template>
 									</Children>
 								</WidgetGroup>
 	
@@ -258,7 +258,7 @@
 
 						<!--
 						**********************************************
-                    	Text- Track Title
+						Text- Track Title
 						**********************************************
 						-->
 						<TrackProperty>
@@ -278,51 +278,63 @@
 							<Size>275f,18</Size>
 							<Elide>right</Elide>
 						</TrackProperty>
-	
-						<!--
-						**********************************************
-						Text- Track Artist
-						**********************************************
-						-->
-						<TrackProperty>
-							<TooltipId>track_artist</TooltipId>
-							<Style>QLabel { font: bold 13px sans-serif;
-									font-family: "Open Sans";
-									background-color: transparent; 
-									color: #191F24; 
-									text-align: left; 
-									padding-left: 1px; }
-							</Style>
-							<Property>artist</Property>
-							<Channel><Variable name="channum"/></Channel>
+
+						<WidgetGroup>
+							<ObjectName>ArtistAndTimeRow</ObjectName>
 							<Pos>39,24</Pos>
-							<Size>210f,18</Size>
-							<Elide>right</Elide>
-						</TrackProperty>
-		
-						<!--
-						**********************************************
-						Text- Playing position / Time remaining
-						**********************************************
-						-->
-						<NumberPos>
-							<TooltipId>track_time</TooltipId>
-							<Style>QLabel { font: bold 13px sans-serif;
-                                                                        font-family: Open Sans;
-							                background-color: transparent; 
-                                                                        color: #191F24;  
-                                                                        text-align: left; 
-                                                                        padding-left: 1px; }
-							</Style>
-							<Channel><Variable name="channum"/></Channel>
-							<Pos>249,24</Pos>
-							<Size>66,18</Size>
-							<!--CSS alignments not respected see bug lp:605530 , lets call <Alignment>-->
-							<Alignment>right</Alignment>
-							<Connection>
-								<ConfigKey>[Channel<Variable name="channum"/>],playposition</ConfigKey>
-							</Connection>
-						</NumberPos>
+							<Size>276f,18f</Size>
+							<Layout>horizontal</Layout>
+							<Children>
+							<!--
+							**********************************************
+							Text- Track Artist
+							**********************************************
+							-->
+							<TrackProperty>
+								<TooltipId>track_artist</TooltipId>
+								<Style>QLabel { font: bold 13px sans-serif;
+										font-family: "Open Sans";
+										background-color: transparent;
+										color: #191F24;
+										text-align: left;
+										padding-left: 1px; }
+								</Style>
+								<Property>artist</Property>
+								<Channel><Variable name="channum"/></Channel>
+								<SizePolicy>me,max</SizePolicy>
+								<Elide>right</Elide>
+							</TrackProperty>
+
+							<!--
+							**********************************************
+							Text- Playing position / Time remaining
+							**********************************************
+							-->
+
+							<WidgetGroup>
+								<ObjectName>PositionGutter</ObjectName>
+								<Layout>horizontal</Layout>
+								<SizePolicy>min,max</SizePolicy>
+								<MinimumSize>66,20</MinimumSize>
+								<MaximumSize>160,30</MaximumSize>
+								<Children>
+								<NumberPos>
+									<TooltipId>track_time</TooltipId>
+									<Style>QLabel { font: bold 13px sans-serif;
+												font-family: Open Sans;
+												background-color: transparent;
+												color: #191F24;
+												text-align: right;
+												padding-left: 1px; }
+									</Style>
+									<Group>[Channel<Variable name="channum"/>]</Group>
+									<Alignment>right</Alignment>
+								</NumberPos>
+								</Children>
+							</WidgetGroup>
+
+							</Children>
+						</WidgetGroup>
 						
 						<!--
 						**********************************************
@@ -404,16 +416,16 @@
 
 						<PushButton>
 							<TooltipId>pitch_up</TooltipId>
-                            <Size>10f,10f</Size>							
-                            <Style></Style>
+							<Size>10f,10f</Size>
+							<Style></Style>
 							<NumberStates>2</NumberStates>
 							<State>
 								<Number>0</Number>
-                                <Text>►</Text>
+								<Text>►</Text>
 							</State>
-						    <State>
+							<State>
 								<Number>0</Number>
-                                <Text>►</Text>
+								<Text>►</Text>
 							</State>
 							<Pos>353,55</Pos>
 							<Connection>
@@ -428,16 +440,16 @@
 
 						<PushButton>
 							<TooltipId>pitch_down</TooltipId>
-                            <Size>10f,10f</Size>
+							<Size>10f,10f</Size>
 							<Style></Style>
 							<NumberStates>2</NumberStates>
 							<State>
 								<Number>0</Number>
-                                <Text>◄</Text>
+								<Text>◄</Text>
 							</State>
 							<State>
 								<Number>1</Number>
-                                <Text>◄</Text>
+								<Text>◄</Text>
 							</State>
 							<Pos>320,55</Pos>
 							<Connection>

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -70,17 +70,23 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     if (!m_pConfig->exists(ConfigKey("[Controls]","PositionDisplay")))
         m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"),ConfigValue(0));
 
-    int positionDisplayType = m_pConfig->getValueString(
-            ConfigKey("[Controls]", "PositionDisplay")).toInt();
-    if (positionDisplayType == 1) {
+    double positionDisplayType = m_pConfig->getValue(
+            ConfigKey("[Controls]", "PositionDisplay"),
+            static_cast<double>(Duration::DisplayMode::Elapsed));
+    if (positionDisplayType ==
+            static_cast<double>(Duration::DisplayMode::Remaining)) {
         radioButtonRemaining->setChecked(true);
-        m_pControlTrackTimeDisplay->set(1.0);
-    } else if (positionDisplayType == 2) {
+        m_pControlTrackTimeDisplay->set(
+            static_cast<double>(Duration::DisplayMode::Remaining));
+    } else if (positionDisplayType ==
+                   static_cast<double>(Duration::DisplayMode::ElapsedAndRemaining)) {
         radioButtonElapsedAndRemaining->setChecked(true);
-        m_pControlTrackTimeDisplay->set(2.0);
+        m_pControlTrackTimeDisplay->set(
+            static_cast<double>(Duration::DisplayMode::ElapsedAndRemaining));
     } else {
         radioButtonElapsed->setChecked(true);
-        m_pControlTrackTimeDisplay->set(0.0);
+        m_pControlTrackTimeDisplay->set(
+            static_cast<double>(Duration::DisplayMode::Elapsed));
     }
     connect(buttonGroupTrackTime, SIGNAL(buttonClicked(QAbstractButton*)),
             this, SLOT(slotSetTrackTimeDisplay(QAbstractButton *)));
@@ -607,16 +613,15 @@ void DlgPrefControls::slotSetSkin(int) {
 }
 
 void DlgPrefControls::slotSetTrackTimeDisplay(QAbstractButton* b) {
-    int timeDisplay = 0;
-    if (b == radioButtonElapsed) {
-        m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"), ConfigValue(0));
-    } else if (b == radioButtonRemaining) {
-        timeDisplay = 1;
-        m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"), ConfigValue(1));
+    double timeDisplay;
+    if (b == radioButtonRemaining) {
+        timeDisplay = static_cast<double>(Duration::DisplayMode::Remaining);
     } else if (b == radioButtonElapsedAndRemaining) {
-        timeDisplay = 2;
-        m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"), ConfigValue(2));
+        timeDisplay = static_cast<double>(Duration::DisplayMode::ElapsedAndRemaining);
+    } else {
+        timeDisplay = static_cast<double>(Duration::DisplayMode::Elapsed);
     }
+    m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"), ConfigValue(timeDisplay));
     m_pControlTrackTimeDisplay->set(timeDisplay);
 }
 

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -70,12 +70,18 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     if (!m_pConfig->exists(ConfigKey("[Controls]","PositionDisplay")))
         m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"),ConfigValue(0));
 
-    if (m_pConfig->getValueString(ConfigKey("[Controls]", "PositionDisplay")).toInt() == 1) {
-        radioButtonRemaining->setChecked(true);
-        m_pControlTrackTimeDisplay->set(1.0);
-    } else {
+    if (m_pConfig->getValueString(
+            ConfigKey("[Controls]", "PositionDisplay")).toInt() == 0) {
         radioButtonElapsed->setChecked(true);
         m_pControlTrackTimeDisplay->set(0.0);
+    } else if (m_pConfig->getValueString(
+                  ConfigKey("[Controls]", "PositionDisplay")).toInt() == 1) {
+        radioButtonRemaining->setChecked(true);
+        m_pControlTrackTimeDisplay->set(1.0);
+    } else if (m_pConfig->getValueString(
+                    ConfigKey("[Controls]", "PositionDisplay")).toInt() == 2) {
+        radioButtonElapsedAndRemaining->setChecked(true);
+        m_pControlTrackTimeDisplay->set(2.0);
     }
     connect(buttonGroupTrackTime, SIGNAL(buttonClicked(QAbstractButton*)),
             this, SLOT(slotSetTrackTimeDisplay(QAbstractButton *)));
@@ -603,25 +609,31 @@ void DlgPrefControls::slotSetSkin(int) {
 
 void DlgPrefControls::slotSetTrackTimeDisplay(QAbstractButton* b) {
     int timeDisplay = 0;
-    if (b == radioButtonRemaining) {
+    if (b == radioButtonElapsed) {
+        m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"), ConfigValue(0));
+    } else if (b == radioButtonRemaining) {
         timeDisplay = 1;
         m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"), ConfigValue(1));
-    }
-    else {
-        m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"), ConfigValue(0));
+    } else if (b == radioButtonElapsedAndRemaining) {
+        timeDisplay = 2;
+        m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"), ConfigValue(2));
     }
     m_pControlTrackTimeDisplay->set(timeDisplay);
 }
 
 void DlgPrefControls::slotSetTrackTimeDisplay(double v) {
-    if (v > 0) {
-        // Remaining
-        radioButtonRemaining->setChecked(true);
-        m_pConfig->set(ConfigKey("[Controls]", "PositionDisplay"), ConfigValue(1));
-    } else {
+    if (v == 0.0) {
         // Elapsed
         radioButtonElapsed->setChecked(true);
         m_pConfig->set(ConfigKey("[Controls]", "PositionDisplay"), ConfigValue(0));
+    } else if (v == 1.0) {
+        // Remaining
+        radioButtonRemaining->setChecked(true);
+        m_pConfig->set(ConfigKey("[Controls]", "PositionDisplay"), ConfigValue(1));
+    } else if (v == 2.0) {
+        // Elapsed and remaining
+        radioButtonElapsedAndRemaining->setChecked(true);
+        m_pConfig->set(ConfigKey("[Controls]", "PositionDisplay"), ConfigValue(2));
     }
 }
 

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -72,21 +72,21 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
 
     double positionDisplayType = m_pConfig->getValue(
             ConfigKey("[Controls]", "PositionDisplay"),
-            static_cast<double>(Duration::DisplayMode::Elapsed));
+            static_cast<double>(TrackTime::DisplayMode::Elapsed));
     if (positionDisplayType ==
-            static_cast<double>(Duration::DisplayMode::Remaining)) {
+            static_cast<double>(TrackTime::DisplayMode::Remaining)) {
         radioButtonRemaining->setChecked(true);
         m_pControlTrackTimeDisplay->set(
-            static_cast<double>(Duration::DisplayMode::Remaining));
+            static_cast<double>(TrackTime::DisplayMode::Remaining));
     } else if (positionDisplayType ==
-                   static_cast<double>(Duration::DisplayMode::ElapsedAndRemaining)) {
+                   static_cast<double>(TrackTime::DisplayMode::ElapsedAndRemaining)) {
         radioButtonElapsedAndRemaining->setChecked(true);
         m_pControlTrackTimeDisplay->set(
-            static_cast<double>(Duration::DisplayMode::ElapsedAndRemaining));
+            static_cast<double>(TrackTime::DisplayMode::ElapsedAndRemaining));
     } else {
         radioButtonElapsed->setChecked(true);
         m_pControlTrackTimeDisplay->set(
-            static_cast<double>(Duration::DisplayMode::Elapsed));
+            static_cast<double>(TrackTime::DisplayMode::Elapsed));
     }
     connect(buttonGroupTrackTime, SIGNAL(buttonClicked(QAbstractButton*)),
             this, SLOT(slotSetTrackTimeDisplay(QAbstractButton *)));
@@ -615,11 +615,11 @@ void DlgPrefControls::slotSetSkin(int) {
 void DlgPrefControls::slotSetTrackTimeDisplay(QAbstractButton* b) {
     double timeDisplay;
     if (b == radioButtonRemaining) {
-        timeDisplay = static_cast<double>(Duration::DisplayMode::Remaining);
+        timeDisplay = static_cast<double>(TrackTime::DisplayMode::Remaining);
     } else if (b == radioButtonElapsedAndRemaining) {
-        timeDisplay = static_cast<double>(Duration::DisplayMode::ElapsedAndRemaining);
+        timeDisplay = static_cast<double>(TrackTime::DisplayMode::ElapsedAndRemaining);
     } else {
-        timeDisplay = static_cast<double>(Duration::DisplayMode::Elapsed);
+        timeDisplay = static_cast<double>(TrackTime::DisplayMode::Elapsed);
     }
     m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"), ConfigValue(timeDisplay));
     m_pControlTrackTimeDisplay->set(timeDisplay);

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -70,18 +70,17 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     if (!m_pConfig->exists(ConfigKey("[Controls]","PositionDisplay")))
         m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"),ConfigValue(0));
 
-    if (m_pConfig->getValueString(
-            ConfigKey("[Controls]", "PositionDisplay")).toInt() == 0) {
-        radioButtonElapsed->setChecked(true);
-        m_pControlTrackTimeDisplay->set(0.0);
-    } else if (m_pConfig->getValueString(
-                  ConfigKey("[Controls]", "PositionDisplay")).toInt() == 1) {
+    int positionDisplayType = m_pConfig->getValueString(
+            ConfigKey("[Controls]", "PositionDisplay")).toInt();
+    if (positionDisplayType == 1) {
         radioButtonRemaining->setChecked(true);
         m_pControlTrackTimeDisplay->set(1.0);
-    } else if (m_pConfig->getValueString(
-                    ConfigKey("[Controls]", "PositionDisplay")).toInt() == 2) {
+    } else if (positionDisplayType == 2) {
         radioButtonElapsedAndRemaining->setChecked(true);
         m_pControlTrackTimeDisplay->set(2.0);
+    } else {
+        radioButtonElapsed->setChecked(true);
+        m_pControlTrackTimeDisplay->set(0.0);
     }
     connect(buttonGroupTrackTime, SIGNAL(buttonClicked(QAbstractButton*)),
             this, SLOT(slotSetTrackTimeDisplay(QAbstractButton *)));
@@ -622,11 +621,7 @@ void DlgPrefControls::slotSetTrackTimeDisplay(QAbstractButton* b) {
 }
 
 void DlgPrefControls::slotSetTrackTimeDisplay(double v) {
-    if (v == 0.0) {
-        // Elapsed
-        radioButtonElapsed->setChecked(true);
-        m_pConfig->set(ConfigKey("[Controls]", "PositionDisplay"), ConfigValue(0));
-    } else if (v == 1.0) {
+    if (v == 1.0) {
         // Remaining
         radioButtonRemaining->setChecked(true);
         m_pConfig->set(ConfigKey("[Controls]", "PositionDisplay"), ConfigValue(1));
@@ -634,6 +629,10 @@ void DlgPrefControls::slotSetTrackTimeDisplay(double v) {
         // Elapsed and remaining
         radioButtonElapsedAndRemaining->setChecked(true);
         m_pConfig->set(ConfigKey("[Controls]", "PositionDisplay"), ConfigValue(2));
+    } else {
+        // Elapsed
+        radioButtonElapsed->setChecked(true);
+        m_pConfig->set(ConfigKey("[Controls]", "PositionDisplay"), ConfigValue(0));
     }
 }
 

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -67,8 +67,10 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
             this, SLOT(slotSetTrackTimeDisplay(double)));
 
     // If not present in the config, set the default value
-    if (!m_pConfig->exists(ConfigKey("[Controls]","PositionDisplay")))
-        m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"),ConfigValue(0));
+    if (!m_pConfig->exists(ConfigKey("[Controls]","PositionDisplay"))) {
+        m_pConfig->set(ConfigKey("[Controls]","PositionDisplay"),
+          QString::number(static_cast<int>(TrackTime::DisplayMode::Remaining)));
+    }
 
     double positionDisplayType = m_pConfig->getValue(
             ConfigKey("[Controls]", "PositionDisplay"),

--- a/src/preferences/dialog/dlgprefcontrols.h
+++ b/src/preferences/dialog/dlgprefcontrols.h
@@ -31,7 +31,7 @@ class PlayerManager;
 class MixxxMainWindow;
 class ControlObject;
 
-namespace Duration {
+namespace TrackTime {
     enum class DisplayMode {
         Elapsed,
         Remaining,

--- a/src/preferences/dialog/dlgprefcontrols.h
+++ b/src/preferences/dialog/dlgprefcontrols.h
@@ -31,6 +31,14 @@ class PlayerManager;
 class MixxxMainWindow;
 class ControlObject;
 
+namespace Duration {
+    enum class DisplayMode {
+        Elapsed,
+        Remaining,
+        ElapsedAndRemaining,
+    };
+}
+
 /**
   *@author Tue & Ken Haste Andersen
   */

--- a/src/preferences/dialog/dlgprefcontrolsdlg.ui
+++ b/src/preferences/dialog/dlgprefcontrolsdlg.ui
@@ -482,6 +482,16 @@
        </attribute>
       </widget>
      </item>
+    <item row="9" column="3">
+      <widget class="QRadioButton" name="radioButtonElapsedAndRemaining">
+       <property name="text">
+        <string>Elapsed and Remaining</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroupTrackTime</string>
+       </attribute>
+      </widget>
+     </item>
      <item row="5" column="1" colspan="2">
       <widget class="QCheckBox" name="checkBoxStartFullScreen">
        <property name="text">

--- a/src/preferences/dialog/dlgprefcontrolsdlg.ui
+++ b/src/preferences/dialog/dlgprefcontrolsdlg.ui
@@ -462,35 +462,39 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="2">
-      <widget class="QRadioButton" name="radioButtonRemaining">
-       <property name="text">
-        <string>Remaining</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">buttonGroupTrackTime</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <widget class="QRadioButton" name="radioButtonElapsed">
-       <property name="text">
-        <string>Elapsed</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">buttonGroupTrackTime</string>
-       </attribute>
-      </widget>
-     </item>
-    <item row="9" column="3">
-      <widget class="QRadioButton" name="radioButtonElapsedAndRemaining">
-       <property name="text">
-        <string>Elapsed and Remaining</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">buttonGroupTrackTime</string>
-       </attribute>
-      </widget>
+     <item row="9" column="1" colspan="2">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+          <widget class="QRadioButton" name="radioButtonElapsed">
+          <property name="text">
+            <string>Elapsed</string>
+          </property>
+          <attribute name="buttonGroup">
+            <string notr="true">buttonGroupTrackTime</string>
+          </attribute>
+          </widget>
+        </item>
+        <item>
+          <widget class="QRadioButton" name="radioButtonRemaining">
+          <property name="text">
+            <string>Remaining</string>
+          </property>
+          <attribute name="buttonGroup">
+            <string notr="true">buttonGroupTrackTime</string>
+          </attribute>
+          </widget>
+        </item>
+        <item>
+          <widget class="QRadioButton" name="radioButtonElapsedAndRemaining">
+          <property name="text">
+            <string>Elapsed and Remaining</string>
+          </property>
+          <attribute name="buttonGroup">
+            <string notr="true">buttonGroupTrackTime</string>
+          </attribute>
+          </widget>
+        </item>
+      </layout>
      </item>
      <item row="5" column="1" colspan="2">
       <widget class="QCheckBox" name="checkBoxStartFullScreen">
@@ -745,6 +749,7 @@ CUP mode:
   <tabstop>ComboBoxCueDefault</tabstop>
   <tabstop>radioButtonElapsed</tabstop>
   <tabstop>radioButtonRemaining</tabstop>
+  <tabstop>radioButtonElapsedAndRemaining</tabstop>
   <tabstop>checkBoxSeekToCue</tabstop>
   <tabstop>checkBoxDisallowLoadToPlayingDeck</tabstop>
   <tabstop>ComboBoxRateRange</tabstop>

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -598,8 +598,8 @@ void Tooltips::addStandardTooltips() {
 
     add("track_time")
             << tr("Track Time")
-            << tr("Displays the elapsed or remaining time of the track loaded.")
-            << tr("Click to toggle between time elapsed/remaining time.");
+            << tr("Displays the elapsed and/or remaining time of the track loaded.")
+            << tr("Click to toggle between time elapsed/remaining time/both.");
 
     add("track_duration")
             << tr("Track Duration")

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -129,12 +129,13 @@ void WNumberPos::slotSetPosition(double dPosition) {
 }
 
 void WNumberPos::slotSetDisplayMode(double remain) {
-    if (remain <= 0.0) {
-        m_displayMode = DisplayMode::Elapsed;
-    } else if (remain == 1.0) {
+    if (remain == 1.0) {
         m_displayMode = DisplayMode::Remaining;
     } else if (remain == 2.0) {
         m_displayMode = DisplayMode::ElapsedAndRemaining;
+    } else {
+        m_displayMode = DisplayMode::Elapsed;
     }
+
     slotSetPosition(m_dOldPosition);
 }

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -53,12 +53,12 @@ void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {
 
     if (leftClick) {
         // Cycle through display modes
-        if (m_displayMode == DisplayMode::Elapsed) {
-            m_displayMode = DisplayMode::Remaining;
-        } else if (m_displayMode == DisplayMode::Remaining) {
-            m_displayMode = DisplayMode::ElapsedAndRemaining;
-        } else if (m_displayMode == DisplayMode::ElapsedAndRemaining) {
-            m_displayMode = DisplayMode::Elapsed;
+        if (m_displayMode == Duration::DisplayMode::Elapsed) {
+            m_displayMode = Duration::DisplayMode::Remaining;
+        } else if (m_displayMode == Duration::DisplayMode::Remaining) {
+            m_displayMode = Duration::DisplayMode::ElapsedAndRemaining;
+        } else if (m_displayMode == Duration::DisplayMode::ElapsedAndRemaining) {
+            m_displayMode = Duration::DisplayMode::Elapsed;
         }
 
         m_pShowTrackTimeRemaining->set(static_cast<double>(m_displayMode));
@@ -94,13 +94,13 @@ void WNumberPos::slotSetPosition(double dPosition) {
         double dDurationMillis = dDurationSeconds * 1000.0;
         double dPosMillis = dPosition * dDurationMillis;
         dPosSecondsElapsed = dPosMillis / 1000.0;
-        if (m_displayMode != DisplayMode::Elapsed) {
+        if (m_displayMode != Duration::DisplayMode::Elapsed) {
             double dPosMillisRemaining = math_max(dDurationMillis - dPosMillis, 0.0);
             dPosSecondsRemaining = dPosMillisRemaining / 1000.0;
         }
     }
 
-    if (m_displayMode == DisplayMode::Elapsed) {
+    if (m_displayMode == Duration::DisplayMode::Elapsed) {
         if (dPosSecondsElapsed >= 0.0) {
             setText(mixxx::Duration::formatSeconds(
                         dPosSecondsElapsed, mixxx::Duration::Precision::CENTISECONDS));
@@ -108,10 +108,10 @@ void WNumberPos::slotSetPosition(double dPosition) {
             setText(QLatin1String("-") % mixxx::Duration::formatSeconds(
                         -dPosSecondsElapsed, mixxx::Duration::Precision::CENTISECONDS));
         }
-    } else if (m_displayMode == DisplayMode::Remaining) {
+    } else if (m_displayMode == Duration::DisplayMode::Remaining) {
         setText(QLatin1String("-") % mixxx::Duration::formatSeconds(
                     dPosSecondsRemaining, mixxx::Duration::Precision::CENTISECONDS));
-    } else if (m_displayMode == DisplayMode::ElapsedAndRemaining) {
+    } else if (m_displayMode == Duration::DisplayMode::ElapsedAndRemaining) {
         if (dPosSecondsElapsed >= 0.0) {
             setText(mixxx::Duration::formatSeconds(
                         dPosSecondsElapsed, mixxx::Duration::Precision::CENTISECONDS)
@@ -130,11 +130,11 @@ void WNumberPos::slotSetPosition(double dPosition) {
 
 void WNumberPos::slotSetDisplayMode(double remain) {
     if (remain == 1.0) {
-        m_displayMode = DisplayMode::Remaining;
+        m_displayMode = Duration::DisplayMode::Remaining;
     } else if (remain == 2.0) {
-        m_displayMode = DisplayMode::ElapsedAndRemaining;
+        m_displayMode = Duration::DisplayMode::ElapsedAndRemaining;
     } else {
-        m_displayMode = DisplayMode::Elapsed;
+        m_displayMode = Duration::DisplayMode::Elapsed;
     }
 
     slotSetPosition(m_dOldPosition);

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -115,13 +115,13 @@ void WNumberPos::slotSetPosition(double dPosition) {
         if (dPosSecondsElapsed >= 0.0) {
             setText(mixxx::Duration::formatSeconds(
                         dPosSecondsElapsed, mixxx::Duration::Precision::CENTISECONDS)
-                    % QLatin1String(" / -") %
+                    % QLatin1String("  -") %
                     mixxx::Duration::formatSeconds(
                         dPosSecondsRemaining, mixxx::Duration::Precision::CENTISECONDS));
         } else {
             setText(QLatin1String("-") % mixxx::Duration::formatSeconds(
                         -dPosSecondsElapsed, mixxx::Duration::Precision::CENTISECONDS)
-                    % QLatin1String(" / -") %
+                    % QLatin1String("  -") %
                     mixxx::Duration::formatSeconds(
                         dPosSecondsRemaining, mixxx::Duration::Precision::CENTISECONDS));
         }

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -53,12 +53,12 @@ void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {
 
     if (leftClick) {
         // Cycle through display modes
-        if (m_displayMode == Duration::DisplayMode::Elapsed) {
-            m_displayMode = Duration::DisplayMode::Remaining;
-        } else if (m_displayMode == Duration::DisplayMode::Remaining) {
-            m_displayMode = Duration::DisplayMode::ElapsedAndRemaining;
-        } else if (m_displayMode == Duration::DisplayMode::ElapsedAndRemaining) {
-            m_displayMode = Duration::DisplayMode::Elapsed;
+        if (m_displayMode == TrackTime::DisplayMode::Elapsed) {
+            m_displayMode = TrackTime::DisplayMode::Remaining;
+        } else if (m_displayMode == TrackTime::DisplayMode::Remaining) {
+            m_displayMode = TrackTime::DisplayMode::ElapsedAndRemaining;
+        } else if (m_displayMode == TrackTime::DisplayMode::ElapsedAndRemaining) {
+            m_displayMode = TrackTime::DisplayMode::Elapsed;
         }
 
         m_pShowTrackTimeRemaining->set(static_cast<double>(m_displayMode));
@@ -94,13 +94,13 @@ void WNumberPos::slotSetPosition(double dPosition) {
         double dDurationMillis = dDurationSeconds * 1000.0;
         double dPosMillis = dPosition * dDurationMillis;
         dPosSecondsElapsed = dPosMillis / 1000.0;
-        if (m_displayMode != Duration::DisplayMode::Elapsed) {
+        if (m_displayMode != TrackTime::DisplayMode::Elapsed) {
             double dPosMillisRemaining = math_max(dDurationMillis - dPosMillis, 0.0);
             dPosSecondsRemaining = dPosMillisRemaining / 1000.0;
         }
     }
 
-    if (m_displayMode == Duration::DisplayMode::Elapsed) {
+    if (m_displayMode == TrackTime::DisplayMode::Elapsed) {
         if (dPosSecondsElapsed >= 0.0) {
             setText(mixxx::Duration::formatSeconds(
                         dPosSecondsElapsed, mixxx::Duration::Precision::CENTISECONDS));
@@ -108,10 +108,10 @@ void WNumberPos::slotSetPosition(double dPosition) {
             setText(QLatin1String("-") % mixxx::Duration::formatSeconds(
                         -dPosSecondsElapsed, mixxx::Duration::Precision::CENTISECONDS));
         }
-    } else if (m_displayMode == Duration::DisplayMode::Remaining) {
+    } else if (m_displayMode == TrackTime::DisplayMode::Remaining) {
         setText(QLatin1String("-") % mixxx::Duration::formatSeconds(
                     dPosSecondsRemaining, mixxx::Duration::Precision::CENTISECONDS));
-    } else if (m_displayMode == Duration::DisplayMode::ElapsedAndRemaining) {
+    } else if (m_displayMode == TrackTime::DisplayMode::ElapsedAndRemaining) {
         if (dPosSecondsElapsed >= 0.0) {
             setText(mixxx::Duration::formatSeconds(
                         dPosSecondsElapsed, mixxx::Duration::Precision::CENTISECONDS)
@@ -130,11 +130,11 @@ void WNumberPos::slotSetPosition(double dPosition) {
 
 void WNumberPos::slotSetDisplayMode(double remain) {
     if (remain == 1.0) {
-        m_displayMode = Duration::DisplayMode::Remaining;
+        m_displayMode = TrackTime::DisplayMode::Remaining;
     } else if (remain == 2.0) {
-        m_displayMode = Duration::DisplayMode::ElapsedAndRemaining;
+        m_displayMode = TrackTime::DisplayMode::ElapsedAndRemaining;
     } else {
-        m_displayMode = Duration::DisplayMode::Elapsed;
+        m_displayMode = TrackTime::DisplayMode::Elapsed;
     }
 
     slotSetPosition(m_dOldPosition);

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -10,15 +10,15 @@
 
 WNumberPos::WNumberPos(const char* group, QWidget* parent)
         : WNumber(parent),
-          m_dOldValue(0.0),
+          m_dOldPosition(0.0),
           m_dTrackSamples(0.0),
           m_dTrackSampleRate(0.0),
           m_bRemain(false) {
     m_pShowTrackTimeRemaining = new ControlProxy(
             "[Controls]", "ShowDurationRemaining", this);
     m_pShowTrackTimeRemaining->connectValueChanged(
-            SLOT(slotSetRemain(double)));
-    slotSetRemain(m_pShowTrackTimeRemaining->get());
+            SLOT(slotSetDisplayMode(double)));
+    slotSetDisplayMode(m_pShowTrackTimeRemaining->get());
 
     // We use the engine's playposition value directly because the parameter
     // normalization done by the widget system used to be unusable for this
@@ -26,7 +26,7 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
     // result, the <Connection> parameter is no longer necessary in skin
     // definitions, but leaving it in is harmless.
     m_pVisualPlaypos = new ControlProxy(group, "playposition", this);
-    m_pVisualPlaypos->connectValueChanged(SLOT(slotSetValue(double)));
+    m_pVisualPlaypos->connectValueChanged(SLOT(slotSetPosition(double)));
 
     m_pTrackSamples = new ControlProxy(
             group, "track_samples", this);
@@ -45,73 +45,96 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
     // set to a valid value.
     m_pTrackSampleRate->emitValueChanged();
 
-    slotSetValue(m_pVisualPlaypos->get());
+    slotSetPosition(m_pVisualPlaypos->get());
 }
 
 void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {
     bool leftClick = pEvent->buttons() & Qt::LeftButton;
 
     if (leftClick) {
-        setRemain(!m_bRemain);
-        m_pShowTrackTimeRemaining->set(m_bRemain ? 1.0 : 0.0);
+        // Cycle through display modes
+        if (m_displayMode == DisplayMode::Elapsed) {
+            m_displayMode = DisplayMode::Remaining;
+        } else if (m_displayMode == DisplayMode::Remaining) {
+            m_displayMode = DisplayMode::ElapsedAndRemaining;
+        } else if (m_displayMode == DisplayMode::ElapsedAndRemaining) {
+            m_displayMode = DisplayMode::Elapsed;
+        }
+
+        m_pShowTrackTimeRemaining->set(static_cast<double>(m_displayMode));
+        slotSetPosition(m_dOldPosition);
     }
 }
 
 void WNumberPos::slotSetTrackSamples(double dSamples) {
     m_dTrackSamples = dSamples;
-    slotSetValue(m_dOldValue);
+    slotSetPosition(m_dOldPosition);
 }
 
 void WNumberPos::slotSetTrackSampleRate(double dSampleRate) {
     m_dTrackSampleRate = dSampleRate;
-    slotSetValue(m_dOldValue);
+    slotSetPosition(m_dOldPosition);
 }
 
+// Reimplementing WNumber::setValue
 void WNumberPos::setValue(double dValue) {
     // Ignore midi-scaled signals from the skin connection.
     Q_UNUSED(dValue);
     // Update our value with the old value.
-    slotSetValue(m_dOldValue);
+    slotSetPosition(m_dOldPosition);
 }
 
-void WNumberPos::slotSetValue(double dValue) {
-    m_dOldValue = dValue;
+void WNumberPos::slotSetPosition(double dPosition) {
+    m_dOldPosition = dPosition;
 
-    double dPosSeconds = 0.0;
+    double dPosSecondsElapsed = 0.0;
+    double dPosSecondsRemaining = 0.0;
     if (m_dTrackSamples > 0 && m_dTrackSampleRate > 0) {
         double dDurationSeconds = (m_dTrackSamples / 2.0) / m_dTrackSampleRate;
         double dDurationMillis = dDurationSeconds * 1000.0;
-        double dPosMillis = dValue * dDurationMillis;
-        if (m_bRemain) {
-            dPosMillis = math_max(dDurationMillis - dPosMillis, 0.0);
+        double dPosMillis = dPosition * dDurationMillis;
+        dPosSecondsElapsed = dPosMillis / 1000.0;
+        if (m_displayMode != DisplayMode::Elapsed) {
+            double dPosMillisRemaining = math_max(dDurationMillis - dPosMillis, 0.0);
+            dPosSecondsRemaining = dPosMillisRemaining / 1000.0;
         }
-        dPosSeconds = dPosMillis / 1000.0;
     }
 
-    QString sPosText;
-    if (dPosSeconds >= 0.0) {
-        sPosText = m_skinText % mixxx::Duration::formatSeconds(
-                dPosSeconds, mixxx::Duration::Precision::CENTISECONDS);
-    } else {
-        sPosText = m_skinText % QLatin1String("-") % mixxx::Duration::formatSeconds(
-                -dPosSeconds, mixxx::Duration::Precision::CENTISECONDS);
+    if (m_displayMode == DisplayMode::Elapsed) {
+        if (dPosSecondsElapsed >= 0.0) {
+            setText(mixxx::Duration::formatSeconds(
+                        dPosSecondsElapsed, mixxx::Duration::Precision::CENTISECONDS));
+        } else {
+            setText(QLatin1String("-") % mixxx::Duration::formatSeconds(
+                        -dPosSecondsElapsed, mixxx::Duration::Precision::CENTISECONDS));
+        }
+    } else if (m_displayMode == DisplayMode::Remaining) {
+        setText(QLatin1String("-") % mixxx::Duration::formatSeconds(
+                    dPosSecondsRemaining, mixxx::Duration::Precision::CENTISECONDS));
+    } else if (m_displayMode == DisplayMode::ElapsedAndRemaining) {
+        if (dPosSecondsElapsed >= 0.0) {
+            setText(mixxx::Duration::formatSeconds(
+                        dPosSecondsElapsed, mixxx::Duration::Precision::CENTISECONDS)
+                    % QLatin1String(" / -") %
+                    mixxx::Duration::formatSeconds(
+                        dPosSecondsRemaining, mixxx::Duration::Precision::CENTISECONDS));
+        } else {
+            setText(QLatin1String("-") % mixxx::Duration::formatSeconds(
+                        -dPosSecondsElapsed, mixxx::Duration::Precision::CENTISECONDS)
+                    % QLatin1String(" / -") %
+                    mixxx::Duration::formatSeconds(
+                        dPosSecondsRemaining, mixxx::Duration::Precision::CENTISECONDS));
+        }
     }
-    setText(sPosText);
 }
 
-void WNumberPos::slotSetRemain(double remain) {
-    setRemain(remain > 0.0);
-}
-
-void WNumberPos::setRemain(bool bRemain) {
-    m_bRemain = bRemain;
-
-    // Shift display state between showing position and remaining
-    if (m_bRemain) {
-        m_skinText = "-";
-    } else {
-        m_skinText = "";
+void WNumberPos::slotSetDisplayMode(double remain) {
+    if (remain <= 0.0) {
+        m_displayMode = DisplayMode::Elapsed;
+    } else if (remain == 1.0) {
+        m_displayMode = DisplayMode::Remaining;
+    } else if (remain == 2.0) {
+        m_displayMode = DisplayMode::ElapsedAndRemaining;
     }
-    // Have the widget redraw itself with its current value.
-    slotSetValue(m_dOldValue);
+    slotSetPosition(m_dOldPosition);
 }

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -14,22 +14,27 @@ class WNumberPos : public WNumber {
   public:
     explicit WNumberPos(const char *group, QWidget *parent=nullptr);
 
-    // Set if the display shows remaining time (true) or position (false)
-    void setRemain(bool bRemain);
-
   protected:
     void mousePressEvent(QMouseEvent* pEvent) override;
 
   private slots:
     void setValue(double dValue) override;
-    void slotSetValue(double);
-    void slotSetRemain(double remain);
+    void slotSetPosition(double);
     void slotSetTrackSampleRate(double dSampleRate);
     void slotSetTrackSamples(double dSamples);
+    void slotSetDisplayMode(double);
 
   private:
+    enum class DisplayMode {
+        Elapsed,
+        Remaining,
+        ElapsedAndRemaining,
+    };
+
+    DisplayMode m_displayMode;
+
     // Old value set
-    double m_dOldValue;
+    double m_dOldPosition;
     double m_dTrackSamples;
     double m_dTrackSampleRate;
     // True if remaining content is being shown

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -6,6 +6,7 @@
 #include <QMouseEvent>
 
 #include "wnumber.h"
+#include "preferences/dialog/dlgprefcontrols.h"
 
 class ControlProxy;
 
@@ -25,13 +26,8 @@ class WNumberPos : public WNumber {
     void slotSetDisplayMode(double);
 
   private:
-    enum class DisplayMode {
-        Elapsed,
-        Remaining,
-        ElapsedAndRemaining,
-    };
 
-    DisplayMode m_displayMode;
+    Duration::DisplayMode m_displayMode;
 
     // Old value set
     double m_dOldPosition;

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -27,7 +27,7 @@ class WNumberPos : public WNumber {
 
   private:
 
-    Duration::DisplayMode m_displayMode;
+    TrackTime::DisplayMode m_displayMode;
 
     // Old value set
     double m_dOldPosition;


### PR DESCRIPTION
Add a third option for WNumberPos to show both the elapsed and remaining time on a deck. When this is chosen, the format is "elapsed time / remaining time".