### PR TITLE
Feature/cleanup history

### DIFF
--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -94,6 +94,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     void removeTrackFromPlaylist(const int playlistId, const TrackId& trackId);
     void removeTrackFromPlaylist(const int playlistId, const int position);
     void removeTracksFromPlaylist(const int playlistId, QList<int>& positions);
+    void removeEmptyPlaylists(const HiddenType hidden);
     // Insert a track into a specific position in a playlist
     bool insertTrackIntoPlaylist(TrackId trackId, int playlistId, int position);
     // Inserts a list of tracks into playlist

--- a/src/library/queryutil.h
+++ b/src/library/queryutil.h
@@ -5,7 +5,7 @@
 #include <QtSql>
 
 
-#define LOG_FAILED_QUERY(query) qDebug() << __FILE__ << __LINE__ << "FAILED QUERY [" \
+#define LOG_FAILED_QUERY(query) qWarning() << __FILE__ << __LINE__ << "FAILED QUERY [" \
     << (query).executedQuery() << "]" << (query).lastError()
 
 class ScopedTransaction {

--- a/src/library/setlogfeature.cpp
+++ b/src/library/setlogfeature.cpp
@@ -18,6 +18,8 @@ SetlogFeature::SetlogFeature(QObject* parent,
         : BasePlaylistFeature(parent, pConfig, pTrackCollection, "SETLOGHOME"),
           m_playlistId(-1) {
     // we cleanup old history playlists that don't have any tracks
+    // it's important that we do this before we bind the new model, otherwise
+    // it will have reference to soon deleted playlists
     m_playlistDao.removeEmptyPlaylists(PlaylistDAO::HiddenType::PLHT_SET_LOG);
     m_pPlaylistTableModel = new PlaylistTableModel(this, pTrackCollection,
                                                    "mixxx.db.model.setlog",

--- a/src/library/setlogfeature.cpp
+++ b/src/library/setlogfeature.cpp
@@ -17,11 +17,11 @@ SetlogFeature::SetlogFeature(QObject* parent,
                              TrackCollection* pTrackCollection)
         : BasePlaylistFeature(parent, pConfig, pTrackCollection, "SETLOGHOME"),
           m_playlistId(-1) {
+    // we cleanup old history playlists that don't have any tracks
+    m_playlistDao.removeEmptyPlaylists(PlaylistDAO::HiddenType::PLHT_SET_LOG);
     m_pPlaylistTableModel = new PlaylistTableModel(this, pTrackCollection,
                                                    "mixxx.db.model.setlog",
                                                    true); //show all tracks
-    // we cleanup old history playlists that don't have any tracks
-    m_playlistDao.removeEmptyPlaylists(PlaylistDAO::HiddenType::PLHT_SET_LOG);
 
     //construct child model
     auto pRootItem = std::make_unique<TreeItem>(this);

--- a/src/library/setlogfeature.cpp
+++ b/src/library/setlogfeature.cpp
@@ -6,6 +6,7 @@
 
 #include "control/controlobject.h"
 #include "library/playlisttablemodel.h"
+#include "library/dao/playlistdao.h"
 #include "library/trackcollection.h"
 #include "library/treeitem.h"
 #include "mixer/playerinfo.h"
@@ -19,6 +20,8 @@ SetlogFeature::SetlogFeature(QObject* parent,
     m_pPlaylistTableModel = new PlaylistTableModel(this, pTrackCollection,
                                                    "mixxx.db.model.setlog",
                                                    true); //show all tracks
+    // we cleanup old history playlists that don't have any tracks
+    m_playlistDao.removeEmptyPlaylists(PlaylistDAO::HiddenType::PLHT_SET_LOG);
 
     //construct child model
     auto pRootItem = std::make_unique<TreeItem>(this);


### PR DESCRIPTION
Remove old history entries that don't have any played tracks.
When mixxx ist started and stopped without any tracks played, it
causes one history entry that is never used and bloats up the menu.

We simply delete all playlists (history entries) that don't have
any tracks associated.