### PR TITLE
Use ConfigObject instead of CmdlineArgs for getting settingsPath

### DIFF
--- a/src/dialog/dlgdevelopertools.cpp
+++ b/src/dialog/dlgdevelopertools.cpp
@@ -9,8 +9,8 @@
 
 DlgDeveloperTools::DlgDeveloperTools(QWidget* pParent,
                                      UserSettingsPointer pConfig)
-        : QDialog(pParent) {
-    Q_UNUSED(pConfig);
+        : QDialog(pParent),
+          m_pConfig(pConfig) {
     setupUi(this);
 
     QList<QSharedPointer<ControlDoublePrivate> > controlsList;
@@ -51,7 +51,7 @@ DlgDeveloperTools::DlgDeveloperTools(QWidget* pParent,
     m_statProxyModel.setSourceModel(&m_statModel);
     statsTable->setModel(&m_statProxyModel);
 
-    QString logFileName = QDir(CmdlineArgs::Instance().getSettingsPath()).filePath("mixxx.log");
+    QString logFileName = QDir(pConfig->getSettingsPath()).filePath("mixxx.log");
     m_logFile.setFileName(logFileName);
     if (!m_logFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
         qWarning() << "ERROR: Could not open log file:" << logFileName;
@@ -130,7 +130,7 @@ void DlgDeveloperTools::slotControlDump() {
 
     QString timestamp = QDateTime::currentDateTime()
             .toString("yyyy-MM-dd_hh'h'mm'm'ss's'");
-    QString dumpFileName = CmdlineArgs::Instance().getSettingsPath() +
+    QString dumpFileName = m_pConfig->getSettingsPath() +
             "/co_dump_" + timestamp + ".csv";
     QFile dumpFile;
     // Note: QFile is closed if it falls out of scope

--- a/src/dialog/dlgdevelopertools.h
+++ b/src/dialog/dlgdevelopertools.h
@@ -27,6 +27,7 @@ class DlgDeveloperTools : public QDialog, public Ui::DlgDeveloperTools {
     void slotControlDump();
 
   private:
+    UserSettingsPointer m_pConfig;
     ControlModel m_controlModel;
     QSortFilterProxyModel m_controlProxyModel;
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -742,7 +742,7 @@ void MixxxMainWindow::initializeKeyboard() {
 
     // Read keyboard configuration and set kdbConfig object in WWidget
     // Check first in user's Mixxx directory
-    QString userKeyboard = QDir(m_cmdLineArgs.getSettingsPath()).filePath("Custom.kbd.cfg");
+    QString userKeyboard = QDir(pConfig->getSettingsPath()).filePath("Custom.kbd.cfg");
 
     // Empty keyboard configuration
     m_pKbdConfigEmpty = new ConfigObject<ConfigValueKbd>(QString());


### PR DESCRIPTION
Whenever possible, use `ConfigObject` instead of `CmdlineArgs` to get `settingsPath` when the meaning is "What is the settings path for the currently running instance of Mixxx?".

There are two remaining:
- One at `src/main.cpp:95` because we need to initialize logging before any config object has been loaded
- One at `src/soundio/soundmanagerconfig.cpp:45` because this class doesn't has any config object and I didn't find a way to pass it due to my poor c++ skills and have no idea of performance or other consequences if we do that.

Other ones are good usage of `CmdlineArgs.getSettingsPath()` meaning "give me the settings path provided specifically on the command line" like when creating the config object.