### PR TITLE
Hint rounding

### DIFF
--- a/src/engine/cachingreader.h
+++ b/src/engine/cachingreader.h
@@ -22,17 +22,22 @@
 // SoundSource will be used 'soon' and so it should be brought into memory by
 // the reader work thread.
 typedef struct Hint {
-    // The sample to ensure is present in memory.
-    int sample;
-    // If a range of samples should be present, use length to indicate that the
-    // range (sample, sample+length) should be present in memory.
-    int length;
+    // The frame to ensure is present in memory.
+    SINT frame;
+    // If a range of frames should be present, use frameCount to indicate that the
+    // range (frame, frame + frameCount) should be present in memory.
+    SINT frameCount;
     // Currently unused -- but in the future could be used to prioritize certain
     // hints over others. A priority of 1 is the highest priority and should be
     // used for samples that will be read imminently. Hints for samples that
     // have the potential to be read (i.e. a cue point) should be issued with
     // priority >10.
     int priority;
+
+    // for the default frame count in forward direction
+    static constexpr SINT kFrameCountForward = 0;
+    static constexpr SINT kFrameCountBackward = -1;
+
 } Hint;
 
 // Note that we use a QVarLengthArray here instead of a QVector. Since this list

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -550,8 +550,8 @@ void CueControl::hintReader(HintVector* pHintList) {
     Hint cue_hint;
     double cuePoint = m_pCuePoint->get();
     if (cuePoint >= 0) {
-        cue_hint.sample = SampleUtil::floorPlayPosToFrameStart(m_pCuePoint->get(), 2);
-        cue_hint.length = 0;
+        cue_hint.frame = SampleUtil::floorPlayPosToFrame(m_pCuePoint->get());
+        cue_hint.frameCount = Hint::kFrameCountForward;
         cue_hint.priority = 10;
         pHintList->append(cue_hint);
     }
@@ -562,8 +562,8 @@ void CueControl::hintReader(HintVector* pHintList) {
     for (const auto& pControl: m_hotcueControls) {
         double position = pControl->getPosition();
         if (position != -1) {
-            cue_hint.sample = SampleUtil::floorPlayPosToFrameStart(position, 2);
-            cue_hint.length = 0;
+            cue_hint.frame = SampleUtil::floorPlayPosToFrame(position);
+            cue_hint.frameCount = Hint::kFrameCountForward;
             cue_hint.priority = 10;
             pHintList->append(cue_hint);
         }

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -11,6 +11,7 @@
 #include "control/controlpushbutton.h"
 #include "control/controlindicator.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
+#include "util/sample.h"
 
 // TODO: Convert these doubles to a standard enum
 // and convert elseif logic to switch statements
@@ -549,7 +550,7 @@ void CueControl::hintReader(HintVector* pHintList) {
     Hint cue_hint;
     double cuePoint = m_pCuePoint->get();
     if (cuePoint >= 0) {
-        cue_hint.sample = m_pCuePoint->get();
+        cue_hint.sample = SampleUtil::floorPlayPosToFrameStart(m_pCuePoint->get(), 2);
         cue_hint.length = 0;
         cue_hint.priority = 10;
         pHintList->append(cue_hint);
@@ -561,9 +562,7 @@ void CueControl::hintReader(HintVector* pHintList) {
     for (const auto& pControl: m_hotcueControls) {
         double position = pControl->getPosition();
         if (position != -1) {
-            cue_hint.sample = position;
-            if (cue_hint.sample % 2 != 0)
-                cue_hint.sample--;
+            cue_hint.sample = SampleUtil::floorPlayPosToFrameStart(position, 2);
             cue_hint.length = 0;
             cue_hint.priority = 10;
             pHintList->append(cue_hint);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1244,9 +1244,13 @@ void EngineBuffer::hintReader(const double dRate) {
     //if slipping, hint about virtual position so we're ready for it
     if (m_bSlipEnabledProcessing) {
         Hint hint;
-        hint.length = 2048; //default length please
-        hint.sample = m_dSlipRate >= 0 ? m_dSlipPosition : m_dSlipPosition - 2048;
+        hint.frame = SampleUtil::floorPlayPosToFrame(m_dSlipPosition);
         hint.priority = 1;
+        if (m_dSlipRate >= 0) {
+            hint.frameCount = Hint::kFrameCountForward;
+        } else {
+            hint.frameCount = Hint::kFrameCountBackward;
+        }
         m_hintList.append(hint);
     }
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1250,9 +1250,7 @@ void EngineBuffer::hintReader(const double dRate) {
         m_hintList.append(hint);
     }
 
-    QListIterator<EngineControl*> it(m_engineControls);
-    while (it.hasNext()) {
-        EngineControl* pControl = it.next();
+    for (const auto& pControl: m_engineControls) {
         pControl->hintReader(&m_hintList);
     }
     m_pReader->hintAndMaybeWake(m_hintList);

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -390,21 +390,21 @@ void LoopingControl::hintReader(HintVector* pHintList) {
         // aren't that bad to make anyway.
         if (loopSamples.start >= 0) {
             loop_hint.priority = 2;
-            loop_hint.sample = SampleUtil::floorPlayPosToFrameStart(loopSamples.start, 2);
-            loop_hint.length = 0; // Let it issue the default length
+            loop_hint.frame = SampleUtil::floorPlayPosToFrame(loopSamples.start);
+            loop_hint.frameCount = Hint::kFrameCountForward;
             pHintList->append(loop_hint);
         }
         if (loopSamples.end >= 0) {
             loop_hint.priority = 10;
-            loop_hint.sample = SampleUtil::ceilPlayPosToFrameStart(loopSamples.end, 2);
-            loop_hint.length = -1; // Let it issue the default (backwards) length
+            loop_hint.frame = SampleUtil::ceilPlayPosToFrame(loopSamples.end);
+            loop_hint.frameCount = Hint::kFrameCountBackward;
             pHintList->append(loop_hint);
         }
     } else {
         if (loopSamples.start >= 0) {
             loop_hint.priority = 10;
-            loop_hint.sample = SampleUtil::floorPlayPosToFrameStart(loopSamples.start, 2);
-            loop_hint.length = 0; // Let it issue the default length
+            loop_hint.frame = SampleUtil::floorPlayPosToFrame(loopSamples.start);
+            loop_hint.frameCount = Hint::kFrameCountForward;
             pHintList->append(loop_hint);
         }
     }

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -11,6 +11,7 @@
 #include "engine/bpmcontrol.h"
 #include "engine/enginecontrol.h"
 #include "util/math.h"
+#include "util/sample.h"
 
 #include "track/track.h"
 #include "track/beats.h"
@@ -389,20 +390,20 @@ void LoopingControl::hintReader(HintVector* pHintList) {
         // aren't that bad to make anyway.
         if (loopSamples.start >= 0) {
             loop_hint.priority = 2;
-            loop_hint.sample = loopSamples.start;
+            loop_hint.sample = SampleUtil::floorPlayPosToFrameStart(loopSamples.start, 2);
             loop_hint.length = 0; // Let it issue the default length
             pHintList->append(loop_hint);
         }
         if (loopSamples.end >= 0) {
             loop_hint.priority = 10;
-            loop_hint.sample = loopSamples.end;
+            loop_hint.sample = SampleUtil::ceilPlayPosToFrameStart(loopSamples.end, 2);
             loop_hint.length = -1; // Let it issue the default (backwards) length
             pHintList->append(loop_hint);
         }
     } else {
         if (loopSamples.start >= 0) {
             loop_hint.priority = 10;
-            loop_hint.sample = loopSamples.start;
+            loop_hint.sample = SampleUtil::floorPlayPosToFrameStart(loopSamples.start, 2);
             loop_hint.length = 0; // Let it issue the default length
             pHintList->append(loop_hint);
         }

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -176,14 +176,17 @@ void ReadAheadManager::hintReader(double dRate, HintVector* pHintList) {
     // SoundTouch can read up to 2 chunks ahead. Always keep 2 chunks ahead in
     // cache.
     SINT frameCountToCache = 2 * CachingReaderChunk::kFrames;
+    current_position.frameCount = frameCountToCache;
 
     // this called after the precious chunk was consumed
-    SINT frame = SampleUtil::roundPlayPosToFrameStart(
-            m_currentPosition, kNumChannels) / kNumChannels;
-    current_position.frameCount = frameCountToCache;
-    current_position.frame = in_reverse ?
-            frame - frameCountToCache:
-            frame;
+    if (in_reverse) {
+        current_position.frame =
+                static_cast<SINT>(ceil(m_currentPosition / kNumChannels)) -
+                frameCountToCache;
+    } else {
+        current_position.frame =
+                static_cast<SINT>(floor(m_currentPosition / kNumChannels));
+    }
 
     // If we are trying to cache before the start of the track,
     // Then we don't need to cache because it's all zeros!

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -175,21 +175,23 @@ void ReadAheadManager::hintReader(double dRate, HintVector* pHintList) {
 
     // SoundTouch can read up to 2 chunks ahead. Always keep 2 chunks ahead in
     // cache.
-    SINT length_to_cache = 2 * CachingReaderChunk::kSamples;
+    SINT frameCountToCache = 2 * CachingReaderChunk::kFrames;
 
     // this called after the precious chunk was consumed
-    int sample = SampleUtil::roundPlayPosToFrameStart(
-            m_currentPosition, kNumChannels);
-    current_position.length = length_to_cache;
-    current_position.sample = in_reverse ?
-            sample - length_to_cache :
-            sample;
+    SINT frame = SampleUtil::roundPlayPosToFrameStart(
+            m_currentPosition, kNumChannels) / kNumChannels;
+    current_position.frameCount = frameCountToCache;
+    current_position.frame = in_reverse ?
+            frame - frameCountToCache:
+            frame;
 
     // If we are trying to cache before the start of the track,
     // Then we don't need to cache because it's all zeros!
-    if (current_position.sample < 0 &&
-        current_position.sample + current_position.length < 0)
-        return;
+    if (current_position.frame < 0 &&
+            current_position.frame + current_position.frameCount < 0)
+    {
+    	return;
+    }
 
     // top priority, we need to read this data immediately
     current_position.priority = 1;

--- a/src/util/sample.h
+++ b/src/util/sample.h
@@ -21,6 +21,11 @@ class SampleUtil {
     };
     Q_DECLARE_FLAGS(CLIP_STATUS, CLIP_FLAG);
 
+    // The PlayPosition, Loops and Cue Points used in the Database and
+    // Mixxx CO interface are expressed as a floating point number of stereo samples.
+    // This is some legacy, we cannot easily revert.
+    static constexpr double kPlayPositionChannels = 2.0;
+
     // Allocated a buffer of CSAMPLE's with length size. Ensures that the buffer
     // is 16-byte aligned for SSE enhancement.
     static CSAMPLE* alloc(SINT size);
@@ -106,6 +111,23 @@ class SampleUtil {
     inline static SINT ceilPlayPosToFrameStart(double playPos, int numChannels) {
         SINT playPosFrames = static_cast<SINT>(ceil(playPos / numChannels));
         return playPosFrames * numChannels;
+    }
+
+    inline static SINT roundPlayPosToFrame(double playPos) {
+        return static_cast<SINT>(round(playPos / kPlayPositionChannels));
+    }
+
+    inline static SINT truncPlayPosToFrame(double playPos) {
+        return static_cast<SINT>(playPos / kPlayPositionChannels);
+    }
+
+    inline static SINT floorPlayPosToFrame(double playPos) {
+        return static_cast<SINT>(floor(playPos / kPlayPositionChannels));
+
+    }
+
+    inline static SINT ceilPlayPosToFrame(double playPos) {
+        return static_cast<SINT>(ceil(playPos / kPlayPositionChannels));
     }
 
     // Multiply every sample in pBuffer by gain


### PR DESCRIPTION
This fixes:
https://bugs.launchpad.net/mixxx/+bug/1666050

And includes some more refactoring towards a n channel engine.

Since we have a fixed stereo interface in the ControlObjects and Database, I have introduces a 
kPlayPositionChannels, that should be used to convert these stereo play positions to frames. 

The hint interface is still a bit messy, because some hints are passed with a fixed length and some with an automatic calculated length. Normally it should not matter if it is a loop or a cue point that should be keep in cache. it is always just a jump to a new frame, so I think we do not need to distinguish the length or direction. 

@uklotzde: What do you think. 
  