### PR TITLE
Fx selector: fix cut-off effect names in drop-down list for Linux

### DIFF
--- a/res/skins/Deere/skin.xml
+++ b/res/skins/Deere/skin.xml
@@ -65,7 +65,7 @@
   </manifest>
 
   <ObjectName>Mixxx</ObjectName>
-  <Style src="skin:style.qss" src-mac="skin:style-mac.qss"/>
+  <Style src="skin:style.qss" src-linux="skin:style-linux.qss" src-mac="skin:style-mac.qss"/>
 
   <Size>1008me,550me</Size>
   <Layout>horizontal</Layout>

--- a/res/skins/Deere/style-linux.qss
+++ b/res/skins/Deere/style-linux.qss
@@ -1,0 +1,26 @@
+/*
+  Deere , Skin for Mixxx 2.1.xx
+  www.mixxx.org
+  Copyright (C) 2010-2015 RJ Ryan <rryan@mixxx.org>, S.Brandt <s.brandt@mixxx.org>
+  This file is part of the "Deere" Skin for Mixxx
+  "Deere" is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported license.
+  http://creativecommons.org/licenses/by-sa/3.0/
+
+  Mixxx skin documentation:
+  http://mixxx.org/wiki/doku.php/creating_skins
+
+  List of controls:
+  http://mixxx.org/wiki/doku.php/mixxxcontrols
+
+  Qt Style Sheets documentation:
+  http://doc.qt.io/qt-4.8/stylesheet-examples.html
+  
+  This file only contains a hack to prevent effect names in effect selector list being cut off.
+
+*/
+
+  WEffectSelector QAbstractItemView {
+    color: #c1cabe;
+    background-color: #201f1f;
+    padding: 0px 0px 0px -5px;
+  }

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -79,7 +79,7 @@
   </manifest>
 
   <ObjectName>Mixxx</ObjectName>
-  <Style src="skin:style.qss" src-mac="skin:style-mac.qss"/>
+  <Style src="skin:style.qss" src-linux="skin:style-linux.qss" src-mac="skin:style-mac.qss"/>
 
   <!-- MinimumSize should not be an exact monitor resolution. There needs
   to be space for the title bar or other chrome at full screen -->

--- a/res/skins/LateNight/style-linux.qss
+++ b/res/skins/LateNight/style-linux.qss
@@ -1,0 +1,15 @@
+/* LateNight 2.1
+ * hack to prevent effect names in effect selector list being cut off */
+
+  WEffectSelector QAbstractItemView {
+    width: 142px;
+    background-color: #0f0f0f;
+    /* padding-left: 6px; */
+    font-size: 12px/13px;
+    /* On Linux, this is not applied but font color from WEffectSelector
+    is inherited. For Windows, it must be defined here */
+    color: #cfb32c;
+    border: 1px solid #666;
+    border-radius: 2px;
+    padding: 0px 0px 0px -10px;
+  }

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -211,7 +211,7 @@
 	-->
 
 	<ObjectName>Mixxx</ObjectName>
-	<Style src="skin:style.qss" src-mac="skin:style-mac.qss"/>
+	<Style src="skin:style.qss" src-linux="skin:style-linux.qss" src-mac="skin:style-mac.qss"/>
 	<Size>1008e,500e</Size>
 	<Layout>vertical</Layout>
     <LaunchImageStyle>

--- a/res/skins/Shade/style-linux.qss
+++ b/res/skins/Shade/style-linux.qss
@@ -1,4 +1,5 @@
-/* hack around text getting cut off with scaled checkbox on Macs with Retina screens */
+/* Shade 2.1
+ * This file only contains a hack to prevent effect names in effect selector list being cut off. */
 WEffectSelector QAbstractItemView {
 	margin: 0px 0px 0px -30px;
 }

--- a/res/skins/Shade/style-linux.qss
+++ b/res/skins/Shade/style-linux.qss
@@ -1,0 +1,10 @@
+/* hack around text getting cut off with scaled checkbox on Macs with Retina screens */
+WEffectSelector QAbstractItemView {
+	margin: 0px 0px 0px -30px;
+}
+
+/* just in case there is a partial checkmark shown on some untested screen, hide
+the checkmark */
+WEffectSelector::indicator {
+    border: 0;
+}

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -1548,8 +1548,8 @@ decks, samplers, mic, aux, fx */
     /* tick mark frame */
     WEffectSelector::indicator:checked {
     /* This is sufficient to completely hide the tick mark,
-      but this alone would show an empty, shadowed box instead of tick mark:  */
-      background-color: transparent;
+      but this alone would show an empty, shadowed box instead of tick mark:
+      background-color: transparent;  */
       /* This should decrease the tick mark's left & right margin but is not respected
       margin: 0px -4px 0px -4px; */
       /* This draws a border. And eliminates the tick mark...
@@ -1560,8 +1560,8 @@ decks, samplers, mic, aux, fx */
       /* Image is rendered correctly but size of the tick mark containers
       won't change. Also, only with this option the hover bg color defined
       above will be applied... it's qt magic
-      image: url(skin:/buttons/btn_fx_selector_tick.svg) no-repeat center center; */
-      background: #0081B7;
+      image: url(skin:/buttons/btn_fx_selector_tick.svg) no-repeat center center;
+      background: #0081B7; */
     }
 
 #FxParametersLeft {


### PR DESCRIPTION
Deere/LateNight: shift effect names left, tick mark still visible
Shade: shift effect names left, tick mark hidden
Tango: revert bg-color hack, bring back tick mark

Tested with Ubuntu 14.04 & Ubuntu Studio 14.04 (xfce session).
This fix is only necessary for a scale factor of 100%.
Above 100% works well, too, since the tick mark is not scaled anyway and therefore all effect names have more horizontal space.
Below 100% it seems to work, too, although thte tick mark is not scaled.

![rc1-fx-names-linux-deere_fixed](https://user-images.githubusercontent.com/5934199/38579373-19004fe6-3d07-11e8-8a7b-0a2061be95ac.png)

![rc1-fx-names-linux-latenight_fixed](https://user-images.githubusercontent.com/5934199/38579377-1c3a8a6e-3d07-11e8-8b89-bc9cdbad830c.png)

![rc1-fx-names-linux-shade_fixed](https://user-images.githubusercontent.com/5934199/38579380-200c6c52-3d07-11e8-8557-7e706f7de8b7.png)

![rc1-fx-names-linux-tango_fixed](https://user-images.githubusercontent.com/5934199/38579387-24c27912-3d07-11e8-9ad9-6c564f7a649e.png)

Please confirm this still looks good with KDE and other desktops


