### PR TITLE
Tooltip issues from Lp1779468

### DIFF
--- a/res/skins/Deere/sampler_text_row.xml
+++ b/res/skins/Deere/sampler_text_row.xml
@@ -42,6 +42,7 @@
 
             </Children>
             <Connection>
+              <!-- This enables the style with the blue play botton -->
               <ConfigKey><Variable name="group"/>,repeat</ConfigKey>
               <BindProperty>visible</BindProperty>
               <Transform>
@@ -73,6 +74,7 @@
 
             </Children>
             <Connection>
+              <!-- This enables the style with the violet play botton -->
               <ConfigKey><Variable name="group"/>,repeat</ConfigKey>
               <BindProperty>visible</BindProperty>
             </Connection>

--- a/res/skins/Deere/sampler_text_row.xml
+++ b/res/skins/Deere/sampler_text_row.xml
@@ -24,7 +24,7 @@
             <Layout>horizontal</Layout>
             <Children>
               <Template src="skin:left_right_display_2state_button.xml">
-                <SetVariable name="TooltipId">play_start</SetVariable>
+                <SetVariable name="TooltipId">cue_gotoandplay_cue_default</SetVariable>
                 <SetVariable name="ObjectName">SamplerPlayButton</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
                 <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
@@ -55,7 +55,7 @@
             <Children>
 
               <Template src="skin:left_right_display_2state_button.xml">
-                <SetVariable name="TooltipId">play_start</SetVariable>
+                <SetVariable name="TooltipId">cue_gotoandplay_cue_default</SetVariable>
                 <SetVariable name="ObjectName">SamplerPlayButtonRepeating</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
                 <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>

--- a/res/skins/Deere/sampler_text_row.xml
+++ b/res/skins/Deere/sampler_text_row.xml
@@ -36,7 +36,7 @@
                 <SetVariable name="state_1_pressed">icon/ic_play_48px.svg</SetVariable>
                 <SetVariable name="state_1_unpressed">icon/ic_play_48px.svg</SetVariable>
                 <SetVariable name="left_connection_control"><Variable name="group"/>,cue_gotoandplay</SetVariable>
-                <SetVariable name="right_connection_control"><Variable name="group"/>,cue_gotoandstop</SetVariable>
+                <SetVariable name="right_connection_control"><Variable name="group"/>,cue_default</SetVariable>
                 <SetVariable name="display_connection_control"><Variable name="group"/>,play</SetVariable>
               </Template>
 
@@ -67,7 +67,7 @@
                 <SetVariable name="state_1_pressed">icon/ic_play_48px.svg</SetVariable>
                 <SetVariable name="state_1_unpressed">icon/ic_play_48px.svg</SetVariable>
                 <SetVariable name="left_connection_control"><Variable name="group"/>,cue_gotoandplay</SetVariable>
-                <SetVariable name="right_connection_control"><Variable name="group"/>,cue_gotoandstop</SetVariable>
+                <SetVariable name="right_connection_control"><Variable name="group"/>,cue_default</SetVariable>
                 <SetVariable name="display_connection_control"><Variable name="group"/>,play</SetVariable>
               </Template>
 

--- a/res/skins/LateNight/sampler.xml
+++ b/res/skins/LateNight/sampler.xml
@@ -40,7 +40,7 @@
                 <SizePolicy>min,min</SizePolicy>
                 <Children>
                   <PushButton>
-                    <TooltipId>play_start</TooltipId>
+                    <TooltipId>cue_gotoandplay_cue_default</TooltipId>
                     <NumberStates>2</NumberStates>
                     <RightClickIsPushButton>true</RightClickIsPushButton>
                     <State>

--- a/res/skins/Shade/sampler.xml
+++ b/res/skins/Shade/sampler.xml
@@ -166,11 +166,18 @@
 									<SignalColor>#191F24</SignalColor>
 									<PlayPosColor>#00FF00</PlayPosColor>
 									<DefaultMark>
-										<Align>top</Align>
+										<Align>bottom|right</Align>
 										<Color>#FD0564</Color>
 										<TextColor>#FFFFFF</TextColor>
 										<Text> %1 </Text>
 									</DefaultMark>
+                  <Mark>
+                    <Control>cue_point</Control>
+                    <Text>C</Text>
+                    <Align>top|right</Align>
+                    <Color>#FF001C</Color>
+                    <TextColor>#FFFFFF</TextColor>
+                  </Mark>
 									<Connection>
 										<ConfigKey>[Sampler<Variable name="samplernum"/>],playposition</ConfigKey>
 										<EmitOnDownPress>false</EmitOnDownPress>

--- a/res/skins/Shade/sampler.xml
+++ b/res/skins/Shade/sampler.xml
@@ -168,7 +168,7 @@
 									<DefaultMark>
 										<Align>bottom|right</Align>
 										<Color>#FD0564</Color>
-										<TextColor>#FFFFFF</TextColor>
+										<TextColor>#000000</TextColor>
 										<Text> %1 </Text>
 									</DefaultMark>
                   <Mark>
@@ -176,7 +176,7 @@
                     <Text>C</Text>
                     <Align>top|right</Align>
                     <Color>#FF001C</Color>
-                    <TextColor>#FFFFFF</TextColor>
+                    <TextColor>#000000</TextColor>
                   </Mark>
 									<Connection>
 										<ConfigKey>[Sampler<Variable name="samplernum"/>],playposition</ConfigKey>

--- a/res/skins/Shade/sampler.xml
+++ b/res/skins/Shade/sampler.xml
@@ -115,7 +115,7 @@
 							<Style>QGroupBox { border: 0px solid red; } QWidget { margin: 10px; padding: 0; }</Style>
 							<Children>	
 								<PushButton>
-									<TooltipId>play_start</TooltipId>
+									<TooltipId>cue_gotoandplay_cue_default</TooltipId>
 									<Style></Style>
 									<NumberStates>2</NumberStates>
 									<RightClickIsPushButton>true</RightClickIsPushButton>

--- a/res/skins/Shade/samplersmall.xml
+++ b/res/skins/Shade/samplersmall.xml
@@ -23,7 +23,7 @@
 						<Size>4f,28f</Size>
 					</WidgetGroup>
 					<PushButton>
-						<TooltipId>play_start</TooltipId>
+						<TooltipId>cue_gotoandplay_cue_default</TooltipId>
 						<Style></Style>
 						<NumberStates>2</NumberStates>
 						<RightClickIsPushButton>true</RightClickIsPushButton>

--- a/res/skins/Tango/preview_deck.xml
+++ b/res/skins/Tango/preview_deck.xml
@@ -80,11 +80,12 @@ Variables:
                 <Children>
                   <Template src="skin:button_2state_right_display.xml">
                     <SetVariable name="ObjectName">PlayCue</SetVariable>
+                    <SetVariable name="TooltipId">play_start</SetVariable>
                     <SetVariable name="Size">24f,34f</SetVariable>
                     <SetVariable name="state_0_icon">play_previewdeck.svg</SetVariable>
                     <SetVariable name="state_1_icon">pause_previewdeck.svg</SetVariable>
                     <SetVariable name="ConfigKey"><Variable name="group"/>,play</SetVariable>
-                    <SetVariable name="ConfigKeyRight"><Variable name="group"/>,cue_default</SetVariable>
+                    <SetVariable name="ConfigKeyRight"><Variable name="group"/>,start</SetVariable>
                     <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,play_indicator</SetVariable>
                   </Template>
                   <!--	Turns Orange when playing Cue/HotCue.

--- a/res/skins/Tango/sampler.xml
+++ b/res/skins/Tango/sampler.xml
@@ -19,6 +19,7 @@ Variables:
         <Children>
           <Template src="skin:button_2state_right_display.xml">
             <SetVariable name="ObjectName">SamplerPlayCue</SetVariable>
+            <SetVariable name="TooltipId">cue_gotoandplay_cue_default</SetVariable>
             <SetVariable name="Size">34f,34f</SetVariable>
             <SetVariable name="state_0_icon">play_sampler.svg</SetVariable>
             <SetVariable name="state_1_icon">pause_sampler.svg</SetVariable>

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -417,16 +417,26 @@ void Tooltips::addStandardTooltips() {
 
     QString whilePlaying = tr("(while playing)");
     QString whileStopped = tr("(while stopped)");
+    QString cueWhilePlaying = tr("Stops track at cue point, OR go to cue point and play after release (CUP mode).");
+    QString cueWhileStopped = tr("Set cue point (Pioneer/Mixxx/Numark mode), set cue point and play after release (CUP mode) "
+            "OR preview from it (Denon mode).");
+    QString cueHint = tr("Hint: Change the default cue mode in Preferences -> Interface.");
     add("cue_default_cue_gotoandstop")
             << tr("Cue")
-            << QString("%1 %2: %3").arg(leftClick, whilePlaying, tr("Stops track at cue point, OR go to cue point and play after release (CUP mode)."))
-            << QString("%1 %2: %3").arg(leftClick, whileStopped, tr("Set cue point (Pioneer/Mixxx/Numark mode), set cue point and play after release (CUP mode) "
-                                                                    "OR preview from it (Denon mode)."))
-            << tr("Hint: Change the default cue mode in Preferences -> Interface.")
+            << QString("%1 %2: %3").arg(leftClick, whilePlaying, cueWhilePlaying)
+            << QString("%1 %2: %3").arg(leftClick, whileStopped, cueWhileStopped)
+            << cueHint
             << quantizeSnap
-            << QString("%1: %2").arg(rightClick, tr("Seeks the track to the cue point and stops."));
+            << QString("%1: %2").arg(rightClick, cueWhileStopped);
+    add("cue_gotoandplay_cue_default")
+            << tr("Play")
+            << QString("%1: %2").arg(leftClick, tr("Plays track from the cue point."))
+            << QString("%1 %2: %3").arg(rightClick, whilePlaying, cueWhilePlaying)
+            << QString("%1 %2: %3").arg(rightClick, whileStopped, cueWhileStopped)
+            << cueHint
+            << quantizeSnap;
 
-    add("pfl")
+      add("pfl")
             << tr("Headphone")
             << tr("Sends the selected channel's audio to the headphone output,")
             << tr("selected in Preferences -> Sound Hardware.");

--- a/src/skin/tooltips.cpp
+++ b/src/skin/tooltips.cpp
@@ -427,7 +427,7 @@ void Tooltips::addStandardTooltips() {
             << QString("%1 %2: %3").arg(leftClick, whileStopped, cueWhileStopped)
             << cueHint
             << quantizeSnap
-            << QString("%1: %2").arg(rightClick, cueWhileStopped);
+            << QString("%1: %2").arg(rightClick, tr("Seeks the track to the cue point and stops."));
     add("cue_gotoandplay_cue_default")
             << tr("Play")
             << QString("%1: %2").arg(leftClick, tr("Plays track from the cue point."))


### PR DESCRIPTION
Some tooltip fixes reported in https://bugs.launchpad.net/mixxx/+bug/1779468
It also equalizes the right click behavior on Samplers and preview decks for all skins. 

I have changed the tooltips. The sampler right click follows CUE mode. Does it work? 