### PR TITLE
mixxx::Logger

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -1128,6 +1128,7 @@ class MixxxCore(Feature):
                    "util/singularsamplebuffer.cpp",
                    "util/circularsamplebuffer.cpp",
                    "util/rotary.cpp",
+                   "util/logger.cpp",
                    "util/logging.cpp",
                    "util/cmdlineargs.cpp",
                    "util/audiosignal.cpp",

--- a/plugins/soundsourcem4a/SConscript
+++ b/plugins/soundsourcem4a/SConscript
@@ -19,6 +19,7 @@ m4a_sources = [
     "util/samplebuffer.cpp",
     "util/singularsamplebuffer.cpp",
     "util/sample.cpp",
+    "util/logging.cpp",
     "track/trackmetadata.cpp",
     "track/trackmetadatataglib.cpp",
     "track/tracknumbers.cpp",

--- a/plugins/soundsourcem4a/SConscript
+++ b/plugins/soundsourcem4a/SConscript
@@ -19,7 +19,7 @@ m4a_sources = [
     "util/samplebuffer.cpp",
     "util/singularsamplebuffer.cpp",
     "util/sample.cpp",
-    "util/logging.cpp",
+    "util/logger.cpp",
     "track/trackmetadata.cpp",
     "track/trackmetadatataglib.cpp",
     "track/tracknumbers.cpp",

--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -1,6 +1,7 @@
 #include "soundsourcem4a.h"
 
 #include "util/sample.h"
+#include "util/logging.h"
 
 #ifdef __WINDOWS__
 #include <io.h>
@@ -22,6 +23,8 @@ typedef unsigned long SAMPLERATE_TYPE;
 namespace mixxx {
 
 namespace {
+
+const Logger kLogger("SoundSourceM4A");
 
 // MP4SampleId is 1-based
 const MP4SampleId kSampleBlockIdMin = 1;
@@ -85,9 +88,9 @@ MP4TrackId findFirstAudioTrackId(MP4FileHandle hFile, const QString& fileName) {
     for (u_int32_t trackId = kMinTrackId; trackId <= maxTrackId; ++trackId) {
         const char* trackType = MP4GetTrackType(hFile, trackId);
         if (!isValidTrackType(trackType)) {
-            qWarning() << "Unsupported track type"
+            kLogger.warning() << "Unsupported track type"
                     << QString((trackType == nullptr) ? "" : trackType);
-            qWarning() << "Skipping track"
+            kLogger.warning() << "Skipping track"
                     << trackId
                     << "of"
                     << maxTrackId
@@ -97,9 +100,9 @@ MP4TrackId findFirstAudioTrackId(MP4FileHandle hFile, const QString& fileName) {
         }
         const char* mediaDataName = MP4GetTrackMediaDataName(hFile, trackId);
         if (!isValidMediaDataName(mediaDataName)) {
-            qWarning() << "Unsupported media data name"
+            kLogger.warning() << "Unsupported media data name"
                     << QString((mediaDataName == nullptr) ? "" : mediaDataName);
-            qWarning() << "Skipping track"
+            kLogger.warning() << "Skipping track"
                     << trackId
                     << "of"
                     << maxTrackId
@@ -115,9 +118,9 @@ MP4TrackId findFirstAudioTrackId(MP4FileHandle hFile, const QString& fileName) {
                 if (MP4_IS_MPEG4_AAC_AUDIO_TYPE(mpeg4AudioType)) {
                     return trackId;
                 } else {
-                    qWarning() << "Unsupported MPEG4 audio type"
+                    kLogger.warning() << "Unsupported MPEG4 audio type"
                             << int(mpeg4AudioType);
-                    qWarning() << "Skipping track"
+                    kLogger.warning() << "Skipping track"
                             << trackId
                             << "of"
                             << maxTrackId
@@ -129,9 +132,9 @@ MP4TrackId findFirstAudioTrackId(MP4FileHandle hFile, const QString& fileName) {
                 return trackId;
             }
         } else {
-            qWarning() << "Unsupported audio type"
+            kLogger.warning() << "Unsupported audio type"
                     << int(audioType);
-            qWarning() << "Skipping track"
+            kLogger.warning() << "Skipping track"
                     << trackId
                     << "of"
                     << maxTrackId
@@ -140,7 +143,7 @@ MP4TrackId findFirstAudioTrackId(MP4FileHandle hFile, const QString& fileName) {
             continue;
         }
         VERIFY_OR_DEBUG_ASSERT(!"unreachable code") {
-            qWarning() << "Skipping track"
+            kLogger.warning() << "Skipping track"
                     << trackId
                     << "of"
                     << maxTrackId
@@ -185,13 +188,13 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSr
     m_hFile = MP4Read(getLocalFileName().toUtf8().constData());
 #endif
     if (MP4_INVALID_FILE_HANDLE == m_hFile) {
-        qWarning() << "Failed to open file for reading:" << getUrlString();
+        kLogger.warning() << "Failed to open file for reading:" << getUrlString();
         return OpenResult::FAILED;
     }
 
     m_trackId = findFirstAudioTrackId(m_hFile, getLocalFileName());
     if (MP4_INVALID_TRACK_ID == m_trackId) {
-        qWarning() << "No AAC track found:" << getUrlString();
+        kLogger.warning() << "No AAC track found:" << getUrlString();
         return OpenResult::ABORTED;
     }
 
@@ -201,7 +204,7 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSr
     // can't currently handle these.
     m_framesPerSampleBlock = MP4GetTrackFixedSampleDuration(m_hFile, m_trackId);
     if (MP4_INVALID_DURATION == m_framesPerSampleBlock) {
-      qWarning() << "Unable to determine the fixed sample duration of track"
+      kLogger.warning() << "Unable to determine the fixed sample duration of track"
               << m_trackId << "in file" << getUrlString();
       // TODO(XXX): The following check for FFmpeg or any another available
       // AAC decoder should be done at runtime and not at compile time.
@@ -217,7 +220,7 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSr
 #else
       // Fallback: Use a default value if FFmpeg is not available (checked
       // at compile time).
-      qWarning() << "Fallback: Using a default sample duration of"
+      kLogger.warning() << "Fallback: Using a default sample duration of"
               << kDefaultFramesPerSampleBlock << "sample frames per block";
       m_framesPerSampleBlock = kDefaultFramesPerSampleBlock;
 #endif // __FFMPEGFILE__
@@ -226,7 +229,7 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSr
     const MP4SampleId numberOfSamples =
             MP4GetTrackNumberOfSamples(m_hFile, m_trackId);
     if (0 >= numberOfSamples) {
-        qWarning() << "Failed to read number of samples from file:" << getUrlString();
+        kLogger.warning() << "Failed to read number of samples from file:" << getUrlString();
         return OpenResult::FAILED;
     }
     m_maxSampleBlockId = kSampleBlockIdMin + (numberOfSamples - 1);
@@ -236,7 +239,7 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSr
     const u_int32_t maxSampleBlockInputSize = MP4GetTrackMaxSampleSize(m_hFile,
             m_trackId);
     if (maxSampleBlockInputSize == 0) {
-        qWarning() << "Failed to read MP4 DecoderConfigDescriptor.bufferSizeDB:"
+        kLogger.warning() << "Failed to read MP4 DecoderConfigDescriptor.bufferSizeDB:"
                 << getUrlString();
         return OpenResult::FAILED;
     }
@@ -244,7 +247,7 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(const AudioSourceConfig& audioSr
         // Workaround for a possible bug in libmp4v2 2.0.0 (Ubuntu 16.04)
         // that returns 4278190742 when opening a corrupt file.
         // https://bugs.launchpad.net/mixxx/+bug/1594169
-        qWarning() << "MP4 DecoderConfigDescriptor.bufferSizeDB ="
+        kLogger.warning() << "MP4 DecoderConfigDescriptor.bufferSizeDB ="
                 << maxSampleBlockInputSize
                 << ">"
                 << kMaxSampleBlockInputSizeLimit
@@ -268,7 +271,7 @@ bool SoundSourceM4A::openDecoder() {
 
     m_hDecoder = NeAACDecOpen();
     if (m_hDecoder == nullptr) {
-        qWarning() << "Failed to open the AAC decoder!";
+        kLogger.warning() << "Failed to open the AAC decoder!";
         return false;
     }
     NeAACDecConfigurationPtr pDecoderConfig = NeAACDecGetCurrentConfiguration(
@@ -283,7 +286,7 @@ bool SoundSourceM4A::openDecoder() {
 
     pDecoderConfig->defObjectType = LC;
     if (!NeAACDecSetConfiguration(m_hDecoder, pDecoderConfig)) {
-        qWarning() << "Failed to configure AAC decoder!";
+        kLogger.warning() << "Failed to configure AAC decoder!";
         return false;
     }
 
@@ -293,7 +296,7 @@ bool SoundSourceM4A::openDecoder() {
             &configBufferSize)) {
         // Failed to get mpeg-4 audio config... this is ok.
         // NeAACDecInit2() will simply use default values instead.
-        qWarning() << "Failed to read the MP4 audio configuration."
+        kLogger.warning() << "Failed to read the MP4 audio configuration."
                 << "Continuing with default values.";
     }
 
@@ -302,7 +305,7 @@ bool SoundSourceM4A::openDecoder() {
     if (0 > NeAACDecInit2(m_hDecoder, configBuffer, configBufferSize,
                     &samplingRate, &channelCount)) {
         free(configBuffer);
-        qWarning() << "Failed to initialize the AAC decoder!";
+        kLogger.warning() << "Failed to initialize the AAC decoder!";
         return false;
     } else {
         free(configBuffer);
@@ -431,7 +434,7 @@ SINT SoundSourceM4A::seekSampleFrame(SINT frameIndex) {
     const SINT skipFrameCount = skipSampleFrames(prefetchFrameCount);
     DEBUG_ASSERT(skipFrameCount <= prefetchFrameCount);
     if (skipFrameCount < prefetchFrameCount) {
-        qWarning() << "Failed to prefetch sample data while seeking"
+        kLogger.warning() << "Failed to prefetch sample data while seeking"
                 << skipFrameCount << "<" << prefetchFrameCount;
     }
 
@@ -479,7 +482,7 @@ SINT SoundSourceM4A::readSampleFrames(
                 if (!MP4ReadSample(m_hFile, m_trackId, m_curSampleBlockId,
                         &pInputBuffer, &inputBufferLength,
                         nullptr, nullptr, nullptr, nullptr)) {
-                    qWarning()
+                    kLogger.warning()
                             << "Failed to read MP4 input data for sample block"
                             << m_curSampleBlockId << "(" << "min ="
                             << kSampleBlockIdMin << "," << "max ="
@@ -527,7 +530,7 @@ SINT SoundSourceM4A::readSampleFrames(
                 decodeBufferCapacity * sizeof(*pDecodeBuffer));
         // Verify the decoding result
         if (0 != decFrameInfo.error) {
-            qWarning() << "AAC decoding error:"
+            kLogger.warning() << "AAC decoding error:"
                     << decFrameInfo.error
                     << NeAACDecGetErrorMessage(decFrameInfo.error)
                     << getUrlString();
@@ -537,13 +540,13 @@ SINT SoundSourceM4A::readSampleFrames(
 
         // Verify the decoded sample data for consistency
         if (getChannelCount() != decFrameInfo.channels) {
-            qWarning() << "Corrupt or unsupported AAC file:"
+            kLogger.warning() << "Corrupt or unsupported AAC file:"
                     << "Unexpected number of channels" << decFrameInfo.channels
                     << "<>" << getChannelCount();
             break; // abort
         }
         if (getSamplingRate() != SINT(decFrameInfo.samplerate)) {
-            qWarning() << "Corrupt or unsupported AAC file:"
+            kLogger.warning() << "Corrupt or unsupported AAC file:"
                     << "Unexpected sampling rate" << decFrameInfo.samplerate
                     << "<>" << getSamplingRate();
             break; // abort

--- a/plugins/soundsourcem4a/soundsourcem4a.cpp
+++ b/plugins/soundsourcem4a/soundsourcem4a.cpp
@@ -1,7 +1,7 @@
 #include "soundsourcem4a.h"
 
 #include "util/sample.h"
-#include "util/logging.h"
+#include "util/logger.h"
 
 #ifdef __WINDOWS__
 #include <io.h>

--- a/plugins/soundsourcemediafoundation/SConscript
+++ b/plugins/soundsourcemediafoundation/SConscript
@@ -27,7 +27,7 @@ if int(build.flags['mediafoundation']):
          'util/singularsamplebuffer.cpp',
          'util/samplebuffer.cpp',
          'util/sample.cpp',
-         'util/logging.cpp',
+         'util/logger.cpp',
          'track/trackmetadata.cpp',
          'track/trackmetadatataglib.cpp',
          'track/tracknumbers.cpp',

--- a/plugins/soundsourcemediafoundation/SConscript
+++ b/plugins/soundsourcemediafoundation/SConscript
@@ -27,6 +27,7 @@ if int(build.flags['mediafoundation']):
          'util/singularsamplebuffer.cpp',
          'util/samplebuffer.cpp',
          'util/sample.cpp',
+         'util/logging.cpp',
          'track/trackmetadata.cpp',
          'track/trackmetadatataglib.cpp',
          'track/tracknumbers.cpp',

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -5,10 +5,11 @@
 #include <propvarutil.h>
 
 #include "util/sample.h"
+#include "util/logging.h"
 
 namespace {
 
-const char* const kLogPreamble = "SoundSourceMediaFoundation:";
+const mixxx::Logger kLogger("SoundSourceMediaFoundation");
 
 const SINT kBytesPerSample = sizeof(CSAMPLE);
 const SINT kBitsPerSample = kBytesPerSample * 8;
@@ -54,7 +55,7 @@ SoundSourceMediaFoundation::~SoundSourceMediaFoundation() {
 
 SoundSource::OpenResult SoundSourceMediaFoundation::tryOpen(const AudioSourceConfig& audioSrcCfg) {
     VERIFY_OR_DEBUG_ASSERT(!SUCCEEDED(m_hrCoInitialize)) {
-        qWarning() << kLogPreamble
+        kLogger.warning()
                 << "Cannot reopen file"
                 << getUrlString();
         return OpenResult::FAILED;
@@ -66,14 +67,14 @@ SoundSource::OpenResult SoundSourceMediaFoundation::tryOpen(const AudioSourceCon
     m_hrCoInitialize = CoInitializeEx(nullptr,
             COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
     if (FAILED(m_hrCoInitialize)) {
-        qWarning() << kLogPreamble
+        kLogger.warning()
                 << "failed to initialize COM";
         return OpenResult::FAILED;
     }
     // Initialize the Media Foundation platform.
     m_hrMFStartup = MFStartup(MF_VERSION);
     if (FAILED(m_hrCoInitialize)) {
-        qWarning() << kLogPreamble
+        kLogger.warning()
                 << "failed to initialize Media Foundation";
         return OpenResult::FAILED;
     }
@@ -89,14 +90,14 @@ SoundSource::OpenResult SoundSourceMediaFoundation::tryOpen(const AudioSourceCon
             &m_pSourceReader);
 
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble
+        kLogger.warning()
                 << "Error opening input file:"
                 << fileName;
         return OpenResult::FAILED;
     }
 
     if (!configureAudioStream(audioSrcCfg)) {
-        qWarning() << kLogPreamble
+        kLogger.warning()
                 << "Failed to configure audio stream";
         return OpenResult::FAILED;
     }
@@ -104,7 +105,7 @@ SoundSource::OpenResult SoundSourceMediaFoundation::tryOpen(const AudioSourceCon
     m_streamUnitConverter = StreamUnitConverter(getSamplingRate());
 
     if (!readProperties()) {
-        qWarning() << kLogPreamble
+        kLogger.warning()
                 << "Failed to read file properties";
         return OpenResult::FAILED;
     }
@@ -208,7 +209,7 @@ SINT SoundSourceMediaFoundation::seekSampleFrame(
                 skipSampleFrames(frameIndex - m_currentFrameIndex);
             }
             if (m_currentFrameIndex != frameIndex) {
-                qWarning() << kLogPreamble
+                kLogger.warning()
                         << "Seek to frame"
                         << frameIndex
                         << "failed";
@@ -223,7 +224,7 @@ SINT SoundSourceMediaFoundation::seekSampleFrame(
             m_currentFrameIndex = frameIndex;
         }
     } else {
-        qWarning() << kLogPreamble
+        kLogger.warning()
                 << "IMFSourceReader::SetCurrentPosition() failed"
                 << hrSetCurrentPosition;
         safeRelease(&m_pSourceReader); // kill the reader
@@ -279,7 +280,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
                         &streamPos,   // [out] LONGLONG *pllTimestamp,
                         &pSample);    // [out] IMFSample **ppSample
         if (FAILED(hrReadSample)) {
-            qWarning() << kLogPreamble
+            kLogger.warning()
                     << "IMFSourceReader::ReadSample() failed"
                     << hrReadSample
                     << "-> abort decoding";
@@ -287,7 +288,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
             break; // abort
         }
         if (dwFlags & MF_SOURCE_READERF_ERROR) {
-            qWarning() << kLogPreamble
+            kLogger.warning()
                     << "IMFSourceReader::ReadSample()"
                     << "detected stream errors"
                     << "(MF_SOURCE_READERF_ERROR)"
@@ -299,7 +300,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
             DEBUG_ASSERT(pSample == nullptr);
             break; // finished reading
         } else if (dwFlags & MF_SOURCE_READERF_CURRENTMEDIATYPECHANGED) {
-            qWarning() << kLogPreamble
+            kLogger.warning()
                     << "IMFSourceReader::ReadSample()"
                     << "detected that the media type has changed"
                     << "(MF_SOURCE_READERF_CURRENTMEDIATYPECHANGED)"
@@ -318,7 +319,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
         HRESULT hrGetBufferCount =
                 pSample->GetBufferCount(&dwSampleBufferCount);
         if (FAILED(hrGetBufferCount)) {
-            qWarning() << kLogPreamble
+            kLogger.warning()
                     << "IMFSample::GetBufferCount() failed"
                     << hrGetBufferCount
                     << "-> abort decoding";
@@ -329,7 +330,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
         DWORD dwSampleTotalLengthInBytes = 0;
         HRESULT hrGetTotalLength = pSample->GetTotalLength(&dwSampleTotalLengthInBytes);
         if (FAILED(hrGetTotalLength)) {
-            qWarning() << kLogPreamble
+            kLogger.warning()
                     << "IMFSample::GetTotalLength() failed"
                     << hrGetTotalLength
                     << "-> abort decoding";
@@ -346,7 +347,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
             sampleBufferCapacity *= 2;
         }
         if (m_sampleBuffer.getCapacity() < sampleBufferCapacity) {
-            qDebug() << kLogPreamble
+            kLogger.debug()
                     << "Enlarging sample buffer capacity"
                     << m_sampleBuffer.getCapacity()
                     << "->"
@@ -359,7 +360,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
             IMFMediaBuffer* pMediaBuffer = nullptr;
             HRESULT hrGetBufferByIndex = pSample->GetBufferByIndex(dwSampleBufferIndex, &pMediaBuffer);
             if (FAILED(hrGetBufferByIndex)) {
-                qWarning() << kLogPreamble
+                kLogger.warning()
                         << "IMFSample::GetBufferByIndex() failed"
                         << hrGetBufferByIndex
                         << "-> abort decoding";
@@ -374,7 +375,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
                     nullptr,
                     &lockedSampleBufferLengthInBytes);
             if (FAILED(hrLock)) {
-                qWarning() << kLogPreamble
+                kLogger.warning()
                         << "IMFMediaBuffer::Lock() failed"
                         << hrLock
                         << "-> abort decoding";
@@ -413,7 +414,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
                     writableChunk.size());
             HRESULT hrUnlock = pMediaBuffer->Unlock();
             VERIFY_OR_DEBUG_ASSERT(SUCCEEDED(hrUnlock)) {
-                qWarning() << kLogPreamble
+                kLogger.warning()
                         << "IMFMediaBuffer::Unlock() failed"
                         << hrUnlock;
                 // ignore and continue
@@ -424,7 +425,7 @@ SINT SoundSourceMediaFoundation::readSampleFrames(
         safeRelease(&pSample);
         if (dwSampleBufferIndex < dwSampleBufferCount) {
             // Failed to read data from all buffers -> kill the reader
-            qWarning() << kLogPreamble
+            kLogger.warning()
                     << "Failed to read all buffered samples"
                     << "-> abort and stop decoding";
             safeRelease(&m_pSourceReader);
@@ -456,7 +457,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     hr = m_pSourceReader->SetStreamSelection(
             MF_SOURCE_READER_ALL_STREAMS, false);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to deselect all streams";
         return false;
     }
@@ -464,7 +465,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     hr = m_pSourceReader->SetStreamSelection(
             kStreamIndex, true);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to select first audio stream";
         return false;
     }
@@ -474,7 +475,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     hr = m_pSourceReader->GetCurrentMediaType(
             kStreamIndex, &pAudioType);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to get current media type from stream";
         return false;
     }
@@ -484,7 +485,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
 
     hr = pAudioType->GetUINT32(MF_MT_AUDIO_AVG_BYTES_PER_SECOND, &avgBytesPerSecond);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "error getting MF_MT_AUDIO_AVG_BYTES_PER_SECOND";
         return false;
     }
@@ -494,7 +495,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
 
     hr = pAudioType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Audio);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to set major type to audio";
         safeRelease(&pAudioType);
         return false;
@@ -502,7 +503,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
 
     hr = pAudioType->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_Float);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to set subtype format to float";
         safeRelease(&pAudioType);
         return false;
@@ -510,7 +511,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
 
     hr = pAudioType->SetUINT32(MF_MT_ALL_SAMPLES_INDEPENDENT, true);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to set all samples independent";
         safeRelease(&pAudioType);
         return false;
@@ -518,7 +519,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
 
     hr = pAudioType->SetUINT32(MF_MT_FIXED_SIZE_SAMPLES, true);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to set fixed size samples";
         safeRelease(&pAudioType);
         return false;
@@ -527,7 +528,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     hr = pAudioType->SetUINT32(
             MF_MT_AUDIO_BITS_PER_SAMPLE, kBitsPerSample);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to set bits per sample:"
                 << kBitsPerSample;
         safeRelease(&pAudioType);
@@ -538,7 +539,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     hr = pAudioType->SetUINT32(
             MF_MT_SAMPLE_SIZE, sampleSize);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to set sample size:"
                 << sampleSize;
         safeRelease(&pAudioType);
@@ -549,7 +550,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     hr = pAudioType->GetUINT32(
             MF_MT_AUDIO_NUM_CHANNELS, &numChannels);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to get actual number of channels";
         return false;
     } else {
@@ -560,7 +561,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
         hr = pAudioType->SetUINT32(
                 MF_MT_AUDIO_NUM_CHANNELS, numChannels);
         if (FAILED(hr)) {
-            qWarning() << kLogPreamble << hr
+            kLogger.warning() << hr
                     << "failed to set number of channels:"
                     << numChannels;
             safeRelease(&pAudioType);
@@ -573,7 +574,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     hr = pAudioType->GetUINT32(
             MF_MT_AUDIO_SAMPLES_PER_SECOND, &samplesPerSecond);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to get samples per second";
         return false;
     } else {
@@ -584,7 +585,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
         hr = pAudioType->SetUINT32(
                 MF_MT_AUDIO_SAMPLES_PER_SECOND, samplesPerSecond);
         if (FAILED(hr)) {
-            qWarning() << kLogPreamble << hr
+            kLogger.warning() << hr
                     << "failed to set samples per second:"
                     << samplesPerSecond;
             safeRelease(&pAudioType);
@@ -598,7 +599,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     hr = m_pSourceReader->SetCurrentMediaType(
             kStreamIndex, nullptr, pAudioType);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to set media type";
         safeRelease(&pAudioType);
         return false;
@@ -611,7 +612,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     hr = m_pSourceReader->GetCurrentMediaType(
             kStreamIndex, &pAudioType);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to retrieve completed media type";
         return false;
     }
@@ -620,7 +621,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     hr = m_pSourceReader->SetStreamSelection(
             kStreamIndex, true);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to select first audio stream (again)";
         return false;
     }
@@ -628,7 +629,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     hr = pAudioType->GetUINT32(
             MF_MT_AUDIO_NUM_CHANNELS, &numChannels);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to get actual number of channels";
         return false;
     }
@@ -637,7 +638,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     hr = pAudioType->GetUINT32(
             MF_MT_AUDIO_SAMPLES_PER_SECOND, &samplesPerSecond);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to get the actual sample rate";
         return false;
     }
@@ -646,14 +647,14 @@ bool SoundSourceMediaFoundation::configureAudioStream(const AudioSourceConfig& a
     UINT32 leftoverBufferSizeInBytes = 0;
     hr = pAudioType->GetUINT32(MF_MT_SAMPLE_SIZE, &leftoverBufferSizeInBytes);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << hr
+        kLogger.warning() << hr
                 << "failed to get sample buffer size (in bytes)";
         return false;
     }
     DEBUG_ASSERT((leftoverBufferSizeInBytes % kBytesPerSample) == 0);
     m_sampleBuffer.resetCapacity(leftoverBufferSizeInBytes / kBytesPerSample);
     DEBUG_ASSERT(m_sampleBuffer.getCapacity() > 0);
-    qDebug() << kLogPreamble
+    kLogger.debug()
             << "Sample buffer capacity"
             << m_sampleBuffer.getCapacity();
 
@@ -672,11 +673,11 @@ bool SoundSourceMediaFoundation::readProperties() {
     hr = m_pSourceReader->GetPresentationAttribute(MF_SOURCE_READER_MEDIASOURCE,
         MF_PD_DURATION, &prop);
     if (FAILED(hr)) {
-        qWarning() << kLogPreamble << "error getting duration";
+        kLogger.warning() << "error getting duration";
         return false;
     }
     setFrameCount(m_streamUnitConverter.toFrameIndex(prop.hVal.QuadPart));
-    qDebug() << kLogPreamble << "Frame count" << getFrameCount();
+    kLogger.debug() << "Frame count" << getFrameCount();
     PropVariantClear(&prop);
 
    

--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.cpp
@@ -5,7 +5,7 @@
 #include <propvarutil.h>
 
 #include "util/sample.h"
-#include "util/logging.h"
+#include "util/logger.h"
 
 namespace {
 

--- a/plugins/soundsourcewv/SConscript
+++ b/plugins/soundsourcewv/SConscript
@@ -19,6 +19,7 @@ wv_sources = [
     "util/samplebuffer.cpp",
     "util/singularsamplebuffer.cpp",
     "util/sample.cpp",
+    "util/logging.cpp",
     "track/trackmetadata.cpp",
     "track/trackmetadatataglib.cpp",
     "track/tracknumbers.cpp",

--- a/plugins/soundsourcewv/SConscript
+++ b/plugins/soundsourcewv/SConscript
@@ -19,7 +19,7 @@ wv_sources = [
     "util/samplebuffer.cpp",
     "util/singularsamplebuffer.cpp",
     "util/sample.cpp",
-    "util/logging.cpp",
+    "util/logger.cpp",
     "track/trackmetadata.cpp",
     "track/trackmetadatataglib.cpp",
     "track/tracknumbers.cpp",

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -1,8 +1,16 @@
-#include "soundsourcewv.h"
-
 #include <QFile>
 
+#include "soundsourcewv.h"
+
+#include "util/logging.h"
+
 namespace mixxx {
+
+namespace {
+
+const Logger kLogger("SoundSourceWV");
+
+} // anonymous namespace
 
 //static
 WavpackStreamReader SoundSourceWV::s_streamReader = {
@@ -52,7 +60,7 @@ SoundSource::OpenResult SoundSourceWV::tryOpen(const AudioSourceConfig& audioSrc
     m_wpc = WavpackOpenFileInputEx(&s_streamReader, m_pWVFile, m_pWVCFile,
             msg, openFlags, 0);
     if (!m_wpc) {
-        qDebug() << "SSWV::open: failed to open file : " << msg;
+        kLogger.debug() << "failed to open file : " << msg;
         return OpenResult::FAILED;
     }
 
@@ -107,7 +115,7 @@ SINT SoundSourceWV::seekSampleFrame(SINT frameIndex) {
         m_curFrameIndex = frameIndex;
         return frameIndex;
     } else {
-        qDebug() << "SSWV::seek : could not seek to frame #" << frameIndex;
+        kLogger.debug() << "could not seek to frame #" << frameIndex;
         return WavpackGetSampleIndex(m_wpc);
     }
 }

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -2,7 +2,7 @@
 
 #include "soundsourcewv.h"
 
-#include "util/logging.h"
+#include "util/logger.h"
 
 namespace mixxx {
 

--- a/src/library/dao/autodjcratesdao.cpp
+++ b/src/library/dao/autodjcratesdao.cpp
@@ -42,6 +42,7 @@ AutoDJCratesDAO::AutoDJCratesDAO(
         TrackCollection* pTrackCollection,
         UserSettingsPointer a_pConfig)
         : m_pTrackCollection(pTrackCollection),
+          m_database(pTrackCollection->database()),
           m_pConfig (a_pConfig),
           // The database has not been created yet.
           m_bAutoDjCratesDbCreated(false),

--- a/src/library/hiddentablemodel.cpp
+++ b/src/library/hiddentablemodel.cpp
@@ -14,7 +14,7 @@ HiddenTableModel::~HiddenTableModel() {
 
 void HiddenTableModel::setTableModel(int id) {
     Q_UNUSED(id);
-    QSqlQuery query;
+    QSqlQuery query(m_database);
     const QString tableName("hidden_songs");
 
     QStringList columns;

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -1,8 +1,15 @@
 #include "sources/audiosource.h"
 
 #include "util/sample.h"
+#include "util/logging.h"
 
 namespace mixxx {
+
+namespace {
+
+const Logger kLogger("AudioSource");
+
+} // anonymous namespace
 
 /*static*/ constexpr AudioSignal::SampleLayout AudioSource::kSampleLayout;
 
@@ -86,7 +93,7 @@ SINT AudioSource::readSampleFramesStereo(
                 return readFrameCount;
             } else {
                 // inefficient transformation through a temporary buffer
-                qDebug() << "Performance warning:"
+                kLogger.debug() << "Performance warning:"
                         << "Allocating a temporary buffer of size"
                         << numberOfSamplesToRead << "for reading stereo samples."
                         << "The size of the provided sample buffer is"
@@ -106,7 +113,7 @@ bool AudioSource::verifyReadable() const {
     bool result = AudioSignal::verifyReadable();
     if (hasBitrate()) {
         VERIFY_OR_DEBUG_ASSERT(isValidBitrate(m_bitrate)) {
-            qWarning() << "Invalid bitrate [kbps]:"
+            kLogger.warning() << "Invalid bitrate [kbps]:"
                     << getBitrate();
             // Don't set the result to false, because bitrate is only
             // an  informational property that does not effect the ability
@@ -114,7 +121,7 @@ bool AudioSource::verifyReadable() const {
         }
     }
     if (isEmpty()) {
-        qWarning() << "AudioSource is empty and does not provide any audio data!";
+        kLogger.warning() << "No audio data available";
         // Don't set the result to false, even if reading from an empty source
         // is pointless!
     }

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -1,7 +1,7 @@
 #include "sources/audiosource.h"
 
 #include "util/sample.h"
-#include "util/logging.h"
+#include "util/logger.h"
 
 namespace mixxx {
 

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -2,10 +2,13 @@
 #include "sources/mp3decoding.h"
 
 #include "util/math.h"
+#include "util/logging.h"
 
 namespace mixxx {
 
 namespace {
+
+const Logger kLogger("SoundSourceCoreAudio");
 
 // The maximum number of samples per MP3 frame
 const SINT kMp3MaxFrameSize = 1152;
@@ -61,7 +64,7 @@ SoundSource::OpenResult SoundSourceCoreAudio::tryOpen(const AudioSourceConfig& a
      */
 
     if (err != noErr) {
-        qDebug() << "SSCA: Error opening file " << fileName;
+        kLogger.debug() << "Error opening file " << fileName;
         return OpenResult::FAILED;
     }
 
@@ -71,7 +74,7 @@ SoundSource::OpenResult SoundSourceCoreAudio::tryOpen(const AudioSourceConfig& a
             kExtAudioFileProperty_FileDataFormat, &inputFormatSize,
             &m_inputFormat);
     if (err != noErr) {
-        qDebug() << "SSCA: Error getting file format (" << fileName << ")";
+        kLogger.debug() << "Error getting file format (" << fileName << ")";
         return OpenResult::ABORTED;
     }
     m_bFileIsMp3 = m_inputFormat.mFormatID == kAudioFormatMPEGLayer3;
@@ -87,7 +90,7 @@ SoundSource::OpenResult SoundSourceCoreAudio::tryOpen(const AudioSourceConfig& a
             kExtAudioFileProperty_ClientDataFormat, sizeof(m_outputFormat),
             &m_outputFormat);
     if (err != noErr) {
-        qDebug() << "SSCA: Error setting file property";
+        kLogger.debug() << "Error setting file property";
         return OpenResult::FAILED;
     }
 
@@ -98,7 +101,7 @@ SoundSource::OpenResult SoundSourceCoreAudio::tryOpen(const AudioSourceConfig& a
             kExtAudioFileProperty_FileLengthFrames, &totalFrameCountSize,
             &totalFrameCount);
     if (err != noErr) {
-        qDebug() << "SSCA: Error getting number of frames";
+        kLogger.debug() << "Error getting number of frames";
         return OpenResult::FAILED;
     }
 
@@ -158,9 +161,9 @@ SINT SoundSourceCoreAudio::seekSampleFrame(SINT frameIndex) {
     }
 
     //_ThrowExceptionIfErr(@"ExtAudioFileSeek", err);
-    //qDebug() << "SSCA: Seeking to" << frameIndex;
+    //kLogger.debug() << "Seeking to" << frameIndex;
     if (err != noErr) {
-        qDebug() << "SSCA: Error seeking to" << frameIndex; // << GetMacOSStatusErrorString(err) << GetMacOSStatusCommentString(err);
+        kLogger.debug() << "Error seeking to" << frameIndex; // << GetMacOSStatusErrorString(err) << GetMacOSStatusCommentString(err);
     }
     return frameIndex;
 }
@@ -182,7 +185,7 @@ SINT SoundSourceCoreAudio::readSampleFrames(
             DEBUG_ASSERT(frameIndexBefore <= frameIndexAfter);
             return frameIndexAfter - frameIndexBefore;
         } else {
-            qWarning() << "SSCA: Error to determine the current position for skipping sample frames" << osErr;
+            kLogger.warning() << "Error to determine the current position for skipping sample frames" << osErr;
             return 0; // abort
         }
     }

--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -2,7 +2,7 @@
 #include "sources/mp3decoding.h"
 
 #include "util/math.h"
-#include "util/logging.h"
+#include "util/logger.h"
 
 namespace mixxx {
 

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -2,6 +2,8 @@
 
 #include "encoder/encoderffmpegresample.h"
 
+#include "util/logging.h"
+
 #include <mutex>
 #include <vector>
 
@@ -16,6 +18,8 @@
 namespace mixxx {
 
 namespace {
+
+const Logger kLogger("SoundSourceFFmpeg");
 
 std::once_flag initFFmpegLibFlag;
 
@@ -80,7 +84,7 @@ bool getFrameCountOfStream(AVStream* pStream, SINT* pFrameCount) {
     int64val *= getSamplingRateOfStream(pStream);
     VERIFY_OR_DEBUG_ASSERT(int64val > 0) {
         // Integer overflow
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "Integer overflow during calculation of frame count";
         return false;
     }
@@ -88,7 +92,7 @@ bool getFrameCountOfStream(AVStream* pStream, SINT* pFrameCount) {
     int64val *= pStream->time_base.num;
     VERIFY_OR_DEBUG_ASSERT(int64val > 0) {
         // Integer overflow
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "Integer overflow during calculation of frame count";
         return false;
     }
@@ -97,7 +101,7 @@ bool getFrameCountOfStream(AVStream* pStream, SINT* pFrameCount) {
     SINT frameCount = int64val;
     VERIFY_OR_DEBUG_ASSERT(static_cast<int64_t>(frameCount) == int64val) {
         // Integer truncation
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "Integer truncation during calculation of frame count";
         return false;
     }
@@ -125,7 +129,7 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileExtensions() const {
             break; // exit loop
         }
 
-        qDebug() << "FFmpeg input format:" << l_SInputFmt->name;
+        kLogger.debug() << "FFmpeg input format:" << l_SInputFmt->name;
 
         if (!strcmp(l_SInputFmt->name, "ac3")) {
             list.append("ac3");
@@ -175,7 +179,7 @@ AVFormatContext* SoundSourceFFmpeg::openInputFile(
     // the AVFormatContext struct before opening the input file???
     AVFormatContext *pInputFormatContext = avformat_alloc_context();
     if (pInputFormatContext == nullptr) {
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "avformat_alloc_context() failed";
         return nullptr;
     }
@@ -203,7 +207,7 @@ AVFormatContext* SoundSourceFFmpeg::openInputFile(
             avformat_open_input(
                     &pInputFormatContext, qBAFilename.constData(), nullptr, nullptr);
     if (avformat_open_input_result != 0) {
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "avformat_open_input() failed and returned"
                 << avformat_open_input_result;
         DEBUG_ASSERT(pInputFormatContext == nullptr);
@@ -235,7 +239,7 @@ SoundSource::OpenResult SoundSourceFFmpeg::openAudioStream(
 
     const int avcodec_open2_result = avcodec_open2(pCodecContext, pDecoder, nullptr);
     if (avcodec_open2_result < 0) {
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "avcodec_open2() failed and returned"
                 << avcodec_open2_result;
         return SoundSource::OpenResult::FAILED;
@@ -257,7 +261,7 @@ void SoundSourceFFmpeg::ClosableAVStreamPtr::close() {
 #if ! AVSTREAM_FROM_API_VERSION_3_1
         const int avcodec_close_result = avcodec_close(m_pClosableStream->codec);
         if (avcodec_close_result != 0) {
-            qWarning() << "[SoundSourceFFmpeg]"
+            kLogger.warning()
                     << "avcodec_close() failed and returned"
                     << avcodec_close_result;
             // ignore error and continue
@@ -308,7 +312,7 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(const AudioSourceConfig& /*au
     AVFormatContext *pInputFormatContext =
             openInputFile(getLocalFileName());
     if (pInputFormatContext == nullptr) {
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "Failed to open input file"
                 << getLocalFileName();
         return OpenResult::FAILED;
@@ -319,7 +323,7 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(const AudioSourceConfig& /*au
     const int avformat_find_stream_info_result =
             avformat_find_stream_info(m_pInputFormatContext, nullptr);
     if (avformat_find_stream_info_result < 0) {
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "avformat_find_stream_info() failed and returned"
                 << avformat_find_stream_info_result;
         return OpenResult::FAILED;
@@ -331,7 +335,7 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(const AudioSourceConfig& /*au
     // Find and open audio stream for decoding
     AVStream* pAudioStream = findFirstAudioStream(m_pInputFormatContext);
     if (pAudioStream == nullptr) {
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "No audio stream found";
         return OpenResult::ABORTED;
     }
@@ -339,7 +343,7 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(const AudioSourceConfig& /*au
     // Find codec to decode stream or pass out
     AVCodec* pDecoder = findDecoderForStream(pAudioStream);
     if (pDecoder == nullptr) {
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "Failed to find a decoder for stream"
                 << pAudioStream->index;
         return SoundSource::OpenResult::ABORTED;
@@ -349,7 +353,7 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(const AudioSourceConfig& /*au
     AVCodecContext *pCodecContext = avcodec_alloc_context3(pDecoder);
 
     if (pCodecContext == nullptr) {
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "Failed to allocate codec context"
                 << pAudioStream->index;
         return SoundSource::OpenResult::ABORTED;
@@ -357,7 +361,7 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(const AudioSourceConfig& /*au
 
     // Add stream parameters to context
     if(avcodec_parameters_to_context(pCodecContext,pAudioStream->codecpar)) {
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "Failed to find to set Code parameter for AVCodecContext"
                 << pAudioStream->index;
         return SoundSource::OpenResult::ABORTED;
@@ -387,13 +391,13 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(const AudioSourceConfig& /*au
 
     const SINT channelCount = getChannelCountOfStream(m_pAudioStream);
     if (!isValidChannelCount(channelCount)) {
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "Stream has invalid number of channels:"
                 << channelCount;
         return OpenResult::FAILED;
     }
     if (channelCount > kMaxChannelCount) {
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "Stream has unsupported number of channels:"
                 << channelCount << ">" << kMaxChannelCount;
         return OpenResult::ABORTED;
@@ -401,7 +405,7 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(const AudioSourceConfig& /*au
 
     const SINT samplingRate = getSamplingRateOfStream(m_pAudioStream);
     if (!isValidSamplingRate(samplingRate)) {
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "Stream has invalid sampling rate:"
                 << samplingRate;
         return OpenResult::FAILED;
@@ -409,7 +413,7 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(const AudioSourceConfig& /*au
 
     SINT frameCount = getFrameCount();
     if (getFrameCountOfStream(m_pAudioStream, &frameCount) && isValidFrameCount(frameCount) == false) {
-        qWarning() << "[SoundSourceFFmpeg]"
+        kLogger.warning()
                 << "Stream has invalid number of frames:"
                 << frameCount;
         return OpenResult::FAILED;
@@ -502,7 +506,7 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
 #endif
 
         if (l_pFrame == nullptr) {
-            qDebug() << "SoundSourceFFmpeg::readFramesToCache: Can't alloc memory!";
+            kLogger.debug() << "readFramesToCache: Can't alloc memory!";
             return false;
         }
 
@@ -554,12 +558,12 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
                 // AVERROR(EAGAIN) means that we need to feed more
                 // That we can decode Frame or Packet
                 if (l_iRet == AVERROR(EAGAIN)) {
-                  qDebug() << "SoundSourceFFmpeg::readFramesToCache: Need more packets to decode!";
+                  kLogger.debug() << "readFramesToCache: Need more packets to decode!";
                   continue;
                 }
 
                 if(l_iRet == AVERROR_EOF || l_iRet == AVERROR(EINVAL)) {
-                      qDebug() << "SoundSourceFFmpeg::readFramesToCache: Warning can't decode frame!";
+                      kLogger.debug() << "readFramesToCache: Warning can't decode frame!";
                 }
 
                 l_iRet = avcodec_receive_frame(m_pAudioContext, l_pFrame);
@@ -567,12 +571,12 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
                 // AVERROR(EAGAIN) means that we need to feed more
                 // That we can decode Frame or Packet
                 if (l_iRet == AVERROR(EAGAIN)) {
-                  qDebug() << "SoundSourceFFmpeg::readFramesToCache: Need more packets to decode!";
+                  kLogger.debug() << "readFramesToCache: Need more packets to decode!";
                   continue;
                 }
 
                 if(l_iRet == AVERROR_EOF || l_iRet == AVERROR(EINVAL)) {
-                      qDebug() << "SoundSourceFFmpeg::readFramesToCache: Warning can't decode frame!";
+                      kLogger.debug() << "readFramesToCache: Warning can't decode frame!";
                 }
 
                 if (l_iRet == AVERROR_EOF || l_iRet < 0) {
@@ -584,14 +588,14 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
 #endif
                     // An error or EOF occurred,index break out and return what
                     // we have so far.
-                    qDebug() << "SoundSourceFFmpeg::readFramesToCache: EOF or uncoverable error!";
+                    kLogger.debug() << "readFramesToCache: EOF or uncoverable error!";
                     l_bStop = true;
                     continue;
                 } else {
                     l_iRet = 0;
                     l_SObj = (struct ffmpegCacheObject *)malloc(sizeof(struct ffmpegCacheObject));
                     if (l_SObj == nullptr) {
-                        qDebug() << "SoundSourceFFmpeg::readFramesToCache: Not enough memory!";
+                        kLogger.debug() << "readFramesToCache: Not enough memory!";
                         l_bStop = true;
                         continue;
                     }
@@ -656,8 +660,7 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
                     } else {
                         free(l_SObj);
                         l_SObj = nullptr;
-                        qDebug() <<
-                                 "SoundSourceFFmpeg::readFramesToCache: General error in audio decode:" <<
+                        kLogger.debug() << "readFramesToCache: General error in audio decode:" <<
                                  l_iRet;
                     }
                 }
@@ -680,7 +683,7 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
 
 
         } else {
-            qDebug() << "SoundSourceFFmpeg::readFramesToCache: Packet too big or File end";
+            kLogger.debug() << "readFramesToCache: Packet too big or File end";
             l_bStop = true;
         }
 
@@ -704,13 +707,12 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
     }
 
     if (l_iFrameCount > 0) {
-        qDebug() <<
-                 "SoundSourceFFmpeg::readFramesToCache(): Frame balance is not 0 it is: " <<
+        kLogger.debug() << "readFramesToCache(): Frame balance is not 0 it is: " <<
                  l_iFrameCount;
     }
 
     if (m_SCache.isEmpty()) {
-        qDebug() << "SoundSourceFFmpeg::readFramesToCache(): Can't read frames. Cache empty!";
+        kLogger.debug() << "readFramesToCache(): Can't read frames. Cache empty!";
         return false;
     }
 
@@ -739,7 +741,7 @@ bool SoundSourceFFmpeg::getBytesFromCache(CSAMPLE* buffer, SINT offset,
 
     // If cache is empty then retun without crash.
     if (m_SCache.isEmpty()) {
-        qDebug() << "SoundSourceFFmpeg::getBytesFromCache: Cache is empty can't return bytes";
+        kLogger.debug() << "getBytesFromCache: Cache is empty can't return bytes";
         if(l_pBuffer != nullptr)
         {
             memset(l_pBuffer, 0x00, l_lLeft);
@@ -787,12 +789,12 @@ bool SoundSourceFFmpeg::getBytesFromCache(CSAMPLE* buffer, SINT offset,
         l_SObj = m_SCache[l_lPos];
 
         if (l_SObj == nullptr) {
-            qDebug() << "SoundSourceFFmpeg::getBytesFromCache: Cache object nullptr";
+            kLogger.debug() << "getBytesFromCache: Cache object nullptr";
             return false;
         }
 
         if (l_pBuffer == nullptr) {
-            qDebug() << "SoundSourceFFmpeg::getBytesFromCache: Out buffer nullptr";
+            kLogger.debug() << "getBytesFromCache: Out buffer nullptr";
             return false;
         }
 
@@ -839,8 +841,7 @@ bool SoundSourceFFmpeg::getBytesFromCache(CSAMPLE* buffer, SINT offset,
                     l_SObj = m_SCache[++ l_lPos];
                     continue;
                 } else {
-                    qDebug() <<
-                             "SoundSourceFFmpeg::getBytesFromCache: Buffer run out. Shouldn't happen!";
+                    kLogger.debug() << "getBytesFromCache: Buffer run out. Shouldn't happen!";
                     if(l_pBuffer != nullptr)
                     {
                         memset(l_pBuffer, 0x00, l_lLeft);
@@ -917,7 +918,7 @@ SINT SoundSourceFFmpeg::seekSampleFrame(SINT frameIndex) {
                                  AVSEEK_FLAG_BACKWARD);
 
         if (ret < 0) {
-            qDebug() << "SoundSourceFFmpeg::seek: Can't seek to 0 byte!";
+            kLogger.debug() << "seek: Can't seek to 0 byte!";
             return -1;
         }
 

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -2,7 +2,7 @@
 
 #include "encoder/encoderffmpegresample.h"
 
-#include "util/logging.h"
+#include "util/logger.h"
 
 #include <mutex>
 #include <vector>

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -2,10 +2,13 @@
 
 #include "util/math.h"
 #include "util/sample.h"
+#include "util/logging.h"
 
 namespace mixxx {
 
 namespace {
+
+const Logger kLogger("SoundSourceFLAC");
 
 // The maximum number of retries to fix seek errors. On a seek error
 // the next seek will start one (or more) sample blocks before the
@@ -79,13 +82,13 @@ SoundSourceFLAC::~SoundSourceFLAC() {
 SoundSource::OpenResult SoundSourceFLAC::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
     DEBUG_ASSERT(!m_file.isOpen());
     if (!m_file.open(QIODevice::ReadOnly)) {
-        qWarning() << "Failed to open FLAC file:" << m_file.fileName();
+        kLogger.warning() << "Failed to open FLAC file:" << m_file.fileName();
         return OpenResult::FAILED;
     }
 
     m_decoder = FLAC__stream_decoder_new();
     if (m_decoder == nullptr) {
-        qWarning() << "Failed to create FLAC decoder!";
+        kLogger.warning() << "Failed to create FLAC decoder!";
         return OpenResult::FAILED;
     }
     FLAC__stream_decoder_set_md5_checking(m_decoder, false);
@@ -94,11 +97,11 @@ SoundSource::OpenResult SoundSourceFLAC::tryOpen(const AudioSourceConfig& /*audi
                     FLAC_seek_cb, FLAC_tell_cb, FLAC_length_cb, FLAC_eof_cb,
                     FLAC_write_cb, FLAC_metadata_cb, FLAC_error_cb, this));
     if (initStatus != FLAC__STREAM_DECODER_INIT_STATUS_OK) {
-        qWarning() << "Failed to initialize FLAC decoder:" << initStatus;
+        kLogger.warning() << "Failed to initialize FLAC decoder:" << initStatus;
         return OpenResult::FAILED;
     }
     if (!FLAC__stream_decoder_process_until_end_of_metadata(m_decoder)) {
-        qWarning() << "Failed to process FLAC metadata:"
+        kLogger.warning() << "Failed to process FLAC metadata:"
                 << FLAC__stream_decoder_get_state(m_decoder);
         return OpenResult::FAILED;
     }
@@ -143,12 +146,12 @@ SINT SoundSourceFLAC::seekSampleFrame(SINT frameIndex) {
             DEBUG_ASSERT(FLAC__STREAM_DECODER_SEEK_ERROR != FLAC__stream_decoder_get_state(m_decoder));
         } else {
             // Failure
-            qWarning() << "Seek error at" << seekFrameIndex << "in" << m_file.fileName();
+            kLogger.warning() << "Seek error at" << seekFrameIndex << "in" << m_file.fileName();
             if (FLAC__STREAM_DECODER_SEEK_ERROR == FLAC__stream_decoder_get_state(m_decoder)) {
                 // Flush the input stream of the decoder according to the
                 // documentation of FLAC__stream_decoder_seek_absolute()
                 if (!FLAC__stream_decoder_flush(m_decoder)) {
-                    qWarning() << "Failed to flush input buffer of the FLAC decoder after seek failure in"
+                    kLogger.warning() << "Failed to flush input buffer of the FLAC decoder after seek failure in"
                             << m_file.fileName();
                     // Invalidate the current position again...
                     m_curFrameIndex = getMaxFrameIndex();
@@ -220,7 +223,7 @@ SINT SoundSourceFLAC::readSampleFrames(
             // will be called with the decoded metadata block or audio frame."
             // See also: https://xiph.org/flac/api/group__flac__stream__decoder.html#ga9d6df4a39892c05955122cf7f987f856
             if (!FLAC__stream_decoder_process_single(m_decoder)) {
-                qWarning() << "Failed to decode FLAC file"
+                kLogger.warning() << "Failed to decode FLAC file"
                         << m_file.fileName();
                 break; // abort
             }
@@ -228,13 +231,13 @@ SINT SoundSourceFLAC::readSampleFrames(
             // complained that it has lost sync for some malformed(?) files
             if (curFrameIndexBeforeProcessing != m_curFrameIndex) {
                 if (curFrameIndexBeforeProcessing > m_curFrameIndex) {
-                    qWarning() << "Trying to adjust frame index"
+                    kLogger.warning() << "Trying to adjust frame index"
                             << m_curFrameIndex << "<>" << curFrameIndexBeforeProcessing
                             << "while decoding FLAC file"
                             << m_file.fileName();
                     skipSampleFrames(curFrameIndexBeforeProcessing - m_curFrameIndex);
                 } else {
-                    qWarning() << "Unexpected frame index"
+                    kLogger.warning() << "Unexpected frame index"
                             << m_curFrameIndex << "<>" << curFrameIndexBeforeProcessing
                             << "while decoding FLAC file"
                             << m_file.fileName();
@@ -304,7 +307,7 @@ FLAC__StreamDecoderSeekStatus SoundSourceFLAC::flacSeek(FLAC__uint64 absolute_by
     if (m_file.seek(absolute_byte_offset)) {
         return FLAC__STREAM_DECODER_SEEK_STATUS_OK;
     } else {
-        qWarning() << "SoundSourceFLAC: An unrecoverable error occurred ("
+        kLogger.warning() << "SoundSourceFLAC: An unrecoverable error occurred ("
                 << m_file.fileName() << ")";
         return FLAC__STREAM_DECODER_SEEK_STATUS_ERROR;
     }
@@ -338,20 +341,20 @@ FLAC__StreamDecoderWriteStatus SoundSourceFLAC::flacWrite(
         const FLAC__Frame* frame, const FLAC__int32* const buffer[]) {
     const SINT numChannels = frame->header.channels;
     if (getChannelCount() > numChannels) {
-        qWarning() << "Corrupt or unsupported FLAC file:"
+        kLogger.warning() << "Corrupt or unsupported FLAC file:"
                 << "Invalid number of channels in FLAC frame header"
                 << frame->header.channels << "<>" << getChannelCount();
         return FLAC__STREAM_DECODER_WRITE_STATUS_ABORT;
     }
     if (getSamplingRate() != SINT(frame->header.sample_rate)) {
-        qWarning() << "Corrupt or unsupported FLAC file:"
+        kLogger.warning() << "Corrupt or unsupported FLAC file:"
                 << "Invalid sample rate in FLAC frame header"
                 << frame->header.sample_rate << "<>" << getSamplingRate();
         return FLAC__STREAM_DECODER_WRITE_STATUS_ABORT;
     }
     const SINT numReadableFrames = frame->header.blocksize;
     if (numReadableFrames > m_maxBlocksize) {
-        qWarning() << "Corrupt or unsupported FLAC file:"
+        kLogger.warning() << "Corrupt or unsupported FLAC file:"
                 << "Block size in FLAC frame header exceeds the maximum block size"
                 << frame->header.blocksize << ">" << m_maxBlocksize;
         return FLAC__STREAM_DECODER_WRITE_STATUS_ABORT;
@@ -370,7 +373,7 @@ FLAC__StreamDecoderWriteStatus SoundSourceFLAC::flacWrite(
     const SINT numWritableFrames = samples2frames(writableChunk.size());
     DEBUG_ASSERT(numWritableFrames <= numReadableFrames);
     if (numWritableFrames < numReadableFrames) {
-        qWarning() << "Sample buffer has not enough free space for all decoded FLAC samples:"
+        kLogger.warning() << "Sample buffer has not enough free space for all decoded FLAC samples:"
                 << numWritableFrames << "<" << numReadableFrames;
     }
 
@@ -418,7 +421,7 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
             if (hasValidChannelCount()) {
                 // already set before -> check for consistency
                 if (getChannelCount() != channelCount) {
-                    qWarning() << "Unexpected channel count:"
+                    kLogger.warning() << "Unexpected channel count:"
                             << channelCount << " <> " << getChannelCount();
                 }
             } else {
@@ -426,7 +429,7 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
                 setChannelCount(channelCount);
             }
         } else {
-            qWarning() << "Invalid channel count:"
+            kLogger.warning() << "Invalid channel count:"
                     << channelCount;
         }
         const SINT samplingRate = metadata->data.stream_info.sample_rate;
@@ -434,7 +437,7 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
             if (hasValidSamplingRate()) {
                 // already set before -> check for consistency
                 if (getSamplingRate() != samplingRate) {
-                    qWarning() << "Unexpected sampling rate:"
+                    kLogger.warning() << "Unexpected sampling rate:"
                             << samplingRate << " <> " << getSamplingRate();
                 }
             } else {
@@ -442,7 +445,7 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
                 setSamplingRate(samplingRate);
             }
         } else {
-            qWarning() << "Invalid sampling rate:"
+            kLogger.warning() << "Invalid sampling rate:"
                     << samplingRate;
         }
         const SINT frameCount = metadata->data.stream_info.total_samples;
@@ -453,7 +456,7 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
         } else {
             // already set before -> check for consistency
             if (getFrameCount() != frameCount) {
-                qWarning() << "Unexpected frame count:"
+                kLogger.warning() << "Unexpected frame count:"
                         << frameCount << " <> " << getFrameCount();
             }
         }
@@ -467,13 +470,13 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
         } else {
             // already set before -> check for consistency
             if (bitsPerSample != m_bitsPerSample) {
-                qWarning() << "Unexpected bits per sample:"
+                kLogger.warning() << "Unexpected bits per sample:"
                         << bitsPerSample << " <> " << m_bitsPerSample;
             }
         }
         m_maxBlocksize = metadata->data.stream_info.max_blocksize;
         if (0 >= m_maxBlocksize) {
-            qWarning() << "Invalid max. blocksize" << m_maxBlocksize;
+            kLogger.warning() << "Invalid max. blocksize" << m_maxBlocksize;
         }
         const SINT sampleBufferCapacity =
                 m_maxBlocksize * getChannelCount();
@@ -504,7 +507,7 @@ void SoundSourceFLAC::flacError(FLAC__StreamDecoderErrorStatus status) {
         error = "STREAM_DECODER_ERROR_STATUS_UNPARSEABLE_STREAM";
         break;
     }
-    qWarning() << "FLAC decoding error" << error << "in file"
+    kLogger.warning() << "FLAC decoding error" << error << "in file"
             << m_file.fileName();
     // not much else to do here... whatever function that initiated whatever
     // decoder method resulted in this error will return an error, and the caller

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -2,7 +2,7 @@
 
 #include "util/math.h"
 #include "util/sample.h"
-#include "util/logging.h"
+#include "util/logger.h"
 
 namespace mixxx {
 

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -3,7 +3,7 @@
 #include "track/trackmetadata.h"
 #include "util/timer.h"
 #include "util/sample.h"
-#include "util/logging.h"
+#include "util/logger.h"
 
 #include <QFile>
 

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -3,6 +3,7 @@
 #include "track/trackmetadata.h"
 #include "util/timer.h"
 #include "util/sample.h"
+#include "util/logging.h"
 
 #include <QFile>
 
@@ -12,6 +13,8 @@
 namespace mixxx {
 
 namespace {
+
+const Logger kLogger("SoundSourceModPlug");
 
 /* read files in 512k chunks */
 const SINT kChunkSizeInBytes = SINT(1) << 19;
@@ -99,7 +102,7 @@ SoundSource::OpenResult SoundSourceModPlug::tryOpen(const AudioSourceConfig& /*a
     // read module file to byte array
     const QString fileName(getLocalFileName());
     QFile modFile(fileName);
-    qDebug() << "[ModPlug] Loading ModPlug module " << modFile.fileName();
+    kLogger.debug() << "Loading ModPlug module " << modFile.fileName();
     modFile.open(QIODevice::ReadOnly);
     m_fileBuf = modFile.readAll();
     modFile.close();
@@ -110,7 +113,7 @@ SoundSource::OpenResult SoundSourceModPlug::tryOpen(const AudioSourceConfig& /*a
     if (m_pModFile == nullptr) {
         // an error occurred
         t.cancel();
-        qDebug() << "[ModPlug] Could not load module file: " << fileName;
+        kLogger.debug() << "Could not load module file: " << fileName;
         return OpenResult::FAILED;
     }
 
@@ -131,7 +134,7 @@ SoundSource::OpenResult SoundSourceModPlug::tryOpen(const AudioSourceConfig& /*a
     const SampleBuffer::size_type sampleBufferCapacity = math_min(
             estimateChunks * chunkSizeInSamples, bufferSizeLimitInSamples);
     m_sampleBuf.reserve(sampleBufferCapacity);
-    qDebug() << "[ModPlug] Reserved " << m_sampleBuf.capacity() << " #samples";
+    kLogger.debug() << "Reserved " << m_sampleBuf.capacity() << " #samples";
 
     // decode samples into sample buffer
     while (m_sampleBuf.size() < bufferSizeLimitInSamples) {
@@ -152,9 +155,9 @@ SoundSource::OpenResult SoundSourceModPlug::tryOpen(const AudioSourceConfig& /*a
             break; // exit loop
         }
     }
-    qDebug() << "[ModPlug] Filled Sample buffer with " << m_sampleBuf.size()
+    kLogger.debug() << "Filled Sample buffer with " << m_sampleBuf.size()
             << " samples.";
-    qDebug() << "[ModPlug] Sample buffer has "
+    kLogger.debug() << "Sample buffer has "
             << m_sampleBuf.capacity() - m_sampleBuf.size()
             << " samples unused capacity.";
 

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -2,7 +2,7 @@
 #include "sources/mp3decoding.h"
 
 #include "util/math.h"
-#include "util/logging.h"
+#include "util/logger.h"
 
 #include <id3tag.h>
 

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -2,12 +2,15 @@
 #include "sources/mp3decoding.h"
 
 #include "util/math.h"
+#include "util/logging.h"
 
 #include <id3tag.h>
 
 namespace mixxx {
 
 namespace {
+
+const Logger kLogger("SoundSourceMP3");
 
 // MP3 does only support 1 or 2 channels
 const SINT kChannelCountMax = AudioSource::kChannelCountStereo;
@@ -123,14 +126,14 @@ bool decodeFrameHeader(
         }
         if (isUnrecoverableError(*pMadStream)) {
             DEBUG_ASSERT(!isStreamValid(*pMadStream));
-            qWarning() << "Unrecoverable MP3 header decoding error:"
+            kLogger.warning() << "Unrecoverable MP3 header decoding error:"
                     << mad_stream_errorstr(pMadStream);
             return false;
         }
     #ifndef QT_NO_DEBUG_OUTPUT
         // Logging of MP3 frame headers should only be enabled
         // for debugging purposes.
-        //logFrameHeader(qDebug(), *pMadHeader);
+        logFrameHeader(kLogger.debug(), *pMadHeader);
     #endif
         if (isRecoverableError(*pMadStream)) {
             if ((MAD_ERROR_LOSTSYNC == pMadStream->error) && skipId3Tag) {
@@ -144,9 +147,9 @@ bool decodeFrameHeader(
                     return false;
                 }
             }
-            qWarning() << "Recoverable MP3 header decoding error:"
+            kLogger.warning() << "Recoverable MP3 header decoding error:"
                     << mad_stream_errorstr(pMadStream);
-            logFrameHeader(qWarning(), *pMadHeader);
+            logFrameHeader(kLogger.warning(), *pMadHeader);
             return false;
         }
     }
@@ -193,7 +196,7 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audio
 
     DEBUG_ASSERT(!m_file.isOpen());
     if (!m_file.open(QIODevice::ReadOnly)) {
-        qWarning() << "Failed to open file:" << m_file.fileName();
+        kLogger.warning() << "Failed to open file:" << m_file.fileName();
         return OpenResult::FAILED;
     }
 
@@ -249,7 +252,7 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audio
 
         const long madFrameLength = mad_timer_count(madHeader.duration, madUnits);
         if (0 >= madFrameLength) {
-            qWarning() << "Skipping MP3 frame with invalid length"
+            kLogger.warning() << "Skipping MP3 frame with invalid length"
                     << madFrameLength
                     << "in:" << m_file.fileName();
             // Skip frame
@@ -258,7 +261,7 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audio
 
         const SINT madChannelCount = MAD_NCHANNELS(&madHeader);
         if (isValidChannelCount(maxChannelCount) && (madChannelCount != maxChannelCount)) {
-            qWarning() << "Differing number of channels"
+            kLogger.warning() << "Differing number of channels"
                     << madChannelCount << "<>" << maxChannelCount
                     << "in some MP3 frame headers:"
                     << m_file.fileName();
@@ -267,7 +270,7 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audio
 
         const int samplingRateIndex = getIndexBySamplingRate(madSampleRate);
         if (samplingRateIndex >= kSamplingRateCount) {
-            qWarning() << "Invalid sample rate:" << m_file.fileName()
+            kLogger.warning() << "Invalid sample rate:" << m_file.fileName()
                     << madSampleRate;
             // Abort
             mad_header_finish(&madHeader);
@@ -294,7 +297,7 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audio
         // Unreachable code for recoverable errors
         DEBUG_ASSERT(!MAD_RECOVERABLE(m_madStream.error));
         if (MAD_ERROR_BUFLEN != m_madStream.error) {
-            qWarning() << "Unrecoverable MP3 header error:"
+            kLogger.warning() << "Unrecoverable MP3 header error:"
                     << mad_stream_errorstr(&m_madStream);
             // Abort
             return OpenResult::FAILED;
@@ -303,7 +306,7 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audio
 
     if (m_seekFrameList.empty()) {
         // This is not a working MP3 file.
-        qWarning() << "SSMP3: This is not a working MP3 file:"
+        kLogger.warning() << "SSMP3: This is not a working MP3 file:"
                 << m_file.fileName();
         // Abort
         return OpenResult::FAILED;
@@ -323,23 +326,23 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audio
     }
 
     if (differentRates > 1) {
-        qWarning() << "Differing sampling rate in some headers:"
+        kLogger.warning() << "Differing sampling rate in some headers:"
                    << m_file.fileName();
         for (int i = 0; i < kSamplingRateCount; ++i) {
             if (0 < headerPerSamplingRate[i]) {
-                qWarning() << headerPerSamplingRate[i] << "MP3 headers with sampling rate" << getSamplingRateByIndex(i);
+                kLogger.warning() << headerPerSamplingRate[i] << "MP3 headers with sampling rate" << getSamplingRateByIndex(i);
             }
         }
 
-        qWarning() << "MP3 files with varying sample rate are not supported!";
-        qWarning() << "Since this happens most likely due to a corrupt file";
-        qWarning() << "Mixxx tries to plays it with the most common sample rate for this file";
+        kLogger.warning() << "MP3 files with varying sample rate are not supported!";
+        kLogger.warning() << "Since this happens most likely due to a corrupt file";
+        kLogger.warning() << "Mixxx tries to plays it with the most common sample rate for this file";
     }
 
     if (mostCommonSamplingRateIndex < kSamplingRateCount) {
         setSamplingRate(getSamplingRateByIndex(mostCommonSamplingRateIndex));
     } else {
-        qWarning() << "No single valid sampling rate in header";
+        kLogger.warning() << "No single valid sampling rate in header";
         // Abort
         return OpenResult::FAILED;
     }
@@ -361,7 +364,7 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(const AudioSourceConfig& /*audio
     restartDecoding(m_seekFrameList.front());
 
     if (m_curFrameIndex != getMinFrameIndex()) {
-        qWarning() << "Failed to start decoding:" << m_file.fileName();
+        kLogger.warning() << "Failed to start decoding:" << m_file.fileName();
         // Abort
         return OpenResult::FAILED;
     }
@@ -388,7 +391,7 @@ void SoundSourceMp3::close() {
 
 void SoundSourceMp3::restartDecoding(
         const SeekFrameType& seekFrame) {
-    qDebug() << "restartDecoding @" << seekFrame.frameIndex;
+    kLogger.debug() << "restartDecoding @" << seekFrame.frameIndex;
 
     // Discard decoded output
     m_madSynthCount = 0;
@@ -534,7 +537,7 @@ SINT SoundSourceMp3::seekSampleFrame(SINT frameIndex) {
         skipSampleFrames(frameIndex - m_curFrameIndex);
         DEBUG_ASSERT(m_curFrameIndex <= frameIndex);
         if (m_curFrameIndex < frameIndex) {
-            qWarning() << "Failed to prefetch sample data while seeking:"
+            kLogger.warning() << "Failed to prefetch sample data while seeking:"
                     << m_curFrameIndex << "<" << frameIndex;
         }
     }
@@ -614,14 +617,14 @@ SINT SoundSourceMp3::readSampleFrames(
                             continue;
                         }
                         if (m_curFrameIndex < getMaxFrameIndex()) {
-                            qWarning() << "Failed to decode the end of the MP3 stream"
+                            kLogger.warning() << "Failed to decode the end of the MP3 stream"
                                     << m_curFrameIndex << "<" << getMaxFrameIndex();
                         }
                     }
                     break;
                 }
                 if (isUnrecoverableError(m_madStream)) {
-                    qWarning() << "Unrecoverable MP3 frame decoding error:"
+                    kLogger.warning() << "Unrecoverable MP3 frame decoding error:"
                             << mad_stream_errorstr(&m_madStream);
                     // Abort decoding
                     break;
@@ -632,11 +635,11 @@ SINT SoundSourceMp3::readSampleFrames(
                         // "lost synchronization" warnings) while skipping
                         // over prefetched frames after seeking.
                         if (pSampleBuffer) {
-                            qWarning() << "Recoverable MP3 frame decoding error:"
+                            kLogger.warning() << "Recoverable MP3 frame decoding error:"
                                     << mad_stream_errorstr(&m_madStream);
                         } else {
                             // Decoded samples will simply be discarded
-                            qDebug() << "Recoverable MP3 frame decoding error while skipping:"
+                            kLogger.debug() << "Recoverable MP3 frame decoding error while skipping:"
                                 << mad_stream_errorstr(&m_madStream);
                         }
                     }
@@ -644,7 +647,7 @@ SINT SoundSourceMp3::readSampleFrames(
                 }
             }
             if (pMadThisFrame == m_madStream.this_frame) {
-                qDebug() << "Retry decoding MP3 frame @" << m_curFrameIndex;
+                kLogger.debug() << "Retry decoding MP3 frame @" << m_curFrameIndex;
                 // Retry decoding
                 continue;
             }
@@ -654,7 +657,7 @@ SINT SoundSourceMp3::readSampleFrames(
 #ifndef QT_NO_DEBUG_OUTPUT
             const SINT madFrameChannelCount = MAD_NCHANNELS(&m_madFrame.header);
             if (madFrameChannelCount != getChannelCount()) {
-                qDebug() << "MP3 frame header with mismatching number of channels"
+                kLogger.debug() << "MP3 frame header with mismatching number of channels"
                         << madFrameChannelCount << "<>" << getChannelCount();
             }
 #endif
@@ -664,7 +667,7 @@ SINT SoundSourceMp3::readSampleFrames(
 #ifndef QT_NO_DEBUG_OUTPUT
             const SINT madSynthSampleRate =  m_madSynth.pcm.samplerate;
             if (madSynthSampleRate != getSamplingRate()) {
-                qDebug() << "Reading MP3 data with different sampling rate"
+                kLogger.debug() << "Reading MP3 data with different sampling rate"
                         << madSynthSampleRate << "<>" << getSamplingRate();
             }
 #endif
@@ -684,7 +687,7 @@ SINT SoundSourceMp3::readSampleFrames(
             DEBUG_ASSERT(madSynthChannelCount <= getChannelCount());
 #ifndef QT_NO_DEBUG_OUTPUT
             if (madSynthChannelCount != getChannelCount()) {
-                qDebug() << "Reading MP3 data with different number of channels"
+                kLogger.debug() << "Reading MP3 data with different number of channels"
                         << madSynthChannelCount << "<>" << getChannelCount();
             }
 #endif

--- a/src/sources/soundsourceoggvorbis.cpp
+++ b/src/sources/soundsourceoggvorbis.cpp
@@ -2,7 +2,7 @@
 
 #include "sources/soundsourceoggvorbis.h"
 
-#include "util/logging.h"
+#include "util/logger.h"
 
 namespace mixxx {
 

--- a/src/sources/soundsourceoggvorbis.cpp
+++ b/src/sources/soundsourceoggvorbis.cpp
@@ -1,10 +1,14 @@
+#include <QFile>
+
 #include "sources/soundsourceoggvorbis.h"
 
-#include <QFile>
+#include "util/logging.h"
 
 namespace mixxx {
 
 namespace {
+
+const Logger kLogger("SoundSourceOggVorbis");
 
 // Parameter for ov_info()
 // See also: https://xiph.org/vorbis/doc/vorbisfile/ov_info.html
@@ -37,7 +41,7 @@ SoundSourceOggVorbis::~SoundSourceOggVorbis() {
 SoundSource::OpenResult SoundSourceOggVorbis::tryOpen(const AudioSourceConfig& /*audioSrcCfg*/) {
     m_pFile = std::make_unique<QFile>(getLocalFileName());
     if(!m_pFile->open(QFile::ReadOnly)) {
-        qWarning() << "SoundSourceOggVorbis:"
+        kLogger.warning()
                 << "Failed to open file for"
                 << getUrlString();
         return OpenResult::FAILED;
@@ -50,19 +54,19 @@ SoundSource::OpenResult SoundSourceOggVorbis::tryOpen(const AudioSourceConfig& /
         break;
     case OV_ENOTVORBIS:
     case OV_EVERSION:
-        qWarning() << "SoundSourceOggVorbis:"
+        kLogger.warning()
             << "Unsupported format in"
             << getUrlString();
         return OpenResult::ABORTED;
     default:
-        qWarning() << "SoundSourceOggVorbis:"
+        kLogger.warning()
             << "Failed to initialize decoder for"
             << getUrlString();
         return OpenResult::FAILED;
     }
 
     if (!ov_seekable(&m_vf)) {
-        qWarning() << "SoundSourceOggVorbis:"
+        kLogger.warning()
                 << "Stream in"
                 << getUrlString()
                 << "is not seekable";
@@ -72,7 +76,7 @@ SoundSource::OpenResult SoundSourceOggVorbis::tryOpen(const AudioSourceConfig& /
     // lookup the ogg's channels and sample rate
     const vorbis_info* vi = ov_info(&m_vf, kCurrentBitstreamLink);
     if (!vi) {
-        qWarning() << "SoundSourceOggVorbis:"
+        kLogger.warning()
                 << "Failed to read stream info from"
                 << getUrlString();
         return OpenResult::FAILED;
@@ -91,7 +95,7 @@ SoundSource::OpenResult SoundSourceOggVorbis::tryOpen(const AudioSourceConfig& /
     if (0 <= pcmTotal) {
         setFrameCount(pcmTotal);
     } else {
-        qWarning() << "SoundSourceOggVorbis:"
+        kLogger.warning()
                 << "Failed to read read total length of"
                 << getUrlString();
         return OpenResult::FAILED;
@@ -103,7 +107,7 @@ SoundSource::OpenResult SoundSourceOggVorbis::tryOpen(const AudioSourceConfig& /
 void SoundSourceOggVorbis::close() {
     const int clearResult = ov_clear(&m_vf);
     if (0 != clearResult) {
-        qWarning() << "Failed to close OggVorbis file" << clearResult;
+        kLogger.warning() << "Failed to close file" << clearResult;
     }
     m_pFile.reset();
 }
@@ -126,7 +130,7 @@ SINT SoundSourceOggVorbis::seekSampleFrame(
     if (0 == seekResult) {
         m_curFrameIndex = frameIndex;
     } else {
-        qWarning() << "Failed to seek OggVorbis file:" << seekResult;
+        kLogger.warning() << "Failed to seek file:" << seekResult;
         const ogg_int64_t pcmOffset = ov_pcm_tell(&m_vf);
         if (0 <= pcmOffset) {
             m_curFrameIndex = pcmOffset;
@@ -202,7 +206,7 @@ SINT SoundSourceOggVorbis::readSampleFrames(
             }
             numberOfFramesRemaining -= readResult;
         } else {
-            qWarning() << "Failed to read from OggVorbis file:" << readResult;
+            kLogger.warning() << "Failed to read from file:" << readResult;
             break; // abort
         }
     }

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -1,6 +1,6 @@
 #include "sources/soundsourceopus.h"
 
-#include "util/logging.h"
+#include "util/logger.h"
 
 namespace mixxx {
 

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -1,5 +1,7 @@
 #include "sources/soundsourceopus.h"
 
+#include "util/logging.h"
+
 namespace mixxx {
 
 // Depends on kNumberOfPrefetchFrames (see below)
@@ -7,6 +9,8 @@ namespace mixxx {
 const CSAMPLE SoundSourceOpus::kMaxDecodingError = 0.01f;
 
 namespace {
+
+const Logger kLogger("SoundSourceOpus");
 
 // Decoded output of opusfile has a fixed sample rate of 48 kHz (fullband)
 constexpr SINT kSamplingRate = 48000;
@@ -142,10 +146,6 @@ Result SoundSourceOpus::parseTrackMetadataAndCoverArt(
                 pTrackMetadata->setReplayGain(trackGain);
             }
         }
-
-        // This is left fot debug reasons!!
-        //qDebug() << "Comment" << i << l_ptrOpusTags->comment_lengths[i] <<
-        //" (" << l_ptrOpusTags->user_comments[i] << ")" << l_STag << "*" << l_SPayload;
     }
 
     return OK;
@@ -168,13 +168,13 @@ SoundSource::OpenResult SoundSourceOpus::tryOpen(const AudioSourceConfig& audioS
     DEBUG_ASSERT(!m_pOggOpusFile);
     m_pOggOpusFile = op_open_file(qBAFilename.constData(), &errorCode);
     if (!m_pOggOpusFile) {
-        qWarning() << "Failed to open OggOpus file:" << getUrlString()
+        kLogger.warning() << "Failed to open OggOpus file:" << getUrlString()
                 << "errorCode" << errorCode;
         return OpenResult::FAILED;
     }
 
     if (!op_seekable(m_pOggOpusFile)) {
-        qWarning() << "SoundSourceOpus:"
+        kLogger.warning() << "SoundSourceOpus:"
                 << "Stream in"
                 << getUrlString()
                 << "is not seekable";
@@ -197,7 +197,7 @@ SoundSource::OpenResult SoundSourceOpus::tryOpen(const AudioSourceConfig& audioS
             setChannelCount(streamChannelCount);
         }
     } else {
-        qWarning() << "Failed to read channel configuration of OggOpus file:" << getUrlString();
+        kLogger.warning() << "Failed to read channel configuration of OggOpus file:" << getUrlString();
         return OpenResult::FAILED;
     }
 
@@ -209,7 +209,7 @@ SoundSource::OpenResult SoundSourceOpus::tryOpen(const AudioSourceConfig& audioS
     if (0 <= pcmTotal) {
         setFrameCount(pcmTotal);
     } else {
-        qWarning() << "Failed to read total length of OggOpus file:" << getUrlString();
+        kLogger.warning() << "Failed to read total length of OggOpus file:" << getUrlString();
         return OpenResult::FAILED;
     }
 
@@ -217,7 +217,7 @@ SoundSource::OpenResult SoundSourceOpus::tryOpen(const AudioSourceConfig& audioS
     if (0 < bitrate) {
         setBitrate(bitrate / 1000);
     } else {
-        qWarning() << "Failed to determine bitrate of OggOpus file:" << getUrlString();
+        kLogger.warning() << "Failed to determine bitrate of OggOpus file:" << getUrlString();
         return OpenResult::FAILED;
     }
 
@@ -262,7 +262,7 @@ SINT SoundSourceOpus::seekSampleFrame(SINT frameIndex) {
         // Skip prefetched frames
         skipSampleFrames(frameIndex - seekIndex);
     } else {
-        qWarning() << "Failed to seek OggOpus file:" << seekResult;
+        kLogger.warning() << "Failed to seek OggOpus file:" << seekResult;
         const ogg_int64_t pcmOffset = op_pcm_tell(m_pOggOpusFile);
         if (0 <= pcmOffset) {
             m_curFrameIndex = pcmOffset;
@@ -317,7 +317,7 @@ SINT SoundSourceOpus::readSampleFrames(
             pSampleBuffer += frames2samples(readResult);
             numberOfFramesRemaining -= readResult;
         } else {
-            qWarning() << "Failed to read sample data from OggOpus file:"
+            kLogger.warning() << "Failed to read sample data from OggOpus file:"
                     << readResult;
             break; // abort
         }
@@ -363,7 +363,7 @@ SINT SoundSourceOpus::readSampleFramesStereo(
             pSampleBuffer += readResult * kChannelCountStereo;
             numberOfFramesRemaining -= readResult;
         } else {
-            qWarning() << "Failed to read sample data from OggOpus file:"
+            kLogger.warning() << "Failed to read sample data from OggOpus file:"
                     << readResult;
             break; // abort
         }

--- a/src/sources/soundsourcepluginlibrary.cpp
+++ b/src/sources/soundsourcepluginlibrary.cpp
@@ -1,8 +1,16 @@
 #include "soundsourcepluginlibrary.h"
 
+#include "util/logging.h"
+
 #include <QMutexLocker>
 
 namespace mixxx {
+
+namespace {
+
+const Logger kLogger("SoundSourcePluginLibrary");
+
+} // anonymous namespace
 
 /*static*/ QMutex SoundSourcePluginLibrary::s_loadedPluginLibrariesMutex;
 /*static*/ QMap<QString, SoundSourcePluginLibraryPointer> SoundSourcePluginLibrary::s_loadedPluginLibraries;
@@ -36,12 +44,12 @@ SoundSourcePluginLibrary::~SoundSourcePluginLibrary() {
 bool SoundSourcePluginLibrary::init() {
     DEBUG_ASSERT(!m_library.isLoaded());
     if (!m_library.load()) {
-        qWarning() << "Failed to dynamically load plugin library"
+        kLogger.warning() << "Failed to dynamically load plugin library"
                 << m_library.fileName()
                 << ":" << m_library.errorString();
         return false;
     }
-    qDebug() << "Dynamically loaded plugin library"
+    kLogger.debug() << "Dynamically loaded plugin library"
             << m_library.fileName();
 
     SoundSourcePluginAPI_getVersionFunc getVersionFunc = (SoundSourcePluginAPI_getVersionFunc)
@@ -52,14 +60,14 @@ bool SoundSourcePluginLibrary::init() {
                     m_library.resolve("getSoundSourceAPIVersion");
     }
     if (getVersionFunc == nullptr) {
-        qWarning() << "Failed to resolve SoundSource plugin API function"
+        kLogger.warning() << "Failed to resolve SoundSource plugin API function"
                 << SoundSourcePluginAPI_getVersionFuncName;
         return initFailedForIncompatiblePlugin();
     }
 
     m_apiVersion = getVersionFunc();
     if (m_apiVersion != MIXXX_SOUNDSOURCEPLUGINAPI_VERSION) {
-        qWarning() << "Incompatible SoundSource plugin API version"
+        kLogger.warning() << "Incompatible SoundSource plugin API version"
                 << m_apiVersion << "<>" << MIXXX_SOUNDSOURCEPLUGINAPI_VERSION;
         return initFailedForIncompatiblePlugin();
     }
@@ -68,7 +76,7 @@ bool SoundSourcePluginLibrary::init() {
             reinterpret_cast<SoundSourcePluginAPI_createSoundSourceProviderFunc>(
                     m_library.resolve(SoundSourcePluginAPI_createSoundSourceProviderFuncName));
     if (createSoundSourceProviderFunc == nullptr) {
-        qWarning() << "Failed to resolve SoundSource plugin API function"
+        kLogger.warning() << "Failed to resolve SoundSource plugin API function"
                 << SoundSourcePluginAPI_createSoundSourceProviderFuncName;
         return initFailedForIncompatiblePlugin();
     }
@@ -77,7 +85,7 @@ bool SoundSourcePluginLibrary::init() {
             reinterpret_cast<SoundSourcePluginAPI_destroySoundSourceProviderFunc>(
                 m_library.resolve(SoundSourcePluginAPI_destroySoundSourceProviderFuncName));
     if (destroySoundSourceProviderFunc == nullptr) {
-        qWarning() << "Failed to resolve SoundSource plugin API function"
+        kLogger.warning() << "Failed to resolve SoundSource plugin API function"
                 << SoundSourcePluginAPI_destroySoundSourceProviderFuncName;
         return initFailedForIncompatiblePlugin();
     }
@@ -88,14 +96,14 @@ bool SoundSourcePluginLibrary::init() {
     if (m_pSoundSourceProvider) {
         return true;
     } else {
-        qWarning() << "Failed to create SoundSource provider for plugin library"
+        kLogger.warning() << "Failed to create SoundSource provider for plugin library"
                 << m_library.fileName();
         return false;
     }
 }
 
 bool SoundSourcePluginLibrary::initFailedForIncompatiblePlugin() const {
-    qWarning() << "Incompatible SoundSource plugin"
+    kLogger.warning() << "Incompatible SoundSource plugin"
             << m_library.fileName();
     return false;
 }

--- a/src/sources/soundsourcepluginlibrary.cpp
+++ b/src/sources/soundsourcepluginlibrary.cpp
@@ -1,6 +1,6 @@
 #include "soundsourcepluginlibrary.h"
 
-#include "util/logging.h"
+#include "util/logger.h"
 
 #include <QMutexLocker>
 

--- a/src/sources/soundsourceproviderregistry.cpp
+++ b/src/sources/soundsourceproviderregistry.cpp
@@ -1,6 +1,6 @@
 #include "soundsourceproviderregistry.h"
 
-#include "util/logging.h"
+#include "util/logger.h"
 
 namespace mixxx {
 

--- a/src/sources/soundsourceproviderregistry.cpp
+++ b/src/sources/soundsourceproviderregistry.cpp
@@ -1,13 +1,21 @@
 #include "soundsourceproviderregistry.h"
 
+#include "util/logging.h"
+
 namespace mixxx {
+
+namespace {
+
+const Logger kLogger("SoundSourceProviderRegistry");
+
+} // anonymous namespace
 
 void SoundSourceProviderRegistry::registerProvider(
         const SoundSourceProviderPointer& pProvider) {
     const QStringList supportedFileExtensions(
             pProvider->getSupportedFileExtensions());
     if (supportedFileExtensions.isEmpty()) {
-        qWarning() << "SoundSource provider"
+        kLogger.warning() << "SoundSource provider"
                 << pProvider->getName()
                 << "does not support any file extensions";
         return; // abort registration
@@ -30,7 +38,7 @@ void SoundSourceProviderRegistry::registerPluginLibrary(
     const QStringList supportedFileExtensions(
             pProvider->getSupportedFileExtensions());
     if (supportedFileExtensions.isEmpty()) {
-        qWarning() << "SoundSource provider"
+        kLogger.warning() << "SoundSource provider"
                 << pProvider->getName()
                 << "does not support any file extensions";
         return; // abort registration

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -202,19 +202,21 @@ void SoundSourceProxy::loadPlugins() {
 
     const QStringList supportedFileExtensions(
             s_soundSourceProviders.getRegisteredFileExtensions());
-    for (const auto &supportedFileExtension: supportedFileExtensions) {
-        kLogger.debug() << "SoundSource providers for file extension" << supportedFileExtension;
-        const QList<mixxx::SoundSourceProviderRegistration> registrationsForFileExtension(
-                s_soundSourceProviders.getRegistrationsForFileExtension(
-                        supportedFileExtension));
-        for (const auto& registration: registrationsForFileExtension) {
-            if (registration.getPluginLibrary()) {
-                kLogger.debug() << " " << static_cast<int>(registration.getProviderPriority())
-                        << ":" << registration.getProvider()->getName()
-                        << "@" << registration.getPluginLibrary()->getFilePath();
-            } else {
-                kLogger.debug() << " " << static_cast<int>(registration.getProviderPriority())
-                        << ":" << registration.getProvider()->getName();
+    if (kLogger.infoEnabled()) {
+        for (const auto &supportedFileExtension: supportedFileExtensions) {
+            kLogger.info() << "SoundSource providers for file extension" << supportedFileExtension;
+            const QList<mixxx::SoundSourceProviderRegistration> registrationsForFileExtension(
+                    s_soundSourceProviders.getRegistrationsForFileExtension(
+                            supportedFileExtension));
+            for (const auto& registration: registrationsForFileExtension) {
+                if (registration.getPluginLibrary()) {
+                    kLogger.info() << " " << static_cast<int>(registration.getProviderPriority())
+                            << ":" << registration.getProvider()->getName()
+                            << "@" << registration.getPluginLibrary()->getFilePath();
+                } else {
+                    kLogger.info() << " " << static_cast<int>(registration.getProviderPriority())
+                            << ":" << registration.getProvider()->getName();
+                }
             }
         }
     }

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -28,7 +28,7 @@
 #include "library/coverartcache.h"
 #include "util/cmdlineargs.h"
 #include "util/regex.h"
-#include "util/logging.h"
+#include "util/logger.h"
 
 //Static memory allocation
 /*static*/ mixxx::SoundSourceProviderRegistry SoundSourceProxy::s_soundSourceProviders;

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -28,6 +28,7 @@
 #include "library/coverartcache.h"
 #include "util/cmdlineargs.h"
 #include "util/regex.h"
+#include "util/logging.h"
 
 //Static memory allocation
 /*static*/ mixxx::SoundSourceProviderRegistry SoundSourceProxy::s_soundSourceProviders;
@@ -35,6 +36,8 @@
 /*static*/ QRegExp SoundSourceProxy::s_supportedFileNamesRegex;
 
 namespace {
+
+const mixxx::Logger kLogger("SoundSourceProxy");
 
 #if (__UNIX__ || __LINUX__ || __APPLE__)
 // Filtering of plugin file names on UNIX systems
@@ -49,7 +52,7 @@ QList<QDir> getSoundSourcePluginDirectories() {
 
     const QString& pluginPath = CmdlineArgs::Instance().getPluginPath();
     if (!pluginPath.isEmpty()) {
-        qDebug() << "Adding plugin path from commandline arg:" << pluginPath;
+        kLogger.debug() << "Adding plugin path from commandline arg:" << pluginPath;
         pluginDirs << QDir(pluginPath);
     }
 
@@ -180,7 +183,7 @@ void SoundSourceProxy::loadPlugins() {
     // that have been registered before (see above)!
     const QList<QDir> pluginDirs(getSoundSourcePluginDirectories());
     for (const auto& pluginDir: pluginDirs) {
-        qDebug() << "Loading SoundSource plugins" << pluginDir.path();
+        kLogger.debug() << "Loading SoundSource plugins" << pluginDir.path();
         const QStringList files(pluginDir.entryList(
                 SOUND_SOURCE_PLUGIN_FILENAME_PATTERN,
                 QDir::Files | QDir::NoDotAndDotDot));
@@ -191,7 +194,7 @@ void SoundSourceProxy::loadPlugins() {
             if (pPluginLibrary) {
                 s_soundSourceProviders.registerPluginLibrary(pPluginLibrary);
             } else {
-                qWarning() << "Failed to load SoundSource plugin"
+                kLogger.warning() << "Failed to load SoundSource plugin"
                         << libFilePath;
             }
         }
@@ -200,17 +203,17 @@ void SoundSourceProxy::loadPlugins() {
     const QStringList supportedFileExtensions(
             s_soundSourceProviders.getRegisteredFileExtensions());
     for (const auto &supportedFileExtension: supportedFileExtensions) {
-        qDebug() << "SoundSource providers for file extension" << supportedFileExtension;
+        kLogger.debug() << "SoundSource providers for file extension" << supportedFileExtension;
         const QList<mixxx::SoundSourceProviderRegistration> registrationsForFileExtension(
                 s_soundSourceProviders.getRegistrationsForFileExtension(
                         supportedFileExtension));
         for (const auto& registration: registrationsForFileExtension) {
             if (registration.getPluginLibrary()) {
-                qDebug() << " " << static_cast<int>(registration.getProviderPriority())
+                kLogger.debug() << " " << static_cast<int>(registration.getProviderPriority())
                         << ":" << registration.getProvider()->getName()
                         << "@" << registration.getPluginLibrary()->getFilePath();
             } else {
-                qDebug() << " " << static_cast<int>(registration.getProviderPriority())
+                kLogger.debug() << " " << static_cast<int>(registration.getProviderPriority())
                         << ":" << registration.getProvider()->getName();
             }
         }
@@ -277,7 +280,7 @@ SoundSourceProxy::findSoundSourceProviderRegistrations(
     }
     QString fileExtension(mixxx::SoundSource::getFileExtensionFromUrl(url));
     if (fileExtension.isEmpty()) {
-        qWarning() << "Unknown file type:" << url.toString();
+        kLogger.warning() << "Unknown file type:" << url.toString();
         return QList<mixxx::SoundSourceProviderRegistration>();
     }
 
@@ -285,7 +288,7 @@ SoundSourceProxy::findSoundSourceProviderRegistrations(
             s_soundSourceProviders.getRegistrationsForFileExtension(
                     fileExtension));
     if (registrationsForFileExtension.isEmpty()) {
-        qWarning() << "Unsupported file type:" << url.toString();
+        kLogger.warning() << "Unsupported file type:" << url.toString();
     }
 
     return registrationsForFileExtension;
@@ -304,7 +307,7 @@ SoundSourceProxy::SaveTrackMetadataResult SoundSourceProxy::saveTrackMetadata(
         if (parsedFromFile || evenIfNeverParsedFromFileBefore) {
             switch (proxy.m_pSoundSource->writeTrackMetadata(trackMetadata)) {
             case OK:
-                qDebug() << "Track metadata has been written into file"
+                kLogger.debug() << "Track metadata has been written into file"
                         << pTrack->getLocation();
                 return SaveTrackMetadataResult::SUCCEEDED;
             case ERR:
@@ -313,12 +316,12 @@ SoundSourceProxy::SaveTrackMetadataResult SoundSourceProxy::saveTrackMetadata(
                 DEBUG_ASSERT(!"unreachable code");
             }
         } else {
-            qDebug() << "Skip writing of track metadata into file"
+            kLogger.debug() << "Skip writing of track metadata into file"
                     << pTrack->getLocation();
             return SaveTrackMetadataResult::SKIPPED;
         }
     }
-    qDebug() << "Failed to write track metadata into file"
+    kLogger.debug() << "Failed to write track metadata into file"
             << pTrack->getLocation();
     return SaveTrackMetadataResult::FAILED;
 }
@@ -363,7 +366,7 @@ void SoundSourceProxy::initSoundSource() {
         mixxx::SoundSourceProviderPointer pProvider(getSoundSourceProvider());
         if (!pProvider) {
             if (!getUrl().isEmpty()) {
-                qWarning() << "No SoundSourceProvider for file"
+                kLogger.warning() << "No SoundSourceProvider for file"
                            << getUrl().toString();
             }
             // Failure
@@ -371,7 +374,7 @@ void SoundSourceProxy::initSoundSource() {
         }
         m_pSoundSource = pProvider->newSoundSource(m_url);
         if (!m_pSoundSource) {
-            qWarning() << "SoundSourceProvider"
+            kLogger.warning() << "SoundSourceProvider"
                        << pProvider->getName()
                        << "failed to create a SoundSource for file"
                        << getUrl().toString();
@@ -381,7 +384,7 @@ void SoundSourceProxy::initSoundSource() {
             DEBUG_ASSERT(!m_pSoundSource);
         } else {
             QString trackType(m_pSoundSource->getType());
-            qDebug() << "SoundSourceProvider"
+            kLogger.debug() << "SoundSourceProvider"
                      << pProvider->getName()
                      << "created a SoundSource for file"
                      << getUrl().toString()
@@ -430,7 +433,7 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
 
     if (!m_pSoundSource) {
         // Silently ignore requests for unsupported files
-        qDebug() << "Unable to parse file tags without a SoundSource"
+        kLogger.debug() << "Unable to parse file tags without a SoundSource"
                  << getUrl().toString();
         return;
     }
@@ -444,7 +447,7 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
     mixxx::TrackMetadata trackMetadata;
     m_pTrack->getTrackMetadata(&trackMetadata, &parsedFromFile);
     if (parsedFromFile && !reloadFromFile) {
-        qDebug() << "Skip parsing of track metadata from file"
+        kLogger.debug() << "Skip parsing of track metadata from file"
                  << getUrl().toString();
         return; // do not reload from file
     }
@@ -472,7 +475,7 @@ void SoundSourceProxy::loadTrackMetadataAndCoverArt(
             parsedCoverArt = true;
         }
     } else {
-        qWarning() << "Failed to parse track metadata from file"
+        kLogger.warning() << "Failed to parse track metadata from file"
                    << getUrl().toString();
         if (parsedFromFile) {
             // Don't overwrite any existing metadata that once has
@@ -572,14 +575,14 @@ private:
 mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSourceConfig& audioSrcCfg) {
     DEBUG_ASSERT(m_pTrack);
     while (m_pSoundSource && !m_pAudioSource) {
-        qDebug() << "Opening file"
+        kLogger.debug() << "Opening file"
                 << getUrl().toString()
                 << "with provider"
                 << getSoundSourceProvider()->getName();
         const mixxx::SoundSource::OpenResult openResult =
                 m_pSoundSource->open(audioSrcCfg);
         if (openResult == mixxx::SoundSource::OpenResult::ABORTED) {
-            qWarning() << "Unable to open file"
+            kLogger.warning() << "Unable to open file"
                     << getUrl().toString()
                     << "with provider"
                     << getSoundSourceProvider()->getName();
@@ -593,7 +596,7 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSo
                     AudioSourceProxy::create(m_pTrack, m_pSoundSource);
             DEBUG_ASSERT(m_pAudioSource);
             if (m_pAudioSource->isEmpty()) {
-                qWarning() << "File is empty"
+                kLogger.warning() << "File is empty"
                            << getUrl().toString();
             }
             // Overwrite metadata with actual audio properties
@@ -612,7 +615,7 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSo
                 }
             }
         } else {
-            qWarning() << "Failed to open file"
+            kLogger.warning() << "Failed to open file"
                        << getUrl().toString()
                        << "with provider"
                        << getSoundSourceProvider()->getName();
@@ -627,7 +630,7 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSo
     }
     // All available providers have returned OpenResult::ABORTED when
     // getting here. m_pSoundSource might already be invalid/null!
-    qWarning() << "Unable to decode file"
+    kLogger.warning() << "Unable to decode file"
             << getUrl().toString();
     DEBUG_ASSERT(!m_pAudioSource);
     return m_pAudioSource;
@@ -638,7 +641,7 @@ void SoundSourceProxy::closeAudioSource() {
         DEBUG_ASSERT(m_pSoundSource);
         m_pSoundSource->close();
         m_pAudioSource = mixxx::AudioSourcePointer();
-        qDebug() << "Closed AudioSource for file"
+        kLogger.debug() << "Closed AudioSource for file"
                  << getUrl().toString();
     }
 }

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -1,8 +1,14 @@
-#include <QDir>
-
 #include "sources/soundsourcesndfile.h"
 
+#include "util/logging.h"
+
 namespace mixxx {
+
+namespace {
+
+const Logger kLogger("SoundSourceSndFile");
+
+} // anonymous namespace
 
 SoundSourceSndFile::SoundSourceSndFile(const QUrl& url)
         : SoundSource(url),
@@ -46,7 +52,7 @@ SoundSource::OpenResult SoundSourceSndFile::tryOpen(const AudioSourceConfig& /*a
             // that contains data in an unsupported format!
             return OpenResult::ABORTED;
         } else {
-            qWarning() << "Error opening libsndfile file:"
+            kLogger.warning() << "Error opening libsndfile file:"
                     << getUrlString()
                     << errorMsg;
             return OpenResult::FAILED;
@@ -69,7 +75,7 @@ void SoundSourceSndFile::close() {
             m_pSndFile = nullptr;
             m_curFrameIndex = getMinFrameIndex();
         } else {
-            qWarning() << "Failed to close file:" << closeResult
+            kLogger.warning() << "Failed to close file:" << closeResult
                     << sf_strerror(m_pSndFile)
                     << getUrlString();
         }
@@ -95,7 +101,7 @@ SINT SoundSourceSndFile::seekSampleFrame(
         m_curFrameIndex = seekResult;
         return seekResult;
     } else {
-        qWarning() << "Failed to seek libsnd file:" << seekResult
+        kLogger.warning() << "Failed to seek libsnd file:" << seekResult
                 << sf_strerror(m_pSndFile);
         return sf_seek(m_pSndFile, 0, SEEK_CUR);
     }
@@ -128,7 +134,7 @@ SINT SoundSourceSndFile::readSampleFrames(
         m_curFrameIndex += readCount;
         return readCount;
     } else {
-        qWarning() << "Failed to read from libsnd file:" << readCount
+        kLogger.warning() << "Failed to read from libsnd file:" << readCount
                 << sf_strerror(m_pSndFile);
         return 0;
     }

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -1,3 +1,5 @@
+#include <QDir>
+
 #include "sources/soundsourcesndfile.h"
 
 #include "util/logging.h"

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -2,7 +2,7 @@
 
 #include "sources/soundsourcesndfile.h"
 
-#include "util/logging.h"
+#include "util/logger.h"
 
 namespace mixxx {
 

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -58,7 +58,9 @@ bool CmdlineArgs::Parse(int &argc, char **argv) {
         } else if (argv[i] == QString("--logLevel") && i+1 < argc) {
             logLevelSet = true;
             auto level = QLatin1String(argv[i+1]);
-            if (level == "debug") {
+            if (level == "trace") {
+                m_logLevel = mixxx::LogLevel::Trace;
+            } else if (level == "debug") {
                 m_logLevel = mixxx::LogLevel::Debug;
             } else if (level == "info") {
                 m_logLevel = mixxx::LogLevel::Info;
@@ -67,7 +69,7 @@ bool CmdlineArgs::Parse(int &argc, char **argv) {
             } else if (level == "critical") {
                 m_logLevel = mixxx::LogLevel::Critical;
             } else {
-                fputs("\nlogLevel argument wasn't 'debug', 'info', 'warning', or 'critical'! Mixxx will only output\n\
+                fputs("\nlogLevel argument wasn't 'trace', 'debug', 'info', 'warning', or 'critical'! Mixxx will only output\n\
 warnings and errors to the console unless this is set properly.\n", stdout);
             }
             i++;
@@ -142,9 +144,10 @@ void CmdlineArgs::printUsage() {
 \n\
 --logLevel LEVEL        Sets the verbosity of command line logging\n\
                         critical - Critical/Fatal only\n\
-                        warning - Above + Warnings\n\
-                        info - Above + Informational messages\n\
-                        debug - Above + Debug/Developer messages\n\
+                        warning  - Above + Warnings\n\
+                        info     - Above + Informational messages\n\
+                        debug    - Above + Debug/Developer messages\n\
+                        trace    - Above + Profiling messages\n\
 \n"
 #ifdef MIXXX_BUILD_DEBUG
 "\

--- a/src/util/db/fwdsqlquery.cpp
+++ b/src/util/db/fwdsqlquery.cpp
@@ -22,11 +22,9 @@ bool prepareQuery(QSqlQuery& query, const QString& statement) {
     }
     if (query.prepare(statement)) {
         if (kLogger.traceEnabled()) {
-            kLogger.trace() << "Preparing"
-                    << statement
-                    << "took"
-                    << timer.elapsed().toIntegerMicros()
-                    << "us";
+            kLogger.tracePerformance(
+                    QString("Preparing \"%1\"").arg(statement),
+                    timer);
         }
         return true;
     } else {
@@ -59,11 +57,11 @@ bool FwdSqlQuery::execPrepared() {
     }
     if (exec()) {
         if (kLogger.traceEnabled()) {
-            kLogger.trace() << "Executing"
-                    << executedQuery()
-                    << "took"
-                    << timer.elapsed().toIntegerMicros()
-                    << "us";
+            if (kLogger.traceEnabled()) {
+                kLogger.tracePerformance(
+                        QString("Executing \"%1\"").arg(executedQuery()),
+                        timer);
+            }
         }
         DEBUG_ASSERT(!hasError());
         // Verify our assumption that the size of the result set

--- a/src/util/db/fwdsqlquery.cpp
+++ b/src/util/db/fwdsqlquery.cpp
@@ -25,7 +25,8 @@ bool prepareQuery(QSqlQuery& query, const QString& statement) {
             kLogger.trace() << "Preparing"
                     << statement
                     << "took"
-                    << timer.elapsed();
+                    << timer.elapsed().toIntegerMicros()
+                    << "us";
         }
         return true;
     } else {
@@ -61,7 +62,8 @@ bool FwdSqlQuery::execPrepared() {
             kLogger.trace() << "Executing"
                     << executedQuery()
                     << "took"
-                    << timer.elapsed();
+                    << timer.elapsed().toIntegerMicros()
+                    << "us";
         }
         DEBUG_ASSERT(!hasError());
         // Verify our assumption that the size of the result set

--- a/src/util/logger.cpp
+++ b/src/util/logger.cpp
@@ -9,20 +9,22 @@ namespace {
 
 const QLatin1String kLogPreambleSuffix(" -");
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-const std::size_t kLogPreambleSuffixLen = std::strlen(kLogPreambleSuffix.latin1());
+const int kLogPreambleSuffixLen = std::strlen(kLogPreambleSuffix.latin1());
+#else
+const int kLogPreambleSuffixLen = kLogPreambleSuffix.size();
 #endif
 
 inline QByteArray preambleChars(const QLatin1String& logContext) {
     QByteArray preamble;
-    std::size_t logContextLen = std::strlen(logContext.latin1());
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+    const int logContextLen = std::strlen(logContext.latin1());
+#else
+    const int logContextLen = logContext.size();
+#endif
     if (logContextLen > 0) {
         preamble.reserve(logContextLen + kLogPreambleSuffixLen);
         preamble.append(logContext.latin1(), logContextLen);
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
         preamble.append(kLogPreambleSuffix.latin1(), kLogPreambleSuffixLen);
-#else
-        preamble.append(kLogPreambleSuffix.latin1(), kLogPreambleSuffix.size());
-#endif
     }
     return preamble;
 }

--- a/src/util/logger.cpp
+++ b/src/util/logger.cpp
@@ -5,20 +5,29 @@
 
 namespace {
 
-inline QString preambleString(const char* logContext) {
-    if ((logContext == nullptr) || (std::strlen(logContext) == 0)) {
-        return QString();
-    } else {
-        return QString("%1 -").arg(logContext);
+const char* const kLogPreambleSuffix = " -";
+const std::size_t kLogPreambleSuffixLen = std::strlen(kLogPreambleSuffix);
+
+inline QByteArray preambleChars(const char* logContext) {
+    QByteArray preamble;
+    if (logContext != nullptr) {
+        std::size_t logContextLen = std::strlen(logContext);
+        if (logContextLen > 0) {
+            preamble.reserve(logContextLen + kLogPreambleSuffixLen);
+            preamble.append(logContext, logContextLen);
+            preamble.append(kLogPreambleSuffix, kLogPreambleSuffixLen);
+        }
     }
+    return preamble;
 }
 
-inline QString preambleString(const QString& logContext) {
-    if (logContext.isEmpty()) {
-        return QString();
-    } else {
-        return QString("%1 -").arg(logContext);
+inline QByteArray preambleChars(const QString& logContext) {
+    QByteArray preamble;
+    if (!logContext.isEmpty()) {
+        preamble = logContext.toLocal8Bit();
+        preamble.append(kLogPreambleSuffix, kLogPreambleSuffixLen);
     }
+    return preamble;
 }
 
 } // anonymous namespace
@@ -26,10 +35,10 @@ inline QString preambleString(const QString& logContext) {
 namespace mixxx {
 
 Logger::Logger(const char* logContext)
-    : m_preambleChars(preambleString(logContext).toLocal8Bit()) {
+    : m_preambleChars(preambleChars(logContext)) {
 }
 Logger::Logger(const QString& logContext)
-    : m_preambleChars(preambleString(logContext).toLocal8Bit()) {
+    : m_preambleChars(preambleChars(logContext)) {
 }
 
 }  // namespace mixxx

--- a/src/util/logger.cpp
+++ b/src/util/logger.cpp
@@ -8,15 +8,13 @@ namespace {
 const char* const kLogPreambleSuffix = " -";
 const std::size_t kLogPreambleSuffixLen = std::strlen(kLogPreambleSuffix);
 
-inline QByteArray preambleChars(const char* logContext) {
+inline QByteArray preambleChars(const QLatin1String& logContext) {
     QByteArray preamble;
-    if (logContext != nullptr) {
-        std::size_t logContextLen = std::strlen(logContext);
-        if (logContextLen > 0) {
-            preamble.reserve(logContextLen + kLogPreambleSuffixLen);
-            preamble.append(logContext, logContextLen);
-            preamble.append(kLogPreambleSuffix, kLogPreambleSuffixLen);
-        }
+    std::size_t logContextLen = std::strlen(logContext.latin1());
+    if (logContextLen > 0) {
+        preamble.reserve(logContextLen + kLogPreambleSuffixLen);
+        preamble.append(logContext.latin1(), logContextLen);
+        preamble.append(kLogPreambleSuffix, kLogPreambleSuffixLen);
     }
     return preamble;
 }
@@ -26,11 +24,11 @@ inline QByteArray preambleChars(const char* logContext) {
 namespace mixxx {
 
 Logger::Logger(const char* logContext)
-    : m_preambleChars(preambleChars(logContext)) {
+    : m_preambleChars(preambleChars(QLatin1String(logContext))) {
 }
 
 Logger::Logger(const QLatin1String& logContext)
-    : m_preambleChars(preambleChars(logContext.latin1())) {
+    : m_preambleChars(preambleChars(logContext)) {
 }
 
 }  // namespace mixxx

--- a/src/util/logger.cpp
+++ b/src/util/logger.cpp
@@ -1,12 +1,16 @@
-#include <cstring>
-
 #include "util/logger.h"
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+#include <cstring>
+#endif
 
 
 namespace {
 
-const char* const kLogPreambleSuffix = " -";
-const std::size_t kLogPreambleSuffixLen = std::strlen(kLogPreambleSuffix);
+const QLatin1String kLogPreambleSuffix(" -");
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+const std::size_t kLogPreambleSuffixLen = std::strlen(kLogPreambleSuffix.latin1());
+#endif
 
 inline QByteArray preambleChars(const QLatin1String& logContext) {
     QByteArray preamble;
@@ -14,7 +18,11 @@ inline QByteArray preambleChars(const QLatin1String& logContext) {
     if (logContextLen > 0) {
         preamble.reserve(logContextLen + kLogPreambleSuffixLen);
         preamble.append(logContext.latin1(), logContextLen);
-        preamble.append(kLogPreambleSuffix, kLogPreambleSuffixLen);
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+        preamble.append(kLogPreambleSuffix.latin1(), kLogPreambleSuffixLen);
+#else
+        preamble.append(kLogPreambleSuffix.latin1(), kLogPreambleSuffix.size());
+#endif
     }
     return preamble;
 }

--- a/src/util/logger.cpp
+++ b/src/util/logger.cpp
@@ -1,0 +1,35 @@
+#include <cstring>
+
+#include "util/logger.h"
+
+
+namespace {
+
+inline QString preambleString(const char* logContext) {
+    if ((logContext == nullptr) || (std::strlen(logContext) == 0)) {
+        return QString();
+    } else {
+        return QString("%1 -").arg(logContext);
+    }
+}
+
+inline QString preambleString(const QString& logContext) {
+    if (logContext.isEmpty()) {
+        return QString();
+    } else {
+        return QString("%1 -").arg(logContext);
+    }
+}
+
+} // anonymous namespace
+
+namespace mixxx {
+
+Logger::Logger(const char* logContext)
+    : m_preambleChars(preambleString(logContext).toLocal8Bit()) {
+}
+Logger::Logger(const QString& logContext)
+    : m_preambleChars(preambleString(logContext).toLocal8Bit()) {
+}
+
+}  // namespace mixxx

--- a/src/util/logger.cpp
+++ b/src/util/logger.cpp
@@ -21,15 +21,6 @@ inline QByteArray preambleChars(const char* logContext) {
     return preamble;
 }
 
-inline QByteArray preambleChars(const QString& logContext) {
-    QByteArray preamble;
-    if (!logContext.isEmpty()) {
-        preamble = logContext.toLocal8Bit();
-        preamble.append(kLogPreambleSuffix, kLogPreambleSuffixLen);
-    }
-    return preamble;
-}
-
 } // anonymous namespace
 
 namespace mixxx {
@@ -37,8 +28,9 @@ namespace mixxx {
 Logger::Logger(const char* logContext)
     : m_preambleChars(preambleChars(logContext)) {
 }
-Logger::Logger(const QString& logContext)
-    : m_preambleChars(preambleChars(logContext)) {
+
+Logger::Logger(const QLatin1String& logContext)
+    : m_preambleChars(preambleChars(logContext.latin1())) {
 }
 
 }  // namespace mixxx

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -7,6 +7,7 @@
 #include <QtDebug>
 
 #include "util/logging.h"
+#include "util/performancetimer.h"
 
 
 namespace mixxx {
@@ -28,6 +29,15 @@ public:
 
     bool traceEnabled() const {
         return Logging::traceEnabled();
+    }
+
+    // Trace the elapsed time of some timed action in microseconds.
+    template<typename T>
+    void tracePerformance(const T& timed, const PerformanceTimer& timer) const {
+        if (traceEnabled()) {
+            trace() << timed << "took"
+                    << timer.elapsed().toIntegerMicros() << "us";
+        }
     }
 
     QDebug debug() const {

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -3,6 +3,7 @@
 
 
 #include <QByteArray>
+#include <QLatin1String>
 #include <QtDebug>
 
 #include "util/logging.h"
@@ -14,7 +15,7 @@ class Logger final {
 public:
     Logger() = default;
     explicit Logger(const char* logContext);
-    explicit Logger(const QString& logContext);
+    explicit Logger(const QLatin1String& logContext);
 
     QDebug log(QDebug stream) const {
         return stream << m_preambleChars.data();

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -39,6 +39,12 @@ public:
                     << timer.elapsed().toIntegerMicros() << "us";
         }
     }
+    void tracePerformance(const QLatin1String& timed, const PerformanceTimer& timer) const {
+        tracePerformance(timed.latin1(), timer);
+    }
+    void tracePerformance(const QString& timed, const PerformanceTimer& timer) const {
+        tracePerformance(timed.toLocal8Bit().data(), timer);
+    }
 
     QDebug debug() const {
         return log(qDebug());

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -1,0 +1,59 @@
+#ifndef MIXXX_UTIL_LOGGER_H
+#define MIXXX_UTIL_LOGGER_H
+
+
+#include <QByteArray>
+#include <QtDebug>
+
+#include "util/logging.h"
+
+
+namespace mixxx {
+
+class Logger final {
+public:
+    Logger() = default;
+    explicit Logger(const char* logContext);
+    explicit Logger(const QString& logContext);
+
+    QDebug log(QDebug stream) const {
+        return stream << m_preambleChars.data();
+    }
+
+    QDebug debug() const {
+        return log(qDebug());
+    }
+
+    bool debugEnabled() const {
+        return Logging::debugEnabled();
+    }
+
+    QDebug info() const {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+        return log(qInfo());
+#else
+        // Qt4 does not support log level Info, use Debug instead
+        return debug();
+#endif
+    }
+
+    bool infoEnabled() const {
+        return Logging::infoEnabled();
+    }
+
+    QDebug warning() const {
+        return log(qWarning());
+    }
+
+    QDebug critical() const {
+        return log(qCritical());
+    }
+
+private:
+    QByteArray m_preambleChars;
+};
+
+}  // namespace mixxx
+
+
+#endif /* MIXXX_UTIL_LOGGER_H */

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -21,6 +21,15 @@ public:
         return stream << m_preambleChars.data();
     }
 
+    QDebug trace() const {
+        // Trace logs just provide more details than debug logs
+        return log(qDebug());
+    }
+
+    bool traceEnabled() const {
+        return Logging::traceEnabled();
+    }
+
     QDebug debug() const {
         return log(qDebug());
     }

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -176,7 +176,7 @@ void MessageHandler(QtMsgType type,
 }  // namespace
 
 // static
-void Logging::initialize(const QString& settingsPath, LogLevel logLevel,
+void Logging::initialize(const QDir& settingsDir, LogLevel logLevel,
                          bool debugAssertBreak) {
     VERIFY_OR_DEBUG_ASSERT(!g_logfile.isOpen()) {
         // Somebody already called Logging::initialize.
@@ -186,7 +186,6 @@ void Logging::initialize(const QString& settingsPath, LogLevel logLevel,
     s_logLevel = logLevel;
 
     QString logFileName;
-    QDir settingsDir(settingsPath);
 
     // Rotate old logfiles.
     for (int i = 9; i >= 0; --i) {
@@ -239,33 +238,6 @@ void Logging::shutdown() {
     if (g_logfile.isOpen()) {
         g_logfile.close();
     }
-}
-
-namespace {
-
-inline QString preambleString(const char* logContext) {
-    if ((logContext == nullptr) || (strlen(logContext) == 0)) {
-        return QString();
-    } else {
-        return QString("%1 -").arg(logContext);
-    }
-}
-
-inline QString preambleString(const QString& logContext) {
-    if (logContext.isEmpty()) {
-        return QString();
-    } else {
-        return QString("%1 -").arg(logContext);
-    }
-}
-
-} // anonymous namespace
-
-Logger::Logger(const char* logContext)
-    : m_preambleChars(preambleString(logContext).toLocal8Bit()) {
-}
-Logger::Logger(const QString& logContext)
-    : m_preambleChars(preambleString(logContext).toLocal8Bit()) {
 }
 
 }  // namespace mixxx

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -241,4 +241,31 @@ void Logging::shutdown() {
     }
 }
 
+namespace {
+
+inline QString preambleString(const char* logContext) {
+    if ((logContext == nullptr) || (strlen(logContext) == 0)) {
+        return QString();
+    } else {
+        return QString("%1 -").arg(logContext);
+    }
+}
+
+inline QString preambleString(const QString& logContext) {
+    if (logContext.isEmpty()) {
+        return QString();
+    } else {
+        return QString("%1 -").arg(logContext);
+    }
+}
+
+} // anonymous namespace
+
+Logger::Logger(const char* logContext)
+    : m_preambleChars(preambleString(logContext).toLocal8Bit()) {
+}
+Logger::Logger(const QString& logContext)
+    : m_preambleChars(preambleString(logContext).toLocal8Bit()) {
+}
+
 }  // namespace mixxx

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -11,6 +11,7 @@ enum class LogLevel {
     Warning = 1,
     Info = 2,
     Debug = 3,
+    Trace = 4, // for profiling etc.
     Default = Warning,
 };
 
@@ -28,6 +29,9 @@ class Logging {
     }
     static bool enabled(LogLevel logLevel) {
         return s_logLevel >= logLevel;
+    }
+    static bool traceEnabled() {
+        return enabled(LogLevel::Trace);
     }
     static bool debugEnabled() {
         return enabled(LogLevel::Debug);

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -70,15 +70,6 @@ public:
         return log(qCritical());
     }
 
-    QDebug fatal() const {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-        return log(qFatal());
-#else
-        // Qt4 does not support QDebug for log level Fatal, use Critical instead
-        return critical();
-#endif
-    }
-
 private:
     QByteArray m_preambleChars;
 };

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -1,7 +1,8 @@
 #ifndef MIXXX_UTIL_LOGGING_H
 #define MIXXX_UTIL_LOGGING_H
 
-#include <QString>
+#include <QtDebug>
+
 
 namespace mixxx {
 
@@ -36,6 +37,50 @@ class Logging {
     Logging() = delete;
 
     static LogLevel s_logLevel;
+};
+
+class Logger final {
+public:
+    Logger() = default;
+    explicit Logger(const char* logContext);
+    explicit Logger(const QString& logContext);
+
+    QDebug log(QDebug stream) const {
+        return stream << m_preambleChars.data();
+    }
+
+    QDebug debug() const {
+        return log(qDebug());
+    }
+
+    QDebug info() const {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+        return log(qInfo());
+#else
+        // Qt4 does not support log level Info, use Debug instead
+        return debug();
+#endif
+    }
+
+    QDebug warning() const {
+        return log(qWarning());
+    }
+
+    QDebug critical() const {
+        return log(qCritical());
+    }
+
+    QDebug fatal() const {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+        return log(qFatal());
+#else
+        // Qt4 does not support QDebug for log level Fatal, use Critical instead
+        return critical();
+#endif
+    }
+
+private:
+    QByteArray m_preambleChars;
 };
 
 }  // namespace mixxx

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -1,7 +1,7 @@
 #ifndef MIXXX_UTIL_LOGGING_H
 #define MIXXX_UTIL_LOGGING_H
 
-#include <QtDebug>
+#include <QDir>
 
 
 namespace mixxx {
@@ -17,7 +17,7 @@ enum class LogLevel {
 class Logging {
   public:
     // These are not thread safe. Only call them on Mixxx startup and shutdown.
-    static void initialize(const QString& settingsPath,
+    static void initialize(const QDir& settingsDir,
                            LogLevel logLevel,
                            bool debugAssertBreak);
     static void shutdown();
@@ -40,49 +40,6 @@ class Logging {
     Logging() = delete;
 
     static LogLevel s_logLevel;
-};
-
-class Logger final {
-public:
-    Logger() = default;
-    explicit Logger(const char* logContext);
-    explicit Logger(const QString& logContext);
-
-    QDebug log(QDebug stream) const {
-        return stream << m_preambleChars.data();
-    }
-
-    QDebug debug() const {
-        return log(qDebug());
-    }
-
-    bool debugEnabled() const {
-        return Logging::debugEnabled();
-    }
-
-    QDebug info() const {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-        return log(qInfo());
-#else
-        // Qt4 does not support log level Info, use Debug instead
-        return debug();
-#endif
-    }
-
-    bool infoEnabled() const {
-        return Logging::infoEnabled();
-    }
-
-    QDebug warning() const {
-        return log(qWarning());
-    }
-
-    QDebug critical() const {
-        return log(qCritical());
-    }
-
-private:
-    QByteArray m_preambleChars;
 };
 
 }  // namespace mixxx

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -32,6 +32,9 @@ class Logging {
     static bool debugEnabled() {
         return enabled(LogLevel::Debug);
     }
+    static bool infoEnabled() {
+        return enabled(LogLevel::Info);
+    }
 
   private:
     Logging() = delete;
@@ -53,6 +56,10 @@ public:
         return log(qDebug());
     }
 
+    bool debugEnabled() const {
+        return Logging::debugEnabled();
+    }
+
     QDebug info() const {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
         return log(qInfo());
@@ -60,6 +67,10 @@ public:
         // Qt4 does not support log level Info, use Debug instead
         return debug();
 #endif
+    }
+
+    bool infoEnabled() const {
+        return Logging::infoEnabled();
     }
 
     QDebug warning() const {


### PR DESCRIPTION
A simple logger that provides the ability to consistently add context information like a class name to log messages. It also helps to transparently use the log levels _Info_ and _Fatal_ in Qt4 code, which are currently not or only partially supported.

As an example I've replaced all Qt logging primitives with the new mixxx::Logger in SoundSources.