### PR TITLE
Bump version number after ABI breaking changes (lp1737815)

### DIFF
--- a/src/sources/soundsourcepluginapi.h
+++ b/src/sources/soundsourcepluginapi.h
@@ -1,8 +1,9 @@
 #ifndef MIXXX_SOUNDSOURCEPLUGINAPI_H
 #define MIXXX_SOUNDSOURCEPLUGINAPI_H
 
-#define MIXXX_SOUNDSOURCEPLUGINAPI_VERSION 16
+#define MIXXX_SOUNDSOURCEPLUGINAPI_VERSION 17
 // SoundSource Plugin API version history:
+//  17 - Mixxx 2.1.0 - Bump version number after ABI breaking changes (lp1737815)
 //  16 - Mixxx 2.1.0 - Support 2 different modes for opening files
 //  15 - Mixxx 2.1.0 - AudioSource v2
 //  14 - Mixxx 2.1.0 - Replace QSharedPointer with std::shared_ptr


### PR DESCRIPTION
Just in case to prevent crashes. Hopefully no more breaking changes until release. We should keep an eye on that!