### PR TITLE
Add support for Traktor cues

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -970,6 +970,7 @@ class MixxxCore(Feature):
 
                    "library/itunes/itunesfeature.cpp",
                    "library/traktor/traktorfeature.cpp",
+                   "library/traktor/traktor_cue.cpp",
 
                    "library/sidebarmodel.cpp",
                    "library/library.cpp",

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -428,19 +428,25 @@ METADATA
   </revision>
   <revision version="28" min_compatible="3">
     <description>
-      Add traktor color support.
-      See library/traktor/traktorfeature.cpp
+      Add traktor cue support.
+      Table represents traktor cues in their native format.
+      Traktor cues are pushed into it when the traktor library is parsed.
+      The traktor cues are read from this table, when a track is added to
+      the library.
+      See library/traktor/traktorfeature.cpp and library/traktor/traktor_cue.cpp
     </description>
     <sql>
       CREATE TABLE IF NOT EXISTS traktor_cues (
         id integer PRIMARY KEY AUTOINCREMENT,
         track_id integer NOT NULL REFERENCES traktor_library(id),
-        type integer DEFAULT 0 NOT NULL,
-        position integer DEFAULT -1 NOT NULL,
-        length integer DEFAULT 0 NOT NULL,
+        displ_order integer DEFAULT 0 NOT NULL,
         hotcue integer DEFAULT -1 NOT NULL,
-        label text DEFAULT '' NOT NULL,
-		color INTEGER DEFAULT 4294901760 NOT NULL);
+        len integer DEFAULT 0 NOT NULL,
+        name text DEFAULT '' NOT NULL,
+        repeats integer DEFAULT -1 NOT NULL,
+        start double DEFAULT -1 NOT NULL,
+        type integer DEFAULT 0 NOT NULL
+      );
     </sql>
   </revision>
 </schema>

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -426,4 +426,21 @@ METADATA
       ALTER TABLE cues ADD COLUMN color INTEGER DEFAULT 4294901760 NOT NULL;
     </sql>
   </revision>
+  <revision version="28" min_compatible="3">
+    <description>
+      Add traktor color support.
+      See library/traktor/traktorfeature.cpp
+    </description>
+    <sql>
+      CREATE TABLE IF NOT EXISTS traktor_cues (
+        id integer PRIMARY KEY AUTOINCREMENT,
+        track_id integer NOT NULL REFERENCES traktor_library(id),
+        type integer DEFAULT 0 NOT NULL,
+        position integer DEFAULT -1 NOT NULL,
+        length integer DEFAULT 0 NOT NULL,
+        hotcue integer DEFAULT -1 NOT NULL,
+        label text DEFAULT '' NOT NULL,
+		color INTEGER DEFAULT 4294901760 NOT NULL);
+    </sql>
+  </revision>
 </schema>

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -11,7 +11,7 @@
 const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
 
 //static
-const int MixxxDb::kRequiredSchemaVersion = 27;
+const int MixxxDb::kRequiredSchemaVersion = 28;
 
 namespace {
 

--- a/src/library/dao/cue.h
+++ b/src/library/dao/cue.h
@@ -23,6 +23,8 @@ class Cue : public QObject {
         JUMP    = 5,
     };
 
+    Cue(int id, TrackId trackId, CueType type, double position, double length,
+        int hotCue, QString label, QColor color);
     ~Cue() override;
 
     bool isDirty() const;
@@ -52,8 +54,6 @@ class Cue : public QObject {
 
   private:
     explicit Cue(TrackId trackId);
-    Cue(int id, TrackId trackId, CueType type, double position, double length,
-        int hotCue, QString label, QColor color);
     void setDirty(bool dirty);
     void setId(int id);
     void setTrackId(TrackId trackId);

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -56,6 +56,9 @@ class TrackCollection : public QObject,
     AnalysisDao& getAnalysisDAO() {
         return m_analysisDao;
     }
+    CueDAO& getCueDAO() {
+        return m_cueDao;
+    }
 
     QSharedPointer<BaseTrackCache> getTrackSource() const {
         return m_pTrackSource;

--- a/src/library/traktor/traktor_cue.cpp
+++ b/src/library/traktor/traktor_cue.cpp
@@ -45,16 +45,27 @@ void TraktorCue::fillQuery(int track_id, QSqlQuery &query) {
 
 CuePointer TraktorCue::toCue(int samplerate) {
     //Incomplete
+    int hotcue = this->hotcue;
     Cue::CueType type;
     switch (this->type) {
         case HOTCUE:
             type = Cue::CueType::CUE;
             break;
-        case AUTOGRID:
+        case LOAD:
             type = Cue::CueType::LOAD;
             break;
+        case LOOP:
+            type = Cue::CueType::LOOP;
+            break;
+        case AUTOGRID:
+            type = Cue::CueType::BEAT;
+            break;
+        case FADEIN:
+        case FADEOUT:
+            qDebug() << "Fade cue points are not yet supported in mixxx";
+            return CuePointer(NULL);
         default:
-            qDebug() << "Unsupported traktor cue type: " << this->type;
+            qDebug() << "Unknown traktor cue type: " << this->type;
             return CuePointer(NULL);
     }
     TrackId track_id(this->track_id);
@@ -62,8 +73,9 @@ CuePointer TraktorCue::toCue(int samplerate) {
     //start is a a float denoting milliseconds
     //convert to stereoSamplePointer
     int position = int(start/1000.0 * double(samplerate) * 2.0);
+    int length = int(len/1000.0 * double(samplerate) * 2.0);
 
-    return CuePointer(new Cue(-1, track_id, type, position, len, hotcue, name, 
-                color));
+    return CuePointer(new Cue(-1, track_id, type, position, length, hotcue,
+                name, color));
 }
 

--- a/src/library/traktor/traktor_cue.cpp
+++ b/src/library/traktor/traktor_cue.cpp
@@ -1,0 +1,69 @@
+#include "library/traktor/traktor_cue.h"
+#include <QSqlRecord>
+
+TraktorCue::TraktorCue(int displ_order, int hotcue, double len, QString name,
+        int repeats, double start, TraktorCueType type) : 
+        displ_order(displ_order), hotcue(hotcue), len(len), name(name), repeats(repeats),
+        start(start), type(type) {
+}
+
+TraktorCue::TraktorCue(const QXmlStreamAttributes &cue_attributes) :
+    TraktorCue(
+        cue_attributes.value("DISPL_ORDER").toString().toInt(),
+        cue_attributes.value("HOTCUE").toString().toInt(),
+        cue_attributes.value("LEN").toString().toDouble(),
+        cue_attributes.value("NAME").toString(),
+        cue_attributes.value("REPEATS").toString().toInt(),
+        cue_attributes.value("START").toString().toDouble(),
+        (TraktorCueType)cue_attributes.value("TYPE").toString().toInt()
+    ) {
+}
+
+TraktorCue::TraktorCue(const QSqlRecord &record, const QSqlQuery &query) :
+    TraktorCue(
+        query.value(record.indexOf("displ_order")).toInt(),
+        query.value(record.indexOf("hotcue")).toInt(),
+        query.value(record.indexOf("len")).toDouble(),
+        query.value(record.indexOf("name")).toString(),
+        query.value(record.indexOf("repeats")).toInt(),
+        query.value(record.indexOf("start")).toDouble(),
+        (TraktorCueType)query.value(record.indexOf("type")).toInt()
+    ) {
+    track_id = query.value(record.indexOf("track_id")).toInt();
+}
+
+void TraktorCue::fillQuery(int track_id, QSqlQuery &query) {
+    query.bindValue(":track_id", track_id);
+    query.bindValue(":displ_order", displ_order);
+    query.bindValue(":hotcue", hotcue);
+    query.bindValue(":len", len);
+    query.bindValue(":name", name);
+    query.bindValue(":repeats", repeats);
+    query.bindValue(":start", start);
+    query.bindValue(":type", type);
+}
+
+CuePointer TraktorCue::toCue(int samplerate) {
+    //Incomplete
+    Cue::CueType type;
+    switch (this->type) {
+        case HOTCUE:
+            type = Cue::CueType::CUE;
+            break;
+        case AUTOGRID:
+            type = Cue::CueType::LOAD;
+            break;
+        default:
+            qDebug() << "Unsupported traktor cue type: " << this->type;
+            return CuePointer(NULL);
+    }
+    TrackId track_id(this->track_id);
+    QColor color("#FF0000");
+    //start is a a float denoting milliseconds
+    //convert to stereoSamplePointer
+    int position = int(start/1000.0 * double(samplerate) * 2.0);
+
+    return CuePointer(new Cue(-1, track_id, type, position, len, hotcue, name, 
+                color));
+}
+

--- a/src/library/traktor/traktor_cue.h
+++ b/src/library/traktor/traktor_cue.h
@@ -11,12 +11,12 @@
                             " VALUES (:track_id, :displ_order, :hotcue, :len," \
                             ":name, :repeats, :start, :type)"
 enum TraktorCueType {
-    HOTCUE,
-    TBD1,
-    TBD2,
-    TBD3,
-    AUTOGRID,
-    TBD5
+    HOTCUE,     //Normal Cue
+    FADEIN,     //Triggered by fadeout in playing deck
+    FADEOUT,    //Triggers fadein cue in other deck
+    LOAD,       //Position to jump to when track is loaded into deck
+    AUTOGRID,   //First beat of track
+    LOOP        //Loop Cue
 };
 
 class TraktorCue {

--- a/src/library/traktor/traktor_cue.h
+++ b/src/library/traktor/traktor_cue.h
@@ -1,0 +1,42 @@
+#ifndef TRAKTOR_CUE_H
+#define TRAKTOR_CUE_H
+
+#include <QString>
+#include <QXmlStreamAttributes>
+#include <QSqlQuery>
+#include "library/dao/cue.h"
+
+#define TRAKTOR_CUE_QUERY "INSERT INTO traktor_cues (track_id, displ_order," \
+                            "hotcue, len, name, repeats, start, type)" \
+                            " VALUES (:track_id, :displ_order, :hotcue, :len," \
+                            ":name, :repeats, :start, :type)"
+enum TraktorCueType {
+    HOTCUE,
+    TBD1,
+    TBD2,
+    TBD3,
+    AUTOGRID,
+    TBD5
+};
+
+class TraktorCue {
+  public:
+    TraktorCue(const QXmlStreamAttributes &cue_attributes);
+    TraktorCue(const QSqlRecord &record, const QSqlQuery &query);
+    CuePointer toCue(int samplerate);
+    void fillQuery(int track_id, QSqlQuery &query);
+    void setTrackId(int track_id);
+
+  private:
+    TraktorCue(int displ_order, int hotcue, double len, QString name, int repeats, double start, TraktorCueType type);
+    int track_id;
+    int displ_order;
+    int hotcue;
+    double len;
+    QString name;
+    int repeats;
+    double start;
+    TraktorCueType type;
+};
+
+#endif // TRAKTOR_CUE_H

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -51,7 +51,7 @@ bool TraktorPlaylistModel::isColumnHiddenByDefault(int column) {
     return BaseSqlTableModel::isColumnHiddenByDefault(column);
 }
 
-void addCuesToTrack(CueDAO &cueDao, TrackPointer pTrack, QString traktorTrackId, const QSqlDatabase &m_database) {
+void addCuesToTrack(TrackPointer pTrack, QString traktorTrackId, const QSqlDatabase &m_database) {
     QList<CuePointer> cues;
     QSqlQuery query(m_database);
     query.prepare("SELECT * FROM traktor_cues WHERE track_id = :track_id");
@@ -65,8 +65,7 @@ void addCuesToTrack(CueDAO &cueDao, TrackPointer pTrack, QString traktorTrackId,
             }
         }
         qDebug() << "Found " << cues.count() << " cues";
-        cueDao.saveTrackCues(pTrack->getId(), cues);
-        pTrack->setCuePoints(cues); //needed?
+        pTrack->setCuePoints(cues);
     } else {
         LOG_FAILED_QUERY(query);
     }
@@ -79,7 +78,7 @@ TrackPointer TraktorTrackModel::getTrack(const QModelIndex& index) const {
     TrackPointer pTrack = BaseExternalTrackModel::getTrack(index);
 
     if (pTrack && !track_already_in_library) {
-        addCuesToTrack(m_pTrackCollection->getCueDAO(), pTrack, id, m_database);
+        addCuesToTrack(pTrack, id, m_database);
     }
 
     return pTrack;
@@ -92,7 +91,7 @@ TrackPointer TraktorPlaylistModel::getTrack(const QModelIndex& index) const {
     TrackPointer pTrack = BaseExternalPlaylistModel::getTrack(index);
 
     if (pTrack && !track_already_in_library) {
-        addCuesToTrack(m_pTrackCollection->getCueDAO(), pTrack, id, m_database);
+        addCuesToTrack(pTrack, id, m_database);
     }
 
     return pTrack;

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -425,19 +425,21 @@ void TraktorFeature::parseTrack(QXmlStreamReader &xml, QSqlQuery &query, QSqlQue
                 //int position = int(attr.value("START").toString().toFloat()/1000.0 * float(samplerate) * 2.0);
                 int position = int(attr.value("START").toString().toDouble()/1000.0 * 48000.0 * 2.0);
                 int length = attr.value("LEN").toString().toInt();
-                int type = attr.value("TYPE").toString().toInt();
+                TraktorCueType type = (TraktorCueType)attr.value("TYPE").toString().toInt();
                 QString label = attr.value("NAME").toString();
-                switch (type) { //TODO
-                    case 0:
-                        type = 1;
+                Cue::CueType cue_type;
+                switch (type) {
+                    case HOTCUE:
+                        cue_type = Cue::CueType::CUE;
                         break;
-                    case 4:
-                        type = 2;
+                    case AUTOGRID:
+                        cue_type = Cue::CueType::LOAD;
                         break;
                     default:
+                        qDebug() << "Unsupported traktor cue type: " << type;
                         continue;
                 }
-                Cue *cue = new Cue(0, TrackId(), (Cue::CueType)type, position, length, hotcue, label, QColor("#FF0000"));
+                Cue *cue = new Cue(0, TrackId(), cue_type, position, length, hotcue, label, QColor("#FF0000"));
                 cues.push_back(CuePointer(cue));
                 continue;
             }

--- a/src/library/traktor/traktorfeature.h
+++ b/src/library/traktor/traktorfeature.h
@@ -25,6 +25,7 @@ class TraktorTrackModel : public BaseExternalTrackModel {
                       TrackCollection* pTrackCollection,
                       QSharedPointer<BaseTrackCache> trackSource);
     virtual bool isColumnHiddenByDefault(int column);
+    TrackPointer getTrack(const QModelIndex& index) const override;
 };
 
 class TraktorPlaylistModel : public BaseExternalPlaylistModel {
@@ -33,6 +34,7 @@ class TraktorPlaylistModel : public BaseExternalPlaylistModel {
                          TrackCollection* pTrackCollection,
                          QSharedPointer<BaseTrackCache> trackSource);
     virtual bool isColumnHiddenByDefault(int column);
+    TrackPointer getTrack(const QModelIndex& index) const override;
 };
 
 class TraktorFeature : public BaseExternalLibraryFeature {
@@ -57,7 +59,7 @@ class TraktorFeature : public BaseExternalLibraryFeature {
     virtual BaseSqlTableModel* getPlaylistModelForPlaylist(QString playlist);
     TreeItem* importLibrary(QString file);
     // parses a track in the music collection
-    void parseTrack(QXmlStreamReader &xml, QSqlQuery &query);
+    void parseTrack(QXmlStreamReader &xml, QSqlQuery &query, QSqlQuery &cue_query);
     // Iterates over all playliost and folders and constructs the childmodel
     TreeItem* parsePlaylists(QXmlStreamReader &xml);
     // processes a particular playlist


### PR DESCRIPTION
Incomplete: No support for other cues then "AutoGrid" (type 4 => type 2) and Hotcues (type 0 => type 1) (but it should be easy to add those)
Not tested: Conversion of Traktor "START" time (in ms) to mixxx "position" (in samples).
My Traktor library is generated from a Rekordbox library and those two position formats don't match well.
Thus I could not really test if original Traktor cue point times match (there might be an offset of 1152 samples).