### PR TITLE
lp1719474: Fix unresponsive scrolling through crates & playlists using encoder

### DIFF
--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -19,11 +19,17 @@
 #include "widget/wlibrarytextbrowser.h"
 #include "util/assert.h"
 
+namespace {
+
+const int kClickedChildActivationTimeoutMillis = 100;
+
+} // anonymous namespace
+
 BasePlaylistFeature::BasePlaylistFeature(QObject* parent,
                                          UserSettingsPointer pConfig,
                                          TrackCollection* pTrackCollection,
                                          QString rootViewName)
-        : LibraryFeature(pConfig, parent),
+        : LibraryFeature(pConfig, kClickedChildActivationTimeoutMillis, parent),
           m_pTrackCollection(pTrackCollection),
           m_playlistDao(pTrackCollection->getPlaylistDAO()),
           m_trackDao(pTrackCollection->getTrackDAO()),

--- a/src/library/crate/cratefeature.cpp
+++ b/src/library/crate/cratefeature.cpp
@@ -29,6 +29,8 @@
 
 namespace {
 
+const int kClickedChildActivationTimeoutMillis = 100;
+
 QString formatLabel(
         const CrateSummary& crateSummary) {
     return QString("%1 (%2) %3").arg(
@@ -42,7 +44,7 @@ QString formatLabel(
 CrateFeature::CrateFeature(Library* pLibrary,
                            TrackCollection* pTrackCollection,
                            UserSettingsPointer pConfig)
-        : LibraryFeature(pConfig),
+        : LibraryFeature(pConfig, kClickedChildActivationTimeoutMillis),
           m_cratesIcon(":/images/library/ic_library_crates.png"),
           m_lockedCrateIcon(":/images/library/ic_library_locked.png"),
           m_pTrackCollection(pTrackCollection),

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -6,18 +6,37 @@
 // KEEP THIS cpp file to tell scons that moc should be called on the class!!!
 // The reason for this is that LibraryFeature uses slots/signals and for this
 // to work the code has to be precompiles by moc
-LibraryFeature::LibraryFeature(QObject *parent)
-        : QObject(parent) {
 
-}
-
-LibraryFeature::LibraryFeature(UserSettingsPointer pConfig, QObject* parent)
+LibraryFeature::LibraryFeature(
+        QObject *parent)
         : QObject(parent),
-          m_pConfig(pConfig) {
+          m_clickedChildActivationTimeoutMillis(0) {
 }
 
-LibraryFeature::~LibraryFeature() {
+LibraryFeature::LibraryFeature(
+        int clickedChildActivationTimeoutMillis,
+        QObject *parent)
+        : QObject(parent),
+          m_clickedChildActivationTimeoutMillis(clickedChildActivationTimeoutMillis) {
+    DEBUG_ASSERT(m_clickedChildActivationTimeoutMillis >= 0);
+}
 
+LibraryFeature::LibraryFeature(
+        UserSettingsPointer pConfig,
+        QObject* parent)
+        : QObject(parent),
+          m_pConfig(pConfig),
+          m_clickedChildActivationTimeoutMillis(0) {
+}
+
+LibraryFeature::LibraryFeature(
+        UserSettingsPointer pConfig,
+        int clickedChildActivationTimeoutMillis,
+        QObject* parent)
+        : QObject(parent),
+          m_pConfig(pConfig),
+          m_clickedChildActivationTimeoutMillis(clickedChildActivationTimeoutMillis) {
+    DEBUG_ASSERT(m_clickedChildActivationTimeoutMillis >= 0);
 }
 
 QStringList LibraryFeature::getPlaylistFiles(QFileDialog::FileMode mode) const {

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -29,11 +29,23 @@ class KeyboardEventFilter;
 class LibraryFeature : public QObject {
   Q_OBJECT
   public:
-    LibraryFeature(QObject* parent = NULL);
+    explicit LibraryFeature(
+          QObject* parent);
+    explicit LibraryFeature(
+            int clickedChildActivationTimeoutMillis,
+            QObject* parent = nullptr);
+    explicit LibraryFeature(
+            UserSettingsPointer pConfig,
+            QObject* parent = nullptr);
+    explicit LibraryFeature(
+            UserSettingsPointer pConfig,
+            int clickedChildActivationTimeoutMillis,
+            QObject* parent = nullptr);
+    ~LibraryFeature() override = default;
 
-    LibraryFeature(UserSettingsPointer pConfig,
-                   QObject* parent = NULL);
-    virtual ~LibraryFeature();
+    int clickedChildActivationTimeoutMillis() const {
+        return m_clickedChildActivationTimeoutMillis;
+    }
 
     virtual QVariant title() = 0;
     virtual QIcon getIcon() = 0;
@@ -124,6 +136,7 @@ class LibraryFeature : public QObject {
   private: 
     QStringList getPlaylistFiles(QFileDialog::FileMode mode) const;
 
+    const int m_clickedChildActivationTimeoutMillis;
 };
 
 #endif /* LIBRARYFEATURE_H */

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -7,6 +7,7 @@
 #include <QAbstractItemModel>
 #include <QList>
 #include <QModelIndex>
+#include <QTimer>
 #include <QVariant>
 
 class LibraryFeature;
@@ -14,8 +15,9 @@ class LibraryFeature;
 class SidebarModel : public QAbstractItemModel {
     Q_OBJECT
   public:
-    explicit SidebarModel(QObject* parent = 0);
-    virtual ~SidebarModel();
+    explicit SidebarModel(
+            QObject* parent = nullptr);
+    ~SidebarModel() override = default;
 
     void addLibraryFeature(LibraryFeature* feature);
     QModelIndex getDefaultSelection();
@@ -64,11 +66,22 @@ class SidebarModel : public QAbstractItemModel {
   signals:
     void selectIndex(const QModelIndex& index);
 
+  private slots:
+    void slotActivateChildAtClickedFeatureIndex();
+
   private:
     QModelIndex translateSourceIndex(const QModelIndex& parent);
     void featureRenamed(LibraryFeature*);
     QList<LibraryFeature*> m_sFeatures;
     unsigned int m_iDefaultSelectedIndex; /** Index of the item in the sidebar model to select at startup. */
+
+    QTimer* const m_clickedChildActivationTimer;
+    LibraryFeature* m_clickedFeature;
+    QModelIndex m_clickedIndex;
+
+    void onFeatureIndexClicked(
+            LibraryFeature* feature,
+            QModelIndex index);
 };
 
 #endif /* SIDEBARMODEL_H */


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1719474

A delay of 100 ms provides (almost) smooth scrolling and doesn't have a noticeable impact on the responsiveness when clicking on a crate or playlist item using the mouse.

You need a controller with a properly mapped encoder to test this PR!