### PR TITLE
highlighting of crates in track context menu

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1632,16 +1632,17 @@ void WTrackTableView::slotPopulateCrateMenu() {
         pCheckBox->setProperty("crateId",
                                 QVariant::fromValue(crate.getId()));
         pCheckBox->setEnabled(!crate.isLocked());
-        // Strangely, the normal backgroud highlighting that happens with
-        // regular QActions does not happen with QWidgetAction. The :selected
-        // pseudo-state unfortunately does not work with QWidgetAction. :hover
-        // works for selecting items with the mouse, but not with the keyboard.
-        // :focus works for the keyboard but with the mouse, the last clicked
-        // item keeps the style after the mouse cursor is moved to hover over
-        // another item.
-        pCheckBox->setStyleSheet(QString(
-            "QCheckBox:hover {background-color: %1;}").arg(
-                pCheckBox->palette().highlight().color().name()));
+        // Strangely, the normal styling of QActions does not automatically
+        // apply to QWidgetActions. The :selected pseudo-state unfortunately
+        // does not work with QWidgetAction. :hover works for selecting items
+        // with the mouse, but not with the keyboard. :focus works for the
+        // keyboard but with the mouse, the last clicked item keeps the style
+        // after the mouse cursor is moved to hover over another item.
+        pCheckBox->setStyleSheet(
+            QString("QCheckBox {color: %1;}").arg(
+                    pCheckBox->palette().text().color().name()) + "\n" +
+            QString("QCheckBox:hover {background-color: %1;}").arg(
+                    pCheckBox->palette().highlight().color().name()));
         pAction->setEnabled(!crate.isLocked());
         pAction->setDefaultWidget(pCheckBox.get());
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1632,6 +1632,16 @@ void WTrackTableView::slotPopulateCrateMenu() {
         pCheckBox->setProperty("crateId",
                                 QVariant::fromValue(crate.getId()));
         pCheckBox->setEnabled(!crate.isLocked());
+        // Strangely, the normal backgroud highlighting that happens with
+        // regular QActions does not happen with QWidgetAction. The :selected
+        // pseudo-state unfortunately does not work with QWidgetAction. :hover
+        // works for selecting items with the mouse, but not with the keyboard.
+        // :focus works for the keyboard but with the mouse, the last clicked
+        // item keeps the style after the mouse cursor is moved to hover over
+        // another item.
+        pCheckBox->setStyleSheet(QString(
+            "QCheckBox:hover {background-color: %1;}").arg(
+                pCheckBox->palette().highlight().color().name()));
         pAction->setEnabled(!crate.isLocked());
         pAction->setDefaultWidget(pCheckBox.get());
 


### PR DESCRIPTION
When looking into https://bugs.launchpad.net/mixxx/+bug/1740193 I noticed that hovered crates in the track context menu do not have the normal background color style applied. I fixed that, however I have not found any way to set the background style for the selected crate when navigating the menu via keyboard. See the comment in the code for details.