### PR TITLE
Fix miniscrollbar hint letters [library-redesign]

### DIFF
--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -78,7 +78,7 @@ QVariant TreeItemModel::data(const QModelIndex &index, int role) const {
         case AbstractRole::RoleBreadCrumb:
             return getBreadCrumbString(item);
         case AbstractRole::RoleGroupingLetter:
-            return StringHelper::getFirstCharForGrouping(item->getData().toString());
+            return StringHelper::getFirstCharForGrouping(item->getLabel());
     }
 
     return QVariant();


### PR DESCRIPTION
The problem was that the `label` for the tree items
did not match the `data` of the items, EXCEPT for the
tracks. In the case of crates and playlists, only the
`label` was the human readable version, whereas the
`data` was the playlist/crate ID in the sqlite database.

It could be that to enable drag/drop from the miniviews
that we will need to modify the tree items in for the
mini track view so that their data is also their track ID.