### PR TITLE
Log flush level

### DIFF
--- a/src/dialog/dlgdevelopertools.cpp
+++ b/src/dialog/dlgdevelopertools.cpp
@@ -5,6 +5,7 @@
 #include "control/control.h"
 #include "util/cmdlineargs.h"
 #include "util/statsmanager.h"
+#include "util/logging.h"
 
 DlgDeveloperTools::DlgDeveloperTools(QWidget* pParent,
                                      UserSettingsPointer pConfig)
@@ -81,24 +82,32 @@ DlgDeveloperTools::DlgDeveloperTools(QWidget* pParent,
 
 void DlgDeveloperTools::timerEvent(QTimerEvent* pEvent) {
     Q_UNUSED(pEvent);
-    if (m_logFile.isOpen()) {
-        QStringList newLines;
-
-        while (true) {
-            QByteArray line = m_logFile.readLine();
-            if (line.isEmpty()) {
-                break;
-            }
-            newLines.append(QString::fromLocal8Bit(line));
-        }
-
-        if (!newLines.isEmpty()) {
-            logTextView->append(newLines.join(""));
-        }
+    if (!isVisible()) {
+        // nothing to do if we are not visible
+        return;
     }
 
     // To save on CPU, only update the models when they are visible.
-    if (toolTabWidget->currentWidget() == controlsTab) {
+    if (toolTabWidget->currentWidget() == logTab) {
+        if (m_logFile.isOpen()) {
+            // ensure, everything is in Buffer.
+            mixxx::Logging::flushLogFile();
+
+            QStringList newLines;
+
+            while (true) {
+                QByteArray line = m_logFile.readLine();
+                if (line.isEmpty()) {
+                    break;
+                }
+                newLines.append(QString::fromLocal8Bit(line));
+            }
+
+            if (!newLines.isEmpty()) {
+                logTextView->append(newLines.join(""));
+            }
+        }
+    } else if (toolTabWidget->currentWidget() == controlsTab) {
         //m_controlModel.updateDirtyRows();
         controlsTable->update();
     } else if (toolTabWidget->currentWidget() == statsTab) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,9 @@ int main(int argc, char * argv[]) {
     QThread::currentThread()->setObjectName("Main");
 
     mixxx::Logging::initialize(args.getSettingsPath(),
-                               args.getLogLevel(), args.getDebugAssertBreak());
+                               args.getLogLevel(),
+                               args.getLogFlushLevel(),
+                               args.getDebugAssertBreak());
 
     MixxxApplication app(argc, argv);
 

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -167,8 +167,8 @@ void CmdlineArgs::printUsage() {
                         debug    - Above + Debug/Developer messages\n\
                         trace    - Above + Profiling messages\n\
 \n\
---logFlushLevel LEVEL   Defines which messages level causes flushing all\n\
-                        messages to mixxx.log. LEVEL is one of the values\n\
+--logFlushLevel LEVEL   Sets the the logging level at which the log buffer\n\
+                        is flushed to mixxx.log. LEVEL is one of the values\n\
                         defined at --logLevel above.\n\
 \n"
 #ifdef MIXXX_BUILD_DEBUG

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -14,7 +14,7 @@ CmdlineArgs::CmdlineArgs()
       m_debugAssertBreak(false),
       m_settingsPathSet(false),
       m_logLevel(mixxx::kLogLevelDefault),
-      m_logFlushLevel(mixxx::kFlushLevelDefault),
+      m_logFlushLevel(mixxx::kLogFlushLevelDefault),
 // We are not ready to switch to XDG folders under Linux, so keeping $HOME/.mixxx as preferences folder. see lp:1463273
 #ifdef __LINUX__
     m_settingsPath(QDir::homePath().append("/").append(SETTINGS_PATH)) {

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -13,7 +13,8 @@ CmdlineArgs::CmdlineArgs()
       m_safeMode(false),
       m_debugAssertBreak(false),
       m_settingsPathSet(false),
-      m_logLevel(mixxx::LogLevel::Default),
+      m_logLevel(mixxx::kLogLevelDefault),
+      m_logFlushLevel(mixxx::kFlushLevelDefault),
 // We are not ready to switch to XDG folders under Linux, so keeping $HOME/.mixxx as preferences folder. see lp:1463273
 #ifdef __LINUX__
     m_settingsPath(QDir::homePath().append("/").append(SETTINGS_PATH)) {
@@ -71,6 +72,23 @@ bool CmdlineArgs::Parse(int &argc, char **argv) {
             } else {
                 fputs("\nlogLevel argument wasn't 'trace', 'debug', 'info', 'warning', or 'critical'! Mixxx will only output\n\
 warnings and errors to the console unless this is set properly.\n", stdout);
+            }
+            i++;
+        } else if (argv[i] == QString("--logFlushLevel") && i+1 < argc) {
+            auto level = QLatin1String(argv[i+1]);
+            if (level == "trace") {
+                m_logFlushLevel = mixxx::LogLevel::Trace;
+            } else if (level == "debug") {
+                m_logFlushLevel = mixxx::LogLevel::Debug;
+            } else if (level == "info") {
+                m_logFlushLevel = mixxx::LogLevel::Info;
+            } else if (level == "warning") {
+                m_logFlushLevel = mixxx::LogLevel::Warning;
+            } else if (level == "critical") {
+                m_logFlushLevel = mixxx::LogLevel::Critical;
+            } else {
+                fputs("\nlogFushLevel argument wasn't 'trace', 'debug', 'info', 'warning', or 'critical'! Mixxx will only flush messages to mixxx.log\n\
+when a critical error occours unless this is set properly.\n", stdout);
             }
             i++;
         } else if (QString::fromLocal8Bit(argv[i]).contains("--midiDebug", Qt::CaseInsensitive) ||
@@ -148,6 +166,10 @@ void CmdlineArgs::printUsage() {
                         info     - Above + Informational messages\n\
                         debug    - Above + Debug/Developer messages\n\
                         trace    - Above + Profiling messages\n\
+\n\
+--logFlushLevel LEVEL   Defines which messages level causes flushing all\n\
+                        messages to mixxx.log. LEVEL is one of the values\n\
+                        defined at --logLevel above.\n\
 \n"
 #ifdef MIXXX_BUILD_DEBUG
 "\

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -49,7 +49,7 @@ class CmdlineArgs final {
     bool m_debugAssertBreak;
     bool m_settingsPathSet; // has --settingsPath been set on command line ?
     mixxx::LogLevel m_logLevel; // Level of stderr logging message verbosity
-    mixxx::LogLevel m_logFlushLevel; // Level of log file flushing
+    mixxx::LogLevel m_logFlushLevel; // Level of mixx.log file flushing
     QString m_locale;
     QString m_settingsPath;
     QString m_resourcePath;

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -27,6 +27,7 @@ class CmdlineArgs final {
     bool getDebugAssertBreak() const { return m_debugAssertBreak; }
     bool getSettingsPathSet() const { return m_settingsPathSet; }
     mixxx::LogLevel getLogLevel() const { return m_logLevel; }
+    mixxx::LogLevel getLogFlushLevel() const { return m_logFlushLevel; }
     bool getTimelineEnabled() const { return !m_timelinePath.isEmpty(); }
     const QString& getLocale() const { return m_locale; }
     const QString& getSettingsPath() const { return m_settingsPath; }
@@ -47,7 +48,8 @@ class CmdlineArgs final {
     bool m_safeMode;
     bool m_debugAssertBreak;
     bool m_settingsPathSet; // has --settingsPath been set on command line ?
-    mixxx::LogLevel m_logLevel; // Level of logging message verbosity
+    mixxx::LogLevel m_logLevel; // Level of stderr logging message verbosity
+    mixxx::LogLevel m_logFlushLevel; // Level of log file flushing
     QString m_locale;
     QString m_settingsPath;
     QString m_resourcePath;

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -240,4 +240,12 @@ void Logging::shutdown() {
     }
 }
 
+// static
+void Logging::flushLogFile() {
+    QMutexLocker locker(&g_mutexLogfile);
+    if (g_logfile.isOpen()) {
+        g_logfile.flush();
+    }
+}
+
 }  // namespace mixxx

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -21,7 +21,8 @@
 namespace mixxx {
 
 // Initialize the log level with the default value
-LogLevel Logging::s_logLevel = LogLevel::Default;
+LogLevel Logging::s_logLevel = kLogLevelDefault;
+LogLevel Logging::s_flushLevel = kFlushLevelDefault;
 
 namespace {
 
@@ -79,18 +80,21 @@ void MessageHandler(QtMsgType type,
 #endif
             shouldPrint = Logging::enabled(LogLevel::Debug) ||
                     isControllerDebug;
+            shouldFlush = Logging::flushing(LogLevel::Debug);
             break;
 #if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
         case QtInfoMsg:
             tag = "Info [";
             baSize += strlen(tag);
             shouldPrint = Logging::enabled(LogLevel::Info);
+            shouldFlush = Logging::flushing(LogLevel::Info);
             break;
 #endif
         case QtWarningMsg:
             tag = "Warning [";
             baSize += strlen(tag);
             shouldPrint = Logging::enabled(LogLevel::Warning);
+            shouldFlush = Logging::flushing(LogLevel::Warning);
             break;
         case QtCriticalMsg:
             tag = "Critical [";
@@ -176,7 +180,9 @@ void MessageHandler(QtMsgType type,
 }  // namespace
 
 // static
-void Logging::initialize(const QDir& settingsDir, LogLevel logLevel,
+void Logging::initialize(const QDir& settingsDir,
+                         LogLevel logLevel,
+                         LogLevel flushLevel,
                          bool debugAssertBreak) {
     VERIFY_OR_DEBUG_ASSERT(!g_logfile.isOpen()) {
         // Somebody already called Logging::initialize.
@@ -184,6 +190,7 @@ void Logging::initialize(const QDir& settingsDir, LogLevel logLevel,
     }
 
     s_logLevel = logLevel;
+    s_flushLevel = flushLevel;
 
     QString logFileName;
 

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -22,7 +22,7 @@ namespace mixxx {
 
 // Initialize the log level with the default value
 LogLevel Logging::s_logLevel = kLogLevelDefault;
-LogLevel Logging::s_flushLevel = kFlushLevelDefault;
+LogLevel Logging::s_logFlushLevel = kLogFlushLevelDefault;
 
 namespace {
 
@@ -182,7 +182,7 @@ void MessageHandler(QtMsgType type,
 // static
 void Logging::initialize(const QDir& settingsDir,
                          LogLevel logLevel,
-                         LogLevel flushLevel,
+                         LogLevel logFlushLevel,
                          bool debugAssertBreak) {
     VERIFY_OR_DEBUG_ASSERT(!g_logfile.isOpen()) {
         // Somebody already called Logging::initialize.
@@ -190,7 +190,7 @@ void Logging::initialize(const QDir& settingsDir,
     }
 
     s_logLevel = logLevel;
-    s_flushLevel = flushLevel;
+    s_logFlushLevel = logFlushLevel;
 
     QString logFileName;
 

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -23,6 +23,8 @@ class Logging {
                            bool debugAssertBreak);
     static void shutdown();
 
+    static void flushLogFile();
+
     // Query the current log level
     static LogLevel logLevel() {
         return s_logLevel;

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -12,25 +12,27 @@ enum class LogLevel {
     Info = 2,
     Debug = 3,
     Trace = 4, // for profiling etc.
-    Default = Warning,
 };
+
+constexpr LogLevel kLogLevelDefault = LogLevel::Warning;
+constexpr LogLevel kFlushLevelDefault = LogLevel::Critical;
 
 class Logging {
   public:
     // These are not thread safe. Only call them on Mixxx startup and shutdown.
     static void initialize(const QDir& settingsDir,
                            LogLevel logLevel,
+                           LogLevel flushLevel,
                            bool debugAssertBreak);
     static void shutdown();
 
     static void flushLogFile();
 
-    // Query the current log level
-    static LogLevel logLevel() {
-        return s_logLevel;
-    }
     static bool enabled(LogLevel logLevel) {
         return s_logLevel >= logLevel;
+    }
+    static bool flushing(LogLevel flushLevel) {
+        return s_flushLevel >= flushLevel;
     }
     static bool traceEnabled() {
         return enabled(LogLevel::Trace);
@@ -46,6 +48,7 @@ class Logging {
     Logging() = delete;
 
     static LogLevel s_logLevel;
+    static LogLevel s_flushLevel;
 };
 
 }  // namespace mixxx

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -15,14 +15,14 @@ enum class LogLevel {
 };
 
 constexpr LogLevel kLogLevelDefault = LogLevel::Warning;
-constexpr LogLevel kFlushLevelDefault = LogLevel::Critical;
+constexpr LogLevel kLogFlushLevelDefault = LogLevel::Critical;
 
 class Logging {
   public:
     // These are not thread safe. Only call them on Mixxx startup and shutdown.
     static void initialize(const QDir& settingsDir,
                            LogLevel logLevel,
-                           LogLevel flushLevel,
+                           LogLevel logFlushLevel,
                            bool debugAssertBreak);
     static void shutdown();
 
@@ -31,8 +31,8 @@ class Logging {
     static bool enabled(LogLevel logLevel) {
         return s_logLevel >= logLevel;
     }
-    static bool flushing(LogLevel flushLevel) {
-        return s_flushLevel >= flushLevel;
+    static bool flushing(LogLevel logFlushLevel) {
+        return s_logFlushLevel >= logFlushLevel;
     }
     static bool traceEnabled() {
         return enabled(LogLevel::Trace);
@@ -48,7 +48,7 @@ class Logging {
     Logging() = delete;
 
     static LogLevel s_logLevel;
-    static LogLevel s_flushLevel;
+    static LogLevel s_logFlushLevel;
 };
 
 }  // namespace mixxx


### PR DESCRIPTION
Added a logFlushLevel comand line option, that allows to define which messages are written mediately to the mixxx.log file. This feature is required to debug Mixxx crashes where the most recent debug messages are not stored to disk, before Mixxx is terminated. 
In addition the mixxx.log file is flushed when observing it in the developers menu log view. 

This PR does break feature freeze, but I think it is worth it to be able to nail down user crash issues faster. It does not break string freeze, because the command line options are not translated.

We can consider to translate them only if we have fixed the pending character encoding issues on Windows. I have filed a bug for it: https://bugs.launchpad.net/mixxx/+bug/1743206 


  