### PR TITLE
Components: hack to set exact center of Pots to 0.5

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -57,7 +57,12 @@
         // default attributes
         // You should probably overwrite at least some of these.
         inValueScale: function (value) {
-            return value / this.max;
+            // Hack to get exact center of pots to return 0.5
+            if (value > (this.max / 2)) {
+                return (value - 1) / (this.max - 1);
+            } else {
+                return value / (this.max + 1);
+            }
         },
         // map input in the XML file, not inValueScale
         input: function (channel, control, value, status, group) {
@@ -358,7 +363,6 @@
     };
     Pot.prototype = new Component({
         relative: false,
-        inValueScale: function (value) { return value / this.max; },
         shift: function () {
             if (this.relative) {
                 this.input = function (channel, control, value, status, group) {


### PR DESCRIPTION
Adapted from ControlPotmeterBehavior::midiValueToParameter. This should work for 14 bit MIDI Pots according to the comment in MidiController::processInputMapping (MSB of 64, LSB of 0 at center).