### PR TITLE
Ramping fixes for Echo and Reverb effects

### DIFF
--- a/lib/reverb/Reverb.cc
+++ b/lib/reverb/Reverb.cc
@@ -437,7 +437,7 @@ void MixxxPlateX2::processBuffer(const sample_t* in, sample_t* out, const uint f
                                  const sample_t bandwidthParam,
                                  const sample_t decayParam,
                                  const sample_t dampingParam,
-                                 const sample_t blendParam) {
+                                 RampingValue<sample_t>* send) {
     // set bandwidth
     input.bandwidth.set(exp(-M_PI * (1. - (.005 + .994*bandwidthParam))));
     // set decay
@@ -446,15 +446,13 @@ void MixxxPlateX2::processBuffer(const sample_t* in, sample_t* out, const uint f
     double damp = exp(-M_PI * (.0005+.9995*dampingParam));
     tank.damping[0].set(damp);
     tank.damping[1].set(damp);
-    // set blend
-    sample_t blend = pow(blendParam, 1.53);
 
     // the modulated lattices interpolate, which needs truncated float
     DSP::FPTruncateMode _truncate;
 
     // loop through the buffer, processing each sample
     for (uint i = 0; i + 1 < frames; i += 2) {
-        sample_t mono_sample = blend * (in[i] + in[i + 1]) / 2;
+        sample_t mono_sample = send->rampedValue() * (in[i] + in[i + 1]) / 2;
         PlateStub::process(mono_sample, decay, &out[i], &out[i+1]);
     }
  }

--- a/lib/reverb/Reverb.h
+++ b/lib/reverb/Reverb.h
@@ -220,6 +220,7 @@ class PlateX2
 };
 #endif
 
+#include <util/rampingvalue.h>
 /// (timrae) Define our own interface instead of using the original LADSPA plugin interface
  class MixxxPlateX2 : public PlateStub {
     public:
@@ -227,7 +228,7 @@ class PlateX2
                            const sample_t bandwidthParam,
                            const sample_t decayParam,
                            const sample_t dampingParam,
-                           const sample_t blendParam);
+                           RampingValue<sample_t>* send);
 
         void init(float sampleRate) {
             fs = sampleRate;

--- a/src/effects/builtin/flangereffect.cpp
+++ b/src/effects/builtin/flangereffect.cpp
@@ -137,6 +137,13 @@ void FlangerEffect::processChannel(const ChannelHandle& handle,
                                    const GroupFeatureState& groupFeatures) {
     Q_UNUSED(handle);
 
+    // FIXME: temporary hack until EffectStates are initialized with the
+    // actual buffer parameters of the engine.
+    pState->mix.setStepsPerCallback(bufferParameters.framesPerBuffer());
+    pState->regen.setStepsPerCallback(bufferParameters.framesPerBuffer());
+    pState->width.setStepsPerCallback(bufferParameters.framesPerBuffer());
+    pState->manual.setStepsPerCallback(bufferParameters.framesPerBuffer());
+
     double lfoPeriodParameter = m_pSpeedParameter->value();
     double lfoPeriodFrames;
     if (groupFeatures.has_beat_length_sec) {
@@ -160,36 +167,26 @@ void FlangerEffect::processChannel(const ChannelHandle& handle,
     }
     pState->previousPeriodFrames = lfoPeriodFrames;
 
-
-    // lfoPeriodSamples is used to calculate the delay for each channel
-    // independently in the loop below, so do not multiply lfoPeriodSamples by
-    // the number of channels.
-
-    CSAMPLE_GAIN mix = m_pMixParameter->value();
-    RampingValue<CSAMPLE_GAIN> mixRamped(
-            pState->prev_mix, mix, bufferParameters.framesPerBuffer());
-    pState->prev_mix = mix;
-
-    CSAMPLE_GAIN regen = m_pRegenParameter->value();
-    RampingValue<CSAMPLE_GAIN> regenRamped(
-            pState->prev_regen, regen, bufferParameters.framesPerBuffer());
-    pState->prev_regen = regen;
+    pState->mix.setCurrentCallbackValue(m_pMixParameter->value());
+    pState->regen.setCurrentCallbackValue(m_pRegenParameter->value());
 
     // With and Manual is limited by amount of amplitude that remains from width
     // to kMaxDelayMs
     double width = m_pWidthParameter->value();
+    pState->width.setCurrentCallbackValue(width);
+
     double manual = m_pManualParameter->value();
     double maxManual = kCenterDelayMs + (kMaxLfoWidthMs - width) / 2;
     double minManual = kCenterDelayMs - (kMaxLfoWidthMs - width) / 2;
     manual = math_clamp(manual, minManual, maxManual);
+    pState->manual.setCurrentCallbackValue(manual);
 
-    RampingValue<double> widthRamped(
-            pState->prev_width, width, bufferParameters.framesPerBuffer());
-    pState->prev_width = width;
-
-    RampingValue<double> manualRamped(
-            pState->prev_manual, manual, bufferParameters.framesPerBuffer());
-    pState->prev_manual = manual;
+    // FIXME: temporary hack until EffectStates are initialized with the
+    // actual buffer parameters of the engine.
+    pState->mix.setStepsPerCallback(bufferParameters.framesPerBuffer());
+    pState->regen.setStepsPerCallback(bufferParameters.framesPerBuffer());
+    pState->width.setStepsPerCallback(bufferParameters.framesPerBuffer());
+    pState->manual.setStepsPerCallback(bufferParameters.framesPerBuffer());
 
     CSAMPLE* delayLeft = pState->delayLeft;
     CSAMPLE* delayRight = pState->delayRight;
@@ -198,10 +195,10 @@ void FlangerEffect::processChannel(const ChannelHandle& handle,
           i < bufferParameters.samplesPerBuffer();
           i += bufferParameters.channelCount()) {
 
-        CSAMPLE_GAIN mix_ramped = mixRamped.getNext();
-        CSAMPLE_GAIN regen_ramped = regenRamped.getNext();
-        double width_ramped = widthRamped.getNext();
-        double manual_ramped = manualRamped.getNext();
+        CSAMPLE_GAIN mix_ramped = pState->mix.rampedValue();
+        CSAMPLE_GAIN regen_ramped = pState->regen.rampedValue();
+        double width_ramped = pState->width.rampedValue();
+        double manual_ramped = pState->manual.rampedValue();
 
         pState->lfoFrames++;
         if (pState->lfoFrames >= lfoPeriodFrames) {
@@ -240,7 +237,5 @@ void FlangerEffect::processChannel(const ChannelHandle& handle,
         SampleUtil::clear(delayLeft, kBufferLenth);
         SampleUtil::clear(delayRight, kBufferLenth);
         pState->previousPeriodFrames = -1;
-        pState->prev_regen = 0;
-        pState->prev_mix = 0;
     }
 }

--- a/src/effects/builtin/flangereffect.cpp
+++ b/src/effects/builtin/flangereffect.cpp
@@ -23,6 +23,7 @@ QString FlangerEffect::getId() {
 // static
 EffectManifestPointer FlangerEffect::getManifest() {
     EffectManifestPointer pManifest(new EffectManifest());
+    pManifest->setEffectRampsFromDry(true);
     pManifest->setId(getId());
     pManifest->setName(QObject::tr("Flanger"));
     pManifest->setShortName(QObject::tr("Flanger"));
@@ -167,7 +168,12 @@ void FlangerEffect::processChannel(const ChannelHandle& handle,
     }
     pState->previousPeriodFrames = lfoPeriodFrames;
 
-    pState->mix.setCurrentCallbackValue(m_pMixParameter->value());
+    if (enableState == EffectEnableState::Disabling) {
+        pState->mix.setCurrentCallbackValue(0);
+    } else {
+        pState->mix.setCurrentCallbackValue(m_pMixParameter->value());
+    }
+
     pState->regen.setCurrentCallbackValue(m_pRegenParameter->value());
 
     // With and Manual is limited by amount of amplitude that remains from width

--- a/src/effects/builtin/flangereffect.h
+++ b/src/effects/builtin/flangereffect.h
@@ -29,10 +29,10 @@ struct FlangerGroupState : public EffectState {
               delayPos(0),
               lfoFrames(0),
               previousPeriodFrames(-1),
-              prev_regen(0),
-              prev_mix(0),
-              prev_width(0),
-              prev_manual(kCenterDelayMs) {
+              regen(bufferParameters.framesPerBuffer()),
+              mix(bufferParameters.framesPerBuffer()),
+              width(bufferParameters.framesPerBuffer()),
+              manual(bufferParameters.framesPerBuffer()) {
         SampleUtil::clear(delayLeft, kBufferLenth);
         SampleUtil::clear(delayRight, kBufferLenth);
     }
@@ -41,10 +41,10 @@ struct FlangerGroupState : public EffectState {
     unsigned int delayPos;
     unsigned int lfoFrames;
     double previousPeriodFrames;
-    CSAMPLE_GAIN prev_regen;
-    CSAMPLE_GAIN prev_mix;
-    CSAMPLE_GAIN prev_width;
-    CSAMPLE_GAIN prev_manual;
+    RampingValue<CSAMPLE_GAIN> regen;
+    RampingValue<CSAMPLE_GAIN> mix;
+    RampingValue<CSAMPLE_GAIN> width;
+    RampingValue<CSAMPLE_GAIN> manual;
 };
 
 class FlangerEffect : public EffectProcessorImpl<FlangerGroupState> {

--- a/src/effects/builtin/phasereffect.h
+++ b/src/effects/builtin/phasereffect.h
@@ -6,6 +6,7 @@
 #include "engine/effects/engineeffectparameter.h"
 #include "util/class.h"
 #include "util/defs.h"
+#include "util/rampingvalue.h"
 #include "util/sample.h"
 #include "util/types.h"
 
@@ -14,14 +15,16 @@
 class PhaserGroupState final : public EffectState {
   public:
     PhaserGroupState(const mixxx::EngineParameters& bufferParameters)
-            : EffectState(bufferParameters) {
+            : EffectState(bufferParameters),
+              depth(bufferParameters.framesPerBuffer()),
+              feedback(bufferParameters.framesPerBuffer()) {
         clear();
     }
 
     void clear() {
         leftPhase = 0;
         rightPhase = 0;
-        oldDepth = 0;
+        depth.setCurrentCallbackValue(0);
         SampleUtil::clear(oldInLeft, MAXSTAGES);
         SampleUtil::clear(oldOutLeft, MAXSTAGES);
         SampleUtil::clear(oldInRight, MAXSTAGES);
@@ -34,8 +37,8 @@ class PhaserGroupState final : public EffectState {
     CSAMPLE oldOutRight[MAXSTAGES];
     CSAMPLE leftPhase;
     CSAMPLE rightPhase;
-    CSAMPLE_GAIN oldDepth;
-
+    RampingValue<CSAMPLE_GAIN> depth;
+    RampingValue<CSAMPLE_GAIN> feedback;
 };
 
 class PhaserEffect : public EffectProcessorImpl<PhaserGroupState> {

--- a/src/effects/builtin/reverbeffect.h
+++ b/src/effects/builtin/reverbeffect.h
@@ -19,14 +19,18 @@
 class ReverbGroupState : public EffectState {
   public:
     ReverbGroupState(const mixxx::EngineParameters& bufferParameters)
-        : EffectState(bufferParameters) {
+        : EffectState(bufferParameters),
+          send(bufferParameters.framesPerBuffer()) {
+        engineParametersChanged(bufferParameters);
     }
 
     void engineParametersChanged(const mixxx::EngineParameters& bufferParameters) {
         sampleRate = bufferParameters.sampleRate();
+        send = RampingValue<sample_t>(bufferParameters.framesPerBuffer());
     }
 
     float sampleRate;
+    RampingValue<sample_t> send;
     MixxxPlateX2 reverb{};
 };
 

--- a/src/util/rampingvalue.h
+++ b/src/util/rampingvalue.h
@@ -1,22 +1,58 @@
 #ifndef MIXXX_UTIL_RAMPINGVALUE_H
 #define MIXXX_UTIL_RAMPINGVALUE_H
 
+// RampingValue is a utility class for numeric values that need to be smoothly
+// ramped across each frame or sample of an audio buffer. It compares the
+// current value of a parameter at the time of an audio engine callback to that
+// parameter's value at the last cycle of the audio engine and smoothly
+// interpolates the intermediate values across the span of the buffer.
 
+// To use a RampingValue, store it as a variable that persists across audio
+// engine callbacks. The constructor takes the number of steps that will be
+// used when iterating over the audio buffer, which is typically the number of
+// frames or samples in the audio engine's buffer. At the start of each audio
+// engine cycle, before the parameter is used, call
+// RampingValue::setCurrentCallbackValue with the parameter value received from
+// outside the audio engine thread. Then, when looping over the audio buffer,
+// get the interpolated value with RampingValue::rampedValue
 template <typename T>
 class RampingValue {
   public:
-    RampingValue(const T& initial, const T& final, int steps) {
-        m_value = initial;
-        m_increment = (final - initial) / steps;
+    RampingValue(int stepsPerCallback)
+        : m_iStepsPerCallback(stepsPerCallback),
+          m_iStepsSinceCallbackStart(0),
+          m_currentCallbackValue(0),
+          m_lastCallbackValue(0) {
     }
 
-    T getNext() {
-        return m_value += m_increment;
+    void setCurrentCallbackValue(const T& currentValue) {
+        m_lastCallbackValue = m_currentCallbackValue;
+        m_currentCallbackValue = currentValue;
+        DEBUG_ASSERT(m_iStepsSinceCallbackStart == m_iStepsPerCallback
+                     || m_iStepsSinceCallbackStart == 0);
+        m_iStepsSinceCallbackStart = 0;
+    }
+
+    T rampedValue() {
+        m_iStepsSinceCallbackStart++;
+        DEBUG_ASSERT(m_iStepsSinceCallbackStart <= m_iStepsPerCallback);
+        T stepSize = (m_currentCallbackValue - m_lastCallbackValue) / m_iStepsPerCallback;
+        return m_lastCallbackValue + stepSize * m_iStepsSinceCallbackStart;
+    }
+
+    // FIXME: This should not be necessary. m_iStepsPerCallback should only need
+    // to be set on initialization. This is a temporary hack around EffectStates
+    // not getting initialized with the actual parameters that the audio engine
+    // is using.
+    void setStepsPerCallback(int stepsPerCallback) {
+        m_iStepsPerCallback = stepsPerCallback;
     }
 
   private:
-    T m_value;
-    T m_increment;
+    int m_iStepsPerCallback;
+    int m_iStepsSinceCallbackStart;
+    T m_currentCallbackValue;
+    T m_lastCallbackValue;
 };
 
 #endif // MIXXX_UTIL_RAMPINGVALUE_H


### PR DESCRIPTION
This continues from #1703 and #1676 to fix the pop sound when enabling/disabling the Echo and Reverb effects in a D+W chain with no other effects in the chain enabled. That was caused by the inappropriate ramping in EngineEffect::process.