### PR TITLE
Make logging more efficient.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,8 @@ int main(int argc, char * argv[]) {
     // ErrorDialogHandler::errorDialog(). TODO(XXX): Remove this hack.
     QThread::currentThread()->setObjectName("Main");
 
-    mixxx::Logging::initialize();
+    mixxx::Logging::initialize(args.getSettingsPath(),
+                               args.getLogLevel(), args.getDebugAssertBreak());
 
     MixxxApplication a(argc, argv);
 

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -1,10 +1,10 @@
 #include "util/logging.h"
 
 #include <stdio.h>
-#include <iostream>
 #include <signal.h>
 
 #include <QByteArray>
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QIODevice>
@@ -15,187 +15,157 @@
 #include <QtDebug>
 #include <QtGlobal>
 
-#include "util/cmdlineargs.h"
 #include "util/assert.h"
 
 namespace mixxx {
 namespace {
 
-QFile Logfile;
-QMutex mutexLogfile;
+// Mutex guarding g_logfile.
+QMutex g_mutexLogfile;
+// The file handle for Mixxx's log file.
+QFile g_logfile;
+// The log level.
+Logging::LogLevel g_logLevel = Logging::kLogLevelDefault;
+// Whether to break on debug assertions.
+bool g_debugAssertBreak = false;
 
-// Debug message handler which outputs to both a logfile and prepends the thread
-// the message came from.
+// Handles actually writing to stderr and the log.
+inline void writeToLog(const QByteArray& message, bool shouldPrint,
+                       bool shouldFlush) {
+    if (shouldPrint) {
+        fwrite(message.constData(), sizeof(char), message.size() + 1, stderr);
+    }
+
+    QMutexLocker locker(&g_mutexLogfile);
+    // Writing to a closed QFile can cause a recursive loop, since it prints an
+    // error using qWarning.
+    if (g_logfile.isOpen()) {
+        g_logfile.write(message);
+        if (shouldFlush) {
+            g_logfile.flush();
+        }
+    }
+}
+
+// Debug message handler which outputs to stderr and a logfile, prepending the
+// thread name and log level.
 void MessageHandler(QtMsgType type,
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
                     const char* input) {
 #else
                     const QMessageLogContext&, const QString& input) {
 #endif
-
-    // It's possible to deadlock if any method in this function can
-    // qDebug/qWarning/etc. Writing to a closed QFile, for example, produces a
-    // qWarning which causes a deadlock. That's why every use of Logfile is
-    // wrapped with isOpen() checks.
-    QMutexLocker locker(&mutexLogfile);
-    QByteArray ba;
-    QThread* thread = QThread::currentThread();
-    if (thread) {
-        ba = "[" + QThread::currentThread()->objectName().toLocal8Bit() + "]: ";
-    } else {
-        ba = "[?]: ";
-    }
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-    bool controllerDebug = strncmp(input, Logging::kControllerDebugPrefix,
-                                   strlen(Logging::kControllerDebugPrefix)) == 0;
-    if (controllerDebug) {
-        ba += (input + strlen(Logging::kControllerDebugPrefix) + 1);
-    } else {
-        ba += input;
-    }
-#else
-    bool controllerDebug = input.startsWith(QLatin1String(Logging::kControllerDebugPrefix));
-    if (controllerDebug) {
-        ba += input.mid(strlen(Logging::kControllerDebugPrefix) + 1).toLocal8Bit();
-    } else {
-        ba += input.toLocal8Bit();
-    }
-#endif
-    ba += "\n";
-
-    if (!Logfile.isOpen()) {
-        // This Must be done in the Message Handler itself, to guarantee that the
-        // QApplication is initialized
-        QString logLocation = CmdlineArgs::Instance().getSettingsPath();
-        QString logFileName;
-
-        // Rotate old logfiles
-        //FIXME: cerr << doesn't get printed until after mixxx quits (???)
-        for (int i = 9; i >= 0; --i) {
-            if (i == 0) {
-                logFileName = QDir(logLocation).filePath("mixxx.log");
-            } else {
-                logFileName = QDir(logLocation).filePath(QString("mixxx.log.%1").arg(i));
-            }
-            QFileInfo logbackup(logFileName);
-            if (logbackup.exists()) {
-                QString olderlogname =
-                        QDir(logLocation).filePath(QString("mixxx.log.%1").arg(i + 1));
-                // This should only happen with number 10
-                if (QFileInfo(olderlogname).exists()) {
-                    QFile::remove(olderlogname);
-                }
-                if (!QFile::rename(logFileName, olderlogname)) {
-                    std::cerr << "Error rolling over logfile " << logFileName.toStdString();
-                }
-            }
-        }
-
-        // WARNING(XXX) getSettingsPath() may not be ready yet. This causes
-        // Logfile writes below to print qWarnings which in turn recurse into
-        // MessageHandler -- potentially deadlocking.
-        // XXX will there ever be a case that we can't write to our current
-        // working directory?
-        Logfile.setFileName(logFileName);
-        Logfile.open(QIODevice::WriteOnly | QIODevice::Text);
-    }
-
-    Logging::LogLevel logLevel = CmdlineArgs::Instance().getLogLevel();
-
+    // For "]: " and '\n'.
+    size_t baSize = 4;
+    const char* tag = nullptr;
+    bool shouldPrint = true;
+    bool shouldFlush = false;
+    bool isDebugAssert = false;
+    bool isControllerDebug = false;
     switch (type) {
-    case QtDebugMsg:
-        if (logLevel >= Logging::LogLevel::Debug || controllerDebug) {
-            fprintf(stderr, "Debug %s", ba.constData());
-        }
-        if (Logfile.isOpen()) {
-            Logfile.write("Debug ");
-            Logfile.write(ba);
-        }
-        break;
+        case QtDebugMsg:
+            tag = "Debug [";
+            baSize += strlen(tag);
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+            isControllerDebug = strncmp(input, Logging::kControllerDebugPrefix,
+                                        strlen(Logging::kControllerDebugPrefix)) == 0;
+#else
+            isControllerDebug = input.startsWith(QLatin1String(
+                Logging::kControllerDebugPrefix));
+#endif
+            shouldPrint = g_logLevel >= Logging::LogLevel::Debug ||
+                    isControllerDebug;
+            break;
 #if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
-    case QtInfoMsg:
-        if (logLevel >= Logging::LogLevel::Info) {
-            fprintf(stderr, "Info %s", ba.constData());
-        }
-        if (Logfile.isOpen()) {
-            Logfile.write("Info ");
-            Logfile.write(ba);
-        }
-        break;
+        case QtInfoMsg:
+            tag = "Info [";
+            baSize += strlen(tag);
+            shouldPrint = g_logLevel >= Logging::LogLevel::Info;
+            break;
 #endif
-    case QtWarningMsg:
-        if (logLevel >= Logging::LogLevel::Warning) {
-            fprintf(stderr, "Warning %s", ba.constData());
-        }
-        if (Logfile.isOpen()) {
-            Logfile.write("Warning ");
-            Logfile.write(ba);
-        }
-        break;
-    case QtCriticalMsg:
-        {
+        case QtWarningMsg:
+            tag = "Warning [";
+            baSize += strlen(tag);
+            shouldPrint = g_logLevel >= Logging::LogLevel::Warning;
+            break;
+        case QtCriticalMsg:
+            tag = "Critical [";
+            baSize += strlen(tag);
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-            bool debugAssert = strncmp(input, kDebugAssertPrefix,
-                                           strlen(kDebugAssertPrefix)) == 0;
+            isDebugAssert = strncmp(input, kDebugAssertPrefix,
+                                    strlen(kDebugAssertPrefix)) == 0;
 #else
-            bool debugAssert = input.startsWith(QLatin1String(kDebugAssertPrefix));
+            isDebugAssert = input.startsWith(QLatin1String(kDebugAssertPrefix));
 #endif
-            if (debugAssert) {
-                if (CmdlineArgs::Instance().getDebugAssertBreak()) {
-                    fputs(ba.constData(), stderr);
-                    if (Logfile.isOpen()) {
-                        Logfile.write(ba);
-                    }
-                    raise(SIGINT);
-                } else {
+            break;
+        case QtFatalMsg:
+            tag = "Fatal [";
+            baSize += strlen(tag);
+            shouldFlush = true;
+            break;
+        default:
+            tag = "Unknown [";
+            baSize += strlen(tag);
+    }
+
+    // qthread.cpp contains a Q_ASSERT that currentThread does not return
+    // nullptr.
+    QByteArray threadName = QThread::currentThread()
+            ->objectName().toLocal8Bit();
+    baSize += threadName.length();
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+    const char* inputOffset = input;
+    if (isControllerDebug) {
+        inputOffset += strlen(Logging::kControllerDebugPrefix) + 1;
+    }
+    baSize += strlen(inputOffset);
+#else
+    QByteArray input8Bit;
+    if (isControllerDebug) {
+        input8Bit = input.mid(strlen(Logging::kControllerDebugPrefix) + 1).toLocal8Bit();
+    } else {
+        input8Bit = input.toLocal8Bit();
+    }
+    baSize += input8Bit.size();
+#endif
+
+    QByteArray ba;
+    ba.reserve(baSize);
+
+    ba += tag;
+    ba += threadName;
+    ba += "]: ";
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+    ba += inputOffset;
+#else
+    ba += input8Bit;
+#endif
+    ba += '\n';
+
+    if (isDebugAssert) {
+        if (g_debugAssertBreak) {
+            writeToLog(ba, true, true);
+            raise(SIGINT);
+            // If the debugger returns, continue normally.
+            return;
+        }
+        // If debug assertions are non-fatal, we will fall through to the normal
+        // writeToLog case below.
 #ifdef MIXXX_DEBUG_ASSERTIONS_FATAL
-                    // re-send as fatal
-                    locker.unlock();
+        // re-send as fatal.
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-                    // The "%s" is intentional. See -Werror=format-security.
-                    qFatal("%s", input);
+        // The "%s" is intentional. See -Werror=format-security.
+        qFatal("%s", input);
 #else
-                    // The "%s" is intentional. See -Werror=format-security.
-                    qFatal("%s", input.toLocal8Bit().constData());
+        // The "%s" is intentional. See -Werror=format-security.
+        qFatal("%s", input8Bit.constData());
 #endif
-                    return;
-#else
-                    fputs(ba.constData(), stderr);
-                    if (Logfile.isOpen()) {
-                        Logfile.write(ba);
-                    }
+        return;
 #endif
-                }
-            } else {
-                // Critical errors are always shown on the console.
-                fprintf(stderr, "Critical %s", ba.constData());
-                if (Logfile.isOpen()) {
-                    Logfile.write("Critical ");
-                    Logfile.write(ba);
-                }
-            }
-        }
-        break;
-    case QtFatalMsg:
-        // Fatal errors are always shown on the console.
-        fprintf(stderr, "Fatal %s", ba.constData());
-        if (Logfile.isOpen()) {
-            Logfile.write("Fatal ");
-            Logfile.write(ba);
-        }
-        break;
-    default:
-        fprintf(stderr, "Unknown %s", ba.constData());
-        if (Logfile.isOpen()) {
-            Logfile.write("Unknown ");
-            Logfile.write(ba);
-        }
-        break;
     }
-    if (Logfile.isOpen()) {
-        Logfile.flush();
-    }
+
+    writeToLog(ba, shouldPrint, shouldFlush);
 }
 
 }  // namespace
@@ -204,7 +174,46 @@ void MessageHandler(QtMsgType type,
 constexpr Logging::LogLevel Logging::kLogLevelDefault;
 
 // static
-void Logging::initialize() {
+void Logging::initialize(const QString& settingsPath, LogLevel logLevel,
+                         bool debugAssertBreak) {
+    VERIFY_OR_DEBUG_ASSERT(!g_logfile.isOpen()) {
+        // Somebody already called Logging::initialize.
+        return;
+    }
+
+    QString logFileName;
+    QDir settingsDir(settingsPath);
+
+    // Rotate old logfiles.
+    for (int i = 9; i >= 0; --i) {
+        if (i == 0) {
+            logFileName = settingsDir.filePath("mixxx.log");
+        } else {
+            logFileName = settingsDir.filePath(QString("mixxx.log.%1").arg(i));
+        }
+        QFileInfo logbackup(logFileName);
+        if (logbackup.exists()) {
+            QString olderlogname =
+                    settingsDir.filePath(QString("mixxx.log.%1").arg(i + 1));
+            // This should only happen with number 10
+            if (QFileInfo(olderlogname).exists()) {
+                QFile::remove(olderlogname);
+            }
+            if (!QFile::rename(logFileName, olderlogname)) {
+                fprintf(stderr, "Error rolling over logfile %s",
+                        logFileName.toLocal8Bit().constData());
+            }
+        }
+    }
+
+    // Since the message handler is not installed yet, we can touch g_logfile
+    // without the lock.
+    g_logfile.setFileName(logFileName);
+    g_logfile.open(QIODevice::WriteOnly | QIODevice::Text);
+    g_logLevel = logLevel;
+    g_debugAssertBreak = debugAssertBreak;
+
+    // Install the Qt message handler.
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     qInstallMsgHandler(MessageHandler);
 #else
@@ -214,17 +223,18 @@ void Logging::initialize() {
 
 // static
 void Logging::shutdown() {
+    // Reset the Qt message handler to default.
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-    qInstallMsgHandler(NULL);  // Reset to default.
+    qInstallMsgHandler(nullptr);
 #else
-    qInstallMessageHandler(NULL);  // Reset to default.
+    qInstallMessageHandler(nullptr);
 #endif
 
-    // Don't make any more output after this
-    //    or mixxx.log will get clobbered!
-    QMutexLocker locker(&mutexLogfile);
-    if (Logfile.isOpen()) {
-        Logfile.close();
+    // Even though we uninstalled the message handler, other threads may have
+    // already entered it.
+    QMutexLocker locker(&g_mutexLogfile);
+    if (g_logfile.isOpen()) {
+        g_logfile.close();
     }
 }
 

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -91,6 +91,7 @@ void MessageHandler(QtMsgType type,
         case QtCriticalMsg:
             tag = "Critical [";
             baSize += strlen(tag);
+            shouldFlush = true;
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
             isDebugAssert = strncmp(input, kDebugAssertPrefix,
                                     strlen(kDebugAssertPrefix)) == 0;

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -1,6 +1,8 @@
 #ifndef MIXXX_UTIL_LOGGING_H
 #define MIXXX_UTIL_LOGGING_H
 
+#include <QString>
+
 namespace mixxx {
 
 class Logging {
@@ -16,13 +18,15 @@ class Logging {
     // command line flags.
     static constexpr const char* kControllerDebugPrefix = "CDBG";
 
-    static void initialize();
+    // These are not thread safe. Only call them on Mixxx startup and shutdown.
+    static void initialize(const QString& settingsPath,
+                           LogLevel logLevel,
+                           bool debugAssertBreak);
     static void shutdown();
+
   private:
     Logging() = delete;
 };
-
-void install_message_handler();
 
 }  // namespace mixxx
 


### PR DESCRIPTION
* Don't flush the log file except on fatal errors.
* Only hold the log file mutex for as little time as needed.
* Reserve QByteArray size for the log message ahead of time to avoid multiple
  mallocs.
* Include log-level tag in the QByteArray so we can write to the file/stderr in
  one call instead of two.
* Use fwrite instead of fputs (to avoid a strlen).
* Do log file rotation in Logging::initialize.