### PR TITLE
Set real time priority for SoundDeviceNetworkThread on Linux

### DIFF
--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -93,8 +93,7 @@ class SoundDeviceNetworkThread : public QThread {
 #ifdef __LINUX__
         struct sched_param spm = { 0 };
         spm.sched_priority = 1;
-        if(pthread_setschedparam(pthread_self(), SCHED_FIFO, &spm)
-        {
+        if(pthread_setschedparam(pthread_self(), SCHED_FIFO, &spm) {
             qWarning() << "SoundDeviceNetworkThread: Failed bumping priority";
         }
 #endif

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -5,6 +5,10 @@
 #include <QSharedPointer>
 #include <QThread>
 
+#ifdef __LINUX__
+#include <pthread.h>
+#endif
+
 #include "util/performancetimer.h"
 #include "util/memory.h"
 #include "soundio/sounddevice.h"
@@ -85,6 +89,16 @@ class SoundDeviceNetworkThread : public QThread {
 
   private:
     void run() {
+
+#ifdef __LINUX__
+        struct sched_param spm = { 0 };
+        spm.sched_priority = 1;
+        if(pthread_setschedparam(pthread_self(), SCHED_FIFO, &spm)
+        {
+            qWarning() << "SoundDeviceNetworkThread: Failed bumping priority";
+        }
+#endif
+
         while(!m_stop) {
             m_pParent->callbackProcessClkRef();
         }


### PR DESCRIPTION
p_pThread->start(QThread::TimeCriticalPriority); does not work on Linux.
As reported here https://bugs.launchpad.net/mixxx/+bug/1641359

I have ported the code from Portaudio that is called if you set PaAlsa_EnableRealtimeScheduling

The result is really great, it allows to use 2.67 ms buffer on my Ubuntu Trusty system without a single underflow. 

Soundcard thread and network thread are on the same priority now. See:

```
$ ps -T -C19,_20 -o priority,ni,pcpu,pid,comm 18061
PRI  NI %CPU   PID COMMAND
 20   0 18.9 18061 mixxx
 20   0  0.0 18061 dconf worker
 20   0  0.0 18061 gdbus
 20   0  0.0 18061 gmain
 20   0  1.0 18061 StatsManager
 20   0  0.0 18061 mixxx
 20   0  0.0 18061 EngineWorkerSch
 20   0  0.0 18061 EngineSideChain
 20   0  0.0 18061 VinylControlPro
 20   0  0.1 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 LibraryScanner 
 20   0  0.7 18061 BrowseThread
 20   0  0.4 18061 AnalyzerQueue
 20   0  0.7 18061 Controller
 20   0  1.0 18061 VSyncThread
 20   0  0.0 18061 QProcessManager
 20   0  0.0 18061 Controller
 -2   -  1.6 18061 mixxx
 -2   -  8.1 18061 SoundDeviceNetw
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo
 20   0  0.0 18061 CachingReaderWo

```