### PR TITLE
Initialize WaveformRendererEndOfTrack::m_pTimeRemainingControl

### DIFF
--- a/src/waveform/renderers/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/waveformrendererendoftrack.cpp
@@ -21,6 +21,7 @@ WaveformRendererEndOfTrack::WaveformRendererEndOfTrack(
       m_pTrackSampleRate(NULL),
       m_pPlayControl(NULL),
       m_pLoopControl(NULL),
+      m_pTimeRemainingControl(NULL),
       m_color(200, 25, 20),
       m_remainingTimeTriggerSeconds(30),
       m_blinkingPeriodMillis(1000) {


### PR DESCRIPTION
cppcheck reported:
[waveform/renderers/waveformrendererendoftrack.cpp:16]: (warning) Member variable 'WaveformRendererEndOfTrack::m_pTimeRemainingControl' is not initialized in the constructor.

While looking at the code I think a

delete m_pTimeRemainingControl;

is missing in the destructor, too?

Feel free to cherry-pick this single commit.
