### PR TITLE
Clementine-playlists to Library integration

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -1030,6 +1030,10 @@ class MixxxCore(Feature):
                    "library/banshee/bansheeplaylistmodel.cpp",
                    "library/banshee/bansheedbconnection.cpp",
 
+                   "library/clementine/clementinefeature.cpp",
+                   "library/clementine/clementineplaylistmodel.cpp",
+                   "library/clementine/clementinedbconnection.cpp",
+
                    "library/itunes/itunesfeature.cpp",
                    "library/traktor/traktorfeature.cpp",
 

--- a/src/library/clementine/clementinedbconnection.cpp
+++ b/src/library/clementine/clementinedbconnection.cpp
@@ -152,6 +152,14 @@ QString ClementineDbConnection::getDatabaseFile() {
 
     QString dbfile;
 
+#ifdef __APPLE__
+    dbfile = QDesktopServices::storageLocation(QDesktopServices::HomeLocation);
+    dbfile += "/Library/Application Support/Clementine/clementine.db";
+    if (QFile::exists(dbfile)) {
+        return dbfile;
+    }
+#endif
+
     dbfile = QDesktopServices::storageLocation(QDesktopServices::HomeLocation);
     dbfile += "/.config/Clementine/clementine.db";
     if (QFile::exists(dbfile)) {

--- a/src/library/clementine/clementinedbconnection.cpp
+++ b/src/library/clementine/clementinedbconnection.cpp
@@ -1,0 +1,162 @@
+#include <QtDebug>
+#include <QDesktopServices>
+#include <QSettings>
+#include <QFile>
+#include <QFileInfo>
+#include <QSqlError>
+
+#include "library/queryutil.h"
+#include "library/clementine/clementinedbconnection.h"
+#include "util/performancetimer.h"
+
+ClementineDbConnection::ClementineDbConnection() {
+}
+
+ClementineDbConnection::~ClementineDbConnection() {
+    qDebug() << "Close Clementine database";
+    m_database.close();
+}
+
+bool ClementineDbConnection::open(const QString& databaseFile) {
+    m_database = QSqlDatabase::addDatabase("QSQLITE");//, "BANSHE_DB_CONNECTION");
+    m_database.setHostName("localhost");
+    m_database.setDatabaseName(databaseFile);
+    m_database.setConnectOptions("SQLITE_OPEN_READONLY");
+
+    //Open the database connection in this thread.
+    if (!m_database.open()) {
+        m_database.setConnectOptions(); // clear options
+        qWarning() << "Failed to open Clementine database." << m_database.lastError();
+        return false;
+    } else {
+        // TODO(DSC): Verify schema
+        // Clementine Schema file:
+        // https://git.gnome.org/browse/Clementine/tree/src/Core/Clementine.Services/Clementine.Database/ClementineDbFormatMigrator.cs
+        // "Grouping" was introduced in schema 19 2008-08-19
+        // Tested from 39 to 45
+        qDebug() << "Successful opened Clementine database";
+        return true;
+    }
+}
+
+QList<struct ClementineDbConnection::Playlist> ClementineDbConnection::getPlaylists() {
+
+    QList<struct ClementineDbConnection::Playlist> list;
+    struct ClementineDbConnection::Playlist playlist;
+
+    QSqlQuery query(m_database);
+    query.prepare("SELECT ROWID, playlists.name FROM playlists ORDER By playlists.name");
+
+    if (query.exec()) {
+        while (query.next()) {
+            playlist.playlistId = query.value(0).toString();
+            playlist.name = query.value(1).toString();
+            list.append(playlist);
+        }
+    } else {
+        LOG_FAILED_QUERY(query);
+    }
+    return list;
+}
+
+QList<struct ClementineDbConnection::PlaylistEntry> ClementineDbConnection::getPlaylistEntries(int playlistId) {
+
+    PerformanceTimer time;
+    time.start();
+
+    QList<struct ClementineDbConnection::PlaylistEntry> list;
+    struct ClementineDbConnection::PlaylistEntry entry;
+
+    QSqlQuery query(m_database);
+    query.setForwardOnly(true); // Saves about 50% time
+
+    QString queryString;
+
+	queryString = QString(
+		"SELECT "
+		"ROWID, "
+		"playlist_items.title, "              // 1
+		"playlist_items.filename, "           // 2
+		"playlist_items.length, "             // 3
+		"playlist_items.artist, "             // 4
+		"playlist_items.year, "               // 5
+		"playlist_items.album, "              // 6
+		"playlist_items.rating, "             // 7
+		"playlist_items.genre, "              // 8
+		"playlist_items.track, "              // 9
+		//"playlist_items.DateAddedStamp, "   //
+		"playlist_items.bpm, "                // 10
+		"playlist_items.bitrate, "            // 11
+		"playlist_items.comment, "            // 12
+		"playlist_items.playcount, "          // 13
+		"playlist_items.composer, "           // 14
+		"playlist_items.grouping, "           // 15
+		"playlist_items.type, "           // 16
+		"playlist_items.albumartist "           // 17
+		"FROM playlist_items "
+		"WHERE playlist_items.playlist = %1")
+			.arg(playlistId);
+
+
+    query.prepare(queryString);
+
+    if (query.exec()) {
+        while (query.next()) {
+        	QString type =  query.value(16).toString();
+        	if(type != "File")
+        		continue;
+            entry.artist = query.value(4).toString();
+            entry.title = query.value(1).toString();
+            entry.trackId = query.value(0).toInt();
+            entry.uri = QUrl::fromEncoded(query.value(2).toByteArray(), QUrl::StrictMode);
+            entry.duration = int(query.value(3).toLongLong() /1000000000);
+            entry.year = query.value(5).toInt();
+            entry.album = query.value(6).toString();
+            entry.albumartist = query.value(17).toString();
+
+            entry.rating = query.value(7).toInt();
+            entry.genre = query.value(8).toString();
+            entry.grouping = query.value(15).toString();
+            entry.tracknumber = query.value(9).toInt();
+            entry.bpm = query.value(10).toInt();
+            entry.bitrate = query.value(11).toInt();
+            entry.comment = query.value(12).toString();
+            entry.playcount = query.value(13).toInt();
+            entry.composer = query.value(14).toString();
+
+            if(entry.artist == "" && entry.title == ""){
+            	entry.artist = "Unknown";
+            	entry.title = entry.uri.toString().split(QDir::separator()).last();
+            }
+            if(entry.bpm == -1){
+            	entry.bpm=0;
+            }
+            if(entry.duration == -1){
+            	entry.duration=0;
+            }
+
+            list.append(entry);
+        }
+    } else {
+        LOG_FAILED_QUERY(query);
+    }
+
+    qDebug() << "ClementineDbConnection::getPlaylistEntries(), took"
+             << time.elapsed().debugMillisWithUnit();
+
+    return list;
+}
+
+// static
+QString ClementineDbConnection::getDatabaseFile() {
+
+    QString dbfile;
+
+    dbfile = QDesktopServices::storageLocation(QDesktopServices::HomeLocation);
+    dbfile += "/.config/Clementine/clementine.db";
+    if (QFile::exists(dbfile)) {
+        return dbfile;
+    }
+
+    return QString();
+}

--- a/src/library/clementine/clementinedbconnection.h
+++ b/src/library/clementine/clementinedbconnection.h
@@ -1,0 +1,51 @@
+#ifndef CLEMENTINEDBCONNECTION_H
+#define CLEMENTINEDBCONNECTION_H
+
+#include <QSqlDatabase>
+#include <QUrl>
+
+class ClementineDbConnection
+{
+public:
+
+    struct Playlist {
+        QString playlistId;
+        QString name;
+    };
+
+    struct PlaylistEntry {
+        int trackId;
+        QString title;
+        QUrl uri;
+        int duration;
+        int year;
+        int rating;
+        QString genre;
+        QString grouping;
+        int tracknumber;
+        int dateadded;
+        int bpm;
+        int bitrate;
+        QString comment;
+        int playcount;
+        QString composer;
+        QString artist;
+        QString album;
+        QString albumartist;
+    };
+
+    ClementineDbConnection();
+    virtual ~ClementineDbConnection();
+
+    static QString getDatabaseFile();
+
+    bool open(const QString& databaseFile);
+    QList<struct Playlist> getPlaylists();
+    QList<struct PlaylistEntry> getPlaylistEntries(int playlistId);
+
+private:
+    QSqlDatabase m_database;
+
+};
+
+#endif // CLEMENTINEDBCONNECTION_H

--- a/src/library/clementine/clementinefeature.cpp
+++ b/src/library/clementine/clementinefeature.cpp
@@ -1,0 +1,156 @@
+#include <QMessageBox>
+#include <QtDebug>
+#include <QList>
+
+#include "library/clementine/clementinefeature.h"
+
+#include "library/clementine/clementinedbconnection.h"
+#include "library/dao/settingsdao.h"
+#include "library/baseexternalplaylistmodel.h"
+#include "library/clementine/clementineplaylistmodel.h"
+
+const QString ClementineFeature::Clementine_MOUNT_KEY = "mixxx.ClementineFeature.mount";
+QString ClementineFeature::m_databaseFile;
+
+ClementineFeature::ClementineFeature(QObject* parent,
+                               TrackCollection* pTrackCollection,
+                               UserSettingsPointer pConfig)
+        : BaseExternalLibraryFeature(parent, pTrackCollection),
+          m_pTrackCollection(pTrackCollection),
+          m_cancelImport(false) {
+    Q_UNUSED(pConfig);
+    m_pClementinePlaylistModel = new ClementinePlaylistModel(this, m_pTrackCollection, &m_connection);
+    m_isActivated = false;
+    m_title = tr("Clementine");
+}
+
+ClementineFeature::~ClementineFeature() {
+    qDebug() << "~ClementineFeature()";
+    // stop import thread, if still running
+    m_cancelImport = true;
+    if (m_future.isRunning()) {
+        qDebug() << "m_future still running";
+        m_future.waitForFinished();
+        qDebug() << "m_future finished";
+    }
+
+    delete m_pClementinePlaylistModel;
+}
+
+// static
+bool ClementineFeature::isSupported() {
+    return !m_databaseFile.isEmpty();
+}
+
+// static
+void ClementineFeature::prepareDbPath(UserSettingsPointer pConfig) {
+    m_databaseFile = pConfig->getValueString(ConfigKey("[Clementine]","Database"));
+    if (!QFile::exists(m_databaseFile)) {
+        // Fall back to default
+        m_databaseFile = ClementineDbConnection::getDatabaseFile();
+    }
+}
+
+QVariant ClementineFeature::title() {
+    return m_title;
+}
+
+QIcon ClementineFeature::getIcon() {
+    return QIcon();//TODO ADD ICON ":/images/library/ic_library_clementine.png");
+}
+
+void ClementineFeature::activate() {
+    qDebug("ClementineFeature::activate()");
+
+    if (!m_isActivated) {
+        if (!QFile::exists(m_databaseFile)) {
+            // Fall back to default
+            m_databaseFile = ClementineDbConnection::getDatabaseFile();
+        }
+
+        if (!QFile::exists(m_databaseFile)) {
+            QMessageBox::warning(
+                    NULL,
+                    tr("Error loading Clementine database"),
+                    tr("Clementine database file not found at\n") +
+                    m_databaseFile);
+            qDebug() << m_databaseFile << "does not exist";
+        }
+
+        if (!m_connection.open(m_databaseFile)) {
+            QMessageBox::warning(
+                    NULL,
+                    tr("Error loading Clementine database"),
+                    tr("There was an error loading your Clementine database at\n") +
+                    m_databaseFile);
+            return;
+        }
+
+        m_isActivated =  true;
+
+        auto pRootItem = std::make_unique<TreeItem>(this);
+        QList<ClementineDbConnection::Playlist> playlists = m_connection.getPlaylists();
+
+        for (const ClementineDbConnection::Playlist& playlist: playlists) {
+            qDebug() << playlist.name;
+            // append the playlist to the child model
+            pRootItem->appendChild(playlist.name, playlist.playlistId);
+        }
+
+        m_childModel.setRootItem(std::move(pRootItem));
+
+        if (m_isActivated) {
+            activate();
+        }
+
+        qDebug() << "Clementine library loaded: success";
+
+        //calls a slot in the sidebarmodel such that 'isLoading' is removed from the feature title.
+        m_title = tr("Clementine");
+        emit(featureLoadingFinished(this));
+    }
+
+    m_pClementinePlaylistModel->setTableModel(0); // Gets the master playlist
+    emit(showTrackModel(m_pClementinePlaylistModel));
+    emit(enableCoverArtDisplay(false));
+}
+
+void ClementineFeature::activateChild(const QModelIndex& index) {
+    TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
+    int playlistID = item->getData().toInt();
+    if (playlistID > 0) {
+        qDebug() << "Activating " << item->getLabel();
+        m_pClementinePlaylistModel->setTableModel(playlistID);
+        emit(showTrackModel(m_pClementinePlaylistModel));
+        emit(enableCoverArtDisplay(false));
+    }
+}
+
+TreeItemModel* ClementineFeature::getChildModel() {
+    return &m_childModel;
+}
+
+void ClementineFeature::appendTrackIdsFromRightClickIndex(QList<TrackId>* trackIds, QString* pPlaylist) {
+    if (m_lastRightClickedIndex.isValid()) {
+        TreeItem *item = static_cast<TreeItem*>(m_lastRightClickedIndex.internalPointer());
+        *pPlaylist = item->getLabel();
+        int playlistID = item->getData().toInt();
+        qDebug() << "ClementineFeature::appendTrackIdsFromRightClickIndex " << *pPlaylist << " " << playlistID;
+        if (playlistID > 0) {
+            ClementinePlaylistModel* pPlaylistModelToAdd = new ClementinePlaylistModel(this, m_pTrackCollection, &m_connection);
+            pPlaylistModelToAdd->setTableModel(playlistID);
+
+            // Copy Tracks
+            int rows = pPlaylistModelToAdd->rowCount();
+            for (int i = 0; i < rows; ++i) {
+                QModelIndex index = pPlaylistModelToAdd->index(i,0);
+                if (index.isValid()) {
+                    //qDebug() << pPlaylistModelToAdd->getTrackLocation(index);
+                    TrackPointer track = pPlaylistModelToAdd->getTrack(index);
+                    trackIds->append(track->getId());
+                }
+            }
+            delete pPlaylistModelToAdd;
+        }
+    }
+}

--- a/src/library/clementine/clementinefeature.h
+++ b/src/library/clementine/clementinefeature.h
@@ -1,0 +1,62 @@
+
+#ifndef CLEMENTINEFEATURE_H
+#define CLEMENTINEFEATURE_H
+
+#include <QStringListModel>
+#include <QtSql>
+#include <QFuture>
+#include <QtConcurrentRun>
+#include <QFutureWatcher>
+
+#include "library/baseexternallibraryfeature.h"
+#include "library/trackcollection.h"
+#include "library/treeitemmodel.h"
+#include "library/treeitem.h"
+#include "library/clementine/clementinedbconnection.h"
+
+
+class ClementinePlaylistModel;
+
+class ClementineFeature : public BaseExternalLibraryFeature {
+    Q_OBJECT
+  public:
+    ClementineFeature(QObject* parent, TrackCollection* pTrackCollection, UserSettingsPointer pConfig);
+    virtual ~ClementineFeature();
+    static bool isSupported();
+    static void prepareDbPath(UserSettingsPointer pConfig);
+
+    virtual QVariant title();
+    virtual QIcon getIcon();
+
+    virtual TreeItemModel* getChildModel();
+
+  public slots:
+    virtual void activate();
+    virtual void activateChild(const QModelIndex& index);
+
+  private:
+    virtual void appendTrackIdsFromRightClickIndex(QList<TrackId>* trackIds, QString* pPlaylist);
+
+    ClementinePlaylistModel* m_pClementinePlaylistModel;
+    TreeItemModel m_childModel;
+    QStringList m_playlists;
+    TrackCollection* m_pTrackCollection;
+    //a new DB connection for the worker thread
+
+    ClementineDbConnection m_connection;
+
+    QSqlDatabase m_database;
+    bool m_isActivated;
+    QString m_dbfile;
+
+    QFutureWatcher<TreeItem*> m_future_watcher;
+    QFuture<TreeItem*> m_future;
+    QString m_title;
+    bool m_cancelImport;
+
+    static QString m_databaseFile;
+
+    static const QString Clementine_MOUNT_KEY;
+};
+
+#endif // CLEMENTINEFEATURE_H

--- a/src/library/clementine/clementineplaylistmodel.cpp
+++ b/src/library/clementine/clementineplaylistmodel.cpp
@@ -1,0 +1,367 @@
+#include <QtAlgorithms>
+#include <QtDebug>
+
+#include "library/clementine/clementineplaylistmodel.h"
+#include "library/clementine/clementinedbconnection.h"
+#include "library/queryutil.h"
+#include "library/starrating.h"
+#include "library/previewbuttondelegate.h"
+#include "track/beatfactory.h"
+#include "track/beats.h"
+#include "mixer/playermanager.h"
+
+#define Clementine_TABLE "Clementine"
+#define CLM_VIEW_ORDER "position"
+#define CLM_ARTIST "artist"
+#define CLM_TITLE "title"
+#define CLM_DURATION "duration"
+#define CLM_URI "location"
+#define CLM_ALBUM "album"
+#define CLM_ALBUM_ARTIST "album_artist"
+#define CLM_YEAR "year"
+#define CLM_RATING "rating"
+#define CLM_GENRE "genre"
+#define CLM_GROUPING "grouping"
+#define CLM_TRACKNUMBER "tracknumber"
+#define CLM_DATEADDED "datetime_added"
+#define CLM_BPM "bpm"
+#define CLM_BITRATE "bitrate"
+#define CLM_COMMENT "comment"
+#define CLM_PLAYCOUNT "timesplayed"
+#define CLM_COMPOSER "composer"
+#define CLM_PREVIEW "preview"
+
+ClementinePlaylistModel::ClementinePlaylistModel(QObject* pParent, TrackCollection* pTrackCollection, ClementineDbConnection* pConnection)
+        : BaseSqlTableModel(pParent, pTrackCollection, "mixxx.db.model.Clementine_playlist"),
+          m_pConnection(pConnection),
+          m_playlistId(-1) {
+}
+
+ClementinePlaylistModel::~ClementinePlaylistModel() {
+}
+
+void ClementinePlaylistModel::setTableModel(int playlistId) {
+    //qDebug() << "ClementinePlaylistModel::setTableModel" << playlistId;
+    if (m_playlistId == playlistId) {
+        qDebug() << "Already focused on playlist " << playlistId;
+        return;
+    }
+
+    if (m_playlistId >= 0) {
+        // Clear old playlist
+        m_playlistId = -1;
+        QSqlQuery query(m_pTrackCollection->database());
+        QString strQuery("DELETE FROM " Clementine_TABLE);
+        if (!query.exec(strQuery)) {
+        }
+    }
+
+    if (playlistId >= 0) {
+        // setup new playlist
+        m_playlistId = playlistId;
+
+        QSqlQuery query(m_pTrackCollection->database());
+        QString strQuery("CREATE TEMP TABLE IF NOT EXISTS " Clementine_TABLE
+            " (" CLM_VIEW_ORDER " INTEGER, "
+                 CLM_ARTIST " TEXT, "
+                 CLM_TITLE " TEXT, "
+                 CLM_DURATION " INTEGER, "
+                 CLM_URI " TEXT, "
+                 CLM_ALBUM " TEXT, "
+                 CLM_ALBUM_ARTIST " TEXT, "
+                 CLM_YEAR " INTEGER, "
+                 CLM_RATING " INTEGER, "
+                 CLM_GENRE " TEXT, "
+                 CLM_GROUPING " TEXT, "
+                 CLM_TRACKNUMBER " INTEGER, "
+                 //CLM_DATEADDED " INTEGER, "
+                 CLM_BPM " INTEGER, "
+                 CLM_BITRATE " INTEGER, "
+                 CLM_COMMENT " TEXT, "
+                 CLM_PLAYCOUNT" INTEGER, "
+                 CLM_COMPOSER " TEXT, "
+                 CLM_PREVIEW " TEXT)");
+        if (!query.exec(strQuery)) {
+            LOG_FAILED_QUERY(query);
+        }
+
+        query.prepare("INSERT INTO " Clementine_TABLE
+                " (" CLM_VIEW_ORDER ", "
+                     CLM_ARTIST ", "
+                     CLM_TITLE ", "
+                     CLM_DURATION ", "
+                     CLM_URI ", "
+                     CLM_ALBUM ", "
+                     CLM_ALBUM_ARTIST ", "
+                     CLM_YEAR ", "
+                     CLM_RATING ", "
+                     CLM_GENRE ", "
+                     CLM_GROUPING ", "
+                     CLM_TRACKNUMBER ", "
+                     //CLM_DATEADDED ", "
+                     CLM_BPM ", "
+                     CLM_BITRATE ", "
+                     CLM_COMMENT ", "
+                     CLM_PLAYCOUNT ", "
+                     CLM_COMPOSER ") "
+                     "VALUES (:"
+                     CLM_VIEW_ORDER ", :"
+                     CLM_ARTIST ", :"
+                     CLM_TITLE ", :"
+                     CLM_DURATION ", :"
+                     CLM_URI ", :"
+                     CLM_ALBUM ", :"
+                     CLM_ALBUM_ARTIST ", :"
+                     CLM_YEAR ", :"
+                     CLM_RATING ", :"
+                     CLM_GENRE ", :"
+                     CLM_GROUPING ", :"
+                     CLM_TRACKNUMBER ", :"
+                     //CLM_DATEADDED ", :"
+                     CLM_BPM ", :"
+                     CLM_BITRATE ", :"
+                     CLM_COMMENT ", :"
+                     CLM_PLAYCOUNT ", :"
+                     CLM_COMPOSER ") ");
+
+
+        QList<struct ClementineDbConnection::PlaylistEntry> list =
+                m_pConnection->getPlaylistEntries(playlistId);
+
+        if (!list.isEmpty()) {
+            beginInsertRows(QModelIndex(), 0, list.size() - 1);
+			int i = 1;
+            foreach (struct ClementineDbConnection::PlaylistEntry entry, list) {
+                query.bindValue(":" CLM_VIEW_ORDER, i++);
+                query.bindValue(":" CLM_ARTIST, entry.artist);
+                query.bindValue(":" CLM_TITLE, entry.title);
+                query.bindValue(":" CLM_DURATION, entry.duration);
+                query.bindValue(":" CLM_URI, entry.uri);
+                query.bindValue(":" CLM_ALBUM, entry.album);
+                query.bindValue(":" CLM_ALBUM_ARTIST, entry.albumartist);
+                query.bindValue(":" CLM_YEAR, entry.year);
+                query.bindValue(":" CLM_RATING, entry.rating);
+                query.bindValue(":" CLM_GENRE, entry.genre);
+                query.bindValue(":" CLM_GROUPING, entry.grouping);
+                query.bindValue(":" CLM_TRACKNUMBER, entry.tracknumber);
+
+                query.bindValue(":" CLM_BPM, entry.bpm);
+                query.bindValue(":" CLM_BITRATE, entry.bitrate);
+                query.bindValue(":" CLM_COMMENT, entry.comment);
+                query.bindValue(":" CLM_PLAYCOUNT, entry.playcount);
+                query.bindValue(":" CLM_COMPOSER, entry.composer);
+
+                if (!query.exec()) {
+                    LOG_FAILED_QUERY(query);
+                }
+                // qDebug() << "-----" << entry.pTrack->title << query.executedQuery();
+            }
+
+            endInsertRows();
+        }
+    }
+
+    QStringList tableColumns;
+    tableColumns << CLM_VIEW_ORDER // 0
+         << CLM_PREVIEW;
+
+    QStringList trackSourceColumns;
+    trackSourceColumns << CLM_VIEW_ORDER // 0
+         << CLM_ARTIST
+         << CLM_TITLE
+         << CLM_DURATION
+         << CLM_URI
+         << CLM_ALBUM
+         << CLM_ALBUM_ARTIST
+         << CLM_YEAR
+         << CLM_RATING
+         << CLM_GENRE
+         << CLM_GROUPING
+         << CLM_TRACKNUMBER
+         //<< CLM_DATEADDED
+         << CLM_BPM
+         << CLM_BITRATE
+         << CLM_COMMENT
+         << CLM_PLAYCOUNT
+         << CLM_COMPOSER;
+
+    QSharedPointer<BaseTrackCache> trackSource(
+            new BaseTrackCache(m_pTrackCollection, Clementine_TABLE, CLM_VIEW_ORDER,
+                    trackSourceColumns, false));
+
+    setTable(Clementine_TABLE, CLM_VIEW_ORDER, tableColumns, trackSource);
+    setSearch("");
+    setDefaultSort(fieldIndex(PLAYLISTTRACKSTABLE_POSITION), Qt::AscendingOrder);
+    setSort(defaultSortColumn(), defaultSortOrder());
+}
+
+bool ClementinePlaylistModel::setData(const QModelIndex& index, const QVariant& value, int role) {
+    Q_UNUSED(index);
+    Q_UNUSED(value);
+    Q_UNUSED(role);
+    return false;
+}
+
+TrackModel::CapabilitiesFlags ClementinePlaylistModel::getCapabilities() const {
+    return TRACKMODELCAPS_NONE
+            | TRACKMODELCAPS_ADDTOPLAYLIST
+            | TRACKMODELCAPS_ADDTOCRATE
+            | TRACKMODELCAPS_ADDTOAUTODJ
+            | TRACKMODELCAPS_LOADTODECK
+            | TRACKMODELCAPS_LOADTOSAMPLER;
+}
+
+Qt::ItemFlags ClementinePlaylistModel::flags(const QModelIndex &index) const {
+    return readWriteFlags(index);
+}
+
+Qt::ItemFlags ClementinePlaylistModel::readWriteFlags(const QModelIndex &index) const {
+    if (!index.isValid()) {
+        return Qt::ItemIsEnabled;
+    }
+
+    Qt::ItemFlags defaultFlags = QAbstractItemModel::flags(index);
+
+    // Enable dragging songs from this data model to elsewhere (like the waveform
+    // widget to load a track into a Player).
+    defaultFlags |= Qt::ItemIsDragEnabled;
+
+    return defaultFlags;
+}
+
+Qt::ItemFlags ClementinePlaylistModel::readOnlyFlags(const QModelIndex &index) const
+{
+    Qt::ItemFlags defaultFlags = QAbstractItemModel::flags(index);
+    if (!index.isValid())
+        return Qt::ItemIsEnabled;
+
+    //Enable dragging songs from this data model to elsewhere (like the waveform widget to
+    //load a track into a Player).
+    defaultFlags |= Qt::ItemIsDragEnabled;
+
+    return defaultFlags;
+}
+
+void ClementinePlaylistModel::tracksChanged(QSet<TrackId> trackIds) {
+    Q_UNUSED(trackIds);
+}
+
+void ClementinePlaylistModel::trackLoaded(QString group, TrackPointer pTrack) {
+    if (group == m_previewDeckGroup) {
+        // If there was a previously loaded track, refresh its rows so the
+        // preview state will update.
+        if (m_previewDeckTrackId.isValid()) {
+            const int numColumns = columnCount();
+            QLinkedList<int> rows = getTrackRows(m_previewDeckTrackId);
+            m_previewDeckTrackId = TrackId(); // invalidate
+            foreach (int row, rows) {
+                QModelIndex left = index(row, 0);
+                QModelIndex right = index(row, numColumns);
+                emit(dataChanged(left, right));
+            }
+        }
+        if (pTrack) {
+            for (int row = 0; row < rowCount(); ++row) {
+                QUrl rowUrl(getFieldString(index(row, 0), CLM_URI));
+                if (rowUrl.toLocalFile() == pTrack->getLocation()) {
+                    m_previewDeckTrackId =
+                            TrackId(getFieldVariant(index(row, 0), CLM_VIEW_ORDER));
+                    break;
+                }
+            }
+        }
+    }
+}
+
+QVariant ClementinePlaylistModel::getFieldVariant(const QModelIndex& index,
+        const QString& fieldName) const {
+    return index.sibling(index.row(), fieldIndex(fieldName)).data();
+}
+
+QString ClementinePlaylistModel::getFieldString(const QModelIndex& index,
+        const QString& fieldName) const {
+    return getFieldVariant(index, fieldName).toString();
+}
+
+TrackPointer ClementinePlaylistModel::getTrack(const QModelIndex& index) const {
+    QString location = getTrackLocation(index);
+
+    if (location.isEmpty()) {
+        // Track is lost
+        return TrackPointer();
+    }
+
+    bool track_already_in_library = false;
+    TrackPointer pTrack = m_pTrackCollection->getTrackDAO()
+            .getOrAddTrack(location, true, &track_already_in_library);
+
+    // If this track was not in the Mixxx library it is now added and will be
+    // saved with the metadata from Clementine. If it was already in the library
+    // then we do not touch it so that we do not over-write the user's metadata.
+    if (pTrack && !track_already_in_library) {
+        pTrack->setArtist(getFieldString(index, CLM_ARTIST));
+        pTrack->setTitle(getFieldString(index, CLM_TITLE));
+        pTrack->setDuration(getFieldString(index, CLM_DURATION).toDouble());
+        pTrack->setAlbum(getFieldString(index, CLM_ALBUM));
+        pTrack->setAlbumArtist(getFieldString(index, CLM_ALBUM_ARTIST));
+        pTrack->setYear(getFieldString(index, CLM_YEAR));
+        pTrack->setGenre(getFieldString(index, CLM_GENRE));
+        pTrack->setGrouping(getFieldString(index, CLM_GROUPING));
+        pTrack->setRating(getFieldString(index, CLM_RATING).toInt());
+        pTrack->setTrackNumber(getFieldString(index, CLM_TRACKNUMBER));
+        double bpm = getFieldString(index, CLM_BPM).toDouble();
+        bpm = pTrack->setBpm(bpm);
+        pTrack->setBitrate(getFieldString(index, CLM_BITRATE).toInt());
+        pTrack->setComment(getFieldString(index, CLM_COMMENT));
+        pTrack->setComposer(getFieldString(index, CLM_COMPOSER));
+        // If the track has a BPM, then give it a static beatgrid.
+        if (bpm > 0) {
+            BeatsPointer pBeats = BeatFactory::makeBeatGrid(*pTrack, bpm, 0.0);
+            pTrack->setBeats(pBeats);
+        }
+
+    }
+    return pTrack;
+}
+
+// Gets the on-disk location of the track at the given location.
+QString ClementinePlaylistModel::getTrackLocation(const QModelIndex& index) const {
+    if (!index.isValid()) {
+        return "";
+    }
+    QUrl url(getFieldString(index, CLM_URI));
+
+    QString location;
+    location = url.toLocalFile();
+
+    qDebug() << location << " = " << url;
+
+    if (!location.isEmpty()) {
+        return location;
+    }
+
+    // Try to convert a smb path location = url.toLocalFile();
+    QString temp_location = url.toString();
+
+    if (temp_location.startsWith("smb://")) {
+        // Hack for samba mounts works only on German GNOME Linux
+        // smb://daniel-desktop/volume/Musik/Lastfm/Limp Bizkit/Chocolate Starfish And The Hot Dog Flavored Water/06 - Rollin' (Air Raid Vehicle).mp3"
+        // TODO(xxx): use gio instead
+
+        location = QDir::homePath() + "/.gvfs/";
+        location += temp_location.section('/', 3, 3);
+        location += " auf ";
+        location += temp_location.section('/', 2, 2);
+        location += "/";
+        location += temp_location.section('/', 4);
+
+        return location;
+    }
+
+    return QString();
+}
+
+bool ClementinePlaylistModel::isColumnInternal(int column) {
+    Q_UNUSED(column);
+    return false;
+}

--- a/src/library/clementine/clementineplaylistmodel.h
+++ b/src/library/clementine/clementineplaylistmodel.h
@@ -1,0 +1,49 @@
+#ifndef CLEMENTINEPLAYLISTMODEL_H
+#define CLEMENTINEPLAYLISTMODEL_H
+
+#include <QHash>
+#include <QtSql>
+
+#include "library/trackmodel.h"
+#include "library/trackcollection.h"
+#include "library/dao/trackdao.h"
+#include "library/clementine/clementinedbconnection.h"
+#include "library/stardelegate.h"
+#include "library/basesqltablemodel.h"
+
+class ClementinePlaylistModel : public BaseSqlTableModel {
+    Q_OBJECT
+  public:
+    ClementinePlaylistModel(QObject* pParent, TrackCollection* pTrackCollection, ClementineDbConnection* pConnection);
+    ~ClementinePlaylistModel() final;
+
+    void setTableModel(int playlistId);
+
+    TrackPointer getTrack(const QModelIndex& index) const final;
+    QString getTrackLocation(const QModelIndex& index) const final;
+    bool isColumnInternal(int column) final;
+
+    Qt::ItemFlags flags(const QModelIndex &index) const final;
+    CapabilitiesFlags getCapabilities() const final;
+
+    bool setData(const QModelIndex& index, const QVariant& value, int role=Qt::EditRole) final;
+
+  protected:
+    // Use this if you want a model that is read-only.
+    Qt::ItemFlags readOnlyFlags(const QModelIndex &index) const final;
+    // Use this if you want a model that can be changed
+    Qt::ItemFlags readWriteFlags(const QModelIndex &index) const final;
+
+  private slots:
+    void tracksChanged(QSet<TrackId> trackIds);
+    void trackLoaded(QString group, TrackPointer pTrack);
+
+  private:
+    QString getFieldString(const QModelIndex& index, const QString& fieldName) const;
+    QVariant getFieldVariant(const QModelIndex& index, const QString& fieldName) const;
+
+    ClementineDbConnection* m_pConnection;
+    int m_playlistId;
+};
+
+#endif // ClementinePLAYLISTMODEL_H

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -19,6 +19,7 @@
 #include "library/browse/browsefeature.h"
 #include "library/crate/cratefeature.h"
 #include "library/rhythmbox/rhythmboxfeature.h"
+#include "library/clementine/clementinefeature.h"
 #include "library/banshee/bansheefeature.h"
 #include "library/recording/recordingfeature.h"
 #include "library/itunes/itunesfeature.h"
@@ -141,6 +142,12 @@ Library::Library(
         BansheeFeature::prepareDbPath(pConfig);
         if (BansheeFeature::isSupported()) {
             addFeature(new BansheeFeature(this, m_pTrackCollection, pConfig));
+        }
+    }
+    if (pConfig->getValue(ConfigKey(kConfigGroup,"ShowClementineLibrary"), true)) {
+        ClementineFeature::prepareDbPath(pConfig);
+        if (ClementineFeature::isSupported()) {
+            addFeature(new ClementineFeature(this, m_pTrackCollection, pConfig));
         }
     }
     if (ITunesFeature::isSupported() &&

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -138,6 +138,7 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_show_banshee->setChecked(true);
     checkBox_show_itunes->setChecked(true);
     checkBox_show_traktor->setChecked(true);
+    checkBox_show_clementine->setChecked(true);
     radioButton_dbclick_bottom->setChecked(false);
     checkBoxEditMetadataSelectedClicked->setChecked(PREF_LIBRARY_EDIT_METADATA_DEFAULT);
     radioButton_dbclick_top->setChecked(false);
@@ -162,6 +163,8 @@ void DlgPrefLibrary::slotUpdate() {
             ConfigKey("[Library]","ShowITunesLibrary"), true));
     checkBox_show_traktor->setChecked(m_pConfig->getValue(
             ConfigKey("[Library]","ShowTraktorLibrary"), true));
+    checkBox_show_clementine->setChecked(m_pConfig->getValue(
+            ConfigKey("[Library]","ShowClementineLibrary"), true));
 
     switch (m_pConfig->getValue<int>(
             ConfigKey("[Library]","TrackLoadAction"), LOAD_TO_DECK)) {
@@ -301,6 +304,8 @@ void DlgPrefLibrary::slotApply() {
                 ConfigValue((int)checkBox_show_itunes->isChecked()));
     m_pConfig->set(ConfigKey("[Library]","ShowTraktorLibrary"),
                 ConfigValue((int)checkBox_show_traktor->isChecked()));
+    m_pConfig->set(ConfigKey("[Library]","ShowClementineLibrary"),
+                ConfigValue((int)checkBox_show_clementine->isChecked()));
     int dbclick_status;
     if (radioButton_dbclick_bottom->isChecked()) {
             dbclick_status = ADD_TO_AUTODJ_BOTTOM;

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -301,7 +301,7 @@
       <string>External Libraries</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_6">
-      <item row="8" column="0">
+      <item row="9" column="0">
        <widget class="QLabel" name="label_10">
         <property name="text">
          <string>You will need to restart Mixxx for these settings to take effect.</string>
@@ -338,7 +338,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QCheckBox" name="checkBox_show_traktor">
         <property name="text">
          <string>Show Traktor Library</string>
@@ -348,17 +348,27 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>All external libraries shown are write protected.</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
+      <item row="6" column="0">
        <widget class="Line" name="line">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="checkBox_show_clementine">
+        <property name="text">
+         <string>Show Clementine Library</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Integration of playlist usage from the clementine player (the one and only good player for linux ;)). I was using the banshee interface as reference and adapted it to the sqlite clementine lib. As they share some similarities it would be possible to refactor it to a more generalized sqlite interface, but for now its also okey this way for me.
Implemented / tested in ubuntu 16.04, but it should work under windows/macos aswell (untested but implemented).
A logo in the same style as the others needs to be added to resources. 

i also just signed the Mixxx Contributor Agreement.

(Its my first pullrequest to a opensource project ever, so if i missed something, please give me a hint :))