### PR TITLE
do not clamp out-of-bounds ControlPotmeter parameters when they are allowed

### DIFF
--- a/src/control/controlbehavior.cpp
+++ b/src/control/controlbehavior.cpp
@@ -56,10 +56,12 @@ double ControlPotmeterBehavior::valueToParameter(double dValue) {
     if (m_dValueRange == 0.0) {
         return 0;
     }
-    if (dValue > m_dMaxValue) {
-        dValue = m_dMaxValue;
-    } else if (dValue < m_dMinValue) {
-        dValue = m_dMinValue;
+    if (!m_bAllowOutOfBounds) {
+        if (dValue > m_dMaxValue) {
+            dValue = m_dMaxValue;
+        } else if (dValue < m_dMinValue) {
+            dValue = m_dMinValue;
+        }
     }
     return (dValue - m_dMinValue) / m_dValueRange;
 }
@@ -116,10 +118,12 @@ double ControlLogPotmeterBehavior::valueToParameter(double dValue) {
     if (m_dValueRange == 0.0) {
         return 0;
     }
-    if (dValue > m_dMaxValue) {
-        dValue = m_dMaxValue;
-    } else if (dValue < m_dMinValue) {
-        dValue = m_dMinValue;
+    if (!m_bAllowOutOfBounds) {
+        if (dValue > m_dMaxValue) {
+            dValue = m_dMaxValue;
+        } else if (dValue < m_dMinValue) {
+            dValue = m_dMinValue;
+        }
     }
     double linPrameter = (dValue - m_dMinValue) / m_dValueRange;
     double dbParamter = ratio2db(linPrameter + m_minOffset * (1 - linPrameter));


### PR DESCRIPTION
Getting the normalized value should reflect the actual value of the ControlPotmeter if out-of-bounds values are allowed, as discovered in #1227.

This has a weird side effect with WSliderComposed:
![slider-out-of-bounds](https://cloud.githubusercontent.com/assets/9455094/24921199/9c93de94-1eaf-11e7-869c-3598f56a8ab5.png)
If this is not desired, I could make WSliderComposed and WKnobComposed clamp parameters.