### PR TITLE
Deere :: quick fix for squeezed samplers

### DIFF
--- a/res/skins/Deere/sample_decks.xml
+++ b/res/skins/Deere/sample_decks.xml
@@ -150,8 +150,13 @@
          WidgetStack with a 'fixed' size policy makes the group track the
          minimum size of the current stack widget. -->
     <SizePolicy>me,f</SizePolicy>
-
     <Children>
+      <!-- Although the minimum size is now tracked correctly, the border
+          applied via qss is not added to child widgets size but substracted
+          from the WidgetStack's usable height.
+          Creating the border with fixed-size WidgetGroups solves this. -->
+      <WidgetGroup><Size>-1me,2f</Size></WidgetGroup>
+
       <WidgetStack currentpage="[Deere],sampler_row_current" persist="true">
         <ObjectName>SampleDecksContainer</ObjectName>
         <NextControl>[Deere],sampler_row_next</NextControl>
@@ -376,6 +381,8 @@
 
         </Children>
       </WidgetStack>
+
+      <WidgetGroup><Size>-1me,2f</Size></WidgetGroup>
 
     </Children>
   </WidgetGroup>

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -131,9 +131,7 @@ TEST1 {
 }
 
 #SampleDecksContainer {
-  border-color: #222;
-  border-style: solid;
-  border-width: 1px 0px 2px 0px;
+  border: 0px;
 }
 
 #SamplerRows {
@@ -633,6 +631,10 @@ QScrollBar::sub-line:horizontal, QScrollBar::sub-line:vertical {
 #Mixxx {
   background-color: black;
   font-family: "Open Sans";
+}
+
+#WaveformSplitter {
+  background-color: #222;
 }
 
 WWidget, QLabel {


### PR DESCRIPTION
Although the size of sampler rows is tracked correctly, the border applied via qss is not added to child widgets size but subtracted from the WidgetStack's usable height.
This squeezes the sampler rows perceptible unless all rows are enabled.

Creating the border with fixed-size WidgetGroups solves this.

before
![deere-sampler-fix-2018-01-09](https://user-images.githubusercontent.com/5934199/34717146-4d1b3e48-f532-11e7-82d7-7021da1b87c2.png)

after
![deere-sampler-fix-2018-01-09_fixed](https://user-images.githubusercontent.com/5934199/34717156-53ac1c5a-f532-11e7-9ead-307720a97a6b.png)
