### PR TITLE
Fix effect selector text getting cut off on Retina Macs

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -982,6 +982,7 @@ WEffectSelector {
     color: #c1cabe;
     background-color: #201f1f;
     selection-background-color: #184880;
+    margin: 0px 0px 0px -7px;
   }
 
 #EffectKnob {

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -982,7 +982,8 @@ WEffectSelector {
     color: #c1cabe;
     background-color: #201f1f;
     selection-background-color: #184880;
-    margin: 0px 0px 0px -7px;
+    /* hack around text getting cut off with scaled checkbox on macOS with Retina screens */
+    margin: 0px 0px 0px -24px;
   }
 
 #EffectKnob {

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -983,7 +983,7 @@ WEffectSelector {
     background-color: #201f1f;
     selection-background-color: #184880;
     /* hack around text getting cut off with scaled checkbox on macOS with Retina screens */
-    margin: 0px 0px 0px -24px;
+    margin: 0px 0px 0px -30px;
   }
 
 #EffectKnob {

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -1205,7 +1205,8 @@ WEffectSelector {
     border: 1px solid #666;
     border-radius: 2px;
     padding: 0px;
-    margin: 0px 0px 0px -7px;
+    /* hack around text getting cut off with scaled checkbox on macOS with Retina screens */
+    margin: 0px 0px 0px -24px;
   }
   /* selected item */
   WEffectSelector::checked {

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -57,12 +57,13 @@ WEffectSelector QAbstractItemView {
 	border: 2px solid #060613;
 	selection-background-color: lightgray;
 	font: 13px;
+	margin: 0px 0px 0px -4px; /* no matter if padding or margin, the left border is gone */
 }
 
 WEffectSelector:item
 {
-	border: 0px;
-	padding-left: 16px;  /* move text right to make room for tick mark */
+	border: 0px;         /* puts tick mark behind item text */
+	padding-left: 14px;  /* move text right to make room for tick mark */
 	font: 13px;
 	height: 17px; 
 }

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -57,6 +57,7 @@ WEffectSelector QAbstractItemView {
 	border: 2px solid #060613;
 	selection-background-color: lightgray;
 	font: 13px;
+	/* hack around text getting cut off with scaled checkbox on macOS with Retina screens */
 	margin: 0px 0px 0px -4px; /* no matter if padding or margin, the left border is gone */
 }
 


### PR DESCRIPTION
Screenshots from 2016 Macbook Pro with 2880 x 1800 screen:
<img width="156" alt="image" src="https://user-images.githubusercontent.com/9455094/38216869-d115d35c-3691-11e8-8650-aead7893b2a6.png">
<img width="209" alt="image" src="https://user-images.githubusercontent.com/9455094/38216948-14a86652-3692-11e8-836d-d0ac97073507.png">

GNU/Linux with 250% scaling:
![image](https://user-images.githubusercontent.com/9455094/38217801-373153f2-3695-11e8-9781-58354c185069.png)
![image](https://user-images.githubusercontent.com/9455094/38217882-7f7576b6-3695-11e8-9826-23eb29255871.png)
