### PR TITLE
Tango 2.1beta :: fix tooltips & Lib radio buttons

### DIFF
--- a/res/skins/Tango/buttons/btn_lib_radio_button_off.svg
+++ b/res/skins/Tango/buttons/btn_lib_radio_button_off.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="100%"
+   height="100%"
+   viewBox="0 0 18 18"
+   id="svg2">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     d="M 9,2 C 5.1323,2 2,5.1323 2,9 c 0,3.8677 3.1323,7 7,7 3.8677,0 7,-3.1323 7,-7 C 16,5.1323 12.868,2 9,2 z M 9,14.6 C 5.906,14.6 3.4,12.094 3.4,9 3.4,5.906 5.906,3.4 9,3.4 c 3.094,0 5.6,2.506 5.6,5.6 0,3.094 -2.506,5.6 -5.6,5.6 z"
+     id="path4"
+     style="fill:#d2d2d2;fill-opacity:1" />
+</svg>

--- a/res/skins/Tango/buttons/btn_lib_radio_button_on.svg
+++ b/res/skins/Tango/buttons/btn_lib_radio_button_on.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="100%"
+   height="100%"
+   viewBox="0 0 18 18"
+   id="svg2">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     d="M 9,4.2652658 C 6.3864267,4.2652658 4.2652658,6.3864267 4.2652658,9 c 0,2.613573 2.1211609,4.734734 4.7347342,4.734734 2.613573,0 4.734734,-2.121161 4.734734,-4.734734 C 13.734734,6.3864267 11.613573,4.2652658 9,4.2652658 z"
+     id="path2987"
+     style="fill:#ff8800;fill-opacity:1" />
+  <path
+     d="M 9,2 C 5.1325,2 2,5.1325 2,9 c 0,3.8675 3.1325,7 7,7 3.8675,0 7,-3.1325 7,-7 C 16,5.1325 12.868,2 9,2 z M 9,3.40625 C 12.094,3.40625 14.59375,5.906 14.59375,9 14.59375,12.094 12.094,14.59375 9,14.59375 5.906,14.59375 3.40625,12.094 3.40625,9 3.40625,5.906 5.906,3.40625 9,3.40625 z"
+     id="path2985"
+     style="fill:#d2d2d2;fill-opacity:1" />
+</svg>

--- a/res/skins/Tango/deck_overview_left.xml
+++ b/res/skins/Tango/deck_overview_left.xml
@@ -78,6 +78,7 @@ Variables:
                 <Children>
                   <Template src="skin:button_2state.xml">
                     <SetVariable name="ObjectName">VinylTogglerLeftPassthrough</SetVariable>
+                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
                     <SetVariable name="Size">15f,50f</SetVariable>
                     <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
                   </Template>
@@ -94,6 +95,7 @@ Variables:
                 <Children>
                   <Template src="skin:button_2state.xml">
                     <SetVariable name="ObjectName">VinylTogglerLeft</SetVariable>
+                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
                     <SetVariable name="Size">15f,50f</SetVariable>
                     <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
                   </Template>

--- a/res/skins/Tango/deck_overview_right.xml
+++ b/res/skins/Tango/deck_overview_right.xml
@@ -86,6 +86,7 @@ Variables:
                 <Children>
                   <Template src="skin:button_2state.xml">
                     <SetVariable name="ObjectName">VinylTogglerRightPassthrough</SetVariable>
+                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
                     <SetVariable name="Size">15f,50f</SetVariable>
                     <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
                   </Template>
@@ -102,6 +103,7 @@ Variables:
                 <Children>
                   <Template src="skin:button_2state.xml">
                     <SetVariable name="ObjectName">VinylTogglerRight</SetVariable>
+                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
                     <SetVariable name="Size">15f,50f</SetVariable>
                     <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
                   </Template>

--- a/res/skins/Tango/mic_aux.xml
+++ b/res/skins/Tango/mic_aux.xml
@@ -59,6 +59,7 @@ Description:
                   <Template src="skin:button_3state_persist.xml">
                     <SetVariable name="ObjectName">MicDuckingButton</SetVariable>
                     <SetVariable name="Size">42f,24f</SetVariable>
+                    <SetVariable name="TooltipId">talkover_duck_mode</SetVariable>
                     <SetVariable name="state_0_text">DUCK</SetVariable>
                     <SetVariable name="state_1_text">AUTO</SetVariable>
                     <SetVariable name="state_2_text">MAN</SetVariable>
@@ -86,7 +87,7 @@ Description:
                       </WidgetGroup>
 
                       <Template src="skin:knob_textless.xml">
-                        <SetVariable name="TooltipId"></SetVariable>
+                        <SetVariable name="TooltipId">talkover_duck_strength</SetVariable>
                         <SetVariable name="ObjectName">MicAuxKnob</SetVariable>
                         <SetVariable name="Size">28f,28f</SetVariable>
                         <SetVariable name="group">[Master]</SetVariable>

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2363,8 +2363,25 @@ QRadioButton {	/*
   Extra declaration for QRadioButton otherwise it shows up with
   wrong colors in Linux with Gnome 	*/
   color: #cfcfcf;
-  }
+}
 
+WLibrary QRadioButton#radioButtonRecentlyAdded,
+WLibrary QRadioButton#radioButtonAllSongs {
+  padding: 1px 3px 3px 1px;
+  color: #cfcfcf;
+}
+
+WLibrary QRadioButton#radioButtonRecentlyAdded {
+  margin: 0px 3px 0px 5px;
+}
+
+WLibrary QRadioButton::indicator:checked {
+  background: url(skin:/buttons/btn_lib_radio_button_on.svg);
+}
+
+WLibrary QRadioButton::indicator:unchecked {
+  background: url(skin:/buttons/btn_lib_radio_button_off.svg);
+}
 /* Test :: increase font size of WOverview "Ready to play, analyzing..." etc.
 WOverview {
   font-size: 16px/16px;


### PR DESCRIPTION
- attempt to fix [lp:1744814](https://bugs.launchpad.net/mixxx/+bug/1744814) (Analyze radio buttons)
- add tooltips to Mic ducking controls
- add tooltips to vinyl controls toggles next to overview waveforms

Anyone has an idea how to style the html links in Crates & Playlists? [lp:1744816](https://bugs.launchpad.net/mixxx/+bug/1744816)
"Create New Playlist" [playlistfeature.cpp#L234](https://github.com/mixxxdj/mixxx/blob/2.1/src/library/playlistfeature.cpp#L234)
"Create New Crate" [cratefeature.cpp#L155](https://github.com/mixxxdj/mixxx/blob/2.1/src/library/crate/cratefeature.cpp#L155)