### PR TITLE
[WIP] Portable install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 dist32
 dist64
+portable/
 
 src/mixxx.rc.include
 src/mixxx.res
@@ -50,6 +51,8 @@ build/wix/subdirs/*.wxs
 # based on .tmpl template file for the second one.
 build/wix/bundle/bundleloc.wxs
 build/wix/ProductID.wxi
+
+mixxx-portable*.zip
 
 *.obj
 *.pdb

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 
 dist32
 dist64
-portable/
+/portable/
 
 src/mixxx.rc.include
 src/mixxx.res

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,6 +58,7 @@ after_test:
 artifacts:
   - path: '*.exe'
   - path: '*.msi'
+  - path: 'mixxx-portable*.zip'
 on_success:
   - echo "*** SUCCESS ***"
 on_failure:

--- a/build/appveyor/build_mixxx.bat
+++ b/build/appveyor/build_mixxx.bat
@@ -140,7 +140,7 @@ set CXXFLAGS=/MP /FS /EHsc /Zc:threadSafeInit-
 set CFLAGS=/MP /FS /EHsc /Zc:threadSafeInit-
 
 set PATH=%BIN_DIR%;%PATH%
-scons.py mixxx makerelease toolchain=msvs winlib=%WINLIB_DIR% build=%BUILD_TYPE% staticlibs=1 staticqt=1 debug_assertions_fatal=1 verbose=0 machine=%MACHINE_TYPE% qtdir=%QTDIR% hss1394=1 mediafoundation=1 opus=1 localecompare=1 optimize=fastbuild virtualize=0 test=1 qt_sqlite_plugin=0 mssdk_dir="%MSSDK_DIR%" build_number_in_title_bar=0 bundle_pdbs=0
+scons.py mixxx makerelease makeportable toolchain=msvs winlib=%WINLIB_DIR% build=%BUILD_TYPE% staticlibs=1 staticqt=1 debug_assertions_fatal=1 verbose=0 machine=%MACHINE_TYPE% qtdir=%QTDIR% hss1394=1 mediafoundation=1 opus=1 localecompare=1 optimize=fastbuild virtualize=0 test=1 qt_sqlite_plugin=0 mssdk_dir="%MSSDK_DIR%" build_number_in_title_bar=0 bundle_pdbs=0
 
 IF ERRORLEVEL 1 (
 echo ==============================

--- a/build/portable/README.md
+++ b/build/portable/README.md
@@ -4,17 +4,17 @@
 
 The Mixxx binary itself is the same for portable or normal installation.
 Portable status is determined at runtime if Mixxx finds directories named
-`settings` and `res` at the same place the executable resides.
+`mixxx-settings` and `mixxx-resources` at the same place the executable resides.
 It will them use its resources from the `res` subdirectory and store all
-settings from the `settings` subdirectory. No attempt will be made to access or
-upgrade configuration outside of that directory. This allow you to used
+settings from the `mixxx-settings` subdirectory. No attempt will be made to
+access or upgrade configuration outside of that directory. This allow you to use
 different portable Mixxx versions without any sharing between their
 configuration.
 
 ## Upgrade
 
 If you want to upgrade from one portable version to another, simply copy the
-`settings` directory in the old version to the new one.
+`mixxx-settings` directory in the old version to the new one.
 
 ## Track management
 

--- a/build/portable/README.md
+++ b/build/portable/README.md
@@ -1,0 +1,37 @@
+# Mixxx Portable installation
+
+## How it works
+
+The Mixxx binary itself is the same for portable or normal installation.
+Portable status is determined at runtime if Mixxx finds directories named
+`settings` and `res` at the same place the executable resides.
+It will them use its resources from the `res` subdirectory and store all
+settings from the `settings` subdirectory. No attempt will be made to access or
+upgrade configuration outside of that directory. This allow you to used
+different portable Mixxx versions without any sharing between their
+configuration.
+
+## Upgrade
+
+If you want to upgrade from one portable version to another, simply copy the
+`settings` directory in the old version to the new one.
+
+## Track management
+
+Currently, Mixxx can't handle relative library folders so if you store portable
+Mixxx and your track on a removable drive, be aware that a different mountpoint
+of drive letter (depending on your OS) for that drive will lead to missing
+tracks (Mixxx is unable to find its tracks himself).
+To recover your tracks, You need to manually add your music directory to the
+library preferences and let Mixxx browse your music folder. It should
+automatically recover missing tracks.
+
+## Performance
+
+If you plan to use portable Mixxx directly from a removable media (USB key or
+external hard drive), chose a drive with good performance as all access to
+Mixxx configuration database and logging will be made on that removable media.
+It is recommended to copy the portable Mixxx folder on the hard drive of the
+computer you use before using portable Mixxx and to copy back the settings
+folder to your removable media after you have finished using Mixxx to backup
+your latest data.

--- a/build/portable/README.md
+++ b/build/portable/README.md
@@ -3,13 +3,22 @@
 ## How it works
 
 The Mixxx binary itself is the same for portable or normal installation.
-Portable status is determined at runtime if Mixxx finds directories named
-`mixxx-settings` and `mixxx-resources` at the same place the executable resides.
-It will them use its resources from the `res` subdirectory and store all
-settings from the `mixxx-settings` subdirectory. No attempt will be made to
-access or upgrade configuration outside of that directory. This allows you to
-use different portable Mixxx versions with completely separate/isolated
-configurations.
+Portable status is determined at runtime if Mixxx executable is named
+`mixxx-portable` (case insensitive and without extension) or if the `--portable`
+command-line argument is passed to Mixxx.
+
+In portable mode, Mixxx looks for its resource files (like skins, controller
+mappings, translations and so on) in a sundirectory `mixxx-resources` at the
+same place the executable resides (location can be overwritten with the
+command-line option `--resourcePath`).
+
+It also store all settings in a subdirectory `mixxx-settings`
+at the same place the executable resides (location can be overwritten with the
+command-line option `--settingsPath`).
+
+No attempt will be made to access or upgrade configuration outside of this
+`mixxx-settings` directory. This allows you to use different portable Mixxx
+versions with completely separate/isolated configurations.
 
 ## Upgrade
 

--- a/build/portable/README.md
+++ b/build/portable/README.md
@@ -7,9 +7,9 @@ Portable status is determined at runtime if Mixxx finds directories named
 `mixxx-settings` and `mixxx-resources` at the same place the executable resides.
 It will them use its resources from the `res` subdirectory and store all
 settings from the `mixxx-settings` subdirectory. No attempt will be made to
-access or upgrade configuration outside of that directory. This allow you to use
-different portable Mixxx versions without any sharing between their
-configuration.
+access or upgrade configuration outside of that directory. This allows you to
+use different portable Mixxx versions with completely separate/isolated
+configurations.
 
 ## Upgrade
 
@@ -19,9 +19,9 @@ If you want to upgrade from one portable version to another, simply copy the
 ## Track management
 
 Currently, Mixxx can't handle relative library folders so if you store portable
-Mixxx and your track on a removable drive, be aware that a different mountpoint
-of drive letter (depending on your OS) for that drive will lead to missing
-tracks (Mixxx is unable to find its tracks himself).
+Mixxx and your tracks on a removable drive, be aware that a different mountpoint
+or drive letter (depending on your OS) for that drive will lead to missing
+tracks because Mixxx will not be able to find them on its own.
 To recover your tracks, You need to manually add your music directory to the
 library preferences and let Mixxx browse your music folder. It should
 automatically recover missing tracks.
@@ -31,7 +31,7 @@ automatically recover missing tracks.
 If you plan to use portable Mixxx directly from a removable media (USB key or
 external hard drive), chose a drive with good performance as all access to
 Mixxx configuration database and logging will be made on that removable media.
-It is recommended to copy the portable Mixxx folder on the hard drive of the
+It is recommended to copy the portable Mixxx folder to the hard drive of the
 computer you use before using portable Mixxx and to copy back the settings
 folder to your removable media after you have finished using Mixxx to backup
 your latest data.

--- a/src/SConscript
+++ b/src/SConscript
@@ -1252,8 +1252,8 @@ def BuildPortablePackage(target, source, env):
     # Ensure temporary target directory is empty before populating
     shutil.rmtree('portable/{}'.format(directory_name), ignore_errors=True)
     os.makedirs('portable/{}'.format(directory_name))
-    os.makedirs('portable/{}/res'.format(directory_name))
-    os.makedirs('portable/{}/settings'.format(directory_name))
+    os.makedirs('portable/{}/mixxx-resources'.format(directory_name))
+    os.makedirs('portable/{}/mixxx-settings'.format(directory_name))
 
     # Handle all subdirectories of dist_dir
     print('  . Copying subdirectories:')
@@ -1266,7 +1266,7 @@ def BuildPortablePackage(target, source, env):
                           'portable/{}/{}'.format(directory_name, subdir))
         else:
             copyDirectory('{}/{}'.format(dist_dir, subdir),
-                          'portable/{}/res/{}'.format(directory_name, subdir))
+                          'portable/{}/mixxx-resources/{}'.format(directory_name, subdir))
 
     print('  . Copying binary files:')
     for file in mixxx_bin:

--- a/src/SConscript
+++ b/src/SConscript
@@ -1261,6 +1261,15 @@ def BuildPortablePackage(target, source, env):
         print('    - {}'.format(os.path.basename(str(file))))
         shutil.copy2('{}/{}'.format(dist_dir, os.path.basename(str(file))),
                                     'portable/{}/{}'.format(directory_name, os.path.basename(str(file))))
+    if build.platform_is_windows:
+        shutil.move('portable/{}/mixxx.exe'.format(directory_name),
+                    'portable/{}/mixxx-portable.exe'.format(directory_name))
+    elif build.platform_is_osx:
+        shutil.move('portable/{}/Mixxx'.format(directory_name),
+                    'portable/{}/Mixxx-portable'.format(directory_name))
+    else:
+        shutil.move('portable/{}/mixxx'.format(directory_name),
+                    'portable/{}/mixxx-portable'.format(directory_name))
 
     print('  . Copying documentation:')
     for file in ['CHANGELOG', 'LICENSE', 'build/portable/README.md']:

--- a/src/SConscript
+++ b/src/SConscript
@@ -1277,7 +1277,7 @@ def BuildPortablePackage(target, source, env):
     print('  . Copying documentation:')
     for file in ['CHANGELOG', 'LICENCE', 'build/portable/README.md']:
         print('    - {}'.format(os.path.basename(file)))
-        shutil.copy2('{}'.format(file)),
+        shutil.copy2('{}'.format(file),
                      'portable/{}/{}'.format(directory_name, os.path.basename(file)))
 
     print("Now building portable package...")

--- a/src/SConscript
+++ b/src/SConscript
@@ -593,6 +593,39 @@ if build.platform_is_windows:
                 sql_dlls = env.Install(os.path.join(base_dist_dir, "sqldrivers"), sqldll_files)
                 env.Alias('mixxx', sql_dlls)
 
+pbchecksAlreadyPrinted = False
+
+def PostBuildChecks():
+    global mixxx_version
+    global pbchecksAlreadyPrinted
+    if pbchecksAlreadyPrinted:
+        return
+    pbchecksAlreadyPrinted = True
+
+    print('\n==== Mixxx Post-Build Checks ====')
+    print('You have built version {}'.format(mixxx_version))
+
+    if build.build_is_debug:
+        print('\nYOU ARE ABOUT TO PACKAGE A DEBUG BUILD!!\n')
+
+    print("Binary has size ", end='')
+    if build.platform_is_windows:
+        os.system('for %I in ('+dist_dir+'\mixxx.exe) do @echo %~zI')
+    else:
+        os.system('ls -lh '+dist_dir+'/mixxx | cut -d \' \' -f 5')
+
+    print("\nTop line of README, check version:")
+    if build.platform_is_windows:
+        os.system('for /l %l in (1,1,1) do @for /f "tokens=1,2* delims=:" %a in (\'findstr /n /r "^" README ^| findstr /r "^%l:"\') do @echo %b')
+    else:
+        os.system('head -n 1 README')
+    print("\nTop 2 lines of LICENSE, check version and copyright dates:")
+    if build.platform_is_windows:
+        os.system('for /l %l in (1,1,2) do @for /f "tokens=1,2* delims=:" %a in (\'findstr /n /r "^" LICENSE ^| findstr /r "^%l:"\') do @echo %b')
+    else:
+        os.system('head -n 2 LICENSE')
+
+
 def win32_find_program_via_registry(program_name):
     # Windows registry access to find where program is installed
     import _winreg
@@ -627,33 +660,15 @@ def win32_find_program_via_registry(program_name):
     return program_location
 
 def BuildRelease(target, source, env):
-    print("==== Mixxx Post-Build Checks ====")
-    print("You have built version %s" % mixxx_version)
-    if build.build_is_debug:
-        print("YOU ARE ABOUT TO PACKAGE A DEBUG BUILD!!")
-    print("Binary has size ", end='')
-    if build.platform_is_windows:
-        os.system('for %I in ('+dist_dir+'\mixxx.exe) do @echo %~zI')
-    else:
-        os.system('ls -lh '+dist_dir+'/mixxx.exe | cut -d \' \' -f 5')
+    PostBuildChecks()
+    print('\n\nNow building MSI package\n')
     print("Installer file ", end='')
     package_name = 'mixxx'
-
     package_version = construct_version(build, mixxx_version, branch_name,
                                         vcs_revision)
     arch = "x64" if build.machine_is_64bit else "x86"
     exe_name = '%s-%s-%s.msi' % (package_name, package_version, arch)
     print(exe_name)
-    print("Top line of README, check version:")
-    if build.platform_is_windows:
-        os.system('for /l %l in (1,1,1) do @for /f "tokens=1,2* delims=:" %a in (\'findstr /n /r "^" README ^| findstr /r "^%l:"\') do @echo %b')
-    else:
-        os.system('head -n 1 README')
-    print("Top 2 lines of LICENSE, check version and copyright dates:")
-    if build.platform_is_windows:
-        os.system('for /l %l in (1,1,2) do @for /f "tokens=1,2* delims=:" %a in (\'findstr /n /r "^" LICENSE ^| findstr /r "^%l:"\') do @echo %b')
-    else:
-        os.system('head -n 2 LICENSE')
     #if (raw_input("Go ahead and build installer (yes/[no])? ") == "yes"):
     if True:
         # TODO(XXX): Installing a runtime isn't specific to MSVS?
@@ -920,6 +935,7 @@ def BuildRelease(target, source, env):
         print("Aborted building installer")
 
 # Do release things
+
 versionbld = Builder(action = BuildRelease, suffix = '.foo', src_suffix = '.bar')
 env.Append(BUILDERS = {'BuildRelease' : versionbld})
 
@@ -956,21 +972,10 @@ def ubuntu_cleanup():
 # Build the Ubuntu package
 def BuildUbuntuPackage(target, source, env):
         global mixxx_version
-        print("==== Mixxx Post-Build Checks ====")
-        print("You have built version " + mixxx_version)
-        print("\n\n")
-
-        print("Top line of README, check version:")
-        os.system('head -n 1 README')
-        print()
-        print("Top 2 lines of LICENSE, check version and copyright dates:")
-        os.system('head -n 2 LICENSE')
-        print()
+        PostBuildChecks()
+        print("\n\nNow building DEB package...\n")
         print("Top line of debian/ubuntu changelog, check version:")
         os.system('head -n 1 build/debian/changelog')
-        print()
-
-        print("Now building DEB package...")
         print()
 
         arch = 'amd64' if build.machine_is_64bit else 'i386'
@@ -1208,15 +1213,8 @@ def copyDirectory(src, dest):
         print('Directory not copied. Error: %s' % e)
 
 def BuildPortablePackage(target, source, env):
-    print("==== Mixxx Post-Build Checks ====")
-    print("You have built version %s" % mixxx_version)
-    if build.build_is_debug:
-        print("YOU ARE ABOUT TO PACKAGE A DEBUG BUILD!!")
-    print("Binary has size ", end='')
-    if build.platform_is_windows:
-        os.system('for %I in ('+dist_dir+'\mixxx.exe) do @echo %~zI')
-    else:
-        os.system('ls -lh '+dist_dir+'/mixxx.exe | cut -d \' \' -f 5')
+    PostBuildChecks()
+    print('\n\nNow building portable package\n')
     print("Archive file ", end='')
     package_name = 'mixxx-portable'
     package_version = mixxx_version
@@ -1237,16 +1235,6 @@ def BuildPortablePackage(target, source, env):
     print('directory_name: {}'.format(directory_name))
     print('archive_name: {}'.format(archive_name))
     print(archive_name)
-    print("Top line of README, check version:")
-    if build.platform_is_windows:
-        os.system('for /l %l in (1,1,1) do @for /f "tokens=1,2* delims=:" %a in (\'findstr /n /r "^" README ^| findstr /r "^%l:"\') do @echo %b')
-    else:
-        os.system('head -n 1 README')
-    print("Top 2 lines of LICENSE, check version and copyright dates:")
-    if build.platform_is_windows:
-        os.system('for /l %l in (1,1,2) do @for /f "tokens=1,2* delims=:" %a in (\'findstr /n /r "^" LICENSE ^| findstr /r "^%l:"\') do @echo %b')
-    else:
-        os.system('head -n 2 LICENSE')
 
     print("Installing Mixxx the portable way in temporary directory...")
     # Ensure temporary target directory is empty before populating

--- a/src/SConscript
+++ b/src/SConscript
@@ -1276,9 +1276,9 @@ def BuildPortablePackage(target, source, env):
 
     print('  . Copying documentation:')
     for file in ['CHANGELOG', 'LICENCE', 'build/portable/README.md']:
-        print('    - {}'.format(os.path.basename(str(file))))
-        shutil.copy2('{}/{}'.format(dist_dir, os.path.basename(str(file))),
-                     'portable/{}/{}'.format(directory_name, os.path.basename(str(file))))
+        print('    - {}'.format(os.path.basename(file)))
+        shutil.copy2('{}'.format(file)),
+                     'portable/{}/{}'.format(directory_name, os.path.basename(file)))
 
     print("Now building portable package...")
     # Zip the directory_name into target archive file

--- a/src/SConscript
+++ b/src/SConscript
@@ -1195,3 +1195,98 @@ env.Append(BUILDERS = {'BuildUbuntuPackage' : versiondebbld})
 if 'makeubuntu' in COMMAND_LINE_TARGETS:
         makeubuntu = env.BuildUbuntuPackage("blah", "defs_version.h" ) #(binary_files)
         env.Alias('makeubuntu', makeubuntu)
+
+
+def copyDirectory(src, dest):
+    try:
+        shutil.copytree(src, dest)
+    # Directories are the same
+    except shutil.Error as e:
+        print('Directory not copied. Error: %s' % e)
+    # Any error saying that the directory doesn't exist
+    except OSError as e:
+        print('Directory not copied. Error: %s' % e)
+
+def BuildPortablePackage(target, source, env):
+    print("==== Mixxx Post-Build Checks ====")
+    print("You have built version %s" % mixxx_version)
+    if build.build_is_debug:
+        print("YOU ARE ABOUT TO PACKAGE A DEBUG BUILD!!")
+    print("Binary has size ", end='')
+    if build.platform_is_windows:
+        os.system('for %I in ('+dist_dir+'\mixxx.exe) do @echo %~zI')
+    else:
+        os.system('ls -lh '+dist_dir+'/mixxx.exe | cut -d \' \' -f 5')
+    print("Archive file ", end='')
+    package_name = 'mixxx-portable'
+    package_version = mixxx_version
+    if build.platform_is_windows:
+        package_system = "windows"
+        arch = "-x64" if build.machine_is_64bit else "-x86"
+    elif build.platform_is_osx:
+        package_system = "osxintel"
+        arch = ""
+    elif build.platform_is_bsd:
+        package_system = "bsd"
+        arch = "-amd64" if build.machine_is_64bit else "-x86"
+    else: # Linux
+        package_system = "linux"
+        arch = "-amd64" if build.machine_is_64bit else "-x86"
+    directory_name = '%s-%s%s' % (package_name, package_version, arch)
+    archive_name = '%s-%s-%s%s.zip' % (package_name, package_version, package_system, arch)
+    print('directory_name: {}'.format(directory_name))
+    print('archive_name: {}'.format(archive_name))
+    print(archive_name)
+    print("Top line of README, check version:")
+    if build.platform_is_windows:
+        os.system('for /l %l in (1,1,1) do @for /f "tokens=1,2* delims=:" %a in (\'findstr /n /r "^" README ^| findstr /r "^%l:"\') do @echo %b')
+    else:
+        os.system('head -n 1 README')
+    print("Top 2 lines of LICENSE, check version and copyright dates:")
+    if build.platform_is_windows:
+        os.system('for /l %l in (1,1,2) do @for /f "tokens=1,2* delims=:" %a in (\'findstr /n /r "^" LICENSE ^| findstr /r "^%l:"\') do @echo %b')
+    else:
+        os.system('head -n 2 LICENSE')
+
+    print("Installing Mixxx the portable way in temporary directory...")
+    # Ensure temporary target directory is empty before populating
+    shutil.rmtree('portable/{}'.format(directory_name), ignore_errors=True)
+    os.makedirs('portable/{}'.format(directory_name))
+    os.makedirs('portable/{}/res'.format(directory_name))
+    os.makedirs('portable/{}/settings'.format(directory_name))
+
+    # Handle all subdirectories of dist_dir
+    print('  . Copying subdirectories:')
+    for subdir in next(os.walk(dist_dir))[1]:
+        print('    - {}'.format(subdir))
+
+        # subdirectories to copy to top-level directory
+        if subdir in ['plugins']:
+            copyDirectory('{}/{}'.format(dist_dir, subdir),
+                          'portable/{}/{}'.format(directory_name, subdir))
+        else:
+            copyDirectory('{}/{}'.format(dist_dir, subdir),
+                          'portable/{}/res/{}'.format(directory_name, subdir))
+
+    print('  . Copying binary files:')
+    for file in mixxx_bin:
+        print('    - {}'.format(file))
+        shutil.copy2('{}/{}'.format(dist_dir, os.path.basename(str(file))),
+                                    'portable/{}/{}'.format(directory_name, os.path.basename(str(file))))
+
+    print("Now building portable package...")
+    # Zip the directory_name into target archive file
+    os.chdir('portable')
+    os.system('7z a ../{} {}'.format(archive_name, directory_name))
+    os.chdir('..')
+
+    print("Cleanup temporary portable installation")
+    shutil.rmtree('portable/{}'.format(directory_name), ignore_errors=True)
+
+#Build the portable package if "makeportable" was passed as an argument
+versionprtbld = Builder(action = BuildPortablePackage)
+env.Append(BUILDERS = {'BuildPortablePackage' : versionprtbld})
+
+if 'makeportable' in COMMAND_LINE_TARGETS:
+        makeportable = env.BuildPortablePackage("blah", "defs_version.h" ) #(binary_files)
+        env.Alias('makeportable', makeportable)

--- a/src/SConscript
+++ b/src/SConscript
@@ -1270,9 +1270,15 @@ def BuildPortablePackage(target, source, env):
 
     print('  . Copying binary files:')
     for file in mixxx_bin:
-        print('    - {}'.format(file))
+        print('    - {}'.format(os.path.basename(str(file))))
         shutil.copy2('{}/{}'.format(dist_dir, os.path.basename(str(file))),
                                     'portable/{}/{}'.format(directory_name, os.path.basename(str(file))))
+
+    print('  . Copying documentation:')
+    for file in ['CHANGELOG', 'LICENCE', 'build/portable/README.md']:
+        print('    - {}'.format(os.path.basename(str(file))))
+        shutil.copy2('{}/{}'.format(dist_dir, os.path.basename(str(file))),
+                     'portable/{}/{}'.format(directory_name, os.path.basename(str(file))))
 
     print("Now building portable package...")
     # Zip the directory_name into target archive file

--- a/src/SConscript
+++ b/src/SConscript
@@ -1275,7 +1275,7 @@ def BuildPortablePackage(target, source, env):
                                     'portable/{}/{}'.format(directory_name, os.path.basename(str(file))))
 
     print('  . Copying documentation:')
-    for file in ['CHANGELOG', 'LICENCE', 'build/portable/README.md']:
+    for file in ['CHANGELOG', 'LICENSE', 'build/portable/README.md']:
         print('    - {}'.format(os.path.basename(file)))
         shutil.copy2('{}'.format(file),
                      'portable/{}/{}'.format(directory_name, os.path.basename(file)))

--- a/src/dialog/dlgdevelopertools.cpp
+++ b/src/dialog/dlgdevelopertools.cpp
@@ -9,8 +9,8 @@
 
 DlgDeveloperTools::DlgDeveloperTools(QWidget* pParent,
                                      UserSettingsPointer pConfig)
-        : QDialog(pParent) {
-    Q_UNUSED(pConfig);
+        : QDialog(pParent),
+          m_pConfig(pConfig) {
     setupUi(this);
 
     QList<QSharedPointer<ControlDoublePrivate> > controlsList;
@@ -51,7 +51,7 @@ DlgDeveloperTools::DlgDeveloperTools(QWidget* pParent,
     m_statProxyModel.setSourceModel(&m_statModel);
     statsTable->setModel(&m_statProxyModel);
 
-    QString logFileName = QDir(CmdlineArgs::Instance().getSettingsPath()).filePath("mixxx.log");
+    QString logFileName = QDir(pConfig->getSettingsPath()).filePath("mixxx.log");
     m_logFile.setFileName(logFileName);
     if (!m_logFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
         qWarning() << "ERROR: Could not open log file:" << logFileName;
@@ -130,7 +130,7 @@ void DlgDeveloperTools::slotControlDump() {
 
     QString timestamp = QDateTime::currentDateTime()
             .toString("yyyy-MM-dd_hh'h'mm'm'ss's'");
-    QString dumpFileName = CmdlineArgs::Instance().getSettingsPath() +
+    QString dumpFileName = m_pConfig->getSettingsPath() +
             "/co_dump_" + timestamp + ".csv";
     QFile dumpFile;
     // Note: QFile is closed if it falls out of scope

--- a/src/dialog/dlgdevelopertools.h
+++ b/src/dialog/dlgdevelopertools.h
@@ -27,6 +27,7 @@ class DlgDeveloperTools : public QDialog, public Ui::DlgDeveloperTools {
     void slotControlDump();
 
   private:
+    UserSettingsPointer m_pConfig;
     ControlModel m_controlModel;
     QSortFilterProxyModel m_controlProxyModel;
 

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -742,7 +742,7 @@ void MixxxMainWindow::initializeKeyboard() {
 
     // Read keyboard configuration and set kdbConfig object in WWidget
     // Check first in user's Mixxx directory
-    QString userKeyboard = QDir(m_cmdLineArgs.getSettingsPath()).filePath("Custom.kbd.cfg");
+    QString userKeyboard = QDir(pConfig->getSettingsPath()).filePath("Custom.kbd.cfg");
 
     // Empty keyboard configuration
     m_pKbdConfigEmpty = new ConfigObject<ConfigValueKbd>(QString());

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -25,10 +25,7 @@ QString computeResourcePath() {
         // running out of a build root ('res' dir exists or our path ends with
         // '_build') and if not then we fall back on a platform-specific method
         // of determining the resource path (see comments below).
-        if (mixxxDir.cd("mixxx-resources")) {
-            // We are running portable
-            qResourcePath = mixxxDir.absolutePath();
-        } else if (mixxxDir.cd("res")) {
+        if (mixxxDir.cd("res")) {
             // We are running out of the repository root.
             qResourcePath = mixxxDir.absolutePath();
         } else if (mixxxDir.absolutePath().endsWith("_build") &&

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -25,7 +25,10 @@ QString computeResourcePath() {
         // running out of a build root ('res' dir exists or our path ends with
         // '_build') and if not then we fall back on a platform-specific method
         // of determining the resource path (see comments below).
-        if (mixxxDir.cd("res")) {
+        if (mixxxDir.cd("mixxx-resources")) {
+            // We are running portable
+            qResourcePath = mixxxDir.absolutePath();
+        } else if (mixxxDir.cd("res")) {
             // We are running out of the repository root.
             qResourcePath = mixxxDir.absolutePath();
         } else if (mixxxDir.absolutePath().endsWith("_build") &&

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -59,9 +59,9 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
         QDir oldLocation = QDir(QDir::homePath());
 
 #ifdef __WINDOWS__
-        Qstring pre170ConfigFile = "mixxx.cfg";
+        QString pre170ConfigFile = "mixxx.cfg";
 #else
-        Qstring pre170ConfigFile = ".mixxx.cfg";
+        QString pre170ConfigFile = ".mixxx.cfg";
 #endif
 
         QFileInfo* pre170Config = new QFileInfo(oldLocation.filePath(pre170ConfigFile));

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -57,12 +57,14 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
     // If we are running portable, do not try reading configuration outside our directory
     if (! CmdlineArgs::Instance().getIsPortable()) {
         QDir oldLocation = QDir(QDir::homePath());
+
 #ifdef __WINDOWS__
-        QFileInfo* pre170Config = new QFileInfo(oldLocation.filePath("mixxx.cfg"));
+        Qstring pre170ConfigFile = "mixxx.cfg";
 #else
-        QFileInfo* pre170Config = new QFileInfo(oldLocation.filePath(".mixxx.cfg"));
+        Qstring pre170ConfigFile = ".mixxx.cfg";
 #endif
 
+        QFileInfo* pre170Config = new QFileInfo(oldLocation.filePath(pre170ConfigFile));
         if (pre170Config->exists()) {
 
             // Move the files to their new location
@@ -76,11 +78,12 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
             QString errorText = "Error moving your %1 file %2 to the new location %3: \n";
 
 #ifdef __WINDOWS__
-            QString oldFilePath = oldLocation.filePath("mixxxtrack.xml");
+            QString pre170MixxxTrackFile = "mixxxtrack.xml";
 #else
-            QString oldFilePath = oldLocation.filePath(".mixxxtrack.xml");
+            QString pre170MixxxTrackFile = ".mixxxtrack.xml";
 #endif
 
+            QString oldFilePath = oldLocation.filePath(pre170MixxxTrackFile);
             QString newFilePath = newLocation.filePath("mixxxtrack.xml");
             QFile* oldFile = new QFile(oldFilePath);
             if (oldFile->exists()) {
@@ -95,10 +98,11 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
             delete oldFile;
 
 #ifdef __WINDOWS__
-            oldFilePath = oldLocation.filePath("mixxxbpmschemes.xml");
+            QString pre170MixxxBPMScheme = "mixxxbpmschemes.xml";
 #else
-            oldFilePath = oldLocation.filePath(".mixxxbpmscheme.xml");
+            QString pre170MixxxBPMScheme = ".mixxxbpmscheme.xml";
 #endif
+            oldFilePath = oldLocation.filePath(pre170MixxxBPMScheme);
             newFilePath = newLocation.filePath("mixxxbpmscheme.xml");
             oldFile = new QFile(oldFilePath);
             if (oldFile->exists()) {
@@ -110,11 +114,13 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
                     }
                 }
                 delete oldFile;
+
 #ifdef __WINDOWS__
-            oldFilePath = oldLocation.filePath("MixxxMIDIBindings.xml");
+            QString pre170MIDIBindings = "MixxxMIDIBindings.xml";
 #else
-            oldFilePath = oldLocation.filePath(".MixxxMIDIBindings.xml");
+            QString pre170MIDIBindings = ".MixxxMIDIBindings.xml";
 #endif
+            oldFilePath = oldLocation.filePath(pre170MIDIBindings);
             newFilePath = newLocation.filePath("MixxxMIDIBindings.xml");
             oldFile = new QFile(oldFilePath);
             if (oldFile->exists()) {
@@ -128,17 +134,16 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
                 }
                 // Tidy up
                 delete oldFile;
-#ifdef __WINDOWS__
-            QFile::remove(oldLocation.filePath("MixxxMIDIDevice.xml")); // Obsolete file, so just delete it
-#else
-            QFile::remove(oldLocation.filePath(".MixxxMIDIDevice.xml")); // Obsolete file, so just delete it
-#endif
 
 #ifdef __WINDOWS__
-            oldFilePath = oldLocation.filePath("mixxx.cfg");
+            QString pre170MIDIDevices = "MixxxMIDIDevice.xml";
 #else
-            oldFilePath = oldLocation.filePath(".mixxx.cfg");
+            QString pre170MIDIDevices = ".MixxxMIDIDevice.xml";
 #endif
+
+            QFile::remove(oldLocation.filePath(pre170MIDIDevices)); // Obsolete file, so just delete it
+
+            oldFilePath = oldLocation.filePath(pre170ConfigFile);
             newFilePath = newLocation.filePath(SETTINGS_FILE);
             oldFile = new QFile(oldFilePath);
             if (oldFile->copy(newFilePath))

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -13,16 +13,27 @@ CmdlineArgs::CmdlineArgs()
       m_safeMode(false),
       m_debugAssertBreak(false),
       m_settingsPathSet(false),
+      m_isPortable(false),
       m_logLevel(mixxx::kLogLevelDefault),
-      m_logFlushLevel(mixxx::kLogFlushLevelDefault),
-// We are not ready to switch to XDG folders under Linux, so keeping $HOME/.mixxx as preferences folder. see lp:1463273
+      m_logFlushLevel(mixxx::kLogFlushLevelDefault) {
+
+    QDir mixxxDir(QCoreApplication::applicationDirPath());
+    if (mixxxDir.cd("settings")) {
+        // We are running portable because there is a settings dir near
+        // Mixxx executable so we use this directory to store settings.
+        m_settingsPath = mixxxDir.absolutePath();
+        m_isPortable = true;
+    } else {
+        // Default values
+        // We are not ready to switch to XDG folders under Linux, so keeping $HOME/.mixxx as preferences folder. see lp:1463273
 #ifdef __LINUX__
-    m_settingsPath(QDir::homePath().append("/").append(SETTINGS_PATH)) {
+        m_settingsPath = QDir::homePath().append("/").append(SETTINGS_PATH);
 #else
-    // TODO(XXX) Trailing slash not needed anymore as we switches from String::append
-    // to QDir::filePath elsewhere in the code. This is candidate for removal.
-    m_settingsPath(QDesktopServices::storageLocation(QDesktopServices::DataLocation).append("/")) {
+        // TODO(XXX) Trailing slash not needed anymore as we switches from String::append
+        // to QDir::filePath elsewhere in the code. This is candidate for removal.
+        m_settingsPath = QDesktopServices::storageLocation(QDesktopServices::DataLocation).append("/");
 #endif
+    }
 }
 
 bool CmdlineArgs::Parse(int &argc, char **argv) {

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -18,8 +18,8 @@ CmdlineArgs::CmdlineArgs()
       m_logFlushLevel(mixxx::kLogFlushLevelDefault) {
 
     QDir mixxxDir(QCoreApplication::applicationDirPath());
-    if (mixxxDir.cd("settings")) {
-        // We are running portable because there is a settings dir near
+    if (mixxxDir.cd("mixxx-settings")) {
+        // We are running portable because there is a mixxx-settings dir near
         // Mixxx executable so we use this directory to store settings.
         m_settingsPath = mixxxDir.absolutePath();
         m_isPortable = true;

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -49,6 +49,7 @@ class CmdlineArgs final {
     bool m_safeMode;
     bool m_debugAssertBreak;
     bool m_settingsPathSet; // has --settingsPath been set on command line ?
+    bool m_resourcePathSet; // has --resourcePath been set on command line ?
     bool m_isPortable; // if we run portable, we shouldn't try to access outside our directory
     mixxx::LogLevel m_logLevel; // Level of stderr logging message verbosity
     mixxx::LogLevel m_logFlushLevel; // Level of mixx.log file flushing

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -26,6 +26,7 @@ class CmdlineArgs final {
     bool getSafeMode() const { return m_safeMode; }
     bool getDebugAssertBreak() const { return m_debugAssertBreak; }
     bool getSettingsPathSet() const { return m_settingsPathSet; }
+    bool getIsPortable() const { return m_isPortable; }
     mixxx::LogLevel getLogLevel() const { return m_logLevel; }
     mixxx::LogLevel getLogFlushLevel() const { return m_logFlushLevel; }
     bool getTimelineEnabled() const { return !m_timelinePath.isEmpty(); }
@@ -48,6 +49,7 @@ class CmdlineArgs final {
     bool m_safeMode;
     bool m_debugAssertBreak;
     bool m_settingsPathSet; // has --settingsPath been set on command line ?
+    bool m_isPortable; // if we run portable, we shouldn't try to access outside our directory
     mixxx::LogLevel m_logLevel; // Level of stderr logging message verbosity
     mixxx::LogLevel m_logFlushLevel; // Level of mixx.log file flushing
     QString m_locale;


### PR DESCRIPTION
This PR add a portable mode to Mixxx (lp:1731689).

The portable mode is triggered if Mixxx executable is named `mixxx-portable` (case-insensitive and without extension, thus working with `Mixxx-portable` under MacOSX and `mixxx-portable.exe` under windows).
The portable mode can also be triggered with new command-line argument `--portable`

When in portable mode, Mixxx will not try to access (for reading or writing) to resources or settings outside of specified directories.
Default settings directory in portable mode is a subdirectory `mixxx-settings` in the same place where the Mixxx-portable executable resides. This can be overwritten with the usual `--settingsPath` command-line argument.
Default resources directory in portable mode is a subdirectory `mixxx-resources` in the same place where the Mixxx-portable executable resides. This can be overwritten with the usual `--resourcePath` command-line argument.

In portable mode, no attempt will be made to migrate old settings from standard folders to avoid any interaction outside Mixxx directory

I also added a `makeportable` target to scons producing a portable archive using 7-zip and configured appveyor to produce portable archives and store them as artifact.

This PR doesn't address Music/tracks folders. This will be added in a future PR