### PR TITLE
remove printing config.log when build fail in appveyor build script

### DIFF
--- a/build/appveyor/build_mixxx.bat
+++ b/build/appveyor/build_mixxx.bat
@@ -148,8 +148,8 @@ echo.
 echo Building Mixxx failed.
 echo.
 REM For debugging, print the configuration log.
-echo Printing config.log:
-type config.log
+REM echo Printing config.log:
+REM type config.log
 ENDLOCAL
 exit /b 1
 ) else (


### PR DESCRIPTION
When a build fail on appveyor, the build script prints the whole config.log. This one is about 1000 lines and contain lots of try/fail to determine the correct configuration, so a lot of errors.
Thus, it is hard to catch the real error that makes the build fail somewhere 1000 lines above the end of buils log.

Commenting-out this should ease finding the real build error cause. I leave it commented out in the build script to allow esay uncommenting in case ob buils system debugging.