### PR TITLE
(travis-ci) fix travis-ci mac build (don't try to install libjpeg as it is already installed)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0         ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install scons portaudio libsndfile libogg libvorbis portmidi taglib libshout protobuf flac ffmpeg libjpeg qt chromaprint rubberband fftw libmodplug libid3tag libmad mp4v2 faad2 wavpack opusfile; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install scons portaudio libsndfile libogg libvorbis portmidi taglib libshout protobuf flac ffmpeg qt chromaprint rubberband fftw libmodplug libid3tag libmad mp4v2 faad2 wavpack opusfile; fi
 
 install:
   ####


### PR DESCRIPTION
This PR fix Travis-CI mac build.

Somewhere between August 6 and August 11 a new version (9b) of `libjpeg` became available for MacOSX. 
`libjpeg 8d` was already installed on the macos builder.
This resulted in a faulty run of `brew install libjpeg`. 
Behaviour of `brew install` is to issue a warning when (the package is already installed and no newer version is available) and an error when the package has a new version available (you have to use `brew upgrade` in order to upgrade a package, not `brew install`).

Removing `libjpeg` from the list of packages to install fixes the error.