### PR TITLE
fix debug assertion and crash when toggling effect unit enable switch

### DIFF
--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -243,8 +243,13 @@ bool EngineEffectChain::process(const ChannelHandle& inputHandle,
     ChannelStatus& channelStatus = m_chainStatusForChannelMatrix[inputHandle][outputHandle];
     EffectEnableState effectiveChainEnableState = channelStatus.enable_state;
 
-    if (m_enableState != EffectEnableState::Enabled) {
-        effectiveChainEnableState = m_enableState;
+    // If the channel is fully disabled, do not let intermediate
+    // enabling/disabing signals from the chain's enable switch override
+    // the channel's state.
+    if (effectiveChainEnableState != EffectEnableState::Disabled) {
+        if (m_enableState != EffectEnableState::Enabled) {
+            effectiveChainEnableState = m_enableState;
+        }
     }
 
     CSAMPLE currentWetGain = m_dMix;


### PR DESCRIPTION
When changing `[EffectRack1_EffectUnitX], enabled`, channels that had never been enabled were getting the intermediate Disabling and Enable EffectEnableStates. This resulted in the `pState != nullptr` debug assertion in EffectProcessorImpl::process getting triggered because EffectStates had not been allocated for those channels. I am not quite sure how, but that sometimes led to a crash when loading another effect in the chain and toggling the chain's enabled switch.

Fixing https://bugs.launchpad.net/mixxx/+bug/1748061