### PR TITLE
Pitch/Tempo slider: set default range for clean profile

### DIFF
--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -105,7 +105,9 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
         // Fall back to old [Controls]RateRange
         if (!m_pConfig->exists(ConfigKey("[Controls]","RateRange")) ||
             m_pConfig->getValueString(ConfigKey("[Controls]", "RateRange")).length() == 0) {
-            m_pConfig->set(ConfigKey("[Controls]", "RateRangePercent"), ConfigValue(8));
+            int rateRangePercent = 8;
+            m_pConfig->set(ConfigKey("[Controls]", "RateRangePercent"), ConfigValue(rateRangePercent));
+            slotSetRateRangePercent(rateRangePercent);
         } else {
             int oldIdx = m_pConfig->getValueString(ConfigKey("[Controls]", "RateRange")).toInt();
             double oldRange = static_cast<double>(oldIdx-1) / 10.0;

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -103,7 +103,8 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     if (!m_pConfig->exists(ConfigKey("[Controls]","RateRangePercent")) ||
         m_pConfig->getValueString(ConfigKey("[Controls]", "RateRangePercent")).length() == 0) {
         // Fall back to old [Controls]RateRange
-        if (m_pConfig->getValueString(ConfigKey("[Controls]", "RateRange")).length() == 0) {
+        if (!m_pConfig->exists(ConfigKey("[Controls]","RateRange")) ||
+            m_pConfig->getValueString(ConfigKey("[Controls]", "RateRange")).length() == 0) {
             m_pConfig->set(ConfigKey("[Controls]", "RateRangePercent"), ConfigValue(8));
         } else {
             int oldIdx = m_pConfig->getValueString(ConfigKey("[Controls]", "RateRange")).toInt();

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -99,13 +99,9 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     connect(ComboBoxRateRange, SIGNAL(activated(int)),
             this, SLOT(slotSetRateRange(int)));
 
-    // If not present in the config, set the default value
-    if (!m_pConfig->exists(ConfigKey("[Controls]","RateRangePercent")) &&
-        !m_pConfig->exists(ConfigKey("[Controls]","RateRange")))
-        m_pConfig->set(ConfigKey("[Controls]","RateRangePercent"),ConfigValue(8));
-
     // Set default range as stored in config file
-    if (m_pConfig->getValueString(ConfigKey("[Controls]", "RateRangePercent")).length() == 0) {
+    if (!m_pConfig->exists(ConfigKey("[Controls]","RateRangePercent")) ||
+        m_pConfig->getValueString(ConfigKey("[Controls]", "RateRangePercent")).length() == 0) {
         // Fall back to old [Controls]RateRange
         if (m_pConfig->getValueString(ConfigKey("[Controls]", "RateRange")).length() == 0) {
             m_pConfig->set(ConfigKey("[Controls]", "RateRangePercent"), ConfigValue(8));

--- a/src/preferences/dialog/dlgprefcontrols.cpp
+++ b/src/preferences/dialog/dlgprefcontrols.cpp
@@ -99,6 +99,11 @@ DlgPrefControls::DlgPrefControls(QWidget * parent, MixxxMainWindow * mixxx,
     connect(ComboBoxRateRange, SIGNAL(activated(int)),
             this, SLOT(slotSetRateRange(int)));
 
+    // If not present in the config, set the default value
+    if (!m_pConfig->exists(ConfigKey("[Controls]","RateRangePercent")) &&
+        !m_pConfig->exists(ConfigKey("[Controls]","RateRange")))
+        m_pConfig->set(ConfigKey("[Controls]","RateRangePercent"),ConfigValue(8));
+
     // Set default range as stored in config file
     if (m_pConfig->getValueString(ConfigKey("[Controls]", "RateRangePercent")).length() == 0) {
         // Fall back to old [Controls]RateRange


### PR DESCRIPTION
Fixing [Bug 1676140](https://bugs.launchpad.net/mixxx/+bug/1676140) Pitch/Tempo slider range default is 0%.
This sets rate range to 8%.

I don't know how to fix the other issue I noticed that defaults would be restored visually but not actually applied.