### PR TITLE
Wix: Install the PDB files by default

### DIFF
--- a/build/wix/mixxx.wxs
+++ b/build/wix/mixxx.wxs
@@ -409,7 +409,7 @@
                Description="!(loc.FeaturePDBDescription)"
                AllowAdvertise='no'
                InstallDefault='local'
-               Level="10">
+               Level="1">
           <ComponentGroupRef Id='mainPDBCompGroup' />
         </Feature>
       <?endif?>


### PR DESCRIPTION
This is last pending 2.1 bug:
https://bugs.launchpad.net/mixxx/+bug/1762737
