### PR TITLE
add Skin Settings to Latenight

### DIFF
--- a/res/skins/LateNight/buttons/btn_skinsettings_close.svg
+++ b/res/skins/LateNight/buttons/btn_skinsettings_close.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="20"
+   height="20"
+   viewBox="0 0 20 20"
+   id="svg3505">
+  <metadata
+     id="metadata3513">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3511" />
+  <path
+     d="M 5.5286634,4.7729214 C 5.3280198,4.766417 5.1316506,4.8340629 4.9828665,4.9828429 4.6852983,5.280411 4.7074447,5.778023 5.0248508,6.0954295 L 8.9293986,9.9999773 5.0248508,13.904525 c -0.3174062,0.317405 -0.3395526,0.815017 -0.041984,1.112586 0.2975681,0.297569 0.7951801,0.275422 1.1125861,-0.04198 L 10,11.070581 l 3.904549,3.904547 c 0.317405,0.317407 0.815017,0.339554 1.112585,0.04198 0.297569,-0.297569 0.275422,-0.795181 -0.04198,-1.112586 L 11.070604,9.9999773 14.975152,6.0954295 C 15.292558,5.778023 15.314705,5.280411 15.017134,4.9828429 14.719566,4.6852749 14.221954,4.7074207 13.904549,5.024825 L 10,8.9293751 6.0954526,5.0248273 C 5.9367496,4.866124 5.7293072,4.7793939 5.5286634,4.7729214 z"
+     id="path3507"
+     style="fill:#eeeeee;fill-opacity:1" />
+</svg>

--- a/res/skins/LateNight/buttons/btn_skinsettings_close_hover.svg
+++ b/res/skins/LateNight/buttons/btn_skinsettings_close_hover.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="20"
+   height="20"
+   viewBox="0 0 20 20"
+   id="svg3515">
+  <metadata
+     id="metadata3523">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3521" />
+  <path
+     d="M 5.5286634,4.7729214 C 5.3280198,4.766417 5.1316506,4.8340629 4.9828665,4.9828429 4.6852983,5.280411 4.7074447,5.778023 5.0248508,6.0954295 L 8.9293986,9.9999773 5.0248508,13.904525 c -0.3174062,0.317405 -0.3395526,0.815017 -0.041984,1.112586 0.2975681,0.297569 0.7951801,0.275422 1.1125861,-0.04198 L 10,11.070581 l 3.904549,3.904547 c 0.317405,0.317407 0.815017,0.339554 1.112585,0.04198 0.297569,-0.297569 0.275422,-0.795181 -0.04198,-1.112586 L 11.070604,9.9999773 14.975152,6.0954295 C 15.292558,5.778023 15.314705,5.280411 15.017134,4.9828429 14.719566,4.6852749 14.221954,4.7074207 13.904549,5.024825 L 10,8.9293751 6.0954526,5.0248273 C 5.9367496,4.866124 5.7293072,4.7793939 5.5286634,4.7729214 z"
+     id="path3517"
+     style="fill:#eeeeee;fill-opacity:1" />
+</svg>

--- a/res/skins/LateNight/deck.xml
+++ b/res/skins/LateNight/deck.xml
@@ -254,6 +254,10 @@
                 </Children>
               </WidgetGroup><!-- RateButtons for different rate directions -->
             </Children>
+	    <Connection>
+	     <ConfigKey persist="true">[Master],show_rate_control</ConfigKey>
+             <BindProperty>visible</BindProperty>
+	    </Connection>
           </WidgetGroup>
 
           <WidgetGroup>
@@ -307,6 +311,10 @@
             </Children>
           </WidgetGroup>
         </Children>
+	 <Connection>
+	  <ConfigKey persist="true">[Master],show_rate_control</ConfigKey>
+          <BindProperty>visible</BindProperty>
+	 </Connection>
       </WidgetGroup><!-- /RateContainer -->
 
       <WidgetGroup>  <!-- Deck Channel

--- a/res/skins/LateNight/deck.xml
+++ b/res/skins/LateNight/deck.xml
@@ -9,7 +9,7 @@
       <WidgetGroup>
         <ObjectName>RateContainer</ObjectName>
         <Layout>vertical</Layout>
-        <SizePolicy>min,me</SizePolicy>
+        <Size>69f,-1me</Size>
         <Children>
           <WidgetGroup>
             <ObjectName>AlignCenter</ObjectName>

--- a/res/skins/LateNight/deck.xml
+++ b/res/skins/LateNight/deck.xml
@@ -254,10 +254,6 @@
                 </Children>
               </WidgetGroup><!-- RateButtons for different rate directions -->
             </Children>
-	    <Connection>
-	     <ConfigKey persist="true">[Master],show_rate_control</ConfigKey>
-             <BindProperty>visible</BindProperty>
-	    </Connection>
           </WidgetGroup>
 
           <WidgetGroup>

--- a/res/skins/LateNight/deck_row_1_keyVinylFx.xml
+++ b/res/skins/LateNight/deck_row_1_keyVinylFx.xml
@@ -86,37 +86,7 @@
         </Connection>
       </PushButton>
 
-      <WidgetGroup>  <!-- spacer -->
-        <Layout>horizontal</Layout>
-        <SizePolicy>min,min</SizePolicy>
-        <Children></Children>
-      </WidgetGroup>
-
       <Template src="skin:vinyl_controls.xml"/>
-
-      <WidgetGroup>
-        <Layout>horizontal</Layout>
-	 <Children>
-          <NumberBpm>
-            <TooltipId>visual_bpm</TooltipId>
-            <Size>40f,22f</Size>
-            <Channel><Variable name="channum" /></Channel>
-            <NumberOfDigits>2</NumberOfDigits>
-            <Connection>
-              <ConfigKey><Variable name="group"/>,visual_bpm</ConfigKey>
-            </Connection>
-          </NumberBpm>
- 	  <Label>
-            <TooltipId>text</TooltipId>
-            <Size>27f,22f</Size>
-            <Text>BPM</Text>
-          </Label>
-	</Children>
-       <Connection>
-        <ConfigKey persist="false">[Master],show_bpm_in_top_bar</ConfigKey>
-        <BindProperty>visible</BindProperty>
-        </Connection>
-      </WidgetGroup>
 
       <WidgetGroup>  <!-- spacer -->
         <Layout>horizontal</Layout>
@@ -128,9 +98,30 @@
         <Layout>horizontal</Layout>
           <ObjectName>AlignRightTop</ObjectName>
            <Children>
+
+			  <WidgetGroup>
+				<Layout>horizontal</Layout>
+          		<ObjectName>AlignCenter</ObjectName>
+				 <Children>
+					  <NumberBpm>
+						<TooltipId>visual_bpm</TooltipId>
+						<Size>30f,10f</Size>
+						<Channel><Variable name="channum" /></Channel>
+						<NumberOfDigits>1</NumberOfDigits>
+						<Connection>
+						  <ConfigKey><Variable name="group"/>,visual_bpm</ConfigKey>
+						</Connection>
+					  </NumberBpm>
+				</Children>
+			   <Connection>
+				<ConfigKey persist="false">[Master],show_bpm_in_top_bar</ConfigKey>
+				<BindProperty>visible</BindProperty>
+				</Connection>
+			  </WidgetGroup>
+
             <!-- FX buttons 1-4 -->
             <PushButton>
-              <Size>30f,22f</Size>
+              <Size>28f,22f</Size>
               <TooltipId>EffectUnit_deck_enabled</TooltipId>
               <ObjectName>FxAssignButton</ObjectName>
               <NumberStates>2</NumberStates>
@@ -149,7 +140,7 @@
             </PushButton>
 
             <PushButton>
-              <Size>30f,22f</Size>
+              <Size>28f,22f</Size>
               <TooltipId>EffectUnit_deck_enabled</TooltipId>
               <ObjectName>FxAssignButton</ObjectName>
               <NumberStates>2</NumberStates>
@@ -175,7 +166,7 @@
               </Connection>
               <Children>
                 <PushButton>
-                  <Size>30f,22f</Size>
+                  <Size>28f,22f</Size>
                   <TooltipId>EffectUnit_deck_enabled</TooltipId>
                   <ObjectName>FxAssignButton</ObjectName>
                   <NumberStates>2</NumberStates>
@@ -194,7 +185,7 @@
                 </PushButton>
 
                 <PushButton>
-                  <Size>30f,22f</Size>
+                  <Size>28f,22f</Size>
                   <TooltipId>EffectUnit_deck_enabled</TooltipId>
                   <ObjectName>FxAssignButton</ObjectName>
                   <NumberStates>2</NumberStates>

--- a/res/skins/LateNight/deck_row_1_keyVinylFx.xml
+++ b/res/skins/LateNight/deck_row_1_keyVinylFx.xml
@@ -195,4 +195,3 @@
     </Children>
   </WidgetGroup>
 </Template>
-

--- a/res/skins/LateNight/deck_row_1_keyVinylFx.xml
+++ b/res/skins/LateNight/deck_row_1_keyVinylFx.xml
@@ -195,3 +195,4 @@
     </Children>
   </WidgetGroup>
 </Template>
+

--- a/res/skins/LateNight/deck_row_1_keyVinylFx.xml
+++ b/res/skins/LateNight/deck_row_1_keyVinylFx.xml
@@ -94,6 +94,30 @@
 
       <Template src="skin:vinyl_controls.xml"/>
 
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+	 <Children>
+          <NumberBpm>
+            <TooltipId>visual_bpm</TooltipId>
+            <Size>40f,22f</Size>
+            <Channel><Variable name="channum" /></Channel>
+            <NumberOfDigits>2</NumberOfDigits>
+            <Connection>
+              <ConfigKey><Variable name="group"/>,visual_bpm</ConfigKey>
+            </Connection>
+          </NumberBpm>
+ 	  <Label>
+            <TooltipId>text</TooltipId>
+            <Size>27f,22f</Size>
+            <Text>BPM</Text>
+          </Label>
+	</Children>
+       <Connection>
+        <ConfigKey persist="false">[Master],show_bpm_in_top_bar</ConfigKey>
+        <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
       <WidgetGroup>  <!-- spacer -->
         <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>

--- a/res/skins/LateNight/deck_row_1_keyVinylFx.xml
+++ b/res/skins/LateNight/deck_row_1_keyVinylFx.xml
@@ -99,26 +99,6 @@
           <ObjectName>AlignRightTop</ObjectName>
            <Children>
 
-			  <WidgetGroup>
-				<Layout>horizontal</Layout>
-          		<ObjectName>AlignCenter</ObjectName>
-				 <Children>
-					  <NumberBpm>
-						<TooltipId>visual_bpm</TooltipId>
-						<Size>30f,10f</Size>
-						<Channel><Variable name="channum" /></Channel>
-						<NumberOfDigits>1</NumberOfDigits>
-						<Connection>
-						  <ConfigKey><Variable name="group"/>,visual_bpm</ConfigKey>
-						</Connection>
-					  </NumberBpm>
-				</Children>
-			   <Connection>
-				<ConfigKey persist="false">[Master],show_bpm_in_top_bar</ConfigKey>
-				  <BindProperty>visible</BindProperty>
-				</Connection>
-			  </WidgetGroup>
-
             <!-- FX buttons 1-4 -->
             <PushButton>
               <Size>28f,22f</Size>

--- a/res/skins/LateNight/deck_row_1_keyVinylFx.xml
+++ b/res/skins/LateNight/deck_row_1_keyVinylFx.xml
@@ -115,7 +115,7 @@
 				</Children>
 			   <Connection>
 				<ConfigKey persist="false">[Master],show_bpm_in_top_bar</ConfigKey>
-				<BindProperty>visible</BindProperty>
+				  <BindProperty>visible</BindProperty>
 				</Connection>
 			  </WidgetGroup>
 

--- a/res/skins/LateNight/decks_right.xml
+++ b/res/skins/LateNight/decks_right.xml
@@ -1,7 +1,7 @@
 <Template>
   <WidgetGroup>
     <ObjectName>DecksSizer</ObjectName>
-    <Layout>vertical</Layout>
+    <Layout>horizontal</Layout>
     <SizePolicy>me,min</SizePolicy>
     <Children>
       <WidgetGroup>
@@ -60,6 +60,15 @@
 
         </Children>
       </WidgetGroup>
+
+      <WidgetGroup>
+        <Size>5f,1min</Size>
+        <Connection>
+          <ConfigKey>[Master],skin_settings</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
     </Children>
   </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/fx.xml
+++ b/res/skins/LateNight/fx.xml
@@ -2,14 +2,27 @@
   <SetVariable name="FxRack">1</SetVariable>
 
   <WidgetGroup>
-    <Layout>vertical</Layout>
+    <Layout>horizontal</Layout>
     <Connection>
       <ConfigKey>[EffectRack<Variable name="FxRack"/>],show</ConfigKey>
       <BindProperty>visible</BindProperty>
     </Connection>
     <Children>
-      <Template src="skin:fx_units_12.xml"/>
-      <Template src="skin:fx_units_34.xml"/>
+      <WidgetGroup>
+        <Layout>vertical</Layout>
+        <Children>
+          <Template src="skin:fx_units_12.xml"/>
+          <Template src="skin:fx_units_34.xml"/>
+        </Children>
+      </WidgetGroup>
+
+      <WidgetGroup>
+        <Size>5f,1min</Size>
+        <Connection>
+          <ConfigKey>[Master],skin_settings</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
     </Children>
   </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/library.xml
+++ b/res/skins/LateNight/library.xml
@@ -79,6 +79,14 @@
             </Children>
           </Splitter>
 
+          <WidgetGroup>
+            <Size>5f,1min</Size>
+            <Connection>
+              <ConfigKey>[Master],skin_settings</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup>
+
         </Children>
       </WidgetGroup>
     </Children>

--- a/res/skins/LateNight/library.xml
+++ b/res/skins/LateNight/library.xml
@@ -1,7 +1,6 @@
 <Template>
   <WidgetGroup>
     <SizePolicy>me,i</SizePolicy>
-    <MinimumSize>1270,-</MinimumSize>
     <Layout>vertical</Layout>
     <Children>
 

--- a/res/skins/LateNight/mic_aux_container.xml
+++ b/res/skins/LateNight/mic_aux_container.xml
@@ -150,6 +150,14 @@
 
       <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
 
+      <WidgetGroup>
+        <Size>5f,1min</Size>
+        <Connection>
+          <ConfigKey>[Master],skin_settings</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
     </Children>
   </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/mixer.xml
+++ b/res/skins/LateNight/mixer.xml
@@ -230,6 +230,11 @@
                             </Connection>
                           </SliderComposed>
                         </Children>
+                        <Connection>
+                          <ConfigKey persist="true">[Master],show_xfader</ConfigKey>
+                          <Transform><Not/></Transform>
+                          <BindProperty>visible</BindProperty>
+                        </Connection>
                       </WidgetGroup>
 
                       <!-- Channel2 xfader switch:

--- a/res/skins/LateNight/samplers_container.xml
+++ b/res/skins/LateNight/samplers_container.xml
@@ -8,17 +8,31 @@
         <SetVariable name="samplernum">1</SetVariable>
       </Template>
 
+      <WidgetGroup><Size>10f,1min</Size></WidgetGroup>
+
       <Template src="skin:sampler.xml">
         <SetVariable name="samplernum">2</SetVariable>
       </Template>
+
+      <WidgetGroup><Size>10f,1min</Size></WidgetGroup>
 
       <Template src="skin:sampler.xml">
         <SetVariable name="samplernum">3</SetVariable>
       </Template>
 
+      <WidgetGroup><Size>10f,1min</Size></WidgetGroup>
+
       <Template src="skin:sampler.xml">
         <SetVariable name="samplernum">4</SetVariable>
       </Template>
+
+      <WidgetGroup>
+        <Size>5f,1min</Size>
+        <Connection>
+          <ConfigKey>[Master],skin_settings</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
 
     </Children>
   </WidgetGroup>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -57,6 +57,7 @@
       <attribute config_key="[Master],maximize_library">0</attribute>
       <attribute config_key="[Master],skin_settings">0</attribute>
       <attribute config_key="[Master],show_rate_control">1</attribute>
+      <attribute config_key="[Master],show_bpm_in_top_bar">0</attribute>
       <!--Disable hidden effect routing Buttons-->
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[MasterOutput]_enable">0</attribute>
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[BusLeft]_enable">0</attribute>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -57,7 +57,6 @@
       <attribute config_key="[Master],maximize_library">0</attribute>
       <attribute config_key="[Master],skin_settings">0</attribute>
       <attribute config_key="[Master],show_rate_control">1</attribute>
-      <attribute config_key="[Master],show_bpm_in_top_bar">0</attribute>
       <!--Disable hidden effect routing Buttons-->
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[MasterOutput]_enable">0</attribute>
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[BusLeft]_enable">0</attribute>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -56,6 +56,7 @@
       <attribute persist="true" config_key="[Skin],8_hotcues">0</attribute>
       <attribute config_key="[Master],maximize_library">0</attribute>
       <attribute config_key="[Master],skin_settings">0</attribute>
+      <attribute config_key="[Master],show_rate_control">1</attribute>
       <!--Disable hidden effect routing Buttons-->
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[MasterOutput]_enable">0</attribute>
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[BusLeft]_enable">0</attribute>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -55,7 +55,7 @@
       <attribute persist="true" config_key="[Master],show_xfader">1</attribute>
       <attribute persist="true" config_key="[Skin],8_hotcues">0</attribute>
       <attribute config_key="[Master],maximize_library">0</attribute>
-      <attribute config_key="[Latenight],skin_settings">0</attribute>
+      <attribute config_key="[Master],skin_settings">0</attribute>
       <!--Disable hidden effect routing Buttons-->
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[MasterOutput]_enable">0</attribute>
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[BusLeft]_enable">0</attribute>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -55,6 +55,7 @@
       <attribute persist="true" config_key="[Master],show_xfader">1</attribute>
       <attribute persist="true" config_key="[Skin],8_hotcues">0</attribute>
       <attribute config_key="[Master],maximize_library">0</attribute>
+      <attribute config_key="[Latenight],skin_settings">0</attribute>
       <!--Disable hidden effect routing Buttons-->
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[MasterOutput]_enable">0</attribute>
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[BusLeft]_enable">0</attribute>
@@ -115,6 +116,10 @@
       <Layout>vertical</Layout>
       <SizePolicy>me,me</SizePolicy>
       <Children>
+        <WidgetGroup><!-- All skin elements-->
+          <Layout>horizontal</Layout>
+          <SizePolicy>me,me</SizePolicy>
+            <Children>
 
         <!-- Select between either the full UI or the big library -->
         <WidgetStack currentpage="[Master],maximize_library">
@@ -128,45 +133,47 @@
               <SplitSizes>1,5</SplitSizes>
               <SplitSizesConfigKey>[LateNight],waveform_splitSize</SplitSizesConfigKey>
               <Collapsible>1,0</Collapsible>
-              <Children>
+                  <Children>
 
-                <Template src="skin:waveforms.xml"/>
+                    <Template src="skin:waveforms.xml"/>
 
-                <WidgetGroup>
+                    <WidgetGroup>
+                      <Layout>vertical</Layout>
+                      <SizePolicy>me,me</SizePolicy>
+                      <Children>
+                        <WidgetGroup>
+                          <Layout>horizontal</Layout>
+                          <SizePolicy>me,max</SizePolicy>
+                          <Children>
+                            <Template src="skin:decks_left.xml"/>
+                            <Template src="skin:mixer.xml"/>
+                            <Template src="skin:decks_right.xml"/>
+                          </Children>
+                        </WidgetGroup>
+                        <Template src="skin:fx.xml"/>
+                        <Template src="skin:lower_half.xml"/>
+                      </Children>
+                    </WidgetGroup>
+
+                  </Children>
+                </Splitter><!-- Decks, Effects ... Library -->
+
+                <!-- MAximized Library -->
+                <WidgetGroup trigger="[Master],maximize_library" on_hide_select="0">
                   <Layout>vertical</Layout>
                   <SizePolicy>me,me</SizePolicy>
                   <Children>
-                    <WidgetGroup>
-                      <Layout>horizontal</Layout>
-                      <SizePolicy>me,max</SizePolicy>
-                      <Children>
-                        <Template src="skin:decks_left.xml"/>
-                        <Template src="skin:mixer.xml"/>
-                        <Template src="skin:decks_right.xml"/>
-                      </Children>
-                    </WidgetGroup>
-                    <Template src="skin:fx.xml"/>
-                    <Template src="skin:lower_half.xml"/>
+                    <SingletonContainer>
+                      <ObjectName>LibrarySingleton</ObjectName>
+                    </SingletonContainer>
                   </Children>
                 </WidgetGroup>
 
               </Children>
-            </Splitter><!-- Decks, Effects ... Library -->
-
-            <!-- MAximized Library -->
-            <WidgetGroup trigger="[Master],maximize_library" on_hide_select="0">
-              <Layout>vertical</Layout>
-              <SizePolicy>me,me</SizePolicy>
-              <Children>
-                <SingletonContainer>
-                  <ObjectName>LibrarySingleton</ObjectName>
-                </SingletonContainer>
-              </Children>
-            </WidgetGroup>
-
+            </WidgetStack>
+            <Template src="skin:skin_settings.xml"/>
           </Children>
-        </WidgetStack>
-
+        </WidgetGroup>
         <Template src="skin:toolbar.xml"/>
       </Children>
     </WidgetGroup>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -120,20 +120,20 @@
         <WidgetGroup><!-- All skin elements-->
           <Layout>horizontal</Layout>
           <SizePolicy>me,me</SizePolicy>
-            <Children>
-
-        <!-- Select between either the full UI or the big library -->
-        <WidgetStack currentpage="[Master],maximize_library">
           <Children>
 
-            <!-- Decks, Effects ... Library -->
-            <Splitter>
-              <ObjectName>HorizontalSplitter</ObjectName>
-              <Orientation>vertical</Orientation>
-              <SizePolicy>me,min</SizePolicy>
-              <SplitSizes>1,5</SplitSizes>
-              <SplitSizesConfigKey>[LateNight],waveform_splitSize</SplitSizesConfigKey>
-              <Collapsible>1,0</Collapsible>
+            <!-- Select between either the full UI or the big library -->
+            <WidgetStack currentpage="[Master],maximize_library">
+              <Children>
+
+                <!-- Waveforms, Decks, Effects... /  Library -->
+                <Splitter>
+                  <ObjectName>HorizontalSplitter</ObjectName>
+                  <Orientation>vertical</Orientation>
+                  <SizePolicy>me,min</SizePolicy>
+                  <SplitSizes>1,5</SplitSizes>
+                  <SplitSizesConfigKey>[LateNight],waveform_splitSize</SplitSizesConfigKey>
+                  <Collapsible>1,0</Collapsible>
                   <Children>
 
                     <Template src="skin:waveforms.xml"/>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -72,6 +72,7 @@ Description:
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
+ 					<SetVariable name="TooltipId">show_previewdeck</SetVariable>
                     <SetVariable name="state_0_text">      Preview Deck</SetVariable>
                     <SetVariable name="state_1_text"> &#10004; Preview Deck</SetVariable>
                     <SetVariable name="width">110</SetVariable>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -115,6 +115,22 @@ Description:
                 </Children>
               </WidgetGroup>
 
+              <WidgetGroup><!-- BPM Top Bar toogle -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="TooltipId">bmp_top_bar_toogle</SetVariable>
+                    <SetVariable name="state_0_text">      BPM in Top Bar</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; BPM in Top Bar</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[Master],show_bpm_in_top_bar</SetVariable>
+                  </Template>
+                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
+                </Children>
+              </WidgetGroup>
             </Children>
           </WidgetGroup><!-- /Deck / General -->
 

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -314,10 +314,10 @@ Description:
             </Children>
           </WidgetGroup><!-- /Effects -->
 
-          <Label><!-- Extras -->
+          <Label><!-- Misc -->
             <ObjectName>CategoryLabel</ObjectName>
             <Size>200f,21f</Size>
-            <Text>Extras</Text>
+            <Text>Misc</Text>
           </Label>
           <WidgetGroup><!-- 4 buttons -->
             <ObjectName>SkinSettingsCategory</ObjectName>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -71,7 +71,7 @@ Description:
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
-                    <SetVariable name="TooltipId">Toggle 4 Decks</SetVariable>
+                    <SetVariable name="TooltipId">toggle_4decks</SetVariable>
                     <SetVariable name="state_0_text">      4 Decks</SetVariable>
                     <SetVariable name="state_1_text"> &#10004; 4 Decks</SetVariable>
                     <SetVariable name="width">110</SetVariable>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -39,7 +39,7 @@ Description:
                 <SetVariable name="TooltipId">skin_settings</SetVariable>
                 <SetVariable name="ObjectName">SkinSettingsClose</SetVariable>
                 <SetVariable name="Size">20f,24f</SetVariable>
-                <SetVariable name="ConfigKey">[Latenight],skin_settings</SetVariable>
+                <SetVariable name="ConfigKey">[Master],skin_settings</SetVariable>
               </Template>
             </Children>
           </WidgetGroup>
@@ -415,7 +415,7 @@ Description:
       </WidgetGroup><!-- /SkinSettings -->
     </Children>
     <Connection>
-      <ConfigKey>[Latenight],skin_settings</ConfigKey>
+      <ConfigKey>[Master],skin_settings</ConfigKey>
       <BindProperty>visible</BindProperty>
     </Connection>
   </WidgetGroup>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -98,6 +98,22 @@ Description:
                 </Children>
               </WidgetGroup>
 
+              <WidgetGroup><!-- Rate Control toogle -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="TooltipId">rate_toggle</SetVariable>
+                    <SetVariable name="state_0_text">      Rate Control</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; Rate Control</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[Master],show_rate_control</SetVariable>
+                  </Template>
+                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
+                </Children>
+              </WidgetGroup>
 
             </Children>
           </WidgetGroup><!-- /Deck / General -->

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -1,0 +1,391 @@
+<!--
+Description:
+  The skin settings menu.
+
+  Bug: qss 'qproperty-layoutAlignment' is not respected for stacked layout.
+  No way to make SkinSettings float on top of main window at the right side
+  while keeping the screen area underneath clickable.
+
+  https://bugs.launchpad.net/mixxx/+bug/1689196
+  On OSX this widget is drawn behind main skin instead on top of it.
+  I removed the stacked layout and placed skin settings on the right hand side of main skin.
+-->
+<Template>
+  <WidgetGroup>
+    <ObjectName>SkinSettingsContainer</ObjectName>
+    <Layout>horizontal</Layout>
+    <Size>205f,1me</Size>
+    <Children>
+      <WidgetGroup>
+        <ObjectName>SkinSettings</ObjectName>
+        <Layout>vertical</Layout>
+        <Size>200f,1me</Size>
+        <Children>
+          <WidgetGroup>
+            <ObjectName>SkinSettingsHeader</ObjectName>
+            <Layout>horizontal</Layout>
+            <SizePolicy>me,f</SizePolicy>
+            <Children>
+              <Label>
+                <ObjectName>CategoryLabel</ObjectName>
+                <Text>Decks / General</Text>
+                <Size>200f,21f</Size>
+              </Label>
+
+              <!-- push Close button to far right -->
+              <WidgetGroup><Size>1me,1me</Size></WidgetGroup>
+
+              <Template src="skin:button_2state.xml">
+                <SetVariable name="TooltipId">skin_settings</SetVariable>
+                <SetVariable name="ObjectName">SkinSettingsClose</SetVariable>
+                <SetVariable name="Size">20f,24f</SetVariable>
+                <SetVariable name="ConfigKey">[Latenight],skin_settings</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup>
+
+          <!-- Each category's MinimumSize & MaximumSize need to be defined
+              in order to let them grow reasonably on big screens, as well as to
+              allow good-looking compression of items on small screens.
+              <SizePolicy> is very hard to handle in many places here due to
+              translucent covers and submenus, defining button sizes explicitely helps.
+
+              Each categroy has a padding: top 2px, bottom 2px
+              For every button we need to provide space (13-17px):
+              MinSize = (num. of buttons/rows x 13px) + 15px + 3px padding + 3px border-bottom
+              MaxSize = (num. of buttons/rows x 17px) + 15px + 3px padding + 3px border-bottom +10px
+              (let's add 10px so sections can grow on big screens) -->
+
+          <!-- Decks / General -->
+          <WidgetGroup><!-- 4 buttons -->
+            <ObjectName>SkinSettingsCategory</ObjectName>
+            <MinimumSize>200,58</MinimumSize>
+            <MaximumSize>200,84</MaximumSize>
+            <SizePolicy>me,me</SizePolicy>
+            <Layout>vertical</Layout>
+            <Children>
+              <WidgetGroup><!-- 2/4 Decks toogle -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="TooltipId">Toggle 4 Decks</SetVariable>
+                    <SetVariable name="state_0_text">      4 Decks</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; 4 Decks</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[Master],show_4decks</SetVariable>
+                  </Template>
+                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
+                </Children>
+              </WidgetGroup>
+
+              <WidgetGroup><!-- 4/8 Hotcue toogle -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="TooltipId">hotcue_toggle</SetVariable>
+                    <SetVariable name="state_0_text">      8 Hotcue</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; 8 Hotcue</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[Skin],8_hotcues</SetVariable>
+                  </Template>
+                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
+                </Children>
+              </WidgetGroup>
+
+
+            </Children>
+          </WidgetGroup><!-- /Deck / General -->
+
+          <!--  Mixer -->
+          <Template src="skin:skin_settings_labelbutton_2state.xml">
+            <SetVariable name="state_0_text">  Mixer &#9744;</SetVariable>
+            <SetVariable name="state_1_text">  Mixer &#9745;</SetVariable>
+            <SetVariable name="width">200f</SetVariable>
+            <SetVariable name="Setting">[Master],show_mixer</SetVariable>
+            <SetVariable name="TooltipId">show_mixer</SetVariable>
+          </Template>
+
+          <WidgetGroup><!-- 4 buttons -->
+            <ObjectName>SkinSettingsCategory</ObjectName>
+            <MinimumSize>200,58</MinimumSize>
+            <MaximumSize>200,84</MaximumSize>
+            <SizePolicy>me,me</SizePolicy>
+            <Layout>vertical</Layout>
+            <Children>
+
+              <WidgetGroup><!-- EQ knobs -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <!-- index 0 due to bug -->
+                  <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
+
+                  <WidgetGroup><!-- translucent cover when Channel Mixer is hidden -->
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>vertical</Layout>
+                    <MinimumSize>182,13</MinimumSize>
+                    <MaximumSize>182,17</MaximumSize>
+                    <SizePolicy>me,me</SizePolicy>
+                    <Connection>
+                      <ConfigKey persist="true">[Master],show_mixer</ConfigKey>
+                      <Transform><Not/></Transform>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
+
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="state_0_text">      EQ Knobs</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; EQ Knobs</SetVariable>
+                    <SetVariable name="Setting">[Master],show_eqs</SetVariable>
+                  </Template>
+
+                </Children>
+              </WidgetGroup><!-- /EQ knobs -->
+
+              <WidgetGroup><!-- EQ Kill -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <!-- index 0 due to bug -->
+                  <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
+
+                  <WidgetGroup><!-- translucent cover when Channel Mixer is hidden -->
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>vertical</Layout>
+                    <MinimumSize>182,13</MinimumSize>
+                    <MaximumSize>182,17</MaximumSize>
+                    <SizePolicy>me,me</SizePolicy>
+                    <Connection>
+                      <ConfigKey persist="true">[Master],show_mixer</ConfigKey>
+                      <Transform><Not/></Transform>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
+
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="state_0_text">      EQ Kill</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; EQ Kill</SetVariable>
+                    <SetVariable name="Setting">[Master],show_eq_kill_buttons</SetVariable>
+                  </Template>
+
+                </Children>
+              </WidgetGroup><!-- /EQ Kill -->
+
+            </Children>
+          </WidgetGroup><!-- /Mixer -->
+
+          <Label><!-- Spinny/Cover -->
+            <ObjectName>CategoryLabel</ObjectName>
+            <Size>200f,21f</Size>
+            <Text>Spinny/Cover</Text>
+          </Label>
+
+          <WidgetGroup><!-- 4 buttons -->
+            <ObjectName>SkinSettingsCategory</ObjectName>
+            <MinimumSize>200,58</MinimumSize>
+            <MaximumSize>200,84</MaximumSize>
+            <SizePolicy>me,me</SizePolicy>
+            <Layout>vertical</Layout>
+            <Children>
+
+              <WidgetGroup><!-- Spinny -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="TooltipId">show_spinny</SetVariable>
+                    <SetVariable name="state_0_text">      Spinny</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; Spinny</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[Spinny],show_spinnies</SetVariable>
+                  </Template>
+                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
+                </Children>
+              </WidgetGroup>
+
+              <WidgetGroup><!-- coverart toogle -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="state_0_text">      Cover Art</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; Cover Art</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[Library],show_coverart</SetVariable>
+                  </Template>
+                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
+                </Children>
+              </WidgetGroup>
+
+            </Children>
+          </WidgetGroup><!-- /Spinny/Cover -->
+
+
+          <!-- Effects -->
+          <Template src="skin:skin_settings_labelbutton_2state.xml">
+            <SetVariable name="state_0_text">  Effects &#9744;</SetVariable>
+            <SetVariable name="state_1_text">  Effects &#9745;</SetVariable>
+            <SetVariable name="width">200f</SetVariable>
+            <SetVariable name="Setting">[EffectRack1],show</SetVariable>
+            <SetVariable name="TooltipId">show_effects</SetVariable>
+          </Template>
+
+          <WidgetGroup><!-- 4 buttons -->
+            <ObjectName>SkinSettingsCategory</ObjectName>
+            <MinimumSize>200,58</MinimumSize>
+            <MaximumSize>200,84</MaximumSize>
+            <SizePolicy>me,me</SizePolicy>
+            <Layout>vertical</Layout>
+            <Children>
+              <WidgetGroup><!-- 4 Effect Units -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <!-- index 0 due to bug -->
+                  <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
+
+                  <WidgetGroup>
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>stacked</Layout>
+                    <MinimumSize>182,13</MinimumSize>
+                    <MaximumSize>182,17</MaximumSize>
+                    <SizePolicy>me,me</SizePolicy>
+                    <Connection>
+                      <ConfigKey persist="true">[EffectRack1],show</ConfigKey>
+                      <Transform><Not/></Transform>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
+
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="state_0_text">      4 EFFECT UNITS</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; 4 EFFECT UNITS</SetVariable>
+                    <SetVariable name="Setting">[Master],show_4effectunits</SetVariable>
+                  </Template>
+                </Children>
+              </WidgetGroup><!-- /4 Effect Units -->
+
+              <WidgetGroup><!-- Super knobs -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <!-- index 0 due to bug -->
+                  <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
+
+                  <WidgetGroup>
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>stacked</Layout>
+                    <MinimumSize>182,13</MinimumSize>
+                    <MaximumSize>182,17</MaximumSize>
+                    <SizePolicy>me,me</SizePolicy>
+                    <Connection>
+                      <ConfigKey persist="true">[EffectRack1],show</ConfigKey>
+                      <Transform><Not/></Transform>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
+
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="state_0_text">      Super Knobs</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; Super Knobs</SetVariable>
+                    <SetVariable name="Setting">[Master],show_superknobs</SetVariable>
+                  </Template>
+                </Children>
+              </WidgetGroup><!-- /Super knobs -->
+
+            </Children>
+          </WidgetGroup><!-- /Effects -->
+
+          <Label><!-- Extras -->
+            <ObjectName>CategoryLabel</ObjectName>
+            <Size>200f,21f</Size>
+            <Text>Extras</Text>
+          </Label>
+          <WidgetGroup><!-- 4 buttons -->
+            <ObjectName>SkinSettingsCategory</ObjectName>
+            <MinimumSize>200,58</MinimumSize>
+            <MaximumSize>200,84</MaximumSize>
+            <SizePolicy>me,me</SizePolicy>
+            <Layout>vertical</Layout>
+            <Children>
+              <WidgetGroup><!-- Preview Deck toogle -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="state_0_text">      Preview Deck</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; Preview Deck</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[PreviewDeck],show_previewdeck</SetVariable>
+                  </Template>
+                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
+                </Children>
+              </WidgetGroup>
+
+              <WidgetGroup><!-- Vinyl Control toogle -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
+                    <SetVariable name="state_0_text">      Vinyl Control</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; Vinyl Control</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[VinylControl],show_vinylcontrol</SetVariable>
+                  </Template>
+                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
+                </Children>
+              </WidgetGroup>
+
+              <WidgetGroup><!-- Microphone toogle -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="state_0_text">      Microphone Section</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; Microphone Section</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[Microphone],show_microphone</SetVariable>
+                  </Template>
+                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
+                </Children>
+              </WidgetGroup>
+
+
+
+            </Children>
+          </WidgetGroup><!-- /Extras -->
+
+        </Children>
+      </WidgetGroup><!-- /SkinSettings -->
+    </Children>
+    <Connection>
+      <ConfigKey>[Latenight],skin_settings</ConfigKey>
+      <BindProperty>visible</BindProperty>
+    </Connection>
+  </WidgetGroup>
+</Template>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -59,11 +59,28 @@ Description:
           <!-- Decks / General -->
           <WidgetGroup><!-- 4 buttons -->
             <ObjectName>SkinSettingsCategory</ObjectName>
-            <MinimumSize>180f,58</MinimumSize>
-            <MaximumSize>180f,84</MaximumSize>
+            <MinimumSize>180f,100</MinimumSize>
+            <MaximumSize>180f,125</MaximumSize>
             <SizePolicy>me,me</SizePolicy>
             <Layout>vertical</Layout>
             <Children>
+
+              <WidgetGroup><!-- Preview Deck toogle -->
+                <Layout>stacked</Layout>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="state_0_text">      Preview Deck</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; Preview Deck</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[PreviewDeck],show_previewdeck</SetVariable>
+                  </Template>
+                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
+                </Children>
+              </WidgetGroup>
+
               <WidgetGroup><!-- 2/4 Decks toogle -->
                 <Layout>stacked</Layout>
                 <MinimumSize>180,13</MinimumSize>
@@ -131,13 +148,48 @@ Description:
                   <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
                 </Children>
               </WidgetGroup>
+
+              <WidgetGroup><!-- Spinny -->
+                <Layout>stacked</Layout>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="TooltipId">show_spinny</SetVariable>
+                    <SetVariable name="state_0_text">      Spinny</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; Spinny</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[Spinny],show_spinnies</SetVariable>
+                  </Template>
+                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
+                </Children>
+              </WidgetGroup>
+
+              <WidgetGroup><!-- Vinyl Control toogle -->
+                <Layout>stacked</Layout>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
+                    <SetVariable name="state_0_text">      Vinyl Control</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; Vinyl Control</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[VinylControl],show_vinylcontrol</SetVariable>
+                  </Template>
+                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
+                </Children>
+              </WidgetGroup>
+
             </Children>
           </WidgetGroup><!-- /Deck / General -->
 
           <!--  Mixer -->
           <Template src="skin:skin_settings_labelbutton_2state.xml">
-            <SetVariable name="state_0_text">  Mixer &#9744;</SetVariable>
-            <SetVariable name="state_1_text">  Mixer &#9745;</SetVariable>
+            <SetVariable name="state_0_text">  &#9744; Mixer </SetVariable>
+            <SetVariable name="state_1_text">  &#9745; Mixer </SetVariable>
             <SetVariable name="width">180f</SetVariable>
             <SetVariable name="Setting">[Master],show_mixer</SetVariable>
             <SetVariable name="TooltipId">show_mixer</SetVariable>
@@ -247,61 +299,11 @@ Description:
             </Children>
           </WidgetGroup><!-- /Mixer -->
 
-          <Label><!-- Spinny/Cover -->
-            <ObjectName>CategoryLabel</ObjectName>
-            <Size>180f,21f</Size>
-            <Text>Spinny/Cover</Text>
-          </Label>
-
-          <WidgetGroup><!-- 4 buttons -->
-            <ObjectName>SkinSettingsCategory</ObjectName>
-            <MinimumSize>180,58</MinimumSize>
-            <MaximumSize>180,84</MaximumSize>
-            <SizePolicy>me,me</SizePolicy>
-            <Layout>vertical</Layout>
-            <Children>
-
-              <WidgetGroup><!-- Spinny -->
-                <Layout>stacked</Layout>
-                <MinimumSize>180,13</MinimumSize>
-                <MaximumSize>180,17</MaximumSize>
-                <SizePolicy>me,me</SizePolicy>
-                <Children>
-                  <Template src="skin:skin_settings_button_2state.xml">
-                    <SetVariable name="TooltipId">show_spinny</SetVariable>
-                    <SetVariable name="state_0_text">      Spinny</SetVariable>
-                    <SetVariable name="state_1_text"> &#10004; Spinny</SetVariable>
-                    <SetVariable name="width">110</SetVariable>
-                    <SetVariable name="Setting">[Spinny],show_spinnies</SetVariable>
-                  </Template>
-                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
-                </Children>
-              </WidgetGroup>
-
-              <WidgetGroup><!-- coverart toogle -->
-                <Layout>stacked</Layout>
-                <MinimumSize>180,13</MinimumSize>
-                <MaximumSize>180,17</MaximumSize>
-                <SizePolicy>me,me</SizePolicy>
-                <Children>
-                  <Template src="skin:skin_settings_button_2state.xml">
-                    <SetVariable name="state_0_text">      Cover Art</SetVariable>
-                    <SetVariable name="state_1_text"> &#10004; Cover Art</SetVariable>
-                    <SetVariable name="width">110</SetVariable>
-                    <SetVariable name="Setting">[Library],show_coverart</SetVariable>
-                  </Template>
-                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
-                </Children>
-              </WidgetGroup>
-
-            </Children>
-          </WidgetGroup><!-- /Spinny/Cover -->
-
 
           <!-- Effects -->
           <Template src="skin:skin_settings_labelbutton_2state.xml">
-            <SetVariable name="state_0_text">  Effects &#9744;</SetVariable>
-            <SetVariable name="state_1_text">  Effects &#9745;</SetVariable>
+            <SetVariable name="state_0_text">  &#9744; Effects </SetVariable>
+            <SetVariable name="state_1_text">  &#9745; Effects </SetVariable>
             <SetVariable name="width">180f</SetVariable>
             <SetVariable name="Setting">[EffectRack1],show</SetVariable>
             <SetVariable name="TooltipId">show_effects</SetVariable>
@@ -376,55 +378,6 @@ Description:
 
             </Children>
           </WidgetGroup><!-- /Effects -->
-
-          <Label><!-- Miscellaneous -->
-            <ObjectName>CategoryLabel</ObjectName>
-            <Size>180f,21f</Size>
-            <Text>Miscellaneous</Text>
-          </Label>
-          <WidgetGroup><!-- 4 buttons -->
-            <ObjectName>SkinSettingsCategory</ObjectName>
-            <MinimumSize>180,58</MinimumSize>
-            <MaximumSize>180,84</MaximumSize>
-            <SizePolicy>me,me</SizePolicy>
-            <Layout>vertical</Layout>
-            <Children>
-              <WidgetGroup><!-- Preview Deck toogle -->
-                <Layout>stacked</Layout>
-                <MinimumSize>180,13</MinimumSize>
-                <MaximumSize>180,17</MaximumSize>
-                <SizePolicy>me,me</SizePolicy>
-                <Children>
-                  <Template src="skin:skin_settings_button_2state.xml">
-                    <SetVariable name="state_0_text">      Preview Deck</SetVariable>
-                    <SetVariable name="state_1_text"> &#10004; Preview Deck</SetVariable>
-                    <SetVariable name="width">110</SetVariable>
-                    <SetVariable name="Setting">[PreviewDeck],show_previewdeck</SetVariable>
-                  </Template>
-                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
-                </Children>
-              </WidgetGroup>
-
-              <WidgetGroup><!-- Vinyl Control toogle -->
-                <Layout>stacked</Layout>
-                <MinimumSize>180,13</MinimumSize>
-                <MaximumSize>180,17</MaximumSize>
-                <SizePolicy>me,me</SizePolicy>
-                <Children>
-                  <Template src="skin:skin_settings_button_2state.xml">
-                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
-                    <SetVariable name="state_0_text">      Vinyl Control</SetVariable>
-                    <SetVariable name="state_1_text"> &#10004; Vinyl Control</SetVariable>
-                    <SetVariable name="width">110</SetVariable>
-                    <SetVariable name="Setting">[VinylControl],show_vinylcontrol</SetVariable>
-                  </Template>
-                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
-                </Children>
-              </WidgetGroup>
-
-            </Children>
-          </WidgetGroup><!-- /Miscellaneous -->
-
         </Children>
       </WidgetGroup><!-- /SkinSettings -->
     </Children>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -14,12 +14,12 @@ Description:
   <WidgetGroup>
     <ObjectName>SkinSettingsContainer</ObjectName>
     <Layout>horizontal</Layout>
-    <Size>205f,1me</Size>
+    <Size>180f,1me</Size>
     <Children>
       <WidgetGroup>
         <ObjectName>SkinSettings</ObjectName>
         <Layout>vertical</Layout>
-        <Size>200f,1me</Size>
+        <Size>180f,1me</Size>
         <Children>
           <WidgetGroup>
             <ObjectName>SkinSettingsHeader</ObjectName>
@@ -29,7 +29,7 @@ Description:
               <Label>
                 <ObjectName>CategoryLabel</ObjectName>
                 <Text>Decks / General</Text>
-                <Size>200f,21f</Size>
+                <Size>180f,21f</Size>
               </Label>
 
               <!-- push Close button to far right -->
@@ -59,15 +59,15 @@ Description:
           <!-- Decks / General -->
           <WidgetGroup><!-- 4 buttons -->
             <ObjectName>SkinSettingsCategory</ObjectName>
-            <MinimumSize>200,58</MinimumSize>
-            <MaximumSize>200,84</MaximumSize>
+            <MinimumSize>180f,58</MinimumSize>
+            <MaximumSize>180f,84</MaximumSize>
             <SizePolicy>me,me</SizePolicy>
             <Layout>vertical</Layout>
             <Children>
               <WidgetGroup><!-- 2/4 Decks toogle -->
                 <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
@@ -81,16 +81,16 @@ Description:
                 </Children>
               </WidgetGroup>
 
-              <WidgetGroup><!-- 4/8 Hotcue toogle -->
+              <WidgetGroup><!-- 4/8 Hotcues toogle -->
                 <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
                     <SetVariable name="TooltipId">hotcue_toggle</SetVariable>
-                    <SetVariable name="state_0_text">      8 Hotcue</SetVariable>
-                    <SetVariable name="state_1_text"> &#10004; 8 Hotcue</SetVariable>
+                    <SetVariable name="state_0_text">      8 Hotcues</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; 8 Hotcues</SetVariable>
                     <SetVariable name="width">110</SetVariable>
                     <SetVariable name="Setting">[Skin],8_hotcues</SetVariable>
                   </Template>
@@ -100,8 +100,8 @@ Description:
 
               <WidgetGroup><!-- Rate Control toogle -->
                 <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
@@ -117,8 +117,8 @@ Description:
 
               <WidgetGroup><!-- BPM Top Bar toogle -->
                 <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
@@ -138,23 +138,23 @@ Description:
           <Template src="skin:skin_settings_labelbutton_2state.xml">
             <SetVariable name="state_0_text">  Mixer &#9744;</SetVariable>
             <SetVariable name="state_1_text">  Mixer &#9745;</SetVariable>
-            <SetVariable name="width">200f</SetVariable>
+            <SetVariable name="width">180f</SetVariable>
             <SetVariable name="Setting">[Master],show_mixer</SetVariable>
             <SetVariable name="TooltipId">show_mixer</SetVariable>
           </Template>
 
           <WidgetGroup><!-- 4 buttons -->
             <ObjectName>SkinSettingsCategory</ObjectName>
-            <MinimumSize>200,58</MinimumSize>
-            <MaximumSize>200,84</MaximumSize>
+            <MinimumSize>180,58</MinimumSize>
+            <MaximumSize>180,84</MaximumSize>
             <SizePolicy>me,me</SizePolicy>
             <Layout>vertical</Layout>
             <Children>
 
               <WidgetGroup><!-- EQ knobs -->
                 <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <!-- index 0 due to bug -->
@@ -163,8 +163,8 @@ Description:
                   <WidgetGroup><!-- translucent cover when Channel Mixer is hidden -->
                     <ObjectName>SubmenuCover</ObjectName>
                     <Layout>vertical</Layout>
-                    <MinimumSize>182,13</MinimumSize>
-                    <MaximumSize>182,17</MaximumSize>
+                    <MinimumSize>180,13</MinimumSize>
+                    <MaximumSize>180,17</MaximumSize>
                     <SizePolicy>me,me</SizePolicy>
                     <Connection>
                       <ConfigKey persist="true">[Master],show_mixer</ConfigKey>
@@ -184,8 +184,8 @@ Description:
 
               <WidgetGroup><!-- EQ Kill -->
                 <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <!-- index 0 due to bug -->
@@ -194,8 +194,8 @@ Description:
                   <WidgetGroup><!-- translucent cover when Channel Mixer is hidden -->
                     <ObjectName>SubmenuCover</ObjectName>
                     <Layout>vertical</Layout>
-                    <MinimumSize>182,13</MinimumSize>
-                    <MaximumSize>182,17</MaximumSize>
+                    <MinimumSize>180,13</MinimumSize>
+                    <MaximumSize>180,17</MaximumSize>
                     <SizePolicy>me,me</SizePolicy>
                     <Connection>
                       <ConfigKey persist="true">[Master],show_mixer</ConfigKey>
@@ -215,8 +215,8 @@ Description:
 
               <WidgetGroup><!-- crossfader -->
                 <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <!-- index 0 due to bug -->
@@ -225,8 +225,8 @@ Description:
                   <WidgetGroup><!-- translucent cover when Channel Mixer is hidden -->
                     <ObjectName>SubmenuCover</ObjectName>
                     <Layout>vertical</Layout>
-                    <MinimumSize>182,13</MinimumSize>
-                    <MaximumSize>182,17</MaximumSize>
+                    <MinimumSize>180,13</MinimumSize>
+                    <MaximumSize>180,17</MaximumSize>
                     <SizePolicy>me,me</SizePolicy>
                     <Connection>
                       <ConfigKey persist="true">[Master],show_mixer</ConfigKey>
@@ -249,22 +249,22 @@ Description:
 
           <Label><!-- Spinny/Cover -->
             <ObjectName>CategoryLabel</ObjectName>
-            <Size>200f,21f</Size>
+            <Size>180f,21f</Size>
             <Text>Spinny/Cover</Text>
           </Label>
 
           <WidgetGroup><!-- 4 buttons -->
             <ObjectName>SkinSettingsCategory</ObjectName>
-            <MinimumSize>200,58</MinimumSize>
-            <MaximumSize>200,84</MaximumSize>
+            <MinimumSize>180,58</MinimumSize>
+            <MaximumSize>180,84</MaximumSize>
             <SizePolicy>me,me</SizePolicy>
             <Layout>vertical</Layout>
             <Children>
 
               <WidgetGroup><!-- Spinny -->
                 <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
@@ -280,8 +280,8 @@ Description:
 
               <WidgetGroup><!-- coverart toogle -->
                 <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
@@ -302,22 +302,22 @@ Description:
           <Template src="skin:skin_settings_labelbutton_2state.xml">
             <SetVariable name="state_0_text">  Effects &#9744;</SetVariable>
             <SetVariable name="state_1_text">  Effects &#9745;</SetVariable>
-            <SetVariable name="width">200f</SetVariable>
+            <SetVariable name="width">180f</SetVariable>
             <SetVariable name="Setting">[EffectRack1],show</SetVariable>
             <SetVariable name="TooltipId">show_effects</SetVariable>
           </Template>
 
           <WidgetGroup><!-- 4 buttons -->
             <ObjectName>SkinSettingsCategory</ObjectName>
-            <MinimumSize>200,58</MinimumSize>
-            <MaximumSize>200,84</MaximumSize>
+            <MinimumSize>180,58</MinimumSize>
+            <MaximumSize>180,84</MaximumSize>
             <SizePolicy>me,me</SizePolicy>
             <Layout>vertical</Layout>
             <Children>
               <WidgetGroup><!-- 4 Effect Units -->
                 <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <!-- index 0 due to bug -->
@@ -326,8 +326,8 @@ Description:
                   <WidgetGroup>
                     <ObjectName>SubmenuCover</ObjectName>
                     <Layout>stacked</Layout>
-                    <MinimumSize>182,13</MinimumSize>
-                    <MaximumSize>182,17</MaximumSize>
+                    <MinimumSize>180,13</MinimumSize>
+                    <MaximumSize>180,17</MaximumSize>
                     <SizePolicy>me,me</SizePolicy>
                     <Connection>
                       <ConfigKey persist="true">[EffectRack1],show</ConfigKey>
@@ -346,8 +346,8 @@ Description:
 
               <WidgetGroup><!-- Super knobs -->
                 <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <!-- index 0 due to bug -->
@@ -356,8 +356,8 @@ Description:
                   <WidgetGroup>
                     <ObjectName>SubmenuCover</ObjectName>
                     <Layout>stacked</Layout>
-                    <MinimumSize>182,13</MinimumSize>
-                    <MaximumSize>182,17</MaximumSize>
+                    <MinimumSize>180,13</MinimumSize>
+                    <MaximumSize>180,17</MaximumSize>
                     <SizePolicy>me,me</SizePolicy>
                     <Connection>
                       <ConfigKey persist="true">[EffectRack1],show</ConfigKey>
@@ -377,22 +377,22 @@ Description:
             </Children>
           </WidgetGroup><!-- /Effects -->
 
-          <Label><!-- Misc -->
+          <Label><!-- Miscellaneous -->
             <ObjectName>CategoryLabel</ObjectName>
-            <Size>200f,21f</Size>
-            <Text>Misc</Text>
+            <Size>180f,21f</Size>
+            <Text>Miscellaneous</Text>
           </Label>
           <WidgetGroup><!-- 4 buttons -->
             <ObjectName>SkinSettingsCategory</ObjectName>
-            <MinimumSize>200,58</MinimumSize>
-            <MaximumSize>200,84</MaximumSize>
+            <MinimumSize>180,58</MinimumSize>
+            <MaximumSize>180,84</MaximumSize>
             <SizePolicy>me,me</SizePolicy>
             <Layout>vertical</Layout>
             <Children>
               <WidgetGroup><!-- Preview Deck toogle -->
                 <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
@@ -407,8 +407,8 @@ Description:
 
               <WidgetGroup><!-- Vinyl Control toogle -->
                 <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
@@ -422,26 +422,8 @@ Description:
                 </Children>
               </WidgetGroup>
 
-              <WidgetGroup><!-- Microphone toogle -->
-                <Layout>stacked</Layout>
-                <MinimumSize>182,13</MinimumSize>
-                <MaximumSize>182,17</MaximumSize>
-                <SizePolicy>me,me</SizePolicy>
-                <Children>
-                  <Template src="skin:skin_settings_button_2state.xml">
-                    <SetVariable name="state_0_text">      Microphone Section</SetVariable>
-                    <SetVariable name="state_1_text"> &#10004; Microphone Section</SetVariable>
-                    <SetVariable name="width">110</SetVariable>
-                    <SetVariable name="Setting">[Microphone],show_microphone</SetVariable>
-                  </Template>
-                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
-                </Children>
-              </WidgetGroup>
-
-
-
             </Children>
-          </WidgetGroup><!-- /Extras -->
+          </WidgetGroup><!-- /Miscellaneous -->
 
         </Children>
       </WidgetGroup><!-- /SkinSettings -->

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -181,6 +181,37 @@ Description:
                 </Children>
               </WidgetGroup><!-- /EQ Kill -->
 
+              <WidgetGroup><!-- crossfader -->
+                <Layout>stacked</Layout>
+                <MinimumSize>182,13</MinimumSize>
+                <MaximumSize>182,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <!-- index 0 due to bug -->
+                  <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
+
+                  <WidgetGroup><!-- translucent cover when Channel Mixer is hidden -->
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>vertical</Layout>
+                    <MinimumSize>182,13</MinimumSize>
+                    <MaximumSize>182,17</MaximumSize>
+                    <SizePolicy>me,me</SizePolicy>
+                    <Connection>
+                      <ConfigKey persist="true">[Master],show_mixer</ConfigKey>
+                      <Transform><Not/></Transform>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
+
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="state_1_text">      Crossfader</SetVariable>
+                    <SetVariable name="state_0_text"> &#10004; Crossfader</SetVariable>
+                    <SetVariable name="Setting">[Master],show_xfader</SetVariable>
+                  </Template>
+
+                </Children>
+              </WidgetGroup><!-- /crossfader -->
+
             </Children>
           </WidgetGroup><!-- /Mixer -->
 

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -59,8 +59,8 @@ Description:
           <!-- Decks / General -->
           <WidgetGroup><!-- 4 buttons -->
             <ObjectName>SkinSettingsCategory</ObjectName>
-            <MinimumSize>180f,100</MinimumSize>
-            <MaximumSize>180f,125</MaximumSize>
+            <MinimumSize>180f,90</MinimumSize>
+            <MaximumSize>180f,115</MaximumSize>
             <SizePolicy>me,me</SizePolicy>
             <Layout>vertical</Layout>
             <Children>
@@ -127,23 +127,6 @@ Description:
                     <SetVariable name="state_1_text"> &#10004; Rate Control</SetVariable>
                     <SetVariable name="width">110</SetVariable>
                     <SetVariable name="Setting">[Master],show_rate_control</SetVariable>
-                  </Template>
-                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
-                </Children>
-              </WidgetGroup>
-
-              <WidgetGroup><!-- BPM Top Bar toogle -->
-                <Layout>stacked</Layout>
-                <MinimumSize>180,13</MinimumSize>
-                <MaximumSize>180,17</MaximumSize>
-                <SizePolicy>me,me</SizePolicy>
-                <Children>
-                  <Template src="skin:skin_settings_button_2state.xml">
-                    <SetVariable name="TooltipId">bmp_top_bar_toogle</SetVariable>
-                    <SetVariable name="state_0_text">      BPM in Top Bar</SetVariable>
-                    <SetVariable name="state_1_text"> &#10004; BPM in Top Bar</SetVariable>
-                    <SetVariable name="width">110</SetVariable>
-                    <SetVariable name="Setting">[Master],show_bpm_in_top_bar</SetVariable>
                   </Template>
                   <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
                 </Children>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -16,6 +16,8 @@ Description:
     <Layout>horizontal</Layout>
     <Size>180f,1me</Size>
     <Children>
+      <WidgetGroup><Size>3f,1me</Size></WidgetGroup>
+      
       <WidgetGroup>
         <ObjectName>SkinSettings</ObjectName>
         <Layout>vertical</Layout>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -67,23 +67,6 @@ Description:
             <Layout>vertical</Layout>
             <Children>
 
-              <WidgetGroup><!-- Preview Deck toogle -->
-                <Layout>stacked</Layout>
-                <MinimumSize>180,13</MinimumSize>
-                <MaximumSize>180,17</MaximumSize>
-                <SizePolicy>me,me</SizePolicy>
-                <Children>
-                  <Template src="skin:skin_settings_button_2state.xml">
- 					<SetVariable name="TooltipId">show_previewdeck</SetVariable>
-                    <SetVariable name="state_0_text">&#9744;  Preview Deck</SetVariable>
-                    <SetVariable name="state_1_text"> &#10004; Preview Deck</SetVariable>
-                    <SetVariable name="width">110</SetVariable>
-                    <SetVariable name="Setting">[PreviewDeck],show_previewdeck</SetVariable>
-                  </Template>
-                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
-                </Children>
-              </WidgetGroup>
-
               <WidgetGroup><!-- 2/4 Decks toogle -->
                 <Layout>stacked</Layout>
                 <MinimumSize>180,13</MinimumSize>
@@ -363,7 +346,58 @@ Description:
               </WidgetGroup><!-- /Super knobs -->
 
             </Children>
-          </WidgetGroup><!-- /Effects -->
+          </WidgetGroup><!-- /Miscellaneous -->
+          <!-- Effects -->
+          <Label>
+            <ObjectName>CategoryLabel</ObjectName>
+            <Text>Miscellaneous</Text>
+            <Size>180f,21f</Size>
+          </Label>
+
+          <WidgetGroup><!-- 4 buttons -->
+            <ObjectName>SkinSettingsCategory</ObjectName>
+            <MinimumSize>180,58</MinimumSize>
+            <MaximumSize>180,84</MaximumSize>
+            <SizePolicy>me,me</SizePolicy>
+            <Layout>vertical</Layout>
+            <Children>
+              <WidgetGroup><!-- Preview Deck -->
+                <Layout>stacked</Layout>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <!-- index 0 due to bug -->
+                  <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
+
+                  <Template src="skin:skin_settings_button_2state.xml">
+ 					<SetVariable name="TooltipId">show_previewdeck</SetVariable>
+                    <SetVariable name="state_0_text">&#9744;  Preview Deck</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; Preview Deck</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[PreviewDeck],show_previewdeck</SetVariable>
+                  </Template>
+                </Children>
+              </WidgetGroup><!-- /Preview Deck -->
+
+              <WidgetGroup><!-- coverart toogle -->
+                <Layout>stacked</Layout>
+                <MinimumSize>180,13</MinimumSize>
+                <MaximumSize>180,17</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Children>
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="state_0_text">&#9744;  Cover Art</SetVariable>
+                    <SetVariable name="state_1_text"> &#10004; Cover Art</SetVariable>
+                    <SetVariable name="width">110</SetVariable>
+                    <SetVariable name="Setting">[Library],show_coverart</SetVariable>
+                  </Template>
+                  <WidgetGroup><SizePolicy>me,min</SizePolicy></WidgetGroup>
+                </Children>
+              </WidgetGroup>
+
+            </Children>
+          </WidgetGroup><!-- /Miscellaneous -->
         </Children>
       </WidgetGroup><!-- /SkinSettings -->
     </Children>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -75,7 +75,7 @@ Description:
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
  					<SetVariable name="TooltipId">show_previewdeck</SetVariable>
-                    <SetVariable name="state_0_text">      Preview Deck</SetVariable>
+                    <SetVariable name="state_0_text">&#9744;  Preview Deck</SetVariable>
                     <SetVariable name="state_1_text"> &#10004; Preview Deck</SetVariable>
                     <SetVariable name="width">110</SetVariable>
                     <SetVariable name="Setting">[PreviewDeck],show_previewdeck</SetVariable>
@@ -92,7 +92,7 @@ Description:
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
                     <SetVariable name="TooltipId">toggle_4decks</SetVariable>
-                    <SetVariable name="state_0_text">      4 Decks</SetVariable>
+                    <SetVariable name="state_0_text">&#9744;  4 Decks</SetVariable>
                     <SetVariable name="state_1_text"> &#10004; 4 Decks</SetVariable>
                     <SetVariable name="width">110</SetVariable>
                     <SetVariable name="Setting">[Master],show_4decks</SetVariable>
@@ -109,7 +109,7 @@ Description:
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
                     <SetVariable name="TooltipId">hotcue_toggle</SetVariable>
-                    <SetVariable name="state_0_text">      8 Hotcues</SetVariable>
+                    <SetVariable name="state_0_text">&#9744;  8 Hotcues</SetVariable>
                     <SetVariable name="state_1_text"> &#10004; 8 Hotcues</SetVariable>
                     <SetVariable name="width">110</SetVariable>
                     <SetVariable name="Setting">[Skin],8_hotcues</SetVariable>
@@ -126,7 +126,7 @@ Description:
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
                     <SetVariable name="TooltipId">rate_toggle</SetVariable>
-                    <SetVariable name="state_0_text">      Rate Control</SetVariable>
+                    <SetVariable name="state_0_text">&#9744;  Rate Control</SetVariable>
                     <SetVariable name="state_1_text"> &#10004; Rate Control</SetVariable>
                     <SetVariable name="width">110</SetVariable>
                     <SetVariable name="Setting">[Master],show_rate_control</SetVariable>
@@ -143,7 +143,7 @@ Description:
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
                     <SetVariable name="TooltipId">show_spinny</SetVariable>
-                    <SetVariable name="state_0_text">      Spinny</SetVariable>
+                    <SetVariable name="state_0_text">&#9744;  Spinny</SetVariable>
                     <SetVariable name="state_1_text"> &#10004; Spinny</SetVariable>
                     <SetVariable name="width">110</SetVariable>
                     <SetVariable name="Setting">[Spinny],show_spinnies</SetVariable>
@@ -160,7 +160,7 @@ Description:
                 <Children>
                   <Template src="skin:skin_settings_button_2state.xml">
                     <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
-                    <SetVariable name="state_0_text">      Vinyl Control</SetVariable>
+                    <SetVariable name="state_0_text">&#9744;  Vinyl Control</SetVariable>
                     <SetVariable name="state_1_text"> &#10004; Vinyl Control</SetVariable>
                     <SetVariable name="width">110</SetVariable>
                     <SetVariable name="Setting">[VinylControl],show_vinylcontrol</SetVariable>
@@ -212,7 +212,7 @@ Description:
                   </WidgetGroup>
 
                   <Template src="skin:skin_settings_button_2state.xml">
-                    <SetVariable name="state_0_text">      EQ Knobs</SetVariable>
+                    <SetVariable name="state_0_text">&#9744;  EQ Knobs</SetVariable>
                     <SetVariable name="state_1_text"> &#10004; EQ Knobs</SetVariable>
                     <SetVariable name="Setting">[Master],show_eqs</SetVariable>
                   </Template>
@@ -243,7 +243,7 @@ Description:
                   </WidgetGroup>
 
                   <Template src="skin:skin_settings_button_2state.xml">
-                    <SetVariable name="state_0_text">      EQ Kill</SetVariable>
+                    <SetVariable name="state_0_text">&#9744;  EQ Kill</SetVariable>
                     <SetVariable name="state_1_text"> &#10004; EQ Kill</SetVariable>
                     <SetVariable name="Setting">[Master],show_eq_kill_buttons</SetVariable>
                   </Template>
@@ -274,7 +274,7 @@ Description:
                   </WidgetGroup>
 
                   <Template src="skin:skin_settings_button_2state.xml">
-                    <SetVariable name="state_1_text">      Crossfader</SetVariable>
+                    <SetVariable name="state_1_text">&#9744;  Crossfader</SetVariable>
                     <SetVariable name="state_0_text"> &#10004; Crossfader</SetVariable>
                     <SetVariable name="Setting">[Master],show_xfader</SetVariable>
                   </Template>
@@ -325,7 +325,7 @@ Description:
                   </WidgetGroup>
 
                   <Template src="skin:skin_settings_button_2state.xml">
-                    <SetVariable name="state_0_text">      4 EFFECT UNITS</SetVariable>
+                    <SetVariable name="state_0_text">&#9744;  4 EFFECT UNITS</SetVariable>
                     <SetVariable name="state_1_text"> &#10004; 4 EFFECT UNITS</SetVariable>
                     <SetVariable name="Setting">[Master],show_4effectunits</SetVariable>
                   </Template>
@@ -355,7 +355,7 @@ Description:
                   </WidgetGroup>
 
                   <Template src="skin:skin_settings_button_2state.xml">
-                    <SetVariable name="state_0_text">      Super Knobs</SetVariable>
+                    <SetVariable name="state_0_text">&#9744;  Super Knobs</SetVariable>
                     <SetVariable name="state_1_text"> &#10004; Super Knobs</SetVariable>
                     <SetVariable name="Setting">[Master],show_superknobs</SetVariable>
                   </Template>

--- a/res/skins/LateNight/skin_settings_button_2state.xml
+++ b/res/skins/LateNight/skin_settings_button_2state.xml
@@ -1,0 +1,34 @@
+<!--
+Description:
+  2-state button for skin settings menu.
+  Can be squeezed so that all skin settings categories fit on small screens.
+Variables:
+  width         :
+  state_X_text  : label text for state X
+  Setting       : persistent left-click control
+-->
+<Template>
+  <PushButton>
+    <TooltipId><Variable name="TooltipId"/></TooltipId>
+    <ObjectName>SkinSettingsButton</ObjectName>
+    <MinimumSize><Variable name="width"/>,13</MinimumSize>
+    <MaximumSize>182,17</MaximumSize>
+    <SizePolicy>min,me</SizePolicy>
+    <NumberStates>2</NumberStates>d
+    <RightClickIsPushButton>false</RightClickIsPushButton>
+    <State>
+      <Number>0</Number>
+      <Text><Variable name="state_0_text"/></Text>
+      <Alignment>left</Alignment>
+    </State>
+    <State>
+      <Number>1</Number>
+      <Text><Variable name="state_1_text"/></Text>
+      <Alignment>left</Alignment>
+    </State>
+    <Connection>
+      <ConfigKey persist="true"><Variable name="Setting"/></ConfigKey>
+      <ButtonState>LeftButton</ButtonState>
+    </Connection>
+  </PushButton>
+</Template>

--- a/res/skins/LateNight/skin_settings_labelbutton_2state.xml
+++ b/res/skins/LateNight/skin_settings_labelbutton_2state.xml
@@ -1,0 +1,34 @@
+<!--
+Description:
+  2-state button for skin settings menu.
+  Can be squeezed so that all skin settings categories fit on small screens.
+Variables:
+  width         :
+  state_X_text  : label text for state X
+  Setting       : persistent left-click control
+-->
+<Template>
+  <PushButton>
+    <TooltipId><Variable name="TooltipId"/></TooltipId>
+    <ObjectName>SkinSettingsLabelButton</ObjectName>
+    <MinimumSize><Variable name="width"/>,21</MinimumSize>
+    <MaximumSize>200,21</MaximumSize>
+    <SizePolicy>min,me</SizePolicy>
+    <NumberStates>2</NumberStates>d
+    <RightClickIsPushButton>false</RightClickIsPushButton>
+    <State>
+      <Number>0</Number>
+      <Text><Variable name="state_0_text"/></Text>
+      <Alignment>left</Alignment>
+    </State>
+    <State>
+      <Number>1</Number>
+      <Text><Variable name="state_1_text"/></Text>
+      <Alignment>left</Alignment>
+    </State>
+    <Connection>
+      <ConfigKey persist="true"><Variable name="Setting"/></ConfigKey>
+      <ButtonState>LeftButton</ButtonState>
+    </Connection>
+  </PushButton>
+</Template>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -568,6 +568,78 @@ WEffectButtonParameter*/
 }
 
 /*################################################################
+ #######  Skin Settings  ########################################
+##############################################################*/
+
+#SkinSettingsContainer{
+  margin-left: 5px;
+  
+}
+
+#SkinSettings {
+  qproperty-layoutAlignment: 'AlignLeft | AlignTop';
+  padding: 2px 0px 0px 0px;
+  text-align: left;
+
+}
+#SkinSettingsHeader {
+  qproperty-layoutAlignment: 'AlignLeft | AlignTop';
+  padding-right: 2px;
+  }
+  #SkinSettingsClose {
+    border-radius:2px;
+    margin-bottom: 4px;
+    background-color: transparent;
+    image: url(skin:/buttons/btn_skinsettings_close.svg) no-repeat center top;
+    }
+    #SkinSettingsClose:hover {
+      border-radius:2px;
+      margin-bottom: 4px;
+      background-color: #0f0f0f;
+      image: url(skin:/buttons/btn_skinsettings_close_hover.svg) no-repeat center top;
+    }
+
+#SkinSettingsCategory {
+  padding: 2px 8px 1px 10px;
+  qproperty-layoutAlignment: 'AlignLeft | AlignTop';
+    border: 1px solid #1e1e1e;
+    border-width: 0px 0px 3px 0px;
+  }
+  #CategoryLabel {
+    font-size: 17px/17px;
+    text-align: left;
+    padding: 5px 0px 0px 3px;
+    color: #eece33;
+  }
+#SkinSettingsButton {
+  padding-top: 1px;
+  font-size: 12px/14px;
+  color: #d2d2d2;
+  }
+
+  #SkinSettingsButton[displayValue="0"] {
+    background-color: none;
+  }
+  #SkinSettingsButton[displayValue="1"],
+  #SkinSettingsButton[displayValue="2"] {
+    background-color: #0f0f0f;
+    color: #eeeeee;
+  }
+  #SkinSettingsButton[displayValue="0"]:hover,
+  #SkinSettingsButton[displayValue="1"]:hover,
+  #SkinSettingsButton[displayValue="2"]:hover {
+    background-color: #202020;
+  }
+
+#SkinSettingsLabelButton {
+    font-size: 17px/17px;
+    text-align: left;
+    padding: 5px 0px 0px 3px;
+    color: #eece33;
+  }
+
+
+/*################################################################
 #######  Loop Controls  ########################################
 ##############################################################*/
 

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -480,7 +480,8 @@ WEffectButtonParameter*/
   border-radius: 2px;
   }
 
-  #GuiToggleButton {
+  #GuiToggleButton,
+  #RecBox {
     margin: 2px;
   }
 

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -614,15 +614,6 @@ WEffectButtonParameter*/
   color: #d2d2d2;
   }
 
-  #SkinSettingsButton[displayValue="0"] {
-    background-color: none;
-  }
-  #SkinSettingsButton[displayValue="1"],
-  #SkinSettingsButton[displayValue="2"] {
-    background-color: #0f0f0f;
-    color: #eeeeee;
-  }
-
 #SkinSettingsLabelButton {
     font-size: 17px/17px;
     text-align: left;

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -595,12 +595,6 @@ WEffectButtonParameter*/
     background-color: transparent;
     image: url(skin:/buttons/btn_skinsettings_close.svg) no-repeat center top;
     }
-    #SkinSettingsClose:hover {
-      border-radius:2px;
-      margin-bottom: 4px;
-      background-color: #0f0f0f;
-      image: url(skin:/buttons/btn_skinsettings_close_hover.svg) no-repeat center top;
-    }
 
 #SkinSettingsCategory {
   padding: 2px 8px 1px 10px;
@@ -627,11 +621,6 @@ WEffectButtonParameter*/
   #SkinSettingsButton[displayValue="2"] {
     background-color: #0f0f0f;
     color: #eeeeee;
-  }
-  #SkinSettingsButton[displayValue="0"]:hover,
-  #SkinSettingsButton[displayValue="1"]:hover,
-  #SkinSettingsButton[displayValue="2"]:hover {
-    background-color: #202020;
   }
 
 #SkinSettingsLabelButton {

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -622,7 +622,7 @@ WEffectButtonParameter*/
   }
 
 #SubmenuCover {
-  background-color: rgba(51, 51, 51, 127);
+  background-color: rgba(15, 15, 15, 180);
 }
 
 /*################################################################

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -573,7 +573,9 @@ WEffectButtonParameter*/
 ##############################################################*/
 
 #SkinSettingsContainer{
-  margin-left: 5px;
+/*  margin-left: 5px;*/
+  border: 1px solid #585858;
+  border-width: 0px 0px 1px 1px;
   
 }
 
@@ -1067,15 +1069,11 @@ border: 0px;
   border-top: 1px solid #585858;
   /*border-bottom: 1px solid #585858;*/
   padding-bottom: 0px;
-  padding-left: 5px;
-  padding-right: 5px;
   padding-top: 5px;
 }
 
 #SamplerDeck {
   margin-top: 5px;
-  margin-left: 5px;
-  margin-right: 5px;
   border: 1px solid #585858;
   background-color: #1e1e1e;
 }
@@ -1170,11 +1168,11 @@ border: 0px;
 }
 
 #EffectUnit1, #EffectUnit3 {
-  margin: 5px 5px 2px 2px;
+  margin: 5px 5px 2px 0px;
 }
 
 #EffectUnit2, #EffectUnit4 {
-  margin: 5px 2px 2px 5px;
+  margin: 5px 0px 2px 5px;
 }
 
 #EffectRows {

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -621,6 +621,9 @@ WEffectButtonParameter*/
     color: #eece33;
   }
 
+#SubmenuCover {
+  background-color: rgba(51, 51, 51, 127);
+}
 
 /*################################################################
 #######  Loop Controls  ########################################

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -101,6 +101,11 @@
             </Connection>
           </PushButton>
 
+          <WidgetGroup>
+            <ObjectName>ToolbarDivider</ObjectName>
+            <Size>13f,9min</Size>
+          </WidgetGroup>
+
           <PushButton>
             <Size>69f,24f</Size>
             <TooltipId>show_samplers</TooltipId>

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -238,7 +238,7 @@
               <Text>SETTINGS</Text>
           </State>
           <Connection>
-            <ConfigKey persist="true">[Latenight],skin_settings</ConfigKey>
+            <ConfigKey persist="true">[Master],skin_settings</ConfigKey>
           </Connection>
          </PushButton>
 

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -38,29 +38,6 @@
           </WidgetGroup>
 
           <PushButton>
-            <Size>56f,24f</Size>
-            <TooltipId>toggle_4decks</TooltipId>
-            <ObjectName>GuiToggleButton</ObjectName>
-            <NumberStates>2</NumberStates>
-            <State>
-              <Number>0</Number>
-              <Text>4 DECKS</Text>
-            </State>
-            <State>
-              <Number>1</Number>
-              <Text>4 DECKS</Text>
-            </State>
-            <Connection>
-              <ConfigKey persist="true">[Master],show_4decks</ConfigKey>
-            </Connection>
-          </PushButton>
-
-          <WidgetGroup>
-            <ObjectName>ToolbarDivider</ObjectName>
-            <Size>13f,9min</Size>
-          </WidgetGroup>
-
-          <PushButton>
             <Size>46f,24f</Size>
             <TooltipId>show_mixer</TooltipId>
             <ObjectName>GuiToggleButton</ObjectName>
@@ -105,24 +82,6 @@
             <ObjectName>ToolbarDivider</ObjectName>
             <Size>13f,9min</Size>
           </WidgetGroup>
-
-          <PushButton>
-            <Size>61f,24f</Size>
-            <TooltipId>show_previewdeck</TooltipId>
-            <ObjectName>GuiToggleButton</ObjectName>
-            <NumberStates>2</NumberStates>
-            <State>
-              <Number>0</Number>
-              <Text>PREVIEW</Text>
-            </State>
-            <State>
-              <Number>1</Number>
-              <Text>PREVIEW</Text>
-            </State>
-            <Connection>
-              <ConfigKey persist="true">[PreviewDeck],show_previewdeck</ConfigKey>
-            </Connection>
-          </PushButton>
 
           <PushButton>
             <Size>59f,24f</Size>

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -142,7 +142,7 @@
       <WidgetGroup><!-- Recording button & recording duration label -->
         <ObjectName>RecBox</ObjectName>
         <Layout>stacked</Layout>
-        <Size>72f,22f</Size>
+        <Size>72f,24f</Size>
         <!-- minus 1px border
             = 70x18 available for text -->
         <Children>
@@ -150,22 +150,22 @@
           <Template src="skin:button_2state.xml">
             <SetVariable name="ObjectName">RecButton</SetVariable>
             <SetVariable name="TooltipId">toggle_recording</SetVariable>
-            <SetVariable name="Size">70f,18f</SetVariable>
+            <SetVariable name="Size">68f,20f</SetVariable>
             <SetVariable name="ConfigKey">[Recording],toggle_recording</SetVariable>
           </Template>
 
           <WidgetGroup><!-- Rec dot + RecDuration -->
             <Layout>horizontal</Layout>
-            <Size>70me,18me</Size>
+            <Size>68f,18f</Size>
             <Children>
               <Label>
                 <ObjectName>RecDot</ObjectName>
-                <Size>15me,18me</Size>
+                <Size>15f,18f</Size>
               </Label>  
 
               <RecordingDuration>
                 <ObjectName>RecDuration</ObjectName>
-                <Size>55me,18me</Size>
+                <Size>53f,18f</Size>
                 <InactiveText>REC</InactiveText>
                 <Alignment>center</Alignment>
               </RecordingDuration>
@@ -176,7 +176,7 @@
           <Template src="skin:button_3state_display.xml">
             <SetVariable name="ObjectName">RecFeedback</SetVariable>
             <SetVariable name="TooltipId">toggle_recording</SetVariable>
-            <SetVariable name="Size">70me,18me</SetVariable>
+            <SetVariable name="Size">66f,18f</SetVariable>
             <SetVariable name="ConfigKey">[Recording],toggle_recording</SetVariable>
             <SetVariable name="ConfigKeyDisp">[Recording],status</SetVariable>
           </Template>

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -160,29 +160,6 @@
             </Connection>
           </PushButton>
 
-          <WidgetGroup>
-            <ObjectName>ToolbarDivider</ObjectName>
-            <Size>13f,9min</Size>
-          </WidgetGroup>
-
-          <PushButton>
-            <Size>69f,24f</Size>
-            <TooltipId>skin_settings</TooltipId>
-            <ObjectName>GuiToggleButton</ObjectName>
-            <NumberStates>2</NumberStates>
-            <State>
-              <Number>0</Number>
-              <Text>SETTINGS</Text>
-           </State>
-           <State>
-              <Number>1</Number>
-              <Text>SETTINGS</Text>
-          </State>
-          <Connection>
-            <ConfigKey persist="true">[Latenight],skin_settings</ConfigKey>
-          </Connection>
-         </PushButton>
-
         </Children>
         <Connection>
           <ConfigKey>[Master],maximize_library</ConfigKey>
@@ -241,6 +218,29 @@
           </Template>
         </Children>
       </WidgetGroup><!-- /Recording button & recording duration label -->
+
+      <WidgetGroup>
+        <ObjectName>ToolbarDivider</ObjectName>
+        <Size>15f,9min</Size>
+      </WidgetGroup>
+
+          <PushButton>
+            <Size>69f,24f</Size>
+            <TooltipId>skin_settings</TooltipId>
+            <ObjectName>GuiToggleButton</ObjectName>
+            <NumberStates>2</NumberStates>
+            <State>
+              <Number>0</Number>
+              <Text>SETTINGS</Text>
+           </State>
+           <State>
+              <Number>1</Number>
+              <Text>SETTINGS</Text>
+          </State>
+          <Connection>
+            <ConfigKey persist="true">[Latenight],skin_settings</ConfigKey>
+          </Connection>
+         </PushButton>
 
       <WidgetGroup> <!-- Spacer -->
         <Layout>horizontal</Layout>

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -55,42 +55,6 @@
             </Connection>
           </PushButton>
 
-          <PushButton>
-            <Size>61f,24f</Size>
-            <TooltipId>show_spinny</TooltipId>
-            <ObjectName>GuiToggleButton</ObjectName>
-            <NumberStates>2</NumberStates>
-            <State>
-              <Number>0</Number>
-              <Text>SPINNIES</Text>
-            </State>
-            <State>
-              <Number>1</Number>
-              <Text>SPINNIES</Text>
-            </State>
-            <Connection>
-              <ConfigKey persist="true">[Spinny],show_spinnies</ConfigKey>
-            </Connection>
-          </PushButton>
-
-          <PushButton>
-            <Size>44f,24f</Size>
-            <TooltipId>show_vinylcontrol</TooltipId>
-            <ObjectName>GuiToggleButton</ObjectName>
-            <NumberStates>2</NumberStates>
-            <State>
-              <Number>0</Number>
-              <Text>VINYL</Text>
-            </State>
-            <State>
-              <Number>1</Number>
-              <Text>VINYL</Text>
-            </State>
-            <Connection>
-              <ConfigKey persist="true">[VinylControl],show_vinylcontrol</ConfigKey>
-            </Connection>
-          </PushButton>
-
           <WidgetGroup>
             <ObjectName>ToolbarDivider</ObjectName>
             <Size>13f,9min</Size>
@@ -115,71 +79,6 @@
           </PushButton>
 
           <WidgetGroup>
-            <SizePolicy>min,min</SizePolicy>
-            <Layout>horizontal</Layout>
-            <Children>
-              <PushButton>
-                <Size>44f,24f</Size>
-                <ObjectName>GuiToggleButton</ObjectName>
-                <NumberStates>2</NumberStates>
-                <State>
-                  <Number>0</Number>
-                  <Text>EQ</Text>
-                </State>
-                <State>
-                  <Number>1</Number>
-                  <Text>EQ</Text>
-                </State>
-                <Connection>
-                  <ConfigKey persist="true">[Master],show_eqs</ConfigKey>
-                </Connection>
-              </PushButton>
-            </Children>
-            <Connection>
-              <ConfigKey persist="true">[Master],show_mixer</ConfigKey>
-              <BindProperty>visible</BindProperty>
-            </Connection>
-          </WidgetGroup>
-
-          <WidgetGroup>
-            <SizePolicy>min,min</SizePolicy>
-            <Layout>horizontal</Layout>
-            <Children>
-              <WidgetGroup>
-                <SizePolicy>min,min</SizePolicy>
-                <Layout>horizontal</Layout>
-                <Children>
-                  <PushButton>
-                    <Size>54f,24f</Size>
-                    <ObjectName>GuiToggleButton</ObjectName>
-                    <NumberStates>2</NumberStates>
-                    <State>
-                      <Number>0</Number>
-                      <Text>EQ KILL</Text>
-                    </State>
-                    <State>
-                      <Number>1</Number>
-                      <Text>EQ KILL</Text>
-                    </State>
-                    <Connection>
-                      <ConfigKey persist="true">[Master],show_eq_kill_buttons</ConfigKey>
-                    </Connection>
-                  </PushButton>
-                </Children>
-                <Connection>
-                  <ConfigKey persist="true">[Master],show_eqs</ConfigKey>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
-            </Children>
-            <Connection>
-              <ConfigKey persist="true">[Master],show_mixer</ConfigKey>
-              <BindProperty>visible</BindProperty>
-            </Connection>
-          </WidgetGroup>
-
-
-          <WidgetGroup>
             <ObjectName>ToolbarDivider</ObjectName>
             <Size>13f,9min</Size>
           </WidgetGroup>
@@ -201,51 +100,6 @@
               <ConfigKey persist="true">[EffectRack1],show</ConfigKey>
             </Connection>
           </PushButton>
-
-          <PushButton>
-            <Size>94f,24f</Size>
-            <TooltipId>show_effects</TooltipId>
-            <ObjectName>GuiToggleButton</ObjectName>
-            <NumberStates>2</NumberStates>
-            <State>
-              <Number>0</Number>
-              <Text>4 EFFECT UNITS</Text>
-            </State>
-            <State>
-              <Number>1</Number>
-              <Text>4 EFFECT UNITS</Text>
-            </State>
-            <Connection>
-              <ConfigKey persist="true">[Master],show_4effectunits</ConfigKey>
-            </Connection>
-          </PushButton>
-
-          <WidgetGroup>
-            <SizePolicy>min,min</SizePolicy>
-            <Layout>horizontal</Layout>
-            <Children>
-              <PushButton>
-                <Size>88f,24f</Size>
-                <ObjectName>GuiToggleButton</ObjectName>
-                <NumberStates>2</NumberStates>
-                <State>
-                  <Number>0</Number>
-                  <Text>Super knobs</Text>
-                </State>
-                <State>
-                  <Number>1</Number>
-                  <Text>Super knobs</Text>
-                </State>
-                <Connection>
-                  <ConfigKey persist="true">[Master],show_superknobs</ConfigKey>
-                </Connection>
-              </PushButton>
-            </Children>
-            <Connection>
-              <ConfigKey persist="true">[EffectRack1],show</ConfigKey>
-              <BindProperty>visible</BindProperty>
-            </Connection>
-          </WidgetGroup>
 
           <WidgetGroup>
             <ObjectName>ToolbarDivider</ObjectName>
@@ -305,6 +159,30 @@
               <ConfigKey persist="true">[Samplers],show_samplers</ConfigKey>
             </Connection>
           </PushButton>
+
+          <WidgetGroup>
+            <ObjectName>ToolbarDivider</ObjectName>
+            <Size>13f,9min</Size>
+          </WidgetGroup>
+
+          <PushButton>
+            <Size>69f,24f</Size>
+            <TooltipId>skin_settings</TooltipId>
+            <ObjectName>GuiToggleButton</ObjectName>
+            <NumberStates>2</NumberStates>
+            <State>
+              <Number>0</Number>
+              <Text>SETTINGS</Text>
+           </State>
+           <State>
+              <Number>1</Number>
+              <Text>SETTINGS</Text>
+          </State>
+          <Connection>
+            <ConfigKey persist="true">[Latenight],skin_settings</ConfigKey>
+          </Connection>
+         </PushButton>
+
         </Children>
         <Connection>
           <ConfigKey>[Master],maximize_library</ConfigKey>

--- a/res/skins/LateNight/vinyl_controls.xml
+++ b/res/skins/LateNight/vinyl_controls.xml
@@ -2,12 +2,12 @@
   <WidgetGroup>
     <ObjectName>VinylControls</ObjectName>
     <Layout>horizontal</Layout>
-    <SizePolicy>max,min</SizePolicy>
+    <SizePolicy>max,f</SizePolicy>
     <Children>
 
       <WidgetGroup>
         <ObjectName>AlignVCenter</ObjectName>
-        <SizePolicy>min,min</SizePolicy>
+        <SizePolicy>f,f</SizePolicy>
         <Layout>horizontal</Layout>
         <Children>
           <StatusLight>

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -392,6 +392,9 @@ void Tooltips::addStandardTooltips() {
     add("hotcue_toggle")
         <<tr("Toggle displayed hotcue, 4 or 8");
 
+    // Show Rate Control
+    add("rate_toggle")
+        <<tr("Toggle visibility of Rate Control");
 
     // Used in cue/hotcue/loop tooltips below.
     QString quantizeSnap = tr("If quantize is enabled, snaps to the nearest beat.");

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -396,11 +396,6 @@ void Tooltips::addStandardTooltips() {
     add("rate_toggle")
         <<tr("Toggle visibility of Rate Control");
 
-    // Show Rate Control
-    add("bmp_top_bar_toogle")
-        <<tr("Toggle visibility of BPM in Top Bar of Deck");
-
-
     // Used in cue/hotcue/loop tooltips below.
     QString quantizeSnap = tr("If quantize is enabled, snaps to the nearest beat.");
     add("quantize")

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -388,6 +388,11 @@ void Tooltips::addStandardTooltips() {
             << tr("Prevents the pitch from changing when the rate changes.")
             << tr("Toggling keylock during playback may result in a momentary audio glitch.");
 
+    // Show 4/8 hotcue
+    add("hotcue_toggle")
+        <<tr("Toggle displayed hotcue, 4 or 8");
+
+
     // Used in cue/hotcue/loop tooltips below.
     QString quantizeSnap = tr("If quantize is enabled, snaps to the nearest beat.");
     add("quantize")

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -396,6 +396,11 @@ void Tooltips::addStandardTooltips() {
     add("rate_toggle")
         <<tr("Toggle visibility of Rate Control");
 
+    // Show Rate Control
+    add("bmp_top_bar_toogle")
+        <<tr("Toggle visibility of BPM in Top Bar of Deck");
+
+
     // Used in cue/hotcue/loop tooltips below.
     QString quantizeSnap = tr("If quantize is enabled, snaps to the nearest beat.");
     add("quantize")


### PR DESCRIPTION
follow up to:
 add Skin Settings to Latenight #1591 
but rebased on branch 2.1

edit:
this was an outdated printscreen, now here the one coresponding to the commited code (only change the ToolbarDivier added before the SETTINGS Button):
![latenight_skin_setting](https://user-images.githubusercontent.com/3403218/39005773-586155f8-4401-11e8-95ae-edfd9ef987b1.png)