### PR TITLE
Recording duration widget

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -852,6 +852,7 @@ class MixxxCore(Feature):
                    "widget/weffectbuttonparameter.cpp",
                    "widget/weffectparameterbase.cpp",
                    "widget/wtime.cpp",
+                   "widget/wrecordingduration.cpp",
                    "widget/wkey.cpp",
                    "widget/wbattery.cpp",
                    "widget/wcombobox.cpp",

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -334,7 +334,8 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
                                                            m_pControllerManager,
                                                            m_pLibrary,
                                                            m_pVCManager,
-                                                           m_pEffectsManager))) {
+                                                           m_pEffectsManager,
+                                                           m_pRecordingManager))) {
         reportCriticalErrorAndQuit(
                 "default skin cannot be loaded see <b>mixxx</b> trace for more information.");
 
@@ -1125,7 +1126,8 @@ void MixxxMainWindow::rebootMixxxView() {
                                                            m_pControllerManager,
                                                            m_pLibrary,
                                                            m_pVCManager,
-                                                           m_pEffectsManager))) {
+                                                           m_pEffectsManager,
+                                                           m_pRecordingManager))) {
 
         QMessageBox::critical(this,
                               tr("Error in skin file"),

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -559,7 +559,6 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
     } else if (nodeName == "Time") {
         result = wrapWidget(parseLabelWidget<WTime>(node));
     } else if (nodeName == "RecordingDuration") {
-//        result = wrapWidget(parseLabelWidget<WRecordingDuration>(node));
         result = wrapWidget(parseRecordingDuration(node));
     } else if (nodeName == "Splitter") {
         result = wrapWidget(parseSplitter(node));

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -30,6 +30,8 @@
 
 #include "effects/effectsmanager.h"
 
+#include "recording/recordingmanager.h"
+
 #include "widget/controlwidgetconnection.h"
 #include "widget/wbasewidget.h"
 #include "widget/wcoverart.h"
@@ -44,6 +46,7 @@
 #include "widget/wstatuslight.h"
 #include "widget/wlabel.h"
 #include "widget/wtime.h"
+#include "widget/wrecordingduration.h"
 #include "widget/wtracktext.h"
 #include "widget/wtrackproperty.h"
 #include "widget/wstarrating.h"
@@ -143,6 +146,7 @@ LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig)
           m_pLibrary(NULL),
           m_pVCManager(NULL),
           m_pEffectsManager(NULL),
+          m_pRecordingManager(NULL),
           m_pParent(NULL) {
 }
 
@@ -152,7 +156,8 @@ LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig,
                                    ControllerManager* pControllerManager,
                                    Library* pLibrary,
                                    VinylControlManager* pVCMan,
-                                   EffectsManager* pEffectsManager)
+                                   EffectsManager* pEffectsManager,
+                                   RecordingManager* pRecordingManager)
         : m_pConfig(pConfig),
           m_pKeyboard(pKeyboard),
           m_pPlayerManager(pPlayerManager),
@@ -160,6 +165,7 @@ LegacySkinParser::LegacySkinParser(UserSettingsPointer pConfig,
           m_pLibrary(pLibrary),
           m_pVCManager(pVCMan),
           m_pEffectsManager(pEffectsManager),
+          m_pRecordingManager(pRecordingManager),
           m_pParent(NULL) {
 }
 
@@ -552,6 +558,9 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
         result = wrapWidget(parseSpinny(node));
     } else if (nodeName == "Time") {
         result = wrapWidget(parseLabelWidget<WTime>(node));
+    } else if (nodeName == "RecordingDuration") {
+//        result = wrapWidget(parseLabelWidget<WRecordingDuration>(node));
+        result = wrapWidget(parseRecordingDuration(node));
     } else if (nodeName == "Splitter") {
         result = wrapWidget(parseSplitter(node));
     } else if (nodeName == "LibrarySidebar") {
@@ -1090,6 +1099,17 @@ QWidget* LegacySkinParser::parseEngineKey(const QDomElement& node) {
 
 QWidget* LegacySkinParser::parseBattery(const QDomElement& node) {
     WBattery *p = new WBattery(m_pParent);
+    setupBaseWidget(node, p);
+    setupWidget(node, p);
+    p->setup(node, *m_pContext);
+    setupConnections(node, p);
+    p->installEventFilter(m_pKeyboard);
+    p->installEventFilter(m_pControllerManager->getControllerLearningEventFilter());
+    return p;
+}
+
+QWidget* LegacySkinParser::parseRecordingDuration(const QDomElement& node) {
+    WRecordingDuration *p = new WRecordingDuration(m_pParent, m_pRecordingManager);
     setupBaseWidget(node, p);
     setupWidget(node, p);
     p->setup(node, *m_pContext);

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -19,6 +19,7 @@ class Library;
 class KeyboardEventFilter;
 class PlayerManager;
 class EffectsManager;
+class RecordingManager;
 class ControllerManager;
 class SkinContext;
 class WLabel;
@@ -34,7 +35,8 @@ class LegacySkinParser : public QObject, public SkinParser {
                      KeyboardEventFilter* pKeyboard, PlayerManager* pPlayerManager,
                      ControllerManager* pControllerManager,
                      Library* pLibrary, VinylControlManager* pVCMan,
-                     EffectsManager* pEffectsManager);
+                     EffectsManager* pEffectsManager,
+                     RecordingManager* pRecordingManager);
     virtual ~LegacySkinParser();
 
     virtual bool canParse(const QString& skinPath);
@@ -104,6 +106,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     QWidget* parseLibrary(const QDomElement& node);
     QWidget* parseLibrarySidebar(const QDomElement& node);
     QWidget* parseBattery(const QDomElement& node);
+    QWidget* parseRecordingDuration(const QDomElement& node);
     QWidget* parseCoverArt(const QDomElement& node);
 
     // Renders a template.
@@ -137,6 +140,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     Library* m_pLibrary;
     VinylControlManager* m_pVCManager;
     EffectsManager* m_pEffectsManager;
+    RecordingManager* m_pRecordingManager;
     QWidget* m_pParent;
     std::unique_ptr<SkinContext> m_pContext;
     Tooltips m_tooltips;

--- a/src/skin/skinloader.cpp
+++ b/src/skin/skinloader.cpp
@@ -18,6 +18,7 @@
 #include "util/debug.h"
 #include "skin/launchimage.h"
 #include "util/timer.h"
+#include "recording/recordingmanager.h"
 
 SkinLoader::SkinLoader(UserSettingsPointer pConfig) :
         m_pConfig(pConfig) {
@@ -115,7 +116,8 @@ QWidget* SkinLoader::loadDefaultSkin(QWidget* pParent,
                                      ControllerManager* pControllerManager,
                                      Library* pLibrary,
                                      VinylControlManager* pVCMan,
-                                     EffectsManager* pEffectsManager) {
+                                     EffectsManager* pEffectsManager,
+                                     RecordingManager* pRecordingManager) {
     ScopedTimer timer("SkinLoader::loadDefaultSkin");
     QString skinPath = getSkinPath();
 
@@ -126,7 +128,7 @@ QWidget* SkinLoader::loadDefaultSkin(QWidget* pParent,
 
     LegacySkinParser legacy(m_pConfig, pKeyboard, pPlayerManager,
                             pControllerManager, pLibrary, pVCMan,
-                            pEffectsManager);
+                            pEffectsManager, pRecordingManager);
     return legacy.parseSkin(skinPath, pParent);
 }
 

--- a/src/skin/skinloader.h
+++ b/src/skin/skinloader.h
@@ -13,6 +13,7 @@ class ControllerManager;
 class Library;
 class VinylControlManager;
 class EffectsManager;
+class RecordingManager;
 class LaunchImage;
 
 class SkinLoader {
@@ -26,7 +27,8 @@ class SkinLoader {
                              ControllerManager* pControllerManager,
                              Library* pLibrary,
                              VinylControlManager* pVCMan,
-                             EffectsManager* pEffectsManager);
+                             EffectsManager* pEffectsManager,
+                             RecordingManager* pRecordingManager);
 
     LaunchImage* loadLaunchImage(QWidget* pParent);
 

--- a/src/widget/wrecordingduration.cpp
+++ b/src/widget/wrecordingduration.cpp
@@ -3,7 +3,6 @@
 WRecordingDuration::WRecordingDuration(QWidget *parent,
                                     RecordingManager* pRecordingManager)
         : WLabel(parent),
-          m_durationRecordedStr(""),
           m_pRecordingManager(pRecordingManager) {
 }
 
@@ -13,10 +12,19 @@ WRecordingDuration::~WRecordingDuration() {
 void WRecordingDuration::setup(const QDomNode& node, const SkinContext& context) {
     WLabel::setup(node, context);
     connect(m_pRecordingManager, SIGNAL(durationRecorded(QString)),
-        this, SLOT(refreshLabelText(QString)));
+        this, SLOT(refreshLabel(QString)));
+    connect(m_pRecordingManager, SIGNAL(isRecordingActive(bool)),
+        this, SLOT(clearLabel(bool)));
 }
 
-void WRecordingDuration::refreshLabelText(QString durationRecorded) {
-    m_durationRecordedStr = durationRecorded;
-    setText(m_durationRecordedStr);
+void WRecordingDuration::clearLabel(bool toggle) {
+    Q_UNUSED(toggle);
+    // If recording is stopped/inactive
+    if(!m_pRecordingManager->isRecordingActive()) {
+        setText("--:--");
+    }
+}
+
+void WRecordingDuration::refreshLabel(QString durationRecorded) {
+    setText(durationRecorded);
 }

--- a/src/widget/wrecordingduration.cpp
+++ b/src/widget/wrecordingduration.cpp
@@ -14,10 +14,10 @@ void WRecordingDuration::setup(const QDomNode& node, const SkinContext& context)
     connect(m_pRecordingManager, SIGNAL(durationRecorded(QString)),
         this, SLOT(refreshLabel(QString)));
     connect(m_pRecordingManager, SIGNAL(isRecording(bool)),
-            this, SLOT(clearLabel(bool)));
+            this, SLOT(slotReccordingInactive(bool)));
 }
 
-void WRecordingDuration::clearLabel(bool isRecording) {
+void WRecordingDuration::slotReccordingInactive(bool isRecording) {
     // If recording is stopped/inactive
     if(!isRecording) {
         setText("--:--");

--- a/src/widget/wrecordingduration.cpp
+++ b/src/widget/wrecordingduration.cpp
@@ -13,14 +13,13 @@ void WRecordingDuration::setup(const QDomNode& node, const SkinContext& context)
     WLabel::setup(node, context);
     connect(m_pRecordingManager, SIGNAL(durationRecorded(QString)),
         this, SLOT(refreshLabel(QString)));
-    connect(m_pRecordingManager, SIGNAL(isRecordingActive(bool)),
-        this, SLOT(clearLabel(bool)));
+    connect(m_pRecordingManager, SIGNAL(isRecording(bool)),
+            this, SLOT(clearLabel(bool)));
 }
 
-void WRecordingDuration::clearLabel(bool toggle) {
-    Q_UNUSED(toggle);
+void WRecordingDuration::clearLabel(bool isRecording) {
     // If recording is stopped/inactive
-    if(!m_pRecordingManager->isRecordingActive()) {
+    if(!isRecording) {
         setText("--:--");
     }
 }

--- a/src/widget/wrecordingduration.cpp
+++ b/src/widget/wrecordingduration.cpp
@@ -1,0 +1,22 @@
+#include "widget/wrecordingduration.h"
+
+WRecordingDuration::WRecordingDuration(QWidget *parent,
+                                    RecordingManager* pRecordingManager)
+        : WLabel(parent),
+          m_durationRecordedStr(""),
+          m_pRecordingManager(pRecordingManager) {
+}
+
+WRecordingDuration::~WRecordingDuration() {
+}
+
+void WRecordingDuration::setup(const QDomNode& node, const SkinContext& context) {
+    WLabel::setup(node, context);
+    connect(m_pRecordingManager, SIGNAL(durationRecorded(QString)),
+        this, SLOT(refreshLabelText(QString)));
+}
+
+void WRecordingDuration::refreshLabelText(QString durationRecorded) {
+    m_durationRecordedStr = durationRecorded;
+    setText(m_durationRecordedStr);
+}

--- a/src/widget/wrecordingduration.h
+++ b/src/widget/wrecordingduration.h
@@ -19,7 +19,7 @@ class WRecordingDuration: public WLabel {
 
   private slots:
     void refreshLabel(QString);
-    void clearLabel(bool);
+    void slotReccordingInactive(bool);
 
   private:
     RecordingManager* m_pRecordingManager;

--- a/src/widget/wrecordingduration.h
+++ b/src/widget/wrecordingduration.h
@@ -19,7 +19,7 @@ class WRecordingDuration: public WLabel {
 
   private slots:
     void refreshLabel(QString);
-    void clearLabel(QString);
+    void clearLabel(bool);
 
   private:
     RecordingManager* m_pRecordingManager;

--- a/src/widget/wrecordingduration.h
+++ b/src/widget/wrecordingduration.h
@@ -18,11 +18,10 @@ class WRecordingDuration: public WLabel {
     void setup(const QDomNode& node, const SkinContext& context) override;
 
   private slots:
-    void refreshLabelText(QString);
+    void refreshLabel(QString);
+    void clearLabel(QString);
 
   private:
-    QString m_durationRecordedStr;
-
     RecordingManager* m_pRecordingManager;
 };
 

--- a/src/widget/wrecordingduration.h
+++ b/src/widget/wrecordingduration.h
@@ -1,0 +1,29 @@
+// wrecordingduration.h
+// WRecordingDuration is a widget showing the duration of running recoding
+// In skin.xml, it is represented by a <RecordingDuration> node.
+
+#ifndef WRECORDINGDURATION_H
+#define WRECORDINGDURATION_H
+
+#include "widget/wlabel.h"
+#include "skin/skincontext.h"
+#include "recording/recordingmanager.h"
+
+class WRecordingDuration: public WLabel {
+    Q_OBJECT
+  public:
+    WRecordingDuration(QWidget* parent, RecordingManager* pRecordingManager);
+    ~WRecordingDuration() override;
+
+    void setup(const QDomNode& node, const SkinContext& context) override;
+
+  private slots:
+    void refreshLabelText(QString);
+
+  private:
+    QString m_durationRecordedStr;
+
+    RecordingManager* m_pRecordingManager;
+};
+
+#endif /* WRECORDINGDURATION_H */


### PR DESCRIPTION
[messed up #1220 with local production branch, so I start over here]

I'd like to introduce a simple label widget called with `<RecordingDuration>`.
It displays the duration of a running recording in the skin, apart from Recording section in Library.

A while ago I filed a [wishlist bug](https://bugs.launchpad.net/mixxx/+bug/1529908) but noone with more C++ experience & spare time picked this up so far.
Newbie that I am, I couldn't make something from the hints @daschuer posted there, so I tried to learn from WTime widget (simple widget) and dlgrecording.cpp (queries recordingmanager for recDurationString).