### PR TITLE
effects widgets tooltip UI polishing

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -856,6 +856,7 @@ class MixxxCore(Feature):
                    "widget/weffect.cpp",
                    "widget/weffectselector.cpp",
                    "widget/weffectparameter.cpp",
+                   "widget/weffectparameterknobcomposed.cpp",
                    "widget/weffectbuttonparameter.cpp",
                    "widget/weffectparameterbase.cpp",
                    "widget/wtime.cpp",

--- a/res/skins/Deere/effect_parameter_knob.xml
+++ b/res/skins/Deere/effect_parameter_knob.xml
@@ -19,16 +19,19 @@
         <Layout>horizontal</Layout>
         <Size>me,20f</Size>
         <Children>
-          <KnobComposed>
-            <TooltipId><Variable name="TooltipId"/></TooltipId>
+          <EffectParameterKnobComposed>
             <Size>20f,20f</Size>
             <Knob>knob_small.svg</Knob>
             <MinAngle>-230</MinAngle>
             <MaxAngle>50</MaxAngle>
+            <EffectRack><Variable name="EffectRack"/></EffectRack>
+            <EffectUnit><Variable name="EffectUnit"/></EffectUnit>
+            <Effect><Variable name="Effect"/></Effect>
+            <EffectParameter><Variable name="EffectParameter"/></EffectParameter>
             <Connection>
               <ConfigKey>[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>_Effect<Variable name="Effect"/>],parameter<Variable name="EffectParameter"/></ConfigKey>
             </Connection>
-          </KnobComposed>
+          </EffectParameterKnobComposed>
         </Children>
       </WidgetGroup>
 

--- a/res/skins/Deere/effect_parameter_knob.xml
+++ b/res/skins/Deere/effect_parameter_knob.xml
@@ -24,10 +24,6 @@
             <Knob>knob_small.svg</Knob>
             <MinAngle>-230</MinAngle>
             <MaxAngle>50</MaxAngle>
-            <EffectRack><Variable name="EffectRack"/></EffectRack>
-            <EffectUnit><Variable name="EffectUnit"/></EffectUnit>
-            <Effect><Variable name="Effect"/></Effect>
-            <EffectParameter><Variable name="EffectParameter"/></EffectParameter>
             <Connection>
               <ConfigKey>[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>_Effect<Variable name="Effect"/>],parameter<Variable name="EffectParameter"/></ConfigKey>
             </Connection>

--- a/res/skins/Deere/equalizer_rack_parameter_left.xml
+++ b/res/skins/Deere/equalizer_rack_parameter_left.xml
@@ -83,10 +83,6 @@
                 <MinAngle>-135</MinAngle>
                 <MaxAngle>135</MaxAngle>
                 <KnobCenterYOffset>1.602</KnobCenterYOffset>
-                <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
-                <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
-                <Effect><Variable name="EffectNumber"/></Effect>
-                <EffectParameter><Variable name="parameter"/></EffectParameter>
                 <Connection>
                   <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
                 </Connection>
@@ -107,10 +103,6 @@
                 <MinAngle>-135</MinAngle>
                 <MaxAngle>135</MaxAngle>
                 <KnobCenterYOffset>1.602</KnobCenterYOffset>
-                <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
-                <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
-                <Effect><Variable name="EffectNumber"/></Effect>
-                <EffectParameter><Variable name="parameter"/></EffectParameter>
                 <Connection>
                   <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
                 </Connection>

--- a/res/skins/Deere/equalizer_rack_parameter_left.xml
+++ b/res/skins/Deere/equalizer_rack_parameter_left.xml
@@ -76,11 +76,21 @@
             <MaximumSize>40,41</MaximumSize>
             <Layout>vertical</Layout>
             <Children>
-              <Template src="skin:knob.xml">
-                <SetVariable name="group"><Variable name="EqualizerEffectGroup"/></SetVariable>
-                <SetVariable name="control">parameter<Variable name="parameter"/></SetVariable>
-                <SetVariable name="color"><Variable name="color"/></SetVariable>
-              </Template>
+              <EffectParameterKnobComposed>
+                <Size>40f,34f</Size>
+                <Knob>knob_<Variable name="color"/>.svg</Knob>
+                <BackPath>knob_bg.svg</BackPath>
+                <MinAngle>-135</MinAngle>
+                <MaxAngle>135</MaxAngle>
+                <KnobCenterYOffset>1.602</KnobCenterYOffset>
+                <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
+                <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
+                <Effect><Variable name="EffectNumber"/></Effect>
+                <EffectParameter><Variable name="parameter"/></EffectParameter>
+                <Connection>
+                  <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
+                </Connection>
+              </EffectParameterKnobComposed>
             </Children>
           </WidgetGroup>
 
@@ -90,11 +100,21 @@
             <MaximumSize>40,45</MaximumSize>
             <Layout>vertical</Layout>
             <Children>
-              <Template src="skin:knob.xml">
-                <SetVariable name="group"><Variable name="EqualizerEffectGroup"/></SetVariable>
-                <SetVariable name="control">parameter<Variable name="parameter"/></SetVariable>
-                <SetVariable name="color"><Variable name="color"/></SetVariable>
-              </Template>
+              <EffectParameterKnobComposed>
+                <Size>40f,34f</Size>
+                <Knob>knob_<Variable name="color"/>.svg</Knob>
+                <BackPath>knob_bg.svg</BackPath>
+                <MinAngle>-135</MinAngle>
+                <MaxAngle>135</MaxAngle>
+                <KnobCenterYOffset>1.602</KnobCenterYOffset>
+                <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
+                <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
+                <Effect><Variable name="EffectNumber"/></Effect>
+                <EffectParameter><Variable name="parameter"/></EffectParameter>
+                <Connection>
+                  <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
+                </Connection>
+              </EffectParameterKnobComposed>
               <EffectParameterName>
                 <Size>40f,10f</Size>
                 <ObjectName>KnobLabel</ObjectName>

--- a/res/skins/Deere/equalizer_rack_parameter_right.xml
+++ b/res/skins/Deere/equalizer_rack_parameter_right.xml
@@ -28,11 +28,21 @@
             <MaximumSize>40,41</MaximumSize>
             <Layout>vertical</Layout>
             <Children>
-              <Template src="skin:knob.xml">
-                <SetVariable name="group"><Variable name="EqualizerEffectGroup"/></SetVariable>
-                <SetVariable name="control">parameter<Variable name="parameter"/></SetVariable>
-                <SetVariable name="color"><Variable name="color"/></SetVariable>
-              </Template>
+              <EffectParameterKnobComposed>
+                <Size>40f,34f</Size>
+                <Knob>knob_<Variable name="color"/>.svg</Knob>
+                <BackPath>knob_bg.svg</BackPath>
+                <MinAngle>-135</MinAngle>
+                <MaxAngle>135</MaxAngle>
+                <KnobCenterYOffset>1.602</KnobCenterYOffset>
+                <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
+                <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
+                <Effect><Variable name="EffectNumber"/></Effect>
+                <EffectParameter><Variable name="parameter"/></EffectParameter>
+                <Connection>
+                  <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
+                </Connection>
+              </EffectParameterKnobComposed>
             </Children>
           </WidgetGroup>
 
@@ -42,11 +52,21 @@
             <MaximumSize>40,45</MaximumSize>
             <Layout>vertical</Layout>
             <Children>
-              <Template src="skin:knob.xml">
-                <SetVariable name="group"><Variable name="EqualizerEffectGroup"/></SetVariable>
-                <SetVariable name="control">parameter<Variable name="parameter"/></SetVariable>
-                <SetVariable name="color"><Variable name="color"/></SetVariable>
-              </Template>
+              <EffectParameterKnobComposed>
+                <Size>40f,34f</Size>
+                <Knob>knob_<Variable name="color"/>.svg</Knob>
+                <BackPath>knob_bg.svg</BackPath>
+                <MinAngle>-135</MinAngle>
+                <MaxAngle>135</MaxAngle>
+                <KnobCenterYOffset>1.602</KnobCenterYOffset>
+                <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
+                <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
+                <Effect><Variable name="EffectNumber"/></Effect>
+                <EffectParameter><Variable name="parameter"/></EffectParameter>
+                <Connection>
+                  <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
+                </Connection>
+              </EffectParameterKnobComposed>
               <EffectParameterName>
                 <Size>40f,10f</Size>
                 <ObjectName>KnobLabel</ObjectName>

--- a/res/skins/Deere/equalizer_rack_parameter_right.xml
+++ b/res/skins/Deere/equalizer_rack_parameter_right.xml
@@ -35,10 +35,6 @@
                 <MinAngle>-135</MinAngle>
                 <MaxAngle>135</MaxAngle>
                 <KnobCenterYOffset>1.602</KnobCenterYOffset>
-                <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
-                <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
-                <Effect><Variable name="EffectNumber"/></Effect>
-                <EffectParameter><Variable name="parameter"/></EffectParameter>
                 <Connection>
                   <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
                 </Connection>
@@ -59,10 +55,6 @@
                 <MinAngle>-135</MinAngle>
                 <MaxAngle>135</MaxAngle>
                 <KnobCenterYOffset>1.602</KnobCenterYOffset>
-                <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
-                <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
-                <Effect><Variable name="EffectNumber"/></Effect>
-                <EffectParameter><Variable name="parameter"/></EffectParameter>
                 <Connection>
                   <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
                 </Connection>

--- a/res/skins/LateNight/effect_parameter_knob.xml
+++ b/res/skins/LateNight/effect_parameter_knob.xml
@@ -18,11 +18,21 @@
         <ObjectName>EffectKnob</ObjectName>
         <MinimumSize>0,50</MinimumSize>
         <Children>
-           <Template src="skin:knob_textless.xml">
-             <SetVariable name="group">[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>_Effect<Variable name="Effect"/>]</SetVariable>
-             <SetVariable name="control">parameter<Variable name="EffectParameter"/></SetVariable>
-           </Template>
-	     </Children>
+          <EffectParameterKnobComposed>
+            <Size>40f,34f</Size>
+            <Knob>knob_indicator.svg</Knob>
+            <BackPath>knob_bg.svg</BackPath>
+            <MinAngle>-135</MinAngle>
+            <MaxAngle>135</MaxAngle>
+            <EffectRack><Variable name="EffectRack"/></EffectRack>
+            <EffectUnit><Variable name="EffectUnit"/></EffectUnit>
+            <Effect><Variable name="Effect"/></Effect>
+            <EffectParameter><Variable name="EffectParameter"/></EffectParameter>
+            <Connection>
+              <ConfigKey>[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>_Effect<Variable name="Effect"/>],parameter<Variable name="EffectParameter"/></ConfigKey>
+            </Connection>
+          </EffectParameterKnobComposed>
+        </Children>
       </WidgetGroup>
       <EffectParameterName>
         <Size>1me,18f</Size>

--- a/res/skins/LateNight/effect_parameter_knob.xml
+++ b/res/skins/LateNight/effect_parameter_knob.xml
@@ -24,10 +24,6 @@
             <BackPath>knob_bg.svg</BackPath>
             <MinAngle>-135</MinAngle>
             <MaxAngle>135</MaxAngle>
-            <EffectRack><Variable name="EffectRack"/></EffectRack>
-            <EffectUnit><Variable name="EffectUnit"/></EffectUnit>
-            <Effect><Variable name="Effect"/></Effect>
-            <EffectParameter><Variable name="EffectParameter"/></EffectParameter>
             <Connection>
               <ConfigKey>[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>_Effect<Variable name="Effect"/>],parameter<Variable name="EffectParameter"/></ConfigKey>
             </Connection>

--- a/res/skins/LateNight/eq_knob.xml
+++ b/res/skins/LateNight/eq_knob.xml
@@ -52,10 +52,6 @@
                         <BackPath>knob_bg.svg</BackPath>
                         <MinAngle>-135</MinAngle>
                         <MaxAngle>135</MaxAngle>
-                        <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
-                        <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
-                        <Effect><Variable name="EffectNumber"/></Effect>
-                        <EffectParameter><Variable name="parameter"/></EffectParameter>
                         <Connection>
                             <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
                         </Connection>

--- a/res/skins/LateNight/eq_knob.xml
+++ b/res/skins/LateNight/eq_knob.xml
@@ -46,10 +46,20 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>me, min</SizePolicy>
                 <Children>
-                    <Template src="skin:knob_textless.xml">
-                       <SetVariable name="group"><Variable name="EqualizerEffectGroup"/></SetVariable>
-                       <SetVariable name="control">parameter<Variable name="parameter"/></SetVariable>
-                    </Template>
+                    <EffectParameterKnobComposed>
+                        <Size>40f,34f</Size>
+                        <Knob>knob_indicator.svg</Knob>
+                        <BackPath>knob_bg.svg</BackPath>
+                        <MinAngle>-135</MinAngle>
+                        <MaxAngle>135</MaxAngle>
+                        <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
+                        <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
+                        <Effect><Variable name="EffectNumber"/></Effect>
+                        <EffectParameter><Variable name="parameter"/></EffectParameter>
+                        <Connection>
+                            <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
+                        </Connection>
+                    </EffectParameterKnobComposed>
                 </Children>
             </WidgetGroup>
         </Children>

--- a/res/skins/Tango/eq_knob_left.xml
+++ b/res/skins/Tango/eq_knob_left.xml
@@ -7,7 +7,11 @@ Variables:
   parameter : EQ parameter number
 -->
 <Template>
-  <SetVariable name="EqualizerEffectGroup">[EqualizerRack1_<Variable name="group"/>_Effect1]</SetVariable>
+  <SetVariable name="EqualizerNumber">1</SetVariable>
+  <SetVariable name="EffectNumber">1</SetVariable>
+  <SetVariable name="EqualizerRackGroup">[EqualizerRack<Variable name="EqualizerNumber"/>]</SetVariable>
+  <SetVariable name="EqualizerEffectUnitGroup">[EqualizerRack<Variable name="EqualizerNumber"/>_<Variable name="group"/>]</SetVariable>
+  <SetVariable name="EqualizerEffectGroup">[EqualizerRack<Variable name="EqualizerNumber"/>_<Variable name="group"/>_Effect<Variable name="EffectNumber"/>]</SetVariable>
   <WidgetGroup>
     <Layout>horizontal</Layout>
     <SizePolicy>min,min</SizePolicy>
@@ -22,12 +26,19 @@ Variables:
             <SizePolicy>min,min</SizePolicy>
             <Layout>stacked</Layout>
             <Children>
-              <Template src="skin:knob_textless.xml">
-                <SetVariable name="Size">30f,30f</SetVariable>
-                <SetVariable name="Color">white</SetVariable>
-                <SetVariable name="group"><Variable name="EqualizerEffectGroup"/></SetVariable>
-                <SetVariable name="ConfigKey">parameter<Variable name="parameter"/></SetVariable>
-              </Template>
+              <EffectParameterKnobComposed>
+                  <Size>30f,30f</Size>
+                  <Knob>skin:/knobs_sliders/knob_white.svg</Knob>
+                  <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
+                  <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
+                  <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
+                  <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
+                  <Effect><Variable name="EffectNumber"/></Effect>
+                  <EffectParameter><Variable name="parameter"/></EffectParameter>
+                  <Connection>
+                      <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
+                  </Connection>
+              </EffectParameterKnobComposed>
               <Template src="skin:button_2state.xml">
                 <SetVariable name="ObjectName">EQKillButtonUnderlayLeft</SetVariable>
                 <SetVariable name="Size">30f,30f</SetVariable>

--- a/res/skins/Tango/eq_knob_left.xml
+++ b/res/skins/Tango/eq_knob_left.xml
@@ -31,10 +31,6 @@ Variables:
                   <Knob>skin:/knobs_sliders/knob_white.svg</Knob>
                   <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
                   <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
-                  <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
-                  <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
-                  <Effect><Variable name="EffectNumber"/></Effect>
-                  <EffectParameter><Variable name="parameter"/></EffectParameter>
                   <Connection>
                       <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
                   </Connection>

--- a/res/skins/Tango/eq_knob_right.xml
+++ b/res/skins/Tango/eq_knob_right.xml
@@ -7,7 +7,11 @@ Variables:
   parameter : EQ parameter number
 -->
 <Template>
-  <SetVariable name="EqualizerEffectGroup">[EqualizerRack1_<Variable name="group"/>_Effect1]</SetVariable>
+  <SetVariable name="EqualizerNumber">1</SetVariable>
+  <SetVariable name="EffectNumber">1</SetVariable>
+  <SetVariable name="EqualizerRackGroup">[EqualizerRack<Variable name="EqualizerNumber"/>]</SetVariable>
+  <SetVariable name="EqualizerEffectUnitGroup">[EqualizerRack<Variable name="EqualizerNumber"/>_<Variable name="group"/>]</SetVariable>
+  <SetVariable name="EqualizerEffectGroup">[EqualizerRack<Variable name="EqualizerNumber"/>_<Variable name="group"/>_Effect<Variable name="EffectNumber"/>]</SetVariable>
   <WidgetGroup>
     <Layout>horizontal</Layout>
     <SizePolicy>min,min</SizePolicy>
@@ -37,12 +41,19 @@ Variables:
             <SizePolicy>min,min</SizePolicy>
             <Layout>stacked</Layout>
             <Children>
-              <Template src="skin:knob_textless.xml">
-                <SetVariable name="Size">30f,30f</SetVariable>
-                <SetVariable name="Color">white</SetVariable>
-                <SetVariable name="group"><Variable name="EqualizerEffectGroup"/></SetVariable>
-                <SetVariable name="ConfigKey">parameter<Variable name="parameter"/></SetVariable>
-              </Template>
+              <EffectParameterKnobComposed>
+                  <Size>30f,30f</Size>
+                  <Knob>skin:/knobs_sliders/knob_white.svg</Knob>
+                  <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
+                  <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
+                  <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
+                  <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
+                  <Effect><Variable name="EffectNumber"/></Effect>
+                  <EffectParameter><Variable name="parameter"/></EffectParameter>
+                  <Connection>
+                      <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
+                  </Connection>
+              </EffectParameterKnobComposed>
               <Template src="skin:button_2state.xml">
                 <SetVariable name="ObjectName">EQKillButtonUnderlayRight</SetVariable>
                 <SetVariable name="Size">30f,30f</SetVariable>

--- a/res/skins/Tango/eq_knob_right.xml
+++ b/res/skins/Tango/eq_knob_right.xml
@@ -46,10 +46,6 @@ Variables:
                   <Knob>skin:/knobs_sliders/knob_white.svg</Knob>
                   <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
                   <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
-                  <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
-                  <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
-                  <Effect><Variable name="EffectNumber"/></Effect>
-                  <EffectParameter><Variable name="parameter"/></EffectParameter>
                   <Connection>
                       <ConfigKey><Variable name="EqualizerEffectGroup"/>,parameter<Variable name="parameter"/></ConfigKey>
                   </Connection>

--- a/res/skins/Tango/fx_parameter_knob.xml
+++ b/res/skins/Tango/fx_parameter_knob.xml
@@ -24,17 +24,23 @@ Variables:
             <Layout>vertical</Layout>
             <Size>51f,26f</Size>
             <Children>
-              <Template src="skin:knob_textless.xml">
-                <SetVariable name="TooltipId">EffectSlot_parameter</SetVariable>
-                <SetVariable name="group"><Variable name="fxGroup_fxNum"/></SetVariable>
-                <SetVariable name="ConfigKey">parameter<Variable name="fxKnobParameter"/></SetVariable>
-                <SetVariable name="Size">26f,26f</SetVariable>
-                <SetVariable name="Color">fx_yellow</SetVariable>
-              </Template>
+              <EffectParameterKnobComposed>
+                  <Size>26f,26f</Size>
+                  <Knob>skin:/knobs_sliders/knob_fx_yellow.svg</Knob>
+                  <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
+                  <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
+                  <EffectRack><Variable name="fxRack"/></EffectRack>
+                  <EffectUnit><Variable name="fxUnit"/></EffectUnit>
+                  <Effect><Variable name="fxNum"/></Effect>
+                  <EffectParameter><Variable name="fxKnobParameter"/></EffectParameter>
+                  <Connection>
+                      <ConfigKey><Variable name="fxGroup_fxNum"/>,parameter<Variable name="fxKnobParameter"/></ConfigKey>
+                  </Connection>
+              </EffectParameterKnobComposed>
             </Children>
           </WidgetGroup>
 
-          <WidgetGroup><!-- Name of paramter -->
+          <WidgetGroup><!-- Name of parameter -->
             <Size>51f,34f</Size>
             <Layout>horizontal</Layout>
             <Children>

--- a/res/skins/Tango/fx_parameter_knob.xml
+++ b/res/skins/Tango/fx_parameter_knob.xml
@@ -29,10 +29,6 @@ Variables:
                   <Knob>skin:/knobs_sliders/knob_fx_yellow.svg</Knob>
                   <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
                   <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
-                  <EffectRack><Variable name="fxRack"/></EffectRack>
-                  <EffectUnit><Variable name="fxUnit"/></EffectUnit>
-                  <Effect><Variable name="fxNum"/></Effect>
-                  <EffectParameter><Variable name="fxKnobParameter"/></EffectParameter>
                   <Connection>
                       <ConfigKey><Variable name="fxGroup_fxNum"/>,parameter<Variable name="fxKnobParameter"/></ConfigKey>
                   </Connection>

--- a/src/effects/native/graphiceqeffect.cpp
+++ b/src/effects/native/graphiceqeffect.cpp
@@ -48,7 +48,7 @@ EffectManifest GraphicEQEffect::getManifest() {
         EffectManifestParameter* mid = manifest.addParameter();
         mid->setId(QString("mid%1").arg(i));
         mid->setName(paramName);
-        mid->setDescription(QObject::tr("Gain for Band Filter %1").arg(i));
+        mid->setDescription(QObject::tr("Gain for Band Filter %1").arg(i + 1));
         mid->setControlHint(EffectManifestParameter::ControlHint::KNOB_LINEAR);
         mid->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
         mid->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1634,6 +1634,11 @@ QWidget* LegacySkinParser::parseEffectParameterKnobComposed(const QDomElement& n
     pParameterKnob->installEventFilter(
         m_pControllerManager->getControllerLearningEventFilter());
     pParameterKnob->Init();
+    const QList<ControlParameterWidgetConnection*> connections =
+            pParameterKnob->connections();
+    if (!connections.isEmpty()) {
+        pParameterKnob->setupEffectParameterSlot(connections.at(0)->getKey());
+    }
     return pParameterKnob;
 }
 

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -58,6 +58,7 @@
 #include "widget/weffect.h"
 #include "widget/weffectselector.h"
 #include "widget/weffectparameter.h"
+#include "widget/weffectparameterknobcomposed.h"
 #include "widget/weffectbuttonparameter.h"
 #include "widget/weffectparameterbase.h"
 #include "widget/wbeatspinbox.h"
@@ -553,6 +554,8 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
         result = wrapWidget(parseEffectName(node));
     } else if (nodeName == "EffectSelector") {
         result = wrapWidget(parseEffectSelector(node));
+    } else if (nodeName == "EffectParameterKnobComposed") {
+        result = wrapWidget(parseEffectParameterKnobComposed(node));
     } else if (nodeName == "EffectParameterName") {
         result = wrapWidget(parseEffectParameterName(node));
     } else if (nodeName == "EffectButtonParameterName") {
@@ -1620,6 +1623,18 @@ QWidget* LegacySkinParser::parseEffectSelector(const QDomElement& node) {
         m_pControllerManager->getControllerLearningEventFilter());
     pSelector->Init();
     return pSelector;
+}
+
+QWidget* LegacySkinParser::parseEffectParameterKnobComposed(const QDomElement& node) {
+    WEffectParameterKnobComposed* pParameterKnob =
+            new WEffectParameterKnobComposed(m_pParent, m_pEffectsManager);
+    commonWidgetSetup(node, pParameterKnob);
+    pParameterKnob->setup(node, *m_pContext);
+    pParameterKnob->installEventFilter(m_pKeyboard);
+    pParameterKnob->installEventFilter(
+        m_pControllerManager->getControllerLearningEventFilter());
+    pParameterKnob->Init();
+    return pParameterKnob;
 }
 
 QWidget* LegacySkinParser::parseEffectPushButton(const QDomElement& element) {

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -81,6 +81,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     QWidget* parseEffectChainName(const QDomElement& node);
     QWidget* parseEffectName(const QDomElement& node);
     QWidget* parseEffectParameterName(const QDomElement& node);
+    QWidget* parseEffectParameterKnobComposed(const QDomElement& node);
     QWidget* parseEffectButtonParameterName(const QDomElement& node);
     QWidget* parseEffectPushButton(const QDomElement& node);
     QWidget* parseEffectSelector(const QDomElement& node);

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -54,6 +54,10 @@ class WBaseWidget {
     double getControlParameterRight() const;
     double getControlParameterDisplay() const;
 
+    inline const QList<ControlParameterWidgetConnection*>& connections() const {
+        return m_connections;
+    };
+
   protected:
     // Whenever a connected control is changed, onConnectedControlChanged is
     // called. This allows the widget implementor to respond to the change and

--- a/src/widget/weffect.cpp
+++ b/src/widget/weffect.cpp
@@ -45,8 +45,7 @@ void WEffect::effectUpdated() {
         if (pEffect) {
             const EffectManifest& manifest = pEffect->getManifest();
             name = manifest.displayName();
-            //: %1 = effect name; %2 = effect description
-            description = tr("%1: %2").arg(manifest.name(), manifest.description());
+            description = QString("%1\n%2").arg(manifest.name(), manifest.description());
         }
     } else {
         name = tr("None");

--- a/src/widget/weffectparameterbase.cpp
+++ b/src/widget/weffectparameterbase.cpp
@@ -23,14 +23,13 @@ void WEffectParameterBase::parameterUpdated() {
     if (m_pEffectParameterSlot) {
         if (!m_pEffectParameterSlot->shortName().isEmpty()) {
             setText(m_pEffectParameterSlot->shortName());
-            //: %1 = effect parameter name; %2 = effect parameter description
-            setBaseTooltip(tr("%1: %2").arg(
-                              m_pEffectParameterSlot->name(),
-                              m_pEffectParameterSlot->description()));
         } else {
             setText(m_pEffectParameterSlot->name());
-            setBaseTooltip(m_pEffectParameterSlot->description());
         }
+        //: %1 = effect parameter name; %2 = effect parameter description
+        setBaseTooltip(tr("%1: %2").arg(
+                          m_pEffectParameterSlot->name(),
+                          m_pEffectParameterSlot->description()));
     } else {
         setText(tr("None"));
         setBaseTooltip(tr("No effect loaded."));

--- a/src/widget/weffectparameterbase.cpp
+++ b/src/widget/weffectparameterbase.cpp
@@ -26,10 +26,9 @@ void WEffectParameterBase::parameterUpdated() {
         } else {
             setText(m_pEffectParameterSlot->name());
         }
-        //: %1 = effect parameter name; %2 = effect parameter description
-        setBaseTooltip(tr("%1: %2").arg(
-                          m_pEffectParameterSlot->name(),
-                          m_pEffectParameterSlot->description()));
+        setBaseTooltip(QString("%1\n%2").arg(
+                       m_pEffectParameterSlot->name(),
+                       m_pEffectParameterSlot->description()));
     } else {
         setText(tr("None"));
         setBaseTooltip(tr("No effect loaded."));

--- a/src/widget/weffectparameterbase.cpp
+++ b/src/widget/weffectparameterbase.cpp
@@ -23,7 +23,7 @@ void WEffectParameterBase::parameterUpdated() {
     if (m_pEffectParameterSlot) {
         if (!m_pEffectParameterSlot->shortName().isEmpty()) {
             setText(m_pEffectParameterSlot->shortName());
-            //: %1 = effect name; %2 = effect description
+            //: %1 = effect parameter name; %2 = effect parameter description
             setBaseTooltip(tr("%1: %2").arg(
                               m_pEffectParameterSlot->name(),
                               m_pEffectParameterSlot->description()));

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -24,14 +24,10 @@ void WEffectParameterKnobComposed::setup(const QDomNode& node,
 
 void WEffectParameterKnobComposed::parameterUpdated() {
     if (m_pEffectParameterSlot) {
-        if (!m_pEffectParameterSlot->shortName().isEmpty()) {
-            //: %1 = effect parameter name; %2 = effect parameter description
-            setBaseTooltip(tr("%1: %2").arg(
-                              m_pEffectParameterSlot->name(),
-                              m_pEffectParameterSlot->description()));
-        } else {
-            setBaseTooltip(m_pEffectParameterSlot->description());
-        }
+        //: %1 = effect parameter name; %2 = effect parameter description
+        setBaseTooltip(tr("%1: %2").arg(
+                          m_pEffectParameterSlot->name(),
+                          m_pEffectParameterSlot->description()));
     } else {
         setBaseTooltip(tr("No effect loaded."));
     }

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -1,26 +1,65 @@
 #include "widget/effectwidgetutils.h"
 #include "widget/weffectparameterknobcomposed.h"
 
-void WEffectParameterKnobComposed::setup(const QDomNode& node,
-                                         const SkinContext& context) {
-    WKnobComposed::setup(node, context);
+namespace {
+const QString effectGroupSeparator = "_";
+const QString groupClose = "]";
+} // anonymous namespace
 
-    EffectRackPointer pRack = EffectWidgetUtils::getEffectRackFromNode(
-            node, context, m_pEffectsManager);
-    EffectChainSlotPointer pChainSlot = EffectWidgetUtils::getEffectChainSlotFromNode(
-            node, context, pRack);
-    EffectSlotPointer pEffectSlot = EffectWidgetUtils::getEffectSlotFromNode(
-            node, context, pChainSlot);
-    EffectParameterSlotBasePointer pParameterSlot =
-            EffectWidgetUtils::getParameterSlotFromNode(
-                    node, context, pEffectSlot);
-    if (pParameterSlot) {
-        setEffectParameterSlot(pParameterSlot);
-    } else {
-        SKIN_WARNING(node, context)
-                << "EffectParameterKnobComposed node could not attach to effect parameter";
+void WEffectParameterKnobComposed::setupEffectParameterSlot(const ConfigKey& configKey) {
+    QStringList parts = configKey.group.split(effectGroupSeparator);
+    QRegExp intRegEx(".*(\\d+).*");
+
+    EffectRackPointer pRack = m_pEffectsManager->getEffectRack(parts.at(0) + groupClose);
+    VERIFY_OR_DEBUG_ASSERT(pRack) {
+        return;
     }
-};
+
+    EffectChainSlotPointer pChainSlot;
+    if (parts.at(0) == "[EffectRack1") {
+        intRegEx.indexIn(parts.at(1));
+        pChainSlot = pRack->getEffectChainSlot(intRegEx.cap(1).toInt() - 1);
+    } else {
+        // Assume a PerGroupRack
+        const QString chainGroup =
+                parts.at(0) + effectGroupSeparator + parts.at(1) + groupClose;
+        for (int i = 0; i < pRack->numEffectChainSlots(); ++i) {
+            EffectChainSlotPointer pSlot = pRack->getEffectChainSlot(i);
+            if (pSlot->getGroup() == chainGroup) {
+                pChainSlot = pSlot;
+                break;
+            }
+        }
+    }
+    VERIFY_OR_DEBUG_ASSERT(pChainSlot) {
+        return;
+    }
+
+    intRegEx.indexIn(parts.at(2));
+    EffectSlotPointer pEffectSlot =
+            pChainSlot->getEffectSlot(intRegEx.cap(1).toInt() - 1);
+    VERIFY_OR_DEBUG_ASSERT(pEffectSlot) {
+        return;
+    }
+
+    intRegEx.indexIn(configKey.item);
+    EffectParameterSlotBasePointer pParameterSlot =
+            pEffectSlot->getEffectParameterSlot(intRegEx.cap(1).toInt() - 1);
+    VERIFY_OR_DEBUG_ASSERT(pParameterSlot) {
+        return;
+    }
+    setEffectParameterSlot(pParameterSlot);
+}
+
+void WEffectParameterKnobComposed::setEffectParameterSlot(
+        EffectParameterSlotBasePointer pParameterSlot) {
+    m_pEffectParameterSlot = pParameterSlot;
+    if (m_pEffectParameterSlot) {
+        connect(m_pEffectParameterSlot.data(), SIGNAL(updated()),
+                this, SLOT(parameterUpdated()));
+    }
+    parameterUpdated();
+}
 
 void WEffectParameterKnobComposed::parameterUpdated() {
     if (m_pEffectParameterSlot) {
@@ -32,14 +71,4 @@ void WEffectParameterKnobComposed::parameterUpdated() {
         // indicates no parameter is loaded, so this tooltip should never be shown.
         setBaseTooltip("");
     }
-}
-
-void WEffectParameterKnobComposed::setEffectParameterSlot(
-        EffectParameterSlotBasePointer pParameterSlot) {
-    m_pEffectParameterSlot = pParameterSlot;
-    if (m_pEffectParameterSlot) {
-        connect(m_pEffectParameterSlot.data(), SIGNAL(updated()),
-                this, SLOT(parameterUpdated()));
-    }
-    parameterUpdated();
 }

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -24,10 +24,9 @@ void WEffectParameterKnobComposed::setup(const QDomNode& node,
 
 void WEffectParameterKnobComposed::parameterUpdated() {
     if (m_pEffectParameterSlot) {
-        //: %1 = effect parameter name; %2 = effect parameter description
-        setBaseTooltip(tr("%1: %2").arg(
-                          m_pEffectParameterSlot->name(),
-                          m_pEffectParameterSlot->description()));
+        setBaseTooltip(QString("%1\n%2").arg(
+                       m_pEffectParameterSlot->name(),
+                       m_pEffectParameterSlot->description()));
     } else {
         setBaseTooltip(tr("No effect loaded."));
     }

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -28,7 +28,9 @@ void WEffectParameterKnobComposed::parameterUpdated() {
                        m_pEffectParameterSlot->name(),
                        m_pEffectParameterSlot->description()));
     } else {
-        setBaseTooltip(tr("No effect loaded."));
+        // The knob should be hidden by the skin when the parameterX_loaded ControlObject
+        // indicates no parameter is loaded, so this tooltip should never be shown.
+        setBaseTooltip("");
     }
 }
 

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -1,0 +1,48 @@
+#include "widget/effectwidgetutils.h"
+#include "widget/weffectparameterknobcomposed.h"
+
+void WEffectParameterKnobComposed::setup(const QDomNode& node,
+                                         const SkinContext& context) {
+    WKnobComposed::setup(node, context);
+
+    EffectRackPointer pRack = EffectWidgetUtils::getEffectRackFromNode(
+            node, context, m_pEffectsManager);
+    EffectChainSlotPointer pChainSlot = EffectWidgetUtils::getEffectChainSlotFromNode(
+            node, context, pRack);
+    EffectSlotPointer pEffectSlot = EffectWidgetUtils::getEffectSlotFromNode(
+            node, context, pChainSlot);
+    EffectParameterSlotBasePointer pParameterSlot =
+            EffectWidgetUtils::getParameterSlotFromNode(
+                    node, context, pEffectSlot);
+    if (pParameterSlot) {
+        setEffectParameterSlot(pParameterSlot);
+    } else {
+        SKIN_WARNING(node, context)
+                << "EffectParameterKnobComposed node could not attach to effect parameter";
+    }
+};
+
+void WEffectParameterKnobComposed::parameterUpdated() {
+    if (m_pEffectParameterSlot) {
+        if (!m_pEffectParameterSlot->shortName().isEmpty()) {
+            //: %1 = effect parameter name; %2 = effect parameter description
+            setBaseTooltip(tr("%1: %2").arg(
+                              m_pEffectParameterSlot->name(),
+                              m_pEffectParameterSlot->description()));
+        } else {
+            setBaseTooltip(m_pEffectParameterSlot->description());
+        }
+    } else {
+        setBaseTooltip(tr("No effect loaded."));
+    }
+}
+
+void WEffectParameterKnobComposed::setEffectParameterSlot(
+        EffectParameterSlotBasePointer pParameterSlot) {
+    m_pEffectParameterSlot = pParameterSlot;
+    if (m_pEffectParameterSlot) {
+        connect(m_pEffectParameterSlot.data(), SIGNAL(updated()),
+                this, SLOT(parameterUpdated()));
+    }
+    parameterUpdated();
+}

--- a/src/widget/weffectparameterknobcomposed.h
+++ b/src/widget/weffectparameterknobcomposed.h
@@ -12,7 +12,7 @@ class WEffectParameterKnobComposed : public WKnobComposed {
         m_pEffectsManager(pEffectsManager) {
     };
 
-    void setup(const QDomNode& node, const SkinContext& context);
+    void setupEffectParameterSlot(const ConfigKey& configKey);
 
   private slots:
     void parameterUpdated();

--- a/src/widget/weffectparameterknobcomposed.h
+++ b/src/widget/weffectparameterknobcomposed.h
@@ -1,0 +1,29 @@
+#ifndef WEFFECTKNOBCOMPOSED_H
+#define WEFFECTKNOBCOMPOSED_H
+
+#include "widget/wknobcomposed.h"
+#include "effects/effectparameterslotbase.h"
+
+class WEffectParameterKnobComposed : public WKnobComposed {
+  Q_OBJECT
+  public:
+    WEffectParameterKnobComposed(QWidget* pParent, EffectsManager* pEffectsManager) :
+        WKnobComposed(pParent),
+        m_pEffectsManager(pEffectsManager) {
+    };
+
+    void setup(const QDomNode& node, const SkinContext& context);
+
+  private slots:
+    void parameterUpdated();
+
+  private:
+    // Set the EffectParameterSlot that should be monitored by this
+    // WEffectKnobComposed.
+    void setEffectParameterSlot(EffectParameterSlotBasePointer pEffectParameterSlot);
+
+    EffectsManager* m_pEffectsManager;
+    EffectParameterSlotBasePointer m_pEffectParameterSlot;
+};
+
+#endif // WEFFECTKNOBCOMPOSED_H

--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -86,6 +86,15 @@ void WEffectPushButton::mouseReleaseEvent(QMouseEvent* e) {
 }
 
 void WEffectPushButton::parameterUpdated() {
+    // Set tooltip
+    if (m_pEffectParameterSlot) {
+        setBaseTooltip(QString("%1\n%2").arg(
+                       m_pEffectParameterSlot->name(),
+                       m_pEffectParameterSlot->description()));
+    } else {
+        setBaseTooltip(tr("No effect loaded."));
+    }
+
     m_pButtonMenu->clear();
     const QList<QPair<QString, double> >& options = m_pEffectParameterSlot->getManifest().getSteps();
     // qDebug() << " HERE IS THE OPTIONS SIZE: " << options.size() << m_pEffectParameterSlot->getManifest().name();

--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -92,7 +92,10 @@ void WEffectPushButton::parameterUpdated() {
                        m_pEffectParameterSlot->name(),
                        m_pEffectParameterSlot->description()));
     } else {
-        setBaseTooltip(tr("No effect loaded."));
+        // The button should be hidden by the skin when the buttonparameterX_loaded
+        // ControlObject indicates no parameter is loaded, so this tooltip should
+        // never be shown.
+        setBaseTooltip("");
     }
 
     m_pButtonMenu->clear();

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -57,8 +57,12 @@ void WEffectSelector::populate() {
                                                        width() - 2);
         addItem(elidedDisplayName, QVariant(manifest.id()));
 
+        // NOTE(Be): Using \n instead of : as the separator does not work in
+        // QComboBox item tooltips.
+        // TODO(Be): Check if this is also the case with Qt5.
         //: %1 = effect name; %2 = effect description
-        QString description = tr("%1: %2").arg(manifest.name(), manifest.description());
+        QString description = tr("%1: %2").arg(manifest.name(),
+                                               manifest.description());
         // The <span/> is a hack to get Qt to treat the string as rich text so
         // it automatically wraps long lines.
         setItemData(i, QVariant("<span/>" + description), Qt::ToolTipRole);


### PR DESCRIPTION
Make a new subclass of WKnobComposed that shows the effect parameter description as the tooltip. Previously effect parameter descriptions were only shown when hovering the cursor over effect parameter names, which is not easily discoverable.