### PR TITLE
library redesign: replace WFeatureClickButton labels with tooltips

### DIFF
--- a/src/widget/wfeatureclickbutton.cpp
+++ b/src/widget/wfeatureclickbutton.cpp
@@ -7,7 +7,6 @@ const int WFeatureClickButton::kHoverTime = 250; // milliseconds
 
 WFeatureClickButton::WFeatureClickButton(LibraryFeature* pFeature, QWidget* parent)
         : QToolButton(parent),
-          m_textControl(ConfigKey("[Library]", "show_icon_text"), this),
           m_pFeature(pFeature) {
     VERIFY_OR_DEBUG_ASSERT(pFeature != nullptr) {
         return;
@@ -17,13 +16,7 @@ WFeatureClickButton::WFeatureClickButton(LibraryFeature* pFeature, QWidget* pare
     connect(this, SIGNAL(clicked()), this, SLOT(slotClicked()));
 
     setIcon(m_pFeature->getIcon());
-    m_textControl.connectValueChanged(SLOT(slotTextDisplayChanged(double)));
-
-    if (m_textControl.valid()) {
-        slotTextDisplayChanged(m_textControl.get());
-    } else {
-        slotTextDisplayChanged(1.0);
-    }
+    setToolTip(m_pFeature->title().toString());
 
     setFocusPolicy(Qt::ClickFocus);
 }
@@ -95,16 +88,6 @@ void WFeatureClickButton::timerEvent(QTimerEvent* event) {
 
 void WFeatureClickButton::slotClicked() {
     emit(clicked(m_pFeature));
-}
-
-void WFeatureClickButton::slotTextDisplayChanged(double value) {
-    if (value < 1.0) {
-        setText("");
-        setToolButtonStyle(Qt::ToolButtonIconOnly);
-    } else {
-        setText(m_pFeature->title().toString());
-        setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    }
 }
 
 void WFeatureClickButton::keyPressEvent(QKeyEvent* event) {

--- a/src/widget/wfeatureclickbutton.h
+++ b/src/widget/wfeatureclickbutton.h
@@ -45,13 +45,11 @@ class WFeatureClickButton : public QToolButton
   private slots:
 
     void slotClicked();
-    void slotTextDisplayChanged(double value);
 
   private:
 
     static const int kHoverTime;
 
-    ControlProxy m_textControl;
     LibraryFeature* m_pFeature;
     QBasicTimer m_hoverTimer;
     bool m_mousEntered;

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -248,15 +248,6 @@ void WMainMenuBar::initialize() {
     createVisibilityControl(pViewShowCoverArt, ConfigKey("[Library]", "show_coverart"));
     pViewMenu->addAction(pViewShowCoverArt);
 
-    QString showTextTitle = tr("Show text in sidebar icons");
-    QString showTextText = tr("Shows the text below the icons in the sidebar");
-    auto pLibraryText = new QAction(showTextTitle, this);
-    pLibraryText->setStatusTip(showTextText);
-    pLibraryText->setWhatsThis(buildWhatsThis(showTextTitle, showTextText));
-    pLibraryText->setCheckable(true);
-    createVisibilityControl(pLibraryText, ConfigKey("[Library]", "show_icon_text"));
-    pViewMenu->addAction(pLibraryText);
-
     QString maximizeLibraryTitle = tr("Maximize Library");
     QString maximizeLibraryText = tr("Maximize the track library to take up all the available screen space.") +
             " " + mayNotBeSupported;


### PR DESCRIPTION
The icon labels took way too much space and were overcomplicated.