### PR TITLE
[TEST] Skins :: hidden waveform cpu fix lp1758660

### DIFF
--- a/res/skins/Deere (64 Samplers)/skin.xml
+++ b/res/skins/Deere (64 Samplers)/skin.xml
@@ -197,6 +197,9 @@
           <Orientation>vertical</Orientation>
           <SplitSizesConfigKey>[Deere],StackedWaveformSplitter</SplitSizesConfigKey>
           <SplitSizes>90,540</SplitSizes>
+      <!-- Prohibit collapsing of waveform container to prevent
+          massive GUI lag with hidden waveforms lp:1758660 -->
+          <Collapsible>0,0</Collapsible>
           <Size>-1me,-1me</Size>
           <Connection>
             <ConfigKey>[Master],maximize_library</ConfigKey>
@@ -208,12 +211,21 @@
             <WidgetGroup><!-- Parallel Waveforms -->
               <ObjectName>Waveforms</ObjectName>
               <Layout>vertical</Layout>
-              <Size>-1me,4min</Size>
+          <!-- Set min-height to 1px to prevent
+              massive GUI lag with hidden waveforms lp:1758660 -->
+              <Size>-1me,1min</Size>
               <Connection>
                 <ConfigKey>[Deere],show_parallel_waveforms</ConfigKey>
                 <BindProperty>visible</BindProperty>
               </Connection>
               <Children>
+
+            <!-- If waveforms' container is dragged to minimal height (1px) we need
+                a 1px spacer here so the waveforms aren't visible -->
+                <WidgetGroup>
+                  <ObjectName>Spacer22</ObjectName>
+                  <Size>0me,1f</Size>
+                </WidgetGroup>
 
                 <WidgetGroup>
                   <Connection>

--- a/res/skins/Deere/skin.xml
+++ b/res/skins/Deere/skin.xml
@@ -197,6 +197,9 @@
           <Orientation>vertical</Orientation>
           <SplitSizesConfigKey>[Deere],StackedWaveformSplitter</SplitSizesConfigKey>
           <SplitSizes>90,540</SplitSizes>
+      <!-- Prohibit collapsing of waveform container to prevent
+          massive GUI lag with hidden waveforms lp:1758660 -->
+          <Collapsible>0,0</Collapsible>
           <Size>-1me,-1me</Size>
           <Connection>
             <ConfigKey>[Master],maximize_library</ConfigKey>
@@ -208,12 +211,21 @@
             <WidgetGroup><!-- Parallel Waveforms -->
               <ObjectName>Waveforms</ObjectName>
               <Layout>vertical</Layout>
-              <Size>-1me,4min</Size>
+          <!-- Set min-height to 1px to prevent
+              massive GUI lag with hidden waveforms lp:1758660 -->
+              <Size>-1me,1min</Size>
               <Connection>
                 <ConfigKey>[Deere],show_parallel_waveforms</ConfigKey>
                 <BindProperty>visible</BindProperty>
               </Connection>
               <Children>
+
+            <!-- If waveforms' container is dragged to minimal height (1px) we need
+                a 1px spacer here so the waveforms aren't visible -->
+                <WidgetGroup>
+                  <ObjectName>Spacer22</ObjectName>
+                  <Size>0me,1f</Size>
+                </WidgetGroup>
 
                 <WidgetGroup>
                   <Connection>

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -761,7 +761,7 @@ WBeatSpinBox {
   padding: 0px 4px 0px 4px;
   qproperty-layoutSpacing: 5;
   background-color: #111111;
-  border-width: 0px 0px 3px 0px;
+  border-width: 0px 0px 2px 0px;
   border-style: solid;
   border-color: #222;
 }

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -126,7 +126,9 @@
               <SizePolicy>me,min</SizePolicy>
               <SplitSizes>1,5</SplitSizes>
               <SplitSizesConfigKey>[LateNight],waveform_splitSize</SplitSizesConfigKey>
-              <Collapsible>1,0</Collapsible>
+          <!-- Prohibit collapsing of waveform container to prevent
+              massive GUI lag with hidden waveforms lp:1758660 -->
+              <Collapsible>0,0</Collapsible>
               <Children>
 
                 <Template src="skin:waveforms.xml"/>

--- a/res/skins/LateNight/waveforms.xml
+++ b/res/skins/LateNight/waveforms.xml
@@ -1,14 +1,19 @@
 <Template>
   <WidgetGroup>
     <Layout>horizontal</Layout>
-    <SizePolicy>me,min</SizePolicy>
+<!-- Set min-height to 1px to prevent
+    massive GUI lag with hidden waveforms lp:1758660 -->
+    <Size>1me,1min</Size>
     <Children>
 
       <!-- Waveforms -->
       <WidgetGroup>
-        <Layout>horizontal</Layout>
-        <Size>100me,40me</Size>
+        <Layout>vertical</Layout>
+        <Size>100me,1me</Size>
         <Children>
+      <!-- If waveforms' container is dragged to minimal height (1px) we need
+          a 1px spacer here so the waveforms aren't visible -->
+          <WidgetGroup><Size>1me,1f</Size></WidgetGroup>
           <SingletonContainer>
             <ObjectName>WaveformsSingleton</ObjectName>
           </SingletonContainer>
@@ -17,7 +22,7 @@
 
       <PushButton>
         <ObjectName>BeatgridButtonsToggle</ObjectName>
-        <Size>28f,40me</Size>
+        <Size>28f,1me</Size>
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>

--- a/res/skins/Tango (64 Samplers)/skin.xml
+++ b/res/skins/Tango (64 Samplers)/skin.xml
@@ -286,10 +286,12 @@
 
                         <Template src="skin:../Tango/decks_12.xml"/>
 
-                    <!-- Load scrolling waveforms Singleton here if the waveforms
+                    <!-- Previous attempt to avoid the log being spammed with
+                        QPainter warnings:
+                        Load scrolling waveforms Singleton here if the waveforms
                         in the waveforms/decks Splitter are collapsed.
                         Otherwise the end-of-track warning would not show up
-                        in overview waveforms. -->
+                        in overview waveforms.
                         <WidgetGroup>
                           <Layout>vertical</Layout>
                           <Size>0me,0f</Size>
@@ -303,7 +305,7 @@
                             <Transform><Not/></Transform>
                             <BindProperty>visible</BindProperty>
                           </Connection>
-                        </WidgetGroup>
+                        </WidgetGroup> -->
 
                         <WidgetGroup>
                           <Layout>vertical</Layout>

--- a/res/skins/Tango/skin.xml
+++ b/res/skins/Tango/skin.xml
@@ -286,10 +286,12 @@
 
                         <Template src="skin:decks_12.xml"/>
 
-                    <!-- Load scrolling waveforms Singleton here if the waveforms
+                    <!-- Previous attempt to avoid the log being spammed with
+                        QPainter warnings:
+                        Load scrolling waveforms Singleton here if the waveforms
                         in the waveforms/decks Splitter are collapsed.
                         Otherwise the end-of-track warning would not show up
-                        in overview waveforms. -->
+                        in overview waveforms.
                         <WidgetGroup>
                           <Layout>vertical</Layout>
                           <Size>0me,0f</Size>
@@ -303,7 +305,7 @@
                             <Transform><Not/></Transform>
                             <BindProperty>visible</BindProperty>
                           </Connection>
-                        </WidgetGroup>
+                        </WidgetGroup> -->
 
                         <WidgetGroup>
                           <Layout>vertical</Layout>

--- a/res/skins/Tango/topbar.xml
+++ b/res/skins/Tango/topbar.xml
@@ -16,6 +16,34 @@ Description:
     <Layout>horizontal</Layout>
     <SizePolicy>me,min</SizePolicy>
     <Children>
+
+      <!-- Show 1x1px scrolling waveforms here if they are hidden by topbar toggle.
+      This prevents massive GUI lag with hidden waveforms lp:1758660 -->
+      <WidgetGroup>
+        <ObjectName>AlignTop</ObjectName>
+        <Layout>vertical</Layout>
+        <Size>1f,28f</Size>
+        <Children>
+          <WidgetGroup>
+            <Layout>vertical</Layout>
+            <Size>1f,1f</Size>
+            <Children>
+              <SingletonContainer>
+                <ObjectName>Waveforms_Singleton</ObjectName>
+              </SingletonContainer>
+            </Children>
+          </WidgetGroup>
+      <!-- layout alignment isn't respected, so we need a spacer here to push
+          the flashing waveform pixel to the top -->
+          <WidgetGroup><Size>1f,1me</Size></WidgetGroup>
+        </Children>
+        <Connection>
+          <ConfigKey persist="true">[Tango],stacked_waveforms</ConfigKey>
+          <Transform><Not/></Transform>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
   <!-- Put Mixerbar & Logo in a container to achieve top alignment
       when Crossfader is enabled. 'qproperty-layoutAlignment' for Topbar
       wouldn't work... -->

--- a/res/skins/Tango/waveform.xml
+++ b/res/skins/Tango/waveform.xml
@@ -80,83 +80,98 @@ Variables:
         </Mark>
       </Visual>
 
-      <WidgetGroup><!-- Transparent container for beatgrid buttons -->
+      <!-- Only show the beatgrid buttons if scrolling waveforms are enabled.
+           Otherwise waveforms' Singleton is shown 1x20px left to MIXXX logo
+           to workaround LP1758660 "GUI lag with hidden waveforms in Tango & Deere,
+                                    using integrated Intel graphics" -->
+      <WidgetGroup>
         <ObjectName>BeatgridButtons</ObjectName>
         <Layout>vertical</Layout>
-        <!-- Horizontal size is 82px and we'll add the WaveformContainer's negative margin
-            (shifts waveform center mark) so that all buttons are visible -->
-        <Size>99f,50me</Size>
+        <SizePolicy>min,me</SizePolicy>
         <Children>
-          <WidgetGroup><Size>1me,0me</Size></WidgetGroup>
-          <WidgetGroup><Size>1me,1f</Size></WidgetGroup>
-
-          <WidgetGroup><!-- beat grid buttons row -->
-            <ObjectName>Spacer0f</ObjectName>
-            <Layout>horizontal</Layout>
-            <SizePolicy>f,f</SizePolicy>
+          <WidgetGroup><!-- Transparent container for beatgrid buttons -->
+            <ObjectName>BeatgridButtons</ObjectName>
+            <Layout>vertical</Layout>
+            <!-- Horizontal size is 82px and we'll add the WaveformContainer's negative margin
+                (shifts waveform center mark) so that all buttons are visible -->
+            <Size>99f,50me</Size>
             <Children>
-              <Template src="skin:button_1state.xml">
-                <SetVariable name="TooltipId">beats_translate_curpos</SetVariable>
-                <SetVariable name="ObjectName">BeatgridCurpos</SetVariable>
-                <SetVariable name="Size">24f,49f</SetVariable>
-                <SetVariable name="ConfigKey"><Variable name="group"/>,beats_translate_curpos</SetVariable>
-              </Template>
+              <WidgetGroup><Size>1me,0me</Size></WidgetGroup>
+              <WidgetGroup><Size>1me,1f</Size></WidgetGroup>
 
-              <WidgetGroup><Size>1min,1f</Size></WidgetGroup>
-
-              <WidgetGroup><!-- beats earlier & faster -->
-                <Layout>vertical</Layout>
+              <WidgetGroup><!-- beat grid buttons row -->
+                <ObjectName>Spacer0f</ObjectName>
+                <Layout>horizontal</Layout>
                 <SizePolicy>f,f</SizePolicy>
                 <Children>
                   <Template src="skin:button_1state.xml">
-                    <SetVariable name="TooltipId">beats_translate_earlier</SetVariable>
-                    <SetVariable name="ObjectName">BeatgridEarlier</SetVariable>
-                    <SetVariable name="Size">28f,24f</SetVariable>
-                    <SetVariable name="ConfigKey"><Variable name="group"/>,beats_translate_earlier</SetVariable>
+                    <SetVariable name="TooltipId">beats_translate_curpos</SetVariable>
+                    <SetVariable name="ObjectName">BeatgridCurpos</SetVariable>
+                    <SetVariable name="Size">24f,49f</SetVariable>
+                    <SetVariable name="ConfigKey"><Variable name="group"/>,beats_translate_curpos</SetVariable>
                   </Template>
 
                   <WidgetGroup><Size>1min,1f</Size></WidgetGroup>
 
-                  <Template src="skin:button_1state.xml">
-                    <SetVariable name="TooltipId">beats_adjust_faster</SetVariable>
-                    <SetVariable name="ObjectName">BeatgridFaster</SetVariable>
-                    <SetVariable name="Size">28f,24f</SetVariable>
-                    <SetVariable name="ConfigKey"><Variable name="group"/>,beats_adjust_faster</SetVariable>
-                  </Template>
+                  <WidgetGroup><!-- beats earlier & faster -->
+                    <Layout>vertical</Layout>
+                    <SizePolicy>f,f</SizePolicy>
+                    <Children>
+                      <Template src="skin:button_1state.xml">
+                        <SetVariable name="TooltipId">beats_translate_earlier</SetVariable>
+                        <SetVariable name="ObjectName">BeatgridEarlier</SetVariable>
+                        <SetVariable name="Size">28f,24f</SetVariable>
+                        <SetVariable name="ConfigKey"><Variable name="group"/>,beats_translate_earlier</SetVariable>
+                      </Template>
+
+                      <WidgetGroup><Size>1min,1f</Size></WidgetGroup>
+
+                      <Template src="skin:button_1state.xml">
+                        <SetVariable name="TooltipId">beats_adjust_faster</SetVariable>
+                        <SetVariable name="ObjectName">BeatgridFaster</SetVariable>
+                        <SetVariable name="Size">28f,24f</SetVariable>
+                        <SetVariable name="ConfigKey"><Variable name="group"/>,beats_adjust_faster</SetVariable>
+                      </Template>
+                    </Children>
+                  </WidgetGroup><!-- /beats earlier & faster -->
+
+                  <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
+
+                  <WidgetGroup><!-- beats later & slower -->
+                    <Layout>vertical</Layout>
+                    <SizePolicy>f,f</SizePolicy>
+                    <Children>
+                      <Template src="skin:button_1state.xml">
+                        <SetVariable name="TooltipId">beats_translate_later</SetVariable>
+                        <SetVariable name="ObjectName">BeatgridLater</SetVariable>
+                        <SetVariable name="Size">28f,24f</SetVariable>
+                        <SetVariable name="ConfigKey"><Variable name="group"/>,beats_translate_later</SetVariable>
+                      </Template>
+
+                      <WidgetGroup><Size>1min,1f</Size></WidgetGroup>
+
+                      <Template src="skin:button_1state.xml">
+                        <SetVariable name="TooltipId">beats_adjust_slower</SetVariable>
+                        <SetVariable name="ObjectName">BeatgridSlower</SetVariable>
+                        <SetVariable name="Size">28f,24f</SetVariable>
+                        <SetVariable name="ConfigKey"><Variable name="group"/>,beats_adjust_slower</SetVariable>
+                      </Template>
+                    </Children>
+                  </WidgetGroup><!-- /beats later & slower -->
                 </Children>
-              </WidgetGroup><!-- /beats earlier & faster -->
+              </WidgetGroup><!-- /beat grid buttons row -->
 
-              <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
-
-              <WidgetGroup><!-- beats later & slower -->
-                <Layout>vertical</Layout>
-                <SizePolicy>f,f</SizePolicy>
-                <Children>
-                  <Template src="skin:button_1state.xml">
-                    <SetVariable name="TooltipId">beats_translate_later</SetVariable>
-                    <SetVariable name="ObjectName">BeatgridLater</SetVariable>
-                    <SetVariable name="Size">28f,24f</SetVariable>
-                    <SetVariable name="ConfigKey"><Variable name="group"/>,beats_translate_later</SetVariable>
-                  </Template>
-
-                  <WidgetGroup><Size>1min,1f</Size></WidgetGroup>
-
-                  <Template src="skin:button_1state.xml">
-                    <SetVariable name="TooltipId">beats_adjust_slower</SetVariable>
-                    <SetVariable name="ObjectName">BeatgridSlower</SetVariable>
-                    <SetVariable name="Size">28f,24f</SetVariable>
-                    <SetVariable name="ConfigKey"><Variable name="group"/>,beats_adjust_slower</SetVariable>
-                  </Template>
-                </Children>
-              </WidgetGroup><!-- /beats later & slower -->
+              <WidgetGroup><Size>1me,0me</Size></WidgetGroup>
+              <WidgetGroup><Size>1me,1f</Size></WidgetGroup>
             </Children>
-          </WidgetGroup><!-- /beat grid buttons row -->
-
-          <WidgetGroup><Size>1me,0me</Size></WidgetGroup>
-          <WidgetGroup><Size>1me,1f</Size></WidgetGroup>
+            <Connection>
+              <ConfigKey persist="true">[Tango],beatgrid_buttons</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup>
         </Children>
         <Connection>
-          <ConfigKey persist="true">[Tango],beatgrid_buttons</ConfigKey>
+          <ConfigKey persist="true">[Tango],stacked_waveforms</ConfigKey>
           <BindProperty>visible</BindProperty>
         </Connection>
       </WidgetGroup><!-- /Transparent container for beatgrid buttons -->

--- a/res/skins/Tango/waveform.xml
+++ b/res/skins/Tango/waveform.xml
@@ -85,7 +85,6 @@ Variables:
            to workaround LP1758660 "GUI lag with hidden waveforms in Tango & Deere,
                                     using integrated Intel graphics" -->
       <WidgetGroup>
-        <ObjectName>BeatgridButtons</ObjectName>
         <Layout>vertical</Layout>
         <SizePolicy>min,me</SizePolicy>
         <Children>

--- a/res/skins/Tango/waveforms_container.xml
+++ b/res/skins/Tango/waveforms_container.xml
@@ -62,13 +62,24 @@ Variables:
         </Children>
       </WidgetGroup><!-- /Waveforms -->
 
-      <WidgetGroup><ObjectName>Spacer0f</ObjectName><Size>1f,1me</Size></WidgetGroup>
+      <WidgetGroup><!-- Spacer + beatgrid button toggle -->
+        <Layout>horizontal</Layout>
+        <Size>15f,22min</Size>
+        <Children>
+          <WidgetGroup><ObjectName>Spacer0f</ObjectName><Size>1f,1me</Size></WidgetGroup>
 
-      <Template src="skin:button_2state_persist.xml">
-        <SetVariable name="ObjectName">BeatgridButtonToggler</SetVariable>
-        <SetVariable name="Size">14f,22me</SetVariable>
-        <SetVariable name="ConfigKey">[Tango],beatgrid_buttons</SetVariable>
-      </Template>
+          <Template src="skin:button_2state_persist.xml">
+            <SetVariable name="ObjectName">BeatgridButtonToggler</SetVariable>
+            <SetVariable name="Size">14f,22me</SetVariable>
+            <SetVariable name="ConfigKey">[Tango],beatgrid_buttons</SetVariable>
+          </Template>
+        </Children>
+        <Connection>
+          <ConfigKey>[Tango],stacked_waveforms</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
     </Children>
   </WidgetGroup>
 </Template>


### PR DESCRIPTION
As noone tried to fix [lp1758660 "GUI lag with hidden waveforms in Tango & Deere, using integrated Intel graphics "](https://bugs.launchpad.net/mixxx/+bug/1758660) in c++ so far, I tried a hack in the skins themselves.

**Deere/LateNight**
waveforms container can't be collapsed anymore, but minimized to 1px. waveforms aren't visible/scratchable then due to a 1px spacer.

**Tango**
If hidden by topbar toggle, the waveforms are now a flashing pixel positioned in the top-left corner of the skin. 

At first I posted skin ZIPs in the bug conversation on launchpad, and @sohet confirmed the fixes is working for him in Tango.
I applied similiar fixes to Deere and LateNight.
If you have an Intel graphics card, please test this.

If this works it would be nice if it would make it into 2.1.1