### PR TITLE
Fix segfault cause by an destoyes SoundDevice after refresh.

### DIFF
--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -290,8 +290,8 @@ void DlgPrefSound::addPath(AudioOutput output) {
         toInsert = new DlgPrefSoundItem(outputTab, type,
             m_outputDevices, false);
     }
-    connect(this, SIGNAL(refreshOutputDevices(const QList<SoundDevice*>&)),
-            toInsert, SLOT(refreshDevices(const QList<SoundDevice*>&)));
+    connect(this, SIGNAL(refreshOutputDevices(const QList<QSharedPointer<SoundDevice>>&)),
+            toInsert, SLOT(refreshDevices(const QList<QSharedPointer<SoundDevice>>&)));
     insertItem(toInsert, outputVLayout);
     connectSoundItem(toInsert);
 }
@@ -321,8 +321,8 @@ void DlgPrefSound::addPath(AudioInput input) {
         toInsert = new DlgPrefSoundItem(inputTab, type,
             m_inputDevices, true);
     }
-    connect(this, SIGNAL(refreshInputDevices(const QList<SoundDevice*>&)),
-            toInsert, SLOT(refreshDevices(const QList<SoundDevice*>&)));
+    connect(this, SIGNAL(refreshInputDevices(const QList<QSharedPointer<SoundDevice>>&)),
+            toInsert, SLOT(refreshDevices(const QList<QSharedPointer<SoundDevice>>&)));
     insertItem(toInsert, inputVLayout);
     connectSoundItem(toInsert);
 }

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -21,7 +21,6 @@
 #include "engine/enginemaster.h"
 #include "mixer/playermanager.h"
 #include "soundio/soundmanager.h"
-#include "soundio/sounddevice.h"
 #include "util/rlimit.h"
 #include "util/scopedoverridecursor.h"
 #include "control/controlproxy.h"
@@ -290,7 +289,7 @@ void DlgPrefSound::addPath(AudioOutput output) {
         toInsert = new DlgPrefSoundItem(outputTab, type,
             m_outputDevices, false);
     }
-    connect(this, SIGNAL(refreshOutputDevices(const QList<QSharedPointer<SoundDevice>>&)),
+    connect(this, SIGNAL(refreshOutputDevices(const QList<SoundDevicePointer>&)),
             toInsert, SLOT(refreshDevices(const QList<QSharedPointer<SoundDevice>>&)));
     insertItem(toInsert, outputVLayout);
     connectSoundItem(toInsert);
@@ -321,8 +320,8 @@ void DlgPrefSound::addPath(AudioInput input) {
         toInsert = new DlgPrefSoundItem(inputTab, type,
             m_inputDevices, true);
     }
-    connect(this, SIGNAL(refreshInputDevices(const QList<QSharedPointer<SoundDevice>>&)),
-            toInsert, SLOT(refreshDevices(const QList<QSharedPointer<SoundDevice>>&)));
+    connect(this, SIGNAL(refreshInputDevices(const QList<SoundDevicePointer>&)),
+            toInsert, SLOT(refreshDevices(const QList<SoundDevicePointer>&)));
     insertItem(toInsert, inputVLayout);
     connectSoundItem(toInsert);
 }

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -290,7 +290,7 @@ void DlgPrefSound::addPath(AudioOutput output) {
             m_outputDevices, false);
     }
     connect(this, SIGNAL(refreshOutputDevices(const QList<SoundDevicePointer>&)),
-            toInsert, SLOT(refreshDevices(const QList<QSharedPointer<SoundDevice>>&)));
+            toInsert, SLOT(refreshDevices(const QList<SoundDevicePointer>&)));
     insertItem(toInsert, outputVLayout);
     connectSoundItem(toInsert);
 }

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -49,8 +49,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
   signals:
     void loadPaths(const SoundManagerConfig &config);
     void writePaths(SoundManagerConfig *config);
-    void refreshOutputDevices(const QList<SoundDevice*> &devices);
-    void refreshInputDevices(const QList<SoundDevice*> &devices);
+    void refreshOutputDevices(const QList<QSharedPointer<SoundDevice>>& devices);
+    void refreshInputDevices(const QList<QSharedPointer<SoundDevice>>& devices);
     void updatingAPI();
     void updatedAPI();
 
@@ -106,8 +106,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlProxy* m_pMasterEnabled;
     ControlProxy* m_pMasterMonoMixdown;
     ControlProxy* m_pMicMonitorMode;
-    QList<SoundDevice*> m_inputDevices;
-    QList<SoundDevice*> m_outputDevices;
+    QList<QSharedPointer<SoundDevice>> m_inputDevices;
+    QList<QSharedPointer<SoundDevice>> m_outputDevices;
     bool m_settingsModified;
     bool m_bLatencyChanged;
     bool m_bSkipConfigClear;

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -21,6 +21,7 @@
 #include "soundio/soundmanagerconfig.h"
 #include "soundio/sounddeviceerror.h"
 #include "preferences/dlgpreferencepage.h"
+#include "soundio/sounddevice.h"
 
 class SoundManager;
 class PlayerManager;
@@ -49,8 +50,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
   signals:
     void loadPaths(const SoundManagerConfig &config);
     void writePaths(SoundManagerConfig *config);
-    void refreshOutputDevices(const QList<QSharedPointer<SoundDevice>>& devices);
-    void refreshInputDevices(const QList<QSharedPointer<SoundDevice>>& devices);
+    void refreshOutputDevices(const QList<SoundDevicePointer>& devices);
+    void refreshInputDevices(const QList<SoundDevicePointer>& devices);
     void updatingAPI();
     void updatedAPI();
 
@@ -106,8 +107,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlProxy* m_pMasterEnabled;
     ControlProxy* m_pMasterMonoMixdown;
     ControlProxy* m_pMicMonitorMode;
-    QList<QSharedPointer<SoundDevice>> m_inputDevices;
-    QList<QSharedPointer<SoundDevice>> m_outputDevices;
+    QList<SoundDevicePointer> m_inputDevices;
+    QList<SoundDevicePointer> m_outputDevices;
     bool m_settingsModified;
     bool m_bLatencyChanged;
     bool m_bSkipConfigClear;

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -66,7 +66,7 @@ void DlgPrefSoundItem::refreshDevices(const QList<SoundDevicePointer>& devices) 
         deviceComboBox->removeItem(deviceComboBox->count() - 1);
     }
     for (const auto& pDevice: qAsConst(m_devices)) {
-        if (!hasSufficientChannels(pDevice.data())) continue;
+        if (!hasSufficientChannels(*pDevice)) continue;
         deviceComboBox->addItem(pDevice->getDisplayName(), pDevice->getInternalName());
     }
     int newIndex = deviceComboBox->findData(oldDev);
@@ -184,7 +184,7 @@ void DlgPrefSoundItem::loadPath(const SoundManagerConfig &config) {
  * record its respective path with the SoundManagerConfig instance at
  * config.
  */
-void DlgPrefSoundItem::writePath(SoundManagerConfig *config) const {
+void DlgPrefSoundItem::writePath(SoundManagerConfig* config) const {
     SoundDevicePointer pDevice = getDevice();
     if (!pDevice) {
         return;
@@ -292,13 +292,12 @@ void DlgPrefSoundItem::setChannel(unsigned int channelBase,
 /**
  * Checks that a given device can act as a source/input for our type.
  */
-int DlgPrefSoundItem::hasSufficientChannels(const SoundDevice* pDevice) const
-{
+int DlgPrefSoundItem::hasSufficientChannels(const SoundDevice& device) const {
     unsigned char needed(AudioPath::minChannelsForType(m_type));
 
     if (m_isInput) {
-        return pDevice->getNumInputChannels() >= needed;
+        return device.getNumInputChannels() >= needed;
     } else {
-        return pDevice->getNumOutputChannels() >= needed;
+        return device.getNumOutputChannels() >= needed;
     }
 }

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -18,6 +18,7 @@
 #include "preferences/dialog/dlgprefsounditem.h"
 #include "soundio/sounddevice.h"
 #include "soundio/soundmanagerconfig.h"
+#include "util/compatibility.h"
 
 /**
  * Constructs a new preferences sound item, representing an AudioPath and SoundDevice
@@ -64,7 +65,7 @@ void DlgPrefSoundItem::refreshDevices(const QList<SoundDevicePointer>& devices) 
     while (deviceComboBox->count() > 1) {
         deviceComboBox->removeItem(deviceComboBox->count() - 1);
     }
-    for (const auto& pDevice: m_devices) {
+    for (const auto& pDevice: qAsConst(m_devices)) {
         if (!hasSufficientChannels(pDevice.data())) continue;
         deviceComboBox->addItem(pDevice->getDisplayName(), pDevice->getInternalName());
     }
@@ -85,7 +86,7 @@ void DlgPrefSoundItem::deviceChanged(int index) {
     if (selection == "None") {
         goto emitAndReturn;
     } else {
-        for (const auto& pDevice: m_devices) {
+        for (const auto& pDevice: qAsConst(m_devices)) {
             if (pDevice->getInternalName() == selection) {
                 if (m_isInput) {
                     numChannels = pDevice->getNumInputChannels();
@@ -240,7 +241,7 @@ SoundDevicePointer DlgPrefSoundItem::getDevice() const {
     if (selection == "None") {
         return SoundDevicePointer();
     }
-    for (const auto& pDevice: m_devices) {
+    for (const auto& pDevice: qAsConst(m_devices)) {
         qDebug() << "1" << pDevice->getDisplayName();
         qDebug() << "2" << pDevice->getInternalName();
         if (selection == pDevice->getInternalName()) {

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -29,7 +29,7 @@
  * @param index the index of the represented AudioPath, if applicable
  */
 DlgPrefSoundItem::DlgPrefSoundItem(QWidget* parent, AudioPathType type,
-                                   const QList<QSharedPointer<SoundDevice>>& devices, bool isInput,
+                                   const QList<SoundDevicePointer>& devices, bool isInput,
                                    unsigned int index)
         : QWidget(parent),
           m_type(type),
@@ -55,7 +55,7 @@ DlgPrefSoundItem::~DlgPrefSoundItem() {
  * Slot called when the parent preferences pane updates its list of sound
  * devices, to update the item widget's list of devices to display.
  */
-void DlgPrefSoundItem::refreshDevices(const QList<QSharedPointer<SoundDevice>>& devices) {
+void DlgPrefSoundItem::refreshDevices(const QList<SoundDevicePointer>& devices) {
     m_devices = devices;
     QString oldDev = deviceComboBox->itemData(deviceComboBox->currentIndex()).toString();
     deviceComboBox->setCurrentIndex(0);
@@ -184,7 +184,7 @@ void DlgPrefSoundItem::loadPath(const SoundManagerConfig &config) {
  * config.
  */
 void DlgPrefSoundItem::writePath(SoundManagerConfig *config) const {
-    QSharedPointer<SoundDevice> pDevice = getDevice();
+    SoundDevicePointer pDevice = getDevice();
     if (pDevice.isNull()) {
         return;
     } // otherwise, this will have a valid audiopath
@@ -235,10 +235,10 @@ void DlgPrefSoundItem::reload() {
  * Gets the currently selected SoundDevice
  * @returns pointer to SoundDevice, or NULL if the "None" option is selected.
  */
-QSharedPointer<SoundDevice> DlgPrefSoundItem::getDevice() const {
+SoundDevicePointer DlgPrefSoundItem::getDevice() const {
     QString selection = deviceComboBox->itemData(deviceComboBox->currentIndex()).toString();
     if (selection == "None") {
-        return QSharedPointer<SoundDevice>();
+        return SoundDevicePointer();
     }
     for (const auto& pDevice: m_devices) {
         qDebug() << "1" << pDevice->getDisplayName();
@@ -249,7 +249,7 @@ QSharedPointer<SoundDevice> DlgPrefSoundItem::getDevice() const {
     }
     // looks like something became invalid ???
     deviceComboBox->setCurrentIndex(0); // set it to none
-    return QSharedPointer<SoundDevice>();
+    return SoundDevicePointer();
 }
 
 /**

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -185,7 +185,7 @@ void DlgPrefSoundItem::loadPath(const SoundManagerConfig &config) {
  */
 void DlgPrefSoundItem::writePath(SoundManagerConfig *config) const {
     SoundDevicePointer pDevice = getDevice();
-    if (pDevice.isNull()) {
+    if (!pDevice) {
         return;
     } // otherwise, this will have a valid audiopath
 

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -28,13 +28,12 @@
  * @param isInput true if this is representing an AudioInput, false otherwise
  * @param index the index of the represented AudioPath, if applicable
  */
-DlgPrefSoundItem::DlgPrefSoundItem(QWidget *parent, AudioPathType type,
-                                   QList<SoundDevice*> &devices, bool isInput,
+DlgPrefSoundItem::DlgPrefSoundItem(QWidget* parent, AudioPathType type,
+                                   const QList<QSharedPointer<SoundDevice>>& devices, bool isInput,
                                    unsigned int index)
         : QWidget(parent),
           m_type(type),
           m_index(index),
-          m_devices(devices),
           m_isInput(isInput),
           m_inhibitSettingChanged(false) {
     setupUi(this);
@@ -45,7 +44,7 @@ DlgPrefSoundItem::DlgPrefSoundItem(QWidget *parent, AudioPathType type,
             this, SLOT(deviceChanged(int)));
     connect(channelComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(channelChanged()));
-    refreshDevices(m_devices);
+    refreshDevices(devices);
 }
 
 DlgPrefSoundItem::~DlgPrefSoundItem() {
@@ -56,7 +55,7 @@ DlgPrefSoundItem::~DlgPrefSoundItem() {
  * Slot called when the parent preferences pane updates its list of sound
  * devices, to update the item widget's list of devices to display.
  */
-void DlgPrefSoundItem::refreshDevices(const QList<SoundDevice*> &devices) {
+void DlgPrefSoundItem::refreshDevices(const QList<QSharedPointer<SoundDevice>>& devices) {
     m_devices = devices;
     QString oldDev = deviceComboBox->itemData(deviceComboBox->currentIndex()).toString();
     deviceComboBox->setCurrentIndex(0);
@@ -65,9 +64,9 @@ void DlgPrefSoundItem::refreshDevices(const QList<SoundDevice*> &devices) {
     while (deviceComboBox->count() > 1) {
         deviceComboBox->removeItem(deviceComboBox->count() - 1);
     }
-    foreach (SoundDevice *device, m_devices) {
-        if (!hasSufficientChannels(device)) continue;
-        deviceComboBox->addItem(device->getDisplayName(), device->getInternalName());
+    for (const auto& pDevice: m_devices) {
+        if (!hasSufficientChannels(pDevice.data())) continue;
+        deviceComboBox->addItem(pDevice->getDisplayName(), pDevice->getInternalName());
     }
     int newIndex = deviceComboBox->findData(oldDev);
     if (newIndex != -1) {
@@ -86,12 +85,12 @@ void DlgPrefSoundItem::deviceChanged(int index) {
     if (selection == "None") {
         goto emitAndReturn;
     } else {
-        foreach (SoundDevice *device, m_devices) {
-            if (device->getInternalName() == selection) {
+        for (const auto& pDevice: m_devices) {
+            if (pDevice->getInternalName() == selection) {
                 if (m_isInput) {
-                    numChannels = device->getNumInputChannels();
+                    numChannels = pDevice->getNumInputChannels();
                 } else {
-                    numChannels = device->getNumOutputChannels();
+                    numChannels = pDevice->getNumOutputChannels();
                 }
             }
         }
@@ -185,8 +184,8 @@ void DlgPrefSoundItem::loadPath(const SoundManagerConfig &config) {
  * config.
  */
 void DlgPrefSoundItem::writePath(SoundManagerConfig *config) const {
-    SoundDevice *device = getDevice();
-    if (device == NULL) {
+    QSharedPointer<SoundDevice> pDevice = getDevice();
+    if (pDevice.isNull()) {
         return;
     } // otherwise, this will have a valid audiopath
 
@@ -201,11 +200,11 @@ void DlgPrefSoundItem::writePath(SoundManagerConfig *config) const {
 
     if (m_isInput) {
         config->addInput(
-                device->getInternalName(),
+                pDevice->getInternalName(),
                 AudioInput(m_type, channelBase, channelCount, m_index));
     } else {
         config->addOutput(
-                device->getInternalName(),
+                pDevice->getInternalName(),
                 AudioOutput(m_type, channelBase, channelCount, m_index));
     }
 }
@@ -236,19 +235,21 @@ void DlgPrefSoundItem::reload() {
  * Gets the currently selected SoundDevice
  * @returns pointer to SoundDevice, or NULL if the "None" option is selected.
  */
-SoundDevice* DlgPrefSoundItem::getDevice() const {
+QSharedPointer<SoundDevice> DlgPrefSoundItem::getDevice() const {
     QString selection = deviceComboBox->itemData(deviceComboBox->currentIndex()).toString();
     if (selection == "None") {
-        return NULL;
+        return QSharedPointer<SoundDevice>();
     }
-    foreach (SoundDevice *device, m_devices) {
-        if (selection == device->getInternalName()) {
-            return device;
+    for (const auto& pDevice: m_devices) {
+        qDebug() << "1" << pDevice->getDisplayName();
+        qDebug() << "2" << pDevice->getInternalName();
+        if (selection == pDevice->getInternalName()) {
+            return pDevice;
         }
     }
     // looks like something became invalid ???
     deviceComboBox->setCurrentIndex(0); // set it to none
-    return NULL;
+    return QSharedPointer<SoundDevice>();
 }
 
 /**
@@ -290,13 +291,13 @@ void DlgPrefSoundItem::setChannel(unsigned int channelBase,
 /**
  * Checks that a given device can act as a source/input for our type.
  */
-int DlgPrefSoundItem::hasSufficientChannels(const SoundDevice *device) const
+int DlgPrefSoundItem::hasSufficientChannels(const SoundDevice* pDevice) const
 {
     unsigned char needed(AudioPath::minChannelsForType(m_type));
 
     if (m_isInput) {
-        return device->getNumInputChannels() >= needed;
+        return pDevice->getNumInputChannels() >= needed;
     } else {
-        return device->getNumOutputChannels() >= needed;
+        return pDevice->getNumOutputChannels() >= needed;
     }
 }

--- a/src/preferences/dialog/dlgprefsounditem.h
+++ b/src/preferences/dialog/dlgprefsounditem.h
@@ -47,7 +47,7 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     void refreshDevices(const QList<SoundDevicePointer>& devices);
     void deviceChanged(int index);
     void channelChanged();
-    void loadPath(const SoundManagerConfig &config);
+    void loadPath(const SoundManagerConfig& config);
     void writePath(SoundManagerConfig *config) const;
     void save();
     void reload();
@@ -56,7 +56,7 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     SoundDevicePointer getDevice() const; // if this returns NULL, we don't have a valid AudioPath
     void setDevice(const QString &deviceName);
     void setChannel(unsigned int channelBase, unsigned int channels);
-    int hasSufficientChannels(const SoundDevice* pDevice) const;
+    int hasSufficientChannels(const SoundDevice& device) const;
 
     AudioPathType m_type;
     unsigned int m_index;

--- a/src/preferences/dialog/dlgprefsounditem.h
+++ b/src/preferences/dialog/dlgprefsounditem.h
@@ -18,6 +18,7 @@
 
 #include "preferences/dialog/ui_dlgprefsounditem.h"
 #include "soundio/soundmanagerutil.h"
+#include "soundio/sounddevice.h"
 
 class SoundDevice;
 class SoundManagerConfig;
@@ -32,7 +33,7 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     Q_OBJECT
   public:
     DlgPrefSoundItem(QWidget* parent, AudioPathType type,
-            const QList<QSharedPointer<SoundDevice>>& devices,
+            const QList<SoundDevicePointer>& devices,
             bool isInput, unsigned int index = 0);
     virtual ~DlgPrefSoundItem();
 
@@ -43,7 +44,7 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     void settingChanged();
 
   public slots:
-    void refreshDevices(const QList<QSharedPointer<SoundDevice>>& devices);
+    void refreshDevices(const QList<SoundDevicePointer>& devices);
     void deviceChanged(int index);
     void channelChanged();
     void loadPath(const SoundManagerConfig &config);
@@ -52,14 +53,14 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     void reload();
 
   private:
-    QSharedPointer<SoundDevice> getDevice() const; // if this returns NULL, we don't have a valid AudioPath
+    SoundDevicePointer getDevice() const; // if this returns NULL, we don't have a valid AudioPath
     void setDevice(const QString &deviceName);
     void setChannel(unsigned int channelBase, unsigned int channels);
     int hasSufficientChannels(const SoundDevice* pDevice) const;
 
     AudioPathType m_type;
     unsigned int m_index;
-    QList<QSharedPointer<SoundDevice>> m_devices;
+    QList<SoundDevicePointer> m_devices;
     bool m_isInput;
     QString m_savedDevice;
     // Because QVariant supports QPoint natively we use a QPoint to store the

--- a/src/preferences/dialog/dlgprefsounditem.h
+++ b/src/preferences/dialog/dlgprefsounditem.h
@@ -31,8 +31,9 @@ class SoundManagerConfig;
 class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     Q_OBJECT
   public:
-    DlgPrefSoundItem(QWidget *parent, AudioPathType type,
-            QList<SoundDevice*> &devices, bool isInput, unsigned int index = 0);
+    DlgPrefSoundItem(QWidget* parent, AudioPathType type,
+            const QList<QSharedPointer<SoundDevice>>& devices,
+            bool isInput, unsigned int index = 0);
     virtual ~DlgPrefSoundItem();
 
     AudioPathType type() const { return m_type; };
@@ -42,7 +43,7 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     void settingChanged();
 
   public slots:
-    void refreshDevices(const QList<SoundDevice*> &devices);
+    void refreshDevices(const QList<QSharedPointer<SoundDevice>>& devices);
     void deviceChanged(int index);
     void channelChanged();
     void loadPath(const SoundManagerConfig &config);
@@ -51,14 +52,14 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     void reload();
 
   private:
-    SoundDevice* getDevice() const; // if this returns NULL, we don't have a valid AudioPath
+    QSharedPointer<SoundDevice> getDevice() const; // if this returns NULL, we don't have a valid AudioPath
     void setDevice(const QString &deviceName);
     void setChannel(unsigned int channelBase, unsigned int channels);
-    int hasSufficientChannels(const SoundDevice *device) const;
+    int hasSufficientChannels(const SoundDevice* pDevice) const;
 
     AudioPathType m_type;
     unsigned int m_index;
-    QList<SoundDevice*> m_devices;
+    QList<QSharedPointer<SoundDevice>> m_devices;
     bool m_isInput;
     QString m_savedDevice;
     // Because QVariant supports QPoint natively we use a QPoint to store the

--- a/src/soundio/sounddevice.h
+++ b/src/soundio/sounddevice.h
@@ -21,14 +21,17 @@
 #include <QString>
 #include <QList>
 
-#include "soundio/soundmanager.h"
+#include "util/types.h"
+#include "preferences/usersettings.h"
 #include "soundio/sounddeviceerror.h"
+#include "soundio/sounddevice.h"
 
-//Forward declarations
 class SoundDevice;
 class SoundManager;
 class AudioOutput;
 class AudioInput;
+class AudioOutputBuffer;
+class AudioInputBuffer;
 
 const QString kNetworkDeviceInternalName = "Network stream";
 
@@ -104,5 +107,7 @@ class SoundDevice {
     QList<AudioOutputBuffer> m_audioOutputs;
     QList<AudioInputBuffer> m_audioInputs;
 };
+
+typedef QSharedPointer<SoundDevice> SoundDevicePointer;
 
 #endif

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -21,18 +21,18 @@ class SoundDeviceNetworkThread;
 class SoundDeviceNetwork : public SoundDevice {
   public:
     SoundDeviceNetwork(UserSettingsPointer config,
-                       SoundManager *sm,
+                       SoundManager* sm,
                        QSharedPointer<EngineNetworkStream> pNetworkStream);
-    virtual ~SoundDeviceNetwork();
+    ~SoundDeviceNetwork() override;
 
-    virtual SoundDeviceError open(bool isClkRefDevice, int syncBuffers);
-    virtual bool isOpen() const;
-    virtual SoundDeviceError close();
-    virtual void readProcess();
-    virtual void writeProcess();
-    virtual QString getError() const;
+    SoundDeviceError open(bool isClkRefDevice, int syncBuffers) override;
+    bool isOpen() const override;
+    SoundDeviceError close() override;
+    void readProcess() override;
+    void writeProcess() override;
+    QString getError() const override;
 
-    virtual unsigned int getDefaultSampleRate() const {
+    unsigned int getDefaultSampleRate() const override {
         return 44100;
     }
 

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -8,6 +8,7 @@
 #include "util/performancetimer.h"
 #include "util/memory.h"
 #include "soundio/sounddevice.h"
+#include "engine/sidechain/networkoutputstreamworker.h"
 
 #define CPU_USAGE_UPDATE_RATE 30 // in 1/s, fits to display frame rate
 #define CPU_OVERLOAD_DURATION 500 // in ms

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -88,8 +88,8 @@ int paV19CallbackClkRef(const void *inputBuffer, void *outputBuffer,
 
 
 SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
-                                           SoundManager *sm,
-                                           const PaDeviceInfo *deviceInfo,
+                                           SoundManager* sm,
+                                           const PaDeviceInfo* deviceInfo,
                                            unsigned int devIndex)
         : SoundDevice(config, sm),
           m_pStream(NULL),

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -25,6 +25,7 @@
 
 #include "soundio/sounddevice.h"
 #include "util/duration.h"
+#include "util/fifo.h"
 
 #define CPU_USAGE_UPDATE_RATE 30 // in 1/s, fits to display frame rate
 

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -39,16 +39,16 @@ typedef int (*EnableAlsaRT)(PaStream* s, int enable);
 class SoundDevicePortAudio : public SoundDevice {
   public:
     SoundDevicePortAudio(UserSettingsPointer config,
-                         SoundManager *sm, const PaDeviceInfo *deviceInfo,
+                         SoundManager* sm, const PaDeviceInfo* deviceInfo,
                          unsigned int devIndex);
-    virtual ~SoundDevicePortAudio();
+    ~SoundDevicePortAudio() override;
 
-    virtual SoundDeviceError open(bool isClkRefDevice, int syncBuffers);
-    virtual bool isOpen() const;
-    virtual SoundDeviceError close();
-    virtual void readProcess();
-    virtual void writeProcess();
-    virtual QString getError() const;
+    SoundDeviceError open(bool isClkRefDevice, int syncBuffers) override;
+    bool isOpen() const override;
+    SoundDeviceError close() override;
+    void readProcess() override;
+    void writeProcess() override;
+    QString getError() const override;
 
     // This callback function gets called everytime the sound device runs out of
     // samples (ie. when it needs more sound to play)
@@ -67,7 +67,7 @@ class SoundDevicePortAudio : public SoundDevice {
                         const PaStreamCallbackTimeInfo *timeInfo,
                         PaStreamCallbackFlags statusFlags);
 
-    virtual unsigned int getDefaultSampleRate() const {
+    unsigned int getDefaultSampleRate() const override {
         return m_deviceInfo ? static_cast<unsigned int>(
             m_deviceInfo->defaultSampleRate) : 44100;
     }

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -411,7 +411,7 @@ SoundDeviceError SoundManager::setupDevices() {
             }
         }
 
-        for (const auto& out: outputs) {
+        for (const auto& out: qAsConst(outputs)) {
             mode.isOutput = true;
             if (pDevice->getInternalName() != kNetworkDeviceInternalName) {
                 haveOutput = true;
@@ -611,7 +611,7 @@ void SoundManager::pushInputBuffers(const QList<AudioInputBuffer>& inputs,
     }
 }
 
-void SoundManager::writeProcess() {
+void SoundManager::writeProcess() const {
     for (const auto& pDevice: m_devices) {
         if (pDevice) {
             pDevice->writeProcess();
@@ -619,7 +619,7 @@ void SoundManager::writeProcess() {
     }
 }
 
-void SoundManager::readProcess() {
+void SoundManager::readProcess() const {
     for (const auto& pDevice: m_devices) {
         if (pDevice) {
             pDevice->readProcess();

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -51,7 +51,7 @@ namespace {
 #define CPU_OVERLOAD_DURATION 500 // in ms
 
 struct DeviceMode {
-    SoundDevice* device;
+    QSharedPointer<SoundDevice> pDevice;
     bool isInput;
     bool isOutput;
 };
@@ -123,29 +123,28 @@ SoundManager::~SoundManager() {
     delete m_pMasterAudioLatencyOverload;
 }
 
-QList<SoundDevice*> SoundManager::getDeviceList(
+QList<QSharedPointer<SoundDevice>> SoundManager::getDeviceList(
     QString filterAPI, bool bOutputDevices, bool bInputDevices) {
     //qDebug() << "SoundManager::getDeviceList";
 
     if (filterAPI == "None") {
-        QList<SoundDevice*> emptyList;
-        return emptyList;
+        return QList<QSharedPointer<SoundDevice>>();
     }
 
     // Create a list of sound devices filtered to match given API and
     // input/output.
-    QList<SoundDevice*> filteredDeviceList;
+    QList<QSharedPointer<SoundDevice>> filteredDeviceList;
 
-    foreach (SoundDevice* device, m_devices) {
+    for (const auto& pDevice: m_devices) {
         // Skip devices that don't match the API, don't have input channels when
         // we want input devices, or don't have output channels when we want
         // output devices.
-        if (device->getHostAPI() != filterAPI ||
-                (bOutputDevices && device->getNumOutputChannels() <= 0) ||
-                (bInputDevices && device->getNumInputChannels() <= 0)) {
+        if (pDevice->getHostAPI() != filterAPI ||
+                (bOutputDevices && pDevice->getNumOutputChannels() <= 0) ||
+                (bInputDevices && pDevice->getNumInputChannels() <= 0)) {
             continue;
         }
-        filteredDeviceList.push_back(device);
+        filteredDeviceList.push_back(pDevice);
     }
     return filteredDeviceList;
 }
@@ -167,7 +166,7 @@ void SoundManager::closeDevices(bool sleepAfterClosing) {
     //qDebug() << "SoundManager::closeDevices()";
 
     bool closed = false;
-    foreach (SoundDevice* pDevice, m_devices) {
+    for (const auto& pDevice: m_devices) {
         if (pDevice->isOpen()) {
             // NOTE(rryan): As of 2009 (?) it has been safe to close() a SoundDevice
             // while callbacks are active.
@@ -187,8 +186,8 @@ void SoundManager::closeDevices(bool sleepAfterClosing) {
     // TODO(rryan): Should we do this before SoundDevice::close()? No! Because
     // then the callback may be running when we call
     // onInputDisconnected/onOutputDisconnected.
-    foreach (SoundDevice* pDevice, m_devices) {
-        foreach (AudioInput in, pDevice->inputs()) {
+    for (const auto& pDevice: m_devices) {
+        for (const auto& in: pDevice->inputs()) {
             // Need to tell all registered AudioDestinations for this AudioInput
             // that the input was disconnected.
             for (QHash<AudioInput, AudioDestination*>::const_iterator it =
@@ -198,12 +197,12 @@ void SoundManager::closeDevices(bool sleepAfterClosing) {
                 m_pMaster->onInputDisconnected(in);
             }
         }
-        foreach (AudioOutput out, pDevice->outputs()) {
+        for (const auto& out: pDevice->outputs()) {
             // Need to tell all registered AudioSources for this AudioOutput
             // that the output was disconnected.
             for (QHash<AudioOutput, AudioSource*>::const_iterator it =
-                         m_registeredSources.find(out);
-                 it != m_registeredSources.end() && it.key() == out; ++it) {
+                    m_registeredSources.find(out);
+                    it != m_registeredSources.end() && it.key() == out; ++it) {
                 it.value()->onOutputDisconnected(out);
             }
         }
@@ -228,11 +227,8 @@ void SoundManager::clearDeviceList(bool sleepAfterClosing) {
     closeDevices(sleepAfterClosing);
 
     // Empty out the list of devices we currently have.
-    while (!m_devices.empty()) {
-        SoundDevice* dev = m_devices.takeLast();
-        delete dev;
-    }
-    m_pErrorDevice = NULL;
+    m_devices.clear();
+    m_pErrorDevice.clear();
 
 #ifdef __PORTAUDIO__
     if (m_paInitialized) {
@@ -314,8 +310,8 @@ void SoundManager::queryDevicesPortaudio() {
             PaTime  defaultHighOutputLatency
             double  defaultSampleRate
          */
-        SoundDevicePortAudio* currentDevice = new SoundDevicePortAudio(
-                m_pConfig, this, deviceInfo, i);
+        auto currentDevice = QSharedPointer<SoundDevice>(new SoundDevicePortAudio(
+                m_pConfig, this, deviceInfo, i));
         m_devices.push_back(currentDevice);
         if (!strcmp(Pa_GetHostApiInfo(deviceInfo->hostApi)->name,
                     MIXXX_PORTAUDIO_JACK_STRING)) {
@@ -326,8 +322,8 @@ void SoundManager::queryDevicesPortaudio() {
 }
 
 void SoundManager::queryDevicesMixxx() {
-    SoundDeviceNetwork* currentDevice = new SoundDeviceNetwork(
-            m_pConfig, this, m_pNetworkStream);
+    auto currentDevice = QSharedPointer<SoundDevice>(new SoundDeviceNetwork(
+            m_pConfig, this, m_pNetworkStream));
     m_devices.append(currentDevice);
 }
 
@@ -344,7 +340,7 @@ SoundDeviceError SoundManager::setupDevices() {
     // results in a stuttering noise (sometimes a loud buzz noise at low
     // latencies) when changing devices.
     //m_pClkRefDevice = NULL;
-    m_pErrorDevice = NULL;
+    m_pErrorDevice.clear();
     int outputDevicesOpened = 0;
     int inputDevicesOpened = 0;
 
@@ -363,7 +359,7 @@ SoundDeviceError SoundManager::setupDevices() {
 
     // Instead of clearing m_pClkRefDevice and then assigning it directly,
     // compute the new one then atomically hand off below.
-    SoundDevice* pNewMasterClockRef = NULL;
+    QSharedPointer<SoundDevice> pNewMasterClockRef;
 
     m_pMasterAudioLatencyOverloadCount->set(0);
 
@@ -375,18 +371,18 @@ SoundDeviceError SoundManager::setupDevices() {
     QList<DeviceMode> toOpen;
     bool haveOutput = false;
     // loop over all available devices
-    foreach (SoundDevice* device, m_devices) {
-        DeviceMode mode = {device, false, false};
-        device->clearInputs();
-        device->clearOutputs();
-        m_pErrorDevice = device;
-        foreach (AudioInput in,
-                 m_config.getInputs().values(device->getInternalName())) {
+    for (const auto& pDevice: m_devices) {
+        DeviceMode mode = {pDevice, false, false};
+        pDevice->clearInputs();
+        pDevice->clearOutputs();
+        m_pErrorDevice = pDevice;
+        for (const auto& in:
+                 m_config.getInputs().values(pDevice->getInternalName())) {
             mode.isInput = true;
             // TODO(bkgood) look into allocating this with the frames per
             // buffer value from SMConfig
             AudioInputBuffer aib(in, SampleUtil::alloc(MAX_BUFFER_LEN));
-            err = device->addInput(aib);
+            err = pDevice->addInput(aib);
             if (err != SOUNDDEVICE_ERROR_OK) {
                 delete [] aib.getBuffer();
                 goto closeAndError;
@@ -404,20 +400,20 @@ SoundDeviceError SoundManager::setupDevices() {
             }
         }
         QList<AudioOutput> outputs =
-                m_config.getOutputs().values(device->getInternalName());
+                m_config.getOutputs().values(pDevice->getInternalName());
 
         // Statically connect the Network Device to the Sidechain
-        if (device->getInternalName() == kNetworkDeviceInternalName) {
+        if (pDevice->getInternalName() == kNetworkDeviceInternalName) {
             AudioOutput out(AudioPath::RECORD_BROADCAST, 0, 2, 0);
             outputs.append(out);
             if (m_config.getForceNetworkClock()) {
-                pNewMasterClockRef = device;
+                pNewMasterClockRef = pDevice;
             }
         }
 
-        foreach (AudioOutput out, outputs) {
+        for (const auto& out: outputs) {
             mode.isOutput = true;
-            if (device->getInternalName() != kNetworkDeviceInternalName) {
+            if (pDevice->getInternalName() != kNetworkDeviceInternalName) {
                 haveOutput = true;
             }
             // following keeps us from asking for a channel buffer EngineMaster
@@ -429,16 +425,16 @@ SoundDeviceError SoundManager::setupDevices() {
             }
 
             AudioOutputBuffer aob(out, pBuffer);
-            err = device->addOutput(aob);
+            err = pDevice->addOutput(aob);
             if (err != SOUNDDEVICE_ERROR_OK) goto closeAndError;
 
             if (!m_config.getForceNetworkClock()) {
                 if (out.getType() == AudioOutput::MASTER) {
-                    pNewMasterClockRef = device;
+                    pNewMasterClockRef = pDevice;
                 } else if ((out.getType() == AudioOutput::DECK ||
                             out.getType() == AudioOutput::BUS)
                         && !pNewMasterClockRef) {
-                    pNewMasterClockRef = device;
+                    pNewMasterClockRef = pDevice;
                 }
             }
 
@@ -452,23 +448,23 @@ SoundDeviceError SoundManager::setupDevices() {
         }
 
         if (mode.isInput || mode.isOutput) {
-            device->setSampleRate(m_config.getSampleRate());
-            device->setFramesPerBuffer(m_config.getFramesPerBuffer());
+            pDevice->setSampleRate(m_config.getSampleRate());
+            pDevice->setFramesPerBuffer(m_config.getFramesPerBuffer());
             toOpen.append(mode);
         }
     }
 
     for (const auto& mode: toOpen) {
-        SoundDevice* device = mode.device;
-        m_pErrorDevice = device;
+        QSharedPointer<SoundDevice> pDevice = mode.pDevice;
+        m_pErrorDevice = pDevice;
 
         // If we have not yet set a clock source then we use the first
-        // output device
-        if (pNewMasterClockRef == NULL &&
+        // output pDevice
+        if (pNewMasterClockRef.isNull() &&
                 (!haveOutput || mode.isOutput)) {
-            pNewMasterClockRef = device;
+            pNewMasterClockRef = pDevice;
             qWarning() << "Output sound device clock reference not set! Using"
-                       << device->getDisplayName();
+                       << pDevice->getDisplayName();
         }
 
         int syncBuffers = m_config.getSyncBuffers();
@@ -477,9 +473,9 @@ SoundDeviceError SoundManager::setupDevices() {
         if (CmdlineArgs::Instance().getSafeMode() && syncBuffers == 0) {
             syncBuffers = 2;
         }
-        err = device->open(pNewMasterClockRef == device, syncBuffers);
+        err = pDevice->open(pNewMasterClockRef == pDevice, syncBuffers);
         if (err != SOUNDDEVICE_ERROR_OK) goto closeAndError;
-        devicesNotFound.remove(device->getInternalName());
+        devicesNotFound.remove(pDevice->getInternalName());
         if (mode.isOutput) {
             ++outputDevicesOpened;
         }
@@ -510,9 +506,8 @@ SoundDeviceError SoundManager::setupDevices() {
         emit(devicesSetup());
         return SOUNDDEVICE_ERROR_OK;
     }
-    m_soundDeviceNotFound.reset(
+    m_pErrorDevice = QSharedPointer<SoundDevice>(
             new SoundDeviceNotFound(*devicesNotFound.constBegin()));
-    m_pErrorDevice = m_soundDeviceNotFound.get();
     return SOUNDDEVICE_ERROR_DEVICE_COUNT;
 
 closeAndError:
@@ -521,14 +516,14 @@ closeAndError:
     return err;
 }
 
-SoundDevice* SoundManager::getErrorDevice() const {
+QSharedPointer<SoundDevice> SoundManager::getErrorDevice() const {
     return m_pErrorDevice;
 }
 
 QString SoundManager::getErrorDeviceName() const {
-    SoundDevice* device = getErrorDevice();
-    if (device != NULL) {
-        return device->getDisplayName();
+    QSharedPointer<SoundDevice> pDevice = getErrorDevice();
+    if (!pDevice.isNull()) {
+        return pDevice->getDisplayName();
     }
     return tr("a device");
 }
@@ -537,10 +532,10 @@ QString SoundManager::getLastErrorMessage(SoundDeviceError err) const {
     QString error;
     QString deviceName(tr("a device"));
     QString detailedError(tr("An unknown error occurred"));
-    SoundDevice* device = getErrorDevice();
-    if (device != NULL) {
-        deviceName = device->getDisplayName();
-        detailedError = device->getError();
+    QSharedPointer<SoundDevice> pDevice = getErrorDevice();
+    if (!pDevice.isNull()) {
+        deviceName = pDevice->getDisplayName();
+        detailedError = pDevice->getError();
     }
     switch (err) {
     case SOUNDDEVICE_ERROR_DUPLICATE_OUTPUT_CHANNEL:
@@ -617,21 +612,17 @@ void SoundManager::pushInputBuffers(const QList<AudioInputBuffer>& inputs,
 }
 
 void SoundManager::writeProcess() {
-    QListIterator<SoundDevice*> dev_it(m_devices);
-    while (dev_it.hasNext()) {
-        SoundDevice* device = dev_it.next();
-        if (device) {
-            device->writeProcess();
+    for (const auto& pDevice: m_devices) {
+        if (!pDevice.isNull()) {
+            pDevice->writeProcess();
         }
     }
 }
 
 void SoundManager::readProcess() {
-    QListIterator<SoundDevice*> dev_it(m_devices);
-    while (dev_it.hasNext()) {
-        SoundDevice* device = dev_it.next();
-        if (device) {
-            device->readProcess();
+    for (const auto& pDevice: m_devices) {
+        if (!pDevice.isNull()) {
+            pDevice->readProcess();
         }
     }
 }

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -166,7 +166,7 @@ void SoundManager::closeDevices(bool sleepAfterClosing) {
     //qDebug() << "SoundManager::closeDevices()";
 
     bool closed = false;
-    for (const auto& pDevice: m_devices) {
+    for (const auto& pDevice: qAsConst(m_devices)) {
         if (pDevice->isOpen()) {
             // NOTE(rryan): As of 2009 (?) it has been safe to close() a SoundDevice
             // while callbacks are active.
@@ -186,7 +186,7 @@ void SoundManager::closeDevices(bool sleepAfterClosing) {
     // TODO(rryan): Should we do this before SoundDevice::close()? No! Because
     // then the callback may be running when we call
     // onInputDisconnected/onOutputDisconnected.
-    for (const auto& pDevice: m_devices) {
+    for (const auto& pDevice: qAsConst(m_devices)) {
         for (const auto& in: pDevice->inputs()) {
             // Need to tell all registered AudioDestinations for this AudioInput
             // that the input was disconnected.
@@ -371,7 +371,7 @@ SoundDeviceError SoundManager::setupDevices() {
     QList<DeviceMode> toOpen;
     bool haveOutput = false;
     // loop over all available devices
-    for (const auto& pDevice: m_devices) {
+    for (const auto& pDevice: qAsConst(m_devices)) {
         DeviceMode mode = {pDevice, false, false};
         pDevice->clearInputs();
         pDevice->clearOutputs();

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -522,7 +522,7 @@ SoundDevicePointer SoundManager::getErrorDevice() const {
 
 QString SoundManager::getErrorDeviceName() const {
     SoundDevicePointer pDevice = getErrorDevice();
-    if (!pDevice.isNull()) {
+    if (pDevice) {
         return pDevice->getDisplayName();
     }
     return tr("a device");
@@ -533,7 +533,7 @@ QString SoundManager::getLastErrorMessage(SoundDeviceError err) const {
     QString deviceName(tr("a device"));
     QString detailedError(tr("An unknown error occurred"));
     SoundDevicePointer pDevice = getErrorDevice();
-    if (!pDevice.isNull()) {
+    if (pDevice) {
         deviceName = pDevice->getDisplayName();
         detailedError = pDevice->getError();
     }
@@ -613,7 +613,7 @@ void SoundManager::pushInputBuffers(const QList<AudioInputBuffer>& inputs,
 
 void SoundManager::writeProcess() {
     for (const auto& pDevice: m_devices) {
-        if (!pDevice.isNull()) {
+        if (pDevice) {
             pDevice->writeProcess();
         }
     }
@@ -621,7 +621,7 @@ void SoundManager::writeProcess() {
 
 void SoundManager::readProcess() {
     for (const auto& pDevice: m_devices) {
-        if (!pDevice.isNull()) {
+        if (pDevice) {
             pDevice->readProcess();
         }
     }

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -62,7 +62,8 @@ class SoundManager : public QObject {
     // Returns a list of all devices we've enumerated that match the provided
     // filterApi, and have at least one output or input channel if the
     // bOutputDevices or bInputDevices are set, respectively.
-    QList<SoundDevice*> getDeviceList(QString filterAPI, bool bOutputDevices, bool bInputDevices);
+    QList<QSharedPointer<SoundDevice>> getDeviceList(
+            QString filterAPI, bool bOutputDevices, bool bInputDevices);
 
     // Creates a list of sound devices
     void clearAndQueryDevices();
@@ -78,7 +79,7 @@ class SoundManager : public QObject {
     void setConfiguredDeckCount(int count);
     int getConfiguredDeckCount() const;
 
-    SoundDevice* getErrorDevice() const;
+    QSharedPointer<SoundDevice> getErrorDevice() const;
     QString getErrorDeviceName() const;
     QString getLastErrorMessage(SoundDeviceError err) const;
 
@@ -149,12 +150,12 @@ class SoundManager : public QObject {
     bool m_paInitialized;
     unsigned int m_jackSampleRate;
 #endif
-    QList<SoundDevice*> m_devices;
+    QList<QSharedPointer<SoundDevice>> m_devices;
     QList<unsigned int> m_samplerates;
     QList<CSAMPLE*> m_inputBuffers;
 
     SoundManagerConfig m_config;
-    SoundDevice* m_pErrorDevice;
+    QSharedPointer<SoundDevice> m_pErrorDevice;
     QHash<AudioOutput, AudioSource*> m_registeredSources;
     QHash<AudioInput, AudioDestination*> m_registeredDestinations;
     ControlObject* m_pControlObjectSoundStatusCO;
@@ -166,8 +167,6 @@ class SoundManager : public QObject {
     int m_underflowUpdateCount;
     ControlProxy* m_pMasterAudioLatencyOverloadCount;
     ControlProxy* m_pMasterAudioLatencyOverload;
-
-    std::unique_ptr<SoundDeviceNotFound> m_soundDeviceNotFound;
 };
 
 #endif

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -104,8 +104,8 @@ class SoundManager : public QObject {
                           const SINT iFramesPerBuffer);
 
 
-    void writeProcess();
-    void readProcess();
+    void writeProcess() const;
+    void readProcess() const;
 
     void registerOutput(AudioOutput output, AudioSource *src);
     void registerInput(AudioInput input, AudioDestination *dest);

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -29,9 +29,9 @@
 #include "engine/sidechain/enginenetworkstream.h"
 #include "soundio/soundmanagerconfig.h"
 #include "soundio/sounddevice.h"
-#include "soundio/sounddeviceerror.h"
 #include "util/types.h"
 #include "util/cmdlineargs.h"
+
 
 class EngineMaster;
 class AudioOutput;
@@ -53,6 +53,7 @@ class SoundDeviceNotFound;
 #define SOUNDMANAGER_CONNECTING 1
 #define SOUNDMANAGER_CONNECTED 2
 
+
 class SoundManager : public QObject {
     Q_OBJECT
   public:
@@ -62,8 +63,8 @@ class SoundManager : public QObject {
     // Returns a list of all devices we've enumerated that match the provided
     // filterApi, and have at least one output or input channel if the
     // bOutputDevices or bInputDevices are set, respectively.
-    QList<QSharedPointer<SoundDevice>> getDeviceList(
-            QString filterAPI, bool bOutputDevices, bool bInputDevices);
+    QList<SoundDevicePointer> getDeviceList(
+            QString filterAPI, bool bOutputDevices, bool bInputDevices) const;
 
     // Creates a list of sound devices
     void clearAndQueryDevices();
@@ -79,7 +80,7 @@ class SoundManager : public QObject {
     void setConfiguredDeckCount(int count);
     int getConfiguredDeckCount() const;
 
-    QSharedPointer<SoundDevice> getErrorDevice() const;
+    SoundDevicePointer getErrorDevice() const;
     QString getErrorDeviceName() const;
     QString getLastErrorMessage(SoundDeviceError err) const;
 
@@ -150,12 +151,12 @@ class SoundManager : public QObject {
     bool m_paInitialized;
     unsigned int m_jackSampleRate;
 #endif
-    QList<QSharedPointer<SoundDevice>> m_devices;
+    QList<SoundDevicePointer> m_devices;
     QList<unsigned int> m_samplerates;
     QList<CSAMPLE*> m_inputBuffers;
 
     SoundManagerConfig m_config;
-    QSharedPointer<SoundDevice> m_pErrorDevice;
+    SoundDevicePointer m_pErrorDevice;
     QHash<AudioOutput, AudioSource*> m_registeredSources;
     QHash<AudioInput, AudioDestination*> m_registeredDestinations;
     ControlObject* m_pControlObjectSoundStatusCO;

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -384,7 +384,7 @@ void SoundManagerConfig::loadDefaults(SoundManager *soundManager, unsigned int f
     if (flags & SoundManagerConfig::DEVICES) {
         clearOutputs();
         clearInputs();
-        QList<QSharedPointer<SoundDevice>> outputDevices = soundManager->getDeviceList(m_api, true, false);
+        QList<SoundDevicePointer> outputDevices = soundManager->getDeviceList(m_api, true, false);
         if (!outputDevices.isEmpty()) {
             for (const auto& pDevice: outputDevices) {
                 if (pDevice->getNumOutputChannels() < 2) {

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -384,15 +384,15 @@ void SoundManagerConfig::loadDefaults(SoundManager *soundManager, unsigned int f
     if (flags & SoundManagerConfig::DEVICES) {
         clearOutputs();
         clearInputs();
-        QList<SoundDevice*> outputDevices = soundManager->getDeviceList(m_api, true, false);
+        QList<QSharedPointer<SoundDevice>> outputDevices = soundManager->getDeviceList(m_api, true, false);
         if (!outputDevices.isEmpty()) {
-            foreach (SoundDevice *device, outputDevices) {
-                if (device->getNumOutputChannels() < 2) {
+            for (const auto& pDevice: outputDevices) {
+                if (pDevice->getNumOutputChannels() < 2) {
                     continue;
                 }
                 AudioOutput masterOut(AudioPath::MASTER, 0, 2, 0);
-                addOutput(device->getInternalName(), masterOut);
-                defaultSampleRate = device->getDefaultSampleRate();
+                addOutput(pDevice->getInternalName(), masterOut);
+                defaultSampleRate = pDevice->getDefaultSampleRate();
                 break;
             }
         }

--- a/src/util/compatibility.h
+++ b/src/util/compatibility.h
@@ -31,4 +31,17 @@ inline QLocale inputLocale() {
 #endif
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
+
+// this adds const to non-const objects (like std::as_const)
+template <typename T>
+struct QAddConst { typedef const T Type; };
+template <typename T>
+constexpr typename QAddConst<T>::Type &qAsConst(T &t) { return t; }
+// prevent rvalue arguments:
+template <typename T>
+void qAsConst(const T &&) = delete;
+
+#endif
+
 #endif /* COMPATABILITY_H */


### PR DESCRIPTION
A first few lines fix has already fixed his by delete the the old devices before we propagate the new. 
But it itches me to much to introduce a smart pointer solution, which unfortunately makes this PR a bit long. 