### PR TITLE
[WIP] better realtime support through realtimekit

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -1147,6 +1147,7 @@ class MixxxCore(Feature):
                    "util/widgethider.cpp",
                    "util/autohidpi.cpp",
                    "util/screensaver.cpp",
+                   "util/realtimehelper.cpp",
 
                    '#res/mixxx.qrc'
                    ]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,7 @@
 #include "util/console.h"
 #include "util/logging.h"
 #include "util/version.h"
+#include "util/realtimehelper.h"
 
 #ifdef Q_OS_LINUX
 #include <X11/Xlib.h>
@@ -60,6 +61,8 @@ int runMixxx(MixxxApplication* app, const CmdlineArgs& args) {
 int main(int argc, char * argv[]) {
     Console console;
 
+    // we may need to set some parameters before we start to create threads
+    mixxx::RealtimeHelper::prepare();
 #ifdef Q_OS_LINUX
     XInitThreads();
 #endif
@@ -91,6 +94,11 @@ int main(int argc, char * argv[]) {
                                args.getLogLevel(), args.getDebugAssertBreak());
 
     MixxxApplication app(argc, argv);
+
+    //RealtimeHelper *rth = new RealtimeHelper(nullptr);
+    mixxx::RealtimeHelper::checkRealtime();
+    // we give mixxx main thead a priority of -5
+    mixxx::RealtimeHelper::requestHighPriority(0, -5);
 
     // Support utf-8 for all translation strings. Not supported in Qt 5.
     // TODO(rryan): Is this needed when we switch to qt5? Some sources claim it

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -23,6 +23,7 @@
 #include "soundio/soundmanager.h"
 #include "soundio/sounddevice.h"
 #include "util/rlimit.h"
+#include "util/realtimehelper.h"
 #include "util/scopedoverridecursor.h"
 #include "control/controlproxy.h"
 
@@ -171,11 +172,8 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
             new ControlProxy("[Master]", "keylock_engine", this);
 
 #ifdef __LINUX__
-    qDebug() << "RLimit Cur " << RLimit::getCurRtPrio();
-    qDebug() << "RLimit Max " << RLimit::getMaxRtPrio();
-
-    if (RLimit::isRtPrioAllowed()) {
-        limitsHint->setText(tr("Realtime scheduling is enabled."));
+    if (mixxx::RealtimeHelper::realtimeAvailable()) {
+        limitsHint->setText(mixxx::RealtimeHelper::getRealtimeStatus());
     }
 #else
     // the limits warning is a Linux only thing

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -109,6 +109,7 @@ class SoundDevicePortAudio : public SoundDevice {
     int m_invalidTimeInfoCount;
     PerformanceTimer m_clkRefTimer;
     PaTime m_lastCallbackEntrytoDacSecs;
+    UserSettingsPointer m_config;
 
 };
 

--- a/src/util/realtimehelper.cpp
+++ b/src/util/realtimehelper.cpp
@@ -1,0 +1,235 @@
+#include "realtimehelper.h"
+#include <QDebug>
+#include <QMetaType>
+#include <QThread>
+//#include <#include "qdbusutil_p.h"QDbusUtil>
+//#include <qdbusutil>
+
+enum REALTIME_STATUS {
+    UNCHECKED = -1,
+    UNAVAILABLE = 0,
+    HIGH_PRIO = 1,
+    AVAILABLE = 100
+};
+
+
+#if __LINUX__
+#include <QDBusInterface>
+
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <error.h>
+#include <errno.h>
+#include <sched.h>
+#include <sys/resource.h>
+
+#include "util/rlimit.h"
+#endif
+
+
+namespace mixxx {
+
+int RealtimeHelper::m_checked = REALTIME_STATUS::UNCHECKED;
+quint32 RealtimeHelper::m_max_rt_prio = 0;
+qint64 RealtimeHelper::m_max_rt_usec = 0;
+qint32 RealtimeHelper::m_min_nice = 0;
+
+void RealtimeHelperTestThread::run() {
+    RealtimeHelper::m_checked = REALTIME_STATUS::UNAVAILABLE;
+
+    if(RealtimeHelper::do_requestHighPriority(0, -2)) {
+        RealtimeHelper::m_checked = REALTIME_STATUS::HIGH_PRIO;
+    }
+
+    if (RealtimeHelper::do_requestRealtime(0, 20, 10000)) {
+        RealtimeHelper::m_checked = REALTIME_STATUS::AVAILABLE;
+    }
+}
+
+
+bool RealtimeHelper::realtimeAvailable() {
+    if (RealtimeHelper::m_checked == REALTIME_STATUS::UNCHECKED) {
+        checkRealtime();
+    }
+    return RealtimeHelper::m_checked >= REALTIME_STATUS::AVAILABLE;
+}
+
+void RealtimeHelper::prepare() {
+    // we have to ensure SCHED_RESET_ON_FORK is set, otherwise rtkit will not give us rt permissions
+    struct sched_param sp;
+
+    if (sched_getparam(0, &sp)) {
+        qWarning() << "sched_getparam failed";
+        RealtimeHelper::m_checked = REALTIME_STATUS::UNAVAILABLE;
+        return;
+    }
+
+    int policy = SCHED_OTHER | SCHED_RESET_ON_FORK;
+    if(sched_setscheduler(0, policy, &sp)) {
+        qWarning() << "Error setting scheduler: " << errno;
+    }
+}
+
+QVariant RealtimeHelper::getRTProperty(QString property) {
+    QDBusMessage message = QDBusMessage::createMethodCall("org.freedesktop.RealtimeKit1",
+                                                          "/org/freedesktop/RealtimeKit1",
+                                                          QLatin1String("org.freedesktop.DBus.Properties"),
+                                                          QLatin1String("Get"));
+    QList<QVariant> arguments;
+    arguments << "org.freedesktop.RealtimeKit1" << property;
+    message.setArguments(arguments);
+    QDBusConnection connection = QDBusConnection::systemBus();
+    QDBusMessage reply = connection.call(message);
+    qDebug() << reply;
+
+    return reply.arguments()[0].value<QDBusVariant>().variant();
+}
+
+bool RealtimeHelper::checkRealtime() {
+
+#if __LINUX__
+
+    qDebug() << "RLimit Cur " << RLimit::getCurRtPrio();
+    qDebug() << "RLimit Max " << RLimit::getMaxRtPrio();
+
+    // Even if for example rtkit is available, we can not be sure the upgrade path
+    // will actually work. We could get a permission denied from policykit for example
+    // we therefore simple spawn a test thread that tries to upgrade as much as possible
+    // and record the sucess.
+
+    RealtimeHelperTestThread *testThread = new RealtimeHelperTestThread();
+    testThread->start();
+    testThread->wait();
+    qDebug() << "Finished realtime testing. Result: " << QString::number(RealtimeHelper::m_checked);
+
+    // get the limits from realtimekit
+    RealtimeHelper::m_max_rt_prio = getRTProperty(QString("MaxRealtimePriority")).toUInt();
+    RealtimeHelper::m_min_nice = getRTProperty(QString("MinNiceLevel")).toInt();
+    RealtimeHelper::m_max_rt_usec = getRTProperty(QString("RTTimeUSecMax")).toLongLong();
+    qDebug() << "max_realtime_priority: " << RealtimeHelper::m_max_rt_prio << \
+                " max_rttime:" << RealtimeHelper::m_max_rt_usec << \
+                " min_nice_level:" << RealtimeHelper::m_min_nice;
+#else // UNSUPPORTED PLATFORM
+
+    RealtimeHelper::m_checked = REALTIME_STATUS::UNAVAILABLE;
+
+#endif
+    return RealtimeHelper::m_checked == REALTIME_STATUS::AVAILABLE;
+}
+
+bool RealtimeHelper::callRTKit(QString method, quint64 threadid, QVariant qprio) {
+    if (threadid == 0) {
+        threadid = syscall(SYS_gettid);
+    }
+
+    QVariant qtid = QVariant::fromValue<quint64>(threadid);
+    //QVariant qprio = QVariant::fromValue((int)priority);
+
+    QDBusInterface *iface = new QDBusInterface("org.freedesktop.RealtimeKit1", "/org/freedesktop/RealtimeKit1", "org.freedesktop.RealtimeKit1",
+                               QDBusConnection::systemBus(), nullptr);
+    if (!iface->isValid()) {
+        return false;
+    }
+
+    QDBusMessage msg = iface->call(method, qtid, qprio);
+    if (msg.type() == QDBusMessage::ErrorMessage) {
+        qWarning() << "Error requesting realtime priority from org.freedesktop.RealtimeKit1: " << msg.errorMessage();
+        return false;
+    }
+    return true;
+}
+
+bool RealtimeHelper::requestHighPriority(quint64 threadid, int priority) {
+    if (RealtimeHelper::m_checked == REALTIME_STATUS::UNCHECKED) {
+        checkRealtime();
+    }
+    if (RealtimeHelper::m_checked == REALTIME_STATUS::UNAVAILABLE) {
+        return false;
+    }
+    return do_requestHighPriority(threadid, priority);
+}
+
+bool RealtimeHelper::requestRealtime(quint64 threadid, unsigned int priority, qint64 rlim_max) {
+    if (RealtimeHelper::m_checked == REALTIME_STATUS::UNCHECKED) {
+        checkRealtime();
+    }
+    if (RealtimeHelper::m_checked == REALTIME_STATUS::UNAVAILABLE) {
+        return false;
+    }
+    return do_requestRealtime(threadid, priority, rlim_max);
+}
+
+QString RealtimeHelper::getRealtimeStatus() {
+    if (RealtimeHelper::m_checked == REALTIME_STATUS::AVAILABLE) {
+        return QObject::tr("Realtime scheduling is enabled.");
+    } else if (RealtimeHelper::m_checked == REALTIME_STATUS::HIGH_PRIO) {
+        return QObject::tr("Realtime scheduling is not availible. High priority is.");
+    } else {
+        return QObject::tr("No higher priorities are available.");
+    }
+}
+
+// actual implementation. We seperate the public API because we use the implemenation in
+// the test thread
+
+#if __LINUX__
+
+bool RealtimeHelper::do_requestHighPriority(quint64 threadid, int priority) {
+    errno = 0;
+    if(nice(priority) != -1 && errno == 0) {
+        // nice actually worked for example though capabilities
+        return true;
+    }
+    // If we request a priority smaller then minimum allowed the request will fail.
+    // better we use the lowest possible value
+    QVariant qprio = QVariant::fromValue((int)qMax(priority, RealtimeHelper::m_min_nice));
+    return callRTKit("MakeThreadHighPriority", threadid, priority);
+}
+
+
+bool RealtimeHelper::do_requestRealtime(quint64 threadid, unsigned int priority, qint64 rlim_max) {
+    // try to use setsched to get realtime priority
+    struct sched_param p;
+    memset(&p, 0, sizeof(p));
+    p.sched_priority = priority;
+    if (sched_setscheduler(0, SCHED_RR|SCHED_RESET_ON_FORK, &p) == 0) {
+        return true;
+    }
+
+    // we check if the rlimt is within the allowed budget
+    if ( rlim_max > RealtimeHelper::m_max_rt_usec ) {
+        qWarning() << "Requested realtime budget not allowed by realtimekit. Requested: " << rlim_max << " allowed:" << RealtimeHelper::m_max_rt_usec;
+        // we should stop here because there is no safe way to request that much budget. realtimekit will kill the process if the budget is overused
+        return false;
+    }
+    // cap the requested priority to whats allowed
+    if ( priority > RealtimeHelper::m_max_rt_prio ) {
+        qWarning() << "Requested realtime priority" << priority << " capping to allowed:" << RealtimeHelper::m_max_rt_prio;
+        priority = RealtimeHelper::m_max_rt_prio;
+    }
+    // for rtkit we need to set rlim_max
+    struct rlimit rlim;
+
+    memset(&rlim, 0, sizeof(rlim));
+    rlim.rlim_cur = rlim.rlim_max = rlim_max; /* 200ms - default for rtkit */
+    if ((setrlimit(RLIMIT_RTTIME, &rlim) < 0)) {
+        fprintf(stderr, "Failed to set RLIMIT_RTTIME: %s\n", strerror(errno));
+    }
+    QVariant qprio = QVariant::fromValue((unsigned int)priority);
+    return callRTKit("MakeThreadRealtime", threadid, qprio);
+}
+
+#else // UNSUPPORTED PLATFORM
+bool RealtimeHelper::do_requestRealtime(quint64 threadid, unsigned int priority, qulonglong rlim_max) {
+    return false;
+}
+bool RealtimeHelper::do_requestHighPriority(quint64 threadid, int priority) {
+    return false;
+}
+#endif
+
+
+}

--- a/src/util/realtimehelper.h
+++ b/src/util/realtimehelper.h
@@ -1,0 +1,44 @@
+#ifndef REALTIMEHELPER_H
+#define REALTIMEHELPER_H
+
+#include <QThread>
+#include <QVariant>
+#include <QString>
+
+
+namespace mixxx {
+
+class RealtimeHelperTestThread : public QThread {
+    Q_OBJECT
+    void run();
+};
+
+#define RLIMIT_DEFAULT 200000LL /* 200ms - default for rtkit */
+
+// Code related to requesting priority changes/realtime priority
+class RealtimeHelper
+{
+public:
+    static bool realtimeAvailable();
+    static void prepare();
+    static bool checkRealtime();
+    static QString getRealtimeStatus();
+    static bool requestRealtime(quint64 threadid, unsigned int priority, qint64 rlim_max = RLIMIT_DEFAULT);
+    static bool requestHighPriority(quint64 threadid, int priority);
+protected:
+    static QVariant getRTProperty(QString property);
+    static bool do_requestRealtime(quint64 threadid, unsigned int priority, qint64 rlim_max);
+    static bool do_requestHighPriority(quint64 threadid, int priority);
+    static bool callRTKit(QString method, quint64 threadid, QVariant qprio);
+    static int m_checked;
+    static quint32 m_max_rt_prio;
+    static qint64 m_max_rt_usec;
+    static qint32 m_min_nice;
+
+
+
+friend class RealtimeHelperTestThread;
+};
+}
+
+#endif // REALTIMEHELPER_H


### PR DESCRIPTION
Add Helperclass for requesting realtime/high priorities.

The mainthread as well as the Engine will try to upgrade priorities. They first
try to lower the nice level to -5 for the main thread and -10 for the Engine.

The Engine further tries to request Realtime Priorities.
4 New settings allow to controll the settings.

[master]
realtime_window = 200000 # useconds mixxx will request as budget
realtime_prio = 15 # realtime priority to request
priority = -10 # nice priority to request
rrenable = false # request realtime priority

by default, no realtime priority is requested. No GUI for the values exist yet.
If the realtime_window is to low, mixxx will get killed from the rtkit watchdog.

The default behavior is to only increase nice levels which will not cause any watchdog behavior.