### PR TITLE
Library-layout fix GUI lag

### DIFF
--- a/src/library/features/libraryfolder/libraryfoldermodel.cpp
+++ b/src/library/features/libraryfolder/libraryfoldermodel.cpp
@@ -35,6 +35,8 @@ LibraryFolderModel::LibraryFolderModel(LibraryFeature* pFeature,
 //             this, SLOT(reloadTree()));
 //     connect(&trackDAO, SIGNAL(trackChanged(TrackId)),
 //             this, SLOT(reloadTree()));
+    connect(&trackDAO, SIGNAL(tracksAdded(QSet<TrackId>)),
+            this, SLOT(tracksAdded(QSet<TrackId>)));
 
     reloadTree();
 }
@@ -128,6 +130,19 @@ QString LibraryFolderModel::getGroupingOptions() {
         return tr("Folders");
 
     return TracksTreeModel::getGroupingOptions();
+}
+
+void LibraryFolderModel::tracksAdded(const QSet<TrackId> trackIds) {
+    if (!m_showFolders) {
+//        TracksTreeModel::tracksAdded(trackIds);
+        return;
+    }
+
+    TreeItem* pRoot = getRootItem();
+
+    // Everything works assuming that there are no intersections
+    DEBUG_ASSERT(!pRoot->m_childTracks.intersects(trackIds));
+
 }
 
 void LibraryFolderModel::createTreeForLibraryDir(const QString& dir, QSqlQuery& query) {

--- a/src/library/features/libraryfolder/libraryfoldermodel.cpp
+++ b/src/library/features/libraryfolder/libraryfoldermodel.cpp
@@ -23,16 +23,6 @@ LibraryFolderModel::LibraryFolderModel(LibraryFeature* pFeature,
     QString showFolders = m_pConfig->getValueString(
             ConfigKey("[Library]", LIBRARYFOLDERMODEL_FOLDER));
     m_showFolders = showFolders.toInt() == 1;
-
-    TrackDAO& trackDAO(pTrackCollection->getTrackDAO());
-    connect(&trackDAO, SIGNAL(forceModelUpdate()), this, SLOT(reloadTree()));
-    connect(&trackDAO, SIGNAL(tracksAdded(QSet<TrackId>)),
-            this, SLOT(tracksAdded(QSet<TrackId>)));
-    connect(&trackDAO, SIGNAL(tracksRemoved(QSet<TrackId>)),
-            this, SLOT(tracksRemoved(QSet<TrackId>)));
-    connect(&trackDAO, SIGNAL(trackChanged(TrackId)),
-            this, SLOT(trackChanged(TrackId)));
-
     reloadTree();
 }
 

--- a/src/library/features/libraryfolder/libraryfoldermodel.h
+++ b/src/library/features/libraryfolder/libraryfoldermodel.h
@@ -22,15 +22,17 @@ class LibraryFolderModel : public TracksTreeModel
     virtual bool setData(const QModelIndex& index, const QVariant& value, int role);
     virtual QVariant data(const QModelIndex &index, int role) const;
 
+  public slots:
+    void tracksAdded(const QSet<TrackId> trackIds) override;
+
   protected:
     void createTracksTree() override;
     QString getGroupingOptions() override;
 
-  private slots:
-    void tracksAdded(const QSet<TrackId> trackIds);
-
   private:
     void createTreeForLibraryDir(const QString& dir, QSqlQuery& query);
+    QString createQueryStr(bool singleId);
+    void insertTrackToTree(TrackId id, QString dir, QString location, TreeItem* pLevel);
 
     bool m_folderRecursive;
     bool m_showFolders;

--- a/src/library/features/libraryfolder/libraryfoldermodel.h
+++ b/src/library/features/libraryfolder/libraryfoldermodel.h
@@ -26,6 +26,9 @@ class LibraryFolderModel : public TracksTreeModel
     void createTracksTree() override;
     QString getGroupingOptions() override;
 
+  private slots:
+    void tracksAdded(const QSet<TrackId> trackIds);
+
   private:
     void createTreeForLibraryDir(const QString& dir, QSqlQuery& query);
 

--- a/src/library/features/tracks/trackstreemodel.cpp
+++ b/src/library/features/tracks/trackstreemodel.cpp
@@ -219,7 +219,6 @@ void TracksTreeModel::createTracksTree() {
                        "FROM library LEFT JOIN track_locations "
                        "ON (%3 = %4) "
                        "WHERE %5 != 1 AND  %7 != 1 "
-//                       "GROUP BY %2 "
                        "ORDER BY %6 ";
     queryStr = queryStr.arg(m_coverQuery.join(","),                                 // 1
                             columns.join(","),                                      // 2
@@ -237,7 +236,7 @@ void TracksTreeModel::createTracksTree() {
         LOG_FAILED_QUERY(query);
         return;
     }
-    qDebug() << "TracksTreeModel::createTracksTree" << query.executedQuery();
+    //qDebug() << "TracksTreeModel::createTracksTree" << query.executedQuery();
 
     // For error handling if there are any columns selected do nothing
     int treeDepth = columns.size();
@@ -306,7 +305,8 @@ void TracksTreeModel::createTracksTree() {
             pTree->m_childTracks.insert(currentId);
             parent[i + 1] = pTree;
 
-            // Add coverart info
+            // Add coverart info, the coverart must only be added on the
+            // Album nodes
             if (treeStartQueryIndex + i == iAlbum) {
                 addCoverArt(cIndex, query, pTree);
             }

--- a/src/library/features/tracks/trackstreemodel.cpp
+++ b/src/library/features/tracks/trackstreemodel.cpp
@@ -207,19 +207,11 @@ QVariant TracksTreeModel::getQuery(TreeItem* pTree) const {
 
 void TracksTreeModel::createTracksTree() {
 
-    QStringList columns;
+    QStringList columns, sortColumns;
     for (const QString& col : m_sortOrder) {
         columns << "library." + col;
-    }
-
-    QStringList sortColumns;
-#ifdef __SQLITE3__
-    for (const QString& col : m_sortOrder) {
         sortColumns << mixxx::DbConnection::collateLexicographically(col);
     }
-#else
-    sortColumns = m_sortOrder;
-#endif
 
     // Sorting is required to create the tree because the tree is sorted and
     // in order to create a tree with levels it must be sorted too.
@@ -229,13 +221,13 @@ void TracksTreeModel::createTracksTree() {
                        "WHERE %5 != 1 AND  %7 != 1 "
                        "GROUP BY %2 "
                        "ORDER BY %6 ";
-    queryStr = queryStr.arg(m_coverQuery.join(","),
-                            columns.join(","),
-                            "library." + LIBRARYTABLE_ID,
-                            "track_locations." + TRACKLOCATIONSTABLE_ID,
-                            "library." + LIBRARYTABLE_MIXXXDELETED,
-                            sortColumns.join(","),
-                            "track_locations." + TRACKLOCATIONSTABLE_FSDELETED);
+    queryStr = queryStr.arg(m_coverQuery.join(","),                                 // 1
+                            columns.join(","),                                      // 2
+                            "library." + LIBRARYTABLE_ID,                           // 3
+                            "track_locations." + TRACKLOCATIONSTABLE_ID,            // 4
+                            "library." + LIBRARYTABLE_MIXXXDELETED,                 // 5
+                            sortColumns.join(","),                                  // 6
+                            "track_locations." + TRACKLOCATIONSTABLE_FSDELETED);    // 7
 
 
     QSqlQuery query(m_pTrackCollection->database());
@@ -245,7 +237,7 @@ void TracksTreeModel::createTracksTree() {
         LOG_FAILED_QUERY(query);
         return;
     }
-    //qDebug() << "LibraryTreeModel::createTracksTree" << query.executedQuery();
+    qDebug() << "LibraryTreeModel::createTracksTree" << query.executedQuery();
 
     int treeDepth = columns.size();
     if (treeDepth <= 0) {

--- a/src/library/features/tracks/trackstreemodel.h
+++ b/src/library/features/tracks/trackstreemodel.h
@@ -28,6 +28,7 @@ class TracksTreeModel : public TreeItemModel {
 
   public slots:
     void reloadTree() override;
+    void tracksRemoved(const QSet<TrackId> trackIds);
 
   protected:
     virtual void createTracksTree();
@@ -56,6 +57,9 @@ class TracksTreeModel : public TreeItemModel {
   private:
     QVariant getQuery(TreeItem* pTree) const;
     void addCoverArt(const CoverIndex& index, const QSqlQuery& query, TreeItem* pTree);
+    QString createQueryStr(bool singleId = false, bool sort = true);
+
+    void removeTracksRecursive(const QSet<TrackId>& trackIds, TreeItem* pTree);
 
 
     QStringList m_sortOrder;

--- a/src/library/features/tracks/trackstreemodel.h
+++ b/src/library/features/tracks/trackstreemodel.h
@@ -35,7 +35,7 @@ class TracksTreeModel : public TreeItemModel {
   protected:
     virtual void createTracksTree();
     virtual QString getGroupingOptions();
-    void removeTracksRecursive(const QSet<TrackId>& trackIds, TreeItem* pTree);
+    bool removeTracksRecursive(const QSet<TrackId>& trackIds, TreeItem* pTree);
 
     parented_ptr<TreeItem> m_pGrouping;
     parented_ptr<TreeItem> m_pShowAll;

--- a/src/library/features/tracks/trackstreemodel.h
+++ b/src/library/features/tracks/trackstreemodel.h
@@ -28,12 +28,14 @@ class TracksTreeModel : public TreeItemModel {
 
   public slots:
     void reloadTree() override;
-    void tracksAdded(const QSet<TrackId> trackIds);
-    void tracksRemoved(const QSet<TrackId> trackIds);
+    virtual void tracksAdded(const QSet<TrackId> trackIds);
+    virtual void tracksRemoved(const QSet<TrackId> trackIds);
+    virtual void trackChanged(TrackId trackId);
 
   protected:
     virtual void createTracksTree();
     virtual QString getGroupingOptions();
+    void removeTracksRecursive(const QSet<TrackId>& trackIds, TreeItem* pTree);
 
     parented_ptr<TreeItem> m_pGrouping;
     parented_ptr<TreeItem> m_pShowAll;
@@ -44,6 +46,12 @@ class TracksTreeModel : public TreeItemModel {
 
   private:
     struct CoverIndex {
+        CoverIndex() {
+            iCoverHash = iCoverLoc = iTrackLoc  = iCoverSrc = iCoverType = -1;
+        }
+
+        CoverIndex(const QSqlRecord& record);
+
         int iCoverHash;
         int iCoverLoc;
         int iTrackLoc;
@@ -58,13 +66,9 @@ class TracksTreeModel : public TreeItemModel {
   private:
     QVariant getQuery(TreeItem* pTree) const;
     void addCoverArt(const CoverIndex& index, const QSqlQuery& query, TreeItem* pTree);
-    QString createQueryStr(bool singleId = false, bool sort = true);
+    QString createQueryStr(bool singleId = false);
 
-    void removeTracksRecursive(const QSet<TrackId>& trackIds, TreeItem* pTree);
-    void addTrackToTree(const QSqlQuery& query, const CoverIndex& cIndex);
-    CoverIndex getCoverIndex(const QSqlQuery& query);
-    CoverIndex getCoverIndex(const QSqlRecord& record);
-
+    void insertTrackToTree(const QSqlQuery& query);
 
     QStringList m_sortOrder;
     QStringList m_coverQuery;

--- a/src/library/features/tracks/trackstreemodel.h
+++ b/src/library/features/tracks/trackstreemodel.h
@@ -28,6 +28,7 @@ class TracksTreeModel : public TreeItemModel {
 
   public slots:
     void reloadTree() override;
+    void tracksAdded(const QSet<TrackId> trackIds);
     void tracksRemoved(const QSet<TrackId> trackIds);
 
   protected:
@@ -60,6 +61,9 @@ class TracksTreeModel : public TreeItemModel {
     QString createQueryStr(bool singleId = false, bool sort = true);
 
     void removeTracksRecursive(const QSet<TrackId>& trackIds, TreeItem* pTree);
+    void addTrackToTree(const QSqlQuery& query, const CoverIndex& cIndex);
+    CoverIndex getCoverIndex(const QSqlQuery& query);
+    CoverIndex getCoverIndex(const QSqlRecord& record);
 
 
     QStringList m_sortOrder;

--- a/src/library/treeitem.cpp
+++ b/src/library/treeitem.cpp
@@ -102,6 +102,14 @@ TreeItem* TreeItem::appendChild(
     return pChild;
 }
 
+TreeItem*TreeItem::insertChild(int row, const QString& label, const QVariant& data) {
+    auto pNewChild = std::make_unique<TreeItem>(feature(), label, data);
+    TreeItem* pChild = pNewChild.get();
+    insertChild(pChild, row); // transfer ownership
+    pNewChild.release(); // release ownership (afterwards)
+    return pChild;
+}
+
 void TreeItem::removeChild(int row) {
     DEBUG_ASSERT(row >= 0);
     DEBUG_ASSERT(row < m_children.size());

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -86,8 +86,8 @@ class TreeItem final {
         m_label = label;
     }
 
-    inline const QString& getLabel() const {
-        count = getTrackCount();
+    inline const QString getLabel() const {
+        int count = getTrackCount();
         if (count > 0) {
             return m_label + " (" + QString::number(count) + ")";
 		}
@@ -138,7 +138,7 @@ class TreeItem final {
 		m_trackCount = count;
 	}
 
-	inline int getTrackCount() {
+    inline int getTrackCount() const {
         if (m_trackCount < 0) {
            return m_childTracks.size();
         }

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -2,6 +2,7 @@
 #define MIXXX_TREEITEM_H
 
 #include <QList>
+#include <QSet>
 #include <QString>
 #include <QVariant>
 #include <QIcon>
@@ -86,8 +87,9 @@ class TreeItem final {
     }
 
     inline const QString& getLabel() const {
-		if (m_trackCount >= 0) {
-			return m_labelNumbered;
+        count = getTrackCount();
+        if (count > 0) {
+            return m_label + " (" + QString::number(count) + ")";
 		}
         return m_label;
     }
@@ -134,12 +136,17 @@ class TreeItem final {
 
 	inline void setTrackCount(int count) {
 		m_trackCount = count;
-		m_labelNumbered = m_label + " (" + QString::number(m_trackCount) + ")";
 	}
 
 	inline int getTrackCount() {
+        if (m_trackCount < 0) {
+           return m_childTracks.size();
+        }
+
 		return m_trackCount;
 	}
+
+    QSet<TrackId> m_childTracks;
 
   private:
     void appendChild(TreeItem* pChild);
@@ -151,7 +158,6 @@ class TreeItem final {
     QList<TreeItem*> m_children; // owned child items
 
     QString m_label;
-	QString m_labelNumbered;
     QVariant m_data;
     QIcon m_icon;
     CoverInfo m_cover;

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -71,6 +71,10 @@ class TreeItem final {
     TreeItem* appendChild(
             const QString& label,
             const QVariant& data = QVariant());
+    TreeItem* insertChild(
+            int row,
+            const QString& label,
+            const QVariant& data = QVariant());
     void removeChild(int row);
 
     // multiple child items


### PR DESCRIPTION
Fix bug re-introduced in #1714 

However there's a problem when adding tracks as the signal `tracksAdded(QSet<TrackId>)` from `TrackDAO` does not provide all the ids for the new added tracks and only a small subsample. 

Does anyone have an idea of why this may happen? Am I using the proper signal to see if new tracks have been added?