### PR TITLE
Install qt5 soundsources to a different folder to avoid crashes, fixes lp1774639

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -374,15 +374,17 @@ if build.platform_is_linux or build.platform_is_bsd:
                 binary = env.Install(unix_bin_path, binary_files)
                 skins = env.Install(os.path.join(unix_share_path, 'mixxx', 'skins'), skin_files)
                 fonts = env.Install(os.path.join(unix_share_path, 'mixxx', 'fonts'), font_files)
-                vamp_plugin =  env.Install(
-                        os.path.join(unix_lib_path, 'mixxx', 'plugins', 'vamp'),
-                        libmixxxminimal_vamp_plugin)
-
                 if qt5:
+                    vamp_plugin =  env.Install(
+                            os.path.join(unix_lib_path, 'mixxx', 'plugins', 'vampqt5'),
+                            libmixxxminimal_vamp_plugin)
                     soundsource_plugins = env.Install(
                             os.path.join(unix_lib_path, 'mixxx', 'plugins', 'soundsourceqt5'),
                             soundsource_plugin_files)
-                else: 
+                else:
+                    vamp_plugin =  env.Install(
+                            os.path.join(unix_lib_path, 'mixxx', 'plugins', 'vamp'),
+                            libmixxxminimal_vamp_plugin) 
                     soundsource_plugins = env.Install(
                             os.path.join(unix_lib_path, 'mixxx', 'plugins', 'soundsource'),
                             soundsource_plugin_files)           

--- a/src/SConscript
+++ b/src/SConscript
@@ -378,9 +378,14 @@ if build.platform_is_linux or build.platform_is_bsd:
                         os.path.join(unix_lib_path, 'mixxx', 'plugins', 'vamp'),
                         libmixxxminimal_vamp_plugin)
 
-                soundsource_plugins = env.Install(
-                        os.path.join(unix_lib_path, 'mixxx', 'plugins', 'soundsource'),
-                        soundsource_plugin_files)
+                if qt5:
+                    soundsource_plugins = env.Install(
+                            os.path.join(unix_lib_path, 'mixxx', 'plugins', 'soundsourceqt5'),
+                            soundsource_plugin_files)
+                else: 
+                    soundsource_plugins = env.Install(
+                            os.path.join(unix_lib_path, 'mixxx', 'plugins', 'soundsource'),
+                            soundsource_plugin_files)           
                 controllermappings = env.Install(os.path.join(unix_share_path, 'mixxx', 'controllers'), controllermappings_files)
                 translations = env.Install(os.path.join(unix_share_path, 'mixxx', 'translations'), translation_files)
                 keyboardmappings = env.Install(os.path.join(unix_share_path, 'mixxx', 'keyboard'), keyboardmappings_files)

--- a/src/analyzer/vamp/vamppluginadapter.cpp
+++ b/src/analyzer/vamp/vamppluginadapter.cpp
@@ -96,15 +96,20 @@ void initPluginPaths() {
         logIgnoringNonExistentPath(dataPluginDir);
     }
 #elif __LINUX__
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    QString vampDir = "vampqt5";
+#else
+    QString vampDir = "vamp";
+#endif
     QDir libPath(UNIX_LIB_PATH);
-    if (libPath.cd("plugins") && libPath.cd("vamp")) {
+    if (libPath.cd("plugins") && libPath.cd(vampDir)) {
         envPathList = composeEnvPathList(envPathList, libPath);
     } else {
         logIgnoringNonExistentPath(libPath);
     }
 
     QDir dataPluginDir(dataLocation);
-    if (dataPluginDir.cd("plugins") && dataPluginDir.cd("vamp")) {
+    if (dataPluginDir.cd("plugins") && dataPluginDir.cd(vampDir)) {
         envPathList = composeEnvPathList(envPathList, dataPluginDir);
     } else {
         logIgnoringNonExistentPath(dataPluginDir);

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -68,12 +68,17 @@ QList<QDir> getSoundSourcePluginDirectories() {
     // 'bin' folder of $PREFIX, so we just traverse
     // ../lib/mixxx/plugins/soundsource.
     QDir libPluginDir(UNIX_LIB_PATH);
-    if (libPluginDir.cd("plugins") && libPluginDir.cd("soundsource")) {
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+        QString soundsourceDir = "soundsourceqt5";
+    #else
+        QString soundsourceDir = "soundsource";
+    #endif
+    if (libPluginDir.cd("plugins") && libPluginDir.cd(soundsourceDir)) {
         pluginDirs << libPluginDir;
     }
 
     QDir dataPluginDir(dataLocation);
-    if (dataPluginDir.cd("plugins") && dataPluginDir.cd("soundsource")) {
+    if (dataPluginDir.cd("plugins") && dataPluginDir.cd(soundsourceDir)) {
         pluginDirs << dataPluginDir;
     }
 


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1774639

This fixes the bug for Linux. I think there is something missing for the Windows and Mac OS installer. 
