### PR TITLE
hide latency compensation warning when changing mic monitor mode

### DIFF
--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -689,6 +689,7 @@ void DlgPrefSound::checkLatencyCompensation() {
             }
         } else {
             latencyCompensationSpinBox->setEnabled(false);
+            latencyCompensationWarningLabel->hide();
         }
     } else {
         micMonitorModeComboBox->setEnabled(false);


### PR DESCRIPTION
It should only be shown when using direct monitor mode.