### PR TITLE
Fix engine.softStart, add tests for engine.brake and ~.softStart

### DIFF
--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -302,10 +302,14 @@ script.midiPitch = function (LSB, MSB, status) {
    Purpose: wrapper around engine.spinback() that can be directly mapped
             from xml for a spinback effect
             e.g: <key>script.spinback</key>
-   Input:   channel, control, value, status, group
+   Input:   channel, control, value, status, group, factor (optional), start rate (optional)
    Output:  none
    -------- ------------------------------------------------------ */
-script.spinback = function(channel, control, value, status, group) {
+script.spinback = function(channel, control, value, status, group, factor, rate) {
+    // set default factor
+    if (factor === undefined) {
+        factor = 1;
+    }
     // disable on note-off or zero value note/cc
     engine.spinback(parseInt(group.substring(8,9)), ((status & 0xF0) !== 0x80 && value > 0));
 }

--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -329,9 +329,10 @@ script.brake = function(channel, control, value, status, group, factor) {
 
 /* -------- ------------------------------------------------------
      script.softStart
-   Purpose: wrapper around engine.brake() that can be directly mapped
-            from xml for a brake effect
-            e.g: <key>script.brake</key>
+   Purpose: wrapper around engine.softStart() that can be directly mapped
+            from xml to start and accelerate a deck from zero to full rate
+            defined by pitch slider, can also interrupt engine.brake()
+            e.g: <key>script.softStart</key>
    Input:   channel, control, value, status, group, acceleration factor (optional)
    Output:  none
    -------- ------------------------------------------------------ */

--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -306,12 +306,19 @@ script.midiPitch = function (LSB, MSB, status) {
    Output:  none
    -------- ------------------------------------------------------ */
 script.spinback = function(channel, control, value, status, group, factor, rate) {
-    // set default factor
-    if (factor === undefined) {
+    // if brake is called from xml mapping without defined factor and rate,
+    // reset to defaults
+    if (factor === undefined && rate === undefined) {
         factor = 1;
+        rate = -10;
+    }
+    // if brake is called from xml mapping without defined rate,
+    // reset to default
+    if (rate === undefined) {
+        rate = -10;
     }
     // disable on note-off or zero value note/cc
-    engine.spinback(parseInt(group.substring(8,9)), ((status & 0xF0) !== 0x80 && value > 0));
+    engine.spinback(parseInt(group.substring(8,9)), ((status & 0xF0) !== 0x80 && value > 0), factor, rate);
 }
 
 /* -------- ------------------------------------------------------
@@ -323,7 +330,8 @@ script.spinback = function(channel, control, value, status, group, factor, rate)
    Output:  none
    -------- ------------------------------------------------------ */
 script.brake = function(channel, control, value, status, group, factor) {
-    // set default factor
+    // if brake is called from xml mapping without factor defined,
+    // reset to default
     if (factor === undefined) {
         factor = 1;
     }

--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -306,14 +306,12 @@ script.midiPitch = function (LSB, MSB, status) {
    Output:  none
    -------- ------------------------------------------------------ */
 script.spinback = function(channel, control, value, status, group, factor, rate) {
-    // if brake is called from xml mapping without defined factor and rate,
-    // reset to defaults
+    // if brake is called without defined factor and rate, reset to defaults
     if (factor === undefined && rate === undefined) {
         factor = 1;
         rate = -10;
     }
-    // if brake is called from xml mapping without defined rate,
-    // reset to default
+    // if brake is called without defined rate, reset to default
     if (rate === undefined) {
         rate = -10;
     }
@@ -330,8 +328,7 @@ script.spinback = function(channel, control, value, status, group, factor, rate)
    Output:  none
    -------- ------------------------------------------------------ */
 script.brake = function(channel, control, value, status, group, factor) {
-    // if brake is called from xml mapping without factor defined,
-    // reset to default
+    // if brake is called without factor defined, reset to default
     if (factor === undefined) {
         factor = 1;
     }
@@ -349,6 +346,7 @@ script.brake = function(channel, control, value, status, group, factor) {
    Output:  none
    -------- ------------------------------------------------------ */
 script.softStart = function(channel, control, value, status, group, factor) {
+    // if softStart is called without factor defined, reset to default
     if (factor === undefined) {
         factor = 1;
     }

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -1234,7 +1234,7 @@ void ControllerEngine::scratchProcess(int timerId) {
         // Once this code path is run, latch so it always runs until reset
         //m_lastMovement[deck] += mixxx::Duration::fromSeconds(1);
     } else if (m_softStartActive[deck]) {
-        // pretend we have moved by (finalRate*default distance)
+        // pretend we have moved by (desired rate*default distance)
         filter->observation(m_rampTo[deck]*kAlphaBetaDt);
     } else {
         // This will (and should) be 0 if no net ticks have been accumulated
@@ -1449,11 +1449,10 @@ void ControllerEngine::brake(int deck, bool activate, double factor, double rate
 
 /*  -------- ------------------------------------------------------
     Purpose: [En/dis]ables softStart effect for the channel
-    Input:   deck, activate/deactivate, factor (optional),
-             rate (optiona)
+    Input:   deck, activate/deactivate, factor (optional)
     Output:  -
     -------- ------------------------------------------------------ */
-void ControllerEngine::softStart(int deck, bool activate, double factor, double finalRate) {
+void ControllerEngine::softStart(int deck, bool activate, double factor) {
     // PlayerManager::groupForDeck is 0-indexed.
     QString group = PlayerManager::groupForDeck(deck - 1);
 
@@ -1473,12 +1472,8 @@ void ControllerEngine::softStart(int deck, bool activate, double factor, double 
     double initRate = 0.0;
 
     if (activate) {
-        // store the new values for this spinback/brake effect
-        if (finalRate == 1.0) {// then rate is really 1.0 or was set to default
-            // so check for real value taking pitch into account
-            finalRate = getDeckRate(group);
-        }
-        m_rampTo[deck] = finalRate;
+        // aquire deck rate
+        m_rampTo[deck] = getDeckRate(group);
 
         // if brake()ing, get current rate from filter
         if (m_brakeActive[deck]) {

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -1256,11 +1256,12 @@ void ControllerEngine::scratchProcess(int timerId) {
 
     // End scratching if we're ramping and the current rate is really close to the rampTo value
     if ((m_ramp[deck] && fabs(m_rampTo[deck] - newRate) <= 0.00001) ||
-        // or if we're in brake or softStart mode and have crossed over the desired value,
+        // or if we brake or softStart and have crossed over the desired value,
         ((m_brakeActive[deck] || m_softStartActive[deck]) && (
             (oldRate > m_rampTo[deck] && newRate < m_rampTo[deck]) ||
-            // TODO ronso0: brake and softStart should be interrupted when stopping the deck
-            (oldRate < m_rampTo[deck] && newRate > m_rampTo[deck])))) {
+            (oldRate < m_rampTo[deck] && newRate > m_rampTo[deck]))) ||
+        // or if the deck was stopped manually during brake or softStart
+        ((m_brakeActive[deck] || m_softStartActive[deck]) && (!isDeckPlaying(group)))) {
         // Not ramping no mo'
         m_ramp[deck] = false;
 

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -118,7 +118,7 @@ class ControllerEngine : public QObject {
     Q_INVOKABLE void softTakeoverIgnoreNextValue(QString group, QString name);
     Q_INVOKABLE void brake(int deck, bool activate, double factor=1.0, double rate=1.0);
     Q_INVOKABLE void spinback(int deck, bool activate, double factor=1.8, double rate=-10.0);
-    Q_INVOKABLE void softStart(int deck, bool activate, double factor=1.0, double finalRate=1.0);
+    Q_INVOKABLE void softStart(int deck, bool activate, double factor=1.0);
 
     // Handler for timers that scripts set.
     virtual void timerEvent(QTimerEvent *event);

--- a/src/test/controllerengine_test.cpp
+++ b/src/test/controllerengine_test.cpp
@@ -360,3 +360,17 @@ TEST_F(ControllerEngineTest, connectControl_TriggerByConnectionObject) {
     // The counter should have been incremented exactly once.
     EXPECT_DOUBLE_EQ(1.0, counter->get());
 }
+
+TEST_F(ControllerEngineTest, softStart) {
+	// Test that brake() toggles [group],scratch2_enable and sets
+	// [group],scratch2 to 'rate' passed as argument (initRate) and sets
+	// [group],scratch2 to actual rate if no parameter is passed respectively
+	// test if [group],play is set to 0 'after a while'?
+	// test if it sets m_softStartActive to 0?
+}
+TEST_F(ControllerEngineTest, brake) {
+	// Test that brake() toggles [group],scratch2_enable and sets
+	// [group]scratch2 to 'rate' passed as argument (initRate)
+	// test if [group],play is set to 0 'after a while'?
+	// test if it sets m_softStartActive to 0?
+}

--- a/src/test/controllerengine_test.cpp
+++ b/src/test/controllerengine_test.cpp
@@ -362,15 +362,16 @@ TEST_F(ControllerEngineTest, connectControl_TriggerByConnectionObject) {
 }
 
 TEST_F(ControllerEngineTest, softStart) {
-	// Test that brake() toggles [group],scratch2_enable and sets
-	// [group],scratch2 to 'rate' passed as argument (initRate) and sets
-	// [group],scratch2 to actual rate if no parameter is passed respectively
-	// test if [group],play is set to 0 'after a while'?
-	// test if it sets m_softStartActive to 0?
+	// Test that brake()
+	// - toggles [group],scratch2_enable
+	// - sets [group],scratch2 to deck rate
+	// - sets [group],play to 0 'after a while' (?)
+	// - sets m_softStartActive to 0 (?)
 }
 TEST_F(ControllerEngineTest, brake) {
-	// Test that brake() toggles [group],scratch2_enable and sets
-	// [group]scratch2 to 'rate' passed as argument (initRate)
-	// test if [group],play is set to 0 'after a while'?
-	// test if it sets m_softStartActive to 0?
+	// Test that brake()
+	// - toggles [group],scratch2_enable
+	// - sets [group]scratch2 to rate passed as argument (initRate)
+	// - sets [group],play to 0 'after a while' (?)
+	// - sets m_softStartActive to 0 (?)
 }

--- a/src/test/controllerengine_test.cpp
+++ b/src/test/controllerengine_test.cpp
@@ -360,18 +360,3 @@ TEST_F(ControllerEngineTest, connectControl_TriggerByConnectionObject) {
     // The counter should have been incremented exactly once.
     EXPECT_DOUBLE_EQ(1.0, counter->get());
 }
-
-//TEST_F(ControllerEngineTest, softStart) {
-	// Test that brake()
-	// - toggles [group],scratch2_enable
-	// - sets [group],scratch2 to deck rate
-	// - sets [group],play to 0 'after a while' (?)
-	// - sets m_softStartActive to 0 (?)
-//}
-//TEST_F(ControllerEngineTest, brake) {
-	// Test that brake()
-	// - toggles [group],scratch2_enable
-	// - sets [group]scratch2 to rate passed as argument (initRate)
-	// - sets [group],play to 0 'after a while' (?)
-	// - sets m_softStartActive to 0 (?)
-//}

--- a/src/test/controllerengine_test.cpp
+++ b/src/test/controllerengine_test.cpp
@@ -361,17 +361,17 @@ TEST_F(ControllerEngineTest, connectControl_TriggerByConnectionObject) {
     EXPECT_DOUBLE_EQ(1.0, counter->get());
 }
 
-TEST_F(ControllerEngineTest, softStart) {
+//TEST_F(ControllerEngineTest, softStart) {
 	// Test that brake()
 	// - toggles [group],scratch2_enable
 	// - sets [group],scratch2 to deck rate
 	// - sets [group],play to 0 'after a while' (?)
 	// - sets m_softStartActive to 0 (?)
-}
-TEST_F(ControllerEngineTest, brake) {
+//}
+//TEST_F(ControllerEngineTest, brake) {
 	// Test that brake()
 	// - toggles [group],scratch2_enable
 	// - sets [group]scratch2 to rate passed as argument (initRate)
 	// - sets [group],play to 0 'after a while' (?)
 	// - sets m_softStartActive to 0 (?)
-}
+//}


### PR DESCRIPTION
I noticed the argument 'finalRate' passed to engine.softStart() doesn't do what it was intended for:
In case 'finalRate' is not equal to actual deck rate, softStart() just accelerates up to 'finalRate', then jumps to deck rate. I think it's not intuitive to automatically set deck's rate to finalRate (and override tempo slider by that), also I suppose I would to have change a lot in scratchProcess. Therefore I removed 'finalRate'.

[WIP 1]
When brake() is called with factors like 0.5 and below, at a certain point sound is not audible anymore due to the very low frequencies produced by scratchProcess, but deck keeps 'playing' for quite a while before it stops. I'll experiment at which rate playback can be stopped safely.

[WIP 2]
And I'm about to learn how to write tests and want to add some for engine.brake() and engine.softStart(). That's where I need some help:

**brake()** gets arguments `deck`, `activate`, deceleration `factor`, initial `rate`. From this values it sets up a filter, initiates scratchprocess() and sets `play` to 0 when rate 0 is reached/crossed.
I think I can check filter and scratchprocess with valid and invalid input, but how to (wait and then) check if `play` was disabled and brakeActive is set to false?

**softStart()** gets arguments `deck`, `activate`, acceleration `factor`. From this values it also sets up a filter, enables play and initiates scratchprocess().
Same as with brake(): how to wait and check if softStartActive is false?