### PR TITLE
DlgPrefInterface: select default skin in combobox with empty profile

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -216,6 +216,9 @@ void DlgPrefInterface::slotUpdateSchemes() {
 
 void DlgPrefInterface::slotUpdate() {
     m_skinOnUpdate = m_pConfig->getValueString(ConfigKey("[Config]", "ResizableSkin"));
+    if (m_skinOnUpdate.isEmpty()) {
+        m_skinOnUpdate = m_pSkinLoader->getDefaultSkinName();
+    }
     ComboBoxSkinconf->setCurrentIndex(ComboBoxSkinconf->findText(m_skinOnUpdate));
     slotUpdateSchemes();
     m_bRebootMixxxView = false;


### PR DESCRIPTION
fixing https://bugs.launchpad.net/mixxx/+bug/1760513