### PR TITLE
lp1777480: Pad unreadable samples with silence on cache miss

### DIFF
--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -366,7 +366,12 @@ CachingReader::ReadResult CachingReader::read(SINT startSample, SINT numSamples,
                     DEBUG_ASSERT(!pChunk ||
                             (pChunk->getState() == CachingReaderChunkForOwner::READ_PENDING));
                     Counter("CachingReader::read(): Failed to read chunk on cache miss")++;
-                    kLogger.debug() << "Cache miss for chunk with index" << chunkIndex << "- abort reading";
+                    if (kLogger.traceEnabled()) {
+                        kLogger.trace()
+                                << "Cache miss for chunk with index"
+                                << chunkIndex
+                                << "- abort reading";
+                    }
                     // Abort reading (see below)
                     DEBUG_ASSERT(bufferedFrameIndexRange.empty());
                 }

--- a/src/engine/cachingreader.h
+++ b/src/engine/cachingreader.h
@@ -83,9 +83,10 @@ class CachingReader : public QObject {
     virtual void process();
 
     // Read numSamples from the SoundSource starting with sample into
-    // buffer. Returns the total number of samples actually written to buffer
-    // support reading stereo samples in reverse (backward) order
-    virtual SINT read(SINT startSample, SINT numSamples, bool reverse, CSAMPLE* buffer);
+    // buffer. It always writes numSamples to the buffer. In case of a chach miss,
+    // it returns false and clears the buffer.
+    // It support reading stereo samples in reverse (backward) order
+    virtual bool read(SINT startSample, SINT numSamples, bool reverse, CSAMPLE* buffer);
 
     // Issue a list of hints, but check whether any of the hints request a chunk
     // that is not in the cache. If any hints do request a chunk not in cache,

--- a/src/engine/cachingreader.h
+++ b/src/engine/cachingreader.h
@@ -82,11 +82,20 @@ class CachingReader : public QObject {
 
     virtual void process();
 
+    enum class ReadResult {
+        // No samples read and buffer untouched(!), try again later in case of a cache miss
+        UNAVAILABLE,
+        // Some samples are missing and corresponding range in buffer has been cleared with silence
+        PARTIALLY_AVAILABLE,
+        // All requested samples are available and have been read into buffer
+        AVAILABLE,
+    };
+
     // Read numSamples from the SoundSource starting with sample into
-    // buffer. It always writes numSamples to the buffer. In case of a chach miss,
-    // it returns false and clears the buffer.
-    // It support reading stereo samples in reverse (backward) order
-    virtual bool read(SINT startSample, SINT numSamples, bool reverse, CSAMPLE* buffer);
+    // buffer. It always writes numSamples to the buffer and otherwise
+    // returns ReadResult::UNAVAILABLE.
+    // It support reading stereo samples in reverse (backward) order.
+    virtual ReadResult read(SINT startSample, SINT numSamples, bool reverse, CSAMPLE* buffer);
 
     // Issue a list of hints, but check whether any of the hints request a chunk
     // that is not in the cache. If any hints do request a chunk not in cache,

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -983,6 +983,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
             // Perform scaling of Reader buffer into buffer.
             double framesRead =
                     m_pScale->scaleBuffer(pOutput, iBufferSize);
+
             // TODO(XXX): The result framesRead might not be an integer value.
             // Converting to samples here does not make sense. All positional
             // calculations should be done in frames instead of samples! Otherwise

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -17,7 +17,8 @@ ReadAheadManager::ReadAheadManager()
           m_pRateControl(NULL),
           m_currentPosition(0),
           m_pReader(NULL),
-          m_pCrossFadeBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)) {
+          m_pCrossFadeBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)),
+          m_cacheMissHappened(false) {
     // For testing only: ReadAheadManagerMock
 }
 
@@ -27,7 +28,8 @@ ReadAheadManager::ReadAheadManager(CachingReader* pReader,
           m_pRateControl(NULL),
           m_currentPosition(0),
           m_pReader(pReader),
-          m_pCrossFadeBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)) {
+          m_pCrossFadeBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)),
+          m_cacheMissHappened(false) {
     DEBUG_ASSERT(m_pLoopingControl != NULL);
     DEBUG_ASSERT(m_pReader != NULL);
 }
@@ -90,7 +92,12 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
     // in case of a chache miss the buffer is cleared and the return value is false;
 
     if (!readSuccess) {
-        qDebug() << "##################################";
+        m_cacheMissHappened = true;
+    } else if (m_cacheMissHappened) {
+        m_cacheMissHappened = false;
+        // Apply raming gain, because the last buffer has unwanted silenced and
+        // new without fading are causing a pop.
+        SampleUtil::applyRampingGain(pOutput, 0.0, 1.0, samples_from_reader);
     }
 
     // Increment or decrement current read-ahead position
@@ -138,6 +145,7 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
 
         if (!readSuccess2) {
             qDebug() << "ERROR: Couldn't get all needed samples for crossfade.";
+            m_cacheMissHappened = true;
         }
 
         // do crossfade from the current buffer into the new loop beginning
@@ -157,6 +165,7 @@ void ReadAheadManager::addRateControl(RateControl* pRateControl) {
 // Not thread-save, call from engine thread only
 void ReadAheadManager::notifySeek(double seekPosition) {
     m_currentPosition = seekPosition;
+    m_cacheMissHappened = false;
     m_readAheadLog.clear();
 
     // TODO(XXX) notifySeek on the engine controls. EngineBuffer currently does

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -84,22 +84,24 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
     SINT start_sample = SampleUtil::roundPlayPosToFrameStart(
             m_currentPosition, kNumChannels);
 
-    SINT samples_read = m_pReader->read(
+    bool readSuccess = m_pReader->read(
             start_sample, samples_from_reader, in_reverse, pOutput);
+    // read() returns a buffer filed up to "samples_from_reader".
+    // in case of a chache miss the buffer is cleared and the return value is false;
 
-    if (samples_read != samples_from_reader) {
-        qDebug() << "didn't get what we wanted" << samples_read << samples_from_reader;
+    if (!readSuccess) {
+        qDebug() << "##################################";
     }
 
     // Increment or decrement current read-ahead position
     // Mixing int and double here is desired, because the fractional frame should
     // be resist
     if (in_reverse) {
-        addReadLogEntry(m_currentPosition, m_currentPosition - samples_read);
-        m_currentPosition -= samples_read;
+        addReadLogEntry(m_currentPosition, m_currentPosition - samples_from_reader);
+        m_currentPosition -= samples_from_reader;
     } else {
-        addReadLogEntry(m_currentPosition, m_currentPosition + samples_read);
-        m_currentPosition += samples_read;
+        addReadLogEntry(m_currentPosition, m_currentPosition + samples_from_reader);
+        m_currentPosition += samples_from_reader;
     }
 
     // Activate on this trigger if necessary
@@ -131,21 +133,21 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
         int loop_read_position = SampleUtil::roundPlayPosToFrameStart(
                 m_currentPosition + (in_reverse ? preloop_samples : -preloop_samples), kNumChannels);
 
-        int looping_samples_read = m_pReader->read(
-                loop_read_position, samples_read, in_reverse, m_pCrossFadeBuffer);
+        bool readSuccess2 = m_pReader->read(
+                loop_read_position, samples_from_reader, in_reverse, m_pCrossFadeBuffer);
 
-        if (looping_samples_read != samples_read) {
+        if (!readSuccess2) {
             qDebug() << "ERROR: Couldn't get all needed samples for crossfade.";
         }
 
         // do crossfade from the current buffer into the new loop beginning
-        if (samples_read != 0) { // avoid division by zero
-            SampleUtil::linearCrossfadeBuffers(pOutput, pOutput, m_pCrossFadeBuffer, samples_read);
+        if (samples_from_reader != 0) { // avoid division by zero
+            SampleUtil::linearCrossfadeBuffers(pOutput, pOutput, m_pCrossFadeBuffer, samples_from_reader);
         }
     }
 
     //qDebug() << "read" << m_currentPosition << samples_read;
-    return samples_read;
+    return samples_from_reader;
 }
 
 void ReadAheadManager::addRateControl(RateControl* pRateControl) {

--- a/src/engine/readaheadmanager.h
+++ b/src/engine/readaheadmanager.h
@@ -125,6 +125,7 @@ class ReadAheadManager {
     double m_currentPosition;
     CachingReader* m_pReader;
     CSAMPLE* m_pCrossFadeBuffer;
+    bool m_cacheMissHappened;
 };
 
 #endif // READAHEADMANGER_H

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -17,12 +17,12 @@ class StubReader : public CachingReader {
     StubReader()
             : CachingReader("[test]", UserSettingsPointer()) { }
 
-    bool read(SINT startSample, SINT numSamples, bool reverse,
+    CachingReader::ReadResult read(SINT startSample, SINT numSamples, bool reverse,
              CSAMPLE* buffer) override {
         Q_UNUSED(startSample);
         Q_UNUSED(reverse);
         SampleUtil::clear(buffer, numSamples);
-        return true;
+        return CachingReader::ReadResult::AVAILABLE;
     }
 };
 

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -17,12 +17,12 @@ class StubReader : public CachingReader {
     StubReader()
             : CachingReader("[test]", UserSettingsPointer()) { }
 
-    SINT read(SINT startSample, SINT numSamples, bool reverse,
+    bool read(SINT startSample, SINT numSamples, bool reverse,
              CSAMPLE* buffer) override {
         Q_UNUSED(startSample);
         Q_UNUSED(reverse);
         SampleUtil::clear(buffer, numSamples);
-        return numSamples;
+        return true;
     }
 };
 


### PR DESCRIPTION
An attempt to fix the timing issues on cache miss as demonstrated in this bug report:
https://bugs.launchpad.net/mixxx/+bug/1777480