### PR TITLE
Feature/history reorder

### DIFF
--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -718,52 +718,6 @@ void BasePlaylistFeature::clearChildModel() {
     m_childModel.removeRows(0, m_childModel.rowCount());
 }
 
-#if 0
-QModelIndex BasePlaylistFeature::indexFromPlaylistId(int playlistId) {
-    QQueue<TreeItem*> pTodoList;
-
-    TreeItem* rootItem = m_childModel.getRootItem();
-
-    DEBUG_ASSERT(rootItem != nullptr);
-
-    pTodoList.enqueue(rootItem);
-
-    TreeItem* cur = rootItem;
-    while(cur) {
-        for(i = 0; i < cur->childRows(); i++) {
-
-        }
-
-    }
-    while (!pTodoList.isEmpty()) {
-        TreeItem* it = pTodoList.dequeue();
-        QVariant data = it->data();
-
-        // we do not assume that the childmodel is unique, so we walk the tree
-        // once completely
-        if (data.canConvert<int>() && data.toInt() == playlistId) {
-
-            it->setLabel(playlist_name);
-        }
-
-        for(int i = 0; i < it->childRows(); i++) {
-            TreeItem* child = it->child(i);
-            pTodoList.append(child);
-        }
-    }
-    int row = 0;
-    for (QList<QPair<int, QString> >::const_iterator it = m_playlistList.begin();
-         it != m_playlistList.end(); ++it, ++row) {
-        int current_id = it->first;
-        QString playlist_name = it->second;
-
-        if (playlistId == current_id) {
-            return m_childModel.index(row, 0);
-        }
-    }
-    return QModelIndex();
-}
-#endif
 
 void BasePlaylistFeature::slotTrackSelected(TrackPointer pTrack) {
     m_pSelectedTrack = pTrack;

--- a/src/library/baseplaylistfeature.h
+++ b/src/library/baseplaylistfeature.h
@@ -77,7 +77,7 @@ class BasePlaylistFeature : public LibraryFeature {
     int playlistIdFromIndex(QModelIndex index);
     // Get the QModelIndex of a playlist based on its id.  Returns QModelIndex()
     // on failure.
-    QModelIndex indexFromPlaylistId(int playlistId);
+    bool checkPlaylistId(int playlistId);
 
     TrackCollection* m_pTrackCollection;
     PlaylistDAO &m_playlistDao;
@@ -99,6 +99,7 @@ class BasePlaylistFeature : public LibraryFeature {
     QModelIndex m_lastRightClickedIndex;
     TreeItemModel m_childModel;
     TrackPointer m_pSelectedTrack;
+    QSet<int> m_playlistsSelectedTrackIsIn;
 
   private slots:
     void slotTrackSelected(TrackPointer pTrack);
@@ -107,7 +108,6 @@ class BasePlaylistFeature : public LibraryFeature {
   private:
     virtual QString getRootViewHtml() const = 0;
 
-    QSet<int> m_playlistsSelectedTrackIsIn;
     QString m_rootViewName;
 };
 

--- a/src/library/setlogfeature.cpp
+++ b/src/library/setlogfeature.cpp
@@ -120,8 +120,8 @@ void SetlogFeature::buildPlaylistList() {
     QSqlTableModel playlistTableModel(this, m_pTrackCollection->database());
     playlistTableModel.setTable("Playlists");
     playlistTableModel.setFilter("hidden=2"); // PLHT_SET_LOG
-    playlistTableModel.setSort(playlistTableModel.fieldIndex("id"),
-                               Qt::AscendingOrder);
+    playlistTableModel.setSort(playlistTableModel.fieldIndex("date_created"),
+                               Qt::DescendingOrder);
     playlistTableModel.select();
     while (playlistTableModel.canFetchMore()) {
         playlistTableModel.fetchMore();
@@ -137,6 +137,55 @@ void SetlogFeature::buildPlaylistList() {
             playlistTableModel.index(row, nameColumn)).toString();
         m_playlistList.append(qMakePair(id, name));
     }
+}
+
+/**
+  * Purpose: When inserting or removing playlists,
+  * we require the sidebar model not to reset.
+  * This method queries the database and does dynamic insertion
+*/
+QModelIndex SetlogFeature::constructChildModel(int selected_id) {
+    buildPlaylistList();
+    QList<TreeItem*> data_list;
+    int selected_row = -1;
+
+    TreeItem* older = new TreeItem(this, tr("Older"), -1);
+    QList<TreeItem*> older_list;
+
+    int row = 0;
+    for (QList<QPair<int, QString> >::const_iterator it = m_playlistList.begin();
+         it != m_playlistList.end(); ++it, ++row) {
+        int playlist_id = it->first;
+        QString playlist_name = it->second;
+
+        if (selected_id == playlist_id) {
+            // save index for selection
+            selected_row = row;
+            m_childModel.index(selected_row, 0);
+        }
+
+
+        // Create the TreeItem whose parent is the invisible root item
+        TreeItem* item = new TreeItem(this, playlist_name, playlist_id);
+        item->setBold(m_playlistsSelectedTrackIsIn.contains(playlist_id));
+
+        decorateChild(item, playlist_id);
+        if (row < 10) {
+            data_list.append(item);
+        } else {
+            older_list.append(item);
+        }
+    }
+    // put all the older playlists into the older folder
+    older->insertChildren(older_list, 0, older_list.count());
+    data_list.append(older);
+    // Append all the newly created TreeItems in a dynamic way to the childmodel
+    m_childModel.insertTreeItemRows(data_list, 0);
+
+    if (selected_row == -1) {
+        return QModelIndex();
+    }
+    return m_childModel.index(selected_row, 0);
 }
 
 void SetlogFeature::decorateChild(TreeItem* item, int playlist_id) {

--- a/src/library/setlogfeature.h
+++ b/src/library/setlogfeature.h
@@ -6,6 +6,7 @@
 #include <QLinkedList>
 #include <QSqlTableModel>
 #include <QAction>
+#include <QModelIndex>
 
 #include "library/baseplaylistfeature.h"
 #include "preferences/usersettings.h"
@@ -35,6 +36,7 @@ public:
   protected:
     void buildPlaylistList();
     void decorateChild(TreeItem *pChild, int playlist_id);
+    virtual QModelIndex constructChildModel(int selected_id);
 
   private slots:
     void slotPlayingTrackChanged(TrackPointer currentPlayingTrack);


### PR DESCRIPTION
When you use mixxx a lot, the number of history entries make the menu very long and does not necessary
 provide the useful information you often need.

If you using mixxx for private playback, you quite often go to the current history to tag the current or previous one. For this you have to scroll to the end of a quite long list. If you want to prevent playing a song from some previous set, the playlists should be visible.

This pull request first removes the assumption that playlist menus are always linear (first commit).

The second commit makes the menu more slim. Only the last 9 playlists are shown, everything older is put into the "Older" submenu so it does not blow the menu that much.

[Screenshot](https://imgur.com/a/KsWNp)

After the library rewrite/nested crates land, I plan to organize the history menu a bit better, maybe group by year for example. This change just tries to bandage the immanent pain points.