### PR TITLE
LateNight 4 decks :: align EQ knobs with Vol fader also without Kill buttons

### DIFF
--- a/res/skins/LateNight/eq_knob_4decks.xml
+++ b/res/skins/LateNight/eq_knob_4decks.xml
@@ -1,0 +1,74 @@
+<!DOCTYPE template>
+<Template>
+  <SetVariable name="FxNum">1</SetVariable>
+  <SetVariable name="FxRack_FxUnit_FxNum">[EqualizerRack1_<Variable name="group"/>_Effect1]</SetVariable>
+
+  <WidgetGroup>
+    <ObjectName>AlignRight</ObjectName>
+    <Layout>horizontal</Layout>
+    <SizePolicy>min,min</SizePolicy>
+    <Children>
+      <WidgetGroup><Size>4f,-1min</Size></WidgetGroup>
+
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <SizePolicy>min,min</SizePolicy>
+        <Children>
+
+          <!-- Kill button -->
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
+            <Size>22f,30min</Size>
+            <Children>
+              <WidgetGroup>
+                <ObjectName>KillButtonLeft</ObjectName>
+                <Layout>horizontal</Layout>
+                <Size>22f,30min</Size>
+                <Children>
+                  <Template src="skin:fx_button.xml">
+                    <SetVariable name="icon">eq_kill</SetVariable>
+                    <SetVariable name="Size">18f,18f</SetVariable>
+                    <SetVariable name="FxParameter">button_parameter<Variable name="FxParameter"/></SetVariable>
+                  </Template>
+                </Children>
+                <Connection>
+                  <ConfigKey>[Master],show_eq_kill_buttons</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </WidgetGroup>
+            </Children>
+          </WidgetGroup>
+
+          <!-- EQ knob -->
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
+            <SizePolicy>me,min</SizePolicy>
+            <Children>
+              <EffectParameterKnobComposed>
+                <Size>40f,34f</Size>
+                <Knob>skin:knob_indicator.svg</Knob>
+                <BackPath>skin:knob_bg.svg</BackPath>
+                <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
+                <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
+                <KnobCenterYOffset>1.598</KnobCenterYOffset>
+                <Connection>
+                  <ConfigKey><Variable name="FxRack_FxUnit_FxNum"/>,parameter<Variable name="FxParameter"/></ConfigKey>
+                </Connection>
+              </EffectParameterKnobComposed>
+            </Children>
+          </WidgetGroup>
+
+        </Children>
+        <Connection>
+          <ConfigKey><Variable name="FxRack_FxUnit_FxNum"/>,parameter<Variable name="FxParameter"/>_loaded</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
+    </Children>
+    <Connection>
+      <ConfigKey>[Master],show_eqs</ConfigKey>
+      <BindProperty>visible</BindProperty>
+    </Connection>
+  </WidgetGroup>
+</Template>

--- a/res/skins/LateNight/mixer.xml
+++ b/res/skins/LateNight/mixer.xml
@@ -146,6 +146,7 @@
                             <SetVariable name="channum">4</SetVariable>
                             <SetVariable name="deckSide">Right</SetVariable>
                           </Template>
+                          <WidgetGroup><Size>4f,1min</Size></WidgetGroup>
                         </Children>
                         <Connection>
                           <ConfigKey persist="true">[Master],show_4decks</ConfigKey>

--- a/res/skins/LateNight/mixer_channel_4decks.xml
+++ b/res/skins/LateNight/mixer_channel_4decks.xml
@@ -52,23 +52,23 @@
         </Children>
       </WidgetGroup>
 
-      <Template src="skin:eq_knob_left.xml">
+      <Template src="skin:eq_knob_4decks.xml">
         <SetVariable name="FxParameter">4</SetVariable>
       </Template>
 
-      <Template src="skin:eq_knob_left.xml">
+      <Template src="skin:eq_knob_4decks.xml">
         <SetVariable name="FxParameter">3</SetVariable>
       </Template>
 
-      <Template src="skin:eq_knob_left.xml">
+      <Template src="skin:eq_knob_4decks.xml">
         <SetVariable name="FxParameter">2</SetVariable>
       </Template>
 
-      <Template src="skin:eq_knob_left.xml">
+      <Template src="skin:eq_knob_4decks.xml">
         <SetVariable name="FxParameter">1</SetVariable>
       </Template>
 
-      <Template src="skin:quick_effect_knob_left.xml"/>
+      <Template src="skin:quick_effect_knob_4decks.xml"/>
 
       <WidgetGroup>
         <ObjectName>CrossfaderSwitch4Decks</ObjectName>
@@ -125,7 +125,7 @@
       </WidgetGroup>
 
       <WidgetGroup>
-        <ObjectName>VuAndSlider</ObjectName>
+        <ObjectName>VuAndSlider4decks</ObjectName>
         <Layout>horizontal</Layout>
         <Children>
           <WidgetGroup>

--- a/res/skins/LateNight/quick_effect_knob_4decks.xml
+++ b/res/skins/LateNight/quick_effect_knob_4decks.xml
@@ -1,0 +1,104 @@
+<!DOCTYPE template>
+<Template>
+  <SetVariable name="QuickEffectGroup">[QuickEffectRack1_<Variable name="group"/>]</SetVariable>
+  <SetVariable name="QuickEffect">[QuickEffectRack1_<Variable name="group"/>_Effect1]</SetVariable>
+  <WidgetGroup>
+    <Layout>vertical</Layout>
+    <SizePolicy>min,min</SizePolicy>
+    <Children>
+
+      <WidgetGroup><!-- Kill button + knob -->
+        <Layout>horizontal</Layout>
+        <SizePolicy>min,min</SizePolicy>
+        <Children>
+          <WidgetGroup><Size>4f,-1min</Size></WidgetGroup>
+
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
+            <Size>22f,30min</Size>
+            <Children>
+              <WidgetGroup>
+                <ObjectName>KillButtonLeft</ObjectName>
+                <Layout>horizontal</Layout>
+                <Size>22f,30min</Size>
+                <Children>
+                  <PushButton>
+                    <TooltipId>QuickEffectRack_enabled</TooltipId>
+                    <Size>18f,18f</Size>
+                    <NumberStates>2</NumberStates>
+                    <State>
+                      <Number>0</Number>
+                      <Pressed>buttons/btn_eq_kill_down.svg</Pressed>
+                      <Unpressed>buttons/btn_eq_kill.svg</Unpressed>
+                    </State>
+                    <State>
+                      <Number>1</Number>
+                      <Pressed>buttons/btn_quickEffect_overdown.svg</Pressed>
+                      <Unpressed>buttons/btn_quickEffect_over.svg</Unpressed>
+                    </State>
+                    <Connection>
+                      <ConfigKey><Variable name="QuickEffect"/>,enabled</ConfigKey>
+                      <ButtonState>LeftButton</ButtonState>
+                    </Connection>
+                  </PushButton>
+                </Children>
+                <Connection>
+                  <ConfigKey>[Master],show_eq_kill_buttons</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </WidgetGroup>
+            </Children>
+          </WidgetGroup>
+
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
+            <SizePolicy>me,min</SizePolicy>
+            <Children>
+              <Template src="skin:knob_textless.xml">
+                <SetVariable name="Size">40f,34f</SetVariable>
+                <SetVariable name="group"><Variable name="QuickEffectGroup"/></SetVariable>
+                <SetVariable name="control">super1</SetVariable>
+                <SetVariable name="TooltipId">QuickEffectRack_super1</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup>
+        </Children>
+        <Connection>
+          <ConfigKey><Variable name="QuickEffect"/>,loaded</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup><!-- /Kill button + knob -->
+
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <SizePolicy>me,f</SizePolicy>
+        <Children>
+          <WidgetGroup>
+            <Size>0min,0min</Size>
+            <Children/>
+          </WidgetGroup>
+
+          <EffectName>
+            <ObjectName>KnobLabel</ObjectName>
+            <MinimumSize>40,12</MinimumSize>
+            <MaximumSize>62,12</MaximumSize>
+            <SizePolicy>me,f</SizePolicy>
+            <Elide>right</Elide>
+            <EffectRackGroup>[QuickEffectRack1]</EffectRackGroup>
+            <EffectUnitGroup><Variable name="QuickEffectGroup"/></EffectUnitGroup>
+            <Effect>1</Effect>
+          </EffectName>
+        </Children>
+        <Connection>
+          <ConfigKey><Variable name="QuickEffect"/>,loaded</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
+    </Children>
+    <Connection>
+      <ConfigKey>[Master],show_eqs</ConfigKey>
+      <BindProperty>visible</BindProperty>
+    </Connection>
+  </WidgetGroup>
+</Template>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -294,6 +294,11 @@ WTime {
   padding: 1px 4px 0px 0px;
 }
 
+#VuAndSlider4decks {
+  qproperty-layoutAlignment: 'AlignHCenter | AlignTop';
+  padding: 1px 0px 0px 0px;
+}
+
 #VuMeter4Decks {
   qproperty-layoutAlignment: 'AlignRight | AlignVCenter';
   padding: 0px 4px 2px 0px;
@@ -676,12 +681,13 @@ WBeatSpinBox {
 }
 
 #CrossfaderAndSwitches2Decks {
-  padding: 0px 10px 0px 10px;
+  qpoperty-layoutAlignment: 'AlignHCenter';
+  padding: 0px;
 }
 
 #CrossfaderSwitch4Decks {
   qproperty-layoutAlignment: 'AlignRight';
-  margin: 1px 10px 0px 0px;
+  margin: 1px 6px 0px 0px;
 }
 
 #PreviewDeck {


### PR DESCRIPTION
before
![latenight-eq-fix_before](https://user-images.githubusercontent.com/5934199/38645485-7c32b4e0-3de4-11e8-9165-92afb9d8531a.png)

after
![latenight-eq-fix_after](https://user-images.githubusercontent.com/5934199/38645493-8008791a-3de4-11e8-8069-dac5a0ee1eb1.png)
