### PR TITLE
library redesign code cleanup

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -960,13 +960,13 @@ class MixxxCore(Feature):
                    "library/features/maintenance/hiddentablemodel.cpp",
                    "library/features/maintenance/maintenancefeature.cpp",
                    "library/features/maintenance/missingtablemodel.cpp",
-                   
-                   "library/features/mixxxlibrary/mixxxlibraryfeature.cpp",
-                   "library/features/mixxxlibrary/mixxxlibrarytreemodel.cpp",
-                   
+
                    "library/features/playlist/playlistfeature.cpp",
                    "library/features/playlist/playlisttablemodel.cpp",
-                   
+
+                   "library/features/tracks/tracksfeature.cpp",
+                   "library/features/tracks/trackstreemodel.cpp",
+
                    # External Library Features
                    "library/features/baseexternalfeature/baseexternallibraryfeature.cpp",
                    "library/features/baseexternalfeature/baseexternalplaylistmodel.cpp",

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -709,7 +709,7 @@ QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
             break;
         case AbstractRole::RoleGroupingLetter:
             if (isValidColumn(column)) {
-                if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_YEAR) && 
+                if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_YEAR) &&
                         value.toString().size() == 4) {
                     // Show the decade
                     value = value.toString().at(2);
@@ -1066,21 +1066,21 @@ void BaseSqlTableModel::restoreQuery(const SavedSearchQuery& query) {
     for (const DbId& id : query.selectedItems) {
         m_savedSelectionIndices.insert(TrackId(id.toVariant()));
     }
-    
+
     deserialzeSortColumns(query.sortOrder);
     search(query.query);
 }
 
-SavedSearchQuery BaseSqlTableModel::saveQuery(const QModelIndexList& indices, 
+SavedSearchQuery BaseSqlTableModel::saveQuery(const QModelIndexList& indices,
                                       SavedSearchQuery query) const {
     query.selectedItems.clear();
     auto ids = getTrackIdsFromIndices(indices);
     for (const TrackId& id : ids) {
         query.selectedItems.insert(id);
     }
-    
+
     query.sortOrder = serializedSortColumns();
-    
+
     return query;
 }
 
@@ -1124,7 +1124,7 @@ QString BaseSqlTableModel::serializedSortColumns() const {
     QTextStream out(&val);
     for (const SortColumn& sc : m_sortColumns) {
 
-        QString name;        
+        QString name;
         if (sc.m_column > 0 && sc.m_column < m_tableColumns.size()) {
             name = m_tableColumns[sc.m_column];
         } else {
@@ -1143,25 +1143,25 @@ QString BaseSqlTableModel::serializedSortColumns() const {
 void BaseSqlTableModel::deserialzeSortColumns(QString serialized) {
     QTextStream in(&serialized);
     m_sortColumns.clear();
-    
+
     while (!in.atEnd()) {
         int ordI = -1;
         QString name;
-        
+
         in >> name >> ordI;
-        
+
         int col = fieldIndex(name);
         if (col < 0) continue;
-        
+
         Qt::SortOrder ord;
         ord = ordI > 0 ? Qt::AscendingOrder : Qt::DescendingOrder;
-        
+
         m_sortColumns << SortColumn(col, ord);
     }
 }
 
 bool BaseSqlTableModel::isValidColumn(int column) const {
-    return 
+    return
         column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUM) ||
         column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ALBUMARTIST) ||
         column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ARTIST) ||

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -53,10 +53,10 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role=Qt::DisplayRole) const final;
     virtual QMimeData* mimeData(const QModelIndexList &indexes) const final;
-    
+
     void saveSelection(const QModelIndexList& selection) override;
     QModelIndexList getSavedSelectionIndices() override;
-    
+
     void restoreQuery(const SavedSearchQuery& query) override;
     SavedSearchQuery saveQuery(const QModelIndexList &indices, SavedSearchQuery query) const override;
 
@@ -82,7 +82,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     void search(const QString& searchText, const QString& extraFilter = QString()) override;
     const QString currentSearch() const override;
     QAbstractItemDelegate* delegateForColumn(const int i, QObject* pParent) override;
-    
+
   public slots:
     void select();
 
@@ -91,7 +91,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
                   const QStringList& tableColumns,
                   QSharedPointer<BaseTrackCache> trackSource);
     void initHeaderData();
-    
+
     QSet<TrackId> getTrackIdsFromIndices(const QModelIndexList& list) const;
 
     // Use this if you want a model that is read-only.

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -98,9 +98,9 @@ class CoverArt : public CoverInfo {
     CoverArt& operator=(CoverArt&&) = default;
 #endif
 
-    // it is not a QPixmap, because it is not safe to use pixmaps 
+    // it is not a QPixmap, because it is not safe to use pixmaps
     // outside the GUI thread
-    QImage image; 
+    QImage image;
     int resizedToWidth;
 };
 

--- a/src/library/dao/savedqueriesdao.cpp
+++ b/src/library/dao/savedqueriesdao.cpp
@@ -13,51 +13,51 @@ SavedSearchQuery SavedQueriesDAO::saveQuery(LibraryFeature* pFeature,
     if (pFeature == nullptr) {
         return SavedSearchQuery();
     }
-    
-    QSqlQuery query(m_database);    
-    query.prepare("INSERT INTO " SAVEDQUERYTABLE 
+
+    QSqlQuery query(m_database);
+    query.prepare("INSERT INTO " SAVEDQUERYTABLE
                   "(libraryFeature, query, title, selectedItems,"
                   "sortOrder, vScrollbarPos, sortColumn, sortAscendingOrder, pinned) "
                   "VALUES (:libraryFeature, :query, :title, :selectedItems, "
                   ":sortOrder, :vScrollbarPos, :sortColumn, :sortAscendingOrder, :pinned)");
-    
+
     query.bindValue(":libraryFeature", pFeature->getSettingsName());
     query.bindValue(":query", sQuery.query);
-    query.bindValue(":title", sQuery.title);        
+    query.bindValue(":title", sQuery.title);
     query.bindValue(":selectedItems", serializeItems(sQuery.selectedItems));
     query.bindValue(":sortOrder", sQuery.sortOrder);
     query.bindValue(":vScrollbarPos", sQuery.vScrollBarPos);
     query.bindValue(":sortColumn", sQuery.sortColumn);
     query.bindValue(":sortAscendingOrder", (int) sQuery.sortAscendingOrder);
     query.bindValue(":pinned", (int) sQuery.pinned);
-    
+
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
     }
-    
+
     if (!query.exec("SELECT id FROM " SAVEDQUERYTABLE
                     " WHERE ROWID=last_inserted_rowid()")) {
         LOG_FAILED_QUERY(query);
     }
-    
+
     query.next();
     sQuery.id = query.value(0).toInt();
     return sQuery;
 }
 
-QList<SavedSearchQuery> SavedQueriesDAO::getSavedQueries(const QString& settingsName) const {    
+QList<SavedSearchQuery> SavedQueriesDAO::getSavedQueries(const QString& settingsName) const {
     QSqlQuery query(m_database);
-    QString queryStr = kSelectStart + 
-                       "FROM " SAVEDQUERYTABLE 
+    QString queryStr = kSelectStart +
+                       "FROM " SAVEDQUERYTABLE
                        " WHERE libraryFeature = :featureName "
                        "ORDER BY pinned DESC, id DESC";
     query.prepare(queryStr);
     query.bindValue(":featureName", settingsName);
-    
+
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
     }
-    
+
     QList<SavedSearchQuery> res;
     while (query.next()) {
         res << valueToQuery(query);
@@ -69,23 +69,23 @@ QList<SavedSearchQuery> SavedQueriesDAO::getSavedQueries(const LibraryFeature* p
     if (pFeature == nullptr) {
         return QList<SavedSearchQuery>();
     }
-    
+
     return getSavedQueries(pFeature->getSettingsName());
 }
 
 SavedSearchQuery SavedQueriesDAO::getSavedQuery(int id) const {
     QSqlQuery query(m_database);
     QString queryStr = kSelectStart +
-                       "FROM " SAVEDQUERYTABLE 
+                       "FROM " SAVEDQUERYTABLE
                        " WHERE id = :id "
                        "ORDER BY id DESC";
     query.prepare(queryStr);
     query.bindValue(":id", id);
-    
+
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
     }
-    
+
     query.next();
     return valueToQuery(query);
 }
@@ -102,7 +102,7 @@ SavedSearchQuery SavedQueriesDAO::moveToFirst(LibraryFeature* pFeature, int id) 
     return moveToFirst(pFeature, getSavedQuery(id));
 }
 
-bool SavedQueriesDAO::updateSavedQuery(const SavedSearchQuery& sQuery) {    
+bool SavedQueriesDAO::updateSavedQuery(const SavedSearchQuery& sQuery) {
     QSqlQuery query(m_database);
     query.prepare("UPDATE " SAVEDQUERYTABLE " SET "
             "query = :query, title = :title, selectedItems = :selectedItems, "
@@ -110,9 +110,9 @@ bool SavedQueriesDAO::updateSavedQuery(const SavedSearchQuery& sQuery) {
             "sortColumn = :sortColumn, "
             "sortAscendingOrder = :sortAscendingOrder, pinned = :pinned "
             "WHERE id = :id");
-    
+
     query.bindValue(":query", sQuery.query);
-    query.bindValue(":title", sQuery.title);        
+    query.bindValue(":title", sQuery.title);
     query.bindValue(":selectedItems", serializeItems(sQuery.selectedItems));
     query.bindValue(":sortOrder", sQuery.sortOrder);
     query.bindValue(":vScrollbarPos", sQuery.vScrollBarPos);
@@ -120,7 +120,7 @@ bool SavedQueriesDAO::updateSavedQuery(const SavedSearchQuery& sQuery) {
     query.bindValue(":sortAscendingOrder", (int) sQuery.sortAscendingOrder);
     query.bindValue(":pinned", (int) sQuery.pinned);
     query.bindValue(":id", sQuery.id);
-    
+
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
         return false;
@@ -161,7 +161,7 @@ int SavedQueriesDAO::getQueryId(const SavedSearchQuery& sQuery) {
 
 QString SavedQueriesDAO::serializeItems(const QSet<DbId>& items) {
     QStringList ret;
-    
+
     for (const DbId& id : items) {
         ret << id.toString();
     }
@@ -175,7 +175,7 @@ QSet<DbId> SavedQueriesDAO::deserializeItems(QString text) {
         int value;
         ss >> value;
         ret.insert(DbId(QVariant(value)));
-    }    
+    }
     return ret;
 }
 
@@ -190,6 +190,6 @@ SavedSearchQuery SavedQueriesDAO::valueToQuery(const QSqlQuery& query) {
     q.sortAscendingOrder = query.value(6).toBool();
     q.pinned = query.value(7).toBool();
     q.id = query.value(8).toInt();
-    
+
     return q;
 }

--- a/src/library/dao/savedqueriesdao.h
+++ b/src/library/dao/savedqueriesdao.h
@@ -21,7 +21,7 @@ enum SavedQueryColumns {
     SORTCOLUMN,
     SORTASCENDINGORDER,
     PINNED,
-    
+
     // NUM_COLUMNS should be always the last item
     NUM_COLUMNS
 };
@@ -40,25 +40,25 @@ const QString SAVEDQUERYTABLE_PINNED = "pinned";
 // This struct allows to save some data to allow interaction between
 // the search bar and the library features
 struct SavedSearchQuery {
-    
-    SavedSearchQuery() : 
+
+    SavedSearchQuery() :
         vScrollBarPos(-1),
-        sortColumn(-1), 
-        sortAscendingOrder(false), 
+        sortColumn(-1),
+        sortAscendingOrder(false),
         pinned(false),
         id(-1) {}
-    
+
     SavedSearchQuery(const SavedSearchQuery& other) = default;
     SavedSearchQuery& operator=(const SavedSearchQuery& other) = default;
     bool operator==(const SavedSearchQuery& other) const {
         return other.title == this->title && other.query == this->query;
     }
-    
+
     QString query;
     QString title;
     QSet<DbId> selectedItems;
     QString sortOrder;
-    
+
     int vScrollBarPos;
     int sortColumn;
     bool sortAscendingOrder;
@@ -84,14 +84,14 @@ class SavedQueriesDAO : public DAO {
     bool deleteSavedQuery(int id);
     bool exists(const SavedSearchQuery& sQuery);
     int getQueryId(const SavedSearchQuery& sQuery);
-    
+
   private:
     static QString serializeItems(const QSet<DbId>& items);
     static QSet<DbId> deserializeItems(QString text);
     static SavedSearchQuery valueToQuery(const QSqlQuery& query);
-    
+
     static const QString kSelectStart;
-    
+
     QSqlDatabase m_database;
 };
 

--- a/src/library/export/trackexportworker.cpp
+++ b/src/library/export/trackexportworker.cpp
@@ -85,13 +85,13 @@ void TrackExportWorker::run() {
         ++i;
         emit(progress(it->fileName(), i, copyList.size()));
     }
-    
+
     // If no file is being copied sleep a bit of time to allow the dialog to be
     // shown, otherwise no dialog is shown and it seems that anything is done
     if (copyList.size() <= 0) {
         QThread::msleep(500);
     }
-    
+
     emit progress("", copyList.size(), copyList.size());
 }
 

--- a/src/library/features/analysis/analysisfeature.cpp
+++ b/src/library/features/analysis/analysisfeature.cpp
@@ -61,38 +61,38 @@ QString AnalysisFeature::getSettingsName() const {
     return "AnalysisFeature";
 }
 
-parented_ptr<QWidget> AnalysisFeature::createPaneWidget(KeyboardEventFilter*, 
+parented_ptr<QWidget> AnalysisFeature::createPaneWidget(KeyboardEventFilter*,
             int paneId, QWidget* parent) {
     auto pTable = createTableWidget(paneId, parent);
     pTable->loadTrackModel(&m_analysisLibraryTableModel);
-    connect(pTable->selectionModel(), 
+    connect(pTable->selectionModel(),
             SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)),
-            this, 
+            this,
             SLOT(tableSelectionChanged(const QItemSelection&, const QItemSelection&)));
-    
+
     return pTable;
 }
 
 parented_ptr<QWidget> AnalysisFeature::createInnerSidebarWidget(
             KeyboardEventFilter* pKeyboard, QWidget* parent) {
     auto pAnalysisView = make_parented<DlgAnalysis>(parent, this);
-    
+
     m_pAnalysisView = pAnalysisView.toWeakRef();
     m_pAnalysisView->setTableModel(&m_analysisLibraryTableModel);
-    
+
     connect(this, SIGNAL(analysisActive(bool)),
             m_pAnalysisView, SLOT(analysisActive(bool)));
     connect(this, SIGNAL(trackAnalysisStarted(int)),
             m_pAnalysisView, SLOT(trackAnalysisStarted(int)));
 
     m_pAnalysisView->installEventFilter(pKeyboard);
-    
+
     // Let the DlgAnalysis know whether or not analysis is active.
     bool bAnalysisActive = m_pAnalyzerQueue != nullptr;
     emit(analysisActive(bAnalysisActive));
-    
+
     m_pAnalysisView->onShow();
-    
+
     return pAnalysisView;
 }
 
@@ -114,10 +114,10 @@ void AnalysisFeature::selectAll() {
 }
 
 void AnalysisFeature::activate() {
-    //qDebug() << "AnalysisFeature::activate()";    
+    //qDebug() << "AnalysisFeature::activate()";
     switchToFeature();
     showBreadCrumb();
-    
+
     if (!m_pAnalysisView.isNull()) {
         restoreSearch(m_pAnalysisView->currentSearch());
     }
@@ -207,7 +207,7 @@ void AnalysisFeature::tableSelectionChanged(const QItemSelection&,
     if (pTable.isNull()) {
         return;
     }
-    
+
     QModelIndexList indexes = pTable->selectionModel()->selectedIndexes();
     m_pAnalysisView->setSelectedIndexes(indexes);
 }

--- a/src/library/features/analysis/analysisfeature.h
+++ b/src/library/features/analysis/analysisfeature.h
@@ -33,12 +33,12 @@ class AnalysisFeature : public LibraryFeature {
 
     bool dropAccept(QList<QUrl> urls, QObject* pSource);
     bool dragMoveAccept(QUrl url);
-    
-    parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter*, int paneId, 
+
+    parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter*, int paneId,
                                            QWidget* parent) override;
-    parented_ptr<QWidget> createInnerSidebarWidget(KeyboardEventFilter* pKeyboard, 
+    parented_ptr<QWidget> createInnerSidebarWidget(KeyboardEventFilter* pKeyboard,
                                                    QWidget* parent) override;
-    
+
     QPointer<TreeItemModel> getChildModel();
     void refreshLibraryModels();
     void stopAnalysis();
@@ -67,7 +67,7 @@ class AnalysisFeature : public LibraryFeature {
     // where x is the current track being analyzed and y is the total number of
     // tracks in the job
     void setTitleProgress(int trackNum, int totalNum);
-    
+
     AnalysisLibraryTableModel* getAnalysisTableModel();
 
     mixxx::DbConnectionPoolPtr m_pDbConnectionPool;

--- a/src/library/features/analysis/dlganalysis.cpp
+++ b/src/library/features/analysis/dlganalysis.cpp
@@ -28,9 +28,9 @@ DlgAnalysis::~DlgAnalysis() {
 void DlgAnalysis::onShow() {
     // Refresh table
     // There might be new tracks dropped to other views
-    if (!m_pAnalysisLibraryTableModel.isNull()) 
+    if (!m_pAnalysisLibraryTableModel.isNull())
         m_pAnalysisLibraryTableModel->select();
-    
+
     // TODO(rryan): This triggers a library search before the UI has even
     // started up. Accounts for 0.2% of skin creation time. Get rid of this!
     radioButtonRecentlyAdded->click();
@@ -41,7 +41,7 @@ void DlgAnalysis::analyze() {
     if (m_bAnalysisActive) {
         m_pAnalysis->stopAnalysis();
     } else {
-        if (m_pAnalysisLibraryTableModel.isNull()) 
+        if (m_pAnalysisLibraryTableModel.isNull())
             return;
         QList<TrackId> trackIds;
         for (QModelIndex selectedIndex : m_selectedIndexes) {
@@ -103,7 +103,7 @@ void DlgAnalysis::setSelectedIndexes(const QModelIndexList& selectedIndexes) {
 
 void DlgAnalysis::setTableModel(AnalysisLibraryTableModel* pTableModel) {
     m_pAnalysisLibraryTableModel = pTableModel;
-    
+
     connect(radioButtonRecentlyAdded, SIGNAL(clicked()),
             m_pAnalysisLibraryTableModel, SLOT(showRecentSongs()));
     connect(radioButtonAllSongs, SIGNAL(clicked()),

--- a/src/library/features/analysis/dlganalysis.h
+++ b/src/library/features/analysis/dlganalysis.h
@@ -11,11 +11,11 @@
 class AnalysisFeature;
 
 class DlgAnalysis : public QFrame, public Ui::DlgAnalysis {
-    
+
     Q_OBJECT
-    
+
   public:
-    
+
     DlgAnalysis(QWidget* parent, AnalysisFeature* pAnalysis);
     ~DlgAnalysis() override;
 
@@ -24,19 +24,19 @@ class DlgAnalysis : public QFrame, public Ui::DlgAnalysis {
         return m_pAnalysisLibraryTableModel->currentSearch();
     }
     int getNumTracks();
-    
+
     // The selected indexes are always from the focused pane
     void setSelectedIndexes(const QModelIndexList& selectedIndexes);
     void setTableModel(AnalysisLibraryTableModel* pTableModel);
 
   public slots:
-    
+
     void analyze();
     void trackAnalysisFinished(int size);
     void trackAnalysisProgress(int progress);
     void trackAnalysisStarted(int size);
     void analysisActive(bool bActive);
-    
+
   private:
     //Note m_pTrackTablePlaceholder is defined in the .ui file
     bool m_bAnalysisActive;
@@ -45,7 +45,7 @@ class DlgAnalysis : public QFrame, public Ui::DlgAnalysis {
     QPointer<AnalysisFeature> m_pAnalysis;
     int m_tracksInQueue;
     int m_currentTrack;
-    
+
     QModelIndexList m_selectedIndexes;
 };
 

--- a/src/library/features/autodj/autodjfeature.cpp
+++ b/src/library/features/autodj/autodjfeature.cpp
@@ -64,7 +64,7 @@ AutoDJFeature::AutoDJFeature(UserSettingsPointer pConfig,
     // Create the "Crates" tree-item under the root item.
     auto pRootItem = std::make_unique<TreeItem>(this);
     m_pCratesTreeItem = pRootItem->appendChild(tr("Crates"));
-    // we set the Icon later, because the icon loader is not fully set up yet 
+    // we set the Icon later, because the icon loader is not fully set up yet
 
     // Create tree-items under "Crates".
     constructCrateChildModel();
@@ -105,7 +105,7 @@ QString AutoDJFeature::getSettingsName() const {
     return "AutoDJFeature";
 }
 
-parented_ptr<QWidget> AutoDJFeature::createPaneWidget(KeyboardEventFilter*, 
+parented_ptr<QWidget> AutoDJFeature::createPaneWidget(KeyboardEventFilter*,
             int paneId, QWidget* parent) {
     auto pTrackTableView = createTableWidget(paneId, parent);
     pTrackTableView->loadTrackModel(m_pAutoDJProcessor->getTableModel());
@@ -122,7 +122,7 @@ parented_ptr<QWidget> AutoDJFeature::createInnerSidebarWidget(
             KeyboardEventFilter* pKeyboard, QWidget* parent) {
     auto pContainer = make_parented<QTabWidget>(parent);
 
-    // now the icon loader is set up and get an icon 
+    // now the icon loader is set up and get an icon
     m_pCratesTreeItem->setIcon(WPixmapStore::getLibraryIcon(
             ":/images/library/ic_library_crates.png"));
 
@@ -337,6 +337,6 @@ void AutoDJFeature::selectionChanged(const QItemSelection&, const QItemSelection
     VERIFY_OR_DEBUG_ASSERT(!m_pAutoDJView.isNull() && !pTable.isNull()) {
         return;
     }
-    
+
     m_pAutoDJView->setSelectedRows(pTable->selectionModel()->selectedRows());
 }

--- a/src/library/features/autodj/autodjfeature.h
+++ b/src/library/features/autodj/autodjfeature.h
@@ -46,9 +46,9 @@ class AutoDJFeature : public LibraryFeature {
     bool dropAccept(QList<QUrl> urls, QObject* pSource);
     bool dragMoveAccept(QUrl url);
 
-    parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter*, int paneId, 
+    parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter*, int paneId,
                                            QWidget* parent) override;
-    parented_ptr<QWidget> createInnerSidebarWidget(KeyboardEventFilter* pKeyboard, 
+    parented_ptr<QWidget> createInnerSidebarWidget(KeyboardEventFilter* pKeyboard,
                                                    QWidget* parent) override;
 
     QPointer<TreeItemModel> getChildModel();

--- a/src/library/features/autodj/dlgautodj.cpp
+++ b/src/library/features/autodj/dlgautodj.cpp
@@ -54,7 +54,7 @@ void DlgAutoDJ::setSelectedRows(const QModelIndexList& selectedRows) {
     updateSelectionInfo();
 }
 
-void DlgAutoDJ::shufflePlaylistButton(bool) {    
+void DlgAutoDJ::shufflePlaylistButton(bool) {
     // Activate regardless of button being checked
     m_pAutoDJProcessor->shufflePlaylist(m_selectedRows);
 }
@@ -134,7 +134,7 @@ void DlgAutoDJ::updateSelectionInfo() {
         labelSelectionInfo->setEnabled(false);
         return;
     }
-    
+
     double duration = 0.0;
     for (const QModelIndex& mIndex : m_selectedRows) {
         TrackPointer pTrack = m_pAutoDJTableModel->getTrack(mIndex);

--- a/src/library/features/autodj/dlgautodj.h
+++ b/src/library/features/autodj/dlgautodj.h
@@ -18,7 +18,7 @@ class DlgAutoDJ : public QFrame, public Ui::DlgAutoDJ {
     Q_OBJECT
   public:
     DlgAutoDJ(QWidget* parent, AutoDJProcessor* pProcessor);
-    
+
     // These seleced rows are always from the focused pane
     void setSelectedRows(const QModelIndexList& selectedRows);
     void onShow();
@@ -35,11 +35,11 @@ class DlgAutoDJ : public QFrame, public Ui::DlgAutoDJ {
 
   signals:
     void addRandomButton(bool buttonChecked);
-    
+
   private:
     AutoDJProcessor* m_pAutoDJProcessor;
     PlaylistTableModel* m_pAutoDJTableModel;
-    
+
     QModelIndexList m_selectedRows;
 };
 

--- a/src/library/features/banshee/bansheefeature.cpp
+++ b/src/library/features/banshee/bansheefeature.cpp
@@ -116,7 +116,7 @@ void BansheeFeature::activate() {
     }
 
     m_pBansheePlaylistModel->setTableModel(0); // Gets the master playlist
-    
+
     showTrackModel(m_pBansheePlaylistModel);
     showBreadCrumb();
 }
@@ -127,7 +127,7 @@ void BansheeFeature::activateChild(const QModelIndex& index) {
     if (playlistID > 0) {
         qDebug() << "Activating " << item->getLabel();
         m_pBansheePlaylistModel->setTableModel(playlistID);
-        
+
         showTrackModel(m_pBansheePlaylistModel);
         showBreadCrumb(item);
     }

--- a/src/library/features/banshee/bansheefeature.h
+++ b/src/library/features/banshee/bansheefeature.h
@@ -57,7 +57,7 @@ class BansheeFeature : public BaseExternalLibraryFeature {
     bool m_cancelImport;
 
     static QString m_databaseFile;
-    
+
     static const QString BANSHEE_MOUNT_KEY;
 };
 

--- a/src/library/features/baseexternalfeature/baseexternallibraryfeature.h
+++ b/src/library/features/baseexternalfeature/baseexternallibraryfeature.h
@@ -12,8 +12,8 @@ class TrackCollection;
 class BaseExternalLibraryFeature : public LibraryFeature {
     Q_OBJECT
   public:
-    BaseExternalLibraryFeature(UserSettingsPointer pConfig, 
-                               Library* pLibrary, 
+    BaseExternalLibraryFeature(UserSettingsPointer pConfig,
+                               Library* pLibrary,
                                QObject* pParent,
                                TrackCollection* pCollection);
     virtual ~BaseExternalLibraryFeature();

--- a/src/library/features/baseplaylist/baseplaylistfeature.cpp
+++ b/src/library/features/baseplaylist/baseplaylistfeature.cpp
@@ -27,7 +27,7 @@ BasePlaylistFeature::BasePlaylistFeature(UserSettingsPointer pConfig,
           m_playlistDao(pTrackCollection->getPlaylistDAO()),
           m_trackDao(pTrackCollection->getTrackDAO()),
           m_pPlaylistTableModel(nullptr) {
-    
+
     m_pCreatePlaylistAction = new QAction(tr("Create New Playlist"),this);
     connect(m_pCreatePlaylistAction, SIGNAL(triggered()),
             this, SLOT(slotCreatePlaylist()));
@@ -138,37 +138,37 @@ void BasePlaylistFeature::activate() {
     showBrowse(m_featurePane);
     switchToFeature();
     showBreadCrumb();
-    
+
     restoreSearch(QString()); // Null String disables search box
 }
 
 void BasePlaylistFeature::activateChild(const QModelIndex& index) {
     adoptPreselectedPane();
-    
+
     if (index == m_lastChildClicked.value(m_featurePane)) {
         restoreSearch("");
         showTable(m_featurePane);
         switchToFeature();
         return;
     }
-    
+
     m_lastChildClicked[m_featurePane] = index;
-    
+
     //qDebug() << "BasePlaylistFeature::activateChild()" << index;
     QSet<int> playlistIds = playlistIdsFromIndex(index);
     m_pPlaylistTableModel = getPlaylistTableModel(m_featurePane);
-    
+
     if (!playlistIds.isEmpty() && m_pPlaylistTableModel) {
         m_pPlaylistTableModel->setTableModel(playlistIds);
         showTable(m_featurePane);
-        
+
         // Set the feature Focus for a moment to allow the LibraryFeature class
         // to find the focused WTrackTable
         showTrackModel(m_pPlaylistTableModel);
-        
+
         restoreSearch("");
         showBreadCrumb(index);
-                
+
     }
 }
 
@@ -340,8 +340,8 @@ void BasePlaylistFeature::slotDeletePlaylist() {
         VERIFY_OR_DEBUG_ASSERT(playlistId >= 0) {
             return;
         }
-        
-        m_playlistDao.deletePlaylist(playlistId);   
+
+        m_playlistDao.deletePlaylist(playlistId);
         activate();
     }
 }
@@ -458,7 +458,7 @@ void BasePlaylistFeature::slotExportPlaylist() {
     if (pTableModel.isNull()) {
         return;
     }
-    
+
     int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
     if (playlistId == -1) {
         return;
@@ -644,7 +644,7 @@ int BasePlaylistFeature::playlistIdFromIndex(const QModelIndex& index) const {
     if (playlistIds.empty() || playlistIds.size() > 1) {
         return -1;
     }
-    
+
     return *playlistIds.begin();
 }
 
@@ -654,7 +654,7 @@ void BasePlaylistFeature::showTable(int paneId) {
     if (it == m_panes.end() || it->isNull() || itId == m_tableIndexByPaneId.end()) {
         return;
     }
-    
+
     (*it)->setCurrentIndex(*itId);
 }
 
@@ -664,7 +664,7 @@ void BasePlaylistFeature::showBrowse(int paneId) {
     if (it == m_panes.end() || it->isNull() || itId == m_browseIndexByPaneId.end()) {
         return;
     }
-    
+
     (*it)->setCurrentIndex(*itId);
 }
 
@@ -679,11 +679,11 @@ void BasePlaylistFeature::slotAnalyzePlaylist() {
     }
 }
 
-parented_ptr<QWidget> BasePlaylistFeature::createPaneWidget(KeyboardEventFilter* pKeyboard, 
+parented_ptr<QWidget> BasePlaylistFeature::createPaneWidget(KeyboardEventFilter* pKeyboard,
                                                int paneId, QWidget* parent) {
     auto pStack = make_parented<WLibraryStack>(parent);
     m_panes[paneId] = pStack.toWeakRef();
-    
+
     auto edit = make_parented<WLibraryTextBrowser>(pStack.get());
     edit->setHtml(getRootViewHtml());
     edit->setOpenLinks(false);
@@ -691,10 +691,10 @@ parented_ptr<QWidget> BasePlaylistFeature::createPaneWidget(KeyboardEventFilter*
     connect(edit.get(), SIGNAL(anchorClicked(const QUrl)),
             this, SLOT(htmlLinkClicked(const QUrl)));
     m_browseIndexByPaneId[paneId] = pStack->addWidget(edit.get());
-    
+
     auto pTable = LibraryFeature::createPaneWidget(pKeyboard, paneId, pStack.get());
     m_tableIndexByPaneId[paneId] = pStack->addWidget(pTable.get());
-    
+
     return pStack;
 }
 
@@ -717,9 +717,9 @@ QModelIndex BasePlaylistFeature::constructChildModel(int selectedId) {
     QPointer<TreeItemModel> pChildModel = getChildModel();
     if (pChildModel.isNull())
         return QModelIndex();
-    
+
     TreeItem* pRoot = pChildModel->setRootItem(std::make_unique<TreeItem>(this));
-    
+
     int row = 0;
     for (const PlaylistItem& p : m_playlistList) {
         if (selectedId == p.id) {
@@ -741,15 +741,15 @@ QModelIndex BasePlaylistFeature::constructChildModel(int selectedId) {
 
 void BasePlaylistFeature::updateChildModel(int selectedId) {
     buildPlaylistList();
-    
+
     QModelIndex index = indexFromPlaylistId(selectedId);
     if (!index.isValid()) {
         return;
     }
     QPointer<TreeItemModel> pChildModel = getChildModel();
-    VERIFY_OR_DEBUG_ASSERT (pChildModel.isNull()) 
+    VERIFY_OR_DEBUG_ASSERT (pChildModel.isNull())
         return;
-    
+
     TreeItem* item = pChildModel->getItem(index);
     VERIFY_OR_DEBUG_ASSERT(item) {
         return;
@@ -760,7 +760,7 @@ void BasePlaylistFeature::updateChildModel(int selectedId) {
         return;
     }
     item->setData(m_playlistList[pos].name);
-    
+
     decorateChild(item, selectedId);
 }
 
@@ -769,7 +769,7 @@ QModelIndex BasePlaylistFeature::indexFromPlaylistId(int playlistId) const {
     if (row < 0) {
         return QModelIndex();
     }
-    
+
     return getConstChildModel()->index(row, 0);
 }
 
@@ -784,12 +784,12 @@ void BasePlaylistFeature::slotTrackSelected(TrackPointer pTrack) {
     // Set all playlists the track is in bold (or if there is no track selected,
     // clear all the bolding).
     QPointer<TreeItemModel> pChildModel = getChildModel();
-    VERIFY_OR_DEBUG_ASSERT(!pChildModel.isNull()) 
+    VERIFY_OR_DEBUG_ASSERT(!pChildModel.isNull())
         return;
-    
-    for (const PlaylistItem& p : m_playlistList) { 
+
+    for (const PlaylistItem& p : m_playlistList) {
         QModelIndex index = indexFromPlaylistId(p.id);
-        
+
         bool shouldBold = m_playlistsSelectedTrackIsIn.contains(p.id);
         pChildModel->setData(index, shouldBold, AbstractRole::RoleBold);
     }

--- a/src/library/features/baseplaylist/baseplaylistfeature.h
+++ b/src/library/features/baseplaylist/baseplaylistfeature.h
@@ -24,7 +24,7 @@ class BasePlaylistFeature : public LibraryFeature {
                         QObject* parent,
                         TrackCollection* pTrackCollection);
     virtual ~BasePlaylistFeature();
-    parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter*pKeyboard, 
+    parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter*pKeyboard,
                                            int paneId, QWidget* parent) override;
 
   signals:
@@ -61,37 +61,37 @@ class BasePlaylistFeature : public LibraryFeature {
     void slotAnalyzePlaylist();
 
   protected:
-    
+
     struct PlaylistItem {
         PlaylistItem() : id(-1) {}
         PlaylistItem(int id) : id(id) {}
         PlaylistItem(int id, QString name) : id(id), name(name) {}
-        
+
         int id;
         QString name;
-        
+
         bool operator==(const PlaylistItem& other) {
             return this->id == other.id;
         }
     };
-    
+
     virtual const TreeItemModel* getConstChildModel() const = 0;
-    
+
     virtual QModelIndex constructChildModel(int selected_id);
     virtual void updateChildModel(int selectedId);
     virtual void buildPlaylistList() = 0;
     virtual void decorateChild(TreeItem *pChild, int playlist_id) = 0;
     virtual void addToAutoDJ(bool bTop);
     QString getValidPlaylistName() const;
-    
+
     QPointer<PlaylistTableModel> getPlaylistTableModel(int paneId = -1);
     virtual parented_ptr<PlaylistTableModel> constructTableModel() = 0;
-    
+
     virtual QSet<int> playlistIdsFromIndex(const QModelIndex& index) const;
     int playlistIdFromIndex(const QModelIndex& index) const;
     void showTable(int paneId);
     void showBrowse(int paneId);
-    
+
     // Get the QModelIndex of a playlist based on its id.  Returns QModelIndex()
     // on failure.
     virtual QModelIndex indexFromPlaylistId(int playlistId) const;
@@ -115,7 +115,7 @@ class BasePlaylistFeature : public LibraryFeature {
     QList<PlaylistItem> m_playlistList;
     QPersistentModelIndex m_lastRightClickedIndex;
     TrackPointer m_pSelectedTrack;
-    
+
     QHash<int, QPersistentModelIndex> m_lastChildClicked;
 
   protected slots:
@@ -125,7 +125,7 @@ class BasePlaylistFeature : public LibraryFeature {
     virtual QString getRootViewHtml() const = 0;
 
     QSet<int> m_playlistsSelectedTrackIsIn;
-    
+
     QHash<int, QPointer<WLibraryStack> > m_panes;
     QHash<int, int> m_browseIndexByPaneId;
     QHash<int, int> m_tableIndexByPaneId;

--- a/src/library/features/browse/browsefeature.cpp
+++ b/src/library/features/browse/browsefeature.cpp
@@ -197,19 +197,19 @@ QPointer<TreeItemModel> BrowseFeature::getChildModel() {
     return &m_childModel;
 }
 
-parented_ptr<QWidget> BrowseFeature::createPaneWidget(KeyboardEventFilter* pKeyboard, 
+parented_ptr<QWidget> BrowseFeature::createPaneWidget(KeyboardEventFilter* pKeyboard,
             int paneId, QWidget* parent) {
     auto pStack = make_parented<WLibraryStack>(parent);
     m_panes[paneId] = pStack.toWeakRef();
-    
+
     auto pEdit = make_parented<WLibraryTextBrowser>(pStack.get());
     pEdit->setHtml(getRootViewHtml());
     pEdit->installEventFilter(pKeyboard);
     m_idBrowse[paneId] = pStack->addWidget(pEdit.get());
-    
+
     auto pTable = LibraryFeature::createPaneWidget(pKeyboard, paneId, pStack.get());
     m_idTable[paneId] = pStack->addWidget(pTable.get());
-    
+
     return pStack;
 }
 
@@ -218,12 +218,12 @@ void BrowseFeature::activate() {
         activateChild(m_lastClickedChild);
         return;
     }
-    
+
     showBrowse(m_featurePane);
     switchToFeature();
     showBreadCrumb();
     restoreSearch(QString());
-    
+
 }
 
 // Note: This is executed whenever you single click on an child item
@@ -233,7 +233,7 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
     QString data = index.data().toString();
     QString dataPath = index.data(AbstractRole::RoleData).toString();
     qDebug() << "BrowseFeature::activateChild " << data << dataPath;
-    
+
     if (dataPath == QUICK_LINK_NODE || dataPath == DEVICE_NODE) {
         m_browseModel.setPath(MDir());
     } else {
@@ -251,12 +251,12 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
         }
         m_browseModel.setPath(dir);
     }
-    
+
     showTable(m_featurePane);
     showTrackModel(&m_proxyModel);
     QString bread = index.data(AbstractRole::RoleBreadCrumb).toString();
     showBreadCrumb(bread, getIcon());
-    
+
 }
 
 void BrowseFeature::onRightClickChild(const QPoint& globalPos,
@@ -282,7 +282,7 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos,
         onLazyChildExpandation(persitstentIndex);
         return;
     }
-    
+
     for (const QString& str : m_quickLinkList) {
         if (str == path) {
              return;
@@ -300,7 +300,7 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos,
 void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
     if (!index.isValid())
         return;
-    
+
     QString label = index.data().toString();
     QString path = index.data(AbstractRole::RoleData).toString();
 

--- a/src/library/features/browse/browsefeature.h
+++ b/src/library/features/browse/browsefeature.h
@@ -40,7 +40,7 @@ class BrowseFeature : public LibraryFeature {
     QString getIconPath() override;
     QString getSettingsName() const override;
 
-    parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter*pKeyboard, 
+    parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter*pKeyboard,
                                            int paneId, QWidget* parent) override;
 
     QPointer<TreeItemModel> getChildModel();
@@ -81,7 +81,7 @@ class BrowseFeature : public LibraryFeature {
     parented_ptr<TreeItem> m_pQuickLinkItem;
     QStringList m_quickLinkList;
     QPersistentModelIndex m_lastClickedChild;
-    
+
     QHash<int, QPointer<WLibraryStack> > m_panes;
     QHash<int, int> m_idBrowse;
     QHash<int, int> m_idTable;

--- a/src/library/features/browse/foldertreemodel.cpp
+++ b/src/library/features/browse/foldertreemodel.cpp
@@ -34,8 +34,8 @@ FolderTreeModel::~FolderTreeModel() {
 bool FolderTreeModel::hasChildren(const QModelIndex& parent) const {
     if (!parent.isValid()) {
         return true;
-    }    
-    
+    }
+
     TreeItem *item = static_cast<TreeItem*>(parent.internalPointer());
     /* Usually the child count is 0 becuase we do lazy initalization
      * However, for, buid-in items such as 'Quick Links' there exist
@@ -44,7 +44,7 @@ bool FolderTreeModel::hasChildren(const QModelIndex& parent) const {
     if (item == nullptr) {
         return false;
     }
-    
+
     if(item->getData().toString() == QUICK_LINK_NODE)
         return true;
     //Can only happen on Windows

--- a/src/library/features/crates/cratefeature.cpp
+++ b/src/library/features/crates/cratefeature.cpp
@@ -204,7 +204,7 @@ void updateTreeItemForTrackSelection(
     pTreeItem->setBold(crateContainsSelectedTrack);
 }
 
-} 
+}
 
 bool CrateFeature::dragMoveAccept(QUrl url) {
     return SoundSourceProxy::isUrlSupported(url) ||
@@ -251,24 +251,24 @@ bool CrateFeature::dragMoveAcceptChild(const QModelIndex& index, QUrl url) {
         Parser::isPlaylistFilenameSupported(url.toLocalFile());
 }
 
-parented_ptr<QWidget> CrateFeature::createPaneWidget(KeyboardEventFilter* pKeyboard, 
+parented_ptr<QWidget> CrateFeature::createPaneWidget(KeyboardEventFilter* pKeyboard,
             int paneId, QWidget* parent) {
     auto pContainer = make_parented<WLibraryStack>(parent);
     m_panes[paneId] = pContainer.toWeakRef();
-    
+
     auto pEdit = make_parented<WLibraryTextBrowser>(pContainer.get());
     pEdit->setHtml(formatRootViewHtml());
     pEdit->setOpenLinks(false);
     pEdit->installEventFilter(pKeyboard);
     connect(pEdit.get(), SIGNAL(anchorClicked(const QUrl)),
             this, SLOT(htmlLinkClicked(const QUrl)));
-    
+
     m_idBrowse[paneId] = pContainer->addWidget(pEdit.get());
-    
-    auto pTable = LibraryFeature::createPaneWidget(pKeyboard, paneId, 
+
+    auto pTable = LibraryFeature::createPaneWidget(pKeyboard, paneId,
                                                    pContainer.get());
     m_idTable[paneId] = pContainer->addWidget(pTable.get());
-    
+
     return pContainer;
 }
 
@@ -284,8 +284,8 @@ void CrateFeature::activate() {
         activateChild(*modelIt);
         return;
     }
-    
-    showBrowse(m_featurePane);    
+
+    showBrowse(m_featurePane);
     switchToFeature();
     showBreadCrumb();
     restoreSearch(QString()); //disable search on crate home
@@ -293,13 +293,13 @@ void CrateFeature::activate() {
 
 void CrateFeature::activateChild(const QModelIndex& index) {
     adoptPreselectedPane();
-    
+
     m_lastClickedIndex[m_featurePane] = index;
     CrateId crateId(crateIdFromIndex(index));
     VERIFY_OR_DEBUG_ASSERT(crateId.isValid()) {
         return;
     }
-    
+
     m_pCrateTableModel = getTableModel(m_featurePane);
     m_pCrateTableModel->selectCrate(crateId);
     showTable(m_featurePane);

--- a/src/library/features/crates/cratefeature.h
+++ b/src/library/features/crates/cratefeature.h
@@ -36,7 +36,7 @@ class CrateFeature : public LibraryFeature {
     QString getIconPath() override;
     QString getSettingsName() const override;
     bool isSinglePane() const override;
-    
+
     void onSearch(QString&) {}
 
     bool dragMoveAccept(QUrl url) override;
@@ -44,9 +44,9 @@ class CrateFeature : public LibraryFeature {
                          QObject* pSource) override;
     bool dragMoveAcceptChild(const QModelIndex& index, QUrl url) override;
 
-    parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter* pKeyboard, 
+    parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter* pKeyboard,
                                            int paneId, QWidget* parent) override;
-    
+
     QPointer<TreeItemModel> getChildModel() override;
 
   signals:

--- a/src/library/features/history/historyfeature.cpp
+++ b/src/library/features/history/historyfeature.cpp
@@ -30,10 +30,10 @@ HistoryFeature::HistoryFeature(UserSettingsPointer pConfig,
     emit(slotGetNewPlaylist());
 
     //construct child model
-    m_pHistoryTreeModel = std::make_unique<HistoryTreeModel>(this, 
+    m_pHistoryTreeModel = std::make_unique<HistoryTreeModel>(this,
                                                              m_pTrackCollection);
     constructChildModel(-1);
-    
+
     connect(&PlayerInfo::instance(), SIGNAL(currentPlayingTrackChanged(TrackPointer)),
             this, SLOT(slotPlayingTrackChanged(TrackPointer)));
 }
@@ -113,13 +113,13 @@ void HistoryFeature::onRightClickChild(const QPoint& globalPos, const QModelInde
 
 void HistoryFeature::buildPlaylistList() {
     m_playlistList.clear();
-    
-    // Setup the sidebar playlist model    
+
+    // Setup the sidebar playlist model
     QSqlQuery query("SELECT id, name FROM Playlists WHERE hidden=2", m_pTrackCollection->database());
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
     }
-    
+
     int iId = query.record().indexOf("id");
     int iName = query.record().indexOf("name");
     while (query.next()) {
@@ -153,7 +153,7 @@ QModelIndex HistoryFeature::constructChildModel(int selected_id) {
 }
 
 parented_ptr<PlaylistTableModel> HistoryFeature::constructTableModel() {
-    return make_parented<PlaylistTableModel>(this, m_pTrackCollection, 
+    return make_parented<PlaylistTableModel>(this, m_pTrackCollection,
             "mixxx.db.model.setlog", true);
 }
 
@@ -222,18 +222,18 @@ void HistoryFeature::slotJoinWithNext() {
         bool ok;
         int currentPlaylistId =
                 m_lastRightClickedIndex.data(AbstractRole::RoleData).toInt(&ok);
-        
+
         if (!ok) {
             return;
         }
 
         bool locked = m_playlistDao.isPlaylistLocked(currentPlaylistId);
-        
+
         if (locked) {
             qDebug() << "Skipping playlist deletion because playlist" << currentPlaylistId << "is locked.";
             return;
         }
-        
+
         // Add every track from right klicked playlist to that with the next smaller ID
         // Although being the name "join with next" this is because it's ordered
         // in descendant order so actually the next playlist in the GUI is the
@@ -242,12 +242,12 @@ void HistoryFeature::slotJoinWithNext() {
         if (previousPlaylistId < 0) {
             return;
         }
-            
+
         m_pPlaylistTableModel->setTableModel(previousPlaylistId);
-        
+
         if (currentPlaylistId == m_playlistId) {
             // mark all the Tracks in the previous Playlist as played
-            
+
             m_pPlaylistTableModel->select();
             int rows = m_pPlaylistTableModel->rowCount();
             for (int i = 0; i < rows; ++i) {
@@ -260,7 +260,7 @@ void HistoryFeature::slotJoinWithNext() {
                     track->setPlayCounter(playCounter);
                 }
             }
-            
+
             // Change current setlog
             m_playlistId = previousPlaylistId;
         }
@@ -308,7 +308,7 @@ void HistoryFeature::slotPlayingTrackChanged(TrackPointer currentPlayingTrack) {
     if (!currentPlayingTrackId.isValid()) {
         return;
     }
-    
+
     m_pPlaylistTableModel = getPlaylistTableModel(-1);
 
     if (m_pPlaylistTableModel->getPlaylist() == m_playlistId) {

--- a/src/library/features/history/historyfeature.h
+++ b/src/library/features/history/historyfeature.h
@@ -16,7 +16,7 @@ class HistoryFeature : public BasePlaylistFeature {
 public:
     HistoryFeature(UserSettingsPointer pConfig,
                   Library* pLibrary,
-                  QObject* parent, 
+                  QObject* parent,
                   TrackCollection* pTrackCollection);
     virtual ~HistoryFeature();
 
@@ -33,9 +33,9 @@ public:
     void slotGetNewPlaylist();
 
   protected:
-    parented_ptr<QWidget> createInnerSidebarWidget(KeyboardEventFilter*, 
+    parented_ptr<QWidget> createInnerSidebarWidget(KeyboardEventFilter*,
                                                    QWidget* parent) override;
-    
+
     const TreeItemModel* getConstChildModel() const override;
     void buildPlaylistList() override;
     QModelIndex constructChildModel(int selected_id);

--- a/src/library/features/history/historytreemodel.h
+++ b/src/library/features/history/historytreemodel.h
@@ -11,7 +11,7 @@ class TrackCollection;
 class HistoryTreeModel : public TreeItemModel
 {
   public:
-    HistoryTreeModel(HistoryFeature* pFeature, TrackCollection* pTrackCollection, 
+    HistoryTreeModel(HistoryFeature* pFeature, TrackCollection* pTrackCollection,
                      QObject* parent = nullptr);
 
     QModelIndex reloadListsTree(int playlistId);
@@ -25,10 +25,10 @@ class HistoryTreeModel : public TreeItemModel
         int iName;
         int iCount;
     };
-    
+
     QList<QVariant> idsFromItem(TreeItem* pTree) const;
     TreeItem* findItemFromPlaylistId(TreeItem* pTree, int playlistId, int& row) const;
-    
+
     QPointer<HistoryFeature> m_pFeature;
     TrackCollection* m_pTrackCollection;
     QStringList m_columns;

--- a/src/library/features/itunes/itunesfeature.cpp
+++ b/src/library/features/itunes/itunesfeature.cpp
@@ -335,7 +335,7 @@ void ITunesFeature::guessMusicLibraryMountpoint(QXmlStreamReader &xml) {
 TreeItem* ITunesFeature::importLibrary() {
     bool isTracksParsed=false;
     bool isMusicFolderLocatedAfterTracks=false;
-  
+
     //Give thread a low priority
     QThread* thisThread = QThread::currentThread();
     thisThread->setPriority(QThread::LowPriority);
@@ -390,10 +390,10 @@ TreeItem* ITunesFeature::importLibrary() {
     }
 
     itunes_file.close();
-    
+
     if (isMusicFolderLocatedAfterTracks) {
         qDebug() << "Updating iTunes real path from " << m_dbItunesRoot << " to " << m_mixxxItunesRoot;
-        // In some iTunes files "Music Folder" XML node is located at the end of file. So, we need to 
+        // In some iTunes files "Music Folder" XML node is located at the end of file. So, we need to
         QSqlQuery query(m_database);
         query.prepare("UPDATE itunes_library SET location = replace( location, :itunes_path, :mixxx_path )");
         query.bindValue(":itunes_path", m_dbItunesRoot.replace(localhost_token(), ""));
@@ -702,7 +702,7 @@ void ITunesFeature::parsePlaylist(QXmlStreamReader &xml, QSqlQuery &query_insert
 
                 if (key == "Playlist Items") {
                     isPlaylistItemsStarted = true;
-                    
+
                     //if the playlist is prebuild don't hit the database
                     if (isSystemPlaylist) continue;
                     query_insert_to_playlists.bindValue(":id", playlist_id);

--- a/src/library/features/itunes/itunesfeature.h
+++ b/src/library/features/itunes/itunesfeature.h
@@ -20,9 +20,9 @@ class BaseExternalPlaylistModel;
 class ITunesFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
  public:
-    ITunesFeature(UserSettingsPointer pConfig, 
+    ITunesFeature(UserSettingsPointer pConfig,
                   Library* pLibrary,
-                  QObject* parent, 
+                  QObject* parent,
                   TrackCollection* pTrackCollection);
     virtual ~ITunesFeature();
     static bool isSupported();

--- a/src/library/features/libraryfolder/libraryfoldermodel.cpp
+++ b/src/library/features/libraryfolder/libraryfoldermodel.cpp
@@ -13,7 +13,7 @@ LibraryFolderModel::LibraryFolderModel(LibraryFeature* pFeature,
                                        TrackCollection* pTrackCollection,
                                        UserSettingsPointer pConfig,
                                        QObject* parent)
-        : MixxxLibraryTreeModel(pFeature, pTrackCollection, pConfig, parent),
+        : TracksTreeModel(pFeature, pTrackCollection, pConfig, parent),
           m_showFolders(false) {
 
     QString recursive = m_pConfig->getValueString(
@@ -51,7 +51,7 @@ bool LibraryFolderModel::setData(
         return true;
     }
     
-    return MixxxLibraryTreeModel::setData(index, value, role);
+    return TracksTreeModel::setData(index, value, role);
 }
 
 QVariant LibraryFolderModel::data(const QModelIndex& index, int role) const {
@@ -61,9 +61,9 @@ QVariant LibraryFolderModel::data(const QModelIndex& index, int role) const {
         if (m_showFolders)
             return LIBRARYFOLDERMODEL_FOLDER;
         
-        return MixxxLibraryTreeModel::data(index, role);
+        return TracksTreeModel::data(index, role);
     } else if (role == AbstractRole::RoleBreadCrumb) {
-        return MixxxLibraryTreeModel::data(index, role);
+        return TracksTreeModel::data(index, role);
     }
     
     TreeItem* pTree = static_cast<TreeItem*>(index.internalPointer());
@@ -75,19 +75,19 @@ QVariant LibraryFolderModel::data(const QModelIndex& index, int role) const {
         // User has clicked the show all item or we are showing the library
         // instead of the folders
         if (!m_showFolders || pTree == m_pShowAll || pTree == m_pGrouping) {
-            return MixxxLibraryTreeModel::data(index, role);
+            return TracksTreeModel::data(index, role);
         }
         
         const QString param("%1:=\"%2\"");
         return param.arg("folder", pTree->getData().toString());
     }
 
-    return MixxxLibraryTreeModel::data(index, role);
+    return TracksTreeModel::data(index, role);
 }
 
 void LibraryFolderModel::createTracksTree() {
     if (!m_showFolders) {
-        MixxxLibraryTreeModel::createTracksTree();
+        TracksTreeModel::createTracksTree();
         return;
     }
     
@@ -125,7 +125,7 @@ QString LibraryFolderModel::getGroupingOptions() {
     if (m_showFolders) 
         return tr("Folders");
     
-    return MixxxLibraryTreeModel::getGroupingOptions();
+    return TracksTreeModel::getGroupingOptions();
 }
 
 void LibraryFolderModel::createTreeForLibraryDir(const QString& dir, QSqlQuery& query) {

--- a/src/library/features/libraryfolder/libraryfoldermodel.cpp
+++ b/src/library/features/libraryfolder/libraryfoldermodel.cpp
@@ -19,14 +19,14 @@ LibraryFolderModel::LibraryFolderModel(LibraryFeature* pFeature,
     QString recursive = m_pConfig->getValueString(
             ConfigKey("[Library]", LIBRARYFOLDERMODEL_RECURSIVE));
     m_folderRecursive = recursive.toInt() == 1;
-    
+
     QString showFolders = m_pConfig->getValueString(
             ConfigKey("[Library]", LIBRARYFOLDERMODEL_FOLDER));
     m_showFolders = showFolders.toInt() == 1;
-    
+
     TrackDAO& trackDAO(pTrackCollection->getTrackDAO());
     connect(&trackDAO, SIGNAL(forceModelUpdate()), this, SLOT(reloadTree()));
-    connect(&trackDAO, SIGNAL(tracksAdded(QSet<TrackId>)), 
+    connect(&trackDAO, SIGNAL(tracksAdded(QSet<TrackId>)),
             this, SLOT(reloadTree()));
     connect(&trackDAO, SIGNAL(tracksRemoved(QSet<TrackId>)),
             this, SLOT(reloadTree()));
@@ -40,17 +40,17 @@ bool LibraryFolderModel::setData(
         const QModelIndex& index, const QVariant& value, int role) {
     if (role == AbstractRole::RoleSorting) {
         QStringList sort = value.toStringList();
-        m_showFolders = sort.first() == LIBRARYFOLDERMODEL_FOLDER;        
+        m_showFolders = sort.first() == LIBRARYFOLDERMODEL_FOLDER;
         m_pConfig->set(ConfigKey("[Library]", LIBRARYFOLDERMODEL_FOLDER),
                        ConfigValue((int)m_showFolders));
-        
+
     } else if (role == AbstractRole::RoleSettings) {
         m_folderRecursive = value.toBool();
-        m_pConfig->set(ConfigKey("[Library]", "FolderRecursive"), 
+        m_pConfig->set(ConfigKey("[Library]", "FolderRecursive"),
                        ConfigValue((int)m_folderRecursive));
         return true;
     }
-    
+
     return TracksTreeModel::setData(index, value, role);
 }
 
@@ -60,24 +60,24 @@ QVariant LibraryFolderModel::data(const QModelIndex& index, int role) const {
     } else if (role == AbstractRole::RoleSorting) {
         if (m_showFolders)
             return LIBRARYFOLDERMODEL_FOLDER;
-        
+
         return TracksTreeModel::data(index, role);
     } else if (role == AbstractRole::RoleBreadCrumb) {
         return TracksTreeModel::data(index, role);
     }
-    
+
     TreeItem* pTree = static_cast<TreeItem*>(index.internalPointer());
     VERIFY_OR_DEBUG_ASSERT(pTree != nullptr) {
         return TreeItemModel::data(index, role);
     }
-    
-    if (role == AbstractRole::RoleQuery) {        
+
+    if (role == AbstractRole::RoleQuery) {
         // User has clicked the show all item or we are showing the library
         // instead of the folders
         if (!m_showFolders || pTree == m_pShowAll || pTree == m_pGrouping) {
             return TracksTreeModel::data(index, role);
         }
-        
+
         const QString param("%1:=\"%2\"");
         return param.arg("folder", pTree->getData().toString());
     }
@@ -90,7 +90,7 @@ void LibraryFolderModel::createTracksTree() {
         TracksTreeModel::createTracksTree();
         return;
     }
-    
+
     // Get the Library directories
     QStringList dirs(m_pTrackCollection->getDirectoryDAO().getDirs());
 
@@ -122,9 +122,9 @@ void LibraryFolderModel::createTracksTree() {
 }
 
 QString LibraryFolderModel::getGroupingOptions() {
-    if (m_showFolders) 
+    if (m_showFolders)
         return tr("Folders");
-    
+
     return TracksTreeModel::getGroupingOptions();
 }
 
@@ -133,17 +133,17 @@ void LibraryFolderModel::createTreeForLibraryDir(const QString& dir, QSqlQuery& 
     QList<TreeItem*> parent;
     parent.append(getRootItem());
     bool first = true;
-    
+
     while (query.next()) {
         QString location = query.value(1).toString();
         //qDebug() << location;
-        
+
         // Remove the first / character
         QString dispValue = location.mid(dir.size());
         if (dispValue.startsWith("/")) {
             dispValue = dispValue.mid(1);
         }
-        
+
         // Add a header
         if (first) {
             first = false;
@@ -156,10 +156,10 @@ void LibraryFolderModel::createTreeForLibraryDir(const QString& dir, QSqlQuery& 
         }
 
         // Do not add empty items
-        if (dispValue.isEmpty()) {    
+        if (dispValue.isEmpty()) {
             continue;
         }
-        
+
         // We always use Qt notation for folders "/"
         QStringList parts = dispValue.split("/");
         int treeDepth = parts.size();
@@ -169,30 +169,30 @@ void LibraryFolderModel::createTreeForLibraryDir(const QString& dir, QSqlQuery& 
                 parent.append(nullptr);
             }
         }
-        
+
         bool change = false;
         for (int i = 0; i < parts.size(); ++i) {
             const QString& val = parts.at(i);
             if (change || val != lastUsed.at(i)) {
                 change = true;
-                
+
                 QString fullPath = dir;
                 for (int j = 0; j <= i; ++j) {
                     fullPath += "/" + parts.at(j);
                 }
-                
+
                 if (m_folderRecursive) {
                     fullPath.append("*");
                 }
-                
+
                 TreeItem* pItem = parent[i]->appendChild(val, fullPath);
                 pItem->setTrackCount(0);
-                
+
                 parent[i + 1] = pItem;
                 lastUsed[i] = val;
             }
         }
-        
+
         // Set track count
         int val = query.value(0).toInt();
         for (int i = 1; i < treeDepth + 1; ++i) {
@@ -200,7 +200,7 @@ void LibraryFolderModel::createTreeForLibraryDir(const QString& dir, QSqlQuery& 
             if (pItem == nullptr) {
                 continue;
             }
-            
+
             pItem->setTrackCount(pItem->getTrackCount() + val);
         }
     }

--- a/src/library/features/libraryfolder/libraryfoldermodel.h
+++ b/src/library/features/libraryfolder/libraryfoldermodel.h
@@ -3,7 +3,7 @@
 
 #include <QSqlQuery>
 
-#include "library/features/mixxxlibrary/mixxxlibrarytreemodel.h"
+#include "library/features/tracks/trackstreemodel.h"
 
 class LibraryFeature;
 class TrackCollection;
@@ -11,7 +11,7 @@ class TrackCollection;
 const QString LIBRARYFOLDERMODEL_FOLDER = "$FOLDER$";
 const QString LIBRARYFOLDERMODEL_RECURSIVE = "FolderRecursive";
 
-class LibraryFolderModel : public MixxxLibraryTreeModel
+class LibraryFolderModel : public TracksTreeModel
 {
   public:
     LibraryFolderModel(LibraryFeature* pFeature, 

--- a/src/library/features/libraryfolder/libraryfoldermodel.h
+++ b/src/library/features/libraryfolder/libraryfoldermodel.h
@@ -14,21 +14,21 @@ const QString LIBRARYFOLDERMODEL_RECURSIVE = "FolderRecursive";
 class LibraryFolderModel : public TracksTreeModel
 {
   public:
-    LibraryFolderModel(LibraryFeature* pFeature, 
-                       TrackCollection* pTrackCollection, 
-                       UserSettingsPointer pConfig, 
+    LibraryFolderModel(LibraryFeature* pFeature,
+                       TrackCollection* pTrackCollection,
+                       UserSettingsPointer pConfig,
                        QObject* parent = nullptr);
-    
+
     virtual bool setData(const QModelIndex& index, const QVariant& value, int role);
     virtual QVariant data(const QModelIndex &index, int role) const;
 
   protected:
     void createTracksTree() override;
     QString getGroupingOptions() override;
-    
+
   private:
     void createTreeForLibraryDir(const QString& dir, QSqlQuery& query);
-    
+
     bool m_folderRecursive;
     bool m_showFolders;
 };

--- a/src/library/features/maintenance/dlghidden.cpp
+++ b/src/library/features/maintenance/dlghidden.cpp
@@ -9,7 +9,7 @@ DlgHidden::DlgHidden(QWidget* parent)
          : QFrame(parent),
            Ui::DlgHidden() {
     setupUi(this);
-    
+
     connect(btnSelect, SIGNAL(clicked()), this, SIGNAL(selectAll()));
     connect(btnPurge, SIGNAL(clicked()), this, SIGNAL(purge()));
     connect(btnUnhide, SIGNAL(clicked()), this, SIGNAL(unhide()));
@@ -21,7 +21,7 @@ DlgHidden::~DlgHidden() {
 void DlgHidden::onShow() {
     VERIFY_OR_DEBUG_ASSERT (!m_pHiddenTableModel.isNull())
         return;
-    
+
     m_pHiddenTableModel->select();
     // no buttons can be selected
     activateButtons(false);

--- a/src/library/features/maintenance/dlghidden.h
+++ b/src/library/features/maintenance/dlghidden.h
@@ -26,7 +26,7 @@ class DlgHidden : public QFrame, public Ui::DlgHidden {
     void onShow();
 
   signals:
-    void selectAll();  
+    void selectAll();
     void unhide();
     void purge();
     void trackSelected(TrackPointer pTrack);

--- a/src/library/features/maintenance/dlgmissing.cpp
+++ b/src/library/features/maintenance/dlgmissing.cpp
@@ -7,8 +7,8 @@
 DlgMissing::DlgMissing(QWidget* parent)
          : QFrame(parent),
            Ui::DlgMissing() {
-    setupUi(this);    
- 
+    setupUi(this);
+
     connect(btnPurge, SIGNAL(clicked()), this, SIGNAL(purge()));
     connect(btnSelect, SIGNAL(clicked()), this, SIGNAL(selectAll()));
 }
@@ -19,7 +19,7 @@ DlgMissing::~DlgMissing() {
 void DlgMissing::onShow() {
     VERIFY_OR_DEBUG_ASSERT(!m_pMissingTableModel.isNull())
         return;
-    
+
     m_pMissingTableModel->select();
     // no buttons can be selected
     activateButtons(false);

--- a/src/library/features/maintenance/dlgmissing.h
+++ b/src/library/features/maintenance/dlgmissing.h
@@ -31,7 +31,7 @@ class DlgMissing : public QFrame, public Ui::DlgMissing {
 
   private:
     void activateButtons(bool enable);
-    
+
     QPointer<MissingTableModel> m_pMissingTableModel;
 };
 

--- a/src/library/features/maintenance/hiddentablemodel.h
+++ b/src/library/features/maintenance/hiddentablemodel.h
@@ -16,7 +16,7 @@ class HiddenTableModel : public BaseSqlTableModel {
     void unhideTracks(const QModelIndexList& indices) final;
     Qt::ItemFlags flags(const QModelIndex &index) const final;
     CapabilitiesFlags getCapabilities() const final;
-    
+
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
     using QObject::parent;
 #endif

--- a/src/library/features/maintenance/maintenancefeature.cpp
+++ b/src/library/features/maintenance/maintenancefeature.cpp
@@ -22,10 +22,10 @@ MaintenanceFeature::MaintenanceFeature(UserSettingsPointer pConfig,
           m_pTab(nullptr),
           m_idExpandedHidden(-1),
           m_idExpandedMissing(-1) {
-    
+
     auto pHiddenTable = make_parented<HiddenTableModel>(this, m_pTrackCollection);
     m_pHiddenTableModel = pHiddenTable.toWeakRef();
-    
+
     auto pMissingTable = make_parented<MissingTableModel>(this, m_pTrackCollection);
     m_pMissingTableModel = pMissingTable.toWeakRef();
 }
@@ -162,7 +162,7 @@ void MaintenanceFeature::slotUnhideHidden() {
     if (pTable.isNull()) {
         return;
     }
-    
+
     pTable->slotUnhide();
 }
 
@@ -172,7 +172,7 @@ void MaintenanceFeature::slotPurge() {
         return;
     }
     pTable->slotPurge();
-    
+
     m_pMissingView->onShow();
     m_pHiddenView->onShow();
 }

--- a/src/library/features/maintenance/maintenancefeature.h
+++ b/src/library/features/maintenance/maintenancefeature.h
@@ -17,7 +17,7 @@ class MaintenanceFeature : public LibraryFeature
     Q_OBJECT
   public:
     MaintenanceFeature(UserSettingsPointer pConfig,
-                       Library* pLibrary, QObject* parent, 
+                       Library* pLibrary, QObject* parent,
                        TrackCollection* pTrackCollection);
 
     QVariant title() override;
@@ -31,7 +31,7 @@ class MaintenanceFeature : public LibraryFeature
     void selectAll();
 
   protected:
-    parented_ptr<QWidget> createInnerSidebarWidget(KeyboardEventFilter* pKeyboard, 
+    parented_ptr<QWidget> createInnerSidebarWidget(KeyboardEventFilter* pKeyboard,
                                                    QWidget* parent);
 
   private:
@@ -44,10 +44,10 @@ class MaintenanceFeature : public LibraryFeature
     const QString kMaintenanceTitle;
     const QString kHiddenTitle;
     const QString kMissingTitle;
-    
+
   private slots:
-    
-    void slotTabIndexChanged(int index);    
+
+    void slotTabIndexChanged(int index);
     void slotUnhideHidden();
     void slotPurge();
 

--- a/src/library/features/maintenance/missingtablemodel.h
+++ b/src/library/features/maintenance/missingtablemodel.h
@@ -23,7 +23,7 @@ class MissingTableModel : public BaseSqlTableModel {
     void purgeTracks(const QModelIndexList& indices) final;
     Qt::ItemFlags flags(const QModelIndex &index) const final;
     CapabilitiesFlags getCapabilities() const final;
-    
+
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
     using QObject::parent;
 #endif

--- a/src/library/features/playlist/playlistfeature.cpp
+++ b/src/library/features/playlist/playlistfeature.cpp
@@ -138,19 +138,19 @@ bool PlaylistFeature::dropAcceptChild(const QModelIndex& index, QList<QUrl> urls
             // The user has canceled
             return false;
         }
-        
+
         playlistId = m_playlistDao.createPlaylist(name);
         // An error happened
         if (playlistId < 0) {
             return false;
         }
     }
-    
+
     // Return whether appendTracksToPlaylist succeeded.
     return m_playlistDao.appendTracksToPlaylist(trackIds, playlistId);
 }
 
-bool PlaylistFeature::dragMoveAcceptChild(const QModelIndex& index, QUrl url) {    
+bool PlaylistFeature::dragMoveAcceptChild(const QModelIndex& index, QUrl url) {
     int playlistId = playlistIdFromIndex(index);
     bool locked = m_playlistDao.isPlaylistLocked(playlistId);
 
@@ -193,14 +193,14 @@ void PlaylistFeature::buildPlaylistList() {
         int count = query.value(countColumn).toInt();
         int duration = query.value(durationColumn).toInt();
         QString itemName = "%1 (%2) %3";
-        itemName = itemName.arg(name, 
+        itemName = itemName.arg(name,
                                 QString::number(count),
                                 mixxx::Duration::formatSeconds(duration));
         m_playlistList << PlaylistItem(id, itemName);
     }
 }
 
-void PlaylistFeature::decorateChild(TreeItem* item, int playlist_id) {    
+void PlaylistFeature::decorateChild(TreeItem* item, int playlist_id) {
     if (m_playlistDao.isPlaylistLocked(playlist_id)) {
         item->setIcon(QIcon(":/images/library/ic_library_locked.png"));
     } else {
@@ -209,7 +209,7 @@ void PlaylistFeature::decorateChild(TreeItem* item, int playlist_id) {
 }
 
 parented_ptr<PlaylistTableModel> PlaylistFeature::constructTableModel() {
-    return make_parented<PlaylistTableModel>(this, m_pTrackCollection, 
+    return make_parented<PlaylistTableModel>(this, m_pTrackCollection,
                                              "mixxx.db.model.playlist");
 }
 

--- a/src/library/features/playlist/playlistfeature.h
+++ b/src/library/features/playlist/playlistfeature.h
@@ -12,9 +12,9 @@ class TreeItem;
 class PlaylistFeature : public BasePlaylistFeature {
     Q_OBJECT
   public:
-    PlaylistFeature(UserSettingsPointer pConfig, 
+    PlaylistFeature(UserSettingsPointer pConfig,
                     Library* pLibrary,
-                    QObject* parent, 
+                    QObject* parent,
                     TrackCollection* pTrackCollection);
     virtual ~PlaylistFeature();
 

--- a/src/library/features/playlist/playlisttablemodel.cpp
+++ b/src/library/features/playlist/playlisttablemodel.cpp
@@ -29,7 +29,7 @@ void PlaylistTableModel::setTableModel(const QSet<int> &playlistIds) {
         qDebug() << "Already focused on playlist " << playlistIds;
         return;
     }
-    
+
     if (playlistIds.size() > 1) {
         // If we are showing many playlist at once this is not a real playlist
         m_iPlaylistId = -1;
@@ -48,7 +48,7 @@ void PlaylistTableModel::setTableModel(const QSet<int> &playlistIds) {
     	    m_pTrackCollection->getPlaylistDAO().removeHiddenTracks(playlistId);
         }
     }
-    
+
     QString playlistTableName = "playlist";
     QStringList sIds;
     for (int n : m_playlistIds) {
@@ -56,7 +56,7 @@ void PlaylistTableModel::setTableModel(const QSet<int> &playlistIds) {
         sIds << sNum;
         playlistTableName.append("_" + sNum);
     }
-    
+
     QSqlQuery query(m_database);
     FieldEscaper escaper(m_database);
 
@@ -101,7 +101,7 @@ int PlaylistTableModel::addTracks(const QModelIndex& index,
     if (locations.isEmpty()) {
         return 0;
     }
-    
+
     int position = getPosition(index);
 
     // Handle weird cases like a drag and drop to an invalid index
@@ -280,7 +280,7 @@ TrackModel::CapabilitiesFlags PlaylistTableModel::getCapabilities() const {
 
 void PlaylistTableModel::saveSelection(const QModelIndexList& selection) {
     m_savedSelectionIndices.clear();
-    
+
     for (const QModelIndex& index : selection) {
         m_savedSelectionIndices.insert(getPosition(index));
     }
@@ -299,7 +299,7 @@ QModelIndexList PlaylistTableModel::getSavedSelectionIndices() {
 
 void PlaylistTableModel::select() {
     BaseSqlTableModel::select();
-    
+
     m_positionToRow.clear();
     for (int i = 0; i < rowCount(); ++i) {
         int pos = getPosition(index(i, 0));

--- a/src/library/features/playlist/playlisttablemodel.h
+++ b/src/library/features/playlist/playlisttablemodel.h
@@ -23,10 +23,10 @@ class PlaylistTableModel : public BaseSqlTableModel {
                    const QModelIndex& destIndex);
     void removeTrack(const QModelIndex& index);
     void shuffleTracks(const QModelIndexList& shuffle, const QModelIndex& exclude);
-    
+
     void saveSelection(const QModelIndexList& selection);
     QModelIndexList getSavedSelectionIndices();
-    
+
     void select() override;
 
     bool isColumnInternal(int column) final;
@@ -38,7 +38,7 @@ class PlaylistTableModel : public BaseSqlTableModel {
     int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
     bool isLocked() final;
     CapabilitiesFlags getCapabilities() const final;
-    
+
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
     using QObject::parent;
 #endif
@@ -47,13 +47,13 @@ class PlaylistTableModel : public BaseSqlTableModel {
     void playlistChanged(int playlistId);
 
   private:
-    
+
     int getPosition(const QModelIndex& index);
-    
+
     int m_iPlaylistId;
     QSet<int> m_playlistIds;
     bool m_showAll;
-    
+
     QHash<int, int> m_positionToRow;
     QSet<int> m_savedSelectionIndices;
 };

--- a/src/library/features/recording/dlgrecording.cpp
+++ b/src/library/features/recording/dlgrecording.cpp
@@ -44,7 +44,7 @@ void DlgRecording::onShow() {
 
 void DlgRecording::setProxyTrackModel(ProxyTrackModel* pProxyModel) {
     m_pProxyModel = pProxyModel;
-    
+
     m_pProxyModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
     m_pProxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
 }

--- a/src/library/features/recording/recordingfeature.cpp
+++ b/src/library/features/recording/recordingfeature.cpp
@@ -19,10 +19,10 @@ RecordingFeature::RecordingFeature(UserSettingsPointer pConfig,
           m_pTrackCollection(pTrackCollection),
           m_pRecordingManager(pRecordingManager),
           m_pRecordingView(nullptr) {
-    
+
     m_childModel.setRootItem(std::make_unique<TreeItem>(this));
-    
-    m_pBrowseModel = make_parented<BrowseTableModel>(this, 
+
+    m_pBrowseModel = make_parented<BrowseTableModel>(this,
             m_pTrackCollection, m_pRecordingManager);
     m_pProxyModel = std::make_unique<ProxyTrackModel>(m_pBrowseModel.get());
 }
@@ -47,23 +47,23 @@ QPointer<TreeItemModel> RecordingFeature::getChildModel() {
     return &m_childModel;
 }
 
-parented_ptr<QWidget> RecordingFeature::createPaneWidget(KeyboardEventFilter*, 
+parented_ptr<QWidget> RecordingFeature::createPaneWidget(KeyboardEventFilter*,
             int paneId, QWidget* parent) {
     auto pTable = LibraryFeature::createTableWidget(paneId, parent);
-    pTable->setSorting(false);    
+    pTable->setSorting(false);
     return pTable;
 }
 
 parented_ptr<QWidget> RecordingFeature::createInnerSidebarWidget(
             KeyboardEventFilter* pKeyboard, QWidget* parent) {
-    auto pRecordingView = make_parented<DlgRecording>(parent, 
+    auto pRecordingView = make_parented<DlgRecording>(parent,
                                                       m_pTrackCollection,
                                                       m_pRecordingManager);
     m_pRecordingView = pRecordingView.toWeakRef();
     m_pRecordingView->installEventFilter(pKeyboard);
     m_pRecordingView->setBrowseTableModel(m_pBrowseModel.get());
     m_pRecordingView->setProxyTrackModel(m_pProxyModel.get());
-    
+
     return pRecordingView;
 }
 
@@ -72,10 +72,10 @@ void RecordingFeature::activate() {
     VERIFY_OR_DEBUG_ASSERT(!m_pRecordingView.isNull()) {
         return;
     }
-    
+
     m_pRecordingView->refreshBrowseModel();
     showTrackModel(m_pProxyModel.get());
     showBreadCrumb();
     restoreSearch("");
-    
+
 }

--- a/src/library/features/recording/recordingfeature.h
+++ b/src/library/features/recording/recordingfeature.h
@@ -33,9 +33,9 @@ class RecordingFeature : public LibraryFeature {
     QString getIconPath() override;
     QString getSettingsName() const override;
 
-    parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter*, int paneId, 
+    parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter*, int paneId,
                                            QWidget* parent) override;
-    parented_ptr<QWidget> createInnerSidebarWidget(KeyboardEventFilter* pKeyboard, 
+    parented_ptr<QWidget> createInnerSidebarWidget(KeyboardEventFilter* pKeyboard,
                                                    QWidget* parent) override;
 
     QPointer<TreeItemModel> getChildModel();
@@ -47,14 +47,14 @@ class RecordingFeature : public LibraryFeature {
     void setRootIndex(const QModelIndex&);
 
   private:
-    
+
     BrowseTableModel* getBrowseTableModel();
     ProxyTrackModel* getProxyTrackModel();
-    
+
     TrackCollection* m_pTrackCollection;
     FolderTreeModel m_childModel;
     RecordingManager* m_pRecordingManager;
-    
+
     QPointer<DlgRecording> m_pRecordingView;
     parented_ptr<BrowseTableModel> m_pBrowseModel;
     std::unique_ptr<ProxyTrackModel> m_pProxyModel;

--- a/src/library/features/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/features/rhythmbox/rhythmboxfeature.cpp
@@ -10,8 +10,8 @@
 #include "library/queryutil.h"
 
 RhythmboxFeature::RhythmboxFeature(UserSettingsPointer pConfig,
-                                   Library* pLibrary, 
-                                   QObject* parent, 
+                                   Library* pLibrary,
+                                   QObject* parent,
                                    TrackCollection* pTrackCollection)
         : BaseExternalLibraryFeature(pConfig, pLibrary, parent, pTrackCollection),
           m_pTrackCollection(pTrackCollection),
@@ -133,7 +133,7 @@ void RhythmboxFeature::activate() {
         //calls a slot in the sidebar model such that 'Rhythmbox (isLoading)' is displayed.
         emit (featureIsLoading(this, true));
     }
-    
+
     showTrackModel(m_pRhythmboxTrackModel);
     showBreadCrumb();
 }
@@ -143,7 +143,7 @@ void RhythmboxFeature::activateChild(const QModelIndex& index) {
     QString playlist = index.data().toString();
     qDebug() << "Activating " << playlist;
     m_pRhythmboxPlaylistModel->setPlaylist(playlist);
-    
+
     showTrackModel(m_pRhythmboxPlaylistModel);
     showBreadCrumb(index);
 }

--- a/src/library/features/rhythmbox/rhythmboxfeature.h
+++ b/src/library/features/rhythmbox/rhythmboxfeature.h
@@ -23,7 +23,7 @@ class RhythmboxFeature : public BaseExternalLibraryFeature {
  public:
     RhythmboxFeature(UserSettingsPointer pConfig,
                      Library* pLibrary,
-                     QObject* parent, 
+                     QObject* parent,
                      TrackCollection* pTrackCollection);
     virtual ~RhythmboxFeature();
     static bool isSupported();

--- a/src/library/features/tracks/tracksfeature.cpp
+++ b/src/library/features/tracks/tracksfeature.cpp
@@ -6,7 +6,7 @@
 #include <QStringList>
 #include <QVBoxLayout>
 
-#include "library/features/mixxxlibrary/mixxxlibraryfeature.h"
+#include "library/features/tracks/tracksfeature.h"
 #include "library/features/libraryfolder/libraryfoldermodel.h"
 
 #include "library/basetrackcache.h"
@@ -21,9 +21,9 @@
 #include "widget/wlibrarystack.h"
 #include "widget/wtracktableview.h"
 
-const QString MixxxLibraryFeature::kLibraryTitle = tr("Tracks");
+const QString TracksFeature::kLibraryTitle = tr("Tracks");
 
-const QStringList MixxxLibraryFeature::kGroupingText {
+const QStringList TracksFeature::kGroupingText {
     tr("Artist > Album"),
     tr("Album"),
     tr("Genre > Artist > Album"),
@@ -31,7 +31,7 @@ const QStringList MixxxLibraryFeature::kGroupingText {
     tr("Folder")
 };
 
-const QList<QStringList> MixxxLibraryFeature::kGroupingOptions {
+const QList<QStringList> TracksFeature::kGroupingOptions {
         { LIBRARYTABLE_ARTIST, LIBRARYTABLE_ALBUM },
         { LIBRARYTABLE_ALBUM },
         { LIBRARYTABLE_GENRE, LIBRARYTABLE_ARTIST, LIBRARYTABLE_ALBUM },
@@ -39,7 +39,7 @@ const QList<QStringList> MixxxLibraryFeature::kGroupingOptions {
         { LIBRARYFOLDERMODEL_FOLDER }
 };
 
-MixxxLibraryFeature::MixxxLibraryFeature(UserSettingsPointer pConfig,
+TracksFeature::TracksFeature(UserSettingsPointer pConfig,
                                          Library* pLibrary,
                                          QObject* parent,
                                          TrackCollection* pTrackCollection)
@@ -128,26 +128,26 @@ MixxxLibraryFeature::MixxxLibraryFeature(UserSettingsPointer pConfig,
             pTrackCollection, "mixxx.db.model.library");
 }
 
-MixxxLibraryFeature::~MixxxLibraryFeature() {
+TracksFeature::~TracksFeature() {
 }
 
-QVariant MixxxLibraryFeature::title() {
+QVariant TracksFeature::title() {
     return kLibraryTitle;
 }
 
-QString MixxxLibraryFeature::getIconPath() {
+QString TracksFeature::getIconPath() {
     return ":/images/library/ic_library_tracks.png";
 }
 
-QString MixxxLibraryFeature::getSettingsName() const {
+QString TracksFeature::getSettingsName() const {
     return "MixxxLibraryFeature";
 }
 
-QPointer<TreeItemModel> MixxxLibraryFeature::getChildModel() {
+QPointer<TreeItemModel> TracksFeature::getChildModel() {
     return m_pChildModel.get();
 }
 
-parented_ptr<QWidget> MixxxLibraryFeature::createInnerSidebarWidget(
+parented_ptr<QWidget> TracksFeature::createInnerSidebarWidget(
             KeyboardEventFilter*, QWidget* parent) {
     auto pSidebar = createLibrarySidebarWidget(parent);
     m_pSidebar = pSidebar.toWeakRef();
@@ -156,20 +156,20 @@ parented_ptr<QWidget> MixxxLibraryFeature::createInnerSidebarWidget(
     return pSidebar;
 }
 
-void MixxxLibraryFeature::refreshLibraryModels() {
+void TracksFeature::refreshLibraryModels() {
     if (m_pLibraryTableModel) {
         m_pLibraryTableModel->select();
     }
 }
 
-void MixxxLibraryFeature::onSearch(const QString&) {
+void TracksFeature::onSearch(const QString&) {
     showBreadCrumb();
     if (!m_pSidebar.isNull()) {
         m_pSidebar->clearSelection();
     }
 }
 
-void MixxxLibraryFeature::activate() {    
+void TracksFeature::activate() {
     if (m_lastClickedIndex.isValid()) {
         activateChild(m_lastClickedIndex);
         return;
@@ -182,7 +182,7 @@ void MixxxLibraryFeature::activate() {
     
 }
 
-void MixxxLibraryFeature::activateChild(const QModelIndex& index) {
+void TracksFeature::activateChild(const QModelIndex& index) {
     m_lastClickedIndex = index;
     
     if (!index.isValid()) return;
@@ -202,11 +202,11 @@ void MixxxLibraryFeature::activateChild(const QModelIndex& index) {
     restoreSearch(query);
 }
 
-void MixxxLibraryFeature::invalidateChild() {
+void TracksFeature::invalidateChild() {
     m_lastClickedIndex = QPersistentModelIndex();
 }
 
-void MixxxLibraryFeature::onRightClickChild(const QPoint& pos, 
+void TracksFeature::onRightClickChild(const QPoint& pos,
                                             const QModelIndex&) {
     
     // Create the sort menu
@@ -242,7 +242,7 @@ void MixxxLibraryFeature::onRightClickChild(const QPoint& pos,
     }
 }
 
-bool MixxxLibraryFeature::dropAccept(QList<QUrl> urls, QObject* pSource) {
+bool TracksFeature::dropAccept(QList<QUrl> urls, QObject* pSource) {
     if (pSource) {
         return false;
     } else {
@@ -256,12 +256,12 @@ bool MixxxLibraryFeature::dropAccept(QList<QUrl> urls, QObject* pSource) {
     }
 }
 
-bool MixxxLibraryFeature::dragMoveAccept(QUrl url) {
+bool TracksFeature::dragMoveAccept(QUrl url) {
     return SoundSourceProxy::isUrlSupported(url) ||
             Parser::isPlaylistFilenameSupported(url.toLocalFile());
 }
 
-void MixxxLibraryFeature::setTreeSettings(const QVariant& settings, 
+void TracksFeature::setTreeSettings(const QVariant& settings,
                                           AbstractRole role) {
     m_pChildModel->setData(QModelIndex(), settings, role);
     m_pChildModel->reloadTree();

--- a/src/library/features/tracks/tracksfeature.cpp
+++ b/src/library/features/tracks/tracksfeature.cpp
@@ -123,8 +123,8 @@ TracksFeature::TracksFeature(UserSettingsPointer pConfig,
             m_pChildModel.get(), SLOT(reloadTree()));
     connect(&m_trackDao, SIGNAL(tracksAdded(QSet<TrackId>)),
             m_pChildModel.get(), SLOT(reloadTree()));
-    
-    m_pLibraryTableModel = make_parented<LibraryTableModel>(this, 
+
+    m_pLibraryTableModel = make_parented<LibraryTableModel>(this,
             pTrackCollection, "mixxx.db.model.library");
 }
 
@@ -151,7 +151,7 @@ parented_ptr<QWidget> TracksFeature::createInnerSidebarWidget(
             KeyboardEventFilter*, QWidget* parent) {
     auto pSidebar = createLibrarySidebarWidget(parent);
     m_pSidebar = pSidebar.toWeakRef();
-    m_pSidebar->setIconSize(m_pChildModel->getDefaultIconSize());    
+    m_pSidebar->setIconSize(m_pChildModel->getDefaultIconSize());
     m_pChildModel->reloadTree();
     return pSidebar;
 }
@@ -174,28 +174,28 @@ void TracksFeature::activate() {
         activateChild(m_lastClickedIndex);
         return;
     }
-    
+
     //qDebug() << "MixxxLibraryFeature::activate()";
     showTrackModel(m_pLibraryTableModel.get());
     restoreSearch("");
     showBreadCrumb();
-    
+
 }
 
 void TracksFeature::activateChild(const QModelIndex& index) {
     m_lastClickedIndex = index;
-    
+
     if (!index.isValid()) return;
 
     QString query = index.data(AbstractRole::RoleQuery).toString();
     //qDebug() << "MixxxLibraryFeature::activateChild" << query;
-    
+
     if (query == "$groupingSettings$") {
         // Act as right click
         onRightClickChild(QCursor::pos(), QModelIndex());
         return;
     }
-    
+
     m_pLibraryTableModel->search(query);
     switchToFeature();
     showBreadCrumb(index.data(AbstractRole::RoleBreadCrumb).toString(), getIcon());
@@ -208,15 +208,15 @@ void TracksFeature::invalidateChild() {
 
 void TracksFeature::onRightClickChild(const QPoint& pos,
                                             const QModelIndex&) {
-    
+
     // Create the sort menu
-    QMenu menu;    
+    QMenu menu;
     QStringList currentSort = m_pChildModel->data(
             QModelIndex(), AbstractRole::RoleSorting).toStringList();
     bool recursive = m_pChildModel->data(
             QModelIndex(), AbstractRole::RoleSettings).toBool();
-    
-    
+
+
     parented_ptr<QActionGroup> orderGroup = make_parented<QActionGroup>(&menu);
     for (int i = 0; i < kGroupingOptions.size(); ++i) {
         QAction* action = menu.addAction(kGroupingText.at(i));
@@ -225,17 +225,17 @@ void TracksFeature::onRightClickChild(const QPoint& pos,
         action->setCheckable(true);
         action->setChecked(currentSort == kGroupingOptions.at(i));
     }
-    
+
     menu.addSeparator();
     QAction* folderRecursive = menu.addAction(tr("Get recursive folder search query"));
     folderRecursive->setCheckable(true);
     folderRecursive->setChecked(recursive);
-    
+
     QAction* selected = menu.exec(pos);
     if (selected == nullptr) {
         return;
     } else if (selected == folderRecursive) {
-        setTreeSettings(folderRecursive->isChecked(), 
+        setTreeSettings(folderRecursive->isChecked(),
                         AbstractRole::RoleSettings);
     } else {
         setTreeSettings(selected->data());
@@ -246,7 +246,7 @@ bool TracksFeature::dropAccept(QList<QUrl> urls, QObject* pSource) {
     if (pSource) {
         return false;
     } else {
-        QList<QFileInfo> files = 
+        QList<QFileInfo> files =
                 DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
 
         // Adds track, does not insert duplicates, handles unremoving logic.

--- a/src/library/features/tracks/tracksfeature.h
+++ b/src/library/features/tracks/tracksfeature.h
@@ -17,7 +17,7 @@
 #include <QVariant>
 
 #include "library/libraryfeature.h"
-#include "library/features/mixxxlibrary/mixxxlibrarytreemodel.h"
+#include "library/features/tracks/trackstreemodel.h"
 #include "library/dao/trackdao.h"
 #include "preferences/usersettings.h"
 
@@ -31,15 +31,15 @@ class WTrackTableView;
 class HiddenTableModel;
 class MissingTableModel;
 
-class MixxxLibraryFeature : public LibraryFeature {
+class TracksFeature : public LibraryFeature {
     Q_OBJECT
 
   public:
-    MixxxLibraryFeature(UserSettingsPointer pConfig,
+    TracksFeature(UserSettingsPointer pConfig,
                         Library* pLibrary,
                         QObject* parent,
                         TrackCollection* pTrackCollection);
-    virtual ~MixxxLibraryFeature();
+    virtual ~TracksFeature();
 
     QVariant title() override;
     QString getIconPath() override;

--- a/src/library/features/tracks/tracksfeature.h
+++ b/src/library/features/tracks/tracksfeature.h
@@ -48,7 +48,7 @@ class TracksFeature : public LibraryFeature {
     bool dropAccept(QList<QUrl> urls, QObject* pSource);
     bool dragMoveAccept(QUrl url);
     QPointer<TreeItemModel> getChildModel();
-    parented_ptr<QWidget> createInnerSidebarWidget(KeyboardEventFilter*, 
+    parented_ptr<QWidget> createInnerSidebarWidget(KeyboardEventFilter*,
                                                    QWidget* parent) override;
 
   public slots:
@@ -70,11 +70,11 @@ class TracksFeature : public LibraryFeature {
     static const QList<QStringList> kGroupingOptions;
     static const QStringList kGroupingText;
     static const QString kLibraryFolder;
-    
+
   private slots:
-    void setTreeSettings(const QVariant &settings, 
+    void setTreeSettings(const QVariant &settings,
                          AbstractRole role = AbstractRole::RoleSorting);
-    
+
   private:
     std::unique_ptr<TreeItemModel> m_pChildModel;
     QPointer<WLibrarySidebar> m_pSidebar;
@@ -83,7 +83,7 @@ class TracksFeature : public LibraryFeature {
     TrackDAO& m_trackDao;
     QPersistentModelIndex m_lastClickedIndex;
     bool m_foldersShown;
-    
+
 };
 
 #endif /* MIXXXLIBRARYFEATURE_H */

--- a/src/library/features/tracks/trackstreemodel.cpp
+++ b/src/library/features/tracks/trackstreemodel.cpp
@@ -8,7 +8,7 @@
 #include "util/stringhelper.h"
 #include "widget/wpixmapstore.h"
 
-#include "library/features/mixxxlibrary/mixxxlibrarytreemodel.h"
+#include "library/features/tracks/trackstreemodel.h"
 #include "util/db/dbconnection.h"
 
 namespace  {
@@ -17,10 +17,10 @@ namespace  {
 // changed so this is a hack to allow using coverarts in the model
 // since there's another pointer to the class there's no problem in two classes
 // coexisting.
-QHash<const MixxxLibraryTreeModel*, QHash<quint16, QModelIndex> > m_hashToIndex;
+QHash<const TracksTreeModel*, QHash<quint16, QModelIndex> > m_hashToIndex;
 }
 
-MixxxLibraryTreeModel::MixxxLibraryTreeModel(LibraryFeature* pFeature,
+TracksTreeModel::TracksTreeModel(LibraryFeature* pFeature,
                                              TrackCollection* pTrackCollection, 
                                              UserSettingsPointer pConfig,
                                              QObject* parent)
@@ -59,7 +59,7 @@ MixxxLibraryTreeModel::MixxxLibraryTreeModel(LibraryFeature* pFeature,
 }
 
 
-QVariant MixxxLibraryTreeModel::data(const QModelIndex& index, int role) const {
+QVariant TracksTreeModel::data(const QModelIndex& index, int role) const {
     if (role == AbstractRole::RoleSorting) {
         return m_sortOrder;
     }
@@ -121,7 +121,7 @@ QVariant MixxxLibraryTreeModel::data(const QModelIndex& index, int role) const {
     return TreeItemModel::data(index, role);
 }
 
-bool MixxxLibraryTreeModel::setData(const QModelIndex& index, const QVariant& value, 
+bool TracksTreeModel::setData(const QModelIndex& index, const QVariant& value,
                                     int role) {
     if (role == AbstractRole::RoleSorting) {
         m_sortOrder = value.toStringList();
@@ -133,7 +133,7 @@ bool MixxxLibraryTreeModel::setData(const QModelIndex& index, const QVariant& va
     }
 }
 
-void MixxxLibraryTreeModel::reloadTree() {    
+void TracksTreeModel::reloadTree() {
     //qDebug() << "LibraryTreeModel::reloadTracksTree";
     beginResetModel();
     // Create root item
@@ -149,7 +149,7 @@ void MixxxLibraryTreeModel::reloadTree() {
     endResetModel();
 }
 
-void MixxxLibraryTreeModel::coverFound(const QObject* requestor, int requestReference,
+void TracksTreeModel::coverFound(const QObject* requestor, int requestReference,
                                        const CoverInfo&, QPixmap pixmap, bool fromCache) {
     
     if (requestor == this && !pixmap.isNull() && !fromCache) {
@@ -163,7 +163,7 @@ void MixxxLibraryTreeModel::coverFound(const QObject* requestor, int requestRefe
     }
 }
 
-QVariant MixxxLibraryTreeModel::getQuery(TreeItem* pTree) const {
+QVariant TracksTreeModel::getQuery(TreeItem* pTree) const {
     VERIFY_OR_DEBUG_ASSERT(pTree != nullptr) {
         return "";
     }
@@ -202,7 +202,7 @@ QVariant MixxxLibraryTreeModel::getQuery(TreeItem* pTree) const {
     return result.join(" ");
 }
 
-void MixxxLibraryTreeModel::createTracksTree() {
+void TracksTreeModel::createTracksTree() {
 
     QStringList columns;
     for (const QString& col : m_sortOrder) {
@@ -322,11 +322,11 @@ void MixxxLibraryTreeModel::createTracksTree() {
     }
 }
 
-QString MixxxLibraryTreeModel::getGroupingOptions() {
+QString TracksTreeModel::getGroupingOptions() {
     return m_sortOrder.join(" > ");
 }
 
-void MixxxLibraryTreeModel::addCoverArt(const MixxxLibraryTreeModel::CoverIndex& index,
+void TracksTreeModel::addCoverArt(const TracksTreeModel::CoverIndex& index,
                                    const QSqlQuery& query, TreeItem* pTree) {
     CoverInfo c;
     c.hash = query.value(index.iCoverHash).toInt();

--- a/src/library/features/tracks/trackstreemodel.cpp
+++ b/src/library/features/tracks/trackstreemodel.cpp
@@ -13,7 +13,7 @@
 
 namespace  {
 // This is used since MixxxLibraryTreeModel inherits QAbstractItemModel
-// and since the data() method is a const method a class atribute can't be 
+// and since the data() method is a const method a class atribute can't be
 // changed so this is a hack to allow using coverarts in the model
 // since there's another pointer to the class there's no problem in two classes
 // coexisting.
@@ -21,14 +21,14 @@ QHash<const TracksTreeModel*, QHash<quint16, QModelIndex> > m_hashToIndex;
 }
 
 TracksTreeModel::TracksTreeModel(LibraryFeature* pFeature,
-                                             TrackCollection* pTrackCollection, 
+                                             TrackCollection* pTrackCollection,
                                              UserSettingsPointer pConfig,
                                              QObject* parent)
         : TreeItemModel(parent),
           m_pFeature(pFeature),
           m_pTrackCollection(pTrackCollection),
-          m_pConfig(pConfig) {    
-    
+          m_pConfig(pConfig) {
+
     QString sort = m_pConfig->getValueString(ConfigKey("[Library]", LIBRARYTREEMODEL_SORT));
     if (sort.isNull()) {
         // By default sort by Artist -> Album
@@ -36,21 +36,21 @@ TracksTreeModel::TracksTreeModel(LibraryFeature* pFeature,
     } else {
         m_sortOrder = sort.split(",");
     }
-    
+
     TrackDAO& trackDAO(pTrackCollection->getTrackDAO());
     connect(&trackDAO, SIGNAL(forceModelUpdate()), this, SLOT(reloadTree()));
-    connect(&trackDAO, SIGNAL(tracksAdded(QSet<TrackId>)), 
+    connect(&trackDAO, SIGNAL(tracksAdded(QSet<TrackId>)),
             this, SLOT(reloadTree()));
     connect(&trackDAO, SIGNAL(tracksRemoved(QSet<TrackId>)),
             this, SLOT(reloadTree()));
     connect(&trackDAO, SIGNAL(trackChanged(TrackId)),
             this, SLOT(reloadTree()));
-    
+
     m_coverQuery << LIBRARYTABLE_COVERART_HASH
-                 << LIBRARYTABLE_COVERART_LOCATION 
+                 << LIBRARYTABLE_COVERART_LOCATION
                  << LIBRARYTABLE_COVERART_SOURCE
                  << LIBRARYTABLE_COVERART_TYPE;
-    
+
     for (QString& s : m_coverQuery) {
         s.prepend("library.");
     }
@@ -63,20 +63,20 @@ QVariant TracksTreeModel::data(const QModelIndex& index, int role) const {
     if (role == AbstractRole::RoleSorting) {
         return m_sortOrder;
     }
-    
-    
+
+
     TreeItem* pTree = static_cast<TreeItem*>(index.internalPointer());
     VERIFY_OR_DEBUG_ASSERT(pTree != nullptr) {
         return TreeItemModel::data(index, role);
     }
-    
+
     if (role == AbstractRole::RoleGroupingLetter) {
         if (pTree == m_pShowAll || pTree == m_pGrouping) {
             return QChar();
         }
         return TreeItemModel::data(index, role);
     }
-    
+
     if (role == AbstractRole::RoleBreadCrumb) {
         if (pTree == m_pShowAll) {
             return m_pFeature->title();
@@ -84,32 +84,32 @@ QVariant TracksTreeModel::data(const QModelIndex& index, int role) const {
             return TreeItemModel::data(index, role);
         }
     }
-    
+
     if (role == AbstractRole::RoleQuery) {
         return getQuery(pTree);
     }
-    
+
     // The decoration role contains the icon in QTreeView
     if (role == Qt::DecorationRole) {
         // Role is decoration role, we need to show the cover art
         const CoverInfo& info = pTree->getCoverInfo();
-        
+
         // Currently we only support this two types of cover info
         if (info.type != CoverInfo::METADATA && info.type != CoverInfo::FILE) {
             return TreeItemModel::data(index, role);
         }
-        
+
         CoverArtCache* pCache = CoverArtCache::instance();
         // Set a maximum size of 32px to not use many cache
         QPixmap pixmap = pCache->requestCover(info, this, 32, false, true);
-        
+
         if (pixmap.isNull()) {
             // The icon is not in the cache so we need to wait until the
             // coverFound slot is called. Since the data function is const
             // and we cannot change that we use m_hashToIndex in an anonymous
             // namespace to store the future value that we will get
             m_hashToIndex[this].insert(info.type, index);
-            
+
             // Return a temporary icon
             return QIcon(":/images/library/cover_default.png");
         } else {
@@ -117,7 +117,7 @@ QVariant TracksTreeModel::data(const QModelIndex& index, int role) const {
             return QIcon(pixmap);
         }
     }
-    
+
     return TreeItemModel::data(index, role);
 }
 
@@ -143,7 +143,7 @@ void TracksTreeModel::reloadTree() {
 
     QString groupTitle = tr("Grouping Options (%1)").arg(getGroupingOptions());
     m_pGrouping = parented_ptr<TreeItem>(pRootItem->appendChild(groupTitle, ""));
-    
+
     // Deletes the old root item if the previous root item was not null
     createTracksTree();
     endResetModel();
@@ -151,13 +151,13 @@ void TracksTreeModel::reloadTree() {
 
 void TracksTreeModel::coverFound(const QObject* requestor, int requestReference,
                                        const CoverInfo&, QPixmap pixmap, bool fromCache) {
-    
+
     if (requestor == this && !pixmap.isNull() && !fromCache) {
         auto it = m_hashToIndex[this].find(requestReference);
         if (it == m_hashToIndex[this].end()) {
             return;
         }
-        
+
         const QModelIndex& index = *it;
         emit(dataChanged(index, index));
     }
@@ -167,25 +167,25 @@ QVariant TracksTreeModel::getQuery(TreeItem* pTree) const {
     VERIFY_OR_DEBUG_ASSERT(pTree != nullptr) {
         return "";
     }
-    
+
     if (pTree == m_pShowAll) {
         return "";
     } else if (pTree == m_pGrouping) {
         return "$groupingSettings$";
     }
-    
+
     const QString param("%1:=\"%2\"");
-    
+
     int depth = 0;
     TreeItem* pAux = pTree;
     QStringList result;
-    
+
     // We need to know the depth before doing anything
     while (pAux->parent() != getRootItem() && pAux->parent() != nullptr) {
         pAux = pAux->parent();
         ++depth;
     }
-    
+
     // Generate the query
     pAux = pTree;
     while (depth >= 0) {
@@ -194,11 +194,11 @@ QVariant TracksTreeModel::getQuery(TreeItem* pTree) const {
             value.append("*");
         }
         result << param.arg(m_sortOrder[depth], value);
-        
+
         pAux = pAux->parent();
         --depth;
-    }    
-    
+    }
+
     return result.join(" ");
 }
 
@@ -208,7 +208,7 @@ void TracksTreeModel::createTracksTree() {
     for (const QString& col : m_sortOrder) {
         columns << "library." + col;
     }
-    
+
     QStringList sortColumns;
 #ifdef __SQLITE3__
     for (const QString& col : m_sortOrder) {
@@ -217,8 +217,8 @@ void TracksTreeModel::createTracksTree() {
 #else
     sortColumns = m_sortOrder;
 #endif
-    
-    // Sorting is required to create the tree because the tree is sorted and 
+
+    // Sorting is required to create the tree because the tree is sorted and
     // in order to create a tree with levels it must be sorted too.
     QString queryStr = "SELECT COUNT(%3),%1,%2 "
                        "FROM library LEFT JOIN track_locations "
@@ -226,14 +226,14 @@ void TracksTreeModel::createTracksTree() {
                        "WHERE %5 != 1 AND  %7 != 1 "
                        "GROUP BY %2 "
                        "ORDER BY %6 ";
-    queryStr = queryStr.arg(m_coverQuery.join(","), 
-                            columns.join(","), 
+    queryStr = queryStr.arg(m_coverQuery.join(","),
+                            columns.join(","),
                             "library." + LIBRARYTABLE_ID,
                             "track_locations." + TRACKLOCATIONSTABLE_ID,
                             "library." + LIBRARYTABLE_MIXXXDELETED,
                             sortColumns.join(","),
                             "track_locations." + TRACKLOCATIONSTABLE_FSDELETED);
-        
+
 
     QSqlQuery query(m_pTrackCollection->database());
     query.prepare(queryStr);
@@ -243,13 +243,13 @@ void TracksTreeModel::createTracksTree() {
         return;
     }
     //qDebug() << "LibraryTreeModel::createTracksTree" << query.executedQuery();
-    
+
     int treeDepth = columns.size();
     if (treeDepth <= 0) {
         return;
     }
     QSqlRecord record = query.record();
-    
+
     int iAlbum = record.indexOf(LIBRARYTABLE_ALBUM);
     CoverIndex cIndex;
     cIndex.iCoverHash = record.indexOf(LIBRARYTABLE_COVERART_HASH);
@@ -257,7 +257,7 @@ void TracksTreeModel::createTracksTree() {
     cIndex.iCoverSrc = record.indexOf(LIBRARYTABLE_COVERART_SOURCE);
     cIndex.iCoverType = record.indexOf(LIBRARYTABLE_COVERART_TYPE);
     cIndex.iTrackLoc = record.indexOf(TRACKLOCATIONSTABLE_LOCATION);
-    
+
     int treeStartQueryIndex = m_coverQuery.size() + 1;
     QVector<QString> lastUsed(treeDepth);
     QChar lastHeader;
@@ -266,49 +266,49 @@ void TracksTreeModel::createTracksTree() {
     // depth i and to set the parent we avoid checking that i + 1 < treeDepth
     QVector<TreeItem*> parent(treeDepth + 1, nullptr);
     parent[0] = getRootItem();
-    
+
     while (query.next()) {
         for (int i = 0; i < treeDepth; ++i) {
             QString treeItemLabel = query.value(treeStartQueryIndex + i).toString();
             QString dataPath = treeItemLabel;
-            
+
             bool unknown = dataPath.isNull();
             if (unknown) {
                 dataPath = "";
                 treeItemLabel = tr("Unknown");
-            }            
-            if (!lastUsed[i].isNull() && dataPath.localeAwareCompare(lastUsed[i]) == 0) {                
+            }
+            if (!lastUsed[i].isNull() && dataPath.localeAwareCompare(lastUsed[i]) == 0) {
                 continue;
             }
 
             if (i == 0 && !unknown) {
                 // If a new top level is added all the following levels must be
-                // reset 
+                // reset
                 lastUsed.fill(QString());
-                
+
                 // Check if a header must be added
                 QChar c = StringHelper::getFirstCharForGrouping(treeItemLabel);
                 if (lastHeader != c) {
                     lastHeader = c;
-                    TreeItem* pTree = 
+                    TreeItem* pTree =
                         parent[0]->appendChild(lastHeader, lastHeader);
                     pTree->setDivider(true);
-                }   
+                }
             }
-            
+
             lastUsed[i] = dataPath;
-            
+
             // We need to create a new item
             TreeItem* pTree = parent[i]->appendChild(treeItemLabel, dataPath);
             pTree->setTrackCount(0);
             parent[i + 1] = pTree;
-            
+
             // Add coverart info
             if (treeStartQueryIndex + i == iAlbum) {
                 addCoverArt(cIndex, query, pTree);
             }
         }
-        
+
         // Set track count
         int val = query.value(0).toInt();
         for (int i = 1; i < treeDepth + 1; ++i) {
@@ -316,7 +316,7 @@ void TracksTreeModel::createTracksTree() {
             if (pTree == nullptr) {
                 continue;
             }
-            
+
             pTree->setTrackCount(pTree->getTrackCount() + val);
         }
     }
@@ -332,7 +332,7 @@ void TracksTreeModel::addCoverArt(const TracksTreeModel::CoverIndex& index,
     c.hash = query.value(index.iCoverHash).toInt();
     c.coverLocation = query.value(index.iCoverLoc).toString();
     c.trackLocation = query.value(index.iTrackLoc).toString();
-    
+
     quint16 source = query.value(index.iCoverSrc).toInt();
     quint16 type = query.value(index.iCoverType).toInt();
     c.source = static_cast<CoverInfo::Source>(source);

--- a/src/library/features/tracks/trackstreemodel.h
+++ b/src/library/features/tracks/trackstreemodel.h
@@ -19,28 +19,28 @@ class TracksTreeModel : public TreeItemModel {
     Q_OBJECT
   public:
     TracksTreeModel(LibraryFeature* pFeature,
-                          TrackCollection* pTrackCollection, 
+                          TrackCollection* pTrackCollection,
                           UserSettingsPointer pConfig,
                           QObject* parent = nullptr);
 
     virtual QVariant data(const QModelIndex& index, int role) const;
     virtual bool setData(const QModelIndex& index, const QVariant& value, int role);
-    
-  public slots:  
+
+  public slots:
     void reloadTree() override;
-    
+
   protected:
     virtual void createTracksTree();
     virtual QString getGroupingOptions();
-    
+
     parented_ptr<TreeItem> m_pGrouping;
     parented_ptr<TreeItem> m_pShowAll;
-    
+
     LibraryFeature* m_pFeature;
     TrackCollection* m_pTrackCollection;
     UserSettingsPointer m_pConfig;
-  
-  private:  
+
+  private:
     struct CoverIndex {
         int iCoverHash;
         int iCoverLoc;
@@ -48,16 +48,16 @@ class TracksTreeModel : public TreeItemModel {
         int iCoverSrc;
         int iCoverType;
     };
-    
+
   private slots:
     void coverFound(const QObject* requestor, int requestReference, const CoverInfo&,
                     QPixmap pixmap, bool fromCache);
-    
-  private:    
+
+  private:
     QVariant getQuery(TreeItem* pTree) const;
     void addCoverArt(const CoverIndex& index, const QSqlQuery& query, TreeItem* pTree);
-    
-    
+
+
     QStringList m_sortOrder;
     QStringList m_coverQuery;
 };

--- a/src/library/features/tracks/trackstreemodel.h
+++ b/src/library/features/tracks/trackstreemodel.h
@@ -15,10 +15,10 @@ class TrackCollection;
 
 const QString LIBRARYTREEMODEL_SORT = "LibraryTree_Sort"; // ConfigValue key for Library Tree Model sort
 
-class MixxxLibraryTreeModel : public TreeItemModel {
+class TracksTreeModel : public TreeItemModel {
     Q_OBJECT
   public:
-    MixxxLibraryTreeModel(LibraryFeature* pFeature, 
+    TracksTreeModel(LibraryFeature* pFeature,
                           TrackCollection* pTrackCollection, 
                           UserSettingsPointer pConfig,
                           QObject* parent = nullptr);

--- a/src/library/features/traktor/traktorfeature.cpp
+++ b/src/library/features/traktor/traktorfeature.cpp
@@ -49,7 +49,7 @@ bool TraktorPlaylistModel::isColumnHiddenByDefault(int column) {
 }
 
 TraktorFeature::TraktorFeature(UserSettingsPointer pConfig,
-                               Library* pLibrary, 
+                               Library* pLibrary,
                                QObject* parent, TrackCollection* pTrackCollection)
         : BaseExternalLibraryFeature(pConfig, pLibrary, parent, pTrackCollection),
           m_pTrackCollection(pTrackCollection),
@@ -160,7 +160,7 @@ void TraktorFeature::activate() {
         //calls a slot in the sidebar model such that 'iTunes (isLoading)' is displayed.
         emit(featureIsLoading(this, true));
     }
-    
+
     showTrackModel(m_pTraktorTableModel);
     showBreadCrumb();
 }
@@ -175,7 +175,7 @@ void TraktorFeature::activateChild(const QModelIndex& index) {
     if (item->isPlaylist()) {
         qDebug() << "Activate Traktor Playlist: " << item->getData().toString();
         m_pTraktorPlaylistModel->setPlaylist(item->getData().toString());
-        
+
         showTrackModel(m_pTraktorPlaylistModel);
         showBreadCrumb(item);
     }

--- a/src/library/features/traktor/traktorfeature.h
+++ b/src/library/features/traktor/traktorfeature.h
@@ -40,7 +40,7 @@ class TraktorFeature : public BaseExternalLibraryFeature {
   public:
     TraktorFeature(UserSettingsPointer pConfig,
                    Library* pLibrary,
-                   QObject* parent, 
+                   QObject* parent,
                    TrackCollection* pTrackCollection);
     virtual ~TraktorFeature();
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -107,7 +107,7 @@ Library::Library(
     // Refresh the library models when the library (re)scan is finished.
     connect(&m_scanner, SIGNAL(scanFinished()),
             this, SLOT(slotRefreshLibraryModels()));
-    
+
     createTrackCache();
     createFeatures(pConfig, pPlayerManager, pRecordingManager);
 
@@ -157,10 +157,10 @@ void Library::bindSearchBar(WSearchLineEdit* searchLine, int id) {
     pPane->bindSearchBar(searchLine);
 }
 
-void Library::bindSidebarButtons(WButtonBar* sidebar) {    
+void Library::bindSidebarButtons(WButtonBar* sidebar) {
     for (LibraryFeature* f : m_features) {
         WFeatureClickButton* button = sidebar->addButton(f);
-        
+
         connect(button, SIGNAL(clicked(LibraryFeature*)),
                 this, SLOT(slotActivateFeature(LibraryFeature*)));
         connect(button, SIGNAL(hoverShow(LibraryFeature*)),
@@ -180,14 +180,14 @@ void Library::bindSidebarButtons(WButtonBar* sidebar) {
 
 void Library::bindPaneWidget(WLibraryPane* pPaneWidget,
                              KeyboardEventFilter* pKeyboard, int paneId) {
-    
+
     // Get the value once to avoid searching again in the hash
     LibraryPaneManager* pPane = getOrCreatePane(paneId);
     if (pPane == nullptr) {
         return;
     }
-    pPane->bindPaneWidget(pPaneWidget, pKeyboard); 
-    
+    pPane->bindPaneWidget(pPaneWidget, pKeyboard);
+
     // Set the current font and row height on all the WTrackTableViews that were
     // just connected to us.
     emit(setTrackTableFont(m_trackTableFont));
@@ -198,7 +198,7 @@ void Library::bindSidebarExpanded(WBaseLibrary* expandedPane,
                                   KeyboardEventFilter* pKeyboard) {
     //qDebug() << "Library::bindSidebarExpanded";
     m_pSidebarExpanded = std::make_unique<LibrarySidebarExpandedManager>(this);
-    m_pSidebarExpanded->addFeatures(m_features);    
+    m_pSidebarExpanded->addFeatures(m_features);
     m_pSidebarExpanded->bindPaneWidget(expandedPane, pKeyboard);
 }
 
@@ -211,11 +211,11 @@ void Library::bindBreadCrumb(WLibraryBreadCrumb* pBreadCrumb, int paneId) {
 void Library::destroyInterface() {
     m_pSidebarExpanded->deleteLater();
     m_pSidebarExpanded.reset(nullptr);
-    
+
     for (LibraryPaneManager* p : m_panes) {
         p->deleteLater();
     }
-    
+
     for (LibraryFeature* f : m_features) {
         f->setFeaturePaneId(-1);
     }
@@ -265,7 +265,7 @@ void Library::switchToFeature(LibraryFeature* pFeature) {
     if (m_pSidebarExpanded) {
         m_pSidebarExpanded->switchToFeature(pFeature);
     }
-    
+
     LibraryPaneManager* pPane = getPreselectedPane();
     if (pPane == nullptr) {
         // No pane is preselected so we are handling an activateChild() method
@@ -274,7 +274,7 @@ void Library::switchToFeature(LibraryFeature* pFeature) {
         handleFocus();
         pPane = getFocusedPane();
     }
-    
+
     pPane->switchToFeature(pFeature);
     m_preselectedPane = -1;
     handlePreselection();
@@ -285,7 +285,7 @@ void Library::showBreadCrumb(int paneId, TreeItem *pTree) {
     VERIFY_OR_DEBUG_ASSERT(pPane) {
         return;
     }
-    
+
     pPane->showBreadCrumb(pTree);
 }
 
@@ -294,7 +294,7 @@ void Library::showBreadCrumb(int paneId, const QString &text, const QIcon &icon)
     VERIFY_OR_DEBUG_ASSERT(pPane) {
         return;
     }
-    
+
     pPane->showBreadCrumb(text, icon);
 }
 
@@ -335,7 +335,7 @@ void Library::paneFocused(LibraryPaneManager* pPane) {
     VERIFY_OR_DEBUG_ASSERT(pPane) {
         return;
     }
-    
+
     if (pPane != m_pSidebarExpanded.get()) {
         m_focusedPaneId = pPane->getPaneId();
         pPane->getCurrentFeature()->setFeaturePaneId(m_focusedPaneId);
@@ -344,7 +344,7 @@ void Library::paneFocused(LibraryPaneManager* pPane) {
         }
         handleFocus();
     }
-    
+
     //qDebug() << "Library::slotPaneFocused" << m_focusedPane;
 }
 
@@ -384,11 +384,11 @@ void Library::onSkinLoadFinished() {
     // Enable the default selection when a new skin is loaded.
     //m_pSidebarModel->activateDefaultSelection();
     if (m_panes.size() > 0) {
-        
+
         auto itF = m_features.begin();
         auto itP = m_panes.begin();
         bool first = true;
-        
+
         // Assign a feature to show on each pane unless there are more panes
         // than features
         while (itP != m_panes.end() && itF != m_features.end()) {
@@ -400,17 +400,17 @@ void Library::onSkinLoadFinished() {
                     pFeature->setFeaturePaneId(m_preselectedPane);
                 }
             }
-            
+
             m_savedFeatures[m_preselectedPane] = *itF;
             (*itP)->setCurrentFeature(*itF);
-            
+
             (*itF)->setFeaturePaneId(m_preselectedPane);
             (*itF)->activate();
-            
+
             ++itP;
             ++itF;
         }
-        
+
         // The first pane always shows the Mixxx Library feature on start
         m_preselectedPane = m_focusedPaneId = m_panes.begin().key();
         handleFocus();
@@ -498,14 +498,14 @@ QStringList Library::getDirs() {
 
 void Library::paneCollapsed(int paneId) {
     m_collapsedPanes.insert(paneId);
-    
+
     // Automatically switch the focus to a non collapsed pane
     LibraryPaneManager* pPane = m_panes.value(paneId);
     if (pPane) {
         pPane->setFocused(false);
     }
 
-    
+
     bool focused = false;
     for (LibraryPaneManager* pPane : m_panes) {
         int auxId = pPane->getPaneId();
@@ -514,7 +514,7 @@ void Library::paneCollapsed(int paneId) {
             pPane->setFocused(true);
             focused = true;
         }
-        
+
         // Save the current feature from all panes
         m_savedFeatures[auxId] = pPane->getCurrentFeature();
     }
@@ -522,7 +522,7 @@ void Library::paneCollapsed(int paneId) {
 
 void Library::paneUncollapsed(int paneId) {
     m_collapsedPanes.remove(paneId);
-    
+
     // If the current shown feature in some pane is the same as the uncollapsed
     // pane feature, switch the feature from one pane to the other and set
     // instead the saved feature
@@ -535,7 +535,7 @@ void Library::paneUncollapsed(int paneId) {
         return;
     }
     pFeature->setFeaturePaneId(pPane->getPaneId());
-    
+
     for (LibraryPaneManager* pPane : m_panes) {
         int auxId = pPane->getPaneId();
         if (auxId != paneId && pFeature == pPane->getCurrentFeature()) {
@@ -544,7 +544,7 @@ void Library::paneUncollapsed(int paneId) {
             pSaved->setFeaturePaneId(auxId);
             pSaved->activate();
         }
-    }    
+    }
 }
 
 void Library::slotActivateFeature(LibraryFeature* pFeature) {
@@ -553,7 +553,7 @@ void Library::slotActivateFeature(LibraryFeature* pFeature) {
         // No pane is preselected, use the saved pane instead
         selectedPane  = pFeature->getFeaturePaneId();
     }
-    
+
     bool featureActivated = false;
     LibraryPaneManager* pSelectedPane = m_panes.value(selectedPane);
     if (pSelectedPane) {
@@ -565,7 +565,7 @@ void Library::slotActivateFeature(LibraryFeature* pFeature) {
             featureActivated = true;
         }
     }
-    
+
     if (!featureActivated) {
         // Feature already in a pane, we need only switch the SidebarExpanded
         if (m_pSidebarExpanded) {
@@ -637,22 +637,22 @@ LibraryPaneManager* Library::getOrCreatePane(int paneId) {
     if (pPane) {
         return pPane;
     }
-    
+
     // The paneId must be non negative
     VERIFY_OR_DEBUG_ASSERT(paneId >= 0) {
         return nullptr;
     }
-    
+
     // Create a new pane only if there are more features than panes
     if (m_panes.size() >= m_features.size()) {
         qWarning() << "Library: there are more panes declared than features";
         return nullptr;
     }
-    
+
     pPane = new LibraryPaneManager(paneId, this);
     pPane->addFeatures(m_features);
     m_panes.insert(paneId, pPane);
-    
+
     m_focusedPaneId = paneId;
     return pPane;
 }
@@ -742,15 +742,15 @@ void Library::createFeatures(
 
     addFeature(new AutoDJFeature(
             pConfig, this, this, pPlayerManager, m_pTrackCollection));
-    
+
     m_pPlaylistFeature = new PlaylistFeature(
             pConfig, this, this, m_pTrackCollection);
     addFeature(m_pPlaylistFeature);
-    
+
     m_pCrateFeature = new CrateFeature(
             pConfig, this, this, m_pTrackCollection);
     addFeature(m_pCrateFeature);
-    
+
     BrowseFeature* browseFeature = new BrowseFeature(
 			pConfig, this, this, m_pTrackCollection, pRecordingManager);
     connect(browseFeature, SIGNAL(scanLibrary()),
@@ -763,9 +763,9 @@ void Library::createFeatures(
 
     addFeature(new RecordingFeature(
 			pConfig, this, this, m_pTrackCollection, pRecordingManager));
-    
+
     addFeature(new HistoryFeature(pConfig, this, this, m_pTrackCollection));
-    
+
     m_pAnalysisFeature = new AnalysisFeature(
 			pConfig, this, m_pTrackCollection, this);
     connect(m_pPlaylistFeature, SIGNAL(analyzeTracks(QList<TrackId>)),
@@ -773,7 +773,7 @@ void Library::createFeatures(
     connect(m_pCrateFeature, SIGNAL(analyzeTracks(QList<TrackId>)),
             m_pAnalysisFeature, SLOT(analyzeTracks(QList<TrackId>)));
     addFeature(m_pAnalysisFeature);
-    
+
     //iTunes and Rhythmbox should be last until we no longer have an obnoxious
     //messagebox popup when you select them. (This forces you to reach for your
     //mouse or keyboard if you're using MIDI control and you scroll through them...)
@@ -796,7 +796,7 @@ void Library::createFeatures(
         pConfig->getValue(ConfigKey("[Library]","ShowTraktorLibrary"), true)) {
         addFeature(new TraktorFeature(pConfig, this, this, m_pTrackCollection));
     }
-    
+
     addFeature(new MaintenanceFeature(pConfig, this, this, m_pTrackCollection));
 }
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -20,7 +20,7 @@
 #include "library/features/history/historyfeature.h"
 #include "library/features/itunes/itunesfeature.h"
 #include "library/features/maintenance/maintenancefeature.h"
-#include "library/features/mixxxlibrary/mixxxlibraryfeature.h"
+#include "library/features/tracks/tracksfeature.h"
 #include "library/features/playlist/playlistfeature.h"
 #include "library/features/recording/recordingfeature.h"
 #include "library/features/rhythmbox/rhythmboxfeature.h"
@@ -70,7 +70,7 @@ Library::Library(
     : m_pConfig(pConfig),
       m_pDbConnectionPool(pDbConnectionPool),
       m_pTrackCollection(new TrackCollection(m_pConfig)),
-      m_pMixxxLibraryFeature(nullptr),
+      m_pTracksFeature(nullptr),
       m_pPlaylistFeature(nullptr),
       m_pCrateFeature(nullptr),
       m_pAnalysisFeature(nullptr),
@@ -368,7 +368,7 @@ int Library::getPreselectedPaneId() {
 }
 
 void Library::slotRefreshLibraryModels() {
-   m_pMixxxLibraryFeature->refreshLibraryModels();
+    m_pTracksFeature->refreshLibraryModels();
    m_pAnalysisFeature->refreshLibraryModels();
 }
 
@@ -736,9 +736,9 @@ void Library::createFeatures(
         UserSettingsPointer pConfig,
         PlayerManagerInterface* pPlayerManager,
         RecordingManager* pRecordingManager) {
-    m_pMixxxLibraryFeature = new MixxxLibraryFeature(
+    m_pTracksFeature = new TracksFeature(
             pConfig, this, this, m_pTrackCollection);
-    addFeature(m_pMixxxLibraryFeature);
+    addFeature(m_pTracksFeature);
 
     addFeature(new AutoDJFeature(
             pConfig, this, this, pPlayerManager, m_pTrackCollection));

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -49,9 +49,9 @@ public:
         HideTracks,
         PurgeTracks
     };
-    
+
     static const int kDefaultRowHeightPx;
-    
+
     static const QString kConfigGroup;
 
     static const ConfigKey kConfigKeyRepairDatabaseOnNextRestart;
@@ -65,21 +65,21 @@ public:
     mixxx::DbConnectionPoolPtr dbConnectionPool() const {
         return m_pDbConnectionPool;
     }
-    
+
     void bindSearchBar(WSearchLineEdit* searchLine, int id);
     void bindSidebarButtons(WButtonBar* sidebar);
     void bindPaneWidget(WLibraryPane *libraryWidget,
                         KeyboardEventFilter* pKeyboard, int paneId);
-    void bindSidebarExpanded(WBaseLibrary *expandedPane, 
+    void bindSidebarExpanded(WBaseLibrary *expandedPane,
                              KeyboardEventFilter* pKeyboard);
     void bindBreadCrumb(WLibraryBreadCrumb *pBreadCrumb, int paneId);
 
     void destroyInterface();
     LibraryView* getActiveView();
-    
+
     void addFeature(LibraryFeature* feature);
     QStringList getDirs();
-    
+
     void paneCollapsed(int paneId);
     void paneUncollapsed(int paneId);
 
@@ -90,7 +90,7 @@ public:
     inline const QFont& getTrackTableFont() const {
         return m_trackTableFont;
     }
-    
+
     void switchToFeature(LibraryFeature* pFeature);
     void showBreadCrumb(int paneId, TreeItem* pTree);
     void showBreadCrumb(int paneId, const QString& text, const QIcon& icon);
@@ -98,17 +98,17 @@ public:
     void restoreSaveButton(int paneId);
     void paneFocused(LibraryPaneManager *pPane);
     void panePreselected(LibraryPaneManager* pPane, bool value);
-    
+
     int getFocusedPaneId();
     int getPreselectedPaneId();
 
     void focusSearch();
 
   public slots:
-    
+
     void slotActivateFeature(LibraryFeature* pFeature);
     void slotHoverFeature(LibraryFeature* pFeature);
-    
+
     // Updates the focus from the feature before changing the view
     void slotLoadTrack(TrackPointer pTrack);
     void slotLoadTrackToPlayer(TrackPointer pTrack, QString group, bool play);
@@ -122,7 +122,7 @@ public:
     void onSkinLoadFinished();
     void slotSetTrackTableFont(const QFont& font);
     void slotSetTrackTableRowHeight(int rowHeight);
-    
+
     void slotSetHoveredFeature(LibraryFeature* pFeature);
     void slotResetHoveredFeature(LibraryFeature* pFeature);
     void slotSetFocusedFeature(LibraryFeature* pFeature);
@@ -135,7 +135,7 @@ public:
   signals:
     void loadTrack(TrackPointer pTrack);
     void loadTrackToPlayer(TrackPointer pTrack, QString group, bool play = false);
-    
+
     // emit this signal to enable/disable the cover art widget
     void enableCoverArtDisplay(bool);
     void trackSelected(TrackPointer pTrack);
@@ -148,21 +148,21 @@ public:
     void scanFinished();
 
   private:
-    
+
     // If the pane exists returns it, otherwise it creates the pane
     LibraryPaneManager* getOrCreatePane(int paneId);
     LibraryPaneManager* getFocusedPane();
     LibraryPaneManager* getPreselectedPane();
-    
+
     void createTrackCache();
     void createFeatures(
             UserSettingsPointer pConfig,
             PlayerManagerInterface *pPlayerManager,
             RecordingManager* pRecordingManager);
-    
+
     void handleFocus();
     void handlePreselection();
-    
+
     const UserSettingsPointer m_pConfig;
 
     // The Mixxx database connection pool
@@ -178,7 +178,7 @@ public:
     QFont m_trackTableFont;
     int m_iTrackTableRowHeight;
     QScopedPointer<ControlObject> m_pKeyNotation;
-    
+
     QHash<int, LibraryPaneManager*> m_panes;
     std::unique_ptr<LibrarySidebarExpandedManager> m_pSidebarExpanded;
     QList<LibraryFeature*> m_features;
@@ -187,7 +187,7 @@ public:
     // Used to show the preselected pane when the mouse is over the button
     LibraryFeature* m_hoveredFeature;
     LibraryFeature* m_focusedFeature;
-    
+
     // Can be any integer as it's used with a HashMap
     int m_focusedPaneId;
     int m_preselectedPane;

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -29,7 +29,7 @@ class LibraryControl;
 class LibraryFeature;
 class LibrarySidebarExpandedManager;
 class LibraryView;
-class MixxxLibraryFeature;
+class TracksFeature;
 class PlaylistFeature;
 class PlayerManagerInterface;
 class TrackCollection;
@@ -169,7 +169,7 @@ public:
     const mixxx::DbConnectionPoolPtr m_pDbConnectionPool;
 
     TrackCollection* m_pTrackCollection;
-    MixxxLibraryFeature* m_pMixxxLibraryFeature;
+    TracksFeature* m_pTracksFeature;
     PlaylistFeature* m_pPlaylistFeature;
     CrateFeature* m_pCrateFeature;
     AnalysisFeature* m_pAnalysisFeature;

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -27,7 +27,7 @@
 // KEEP THIS cpp file to tell scons that moc should be called on the class!!!
 // The reason for this is that LibraryFeature uses slots/signals and for this
 // to work the code has to be precompiled by moc
-LibraryFeature::LibraryFeature(UserSettingsPointer pConfig, 
+LibraryFeature::LibraryFeature(UserSettingsPointer pConfig,
                                Library* pLibrary,
                                TrackCollection* pTrackCollection,
                                QObject* parent)
@@ -50,7 +50,7 @@ bool LibraryFeature::isSinglePane() const {
     return true;
 }
 
-QIcon LibraryFeature::getIcon() {    
+QIcon LibraryFeature::getIcon() {
     return WPixmapStore::getLibraryIcon(getIconPath());
 }
 
@@ -66,7 +66,7 @@ bool LibraryFeature::dragMoveAcceptChild(const QModelIndex &, QUrl) {
     return false;
 }
 
-parented_ptr<QWidget> LibraryFeature::createPaneWidget(KeyboardEventFilter* pKeyboard, 
+parented_ptr<QWidget> LibraryFeature::createPaneWidget(KeyboardEventFilter* pKeyboard,
                                           int paneId, QWidget* parent) {
     Q_UNUSED(pKeyboard);
     return createTableWidget(paneId, parent);
@@ -76,30 +76,30 @@ parented_ptr<QWidget> LibraryFeature::createSidebarWidget(KeyboardEventFilter* p
     //qDebug() << "LibraryFeature::bindSidebarWidget";
     auto pContainer = make_parented<QFrame>(parent);
     pContainer->setContentsMargins(0,0,0,0);
-    
+
     auto pLayout = make_parented<QVBoxLayout>(pContainer.get());
     pLayout->setContentsMargins(0,0,0,0);
     pLayout->setSpacing(0);
     pContainer->setLayout(pLayout.get());
-    
+
     // Note: cannot set directly set pLayout as parent, because it is not a QWidget
     auto pLayoutTitle = std::make_unique<QHBoxLayout>();
-    
+
     auto pIcon = make_parented<QLabel>(pContainer.get());
     int height = pIcon->fontMetrics().height();
     pIcon->setPixmap(getIcon().pixmap(height));
     pLayoutTitle->addWidget(pIcon.get());
-    
+
     auto pTitle = make_parented<QLabel>(title().toString(), pContainer.get());
     pLayoutTitle->addWidget(pTitle.get());
-    pLayoutTitle->addSpacerItem(new QSpacerItem(0, 0, 
-                                                QSizePolicy::Expanding, 
+    pLayoutTitle->addSpacerItem(new QSpacerItem(0, 0,
+                                                QSizePolicy::Expanding,
                                                 QSizePolicy::Minimum));
     pLayout->addLayout(pLayoutTitle.release());
-    
+
     auto pSidebar = createInnerSidebarWidget(pKeyboard, pContainer.get());
     pLayout->addWidget(pSidebar.get());
-    
+
     return pContainer;
 }
 
@@ -130,7 +130,7 @@ SavedSearchQuery LibraryFeature::saveQuery(SavedSearchQuery sQuery) {
     if (pTable == nullptr) {
         return SavedSearchQuery();
     }
-    
+
     sQuery = pTable->saveQuery(sQuery);
     int qId = m_savedDAO.getQueryId(sQuery);
     if (qId >= 0) {
@@ -145,17 +145,17 @@ SavedSearchQuery LibraryFeature::saveQuery(SavedSearchQuery sQuery) {
         box.addButton(QMessageBox::No);
         box.setDefaultButton(QMessageBox::Yes);
         box.setEscapeButton(QMessageBox::No);
-        
+
         if (box.exec() == QMessageBox::No) {
             // No pressed
             m_savedDAO.moveToFirst(this, qId);
             return sQuery;
         } else {
-            // Yes pressed 
+            // Yes pressed
             m_savedDAO.deleteSavedQuery(qId);
         }
     }
-    
+
     // A saved query goes the first in the list
     return m_savedDAO.saveQuery(this, sQuery);
 }
@@ -165,26 +165,26 @@ void LibraryFeature::restoreQuery(int id) {
     if (pTable == nullptr) {
         return;
     }
-    
+
     // Move the query to the first position to be reused later by the user
     const SavedSearchQuery& sQuery = m_savedDAO.moveToFirst(this, id);
     pTable->restoreQuery(sQuery);
     restoreSearch(sQuery.query.isNull() ? "" : sQuery.query);
 }
 
-QList<SavedSearchQuery> LibraryFeature::getSavedQueries() const {    
+QList<SavedSearchQuery> LibraryFeature::getSavedQueries() const {
     return m_savedDAO.getSavedQueries(this);
 }
 
 parented_ptr<WTrackTableView> LibraryFeature::createTableWidget(int paneId, QWidget* parent) {
-    auto pTrackTableView = make_parented<WTrackTableView>(parent, m_pConfig, 
+    auto pTrackTableView = make_parented<WTrackTableView>(parent, m_pConfig,
             m_pTrackCollection, true);
-    
+
     m_trackTablesByPaneId[paneId] = pTrackTableView.get();
-        
+
     auto pScrollBar = make_parented<WMiniViewScrollBar>(pTrackTableView.get());
     pTrackTableView->setScrollBar(pScrollBar.get());
-    
+
     connect(pTrackTableView.get(), SIGNAL(loadTrack(TrackPointer)),
             this, SIGNAL(loadTrack(TrackPointer)));
     connect(pTrackTableView.get(), SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)),
@@ -193,12 +193,12 @@ parented_ptr<WTrackTableView> LibraryFeature::createTableWidget(int paneId, QWid
             this, SIGNAL(trackSelected(TrackPointer)));
     connect(pTrackTableView.get(), SIGNAL(tableChanged()),
             this, SLOT(restoreSaveButton()));
-    
+
     connect(m_pLibrary, SIGNAL(setTrackTableFont(QFont)),
             pTrackTableView.get(), SLOT(setTrackTableFont(QFont)));
     connect(m_pLibrary, SIGNAL(setTrackTableRowHeight(int)),
             pTrackTableView.get(), SLOT(setTrackTableRowHeight(int)));
-    
+
     return pTrackTableView;
 }
 
@@ -211,7 +211,7 @@ parented_ptr<WLibrarySidebar> LibraryFeature::createLibrarySidebarWidget(QWidget
     auto pSidebar = make_parented<WLibrarySidebar>(parent);
     QAbstractItemModel* pModel = getChildModel();
     pSidebar->setModel(pModel);
-    
+
     // Set sidebar mini view
     auto pMiniView = make_parented<WMiniViewScrollBar>(pSidebar.get());
     pMiniView->setTreeView(pSidebar.get());
@@ -219,7 +219,7 @@ parented_ptr<WLibrarySidebar> LibraryFeature::createLibrarySidebarWidget(QWidget
     pSidebar->setVerticalScrollBar(pMiniView.get());
     // invalidate probably stored QModelIndex
     invalidateChild();
-    
+
     connect(pSidebar.get(), SIGNAL(pressed(const QModelIndex&)),
             this, SLOT(activateChild(const QModelIndex&)));
     connect(pSidebar.get(), SIGNAL(doubleClicked(const QModelIndex&)),
@@ -230,7 +230,7 @@ parented_ptr<WLibrarySidebar> LibraryFeature::createLibrarySidebarWidget(QWidget
             this, SLOT(onLazyChildExpandation(const QModelIndex&)));
     connect(this, SIGNAL(selectIndex(const QModelIndex&)),
             pSidebar.get(), SLOT(selectIndex(const QModelIndex&)));
-    
+
     connect(pSidebar.get(), SIGNAL(hovered()),
             this, SLOT(slotSetHoveredSidebar()));
     connect(pSidebar.get(), SIGNAL(leaved()),

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -33,21 +33,21 @@ class LibraryFeature : public QObject {
 
     // The parent does not necessary be the Library
     LibraryFeature(UserSettingsPointer pConfig,
-                   Library* pLibrary, TrackCollection* pTrackCollection, 
+                   Library* pLibrary, TrackCollection* pTrackCollection,
                    QObject* parent = nullptr);
-    
+
     virtual ~LibraryFeature();
 
     virtual QVariant title() = 0;
     virtual QString getIconPath() = 0;
-    
+
     // This name must be unique for each feature
-    virtual QString getSettingsName() const; 
+    virtual QString getSettingsName() const;
     virtual bool isSinglePane() const;
 
     QIcon getIcon();
 
-    virtual bool dropAccept(QList<QUrl> /* urls */, 
+    virtual bool dropAccept(QList<QUrl> /* urls */,
                             QObject* /* pSource */) {
         return false;
     }
@@ -57,25 +57,25 @@ class LibraryFeature : public QObject {
     virtual bool dragMoveAccept(QUrl url);
     virtual bool dragMoveAcceptChild(const QModelIndex& index,
                                      QUrl url);
-    
+
     // Reimplement this to register custom views with the library widget
     // at the right pane.
-    virtual parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter* pKeyboard, 
+    virtual parented_ptr<QWidget> createPaneWidget(KeyboardEventFilter* pKeyboard,
                                                    int paneId, QWidget* parent);
-    
+
     // Reimplement this to register custom views with the library widget,
     // at the sidebar expanded pane
     virtual parented_ptr<QWidget> createSidebarWidget(KeyboardEventFilter* pKeyboard,
                                                       QWidget* parent);
-    
+
     virtual QPointer<TreeItemModel> getChildModel() = 0;
-    
+
     virtual void setFeaturePaneId(int paneId);
     int getFeaturePaneId();
-    
+
     int getFocusedPane();
     void adoptPreselectedPane();
-    
+
     virtual SavedSearchQuery saveQuery(SavedSearchQuery sQuery);
     virtual void restoreQuery(int id);
     virtual QList<SavedSearchQuery> getSavedQueries() const;
@@ -90,21 +90,21 @@ class LibraryFeature : public QObject {
     // called when you right click on the root item
     virtual void onRightClick(const QPoint&) {}
     // called when you right click on a child item, e.g., a concrete playlist or crate
-    virtual void onRightClickChild(const QPoint& /* globalPos */, 
+    virtual void onRightClickChild(const QPoint& /* globalPos */,
                                    const QModelIndex& /* index */) {}
     // Only implement this, if using incremental or lazy childmodels, see BrowseFeature.
     // This method is executed whenever you **double** click child items
     virtual void onLazyChildExpandation(const QModelIndex&) {}
-    
+
     virtual void onSearch(const QString&) {}
-    
+
     void slotSetHoveredSidebar() { emit hovered(this); };
     void slotResetHoveredSidebar() { emit leaved(this); };
     void slotSetFocusedSidebar() { emit focusIn(this); };
     void slotResetFocusedSidebar() { emit focusOut(this); };
 
   signals:
-    
+
     void loadTrack(TrackPointer);
     void loadTrackToPlayer(TrackPointer pTrack, QString group, bool play = false);
     // emit this signal before you parse a large music collection, e.g., iTunes, Traktor.
@@ -119,7 +119,7 @@ class LibraryFeature : public QObject {
     // emit this signal to enable/disable the cover art widget
     void enableCoverArtDisplay(bool);
     void trackSelected(TrackPointer);
-    
+
     void hovered(LibraryFeature* pLibraryFeature);
     void leaved(LibraryFeature* pLibraryFeature);
     void focusIn(LibraryFeature* pLibraryFeature);
@@ -127,10 +127,10 @@ class LibraryFeature : public QObject {
 
   protected slots:
     void restoreSaveButton();
-    
+
   protected:
     QStringList getPlaylistFiles() const {
-        return getPlaylistFiles(QFileDialog::ExistingFiles); 
+        return getPlaylistFiles(QFileDialog::ExistingFiles);
     }
     QString getPlaylistFile() const {
         const QStringList playListFiles = getPlaylistFiles();
@@ -140,18 +140,18 @@ class LibraryFeature : public QObject {
             return playListFiles.first();
         }
     }
-    
+
     // Creates a table widget with no model
     parented_ptr<WTrackTableView> createTableWidget(int paneId, QWidget *parent);
-    
+
     // Creates a WLibrarySidebar widget with the getChildModel() function as
     // model
     parented_ptr<WLibrarySidebar> createLibrarySidebarWidget(QWidget* parent);
-    
+
     // Override this function to create a custom inner widget for the sidebar,
     // the default widget is a WLibrarySidebar widget
     virtual parented_ptr<QWidget> createInnerSidebarWidget(KeyboardEventFilter* pKeyboard, QWidget* parent);
-    
+
     void showTrackModel(QAbstractItemModel* model);
     void switchToFeature();
     void restoreSearch(const QString& search);
@@ -159,17 +159,17 @@ class LibraryFeature : public QObject {
     void showBreadCrumb(const QModelIndex& index);
     void showBreadCrumb(const QString& text, const QIcon &icon);
     void showBreadCrumb();
-    
+
     WTrackTableView* getFocusedTable();
-    
+
     UserSettingsPointer m_pConfig;
     Library* m_pLibrary;
     TrackCollection* m_pTrackCollection;
     SavedQueriesDAO& m_savedDAO;
-    
+
     int m_featurePane;
-    
-  private: 
+
+  private:
     QStringList getPlaylistFiles(QFileDialog::FileMode mode) const;
     QHash<int, QPointer<WTrackTableView> > m_trackTablesByPaneId;
 };

--- a/src/library/librarypanemanager.cpp
+++ b/src/library/librarypanemanager.cpp
@@ -23,7 +23,7 @@ void LibraryPaneManager::bindPaneWidget(WBaseLibrary* pPaneWidget,
                                         KeyboardEventFilter* pKeyboard) {
     //qDebug() << "LibraryPaneManager::bindLibraryWidget" << libraryWidget;
     m_pPaneWidget = pPaneWidget;
-    
+
     connect(m_pPaneWidget, SIGNAL(focused()),
             this, SLOT(slotPaneFocused()));
     connect(m_pPaneWidget, SIGNAL(collapsed()),
@@ -34,8 +34,8 @@ void LibraryPaneManager::bindPaneWidget(WBaseLibrary* pPaneWidget,
     if (qobject_cast<WLibraryPane*>(m_pPaneWidget) == nullptr) {
         return;
     }
-    for (LibraryFeature* f : m_features) {        
-        auto pFeaturePaneWidget = f->createPaneWidget(pKeyboard, m_paneId, 
+    for (LibraryFeature* f : m_features) {
+        auto pFeaturePaneWidget = f->createPaneWidget(pKeyboard, m_paneId,
                                                       m_pPaneWidget);
         m_pPaneWidget->registerView(f, pFeaturePaneWidget.get());
     }
@@ -92,7 +92,7 @@ void LibraryPaneManager::setFocused(bool value) {
     VERIFY_OR_DEBUG_ASSERT(m_pPaneWidget) {
         return;
     }
-    
+
     m_pPaneWidget->setProperty("showFocus", (int) value);
 }
 
@@ -119,7 +119,7 @@ void LibraryPaneManager::showBreadCrumb(TreeItem *pTree) {
     VERIFY_OR_DEBUG_ASSERT(!m_pBreadCrumb.isNull()) {
         return;
     }
-    
+
     m_pBreadCrumb->showBreadCrumb(pTree);
 }
 
@@ -182,7 +182,7 @@ void LibraryPaneManager::slotSearchCancel() {
 
 void LibraryPaneManager::slotSearch(const QString& text) {
     VERIFY_OR_DEBUG_ASSERT(!m_pPaneWidget.isNull()) {
-        return;    
+        return;
     }
     m_pPaneWidget->search(text);
     m_pCurrentFeature->onSearch(text);

--- a/src/library/librarypanemanager.h
+++ b/src/library/librarypanemanager.h
@@ -35,29 +35,29 @@ class LibraryPaneManager : public QObject {
     void addFeatures(const QList<LibraryFeature*>& features);
 
     WBaseLibrary* getPaneWidget();
-    
+
     void setCurrentFeature(LibraryFeature* pFeature);
     LibraryFeature* getCurrentFeature() const;
 
     void setFocused(bool value);
-    
+
     void restoreSearch(const QString& text);
     void restoreSaveButton();
     void switchToFeature(LibraryFeature* pFeature);
     void showBreadCrumb(TreeItem* pTree);
     void showBreadCrumb(const QString& text, const QIcon &icon);
-    
+
     int getPaneId() const;
-    
+
     void setPreselected(bool value);
     bool isPreselected() const;
-    
+
     void setPreviewed(bool value);
 
     bool focusSearch();
 
   signals:
-    
+
     void searchCleared();
     void searchStarting();
 
@@ -80,7 +80,7 @@ class LibraryPaneManager : public QObject {
     QPointer<WSearchLineEdit> m_pSearchBar;
 
   private:
-    
+
     LibraryFeature* m_pCurrentFeature;
     int m_paneId;
     Library* m_pLibrary;

--- a/src/library/librarysidebarexpandedmanager.cpp
+++ b/src/library/librarysidebarexpandedmanager.cpp
@@ -1,7 +1,7 @@
 #include "librarysidebarexpandedmanager.h"
 #include "library/libraryfeature.h"
 
-LibrarySidebarExpandedManager::LibrarySidebarExpandedManager(Library *pLibrary, 
+LibrarySidebarExpandedManager::LibrarySidebarExpandedManager(Library *pLibrary,
                                                              QObject* parent)
         : LibraryPaneManager(-1, pLibrary, parent) {
 
@@ -11,7 +11,7 @@ void LibrarySidebarExpandedManager::bindPaneWidget(WBaseLibrary* sidebarWidget,
                                                    KeyboardEventFilter* pKeyboard) {
     m_pPaneWidget = sidebarWidget;
 
-    for (LibraryFeature* f : m_features) {        
+    for (LibraryFeature* f : m_features) {
         auto pPane = f->createSidebarWidget(pKeyboard, m_pPaneWidget);
         if (pPane.get() == nullptr) {
             continue;

--- a/src/library/librarytablemodel.h
+++ b/src/library/librarytablemodel.h
@@ -17,7 +17,7 @@ class LibraryTableModel : public BaseSqlTableModel {
     // number of successful additions.
     int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
     TrackModel::CapabilitiesFlags getCapabilities() const final;
-    
+
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
     using QObject::parent;
 #endif

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -147,26 +147,26 @@ class TrackModel {
 
     virtual void select() {
     }
-    
+
     virtual void saveSelection(const QModelIndexList&) {
     }
-    
+
     virtual QModelIndexList getSavedSelectionIndices() {
         return QModelIndexList();
     }
 
     virtual void restoreQuery(const SavedSearchQuery&) {
     }
-    
-    virtual SavedSearchQuery saveQuery(const QModelIndexList& /* selected */, 
+
+    virtual SavedSearchQuery saveQuery(const QModelIndexList& /* selected */,
                                        SavedSearchQuery query = SavedSearchQuery()) const {
         return query;
     }
-    
+
     virtual SavedSearchQuery saveQuery(SavedSearchQuery = SavedSearchQuery()) {
         return SavedSearchQuery();
     }
-    
+
   private:
     QSqlDatabase m_db;
     QString m_settingsNamespace;

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -14,7 +14,7 @@ class CoverInfo;
 class TreeItem final {
   public:
     static const int kInvalidRow = -1;
-    
+
 	TreeItem(); // creates an invisible root item for the tree
     explicit TreeItem(
             LibraryFeature* pFeature,
@@ -105,7 +105,7 @@ class TreeItem final {
     inline const QIcon& getIcon() {
         return m_icon;
     }
-    
+
 	// Returns true if we have a leaf node
     bool isPlaylist() const;
     // Returns true if we have an inner node
@@ -124,14 +124,14 @@ class TreeItem final {
 	inline bool isDivider() const {
 		return m_divider;
 	}
-    
+
 	inline void setCoverInfo(const CoverInfo& cover) {
 		m_cover = cover;
 	}
 	inline const CoverInfo& getCoverInfo() const {
 		return m_cover;
 	}
-    
+
 	inline void setTrackCount(int count) {
 		m_trackCount = count;
 		m_labelNumbered = m_label + " (" + QString::number(m_trackCount) + ")";
@@ -146,10 +146,10 @@ class TreeItem final {
 	void insertChild(TreeItem* pChild, int row);
 
     LibraryFeature* m_pFeature;
-    
+
     TreeItem* m_pParent;
     QList<TreeItem*> m_children; // owned child items
-    
+
     QString m_label;
 	QString m_labelNumbered;
     QVariant m_data;

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -53,7 +53,7 @@ QVariant TreeItemModel::data(const QModelIndex &index, int role) const {
         return QVariant();
     }
 
-    // We use Qt::UserRole to ask for the datapath.    
+    // We use Qt::UserRole to ask for the datapath.
     switch(role) {
         case Qt::DisplayRole:
             return item->getLabel();
@@ -118,12 +118,12 @@ Qt::ItemFlags TreeItemModel::flags(const QModelIndex &index) const {
     if (!index.isValid())
         return 0;
     Qt::ItemFlags flags = Qt::ItemIsEnabled;
-    
+
     bool divider = index.data(AbstractRole::RoleDivider).toBool();
     if (!divider) {
         flags |= Qt::ItemIsSelectable;
     }
-    
+
     return flags;
 }
 
@@ -244,7 +244,7 @@ void TreeItemModel::triggerRepaint() {
 }
 
 //static
-QString TreeItemModel::getBreadCrumbString(TreeItem* pTree) {    
+QString TreeItemModel::getBreadCrumbString(TreeItem* pTree) {
     // Base case
     if (pTree == nullptr || pTree->feature() == nullptr) {
         return QString();
@@ -252,7 +252,7 @@ QString TreeItemModel::getBreadCrumbString(TreeItem* pTree) {
     else if (pTree->parent() == nullptr) {
         return pTree->feature()->title().toString();
     }
-    
+
     // Recursive case
     QString text = pTree->getLabel();
     QString next = getBreadCrumbString(pTree->parent());
@@ -275,17 +275,17 @@ bool TreeItemModel::dropAccept(const QModelIndex& index, QList<QUrl> urls,
     if (pFeature == nullptr) {
         return false;
     }
-    
+
     return pFeature->dropAcceptChild(index, urls, pSource);
 }
 
 bool TreeItemModel::dragMoveAccept(const QModelIndex& index, QUrl url) {
-    //qDebug() << "TreeItemModel::dragMoveAccept() index=" << index << url;    
+    //qDebug() << "TreeItemModel::dragMoveAccept() index=" << index << url;
     LibraryFeature* pFeature = getFeatureFromIndex(index);
     if (pFeature == nullptr) {
         return false;
     }
-    
+
     return pFeature->dragMoveAcceptChild(index, url);
 }
 


### PR DESCRIPTION
Reading through the code for the library redesign branch, I got really confused between "MixxxLibrary" and the generic term "Library". So rename the "MixxxLibrary" classes to "Tracks", matching the new label in the GUI.