### PR TITLE
lp1738227: Fix unresponsiveness during analysis caused by BaseTrackCache

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -1085,7 +1085,7 @@ class MixxxCore(Feature):
                    "track/playcounter.cpp",
                    "track/replaygain.cpp",
                    "track/track.cpp",
-                   "track/trackcache.cpp",
+                   "track/globaltrackcache.cpp",
                    "track/trackmetadata.cpp",
                    "track/trackmetadatataglib.cpp",
                    "track/tracknumbers.cpp",

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -3,9 +3,6 @@
 
 #include "library/basetrackcache.h"
 
-#include <QScopedPointer>
-
-#include "control/controlproxy.h"
 #include "library/trackcollection.h"
 #include "library/searchqueryparser.h"
 #include "library/queryutil.h"
@@ -44,7 +41,6 @@ BaseTrackCache::BaseTrackCache(TrackCollection* pTrackCollection,
                     << "title"
                     << "genre";
 
-    m_pKeyNotationCP = new ControlProxy("[Library]", "key_notation", this);
     // Convert all the search column names to their field indexes because we use
     // them a bunch.
     m_searchColumnIndices.resize(m_searchColumns.size());
@@ -704,13 +700,12 @@ int BaseTrackCache::compareColumnValues(int sortColumn, Qt::SortOrder sortOrder,
         else
             result = -1;
     } else if (sortColumn == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY)) {
-        KeyUtils::KeyNotation notation = KeyUtils::keyNotationFromNumericValue(
-            m_pKeyNotationCP->get());
+        KeyUtils::KeyNotation keyNotation = m_columnCache.keyNotation();
 
         int key1 = KeyUtils::keyToCircleOfFifthsOrder(
-            KeyUtils::guessKeyFromText(val1.toString()), notation);
+            KeyUtils::guessKeyFromText(val1.toString()), keyNotation);
         int key2 = KeyUtils::keyToCircleOfFifthsOrder(
-            KeyUtils::guessKeyFromText(val2.toString()), notation);
+            KeyUtils::guessKeyFromText(val2.toString()), keyNotation);
         if (key1 > key2) {
             result = 1;
         } else if (key1 < key2) {

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -10,7 +10,7 @@
 #include "library/searchqueryparser.h"
 #include "library/queryutil.h"
 #include "track/keyutils.h"
-#include "track/trackcache.h"
+#include "track/globaltrackcache.h"
 #include "util/performancetimer.h"
 
 namespace {
@@ -158,7 +158,7 @@ void BaseTrackCache::refreshCachedTrack(TrackId trackId) const {
     if (trackId.isValid()) {
         refreshCachedTrack(
                 std::move(trackId),
-                TrackCache::instance().lookupById(trackId).getTrack());
+                GlobalTrackCache::instance().lookupById(trackId).getTrack());
     } else {
         resetCachedTrack();
     }

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -156,9 +156,11 @@ TrackPointer BaseTrackCache::lookupCachedTrack(TrackId trackId) const {
 void BaseTrackCache::refreshCachedTrack(TrackId trackId) const {
     DEBUG_ASSERT(m_bIsCaching);
     if (trackId.isValid()) {
+        auto trackPtr =
+                GlobalTrackCache::instance().lookupById(trackId).getTrack();
         refreshCachedTrack(
                 std::move(trackId),
-                GlobalTrackCache::instance().lookupById(trackId).getTrack());
+                std::move(trackPtr));
     } else {
         resetCachedTrack();
     }

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -89,6 +89,11 @@ class BaseTrackCache : public QObject {
 
   private:
     TrackPointer lookupCachedTrack(TrackId trackId) const;
+    void refreshCachedTrack(TrackId trackId) const;
+    void refreshCachedTrack(TrackPointer pTrack) const;
+    void refreshCachedTrack(TrackId trackId, TrackPointer pTrack) const;
+    void resetCachedTrack() const;
+
     bool updateIndexWithQuery(const QString& query);
     bool updateIndexWithTrackpointer(TrackPointer pTrack);
     void updateTrackInIndex(TrackId trackId);
@@ -125,6 +130,12 @@ class BaseTrackCache : public QObject {
     // Temporary storage for filterAndSort()
 
     QVector<TrackId> m_trackOrder;
+
+    // Remember key and value of the most recent cache lookup to avoid querying
+    // the global track cache again and again while populating the columns
+    // of a single row. These members serve as a single-valued private cache.
+    mutable TrackId m_cachedTrackId;
+    mutable TrackPointer m_cachedTrackPtr;
 
     // This set is updated by signals from the Track object. It might contain
     // false positives, i.e. track ids of tracks that are neither cached nor

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -88,11 +88,11 @@ class BaseTrackCache : public QObject {
     void slotDbTrackAdded(TrackPointer pTrack);
 
   private:
-    TrackPointer lookupCachedTrack(TrackId trackId) const;
-    void refreshCachedTrack(TrackId trackId) const;
-    void refreshCachedTrack(TrackPointer pTrack) const;
-    void refreshCachedTrack(TrackId trackId, TrackPointer pTrack) const;
-    void resetCachedTrack() const;
+    TrackPointer getRecentTrack(TrackId trackId) const;
+    void refreshRecentTrack(TrackId trackId) const;
+    void replaceRecentTrack(TrackPointer pTrack) const;
+    void replaceRecentTrack(TrackId trackId, TrackPointer pTrack) const;
+    void resetRecentTrack() const;
 
     bool updateIndexWithQuery(const QString& query);
     bool updateIndexWithTrackpointer(TrackPointer pTrack);
@@ -134,13 +134,13 @@ class BaseTrackCache : public QObject {
     // Remember key and value of the most recent cache lookup to avoid querying
     // the global track cache again and again while populating the columns
     // of a single row. These members serve as a single-valued private cache.
-    mutable TrackId m_cachedTrackId;
-    mutable TrackPointer m_cachedTrackPtr;
+    mutable TrackId m_recentTrackId;
+    mutable TrackPointer m_recentTrackPtr;
 
     // This set is updated by signals from the Track object. It might contain
     // false positives, i.e. track ids of tracks that are neither cached nor
-    // dirty. Each invocation of lookupCachedTrack() will take care of
-    // updating this set by inserting and removing entries as required.
+    // dirty. Each invocation of getRecentTrack() will take care of updating
+    // this set by inserting and removing entries as required.
     mutable QSet<TrackId> m_dirtyTracks;
 
     bool m_bIndexBuilt;

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -13,7 +13,6 @@
 #include <QSqlDatabase>
 #include <QVector>
 
-#include "control/controlproxy.h"
 #include "library/dao/trackdao.h"
 #include "library/columncache.h"
 #include "track/track.h"
@@ -122,7 +121,7 @@ class BaseTrackCache : public QObject {
     const int m_columnCount;
     const QString m_columnsJoined;
 
-    ColumnCache m_columnCache;
+    const ColumnCache m_columnCache;
 
     QStringList m_searchColumns;
     QVector<int> m_searchColumnIndices;

--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -10,7 +10,7 @@
 #include "library/browse/browsetablemodel.h"
 
 #include "sources/soundsourceproxy.h"
-#include "track/trackcache.h"
+#include "track/globaltrackcache.h"
 #include "util/trace.h"
 
 
@@ -155,9 +155,9 @@ void BrowseThread::populateModel() {
         const QString filepath = fileIt.next();
         {
             TrackPointer pTrack =
-                TrackCache::instance().resolve(
+                GlobalTrackCache::instance().resolve(
                         filepath, thisPath.token()).getTrack();
-            // The TrackCache is unlocked instantly even if a new track object
+            // The GlobalTrackCache is unlocked instantly even if a new track object
             // has been created and inserted into the cache. Newly created track
             // objects will only contain a reference of the corresponding file,
             // but not any metadata, yet. This reduces lock contention on the

--- a/src/library/columncache.cpp
+++ b/src/library/columncache.cpp
@@ -2,9 +2,8 @@
 
 #include "library/dao/trackschema.h"
 #include "library/dao/playlistdao.h"
-#include "track/keyutils.h"
 #include "track/key_preferences.h"
-#include "control/controlproxy.h"
+
 
  ColumnCache::ColumnCache(const QStringList& columns) {
     m_pKeyNotationCP = new ControlProxy("[Library]", "key_notation", this);

--- a/src/library/columncache.h
+++ b/src/library/columncache.h
@@ -6,9 +6,8 @@
 #include <QStringList>
 
 #include "track/keyutils.h"
+#include "control/controlproxy.h"
 #include "preferences/usersettings.h"
-
-class ControlProxy;
 
 // Caches the index of frequently used columns and provides a lookup-table of
 // column name to index.
@@ -107,6 +106,11 @@ class ColumnCache : public QObject {
     QMap<QString, int> m_columnIndexByName;
     // A mapping from column enum to logical index.
     int m_columnIndexByEnum[NUM_COLUMNS];
+
+    KeyUtils::KeyNotation keyNotation() const {
+        return KeyUtils::keyNotationFromNumericValue(
+                m_pKeyNotationCP->get());
+    }
 
   private:
     ControlProxy* m_pKeyNotationCP;

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -20,8 +20,8 @@ class AnalysisDao;
 class CueDAO;
 class LibraryHashDAO;
 class TrackCollection;
-class TrackCacheLocker;
-class TrackCacheResolver;
+class GlobalTrackCacheLocker;
+class GlobalTrackCacheResolver;
 
 
 class TrackDAO : public QObject, public virtual DAO {
@@ -60,7 +60,7 @@ class TrackDAO : public QObject, public virtual DAO {
 
     void addTracksPrepare();
     TrackPointer addTracksAddFile(const QFileInfo& fileInfo, bool unremove);
-    TrackPointer addTracksAddTrack(TrackCacheResolver&& /*r-value ref*/ cacheResolver, bool unremove);
+    TrackPointer addTracksAddTrack(GlobalTrackCacheResolver&& /*r-value ref*/ cacheResolver, bool unremove);
     TrackId addTracksAddTrack(const TrackPointer& pTrack, bool unremove);
     void addTracksFinish(bool rollback = false);
 
@@ -134,7 +134,7 @@ class TrackDAO : public QObject, public virtual DAO {
     TrackPointer getTrackFromDB(TrackId trackId) const;
 
     friend class TrackCollection;
-    void saveTrack(TrackCacheLocker* pCacheLocker, Track* pTrack);
+    void saveTrack(GlobalTrackCacheLocker* pCacheLocker, Track* pTrack);
     bool updateTrack(Track* pTrack);
 
     QSqlDatabase m_database;

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -422,6 +422,6 @@ void Library::slotSetTrackTableRowHeight(int rowHeight) {
     emit(setTrackTableRowHeight(rowHeight));
 }
 
-void Library::onEvictingTrackFromCache(TrackCacheLocker* pCacheLocker, Track* pTrack) {
+void Library::onEvictingTrackFromCache(GlobalTrackCacheLocker* pCacheLocker, Track* pTrack) {
     m_pTrackCollection->saveTrack(pCacheLocker, pTrack);
 }

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -13,7 +13,7 @@
 #include <QFont>
 
 #include "preferences/usersettings.h"
-#include "track/trackcache.h"
+#include "track/globaltrackcache.h"
 #include "recording/recordingmanager.h"
 #include "analysisfeature.h"
 #include "library/coverartcache.h"
@@ -37,7 +37,7 @@ class KeyboardEventFilter;
 class PlayerManagerInterface;
 
 class Library: public QObject,
-    public virtual /*implements*/ TrackCacheEvictor {
+    public virtual /*implements*/ GlobalTrackCacheEvictor {
     Q_OBJECT
 
   public:
@@ -81,7 +81,7 @@ class Library: public QObject,
 
     static const int kDefaultRowHeightPx;
 
-    void onEvictingTrackFromCache(TrackCacheLocker* pCacheLocker, Track* pTrack) override;
+    void onEvictingTrackFromCache(GlobalTrackCacheLocker* pCacheLocker, Track* pTrack) override;
 
   public slots:
     void slotShowTrackModel(QAbstractItemModel* model);

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -2,7 +2,7 @@
 
 #include "library/trackcollection.h"
 
-#include "track/trackcache.h"
+#include "track/globaltrackcache.h"
 #include "util/logger.h"
 #include "util/db/sqltransaction.h"
 
@@ -68,7 +68,7 @@ void TrackCollection::relocateDirectory(QString oldDir, QString newDir) {
             m_directoryDao.relocateDirectory(oldDir, newDir));
 
     // Discard all cached tracks
-    TrackCache::instance().evictAll();
+    GlobalTrackCache::instance().evictAll();
 
     m_trackDao.databaseTracksMoved(std::move(movedIds), QSet<TrackId>());
 }
@@ -329,6 +329,6 @@ bool TrackCollection::updateAutoDjCrate(
     return updateCrate(crate);
 }
 
-void TrackCollection::saveTrack(TrackCacheLocker* pCacheLocker, Track* pTrack) {
+void TrackCollection::saveTrack(GlobalTrackCacheLocker* pCacheLocker, Track* pTrack) {
     m_trackDao.saveTrack(pCacheLocker, pTrack);
 }

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -80,7 +80,7 @@ class TrackCollection : public QObject,
 
     bool updateAutoDjCrate(CrateId crateId, bool isAutoDjSource);
 
-    void saveTrack(TrackCacheLocker* pCacheLocker, Track* pTrack);
+    void saveTrack(GlobalTrackCacheLocker* pCacheLocker, Track* pTrack);
 
   signals:
     void crateInserted(CrateId id);

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -290,13 +290,13 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
             m_pDbConnectionPool,
             m_pPlayerManager,
             m_pRecordingManager);
-    // Create the singular TrackCache instance immediately after
+    // Create the singular GlobalTrackCache instance immediately after
     // the Library has been created and BEFORE binding the
     // PlayerManager to it!
-    TrackCache::createInstance(m_pLibrary);
+    GlobalTrackCache::createInstance(m_pLibrary);
 
     // Binding the PlayManager to the Library may already trigger
-    // loading of tracks which requires that the TrackCache has
+    // loading of tracks which requires that the GlobalTrackCache has
     // been created. Otherwise Mixxx might hang when accessing
     // the uninitialized singleton instance!
     m_pPlayerManager->bindToLibrary(m_pLibrary);
@@ -582,7 +582,7 @@ void MixxxMainWindow::finalize() {
 
     // Evict all remaining tracks from the cache to trigger
     // updating of modified tracks.
-    TrackCache::instance().evictAll();
+    GlobalTrackCache::instance().evictAll();
 
     // Delete the library after the view so there are no dangling pointers to
     // the data models.
@@ -590,10 +590,10 @@ void MixxxMainWindow::finalize() {
     qDebug() << t.elapsed(false).debugMillisWithUnit() << "deleting Library";
     delete m_pLibrary;
 
-    // The TrackCache singleton must be destroyed immediately
+    // The GlobalTrackCache singleton must be destroyed immediately
     // after the library has been destroyed!
-    qDebug() << "Destroying TrackCache" << t.elapsed(false);
-    TrackCache::destroyInstance();
+    qDebug() << "Destroying GlobalTrackCache" << t.elapsed(false);
+    GlobalTrackCache::destroyInstance();
 
     qDebug() << t.elapsed(false).debugMillisWithUnit() << "closing database connection(s)";
     m_pDbConnectionPool->destroyThreadLocalConnection();

--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -7,14 +7,14 @@
 #include "library/trackcollection.h"
 #include "util/db/dbconnectionpooler.h"
 #include "util/db/dbconnectionpooled.h"
-#include "track/trackcache.h"
+#include "track/globaltrackcache.h"
 
 
 class LibraryTest : public MixxxTest,
-    public virtual /*implements*/ TrackCacheEvictor {
+    public virtual /*implements*/ GlobalTrackCacheEvictor {
 
   public:
-    void onEvictingTrackFromCache(TrackCacheLocker* pCacheLocker, Track* pTrack) override {
+    void onEvictingTrackFromCache(GlobalTrackCacheLocker* pCacheLocker, Track* pTrack) override {
         m_trackCollection.saveTrack(pCacheLocker, pTrack);
     }
 
@@ -26,11 +26,11 @@ class LibraryTest : public MixxxTest,
           m_trackCollection(config()) {
         MixxxDb::initDatabaseSchema(m_dbConnection);
         m_trackCollection.connectDatabase(m_dbConnection);
-        TrackCache::createInstance(this);
+        GlobalTrackCache::createInstance(this);
     }
     ~LibraryTest() override {
-        TrackCache::instance().evictAll();
-        TrackCache::destroyInstance();
+        GlobalTrackCache::instance().evictAll();
+        GlobalTrackCache::destroyInstance();
         m_trackCollection.disconnectDatabase();
     }
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -31,7 +31,7 @@ class Track : public QObject {
     // be updated.
     // NOTE(uklotzde): Temporary track objects do not provide any guarantees
     // regarding safe file access, i.e. tags might be written back into the
-    // file whenever the corresponding track is evicted from TrackCache!
+    // file whenever the corresponding track is evicted from GlobalTrackCache!
     static TrackPointer newTemporary(
             const QFileInfo& fileInfo = QFileInfo(),
             const SecurityTokenPointer& pSecurityToken = SecurityTokenPointer());
@@ -325,7 +325,7 @@ class Track : public QObject {
           TrackId trackId);
 
     // Set a unique identifier for the track. Only used by
-    // TrackCacheResolver!
+    // GlobalTrackCacheResolver!
     void initId(TrackId id); // write-once
 
     // Set whether the TIO is dirty or not and unlock before emitting
@@ -383,8 +383,8 @@ class Track : public QObject {
     QAtomicInt m_analyzerProgress; // in 0.1%
 
     friend class TrackDAO;
-    friend class TrackCache;
-    friend class TrackCacheResolver;
+    friend class GlobalTrackCache;
+    friend class GlobalTrackCacheResolver;
     friend class SoundSourceProxy;
 };
 


### PR DESCRIPTION
It turned out that the main reason for the unresponsiveness was actually the lack of local caching in _BaseTrackCache_ after we removed the recent tracks cache from TrackDAO. I've added a single-element cache of the last id and the corresponding pointer that has been looked up from the global cache. This is sufficient since data() is read row by row, track by track.

The implementation is not bad, but more or less some kind of "duck tape". We need to revisit this code anyway before improving database access.

Metadata might now be exported with a short delay, as long as the modified track is still referenced by any _BaseTrackCache_ instance. I don't expect any other unexpected side-effects.

Finally I renamed _TrackCache_ into _GlobalTrackCache_ to avoid confusing it with _BaseTrackCache_. I also improved the logging in _GlobalTrackCache_, which will be very detailed when activating the _trace_ log level. All debug and trace output is enclosed in conditional blocks.