### PR TITLE
Remove valueChangedFromEngine 

### DIFF
--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -29,25 +29,12 @@ ControlObject::ControlObject() {
 }
 
 ControlObject::ControlObject(ConfigKey key, bool bIgnoreNops, bool bTrack,
-                             bool bPersist, double defaultValue) {
-    initialize(key, bIgnoreNops, bTrack, bPersist, defaultValue);
-}
-
-ControlObject::~ControlObject() {
-    if (m_pControl) {
-        m_pControl->removeCreatorCO();
-    }
-}
-
-void ControlObject::initialize(ConfigKey key, bool bIgnoreNops, bool bTrack,
-                               bool bPersist, double defaultValue) {
-    m_key = key;
-
+                             bool bPersist, double defaultValue)
+        : m_key(key) {
     // Don't bother looking up the control if key is NULL. Prevents log spew.
     if (!m_key.isNull()) {
         m_pControl = ControlDoublePrivate::getControl(m_key, true, this,
-                                                      bIgnoreNops, bTrack,
-                                                      bPersist, defaultValue);
+                bIgnoreNops, bTrack, bPersist, defaultValue);
     }
 
     // getControl can fail and return a NULL control even with the create flag.
@@ -58,13 +45,17 @@ void ControlObject::initialize(ConfigKey key, bool bIgnoreNops, bool bTrack,
     }
 }
 
+ControlObject::~ControlObject() {
+    if (m_pControl) {
+        m_pControl->removeCreatorCO();
+    }
+}
+
 // slot
 void ControlObject::privateValueChanged(double dValue, QObject* pSender) {
     // Only emit valueChanged() if we did not originate this change.
     if (pSender != this) {
         emit(valueChanged(dValue));
-    } else {
-        emit(valueChangedFromEngine(dValue));
     }
 }
 

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -159,7 +159,6 @@ class ControlObject : public QObject {
 
   signals:
     void valueChanged(double);
-    void valueChangedFromEngine(double);
 
   public:
     // DEPRECATED: Called to set the control value from the controller
@@ -177,8 +176,6 @@ class ControlObject : public QObject {
     void readOnlyHandler(double v);
 
   private:
-    void initialize(ConfigKey key, bool bIgnoreNops, bool bTrack,
-                    bool bPersist, double defaultValue);
     inline bool ignoreNops() const {
         return m_pControl ? m_pControl->ignoreNops() : true;
     }

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -541,7 +541,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                                effectUnitGroups);
 
             const int iNumDecks = ControlObject::get(
-                ConfigKey("[Master]", "num_decks"));
+                    ConfigKey("[Master]", "num_decks"));
             for (int iDeckNumber = 1; iDeckNumber <= iNumDecks; ++iDeckNumber) {
                 // PlayerManager::groupForDeck is 0-indexed.
                 QString playerGroup = PlayerManager::groupForDeck(iDeckNumber - 1);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -650,7 +650,7 @@ void EngineBuffer::slotControlPlayRequest(double v) {
     bool verifiedPlay = updateIndicatorsAndModifyPlay(v > 0.0);
 
     if (!oldPlay && verifiedPlay) {
-        if (m_pQuantize->get() > 0.0
+        if (m_pQuantize->toBool()
 #ifdef __VINYLCONTROL__
                 && m_pVinylControlControl && !m_pVinylControlControl->isEnabled()
 #endif
@@ -887,7 +887,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
         // we need to sync phase or we'll be totally out of whack and the sync
         // adjuster will kick in and push the track back in to sync with the
         // master.
-        if (m_scratching_old && !is_scratching && m_pQuantize->get() > 0.0
+        if (m_scratching_old && !is_scratching && m_pQuantize->toBool()
                 && m_pSyncControl->getSyncMode() == SYNC_FOLLOWER && !paused) {
             // TODO() The resulting seek is processed in the following callback
             // That is to late
@@ -1020,13 +1020,13 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
         at_start = m_filepos_play <= 0;
         at_end = m_filepos_play >= m_trackSamplesOld;
 
-        bool repeat_enabled = m_pRepeat->get() != 0.0;
+        bool repeat_enabled = m_pRepeat->toBool();
 
         bool end_of_track = //(at_start && backwards) ||
             (at_end && !backwards);
 
         // If playbutton is pressed, check if we are at start or end of track
-        if ((m_playButton->get() || (m_fwdButton->get() || m_backButton->get()))
+        if ((m_playButton->toBool() || (m_fwdButton->toBool() || m_backButton->toBool()))
                 && end_of_track) {
             if (repeat_enabled) {
                 double fractionalPos = at_start ? 1.0 : 0;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -175,7 +175,6 @@ class EngineBuffer : public EngineObject {
     void slotControlSeek(double);
     void slotControlSeekAbs(double);
     void slotControlSeekExact(double);
-    void slotControlSlip(double);
     void slotKeylockEngineChanged(double);
 
     void slotEjectTrack(double);
@@ -306,8 +305,6 @@ class EngineBuffer : public EngineObject {
     double m_dSlipPosition;
     // Saved value of rate for slip mode
     double m_dSlipRate;
-    // m_slipEnabled is a boolean accessed from multiple threads, so we use an atomic int.
-    QAtomicInt m_slipEnabled;
     // m_bSlipEnabledProcessing is only used by the engine processing thread.
     bool m_bSlipEnabledProcessing;
 

--- a/src/engine/keycontrol.cpp
+++ b/src/engine/keycontrol.cpp
@@ -77,56 +77,28 @@ KeyControl::KeyControl(QString group,
     m_keyunlockMode->setButtonMode(ControlPushButton::TOGGLE);
 
     // In case of vinyl control "rate" is a filtered mean value for display
-    m_pRateSlider = ControlObject::getControl(ConfigKey(group, "rate"));
-    connect(m_pRateSlider, SIGNAL(valueChanged(double)),
-            this, SLOT(slotRateChanged()),
-            Qt::DirectConnection);
-    connect(m_pRateSlider, SIGNAL(valueChangedFromEngine(double)),
-            this, SLOT(slotRateChanged()),
+    m_pRateSlider = new ControlProxy(group, "rate", this);
+    m_pRateSlider->connectValueChanged(SLOT(slotRateChanged()),
             Qt::DirectConnection);
 
-    m_pRateRange = ControlObject::getControl(ConfigKey(group, "rateRange"));
-    connect(m_pRateRange, SIGNAL(valueChanged(double)),
-            this, SLOT(slotRateChanged()),
-            Qt::DirectConnection);
-    connect(m_pRateRange, SIGNAL(valueChangedFromEngine(double)),
-            this, SLOT(slotRateChanged()),
+    m_pRateRange = new ControlProxy(group, "rateRange", this);
+    m_pRateRange->connectValueChanged(SLOT(slotRateChanged()),
             Qt::DirectConnection);
 
-    m_pRateDir = ControlObject::getControl(ConfigKey(group, "rate_dir"));
-    connect(m_pRateDir, SIGNAL(valueChanged(double)),
-            this, SLOT(slotRateChanged()),
-            Qt::DirectConnection);
-    connect(m_pRateDir, SIGNAL(valueChangedFromEngine(double)),
-            this, SLOT(slotRateChanged()),
+    m_pRateDir = new ControlProxy(group, "rate_dir", this);
+    m_pRateDir->connectValueChanged(SLOT(slotRateChanged()),
             Qt::DirectConnection);
 
-    m_pVCEnabled = ControlObject::getControl(ConfigKey(group, "vinylcontrol_enabled"));
-    if (m_pVCEnabled) {
-        connect(m_pVCEnabled, SIGNAL(valueChanged(double)),
-                this, SLOT(slotRateChanged()),
+    m_pVCEnabled = new ControlProxy(group, "vinylcontrol_enabled", this);
+    m_pVCEnabled->connectValueChanged(SLOT(slotRateChanged()),
+            Qt::DirectConnection);
+
+    m_pVCRate = new ControlProxy(group, "vinylcontrol_rate", this);
+    m_pVCRate->connectValueChanged(SLOT(slotRateChanged()),
                 Qt::DirectConnection);
-        connect(m_pVCEnabled, SIGNAL(valueChangedFromEngine(double)),
-                this, SLOT(slotRateChanged()),
-                Qt::DirectConnection);
-    }
 
-    m_pVCRate = ControlObject::getControl(ConfigKey(group, "vinylcontrol_rate"));
-    if (m_pVCRate) {
-        connect(m_pVCRate, SIGNAL(valueChanged(double)),
-                this, SLOT(slotRateChanged()),
-                Qt::DirectConnection);
-        connect(m_pVCRate, SIGNAL(valueChangedFromEngine(double)),
-                this, SLOT(slotRateChanged()),
-                Qt::DirectConnection);
-    }
-
-    m_pKeylock = ControlObject::getControl(ConfigKey(group, "keylock"));
-    connect(m_pKeylock, SIGNAL(valueChanged(double)),
-            this, SLOT(slotRateChanged()),
-            Qt::DirectConnection);
-    connect(m_pKeylock, SIGNAL(valueChangedFromEngine(double)),
-            this, SLOT(slotRateChanged()),
+    m_pKeylock = new ControlProxy(group, "keylock", this);
+    m_pKeylock->connectValueChanged(SLOT(slotRateChanged()),
             Qt::DirectConnection);
 }
 
@@ -172,10 +144,12 @@ void KeyControl::updateRate() {
     // If rate is not 1.0 then we have to try and calculate the octave change
     // caused by it.
 
-    if(m_pVCEnabled && m_pVCEnabled->toBool()) {
+    if(m_pVCEnabled->toBool()) {
         m_pitchRateInfo.tempoRatio = m_pVCRate->get();
     } else {
-        m_pitchRateInfo.tempoRatio = 1.0 + m_pRateDir->get() * m_pRateRange->get() * m_pRateSlider->get();
+        m_pitchRateInfo.tempoRatio = 1.0
+                + m_pRateDir->get() * m_pRateRange->get()
+                        * m_pRateSlider->get();
     }
 
     if (m_pitchRateInfo.tempoRatio == 0) {

--- a/src/engine/keycontrol.h
+++ b/src/engine/keycontrol.h
@@ -50,15 +50,14 @@ class KeyControl : public EngineControl {
     void updatePitchAdjust();
     void updateRate();
 
-    // ControlObjects that come from EngineBuffer
-    ControlObject* m_pRateSlider;
-    ControlObject* m_pRateRange;
-    ControlObject* m_pRateDir;
+    ControlProxy* m_pRateSlider;
+    ControlProxy* m_pRateRange;
+    ControlProxy* m_pRateDir;
 
-    ControlObject* m_pVCRate;
-    ControlObject* m_pVCEnabled;
+    ControlProxy* m_pVCRate;
+    ControlProxy* m_pVCEnabled;
 
-    ControlObject* m_pKeylock;
+    ControlProxy* m_pKeylock;
     ControlPotmeter* m_pPitch;
     ControlPotmeter* m_pPitchAdjust;
     ControlPushButton* m_pButtonSyncKey;

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -314,6 +314,12 @@ void PlayerManager::slotChangeNumAuxiliaries(double v) {
     m_pCONumAuxiliaries->setAndConfirm(m_auxiliaries.size());
 }
 
+void PlayerManager::addDeck() {
+    QMutexLocker locker(&m_mutex);
+    double count = m_pCONumDecks->get() + 1;
+    slotChangeNumDecks(count);
+}
+
 void PlayerManager::addConfiguredDecks() {
     slotChangeNumDecks(m_pSoundManager->getConfiguredDeckCount());
 }

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -383,7 +383,7 @@ void PlayerManager::loadSamplers() {
 
 void PlayerManager::addSampler() {
     QMutexLocker locker(&m_mutex);
-    double count = m_pCONumDecks->get() + 1;
+    double count = m_pCONumSamplers->get() + 1;
     slotChangeNumSamplers(count);
 }
 

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -46,43 +46,23 @@ PlayerManager::PlayerManager(UserSettingsPointer pConfig,
         m_pCONumDecks(new ControlObject(
                 ConfigKey("[Master]", "num_decks"), true, true)),
         m_pCONumSamplers(new ControlObject(
-            ConfigKey("[Master]", "num_samplers"), true, true)),
+                ConfigKey("[Master]", "num_samplers"), true, true)),
         m_pCONumPreviewDecks(new ControlObject(
-            ConfigKey("[Master]", "num_preview_decks"), true, true)),
+                ConfigKey("[Master]", "num_preview_decks"), true, true)),
         m_pCONumMicrophones(new ControlObject(
                 ConfigKey("[Master]", "num_microphones"), true, true)),
         m_pCONumAuxiliaries(new ControlObject(
                 ConfigKey("[Master]", "num_auxiliaries"), true, true)) {
-    connect(m_pCONumDecks, SIGNAL(valueChanged(double)),
-            this, SLOT(slotNumDecksControlChanged(double)),
-            Qt::DirectConnection);
-    connect(m_pCONumDecks, SIGNAL(valueChangedFromEngine(double)),
-            this, SLOT(slotNumDecksControlChanged(double)),
-            Qt::DirectConnection);
-    connect(m_pCONumSamplers, SIGNAL(valueChanged(double)),
-            this, SLOT(slotNumSamplersControlChanged(double)),
-            Qt::DirectConnection);
-    connect(m_pCONumSamplers, SIGNAL(valueChangedFromEngine(double)),
-            this, SLOT(slotNumSamplersControlChanged(double)),
-            Qt::DirectConnection);
-    connect(m_pCONumPreviewDecks, SIGNAL(valueChanged(double)),
-            this, SLOT(slotNumPreviewDecksControlChanged(double)),
-            Qt::DirectConnection);
-    connect(m_pCONumPreviewDecks, SIGNAL(valueChangedFromEngine(double)),
-            this, SLOT(slotNumPreviewDecksControlChanged(double)),
-            Qt::DirectConnection);
-    connect(m_pCONumMicrophones, SIGNAL(valueChanged(double)),
-            this, SLOT(slotNumMicrophonesControlChanged(double)),
-            Qt::DirectConnection);
-    connect(m_pCONumMicrophones, SIGNAL(valueChangedFromEngine(double)),
-            this, SLOT(slotNumMicrophonesControlChanged(double)),
-            Qt::DirectConnection);
-    connect(m_pCONumAuxiliaries, SIGNAL(valueChanged(double)),
-            this, SLOT(slotNumAuxiliariesControlChanged(double)),
-            Qt::DirectConnection);
-    connect(m_pCONumAuxiliaries, SIGNAL(valueChangedFromEngine(double)),
-            this, SLOT(slotNumAuxiliariesControlChanged(double)),
-            Qt::DirectConnection);
+    m_pCONumDecks->connectValueChangeRequest(this,
+            SLOT(slotChangeNumDecks(double)), Qt::DirectConnection);
+    m_pCONumSamplers->connectValueChangeRequest(this,
+            SLOT(slotChangeNumSamplers(double)), Qt::DirectConnection);
+    m_pCONumPreviewDecks->connectValueChangeRequest(this,
+            SLOT(slotChangeNumPreviewDecks(double)), Qt::DirectConnection);
+    m_pCONumMicrophones->connectValueChangeRequest(this,
+            SLOT(slotChangeNumMicrophones(double)), Qt::DirectConnection);
+    m_pCONumAuxiliaries->connectValueChangeRequest(this,
+            SLOT(slotChangeNumAuxiliaries(double)), Qt::DirectConnection);
 
     // This is parented to the PlayerManager so does not need to be deleted
     m_pSamplerBank = new SamplerBank(this);
@@ -254,7 +234,7 @@ unsigned int PlayerManager::numPreviewDecks() {
     return pCOPNumPreviewDecks ? pCOPNumPreviewDecks->get() : 0;
 }
 
-void PlayerManager::slotNumDecksControlChanged(double v) {
+void PlayerManager::slotChangeNumDecks(double v) {
     QMutexLocker locker(&m_mutex);
     int num = (int)v;
 
@@ -264,22 +244,24 @@ void PlayerManager::slotNumDecksControlChanged(double v) {
 
     if (num < m_decks.size()) {
         // The request was invalid -- reset the value.
-        m_pCONumDecks->set(m_decks.size());
         qDebug() << "Ignoring request to reduce the number of decks to" << num;
         return;
     }
 
-    while (m_decks.size() < num) {
-        addDeckInner();
+    if (m_decks.size() < num) {
+        do {
+            addDeckInner();
+        } while (m_decks.size() < num);
+        m_pCONumDecks->setAndConfirm(m_decks.size());
+        emit(numberOfDecksChanged(m_decks.count()));
     }
 }
 
-void PlayerManager::slotNumSamplersControlChanged(double v) {
+void PlayerManager::slotChangeNumSamplers(double v) {
     QMutexLocker locker(&m_mutex);
     int num = (int)v;
     if (num < m_samplers.size()) {
-        // The request was invalid -- reset the value.
-        m_pCONumSamplers->set(m_samplers.size());
+        // The request was invalid -- don't set the value.
         qDebug() << "Ignoring request to reduce the number of samplers to" << num;
         return;
     }
@@ -287,66 +269,53 @@ void PlayerManager::slotNumSamplersControlChanged(double v) {
     while (m_samplers.size() < num) {
         addSamplerInner();
     }
+    m_pCONumSamplers->setAndConfirm(m_samplers.size());
 }
 
-void PlayerManager::slotNumPreviewDecksControlChanged(double v) {
+void PlayerManager::slotChangeNumPreviewDecks(double v) {
     QMutexLocker locker(&m_mutex);
     int num = (int)v;
     if (num < m_preview_decks.size()) {
-        // The request was invalid -- reset the value.
-        m_pCONumPreviewDecks->set(m_preview_decks.size());
+        // The request was invalid -- don't set the value.
         qDebug() << "Ignoring request to reduce the number of preview decks to" << num;
         return;
     }
-
     while (m_preview_decks.size() < num) {
         addPreviewDeckInner();
     }
+    m_pCONumPreviewDecks->setAndConfirm(m_preview_decks.size());
 }
 
-void PlayerManager::slotNumMicrophonesControlChanged(double v) {
+void PlayerManager::slotChangeNumMicrophones(double v) {
     QMutexLocker locker(&m_mutex);
     int num = (int)v;
     if (num < m_microphones.size()) {
-        // The request was invalid -- reset the value.
-        m_pCONumMicrophones->set(m_microphones.size());
+        // The request was invalid -- don't set the value.
         qDebug() << "Ignoring request to reduce the number of microphones to" << num;
         return;
     }
-
     while (m_microphones.size() < num) {
         addMicrophoneInner();
     }
+    m_pCONumMicrophones->setAndConfirm(m_microphones.size());
 }
 
-void PlayerManager::slotNumAuxiliariesControlChanged(double v) {
+void PlayerManager::slotChangeNumAuxiliaries(double v) {
     QMutexLocker locker(&m_mutex);
     int num = (int)v;
     if (num < m_auxiliaries.size()) {
-        // The request was invalid -- reset the value.
-        m_pCONumAuxiliaries->set(m_auxiliaries.size());
+        // The request was invalid -- don't set the value.
         qDebug() << "Ignoring request to reduce the number of auxiliaries to" << num;
         return;
     }
-
     while (m_auxiliaries.size() < num) {
         addAuxiliaryInner();
     }
-}
-
-void PlayerManager::addDeck() {
-    QMutexLocker locker(&m_mutex);
-    addDeckInner();
-    m_pCONumDecks->set((double)m_decks.count());
-    emit(numberOfDecksChanged(m_decks.count()));
+    m_pCONumAuxiliaries->setAndConfirm(m_auxiliaries.size());
 }
 
 void PlayerManager::addConfiguredDecks() {
-    // Cache this value in case it changes out from under us.
-    int deck_count = m_pSoundManager->getConfiguredDeckCount();
-    for (int i = 0; i < deck_count; ++i) {
-        addDeck();
-    }
+    slotChangeNumDecks(m_pSoundManager->getConfiguredDeckCount());
 }
 
 void PlayerManager::addDeckInner() {
@@ -414,8 +383,8 @@ void PlayerManager::loadSamplers() {
 
 void PlayerManager::addSampler() {
     QMutexLocker locker(&m_mutex);
-    addSamplerInner();
-    m_pCONumSamplers->set(m_samplers.count());
+    double count = m_pCONumDecks->get() + 1;
+    slotChangeNumSamplers(count);
 }
 
 void PlayerManager::addSamplerInner() {
@@ -442,8 +411,7 @@ void PlayerManager::addSamplerInner() {
 
 void PlayerManager::addPreviewDeck() {
     QMutexLocker locker(&m_mutex);
-    addPreviewDeckInner();
-    m_pCONumPreviewDecks->set(m_preview_decks.count());
+    slotChangeNumPreviewDecks(m_pCONumPreviewDecks->get() + 1);
 }
 
 void PlayerManager::addPreviewDeckInner() {
@@ -470,8 +438,7 @@ void PlayerManager::addPreviewDeckInner() {
 
 void PlayerManager::addMicrophone() {
     QMutexLocker locker(&m_mutex);
-    addMicrophoneInner();
-    m_pCONumMicrophones->set(m_microphones.count());
+    slotChangeNumMicrophones(m_pCONumMicrophones->get() + 1);
 }
 
 void PlayerManager::addMicrophoneInner() {
@@ -487,8 +454,7 @@ void PlayerManager::addMicrophoneInner() {
 
 void PlayerManager::addAuxiliary() {
     QMutexLocker locker(&m_mutex);
-    addAuxiliaryInner();
-    m_pCONumAuxiliaries->set(m_auxiliaries.count());
+    slotChangeNumAuxiliaries(m_pCONumAuxiliaries->get() + 1);
 }
 
 void PlayerManager::addAuxiliaryInner() {

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -63,6 +63,10 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
                   EngineMaster* pEngine);
     virtual ~PlayerManager();
 
+    // Add a deck to the PlayerManager
+    // (currently unused, keept for consistency with other types)
+    void addDeck();
+
     // Add number of decks according to configuration.
     void addConfiguredDecks();
 
@@ -84,7 +88,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     // Return the number of players. Thread-safe.
     static unsigned int numDecks();
 
-    unsigned int numberOfDecks() const {
+    unsigned int numberOfDecks() const override {
         return numDecks();
     }
 
@@ -103,28 +107,28 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     // Return the number of samplers. Thread-safe.
     static unsigned int numSamplers();
 
-    unsigned int numberOfSamplers() const {
+    unsigned int numberOfSamplers() const override {
         return numSamplers();
     }
 
     // Return the number of preview decks. Thread-safe.
     static unsigned int numPreviewDecks();
 
-    unsigned int numberOfPreviewDecks() const {
+    unsigned int numberOfPreviewDecks() const override {
         return numPreviewDecks();
     }
 
     // Get a BaseTrackPlayer (i.e. a Deck, Sampler or PreviewDeck) by its
     // group. Auxiliaries and microphones are not players.
-    BaseTrackPlayer* getPlayer(QString group) const;
+    BaseTrackPlayer* getPlayer(QString group) const override;
 
     // Get the deck by its deck number. Decks are numbered starting with 1.
-    Deck* getDeck(unsigned int player) const;
+    Deck* getDeck(unsigned int player) const override;
 
-    PreviewDeck* getPreviewDeck(unsigned int libPreviewPlayer) const;
+    PreviewDeck* getPreviewDeck(unsigned int libPreviewPlayer) const override;
 
     // Get the sampler by its number. Samplers are numbered starting with 1.
-    Sampler* getSampler(unsigned int sampler) const;
+    Sampler* getSampler(unsigned int sampler) const override;
 
     // Get the microphone by its number. Microphones are numbered starting with 1.
     Microphone* getMicrophone(unsigned int microphone) const;

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -63,9 +63,6 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
                   EngineMaster* pEngine);
     virtual ~PlayerManager();
 
-    // Add a deck to the PlayerManager
-    void addDeck();
-
     // Add number of decks according to configuration.
     void addConfiguredDecks();
 
@@ -192,11 +189,11 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     // Loads the location to the sampler. samplerNumber is 1-indexed
     void slotLoadToSampler(QString location, int samplerNumber);
 
-    void slotNumDecksControlChanged(double v);
-    void slotNumSamplersControlChanged(double v);
-    void slotNumPreviewDecksControlChanged(double v);
-    void slotNumMicrophonesControlChanged(double v);
-    void slotNumAuxiliariesControlChanged(double v);
+    void slotChangeNumDecks(double v);
+    void slotChangeNumSamplers(double v);
+    void slotChangeNumPreviewDecks(double v);
+    void slotChangeNumMicrophones(double v);
+    void slotChangeNumAuxiliaries(double v);
 
   signals:
     void loadLocationToPlayer(QString location, QString group);

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -94,7 +94,7 @@ QMutex LegacySkinParser::s_safeStringMutex;
 static bool sDebug = false;
 
 ControlObject* controlFromConfigKey(const ConfigKey& key, bool bPersist,
-                                    bool* created) {
+                                    bool* pCreated) {
     if (key.isEmpty()) {
         return nullptr;
     }
@@ -103,8 +103,8 @@ ControlObject* controlFromConfigKey(const ConfigKey& key, bool bPersist,
     ControlObject* pControl = ControlObject::getControl(key, false);
 
     if (pControl) {
-        if (created) {
-            *created = false;
+        if (pCreated) {
+            *pCreated = false;
         }
         return pControl;
     }
@@ -119,8 +119,8 @@ ControlObject* controlFromConfigKey(const ConfigKey& key, bool bPersist,
     // button, actually make it a push button and set it to toggle.
     ControlPushButton* controlButton = new ControlPushButton(key, bPersist);
     controlButton->setButtonMode(ControlPushButton::TOGGLE);
-    if (created) {
-        *created = true;
+    if (pCreated) {
+        *pCreated = true;
     }
     return controlButton;
 }
@@ -671,13 +671,22 @@ QWidget* LegacySkinParser::parseWidgetStack(const QDomElement& node) {
     bool createdNext = false;
     ControlObject* pNextControl = controlFromConfigNode(
             node.toElement(), "NextControl", &createdNext);
+    ConfigKey nextConfigKey;
+    if (pNextControl != nullptr) {
+        nextConfigKey = pNextControl->getKey();
+    }
 
     bool createdPrev = false;
     ControlObject* pPrevControl = controlFromConfigNode(
             node.toElement(), "PrevControl", &createdPrev);
+    ConfigKey prevConfigKey;
+    if (pPrevControl != nullptr) {
+        prevConfigKey = pPrevControl->getKey();
+    }
 
     bool createdCurrentPage = false;
     ControlObject* pCurrentPageControl = NULL;
+    ConfigKey currentPageConfigKey;
     QString currentpage_co = node.attribute("currentpage");
     if (currentpage_co.length() > 0) {
         ConfigKey configKey = ConfigKey::parseCommaSeparated(currentpage_co);
@@ -685,10 +694,13 @@ QWidget* LegacySkinParser::parseWidgetStack(const QDomElement& node) {
         bool persist = m_pContext->selectAttributeBool(node, "persist", false);
         pCurrentPageControl = controlFromConfigKey(configKey, persist,
                                                    &createdCurrentPage);
+        if (pCurrentPageControl != nullptr) {
+            currentPageConfigKey = pCurrentPageControl->getKey();
+        }
     }
 
-    WWidgetStack* pStack = new WWidgetStack(m_pParent, pNextControl,
-                                            pPrevControl, pCurrentPageControl);
+    WWidgetStack* pStack = new WWidgetStack(m_pParent, nextConfigKey,
+            prevConfigKey, currentPageConfigKey);
     pStack->setObjectName("WidgetStack");
     pStack->setContentsMargins(0, 0, 0, 0);
     commonWidgetSetup(node, pStack);
@@ -1112,7 +1124,12 @@ QWidget* LegacySkinParser::parseBeatSpinBox(const QDomElement& node) {
     bool createdValueControl = false;
     ControlObject* valueControl = controlFromConfigNode(node.toElement(), "Value", &createdValueControl);
 
-    WBeatSpinBox* pSpinbox = new WBeatSpinBox(m_pParent, valueControl);
+    ConfigKey configKey;
+    if (valueControl != nullptr) {
+        configKey = valueControl->getKey();
+    }
+
+    WBeatSpinBox* pSpinbox = new WBeatSpinBox(m_pParent, configKey);
     commonWidgetSetup(node, pSpinbox);
     pSpinbox->setup(node, *m_pContext);
 

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -82,8 +82,6 @@ TEST_F(EngineSyncTest, ControlObjectsExist) {
 TEST_F(EngineSyncTest, SetMasterSuccess) {
     // If we set the first channel to master, EngineSync should get that message.
 
-    // Throughout these tests we use ControlProxys so that we can trigger ValueChanged,
-    // and not just ValueChangedFromEngine.
     auto pButtonMasterSync1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonMasterSync1->slotSet(SYNC_MASTER);
     ProcessBuffer();

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -79,7 +79,7 @@ class BaseSignalPathTest : public MixxxTest {
         m_pPreview1 = new PreviewDeck(NULL, m_pConfig,
                                       m_pEngineMaster, m_pEffectsManager,
                                       EngineChannel::CENTER, m_sPreviewGroup);
-        ControlObject::getControl(ConfigKey(m_sPreviewGroup, "file_bpm"))->set(2.0);
+        ControlObject::set(ConfigKey(m_sPreviewGroup, "file_bpm"), 2.0);
 
         // TODO(owilliams) Tests fail with this turned on because EngineSync is syncing
         // to this sampler.  FIX IT!
@@ -113,12 +113,9 @@ class BaseSignalPathTest : public MixxxTest {
     }
 
     void addDeck(EngineDeck* pDeck) {
-        ControlObject::getControl(ConfigKey(pDeck->getGroup(), "master"))
-                ->set(1.0);
-        ControlObject::getControl(ConfigKey(pDeck->getGroup(), "rate_dir"))
-                ->set(kDefaultRateDir);
-        ControlObject::getControl(ConfigKey(pDeck->getGroup(), "rateRange"))
-                ->set(kDefaultRateRange);
+        ControlObject::set(ConfigKey(pDeck->getGroup(), "master"), 1.0);
+        ControlObject::set(ConfigKey(pDeck->getGroup(), "rate_dir"), kDefaultRateDir);
+        ControlObject::set(ConfigKey(pDeck->getGroup(), "rateRange"), kDefaultRateRange);
         m_pNumDecks->set(m_pNumDecks->get() + 1);
     }
 

--- a/src/test/wwidgetstack_test.cpp
+++ b/src/test/wwidgetstack_test.cpp
@@ -26,9 +26,9 @@ class WWidgetStackTest : public MixxxTest {
                 new ControlPushButton(ConfigKey(m_pGroup, "next")));
         m_pCurPageControl.reset(
                 new ControlObject(ConfigKey(m_pGroup, "page")));
-        m_pStack.reset(new WWidgetStack(NULL, m_pNextControl.data(),
-                                        m_pPrevControl.data(),
-                                        m_pCurPageControl.data()));
+        m_pStack.reset(new WWidgetStack(NULL, m_pNextControl->getKey(),
+                                        m_pPrevControl->getKey(),
+                                        m_pCurPageControl->getKey()));
 
         // 0-based index
         m_pCurPageControl->set(1);
@@ -111,9 +111,9 @@ TEST_F(WWidgetStackTest, MaintainPageControlValue) {
             new ControlObject(ConfigKey(m_pGroup,
                                         "MaintainPageControlValue-page")));
     QScopedPointer<WWidgetStack> stack(
-            new WWidgetStack(NULL, m_pNextControl.data(),
-                             m_pPrevControl.data(),
-                             m_pCurPageControl.data()));
+            new WWidgetStack(NULL, m_pNextControl->getKey(),
+                             m_pPrevControl->getKey(),
+                             m_pCurPageControl->getKey()));
 
     QWidget page0;
     QWidget page1;

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -136,8 +136,8 @@ VinylControlXwax::VinylControlXwax(UserSettingsPointer pConfig, QString group)
         speed = 1.35;
     }
 
-    double latency = ControlObject::getControl(
-            ConfigKey("[Master]", "latency"))->get();
+    double latency = ControlObject::get(
+            ConfigKey("[Master]", "latency"));
     if (latency <= 0 || latency > 200) {
         qDebug() << "Failed to get sane latency, assuming 20 as a reasonable value";
         latency = 20;

--- a/src/widget/wbeatspinbox.cpp
+++ b/src/widget/wbeatspinbox.cpp
@@ -8,14 +8,11 @@
 
 QRegExp WBeatSpinBox::s_regexpBlacklist("[^0-9.,/ ]");
 
-WBeatSpinBox::WBeatSpinBox(QWidget * parent, ControlObject* pValueControl,
+WBeatSpinBox::WBeatSpinBox(QWidget* parent, const ConfigKey& configKey,
                            int decimals, double minimum, double maximum)
         : QDoubleSpinBox(parent),
           WBaseWidget(this),
-          m_valueControl(
-            pValueControl ?
-            pValueControl->getKey() : ConfigKey(), this
-          ),
+          m_valueControl(configKey, this),
           m_scaleFactor(1.0) {
     // replace the original QLineEdit by one that supports font scaling.
     setLineEdit(new WBeatLineEdit(this));

--- a/src/widget/wbeatspinbox.h
+++ b/src/widget/wbeatspinbox.h
@@ -13,10 +13,8 @@ class ControlProxy;
 class WBeatSpinBox : public QDoubleSpinBox, public WBaseWidget {
     Q_OBJECT
   public:
-    WBeatSpinBox(QWidget *parent=nullptr,
-                        ControlObject* pValueControl=nullptr,
-                        int decimals=5,
-                        double minimum=0.03125, double maximum=512.00);
+    WBeatSpinBox(QWidget* parent, const ConfigKey& configKey, int decimals = 5,
+            double minimum = 0.03125, double maximum = 512.00);
 
     void setup(const QDomNode& node, const SkinContext& context);
 

--- a/src/widget/wwidgetstack.cpp
+++ b/src/widget/wwidgetstack.cpp
@@ -27,21 +27,13 @@ void WidgetStackControlListener::onCurrentWidgetChanged(int index) {
     }
 }
 
-WWidgetStack::WWidgetStack(QWidget* pParent,
-                           ControlObject* pNextControl,
-                           ControlObject* pPrevControl,
-                           ControlObject* pCurrentPageControl)
+WWidgetStack::WWidgetStack(QWidget* pParent, const ConfigKey& nextConfigKey,
+        const ConfigKey& prevConfigKey, const ConfigKey& currentPageConfigKey)
         : QStackedWidget(pParent),
           WBaseWidget(this),
-          m_nextControl(
-                  pNextControl ?
-                  pNextControl->getKey() : ConfigKey(), this),
-          m_prevControl(
-                  pPrevControl ?
-                  pPrevControl->getKey() : ConfigKey(), this),
-          m_currentPageControl(
-                  pCurrentPageControl ?
-                  pCurrentPageControl->getKey() : ConfigKey(), this) {
+          m_nextControl(nextConfigKey, this),
+          m_prevControl(prevConfigKey, this),
+          m_currentPageControl(currentPageConfigKey, this) {
     m_nextControl.connectValueChanged(SLOT(onNextControlChanged(double)));
     m_prevControl.connectValueChanged(SLOT(onPrevControlChanged(double)));
     m_currentPageControl.connectValueChanged(

--- a/src/widget/wwidgetstack.h
+++ b/src/widget/wwidgetstack.h
@@ -40,9 +40,9 @@ class WWidgetStack : public QStackedWidget, public WBaseWidget {
     Q_OBJECT
   public:
     WWidgetStack(QWidget* pParent,
-                 ControlObject* pNextControl,
-                 ControlObject* pPrevControl,
-                 ControlObject* pCurrentPageControl);
+                 const ConfigKey& nextConfigKey,
+                 const ConfigKey& prevConfigKey,
+                 const ConfigKey& currentPageConfigKey);
 
     // We don't want to change pages until all the pages have been added,
     // so we override Init and hook up the connection there.


### PR DESCRIPTION
This removed the valueChangedFromEngine() signal. The name was legacy and now wrong anyway. 
It should be named valueChangedOwnSet() or similar. 

But we actually don't really need it, with the new ControObject and ControlProxy objects. 
I have also replaces a possible race with setting and resetting the various Num Controls. 
Now the valueChangeRequest is usedand the num controls are always valid. 



