### PR TITLE
Soundtouch 2.0

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -581,7 +581,7 @@ class SoundTouch(Dependence):
 
         if build.platform_is_linux:
             # Try using system lib
-            if conf.CheckForPKG('soundtouch', '1.8.0'):
+            if conf.CheckForPKG('soundtouch', '2.0.0'):
                 # System Lib found
                 build.env.ParseConfig('pkg-config soundtouch --silence-errors \
                                       --cflags --libs')


### PR DESCRIPTION
As discussed in https://bugs.launchpad.net/mixxx/+bug/1577042 we fall back to Soundtouch 2.0 in our own source tree until the distros have updated their versions as well.
This has already happen in Ubuntu Trusty which has soundtouch 1.7 and we require 1.8 