### PR TITLE
Fix plugin build on Fedora 27 with SCons 2.5.1

### DIFF
--- a/plugins/soundsourcem4a/SConscript
+++ b/plugins/soundsourcem4a/SConscript
@@ -54,6 +54,12 @@ if int(build.flags['faad']):
                 'libfaad', 'neaacdec.h', 'c++',
                 call = 'NeAACDecInit2(0, 0, 0, (unsigned long*)0, (unsigned char*)0);',
                 autoadd=False)
+        # Only the second check succeeds!! BUT WHY??
+        # See also: https://stackoverflow.com/questions/26245218/how-to-clear-scons-cache-checklibwithheader-returns-no-first-time-called-ye
+        have_faad_27_or_newer = conf.CheckLibWithHeader(
+                'libfaad', 'neaacdec.h', 'c++',
+                call = 'NeAACDecInit2(0, 0, 0, (unsigned long*)0, (unsigned char*)0);',
+                autoadd=False)
         if not have_faad_27_or_newer:
             env.Append(CPPDEFINES = '__M4AHACK__')
             print("libfaad 2.6 compatibility mode... enabled")

--- a/plugins/soundsourcem4a/SConscript
+++ b/plugins/soundsourcem4a/SConscript
@@ -35,31 +35,28 @@ if int(build.flags['faad']):
     conf = Configure(env)
 
     have_mp4v2_h = conf.CheckHeader('mp4v2/mp4v2.h')
+    if have_mp4v2_h:
+        env.Append(CPPDEFINES = '__MP4V2__')
+
     have_mp4 = conf.CheckLib(['mp4v2', 'libmp4v2']) or \
         conf.CheckLib('mp4')
 
     have_faad = conf.CheckLib(['faad', 'libfaad'])
-    have_faad_26 = False
-
     # We have to check for libfaad version 2.6 or 2.7. In libfaad
     # version 2.7, the type for the samplerate is unsigned long*,
     # while in 2.6 the type is uint32_t*. We can use the optional
     # call parameter to CheckLibWithHeader to build a test file to
     # check which one this faad.h supports.
-
-    # Check for libfaad version 2.6. This check doesn't work correctly on Windows
-    # And we build it manually anyway, so we know it's v2.7
+    # This check doesn't work correctly on Windows and we build it
+    # manually anyway, so we know it's v2.7.
     if have_faad and not build.platform_is_windows:
-        have_faad_26 = (not conf.CheckLibWithHeader(
-                'libfaad', 'faad.h', 'c++',
-                call = 'faacDecInit2(0, 0, 0, (unsigned long*)0, (unsigned char*)0);',
-                autoadd=False))
-
-    if have_faad_26:
-        env.Append(CPPDEFINES = '__M4AHACK__')
-        print("libfaad 2.6 compatibility mode... enabled")
-    if have_mp4v2_h:
-        env.Append(CPPDEFINES = '__MP4V2__')
+        have_faad_27_or_newer = conf.CheckLibWithHeader(
+                'libfaad', 'neaacdec.h', 'c++',
+                call = 'NeAACDecInit2(0, 0, 0, (unsigned long*)0, (unsigned char*)0);',
+                autoadd=False)
+        if not have_faad_27_or_newer:
+            env.Append(CPPDEFINES = '__M4AHACK__')
+            print("libfaad 2.6 compatibility mode... enabled")
 
     env = conf.Finish()
     results = []


### PR DESCRIPTION
These 2 commits have been cherry-picked from #1317. Without this fix FAAD2 is not detected reliably and the build of the SoundSourceM4A plugin often fails. Very annoying when testing other branches.