### PR TITLE
LateNight: fix effects widgets overlapping with superknob showing

### DIFF
--- a/res/skins/LateNight/fx_slot.xml
+++ b/res/skins/LateNight/fx_slot.xml
@@ -81,12 +81,12 @@
 
           <WidgetGroup>
             <Layout>horizontal</Layout>
-            <MinimumSize>110,26</MinimumSize>
+            <MinimumSize>102,26</MinimumSize>
             <MaximumSize>150,26</MaximumSize>
             <SizePolicy>me,f</SizePolicy>
             <Children>
               <EffectSelector>
-                <MinimumSize>110,26</MinimumSize>
+                <MinimumSize>102,26</MinimumSize>
                 <MaximumSize>150,26</MaximumSize>
                 <SizePolicy>me,f</SizePolicy>
                 <EffectRack><Variable name="FxRack"/></EffectRack>


### PR DESCRIPTION
@ronso0 is this what you were thinking of doing? If not, please open another PR for your fix.
![screenshot from 2018-04-15 11-59-32](https://user-images.githubusercontent.com/9455094/38781008-7ea629e2-40a4-11e8-96a7-bd30b593d892.png)

Screenshot is on my 3840 x 2160 screen at 100% scaling hence the big text in the library

fixing https://bugs.launchpad.net/mixxx/+bug/1764099