### PR TITLE
Controller script js import

### DIFF
--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -601,7 +601,7 @@ QScriptValue ControllerEngine::include(QScriptContext *context, QScriptEngine *e
     if (!loadSuccess) {
         QString errorString = QString("ControllerEngine: error while including file %1, from file %2")
                 .arg(parentFileName, includedAbsoluteFileName);
-        return context->throwError(QScriptContext::TypeError, errorString);
+        return context->throwError(QScriptContext::UnknownError, errorString);
     }
 
     return QScriptValue(QScriptValue::UndefinedValue);

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -224,6 +224,7 @@ class ControllerEngine : public QObject {
     // Filesystem watcher for script auto-reload
     QFileSystemWatcher m_scriptWatcher;
     QList<QString> m_lastScriptPaths;
+    QSet<QString> m_loadedScriptsPaths;
 
     friend class ControllerEngineTest;
 };

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -71,6 +71,8 @@ class ScriptConnectionInvokableWrapper : public QObject {
     QString m_idString;
 };
 
+Q_DECLARE_METATYPE(ControllerEngine*)
+
 class ControllerEngine : public QObject {
     Q_OBJECT
   public:
@@ -101,6 +103,12 @@ class ControllerEngine : public QObject {
     void triggerScriptConnection(const ScriptConnection conn);
 
   protected:
+    /**
+    * Loads a JS file into the execution engine.
+    * @param fileName - The path of file to add to the JS engine, relative to the file that contains the include call.
+    */
+    static QScriptValue include(QScriptContext *context, QScriptEngine *engine);
+
     Q_INVOKABLE double getValue(QString group, QString name);
     Q_INVOKABLE void setValue(QString group, QString name, double newValue);
     Q_INVOKABLE double getParameter(QString group, QString name);

--- a/src/test/controllerscripttestfiles/controllerscripttestfile1.js
+++ b/src/test/controllerscripttestfiles/controllerscripttestfile1.js
@@ -1,0 +1,2 @@
+include("subfolder/controllerscripttestfile2.js");
+include("./controllerscripttestfile3.js");

--- a/src/test/controllerscripttestfiles/controllerscripttestfile3.js
+++ b/src/test/controllerscripttestfiles/controllerscripttestfile3.js
@@ -1,0 +1,3 @@
+;(function (global) {
+    global.file3Loaded = true;
+}(this));

--- a/src/test/controllerscripttestfiles/controllerscripttestfile4.js
+++ b/src/test/controllerscripttestfiles/controllerscripttestfile4.js
@@ -1,0 +1,3 @@
+;(function (global) {
+    global.file4Loaded = true;
+}(this));

--- a/src/test/controllerscripttestfiles/controllerscripttestfile5.js
+++ b/src/test/controllerscripttestfiles/controllerscripttestfile5.js
@@ -1,0 +1,7 @@
+;(function (global) {
+    include("controllerscripttestfile5.js")
+    if (global.counter === undefined) {
+        global.counter = 0;
+    }
+    global.counter += 1;
+}(this));

--- a/src/test/controllerscripttestfiles/subfolder/controllerscripttestfile2.js
+++ b/src/test/controllerscripttestfiles/subfolder/controllerscripttestfile2.js
@@ -1,0 +1,1 @@
+include("../controllerscripttestfile4.js");


### PR DESCRIPTION
This PR adds a new include function for JS controller scripts. It allows JS scripts to include other js files. This new function can work with the current way to include scripts by specifying them in the xml.

The include function takes a filename as only parameter and then loads and evaluates the content of that file:
`include("commonFunctions.js");`

The filename can be specified with an absolute path or a relative path. The relative path is taken relative to the importing file. The path syntax is the one specified for Qt (unix style).
`include("../scripts/commonFunctions.js");`
`include("/home/ferran/mixxx_scripts/commonFunctions.js");`

Files are only included once, so it's safe to include the same file from several sources. It is also safe to include a file that has been already included in the xml.

If a call to include is removed from a file while mixxx is running, mixxx reloads the including file live and the included file content is no longer available.

JS snippets in the xml files can't include script files. Only JS loaded from a script file can include other files. (there is no unit test for this because ControllerEngine resets itself when a script file is updated, this makes the test difficult to implement. It has been manually tested in linux though).

You can see some simple examples in the unit tests.

**Why this new way of including controller scripts?**

It's now easier to maintain complex mappings:
- Script files can now be organized in folders and subfolders.
- Now script files are included live: no need to re-apply the xml mapping to a controller to include/uninclude a new script file.
- Only the main script file needs to be specified in the xml file: set and forget.

Easy to share scripts:
- Ben creates a complex controller script library that is written in several files. Mary downloads Ben's library. Before PR, Mary needed to manually specify every file of the library in her xml file. Now, she only needs to include the main file of Ben's library in her script file. The rest of the includes are handled by the library itself.

Kazakore recently [shared in the forums](https://www.mixxx.org/forums/viewtopic.php?f=7&t=11677&p=37502) a massive xml file with all the possible midi messages a controller can send. With that xml and this PR, a developer can now forget about the xml during script development, which greatly decreases the development time.

**TODO:**
- [ ] If a file specified with relative path is not found, search it relative to res/controllers/
- [ ] Document in wiki