### PR TITLE
increase maximum sharpness of crossfader curve for scratching

### DIFF
--- a/src/engine/enginexfader.cpp
+++ b/src/engine/enginexfader.cpp
@@ -5,7 +5,7 @@
 //static
 const char* EngineXfader::kXfaderConfigKey = "[Mixer Profile]";
 const double EngineXfader::kTransformDefault = 1.0;
-const double EngineXfader::kTransformMax = 1000.0;
+const double EngineXfader::kTransformMax = 10000.0;
 const double EngineXfader::kTransformMin = 0.6;
 
 double EngineXfader::getPowerCalibration(double transform) {


### PR DESCRIPTION
A user on the forum complained that it was not sharp enough:
https://mixxx.org/forums/viewtopic.php?f=3&t=9243