### PR TITLE
Echo effect: do not artificially clamp internal buffer

### DIFF
--- a/src/effects/builtin/echoeffect.cpp
+++ b/src/effects/builtin/echoeffect.cpp
@@ -211,13 +211,10 @@ void EchoEffect::processChannel(const ChannelHandle& handle, EchoGroupState* pGr
         incrementRing(&read_position, bufferParameters.channelCount(),
                 gs.delay_buf.size());
 
-        // Actual delays distort and saturate, so clamp the buffer here.
-        gs.delay_buf[gs.write_position] = SampleUtil::clampSample(
-                pInput[i] * send_ramped +
-                bufferedSampleLeft * feedback_ramped);
-        gs.delay_buf[gs.write_position + 1] = SampleUtil::clampSample(
-                pInput[i + 1] * send_ramped +
-                bufferedSampleLeft * feedback_ramped);
+        gs.delay_buf[gs.write_position] = pInput[i] * send_ramped
+                + bufferedSampleLeft * feedback_ramped;
+        gs.delay_buf[gs.write_position + 1] = pInput[i + 1] * send_ramped
+                + bufferedSampleLeft * feedback_ramped;
 
         // Pingpong the output.  If the pingpong value is zero, all of the
         // math below should result in a simple copy of delay buf to pOutput.


### PR DESCRIPTION
It is up to the user to control the level with the chain mix knob and Echo's send knob. It can be surprising to accidentally distort the signal when an Echo effect is in a chain. Digital signals are not clamped elsewhere in Mixxx before they are sent to the audio interface, so I do not think they should be here. If the user does want distortion, we can provide that in the future with a distortion effect (refer to https://bugs.launchpad.net/mixxx/+bug/1706444 ).