### PR TITLE
lp1743866: Optimize and improve handling of cover art

### DIFF
--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -109,7 +109,7 @@ void CoverArtCache::requestCover(const Track& track,
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache == nullptr) return;
 
-    CoverInfo info = track.getCoverInfo();
+    CoverInfo info = track.getCoverInfoWithLocation();
     pCache->requestCover(info, pRequestor, 0, false, true);
 }
 

--- a/src/library/coverartcache.h
+++ b/src/library/coverartcache.h
@@ -55,7 +55,7 @@ class CoverArtCache : public QObject, public Singleton<CoverArtCache> {
 
   signals:
     void coverFound(const QObject* requestor,
-                    const CoverInfo& info, QPixmap pixmap, bool fromCache);
+                    const CoverInfoRelative& info, QPixmap pixmap, bool fromCache);
 
   protected:
     CoverArtCache();

--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -21,9 +21,9 @@ CoverArtDelegate::CoverArtDelegate(QObject *parent)
 
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache) {
-        connect(pCache, SIGNAL(coverFound(const QObject*, const CoverInfo&,
+        connect(pCache, SIGNAL(coverFound(const QObject*, const CoverInfoRelative&,
                                           QPixmap, bool)),
-                this, SLOT(slotCoverFound(const QObject*, const CoverInfo&,
+                this, SLOT(slotCoverFound(const QObject*, const CoverInfoRelative&,
                                           QPixmap, bool)));
     }
 
@@ -69,7 +69,7 @@ void CoverArtDelegate::slotOnlyCachedCoverArt(bool b) {
 }
 
 void CoverArtDelegate::slotCoverFound(const QObject* pRequestor,
-                                      const CoverInfo& info,
+                                      const CoverInfoRelative& info,
                                       QPixmap pixmap, bool fromCache) {
     if (pRequestor == this && !pixmap.isNull() && !fromCache) {
         // qDebug() << "CoverArtDelegate::slotCoverFound" << pRequestor << info

--- a/src/library/coverartdelegate.h
+++ b/src/library/coverartdelegate.h
@@ -36,7 +36,7 @@ class CoverArtDelegate : public QStyledItemDelegate {
     void slotOnlyCachedCoverArt(bool b);
 
     void slotCoverFound(const QObject* pRequestor,
-                        const CoverInfo& info,
+                        const CoverInfoRelative& info,
                         QPixmap pixmap, bool fromCache);
 
   private:

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -424,7 +424,7 @@ namespace {
         pTrackLibraryQuery->bindValue(":timesplayed", playCounter.getTimesPlayed());
         pTrackLibraryQuery->bindValue(":played", playCounter.isPlayed() ? 1 : 0);
 
-        const CoverInfo coverInfo(track.getCoverInfo());
+        const CoverInfoRelative coverInfo(track.getCoverInfo());
         pTrackLibraryQuery->bindValue(":coverart_source", coverInfo.source);
         pTrackLibraryQuery->bindValue(":coverart_type", coverInfo.type);
         pTrackLibraryQuery->bindValue(":coverart_location", coverInfo.coverLocation);

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -12,16 +12,16 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlay
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache != nullptr) {
         connect(pCache, SIGNAL(coverFound(const QObject*,
-                                          const CoverInfo&, QPixmap, bool)),
+                                          const CoverInfoRelative&, QPixmap, bool)),
                 this, SLOT(slotCoverFound(const QObject*,
-                                          const CoverInfo&, QPixmap, bool)));
+                                          const CoverInfoRelative&, QPixmap, bool)));
     }
 
     setContextMenuPolicy(Qt::CustomContextMenu);
     connect(this, SIGNAL(customContextMenuRequested(QPoint)),
             this, SLOT(slotCoverMenu(QPoint)));
-    connect(m_pCoverMenu, SIGNAL(coverInfoSelected(const CoverInfo&)),
-            this, SLOT(slotCoverInfoSelected(const CoverInfo&)));
+    connect(m_pCoverMenu, SIGNAL(coverInfoSelected(const CoverInfoRelative&)),
+            this, SLOT(slotCoverInfoSelected(const CoverInfoRelative&)));
     connect(m_pCoverMenu, SIGNAL(reloadCoverArt()),
             this, SLOT(slotReloadCoverArt()));
 
@@ -93,7 +93,7 @@ void DlgCoverArtFullSize::slotTrackCoverArtUpdated() {
 }
 
 void DlgCoverArtFullSize::slotCoverFound(const QObject* pRequestor,
-                                         const CoverInfo& info, QPixmap pixmap,
+                                         const CoverInfoRelative& info, QPixmap pixmap,
                                          bool fromCache) {
     Q_UNUSED(info);
     Q_UNUSED(fromCache);
@@ -136,13 +136,13 @@ void DlgCoverArtFullSize::slotCoverFound(const QObject* pRequestor,
 // slots to handle signals from the context menu
 void DlgCoverArtFullSize::slotReloadCoverArt() {
     if (m_pLoadedTrack != nullptr) {
-        CoverInfo coverInfo =
+        auto coverInfo =
                 CoverArtUtils::guessCoverInfo(*m_pLoadedTrack);
         slotCoverInfoSelected(coverInfo);
     }
 }
 
-void DlgCoverArtFullSize::slotCoverInfoSelected(const CoverInfo& coverInfo) {
+void DlgCoverArtFullSize::slotCoverInfoSelected(const CoverInfoRelative& coverInfo) {
     // qDebug() << "DlgCoverArtFullSize::slotCoverInfoSelected" << coverInfo;
     if (m_pLoadedTrack != nullptr) {
         m_pLoadedTrack->setCoverInfo(coverInfo);

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -25,12 +25,12 @@ class DlgCoverArtFullSize
   public slots:
     void slotLoadTrack(TrackPointer);
     void slotCoverFound(const QObject* pRequestor,
-            const CoverInfo& info, QPixmap pixmap, bool fromCache);
+            const CoverInfoRelative& info, QPixmap pixmap, bool fromCache);
     void slotTrackCoverArtUpdated();
 
     // slots that handle signals from WCoverArtMenu
     void slotCoverMenu(const QPoint& pos);
-    void slotCoverInfoSelected(const CoverInfo& coverInfo);
+    void slotCoverInfoSelected(const CoverInfoRelative& coverInfo);
     void slotReloadCoverArt();
 
   private:

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -90,11 +90,11 @@ void DlgTrackInfo::init() {
 
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache != NULL) {
-        connect(pCache, SIGNAL(coverFound(const QObject*, const CoverInfo&, QPixmap, bool)),
-                this, SLOT(slotCoverFound(const QObject*, const CoverInfo&, QPixmap, bool)));
+        connect(pCache, SIGNAL(coverFound(const QObject*, const CoverInfoRelative&, QPixmap, bool)),
+                this, SLOT(slotCoverFound(const QObject*, const CoverInfoRelative&, QPixmap, bool)));
     }
-    connect(m_pWCoverArtLabel, SIGNAL(coverInfoSelected(const CoverInfo&)),
-            this, SLOT(slotCoverInfoSelected(const CoverInfo&)));
+    connect(m_pWCoverArtLabel, SIGNAL(coverInfoSelected(const CoverInfoRelative&)),
+            this, SLOT(slotCoverInfoSelected(const CoverInfoRelative&)));
     connect(m_pWCoverArtLabel, SIGNAL(reloadCoverArt()),
             this, SLOT(slotReloadCoverArt()));
 }
@@ -177,7 +177,7 @@ void DlgTrackInfo::populateFields(const Track& track) {
 
     reloadTrackBeats(track);
 
-    m_loadedCoverInfo = track.getCoverInfo();
+    m_loadedCoverInfo = track.getCoverInfoWithLocation();
     m_pWCoverArtLabel->setCoverArt(m_loadedCoverInfo, QPixmap());
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache != NULL) {
@@ -227,7 +227,7 @@ void DlgTrackInfo::loadTrack(TrackPointer pTrack) {
 }
 
 void DlgTrackInfo::slotCoverFound(const QObject* pRequestor,
-                                  const CoverInfo& info,
+                                  const CoverInfoRelative& info,
                                   QPixmap pixmap, bool fromCache) {
     Q_UNUSED(fromCache);
     if (pRequestor == this && m_pLoadedTrack &&

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -62,7 +62,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotOpenInFileBrowser();
 
     void slotCoverFound(const QObject* pRequestor,
-                        const CoverInfo& info, QPixmap pixmap, bool fromCache);
+                        const CoverInfoRelative& info, QPixmap pixmap, bool fromCache);
     void slotCoverInfoSelected(const CoverInfo& coverInfo);
     void slotReloadCoverArt();
 

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -455,9 +455,7 @@ void SoundSourceProxy::updateTrackFromSource(
         return; // abort
     }
 
-    // Cast away the enriched track location by explicitly slicing the
-    // returned CoverInfo to CoverInfoRelative
-    const CoverInfoRelative coverInfo(m_pTrack->getCoverInfo());
+    const CoverInfoRelative coverInfo = m_pTrack->getCoverInfo();
 
     QImage coverImg;
     DEBUG_ASSERT(coverImg.isNull());
@@ -531,21 +529,21 @@ void SoundSourceProxy::updateTrackFromSource(
     m_pTrack->setTrackMetadata(trackMetadata, metadataImported.second);
 
     if (pCoverImg) {
-        CoverInfoRelative coverInfoRelative;
+        CoverInfoRelative coverInfoNew;
         if (pCoverImg->isNull()) {
             kLogger.info()
                     << "No embedded cover art found in file"
                     << getUrl().toString();
             // Cover art should be (re-)set to none
-            DEBUG_ASSERT(coverInfoRelative.type == CoverInfo::NONE);
+            DEBUG_ASSERT(coverInfoNew.type == CoverInfo::NONE);
         } else {
-            coverInfoRelative.type = CoverInfo::METADATA;
-            coverInfoRelative.source = CoverInfo::GUESSED;
-            DEBUG_ASSERT(coverInfoRelative.coverLocation.isEmpty());
+            coverInfoNew.type = CoverInfo::METADATA;
+            coverInfoNew.source = CoverInfo::GUESSED;
+            DEBUG_ASSERT(coverInfoNew.coverLocation.isEmpty());
             // TODO(XXX) here we may introduce a duplicate hash code
-            coverInfoRelative.hash = CoverArtUtils::calculateHash(coverImg);
+            coverInfoNew.hash = CoverArtUtils::calculateHash(coverImg);
         }
-        m_pTrack->setCoverInfo(coverInfoRelative);
+        m_pTrack->setCoverInfo(coverInfoNew);
     }
 }
 

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -126,7 +126,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
     // Looking for a track with embedded cover.
     pTrack = TrackPointer(Track::newTemporary(kTrackLocationTest));
     SoundSourceProxy(pTrack).updateTrackFromSource();
-    CoverInfo result = pTrack->getCoverInfo();
+    CoverInfo result = pTrack->getCoverInfoWithLocation();
     EXPECT_EQ(result.type, CoverInfo::METADATA);
     EXPECT_EQ(result.source, CoverInfo::GUESSED);
     EXPECT_EQ(result.coverLocation, QString());

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -910,26 +910,14 @@ bool Track::isBpmLocked() const {
     return m_record.getBpmLocked();
 }
 
-void Track::setCoverInfo(const CoverInfoRelative& coverInfoRelative) {
+void Track::setCoverInfo(const CoverInfoRelative& coverInfo) {
+    DEBUG_ASSERT((coverInfo.type != CoverInfo::METADATA) || coverInfo.coverLocation.isEmpty());
+    DEBUG_ASSERT((coverInfo.source != CoverInfo::UNKNOWN) || (coverInfo.type == CoverInfo::NONE));
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(&m_record.refCoverInfo(), coverInfoRelative)) {
+    if (compareAndSet(&m_record.refCoverInfo(), coverInfo)) {
         markDirtyAndUnlock(&lock);
         emit(coverArtUpdated());
     }
-}
-
-void Track::setCoverInfo(const CoverInfo& coverInfo) {
-    CoverInfoRelative coverInfoRelative(coverInfo);
-    QMutexLocker lock(&m_qMutex);
-    DEBUG_ASSERT(coverInfo.trackLocation == m_fileInfo.absoluteFilePath());
-    if (compareAndSet(&m_record.refCoverInfo(), coverInfoRelative)) {
-        markDirtyAndUnlock(&lock);
-        emit(coverArtUpdated());
-    }
-}
-
-void Track::setCoverInfo(const CoverArt& coverArt) {
-    setCoverInfo(static_cast<const CoverInfo&>(coverArt));
 }
 
 CoverInfo Track::getCoverInfo() const {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -920,7 +920,12 @@ void Track::setCoverInfo(const CoverInfoRelative& coverInfo) {
     }
 }
 
-CoverInfo Track::getCoverInfo() const {
+CoverInfoRelative Track::getCoverInfo() const {
+    QMutexLocker lock(&m_qMutex);
+    return m_record.getCoverInfo();
+}
+
+CoverInfo Track::getCoverInfoWithLocation() const {
     QMutexLocker lock(&m_qMutex);
     return CoverInfo(m_record.getCoverInfo(), m_fileInfo.absoluteFilePath());
 }

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -269,8 +269,8 @@ class Track : public QObject {
     QString getKeyText() const;
 
     void setCoverInfo(const CoverInfoRelative& coverInfo);
-
-    CoverInfo getCoverInfo() const;
+    CoverInfoRelative getCoverInfo() const;
+    CoverInfo getCoverInfoWithLocation() const;
 
     quint16 getCoverHash() const;
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -268,9 +268,7 @@ class Track : public QObject {
     mixxx::track::io::key::ChromaticKey getKey() const;
     QString getKeyText() const;
 
-    void setCoverInfo(const CoverInfoRelative& coverInfoRelative);
-    void setCoverInfo(const CoverInfo& coverInfo);
-    void setCoverInfo(const CoverArt& coverArt);
+    void setCoverInfo(const CoverInfoRelative& coverInfo);
 
     CoverInfo getCoverInfo() const;
 

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -33,12 +33,12 @@ WCoverArt::WCoverArt(QWidget* parent,
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache != nullptr) {
         connect(pCache, SIGNAL(coverFound(const QObject*,
-                                          const CoverInfo&, QPixmap, bool)),
+                                          const CoverInfoRelative&, QPixmap, bool)),
                 this, SLOT(slotCoverFound(const QObject*,
-                                          const CoverInfo&, QPixmap, bool)));
+                                          const CoverInfoRelative&, QPixmap, bool)));
     }
-    connect(m_pMenu, SIGNAL(coverInfoSelected(const CoverInfo&)),
-            this, SLOT(slotCoverInfoSelected(const CoverInfo&)));
+    connect(m_pMenu, SIGNAL(coverInfoSelected(const CoverInfoRelative&)),
+            this, SLOT(slotCoverInfoSelected(const CoverInfoRelative&)));
     connect(m_pMenu, SIGNAL(reloadCoverArt()),
             this, SLOT(slotReloadCoverArt()));
 
@@ -105,7 +105,7 @@ void WCoverArt::slotReloadCoverArt() {
     }
 }
 
-void WCoverArt::slotCoverInfoSelected(const CoverInfo& coverInfo) {
+void WCoverArt::slotCoverInfoSelected(const CoverInfoRelative& coverInfo) {
     if (m_loadedTrack) {
         // Will trigger slotTrackCoverArtUpdated().
         m_loadedTrack->setCoverInfo(coverInfo);
@@ -147,7 +147,7 @@ void WCoverArt::slotTrackCoverArtUpdated() {
 }
 
 void WCoverArt::slotCoverFound(const QObject* pRequestor,
-                               const CoverInfo& info, QPixmap pixmap,
+                               const CoverInfoRelative& info, QPixmap pixmap,
                                bool fromCache) {
     Q_UNUSED(info);
     Q_UNUSED(fromCache);

--- a/src/widget/wcoverart.h
+++ b/src/widget/wcoverart.h
@@ -36,8 +36,8 @@ class WCoverArt : public QWidget, public WBaseWidget {
 
   private slots:
     void slotCoverFound(const QObject* pRequestor,
-                        const CoverInfo& info, QPixmap pixmap, bool fromCache);
-    void slotCoverInfoSelected(const CoverInfo& coverInfo);
+                        const CoverInfoRelative& info, QPixmap pixmap, bool fromCache);
+    void slotCoverInfoSelected(const CoverInfoRelative& coverInfo);
     void slotReloadCoverArt();
     void slotTrackCoverArtUpdated();
 

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -18,8 +18,8 @@ WCoverArtLabel::WCoverArtLabel(QWidget* parent)
     setContextMenuPolicy(Qt::CustomContextMenu);
     connect(this, SIGNAL(customContextMenuRequested(QPoint)),
             this, SLOT(slotCoverMenu(QPoint)));
-    connect(m_pCoverMenu, SIGNAL(coverInfoSelected(const CoverInfo&)),
-            this, SIGNAL(coverInfoSelected(const CoverInfo&)));
+    connect(m_pCoverMenu, SIGNAL(coverInfoSelected(const CoverInfoRelative&)),
+            this, SIGNAL(coverInfoSelected(const CoverInfoRelative&)));
     connect(m_pCoverMenu, SIGNAL(reloadCoverArt()),
             this, SIGNAL(reloadCoverArt()));
 

--- a/src/widget/wcoverartlabel.h
+++ b/src/widget/wcoverartlabel.h
@@ -21,7 +21,7 @@ class WCoverArtLabel : public QLabel {
     void loadTrack(TrackPointer pTrack);
 
   signals:
-    void coverInfoSelected(const CoverInfo& coverInfo);
+    void coverInfoSelected(const CoverInfoRelative& coverInfo);
     void reloadCoverArt();
 
   protected:

--- a/src/widget/wcoverartmenu.cpp
+++ b/src/widget/wcoverartmenu.cpp
@@ -69,7 +69,7 @@ void WCoverArtMenu::slotChange() {
 
     // TODO(rryan): Ask if user wants to copy the file.
 
-    CoverInfo coverInfo;
+    CoverInfoRelative coverInfo;
     // Create a security token for the file.
     QFileInfo selectedCover(selectedCoverPath);
     SecurityTokenPointer pToken = Sandbox::openSecurityToken(
@@ -84,7 +84,6 @@ void WCoverArtMenu::slotChange() {
     coverInfo.coverLocation = selectedCoverPath;
     // TODO() here we may introduce a duplicate hash code
     coverInfo.hash = CoverArtUtils::calculateHash(image);
-    coverInfo.trackLocation = m_coverInfo.trackLocation;
     qDebug() << "WCoverArtMenu::slotChange emit" << coverInfo;
     emit(coverInfoSelected(coverInfo));
 }

--- a/src/widget/wcoverartmenu.h
+++ b/src/widget/wcoverartmenu.h
@@ -23,7 +23,7 @@ class WCoverArtMenu : public QMenu {
     void setCoverArt(const CoverInfo& coverInfo);
 
   signals:
-    void coverInfoSelected(const CoverInfo& coverInfo);
+    void coverInfoSelected(const CoverInfoRelative& coverInfo);
     void reloadCoverArt();
 
   private slots:

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -76,9 +76,9 @@ WSpinny::WSpinny(QWidget* parent, const QString& group,
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache != nullptr) {
         connect(pCache, SIGNAL(coverFound(const QObject*,
-                                          const CoverInfo&, QPixmap, bool)),
+                                          const CoverInfoRelative&, QPixmap, bool)),
                 this, SLOT(slotCoverFound(const QObject*,
-                                          const CoverInfo&, QPixmap, bool)));
+                                          const CoverInfoRelative&, QPixmap, bool)));
     }
 
     if (m_pPlayer != nullptr) {
@@ -90,8 +90,8 @@ WSpinny::WSpinny(QWidget* parent, const QString& group,
         slotLoadTrack(m_pPlayer->getLoadedTrack());
     }
 
-    connect(m_pCoverMenu, SIGNAL(coverInfoSelected(const CoverInfo&)),
-        this, SLOT(slotCoverInfoSelected(const CoverInfo&)));
+    connect(m_pCoverMenu, SIGNAL(coverInfoSelected(const CoverInfoRelative&)),
+        this, SLOT(slotCoverInfoSelected(const CoverInfoRelative&)));
     connect(m_pCoverMenu, SIGNAL(reloadCoverArt()),
         this, SLOT(slotReloadCoverArt()));
 }
@@ -282,7 +282,7 @@ void WSpinny::slotTrackCoverArtUpdated() {
 }
 
 void WSpinny::slotCoverFound(const QObject* pRequestor,
-                             const CoverInfo& info, QPixmap pixmap,
+                             const CoverInfoRelative& info, QPixmap pixmap,
                              bool fromCache) {
     Q_UNUSED(info);
     Q_UNUSED(fromCache);
@@ -297,7 +297,7 @@ void WSpinny::slotCoverFound(const QObject* pRequestor,
     }
 }
 
-void WSpinny::slotCoverInfoSelected(const CoverInfo& coverInfo) {
+void WSpinny::slotCoverInfoSelected(const CoverInfoRelative& coverInfo) {
     if (m_loadedTrack != nullptr) {
         // Will trigger slotTrackCoverArtUpdated().
         m_loadedTrack->setCoverInfo(coverInfo);

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -47,8 +47,8 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
   protected slots:
     void maybeUpdate();
     void slotCoverFound(const QObject* pRequestor,
-                        const CoverInfo& info, QPixmap pixmap, bool fromCache);
-    void slotCoverInfoSelected(const CoverInfo& coverInfo);
+                        const CoverInfoRelative& info, QPixmap pixmap, bool fromCache);
+    void slotCoverInfoSelected(const CoverInfoRelative& coverInfo);
     void slotReloadCoverArt();
     void slotTrackCoverArtUpdated();
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -100,8 +100,8 @@ WTrackTableView::WTrackTableView(QWidget * parent,
     m_pCoverMenu = new WCoverArtMenu(this);
     m_pCoverMenu->setTitle(tr("Cover Art"));
 
-    connect(m_pCoverMenu, SIGNAL(coverInfoSelected(const CoverInfo&)),
-            this, SLOT(slotCoverInfoSelected(const CoverInfo&)));
+    connect(m_pCoverMenu, SIGNAL(coverInfoSelected(const CoverInfoRelative&)),
+            this, SLOT(slotCoverInfoSelected(const CoverInfoRelative&)));
     connect(m_pCoverMenu, SIGNAL(reloadCoverArt()),
             this, SLOT(slotReloadCoverArt()));
 
@@ -1915,7 +1915,7 @@ void WTrackTableView::slotClearAllMetadata() {
     slotClearWaveform();
 }
 
-void WTrackTableView::slotCoverInfoSelected(const CoverInfo& coverInfo) {
+void WTrackTableView::slotCoverInfoSelected(const CoverInfoRelative& coverInfo) {
     TrackModel* trackModel = getTrackModel();
     if (trackModel == nullptr) {
         return;

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -89,7 +89,7 @@ class WTrackTableView : public WLibraryTableView {
     // Signalled 20 times per second (every 50ms) by GuiTick.
     void slotGuiTick50ms(double);
     void slotScrollValueChanged(int);
-    void slotCoverInfoSelected(const CoverInfo& coverInfo);
+    void slotCoverInfoSelected(const CoverInfoRelative& coverInfo);
     void slotReloadCoverArt();
 
     void slotTrackInfoClosed();


### PR DESCRIPTION
While analyzing [lp1743866](https://bugs.launchpad.net/mixxx/+bug/1743866) I found some minor issues and an opportunity for optimization:
- Fixed debug assertion when clearing cover manually
- Use CoverInfoRelative instead of CoverInfo without the track's actual location wherever possible

Unfortunately I cannot reproduce the reported bug and analyzing the code didn't reveal any issues. User selected cover art is never overruled implicitly. Only guessed or unknown cover art might be updated while loading tracks.