### PR TITLE
TrackCache: Fixes and optimizations (lp1738253/17382271738028)

### DIFF
--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -145,9 +145,9 @@ void BaseTrackCache::setSearchColumns(const QStringList& columns) {
 }
 
 TrackPointer BaseTrackCache::lookupCachedTrack(TrackId trackId) const {
-    TrackCacheLocker cacheLocker(
-            TrackCache::instance().lookupById(trackId));
-    auto pTrack = cacheLocker.getTrack();
+    auto pTrack = TrackCache::instance().lookupById(trackId).getTrack();
+    // After obtaining a strong reference of the Track object the lock
+    // on TrackCache has been released instantly to reduce lock contention!
     if (pTrack && pTrack->isDirty()) {
         m_dirtyTracks.insert(trackId);
         return pTrack;

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -145,16 +145,18 @@ void BaseTrackCache::setSearchColumns(const QStringList& columns) {
 }
 
 TrackPointer BaseTrackCache::lookupCachedTrack(TrackId trackId) const {
-    auto pTrack = TrackCache::instance().lookupById(trackId).getTrack();
-    // After obtaining a strong reference of the Track object the lock
-    // on TrackCache has been released instantly to reduce lock contention!
-    if (pTrack && pTrack->isDirty()) {
-        m_dirtyTracks.insert(trackId);
-        return pTrack;
-    } else {
-        m_dirtyTracks.remove(trackId);
-        return TrackPointer();
+    TrackPointer pTrack;
+    if (m_bIsCaching) {
+        pTrack = TrackCache::instance().lookupById(trackId).getTrack();
+        // After obtaining a strong reference of the Track object the lock
+        // on TrackCache has been released instantly to reduce lock contention!
+        if (pTrack && pTrack->isDirty()) {
+            m_dirtyTracks.insert(trackId);
+        } else {
+            m_dirtyTracks.remove(trackId);
+        }
     }
+    return pTrack;
 }
 
 bool BaseTrackCache::updateIndexWithTrackpointer(TrackPointer pTrack) {

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -635,13 +635,22 @@ TrackPointer TrackDAO::addTracksAddFile(const QFileInfo& fileInfo, bool unremove
 
     TrackCacheResolver cacheResolver(
             TrackCache::instance().resolve(fileInfo));
-    TrackPointer pTrack(cacheResolver.getTrack());
+    const TrackPointer pTrack = cacheResolver.getTrack();
     if (!pTrack) {
         qWarning() << "TrackDAO::addTracksAddFile:"
                 << "File not found"
                 << TrackRef::location(fileInfo);
         return TrackPointer();
     }
+    const TrackId trackId = pTrack->getId();
+    if (trackId.isValid()) {
+        qDebug() << "TrackDAO::addTracksAddFile:"
+                << "Track has already been added to the database"
+                << trackId;
+        return TrackPointer();
+    }
+    // Keep the TrackCache locked until the id of the Track
+    // object is known and has been updated in the cache.
 
     // Initially (re-)import the metadata for the newly created track
     // from the file.

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -20,6 +20,7 @@ class AnalysisDao;
 class CueDAO;
 class LibraryHashDAO;
 class TrackCollection;
+class TrackCacheLocker;
 class TrackCacheResolver;
 
 
@@ -133,7 +134,7 @@ class TrackDAO : public QObject, public virtual DAO {
     TrackPointer getTrackFromDB(TrackId trackId) const;
 
     friend class TrackCollection;
-    void saveTrack(Track* pTrack);
+    void saveTrack(TrackCacheLocker* pCacheLocker, Track* pTrack);
     bool updateTrack(Track* pTrack);
 
     QSqlDatabase m_database;

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -422,6 +422,6 @@ void Library::slotSetTrackTableRowHeight(int rowHeight) {
     emit(setTrackTableRowHeight(rowHeight));
 }
 
-void Library::onEvictingTrackFromCache(Track* pTrack) {
-    m_pTrackCollection->saveTrack(pTrack);
+void Library::onEvictingTrackFromCache(TrackCacheLocker* pCacheLocker, Track* pTrack) {
+    m_pTrackCollection->saveTrack(pCacheLocker, pTrack);
 }

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -81,7 +81,7 @@ class Library: public QObject,
 
     static const int kDefaultRowHeightPx;
 
-    void onEvictingTrackFromCache(Track* pTrack) override;
+    void onEvictingTrackFromCache(TrackCacheLocker* pCacheLocker, Track* pTrack) override;
 
   public slots:
     void slotShowTrackModel(QAbstractItemModel* model);

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -329,6 +329,6 @@ bool TrackCollection::updateAutoDjCrate(
     return updateCrate(crate);
 }
 
-void TrackCollection::saveTrack(Track* pTrack) {
-    m_trackDao.saveTrack(pTrack);
+void TrackCollection::saveTrack(TrackCacheLocker* pCacheLocker, Track* pTrack) {
+    m_trackDao.saveTrack(pCacheLocker, pTrack);
 }

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -80,7 +80,7 @@ class TrackCollection : public QObject,
 
     bool updateAutoDjCrate(CrateId crateId, bool isAutoDjSource);
 
-    void saveTrack(Track* pTrack);
+    void saveTrack(TrackCacheLocker* pCacheLocker, Track* pTrack);
 
   signals:
     void crateInserted(CrateId id);

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -286,10 +286,16 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
             m_pDbConnectionPool,
             m_pPlayerManager,
             m_pRecordingManager);
-    m_pPlayerManager->bindToLibrary(m_pLibrary);
-
-    // Create the singular TrackCache instance
+    // Create the singular TrackCache instance immediately after
+    // the Library has been created and BEFORE binding the
+    // PlayerManager to it!
     TrackCache::createInstance(m_pLibrary);
+
+    // Binding the PlayManager to the Library may already trigger
+    // loading of tracks which requires that the TrackCache has
+    // been created. Otherwise Mixxx might hang when accessing
+    // the uninitialized singleton instance!
+    m_pPlayerManager->bindToLibrary(m_pLibrary);
 
     launchProgress(40);
 

--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -14,8 +14,8 @@ class LibraryTest : public MixxxTest,
     public virtual /*implements*/ TrackCacheEvictor {
 
   public:
-    void onEvictingTrackFromCache(Track* pTrack) override {
-        m_trackCollection.saveTrack(pTrack);
+    void onEvictingTrackFromCache(TrackCacheLocker* pCacheLocker, Track* pTrack) override {
+        m_trackCollection.saveTrack(pCacheLocker, pTrack);
     }
 
   protected:

--- a/src/track/trackcache.cpp
+++ b/src/track/trackcache.cpp
@@ -389,7 +389,6 @@ TrackRef TrackCache::updateTrackIdInternal(
         DEBUG_ASSERT(m_tracksById.end() == m_tracksById.find(trackId));
         TrackRef trackRefWithId(trackRef, trackId);
         Item item(trackRefWithId, pTrack);
-        if (trackRef.hasId())
         m_tracksById.insert(
                 item.ref.getId(),
                 item);

--- a/src/track/trackcache.cpp
+++ b/src/track/trackcache.cpp
@@ -224,27 +224,6 @@ TrackCacheLocker TrackCache::lookupById(
     return std::move(cacheLocker);
 }
 
-TrackCacheLocker TrackCache::lookupOrCreateTemporaryForFile(
-        const QFileInfo& fileInfo,
-        const SecurityTokenPointer& pSecurityToken) const {
-    const TrackRef trackRef(TrackRef::fromFileInfo(fileInfo));
-    TrackCacheLocker cacheLocker;
-    if (trackRef.isValid()) {
-        const TrackPointer pTrack(lookupInternal(trackRef));
-        if (pTrack) {
-            cacheLocker.m_lookupResult = TrackCacheLookupResult::HIT;
-            cacheLocker.m_trackRef = createTrackRef(*pTrack);
-            cacheLocker.m_pTrack = pTrack;
-        } else {
-            cacheLocker.m_lookupResult = TrackCacheLookupResult::MISS;
-            cacheLocker.m_trackRef = trackRef;
-            cacheLocker.m_pTrack =
-                    Track::newTemporary(fileInfo, pSecurityToken);
-        }
-    }
-    return std::move(cacheLocker);
-}
-
 TrackPointer TrackCache::lookupInternal(
         const TrackId& trackId) const {
     const auto trackById(m_tracksById.find(trackId));

--- a/src/track/trackcache.cpp
+++ b/src/track/trackcache.cpp
@@ -1,9 +1,12 @@
 #include "track/trackcache.h"
 
 #include "util/assert.h"
+#include "util/logger.h"
 
 
 namespace {
+
+const mixxx::Logger kLogger("TrackCache");
 
 inline
 TrackRef createTrackRef(const Track& track) {
@@ -279,7 +282,7 @@ bool TrackCache::resolveInternal(
     DEBUG_ASSERT(nullptr != pCacheResolver);
     // Primary lookup by id (if available)
     if (trackId.isValid()) {
-        qDebug() << "TrackCache:"
+        kLogger.debug()
                 << "Resolving track by id"
                 << trackId;
         const auto trackById(m_tracksById.find(trackId));
@@ -288,7 +291,7 @@ bool TrackCache::resolveInternal(
             TrackRef resolvedTrackRef((*trackById).ref);
             TrackPointer pResolvedTrack((*trackById).weakPtr);
             if (pResolvedTrack) {
-                qDebug() << "TrackCache:"
+                kLogger.debug()
                         << "Cache hit - found track by id"
                         << resolvedTrackRef;
                 *pCacheResolver = TrackCacheResolver(
@@ -299,7 +302,7 @@ bool TrackCache::resolveInternal(
                 return true;
             } else {
                 // Explicitly evict the cached track before the deleter does it
-                qDebug() << "TrackCache:"
+                kLogger.debug()
                         << "Cache hit - evicting zombie track"
                         << resolvedTrackRef;
                 Track* pEvictedTrack = evictInternal(resolvedTrackRef);
@@ -313,7 +316,7 @@ bool TrackCache::resolveInternal(
     // avoid calculating the canonical file path if it is not needed.
     TrackRef trackRef(TrackRef::fromFileInfo(fileInfo, trackId));
     if (trackRef.hasCanonicalLocation()) {
-        qDebug() << "TrackCache:"
+        kLogger.debug()
                 << "Resolving track by canonical location"
                 << trackRef.getCanonicalLocation();
         const auto trackByCanonicalLocation(
@@ -324,7 +327,7 @@ bool TrackCache::resolveInternal(
             TrackRef resolvedTrackRef((*trackByCanonicalLocation).ref);
             TrackPointer pResolvedTrack((*trackByCanonicalLocation).weakPtr);
             if (pResolvedTrack) {
-                qDebug() << "TrackCache:"
+                kLogger.debug()
                         << "Cache hit - found track by canonical location"
                         << resolvedTrackRef;
                 // Consistency: Resolving by id  must return the same result!
@@ -338,7 +341,7 @@ bool TrackCache::resolveInternal(
                 return true;
             } else {
                 // Explicitly evict the cached track before the deleter does it
-                qDebug() << "TrackCache:"
+                kLogger.debug()
                         << "Cache hit - evicting zombie track"
                         << resolvedTrackRef;
                 Track* pEvictedTrack = evictInternal(resolvedTrackRef);
@@ -365,12 +368,12 @@ TrackCacheResolver TrackCache::resolve(
     }
     if (!trackRef.isValid()) {
         DEBUG_ASSERT(cacheResolver.getTrackCacheLookupResult() == TrackCacheLookupResult::NONE);
-        qWarning() << "TrackCache:"
+        kLogger.warning()
                 << "Cache miss - ignoring invalid track"
                 << trackRef;
         return cacheResolver;
     }
-    qDebug() << "TrackCache:"
+    kLogger.debug()
             << "Cache miss - inserting new track into cache"
             << trackRef;
     TrackPointer pTrack(
@@ -431,7 +434,7 @@ void TrackCache::evict(
 
 TrackCache::Item TrackCache::purgeInternal(
         const TrackRef& trackRef) {
-    qDebug() << "TrackCache:"
+    kLogger.debug()
             << "Purging track"
             << trackRef;
 
@@ -478,7 +481,7 @@ TrackCache::Item TrackCache::purgeInternal(
 
 Track* TrackCache::evictInternal(
         const TrackRef& trackRef) {
-    qDebug() << "TrackCache:"
+    kLogger.debug()
             << "Evicting track"
             << trackRef;
 
@@ -494,7 +497,7 @@ Track* TrackCache::evictInternal(
         // Keep the cache locked while evicting the track object!
         m_pEvictor->onEvictingTrackFromCache(purgedItem.plainPtr);
     } else {
-        qDebug() << "TrackCache:"
+        kLogger.debug()
                 << "Uncached track cannot be evicted"
                 << trackRef;
     }

--- a/src/track/trackcache.h
+++ b/src/track/trackcache.h
@@ -127,18 +127,6 @@ public:
     TrackCacheLocker lookupById(
             const TrackId& trackId) const;
 
-    // Lookup an existing Track object in the cache or create
-    // a temporary object on cache miss. The temporary object for
-    // the file should be released before the cache is unlocked
-    // to prevent concurrent file access.
-    //
-    // NOTE: The TrackCache is locked during the lifetime of the
-    // result object. It should be destroyed ASAP to reduce lock
-    // contention!
-    TrackCacheLocker lookupOrCreateTemporaryForFile(
-            const QFileInfo& fileInfo,
-            const SecurityTokenPointer& pSecurityToken = SecurityTokenPointer()) const;
-
     QList<TrackPointer> lookupAll() const;
 
     // Lookup an existing or create a new Track object.

--- a/src/track/trackcache.h
+++ b/src/track/trackcache.h
@@ -120,6 +120,10 @@ public:
     }
 
     // Lookup an existing Track object in the cache.
+    //
+    // NOTE: The TrackCache is locked during the lifetime of the
+    // result object. It should be destroyed ASAP to reduce lock
+    // contention!
     TrackCacheLocker lookupById(
             const TrackId& trackId) const;
 
@@ -127,13 +131,21 @@ public:
     // a temporary object on cache miss. The temporary object for
     // the file should be released before the cache is unlocked
     // to prevent concurrent file access.
+    //
+    // NOTE: The TrackCache is locked during the lifetime of the
+    // result object. It should be destroyed ASAP to reduce lock
+    // contention!
     TrackCacheLocker lookupOrCreateTemporaryForFile(
             const QFileInfo& fileInfo,
             const SecurityTokenPointer& pSecurityToken = SecurityTokenPointer()) const;
 
     QList<TrackPointer> lookupAll() const;
 
-    // Lookup an existing or create a new Track object
+    // Lookup an existing or create a new Track object.
+    //
+    // NOTE: The TrackCache is locked during the lifetime of the
+    // result object. It should be destroyed ASAP to reduce lock
+    // contention!
     TrackCacheResolver resolve(
             const QFileInfo& fileInfo,
             const SecurityTokenPointer& pSecurityToken = SecurityTokenPointer()) {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1363,11 +1363,13 @@ QList<TrackId> WTrackTableView::getSelectedTrackIds() const {
     trackIds.reserve(rows.size());
     for (const QModelIndex& row: rows) {
         const TrackId trackId = pTrackModel->getTrackId(row);
-        VERIFY_OR_DEBUG_ASSERT(trackId.isValid()) {
-            qWarning() << "Skipping invalid track id @" << row;
-            continue;
+        if (trackId.isValid()) {
+            trackIds.append(trackId);
+        } else {
+            // This happens in the browse view where only some tracks
+            // have an id.
+            qDebug() << "Skipping row" << row << "with invalid track id";
         }
-        trackIds.append(trackId);
     }
 
     return trackIds;


### PR DESCRIPTION
By removing the recent tracks cache from TrackDAO the new TrackCache has now become the central authority for accessing track objects. I didn't notice that lock contention was much too high in some uses cases. Now time spans during which TrackCache is locked should be much shorter!

The most time consuming operation is when entries are evicted and the cache must be kept locked while both updating the database and exporting metadata for safety reasons. I will try to extract the database update from the lock scope, but this might not be possible with the current architecture that closely couples the database and UI layers. Please test if enabling export of track metadata makes a difference for you. I am running my tests at ~~10~~11.6 ms latency with metadata export enabled and ~~didn't notice any drop outs so far~~ dropouts still occur. But these dropouts also occur with older versions where the TrackCache & Export stuff has not been merged. I'm still trying to find out where this regression started.

I even discovered a serious bug in TrackCache after changing the access pattern in the browse view. It was caused by a strayed line of code that may have survived a previous merge. Luckily the multitude of debug assertions with consistency checks revealed this bug instantly.

Please note that the "sluggish" response during batch analysis is still not fixed, although it might also profit from these changes.