### PR TITLE
lp1742541: Improve import and update of track metadata + cover art from file tags

### DIFF
--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -319,7 +319,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         return MetadataSource::importTrackMetadataAndCoverImage(pTrackMetadata, pCoverImage);
     }
 
-    kLogger.warning()
+    kLogger.debug()
             << "No track metadata or cover art found"
             << "in file" << m_fileName
             << "with type" << m_fileType;

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -47,23 +47,28 @@ class AiffFile: public TagLib::RIFF::AIFF::File {
         : TagLib::RIFF::AIFF::File(fileName) {
     }
 
-    void importTrackMetadataFromTextChunks(TrackMetadata* pTrackMetadata) /*non-const*/ {
+    bool importTrackMetadataFromTextChunks(TrackMetadata* pTrackMetadata) /*non-const*/ {
         if (pTrackMetadata == nullptr) {
-            return; // nothing to do
+            return false; // nothing to do
         }
+        bool imported = false;
         for(unsigned int i = 0; i < chunkCount(); ++i) {
             const TagLib::ByteVector chunkId(TagLib::RIFF::AIFF::File::chunkName(i));
             if (chunkId == "NAME") {
                 pTrackMetadata->refTrackInfo().setTitle(decodeChunkText(
                         TagLib::RIFF::AIFF::File::chunkData(i)));
+                imported = true;
             } else if (chunkId == "AUTH") {
                 pTrackMetadata->refTrackInfo().setArtist(decodeChunkText(
                         TagLib::RIFF::AIFF::File::chunkData(i)));
+                imported = true;
             } else if (chunkId == "ANNO") {
                 pTrackMetadata->refTrackInfo().setComment(decodeChunkText(
                         TagLib::RIFF::AIFF::File::chunkData(i)));
+                imported = true;
             }
         }
+        return imported;
     }
 
   private:
@@ -87,13 +92,13 @@ QDateTime getMetadataSynchronized(QFileInfo fileInfo) {
 } // anonymous namespace
 
 std::pair<MetadataSourceTagLib::ImportResult, QDateTime>
-MetadataSourceTagLib::afterImportSucceeded() const {
-    return std::make_pair(ImportResult::Succeeded, getMetadataSynchronized(QFileInfo(m_fileName)));
+MetadataSourceTagLib::afterImport(ImportResult importResult) const {
+    return std::make_pair(importResult, getMetadataSynchronized(QFileInfo(m_fileName)));
 }
 
 std::pair<MetadataSourceTagLib::ExportResult, QDateTime>
-MetadataSourceTagLib::afterExportSucceeded() const {
-    return std::make_pair(ExportResult::Succeeded, getMetadataSynchronized(QFileInfo(m_fileName)));
+MetadataSourceTagLib::afterExport(ExportResult exportResult) const {
+    return std::make_pair(exportResult, getMetadataSynchronized(QFileInfo(m_fileName)));
 }
 
 std::pair<MetadataSource::ImportResult, QDateTime>
@@ -105,7 +110,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
                 << "Nothing to import"
                 << "from file" << m_fileName
                 << "with type" << m_fileType;
-        return std::make_pair(MetadataSource::ImportResult::Unavailable, QDateTime());
+        return afterImport(ImportResult::Unavailable);
     }
     kLogger.trace() << "Importing"
             << ((pTrackMetadata && pCoverImage) ? "track metadata and cover art" : (pTrackMetadata ? "track metadata" : "cover art"))
@@ -128,20 +133,20 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
             if (pID3v2Tag) {
                 taglib::importTrackMetadataFromID3v2Tag(pTrackMetadata, *pID3v2Tag);
                 taglib::importCoverImageFromID3v2Tag(pCoverImage, *pID3v2Tag);
-                return afterImportSucceeded();
+                return afterImport(ImportResult::Succeeded);
             } else {
                 const TagLib::APE::Tag* pAPETag =
                         taglib::hasAPETag(file) ? file.APETag() : nullptr;
                 if (pAPETag) {
                     taglib::importTrackMetadataFromAPETag(pTrackMetadata, *pAPETag);
                     taglib::importCoverImageFromAPETag(pCoverImage, *pAPETag);
-                    return afterImportSucceeded();
+                    return afterImport(ImportResult::Succeeded);
                 } else {
                     // fallback
                     const TagLib::Tag* pTag(file.tag());
                     if (pTag) {
                         taglib::importTrackMetadataFromTag(pTrackMetadata, *pTag);
-                        return afterImportSucceeded();
+                        return afterImport(ImportResult::Succeeded);
                     }
                 }
             }
@@ -156,13 +161,13 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
             if (pMP4Tag) {
                 taglib::importTrackMetadataFromMP4Tag(pTrackMetadata, *pMP4Tag);
                 taglib::importCoverImageFromMP4Tag(pCoverImage, *pMP4Tag);
-                return afterImportSucceeded();
+                return afterImport(ImportResult::Succeeded);
             } else {
                 // fallback
                 const TagLib::Tag* pTag(file.tag());
                 if (pTag) {
                     taglib::importTrackMetadataFromTag(pTrackMetadata, *pTag);
-                    return afterImportSucceeded();
+                    return afterImport(ImportResult::Succeeded);
                 }
             }
         }
@@ -183,20 +188,20 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
             if (pXiphComment) {
                 taglib::importTrackMetadataFromVorbisCommentTag(pTrackMetadata, *pXiphComment);
                 taglib::importCoverImageFromVorbisCommentTag(pCoverImage, *pXiphComment);
-                return afterImportSucceeded();
+                return afterImport(ImportResult::Succeeded);
             } else {
                 const TagLib::ID3v2::Tag* pID3v2Tag =
                         taglib::hasID3v2Tag(file) ? file.ID3v2Tag() : nullptr;
                 if (pID3v2Tag) {
                     taglib::importTrackMetadataFromID3v2Tag(pTrackMetadata, *pID3v2Tag);
                     taglib::importCoverImageFromID3v2Tag(pCoverImage, *pID3v2Tag);
-                    return afterImportSucceeded();
+                    return afterImport(ImportResult::Succeeded);
                 } else {
                     // fallback
                     const TagLib::Tag* pTag(file.tag());
                     if (pTag) {
                         taglib::importTrackMetadataFromTag(pTrackMetadata, *pTag);
-                        return afterImportSucceeded();
+                        return afterImport(ImportResult::Succeeded);
                     }
                 }
             }
@@ -211,13 +216,13 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
             if (pXiphComment) {
                 taglib::importTrackMetadataFromVorbisCommentTag(pTrackMetadata, *pXiphComment);
                 taglib::importCoverImageFromVorbisCommentTag(pCoverImage, *pXiphComment);
-                return afterImportSucceeded();
+                return afterImport(ImportResult::Succeeded);
             } else {
                 // fallback
                 const TagLib::Tag* pTag(file.tag());
                 if (pTag) {
                     taglib::importTrackMetadataFromTag(pTrackMetadata, *pTag);
-                    return afterImportSucceeded();
+                    return afterImport(ImportResult::Succeeded);
                 }
             }
         }
@@ -232,13 +237,13 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
             if (pXiphComment) {
                 taglib::importTrackMetadataFromVorbisCommentTag(pTrackMetadata, *pXiphComment);
                 taglib::importCoverImageFromVorbisCommentTag(pCoverImage, *pXiphComment);
-                 return afterImportSucceeded();
+                 return afterImport(ImportResult::Succeeded);
             } else {
                 // fallback
                 const TagLib::Tag* pTag(file.tag());
                 if (pTag) {
                     taglib::importTrackMetadataFromTag(pTrackMetadata, *pTag);
-                    return afterImportSucceeded();
+                    return afterImport(ImportResult::Succeeded);
                 }
             }
         }
@@ -254,13 +259,13 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
             if (pAPETag) {
                 taglib::importTrackMetadataFromAPETag(pTrackMetadata, *pAPETag);
                 taglib::importCoverImageFromAPETag(pCoverImage, *pAPETag);
-                return afterImportSucceeded();
+                return afterImport(ImportResult::Succeeded);
             } else {
                 // fallback
                 const TagLib::Tag* pTag(file.tag());
                 if (pTag) {
                     taglib::importTrackMetadataFromTag(pTrackMetadata, *pTag);
-                    return afterImportSucceeded();
+                    return afterImport(ImportResult::Succeeded);
                 }
             }
         }
@@ -279,13 +284,13 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
             if (pID3v2Tag) {
                 taglib::importTrackMetadataFromID3v2Tag(pTrackMetadata, *pID3v2Tag);
                 taglib::importCoverImageFromID3v2Tag(pCoverImage, *pID3v2Tag);
-                return afterImportSucceeded();
+                return afterImport(ImportResult::Succeeded);
             } else {
                 // fallback
                 const TagLib::RIFF::Info::Tag* pTag = file.InfoTag();
                 if (pTag) {
                     taglib::importTrackMetadataFromRIFFTag(pTrackMetadata, *pTag);
-                    return afterImportSucceeded();
+                    return afterImport(ImportResult::Succeeded);
                 }
             }
         }
@@ -303,11 +308,13 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
             if (pID3v2Tag) {
                 taglib::importTrackMetadataFromID3v2Tag(pTrackMetadata, *pID3v2Tag);
                 taglib::importCoverImageFromID3v2Tag(pCoverImage, *pID3v2Tag);
+                return afterImport(ImportResult::Succeeded);
             } else {
                 // fallback
-                file.importTrackMetadataFromTextChunks(pTrackMetadata);
+                if (file.importTrackMetadataFromTextChunks(pTrackMetadata)) {
+                    return afterImport(ImportResult::Succeeded);
+                }
             }
-            return afterImportSucceeded();
         }
         break;
     }
@@ -316,14 +323,14 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
             << "Cannot import track metadata"
             << "from file" << m_fileName
             << "with unknown or unsupported type" << m_fileType;
-        return MetadataSource::importTrackMetadataAndCoverImage(pTrackMetadata, pCoverImage);
+        return afterImport(ImportResult::Failed);
     }
 
     kLogger.debug()
             << "No track metadata or cover art found"
             << "in file" << m_fileName
             << "with type" << m_fileType;
-    return MetadataSource::importTrackMetadataAndCoverImage(pTrackMetadata, pCoverImage);
+    return afterImport(ImportResult::Unavailable);
 }
 
 namespace {
@@ -794,7 +801,7 @@ MetadataSourceTagLib::exportTrackMetadata(
             << "into file" << m_fileName
             << "with unknown or unsupported type"
             << m_fileType;
-        return MetadataSource::exportTrackMetadata(trackMetadata);
+        return afterExport(ExportResult::Unsupported);
     }
 
     if (pTagSaver->hasModifiedTags()) {
@@ -803,14 +810,14 @@ MetadataSourceTagLib::exportTrackMetadata(
             pTagSaver.reset();
             // Now we can safely replace the original file with the temporary file
             if (safelyWritableFile.commit()) {
-                return afterExportSucceeded();
+                return afterExport(ExportResult::Succeeded);
             }
         }
         kLogger.warning() << "Failed to save tags of file" << m_fileName;
     } else {
         kLogger.warning() << "Failed to modify tags of file" << m_fileName;
     }
-    return std::make_pair(ExportResult::Failed, QDateTime());
+    return afterExport(ExportResult::Failed);
 }
 
 } // namespace mixxx

--- a/src/sources/metadatasourcetaglib.h
+++ b/src/sources/metadatasourcetaglib.h
@@ -30,8 +30,8 @@ class MetadataSourceTagLib: public MetadataSource {
             const TrackMetadata& trackMetadata) const override;
 
   private:
-    std::pair<ImportResult, QDateTime> afterImportSucceeded() const;
-    std::pair<ExportResult, QDateTime> afterExportSucceeded() const;
+    std::pair<ImportResult, QDateTime> afterImport(ImportResult importResult) const;
+    std::pair<ExportResult, QDateTime> afterExport(ExportResult exportResult) const;
 
     QString m_fileName;
     taglib::FileType m_fileType;

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -390,14 +390,16 @@ namespace {
     // or "artist_-_title.xxx".
     // This function does not overwrite any existing (non-empty) artist
     // and title fields!
-    void parseMetadataFromFileName(mixxx::TrackMetadata* pTrackMetadata, QString fileName) {
+    bool parseMetadataFromFileName(mixxx::TrackMetadata* pTrackMetadata, QString fileName) {
         fileName.replace("_", " ");
         QString titleWithFileType;
+        bool parsed = false;
         if (fileName.count('-') == 1) {
             if (pTrackMetadata->getTrackInfo().getArtist().isEmpty()) {
                 const QString artist(fileName.section('-', 0, 0).trimmed());
                 if (!artist.isEmpty()) {
                     pTrackMetadata->refTrackInfo().setArtist(artist);
+                    parsed = true;
                 }
             }
             titleWithFileType = fileName.section('-', 1, 1).trimmed();
@@ -408,8 +410,10 @@ namespace {
             const QString title(titleWithFileType.section('.', 0, -2).trimmed());
             if (!title.isEmpty()) {
                 pTrackMetadata->refTrackInfo().setTitle(title);
+                parsed = true;
             }
         }
+        return parsed;
     }
 } // anonymous namespace
 
@@ -422,97 +426,119 @@ void SoundSourceProxy::updateTrackFromSource(
         return; // abort
     }
     if (!m_pSoundSource) {
-        kLogger.warning() << "Unable to parse tags from unsupported file type"
-                 << getUrl().toString();
+        kLogger.warning()
+                << "Unable to update track from unsupported file type"
+                << getUrl().toString();
         return; // abort
     }
 
-    // Use the existing trackMetadata as default values. Otherwise
-    // existing values in the library will be overwritten with
-    // empty values if the corresponding file tags are missing.
-    // Depending on the file type some kind of tags might even
-    // not be supported at all and those would get lost!
+    // Initialize or update the file/format as reported by the associated
+    // SoundSource. This operation might already set the dirty flag of the
+    // track object, but we don't care.
+    m_pTrack->setType(m_pSoundSource->getType());
+
+    // Use the existing track metadata as default values. Otherwise
+    // existing values in the library would be overwritten with empty
+    // values if the corresponding file tags are missing. Depending
+    // on the file type some kind of tags might even not be supported
+    // at all and this information would get lost entirely otherwise!
     mixxx::TrackMetadata trackMetadata;
     bool metadataSynchronized = false;
     m_pTrack->getTrackMetadata(&trackMetadata, &metadataSynchronized);
-    // Cast away the enriched track location by explicitly slicing the
-    // returned CoverInfo to CoverInfoRelative
-    const CoverInfoRelative coverInfo(m_pTrack->getCoverInfo());
-    QImage coverImg;
-    DEBUG_ASSERT(coverImg.isNull());
-    QImage* pCoverImg;
-    // If the file tags have already been parsed once, both track metadata
-    // and cover art should not be updated implicitly.
-    if (metadataSynchronized) {
-        if (importTrackMetadataMode == ImportTrackMetadataMode::Once) {
-            kLogger.info() << "Skip parsing of track metadata and cover art from file"
-                     << getUrl().toString();
-            return; // abort
-        }
-        // Only parse and update cover art from file tags if the track has
-        // no cover art or if cover art has already been loaded from file tags.
-        if (((coverInfo.type == CoverInfo::METADATA) ||
-                (coverInfo.type == CoverInfo::NONE)) &&
-                (coverInfo.source != CoverInfo::USER_SELECTED)) {
-            pCoverImg = &coverImg;
-        } else {
-            pCoverImg = nullptr;
-            kLogger.info() << "Skip parsing of cover art from file"
-                       << getUrl().toString();
-        }
-    } else {
-        // If the file tags have never been parsed before it doesn't matter
-        // if the track is marked as dirty or not. In this case the track
-        // object has just been created.
-        pCoverImg = &coverImg;
-    }
-
-    // Parse the tags stored in the audio file
-    const auto metadataImported =
-            m_pSoundSource->importTrackMetadataAndCoverImage(
-                    &trackMetadata, pCoverImg);
-    if (metadataImported.first != mixxx::MetadataSource::ImportResult::Succeeded) {
-        kLogger.debug() << "Failed to parse track metadata and/or cover art from file"
-                   << getUrl().toString();
+    // If the file tags have already been parsed at least once, the
+    // existing track metadata should not be updated implicitly, i.e.
+    // if the user did not explicitly choose to (re-)import metadata
+    // explicitly from this file.
+    if (metadataSynchronized &&
+        (importTrackMetadataMode == ImportTrackMetadataMode::Once)) {
+        kLogger.debug()
+                << "Skip importing of track metadata and embedded cover art from file"
+                << getUrl().toString();
         return; // abort
     }
 
-    if (!metadataSynchronized &&
-            (trackMetadata.getTrackInfo().getArtist().isEmpty() ||
-                    trackMetadata.getTrackInfo().getTitle().isEmpty())) {
-        // Fallback: If Artist or title fields are blank initially try to parse
-        // them from the file name.
-        // TODO(rryan): Should we re-visit this decision?
-        parseMetadataFromFileName(&trackMetadata, m_pTrack->getFileInfo().fileName());
-    }
+    // Cast away the enriched track location by explicitly slicing the
+    // returned CoverInfo to CoverInfoRelative
+    const CoverInfoRelative coverInfo(m_pTrack->getCoverInfo());
 
-    // Until this point the track object has not been modified.
-    // Now we start updating it...
-
-    // Initialize or update the file/format as reported by the
-    // responsible SoundSource
-    m_pTrack->setType(m_pSoundSource->getType());
-
-    if (metadataSynchronized) {
-        kLogger.info() << "Importing track metadata from file"
-                 << getUrl().toString();
+    QImage coverImg;
+    DEBUG_ASSERT(coverImg.isNull());
+    QImage* pCoverImg; // pointer is also used as a flag
+    // Embedded cover art is imported together with the track's metadata.
+    // But only if the user has not selected external cover art for this
+    // track!
+    if (((coverInfo.type == CoverInfo::METADATA) ||
+            (coverInfo.type == CoverInfo::NONE)) &&
+            (coverInfo.source != CoverInfo::USER_SELECTED)) {
+        // Import embedded cover art
+        pCoverImg = &coverImg;
     } else {
-        kLogger.info() << "Initializing track metadata from file"
-                 << getUrl().toString();
+        kLogger.debug()
+                << "Skip importing of embedded cover art from file"
+                << getUrl().toString();
+        // Continue with nullptr
+        pCoverImg = nullptr;
     }
-    DEBUG_ASSERT(!metadataImported.second.isNull());
+
+    // Parse the tags stored in the audio file
+    auto metadataImported =
+            m_pSoundSource->importTrackMetadataAndCoverImage(
+                    &trackMetadata, pCoverImg);
+    if (metadataImported.first == mixxx::MetadataSource::ImportResult::Failed) {
+        kLogger.warning()
+                << "Failed to import track metadata"
+                << (pCoverImg ? "and embedded cover art" : "")
+                << "from file"
+                << getUrl().toString();
+        // Continue for now, but the abort may follow shortly if the
+        // track already has metadata (see below)
+    }
+    if (metadataSynchronized) {
+        // Metadata has been synchronized successfully at least
+        // once in the past. Only overwrite this information if
+        // new data has actually been imported, otherwise abort
+        // and preserve the existing data!
+        if (metadataImported.first == mixxx::MetadataSource::ImportResult::Succeeded) {
+            kLogger.info()
+                    << "Updating track metadata"
+                    << (pCoverImg ? "and embedded cover art" : "")
+                    << "from file"
+                    << getUrl().toString();
+        } else {
+            return; // abort
+        }
+    } else {
+        DEBUG_ASSERT(pCoverImg);
+        kLogger.info()
+                << "Initializing track metadata and embedded cover art from file"
+                << getUrl().toString();
+    }
+
+    // Fallback: If artist or title fields are blank then try to populate
+    // them from the file name. This might happen if tags are unavailable,
+    // unreadable, or partially/completely missing.
+    // TODO(rryan): Should we re-visit this decision?
+    if (trackMetadata.getTrackInfo().getArtist().isEmpty() ||
+            trackMetadata.getTrackInfo().getTitle().isEmpty()) {
+        kLogger.info()
+                << "Adding missing artist/title from file name"
+                << getUrl().toString();
+        if (parseMetadataFromFileName(&trackMetadata, m_pTrack->getFileInfo().fileName()) &&
+                metadataImported.second.isNull()) {
+            // Since this is also some kind of metadata import, we mark the
+            // track's metadata as synchronized with the time stamp of the file.
+            metadataImported.second = m_pTrack->getFileInfo().lastModified();
+        }
+    }
+
     m_pTrack->setTrackMetadata(trackMetadata, metadataImported.second);
 
     if (pCoverImg) {
         CoverInfoRelative coverInfoRelative;
         if (pCoverImg->isNull()) {
-            if (coverInfo.type == CoverInfo::NONE) {
-                kLogger.info() << "No cover art found in file"
-                           << getUrl().toString();
-            } else {
-                kLogger.warning() << "Cover art is missing from file"
-                        << getUrl().toString();
-            }
+            kLogger.info()
+                    << "No embedded cover art found in file"
+                    << getUrl().toString();
             // Cover art should be (re-)set to none
             DEBUG_ASSERT(coverInfoRelative.type == CoverInfo::NONE);
         } else {
@@ -521,18 +547,6 @@ void SoundSourceProxy::updateTrackFromSource(
             DEBUG_ASSERT(coverInfoRelative.coverLocation.isEmpty());
             // TODO(XXX) here we may introduce a duplicate hash code
             coverInfoRelative.hash = CoverArtUtils::calculateHash(coverImg);
-        }
-        if (coverInfoRelative.type == CoverInfo::NONE) {
-            kLogger.info() << "Resetting cover art for file"
-                     << getUrl().toString();
-        } else {
-            if (coverInfo.type == CoverInfo::NONE) {
-                kLogger.info() << "Initializing cover art from file"
-                         << getUrl().toString();
-            } else {
-                kLogger.info() << "Updating cover art from file"
-                        << getUrl().toString();
-            }
         }
         m_pTrack->setCoverInfo(coverInfoRelative);
     }

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -472,7 +472,7 @@ void SoundSourceProxy::updateTrackFromSource(
             m_pSoundSource->importTrackMetadataAndCoverImage(
                     &trackMetadata, pCoverImg);
     if (metadataImported.first != mixxx::MetadataSource::ImportResult::Succeeded) {
-        kLogger.warning() << "Failed to parse track metadata and/or cover art from file"
+        kLogger.debug() << "Failed to parse track metadata and/or cover art from file"
                    << getUrl().toString();
         return; // abort
     }

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -432,9 +432,7 @@ void SoundSourceProxy::updateTrackFromSource(
         return; // abort
     }
 
-    // Initialize or update the file/format as reported by the associated
-    // SoundSource. This operation might already set the dirty flag of the
-    // track object, but we don't care.
+    // The SoundSource provides the actual type of the corresponding file
     m_pTrack->setType(m_pSoundSource->getType());
 
     // Use the existing track metadata as default values. Otherwise
@@ -517,7 +515,6 @@ void SoundSourceProxy::updateTrackFromSource(
     // Fallback: If artist or title fields are blank then try to populate
     // them from the file name. This might happen if tags are unavailable,
     // unreadable, or partially/completely missing.
-    // TODO(rryan): Should we re-visit this decision?
     if (trackMetadata.getTrackInfo().getArtist().isEmpty() ||
             trackMetadata.getTrackInfo().getTitle().isEmpty()) {
         kLogger.info()


### PR DESCRIPTION
Reducing the log spam was only the first step.

I noticed that the import and following update of track metadata and cover art from file tags could need some housekeeping. It should be simpler and easier to follow now. The behavior only changed slightly in case of errors. If you don't notice any unexpected differences in operation then this is a good sign!

Some information like the time stamp from the file is still only evaluated partially. It will be needed when we decide to replace the simple flag in the library with a time stamp. This would allow us to synchronize tracks and their files more reliably and detect when the external file has changed and consequently a re-import of tags might be needed.