### PR TITLE
[Don't merge] lp1748758: Fix metadata export of selected tracks

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -194,13 +194,15 @@ void TrackDAO::saveTrack(GlobalTrackCacheLocker* pCacheLocker, Track* pTrack) {
     if (pTrack->isDirty()) {
         qDebug() << "TrackDAO: Saving track" << pTrack->getLocation();
 
-        // Write audio meta data, if enabled in the preferences.
+        // Write audio meta data, if explicitly requested by the user
+        // for this track or enabled in the preferences for all tracks.
         //
         // This must be done before updating the database, because
         // a timestamp is used to keep track of when metadata has been
         // last synchronized. Exporting metadata will update this time
         // stamp on the track object!
-        if (m_pConfig && m_pConfig->getValueString(ConfigKey("[Library]","SyncTrackMetadataExport")).toInt() == 1) {
+        if (pTrack->isMarkedForMetadataExport() ||
+                (m_pConfig && m_pConfig->getValueString(ConfigKey("[Library]","SyncTrackMetadataExport")).toInt() == 1)) {
             SoundSourceProxy::exportTrackMetadataBeforeSaving(pTrack);
         }
 

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -191,42 +191,46 @@ bool TrackDAO::trackExistsInDatabase(const QString& absoluteFilePath) {
 void TrackDAO::saveTrack(GlobalTrackCacheLocker* pCacheLocker, Track* pTrack) {
     DEBUG_ASSERT(pTrack);
 
+    // Write audio meta data, if explicitly requested by the user
+    // for individual tracks or enabled in the preferences for all
+    // tracks.
+    //
+    // This must be done before updating the database, because
+    // a timestamp is used to keep track of when metadata has been
+    // last synchronized. Exporting metadata will update this time
+    // stamp on the track object!
+    if (pTrack->isMarkedForMetadataExport() ||
+            (pTrack->isDirty() && m_pConfig && m_pConfig->getValueString(ConfigKey("[Library]","SyncTrackMetadataExport")).toInt() == 1)) {
+        SoundSourceProxy::exportTrackMetadataBeforeSaving(pTrack);
+    }
+
+    // The track cache can safely be unlocked now that the metadata has
+    // been exported to the file. Updating the database is thread-safe
+    // an we accept this very small chance of a race condition here.
+    // Exporting metadata to a file cannot be rolled back if updating
+    // the database fails, so we have to account for inconsistencies
+    // in any case!
+    // Unlocking the cache now reduces lock contention and keeps the
+    // UI as responsive as possible.
+    if (pCacheLocker) {
+        pCacheLocker->unlockCache();
+    }
+
     if (pTrack->isDirty()) {
-        qDebug() << "TrackDAO: Saving track" << pTrack->getLocation();
-
-        // Write audio meta data, if explicitly requested by the user
-        // for this track or enabled in the preferences for all tracks.
-        //
-        // This must be done before updating the database, because
-        // a timestamp is used to keep track of when metadata has been
-        // last synchronized. Exporting metadata will update this time
-        // stamp on the track object!
-        if (pTrack->isMarkedForMetadataExport() ||
-                (m_pConfig && m_pConfig->getValueString(ConfigKey("[Library]","SyncTrackMetadataExport")).toInt() == 1)) {
-            SoundSourceProxy::exportTrackMetadataBeforeSaving(pTrack);
-        }
-
-        // The track cache can safely be unlocked now that the metadata has
-        // been exported to the file. Updating the database is thread-safe
-        // an we accept this very small chance of a race condition here.
-        // Exporting metadata to a file cannot be rolled back if updating
-        // the database fails, so we have to account for inconsistencies
-        // in any case!
-        // Unlocking the cache now reduces lock contention and keeps the
-        // UI as responsive as possible.
-        if (pCacheLocker) {
-            pCacheLocker->unlockCache();
-        }
-
+        const TrackId trackId = pTrack->getId();
         // Only update the database if the track has already been added!
-        const TrackId trackId(pTrack->getId());
-        if (trackId.isValid() && updateTrack(pTrack)) {
-            // BaseTrackCache must be informed separately, because the
-            // track has already been disconnected and TrackDAO does
-            // not receive any signals that are usually forwarded to
-            // BaseTrackCache.
-            DEBUG_ASSERT(!pTrack->isDirty());
-            emit(trackClean(trackId));
+        if (trackId.isValid()) {
+            qDebug() << "TrackDAO: Saving track"
+                    << trackId
+                    << pTrack->getLocation();
+            if (updateTrack(pTrack)) {
+                // BaseTrackCache must be informed separately, because the
+                // track has already been disconnected and TrackDAO does
+                // not receive any signals that are usually forwarded to
+                // BaseTrackCache.
+                DEBUG_ASSERT(!pTrack->isDirty());
+                emit(trackClean(trackId));
+            }
         }
     }
 }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -830,9 +830,9 @@ bool Track::isDirty() {
 
 void Track::markForMetadataExport() {
     QMutexLocker lock(&m_qMutex);
-    if (compareAndSet(&m_bMarkedForMetadataExport, true)) {
-        markDirtyAndUnlock(&lock);
-    }
+    m_bMarkedForMetadataExport = true;
+    // No need to mark the track as dirty, because this flag
+    // is transient and not stored in the database.
 }
 
 bool Track::isMarkedForMetadataExport() const {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -835,6 +835,11 @@ void Track::markForMetadataExport() {
     }
 }
 
+bool Track::isMarkedForMetadataExport() const {
+    QMutexLocker lock(&m_qMutex);
+    return m_bMarkedForMetadataExport;
+}
+
 int Track::getRating() const {
     QMutexLocker lock(&m_qMutex);
     return m_record.getRating();

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -295,6 +295,7 @@ class Track : public QObject {
     // export is deferred to prevent race conditions when writing into
     // files that are still opened for reading.
     void markForMetadataExport();
+    bool isMarkedForMetadataExport() const;
 
   public slots:
     void slotCueUpdated();

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1496,6 +1496,7 @@ void WTrackTableView::slotExportTrackMetadataIntoFileTags() {
             // corresponding track object have been dropped. Otherwise
             // writing to files that are still used for playback might
             // cause crashes or at least audible glitches!
+            mixxx::DlgTrackMetadataExport::showMessageBoxOncePerSession();
             pTrack->markForMetadataExport();
         }
     }


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1748758

- Metadata must be exported for selected tracks even if the general preference option is disabled
- The _dirty_ and the _export metadata_ flag of a track need to be handled separately
