### PR TITLE
Components: refactor Button input handling

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -505,7 +505,9 @@
                 if (typeof component.shift === 'function') {
                     if (component instanceof Button
                         && (component.type === Button.prototype.types.push
-                            || component.type === undefined)) {
+                            || component.type === undefined)
+                        && component.inKey !== undefined
+                        && component.input === Button.prototype.input) {
                         if (engine.getValue(component.group, component.inKey) !== 0) {
                             engine.setValue(component.group, component.inKey, 0);
                         }
@@ -521,7 +523,9 @@
                 if (typeof component.unshift === 'function') {
                     if (component instanceof Button
                         && (component.type === Button.prototype.types.push
-                            || component.type === undefined)) {
+                            || component.type === undefined)
+                        && component.inKey !== undefined
+                        && component.input === Button.prototype.input) {
                         if (engine.getValue(component.group, component.inKey) !== 0) {
                             engine.setValue(component.group, component.inKey, 0);
                         }

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -163,7 +163,13 @@
         Component.call(this, options);
     };
     Button.prototype = new Component({
-        onlyOnPress: true,
+        types: {
+            push: 0,
+            toggle: 1,
+            trigger: 2,
+            powerWindow: 3,
+        },
+        type: 0,
         on: 127,
         off: 0,
         // Time in milliseconds to distinguish a short press from a long press.
@@ -174,9 +180,18 @@
         isPress: function (channel, control, value, status) {
             return value > 0;
         },
-        inValueScale: function () { return ! this.inGetValue(); },
         input: function (channel, control, value, status, group) {
-            if (this.powerWindow) {
+            if (this.type === undefined || this.type === this.types.push) {
+                this.inSetValue(this.isPress(channel, control, value, status));
+            } else if (this.type === this.types.toggle) {
+                if (this.isPress(channel, control, value, status)) {
+                    this.inToggle();
+                }
+            } else if (this.type === this.types.trigger) {
+                if (this.isPress(channel, control, value, status)) {
+                    this.inSetValue(1);
+                }
+            } else if (this.type === this.types.powerWindow) {
                 if (this.isPress(channel, control, value, status)) {
                     script.toggleControl(this.group, this.inKey);
                     this.longPressTimer = engine.beginTimer(this.longPressTimeout, function () {
@@ -191,14 +206,6 @@
                         this.isLongPressed = false;
                         this.longPressTimer = 0;
                     }
-                }
-            } else {
-                if (this.onlyOnPress) {
-                    if (this.isPress(channel, control, value, status)) {
-                        this.inSetValue(this.inValueScale(value));
-                    }
-                } else {
-                    this.inSetValue(this.inValueScale(value));
                 }
             }
         },
@@ -217,6 +224,7 @@
         shift: function () {
             this.inKey = 'reverse';
         },
+        type: Button.prototype.types.toggle,
         outKey: 'play_indicator',
     });
 
@@ -229,9 +237,6 @@
         },
         shift: function () {
             this.inKey = 'start_stop';
-        },
-        input: function (channel, control, value, status, group) {
-            this.inSetValue(this.isPress(channel, control, value, status));
         },
         outKey: 'cue_indicator',
     });
@@ -258,6 +263,7 @@
         },
         shift: function () {
             this.inKey = 'quantize';
+            this.type = Button.prototype.types.toggle;
             this.input = Button.prototype.input;
         },
         outKey: 'sync_enabled',
@@ -290,7 +296,6 @@
         shift: function () {
             this.inKey = 'hotcue_' + this.number + '_clear';
         },
-        onlyOnPress: false,
     });
 
     var SamplerButton = function (options) {
@@ -354,7 +359,9 @@
         options.group = '[EffectRack1_EffectUnit' + options.effectUnit + ']';
         Button.call(this, options);
     };
-    EffectAssignmentButton.prototype = new Button();
+    EffectAssignmentButton.prototype = new Button({
+        type: Button.prototype.types.toggle,
+    });
 
     var Pot = function (options) {
         Component.call(this, options);
@@ -496,6 +503,13 @@
         shift: function () {
             this.forEachComponent(function (component) {
                 if (typeof component.shift === 'function') {
+                    if (component instanceof Button
+                        && (component.type === Button.prototype.types.push
+                            || component.type === undefined)) {
+                        if (engine.getValue(component.group, component.inKey) !== 0) {
+                            engine.setValue(component.group, component.inKey, 0);
+                        }
+                    }
                     component.shift();
                 }
                 // Set isShifted for child ComponentContainers forEachComponent is iterating through recursively
@@ -505,6 +519,13 @@
         unshift: function () {
             this.forEachComponent(function (component) {
                 if (typeof component.unshift === 'function') {
+                    if (component instanceof Button
+                        && (component.type === Button.prototype.types.push
+                            || component.type === undefined)) {
+                        if (engine.getValue(component.group, component.inKey) !== 0) {
+                            engine.setValue(component.group, component.inKey, 0);
+                        }
+                    }
                     component.unshift();
                 }
                 // Set isShifted for child ComponentContainers forEachComponent is iterating through recursively
@@ -721,6 +742,7 @@
             this[channel] = new Button({
                 group: eu.group,
                 key: 'group_[' + channel + ']_enable',
+                type: Button.prototype.types.toggle,
                 outConnect: false,
             });
         };
@@ -807,7 +829,7 @@
         this.EffectEnableButton.prototype = new Button({
             stopEffectFocusChooseMode: function () {
                 this.inKey = 'enabled';
-                this.powerWindow = true;
+                this.type = Button.prototype.types.powerWindow;
                 this.input = Button.prototype.input;
 
                 this.outKey = 'enabled';

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -188,19 +188,17 @@
                 }
             } else if (this.type === this.types.powerWindow) {
                 if (this.isPress(channel, control, value, status)) {
-                    script.toggleControl(this.group, this.inKey);
+                    this.inToggle();
                     this.longPressTimer = engine.beginTimer(this.longPressTimeout, function () {
                         this.isLongPressed = true;
                     }, true);
                 } else {
                     if (this.isLongPressed) {
-                        script.toggleControl(this.group, this.inKey);
-                    }
-                    if (this.longPressTimer) {
+                        this.inToggle();
+                    } else {
                         engine.stopTimer(this.longPressTimer);
-                        this.isLongPressed = false;
-                        this.longPressTimer = 0;
                     }
+                    this.isLongPressed = false;
                 }
             }
         },

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -166,8 +166,7 @@
         types: {
             push: 0,
             toggle: 1,
-            trigger: 2,
-            powerWindow: 3,
+            powerWindow: 2,
         },
         type: 0,
         on: 127,
@@ -186,10 +185,6 @@
             } else if (this.type === this.types.toggle) {
                 if (this.isPress(channel, control, value, status)) {
                     this.inToggle();
-                }
-            } else if (this.type === this.types.trigger) {
-                if (this.isPress(channel, control, value, status)) {
-                    this.inSetValue(1);
                 }
             } else if (this.type === this.types.powerWindow) {
                 if (this.isPress(channel, control, value, status)) {


### PR DESCRIPTION
Remove the old onlyOnPress Button property. When set to false, this would toggle the value of a Control on button up and button down, which is [not really the correct behavior](https://github.com/mixxxdj/mixxx/pull/1184#discussion_r100699865). Instead, let Buttons have a type, with the default type being push. The button types are:

  * push: set inKey to 1 on button press and 0 on button release
  * toggle: invert value of inKey on button press
  * powerWindow: like toggle, but toggles the value of inKey again on button up when long pressed

The ComponentContainer.shift() and ComponentContainer.unshift() functions automatically take care of setting the inKey of push type Buttons to 0 on shift/unshift to ensure that it does not matter whether shift or the Button is released first. Before this [required some ugly hacks](https://github.com/mixxxdj/mixxx/pull/1243#issuecomment-304557891) that would have to be implemented by each Button.

This is a backwards incompatible change. Previously, the default was to set the onlyOnPress property to `true`, equivalent to the new toggle type. Buttons that had onlyOnPress set to `false` before can simply remove that and use the default push type. All the special Buttons implemented in the library such as HotcueButton and the Buttons for the EffectUnit have been updated appropriately. I'll update #1200 and #1243 for the new API.