### PR TITLE
library redesign GUI lag

### DIFF
--- a/src/library/features/libraryfolder/libraryfoldermodel.cpp
+++ b/src/library/features/libraryfolder/libraryfoldermodel.cpp
@@ -26,12 +26,15 @@ LibraryFolderModel::LibraryFolderModel(LibraryFeature* pFeature,
 
     TrackDAO& trackDAO(pTrackCollection->getTrackDAO());
     connect(&trackDAO, SIGNAL(forceModelUpdate()), this, SLOT(reloadTree()));
-    connect(&trackDAO, SIGNAL(tracksAdded(QSet<TrackId>)),
-            this, SLOT(reloadTree()));
-    connect(&trackDAO, SIGNAL(tracksRemoved(QSet<TrackId>)),
-            this, SLOT(reloadTree()));
-    connect(&trackDAO, SIGNAL(trackChanged(TrackId)),
-            this, SLOT(reloadTree()));
+// FIXME: This is extremely inefficient! The entire model should not
+// be rebuilt when tracks change. Only the part of the model relevant
+// to those tracks should get updated.
+//     connect(&trackDAO, SIGNAL(tracksAdded(QSet<TrackId>)),
+//             this, SLOT(reloadTree()));
+//     connect(&trackDAO, SIGNAL(tracksRemoved(QSet<TrackId>)),
+//             this, SLOT(reloadTree()));
+//     connect(&trackDAO, SIGNAL(trackChanged(TrackId)),
+//             this, SLOT(reloadTree()));
 
     reloadTree();
 }

--- a/src/library/features/tracks/tracksfeature.cpp
+++ b/src/library/features/tracks/tracksfeature.cpp
@@ -121,12 +121,15 @@ TracksFeature::TracksFeature(UserSettingsPointer pConfig,
 
     m_pChildModel = std::make_unique<LibraryFolderModel>(this,
             m_pTrackCollection, m_pConfig);
-    connect(&m_trackDao, SIGNAL(trackChanged(TrackId)),
-            m_pChildModel.get(), SLOT(reloadTree()));
-    connect(&m_trackDao, SIGNAL(tracksRemoved(QSet<TrackId>)),
-            m_pChildModel.get(), SLOT(reloadTree()));
-    connect(&m_trackDao, SIGNAL(tracksAdded(QSet<TrackId>)),
-            m_pChildModel.get(), SLOT(reloadTree()));
+// FIXME: This is extremely inefficient! The entire model should not
+// be rebuilt when tracks change. Only the part of the model relevant
+// to those tracks should get updated.
+//     connect(&m_trackDao, SIGNAL(trackChanged(TrackId)),
+//             m_pChildModel.get(), SLOT(reloadTree()));
+//     connect(&m_trackDao, SIGNAL(tracksRemoved(QSet<TrackId>)),
+//             m_pChildModel.get(), SLOT(reloadTree()));
+//     connect(&m_trackDao, SIGNAL(tracksAdded(QSet<TrackId>)),
+//             m_pChildModel.get(), SLOT(reloadTree()));
 
     m_pLibraryTableModel = make_parented<LibraryTableModel>(this,
             pTrackCollection, "mixxx.db.model.library");

--- a/src/library/features/tracks/trackstreemodel.cpp
+++ b/src/library/features/tracks/trackstreemodel.cpp
@@ -39,12 +39,15 @@ TracksTreeModel::TracksTreeModel(LibraryFeature* pFeature,
 
     TrackDAO& trackDAO(pTrackCollection->getTrackDAO());
     connect(&trackDAO, SIGNAL(forceModelUpdate()), this, SLOT(reloadTree()));
-    connect(&trackDAO, SIGNAL(tracksAdded(QSet<TrackId>)),
-            this, SLOT(reloadTree()));
-    connect(&trackDAO, SIGNAL(tracksRemoved(QSet<TrackId>)),
-            this, SLOT(reloadTree()));
-    connect(&trackDAO, SIGNAL(trackChanged(TrackId)),
-            this, SLOT(reloadTree()));
+// FIXME: This is extremely inefficient! The entire model should not
+// be rebuilt when tracks change. Only the part of the model relevant
+// to those tracks should get updated.
+//     connect(&trackDAO, SIGNAL(tracksAdded(QSet<TrackId>)),
+//             this, SLOT(reloadTree()));
+//     connect(&trackDAO, SIGNAL(tracksRemoved(QSet<TrackId>)),
+//             this, SLOT(reloadTree()));
+//     connect(&trackDAO, SIGNAL(trackChanged(TrackId)),
+//             this, SLOT(reloadTree()));
 
     m_coverQuery << LIBRARYTABLE_COVERART_HASH
                  << LIBRARYTABLE_COVERART_LOCATION


### PR DESCRIPTION
I'm doubtful this should actually be merged, but I am opening this pull request to bring attention to the issue. After a weekend of Git bisecting and cherry picking fixes for build failures, I found 4cc9dc5b31b491ed5c3cfede0b3cac17e841025c to be the commit that introduced the big lag whenever a Track object changed. This is easily testable by loading a track, not playing the deck, and setting a new hotcue. The lag scales with the number of tracks in the database.

I think these signals could be handled much more efficiently by updating the parts of the TracksTreeModel relevant to the changed Tracks instead of [executing this expensive database query](https://github.com/mixxxdj/mixxx/blob/jmigual-library-redesign/src/library/features/tracks/trackstreemodel.cpp#L223) to rebuild the entire model. @daschuer, @uklotzde, @jmigual, or @gramanas, would you like to try implementing that?