### PR TITLE
Fix scons 'build/features.py' linux build script <tab>

### DIFF
--- a/build/features.py
+++ b/build/features.py
@@ -1298,7 +1298,7 @@ class Lilv(Feature):
                 raise Exception('Missing liblilv-0 (needs at least 0.5)')
 
             build.env.Append(CPPDEFINES='__LILV__')
-	    build.env.ParseConfig('pkg-config lilv-0 --silence-errors \
+            build.env.ParseConfig('pkg-config lilv-0 --silence-errors \
                                   --cflags --libs')
 
     def sources(self, build):


### PR DESCRIPTION
Fix build script where <tab> has lurged in:
<pre>
File "/home/tuukka/src/c/mixxx/build/features.py", line 1301

    build.env.ParseConfig('pkg-config lilv-0 --silence-errors \
                                                              ^
TabError: inconsistent use of tabs and spaces in indentation
</pre>