### PR TITLE
fix controller mapping validation test

### DIFF
--- a/res/controllers/Reloop Terminal Mix 2-4.js
+++ b/res/controllers/Reloop Terminal Mix 2-4.js
@@ -42,6 +42,46 @@ TerminalMix.init = function (id,debug) {
         }
     }
 
+    // New mapping of FX units using midi-components-0.0.js
+    // EffectUnits 1 & 3. Usage:
+    // new components.EffectUnit([int list EffUnit numbers], bool allowFocusWhenParametersHidden)
+    TerminalMix.effectUnit13 = new components.EffectUnit([1,3]);
+    TerminalMix.effectUnit13.enableButtons[1].midi = [0x90, 0x07];
+    TerminalMix.effectUnit13.enableButtons[2].midi = [0x90, 0x08];
+    TerminalMix.effectUnit13.enableButtons[3].midi = [0x90, 0x09];
+    TerminalMix.effectUnit13.knobs[1].midi = [0xB0, 0x03];
+    TerminalMix.effectUnit13.knobs[2].midi = [0xB0, 0x04];
+    TerminalMix.effectUnit13.knobs[3].midi = [0xB0, 0x05];
+    TerminalMix.effectUnit13.dryWetKnob.midi = [0xB0, 0x06];
+    TerminalMix.effectUnit13.dryWetKnob.input = function (channel, control, value, status, group) {
+        if (value === 63) {
+          this.inSetParameter(this.inGetParameter() - .07);
+        } else if (value === 65) {
+          this.inSetParameter(this.inGetParameter() + .07);
+        }
+    };
+    TerminalMix.effectUnit13.effectFocusButton.midi = [0x90, 0x0A];
+    TerminalMix.effectUnit13.init();
+
+    // EffectUnits 2 & 4
+    TerminalMix.effectUnit24 = new components.EffectUnit([2,4]);
+    TerminalMix.effectUnit24.enableButtons[1].midi = [0x91, 0x07];
+    TerminalMix.effectUnit24.enableButtons[2].midi = [0x91, 0x08];
+    TerminalMix.effectUnit24.enableButtons[3].midi = [0x91, 0x09];
+    TerminalMix.effectUnit24.knobs[1].midi = [0xB1, 0x03];
+    TerminalMix.effectUnit24.knobs[2].midi = [0xB1, 0x04];
+    TerminalMix.effectUnit24.knobs[3].midi = [0xB1, 0x05];
+    TerminalMix.effectUnit24.dryWetKnob.midi = [0xB1, 0x06];
+    TerminalMix.effectUnit24.dryWetKnob.input = function (channel, control, value, status, group) {
+        if (value === 63) {
+          this.inSetParameter(this.inGetParameter() - .07);
+        } else if (value === 65) {
+          this.inSetParameter(this.inGetParameter() + .07);
+        }
+    };
+    TerminalMix.effectUnit24.effectFocusButton.midi = [0x91, 0x0A];
+    TerminalMix.effectUnit24.init();
+
     // Enable four decks in v1.11.x
     engine.setValue("[Master]", "num_decks", 4);
 
@@ -499,46 +539,6 @@ TerminalMix.shiftButtonR = function (channel, control, value, status, group) {
     TerminalMix.shiftedR = false;
   }
 }
-
-// New mapping of FX units using midi-components-0.0.js
-// EffectUnits 1 & 3. Usage:
-// new components.EffectUnit([int list EffUnit numbers], bool allowFocusWhenParametersHidden)
-TerminalMix.effectUnit13 = new components.EffectUnit([1,3]);
-TerminalMix.effectUnit13.enableButtons[1].midi = [0x90, 0x07];
-TerminalMix.effectUnit13.enableButtons[2].midi = [0x90, 0x08];
-TerminalMix.effectUnit13.enableButtons[3].midi = [0x90, 0x09];
-TerminalMix.effectUnit13.knobs[1].midi = [0xB0, 0x03];
-TerminalMix.effectUnit13.knobs[2].midi = [0xB0, 0x04];
-TerminalMix.effectUnit13.knobs[3].midi = [0xB0, 0x05];
-TerminalMix.effectUnit13.dryWetKnob.midi = [0xB0, 0x06];
-TerminalMix.effectUnit13.dryWetKnob.input = function (channel, control, value, status, group) {
-    if (value === 63) {
-       this.inSetParameter(this.inGetParameter() - .07);
-    } else if (value === 65) {
-       this.inSetParameter(this.inGetParameter() + .07);
-    }
-};
-TerminalMix.effectUnit13.effectFocusButton.midi = [0x90, 0x0A];
-TerminalMix.effectUnit13.init();
-
-// EffectUnits 2 & 4
-TerminalMix.effectUnit24 = new components.EffectUnit([2,4]);
-TerminalMix.effectUnit24.enableButtons[1].midi = [0x91, 0x07];
-TerminalMix.effectUnit24.enableButtons[2].midi = [0x91, 0x08];
-TerminalMix.effectUnit24.enableButtons[3].midi = [0x91, 0x09];
-TerminalMix.effectUnit24.knobs[1].midi = [0xB1, 0x03];
-TerminalMix.effectUnit24.knobs[2].midi = [0xB1, 0x04];
-TerminalMix.effectUnit24.knobs[3].midi = [0xB1, 0x05];
-TerminalMix.effectUnit24.dryWetKnob.midi = [0xB1, 0x06];
-TerminalMix.effectUnit24.dryWetKnob.input = function (channel, control, value, status, group) {
-    if (value === 63) {
-       this.inSetParameter(this.inGetParameter() - .07);
-    } else if (value === 65) {
-       this.inSetParameter(this.inGetParameter() + .07);
-    }
-};
-TerminalMix.effectUnit24.effectFocusButton.midi = [0x91, 0x0A];
-TerminalMix.effectUnit24.init();
 
 // ----------- LED Output functions -------------
 


### PR DESCRIPTION
working around this error that happens when the Components EffectUnit is initialized by the test:
```
ControllerEngine: Watching JS File: "E:/Jenkins/workspace/v2.1/mixxx-2.1-release/architecture/amd64/platform/windows/res/controllers/Reloop Terminal Mix 2-4.js"
ControllerEngine: Loading "E:/Jenkins/workspace/v2.1/mixxx-2.1-release/architecture/amd64/platform/windows/res/controllers/Reloop Terminal Mix 2-4.js"
ControlDoublePrivate::getControl returning NULL for ( "[EffectRack1_EffectUnit1]" , "show_parameters" )
"ControllerEngine: script tried to connect to ControlObject ([EffectRack1_EffectUnit1], show_parameters) which is non-existent, ignoring."
ControllerEngine: "Uncaught exception at line 666 in file E:/Jenkins/workspace/v2.1/mixxx-2.1-release/architecture/amd64/platform/windows/res/controllers/midi-components-0.0.js: TypeError: Result of expression 'this.showParametersConnection' [undefined] is not an object."
ControllerEngine shutting down...
src\test\controller_preset_validation_test.cpp(194): error: Value of: testLoadPreset(preset)
  Actual: false
Expected: true
```
@ronso0 can you confirm that the Reloop Terminal Mix mapping still works with this?