### PR TITLE
remove persistence from EffectUnit routing switches

### DIFF
--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -315,7 +315,7 @@ void EffectChainSlot::registerChannel(const ChannelHandleAndGroup& handle_group)
     }
     ControlPushButton* pEnableControl = new ControlPushButton(
             ConfigKey(m_group, QString("group_%1_enable").arg(handle_group.name())),
-            true, initialValue);
+            false, initialValue);
     pEnableControl->setButtonMode(ControlPushButton::POWERWINDOW);
 
     ChannelInfo* pInfo = new ChannelInfo(handle_group, pEnableControl);


### PR DESCRIPTION
I thought this would be useful before when I worked on #1103, but experience has shown it is annoying. I want effect unit 1 assigned to deck 2, unit 2 to deck 2, unit 3 to deck 3, and unit 4 to deck 4 on startup regardless of how the routing switches happened to be when I last shut down Mixxx.