### PR TITLE
[WIP] Music glyphs in Key display

### DIFF
--- a/res/fonts/music-glyphs.txt
+++ b/res/fonts/music-glyphs.txt
@@ -1,0 +1,5 @@
+Music Flat Sign U+266D
+https://unicode-table.com/en/266D/
+
+Music Sharp Sign U+266F
+https://unicode-table.com/en/266F/


### PR DESCRIPTION
The glyphs for musical [Sharp Sign ♯](https://unicode-table.com/en/266F/) and [Flat Sign ♭](https://unicode-table.com/en/266D/) are hard to read in all skins because the fonts we rely on don't contain those glyphs (neither regular nor bold) and Mixxx uses fallback fonts. Probably you already notice this in the browser..
![all-skins_old](https://user-images.githubusercontent.com/5934199/33890463-9ef30e70-df53-11e7-9c18-bfa90cf6b951.png)

To improve this situation we could modify the fonts we ship with Mixxx, Open Sans and Ubuntu. I tried to adjust ♯ a bit with font-forge in Ubuntu Bold and it works well:
![tango_bold](https://user-images.githubusercontent.com/5934199/33890580-f8f71178-df53-11e7-8aff-133d1fc7df9e.png)

What do you think?