### PR TITLE
Add ability for Auto DJ to change speed with crossfade

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -541,6 +541,10 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
                         otherDeck.setPlayPosition(maxPlaypos);
                     }
                 }
+                ControlProxy* toRate = new ControlProxy(otherDeck.group, "rate");
+                qDebug() << "initialSyncRate" << otherDeck.group << "=" << toRate->get();
+                this->initialSyncRate = toRate->get();
+                delete toRate;
                 otherDeck.play();
             }
 
@@ -565,12 +569,22 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
             // posThreshold+fadeDuration, we move the crossfader linearly with
             // movements in this track's play position.
 
+            double percentage = (thisPlayPosition - thisDeck.posThreshold) /
+                    (posFadeEnd - thisDeck.posThreshold);
+
+            //Adjust rate of target deck to approach 0% difference to what master sync has planned
+            if (m_pConfig->getValueString(ConfigKey(kConfigKey, "SyncBpm")).toInt() == 1) {
+                double newRate = (1.0 - percentage) * this->initialSyncRate;
+                ControlProxy* m_pCORate = new ControlProxy(otherDeck.group, "rate");
+                m_pCORate->set(newRate);
+                delete m_pCORate;
+            }
+
             // If thisDeck is left, the new crossfade value is -1 plus the
             // adjustment.  If thisDeck is right, the new value is 1.0 minus the
             // adjustment.
             double crossfadeEdgeValue = -1.0;
-            double adjustment = 2 * (thisPlayPosition - thisDeck.posThreshold) /
-                    (posFadeEnd - thisDeck.posThreshold);
+            double adjustment = percentage * 2;
             bool isLeft = thisDeck.isLeft();
             if (!isLeft) {
                 crossfadeEdgeValue = 1.0;

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -541,8 +541,9 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
                         otherDeck.setPlayPosition(maxPlaypos);
                     }
                 }
+                // Store the initial speed of the target deck, to compute
+                // adjustments later.
                 ControlProxy* toRate = new ControlProxy(otherDeck.group, "rate");
-                qDebug() << "initialSyncRate" << otherDeck.group << "=" << toRate->get();
                 this->initialSyncRate = toRate->get();
                 delete toRate;
                 otherDeck.play();
@@ -572,7 +573,8 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
             double percentage = (thisPlayPosition - thisDeck.posThreshold) /
                     (posFadeEnd - thisDeck.posThreshold);
 
-            //Adjust rate of target deck to approach 0% difference to what master sync has planned
+            // Adjust rate of target deck to approach 0% difference to target
+            // deck's speed
             if (m_pConfig->getValueString(ConfigKey(kConfigKey, "SyncBpm")).toInt() == 1) {
                 double newRate = (1.0 - percentage) * this->initialSyncRate;
                 ControlProxy* m_pCORate = new ControlProxy(otherDeck.group, "rate");

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -204,6 +204,7 @@ class AutoDJProcessor : public QObject {
 
     ControlProxy* m_pCOCrossfader;
     ControlProxy* m_pCOCrossfaderReverse;
+    double initialSyncRate;
 
     ControlPushButton* m_pSkipNext;
     ControlPushButton* m_pFadeNow;

--- a/src/preferences/dialog/dlgprefautodj.cpp
+++ b/src/preferences/dialog/dlgprefautodj.cpp
@@ -59,6 +59,13 @@ DlgPrefAutoDJ::DlgPrefAutoDJ(QWidget* pParent,
             SLOT(slotEnableAutoDJRandomQueue(int)));
     connect(autoDJRandomQueueMinimumSpinBox, SIGNAL(valueChanged(int)), this,
             SLOT(slotSetAutoDJRandomQueueMin(int)));
+
+    // Sync BPM during crossfade
+    ComboBoxAutoDjSyncBpm->addItem(tr("Off"));
+    ComboBoxAutoDjSyncBpm->addItem(tr("On"));
+    ComboBoxAutoDjSyncBpm->setCurrentIndex(m_pConfig->getValueString(ConfigKey("[Auto DJ]", "SyncBpm")).toInt());
+    connect(ComboBoxAutoDjSyncBpm, SIGNAL(activated(int)),
+            this, SLOT(slotSetAutoDjSyncBpm(int)));
 }
 
 DlgPrefAutoDJ::~DlgPrefAutoDJ() {
@@ -88,6 +95,8 @@ void DlgPrefAutoDJ::slotApply() {
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "EnableRandomQueue"),
             m_pConfig->getValue(
                     ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"), 0));
+    m_pConfig->setValue(ConfigKey("[Auto DJ]", "SyncBpm"),
+            m_pConfig->getValue(ConfigKey("[Auto DJ]", "SyncBpmBuff"), 0));
 }
 
 void DlgPrefAutoDJ::slotCancel() {
@@ -128,6 +137,11 @@ void DlgPrefAutoDJ::slotCancel() {
                     ConfigKey("[Auto DJ]", "EnableRandomQueue"), 0));
     slotEnableAutoDJRandomQueueComboBox(
             m_pConfig->getValue<int>(ConfigKey("[Auto DJ]", "Requeue")));
+    ComboBoxAutoDjRequeue->setCurrentIndex(
+            m_pConfig->getValue(ConfigKey("[Auto DJ]", "Requeue"), 0));
+    m_pConfig->setValue(ConfigKey("[Auto DJ]", "SyncBpmBuff"),
+            m_pConfig->getValue(ConfigKey("[Auto DJ]", "SyncBpm"), 0));
+
 }
 
 void DlgPrefAutoDJ::slotResetToDefaults() {
@@ -147,6 +161,9 @@ void DlgPrefAutoDJ::slotResetToDefaults() {
     m_pConfig->set(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),QString("0"));
     autoDJRandomQueueMinimumSpinBox->setEnabled(false);
     ComboBoxAutoDjRandomQueue->setEnabled(true);
+
+    ComboBoxAutoDjSyncBpm->setCurrentIndex(0);
+    m_pConfig->set(ConfigKey("[Auto DJ]", "SyncBpmBuff"),ConfigValue(0));
 }
 
 void DlgPrefAutoDJ::slotSetAutoDjRequeue(int) {
@@ -206,4 +223,9 @@ void DlgPrefAutoDJ::slotEnableAutoDJRandomQueue(int a_iValue) {
         m_pConfig->set(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
                 ConfigValue(1));
     }
+}
+
+void DlgPrefAutoDJ::slotSetAutoDjSyncBpm(int) {
+    m_pConfig->set(ConfigKey("[Auto DJ]", "SyncBpmBuff"),
+            ConfigValue(ComboBoxAutoDjSyncBpm->currentIndex()));
 }

--- a/src/preferences/dialog/dlgprefautodj.h
+++ b/src/preferences/dialog/dlgprefautodj.h
@@ -27,6 +27,7 @@ class DlgPrefAutoDJ : public DlgPreferencePage, public Ui::DlgPrefAutoDJDlg {
     void slotSetAutoDJRandomQueueMin(int);
     void slotEnableAutoDJRandomQueueComboBox(int);
     void slotEnableAutoDJRandomQueue(int);
+    void slotSetAutoDjSyncBpm(int);
 
   private:
     UserSettingsPointer m_pConfig;

--- a/src/preferences/dialog/dlgprefautodjdlg.ui
+++ b/src/preferences/dialog/dlgprefautodjdlg.ui
@@ -126,6 +126,23 @@
        </property>
       </widget>
      </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="textAutoDjSyncBpm">
+       <property name="text">
+        <string>Sync BPM during crossfade</string>
+       </property>
+       <property name="buddy">
+        <cstring>ComboBoxAutoDjSyncBpm</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QComboBox" name="ComboBoxAutoDjSyncBpm">
+       <property name="toolTip">
+        <string>Adjust BPM while crossfading</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item row="1" column="0">


### PR DESCRIPTION
If enabled in preferences, Auto DJ will adjust the target deck's speed to approach 0% change. Works best with master sync enabled across decks, but it is not required.