### PR TITLE
color schema style

### DIFF
--- a/src/skin/colorschemeparser.cpp
+++ b/src/skin/colorschemeparser.cpp
@@ -10,9 +10,11 @@
 #include "skin/imgloader.h"
 #include "skin/imgcolor.h"
 #include "skin/imginvert.h"
+#include "skin/legacyskinparser.h"
 
 void ColorSchemeParser::setupLegacyColorSchemes(QDomElement docElem,
-                                                UserSettingsPointer pConfig) {
+                                                UserSettingsPointer pConfig,
+                                                QString* pStyle) {
     QDomNode colsch = docElem.namedItem("Schemes");
 
     bool found = false;
@@ -41,6 +43,10 @@ void ColorSchemeParser::setupLegacyColorSchemes(QDomElement docElem,
             WPixmapStore::setLoader(imsrc);
             WImageStore::setLoader(imsrc);
             WSkinColor::setLoader(imsrc);
+
+            if (pStyle) {
+                *pStyle = LegacySkinParser::getStyleFromNode(sch);
+            }
         }
     }
     if (!found) {

--- a/src/skin/colorschemeparser.h
+++ b/src/skin/colorschemeparser.h
@@ -7,7 +7,8 @@ class ImgSource;
 
 class ColorSchemeParser {
   public:
-    static void setupLegacyColorSchemes(QDomElement docElem, UserSettingsPointer pConfig);
+    static void setupLegacyColorSchemes(
+            QDomElement docElem, UserSettingsPointer pConfig, QString* pStyle);
   private:
     static ImgSource* parseFilters(QDomNode filter);
     ColorSchemeParser() { }

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -372,7 +372,7 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
         }
     }
 
-    ColorSchemeParser::setupLegacyColorSchemes(skinDocument, m_pConfig);
+    ColorSchemeParser::setupLegacyColorSchemes(skinDocument, m_pConfig, &m_style);
 
     QStringList skinPaths(skinPath);
     QDir::setSearchPaths("skin", skinPaths);
@@ -1966,13 +1966,18 @@ void LegacySkinParser::setupWidget(const QDomNode& node,
     }
     setupSize(node, pWidget);
 
-    QString style = getStyleFromNode(node);
     // Check if we should apply legacy library styling to this node.
     if (m_pContext->selectBool(node, "LegacyTableViewStyle", false)) {
-        style = getLibraryStyle(node);
+        m_style.append(getLibraryStyle(node));
+    } else {
+        // use append here, because we may have already a style from the
+        // color shema.
+        m_style.append(getStyleFromNode(node));
     }
-    if (!style.isEmpty()) {
-        pWidget->setStyleSheet(style);
+
+    if (!m_style.isEmpty()) {
+        pWidget->setStyleSheet(m_style);
+        m_style.clear(); // only apply color scheme to the first widget
     }
 }
 

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1847,8 +1847,9 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
     }
 }
 
+//static
 QString LegacySkinParser::getStyleFromNode(const QDomNode& node) {
-    QDomElement styleElement = m_pContext->selectElement(node, "Style");
+    QDomElement styleElement = SkinContext::selectElement(node, "Style");
 
     if (styleElement.isNull()) {
         return QString();

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1966,18 +1966,18 @@ void LegacySkinParser::setupWidget(const QDomNode& node,
     }
     setupSize(node, pWidget);
 
+    QString style = getStyleFromNode(node);
     // Check if we should apply legacy library styling to this node.
     if (m_pContext->selectBool(node, "LegacyTableViewStyle", false)) {
-        m_style.append(getLibraryStyle(node));
-    } else {
-        // use append here, because we may have already a style from the
-        // color shema.
-        m_style.append(getStyleFromNode(node));
+        style = getLibraryStyle(node);
     }
-
+    // check if we have a style from color schema: 
     if (!m_style.isEmpty()) {
-        pWidget->setStyleSheet(m_style);
+        style.append(m_style);
         m_style.clear(); // only apply color scheme to the first widget
+    }
+    if (!style.isEmpty()) {
+        pWidget->setStyleSheet(style);
     }
 }
 

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -53,6 +53,8 @@ class LegacySkinParser : public QObject, public SkinParser {
     static Qt::MouseButton parseButtonState(const QDomNode& node,
                                             const SkinContext& context);
 
+    static QString getStyleFromNode(const QDomNode& node);
+
   private:
     static QDomElement openSkin(const QString& skinPath);
 
@@ -125,7 +127,6 @@ class LegacySkinParser : public QObject, public SkinParser {
     void setupConnections(const QDomNode& node, WBaseWidget* pWidget);
     void addShortcutToToolTip(WBaseWidget* pWidget, const QString& shortcut, const QString& cmd);
     QString getLibraryStyle(const QDomNode& node);
-    QString getStyleFromNode(const QDomNode& node);
 
     QString lookupNodeGroup(const QDomElement& node);
     static const char* safeChannelString(const QString& channelStr);

--- a/src/skin/legacyskinparser.h
+++ b/src/skin/legacyskinparser.h
@@ -147,6 +147,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     RecordingManager* m_pRecordingManager;
     QWidget* m_pParent;
     std::unique_ptr<SkinContext> m_pContext;
+    QString m_style;
     Tooltips m_tooltips;
     QHash<QString, QDomElement> m_templateCache;
     static QList<const char*> s_channelStrs;

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -55,7 +55,7 @@ class SkinContext {
     // Updates the SkinContext with 'element', a <SetVariable> node.
     void updateVariable(const QDomElement& element);
 
-    inline QDomNode selectNode(const QDomNode& node, const QString& nodeName) const {
+    static inline QDomNode selectNode(const QDomNode& node, const QString& nodeName) {
         QDomNode child = node.firstChild();
         while (!child.isNull()) {
             if (child.nodeName() == nodeName) {
@@ -66,7 +66,7 @@ class SkinContext {
         return QDomNode();
     }
 
-    inline QDomElement selectElement(const QDomNode& node, const QString& nodeName) const {
+    static inline QDomElement selectElement(const QDomNode& node, const QString& nodeName) {
         QDomNode child = selectNode(node, nodeName);
         return child.toElement();
     }


### PR DESCRIPTION
This PR allows to add a style region to the color schema like this 

```
		<Scheme>
			<Name>Dark</Name>
			<Filters>
				<HSVTweak>
					<HConst>90</HConst>
					<SConst>-30</SConst>
					<VConst>-30</VConst>
				</HSVTweak>
				<Add>
					<Amount>-40</Amount>
				</Add>
			</Filters>
		    <Style src="skin:dark.qss"/>
		</Scheme> 
```

it is required for Shade and the SpinBox and ComboBox controls. 

The read style is stored and merged with the style of the next widget parsed, the base widget of the skin. 

It would be cool if we use this also to add a daylight schema our upcoming 2.1 default skin. 
 

