### PR TITLE
singleton fix for QT 5.10 and other miscellaneous warnings

### DIFF
--- a/lib/xwax/lut_win32.cpp
+++ b/lib/xwax/lut_win32.cpp
@@ -45,7 +45,7 @@ int lut_init(struct lut *lut, int nslots)
     bytes = sizeof(struct slot) * nslots + sizeof(slot_no_t) * hashes;
 
     fprintf(stderr, "Lookup table has %d hashes to %d slots"
-            " (%d slots per hash, %u Kb)\n",
+            " (%d slots per hash, %zuKb)\n",
             hashes, nslots, nslots / hashes, bytes / 1024);
 
     lut->slot = (struct slot*)(malloc(sizeof(struct slot) * nslots));

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -125,7 +125,7 @@ MixxxMainWindow::MixxxMainWindow(QApplication* pApp, const CmdlineArgs& args)
 
     // Only record stats in developer mode.
     if (m_cmdLineArgs.getDeveloper()) {
-        StatsManager::create();
+        StatsManager::createInstance();
     }
 
     m_pSettingsManager = new SettingsManager(this, args.getSettingsPath());
@@ -264,7 +264,7 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
     delete pModplugPrefs; // not needed anymore
 #endif
 
-    CoverArtCache::create();
+    CoverArtCache::createInstance();
 
     m_pDbConnectionPool = MixxxDb(pConfig).connectionPool();
     if (!m_pDbConnectionPool) {
@@ -325,7 +325,7 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
 
     launchProgress(47);
 
-    WaveformWidgetFactory::create(); // takes a long time
+    WaveformWidgetFactory::createInstance(); // takes a long time
     WaveformWidgetFactory::instance()->startVSync(m_pGuiTick);
     WaveformWidgetFactory::instance()->setConfig(pConfig);
 

--- a/src/util/singleton.h
+++ b/src/util/singleton.h
@@ -6,7 +6,7 @@
 template<class T>
 class Singleton {
   public:
-    static T* create() {
+    static T* createInstance() {
         if (!m_instance) {
             m_instance = new T();
         }

--- a/src/util/widgethider.cpp
+++ b/src/util/widgethider.cpp
@@ -25,7 +25,8 @@ void WidgetHider::showWidget(QWidget* w) {
     w->update();
 }
 #else
-bool WidgetHider::eventFilter(QObject*, QEvent*) {
+bool WidgetHider::eventFilter(QObject* watched, QEvent* event) {
+    return QObject::eventFilter(watched,event);
 }
 
 void WidgetHider::retainSizeFor(QWidget* widget)


### PR DESCRIPTION
Basically a fix for recent travisci failures due to an upgrade to QT 5.10 and the existence of a create() method in QThread in this version.

Also, two miscellaneous warnings should be fixed with this.