### PR TITLE
replace broken ChooseItem by working GoToItem

### DIFF
--- a/res/controllers/Denon MC4000.midi.xml
+++ b/res/controllers/Denon MC4000.midi.xml
@@ -941,10 +941,10 @@
                     <selectknob/>
                 </options>
             </control>
-            <!-- Library encoder button push maps to ChooseItem -->
+            <!-- Library encoder button push maps to GoToItem -->
             <control>
                 <group>[Library]</group>
-                <key>ChooseItem</key>
+                <key>GoToItem</key>
                 <status>0x9F</status>
                 <midino>0x1F</midino>
                 <options>

--- a/res/controllers/Numark-Mixtrack-3-scripts.js
+++ b/res/controllers/Numark-Mixtrack-3-scripts.js
@@ -1074,27 +1074,20 @@ NumarkMixtrack3.PlayButton = function(channel, control, value, status, group) {
     }
 };
 
-/******************     Browse Button/Knob :
- * Track list mode.....:
- * - Turn         : Select a track in the play list
- * - Push         : Load Selected track into first stopped deck
- * Directory mode...... :
- * - SHIFT + Turn : Select Play List/Side bar item
- * - SHIFT + Push : Open/Close selected side bar item.
- *                   Load the selected track (if any) and play.
- * *********************************************************************/
 NumarkMixtrack3.BrowseButton = function(channel, control, value, status, group) {
     var shifted = (NumarkMixtrack3.decks.D1.shiftKey || NumarkMixtrack3.decks
         .D2.shiftKey || NumarkMixtrack3.decks.D3.shiftKey || NumarkMixtrack3.decks.D4.shiftKey);
 
-    if (shifted && value === ON) {
-        // SHIFT + BROWSE push : directory mode -- > Open/Close selected side bar item
-        engine.setValue('[Library]', 'ChooseItem', true);
-    } else {
-        // Browse push : maximize/minimize library view
-        if (value === ON) {
-            script.toggleControl('[Master]', 'maximize_library');
-        }
+    if (value === ON) {
+	    if (shifted) {
+	        // SHIFT + BROWSE push : directory mode -- > Open/Close selected side bar item
+	        engine.setValue('[Library]', 'GoToItem', true);
+	    } else {
+	        // Browse push : maximize/minimize library view
+	        if (value === ON) {
+	            script.toggleControl('[Master]', 'maximize_library');
+	        }
+	    }
     }
 };
 

--- a/res/controllers/Pioneer-DDJ-SX-scripts.js
+++ b/res/controllers/Pioneer-DDJ-SX-scripts.js
@@ -2258,7 +2258,7 @@ PioneerDDJSX.rotarySelectorClick = function(channel, control, value, status) {
 
 PioneerDDJSX.rotarySelectorShiftedClick = function(channel, control, value, status) {
     if (PioneerDDJSX.useNewLibraryControls) {
-        script.toggleControl("[Library]", "ChooseItem");
+        script.toggleControl("[Library]", "GoToItem");
     } else {
         script.toggleControl("[Playlist]", "ToggleSelectedSidebarItem");
     }

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -415,6 +415,10 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                        tr("Move focus to right/left pane"),
                        tr("Move focus one pane to right or left using a knob, as if pressing TAB/SHIFT+TAB keys"),
                        m_libraryStr, libraryMenu);
+    addPrefixedControl("[Library]", "GoToItem",
+                       tr("Go to the currently selected item"),
+                       tr("Choose the currently selected item and advance forward one pane if appropriate"),
+                       m_libraryStr, libraryMenu);
     addPrefixedControl("[Library]", "AutoDjAddBottom",
                        tr("Add to Auto DJ Queue (bottom)"),
                        tr("Append the selected track to the Auto DJ Queue"),

--- a/src/dialog/dlgabout.cpp
+++ b/src/dialog/dlgabout.cpp
@@ -91,7 +91,8 @@ DlgAbout::DlgAbout(QWidget* parent) : QDialog(parent), Ui::DlgAboutDlg() {
             << "Stefan Weber"
             << "Eduardo Acero"
 			<< "Kshitij Gupta"
-			<< "Thomas Jarosch";
+			<< "Thomas Jarosch"
+			<< "Matthew Nicholson";
 
     QStringList specialThanks;
     specialThanks

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -48,6 +48,10 @@ class AutoDJFeature : public LibraryFeature {
 
     TreeItemModel* getChildModel();
 
+    bool hasTrackTable() override {
+        return true;
+    }
+
   public slots:
     void activate();
 

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -11,6 +11,7 @@
 #include "mixer/playermanager.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarysidebar.h"
+#include "widget/wtracktableview.h"
 #include "library/library.h"
 #include "library/libraryview.h"
 
@@ -92,9 +93,9 @@ LibraryControl::LibraryControl(Library* pLibrary)
     connect(m_pMoveFocusBackward.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocusBackward(double)));
     connect(m_pMoveFocus.get(), SIGNAL(valueChanged(double)),this, SLOT(slotMoveFocus(double)));
 
-    // Control to choose the currently selected item in focussed widget (double click)
-    m_pChooseItem = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "ChooseItem"));
-    connect(m_pChooseItem.get(), SIGNAL(valueChanged(double)), this, SLOT(slotChooseItem(double)));
+    // Control to "goto" the currently selected item in focussed widget (context dependent)
+    m_pGoToItem = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "GoToItem"));
+    connect(m_pGoToItem.get(), SIGNAL(valueChanged(double)), this, SLOT(slotGoToItem(double)));
 
     // Auto DJ controls
     m_pAutoDjAddTop = std::make_unique<ControlPushButton>(ConfigKey("[Library]","AutoDjAddTop"));
@@ -451,8 +452,7 @@ void LibraryControl::slotToggleSelectedSidebarItem(double v) {
     }
 }
 
-void LibraryControl::slotChooseItem(double v) {
-    // XXX: Make this more generic? If Enter key is mapped correctly maybe we can use that
+void LibraryControl::slotGoToItem(double v) {
     if (!m_pLibraryWidget) {
         return;
     }
@@ -472,7 +472,21 @@ void LibraryControl::slotChooseItem(double v) {
         setLibraryFocus();
     }
 }
+/*
+=======
 
+    if (v > 0) {
+        if (dynamic_cast<WTrackTableView*>(QApplication::focusWidget())) {
+            // If main pane is focused then try to load the selected track into first stopped
+            return slotLoadSelectedIntoFirstStopped(v);
+        } else {
+            // Otherwise we press return + tab to select current item and go to the next pane
+            emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier});
+            emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier});
+        }
+    }
+>>>>>>> Replace the ChooseItem control with new GoToItem
+*/
 void LibraryControl::slotFontSize(double v) {
     if (v == 0.0) {
         return;

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -471,22 +471,12 @@ void LibraryControl::slotGoToItem(double v) {
     {
         setLibraryFocus();
     }
+    // TODO(xxx) instead of remote control the widgets individual, we should 
+    // translate this into Alt+Return and handle it at each library widget 
+    // individual https://bugs.launchpad.net/mixxx/+bug/1758618
+    //emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Return, Qt::AltModifier});
 }
-/*
-=======
 
-    if (v > 0) {
-        if (dynamic_cast<WTrackTableView*>(QApplication::focusWidget())) {
-            // If main pane is focused then try to load the selected track into first stopped
-            return slotLoadSelectedIntoFirstStopped(v);
-        } else {
-            // Otherwise we press return + tab to select current item and go to the next pane
-            emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier});
-            emitKeyEvent(QKeyEvent{QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier});
-        }
-    }
->>>>>>> Replace the ChooseItem control with new GoToItem
-*/
 void LibraryControl::slotFontSize(double v) {
     if (v == 0.0) {
         return;

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -463,13 +463,14 @@ void LibraryControl::slotGoToItem(double v) {
     }
 
     // Focus the library if this is a leaf node in the tree
-    if (m_pSidebarWidget && v > 0
-            && m_pSidebarWidget->hasFocus()
-            && m_pSidebarWidget->isLeafNodeSelected()) {
-        setLibraryFocus();
-    } else {
-        // Otherwise toggle the sidebar item expanded state
-        slotToggleSelectedSidebarItem(v);
+    if (m_pSidebarWidget->hasFocus()) {
+        if (m_pSidebarWidget && v > 0
+                && m_pSidebarWidget->isLeafNodeSelected()) {
+            setLibraryFocus();
+        } else {
+            // Otherwise toggle the sidebar item expanded state
+            slotToggleSelectedSidebarItem(v);
+        }
     }
     // TODO(xxx) instead of remote control the widgets individual, we should 
     // translate this into Alt+Return and handle it at each library widget 

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -461,15 +461,15 @@ void LibraryControl::slotGoToItem(double v) {
     if (activeView && activeView->hasFocus()) {
         return slotLoadSelectedIntoFirstStopped(v);
     }
-    // Otherwise toggle the sidebar item expanded state (like a double-click)
-    slotToggleSelectedSidebarItem(v);
 
     // Focus the library if this is a leaf node in the tree
     if (m_pSidebarWidget && v > 0
-        && m_pSidebarWidget->hasFocus()
-        && m_pSidebarWidget->isLeafNodeSelected())
-    {
+            && m_pSidebarWidget->hasFocus()
+            && m_pSidebarWidget->isLeafNodeSelected()) {
         setLibraryFocus();
+    } else {
+        // Otherwise toggle the sidebar item expanded state
+        slotToggleSelectedSidebarItem(v);
     }
     // TODO(xxx) instead of remote control the widgets individual, we should 
     // translate this into Alt+Return and handle it at each library widget 

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -463,6 +463,14 @@ void LibraryControl::slotChooseItem(double v) {
     }
     // Otherwise toggle the sidebar item expanded state (like a double-click)
     slotToggleSelectedSidebarItem(v);
+
+    // Focus the library if this is a leaf node in the tree
+    if (m_pSidebarWidget && v > 0
+        && m_pSidebarWidget->hasFocus()
+        && m_pSidebarWidget->isLeafNodeSelected())
+    {
+        setLibraryFocus();
+    }
 }
 
 void LibraryControl::slotFontSize(double v) {

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -58,7 +58,7 @@ class LibraryControl : public QObject {
     void slotMoveFocusForward(double);
     void slotMoveFocusBackward(double);
     void slotMoveFocus(double);
-    void slotChooseItem(double v);
+    void slotGoToItem(double v);
 
     // Deprecated navigation slots
     void slotLoadSelectedTrackToGroup(QString group, bool play);
@@ -111,7 +111,7 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlEncoder> m_pMoveFocus;
 
     // Control to choose the currently selected item in focused widget (double click)
-    std::unique_ptr<ControlObject> m_pChooseItem;
+    std::unique_ptr<ControlObject> m_pGoToItem;
 
     // Add to Auto-Dj Cueue
     std::unique_ptr<ControlObject> m_pAutoDjAddTop;

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -65,6 +65,10 @@ class LibraryFeature : public QObject {
                             KeyboardEventFilter* /* keyboard */) {}
     virtual TreeItemModel* getChildModel() = 0;
 
+    virtual bool hasTrackTable() {
+        return false;
+    }
+
   protected:
     QStringList getPlaylistFiles() const {
         return getPlaylistFiles(QFileDialog::ExistingFiles);

--- a/src/library/mixxxlibraryfeature.h
+++ b/src/library/mixxxlibraryfeature.h
@@ -42,6 +42,10 @@ class MixxxLibraryFeature : public LibraryFeature {
     void bindWidget(WLibrary* pLibrary,
                     KeyboardEventFilter* pKeyboard);
 
+    bool hasTrackTable() override {
+        return true;
+    }
+
   public slots:
     void activate();
     void activateChild(const QModelIndex& index);

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -293,6 +293,14 @@ bool SidebarModel::dropAccept(const QModelIndex& index, QList<QUrl> urls,
     return result;
 }
 
+bool SidebarModel::hasTrackTable(const QModelIndex& index) const {
+    if (index.internalPointer() == this) {
+     return m_sFeatures[index.row()]->hasTrackTable();
+    }
+    return false;
+}
+
+
 bool SidebarModel::dragMoveAccept(const QModelIndex& index, QUrl url) {
     //qDebug() << "SidebarModel::dragMoveAccept() index=" << index << url;
     bool result = false;

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -33,6 +33,7 @@ class SidebarModel : public QAbstractItemModel {
     bool dropAccept(const QModelIndex& index, QList<QUrl> urls, QObject* pSource);
     bool dragMoveAccept(const QModelIndex& index, QUrl url);
     virtual bool hasChildren(const QModelIndex& parent = QModelIndex()) const;
+    bool hasTrackTable(const QModelIndex& index) const;
 
   public slots:
     void clicked(const QModelIndex& index);

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -194,6 +194,10 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
             emit(pressed(index));
         }
         return;
+    //} else if (event->key() == Qt::Key_Enter && (event->modifiers() & Qt::AltModifier)) {
+    //    // encoder click via "GoToItem"
+    //    qDebug() << "GoToItem";
+    //    TODO(xxx) decide what todo here instead of in librarycontrol
     }
 
     // Fall through to deafult handler.

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -82,7 +82,7 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
             if (sidebarModel) {
                 accepted = false;
                 for (const QUrl& url : urls) {
-                    QModelIndex destIndex = this->indexAt(event->pos());
+                    QModelIndex destIndex = indexAt(event->pos());
                     if (sidebarModel->dragMoveAccept(destIndex, url)) {
                         // We only need one URL to be valid for us
                         // to accept the whole drag...
@@ -170,7 +170,13 @@ bool WLibrarySidebar::isLeafNodeSelected() {
     QModelIndexList selectedIndices = this->selectionModel()->selectedRows();
     if (selectedIndices.size() > 0) {
         QModelIndex index = selectedIndices.at(0);
-        return !index.model()->hasChildren(index);
+        if(!index.model()->hasChildren(index)) {
+            return true;
+        }
+        const SidebarModel* sidebarModel = dynamic_cast<const SidebarModel*>(index.model());
+        if (sidebarModel) {
+            return sidebarModel->hasTrackTable(index);
+        }
     }
     return false;
 }

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -166,6 +166,15 @@ void WLibrarySidebar::toggleSelectedItem() {
     }
 }
 
+bool WLibrarySidebar::isLeafNodeSelected() {
+    QModelIndexList selectedIndices = this->selectionModel()->selectedRows();
+    if (selectedIndices.size() > 0) {
+        QModelIndex index = selectedIndices.at(0);
+        return !index.model()->hasChildren(index);
+    }
+    return false;
+}
+
 void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
     if (event->key() == Qt::Key_Return) {
         toggleSelectedItem();

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -26,6 +26,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void keyPressEvent(QKeyEvent* event) override;
     void timerEvent(QTimerEvent* event) override;
     void toggleSelectedItem();
+    bool isLeafNodeSelected();
 
   public slots:
     void selectIndex(const QModelIndex&);


### PR DESCRIPTION
This continues: 
https://github.com/mixxxdj/mixxx/pull/1493
https://github.com/daschuer/mixxx/pull/12

ChooseItem was introduced with 2.1 alpha but has never worked sufficient.
In 2.2 we will have  GoToItem, which is intended to be mapped to the library encoder push. 

This PR prevents us from maintaining broken legacy in 2.2. And allows to map controllers for 2.1 and 2.2 in the same way. 

If focus is on the library tree GoToItem switches to the track table if the knot has one, or if it is a leaf knot.
Otherwise it expands/collapses the tree. This works for Tracks and AutoDJ, because the most used track table is at the features root. 
The only exception is the Brows view. Where GoToItem goes always into the sub folder. 
I assume that this fits for most cases because tracks sibling with other folders should be less common.   
 


 
