### PR TITLE
Fixed metronome effect

### DIFF
--- a/src/effects/native/metronomeeffect.cpp
+++ b/src/effects/native/metronomeeffect.cpp
@@ -96,10 +96,12 @@ void MetronomeEffect::processChannel(
             if (maxFrames > clickSize &&
                     currentFrame > clickSize &&
                     currentFrame < maxFrames - clickSize &&
-                    gs->m_framesSinceClickStart > clickSize) {
+                    gs->m_framesSinceClickStart > clickSize &&
+                    currentFrame != gs->m_previousFrame) {
                 // plays a single click on low speed
                 gs->m_framesSinceClickStart = currentFrame;
             }
+            gs->m_previousFrame = currentFrame;
         }
     } else {
         maxFrames = bufferParameters.sampleRate() * 60 / m_pBpmParameter->value();

--- a/src/effects/native/metronomeeffect.cpp
+++ b/src/effects/native/metronomeeffect.cpp
@@ -88,8 +88,13 @@ void MetronomeEffect::processChannel(
         click = kClick48000;
     }
 
+    SampleUtil::copy(pOutput, pInput, bufferParameters.samplesPerBuffer());
+
     unsigned int maxFrames;
-    if (m_pSyncParameter->toBool() && groupFeatures.has_bpm) {
+    if (m_pSyncParameter->toBool()) {
+        if (groupFeatures.bpm <= 0)
+            return;
+
         maxFrames = bufferParameters.sampleRate() * 60 / groupFeatures.bpm;
 
         if (groupFeatures.has_beat_fraction) {
@@ -110,8 +115,6 @@ void MetronomeEffect::processChannel(
     } else {
         maxFrames = bufferParameters.sampleRate() * 60 / m_pBpmParameter->value();
     }
-
-    SampleUtil::copy(pOutput, pInput, bufferParameters.samplesPerBuffer());
 
     if (gs->m_framesSinceClickStart < clickSize) {
         // still in click region, write remaining click frames.
@@ -142,4 +145,3 @@ void MetronomeEffect::processChannel(
                 copyFrames);
     }
 }
-

--- a/src/effects/native/metronomeeffect.cpp
+++ b/src/effects/native/metronomeeffect.cpp
@@ -98,10 +98,14 @@ void MetronomeEffect::processChannel(
                     currentFrame > clickSize &&
                     currentFrame < maxFrames - clickSize &&
                     gs->m_framesSinceClickStart > clickSize &&
-                    groupFeatures.isPlaying) {
+                    (
+                        groupFeatures.isPlaying ||
+                        currentFrame != gs->m_previousFrame
+                    )) {
                 // plays a single click on low speed
                 gs->m_framesSinceClickStart = currentFrame;
             }
+            gs->m_previousFrame = currentFrame;
         }
     } else {
         maxFrames = bufferParameters.sampleRate() * 60 / m_pBpmParameter->value();

--- a/src/effects/native/metronomeeffect.cpp
+++ b/src/effects/native/metronomeeffect.cpp
@@ -89,19 +89,19 @@ void MetronomeEffect::processChannel(
     }
 
     unsigned int maxFrames;
-    if (m_pSyncParameter->toBool() && groupFeatures.has_beat_length_sec) {
-        maxFrames = bufferParameters.sampleRate() * groupFeatures.beat_length_sec;
+    if (m_pSyncParameter->toBool() && groupFeatures.has_bpm) {
+        maxFrames = bufferParameters.sampleRate() * 60 / groupFeatures.bpm;
+
         if (groupFeatures.has_beat_fraction) {
             unsigned int currentFrame =  maxFrames * groupFeatures.beat_fraction;
             if (maxFrames > clickSize &&
                     currentFrame > clickSize &&
                     currentFrame < maxFrames - clickSize &&
                     gs->m_framesSinceClickStart > clickSize &&
-                    currentFrame != gs->m_previousFrame) {
+                    groupFeatures.isPlaying) {
                 // plays a single click on low speed
                 gs->m_framesSinceClickStart = currentFrame;
             }
-            gs->m_previousFrame = currentFrame;
         }
     } else {
         maxFrames = bufferParameters.sampleRate() * 60 / m_pBpmParameter->value();

--- a/src/effects/native/metronomeeffect.cpp
+++ b/src/effects/native/metronomeeffect.cpp
@@ -103,10 +103,7 @@ void MetronomeEffect::processChannel(
                     currentFrame > clickSize &&
                     currentFrame < maxFrames - clickSize &&
                     gs->m_framesSinceClickStart > clickSize &&
-                    (
-                        groupFeatures.isPlaying ||
-                        currentFrame != gs->m_previousFrame
-                    )) {
+                    currentFrame != gs->m_previousFrame) {
                 // plays a single click on low speed
                 gs->m_framesSinceClickStart = currentFrame;
             }

--- a/src/effects/native/metronomeeffect.h
+++ b/src/effects/native/metronomeeffect.h
@@ -17,14 +17,12 @@ class MetronomeGroupState final : public EffectState {
   public:
     MetronomeGroupState(const mixxx::EngineParameters& bufferParameters)
       : EffectState(bufferParameters),
-        m_framesSinceClickStart(0),
-        m_previousFrame(-1) {
+        m_framesSinceClickStart(0) {
     }
     ~MetronomeGroupState() {
     }
 
     unsigned int m_framesSinceClickStart;
-    unsigned int m_previousFrame;
 };
 
 class MetronomeEffect : public EffectProcessorImpl<MetronomeGroupState> {

--- a/src/effects/native/metronomeeffect.h
+++ b/src/effects/native/metronomeeffect.h
@@ -17,12 +17,14 @@ class MetronomeGroupState final : public EffectState {
   public:
     MetronomeGroupState(const mixxx::EngineParameters& bufferParameters)
       : EffectState(bufferParameters),
-        m_framesSinceClickStart(0) {
+        m_framesSinceClickStart(0),
+        m_previousFrame(-1) {
     }
     ~MetronomeGroupState() {
     }
 
     unsigned int m_framesSinceClickStart;
+    unsigned int m_previousFrame;
 };
 
 class MetronomeEffect : public EffectProcessorImpl<MetronomeGroupState> {

--- a/src/effects/native/metronomeeffect.h
+++ b/src/effects/native/metronomeeffect.h
@@ -17,12 +17,14 @@ class MetronomeGroupState final : public EffectState {
   public:
     MetronomeGroupState(const mixxx::EngineParameters& bufferParameters)
       : EffectState(bufferParameters),
-        m_framesSinceClickStart(0) {
+        m_framesSinceClickStart(0),
+        m_previousFrame(0) {
     }
     ~MetronomeGroupState() {
     }
 
     unsigned int m_framesSinceClickStart;
+    unsigned int m_previousFrame;
 };
 
 class MetronomeEffect : public EffectProcessorImpl<MetronomeGroupState> {

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -849,6 +849,11 @@ void BpmControl::collectFeatures(GroupFeatureState* pGroupFeatures) const {
 
         pGroupFeatures->has_beat_fraction = true;
         pGroupFeatures->beat_fraction = dThisBeatFraction;
+
+        pGroupFeatures->has_bpm = true;
+        pGroupFeatures->bpm = getBpm();
+
+        pGroupFeatures->isPlaying = m_pPlayButton->get();
     }
 }
 

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -852,8 +852,6 @@ void BpmControl::collectFeatures(GroupFeatureState* pGroupFeatures) const {
 
         pGroupFeatures->has_bpm = true;
         pGroupFeatures->bpm = getBpm();
-
-        pGroupFeatures->isPlaying = m_pPlayButton->get();
     }
 }
 

--- a/src/engine/effects/groupfeaturestate.h
+++ b/src/engine/effects/groupfeaturestate.h
@@ -12,8 +12,7 @@ struct GroupFeatureState {
               has_gain(false),
               gain(1.0),
               has_bpm(false),
-              bpm(0.0),
-              isPlaying(false) {
+              bpm(0.0) {
     }
 
     // The beat length in seconds.
@@ -30,8 +29,6 @@ struct GroupFeatureState {
 
     bool has_bpm;
     double bpm;
-
-    bool isPlaying;
 };
 
 #endif /* GROUPFEATURESTATE_H */

--- a/src/engine/effects/groupfeaturestate.h
+++ b/src/engine/effects/groupfeaturestate.h
@@ -10,7 +10,10 @@ struct GroupFeatureState {
               has_beat_fraction(false),
               beat_fraction(0.0),
               has_gain(false),
-              gain(1.0) {
+              gain(1.0),
+              has_bpm(false),
+              bpm(0.0),
+              isPlaying(false) {
     }
 
     // The beat length in seconds.
@@ -24,6 +27,11 @@ struct GroupFeatureState {
 
     bool has_gain;
     double gain;
+
+    bool has_bpm;
+    double bpm;
+
+    bool isPlaying;
 };
 
 #endif /* GROUPFEATURESTATE_H */


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1750783

m_framesSinceClickStart was continuously increasing with the buffer size, even if the track was paused. This was imitating a playing track for the metronome effect with a different BPM.

Fixed by not adding the buffer size to m_framesSinceClickStart on each function call but only adding the value when it is actually buffering the click sound. Added a `m_isBuffered` boolean which holds true if the currentFrame was near the end of the beat and some frames of the click sound in the beginning could be buffered in the same function call.