### PR TITLE
do not reload QuickEffect when opening Preferences dialog

### DIFF
--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -30,6 +30,10 @@ class EffectSlot : public QObject {
     // returns a null EffectPointer.
     EffectPointer getEffect() const;
 
+    inline bool getEnableState() const {
+        return m_pControlEnabled->toBool();
+    }
+
     inline int getEffectSlotNumber() const {
         return m_iEffectNumber;
     }


### PR DESCRIPTION
This caused the QuickEffect to be enabled when opening the Preferences if it had been disabled. Fixing
https://bugs.launchpad.net/mixxx/+bug/1719595