### PR TITLE
reduce memory usage for Echo effect

### DIFF
--- a/src/effects/native/echoeffect.h
+++ b/src/effects/native/echoeffect.h
@@ -14,9 +14,9 @@
 #include "util/samplebuffer.h"
 
 struct EchoGroupState {
-    // 3 seconds max. This supports the full range of 2 beats for tempos down to
-    // 40 BPM.
-    static constexpr int kMaxDelaySeconds = 3;
+    // 2 seconds max. This supports the full range of 2 beats for tempos down to
+    // 60 BPM.
+    static constexpr int kMaxDelaySeconds = 2;
     static constexpr auto kChannelCount = mixxx::kEngineChannelCount;
 
     // TODO: allocate buffers of the appropriate size when the sample rate is configured

--- a/src/effects/native/echoeffect.h
+++ b/src/effects/native/echoeffect.h
@@ -7,6 +7,7 @@
 #include "engine/engine.h"
 #include "engine/effects/engineeffect.h"
 #include "engine/effects/engineeffectparameter.h"
+#include "soundio/soundmanager.h"
 #include "util/class.h"
 #include "util/defs.h"
 #include "util/sample.h"
@@ -18,9 +19,12 @@ struct EchoGroupState {
     static constexpr int kMaxDelaySeconds = 3;
     static constexpr auto kChannelCount = mixxx::kEngineChannelCount;
 
+    // TODO: allocate buffers of the appropriate size when the sample rate is configured
     EchoGroupState()
-            : delay_buf(mixxx::AudioSignal::SampleRate::max() * kMaxDelaySeconds *
-                        kChannelCount) {
+            : delay_buf(kMaxDelaySeconds * kChannelCount *
+                        SoundManager::s_iSupportedSampleRates[
+                            sizeof(SoundManager::s_iSupportedSampleRates) /
+                            sizeof(SoundManager::s_iSupportedSampleRates[0]) - 1]) {
         delay_buf.clear();
         prev_send = 0.0f;
         prev_feedback= 0.0f;

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -52,7 +52,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
             this, SLOT(apiChanged(int)));
 
     sampleRateComboBox->clear();
-    foreach (unsigned int srate, m_pSoundManager->getSampleRates()) {
+    for (unsigned int srate : SoundManager::s_iSupportedSampleRates) {
         if (srate > 0) {
             // no ridiculous sample rate values. prohibiting zero means
             // avoiding a potential div-by-0 error in ::updateLatencies

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -59,6 +59,21 @@ class SoundManager : public QObject {
     SoundManager(UserSettingsPointer pConfig, EngineMaster *_master);
     virtual ~SoundManager();
 
+    // PortAudio sample rate enumeration is very slow on Linux
+    // (ALSA dmix sucks, so we can't blame PortAudio), so use this static
+    // list of supported sample rates.
+
+    // There is no reason Mixxx should support higher sample rates for playback,
+    // even if a user's sound card does. It provides no benefit and is likely to
+    // introduce introduce intermodulation distortion when playing ultrasonic
+    // frequencies. Refer to http://xiph.org/~xiphmont/demo/neil-young.html
+    // for details.
+    constexpr static const unsigned int s_iSupportedSampleRates[3] = {
+        44100,
+        48000,
+        96000
+    };
+
     // Returns a list of all devices we've enumerated that match the provided
     // filterApi, and have at least one output or input channel if the
     // bOutputDevices or bInputDevices are set, respectively.
@@ -81,12 +96,6 @@ class SoundManager : public QObject {
     SoundDevice* getErrorDevice() const;
     QString getErrorDeviceName() const;
     QString getLastErrorMessage(SoundDeviceError err) const;
-
-    // Returns a list of samplerates we will attempt to support for a given API.
-    QList<unsigned int> getSampleRates(QString api) const;
-
-    // Convenience overload for SoundManager::getSampleRates(QString)
-    QList<unsigned int> getSampleRates() const;
 
     // Get a list of host APIs supported by PortAudio.
     QList<QString> getHostAPIList() const;
@@ -150,7 +159,6 @@ class SoundManager : public QObject {
     unsigned int m_jackSampleRate;
 #endif
     QList<SoundDevice*> m_devices;
-    QList<unsigned int> m_samplerates;
     QList<CSAMPLE*> m_inputBuffers;
 
     SoundManagerConfig m_config;

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -216,11 +216,13 @@ void SoundManagerConfig::setForceNetworkClock(bool force) {
  * @returns false if the sample rate is not found in SoundManager's list,
  *          otherwise true
  */
-bool SoundManagerConfig::checkSampleRate(const SoundManager &soundManager) {
-    if (!soundManager.getSampleRates(m_api).contains(m_sampleRate)) {
-        return false;
+bool SoundManagerConfig::checkSampleRate() {
+    for (const unsigned int& rate : SoundManager::s_iSupportedSampleRates) {
+        if (rate == m_sampleRate) {
+            return true;
+        }
     }
-    return true;
+    return false;
 }
 
 unsigned int SoundManagerConfig::getDeckCount() const {
@@ -398,15 +400,15 @@ void SoundManagerConfig::loadDefaults(SoundManager *soundManager, unsigned int f
         }
     }
     if (flags & SoundManagerConfig::OTHER) {
-        QList<unsigned int> sampleRates = soundManager->getSampleRates(m_api);
-        if (sampleRates.contains(defaultSampleRate)) {
-            m_sampleRate = defaultSampleRate;
-        } else if (sampleRates.contains(kFallbackSampleRate)) {
-            m_sampleRate = kFallbackSampleRate;
-        } else if (!sampleRates.isEmpty()) {
-            m_sampleRate = sampleRates.first();
-        } else {
-            qWarning() << "got empty sample rate list from SoundManager, this is a bug";
+        m_sampleRate = defaultSampleRate;
+        bool bDefaultSampleRateIsSupported = false;
+        for (const unsigned int& rate : SoundManager::s_iSupportedSampleRates) {
+            if (rate == defaultSampleRate) {
+                bDefaultSampleRateIsSupported = true;
+                break;
+            }
+        }
+        if (!bDefaultSampleRateIsSupported) {
             m_sampleRate = kFallbackSampleRate;
         }
         m_audioBufferSizeIndex = kDefaultAudioBufferSizeIndex;

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -54,7 +54,7 @@ public:
     bool checkAPI(const SoundManager &soundManager);
     unsigned int getSampleRate() const;
     void setSampleRate(unsigned int sampleRate);
-    bool checkSampleRate(const SoundManager &soundManager);
+    bool checkSampleRate();
 
     // Record the number of decks configured with this setup so they can
     // be created and configured.


### PR DESCRIPTION
The Echo effect refers to this constant to determine the size of the buffers it allocates, resulting in a huge waste of memory when this constant is 192 kHz. When effects maintain state for both the master output and headphones output in PR #1254, this resulted in the Echo effect allocating about 400 MB!

There is no reason Mixxx should support 192 kHz, even if a user's sound card does. It provides no benefit and is likely to introduce introduce intermodulation distortion when playing ultrasonic
frequencies. Refer to http://xiph.org/~xiphmont/demo/neil-young.html for details.