### PR TITLE
introduce ControllerEngine::makeConnection and deprecate ControllerEngine::connectControl

### DIFF
--- a/src/control/controlobjectscript.cpp
+++ b/src/control/controlobjectscript.cpp
@@ -6,11 +6,11 @@ ControlObjectScript::ControlObjectScript(const ConfigKey& key, QObject* pParent)
         : ControlProxy(key, pParent) {
 }
 
-void ControlObjectScript::connectScriptFunction(
+bool ControlObjectScript::addConnection(
         const ControllerEngineConnection& conn) {
-    if (m_connectedScriptFunctions.isEmpty()) {
-        // we connect the slots only, if there will be actually a script
-        // connected
+    if (m_controllerEngineConnections.isEmpty()) {
+        // Only connect the slots when they are actually needed
+        // by script connections.
         connect(m_pControl.data(), SIGNAL(valueChanged(double, QObject*)),
                 this, SLOT(slotValueChanged(double,QObject*)),
                 Qt::QueuedConnection);
@@ -18,28 +18,63 @@ void ControlObjectScript::connectScriptFunction(
                 this, SLOT(slotValueChanged(double,QObject*)),
                 Qt::QueuedConnection);
     }
-    m_connectedScriptFunctions.append(conn);
+
+    for (const auto& priorConnection: m_controllerEngineConnections) {
+        if (conn == priorConnection) {
+            qWarning() << "Connection " + conn.id.toString() +
+                          " already connected to (" +
+                          conn.key.group + ", " + conn.key.item +
+                          "). Ignoring attempt to connect again.";
+            return false;
+        }
+    }
+
+    m_controllerEngineConnections.append(conn);
+    controllerDebug("Connected (" +
+                    conn.key.group + ", " + conn.key.item +
+                    ") to connection " + conn.id.toString());
+    return true;
 }
 
-bool ControlObjectScript::disconnectScriptFunction(
+bool ControlObjectScript::removeConnection(
         const ControllerEngineConnection& conn) {
-    bool ret = m_connectedScriptFunctions.removeAll(conn) > 0;
-    if (m_connectedScriptFunctions.isEmpty()) {
+    bool success = m_controllerEngineConnections.removeOne(conn);
+    if (success) {
+        controllerDebug("Disconnected (" +
+                        conn.key.group + ", " + conn.key.item +
+                        ") from connection " + conn.id.toString());
+    } else {
+        qWarning() << "Failed to disconnect (" +
+                      conn.key.group + ", " + conn.key.item +
+                      ") from connection " + conn.id.toString();
+    }
+    if (m_controllerEngineConnections.isEmpty()) {
         // no script left, we can disconnected
         disconnect(m_pControl.data(), SIGNAL(valueChanged(double, QObject*)),
                 this, SLOT(slotValueChanged(double,QObject*)));
         disconnect(this, SIGNAL(trigger(double, QObject*)),
                 this, SLOT(slotValueChanged(double,QObject*)));
     }
-    return ret;
+    return success;
+}
+
+void ControlObjectScript::disconnectAllConnectionsToFunction(const QScriptValue& function) {
+    // Make a local copy of m_controllerEngineConnections because items are removed
+    // within the loop.
+    QList<ControllerEngineConnection> connections = m_controllerEngineConnections;
+    for (const auto& conn: connections) {
+        if (conn.function.strictlyEquals(function)) {
+            m_controllerEngineConnections.removeOne(conn);
+        }
+    }
 }
 
 void ControlObjectScript::slotValueChanged(double value, QObject*) {
-    // Make a local copy of m_connectedScriptFunctions fist.
+    // Make a local copy of m_connectedScriptFunctions first.
     // This allows a script to disconnect a callback from the callback
     // itself. Otherwise the this may crash since the disconnect call
     // happens during conn.function.call() in the middle of the loop below.
-    QList<ControllerEngineConnection> connections = m_connectedScriptFunctions;
+    QList<ControllerEngineConnection> connections = m_controllerEngineConnections;
     for (auto&& conn: connections) {
         conn.executeCallback(value);
     }

--- a/src/control/controlobjectscript.cpp
+++ b/src/control/controlobjectscript.cpp
@@ -56,12 +56,11 @@ void ControlObjectScript::removeScriptConnection(const ScriptConnection& conn) {
 }
 
 void ControlObjectScript::disconnectAllConnectionsToFunction(const QScriptValue& function) {
-    // Make a local copy of m_scriptConnections because items are removed
-    // within the loop.
+    // Make a local copy of m_scriptConnections because items are removed within the loop.
     QList<ScriptConnection> connections = m_scriptConnections;
     for (const auto& conn: connections) {
         if (conn.callback.strictlyEquals(function)) {
-            m_scriptConnections.removeOne(conn);
+            removeScriptConnection(conn);
         }
     }
 }

--- a/src/control/controlobjectscript.cpp
+++ b/src/control/controlobjectscript.cpp
@@ -35,7 +35,7 @@ bool ControlObjectScript::addScriptConnection(const ScriptConnection& conn) {
     return true;
 }
 
-bool ControlObjectScript::removeScriptConnection(const ScriptConnection& conn) {
+void ControlObjectScript::removeScriptConnection(const ScriptConnection& conn) {
     bool success = m_scriptConnections.removeOne(conn);
     if (success) {
         controllerDebug("Disconnected (" +
@@ -53,7 +53,6 @@ bool ControlObjectScript::removeScriptConnection(const ScriptConnection& conn) {
         disconnect(this, SIGNAL(trigger(double, QObject*)),
                 this, SLOT(slotValueChanged(double,QObject*)));
     }
-    return success;
 }
 
 void ControlObjectScript::disconnectAllConnectionsToFunction(const QScriptValue& function) {

--- a/src/control/controlobjectscript.h
+++ b/src/control/controlobjectscript.h
@@ -15,8 +15,11 @@ class ControlObjectScript : public ControlProxy {
 
     void removeScriptConnection(const ScriptConnection& conn);
 
+    // Required for legacy behavior of ControllerEngine::connectControl
     inline int countConnections() {
             return m_scriptConnections.size(); };
+    inline ScriptConnection firstConnection() {
+            return m_scriptConnections.first(); };
     void disconnectAllConnectionsToFunction(const QScriptValue& function);
 
     // Called from update();

--- a/src/control/controlobjectscript.h
+++ b/src/control/controlobjectscript.h
@@ -11,14 +11,12 @@ class ControlObjectScript : public ControlProxy {
   public:
     explicit ControlObjectScript(const ConfigKey& key, QObject* pParent = nullptr);
 
-    bool addConnection(
-            const ControllerEngineConnection& conn);
+    bool addScriptConnection(const ScriptConnection& conn);
 
-    bool removeConnection(
-            const ControllerEngineConnection& conn);
+    bool removeScriptConnection(const ScriptConnection& conn);
 
     inline int countConnections() {
-            return m_controllerEngineConnections.size(); };
+            return m_scriptConnections.size(); };
     void disconnectAllConnectionsToFunction(const QScriptValue& function);
 
     // Called from update();
@@ -35,7 +33,7 @@ class ControlObjectScript : public ControlProxy {
     void slotValueChanged(double v, QObject*);
 
   private:
-    QList<ControllerEngineConnection> m_controllerEngineConnections;
+    QList<ScriptConnection> m_scriptConnections;
 };
 
 #endif // CONTROLOBJECTSCRIPT_H

--- a/src/control/controlobjectscript.h
+++ b/src/control/controlobjectscript.h
@@ -13,7 +13,7 @@ class ControlObjectScript : public ControlProxy {
 
     bool addScriptConnection(const ScriptConnection& conn);
 
-    bool removeScriptConnection(const ScriptConnection& conn);
+    void removeScriptConnection(const ScriptConnection& conn);
 
     inline int countConnections() {
             return m_scriptConnections.size(); };

--- a/src/control/controlobjectscript.h
+++ b/src/control/controlobjectscript.h
@@ -2,7 +2,7 @@
 #define CONTROLOBJECTSCRIPT_H
 
 #include "controllers/controllerengine.h"
-
+#include "controllers/controllerdebug.h"
 #include "control/controlproxy.h"
 
 // this is used for communicate with controller scripts
@@ -11,11 +11,15 @@ class ControlObjectScript : public ControlProxy {
   public:
     explicit ControlObjectScript(const ConfigKey& key, QObject* pParent = nullptr);
 
-    void connectScriptFunction(
+    bool addConnection(
             const ControllerEngineConnection& conn);
 
-    bool disconnectScriptFunction(
+    bool removeConnection(
             const ControllerEngineConnection& conn);
+
+    inline int countConnections() {
+            return m_controllerEngineConnections.size(); };
+    void disconnectAllConnectionsToFunction(const QScriptValue& function);
 
     // Called from update();
     void emitValueChanged() override {
@@ -31,7 +35,7 @@ class ControlObjectScript : public ControlProxy {
     void slotValueChanged(double v, QObject*);
 
   private:
-    QList<ControllerEngineConnection> m_connectedScriptFunctions;
+    QList<ControllerEngineConnection> m_controllerEngineConnections;
 };
 
 #endif // CONTROLOBJECTSCRIPT_H

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -813,8 +813,9 @@ void ScriptConnection::executeCallback(double value) const {
     QScriptValue func = callback; // copy function because QScriptValue::call is not const
     QScriptValue result = func.call(context, args);
     if (result.isError()) {
-        qWarning() << "ControllerEngine: Invocation of callback" << id.toString()
-                   << "failed:" << result.toString();
+        qWarning() << "ControllerEngine: Invocation of connection " << id.toString()
+                   << "connected to (" + key.group + ", " + key.item + ") failed:"
+                   << result.toString();
     }
 }
 
@@ -831,7 +832,8 @@ void ControllerEngine::removeScriptConnection(const ScriptConnection connection)
     }
 
     if (!coScript->removeScriptConnection(connection)) {
-        qWarning() << "Could not disconnect connection" << connection.id.toString();
+        qWarning() << "Could not disconnect script connection " << connection.id.toString()
+                   << "from (" + connection.key.group + ", " + connection.key.item + ")";
     }
 }
 

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -822,7 +822,7 @@ QScriptValue ControllerEngine::connectControl(
     }
 
     ControlObjectScript* coScript = getControlObjectScript(group, name);
-    // This check is redundant with makeConnectionInner, but the
+    // This check is redundant with makeConnection, but the
     // ControlObjectScript is also needed here to check for duplicate connections.
     if (coScript == nullptr) {
         if (disconnect) {
@@ -836,7 +836,7 @@ QScriptValue ControllerEngine::connectControl(
     }
 
     if (passedCallback.isString()) {
-        // This check is redundant with makeConnectionInner, but it must be done here
+        // This check is redundant with makeConnection, but it must be done here
         // before evaluating the code string.
         if (m_pEngine == nullptr) {
             qWarning() << "Tried to connect script callback, but there is no script engine!";

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -831,10 +831,7 @@ void ControllerEngine::removeScriptConnection(const ScriptConnection connection)
         return;
     }
 
-    if (!coScript->removeScriptConnection(connection)) {
-        qWarning() << "Could not disconnect script connection " << connection.id.toString()
-                   << "from (" + connection.key.group + ", " + connection.key.item + ")";
-    }
+    coScript->removeScriptConnection(connection);
 }
 
 void ScriptConnectionInvokableWrapper::disconnect() {

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -753,7 +753,12 @@ QScriptValue ControllerEngine::connectControl(
                        << "but this is not allowed when passing a callback as a string."
                        << "If you actually want to create duplicate connections,"
                        << "pass the callback as a JavaScript function.";
-            return QScriptValue(false);
+
+            ScriptConnection connection = coScript->firstConnection();
+
+            return m_pEngine->newQObject(
+                new ScriptConnectionInvokableWrapper(connection),
+                QScriptEngine::ScriptOwnership);
         }
     } else if (callback.isQObject()) {
         // Assume a ScriptConnection

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -47,7 +47,7 @@ class ScriptConnection {
     }
 };
 
-// ScriptConnectionInvokableWrapper is an class providing scripts
+// ScriptConnectionInvokableWrapper is a class providing scripts
 // with an interface to ScriptConnection.
 class ScriptConnectionInvokableWrapper : public QObject {
     Q_OBJECT

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -109,8 +109,12 @@ class ControllerEngine : public QObject {
     Q_INVOKABLE void reset(QString group, QString name);
     Q_INVOKABLE double getDefaultValue(QString group, QString name);
     Q_INVOKABLE double getDefaultParameter(QString group, QString name);
+    Q_INVOKABLE QScriptValue makeConnection(QString group, QString name,
+                                            const QScriptValue callback);
+    // DEPRECATED: Use makeConnection instead.
     Q_INVOKABLE QScriptValue connectControl(QString group, QString name,
-                                            const QScriptValue function, bool disconnect = false);
+                                            const QScriptValue passedCallback,
+                                            bool disconnect = false);
     // Called indirectly by the objects returned by connectControl
     Q_INVOKABLE void trigger(QString group, QString name);
     Q_INVOKABLE void log(QString message);

--- a/src/test/controllerengine_test.cpp
+++ b/src/test/controllerengine_test.cpp
@@ -321,7 +321,7 @@ TEST_F(ControllerEngineTest, connectControl_ByFunctionAllowDuplicateConnections)
 TEST_F(ControllerEngineTest, connectControl_toDisconnectRemovesAllConnections) {
     // Test that every connection to a ControlObject is disconnected
     // by calling engine.connectControl(..., true). Individual connections
-    // can only be connected by storing the connection object returned by
+    // can only be disconnected by storing the connection object returned by
     // engine.connectControl and calling that object's 'disconnect' method.
     auto co = std::make_unique<ControlObject>(ConfigKey("[Test]", "co"));
     auto pass = std::make_unique<ControlObject>(ConfigKey("[Test]", "passed"));
@@ -471,7 +471,9 @@ TEST_F(ControllerEngineTest, connectionObjectTrigger) {
 }
 
 TEST_F(ControllerEngineTest, connectionExecutesWithCorrectThisObject) {
-    // Test that connecting and disconnecting with a function value works.
+    // Test that callback functions are executed with JavaScript's
+    // 'this' keyword referring to the object in which the connection
+    // was created.
     auto co = std::make_unique<ControlObject>(ConfigKey("[Test]", "co"));
     auto pass = std::make_unique<ControlObject>(ConfigKey("[Test]", "passed"));
 


### PR DESCRIPTION
This fixes a bug in which calling the disconnect() method of script callback connection objects would disconnect all callbacks connected to its ControlObject that shared a callback function. This created a very confusing situation when I accidentally created two Components that both connected the same components.Button.prototype.output function to the same ControlObject -- even though those callback functions would execute in different contexts and have different effects. I have also added tests for the quirky, inconsistent behavior of ControllerEngine::connectControl() and useful debugging messages.