### PR TITLE
Keylock: Option how key is unlocked/reset

### DIFF
--- a/src/engine/keycontrol.cpp
+++ b/src/engine/keycontrol.cpp
@@ -11,7 +11,7 @@
 
 //static const double kLockOriginalKey = 0;
 static const double kLockCurrentKey = 1;
-static const double kResetUnlockedKey = 1;
+static const double kKeepUnlockedKey = 1;
 
 KeyControl::KeyControl(QString group,
                        UserSettingsPointer pConfig)
@@ -217,15 +217,17 @@ void KeyControl::updateRate() {
         // !bKeylock
         if (m_pitchRateInfo.keylock) {
             // Disabling Keylock
-            // If "Reset (unlocked) Key" is enabled
-            if (m_keyunlockMode->get() == kResetUnlockedKey) {
+            // If "Keep unlocked key" is enabled
+            if (m_keyunlockMode->get() == kKeepUnlockedKey) {
+                // don't reset to linear pitch, instead adopt speedSliderPitchRatio
+                // change as pitchTweakRatio
+                m_pitchRateInfo.pitchTweakRatio *=
+                 (speedSliderPitchRatio / m_pitchRateInfo.tempoRatio);
+            } else {
                 // If 'current' aka 'not original' key was locked
                 if (m_keylockMode->get() == kLockCurrentKey) {
                     // reset to linear pitch
                     m_pitchRateInfo.pitchTweakRatio = 1.0;
-                    // For not resetting to linear pitch:
-                    // Adopt speedPitchRatio change as pitchTweakRatio
-                    //pitchRateInfo.pitchTweakRatio *= (m_speedSliderPitchRatio / pitchRateInfo.tempoRatio);
                 }
             }
             m_pitchRateInfo.keylock = false;

--- a/src/engine/keycontrol.cpp
+++ b/src/engine/keycontrol.cpp
@@ -11,9 +11,10 @@
 
 //static const double kLockOriginalKey = 0;
 static const double kLockCurrentKey = 1;
+static const double kUnlockKeyToRate = 1;
 
 KeyControl::KeyControl(QString group,
-                       UserSettingsPointer pConfig)
+						UserSettingsPointer pConfig)
         : EngineControl(group, pConfig) {
     m_pitchRateInfo.pitchRatio = 1.0;
     m_pitchRateInfo.tempoRatio = 1.0;
@@ -64,13 +65,16 @@ KeyControl::KeyControl(QString group,
             Qt::DirectConnection);
 
     m_pEngineKeyDistance = new ControlPotmeter(ConfigKey(group, "visual_key_distance"),
-                                               -0.5, 0.5);
+												-0.5, 0.5);
     connect(m_pEngineKeyDistance, SIGNAL(valueChanged(double)),
             this, SLOT(slotSetEngineKeyDistance(double)),
             Qt::DirectConnection);
 
     m_keylockMode = new ControlPushButton(ConfigKey(group, "keylockMode"));
     m_keylockMode->setButtonMode(ControlPushButton::TOGGLE);
+
+    m_keyunlockMode = new ControlPushButton(ConfigKey(group, "keyunlockMode"));
+    m_keyunlockMode->setButtonMode(ControlPushButton::TOGGLE);
 
     // In case of vinyl control "rate" is a filtered mean value for display
     m_pRateSlider = ControlObject::getControl(ConfigKey(group, "rate"));
@@ -135,6 +139,7 @@ KeyControl::~KeyControl() {
     delete m_pEngineKey;
     delete m_pEngineKeyDistance;
     delete m_keylockMode;
+    delete m_keyunlockMode;
 }
 
 KeyControl::PitchTempoRatio KeyControl::getPitchTempoRatio() {
@@ -212,12 +217,14 @@ void KeyControl::updateRate() {
         // !bKeylock
         if (m_pitchRateInfo.keylock) {
             // Disabling Keylock
-            if (m_keylockMode->get() == kLockCurrentKey) {
-                // reset to linear pitch
-                m_pitchRateInfo.pitchTweakRatio = 1.0;
-                // For not resetting to linear pitch:
-                // Adopt speedPitchRatio change as pitchTweakRatio
-                //pitchRateInfo.pitchTweakRatio *= (m_speedSliderPitchRatio / pitchRateInfo.tempoRatio);
+            if (m_keyunlockMode->get() == kUnlockKeyToRate) {
+                if (m_keylockMode->get() == kLockCurrentKey) {
+                    // reset to linear pitch
+                    m_pitchRateInfo.pitchTweakRatio = 1.0;
+                    // For not resetting to linear pitch:
+                    // Adopt speedPitchRatio change as pitchTweakRatio
+                    //pitchRateInfo.pitchTweakRatio *= (m_speedSliderPitchRatio / pitchRateInfo.tempoRatio);
+                }
             }
             m_pitchRateInfo.keylock = false;
         }

--- a/src/engine/keycontrol.cpp
+++ b/src/engine/keycontrol.cpp
@@ -11,7 +11,7 @@
 
 //static const double kLockOriginalKey = 0;
 static const double kLockCurrentKey = 1;
-static const double kUnlockKeyToRate = 1;
+static const double kResetUnlockedKey = 1;
 
 KeyControl::KeyControl(QString group,
                        UserSettingsPointer pConfig)
@@ -217,7 +217,9 @@ void KeyControl::updateRate() {
         // !bKeylock
         if (m_pitchRateInfo.keylock) {
             // Disabling Keylock
-            if (m_keyunlockMode->get() == kUnlockKeyToRate) {
+            // If "Reset (unlocked) Key" is enabled
+            if (m_keyunlockMode->get() == kResetUnlockedKey) {
+                // If 'current' aka 'not original' key was locked
                 if (m_keylockMode->get() == kLockCurrentKey) {
                     // reset to linear pitch
                     m_pitchRateInfo.pitchTweakRatio = 1.0;

--- a/src/engine/keycontrol.cpp
+++ b/src/engine/keycontrol.cpp
@@ -14,7 +14,7 @@ static const double kLockCurrentKey = 1;
 static const double kUnlockKeyToRate = 1;
 
 KeyControl::KeyControl(QString group,
-						UserSettingsPointer pConfig)
+                       UserSettingsPointer pConfig)
         : EngineControl(group, pConfig) {
     m_pitchRateInfo.pitchRatio = 1.0;
     m_pitchRateInfo.tempoRatio = 1.0;
@@ -65,7 +65,7 @@ KeyControl::KeyControl(QString group,
             Qt::DirectConnection);
 
     m_pEngineKeyDistance = new ControlPotmeter(ConfigKey(group, "visual_key_distance"),
-												-0.5, 0.5);
+                                               -0.5, 0.5);
     connect(m_pEngineKeyDistance, SIGNAL(valueChanged(double)),
             this, SLOT(slotSetEngineKeyDistance(double)),
             Qt::DirectConnection);

--- a/src/engine/keycontrol.cpp
+++ b/src/engine/keycontrol.cpp
@@ -223,6 +223,10 @@ void KeyControl::updateRate() {
                 // change as pitchTweakRatio
                 m_pitchRateInfo.pitchTweakRatio *=
                  (speedSliderPitchRatio / m_pitchRateInfo.tempoRatio);
+                // adopt pitch_adjust now so that it doesn't jump and resets key
+                // when touching pitch_adjust knob after unlock with offset key
+                m_pPitchAdjust->set(
+                    KeyUtils::powerOf2ToSemitoneChange(m_pitchRateInfo.pitchTweakRatio));
             } else {
                 // If 'current' aka 'not original' key was locked
                 if (m_keylockMode->get() == kLockCurrentKey) {

--- a/src/engine/keycontrol.h
+++ b/src/engine/keycontrol.h
@@ -66,6 +66,7 @@ class KeyControl : public EngineControl {
     ControlPushButton* m_pButtonSyncKey;
     ControlPushButton* m_pButtonResetKey;
     ControlPushButton* m_keylockMode;
+    ControlPushButton* m_keyunlockMode;
 
     /** The current loaded file's detected key */
     ControlObject* m_pFileKey;

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -138,7 +138,7 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     connect(buttonGroupKeyUnlockMode, SIGNAL(buttonClicked(QAbstractButton*)),
             this, SLOT(slotKeyUnlockMode(QAbstractButton *)));
 
-    // 0 Keep locked key, 1 Calculate key from tempo
+    // 0 Keep locked key, 1 Reset locked key
     m_keyunlockMode = m_pConfig->getValue(
         ConfigKey("[Controls]", "keyunlockMode"), 0);
     foreach (ControlProxy* pControl, m_keyunlockModeControls) {
@@ -443,9 +443,9 @@ void DlgPrefControls::slotUpdate() {
         radioButtonOriginalKey->setChecked(true);
 
     if (m_keyunlockMode == 1)
-        radioButtonCalculateNewKey->setChecked(true);
+        radioButtonResetUnlockedKey->setChecked(true);
     else
-        radioButtonKeepLockedKey->setChecked(true);
+        radioButtonKeepUnlockedKey->setChecked(true);
 
     checkBoxResetSpeed->setChecked(m_speedAutoReset);
     checkBoxResetPitch->setChecked(m_pitchAutoReset);
@@ -502,9 +502,9 @@ void DlgPrefControls::slotResetToDefaults() {
     m_keylockMode = 0;
     radioButtonOriginalKey->setChecked(true);
 
-    // Unlock to key calculated from current rate
+    // Keep unlocked key
     m_keyunlockMode = 0;
-    radioButtonCalculateNewKey->setChecked(true);
+    radioButtonKeepUnlockedKey->setChecked(true);
 }
 
 void DlgPrefControls::slotSetLocale(int pos) {
@@ -567,7 +567,7 @@ void DlgPrefControls::slotKeyLockMode(QAbstractButton* b) {
 }
 
 void DlgPrefControls::slotKeyUnlockMode(QAbstractButton* b) {
-    if (b == radioButtonCalculateNewKey) {
+    if (b == radioButtonResetUnlockedKey) {
         m_keyunlockMode = 1;
     }
     else { m_keyunlockMode = 0; }
@@ -818,9 +818,11 @@ void DlgPrefControls::slotNumSamplersChanged(double new_count) {
                 group, "keylockMode"));
         m_keylockModeControls.last()->set(m_keylockMode);
         // Do we need key un-lock mode for Samplers as well?
-        // Except GUI, they don't have proper (physical!) controls
+        // Except GUI, they probably don't have proper (physical!) controls
         // to change pitch.
-        // Test if build succeeds...
+        m_keyunlockModeControls.push_back(new ControlProxy(
+                group, "keyunlockMode"));
+        m_keyunlockModeControls.last()->set(m_keyunlockMode);
     }
 
     m_iNumConfiguredSamplers = numsamplers;

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -138,7 +138,7 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     connect(buttonGroupKeyUnlockMode, SIGNAL(buttonClicked(QAbstractButton*)),
             this, SLOT(slotKeyUnlockMode(QAbstractButton *)));
 
-    // 0 Keep locked key, 1 Reset locked key (default)
+    // 0 Reset locked key (default), 1 Keep locked key
     m_keyunlockMode = m_pConfig->getValue(
         ConfigKey("[Controls]", "keyunlockMode"), 0);
     foreach (ControlProxy* pControl, m_keyunlockModeControls) {
@@ -443,9 +443,9 @@ void DlgPrefControls::slotUpdate() {
         radioButtonOriginalKey->setChecked(true);
 
     if (m_keyunlockMode == 1)
-        radioButtonResetUnlockedKey->setChecked(true);
-    else
         radioButtonKeepUnlockedKey->setChecked(true);
+    else
+        radioButtonResetUnlockedKey->setChecked(true);
 
     checkBoxResetSpeed->setChecked(m_speedAutoReset);
     checkBoxResetPitch->setChecked(m_pitchAutoReset);
@@ -503,8 +503,8 @@ void DlgPrefControls::slotResetToDefaults() {
     radioButtonOriginalKey->setChecked(true);
 
     // Reset key on unlock
-    m_keyunlockMode = 1;
-    radioButtonKeepUnlockedKey->setChecked(true);
+    m_keyunlockMode = 0;
+    radioButtonResetUnlockedKey->setChecked(true);
 }
 
 void DlgPrefControls::slotSetLocale(int pos) {
@@ -568,9 +568,9 @@ void DlgPrefControls::slotKeyLockMode(QAbstractButton* b) {
 
 void DlgPrefControls::slotKeyUnlockMode(QAbstractButton* b) {
     if (b == radioButtonResetUnlockedKey) {
-        m_keyunlockMode = 1;
+        m_keyunlockMode = 0;
     }
-    else { m_keyunlockMode = 0; }
+    else { m_keyunlockMode = 1; }
 }
 
 void DlgPrefControls::slotSetAllowTrackLoadToPlayingDeck(bool b) {

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-							dlgprefcontrols.cpp  -  description
+                            dlgprefcontrols.cpp  -  description
                             -------------------
     begin                : Sat Jul 5 2003
     copyright            : (C) 2003 by Tue & Ken Haste Andersen
@@ -40,9 +40,9 @@
 #include "defs_urls.h"
 
 DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
-								 SkinLoader* pSkinLoader,
-								 PlayerManager* pPlayerManager,
-								 UserSettingsPointer  pConfig)
+                                 SkinLoader* pSkinLoader,
+                                 PlayerManager* pPlayerManager,
+                                 UserSettingsPointer  pConfig)
         :  DlgPreferencePage(parent),
            m_pConfig(pConfig),
            m_mixxx(mixxx),
@@ -316,7 +316,7 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     // Start in fullscreen mode
     //
     checkBoxStartFullScreen->setChecked(m_pConfig->getValueString(
-                       ConfigKey("[Config]", "StartInFullscreen")).toInt()==1);
+                    ConfigKey("[Config]", "StartInFullscreen")).toInt()==1);
     connect(checkBoxStartFullScreen, SIGNAL(toggled(bool)),
             this, SLOT(slotSetStartInFullScreen(bool)));
     //
@@ -425,7 +425,7 @@ void DlgPrefControls::slotUpdate() {
     int idx = ComboBoxRateRange->findData(static_cast<int>(deck1RateRange * 100));
     if (idx == -1) {
         ComboBoxRateRange->addItem(QString::number(deck1RateRange * 100.).append("%"),
-                                   deck1RateRange * 100.);
+                                deck1RateRange * 100.);
     }
 
     ComboBoxRateRange->setCurrentIndex(idx);
@@ -559,7 +559,7 @@ void DlgPrefControls::slotKeyLockMode(QAbstractButton* b) {
 void DlgPrefControls::slotSetAllowTrackLoadToPlayingDeck(bool b) {
     // If b is true, it means NOT to allow track loading
     m_pConfig->set(ConfigKey("[Controls]", "AllowTrackLoadToPlayingDeck"),
-				   ConfigValue(b?0:1));
+                   ConfigValue(b?0:1));
 }
 
 void DlgPrefControls::slotSetCueDefault(int index)
@@ -705,7 +705,7 @@ void DlgPrefControls::slotApply() {
                    ConfigValue(configSPAutoReset));
 
     m_pConfig->set(ConfigKey("[Controls]", "keylockMode"),
-        		   ConfigValue(m_keylockMode));
+                   ConfigValue(m_keylockMode));
     // Set key lock behavior for every group
     foreach (ControlProxy* pControl, m_keylockModeControls) {
         pControl->set(m_keylockMode);
@@ -762,7 +762,7 @@ void DlgPrefControls::slotNumDecksChanged(double new_count) {
         m_cueControls.push_back(new ControlProxy(
                 group, "cue_mode"));
         m_keylockModeControls.push_back(new ControlProxy(
-                        group, "keylockMode"));
+                group, "keylockMode"));
         m_keylockModeControls.last()->set(m_keylockMode);
     }
 

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
-                          dlgprefcontrols.cpp  -  description
-                             -------------------
+							dlgprefcontrols.cpp  -  description
+                            -------------------
     begin                : Sat Jul 5 2003
     copyright            : (C) 2003 by Tue & Ken Haste Andersen
     email                : haste@diku.dk
@@ -40,9 +40,9 @@
 #include "defs_urls.h"
 
 DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
-                                 SkinLoader* pSkinLoader,
-                                 PlayerManager* pPlayerManager,
-                                 UserSettingsPointer  pConfig)
+								 SkinLoader* pSkinLoader,
+								 PlayerManager* pPlayerManager,
+								 UserSettingsPointer  pConfig)
         :  DlgPreferencePage(parent),
            m_pConfig(pConfig),
            m_mixxx(mixxx),
@@ -125,10 +125,24 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     connect(buttonGroupKeyLockMode, SIGNAL(buttonClicked(QAbstractButton*)),
             this, SLOT(slotKeyLockMode(QAbstractButton *)));
 
+    // 0 Lock original key, 1 Lock current key
     m_keylockMode = m_pConfig->getValue(
         ConfigKey("[Controls]", "keylockMode"), 0);
     foreach (ControlProxy* pControl, m_keylockModeControls) {
         pControl->set(m_keylockMode);
+    }
+
+    //
+    // Key unlock mode
+    //
+    connect(buttonGroupKeyUnlockMode, SIGNAL(buttonClicked(QAbstractButton*)),
+            this, SLOT(slotKeyUnlockMode(QAbstractButton *)));
+
+    // 0 Keep locked key, 1 Calculate key from tempo
+    m_keyunlockMode = m_pConfig->getValue(
+        ConfigKey("[Controls]", "keyunlockMode"), 0);
+    foreach (ControlProxy* pControl, m_keylockModeControls) {
+        pControl->set(m_keyunlockMode);
     }
 
     //
@@ -545,7 +559,7 @@ void DlgPrefControls::slotKeyLockMode(QAbstractButton* b) {
 void DlgPrefControls::slotSetAllowTrackLoadToPlayingDeck(bool b) {
     // If b is true, it means NOT to allow track loading
     m_pConfig->set(ConfigKey("[Controls]", "AllowTrackLoadToPlayingDeck"),
-                   ConfigValue(b?0:1));
+				   ConfigValue(b?0:1));
 }
 
 void DlgPrefControls::slotSetCueDefault(int index)
@@ -691,7 +705,7 @@ void DlgPrefControls::slotApply() {
                    ConfigValue(configSPAutoReset));
 
     m_pConfig->set(ConfigKey("[Controls]", "keylockMode"),
-            ConfigValue(m_keylockMode));
+        		   ConfigValue(m_keylockMode));
     // Set key lock behavior for every group
     foreach (ControlProxy* pControl, m_keylockModeControls) {
         pControl->set(m_keylockMode);
@@ -774,7 +788,7 @@ void DlgPrefControls::slotNumSamplersChanged(double new_count) {
         m_cueControls.push_back(new ControlProxy(
                 group, "cue_mode"));
         m_keylockModeControls.push_back(new ControlProxy(
-                        group, "keylockMode"));
+                group, "keylockMode"));
         m_keylockModeControls.last()->set(m_keylockMode);
     }
 

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -138,7 +138,7 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     connect(buttonGroupKeyUnlockMode, SIGNAL(buttonClicked(QAbstractButton*)),
             this, SLOT(slotKeyUnlockMode(QAbstractButton *)));
 
-    // 0 Keep locked key, 1 Reset locked key
+    // 0 Keep locked key, 1 Reset locked key (default)
     m_keyunlockMode = m_pConfig->getValue(
         ConfigKey("[Controls]", "keyunlockMode"), 0);
     foreach (ControlProxy* pControl, m_keyunlockModeControls) {
@@ -502,8 +502,8 @@ void DlgPrefControls::slotResetToDefaults() {
     m_keylockMode = 0;
     radioButtonOriginalKey->setChecked(true);
 
-    // Keep unlocked key
-    m_keyunlockMode = 0;
+    // Reset key on unlock
+    m_keyunlockMode = 1;
     radioButtonKeepUnlockedKey->setChecked(true);
 }
 
@@ -817,9 +817,6 @@ void DlgPrefControls::slotNumSamplersChanged(double new_count) {
         m_keylockModeControls.push_back(new ControlProxy(
                 group, "keylockMode"));
         m_keylockModeControls.last()->set(m_keylockMode);
-        // Do we need key un-lock mode for Samplers as well?
-        // Except GUI, they probably don't have proper (physical!) controls
-        // to change pitch.
         m_keyunlockModeControls.push_back(new ControlProxy(
                 group, "keyunlockMode"));
         m_keyunlockModeControls.last()->set(m_keyunlockMode);

--- a/src/preferences/dialog/dlgprefcontrols.h
+++ b/src/preferences/dialog/dlgprefcontrols.h
@@ -53,6 +53,7 @@ class DlgPrefControls : public DlgPreferencePage, public Ui::DlgPrefControlsDlg 
     void slotSetRateDir(bool invert);
     void slotSetRateDir(int pos);
     void slotKeyLockMode(QAbstractButton*);
+    void slotKeyUnlockMode(QAbstractButton*);
     void slotSetRateTempLeft(double);
     void slotSetRateTempRight(double);
     void slotSetRatePermLeft(double);
@@ -96,6 +97,7 @@ class DlgPrefControls : public DlgPreferencePage, public Ui::DlgPrefControlsDlg 
     QList<ControlProxy*> m_rateDirControls;
     QList<ControlProxy*> m_rateRangeControls;
     QList<ControlProxy*> m_keylockModeControls;
+    QList<ControlProxy*> m_keyunlockModeControls;
     MixxxMainWindow *m_mixxx;
     SkinLoader* m_pSkinLoader;
     PlayerManager* m_pPlayerManager;
@@ -106,6 +108,7 @@ class DlgPrefControls : public DlgPreferencePage, public Ui::DlgPrefControlsDlg 
     bool m_speedAutoReset;
     bool m_pitchAutoReset;
     int m_keylockMode;
+    int m_keyunlockMode;
 };
 
 #endif

--- a/src/preferences/dialog/dlgprefcontrolsdlg.ui
+++ b/src/preferences/dialog/dlgprefcontrolsdlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>562</width>
-    <height>598</height>
+    <height>632</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -421,9 +421,9 @@
          </widget>
         </item>
         <item row="3" column="1">
-         <widget class="QRadioButton" name="radioButtonCalculateNewKey">
+         <widget class="QRadioButton" name="radioButtonKeepUnlockedKey">
           <property name="text">
-           <string>Adapt key to current tempo</string>
+           <string>Keep key</string>
           </property>
           <attribute name="buttonGroup">
            <string notr="true">buttonGroupKeyUnlockMode</string>
@@ -431,9 +431,9 @@
          </widget>
         </item>
         <item row="3" column="2">
-         <widget class="QRadioButton" name="radioButtonKeepLockedKey">
+         <widget class="QRadioButton" name="radioButtonResetUnlockedKey">
           <property name="text">
-           <string>Keep previously locked key</string>
+           <string>Reset key</string>
           </property>
           <attribute name="buttonGroup">
            <string notr="true">buttonGroupKeyUnlockMode</string>
@@ -770,8 +770,8 @@ CUP mode:
   <tabstop>checkBoxResetSpeed</tabstop>
   <tabstop>radioButtonOriginalKey</tabstop>
   <tabstop>radioButtonCurrentKey</tabstop>
-  <tabstop>radioButtonCalculateNewKey</tabstop>
-  <tabstop>radioButtonKeepLockedKey</tabstop>
+  <tabstop>radioButtonKeepUnlockedKey</tabstop>
+  <tabstop>radioButtonResetUnlockedKey</tabstop>
   <tabstop>radioButtonSpeedBendRamping</tabstop>
   <tabstop>radioButtonSpeedBendStatic</tabstop>
   <tabstop>SliderRateRampSensitivity</tabstop>

--- a/src/preferences/dialog/dlgprefcontrolsdlg.ui
+++ b/src/preferences/dialog/dlgprefcontrolsdlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>485</width>
-    <height>571</height>
+    <width>562</width>
+    <height>598</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -421,9 +421,9 @@
          </widget>
         </item>
         <item row="3" column="1">
-         <widget class="QRadioButton" name="radioButtonKeepLockedKey">
+         <widget class="QRadioButton" name="radioButtonCalculateNewKey">
           <property name="text">
-           <string>Keep previously locked key</string>
+           <string>Adapt key to current tempo</string>
           </property>
           <attribute name="buttonGroup">
            <string notr="true">buttonGroupKeyUnlockMode</string>
@@ -431,9 +431,9 @@
          </widget>
         </item>
         <item row="3" column="2">
-         <widget class="QRadioButton" name="radioButtonCalculateNewKey">
+         <widget class="QRadioButton" name="radioButtonKeepLockedKey">
           <property name="text">
-           <string>Adapt key to current tempo</string>
+           <string>Keep previously locked key</string>
           </property>
           <attribute name="buttonGroup">
            <string notr="true">buttonGroupKeyUnlockMode</string>
@@ -770,8 +770,8 @@ CUP mode:
   <tabstop>checkBoxResetSpeed</tabstop>
   <tabstop>radioButtonOriginalKey</tabstop>
   <tabstop>radioButtonCurrentKey</tabstop>
-  <tabstop>radioButtonKeepLockedKey</tabstop>
   <tabstop>radioButtonCalculateNewKey</tabstop>
+  <tabstop>radioButtonKeepLockedKey</tabstop>
   <tabstop>radioButtonSpeedBendRamping</tabstop>
   <tabstop>radioButtonSpeedBendStatic</tabstop>
   <tabstop>SliderRateRampSensitivity</tabstop>

--- a/src/preferences/dialog/dlgprefcontrolsdlg.ui
+++ b/src/preferences/dialog/dlgprefcontrolsdlg.ui
@@ -421,9 +421,9 @@
          </widget>
         </item>
         <item row="3" column="1">
-         <widget class="QRadioButton" name="radioButtonKeepUnlockedKey">
+         <widget class="QRadioButton" name="radioButtonResetUnlockedKey">
           <property name="text">
-           <string>Keep key</string>
+           <string>Reset key</string>
           </property>
           <attribute name="buttonGroup">
            <string notr="true">buttonGroupKeyUnlockMode</string>
@@ -431,9 +431,9 @@
          </widget>
         </item>
         <item row="3" column="2">
-         <widget class="QRadioButton" name="radioButtonResetUnlockedKey">
+         <widget class="QRadioButton" name="radioButtonKeepUnlockedKey">
           <property name="text">
-           <string>Reset key</string>
+           <string>Keep key</string>
           </property>
           <attribute name="buttonGroup">
            <string notr="true">buttonGroupKeyUnlockMode</string>
@@ -770,8 +770,8 @@ CUP mode:
   <tabstop>checkBoxResetSpeed</tabstop>
   <tabstop>radioButtonOriginalKey</tabstop>
   <tabstop>radioButtonCurrentKey</tabstop>
-  <tabstop>radioButtonKeepUnlockedKey</tabstop>
   <tabstop>radioButtonResetUnlockedKey</tabstop>
+  <tabstop>radioButtonKeepUnlockedKey</tabstop>
   <tabstop>radioButtonSpeedBendRamping</tabstop>
   <tabstop>radioButtonSpeedBendStatic</tabstop>
   <tabstop>SliderRateRampSensitivity</tabstop>

--- a/src/preferences/dialog/dlgprefcontrolsdlg.ui
+++ b/src/preferences/dialog/dlgprefcontrolsdlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>485</width>
-    <height>554</height>
+    <height>571</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -22,7 +22,7 @@
      <layout class="QGridLayout" name="gridLayout_7">
       <item row="0" column="0">
        <layout class="QGridLayout" name="GridLayoutSpeedOptions">
-        <item row="6" column="1">
+        <item row="7" column="1">
          <widget class="QDoubleSpinBox" name="spinBoxPermRateLeft">
           <property name="toolTip">
            <string>Permanent rate change when left-clicking</string>
@@ -50,7 +50,7 @@
           </property>
          </widget>
         </item>
-        <item row="7" column="1">
+        <item row="8" column="1">
          <widget class="QDoubleSpinBox" name="spinBoxPermRateRight">
           <property name="toolTip">
            <string>Permanent rate change when right-clicking</string>
@@ -98,7 +98,7 @@
           </attribute>
          </widget>
         </item>
-        <item row="7" column="2">
+        <item row="8" column="2">
          <widget class="QDoubleSpinBox" name="spinBoxTempRateRight">
           <property name="enabled">
            <bool>false</bool>
@@ -129,7 +129,7 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
+        <item row="6" column="1">
          <widget class="QLabel" name="labelSpeedPermanent">
           <property name="text">
            <string>Permanent</string>
@@ -139,7 +139,7 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="1" colspan="2">
+        <item row="5" column="1" colspan="2">
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <widget class="QSlider" name="SliderRateRampSensitivity">
@@ -187,7 +187,7 @@
           </item>
          </layout>
         </item>
-        <item row="5" column="2">
+        <item row="6" column="2">
          <widget class="QLabel" name="labelSpeedTemporary">
           <property name="enabled">
            <bool>false</bool>
@@ -210,7 +210,7 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
+        <item row="5" column="0">
          <widget class="QLabel" name="labelSpeedRampSensitivity">
           <property name="enabled">
            <bool>false</bool>
@@ -223,7 +223,7 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="4" column="0">
          <widget class="QLabel" name="labelSpeedBendBehavior">
           <property name="text">
            <string>Pitch bend behavior</string>
@@ -243,7 +243,7 @@
           </attribute>
          </widget>
         </item>
-        <item row="6" column="2">
+        <item row="7" column="2">
          <widget class="QDoubleSpinBox" name="spinBoxTempRateLeft">
           <property name="enabled">
            <bool>false</bool>
@@ -294,14 +294,14 @@
           </attribute>
          </widget>
         </item>
-        <item row="5" column="0">
+        <item row="6" column="0">
          <widget class="QLabel" name="labelSpeedAdjustment">
           <property name="text">
            <string>Adjustment buttons:</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="0">
+        <item row="7" column="0">
          <widget class="QLabel" name="labelSpeedCoarse">
           <property name="enabled">
            <bool>true</bool>
@@ -326,7 +326,7 @@
           </property>
          </widget>
         </item>
-        <item row="7" column="0">
+        <item row="8" column="0">
          <widget class="QLabel" name="labelSpeedFine">
           <property name="enabled">
            <bool>true</bool>
@@ -362,7 +362,7 @@
          </widget>
         </item>
         <item row="0" column="0">
-         <widget class="QLabel" name="lableSpeedSliderrange">
+         <widget class="QLabel" name="labelSpeedSliderrange">
           <property name="enabled">
            <bool>true</bool>
           </property>
@@ -390,7 +390,7 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="2">
+        <item row="4" column="2">
          <widget class="QRadioButton" name="radioButtonSpeedBendStatic">
           <property name="text">
            <string>Abrupt jump</string>
@@ -400,7 +400,7 @@
           </attribute>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="4" column="1">
          <widget class="QRadioButton" name="radioButtonSpeedBendRamping">
           <property name="toolTip">
            <string>Smoothly adjusts deck speed when temporary change buttons are held down</string>
@@ -410,6 +410,33 @@
           </property>
           <attribute name="buttonGroup">
            <string notr="true">buttonGroupSpeedBendBehavior</string>
+          </attribute>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="labelKeyunlockMode">
+          <property name="text">
+           <string>Keyunlock mode</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QRadioButton" name="radioButtonKeepLockedKey">
+          <property name="text">
+           <string>Keep previously locked key</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupKeyUnlockMode</string>
+          </attribute>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="QRadioButton" name="radioButtonCalculateNewKey">
+          <property name="text">
+           <string>Adapt key to current tempo</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupKeyUnlockMode</string>
           </attribute>
          </widget>
         </item>
@@ -743,6 +770,8 @@ CUP mode:
   <tabstop>checkBoxResetSpeed</tabstop>
   <tabstop>radioButtonOriginalKey</tabstop>
   <tabstop>radioButtonCurrentKey</tabstop>
+  <tabstop>radioButtonKeepLockedKey</tabstop>
+  <tabstop>radioButtonCalculateNewKey</tabstop>
   <tabstop>radioButtonSpeedBendRamping</tabstop>
   <tabstop>radioButtonSpeedBendStatic</tabstop>
   <tabstop>SliderRateRampSensitivity</tabstop>
@@ -885,6 +914,7 @@ CUP mode:
  </connections>
  <buttongroups>
   <buttongroup name="buttonGroupKeyLockMode"/>
+  <buttongroup name="buttonGroupKeyUnlockMode"/>
   <buttongroup name="buttonGroupTooltips"/>
   <buttongroup name="buttonGroupSpeedPitchReset">
    <property name="exclusive">


### PR DESCRIPTION
In #8745 I described the -at least for me- unexpected behaviour when releasing keylock
while rate is not 0 (pitch slider is off center), and got to know the reasons for the
**current situation**:
1 a track is running, keylock is ON, pitch/tempo != original
2 release keylock
3 key is reset to original > That 'jumping' key on right now is odd!

**How I would love it**:
2 release keylock
3 key is kept but now unlocked
4 any further rate change changes key accordingly

Reason is, with unlocked key it's much fun gently nudging the jogwheels to temporarily
vary the key to simulate an old turntable, or a worn out cassette. 


I added another row in Preferences > Interface called "Keyunlock mode" where users can choose
wether to adapt key to current tempo (default, current behaviour) or to keep previously locked key
until next rate change. This way, the unlock behaviour wouldn't change, unless users choose so.

I will test if this works out with my changes so far.
The wording is just a quick shot.

What do you think?