### PR TITLE
[WIP] Add plugable AutoDJ song selection infrastructure.

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -916,6 +916,7 @@ class MixxxCore(Feature):
                    "library/analysisfeature.cpp",
                    "library/autodj/autodjfeature.cpp",
                    "library/autodj/autodjprocessor.cpp",
+                   "library/autodj/trackselector.cpp",
                    "library/dao/directorydao.cpp",
                    "library/mixxxlibraryfeature.cpp",
                    "library/baseplaylistfeature.cpp",

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -11,11 +11,14 @@
 #include "library/playlisttablemodel.h"
 #include "track/track.h"
 #include "util/class.h"
+#include "library/autodj/trackselector.h"
 
 class ControlPushButton;
 class TrackCollection;
 class PlayerManagerInterface;
 class BaseTrackPlayer;
+class AutoDJProcessor;
+
 
 class DeckAttributes : public QObject {
     Q_OBJECT
@@ -131,10 +134,20 @@ class AutoDJProcessor : public QObject {
         return m_pAutoDJTableModel;
     }
 
+    TrackSelector* getSelector() const {
+        return m_selector;
+    }
+
+    QList<TrackSelector*> getSelectorList() {
+        return m_registeredSelectors;
+    }
+
     bool nextTrackLoaded();
+    bool registerSelector(TrackSelector* selector);
 
   public slots:
     void setTransitionTime(int seconds);
+    void setSelector(QString id);
 
     AutoDJError shufflePlaylist(const QModelIndexList& selectedIndices);
     AutoDJError skipNext();
@@ -177,6 +190,8 @@ class AutoDJProcessor : public QObject {
     double getCrossfader() const;
     void setCrossfader(double value, bool right);
 
+    void registerSelectors();
+
     TrackPointer getNextTrackFromQueue();
     bool loadNextTrackFromQueue(const DeckAttributes& pDeck, bool play = false);
     void calculateTransition(DeckAttributes* pFromDeck,
@@ -199,6 +214,9 @@ class AutoDJProcessor : public QObject {
     AutoDJState m_eState;
     double m_transitionTime; // the desired value set by the user
     double m_nextTransitionTime; // the tweaked value actually used
+
+    TrackSelector* m_selector;
+    QList<TrackSelector*> m_registeredSelectors;
 
     QList<DeckAttributes*> m_decks;
 

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -83,6 +83,21 @@ DlgAutoDJ::DlgAutoDJ(QWidget* parent,
     autoDJStateChanged(m_pAutoDJProcessor->getState());
 
     updateSelectionInfo();
+
+    // populate the mode combobox
+    auto selectors = m_pAutoDJProcessor->getSelectorList();
+    foreach(TrackSelector* selector, selectors)
+    {
+        comboBoxSelector->addItem(selector->getName(), selector->getId());
+        if(m_pAutoDJProcessor->getSelector() &&
+           selector->getId() == m_pAutoDJProcessor->getSelector()->getId()) {
+            comboBoxSelector->setCurrentIndex(comboBoxSelector->count()-1);
+        }
+    }
+
+    connect(comboBoxSelector, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(selectorChanged(int)));
+
 }
 
 DlgAutoDJ::~DlgAutoDJ() {
@@ -114,6 +129,13 @@ void DlgAutoDJ::loadSelectedTrackToGroup(QString group, bool play) {
 void DlgAutoDJ::moveSelection(int delta) {
     m_pTrackTableView->moveSelection(delta);
 }
+
+void DlgAutoDJ::selectorChanged(int index) {
+    qDebug() << "seletorChanged: " << index;
+    QString id = comboBoxSelector->itemData(index).toString();
+    m_pAutoDJProcessor->setSelector(id);
+}
+
 
 void DlgAutoDJ::shufflePlaylistButton(bool) {
     QModelIndexList indexList = m_pTrackTableView->selectionModel()->selectedRows();

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -43,6 +43,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void setTrackTableFont(const QFont& font);
     void setTrackTableRowHeight(int rowHeight);
     void updateSelectionInfo();
+    void selectorChanged(int index);
 
   signals:
     void addRandomButton(bool buttonChecked);

--- a/src/library/autodj/dlgautodj.ui
+++ b/src/library/autodj/dlgautodj.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>560</width>
+    <width>613</width>
     <height>399</height>
    </rect>
   </property>
@@ -122,6 +122,16 @@ If no track sources are configured, the track is added from the library instead.
        </property>
        <property name="text">
         <string>sec.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboBoxSelector">
+       <property name="toolTip">
+        <string>Selects mode how the next track is chosen</string>
+       </property>
+       <property name="whatsThis">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The AutoDj can select the next song based on different stategies. Linear, Random or based on harmonic stategies.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
       </widget>
      </item>

--- a/src/library/autodj/trackselector.cpp
+++ b/src/library/autodj/trackselector.cpp
@@ -1,0 +1,69 @@
+#include "trackselector.h"
+#include "library/autodj/autodjprocessor.h"
+
+
+
+TrackSelector::TrackSelector(AutoDJProcessor* processor) :
+   QObject(processor),
+   m_processor(processor) {}
+/*
+TrackPointer TrackSelector::getNextTrackFromQueue() {
+    assert(false);
+}
+*/
+
+/* LinearSelector */
+
+LinearSelector::LinearSelector(AutoDJProcessor* processor): TrackSelector(processor) { }
+
+
+TrackPointer LinearSelector::getNextTrackFromQueue() {
+    PlaylistTableModel* model(m_processor->getTableModel());
+
+    while (true) {
+        TrackPointer nextTrack = model->getTrack(model->index(0, 0));
+
+        if (nextTrack) {
+            if (nextTrack->exists()) {
+                return nextTrack;
+            } else {
+                // Remove missing song from auto DJ playlist.
+                model->removeTrack(model->index(0, 0));
+            }
+        } else {
+            // We're out of tracks. Return the null TrackPointer.
+            return nextTrack;
+        }
+    }
+
+}
+
+
+/* RandomSelector */
+RandomSelector::RandomSelector(AutoDJProcessor* processor): TrackSelector(processor) { }
+
+
+TrackPointer RandomSelector::getNextTrackFromQueue() {
+    PlaylistTableModel* model(m_processor->getTableModel());
+
+    while (true) {
+        int trackCount = model->rowCount();
+        int nextPos = qrand()%trackCount;
+        qDebug() << "RandomSelector: chose track row:" << nextPos;
+        TrackPointer nextTrack = model->getTrack(model->index(nextPos, 0));
+
+        if (nextTrack) {
+            if (nextTrack->exists()) {
+                return nextTrack;
+            } else {
+                // Remove missing song from auto DJ playlist.
+                model->removeTrack(model->index(nextPos, 0));
+            }
+        } else {
+            // We're out of tracks. Return the null TrackPointer.
+            return nextTrack;
+        }
+    }
+
+}
+

--- a/src/library/autodj/trackselector.h
+++ b/src/library/autodj/trackselector.h
@@ -1,0 +1,94 @@
+#ifndef TRACKSELECTOR_H
+#define TRACKSELECTOR_H
+
+#include <QObject>
+
+#include "library/playlisttablemodel.h"
+#include "track/track.h"
+#include "util/class.h"
+
+
+class ITrackSelector
+{
+  public:
+    virtual ~ITrackSelector(){} // do not forget this
+
+    virtual const QString getName() = 0;
+
+    virtual const QString getId() = 0;
+
+    virtual TrackPointer getNextTrackFromQueue() = 0;
+
+
+};
+
+Q_DECLARE_INTERFACE(ITrackSelector, "ITrackSelector") // define this out of namespace scope
+
+
+/*!
+    \class TrackSelector
+    \brief Base class that is responsible for selecting the next AutoDJ tack
+*/
+
+class TrackSelector : public QObject, public ITrackSelector {
+    Q_OBJECT
+    Q_INTERFACES(ITrackSelector)
+  public:
+    TrackSelector(AutoDJProcessor* processor);
+
+  protected:
+    AutoDJProcessor* m_processor;
+    char* m_id;
+};
+
+/*
+class TrackSelector : public QObject {
+    Q_OBJECT
+  public:
+    TrackSelector(AutoDJProcessor* processor);
+
+    virtual const QString getName() = 0;
+
+    virtual const char* getId() = 0;
+
+    virtual TrackPointer getNextTrackFromQueue() = 0;
+
+  protected:
+    AutoDJProcessor* m_processor;
+    char* m_id;
+};
+*/
+
+class LinearSelector: public TrackSelector {
+    Q_OBJECT
+  public:
+    LinearSelector(AutoDJProcessor* processor);
+
+    const QString getName() {
+        return tr("Linear");
+    }
+
+    const QString getId() {
+        return QString("linear");
+    }
+    TrackPointer getNextTrackFromQueue();
+};
+
+
+class RandomSelector: public TrackSelector {
+    Q_OBJECT
+  public:
+    RandomSelector(AutoDJProcessor* processor);
+
+    const QString getName() {
+        return tr("Random");
+    }
+
+    const QString getId() {
+        return QString("random");
+    }
+    TrackPointer getNextTrackFromQueue();
+};
+
+
+#endif // TRACKSELECTOR_H


### PR DESCRIPTION
Add infrastructure so different stategies can be implemented and used for
the AutoDJ.
* Implement linear selector which just selects the next song (old behaviour).
* Add random selector which just picks any track from the track list.

This will allow more advanced stategies in the future based on harmonic theory.

see also #1354 discussion. 

Also Planned:
* Album mode - tries to play a complete album - fixes @Be-ing 's usecase (mine too)
* Harmonic mixing modes - fixes many usecases ( especially unintended party mode )

New song selection will also ask the mode plugin for more songs to add to the queue. One possibility could be that the album mode would look for the next song of the current album in the library if it's not in the queue.
Or the harmonic mixing mode would look for a song in the correct range of candidates.
