### PR TITLE
Deere :: use gapless ring for HeadMix knob

### DIFF
--- a/res/skins/Deere/tool_bar.xml
+++ b/res/skins/Deere/tool_bar.xml
@@ -53,7 +53,7 @@
                 <SetVariable name="TooltipId">headMix</SetVariable>
                 <SetVariable name="group">[Master]</SetVariable>
                 <SetVariable name="control">headMix</SetVariable>
-                <SetVariable name="color">blue</SetVariable>
+                <SetVariable name="color">blue_gapless</SetVariable>
                 <SetVariable name="label">Head Mix</SetVariable>
               </Template>
 


### PR DESCRIPTION
The HeadMix knob defaults to fully left, so center gap is pointless.