### PR TITLE
Update config string value for recent mixxx versions.

### DIFF
--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -37,7 +37,6 @@
 
 Upgrade::Upgrade()
         : m_bFirstRun(false),
-          m_bUpgraded(false),
           m_bRescanLibrary(false) {
 }
 
@@ -85,7 +84,6 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
         if (oldFile->exists()) {
             if (oldFile->copy(newFilePath)) {
                 oldFile->remove();
-                m_bUpgraded = true;
             }
             else {
                 if (oldFile->error()==14) qDebug() << errorText.arg("library", oldFilePath, newFilePath) << "The destination file already exists.";
@@ -351,7 +349,6 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
         if (successful) {
             qDebug() << "Upgrade Successful";
             configVersion = "1.11.0";
-            m_bUpgraded = true;
             config->set(ConfigKey("[Config]","Version"),
                         ConfigValue(configVersion));
         } else {
@@ -409,12 +406,17 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
         // updated
         if (successful) {
             configVersion = MIXXX_VERSION;
-            m_bUpgraded = true;
             config->set(ConfigKey("[Config]","Version"), ConfigValue(MIXXX_VERSION));
         }
         else {
             qDebug() << "Upgrade failed!\n";
         }
+    }
+
+    if (configVersion.startsWith("1.12") || configVersion.startsWith("2.0")) {
+        // No special upgrade required, just update the value.
+        configVersion = MIXXX_VERSION;
+        config->set(ConfigKey("[Config]","Version"), ConfigValue(MIXXX_VERSION));
     }
 
     if (configVersion == MIXXX_VERSION) qDebug() << "Configuration file is now at the current version" << MIXXX_VERSION;

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -421,12 +421,6 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
 
     if (configVersion == MIXXX_VERSION) qDebug() << "Configuration file is now at the current version" << MIXXX_VERSION;
     else {
-        /* Way too verbose, this confuses the hell out of Linux users when they see this:
-        qWarning() << "Configuration file is at version" << configVersion
-                   << "and I don't know how to upgrade it to the current" << MIXXX_VERSION
-                   << "\n   (That means a function to do this needs to be added to upgrade.cpp.)"
-                   << "\n-> Leaving the configuration file version as-is.";
-        */
         qWarning() << "Configuration file is at version" << configVersion
                    << "instead of the current" << MIXXX_VERSION;
     }

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -413,7 +413,9 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
         }
     }
 
-    if (configVersion.startsWith("1.12") || configVersion.startsWith("2.0")) {
+    if (configVersion.startsWith("1.12") ||
+        configVersion.startsWith("2.0") ||
+        configVersion.startsWith("2.1rc")) {
         // No special upgrade required, just update the value.
         configVersion = MIXXX_VERSION;
         config->set(ConfigKey("[Config]","Version"), ConfigValue(MIXXX_VERSION));

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -415,7 +415,7 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
 
     if (configVersion.startsWith("1.12") ||
         configVersion.startsWith("2.0") ||
-        configVersion.startsWith("2.1.0-rc")) {
+        configVersion.startsWith("2.1.0")) {
         // No special upgrade required, just update the value.
         configVersion = MIXXX_VERSION;
         config->set(ConfigKey("[Config]","Version"), ConfigValue(MIXXX_VERSION));

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -415,7 +415,7 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
 
     if (configVersion.startsWith("1.12") ||
         configVersion.startsWith("2.0") ||
-        configVersion.startsWith("2.1rc")) {
+        configVersion.startsWith("2.1.0-rc")) {
         // No special upgrade required, just update the value.
         configVersion = MIXXX_VERSION;
         config->set(ConfigKey("[Config]","Version"), ConfigValue(MIXXX_VERSION));

--- a/src/preferences/upgrade.h
+++ b/src/preferences/upgrade.h
@@ -27,14 +27,12 @@ class Upgrade {
 
     UserSettingsPointer versionUpgrade(const QString& settingsPath);
     bool isFirstRun() { return m_bFirstRun; };
-    bool isUpgraded() { return m_bUpgraded; };
     bool rescanLibrary() {return m_bRescanLibrary; };
 
   private:
     bool askReanalyzeBeats();
     bool askReScanLibrary();
     bool m_bFirstRun;
-    bool m_bUpgraded;
     bool m_bRescanLibrary;
 };
 


### PR DESCRIPTION
This prevents spurious config version warning.
Also delete m_bUpgraded dead code.

./mixxx-test passes