### PR TITLE
Fix release build with Qt 5.10

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -1258,9 +1258,10 @@ class MixxxCore(Feature):
 
             # In a release build we want to disable all Q_ASSERTs in Qt headers
             # that we include. We can't define QT_NO_DEBUG because that would
-            # mean turning off QDebug output. qt_noop() is what Qt defines
-            # Q_ASSERT to be when QT_NO_DEBUG is defined.
-            build.env.Append(CPPDEFINES="'Q_ASSERT(x)=qt_noop()'")
+            # mean turning off QDebug output. So we pass the same code as qtbase
+            # uses in qglobal.h for QT_NO_DEBUG set from qtbase 5.10 on. To get
+            # Windows builds happy, 'static_cast<void>' was replaced by '(void)'
+            build.env.Append(CPPDEFINES="'Q_ASSERT(x)=(void)(false&&(x))'")
 
         if int(SCons.ARGUMENTS.get('debug_assertions_fatal', 0)):
             build.env.Append(CPPDEFINES='MIXXX_DEBUG_ASSERTIONS_FATAL')


### PR DESCRIPTION
Moving Qt from 5.9.4 -> 5.10.1 causes build failures for mixxx:

| <command-line>:0:20: error: call to non-constexpr function 'void qt_noop()'
| /usr/include/qt5/QtCore/qstringview.h:291:14: note: in expansion of macro 'Q_ASSERT'
|     { return Q_ASSERT(int(size()) == size()), int(size()); }
| .. many-more errors of same kind

This is caused by a different usage of Q_ASSERT in qtbase. For further details
see qtbase

commit 8ea27bb1c669e21100a6a042b0378b3346bdf671
Author: Marc Mutz <marc.mutz@kdab.com>
Date:   Tue Mar 14 22:45:05 2017 +0100

    Make Q_ASSERT() usable in constexpr functions

Fix mixxx by copying/aliging the new definition of Q_ASSERT from qglobal.h
shipped with 5.10.1.

Tested for Qt 5.9.4 and 5.10.1

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>