### PR TITLE
allow escape loops seeking backwards 

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -1062,6 +1062,7 @@ class MixxxCore(Feature):
                    "track/beatgrid.cpp",
                    "track/beatmap.cpp",
                    "track/beatutils.cpp",
+                   "track/beats.cpp",
                    "track/bpm.cpp",
                    "track/keyfactory.cpp",
                    "track/keys.cpp",

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -792,17 +792,6 @@ void BpmControl::setCurrentSample(const double dCurrentSample, const double dTot
     EngineControl::setCurrentSample(dCurrentSample, dTotalSamples);
 }
 
-double BpmControl::process(const double dRate,
-                           const double dCurrentSample,
-                           const double dTotalSamples,
-                           const int iBufferSize) {
-    Q_UNUSED(dRate);
-    Q_UNUSED(dCurrentSample);
-    Q_UNUSED(dTotalSamples);
-    Q_UNUSED(iBufferSize);
-    return kNoTrigger;
-}
-
 double BpmControl::updateLocalBpm() {
     double prev_local_bpm = m_pLocalBpm->get();
     double local_bpm = 0;

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -20,7 +20,7 @@ class BpmControl : public EngineControl {
 
   public:
     BpmControl(QString group, UserSettingsPointer pConfig);
-    virtual ~BpmControl();
+    ~BpmControl() override;
 
     double getBpm() const;
     double getLocalBpm() const { return m_pLocalBpm ? m_pLocalBpm->get() : 0.0; }
@@ -38,11 +38,11 @@ class BpmControl : public EngineControl {
     double getBeatDistance(double dThisPosition) const;
     double getPreviousSample() const { return m_dPreviousSample; }
 
-    void setCurrentSample(const double dCurrentSample, const double dTotalSamples);
+    void setCurrentSample(const double dCurrentSample, const double dTotalSamples) override;
     double process(const double dRate,
                    const double dCurrentSample,
                    const double dTotalSamples,
-                   const int iBufferSize);
+                   const int iBufferSize) override;
     void setTargetBeatDistance(double beatDistance);
     void setInstantaneousBpm(double instantaneousBpm);
     void resetSyncAdjustment();

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -39,10 +39,6 @@ class BpmControl : public EngineControl {
     double getPreviousSample() const { return m_dPreviousSample; }
 
     void setCurrentSample(const double dCurrentSample, const double dTotalSamples) override;
-    double process(const double dRate,
-                   const double dCurrentSample,
-                   const double dTotalSamples,
-                   const int iBufferSize) override;
     void setTargetBeatDistance(double beatDistance);
     void setInstantaneousBpm(double instantaneousBpm);
     void resetSyncAdjustment();

--- a/src/engine/clockcontrol.cpp
+++ b/src/engine/clockcontrol.cpp
@@ -46,7 +46,7 @@ void ClockControl::slotBeatsUpdated() {
     }
 }
 
-double ClockControl::process(const double dRate,
+void ClockControl::process(const double dRate,
                              const double currentSample,
                              const double totalSamples,
                              const int iBuffersize) {
@@ -66,6 +66,4 @@ double ClockControl::process(const double dRate,
         double distanceToClosestBeat = fabs(currentSample - closestBeat);
         m_pCOBeatActive->set(distanceToClosestBeat < blinkIntervalSamples / 2.0);
     }
-
-    return kNoTrigger;
 }

--- a/src/engine/clockcontrol.h
+++ b/src/engine/clockcontrol.h
@@ -18,7 +18,7 @@ class ClockControl: public EngineControl {
 
     ~ClockControl() override;
 
-    double process(const double dRate, const double currentSample,
+    void process(const double dRate, const double currentSample,
                    const double totalSamples, const int iBufferSize) override;
 
   public slots:

--- a/src/engine/clockcontrol.h
+++ b/src/engine/clockcontrol.h
@@ -16,10 +16,10 @@ class ClockControl: public EngineControl {
     ClockControl(QString group,
                  UserSettingsPointer pConfig);
 
-    virtual ~ClockControl();
+    ~ClockControl() override;
 
     double process(const double dRate, const double currentSample,
-                   const double totalSamples, const int iBufferSize);
+                   const double totalSamples, const int iBufferSize) override;
 
   public slots:
     void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;

--- a/src/engine/cuecontrol.h
+++ b/src/engine/cuecontrol.h
@@ -86,9 +86,9 @@ class CueControl : public EngineControl {
   public:
     CueControl(QString group,
                UserSettingsPointer pConfig);
-    virtual ~CueControl();
+    ~CueControl() override;
 
-    virtual void hintReader(HintVector* pHintList);
+    virtual void hintReader(HintVector* pHintList) override;
     bool updateIndicatorsAndModifyPlay(bool newPlay, bool playPossible);
     void updateIndicators();
     bool isTrackAtCue();

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -19,7 +19,7 @@ EngineControl::EngineControl(QString group,
 EngineControl::~EngineControl() {
 }
 
-double EngineControl::process(const double dRate,
+void EngineControl::process(const double dRate,
                            const double dCurrentSample,
                            const double dTotalSamples,
                            const int iBufferSize) {
@@ -27,7 +27,6 @@ double EngineControl::process(const double dRate,
     Q_UNUSED(dCurrentSample);
     Q_UNUSED(dTotalSamples);
     Q_UNUSED(iBufferSize);
-    return kNoTrigger;
 }
 
 void EngineControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -30,17 +30,6 @@ double EngineControl::process(const double dRate,
     return kNoTrigger;
 }
 
-double EngineControl::nextTrigger(const double dRate,
-                                  const double currentSample,
-                                  const double totalSamples,
-                                  const int iBufferSize) {
-    Q_UNUSED(dRate);
-    Q_UNUSED(currentSample);
-    Q_UNUSED(totalSamples);
-    Q_UNUSED(iBufferSize);
-    return kNoTrigger;
-}
-
 void EngineControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     Q_UNUSED(pNewTrack);
     Q_UNUSED(pOldTrack);

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -41,17 +41,6 @@ double EngineControl::nextTrigger(const double dRate,
     return kNoTrigger;
 }
 
-double EngineControl::getTrigger(const double dRate,
-                                 const double currentSample,
-                                 const double totalSamples,
-                                 const int iBufferSize) {
-    Q_UNUSED(dRate);
-    Q_UNUSED(currentSample);
-    Q_UNUSED(totalSamples);
-    Q_UNUSED(iBufferSize);
-    return kNoTrigger;
-}
-
 void EngineControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
     Q_UNUSED(pNewTrack);
     Q_UNUSED(pOldTrack);

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -49,11 +49,6 @@ class EngineControl : public QObject {
                            const double dTotalSamples,
                            const int iBufferSize);
 
-    virtual double nextTrigger(const double dRate,
-                               const double dCurrentSample,
-                               const double dTotalSamples,
-                               const int iBufferSize);
-
     // hintReader allows the EngineControl to provide hints to the reader to
     // indicate that the given portion of a song is a potential imminent seek
     // target.

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -36,7 +36,7 @@ class EngineControl : public QObject {
   public:
     EngineControl(QString group,
                   UserSettingsPointer pConfig);
-    virtual ~EngineControl();
+    ~EngineControl() override;
 
     // Called by EngineBuffer::process every latency period. See the above
     // comments for information about guarantees that hold during this call. An
@@ -53,11 +53,6 @@ class EngineControl : public QObject {
                                const double dCurrentSample,
                                const double dTotalSamples,
                                const int iBufferSize);
-
-    virtual double getTrigger(const double dRate,
-                              const double dCurrentSample,
-                              const double dTotalSamples,
-                              const int iBufferSize);
 
     // hintReader allows the EngineControl to provide hints to the reader to
     // indicate that the given portion of a song is a potential imminent seek

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -41,10 +41,8 @@ class EngineControl : public QObject {
     // Called by EngineBuffer::process every latency period. See the above
     // comments for information about guarantees that hold during this call. An
     // EngineControl can perform any upkeep operations that are necessary during
-    // this call. If the EngineControl would like to request the playback
-    // position to be altered, it should return the sample to seek to from this
-    // method. Otherwise it should return kNoTrigger.
-    virtual double process(const double dRate,
+    // this call.
+    virtual void process(const double dRate,
                            const double dCurrentSample,
                            const double dTotalSamples,
                            const int iBufferSize);

--- a/src/engine/keycontrol.h
+++ b/src/engine/keycontrol.h
@@ -25,7 +25,7 @@ class KeyControl : public EngineControl {
     };
 
     KeyControl(QString group, UserSettingsPointer pConfig);
-    virtual ~KeyControl();
+    ~KeyControl() override;
 
     // Returns a struct, with the results of the last pitch and tempo calculations
     KeyControl::PitchTempoRatio getPitchTempoRatio();

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -1090,7 +1090,7 @@ void LoopingControl::slotLoopMove(double beats) {
         double new_loop_in = m_pBeats->findNBeatsFromSample(loopSamples.start, beats);
         double new_loop_out = currentLoopMatchesBeatloopSize() ?
                 m_pBeats->findNBeatsFromSample(new_loop_in, m_pCOBeatLoopSize->get()) :
-                m_pBeats->findNBeatsFromSample(loopSamples.start, beats);
+                m_pBeats->findNBeatsFromSample(loopSamples.end, beats);
 
         // If we are looping make sure that the play head does not leave the
         // loop as a result of our adjustment.
@@ -1120,6 +1120,7 @@ int LoopingControl::seekInsideAdjustedLoop(
     }
 
     double new_loop_size = new_loop_out - new_loop_in;
+    DEBUG_ASSERT(new_loop_size > 0);
     double adjusted_position = currentSample;
     while (adjusted_position > new_loop_out) {
         adjusted_position -= new_loop_size;

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -847,13 +847,11 @@ bool LoopingControl::currentLoopMatchesBeatloopSize() {
     LoopSamples loopSamples = m_loopSamples.getValue();
 
     // Calculate where the loop out point would be if it is a beatloop
-    int beatLoopOutPoint =
+    double beatLoopOutPoint =
         m_pBeats->findNBeatsFromSample(loopSamples.start, m_pCOBeatLoopSize->get());
-    if (!even(beatLoopOutPoint)) {
-        beatLoopOutPoint--;
-    }
 
-    return loopSamples.end == beatLoopOutPoint;
+    return loopSamples.end > beatLoopOutPoint - 2 &&
+            loopSamples.end < beatLoopOutPoint + 2;
 }
 
 void LoopingControl::updateBeatLoopingControls() {

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -473,6 +473,12 @@ void LoopingControl::setLoopInToCurrentPosition() {
 
     m_pCOLoopStartPosition->set(loopSamples.start);
 
+    // start looping
+    if (loopSamples.start != kNoTrigger &&
+            loopSamples.end != kNoTrigger) {
+        setLoopingEnabled(true);
+    }
+
     if (m_pQuantizeEnabled->toBool()
             && loopSamples.start < loopSamples.end
             && m_pBeats != nullptr) {

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -334,9 +334,7 @@ double LoopingControl::process(const double dRate,
 
 // This must be called only once from the engine thread
 double LoopingControl::getLoopTarget(
-        const double dRate, const double currentSample) {
-    bool reverse = dRate < 0;
-
+        bool reverse, const double currentSample) {
     double retval = kNoTrigger;
     bool loopMovedOut = false;
     LoopSamples loopSamples = m_loopSamples.getValue();
@@ -373,19 +371,15 @@ double LoopingControl::getLoopTarget(
     return retval;
 }
 
-double LoopingControl::nextTrigger(const double dRate,
-                                   const double currentSample,
-                                   const double totalSamples,
-                                   const int iBufferSize) {
+double LoopingControl::nextTrigger(bool reverse,
+                                   const double currentSample) {
     Q_UNUSED(currentSample);
-    Q_UNUSED(totalSamples);
-    Q_UNUSED(iBufferSize);
-    bool bReverse = dRate < 0;
+
     LoopSamples loopSamples = m_loopSamples.getValue();
 
     if (m_bLoopingEnabled &&
             !m_bAdjustingLoopIn && !m_bAdjustingLoopOut) {
-        if (bReverse) {
+        if (reverse) {
             return loopSamples.start;
         } else {
             return loopSamples.end;

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -39,7 +39,13 @@ QList<double> LoopingControl::getBeatSizes() {
 
 LoopingControl::LoopingControl(QString group,
                                UserSettingsPointer pConfig)
-        : EngineControl(group, pConfig) {
+        : EngineControl(group, pConfig),
+          m_bLoopingEnabled(false),
+          m_bLoopRollActive(false),
+          m_bLoopManualTogglePressedToExitLoop(false),
+          m_bAdjustingLoopIn(false),
+          m_bAdjustingLoopOut(false),
+          m_bLoopOutPressedWhileLoopDisabled(false) {
     LoopSamples loopSamples = { kNoTrigger, kNoTrigger };
     m_loopSamples.setValue(loopSamples);
     m_iCurrentSample = 0;

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -315,6 +315,7 @@ double LoopingControl::process(const double dRate,
                                const int iBufferSize) {
     Q_UNUSED(totalSamples);
     Q_UNUSED(iBufferSize);
+    Q_UNUSED(dRate);
 
     int currentSampleEven = static_cast<int>(currentSample);
     if (!even(currentSampleEven)) {
@@ -322,16 +323,25 @@ double LoopingControl::process(const double dRate,
     }
     m_iCurrentSample = currentSampleEven;
 
+    if (m_bAdjustingLoopIn) {
+        setLoopInToCurrentPosition();
+    } else if (m_bAdjustingLoopOut) {
+        setLoopOutToCurrentPosition();
+    }
+
+    return kNoTrigger;
+}
+
+double LoopingControl::getLoopTarget(
+        const double dRate, const double currentSample) {
     bool reverse = dRate < 0;
 
     double retval = kNoTrigger;
     LoopSamples loopSamples = m_loopSamples.getValue();
 
-    if (m_bAdjustingLoopIn) {
-        setLoopInToCurrentPosition();
-    } else if (m_bAdjustingLoopOut) {
-        setLoopOutToCurrentPosition();
-    } else if (m_bLoopingEnabled &&
+    if (!m_bAdjustingLoopIn &&
+            !m_bAdjustingLoopOut &&
+            m_bLoopingEnabled &&
             loopSamples.start != kNoTrigger &&
             loopSamples.end != kNoTrigger) {
         if (reverse) {

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -1013,6 +1013,10 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
         return;
     }
 
+    m_loopSamples.setValue(newloopSamples);
+    m_pCOLoopStartPosition->set(newloopSamples.start);
+    m_pCOLoopEndPosition->set(newloopSamples.end);
+
     // If resizing an inactive loop by changing beatloop_size,
     // do not seek to the adjusted loop.
     if (keepStartPoint && (enable || m_bLoopingEnabled)) {
@@ -1020,9 +1024,6 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
                 newloopSamples.start, newloopSamples.end);
     }
 
-    m_loopSamples.setValue(newloopSamples);
-    m_pCOLoopStartPosition->set(newloopSamples.start);
-    m_pCOLoopEndPosition->set(newloopSamples.end);
     if (enable) {
         setLoopingEnabled(true);
     }
@@ -1114,10 +1115,10 @@ void LoopingControl::slotLoopMove(double beats) {
         }
 
         loopSamples.start = new_loop_in;
-        m_pCOLoopStartPosition->set(new_loop_in);
         loopSamples.end = new_loop_out;
-        m_pCOLoopEndPosition->set(new_loop_out);
         m_loopSamples.setValue(loopSamples);
+        m_pCOLoopStartPosition->set(new_loop_in);
+        m_pCOLoopEndPosition->set(new_loop_out);
 
         // If we are looping make sure that the play head does not leave the
         // loop as a result of our adjustment.

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -304,7 +304,7 @@ void LoopingControl::slotLoopDouble(double pressed) {
     slotBeatLoop(m_pCOBeatLoopSize->get() * 2.0, true, false);
 }
 
-double LoopingControl::process(const double dRate,
+void LoopingControl::process(const double dRate,
                                const double currentSample,
                                const double totalSamples,
                                const int iBufferSize) {
@@ -323,8 +323,6 @@ double LoopingControl::process(const double dRate,
     } else if (m_bAdjustingLoopOut) {
         setLoopOutToCurrentPosition();
     }
-
-    return kNoTrigger;
 }
 
 double LoopingControl::nextTrigger(bool reverse,

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -44,6 +44,8 @@ LoopingControl::LoopingControl(QString group,
           m_bLoopRollActive(false),
           m_bAdjustingLoopIn(false),
           m_bAdjustingLoopOut(false),
+          m_bAdjustingLoopInOld(false),
+          m_bAdjustingLoopOutOld(false),
           m_bLoopOutPressedWhileLoopDisabled(false) {
     m_oldLoopSamples = { kNoTrigger, kNoTrigger, false };
     m_loopSamples.setValue(m_oldLoopSamples);
@@ -338,6 +340,24 @@ double LoopingControl::nextTrigger(bool reverse,
     *pTarget = kNoTrigger;
 
     LoopSamples loopSamples = m_loopSamples.getValue();
+
+    if (m_bAdjustingLoopInOld != m_bAdjustingLoopIn) {
+        m_bAdjustingLoopInOld = m_bAdjustingLoopIn;
+        if (reverse && !m_bAdjustingLoopIn) {
+            m_oldLoopSamples = loopSamples;
+            *pTarget = loopSamples.end;
+            return currentSample;
+        }
+    }
+
+    if (m_bAdjustingLoopOutOld != m_bAdjustingLoopOut) {
+        m_bAdjustingLoopOutOld = m_bAdjustingLoopOut;
+        if (!reverse && !m_bAdjustingLoopOut) {
+            m_oldLoopSamples = loopSamples;
+            *pTarget = loopSamples.start;
+            return currentSample;
+        }
+    }
 
     if (m_bLoopingEnabled &&
             !m_bAdjustingLoopIn && !m_bAdjustingLoopOut &&

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -676,9 +676,7 @@ void LoopingControl::slotReloopAndStop(double pressed) {
 }
 
 void LoopingControl::slotLoopStartPos(double pos) {
-    if (!m_pTrack) {
-        return;
-    }
+    // This slot is called before trackLoaded() for a new Track
 
     int newpos = pos;
     if (newpos != kNoTrigger && !even(newpos)) {
@@ -711,9 +709,7 @@ void LoopingControl::slotLoopStartPos(double pos) {
 }
 
 void LoopingControl::slotLoopEndPos(double pos) {
-    if (!m_pTrack) {
-        return;
-    }
+    // This slot is called before trackLoaded() for a new Track
 
     int newpos = pos;
     if (newpos != -1 && !even(newpos)) {

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -656,9 +656,7 @@ void LoopingControl::slotReloopToggle(double val) {
         if (loopSamples.start != kNoTrigger && loopSamples.end != kNoTrigger &&
                 loopSamples.start <= loopSamples.end) {
             setLoopingEnabled(true);
-            // If we're not playing, jump to the loop in point so the waveform
-            // shows where it will play from when playback resumes.
-            if (!m_pPlayButton->toBool() && getCurrentSample() > loopSamples.start) {
+            if (getCurrentSample() > loopSamples.end) {
                 slotLoopInGoto(1);
             }
         }

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -365,27 +365,6 @@ double LoopingControl::nextTrigger(const double dRate,
     return kNoTrigger;
 }
 
-double LoopingControl::getTrigger(const double dRate,
-                                  const double currentSample,
-                                  const double totalSamples,
-                                  const int iBufferSize) {
-    Q_UNUSED(currentSample);
-    Q_UNUSED(totalSamples);
-    Q_UNUSED(iBufferSize);
-    bool bReverse = dRate < 0;
-    LoopSamples loopSamples = m_loopSamples.getValue();
-
-    if (m_bLoopingEnabled && !m_bReloopCatchUpcomingLoop &&
-            !m_bAdjustingLoopIn && !m_bAdjustingLoopOut) {
-        if (bReverse) {
-            return loopSamples.end;
-        } else {
-            return loopSamples.start;
-        }
-    }
-    return kNoTrigger;
-}
-
 void LoopingControl::hintReader(HintVector* pHintList) {
     LoopSamples loopSamples = m_loopSamples.getValue();
     Hint loop_hint;

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -337,7 +337,7 @@ double LoopingControl::getLoopTarget(
         bool reverse, const double currentSample) {
     double retval = kNoTrigger;
     bool loopMovedOut = false;
-    LoopSamples loopSamples = m_loopSamples.getValue();
+    LoopSamples loopSamples = m_engineLoopSamples;
     if (loopSamples.start != m_oldLoopSamples.start ||
             loopSamples.end != m_oldLoopSamples.end) {
         if (currentSample >= loopSamples.start - 2 &&
@@ -376,6 +376,8 @@ double LoopingControl::nextTrigger(bool reverse,
     Q_UNUSED(currentSample);
 
     LoopSamples loopSamples = m_loopSamples.getValue();
+    // Store loop samples for later getLoopTarget()
+    m_engineLoopSamples = loopSamples;
 
     if (m_bLoopingEnabled &&
             !m_bAdjustingLoopIn && !m_bAdjustingLoopOut) {

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -501,7 +501,7 @@ void LoopingControl::slotLoopInGoto(double pressed) {
 void LoopingControl::setLoopOutToCurrentPosition() {
     LoopSamples loopSamples = m_loopSamples.getValue();
     double quantizedBeat = -1;
-    int pos = m_iCurrentSample;
+    int pos = m_iCurrentSample + 2;
     if (m_pQuantizeEnabled->toBool() && m_pBeats != nullptr) {
         if (m_bAdjustingLoopOut) {
             double closestBeat = m_pClosestBeat->get();

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -745,12 +745,19 @@ void LoopingControl::slotLoopEndPos(double pos) {
 void LoopingControl::notifySeek(double dNewPlaypos) {
     LoopSamples loopSamples = m_loopSamples.getValue();
     if (m_bLoopingEnabled) {
-        // Disable loop when we jumping out, using hot cues or waveform overview.
+        // Disable loop when we jumping out, or over a catching loop,
+        // using hot cues or waveform overview.
         // + 2 because the new playposition can be rounded to loop end because of
         // playing not at rate 1.
         if (m_iCurrentSample >= loopSamples.start - 2 &&
                 m_iCurrentSample <= loopSamples.end + 2 &&
-                (dNewPlaypos < loopSamples.start - 2 || dNewPlaypos > loopSamples.end + 2)) {
+                dNewPlaypos < loopSamples.start - 2) {
+            // jumping out of loop in backwards
+            setLoopingEnabled(false);
+        }
+        if (m_iCurrentSample <= loopSamples.end + 2 &&
+                dNewPlaypos > loopSamples.end + 2) {
+            // jumping out a loop or over a catching loop forward
             setLoopingEnabled(false);
         }
     }

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -728,7 +728,9 @@ void LoopingControl::notifySeek(double dNewPlaypos) {
     if (m_bLoopingEnabled) {
         // Disable loop when we jump after it, using hot cues or waveform overview
         // If we jump before, the loop it is kept enabled as catching loop
-        if (dNewPlaypos > loopSamples.end) {
+        // + 2 because the new playposition can be rounded to loop end because of
+        // playing not at rate 1.
+        if (dNewPlaypos > loopSamples.end + 2) {
             setLoopingEnabled(false);
         }
     }

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -42,7 +42,6 @@ LoopingControl::LoopingControl(QString group,
         : EngineControl(group, pConfig),
           m_bLoopingEnabled(false),
           m_bLoopRollActive(false),
-          m_bLoopManualTogglePressedToExitLoop(false),
           m_bAdjustingLoopIn(false),
           m_bAdjustingLoopOut(false),
           m_bLoopOutPressedWhileLoopDisabled(false) {

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -1081,10 +1081,10 @@ void LoopingControl::slotLoopMove(double beats) {
 
     if (BpmControl::getBeatContext(m_pBeats, getCurrentSample(),
                                    nullptr, nullptr, nullptr, nullptr)) {
-        double old_loop_in = loopSamples.start;
-        double old_loop_out = loopSamples.end;
-        double new_loop_in = m_pBeats->findNBeatsFromSample(old_loop_in, beats);
-        double new_loop_out = m_pBeats->findNBeatsFromSample(old_loop_out, beats);
+        double new_loop_in = m_pBeats->findNBeatsFromSample(loopSamples.start, beats);
+        double new_loop_out = currentLoopMatchesBeatloopSize() ?
+                m_pBeats->findNBeatsFromSample(new_loop_in, m_pCOBeatLoopSize->get()) :
+                m_pBeats->findNBeatsFromSample(loopSamples.start, beats);
 
         // If we are looping make sure that the play head does not leave the
         // loop as a result of our adjustment.

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -751,7 +751,9 @@ void LoopingControl::notifySeek(double dNewPlaypos) {
         // Disable loop when we jumping out, using hot cues or waveform overview.
         // + 2 because the new playposition can be rounded to loop end because of
         // playing not at rate 1.
-        if (dNewPlaypos < loopSamples.start - 2 || dNewPlaypos > loopSamples.end + 2) {
+        if (m_iCurrentSample >= loopSamples.start - 2 &&
+                m_iCurrentSample <= loopSamples.end + 2 &&
+                (dNewPlaypos < loopSamples.start - 2 || dNewPlaypos > loopSamples.end + 2)) {
             setLoopingEnabled(false);
         }
     }

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -335,8 +335,6 @@ void LoopingControl::process(const double dRate,
 double LoopingControl::nextTrigger(bool reverse,
         const double currentSample,
         double *pTarget) {
-    Q_UNUSED(currentSample);
-
     *pTarget = kNoTrigger;
 
     LoopSamples loopSamples = m_loopSamples.getValue();
@@ -938,8 +936,8 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
         // the end of the track, let beatloop_size be set to
         // a smaller size, but not get larger.
         double previousBeatloopSize = m_pCOBeatLoopSize->get();
-        double previousBeatloopOutPoint =
-            m_pBeats->findNBeatsFromSample(newloopSamples.start, previousBeatloopSize);
+        double previousBeatloopOutPoint = m_pBeats->findNBeatsFromSample(
+                newloopSamples.start, previousBeatloopSize);
         if (previousBeatloopOutPoint < newloopSamples.start
                 && beats < previousBeatloopSize) {
             m_pCOBeatLoopSize->setAndConfirm(beats);
@@ -951,9 +949,9 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
     // do not resize the existing loop until beatloop_size matches
     // the size of the existing loop.
     // Do not return immediately so beatloop_size can be updated.
-    bool avoidResize = false;
+    bool omitResize = false;
     if (!currentLoopMatchesBeatloopSize() && !enable) {
-        avoidResize = true;
+        omitResize = true;
     }
 
     if (m_pCOBeatLoopSize->get() != beats) {
@@ -966,7 +964,7 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
         return;
     }
 
-    if (avoidResize) {
+    if (omitResize) {
         return;
     }
 

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -732,14 +732,14 @@ void LoopingControl::slotLoopEndPos(double pos) {
     m_loopSamples.setValue(loopSamples);
 }
 
+// This is called from the engine thread
 void LoopingControl::notifySeek(double dNewPlaypos) {
     LoopSamples loopSamples = m_loopSamples.getValue();
     if (m_bLoopingEnabled) {
-        // Disable loop when we jump after it, using hot cues or waveform overview
-        // If we jump before, the loop it is kept enabled as catching loop
+        // Disable loop when we jumping out, using hot cues or waveform overview.
         // + 2 because the new playposition can be rounded to loop end because of
         // playing not at rate 1.
-        if (dNewPlaypos > loopSamples.end + 2) {
+        if (dNewPlaypos < loopSamples.start - 2 || dNewPlaypos > loopSamples.end + 2) {
             setLoopingEnabled(false);
         }
     }

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -33,7 +33,7 @@ class LoopingControl : public EngineControl {
     // process() updates the internal state of the LoopingControl to reflect the
     // correct current sample. If a loop should be taken LoopingControl returns
     // the sample that should be seeked to. Otherwise it returns currentSample.
-    double process(const double dRate,
+    void process(const double dRate,
                    const double currentSample,
                    const double totalSamples,
                    const int iBufferSize) override;

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -125,12 +125,12 @@ class LoopingControl : public EngineControl {
     ControlObject* m_pSlipEnabled;
     ControlObject* m_pPlayButton;
 
-    bool m_bLoopingEnabled = false;
-    bool m_bLoopRollActive = false;
-    bool m_bLoopManualTogglePressedToExitLoop = false;
-    bool m_bAdjustingLoopIn = false;
-    bool m_bAdjustingLoopOut = false;
-    bool m_bLoopOutPressedWhileLoopDisabled = false;
+    bool m_bLoopingEnabled;
+    bool m_bLoopRollActive;
+    bool m_bLoopManualTogglePressedToExitLoop;
+    bool m_bAdjustingLoopIn;
+    bool m_bAdjustingLoopOut;
+    bool m_bLoopOutPressedWhileLoopDisabled;
     // TODO(DSC) Make the following values double
     ControlValueAtomic<LoopSamples> m_loopSamples;
     QAtomicInt m_iCurrentSample;

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -133,7 +133,6 @@ class LoopingControl : public EngineControl {
     // TODO(DSC) Make the following values double
     ControlValueAtomic<LoopSamples> m_loopSamples;
     LoopSamples m_oldLoopSamples;
-    LoopSamples m_engineLoopSamples;
     QAtomicInt m_iCurrentSample;
     ControlObject* m_pQuantizeEnabled;
     ControlObject* m_pNextBeat;

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -39,14 +39,12 @@ class LoopingControl : public EngineControl {
                    const int iBufferSize) override;
 
     virtual double getLoopTarget(
-            const double dRate, const double currentSample);
+            bool reverse, const double currentSample);
 
     // nextTrigger returns the sample at which the engine will be triggered to
     // take a loop, given the value of currentSample and dRate.
-    virtual double nextTrigger(const double dRate,
-                       const double currentSample,
-                       const double totalSamples,
-                       const int iBufferSize);
+    virtual double nextTrigger(bool reverse,
+                       const double currentSample);
 
     // hintReader will add to hintList hints both the loop in and loop out
     // sample, if set.

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -38,13 +38,11 @@ class LoopingControl : public EngineControl {
                    const double totalSamples,
                    const int iBufferSize) override;
 
-    virtual double getLoopTarget(
-            bool reverse, const double currentSample);
-
     // nextTrigger returns the sample at which the engine will be triggered to
     // take a loop, given the value of currentSample and dRate.
     virtual double nextTrigger(bool reverse,
-                       const double currentSample);
+                       const double currentSample,
+                       double *pTarget);
 
     // hintReader will add to hintList hints both the loop in and loop out
     // sample, if set.
@@ -93,6 +91,7 @@ class LoopingControl : public EngineControl {
     struct LoopSamples {
         int start;
         int end;
+        bool seek;
     };
 
     void setLoopingEnabled(bool enabled);
@@ -105,8 +104,8 @@ class LoopingControl : public EngineControl {
     // When a loop changes size such that the playposition is outside of the loop,
     // we can figure out the best place in the new loop to seek to maintain
     // the beat.  It will even keep multi-bar phrasing correct with 4/4 tracks.
-    void seekInsideAdjustedLoop(int old_loop_in, int old_loop_out,
-                                int new_loop_in, int new_loop_out);
+    int seekInsideAdjustedLoop(int currentSample,
+            int old_loop_in, int new_loop_in, int new_loop_out);
 
     ControlPushButton* m_pCOBeatLoopActivate;
     ControlPushButton* m_pCOBeatLoopRollActivate;

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -89,8 +89,8 @@ class LoopingControl : public EngineControl {
   private:
 
     struct LoopSamples {
-        int start;
-        int end;
+        double start;
+        double end;
         bool seek;
     };
 
@@ -104,8 +104,8 @@ class LoopingControl : public EngineControl {
     // When a loop changes size such that the playposition is outside of the loop,
     // we can figure out the best place in the new loop to seek to maintain
     // the beat.  It will even keep multi-bar phrasing correct with 4/4 tracks.
-    int seekInsideAdjustedLoop(int currentSample,
-            int old_loop_in, int new_loop_in, int new_loop_out);
+    int seekInsideAdjustedLoop(double currentSample,
+            double old_loop_in, double new_loop_in, double new_loop_out);
 
     ControlPushButton* m_pCOBeatLoopActivate;
     ControlPushButton* m_pCOBeatLoopRollActivate;

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -128,7 +128,6 @@ class LoopingControl : public EngineControl {
     bool m_bLoopingEnabled = false;
     bool m_bLoopRollActive = false;
     bool m_bLoopManualTogglePressedToExitLoop = false;
-    bool m_bReloopCatchUpcomingLoop = false;
     bool m_bAdjustingLoopIn = false;
     bool m_bAdjustingLoopOut = false;
     bool m_bLoopOutPressedWhileLoopDisabled = false;

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -91,7 +91,7 @@ class LoopingControl : public EngineControl {
     struct LoopSamples {
         double start;
         double end;
-        bool seek;
+        bool seek; // force the playposition to be inside the loop after adjusting it.
     };
 
     void setLoopingEnabled(bool enabled);
@@ -135,7 +135,7 @@ class LoopingControl : public EngineControl {
     // TODO(DSC) Make the following values double
     ControlValueAtomic<LoopSamples> m_loopSamples;
     LoopSamples m_oldLoopSamples;
-    QAtomicInt m_iCurrentSample;
+    ControlValueAtomic<double> m_currentSample;
     ControlObject* m_pQuantizeEnabled;
     ControlObject* m_pNextBeat;
     ControlObject* m_pPreviousBeat;

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -129,6 +129,8 @@ class LoopingControl : public EngineControl {
     bool m_bLoopRollActive;
     bool m_bAdjustingLoopIn;
     bool m_bAdjustingLoopOut;
+    bool m_bAdjustingLoopInOld;
+    bool m_bAdjustingLoopOutOld;
     bool m_bLoopOutPressedWhileLoopDisabled;
     // TODO(DSC) Make the following values double
     ControlValueAtomic<LoopSamples> m_loopSamples;

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -129,13 +129,13 @@ class LoopingControl : public EngineControl {
     ControlObject* m_pPlayButton;
 
     bool m_bLoopingEnabled;
-    bool m_bLoopSamplesChanged;
     bool m_bLoopRollActive;
     bool m_bAdjustingLoopIn;
     bool m_bAdjustingLoopOut;
     bool m_bLoopOutPressedWhileLoopDisabled;
     // TODO(DSC) Make the following values double
     ControlValueAtomic<LoopSamples> m_loopSamples;
+    LoopSamples m_oldLoopSamples;
     QAtomicInt m_iCurrentSample;
     ControlObject* m_pQuantizeEnabled;
     ControlObject* m_pNextBeat;

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -28,35 +28,28 @@ class LoopingControl : public EngineControl {
     static QList<double> getBeatSizes();
 
     LoopingControl(QString group, UserSettingsPointer pConfig);
-    virtual ~LoopingControl();
+    ~LoopingControl() override;
 
     // process() updates the internal state of the LoopingControl to reflect the
     // correct current sample. If a loop should be taken LoopingControl returns
     // the sample that should be seeked to. Otherwise it returns currentSample.
-    virtual double process(const double dRate,
+    double process(const double dRate,
                    const double currentSample,
                    const double totalSamples,
-                   const int iBufferSize);
+                   const int iBufferSize) override;
 
     // nextTrigger returns the sample at which the engine will be triggered to
     // take a loop, given the value of currentSample and dRate.
-    virtual double nextTrigger(const double dRate,
+    double nextTrigger(const double dRate,
                        const double currentSample,
                        const double totalSamples,
-                       const int iBufferSize);
-
-    // getTrigger returns the sample that the engine will next be triggered to
-    // loop to, given the value of currentSample and dRate.
-    virtual double getTrigger(const double dRate,
-                      const double currentSample,
-                      const double totalSamples,
-                      const int iBufferSize);
+                       const int iBufferSize) override;
 
     // hintReader will add to hintList hints both the loop in and loop out
     // sample, if set.
-    virtual void hintReader(HintVector* pHintList);
+    void hintReader(HintVector* pHintList) override;
 
-    virtual void notifySeek(double dNewPlaypos);
+    void notifySeek(double dNewPlaypos) override;
 
   public slots:
     void slotLoopIn(double pressed);

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -38,7 +38,7 @@ class LoopingControl : public EngineControl {
                    const double totalSamples,
                    const int iBufferSize) override;
 
-    double getLoopTarget(
+    virtual double getLoopTarget(
             const double dRate, const double currentSample);
 
     // nextTrigger returns the sample at which the engine will be triggered to

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -40,10 +40,10 @@ class LoopingControl : public EngineControl {
 
     // nextTrigger returns the sample at which the engine will be triggered to
     // take a loop, given the value of currentSample and dRate.
-    double nextTrigger(const double dRate,
+    virtual double nextTrigger(const double dRate,
                        const double currentSample,
                        const double totalSamples,
-                       const int iBufferSize) override;
+                       const int iBufferSize);
 
     // hintReader will add to hintList hints both the loop in and loop out
     // sample, if set.

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -38,6 +38,9 @@ class LoopingControl : public EngineControl {
                    const double totalSamples,
                    const int iBufferSize) override;
 
+    double getLoopTarget(
+            const double dRate, const double currentSample);
+
     // nextTrigger returns the sample at which the engine will be triggered to
     // take a loop, given the value of currentSample and dRate.
     virtual double nextTrigger(const double dRate,
@@ -126,6 +129,7 @@ class LoopingControl : public EngineControl {
     ControlObject* m_pPlayButton;
 
     bool m_bLoopingEnabled;
+    bool m_bLoopSamplesChanged;
     bool m_bLoopRollActive;
     bool m_bAdjustingLoopIn;
     bool m_bAdjustingLoopOut;

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -134,6 +134,7 @@ class LoopingControl : public EngineControl {
     // TODO(DSC) Make the following values double
     ControlValueAtomic<LoopSamples> m_loopSamples;
     LoopSamples m_oldLoopSamples;
+    LoopSamples m_engineLoopSamples;
     QAtomicInt m_iCurrentSample;
     ControlObject* m_pQuantizeEnabled;
     ControlObject* m_pNextBeat;

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -127,7 +127,6 @@ class LoopingControl : public EngineControl {
 
     bool m_bLoopingEnabled;
     bool m_bLoopRollActive;
-    bool m_bLoopManualTogglePressedToExitLoop;
     bool m_bAdjustingLoopIn;
     bool m_bAdjustingLoopOut;
     bool m_bLoopOutPressedWhileLoopDisabled;

--- a/src/engine/quantizecontrol.h
+++ b/src/engine/quantizecontrol.h
@@ -16,10 +16,10 @@ class QuantizeControl : public EngineControl {
     Q_OBJECT
   public:
     QuantizeControl(QString group, UserSettingsPointer pConfig);
-    virtual ~QuantizeControl();
+    ~QuantizeControl() override;
 
-    virtual void setCurrentSample(const double dCurrentSample,
-                                  const double dTotalSamples);
+    void setCurrentSample(const double dCurrentSample,
+            const double dTotalSamples) override;
 
   public slots:
     void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -512,7 +512,7 @@ double RateControl::calculateSpeed(double baserate, double speed, bool paused,
     return rate;
 }
 
-double RateControl::process(const double rate,
+void RateControl::process(const double rate,
                             const double currentSample,
                             const double totalSamples,
                             const int bufferSamples)
@@ -547,7 +547,7 @@ double RateControl::process(const double rate,
             // Avoid Division by Zero
             if (range == 0) {
                 qDebug() << "Avoiding a Division by Zero in RATERAMP_STEP code";
-                return kNoTrigger;
+                return;
             }
 
             double change = m_pRateDir->get() * m_dTemp /
@@ -611,8 +611,6 @@ double RateControl::process(const double rate,
             resetRateTemp();
         }
     }
-
-    return kNoTrigger;
 }
 
 double RateControl::getTempRate() {

--- a/src/engine/ratecontrol.h
+++ b/src/engine/ratecontrol.h
@@ -37,7 +37,7 @@ public:
     void setBpmControl(BpmControl* bpmcontrol);
     // Must be called during each callback of the audio thread so that
     // RateControl has a chance to update itself.
-    double process(const double dRate,
+    void process(const double dRate,
                    const double currentSample,
                    const double totalSamples,
                    const int bufferSamples) override;

--- a/src/engine/ratecontrol.h
+++ b/src/engine/ratecontrol.h
@@ -32,7 +32,7 @@ class RateControl : public EngineControl {
     Q_OBJECT
 public:
     RateControl(QString group, UserSettingsPointer pConfig);
-    virtual ~RateControl();
+    ~RateControl() override;
 
     void setBpmControl(BpmControl* bpmcontrol);
     // Must be called during each callback of the audio thread so that
@@ -40,7 +40,7 @@ public:
     double process(const double dRate,
                    const double currentSample,
                    const double totalSamples,
-                   const int bufferSamples);
+                   const int bufferSamples) override;
     // Returns the current engine rate.  "reportScratching" is used to tell
     // the caller that the user is currently scratching, and this is used to
     // disable keylock.
@@ -61,7 +61,7 @@ public:
     static void setRateRamp(bool);
     // Set Rate Ramp Sensitivity
     static void setRateRampSensitivity(int);
-    virtual void notifySeek(double dNewPlaypos);
+    void notifySeek(double dNewPlaypos) override;
 
   public slots:
     void slotReverseRollActivate(double);

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -216,8 +216,9 @@ void ReadAheadManager::addReadLogEntry(double virtualPlaypositionStart,
 }
 
 // Not thread-save, call from engine thread only
-double ReadAheadManager::getFilePlaypositionFromLog(double currentFilePlayposition,
-                                                             double numConsumedSamples) {
+double ReadAheadManager::getFilePlaypositionFromLog(
+        double currentFilePlayposition, double numConsumedSamples) {
+
     if (numConsumedSamples == 0) {
         return currentFilePlayposition;
     }

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -105,8 +105,8 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
     if (loop_active) {
         // LoopingControl makes the decision about whether we should jump to
         // the other end of the loop or not
-        const double loop_target = m_pLoopingControl->process(
-                dRate, m_currentPosition, 0, 0);
+        const double loop_target = m_pLoopingControl->getLoopTarget(
+                dRate, m_currentPosition);
 
         if (loop_target != kNoTrigger) {
             // Jump to other end of loop.

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -62,7 +62,7 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
         samplesToLoopTrigger = in_reverse ?
                 m_currentPosition - loop_trigger :
                 loop_trigger - m_currentPosition;
-        if (samplesToLoopTrigger >= 0.0) {
+        if (samplesToLoopTrigger > 0.0) {
             // We can only read whole frames from the reader.
             // Use ceil here, to be sure to reach the loop trigger.
             preloop_samples = SampleUtil::ceilPlayPosToFrameStart(
@@ -72,6 +72,9 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
                 reachedTrigger = true;
                 samples_from_reader = preloop_samples;
             }
+        } else {
+            reachedTrigger = true;
+            samples_from_reader = 0;
         }
     }
 

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -60,10 +60,7 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
         samplesToLoopTrigger = in_reverse ?
                 m_currentPosition - loop_trigger :
                 loop_trigger - m_currentPosition;
-        if (samplesToLoopTrigger < 0) {
-            // We have already passed the loop trigger
-            samples_from_reader = 0;
-        } else {
+        if (samplesToLoopTrigger > 0) {
             // We can only read whole frames from the reader.
             // Use ceil here, to be sure to reach the loop trigger.
             preloop_samples = SampleUtil::ceilPlayPosToFrameStart(
@@ -238,8 +235,8 @@ double ReadAheadManager::getFilePlaypositionFromLog(
 
         // Notify EngineControls that we have taken a seek.
         // Every new entry start with a seek
+        // (Not looping control)
         if (shouldNotifySeek) {
-            m_pLoopingControl->notifySeek(entry.virtualPlaypositionStart);
             if (m_pRateControl) {
                 m_pRateControl->notifySeek(entry.virtualPlaypositionStart);
             }

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -50,7 +50,7 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
 
     // A loop will only limit the amount we can read in one shot.
     const double loop_trigger = m_pLoopingControl->nextTrigger(
-            dRate, m_currentPosition, 0, 0);
+            in_reverse, m_currentPosition);
     bool loop_active = loop_trigger != kNoTrigger;
     SINT preloop_samples = 0;
     double samplesToLoopTrigger = 0.0;
@@ -103,7 +103,7 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
         // LoopingControl makes the decision about whether we should jump to
         // the other end of the loop or not
         const double loop_target = m_pLoopingControl->getLoopTarget(
-                dRate, m_currentPosition);
+                in_reverse, m_currentPosition);
 
         if (loop_target != kNoTrigger) {
             // Jump to other end of loop.

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -62,7 +62,7 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
         samplesToLoopTrigger = in_reverse ?
                 m_currentPosition - loop_trigger :
                 loop_trigger - m_currentPosition;
-        if (samplesToLoopTrigger > 0.0) {
+        if (samplesToLoopTrigger >= 0.0) {
             // We can only read whole frames from the reader.
             // Use ceil here, to be sure to reach the loop trigger.
             preloop_samples = SampleUtil::ceilPlayPosToFrameStart(
@@ -72,9 +72,6 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
                 reachedTrigger = true;
                 samples_from_reader = preloop_samples;
             }
-        } else {
-            reachedTrigger = true;
-            samples_from_reader = 0;
         }
     }
 

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -66,8 +66,8 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
         } else {
             // We can only read whole frames from the reader.
             // Use ceil here, to be sure to reach the loop trigger.
-            preloop_samples = SampleUtil::ceilPlayPosToFrameStart(samplesToLoopTrigger,
-                    kNumChannels);
+            preloop_samples = SampleUtil::ceilPlayPosToFrameStart(
+                    samplesToLoopTrigger, kNumChannels);
             // clamp requested samples from the caller to the loop trigger point
             samples_from_reader = math_clamp(requested_samples,
                     static_cast<SINT>(0), preloop_samples);
@@ -103,12 +103,13 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
 
     // Activate on this trigger if necessary
     if (loop_active) {
-        // LoopingControl makes the decision about whether we should loop or
-        // not.
+        // LoopingControl makes the decision about whether we should jump to
+        // the other end of the loop or not
         const double loop_target = m_pLoopingControl->process(
                 dRate, m_currentPosition, 0, 0);
 
         if (loop_target != kNoTrigger) {
+            // Jump to other end of loop.
             m_currentPosition = loop_target;
             if (preloop_samples > 0) {
                 // we are up to one frame ahead of the loop trigger

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -22,7 +22,7 @@ class SyncControl : public EngineControl, public Syncable {
     static const double kBpmDouble;
     SyncControl(const QString& group, UserSettingsPointer pConfig,
                 EngineChannel* pChannel, SyncableListener* pEngineSync);
-    virtual ~SyncControl();
+    ~SyncControl() override;
 
     const QString& getGroup() const { return m_sGroup; }
     EngineChannel* getChannel() const { return m_pChannel; }

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -11,6 +11,10 @@
 #include "test/mockedenginebackendtest.h"
 #include "util/memory.h"
 
+// Due to rounding errors loop positions should be compared with EXPECT_NEAR instead of EXPECT_EQ.
+// NOTE(uklotzde, 2017-12-10): The rounding errors currently only appeared with GCC 7.2.1.
+constexpr double kLoopPositionMaxAbsError = 0.000000001;
+
 class LoopingControlTest : public MockedEngineBackendTest {
   public:
     LoopingControlTest()
@@ -527,7 +531,7 @@ TEST_F(LoopingControlTest, LoopMoveTest) {
     m_pButtonBeatMoveBackward->set(0.0);
     ProcessBuffer();
     EXPECT_EQ(0, m_pLoopStartPoint->get());
-    EXPECT_NEAR(300, m_pLoopEndPoint->get(), 0.000000001);
+    EXPECT_NEAR(300, m_pLoopEndPoint->get(), kLoopPositionMaxAbsError);
     ProcessBuffer();
     EXPECT_EQ(200, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
 
@@ -552,7 +556,7 @@ TEST_F(LoopingControlTest, LoopMoveTest) {
     m_pButtonBeatMoveBackward->set(0.0);
     ProcessBuffer();
     EXPECT_EQ(0, m_pLoopStartPoint->get());
-    EXPECT_NEAR(300, m_pLoopEndPoint->get(), 0.000000001);
+    EXPECT_NEAR(300, m_pLoopEndPoint->get(), kLoopPositionMaxAbsError);
     EXPECT_EQ(500, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
 }
 

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -110,10 +110,10 @@ TEST_F(LoopingControlTest, LoopSet) {
 
 TEST_F(LoopingControlTest, LoopSetOddSamples) {
     m_pLoopStartPoint->slotSet(1);
-    m_pLoopEndPoint->slotSet(101);
+    m_pLoopEndPoint->slotSet(101.5);
     seekToSampleAndProcess(50);
-    EXPECT_EQ(0, m_pLoopStartPoint->get());
-    EXPECT_EQ(100, m_pLoopEndPoint->get());
+    EXPECT_EQ(1, m_pLoopStartPoint->get());
+    EXPECT_EQ(101.5, m_pLoopEndPoint->get());
 }
 
 TEST_F(LoopingControlTest, LoopInSetInsideLoopContinues) {

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -390,7 +390,11 @@ TEST_F(LoopingControlTest, LoopScale_HalvesLoop) {
     EXPECT_EQ(500, m_pLoopEndPoint->get());
     // Since the current sample was out of range of the new loop,
     // the current sample should reseek based on the new loop size.
-    EXPECT_EQ(300, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    double target;
+    double trigger = m_pChannel1->getEngineBuffer()->m_pLoopingControl->nextTrigger(
+            false, 1800, &target);
+    EXPECT_EQ(300, target);
+    EXPECT_EQ(1800, trigger);
 }
 
 TEST_F(LoopingControlTest, LoopDoubleButton_IgnoresPastTrackEnd) {
@@ -513,7 +517,11 @@ TEST_F(LoopingControlTest, LoopMoveTest) {
     EXPECT_EQ(44100, m_pLoopStartPoint->get());
     EXPECT_EQ(44400, m_pLoopEndPoint->get());
     // Should seek to the corresponding offset within the moved loop
-    EXPECT_EQ(44110, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    double target;
+    double trigger = m_pChannel1->getEngineBuffer()->m_pLoopingControl->nextTrigger(
+            false, 10, &target);
+    EXPECT_EQ(44110, target);
+    EXPECT_EQ(10, trigger);
 
     // Move backward so that the current position is outside the new location of the loop
     m_pChannel1->getEngineBuffer()->queueNewPlaypos(44300, EngineBuffer::SEEK_STANDARD);
@@ -523,9 +531,12 @@ TEST_F(LoopingControlTest, LoopMoveTest) {
     ProcessBuffer();
     EXPECT_EQ(0, m_pLoopStartPoint->get());
     EXPECT_EQ(300, m_pLoopEndPoint->get());
-    EXPECT_EQ(200, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    trigger = m_pChannel1->getEngineBuffer()->m_pLoopingControl->nextTrigger(
+            false, 44300, &target);
+    EXPECT_EQ(200, target);
+    EXPECT_EQ(44300, trigger);
 
-    // Now repeat the test with looping disabled (should not affect the
+     // Now repeat the test with looping disabled (should not affect the
     // playhead).
     m_pButtonReloopToggle->slotSet(1);
     EXPECT_FALSE(isLoopEnabled());
@@ -537,7 +548,10 @@ TEST_F(LoopingControlTest, LoopMoveTest) {
     EXPECT_EQ(44100, m_pLoopStartPoint->get());
     EXPECT_EQ(44400, m_pLoopEndPoint->get());
     // Should not seek inside the moved loop when the loop is disabled
-    EXPECT_EQ(200, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    trigger = m_pChannel1->getEngineBuffer()->m_pLoopingControl->nextTrigger(
+            false, 200, &target);
+    EXPECT_EQ(-1, target);
+    EXPECT_EQ(-1, trigger);
 
     // Move backward so that the current position is outside the new location of the loop
     m_pChannel1->getEngineBuffer()->queueNewPlaypos(500, EngineBuffer::SEEK_STANDARD);
@@ -577,7 +591,11 @@ TEST_F(LoopingControlTest, LoopResizeSeek) {
     // loop.
     EXPECT_EQ(0, m_pLoopStartPoint->get());
     EXPECT_EQ(450, m_pLoopEndPoint->get());
-    EXPECT_EQ(50, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    double target;
+    double trigger = m_pChannel1->getEngineBuffer()->m_pLoopingControl->nextTrigger(
+            false, 500, &target);
+    EXPECT_EQ(50, target);
+    EXPECT_EQ(500, trigger);
 
     // But if looping is not enabled, no warping occurs.
     m_pLoopStartPoint->slotSet(0);

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -527,7 +527,7 @@ TEST_F(LoopingControlTest, LoopMoveTest) {
     m_pButtonBeatMoveBackward->set(0.0);
     ProcessBuffer();
     EXPECT_EQ(0, m_pLoopStartPoint->get());
-    EXPECT_EQ(300, m_pLoopEndPoint->get());
+    EXPECT_NEAR(300, m_pLoopEndPoint->get(), 0.000000001);
     ProcessBuffer();
     EXPECT_EQ(200, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
 
@@ -552,7 +552,7 @@ TEST_F(LoopingControlTest, LoopMoveTest) {
     m_pButtonBeatMoveBackward->set(0.0);
     ProcessBuffer();
     EXPECT_EQ(0, m_pLoopStartPoint->get());
-    EXPECT_EQ(300, m_pLoopEndPoint->get());
+    EXPECT_NEAR(300, m_pLoopEndPoint->get(), 0.000000001);
     EXPECT_EQ(500, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
 }
 

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -848,3 +848,23 @@ TEST_F(LoopingControlTest, Beatjump_MovesLoopBoundaries) {
     EXPECT_EQ(beatLength, m_pLoopStartPoint->get());
     EXPECT_EQ(beatLength * 2, m_pLoopEndPoint->get());
 }
+
+TEST_F(LoopingControlTest, LoopEscape) {
+    m_pLoopStartPoint->slotSet(100);
+    m_pLoopEndPoint->slotSet(200);
+    m_pButtonReloopToggle->set(1.0);
+    m_pButtonReloopToggle->set(0.0);
+    ProcessBuffer();
+    EXPECT_TRUE(isLoopEnabled());
+    // seek outside a loop schould disable it
+    seekToSampleAndProcess(300);
+    EXPECT_FALSE(isLoopEnabled());
+
+    m_pButtonReloopToggle->set(1.0);
+    m_pButtonReloopToggle->set(0.0);
+    ProcessBuffer();
+    EXPECT_TRUE(isLoopEnabled());
+    // seek outside a loop schould disable it
+    seekToSampleAndProcess(50);
+    EXPECT_FALSE(isLoopEnabled());
+}

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -63,25 +63,12 @@ class StubLoopControl : public LoopingControl {
         return m_processReturnValues.takeFirst();
     }
 
-    // getTrigger returns the sample that the engine will next be triggered to
-    // loop to, given the value of currentSample and dRate.
-    double getTrigger(const double dRate,
-                      const double currentSample,
-                      const double totalSamples,
-                      const int iBufferSize) override {
-        Q_UNUSED(dRate);
-        Q_UNUSED(currentSample);
-        Q_UNUSED(totalSamples);
-        Q_UNUSED(iBufferSize);
-        return kNoTrigger;
-    }
-
     // hintReader has no effect in this stubbed class
     void hintReader(HintVector* pHintList) override {
         Q_UNUSED(pHintList);
     }
 
-    void notifySeek(double dNewPlaypos) {
+    void notifySeek(double dNewPlaypos) override {
         Q_UNUSED(dNewPlaypos);
     }
 

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -39,14 +39,10 @@ class StubLoopControl : public LoopingControl {
         m_processReturnValues.push_back(value);
     }
 
-    double nextTrigger(const double dRate,
-                       const double currentSample,
-                       const double totalSamples,
-                       const int iBufferSize) override {
-        Q_UNUSED(dRate);
+    double nextTrigger(bool reverse,
+                       const double currentSample) override {
+        Q_UNUSED(reverse);
         Q_UNUSED(currentSample);
-        Q_UNUSED(totalSamples);
-        Q_UNUSED(iBufferSize);
         RELEASE_ASSERT(!m_triggerReturnValues.isEmpty());
         return m_triggerReturnValues.takeFirst();
     }
@@ -63,9 +59,10 @@ class StubLoopControl : public LoopingControl {
         return m_processReturnValues.takeFirst();
     }
 
-    double getLoopTarget(const double dRate,
+    double getLoopTarget(bool reverse,
                    const double dCurrentSample) override {
-        Q_UNUSED(dRate);
+        Q_UNUSED(reverse);
+        Q_UNUSED(dCurrentSample);
         RELEASE_ASSERT(!m_processReturnValues.isEmpty());
         return m_processReturnValues.takeFirst();
     }

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -35,36 +35,20 @@ class StubLoopControl : public LoopingControl {
         m_triggerReturnValues.push_back(value);
     }
 
-    void pushProcessReturnValue(double value) {
-        m_processReturnValues.push_back(value);
+    void pushTargetReturnValue(double value) {
+        m_targetReturnValues.push_back(value);
     }
 
     double nextTrigger(bool reverse,
-                       const double currentSample) override {
+                       const double currentSample,
+                       double* pTarget) override {
         Q_UNUSED(reverse);
         Q_UNUSED(currentSample);
+        Q_UNUSED(pTarget);
+        RELEASE_ASSERT(!m_targetReturnValues.isEmpty());
+        *pTarget = m_targetReturnValues.takeFirst();
         RELEASE_ASSERT(!m_triggerReturnValues.isEmpty());
         return m_triggerReturnValues.takeFirst();
-    }
-
-    double process(const double dRate,
-                   const double dCurrentSample,
-                   const double dTotalSamples,
-                   const int iBufferSize) override {
-        Q_UNUSED(dRate);
-        Q_UNUSED(dCurrentSample);
-        Q_UNUSED(dTotalSamples);
-        Q_UNUSED(iBufferSize);
-        RELEASE_ASSERT(!m_processReturnValues.isEmpty());
-        return m_processReturnValues.takeFirst();
-    }
-
-    double getLoopTarget(bool reverse,
-                   const double dCurrentSample) override {
-        Q_UNUSED(reverse);
-        Q_UNUSED(dCurrentSample);
-        RELEASE_ASSERT(!m_processReturnValues.isEmpty());
-        return m_processReturnValues.takeFirst();
     }
 
     // hintReader has no effect in this stubbed class
@@ -84,7 +68,7 @@ class StubLoopControl : public LoopingControl {
 
   protected:
     QList<double> m_triggerReturnValues;
-    QList<double> m_processReturnValues;
+    QList<double> m_targetReturnValues;
 };
 
 class ReadAheadManagerTest : public MixxxTest {
@@ -117,12 +101,12 @@ TEST_F(ReadAheadManagerTest, FractionalFrameLoop) {
     m_pLoopControl->pushTriggerReturnValue(20.2);
     m_pLoopControl->pushTriggerReturnValue(20.2);
     // Process value is the sample we should seek to.
-    m_pLoopControl->pushProcessReturnValue(3.3);
-    m_pLoopControl->pushProcessReturnValue(3.3);
-    m_pLoopControl->pushProcessReturnValue(3.3);
-    m_pLoopControl->pushProcessReturnValue(3.3);
-    m_pLoopControl->pushProcessReturnValue(3.3);
-    m_pLoopControl->pushProcessReturnValue(kNoTrigger);
+    m_pLoopControl->pushTargetReturnValue(3.3);
+    m_pLoopControl->pushTargetReturnValue(3.3);
+    m_pLoopControl->pushTargetReturnValue(3.3);
+    m_pLoopControl->pushTargetReturnValue(3.3);
+    m_pLoopControl->pushTargetReturnValue(3.3);
+    m_pLoopControl->pushTargetReturnValue(kNoTrigger);
     // read from start to loop trigger, overshoot 0.3
     EXPECT_EQ(20, m_pReadAheadManager->getNextSamples(1.0, m_pBuffer, 100));
     // read loop

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -63,6 +63,13 @@ class StubLoopControl : public LoopingControl {
         return m_processReturnValues.takeFirst();
     }
 
+    double getLoopTarget(const double dRate,
+                   const double dCurrentSample) override {
+        Q_UNUSED(dRate);
+        RELEASE_ASSERT(!m_processReturnValues.isEmpty());
+        return m_processReturnValues.takeFirst();
+    }
+
     // hintReader has no effect in this stubbed class
     void hintReader(HintVector* pHintList) override {
         Q_UNUSED(pHintList);
@@ -100,30 +107,6 @@ class ReadAheadManagerTest : public MixxxTest {
     QScopedPointer<ReadAheadManager> m_pReadAheadManager;
     CSAMPLE* m_pBuffer;
 };
-
-TEST_F(ReadAheadManagerTest, LoopEnableSeekBackward) {
-    // If a loop is enabled and the current playposition is ahead of the loop,
-    // we should seek to the beginning of the loop.
-    m_pReadAheadManager->notifySeek(110);
-    // Trigger value means, the sample that triggers the loop (loop out)
-    m_pLoopControl->pushTriggerReturnValue(100);
-    // Process value is the sample we should seek to
-    m_pLoopControl->pushProcessReturnValue(10);
-    EXPECT_EQ(0, m_pReadAheadManager->getNextSamples(1.0, m_pBuffer, 100));
-    EXPECT_EQ(10, m_pReadAheadManager->getPlaypos());
-}
-
-TEST_F(ReadAheadManagerTest, InReverseLoopEnableSeekForward) {
-    // If we are in reverse, a loop is enabled, and the current playposition
-    // is before of the loop, we should seek to the out point of the loop.
-    m_pReadAheadManager->notifySeek(1);
-    // Trigger value means, the sample that triggers the loop (loop in)
-    m_pLoopControl->pushTriggerReturnValue(10);
-    // Process value is the sample we should seek to.
-    m_pLoopControl->pushProcessReturnValue(100);
-    EXPECT_EQ(0, m_pReadAheadManager->getNextSamples(-1.0, m_pBuffer, 100));
-    EXPECT_EQ(100, m_pReadAheadManager->getPlaypos());
-}
 
 TEST_F(ReadAheadManagerTest, FractionalFrameLoop) {
     // If we are in reverse, a loop is enabled, and the current playposition

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -1,0 +1,55 @@
+
+#include "track/beats.h"
+
+
+
+int Beats::numBeatsInRange(double dStartSample, double dEndSample) {
+    double dLastCountedBeat = 0.0;
+    int iBeatsCounter;
+    for (iBeatsCounter = 1; dLastCountedBeat < dEndSample; iBeatsCounter++) {
+        dLastCountedBeat = findNthBeat(dStartSample, iBeatsCounter);
+        if (dLastCountedBeat == -1) {
+            break;
+        }
+    }
+    return iBeatsCounter - 2;
+};
+
+double Beats::findNBeatsFromSample(double fromSample, double beats) const {
+    double nthBeat;
+    double prevBeat;
+    double nextBeat;
+
+    if (!findPrevNextBeats(fromSample, &prevBeat, &nextBeat)) {
+        return fromSample;
+    }
+    double fromFractionBeats = (fromSample - prevBeat) / (nextBeat - prevBeat);
+    double beatsFromPrevBeat = fromFractionBeats + beats;
+
+    int fullBeats = static_cast<int>(beatsFromPrevBeat);
+    double fractionBeats = beatsFromPrevBeat - fullBeats;
+
+    // Add the length between this beat and the fullbeats'th beat
+    // to the end position
+    if (fullBeats > 0) {
+        nthBeat = findNthBeat(nextBeat, fullBeats);
+    } else {
+        nthBeat = findNthBeat(prevBeat, fullBeats - 1);
+    }
+
+    if (nthBeat == -1) {
+        return fromSample;
+    }
+
+    // Add the fraction of the beat
+    if (fractionBeats != 0) {
+        nextBeat = findNthBeat(nthBeat, 2);
+        if (nextBeat == -1) {
+            return fromSample;
+        }
+        nthBeat += (nextBeat - nthBeat) * fractionBeats;
+    }
+
+    return nthBeat;
+};
+

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -104,45 +104,12 @@ class Beats {
     // then dSamples is returned. If no beat can be found, returns -1.
     virtual double findNthBeat(double dSamples, int n) const = 0;
 
-    inline int numBeatsInRange(double dStartSample, double dEndSample) {
-        double dLastCountedBeat = 0.0;
-        int iBeatsCounter;
-        for (iBeatsCounter = 1; dLastCountedBeat < dEndSample; iBeatsCounter++) {
-            dLastCountedBeat = findNthBeat(dStartSample, iBeatsCounter);
-            if (dLastCountedBeat == -1) {
-                break;
-            }
-        }
-        return iBeatsCounter - 2;
-    };
+    int numBeatsInRange(double dStartSample, double dEndSample);
 
     // Find the sample N beats away from dSample. The number of beats may be
     // negative and does not need to be an integer.
-    inline double findNBeatsFromSample(double dSample, double beats) const {
-        double endSample = dSample;
-        double thisBeat = 0.0, nthBeat = 0.0;
-        int fullBeats = static_cast<int>(beats);
-        // Add the length between this beat and the fullbeats'th beat
-        // to the end position
-        if (beats > 0) {
-            thisBeat = findNthBeat(dSample, 1);
-            nthBeat = findNthBeat(dSample, fullBeats + 1);
-        } else if (beats < 0) {
-            thisBeat = findNthBeat(dSample, -1);
-            nthBeat = findNthBeat(dSample, fullBeats - 1);
-        }
-        endSample += nthBeat - thisBeat;
+    double findNBeatsFromSample(double fromSample, double beats) const;
 
-        // Add the fraction of the beat
-        double fractionBeats = beats - static_cast<double>(fullBeats);
-        if (fractionBeats != 0) {
-            double endNextBeat, endPrevBeat;
-            findPrevNextBeats(endSample, &endPrevBeat, &endNextBeat);
-            endSample += (endNextBeat - endPrevBeat) * fractionBeats;
-        }
-
-        return endSample;
-    };
 
     // Adds to pBeatsList the position in samples of every beat occuring between
     // startPosition and endPosition. BeatIterator must be iterated while


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/mixxx/+bug/1716897
Now you can jump back to cue, or any other position and the loop remains active. 

This discovers also a "bug", that is jumps back to loop after changing the direction.
In this case we are suddenly "after" the loop.
How  should we handle this? Normaly we disable the loop if we jump after it. In this case it seems also be wrong. 


