### PR TITLE
cut effects' input when disabling and let output trail

### DIFF
--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -35,16 +35,12 @@ class EngineEffect : public EffectsRequestHandler {
         const EffectsRequest& message,
         EffectsResponsePipe* pResponsePipe);
 
-    void process(const ChannelHandle& handle,
+    bool process(const ChannelHandle& handle,
                  const CSAMPLE* pInput, CSAMPLE* pOutput,
                  const unsigned int numSamples,
                  const unsigned int sampleRate,
                  const EffectProcessor::EnableState enableState,
                  const GroupFeatureState& groupFeatures);
-
-    bool disabled() const {
-        return m_enableState == EffectProcessor::DISABLED;
-    }
 
   private:
     QString debugString() const {
@@ -53,8 +49,9 @@ class EngineEffect : public EffectsRequestHandler {
 
     EffectManifest m_manifest;
     EffectProcessor* m_pProcessor;
-    EffectProcessor::EnableState m_enableState;
+    bool m_bEffectSlotEnabled;
     bool m_effectRampsFromDry;
+    QHash<const ChannelHandle&, EffectProcessor::EnableState> m_channelEnableState;
     // Must not be modified after construction.
     QVector<EngineEffectParameter*> m_parameters;
     QMap<QString, EngineEffectParameter*> m_parametersById;

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -62,7 +62,7 @@ class EngineEffectChain : public EffectsRequestHandler {
     ChannelStatus& getChannelStatus(const ChannelHandle& handle);
 
     QString m_id;
-    EffectProcessor::EnableState m_enableState;
+    EffectProcessor::EnableState m_chainEnableState;
     EffectChain::InsertionType m_insertionType;
     CSAMPLE m_dMix;
     QList<EngineEffect*> m_effects;


### PR DESCRIPTION
... until it gets quiet. This lets Echo and Reverb fade out instead of abruptly stopping when disabled. Addressing [Lauchpad Bug 1481170](https://bugs.launchpad.net/mixxx/+bug/1481170).

Now that I have implemented this, I am doubtful it should be merged. As discussed on Launchpad, this will be problematic for effects that generate output independent of an input signal, like a distortion, metronome, or synthesizer effect. That could be worked around by letting those effects send the effect system a signal to turn themselves off when the effect system tells them to go into the intermediate disabling state. However, that wouldn't work for external effects.

I think [post-fader effects](https://bugs.launchpad.net/mixxx/+bug/1370837) are needed accomplish what I actually wanted to achieve with this.