### PR TITLE
Fix CachingReader compiler warnings about non-trivial types

### DIFF
--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -204,7 +204,7 @@ void CachingReader::process() {
         } else if (status.status == TRACK_LOADED) {
             m_readerStatus = status.status;
             // Reset the max. readable frame index
-            m_readableFrameIndexRange = status.readableFrameIndexRange;
+            m_readableFrameIndexRange = status.readableFrameIndexRange();
             // Free all chunks with sample data from a previous track
             freeAllChunks();
         }
@@ -212,7 +212,7 @@ void CachingReader::process() {
             // Adjust the readable frame index range after loading or reading
             m_readableFrameIndexRange = intersect(
                     m_readableFrameIndexRange,
-                    status.readableFrameIndexRange);
+                    status.readableFrameIndexRange());
         } else {
             // Reset the readable frame index range
             m_readableFrameIndexRange = mixxx::IndexRange();
@@ -467,8 +467,8 @@ void CachingReader::hintAndMaybeWake(const HintVector& hintList) {
                 }
                 // Do not insert the allocated chunk into the MRU/LRU list,
                 // because it will be handed over to the worker immediately
-                CachingReaderChunkReadRequest request(pChunk);
-                pChunk->giveToWorker();
+                CachingReaderChunkReadRequest request;
+                request.giveToWorker(pChunk);
                 // kLogger.debug() << "Requesting read of chunk" << current << "into" << pChunk;
                 // kLogger.debug() << "Requesting read into " << request.chunk->data;
                 if (m_chunkReadRequestFIFO.write(&request, 1) != 1) {


### PR DESCRIPTION
DONE:
- Only use trivial members
- Replace constructor with explicit initialization functions

New warnings from GCC 8.1.1:
```
[CXX] src/engine/cachingreader.cpp
In file included from src/engine/cachingreader.h:18,
                 from src/engine/cachingreader.cpp:4:
src/util/fifo.h: In instantiation of ‘FIFO<DataType>::FIFO(int) [with DataType = CachingReaderChunkReadRequest]’:
src/engine/cachingreader.cpp:40:71:   required from here
src/util/fifo.h:25:15: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct CachingReaderChunkReadRequest’; use assignment or value-initialization instead [-Wclass-memaccess]
         memset(m_data, 0, sizeof(DataType) * size);
         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from src/engine/cachingreader.h:19,
                 from src/engine/cachingreader.cpp:4:
src/engine/cachingreaderworker.h:17:16: note: ‘struct CachingReaderChunkReadRequest’ declared here
 typedef struct CachingReaderChunkReadRequest {
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from src/engine/cachingreader.h:18,
                 from src/engine/cachingreader.cpp:4:
src/util/fifo.h: In instantiation of ‘FIFO<DataType>::FIFO(int) [with DataType = ReaderStatusUpdate]’:
src/engine/cachingreader.cpp:40:71:   required from here
src/util/fifo.h:25:15: warning: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘struct ReaderStatusUpdate’ with no trivial copy-assignment; use assignment or value-initialization instead [-Wclass-memaccess]
         memset(m_data, 0, sizeof(DataType) * size);
         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from src/engine/cachingreader.h:19,
                 from src/engine/cachingreader.cpp:4:
src/engine/cachingreaderworker.h:35:16: note: ‘struct ReaderStatusUpdate’ declared here
 typedef struct ReaderStatusUpdate {
                ^~~~~~~~~~~~~~~~~~
```