### PR TITLE
fix crash after starting up with multiple input channels routed to an effect unit

### DIFF
--- a/src/effects/effectchain.h
+++ b/src/effects/effectchain.h
@@ -123,7 +123,6 @@ class EffectChain : public QObject {
     QList<EffectPointer> m_effects;
     EngineEffectChain* m_pEngineEffectChain;
     bool m_bAddedToEngine;
-    EffectStatesMapArray m_effectStatesMapArray;
 
     DISALLOW_COPY_AND_ASSIGN(EffectChain);
 };

--- a/src/effects/effectprocessor.h
+++ b/src/effects/effectprocessor.h
@@ -108,17 +108,23 @@ class EffectProcessorImpl : public EffectProcessor {
         if (kEffectDebugOutput) {
             qDebug() << "~EffectProcessorImpl" << this;
         }
+        int inputChannelHandleNumber = 0;
         for (ChannelHandleMap<EffectSpecificState*>& outputsMap : m_channelStateMatrix) {
+            int outputChannelHandleNumber = 0;
             for (EffectSpecificState* pState : outputsMap) {
                 VERIFY_OR_DEBUG_ASSERT(pState != nullptr) {
                     continue;
                 }
                 if (kEffectDebugOutput) {
-                    qDebug() << "~EffectProcessorImpl deleting state" << pState;
+                    qDebug() << "~EffectProcessorImpl deleting EffectState" << pState
+                             << "for input ChannelHandle(" << inputChannelHandleNumber << ")"
+                             << "and output ChannelHandle(" << outputChannelHandleNumber << ")";
                 }
                 delete pState;
+                outputChannelHandleNumber++;
             }
             outputsMap.clear();
+            inputChannelHandleNumber++;
         }
         m_channelStateMatrix.clear();
     };

--- a/src/engine/effects/message.h
+++ b/src/engine/effects/message.h
@@ -71,6 +71,18 @@ struct EffectsRequest {
 #undef CLEAR_STRUCT
     }
 
+    ~EffectsRequest() {
+        if (type == ENABLE_EFFECT_CHAIN_FOR_INPUT_CHANNEL) {
+            VERIFY_OR_DEBUG_ASSERT(EnableInputChannelForChain.pEffectStatesMapArray != nullptr) {
+                return;
+            }
+            // This only deletes the container used to passed the EffectStates
+            // to EffectProcessorImpl. The EffectStates are managed by
+            // EffectProcessorImpl.
+            delete EnableInputChannelForChain.pEffectStatesMapArray;
+        }
+    }
+
     MessageType type;
     qint64 request_id;
 

--- a/src/engine/effects/message.h
+++ b/src/engine/effects/message.h
@@ -71,6 +71,8 @@ struct EffectsRequest {
 #undef CLEAR_STRUCT
     }
 
+    // This is called from the main thread by EffectsManager after receiving a
+    // response from EngineEffectsManager in the audio engine thread.
     ~EffectsRequest() {
         if (type == ENABLE_EFFECT_CHAIN_FOR_INPUT_CHANNEL) {
             VERIFY_OR_DEBUG_ASSERT(EnableInputChannelForChain.pEffectStatesMapArray != nullptr) {


### PR DESCRIPTION
This fixes a crash deleting EffectStates after starting up with an effect unit assigned to multiple input channels. EffectChain::enableForInputChannel kept reusing the same array for EffectStates and putting a pointer to this on the effects MessagePipe. That assumed that the engine had a chance to process the message to load the states by calling EffectProcessorImpl::loadStatesForInputChannel before the next call to EffectChain::enableForInputChannel. On startup, before the engine starts, this assumption is not true. The result was that EffectProcessorImpl ended up storing pointers to the same
EffectStates for multiple input channels. This caused a crash when ~EffectProcessorImpl tried to delete the EffectStates for the second input channel because the EffectState had already been deleted when
deleting the EffectStates for the first input channel.

Fixes https://bugs.launchpad.net/mixxx/+bug/1740531