### PR TITLE
add option to reset deck gain on track load

### DIFF
--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -320,6 +320,9 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
             if (m_pHighFilterKill != NULL) {
                 m_pHighFilterKill->set(0.0);
             }
+        }
+        if (m_pConfig->getValue(
+                ConfigKey("[Mixer Profile]", "GainAutoReset"), false)) {
             m_pPreGain->set(1.0);
         }
         int reset = m_pConfig->getValue<int>(

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -52,7 +52,8 @@ DlgPrefEQ::DlgPrefEQ(QWidget* pParent, EffectsManager* pEffectsManager,
           m_firstSelectorLabel(NULL),
           m_pNumDecks(NULL),
           m_inSlotPopulateDeckEffectSelectors(false),
-          m_bEqAutoReset(false) {
+          m_bEqAutoReset(false),
+          m_bGainAutoReset(false) {
     m_pEQEffectRack = m_pEffectsManager->getEqualizerRack(0);
     m_pQuickEffectRack = m_pEffectsManager->getQuickEffectRack(0);
 
@@ -67,6 +68,7 @@ DlgPrefEQ::DlgPrefEQ(QWidget* pParent, EffectsManager* pEffectsManager,
     connect(SliderLoEQ, SIGNAL(sliderReleased()), this, SLOT(slotUpdateLoEQ()));
 
     connect(CheckBoxEqAutoReset, SIGNAL(stateChanged(int)), this, SLOT(slotUpdateEqAutoReset(int)));
+    connect(CheckBoxGainAutoReset, SIGNAL(stateChanged(int)), this, SLOT(slotUpdateGainAutoReset(int)));
     connect(CheckBoxBypass, SIGNAL(stateChanged(int)), this, SLOT(slotBypass(int)));
 
     connect(CheckBoxEqOnly, SIGNAL(stateChanged(int)),
@@ -307,6 +309,9 @@ void DlgPrefEQ::loadSettings() {
     m_bEqAutoReset = static_cast<bool>(m_pConfig->getValueString(
             ConfigKey(kConfigKey, "EqAutoReset")).toInt());
     CheckBoxEqAutoReset->setChecked(m_bEqAutoReset);
+    m_bGainAutoReset = static_cast<bool>(m_pConfig->getValueString(
+            ConfigKey(kConfigKey, "GainAutoReset")).toInt());
+    CheckBoxGainAutoReset->setChecked(m_bGainAutoReset);
     CheckBoxBypass->setChecked(m_pConfig->getValue(
             ConfigKey(kConfigKey, kEnableEqs), QString("yes")) == "no");
     CheckBoxEqOnly->setChecked(m_pConfig->getValue(
@@ -370,6 +375,8 @@ void DlgPrefEQ::slotResetToDefaults() {
     CheckBoxSingleEqEffect->setChecked(Qt::Checked);
     m_bEqAutoReset = false;
     CheckBoxEqAutoReset->setChecked(Qt::Unchecked);
+    m_bGainAutoReset = false;
+    CheckBoxGainAutoReset->setChecked(Qt::Unchecked);
     slotUpdate();
     slotApply();
 }
@@ -578,6 +585,8 @@ void DlgPrefEQ::slotApply() {
     m_COHiFreq.set(m_highEqFreq);
     m_pConfig->set(ConfigKey(kConfigKey,"EqAutoReset"),
             ConfigValue(m_bEqAutoReset ? 1 : 0));
+    m_pConfig->set(ConfigKey(kConfigKey,"GainAutoReset"),
+        ConfigValue(m_bGainAutoReset ? 1 : 0));
     applySelections();
 }
 
@@ -587,10 +596,15 @@ void DlgPrefEQ::slotUpdate() {
     slotUpdateHiEQ();
     slotPopulateDeckEffectSelectors();
     CheckBoxEqAutoReset->setChecked(m_bEqAutoReset);
+    CheckBoxGainAutoReset->setChecked(m_bGainAutoReset);
 }
 
 void DlgPrefEQ::slotUpdateEqAutoReset(int i) {
     m_bEqAutoReset = static_cast<bool>(i);
+}
+
+void DlgPrefEQ::slotUpdateGainAutoReset(int i) {
+    m_bGainAutoReset = static_cast<bool>(i);
 }
 
 void DlgPrefEQ::slotBypass(int state) {

--- a/src/preferences/dialog/dlgprefeq.h
+++ b/src/preferences/dialog/dlgprefeq.h
@@ -57,6 +57,7 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     void slotUpdate();
     void slotResetToDefaults();
     void slotUpdateEqAutoReset(int);
+    void slotUpdateGainAutoReset(int);
     void slotBypass(int state);
     // Update the Master EQ
     void slotUpdateMasterEQParameter(int value);
@@ -103,6 +104,7 @@ class DlgPrefEQ : public DlgPreferencePage, public Ui::DlgPrefEQDlg  {
     QWeakPointer<Effect> m_pEffectMasterEQ;
 
     bool m_bEqAutoReset;
+    bool m_bGainAutoReset;
 };
 
 #endif

--- a/src/preferences/dialog/dlgprefeqdlg.ui
+++ b/src/preferences/dialog/dlgprefeqdlg.ui
@@ -372,6 +372,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="CheckBoxGainAutoReset">
+         <property name="toolTip">
+          <string>Resets the deck gain to unity when loading a track.</string>
+         </property>
+         <property name="text">
+          <string>Reset gain on track load</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="CheckBoxBypass">
          <property name="text">
           <string>Bypass EQ effect processing</string>


### PR DESCRIPTION
This option is helpful for use with controllers that have EQ knobs but no gain knobs like the Hercules P32 and Pioneer DDJ-SB. Previously this was confusingly conflated with resetting EQs on track load, which does not work well with such controllers.