### PR TITLE
focus library on [Library] ChooseItem from sidebar

### DIFF
--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -465,6 +465,14 @@ void LibraryControl::slotChooseItem(double v) {
     }
     // Otherwise toggle the sidebar item expanded state (like a double-click)
     slotToggleSelectedSidebarItem(v);
+
+    // Focus the library if this is a leaf node in the tree
+    if (m_pSidebarWidget && v > 0
+        && m_pSidebarWidget->hasFocus()
+        && m_pSidebarWidget->isLeafNodeSelected())
+    {
+        setLibraryFocus();
+    }
 }
 
 void LibraryControl::slotFontSize(double v) {

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -166,6 +166,15 @@ void WLibrarySidebar::toggleSelectedItem() {
     }
 }
 
+bool WLibrarySidebar::isLeafNodeSelected() {
+    QModelIndexList selectedIndices = this->selectionModel()->selectedRows();
+    if (selectedIndices.size() > 0) {
+        QModelIndex index = selectedIndices.at(0);
+        return !index.model()->hasChildren(index);
+    }
+    return false;
+}
+
 void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
     if (event->key() == Qt::Key_Return) {
         toggleSelectedItem();

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -26,6 +26,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void keyPressEvent(QKeyEvent* event) override;
     void timerEvent(QTimerEvent* event) override;
     void toggleSelectedItem();
+    bool isLeafNodeSelected();
 
   public slots:
     void selectIndex(const QModelIndex&);


### PR DESCRIPTION
When the browse knob is mapped to [Library] ChooseItem this will cause
the library to be focused when a leaf node in the sideview is chosen.
Focus only changes when a leaf node is selected, otherwise the given
tree node is expanded or collapsed.