### PR TITLE
Fix key reset button issue under LP #1748001, plus some typo fixes in keycontrol.cpp

### DIFF
--- a/src/engine/keycontrol.cpp
+++ b/src/engine/keycontrol.cpp
@@ -24,7 +24,7 @@ KeyControl::KeyControl(QString group,
     // pitch is the distance to the original pitch in semitones
     // knob in semitones; 9.4 ct per midi step allowOutOfBounds = true;
     m_pPitch = new ControlPotmeter(ConfigKey(group, "pitch"), -6.0, 6.0, true);
-    // Course adjust by full semitone steps.
+    // Coarse adjust by full semitone steps.
     m_pPitch->setStepCount(12);
     // Fine adjust with semitone / 10 = 10 ct;.
     m_pPitch->setSmallStepCount(120);
@@ -36,7 +36,7 @@ KeyControl::KeyControl(QString group,
     // set by the speed slider or to the locked key.
     // pitch_adjust knob in semitones; 4.7 ct per midi step; allowOutOfBounds = true;
     m_pPitchAdjust = new ControlPotmeter(ConfigKey(group, "pitch_adjust"), -3.0, 3.0, true);
-    // Course adjust by full semitone steps.
+    // Coarse adjust by full semitone steps.
     m_pPitchAdjust->setStepCount(6);
     // Fine adjust with semitone / 10 = 10 ct;.
     m_pPitchAdjust->setSmallStepCount(60);
@@ -266,7 +266,6 @@ void KeyControl::updateKeyCOs(double fileKeyNumeric, double pitchOctaves) {
     //qDebug() << "updateKeyCOs 2" << diff_to_nearest_full_key;
 }
 
-
 void KeyControl::slotSetEngineKey(double key) {
     // Always set to a full key, reset key_distance
     setEngineKey(key, 0.0);
@@ -345,7 +344,7 @@ void KeyControl::updatePitchAdjust() {
     // speedSliderPitchRatio must be unchanged
     double pitchAdjustKnobRatio = KeyUtils::semitoneChangeToPowerOf2(pitchAdjust);
 
-    // pitch_adjust is a offset to the pitch set by the speed controls
+    // pitch_adjust is an offset to the pitch set by the speed controls
     // calc absolute pitch
     m_pitchRateInfo.pitchTweakRatio = pitchAdjustKnobRatio;
     m_pitchRateInfo.pitchRatio = pitchAdjustKnobRatio * speedSliderPitchRatio;
@@ -368,7 +367,8 @@ void KeyControl::slotSyncKey(double v) {
 
 void KeyControl::slotResetKey(double v) {
     if (v > 0) {
-        slotSetEngineKey(m_pFileKey->get());
+        m_pPitch->set(0);
+        slotPitchChanged(0);
     }
 }
 


### PR DESCRIPTION
LP bug [here](https://bugs.launchpad.net/mixxx/+bug/1748001), Zulip discussion [here](https://mixxx.zulipchat.com/#narrow/stream/109171-development/subject/Reset.20key.20button.2Ftracks.20with.20no.20key/near/130053817). Previous botched attempt at pull request [here](https://github.com/mixxxdj/mixxx/pull/1757)