### PR TITLE
prevent accidental editing of metadata from track table

### DIFF
--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -167,12 +167,15 @@ void DlgPrefLibrary::slotUpdate() {
             ConfigKey("[Library]","ShowTraktorLibrary"), true));
 
     switch (m_pConfig->getValue<int>(
-            ConfigKey("[Library]","TrackLoadAction"), LOAD_TRACK_DECK)) {
-    case ADD_TRACK_BOTTOM:
+            ConfigKey("[Library]","TrackLoadAction"), LOAD_TO_DECK)) {
+    case ADD_TO_AUTODJ_BOTTOM:
             radioButton_dbclick_bottom->setChecked(true);
             break;
-    case ADD_TRACK_TOP:
+    case ADD_TO_AUTODJ_TOP:
             radioButton_dbclick_top->setChecked(true);
+            break;
+    case EDIT_METADATA:
+            radioButton_dbclick_edit_metadata->setChecked(true);
             break;
     default:
             radioButton_dbclick_deck->setChecked(true);
@@ -300,11 +303,13 @@ void DlgPrefLibrary::slotApply() {
                 ConfigValue((int)checkBox_show_traktor->isChecked()));
     int dbclick_status;
     if (radioButton_dbclick_bottom->isChecked()) {
-            dbclick_status = ADD_TRACK_BOTTOM;
+            dbclick_status = ADD_TO_AUTODJ_BOTTOM;
     } else if (radioButton_dbclick_top->isChecked()) {
-            dbclick_status = ADD_TRACK_TOP;
+            dbclick_status = ADD_TO_AUTODJ_TOP;
+    } else if (radioButton_dbclick_edit_metadata->isChecked()) {
+            dbclick_status = EDIT_METADATA;
     } else {
-            dbclick_status = LOAD_TRACK_DECK;
+            dbclick_status = LOAD_TO_DECK;
     }
     m_pConfig->set(ConfigKey("[Library]","TrackLoadAction"),
                 ConfigValue(dbclick_status));

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -17,10 +17,11 @@
 class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     Q_OBJECT
   public:
-    enum TrackLoadAction {
-        LOAD_TRACK_DECK,  // Load track to next available deck.
-        ADD_TRACK_BOTTOM, // Add track to Auto-DJ Queue (bottom).
-        ADD_TRACK_TOP     // Add track to Auto-DJ Queue (top).
+    enum TrackDoubleClickAction {
+        LOAD_TO_DECK,
+        ADD_TO_AUTODJ_BOTTOM,
+        ADD_TO_AUTODJ_TOP,
+        EDIT_METADATA
     };
 
     DlgPrefLibrary(

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -261,13 +261,6 @@
       <string extracomment="Sets default action when double-clicking a track in the library.">Track Load Action</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_5">
-      <item row="2" column="0">
-       <widget class="QRadioButton" name="radioButton_dbclick_top">
-        <property name="text">
-         <string>Add track to Auto DJ Queue (top)</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QRadioButton" name="radioButton_dbclick_deck">
         <property name="text">
@@ -282,6 +275,20 @@
        <widget class="QRadioButton" name="radioButton_dbclick_bottom">
         <property name="text">
          <string>Add track to Auto DJ Queue (bottom)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QRadioButton" name="radioButton_dbclick_top">
+        <property name="text">
+         <string>Add track to Auto DJ Queue (top)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QRadioButton" name="radioButton_dbclick_edit_metadata">
+        <property name="text">
+         <string>Edit metadata</string>
         </property>
        </widget>
       </item>

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -105,9 +105,7 @@ WTrackTableView::WTrackTableView(QWidget * parent,
     connect(m_pCoverMenu, SIGNAL(reloadCoverArt()),
             this, SLOT(slotReloadCoverArt()));
 
-
-    // Disable editing
-    //setEditTriggers(QAbstractItemView::NoEditTriggers);
+    setEditTriggers(QAbstractItemView::EditKeyPressed);
 
     // Create all the context m_pMenu->actions (stuff that shows up when you
     //right-click)

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -537,28 +537,34 @@ void WTrackTableView::createActions() {
 
 // slot
 void WTrackTableView::slotMouseDoubleClicked(const QModelIndex &index) {
-    if (!modelHasCapabilities(TrackModel::TRACKMODELCAPS_LOADTODECK)) {
-        return;
-    }
     // Read the current TrackLoadAction settings
-    int action = DlgPrefLibrary::LOAD_TRACK_DECK; // default action
-    if (modelHasCapabilities(TrackModel::TRACKMODELCAPS_ADDTOAUTODJ)) {
-        action = m_pConfig->getValueString(ConfigKey("[Library]","TrackLoadAction")).toInt();
-    }
-    switch (action) {
-    case DlgPrefLibrary::ADD_TRACK_BOTTOM:
-            sendToAutoDJ(PlaylistDAO::AutoDJSendLoc::BOTTOM); // add track to Auto-DJ Queue (bottom)
-            break;
-    case DlgPrefLibrary::ADD_TRACK_TOP:
-            sendToAutoDJ(PlaylistDAO::AutoDJSendLoc::TOP); // add track to Auto-DJ Queue (top)
-            break;
-    default: // load track to next available deck
-            TrackModel* trackModel = getTrackModel();
-            TrackPointer pTrack;
-            if (trackModel && (pTrack = trackModel->getTrack(index))) {
-                emit(loadTrack(pTrack));
-            }
-            break;
+    int doubleClickActionConfigValue = m_pConfig->getValue(
+            ConfigKey("[Library]","TrackLoadAction"),
+            static_cast<int>(DlgPrefLibrary::LOAD_TO_DECK));
+    DlgPrefLibrary::TrackDoubleClickAction doubleClickAction =
+            static_cast<DlgPrefLibrary::TrackDoubleClickAction>(doubleClickActionConfigValue);
+
+    if (doubleClickAction == DlgPrefLibrary::LOAD_TO_DECK
+        && modelHasCapabilities(TrackModel::TRACKMODELCAPS_LOADTODECK)) {
+        TrackModel* trackModel = getTrackModel();
+        VERIFY_OR_DEBUG_ASSERT(trackModel) {
+            return;
+        }
+
+        TrackPointer pTrack = trackModel->getTrack(index);
+        VERIFY_OR_DEBUG_ASSERT(pTrack) {
+            return;
+        }
+
+        emit(loadTrack(pTrack));
+    } else if (doubleClickAction == DlgPrefLibrary::ADD_TO_AUTODJ_BOTTOM
+        && modelHasCapabilities(TrackModel::TRACKMODELCAPS_ADDTOAUTODJ)) {
+        sendToAutoDJ(PlaylistDAO::AutoDJSendLoc::BOTTOM);
+    } else if (doubleClickAction == DlgPrefLibrary::ADD_TO_AUTODJ_TOP
+        && modelHasCapabilities(TrackModel::TRACKMODELCAPS_ADDTOAUTODJ)) {
+        sendToAutoDJ(PlaylistDAO::AutoDJSendLoc::TOP);
+    } else if (doubleClickAction == DlgPrefLibrary::EDIT_METADATA) {
+        edit(index);
     }
 }
 


### PR DESCRIPTION
Before, it was easy to accidentally edit metadata, which is especially dangerous now that Mixxx supports writing metadata back to file tags.

Unfortunately the default F2 keyboard shortcut interferes with this. It works if keyboard shortcuts are turned off. I am not sure what to do about that or if anything should be done. The default keyboard shortcut for F2 is rate_perm_up, which makes such big jumps in the tempo that it's not really useful. I am hesitant to make a change to the default keyboard mapping this close to the 2.1 release. We may leave this known issue unresolved for 2.1.

Fixing https://bugs.launchpad.net/mixxx/+bug/1743238