### PR TITLE
add zulip notification from apveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,6 @@ configuration:
 #  - release
 #  - debug
 environment:
-  ZULIP_EMAIL:
-    secure: sIPLydvxMgNTxZAUD/Ia97wxEX9phggY3TDPyidvWPgQrCqCPyaaA1iyNHf9J+amgW2mF4EQHgfI/XzfgmsvMg==
   ENVIRONMENTS_URL: https://downloads.mixxx.org/builds/buildserver/2.1.x-windows/
   ENVIRONMENTS_PATH: C:\mixxx-buildserver
   matrix:
@@ -79,11 +77,14 @@ deploy:
     name: downloads.mixxx.org
 
 notifications:
-  - provider: Email
-    to:
-      - '%ZULIP_EMAIL%'
-    subject: 'Build {{status}}'                  # optional
-    message: "{{message}}, {{commitId}}, ..."    # optional
+  - provider: Webhook
+    url: https://mixxx.zulipchat.com/api/v1/messages
+    method: POST
+    content_type: application/x-www-form-urlencoded
+    headers:
+      Authorization:
+        secure: 95cbVBcC4rogjE5VNdhuYm8cnjPF8+7SeQXySqcxAqrFZxK+/Kcn3Q2hRb2iZfUEKZ+EdCYwx7EbpZdSiZc5goAuJT+/QXXT/Ls+fzc+eSy4Sz1Ic5t2BjLhmYZLdnBL3uIVceNSb8GzYPQx0+xy7g==
+    on_build_success: true
+    on_build_failure: true
     on_build_status_changed: true
-  #- provider: Webhook  # Not suported by Zulip yet
-
+    body: "type=stream&to=appveyor&subject={{projectName}} Build {{buildVersion}} {{status}}&content=Build {{buildVersion}} {{status}}{{#failed}} :x:{{/failed}}{{#passed}} :y:{{/passed}} {{buildUrl}}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,4 +87,4 @@ notifications:
     on_build_success: true
     on_build_failure: true
     on_build_status_changed: true
-    body: "type=stream&to=appveyor&subject={{projectName}} Build {{buildVersion}} {{status}}&content=Build {{buildVersion}} {{status}}{{#failed}} :x:{{/failed}}{{#passed}} :y:{{/passed}} {{buildUrl}}"
+    body: "type=stream&to=appveyor&subject={{projectName}} Build {{buildVersion}} {{status}}&content=Build {{buildVersion}} {{status}}{{#isPullRequest}} (PR #{{pullRequestId}}) {{/isPullRequest}}{{#failed}} :x:{{/failed}}{{#passed}} :y:{{/passed}} {{buildUrl}}"


### PR DESCRIPTION
This PR adds notifications from appveyor to zulip.

It uses zulip rest API to publish messages.

Custom icons `:x:` and `:y:` - respectively failed and success - have been defined in zulip