### PR TITLE
LateNight 2.1 :: set minimum size for scrolling waveforms

### DIFF
--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -103,9 +103,9 @@
               <ObjectName>CoverArtSplitter</ObjectName>
               <Orientation>vertical</Orientation>
               <SizePolicy>me,min</SizePolicy>
-              <SplitSizes>100,10000</SplitSizes>
+              <SplitSizes>1,5</SplitSizes>
               <SplitSizesConfigKey>[LateNight],waveform_splitSize</SplitSizesConfigKey>
-              <Collapsible>0,0</Collapsible>
+              <Collapsible>1,0</Collapsible>
               <Children>
 
                 <Template src="skin:waveforms.xml"/>

--- a/res/skins/LateNight/waveforms.xml
+++ b/res/skins/LateNight/waveforms.xml
@@ -1,7 +1,7 @@
 <Template>
   <WidgetGroup>
     <Layout>vertical</Layout>
-    <Size>0me,0min</Size>
+    <Size>0me,40min</Size>
     <Children>
 
       <WidgetGroup><!-- Waveform 3 -->


### PR DESCRIPTION
This fixes that waveforms were tiny or invisible (except splitter handle) when starting with clean profile.

Funny it somehow respects Splitter's `<SplitSizes>1,5</SplitSizes>` once the waveforms template has a minimum size set.