### PR TITLE
fix scaling of WEffectSelector and WBeatSpinBox

### DIFF
--- a/res/skins/Deere/effect_single_no_parameters.xml
+++ b/res/skins/Deere/effect_single_no_parameters.xml
@@ -35,6 +35,7 @@ Variables:
             <EffectRack><Variable name="EffectRack"/></EffectRack>
             <EffectUnit><Variable name="EffectUnit"/></EffectUnit>
             <Effect><Variable name="Effect"/></Effect>
+            <Size>120f,-1</Size>
           </EffectSelector>
 
         </Children>
@@ -82,6 +83,7 @@ Variables:
             <EffectRack><Variable name="EffectRack"/></EffectRack>
             <EffectUnit><Variable name="EffectUnit"/></EffectUnit>
             <Effect><Variable name="Effect"/></Effect>
+            <Size>120f,-1</Size>
           </EffectSelector>
 
         </Children>

--- a/res/skins/Deere/effect_single_with_parameters_row.xml
+++ b/res/skins/Deere/effect_single_with_parameters_row.xml
@@ -55,6 +55,7 @@ Variables:
             <EffectRack><Variable name="EffectRack"/></EffectRack>
             <EffectUnit><Variable name="EffectUnit"/></EffectUnit>
             <Effect><Variable name="Effect"/></Effect>
+            <Size>120f,-1</Size>
           </EffectSelector>
 
           <Template src="skin:effect_parameter_knob.xml">

--- a/res/skins/LateNight/fx_slot.xml
+++ b/res/skins/LateNight/fx_slot.xml
@@ -81,12 +81,10 @@
 
           <WidgetGroup>
             <Layout>horizontal</Layout>
-            <MinimumSize>72,26</MinimumSize>
-            <MaximumSize>120,-1</MaximumSize>
-            <SizePolicy>me,me</SizePolicy>
+            <Size>120f,26f</Size>
             <Children>
               <EffectSelector>
-                <Size>72me,26p</Size>
+                <Size>120f,26f</Size>
                 <EffectRack><Variable name="FxRack"/></EffectRack>
                 <EffectUnit><Variable name="FxUnit"/></EffectUnit>
                 <Effect><Variable name="FxNum"/></Effect>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -1202,8 +1202,7 @@ WEffectSelector {
     }
 
   WEffectSelector QAbstractItemView {
-    min-width: 142px;
-    max-width: 200px;
+    width: 142px;
     background-color: #0f0f0f;
     /* padding-left: 6px; */
     font-size: 12px/13px;

--- a/res/skins/Tango/fx_toggle_selector.xml
+++ b/res/skins/Tango/fx_toggle_selector.xml
@@ -55,6 +55,7 @@ Variables:
         <EffectUnit><Variable name="FxUnit"/></EffectUnit>
         <Effect><Variable name="FxNum"/></Effect>
         <Elide>right</Elide>
+        <Size>82f,20f</Size>
       </EffectSelector>
 
     </Children>

--- a/src/widget/wbeatspinbox.cpp
+++ b/src/widget/wbeatspinbox.cpp
@@ -10,7 +10,8 @@ QRegExp WBeatSpinBox::s_regexpBlacklist("[^0-9.,/ ]");
 
 WBeatSpinBox::WBeatSpinBox(QWidget * parent, ControlObject* pValueControl,
                            int decimals, double minimum, double maximum)
-        : WBaseWidget(parent),
+        : QDoubleSpinBox(parent),
+          WBaseWidget(this),
           m_valueControl(
             pValueControl ?
             pValueControl->getKey() : ConfigKey(), this

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -7,7 +7,7 @@
 
 WEffectSelector::WEffectSelector(QWidget* pParent, EffectsManager* pEffectsManager)
         : QComboBox(pParent),
-          WBaseWidget(pParent),
+          WBaseWidget(this),
           m_pEffectsManager(pEffectsManager),
           m_scaleFactor(1.0) {
     // Prevent this widget from getting focused to avoid


### PR DESCRIPTION
~~This was easier than expected. :)~~ This was pretty tricky to find the bug.

Before:
![image](https://user-images.githubusercontent.com/9455094/36543586-c47e1f48-17a9-11e8-8130-7ffbf3181c95.png)

After:
![screenshot from 2018-02-22 08-14-21](https://user-images.githubusercontent.com/9455094/36543639-eb10f16c-17a9-11e8-99a0-3ae92609a150.png)

The selection arrow still does not scale, but that's not a big deal.