### PR TITLE
Pull database connectivity up from Library into MainWindow

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -59,20 +59,22 @@ const QString Library::m_sTrackViewName = QString("WTrackTableView");
 // The default row height of the library.
 const int Library::kDefaultRowHeightPx = 20;
 
-Library::Library(QObject* parent, UserSettingsPointer pConfig,
-                 PlayerManagerInterface* pPlayerManager,
-                 RecordingManager* pRecordingManager) :
-        m_pConfig(pConfig),
-        m_mixxxDb(pConfig),
-        m_dbConnectionPooler(m_mixxxDb.connectionPool()),
-        m_pSidebarModel(new SidebarModel(parent)),
-        m_pTrackCollection(new TrackCollection(pConfig)),
-        m_pLibraryControl(new LibraryControl(this)),
-        m_pMixxxLibraryFeature(nullptr),
-        m_pPlaylistFeature(nullptr),
-        m_pCrateFeature(nullptr),
-        m_pAnalysisFeature(nullptr),
-        m_scanner(m_mixxxDb.connectionPool(), m_pTrackCollection, pConfig) {
+Library::Library(
+        QObject* parent,
+        UserSettingsPointer pConfig,
+        PlayerManagerInterface* pPlayerManager,
+        RecordingManager* pRecordingManager)
+    : m_pConfig(pConfig),
+      m_mixxxDb(pConfig),
+      m_dbConnectionPooler(m_mixxxDb.connectionPool()),
+      m_pSidebarModel(new SidebarModel(parent)),
+      m_pTrackCollection(new TrackCollection(pConfig)),
+      m_pLibraryControl(new LibraryControl(this)),
+      m_pMixxxLibraryFeature(nullptr),
+      m_pPlaylistFeature(nullptr),
+      m_pCrateFeature(nullptr),
+      m_pAnalysisFeature(nullptr),
+      m_scanner(m_mixxxDb.connectionPool(), m_pTrackCollection, pConfig) {
     kLogger.info() << "Opening datbase connection";
 
     const mixxx::DbConnectionPooled dbConnectionPooled(m_mixxxDb.connectionPool());

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -68,7 +68,6 @@ Library::Library(QObject* parent, UserSettingsPointer pConfig,
         m_pSidebarModel(new SidebarModel(parent)),
         m_pTrackCollection(new TrackCollection(pConfig)),
         m_pLibraryControl(new LibraryControl(this)),
-        m_pRecordingManager(pRecordingManager),
         m_scanner(m_mixxxDb.connectionPool(), m_pTrackCollection, pConfig) {
     kLogger.info() << "Opening datbase connection";
 
@@ -127,7 +126,7 @@ Library::Library(QObject* parent, UserSettingsPointer pConfig,
     m_pCrateFeature = new CrateFeature(this, m_pTrackCollection, m_pConfig);
     addFeature(m_pCrateFeature);
     BrowseFeature* browseFeature = new BrowseFeature(
-        this, pConfig, m_pTrackCollection, m_pRecordingManager);
+        this, pConfig, m_pTrackCollection, pRecordingManager);
     connect(browseFeature, SIGNAL(scanLibrary()),
             &m_scanner, SLOT(scan()));
     connect(&m_scanner, SIGNAL(scanStarted()),
@@ -136,7 +135,7 @@ Library::Library(QObject* parent, UserSettingsPointer pConfig,
             browseFeature, SLOT(slotLibraryScanFinished()));
 
     addFeature(browseFeature);
-    addFeature(new RecordingFeature(this, pConfig, m_pTrackCollection, m_pRecordingManager));
+    addFeature(new RecordingFeature(this, pConfig, m_pTrackCollection, pRecordingManager));
     addFeature(new SetlogFeature(this, pConfig, m_pTrackCollection));
     m_pAnalysisFeature = new AnalysisFeature(this, pConfig, m_pTrackCollection);
     connect(m_pPlaylistFeature, SIGNAL(analyzeTracks(QList<TrackId>)),

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -68,6 +68,10 @@ Library::Library(QObject* parent, UserSettingsPointer pConfig,
         m_pSidebarModel(new SidebarModel(parent)),
         m_pTrackCollection(new TrackCollection(pConfig)),
         m_pLibraryControl(new LibraryControl(this)),
+        m_pMixxxLibraryFeature(nullptr),
+        m_pPlaylistFeature(nullptr),
+        m_pCrateFeature(nullptr),
+        m_pAnalysisFeature(nullptr),
         m_scanner(m_mixxxDb.connectionPool(), m_pTrackCollection, pConfig) {
     kLogger.info() << "Opening datbase connection";
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -62,11 +62,11 @@ const int Library::kDefaultRowHeightPx = 20;
 Library::Library(
         QObject* parent,
         UserSettingsPointer pConfig,
+        mixxx::DbConnectionPoolPtr pDbConnectionPool,
         PlayerManagerInterface* pPlayerManager,
         RecordingManager* pRecordingManager)
     : m_pConfig(pConfig),
-      m_mixxxDb(pConfig),
-      m_dbConnectionPooler(m_mixxxDb.connectionPool()),
+      m_pDbConnectionPool(pDbConnectionPool),
       m_pSidebarModel(new SidebarModel(parent)),
       m_pTrackCollection(new TrackCollection(pConfig)),
       m_pLibraryControl(new LibraryControl(this)),
@@ -74,28 +74,10 @@ Library::Library(
       m_pPlaylistFeature(nullptr),
       m_pCrateFeature(nullptr),
       m_pAnalysisFeature(nullptr),
-      m_scanner(m_mixxxDb.connectionPool(), m_pTrackCollection, pConfig) {
-    kLogger.info() << "Opening datbase connection";
+      m_scanner(pDbConnectionPool, m_pTrackCollection, pConfig) {
 
-    const mixxx::DbConnectionPooled dbConnectionPooled(m_mixxxDb.connectionPool());
-    if (!dbConnectionPooled) {
-        QMessageBox::critical(0, tr("Cannot open database"),
-                            tr("Unable to establish a database connection.\n"
-                                "Mixxx requires QT with SQLite support. Please read "
-                                "the Qt SQL driver documentation for information on how "
-                                "to build it.\n\n"
-                                "Click OK to exit."), QMessageBox::Ok);
-        // TODO(XXX) something a little more elegant
-        exit(-1);
-    }
+    const mixxx::DbConnectionPooled dbConnectionPooled(pDbConnectionPool);
     QSqlDatabase dbConnection(dbConnectionPooled);
-    DEBUG_ASSERT(dbConnection.isOpen());
-
-    kLogger.info() << "Initializing or upgrading database schema";
-    if (!MixxxDb::initDatabaseSchema(dbConnection)) {
-        // TODO(XXX) something a little more elegant
-        exit(-1);
-    }
 
     // TODO(XXX): Add a checkbox in the library preferences for checking
     // and repairing the database on the next restart of the application.

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -76,8 +76,7 @@ Library::Library(
       m_pAnalysisFeature(nullptr),
       m_scanner(pDbConnectionPool, m_pTrackCollection, pConfig) {
 
-    const mixxx::DbConnectionPooled dbConnectionPooled(pDbConnectionPool);
-    QSqlDatabase dbConnection(dbConnectionPooled);
+    QSqlDatabase dbConnection = mixxx::DbConnectionPooled(m_pDbConnectionPool);
 
     // TODO(XXX): Add a checkbox in the library preferences for checking
     // and repairing the database on the next restart of the application.

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -49,7 +49,7 @@ class Library : public QObject {
             UserSettingsPointer pConfig,
             PlayerManagerInterface* pPlayerManager,
             RecordingManager* pRecordingManager);
-    virtual ~Library();
+    ~Library() override;
 
     mixxx::DbConnectionPoolPtr dbConnectionPool() const {
         return m_mixxxDb.connectionPool();

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -135,6 +135,7 @@ class Library : public QObject {
 
     SidebarModel* m_pSidebarModel;
     TrackCollection* m_pTrackCollection;
+    LibraryControl* m_pLibraryControl;
     QList<LibraryFeature*> m_features;
     const static QString m_sTrackViewName;
     const static QString m_sAutoDJViewName;
@@ -142,7 +143,6 @@ class Library : public QObject {
     PlaylistFeature* m_pPlaylistFeature;
     CrateFeature* m_pCrateFeature;
     AnalysisFeature* m_pAnalysisFeature;
-    LibraryControl* m_pLibraryControl;
     LibraryScanner m_scanner;
     QFont m_trackTableFont;
     int m_iTrackTableRowHeight;

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -13,14 +13,13 @@
 #include <QFont>
 
 #include "preferences/usersettings.h"
-#include "database/mixxxdb.h"
 #include "track/track.h"
 #include "recording/recordingmanager.h"
 #include "analysisfeature.h"
 #include "library/coverartcache.h"
 #include "library/setlogfeature.h"
 #include "library/scanner/libraryscanner.h"
-#include "util/db/dbconnectionpooler.h"
+#include "util/db/dbconnectionpool.h"
 
 class TrackModel;
 class TrackCollection;
@@ -47,12 +46,13 @@ class Library : public QObject {
 
     Library(QObject* parent,
             UserSettingsPointer pConfig,
+            mixxx::DbConnectionPoolPtr pDbConnectionPool,
             PlayerManagerInterface* pPlayerManager,
             RecordingManager* pRecordingManager);
     ~Library() override;
 
     mixxx::DbConnectionPoolPtr dbConnectionPool() const {
-        return m_mixxxDb.connectionPool();
+        return m_pDbConnectionPool;
     }
 
     void bindWidget(WLibrary* libraryWidget,
@@ -124,14 +124,8 @@ class Library : public QObject {
   private:
     const UserSettingsPointer m_pConfig;
 
-    // The Mixxx SQLite3 database
-    const MixxxDb m_mixxxDb;
-
-    // The Mixxx database connection for the thread that creates
-    // and owns this library instance. TODO(XXX): Move database
-    // related code out of the GUI into multiple, dedicated
-    // worker threads.
-    const mixxx::DbConnectionPooler m_dbConnectionPooler;
+    // The Mixxx database connection pool
+    const mixxx::DbConnectionPoolPtr m_pDbConnectionPool;
 
     SidebarModel* m_pSidebarModel;
     TrackCollection* m_pTrackCollection;

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -143,7 +143,6 @@ class Library : public QObject {
     CrateFeature* m_pCrateFeature;
     AnalysisFeature* m_pAnalysisFeature;
     LibraryControl* m_pLibraryControl;
-    RecordingManager* m_pRecordingManager;
     LibraryScanner m_scanner;
     QFont m_trackTableFont;
     int m_iTrackTableRowHeight;

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -96,15 +96,13 @@ void LibraryScanner::run() {
         Trace trace("LibraryScanner");
 
         const mixxx::DbConnectionPooler dbConnectionPooler(m_pDbConnectionPool);
-        const mixxx::DbConnectionPooled dbConnectionPooled(m_pDbConnectionPool);
-        if (!dbConnectionPooled) {
+        QSqlDatabase dbConnection = mixxx::DbConnectionPooled(m_pDbConnectionPool);
+        if (!dbConnection.isOpen()) {
             kLogger.warning()
                     << "Failed to open database connection for library scanner";
             kLogger.debug() << "Exiting thread";
             return;
         }
-        QSqlDatabase dbConnection(dbConnectionPooled);
-        DEBUG_ASSERT(dbConnection.isOpen());
 
         m_libraryHashDao.initialize(dbConnection);
         m_cueDao.initialize(dbConnection);
@@ -242,8 +240,7 @@ void LibraryScanner::cleanUpScan() {
 
     // Start a transaction for all the library hashing (moved file
     // detection) stuff.
-    const mixxx::DbConnectionPooled dbConnectionPooled(m_pDbConnectionPool);
-    QSqlDatabase dbConnection(dbConnectionPooled);
+    QSqlDatabase dbConnection = mixxx::DbConnectionPooled(m_pDbConnectionPool);
     ScopedTransaction transaction(dbConnection);
 
     kLogger.debug() << "Marking tracks in changed directories as verified";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,27 @@
 #include <X11/Xlib.h>
 #endif
 
+namespace {
+
+int runMixxx(MixxxApplication* app, const CmdlineArgs& args) {
+    int result = -1;
+    MixxxMainWindow mainWindow(app, args);
+    // If startup produced a fatal error, then don't even start the
+    // Qt event loop.
+    if (ErrorDialogHandler::instance()->checkError()) {
+        mainWindow.finalize();
+    } else {
+        qDebug() << "Displaying main window";
+        mainWindow.show();
+
+        qDebug() << "Running Mixxx";
+        result = app->exec();
+    }
+    return result;
+}
+
+} // anonymous namespace
+
 int main(int argc, char * argv[]) {
     Console console;
 
@@ -69,7 +90,7 @@ int main(int argc, char * argv[]) {
     mixxx::Logging::initialize(args.getSettingsPath(),
                                args.getLogLevel(), args.getDebugAssertBreak());
 
-    MixxxApplication a(argc, argv);
+    MixxxApplication app(argc, argv);
 
     // Support utf-8 for all translation strings. Not supported in Qt 5.
     // TODO(rryan): Is this needed when we switch to qt5? Some sources claim it
@@ -98,26 +119,10 @@ int main(int argc, char * argv[]) {
     }
 #endif
 
-    MixxxMainWindow* mixxx = new MixxxMainWindow(&a, args);
-
     // When the last window is closed, terminate the Qt event loop.
-    QObject::connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));
+    QObject::connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
 
-    int result = -1;
-
-    // If startup produced a fatal error, then don't even start the Qt event
-    // loop.
-    if (ErrorDialogHandler::instance()->checkError()) {
-        mixxx->finalize();
-    } else {
-        qDebug() << "Displaying mixxx";
-        mixxx->show();
-
-        qDebug() << "Running Mixxx";
-        result = a.exec();
-    }
-
-    delete mixxx;
+    int result = runMixxx(&app, args);
 
     qDebug() << "Mixxx shutdown complete with code" << result;
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -662,8 +662,8 @@ void MixxxMainWindow::finalize() {
 
 bool MixxxMainWindow::initializeDatabase() {
     kLogger.info() << "Connecting to database";
-    const mixxx::DbConnectionPooled dbConnectionPooled(m_pDbConnectionPool);
-    if (!dbConnectionPooled) {
+    QSqlDatabase dbConnection = mixxx::DbConnectionPooled(m_pDbConnectionPool);
+    if (!dbConnection.isOpen()) {
         QMessageBox::critical(0, tr("Cannot open database"),
                             tr("Unable to establish a database connection.\n"
                                 "Mixxx requires QT with SQLite support. Please read "
@@ -672,8 +672,6 @@ bool MixxxMainWindow::initializeDatabase() {
                                 "Click OK to exit."), QMessageBox::Ok);
         return false;
     }
-    QSqlDatabase dbConnection(dbConnectionPooled);
-    DEBUG_ASSERT(dbConnection.isOpen());
 
     kLogger.info() << "Initializing or upgrading database schema";
     return MixxxDb::initDatabaseSchema(dbConnection);

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -48,6 +48,7 @@
 #include "track/track.h"
 #include "waveform/waveformwidgetfactory.h"
 #include "waveform/sharedglcontext.h"
+#include "database/mixxxdb.h"
 #include "util/debug.h"
 #include "util/statsmanager.h"
 #include "util/timer.h"
@@ -66,6 +67,8 @@
 #include "preferences/settingsmanager.h"
 #include "widget/wmainmenubar.h"
 #include "util/screensaver.h"
+#include "util/logger.h"
+#include "util/db/dbconnectionpooled.h"
 
 #ifdef __VINYLCONTROL__
 #include "vinylcontrol/vinylcontrolmanager.h"
@@ -74,6 +77,12 @@
 #ifdef __MODPLUG__
 #include "preferences/dialog/dlgprefmodplug.h"
 #endif
+
+namespace {
+
+const mixxx::Logger kLogger("MixxxMainWindow");
+
+} // anonymous namespace
 
 // static
 const int MixxxMainWindow::kMicrophoneCount = 4;
@@ -257,13 +266,29 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
 
     CoverArtCache::create();
 
-    // (long)
-    m_pLibrary = new Library(this, pConfig,
-                             m_pPlayerManager,
-                             m_pRecordingManager);
-    m_pPlayerManager->bindToLibrary(m_pLibrary);
+    m_pDbConnectionPool = MixxxDb(pConfig).connectionPool();
+    if (!m_pDbConnectionPool) {
+        // TODO(XXX) something a little more elegant
+        exit(-1);
+    }
+    // Create a connection for the main thread
+    m_pDbConnectionPool->createThreadLocalConnection();
+    if (!initializeDatabase()) {
+        // TODO(XXX) something a little more elegant
+        exit(-1);
+    }
 
     launchProgress(35);
+
+    m_pLibrary = new Library(
+            this,
+            pConfig,
+            m_pDbConnectionPool,
+            m_pPlayerManager,
+            m_pRecordingManager);
+    m_pPlayerManager->bindToLibrary(m_pLibrary);
+
+    launchProgress(40);
 
     // Get Music dir
     bool hasChanged_MusicDir = false;
@@ -542,6 +567,10 @@ void MixxxMainWindow::finalize() {
     qDebug() << t.elapsed(false).debugMillisWithUnit() << "deleting Library";
     delete m_pLibrary;
 
+    qDebug() << t.elapsed(false).debugMillisWithUnit() << "closing database connection(s)";
+    m_pDbConnectionPool->destroyThreadLocalConnection();
+    m_pDbConnectionPool.reset(); // should drop the last reference
+
     // PlayerManager depends on Engine, SoundManager, VinylControlManager, and Config
     qDebug() << t.elapsed(false).debugMillisWithUnit() << "deleting PlayerManager";
     delete m_pPlayerManager;
@@ -629,6 +658,25 @@ void MixxxMainWindow::finalize() {
     // Report the total time we have been running.
     m_runtime_timer.elapsed(true);
     StatsManager::destroy();
+}
+
+bool MixxxMainWindow::initializeDatabase() {
+    kLogger.info() << "Connecting to database";
+    const mixxx::DbConnectionPooled dbConnectionPooled(m_pDbConnectionPool);
+    if (!dbConnectionPooled) {
+        QMessageBox::critical(0, tr("Cannot open database"),
+                            tr("Unable to establish a database connection.\n"
+                                "Mixxx requires QT with SQLite support. Please read "
+                                "the Qt SQL driver documentation for information on how "
+                                "to build it.\n\n"
+                                "Click OK to exit."), QMessageBox::Ok);
+        return false;
+    }
+    QSqlDatabase dbConnection(dbConnectionPooled);
+    DEBUG_ASSERT(dbConnection.isOpen());
+
+    kLogger.info() << "Initializing or upgrading database schema";
+    return MixxxDb::initDatabaseSchema(dbConnection);
 }
 
 void MixxxMainWindow::initializeWindow() {

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -27,6 +27,7 @@
 #include "track/track.h"
 #include "util/cmdlineargs.h"
 #include "util/timer.h"
+#include "util/db/dbconnectionpool.h"
 #include "soundio/sounddeviceerror.h"
 
 class ControlPushButton;
@@ -57,7 +58,7 @@ class MixxxMainWindow : public QMainWindow {
   public:
     // Construtor. files is a list of command line arguments
     MixxxMainWindow(QApplication *app, const CmdlineArgs& args);
-    virtual ~MixxxMainWindow();
+    ~MixxxMainWindow() override;
 
     void initialize(QApplication *app, const CmdlineArgs& args);
     void finalize();
@@ -114,9 +115,13 @@ class MixxxMainWindow : public QMainWindow {
     // progresses the launch image progress bar
     // this must be called from the GUi thread only
     void launchProgress(int progress);
+
     void initializeWindow();
     void initializeKeyboard();
     void checkDirectRendering();
+
+    bool initializeDatabase();
+
     bool confirmExit();
     QDialog::DialogCode soundDeviceErrorDlg(
             const QString &title, const QString &text, bool* retryClicked);
@@ -158,6 +163,10 @@ class MixxxMainWindow : public QMainWindow {
     VinylControlManager* m_pVCManager;
 
     KeyboardEventFilter* m_pKeyboard;
+
+    // The Mixxx database connection pool
+    mixxx::DbConnectionPoolPtr m_pDbConnectionPool;
+
     // The library management object
     Library* m_pLibrary;
 

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -60,7 +60,6 @@ class MixxxMainWindow : public QMainWindow {
     MixxxMainWindow(QApplication *app, const CmdlineArgs& args);
     ~MixxxMainWindow() override;
 
-    void initialize(QApplication *app, const CmdlineArgs& args);
     void finalize();
 
     // creates the menu_bar and inserts the file Menu
@@ -112,6 +111,8 @@ class MixxxMainWindow : public QMainWindow {
     virtual bool event(QEvent* e);
 
   private:
+    void initialize(QApplication *app, const CmdlineArgs& args);
+
     // progresses the launch image progress bar
     // this must be called from the GUi thread only
     void launchProgress(int progress);

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -220,8 +220,7 @@ void DlgPrefWaveform::slotWaveformMeasured(float frameRate, int droppedFrames) {
 
 void DlgPrefWaveform::slotClearCachedWaveforms() {
     AnalysisDao analysisDao(m_pConfig);
-    const mixxx::DbConnectionPooled dbConnectionPooled(m_pLibrary->dbConnectionPool());
-    QSqlDatabase dbConnection(dbConnectionPooled);
+    QSqlDatabase dbConnection = mixxx::DbConnectionPooled(m_pLibrary->dbConnectionPool());
     analysisDao.deleteAnalysesByType(dbConnection, AnalysisDao::TYPE_WAVEFORM);
     analysisDao.deleteAnalysesByType(dbConnection, AnalysisDao::TYPE_WAVESUMMARY);
     calculateCachedWaveformDiskUsage();
@@ -229,8 +228,7 @@ void DlgPrefWaveform::slotClearCachedWaveforms() {
 
 void DlgPrefWaveform::calculateCachedWaveformDiskUsage() {
     AnalysisDao analysisDao(m_pConfig);
-    const mixxx::DbConnectionPooled dbConnectionPooled(m_pLibrary->dbConnectionPool());
-    QSqlDatabase dbConnection(dbConnectionPooled);
+    QSqlDatabase dbConnection = mixxx::DbConnectionPooled(m_pLibrary->dbConnectionPool());
     size_t numBytes = analysisDao.getDiskUsageInBytes(dbConnection, AnalysisDao::TYPE_WAVEFORM) +
             analysisDao.getDiskUsageInBytes(dbConnection, AnalysisDao::TYPE_WAVESUMMARY);
 

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -367,8 +367,7 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
             const mixxx::DbConnectionPooler dbConnectionPooler(
                     mixxxDb.connectionPool());
             if (dbConnectionPooler) {
-                const mixxx::DbConnectionPooled dbConnectionPooled(mixxxDb.connectionPool());
-                QSqlDatabase dbConnection(dbConnectionPooled);
+                QSqlDatabase dbConnection = mixxx::DbConnectionPooled(mixxxDb.connectionPool());
                 DEBUG_ASSERT(dbConnection.isOpen());
                 if (MixxxDb::initDatabaseSchema(dbConnection)) {
                     TrackCollection tc(config);

--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -14,11 +14,10 @@ class LibraryTest : public MixxxTest {
     LibraryTest()
         : m_mixxxDb(config()),
           m_dbConnectionPooler(m_mixxxDb.connectionPool()),
-          m_dbConnectionPooled(m_mixxxDb.connectionPool()),
+          m_dbConnection(mixxx::DbConnectionPooled(m_mixxxDb.connectionPool())),
           m_trackCollection(config()) {
-        QSqlDatabase dbConnection(m_dbConnectionPooled);
-        MixxxDb::initDatabaseSchema(dbConnection);
-        m_trackCollection.connectDatabase(dbConnection);
+        MixxxDb::initDatabaseSchema(m_dbConnection);
+        m_trackCollection.connectDatabase(m_dbConnection);
     }
     ~LibraryTest() override {
         m_trackCollection.disconnectDatabase();
@@ -29,7 +28,7 @@ class LibraryTest : public MixxxTest {
     }
 
     QSqlDatabase dbConnection() const {
-        return static_cast<QSqlDatabase>(m_dbConnectionPooled);
+        return m_dbConnection;
     }
 
     TrackCollection* collection() {
@@ -39,7 +38,7 @@ class LibraryTest : public MixxxTest {
   private:
     const MixxxDb m_mixxxDb;
     const mixxx::DbConnectionPooler m_dbConnectionPooler;
-    const mixxx::DbConnectionPooled m_dbConnectionPooled;
+    QSqlDatabase m_dbConnection;
     TrackCollection m_trackCollection;
 };
 

--- a/src/test/queryutiltest.cpp
+++ b/src/test/queryutiltest.cpp
@@ -14,8 +14,7 @@ class QueryUtilTest : public MixxxTest {
     QueryUtilTest()
           : m_mixxxDb(config()),
             m_dbConnectionPooler(m_mixxxDb.connectionPool()),
-            m_dbConnectionPooled(m_mixxxDb.connectionPool()),
-            m_dbConnection(m_dbConnectionPooled) {
+            m_dbConnection(mixxx::DbConnectionPooled(m_mixxxDb.connectionPool())) {
         // This test only needs a connection to an empty database
         // without any particular schema. No need to initialize the
         // database schema.
@@ -24,7 +23,6 @@ class QueryUtilTest : public MixxxTest {
   private:
     const MixxxDb m_mixxxDb;
     const mixxx::DbConnectionPooler m_dbConnectionPooler;
-    const mixxx::DbConnectionPooled m_dbConnectionPooled;
 
   protected:
     QSqlDatabase m_dbConnection;

--- a/src/test/schemamanager_test.cpp
+++ b/src/test/schemamanager_test.cpp
@@ -17,20 +17,16 @@ class SchemaManagerTest : public MixxxTest {
     SchemaManagerTest()
             : m_mixxxDb(config()),
               m_dbConnectionPooler(m_mixxxDb.connectionPool()),
-              m_dbConnectionPooled(m_mixxxDb.connectionPool()),
-              m_dbConnection(m_dbConnectionPooled) {
+              m_dbConnection(mixxx::DbConnectionPooled(m_mixxxDb.connectionPool())) {
     }
 
     QSqlDatabase dbConnection() const {
-        return static_cast<QSqlDatabase>(m_dbConnectionPooled);
+        return m_dbConnection;
     }
 
   private:
     const MixxxDb m_mixxxDb;
     const mixxx::DbConnectionPooler m_dbConnectionPooler;
-    const mixxx::DbConnectionPooled m_dbConnectionPooled;
-
-  protected:
     QSqlDatabase m_dbConnection;
 };
 

--- a/src/util/db/dbconnectionpool.h
+++ b/src/util/db/dbconnectionpool.h
@@ -33,13 +33,15 @@ class DbConnectionPool final {
             const DbConnection::Params& params,
             const QString& connectionName);
 
+    // Prefer to use DbConnectionPooler instead of the
+    // following functions. Only if there is no appropriate
+    // scoping possible then use these functions directly.
+    bool createThreadLocalConnection();
+    void destroyThreadLocalConnection();
+
   private:
     DbConnectionPool(const DbConnectionPool&) = delete;
     DbConnectionPool(const DbConnectionPool&&) = delete;
-
-    friend class DbConnectionPooler;
-    bool createThreadLocalConnection();
-    void destroyThreadLocalConnection();
 
     // Returns a database connection for the current thread, that has
     // previously been created by instantiating DbConnectionPooler. The

--- a/src/util/db/dbconnectionpooled.h
+++ b/src/util/db/dbconnectionpooled.h
@@ -29,8 +29,11 @@ class DbConnectionPooled final {
     // connection pool is missing or if the pool does not contain a
     // thread-local connection for this thread (previously created
     // by some DbConnectionPooler). On failure a non-functional default
-    // constructed database commection is returned.
-    explicit operator QSqlDatabase() const;
+    // constructed database connection is returned.
+    //
+    // The returned connections is not bound to this instance:
+    // QSqlDatabase dbConnection = DbConnectionPooled(...);
+    /*implicit*/ operator QSqlDatabase() const;
 
   private:
     DbConnectionPoolPtr m_pDbConnectionPool;


### PR DESCRIPTION
The database belongs to whole the application and not only to the library. And since we're opening a default connection for the main thread that exists until the application is shut down it should explicitly reside in some main application component. The library is just an ordinary client that needs to access the database during its lifetime.

Contains some minor fixes:
* Unused member variable
* Uninitialized pointers
* More documentation and simplified usage of DbConnectionPooled