### PR TITLE
2phase deletion with Functor

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -435,40 +435,10 @@ void Library::saveCachedTrack(TrackPointer pTrack) noexcept {
     // ensure that we have exclusive (write) access on the file
     // and not reader or writer is accessing the same file
     // concurrently.
-    // Pass the track object via a plain pointer to prevent the
-    // creation of any new references from the shared pointer
-    // that will be deleted soon!
     m_pTrackCollection->exportTrackMetadata(pTrack.get());
 
-    // NOTE(uklotzde, 2018-02-20):
-    // Database updates must be executed in the context of the
-    // main thread. When saving is triggered from another
-    // thread the call needs to be dispatched through a queued
-    // connection and is deferred until the event loop of the
-    // receiving thread that handles the event. The actual
-    // execution might happen when the cache has already been
-    // unlocked after leaving this function.
-    // Race conditions between database readers and writers are
-    // impossible as long as all database actions are executed in
-    // the main thread and the invocation is submitted through
-    // a direct connection.
-    // This method might be invoked from a different thread than
-    // the main thread. But database updates are currently only
-    // allowed from the main thread!
-    QMetaObject::invokeMethod(
-            this,
-            "saveTrack",
-            // Qt will choose either a direct or a queued connection
-            // depending on the thread from which this method has
-            // been invoked!
-            Qt::AutoConnection,
-            Q_ARG(TrackPointer, pTrack));
-}
-
-void Library::saveTrack(TrackPointer pTrack) {
-    // Update the database
-    // Pass the track object via a plain pointer to prevent the
-    // creation of any new references from the shared pointer
-    // that will be deleted soon!
+    // The track must be saved while the cache is locked to
+    // prevent that a new track is created from the outdated
+    // metadata that is is the database before saving is finished.
     m_pTrackCollection->saveTrack(pTrack.get());
 }

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -422,7 +422,7 @@ void Library::slotSetTrackTableRowHeight(int rowHeight) {
     emit(setTrackTableRowHeight(rowHeight));
 }
 
-void Library::saveCachedTrack(TrackPointer pTrack) noexcept {
+void Library::saveCachedTrack(Track* pTrack) noexcept {
     // It can produce dangerous signal loops if the track is still
     // sending signals while being saved!
     // See: https://bugs.launchpad.net/mixxx/+bug/1365708
@@ -435,10 +435,10 @@ void Library::saveCachedTrack(TrackPointer pTrack) noexcept {
     // ensure that we have exclusive (write) access on the file
     // and not reader or writer is accessing the same file
     // concurrently.
-    m_pTrackCollection->exportTrackMetadata(pTrack.get());
+    m_pTrackCollection->exportTrackMetadata(pTrack);
 
     // The track must be saved while the cache is locked to
     // prevent that a new track is created from the outdated
     // metadata that is is the database before saving is finished.
-    m_pTrackCollection->saveTrack(pTrack.get());
+    m_pTrackCollection->saveTrack(pTrack);
 }

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -124,7 +124,7 @@ class Library: public QObject,
 
   private:
     // Callback for GlobalTrackCache
-    void saveCachedTrack(TrackPointer pTrack) noexcept override;
+    void saveCachedTrack(Track* pTrack) noexcept override;
 
     const UserSettingsPointer m_pConfig;
 

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -122,9 +122,6 @@ class Library: public QObject,
     void scanStarted();
     void scanFinished();
 
-  private slots:
-    void saveTrack(TrackPointer pTrack);
-
   private:
     // Callback for GlobalTrackCache
     void saveCachedTrack(TrackPointer pTrack) noexcept override;

--- a/src/test/globaltrackcache_test.cpp
+++ b/src/test/globaltrackcache_test.cpp
@@ -60,7 +60,7 @@ class TrackTitleThread: public QThread {
 
 class GlobalTrackCacheTest: public MixxxTest, public virtual GlobalTrackCacheSaver {
   public:
-    void saveCachedTrack(TrackPointer pTrack) noexcept override {
+    void saveCachedTrack(Track* pTrack) noexcept override {
         ASSERT_FALSE(pTrack == nullptr);
     }
 

--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -14,9 +14,9 @@ class LibraryTest : public MixxxTest,
     public virtual /*implements*/ GlobalTrackCacheSaver {
 
   public:
-    void saveCachedTrack(TrackPointer pTrack) noexcept override {
-        m_trackCollection.exportTrackMetadata(pTrack.get());
-        m_trackCollection.saveTrack(pTrack.get());
+    void saveCachedTrack(Track* pTrack) noexcept override {
+        m_trackCollection.exportTrackMetadata(pTrack);
+        m_trackCollection.saveTrack(pTrack);
     }
 
   protected:

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -40,10 +40,8 @@ struct EvictAndSaveFunctor {
     }
 
     void operator()(Track* plainPtr) {
-        TrackPointer deletingPtr;
-        m_deletingPtr.swap(deletingPtr);
-        DEBUG_ASSERT(plainPtr == deletingPtr.get());
-        GlobalTrackCache::evictAndSaveCachedTrack(std::move(deletingPtr));
+        DEBUG_ASSERT(plainPtr == m_deletingPtr.get());
+        GlobalTrackCache::evictAndSaveCachedTrack(std::move(m_deletingPtr));
     }
     TrackPointer m_deletingPtr;
 };

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -34,8 +34,9 @@ TrackRef createTrackRef(const Track& track) {
     return TrackRef::fromFileInfo(track.getFileInfo(), track.getId());
 }
 
-struct EvictAndSaveFunctor {
-    EvictAndSaveFunctor(TrackPointer deletingPtr)
+class EvictAndSaveFunctor {
+  public:
+    explicit EvictAndSaveFunctor(TrackPointer deletingPtr)
         : m_deletingPtr(std::move(deletingPtr)) {
     }
 
@@ -43,6 +44,8 @@ struct EvictAndSaveFunctor {
         DEBUG_ASSERT(plainPtr == m_deletingPtr.get());
         GlobalTrackCache::evictAndSaveCachedTrack(std::move(m_deletingPtr));
     }
+
+  private:
     TrackPointer m_deletingPtr;
 };
 

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -39,17 +39,15 @@ class GlobalTrackCacheEntry final {
     // is not longer referenced, the track is saved and evicted
     // from the cache.
   public:
-    GlobalTrackCacheEntry(
-            TrackPointer deletingPtr, TrackWeakPointer savingWeakPtr)
-        : m_deletingPtr(std::move(deletingPtr)),
-          m_savingWeakPtr(std::move(savingWeakPtr)) {
+    explicit GlobalTrackCacheEntry(
+            std::unique_ptr<Track, void (&)(Track*)> deletingPtr)
+        : m_deletingPtr(std::move(deletingPtr)) {
     }
+
+    GlobalTrackCacheEntry(const GlobalTrackCacheEntry& other) = delete;
 
     Track* getPlainPtr() const {
         return m_deletingPtr.get();
-    }
-    const TrackPointer& getDeletingPtr() const {
-        return m_deletingPtr;
     }
     const TrackWeakPointer& getSavingWeakPtr() const {
         return m_savingWeakPtr;
@@ -59,7 +57,7 @@ class GlobalTrackCacheEntry final {
     }
 
   private:
-    TrackPointer m_deletingPtr;
+    std::unique_ptr<Track, void (&)(Track*)> m_deletingPtr;
     TrackWeakPointer m_savingWeakPtr;
 };
 
@@ -165,8 +163,7 @@ private:
 class /*interface*/ GlobalTrackCacheSaver {
 private:
     friend class GlobalTrackCache;
-    virtual void saveCachedTrack(
-            TrackPointer pTrack) noexcept = 0;
+    virtual void saveCachedTrack(Track* pTrack) noexcept = 0;
 
 protected:
     virtual ~GlobalTrackCacheSaver() {}

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -151,7 +151,7 @@ public:
     static void destroyInstance();
 
     // Deleter callbacks for the smart-pointer
-    static void evictAndSaveCachedTrack(Track* plainPtr);
+    static void evictAndSaveCachedTrack(TrackPointer plainPtr);
 
 private:
     friend class GlobalTrackCacheLocker;
@@ -186,9 +186,9 @@ private:
             TrackRef trackRef,
             TrackId trackId);
 
-    void evictAndSave(Track* plainPtr);
+    void evictAndSave(TrackPointer deletingPtr);
 
-    typedef std::unordered_map<Track*, TrackWeakPointer> CachedTracks;
+    typedef std::unordered_map<Track*, std::pair<TrackWeakPointer, TrackPointer> >CachedTracks;
 
     bool evict(Track* plainPtr);
     bool isEvicted(Track* plainPtr) const;

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -198,10 +198,6 @@ private:
     explicit GlobalTrackCache(GlobalTrackCacheSaver* pDeleter);
     ~GlobalTrackCache();
 
-    // This function should only be called DEBUG_ASSERT statements
-    // to verify the class invariants during development.
-    bool verifyConsistency() const;
-
     void relocateTracks(
             GlobalTrackCacheRelocator* /*nullable*/ pRelocator);
 
@@ -210,8 +206,7 @@ private:
     TrackPointer lookupByRef(
             const TrackRef& trackRef);
 
-    TrackPointer revive(
-            Track* plainPtr);
+    TrackPointer revive(GlobalTrackCacheEntryPointer entryPtr);
 
     void resolve(
             GlobalTrackCacheResolver* /*in/out*/ pCacheResolver,
@@ -224,8 +219,6 @@ private:
             TrackRef trackRef,
             TrackId trackId);
 
-    typedef std::unordered_map<Track*, GlobalTrackCacheEntryPointer>CachedTracks;
-
     bool evict(Track* plainPtr);
     bool isEvicted(Track* plainPtr) const;
 
@@ -237,8 +230,6 @@ private:
     mutable QMutex m_mutex;
 
     GlobalTrackCacheSaver* m_pSaver;
-
-    CachedTracks m_cachedTracks;
 
     // This caches the unsaved Tracks by ID
     typedef std::unordered_map<TrackId, GlobalTrackCacheEntryPointer, TrackId::hash_fun_t> TracksById;

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -150,12 +150,12 @@ public:
     // See also: GlobalTrackCacheLocker::deactivateCache()
     static void destroyInstance();
 
+    // Deleter callbacks for the smart-pointer
+    static void evictAndSaveCachedTrack(Track* plainPtr);
+
 private:
     friend class GlobalTrackCacheLocker;
     friend class GlobalTrackCacheResolver;
-
-    // Deleter callbacks for the smart-pointer
-    static void evictAndSaveCachedTrack(Track* plainPtr);
 
     explicit GlobalTrackCache(GlobalTrackCacheSaver* pDeleter);
     ~GlobalTrackCache();

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -139,7 +139,9 @@ protected:
     virtual ~GlobalTrackCacheSaver() {}
 };
 
-class GlobalTrackCache {
+class GlobalTrackCache : public QObject {
+    Q_OBJECT
+
 public:
     static void createInstance(GlobalTrackCacheSaver* pDeleter);
     // NOTE(uklotzde, 2018-02-20): We decided not to destroy the singular
@@ -152,6 +154,9 @@ public:
 
     // Deleter callbacks for the smart-pointer
     static void evictAndSaveCachedTrack(TrackPointer plainPtr);
+
+private slots:
+    void evictAndSave(TrackPointer deletingPtr);
 
 private:
     friend class GlobalTrackCacheLocker;
@@ -185,8 +190,6 @@ private:
             const TrackPointer& strongPtr,
             TrackRef trackRef,
             TrackId trackId);
-
-    void evictAndSave(TrackPointer deletingPtr);
 
     typedef std::unordered_map<Track*, std::pair<TrackWeakPointer, TrackPointer> >CachedTracks;
 


### PR DESCRIPTION
This is a proof concept using an initial std::shared_ptr 
It works quite good to inject a strong pointer into the reference counting object via a functor deleter. 
This way the original deleting ptr counts the second instances of std::shared_ptr used for saving. 
 
I see also a good chance to get rid of all the reviving, related race conditions and complicated management code because we have not to deal with an already deleted Track pointer any more. 

@uklotzde: What do you think? Is this on a good track?  
