### PR TITLE
disable Qt4 touchscreen hack on macOS

### DIFF
--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -48,6 +48,8 @@ void MixxxApplication::registerMetaTypes() {
     qRegisterMetaType<mixxx::Duration>("mixxx::Duration");
 }
 
+// Macs do not have touchscreens
+#ifndef Q_OS_MAC
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 
 extern void qt_translateRawTouchEvent(QWidget *window,
@@ -181,6 +183,7 @@ bool MixxxApplication::notify(QObject* target, QEvent* event) {
     return ret;
 }
 #endif // QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+#endif // Q_OS_MAC
 
 bool MixxxApplication::touchIsRightButton() {
     if (!m_pTouchShift) {

--- a/src/mixxxapplication.h
+++ b/src/mixxxapplication.h
@@ -11,8 +11,10 @@ class MixxxApplication : public QApplication {
     MixxxApplication(int& argc, char** argv);
     ~MixxxApplication() override;
 
+#ifndef Q_OS_MAC
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     virtual bool notify(QObject*, QEvent*);
+#endif
 #endif
 
   private:


### PR DESCRIPTION
Macs do not have touch screens and this may be causing UI lagging issues:
https://bugs.launchpad.net/mixxx/+bug/1759433

@esbrandt could you test this?