### PR TITLE
Add hotcue mappings to hercules RMX keypad

### DIFF
--- a/res/controllers/Hercules-DJ-Console-RMX-hid-scripts.js
+++ b/res/controllers/Hercules-DJ-Console-RMX-hid-scripts.js
@@ -163,10 +163,27 @@ RMX.init = function() {
 
   var print_unhandled_button = function(g,e,v) { print("Unhandled button");};
 
-  c.capture("keypad1","all", print_unhandled_button );
-  c.capture("keypad2","all", print_unhandled_button );
-  c.capture("keypad3","all", print_unhandled_button );
-  c.capture("keypad4","all", print_unhandled_button );
+  c.capture("keypad1","all", function(g, e, v) {
+    engine.setValue(g,"hotcue_1_activate",v)
+  } );
+  c.capture("keypad2","all", function(g, e, v) {
+    engine.setValue(g,"hotcue_2_activate",v)
+  } );
+  c.capture("keypad3","all", function(g, e, v) {
+    engine.setValue(g,"hotcue_3_activate",v)
+  } );
+  c.capture("keypad4","all", function(g, e, v) {
+    engine.setValue(g,"hotcue_4_activate",v)
+  } );
+  
+  c.capture("keypad5","all", function(g, e, v) {
+    engine.setValue(g,"loop_in",v)
+  } );
+  c.capture("keypad6","all", function(g, e, v) {
+    engine.setValue(g,"loop_out",v)
+  } );
+  
+  
   c.capture("keypad5","all", print_unhandled_button );
   c.capture("keypad6","all", print_unhandled_button );
 

--- a/res/controllers/Hercules-DJ-Console-RMX-hid-scripts.js
+++ b/res/controllers/Hercules-DJ-Console-RMX-hid-scripts.js
@@ -182,10 +182,6 @@ RMX.init = function() {
   c.capture("keypad6","all", function(g, e, v) {
     engine.setValue(g,"loop_out",v)
   } );
-  
-  
-  c.capture("keypad5","all", print_unhandled_button );
-  c.capture("keypad6","all", print_unhandled_button );
 
   var filterKill = function(g, e, v) {
     engine.setValue(g, e, !engine.getValue(g, e));


### PR DESCRIPTION
Hi there

I replaced my ION discover DJ with a second hand hercules DJ RMX.
after messing around with udev and other settings, I got it to work, but discovered the keypad was completely unmapped. the wiki page for this controller is also out-of-date showing 2 possible mappings with 1 having keypad 5 and 6 mapped to the flanger effect from pre-mixxx 2.0.
I changed the script to use the hotcue buttons where they are designed for. unfortunately mixxx only has 4 hotcues so I mapped 5 and 6 to loop_in and loop_out (since I use them a lot).

if necessary I can also update the wiki page @https://www.mixxx.org/wiki/doku.php/hercules_dj_console_rmx if this MR gets approved.