### PR TITLE
[WIP] Lib redesign skins :: follow up & small fixes

### DIFF
--- a/res/skins/Tango (64 Samplers)/skin.xml
+++ b/res/skins/Tango (64 Samplers)/skin.xml
@@ -258,7 +258,7 @@
                 <Template src="skin:../Tango/topbar.xml"/>
 
                 <Splitter>
-                  <ObjectName>WaveformSplitter</ObjectName>
+                  <ObjectName>VerticalSplitter</ObjectName>
                   <SizePolicy>me,me</SizePolicy>
                   <Orientation>vertical</Orientation>
                   <SplitSizes>100,10000</SplitSizes>

--- a/res/skins/Tango/library.xml
+++ b/res/skins/Tango/library.xml
@@ -99,21 +99,6 @@ Description:
                         </Connection>
                       </SingletonContainer>
 
-                      <WidgetGroup>
-                        <Layout>horizontal</Layout>
-                        <SizePolicy>min,min</SizePolicy>
-                        <Children>
-                          <WidgetGroup><Size>0min,0min</Size></WidgetGroup>
-                          <Template src="skin:button_2state_persist.xml">
-                            <SetVariable name="ObjectName">LibCoverArtButton</SetVariable>
-                            <!-- Icon size is 48x48px (24x24px), margin: left 2px, bottom 4px -->
-                            <SetVariable name="Size">26f,26f</SetVariable>
-                            <SetVariable name="ConfigKey">[Library],show_coverart</SetVariable>
-                          </Template>
-                          <WidgetGroup><Size>0min,0min</Size></WidgetGroup>
-                        </Children>
-                      </WidgetGroup>
-
                       <LibrarySidebarButtons>
                         <ObjectName>LibrarySidebarButtons</ObjectName>
                         <SizePolicy>min,me</SizePolicy>


### PR DESCRIPTION
- [x] Tango: remove CoverArt quick toggle from library sidebar
- [ ] Tango:  put it into Misc. section in Skin Settings menu
- [x] Tango: repair waveform splitter graphics for Tang0-64-samplers
- [ ] vectorize buttons in library (branch icons, Maintenance > wrench icon, preview buttons, conflicts after #1774)
- [ ] vectorize Preferences icons (conflicts after #1774)

Did you notice anything else?
