### PR TITLE
Effects ramping fixes

### DIFF
--- a/lib/reverb/Reverb.h
+++ b/lib/reverb/Reverb.h
@@ -227,7 +227,8 @@ class PlateX2
                            const sample_t bandwidthParam,
                            const sample_t decayParam,
                            const sample_t dampingParam,
-                           const sample_t blendParam);
+                           const sample_t currentSend,
+                           const sample_t previousSend);
 
         void init(float sampleRate) {
             fs = sampleRate;

--- a/src/effects/builtin/reverbeffect.h
+++ b/src/effects/builtin/reverbeffect.h
@@ -19,14 +19,17 @@
 class ReverbGroupState : public EffectState {
   public:
     ReverbGroupState(const mixxx::EngineParameters& bufferParameters)
-        : EffectState(bufferParameters) {
+        : EffectState(bufferParameters),
+          sendPrevious(0) {
     }
 
     void engineParametersChanged(const mixxx::EngineParameters& bufferParameters) {
         sampleRate = bufferParameters.sampleRate();
+        sendPrevious = 0;
     }
 
     float sampleRate;
+    float sendPrevious;
     MixxxPlateX2 reverb{};
 };
 


### PR DESCRIPTION
Fix the pop sound when toggling Echo and Reverb on/off in a D+W mode chain. This PR supercedes #1709 and uses the original implementation of the RampingValue utility class.