### PR TITLE
Avoid printing '\0' to stderr

### DIFF
--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -37,7 +37,7 @@ bool g_debugAssertBreak = false;
 inline void writeToLog(const QByteArray& message, bool shouldPrint,
                        bool shouldFlush) {
     if (shouldPrint) {
-        fwrite(message.constData(), sizeof(char), message.size() + 1, stderr);
+        fwrite(message.constData(), sizeof(char), message.size(), stderr);
     }
 
     QMutexLocker locker(&g_mutexLogfile);


### PR DESCRIPTION
The additional + 1 prints the terminating '\0' to stderr. 
This cause that Eclipse is not able to catch the output. 
Hopefully it fixes also some other logging issues. 

For reference the fputs implementation: 
https://android.googlesource.com/platform/bionic/+/ics-mr0/libc/stdio/fputs.c
https://android.googlesource.com/platform/bionic/+/ics-mr0/libc/stdio/fwrite.c