### PR TITLE
Allow maximum deck speed of 4x normal

### DIFF
--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -42,7 +42,7 @@ RateControl::RateControl(QString group,
     m_pScratchController = new PositionScratchController(group);
 
     m_pRateDir = new ControlObject(ConfigKey(group, "rate_dir"));
-    m_pRateRange = new ControlPotmeter(ConfigKey(group, "rateRange"), 0.01, 0.90);
+    m_pRateRange = new ControlPotmeter(ConfigKey(group, "rateRange"), 0.01, 4.00);
     // Allow rate slider to go out of bounds so that master sync rate
     // adjustments are not capped.
     m_pRateSlider = new ControlPotmeter(ConfigKey(group, "rate"),


### PR DESCRIPTION
- Max speed must at least be 2x normal (100%, 1.0) for certain controller pitch range change wraparounds (AA VMS, Reloop TerminalMix) and effects (Stanton SCS.3d) to work. (see https://github.com/mixxxdj/mixxx/pull/1490#issuecomment-377559797)
- There is a use case for increasing speed beyond 100% such as sample pads or a keyboard sample controller. (Beyond 400% starts to become inaudible so that's a good upper bound. Otherwise there's no need to artificially limit it here.)