### PR TITLE
microphone I/O revamp

### DIFF
--- a/src/engine/enginechannel.cpp
+++ b/src/engine/enginechannel.cpp
@@ -21,8 +21,10 @@
 #include "control/controlpushbutton.h"
 
 EngineChannel::EngineChannel(const ChannelHandleAndGroup& handle_group,
-                             EngineChannel::ChannelOrientation defaultOrientation)
-        : m_group(handle_group) {
+                             EngineChannel::ChannelOrientation defaultOrientation,
+                             bool isTalkoverChannel)
+        : m_group(handle_group),
+          m_bIsTalkoverChannel(isTalkoverChannel) {
     m_pPFL = new ControlPushButton(ConfigKey(getGroup(), "pfl"));
     m_pPFL->setButtonMode(ControlPushButton::TOGGLE);
     m_pMaster = new ControlPushButton(ConfigKey(getGroup(), "master"));

--- a/src/engine/enginechannel.h
+++ b/src/engine/enginechannel.h
@@ -39,7 +39,8 @@ class EngineChannel : public EngineObject {
     };
 
     EngineChannel(const ChannelHandleAndGroup& handle_group,
-                  ChannelOrientation defaultOrientation = CENTER);
+                  ChannelOrientation defaultOrientation = CENTER,
+                  bool isInput = false);
     virtual ~EngineChannel();
 
     virtual ChannelOrientation getOrientation() const;
@@ -59,6 +60,7 @@ class EngineChannel : public EngineObject {
     virtual bool isMasterEnabled() const;
     void setTalkover(bool enabled);
     virtual bool isTalkoverEnabled() const;
+    inline bool isTalkoverChannel() { return m_bIsTalkoverChannel; };
 
     virtual void process(CSAMPLE* pOut, const int iBufferSize) = 0;
     virtual void postProcess(const int iBuffersize) = 0;
@@ -82,6 +84,8 @@ class EngineChannel : public EngineObject {
     ControlPushButton* m_pOrientationRight;
     ControlPushButton* m_pOrientationCenter;
     ControlPushButton* m_pTalkover;
+    bool m_bIsTalkoverChannel;
 };
 
 #endif
+

--- a/src/engine/enginechannel.h
+++ b/src/engine/enginechannel.h
@@ -40,7 +40,7 @@ class EngineChannel : public EngineObject {
 
     EngineChannel(const ChannelHandleAndGroup& handle_group,
                   ChannelOrientation defaultOrientation = CENTER,
-                  bool isInput = false);
+                  bool isTalkoverChannel = false);
     virtual ~EngineChannel();
 
     virtual ChannelOrientation getOrientation() const;

--- a/src/engine/enginedelay.cpp
+++ b/src/engine/enginedelay.cpp
@@ -81,3 +81,7 @@ void EngineDelay::process(CSAMPLE* pInOut, const int iBufferSize) {
         }
     }
 }
+
+void EngineDelay::setDelay(double newDelay) {
+    m_pDelayPot->set(newDelay);
+}

--- a/src/engine/enginedelay.cpp
+++ b/src/engine/enginedelay.cpp
@@ -24,12 +24,12 @@
 const int kiMaxDelay = 40000; // 208 ms @ 96 kb/s
 const double kdMaxDelayPot = 200; // 200 ms
 
-EngineDelay::EngineDelay(const char* group, ConfigKey delayControl)
+EngineDelay::EngineDelay(const char* group, ConfigKey delayControl, bool bPersist)
         : m_iDelayPos(0),
           m_iDelay(0) {
     m_pDelayBuffer = SampleUtil::alloc(kiMaxDelay);
     SampleUtil::clear(m_pDelayBuffer, kiMaxDelay);
-    m_pDelayPot = new ControlPotmeter(delayControl, 0, kdMaxDelayPot, false, true, false, true);
+    m_pDelayPot = new ControlPotmeter(delayControl, 0, kdMaxDelayPot, false, true, false, bPersist);
     m_pDelayPot->setDefaultValue(0);
     connect(m_pDelayPot, SIGNAL(valueChanged(double)), this,
             SLOT(slotDelayChanged()), Qt::DirectConnection);

--- a/src/engine/enginedelay.cpp
+++ b/src/engine/enginedelay.cpp
@@ -18,11 +18,15 @@
 
 #include "control/controlproxy.h"
 #include "control/controlpotmeter.h"
+#include "util/audiosignal.h"
 #include "util/assert.h"
 #include "util/sample.h"
 
-const int kiMaxDelay = 40000; // 208 ms @ 96 kb/s
-const double kdMaxDelayPot = 200; // 200 ms
+namespace {
+constexpr double kdMaxDelayPot = 500;
+constexpr int kiMaxDelay = (kdMaxDelayPot + 8) / 1000 *
+    mixxx::AudioSignal::kSamplingRateMax * mixxx::AudioSignal::kChannelCountStereo;
+} // anonymous namespace
 
 EngineDelay::EngineDelay(const char* group, ConfigKey delayControl, bool bPersist)
         : m_iDelayPos(0),

--- a/src/engine/enginedelay.h
+++ b/src/engine/enginedelay.h
@@ -26,7 +26,7 @@ class ControlProxy;
 class EngineDelay : public EngineObject {
     Q_OBJECT
   public:
-    EngineDelay(const char* group, ConfigKey delayControl);
+    EngineDelay(const char* group, ConfigKey delayControl, bool bPersist = false);
     virtual ~EngineDelay();
 
     void process(CSAMPLE* pInOut, const int iBufferSize);

--- a/src/engine/enginedelay.h
+++ b/src/engine/enginedelay.h
@@ -26,7 +26,7 @@ class ControlProxy;
 class EngineDelay : public EngineObject {
     Q_OBJECT
   public:
-    EngineDelay(const char* group, ConfigKey delayControl, bool bPersist = false);
+    EngineDelay(const char* group, ConfigKey delayControl, bool bPersist = true);
     virtual ~EngineDelay();
 
     void process(CSAMPLE* pInOut, const int iBufferSize);

--- a/src/engine/enginedelay.h
+++ b/src/engine/enginedelay.h
@@ -31,6 +31,8 @@ class EngineDelay : public EngineObject {
 
     void process(CSAMPLE* pInOut, const int iBufferSize);
 
+    void setDelay(double newDelay);
+
   public slots:
     void slotDelayChanged();
 

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -448,24 +448,20 @@ void EngineMaster::process(const int iBufferSize) {
 
         if (configuredTalkoverMixMode != TalkoverMixMode::DIRECT_MONITOR
             && m_pNumMicsConfigured->get() > 0) {
-            m_pInputLatencyCompensationHeadphonesDelay->process(m_pHead, iBufferSize);
-        }
+            if (m_bRampingGain) {
+                ChannelMixer::mixChannelsRamping(
+                        m_headphoneGain, &m_activeTalkoverHeadphoneChannels,
+                        &m_channelHeadphoneGainCache,
+                        m_pTalkoverHeadphones, iBufferSize);
+            } else {
+                ChannelMixer::mixChannels(
+                        m_headphoneGain, &m_activeTalkoverHeadphoneChannels,
+                        &m_channelHeadphoneGainCache,
+                        m_pTalkoverHeadphones, iBufferSize);
+            }
 
-        if (m_bRampingGain) {
-            ChannelMixer::mixChannelsRamping(
-                    m_headphoneGain, &m_activeTalkoverHeadphoneChannels,
-                    &m_channelHeadphoneGainCache,
-                    m_pTalkoverHeadphones, iBufferSize);
-        } else {
-            ChannelMixer::mixChannels(
-                    m_headphoneGain, &m_activeTalkoverHeadphoneChannels,
-                    &m_channelHeadphoneGainCache,
-                    m_pTalkoverHeadphones, iBufferSize);
-        }
-
-        if (configuredTalkoverMixMode != TalkoverMixMode::DIRECT_MONITOR
-            && m_pNumMicsConfigured->get() > 0) {
             m_pInputLatencyCompensationHeadphonesDelay->process(m_pHead, iBufferSize);
+
             SampleUtil::copy2WithGain(m_pHead,
                 m_pHead, 1.0,
                 m_pTalkoverHeadphones, 1.0,

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -177,7 +177,7 @@ EngineMaster::EngineMaster(UserSettingsPointer pConfig,
     m_pBoothEnabled->setReadOnly();
     m_pMasterMonoMixdown = new ControlObject(ConfigKey(group, "mono_mixdown"),
             true, false, true);  // persist = true
-    m_pTalkoverMixMode = new ControlObject(ConfigKey(group, "talkover_mix"),
+    m_pMicMonitorMode = new ControlObject(ConfigKey(group, "talkover_mix"),
             true, false, true);  // persist = true
     m_pHeadphoneEnabled = new ControlObject(ConfigKey(group, "headEnabled"));
     m_pHeadphoneEnabled->setReadOnly();
@@ -219,7 +219,7 @@ EngineMaster::~EngineMaster() {
 
     delete m_pMasterEnabled;
     delete m_pMasterMonoMixdown;
-    delete m_pTalkoverMixMode;
+    delete m_pMicMonitorMode;
     delete m_pHeadphoneEnabled;
 
     SampleUtil::free(m_pHead);
@@ -492,12 +492,12 @@ void EngineMaster::process(const int iBufferSize) {
             m_pOutputBusBuffers[EngineChannel::RIGHT], 1.0,
             iBufferSize);
 
-        TalkoverMixMode configuredTalkoverMixMode = static_cast<TalkoverMixMode>(
-            static_cast<int>(m_pTalkoverMixMode->get()));
+        MicMonitorMode configuredMicMonitorMode = static_cast<MicMonitorMode>(
+            static_cast<int>(m_pMicMonitorMode->get()));
 
         // Process master, booth, and record/broadcast buffers according to the
-        // TalkoverMixMode configured in DlgPrefSound
-        if (configuredTalkoverMixMode == TalkoverMixMode::MASTER) {
+        // MicMonitorMode configured in DlgPrefSound
+        if (configuredMicMonitorMode == MicMonitorMode::MASTER) {
             // Process master channel effects
             // TODO(Be): Move this after mixing in talkover. To apply master effects
             // to both the master and booth in that case will require refactoring
@@ -551,12 +551,12 @@ void EngineMaster::process(const int iBufferSize) {
 
             // Record/broadcast signal is the same as the master output
             m_ppSidechainOutput = &m_pMaster;
-        } else if (configuredTalkoverMixMode == TalkoverMixMode::MASTER_AND_BOOTH) {
+        } else if (configuredMicMonitorMode == MicMonitorMode::MASTER_AND_BOOTH) {
             // Process master channel effects
             // TODO(Be): Move this after mixing in talkover. For the MASTER only
-            // TalkoverMixMode above, that will require refactoring the effects system
+            // MicMonitorMode above, that will require refactoring the effects system
             // to be able to process the same effects on different buffers
-            // within the same callback. For consistency between the TalkoverMixModes,
+            // within the same callback. For consistency between the MicMonitorModes,
             // process master effects here before mixing in talkover.
             if (m_pEngineEffectsManager) {
                 GroupFeatureState masterFeatures;
@@ -605,7 +605,7 @@ void EngineMaster::process(const int iBufferSize) {
 
             // Record/broadcast signal is the same as the master output
             m_ppSidechainOutput = &m_pMaster;
-        } else if (configuredTalkoverMixMode == TalkoverMixMode::DIRECT_MONITOR) {
+        } else if (configuredMicMonitorMode == MicMonitorMode::DIRECT_MONITOR) {
             // Skip mixing talkover with the master and booth outputs
             // if using direct monitoring because it is being mixed in hardware
             // without the latency of sending the signal into Mixxx for processing.

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -101,6 +101,7 @@ EngineMaster::EngineMaster(UserSettingsPointer pConfig,
 
     m_pMasterDelay = new EngineDelay(group, ConfigKey(group, "delay"));
     m_pHeadDelay = new EngineDelay(group, ConfigKey(group, "headDelay"));
+    m_pBoothDelay = new EngineDelay(group, ConfigKey(group, "boothDelay"));
     m_pInputLatencyCompensationDelay = new EngineDelay(group,
         ConfigKey(group, "inputLatency"));
     m_pInputLatencyCompensationHeadphonesDelay = new EngineDelay(group,
@@ -202,6 +203,7 @@ EngineMaster::~EngineMaster() {
     delete m_pEngineSideChain;
     delete m_pMasterDelay;
     delete m_pHeadDelay;
+    delete m_pBoothDelay;
     delete m_pInputLatencyCompensationDelay;
     delete m_pInputLatencyCompensationHeadphonesDelay;
     delete m_pRoundTripLatency;
@@ -812,6 +814,9 @@ void EngineMaster::process(const int iBufferSize) {
     }
     if (headphoneEnabled) {
         m_pHeadDelay->process(m_pHead, iBufferSize);
+    }
+    if (boothEnabled) {
+        m_pBoothDelay->process(m_pBooth, iBufferSize);
     }
 
     // We're close to the end of the callback. Wake up the engine worker

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -500,6 +500,7 @@ void EngineMaster::process(const int iBufferSize) {
 
         // Process master, booth, and record/broadcast buffers according to the
         // MicMonitorMode configured in DlgPrefSound
+        // TODO(Be): make SampleUtil ramping functions update the old gain variable
         if (configuredMicMonitorMode == MicMonitorMode::MASTER) {
             // Process master channel effects
             // TODO(Be): Move this after mixing in talkover. To apply master effects

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -841,7 +841,7 @@ const CSAMPLE* EngineMaster::buffer(AudioOutput output) const {
     case AudioOutput::DECK:
         return getDeckBuffer(output.getIndex());
         break;
-    case AudioOutput::SIDECHAIN:
+    case AudioOutput::RECORD_BROADCAST:
         return getSidechainBuffer();
         break;
     default:
@@ -869,7 +869,7 @@ void EngineMaster::onOutputConnected(AudioOutput output) {
         case AudioOutput::DECK:
             // We don't track enabled decks.
             break;
-        case AudioOutput::SIDECHAIN:
+        case AudioOutput::RECORD_BROADCAST:
             // We don't track enabled sidechain.
             break;
         default:
@@ -895,7 +895,7 @@ void EngineMaster::onOutputDisconnected(AudioOutput output) {
         case AudioOutput::DECK:
             // We don't track enabled decks.
             break;
-        case AudioOutput::SIDECHAIN:
+        case AudioOutput::RECORD_BROADCAST:
             // We don't track enabled sidechain.
             break;
         default:
@@ -951,5 +951,5 @@ void EngineMaster::registerNonEngineChannelSoundIO(SoundManager* pSoundManager) 
     for (int o = EngineChannel::LEFT; o <= EngineChannel::RIGHT; o++) {
         pSoundManager->registerOutput(AudioOutput(AudioOutput::BUS, 0, 2, o), this);
     }
-    pSoundManager->registerOutput(AudioOutput(AudioOutput::SIDECHAIN, 0, 2), this);
+    pSoundManager->registerOutput(AudioOutput(AudioOutput::RECORD_BROADCAST, 0, 2), this);
 }

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -456,6 +456,7 @@ void EngineMaster::process(const int iBufferSize) {
     // Make the mix for each crossfader orientation output bus.
     // m_masterGain takes care of applying the attenuation from
     // channel volume faders, crossfader, and talkover ducking.
+    // Talkover is mixed in later according to the configured MicMonitorMode
     for (int o = EngineChannel::LEFT; o <= EngineChannel::RIGHT; o++) {
         if (m_bRampingGain) {
             ChannelMixer::mixChannelsRamping(
@@ -530,6 +531,8 @@ void EngineMaster::process(const int iBufferSize) {
             }
 
             // Apply master gain
+            // TODO(Be): make this not affect the headphones. Refer to
+            // https://bugs.launchpad.net/mixxx/+bug/1458213
             CSAMPLE master_gain = m_pMasterGain->get();
             if (m_bRampingGain) {
                 SampleUtil::applyRampingGain(m_pMaster, m_masterGainOld, master_gain,
@@ -572,6 +575,8 @@ void EngineMaster::process(const int iBufferSize) {
             }
 
             // Apply master gain
+            // TODO(Be): make this not affect the headphones. Refer to
+            // https://bugs.launchpad.net/mixxx/+bug/1458213
             CSAMPLE master_gain = m_pMasterGain->get();
             if (m_bRampingGain) {
                 SampleUtil::applyRampingGain(m_pMaster, m_masterGainOld, master_gain,
@@ -609,6 +614,8 @@ void EngineMaster::process(const int iBufferSize) {
             applyMasterEffects(iBufferSize, iSampleRate);
 
             // Apply master gain
+            // TODO(Be): make this not affect the headphones. Refer to
+            // https://bugs.launchpad.net/mixxx/+bug/1458213
             CSAMPLE master_gain = m_pMasterGain->get();
             if (m_bRampingGain) {
                 SampleUtil::applyRampingGain(m_pMaster, m_masterGainOld, master_gain,

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -103,7 +103,7 @@ EngineMaster::EngineMaster(UserSettingsPointer pConfig,
     m_pHeadDelay = new EngineDelay(group, ConfigKey(group, "headDelay"));
     m_pBoothDelay = new EngineDelay(group, ConfigKey(group, "boothDelay"));
     m_pLatencyCompensationDelay = new EngineDelay(group,
-        ConfigKey(group, "roundTripLatency"));
+        ConfigKey(group, "microphoneLatencyCompensation"));
     m_pNumMicsConfigured = new ControlObject(ConfigKey(group, "num_mics_configured"));
 
     // Headphone volume

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -503,19 +503,7 @@ void EngineMaster::process(const int iBufferSize) {
             // to both the master and booth in that case will require refactoring
             // the effects system to be able to process the same effects on multiple
             // buffers within the same callback.
-            if (m_pEngineEffectsManager) {
-                GroupFeatureState masterFeatures;
-                // Well, this is delayed by one buffer (it's dependent on the
-                // output). Oh well.
-                if (m_pVumeter != NULL) {
-                    m_pVumeter->collectFeatures(&masterFeatures);
-                }
-                masterFeatures.has_gain = true;
-                masterFeatures.gain = m_pMasterGain->get();
-                m_pEngineEffectsManager->process(m_masterHandle.handle(), m_pMaster,
-                                                iBufferSize, iSampleRate,
-                                                masterFeatures);
-            }
+            applyMasterEffects(iBufferSize, iSampleRate);
 
             // Copy master mix to booth output with booth gain before mixing
             // talkover with master mix
@@ -558,19 +546,7 @@ void EngineMaster::process(const int iBufferSize) {
             // to be able to process the same effects on different buffers
             // within the same callback. For consistency between the MicMonitorModes,
             // process master effects here before mixing in talkover.
-            if (m_pEngineEffectsManager) {
-                GroupFeatureState masterFeatures;
-                // Well, this is delayed by one buffer (it's dependent on the
-                // output). Oh well.
-                if (m_pVumeter != NULL) {
-                    m_pVumeter->collectFeatures(&masterFeatures);
-                }
-                masterFeatures.has_gain = true;
-                masterFeatures.gain = m_pMasterGain->get();
-                m_pEngineEffectsManager->process(m_masterHandle.handle(), m_pMaster,
-                                                iBufferSize, iSampleRate,
-                                                masterFeatures);
-            }
+            applyMasterEffects(iBufferSize, iSampleRate);
 
             // Mix talkover with master
             if (m_pNumMicsConfigured->get() > 0) {
@@ -628,19 +604,7 @@ void EngineMaster::process(const int iBufferSize) {
             // NOTE(Be): This should occur before mixing in talkover for the
             // record/broadcast signal so the record/broadcast signal is the same
             // as what is heard on the master & booth outputs.
-            if (m_pEngineEffectsManager) {
-                GroupFeatureState masterFeatures;
-                // Well, this is delayed by one buffer (it's dependent on the
-                // output). Oh well.
-                if (m_pVumeter != NULL) {
-                    m_pVumeter->collectFeatures(&masterFeatures);
-                }
-                masterFeatures.has_gain = true;
-                masterFeatures.gain = m_pMasterGain->get();
-                m_pEngineEffectsManager->process(m_masterHandle.handle(), m_pMaster,
-                                                iBufferSize, iSampleRate,
-                                                masterFeatures);
-            }
+            applyMasterEffects(iBufferSize, iSampleRate);
 
             // Apply master gain
             CSAMPLE master_gain = m_pMasterGain->get();
@@ -777,6 +741,22 @@ void EngineMaster::process(const int iBufferSize) {
     // We're close to the end of the callback. Wake up the engine worker
     // scheduler so that it runs the workers.
     m_pWorkerScheduler->runWorkers();
+}
+
+void EngineMaster::applyMasterEffects(const int iBufferSize, const int iSampleRate) {
+    if (m_pEngineEffectsManager) {
+        GroupFeatureState masterFeatures;
+        // Well, this is delayed by one buffer (it's dependent on the
+        // output). Oh well.
+        if (m_pVumeter != NULL) {
+            m_pVumeter->collectFeatures(&masterFeatures);
+        }
+        masterFeatures.has_gain = true;
+        masterFeatures.gain = m_pMasterGain->get();
+        m_pEngineEffectsManager->process(m_masterHandle.handle(), m_pMaster,
+                                        iBufferSize, iSampleRate,
+                                        masterFeatures);
+    }
 }
 
 void EngineMaster::addChannel(EngineChannel* pChannel) {

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -940,3 +940,16 @@ void EngineMaster::onInputDisconnected(AudioInput input) {
           break;
     }
 }
+
+void EngineMaster::registerNonEngineChannelSoundIO(SoundManager* pSoundManager) {
+    pSoundManager->registerInput(AudioInput(AudioPath::RECORD_BROADCAST, 0, 2),
+                                 m_pEngineSideChain);
+
+    pSoundManager->registerOutput(AudioOutput(AudioOutput::MASTER, 0, 2), this);
+    pSoundManager->registerOutput(AudioOutput(AudioOutput::HEADPHONES, 0, 2), this);
+    pSoundManager->registerOutput(AudioOutput(AudioOutput::BOOTH, 0, 2), this);
+    for (int o = EngineChannel::LEFT; o <= EngineChannel::RIGHT; o++) {
+        pSoundManager->registerOutput(AudioOutput(AudioOutput::BUS, 0, 2, o), this);
+    }
+    pSoundManager->registerOutput(AudioOutput(AudioOutput::SIDECHAIN, 0, 2), this);
+}

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -146,6 +146,8 @@ EngineMaster::EngineMaster(UserSettingsPointer pConfig,
         SampleUtil::clear(m_pOutputBusBuffers[o], MAX_BUFFER_LEN);
     }
 
+    m_ppSidechainOutput = &m_pMaster;
+
     // Starts a thread for recording and broadcast
     m_pEngineSideChain = bEnableSidechain ? new EngineSideChain(pConfig) : NULL;
 
@@ -256,7 +258,7 @@ const CSAMPLE* EngineMaster::getHeadphoneBuffer() const {
 }
 
 const CSAMPLE* EngineMaster::getSidechainBuffer() const {
-    return m_pMaster;
+    return *m_ppSidechainOutput;
 }
 
 void EngineMaster::processChannels(int iBufferSize) {

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -175,7 +175,8 @@ EngineMaster::EngineMaster(UserSettingsPointer pConfig,
     m_pKeylockEngine->set(pConfig->getValueString(
             ConfigKey(group, "keylock_engine")).toDouble());
 
-    // TODO: Make this read only but let EngineMasterTest enable it
+    // TODO: Make this read only and make EngineMaster decide whether
+    // processing the master mix is necessary.
     m_pMasterEnabled = new ControlObject(ConfigKey(group, "enabled"),
             true, false, true);  // persist = true
     m_pBoothEnabled = new ControlObject(ConfigKey(group, "booth_enabled"));

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -670,6 +670,10 @@ void EngineMaster::process(const int iBufferSize) {
                 // delayed.
                 SampleUtil::copy(m_pSidechain, m_pMaster, iBufferSize);
                 m_pInputLatencyCompensationDelay->process(m_pSidechain, iBufferSize);
+                SampleUtil::copy2WithGain(m_pSidechain,
+                                          m_pSidechain, 1.0,
+                                          m_pTalkover, 1.0,
+                                          iBufferSize);
                 m_pEngineSideChain->writeSamples(m_pSidechain, iBufferSize);
             } else {
                 m_pEngineSideChain->writeSamples(m_pMaster, iBufferSize);

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -540,16 +540,24 @@ void EngineMaster::process(const int iBufferSize) {
         // Process master, booth, and record/broadcast buffers according to the
         // TalkoverMixMode configured in DlgPrefSound
 
-        // Mixxx gets input signals delayed by the input latency,
-        // so to preserve the relative timing of the input with Mixxx's outputs
-        // (headphones, master, booth, and record/broadcast), delay the outputs
-        // by the input latency before mixing the inputs into them.
-
-        // This way, if the microphone user is on beat with the output they hear from
-        // the speakers/headphones, the input will remain on beat at the expense of
-        // adding some latency to Mixxx's output (no latency will be added to the
-        // microphone signal though). If no microphone inputs are configured, avoid adding
-        // this extra latency.
+        // If a musician using a microphone plays on beat with the output they hear
+        // from Mixxx, when the input is processed by Mixxx and sent back out of Mixxx,
+        // they should hear themselves playing on beat. Due to the nature of digial audio,
+        // the user does not hear the output of Mixxx in the instant Mixxx is processing
+        // it. There is an output latency between the time Mixxx processes the audio
+        // and the user hears it. So if the microphone user plays on beat with what they
+        // hear, they will be playing out of sync with the engine's processing by the
+        // output latency. Additionally, Mixxx gets input signals delayed by the
+        // input latency. By the time Mixxx receives the input signal, a full
+        // round trip through the signal chain has elapsed since Mixxx processed the
+        // output signal. Therefore, to preserve the relative timing of the input with
+        // Mixxx's outputs (headphones, master, booth, and record/broadcast),
+        // the outputs must be delayed by the round trip latency before mixing
+        // the inputs into them. Unfortunately this adds some latency to Mixxx's outputs,
+        // so manipulating controls in Mixxx will feel less responsive. However,
+        // no latency will be added to the input signal as it passes through Mixxx.
+        // If no microphone inputs are configured, the outputs are not delayed to
+        // avoid adding unnecessary latency.
 
         // If the input signal is being directly monitored (mixed with the master output
         // in hardware), do not delay the audible outputs. However, delay the

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -220,9 +220,13 @@ class EngineMaster : public QObject, public AudioSource {
     };
 
     enum class MicMonitorMode {
+        // These are out of order with how they are listed in DlgPrefSound for backwards
+        // compatibility with Mixxx 2.0 user settings. In Mixxx 2.0, before the
+        // booth output was added, this was a binary option without
+        // the MASTER_AND_BOOTH mode.
         MASTER = 0,
-        MASTER_AND_BOOTH,
         DIRECT_MONITOR,
+        MASTER_AND_BOOTH
     };
 
     template<typename T, unsigned int CAPACITY>

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -97,6 +97,8 @@ class EngineMaster : public QObject, public AudioSource {
     // in the future.
     virtual void onOutputConnected(AudioOutput output);
     virtual void onOutputDisconnected(AudioOutput output);
+    void onInputConnected(AudioInput input);
+    void onInputDisconnected(AudioInput input);
 
     void process(const int iBufferSize);
 
@@ -212,6 +214,13 @@ class EngineMaster : public QObject, public AudioSource {
         double m_dRightGain;
         double m_dTalkoverDuckingGain;
     };
+
+    enum class TalkoverMixMode {
+        MASTER = 0,
+        MASTER_AND_BOOTH,
+        DIRECT_MONITOR,
+    };
+
     template<typename T, unsigned int CAPACITY>
     class FastVector {
       public:
@@ -288,12 +297,15 @@ class EngineMaster : public QObject, public AudioSource {
     QVarLengthArray<ChannelInfo*, kPreallocatedChannels> m_activeBusChannels[3];
     QVarLengthArray<ChannelInfo*, kPreallocatedChannels> m_activeHeadphoneChannels;
     QVarLengthArray<ChannelInfo*, kPreallocatedChannels> m_activeTalkoverChannels;
+    QVarLengthArray<ChannelInfo*, kPreallocatedChannels> m_activeTalkoverHeadphoneChannels;
 
     // Mixing buffers for each output.
     CSAMPLE* m_pOutputBusBuffers[3];
     CSAMPLE* m_pBooth;
     CSAMPLE* m_pHead;
     CSAMPLE* m_pTalkover;
+    CSAMPLE* m_pTalkoverHeadphones;
+    CSAMPLE* m_pSidechain;
 
     EngineWorkerScheduler* m_pWorkerScheduler;
     EngineSync* m_pMasterSync;
@@ -305,11 +317,15 @@ class EngineMaster : public QObject, public AudioSource {
     ControlObject* m_pMasterLatency;
     ControlObject* m_pMasterAudioBufferSize;
     ControlObject* m_pAudioLatencyOverloadCount;
+    ControlObject* m_pInputLatencyOffset;
+    ControlObject* m_pNumMicsConfigured;
     ControlPotmeter* m_pAudioLatencyUsage;
     ControlPotmeter* m_pAudioLatencyOverload;
     EngineTalkoverDucking* m_pTalkoverDucking;
     EngineDelay* m_pMasterDelay;
     EngineDelay* m_pHeadDelay;
+    EngineDelay* m_pInputLatencyCompensationDelay;
+    EngineDelay* m_pInputLatencyCompensationHeadphonesDelay;
 
     EngineVuMeter* m_pVumeter;
     EngineSideChain* m_pEngineSideChain;
@@ -344,7 +360,7 @@ class EngineMaster : public QObject, public AudioSource {
     ControlObject* m_pBoothEnabled;
     // Mix two Mono channels. This is useful for outdoor gigs
     ControlObject* m_pMasterMonoMixdown;
-    ControlObject* m_pBoothTalkoverMix;
+    ControlObject* m_pTalkoverMixMode;
     ControlObject* m_pHeadphoneEnabled;
 
     volatile bool m_bBusOutputConnected[3];

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -307,7 +307,6 @@ class EngineMaster : public QObject, public AudioSource {
     QVarLengthArray<ChannelInfo*, kPreallocatedChannels> m_activeBusChannels[3];
     QVarLengthArray<ChannelInfo*, kPreallocatedChannels> m_activeHeadphoneChannels;
     QVarLengthArray<ChannelInfo*, kPreallocatedChannels> m_activeTalkoverChannels;
-    QVarLengthArray<ChannelInfo*, kPreallocatedChannels> m_activeTalkoverHeadphoneChannels;
 
     // Mixing buffers for each output.
     CSAMPLE* m_pOutputBusBuffers[3];
@@ -335,8 +334,7 @@ class EngineMaster : public QObject, public AudioSource {
     EngineDelay* m_pMasterDelay;
     EngineDelay* m_pHeadDelay;
     EngineDelay* m_pBoothDelay;
-    EngineDelay* m_pInputLatencyCompensationDelay;
-    EngineDelay* m_pInputLatencyCompensationHeadphonesDelay;
+    EngineDelay* m_pLatencyCompensationDelay;
 
     EngineVuMeter* m_pVumeter;
     EngineSideChain* m_pEngineSideChain;

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -309,7 +309,8 @@ class EngineMaster : public QObject, public AudioSource {
     CSAMPLE* m_pHead;
     CSAMPLE* m_pTalkover;
     CSAMPLE* m_pTalkoverHeadphones;
-    CSAMPLE* m_pSidechain;
+    CSAMPLE* m_pSidechainMix;
+    CSAMPLE** m_ppSidechainOutput;
 
     EngineWorkerScheduler* m_pWorkerScheduler;
     EngineSync* m_pMasterSync;

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -272,6 +272,12 @@ class EngineMaster : public QObject, public AudioSource {
     // The master buffer is protected so it can be accessed by test subclasses.
     CSAMPLE* m_pMaster;
 
+    // ControlObjects for switching off unnecessary processing
+    // These are protected so tests can set them
+    ControlObject* m_pHeadphoneEnabled;
+    ControlObject* m_pMasterEnabled;
+    ControlObject* m_pBoothEnabled;
+
   private:
     void mixChannels(unsigned int channelBitvector, unsigned int maxChannels,
                      CSAMPLE* pOutput, unsigned int iBufferSize, GainCalculator* pGainCalculator);
@@ -359,14 +365,9 @@ class EngineMaster : public QObject, public AudioSource {
     const ChannelHandleAndGroup m_busCenterHandle;
     const ChannelHandleAndGroup m_busRightHandle;
 
-    // Produce the Master Mixxx, not Required if connected to left
-    // and right Bus and no recording and broadcast active
-    ControlObject* m_pMasterEnabled;
-    ControlObject* m_pBoothEnabled;
     // Mix two Mono channels. This is useful for outdoor gigs
     ControlObject* m_pMasterMonoMixdown;
     ControlObject* m_pTalkoverMixMode;
-    ControlObject* m_pHeadphoneEnabled;
 
     volatile bool m_bBusOutputConnected[3];
     bool m_bExternalRecordBroadcastInputConnected;

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -322,7 +322,6 @@ class EngineMaster : public QObject, public AudioSource {
     ControlObject* m_pMasterLatency;
     ControlObject* m_pMasterAudioBufferSize;
     ControlObject* m_pAudioLatencyOverloadCount;
-    ControlObject* m_pRoundTripLatency;
     ControlObject* m_pNumMicsConfigured;
     ControlPotmeter* m_pAudioLatencyUsage;
     ControlPotmeter* m_pAudioLatencyOverload;

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -27,6 +27,7 @@
 #include "engine/engineobject.h"
 #include "engine/enginechannel.h"
 #include "engine/channelhandle.h"
+#include "soundio/soundmanager.h"
 #include "soundio/soundmanagerutil.h"
 #include "recording/recordingmanager.h"
 
@@ -89,6 +90,9 @@ class EngineMaster : public QObject, public AudioSource {
         return ChannelHandleAndGroup(
                 m_channelHandleFactory.getOrCreateHandle(group), group);
     }
+
+    // Register the sound I/O that does not correspond to any EngineChannel object
+    void registerNonEngineChannelSoundIO(SoundManager* pSoundManager);
 
     // WARNING: These methods are called by the main thread. They should only
     // touch the volatile bool connected indicators (see below). However, when

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -186,29 +186,31 @@ class EngineMaster : public QObject, public AudioSource {
         OrientationVolumeGainCalculator()
                 : m_dLeftGain(1.0),
                   m_dCenterGain(1.0),
-                  m_dRightGain(1.0) {
+                  m_dRightGain(1.0),
+                  m_dTalkoverDuckingGain(1.0) {
         }
 
         inline double getGain(ChannelInfo* pChannelInfo) const {
-            const double channelVolume = pChannelInfo->m_pVolumeControl->get();
+            const double channelGain = pChannelInfo->m_pVolumeControl->get();
             const double orientationGain = EngineMaster::gainForOrientation(
                     pChannelInfo->m_pChannel->getOrientation(),
                     m_dLeftGain, m_dCenterGain, m_dRightGain);
-            return channelVolume * orientationGain;
+            return channelGain * orientationGain * m_dTalkoverDuckingGain;
         }
 
-        inline void setGains(double leftGain,
-                double centerGain, double rightGain) {
+        inline void setGains(double leftGain, double centerGain, double rightGain,
+                             double talkoverDuckingGain) {
             m_dLeftGain = leftGain;
             m_dCenterGain = centerGain;
             m_dRightGain = rightGain;
+            m_dTalkoverDuckingGain = talkoverDuckingGain;
         }
 
       private:
-        double m_dVolume;
         double m_dLeftGain;
         double m_dCenterGain;
         double m_dRightGain;
+        double m_dTalkoverDuckingGain;
     };
     template<typename T, unsigned int CAPACITY>
     class FastVector {
@@ -293,12 +295,11 @@ class EngineMaster : public QObject, public AudioSource {
     CSAMPLE* m_pHead;
     CSAMPLE* m_pTalkover;
 
-    CSAMPLE** m_ppSidechain; // points to master or to talkover buffer
-
     EngineWorkerScheduler* m_pWorkerScheduler;
     EngineSync* m_pMasterSync;
 
     ControlObject* m_pMasterGain;
+    ControlObject* m_pBoothGain;
     ControlObject* m_pHeadGain;
     ControlObject* m_pMasterSampleRate;
     ControlObject* m_pMasterLatency;
@@ -327,6 +328,7 @@ class EngineMaster : public QObject, public AudioSource {
     TalkoverGainCalculator m_talkoverGain;
     OrientationVolumeGainCalculator m_masterGain;
     CSAMPLE m_masterGainOld;
+    CSAMPLE m_boothGainOld;
     CSAMPLE m_headphoneMasterGainOld;
     CSAMPLE m_headphoneGainOld;
 
@@ -339,6 +341,7 @@ class EngineMaster : public QObject, public AudioSource {
     // Produce the Master Mixxx, not Required if connected to left
     // and right Bus and no recording and broadcast active
     ControlObject* m_pMasterEnabled;
+    ControlObject* m_pBoothEnabled;
     // Mix two Mono channels. This is useful for outdoor gigs
     ControlObject* m_pMasterMonoMixdown;
     ControlObject* m_pBoothTalkoverMix;

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -364,6 +364,7 @@ class EngineMaster : public QObject, public AudioSource {
     ControlObject* m_pHeadphoneEnabled;
 
     volatile bool m_bBusOutputConnected[3];
+    bool m_bExternalRecordBroadcastInputConnected;
 };
 
 #endif

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -289,6 +289,8 @@ class EngineMaster : public QObject, public AudioSource {
     // respective output.
     void processChannels(int iBufferSize);
 
+    void applyMasterEffects(const int iBufferSize, const int iSampleRate);
+
     ChannelHandleFactory m_channelHandleFactory;
     EngineEffectsManager* m_pEngineEffectsManager;
     bool m_bRampingGain;

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -197,11 +197,11 @@ class EngineMaster : public QObject, public AudioSource {
         }
 
         inline double getGain(ChannelInfo* pChannelInfo) const {
-            const double channelGain = pChannelInfo->m_pVolumeControl->get();
+            const double channelVolume = pChannelInfo->m_pVolumeControl->get();
             const double orientationGain = EngineMaster::gainForOrientation(
                     pChannelInfo->m_pChannel->getOrientation(),
                     m_dLeftGain, m_dCenterGain, m_dRightGain);
-            return channelGain * orientationGain * m_dTalkoverDuckingGain;
+            return channelVolume * orientationGain * m_dTalkoverDuckingGain;
         }
 
         inline void setGains(double leftGain, double centerGain, double rightGain,

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -126,6 +126,7 @@ class EngineMaster : public QObject, public AudioSource {
 
     // These are really only exposed for tests to use.
     const CSAMPLE* getMasterBuffer() const;
+    const CSAMPLE* getBoothBuffer() const;
     const CSAMPLE* getHeadphoneBuffer() const;
     const CSAMPLE* getOutputBusBuffer(unsigned int i) const;
     const CSAMPLE* getDeckBuffer(unsigned int i) const;
@@ -183,8 +184,7 @@ class EngineMaster : public QObject, public AudioSource {
     class OrientationVolumeGainCalculator : public GainCalculator {
       public:
         OrientationVolumeGainCalculator()
-                : m_dVolume(1.0),
-                  m_dLeftGain(1.0),
+                : m_dLeftGain(1.0),
                   m_dCenterGain(1.0),
                   m_dRightGain(1.0) {
         }
@@ -194,12 +194,11 @@ class EngineMaster : public QObject, public AudioSource {
             const double orientationGain = EngineMaster::gainForOrientation(
                     pChannelInfo->m_pChannel->getOrientation(),
                     m_dLeftGain, m_dCenterGain, m_dRightGain);
-            return m_dVolume * channelVolume * orientationGain;
+            return channelVolume * orientationGain;
         }
 
-        inline void setGains(double dVolume, double leftGain,
+        inline void setGains(double leftGain,
                 double centerGain, double rightGain) {
-            m_dVolume = dVolume;
             m_dLeftGain = leftGain;
             m_dCenterGain = centerGain;
             m_dRightGain = rightGain;
@@ -290,6 +289,7 @@ class EngineMaster : public QObject, public AudioSource {
 
     // Mixing buffers for each output.
     CSAMPLE* m_pOutputBusBuffers[3];
+    CSAMPLE* m_pBooth;
     CSAMPLE* m_pHead;
     CSAMPLE* m_pTalkover;
 
@@ -341,7 +341,7 @@ class EngineMaster : public QObject, public AudioSource {
     ControlObject* m_pMasterEnabled;
     // Mix two Mono channels. This is useful for outdoor gigs
     ControlObject* m_pMasterMonoMixdown;
-    ControlObject* m_pMasterTalkoverMix;
+    ControlObject* m_pBoothTalkoverMix;
     ControlObject* m_pHeadphoneEnabled;
 
     volatile bool m_bBusOutputConnected[3];

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -329,6 +329,7 @@ class EngineMaster : public QObject, public AudioSource {
     EngineTalkoverDucking* m_pTalkoverDucking;
     EngineDelay* m_pMasterDelay;
     EngineDelay* m_pHeadDelay;
+    EngineDelay* m_pBoothDelay;
     EngineDelay* m_pInputLatencyCompensationDelay;
     EngineDelay* m_pInputLatencyCompensationHeadphonesDelay;
 

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -219,7 +219,7 @@ class EngineMaster : public QObject, public AudioSource {
         double m_dTalkoverDuckingGain;
     };
 
-    enum class TalkoverMixMode {
+    enum class MicMonitorMode {
         MASTER = 0,
         MASTER_AND_BOOTH,
         DIRECT_MONITOR,
@@ -365,7 +365,7 @@ class EngineMaster : public QObject, public AudioSource {
 
     // Mix two Mono channels. This is useful for outdoor gigs
     ControlObject* m_pMasterMonoMixdown;
-    ControlObject* m_pTalkoverMixMode;
+    ControlObject* m_pMicMonitorMode;
 
     volatile bool m_bBusOutputConnected[3];
     bool m_bExternalRecordBroadcastInputConnected;

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -317,7 +317,7 @@ class EngineMaster : public QObject, public AudioSource {
     ControlObject* m_pMasterLatency;
     ControlObject* m_pMasterAudioBufferSize;
     ControlObject* m_pAudioLatencyOverloadCount;
-    ControlObject* m_pInputLatencyOffset;
+    ControlObject* m_pRoundTripLatency;
     ControlObject* m_pNumMicsConfigured;
     ControlPotmeter* m_pAudioLatencyUsage;
     ControlPotmeter* m_pAudioLatencyOverload;

--- a/src/engine/enginemicrophone.cpp
+++ b/src/engine/enginemicrophone.cpp
@@ -14,7 +14,7 @@
 
 EngineMicrophone::EngineMicrophone(const ChannelHandleAndGroup& handle_group,
                                    EffectsManager* pEffectsManager)
-        : EngineChannel(handle_group, EngineChannel::CENTER),
+        : EngineChannel(handle_group, EngineChannel::CENTER, true),
           m_pEngineEffectsManager(pEffectsManager ? pEffectsManager->getEngineEffectsManager() : NULL),
           m_vuMeter(getGroup()),
           m_pInputConfigured(new ControlObject(ConfigKey(getGroup(), "input_configured"))),

--- a/src/engine/sidechain/enginesidechain.cpp
+++ b/src/engine/sidechain/enginesidechain.cpp
@@ -92,7 +92,7 @@ void EngineSideChain::writeSamples(const CSAMPLE* pBuffer, int iFrames) {
     const int iSamples = iFrames * kChannels;
     int samples_written = m_sampleFifo.write(pBuffer, iSamples);
 
-    if (samples_written != iFrames) {
+    if (samples_written != iSamples) {
         Counter("EngineSideChain::writeSamples buffer overrun").increment();
     }
 

--- a/src/engine/sidechain/enginesidechain.cpp
+++ b/src/engine/sidechain/enginesidechain.cpp
@@ -75,11 +75,24 @@ void EngineSideChain::addSideChainWorker(SideChainWorker* pWorker) {
     m_workers.append(pWorker);
 }
 
-void EngineSideChain::writeSamples(const CSAMPLE* newBuffer, int buffer_size) {
-    Trace sidechain("EngineSideChain::writeSamples");
-    int samples_written = m_sampleFifo.write(newBuffer, buffer_size);
+void EngineSideChain::receiveBuffer(AudioInput input,
+                                    const CSAMPLE* pBuffer,
+                                    unsigned int iFrames) {
+    if (input.getType() != AudioInput::RECORD_BROADCAST) {
+        qDebug() << "WARNING: AudioInput type is not RECORD_BROADCAST. Ignoring incoming buffer.";
+        return;
+    }
+    writeSamples(pBuffer, iFrames);
+}
 
-    if (samples_written != buffer_size) {
+void EngineSideChain::writeSamples(const CSAMPLE* pBuffer, int iFrames) {
+    Trace sidechain("EngineSideChain::writeSamples");
+    // TODO: remove assumption of stereo buffer
+    const int kChannels = 2;
+    const int iSamples = iFrames * kChannels;
+    int samples_written = m_sampleFifo.write(pBuffer, iSamples);
+
+    if (samples_written != iFrames) {
         Counter("EngineSideChain::writeSamples buffer overrun").increment();
     }
 

--- a/src/engine/sidechain/enginesidechain.h
+++ b/src/engine/sidechain/enginesidechain.h
@@ -24,11 +24,12 @@
 
 #include "preferences/usersettings.h"
 #include "engine/sidechain/sidechainworker.h"
+#include "soundio/soundmanagerutil.h"
 #include "util/fifo.h"
 #include "util/mutex.h"
 #include "util/types.h"
 
-class EngineSideChain : public QThread {
+class EngineSideChain : public QThread, public AudioDestination {
     Q_OBJECT
   public:
     EngineSideChain(UserSettingsPointer pConfig);
@@ -37,13 +38,19 @@ class EngineSideChain : public QThread {
     // Not thread-safe, wait-free. Submit buffer of samples to the sidechain for
     // processing. Should only be called from a single writer thread (typically
     // the engine callback).
-    void writeSamples(const CSAMPLE* buffer, int buffer_size);
+    void writeSamples(const CSAMPLE* pBuffer, int iFrames);
+
+    // Thin wrapper around writeSamples that is used by SoundManager when receiving
+    // from a sound card input instead of the engine
+    void receiveBuffer(AudioInput input,
+                       const CSAMPLE* pBuffer,
+                       unsigned int iFrames) override;
 
     // Thread-safe, blocking.
     void addSideChainWorker(SideChainWorker* pWorker);
 
   private:
-    void run();
+    void run() override;
 
     UserSettingsPointer m_pConfig;
     // Indicates that the thread should exit.

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -83,6 +83,8 @@ PlayerManager::PlayerManager(UserSettingsPointer pConfig,
     // register the engine's outputs
     m_pSoundManager->registerOutput(AudioOutput(AudioOutput::MASTER, 0, 2),
                                     m_pEngine);
+    m_pSoundManager->registerOutput(AudioOutput(AudioOutput::BOOTH, 0, 2),
+                                    m_pEngine);
     m_pSoundManager->registerOutput(AudioOutput(AudioOutput::HEADPHONES, 0, 2),
                                     m_pEngine);
     for (int o = EngineChannel::LEFT; o <= EngineChannel::RIGHT; o++) {

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -79,20 +79,6 @@ PlayerManager::PlayerManager(UserSettingsPointer pConfig,
 
     // This is parented to the PlayerManager so does not need to be deleted
     m_pSamplerBank = new SamplerBank(this);
-
-    // register the engine's outputs
-    m_pSoundManager->registerOutput(AudioOutput(AudioOutput::MASTER, 0, 2),
-                                    m_pEngine);
-    m_pSoundManager->registerOutput(AudioOutput(AudioOutput::BOOTH, 0, 2),
-                                    m_pEngine);
-    m_pSoundManager->registerOutput(AudioOutput(AudioOutput::HEADPHONES, 0, 2),
-                                    m_pEngine);
-    for (int o = EngineChannel::LEFT; o <= EngineChannel::RIGHT; o++) {
-        m_pSoundManager->registerOutput(AudioOutput(AudioOutput::BUS, 0, 2, o),
-                                        m_pEngine);
-    }
-    m_pSoundManager->registerOutput(AudioOutput(AudioOutput::SIDECHAIN, 0, 2),
-                                    m_pEngine);
 }
 
 PlayerManager::~PlayerManager() {

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -192,11 +192,10 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
 
     launchProgress(8);
 
-    // Initialize player device
-    // while this is created here, setupDevices needs to be called sometime
-    // after the players are added to the engine (as is done currently) -- bkgood
-    // (long)
+    // Although m_pSoundManager is created here, m_pSoundManager->setupDevices()
+    // needs to be called after m_pPlayerManager registers sound IO for each EngineChannel.
     m_pSoundManager = new SoundManager(pConfig, m_pEngine);
+    m_pEngine->registerNonEngineChannelSoundIO(m_pSoundManager);
 
     m_pRecordingManager = new RecordingManager(pConfig, m_pEngine);
 

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -416,7 +416,9 @@ void DlgPreferences::slotButtonPressed(QAbstractButton* pButton) {
             }
             break;
         case QDialogButtonBox::AcceptRole:
-            emit(applyPreferences());
+            if (pCurrentPage != NULL) {
+                pCurrentPage->slotApply();
+            }
             accept();
             break;
         case QDialogButtonBox::RejectRole:
@@ -436,8 +438,6 @@ void DlgPreferences::addPageWidget(DlgPreferencePage* pWidget) {
     connect(this, SIGNAL(showDlg()),
             pWidget, SLOT(slotUpdate()));
 
-    connect(this, SIGNAL(applyPreferences()),
-            pWidget, SLOT(slotApply()));
     connect(this, SIGNAL(cancelPreferences()),
             pWidget, SLOT(slotCancel()));
     connect(this, SIGNAL(resetToDefaults()),

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -416,9 +416,7 @@ void DlgPreferences::slotButtonPressed(QAbstractButton* pButton) {
             }
             break;
         case QDialogButtonBox::AcceptRole:
-            if (pCurrentPage != NULL) {
-                pCurrentPage->slotApply();
-            }
+            emit(applyPreferences());
             accept();
             break;
         case QDialogButtonBox::RejectRole:
@@ -438,6 +436,8 @@ void DlgPreferences::addPageWidget(DlgPreferencePage* pWidget) {
     connect(this, SIGNAL(showDlg()),
             pWidget, SLOT(slotUpdate()));
 
+    connect(this, SIGNAL(applyPreferences()),
+            pWidget, SLOT(slotApply()));
     connect(this, SIGNAL(cancelPreferences()),
             pWidget, SLOT(slotCancel()));
     connect(this, SIGNAL(resetToDefaults()),

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -79,8 +79,6 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
     void closeDlg();
     void showDlg();
 
-    // Emitted just after the user clicks Apply or OK.
-    void applyPreferences();
     // Emitted if the user clicks Cancel
     void cancelPreferences();
     // Emitted if the user clicks Reset to Defaults.

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -79,6 +79,8 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
     void closeDlg();
     void showDlg();
 
+    // Emitted just after the user clicks Apply or OK.
+    void applyPreferences();
     // Emitted if the user clicks Cancel
     void cancelPreferences();
     // Emitted if the user clicks Reset to Defaults.

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -113,13 +113,12 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     m_pMasterLatency = new ControlProxy("[Master]", "latency", this);
     m_pMasterLatency->connectValueChanged(SLOT(masterLatencyChanged(double)));
 
-
-    m_pHeadDelay = new ControlProxy("[Master]", "headDelay", this);
     m_pMasterDelay = new ControlProxy("[Master]", "delay", this);
+    m_pHeadDelay = new ControlProxy("[Master]", "headDelay", this);
     m_pRoundTripLatency = new ControlProxy("[Master]", "roundTripLatency", this);
 
-    headDelaySpinBox->setValue(m_pHeadDelay->get());
     masterDelaySpinBox->setValue(m_pMasterDelay->get());
+    headDelaySpinBox->setValue(m_pHeadDelay->get());
     roundTripLatencySpinBox->setValue(m_pRoundTripLatency->get());
 
     // TODO: remove this option by automatically disabling/enabling the master mix
@@ -153,10 +152,10 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     m_pKeylockEngine =
             new ControlProxy("[Master]", "keylock_engine", this);
 
-    connect(headDelaySpinBox, SIGNAL(valueChanged(double)),
-            this, SLOT(headDelayChanged(double)));
     connect(masterDelaySpinBox, SIGNAL(valueChanged(double)),
             this, SLOT(masterDelayChanged(double)));
+    connect(headDelaySpinBox, SIGNAL(valueChanged(double)),
+            this, SLOT(headDelayChanged(double)));
     connect(roundTripLatencySpinBox, SIGNAL(valueChanged(double)),
             this, SLOT(roundTripLatencyChanged(double)));
 
@@ -563,12 +562,12 @@ void DlgPrefSound::masterLatencyChanged(double latency) {
     update();
 }
 
-void DlgPrefSound::headDelayChanged(double value) {
-    m_pHeadDelay->set(value);
-}
-
 void DlgPrefSound::masterDelayChanged(double value) {
     m_pMasterDelay->set(value);
+}
+
+void DlgPrefSound::headDelayChanged(double value) {
+    m_pHeadDelay->set(value);
 }
 
 void DlgPrefSound::roundTripLatencyChanged(double value) {

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -120,6 +120,8 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
     headDelaySpinBox->setValue(m_pHeadDelay->get());
     masterDelaySpinBox->setValue(m_pMasterDelay->get());
 
+    // TODO: remove this option by automatically disabling/enabling the master mix
+    // when recording, broadcasting, headphone, and master outputs are enabled/disabled
     m_pMasterEnabled = new ControlProxy("[Master]", "enabled", this);
     masterMixComboBox->addItem(tr("Disabled"));
     masterMixComboBox->addItem(tr("Enabled"));

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -424,7 +424,7 @@ void DlgPrefSound::loadSettings(const SoundManagerConfig &config) {
     } else {
         bool measuredRoundTripLatencyAtDefault =
             m_pRoundTripLatency->get() == roundTripLatencySpinBox->minimum();
-        roundTripLatencySpinBox->setMinimum(config.getProcessingLatency() * 2.0);
+        roundTripLatencySpinBox->setMinimum(config.getProcessingLatency());
         if (measuredRoundTripLatencyAtDefault) {
             roundTripLatencySpinBox->setValue(roundTripLatencySpinBox->minimum());
         } else {

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -454,11 +454,13 @@ void DlgPrefSound::apiChanged(int index) {
     refreshDevices();
     // JACK sets its own buffer size and sample rate that Mixxx cannot change.
     // TODO(Be): Get the buffer size from JACK and update audioBufferComboBox.
-    // PortAudio does not have a way to get the buffer size from JACK as of June 2017.
+    // PortAudio does not have a way to get the buffer size from JACK as of July 2017.
     if (m_config.getAPI() == MIXXX_PORTAUDIO_JACK_STRING) {
+        sampleRateComboBox->setEnabled(false);
         latencyLabel->setEnabled(false);
         audioBufferComboBox->setEnabled(false);
     } else {
+        sampleRateComboBox->setEnabled(true);
         latencyLabel->setEnabled(true);
         audioBufferComboBox->setEnabled(true);
     }

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -136,13 +136,13 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
             this, SLOT(masterOutputModeComboBoxChanged(int)));
     m_pMasterMonoMixdown->connectValueChanged(SLOT(masterMonoMixdownChanged(double)));
 
-    m_pMasterTalkoverMix = new ControlProxy("[Master]", "talkover_mix", this);
-    micMixComboBox->addItem(tr("Master output"));
-    micMixComboBox->addItem(tr("Broadcast and Recording only"));
-    micMixComboBox->setCurrentIndex((int)m_pMasterTalkoverMix->get());
+    m_pBoothTalkoverMix = new ControlProxy("[Master]", "talkover_mix", this);
+    micMixComboBox->addItem(tr("Master output only"));
+    micMixComboBox->addItem(tr("Master and booth outputs"));
+    micMixComboBox->setCurrentIndex((int)m_pBoothTalkoverMix->get());
     connect(micMixComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(talkoverMixComboBoxChanged(int)));
-    m_pMasterTalkoverMix->connectValueChanged(SLOT(talkoverMixChanged(double)));
+    m_pBoothTalkoverMix->connectValueChanged(SLOT(talkoverMixChanged(double)));
 
 
     m_pKeylockEngine =
@@ -540,7 +540,7 @@ void DlgPrefSound::slotResetToDefaults() {
     m_pHeadDelay->set(0.0);
 
     // Enable talkover master output
-    m_pMasterTalkoverMix->set(0.0);
+    m_pBoothTalkoverMix->set(0.0);
     micMixComboBox->setCurrentIndex(0);
 
     settingChanged(); // force the apply button to enable
@@ -581,7 +581,7 @@ void DlgPrefSound::masterMonoMixdownChanged(double value) {
 }
 
 void DlgPrefSound::talkoverMixComboBoxChanged(int value) {
-    m_pMasterTalkoverMix->set((double)value);
+    m_pBoothTalkoverMix->set((double)value);
 }
 
 void DlgPrefSound::talkoverMixChanged(double value) {

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -613,6 +613,8 @@ void DlgPrefSound::slotResetToDefaults() {
     m_pTalkoverMixMode->set(0.0);
     micMixComboBox->setCurrentIndex(0);
 
+    roundTripLatencySpinBox->setValue(roundTripLatencySpinBox->minimum());
+
     settingChanged(); // force the apply button to enable
 }
 

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -115,10 +115,12 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
 
     m_pMasterDelay = new ControlProxy("[Master]", "delay", this);
     m_pHeadDelay = new ControlProxy("[Master]", "headDelay", this);
+    m_pBoothDelay = new ControlProxy("[Master]", "boothDelay", this);
     m_pRoundTripLatency = new ControlProxy("[Master]", "roundTripLatency", this);
 
     masterDelaySpinBox->setValue(m_pMasterDelay->get());
     headDelaySpinBox->setValue(m_pHeadDelay->get());
+    boothDelaySpinBox->setValue(m_pBoothDelay->get());
     roundTripLatencySpinBox->setValue(m_pRoundTripLatency->get());
 
     // TODO: remove this option by automatically disabling/enabling the master mix
@@ -156,6 +158,8 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
             this, SLOT(masterDelayChanged(double)));
     connect(headDelaySpinBox, SIGNAL(valueChanged(double)),
             this, SLOT(headDelayChanged(double)));
+    connect(boothDelaySpinBox, SIGNAL(valueChanged(double)),
+            this, SLOT(boothDelayChanged(double)));
     connect(roundTripLatencySpinBox, SIGNAL(valueChanged(double)),
             this, SLOT(roundTripLatencyChanged(double)));
 
@@ -545,6 +549,9 @@ void DlgPrefSound::slotResetToDefaults() {
     headDelaySpinBox->setValue(0.0);
     m_pHeadDelay->set(0.0);
 
+    boothDelaySpinBox->setValue(0.0);
+    m_pBoothDelay->set(0.0);
+
     // Enable talkover master output
     m_pTalkoverMixMode->set(0.0);
     micMixComboBox->setCurrentIndex(0);
@@ -568,6 +575,10 @@ void DlgPrefSound::masterDelayChanged(double value) {
 
 void DlgPrefSound::headDelayChanged(double value) {
     m_pHeadDelay->set(value);
+}
+
+void DlgPrefSound::boothDelayChanged(double value) {
+    m_pBoothDelay->set(value);
 }
 
 void DlgPrefSound::roundTripLatencyChanged(double value) {

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -400,6 +400,11 @@ void DlgPrefSound::loadSettings(const SoundManagerConfig &config) {
         audioBufferComboBox->setCurrentIndex(sizeIndex);
     }
 
+    // Setting the index of audioBufferComboBox here sets m_bLatencyChanged to true,
+    // but m_bLatencyChanged should only be true when the user has edited the
+    // buffer size or sample rate.
+    m_bLatencyChanged = false;
+
     int syncBuffers = m_config.getSyncBuffers();
     if (syncBuffers == 0) {
         // "Experimental (no delay)"))

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -639,9 +639,8 @@ void DlgPrefSound::roundTripLatencySpinboxChanged(double value) {
 }
 
 void DlgPrefSound::roundTripLatencyChanged(double newRoundTripLatency) {
-    double inputLatencyCompensation = newRoundTripLatency / 2.0;
-    m_pInputLatencyCompensationDelay->set(inputLatencyCompensation);
-    m_pInputLatencyCompensationHeadphonesDelay->set(inputLatencyCompensation);
+    m_pInputLatencyCompensationDelay->set(newRoundTripLatency);
+    m_pInputLatencyCompensationHeadphonesDelay->set(newRoundTripLatency);
 }
 
 void DlgPrefSound::masterMixChanged(int value) {

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -80,18 +80,18 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
                         static_cast<EngineBuffer::KeylockEngine>(i)));
     }
 
-    m_pRoundTripLatency = new ControlProxy("[Master]", "roundTripLatency", this);
+    m_pLatencyCompensation = new ControlProxy("[Master]", "microphoneLatencyCompensation", this);
     m_pMasterDelay = new ControlProxy("[Master]", "delay", this);
     m_pHeadDelay = new ControlProxy("[Master]", "headDelay", this);
     m_pBoothDelay = new ControlProxy("[Master]", "boothDelay", this);
 
-    roundTripLatencySpinBox->setValue(m_pRoundTripLatency->get());
+    latencyCompensationSpinBox->setValue(m_pLatencyCompensation->get());
     masterDelaySpinBox->setValue(m_pMasterDelay->get());
     headDelaySpinBox->setValue(m_pHeadDelay->get());
     boothDelaySpinBox->setValue(m_pBoothDelay->get());
 
-    connect(roundTripLatencySpinBox, SIGNAL(valueChanged(double)),
-            this, SLOT(roundTripLatencySpinboxChanged(double)));
+    connect(latencyCompensationSpinBox, SIGNAL(valueChanged(double)),
+            this, SLOT(latencyCompensationSpinboxChanged(double)));
     connect(masterDelaySpinBox, SIGNAL(valueChanged(double)),
             this, SLOT(masterDelaySpinboxChanged(double)));
     connect(headDelaySpinBox, SIGNAL(valueChanged(double)),
@@ -178,7 +178,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
 }
 
 DlgPrefSound::~DlgPrefSound() {
-    delete m_pRoundTripLatency;
+    delete m_pLatencyCompensation;
 }
 
 /**
@@ -208,11 +208,11 @@ void DlgPrefSound::slotApply() {
               static_cast<int>(m_pMicMonitorMode->get()));
     if (configuredMicMonitorMode == EngineMaster::MicMonitorMode::DIRECT_MONITOR
         && m_bLatencyChanged
-        && m_pRoundTripLatency->get() != roundTripLatencySpinBox->minimum()) {
+        && m_pLatencyCompensation->get() != latencyCompensationSpinBox->minimum()) {
         QMessageBox latencyChangeWarningBox;
         latencyChangeWarningBox.setIcon(QMessageBox::Warning);
         latencyChangeWarningBox.setText(tr("Change processing latency?"));
-        latencyChangeWarningBox.setInformativeText(tr("Changing Mixxx's Audio Buffer and/or Sample Rate changes the real round trip latency through your hardware and software. You have set a Measured Round Trip Latency of %1 ms. When you change the round trip latency, it should be measured again to exactly align microphone inputs with Mixxx's outputs.").arg(m_pRoundTripLatency->get())
+        latencyChangeWarningBox.setInformativeText(tr("Changing Mixxx's Audio Buffer and/or Sample Rate changes the real round trip latency through your hardware and software. You have set a Measured Round Trip Latency of %1 ms. When you change the round trip latency, it should be measured again to exactly align microphone inputs with Mixxx's outputs.").arg(m_pLatencyCompensation->get())
         + "\n\n" +
         tr("If you apply the new settings, the Measured Round Trip Latency will be reset to the default. Microphone inputs will be slightly out of time with Mixxx's outputs until you enter a new Measured Round Trip Latency. Are you sure you want to apply the new Audio Buffer and Sample Rate settings?"));
         latencyChangeWarningBox.setStandardButtons(QMessageBox::Cancel |
@@ -223,7 +223,7 @@ void DlgPrefSound::slotApply() {
         if (userResponse == QMessageBox::Cancel) {
             return;
         } else {
-            roundTripLatencySpinBox->setValue(roundTripLatencySpinBox->minimum());
+            latencyCompensationSpinBox->setValue(latencyCompensationSpinBox->minimum());
         }
     }
 
@@ -413,13 +413,13 @@ void DlgPrefSound::loadSettings(const SoundManagerConfig &config) {
     if (m_config.getAPI() == MIXXX_PORTAUDIO_JACK_STRING) {
         // TODO(Be): Get the processing latency from JACK. PortAudio does
         // not support this as of June 2017.
-        roundTripLatencySpinBox->setMinimum(0.0);
+        latencyCompensationSpinBox->setMinimum(0.0);
     } else {
-        bool measuredRoundTripLatencyAtDefault =
-            m_pRoundTripLatency->get() == roundTripLatencySpinBox->minimum();
-        roundTripLatencySpinBox->setMinimum(config.getProcessingLatency());
-        if (measuredRoundTripLatencyAtDefault) {
-            roundTripLatencySpinBox->setValue(roundTripLatencySpinBox->minimum());
+        bool latencyCompensationAtDefault =
+            m_pLatencyCompensation->get() == latencyCompensationSpinBox->minimum();
+        latencyCompensationSpinBox->setMinimum(config.getProcessingLatency());
+        if (latencyCompensationAtDefault) {
+            latencyCompensationSpinBox->setValue(latencyCompensationSpinBox->minimum());
         }
     }
 
@@ -605,7 +605,7 @@ void DlgPrefSound::slotResetToDefaults() {
     m_pMicMonitorMode->set(0.0);
     micMonitorComboBox->setCurrentIndex(0);
 
-    roundTripLatencySpinBox->setValue(roundTripLatencySpinBox->minimum());
+    latencyCompensationSpinBox->setValue(latencyCompensationSpinBox->minimum());
 
     settingChanged(); // force the apply button to enable
 }
@@ -620,8 +620,8 @@ void DlgPrefSound::masterLatencyChanged(double latency) {
     update();
 }
 
-void DlgPrefSound::roundTripLatencySpinboxChanged(double value) {
-    m_pRoundTripLatency->set(value);
+void DlgPrefSound::latencyCompensationSpinboxChanged(double value) {
+    m_pLatencyCompensation->set(value);
 }
 
 void DlgPrefSound::masterDelaySpinboxChanged(double value) {

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -663,6 +663,10 @@ void DlgPrefSound::checkLatencyCompensation() {
 
     emit(writePaths(&m_config));
 
+    if (m_config.hasExternalRecordBroadcast()) {
+        latencyCompensationSpinBox->setEnabled(false);
+        latencyCompensationWarningLabel->hide();
+    }
     if (configuredMicMonitorMode == EngineMaster::MicMonitorMode::DIRECT_MONITOR
         && m_config.hasMicInputs()) {
         QString warningIcon("<html><img src=':/images/preferences/ic_preferences_warning.png' width='20' height='20'></html> ");

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -116,9 +116,11 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
 
     m_pHeadDelay = new ControlProxy("[Master]", "headDelay", this);
     m_pMasterDelay = new ControlProxy("[Master]", "delay", this);
+    m_pInputLatencyOffset = new ControlProxy("[Master]", "inputOffset", this);
 
     headDelaySpinBox->setValue(m_pHeadDelay->get());
     masterDelaySpinBox->setValue(m_pMasterDelay->get());
+    inputOffsetSpinBox->setValue(m_pInputLatencyOffset->get());
 
     // TODO: remove this option by automatically disabling/enabling the master mix
     // when recording, broadcasting, headphone, and master outputs are enabled/disabled
@@ -138,13 +140,14 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
             this, SLOT(masterOutputModeComboBoxChanged(int)));
     m_pMasterMonoMixdown->connectValueChanged(SLOT(masterMonoMixdownChanged(double)));
 
-    m_pBoothTalkoverMix = new ControlProxy("[Master]", "talkover_mix", this);
+    m_pTalkoverMixMode = new ControlProxy("[Master]", "talkover_mix", this);
     micMixComboBox->addItem(tr("Master output only"));
     micMixComboBox->addItem(tr("Master and booth outputs"));
-    micMixComboBox->setCurrentIndex((int)m_pBoothTalkoverMix->get());
+    micMixComboBox->addItem(tr("Direct monitor (recording and broadcasting only)"));
+    micMixComboBox->setCurrentIndex((int)m_pTalkoverMixMode->get());
     connect(micMixComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(talkoverMixComboBoxChanged(int)));
-    m_pBoothTalkoverMix->connectValueChanged(SLOT(talkoverMixChanged(double)));
+    m_pTalkoverMixMode->connectValueChanged(SLOT(talkoverMixChanged(double)));
 
 
     m_pKeylockEngine =
@@ -154,6 +157,8 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
             this, SLOT(headDelayChanged(double)));
     connect(masterDelaySpinBox, SIGNAL(valueChanged(double)),
             this, SLOT(masterDelayChanged(double)));
+    connect(inputOffsetSpinBox, SIGNAL(valueChanged(double)),
+            this, SLOT(inputOffsetChanged(double)));
 
 
 #ifdef __LINUX__
@@ -542,7 +547,7 @@ void DlgPrefSound::slotResetToDefaults() {
     m_pHeadDelay->set(0.0);
 
     // Enable talkover master output
-    m_pBoothTalkoverMix->set(0.0);
+    m_pTalkoverMixMode->set(0.0);
     micMixComboBox->setCurrentIndex(0);
 
     settingChanged(); // force the apply button to enable
@@ -566,6 +571,10 @@ void DlgPrefSound::masterDelayChanged(double value) {
     m_pMasterDelay->set(value);
 }
 
+void DlgPrefSound::inputOffsetChanged(double value) {
+    m_pInputLatencyOffset->set(value);
+}
+
 void DlgPrefSound::masterMixChanged(int value) {
     m_pMasterEnabled->set(value);
 }
@@ -583,7 +592,7 @@ void DlgPrefSound::masterMonoMixdownChanged(double value) {
 }
 
 void DlgPrefSound::talkoverMixComboBoxChanged(int value) {
-    m_pBoothTalkoverMix->set((double)value);
+    m_pTalkoverMixMode->set((double)value);
 }
 
 void DlgPrefSound::talkoverMixChanged(double value) {

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -80,16 +80,18 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
                         static_cast<EngineBuffer::KeylockEngine>(i)));
     }
 
+    m_pRoundTripLatency = new ControlProxy("[Master]", "roundTripLatency", this);
     m_pMasterDelay = new ControlProxy("[Master]", "delay", this);
     m_pHeadDelay = new ControlProxy("[Master]", "headDelay", this);
     m_pBoothDelay = new ControlProxy("[Master]", "boothDelay", this);
-    m_pRoundTripLatency = new ControlProxy("[Master]", "roundTripLatency", this);
 
+    roundTripLatencySpinBox->setValue(m_pRoundTripLatency->get());
     masterDelaySpinBox->setValue(m_pMasterDelay->get());
     headDelaySpinBox->setValue(m_pHeadDelay->get());
     boothDelaySpinBox->setValue(m_pBoothDelay->get());
-    roundTripLatencySpinBox->setValue(m_pRoundTripLatency->get());
 
+    connect(roundTripLatencySpinBox, SIGNAL(valueChanged(double)),
+            this, SLOT(roundTripLatencySpinboxChanged(double)));
     connect(masterDelaySpinBox, SIGNAL(valueChanged(double)),
             this, SLOT(masterDelaySpinboxChanged(double)));
     connect(headDelaySpinBox, SIGNAL(valueChanged(double)),
@@ -149,14 +151,14 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
             this, SLOT(masterOutputModeComboBoxChanged(int)));
     m_pMasterMonoMixdown->connectValueChanged(SLOT(masterMonoMixdownChanged(double)));
 
-    m_pTalkoverMixMode = new ControlProxy("[Master]", "talkover_mix", this);
-    micMixComboBox->addItem(tr("Master output only"));
-    micMixComboBox->addItem(tr("Master and booth outputs"));
-    micMixComboBox->addItem(tr("Direct monitor (recording and broadcasting only)"));
-    micMixComboBox->setCurrentIndex((int)m_pTalkoverMixMode->get());
-    connect(micMixComboBox, SIGNAL(currentIndexChanged(int)),
-            this, SLOT(talkoverMixComboBoxChanged(int)));
-    m_pTalkoverMixMode->connectValueChanged(SLOT(talkoverMixChanged(double)));
+    m_pMicMonitorMode = new ControlProxy("[Master]", "talkover_mix", this);
+    micMonitorComboBox->addItem(tr("Master output only"));
+    micMonitorComboBox->addItem(tr("Master and booth outputs"));
+    micMonitorComboBox->addItem(tr("Direct monitor (recording and broadcasting only)"));
+    micMonitorComboBox->setCurrentIndex((int)m_pMicMonitorMode->get());
+    connect(micMonitorComboBox, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(micMonitorModeComboBoxChanged(int)));
+    m_pMicMonitorMode->connectValueChanged(SLOT(micMonitorModeChanged(double)));
 
     m_pKeylockEngine =
             new ControlProxy("[Master]", "keylock_engine", this);
@@ -201,10 +203,10 @@ void DlgPrefSound::slotApply() {
         return;
     }
 
-    EngineMaster::TalkoverMixMode configuredTalkoverMixMode =
-        static_cast<EngineMaster::TalkoverMixMode>(
-              static_cast<int>(m_pTalkoverMixMode->get()));
-    if (configuredTalkoverMixMode == EngineMaster::TalkoverMixMode::DIRECT_MONITOR
+    EngineMaster::MicMonitorMode configuredMicMonitorMode =
+        static_cast<EngineMaster::MicMonitorMode>(
+              static_cast<int>(m_pMicMonitorMode->get()));
+    if (configuredMicMonitorMode == EngineMaster::MicMonitorMode::DIRECT_MONITOR
         && m_bLatencyChanged
         && m_pRoundTripLatency->get() != roundTripLatencySpinBox->minimum()) {
         QMessageBox latencyChangeWarningBox;
@@ -600,8 +602,8 @@ void DlgPrefSound::slotResetToDefaults() {
     m_pBoothDelay->set(0.0);
 
     // Enable talkover master output
-    m_pTalkoverMixMode->set(0.0);
-    micMixComboBox->setCurrentIndex(0);
+    m_pMicMonitorMode->set(0.0);
+    micMonitorComboBox->setCurrentIndex(0);
 
     roundTripLatencySpinBox->setValue(roundTripLatencySpinBox->minimum());
 
@@ -616,6 +618,10 @@ void DlgPrefSound::bufferUnderflow(double count) {
 void DlgPrefSound::masterLatencyChanged(double latency) {
     currentLatency->setText(QString("%1 ms").arg(latency));
     update();
+}
+
+void DlgPrefSound::roundTripLatencySpinboxChanged(double value) {
+    m_pRoundTripLatency->set(value);
 }
 
 void DlgPrefSound::masterDelaySpinboxChanged(double value) {
@@ -646,10 +652,10 @@ void DlgPrefSound::masterMonoMixdownChanged(double value) {
     masterOutputModeComboBox->setCurrentIndex(value ? 1 : 0);
 }
 
-void DlgPrefSound::talkoverMixComboBoxChanged(int value) {
-    m_pTalkoverMixMode->set((double)value);
+void DlgPrefSound::micMonitorModeComboBoxChanged(int value) {
+    m_pMicMonitorMode->set((double)value);
 }
 
-void DlgPrefSound::talkoverMixChanged(double value) {
-    micMixComboBox->setCurrentIndex(value ? 1 : 0);
+void DlgPrefSound::micMonitorModeChanged(double value) {
+    micMonitorComboBox->setCurrentIndex(value ? 1 : 0);
 }

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -116,11 +116,11 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
 
     m_pHeadDelay = new ControlProxy("[Master]", "headDelay", this);
     m_pMasterDelay = new ControlProxy("[Master]", "delay", this);
-    m_pInputLatencyOffset = new ControlProxy("[Master]", "inputOffset", this);
+    m_pRoundTripLatency = new ControlProxy("[Master]", "roundTripLatency", this);
 
     headDelaySpinBox->setValue(m_pHeadDelay->get());
     masterDelaySpinBox->setValue(m_pMasterDelay->get());
-    inputOffsetSpinBox->setValue(m_pInputLatencyOffset->get());
+    roundTripLatencySpinBox->setValue(m_pRoundTripLatency->get());
 
     // TODO: remove this option by automatically disabling/enabling the master mix
     // when recording, broadcasting, headphone, and master outputs are enabled/disabled
@@ -157,8 +157,8 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
             this, SLOT(headDelayChanged(double)));
     connect(masterDelaySpinBox, SIGNAL(valueChanged(double)),
             this, SLOT(masterDelayChanged(double)));
-    connect(inputOffsetSpinBox, SIGNAL(valueChanged(double)),
-            this, SLOT(inputOffsetChanged(double)));
+    connect(roundTripLatencySpinBox, SIGNAL(valueChanged(double)),
+            this, SLOT(roundTripLatencyChanged(double)));
 
 
 #ifdef __LINUX__
@@ -571,8 +571,8 @@ void DlgPrefSound::masterDelayChanged(double value) {
     m_pMasterDelay->set(value);
 }
 
-void DlgPrefSound::inputOffsetChanged(double value) {
-    m_pInputLatencyOffset->set(value);
+void DlgPrefSound::roundTripLatencyChanged(double value) {
+    m_pRoundTripLatency->set(value);
 }
 
 void DlgPrefSound::masterMixChanged(int value) {

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -60,7 +60,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void slotResetToDefaults();
     void bufferUnderflow(double count);
     void masterLatencyChanged(double latency);
-    void roundTripLatencySpinboxChanged(double value);
+    void latencyCompensationSpinboxChanged(double value);
     void masterDelaySpinboxChanged(double value);
     void headDelaySpinboxChanged(double value);
     void boothDelaySpinboxChanged(double value);
@@ -99,7 +99,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlProxy* m_pHeadDelay;
     ControlProxy* m_pMasterDelay;
     ControlProxy* m_pBoothDelay;
-    ControlProxy* m_pRoundTripLatency;
+    ControlProxy* m_pLatencyCompensation;
     ControlProxy* m_pKeylockEngine;
     ControlProxy* m_pMasterEnabled;
     ControlProxy* m_pMasterMonoMixdown;

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -63,8 +63,6 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void masterDelaySpinboxChanged(double value);
     void headDelaySpinboxChanged(double value);
     void boothDelaySpinboxChanged(double value);
-    void roundTripLatencySpinboxChanged(double value);
-    void roundTripLatencyChanged(double newRoundTripLatency);
     void masterMixChanged(int value);
     void masterEnabledChanged(double value);
     void masterOutputModeComboBoxChanged(int value);
@@ -100,9 +98,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlProxy* m_pHeadDelay;
     ControlProxy* m_pMasterDelay;
     ControlProxy* m_pBoothDelay;
-    ControlObject* m_pRoundTripLatency;
-    ControlProxy* m_pInputLatencyCompensationDelay;
-    ControlProxy* m_pInputLatencyCompensationHeadphonesDelay;
+    ControlProxy* m_pRoundTripLatency;
     ControlProxy* m_pKeylockEngine;
     ControlProxy* m_pMasterEnabled;
     ControlProxy* m_pMasterMonoMixdown;

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -60,10 +60,11 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void slotResetToDefaults();
     void bufferUnderflow(double count);
     void masterLatencyChanged(double latency);
-    void masterDelayChanged(double value);
-    void headDelayChanged(double value);
-    void boothDelayChanged(double value);
-    void roundTripLatencyChanged(double value);
+    void masterDelaySpinboxChanged(double value);
+    void headDelaySpinboxChanged(double value);
+    void boothDelaySpinboxChanged(double value);
+    void roundTripLatencySpinboxChanged(double value);
+    void roundTripLatencyChanged(double newRoundTripLatency);
     void masterMixChanged(int value);
     void masterEnabledChanged(double value);
     void masterOutputModeComboBoxChanged(int value);
@@ -99,7 +100,9 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlProxy* m_pHeadDelay;
     ControlProxy* m_pMasterDelay;
     ControlProxy* m_pBoothDelay;
-    ControlProxy* m_pRoundTripLatency;
+    ControlObject* m_pRoundTripLatency;
+    ControlProxy* m_pInputLatencyCompensationDelay;
+    ControlProxy* m_pInputLatencyCompensationHeadphonesDelay;
     ControlProxy* m_pKeylockEngine;
     ControlProxy* m_pMasterEnabled;
     ControlProxy* m_pMasterMonoMixdown;
@@ -107,6 +110,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     QList<SoundDevice*> m_inputDevices;
     QList<SoundDevice*> m_outputDevices;
     bool m_settingsModified;
+    bool m_bLatencyChanged;
     SoundManagerConfig m_config;
     bool m_loading;
 };

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -82,6 +82,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void syncBuffersChanged(int index);
     void refreshDevices();
     void settingChanged();
+    void deviceSettingChanged();
     void queryClicked();
 
   private:

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -62,6 +62,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void masterLatencyChanged(double latency);
     void masterDelayChanged(double value);
     void headDelayChanged(double value);
+    void boothDelayChanged(double value);
     void roundTripLatencyChanged(double value);
     void masterMixChanged(int value);
     void masterEnabledChanged(double value);
@@ -97,6 +98,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlProxy* m_pMasterLatency;
     ControlProxy* m_pHeadDelay;
     ControlProxy* m_pMasterDelay;
+    ControlProxy* m_pBoothDelay;
     ControlProxy* m_pRoundTripLatency;
     ControlProxy* m_pKeylockEngine;
     ControlProxy* m_pMasterEnabled;

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -69,7 +69,6 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void masterOutputModeComboBoxChanged(int value);
     void masterMonoMixdownChanged(double value);
     void micMonitorModeComboBoxChanged(int value);
-    void micMonitorModeChanged(double value);
 
   private slots:
     void addPath(AudioOutput output);
@@ -90,6 +89,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void connectSoundItem(DlgPrefSoundItem *item);
     void loadSettings(const SoundManagerConfig &config);
     void insertItem(DlgPrefSoundItem *pItem, QVBoxLayout *pLayout);
+    void checkLatencyCompensation();
 
     SoundManager *m_pSoundManager;
     PlayerManager *m_pPlayerManager;
@@ -108,6 +108,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     QList<SoundDevice*> m_outputDevices;
     bool m_settingsModified;
     bool m_bLatencyChanged;
+    bool m_bSkipConfigClear;
     SoundManagerConfig m_config;
     bool m_loading;
 };

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -60,6 +60,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void slotResetToDefaults();
     void bufferUnderflow(double count);
     void masterLatencyChanged(double latency);
+    void roundTripLatencySpinboxChanged(double value);
     void masterDelaySpinboxChanged(double value);
     void headDelaySpinboxChanged(double value);
     void boothDelaySpinboxChanged(double value);
@@ -67,8 +68,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void masterEnabledChanged(double value);
     void masterOutputModeComboBoxChanged(int value);
     void masterMonoMixdownChanged(double value);
-    void talkoverMixComboBoxChanged(int value);
-    void talkoverMixChanged(double value);
+    void micMonitorModeComboBoxChanged(int value);
+    void micMonitorModeChanged(double value);
 
   private slots:
     void addPath(AudioOutput output);
@@ -102,7 +103,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlProxy* m_pKeylockEngine;
     ControlProxy* m_pMasterEnabled;
     ControlProxy* m_pMasterMonoMixdown;
-    ControlProxy* m_pTalkoverMixMode;
+    ControlProxy* m_pMicMonitorMode;
     QList<SoundDevice*> m_inputDevices;
     QList<SoundDevice*> m_outputDevices;
     bool m_settingsModified;

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -62,6 +62,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void masterLatencyChanged(double latency);
     void headDelayChanged(double value);
     void masterDelayChanged(double value);
+    void inputOffsetChanged(double value);
     void masterMixChanged(int value);
     void masterEnabledChanged(double value);
     void masterOutputModeComboBoxChanged(int value);
@@ -96,10 +97,11 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlProxy* m_pMasterLatency;
     ControlProxy* m_pHeadDelay;
     ControlProxy* m_pMasterDelay;
+    ControlProxy* m_pInputLatencyOffset;
     ControlProxy* m_pKeylockEngine;
     ControlProxy* m_pMasterEnabled;
     ControlProxy* m_pMasterMonoMixdown;
-    ControlProxy* m_pBoothTalkoverMix;
+    ControlProxy* m_pTalkoverMixMode;
     QList<SoundDevice*> m_inputDevices;
     QList<SoundDevice*> m_outputDevices;
     bool m_settingsModified;

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -60,8 +60,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void slotResetToDefaults();
     void bufferUnderflow(double count);
     void masterLatencyChanged(double latency);
-    void headDelayChanged(double value);
     void masterDelayChanged(double value);
+    void headDelayChanged(double value);
     void roundTripLatencyChanged(double value);
     void masterMixChanged(int value);
     void masterEnabledChanged(double value);

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -62,7 +62,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void masterLatencyChanged(double latency);
     void headDelayChanged(double value);
     void masterDelayChanged(double value);
-    void inputOffsetChanged(double value);
+    void roundTripLatencyChanged(double value);
     void masterMixChanged(int value);
     void masterEnabledChanged(double value);
     void masterOutputModeComboBoxChanged(int value);
@@ -97,7 +97,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlProxy* m_pMasterLatency;
     ControlProxy* m_pHeadDelay;
     ControlProxy* m_pMasterDelay;
-    ControlProxy* m_pInputLatencyOffset;
+    ControlProxy* m_pRoundTripLatency;
     ControlProxy* m_pKeylockEngine;
     ControlProxy* m_pMasterEnabled;
     ControlProxy* m_pMasterMonoMixdown;

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -99,7 +99,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlProxy* m_pKeylockEngine;
     ControlProxy* m_pMasterEnabled;
     ControlProxy* m_pMasterMonoMixdown;
-    ControlProxy* m_pMasterTalkoverMix;
+    ControlProxy* m_pBoothTalkoverMix;
     QList<SoundDevice*> m_inputDevices;
     QList<SoundDevice*> m_outputDevices;
     bool m_settingsModified;

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -155,14 +155,14 @@
       <widget class="QComboBox" name="masterMixComboBox"/>
      </item>
      <item row="10" column="0">
-      <widget class="QLabel" name="inputOffsetLabel">
+      <widget class="QLabel" name="roundTripLatencyLabel">
        <property name="text">
-        <string>Measured Input Latency Offset</string>
+        <string>Measured Round Trip Latency</string>
        </property>
       </widget>
      </item>
      <item row="10" column="1">
-      <widget class="QDoubleSpinBox" name="inputOffsetSpinBox">
+      <widget class="QDoubleSpinBox" name="roundTripLatencySpinBox">
        <property name="suffix">
         <string> ms</string>
        </property>

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -99,14 +99,14 @@
       <widget class="QComboBox" name="masterOutputModeComboBox"/>
      </item>
      <item row="7" column="0">
-      <widget class="QLabel" name="micMonitorLabel">
+      <widget class="QLabel" name="micMonitorModeLabel">
        <property name="text">
         <string>Microphone Monitor Mode</string>
        </property>
       </widget>
      </item>
      <item row="7" column="1">
-      <widget class="QComboBox" name="micMonitorComboBox"/>
+      <widget class="QComboBox" name="micMonitorModeComboBox"/>
      </item>
      <item row="8" column="0">
       <widget class="QLabel" name="latencyCompensationLabel">

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -124,7 +124,7 @@
         <number>3</number>
        </property>
        <property name="maximum">
-        <double>1000.000000000000000</double>
+        <double>500.000000000000000</double>
        </property>
        <property name="singleStep">
         <double>0.100000000000000</double>
@@ -147,7 +147,7 @@
         <number>3</number>
        </property>
        <property name="maximum">
-        <double>1000.000000000000000</double>
+        <double>500.000000000000000</double>
        </property>
        <property name="singleStep">
         <double>0.100000000000000</double>
@@ -170,7 +170,7 @@
         <number>3</number>
        </property>
        <property name="maximum">
-        <double>1000.000000000000000</double>
+        <double>500.000000000000000</double>
        </property>
        <property name="singleStep">
         <double>0.100000000000000</double>
@@ -193,7 +193,7 @@
         <number>3</number>
        </property>
        <property name="maximum">
-        <double>1000.000000000000000</double>
+        <double>500.000000000000000</double>
        </property>
        <property name="singleStep">
         <double>0.100000000000000</double>

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -109,14 +109,14 @@
       <widget class="QComboBox" name="micMonitorComboBox"/>
      </item>
      <item row="8" column="0">
-      <widget class="QLabel" name="roundTripLatencyLabel">
+      <widget class="QLabel" name="latencyCompensationLabel">
        <property name="text">
-        <string>Measured Round Trip Latency</string>
+        <string>Microphone Latency Compensation</string>
        </property>
       </widget>
      </item>
      <item row="8" column="1">
-      <widget class="QDoubleSpinBox" name="roundTripLatencySpinBox">
+      <widget class="QDoubleSpinBox" name="latencyCompensationSpinBox">
        <property name="suffix">
         <string> ms</string>
        </property>

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>686</width>
-    <height>584</height>
+    <height>753</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,13 +16,75 @@
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <item row="9" column="0">
+      <widget class="QLabel" name="masterDelayLabel">
+       <property name="text">
+        <string>Master Delay</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="apiLabel">
+       <property name="text">
+        <string>Sound API</string>
+       </property>
+       <property name="buddy">
+        <cstring>apiComboBox</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="audioBufferComboBox"/>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="sampleRateComboBox"/>
+     </item>
+     <item row="7" column="1">
+      <widget class="QComboBox" name="micMixComboBox"/>
+     </item>
+     <item row="6" column="1">
+      <widget class="QComboBox" name="masterOutputModeComboBox"/>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="masterMonoLabel">
+       <property name="text">
+        <string>Master Output Mode</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1">
       <widget class="QComboBox" name="apiComboBox"/>
+     </item>
+     <item row="8" column="1">
+      <widget class="QDoubleSpinBox" name="headDelaySpinBox">
+       <property name="suffix">
+        <string extracomment="milliseconds"> ms</string>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="maximum">
+        <double>200.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="deviceSyncComboBox"/>
      </item>
      <item row="8" column="0">
       <widget class="QLabel" name="headDelayLabel">
        <property name="text">
         <string>Headphone Delay</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="deviceSyncLabel">
+       <property name="text">
+        <string>Multi-Soundcard Synchronization</string>
        </property>
       </widget>
      </item>
@@ -36,90 +98,38 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
-      <widget class="QDoubleSpinBox" name="masterDelaySpinBox">
-       <property name="suffix">
-        <string extracomment="milliseconds"> ms</string>
-       </property>
-       <property name="decimals">
-        <number>2</number>
-       </property>
-       <property name="maximum">
-        <double>200.000000000000000</double>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="0">
       <widget class="QLabel" name="sampleRateLabel">
        <property name="text">
-        <string>Sample Rate</string>
+        <string>Sa&amp;mple Rate</string>
        </property>
        <property name="buddy">
         <cstring>sampleRateComboBox</cstring>
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
-      <spacer name="outputVSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::MinimumExpanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>1</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="sampleRateComboBox"/>
-     </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="audioBufferComboBox"/>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="apiLabel">
+     <item row="7" column="0">
+      <widget class="QLabel" name="micMixLabel">
        <property name="text">
-        <string>Sound API</string>
-       </property>
-       <property name="buddy">
-        <cstring>apiComboBox</cstring>
+        <string>Microphone Mix Mode</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
-      <widget class="QDoubleSpinBox" name="headDelaySpinBox">
+     <item row="9" column="1">
+      <widget class="QDoubleSpinBox" name="masterDelaySpinBox">
        <property name="suffix">
         <string extracomment="milliseconds"> ms</string>
        </property>
        <property name="decimals">
-        <number>2</number>
+        <number>3</number>
        </property>
        <property name="maximum">
         <double>200.000000000000000</double>
        </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="masterDelayLabel">
-       <property name="text">
-        <string>Master Delay</string>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
        </property>
       </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="deviceSyncLabel">
-       <property name="text">
-        <string>Multi-Soundcard Synchronization</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QComboBox" name="deviceSyncComboBox"/>
      </item>
      <item row="5" column="0">
       <widget class="QLabel" name="masteMixLabel">
@@ -128,13 +138,10 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QComboBox" name="masterMixComboBox"/>
-     </item>
      <item row="4" column="0">
       <widget class="QLabel" name="keylockLabel">
        <property name="text">
-        <string>Keylock/Pitch-Bending Engine</string>
+        <string>&amp;Keylock/Pitch-Bending Engine</string>
        </property>
        <property name="buddy">
         <cstring>keylockComboBox</cstring>
@@ -144,25 +151,31 @@
      <item row="4" column="1">
       <widget class="QComboBox" name="keylockComboBox"/>
      </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="masterMonoLabel">
+     <item row="5" column="1">
+      <widget class="QComboBox" name="masterMixComboBox"/>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="inputOffsetLabel">
        <property name="text">
-        <string>Master Output Mode</string>
+        <string>Measured Input Latency Offset</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
-      <widget class="QComboBox" name="masterOutputModeComboBox"/>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="micMixLabel">
-       <property name="text">
-        <string>Microphone/Talkover Mix</string>
+     <item row="10" column="1">
+      <widget class="QDoubleSpinBox" name="inputOffsetSpinBox">
+       <property name="suffix">
+        <string> ms</string>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="maximum">
+        <double>200.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
        </property>
       </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="QComboBox" name="micMixComboBox"/>
      </item>
     </layout>
    </item>
@@ -316,39 +329,39 @@
        </widget>
       </item>
       <item row="6" column="0">
-        <widget class="QLabel" name="latencyLabel">
-         <property name="text">
-          <string>System Reported Latency</string>
-         </property>
-         <property name="buddy">
-          <cstring>audioBufferComboBox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="QLabel" name="currentLatency">
-         <property name="text">
-          <string>20 ms</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="underflowLabel">
-         <property name="text">
-          <string>Buffer Underflow Count</string>
-         </property>
-         <property name="buddy">
-          <cstring>audioBufferComboBox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="QLabel" name="bufferUnderflowCount">
-         <property name="text">
-          <string>0</string>
-         </property>
-        </widget>
-       </item>
+       <widget class="QLabel" name="latencyLabel">
+        <property name="text">
+         <string>System Reported &amp;Latency</string>
+        </property>
+        <property name="buddy">
+         <cstring>audioBufferComboBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLabel" name="currentLatency">
+        <property name="text">
+         <string>20 ms</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="underflowLabel">
+        <property name="text">
+         <string>Buffer &amp;Underflow Count</string>
+        </property>
+        <property name="buddy">
+         <cstring>audioBufferComboBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QLabel" name="bufferUnderflowCount">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -16,13 +16,6 @@
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="9" column="0">
-      <widget class="QLabel" name="masterDelayLabel">
-       <property name="text">
-        <string>Master Delay</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="apiLabel">
        <property name="text">
@@ -33,17 +26,67 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="audioBufferComboBox"/>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="apiComboBox"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="sampleRateLabel">
+       <property name="text">
+        <string>Sa&amp;mple Rate</string>
+       </property>
+       <property name="buddy">
+        <cstring>sampleRateComboBox</cstring>
+       </property>
+      </widget>
      </item>
      <item row="1" column="1">
       <widget class="QComboBox" name="sampleRateComboBox"/>
      </item>
-     <item row="7" column="1">
-      <widget class="QComboBox" name="micMixComboBox"/>
+     <item row="2" column="0">
+      <widget class="QLabel" name="audioBufferLabel">
+       <property name="text">
+        <string>Audio Buffer</string>
+       </property>
+       <property name="buddy">
+        <cstring>audioBufferComboBox</cstring>
+       </property>
+      </widget>
      </item>
-     <item row="6" column="1">
-      <widget class="QComboBox" name="masterOutputModeComboBox"/>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="audioBufferComboBox"/>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="deviceSyncLabel">
+       <property name="text">
+        <string>Multi-Soundcard Synchronization</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="deviceSyncComboBox"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="keylockLabel">
+       <property name="text">
+        <string>&amp;Keylock/Pitch-Bending Engine</string>
+       </property>
+       <property name="buddy">
+        <cstring>keylockComboBox</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QComboBox" name="keylockComboBox"/>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="masteMixLabel">
+       <property name="text">
+        <string>Master Mix</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QComboBox" name="masterMixComboBox"/>
      </item>
      <item row="6" column="0">
       <widget class="QLabel" name="masterMonoLabel">
@@ -52,8 +95,25 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="apiComboBox"/>
+     <item row="6" column="1">
+      <widget class="QComboBox" name="masterOutputModeComboBox"/>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="micMixLabel">
+       <property name="text">
+        <string>Microphone Mix Mode</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QComboBox" name="micMixComboBox"/>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="headDelayLabel">
+       <property name="text">
+        <string>Headphone Delay</string>
+       </property>
+      </widget>
      </item>
      <item row="8" column="1">
       <widget class="QDoubleSpinBox" name="headDelaySpinBox">
@@ -71,47 +131,10 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QComboBox" name="deviceSyncComboBox"/>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="headDelayLabel">
+     <item row="9" column="0">
+      <widget class="QLabel" name="masterDelayLabel">
        <property name="text">
-        <string>Headphone Delay</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="deviceSyncLabel">
-       <property name="text">
-        <string>Multi-Soundcard Synchronization</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="audioBufferLabel">
-       <property name="text">
-        <string>Audio Buffer</string>
-       </property>
-       <property name="buddy">
-        <cstring>audioBufferComboBox</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="sampleRateLabel">
-       <property name="text">
-        <string>Sa&amp;mple Rate</string>
-       </property>
-       <property name="buddy">
-        <cstring>sampleRateComboBox</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="micMixLabel">
-       <property name="text">
-        <string>Microphone Mix Mode</string>
+        <string>Master Delay</string>
        </property>
       </widget>
      </item>
@@ -130,29 +153,6 @@
         <double>0.100000000000000</double>
        </property>
       </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="masteMixLabel">
-       <property name="text">
-        <string>Master Mix</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="keylockLabel">
-       <property name="text">
-        <string>&amp;Keylock/Pitch-Bending Engine</string>
-       </property>
-       <property name="buddy">
-        <cstring>keylockComboBox</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QComboBox" name="keylockComboBox"/>
-     </item>
-     <item row="5" column="1">
-      <widget class="QComboBox" name="masterMixComboBox"/>
      </item>
      <item row="10" column="0">
       <widget class="QLabel" name="roundTripLatencyLabel">
@@ -298,7 +298,7 @@
       <item row="3" column="0" colspan="2">
        <widget class="QLabel" name="limitsHint">
         <property name="text">
-         <string>Enable Realtime scheduling (currently disabled), see the &lt;a href=&quot;http://mixxx.org/wiki/doku.php/adjusting_audio_latency&quot;&gt;Mixxx Wiki&lt;/a&gt;.</string>
+         <string>Enable Realtime scheduling (currently disabled), see the &lt;a href="http://mixxx.org/wiki/doku.php/adjusting_audio_latency"&gt;Mixxx Wiki&lt;/a&gt;.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -311,7 +311,7 @@
       <item row="4" column="0" colspan="2">
        <widget class="QLabel" name="hardwareGuide">
         <property name="text">
-         <string>The &lt;a href=&quot;http://mixxx.org/wiki/doku.php/hardware_compatibility&quot;&gt;Mixxx DJ Hardware Guide&lt;/a&gt; lists sound cards and controllers you may want to consider for using Mixxx.</string>
+         <string>The &lt;a href="http://mixxx.org/wiki/doku.php/hardware_compatibility"&gt;Mixxx DJ Hardware Guide&lt;/a&gt; lists sound cards and controllers you may want to consider for using Mixxx.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>686</width>
-    <height>753</height>
+    <height>852</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -75,6 +75,9 @@
        </property>
       </widget>
      </item>
+     <item row="5" column="1">
+      <widget class="QComboBox" name="masterMixComboBox"/>
+     </item>
      <item row="4" column="1">
       <widget class="QComboBox" name="keylockComboBox"/>
      </item>
@@ -85,8 +88,8 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QComboBox" name="masterMixComboBox"/>
+     <item row="6" column="1">
+      <widget class="QComboBox" name="masterOutputModeComboBox"/>
      </item>
      <item row="6" column="0">
       <widget class="QLabel" name="masterMonoLabel">
@@ -95,8 +98,8 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
-      <widget class="QComboBox" name="masterOutputModeComboBox"/>
+     <item row="7" column="1">
+      <widget class="QComboBox" name="micMonitorModeComboBox"/>
      </item>
      <item row="7" column="0">
       <widget class="QLabel" name="micMonitorModeLabel">
@@ -104,9 +107,6 @@
         <string>Microphone Monitor Mode</string>
        </property>
       </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="QComboBox" name="micMonitorModeComboBox"/>
      </item>
      <item row="8" column="0">
       <widget class="QLabel" name="latencyCompensationLabel">
@@ -131,14 +131,14 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="0">
+     <item row="10" column="0">
       <widget class="QLabel" name="masterDelayLabel">
        <property name="text">
         <string>Master Delay</string>
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
+     <item row="10" column="1">
       <widget class="QDoubleSpinBox" name="masterDelaySpinBox">
        <property name="suffix">
         <string extracomment="milliseconds"> ms</string>
@@ -154,14 +154,14 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
+     <item row="11" column="0">
       <widget class="QLabel" name="headDelayLabel">
        <property name="text">
         <string>Headphone Delay</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
+     <item row="11" column="1">
       <widget class="QDoubleSpinBox" name="headDelaySpinBox">
        <property name="suffix">
         <string extracomment="milliseconds"> ms</string>
@@ -177,14 +177,14 @@
        </property>
       </widget>
      </item>
-     <item row="11" column="0">
+     <item row="12" column="0">
       <widget class="QLabel" name="boothDelayLabel">
        <property name="text">
         <string>Booth Delay</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="1">
+     <item row="12" column="1">
       <widget class="QDoubleSpinBox" name="boothDelaySpinBox">
        <property name="suffix">
         <string extracomment="milliseconds"> ms</string>
@@ -197,6 +197,13 @@
        </property>
        <property name="singleStep">
         <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0" colspan="2">
+      <widget class="QLabel" name="latencyCompensationWarningLabel">
+       <property name="text">
+        <string>warning goes here</string>
        </property>
       </widget>
      </item>
@@ -321,7 +328,7 @@
       <item row="3" column="0" colspan="2">
        <widget class="QLabel" name="limitsHint">
         <property name="text">
-         <string>Enable Realtime scheduling (currently disabled), see the &lt;a href="http://mixxx.org/wiki/doku.php/adjusting_audio_latency"&gt;Mixxx Wiki&lt;/a&gt;.</string>
+         <string>Enable Realtime scheduling (currently disabled), see the &lt;a href=&quot;http://mixxx.org/wiki/doku.php/adjusting_audio_latency&quot;&gt;Mixxx Wiki&lt;/a&gt;.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -334,7 +341,7 @@
       <item row="4" column="0" colspan="2">
        <widget class="QLabel" name="hardwareGuide">
         <property name="text">
-         <string>The &lt;a href="http://mixxx.org/wiki/doku.php/hardware_compatibility"&gt;Mixxx DJ Hardware Guide&lt;/a&gt; lists sound cards and controllers you may want to consider for using Mixxx.</string>
+         <string>The &lt;a href=&quot;http://mixxx.org/wiki/doku.php/hardware_compatibility&quot;&gt;Mixxx DJ Hardware Guide&lt;/a&gt; lists sound cards and controllers you may want to consider for using Mixxx.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -155,13 +155,36 @@
       </widget>
      </item>
      <item row="10" column="0">
+      <widget class="QLabel" name="boothDelayLabel">
+       <property name="text">
+        <string>Booth Delay</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QDoubleSpinBox" name="boothDelaySpinBox">
+       <property name="suffix">
+        <string extracomment="milliseconds"> ms</string>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="maximum">
+        <double>200.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="0">
       <widget class="QLabel" name="roundTripLatencyLabel">
        <property name="text">
         <string>Measured Round Trip Latency</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
+     <item row="11" column="1">
       <widget class="QDoubleSpinBox" name="roundTripLatencySpinBox">
        <property name="suffix">
         <string> ms</string>

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -124,7 +124,7 @@
         <number>3</number>
        </property>
        <property name="maximum">
-        <double>200.000000000000000</double>
+        <double>1000.000000000000000</double>
        </property>
        <property name="singleStep">
         <double>0.100000000000000</double>
@@ -147,7 +147,7 @@
         <number>3</number>
        </property>
        <property name="maximum">
-        <double>200.000000000000000</double>
+        <double>1000.000000000000000</double>
        </property>
        <property name="singleStep">
         <double>0.100000000000000</double>
@@ -170,7 +170,7 @@
         <number>3</number>
        </property>
        <property name="maximum">
-        <double>200.000000000000000</double>
+        <double>1000.000000000000000</double>
        </property>
        <property name="singleStep">
         <double>0.100000000000000</double>
@@ -193,7 +193,7 @@
         <number>3</number>
        </property>
        <property name="maximum">
-        <double>200.000000000000000</double>
+        <double>1000.000000000000000</double>
        </property>
        <property name="singleStep">
         <double>0.100000000000000</double>

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -99,23 +99,46 @@
       <widget class="QComboBox" name="masterOutputModeComboBox"/>
      </item>
      <item row="7" column="0">
-      <widget class="QLabel" name="micMixLabel">
+      <widget class="QLabel" name="micMonitorLabel">
        <property name="text">
-        <string>Microphone Mix Mode</string>
+        <string>Microphone Monitor Mode</string>
        </property>
       </widget>
      </item>
      <item row="7" column="1">
-      <widget class="QComboBox" name="micMixComboBox"/>
+      <widget class="QComboBox" name="micMonitorComboBox"/>
      </item>
      <item row="8" column="0">
+      <widget class="QLabel" name="roundTripLatencyLabel">
+       <property name="text">
+        <string>Measured Round Trip Latency</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QDoubleSpinBox" name="roundTripLatencySpinBox">
+       <property name="suffix">
+        <string> ms</string>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="maximum">
+        <double>1000.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
       <widget class="QLabel" name="masterDelayLabel">
        <property name="text">
         <string>Master Delay</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
+     <item row="9" column="1">
       <widget class="QDoubleSpinBox" name="masterDelaySpinBox">
        <property name="suffix">
         <string extracomment="milliseconds"> ms</string>
@@ -131,14 +154,14 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="0">
+     <item row="10" column="0">
       <widget class="QLabel" name="headDelayLabel">
        <property name="text">
         <string>Headphone Delay</string>
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
+     <item row="10" column="1">
       <widget class="QDoubleSpinBox" name="headDelaySpinBox">
        <property name="suffix">
         <string extracomment="milliseconds"> ms</string>
@@ -154,40 +177,17 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
+     <item row="11" column="0">
       <widget class="QLabel" name="boothDelayLabel">
        <property name="text">
         <string>Booth Delay</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
+     <item row="11" column="1">
       <widget class="QDoubleSpinBox" name="boothDelaySpinBox">
        <property name="suffix">
         <string extracomment="milliseconds"> ms</string>
-       </property>
-       <property name="decimals">
-        <number>3</number>
-       </property>
-       <property name="maximum">
-        <double>1000.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="0">
-      <widget class="QLabel" name="roundTripLatencyLabel">
-       <property name="text">
-        <string>Measured Round Trip Latency</string>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="1">
-      <widget class="QDoubleSpinBox" name="roundTripLatencySpinBox">
-       <property name="suffix">
-        <string> ms</string>
        </property>
        <property name="decimals">
         <number>3</number>

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -109,14 +109,14 @@
       <widget class="QComboBox" name="micMixComboBox"/>
      </item>
      <item row="8" column="0">
-      <widget class="QLabel" name="headDelayLabel">
+      <widget class="QLabel" name="masterDelayLabel">
        <property name="text">
-        <string>Headphone Delay</string>
+        <string>Master Delay</string>
        </property>
       </widget>
      </item>
      <item row="8" column="1">
-      <widget class="QDoubleSpinBox" name="headDelaySpinBox">
+      <widget class="QDoubleSpinBox" name="masterDelaySpinBox">
        <property name="suffix">
         <string extracomment="milliseconds"> ms</string>
        </property>
@@ -132,14 +132,14 @@
       </widget>
      </item>
      <item row="9" column="0">
-      <widget class="QLabel" name="masterDelayLabel">
+      <widget class="QLabel" name="headDelayLabel">
        <property name="text">
-        <string>Master Delay</string>
+        <string>Headphone Delay</string>
        </property>
       </widget>
      </item>
      <item row="9" column="1">
-      <widget class="QDoubleSpinBox" name="masterDelaySpinBox">
+      <widget class="QDoubleSpinBox" name="headDelaySpinBox">
        <property name="suffix">
         <string extracomment="milliseconds"> ms</string>
        </property>

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -28,6 +28,7 @@
 #include "engine/enginebuffer.h"
 #include "engine/enginemaster.h"
 #include "engine/sidechain/enginenetworkstream.h"
+#include "engine/sidechain/enginesidechain.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddevicenetwork.h"
 #include "soundio/sounddevicenotfound.h"
@@ -79,6 +80,9 @@ SoundManager::SoundManager(UserSettingsPointer pConfig,
 
     m_pNetworkStream = QSharedPointer<EngineNetworkStream>(
             new EngineNetworkStream(2, 0));
+
+    AudioInput recordInput = AudioInput(AudioPath::RECORD_BROADCAST, 0, 2);
+    registerInput(recordInput, pMaster->getSideChain());
 
     queryDevices();
 

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -179,6 +179,7 @@ void SoundManager::closeDevices(bool sleepAfterClosing) {
                          m_registeredDestinations.find(in);
                  it != m_registeredDestinations.end() && it.key() == in; ++it) {
                 it.value()->onInputUnconfigured(in);
+                m_pMaster->onInputDisconnected(in);
             }
         }
         foreach (AudioOutput out, pDevice->outputs()) {
@@ -381,6 +382,7 @@ SoundDeviceError SoundManager::setupDevices() {
                     it != m_registeredDestinations.end() && it.key() == in;
                     ++it) {
                 it.value()->onInputConfigured(in);
+                m_pMaster->onInputConnected(in);
             }
         }
         QList<AudioOutput> outputs =

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -391,7 +391,7 @@ SoundDeviceError SoundManager::setupDevices() {
 
         // Statically connect the Network Device to the Sidechain
         if (device->getInternalName() == kNetworkDeviceInternalName) {
-            AudioOutput out(AudioPath::SIDECHAIN, 0, 2, 0);
+            AudioOutput out(AudioPath::RECORD_BROADCAST, 0, 2, 0);
             outputs.append(out);
         }
 

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -81,9 +81,6 @@ SoundManager::SoundManager(UserSettingsPointer pConfig,
     m_pNetworkStream = QSharedPointer<EngineNetworkStream>(
             new EngineNetworkStream(2, 0));
 
-    AudioInput recordInput = AudioInput(AudioPath::RECORD_BROADCAST, 0, 2);
-    registerInput(recordInput, pMaster->getSideChain());
-
     queryDevices();
 
     if (!m_config.readFromDisk()) {
@@ -615,7 +612,6 @@ void SoundManager::readProcess() {
         }
     }
 }
-
 
 void SoundManager::registerOutput(AudioOutput output, AudioSource *src) {
     if (m_registeredSources.contains(output)) {

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -250,6 +250,8 @@ unsigned int SoundManagerConfig::getAudioBufferSizeIndex() const {
     return m_audioBufferSizeIndex;
 }
 
+// FIXME: This is incorrect when using JACK as the sound API!
+// m_audioBufferSizeIndex does not reflect JACK's buffer size.
 unsigned int SoundManagerConfig::getFramesPerBuffer() const {
     // endless loop otherwise
     unsigned int audioBufferSizeIndex = m_audioBufferSizeIndex;
@@ -266,6 +268,12 @@ unsigned int SoundManagerConfig::getFramesPerBuffer() const {
         framesPerBuffer <<= 1; // *= 2
     }
     return framesPerBuffer;
+}
+
+// FIXME: This is incorrect when using JACK as the sound API!
+// m_audioBufferSizeIndex does not reflect JACK's buffer size.
+double SoundManagerConfig::getProcessingLatency() const {
+    return static_cast<double>(getFramesPerBuffer()) / m_sampleRate * 1000.0;
 }
 
 

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -38,7 +38,9 @@ SoundManagerConfig::SoundManagerConfig()
       m_sampleRate(kFallbackSampleRate),
       m_deckCount(kDefaultDeckCount),
       m_audioBufferSizeIndex(kDefaultAudioBufferSizeIndex),
-      m_syncBuffers(2) {
+      m_syncBuffers(2),
+      m_iNumMicInputs(0),
+      m_bExternalRecordBroadcastConnected(false) {
     m_configFile = QFileInfo(QDir(CmdlineArgs::Instance().getSettingsPath()).filePath(SOUNDMANAGERCONFIG_FILENAME));
 }
 
@@ -297,6 +299,8 @@ void SoundManagerConfig::addInput(const QString &device, const AudioInput &in) {
     m_inputs.insert(device, in);
     if (in.getType() == AudioPath::MICROPHONE) {
         m_iNumMicInputs++;
+    } else if (in.getType() == AudioPath::RECORD_BROADCAST) {
+        m_bExternalRecordBroadcastConnected = true;
     }
 }
 
@@ -315,10 +319,15 @@ void SoundManagerConfig::clearOutputs() {
 void SoundManagerConfig::clearInputs() {
     m_inputs.clear();
     m_iNumMicInputs = 0;
+    m_bExternalRecordBroadcastConnected = false;
 }
 
 bool SoundManagerConfig::hasMicInputs() {
     return m_iNumMicInputs;
+}
+
+bool SoundManagerConfig::hasExternalRecordBroadcast() {
+    return m_bExternalRecordBroadcastConnected;
 }
 
 /**

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -295,6 +295,9 @@ void SoundManagerConfig::addOutput(const QString &device, const AudioOutput &out
 
 void SoundManagerConfig::addInput(const QString &device, const AudioInput &in) {
     m_inputs.insert(device, in);
+    if (in.getType() == AudioPath::MICROPHONE) {
+        m_iNumMicInputs++;
+    }
 }
 
 QMultiHash<QString, AudioOutput> SoundManagerConfig::getOutputs() const {
@@ -311,6 +314,11 @@ void SoundManagerConfig::clearOutputs() {
 
 void SoundManagerConfig::clearInputs() {
     m_inputs.clear();
+    m_iNumMicInputs = 0;
+}
+
+bool SoundManagerConfig::hasMicInputs() {
+    return m_iNumMicInputs;
 }
 
 /**

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -76,6 +76,7 @@ public:
     QMultiHash<QString, AudioInput> getInputs() const;
     void clearOutputs();
     void clearInputs();
+    bool hasMicInputs();
     void loadDefaults(SoundManager *soundManager, unsigned int flags);
 private:
     QFileInfo m_configFile;
@@ -92,5 +93,6 @@ private:
     unsigned int m_syncBuffers;
     QMultiHash<QString, AudioOutput> m_outputs;
     QMultiHash<QString, AudioInput> m_inputs;
+    int m_iNumMicInputs;
 };
 #endif

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -65,6 +65,8 @@ public:
 
     unsigned int getAudioBufferSizeIndex() const;
     unsigned int getFramesPerBuffer() const;
+    // Returns the processing latency in milliseconds
+    double getProcessingLatency() const;
     void setAudioBufferSizeIndex(unsigned int latency);
     unsigned int getSyncBuffers() const;
     void setSyncBuffers(unsigned int sampleRate);

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -77,6 +77,7 @@ public:
     void clearOutputs();
     void clearInputs();
     bool hasMicInputs();
+    bool hasExternalRecordBroadcast();
     void loadDefaults(SoundManager *soundManager, unsigned int flags);
 private:
     QFileInfo m_configFile;
@@ -94,5 +95,6 @@ private:
     QMultiHash<QString, AudioOutput> m_outputs;
     QMultiHash<QString, AudioInput> m_inputs;
     int m_iNumMicInputs;
+    bool m_bExternalRecordBroadcastConnected;
 };
 #endif

--- a/src/soundio/soundmanagerutil.cpp
+++ b/src/soundio/soundmanagerutil.cpp
@@ -171,8 +171,6 @@ QString AudioPath::getStringFromType(AudioPathType type) {
         return QString::fromAscii("Microphone");
     case AUXILIARY:
         return QString::fromAscii("Auxiliary");
-    case SIDECHAIN:
-        return QString::fromAscii("Sidechain");
     }
     return QString::fromAscii("Unknown path type %1").arg(type);
 }
@@ -218,8 +216,6 @@ QString AudioPath::getTrStringFromType(AudioPathType type, unsigned char index) 
     case AUXILIARY:
         return QString("%1 %2").arg(QObject::tr("Auxiliary"),
                                     QString::number(index + 1));
-    case SIDECHAIN:
-        return QObject::tr("Sidechain");
     }
     return QObject::tr("Unknown path type %1").arg(type);
 }
@@ -246,8 +242,8 @@ AudioPathType AudioPath::getTypeFromString(QString string) {
         return AudioPath::MICROPHONE;
     } else if (string == AudioPath::getStringFromType(AudioPath::AUXILIARY).toLower()) {
         return AudioPath::AUXILIARY;
-    } else if (string == AudioPath::getStringFromType(AudioPath::SIDECHAIN).toLower()) {
-        return AudioPath::SIDECHAIN;
+    } else if (string == AudioPath::getStringFromType(AudioPath::RECORD_BROADCAST).toLower()) {
+        return AudioPath::RECORD_BROADCAST;
     } else {
         return AudioPath::INVALID;
     }
@@ -364,12 +360,12 @@ QList<AudioPathType> AudioOutput::getSupportedTypes() {
     types.append(HEADPHONES);
     types.append(BUS);
     types.append(DECK);
-    types.append(SIDECHAIN);
+    types.append(RECORD_BROADCAST);
     return types;
 }
 
 bool AudioOutput::isHidden() {
-    return m_type == SIDECHAIN;
+    return m_type == RECORD_BROADCAST;
 }
 
 

--- a/src/soundio/soundmanagerutil.cpp
+++ b/src/soundio/soundmanagerutil.cpp
@@ -155,6 +155,8 @@ QString AudioPath::getStringFromType(AudioPathType type) {
         return QString::fromAscii("Invalid");
     case MASTER:
         return QString::fromAscii("Master");
+    case BOOTH:
+        return QString::fromAscii("Booth");
     case HEADPHONES:
         return QString::fromAscii("Headphones");
     case BUS:
@@ -185,6 +187,8 @@ QString AudioPath::getTrStringFromType(AudioPathType type, unsigned char index) 
         return QObject::tr("Invalid");
     case MASTER:
         return QObject::tr("Master");
+    case BOOTH:
+        return QObject::tr("Booth");
     case HEADPHONES:
         return QObject::tr("Headphones");
     case BUS:
@@ -224,6 +228,8 @@ AudioPathType AudioPath::getTypeFromString(QString string) {
     string = string.toLower();
     if (string == AudioPath::getStringFromType(AudioPath::MASTER).toLower()) {
         return AudioPath::MASTER;
+    } else if (string == AudioPath::getStringFromType(AudioPath::BOOTH).toLower()) {
+        return AudioPath::BOOTH;
     } else if (string == AudioPath::getStringFromType(AudioPath::HEADPHONES).toLower()) {
         return AudioPath::HEADPHONES;
     } else if (string == AudioPath::getStringFromType(AudioPath::BUS).toLower()) {
@@ -350,6 +356,7 @@ AudioOutput AudioOutput::fromXML(const QDomElement &xml) {
 QList<AudioPathType> AudioOutput::getSupportedTypes() {
     QList<AudioPathType> types;
     types.append(MASTER);
+    types.append(BOOTH);
     types.append(HEADPHONES);
     types.append(BUS);
     types.append(DECK);

--- a/src/soundio/soundmanagerutil.cpp
+++ b/src/soundio/soundmanagerutil.cpp
@@ -163,6 +163,8 @@ QString AudioPath::getStringFromType(AudioPathType type) {
         return QString::fromAscii("Bus");
     case DECK:
         return QString::fromAscii("Deck");
+    case RECORD_BROADCAST:
+        return QString::fromAscii("Record/Broadcast");
     case VINYLCONTROL:
         return QString::fromAscii("Vinyl Control");
     case MICROPHONE:
@@ -205,6 +207,8 @@ QString AudioPath::getTrStringFromType(AudioPathType type, unsigned char index) 
     case DECK:
         return QString("%1 %2").arg(QObject::tr("Deck"),
                                     QString::number(index + 1));
+    case RECORD_BROADCAST:
+        return QObject::tr("Record/Broadcast");
     case VINYLCONTROL:
         return QString("%1 %2").arg(QObject::tr("Vinyl Control"),
                                     QString::number(index + 1));
@@ -446,6 +450,7 @@ QList<AudioPathType> AudioInput::getSupportedTypes() {
 #endif
     types.append(AUXILIARY);
     types.append(MICROPHONE);
+    types.append(RECORD_BROADCAST);
     return types;
 }
 

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -56,8 +56,8 @@ public:
     // (if necessary), etc. -- bkgood
     enum AudioPathType {
         MASTER,
-        BOOTH,
         HEADPHONES,
+        BOOTH,
         BUS,
         DECK,
         RECORD_BROADCAST,

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -60,6 +60,7 @@ public:
         HEADPHONES,
         BUS,
         DECK,
+        RECORD_BROADCAST,
         VINYLCONTROL,
         MICROPHONE,
         AUXILIARY,

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -56,6 +56,7 @@ public:
     // (if necessary), etc. -- bkgood
     enum AudioPathType {
         MASTER,
+        BOOTH,
         HEADPHONES,
         BUS,
         DECK,

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -64,7 +64,6 @@ public:
         VINYLCONTROL,
         MICROPHONE,
         AUXILIARY,
-        SIDECHAIN,
         INVALID, // if this isn't last bad things will happen -bkgood
     };
     AudioPath(unsigned char channelBase, unsigned char channels);

--- a/src/test/enginemastertest.cpp
+++ b/src/test/enginemastertest.cpp
@@ -7,6 +7,7 @@
 #include "engine/enginechannel.h"
 #include "engine/enginemaster.h"
 #include "test/mixxxtest.h"
+#include "test/signalpathtest.h"
 #include "util/defs.h"
 #include "util/sample.h"
 #include "util/types.h"
@@ -40,14 +41,11 @@ class EngineChannelMock : public EngineChannel {
 class EngineMasterTest : public MixxxTest {
   protected:
     void SetUp() override {
-        m_pMaster = new EngineMaster(config(), "[Master]", NULL, false, false);
-        m_pMasterEnabled = new ControlProxy(ConfigKey("[Master]", "enabled"));
-        m_pMasterEnabled->set(1);
+        m_pMaster = new TestEngineMaster(config(), "[Master]", NULL, false, false);
     }
 
     void TearDown() override {
         delete m_pMaster;
-        delete m_pMasterEnabled;
     }
 
     void ClearBuffer(CSAMPLE* pBuffer, int length) {
@@ -71,7 +69,6 @@ class EngineMasterTest : public MixxxTest {
     }
 
     EngineMaster* m_pMaster;
-    ControlProxy* m_pMasterEnabled;
 };
 
 TEST_F(EngineMasterTest, SingleChannelOutputWorks) {

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -40,7 +40,11 @@ class TestEngineMaster : public EngineMaster {
                      bool bEnableSidechain,
                      bool bRampingGain)
         : EngineMaster(_config, group, pEffectsManager,
-                       bEnableSidechain, bRampingGain) { }
+                       bEnableSidechain, bRampingGain) {
+         m_pMasterEnabled->forceSet(1);
+         m_pHeadphoneEnabled->forceSet(1);
+         m_pBoothEnabled->forceSet(1);
+    }
 
     CSAMPLE* masterBuffer() {
         return m_pMaster;


### PR DESCRIPTION
This replaces the option to exclude the microphone inputs from the master output. That was sufficient for broadcasting users, but there was no way to have a master output with the mics and a booth monitor signal
without the mics for live use. Previously that required plugging a mic into an external hardware mixer or a DJ controller with a mic input hard wired to the master output only, but with this PR it is possible to do with Mixxx and any sound card with enough output channels. The broadcasting use case is still supported by connecting the speakers to Mixxx's booth output, which excludes the mics by default. This is more aligned with how hardware mixers work than the unconventional "Master output/Recording and Broadcasting only" option that was not self-explanatory.

As a nice benefit over using a hardware mixer for this, Mixxx's effects could be used on the mic signal, although the effects would be applied to both the master and booth outputs. Perhaps for Aris' GSoC project he could add a special effect unit that applies effects to the mic signals going to the booth output but not the master output. It would be useful to use the graphic EQ effect in that effect unit to prevent a frequency from feeding back without changing the sound of the master output.

If the microphone user(s) want to hear themselves, the mics can optionally be mixed into the booth output. In this case it is just a more convenient way to duplicate the master output with an independent volume control on the sound card without having to split the master output signal at the OS level, with a splitter cable, or with a hardware mixer.