### PR TITLE
reimplement sorting order of controller mappings from 2.0

### DIFF
--- a/src/controllers/controllerpresetinfo.cpp
+++ b/src/controllers/controllerpresetinfo.cpp
@@ -29,7 +29,9 @@ PresetInfo::PresetInfo(const QString& preset_path)
     // info.forums      Link to mixxx forum discussion for the preset
     // info.wiki        Link to mixxx wiki for the preset
     // info.devices.product List of device matches, specific to device type
-    m_path = QFileInfo(preset_path).absoluteFilePath();
+    QFileInfo fileInfo(preset_path);
+    m_path = fileInfo.absoluteFilePath();
+    m_dirPath = fileInfo.dir().absolutePath();
     m_name = "";
     m_author = "";
     m_description = "";
@@ -50,7 +52,11 @@ PresetInfo::PresetInfo(const QString& preset_path)
     m_valid = true;
 
     QDomElement dom_name = info.firstChildElement("name");
-    if (!dom_name.isNull()) m_name = dom_name.text();
+    if (!dom_name.isNull()) {
+        m_name = dom_name.text();
+    } else {
+        m_name = fileInfo.baseName();
+    }
 
     QDomElement dom_author = info.firstChildElement("author");
     if (!dom_author.isNull()) m_author = dom_author.text();

--- a/src/controllers/controllerpresetinfo.h
+++ b/src/controllers/controllerpresetinfo.h
@@ -48,14 +48,8 @@ class PresetInfo {
     }
 
     inline const QString getPath() const { return m_path; }
-
-    inline const QString getName() const {
-        if (m_name.length() != 0) {
-            return m_name;
-        } else {
-            return QFileInfo(m_path).baseName();
-        }
-    }
+    inline const QString getDirPath() const { return m_dirPath; }
+    inline const QString getName() const { return m_name; }
     inline const QString getDescription() const { return m_description; }
     inline const QString getForumLink() const { return m_forumlink; }
     inline const QString getWikiLink() const { return m_wikilink; }
@@ -69,6 +63,7 @@ class PresetInfo {
 
     bool m_valid;
     QString m_path;
+    QString m_dirPath;
     QString m_name;
     QString m_author;
     QString m_description;

--- a/src/controllers/controllerpresetinfo.h
+++ b/src/controllers/controllerpresetinfo.h
@@ -16,6 +16,7 @@
 #include <QMap>
 #include <QList>
 #include <QDomElement>
+#include <QFileInfo>
 
 #include "preferences/usersettings.h"
 #include "controllers/controllerpreset.h"
@@ -48,7 +49,13 @@ class PresetInfo {
 
     inline const QString getPath() const { return m_path; }
 
-    inline const QString getName() const { return m_name; }
+    inline const QString getName() const {
+        if (m_name.length() != 0) {
+            return m_name;
+        } else {
+            return QFileInfo(m_path).baseName();
+        }
+    }
     inline const QString getDescription() const { return m_description; }
     inline const QString getForumLink() const { return m_forumlink; }
     inline const QString getWikiLink() const { return m_wikilink; }

--- a/src/controllers/controllerpresetinfoenumerator.cpp
+++ b/src/controllers/controllerpresetinfoenumerator.cpp
@@ -10,6 +10,12 @@
 
 #include "controllers/defs_controllers.h"
 
+namespace {
+bool presetInfoNameComparator(const PresetInfo &a, const PresetInfo &b) {
+    return a.getName() < b.getName();
+}
+}
+
 PresetInfoEnumerator::PresetInfoEnumerator(const QStringList& searchPaths)
         : m_controllerDirPaths(searchPaths) {
     loadSupportedPresets();
@@ -44,6 +50,10 @@ void PresetInfoEnumerator::loadSupportedPresets() {
             }
         }
     }
+
+    qSort(m_midiPresets.begin(), m_midiPresets.end(), presetInfoNameComparator);
+    qSort(m_hidPresets.begin(), m_hidPresets.end(), presetInfoNameComparator);
+    qSort(m_bulkPresets.begin(), m_bulkPresets.end(), presetInfoNameComparator);
 
     qDebug() << "Extension" << MIDI_PRESET_EXTENSION << "total"
              << m_midiPresets.length() << "presets";

--- a/src/controllers/controllerpresetinfoenumerator.cpp
+++ b/src/controllers/controllerpresetinfoenumerator.cpp
@@ -12,7 +12,20 @@
 
 namespace {
 bool presetInfoNameComparator(const PresetInfo &a, const PresetInfo &b) {
-    return a.getName() < b.getName();
+    if (a.getDirPath() == b.getDirPath()) {
+        // FIXME: Mixxx copies every loaded mapping into the user mapping folder
+        // with a different file name. This is confusing, especially when developing
+        // a mapping and working on it in the user mapping folder. Sorting
+        // by file path here is a quick hack to keep the identically named mappings
+        // in a consistent order.
+        if (a.getName() == b.getName()) {
+            return a.getPath() < b.getPath();
+        } else {
+            return a.getName() < b.getName();
+        }
+    } else {
+        return a.getDirPath() < b.getDirPath();
+    }
 }
 }
 

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -229,15 +229,6 @@ void DlgPrefController::slotDirty() {
     m_bDirty = true;
 }
 
-const QString DlgPrefController::presetDisplayName(const PresetInfo& info) {
-    if (QFileInfo(info.getPath()).absoluteDir() == userPresetsPath(m_pConfig)) {
-        //: Shown in combobox to select controller mappings to distinguish user-installed mappings from mappings included in Mixxx
-        return info.getName() + " (" + tr("user") + ")";
-    } else {
-        return info.getName();
-    }
-}
-
 void DlgPrefController::enumeratePresets() {
     m_ui.comboBoxPreset->clear();
 
@@ -264,7 +255,7 @@ void DlgPrefController::enumeratePresets() {
 
     PresetInfo match;
     for (const PresetInfo& preset : presets) {
-        m_ui.comboBoxPreset->addItem(presetDisplayName(preset), preset.getPath());
+        m_ui.comboBoxPreset->addItem(preset.getName(), preset.getPath());
         if (m_pController->matchPreset(preset)) {
             match = preset;
         }
@@ -272,7 +263,7 @@ void DlgPrefController::enumeratePresets() {
 
     // Jump to matching device in list if it was found.
     if (match.isValid()) {
-        int index = m_ui.comboBoxPreset->findText(presetDisplayName(match));
+        int index = m_ui.comboBoxPreset->findText(match.getName());
         if (index != -1) {
             m_ui.comboBoxPreset->setCurrentIndex(index);
         }

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -86,7 +86,6 @@ class DlgPrefController : public DlgPreferencePage {
     void savePreset(QString path);
     void initTableView(QTableView* pTable);
 
-    const QString presetDisplayName(const PresetInfo& info);
     // Reload the mappings in the dropdown dialog
     void enumeratePresets();
 

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -86,6 +86,7 @@ class DlgPrefController : public DlgPreferencePage {
     void savePreset(QString path);
     void initTableView(QTableView* pTable);
 
+    const QString presetDisplayName(const PresetInfo& info);
     // Reload the mappings in the dropdown dialog
     void enumeratePresets();
 


### PR DESCRIPTION
... to distinguish them from mappings shipped with Mixxx in the system resource folder. Fixing
https://bugs.launchpad.net/mixxx/+bug/1732712

Mixxx also should not copy the mapping into the user folder unless the user modifies it. However, implementing that would require more extensive changes that I am hesitant to do this far into the 2.1 beta period.