### PR TITLE
EffectParameterKnob

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -856,6 +856,7 @@ class MixxxCore(Feature):
                    "widget/weffect.cpp",
                    "widget/weffectselector.cpp",
                    "widget/weffectparameter.cpp",
+                   "widget/weffectparameterknob.cpp",
                    "widget/weffectparameterknobcomposed.cpp",
                    "widget/weffectbuttonparameter.cpp",
                    "widget/weffectparameterbase.cpp",

--- a/res/skins/Deere/effect_button_parameter.xml
+++ b/res/skins/Deere/effect_button_parameter.xml
@@ -19,10 +19,6 @@
           <EffectPushButton>
             <Size>55f,15f</Size>
             <ObjectName>EffectButton</ObjectName>
-            <EffectRack><Variable name="EffectRack"/></EffectRack>
-            <EffectUnit><Variable name="EffectUnit"/></EffectUnit>
-            <Effect><Variable name="Effect"/></Effect>
-            <EffectButtonParameter><Variable name="EffectButtonParameter"/></EffectButtonParameter>
             <NumberStates>2</NumberStates>
               <State>
                 <Number>0</Number>

--- a/res/skins/Deere/equalizer_rack_parameter_left.xml
+++ b/res/skins/Deere/equalizer_rack_parameter_left.xml
@@ -34,10 +34,6 @@
             <TooltipId><Variable name="button_TooltipId"/></TooltipId>
             <Size>15f,15f</Size>
             <ObjectName>CircleButton</ObjectName>
-            <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
-            <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
-            <Effect><Variable name="EffectNumber"/></Effect>
-            <EffectButtonParameter><Variable name="parameter"/></EffectButtonParameter>
             <NumberStates>2</NumberStates>
             <State>
               <Number>0</Number>

--- a/res/skins/Deere/equalizer_rack_parameter_right.xml
+++ b/res/skins/Deere/equalizer_rack_parameter_right.xml
@@ -89,10 +89,6 @@
             <TooltipId><Variable name="button_TooltipId"/></TooltipId>
             <Size>15f,15f</Size>
             <ObjectName>CircleButton</ObjectName>
-            <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
-            <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
-            <Effect><Variable name="EffectNumber"/></Effect>
-            <EffectButtonParameter><Variable name="parameter"/></EffectButtonParameter>
             <NumberStates>2</NumberStates>
             <State>
               <Number>0</Number>

--- a/res/skins/Deere/quick_effect_superknob_left.xml
+++ b/res/skins/Deere/quick_effect_superknob_left.xml
@@ -15,7 +15,7 @@
     <Layout>horizontal</Layout>
     <Children>
 
-      <!--Wrap the EffectPushButton in a vertical WidgetGroup with spacers to ensure it stays in the
+      <!--Wrap the PushButton in a vertical WidgetGroup with spacers to ensure it stays in the
       correct position when the knobs get further apart and closer together.-->
       <WidgetGroup>
         <Layout>vertical</Layout>

--- a/res/skins/Deere/quick_effect_superknob_left.xml
+++ b/res/skins/Deere/quick_effect_superknob_left.xml
@@ -27,14 +27,10 @@
             <Children/>
           </WidgetGroup>
 
-          <EffectPushButton>
+          <PushButton>
             <TooltipId><Variable name="button_TooltipId"/></TooltipId>
             <Size>15f,15f</Size>
             <ObjectName>CircleButton</ObjectName>
-            <EffectRackGroup><Variable name="QuickEffectRackGroup"/></EffectRackGroup>
-            <EffectUnitGroup><Variable name="QuickEffectUnitGroup"/></EffectUnitGroup>
-            <Effect><Variable name="QuickEffect"/></Effect>
-            <EffectButtonParameter><Variable name="QuickEffect"/></EffectButtonParameter>
             <NumberStates>2</NumberStates>
             <State>
               <Number>0</Number>
@@ -52,7 +48,7 @@
               <ConfigKey><Variable name="QuickEffectEffectGroup"/>,enabled</ConfigKey>
               <ButtonState>LeftButton</ButtonState>
             </Connection>
-          </EffectPushButton>
+          </PushButton>
 
           <WidgetGroup>
             <Layout>vertical</Layout>

--- a/res/skins/Deere/quick_effect_superknob_right.xml
+++ b/res/skins/Deere/quick_effect_superknob_right.xml
@@ -69,14 +69,10 @@
             <Children/>
           </WidgetGroup>
 
-          <EffectPushButton>
+          <PushButton>
             <TooltipId><Variable name="button_TooltipId"/></TooltipId>
             <Size>15f,15f</Size>
             <ObjectName>CircleButton</ObjectName>
-            <EffectRackGroup><Variable name="QuickEffectRackGroup"/></EffectRackGroup>
-            <EffectUnitGroup><Variable name="QuickEffectUnitGroup"/></EffectUnitGroup>
-            <Effect><Variable name="QuickEffect"/></Effect>
-            <EffectButtonParameter><Variable name="QuickEffect"/></EffectButtonParameter>
             <NumberStates>2</NumberStates>
             <State>
               <Number>0</Number>
@@ -94,7 +90,7 @@
               <ConfigKey><Variable name="QuickEffectEffectGroup"/>,enabled</ConfigKey>
               <ButtonState>LeftButton</ButtonState>
             </Connection>
-          </EffectPushButton>
+          </PushButton>
 
           <WidgetGroup>
             <Layout>vertical</Layout>

--- a/res/skins/Deere/quick_effect_superknob_right.xml
+++ b/res/skins/Deere/quick_effect_superknob_right.xml
@@ -57,7 +57,7 @@
         </Children>
       </SizeAwareStack>
 
-      <!--Wrap the EffectPushButton in a vertical WidgetGroup with spacers to ensure it stays in the
+      <!--Wrap the PushButton in a vertical WidgetGroup with spacers to ensure it stays in the
       correct position when the knobs get further apart and closer together.-->
       <WidgetGroup>
         <Layout>vertical</Layout>

--- a/res/skins/LateNight/eq_knob.xml
+++ b/res/skins/LateNight/eq_knob.xml
@@ -20,10 +20,6 @@
                 <MinimumSize>26,30</MinimumSize>
                 <Children>
                     <EffectPushButton>
-                        <EffectRackGroup><Variable name="EqualizerRackGroup"/></EffectRackGroup>
-                        <EffectUnitGroup><Variable name="EqualizerEffectUnitGroup"/></EffectUnitGroup>
-                        <Effect><Variable name="EffectNumber"/></Effect>
-                        <EffectButtonParameter><Variable name="parameter"/></EffectButtonParameter>
                         <NumberStates>2</NumberStates>
                         <State>
                             <Number>0</Number>

--- a/res/skins/Shade/effect_parameter_button.xml
+++ b/res/skins/Shade/effect_parameter_button.xml
@@ -38,14 +38,6 @@
 			<Size>38,26</Size>
 			<Children>
 				<EffectPushButton>
-					<TooltipId></TooltipId>
-					<Style></Style>
-					
-					<EffectRack>1</EffectRack>
-					<EffectUnit><Variable name="effectunitnum"/></EffectUnit>
-					<Effect><Variable name="effectnum"/></Effect>
-					<EffectButtonParameter><Variable name="effectparameternum"/></EffectButtonParameter>
-	
 					<NumberStates>2</NumberStates>
 					<State>
 						<Number>0</Number>

--- a/res/skins/Shade/effect_parameter_knob.xml
+++ b/res/skins/Shade/effect_parameter_knob.xml
@@ -37,14 +37,14 @@
 				<Layout>vertical</Layout>
 				<Size>38,26</Size>
 				<Children>
-					<Knob>			
+					<EffectParameterKnob>			
 						<Style></Style>
 						<NumberStates>64</NumberStates>
 						<Path>knobs/knob_rotary_s%1.png</Path>
 						<Connection>
 							<ConfigKey>[EffectRack1_EffectUnit<Variable name="effectunitnum"/>_Effect<Variable name="effectnum"/>],parameter<Variable name="effectparameternum"/></ConfigKey>
 						</Connection>
-					</Knob>
+					</EffectParameterKnob>
 					<PushButton>
 						<Size>38f,8f</Size>
 						<NumberStates>5</NumberStates>

--- a/res/skins/Shade/mixer_panel.xml
+++ b/res/skins/Shade/mixer_panel.xml
@@ -754,48 +754,42 @@
 								<ConfigKey>[Channel1],pregain</ConfigKey>
 							</Connection>
 						</Knob>
-						<Knob>
-							<TooltipId>filterHigh</TooltipId>
-							<Style></Style>
+						<EffectParameterKnob>
 							<NumberStates>64</NumberStates>
 							<Path>knobs/knob_rotary_s%1.png</Path>
 							<Pos>32,112</Pos>
 							<Connection>
-								<ConfigKey>[Channel1],filterHigh</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel1]_Effect1],parameter3</ConfigKey>
 							</Connection>
-								<Connection>
-						        	<ConfigKey>[Channel1],filterHigh_loaded</ConfigKey>
-						        	<BindProperty>visible</BindProperty>
-					        	</Connection>
-						</Knob>
-						<Knob>
-							<TooltipId>filterMid</TooltipId>
-							<Style></Style>
+							<Connection>
+								<ConfigKey>[EqualizerRack1_[Channel1]_Effect1],parameter3_loaded</ConfigKey>
+								<BindProperty>visible</BindProperty>
+							</Connection>
+						</EffectParameterKnob>
+						<EffectParameterKnob>
 							<NumberStates>64</NumberStates>
 							<Path>knobs/knob_rotary_s%1.png</Path>
 							<Pos>32,141</Pos>
 							<Connection>
-								<ConfigKey>[Channel1],filterMid</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel1]_Effect1],parameter2</ConfigKey>
 							</Connection>
 							<Connection>
-						        	<ConfigKey>[Channel1],filterMid_loaded</ConfigKey>
-						        	<BindProperty>visible</BindProperty>
-					        	</Connection>
-						</Knob>
-						<Knob>
-							<TooltipId>filterLow</TooltipId>
-							<Style></Style>
+							<ConfigKey>[EqualizerRack1_[Channel1]_Effect1],parameter2_loaded</ConfigKey>
+								<BindProperty>visible</BindProperty>
+							</Connection>
+						</EffectParameterKnob>
+						<EffectParameterKnob>
 							<NumberStates>64</NumberStates>
 							<Path>knobs/knob_rotary_s%1.png</Path>
 							<Pos>32,170</Pos>
 							<Connection>
-								<ConfigKey>[Channel1],filterLow</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel1]_Effect1],parameter1</ConfigKey>
 							</Connection>
 							<Connection>
-								<ConfigKey>[Channel1],filterLow_loaded</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel1]_Effect1],parameter1_loaded</ConfigKey>
 								<BindProperty>visible</BindProperty>
 							</Connection>
-						</Knob>
+						</EffectParameterKnob>
 
 						<Knob>
 							<TooltipId>pregain</TooltipId>
@@ -807,48 +801,46 @@
 								<ConfigKey>[Channel2],pregain</ConfigKey>
 							</Connection>
 						</Knob>
-						<Knob>
-							<TooltipId>filterHigh</TooltipId>
-							<Style></Style>
+						<EffectParameterKnob>
 							<NumberStates>64</NumberStates>
 							<Path>knobs/knob_rotary_s%1.png</Path>
 							<Pos>196,112</Pos>
 							<Connection>
-								<ConfigKey>[Channel2],filterHigh</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel2]_Effect1],parameter3</ConfigKey>
 							</Connection>
 							<Connection>
-						        	<ConfigKey>[Channel2],filterHigh_loaded</ConfigKey>
-						        	<BindProperty>visible</BindProperty>
-					        	</Connection>
-						</Knob>
-						<Knob>
+								<ConfigKey>[EqualizerRack1_[Channel2]_Effect1],parameter3_loaded</ConfigKey>
+								<BindProperty>visible</BindProperty>
+							</Connection>
+						</EffectParameterKnob>
+						<EffectParameterKnob>
 							<TooltipId>filterMid</TooltipId>
 							<Style></Style>
 							<NumberStates>64</NumberStates>
 							<Path>knobs/knob_rotary_s%1.png</Path>
 							<Pos>196,141</Pos>
 							<Connection>
-								<ConfigKey>[Channel2],filterMid</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel2]_Effect1],parameter2</ConfigKey>
 							</Connection>
 							<Connection>
-						        	<ConfigKey>[Channel2],filterMid_loaded</ConfigKey>
-						        	<BindProperty>visible</BindProperty>
-					        	</Connection>
-						</Knob>
-						<Knob>
+								<ConfigKey>[EqualizerRack1_[Channel2]_Effect1],parameter2_loaded</ConfigKey>
+								<BindProperty>visible</BindProperty>
+							</Connection>
+						</EffectParameterKnob>
+						<EffectParameterKnob>
 							<TooltipId>filterLow</TooltipId>
 							<Style></Style>
 							<NumberStates>64</NumberStates>
 							<Path>knobs/knob_rotary_s%1.png</Path>
 							<Pos>196,170</Pos>
 							<Connection>
-								<ConfigKey>[Channel2],filterLow</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel2]_Effect1],parameter1</ConfigKey>
 							</Connection>
 							<Connection>
-								<ConfigKey>[Channel2],filterLow_loaded</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel2]_Effect1],parameter1_loaded</ConfigKey>
 								<BindProperty>visible</BindProperty>
 							</Connection>
-						</Knob>
+						</EffectParameterKnob>
 
 						<!--
 						**********************************************

--- a/res/skins/Shade/mixer_panel.xml
+++ b/res/skins/Shade/mixer_panel.xml
@@ -407,9 +407,7 @@
 						Button- Frequency Kill
 						**********************************************
 						-->
-						<PushButton>
-							<TooltipId>filterHighKill</TooltipId>
-							<Style></Style>
+						<EffectPushButton>
 							<NumberStates>2</NumberStates>
 							<State>
 								<Number>0</Number>
@@ -423,18 +421,16 @@
 							</State>
 							<Pos>11,120</Pos>
 							<Connection>
-								<ConfigKey>[Channel1],filterHighKill</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel1]_Effect1],button_parameter3</ConfigKey>
 								<EmitOnPressAndRelease>true</EmitOnPressAndRelease>
 								<ButtonState>LeftButton</ButtonState>
 							</Connection>
 							<Connection>
-						        <ConfigKey>[Channel1],filterHighKill_loaded</ConfigKey>
+						        <ConfigKey>[EqualizerRack1_[Channel1]_Effect1],button_parameter3_loaded</ConfigKey>
 						        <BindProperty>visible</BindProperty>
 					        </Connection>
-						</PushButton>
-						<PushButton>
-							<TooltipId>filterMidKill</TooltipId>
-							<Style></Style>
+						</EffectPushButton>
+						<EffectPushButton>
 							<NumberStates>2</NumberStates>
 							<State>
 								<Number>0</Number>
@@ -448,18 +444,16 @@
 							</State>
 							<Pos>11,149</Pos>
 							<Connection>
-								<ConfigKey>[Channel1],filterMidKill</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel1]_Effect1],button_parameter2</ConfigKey>
 								<EmitOnPressAndRelease>true</EmitOnPressAndRelease>
 								<ButtonState>LeftButton</ButtonState>
 							</Connection>
 							<Connection>
-						        <ConfigKey>[Channel1],filterMidKill_loaded</ConfigKey>
+						        <ConfigKey>[EqualizerRack1_[Channel1]_Effect1],button_parameter2_loaded</ConfigKey>
 						        <BindProperty>visible</BindProperty>
 					        </Connection>
-						</PushButton>
-						<PushButton>
-							<TooltipId>filterLowKill</TooltipId>
-							<Style></Style>
+						</EffectPushButton>
+						<EffectPushButton>
 							<NumberStates>2</NumberStates>
 							<State>
 								<Number>0</Number>
@@ -473,19 +467,17 @@
 							</State>
 							<Pos>11,178</Pos>
 							<Connection>
-								<ConfigKey>[Channel1],filterLowKill</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel1]_Effect1],button_parameter1</ConfigKey>
 								<EmitOnPressAndRelease>true</EmitOnPressAndRelease>
 								<ButtonState>LeftButton</ButtonState>
 							</Connection>
 							<Connection>
-								<ConfigKey>[Channel1],filterLowKill_loaded</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel1]_Effect1],button_parameter1_loaded</ConfigKey>
 								<BindProperty>visible</BindProperty>
 							</Connection>
-						</PushButton>
+						</EffectPushButton>
 
-						<PushButton>
-							<TooltipId>filterHighKill</TooltipId>
-							<Style></Style>
+						<EffectPushButton>
 							<NumberStates>2</NumberStates>
 							<State>
 								<Number>0</Number>
@@ -499,18 +491,16 @@
 							</State>
 							<Pos>229,120</Pos>
 							<Connection>
-								<ConfigKey>[Channel2],filterHighKill</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel2]_Effect1],button_parameter3</ConfigKey>
 								<EmitOnPressAndRelease>true</EmitOnPressAndRelease>
 								<ButtonState>LeftButton</ButtonState>
 							</Connection>
 							<Connection>
-								<ConfigKey>[Channel2],filterHighKill_loaded</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel2]_Effect1],button_parameter3_loaded</ConfigKey>
 								<BindProperty>visible</BindProperty>
 							</Connection>
-						</PushButton>
-						<PushButton>
-							<TooltipId>filterMidKill</TooltipId>
-							<Style></Style>
+						</EffectPushButton>
+						<EffectPushButton>
 							<NumberStates>2</NumberStates>
 							<State>
 								<Number>0</Number>
@@ -524,18 +514,16 @@
 							</State>
 							<Pos>229,149</Pos>
 							<Connection>
-								<ConfigKey>[Channel2],filterMidKill</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel2]_Effect1],button_parameter2</ConfigKey>
 								<EmitOnPressAndRelease>true</EmitOnPressAndRelease>
 								<ButtonState>LeftButton</ButtonState>
 							</Connection>
 								<Connection>
-						        	<ConfigKey>[Channel2],filterMidKill_loaded</ConfigKey>
+						        	<ConfigKey>[EqualizerRack1_[Channel1]_Effect2],button_parameter2_loaded</ConfigKey>
 						        	<BindProperty>visible</BindProperty>
 					        	</Connection>
-						</PushButton>
-						<PushButton>
-							<TooltipId>filterLowKill</TooltipId>
-							<Style></Style>
+						</EffectPushButton>
+						<EffectPushButton>
 							<NumberStates>2</NumberStates>
 							<State>
 								<Number>0</Number>
@@ -549,15 +537,15 @@
 							</State>
 							<Pos>229,178</Pos>
 							<Connection>
-								<ConfigKey>[Channel2],filterLowKill</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel2]_Effect1],button_parameter1</ConfigKey>
 								<EmitOnPressAndRelease>true</EmitOnPressAndRelease>
 								<ButtonState>LeftButton</ButtonState>
 							</Connection>
 							<Connection>
-								<ConfigKey>[Channel2],filterLowKill_loaded</ConfigKey>
+								<ConfigKey>[EqualizerRack1_[Channel2]_Effect1],button_parameter1_loaded</ConfigKey>
 								<BindProperty>visible</BindProperty>
 							</Connection>
-						</PushButton>
+						</EffectPushButton>
 
 						<!--
 						**********************************************

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -37,6 +37,7 @@ class EffectSlot : public QObject {
     unsigned int numParameterSlots() const;
     EffectParameterSlotPointer addEffectParameterSlot();
     EffectParameterSlotPointer getEffectParameterSlot(unsigned int slotNumber);
+    EffectParameterSlotPointer getEffectParameterSlotForConfigKey(unsigned int slotNumber);
     inline const QList<EffectParameterSlotPointer>& getEffectParameterSlots() const {
         return m_parameters;
     };

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -10,8 +10,6 @@
 #include "util/assert.h"
 
 namespace {
-const char* kEqualizerRackName = "[EqualizerChain]";
-const char* kQuickEffectRackName = "[QuickEffectChain]";
 const QString kEffectGroupSeparator = "_";
 const QString kGroupClose = "]";
 } // anonymous namespace

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -60,6 +60,8 @@ class EffectsManager : public QObject {
 
     EffectParameterSlotPointer getEffectParameterSlot(
             const ConfigKey& configKey);
+    EffectButtonParameterSlotPointer getEffectButtonParameterSlot(
+            const ConfigKey& configKey);
 
     QString getNextEffectId(const QString& effectId);
     QString getPrevEffectId(const QString& effectId);

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -57,6 +57,7 @@ class EffectsManager : public QObject {
     QuickEffectRackPointer getQuickEffectRack(int rack);
 
     EffectRackPointer getEffectRack(const QString& group);
+    EffectSlotPointer getEffectSlot(const QString& group);
 
     EffectParameterSlotPointer getEffectParameterSlot(
             const ConfigKey& configKey);

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -58,6 +58,9 @@ class EffectsManager : public QObject {
 
     EffectRackPointer getEffectRack(const QString& group);
 
+    EffectParameterSlotPointer getEffectParameterSlot(
+            const ConfigKey& configKey);
+
     QString getNextEffectId(const QString& effectId);
     QString getPrevEffectId(const QString& effectId);
 

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1641,6 +1641,9 @@ QWidget* LegacySkinParser::parseEffectParameterKnob(const QDomElement& node) {
             pParameterKnob->connections();
     if (!connections.isEmpty()) {
         pParameterKnob->setupEffectParameterSlot(connections.at(0)->getKey());
+    } else {
+        SKIN_WARNING(node, *m_pContext)
+                << "EffectParameterKnob node could not attach to effect parameter.";
     }
     return pParameterKnob;
 }
@@ -1658,6 +1661,9 @@ QWidget* LegacySkinParser::parseEffectParameterKnobComposed(const QDomElement& n
             pParameterKnob->connections();
     if (!connections.isEmpty()) {
         pParameterKnob->setupEffectParameterSlot(connections.at(0)->getKey());
+    } else {
+        SKIN_WARNING(node, *m_pContext)
+                << "EffectParameterKnobComposed node could not attach to effect parameter.";
     }
     return pParameterKnob;
 }
@@ -1670,6 +1676,14 @@ QWidget* LegacySkinParser::parseEffectPushButton(const QDomElement& element) {
     pWidget->installEventFilter(
             m_pControllerManager->getControllerLearningEventFilter());
     pWidget->Init();
+    const QList<ControlParameterWidgetConnection*> connections =
+            pWidget->leftConnections();
+    if (!connections.isEmpty()) {
+        pWidget->setupEffectParameterSlot(connections.at(0)->getKey());
+    } else {
+        SKIN_WARNING(element, *m_pContext)
+                << "EffectPushButton node could not attach to effect parameter.";
+    }
     return pWidget;
 }
 

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -58,6 +58,7 @@
 #include "widget/weffect.h"
 #include "widget/weffectselector.h"
 #include "widget/weffectparameter.h"
+#include "widget/weffectparameterknob.h"
 #include "widget/weffectparameterknobcomposed.h"
 #include "widget/weffectbuttonparameter.h"
 #include "widget/weffectparameterbase.h"
@@ -554,6 +555,8 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
         result = wrapWidget(parseEffectName(node));
     } else if (nodeName == "EffectSelector") {
         result = wrapWidget(parseEffectSelector(node));
+    } else if (nodeName == "EffectParameterKnob") {
+        result = wrapWidget(parseEffectParameterKnob(node));
     } else if (nodeName == "EffectParameterKnobComposed") {
         result = wrapWidget(parseEffectParameterKnobComposed(node));
     } else if (nodeName == "EffectParameterName") {
@@ -1623,6 +1626,23 @@ QWidget* LegacySkinParser::parseEffectSelector(const QDomElement& node) {
         m_pControllerManager->getControllerLearningEventFilter());
     pSelector->Init();
     return pSelector;
+}
+
+QWidget* LegacySkinParser::parseEffectParameterKnob(const QDomElement& node) {
+    WEffectParameterKnob* pParameterKnob =
+            new WEffectParameterKnob(m_pParent, m_pEffectsManager);
+    commonWidgetSetup(node, pParameterKnob);
+    pParameterKnob->setup(node, *m_pContext);
+    pParameterKnob->installEventFilter(m_pKeyboard);
+    pParameterKnob->installEventFilter(
+        m_pControllerManager->getControllerLearningEventFilter());
+    pParameterKnob->Init();
+    const QList<ControlParameterWidgetConnection*> connections =
+            pParameterKnob->connections();
+    if (!connections.isEmpty()) {
+        pParameterKnob->setupEffectParameterSlot(connections.at(0)->getKey());
+    }
+    return pParameterKnob;
 }
 
 QWidget* LegacySkinParser::parseEffectParameterKnobComposed(const QDomElement& node) {

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -81,6 +81,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     QWidget* parseEffectChainName(const QDomElement& node);
     QWidget* parseEffectName(const QDomElement& node);
     QWidget* parseEffectParameterName(const QDomElement& node);
+    QWidget* parseEffectParameterKnob(const QDomElement& node);
     QWidget* parseEffectParameterKnobComposed(const QDomElement& node);
     QWidget* parseEffectButtonParameterName(const QDomElement& node);
     QWidget* parseEffectPushButton(const QDomElement& node);

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -57,6 +57,10 @@ class WBaseWidget {
     inline const QList<ControlParameterWidgetConnection*>& connections() const {
         return m_connections;
     };
+    inline const QList<ControlParameterWidgetConnection*>& leftConnections() const {
+        return m_leftConnections;
+    };
+
 
   protected:
     // Whenever a connected control is changed, onConnectedControlChanged is

--- a/src/widget/weffectparameterknob.cpp
+++ b/src/widget/weffectparameterknob.cpp
@@ -1,50 +1,9 @@
 #include "widget/effectwidgetutils.h"
 #include "widget/weffectparameterknob.h"
 
-namespace {
-const QString effectGroupSeparator = "_";
-const QString groupClose = "]";
-} // anonymous namespace
-
 void WEffectParameterKnob::setupEffectParameterSlot(const ConfigKey& configKey) {
-    QStringList parts = configKey.group.split(effectGroupSeparator);
-    QRegExp intRegEx(".*(\\d+).*");
-
-    EffectRackPointer pRack = m_pEffectsManager->getEffectRack(parts.at(0) + groupClose);
-    VERIFY_OR_DEBUG_ASSERT(pRack) {
-        return;
-    }
-
-    EffectChainSlotPointer pChainSlot;
-    if (parts.at(0) == "[EffectRack1") {
-        intRegEx.indexIn(parts.at(1));
-        pChainSlot = pRack->getEffectChainSlot(intRegEx.cap(1).toInt() - 1);
-    } else {
-        // Assume a PerGroupRack
-        const QString chainGroup =
-                parts.at(0) + effectGroupSeparator + parts.at(1) + groupClose;
-        for (int i = 0; i < pRack->numEffectChainSlots(); ++i) {
-            EffectChainSlotPointer pSlot = pRack->getEffectChainSlot(i);
-            if (pSlot->getGroup() == chainGroup) {
-                pChainSlot = pSlot;
-                break;
-            }
-        }
-    }
-    VERIFY_OR_DEBUG_ASSERT(pChainSlot) {
-        return;
-    }
-
-    intRegEx.indexIn(parts.at(2));
-    EffectSlotPointer pEffectSlot =
-            pChainSlot->getEffectSlot(intRegEx.cap(1).toInt() - 1);
-    VERIFY_OR_DEBUG_ASSERT(pEffectSlot) {
-        return;
-    }
-
-    intRegEx.indexIn(configKey.item);
-    EffectParameterSlotBasePointer pParameterSlot =
-            pEffectSlot->getEffectParameterSlot(intRegEx.cap(1).toInt() - 1);
+    EffectParameterSlotPointer pParameterSlot =
+            m_pEffectsManager->getEffectParameterSlot(configKey);
     VERIFY_OR_DEBUG_ASSERT(pParameterSlot) {
         return;
     }
@@ -52,7 +11,7 @@ void WEffectParameterKnob::setupEffectParameterSlot(const ConfigKey& configKey) 
 }
 
 void WEffectParameterKnob::setEffectParameterSlot(
-        EffectParameterSlotBasePointer pParameterSlot) {
+        EffectParameterSlotPointer pParameterSlot) {
     m_pEffectParameterSlot = pParameterSlot;
     if (m_pEffectParameterSlot) {
         connect(m_pEffectParameterSlot.data(), SIGNAL(updated()),

--- a/src/widget/weffectparameterknob.cpp
+++ b/src/widget/weffectparameterknob.cpp
@@ -1,0 +1,74 @@
+#include "widget/effectwidgetutils.h"
+#include "widget/weffectparameterknob.h"
+
+namespace {
+const QString effectGroupSeparator = "_";
+const QString groupClose = "]";
+} // anonymous namespace
+
+void WEffectParameterKnob::setupEffectParameterSlot(const ConfigKey& configKey) {
+    QStringList parts = configKey.group.split(effectGroupSeparator);
+    QRegExp intRegEx(".*(\\d+).*");
+
+    EffectRackPointer pRack = m_pEffectsManager->getEffectRack(parts.at(0) + groupClose);
+    VERIFY_OR_DEBUG_ASSERT(pRack) {
+        return;
+    }
+
+    EffectChainSlotPointer pChainSlot;
+    if (parts.at(0) == "[EffectRack1") {
+        intRegEx.indexIn(parts.at(1));
+        pChainSlot = pRack->getEffectChainSlot(intRegEx.cap(1).toInt() - 1);
+    } else {
+        // Assume a PerGroupRack
+        const QString chainGroup =
+                parts.at(0) + effectGroupSeparator + parts.at(1) + groupClose;
+        for (int i = 0; i < pRack->numEffectChainSlots(); ++i) {
+            EffectChainSlotPointer pSlot = pRack->getEffectChainSlot(i);
+            if (pSlot->getGroup() == chainGroup) {
+                pChainSlot = pSlot;
+                break;
+            }
+        }
+    }
+    VERIFY_OR_DEBUG_ASSERT(pChainSlot) {
+        return;
+    }
+
+    intRegEx.indexIn(parts.at(2));
+    EffectSlotPointer pEffectSlot =
+            pChainSlot->getEffectSlot(intRegEx.cap(1).toInt() - 1);
+    VERIFY_OR_DEBUG_ASSERT(pEffectSlot) {
+        return;
+    }
+
+    intRegEx.indexIn(configKey.item);
+    EffectParameterSlotBasePointer pParameterSlot =
+            pEffectSlot->getEffectParameterSlot(intRegEx.cap(1).toInt() - 1);
+    VERIFY_OR_DEBUG_ASSERT(pParameterSlot) {
+        return;
+    }
+    setEffectParameterSlot(pParameterSlot);
+}
+
+void WEffectParameterKnob::setEffectParameterSlot(
+        EffectParameterSlotBasePointer pParameterSlot) {
+    m_pEffectParameterSlot = pParameterSlot;
+    if (m_pEffectParameterSlot) {
+        connect(m_pEffectParameterSlot.data(), SIGNAL(updated()),
+                this, SLOT(parameterUpdated()));
+    }
+    parameterUpdated();
+}
+
+void WEffectParameterKnob::parameterUpdated() {
+    if (m_pEffectParameterSlot) {
+        setBaseTooltip(QString("%1\n%2").arg(
+                       m_pEffectParameterSlot->name(),
+                       m_pEffectParameterSlot->description()));
+    } else {
+        // The knob should be hidden by the skin when the parameterX_loaded ControlObject
+        // indicates no parameter is loaded, so this tooltip should never be shown.
+        setBaseTooltip("");
+    }
+}

--- a/src/widget/weffectparameterknob.cpp
+++ b/src/widget/weffectparameterknob.cpp
@@ -4,7 +4,9 @@
 void WEffectParameterKnob::setupEffectParameterSlot(const ConfigKey& configKey) {
     EffectParameterSlotPointer pParameterSlot =
             m_pEffectsManager->getEffectParameterSlot(configKey);
-    VERIFY_OR_DEBUG_ASSERT(pParameterSlot) {
+    if (!pParameterSlot) {
+        qWarning() << "EffectParameterKnob" << configKey <<
+                "is not an effect parameter.";
         return;
     }
     setEffectParameterSlot(pParameterSlot);

--- a/src/widget/weffectparameterknob.h
+++ b/src/widget/weffectparameterknob.h
@@ -1,0 +1,29 @@
+#ifndef WEFFECTKNOB_H
+#define WEFFECTKNOB_H
+
+#include "widget/wknob.h"
+#include "effects/effectparameterslotbase.h"
+
+class WEffectParameterKnob : public WKnob {
+  Q_OBJECT
+  public:
+    WEffectParameterKnob(QWidget* pParent, EffectsManager* pEffectsManager) :
+        WKnob(pParent),
+        m_pEffectsManager(pEffectsManager) {
+    };
+
+    void setupEffectParameterSlot(const ConfigKey& configKey);
+
+  private slots:
+    void parameterUpdated();
+
+  private:
+    // Set the EffectParameterSlot that should be monitored by this
+    // WEffectKnobComposed.
+    void setEffectParameterSlot(EffectParameterSlotBasePointer pEffectParameterSlot);
+
+    EffectsManager* m_pEffectsManager;
+    EffectParameterSlotBasePointer m_pEffectParameterSlot;
+};
+
+#endif // WEFFECTKNOB_H

--- a/src/widget/weffectparameterknob.h
+++ b/src/widget/weffectparameterknob.h
@@ -4,6 +4,11 @@
 #include "widget/wknob.h"
 #include "effects/effectparameterslot.h"
 
+// This is used for effect parameter knobs with dynamic
+// tooltips, if the knob value is displayed by one of e.g.
+// 64 pixmaps.
+// If the knob value can be displayed by rotating a single
+// SVG, use WEffectParameterKnobComposed.
 class WEffectParameterKnob : public WKnob {
   Q_OBJECT
   public:

--- a/src/widget/weffectparameterknob.h
+++ b/src/widget/weffectparameterknob.h
@@ -2,7 +2,7 @@
 #define WEFFECTKNOB_H
 
 #include "widget/wknob.h"
-#include "effects/effectparameterslotbase.h"
+#include "effects/effectparameterslot.h"
 
 class WEffectParameterKnob : public WKnob {
   Q_OBJECT
@@ -20,7 +20,7 @@ class WEffectParameterKnob : public WKnob {
   private:
     // Set the EffectParameterSlot that should be monitored by this
     // WEffectKnobComposed.
-    void setEffectParameterSlot(EffectParameterSlotBasePointer pEffectParameterSlot);
+    void setEffectParameterSlot(EffectParameterSlotPointer pParameterSlot);
 
     EffectsManager* m_pEffectsManager;
     EffectParameterSlotBasePointer m_pEffectParameterSlot;

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -7,44 +7,8 @@ const QString groupClose = "]";
 } // anonymous namespace
 
 void WEffectParameterKnobComposed::setupEffectParameterSlot(const ConfigKey& configKey) {
-    QStringList parts = configKey.group.split(effectGroupSeparator);
-    QRegExp intRegEx(".*(\\d+).*");
-
-    EffectRackPointer pRack = m_pEffectsManager->getEffectRack(parts.at(0) + groupClose);
-    VERIFY_OR_DEBUG_ASSERT(pRack) {
-        return;
-    }
-
-    EffectChainSlotPointer pChainSlot;
-    if (parts.at(0) == "[EffectRack1") {
-        intRegEx.indexIn(parts.at(1));
-        pChainSlot = pRack->getEffectChainSlot(intRegEx.cap(1).toInt() - 1);
-    } else {
-        // Assume a PerGroupRack
-        const QString chainGroup =
-                parts.at(0) + effectGroupSeparator + parts.at(1) + groupClose;
-        for (int i = 0; i < pRack->numEffectChainSlots(); ++i) {
-            EffectChainSlotPointer pSlot = pRack->getEffectChainSlot(i);
-            if (pSlot->getGroup() == chainGroup) {
-                pChainSlot = pSlot;
-                break;
-            }
-        }
-    }
-    VERIFY_OR_DEBUG_ASSERT(pChainSlot) {
-        return;
-    }
-
-    intRegEx.indexIn(parts.at(2));
-    EffectSlotPointer pEffectSlot =
-            pChainSlot->getEffectSlot(intRegEx.cap(1).toInt() - 1);
-    VERIFY_OR_DEBUG_ASSERT(pEffectSlot) {
-        return;
-    }
-
-    intRegEx.indexIn(configKey.item);
-    EffectParameterSlotBasePointer pParameterSlot =
-            pEffectSlot->getEffectParameterSlot(intRegEx.cap(1).toInt() - 1);
+    EffectParameterSlotPointer pParameterSlot =
+            m_pEffectsManager->getEffectParameterSlot(configKey);
     VERIFY_OR_DEBUG_ASSERT(pParameterSlot) {
         return;
     }
@@ -52,7 +16,7 @@ void WEffectParameterKnobComposed::setupEffectParameterSlot(const ConfigKey& con
 }
 
 void WEffectParameterKnobComposed::setEffectParameterSlot(
-        EffectParameterSlotBasePointer pParameterSlot) {
+        EffectParameterSlotPointer pParameterSlot) {
     m_pEffectParameterSlot = pParameterSlot;
     if (m_pEffectParameterSlot) {
         connect(m_pEffectParameterSlot.data(), SIGNAL(updated()),

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -9,7 +9,9 @@ const QString groupClose = "]";
 void WEffectParameterKnobComposed::setupEffectParameterSlot(const ConfigKey& configKey) {
     EffectParameterSlotPointer pParameterSlot =
             m_pEffectsManager->getEffectParameterSlot(configKey);
-    VERIFY_OR_DEBUG_ASSERT(pParameterSlot) {
+    if (!pParameterSlot) {
+        qWarning() << "EffectParameterKnobComposed" << configKey <<
+                "is not an effect parameter.";
         return;
     }
     setEffectParameterSlot(pParameterSlot);

--- a/src/widget/weffectparameterknobcomposed.h
+++ b/src/widget/weffectparameterknobcomposed.h
@@ -2,7 +2,7 @@
 #define WEFFECTKNOBCOMPOSED_H
 
 #include "widget/wknobcomposed.h"
-#include "effects/effectparameterslotbase.h"
+#include "effects/effectparameterslot.h"
 
 class WEffectParameterKnobComposed : public WKnobComposed {
   Q_OBJECT
@@ -20,7 +20,7 @@ class WEffectParameterKnobComposed : public WKnobComposed {
   private:
     // Set the EffectParameterSlot that should be monitored by this
     // WEffectKnobComposed.
-    void setEffectParameterSlot(EffectParameterSlotBasePointer pEffectParameterSlot);
+    void setEffectParameterSlot(EffectParameterSlotPointer pParameterSlot);
 
     EffectsManager* m_pEffectsManager;
     EffectParameterSlotBasePointer m_pEffectParameterSlot;

--- a/src/widget/weffectparameterknobcomposed.h
+++ b/src/widget/weffectparameterknobcomposed.h
@@ -4,6 +4,12 @@
 #include "widget/wknobcomposed.h"
 #include "effects/effectparameterslot.h"
 
+// This is used for effect parameter knobs with dynamic
+// tooltips, if the knob value is displayed by rotating a
+// single SVG image.
+// For mor complex transitions you may consider to use
+// WEffectParameterKnob, which displays one of e.g. 64
+// pixmaps
 class WEffectParameterKnobComposed : public WKnobComposed {
   Q_OBJECT
   public:

--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -17,27 +17,29 @@ void WEffectPushButton::setup(const QDomNode& node, const SkinContext& context) 
     m_pButtonMenu = new QMenu(this);
     connect(m_pButtonMenu, SIGNAL(triggered(QAction*)),
             this, SLOT(slotActionChosen(QAction*)));
-
-    // EffectWidgetUtils propagates NULLs so this is all safe.
-    EffectRackPointer pRack = EffectWidgetUtils::getEffectRackFromNode(
-            node, context, m_pEffectsManager);
-    EffectChainSlotPointer pChainSlot = EffectWidgetUtils::getEffectChainSlotFromNode(
-            node, context, pRack);
-    EffectSlotPointer pEffectSlot = EffectWidgetUtils::getEffectSlotFromNode(
-            node, context, pChainSlot);
-    EffectParameterSlotBasePointer pParameterSlot =
-            EffectWidgetUtils::getButtonParameterSlotFromNode(
-                    node, context, pEffectSlot);
-    if (pParameterSlot) {
-        m_pEffectParameterSlot = pParameterSlot;
-        connect(pParameterSlot.data(), SIGNAL(updated()),
-                this, SLOT(parameterUpdated()));
-        parameterUpdated();
-    } else {
-        SKIN_WARNING(node, context)
-                << "EffectPushButton node could not attach to effect parameter.";
-    }
 }
+
+void WEffectPushButton::setupEffectParameterSlot(const ConfigKey& configKey) {
+    EffectButtonParameterSlotPointer pParameterSlot =
+            m_pEffectsManager->getEffectButtonParameterSlot(configKey);
+    if (!pParameterSlot) {
+        qWarning() << "EffectPushButton" << configKey <<
+                "is not an effect button parameter.";
+        return;
+    }
+    setEffectParameterSlot(pParameterSlot);
+}
+
+void WEffectPushButton::setEffectParameterSlot(
+        EffectButtonParameterSlotPointer pParameterSlot) {
+    m_pEffectParameterSlot = pParameterSlot;
+    if (m_pEffectParameterSlot) {
+        connect(m_pEffectParameterSlot.data(), SIGNAL(updated()),
+                this, SLOT(parameterUpdated()));
+    }
+    parameterUpdated();
+}
+
 
 void WEffectPushButton::onConnectedControlChanged(double dParameter, double dValue) {
     for (const auto& action : m_pButtonMenu->actions()) {

--- a/src/widget/weffectpushbutton.h
+++ b/src/widget/weffectpushbutton.h
@@ -17,6 +17,7 @@ class WEffectPushButton : public WPushButton {
     WEffectPushButton(QWidget* pParent, EffectsManager* pEffectsManager);
 
     void setup(const QDomNode& node, const SkinContext& context) override;
+    void setupEffectParameterSlot(const ConfigKey& configKey);
 
   public slots:
     void onConnectedControlChanged(double dParameter, double dValue) override;
@@ -30,6 +31,11 @@ class WEffectPushButton : public WPushButton {
     void slotActionChosen(QAction* action);
 
   private:
+    // Set the EffectParameterSlot that should be monitored by this
+    // WEffectKnobComposed.
+    void setEffectParameterSlot(EffectButtonParameterSlotPointer pParameterSlot);
+
+
     EffectsManager* m_pEffectsManager;
     EffectParameterSlotBasePointer m_pEffectParameterSlot;
     QMenu* m_pButtonMenu;

--- a/src/widget/wknob.h
+++ b/src/widget/wknob.h
@@ -1,20 +1,3 @@
-/***************************************************************************
-                          wknob.h  -  description
-                             -------------------
-    begin                : Fri Jun 21 2002
-    copyright            : (C) 2002 by Tue & Ken Haste Andersen
-    email                : haste@diku.dk
- ***************************************************************************/
-
-/***************************************************************************
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- ***************************************************************************/
-
 #ifndef WKNOB_H
 #define WKNOB_H
 
@@ -27,6 +10,10 @@
 #include "widget/wdisplay.h"
 #include "widget/knobeventhandler.h"
 
+// This is used for knobs if the knob value is displayed by
+// one of e.g. 64 pixmaps.
+// If the knob value can be displayed by rotating a single
+// SVG, use WKnobComposed.
 class WKnob : public WDisplay {
    Q_OBJECT
   public:

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -12,6 +12,11 @@
 #include "widget/wimagestore.h"
 #include "skin/skincontext.h"
 
+// This is used for knobs, if the knob value can be displayed
+// by rotating a single SVG image.
+// For more complex transitions you may consider to use
+// WEffectParameterKnob, which displays one of e.g. 64
+// pixmaps.
 class WKnobComposed : public WWidget {
     Q_OBJECT
   public:


### PR DESCRIPTION
This is the EffectParameterKnobComposed for a row of Pixmaps. 

Originally I have tried to use EffectParameterKnobComposed for the Shade knobs, but then I have noticed that it's design is not able to get by rotating an SVG. This means Knob widgets are not obsolete because we can define fancy knobs of any kind. 

I have clarified this by comments. 
The load time of EffectParameterKnobComposed is faster.