### PR TITLE
allow fractional values for skin scaling

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -122,52 +122,34 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     AutoHiDpi autoHiDpi;
     m_dScaleFactorAuto = autoHiDpi.getScaleFactor();
-    double scaleFactor = m_dScaleFactorAuto;
-    if (scaleFactor > 0) {
+    m_dScaleFactor = m_dScaleFactorAuto;
+    if (m_dScaleFactor > 0) {
         // we got a valid auto scale factor
         bool scaleFactorAuto = m_pConfig->getValue(
                 ConfigKey("[Config]", "ScaleFactorAuto"), true);
         checkBoxScaleFactorAuto->setChecked(scaleFactorAuto);
         if (scaleFactorAuto) {
-            comboBoxScaleFactor->setEnabled(false);
+            spinBoxScaleFactor->setEnabled(false);
             m_pConfig->setValue(
                     ConfigKey("[Config]", "ScaleFactor"), m_dScaleFactorAuto);
         } else {
-            scaleFactor = m_pConfig->getValue(
+            m_dScaleFactor = m_pConfig->getValue(
                         ConfigKey("[Config]", "ScaleFactor"), 1.0);
         }
     } else {
         checkBoxScaleFactorAuto->setEnabled(false);
-        scaleFactor = m_pConfig->getValue(
+        m_dScaleFactor = m_pConfig->getValue(
                     ConfigKey("[Config]", "ScaleFactor"), 1.0);
     }
+
     connect(checkBoxScaleFactorAuto, SIGNAL(toggled(bool)),
             this, SLOT(slotSetScaleFactorAuto(bool)));
+    connect(spinBoxScaleFactor, SIGNAL(valueChanged(double)),
+            this, SLOT(slotSetScaleFactor(double)));
 
-    //: Entry of the HiDPI scale combo box. %1 is the scale factor in percent
-    comboBoxScaleFactor->addItem(QString(tr("%1 %")).arg(50), 0.5);
-    comboBoxScaleFactor->addItem(QString(tr("%1 %")).arg(100), 1);
-    comboBoxScaleFactor->addItem(QString(tr("%1 %")).arg(200), 2);
-    comboBoxScaleFactor->addItem(QString(tr("%1 %")).arg(300), 3);
-    comboBoxScaleFactor->addItem(QString(tr("%1 %")).arg(400), 4);
-    int i;
-    for (i = 0; i < comboBoxScaleFactor->count(); ++i) {
-        if (scaleFactor == comboBoxScaleFactor->itemData(i)) {
-            comboBoxScaleFactor->setCurrentIndex(i);
-            break;
-        }
-    }
-    if (i == comboBoxScaleFactor->count()) {
-        // no default scale, add custom scale
-        comboBoxScaleFactor->addItem(
-                QString(tr("%1 % (Experimental)")).arg(scaleFactor * 100), scaleFactor);
-        comboBoxScaleFactor->setCurrentIndex(i);
-    }
-    connect(comboBoxScaleFactor, SIGNAL(activated(int)),
-            this, SLOT(slotSetScaleFactor(int)));
 #else
     checkBoxScaleFactorAuto->hide();
-    comboBoxScaleFactor->hide();
+    spinBoxScaleFactor->hide();
     labelScaleFactor->hide();
 #endif
 
@@ -244,9 +226,10 @@ void DlgPrefInterface::slotUpdate() {
     checkBoxScaleFactorAuto->setChecked(m_pConfig->getValue(
             ConfigKey("[Config]", "ScaleFactorAuto"), m_bUseAutoScaleFactor));
 
-    comboBoxScaleFactor->setCurrentIndex(comboBoxScaleFactor->findData(
-            m_pConfig->getValue(
-                    ConfigKey("[Config]", "ScaleFactor"), m_dScaleFactorAuto)));
+    // The spinbox shows a percentage but Mixxx stores a multiplication factor
+    // with 1.00 as no scaling, so multiply the stored value by 100.
+    spinBoxScaleFactor->setValue(m_pConfig->getValue(
+                    ConfigKey("[Config]", "ScaleFactor"), m_dScaleFactor) * 100);
 
     checkBoxStartFullScreen->setChecked(m_pConfig->getValue(
             ConfigKey("[Config]", "StartInFullscreen"), m_bStartWithFullScreen));
@@ -266,7 +249,8 @@ void DlgPrefInterface::slotResetToDefaults() {
     ComboBoxLocale->setCurrentIndex(0);
 
     // Default to normal size widgets
-    comboBoxScaleFactor->setCurrentIndex(1); // 100 %
+    // The spinbox shows a percentage with 100% as no scaling.
+    spinBoxScaleFactor->setValue(100);
     if (m_dScaleFactorAuto > 0) {
         checkBoxScaleFactorAuto->setChecked(true);
     }
@@ -286,10 +270,12 @@ void DlgPrefInterface::slotSetLocale(int pos) {
     m_locale = ComboBoxLocale->itemData(pos).toString();
 }
 
-void DlgPrefInterface::slotSetScaleFactor(int index) {
-    double newScaleFactor = comboBoxScaleFactor->itemData(index).toDouble();
-    if (m_dScaleFactor != newScaleFactor) {
-        m_dScaleFactor = newScaleFactor;
+void DlgPrefInterface::slotSetScaleFactor(double newValue) {
+    // The spinbox shows a percentage, but Mixxx stores a multiplication factor
+    // with 1.00 as no change.
+    newValue /= 100.0;
+    if (m_dScaleFactor != newValue) {
+        m_dScaleFactor = newValue;
         m_bRebootMixxxView = true;
     }
 }
@@ -300,11 +286,11 @@ void DlgPrefInterface::slotSetScaleFactorAuto(bool newValue) {
             m_bRebootMixxxView = true;
         }
     } else {
-        slotSetScaleFactor(comboBoxScaleFactor->currentIndex());
+        slotSetScaleFactor(newValue);
     }
 
     m_bUseAutoScaleFactor = newValue;
-    comboBoxScaleFactor->setEnabled(!newValue);
+    spinBoxScaleFactor->setEnabled(!newValue);
 }
 
 void DlgPrefInterface::slotSetTooltips() {

--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -53,7 +53,7 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
     void slotSetScheme(int);
     void slotUpdateSchemes();
     void slotSetLocale(int);
-    void slotSetScaleFactor(int index);
+    void slotSetScaleFactor(double newValue);
     void slotSetScaleFactorAuto(bool checked);
 
   private:

--- a/src/preferences/dialog/dlgprefinterfacedlg.ui
+++ b/src/preferences/dialog/dlgprefinterfacedlg.ui
@@ -63,7 +63,7 @@
        </widget>
       </item>
       <item row="2" column="0" rowspan="2">
-       <widget class="QLabel" name="lableColorScheme">
+       <widget class="QLabel" name="labelColorScheme">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -195,9 +195,26 @@
        </widget>
       </item>
       <item row="6" column="1">
-       <widget class="QComboBox" name="comboBoxScaleFactor">
+       <widget class="QDoubleSpinBox" name="spinBoxScaleFactor">
         <property name="toolTip">
          <string>Change the size of text, buttons, and other items.</string>
+        </property>
+        <property name="decimals">
+         <number>0</number>
+        </property>
+        <property name="suffix">
+         <string notr="true"> %</string>
+        </property>
+        <property name="singleStep">
+         <double>25.0</double>
+        </property>
+        <property name="minimum">
+         <double>1.00</double>
+        </property>
+        <!-- There should not actually be a maximum, but the default maximum is
+        100, which is too low. -->
+        <property name="maximum">
+         <double>100000000000000000000</double>
         </property>
        </widget>
       </item>

--- a/src/preferences/dialog/dlgprefinterfacedlg.ui
+++ b/src/preferences/dialog/dlgprefinterfacedlg.ui
@@ -208,16 +208,11 @@
         <property name="singleStep">
          <double>25.0</double>
         </property>
-        <!-- Technically values between 0% and 25% would work, but 0% is invalid.
-        Setting the minimum to 1% makes an odd situation if the user then steps
-        up to 26%, 51%, and so on. So set the minimum to one step size. -->
         <property name="minimum">
-         <double>25.0</double>
+         <double>50.0</double>
         </property>
-        <!-- There should not actually be a maximum, but the default maximum is
-        100, which is too low. -->
         <property name="maximum">
-         <double>100000000000000000000</double>
+         <double>400</double>
         </property>
        </widget>
       </item>

--- a/src/preferences/dialog/dlgprefinterfacedlg.ui
+++ b/src/preferences/dialog/dlgprefinterfacedlg.ui
@@ -208,8 +208,11 @@
         <property name="singleStep">
          <double>25.0</double>
         </property>
+        <!-- Technically values between 0% and 25% would work, but 0% is invalid.
+        Setting the minimum to 1% makes an odd situation if the user then steps
+        up to 26%, 51%, and so on. So set the minimum to one step size. -->
         <property name="minimum">
-         <double>1.00</double>
+         <double>25.0</double>
         </property>
         <!-- There should not actually be a maximum, but the default maximum is
         100, which is too low. -->


### PR DESCRIPTION
Integer multiples do not work well for all screens and there is such a wide variety of screens and screen sizes that Mixxx cannot anticipate all the scale factors a user might want. This also fixes an annoying bug wherein Mixxx would revert to the default 100% when the ScaleFactor setting was manually edited in mixxx.cfg.