### PR TITLE
reimplement parameters reflecting metaknob when switching effects

### DIFF
--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -183,6 +183,8 @@ void EffectSlot::loadEffect(EffectPointer pEffect) {
             pParameter->loadEffect(pEffect);
         }
 
+        slotEffectMetaParameter(m_pControlMetaParameter->get(), true);
+
         emit(effectLoaded(pEffect, m_iEffectNumber));
     } else {
         clear();


### PR DESCRIPTION
This behavior was implemented in 59872909392e2b7f70218cf1497e41d585fc1ec0 in PR #1062 then broken by PR #1148. We are in feature freeze for 2.1 and the new feature proposed in #1148 has not been properly implemented. 2.1 is currently in a broken state, as [reported by a new user](https://bugs.launchpad.net/mixxx/+bug/1750649). This reverts to the intended behavior from PR #1062, which extended the behavior of the superknob when switching effect chains in Mixxx 2.0 down to the metaknobs when switching effects.