### PR TITLE
Added Two Band Paramtric EQ

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -711,6 +711,7 @@ class MixxxCore(Feature):
                    "effects/native/biquadfullkilleqeffect.cpp",
                    "effects/native/loudnesscontoureffect.cpp",
                    "effects/native/graphiceqeffect.cpp",
+                   "effects/native/parametriceqeffect.cpp",
                    "effects/native/flangereffect.cpp",
                    "effects/native/filtereffect.cpp",
                    "effects/native/moogladder4filtereffect.cpp",

--- a/src/effects/native/nativebackend.cpp
+++ b/src/effects/native/nativebackend.cpp
@@ -10,6 +10,7 @@
 #include "effects/native/threebandbiquadeqeffect.h"
 #include "effects/native/biquadfullkilleqeffect.h"
 #include "effects/native/graphiceqeffect.h"
+#include "effects/native/parametriceqeffect.h"
 #include "effects/native/filtereffect.h"
 #include "effects/native/moogladder4filtereffect.h"
 #ifndef __MACAPPSTORE__
@@ -31,6 +32,7 @@ NativeBackend::NativeBackend(QObject* pParent)
     registerEffect<BiquadFullKillEQEffect>();
     // Compensations EQs
     registerEffect<GraphicEQEffect>();
+    registerEffect<ParametricEQEffect>();
     registerEffect<LoudnessContourEffect>();
     // Fading Effects
     registerEffect<FilterEffect>();

--- a/src/effects/native/parametriceqeffect.cpp
+++ b/src/effects/native/parametriceqeffect.cpp
@@ -41,7 +41,9 @@ EffectManifest ParametricEQEffect::getManifest() {
     lfmQ->setId("q1");
     lfmQ->setName(QObject::tr("Q 1"));
     lfmQ->setDescription(QObject::tr(
-            "Controls the bandwidth of the filter. A lower Q affects a wider band of frequencies, a higher Q affects a narrower band of frequencies."));
+            "Controls the bandwidth of the filter.\n"
+            "A lower Q affects a wider band of frequencies,\n"
+            "a higher Q affects a narrower band of frequencies."));
     lfmQ->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
     lfmQ->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     lfmQ->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
@@ -78,7 +80,9 @@ EffectManifest ParametricEQEffect::getManifest() {
     hfmQ->setId("q2");
     hfmQ->setName(QObject::tr("Q 2"));
     hfmQ->setDescription(QObject::tr(
-            "Controls the bandwidth of the filter. A lower Q affects a wider band of frequencies, a higher Q affects a narrower band of frequencies."));
+            "Controls the bandwidth of the filter.\n"
+            "A lower Q affects a wider band of frequencies,\n"
+            "a higher Q affects a narrower band of frequencies."));
     hfmQ->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
     hfmQ->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     hfmQ->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);

--- a/src/effects/native/parametriceqeffect.cpp
+++ b/src/effects/native/parametriceqeffect.cpp
@@ -21,14 +21,14 @@ EffectManifest ParametricEQEffect::getManifest() {
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr(
-        "An 2-band parametric equalizer based on biquad filters"));
+        "An gentle 2-band parametric equalizer based on biquad filters"));
     manifest.setEffectRampsFromDry(true);
     manifest.setIsMasterEQ(true);
 
     EffectManifestParameter* lfmGain = manifest.addParameter();
     lfmGain->setId("gain1");
     lfmGain->setName(QObject::tr("Gain 1"));
-    lfmGain->setDescription(QObject::tr("Gain for Mid Filter 1"));
+    lfmGain->setDescription(QObject::tr("Gain for Filter 1"));
     lfmGain->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
     lfmGain->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     lfmGain->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
@@ -40,7 +40,8 @@ EffectManifest ParametricEQEffect::getManifest() {
     EffectManifestParameter* lfmQ = manifest.addParameter();
     lfmQ->setId("q1");
     lfmQ->setName(QObject::tr("Q 1"));
-    lfmQ->setDescription(QObject::tr("Q for Mid Filter 1"));
+    lfmQ->setDescription(QObject::tr(
+            "Controls the bandwidth of the filter. A lower Q affects a wider band of frequencies, a higher Q affects a narrower band of frequencies."));
     lfmQ->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
     lfmQ->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     lfmQ->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
@@ -52,7 +53,7 @@ EffectManifest ParametricEQEffect::getManifest() {
     EffectManifestParameter* lfmCenter = manifest.addParameter();
     lfmCenter->setId("center1");
     lfmCenter->setName(QObject::tr("Center 1"));
-    lfmCenter->setDescription(QObject::tr("Center frequency for Mid Filter 1 in Hz"));
+    lfmCenter->setDescription(QObject::tr("Center frequency for Filter 1 in Hz"));
     lfmCenter->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
     lfmCenter->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     lfmCenter->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
@@ -64,7 +65,7 @@ EffectManifest ParametricEQEffect::getManifest() {
     EffectManifestParameter* hfmGain = manifest.addParameter();
     hfmGain->setId("gain2");
     hfmGain->setName(QObject::tr("Gain 2"));
-    hfmGain->setDescription(QObject::tr("Gain for Mid Filter 2"));
+    hfmGain->setDescription(QObject::tr("Gain for Filter 2"));
     hfmGain->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
     hfmGain->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     hfmGain->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
@@ -76,7 +77,8 @@ EffectManifest ParametricEQEffect::getManifest() {
     EffectManifestParameter* hfmQ = manifest.addParameter();
     hfmQ->setId("q2");
     hfmQ->setName(QObject::tr("Q 2"));
-    hfmQ->setDescription(QObject::tr("Q for Mid Filter 2"));
+    hfmQ->setDescription(QObject::tr(
+            "Controls the bandwidth of the filter. A lower Q affects a wider band of frequencies, a higher Q affects a narrower band of frequencies."));
     hfmQ->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
     hfmQ->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     hfmQ->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
@@ -88,7 +90,7 @@ EffectManifest ParametricEQEffect::getManifest() {
     EffectManifestParameter* hfmCenter = manifest.addParameter();
     hfmCenter->setId("center2");
     hfmCenter->setName(QObject::tr("Center 2"));
-    hfmCenter->setDescription(QObject::tr("Center frequency for Mid Filter 2 in Hz"));
+    hfmCenter->setDescription(QObject::tr("Center frequency for Filter 2 in Hz"));
     hfmCenter->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
     hfmCenter->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     hfmCenter->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);

--- a/src/effects/native/parametriceqeffect.cpp
+++ b/src/effects/native/parametriceqeffect.cpp
@@ -24,9 +24,9 @@ EffectManifest ParametricEQEffect::getManifest() {
     manifest.setIsMasterEQ(true);
 
     EffectManifestParameter* lfmGain = manifest.addParameter();
-    lfmGain->setId("lmfGain");
-    lfmGain->setName(QString("LMF Gain"));
-    lfmGain->setDescription(QObject::tr("Gain for Low Mid Filter"));
+    lfmGain->setId("gain1");
+    lfmGain->setName(QObject::tr("Gain 1"));
+    lfmGain->setDescription(QObject::tr("Gain for Mid Filter 1"));
     lfmGain->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
     lfmGain->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     lfmGain->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
@@ -36,9 +36,9 @@ EffectManifest ParametricEQEffect::getManifest() {
     lfmGain->setMaximum(18);
 
     EffectManifestParameter* lfmQ = manifest.addParameter();
-    lfmQ->setId("lmfQ");
-    lfmQ->setName(QString("LMF Q"));
-    lfmQ->setDescription(QObject::tr("Q for Low Mid Filter"));
+    lfmQ->setId("q1");
+    lfmQ->setName(QObject::tr("Q 1"));
+    lfmQ->setDescription(QObject::tr("Q for Mid Filter 1"));
     lfmQ->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
     lfmQ->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     lfmQ->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
@@ -48,21 +48,21 @@ EffectManifest ParametricEQEffect::getManifest() {
     lfmQ->setMaximum(3.0);
 
     EffectManifestParameter* lfmCenter = manifest.addParameter();
-    lfmCenter->setId("lmfCenter");
-    lfmCenter->setName(QString("LMF Center"));
-    lfmCenter->setDescription(QObject::tr("Center frequency for Low Mid Filter"));
+    lfmCenter->setId("center1");
+    lfmCenter->setName(QObject::tr("Center 1"));
+    lfmCenter->setDescription(QObject::tr("Center frequency for Mid Filter 1 in Hz"));
     lfmCenter->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
     lfmCenter->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     lfmCenter->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
     lfmCenter->setNeutralPointOnScale(0.5);
-    lfmCenter->setDefault(550);
+    lfmCenter->setDefault(1000); // 1kHz
     lfmCenter->setMinimum(100);
-    lfmCenter->setMaximum(5000);
+    lfmCenter->setMaximum(14000);
 
     EffectManifestParameter* hfmGain = manifest.addParameter();
-    hfmGain->setId("hmfGain");
-    hfmGain->setName(QString("HMF Gain"));
-    hfmGain->setDescription(QObject::tr("Gain for High Mid Filter"));
+    hfmGain->setId("gain2");
+    hfmGain->setName(QObject::tr("Gain 2"));
+    hfmGain->setDescription(QObject::tr("Gain for Mid Filter 2"));
     hfmGain->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
     hfmGain->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     hfmGain->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
@@ -72,9 +72,9 @@ EffectManifest ParametricEQEffect::getManifest() {
     hfmGain->setMaximum(18);
 
     EffectManifestParameter* hfmQ = manifest.addParameter();
-    hfmQ->setId("hmfQ");
-    hfmQ->setName(QString("HMF Q"));
-    hfmQ->setDescription(QObject::tr("Q for High Mid Filter"));
+    hfmQ->setId("q2");
+    hfmQ->setName(QObject::tr("Q 2"));
+    hfmQ->setDescription(QObject::tr("Q for Mid Filter 2"));
     hfmQ->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
     hfmQ->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     hfmQ->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
@@ -84,15 +84,15 @@ EffectManifest ParametricEQEffect::getManifest() {
     hfmQ->setMaximum(3.0);
 
     EffectManifestParameter* hfmCenter = manifest.addParameter();
-    hfmCenter->setId("hmfCenter");
-    hfmCenter->setName(QString("LMF Center"));
-    hfmCenter->setDescription(QObject::tr("Center frequency for Low Mid Filter"));
+    hfmCenter->setId("center2");
+    hfmCenter->setName(QObject::tr("Center 2"));
+    hfmCenter->setDescription(QObject::tr("Center frequency for Mid Filter 2 in Hz"));
     hfmCenter->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
     hfmCenter->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     hfmCenter->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
     hfmCenter->setNeutralPointOnScale(0.5);
-    hfmCenter->setDefault(2600);
-    hfmCenter->setMinimum(1500);
+    hfmCenter->setDefault(3000); // 3 kHz
+    hfmCenter->setMinimum(100);
     hfmCenter->setMaximum(14000);
 
     return manifest;
@@ -125,12 +125,12 @@ ParametricEQEffect::ParametricEQEffect(EngineEffect* pEffect,
                                  const EffectManifest& manifest)
         : m_oldSampleRate(44100) {
     Q_UNUSED(manifest);
-    m_pPotGain.append(pEffect->getParameterById("lmfGain"));
-    m_pPotQ.append(pEffect->getParameterById("lmfQ"));
-    m_pPotCenter.append(pEffect->getParameterById("lmfCenter"));
-    m_pPotGain.append(pEffect->getParameterById("hmfGain"));
-    m_pPotQ.append(pEffect->getParameterById("hmfQ"));
-    m_pPotCenter.append(pEffect->getParameterById("hmfCenter"));
+    m_pPotGain.append(pEffect->getParameterById("gain1"));
+    m_pPotQ.append(pEffect->getParameterById("q1"));
+    m_pPotCenter.append(pEffect->getParameterById("center1"));
+    m_pPotGain.append(pEffect->getParameterById("gain2"));
+    m_pPotQ.append(pEffect->getParameterById("q2"));
+    m_pPotCenter.append(pEffect->getParameterById("center2"));
 }
 
 ParametricEQEffect::~ParametricEQEffect() {

--- a/src/effects/native/parametriceqeffect.cpp
+++ b/src/effects/native/parametriceqeffect.cpp
@@ -109,14 +109,8 @@ ParametricEQEffectGroupState::ParametricEQEffectGroupState() {
 
     // Initialize the filters with default parameters
     for (int i = 0; i < kBandCount; i++) {
-        m_bands.append(new EngineFilterBiquad1Peaking(
+        m_bands.push_back(std::make_unique<EngineFilterBiquad1Peaking>(
                 44100, m_oldCenter[i], m_oldQ[i]));
-    }
-}
-
-ParametricEQEffectGroupState::~ParametricEQEffectGroupState() {
-    foreach (EngineFilterBiquad1Peaking* filter, m_bands) {
-        delete filter;
     }
 }
 

--- a/src/effects/native/parametriceqeffect.cpp
+++ b/src/effects/native/parametriceqeffect.cpp
@@ -1,0 +1,220 @@
+#include "effects/native/parametriceqeffect.h"
+#include "util/math.h"
+
+namespace {
+    int kBandCount = 2;
+}
+
+// static
+QString ParametricEQEffect::getId() {
+    return "org.mixxx.effects.parametriceq";
+}
+
+// static
+EffectManifest ParametricEQEffect::getManifest() {
+    EffectManifest manifest;
+    manifest.setId(getId());
+    manifest.setName(QObject::tr("Parametric Equalizer"));
+    manifest.setShortName(QObject::tr("Param EQ"));
+    manifest.setAuthor("The Mixxx Team");
+    manifest.setVersion("1.0");
+    manifest.setDescription(QObject::tr(
+        "An 2-band parametric equalizer based on biquad filters"));
+    manifest.setEffectRampsFromDry(true);
+    manifest.setIsMasterEQ(true);
+
+    EffectManifestParameter* lfmGain = manifest.addParameter();
+    lfmGain->setId("lmfGain");
+    lfmGain->setName(QString("LMF Gain"));
+    lfmGain->setDescription(QObject::tr("Gain for Low Mid Filter"));
+    lfmGain->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
+    lfmGain->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    lfmGain->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
+    lfmGain->setNeutralPointOnScale(0.5);
+    lfmGain->setDefault(0);
+    lfmGain->setMinimum(-18);
+    lfmGain->setMaximum(18);
+
+    EffectManifestParameter* lfmQ = manifest.addParameter();
+    lfmQ->setId("lmfQ");
+    lfmQ->setName(QString("LMF Q"));
+    lfmQ->setDescription(QObject::tr("Q for Low Mid Filter"));
+    lfmQ->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
+    lfmQ->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    lfmQ->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
+    lfmQ->setNeutralPointOnScale(0.5);
+    lfmQ->setDefault(1.75);
+    lfmQ->setMinimum(0.5);
+    lfmQ->setMaximum(3.0);
+
+    EffectManifestParameter* lfmCenter = manifest.addParameter();
+    lfmCenter->setId("lmfCenter");
+    lfmCenter->setName(QString("LMF Center"));
+    lfmCenter->setDescription(QObject::tr("Center frequency for Low Mid Filter"));
+    lfmCenter->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
+    lfmCenter->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    lfmCenter->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
+    lfmCenter->setNeutralPointOnScale(0.5);
+    lfmCenter->setDefault(550);
+    lfmCenter->setMinimum(100);
+    lfmCenter->setMaximum(5000);
+
+    EffectManifestParameter* hfmGain = manifest.addParameter();
+    hfmGain->setId("hmfGain");
+    hfmGain->setName(QString("HMF Gain"));
+    hfmGain->setDescription(QObject::tr("Gain for High Mid Filter"));
+    hfmGain->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
+    hfmGain->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    hfmGain->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
+    hfmGain->setNeutralPointOnScale(0.5);
+    hfmGain->setDefault(0);
+    hfmGain->setMinimum(-18);
+    hfmGain->setMaximum(18);
+
+    EffectManifestParameter* hfmQ = manifest.addParameter();
+    hfmQ->setId("hmfQ");
+    hfmQ->setName(QString("HMF Q"));
+    hfmQ->setDescription(QObject::tr("Q for High Mid Filter"));
+    hfmQ->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
+    hfmQ->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    hfmQ->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
+    hfmQ->setNeutralPointOnScale(0.5);
+    hfmQ->setDefault(1.75);
+    hfmQ->setMinimum(0.5);
+    hfmQ->setMaximum(3.0);
+
+    EffectManifestParameter* hfmCenter = manifest.addParameter();
+    hfmCenter->setId("hmfCenter");
+    hfmCenter->setName(QString("LMF Center"));
+    hfmCenter->setDescription(QObject::tr("Center frequency for Low Mid Filter"));
+    hfmCenter->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
+    hfmCenter->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    hfmCenter->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
+    hfmCenter->setNeutralPointOnScale(0.5);
+    hfmCenter->setDefault(2600);
+    hfmCenter->setMinimum(1500);
+    hfmCenter->setMaximum(14000);
+
+    return manifest;
+}
+
+ParametricEQEffectGroupState::ParametricEQEffectGroupState() {
+    for (int i = 0; i < kBandCount; i++) {
+        m_oldGain.append(1.0);
+        m_oldQ.append(1.75);
+    }
+
+    m_oldCenter.append(550);
+    m_oldCenter.append(2600);
+
+    // Initialize the filters with default parameters
+    for (int i = 0; i < kBandCount; i++) {
+        m_bands.append(new EngineFilterBiquad1Peaking(
+                44100, m_oldCenter[i], m_oldQ[i]));
+    }
+}
+
+ParametricEQEffectGroupState::~ParametricEQEffectGroupState() {
+    foreach (EngineFilterBiquad1Peaking* filter, m_bands) {
+        delete filter;
+    }
+}
+
+void ParametricEQEffectGroupState::setFilters(int sampleRate) {
+    for (int i = 0; i < kBandCount; i++) {
+        m_bands[i]->setFrequencyCorners(
+                sampleRate, m_oldCenter[i], m_oldQ[i], m_oldGain[i]);
+    }
+}
+
+ParametricEQEffect::ParametricEQEffect(EngineEffect* pEffect,
+                                 const EffectManifest& manifest)
+        : m_oldSampleRate(44100) {
+    Q_UNUSED(manifest);
+    m_pPotGain.append(pEffect->getParameterById("lmfGain"));
+    m_pPotQ.append(pEffect->getParameterById("lmfQ"));
+    m_pPotCenter.append(pEffect->getParameterById("lmfCenter"));
+    m_pPotGain.append(pEffect->getParameterById("hmfGain"));
+    m_pPotQ.append(pEffect->getParameterById("hmfQ"));
+    m_pPotCenter.append(pEffect->getParameterById("hmfCenter"));
+}
+
+ParametricEQEffect::~ParametricEQEffect() {
+}
+
+void ParametricEQEffect::processChannel(const ChannelHandle& handle,
+                                     ParametricEQEffectGroupState* pState,
+                                     const CSAMPLE* pInput, CSAMPLE* pOutput,
+                                     const unsigned int numSamples,
+                                     const unsigned int sampleRate,
+                                     const EffectProcessor::EnableState enableState,
+                                     const GroupFeatureState& groupFeatures) {
+    Q_UNUSED(handle);
+    Q_UNUSED(groupFeatures);
+
+    // If the sample rate has changed, initialize the filters using the new
+    // sample rate
+    if (m_oldSampleRate != sampleRate) {
+        m_oldSampleRate = sampleRate;
+        pState->setFilters(sampleRate);
+    }
+
+    CSAMPLE_GAIN fGain[2];
+    CSAMPLE_GAIN fQ[2];
+    CSAMPLE_GAIN fCenter[2];
+
+    if (enableState == EffectProcessor::DISABLING) {
+         // Ramp to dry, when disabling, this will ramp from dry when enabling as well
+        for (int i = 0; i < kBandCount; i++) {
+            fGain[i] = 1.0;
+        }
+    } else {
+        for (int i = 0; i < kBandCount; i++) {
+            fGain[i] = m_pPotGain[i]->value();
+        }
+    }
+
+    for (int i = 0; i < kBandCount; i++) {
+        fGain[i] = m_pPotGain[i]->value();
+        fQ[i] = m_pPotQ[i]->value();
+        fCenter[i] = m_pPotCenter[i]->value();
+    }
+
+    for (int i = 0; i < kBandCount; i++) {
+        if (fGain[i] != pState->m_oldGain[i] ||
+                fQ[i] != pState->m_oldQ[i] ||
+                fCenter[i] != pState->m_oldCenter[i]) {
+            pState->m_bands[i]->setFrequencyCorners(
+                    sampleRate, fCenter[i], fQ[i], fGain[i]);
+        }
+    }
+
+    if (fGain[0]) {
+        pState->m_bands[0]->process(pInput, pOutput, numSamples);
+        if (fGain[1]) {
+            pState->m_bands[1]->process(pOutput, pOutput, numSamples);
+        } else {
+            pState->m_bands[1]->pauseFilter();
+        }
+    } else {
+        pState->m_bands[0]->pauseFilter();
+        if (fGain[1]) {
+            pState->m_bands[1]->process(pInput, pOutput, numSamples);
+        } else {
+            pState->m_bands[1]->pauseFilter();
+            SampleUtil::copy(pOutput, pInput, numSamples);
+        }
+    }
+
+    for (int i = 0; i < kBandCount; i++) {
+        pState->m_oldGain[i] = fGain[i];
+        pState->m_oldQ[i] = fQ[i];
+        pState->m_oldCenter[i] = fCenter[i];
+    }
+
+    if (enableState == EffectProcessor::DISABLING) {
+        for (int i = 0; i < kBandCount; i++) {
+            pState->m_bands[i]->pauseFilter();
+        }
+    }
+}

--- a/src/effects/native/parametriceqeffect.cpp
+++ b/src/effects/native/parametriceqeffect.cpp
@@ -2,9 +2,9 @@
 #include "util/math.h"
 
 namespace {
-    int kBandCount = 2;
-    double kDefaultCenter1 = 1000; // 1 kHz
-    double kDefaultCenter2 = 3000; // 3 kHz
+    constexpr int kBandCount = 2;
+    constexpr double kDefaultCenter1 = 1000; // 1 kHz
+    constexpr double kDefaultCenter2 = 3000; // 3 kHz
 }
 
 // static
@@ -159,24 +159,15 @@ void ParametricEQEffect::processChannel(const ChannelHandle& handle,
     CSAMPLE_GAIN fQ[2];
     CSAMPLE_GAIN fCenter[2];
 
-    if (enableState == EffectProcessor::DISABLING) {
-         // Ramp to dry, when disabling, this will ramp from dry when enabling as well
-        for (int i = 0; i < kBandCount; i++) {
+    for (int i = 0; i < kBandCount; i++) {
+        if (enableState == EffectProcessor::DISABLING) {
+            // Ramp to dry, when disabling, this will ramp from dry when enabling as well
             fGain[i] = 1.0;
-        }
-    } else {
-        for (int i = 0; i < kBandCount; i++) {
+        } else {
             fGain[i] = m_pPotGain[i]->value();
         }
-    }
-
-    for (int i = 0; i < kBandCount; i++) {
-        fGain[i] = m_pPotGain[i]->value();
         fQ[i] = m_pPotQ[i]->value();
         fCenter[i] = m_pPotCenter[i]->value();
-    }
-
-    for (int i = 0; i < kBandCount; i++) {
         if (fGain[i] != pState->m_oldGain[i] ||
                 fQ[i] != pState->m_oldQ[i] ||
                 fCenter[i] != pState->m_oldCenter[i]) {

--- a/src/effects/native/parametriceqeffect.cpp
+++ b/src/effects/native/parametriceqeffect.cpp
@@ -21,7 +21,9 @@ EffectManifest ParametricEQEffect::getManifest() {
     manifest.setAuthor("The Mixxx Team");
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr(
-        "An gentle 2-band parametric equalizer based on biquad filters"));
+        "An gentle 2-band parametric equalizer based on biquad filters.\n"
+        "It is designed as a complement to the steep mixing EQs in the Effect rack\n"
+        "to improve the sound of the track."));
     manifest.setEffectRampsFromDry(true);
     manifest.setIsMasterEQ(true);
 

--- a/src/effects/native/parametriceqeffect.cpp
+++ b/src/effects/native/parametriceqeffect.cpp
@@ -22,88 +22,87 @@ EffectManifest ParametricEQEffect::getManifest() {
     manifest.setVersion("1.0");
     manifest.setDescription(QObject::tr(
         "An gentle 2-band parametric equalizer based on biquad filters.\n"
-        "It is designed as a complement to the steep mixing EQs in the Effect rack\n"
-        "to improve the sound of the track."));
+        "It is designed as a complement to the steep mixing equalizers."));
     manifest.setEffectRampsFromDry(true);
     manifest.setIsMasterEQ(true);
 
-    EffectManifestParameter* lfmGain = manifest.addParameter();
-    lfmGain->setId("gain1");
-    lfmGain->setName(QObject::tr("Gain 1"));
-    lfmGain->setDescription(QObject::tr("Gain for Filter 1"));
-    lfmGain->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
-    lfmGain->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
-    lfmGain->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
-    lfmGain->setNeutralPointOnScale(0.5);
-    lfmGain->setDefault(0);
-    lfmGain->setMinimum(-18);
-    lfmGain->setMaximum(18); // dB
+    EffectManifestParameter* gain1 = manifest.addParameter();
+    gain1->setId("gain1");
+    gain1->setName(QObject::tr("Gain 1"));
+    gain1->setDescription(QObject::tr("Gain for Filter 1"));
+    gain1->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
+    gain1->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    gain1->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
+    gain1->setNeutralPointOnScale(0.5);
+    gain1->setDefault(0);
+    gain1->setMinimum(-18);
+    gain1->setMaximum(18); // dB
 
-    EffectManifestParameter* lfmQ = manifest.addParameter();
-    lfmQ->setId("q1");
-    lfmQ->setName(QObject::tr("Q 1"));
-    lfmQ->setDescription(QObject::tr(
-            "Controls the bandwidth of the filter.\n"
+    EffectManifestParameter* q1 = manifest.addParameter();
+    q1->setId("q1");
+    q1->setName(QObject::tr("Q 1"));
+    q1->setDescription(QObject::tr(
+            "Controls the bandwidth of Filter 1.\n"
             "A lower Q affects a wider band of frequencies,\n"
             "a higher Q affects a narrower band of frequencies."));
-    lfmQ->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
-    lfmQ->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
-    lfmQ->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
-    lfmQ->setNeutralPointOnScale(0.5);
-    lfmQ->setDefault(1.75);
-    lfmQ->setMinimum(0.5);
-    lfmQ->setMaximum(3.0);
+    q1->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
+    q1->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    q1->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
+    q1->setNeutralPointOnScale(0.5);
+    q1->setDefault(1.75);
+    q1->setMinimum(0.5);
+    q1->setMaximum(3.0);
 
-    EffectManifestParameter* lfmCenter = manifest.addParameter();
-    lfmCenter->setId("center1");
-    lfmCenter->setName(QObject::tr("Center 1"));
-    lfmCenter->setDescription(QObject::tr("Center frequency for Filter 1, from 100 Hz to 14 kHz"));
-    lfmCenter->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
-    lfmCenter->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
-    lfmCenter->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
-    lfmCenter->setNeutralPointOnScale(0.5);
-    lfmCenter->setDefault(kDefaultCenter1);
-    lfmCenter->setMinimum(100); // 100 Hz
-    lfmCenter->setMaximum(14000); // 14 kHz
+    EffectManifestParameter* center1 = manifest.addParameter();
+    center1->setId("center1");
+    center1->setName(QObject::tr("Center 1"));
+    center1->setDescription(QObject::tr("Center frequency for Filter 1, from 100 Hz to 14 kHz"));
+    center1->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
+    center1->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    center1->setUnitsHint(EffectManifestParameter::UnitsHint::HERTZ);
+    center1->setNeutralPointOnScale(0.5);
+    center1->setDefault(kDefaultCenter1);
+    center1->setMinimum(100);
+    center1->setMaximum(14000);
 
-    EffectManifestParameter* hfmGain = manifest.addParameter();
-    hfmGain->setId("gain2");
-    hfmGain->setName(QObject::tr("Gain 2"));
-    hfmGain->setDescription(QObject::tr("Gain for Filter 2"));
-    hfmGain->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
-    hfmGain->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
-    hfmGain->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
-    hfmGain->setNeutralPointOnScale(0.5);
-    hfmGain->setDefault(0);
-    hfmGain->setMinimum(-18);
-    hfmGain->setMaximum(18); // dB
+    EffectManifestParameter* gain2 = manifest.addParameter();
+    gain2->setId("gain2");
+    gain2->setName(QObject::tr("Gain 2"));
+    gain2->setDescription(QObject::tr("Gain for Filter 2"));
+    gain2->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
+    gain2->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    gain2->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
+    gain2->setNeutralPointOnScale(0.5);
+    gain2->setDefault(0);
+    gain2->setMinimum(-18);
+    gain2->setMaximum(18); // dB
 
-    EffectManifestParameter* hfmQ = manifest.addParameter();
-    hfmQ->setId("q2");
-    hfmQ->setName(QObject::tr("Q 2"));
-    hfmQ->setDescription(QObject::tr(
-            "Controls the bandwidth of the filter.\n"
+    EffectManifestParameter* q2 = manifest.addParameter();
+    q2->setId("q2");
+    q2->setName(QObject::tr("Q 2"));
+    q2->setDescription(QObject::tr(
+            "Controls the bandwidth of Filter 2.\n"
             "A lower Q affects a wider band of frequencies,\n"
             "a higher Q affects a narrower band of frequencies."));
-    hfmQ->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
-    hfmQ->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
-    hfmQ->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
-    hfmQ->setNeutralPointOnScale(0.5);
-    hfmQ->setDefault(1.75);
-    hfmQ->setMinimum(0.5);
-    hfmQ->setMaximum(3.0);
+    q2->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
+    q2->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    q2->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
+    q2->setNeutralPointOnScale(0.5);
+    q2->setDefault(1.75);
+    q2->setMinimum(0.5);
+    q2->setMaximum(3.0);
 
-    EffectManifestParameter* hfmCenter = manifest.addParameter();
-    hfmCenter->setId("center2");
-    hfmCenter->setName(QObject::tr("Center 2"));
-    hfmCenter->setDescription(QObject::tr("Center frequency for Filter 2, from 100 Hz to 14 kHz"));
-    hfmCenter->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
-    hfmCenter->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
-    hfmCenter->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
-    hfmCenter->setNeutralPointOnScale(0.5);
-    hfmCenter->setDefault(kDefaultCenter2);
-    hfmCenter->setMinimum(100); // 1kHz
-    hfmCenter->setMaximum(14000); // 1kHz
+    EffectManifestParameter* center2 = manifest.addParameter();
+    center2->setId("center2");
+    center2->setName(QObject::tr("Center 2"));
+    center2->setDescription(QObject::tr("Center frequency for Filter 2, from 100 Hz to 14 kHz"));
+    center2->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
+    center2->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
+    center2->setUnitsHint(EffectManifestParameter::UnitsHint::HERTZ);
+    center2->setNeutralPointOnScale(0.5);
+    center2->setDefault(kDefaultCenter2);
+    center2->setMinimum(100);
+    center2->setMaximum(14000);
 
     return manifest;
 }

--- a/src/effects/native/parametriceqeffect.cpp
+++ b/src/effects/native/parametriceqeffect.cpp
@@ -53,14 +53,14 @@ EffectManifest ParametricEQEffect::getManifest() {
     EffectManifestParameter* lfmCenter = manifest.addParameter();
     lfmCenter->setId("center1");
     lfmCenter->setName(QObject::tr("Center 1"));
-    lfmCenter->setDescription(QObject::tr("Center frequency for Filter 1 in Hz"));
+    lfmCenter->setDescription(QObject::tr("Center frequency for Filter 1, from 100 Hz to 14 kHz"));
     lfmCenter->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
     lfmCenter->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     lfmCenter->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
     lfmCenter->setNeutralPointOnScale(0.5);
     lfmCenter->setDefault(kDefaultCenter1);
-    lfmCenter->setMinimum(100); // 1kHz
-    lfmCenter->setMaximum(14000); // 1kHz
+    lfmCenter->setMinimum(100); // 100 Hz
+    lfmCenter->setMaximum(14000); // 14 kHz
 
     EffectManifestParameter* hfmGain = manifest.addParameter();
     hfmGain->setId("gain2");
@@ -90,7 +90,7 @@ EffectManifest ParametricEQEffect::getManifest() {
     EffectManifestParameter* hfmCenter = manifest.addParameter();
     hfmCenter->setId("center2");
     hfmCenter->setName(QObject::tr("Center 2"));
-    hfmCenter->setDescription(QObject::tr("Center frequency for Filter 2 in Hz"));
+    hfmCenter->setDescription(QObject::tr("Center frequency for Filter 2, from 100 Hz to 14 kHz"));
     hfmCenter->setControlHint(EffectManifestParameter::ControlHint::KNOB_LOGARITHMIC);
     hfmCenter->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     hfmCenter->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);

--- a/src/effects/native/parametriceqeffect.cpp
+++ b/src/effects/native/parametriceqeffect.cpp
@@ -3,6 +3,8 @@
 
 namespace {
     int kBandCount = 2;
+    double kDefaultCenter1 = 1000; // 1 kHz
+    double kDefaultCenter2 = 3000; // 3 kHz
 }
 
 // static
@@ -33,7 +35,7 @@ EffectManifest ParametricEQEffect::getManifest() {
     lfmGain->setNeutralPointOnScale(0.5);
     lfmGain->setDefault(0);
     lfmGain->setMinimum(-18);
-    lfmGain->setMaximum(18);
+    lfmGain->setMaximum(18); // dB
 
     EffectManifestParameter* lfmQ = manifest.addParameter();
     lfmQ->setId("q1");
@@ -55,9 +57,9 @@ EffectManifest ParametricEQEffect::getManifest() {
     lfmCenter->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     lfmCenter->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
     lfmCenter->setNeutralPointOnScale(0.5);
-    lfmCenter->setDefault(1000); // 1kHz
-    lfmCenter->setMinimum(100);
-    lfmCenter->setMaximum(14000);
+    lfmCenter->setDefault(kDefaultCenter1);
+    lfmCenter->setMinimum(100); // 1kHz
+    lfmCenter->setMaximum(14000); // 1kHz
 
     EffectManifestParameter* hfmGain = manifest.addParameter();
     hfmGain->setId("gain2");
@@ -69,7 +71,7 @@ EffectManifest ParametricEQEffect::getManifest() {
     hfmGain->setNeutralPointOnScale(0.5);
     hfmGain->setDefault(0);
     hfmGain->setMinimum(-18);
-    hfmGain->setMaximum(18);
+    hfmGain->setMaximum(18); // dB
 
     EffectManifestParameter* hfmQ = manifest.addParameter();
     hfmQ->setId("q2");
@@ -91,9 +93,9 @@ EffectManifest ParametricEQEffect::getManifest() {
     hfmCenter->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     hfmCenter->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
     hfmCenter->setNeutralPointOnScale(0.5);
-    hfmCenter->setDefault(3000); // 3 kHz
-    hfmCenter->setMinimum(100);
-    hfmCenter->setMaximum(14000);
+    hfmCenter->setDefault(kDefaultCenter2);
+    hfmCenter->setMinimum(100); // 1kHz
+    hfmCenter->setMaximum(14000); // 1kHz
 
     return manifest;
 }
@@ -104,8 +106,8 @@ ParametricEQEffectGroupState::ParametricEQEffectGroupState() {
         m_oldQ.append(1.75);
     }
 
-    m_oldCenter.append(550);
-    m_oldCenter.append(2600);
+    m_oldCenter.append(kDefaultCenter1);
+    m_oldCenter.append(kDefaultCenter2);
 
     // Initialize the filters with default parameters
     for (int i = 0; i < kBandCount; i++) {

--- a/src/effects/native/parametriceqeffect.h
+++ b/src/effects/native/parametriceqeffect.h
@@ -16,7 +16,7 @@
 #include "util/types.h"
 #include "util/memory.h"
 
-// The ParamtricEQEffect models the mid bands from a SSL Black EQ (242)
+// The ParametricEQEffect models the mid bands from a SSL Black EQ (242)
 // with a gentle parameter range, as requested here:
 // https://www.mixxx.org/forums/viewtopic.php?f=3&t=9239&p=33312&hilit=SSL#p33312
 // The main use case is to tweak the room or recording sound, which is hard to achieve

--- a/src/effects/native/parametriceqeffect.h
+++ b/src/effects/native/parametriceqeffect.h
@@ -16,6 +16,12 @@
 #include "util/types.h"
 #include "util/memory.h"
 
+// The ParamtricEQEffect models the mid bands from a SSL Black EQ (242)
+// with a gentle parameter range, as requested here:
+// https://www.mixxx.org/forums/viewtopic.php?f=3&t=9239&p=33312&hilit=SSL#p33312
+// The main use case is to tweak the room or recording sound, which is hard to acheve
+// with the sharp and wide curves of the mixing EQs.
+
 class ParametricEQEffectGroupState final {
   public:
     ParametricEQEffectGroupState();

--- a/src/effects/native/parametriceqeffect.h
+++ b/src/effects/native/parametriceqeffect.h
@@ -19,7 +19,7 @@
 // The ParamtricEQEffect models the mid bands from a SSL Black EQ (242)
 // with a gentle parameter range, as requested here:
 // https://www.mixxx.org/forums/viewtopic.php?f=3&t=9239&p=33312&hilit=SSL#p33312
-// The main use case is to tweak the room or recording sound, which is hard to acheve
+// The main use case is to tweak the room or recording sound, which is hard to achieve
 // with the sharp and wide curves of the mixing EQs.
 
 class ParametricEQEffectGroupState final {

--- a/src/effects/native/parametriceqeffect.h
+++ b/src/effects/native/parametriceqeffect.h
@@ -1,6 +1,7 @@
 #ifndef PARAMERICEQEFFECT_H
 #define PARAMERICEQEFFECT_H
 
+#include <vector>
 #include <QMap>
 
 #include "control/controlproxy.h"
@@ -13,15 +14,15 @@
 #include "util/defs.h"
 #include "util/sample.h"
 #include "util/types.h"
+#include "util/memory.h"
 
 class ParametricEQEffectGroupState final {
   public:
     ParametricEQEffectGroupState();
-    ~ParametricEQEffectGroupState();
 
     void setFilters(int sampleRate);
 
-    QList<EngineFilterBiquad1Peaking*> m_bands;
+    std::vector<std::unique_ptr<EngineFilterBiquad1Peaking> > m_bands;
     QList<double> m_oldGain;
     QList<double> m_oldCenter;
     QList<double> m_oldQ;

--- a/src/effects/native/parametriceqeffect.h
+++ b/src/effects/native/parametriceqeffect.h
@@ -1,0 +1,64 @@
+#ifndef PARAMERICEQEFFECT_H
+#define PARAMERICEQEFFECT_H
+
+#include <QMap>
+
+#include "control/controlproxy.h"
+#include "effects/effect.h"
+#include "effects/effectprocessor.h"
+#include "engine/effects/engineeffect.h"
+#include "engine/effects/engineeffectparameter.h"
+#include "engine/enginefilterbiquad1.h"
+#include "util/class.h"
+#include "util/defs.h"
+#include "util/sample.h"
+#include "util/types.h"
+
+class ParametricEQEffectGroupState final {
+  public:
+    ParametricEQEffectGroupState();
+    ~ParametricEQEffectGroupState();
+
+    void setFilters(int sampleRate);
+
+    QList<EngineFilterBiquad1Peaking*> m_bands;
+    QList<double> m_oldGain;
+    QList<double> m_oldCenter;
+    QList<double> m_oldQ;
+
+    QList<CSAMPLE*> m_pBufs;
+};
+
+class ParametricEQEffect : public PerChannelEffectProcessor<ParametricEQEffectGroupState> {
+  public:
+    ParametricEQEffect(EngineEffect* pEffect, const EffectManifest& manifest);
+    virtual ~ParametricEQEffect();
+
+    static QString getId();
+    static EffectManifest getManifest();
+
+    // See effectprocessor.h
+    void processChannel(const ChannelHandle& handle,
+                        ParametricEQEffectGroupState* pState,
+                        const CSAMPLE* pInput, CSAMPLE *pOutput,
+                        const unsigned int numSamples,
+                        const unsigned int sampleRate,
+                        const EffectProcessor::EnableState enableState,
+                        const GroupFeatureState& groupFeatureState);
+
+  private:
+    QString debugString() const {
+        return getId();
+    }
+
+    QList<EngineEffectParameter*> m_pPotGain;
+    QList<EngineEffectParameter*> m_pPotQ;
+    QList<EngineEffectParameter*> m_pPotCenter;
+
+
+    unsigned int m_oldSampleRate;
+
+    DISALLOW_COPY_AND_ASSIGN(ParametricEQEffect);
+};
+
+#endif // PARAMERICEQEFFECT_H


### PR DESCRIPTION
This was requested in the forums and it was easy to split two bands from the graphic EQ and make them fully parametric. 
https://www.mixxx.org/forums/viewtopic.php?f=3&t=9239&p=33312&hilit=SSL#p33312

It models the mid bands from a SSL Black EQ (242)  