### PR TITLE
Latenight fix: group FX Buttons in deck

### DIFF
--- a/res/skins/LateNight/deck_row_1_keyVinylFx.xml
+++ b/res/skins/LateNight/deck_row_1_keyVinylFx.xml
@@ -99,94 +99,99 @@
         <SizePolicy>min,min</SizePolicy>
         <Children></Children>
       </WidgetGroup>
-
-      <!-- FX buttons 1-4 -->
-      <PushButton>
-        <Size>30f,22f</Size>
-        <TooltipId>EffectUnit_deck_enabled</TooltipId>
-        <ObjectName>FxAssignButton</ObjectName>
-        <NumberStates>2</NumberStates>
-        <State>
-          <Number>0</Number>
-          <Text>FX&#8202;1</Text>
-        </State>
-        <State>
-          <Number>1</Number>
-          <Text>FX&#8202;1</Text>
-        </State>
-        <Connection>
-          <ConfigKey>[EffectRack1_EffectUnit1],group_<Variable name="group"/>_enable</ConfigKey>
-          <ButtonState>LeftButton</ButtonState>
-        </Connection>
-      </PushButton>
-
-      <PushButton>
-        <Size>30f,22f</Size>
-        <TooltipId>EffectUnit_deck_enabled</TooltipId>
-        <ObjectName>FxAssignButton</ObjectName>
-        <NumberStates>2</NumberStates>
-        <State>
-          <Number>0</Number>
-          <Text>FX&#8202;2</Text>
-        </State>
-        <State>
-          <Number>1</Number>
-          <Text>FX&#8202;2</Text>
-        </State>
-        <Connection>
-          <ConfigKey>[EffectRack1_EffectUnit2],group_<Variable name="group"/>_enable</ConfigKey>
-          <ButtonState>LeftButton</ButtonState>
-        </Connection>
-      </PushButton>
-
+      
       <WidgetGroup>
         <Layout>horizontal</Layout>
-        <Connection>
-          <ConfigKey>[Master],show_4effectunits</ConfigKey>
-          <BindProperty>visible</BindProperty>
-        </Connection>
-        <Children>
-          <PushButton>
-            <Size>30f,22f</Size>
-            <TooltipId>EffectUnit_deck_enabled</TooltipId>
-            <ObjectName>FxAssignButton</ObjectName>
-            <NumberStates>2</NumberStates>
-            <State>
-              <Number>0</Number>
-              <Text>FX&#8202;3</Text>
-            </State>
-            <State>
-              <Number>1</Number>
-              <Text>FX&#8202;3</Text>
-            </State>
-            <Connection>
-              <ConfigKey>[EffectRack1_EffectUnit3],group_<Variable name="group"/>_enable</ConfigKey>
-              <ButtonState>LeftButton</ButtonState>
-            </Connection>
-          </PushButton>
+          <ObjectName>AlignRightTop</ObjectName>
+           <Children>
+            <!-- FX buttons 1-4 -->
+            <PushButton>
+              <Size>30f,22f</Size>
+              <TooltipId>EffectUnit_deck_enabled</TooltipId>
+              <ObjectName>FxAssignButton</ObjectName>
+              <NumberStates>2</NumberStates>
+              <State>
+                <Number>0</Number>
+                <Text>FX&#8202;1</Text>
+              </State>
+              <State>
+                <Number>1</Number>
+                <Text>FX&#8202;1</Text>
+              </State>
+              <Connection>
+                <ConfigKey>[EffectRack1_EffectUnit1],group_<Variable name="group"/>_enable</ConfigKey>
+                <ButtonState>LeftButton</ButtonState>
+              </Connection>
+            </PushButton>
 
-          <PushButton>
-            <Size>30f,22f</Size>
-            <TooltipId>EffectUnit_deck_enabled</TooltipId>
-            <ObjectName>FxAssignButton</ObjectName>
-            <NumberStates>2</NumberStates>
-            <State>
-              <Number>0</Number>
-              <Text>FX&#8202;4</Text>
-            </State>
-            <State>
-              <Number>1</Number>
-              <Text>FX&#8202;4</Text>
-            </State>
-            <Connection>
-              <ConfigKey>[EffectRack1_EffectUnit4],group_<Variable name="group"/>_enable</ConfigKey>
-              <ButtonState>LeftButton</ButtonState>
-            </Connection>
-          </PushButton>
-        </Children>
-      </WidgetGroup>
-      <!-- /FX buttons 1-4 -->
+            <PushButton>
+              <Size>30f,22f</Size>
+              <TooltipId>EffectUnit_deck_enabled</TooltipId>
+              <ObjectName>FxAssignButton</ObjectName>
+              <NumberStates>2</NumberStates>
+              <State>
+                <Number>0</Number>
+                <Text>FX&#8202;2</Text>
+              </State>
+              <State>
+                <Number>1</Number>
+                <Text>FX&#8202;2</Text>
+              </State>
+              <Connection>
+                <ConfigKey>[EffectRack1_EffectUnit2],group_<Variable name="group"/>_enable</ConfigKey>
+                <ButtonState>LeftButton</ButtonState>
+              </Connection>
+            </PushButton>
 
+            <WidgetGroup>
+              <Layout>horizontal</Layout>
+              <Connection>
+                <ConfigKey>[Master],show_4effectunits</ConfigKey>
+                <BindProperty>visible</BindProperty>
+              </Connection>
+              <Children>
+                <PushButton>
+                  <Size>30f,22f</Size>
+                  <TooltipId>EffectUnit_deck_enabled</TooltipId>
+                  <ObjectName>FxAssignButton</ObjectName>
+                  <NumberStates>2</NumberStates>
+                  <State>
+                    <Number>0</Number>
+                    <Text>FX&#8202;3</Text>
+                  </State>
+                  <State>
+                    <Number>1</Number>
+                    <Text>FX&#8202;3</Text>
+                  </State>
+                  <Connection>
+                    <ConfigKey>[EffectRack1_EffectUnit3],group_<Variable name="group"/>_enable</ConfigKey>
+                    <ButtonState>LeftButton</ButtonState>
+                  </Connection>
+                </PushButton>
+
+                <PushButton>
+                  <Size>30f,22f</Size>
+                  <TooltipId>EffectUnit_deck_enabled</TooltipId>
+                  <ObjectName>FxAssignButton</ObjectName>
+                  <NumberStates>2</NumberStates>
+                  <State>
+                    <Number>0</Number>
+                    <Text>FX&#8202;4</Text>
+                  </State>
+                  <State>
+                    <Number>1</Number>
+                    <Text>FX&#8202;4</Text>
+                  </State>
+                  <Connection>
+                    <ConfigKey>[EffectRack1_EffectUnit4],group_<Variable name="group"/>_enable</ConfigKey>
+                    <ButtonState>LeftButton</ButtonState>
+                  </Connection>
+                </PushButton>
+              </Children>
+            </WidgetGroup>
+            <!-- /FX buttons 1-4 -->
+      </Children>
+     </WidgetGroup>
     </Children>
   </WidgetGroup>
 </Template>


### PR DESCRIPTION
fix for 


> @ronso0 
Btw that space right to FX3/4 buttons looks weird.

=> the space between FX1/2 and FX3/4 is only visible if the window if wide enough, same for the space right to FX3/4.

=> fix: group and align all the FX buttons on top right

as it seems  #1623 may not go to 2.1.x here a separated PR with the FX Button fix

before:
![before_latenight](https://user-images.githubusercontent.com/3403218/39093025-2d99d768-4619-11e8-8d31-26e0eaf53955.png)

with this fix:
![after_latenight](https://user-images.githubusercontent.com/3403218/39093026-2f795b80-4619-11e8-8e4a-48aa0dd83a8d.png)
