### PR TITLE
Shade :: make library sidebar split size persistent

### DIFF
--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -457,8 +457,9 @@
 					<Children>
 						<Splitter>
 							<Size>me,me</Size>
-							<Style></Style>
-							<SplitSizes>1,e</SplitSizes>
+							<SplitSizes>1,6</SplitSizes>
+							<Collapsible>1,0</Collapsible>
+							<SplitSizesConfigKey>[Shade],splitSizeLibTree</SplitSizesConfigKey>
 							<Children>
 								<WidgetGroup>
 									<Style>QGroupBox {}</Style>
@@ -616,7 +617,6 @@
 											<!-- Preview Deck Column 2-->
 												<WidgetGroup>
 													<MinimumSize>20,62</MinimumSize>
-
 													<Children>
 													<!--
 													**********************************************
@@ -707,6 +707,7 @@
 									<!-- Library Table-->
 									<Style>QGroupBox {}</Style>
 									<Layout>vertical</Layout>
+									<SizePolicy>me,me</SizePolicy>
 									<Children>
 										<Library></Library>
 									</Children>


### PR DESCRIPTION
Fixing https://bugs.launchpad.net/mixxx/+bug/1760490

After clean start without mixxx.cfg it looks like this:
![shade-lib-split-fix](https://user-images.githubusercontent.com/5934199/38178350-496b1d02-3611-11e8-8a2b-0099b0a94bad.png)
