### PR TITLE
Deere grid fix

### DIFF
--- a/res/skins/Deere/deck.xml
+++ b/res/skins/Deere/deck.xml
@@ -24,6 +24,10 @@
           <WidgetGroup>
             <Layout>vertical</Layout>
             <Children>
+              <WidgetGroup>
+                <ObjectName>Spacer22</ObjectName>
+                <Size>0me,1f</Size>
+              </WidgetGroup>
               <SingletonContainer>
                 <ObjectName>DeckVisualRow<Variable name="i" /></ObjectName>
               </SingletonContainer>

--- a/res/skins/Deere/deck_controls_row.xml
+++ b/res/skins/Deere/deck_controls_row.xml
@@ -9,16 +9,19 @@
   <WidgetGroup>
     <ObjectName>ControlsRow</ObjectName>
     <Layout>horizontal</Layout>
-    <MinimumSize>-1,47</MinimumSize>
-    <SizePolicy>me,min</SizePolicy>
+    <SizePolicy>me,max</SizePolicy>
     <Children>
-      <Template src="skin:hotcue.xml"/>
       <!-- Expanding spacers in between control contexts -->
-      <WidgetGroup><Size>3me,1min</Size><Children/></WidgetGroup>
+      <WidgetGroup><Size>3me,1min</Size></WidgetGroup>
       <Template src="skin:loop.xml"/>
-      <WidgetGroup><Size>3me,1min</Size><Children/></WidgetGroup>
+      <WidgetGroup><Size>3me,1min</Size></WidgetGroup>
       <Template src="skin:beatjump.xml"/>
-      <WidgetGroup><Size>3me,1min</Size><Children/></WidgetGroup>
+      <WidgetGroup><Size>3me,1min</Size></WidgetGroup>
+      <Template src="skin:hotcue.xml"/>
+      <WidgetGroup>
+        <Size>3me,1min</Size>
+        <MaximumSize>12,-1</MaximumSize>
+      </WidgetGroup>
 
       <WidgetGroup>
         <Layout>vertical</Layout>

--- a/res/skins/Deere/deck_overview_row.xml
+++ b/res/skins/Deere/deck_overview_row.xml
@@ -10,16 +10,18 @@
     <ObjectName>OverviewRow</ObjectName>
     <Layout>horizontal</Layout>
     <SizePolicy>me,me</SizePolicy>
-    <MinimumSize>-1,40</MinimumSize>
-    <MaximumSize>-1,80</MaximumSize>
+    <MinimumSize>-1,46</MinimumSize>
+    <MaximumSize>-1,-1</MaximumSize>
     <Children>
       <WidgetGroup>
-        <ObjectName>ButtonGrid</ObjectName>
+        <ObjectName>DeckControlsGrid</ObjectName>
         <Layout>vertical</Layout>
+        <SizePolicy>min,min</SizePolicy>
         <Children>
           <WidgetGroup>
-            <ObjectName>ButtonGrid</ObjectName>
+            <ObjectName>DeckControlsGrid</ObjectName>
             <Layout>horizontal</Layout>
+            <SizePolicy>min,min</SizePolicy>
             <Children>
 
               <Template src="skin:left_2state_button.xml">
@@ -69,8 +71,9 @@
           </WidgetGroup>
 
           <WidgetGroup>
-            <ObjectName>ButtonGrid</ObjectName>
+            <ObjectName>DeckControlsGrid</ObjectName>
             <Layout>horizontal</Layout>
+            <SizePolicy>min,min</SizePolicy>
             <Children>
               <Template src="skin:left_2state_button.xml">
                 <SetVariable name="TooltipId">eject</SetVariable>
@@ -120,17 +123,16 @@
             </Children>
           </WidgetGroup>
         </Children>
-        <Connection>
-          <ConfigKey>[Deere],show_minimal_deck_controls</ConfigKey>
-          <BindProperty>visible</BindProperty>
-          <Transform>
-            <Not/>
-          </Transform>
-        </Connection>
       </WidgetGroup>
+
+      <!-- Can't apply margin & padding to WOverview.
+          Due to qproperty-layoutSpacing, this spacer creates a 5px
+          gap between deck options and overview and FX assignment buttons -->
+      <WidgetGroup><Size>1f,0min</Size></WidgetGroup>
 
       <Overview>
         <TooltipId>waveform_overview</TooltipId>
+        <ObjectName>DeckOverview</ObjectName>
         <Group><Variable name="group"/></Group>
         <SizePolicy>me,me</SizePolicy>
         <BgColor><Variable name="DeckBackgroundColor"/></BgColor>
@@ -169,16 +171,15 @@
         </Connection>
       </Overview>
 
+      <!-- Can't apply margin & padding to WOverview.
+          Due to qproperty-layoutSpacing, this spacer creates a 5px
+          gap between deck options and overview and FX assignment buttons -->
+      <WidgetGroup><Size>1f,0min</Size></WidgetGroup>
+
       <WidgetGroup>
-        <ObjectName>ButtonGrid</ObjectName>
+        <ObjectName>DeckControlsGrid</ObjectName>
         <Layout>vertical</Layout>
-        <Connection>
-          <ConfigKey>[Master],show_4effectunits</ConfigKey>
-          <BindProperty>visible</BindProperty>
-          <Transform>
-            <Not/>
-          </Transform>
-        </Connection>
+        <SizePolicy>min,min</SizePolicy>
         <Children>
           <Template src="skin:fx_unit_group_assignment_button.xml">
             <SetVariable name="EffectUnit">1</SetVariable>
@@ -193,31 +194,17 @@
       </WidgetGroup>
 
       <WidgetGroup>
-        <Layout>vertical</Layout>
+        <Layout>horizontal</Layout>
         <Connection>
           <ConfigKey>[Master],show_4effectunits</ConfigKey>
           <BindProperty>visible</BindProperty>
         </Connection>
         <Children>
-          <WidgetGroup>
-            <ObjectName>ButtonGrid</ObjectName>
-            <Layout>horizontal</Layout>
-            <Children>
-              <Template src="skin:fx_unit_group_assignment_button.xml">
-                <SetVariable name="EffectUnit">1</SetVariable>
-                <SetVariable name="SourceType">deck</SetVariable>
-              </Template>
-
-              <Template src="skin:fx_unit_group_assignment_button.xml">
-                <SetVariable name="EffectUnit">2</SetVariable>
-                <SetVariable name="SourceType">deck</SetVariable>
-              </Template>
-            </Children>
-          </WidgetGroup>
 
           <WidgetGroup>
-            <ObjectName>ButtonGrid</ObjectName>
-            <Layout>horizontal</Layout>
+            <ObjectName>DeckControlsGrid</ObjectName>
+            <Layout>vertical</Layout>
+            <SizePolicy>min,min</SizePolicy>
             <Children>
               <Template src="skin:fx_unit_group_assignment_button.xml">
                 <SetVariable name="EffectUnit">3</SetVariable>

--- a/res/skins/Deere/hotcue.xml
+++ b/res/skins/Deere/hotcue.xml
@@ -8,11 +8,11 @@
 <Template>
   <!--Default grid Hotcue 1-4 -->
   <WidgetGroup>
-    <ObjectName>HotcueGrid</ObjectName>
     <Layout>vertical</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
       <WidgetGroup>
+        <ObjectName>HotcueGrid</ObjectName>
         <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
@@ -26,6 +26,7 @@
       </WidgetGroup>
 
       <WidgetGroup>
+        <ObjectName>HotcueGrid</ObjectName>
         <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
@@ -49,11 +50,11 @@
 
   <!--Extended grid Hotcue 1-8 -->
   <WidgetGroup>
-    <ObjectName>HotcueGridExtended</ObjectName>
     <Layout>vertical</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
       <WidgetGroup>
+        <ObjectName>HotcueGrid</ObjectName>
         <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
@@ -73,6 +74,7 @@
       </WidgetGroup>
 
       <WidgetGroup>
+        <ObjectName>HotcueGrid</ObjectName>
         <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -653,7 +653,7 @@ WWidget, QLabel {
 }
 
 #OverviewRow {
-  qproperty-layoutSpacing: 5;
+  qproperty-layoutSpacing: 2;
 }
 /* End spacing for Deck overview row */
 
@@ -682,16 +682,21 @@ WWidget, QLabel {
 
 /* Start spacing for Deck controls row (transport, beatgrid, looping, hotcue, vinylcontrol) */
 
-#HotcueGrid, #HotcueGridExtended,
-#VinylControlsContainer {
-  background-color: #333;
+#HotcueGrid,
+#VinylControlsGrid {
   padding: 1px;
   qproperty-layoutSpacing: 2;
 }
 
-#HotcueGrid WWidgetGroup, #HotcueGridExtended WWidgetGroup,
-#VinylControlsContainer WWidgetGroup {
+#HotcueGrid WWidgetGroup,
+#VinylControlsGrid WWidgetGroup,
+#DeckControlsGrid WWidgetGroup {
   qproperty-layoutSpacing: 2;
+}
+
+#DeckControlsGrid {
+  qproperty-layoutSpacing: 2;
+  padding: 0px;
 }
 
 WBeatSpinBox {
@@ -1077,6 +1082,7 @@ WNumberRate {
   qproperty-layoutAlignment: 'AlignTop';
   background-color: #333;
   margin: 0px 1.5px 3px 1.5px;
+  padding: 0px 0px 3px 0px;
 }
 
 #DeckMixer {

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -28,7 +28,7 @@
 }
 
 #CrossfaderContainer {
-  padding: 3px;
+  padding: 3px 3px 0px 3px;
 }
 
 #DeckTextRow {

--- a/res/skins/Deere/vinylcontrol.xml
+++ b/res/skins/Deere/vinylcontrol.xml
@@ -6,7 +6,7 @@
     <Children>
 
       <WidgetGroup>
-        <ObjectName>VinylControlsContainer</ObjectName>
+        <ObjectName>VinylControlsGrid</ObjectName>
         <Layout>vertical</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
@@ -35,7 +35,7 @@
       </WidgetGroup>
 
       <WidgetGroup>
-        <ObjectName>VinylControlsContainer</ObjectName>
+        <ObjectName>VinylControlsGrid</ObjectName>
         <Layout>vertical</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>


### PR DESCRIPTION
In this PR I fix the button grids. The layout spacing was not applied reliably, i.e. it was okay when starting with 4 hotcues, but after switching to 8 hotcues the buttons were sticking together. After restart spacing was okay but not woorking for 4 hotcues...

Fixed for
- deck controls
- hotcues
- FX assign buttons
- Vinyl controls

Also I moved the hotcue grid next to Play/Cue.

![deere-grid-fix-2017-12-30](https://user-images.githubusercontent.com/5934199/34461812-5438c7ee-ee35-11e7-98f6-bb9a21902734.png)


Happy new years eve to all of you!!