### PR TITLE
fix headphone effects

### DIFF
--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -239,7 +239,6 @@ bool EngineEffectChain::process(const ChannelHandle& inputHandle,
         // after writing to the output buffer. This requires not to use the same buffer
         // for in and output: Also, ChannelMixer::applyEffectsAndMixChannels
         // requires that the input buffer does not get modified.
-        bool processingOccured = false;
         CSAMPLE* pIntermediateInput = pIn;
         CSAMPLE* pIntermediateOutput;
 


### PR DESCRIPTION
I accidentally declared a variable in an inner scope with the same name as one in the outer scope. 🤦‍ I spent all day, just to delete one line of code...

fixes https://bugs.launchpad.net/mixxx/+bug/1740423