### PR TITLE
Fix crash when exporting metadata into inexistent files

### DIFF
--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -59,7 +59,6 @@ LibraryScanner::LibraryScanner(
     // when we detected moved files, and the TIOs corresponding to the moved
     // files would then have the wrong track location.
     TrackDAO* dao = &(m_pTrackCollection->getTrackDAO());
-    connect(this, SIGNAL(scanFinished()), dao, SLOT(clearCache()));
     connect(this, SIGNAL(trackAdded(TrackPointer)),
             dao, SLOT(databaseTrackAdded(TrackPointer)));
     connect(this, SIGNAL(tracksMoved(QSet<TrackId>, QSet<TrackId>)),

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -304,7 +304,14 @@ SoundSourceProxy::exportTrackMetadataBeforeSaving(Track* pTrack) {
     DEBUG_ASSERT(pTrack);
     mixxx::MetadataSourcePointer pMetadataSource =
             SoundSourceProxy(pTrack).m_pSoundSource;
-    return pTrack->exportMetadata(pMetadataSource);
+    if (pMetadataSource) {
+        return pTrack->exportMetadata(pMetadataSource);
+    } else {
+        kLogger.warning()
+                << "Unable to export track metadata into file"
+                << pTrack->getLocation();
+        return Track::ExportMetadataResult::Skipped;
+    }
 }
 
 SoundSourceProxy::SoundSourceProxy(


### PR DESCRIPTION
...or if no appropriate SoundSource is available.

I just noticed this when I forgot to mount the volume containing my music collection. But it might also happen if no decoder is available for some file type.