### PR TITLE
pan effect

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -704,6 +704,7 @@ class MixxxCore(Feature):
 
                    "effects/native/nativebackend.cpp",
                    "effects/native/bitcrushereffect.cpp",
+                   "effects/native/paneffect.cpp",
                    "effects/native/linkwitzriley8eqeffect.cpp",
                    "effects/native/bessel4lvmixeqeffect.cpp",
                    "effects/native/bessel8lvmixeqeffect.cpp",

--- a/src/effects/native/autopaneffect.cpp
+++ b/src/effects/native/autopaneffect.cpp
@@ -96,7 +96,7 @@ AutoPanEffect::AutoPanEffect(EngineEffect* pEffect, const EffectManifest& manife
 AutoPanEffect::~AutoPanEffect() {
 }
 
-void AutoPanEffect::processChannel(const ChannelHandle& handle, PanGroupState* pGroupState,
+void AutoPanEffect::processChannel(const ChannelHandle& handle, AutoPanGroupState* pGroupState,
                               const CSAMPLE* pInput,
                               CSAMPLE* pOutput, const unsigned int numSamples,
                               const unsigned int sampleRate,
@@ -108,7 +108,7 @@ void AutoPanEffect::processChannel(const ChannelHandle& handle, PanGroupState* p
         return;
     }
 
-    PanGroupState& gs = *pGroupState;
+    AutoPanGroupState& gs = *pGroupState;
     double width = m_pWidthParameter->value();
     double period = m_pPeriodParameter->value();
     double periodUnit = m_pPeriodUnitParameter->value();

--- a/src/effects/native/autopaneffect.h
+++ b/src/effects/native/autopaneffect.h
@@ -65,16 +65,13 @@ struct AutoPanGroupState {
     AutoPanGroupState() {
         time = 0;
         delay = new EngineFilterPanSingle<panMaxDelay>();
-        m_pDelayBuf = SampleUtil::alloc(MAX_BUFFER_LEN);
         m_dPreviousPeriod = -1.0;
     }
     ~AutoPanGroupState() {
-        SampleUtil::free(m_pDelayBuf);
     }
     unsigned int time;
     RampedSample frac;
     EngineFilterPanSingle<panMaxDelay>* delay;
-    CSAMPLE* m_pDelayBuf;
     double m_dPreviousPeriod;
 };
 

--- a/src/effects/native/autopaneffect.h
+++ b/src/effects/native/autopaneffect.h
@@ -61,14 +61,14 @@ class RampedSample {
 static const int panMaxDelay = 3300; // allows a 30 Hz filter at 97346;
 // static const int panMaxDelay = 50000; // high for debug;
 
-struct PanGroupState {
-    PanGroupState() {
+struct AutoPanGroupState {
+    AutoPanGroupState() {
         time = 0;
         delay = new EngineFilterPanSingle<panMaxDelay>();
         m_pDelayBuf = SampleUtil::alloc(MAX_BUFFER_LEN);
         m_dPreviousPeriod = -1.0;
     }
-    ~PanGroupState() {
+    ~AutoPanGroupState() {
         SampleUtil::free(m_pDelayBuf);
     }
     unsigned int time;
@@ -78,7 +78,7 @@ struct PanGroupState {
     double m_dPreviousPeriod;
 };
 
-class AutoPanEffect : public PerChannelEffectProcessor<PanGroupState> {
+class AutoPanEffect : public PerChannelEffectProcessor<AutoPanGroupState> {
   public:
     AutoPanEffect(EngineEffect* pEffect, const EffectManifest& manifest);
     virtual ~AutoPanEffect();
@@ -88,7 +88,7 @@ class AutoPanEffect : public PerChannelEffectProcessor<PanGroupState> {
 
     // See effectprocessor.h
     void processChannel(const ChannelHandle& handle,
-                      PanGroupState* pState,
+                        AutoPanGroupState* pState,
                       const CSAMPLE* pInput, CSAMPLE* pOutput,
                       const unsigned int numSamples,
                       const unsigned int sampleRate,

--- a/src/effects/native/nativebackend.cpp
+++ b/src/effects/native/nativebackend.cpp
@@ -4,6 +4,7 @@
 #include "effects/native/nativebackend.h"
 #include "effects/native/flangereffect.h"
 #include "effects/native/bitcrushereffect.h"
+#include "effects/native/paneffect.h"
 #include "effects/native/linkwitzriley8eqeffect.h"
 #include "effects/native/bessel8lvmixeqeffect.h"
 #include "effects/native/bessel4lvmixeqeffect.h"
@@ -36,6 +37,7 @@ NativeBackend::NativeBackend(QObject* pParent)
     registerEffect<FilterEffect>();
     registerEffect<MoogLadder4FilterEffect>();
     registerEffect<BitCrusherEffect>();
+    registerEffect<PanEffect>();
     // Fancy effects
     registerEffect<FlangerEffect>();
     registerEffect<EchoEffect>();

--- a/src/effects/native/paneffect.cpp
+++ b/src/effects/native/paneffect.cpp
@@ -1,0 +1,74 @@
+#include "effects/native/paneffect.h"
+
+// static
+QString PanEffect::getId() {
+    return "org.mixxx.effects.pan";
+}
+
+// static
+EffectManifest PanEffect::getManifest() {
+    EffectManifest manifest;
+    manifest.setId(getId());
+    manifest.setName(QObject::tr("Pan"));
+    manifest.setAuthor("The Mixxx Team");
+    manifest.setVersion("1.0");
+    manifest.setDescription(QObject::tr("Adjust the left/right balance"));
+
+    EffectManifestParameter* left = manifest.addParameter();
+    left->setId("left");
+    left->setName(QObject::tr("Left"));
+    left->setDescription(QObject::tr("Level of the left channel"));
+    left->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
+    left->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    left->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
+    left->setDefaultLinkType(EffectManifestParameter::LinkType::LINKED_RIGHT);
+    left->setDefaultLinkInversion(EffectManifestParameter::LinkInversion::INVERTED);
+    left->setMinimum(0.0);
+    left->setMaximum(1.0);
+    left->setDefault(1.0);
+
+    EffectManifestParameter* right = manifest.addParameter();
+    right->setId("right");
+    right->setName(QObject::tr("Right"));
+    right->setDescription(QObject::tr("Level of the right channel"));
+    right->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
+    right->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    right->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
+    right->setDefaultLinkType(EffectManifestParameter::LinkType::LINKED_LEFT);
+    right->setMinimum(0.0);
+    right->setMaximum(1.0);
+    right->setDefault(1.0);
+
+    return manifest;
+}
+
+PanEffect::PanEffect(EngineEffect* pEffect, const EffectManifest& manifest)
+          : m_pLeftParameter(pEffect->getParameterById("left")),
+            m_pRightParameter(pEffect->getParameterById("right")) {
+    Q_UNUSED(manifest);
+}
+
+PanEffect::~PanEffect() {
+}
+
+void PanEffect::processChannel(const ChannelHandle& handle,
+                               PanGroupState* pGroupState,
+                               const CSAMPLE* pInput,
+                               CSAMPLE* pOutput, const unsigned int numSamples,
+                               const unsigned int sampleRate,
+                               const EffectProcessor::EnableState enableState,
+                               const GroupFeatureState& groupFeatures) {
+    Q_UNUSED(handle);
+    Q_UNUSED(pGroupState);
+    Q_UNUSED(sampleRate);
+    Q_UNUSED(enableState);
+    Q_UNUSED(groupFeatures);
+
+    CSAMPLE left = m_pLeftParameter->value();
+    CSAMPLE right = m_pRightParameter->value();
+
+    for (unsigned int i = 0; i < numSamples; i += 2) {
+        pOutput[i] = pInput[i] * left;
+        pOutput[i + 1] = pInput[i + 1] * right;
+    }
+}

--- a/src/effects/native/paneffect.h
+++ b/src/effects/native/paneffect.h
@@ -1,0 +1,41 @@
+#ifndef PANEFFECT_H
+#define PANEFFECT_H
+
+#include "effects/effectprocessor.h"
+#include "engine/effects/engineeffect.h"
+#include "engine/effects/engineeffectparameter.h"
+
+// This effect does not need to store any state.
+struct PanGroupState {
+};
+
+class PanEffect : public PerChannelEffectProcessor<PanGroupState> {
+  public:
+    PanEffect(EngineEffect* pEffect, const EffectManifest& manifest);
+    virtual ~PanEffect();
+
+    static QString getId();
+    static EffectManifest getManifest();
+
+    // See effectprocessor.h
+    void processChannel(const ChannelHandle& handle,
+                        PanGroupState* pState,
+                        const CSAMPLE* pInput, CSAMPLE* pOutput,
+                        const unsigned int numSamples,
+                        const unsigned int sampleRate,
+                        const EffectProcessor::EnableState enableState,
+                        const GroupFeatureState& groupFeatures);
+
+  private:
+
+    QString debugString() const {
+        return getId();
+    }
+
+    EngineEffectParameter* m_pLeftParameter;
+    EngineEffectParameter* m_pRightParameter;
+
+    DISALLOW_COPY_AND_ASSIGN(PanEffect);
+};
+
+#endif /* PANEFFECT_H */

--- a/src/effects/native/paneffect.h
+++ b/src/effects/native/paneffect.h
@@ -34,6 +34,7 @@ class PanEffect : public PerChannelEffectProcessor<PanGroupState> {
 
     EngineEffectParameter* m_pLeftParameter;
     EngineEffectParameter* m_pRightParameter;
+    EngineEffectParameter* m_pMidSideParameter;
 
     DISALLOW_COPY_AND_ASSIGN(PanEffect);
 };


### PR DESCRIPTION
The left and right parameters attenuate their respective channels. The metaknob works like a typical pan knob on a mixer:
  * left: full left channel, no right channel
  * middle: full left and right channels
  * right: no left channel, full right channel

This is more fun than I thought it would be. Try chaining Pan -> Filter -> Echo, unlinking the Filter's LPF parameter, using the left-and-right linking for the HPF parameter, and moving the Pan & Filter metaknobs in opposite directions.

Implementing [Launchpad ticket #1689095](https://bugs.launchpad.net/mixxx/+bug/1689095)