### PR TITLE
Deere .: remove center gap from Meta/Super knob ring

### DIFF
--- a/res/skins/Deere/effect_meta_knob.xml
+++ b/res/skins/Deere/effect_meta_knob.xml
@@ -17,7 +17,7 @@
         <SetVariable name="TooltipId">EffectSlot_metaknob</SetVariable>
         <SetVariable name="group">[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>_Effect<Variable name="Effect"/>]</SetVariable>
         <SetVariable name="control">meta</SetVariable>
-        <SetVariable name="color">blue</SetVariable>
+        <SetVariable name="color">blue_gapless</SetVariable>
       </Template>
     </Children>
   </WidgetGroup>

--- a/res/skins/Deere/effect_unit_no_parameters.xml
+++ b/res/skins/Deere/effect_unit_no_parameters.xml
@@ -62,7 +62,7 @@ Variables:
                     <SetVariable name="TooltipId">EffectUnit_super1</SetVariable>
                     <SetVariable name="control">super1</SetVariable>
                     <SetVariable name="label">Super</SetVariable>
-                    <SetVariable name="color">blue</SetVariable>
+                    <SetVariable name="color">blue_gapless</SetVariable>
                   </Template>
                 </Children>
               </WidgetGroup>

--- a/res/skins/Deere/effect_unit_with_parameters.xml
+++ b/res/skins/Deere/effect_unit_with_parameters.xml
@@ -64,7 +64,7 @@ Variables:
                     <SetVariable name="TooltipId">EffectUnit_super1</SetVariable>
                     <SetVariable name="control">super1</SetVariable>
                     <SetVariable name="label">Super</SetVariable>
-                    <SetVariable name="color">blue</SetVariable>
+                    <SetVariable name="color">blue_gapless</SetVariable>
                   </Template>
                 </Children>
               </WidgetGroup>

--- a/res/skins/Deere/knob_bg_blue_gapless.svg
+++ b/res/skins/Deere/knob_bg_blue_gapless.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   width="40"
+   height="34"
+   id="svg2">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5441">
+      <stop
+         id="stop5443"
+         style="stop-color:#060606;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5445"
+         style="stop-color:#343434;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="256.73965"
+       y1="472.02954"
+       x2="484.71231"
+       y2="472.02954"
+       id="linearGradient3839"
+       xlink:href="#linearGradient5441"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.10675958,0,0,0.1067605,-60.001687,-36.030994)" />
+    <linearGradient
+       x1="202.50447"
+       y1="618.50647"
+       x2="202.48778"
+       y2="634.36542"
+       id="linearGradient4945"
+       xlink:href="#linearGradient4937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.257316,0,0,1,-241.05158,-602.90563)" />
+    <linearGradient
+       id="linearGradient4937">
+      <stop
+         id="stop4939"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4185"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="0.25399527" />
+      <stop
+         id="stop4941"
+         style="stop-color:#afafaf;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 7.6728885,30.696176 a 15.865708,15.865708 0 1 1 22.0424935,0"
+     transform="matrix(0.96904934,0,0,0.96870025,1.8847978,-0.06558939)"
+     id="path6998"
+     style="color:#000000;fill:none;stroke:#489aff;stroke-width:2.3222816;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+</svg>


### PR DESCRIPTION
As requested in #1399 

related bug: [lp:1698408 effect specific Meta knob/QuickEffect knob default position](https://bugs.launchpad.net/mixxx/+bug/1698408)
related PR: #645 Knob masked ring