### PR TITLE
Fixed erroneous indicators after track eject

### DIFF
--- a/src/engine/cachingreaderworker.cpp
+++ b/src/engine/cachingreaderworker.cpp
@@ -129,9 +129,6 @@ mixxx::AudioSourcePointer openAudioSourceForReading(const TrackPointer& pTrack, 
 } // anonymous namespace
 
 void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
-    // Emit that a new track is loading, stops the current track
-    emit(trackLoading());
-
     ReaderStatusUpdate status;
     status.status = TRACK_NOT_LOADED;
 
@@ -142,6 +139,9 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
         m_pReaderStatusFIFO->writeBlocking(&status, 1);
         return;
     }
+
+    // Emit that a new track is loading, stops the current track
+    emit(trackLoading());
 
     QString filename = pTrack->getLocation();
     if (filename.isEmpty() || !pTrack->exists()) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -566,6 +566,10 @@ void EngineBuffer::ejectTrack() {
     m_playButton->set(0.0);
     m_visualBpm->set(0.0);
     m_visualKey->set(0.0);
+    m_timeElapsed->set(0);
+    m_timeRemaining->set(0);
+    m_playposSlider->set(0);
+    m_pCueControl->updateIndicators();
     doSeekFractional(0.0, SEEK_EXACT);
     m_pause.unlock();
 


### PR DESCRIPTION
[https://bugs.launchpad.net/mixxx/+bug/1741359](https://bugs.launchpad.net/mixxx/+bug/1741359)

- Fixed toggling play button after track eject in all CUE modes.
- Fixed blinking play button after track eject in all blinking CUE modes.
- Fixed time indicators after track eject.

The deck thread got stuck in loading state after ejecting a track which caused the play button indicators to malfunction. The time indicators were not being reset.

P.S.: This is my first PR :)