### PR TITLE
lp1766834: Detect M4A decoding errors on Windows

### DIFF
--- a/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
+++ b/plugins/soundsourcemediafoundation/soundsourcemediafoundation.h
@@ -17,37 +17,42 @@ class StreamUnitConverter final {
   public:
     StreamUnitConverter()
         : m_pAudioSource(nullptr),
-          m_streamUnitsPerFrame(0.0),
-          m_toFrameIndexBias(0) {
+          m_fromSampleFramesToStreamUnits(0),
+          m_fromStreamUnitsToSampleFrames(0) {
     }
     explicit StreamUnitConverter(const AudioSource* pAudioSource)
         : m_pAudioSource(pAudioSource),
-          m_streamUnitsPerFrame(double(kStreamUnitsPerSecond) / double(pAudioSource->sampleRate())),
-          m_toFrameIndexBias(kStreamUnitsPerSecond / pAudioSource->sampleRate() / 2) {
-        // The stream units should actually be much shorter
-        // than the frames to minimize jitter. Even a frame
-        // at 192 kHz has a length of about 5000 ns >> 100 ns.
-        DEBUG_ASSERT(m_streamUnitsPerFrame >= 50);
-        DEBUG_ASSERT(m_toFrameIndexBias > 0);
+          m_fromSampleFramesToStreamUnits(double(kStreamUnitsPerSecond) / double(pAudioSource->sampleRate())),
+          m_fromStreamUnitsToSampleFrames(double(pAudioSource->sampleRate()) / double(kStreamUnitsPerSecond)){
+        // The stream units should actually be much shorter than
+        // sample frames to minimize jitter and rounding. Even a
+        // frame at 192 kHz has a length of about 5000 ns >> 100 ns.
+        DEBUG_ASSERT(m_fromStreamUnitsToSampleFrames >= 50);
     }
 
     LONGLONG fromFrameIndex(SINT frameIndex) const {
+        DEBUG_ASSERT(m_fromSampleFramesToStreamUnits > 0);
         // Used for seeking, so we need to round down to hit the
         // corresponding stream unit where the given stream unit
-        // starts
-        return floor((frameIndex - m_pAudioSource->frameIndexMin()) * m_streamUnitsPerFrame);
+        // starts. The reader will skip samples until it reaches
+        // the actual target position for reading.
+        const SINT frameIndexOffset = frameIndex - m_pAudioSource->frameIndexMin();
+        return static_cast<LONGLONG>(floor(frameIndexOffset * m_fromSampleFramesToStreamUnits));
     }
 
     SINT toFrameIndex(LONGLONG streamPos) const {
-        // NOTE(uklotzde): Add m_toFrameIndexBias to account for rounding errors
-        return m_pAudioSource->frameIndexMin() +
-                static_cast<SINT>(floor((streamPos + m_toFrameIndexBias) / m_streamUnitsPerFrame));
+        DEBUG_ASSERT(m_fromStreamUnitsToSampleFrames > 0);
+        // The stream reports positions in units of 100ns. We have
+        // to round(!) this value to obtain the actual position in
+        // sample frames.
+        const SINT frameIndexOffset = static_cast<SINT>(round(streamPos * m_fromStreamUnitsToSampleFrames));
+        return m_pAudioSource->frameIndexMin() + frameIndexOffset;
     }
 
   private:
     const AudioSource* m_pAudioSource;
-    double m_streamUnitsPerFrame;
-    SINT m_toFrameIndexBias;
+    double m_fromSampleFramesToStreamUnits;
+    double m_fromStreamUnitsToSampleFrames;
 };
 
 class SoundSourceMediaFoundation: public mixxx::SoundSourcePlugin {


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1766834

I don't know how frequently the decoder gets out of sync while reading. Currently we have only a single
example provided by Sean. But it is definitely a critical issue if playback or analysis stops unexpectedly!!