### PR TITLE
Hotfix: Logger must not use any static data for initialization

### DIFF
--- a/src/util/logger.cpp
+++ b/src/util/logger.cpp
@@ -1,18 +1,16 @@
 #include "util/logger.h"
 
+
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 #include <cstring>
 #endif
 
+// NOTE(uklotzde): The initialization of Logger must not depend on any
+// static data, because Logger instances are usually instantiated as
+// static instances within other compilation units. The order of static
+// initializations across compilation units is undefined!!
 
 namespace {
-
-const QLatin1String kLogPreambleSuffix(" -");
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-const int kLogPreambleSuffixLen = std::strlen(kLogPreambleSuffix.latin1());
-#else
-const int kLogPreambleSuffixLen = kLogPreambleSuffix.size();
-#endif
 
 inline QByteArray preambleChars(const QLatin1String& logContext) {
     QByteArray preamble;
@@ -22,9 +20,15 @@ inline QByteArray preambleChars(const QLatin1String& logContext) {
     const int logContextLen = logContext.size();
 #endif
     if (logContextLen > 0) {
-        preamble.reserve(logContextLen + kLogPreambleSuffixLen);
+        const QLatin1String preambleSuffix(" -");
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+        const int preambleSuffixLen = std::strlen(preambleSuffix.latin1());
+#else
+        const int preambleSuffixLen = preambleSuffix.size();
+#endif
+        preamble.reserve(logContextLen + preambleSuffixLen);
         preamble.append(logContext.latin1(), logContextLen);
-        preamble.append(kLogPreambleSuffix.latin1(), kLogPreambleSuffixLen);
+        preamble.append(preambleSuffix.latin1(), preambleSuffixLen);
     }
     return preamble;
 }


### PR DESCRIPTION
Well, we should have noticed this earlier ;)