### PR TITLE
Deere: Fix background-color code

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -1029,7 +1029,7 @@ WEffectSelector {
   }
 
   WEffectSelector::item:selected {
-    background-color: #08080;
+    background-color: #080808;
   }
 
   /* currently loaded effect */


### PR DESCRIPTION
Why does no one care about this reasonable warning!?
```
Warning [Main]: QCssParser::parseHexColor: Unknown color name '#08080'
```