### PR TITLE
Implement switchable time format for decks

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -653,7 +653,7 @@ QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
             if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DURATION)) {
                 int duration = value.toInt();
                 if (duration > 0) {
-                    value = mixxx::Duration::formatSeconds(duration);
+                    value = mixxx::Duration::formatTime(duration);
                 } else {
                     value = QString();
                 }

--- a/src/library/crate/cratesummary.h
+++ b/src/library/crate/cratesummary.h
@@ -34,7 +34,7 @@ public:
     }
     // Returns the duration formatted as a string H:MM:SS
     QString getTrackDurationText() const {
-        return mixxx::Duration::formatSeconds(getTrackDuration(), mixxx::Duration::Precision::SECONDS);
+        return mixxx::Duration::formatTime(getTrackDuration(), mixxx::Duration::Precision::SECONDS);
     }
 
 private:

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -119,6 +119,8 @@ DlgPrefDeck::DlgPrefDeck(QWidget * parent, MixxxMainWindow * mixxx,
     comboBoxTimeFormat->clear();
     comboBoxTimeFormat->addItem(tr("hh:mm:ss.zzz - Traditional"),
                                 static_cast<int>(TrackTime::DisplayFormat::TRADITIONAL));
+    comboBoxTimeFormat->addItem(tr("s%1zz - Seconds").arg(mixxx::DurationBase::kCentisecondSeperator),
+                                static_cast<int>(TrackTime::DisplayFormat::SECOND));
     comboBoxTimeFormat->addItem(tr("k.sss%1zz - Kiloseconds").arg(mixxx::DurationBase::kCentisecondSeperator),
                                 static_cast<int>(TrackTime::DisplayFormat::KILO_SECOND));
     comboBoxTimeFormat->addItem(tr("hs.ss%1zz - Hectoseconds").arg(mixxx::DurationBase::kCentisecondSeperator),

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -23,8 +23,9 @@ namespace TrackTime {
         ElapsedAndRemaining,
     };
     enum class DisplayFormat {
-        DEFAULT,
+        TRADITIONAL,
         KILO_SECOND,
+        HECTO_SECOND,
     };
 }
 
@@ -72,7 +73,6 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     void slotRateRampSensitivitySlider(int);
 
     void slotTimeFormatChanged(double);
-    void slotTimeFormatChanged(int);
 
     void slotNumDecksChanged(double, bool initializing=false);
     void slotNumSamplersChanged(double, bool initializing=false);
@@ -108,7 +108,6 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     int m_iNumConfiguredSamplers;
 
     TrackTime::DisplayMode m_timeDisplayMode;
-    TrackTime::DisplayFormat m_timeDisplayFormat;
 
     int m_iCueMode;
 

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -22,6 +22,10 @@ namespace TrackTime {
         Remaining,
         ElapsedAndRemaining,
     };
+    enum class DisplayFormat {
+        DEFAULT,
+        KILO_SECOND,
+    };
 }
 
 enum class KeylockMode {
@@ -67,6 +71,9 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     void slotRateRampingModeLinearButton(bool);
     void slotRateRampSensitivitySlider(int);
 
+    void slotTimeFormatChanged(double);
+    void slotTimeFormatChanged(int);
+
     void slotNumDecksChanged(double, bool initializing=false);
     void slotNumSamplersChanged(double, bool initializing=false);
 
@@ -85,6 +92,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
 
     UserSettingsPointer m_pConfig;
     ControlObject* m_pControlTrackTimeDisplay;
+    ControlObject* m_pControlTrackTimeFormat;
     ControlProxy* m_pNumDecks;
     ControlProxy* m_pNumSamplers;
     QList<ControlProxy*> m_cueControls;
@@ -100,6 +108,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     int m_iNumConfiguredSamplers;
 
     TrackTime::DisplayMode m_timeDisplayMode;
+    TrackTime::DisplayFormat m_timeDisplayFormat;
 
     int m_iCueMode;
 

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -24,6 +24,7 @@ namespace TrackTime {
     };
     enum class DisplayFormat {
         TRADITIONAL,
+        SECOND,
         KILO_SECOND,
         HECTO_SECOND,
     };

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -20,6 +20,90 @@
       <string>Deck options</string>
      </property>
      <layout class="QGridLayout" name="GridLayout1">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+      <item row="3" column="0">
+       <widget class="QLabel" name="labelAutoCue">
+        <property name="text">
+         <string>Auto cue</string>
+        </property>
+        <property name="buddy">
+         <cstring>checkBoxSeekToCue</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelPositionDisplay">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="text">
+         <string>Track time display</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="buddy">
+         <cstring>radioButtonElapsed</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1" colspan="2">
+       <widget class="QCheckBox" name="checkBoxDisallowLoadToPlayingDeck">
+        <property name="text">
+         <string>Do not load tracks into playing decks</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1" colspan="2">
+       <widget class="QCheckBox" name="checkBoxSeekToCue">
+        <property name="toolTip">
+         <string>Automatically seeks to the first saved cue point on track load.
+            If none exists, seeks to the beginning of the track.</string>
+        </property>
+        <property name="text">
+         <string>Jump to main cue point on track load</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QRadioButton" name="radioButtonElapsed">
+          <property name="text">
+           <string>Elapsed</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupTrackTime</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioButtonRemaining">
+          <property name="text">
+           <string>Remaining</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupTrackTime</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioButtonElapsedAndRemaining">
+          <property name="text">
+           <string>Elapsed and Remaining</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupTrackTime</string>
+          </attribute>
+         </widget>
+        </item>
+       </layout>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="labelCueMode">
         <property name="text">
@@ -58,96 +142,25 @@ CUP mode:
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="labelPositionDisplay">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-        <property name="text">
-         <string>Track time display</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-        <property name="buddy">
-         <cstring>radioButtonElapsed</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QRadioButton" name="radioButtonElapsed">
-          <property name="text">
-           <string>Elapsed</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupTrackTime</string>
-          </attribute>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="radioButtonRemaining">
-          <property name="text">
-           <string>Remaining</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupTrackTime</string>
-          </attribute>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="radioButtonElapsedAndRemaining">
-          <property name="text">
-           <string>Elapsed and Remaining</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupTrackTime</string>
-          </attribute>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="labelAutoCue">
-        <property name="text">
-         <string>Auto cue</string>
-        </property>
-        <property name="buddy">
-         <cstring>checkBoxSeekToCue</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1" colspan="2">
-       <widget class="QCheckBox" name="checkBoxSeekToCue">
-        <property name="toolTip">
-         <string>Automatically seeks to the first saved cue point on track load.
-            If none exists, seeks to the beginning of the track.</string>
-        </property>
-        <property name="text">
-         <string>Jump to main cue point on track load</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="labelPlayingTrackProtection">
         <property name="text">
-         <string>Playing track protection</string>
+         <string>Pla&amp;ying track protection</string>
         </property>
         <property name="buddy">
          <cstring>checkBoxDisallowLoadToPlayingDeck</cstring>
         </property>
        </widget>
       </item>
-      <item row="3" column="1" colspan="2">
-       <widget class="QCheckBox" name="checkBoxDisallowLoadToPlayingDeck">
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelTimeDisplay">
         <property name="text">
-         <string>Do not load tracks into playing decks</string>
+         <string>Time Format</string>
         </property>
        </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="comboBoxTimeFormat"/>
       </item>
      </layout>
     </widget>
@@ -755,13 +768,13 @@ CUP mode:
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="buttonGroupKeyLockMode"/>
-  <buttongroup name="buttonGroupKeyUnlockMode"/>
   <buttongroup name="buttonGroupSpeedPitchReset">
    <property name="exclusive">
     <bool>false</bool>
    </property>
   </buttongroup>
+  <buttongroup name="buttonGroupKeyLockMode"/>
+  <buttongroup name="buttonGroupKeyUnlockMode"/>
   <buttongroup name="buttonGroupTrackTime"/>
   <buttongroup name="buttonGroupSpeedBendBehavior"/>
  </buttongroups>

--- a/src/test/durationutiltest.cpp
+++ b/src/test/durationutiltest.cpp
@@ -41,6 +41,23 @@ class DurationUtilTest : public testing::Test {
             mixxx::Duration::formatSeconds(dSeconds, mixxx::Duration::Precision::MILLISECONDS);
         EXPECT_EQ(actualMilliseconds, actualMilliseconds);
     }
+
+    void formatKiloSeconds(QString expectedMilliseconds, double dSeconds) {
+        ASSERT_LE(4, expectedMilliseconds.length()); // 3 digits + 1 decimal point
+        const QString actualSeconds =
+            mixxx::Duration::formatKiloSeconds(dSeconds, mixxx::Duration::Precision::SECONDS);
+        const QString expectedSeconds =
+                adjustPrecision(expectedMilliseconds, mixxx::Duration::Precision::SECONDS);
+        EXPECT_EQ(expectedSeconds, actualSeconds);
+        const QString expectedCentiseconds =
+                adjustPrecision(expectedMilliseconds, mixxx::Duration::Precision::CENTISECONDS);
+        const QString actualCentiseconds =
+            mixxx::Duration::formatKiloSeconds(dSeconds, mixxx::Duration::Precision::CENTISECONDS);
+        EXPECT_EQ(expectedCentiseconds, actualCentiseconds);
+        const QString actualMilliseconds =
+            mixxx::Duration::formatKiloSeconds(dSeconds, mixxx::Duration::Precision::MILLISECONDS);
+        EXPECT_EQ(actualMilliseconds, actualMilliseconds);
+    }
 };
 
 TEST_F(DurationUtilTest, FormatSecondsNegative) {
@@ -59,6 +76,20 @@ TEST_F(DurationUtilTest, FormatSeconds) {
     formatSeconds("01:00:00.000", 3600);
     formatSeconds("23:59:59.000", 24 * 3600 - 1);
     formatSeconds("1d, 00:00:00.000", 24 * 3600);
+}
+
+TEST_F(DurationUtilTest, FormatKiloSeconds) {
+    formatKiloSeconds("0.000:000", 0);
+    formatKiloSeconds("0.001:000", 1);
+    formatKiloSeconds("0.001:500", 1.5);
+    formatKiloSeconds("0.001:510", 1.51);
+    formatKiloSeconds("0.001:490", 1.49);
+    formatKiloSeconds("0.059:000", 59);
+    formatKiloSeconds("0.060:000", 60);
+    formatKiloSeconds("0.061:123", 61.1234);
+    formatKiloSeconds("0.999:990", 999.99);
+    formatKiloSeconds("1.000:000", 1000.00);
+    formatKiloSeconds("1d, 0.000:000", 24 * 3600);
 }
 
 } // anonymous namespace

--- a/src/test/durationutiltest.cpp
+++ b/src/test/durationutiltest.cpp
@@ -138,17 +138,17 @@ TEST_F(DurationUtilTest, FormatKiloSeconds) {
 }
 
 TEST_F(DurationUtilTest, FormatHectoSeconds) {
-    formatHectoSeconds(QString::fromUtf8("0.00\u2009000"), 0);
-    formatHectoSeconds(QString::fromUtf8("0.01\u2009000"), 1);
-    formatHectoSeconds(QString::fromUtf8("0.01\u2009500"), 1.5);
-    formatHectoSeconds(QString::fromUtf8("0.01\u2009510"), 1.51);
-    formatHectoSeconds(QString::fromUtf8("0.01\u2009490"), 1.49);
-    formatHectoSeconds(QString::fromUtf8("0.59\u2009000"), 59);
-    formatHectoSeconds(QString::fromUtf8("0.60\u2009000"), 60);
-    formatHectoSeconds(QString::fromUtf8("0.61\u2009123"), 61.1234);
-    formatHectoSeconds(QString::fromUtf8("9.99\u2009990"), 999.99);
-    formatHectoSeconds(QString::fromUtf8("10.00\u2009000"), 1000.00);
-    formatHectoSeconds(QString::fromUtf8("864.00\u2009000"), 24 * 3600);
+    formatHectoSeconds(QString::fromUtf8("0\u231E00\u2009000"), 0);
+    formatHectoSeconds(QString::fromUtf8("0\u231E01\u2009000"), 1);
+    formatHectoSeconds(QString::fromUtf8("0\u231E01\u2009500"), 1.5);
+    formatHectoSeconds(QString::fromUtf8("0\u231E01\u2009510"), 1.51);
+    formatHectoSeconds(QString::fromUtf8("0\u231E01\u2009490"), 1.49);
+    formatHectoSeconds(QString::fromUtf8("0\u231E59\u2009000"), 59);
+    formatHectoSeconds(QString::fromUtf8("0\u231E60\u2009000"), 60);
+    formatHectoSeconds(QString::fromUtf8("0\u231E61\u2009123"), 61.1234);
+    formatHectoSeconds(QString::fromUtf8("9\u231E99\u2009990"), 999.99);
+    formatHectoSeconds(QString::fromUtf8("10\u231E00\u2009000"), 1000.00);
+    formatHectoSeconds(QString::fromUtf8("864\u231E00\u2009000"), 24 * 3600);
 }
 
 

--- a/src/test/durationutiltest.cpp
+++ b/src/test/durationutiltest.cpp
@@ -58,6 +58,23 @@ class DurationUtilTest : public testing::Test {
             mixxx::Duration::formatKiloSeconds(dSeconds, mixxx::Duration::Precision::MILLISECONDS);
         EXPECT_EQ(actualMilliseconds, actualMilliseconds);
     }
+
+    void formatHectoSeconds(QString expectedMilliseconds, double dSeconds) {
+        ASSERT_LE(4, expectedMilliseconds.length()); // 3 digits + 1 decimal point
+        const QString actualSeconds =
+            mixxx::Duration::formatHectoSeconds(dSeconds, mixxx::Duration::Precision::SECONDS);
+        const QString expectedSeconds =
+                adjustPrecision(expectedMilliseconds, mixxx::Duration::Precision::SECONDS);
+        EXPECT_EQ(expectedSeconds, actualSeconds);
+        const QString expectedCentiseconds =
+                adjustPrecision(expectedMilliseconds, mixxx::Duration::Precision::CENTISECONDS);
+        const QString actualCentiseconds =
+            mixxx::Duration::formatHectoSeconds(dSeconds, mixxx::Duration::Precision::CENTISECONDS);
+        EXPECT_EQ(expectedCentiseconds, actualCentiseconds);
+        const QString actualMilliseconds =
+            mixxx::Duration::formatHectoSeconds(dSeconds, mixxx::Duration::Precision::MILLISECONDS);
+        EXPECT_EQ(actualMilliseconds, actualMilliseconds);
+    }
 };
 
 TEST_F(DurationUtilTest, FormatSecondsNegative) {
@@ -75,21 +92,38 @@ TEST_F(DurationUtilTest, FormatSeconds) {
     formatSeconds("59:59.999", 3599.999);
     formatSeconds("01:00:00.000", 3600);
     formatSeconds("23:59:59.000", 24 * 3600 - 1);
-    formatSeconds("1d, 00:00:00.000", 24 * 3600);
+    formatSeconds("24:00:00.000", 24 * 3600);
+    formatSeconds("24:00:01.000", 24 * 3600 + 1);
+    formatSeconds("25:00:01.000", 25 * 3600 + 1);
 }
 
 TEST_F(DurationUtilTest, FormatKiloSeconds) {
-    formatKiloSeconds("0.000:000", 0);
-    formatKiloSeconds("0.001:000", 1);
-    formatKiloSeconds("0.001:500", 1.5);
-    formatKiloSeconds("0.001:510", 1.51);
-    formatKiloSeconds("0.001:490", 1.49);
-    formatKiloSeconds("0.059:000", 59);
-    formatKiloSeconds("0.060:000", 60);
-    formatKiloSeconds("0.061:123", 61.1234);
-    formatKiloSeconds("0.999:990", 999.99);
-    formatKiloSeconds("1.000:000", 1000.00);
-    formatKiloSeconds("1d, 0.000:000", 24 * 3600);
+    formatKiloSeconds(QString::fromUtf8("0.000\u2009000"), 0);
+    formatKiloSeconds(QString::fromUtf8("0.001\u2009000"), 1);
+    formatKiloSeconds(QString::fromUtf8("0.001\u2009500"), 1.5);
+    formatKiloSeconds(QString::fromUtf8("0.001\u2009510"), 1.51);
+    formatKiloSeconds(QString::fromUtf8("0.001\u2009490"), 1.49);
+    formatKiloSeconds(QString::fromUtf8("0.059\u2009000"), 59);
+    formatKiloSeconds(QString::fromUtf8("0.060\u2009000"), 60);
+    formatKiloSeconds(QString::fromUtf8("0.061\u2009123"), 61.1234);
+    formatKiloSeconds(QString::fromUtf8("0.999\u2009990"), 999.99);
+    formatKiloSeconds(QString::fromUtf8("1.000\u2009000"), 1000.00);
+    formatKiloSeconds(QString::fromUtf8("86.400\u2009000"), 24 * 3600);
 }
+
+TEST_F(DurationUtilTest, FormatHectoSeconds) {
+    formatHectoSeconds(QString::fromUtf8("0.00\u2009000"), 0);
+    formatHectoSeconds(QString::fromUtf8("0.01\u2009000"), 1);
+    formatHectoSeconds(QString::fromUtf8("0.01\u2009500"), 1.5);
+    formatHectoSeconds(QString::fromUtf8("0.01\u2009510"), 1.51);
+    formatHectoSeconds(QString::fromUtf8("0.01\u2009490"), 1.49);
+    formatHectoSeconds(QString::fromUtf8("0.59\u2009000"), 59);
+    formatHectoSeconds(QString::fromUtf8("0.60\u2009000"), 60);
+    formatHectoSeconds(QString::fromUtf8("0.61\u2009123"), 61.1234);
+    formatHectoSeconds(QString::fromUtf8("9.99\u2009990"), 999.99);
+    formatHectoSeconds(QString::fromUtf8("10.00\u2009000"), 1000.00);
+    formatHectoSeconds(QString::fromUtf8("864.00\u2009000"), 24 * 3600);
+}
+
 
 } // anonymous namespace

--- a/src/test/durationutiltest.cpp
+++ b/src/test/durationutiltest.cpp
@@ -25,6 +25,23 @@ class DurationUtilTest : public testing::Test {
         }
     }
 
+    void formatTime(QString expectedMilliseconds, double dSeconds) {
+        ASSERT_LE(4, expectedMilliseconds.length()); // 3 digits + 1 decimal point
+        const QString actualSeconds =
+            mixxx::Duration::formatTime(dSeconds, mixxx::Duration::Precision::SECONDS);
+        const QString expectedSeconds =
+                adjustPrecision(expectedMilliseconds, mixxx::Duration::Precision::SECONDS);
+        EXPECT_EQ(expectedSeconds, actualSeconds);
+        const QString expectedCentiseconds =
+                adjustPrecision(expectedMilliseconds, mixxx::Duration::Precision::CENTISECONDS);
+        const QString actualCentiseconds =
+            mixxx::Duration::formatTime(dSeconds, mixxx::Duration::Precision::CENTISECONDS);
+        EXPECT_EQ(expectedCentiseconds, actualCentiseconds);
+        const QString actualMilliseconds =
+            mixxx::Duration::formatTime(dSeconds, mixxx::Duration::Precision::MILLISECONDS);
+        EXPECT_EQ(actualMilliseconds, actualMilliseconds);
+    }
+
     void formatSeconds(QString expectedMilliseconds, double dSeconds) {
         ASSERT_LE(4, expectedMilliseconds.length()); // 3 digits + 1 decimal point
         const QString actualSeconds =
@@ -78,24 +95,33 @@ class DurationUtilTest : public testing::Test {
 };
 
 TEST_F(DurationUtilTest, FormatSecondsNegative) {
-    EXPECT_EQ("?", mixxx::Duration::formatSeconds(-1, mixxx::Duration::Precision::SECONDS));
-    EXPECT_EQ("?", mixxx::Duration::formatSeconds(-1, mixxx::Duration::Precision::CENTISECONDS));
-    EXPECT_EQ("?", mixxx::Duration::formatSeconds(-1, mixxx::Duration::Precision::MILLISECONDS));
+    EXPECT_EQ("?", mixxx::Duration::formatTime(-1, mixxx::Duration::Precision::SECONDS));
+    EXPECT_EQ("?", mixxx::Duration::formatTime(-1, mixxx::Duration::Precision::CENTISECONDS));
+    EXPECT_EQ("?", mixxx::Duration::formatTime(-1, mixxx::Duration::Precision::MILLISECONDS));
 }
 
-TEST_F(DurationUtilTest, FormatSeconds) {
-    formatSeconds("00:00.000", 0);
-    formatSeconds("00:01.000", 1);
-    formatSeconds("00:59.000", 59);
-    formatSeconds("01:00.000", 60);
-    formatSeconds("01:01.123", 61.1234);
-    formatSeconds("59:59.999", 3599.999);
-    formatSeconds("01:00:00.000", 3600);
-    formatSeconds("23:59:59.000", 24 * 3600 - 1);
-    formatSeconds("24:00:00.000", 24 * 3600);
-    formatSeconds("24:00:01.000", 24 * 3600 + 1);
-    formatSeconds("25:00:01.000", 25 * 3600 + 1);
+TEST_F(DurationUtilTest, formatTime) {
+    formatTime("00:00.000", 0);
+    formatTime("00:01.000", 1);
+    formatTime("00:59.000", 59);
+    formatTime("01:00.000", 60);
+    formatTime("01:01.123", 61.1234);
+    formatTime("59:59.999", 3599.999);
+    formatTime("01:00:00.000", 3600);
+    formatTime("23:59:59.000", 24 * 3600 - 1);
+    formatTime("24:00:00.000", 24 * 3600);
+    formatTime("24:00:01.000", 24 * 3600 + 1);
+    formatTime("25:00:01.000", 25 * 3600 + 1);
 }
+
+TEST_F(DurationUtilTest, formatSecond) {
+    formatSeconds("0.000", 0);
+    formatSeconds("1.000", 1);
+    formatSeconds("59.000", 59);
+    formatSeconds("60.000", 60);
+    formatSeconds("321.123", 321.1234);
+}
+
 
 TEST_F(DurationUtilTest, FormatKiloSeconds) {
     formatKiloSeconds(QString::fromUtf8("0.000\u2009000"), 0);

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -442,7 +442,7 @@ QString Track::getDurationText(mixxx::Duration::Precision precision) const {
     } else {
         duration = getDuration(DurationRounding::NONE);
     }
-    return mixxx::Duration::formatSeconds(duration, precision);
+    return mixxx::Duration::formatTime(duration, precision);
 }
 
 QString Track::getTitle() const {

--- a/src/util/duration.cpp
+++ b/src/util/duration.cpp
@@ -3,7 +3,7 @@
 #include <QtGlobal>
 #include <QStringBuilder>
 #include <QTime>
-
+#include <math.h>
 #include "util/assert.h"
 #include "util/math.h"
 
@@ -38,6 +38,37 @@ QString DurationBase::formatSeconds(double dSeconds, Precision precision) {
             QLatin1String(Precision::SECONDS == precision ? "" : ".zzz");
 
     QString durationString = t.toString(formatString);
+
+    // The format string gives us milliseconds but we want
+    // centiseconds. Slice one character off.
+    if (Precision::CENTISECONDS == precision) {
+        DEBUG_ASSERT(1 <= durationString.length());
+        durationString = durationString.left(durationString.length() - 1);
+    }
+
+    return durationString;
+}
+// static
+QString DurationBase::formatKiloSeconds(double dSeconds, Precision precision) {
+    if (dSeconds < 0.0) {
+        // negative durations are not supported
+        return "?";
+    }
+
+    const qint64 days = static_cast<qint64>(std::floor(dSeconds)) / kSecondsPerDay;
+    dSeconds -= days * kSecondsPerDay;
+
+    int kilos = (int)dSeconds / 1000;
+    double seconds = floor(fmod(dSeconds, 1000));
+    double subs = fmod(dSeconds, 1);
+
+    QString durationString =
+            (days > 0 ? (QString::number(days) %
+                         QLatin1String("d, ")) : QString()) %
+            QString("%1.%2").arg(kilos, 0, 10).arg(seconds, 3, 'f', 0, QLatin1Char('0'));
+    if (Precision::SECONDS != precision) {
+            durationString += QString(":") % QString::number(subs, 'f', 3).right(3);
+    }
 
     // The format string gives us milliseconds but we want
     // centiseconds. Slice one character off.

--- a/src/util/duration.cpp
+++ b/src/util/duration.cpp
@@ -21,7 +21,7 @@ static const qint64 kSecondsPerDay = 24 * kSecondsPerHour;
 QString DurationBase::kCentisecondSeperator = QString::fromUtf8("\u2009");
 
 // static
-QString DurationBase::formatSeconds(double dSeconds, Precision precision) {
+QString DurationBase::formatTime(double dSeconds, Precision precision) {
     if (dSeconds < 0.0) {
         // negative durations are not supported
         return "?";
@@ -52,6 +52,25 @@ QString DurationBase::formatSeconds(double dSeconds, Precision precision) {
 
     return durationString;
 }
+
+QString DurationBase::formatSeconds(double dSeconds, Precision precision) {
+    if (dSeconds < 0.0) {
+        // negative durations are not supported
+        return "?";
+    }
+    QString durationString;
+
+    if (Precision::CENTISECONDS == precision) {
+        durationString = QString("%1").arg(dSeconds,1,'f',2,'0');
+    } else if (Precision::MILLISECONDS == precision) {
+        durationString = QString("%1").arg(dSeconds,1,'f',3,'0');
+    } else {
+        durationString = QString("%1").arg(dSeconds,1,'f',0,'0');
+    }
+
+    return durationString;
+}
+
 // static
 QString DurationBase::formatKiloSeconds(double dSeconds, Precision precision) {
     if (dSeconds < 0.0) {

--- a/src/util/duration.cpp
+++ b/src/util/duration.cpp
@@ -18,7 +18,8 @@ static const qint64 kSecondsPerDay = 24 * kSecondsPerHour;
 } // namespace
 
 // static
-QString DurationBase::kCentisecondSeperator = QString::fromUtf8("\u2009");
+QChar DurationBase::kCentisecondSeperator = QChar(0x2009);
+QChar DurationBase::kHectosecondSeperator = QChar(0x231E);
 
 // static
 QString DurationBase::formatTime(double dSeconds, Precision precision) {
@@ -110,7 +111,7 @@ QString DurationBase::formatHectoSeconds(double dSeconds, Precision precision) {
     double subs = fmod(dSeconds, 1);
 
     QString durationString =
-            QString("%1.%2").arg(hecto, 0, 10).arg(seconds, 2, 'f', 0, QLatin1Char('0'));
+            QString("%1%2%3").arg(hecto, 0, 10).arg(kHectosecondSeperator).arg(seconds, 2, 'f', 0, QLatin1Char('0'));
     if (Precision::SECONDS != precision) {
             durationString += kCentisecondSeperator % QString::number(subs, 'f', 3).right(3);
     }

--- a/src/util/duration.h
+++ b/src/util/duration.h
@@ -70,10 +70,13 @@ class DurationBase {
 
     // The standard way of formatting a floating-point duration in seconds.
     // Used for display of track duration, etc.
+    static QString formatTime(
+            double dSeconds,
+            Precision precision = Precision::SECONDS);
+    // Alternative format for duration based on seconds
     static QString formatSeconds(
             double dSeconds,
             Precision precision = Precision::SECONDS);
-    // Alternative format for duration based on kilo seconds
     static QString formatKiloSeconds(
             double dSeconds,
             Precision precision = Precision::SECONDS);

--- a/src/util/duration.h
+++ b/src/util/duration.h
@@ -77,12 +77,16 @@ class DurationBase {
     static QString formatKiloSeconds(
             double dSeconds,
             Precision precision = Precision::SECONDS);
+    static QString formatHectoSeconds(
+            double dSeconds,
+            Precision precision = Precision::SECONDS);
 
     static constexpr qint64 kMillisPerSecond = 1000;
     static constexpr qint64 kMicrosPerSecond = kMillisPerSecond * 1000;
     static constexpr qint64 kNanosPerSecond  = kMicrosPerSecond * 1000;
     static constexpr qint64 kNanosPerMilli   = kNanosPerSecond / 1000;
     static constexpr qint64 kNanosPerMicro   = kNanosPerMilli / 1000;
+    static QString kCentisecondSeperator;
 
   protected:
     explicit DurationBase(qint64 durationNanos)

--- a/src/util/duration.h
+++ b/src/util/duration.h
@@ -73,6 +73,10 @@ class DurationBase {
     static QString formatSeconds(
             double dSeconds,
             Precision precision = Precision::SECONDS);
+    // Alternative format for duration based on kilo seconds
+    static QString formatKiloSeconds(
+            double dSeconds,
+            Precision precision = Precision::SECONDS);
 
     static constexpr qint64 kMillisPerSecond = 1000;
     static constexpr qint64 kMicrosPerSecond = kMillisPerSecond * 1000;

--- a/src/util/duration.h
+++ b/src/util/duration.h
@@ -89,7 +89,8 @@ class DurationBase {
     static constexpr qint64 kNanosPerSecond  = kMicrosPerSecond * 1000;
     static constexpr qint64 kNanosPerMilli   = kNanosPerSecond / 1000;
     static constexpr qint64 kNanosPerMicro   = kNanosPerMilli / 1000;
-    static QString kCentisecondSeperator;
+    static QChar kCentisecondSeperator;
+    static QChar kHectosecondSeperator;
 
   protected:
     explicit DurationBase(qint64 durationNanos)

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -62,6 +62,8 @@ void WNumberPos::slotSetTimeElapsed(double dTimeElapsed) {
 
     if (m_displayFormat == TrackTime::DisplayFormat::KILO_SECOND) {
         formatter = &mixxx::Duration::formatKiloSeconds;
+    } else if (m_displayFormat == TrackTime::DisplayFormat::HECTO_SECOND) {
+        formatter = &mixxx::Duration::formatHectoSeconds;
     } else {
         formatter = &mixxx::Duration::formatSeconds;
     }

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -64,8 +64,10 @@ void WNumberPos::slotSetTimeElapsed(double dTimeElapsed) {
         formatter = &mixxx::Duration::formatKiloSeconds;
     } else if (m_displayFormat == TrackTime::DisplayFormat::HECTO_SECOND) {
         formatter = &mixxx::Duration::formatHectoSeconds;
+    } else if (m_displayFormat == TrackTime::DisplayFormat::SECOND) {
+       formatter = &mixxx::Duration::formatSeconds;
     } else {
-        formatter = &mixxx::Duration::formatSeconds;
+        formatter = &mixxx::Duration::formatTime;
     }
 
     if (m_displayMode == TrackTime::DisplayMode::Elapsed) {

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -23,15 +23,18 @@ class WNumberPos : public WNumber {
     void slotSetTimeElapsed(double);
     void slotTimeRemainingUpdated(double);
     void slotSetDisplayMode(double);
+    void slotSetTimeFormat(double);
 
   private:
 
     TrackTime::DisplayMode m_displayMode;
+    TrackTime::DisplayFormat m_displayFormat;
 
     double m_dOldTimeElapsed;
     ControlProxy* m_pTimeElapsed;
     ControlProxy* m_pTimeRemaining;
     ControlProxy* m_pShowTrackTimeRemaining;
+    ControlProxy* m_pTimeFormat;
 };
 
 #endif


### PR DESCRIPTION
The display format on the decks can now be configured.
Implement first alternative display based on kiloseconds.

If you mixx tracks based on first and last downbeat, it is unnecessary complicated to use minutes. The first alternative display shows "k.sss:zzz" following roughly the idea of the kilosecond so it can be much easier calculated when the next track should be started.