### PR TITLE
Multi-broadcasting: fix reported issues

### DIFF
--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -298,7 +298,7 @@ bool BroadcastProfile::loadValues(const QString& filename) {
     m_customTitle = XmlParse::selectNodeQString(doc, kCustomTitle);
     m_metadataFormat = XmlParse::selectNodeQString(doc, kMetadataFormat);
     m_oggDynamicUpdate =
-            (bool)XmlParse::selectNodeInt(doc, kMetadataFormat);
+            (bool)XmlParse::selectNodeInt(doc, kOggDynamicUpdate);
 
     return true;
 }

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -177,7 +177,7 @@ void DlgPrefBroadcast::slotApply() {
                 QMessageBox::warning(
                     this, tr("Action failed"),
                     tr("'%1' has the same Icecast mountpoint as '%2'.\n"
-                       "Two connections on the same server can't have the same mountpoint.")
+                       "Two source connections to the same server can't have the same mountpoint.")
                        .arg(profileName).arg(profileNameWithSameMountpoint));
                 return;
             }
@@ -236,7 +236,7 @@ void DlgPrefBroadcast::enableCustomMetadataChanged(int value) {
 void DlgPrefBroadcast::btnCreateConnectionClicked() {
     if(m_pSettingsModel->rowCount() >= BROADCAST_MAX_CONNECTIONS) {
         QMessageBox::warning(this, tr("Action failed"),
-                tr("You can't create more than %1 Live Broadcasting connections.")
+                tr("You can't create more than %1 source connections.")
                 .arg(BROADCAST_MAX_CONNECTIONS));
         return;
     }
@@ -249,7 +249,7 @@ void DlgPrefBroadcast::btnCreateConnectionClicked() {
     QString newName;
     do {
         profileNumber++;
-        newName = tr("Connection %1").arg(profileNumber);
+        newName = tr("Source connection %1").arg(profileNumber);
         existingProfile = m_pSettingsModel->getProfileByName(newName);
     } while(!existingProfile.isNull());
 
@@ -490,7 +490,7 @@ void DlgPrefBroadcast::setValuesToProfile(BroadcastProfilePtr profile) {
 void DlgPrefBroadcast::btnRemoveConnectionClicked() {
     if(m_pSettingsModel->rowCount() < 2) {
         QMessageBox::information(this, tr("Action failed"),
-                tr("At least one connection is required."));
+                tr("At least one source connection is required."));
         return;
     }
 
@@ -534,7 +534,7 @@ void DlgPrefBroadcast::btnRenameConnectionClicked() {
 void DlgPrefBroadcast::btnDisconnectAllClicked() {
     auto response = QMessageBox::question(this,
             tr("Confirmation required"),
-            tr("Are you sure you want to disconnect every active Live Broadcasting source connection?"),
+            tr("Are you sure you want to disconnect every active source connection?"),
             QMessageBox::Yes, QMessageBox::No);
 
     if(response == QMessageBox::Yes) {

--- a/src/preferences/dialog/dlgprefbroadcast.h
+++ b/src/preferences/dialog/dlgprefbroadcast.h
@@ -30,8 +30,7 @@ class DlgPrefBroadcast : public DlgPreferencePage, public Ui::DlgPrefBroadcastDl
     void checkBoxEnableReconnectChanged(int value);
     void checkBoxLimitReconnectsChanged(int value);
     void enableCustomMetadataChanged(int value);
-    void profileListItemSelected(const QModelIndex& selected,
-            const QModelIndex& deselected);
+    void connectionListItemSelected(const QModelIndex& selected);
 
   signals:
     void apply(const QString &);

--- a/src/preferences/dialog/dlgprefbroadcastdlg.ui
+++ b/src/preferences/dialog/dlgprefbroadcastdlg.ui
@@ -174,7 +174,16 @@
            <item>
             <widget class="QWidget" name="widgetReconnectControls" native="true">
              <layout class="QGridLayout" name="gridLayout_5">
-              <property name="margin">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item row="0" column="0">
@@ -634,7 +643,7 @@ p, li { white-space: pre-wrap; }
       <item row="0" column="0" colspan="2">
        <widget class="QLabel" name="labelHowtoSettings">
         <property name="text">
-         <string>Select a connection above to edit its settings here</string>
+         <string>Select a source connection above to edit its settings here</string>
         </property>
        </widget>
       </item>
@@ -757,7 +766,16 @@ p, li { white-space: pre-wrap; }
          <item row="1" column="0">
           <widget class="QWidget" name="groupPasswordStorage" native="true">
            <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <item>


### PR DESCRIPTION
This PR fixes two issues reported on PR #1300 and the forum ([thread here](https://mixxx.org/forums/viewtopic.php?f=3&t=9496&view=unread#unread)) regarding the Live Broadcasting settings UI:
- Connection option "Dynamically update Ogg Vorbis metadata" isn't saved. Caused by a typo (actually a copy-paste mistake) in `BroadcastProfile`.
- Connection selection is wrong under some circumstances. This is because the settings panel calls `QTableView::selectRow` when updating but this method only updates the UI without triggering the expected "selection changed" signals.