### PR TITLE
components.js fixes

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -578,11 +578,11 @@
             this.currentDeck = newGroup;
             this.reconnectComponents(function (component) {
                 if (component.group.search(script.channelRegEx) !== -1) {
-                    component.group = this.currentDeck;
+                    component.group = newGroup;
                 } else if (component.group.search(script.eqRegEx) !== -1) {
-                    component.group = '[EqualizerRack1_' + this.currentDeck + '_Effect1]';
+                    component.group = '[EqualizerRack1_' + newGroup + '_Effect1]';
                 } else if (component.group.search(script.quickEffectRegEx) !== -1) {
-                    component.group = '[QuickEffectRack1_' + this.currentDeck + ']';
+                    component.group = '[QuickEffectRack1_' + newGroup + ']';
                 }
                 // Do not alter the Component's group if it does not match any of those RegExs.
 

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -577,7 +577,8 @@
         setCurrentDeck: function (newGroup) {
             this.currentDeck = newGroup;
             this.reconnectComponents(function (component) {
-                if (component.group.search(script.channelRegEx) !== -1) {
+                if (component.group === undefined
+                      || component.group.search(script.channelRegEx) !== -1) {
                     component.group = newGroup;
                 } else if (component.group.search(script.eqRegEx) !== -1) {
                     component.group = '[EqualizerRack1_' + newGroup + '_Effect1]';


### PR DESCRIPTION
Since `forEachComponent` evaluates callbacks within the context of the current
component container, `this.currentDeck` will be undefined after we recurse into
a component container inside of the current deck.

Instead, we now propagate the current deck downwards by referring to the
argument `setCurrentDeck` was invoked with.