### PR TITLE
WEffectSelector: fix tooltip not showing on startup

### DIFF
--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -101,6 +101,7 @@ void WEffectSelector::slotEffectUpdated() {
 
     if (newIndex != -1 && newIndex != currentIndex()) {
         setCurrentIndex(newIndex);
+        setBaseTooltip(itemData(newIndex, Qt::ToolTipRole).toString());
     }
 }
 


### PR DESCRIPTION
Before the tooltip was only set when a new effect was selected from the dropdown, but the tooltip was not shown for the effects loaded from effects.xml on startup.