### PR TITLE
set LateNight minimum height to 550px

### DIFF
--- a/res/skins/Deere/skin.xml
+++ b/res/skins/Deere/skin.xml
@@ -67,7 +67,7 @@
   <ObjectName>Mixxx</ObjectName>
   <Style src="skin:style.qss" src-mac="skin:style-mac.qss"/>
 
-  <Size>1008me,550me</Size>
+  <Size>1008me,500me</Size>
   <Layout>horizontal</Layout>
 
   <Children>

--- a/res/skins/Deere/skin.xml
+++ b/res/skins/Deere/skin.xml
@@ -67,7 +67,7 @@
   <ObjectName>Mixxx</ObjectName>
   <Style src="skin:style.qss" src-mac="skin:style-mac.qss"/>
 
-  <Size>1008me,500me</Size>
+  <Size>1008me,550me</Size>
   <Layout>horizontal</Layout>
 
   <Children>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -83,7 +83,7 @@
 
   <!-- MinimumSize should not be an exact monitor resolution. There needs
   to be space for the title bar or other chrome at full screen -->
-  <MinimumSize>1270,666</MinimumSize>
+  <MinimumSize>1270,500</MinimumSize>
   <SizePolicy>me,me</SizePolicy>
   <Layout>vertical</Layout>
 

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -83,7 +83,7 @@
 
   <!-- MinimumSize should not be an exact monitor resolution. There needs
   to be space for the title bar or other chrome at full screen -->
-  <MinimumSize>1270,500</MinimumSize>
+  <MinimumSize>1270,550</MinimumSize>
   <SizePolicy>me,me</SizePolicy>
   <Layout>vertical</Layout>
 


### PR DESCRIPTION
LateNight did not completely fit on my old 1366 x 768 laptop screen before without full screen mode.
![image](https://user-images.githubusercontent.com/9455094/38348829-d269f20e-3869-11e8-8ad3-a00d3e3ded7a.png)
Notice the bottom of the Record button getting cut off.