### PR TITLE
fix FilterGroupState crash

### DIFF
--- a/src/effects/native/filtereffect.cpp
+++ b/src/effects/native/filtereffect.cpp
@@ -81,11 +81,10 @@ FilterGroupState::FilterGroupState(const mixxx::EngineParameters& bufferParamete
 }
 
 void FilterGroupState::engineParametersChanged(const mixxx::EngineParameters& bufferParameters) {
-    m_pBuf = SampleUtil::alloc(bufferParameters.samplesPerBuffer());
+    m_buffer = mixxx::SampleBuffer(bufferParameters.samplesPerBuffer());
 }
 
 FilterGroupState::~FilterGroupState() {
-    delete m_pBuf;
     delete m_pLowFilter;
     delete m_pHighFilter;
 }
@@ -149,8 +148,8 @@ void FilterEffect::processChannel(const ChannelHandle& handle,
         pState->m_pHighFilter->setFrequencyCorners(1, hpf, clampedQ);
     }
 
-    const CSAMPLE* pLpfInput = pState->m_pBuf;
-    CSAMPLE* pHpfOutput = pState->m_pBuf;
+    const CSAMPLE* pLpfInput = pState->m_buffer.data();
+    CSAMPLE* pHpfOutput = pState->m_buffer.data();
     if (lpf >= maxCornerNormalized && pState->m_loFreq >= maxCornerNormalized) {
         // Lpf disabled Hpf can write directly to output
         pHpfOutput = pOutput;

--- a/src/effects/native/filtereffect.h
+++ b/src/effects/native/filtereffect.h
@@ -9,6 +9,7 @@
 #include "util/class.h"
 #include "util/defs.h"
 #include "util/sample.h"
+#include "util/samplebuffer.h"
 #include "util/types.h"
 
 struct FilterGroupState : public EffectState {
@@ -19,7 +20,7 @@ struct FilterGroupState : public EffectState {
 
     void setFilters(int sampleRate, double lowFreq, double highFreq);
 
-    CSAMPLE* m_pBuf;
+    mixxx::SampleBuffer m_buffer;
     EngineFilterBiquad1Low* m_pLowFilter;
     EngineFilterBiquad1High* m_pHighFilter;
 


### PR DESCRIPTION
Oops, in fffc93099c77321dc2e9962881dfe4d27c3b3c0c I deleted a pointer, not an object.

(Hopefully) fixes https://bugs.launchpad.net/mixxx/+bug/1739924