### PR TITLE
Check for free diskspace when recording

### DIFF
--- a/src/recording/recordingmanager.cpp
+++ b/src/recording/recordingmanager.cpp
@@ -23,8 +23,8 @@
 #include "recording/defs_recording.h"
 #include "recording/recordingmanager.h"
 
-// one gigabyte
-#define MIN_DISK_FREE (qint64)1024*1024*1024
+// one gibibyte
+#define MIN_DISK_FREE 1024 * 1024 * 1024ll
 
 RecordingManager::RecordingManager(UserSettingsPointer pConfig, EngineMaster* pEngine)
         : m_pConfig(pConfig),
@@ -271,8 +271,8 @@ void RecordingManager::slotBytesRecorded(int bytes)
         // FIXME(poelzi) temporary display a error message. Replace this with Message Infrastructure when ready
         QMessageBox::warning(
             NULL,
-            tr("Free Space Warning"),
-            tr("There is less then 1 gb of useable space in the recording folder"));
+            tr("Low Disk Space Warning"),
+            tr("There is less then 1 GiB of useable space in the recording folder"));
     }
 }
 

--- a/src/recording/recordingmanager.h
+++ b/src/recording/recordingmanager.h
@@ -72,6 +72,7 @@ class RecordingManager : public QObject
 
     quint64 getFileSplitSize();
     unsigned int getFileSplitSeconds();
+    qint64 getFreeSpace();
 
     UserSettingsPointer m_pConfig;
     QString m_recordingDir;
@@ -83,6 +84,9 @@ class RecordingManager : public QObject
     QString m_recordingLocation;
 
     bool m_bRecording;
+    bool m_dfSilence;
+    qint64 m_dfCounter;
+
     // will be a very large number
     quint64 m_iNumberOfBytesRecorded;
     quint64 m_iNumberOfBytesRecordedSplit;


### PR DESCRIPTION
Check every 1MB of written stream for free diskspace.
Warn the user if free space drops below 1GB.

Not supported on Windows + QT4, QT5 should be fine.