### PR TITLE
move Record/Broadcast input to the bottom of configuration dialog

### DIFF
--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -60,10 +60,10 @@ public:
         BOOTH,
         BUS,
         DECK,
-        RECORD_BROADCAST,
         VINYLCONTROL,
         MICROPHONE,
         AUXILIARY,
+        RECORD_BROADCAST,
         INVALID, // if this isn't last bad things will happen -bkgood
     };
     AudioPath(unsigned char channelBase, unsigned char channels);


### PR DESCRIPTION
Lots of 2.1 beta users have been getting confused and configuring their microphone inputs for the Record/Broadcast input. Hopefully this helps and doesn't make the new Record/Broadcast feature too hard to find.