### PR TITLE
lp1766042: Fix FLAC decoding (-6 dB) and upgrade DB schema

### DIFF
--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -77,9 +77,16 @@ SoundSource::OpenResult SoundSourceWV::tryOpen(
         m_sampleScaleFactor = CSAMPLE_PEAK;
     } else {
         const int bitsPerSample = WavpackGetBitsPerSample(m_wpc);
-        const uint32_t wavpackPeakSampleValue = 1u
-                << (bitsPerSample - 1);
-        m_sampleScaleFactor = CSAMPLE_PEAK / wavpackPeakSampleValue;
+        if (bitsPerSample > 0) {
+            const uint32_t wavpackPeakSampleValue = 1u
+                    << (bitsPerSample - 1);
+            m_sampleScaleFactor = CSAMPLE_PEAK / wavpackPeakSampleValue;
+        } else {
+            kLogger.warning()
+                    << "Invalid bits per sample:"
+                    << bitsPerSample;
+            return OpenResult::Aborted;
+        }
     }
 
     m_curFrameIndex = frameIndexMin();

--- a/plugins/soundsourcewv/soundsourcewv.cpp
+++ b/plugins/soundsourcewv/soundsourcewv.cpp
@@ -77,10 +77,12 @@ SoundSource::OpenResult SoundSourceWV::tryOpen(
         m_sampleScaleFactor = CSAMPLE_PEAK;
     } else {
         const int bitsPerSample = WavpackGetBitsPerSample(m_wpc);
-        if (bitsPerSample > 0) {
-            const uint32_t wavpackPeakSampleValue = 1u
-                    << (bitsPerSample - 1);
-            m_sampleScaleFactor = CSAMPLE_PEAK / wavpackPeakSampleValue;
+        if ((bitsPerSample >= 8) && (bitsPerSample <= 32)) {
+            // Range of signed sample values: [-2 ^ (bitsPerSample - 1), 2 ^ (bitsPerSample - 1) - 1]
+            const uint32_t absSamplePeak = 1u << (bitsPerSample - 1);
+            DEBUG_ASSERT(absSamplePeak > 0);
+            // Scaled range of sample values: [-CSAMPLE_PEAK, CSAMPLE_PEAK)
+            m_sampleScaleFactor = CSAMPLE_PEAK / absSamplePeak;
         } else {
             kLogger.warning()
                     << "Invalid bits per sample:"

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -386,7 +386,7 @@ METADATA
   <revision version="24" min_compatible="3">
     <description>
       Add cover art support. Default source is UNKNOWN and default type is NONE.
-      See library/coverart.h.
+      <!-- See library/coverart.h. -->
     </description>
     <sql>
       ALTER TABLE library ADD COLUMN coverart_source INTEGER DEFAULT 0;
@@ -419,7 +419,7 @@ METADATA
   <revision version="27" min_compatible="3">
     <description>
       Add cue color support. Default color is #FF0000.
-      See library/dao/cue.h.
+      <!-- See library/dao/cue.h. -->
     </description>
     <sql>
       <!-- Default color is #FFFF0000 (in base 10) -->
@@ -429,7 +429,7 @@ METADATA
   <revision version="28" min_compatible="3">
     <description>
       Reset replay gain info for all FLAC files after fixing a decoding bug in version 2.1.0.
-      See also: https://bugs.launchpad.net/mixxx/+bug/1766042
+      <!-- See also: https://bugs.launchpad.net/mixxx/+bug/1766042                     -->
     </description>
     <sql>
       <!-- Reset replay gain values to default -->

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -433,7 +433,7 @@ METADATA
     </description>
     <sql>
       <!-- Reset replay gain values to default -->
-      UPDATE library SET (replaygain,replaygain_peak)=(0.0,-1.0) WHERE filetype='flac';
+      UPDATE library SET (replaygain,replaygain_peak)=(0.0,-1.0) WHERE filetype='flac' COLLATE NOCASE;
     </sql>
   </revision>
 </schema>

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -426,4 +426,14 @@ METADATA
       ALTER TABLE cues ADD COLUMN color INTEGER DEFAULT 4294901760 NOT NULL;
     </sql>
   </revision>
+  <revision version="28" min_compatible="3">
+    <description>
+      Reset replay gain info for all FLAC files after fixing a decoding bug in version 2.1.0.
+      See also: https://bugs.launchpad.net/mixxx/+bug/1766042
+    </description>
+    <sql>
+      <!-- Reset replay gain values to default -->
+      UPDATE library SET (replaygain,replaygain_peak)=(0.0,-1.0) WHERE filetype='flac';
+    </sql>
+  </revision>
 </schema>

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -429,11 +429,13 @@ METADATA
   <revision version="28" min_compatible="3">
     <description>
       Reset replay gain info for all FLAC files after fixing a decoding bug in version 2.1.0.
+      <!-- The value of 'replaygain_peak' is not yet calculated by any Mixxx analyzer, -->
+      <!-- so we should leave it untouched and don't need to reset it here!            -->
       <!-- See also: https://bugs.launchpad.net/mixxx/+bug/1766042                     -->
     </description>
     <sql>
-      <!-- Reset replay gain values to default -->
-      UPDATE library SET (replaygain,replaygain_peak)=(0.0,-1.0) WHERE filetype='flac' COLLATE NOCASE;
+      <!-- Reset replay gain to default value -->
+      UPDATE library SET replaygain=0.0 WHERE filetype='flac' COLLATE NOCASE;
     </sql>
   </revision>
 </schema>

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -11,7 +11,7 @@
 const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
 
 //static
-const int MixxxDb::kRequiredSchemaVersion = 27;
+const int MixxxDb::kRequiredSchemaVersion = 28;
 
 namespace {
 

--- a/src/dialog/dlgabout.cpp
+++ b/src/dialog/dlgabout.cpp
@@ -83,17 +83,18 @@ DlgAbout::DlgAbout(QWidget* parent) : QDialog(parent), Ui::DlgAboutDlg() {
             << "Devananda van der Veen"
             << "Tatsuyuki Ishi"
             << "Kilian Feess"
-			<< "Conner Phillips"
-			<< "Daniel Poelzleithner"
+            << "Conner Phillips"
+            << "Daniel Poelzleithner"
             << "Artyom Lyan"
             << "Johan Lasperas"
             << "Olaf Hering"
             << "Stefan Weber"
             << "Eduardo Acero"
-			<< "Kshitij Gupta"
-			<< "Thomas Jarosch"
-			<< "Matthew Nicholson"
-			<< "ronso0";
+            << "Kshitij Gupta"
+            << "Thomas Jarosch"
+            << "Matthew Nicholson"
+            << "ronso0"
+            << "Jamie Gifford";
 
     QStringList specialThanks;
     specialThanks

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -437,7 +437,7 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
             // not set before
             m_bitsPerSample = bitsPerSample;
             m_sampleScaleFactor = CSAMPLE_PEAK
-                    / CSAMPLE(FLAC__int32(1) << bitsPerSample);
+                    / CSAMPLE(FLAC__int32(1) << (bitsPerSample - 1));
         } else {
             // already set before -> check for consistency
             if (bitsPerSample != m_bitsPerSample) {

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -435,13 +435,13 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
         DEBUG_ASSERT(kBitsPerSampleDefault != bitsPerSample);
         if (kBitsPerSampleDefault == m_bitsPerSample) {
             // not set before
-            if (bitsPerSample > 0) {
+            if ((bitsPerSample >= 8) && (bitsPerSample <= 32)) {
                 m_bitsPerSample = bitsPerSample;
-                // Range of signed(!) sample values: [2 ^ (bitsPerSample - 1), 2 ^ (bitsPerSample - 1) - 1]
-                // See also: https://bugs.launchpad.net/mixxx/+bug/1766042
-                const auto maxAbsSampleValue = FLAC__int32(1) << (bitsPerSample - 1);
-                // Scaled range of samples values: [-1.0, 1.0)
-                m_sampleScaleFactor = CSAMPLE_PEAK / CSAMPLE(maxAbsSampleValue);
+                // Range of signed) sample values: [-2 ^ (bitsPerSample - 1), 2 ^ (bitsPerSample - 1) - 1]
+                const uint32_t absSamplePeak = 1u << (bitsPerSample - 1);
+                DEBUG_ASSERT(absSamplePeak > 0);
+                // Scaled range of samples values: [-CSAMPLE_PEAK, CSAMPLE_PEAK)
+                m_sampleScaleFactor = CSAMPLE_PEAK / absSamplePeak;
             } else {
                 kLogger.warning()
                         << "Invalid bits per sample:"

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -436,8 +436,11 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
         if (kBitsPerSampleDefault == m_bitsPerSample) {
             // not set before
             m_bitsPerSample = bitsPerSample;
-            m_sampleScaleFactor = CSAMPLE_PEAK
-                    / CSAMPLE(FLAC__int32(1) << (bitsPerSample - 1));
+            // Range of signed(!) sample values: [2 ^ (bitsPerSample - 1), 2 ^ (bitsPerSample - 1) - 1]
+            // See also: https://bugs.launchpad.net/mixxx/+bug/1766042
+            const auto maxAbsSampleValue = FLAC__int32(1) << (bitsPerSample - 1);
+            // Scaled range of samples values: [-1.0, 1.0)
+            m_sampleScaleFactor = CSAMPLE_PEAK / CSAMPLE(maxAbsSampleValue);
         } else {
             // already set before -> check for consistency
             if (bitsPerSample != m_bitsPerSample) {

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -435,12 +435,18 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
         DEBUG_ASSERT(kBitsPerSampleDefault != bitsPerSample);
         if (kBitsPerSampleDefault == m_bitsPerSample) {
             // not set before
-            m_bitsPerSample = bitsPerSample;
-            // Range of signed(!) sample values: [2 ^ (bitsPerSample - 1), 2 ^ (bitsPerSample - 1) - 1]
-            // See also: https://bugs.launchpad.net/mixxx/+bug/1766042
-            const auto maxAbsSampleValue = FLAC__int32(1) << (bitsPerSample - 1);
-            // Scaled range of samples values: [-1.0, 1.0)
-            m_sampleScaleFactor = CSAMPLE_PEAK / CSAMPLE(maxAbsSampleValue);
+            if (bitsPerSample > 0) {
+                m_bitsPerSample = bitsPerSample;
+                // Range of signed(!) sample values: [2 ^ (bitsPerSample - 1), 2 ^ (bitsPerSample - 1) - 1]
+                // See also: https://bugs.launchpad.net/mixxx/+bug/1766042
+                const auto maxAbsSampleValue = FLAC__int32(1) << (bitsPerSample - 1);
+                // Scaled range of samples values: [-1.0, 1.0)
+                m_sampleScaleFactor = CSAMPLE_PEAK / CSAMPLE(maxAbsSampleValue);
+            } else {
+                kLogger.warning()
+                        << "Invalid bits per sample:"
+                        << bitsPerSample;
+            }
         } else {
             // already set before -> check for consistency
             if (bitsPerSample != m_bitsPerSample) {

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -435,7 +435,7 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
         DEBUG_ASSERT(kBitsPerSampleDefault != bitsPerSample);
         if (kBitsPerSampleDefault == m_bitsPerSample) {
             // not set before
-            if ((bitsPerSample >= 8) && (bitsPerSample <= 32)) {
+            if ((bitsPerSample >= 4) && (bitsPerSample <= 32)) {
                 m_bitsPerSample = bitsPerSample;
                 // Range of signed) sample values: [-2 ^ (bitsPerSample - 1), 2 ^ (bitsPerSample - 1) - 1]
                 const uint32_t absSamplePeak = 1u << (bitsPerSample - 1);


### PR DESCRIPTION
- https://bugs.launchpad.net/mixxx/+bug/1766042
- Follow-up of #1633
- Database schema upgrade that resets the replay gain info of all FLAC files
