### PR TITLE
Enable sorting on Recordings View

### DIFF
--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -20,7 +20,7 @@ DlgRecording::DlgRecording(QWidget* parent, UserSettingsPointer pConfig,
           m_durationRecordedStr("--:--"),
           m_pRecordingManager(pRecordingManager) {
     setupUi(this);
-    m_pTrackTableView = new WTrackTableView(this, pConfig, m_pTrackCollection, false); // No sorting
+    m_pTrackTableView = new WTrackTableView(this, pConfig, m_pTrackCollection, true);
     m_pTrackTableView->installEventFilter(pKeyboard);
 
     connect(m_pTrackTableView, SIGNAL(loadTrack(TrackPointer)),


### PR DESCRIPTION
There seem to be no reason why sorting is disabled except historical reasons. Testing with sorting enabled showed no strange side effects and allowed better navigation i a fullish directory.