### PR TITLE
Tape echo

### DIFF
--- a/src/effects/native/echoeffect.cpp
+++ b/src/effects/native/echoeffect.cpp
@@ -6,6 +6,7 @@
 #include "util/math.h"
 
 #define INCREMENT_RING(index, increment, length) index = (index + increment) % length
+#define DECREMENT_RING(index, decrement, length) index = (index + length - decrement) % length
 
 constexpr int EchoGroupState::kMaxDelaySeconds;
 constexpr int EchoGroupState::kChannelCount;
@@ -132,7 +133,7 @@ void EchoEffect::processChannel(const ChannelHandle& handle, EchoGroupState* pGr
     double feedback_amount = m_pFeedbackParameter->value();
     double pingpong_frac = m_pPingPongParameter->value();
 
-    int delay_samples;
+    int delay_frames;
     if (groupFeatures.has_beat_length_sec) {
         // period is a number of beats
         if (m_pQuantizeParameter->toBool()) {
@@ -143,57 +144,50 @@ void EchoEffect::processChannel(const ChannelHandle& handle, EchoGroupState* pGr
         } else if (period < 1/8.0) {
             period = 1/8.0;
         }
-        delay_samples = period * groupFeatures.beat_length_sec
-                * sampleRate * EchoGroupState::kChannelCount;
+        delay_frames = period * groupFeatures.beat_length_sec * sampleRate;
     } else {
         // period is a number of seconds
         period = std::max(period, 1/8.0);
-        delay_samples = period * sampleRate * EchoGroupState::kChannelCount;
+        delay_frames = period * sampleRate;
     }
-    VERIFY_OR_DEBUG_ASSERT(delay_samples > 0) {
-        delay_samples = 1;
+    VERIFY_OR_DEBUG_ASSERT(delay_frames > 0) {
+        delay_frames = 1;
     }
+
+    int delay_samples = delay_frames * gs.kChannelCount;
     VERIFY_OR_DEBUG_ASSERT(delay_samples <= gs.delay_buf.size()) {
         delay_samples = gs.delay_buf.size();
     }
 
-    if (period < gs.prev_period) {
-        // If the delay time has shrunk, we may need to wrap the write position.
-        gs.write_position = gs.write_position % delay_samples;
-    } else if (period > gs.prev_period) {
-        // If the delay time has grown, we need to zero out the new portion
-        // of the buffer we are using.
-        SampleUtil::applyGain(gs.delay_buf.data(gs.prev_delay_samples), 0,
-                              gs.delay_buf.size() - gs.prev_delay_samples);
-    }
-
     int read_position = gs.write_position;
+    DECREMENT_RING(read_position, delay_samples, gs.delay_buf.size());
 
     // Feedback the delay buffer and then add the new input.
     const CSAMPLE_GAIN send_delta = (send_amount - gs.prev_send) /
             (numSamples / EchoGroupState::kChannelCount);
     const CSAMPLE_GAIN send_start = send_amount + send_delta;
-    for (unsigned int i = 0; i < numSamples; i += EchoGroupState::kChannelCount) {
-        CSAMPLE_GAIN send_ramped = send_start;
-        if (send_delta > 0.0) {
-            send_ramped += send_delta * i / EchoGroupState::kChannelCount;
-        }
-        gs.delay_buf[gs.write_position] *= feedback_amount;
-        gs.delay_buf[gs.write_position + 1] *= feedback_amount;
-        gs.delay_buf[gs.write_position] += pInput[i] * send_ramped;
-        gs.delay_buf[gs.write_position + 1] += pInput[i + 1] * send_ramped;
-        // Actual delays distort and saturate, so clamp the buffer here.
-        gs.delay_buf[gs.write_position] =
-                SampleUtil::clampSample(gs.delay_buf[gs.write_position]);
-        gs.delay_buf[gs.write_position + 1] =
-                SampleUtil::clampSample(gs.delay_buf[gs.write_position + 1]);
-        INCREMENT_RING(gs.write_position, EchoGroupState::kChannelCount, delay_samples);
-    }
 
-    // Pingpong the output.  If the pingpong value is zero, all of the
-    // math below should result in a simple copy of delay buf to pOutput.
+    const CSAMPLE_GAIN feedback_delta = (feedback_amount - gs.prev_feedback) /
+            (numSamples / EchoGroupState::kChannelCount);
+    const CSAMPLE_GAIN feedback_start = feedback_amount + feedback_delta;
+
     for (unsigned int i = 0; i < numSamples; i += EchoGroupState::kChannelCount) {
-        if (gs.ping_pong_left) {
+        CSAMPLE_GAIN send_ramped = send_start
+                + send_delta * i / EchoGroupState::kChannelCount;
+        CSAMPLE_GAIN feedback_ramped = feedback_start
+                + feedback_delta * i / EchoGroupState::kChannelCount;
+
+        // Actual delays distort and saturate, so clamp the buffer here.
+        gs.delay_buf[gs.write_position] = SampleUtil::clampSample(
+                pInput[i] * send_ramped +
+                gs.delay_buf[read_position] * feedback_ramped);
+        gs.delay_buf[gs.write_position + 1] = SampleUtil::clampSample(
+                pInput[i + 1] * send_ramped +
+                gs.delay_buf[read_position + 1] * feedback_ramped);
+
+        // Pingpong the output.  If the pingpong value is zero, all of the
+        // math below should result in a simple copy of delay buf to pOutput.
+        if (gs.ping_pong < delay_samples / 2) {
             // Left sample plus a fraction of the right sample, normalized
             // by 1 + fraction.
             pOutput[i] = pInput[i] +
@@ -215,10 +209,13 @@ void EchoEffect::processChannel(const ChannelHandle& handle, EchoGroupState* pGr
                     (1 + pingpong_frac)) / 2.0;
         }
 
-        INCREMENT_RING(read_position, EchoGroupState::kChannelCount, delay_samples);
-        // If the buffer has looped around, flip-flop the ping-pong.
-        if (read_position == 0) {
-            gs.ping_pong_left = !gs.ping_pong_left;
+        INCREMENT_RING(gs.write_position, EchoGroupState::kChannelCount,
+                gs.delay_buf.size());
+        INCREMENT_RING(read_position, EchoGroupState::kChannelCount,
+                gs.delay_buf.size());
+
+        if (++gs.ping_pong >= delay_samples) {
+            gs.ping_pong = 0;
         }
     }
 
@@ -226,7 +223,7 @@ void EchoEffect::processChannel(const ChannelHandle& handle, EchoGroupState* pGr
         gs.delay_buf.clear();
     }
 
-    gs.prev_period = period;
     gs.prev_send = send_amount;
+    gs.prev_feedback = feedback_amount;
     gs.prev_delay_samples = delay_samples;
 }

--- a/src/effects/native/echoeffect.cpp
+++ b/src/effects/native/echoeffect.cpp
@@ -48,7 +48,7 @@ EffectManifest EchoEffect::getManifest() {
     feedback->setSemanticHint(EffectManifestParameter::SemanticHint::UNKNOWN);
     feedback->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
     feedback->setMinimum(0.00);
-    feedback->setDefault(0.75);
+    feedback->setDefault(db2ratio(-3.0));
     feedback->setMaximum(1.00);
 
     EffectManifestParameter* pingpong = manifest.addParameter();
@@ -75,7 +75,7 @@ EffectManifest EchoEffect::getManifest() {
     send->setUnitsHint(EffectManifestParameter::UnitsHint::UNKNOWN);
     send->setDefaultLinkType(EffectManifestParameter::LinkType::LINKED);
     send->setMinimum(0.0);
-    send->setDefault(1.0);
+    send->setDefault(db2ratio(-3.0));
     send->setMaximum(1.0);
 
     EffectManifestParameter* quantize = manifest.addParameter();
@@ -208,19 +208,19 @@ void EchoEffect::processChannel(const ChannelHandle& handle, EchoGroupState* pGr
             // by 1 + fraction.
             pOutput[i] = pInput[i] +
                     ((bufferedSample0 + bufferedSample1 * pingpong_frac) /
-                    (1 + pingpong_frac)) / 2.0;
+                    (1 + pingpong_frac));
             // Right sample reduced by (1 - fraction)
             pOutput[i + 1] = pInput[i + 1] +
-                    (bufferedSample1 * (1 - pingpong_frac)) / 2.0;
+                    (bufferedSample1 * (1 - pingpong_frac));
         } else {
             // Left sample reduced by (1 - fraction)
             pOutput[i] = pInput[i] +
-                    (bufferedSample0 * (1 - pingpong_frac)) / 2.0;
+                    (bufferedSample0 * (1 - pingpong_frac));
             // Right sample plus fraction of left sample, normalized by
             // 1 + fraction
             pOutput[i + 1] = pInput[i + 1] +
                     ((bufferedSample1 + bufferedSample0 * pingpong_frac) /
-                    (1 + pingpong_frac)) / 2.0;
+                    (1 + pingpong_frac));
         }
 
         INCREMENT_RING(gs.write_position, EchoGroupState::kChannelCount,

--- a/src/effects/native/echoeffect.cpp
+++ b/src/effects/native/echoeffect.cpp
@@ -7,7 +7,6 @@
 
 constexpr int EchoGroupState::kMaxDelaySeconds;
 constexpr int EchoGroupState::kChannelCount;
-constexpr int EchoGroupState::kRampLength;
 
 namespace {
 

--- a/src/effects/native/echoeffect.h
+++ b/src/effects/native/echoeffect.h
@@ -27,19 +27,19 @@ struct EchoGroupState {
             : delay_buf(mixxx::AudioSignal::kSamplingRateMax * kMaxDelaySeconds *
                         kChannelCount) {
         delay_buf.clear();
-        prev_period = 0.0;
-        prev_send = 0.0;
+        prev_send = 0.0f;
+        prev_feedback= 0.0f;
         prev_delay_samples = 0;
         write_position = 0;
-        ping_pong_left = true;
+        ping_pong = 0;
     }
 
     SampleBuffer delay_buf;
-    double prev_period;
     CSAMPLE_GAIN prev_send;
+    CSAMPLE_GAIN prev_feedback;
     int prev_delay_samples;
     int write_position;
-    bool ping_pong_left;
+    int ping_pong;
 };
 
 class EchoEffect : public PerChannelEffectProcessor<EchoGroupState> {

--- a/src/effects/native/echoeffect.h
+++ b/src/effects/native/echoeffect.h
@@ -19,9 +19,6 @@ struct EchoGroupState {
     static constexpr int kMaxDelaySeconds = 3;
     // TODO(XXX): When we move from stereo to multi-channel this needs updating.
     static constexpr int kChannelCount = mixxx::AudioSignal::kChannelCountStereo;
-    // Ramp length in samples when we are at the start of an echo.
-    // TODO(XXX): make this samplerate independent
-    static constexpr int kRampLength = 500;
 
     EchoGroupState()
             : delay_buf(mixxx::AudioSignal::kSamplingRateMax * kMaxDelaySeconds *

--- a/src/util/math.h
+++ b/src/util/math.h
@@ -18,6 +18,7 @@
 // after our fpclassify hack 
 
 #include <algorithm>
+#include <type_traits>
 
 #include "util/assert.h"
 #include "util/fpclassify.h"
@@ -74,11 +75,19 @@ inline double roundToFraction(double value, int denominator) {
 
 template <typename T>
 inline const T ratio2db(const T a) {
+    static_assert(std::is_same<float, T>::value ||
+                  std::is_same<double, T>::value ||
+                  std::is_same<long double, T>::value,
+                  "ratio2db works only for floating point types");
     return log10(a) * 20;
 }
 
 template <typename T>
 inline const T db2ratio(const T a) {
+    static_assert(std::is_same<float, T>::value ||
+                  std::is_same<double, T>::value ||
+                  std::is_same<long double, T>::value,
+                  "db2ratio works only for floating point types");
     return pow(10, a / 20);
 }
 


### PR DESCRIPTION
This fixes the silent gaps when changing the time parameter of the echo effect, by changing the implementation on the delay buffer. Now we use always the full ring, like a tape delay. 

When changing time, the new time is faded into the old time. During the delvelopment, I have also implemented a pitched fade, but this results into a row of unnatural high pitched sounds. 
I assume that this is due to the unregular and slow sampling of the parameter knob, and due the wide pitch range.   

I have also removed the fixed -6 dB offset of the send signal. This allows to have finally a natural -3 dB echo sound by default. 