### PR TITLE
LateNight: Reposition spinnies so they can be bigger

### DIFF
--- a/res/skins/LateNight/deck.xml
+++ b/res/skins/LateNight/deck.xml
@@ -318,9 +318,22 @@
         <SizePolicy>me,min</SizePolicy>
         <Layout>vertical</Layout>
         <Children>
-          <Template src="skin:deck_row_1_keyVinylFx.xml" />
-          <Template src="skin:deck_row_2_3_TitleArtistTime.xml" />
-          <Template src="skin:deck_row_4_overviewSpinny.xml" />
+          <WidgetGroup>
+            <SizePolicy>me,min</SizePolicy>
+            <Layout>horizontal</Layout>
+            <Children>
+              <Template src="skin:spinny.xml"/>
+              <WidgetGroup>
+                <SizePolicy>me,min</SizePolicy>
+                <Layout>vertical</Layout>
+                <Children>
+                  <Template src="skin:deck_row_1_keyVinylFx.xml" />
+                  <Template src="skin:deck_row_2_3_TitleArtistTime.xml" />
+                  <Template src="skin:deck_row_4_overviewSpinny.xml" />
+                </Children>
+              </WidgetGroup>
+            </Children>
+          </WidgetGroup>
           <Template src="skin:deck_row_5_transportLoopJump.xml" />
         </Children>
       </WidgetGroup> <!-- /Deck Channel1 -->

--- a/res/skins/LateNight/deck.xml
+++ b/res/skins/LateNight/deck.xml
@@ -318,6 +318,7 @@
         <SizePolicy>me,min</SizePolicy>
         <Layout>vertical</Layout>
         <Children>
+          <Template src="skin:deck_row_1_keyVinylFx.xml" />
           <WidgetGroup>
             <SizePolicy>me,min</SizePolicy>
             <Layout>horizontal</Layout>
@@ -327,7 +328,6 @@
                 <SizePolicy>me,min</SizePolicy>
                 <Layout>vertical</Layout>
                 <Children>
-                  <Template src="skin:deck_row_1_keyVinylFx.xml" />
                   <Template src="skin:deck_row_2_3_TitleArtistTime.xml" />
                   <Template src="skin:deck_row_4_overviewSpinny.xml" />
                 </Children>

--- a/res/skins/LateNight/deck_row_4_overviewSpinny.xml
+++ b/res/skins/LateNight/deck_row_4_overviewSpinny.xml
@@ -4,9 +4,6 @@
     <Layout>horizontal</Layout>
     <SizePolicy>me,me</SizePolicy>
     <Children>
-
-      <Template src="skin:spinny.xml"/>
-
       <Overview>
         <TooltipId>waveform_overview</TooltipId>
         <Channel><Variable name="channum"/></Channel>
@@ -66,7 +63,7 @@
         <ObjectName>DeckControls</ObjectName>
         <Layout>vertical</Layout>
         <Children>
-          
+
           <WidgetGroup><Size>0min,0me</Size></WidgetGroup>
 
           <WidgetGroup>
@@ -83,7 +80,7 @@
               </StarRating>
             </Children>
           </WidgetGroup>
-          
+
           <WidgetGroup><Size>0min,0me</Size></WidgetGroup>
 
           <!-- Deck controls row 1 -->
@@ -208,9 +205,9 @@
 
             </Children>
           </WidgetGroup><!-- /Deck controls row 2 -->
-          
+
           <WidgetGroup><Size>0min,0me</Size></WidgetGroup>
-          
+
         </Children>
       </WidgetGroup>
     </Children>

--- a/res/skins/LateNight/spinny.xml
+++ b/res/skins/LateNight/spinny.xml
@@ -1,6 +1,7 @@
 <Template>
   <WidgetStack currentpage="[Spinny],show_spinnies" persist="true">
-    <Size>54f,52me</Size>
+    <ObjectName>SpinnyContainer</ObjectName>
+    <Size>104f,102me</Size>
     <Children>
       <WidgetGroup>
         <ObjectName>AlignHCenter</ObjectName>
@@ -23,7 +24,7 @@
         <Children>
           <Spinny>
             <TooltipId>spinny</TooltipId>
-            <Size>50f,50f</Size>
+            <Size>100f,100f</Size>
             <Group><Variable name="group"/></Group>
             <PathBackground scalemode="STRETCH_ASPECT">style/spinny_bg.svg</PathBackground>
             <PathMask scalemode="STRETCH_ASPECT">style/spinny<Variable name="channum"/>_mask.svg</PathMask>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -139,6 +139,13 @@ WTime {
   background-color: #1e1e1e;
 }
 
+#SpinnyContainer {
+  qproperty-layoutAlignment: 'AlignHCenter';
+  background-color: #1e1e1e;
+  border-bottom: 1px solid #585858;
+  border-right: 1px solid #585858;
+}
+
 #VisualizationContainer {
   border: 1px solid #585858;
   border-top: 0px;


### PR DESCRIPTION
Hey @ronso0 and @nopeppermint, I've noticed the spinnies in latenight are quite small, but it looks like there's enough room to make them bigger, even at the smallest window size.  Here's a quick change I made to do so.

![image](https://user-images.githubusercontent.com/888940/42139615-8bd48666-7d5f-11e8-9cbe-5f15010d451d.png)
