### PR TITLE
Allow waveform to scale up above 100%

### DIFF
--- a/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
@@ -99,7 +99,7 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
         }
         glEnd();
 
-        glLineWidth(1.1);
+        glLineWidth(2.0);
         glEnable(GL_LINE_SMOOTH);
 
         glBegin(GL_LINES); {
@@ -155,7 +155,7 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
 
         glScalef(1.f,allGain,1.f);
 
-        glLineWidth(1.1);
+        glLineWidth(2.0);
         glEnable(GL_LINE_SMOOTH);
 
         glBegin(GL_LINES); {

--- a/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
@@ -67,7 +67,6 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
     float maxLow[2];
     float maxMid[2];
     float maxHigh[2];
-    float meanIndex;
 
 #ifndef __OPENGLES__
 
@@ -99,10 +98,7 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
         }
         glEnd();
 
-        glLineWidth(2.0);
-        glEnable(GL_LINE_SMOOTH);
-
-        glBegin(GL_LINES); {
+        glBegin(GL_QUADS); {
             for (int visualIndex = firstVisualIndex;
                  visualIndex < lastVisualIndex;
                  visualIndex += 2) {
@@ -120,19 +116,23 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
                 maxMid[1] = (float)data[visualIndex+1].filtered.mid;
                 maxHigh[1] = (float)data[visualIndex+1].filtered.high;
 
-                meanIndex = visualIndex;
-
                 glColor4f(m_lowColor_r, m_lowColor_g, m_lowColor_b, 0.8);
-                glVertex2f(meanIndex,lowGain*maxLow[0]);
-                glVertex2f(meanIndex,-1.f*lowGain*maxLow[1]);
+                glVertex2f(visualIndex - 1.0f, lowGain * maxLow[0]);
+                glVertex2f(visualIndex - 1.0f, -1.0f * lowGain * maxLow[1]);
+                glVertex2f(visualIndex + 1.0f, -1.0f * lowGain * maxLow[1]);
+                glVertex2f(visualIndex + 1.0f, lowGain * maxLow[0]);
 
                 glColor4f(m_midColor_r, m_midColor_g, m_midColor_b, 0.85);
-                glVertex2f(meanIndex,midGain*maxMid[0]);
-                glVertex2f(meanIndex,-1.f*midGain*maxMid[1]);
+                glVertex2f(visualIndex - 1.0f, midGain * maxMid[0]);
+                glVertex2f(visualIndex - 1.0f, -1.0f * midGain * maxMid[1]);
+                glVertex2f(visualIndex + 1.0f, -1.0f * midGain * maxMid[1]);
+                glVertex2f(visualIndex + 1.0f, midGain * maxMid[0]);
 
                 glColor4f(m_highColor_r, m_highColor_g, m_highColor_b, 0.9);
-                glVertex2f(meanIndex,highGain*maxHigh[0]);
-                glVertex2f(meanIndex,-1.f*highGain*maxHigh[1]);
+                glVertex2f(visualIndex - 1.0f, highGain * maxHigh[0]);
+                glVertex2f(visualIndex - 1.0f, -1.0f * highGain * maxHigh[1]);
+                glVertex2f(visualIndex + 1.0f, -1.0f * highGain * maxHigh[1]);
+                glVertex2f(visualIndex + 1.0f, highGain * maxHigh[0]);
             }
         }
         glEnd();
@@ -155,10 +155,7 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
 
         glScalef(1.f,allGain,1.f);
 
-        glLineWidth(2.0);
-        glEnable(GL_LINE_SMOOTH);
-
-        glBegin(GL_LINES); {
+        glBegin(GL_QUADS); {
             for (int visualIndex = firstVisualIndex;
                  visualIndex < lastVisualIndex;
                  visualIndex += 2) {
@@ -177,16 +174,22 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
                 maxHigh[1] = (float)data[visualIndex+1].filtered.high;
 
                 glColor4f(m_lowColor_r, m_lowColor_g, m_lowColor_b, 0.8);
-                glVertex2f(float(visualIndex),0.f);
-                glVertex2f(float(visualIndex),lowGain*math_max(maxLow[0],maxLow[1]));
+                glVertex2f(float(visualIndex) - 1.0f, 0.0f);
+                glVertex2f(float(visualIndex) - 1.0f, lowGain * math_max(maxLow[0], maxLow[1]));
+                glVertex2f(float(visualIndex) + 1.0f, lowGain * math_max(maxLow[0], maxLow[1]));
+                glVertex2f(float(visualIndex) + 1.0f, 0.0f);
 
                 glColor4f(m_midColor_r, m_midColor_g, m_midColor_b, 0.85);
-                glVertex2f(float(visualIndex),0.f);
-                glVertex2f(float(visualIndex),midGain*math_max(maxMid[0],maxMid[1]));
+                glVertex2f(float(visualIndex) - 1.0f, 0.0f);
+                glVertex2f(float(visualIndex) - 1.0f, midGain * math_max(maxMid[0], maxMid[1]));
+                glVertex2f(float(visualIndex) + 1.0f, midGain * math_max(maxMid[0], maxMid[1]));
+                glVertex2f(float(visualIndex) + 1.0f, 0.0f);
 
                 glColor4f(m_highColor_r, m_highColor_g, m_highColor_b, 0.9);
-                glVertex2f(float(visualIndex),0.f);
-                glVertex2f(float(visualIndex),highGain*math_max(maxHigh[0],maxHigh[1]));
+                glVertex2f(float(visualIndex) - 1.0f, 0.0f);
+                glVertex2f(float(visualIndex) - 1.0f, highGain * math_max(maxHigh[0], maxHigh[1]));
+                glVertex2f(float(visualIndex) + 1.0f, highGain * math_max(maxHigh[0], maxHigh[1]));
+                glVertex2f(float(visualIndex) + 1.0f, 0.0f);
             }
         }
         glEnd();

--- a/src/waveform/renderers/glwaveformrendererrgb.cpp
+++ b/src/waveform/renderers/glwaveformrendererrgb.cpp
@@ -91,10 +91,7 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
         }
         glEnd();
 
-        glLineWidth(2.0);
-        glEnable(GL_LINE_SMOOTH);
-
-        glBegin(GL_LINES); {
+        glBegin(GL_QUADS); {
             for (int visualIndex = firstVisualIndex;
                  visualIndex < lastVisualIndex;
                  visualIndex += 2) {
@@ -107,6 +104,7 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
                     break;
                 }
 
+
                 float left_low    = lowGain  * (float) data[visualIndex].filtered.low;
                 float left_mid    = midGain  * (float) data[visualIndex].filtered.mid;
                 float left_high   = highGain * (float) data[visualIndex].filtered.high;
@@ -117,8 +115,10 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
                 float left_max    = math_max3(left_red, left_green, left_blue);
                 if (left_max > 0.0f) {  // Prevent division by zero
                     glColor4f(left_red / left_max, left_green / left_max, left_blue / left_max, 0.8f);
-                    glVertex2f(visualIndex, 0.0f);
-                    glVertex2f(visualIndex, left_all);
+                    glVertex2f(visualIndex - 1.0f, 0.0f);
+                    glVertex2f(visualIndex - 1.0f, left_all);
+                    glVertex2f(visualIndex + 1.0f, left_all);
+                    glVertex2f(visualIndex + 1.0f, 0.0f);
                 }
 
                 float right_low   = lowGain  * (float) data[visualIndex+1].filtered.low;
@@ -131,8 +131,10 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
                 float right_max   = math_max3(right_red, right_green, right_blue);
                 if (right_max > 0.0f) {  // Prevent division by zero
                     glColor4f(right_red / right_max, right_green / right_max, right_blue / right_max, 0.8f);
-                    glVertex2f(visualIndex, 0.0f);
-                    glVertex2f(visualIndex, -1.0f * right_all);
+                    glVertex2f(visualIndex - 1.0f, 0.0f);
+                    glVertex2f(visualIndex - 1.0f, -1.0f * right_all);
+                    glVertex2f(visualIndex + 1.0f, -1.0f * right_all);
+                    glVertex2f(visualIndex + 1.0f, 0.0f);
                 }
             }
         }
@@ -159,10 +161,7 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
 
         glScalef(1.0f, allGain, 1.0f);
 
-        glLineWidth(2.0);
-        glEnable(GL_LINE_SMOOTH);
-
-        glBegin(GL_LINES); {
+        glBegin(GL_QUADS); {
             for (int visualIndex = firstVisualIndex;
                  visualIndex < lastVisualIndex;
                  visualIndex += 2) {
@@ -188,8 +187,10 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
                 float max = math_max3(red, green, blue);
                 if (max > 0.0f) {  // Prevent division by zero
                     glColor4f(red / max, green / max, blue / max, 0.9f);
-                    glVertex2f(float(visualIndex), 0.0f);
-                    glVertex2f(float(visualIndex), all);
+                    glVertex2f(float(visualIndex) - 1.0f, 0.0f);
+                    glVertex2f(float(visualIndex) - 1.0f, all);
+                    glVertex2f(float(visualIndex) + 1.0f, all);
+                    glVertex2f(float(visualIndex) + 1.0f, 0.0f);
                 }
             }
         }

--- a/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
@@ -97,10 +97,7 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
         }
         glEnd();
 
-        glLineWidth(2.0);
-        glEnable(GL_LINE_SMOOTH);
-
-        glBegin(GL_LINES); {
+        glBegin(GL_QUADS); {
             for (int visualIndex = firstVisualIndex;
                  visualIndex < lastVisualIndex;
                  visualIndex += 2) {
@@ -114,8 +111,10 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
                 maxAll[0] = (float)data[visualIndex].filtered.all;
                 maxAll[1] = (float)data[visualIndex+1].filtered.all;
                 glColor4f(m_signalColor_r, m_signalColor_g, m_signalColor_b, 0.9);
-                glVertex2f(visualIndex,maxAll[0]);
-                glVertex2f(visualIndex,-1.f*maxAll[1]);
+                glVertex2f(visualIndex - 1.0f, maxAll[0]);
+                glVertex2f(visualIndex - 1.0f, -1.0f * maxAll[1]);
+                glVertex2f(visualIndex + 1.0f, -1.0f * maxAll[1]);
+                glVertex2f(visualIndex + 1.0f, maxAll[0]);
             }
         }
         glEnd();
@@ -138,10 +137,7 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
 
         glScalef(1.f, allGain, 1.f);
 
-        glLineWidth(2.0);
-        glEnable(GL_LINE_SMOOTH);
-
-        glBegin(GL_LINES); {
+        glBegin(GL_QUADS); {
             for (int visualIndex = firstVisualIndex;
                  visualIndex < lastVisualIndex;
                  visualIndex += 2) {
@@ -155,8 +151,10 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
                 maxAll[0] = (float)data[visualIndex].filtered.all;
                 maxAll[1] = (float)data[visualIndex+1].filtered.all;
                 glColor4f(m_signalColor_r, m_signalColor_g, m_signalColor_b, 0.8);
-                glVertex2f(float(visualIndex),0.f);
-                glVertex2f(float(visualIndex),math_max(maxAll[0],maxAll[1]));
+                glVertex2f(float(visualIndex) - 1.0f, 0.0f);
+                glVertex2f(float(visualIndex) - 1.0f, math_max(maxAll[0], maxAll[1]));
+                glVertex2f(float(visualIndex) + 1.0f, math_max(maxAll[0], maxAll[1]));
+                glVertex2f(float(visualIndex) + 1.0f, 0.0f);
             }
         }
         glEnd();

--- a/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
@@ -97,7 +97,7 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
         }
         glEnd();
 
-        glLineWidth(1.1);
+        glLineWidth(2.0);
         glEnable(GL_LINE_SMOOTH);
 
         glBegin(GL_LINES); {
@@ -138,7 +138,7 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
 
         glScalef(1.f, allGain, 1.f);
 
-        glLineWidth(1.1);
+        glLineWidth(2.0);
         glEnable(GL_LINE_SMOOTH);
 
         glBegin(GL_LINES); {

--- a/src/waveform/renderers/waveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.cpp
@@ -221,15 +221,17 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
         }
     }
 
-    painter->setPen(QPen(QBrush(m_pColors->getLowColor()), 1));
+    double lineThickness = math_max(1.0, 1.0 / m_waveformRenderer->getVisualSamplePerPixel());
+
+    painter->setPen(QPen(QBrush(m_pColors->getLowColor()), lineThickness, Qt::SolidLine, Qt::FlatCap));
     if (m_pLowKillControlObject && m_pLowKillControlObject->get() == 0.0) {
        painter->drawLines(&m_lowLines[0], actualLowLineNumber);
     }
-    painter->setPen(QPen(QBrush(m_pColors->getMidColor()), 1));
+    painter->setPen(QPen(QBrush(m_pColors->getMidColor()), lineThickness, Qt::SolidLine, Qt::FlatCap));
     if (m_pMidKillControlObject && m_pMidKillControlObject->get() == 0.0) {
         painter->drawLines(&m_midLines[0], actualMidLineNumber);
     }
-    painter->setPen(QPen(QBrush(m_pColors->getHighColor()), 1));
+    painter->setPen(QPen(QBrush(m_pColors->getHighColor()), lineThickness, Qt::SolidLine, Qt::FlatCap));
     if (m_pHighKillControlObject && m_pHighKillControlObject->get() == 0.0) {
         painter->drawLines(&m_highLines[0], actualHighLineNumber);
     }

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -78,6 +78,10 @@ void WaveformRendererHSV::draw(QPainter* painter,
     QColor color;
     float lo, hi, total;
 
+    QPen pen;
+    pen.setCapStyle(Qt::FlatCap);
+    pen.setWidth(math_max(1.0, 1.0 / m_waveformRenderer->getVisualSamplePerPixel()));
+
     const int breadth = m_waveformRenderer->getBreadth();
     const float halfBreadth = (float)breadth / 2.0;
 
@@ -155,7 +159,9 @@ void WaveformRendererHSV::draw(QPainter* painter,
             // Set color
             color.setHsvF(h, 1.0-hi, 1.0-lo);
 
-            painter->setPen(color);
+            pen.setColor(color);
+
+            painter->setPen(pen);
             switch (m_alignment) {
                 case Qt::AlignBottom :
                 case Qt::AlignRight :

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -69,6 +69,10 @@ void WaveformRendererRGB::draw(QPainter* painter,
 
     QColor color;
 
+    QPen pen;
+    pen.setCapStyle(Qt::FlatCap);
+    pen.setWidthF(math_max(1.0, 1.0 / m_waveformRenderer->getVisualSamplePerPixel()));
+
     const int breadth = m_waveformRenderer->getBreadth();
     const float halfBreadth = (float)breadth / 2.0;
 
@@ -149,7 +153,9 @@ void WaveformRendererRGB::draw(QPainter* painter,
             // Set color
             color.setRgbF(red / max, green / max, blue / max);
 
-            painter->setPen(color);
+            pen.setColor(color);
+
+            painter->setPen(pen);
             switch (m_alignment) {
                 case Qt::AlignBottom:
                 case Qt::AlignRight:

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -120,9 +120,7 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
     //Legacy stuff (Ryan it that OK?) -> Limit our rate adjustment to < 99%, "Bad Things" might happen otherwise.
     m_rateAdjust = m_rateDir * math_min(0.99, m_rate * m_rateRange);
 
-    //rate adjust may have change sampling per
-    //vRince for the moment only more than one sample per pixel is supported
-    //due to the fact we play the visual play pos modulo floor m_visualSamplePerPixel ...
+    // Allow waveform to spread one visual sample across two pixels
     double visualSamplePerPixel = m_zoomFactor * (1.0 + m_rateAdjust) / m_scaleFactor;
     m_visualSamplePerPixel = math_max(0.5, visualSamplePerPixel);
 

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -124,7 +124,7 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
     //vRince for the moment only more than one sample per pixel is supported
     //due to the fact we play the visual play pos modulo floor m_visualSamplePerPixel ...
     double visualSamplePerPixel = m_zoomFactor * (1.0 + m_rateAdjust) / m_scaleFactor;
-    m_visualSamplePerPixel = math_max(1.0, visualSamplePerPixel);
+    m_visualSamplePerPixel = math_max(0.5, visualSamplePerPixel);
 
     TrackPointer pTrack(m_pTrack);
     ConstWaveformPointer pWaveform = pTrack ? pTrack->getWaveform() : ConstWaveformPointer();

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -120,9 +120,12 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
     //Legacy stuff (Ryan it that OK?) -> Limit our rate adjustment to < 99%, "Bad Things" might happen otherwise.
     m_rateAdjust = m_rateDir * math_min(0.99, m_rate * m_rateRange);
 
-    // Allow waveform to spread one visual sample across two pixels
+    // Compute visual sample to pixel ratio
+    // Allow waveform to spread one visual sample across a hundred pixels
+    // NOTE: The hundred pixel limit is totally arbitrary. Theoretically,
+    // there should be no limit to how far the waveforms can be zoomed in.
     double visualSamplePerPixel = m_zoomFactor * (1.0 + m_rateAdjust) / m_scaleFactor;
-    m_visualSamplePerPixel = math_max(0.5, visualSamplePerPixel);
+    m_visualSamplePerPixel = math_max(0.01, visualSamplePerPixel);
 
     TrackPointer pTrack(m_pTrack);
     ConstWaveformPointer pWaveform = pTrack ? pTrack->getWaveform() : ConstWaveformPointer();


### PR DESCRIPTION
This PR fixes an usability issue when beat-matching with waveforms zoomed at 100%.

(I know, I should beat-match by ear, not by eye.) 😄 

EDIT: This also fixes issue that waveform doesn't scale up with HiDPI scaling setting, as well as these:

https://bugs.launchpad.net/mixxx/+bug/1269146
https://bugs.launchpad.net/mixxx/+bug/1751331
