### PR TITLE
hack around distributions disabling qDebug by default with Qt5

### DIFF
--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -15,6 +15,10 @@
 #include <QtDebug>
 #include <QtGlobal>
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
+#include <QLoggingCategory>
+#endif
+
 #include "controllers/controllerdebug.h"
 #include "util/assert.h"
 
@@ -227,6 +231,17 @@ void Logging::initialize(const QDir& settingsDir,
     qInstallMsgHandler(MessageHandler);
 #else
     qInstallMessageHandler(MessageHandler);
+#endif
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
+    // Ugly hack around distributions disabling debugging in Qt applications.
+    // This restores the default Qt behavior. It is required for getting useful
+    // logs from users and for developing controller mappings.
+    // Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=1227295
+    // Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=886437
+    // Ubuntu: https://bugs.launchpad.net/ubuntu/+source/qtbase-opensource-src/+bug/1731646
+    QLoggingCategory::setFilterRules("*.debug=true\n"
+                                     "qt.*.debug=false");
 #endif
 }
 


### PR DESCRIPTION
Distributions are disabling debugging level messages from all Qt applications, overriding Qt's defaults. This interferes with us getting useful logs from users and developing controller mappings. So, use `QLoggingCategory::setFilterRules` to restore Qt's default behavior.

Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=1227295
Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=886437
Ubuntu: https://bugs.launchpad.net/ubuntu/+source/qtbase-opensource-src/+bug/1731646