### PR TITLE
American Audio VMS2 & VMS4/4.1: unmap volume faders

### DIFF
--- a/res/controllers/American Audio VMS2.midi.xml
+++ b/res/controllers/American Audio VMS2.midi.xml
@@ -1269,15 +1269,6 @@
       <!-- Mixer main-->
       <control>
 	<group>[Master]</group>
-	<key>crossfader</key>
-	<status>0xB0</status>
-	<midino>0x1F</midino>
-	<options>
-	  <invert/>
-	</options>
-      </control>
-      <control>
-	<group>[Master]</group>
 	<key>headMix</key>
 	<status>0xB0</status>
 	<midino>0x22</midino>
@@ -1350,15 +1341,6 @@
 	</options>
       </control>
       <control>
-	<group>[Channel1]</group>
-	<key>volume</key>
-	<status>0xB0</status>
-	<midino>0x04</midino>
-	<options>
-	  <!-- soft-takeover /-->
-	</options>
-      </control>
-      <control>
 	<!-- on -->
 	<group>[Channel1]</group>
 	<key>pfl</key>
@@ -1411,15 +1393,6 @@
 	<key>filterLow</key>
 	<status>0xB0</status>
 	<midino>0x08</midino>
-	<options>
-	  <!-- soft-takeover /-->
-	</options>
-      </control>
-      <control>
-	<group>[Channel2]</group>
-	<key>volume</key>
-	<status>0xB0</status>
-	<midino>0x09</midino>
 	<options>
 	  <!-- soft-takeover /-->
 	</options>

--- a/res/controllers/American Audio VMS4.midi.xml
+++ b/res/controllers/American Audio VMS4.midi.xml
@@ -1354,16 +1354,6 @@
          <!-- Mixer main-->
          <control>
             <group>[Master]</group>
-            <key>crossfader</key>
-            <status>0xB0</status>
-            <midino>0x1F</midino>
-            <options>
-               <invert/>
-               <soft-takeover/>
-            </options>
-         </control>
-         <control>
-            <group>[Master]</group>
             <key>headMix</key>
             <status>0xB0</status>
             <midino>0x22</midino>
@@ -1436,15 +1426,6 @@
                 <soft-takeover />
             </options>
          </control>
-         <control>
-            <group>[Channel1]</group>
-            <key>volume</key>
-            <status>0xB0</status>
-            <midino>0x09</midino>
-            <options>
-                <soft-takeover />
-            </options>
-         </control>
          <control><!-- on -->
             <group>[Channel1]</group>
             <key>pfl</key>
@@ -1497,15 +1478,6 @@
             <key>parameter1</key>
             <status>0xB0</status>
             <midino>0x0D</midino>
-            <options>
-                <soft-takeover />
-            </options>
-         </control>
-         <control>
-            <group>[Channel2]</group>
-            <key>volume</key>
-            <status>0xB0</status>
-            <midino>0x0E</midino>
             <options>
                 <soft-takeover />
             </options>
@@ -1566,15 +1538,6 @@
                  <soft-takeover />
              </options>
          </control>
-         <control>
-             <group>[Channel3]</group>
-             <key>volume</key>
-             <status>0xB0</status>
-             <midino>0x04</midino>
-             <options>
-                 <soft-takeover />
-             </options>
-         </control>
          <control><!-- on -->
              <group>[Channel3]</group>
              <key>pfl</key>
@@ -1627,15 +1590,6 @@
              <key>parameter1</key>
              <status>0xB0</status>
              <midino>0x12</midino>
-             <options>
-                 <soft-takeover />
-             </options>
-         </control>
-         <control>
-             <group>[Channel4]</group>
-             <key>volume</key>
-             <status>0xB0</status>
-             <midino>0x13</midino>
              <options>
                  <soft-takeover />
              </options>


### PR DESCRIPTION
These devices combine a MIDI controller and hardware mixer. Unfortunately there is no way to decouple these different functions except for bypassing the VMS' equalizers. In Mixxx 2.1, the umixed Deck 1-4 outputs were changed so they are now affected by the deck volume faders. This was done because effects are now processed after the volume faders. Sending the output signals to the Deck 1-4 outputs before the volume fader would make effects unusable with external mixers. (Alternatively, it would be possible to do duplicate effects processing before the volume faders for the Deck 1-4 outputs like what is done for the Headphones output, but that would complicate the mixing engine code and of course the software volume fader could not be used to cut input to effects.)

The issue was reported by a [user on the forum](https://mixxx.org/forums/viewtopic.php?f=3&t=11679).