### PR TITLE
disable track table editing after clicking selected track by default on macOS

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -174,7 +174,8 @@ Library::Library(
     }
 
     m_editMetadataSelectedClick = m_pConfig->getValue(
-            ConfigKey(kConfigGroup, "EditMetadataSelectedClick"), true);
+            ConfigKey(kConfigGroup, "EditMetadataSelectedClick"),
+            PREF_LIBRARY_EDIT_METADATA_DEFAULT);
 }
 
 Library::~Library() {

--- a/src/library/library_preferences.h
+++ b/src/library/library_preferences.h
@@ -3,4 +3,12 @@
 
 #define PREF_LEGACY_LIBRARY_DIR ConfigKey("[Playlist]","Directory")
 
+// disable inline metadata editing in track table on selected click
+// by default on macOS due to https://bugs.launchpad.net/mixxx/+bug/1665583
+#ifdef Q_OS_MAC
+#define PREF_LIBRARY_EDIT_METADATA_DEFAULT false
+#else
+#define PREF_LIBRARY_EDIT_METADATA_DEFAULT true
+#endif
+
 #endif /* LIBRARY_PREFERENCES_H */

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -139,7 +139,11 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_show_itunes->setChecked(true);
     checkBox_show_traktor->setChecked(true);
     radioButton_dbclick_bottom->setChecked(false);
+#ifdef Q_OS_MAC
     checkBoxEditMetadataSelectedClicked->setChecked(false);
+#else
+    checkBoxEditMetadataSelectedClicked->setChecked(true);
+#endif
     radioButton_dbclick_top->setChecked(false);
     radioButton_dbclick_deck->setChecked(true);
     spinBoxRowHeight->setValue(Library::kDefaultRowHeightPx);
@@ -177,7 +181,13 @@ void DlgPrefLibrary::slotUpdate() {
     }
 
     bool editMetadataSelectedClick = m_pConfig->getValue(
-            ConfigKey("[Library]","EditMetadataSelectedClick"), false);
+            ConfigKey("[Library]","EditMetadataSelectedClick"),
+// disable by default on macOS due to https://bugs.launchpad.net/mixxx/+bug/1665583
+#ifdef Q_OS_MAC
+            false);
+#else
+            true);
+#endif
     checkBoxEditMetadataSelectedClicked->setChecked(editMetadataSelectedClick);
     m_pLibrary->setEditMedatataSelectedClick(editMetadataSelectedClick);
 

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -139,7 +139,7 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_show_itunes->setChecked(true);
     checkBox_show_traktor->setChecked(true);
     radioButton_dbclick_bottom->setChecked(false);
-    checkBoxDisableSelectedClick->setChecked(false);
+    checkBoxEditMetadataSelectedClicked->setChecked(true);
     radioButton_dbclick_top->setChecked(false);
     radioButton_dbclick_deck->setChecked(true);
     spinBoxRowHeight->setValue(Library::kDefaultRowHeightPx);
@@ -176,8 +176,8 @@ void DlgPrefLibrary::slotUpdate() {
             break;
     }
 
-    checkBoxDisableSelectedClick->setChecked(
-            !m_pConfig->getValue(
+    checkBoxEditMetadataSelectedClicked->setChecked(
+            m_pConfig->getValue(
                         ConfigKey("[Library]","EditMetadataSelectedClick"), true));
 
     m_originalTrackTableFont = m_pLibrary->getTrackTableFont();
@@ -311,9 +311,9 @@ void DlgPrefLibrary::slotApply() {
                 ConfigValue(dbclick_status));
 
     m_pConfig->set(ConfigKey("[Library]", "EditMetadataSelectedClick"),
-            ConfigValue(!checkBoxDisableSelectedClick->checkState()));
+            ConfigValue(checkBoxEditMetadataSelectedClicked->checkState()));
     m_pLibrary->setEditMedatataSelectedClick(
-            !checkBoxDisableSelectedClick->checkState());
+            checkBoxEditMetadataSelectedClicked->checkState());
 
     QFont font = m_pLibrary->getTrackTableFont();
     if (m_originalTrackTableFont != font) {

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -139,11 +139,7 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_show_itunes->setChecked(true);
     checkBox_show_traktor->setChecked(true);
     radioButton_dbclick_bottom->setChecked(false);
-#ifdef Q_OS_MAC
-    checkBoxEditMetadataSelectedClicked->setChecked(false);
-#else
-    checkBoxEditMetadataSelectedClicked->setChecked(true);
-#endif
+    checkBoxEditMetadataSelectedClicked->setChecked(PREF_LIBRARY_EDIT_METADATA_DEFAULT);
     radioButton_dbclick_top->setChecked(false);
     radioButton_dbclick_deck->setChecked(true);
     spinBoxRowHeight->setValue(Library::kDefaultRowHeightPx);
@@ -182,12 +178,7 @@ void DlgPrefLibrary::slotUpdate() {
 
     bool editMetadataSelectedClick = m_pConfig->getValue(
             ConfigKey("[Library]","EditMetadataSelectedClick"),
-// disable by default on macOS due to https://bugs.launchpad.net/mixxx/+bug/1665583
-#ifdef Q_OS_MAC
-            false);
-#else
-            true);
-#endif
+            PREF_LIBRARY_EDIT_METADATA_DEFAULT);
     checkBoxEditMetadataSelectedClicked->setChecked(editMetadataSelectedClick);
     m_pLibrary->setEditMedatataSelectedClick(editMetadataSelectedClick);
 

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -139,7 +139,7 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_show_itunes->setChecked(true);
     checkBox_show_traktor->setChecked(true);
     radioButton_dbclick_bottom->setChecked(false);
-    checkBoxEditMetadataSelectedClicked->setChecked(true);
+    checkBoxEditMetadataSelectedClicked->setChecked(false);
     radioButton_dbclick_top->setChecked(false);
     radioButton_dbclick_deck->setChecked(true);
     spinBoxRowHeight->setValue(Library::kDefaultRowHeightPx);
@@ -176,9 +176,10 @@ void DlgPrefLibrary::slotUpdate() {
             break;
     }
 
-    checkBoxEditMetadataSelectedClicked->setChecked(
-            m_pConfig->getValue(
-                        ConfigKey("[Library]","EditMetadataSelectedClick"), true));
+    bool editMetadataSelectedClick = m_pConfig->getValue(
+            ConfigKey("[Library]","EditMetadataSelectedClick"), false);
+    checkBoxEditMetadataSelectedClicked->setChecked(editMetadataSelectedClick);
+    m_pLibrary->setEditMedatataSelectedClick(editMetadataSelectedClick);
 
     m_originalTrackTableFont = m_pLibrary->getTrackTableFont();
     m_iOriginalTrackTableRowHeight = m_pLibrary->getTrackTableRowHeight();

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -8,6 +8,7 @@
 #include "preferences/dialog/ui_dlgpreflibrarydlg.h"
 #include "preferences/usersettings.h"
 #include "library/library.h"
+#include "library/library_preferences.h"
 #include "preferences/dlgpreferencepage.h"
 
 /**

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -250,9 +250,9 @@
        </widget>
       </item>
       <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="checkBoxDisableSelectedClick">
+       <widget class="QCheckBox" name="checkBoxEditMetadataSelectedClicked">
         <property name="text">
-         <string>Prevent editing of metadata by clicking selected track</string>
+         <string>Edit metadata after clicking selected track</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
As discussed in #1561