### PR TITLE
Fix Linux Nightly Builds

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -215,9 +215,9 @@ class Qt(Dependence):
                 import subprocess
                 try:
                     if qt5:
-                        core = subprocess.Popen(["pkg-config", "--variable=libdir", "Qt5Core"], stdout = subprocess.PIPE).communicate()[0].decode(sys.stdout.encoding).rstrip()
+                        core = subprocess.Popen(["pkg-config", "--variable=libdir", "Qt5Core"], stdout = subprocess.PIPE).communicate()[0].rstrip()
                     else:
-                        core = subprocess.Popen(["pkg-config", "--variable=libdir", "QtCore"], stdout = subprocess.PIPE).communicate()[0].decode(sys.stdout.encoding).rstrip()
+                        core = subprocess.Popen(["pkg-config", "--variable=libdir", "QtCore"], stdout = subprocess.PIPE).communicate()[0].rstrip()
                 finally:
                     if os.path.isdir(core):
                         return core

--- a/build/qt5.py
+++ b/build/qt5.py
@@ -550,9 +550,9 @@ def _find_qtdirs(qt5dir, module):
                 else:
                     module5 = module
                 if not os.path.isdir(QT5LIBDIR):
-                    QT5LIBDIR = subprocess.Popen(["pkg-config", "--variable=libdir", module5], stdout = subprocess.PIPE).communicate()[0].decode(sys.stdout.encoding).rstrip()
+                    QT5LIBDIR = subprocess.Popen(["pkg-config", "--variable=libdir", module5], stdout = subprocess.PIPE).communicate()[0].rstrip()
                 if not os.path.isdir(QT5INCDIR):
-                    QT5INCDIR = subprocess.Popen(["pkg-config", "--variable=includedir", module5], stdout = subprocess.PIPE).communicate()[0].decode(sys.stdout.encoding).rstrip()
+                    QT5INCDIR = subprocess.Popen(["pkg-config", "--variable=includedir", module5], stdout = subprocess.PIPE).communicate()[0].rstrip()
             finally:
                 pass
     return QT5LIBDIR, QT5INCDIR, os.path.join(QT5INCDIR,module)


### PR DESCRIPTION
Revert "Decode subprocess output from bytes to str"

This reverts commit 3d49037c844e4a37493729388a07d3cc95c24e3d.

When piping ouput from scons during a build sys.stdout.encoding that is used for decoding output from a subprocess seems to be undefined and decoding fails:

https://stackoverflow.com/questions/492483/setting-the-correct-encoding-when-piping-stdout-in-python