### PR TITLE
Use devicePixelRatio to scale the viewport in GLSLWaveformRendererSignal.

### DIFF
--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -11,13 +11,10 @@ GLSLWaveformRendererSignal::GLSLWaveformRendererSignal(WaveformWidgetRenderer* w
         : WaveformRendererSignalBase(waveformWidgetRenderer),
           m_unitQuadListId(-1),
           m_textureId(0),
-          m_loadedWaveform(0),
-          m_frameBuffersValid(false),
-          m_framebuffer(NULL),
+          m_textureRenderedWaveformCompletion(0),
           m_bDumpPng(false),
           m_shadersValid(false),
-          m_rgbShader(rgbShader),
-          m_frameShaderProgram(NULL) {
+          m_rgbShader(rgbShader) {
 }
 
 GLSLWaveformRendererSignal::~GLSLWaveformRendererSignal() {
@@ -27,11 +24,6 @@ GLSLWaveformRendererSignal::~GLSLWaveformRendererSignal() {
 
     if (m_frameShaderProgram) {
         m_frameShaderProgram->removeAllShaders();
-        delete m_frameShaderProgram;
-    }
-
-    if (m_framebuffer) {
-        delete m_framebuffer;
     }
 }
 
@@ -85,7 +77,7 @@ bool GLSLWaveformRendererSignal::loadTexture() {
     TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
     ConstWaveformPointer waveform;
     int dataSize = 0;
-    const WaveformData* data = NULL;
+    const WaveformData* data = nullptr;
 
     if (trackInfo) {
         waveform = trackInfo->getWaveform();
@@ -103,20 +95,22 @@ bool GLSLWaveformRendererSignal::loadTexture() {
         glGenTextures(1, &m_textureId);
 
         int error = glGetError();
-        if (error)
+        if (error) {
             qDebug() << "GLSLWaveformRendererSignal::loadTexture - m_textureId" << m_textureId << "error" << error;
+        }
     }
 
     glBindTexture(GL_TEXTURE_2D, m_textureId);
 
     int error = glGetError();
-    if (error)
+    if (error) {
         qDebug() << "GLSLWaveformRendererSignal::loadTexture - bind error" << error;
+    }
 
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
-    if (waveform != NULL && data != NULL) {
+    if (waveform != nullptr && data != nullptr) {
         // Waveform ensures that getTextureSize is a multiple of
         // getTextureStride so there is no rounding here.
         int textureWidth = waveform->getTextureStride();
@@ -125,10 +119,11 @@ bool GLSLWaveformRendererSignal::loadTexture() {
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, textureWidth, textureHeight, 0,
                      GL_RGBA, GL_UNSIGNED_BYTE, data);
         int error = glGetError();
-        if (error)
+        if (error) {
             qDebug() << "GLSLWaveformRendererSignal::loadTexture - glTexImage2D error" << error;
+        }
     } else {
-        glDeleteTextures(1,&m_textureId);
+        glDeleteTextures(1, &m_textureId);
         m_textureId = 0;
     }
 
@@ -139,8 +134,9 @@ bool GLSLWaveformRendererSignal::loadTexture() {
 
 void GLSLWaveformRendererSignal::createGeometry() {
 
-    if (m_unitQuadListId != -1)
+    if (m_unitQuadListId != -1) {
         return;
+    }
 
 #ifndef __OPENGLES__
 
@@ -174,34 +170,28 @@ void GLSLWaveformRendererSignal::createGeometry() {
 #endif
 }
 
-void GLSLWaveformRendererSignal::createFrameBuffers()
-{
-    m_frameBuffersValid = false;
+void GLSLWaveformRendererSignal::createFrameBuffers() {
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+    // We create a frame buffer that is 4x the size of the renderer itself to
+    // "oversample" the texture relative to the surface we're drawing on.
+    const int oversamplingFactor = 4;
+    const int bufferWidth = oversamplingFactor * m_waveformRenderer->getWidth() * devicePixelRatio;
+    const int bufferHeight = oversamplingFactor * m_waveformRenderer->getHeight() * devicePixelRatio;
 
-    int bufferWidth = m_waveformRenderer->getWidth();
-    int bufferHeight = m_waveformRenderer->getHeight();
+    m_framebuffer = std::make_unique<QGLFramebufferObject>(bufferWidth,
+                                                           bufferHeight);
 
-    if (m_framebuffer)
-        delete m_framebuffer;
-
-    //should work with any version of OpenGl
-    m_framebuffer = new QGLFramebufferObject(bufferWidth * 4, bufferHeight * 4);
-
-    if (!m_framebuffer->isValid())
+    if (!m_framebuffer->isValid()) {
         qWarning() << "GLSLWaveformRendererSignal::createFrameBuffer - frame buffer not valid";
-
-    m_frameBuffersValid = m_framebuffer->isValid();
-
-    //qDebug() << m_waveformRenderer->getWidth();
-    //qDebug() << m_waveformRenderer->getWidth()*3;
-    //qDebug() << bufferWidth;
+    }
 }
 
 bool GLSLWaveformRendererSignal::onInit() {
-    m_loadedWaveform = 0;
+    m_textureRenderedWaveformCompletion = 0;
 
-    if (!m_frameShaderProgram)
-        m_frameShaderProgram = new QGLShaderProgram();
+    if (!m_frameShaderProgram) {
+        m_frameShaderProgram = std::make_unique<QGLShaderProgram>();
+    }
 
     if (!loadShaders()) {
         return false;
@@ -245,12 +235,12 @@ void GLSLWaveformRendererSignal::onResize() {
 }
 
 void GLSLWaveformRendererSignal::slotWaveformUpdated() {
-    m_loadedWaveform = 0;
+    m_textureRenderedWaveformCompletion = 0;
     loadTexture();
 }
 
 void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/) {
-    if (!m_frameBuffersValid || !m_shadersValid) {
+    if (!m_framebuffer || !m_framebuffer->isValid() || !m_shadersValid) {
         return;
     }
 
@@ -270,19 +260,19 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
     }
 
     const WaveformData* data = waveform->data();
-    if (data == NULL) {
+    if (data == nullptr) {
         return;
     }
 
     // save the GL state set for QPainter
     painter->beginNativePainting();
 
-    //NOTE: (vRince) completion can change during loadTexture
-    //do not remove currenCompletion temp variable !
+    // NOTE(vRince): completion can change during loadTexture
+    // do not remove currenCompletion temp variable !
     const int currentCompletion = waveform->getCompletion();
-    if (m_loadedWaveform < currentCompletion) {
+    if (m_textureRenderedWaveformCompletion < currentCompletion) {
         loadTexture();
-        m_loadedWaveform = currentCompletion;
+        m_textureRenderedWaveformCompletion = currentCompletion;
     }
 
     // Per-band gain from the EQ knobs.
@@ -406,9 +396,14 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glEnable(GL_TEXTURE_2D);
 
-    //paint buffer into viewport
+    // paint buffer into viewport
     {
-        glViewport(0, 0, m_waveformRenderer->getWidth(), m_waveformRenderer->getHeight());
+        // OpenGL pixels are real screen pixels, not device independent
+        // pixels like QPainter provides. We scale the viewport by the
+        // devicePixelRatio to render the texture to the surface.
+        const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+        glViewport(0, 0, devicePixelRatio * m_waveformRenderer->getWidth(),
+                   devicePixelRatio * m_waveformRenderer->getHeight());
         glBindTexture(GL_TEXTURE_2D, m_framebuffer->texture());
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/src/waveform/renderers/glslwaveformrenderersignal.h
+++ b/src/waveform/renderers/glslwaveformrenderersignal.h
@@ -6,21 +6,22 @@
 #include <QtOpenGL>
 
 #include "track/track.h"
-#include "waveformrenderersignalbase.h"
+#include "util/memory.h"
+#include "waveform/renderers/waveformrenderersignalbase.h"
 
 class GLSLWaveformRendererSignal : public QObject, public WaveformRendererSignalBase {
     Q_OBJECT
   public:
-    explicit GLSLWaveformRendererSignal(
-            WaveformWidgetRenderer* waveformWidgetRenderer, bool rgbShader);
-    virtual ~GLSLWaveformRendererSignal();
+    GLSLWaveformRendererSignal(WaveformWidgetRenderer* waveformWidgetRenderer,
+                               bool rgbShader);
+    ~GLSLWaveformRendererSignal() override;
 
-    virtual bool onInit();
-    virtual void onSetup(const QDomNode& node);
-    virtual void draw(QPainter* painter, QPaintEvent* event);
+    bool onInit() override;
+    void onSetup(const QDomNode& node) override;
+    void draw(QPainter* painter, QPaintEvent* event) override;
 
-    virtual void onSetTrack();
-    virtual void onResize();
+    void onSetTrack() override;
+    void onResize() override;
 
     void debugClick();
     bool loadShaders();
@@ -37,18 +38,17 @@ class GLSLWaveformRendererSignal : public QObject, public WaveformRendererSignal
     GLuint m_textureId;
 
     TrackPointer m_loadedTrack;
-    int m_loadedWaveform;
+    int m_textureRenderedWaveformCompletion;
 
-    //Frame buffer for two pass rendering
-    bool m_frameBuffersValid;
-    QGLFramebufferObject* m_framebuffer;
+    // Frame buffer for two pass rendering.
+    std::unique_ptr<QGLFramebufferObject> m_framebuffer;
 
     bool m_bDumpPng;
 
     // shaders
     bool m_shadersValid;
     bool m_rgbShader;
-    QGLShaderProgram* m_frameShaderProgram;
+    std::unique_ptr<QGLShaderProgram> m_frameShaderProgram;
 };
 
 class GLSLWaveformRendererFilteredSignal : public GLSLWaveformRendererSignal {
@@ -56,7 +56,7 @@ class GLSLWaveformRendererFilteredSignal : public GLSLWaveformRendererSignal {
     GLSLWaveformRendererFilteredSignal(
         WaveformWidgetRenderer* waveformWidgetRenderer)
         : GLSLWaveformRendererSignal(waveformWidgetRenderer, false) {}
-    virtual ~GLSLWaveformRendererFilteredSignal() {}
+    ~GLSLWaveformRendererFilteredSignal() override {}
 };
 
 class GLSLWaveformRendererRGBSignal : public GLSLWaveformRendererSignal {
@@ -64,7 +64,7 @@ class GLSLWaveformRendererRGBSignal : public GLSLWaveformRendererSignal {
     GLSLWaveformRendererRGBSignal(
         WaveformWidgetRenderer* waveformWidgetRenderer)
         : GLSLWaveformRendererSignal(waveformWidgetRenderer, true) {}
-    virtual ~GLSLWaveformRendererRGBSignal() {}
+    ~GLSLWaveformRendererRGBSignal() override {}
 };
 
 #endif // GLWAVEFORMRENDERERSIGNALSHADER_H

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -19,6 +19,7 @@ WaveformWidgetRenderer::WaveformWidgetRenderer(const char* group)
       m_orientation(Qt::Horizontal),
       m_height(-1),
       m_width(-1),
+      m_devicePixelRatio(1.0f),
 
       m_firstDisplayedPosition(0.0),
       m_lastDisplayedPosition(0.0),
@@ -260,9 +261,10 @@ void WaveformWidgetRenderer::draw(QPainter* painter, QPaintEvent* event) {
     //qDebug() << "draw() ende" << timer.restart().formatNanosWithUnit();
 }
 
-void WaveformWidgetRenderer::resize(int width, int height) {
+void WaveformWidgetRenderer::resize(int width, int height, float devicePixelRatio) {
     m_width = width;
     m_height = height;
+    m_devicePixelRatio = devicePixelRatio;
     for (int i = 0; i < m_rendererStack.size(); ++i) {
         m_rendererStack[i]->setDirty(true);
         m_rendererStack[i]->onResize();

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -77,9 +77,10 @@ class WaveformWidgetRenderer {
 
     int beatGridAlpha() const { return m_alphaBeatGrid; }
 
-    void resize(int width, int height);
+    virtual void resize(int width, int height, float devicePixelRatio);
     int getHeight() const { return m_height;}
     int getWidth() const { return m_width;}
+    float getDevicePixelRatio() const { return m_devicePixelRatio; }
     int getLength() const { return m_orientation == Qt::Horizontal ? m_width : m_height;}
     int getBreadth() const { return m_orientation == Qt::Horizontal ? m_height : m_width;}
     Qt::Orientation getOrientation() const { return m_orientation;}
@@ -112,6 +113,7 @@ class WaveformWidgetRenderer {
     Qt::Orientation m_orientation;
     int m_height;
     int m_width;
+    float m_devicePixelRatio;
     WaveformSignalColors m_colors;
 
     double m_firstDisplayedPosition;

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -5,6 +5,8 @@
 #include <QtDebug>
 #include <QGLFormat>
 #include <QGLShaderProgram>
+#include <QGuiApplication>
+#include <QWindow>
 
 #include "waveform/waveformwidgetfactory.h"
 
@@ -389,6 +391,8 @@ bool WaveformWidgetFactory::setWidgetTypeFromHandle(int handleIndex) {
     m_skipRender = true;
     //qDebug() << "recreate start";
 
+    const float devicePixelRatio = getDevicePixelRatio();
+
     //re-create/setup all waveform widgets
     for (int i = 0; i < m_waveformWidgetHolders.size(); i++) {
         WaveformWidgetHolder& holder = m_waveformWidgetHolders[i];
@@ -408,7 +412,7 @@ bool WaveformWidgetFactory::setWidgetTypeFromHandle(int handleIndex) {
         // resize() doesn't seem to get called on the widget. I think Qt skips
         // it since the size didn't change.
         //viewer->resize(viewer->size());
-        widget->resize(viewer->width(), viewer->height());
+        widget->resize(viewer->width(), viewer->height(), devicePixelRatio);
         widget->setTrack(pTrack);
         widget->getWidget()->show();
         viewer->update();
@@ -791,4 +795,14 @@ void WaveformWidgetFactory::startVSync(GuiTick* pGuiTick) {
 
 void WaveformWidgetFactory::getAvailableVSyncTypes(QList<QPair<int, QString > >* pList) {
     m_vsyncThread->getAvailableVSyncTypes(pList);
+}
+
+// static
+float WaveformWidgetFactory::getDevicePixelRatio() {
+    float devicePixelRatio = 1.0;
+    QWindow* pWindow = QGuiApplication::focusWindow();
+    if (pWindow != nullptr) {
+        devicePixelRatio = pWindow->devicePixelRatio();
+    }
+    return devicePixelRatio;
 }

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -113,6 +113,11 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
 
     WaveformWidgetType::Type autoChooseWidgetType() const;
 
+    // Returns the devicePixelRatio for the current window. This is the scaling
+    // factor between screen pixels and "device independent pixels". For
+    // example, on macOS with a retina display the ratio is 2.
+    static float getDevicePixelRatio();
+
   signals:
     void waveformUpdateTick();
     void waveformMeasured(float frameRate, int droppedFrames);

--- a/src/waveform/widgets/glslwaveformwidget.cpp
+++ b/src/waveform/widgets/glslwaveformwidget.cpp
@@ -85,11 +85,11 @@ mixxx::Duration GLSLWaveformWidget::render() {
     return t1; // return timer for painter setup
 }
 
-void GLSLWaveformWidget::resize(int width, int height) {
-    //NOTE: (vrince) this is needed since we allocation buffer on resize
-    //and the Gl Context should be properly set
+void GLSLWaveformWidget::resize(int width, int height, float devicePixelRatio) {
+    // NOTE: (vrince) this is needed since we allocation buffer on resize
+    // and the Gl Context should be properly set
     makeCurrent();
-    WaveformWidgetAbstract::resize(width,height);
+    WaveformWidgetAbstract::resize(width, height, devicePixelRatio);
 }
 
 void GLSLWaveformWidget::mouseDoubleClickEvent(QMouseEvent *event) {

--- a/src/waveform/widgets/glslwaveformwidget.h
+++ b/src/waveform/widgets/glslwaveformwidget.h
@@ -14,7 +14,7 @@ class GLSLWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
                        bool rgbRenderer);
     virtual ~GLSLWaveformWidget();
 
-    virtual void resize(int width, int height);
+    void resize(int width, int height, float devicePixelRatio) override;
 
   protected:
     virtual void castToQWidget();
@@ -33,7 +33,7 @@ class GLSLFilteredWaveformWidget : public GLSLWaveformWidget {
     GLSLFilteredWaveformWidget(const char* group, QWidget* parent);
     virtual ~GLSLFilteredWaveformWidget() {}
 
-    virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::GLSLFilteredWaveform; }
+    WaveformWidgetType::Type getType() const override { return WaveformWidgetType::GLSLFilteredWaveform; }
 
     static inline QString getWaveformWidgetName() { return tr("Filtered"); }
     static inline bool useOpenGl() { return true; }
@@ -46,7 +46,7 @@ class GLSLRGBWaveformWidget : public GLSLWaveformWidget {
     GLSLRGBWaveformWidget(const char* group, QWidget* parent);
     virtual ~GLSLRGBWaveformWidget() {}
 
-    virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::GLSLRGBWaveform; }
+    WaveformWidgetType::Type getType() const override { return WaveformWidgetType::GLSLRGBWaveform; }
 
     static inline QString getWaveformWidgetName() { return tr("RGB"); }
     static inline bool useOpenGl() { return true; }

--- a/src/waveform/widgets/waveformwidgetabstract.cpp
+++ b/src/waveform/widgets/waveformwidgetabstract.cpp
@@ -38,9 +38,9 @@ mixxx::Duration WaveformWidgetAbstract::render() {
     return mixxx::Duration();
 }
 
-void WaveformWidgetAbstract::resize(int width, int height) {
+void WaveformWidgetAbstract::resize(int width, int height, float devicePixelRatio) {
     if (m_widget) {
         m_widget->resize(width, height);
     }
-    WaveformWidgetRenderer::resize(width, height);
+    WaveformWidgetRenderer::resize(width, height, devicePixelRatio);
 }

--- a/src/waveform/widgets/waveformwidgetabstract.h
+++ b/src/waveform/widgets/waveformwidgetabstract.h
@@ -32,8 +32,7 @@ class WaveformWidgetAbstract : public WaveformWidgetRenderer {
 
     virtual void preRender(VSyncThread* vsyncThread);
     virtual mixxx::Duration render();
-
-    virtual void resize(int width, int height);
+    virtual void resize(int width, int height, float devicePixelRatio) override;
 
   protected:
     QWidget* m_widget;

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -51,7 +51,8 @@ void WWaveformViewer::setup(const QDomNode& node, const SkinContext& context) {
 
 void WWaveformViewer::resizeEvent(QResizeEvent* /*event*/) {
     if (m_waveformWidget) {
-        m_waveformWidget->resize(width(), height());
+        m_waveformWidget->resize(width(), height(),
+                                 WaveformWidgetFactory::getDevicePixelRatio());
     }
 }
 


### PR DESCRIPTION
Fixes Bug #1779972. Also fixes some lint and makes some minor C++11 style upgrades.