### PR TITLE
User Preference to Hide beat grid on waveform

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -65,6 +65,8 @@ DlgPrefWaveform::DlgPrefWaveform(QWidget* pParent, MixxxMainWindow* pMixxx,
             this, SLOT(slotSetVisualGainHigh(double)));
     connect(normalizeOverviewCheckBox, SIGNAL(toggled(bool)),
             this, SLOT(slotSetNormalizeOverview(bool)));
+    connect(beatGridLinesCheckBox, SIGNAL(toggled(bool)),
+            this, SLOT(slotSetGridLines(bool)));
     connect(factory, SIGNAL(waveformMeasured(float,int)),
             this, SLOT(slotWaveformMeasured(float,int)));
     connect(waveformOverviewComboBox, SIGNAL(currentIndexChanged(int)),
@@ -102,6 +104,7 @@ void DlgPrefWaveform::slotUpdate() {
     highVisualGain->setValue(factory->getVisualGain(WaveformWidgetFactory::High));
     normalizeOverviewCheckBox->setChecked(factory->isOverviewNormalized());
     defaultZoomComboBox->setCurrentIndex(factory->getDefaultZoom() - 1);
+    beatGridLinesCheckBox->setChecked(factory->enableGrid());
 
     // By default we set RGB woverview = "2"
     int overviewType = m_pConfig->getValue(
@@ -159,6 +162,9 @@ void DlgPrefWaveform::slotResetToDefaults() {
     // Waveform caching enabled.
     enableWaveformCaching->setChecked(true);
     enableWaveformGenerationWithAnalysis->setChecked(false);
+
+    // Grid lines on waveform is default
+    beatGridLinesCheckBox->setChecked(true);
 }
 
 void DlgPrefWaveform::slotSetFrameRate(int frameRate) {
@@ -224,6 +230,10 @@ void DlgPrefWaveform::slotClearCachedWaveforms() {
         analysisDao.deleteAnalysesByType(AnalysisDao::TYPE_WAVESUMMARY);
         calculateCachedWaveformDiskUsage();
     }
+}
+
+void DlgPrefWaveform::slotSetGridLines(bool displayGrid){
+    WaveformWidgetFactory::instance()->setDisplayGrid(displayGrid);
 }
 
 void DlgPrefWaveform::calculateCachedWaveformDiskUsage() {

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -163,7 +163,7 @@ void DlgPrefWaveform::slotResetToDefaults() {
     enableWaveformCaching->setChecked(true);
     enableWaveformGenerationWithAnalysis->setChecked(false);
 
-    // Grid lines on waveform is default
+    // Beat grid lines on waveform is default
     beatGridLinesCheckBox->setChecked(true);
 }
 
@@ -232,7 +232,7 @@ void DlgPrefWaveform::slotClearCachedWaveforms() {
     }
 }
 
-void DlgPrefWaveform::slotSetGridLines(bool displayGrid){
+void DlgPrefWaveform::slotSetGridLines(bool displayGrid) {
     WaveformWidgetFactory::instance()->setDisplayBeatGrid(displayGrid);
 }
 

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -104,7 +104,7 @@ void DlgPrefWaveform::slotUpdate() {
     highVisualGain->setValue(factory->getVisualGain(WaveformWidgetFactory::High));
     normalizeOverviewCheckBox->setChecked(factory->isOverviewNormalized());
     defaultZoomComboBox->setCurrentIndex(factory->getDefaultZoom() - 1);
-    beatGridLinesCheckBox->setChecked(factory->enableGrid());
+    beatGridLinesCheckBox->setChecked(factory->isBeatGridEnabled());
 
     // By default we set RGB woverview = "2"
     int overviewType = m_pConfig->getValue(
@@ -233,7 +233,7 @@ void DlgPrefWaveform::slotClearCachedWaveforms() {
 }
 
 void DlgPrefWaveform::slotSetGridLines(bool displayGrid){
-    WaveformWidgetFactory::instance()->setDisplayGrid(displayGrid);
+    WaveformWidgetFactory::instance()->setDisplayBeatGrid(displayGrid);
 }
 
 void DlgPrefWaveform::calculateCachedWaveformDiskUsage() {

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -36,6 +36,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotSetNormalizeOverview(bool normalize);
     void slotWaveformMeasured(float frameRate, int droppedFrames);
     void slotClearCachedWaveforms();
+    void slotSetGridLines(bool displayGrid);
 
   private:
     void initWaveformControl();

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>536</width>
-    <height>445</height>
+    <width>1032</width>
+    <height>836</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,7 +16,7 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout_2">
-     <item row="7" column="0">
+     <item row="8" column="0">
       <widget class="QLabel" name="visualGainLabel">
        <property name="text">
         <string>Visual gain</string>
@@ -57,14 +57,14 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="7" column="1">
       <widget class="QCheckBox" name="normalizeOverviewCheckBox">
        <property name="text">
         <string>Normalize waveform overview</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
+     <item row="11" column="1">
       <widget class="QLabel" name="openGlStatusIcon">
        <property name="toolTip">
         <string>Displays which OpenGL version is supported by the current platform.</string>
@@ -93,26 +93,13 @@
        </property>
       </widget>
      </item>
-     <item row="11" column="0">
+     <item row="12" column="0">
       <widget class="QLabel" name="openGlStatusLabel_2">
        <property name="toolTip">
         <string/>
        </property>
        <property name="text">
         <string>Average frame rate</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="0">
-      <widget class="QLabel" name="BeatgridWaveform">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="text">
-        <string>Display grid lines on waveform</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -135,14 +122,14 @@
      <item row="4" column="1" colspan="3">
       <widget class="QComboBox" name="defaultZoomComboBox"/>
      </item>
-     <item row="9" column="0" colspan="4">
+     <item row="10" column="0" colspan="4">
       <widget class="Line" name="line">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
+     <item row="11" column="0">
       <widget class="QLabel" name="openGlStatusLabel">
        <property name="toolTip">
         <string/>
@@ -177,7 +164,7 @@
        </property>
       </widget>
      </item>
-     <item row="7" column="1" colspan="3">
+     <item row="8" column="1" colspan="3">
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="1" column="2">
         <widget class="QDoubleSpinBox" name="midVisualGain">
@@ -333,23 +320,13 @@
        </property>
       </widget>
      </item>
-     <item row="11" column="1">
+     <item row="12" column="1">
       <widget class="QLabel" name="frameRateAverage">
        <property name="toolTip">
         <string>Displays the actual frame rate.</string>
        </property>
        <property name="text">
         <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="1">
-      <widget class="QCheckBox" name="beatGridLinesCheckBox">
-       <property name="toolTip">
-        <string>Beat Grid</string>
-       </property>
-       <property name="text">
-        <string>Show Beat Markers</string>
        </property>
       </widget>
      </item>
@@ -433,7 +410,7 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="0">
+     <item row="9" column="0">
       <widget class="QLabel" name="cachedWaveforms">
        <property name="text">
         <string>Caching</string>
@@ -443,7 +420,7 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="1" colspan="3">
+     <item row="9" column="1" colspan="3">
       <layout class="QGridLayout" name="cachingGridLayout">
        <item row="3" column="1">
         <widget class="QPushButton" name="clearCachedWaveforms">
@@ -487,6 +464,29 @@
         </widget>
        </item>
       </layout>
+     </item>
+     <item row="6" column="1">
+      <widget class="QCheckBox" name="beatGridLinesCheckBox">
+       <property name="toolTip">
+        <string>Beat Grid</string>
+       </property>
+       <property name="text">
+        <string>Show Beat Markers</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="BeatgridWaveform">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Beat Grid</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -346,10 +346,10 @@
      <item row="12" column="1">
       <widget class="QCheckBox" name="beatGridLinesCheckBox">
        <property name="toolTip">
-        <string>Display beat grid lines on waveform</string>
+        <string>Beat Grid</string>
        </property>
        <property name="text">
-        <string>Enable Beat Grid Lines</string>
+        <string>Show Beat Markers</string>
        </property>
       </widget>
      </item>

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -16,7 +16,7 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout_2">
-     <item row="8" column="0">
+     <item row="9" column="0">
       <widget class="QLabel" name="visualGainLabel">
        <property name="text">
         <string>Visual gain</string>
@@ -57,14 +57,14 @@
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
+     <item row="8" column="1">
       <widget class="QCheckBox" name="normalizeOverviewCheckBox">
        <property name="text">
         <string>Normalize waveform overview</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="1">
+     <item row="12" column="1">
       <widget class="QLabel" name="openGlStatusIcon">
        <property name="toolTip">
         <string>Displays which OpenGL version is supported by the current platform.</string>
@@ -93,7 +93,7 @@
        </property>
       </widget>
      </item>
-     <item row="12" column="0">
+     <item row="13" column="0">
       <widget class="QLabel" name="openGlStatusLabel_2">
        <property name="toolTip">
         <string/>
@@ -119,17 +119,17 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1" colspan="3">
+     <item row="5" column="1" colspan="3">
       <widget class="QComboBox" name="defaultZoomComboBox"/>
      </item>
-     <item row="10" column="0" colspan="4">
+     <item row="11" column="0" colspan="4">
       <widget class="Line" name="line">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
       </widget>
      </item>
-     <item row="11" column="0">
+     <item row="12" column="0">
       <widget class="QLabel" name="openGlStatusLabel">
        <property name="toolTip">
         <string/>
@@ -164,7 +164,7 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="1" colspan="3">
+     <item row="9" column="1" colspan="3">
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="1" column="2">
         <widget class="QDoubleSpinBox" name="midVisualGain">
@@ -320,7 +320,7 @@
        </property>
       </widget>
      </item>
-     <item row="12" column="1">
+     <item row="13" column="1">
       <widget class="QLabel" name="frameRateAverage">
        <property name="toolTip">
         <string>Displays the actual frame rate.</string>
@@ -387,7 +387,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="defaultZoomLabel">
        <property name="text">
         <string extracomment="Waveform zoom">Default zoom level</string>
@@ -400,7 +400,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1" colspan="3">
+     <item row="6" column="1" colspan="3">
       <widget class="QCheckBox" name="synchronizeZoomCheckBox">
        <property name="toolTip">
         <string>Synchronize zoom level across all waveform displays.</string>
@@ -410,7 +410,7 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="0">
+     <item row="10" column="0">
       <widget class="QLabel" name="cachedWaveforms">
        <property name="text">
         <string>Caching</string>
@@ -420,7 +420,7 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="1" colspan="3">
+     <item row="10" column="1" colspan="3">
       <layout class="QGridLayout" name="cachingGridLayout">
        <item row="3" column="1">
         <widget class="QPushButton" name="clearCachedWaveforms">
@@ -465,17 +465,7 @@
        </item>
       </layout>
      </item>
-     <item row="6" column="1">
-      <widget class="QCheckBox" name="beatGridLinesCheckBox">
-       <property name="toolTip">
-        <string>Beat Grid</string>
-       </property>
-       <property name="text">
-        <string>Show Beat Markers</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="BeatgridWaveform">
        <property name="toolTip">
         <string/>
@@ -485,6 +475,16 @@
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QCheckBox" name="beatGridLinesCheckBox">
+       <property name="toolTip">
+        <string>Beat Grid</string>
+       </property>
+       <property name="text">
+        <string>Show Beat Markers</string>
        </property>
       </widget>
      </item>

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -106,6 +106,19 @@
        </property>
       </widget>
      </item>
+     <item row="12" column="0">
+      <widget class="QLabel" name="BeatgridWaveform">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Display grid lines on waveform</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
      <item row="2" column="0">
       <widget class="QLabel" name="frameRateLabel">
        <property name="text">
@@ -327,6 +340,16 @@
        </property>
        <property name="text">
         <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="1">
+      <widget class="QCheckBox" name="beatGridLinesCheckBox">
+       <property name="toolTip">
+        <string>Display beat grid lines on waveform</string>
+       </property>
+       <property name="text">
+        <string>Enable Beat Grid Lines</string>
        </property>
       </widget>
      </item>

--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -37,7 +37,7 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     if (!trackBeats)
         return;
 
-    if (!m_waveformRenderer->renderGrid())
+    if (!m_waveformRenderer->isBeatGridEnabled())
         return;
 
     const int trackSamples = m_waveformRenderer->getTrackSamples();

--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -37,6 +37,9 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     if (!trackBeats)
         return;
 
+    if (!m_waveformRenderer->renderGrid())
+        return;
+
     const int trackSamples = m_waveformRenderer->getTrackSamples();
     if (trackSamples <= 0) {
         return;

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -42,7 +42,8 @@ WaveformWidgetRenderer::WaveformWidgetRenderer(const char* group)
       m_gain(1.0),
       m_pTrackSamplesControlObject(NULL),
       m_trackSamples(0.0),
-      m_scaleFactor(1.0) {
+      m_scaleFactor(1.0),
+      m_renderGrid(true) {
 
     //qDebug() << "WaveformWidgetRenderer";
 
@@ -272,6 +273,10 @@ void WaveformWidgetRenderer::setup(
 void WaveformWidgetRenderer::setZoom(int zoom) {
     //qDebug() << "WaveformWidgetRenderer::setZoom" << zoom;
     m_zoomFactor = math_clamp<double>(zoom, s_waveformMinZoom, s_waveformMaxZoom);
+}
+
+void WaveformWidgetRenderer::setDisplayGrid(bool set){
+    m_renderGrid = set;
 }
 
 void WaveformWidgetRenderer::setTrack(TrackPointer track) {

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -275,7 +275,7 @@ void WaveformWidgetRenderer::setZoom(int zoom) {
     m_zoomFactor = math_clamp<double>(zoom, s_waveformMinZoom, s_waveformMaxZoom);
 }
 
-void WaveformWidgetRenderer::setDisplayBeatGrid(bool set){
+void WaveformWidgetRenderer::setDisplayBeatGrid(bool set) {
     m_enableBeatGrid = set;
 }
 

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -27,6 +27,7 @@ WaveformWidgetRenderer::WaveformWidgetRenderer(const char* group)
       m_rateAdjust(0.0),
       m_visualSamplePerPixel(1.0),
       m_audioSamplePerPixel(1.0),
+      m_enableBeatGrid(true),
 
       // Really create some to manage those;
       m_visualPlayPosition(NULL),
@@ -42,8 +43,7 @@ WaveformWidgetRenderer::WaveformWidgetRenderer(const char* group)
       m_gain(1.0),
       m_pTrackSamplesControlObject(NULL),
       m_trackSamples(0.0),
-      m_scaleFactor(1.0),
-      m_renderGrid(true) {
+      m_scaleFactor(1.0) {
 
     //qDebug() << "WaveformWidgetRenderer";
 
@@ -275,8 +275,8 @@ void WaveformWidgetRenderer::setZoom(int zoom) {
     m_zoomFactor = math_clamp<double>(zoom, s_waveformMinZoom, s_waveformMaxZoom);
 }
 
-void WaveformWidgetRenderer::setDisplayGrid(bool set){
-    m_renderGrid = set;
+void WaveformWidgetRenderer::setDisplayBeatGrid(bool set){
+    m_enableBeatGrid = set;
 }
 
 void WaveformWidgetRenderer::setTrack(TrackPointer track) {

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -44,6 +44,8 @@ class WaveformWidgetRenderer {
 
     void setZoom(int zoom);
 
+    void setDisplayGrid(bool set);
+
     double getVisualSamplePerPixel() const { return m_visualSamplePerPixel;};
     double getAudioSamplePerPixel() const { return m_audioSamplePerPixel;};
 
@@ -70,6 +72,8 @@ class WaveformWidgetRenderer {
     double getRateAdjust() const { return m_rateAdjust;}
     double getGain() const { return m_gain;}
     int getTrackSamples() const { return m_trackSamples;}
+
+    bool renderGrid() const { return m_renderGrid; }
 
     void resize(int width, int height);
     int getHeight() const { return m_height;}
@@ -105,6 +109,8 @@ class WaveformWidgetRenderer {
     double m_rateAdjust;
     double m_visualSamplePerPixel;
     double m_audioSamplePerPixel;
+
+    bool m_renderGrid;
 
     //TODO: vRince create some class to manage control/value
     //ControlConnection

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -44,7 +44,7 @@ class WaveformWidgetRenderer {
 
     void setZoom(int zoom);
 
-    void setDisplayGrid(bool set);
+    void setDisplayBeatGrid(bool set);
 
     double getVisualSamplePerPixel() const { return m_visualSamplePerPixel;};
     double getAudioSamplePerPixel() const { return m_audioSamplePerPixel;};
@@ -73,7 +73,7 @@ class WaveformWidgetRenderer {
     double getGain() const { return m_gain;}
     int getTrackSamples() const { return m_trackSamples;}
 
-    bool renderGrid() const { return m_renderGrid; }
+    bool isBeatGridEnabled() const { return m_enableBeatGrid; }
 
     void resize(int width, int height);
     int getHeight() const { return m_height;}
@@ -110,7 +110,7 @@ class WaveformWidgetRenderer {
     double m_visualSamplePerPixel;
     double m_audioSamplePerPixel;
 
-    bool m_renderGrid;
+    bool m_enableBeatGrid;
 
     //TODO: vRince create some class to manage control/value
     //ControlConnection

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -304,6 +304,7 @@ bool WaveformWidgetFactory::setWaveformWidget(WWaveformViewer* viewer,
     }
 
     viewer->setZoom(m_defaultZoom);
+    viewer->setDisplayBeatGrid(m_beatGridEnabled);
     viewer->update();
 
     qDebug() << "WaveformWidgetFactory::setWaveformWidget - waveform widget added in factory, index" << index;

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -224,12 +224,9 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
         m_config->set(ConfigKey("[Waveform]","ZoomSynchronization"), ConfigValue(m_zoomSync));
     }
 
-    int showBeatGrid = m_config->getValue(ConfigKey("[Waveform]", "beatGridLinesCheckBox")).toInt(&ok);
-    if (ok) {
-        setDisplayBeatGrid(static_cast<bool>(showBeatGrid));
-    } else {
-        m_config->set(ConfigKey("[Waveform]", "beatGridLinesCheckBox"), ConfigValue(m_beatGridEnabled));
-    }
+    int showBeatGrid = m_config->getValue(ConfigKey("[Waveform]", "beatGridLinesCheckBox"), m_beatGridEnabled);
+    setDisplayBeatGrid(static_cast<bool>(showBeatGrid));
+
 
     WaveformWidgetType::Type type = static_cast<WaveformWidgetType::Type>(
             m_config->getValueString(ConfigKey("[Waveform]","WaveformType")).toInt(&ok));

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -67,11 +67,11 @@ WaveformWidgetFactory::WaveformWidgetFactory() :
         m_overviewNormalized(false),
         m_openGLAvailable(false),
         m_openGLShaderAvailable(false),
+        m_beatGridEnabled(true),
         m_vsyncThread(NULL),
         m_frameCnt(0),
         m_actualFrameRate(0),
-        m_vSyncType(0),
-        m_gridEnabled(true) {
+        m_vSyncType(0) {
 
     m_visualGain[All] = 1.0;
     m_visualGain[Low] = 1.0;
@@ -224,11 +224,11 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
         m_config->set(ConfigKey("[Waveform]","ZoomSynchronization"), ConfigValue(m_zoomSync));
     }
 
-    int displayGrid = m_config->getValueString(ConfigKey("[Waveform]", "beatGridLinesCheckBox")).toInt(&ok);
+    int showBeatGrid = m_config->getValue(ConfigKey("[Waveform]", "beatGridLinesCheckBox")).toInt(&ok);
     if(ok) {
-        setDisplayGrid(static_cast<bool>(displayGrid));
+        setDisplayBeatGrid(static_cast<bool>(showBeatGrid));
     } else {
-        m_config->set(ConfigKey("[Waveform]", "beatGridLinesCheckBox"), ConfigValue(m_gridEnabled));
+        m_config->set(ConfigKey("[Waveform]", "beatGridLinesCheckBox"), ConfigValue(m_beatGridEnabled));
     }
 
     WaveformWidgetType::Type type = static_cast<WaveformWidgetType::Type>(
@@ -440,10 +440,10 @@ void WaveformWidgetFactory::setZoomSync(bool sync) {
     }
 }
 
-void WaveformWidgetFactory::setDisplayGrid(bool sync){
-    m_gridEnabled = sync;
+void WaveformWidgetFactory::setDisplayBeatGrid(bool sync){
+    m_beatGridEnabled = sync;
     if (m_config){
-        m_config->set(ConfigKey("[Waveform]", "beatGridLinesCheckBox"), ConfigValue(m_gridEnabled));
+        m_config->set(ConfigKey("[Waveform]", "beatGridLinesCheckBox"), ConfigValue(m_beatGridEnabled));
     }
 
     if(m_waveformWidgetHolders.size() == 0){
@@ -451,7 +451,7 @@ void WaveformWidgetFactory::setDisplayGrid(bool sync){
     }
 
     for (int i = 0; i < m_waveformWidgetHolders.size(); i++){
-        m_waveformWidgetHolders[i].m_waveformWidget->setDisplayGrid(m_gridEnabled);
+        m_waveformWidgetHolders[i].m_waveformWidget->setDisplayBeatGrid(m_beatGridEnabled);
     }
 
 }

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -224,9 +224,8 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
         m_config->set(ConfigKey("[Waveform]","ZoomSynchronization"), ConfigValue(m_zoomSync));
     }
 
-    int showBeatGrid = m_config->getValue(ConfigKey("[Waveform]", "beatGridLinesCheckBox"), m_beatGridEnabled);
-    setDisplayBeatGrid(static_cast<bool>(showBeatGrid));
-
+    bool showBeatGrid = m_config->getValue(ConfigKey("[Waveform]", "beatGridLinesCheckBox"), m_beatGridEnabled);
+    setDisplayBeatGrid(showBeatGrid);
 
     WaveformWidgetType::Type type = static_cast<WaveformWidgetType::Type>(
             m_config->getValueString(ConfigKey("[Waveform]","WaveformType")).toInt(&ok));

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -225,7 +225,7 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
     }
 
     int showBeatGrid = m_config->getValue(ConfigKey("[Waveform]", "beatGridLinesCheckBox")).toInt(&ok);
-    if(ok) {
+    if (ok) {
         setDisplayBeatGrid(static_cast<bool>(showBeatGrid));
     } else {
         m_config->set(ConfigKey("[Waveform]", "beatGridLinesCheckBox"), ConfigValue(m_beatGridEnabled));
@@ -440,17 +440,17 @@ void WaveformWidgetFactory::setZoomSync(bool sync) {
     }
 }
 
-void WaveformWidgetFactory::setDisplayBeatGrid(bool sync){
+void WaveformWidgetFactory::setDisplayBeatGrid(bool sync) {
     m_beatGridEnabled = sync;
-    if (m_config){
+    if (m_config) {
         m_config->set(ConfigKey("[Waveform]", "beatGridLinesCheckBox"), ConfigValue(m_beatGridEnabled));
     }
 
-    if(m_waveformWidgetHolders.size() == 0){
+    if (m_waveformWidgetHolders.size() == 0) {
         return;
     }
 
-    for (int i = 0; i < m_waveformWidgetHolders.size(); i++){
+    for (int i = 0; i < m_waveformWidgetHolders.size(); i++) {
         m_waveformWidgetHolders[i].m_waveformWidget->setDisplayBeatGrid(m_beatGridEnabled);
     }
 

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -70,7 +70,8 @@ WaveformWidgetFactory::WaveformWidgetFactory() :
         m_vsyncThread(NULL),
         m_frameCnt(0),
         m_actualFrameRate(0),
-        m_vSyncType(0) {
+        m_vSyncType(0),
+        m_gridEnabled(true) {
 
     m_visualGain[All] = 1.0;
     m_visualGain[Low] = 1.0;
@@ -221,6 +222,13 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
         setZoomSync(static_cast<bool>(zoomSync));
     } else {
         m_config->set(ConfigKey("[Waveform]","ZoomSynchronization"), ConfigValue(m_zoomSync));
+    }
+
+    int displayGrid = m_config->getValueString(ConfigKey("[Waveform]", "beatGridLinesCheckBox")).toInt(&ok);
+    if(ok) {
+        setDisplayGrid(static_cast<bool>(displayGrid));
+    } else {
+        m_config->set(ConfigKey("[Waveform]", "beatGridLinesCheckBox"), ConfigValue(m_gridEnabled));
     }
 
     WaveformWidgetType::Type type = static_cast<WaveformWidgetType::Type>(
@@ -430,6 +438,22 @@ void WaveformWidgetFactory::setZoomSync(bool sync) {
     for (int i = 1; i < m_waveformWidgetHolders.size(); i++) {
         m_waveformWidgetHolders[i].m_waveformViewer->setZoom(refZoom);
     }
+}
+
+void WaveformWidgetFactory::setDisplayGrid(bool sync){
+    m_gridEnabled = sync;
+    if (m_config){
+        m_config->set(ConfigKey("[Waveform]", "beatGridLinesCheckBox"), ConfigValue(m_gridEnabled));
+    }
+
+    if(m_waveformWidgetHolders.size() == 0){
+        return;
+    }
+
+    for (int i = 0; i < m_waveformWidgetHolders.size(); i++){
+        m_waveformWidgetHolders[i].m_waveformWidget->setDisplayGrid(m_gridEnabled);
+    }
+
 }
 
 void WaveformWidgetFactory::setVisualGain(FilterIndex index, double gain) {

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -87,8 +87,8 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void setZoomSync(bool sync);
     int isZoomSync() const { return m_zoomSync;}
 
-    void setDisplayGrid(bool sync);
-    bool enableGrid() const { return m_gridEnabled; }
+    void setDisplayBeatGrid(bool sync);
+    bool isBeatGridEnabled() const { return m_beatGridEnabled; }
 
     void setVisualGain(FilterIndex index, double gain);
     double getVisualGain(FilterIndex index) const;
@@ -141,7 +141,6 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     UserSettingsPointer m_config;
 
     bool m_skipRender;
-    bool m_gridEnabled;
     int m_frameRate;
     int m_endOfTrackWarningTime;
     int m_defaultZoom;
@@ -152,6 +151,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     bool m_openGLAvailable;
     QString m_openGLVersion;
     bool m_openGLShaderAvailable;
+    bool m_beatGridEnabled;
 
     VSyncThread* m_vsyncThread;
 

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -87,6 +87,9 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void setZoomSync(bool sync);
     int isZoomSync() const { return m_zoomSync;}
 
+    void setDisplayGrid(bool sync);
+    bool enableGrid() const { return m_gridEnabled; }
+
     void setVisualGain(FilterIndex index, double gain);
     double getVisualGain(FilterIndex index) const;
 
@@ -138,6 +141,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     UserSettingsPointer m_config;
 
     bool m_skipRender;
+    bool m_gridEnabled;
     int m_frameRate;
     int m_endOfTrackWarningTime;
     int m_defaultZoom;

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -215,6 +215,10 @@ void WWaveformViewer::setZoom(int zoom) {
     }
 }
 
+void WWaveformViewer::setDisplayBeatGrid(bool set) {
+    m_waveformWidget->setDisplayBeatGrid(set);
+}
+
 void WWaveformViewer::setWaveformWidget(WaveformWidgetAbstract* waveformWidget) {
     if (m_waveformWidget) {
         QWidget* pWidget = m_waveformWidget->getWidget();

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -56,6 +56,7 @@ private:
     }
     //direct access to let factory sync/set default zoom
     void setZoom(int zoom);
+    void setDisplayBeatGrid(bool set);
 
 private:
     const char* m_pGroup;


### PR DESCRIPTION
These changes are to enable the functionality requested in bug 1659888 : https://bugs.launchpad.net/mixxx/+bug/1659888 . I have done some testing on it and it is working. Please let me know if anything needs to be changed.

	modified:   src/preferences/dialog/dlgprefwaveform.h
	modified:   src/preferences/dialog/dlgprefwaveformdlg.ui
	modified:   src/waveform/renderers/waveformrenderbeat.cpp
	modified:   src/waveform/renderers/waveformwidgetrenderer.cpp
	modified:   src/waveform/renderers/waveformwidgetrenderer.h
	modified:   src/waveform/waveformwidgetfactory.cpp
	modified:   src/waveform/waveformwidgetfactory.h

Added functionality to hide beat grid lines on waveform.