### PR TITLE
GlobalTrackCache SIGSEGV: Improve 2-phase deletion of cached track objects

### DIFF
--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -154,8 +154,8 @@ private:
     friend class GlobalTrackCacheLocker;
     friend class GlobalTrackCacheResolver;
 
-    // Callback for the smart-pointer
-    static void deleter(Track* plainPtr);
+    // Deleter callbacks for the smart-pointer
+    static void evictAndSaveCachedTrack(Track* plainPtr);
 
     explicit GlobalTrackCache(GlobalTrackCacheSaver* pDeleter);
     ~GlobalTrackCache();
@@ -186,13 +186,12 @@ private:
             TrackRef trackRef,
             TrackId trackId);
 
-    void evictOrDelete(Track* plainPtr);
+    void evictAndSave(Track* plainPtr);
 
-    typedef std::unordered_map<Track*, TrackWeakPointer> AllocatedTracks;
+    typedef std::unordered_map<Track*, TrackWeakPointer> CachedTracks;
 
-    bool evictAndSave(TrackPointer strongPtr);
-
-    void evict(TrackPointer strongPtr);
+    bool evict(Track* plainPtr);
+    bool isEvicted(Track* plainPtr) const;
 
     bool isEmpty() const;
 
@@ -203,13 +202,7 @@ private:
 
     GlobalTrackCacheSaver* m_pSaver;
 
-    // This is the owner of the Track objects.
-    // The tracks are saved back to database and file metatdata if the first
-    // shared_ptr expires. This time the Track is still cached.
-    // Than the track is copied into a second shared_ptr used while saving the
-    // track. If this also expires, the track is finally deleted and removed
-    // from the index.
-    AllocatedTracks m_allocatedTracks;
+    CachedTracks m_cachedTracks;
 
     // This caches the unsaved Tracks by ID
     typedef std::unordered_map<TrackId, Track*, TrackId::hash_fun_t> TracksById;


### PR DESCRIPTION
Follow-up of #1492 

I experienced 2 crashes when using Mixxx with the new analysis framework. Unfortunately I was only able to reproduce the crash once, but never again. The logs indicate that the same memory address has been reused for another track. Deletion of the first track object finished as expected, but Mixxx crashed when trying to delete the second object that was allocated at the same memory address.

This fix basically resembles my previous version, although simplified and much more elegantly and efficiently. After evicting a track object the cache passes ownership to the saver callback. This is accomplished with a custom deleter that eventually deallocates the track object by invoking QObject::deleteLater() after all references have been dropped. The cache is not involved any more and no race conditions can occur. Erasing the pointer from all internal data structures ensures that evicted pointers have completely disappeared from the cache. Even the case when a delayed deletion callback arrives for the same memory address that already stores a newly allocated object is handled correctly. This callback will simply be rejected, unless the corresponding shared_ptr has expired.

The modified code should ensure that neither double free nor any use after free will occur. It should be simpler than before and easier to reason about.