### PR TITLE
Scale syncing of temporal effect parameters with rate slider

### DIFF
--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -864,7 +864,7 @@ void BpmControl::collectFeatures(GroupFeatureState* pGroupFeatures) const {
                        &dThisBeatLength, &dThisBeatFraction)) {
         pGroupFeatures->has_beat_length_sec = true;
         // Note: dThisBeatLength is fractional frames count * 2 (stereo samples)  
-        pGroupFeatures->beat_length_sec = dThisBeatLength / m_pTrack->getSampleRate() / 2; 
+        pGroupFeatures->beat_length_sec = dThisBeatLength / m_pTrack->getSampleRate() / 2 * calcRateRatio();
 
         pGroupFeatures->has_beat_fraction = true;
         pGroupFeatures->beat_fraction = dThisBeatFraction;


### PR DESCRIPTION
Without this, effects get out of sync when the rate slider is not at center.