### PR TITLE
Sampler fix skin changes and lp1758485 fix

### DIFF
--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -829,7 +829,7 @@ QWidget* LegacySkinParser::parseBackground(const QDomElement& node,
 
     QString filename = m_pContext->selectString(node, "Path");
     QPixmap* background = WPixmapStore::getPixmapNoCache(
-        m_pContext->getSkinPath(filename), m_pContext->getScaleFactor());
+        m_pContext->makeSkinPath(filename), m_pContext->getScaleFactor());
 
     bg->move(0, 0);
     if (background != NULL && !background->isNull()) {

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -307,7 +307,7 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
     qDebug() << "LegacySkinParser loading skin:" << skinPath;
 
     m_pContext = std::make_unique<SkinContext>(m_pConfig, skinPath + "/skin.xml");
-    m_pContext->setSkinBasePath(skinPath + "/");
+    m_pContext->setSkinBasePath(skinPath);
 
     if (m_pParent) {
         qDebug() << "ERROR: Somehow a parent already exists -- you are probably re-using a LegacySkinParser which is not advisable!";
@@ -379,9 +379,6 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
     }
 
     ColorSchemeParser::setupLegacyColorSchemes(skinDocument, m_pConfig, &m_style);
-
-    QStringList skinPaths(skinPath);
-    QDir::setSearchPaths("skin", skinPaths);
 
     // don't parent till here so the first opengl waveform doesn't screw
     // up --bkgood

--- a/src/skin/pixmapsource.cpp
+++ b/src/skin/pixmapsource.cpp
@@ -15,11 +15,11 @@ PixmapSource::PixmapSource(const QString& filepath)
     }
 }
 
-QByteArray PixmapSource::getData() const {
+const QByteArray& PixmapSource::getSvgSourceData() const {
     return m_svgSourceData;
 }
 
-QString PixmapSource::getPath() const {
+const QString& PixmapSource::getPath() const {
     return m_path;
 }
 

--- a/src/skin/pixmapsource.h
+++ b/src/skin/pixmapsource.h
@@ -15,8 +15,8 @@ class PixmapSource final {
     bool isSVG() const;
     bool isBitmap() const;
     void setSVG(const QByteArray& content);
-    QString getPath() const;
-    QByteArray getData() const;
+    const QString& getPath() const;
+    const QByteArray& getSvgSourceData() const;
     QString getId() const;
 
   private:

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -41,8 +41,7 @@ SkinContext::SkinContext(UserSettingsPointer pConfig,
 }
 
 SkinContext::SkinContext(const SkinContext& parent)
-        : m_xmlPath(parent.m_xmlPath),
-          m_skinBasePath(parent.m_skinBasePath),
+        : m_skinBasePath(parent.m_skinBasePath),
           m_pConfig(parent.m_pConfig),
           m_variables(parent.variables()),
           m_pScriptEngine(parent.m_pScriptEngine),
@@ -54,6 +53,7 @@ SkinContext::SkinContext(const SkinContext& parent)
           m_scaleFactor(parent.m_scaleFactor) {
     // we generate a new global object to preserve the scope between
     // a context and its children
+    setXmlPath(parent.m_xmlPath);
     QScriptValue context = m_pScriptEngine->pushContext()->activationObject();
     QScriptValue newGlobal = m_pScriptEngine->newObject();
     QScriptValueIterator it(m_parentGlobal);
@@ -167,16 +167,16 @@ QString SkinContext::nodeToString(const QDomNode& node) const {
 }
 
 PixmapSource SkinContext::getPixmapSource(const QDomNode& pixmapNode) const {
-    const SvgParser svgParser(*this);
-
     if (!pixmapNode.isNull()) {
         QDomNode svgNode = selectNode(pixmapNode, "svg");
         if (!svgNode.isNull()) {
             // inline svg
+            SvgParser svgParser(*this);
             const QByteArray rslt = svgParser.saveToQByteArray(
                     svgParser.parseSvgTree(svgNode, m_xmlPath));
             PixmapSource source;
             source.setSVG(rslt);
+            return source;
         } else {
             // filename.
             return getPixmapSourceInner(nodeToString(pixmapNode));

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -208,7 +208,7 @@ QDomElement SkinContext::loadSvg(const QString& filename) const {
 
 PixmapSource SkinContext::getPixmapSourceInner(const QString& filename) const {
     if (!filename.isEmpty()) {
-        return PixmapSource(getSkinPath(filename));
+        return PixmapSource(makeSkinPath(filename));
     }
     return PixmapSource();
 }

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -32,6 +32,11 @@ class SkinContext {
 
     // Gets a path relative to the skin path.
     QString makeSkinPath(const QString& relativePath) const {
+        if (relativePath.startsWith("/") || relativePath.contains(":")) {
+            // This is already an absolut path start with the root folder "/"
+            // a windows drive letter e.g. "C:" or a qt search path prefix
+            return relativePath;
+        }
         return QString("skin:").append(relativePath);
     }
 

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -39,7 +39,14 @@ class SkinContext {
     void setSkinBasePath(const QString& skinBasePath) {
         QStringList skinPaths(skinBasePath);
         QDir::setSearchPaths("skin", skinPaths);
-        m_skinBasePath = QDir(skinBasePath);
+        m_skinBasePath = skinBasePath;
+    }
+
+    // Sets the base path used by getSkinPath.
+    void setSkinTemplatePath(const QString& skinTemplatePath) {
+        QStringList skinPaths(m_skinBasePath);
+        skinPaths.append(skinTemplatePath);
+        QDir::setSearchPaths("skin", skinPaths);
     }
 
     // Variable lookup and modification methods.
@@ -265,7 +272,7 @@ class SkinContext {
     QString variableNodeToText(const QDomElement& element) const;
 
     QString m_xmlPath;
-    QDir m_skinBasePath;
+    QString m_skinBasePath;
     UserSettingsPointer m_pConfig;
 
     QHash<QString, QString> m_variables;

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -31,8 +31,8 @@ class SkinContext {
     virtual ~SkinContext();
 
     // Gets a path relative to the skin path.
-    QString getSkinPath(const QString& relativePath) const {
-        return m_skinBasePath.filePath(relativePath);
+    QString makeSkinPath(const QString& relativePath) const {
+        return QString("skin:").append(relativePath);
     }
 
     // Sets the base path used by getSkinPath.

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -37,6 +37,8 @@ class SkinContext {
 
     // Sets the base path used by getSkinPath.
     void setSkinBasePath(const QString& skinBasePath) {
+        QStringList skinPaths(skinBasePath);
+        QDir::setSearchPaths("skin", skinPaths);
         m_skinBasePath = QDir(skinBasePath);
     }
 

--- a/src/skin/svgparser.cpp
+++ b/src/skin/svgparser.cpp
@@ -6,13 +6,14 @@
 
 SvgParser::SvgParser(const SkinContext& parent)
         : m_parentContext(parent) {
+    m_pChildContext.reset(new SkinContext(m_parentContext));
 }
 
 SvgParser::~SvgParser() {
 }
 
 QDomNode SvgParser::parseSvgTree(const QDomNode& svgSkinNode,
-                                 const QString& sourcePath) const {
+                                 const QString& sourcePath) {
     m_currentFile = sourcePath;
     // clone svg to don't alter xml input
     QDomElement svgNode = svgSkinNode.cloneNode(true).toElement();
@@ -83,21 +84,19 @@ void SvgParser::parseElement(QDomElement* element) const {
         // Look for a filepath in the "src" attribute
         // QString scriptPath = element->toElement().attribute("src");
 
-        auto childContext = lazyChildContext();
-
         QString scriptPath = element->attribute("src");
         if (!scriptPath.isNull()) {
-            QFile scriptFile(childContext.getSkinPath(scriptPath));
+            QFile scriptFile(m_pChildContext->getSkinPath(scriptPath));
             if (!scriptFile.open(QIODevice::ReadOnly|QIODevice::Text)) {
                 qDebug() << "ERROR: Failed to open script file";
             }
             QTextStream in(&scriptFile);
-            QScriptValue result = childContext.evaluateScript(
+            QScriptValue result = m_pChildContext->evaluateScript(
                 in.readAll(), scriptPath);
         } else {
             // Evaluates the content of the script element
             // QString expression = m_context.nodeToString(*element);
-            QScriptValue result = childContext.evaluateScript(
+            QScriptValue result = m_pChildContext->evaluateScript(
                 element->text(), m_currentFile, element->lineNumber());
         }
     }
@@ -155,10 +154,9 @@ QByteArray SvgParser::saveToQByteArray(const QDomNode& svgNode) const {
 
 QScriptValue SvgParser::evaluateTemplateExpression(const QString& expression,
                                                    int lineNumber) const {
-    auto childContext = lazyChildContext();
-    QScriptValue out = childContext.evaluateScript(
+    QScriptValue out = m_pChildContext->evaluateScript(
         expression, m_currentFile, lineNumber);
-    if (childContext.getScriptEngine()->hasUncaughtException()) {
+    if (m_pChildContext->getScriptEngine()->hasUncaughtException()) {
         // return an empty string as replacement for the in-attribute expression
         return QScriptValue();
     } else {

--- a/src/skin/svgparser.cpp
+++ b/src/skin/svgparser.cpp
@@ -86,7 +86,7 @@ void SvgParser::parseElement(QDomElement* element) const {
 
         QString scriptPath = element->attribute("src");
         if (!scriptPath.isNull()) {
-            QFile scriptFile(m_pChildContext->getSkinPath(scriptPath));
+            QFile scriptFile(m_pChildContext->makeSkinPath(scriptPath));
             if (!scriptFile.open(QIODevice::ReadOnly|QIODevice::Text)) {
                 qDebug() << "ERROR: Failed to open script file";
             }

--- a/src/skin/svgparser.h
+++ b/src/skin/svgparser.h
@@ -17,26 +17,19 @@ class SvgParser {
     virtual ~SvgParser();
 
     QDomNode parseSvgTree(const QDomNode& svgSkinNode,
-                          const QString& sourcePath) const;
+                          const QString& sourcePath);
     QByteArray saveToQByteArray(const QDomNode& svgNode) const;
 
   private:
-    const SkinContext& lazyChildContext() const {
-        if (m_pLazyContext.isNull()) {
-            m_pLazyContext.reset(new SkinContext(m_parentContext));
-        }
-        return *m_pLazyContext;
-    }
     void scanTree(QDomElement* node) const;
     void parseElement(QDomElement* svgNode) const;
     void parseAttributes(QDomElement* element) const;
-    QScriptValue evaluateTemplateExpression(const QString& expression,
-                                            int lineNumber) const;
+    QScriptValue evaluateTemplateExpression(
+            const QString& expression, int lineNumber) const;
 
     const SkinContext& m_parentContext;
-    mutable QScopedPointer<SkinContext> m_pLazyContext;
-    mutable QString m_currentFile;
-    mutable QRegExp m_hookRx;
+    QScopedPointer<SkinContext> m_pChildContext;
+    QString m_currentFile;
 };
 
 #endif /* SVGPARSER_H */

--- a/src/waveform/renderers/waveformmarkproperties.cpp
+++ b/src/waveform/renderers/waveformmarkproperties.cpp
@@ -67,6 +67,6 @@ WaveformMarkProperties::WaveformMarkProperties(const QDomNode& node,
     m_text = context.selectString(node, "Text").arg(hotCue + 1);
     m_pixmapPath = context.selectString(node, "Pixmap");
     if (!m_pixmapPath.isEmpty()) {
-        m_pixmapPath = context.getSkinPath(m_pixmapPath);
+        m_pixmapPath = context.makeSkinPath(m_pixmapPath);
     }
 }

--- a/src/waveform/renderers/waveformrenderbackground.cpp
+++ b/src/waveform/renderers/waveformrenderbackground.cpp
@@ -19,7 +19,7 @@ void WaveformRenderBackground::setup(const QDomNode& node,
     m_backgroundColor = m_waveformRenderer->getWaveformSignalColors()->getBgColor();
     QString backgroundPixmapPath = context.selectString(node, "BgPixmap");
     if (!backgroundPixmapPath.isEmpty()) {
-        m_backgroundPixmapPath = context.getSkinPath(backgroundPixmapPath);
+        m_backgroundPixmapPath = context.makeSkinPath(backgroundPixmapPath);
     }
     setDirty(true);
 }

--- a/src/widget/wdisplay.cpp
+++ b/src/widget/wdisplay.cpp
@@ -58,7 +58,7 @@ void WDisplay::setup(const QDomNode& node, const SkinContext& context) {
     Paintable::DrawMode pathMode =
             context.selectScaleMode(pathNode, Paintable::FIXED);
     for (int i = 0; i < m_pixmaps.size(); ++i) {
-        setPixmap(&m_pixmaps, i, context.getSkinPath(path.arg(i)),
+        setPixmap(&m_pixmaps, i, context.makeSkinPath(path.arg(i)),
                   pathMode, context.getScaleFactor());
     }
 
@@ -72,7 +72,7 @@ void WDisplay::setup(const QDomNode& node, const SkinContext& context) {
             context.selectScaleMode(disabledNode, Paintable::FIXED);
         for (int i = 0; i < m_disabledPixmaps.size(); ++i) {
             setPixmap(&m_disabledPixmaps, i,
-                      context.getSkinPath(disabledPath.arg(i)),
+                      context.makeSkinPath(disabledPath.arg(i)),
                       disabledMode, context.getScaleFactor());
         }
         m_bDisabledLoaded = true;

--- a/src/widget/wimagestore.cpp
+++ b/src/widget/wimagestore.cpp
@@ -62,10 +62,20 @@ QImage* WImageStore::getImageNoCache(const PixmapSource& source, double scaleFac
     QImage* pImage;
     if (source.isSVG()) {
         QSvgRenderer renderer;
-        if (source.getData().isEmpty()) {
-            renderer.load(source.getPath());
+
+        if (!source.getSvgSourceData().isEmpty()) {
+            // Call here the different overload for svg content
+            if (!renderer.load(source.getSvgSourceData())) {
+                // The above line already logs a warning
+                return pImage;
+            }
+        } else if (!source.getPath().isEmpty()) {
+            if (!renderer.load(source.getPath())) {
+                // The above line already logs a warning
+                return pImage;
+            }
         } else {
-            renderer.load(source.getData());
+            return pImage;
         }
 
         pImage = new QImage(renderer.defaultSize() * scaleFactor,

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -72,7 +72,7 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
     m_backgroundPixmapPath = context.selectString(node, "BgPixmap");
     if (!m_backgroundPixmapPath.isEmpty()) {
         m_backgroundPixmap = *WPixmapStore::getPixmapNoCache(
-                context.getSkinPath(m_backgroundPixmapPath),
+                context.makeSkinPath(m_backgroundPixmapPath),
                 m_scaleFactor);
     }
 


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/mixxx/+bug/1758485

It is also the base for https://github.com/mixxxdj/mixxx/pull/1499

It adds the current template directory to the "skin:" search path.
This way it is allowed to build a second skin based on a first. All files are taken from the second folder. If not found, it takes the files from the folder of the current template. 


