### PR TITLE
LateNight :: fix squeezed fx-selector + squeezed Vinyl buttons

### DIFF
--- a/res/skins/LateNight/deck_row_1_keyVinylFx.xml
+++ b/res/skins/LateNight/deck_row_1_keyVinylFx.xml
@@ -102,7 +102,7 @@
 
       <!-- FX buttons 1-4 -->
       <PushButton>
-        <Size>35f,22f</Size>
+        <Size>32f,22f</Size>
         <TooltipId>EffectUnit_deck_enabled</TooltipId>
         <ObjectName>FxAssignButton</ObjectName>
         <NumberStates>2</NumberStates>
@@ -121,7 +121,7 @@
       </PushButton>
 
       <PushButton>
-        <Size>35f,22f</Size>
+        <Size>32f,22f</Size>
         <TooltipId>EffectUnit_deck_enabled</TooltipId>
         <ObjectName>FxAssignButton</ObjectName>
         <NumberStates>2</NumberStates>
@@ -147,7 +147,7 @@
         </Connection>
         <Children>
           <PushButton>
-            <Size>35f,22f</Size>
+            <Size>32f,22f</Size>
             <TooltipId>EffectUnit_deck_enabled</TooltipId>
             <ObjectName>FxAssignButton</ObjectName>
             <NumberStates>2</NumberStates>
@@ -166,7 +166,7 @@
           </PushButton>
 
           <PushButton>
-            <Size>35f,22f</Size>
+            <Size>32f,22f</Size>
             <TooltipId>EffectUnit_deck_enabled</TooltipId>
             <ObjectName>FxAssignButton</ObjectName>
             <NumberStates>2</NumberStates>

--- a/res/skins/LateNight/fx_slot.xml
+++ b/res/skins/LateNight/fx_slot.xml
@@ -81,12 +81,12 @@
 
           <WidgetGroup>
             <Layout>horizontal</Layout>
-            <MinimumSize>110,26</MinimumSize>
+            <MinimumSize>97,26</MinimumSize>
             <MaximumSize>150,26</MaximumSize>
             <SizePolicy>me,f</SizePolicy>
             <Children>
               <EffectSelector>
-                <MinimumSize>110,26</MinimumSize>
+                <MinimumSize>97,26</MinimumSize>
                 <MaximumSize>150,26</MaximumSize>
                 <SizePolicy>me,f</SizePolicy>
                 <EffectRack><Variable name="FxRack"/></EffectRack>

--- a/res/skins/LateNight/fx_slot.xml
+++ b/res/skins/LateNight/fx_slot.xml
@@ -81,12 +81,12 @@
 
           <WidgetGroup>
             <Layout>horizontal</Layout>
-            <MinimumSize>97,26</MinimumSize>
+            <MinimumSize>102,26</MinimumSize>
             <MaximumSize>150,26</MaximumSize>
             <SizePolicy>me,f</SizePolicy>
             <Children>
               <EffectSelector>
-                <MinimumSize>97,26</MinimumSize>
+                <MinimumSize>102,26</MinimumSize>
                 <MaximumSize>150,26</MaximumSize>
                 <SizePolicy>me,f</SizePolicy>
                 <EffectRack><Variable name="FxRack"/></EffectRack>


### PR DESCRIPTION
fixes https://bugs.launchpad.net/mixxx/+bug/1764099
and reduces FX buttons to make Vinyl buttons readable at minimum window width.

![latenight-fx-vinyl-fix](https://user-images.githubusercontent.com/5934199/38781355-c7fdcf70-40e3-11e8-914d-e39baa34bbbb.png)
