### PR TITLE
Fix biquad EQ

### DIFF
--- a/src/effects/native/threebandbiquadeqeffect.cpp
+++ b/src/effects/native/threebandbiquadeqeffect.cpp
@@ -34,7 +34,7 @@ double knobValueToBiquadGainDb (double value, bool kill) {
     }
 
     double ret = value - 1;
-    if (value >= 0) {
+    if (ret >= 0) {
         ret *= kBoostGain;
     } else {
         ret *= -kKillGain;

--- a/src/effects/native/threebandbiquadeqeffect.cpp
+++ b/src/effects/native/threebandbiquadeqeffect.cpp
@@ -17,7 +17,7 @@ static const double kQBoost = 0.3;
 static const double kQKill = 0.9;
 static const double kQKillShelve = 0.4;
 static const double kBoostGain = 12;
-static const double kKillGain = -23;
+static const double kKillGain = -36;
 
 
 double getCenterFrequency(double low, double high) {

--- a/src/effects/native/threebandbiquadeqeffect.cpp
+++ b/src/effects/native/threebandbiquadeqeffect.cpp
@@ -17,7 +17,7 @@ static const double kQBoost = 0.3;
 static const double kQKill = 0.9;
 static const double kQKillShelve = 0.4;
 static const double kBoostGain = 12;
-static const double kKillGain = -36;
+static const double kKillGain = -26;
 
 
 double getCenterFrequency(double low, double high) {


### PR DESCRIPTION
When playing with parameter ranges for #1310 I took a look at the code for the 3 band biquad EQ and realized the cut & boost were symmetric instead of asymmetric as they were intended. After fixing that bug, I increased the limit of how much it cuts to -36 dB, which is an arbitrary value that seems to work well. I just chose it because it's an integer multiple of the boost amount (+12 dB).

I think this obviates the need for the biquad + Bessel combination EQ that does not sound as good. There's no need to remove that when it's working, but I think the plain 3 band biquad should be the default. It's close enough to a full kill that I think very few users would care that it's not 100% kill.