### PR TITLE
Enable Mixxx's HDPI scaling for all versions QT < 5.6

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -109,7 +109,7 @@ DlgPrefInterface::DlgPrefInterface(QWidget * parent, MixxxMainWindow * mixxx,
     slotUpdateSchemes();
 
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
     AutoHiDpi autoHiDpi;
     m_dScaleFactorAuto = autoHiDpi.getScaleFactor();
     m_dScaleFactor = m_dScaleFactorAuto;

--- a/src/skin/skincontext.cpp
+++ b/src/skin/skincontext.cpp
@@ -32,7 +32,7 @@ SkinContext::SkinContext(UserSettingsPointer pConfig,
         m_hookRx.setPattern(hooksPattern.toString());
     }
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
     // Load the config option once, here, rather than in setupSize.
     m_scaleFactor = m_pConfig->getValue(ConfigKey("[Config]","ScaleFactor"), 1.0);
 #else


### PR DESCRIPTION
This brings back Mixxx's own scaling solution for Ubuntu Trusty and Xenial. 
Discussed in #1521