### PR TITLE
Skins :: fix CPU usage & end-of-track warning when waveforms are hidden/collapsed

### DIFF
--- a/res/skins/Deere/skin.xml
+++ b/res/skins/Deere/skin.xml
@@ -186,6 +186,7 @@
             <WidgetGroup><!-- Parallel Waveforms -->
               <ObjectName>Waveforms</ObjectName>
               <Layout>vertical</Layout>
+              <Size>-1me,4min</Size>
               <Connection>
                 <ConfigKey>[Deere],show_parallel_waveforms</ConfigKey>
                 <BindProperty>visible</BindProperty>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -73,6 +73,14 @@
     <!-- Define singletons as early in the skin as possible.  Note that the
     library doesn't actually appear here, it's just instantiated and configured.
     -->
+
+    <SingletonDefinition>
+      <ObjectName>WaveformsSingleton</ObjectName>
+      <Children>
+        <Template src="skin:waveforms_singleton.xml"/>
+      </Children>
+    </SingletonDefinition>
+
     <SingletonDefinition>
       <ObjectName>LibrarySingleton</ObjectName>
       <Children>

--- a/res/skins/LateNight/waveforms.xml
+++ b/res/skins/LateNight/waveforms.xml
@@ -4,81 +4,16 @@
     <SizePolicy>me,min</SizePolicy>
     <Children>
 
-      <WidgetGroup><!-- Waveforms -->
-        <Layout>vertical</Layout>
-        <SizePolicy>me,min</SizePolicy>
+      <!-- Waveforms -->
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Size>100me,40me</Size>
         <Children>
-
-          <WidgetGroup><!-- Waveform 3 -->
-            <Layout>horizontal</Layout>
-            <SizePolicy>me,me</SizePolicy>
-            <Children>
-              <Template src="skin:waveform.xml">
-                <SetVariable name="channum">3</SetVariable>
-                <SetVariable name="signal_color">#09B2AE</SetVariable>
-                <SetVariable name="SignalBgColor">#012322</SetVariable>
-                <SetVariable name="SignalRGBLowColor">#cb3433</SetVariable>
-                <SetVariable name="SignalRGBMidColor">#00ff33</SetVariable>
-                <SetVariable name="SignalRGBHighColor">#0034fe</SetVariable>
-              </Template>
-            </Children>
-            <Connection>
-              <ConfigKey persist="true">[Master],show_4decks</ConfigKey>
-              <BindProperty>visible</BindProperty>
-            </Connection>
-          </WidgetGroup><!-- Waveform 3 -->
-
-          <WidgetGroup><!-- Waveform 1 -->
-            <Layout>horizontal</Layout>
-            <SizePolicy>me,me</SizePolicy>
-            <Children>
-              <Template src="skin:waveform.xml">
-                <SetVariable name="channum">1</SetVariable>
-                <SetVariable name="signal_color">#E7C413</SetVariable>
-                <SetVariable name="SignalBgColor">#2f290a</SetVariable>
-                <SetVariable name="SignalRGBLowColor">#ff2a00</SetVariable>
-                <SetVariable name="SignalRGBMidColor">#33f600</SetVariable>
-                <SetVariable name="SignalRGBHighColor">#332acc</SetVariable>
-              </Template>
-            </Children>
-          </WidgetGroup>
-
-          <WidgetGroup><!-- Waveform 2 -->
-            <Layout>horizontal</Layout>
-            <SizePolicy>me,me</SizePolicy>
-            <Children>
-              <Template src="skin:waveform.xml">
-                <SetVariable name="channum">2</SetVariable>
-                <SetVariable name="signal_color">#E7C413</SetVariable>
-                <SetVariable name="SignalBgColor">#2f290a</SetVariable>
-                <SetVariable name="SignalRGBLowColor">#ff2a00</SetVariable>
-                <SetVariable name="SignalRGBMidColor">#33f600</SetVariable>
-                <SetVariable name="SignalRGBHighColor">#332acc</SetVariable>
-              </Template>
-            </Children>
-          </WidgetGroup><!-- Waveform 2 -->
-
-          <WidgetGroup><!-- Waveform 4 -->
-            <Layout>horizontal</Layout>
-            <SizePolicy>me,me</SizePolicy>
-            <Children>
-              <Template src="skin:waveform.xml">
-                <SetVariable name="channum">4</SetVariable>
-                <SetVariable name="signal_color">#09B2AE</SetVariable>
-                <SetVariable name="SignalBgColor">#012322</SetVariable>
-                <SetVariable name="SignalRGBLowColor">#cb3433</SetVariable>
-                <SetVariable name="SignalRGBMidColor">#00ff33</SetVariable>
-                <SetVariable name="SignalRGBHighColor">#0034fe</SetVariable>
-              </Template>
-            </Children>
-            <Connection>
-              <ConfigKey persist="true">[Master],show_4decks</ConfigKey>
-              <BindProperty>visible</BindProperty>
-            </Connection>
-          </WidgetGroup><!-- Waveform 4 -->
-
+          <SingletonContainer>
+            <ObjectName>WaveformsSingleton</ObjectName>
+          </SingletonContainer>
         </Children>
-      </WidgetGroup><!-- /Waveforms -->
+      </WidgetGroup>
 
       <PushButton>
         <ObjectName>BeatgridButtonsToggle</ObjectName>

--- a/res/skins/LateNight/waveforms_singleton.xml
+++ b/res/skins/LateNight/waveforms_singleton.xml
@@ -1,0 +1,85 @@
+<Template>
+  <WidgetGroup>
+    <Layout>horizontal</Layout>
+    <SizePolicy>me,min</SizePolicy>
+    <Children>
+
+      <WidgetGroup><!-- Waveforms -->
+        <Layout>vertical</Layout>
+        <SizePolicy>me,min</SizePolicy>
+        <Children>
+
+          <WidgetGroup><!-- Waveform 3 -->
+            <Layout>horizontal</Layout>
+            <SizePolicy>me,me</SizePolicy>
+            <Children>
+              <Template src="skin:waveform.xml">
+                <SetVariable name="channum">3</SetVariable>
+                <SetVariable name="signal_color">#09B2AE</SetVariable>
+                <SetVariable name="SignalBgColor">#012322</SetVariable>
+                <SetVariable name="SignalRGBLowColor">#cb3433</SetVariable>
+                <SetVariable name="SignalRGBMidColor">#00ff33</SetVariable>
+                <SetVariable name="SignalRGBHighColor">#0034fe</SetVariable>
+              </Template>
+            </Children>
+            <Connection>
+              <ConfigKey persist="true">[Master],show_4decks</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup><!-- Waveform 3 -->
+
+          <WidgetGroup><!-- Waveform 1 -->
+            <Layout>horizontal</Layout>
+            <SizePolicy>me,me</SizePolicy>
+            <Children>
+              <Template src="skin:waveform.xml">
+                <SetVariable name="channum">1</SetVariable>
+                <SetVariable name="signal_color">#E7C413</SetVariable>
+                <SetVariable name="SignalBgColor">#2f290a</SetVariable>
+                <SetVariable name="SignalRGBLowColor">#ff2a00</SetVariable>
+                <SetVariable name="SignalRGBMidColor">#33f600</SetVariable>
+                <SetVariable name="SignalRGBHighColor">#332acc</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup>
+
+          <WidgetGroup><!-- Waveform 2 -->
+            <Layout>horizontal</Layout>
+            <SizePolicy>me,me</SizePolicy>
+            <Children>
+              <Template src="skin:waveform.xml">
+                <SetVariable name="channum">2</SetVariable>
+                <SetVariable name="signal_color">#E7C413</SetVariable>
+                <SetVariable name="SignalBgColor">#2f290a</SetVariable>
+                <SetVariable name="SignalRGBLowColor">#ff2a00</SetVariable>
+                <SetVariable name="SignalRGBMidColor">#33f600</SetVariable>
+                <SetVariable name="SignalRGBHighColor">#332acc</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup><!-- Waveform 2 -->
+
+          <WidgetGroup><!-- Waveform 4 -->
+            <Layout>horizontal</Layout>
+            <SizePolicy>me,me</SizePolicy>
+            <Children>
+              <Template src="skin:waveform.xml">
+                <SetVariable name="channum">4</SetVariable>
+                <SetVariable name="signal_color">#09B2AE</SetVariable>
+                <SetVariable name="SignalBgColor">#012322</SetVariable>
+                <SetVariable name="SignalRGBLowColor">#cb3433</SetVariable>
+                <SetVariable name="SignalRGBMidColor">#00ff33</SetVariable>
+                <SetVariable name="SignalRGBHighColor">#0034fe</SetVariable>
+              </Template>
+            </Children>
+            <Connection>
+              <ConfigKey persist="true">[Master],show_4decks</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup><!-- Waveform 4 -->
+
+        </Children>
+      </WidgetGroup><!-- /Waveforms -->
+
+    </Children>
+  </WidgetGroup>
+</Template>

--- a/res/skins/Tango/skin.xml
+++ b/res/skins/Tango/skin.xml
@@ -188,6 +188,14 @@
      Singleton definitions  #######################################
    ############################################################### -->
     <SingletonDefinition>
+      <ObjectName>Waveforms_Singleton</ObjectName>
+      <Children>
+        <Template src="skin:waveforms_container.xml"/>
+      </Children>
+    </SingletonDefinition>
+
+
+    <SingletonDefinition>
       <ObjectName>Library_Singleton</ObjectName>
       <Children>
         <Template src="skin:library.xml"/>
@@ -262,7 +270,9 @@
                       <Layout>vertical</Layout>
                       <SizePolicy>me,max</SizePolicy>
                       <Children>
-                        <Template src="skin:waveforms_container.xml"/>
+                        <SingletonContainer>
+                          <ObjectName>Waveforms_Singleton</ObjectName>
+                        </SingletonContainer>
                       </Children>
                       <Connection>
                         <ConfigKey persist="true">[Tango],stacked_waveforms</ConfigKey>
@@ -276,6 +286,25 @@
                       <Children>
 
                         <Template src="skin:decks_12.xml"/>
+
+                    <!-- Load scrolling waveforms Singleton here if the waveforms
+                        in the waveforms/decks Splitter are collapsed.
+                        Otherwise the end-of-track warning would not show up
+                        in overview waveforms. -->
+                        <WidgetGroup>
+                          <Layout>vertical</Layout>
+                          <Size>0me,0f</Size>
+                          <Children>
+                            <SingletonContainer>
+                              <ObjectName>Waveforms_Singleton</ObjectName>
+                            </SingletonContainer>
+                          </Children>
+                          <Connection>
+                            <ConfigKey persist="true">[Tango],stacked_waveforms</ConfigKey>
+                            <Transform><Not/></Transform>
+                            <BindProperty>visible</BindProperty>
+                          </Connection>
+                        </WidgetGroup>
 
                         <WidgetGroup>
                           <Layout>vertical</Layout>


### PR DESCRIPTION
This fixes [lp:1746475 "CPU usage doubles when hiding waveforms"](https://bugs.launchpad.net/mixxx/+bug/1746475) in Deere & LateNight
and [lp:1746110 "No end of track warning if Waveform Display not enabled"](https://bugs.launchpad.net/mixxx/+bug/1746110) in Tango

Symptoms reported in [lp:1748170 "Log file grows rapidly"](https://bugs.launchpad.net/mixxx/+bug/1748170), log file is spammed with these entries:
```
Warning [Main]: QPainter::begin: Paint device returned engine == 0, type: 3
Warning [Main]: QPainter::setRenderHint: Painter must be active to set rendering hints
Warning [Main]: QPainter::setMatrixEnabled: Painter not active
Warning [Main]: QPainter::setPen: Painter not active
Warning [Main]: QPainter::setBrush: Painter not active
Warning [Main]: QPainter::setBrush: Painter not active
Warning [Main]: QPainter::setFont: Painter not active
Warning [Main]: QPainter::setPen: Painter not active
Warning [Main]: QPainter::begin: Paint device returned engine == 0, type: 3
Warning [Main]: QPainter::setRenderHint: Painter must be active to set rendering hints
```

Deere > CPU
> set minimum container height in waveforms/decks Splitter to 4px. this has no effect in skin but is apparently sufficient to keep CPU usage constant


LateNight > CPU
> load waveforms as Singleton, set minimum container height in waveforms/decks Splitter to 40px


Tango > end-of-track warning
> load waveforms as Singleton and place it below decks with zero height if top waveforms are hidden

