### PR TITLE
Allow re-import of metadata for tracks with unsaved changes

### DIFF
--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -427,8 +427,7 @@ void SoundSourceProxy::updateTrackFromSource(
     // not be supported at all and those would get lost!
     mixxx::TrackMetadata trackMetadata;
     bool metadataSynchronized = false;
-    bool isDirty = false;
-    m_pTrack->getTrackMetadata(&trackMetadata, &metadataSynchronized, &isDirty);
+    m_pTrack->getTrackMetadata(&trackMetadata, &metadataSynchronized);
     // Cast away the enriched track location by explicitly slicing the
     // returned CoverInfo to CoverInfoRelative
     const CoverInfoRelative coverInfo(m_pTrack->getCoverInfo());
@@ -438,7 +437,7 @@ void SoundSourceProxy::updateTrackFromSource(
     // If the file tags have already been parsed once, both track metadata
     // and cover art should not be updated implicitly.
     if (metadataSynchronized) {
-        if (isDirty || (importTrackMetadataMode == ImportTrackMetadataMode::Once)) {
+        if (importTrackMetadataMode == ImportTrackMetadataMode::Once) {
             kLogger.info() << "Skip parsing of track metadata and cover art from file"
                      << getUrl().toString();
             return; // abort

--- a/src/test/trackupdate_test.cpp
+++ b/src/test/trackupdate_test.cpp
@@ -136,9 +136,9 @@ TEST_F(TrackUpdateTest, parseModifiedDirtyAgain) {
     pTrack->getTrackMetadata(&trackMetadataAfter);
     auto coverInfoAfter = pTrack->getCoverInfo();
 
-    // Not updated
+    // Updated
     EXPECT_TRUE(pTrack->isMetadataSynchronized());
     EXPECT_TRUE(pTrack->isDirty());
-    EXPECT_EQ(trackMetadataBefore, trackMetadataAfter);
+    EXPECT_NE(trackMetadataBefore, trackMetadataAfter);
     EXPECT_EQ(coverInfoBefore, coverInfoAfter);
 }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -144,16 +144,12 @@ void Track::setTrackMetadata(
 
 void Track::getTrackMetadata(
         mixxx::TrackMetadata* pTrackMetadata,
-        bool* pMetadataSynchronized,
-        bool* pDirty) const {
+        bool* pMetadataSynchronized) const {
     DEBUG_ASSERT(pTrackMetadata);
     QMutexLocker lock(&m_qMutex);
     *pTrackMetadata = m_record.getMetadata();
     if (pMetadataSynchronized != nullptr) {
         *pMetadataSynchronized = m_record.getMetadataSynchronized();
-    }
-    if (pDirty != nullptr) {
-        *pDirty = m_bDirty;
     }
 }
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -281,8 +281,7 @@ class Track : public QObject {
             QDateTime metadataSynchronized);
     void getTrackMetadata(
             mixxx::TrackMetadata* pTrackMetadata,
-            bool* pMetadataSynchronized = nullptr,
-            bool* pDirty = nullptr) const;
+            bool* pMetadataSynchronized = nullptr) const;
 
     void getTrackRecord(
             mixxx::TrackRecord* pTrackRecord,

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1388,10 +1388,28 @@ void WTrackTableView::slotImportTrackMetadata() {
 
     for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
+        if (pTrack && pTrack->isDirty()) {
+            if (QMessageBox::Apply == QMessageBox::question(
+                    nullptr,
+                    tr("Import Track Metadata"),
+                    tr("One or more selected tracks have unsaved changes. Continue anyway?"),
+                    QMessageBox::Apply | QMessageBox::Cancel,
+                    QMessageBox::Apply)) {
+                // Continue with import
+                break;
+            } else {
+                // Abort import
+                return;
+            }
+        }
+    }
+
+    for (const QModelIndex& index : indices) {
+        TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
             // The user has explicitly requested to reload metadata from the file
-            // to override the information within Mixxx! Cover art is reloaded
-            // separately.
+            // to override the information within Mixxx! Custom cover art must be
+            // reloaded separately.
             SoundSourceProxy(pTrack).updateTrackFromSource(
                     SoundSourceProxy::ImportTrackMetadataMode::Again);
         }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1388,24 +1388,6 @@ void WTrackTableView::slotImportTrackMetadata() {
 
     for (const QModelIndex& index : indices) {
         TrackPointer pTrack = trackModel->getTrack(index);
-        if (pTrack && pTrack->isDirty()) {
-            if (QMessageBox::Apply == QMessageBox::question(
-                    nullptr,
-                    tr("Import Track Metadata"),
-                    tr("One or more selected tracks have unsaved changes. Continue anyway?"),
-                    QMessageBox::Apply | QMessageBox::Cancel,
-                    QMessageBox::Apply)) {
-                // Continue with import
-                break;
-            } else {
-                // Abort import
-                return;
-            }
-        }
-    }
-
-    for (const QModelIndex& index : indices) {
-        TrackPointer pTrack = trackModel->getTrack(index);
         if (pTrack) {
             // The user has explicitly requested to reload metadata from the file
             // to override the information within Mixxx! Custom cover art must be


### PR DESCRIPTION
This bug or unexpected behaviour was discovered while reviewing #728 

Now re-import of metadata should work as expected, especially for tracks with unsaved metadata that are cached in Mixxx before the database is updated.