### PR TITLE
Shade/Deere :: fix cut off effect selector text lp:1760229

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -982,6 +982,7 @@ WEffectSelector {
     color: #c1cabe;
     background-color: #201f1f;
     selection-background-color: #184880;
+    margin: 0px 0px 0px -7px;
   }
 
 #EffectKnob {

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -57,12 +57,13 @@ WEffectSelector QAbstractItemView {
 	border: 2px solid #060613;
 	selection-background-color: lightgray;
 	font: 13px;
+	margin: 0px 0px 0px -4px; /* no matter if padding or margin, the left border is gone */
 }
 
 WEffectSelector:item
 {
-	border: 0px;
-	padding-left: 16px;  /* move text right to make room for tick mark */
+	border: 0px;         /* puts tick mark behind item text */
+	padding-left: 14px;  /* move text right to make room for tick mark */
 	font: 13px;
 	height: 17px; 
 }


### PR DESCRIPTION
Do those 6 extra pixels solve the issue for Shade?
Drawback: the left border of QAbstractItemView os lost..

before
![shade-fx-fix_before](https://user-images.githubusercontent.com/5934199/38213551-f406afe6-36c1-11e8-90bb-3b16df5cc8ec.png)

after
![shade-fx-fix_after](https://user-images.githubusercontent.com/5934199/38213561-fb3430cc-36c1-11e8-87a0-e4d0acb95b40.png)

Deere
![deere-fx-fix_after](https://user-images.githubusercontent.com/5934199/38213567-009cdfc8-36c2-11e8-9d56-a2a2d7824802.png)

