### PR TITLE
lp1766360: Fix integration of external track libraries

### DIFF
--- a/src/library/baseexternalplaylistmodel.cpp
+++ b/src/library/baseexternalplaylistmodel.cpp
@@ -21,8 +21,9 @@ BaseExternalPlaylistModel::~BaseExternalPlaylistModel() {
 }
 
 TrackPointer BaseExternalPlaylistModel::getTrack(const QModelIndex& index) const {
-    QString location = index.sibling(
+    QString nativeLocation = index.sibling(
             index.row(), fieldIndex("location")).data().toString();
+    QString location = QDir::fromNativeSeparators(nativeLocation);
 
     if (location.isEmpty()) {
         // Track is lost
@@ -150,7 +151,8 @@ void BaseExternalPlaylistModel::trackLoaded(QString group, TrackPointer pTrack) 
             // The external table has foreign Track IDs, so we need to compare
             // by location
             for (int row = 0; row < rowCount(); ++row) {
-                QString location = index(row, fieldIndex("location")).data().toString();
+                QString nativeLocation = index(row, fieldIndex("location")).data().toString();
+                QString location = QDir::fromNativeSeparators(nativeLocation);
                 if (location == pTrack->getLocation()) {
                     m_previewDeckTrackId = TrackId(index(row, 0).data());
                     //Debug() << "foreign track id" << m_previewDeckTrackId;

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -47,7 +47,8 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
     QString genre = index.sibling(index.row(), fieldIndex("genre")).data().toString();
     float bpm = index.sibling(index.row(), fieldIndex("bpm")).data().toString().toFloat();
 
-    QString location = index.sibling(index.row(), fieldIndex("location")).data().toString();
+    QString nativeLocation = index.sibling(index.row(), fieldIndex("location")).data().toString();
+    QString location = QDir::fromNativeSeparators(nativeLocation);
 
     if (location.isEmpty()) {
         // Track is lost
@@ -104,7 +105,8 @@ void BaseExternalTrackModel::trackLoaded(QString group, TrackPointer pTrack) {
             // The external table has foreign Track IDs, so we need to compare
             // by location
             for (int row = 0; row < rowCount(); ++row) {
-                QString location = index(row, fieldIndex("location")).data().toString();
+                QString nativeLocation = index(row, fieldIndex("location")).data().toString();
+                QString location = QDir::fromNativeSeparators(nativeLocation);
                 if (location == pTrack->getLocation()) {
                     m_previewDeckTrackId = TrackId(index(row, 0).data());
                     //qDebug() << "foreign track id" << m_previewDeckTrackId;

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -60,8 +60,9 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
 
     if (pTrack) {
         // If this track was not in the Mixxx library it is now added and will be
-        // saved with the metadata from iTunes. If it was already in the library
-        // then we do not touch it so that we do not over-write the user's metadata.
+        // saved with the metadata from external library. If it was already in the
+        // Mixxx library then we do not touch it so that we do not over-write the
+        // user's metadata.
         if (!track_already_in_library) {
             pTrack->setArtist(artist);
             pTrack->setTitle(title);

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -58,18 +58,31 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
     TrackPointer pTrack = m_pTrackCollection->getTrackDAO()
             .getOrAddTrack(location, true, &track_already_in_library);
 
-    // If this track was not in the Mixxx library it is now added and will be
-    // saved with the metadata from iTunes. If it was already in the library
-    // then we do not touch it so that we do not over-write the user's metadata.
-    if (pTrack && !track_already_in_library) {
-        pTrack->setArtist(artist);
-        pTrack->setTitle(title);
-        pTrack->setAlbum(album);
-        pTrack->setYear(year);
-        pTrack->setGenre(genre);
-        pTrack->setBpm(bpm);
+    if (pTrack) {
+        // If this track was not in the Mixxx library it is now added and will be
+        // saved with the metadata from iTunes. If it was already in the library
+        // then we do not touch it so that we do not over-write the user's metadata.
+        if (!track_already_in_library) {
+            pTrack->setArtist(artist);
+            pTrack->setTitle(title);
+            pTrack->setAlbum(album);
+            pTrack->setYear(year);
+            pTrack->setGenre(genre);
+            pTrack->setBpm(bpm);
+        }
+    } else {
+        qWarning() << "Failed to load external track" << location;
     }
     return pTrack;
+}
+
+TrackId BaseExternalTrackModel::getTrackId(const QModelIndex& index) const {
+    const auto track = getTrack(index);
+    if (track) {
+        return track->getId();
+    } else {
+        return TrackId();
+    }
 }
 
 void BaseExternalTrackModel::trackLoaded(QString group, TrackPointer pTrack) {

--- a/src/library/baseexternaltrackmodel.h
+++ b/src/library/baseexternaltrackmodel.h
@@ -7,7 +7,6 @@
 
 #include "library/trackmodel.h"
 #include "library/basesqltablemodel.h"
-#include "track/track.h"
 
 class TrackCollection;
 
@@ -22,6 +21,7 @@ class BaseExternalTrackModel : public BaseSqlTableModel {
     ~BaseExternalTrackModel() override;
 
     CapabilitiesFlags getCapabilities() const override;
+    TrackId getTrackId(const QModelIndex& index) const override;
     TrackPointer getTrack(const QModelIndex& index) const override;
     void trackLoaded(QString group, TrackPointer pTrack) override;
     bool isColumnInternal(int column) override;

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -179,14 +179,6 @@ QString TrackDAO::getTrackLocation(TrackId trackId) {
     return trackLocation;
 }
 
-/** Check if a track exists in the library table already.
-    @param file_location The full path to the track on disk, including the filename.
-    @return true if the track is found in the library table, false otherwise.
-*/
-bool TrackDAO::trackExistsInDatabase(const QString& absoluteFilePath) {
-    return getTrackId(absoluteFilePath).isValid();
-}
-
 void TrackDAO::saveTrack(Track* pTrack) {
     DEBUG_ASSERT(pTrack);
     if (pTrack->isDirty()) {

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -90,7 +90,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     void markTracksInDirectoriesAsVerified(const QStringList& directories);
     void invalidateTrackLocationsInLibrary();
     void markUnverifiedTracksAsDeleted();
-    void markTrackLocationsAsDeleted(const QString& directory);
     bool detectMovedTracks(QSet<TrackId>* pTracksMovedSetOld,
                           QSet<TrackId>* pTracksMovedSetNew,
                           const QStringList& addedTracks,

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -43,8 +43,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     QList<TrackId> getTrackIds(const QList<QFileInfo>& files);
     QList<TrackId> getTrackIds(const QDir& dir);
 
-    bool trackExistsInDatabase(const QString& absoluteFilePath);
-
     // WARNING: Only call this from the main thread instance of TrackDAO.
     TrackPointer getTrack(TrackId trackId) const;
 


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1766360

Affects all external track libraries, not only iTunes! I will re-test Windows+iTunes after AppVeyor has built the artifact.

Add a missing override to BaseExternalTrackModel. I wonder if there are more of these "gems" hidden inside the code?! This was a tough one, even though it looks like an easy fix. Implementation inheritance is evil!!