### PR TITLE
Components: add optional relative mode for Pot and support 14 bit MIDI

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -327,7 +327,7 @@
                     // physical potentiometer for calculating how much it moves
                     // when shift is released.
                     if (this.MSB !== undefined) {
-                        value = this.MSB << 7 + value;
+                        value = (this.MSB << 7) + value;
                     }
                     this.previousValueReceived = value;
                 }
@@ -336,7 +336,7 @@
         unshift: function () {
             this.input = function (channel, control, value, status, group) {
                 if (this.MSB !== undefined) {
-                    value = this.MSB << 7 + value;
+                    value = (this.MSB << 7) + value;
                 }
                 if (this.relative) {
                     if (this.previousValueReceived !== undefined) {

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -323,6 +323,9 @@
         shift: function () {
             if (this.relative) {
                 this.input = function (channel, control, value, status, group) {
+                    // Do not manipulate inKey, just store the position of the
+                    // physical potentiometer for calculating how much it moves
+                    // when shift is released.
                     if (this.MSB !== undefined) {
                         value = this.MSB << 7 + value;
                     }

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -341,15 +341,26 @@
                 if (this.relative) {
                     if (this.previousValueReceived !== undefined) {
                         var delta = (value - this.previousValueReceived) / this.max;
+                        if (this.invert) {
+                            delta = -delta;
+                        }
                         this.inSetParameter(this.inGetParameter() + delta);
                     } else {
+                        var newValue = value / this.max;
+                        if (this.invert) {
+                            newValue = 1 - newValue;
+                        }
                         if (this.loadStateOnStartup) {
-                            this.inSetParameter(value / this.max);
+                            this.inSetParameter(newValue);
                         }
                     }
                     this.previousValueReceived = value;
                 } else {
-                    this.inSetParameter(this.inValueScale(value));
+                    var newValue = this.inValueScale(value);
+                    if (this.invert) {
+                        newValue = 1 - newValue;
+                    }
+                    this.inSetParameter(newValue);
                     if (!this.firstValueReceived) {
                         this.firstValueReceived = true;
                         this.connect();


### PR DESCRIPTION
This could be an interesting alternative to dealing with soft takeover. Set the `relative` property of a Pot to `true` to enable. Set `loadStateOnStartup` property to true if the mapping queries the controller for the state of Pots on startup (that is only necessary if `relative` is true). In relative mode, moving the Pot with shift does not move the software value in Mixxx.