### PR TITLE
fix crash pressing Apply in DlgPrefLV2

### DIFF
--- a/src/effects/effectrack.cpp
+++ b/src/effects/effectrack.cpp
@@ -214,7 +214,7 @@ QDomElement EffectRack::toXml(QDomDocument* doc) const {
 
 void EffectRack::refresh() {
     for (const auto& pChainSlot: m_effectChainSlots) {
-        EffectChainPointer pChain = pChainSlot->getEffectChain();
+        EffectChainPointer pChain = pChainSlot->getOrCreateEffectChain(m_pEffectsManager);
         pChain->refreshAllEffects();
     }
 }


### PR DESCRIPTION
when Mixxx is loaded with an effects.xml file that has any empty
effects chains

fixing https://bugs.launchpad.net/mixxx/+bug/1773097

This is just a quick hack on top of an overcomplicated
architecture. EffectChain and EffectChainSlot need to be merged
before adding any more features to the effects system.