### PR TITLE
lp1766094: Fix clearing of ReplayGain gain/ratio in file tags

### DIFF
--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -492,9 +492,8 @@ TagLib::ID3v2::CommentsFrame* findFirstCommentsFrame(
 }
 
 TagLib::ID3v2::CommentsFrame* findFirstCommentsFrameWithoutDescription(
-        const TagLib::ID3v2::Tag& tag,
-        bool preferNotEmpty = true) {
-    return findFirstCommentsFrame(tag, QString(), preferNotEmpty);
+        const TagLib::ID3v2::Tag& tag) {
+    return findFirstCommentsFrame(tag, QString());
 }
 
 // Finds the first text frame that with a matching description (case-insensitive).
@@ -538,10 +537,9 @@ TagLib::ID3v2::UserTextIdentificationFrame* findFirstUserTextIdentificationFrame
 inline
 QString readFirstUserTextIdentificationFrame(
         const TagLib::ID3v2::Tag& tag,
-        const QString& description,
-        bool preferNotEmpty = true) {
+        const QString& description) {
     const TagLib::ID3v2::UserTextIdentificationFrame* pTextFrame =
-            findFirstUserTextIdentificationFrame(tag, description, preferNotEmpty);
+            findFirstUserTextIdentificationFrame(tag, description);
     if (pTextFrame && (pTextFrame->fieldList().size() > 1)) {
         // The actual value is stored in the 2nd field
         return toQString(pTextFrame->fieldList()[1]);
@@ -628,7 +626,7 @@ void writeID3v2CommentsFrame(
         const QString& description,
         bool isNumericOrURL = false) {
     TagLib::ID3v2::CommentsFrame* pFrame =
-            findFirstCommentsFrame(*pTag, description);
+            findFirstCommentsFrame(*pTag, description, true);
     if (pFrame) {
         // Modify existing frame
         if (text.isEmpty()) {

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -227,13 +227,7 @@ bool parseBpm(TrackMetadata* pTrackMetadata, QString sBpm) {
 
 inline
 QString formatReplayGainGain(const ReplayGain& replayGain) {
-    const double gainRatio(replayGain.getRatio());
-    return ReplayGain::ratioToString(gainRatio);
-}
-
-inline
-bool hasTrackGain(const TrackMetadata& trackMetadata) {
-    return trackMetadata.getTrackInfo().getReplayGain().hasRatio();
+    return ReplayGain::ratioToString(replayGain.getRatio());
 }
 
 inline
@@ -1860,13 +1854,15 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
 
     writeID3v2TextIdentificationFrame(pTag, "TKEY", trackMetadata.getTrackInfo().getKey());
 
-    if (hasTrackGain(trackMetadata)) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "REPLAYGAIN_TRACK_GAIN",
-                formatTrackGain(trackMetadata),
-                true);
-    }
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "REPLAYGAIN_TRACK_GAIN",
+            formatTrackGain(trackMetadata),
+            true);
+    // NOTE(uklotzde, 2018-04-22): The analyzers currently doesn't
+    // calculate a peak value, so leave it untouched in the file if
+    // the value is invalid/absent. Otherwise the ID3 frame would
+    // be deleted.
     if (hasTrackPeak(trackMetadata)) {
         writeID3v2UserTextIdentificationFrame(
                 pTag,
@@ -2000,10 +1996,12 @@ bool exportTrackMetadataIntoAPETag(TagLib::APE::Tag* pTag, const TrackMetadata& 
     writeAPEItem(pTag, "INITIALKEY",
             toTagLibString(trackMetadata.getTrackInfo().getKey()));
 
-    if (hasTrackGain(trackMetadata)) {
-        writeAPEItem(pTag, "REPLAYGAIN_TRACK_GAIN",
-                toTagLibString(formatTrackGain(trackMetadata)));
-    }
+    writeAPEItem(pTag, "REPLAYGAIN_TRACK_GAIN",
+            toTagLibString(formatTrackGain(trackMetadata)));
+    // NOTE(uklotzde, 2018-04-22): The analyzers currently doesn't
+    // calculate a peak value, so leave it untouched in the file if
+    // the value is invalid/absent. Otherwise the APE item would be
+    // deleted.
     if (hasTrackPeak(trackMetadata)) {
         writeAPEItem(pTag, "REPLAYGAIN_TRACK_PEAK",
                 toTagLibString(formatTrackPeak(trackMetadata)));
@@ -2149,10 +2147,12 @@ bool exportTrackMetadataIntoXiphComment(TagLib::Ogg::XiphComment* pTag,
     writeXiphCommentField(pTag, "INITIALKEY", key); // recommended field
     updateXiphCommentField(pTag, "KEY", key); // alternative field
 
-    if (hasTrackGain(trackMetadata)) {
-        writeXiphCommentField(pTag, "REPLAYGAIN_TRACK_GAIN",
-                toTagLibString(formatTrackGain(trackMetadata)));
-    }
+    writeXiphCommentField(pTag, "REPLAYGAIN_TRACK_GAIN",
+            toTagLibString(formatTrackGain(trackMetadata)));
+    // NOTE(uklotzde, 2018-04-22): The analyzers currently doesn't
+    // calculate a peak value, so leave it untouched in the file if
+    // the value is invalid/absent. Otherwise the comment field would
+    // be deleted.
     if (hasTrackPeak(trackMetadata)) {
         writeXiphCommentField(pTag, "REPLAYGAIN_TRACK_PEAK",
                 toTagLibString(formatTrackPeak(trackMetadata)));
@@ -2282,10 +2282,12 @@ bool exportTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& 
     writeMP4Atom(pTag, "----:com.apple.iTunes:initialkey", key); // preferred
     updateMP4Atom(pTag, "----:com.apple.iTunes:KEY", key); // alternative
 
-    if (hasTrackGain(trackMetadata)) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_track_gain",
-                toTagLibString(formatTrackGain(trackMetadata)));
-    }
+    writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_track_gain",
+            toTagLibString(formatTrackGain(trackMetadata)));
+    // NOTE(uklotzde, 2018-04-22): The analyzers currently doesn't
+    // calculate a peak value, so leave it untouched in the file if
+    // the value is invalid/absent. Otherwise the MP4 atom would be
+    // deleted.
     if (hasTrackPeak(trackMetadata)) {
         writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_track_peak",
                 toTagLibString(formatTrackPeak(trackMetadata)));


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1766094

Only write gain aka ratio values unconditionally, **but not** peak values! I added detailed notes in the code that explain why we need to make a distinction.

We need this functionality to advice users to clear the ReplayGain values of all their FLAC files caused by #1636