### PR TITLE
Change dimensions of ABOUT dialog, so you can read at least the dev t…

### DIFF
--- a/src/dialog/dlgaboutdlg.ui
+++ b/src/dialog/dlgaboutdlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>262</width>
-    <height>322</height>
+    <width>300</width>
+    <height>424</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -78,7 +78,7 @@
    <item>
     <widget class="QLabel" name="version_label">
      <property name="text">
-      <string notr="true">1.x.x</string>
+      <string notr="true">2.x.x</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -89,44 +89,60 @@
     </widget>
    </item>
    <item>
-     <widget class="QTabWidget" name="tabs">
-       <widget class="QWidget" name="creditsTab">
-         <attribute name="title">
-           <string>Credits</string>
-         </attribute>
-         <layout class="QGridLayout" name="creditsTabLayout">
-           <item row="0" column="0">
-              <widget class="QTextBrowser" name="textBrowser">
-                <property name="html">
-                  <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-            &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-            p, li { white-space: pre-wrap; }
-            &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Lucida Grande'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-            &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif'; font-size:9pt;&quot;&gt;Credits go here&lt;/span&gt;&lt;/p&gt;
-            &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="textInteractionFlags">
-                  <set>Qt::NoTextInteraction</set>
-                </property>
-              </widget>
-           </item>
-         </layout>
-       </widget>
-       <widget class="QWidget" name="licenseTab">
-         <attribute name="title">
-           <string>License</string>
-         </attribute>
-         <layout class="QGridLayout" name="licenseTabLayout">
-          <item row="0" column="0">
-            <widget class="QTextBrowser" name="licenseText">
-              <property name="textInteractionFlags">
-                <set>Qt::NoTextInteraction</set>
-              </property>
-            </widget>
-           </item>
-         </layout>
-       </widget>
+    <widget class="QTabWidget" name="tabs">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="documentMode">
+      <bool>false</bool>
+     </property>
+     <property name="movable">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="creditsTab">
+      <attribute name="title">
+       <string>Credits</string>
+      </attribute>
+      <layout class="QGridLayout" name="creditsTabLayout">
+       <property name="margin">
+        <number>12</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QTextBrowser" name="textBrowser">
+         <property name="html">
+          <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.SF NS Text'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande';&quot;&gt;            &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif'; font-size:9pt;&quot;&gt;Credits go here&lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande';&quot;&gt;            &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Sans Serif'; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::NoTextInteraction</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
+     <widget class="QWidget" name="licenseTab">
+      <attribute name="title">
+       <string>License</string>
+      </attribute>
+      <layout class="QGridLayout" name="licenseTabLayout">
+       <property name="margin">
+        <number>12</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QTextBrowser" name="licenseText">
+         <property name="textInteractionFlags">
+          <set>Qt::NoTextInteraction</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">


### PR DESCRIPTION
…eam names without resizing.

* Lower margin values for the text browsers inside the tabs, makes effective space for the text display bigger
* Change default dimensions of the dialog box to A4 vertical ratio (1.14:1)

Follow up to #1553

**experimental**
![experimental](https://user-images.githubusercontent.com/4525897/38019031-d666bb56-3276-11e8-90fc-81f1a0428a4b.png)

**base**
![base](https://user-images.githubusercontent.com/4525897/38019024-d4949a14-3276-11e8-835f-b7fb1b978a5e.png)

