### PR TITLE
Tango: change name of skin menu "Extras" to "Misc"

### DIFF
--- a/res/skins/Tango (64 Samplers)/skin_settings.xml
+++ b/res/skins/Tango (64 Samplers)/skin_settings.xml
@@ -743,10 +743,10 @@ Description:
             </Children>
           </WidgetGroup><!-- /Effects -->
 
-          <Label><!-- Extras -->
+          <Label><!-- Misc -->
             <ObjectName>CategoryLabel</ObjectName>
             <Size>200f,21f</Size>
-            <Text>Extras</Text>
+            <Text>Misc</Text>
           </Label>
           <WidgetGroup>
             <ObjectName>SkinSettingsCategory</ObjectName>
@@ -841,7 +841,7 @@ Description:
                 </Children>
               </WidgetGroup><!-- /Load/Save Sampler Bank -->
             </Children>
-          </WidgetGroup><!-- /Extras -->
+          </WidgetGroup><!-- /Misc -->
         </Children>
       </WidgetGroup><!-- /SkinSettings -->
     </Children>

--- a/res/skins/Tango/skin_settings.xml
+++ b/res/skins/Tango/skin_settings.xml
@@ -743,10 +743,10 @@ Description:
             </Children>
           </WidgetGroup><!-- /Effects -->
 
-          <Label><!-- Extras -->
+          <Label><!-- Misc -->
             <ObjectName>CategoryLabel</ObjectName>
             <Size>200f,21f</Size>
-            <Text>Extras</Text>
+            <Text>Misc</Text>
           </Label>
           <WidgetGroup>
             <ObjectName>SkinSettingsCategory</ObjectName>
@@ -839,7 +839,7 @@ Description:
                 </Children>
               </WidgetGroup><!-- /Load/Save Sampler Bank -->
             </Children>
-          </WidgetGroup><!-- /Extras -->
+          </WidgetGroup><!-- /Misc -->
         </Children>
       </WidgetGroup><!-- /SkinSettings -->
     </Children>


### PR DESCRIPTION
as requested by @ronso0 in #1623
 > "Misc" would work for me. Could you change that in Tango/Deere as well?