### PR TITLE
lp1695766: Use an in-memory database to speed up library tests

### DIFF
--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -19,11 +19,12 @@ const mixxx::Logger kLogger("MixxxDb");
 
 // The connection parameters for the main Mixxx DB
 mixxx::DbConnection::Params dbConnectionParams(
-        const UserSettingsPointer& pConfig) {
+        const UserSettingsPointer& pConfig,
+        bool inMemoryConnection) {
     mixxx::DbConnection::Params params;
     params.type = "QSQLITE";
     params.hostName = "localhost";
-    params.filePath = QDir(pConfig->getSettingsPath()).filePath("mixxxdb.sqlite");
+    params.filePath = inMemoryConnection ? QString(":memory:") : QDir(pConfig->getSettingsPath()).filePath("mixxxdb.sqlite");
     params.userName = "mixxx";
     params.password = "mixxx";
     return params;
@@ -32,8 +33,9 @@ mixxx::DbConnection::Params dbConnectionParams(
 } // anonymous namespace
 
 MixxxDb::MixxxDb(
-        const UserSettingsPointer& pConfig)
-    : m_pDbConnectionPool(std::make_shared<mixxx::DbConnectionPool>(dbConnectionParams(pConfig), "MIXXX")) {
+        const UserSettingsPointer& pConfig,
+        bool inMemoryConnection)
+    : m_pDbConnectionPool(std::make_shared<mixxx::DbConnectionPool>(dbConnectionParams(pConfig, inMemoryConnection), "MIXXX")) {
 }
 
 bool MixxxDb::initDatabaseSchema(

--- a/src/database/mixxxdb.h
+++ b/src/database/mixxxdb.h
@@ -23,7 +23,8 @@ class MixxxDb : public QObject {
             int schemaVersion = kRequiredSchemaVersion);
 
     explicit MixxxDb(
-            const UserSettingsPointer& pConfig);
+            const UserSettingsPointer& pConfig,
+            bool inMemoryConnection = false);
 
     mixxx::DbConnectionPoolPtr connectionPool() const {
         return m_pDbConnectionPool;

--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -9,6 +9,9 @@
 #include "util/db/dbconnectionpooled.h"
 #include "track/globaltrackcache.h"
 
+namespace {
+    const bool kInMemoryDbConnection = true;
+} // anonymous namespace
 
 class LibraryTest : public MixxxTest,
     public virtual /*implements*/ GlobalTrackCacheSaver {
@@ -21,7 +24,7 @@ class LibraryTest : public MixxxTest,
 
   protected:
     LibraryTest()
-        : m_mixxxDb(config()),
+        : m_mixxxDb(config(), kInMemoryDbConnection),
           m_dbConnectionPooler(m_mixxxDb.connectionPool()),
           m_dbConnection(mixxx::DbConnectionPooled(m_mixxxDb.connectionPool())),
           m_trackCollection(config()) {


### PR DESCRIPTION
Simple and with minimal code changes. Hopefully this helps.
https://bugs.launchpad.net/mixxx/+bug/1695766