### PR TITLE
lp1746325 : Fix empty deck can be played

### DIFF
--- a/src/engine/cachingreaderworker.cpp
+++ b/src/engine/cachingreaderworker.cpp
@@ -129,9 +129,6 @@ mixxx::AudioSourcePointer openAudioSourceForReading(const TrackPointer& pTrack, 
 } // anonymous namespace
 
 void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
-    // Emit that a new track is loading, stops the current track
-    emit(trackLoading());
-
     ReaderStatusUpdate status;
     status.status = TRACK_NOT_LOADED;
 
@@ -142,6 +139,9 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
         m_pReaderStatusFIFO->writeBlocking(&status, 1);
         return;
     }
+
+    // Emit that a new track is loading, stops the current track
+    emit(trackLoading());
 
     QString filename = pTrack->getLocation();
     if (filename.isEmpty() || !pTrack->exists()) {


### PR DESCRIPTION
Issue : when a deck is empty (after ejecting or when loading a track failed), it is possible to play it.
Cause : Unloading a track is done by loading an empty track. This is a special case where the deck would enter a 'track loading' state without exiting it. A deck can be played when it is loading a track.
Fix : Do not consider a track is loading when it is an empty track.
