### PR TITLE
Fix crossfader preferences graph not being updated on type change

### DIFF
--- a/src/preferences/dialog/dlgprefcrossfader.cpp
+++ b/src/preferences/dialog/dlgprefcrossfader.cpp
@@ -198,6 +198,7 @@ void DlgPrefCrossfader::drawXfaderDisplay()
 
     graphicsViewXfader->setScene(m_pxfScene);
     graphicsViewXfader->show();
+    graphicsViewXfader->repaint();
 }
 
 // Update and save the crossfader's parameters from the dialog's widgets.


### PR DESCRIPTION
On my mac, when I change the crossfader typer, the curve graph is not updated. This PR fixes this issue.