### PR TITLE
lp1783392: Configurable debouncing timeout for WSearchLineEdit

### DIFF
--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -11,8 +11,13 @@
 #include "preferences/dialog/dlgpreflibrary.h"
 #include "library/dlgtrackmetadataexport.h"
 #include "sources/soundsourceproxy.h"
+#include "widget/wsearchlineedit.h"
 
 #define MIXXX_ADDONS_URL "http://www.mixxx.org/wiki/doku.php/add-ons"
+
+namespace {
+    const ConfigKey kSearchDebouncingTimeoutMillisKey = ConfigKey("[Library]","SearchDebouncingTimeoutMillis");
+}
 
 DlgPrefLibrary::DlgPrefLibrary(
         QWidget* pParent,
@@ -54,6 +59,16 @@ DlgPrefLibrary::DlgPrefLibrary(
     spinBoxRowHeight->setValue(rowHeight);
     connect(spinBoxRowHeight, SIGNAL(valueChanged(int)),
             this, SLOT(slotRowHeightValueChanged(int)));
+
+    searchDebouncingTimeoutSpinBox->setMinimum(WSearchLineEdit::kMinDebouncingTimeoutMillis);
+    searchDebouncingTimeoutSpinBox->setMaximum(WSearchLineEdit::kMaxDebouncingTimeoutMillis);
+    const auto searchDebouncingTimeoutMillis =
+            m_pConfig->getValue(
+                    ConfigKey("[Library]","SearchDebouncingTimeoutMillis"),
+                    WSearchLineEdit::kDefaultDebouncingTimeoutMillis);
+    searchDebouncingTimeoutSpinBox->setValue(searchDebouncingTimeoutMillis);
+    connect(searchDebouncingTimeoutSpinBox, SIGNAL(valueChanged(int)),
+            this, SLOT(slotSearchDebouncingTimeoutMillisChanged(int)));
 
     connect(libraryFontButton, SIGNAL(clicked()),
             this, SLOT(slotSelectFont()));
@@ -359,6 +374,13 @@ void DlgPrefLibrary::slotSelectFont() {
     if (ok) {
         setLibraryFont(font);
     }
+}
+
+void DlgPrefLibrary::slotSearchDebouncingTimeoutMillisChanged(int searchDebouncingTimeoutMillis) {
+    m_pConfig->setValue(
+            kSearchDebouncingTimeoutMillisKey,
+            searchDebouncingTimeoutMillis);
+    WSearchLineEdit::setDebouncingTimeoutMillis(searchDebouncingTimeoutMillis);
 }
 
 void DlgPrefLibrary::slotSyncTrackMetadataExportToggled() {

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -56,6 +56,7 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     void slotRowHeightValueChanged(int);
     void slotSelectFont();
     void slotSyncTrackMetadataExportToggled();
+    void slotSearchDebouncingTimeoutMillisChanged(int);
 
   private:
     void initializeDirList();

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -193,13 +193,20 @@
        </widget>
       </item>
       <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="checkBoxEditMetadataSelectedClicked">
+        <property name="text">
+         <string>Edit metadata after clicking selected track</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBox_use_relative_path">
         <property name="text">
          <string>Use relative paths for playlist export if possible</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="rowHeightLabel">
         <property name="text">
          <string>Library Row Height:</string>
@@ -209,7 +216,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1" colspan="2">
+      <item row="3" column="1" colspan="2">
        <widget class="QSpinBox" name="spinBoxRowHeight">
         <property name="suffix">
          <string> px</string>
@@ -225,7 +232,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="libraryFontLabel">
         <property name="text">
          <string>Library Font:</string>
@@ -235,24 +242,34 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QLineEdit" name="libraryFont">
         <property name="readOnly">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="3" column="2">
+      <item row="4" column="2">
        <widget class="QToolButton" name="libraryFontButton">
         <property name="text">
          <string>...</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="checkBoxEditMetadataSelectedClicked">
+      <item row="5" column="0">
+       <widget class="QLabel" name="searchDebouncingTimeoutLabel">
         <property name="text">
-         <string>Edit metadata after clicking selected track</string>
+         <string>Search-as-you-type timeout:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1" colspan="2">
+       <widget class="QSpinBox" name="searchDebouncingTimeoutSpinBox">
+        <property name="suffix">
+         <string> ms</string>
         </property>
        </widget>
       </item>

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1182,6 +1182,16 @@ QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
 }
 
 QWidget* LegacySkinParser::parseSearchBox(const QDomElement& node) {
+    // TODO(XXX): Currently this is the only opportunity to initialize
+    // the static configuration settings of the widget. The settings
+    // don't need to be static, if the widget instance could be connected
+    // to changes in the configuration.
+    const auto searchDebouncingTimeoutMillis =
+            m_pConfig->getValue(
+                    ConfigKey("[Library]","SearchDebouncingTimeoutMillis"),
+                    WSearchLineEdit::kDefaultDebouncingTimeoutMillis);
+    WSearchLineEdit::setDebouncingTimeoutMillis(searchDebouncingTimeoutMillis);
+
     WSearchLineEdit* pLineEditSearch = new WSearchLineEdit(m_pParent);
     commonWidgetSetup(node, pLineEditSearch, false);
     pLineEditSearch->setup(node, *m_pContext);

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -18,14 +18,38 @@ const mixxx::Logger kLogger("WSearchLineEdit");
 const QColor kDefaultForegroundColor = QColor(0, 0, 0);
 const QColor kDefaultBackgroundColor = QColor(255, 255, 255);
 
-// Delay for triggering a search while typing.
-const int kDebouncingTimeoutMillis = 300;
-
 const QString kEmptySearch = "";
 
 const QString kDisabledText = "- - -";
 
+int verifyDebouncingTimeoutMillis(int debouncingTimeoutMillis) {
+    VERIFY_OR_DEBUG_ASSERT(debouncingTimeoutMillis >= WSearchLineEdit::kMinDebouncingTimeoutMillis) {
+        debouncingTimeoutMillis = WSearchLineEdit::kMinDebouncingTimeoutMillis;
+    }
+    VERIFY_OR_DEBUG_ASSERT(debouncingTimeoutMillis <= WSearchLineEdit::kMaxDebouncingTimeoutMillis) {
+        debouncingTimeoutMillis = WSearchLineEdit::kMaxDebouncingTimeoutMillis;
+    }
+    return debouncingTimeoutMillis;
+}
+
 } // namespace
+
+//static
+constexpr int WSearchLineEdit::kMinDebouncingTimeoutMillis;
+
+//static
+constexpr int WSearchLineEdit::kDefaultDebouncingTimeoutMillis;
+
+//static
+constexpr int WSearchLineEdit::kMaxDebouncingTimeoutMillis;
+
+//static
+int WSearchLineEdit::s_debouncingTimeoutMillis = kDefaultDebouncingTimeoutMillis;
+
+//static
+void WSearchLineEdit::setDebouncingTimeoutMillis(int debouncingTimeoutMillis) {
+    s_debouncingTimeoutMillis = verifyDebouncingTimeoutMillis(debouncingTimeoutMillis);
+}
 
 WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
     : QLineEdit(pParent),
@@ -253,7 +277,7 @@ void WSearchLineEdit::updateText(const QString& text) {
     if (isEnabled() && (m_state == State::Active)) {
         updateClearButton(text);
         DEBUG_ASSERT(m_debouncingTimer.isSingleShot());
-        m_debouncingTimer.start(kDebouncingTimeoutMillis);
+        m_debouncingTimer.start(s_debouncingTimeoutMillis);
     } else {
         updateClearButton(QString());
         m_debouncingTimer.stop();

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -103,7 +103,7 @@ void WSearchLineEdit::setup(const QDomNode& node, const SkinContext& context) {
         } else {
             kLogger.warning()
                     << "Failed to parse foreground color"
-                    << bgColorName;
+                    << fgColorName;
         }
     }
     m_foregroundColor = WSkinColor::getCorrectColor(m_foregroundColor);

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -19,6 +19,14 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
         Active,
     };
 
+    // Delay for triggering a search while typing
+    static constexpr int kMinDebouncingTimeoutMillis = 100;
+    static constexpr int kDefaultDebouncingTimeoutMillis = 300;
+    static constexpr int kMaxDebouncingTimeoutMillis = 9999;
+
+    // TODO(XXX): Replace with a public slot
+    static void setDebouncingTimeoutMillis(int debouncingTimeoutMillis);
+
     explicit WSearchLineEdit(QWidget* pParent);
     ~WSearchLineEdit() override = default;
 
@@ -45,6 +53,13 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     void triggerSearch();
 
   private:
+    // TODO(XXX): This setting shouldn't be static and the widget
+    // should instead define a public slot for changing the value.
+    // But this would require to connect the widget instance to some
+    // value provider that sends signals whenever the corresponding
+    // configuration value changes.
+    static int s_debouncingTimeoutMillis;
+
     void showPlaceholder();
     void showSearchText(const QString& text);
     void updateEditBox(const QString& text);
@@ -56,6 +71,7 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     QToolButton* const m_clearButton;
 
     QColor m_foregroundColor;
+
     QTimer m_debouncingTimer;
 
     State m_state;


### PR DESCRIPTION
Add a configurable debouncing timeout for the search edit field. Depending on the size of their library users are now able to adjust this to mitigate the issues caused by locking the UI thread while searching.

Another user now has exactly reported the same issues that I am experiencing, i.e. Mixxx is almost unusable with bigger libraries and the default settings: https://bugs.launchpad.net/mixxx/+bug/1783392