### PR TITLE
Code by John Doe for adding color picker to library, LP #1100882

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -984,7 +984,9 @@ class MixxxCore(Feature):
                    "src/library/bpmdelegate.cpp",
                    "src/library/previewbuttondelegate.cpp",
                    "src/library/coverartdelegate.cpp",
-				   "src/library/tableitemdelegate.cpp",
+                   "src/library/tableitemdelegate.cpp",
+                   "src/library/colordelegate.cpp",
+                   "src/library/trackcolorpicker.cpp",
 
                    "src/library/treeitemmodel.cpp",
                    "src/library/treeitem.cpp",


### PR DESCRIPTION
I've taken the patch file posted at the end of the thread on [this Launchpad bug](https://bugs.launchpad.net/mixxx/+bug/1100882/), applied it and updated any necessary bits based on changed/moved code. It builds and runs and does what it's supposed to do. Not saying it's fit for release necessarily, but here it is if anybody wants to take a look.