### PR TITLE
Fix macOS build: Add explicit includes for QButtonGroup and QStyle.

### DIFF
--- a/src/library/dlganalysis.h
+++ b/src/library/dlganalysis.h
@@ -1,6 +1,7 @@
 #ifndef DLGANALYSIS_H
 #define DLGANALYSIS_H
 
+#include <QButtonGroup>
 #include <QItemSelection>
 
 #include "preferences/usersettings.h"

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -1,4 +1,5 @@
 #include <QDesktopWidget>
+#include <QStyle>
 #include <QWheelEvent>
 
 #include "library/dlgcoverartfullsize.h"

--- a/src/preferences/dialog/dlgprefcrossfader.cpp
+++ b/src/preferences/dialog/dlgprefcrossfader.cpp
@@ -1,3 +1,4 @@
+#include <QButtonGroup>
 #include <QtDebug>
 
 #include "preferences/dialog/dlgprefcrossfader.h"

--- a/src/preferences/dialog/dlgprefrecord.h
+++ b/src/preferences/dialog/dlgprefrecord.h
@@ -1,6 +1,7 @@
 #ifndef DLGPREFRECORD_H
 #define DLGPREFRECORD_H
 
+#include <QButtonGroup>
 #include <QRadioButton>
 #include <QWidget>
 

--- a/src/preferences/dialog/dlgprefreplaygain.h
+++ b/src/preferences/dialog/dlgprefreplaygain.h
@@ -1,6 +1,7 @@
 #ifndef DLGPREFREPLAYGAIN_H
 #define DLGPREFREPLAYGAIN_H
 
+#include <QButtonGroup>
 #include <QWidget>
 
 #include "preferences/dialog/ui_dlgprefreplaygaindlg.h"


### PR DESCRIPTION
Homebrew updated to Qt 5.11, which removes an include of QButtonGroup somewhere.