### PR TITLE
Fixing Bug 1693972, by always loading an empty chain just before it is required

### DIFF
--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -300,7 +300,7 @@ EffectChainPointer EffectChain::createFromXml(EffectsManager* pEffectsManager,
     QString insertionTypeStr = XmlParse::selectNodeQString(element,
                                                            EffectXml::ChainInsertionType);
 
-    EffectChainPointer pChain = EffectChainPointer(new EffectChain(pEffectsManager, id));
+    EffectChainPointer pChain(new EffectChain(pEffectsManager, id));
     pChain->setName(name);
     pChain->setDescription(description);
     InsertionType insertionType = insertionTypeFromString(insertionTypeStr);

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -300,16 +300,13 @@ EffectChainPointer EffectChain::createFromXml(EffectsManager* pEffectsManager,
     QString insertionTypeStr = XmlParse::selectNodeQString(element,
                                                            EffectXml::ChainInsertionType);
 
-    EffectChain* pChain = new EffectChain(pEffectsManager, id);
+    EffectChainPointer pChain = EffectChainPointer(new EffectChain(pEffectsManager, id));
     pChain->setName(name);
     pChain->setDescription(description);
     InsertionType insertionType = insertionTypeFromString(insertionTypeStr);
     if (insertionType != NUM_INSERTION_TYPES) {
         pChain->setInsertionType(insertionType);
     }
-
-    EffectChainPointer pChainWrapped(pChain);
-    pEffectsManager->getEffectChainManager()->addEffectChain(pChainWrapped);
 
     QDomElement effects = XmlParse::selectElement(element, EffectXml::EffectsRoot);
     QDomNodeList effectChildren = effects.childNodes();
@@ -323,5 +320,5 @@ EffectChainPointer EffectChain::createFromXml(EffectsManager* pEffectsManager,
         }
     }
 
-    return pChainWrapped;
+    return pChain;
 }

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -291,6 +291,11 @@ void EffectChain::sendParameterUpdate() {
 // static
 EffectChainPointer EffectChain::createFromXml(EffectsManager* pEffectsManager,
                                         const QDomElement& element) {
+    if (!element.hasChildNodes()) {
+        // An empty element <EffectChain/> is treated as an ejected Chain (null)
+        return EffectChainPointer();
+    }
+
     QString id = XmlParse::selectNodeQString(element,
                                              EffectXml::ChainId);
     QString name = XmlParse::selectNodeQString(element,

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -19,7 +19,7 @@ EffectChain::EffectChain(EffectsManager* pEffectsManager, const QString& id,
           m_name(""),
           m_insertionType(EffectChain::INSERT),
           m_dMix(0),
-          m_pEngineEffectChain(NULL),
+          m_pEngineEffectChain(nullptr),
           m_bAddedToEngine(false) {
 }
 
@@ -51,6 +51,10 @@ void EffectChain::addToEngine(EngineEffectRack* pRack, int iIndex) {
 }
 
 void EffectChain::removeFromEngine(EngineEffectRack* pRack, int iIndex) {
+    if (!m_bAddedToEngine) {
+        return;
+    }
+
     // Order doesn't matter when removing.
     for (int i = 0; i < m_effects.size(); ++i) {
         EffectPointer pEffect = m_effects[i];
@@ -67,7 +71,7 @@ void EffectChain::removeFromEngine(EngineEffectRack* pRack, int iIndex) {
     m_pEffectsManager->writeRequest(pRequest);
     m_bAddedToEngine = false;
 
-    m_pEngineEffectChain = NULL;
+    m_pEngineEffectChain = nullptr;
 }
 
 void EffectChain::updateEngineState() {
@@ -147,6 +151,9 @@ void EffectChain::setEnabled(bool enabled) {
 }
 
 void EffectChain::enableForChannel(const ChannelHandleAndGroup& handle_group) {
+    if (!m_bAddedToEngine) {
+        return;
+    }
     if (!m_enabledChannels.contains(handle_group)) {
         m_enabledChannels.insert(handle_group);
 
@@ -169,6 +176,9 @@ const QSet<ChannelHandleAndGroup>& EffectChain::enabledChannels() const {
 }
 
 void EffectChain::disableForChannel(const ChannelHandleAndGroup& handle_group) {
+    if (!m_bAddedToEngine) {
+        return;
+    }
     if (m_enabledChannels.remove(handle_group)) {
         EffectsRequest* request = new EffectsRequest();
         request->type = EffectsRequest::DISABLE_EFFECT_CHAIN_FOR_CHANNEL;

--- a/src/effects/effectchainmanager.cpp
+++ b/src/effects/effectchainmanager.cpp
@@ -188,10 +188,12 @@ void EffectChainManager::loadEffectChains(
             QDomElement chainElement = chainNode.toElement();
             EffectChainPointer pChain = EffectChain::createFromXml(
                     m_pEffectsManager, chainElement);
-            EffectChainSlotPointer pChainSlot = pRack->getEffectChainSlot(i);
-            if (pChainSlot) {
-                pChainSlot->loadEffectChain(pChain);
-                pChainSlot->loadChainSlotFromXml(chainElement);
+            if (!pChain->name().isEmpty()) { // skip unnamed = ejected chains.
+                EffectChainSlotPointer pChainSlot = pRack->getEffectChainSlot(i);
+                if (pChainSlot) {
+                    pChainSlot->loadEffectChain(pChain);
+                    pChainSlot->loadChainSlotFromXml(chainElement);
+                }
             }
         }
     }

--- a/src/effects/effectchainmanager.cpp
+++ b/src/effects/effectchainmanager.cpp
@@ -48,7 +48,7 @@ StandardEffectRackPointer EffectChainManager::getStandardEffectRack(int i) {
 
 EqualizerRackPointer EffectChainManager::addEqualizerRack() {
     EqualizerRackPointer pRack(new EqualizerRack(
-        m_pEffectsManager, this, m_equalizerEffectRacks.size()));
+            m_pEffectsManager, this, m_equalizerEffectRacks.size()));
     m_equalizerEffectRacks.append(pRack);
     m_effectRacksByGroup.insert(pRack->getGroup(), pRack);
     return pRack;
@@ -164,12 +164,8 @@ bool EffectChainManager::saveEffectChains() {
     return true;
 }
 
-QList<std::pair<EffectChainPointer, QDomElement>> EffectChainManager::loadEffectChains() {
-    // StandardEffectRack::addEffectChainSlot uses both the EffectChainPointer
-    // and the saved state from the XML to initialize the respective
-    // EffectChain/Effect/EffectParameter/EffectButtonParameter Slots
-    QList<std::pair<EffectChainPointer, QDomElement>> loadedChains;
-
+void EffectChainManager::loadEffectChains(
+        StandardEffectRack* pRack) {
     QDir settingsPath(m_pConfig->getSettingsPath());
     QFile file(settingsPath.absoluteFilePath("effects.xml"));
     QDomDocument doc;
@@ -177,12 +173,7 @@ QList<std::pair<EffectChainPointer, QDomElement>> EffectChainManager::loadEffect
     QDomElement emptyChainElement = doc.createElement(EffectXml::Chain);
     // Check that XML file can be opened and is valid XML
     if (!file.open(QIODevice::ReadOnly) || !doc.setContent(&file)) {
-        for (int i = 0; i < kNumStandardEffectChains; ++i) {
-            EffectChainPointer pEmptyChain = EffectChainPointer(
-                new EffectChain(m_pEffectsManager, QString(), EffectChainPointer()));
-            loadedChains.append(std::make_pair(pEmptyChain, emptyChainElement));
-        }
-        return loadedChains;
+        return;
     }
 
     QDomElement root = doc.documentElement();
@@ -196,20 +187,12 @@ QList<std::pair<EffectChainPointer, QDomElement>> EffectChainManager::loadEffect
         if (chainNode.isElement()) {
             QDomElement chainElement = chainNode.toElement();
             EffectChainPointer pChain = EffectChain::createFromXml(
-                m_pEffectsManager, chainElement);
-
-            loadedChains.append(std::make_pair(pChain, chainElement));
-            m_effectChains.append(pChain);
+                    m_pEffectsManager, chainElement);
+            EffectChainSlotPointer pChainSlot = pRack->getEffectChainSlot(i);
+            if (pChainSlot) {
+                pChainSlot->loadEffectChain(pChain);
+                pChainSlot->loadChainSlotFromXml(chainElement);
+            }
         }
     }
-
-    // Make sure there are enough chains if the XML file does not have
-    // enough <EffectChain> elements
-    for (int i = loadedChains.size(); i < kNumStandardEffectChains; ++i) {
-        EffectChainPointer pEmptyChain = EffectChainPointer(
-            new EffectChain(m_pEffectsManager, QString(), EffectChainPointer()));
-        loadedChains.append(std::make_pair(pEmptyChain, emptyChainElement));
-    }
-
-    return loadedChains;
 }

--- a/src/effects/effectchainmanager.cpp
+++ b/src/effects/effectchainmanager.cpp
@@ -188,7 +188,7 @@ void EffectChainManager::loadEffectChains(
             QDomElement chainElement = chainNode.toElement();
             EffectChainPointer pChain = EffectChain::createFromXml(
                     m_pEffectsManager, chainElement);
-            if (!pChain->name().isEmpty()) { // skip unnamed = ejected chains.
+            if (pChain) { // null = ejected chains.
                 EffectChainSlotPointer pChainSlot = pRack->getEffectChainSlot(i);
                 if (pChainSlot) {
                     pChainSlot->loadEffectChain(pChain);

--- a/src/effects/effectchainmanager.h
+++ b/src/effects/effectchainmanager.h
@@ -51,7 +51,8 @@ class EffectChainManager : public QObject {
     EffectChainPointer getPrevEffectChain(EffectChainPointer pEffectChain);
 
     bool saveEffectChains();
-    QList<std::pair<EffectChainPointer, QDomElement>> loadEffectChains();
+    void loadEffectChains(
+            StandardEffectRack* pRack);
 
     static const int kNumEffectsPerUnit = 4;
     static const int kNumStandardEffectChains = 4;

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -244,7 +244,7 @@ EffectChainPointer EffectChainSlot::getEffectChain() const {
     return m_pEffectChain;
 }
 
-EffectChainPointer EffectChainSlot::getAndEndsureEffectChain(
+EffectChainPointer EffectChainSlot::getAndEnsureEffectChain(
         EffectsManager* pEffectsManager) {
     if (!m_pEffectChain) {
         auto pEffectChain = EffectChainPointer(

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -244,6 +244,17 @@ EffectChainPointer EffectChainSlot::getEffectChain() const {
     return m_pEffectChain;
 }
 
+EffectChainPointer EffectChainSlot::getAndEndsureEffectChain(
+        EffectsManager* pEffectsManager) {
+    if (!m_pEffectChain) {
+        auto pEffectChain = EffectChainPointer(
+                new EffectChain(pEffectsManager, QString()));
+        pEffectChain->setName(QObject::tr("Empty Chain"));
+        loadEffectChain(pEffectChain);
+    }
+    return m_pEffectChain;
+}
+
 void EffectChainSlot::clear() {
     // Stop listening to signals from any loaded effect
     if (m_pEffectChain) {

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -244,7 +244,7 @@ EffectChainPointer EffectChainSlot::getEffectChain() const {
     return m_pEffectChain;
 }
 
-EffectChainPointer EffectChainSlot::getAndEnsureEffectChain(
+EffectChainPointer EffectChainSlot::getOrCreateEffectChain(
         EffectsManager* pEffectsManager) {
     if (!m_pEffectChain) {
         EffectChainPointer pEffectChain(

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -247,7 +247,7 @@ EffectChainPointer EffectChainSlot::getEffectChain() const {
 EffectChainPointer EffectChainSlot::getAndEnsureEffectChain(
         EffectsManager* pEffectsManager) {
     if (!m_pEffectChain) {
-        auto pEffectChain = EffectChainPointer(
+        EffectChainPointer pEffectChain(
                 new EffectChain(pEffectsManager, QString()));
         pEffectChain->setName(QObject::tr("Empty Chain"));
         loadEffectChain(pEffectChain);

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -249,7 +249,8 @@ EffectChainPointer EffectChainSlot::getAndEnsureEffectChain(
     if (!m_pEffectChain) {
         EffectChainPointer pEffectChain(
                 new EffectChain(pEffectsManager, QString()));
-        pEffectChain->setName(QObject::tr("Empty Chain"));
+        //: Name for an empty effect chain, that is created after eject
+        pEffectChain->setName(tr("Empty Chain"));
         loadEffectChain(pEffectChain);
     }
     return m_pEffectChain;

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -448,7 +448,7 @@ unsigned int EffectChainSlot::getChainSlotNumber() const {
 QDomElement EffectChainSlot::toXml(QDomDocument* doc) const {
     QDomElement chainElement = doc->createElement(EffectXml::Chain);
     if (m_pEffectChain == nullptr) {
-        // ejected chains are stored with empty names
+        // ejected chains are stored empty <EffectChain/>
         return chainElement;
     }
 

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -447,21 +447,22 @@ unsigned int EffectChainSlot::getChainSlotNumber() const {
 QDomElement EffectChainSlot::toXml(QDomDocument* doc) const {
     QDomElement chainElement = doc->createElement(EffectXml::Chain);
     if (m_pEffectChain == nullptr) {
+        // ejected chains are stored with empty names
         return chainElement;
     }
 
     XmlParse::addElement(*doc, chainElement, EffectXml::ChainId,
-                         m_pEffectChain->id());
+            m_pEffectChain->id());
     XmlParse::addElement(*doc, chainElement, EffectXml::ChainName,
-                         m_pEffectChain->name());
+            m_pEffectChain->name());
     XmlParse::addElement(*doc, chainElement, EffectXml::ChainDescription,
-                         m_pEffectChain->description());
+            m_pEffectChain->description());
     XmlParse::addElement(*doc, chainElement, EffectXml::ChainInsertionType,
-                         EffectChain::insertionTypeToString(
-                           static_cast<EffectChain::InsertionType>(
-                              static_cast<int>(m_pControlChainInsertionType->get()))));
+            EffectChain::insertionTypeToString(
+                    static_cast<EffectChain::InsertionType>(
+                            static_cast<int>(m_pControlChainInsertionType->get()))));
     XmlParse::addElement(*doc, chainElement, EffectXml::ChainSuperParameter,
-                         QString::number(m_pControlChainSuperParameter->get()));
+            QString::number(m_pControlChainSuperParameter->get()));
 
     QDomElement effectsElement = doc->createElement(EffectXml::EffectsRoot);
     for (const auto& pEffectSlot : m_slots) {

--- a/src/effects/effectchainslot.h
+++ b/src/effects/effectchainslot.h
@@ -35,6 +35,7 @@ class EffectChainSlot : public QObject {
 
     void loadEffectChain(EffectChainPointer pEffectChain);
     EffectChainPointer getEffectChain() const;
+    EffectChainPointer getAndEndsureEffectChain(EffectsManager* pEffectsManager);
 
     void registerChannel(const ChannelHandleAndGroup& handle_group);
 

--- a/src/effects/effectchainslot.h
+++ b/src/effects/effectchainslot.h
@@ -35,7 +35,7 @@ class EffectChainSlot : public QObject {
 
     void loadEffectChain(EffectChainPointer pEffectChain);
     EffectChainPointer getEffectChain() const;
-    EffectChainPointer getAndEnsureEffectChain(EffectsManager* pEffectsManager);
+    EffectChainPointer getOrCreateEffectChain(EffectsManager* pEffectsManager);
 
     void registerChannel(const ChannelHandleAndGroup& handle_group);
 

--- a/src/effects/effectchainslot.h
+++ b/src/effects/effectchainslot.h
@@ -35,7 +35,7 @@ class EffectChainSlot : public QObject {
 
     void loadEffectChain(EffectChainPointer pEffectChain);
     EffectChainPointer getEffectChain() const;
-    EffectChainPointer getAndEndsureEffectChain(EffectsManager* pEffectsManager);
+    EffectChainPointer getAndEnsureEffectChain(EffectsManager* pEffectsManager);
 
     void registerChannel(const ChannelHandleAndGroup& handle_group);
 

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -147,7 +147,7 @@ void EffectRack::maybeLoadEffect(const unsigned int iChainSlotNumber,
     }
 
     if (loadNew) {
-        EffectChainPointer pChain = pChainSlot->getAndEnsureEffectChain(m_pEffectsManager);
+        EffectChainPointer pChain = pChainSlot->getOrCreateEffectChain(m_pEffectsManager);
         EffectPointer pEffect = m_pEffectsManager->instantiateEffect(id);
         pChain->replaceEffect(iEffectSlotNumber, pEffect);
     }
@@ -165,7 +165,7 @@ void EffectRack::loadNextEffect(const unsigned int iChainSlotNumber,
     EffectPointer pNextEffect = m_pEffectsManager->instantiateEffect(nextEffectId);
 
     EffectChainSlotPointer pChainSlot = m_effectChainSlots[iChainSlotNumber];
-    EffectChainPointer pChain = pChainSlot->getAndEnsureEffectChain(m_pEffectsManager);
+    EffectChainPointer pChain = pChainSlot->getOrCreateEffectChain(m_pEffectsManager);
     pChain->replaceEffect(iEffectSlotNumber, pNextEffect);
 }
 
@@ -182,7 +182,7 @@ void EffectRack::loadPrevEffect(const unsigned int iChainSlotNumber,
     EffectPointer pPrevEffect = m_pEffectsManager->instantiateEffect(prevEffectId);
 
     EffectChainSlotPointer pChainSlot = m_effectChainSlots[iChainSlotNumber];
-    EffectChainPointer pChain = pChainSlot->getAndEnsureEffectChain(m_pEffectsManager);
+    EffectChainPointer pChain = pChainSlot->getOrCreateEffectChain(m_pEffectsManager);
     pChain->replaceEffect(iEffectSlotNumber, pPrevEffect);
 }
 
@@ -308,7 +308,7 @@ void QuickEffectRack::configureEffectChainSlotForGroup(
 
     // Now load an empty effect chain into the slot so that users can edit
     // effect slots on the fly without having to load a chain.
-    EffectChainPointer pChain = pSlot->getAndEnsureEffectChain(m_pEffectsManager);
+    EffectChainPointer pChain = pSlot->getOrCreateEffectChain(m_pEffectsManager);
 
     // Enable the chain for the channel by default.
     pChain->enableForChannel(handle_group);
@@ -329,7 +329,7 @@ bool QuickEffectRack::loadEffectToGroup(const QString& groupName,
         return false;
     }
 
-    EffectChainPointer pChain = pChainSlot->getAndEnsureEffectChain(m_pEffectsManager);
+    EffectChainPointer pChain = pChainSlot->getOrCreateEffectChain(m_pEffectsManager);
     // TODO(rryan): remove.
     foreach (const ChannelHandleAndGroup& handle_group,
              m_pEffectChainManager->registeredChannels()) {
@@ -365,7 +365,7 @@ bool EqualizerRack::loadEffectToGroup(const QString& groupName,
         return false;
     }
 
-    EffectChainPointer pChain = pChainSlot->getAndEnsureEffectChain(m_pEffectsManager);
+    EffectChainPointer pChain = pChainSlot->getOrCreateEffectChain(m_pEffectsManager);
     // TODO(rryan): remove.
     foreach (const ChannelHandleAndGroup& handle_group,
              m_pEffectChainManager->registeredChannels()) {
@@ -398,7 +398,7 @@ void EqualizerRack::configureEffectChainSlotForGroup(EffectChainSlotPointer pSlo
 
     // Now load an empty effect chain into the slot so that users can edit
     // effect slots on the fly without having to load a chain.
-    EffectChainPointer pChain = pSlot->getAndEnsureEffectChain(m_pEffectsManager);
+    EffectChainPointer pChain = pSlot->getOrCreateEffectChain(m_pEffectsManager);
 
     // Enable the chain for the channel by default.
     pChain->enableForChannel(handle_group);

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -81,13 +81,6 @@ void EffectRack::slotClearRack(double v) {
     }
 }
 
-EffectChainPointer EffectRack::makeEmptyChain() {
-    EffectChainPointer pChain(new EffectChain(m_pEffectsManager, QString(),
-                                              EffectChainPointer()));
-    pChain->setName(tr("Empty Chain"));
-    return pChain;
-}
-
 int EffectRack::numEffectChainSlots() const {
     return m_effectChainSlots.size();
 }
@@ -154,7 +147,7 @@ void EffectRack::maybeLoadEffect(const unsigned int iChainSlotNumber,
     }
 
     if (loadNew) {
-        EffectChainPointer pChain = pChainSlot->getEffectChain();
+        EffectChainPointer pChain = pChainSlot->getAndEndsureEffectChain(m_pEffectsManager);
         EffectPointer pEffect = m_pEffectsManager->instantiateEffect(id);
         pChain->replaceEffect(iEffectSlotNumber, pEffect);
     }
@@ -172,11 +165,7 @@ void EffectRack::loadNextEffect(const unsigned int iChainSlotNumber,
     EffectPointer pNextEffect = m_pEffectsManager->instantiateEffect(nextEffectId);
 
     EffectChainSlotPointer pChainSlot = m_effectChainSlots[iChainSlotNumber];
-    EffectChainPointer pChain = pChainSlot->getEffectChain();
-    if (!pChain) {
-        pChain = makeEmptyChain();
-        pChainSlot->loadEffectChain(pChain);
-    }
+    EffectChainPointer pChain = pChainSlot->getAndEndsureEffectChain(m_pEffectsManager);
     pChain->replaceEffect(iEffectSlotNumber, pNextEffect);
 }
 
@@ -193,12 +182,7 @@ void EffectRack::loadPrevEffect(const unsigned int iChainSlotNumber,
     EffectPointer pPrevEffect = m_pEffectsManager->instantiateEffect(prevEffectId);
 
     EffectChainSlotPointer pChainSlot = m_effectChainSlots[iChainSlotNumber];
-    EffectChainPointer pChain = pChainSlot->getEffectChain();
-    if (!pChain) {
-        pChain = makeEmptyChain();
-        pChainSlot->loadEffectChain(pChain);
-    }
-
+    EffectChainPointer pChain = pChainSlot->getAndEndsureEffectChain(m_pEffectsManager);
     pChain->replaceEffect(iEffectSlotNumber, pPrevEffect);
 }
 
@@ -329,8 +313,7 @@ void QuickEffectRack::configureEffectChainSlotForGroup(
 
     // Now load an empty effect chain into the slot so that users can edit
     // effect slots on the fly without having to load a chain.
-    EffectChainPointer pChain = makeEmptyChain();
-    pSlot->loadEffectChain(pChain);
+    EffectChainPointer pChain = pSlot->getAndEndsureEffectChain(m_pEffectsManager);
 
     // Enable the chain for the channel by default.
     pChain->enableForChannel(handle_group);
@@ -351,19 +334,15 @@ bool QuickEffectRack::loadEffectToGroup(const QString& groupName,
         return false;
     }
 
-    EffectChainPointer pChain = pChainSlot->getEffectChain();
-    if (pChain.isNull()) {
-        pChain = makeEmptyChain();
-        pChainSlot->loadEffectChain(pChain);
-        // TODO(rryan): remove.
-        foreach (const ChannelHandleAndGroup& handle_group,
-                 m_pEffectChainManager->registeredChannels()) {
-            if (handle_group.name() == groupName) {
-                pChain->enableForChannel(handle_group);
-            }
+    EffectChainPointer pChain = pChainSlot->getAndEndsureEffectChain(m_pEffectsManager);
+    // TODO(rryan): remove.
+    foreach (const ChannelHandleAndGroup& handle_group,
+             m_pEffectChainManager->registeredChannels()) {
+        if (handle_group.name() == groupName) {
+            pChain->enableForChannel(handle_group);
         }
-        pChain->setMix(1.0);
     }
+    pChain->setMix(1.0);
 
     pChain->replaceEffect(0, pEffect);
 
@@ -391,19 +370,15 @@ bool EqualizerRack::loadEffectToGroup(const QString& groupName,
         return false;
     }
 
-    EffectChainPointer pChain = pChainSlot->getEffectChain();
-    if (pChain.isNull()) {
-        pChain = makeEmptyChain();
-        pChainSlot->loadEffectChain(pChain);
-        // TODO(rryan): remove.
-        foreach (const ChannelHandleAndGroup& handle_group,
-                 m_pEffectChainManager->registeredChannels()) {
-            if (handle_group.name() == groupName) {
-                pChain->enableForChannel(handle_group);
-            }
+    EffectChainPointer pChain = pChainSlot->getAndEndsureEffectChain(m_pEffectsManager);
+    // TODO(rryan): remove.
+    foreach (const ChannelHandleAndGroup& handle_group,
+             m_pEffectChainManager->registeredChannels()) {
+        if (handle_group.name() == groupName) {
+            pChain->enableForChannel(handle_group);
         }
-        pChain->setMix(1.0);
     }
+    pChain->setMix(1.0);
 
     pChain->replaceEffect(0, pEffect);
     if (pEffect != nullptr) {
@@ -428,8 +403,7 @@ void EqualizerRack::configureEffectChainSlotForGroup(EffectChainSlotPointer pSlo
 
     // Now load an empty effect chain into the slot so that users can edit
     // effect slots on the fly without having to load a chain.
-    EffectChainPointer pChain = makeEmptyChain();
-    pSlot->loadEffectChain(pChain);
+    EffectChainPointer pChain = pSlot->getAndEndsureEffectChain(m_pEffectsManager);
 
     // Enable the chain for the channel by default.
     pChain->enableForChannel(handle_group);

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -147,7 +147,7 @@ void EffectRack::maybeLoadEffect(const unsigned int iChainSlotNumber,
     }
 
     if (loadNew) {
-        EffectChainPointer pChain = pChainSlot->getAndEndsureEffectChain(m_pEffectsManager);
+        EffectChainPointer pChain = pChainSlot->getAndEnsureEffectChain(m_pEffectsManager);
         EffectPointer pEffect = m_pEffectsManager->instantiateEffect(id);
         pChain->replaceEffect(iEffectSlotNumber, pEffect);
     }
@@ -165,7 +165,7 @@ void EffectRack::loadNextEffect(const unsigned int iChainSlotNumber,
     EffectPointer pNextEffect = m_pEffectsManager->instantiateEffect(nextEffectId);
 
     EffectChainSlotPointer pChainSlot = m_effectChainSlots[iChainSlotNumber];
-    EffectChainPointer pChain = pChainSlot->getAndEndsureEffectChain(m_pEffectsManager);
+    EffectChainPointer pChain = pChainSlot->getAndEnsureEffectChain(m_pEffectsManager);
     pChain->replaceEffect(iEffectSlotNumber, pNextEffect);
 }
 
@@ -182,7 +182,7 @@ void EffectRack::loadPrevEffect(const unsigned int iChainSlotNumber,
     EffectPointer pPrevEffect = m_pEffectsManager->instantiateEffect(prevEffectId);
 
     EffectChainSlotPointer pChainSlot = m_effectChainSlots[iChainSlotNumber];
-    EffectChainPointer pChain = pChainSlot->getAndEndsureEffectChain(m_pEffectsManager);
+    EffectChainPointer pChain = pChainSlot->getAndEnsureEffectChain(m_pEffectsManager);
     pChain->replaceEffect(iEffectSlotNumber, pPrevEffect);
 }
 
@@ -313,7 +313,7 @@ void QuickEffectRack::configureEffectChainSlotForGroup(
 
     // Now load an empty effect chain into the slot so that users can edit
     // effect slots on the fly without having to load a chain.
-    EffectChainPointer pChain = pSlot->getAndEndsureEffectChain(m_pEffectsManager);
+    EffectChainPointer pChain = pSlot->getAndEnsureEffectChain(m_pEffectsManager);
 
     // Enable the chain for the channel by default.
     pChain->enableForChannel(handle_group);
@@ -334,7 +334,7 @@ bool QuickEffectRack::loadEffectToGroup(const QString& groupName,
         return false;
     }
 
-    EffectChainPointer pChain = pChainSlot->getAndEndsureEffectChain(m_pEffectsManager);
+    EffectChainPointer pChain = pChainSlot->getAndEnsureEffectChain(m_pEffectsManager);
     // TODO(rryan): remove.
     foreach (const ChannelHandleAndGroup& handle_group,
              m_pEffectChainManager->registeredChannels()) {
@@ -370,7 +370,7 @@ bool EqualizerRack::loadEffectToGroup(const QString& groupName,
         return false;
     }
 
-    EffectChainPointer pChain = pChainSlot->getAndEndsureEffectChain(m_pEffectsManager);
+    EffectChainPointer pChain = pChainSlot->getAndEnsureEffectChain(m_pEffectsManager);
     // TODO(rryan): remove.
     foreach (const ChannelHandleAndGroup& handle_group,
              m_pEffectChainManager->registeredChannels()) {
@@ -403,7 +403,7 @@ void EqualizerRack::configureEffectChainSlotForGroup(EffectChainSlotPointer pSlo
 
     // Now load an empty effect chain into the slot so that users can edit
     // effect slots on the fly without having to load a chain.
-    EffectChainPointer pChain = pSlot->getAndEndsureEffectChain(m_pEffectsManager);
+    EffectChainPointer pChain = pSlot->getAndEnsureEffectChain(m_pEffectsManager);
 
     // Enable the chain for the channel by default.
     pChain->enableForChannel(handle_group);

--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -209,8 +209,7 @@ StandardEffectRack::StandardEffectRack(EffectsManager* pEffectsManager,
                      formatGroupString(iRackNumber)) {
 }
 
-EffectChainSlotPointer StandardEffectRack::addEffectChainSlot(EffectChainPointer pChain,
-                                                              const QDomElement& effectChainElement) {
+EffectChainSlotPointer StandardEffectRack::addEffectChainSlot() {
     int iChainSlotNumber = numEffectChainSlots();
 
     QString group = formatEffectChainSlotGroupString(getRackNumber(),
@@ -220,8 +219,8 @@ EffectChainSlotPointer StandardEffectRack::addEffectChainSlot(EffectChainPointer
 
     for (int i = 0; i < EffectChainManager::kNumEffectsPerUnit; ++i) {
         pChainSlot->addEffectSlot(
-            StandardEffectRack::formatEffectSlotGroupString(
-                getRackNumber(), iChainSlotNumber, i));
+                StandardEffectRack::formatEffectSlotGroupString(
+                        getRackNumber(), iChainSlotNumber, i));
     }
 
     connect(pChainSlot, SIGNAL(nextChain(unsigned int, EffectChainPointer)),
@@ -243,10 +242,6 @@ EffectChainSlotPointer StandardEffectRack::addEffectChainSlot(EffectChainPointer
 
     EffectChainSlotPointer pChainSlotPointer = EffectChainSlotPointer(pChainSlot);
     addEffectChainSlotInternal(pChainSlotPointer);
-
-    pChainSlotPointer->loadEffectChain(pChain);
-
-    pChainSlot->loadChainSlotFromXml(effectChainElement);
 
     return pChainSlotPointer;
 }

--- a/src/effects/effectrack.h
+++ b/src/effects/effectrack.h
@@ -72,7 +72,6 @@ class EffectRack : public QObject {
 
   protected:
     void addEffectChainSlotInternal(EffectChainSlotPointer pChainSlot);
-    virtual EffectChainPointer makeEmptyChain();
 
     // We could make accessors for these for sub-classes. Doesn't really matter.
     EffectsManager* m_pEffectsManager;

--- a/src/effects/effectrack.h
+++ b/src/effects/effectrack.h
@@ -115,8 +115,7 @@ class StandardEffectRack : public EffectRack {
                 .arg(QString::number(iEffectSlotNumber + 1));
     }
 
-    EffectChainSlotPointer addEffectChainSlot(EffectChainPointer pChain,
-                                              const QDomElement& effectChainElement);
+    EffectChainSlotPointer addEffectChainSlot();
 };
 
 class PerGroupRack : public EffectRack {

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -240,7 +240,7 @@ void EffectsManager::setup() {
     // populate rack and restore state from effects.xml
     m_pEffectChainManager->loadEffectChains(pStandardRack.data());
 
-    EffectChainPointer pChain = EffectChainPointer(new EffectChain(
+    EffectChainPointer pChain(new EffectChain(
            this, "org.mixxx.effectchain.flanger"));
     pChain->setName(tr("Flanger"));
     EffectPointer pEffect = instantiateEffect(

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -232,13 +232,13 @@ void EffectsManager::setup() {
     addQuickEffectRack();
 
     // Add a general purpose rack
-    QList<std::pair<EffectChainPointer, QDomElement>> savedChains;
-    savedChains = m_pEffectChainManager->loadEffectChains();
-
     StandardEffectRackPointer pStandardRack = addStandardEffectRack();
-    for (auto chain : savedChains) {
-        pStandardRack->addEffectChainSlot(chain.first, chain.second);
+    for (int i = 0; i < EffectChainManager::kNumStandardEffectChains; ++i) {
+        pStandardRack->addEffectChainSlot();
     }
+
+    // populate rack and restore state from effects.xml
+    m_pEffectChainManager->loadEffectChains(pStandardRack.data());
 
     EffectChainPointer pChain = EffectChainPointer(new EffectChain(
            this, "org.mixxx.effectchain.flanger"));

--- a/src/engine/effects/engineeffectrack.cpp
+++ b/src/engine/effects/engineeffectrack.cpp
@@ -77,7 +77,7 @@ bool EngineEffectRack::addEffectChain(EngineEffectChain* pChain, int iIndex) {
 }
 
 bool EngineEffectRack::removeEffectChain(EngineEffectChain* pChain, int iIndex) {
-    if (iIndex < 0) {
+    VERIFY_OR_DEBUG_ASSERT(iIndex < m_chains.size()) {
         if (kEffectDebugOutput) {
             qDebug() << debugString()
                      << "WARNING: REMOVE_CHAIN_FROM_RACK message with invalid index:"

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -703,7 +703,7 @@ void DlgPrefEQ::slotMasterEqEffectChanged(int effectIndex) {
             m_pEQEffectRack->getGroupEffectChainSlot("[Master]");
 
     if (pChainSlot) {
-        EffectChainPointer pChain = pChainSlot->getAndEnsureEffectChain(m_pEffectsManager);
+        EffectChainPointer pChain = pChainSlot->getOrCreateEffectChain(m_pEffectsManager);
         EffectPointer pEffect = m_pEffectsManager->instantiateEffect(effectId);
         pChain->replaceEffect(0, pEffect);
 

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -703,7 +703,7 @@ void DlgPrefEQ::slotMasterEqEffectChanged(int effectIndex) {
             m_pEQEffectRack->getGroupEffectChainSlot("[Master]");
 
     if (pChainSlot) {
-        EffectChainPointer pChain = pChainSlot->getAndEndsureEffectChain(m_pEffectsManager);
+        EffectChainPointer pChain = pChainSlot->getAndEnsureEffectChain(m_pEffectsManager);
         EffectPointer pEffect = m_pEffectsManager->instantiateEffect(effectId);
         pChain->replaceEffect(0, pEffect);
 

--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -703,13 +703,7 @@ void DlgPrefEQ::slotMasterEqEffectChanged(int effectIndex) {
             m_pEQEffectRack->getGroupEffectChainSlot("[Master]");
 
     if (pChainSlot) {
-        EffectChainPointer pChain = pChainSlot->getEffectChain();
-        if (pChain.isNull()) {
-            pChain = EffectChainPointer(new EffectChain(m_pEffectsManager, QString(),
-                                        EffectChainPointer()));
-            pChain->setName(QObject::tr("Empty Chain"));
-            pChainSlot->loadEffectChain(pChain);
-        }
+        EffectChainPointer pChain = pChainSlot->getAndEndsureEffectChain(m_pEffectsManager);
         EffectPointer pEffect = m_pEffectsManager->instantiateEffect(effectId);
         pChain->replaceEffect(0, pEffect);
 

--- a/src/test/effectchainslottest.cpp
+++ b/src/test/effectchainslottest.cpp
@@ -36,12 +36,11 @@ TEST_F(EffectChainSlotTest, ChainSlotMirrorsLoadedChain) {
     int iChainNumber = 0;
 
     StandardEffectRackPointer pRack = m_pEffectsManager->addStandardEffectRack();
-    EffectChainSlotPointer pSlot = pRack->addEffectChainSlot(pChain, QDomElement());
-    pSlot->clear();
+    EffectChainSlotPointer pChainSlot = pRack->addEffectChainSlot();
 
     QString group = StandardEffectRack::formatEffectChainSlotGroupString(
         iRackNumber, iChainNumber);
-    pSlot->loadEffectChain(pChain);
+    pChainSlot->loadEffectChain(pChain);
 
     pChain->setEnabled(true);
     EXPECT_LT(0.0, ControlObject::get(ConfigKey(group, "enabled")));
@@ -89,7 +88,8 @@ TEST_F(EffectChainSlotTest, ChainSlotMirrorsLoadedChain_StartsWithChainLoaded) {
     int iChainNumber = 0;
 
     StandardEffectRackPointer pRack = m_pEffectsManager->addStandardEffectRack();
-    EffectChainSlotPointer pSlot = pRack->addEffectChainSlot(pChain, QDomElement());
+    EffectChainSlotPointer pChainSlot = pRack->addEffectChainSlot();
+    pChainSlot->loadEffectChain(pChain); 
     QString group = StandardEffectRack::formatEffectChainSlotGroupString(
         iRackNumber, iChainNumber);
     EXPECT_DOUBLE_EQ(1.0, ControlObject::get(ConfigKey(group, "loaded")));
@@ -103,15 +103,12 @@ TEST_F(EffectChainSlotTest, ChainSlotMirrorsLoadedChain_Clear) {
     int iChainNumber = 0;
 
     StandardEffectRackPointer pRack = m_pEffectsManager->addStandardEffectRack();
-    EffectChainSlotPointer pSlot = pRack->addEffectChainSlot(pChain, QDomElement());
-
-    // Clear the default chain.
-    pSlot->clear();
+    EffectChainSlotPointer pChainSlot = pRack->addEffectChainSlot();
 
     QString group = StandardEffectRack::formatEffectChainSlotGroupString(
         iRackNumber, iChainNumber);
     EXPECT_DOUBLE_EQ(0.0, ControlObject::get(ConfigKey(group, "loaded")));
-    pSlot->loadEffectChain(pChain);
+    pChainSlot->loadEffectChain(pChain);
     EXPECT_DOUBLE_EQ(1.0, ControlObject::get(ConfigKey(group, "loaded")));
     ControlObject::set(ConfigKey(group, "clear"), 1.0);
     EXPECT_DOUBLE_EQ(0.0, ControlObject::get(ConfigKey(group, "loaded")));

--- a/src/test/effectslottest.cpp
+++ b/src/test/effectslottest.cpp
@@ -39,7 +39,8 @@ TEST_F(EffectSlotTest, ControlsReflectSlotState) {
     int iEffectNumber = 0;
 
     StandardEffectRackPointer pRack = m_pEffectsManager->addStandardEffectRack();
-    EffectChainSlotPointer pChainSlot = pRack->addEffectChainSlot(pChain, QDomElement());
+    EffectChainSlotPointer pChainSlot = pRack->addEffectChainSlot();
+    pChainSlot->loadEffectChain(pChain);
     // StandardEffectRack::addEffectChainSlot automatically adds 4 effect
     // slots. In the future we will probably remove this so this will just start
     // segfaulting.

--- a/src/test/metaknob_link_test.cpp
+++ b/src/test/metaknob_link_test.cpp
@@ -29,10 +29,8 @@ class MetaLinkTest : public BaseEffectTest {
         int iEffectNumber = 0;
 
         StandardEffectRackPointer pRack = m_pEffectsManager->addStandardEffectRack();
-        m_pChainSlot = pRack->addEffectChainSlot(pChain, QDomElement());
-        // StandardEffectRack::addEffectChainSlot automatically adds 4 effect
-        // slots. In the future we will probably remove this so this will just
-        // start segfaulting.
+        m_pChainSlot = pRack->addEffectChainSlot();
+        m_pChainSlot->loadEffectChain(pChain);
         m_pEffectSlot = m_pChainSlot->getEffectSlot(0);
 
         QString group = StandardEffectRack::formatEffectSlotGroupString(


### PR DESCRIPTION
This is an alternative solution to https://github.com/mixxxdj/mixxx/pull/1269, and keeps the old behaviour that a null chain is allowed after clearing it. Once we add an single effect, the chain is created on the fly, now in a single common function. 

I have added also some more misusing null checks.  

This bug points us also to an old open discussion that the Name "Empty Chain" is odd.
https://bugs.launchpad.net/mixxx/+bug/1523724
https://github.com/mixxxdj/mixxx/pull/618#issuecomment-118011942 
@Be-ing How about "New Chain"

