### PR TITLE
lp1689014 : Fix crash when parsing bad xml controller file

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -388,6 +388,10 @@ void DlgPrefController::slotLoadPreset(int chosenIndex) {
     ControllerPresetPointer pPreset = ControllerPresetFileHandler::loadPreset(
         presetPath, ControllerManager::getPresetPaths(m_pConfig));
 
+    if (!pPreset) {
+        return;
+    }
+
     // Import the preset scripts to the user scripts folder.
     for (QList<ControllerPreset::ScriptFileInfo>::iterator it =
                  pPreset->scripts.begin(); it != pPreset->scripts.end(); ++it) {

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -389,9 +389,6 @@ void DlgPrefController::slotLoadPreset(int chosenIndex) {
         presetPath, ControllerManager::getPresetPaths(m_pConfig));
 
     if (!pPreset) {
-        QMessageBox::warning(
-            this, tr("Action failed"),
-            tr("Failed to parse preset file"));
         return;
     }
 

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -389,6 +389,9 @@ void DlgPrefController::slotLoadPreset(int chosenIndex) {
         presetPath, ControllerManager::getPresetPaths(m_pConfig));
 
     if (!pPreset) {
+        QMessageBox::warning(
+            this, tr("Action failed"),
+            tr("Failed to parse preset file"));
         return;
     }
 


### PR DESCRIPTION
[https://bugs.launchpad.net/mixxx/+bug/1689014](https://bugs.launchpad.net/mixxx/+bug/1689014)

Ignores ill-formatted XML files when  loading a controller preset instead of crashing. 