### PR TITLE
lp1719474 Follow-up: Fix navigation usability issues in sidebar tree

### DIFF
--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -19,17 +19,11 @@
 #include "widget/wlibrarytextbrowser.h"
 #include "util/assert.h"
 
-namespace {
-
-const int kClickedChildActivationTimeoutMillis = 100;
-
-} // anonymous namespace
-
 BasePlaylistFeature::BasePlaylistFeature(QObject* parent,
                                          UserSettingsPointer pConfig,
                                          TrackCollection* pTrackCollection,
                                          QString rootViewName)
-        : LibraryFeature(pConfig, kClickedChildActivationTimeoutMillis, parent),
+        : LibraryFeature(pConfig, parent),
           m_pTrackCollection(pTrackCollection),
           m_playlistDao(pTrackCollection->getPlaylistDAO()),
           m_trackDao(pTrackCollection->getTrackDAO()),

--- a/src/library/crate/cratefeature.cpp
+++ b/src/library/crate/cratefeature.cpp
@@ -29,8 +29,6 @@
 
 namespace {
 
-const int kClickedChildActivationTimeoutMillis = 100;
-
 QString formatLabel(
         const CrateSummary& crateSummary) {
     return QString("%1 (%2) %3").arg(
@@ -44,7 +42,7 @@ QString formatLabel(
 CrateFeature::CrateFeature(Library* pLibrary,
                            TrackCollection* pTrackCollection,
                            UserSettingsPointer pConfig)
-        : LibraryFeature(pConfig, kClickedChildActivationTimeoutMillis),
+        : LibraryFeature(pConfig),
           m_cratesIcon(":/images/library/ic_library_crates.png"),
           m_lockedCrateIcon(":/images/library/ic_library_locked.png"),
           m_pTrackCollection(pTrackCollection),

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -210,6 +210,8 @@ void Library::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
     connect(m_pSidebarModel, SIGNAL(selectIndex(const QModelIndex&)),
             pSidebarWidget, SLOT(selectIndex(const QModelIndex&)));
     connect(pSidebarWidget, SIGNAL(pressed(const QModelIndex&)),
+            m_pSidebarModel, SLOT(pressed(const QModelIndex&)));
+    connect(pSidebarWidget, SIGNAL(clicked(const QModelIndex&)),
             m_pSidebarModel, SLOT(clicked(const QModelIndex&)));
     // Lazy model: Let triangle symbol increment the model
     connect(pSidebarWidget, SIGNAL(expanded(const QModelIndex&)),

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -7,10 +7,19 @@
 // The reason for this is that LibraryFeature uses slots/signals and for this
 // to work the code has to be precompiles by moc
 
+namespace {
+
+// The time between selecting and activating a feature item in the left
+// pane. This is required to allow smooth and responsive scrolling through
+// a list of items with an encoder!
+const int kDefaultClickedChildActivationTimeoutMillis = 250;
+
+} // anonymous namespace
+
 LibraryFeature::LibraryFeature(
         QObject *parent)
         : QObject(parent),
-          m_clickedChildActivationTimeoutMillis(0) {
+          m_clickedChildActivationTimeoutMillis(kDefaultClickedChildActivationTimeoutMillis) {
 }
 
 LibraryFeature::LibraryFeature(
@@ -26,7 +35,7 @@ LibraryFeature::LibraryFeature(
         QObject* parent)
         : QObject(parent),
           m_pConfig(pConfig),
-          m_clickedChildActivationTimeoutMillis(0) {
+          m_clickedChildActivationTimeoutMillis(kDefaultClickedChildActivationTimeoutMillis) {
 }
 
 LibraryFeature::LibraryFeature(

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -7,45 +7,16 @@
 // The reason for this is that LibraryFeature uses slots/signals and for this
 // to work the code has to be precompiles by moc
 
-namespace {
-
-// The time between selecting and activating a feature item in the left
-// pane. This is required to allow smooth and responsive scrolling through
-// a list of items with an encoder!
-const int kDefaultClickedChildActivationTimeoutMillis = 250;
-
-} // anonymous namespace
-
 LibraryFeature::LibraryFeature(
         QObject *parent)
-        : QObject(parent),
-          m_clickedChildActivationTimeoutMillis(kDefaultClickedChildActivationTimeoutMillis) {
-}
-
-LibraryFeature::LibraryFeature(
-        int clickedChildActivationTimeoutMillis,
-        QObject *parent)
-        : QObject(parent),
-          m_clickedChildActivationTimeoutMillis(clickedChildActivationTimeoutMillis) {
-    DEBUG_ASSERT(m_clickedChildActivationTimeoutMillis >= 0);
+        : QObject(parent) {
 }
 
 LibraryFeature::LibraryFeature(
         UserSettingsPointer pConfig,
         QObject* parent)
         : QObject(parent),
-          m_pConfig(pConfig),
-          m_clickedChildActivationTimeoutMillis(kDefaultClickedChildActivationTimeoutMillis) {
-}
-
-LibraryFeature::LibraryFeature(
-        UserSettingsPointer pConfig,
-        int clickedChildActivationTimeoutMillis,
-        QObject* parent)
-        : QObject(parent),
-          m_pConfig(pConfig),
-          m_clickedChildActivationTimeoutMillis(clickedChildActivationTimeoutMillis) {
-    DEBUG_ASSERT(m_clickedChildActivationTimeoutMillis >= 0);
+          m_pConfig(pConfig) {
 }
 
 QStringList LibraryFeature::getPlaylistFiles(QFileDialog::FileMode mode) const {

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -30,22 +30,11 @@ class LibraryFeature : public QObject {
   Q_OBJECT
   public:
     explicit LibraryFeature(
-          QObject* parent);
-    explicit LibraryFeature(
-            int clickedChildActivationTimeoutMillis,
-            QObject* parent = nullptr);
+          QObject* parent = nullptr);
     explicit LibraryFeature(
             UserSettingsPointer pConfig,
-            QObject* parent = nullptr);
-    explicit LibraryFeature(
-            UserSettingsPointer pConfig,
-            int clickedChildActivationTimeoutMillis,
             QObject* parent = nullptr);
     ~LibraryFeature() override = default;
-
-    int clickedChildActivationTimeoutMillis() const {
-        return m_clickedChildActivationTimeoutMillis;
-    }
 
     virtual QVariant title() = 0;
     virtual QIcon getIcon() = 0;
@@ -135,8 +124,6 @@ class LibraryFeature : public QObject {
 
   private: 
     QStringList getPlaylistFiles(QFileDialog::FileMode mode) const;
-
-    const int m_clickedChildActivationTimeoutMillis;
 };
 
 #endif /* LIBRARYFEATURE_H */

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -38,6 +38,7 @@ class SidebarModel : public QAbstractItemModel {
     bool hasTrackTable(const QModelIndex& index) const;
 
   public slots:
+    void pressed(const QModelIndex& index);
     void clicked(const QModelIndex& index);
     void doubleClicked(const QModelIndex& index);
     void rightClicked(const QPoint& globalPos, const QModelIndex& index);
@@ -67,7 +68,7 @@ class SidebarModel : public QAbstractItemModel {
     void selectIndex(const QModelIndex& index);
 
   private slots:
-    void slotActivateChildAtClickedFeatureIndex();
+    void slotPressedUntilClickedTimeout();
 
   private:
     QModelIndex translateSourceIndex(const QModelIndex& parent);
@@ -75,13 +76,11 @@ class SidebarModel : public QAbstractItemModel {
     QList<LibraryFeature*> m_sFeatures;
     unsigned int m_iDefaultSelectedIndex; /** Index of the item in the sidebar model to select at startup. */
 
-    QTimer* const m_clickedChildActivationTimer;
-    LibraryFeature* m_clickedFeature;
-    QModelIndex m_clickedIndex;
+    QTimer* const m_pressedUntilClickedTimer;
+    QModelIndex m_pressedIndex;
 
-    void onFeatureIndexClicked(
-            LibraryFeature* feature,
-            QModelIndex index);
+    void startPressedUntilClickedTimer(QModelIndex pressedIndex);
+    void stopPressedUntilClickedTimer();
 };
 
 #endif /* SIDEBARMODEL_H */


### PR DESCRIPTION
From the discussion in #1619

A timeout of ~~250~~300 ms still feels responsive and scrolling slowly through the list of playlists and crates is possible. This new timeout is now used for every LibraryFeature ~~as a default, unless customized in a derived class~~!