### PR TITLE
Disable  EngineBufferE2ETest.KeylockReverseTest (lp1740697)

### DIFF
--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -329,6 +329,10 @@ TEST_F(EngineBufferE2ETest, DISABLED_RubberbandToggleTest) {
 TEST_F(EngineBufferE2ETest, KeylockReverseTest) {
     // Confirm that when toggling reverse while keylock is on, interpolation
     // is smooth.
+    ControlObject::set(ConfigKey("[Master]", "keylock_engine"),
+                       static_cast<double>(EngineBuffer::SOUNDTOUCH));
+    ControlObject::set(ConfigKey(m_sGroup1, "keylockMode"),
+                       0.0);
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), 0.5);
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     ControlObject::set(ConfigKey(m_sGroup1, "keylock"), 1.0);

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -326,7 +326,12 @@ TEST_F(EngineBufferE2ETest, DISABLED_RubberbandToggleTest) {
                                 kProcessBufferSize, "RubberbandTestRegular");
 }
 
-TEST_F(EngineBufferE2ETest, KeylockReverseTest) {
+// DISABLED: This test is too dependent on the sound touch library version.
+// NOTE(uklotzde, 2018-01-10): We have also seen spurious failures on the
+// Linux build server under high load. These failures might by caused by
+// delayed asynchronous reads from CachingReader. The corresponding chunks
+// will be filled with 0-samples by the engine buffer scaler.
+TEST_F(EngineBufferE2ETest, DISABLED_KeylockReverseTest) {
     // Confirm that when toggling reverse while keylock is on, interpolation
     // is smooth.
     ControlObject::set(ConfigKey("[Master]", "keylock_engine"),


### PR DESCRIPTION
Not really a fix. As a quick workaround I disabled the failing test like all other keylock tests.

Control values have not been set explicitly before the test, but I suppose that this didn't cause the failures.

In the long term we need to add a synchronous test execution mode to CachingReader to avoid failures caused by delayed reading of requested sampled under high load.