### PR TITLE
RecDuration widget: show custom text when not recording

### DIFF
--- a/src/widget/wrecordingduration.cpp
+++ b/src/widget/wrecordingduration.cpp
@@ -18,11 +18,14 @@ void WRecordingDuration::setup(const QDomNode& node, const SkinContext& context)
 
     // When we're recording show text from "InactiveText" node
     QString inactiveText;
-    if (context.hasNodeSelectString(node, "InactiveText", &m_inactiveText)) {
-        // Set inactiveText here already because slotRecordingInactive
-        // is refreshed first when we start recording
-        setText(m_inactiveText);
+    if (context.hasNodeSelectString(node, "InactiveText", &inactiveText)) {
+        m_inactiveText = inactiveText;
+    } else {
+        m_inactiveText = QString("--:--");
     }
+    // Set inactiveText here already because slotRecordingInactive
+    // is refreshed first when we start recording
+    setText(m_inactiveText);
 }
 
 void WRecordingDuration::slotRecordingInactive(bool isRecording) {

--- a/src/widget/wrecordingduration.cpp
+++ b/src/widget/wrecordingduration.cpp
@@ -26,7 +26,7 @@ void WRecordingDuration::setup(const QDomNode& node, const SkinContext& context)
 }
 
 void WRecordingDuration::slotRecordingInactive(bool isRecording) {
-    // When we're recording show InactiveText
+    // When we're not recording show InactiveText
     if(!isRecording) {
         setText(m_inactiveText);
     }

--- a/src/widget/wrecordingduration.cpp
+++ b/src/widget/wrecordingduration.cpp
@@ -15,12 +15,20 @@ void WRecordingDuration::setup(const QDomNode& node, const SkinContext& context)
         this, SLOT(refreshLabel(QString)));
     connect(m_pRecordingManager, SIGNAL(isRecording(bool)),
             this, SLOT(slotRecordingInactive(bool)));
+
+    // When we're recording show text from "InactiveText" node
+    QString inactiveText;
+    if (context.hasNodeSelectString(node, "InactiveText", &m_inactiveText)) {
+        // Set inactiveText here already because slotRecordingInactive
+        // is refreshed first when we start recording
+        setText(m_inactiveText);
+    }
 }
 
 void WRecordingDuration::slotRecordingInactive(bool isRecording) {
-    // If recording is stopped/inactive
+    // When we're recording show InactiveText
     if(!isRecording) {
-        setText("--:--");
+        setText(m_inactiveText);
     }
 }
 

--- a/src/widget/wrecordingduration.h
+++ b/src/widget/wrecordingduration.h
@@ -17,6 +17,9 @@ class WRecordingDuration: public WLabel {
 
     void setup(const QDomNode& node, const SkinContext& context) override;
 
+  protected:
+    QString m_inactiveText;
+
   private slots:
     void refreshLabel(QString);
     void slotRecordingInactive(bool);

--- a/src/widget/wrecordingduration.h
+++ b/src/widget/wrecordingduration.h
@@ -1,6 +1,6 @@
 // wrecordingduration.h
 // WRecordingDuration is a widget showing the duration of running recoding
-// In skin.xml, it is represented by a <RecordingDuration> node.
+// In skin it is represented by a <RecordingDuration> node.
 
 #ifndef WRECORDINGDURATION_H
 #define WRECORDINGDURATION_H
@@ -17,15 +17,13 @@ class WRecordingDuration: public WLabel {
 
     void setup(const QDomNode& node, const SkinContext& context) override;
 
-  protected:
-    QString m_inactiveText;
-
   private slots:
     void refreshLabel(QString);
     void slotRecordingInactive(bool);
 
   private:
     RecordingManager* m_pRecordingManager;
+    QString m_inactiveText;
 };
 
 #endif /* WRECORDINGDURATION_H */


### PR DESCRIPTION
I'm tuning RecordingDuration widget in a way that you can define a string to display
when recording is not active (yet), instead of default `--:--`

Node name is `<InactiveText>`

Reason to implement this is that working around the default string was quite annoying
while revamping Tango recently.