### PR TITLE
Deere: redesign fader and knob colors

### DIFF
--- a/res/skins/Deere/auxiliary.xml
+++ b/res/skins/Deere/auxiliary.xml
@@ -39,7 +39,7 @@
               <Template src="skin:knob_with_button.xml">
                 <SetVariable name="TooltipId">microphone_pregain</SetVariable>
                 <SetVariable name="control">pregain</SetVariable>
-                <SetVariable name="color">carmine</SetVariable>
+                <SetVariable name="color">green</SetVariable>
                 <SetVariable name="button_TooltipId">mute</SetVariable>
                 <SetVariable name="button_control">mute</SetVariable>
                 <SetVariable name="label">Gain</SetVariable>

--- a/res/skins/Deere/effect_unit_no_parameters.xml
+++ b/res/skins/Deere/effect_unit_no_parameters.xml
@@ -71,7 +71,7 @@ Variables:
                 <SetVariable name="TooltipId">EffectUnit_mix</SetVariable>
                 <SetVariable name="control">mix</SetVariable>
                 <SetVariable name="label">Mix</SetVariable>
-                <SetVariable name="color">orange</SetVariable>
+                <SetVariable name="color">purple_gapless</SetVariable>
               </Template>
             </Children>
           </WidgetGroup>

--- a/res/skins/Deere/effect_unit_no_parameters.xml
+++ b/res/skins/Deere/effect_unit_no_parameters.xml
@@ -58,19 +58,17 @@ Variables:
                   <BindProperty>visible</BindProperty>
                 </Connection>
                 <Children>
-                  <Template src="skin:knob_with_label.xml">
+                  <Template src="skin:knob.xml">
                     <SetVariable name="TooltipId">EffectUnit_super1</SetVariable>
                     <SetVariable name="control">super1</SetVariable>
-                    <SetVariable name="label">Super</SetVariable>
                     <SetVariable name="color">blue_gapless</SetVariable>
                   </Template>
                 </Children>
               </WidgetGroup>
 
-              <Template src="skin:knob_with_label.xml">
+              <Template src="skin:knob.xml">
                 <SetVariable name="TooltipId">EffectUnit_mix</SetVariable>
                 <SetVariable name="control">mix</SetVariable>
-                <SetVariable name="label">Mix</SetVariable>
                 <SetVariable name="color">purple_gapless</SetVariable>
               </Template>
             </Children>

--- a/res/skins/Deere/effect_unit_with_parameters.xml
+++ b/res/skins/Deere/effect_unit_with_parameters.xml
@@ -50,7 +50,7 @@ Variables:
                 <SetVariable name="TooltipId">EffectUnit_mix</SetVariable>
                 <SetVariable name="control">mix</SetVariable>
                 <SetVariable name="label">Mix</SetVariable>
-                <SetVariable name="color">orange</SetVariable>
+                <SetVariable name="color">purple_gapless</SetVariable>
               </Template>
 
               <WidgetGroup>

--- a/res/skins/Deere/effect_unit_with_parameters.xml
+++ b/res/skins/Deere/effect_unit_with_parameters.xml
@@ -46,10 +46,9 @@ Variables:
             <SizePolicy>max,max</SizePolicy>
             <Children>
 
-              <Template src="skin:knob_with_label.xml">
+              <Template src="skin:knob.xml">
                 <SetVariable name="TooltipId">EffectUnit_mix</SetVariable>
                 <SetVariable name="control">mix</SetVariable>
-                <SetVariable name="label">Mix</SetVariable>
                 <SetVariable name="color">purple_gapless</SetVariable>
               </Template>
 
@@ -60,10 +59,9 @@ Variables:
                   <BindProperty>visible</BindProperty>
                 </Connection>
                 <Children>
-                  <Template src="skin:knob_with_label.xml">
+                  <Template src="skin:knob.xml">
                     <SetVariable name="TooltipId">EffectUnit_super1</SetVariable>
                     <SetVariable name="control">super1</SetVariable>
-                    <SetVariable name="label">Super</SetVariable>
                     <SetVariable name="color">blue_gapless</SetVariable>
                   </Template>
                 </Children>

--- a/res/skins/Deere/equalizer_rack_parameter_left.xml
+++ b/res/skins/Deere/equalizer_rack_parameter_left.xml
@@ -20,7 +20,7 @@
     <Children>
 
       <EffectPushButton>
-        <TooltipId><Variable name="button_TooltipId"/></TooltipId>
+        <TooltipId>EqualizerRack_effect_button_parameter</TooltipId>
         <Size>15f,15f</Size>
         <ObjectName>CircleButton</ObjectName>
         <NumberStates>2</NumberStates>
@@ -65,7 +65,7 @@
           <EffectParameterKnobComposed>
             <Size>40f,34f</Size>
             <Knob>knob.svg</Knob>
-            <BackPath>knob_bg_<Variable name="color"/>.svg</BackPath>
+            <BackPath>knob_bg_purple.svg</BackPath>
             <MinAngle>-135</MinAngle>
             <MaxAngle>135</MaxAngle>
             <KnobCenterYOffset>1.602</KnobCenterYOffset>

--- a/res/skins/Deere/equalizer_rack_parameter_right.xml
+++ b/res/skins/Deere/equalizer_rack_parameter_right.xml
@@ -28,7 +28,7 @@
           <EffectParameterKnobComposed>
             <Size>40f,34f</Size>
             <Knob>knob.svg</Knob>
-            <BackPath>knob_bg_<Variable name="color"/>.svg</BackPath>
+            <BackPath>knob_bg_purple.svg</BackPath>
             <MinAngle>-135</MinAngle>
             <MaxAngle>135</MaxAngle>
             <KnobCenterYOffset>1.602</KnobCenterYOffset>
@@ -40,7 +40,7 @@
       </WidgetGroup>
 
       <EffectPushButton>
-        <TooltipId><Variable name="button_TooltipId"/></TooltipId>
+        <TooltipId>EqualizerRack_effect_button_parameter</TooltipId>
         <Size>15f,15f</Size>
         <ObjectName>CircleButton</ObjectName>
         <NumberStates>2</NumberStates>

--- a/res/skins/Deere/handle-crossfader-orange.svg
+++ b/res/skins/Deere/handle-crossfader-orange.svg
@@ -10,10 +10,10 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   width="200"
-   height="75"
+   width="80"
+   height="200"
    id="svg2"
-   sodipodi:docname="handle-vertical-purple.svg"
+   sodipodi:docname="handle-crossfader-orange.svg"
    inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -24,15 +24,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1476"
-     inkscape:window-height="1001"
-     id="namedview3867"
+     inkscape:window-width="1031"
+     inkscape:window-height="553"
+     id="namedview6629"
      showgrid="false"
-     inkscape:zoom="3.1466667"
-     inkscape:cx="12.923729"
-     inkscape:cy="37.5"
-     inkscape:window-x="1833"
-     inkscape:window-y="200"
+     inkscape:zoom="1.668772"
+     inkscape:cx="-124.98688"
+     inkscape:cy="111.41787"
+     inkscape:window-x="1815"
+     inkscape:window-y="642"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg2" />
   <metadata
@@ -43,30 +43,30 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs10" />
   <rect
-     width="65"
+     width="70"
      height="190"
      rx="10"
      ry="10"
-     x="-70"
-     y="5"
-     transform="matrix(0,-1,1,0,0,0)"
+     x="-75"
+     y="-195"
+     transform="scale(-1,-1)"
      id="rect4138"
-     style="fill:#333333;fill-opacity:1;stroke:#e0e0e0;stroke-width:9.99999905;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:#333333;fill-opacity:1;stroke:#e0e0e0;stroke-width:10;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
   <rect
      width="155.73222"
-     height="29.525"
+     height="34.525127"
      rx="2"
      ry="2"
-     x="-177.86612"
-     y="-52.262566"
-     transform="scale(-1,-1)"
+     x="22.133881"
+     y="-57.262573"
+     transform="matrix(0,1,-1,0,0,0)"
      id="rect4151-3"
-     style="fill:#f2d440;fill-opacity:1;stroke:none" />
+     style="fill:#ffb108;fill-opacity:1;stroke:none" />
 </svg>

--- a/res/skins/Deere/handle-vertical-orange.svg
+++ b/res/skins/Deere/handle-vertical-orange.svg
@@ -13,7 +13,7 @@
    width="200"
    height="75"
    id="svg2"
-   sodipodi:docname="handle-vertical-purple.svg"
+   sodipodi:docname="handle-vertical-orange.svg"
    inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -24,15 +24,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1476"
-     inkscape:window-height="1001"
-     id="namedview3867"
+     inkscape:window-width="1427"
+     inkscape:window-height="1027"
+     id="namedview3759"
      showgrid="false"
-     inkscape:zoom="3.1466667"
-     inkscape:cx="12.923729"
-     inkscape:cy="37.5"
-     inkscape:window-x="1833"
-     inkscape:window-y="200"
+     inkscape:zoom="3.2138003"
+     inkscape:cx="106.62163"
+     inkscape:cy="24.897328"
+     inkscape:window-x="0"
+     inkscape:window-y="68"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg2" />
   <metadata
@@ -43,7 +43,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -68,5 +68,15 @@
      y="-52.262566"
      transform="scale(-1,-1)"
      id="rect4151-3"
-     style="fill:#f2d440;fill-opacity:1;stroke:none" />
+     style="fill:#e3ca1f;fill-opacity:1;stroke:none" />
+  <rect
+     style="fill:#ffb108;fill-opacity:1;stroke:none"
+     id="rect5888"
+     transform="scale(-1,-1)"
+     y="-52.262566"
+     x="-177.86612"
+     ry="2"
+     rx="2"
+     height="29.525"
+     width="155.73222" />
 </svg>

--- a/res/skins/Deere/knob_bg_green.svg
+++ b/res/skins/Deere/knob_bg_green.svg
@@ -14,7 +14,7 @@
    width="40"
    height="34"
    id="svg2"
-   sodipodi:docname="knob_bg_purple.svg"
+   sodipodi:docname="knob_bg_green.svg"
    inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -25,12 +25,12 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1685"
-     inkscape:window-height="1158"
-     id="namedview5343"
+     inkscape:window-width="1731"
+     inkscape:window-height="1191"
+     id="namedview5958"
      showgrid="false"
-     inkscape:zoom="5.6370316"
-     inkscape:cx="-19.474576"
+     inkscape:zoom="6.9411765"
+     inkscape:cx="-2.2759914"
      inkscape:cy="17"
      inkscape:window-x="0"
      inkscape:window-y="68"
@@ -95,19 +95,14 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <ellipse
-     cx="-13.524048"
-     cy="0.45841381"
-     rx="2.5876327"
-     ry="2.4899862"
-     id="path4202"
-     style="opacity:0;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   <path
-     d="M 9.3196275,29.68685 A 15.375,15.375 0 0 1 17.860214,3.4016293"
-     id="path2995"
-     style="color:#000000;fill:none;stroke:#9129ec;stroke-width:1.85000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="M 22.106891,3.6356876 A 15.138641,15.138641 0 0 1 30.516184,29.516828"
+     transform="matrix(1.0154791,0,0,1.0154791,-0.30959245,-0.28832938)"
+     id="path4981"
+     style="color:#000000;fill:none;stroke:#648829;stroke-width:2.11722732;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.77842563;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   <path
-     d="M 22.139786,3.4016293 A 15.375,15.375 0 0 1 30.680372,29.68685"
-     id="path2995-5"
-     style="color:#000000;fill:none;stroke:#9129ec;stroke-width:1.85000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="M 9.483816,29.516828 A 15.138641,15.138641 0 0 1 17.893108,3.6356878"
+     transform="matrix(1.0154791,0,0,1.0154791,-0.30959245,-0.28832938)"
+     id="path4981-5"
+     style="color:#000000;fill:none;stroke:#648829;stroke-width:2.11722732;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.77842563;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
 </svg>

--- a/res/skins/Deere/knob_bg_green.svg
+++ b/res/skins/Deere/knob_bg_green.svg
@@ -30,7 +30,7 @@
      id="namedview5958"
      showgrid="false"
      inkscape:zoom="6.9411765"
-     inkscape:cx="-2.2759914"
+     inkscape:cx="10.113839"
      inkscape:cy="17"
      inkscape:window-x="0"
      inkscape:window-y="68"
@@ -91,7 +91,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -99,10 +99,10 @@
      d="M 22.106891,3.6356876 A 15.138641,15.138641 0 0 1 30.516184,29.516828"
      transform="matrix(1.0154791,0,0,1.0154791,-0.30959245,-0.28832938)"
      id="path4981"
-     style="color:#000000;fill:none;stroke:#648829;stroke-width:2.11722732;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.77842563;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;fill:none;stroke:#60a71f;stroke-width:2.11722732;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.77842563;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   <path
      d="M 9.483816,29.516828 A 15.138641,15.138641 0 0 1 17.893108,3.6356878"
      transform="matrix(1.0154791,0,0,1.0154791,-0.30959245,-0.28832938)"
      id="path4981-5"
-     style="color:#000000;fill:none;stroke:#648829;stroke-width:2.11722732;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.77842563;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;fill:none;stroke:#60a71f;stroke-width:2.11722732;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.77842563;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
 </svg>

--- a/res/skins/Deere/knob_bg_orange.svg
+++ b/res/skins/Deere/knob_bg_orange.svg
@@ -8,10 +8,34 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="40"
    height="34"
-   id="svg2">
+   id="svg2"
+   sodipodi:docname="knob_bg_orange.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1685"
+     inkscape:window-height="1158"
+     id="namedview5343"
+     showgrid="false"
+     inkscape:zoom="5.6370316"
+     inkscape:cx="-19.474576"
+     inkscape:cy="17"
+     inkscape:window-x="0"
+     inkscape:window-y="68"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
   <defs
      id="defs4">
     <linearGradient
@@ -67,7 +91,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -81,9 +105,9 @@
   <path
      d="M 9.3196275,29.68685 A 15.375,15.375 0 0 1 17.860214,3.4016293"
      id="path2995"
-     style="color:#000000;fill:none;stroke:#fc9d00;stroke-width:1.85000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;fill:none;stroke:#9129ec;stroke-width:1.85000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   <path
      d="M 22.139786,3.4016293 A 15.375,15.375 0 0 1 30.680372,29.68685"
      id="path2995-5"
-     style="color:#000000;fill:none;stroke:#fc9d00;stroke-width:1.85000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;fill:none;stroke:#9129ec;stroke-width:1.85000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
 </svg>

--- a/res/skins/Deere/knob_bg_purple.svg
+++ b/res/skins/Deere/knob_bg_purple.svg
@@ -25,12 +25,12 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1685"
-     inkscape:window-height="1158"
+     inkscape:window-width="1302"
+     inkscape:window-height="920"
      id="namedview5343"
      showgrid="false"
      inkscape:zoom="5.6370316"
-     inkscape:cx="-19.474576"
+     inkscape:cx="16.00509"
      inkscape:cy="17"
      inkscape:window-x="0"
      inkscape:window-y="68"
@@ -91,7 +91,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -105,9 +105,9 @@
   <path
      d="M 9.3196275,29.68685 A 15.375,15.375 0 0 1 17.860214,3.4016293"
      id="path2995"
-     style="color:#000000;fill:none;stroke:#9129ec;stroke-width:1.85000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;fill:none;stroke:#b03eec;stroke-width:1.85000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   <path
      d="M 22.139786,3.4016293 A 15.375,15.375 0 0 1 30.680372,29.68685"
      id="path2995-5"
-     style="color:#000000;fill:none;stroke:#9129ec;stroke-width:1.85000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;fill:none;stroke:#b03eec;stroke-width:1.85000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
 </svg>

--- a/res/skins/Deere/knob_bg_purple_gapless.svg
+++ b/res/skins/Deere/knob_bg_purple_gapless.svg
@@ -30,10 +30,10 @@
      id="namedview897"
      showgrid="false"
      inkscape:zoom="6.9411765"
-     inkscape:cx="-13.711864"
+     inkscape:cx="21.728814"
      inkscape:cy="17"
-     inkscape:window-x="0"
-     inkscape:window-y="68"
+     inkscape:window-x="625"
+     inkscape:window-y="1223"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg2" />
   <defs
@@ -91,7 +91,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -99,5 +99,5 @@
      d="m 7.6728885,30.696176 a 15.865708,15.865708 0 1 1 22.0424935,0"
      transform="matrix(0.96904934,0,0,0.96870025,1.8847978,-0.06558939)"
      id="path6998"
-     style="color:#000000;fill:none;stroke:#9129ec;stroke-width:2.3222816;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;fill:none;stroke:#b03eec;stroke-width:2.3222816;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
 </svg>

--- a/res/skins/Deere/knob_bg_purple_gapless.svg
+++ b/res/skins/Deere/knob_bg_purple_gapless.svg
@@ -14,7 +14,7 @@
    width="40"
    height="34"
    id="svg2"
-   sodipodi:docname="knob_bg_purple.svg"
+   sodipodi:docname="knob_bg_purple_gapless.svg"
    inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -25,12 +25,12 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1685"
-     inkscape:window-height="1158"
-     id="namedview5343"
+     inkscape:window-width="1031"
+     inkscape:window-height="553"
+     id="namedview897"
      showgrid="false"
-     inkscape:zoom="5.6370316"
-     inkscape:cx="-19.474576"
+     inkscape:zoom="6.9411765"
+     inkscape:cx="-13.711864"
      inkscape:cy="17"
      inkscape:window-x="0"
      inkscape:window-y="68"
@@ -95,19 +95,9 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <ellipse
-     cx="-13.524048"
-     cy="0.45841381"
-     rx="2.5876327"
-     ry="2.4899862"
-     id="path4202"
-     style="opacity:0;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   <path
-     d="M 9.3196275,29.68685 A 15.375,15.375 0 0 1 17.860214,3.4016293"
-     id="path2995"
-     style="color:#000000;fill:none;stroke:#9129ec;stroke-width:1.85000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     d="M 22.139786,3.4016293 A 15.375,15.375 0 0 1 30.680372,29.68685"
-     id="path2995-5"
-     style="color:#000000;fill:none;stroke:#9129ec;stroke-width:1.85000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 7.6728885,30.696176 a 15.865708,15.865708 0 1 1 22.0424935,0"
+     transform="matrix(0.96904934,0,0,0.96870025,1.8847978,-0.06558939)"
+     id="path6998"
+     style="color:#000000;fill:none;stroke:#9129ec;stroke-width:2.3222816;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
 </svg>

--- a/res/skins/Deere/microphone.xml
+++ b/res/skins/Deere/microphone.xml
@@ -33,7 +33,7 @@
           <Template src="skin:knob_with_button.xml">
             <SetVariable name="TooltipId">microphone_pregain</SetVariable>
             <SetVariable name="control">pregain</SetVariable>
-            <SetVariable name="color">carmine</SetVariable>
+            <SetVariable name="color">green</SetVariable>
             <SetVariable name="button_TooltipId">mute</SetVariable>
             <SetVariable name="button_control">mute</SetVariable>
             <SetVariable name="label">Gain</SetVariable>

--- a/res/skins/Deere/mixer.xml
+++ b/res/skins/Deere/mixer.xml
@@ -217,7 +217,7 @@
                         <TooltipId>crossfader</TooltipId>
                         <Size>1me,40f</Size>
                         <Slider scalemode="STRETCH">slider-crossfader.svg</Slider>
-                        <Handle scalemode="STRETCH_ASPECT">handle-crossfader-grey.svg</Handle>
+                        <Handle scalemode="STRETCH_ASPECT">handle-crossfader-orange.svg</Handle>
                         <Horizontal>true</Horizontal>
                         <Connection>
                           <ConfigKey>[Master],crossfader</ConfigKey>

--- a/res/skins/Deere/mixer_column_eq_left.xml
+++ b/res/skins/Deere/mixer_column_eq_left.xml
@@ -25,7 +25,7 @@
               <Template src="skin:knob_with_button_left.xml">
                 <SetVariable name="TooltipId">pregain</SetVariable>
                 <SetVariable name="control">pregain</SetVariable>
-                <SetVariable name="color">grey</SetVariable>
+                <SetVariable name="color">green</SetVariable>
                 <SetVariable name="button_TooltipId">mute</SetVariable>
                 <SetVariable name="button_control">mute</SetVariable>
               </Template>
@@ -48,7 +48,7 @@
               <Template src="skin:knob.xml">
                 <SetVariable name="TooltipId">pregain</SetVariable>
                 <SetVariable name="control">pregain</SetVariable>
-                <SetVariable name="color">grey</SetVariable>
+                <SetVariable name="color">green</SetVariable>
               </Template>
             </Children>
             <Connection>
@@ -105,28 +105,18 @@
 
       <Template src="skin:equalizer_rack_parameter_left.xml">
         <SetVariable name="parameter">4</SetVariable>
-        <SetVariable name="color">orange</SetVariable>
       </Template>
 
       <Template src="skin:equalizer_rack_parameter_left.xml">
-        <SetVariable name="TooltipId">EqualizerRack_effect_parameter</SetVariable>
-        <SetVariable name="button_TooltipId">EqualizerRack_effect_button_parameter</SetVariable>
         <SetVariable name="parameter">3</SetVariable>
-        <SetVariable name="color">orange</SetVariable>
       </Template>
 
       <Template src="skin:equalizer_rack_parameter_left.xml">
-        <SetVariable name="TooltipId">EqualizerRack_effect_parameter</SetVariable>
-        <SetVariable name="button_TooltipId">EqualizerRack_effect_button_parameter</SetVariable>
         <SetVariable name="parameter">2</SetVariable>
-        <SetVariable name="color">orange</SetVariable>
       </Template>
 
       <Template src="skin:equalizer_rack_parameter_left.xml">
-        <SetVariable name="TooltipId">EqualizerRack_effect_parameter</SetVariable>
-        <SetVariable name="button_TooltipId">EqualizerRack_effect_button_parameter</SetVariable>
         <SetVariable name="parameter">1</SetVariable>
-        <SetVariable name="color">orange</SetVariable>
       </Template>
 
       <Template src="skin:quick_effect_superknob_left.xml">

--- a/res/skins/Deere/mixer_column_eq_right.xml
+++ b/res/skins/Deere/mixer_column_eq_right.xml
@@ -25,7 +25,7 @@
               <Template src="skin:knob_with_button_right.xml">
                 <SetVariable name="TooltipId">pregain</SetVariable>
                 <SetVariable name="control">pregain</SetVariable>
-                <SetVariable name="color">grey</SetVariable>
+                <SetVariable name="color">green</SetVariable>
                 <SetVariable name="button_TooltipId">mute</SetVariable>
                 <SetVariable name="button_control">mute</SetVariable>
               </Template>
@@ -43,7 +43,7 @@
               <Template src="skin:knob.xml">
                 <SetVariable name="TooltipId">pregain</SetVariable>
                 <SetVariable name="control">pregain</SetVariable>
-                <SetVariable name="color">grey</SetVariable>
+                <SetVariable name="color">green</SetVariable>
               </Template>
 
               <WidgetGroup><!-- Expanding spacer to push EQ knob to opposite side -->
@@ -105,28 +105,18 @@
 
       <Template src="skin:equalizer_rack_parameter_right.xml">
         <SetVariable name="parameter">4</SetVariable>
-        <SetVariable name="color">orange</SetVariable>
       </Template>
 
       <Template src="skin:equalizer_rack_parameter_right.xml">
-        <SetVariable name="TooltipId">EqualizerRack_effect_parameter</SetVariable>
-        <SetVariable name="button_TooltipId">EqualizerRack_effect_button_parameter</SetVariable>
         <SetVariable name="parameter">3</SetVariable>
-        <SetVariable name="color">orange</SetVariable>
       </Template>
 
       <Template src="skin:equalizer_rack_parameter_right.xml">
-        <SetVariable name="TooltipId">EqualizerRack_effect_parameter</SetVariable>
-        <SetVariable name="button_TooltipId">EqualizerRack_effect_button_parameter</SetVariable>
         <SetVariable name="parameter">2</SetVariable>
-        <SetVariable name="color">orange</SetVariable>
       </Template>
 
       <Template src="skin:equalizer_rack_parameter_right.xml">
-        <SetVariable name="TooltipId">EqualizerRack_effect_parameter</SetVariable>
-        <SetVariable name="button_TooltipId">EqualizerRack_effect_button_parameter</SetVariable>
         <SetVariable name="parameter">1</SetVariable>
-        <SetVariable name="color">orange</SetVariable>
       </Template>
 
       <Template src="skin:quick_effect_superknob_right.xml">

--- a/res/skins/Deere/mixer_column_gain_levels.xml
+++ b/res/skins/Deere/mixer_column_gain_levels.xml
@@ -20,7 +20,7 @@
               <Template src="skin:knob.xml">
                 <SetVariable name="TooltipId">pregain</SetVariable>
                 <SetVariable name="control">pregain</SetVariable>
-                <SetVariable name="color">grey</SetVariable>
+                <SetVariable name="color">green</SetVariable>
               </Template>
             </Children>
             <Connection>
@@ -48,7 +48,7 @@
           <Template src="skin:knob.xml">
             <SetVariable name="TooltipId">pregain</SetVariable>
             <SetVariable name="control">pregain</SetVariable>
-            <SetVariable name="color">grey</SetVariable>
+            <SetVariable name="color">green</SetVariable>
           </Template>
         </Children>
         <Connection>

--- a/res/skins/Deere/mixer_column_volume.xml
+++ b/res/skins/Deere/mixer_column_volume.xml
@@ -83,7 +83,7 @@
                 <MinimumSize>40,50</MinimumSize>
                 <MaximumSize>40,150</MaximumSize>
                 <Slider scalemode="STRETCH">slider-vertical.svg</Slider>
-                <Handle scalemode="STRETCH_ASPECT">handle-vertical-grey.svg</Handle>
+                <Handle scalemode="STRETCH_ASPECT">handle-vertical-orange.svg</Handle>
                 <Horizontal>false</Horizontal>
                 <Connection>
                   <ConfigKey><Variable name="group"/>,volume</ConfigKey>
@@ -110,7 +110,7 @@
                 <SizePolicy>min,me</SizePolicy>
                 <MinimumSize>40,80</MinimumSize>
                 <Slider scalemode="STRETCH">slider-vertical.svg</Slider>
-                <Handle scalemode="STRETCH_ASPECT">handle-vertical-grey.svg</Handle>
+                <Handle scalemode="STRETCH_ASPECT">handle-vertical-orange.svg</Handle>
                 <Horizontal>false</Horizontal>
                 <Connection>
                   <ConfigKey><Variable name="group"/>,volume</ConfigKey>

--- a/res/skins/Deere/mixer_controls_condensed_left.xml
+++ b/res/skins/Deere/mixer_controls_condensed_left.xml
@@ -80,7 +80,7 @@
                 <MinimumSize>40,50</MinimumSize>
                 <MaximumSize>40,-1</MaximumSize>
                 <Slider scalemode="STRETCH">slider-vertical.svg</Slider>
-                <Handle scalemode="STRETCH_ASPECT">handle-vertical-grey.svg</Handle>
+                <Handle scalemode="STRETCH_ASPECT">handle-vertical-orange.svg</Handle>
                 <Horizontal>false</Horizontal>
                 <Connection>
                   <ConfigKey><Variable name="group"/>,volume</ConfigKey>

--- a/res/skins/Deere/mixer_controls_condensed_right.xml
+++ b/res/skins/Deere/mixer_controls_condensed_right.xml
@@ -69,7 +69,7 @@
                 <MinimumSize>40,50</MinimumSize>
                 <MaximumSize>40,-1</MaximumSize>
                 <Slider scalemode="STRETCH">slider-vertical.svg</Slider>
-                <Handle scalemode="STRETCH_ASPECT">handle-vertical-grey.svg</Handle>
+                <Handle scalemode="STRETCH_ASPECT">handle-vertical-orange.svg</Handle>
                 <Horizontal>false</Horizontal>
                 <Connection>
                   <ConfigKey><Variable name="group"/>,volume</ConfigKey>

--- a/res/skins/Deere/tool_bar.xml
+++ b/res/skins/Deere/tool_bar.xml
@@ -1,3 +1,4 @@
+
 <!DOCTYPE template>
 <!--
   Description:
@@ -61,7 +62,7 @@
                 <SetVariable name="TooltipId">headphone_gain</SetVariable>
                 <SetVariable name="group">[Master]</SetVariable>
                 <SetVariable name="control">headGain</SetVariable>
-                <SetVariable name="color">carmine</SetVariable>
+                <SetVariable name="color">green</SetVariable>
                 <SetVariable name="label">Head</SetVariable>
               </Template>
 
@@ -92,7 +93,7 @@
                 <SetVariable name="TooltipId">balance</SetVariable>
                 <SetVariable name="group">[Master]</SetVariable>
                 <SetVariable name="control">balance</SetVariable>
-                <SetVariable name="color">orange</SetVariable>
+                <SetVariable name="color">purple</SetVariable>
                 <SetVariable name="label">Balance</SetVariable>
               </Template>
 
@@ -100,7 +101,7 @@
                 <SetVariable name="TooltipId">master_gain</SetVariable>
                 <SetVariable name="group">[Master]</SetVariable>
                 <SetVariable name="control">gain</SetVariable>
-                <SetVariable name="color">grey</SetVariable>
+                <SetVariable name="color">green</SetVariable>
                 <SetVariable name="label">Master</SetVariable>
               </Template>
 


### PR DESCRIPTION
Continuing #1399.
Before:
![screenshot from 2018-04-01 21-11-51](https://user-images.githubusercontent.com/9455094/38180318-5424b002-35f1-11e8-8090-c04eb7d5dde9.png)

After:
![deere-knob-colors](https://user-images.githubusercontent.com/9455094/38180294-24cbfde2-35f1-11e8-8ab6-b8319ba054f6.png)
