### PR TITLE
library redesign AutoDJ control pane small cleanups

### DIFF
--- a/res/skins/Deere/library.xml
+++ b/res/skins/Deere/library.xml
@@ -201,6 +201,22 @@
                   </LibraryPane>
                 </Children>
               </WidgetGroup>
+
+              <WidgetGroup>
+                <Layout>vertical</Layout>
+                <Children>
+                  <LibraryBreadCrumb>
+                    <ObjectName>LibraryBreadCrumb</ObjectName>
+                    <Id>2</Id>
+                  </LibraryBreadCrumb>
+                  <SearchBox>
+                    <Id>2</Id>
+                  </SearchBox>
+                  <LibraryPane>
+                    <Id>2</Id>
+                  </LibraryPane>
+                </Children>
+              </WidgetGroup>
             </Children>
           </Splitter>
         </Children>

--- a/src/library/features/autodj/autodjfeature.cpp
+++ b/src/library/features/autodj/autodjfeature.cpp
@@ -137,7 +137,7 @@ parented_ptr<QWidget> AutoDJFeature::createInnerSidebarWidget(
 
     // Add drop target
     auto pSidebar = createLibrarySidebarWidget(pContainer.get());
-    pContainer->addTab(pSidebar.get(), tr("Track source"));
+    pContainer->addTab(pSidebar.get(), tr("Sources"));
 
     // Be informed when the user wants to add another random track.
     connect(m_pAutoDJProcessor,SIGNAL(randomTrackRequested(int)),

--- a/src/library/features/autodj/dlgautodj.cpp
+++ b/src/library/features/autodj/dlgautodj.cpp
@@ -105,14 +105,14 @@ void DlgAutoDJ::autoDJStateChanged(AutoDJProcessor::AutoDJState state) {
     if (state == AutoDJProcessor::ADJ_DISABLED) {
         pushButtonAutoDJ->setChecked(false);
         pushButtonAutoDJ->setToolTip(tr("Enable Auto DJ"));
-        pushButtonAutoDJ->setText(tr("Enable Auto DJ"));
+        pushButtonAutoDJ->setText(tr("Enable"));
         pushButtonFadeNow->setEnabled(false);
         pushButtonSkipNext->setEnabled(false);
     } else {
         // No matter the mode, you can always disable once it is enabled.
         pushButtonAutoDJ->setChecked(true);
         pushButtonAutoDJ->setToolTip(tr("Disable Auto DJ"));
-        pushButtonAutoDJ->setText(tr("Disable Auto DJ"));
+        pushButtonAutoDJ->setText(tr("Disable"));
 
         // If fading, you can't hit fade now.
         if (state == AutoDJProcessor::ADJ_P1FADING ||

--- a/src/library/features/autodj/dlgautodj.ui
+++ b/src/library/features/autodj/dlgautodj.ui
@@ -13,6 +13,19 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QPushButton" name="pushButtonAutoDJ">
+     <property name="toolTip">
+      <string>Turn Auto DJ on or off.</string>
+     </property>
+     <property name="text">
+      <string>Enable</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QVBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="labelTransitionAppendix">
@@ -52,26 +65,6 @@
     </layout>
    </item>
    <item>
-    <widget class="QPushButton" name="pushButtonAutoDJ">
-     <property name="toolTip">
-      <string>Turn Auto DJ on or off.</string>
-     </property>
-     <property name="text">
-      <string>Enable</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="labelSelectionInfo">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QPushButton" name="pushButtonFadeNow">
      <property name="toolTip">
       <string>Trigger the transition to the next track.</string>
@@ -92,6 +85,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QPushButton" name="pushButtonShuffle">
+     <property name="toolTip">
+      <string>Shuffle the content of the Auto DJ queue.</string>
+     </property>
+     <property name="text">
+      <string>Shuffle</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QPushButton" name="pushButtonAddRandom">
      <property name="toolTip">
      <string>Adds a random track from track sources (crates) to the Auto DJ queue.
@@ -103,12 +106,9 @@ If no track sources are configured, the track is added from the library instead.
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="pushButtonShuffle">
-     <property name="toolTip">
-      <string>Shuffle the content of the Auto DJ queue.</string>
-     </property>
+    <widget class="QLabel" name="labelSelectionInfo">
      <property name="text">
-      <string>Shuffle</string>
+      <string/>
      </property>
     </widget>
    </item>

--- a/src/library/features/autodj/dlgautodj.ui
+++ b/src/library/features/autodj/dlgautodj.ui
@@ -6,8 +6,6 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>507</width>
-    <height>399</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,24 +13,27 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QVBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="labelTransitionAppendix">
        <property name="toolTip">
-        <string comment="&quot;sec.&quot; as in seconds">Seconds</string>
+        <string>Determines the duration of the transition.</string>
        </property>
        <property name="text">
-        <string>sec.</string>
+        <string>Transition</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QSpinBox" name="spinBoxTransition">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
+        <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="suffix">
+        <string> s</string>
        </property>
        <property name="toolTip">
         <string>Determines the duration of the transition.</string>
@@ -48,19 +49,6 @@
        </property>
       </widget>
      </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
     </layout>
    </item>
    <item>
@@ -69,7 +57,7 @@
       <string>Turn Auto DJ on or off.</string>
      </property>
      <property name="text">
-      <string>Enable Auto DJ</string>
+      <string>Enable</string>
      </property>
      <property name="checkable">
       <bool>true</bool>
@@ -89,7 +77,7 @@
       <string>Trigger the transition to the next track.</string>
      </property>
      <property name="text">
-      <string>Fade Now</string>
+      <string>Fade</string>
      </property>
     </widget>
    </item>
@@ -99,10 +87,7 @@
       <string>Skip the next track in the Auto DJ queue.</string>
      </property>
      <property name="text">
-      <string>Skip Track</string>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
+      <string>Skip</string>
      </property>
     </widget>
    </item>
@@ -113,7 +98,7 @@
 If no track sources are configured, the track is added from the library instead.</string>
      </property>
      <property name="text">
-      <string>Add Random</string>
+      <string>Random</string>
      </property>
     </widget>
    </item>
@@ -125,23 +110,7 @@ If no track sources are configured, the track is added from the library instead.
      <property name="text">
       <string>Shuffle</string>
      </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>172</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Some quick fixes to let the control pane of AutoDJ in the library redesign to not need so much horizontal space. We still need better solutions for the awkward tabs at the top and the highlighted track times, but those are outside the scope of this quick fix PR. This is more a proof of concept to demonstrate that there can be sufficient horizontal space for two track tables with two control panes showing.
![image](https://user-images.githubusercontent.com/9455094/30946994-c5c01d80-a3cc-11e7-8e09-3906fb9cde56.png)
