### PR TITLE
put license in About dialog

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,21 @@
 Mixxx version 2.1, Digital DJ'ing software.
 Copyright (C) 2001-2018 Mixxx Development Team
 
-Promotional tracks are copyright their respective owners and
-distributed with permission.
+Mixxx is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version. The full text of the GNU
+General Public License, version 2 can be found below. The licenses
+of software libraries distributed together with Mixxx can be found
+below as well.
+
+Mixxx is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+This distribution of Mixxx may include skins that are licensed under a
+Creative Commons license. Full licensing information is available
+individually for each skin, located in their "skin.xml" file.
 
 Depending on your platform, you may receive a copy of PortAudio
 (http://www.portaudio.com/) which is distributed under the
@@ -16,31 +29,8 @@ available at http://www.steinberg.net/en/company/developer.html .
 
 On Windows you may receive a copy of the Microsoft Visual Studio runtime
 libraries. These are distributed only for the purpose of allowing
-Mixxx to run as per the license agreement for Visual Studio 2005/2008 and
+Mixxx to run as per the license agreement for Visual Studio and
 are copyright of Microsoft.
-
-This distribution of Mixxx may include skins that are licensed under a
-Creative Commons license. Full licensing information is available
-individually for each skin, located in their "skin.xml" file.
-
-The source code for Mixxx itself is licensed under the GPL v2 and
-the GPL v2 with an App Store exception as follows:
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-
-Mixxx comes with ABSOLUTELY NO WARRANTY;
 
 
 		    GNU GENERAL PUBLIC LICENSE

--- a/res/mixxx.qrc
+++ b/res/mixxx.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/">
+        <file>../LICENSE</file>
         <file>images/ic_mixxx_window.png</file>
         <file>images/library/cover_default.png</file>
         <file>images/library/cross.png</file>

--- a/src/dialog/dlgabout.cpp
+++ b/src/dialog/dlgabout.cpp
@@ -1,5 +1,6 @@
 #include "dialog/dlgabout.h"
 #include "util/version.h"
+#include <QFile>
 
 DlgAbout::DlgAbout(QWidget* parent) : QDialog(parent), Ui::DlgAboutDlg() {
     setupUi(this);
@@ -23,6 +24,13 @@ DlgAbout::DlgAbout(QWidget* parent) : QDialog(parent), Ui::DlgAboutDlg() {
         version.append(QString("(%1)").arg(buildInfo.join(" ")));
     }
     version_label->setText(version.join(" "));
+
+    QFile licenseFile(":/LICENSE");
+    if (!licenseFile.open(QIODevice::ReadOnly)) {
+        qWarning() << "LICENSE file not found";
+    } else {
+        licenseText->setPlainText(licenseFile.readAll());
+    }
 
     QString s_devTeam = tr("Mixxx %1 Development Team").arg(mixxxVersion);
     QString s_contributions = tr("With contributions from:");

--- a/src/dialog/dlgaboutdlg.ui
+++ b/src/dialog/dlgaboutdlg.ui
@@ -89,19 +89,44 @@
     </widget>
    </item>
    <item>
-    <widget class="QTextBrowser" name="textBrowser">
-     <property name="html">
-      <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Lucida Grande'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif'; font-size:9pt;&quot;&gt;Credits go here&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::NoTextInteraction</set>
-     </property>
-    </widget>
+     <widget class="QTabWidget" name="tabs">
+       <widget class="QWidget" name="creditsTab">
+         <attribute name="title">
+           <string>Credits</string>
+         </attribute>
+         <layout class="QGridLayout" name="creditsTabLayout">
+           <item row="0" column="0">
+              <widget class="QTextBrowser" name="textBrowser">
+                <property name="html">
+                  <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+            &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+            p, li { white-space: pre-wrap; }
+            &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Lucida Grande'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
+            &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif'; font-size:9pt;&quot;&gt;Credits go here&lt;/span&gt;&lt;/p&gt;
+            &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="textInteractionFlags">
+                  <set>Qt::NoTextInteraction</set>
+                </property>
+              </widget>
+           </item>
+         </layout>
+       </widget>
+       <widget class="QWidget" name="licenseTab">
+         <attribute name="title">
+           <string>License</string>
+         </attribute>
+         <layout class="QGridLayout" name="licenseTabLayout">
+          <item row="0" column="0">
+            <widget class="QTextBrowser" name="licenseText">
+              <property name="textInteractionFlags">
+                <set>Qt::NoTextInteraction</set>
+              </property>
+            </widget>
+           </item>
+         </layout>
+       </widget>
+     </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">


### PR DESCRIPTION
Including the whole text in the .ui file is clunky, but I don't know what would be better. I thought about putting a symlink to the LICENSE file inside the `res` folder and including it in the QRC file. Git can handle symlinks, but I think dealing with them on Windows is a pain.