### PR TITLE
Kontrol s4 mappings LED updates and autoslip mode

### DIFF
--- a/res/controllers/Traktor-Kontrol-S4-MK2-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK2-hid-scripts.js
@@ -1593,7 +1593,6 @@ TraktorS4MK2.onVuMeterChanged = function(value, group, key) {
 TraktorS4MK2.onLoopEnabledChanged = function(value, group, key) {
   TraktorS4MK2.outputCallbackLoop(value, group, "loop_in");
   TraktorS4MK2.outputCallbackLoop(value, group, "loop_out");
-  print('Loop enabled or disabled');
   TraktorS4MK2.slipAutoHandler(group, value);
 }
 

--- a/res/controllers/Traktor-Kontrol-S4-MK2-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK2-hid-scripts.js
@@ -945,12 +945,12 @@ TraktorS4MK2.cueHandler = function(field) {
   var splitted = field.id.split(".");
   var group = splitted[0];
   if (TraktorS4MK2.controller.shift_pressed[group]) {
-    if (TraktorS4MK2.ShiftCueButtonAction == "REWIND") {
+    if (TraktorS4MK2.ShiftCueButtonAction === "REWIND") {
       if (field.value === 0) {
         return;
       }
       engine.setValue(field.group, "start_stop", 1);
-    } else if (TraktorS4MK2.ShiftCueButtonAction == "REVERSEROLL") {
+    } else if (TraktorS4MK2.ShiftCueButtonAction === "REVERSEROLL") {
       engine.setValue(field.group, "reverseroll", field.value);
     } else {
       print ("Traktor S4 WARNING: Invalid ShiftCueButtonAction picked.  Must be either REWIND " +

--- a/res/controllers/Traktor-Kontrol-S4-MK2-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK2-hid-scripts.js
@@ -1474,7 +1474,7 @@ TraktorS4MK2.resolveDeckIfActive = function(group) {
 }
 
 TraktorS4MK2.outputChannelCallback = function(value,group,key) {
-  var led_value = 0x19;
+  var led_value = 0x09;
   if (value) {
     led_value = 0x7F;
   }
@@ -1495,7 +1495,7 @@ TraktorS4MK2.outputCallback = function(value,group,key) {
     return;
   }
 
-  var led_value = 0x1F;
+  var led_value = 0x09;
   if (value) {
     led_value = 0x7F;
   }
@@ -1508,7 +1508,7 @@ TraktorS4MK2.outputCallbackLoop = function(value,group,key) {
     return;
   }
 
-  var led_value = 0x1F;
+  var led_value = 0x09;
   if (engine.getValue(group, "loop_enabled")) {
     led_value = 0x7F;
   }
@@ -1538,13 +1538,13 @@ TraktorS4MK2.outputCueCallback = function(value, group, key) {
   // Use different colors for decks 1/2 and 3/4 that match LateNight (red and blue).
   if (group === "[Channel1]" || group === "[Channel2]") {
     if (value === 1) {
-      RGB_value = [0x7F, 0x02, 0x02];
+      RGB_value = [0x7F, 0x04, 0x04];
     } else {
-      RGB_value = [0x1F, 0x02, 0x02];
+      RGB_value = [0x08, 0x01, 0x01];
     }
   } else {
     if (value === 1) {
-      RGB_value = [0x04, 0x1F, 0x7F];
+      RGB_value = [0x04, 0x04, 0x7F];
     } else {
       RGB_value = [0x01, 0x01, 0x08];
     }


### PR DESCRIPTION
Summary:

- Auto Slip Mode added:
  - Press Play (in the loop recorder) + Flux
  - Remix LED lights up
  - Jog wheel scratches will start slip mode on wheel press and exit on touch up
  - Entering a loop will start slip mode, on loop exit slip mode also exits
  - Hotcues on touchdown will start slip mode, on touchup exit
- Add range for speed splider - 8, 16, 24, 50, 90 : Shift + flux/reset buttons
- LED colours slightly changed to match LateNight
- Minor code changes 