### PR TITLE
Remove ability to re-order history playlists

### DIFF
--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -255,6 +255,10 @@ TrackModel::CapabilitiesFlags PlaylistTableModel::getCapabilities() const {
     if (m_iPlaylistId != m_pTrackCollection->getPlaylistDAO().getPlaylistIdFromName(AUTODJ_TABLE)) {
         caps |= TRACKMODELCAPS_ADDTOAUTODJ;
     }
+    // Disable reording tracks for history playlists
+    if (m_pTrackCollection->getPlaylistDAO().getHiddenType(m_iPlaylistId)== PlaylistDAO::PLHT_SET_LOG) {
+        caps &= ~TRACKMODELCAPS_REORDER;
+    }
     bool locked = m_pTrackCollection->getPlaylistDAO().isPlaylistLocked(m_iPlaylistId);
     if (locked) {
         caps |= TRACKMODELCAPS_LOCKED;


### PR DESCRIPTION
Added as discussed here https://bugs.launchpad.net/mixxx/+bug/1720645

Would someone mind explaining the reasoning behind the hiddentype stuff to me? Seems very roundabout in my opinion.