### PR TITLE
Update American Audio VMS4 preset for Mixxx v2.1.x

### DIFF
--- a/res/controllers/American Audio VMS4.midi.xml
+++ b/res/controllers/American Audio VMS4.midi.xml
@@ -714,6 +714,15 @@ Assumes "Post EQ" mode. (See Wiki for full setup instructions.)</description>
                <Script-Binding/>
             </options>
          </control>
+         <control>  <!-- Shifted -->
+            <group>[EffectRack1_EffectUnit1]</group>
+            <key>VMS4.strip_fx_dw</key>
+            <status>0xB1</status>
+            <midino>0x28</midino>
+            <options>
+               <Script-Binding/>
+            </options>
+         </control>
         <control>
             <group>[Channel1]</group>
             <key>VMS4.strip_touch</key>
@@ -1406,6 +1415,15 @@ Assumes "Post EQ" mode. (See Wiki for full setup instructions.)</description>
             <group>[Library]</group>
             <key>VMS4.strip_scroll</key>
             <status>0xB0</status>
+            <midino>0x2D</midino>
+            <options>
+               <Script-Binding/>
+            </options>
+         </control>
+         <control>  <!-- Shifted -->
+            <group>[EffectRack1_EffectUnit2]</group>
+            <key>VMS4.strip_fx_dw</key>
+            <status>0xB1</status>
             <midino>0x2D</midino>
             <options>
                <Script-Binding/>

--- a/res/controllers/American Audio VMS4.midi.xml
+++ b/res/controllers/American Audio VMS4.midi.xml
@@ -4,7 +4,7 @@
       <name>American Audio VMS4/4.1</name>
       <author>Anders Gunnarsson &amp; Sean M. Pappalardo</author>
       <wiki>http://mixxx.org/wiki/doku.php/american_audio_vms4</wiki>
-      <description>2-deck control/4-deck mixer preset for Mixxx 2.0. Assumes "Post EQ" mode. (See Wiki for full setup instructions.)</description>
+      <description>2-deck control/4-deck mixer preset for Mixxx 2.1. Assumes "Post EQ" mode. (See Wiki for full setup instructions.)</description>
    </info>
    <controller id="American Audio VMS4">
       <scriptfiles>
@@ -270,25 +270,37 @@
          </control>
          <control><!-- on -->
             <group>[Channel1]</group>
+            <key>cue_play</key>
+            <status>0x91</status>
+            <midino>0x0C</midino>
+         </control>
+         <control><!-- off -->
+            <group>[Channel1]</group>
+            <key>cue_play</key>
+            <status>0x81</status>
+            <midino>0x0C</midino>
+         </control>
+         <control><!-- on -->
+            <group>[Channel1]</group>
             <key>play</key>
             <status>0x90</status>
             <midino>0x0D</midino>
          </control>
          <control><!-- off -->
-             <group>[Channel1]</group>
-             <key>play</key>
-             <status>0x80</status>
-             <midino>0x0D</midino>
+            <group>[Channel1]</group>
+            <key>play</key>
+            <status>0x80</status>
+            <midino>0x0D</midino>
          </control>
          <control><!-- Shifted Play -->
             <group>[Channel1]</group>
-            <key>start_play</key>
+            <key>sync_master</key>
             <status>0x91</status>
             <midino>0x0D</midino>
          </control>
          <control><!-- Shifted Play -->
             <group>[Channel1]</group>
-            <key>start_play</key>
+            <key>sync_master</key>
             <status>0x81</status>
             <midino>0x0D</midino>
          </control>
@@ -487,7 +499,7 @@
          </control>
          <control><!-- on -->
             <group>[Channel1]</group>
-            <key>reloop_exit</key>
+            <key>reloop_toggle</key>
             <status>0x90</status>
             <midino>0x21</midino>
             <options>
@@ -496,7 +508,7 @@
          </control>
          <control><!-- off -->
             <group>[Channel1]</group>
-            <key>reloop_exit</key>
+            <key>reloop_toggle</key>
             <status>0x80</status>
             <midino>0x21</midino>
             <options>
@@ -924,19 +936,31 @@
          </control>
          <control><!-- on -->
             <group>[Channel2]</group>
+            <key>cue_play</key>
+            <status>0x91</status>
+            <midino>0x2E</midino>
+         </control>
+         <control><!-- off -->
+            <group>[Channel2]</group>
+            <key>cue_play</key>
+            <status>0x81</status>
+            <midino>0x2E</midino>
+         </control>
+         <control><!-- on -->
+            <group>[Channel2]</group>
             <key>play</key>
             <status>0x90</status>
             <midino>0x2F</midino>
          </control>
          <control><!-- Shifted Play -->
             <group>[Channel2]</group>
-            <key>start_play</key>
+            <key>sync_master</key>
             <status>0x91</status>
             <midino>0x2F</midino>
          </control>
          <control><!-- Shifted Play -->
             <group>[Channel2]</group>
-            <key>start_play</key>
+            <key>sync_master</key>
             <status>0x81</status>
             <midino>0x2F</midino>
          </control>
@@ -1136,7 +1160,7 @@
          </control>
          <control><!-- on -->
             <group>[Channel2]</group>
-            <key>reloop_exit</key>
+            <key>reloop_toggle</key>
             <status>0x90</status>
             <midino>0x43</midino>
             <options>
@@ -1145,7 +1169,7 @@
          </control>
          <control><!-- off -->
             <group>[Channel2]</group>
-            <key>reloop_exit</key>
+            <key>reloop_toggle</key>
             <status>0x80</status>
             <midino>0x43</midino>
             <options>

--- a/res/controllers/American Audio VMS4.midi.xml
+++ b/res/controllers/American Audio VMS4.midi.xml
@@ -4,7 +4,8 @@
       <name>American Audio VMS4/4.1</name>
       <author>Anders Gunnarsson &amp; Sean M. Pappalardo</author>
       <wiki>http://mixxx.org/wiki/doku.php/american_audio_vms4</wiki>
-      <description>2-deck control/4-deck mixer preset for Mixxx 2.1. Assumes "Post EQ" mode. (See Wiki for full setup instructions.)</description>
+      <description>2-deck control/4-deck mixer preset for Mixxx 2.1. 
+Assumes "Post EQ" mode. (See Wiki for full setup instructions.)</description>
    </info>
    <controller id="American Audio VMS4">
       <scriptfiles>
@@ -270,13 +271,13 @@
          </control>
          <control><!-- on -->
             <group>[Channel1]</group>
-            <key>cue_play</key>
+            <key>cue_gotoandplay</key>
             <status>0x91</status>
             <midino>0x0C</midino>
          </control>
          <control><!-- off -->
             <group>[Channel1]</group>
-            <key>cue_play</key>
+            <key>cue_gotoandplay</key>
             <status>0x81</status>
             <midino>0x0C</midino>
          </control>
@@ -705,10 +706,46 @@
             </options>
          </control>
          <control>
-            <group>[Channel1]</group>
-            <key>VMS4.touch_strip</key>
+            <group>[Library]</group>
+            <key>VMS4.strip_scroll</key>
             <status>0xB0</status>
             <midino>0x28</midino>
+            <options>
+               <Script-Binding/>
+            </options>
+         </control>
+        <control>
+            <group>[Channel1]</group>
+            <key>VMS4.strip_touch</key>
+            <status>0x90</status>
+            <midino>0x57</midino>
+            <options>
+               <Script-Binding/>
+            </options>
+         </control>
+        <control>
+            <group>[Channel1]</group>
+            <key>VMS4.strip_touch</key>
+            <status>0x80</status>
+            <midino>0x57</midino>
+            <options>
+               <Script-Binding/>
+            </options>
+         </control>
+         <control> <!-- Shifted -->
+            <group>[Channel1]</group>
+            <key>VMS4.strip_touch</key>
+            <status>0x91</status>
+            <midino>0x57</midino>
+            <options>
+               <Script-Binding/>
+            </options>
+         </control>
+        <control>
+            <group>[Channel1]</group>
+            <key>VMS4.strip_touch</key>
+            <status>0x81</status>
+            <midino>0x57</midino>
             <options>
                <Script-Binding/>
             </options>
@@ -936,13 +973,13 @@
          </control>
          <control><!-- on -->
             <group>[Channel2]</group>
-            <key>cue_play</key>
+            <key>cue_gotoandplay</key>
             <status>0x91</status>
             <midino>0x2E</midino>
          </control>
          <control><!-- off -->
             <group>[Channel2]</group>
-            <key>cue_play</key>
+            <key>cue_gotoandplay</key>
             <status>0x81</status>
             <midino>0x2E</midino>
          </control>
@@ -1366,10 +1403,46 @@
             </options>
          </control>
          <control>
-            <group>[Channel2]</group>
-            <key>VMS4.touch_strip</key>
+            <group>[Library]</group>
+            <key>VMS4.strip_scroll</key>
             <status>0xB0</status>
             <midino>0x2D</midino>
+            <options>
+               <Script-Binding/>
+            </options>
+         </control>
+        <control>
+            <group>[Channel2]</group>
+            <key>VMS4.strip_touch</key>
+            <status>0x90</status>
+            <midino>0x58</midino>
+            <options>
+               <Script-Binding/>
+            </options>
+         </control>
+        <control>
+            <group>[Channel2]</group>
+            <key>VMS4.strip_touch</key>
+            <status>0x80</status>
+            <midino>0x58</midino>
+            <options>
+               <Script-Binding/>
+            </options>
+         </control>
+         <control> <!-- Shifted -->
+            <group>[Channel2]</group>
+            <key>VMS4.strip_touch</key>
+            <status>0x91</status>
+            <midino>0x58</midino>
+            <options>
+               <Script-Binding/>
+            </options>
+         </control>
+        <control>
+            <group>[Channel2]</group>
+            <key>VMS4.strip_touch</key>
+            <status>0x81</status>
+            <midino>0x58</midino>
             <options>
                <Script-Binding/>
             </options>

--- a/res/controllers/American Audio VMS4.midi.xml
+++ b/res/controllers/American Audio VMS4.midi.xml
@@ -715,7 +715,7 @@ Assumes "Post EQ" mode. (See Wiki for full setup instructions.)</description>
             </options>
          </control>
          <control>  <!-- Shifted -->
-            <group>[EffectRack1_EffectUnit1]</group>
+            <group>[Channel1]</group>
             <key>VMS4.strip_fx_dw</key>
             <status>0xB1</status>
             <midino>0x28</midino>
@@ -1421,7 +1421,7 @@ Assumes "Post EQ" mode. (See Wiki for full setup instructions.)</description>
             </options>
          </control>
          <control>  <!-- Shifted -->
-            <group>[EffectRack1_EffectUnit2]</group>
+            <group>[Channel2]</group>
             <key>VMS4.strip_fx_dw</key>
             <status>0xB1</status>
             <midino>0x2D</midino>

--- a/res/controllers/American-Audio-VMS4-scripts.js
+++ b/res/controllers/American-Audio-VMS4-scripts.js
@@ -313,14 +313,14 @@ VMS4.effectSelect = function(channel, control, value, status, group) {
     
     diff += wrapCount*128;
     
-    engine.setValue("[EffectRack1_EffectUnit"+VMS4.GetDeckNum(group)+"]","chain_selector",diff);
+    engine.setValue("[EffectRack1_EffectUnit"+VMS4.GetDeckNum(group)+"_Effect1]","effect_selector",diff);
 }
 
 VMS4.effectSelectPress = function(channel, control, value, status, group) {
     var deckNum = VMS4.GetDeckNum(group);
     if (value > 0x40) {
-        engine.setValue("[EffectRack1_EffectUnit"+deckNum+"]","enabled",
-                        !engine.getValue("[EffectRack1_EffectUnit"+deckNum+"]","enabled")
+        engine.setValue("[EffectRack1_EffectUnit"+deckNum+"_Effect1]","enabled",
+                        !engine.getValue("[EffectRack1_EffectUnit"+deckNum+"_Effect1]","enabled")
         );
     }
 }

--- a/res/controllers/American-Audio-VMS4-scripts.js
+++ b/res/controllers/American-Audio-VMS4-scripts.js
@@ -395,7 +395,7 @@ VMS4.jog_move_msb = function(channel, control, value, status, group) {
 VMS4.touch_strip = function(channel, control, value, status, group) {
    // Only modify the playposition if the deck is NOT playing!
    if (engine.getValue(group, "play") === 0) {
-      engine.setValue(group, "playposition", value);
+       engine.setValue(group, "playposition", value/0x7F);
    }
 }
 

--- a/res/controllers/American-Audio-VMS4-scripts.js
+++ b/res/controllers/American-Audio-VMS4-scripts.js
@@ -1,7 +1,7 @@
 /**
- * American Audio VMS4 controller script v2.0 for Mixxx v2.0
+ * American Audio VMS4 controller script v2.1 for Mixxx v2.1.x
  * Copyright (C) 2010  Anders Gunnarsson
- * Copyright (C) 2011-2015  Sean M. Pappalardo
+ * Copyright (C) 2011-2018  Sean M. Pappalardo
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -228,6 +228,8 @@ VMS4.Deck.prototype.keyLockButtonHandler = function(value) {
 }
 
 VMS4.Deck.prototype.effectParamButtonHandler = function(value) {
+    // Couldn't get this to work. The buttons are mapped instead to VMS4.effectParameterButton
+    
 //     if(value == ButtonState.pressed) {
 //         this.controlEffectParameter=!this.controlEffectParameter;
 //         if (this.controlEffectParameter) {
@@ -244,6 +246,10 @@ VMS4.Deck.prototype.effectParamButtonHandler = function(value) {
 VMS4.Decks = {"Left":new VMS4.Deck(1,"[Channel1]"), "Right":new VMS4.Deck(2,"[Channel2]")};
 VMS4.GroupToDeck = {"[Channel1]":"Left", "[Channel2]":"Right"};
 VMS4.GroupToDeckNum = {"[Channel1]":1, "[Channel2]":2, "[Channel3]":3, "[Channel4]":4};
+VMS4.StripToSide = {0x28:"Left", 0x2D:"Right"};
+VMS4.touchStripPos = {"Left":null, "Right":null}; // Stores the position on touch
+                                                  // to convert the absolute sliders
+                                                  // to relative ones
 
 VMS4.GetDeck = function(group) {
    try {
@@ -392,11 +398,40 @@ VMS4.jog_move_msb = function(channel, control, value, status, group) {
    deck.jogMsb = value;
 }
 
-VMS4.touch_strip = function(channel, control, value, status, group) {
-   // Only modify the playposition if the deck is NOT playing!
-   if (engine.getValue(group, "play") === 0) {
-       engine.setValue(group, "playposition", value/0x7F);
-   }
+// VMS4.touch_strip = function(channel, control, value, status, group) {
+//    // Only modify the playposition if the deck is NOT playing!
+//    if (engine.getValue(group, "play") === 0) {
+//        engine.setValue(group, "playposition", value/0x7F);
+//    }
+// }
+
+VMS4.strip_touch = function(channel, control, value, status, group) {
+    var deck = VMS4.GetDeckNum(group);
+    if (deck === 1) {    // Left side
+        if ((status & 0xF0) === 0x90) {    // If button down
+            // TODO: Need a CO to focus explicitly on category selection pane
+            //  "[Library]","MoveFocus" just toggles and is frustrating
+        } else {    // Button up
+            VMS4.touchStripPos["Left"] = null;
+        }
+    } else {    // Right side
+        if ((status & 0xF0) === 0x90) {    // If button down
+            // TODO: Need a CO to focus explicitly on track selection pane
+            //  "[Library]","MoveFocus" just toggles and is frustrating
+        } else {    // Button up
+            VMS4.touchStripPos["Right"] = null;
+        }
+    }
+}
+
+VMS4.strip_scroll = function(channel, control, value, status, group) {
+    var side = VMS4.StripToSide[control];
+    if (VMS4.touchStripPos[side] != null) {
+        // Higher on the strip gives a higher value, and up is negative on Library
+        //  scroll controls
+        engine.setValue(group, "MoveVertical", VMS4.touchStripPos[side] - value);
+    }
+    VMS4.touchStripPos[side] = value;
 }
 
 VMS4.vinyl = function(channel, control, value, status, group) {

--- a/res/controllers/American-Audio-VMS4-scripts.js
+++ b/res/controllers/American-Audio-VMS4-scripts.js
@@ -326,9 +326,7 @@ VMS4.effectSelect = function(channel, control, value, status, group) {
 VMS4.effectSelectPress = function(channel, control, value, status, group) {
     var deckNum = VMS4.GetDeckNum(group);
     if (value > 0x40) {
-        engine.setValue("[EffectRack1_EffectUnit"+deckNum+"_Effect1]","enabled",
-                        !engine.getValue("[EffectRack1_EffectUnit"+deckNum+"_Effect1]","enabled")
-        );
+        script.toggleControl("[EffectRack1_EffectUnit"+deckNum+"_Effect1]","enabled");
     }
 }
 
@@ -416,7 +414,7 @@ VMS4.strip_touch = function(channel, control, value, status, group) {
 
 VMS4.strip_scroll = function(channel, control, value, status, group) {
     var side = VMS4.StripToSide[control];
-    if (VMS4.touchStripPos[side] != null) {
+    if (VMS4.touchStripPos[side] !== null) {
         // Higher on the strip gives a higher value, and up is negative on Library
         //  scroll controls
         if (side === "Left") {

--- a/res/controllers/American-Audio-VMS4-scripts.js
+++ b/res/controllers/American-Audio-VMS4-scripts.js
@@ -396,7 +396,13 @@ VMS4.jog_move_msb = function(channel, control, value, status, group) {
 }
 
 VMS4.strip_fx_dw = function(channel, control, value, status, group) {
-    engine.setParameter(group,"mix",value/0x7F);
+    var deck = VMS4.GetDeckNum(group);
+    // When the deck is playing, adjust effect dry/wet. When it isn't, do needle drop.
+    if (engine.getValue(group, "play") === 0) {
+        engine.setValue(group, "playposition", value/0x7F);
+    } else {
+        engine.setParameter("[EffectRack1_EffectUnit"+deck+"]","mix",value/0x7F);
+    }
 }
 
 VMS4.strip_touch = function(channel, control, value, status, group) {

--- a/res/controllers/American-Audio-VMS4-scripts.js
+++ b/res/controllers/American-Audio-VMS4-scripts.js
@@ -319,7 +319,8 @@ VMS4.effectSelect = function(channel, control, value, status, group) {
     
     diff += wrapCount*128;
     
-    engine.setValue("[EffectRack1_EffectUnit"+VMS4.GetDeckNum(group)+"_Effect1]","effect_selector",diff);
+    engine.setValue("[EffectRack1_EffectUnit"+VMS4.GetDeckNum(group)+"_Effect1]",
+                    "effect_selector",diff);
 }
 
 VMS4.effectSelectPress = function(channel, control, value, status, group) {
@@ -336,11 +337,9 @@ VMS4.effectControl = function(channel, control, value, status, group) {
     var deck = VMS4.GetDeck(group);
     var deckNum = VMS4.GetDeckNum(group);
     if (deck.controlEffectParameter) {
-        engine.setValue("[EffectRack1_EffectUnit"+deckNum+"]","super1",
-                        script.absoluteLin(value,0,1));
+        engine.setParameter("[EffectRack1_EffectUnit"+deckNum+"]","super1",value/0x7F);
     } else {
-        engine.setValue("[EffectRack1_EffectUnit"+deckNum+"]","mix",
-                        script.absoluteLin(value,0,1));
+        engine.setParameter("[EffectRack1_EffectUnit"+deckNum+"]","mix",value/0x7F);
     }
 }
 
@@ -398,27 +397,18 @@ VMS4.jog_move_msb = function(channel, control, value, status, group) {
    deck.jogMsb = value;
 }
 
-// VMS4.touch_strip = function(channel, control, value, status, group) {
-//    // Only modify the playposition if the deck is NOT playing!
-//    if (engine.getValue(group, "play") === 0) {
-//        engine.setValue(group, "playposition", value/0x7F);
-//    }
-// }
+VMS4.strip_fx_dw = function(channel, control, value, status, group) {
+    engine.setParameter(group,"mix",value/0x7F);
+}
 
 VMS4.strip_touch = function(channel, control, value, status, group) {
     var deck = VMS4.GetDeckNum(group);
     if (deck === 1) {    // Left side
-        if ((status & 0xF0) === 0x90) {    // If button down
-            // TODO: Need a CO to focus explicitly on category selection pane
-            //  "[Library]","MoveFocus" just toggles and is frustrating
-        } else {    // Button up
+        if ((status & 0xF0) === 0x80) {    // If button up
             VMS4.touchStripPos["Left"] = null;
         }
     } else {    // Right side
-        if ((status & 0xF0) === 0x90) {    // If button down
-            // TODO: Need a CO to focus explicitly on track selection pane
-            //  "[Library]","MoveFocus" just toggles and is frustrating
-        } else {    // Button up
+        if ((status & 0xF0) === 0x80) {    // If button up
             VMS4.touchStripPos["Right"] = null;
         }
     }
@@ -429,7 +419,13 @@ VMS4.strip_scroll = function(channel, control, value, status, group) {
     if (VMS4.touchStripPos[side] != null) {
         // Higher on the strip gives a higher value, and up is negative on Library
         //  scroll controls
-        engine.setValue(group, "MoveVertical", VMS4.touchStripPos[side] - value);
+        if (side === "Left") {
+            engine.setValue("[Playlist]", "SelectPlaylist", 
+                            VMS4.touchStripPos[side] - value);
+        } else {
+            engine.setValue("[Playlist]", "SelectTrackKnob", 
+                            VMS4.touchStripPos[side] - value);
+        }
     }
     VMS4.touchStripPos[side] = value;
 }


### PR DESCRIPTION
- Add cue-play function on shifted CUE buttons (to match Traktor Edition label)
- Add sync_master on shifted PLAY buttons (to match Traktor Edition label)
- Update reloop buttons to use reloop_toggle
- Make effect controls operate on UnitN_EffectM, correcting behavior
- Add library pane scrolling to touch strips
- Add effects dry/wet control to shifted touch strips (to match Traktor Edition labels), replaces needle-drop functionality
- Replace setValue() with setParameter() on effect parameter controls
- Update version numbers