### PR TITLE
disable metadata editing in track table after click by default

### DIFF
--- a/src/library/library_preferences.h
+++ b/src/library/library_preferences.h
@@ -3,12 +3,6 @@
 
 #define PREF_LEGACY_LIBRARY_DIR ConfigKey("[Playlist]","Directory")
 
-// disable inline metadata editing in track table on selected click
-// by default on macOS due to https://bugs.launchpad.net/mixxx/+bug/1665583
-#ifdef Q_OS_MAC
 #define PREF_LIBRARY_EDIT_METADATA_DEFAULT false
-#else
-#define PREF_LIBRARY_EDIT_METADATA_DEFAULT true
-#endif
 
 #endif /* LIBRARY_PREFERENCES_H */


### PR DESCRIPTION
As [previously agreed](https://github.com/mixxxdj/mixxx/pull/1568#issuecomment-378613422)