### PR TITLE
(appveyor) fix NSIS patch after appveyor NSIS upgrade

### DIFF
--- a/build/appveyor/NSIS.patch
+++ b/build/appveyor/NSIS.patch
@@ -1,28 +1,15 @@
---- MultiUser.nsh.orig	2016-03-11 19:16:38.000000000 +0000
-+++ MultiUser.nsh	2017-01-18 19:43:33.803305800 +0000
-@@ -91,7 +91,11 @@
-     !if "${UNINSTALLER_PREFIX}" != UN
-       ;Set default installation location for installer
-       !ifdef MULTIUSER_INSTALLMODE_INSTDIR
--        StrCpy $INSTDIR "$PROGRAMFILES\${MULTIUSER_INSTALLMODE_INSTDIR}"
-+        !ifdef MULTIUSER_USE_PROGRAMFILES64
-+          StrCpy $INSTDIR "$PROGRAMFILES64\${MULTIUSER_INSTALLMODE_INSTDIR}"
-+        !else
-+          StrCpy $INSTDIR "$PROGRAMFILES\${MULTIUSER_INSTALLMODE_INSTDIR}"
-+        !endif
-       !endif
-     !endif
-
-@@ -129,7 +133,11 @@
+--- MultiUser.nsh.orig  2017-09-16 20:03:48.000000000 +0000
++++ MultiUser.nsh       2017-09-16 20:14:24.236880542 +0000
+@@ -133,7 +133,11 @@
          ${if} ${AtLeastWin2000}
            StrCpy $INSTDIR "$LOCALAPPDATA\${MULTIUSER_INSTALLMODE_INSTDIR}"
          ${else}
 -          StrCpy $INSTDIR "$PROGRAMFILES\${MULTIUSER_INSTALLMODE_INSTDIR}"
-+		  !ifdef MULTIUSER_USE_PROGRAMFILES64
++         !ifdef MULTIUSER_USE_PROGRAMFILES64
 +            StrCpy $INSTDIR "$PROGRAMFILES64\${MULTIUSER_INSTALLMODE_INSTDIR}"
 +          !else
 +            StrCpy $INSTDIR "$PROGRAMFILES\${MULTIUSER_INSTALLMODE_INSTDIR}"
-+		  !endif
++         !endif
          ${endif}
        !endif
      !endif


### PR DESCRIPTION
Appveyor updated NSIS in their build server image on September 07, 2017 [1] so our patch to NSIS is no longer valid and all appveyor build fail since then.
This PR updates the NSIS patch to fix appveyor CI builds.

[1] https://www.appveyor.com/updates/