### PR TITLE
Deere & LateNight & Tango :: fix lp:1758174 squeezed fx parameters at minimum window width 

### DIFF
--- a/res/skins/Deere/effect_button_parameter.xml
+++ b/res/skins/Deere/effect_button_parameter.xml
@@ -17,7 +17,9 @@
         <Layout>vertical</Layout>
         <Children>
           <EffectPushButton>
-            <Size>55f,15f</Size>
+            <MinimumSize>34,15</MinimumSize>
+            <MaximumSize>55,15</MaximumSize>
+            <SizePolicy>me,f</SizePolicy>
             <ObjectName>EffectButton</ObjectName>
             <NumberStates>2</NumberStates>
               <State>
@@ -35,7 +37,10 @@
           </EffectPushButton>
 
           <EffectButtonParameterName>
-            <Size>55f,15f</Size>
+            <MinimumSize>34,15</MinimumSize>
+            <MaximumSize>55,15</MaximumSize>
+            <SizePolicy>me,f</SizePolicy>
+            <Elide>right</Elide>
             <ObjectName>EffectButtonLabel</ObjectName>
             <EffectRack><Variable name="EffectRack"/></EffectRack>
             <EffectUnit><Variable name="EffectUnit"/></EffectUnit>

--- a/res/skins/Deere/effect_parameter_knob.xml
+++ b/res/skins/Deere/effect_parameter_knob.xml
@@ -11,7 +11,9 @@
 <Template>
   <WidgetGroup>
     <Layout>vertical</Layout>
-    <Size>55f,42f</Size>
+    <MinimumSize>34,42</MinimumSize>
+    <MaximumSize>55,42</MaximumSize>
+    <SizePolicy>me,f</SizePolicy>
     <Children>
 
       <WidgetGroup>
@@ -32,12 +34,15 @@
       </WidgetGroup>
 
       <EffectParameterName>
-        <Size>55f,12f</Size>
+        <MinimumSize>34,12</MinimumSize>
+        <MaximumSize>55,12</MaximumSize>
+        <SizePolicy>me,f</SizePolicy>
         <ObjectName>EffectKnobLabel</ObjectName>
         <EffectRack><Variable name="EffectRack"/></EffectRack>
         <EffectUnit><Variable name="EffectUnit"/></EffectUnit>
         <Effect><Variable name="Effect"/></Effect>
         <EffectParameter><Variable name="EffectParameter"/></EffectParameter>
+        <Elide>right</Elide>
       </EffectParameterName>
 
       <Template src="skin:left_5state_button.xml">

--- a/res/skins/Deere/effect_single_with_parameters_row.xml
+++ b/res/skins/Deere/effect_single_with_parameters_row.xml
@@ -55,40 +55,34 @@ Variables:
             <EffectRack><Variable name="EffectRack"/></EffectRack>
             <EffectUnit><Variable name="EffectUnit"/></EffectUnit>
             <Effect><Variable name="Effect"/></Effect>
-            <Size>120f,-1</Size>
+            <MinimumSize>85,22</MinimumSize>
+            <MaximumSize>120,22</MaximumSize>
+            <SizePolicy>min,f</SizePolicy>
           </EffectSelector>
 
           <Template src="skin:effect_parameter_knob.xml">
             <SetVariable name="EffectParameter">1</SetVariable>
-            <SetVariable name="color">blue</SetVariable>
           </Template>
           <Template src="skin:effect_parameter_knob.xml">
             <SetVariable name="EffectParameter">2</SetVariable>
-            <SetVariable name="color">blue</SetVariable>
           </Template>
           <Template src="skin:effect_parameter_knob.xml">
             <SetVariable name="EffectParameter">3</SetVariable>
-            <SetVariable name="color">blue</SetVariable>
           </Template>
           <Template src="skin:effect_parameter_knob.xml">
             <SetVariable name="EffectParameter">4</SetVariable>
-            <SetVariable name="color">blue</SetVariable>
           </Template>
           <Template src="skin:effect_parameter_knob.xml">
             <SetVariable name="EffectParameter">5</SetVariable>
-            <SetVariable name="color">blue</SetVariable>
           </Template>
           <Template src="skin:effect_parameter_knob.xml">
             <SetVariable name="EffectParameter">6</SetVariable>
-            <SetVariable name="color">blue</SetVariable>
           </Template>
           <Template src="skin:effect_parameter_knob.xml">
             <SetVariable name="EffectParameter">7</SetVariable>
-            <SetVariable name="color">blue</SetVariable>
           </Template>
           <Template src="skin:effect_parameter_knob.xml">
             <SetVariable name="EffectParameter">8</SetVariable>
-            <SetVariable name="color">blue</SetVariable>
           </Template>
 
           <Template src="skin:effect_button_parameter.xml">

--- a/res/skins/Deere/skin.xml
+++ b/res/skins/Deere/skin.xml
@@ -67,7 +67,7 @@
   <ObjectName>Mixxx</ObjectName>
   <Style src="skin:style.qss"/>
 
-  <Size>1024me,550me</Size>
+  <Size>1008me,550me</Size>
   <Layout>horizontal</Layout>
 
   <Children>

--- a/res/skins/LateNight/fx_parameter_button.xml
+++ b/res/skins/LateNight/fx_parameter_button.xml
@@ -13,7 +13,9 @@
 
   <WidgetGroup>
     <Layout>vertical</Layout>
-    <Size>60f,35min</Size>
+    <MinimumSize>55,35</MinimumSize>
+    <MaximumSize>60,-1</MaximumSize>
+    <SizePolicy>me,min</SizePolicy>
     <Children>
 
       <WidgetGroup>

--- a/res/skins/LateNight/fx_parameter_knob.xml
+++ b/res/skins/LateNight/fx_parameter_knob.xml
@@ -14,7 +14,9 @@
   <WidgetGroup>
     <ObjectName>FxKnobContainer</ObjectName>
     <Layout>vertical</Layout>
-    <Size>60f,-1me</Size>
+    <MinimumSize>55,35</MinimumSize>
+    <MaximumSize>60,-1</MaximumSize>
+    <SizePolicy>me,me</SizePolicy>
     <Children>
 
       <WidgetGroup><Size>1min,1f</Size></WidgetGroup>
@@ -68,7 +70,7 @@
       <Template src="skin:button_5state.xml">
         <SetVariable name="TooltipId">EffectSlot_parameter_link_type</SetVariable>
         <SetVariable name="ObjectName">FxSuperLinkButton</SetVariable>
-        <SetVariable name="Size">60f,5f</SetVariable>
+        <SetVariable name="Size">55me,5f</SetVariable>
         <SetVariable name="ConfigKey"><Variable name="FxRack_FxUnit_FxNum"/>,parameter<Variable name="FxParameter"/>_link_type</SetVariable>
       </Template>
 
@@ -78,7 +80,7 @@
       <Template src="skin:button_2state.xml">
         <SetVariable name="TooltipId">EffectSlot_parameter_inversion</SetVariable>
         <SetVariable name="ObjectName">FxSuperLinkInvertButton</SetVariable>
-        <SetVariable name="Size">60f,7f</SetVariable>
+        <SetVariable name="Size">55me,7f</SetVariable>
         <SetVariable name="ConfigKey"><Variable name="FxRack_FxUnit_FxNum"/>,parameter<Variable name="FxParameter"/>_link_inverse</SetVariable>
       </Template>
 

--- a/res/skins/LateNight/fx_slot.xml
+++ b/res/skins/LateNight/fx_slot.xml
@@ -23,7 +23,7 @@
             <Layout>horizontal</Layout>
             <SizePolicy>min,min</SizePolicy>
             <Children>
-              <WidgetGroup><Size>0me,-1min</Size></WidgetGroup>
+              <WidgetGroup><Size>0min,-1min</Size></WidgetGroup>
               <Template src="skin:fx_parameter_button.xml">
                 <SetVariable name="FxParameter">1</SetVariable>
               </Template>

--- a/res/skins/LateNight/library.xml
+++ b/res/skins/LateNight/library.xml
@@ -2,7 +2,7 @@
   <WidgetGroup>
     <ObjectName>Library</ObjectName>
     <SizePolicy>me,i</SizePolicy>
-    <MinimumSize>1280,-</MinimumSize>
+    <MinimumSize>1270,-</MinimumSize>
     <Layout>vertical</Layout>
     <Children>
 

--- a/res/skins/Tango/fx_parameter_button.xml
+++ b/res/skins/Tango/fx_parameter_button.xml
@@ -40,6 +40,7 @@ Variables:
             <Effect><Variable name="FxNum"/></Effect>
             <EffectButtonParameter><Variable name="FxParameter"/></EffectButtonParameter>
             <Alignment>center</Alignment>
+            <Elide>right</Elide>
           </EffectButtonParameterName>
           <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
         </Children>

--- a/res/skins/Tango/fx_parameter_knob.xml
+++ b/res/skins/Tango/fx_parameter_knob.xml
@@ -14,18 +14,24 @@ Variables:
 
   <WidgetGroup>
     <Layout>vertical</Layout>
-    <Size>52f,47f</Size>
+    <MinimumSize>43,47</MinimumSize>
+    <MaximumSize>52,47</MaximumSize>
+    <SizePolicy>me,f</SizePolicy>
     <Children>
 
       <WidgetGroup><!-- Parameter knob + parameter name -->
         <Layout>vertical</Layout>
-        <Size>52f,34f</Size>
+        <MinimumSize>42,34</MinimumSize>
+        <MaximumSize>51,34</MaximumSize>
+        <SizePolicy>me,f</SizePolicy>
         <Children>
 
           <WidgetGroup><!-- Effect parameter knob -->
             <ObjectName>FxParameterKnob</ObjectName>
             <Layout>vertical</Layout>
-            <Size>51f,23f</Size>
+            <MinimumSize>42,23</MinimumSize>
+            <MaximumSize>51,23</MaximumSize>
+            <SizePolicy>me,f</SizePolicy>
             <Children>
               <EffectParameterKnobComposed>
                 <Size>26f,23f</Size>
@@ -42,7 +48,9 @@ Variables:
           </WidgetGroup>
 
           <WidgetGroup><!-- Name of parameter -->
-            <Size>51f,11f</Size>
+            <MinimumSize>42,11</MinimumSize>
+            <MaximumSize>51,11</MaximumSize>
+            <SizePolicy>me,f</SizePolicy>
             <Layout>horizontal</Layout>
             <Children>
               <!-- To keep text centered it's in an container with spacers on the left/right -->
@@ -68,7 +76,7 @@ Variables:
       <Template src="skin:button_5state.xml">
         <SetVariable name="TooltipId">EffectSlot_parameter_link_type</SetVariable>
         <SetVariable name="ObjectName">FxSuperLinkButton</SetVariable>
-        <SetVariable name="Size">51f,5f</SetVariable>
+        <SetVariable name="Size">42me,5f</SetVariable>
         <SetVariable name="ConfigKey"><Variable name="FxRack_FxUnit_FxNum"/>,parameter<Variable name="FxParameter"/>_link_type</SetVariable>
       </Template>
 
@@ -78,7 +86,7 @@ Variables:
       <Template src="skin:button_2state.xml">
         <SetVariable name="TooltipId">EffectSlot_parameter_inversion</SetVariable>
         <SetVariable name="ObjectName">FxSuperLinkInvertButton</SetVariable>
-        <SetVariable name="Size">51f,5f</SetVariable>
+        <SetVariable name="Size">42me,5f</SetVariable>
         <SetVariable name="ConfigKey"><Variable name="FxRack_FxUnit_FxNum"/>,parameter<Variable name="FxParameter"/>_link_inverse</SetVariable>
       </Template>
 

--- a/res/skins/Tango/fx_parameter_row.xml
+++ b/res/skins/Tango/fx_parameter_row.xml
@@ -7,9 +7,9 @@ Variables passed through from fx_unit:
 -->
 <Template>
   <WidgetGroup>
-    <ObjectName>FxParameters</ObjectName>
+    <ObjectName>FxParameters<Variable name="Side"/></ObjectName>
     <Layout>horizontal</Layout>
-    <Size>max,max</Size>
+    <Size>min,max</Size>
     <Children>
 
       <Template src="skin:fx_parameter_knob.xml">

--- a/res/skins/Tango/fx_unit_left.xml
+++ b/res/skins/Tango/fx_unit_left.xml
@@ -30,7 +30,11 @@ Variables:
                 <SizePolicy>min,min</SizePolicy>
                 <Layout>horizontal</Layout>
                 <Children>
-                  <Template src="skin:fx_parameter_row.xml"><SetVariable name="FxNum">1</SetVariable></Template>
+                  <WidgetGroup><Size>0min,1min</Size></WidgetGroup>
+                  <Template src="skin:fx_parameter_row.xml">
+                    <SetVariable name="FxNum">1</SetVariable>
+                    <SetVariable name="Side">Left</SetVariable>
+                  </Template>
                   <WidgetGroup><Size>5f,1min</Size></WidgetGroup>
                   <Template src="skin:fx_toggle_selector.xml"><SetVariable name="FxNum">1</SetVariable></Template>
                   <WidgetGroup><Size>2f,1min</Size></WidgetGroup>
@@ -47,7 +51,11 @@ Variables:
                 <SizePolicy>min,min</SizePolicy>
                 <Layout>horizontal</Layout>
                 <Children>
-                  <Template src="skin:fx_parameter_row.xml"><SetVariable name="FxNum">2</SetVariable></Template>
+                  <WidgetGroup><Size>0min,1min</Size></WidgetGroup>
+                  <Template src="skin:fx_parameter_row.xml">
+                    <SetVariable name="FxNum">2</SetVariable>
+                    <SetVariable name="Side">Left</SetVariable>
+                  </Template>
                   <WidgetGroup><Size>5f,1min</Size></WidgetGroup>
                   <Template src="skin:fx_toggle_selector.xml"><SetVariable name="FxNum">2</SetVariable></Template>
                   <WidgetGroup><Size>2f,1min</Size></WidgetGroup>
@@ -64,7 +72,11 @@ Variables:
                 <SizePolicy>min,min</SizePolicy>
                 <Layout>horizontal</Layout>
                 <Children>
-                  <Template src="skin:fx_parameter_row.xml"><SetVariable name="FxNum">3</SetVariable></Template>
+                  <WidgetGroup><Size>0min,1min</Size></WidgetGroup>
+                  <Template src="skin:fx_parameter_row.xml">
+                    <SetVariable name="FxNum">3</SetVariable>
+                    <SetVariable name="Side">Left</SetVariable>
+                  </Template>
                   <WidgetGroup><Size>5f,1min</Size></WidgetGroup>
                   <Template src="skin:fx_toggle_selector.xml"><SetVariable name="FxNum">3</SetVariable></Template>
                   <WidgetGroup><Size>2f,1min</Size></WidgetGroup>

--- a/res/skins/Tango/fx_unit_right.xml
+++ b/res/skins/Tango/fx_unit_right.xml
@@ -165,7 +165,11 @@ Variables:
                   <WidgetGroup><Size>2f,1min</Size></WidgetGroup>
                   <Template src="skin:fx_toggle_selector.xml"><SetVariable name="FxNum">1</SetVariable></Template>
                   <WidgetGroup><Size>5f,1min</Size></WidgetGroup>
-                  <Template src="skin:fx_parameter_row.xml"><SetVariable name="FxNum">1</SetVariable></Template>
+                  <Template src="skin:fx_parameter_row.xml">
+                    <SetVariable name="FxNum">1</SetVariable>
+                    <SetVariable name="Side">Right</SetVariable>
+                  </Template>
+                  <WidgetGroup><Size>0min,1min</Size></WidgetGroup>
                 </Children>
               </WidgetGroup><!-- /EffectSlot 1 -->
 
@@ -182,7 +186,11 @@ Variables:
                   <WidgetGroup><Size>2f,1min</Size></WidgetGroup>
                   <Template src="skin:fx_toggle_selector.xml"><SetVariable name="FxNum">2</SetVariable></Template>
                   <WidgetGroup><Size>5f,1min</Size></WidgetGroup>
-                  <Template src="skin:fx_parameter_row.xml"><SetVariable name="FxNum">2</SetVariable></Template>
+                  <Template src="skin:fx_parameter_row.xml">
+                    <SetVariable name="FxNum">2</SetVariable>
+                    <SetVariable name="Side">Right</SetVariable>
+                  </Template>
+                  <WidgetGroup><Size>0min,1min</Size></WidgetGroup>
                 </Children>
               </WidgetGroup><!-- /EffectSlot 2 -->
 
@@ -198,7 +206,10 @@ Variables:
                   <Template src="skin:fx_metaknob.xml"><SetVariable name="FxNum">3</SetVariable></Template>
                   <Template src="skin:fx_toggle_selector.xml"><SetVariable name="FxNum">3</SetVariable></Template>
                   <WidgetGroup><Size>5f,1min</Size></WidgetGroup>
-                  <Template src="skin:fx_parameter_row.xml"><SetVariable name="FxNum">3</SetVariable></Template>
+                  <Template src="skin:fx_parameter_row.xml">
+                    <SetVariable name="FxNum">3</SetVariable>
+                    <SetVariable name="Side">Right</SetVariable>
+                  </Template>
                 </Children>
               </WidgetGroup><!-- /EffectSlot 3 -->
             </Children>

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -1566,6 +1566,18 @@ decks, samplers, mic, aux, fx */
       background: #0081B7;
     }
 
+#FxParametersLeft {
+  qproperty-layoutAlignment: 'AlignRight';
+}
+
+#FxParametersRight {
+  qproperty-layoutAlignment: 'AlignLeft';
+}
+
+#FxParameterKnob {
+  padding-right: 1px;
+}
+
 #FxParameterKnob {
   qproperty-layoutAlignment: 'AlignCenter';
   margin-right: 1px;
@@ -1614,6 +1626,7 @@ decks, samplers, mic, aux, fx */
   /* those buttons are only 5px tall, that's why they won't accept
   3px radius which is set for all WPushButtons */
   border-radius: 2px;
+  margin-right: 1px;
 }
 
 #FxSuperLinkButton[value="0"],


### PR DESCRIPTION
last-minute fix for https://bugs.launchpad.net/mixxx/+bug/1758174

before
![deere-fx-squeeze-fix-before](https://user-images.githubusercontent.com/5934199/38340136-1f9cf83e-3872-11e8-9ff0-d793434497f9.png)

![latenight-fx-squeeze-fix-before](https://user-images.githubusercontent.com/5934199/38340140-25cee9f6-3872-11e8-873b-7062e6c06986.png)

now
![deere-fx-squeeze-fix-after](https://user-images.githubusercontent.com/5934199/38340147-2cb6b03c-3872-11e8-9de6-313a20bc6e18.png)

![latenight-fx-squeeze-fix-after](https://user-images.githubusercontent.com/5934199/38340152-34c647d8-3872-11e8-98f1-e2e4c78e6755.png)

I don't notice any side effects, also effect list expands horizontally as it did before.

