### PR TITLE
Deere: uncomment sampler template

### DIFF
--- a/res/skins/Deere/skin.xml
+++ b/res/skins/Deere/skin.xml
@@ -9,7 +9,7 @@
     <license>Creative Commons Attribution, Share-Alike 3.0 Unported</license>
     <attributes>
       <attribute config_key="[Master],num_decks">4</attribute>
-      <attribute config_key="[Master],num_samplers">8</attribute>
+      <attribute config_key="[Master],num_samplers">64</attribute>
       <attribute config_key="[Master],num_preview_decks">1</attribute>
       <attribute config_key="[Library],show_library">1</attribute>
 
@@ -234,7 +234,7 @@
               <Children>
                 <Template src="skin:main_decks.xml"/>
                 <Template src="skin:effect_rack.xml"/>
-                <!--Template src="skin:sample_decks.xml"/-->
+                <Template src="skin:sample_decks.xml"/>
                 <Template src="skin:microphone_rack.xml"/>
                 <SingletonContainer>
                   <ObjectName>Library</ObjectName>


### PR DESCRIPTION
Thanks for catching this @sblaisot! It looks like @ronso0 commented out the whole sampler template for testing and accidentally committed it.