### PR TITLE
don't make EffectUnit show_focus CO persist

### DIFF
--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -70,8 +70,7 @@ EffectChainSlot::EffectChainSlot(EffectRack* pRack, const QString& group,
     // ControlObjects for skin <-> controller mapping interaction.
     // Refer to comment in header for full explanation.
     m_pControlChainShowFocus = new ControlPushButton(
-                                   ConfigKey(m_group, "show_focus"),
-                                   true);
+                                   ConfigKey(m_group, "show_focus"));
     m_pControlChainShowFocus->setButtonMode(ControlPushButton::TOGGLE);
 
     m_pControlChainShowParameters = new ControlPushButton(


### PR DESCRIPTION
If a controller mapping sets show_focus to 1 and Mixxx is restarted without the controller plugged in, focus should not be shown.