### PR TITLE
make sure effect chains are initialized properly

### DIFF
--- a/src/effects/effectchainmanager.h
+++ b/src/effects/effectchainmanager.h
@@ -54,6 +54,7 @@ class EffectChainManager : public QObject {
     QList<std::pair<EffectChainPointer, QDomElement>> loadEffectChains();
 
     static const int kNumEffectsPerUnit = 4;
+    static const int kNumStandardEffectChains = 4;
 
   private:
     QString debugString() const {


### PR DESCRIPTION
if effects.xml is a valid XML file but does not contain enough <EffectChain> elements like [this](https://github.com/mixxxdj/mixxx/pull/1092#issuecomment-295006581). That should never happen, but in case it does, this change will catch it.