### PR TITLE
[PoC] Speedup DB schema initialization and migration

### DIFF
--- a/res/mixxx.qrc
+++ b/res/mixxx.qrc
@@ -49,6 +49,7 @@
         <file>images/preferences/ic_preferences_waveforms.png</file>
         <file>images/templates/logo_mixxx.png</file>
         <file>schema.xml</file>
+        <file>schema_v0-to-v27.sql</file>
         <file>shaders/filteredsignal.frag</file>
         <file>shaders/passthrough.vert</file>
         <file>shaders/rgbsignal.frag</file>

--- a/res/schema_v0-to-v27.sql
+++ b/res/schema_v0-to-v27.sql
@@ -1,0 +1,152 @@
+---------------------------------------------------------------------------------------------------
+-- HOWTO: Create a schema migration/initialization file from a fresh mixxxdb.sqlite database
+-- 1) Export entire schema into file: echo -e '.output schema_v0-to-v<mixxxdb.version>.sql\n.schema' | sqlite3 "~/.mixxx/mixxxdb.sqlite"
+-- 2) Delete create statement(s) for system table(s) named 'sqlite_...'
+-- 3) Add insert statements for name/value pairs into table 'settings'
+---------------------------------------------------------------------------------------------------
+
+CREATE TABLE settings (
+        name TEXT UNIQUE NOT NULL,
+        value TEXT,
+        locked INTEGER DEFAULT 0,
+        hidden INTEGER DEFAULT 0);
+INSERT INTO settings (name, value) VALUES ('mixxx.schema.version', 27);
+INSERT INTO settings (name, value) VALUES ('mixxx.schema.min_compatible_version', 3);
+CREATE TABLE track_locations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        location varchar(512) UNIQUE,
+        filename varchar(512),
+        directory varchar(512),
+        filesize INTEGER,
+        fs_deleted INTEGER,
+        needs_verification INTEGER);
+CREATE TABLE LibraryHashes (
+        directory_path VARCHAR(256) primary key,
+        hash INTEGER,
+        directory_deleted INTEGER, needs_verification INTEGER DEFAULT 0);
+CREATE TABLE Playlists (
+        id INTEGER primary key,
+        name varchar(48),
+        position INTEGER,
+        hidden INTEGER DEFAULT 0 NOT NULL,
+        date_created datetime,
+        date_modified datetime, locked integer DEFAULT 0);
+CREATE TABLE PlaylistTracks (
+        id INTEGER primary key,
+        playlist_id INTEGER REFERENCES Playlists(id),
+        track_id INTEGER REFERENCES library(id),
+        position INTEGER, pl_datetime_added);
+CREATE TABLE cues (
+        id integer PRIMARY KEY AUTOINCREMENT,
+        track_id integer NOT NULL REFERENCES library(id),
+        type integer DEFAULT 0 NOT NULL,
+        position integer DEFAULT -1 NOT NULL,
+        length integer DEFAULT 0 NOT NULL,
+        hotcue integer DEFAULT -1 NOT NULL,
+        label text DEFAULT '' NOT NULL, color INTEGER DEFAULT 4294901760 NOT NULL);
+CREATE TABLE crates (
+        id integer PRIMARY KEY AUTOINCREMENT,
+        name varchar(48) UNIQUE NOT NULL,
+        count integer DEFAULT 0,
+        show integer DEFAULT 1, locked integer DEFAULT 0, autodj_source integer DEFAULT 0);
+CREATE TABLE crate_tracks (
+        crate_id integer NOT NULL REFERENCES crates(id),
+        track_id integer NOT NULL REFERENCES library(id),
+        UNIQUE (crate_id, track_id));
+CREATE TABLE library (
+        id INTEGER primary key AUTOINCREMENT,
+        artist varchar(64),
+        title varchar(64),
+        album varchar(64),
+        year varchar(16),
+        genre varchar(64),
+        tracknumber varchar(3),
+        location integer REFERENCES track_locations(location),
+        comment varchar(256),
+        url varchar(256),
+        duration float,
+        bitrate integer,
+        samplerate integer,
+        cuepoint integer,
+        bpm float,
+        wavesummaryhex blob,
+        channels integer,
+        datetime_added DEFAULT CURRENT_TIMESTAMP,
+        mixxx_deleted integer,
+        played integer,
+        header_parsed integer DEFAULT 0, filetype varchar(8) DEFAULT "?", replaygain float DEFAULT 0, timesplayed integer DEFAULT 0, rating integer DEFAULT 0, key varchar(8) DEFAULT "", beats BLOB, beats_version TEXT, composer varchar(64) DEFAULT "", bpm_lock INTEGER DEFAULT 0, beats_sub_version TEXT DEFAULT '', keys BLOB, keys_version TEXT, keys_sub_version TEXT, key_id INTEGER DEFAULT 0, grouping TEXT DEFAULT "", album_artist TEXT DEFAULT "", coverart_source INTEGER DEFAULT 0, coverart_type INTEGER DEFAULT 0, coverart_location TEXT DEFAULT "", coverart_hash INTEGER DEFAULT 0, replaygain_peak REAL DEFAULT -1.0, tracktotal TEXT DEFAULT '//');
+CREATE TABLE itunes_library (
+        id INTEGER primary key,
+        artist varchar(48), title varchar(48),
+        album varchar(48), year varchar(16),
+        genre varchar(32), tracknumber varchar(3),
+        location varchar(512),
+        comment varchar(60),
+        duration integer,
+        bitrate integer,
+        bpm integer,
+        rating integer, grouping TEXT DEFAULT "", album_artist TEXT DEFAULT "");
+CREATE TABLE itunes_playlists (
+        id INTEGER primary key,
+        name varchar(100) UNIQUE);
+CREATE TABLE itunes_playlist_tracks (
+        id INTEGER primary key AUTOINCREMENT,
+        playlist_id INTEGER REFERENCES itunes_playlist(id),
+        track_id INTEGER REFERENCES itunes_library(id), position INTEGER DEFAULT 0);
+CREATE TABLE traktor_library (
+        id INTEGER primary key AUTOINCREMENT,
+        artist varchar(48), title varchar(48),
+        album varchar(48), year varchar(16),
+        genre varchar(32), tracknumber varchar(3),
+        location varchar(512) UNIQUE,
+        comment varchar(60),
+        duration integer,
+        bitrate integer,
+        bpm float,
+        key varchar(6),
+        rating integer
+        );
+CREATE TABLE traktor_playlists (
+        id INTEGER primary key,
+        name varchar(100) UNIQUE
+        );
+CREATE TABLE traktor_playlist_tracks (
+        id INTEGER primary key AUTOINCREMENT,
+        playlist_id INTEGER REFERENCES traktor_playlist(id),
+        track_id INTEGER REFERENCES traktor_library(id)
+        , position INTEGER DEFAULT 0);
+CREATE TABLE rhythmbox_library (
+        id INTEGER primary key AUTOINCREMENT,
+        artist varchar(48), title varchar(48),
+        album varchar(48), year varchar(16),
+        genre varchar(32), tracknumber varchar(3),
+        location varchar(512) UNIQUE,
+        comment varchar(60),
+        duration integer,
+        bitrate integer,
+        bpm float,
+        key varchar(6),
+        rating integer
+        );
+CREATE TABLE rhythmbox_playlists (
+        id INTEGER primary key AUTOINCREMENT,
+        name varchar(100) UNIQUE
+        );
+CREATE TABLE rhythmbox_playlist_tracks (
+        id INTEGER primary key AUTOINCREMENT,
+        playlist_id INTEGER REFERENCES rhythmbox_playlist(id),
+        track_id INTEGER REFERENCES rhythmbox_library(id)
+        , position INTEGER DEFAULT 0);
+CREATE TABLE track_analysis (
+      id INTEGER primary key AUTOINCREMENT,
+      track_id INTEGER NOT NULL REFERENCES track_locations(id),
+      type varchar(512),
+      description varchar(1024),
+      version varchar(512),
+      created DEFAULT CURRENT_TIMESTAMP,
+      data_checksum varchar(512)
+    );
+CREATE INDEX track_analysis_track_id_index ON track_analysis (track_id);
+CREATE TABLE directories (
+        directory TEXT UNIQUE
+      );

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -8,7 +8,7 @@
 
 // The schema XML is baked into the binary via Qt resources.
 //static
-const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
+const QString MixxxDb::kDefaultSchemaBaseName(":/schema");
 
 //static
 const int MixxxDb::kRequiredSchemaVersion = 27;
@@ -38,7 +38,7 @@ MixxxDb::MixxxDb(
 
 bool MixxxDb::initDatabaseSchema(
         const QSqlDatabase& database,
-        const QString& schemaFile,
+        const QString& schemaBaseName,
         int schemaVersion) {
     QString okToExit = tr("Click OK to exit.");
     QString upgradeFailed = tr("Cannot upgrade database schema");
@@ -48,7 +48,7 @@ bool MixxxDb::initDatabaseSchema(
     QString helpEmail = tr("For help with database issues contact:") + "\n" +
                            "mixxx-devel@lists.sourceforge.net";
 
-    switch (SchemaManager(database).upgradeToSchemaVersion(schemaFile, schemaVersion)) {
+    switch (SchemaManager(database).upgradeToSchemaVersion(schemaBaseName, schemaVersion)) {
         case SchemaManager::Result::CurrentVersion:
         case SchemaManager::Result::UpgradeSucceeded:
         case SchemaManager::Result::NewerVersionBackwardsCompatible:

--- a/src/database/mixxxdb.h
+++ b/src/database/mixxxdb.h
@@ -13,13 +13,13 @@ class MixxxDb : public QObject {
     Q_OBJECT
 
   public:
-    static const QString kDefaultSchemaFile;
+    static const QString kDefaultSchemaBaseName;
 
     static const int kRequiredSchemaVersion;
 
     static bool initDatabaseSchema(
             const QSqlDatabase& database,
-            const QString& schemaFile = kDefaultSchemaFile,
+            const QString& schemaBaseName = kDefaultSchemaBaseName,
             int schemaVersion = kRequiredSchemaVersion);
 
     explicit MixxxDb(

--- a/src/database/schemamanager.h
+++ b/src/database/schemamanager.h
@@ -29,7 +29,7 @@ class SchemaManager {
     bool isBackwardsCompatibleWithVersion(int targetVersion) const;
 
     Result upgradeToSchemaVersion(
-            const QString& schemaFilename,
+            const QString& schemaBaseName,
             int targetVersion);
 
   private:

--- a/src/test/schemamanager_test.cpp
+++ b/src/test/schemamanager_test.cpp
@@ -35,14 +35,14 @@ TEST_F(SchemaManagerTest, CanUpgradeFreshDatabaseToRequiredVersion) {
     {
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-                MixxxDb::kDefaultSchemaFile, MixxxDb::kRequiredSchemaVersion);
+                MixxxDb::kDefaultSchemaBaseName, MixxxDb::kRequiredSchemaVersion);
         EXPECT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
     }
     // Subsequent upgrade(s)
     {
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-                MixxxDb::kDefaultSchemaFile, MixxxDb::kRequiredSchemaVersion);
+                MixxxDb::kDefaultSchemaBaseName, MixxxDb::kRequiredSchemaVersion);
         EXPECT_EQ(SchemaManager::Result::CurrentVersion, result);
     }
 }
@@ -60,7 +60,7 @@ TEST_F(SchemaManagerTest, BackwardsCompatibleVersion) {
         // Upgrade to version 1 to get the settings table.
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-                MixxxDb::kDefaultSchemaFile, 1);
+                MixxxDb::kDefaultSchemaBaseName, 1);
         EXPECT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
 
         SettingsDAO settings(dbConnection());
@@ -76,7 +76,7 @@ TEST_F(SchemaManagerTest, BackwardsCompatibleVersion) {
 
     SchemaManager schemaManager(dbConnection());
     SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-            MixxxDb::kDefaultSchemaFile, MixxxDb::kRequiredSchemaVersion);
+            MixxxDb::kDefaultSchemaBaseName, MixxxDb::kRequiredSchemaVersion);
     EXPECT_EQ(SchemaManager::Result::NewerVersionBackwardsCompatible, result);
 }
 
@@ -86,7 +86,7 @@ TEST_F(SchemaManagerTest, BackwardsIncompatibleVersion) {
         // Upgrade to version 1 to get the settings table.
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-                MixxxDb::kDefaultSchemaFile, 1);
+                MixxxDb::kDefaultSchemaBaseName, 1);
         EXPECT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
 
         SettingsDAO settings(dbConnection());
@@ -102,7 +102,7 @@ TEST_F(SchemaManagerTest, BackwardsIncompatibleVersion) {
 
     SchemaManager schemaManager(dbConnection());
     SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-            MixxxDb::kDefaultSchemaFile, MixxxDb::kRequiredSchemaVersion);
+            MixxxDb::kDefaultSchemaBaseName, MixxxDb::kRequiredSchemaVersion);
     EXPECT_EQ(SchemaManager::Result::NewerVersionIncompatible, result);
 }
 
@@ -112,7 +112,7 @@ TEST_F(SchemaManagerTest, FailedUpgrade) {
         // Upgrade to version 3 to get the modern library table.
         SchemaManager schemaManager(dbConnection());
         SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-                MixxxDb::kDefaultSchemaFile, 3);
+                MixxxDb::kDefaultSchemaBaseName, 3);
         EXPECT_EQ(SchemaManager::Result::UpgradeSucceeded, result);
     }
 
@@ -123,6 +123,6 @@ TEST_F(SchemaManagerTest, FailedUpgrade) {
 
     SchemaManager schemaManager(dbConnection());
     SchemaManager::Result result = schemaManager.upgradeToSchemaVersion(
-            MixxxDb::kDefaultSchemaFile, MixxxDb::kRequiredSchemaVersion);
+            MixxxDb::kDefaultSchemaBaseName, MixxxDb::kRequiredSchemaVersion);
     EXPECT_EQ(SchemaManager::Result::UpgradeFailed, result);
 }


### PR DESCRIPTION
Using plain .sql text files would be simpler, is modular, and provides more flexibility, see Flyway. The only minor drawback is that we have to deal with implicit character encodings, though.

As a proof of concept I exported (and slightly edited) an SQL script that initializes a newly created, empty database at version 0 to our current version 27 in a single step/transaction. Execution time for running the tests locally has been reduced from 40 sec to 20 sec. OS X build on Travis finished successfully in less than 40 min.

Both migration mechanisms are enabled. The existing XML migration is still used as a fallback if no path composed of SQL files for reaching the target version exists. The algorithm for finding such a path is very simple, just migrate the current to the highest available version and repeat until reaching the target version or no migration file is available. By providing SQL scripts (both incremental and cumulative) for new versions the XML variant could be phased out over time. The cumulative script only needs to be provided for the current version and should be generated eventually.

This is a fully functional prototype. Suggestions are welcome! We don't need to implement each and every possible feature and automation tasks at once. Just lay the foundations to enable future extensions.