### PR TITLE
Tango skin :: revert loop button to reloop_exit

### DIFF
--- a/res/skins/Tango/deck_loop_beatjump_right.xml
+++ b/res/skins/Tango/deck_loop_beatjump_right.xml
@@ -23,12 +23,12 @@
     </Children>
     <Connection>
       <ConfigKey persist="true">[Tango],loop_beatjump_controls</ConfigKey>
-      <Transform><IsEqual>1</IsEqual></Transform>
       <BindProperty>visible</BindProperty>
     </Connection>
   </WidgetGroup><!-- /Loop/Jump 2.0 -->
 
-  <WidgetGroup><!-- Loop/Jump 2.1 compact -->
+  <!-- Loop/Jump 2.1 compact
+  <WidgetGroup>
     <ObjectName>DeckLoopBeatjump</ObjectName>
     <SizePolicy>min,min</SizePolicy>
     <Layout>horizontal</Layout>
@@ -44,9 +44,10 @@
       <Transform><IsEqual>2</IsEqual></Transform>
       <BindProperty>visible</BindProperty>
     </Connection>
-  </WidgetGroup><!-- /Loop/Jump 2.1 compact -->
+  </WidgetGroup> -->
 
-  <WidgetGroup><!-- Loop/Jump 2.1+ advanced -->
+  <!-- Loop/Jump 2.1+ advanced
+  <WidgetGroup>
     <ObjectName>DeckLoopBeatjump</ObjectName>
     <SizePolicy>min,min</SizePolicy>
     <Layout>horizontal</Layout>
@@ -67,5 +68,5 @@
       <Transform><IsEqual>3</IsEqual></Transform>
       <BindProperty>visible</BindProperty>
     </Connection>
-  </WidgetGroup><!-- /Loop/Jump 2.1+ advanced -->
+  </WidgetGroup>   -->
 </Template>

--- a/res/skins/Tango/loop_basics.xml
+++ b/res/skins/Tango/loop_basics.xml
@@ -21,12 +21,21 @@ Variables:
           <SetVariable name="ConfigKeyRight"><Variable name="group"/>,loop_in_goto</SetVariable>
         </Template>
           <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
+        <!-- ToDo(ronso0) uncomment as soon as #1187 is merged
         <Template src="skin:button_2state_right_display.xml">
           <SetVariable name="TooltipId">reloop_toggle</SetVariable>
           <SetVariable name="ObjectName">LoopIndicator</SetVariable>
           <SetVariable name="Size">45f,45f</SetVariable>
           <SetVariable name="ConfigKey"><Variable name="group"/>,reloop_toggle</SetVariable>
           <SetVariable name="ConfigKeyRight"><Variable name="group"/>,reloop_andstop</SetVariable>
+          <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,loop_enabled</SetVariable>
+        </Template> -->
+        <Template src="skin:button_2state_right_display.xml">
+          <SetVariable name="TooltipId">reloop_exit</SetVariable>
+          <SetVariable name="ObjectName">LoopIndicator</SetVariable>
+          <SetVariable name="Size">45f,45f</SetVariable>
+          <SetVariable name="ConfigKey"><Variable name="group"/>,reloop_exit</SetVariable>
+          <SetVariable name="ConfigKeyRight"><Variable name="group"/>,reloop_exit</SetVariable>
           <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,loop_enabled</SetVariable>
         </Template>
           <WidgetGroup><Size>1f,1min</Size></WidgetGroup>

--- a/res/skins/Tango/loop_scale.xml
+++ b/res/skins/Tango/loop_scale.xml
@@ -10,22 +10,23 @@ Variables:
     <Layout>vertical</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
+      <!-- ToDo (ronso0) update COs as soon as #1187 is merged -->
       <Template src="skin:button_1state.xml">
-        <SetVariable name="TooltipId">beatloop_double</SetVariable>
+        <SetVariable name="TooltipId">loop_double</SetVariable>
         <SetVariable name="ObjectName">LoopBeatJumpButton</SetVariable>
         <SetVariable name="Size">22f,22f</SetVariable>
         <SetVariable name="state_0_pressed">loopbeat_plus_hover.svg</SetVariable>
         <SetVariable name="state_0_unpressed">loopbeat_plus.svg</SetVariable>
-        <SetVariable name="ConfigKey"><Variable name="group"/>,beatloop_double</SetVariable>
+        <SetVariable name="ConfigKey"><Variable name="group"/>,loop_double</SetVariable>
       </Template>
         <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
       <Template src="skin:button_1state.xml">
-        <SetVariable name="TooltipId">beatloop_halve</SetVariable>
+        <SetVariable name="TooltipId">loop_halve</SetVariable>
         <SetVariable name="ObjectName">LoopBeatJumpButton</SetVariable>
         <SetVariable name="Size">22f,22f</SetVariable>
         <SetVariable name="state_0_pressed">loopbeat_minus_hover.svg</SetVariable>
         <SetVariable name="state_0_unpressed">loopbeat_minus.svg</SetVariable>
-        <SetVariable name="ConfigKey"><Variable name="group"/>,beatloop_halve</SetVariable>
+        <SetVariable name="ConfigKey"><Variable name="group"/>,loop_halve</SetVariable>
       </Template>
     </Children>
   </WidgetGroup>


### PR DESCRIPTION
Apparently reloop_toggle doesn't work, yet, since it's part of #1187 
Here I reverted the 2.0 loop button to reloop_exit

**Edit** Maybe the controls wiki should be reverted, as well