### PR TITLE
Fix wrong debug assertions

### DIFF
--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -477,16 +477,7 @@ void SoundSourceProxy::updateTrack(
     } else {
         // If the file tags have never been parsed before it doesn't matter
         // if the track is marked as dirty or not. In this case the track
-        // object has just been created. But better check that those
-        // assumptions are correct.
-        VERIFY_OR_DEBUG_ASSERT(trackMetadata == mixxx::TrackMetadata()) {
-            kLogger.warning() << "Reloading track metadata from file"
-                     << getUrl().toString();
-        }
-        VERIFY_OR_DEBUG_ASSERT(coverInfo == CoverInfo()) {
-            kLogger.warning() << "Reloading cover art from file"
-                     << getUrl().toString();
-        }
+        // object has just been created.
         pCoverImg = &coverImg;
     }
 


### PR DESCRIPTION
... when adding new files without tags to the library. The source field has already been set to GUESSED while all other fields contain default values.

Usually I don't add files without tags to the library so I didn't notice this minor regression. Can be tested by adding our test files.