### PR TITLE
Set text elide mode to left in WTrackTableView

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -44,6 +44,7 @@ WTrackTableView::WTrackTableView(QWidget * parent,
           m_selectionChangedSinceLastGuiTick(true),
           m_loadCachedOnly(false) {
 
+    setTextElideMode(Qt::ElideLeft);
 
     connect(&m_loadTrackMapper, SIGNAL(mapped(QString)),
             this, SLOT(loadSelectionToGroup(QString)));


### PR DESCRIPTION
I think that the location column looks better with elide mode to the left. Maybe the other columns should stay with it set to the right.

![mixxx_elidemode_left](https://user-images.githubusercontent.com/293677/27330029-db1262f0-5585-11e7-97c5-a77846769524.png)