### PR TITLE
Add mixed version of OpenKey/Lancelot notation

### DIFF
--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -79,8 +79,12 @@ DlgPrefKey::DlgPrefKey(QWidget* parent, UserSettingsPointer pConfig)
 
     connect(radioNotationOpenKey, SIGNAL(toggled(bool)),
             this, SLOT(setNotationOpenKey(bool)));
+    connect(radioNotationOpenKeyMixed, SIGNAL(toggled(bool)),
+            this, SLOT(setNotationOpenKeyMixed(bool)));
     connect(radioNotationLancelot, SIGNAL(toggled(bool)),
             this, SLOT(setNotationLancelot(bool)));
+    connect(radioNotationLancelotMixed, SIGNAL(toggled(bool)),
+            this, SLOT(setNotationLancelotMixed(bool)));
     connect(radioNotationTraditional, SIGNAL(toggled(bool)),
             this, SLOT(setNotationTraditional(bool)));
     connect(radioNotationCustom, SIGNAL(toggled(bool)),
@@ -102,9 +106,15 @@ void DlgPrefKey::loadSettings() {
     if (notation == KEY_NOTATION_OPEN_KEY) {
         radioNotationOpenKey->setChecked(true);
         setNotationOpenKey(true);
+    } else if (notation == KEY_NOTATION_OPEN_KEY_MIXED) {
+        radioNotationOpenKeyMixed->setChecked(true);
+        setNotationOpenKeyMixed(true);
     } else if (notation == KEY_NOTATION_LANCELOT) {
         radioNotationLancelot->setChecked(true);
         setNotationLancelot(true);
+    } else if (notation == KEY_NOTATION_LANCELOT_MIXED) {
+        radioNotationLancelotMixed->setChecked(true);
+        setNotationLancelotMixed(true);
     } else if (notation == KEY_NOTATION_TRADITIONAL) {
         radioNotationTraditional->setChecked(true);
         setNotationTraditional(true);
@@ -192,6 +202,12 @@ void DlgPrefKey::slotApply() {
         if (radioNotationOpenKey->isChecked()) {
             notation_name = KEY_NOTATION_OPEN_KEY;
             notation_type = KeyUtils::OPEN_KEY;
+        } else if (radioNotationOpenKeyMixed->isChecked()) {
+            notation_name = KEY_NOTATION_OPEN_KEY_MIXED;
+            notation_type = KeyUtils::OPEN_KEY_MIXED;
+        } else if (radioNotationLancelotMixed->isChecked()) {
+            notation_name = KEY_NOTATION_LANCELOT_MIXED;
+            notation_type = KeyUtils::LANCELOT_MIXED;
         } else if (radioNotationTraditional->isChecked()) {
             notation_name = KEY_NOTATION_TRADITIONAL;
             notation_type = KeyUtils::TRADITIONAL;
@@ -269,8 +285,20 @@ void DlgPrefKey::setNotationOpenKey(bool active) {
     }
 }
 
+void DlgPrefKey::setNotationOpenKeyMixed(bool active) {
+    if (active) {
+        setNotation(KeyUtils::OPEN_KEY_MIXED);
+    }
+}
+
 void DlgPrefKey::setNotationLancelot(bool active) {
     if (active) {
         setNotation(KeyUtils::LANCELOT);
+    }
+}
+
+void DlgPrefKey::setNotationLancelotMixed(bool active) {
+    if (active) {
+        setNotation(KeyUtils::LANCELOT_MIXED);
     }
 }

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -106,13 +106,13 @@ void DlgPrefKey::loadSettings() {
     if (notation == KEY_NOTATION_OPEN_KEY) {
         radioNotationOpenKey->setChecked(true);
         setNotationOpenKey(true);
-    } else if (notation == KEY_NOTATION_OPEN_KEY_TRADITIONAL) {
+    } else if (notation == KEY_NOTATION_OPEN_KEY_AND_TRADITIONAL) {
         radioNotationOpenKeyTraditional->setChecked(true);
         setNotationOpenKeyTraditional(true);
     } else if (notation == KEY_NOTATION_LANCELOT) {
         radioNotationLancelot->setChecked(true);
         setNotationLancelot(true);
-    } else if (notation == KEY_NOTATION_LANCELOT_TRADITIONAL) {
+    } else if (notation == KEY_NOTATION_LANCELOT_AND_TRADITIONAL) {
         radioNotationLancelotTraditional->setChecked(true);
         setNotationLancelotTraditional(true);
     } else if (notation == KEY_NOTATION_TRADITIONAL) {
@@ -203,11 +203,11 @@ void DlgPrefKey::slotApply() {
             notation_name = KEY_NOTATION_OPEN_KEY;
             notation_type = KeyUtils::OPEN_KEY;
         } else if (radioNotationOpenKeyTraditional->isChecked()) {
-            notation_name = KEY_NOTATION_OPEN_KEY_TRADITIONAL;
-            notation_type = KeyUtils::OPEN_KEY_TRADITIONAL;
+            notation_name = KEY_NOTATION_OPEN_KEY_AND_TRADITIONAL;
+            notation_type = KeyUtils::OPEN_KEY_AND_TRADITIONAL;
         } else if (radioNotationLancelotTraditional->isChecked()) {
-            notation_name = KEY_NOTATION_LANCELOT_TRADITIONAL;
-            notation_type = KeyUtils::LANCELOT_TRADITIONAL;
+            notation_name = KEY_NOTATION_LANCELOT_AND_TRADITIONAL;
+            notation_type = KeyUtils::LANCELOT_AND_TRADITIONAL;
         } else if (radioNotationTraditional->isChecked()) {
             notation_name = KEY_NOTATION_TRADITIONAL;
             notation_type = KeyUtils::TRADITIONAL;
@@ -287,7 +287,7 @@ void DlgPrefKey::setNotationOpenKey(bool active) {
 
 void DlgPrefKey::setNotationOpenKeyTraditional(bool active) {
     if (active) {
-        setNotation(KeyUtils::OPEN_KEY_TRADITIONAL);
+        setNotation(KeyUtils::OPEN_KEY_AND_TRADITIONAL);
     }
 }
 
@@ -299,6 +299,6 @@ void DlgPrefKey::setNotationLancelot(bool active) {
 
 void DlgPrefKey::setNotationLancelotTraditional(bool active) {
     if (active) {
-        setNotation(KeyUtils::LANCELOT_TRADITIONAL);
+        setNotation(KeyUtils::LANCELOT_AND_TRADITIONAL);
     }
 }

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -79,12 +79,12 @@ DlgPrefKey::DlgPrefKey(QWidget* parent, UserSettingsPointer pConfig)
 
     connect(radioNotationOpenKey, SIGNAL(toggled(bool)),
             this, SLOT(setNotationOpenKey(bool)));
-    connect(radioNotationOpenKeyMixed, SIGNAL(toggled(bool)),
-            this, SLOT(setNotationOpenKeyMixed(bool)));
+    connect(radioNotationOpenKeyTraditional, SIGNAL(toggled(bool)),
+            this, SLOT(setNotationOpenKeyTraditional(bool)));
     connect(radioNotationLancelot, SIGNAL(toggled(bool)),
             this, SLOT(setNotationLancelot(bool)));
-    connect(radioNotationLancelotMixed, SIGNAL(toggled(bool)),
-            this, SLOT(setNotationLancelotMixed(bool)));
+    connect(radioNotationLancelotTraditional, SIGNAL(toggled(bool)),
+            this, SLOT(setNotationLancelotTraditional(bool)));
     connect(radioNotationTraditional, SIGNAL(toggled(bool)),
             this, SLOT(setNotationTraditional(bool)));
     connect(radioNotationCustom, SIGNAL(toggled(bool)),
@@ -106,15 +106,15 @@ void DlgPrefKey::loadSettings() {
     if (notation == KEY_NOTATION_OPEN_KEY) {
         radioNotationOpenKey->setChecked(true);
         setNotationOpenKey(true);
-    } else if (notation == KEY_NOTATION_OPEN_KEY_MIXED) {
-        radioNotationOpenKeyMixed->setChecked(true);
-        setNotationOpenKeyMixed(true);
+    } else if (notation == KEY_NOTATION_OPEN_KEY_TRADITIONAL) {
+        radioNotationOpenKeyTraditional->setChecked(true);
+        setNotationOpenKeyTraditional(true);
     } else if (notation == KEY_NOTATION_LANCELOT) {
         radioNotationLancelot->setChecked(true);
         setNotationLancelot(true);
-    } else if (notation == KEY_NOTATION_LANCELOT_MIXED) {
-        radioNotationLancelotMixed->setChecked(true);
-        setNotationLancelotMixed(true);
+    } else if (notation == KEY_NOTATION_LANCELOT_TRADITIONAL) {
+        radioNotationLancelotTraditional->setChecked(true);
+        setNotationLancelotTraditional(true);
     } else if (notation == KEY_NOTATION_TRADITIONAL) {
         radioNotationTraditional->setChecked(true);
         setNotationTraditional(true);
@@ -202,12 +202,12 @@ void DlgPrefKey::slotApply() {
         if (radioNotationOpenKey->isChecked()) {
             notation_name = KEY_NOTATION_OPEN_KEY;
             notation_type = KeyUtils::OPEN_KEY;
-        } else if (radioNotationOpenKeyMixed->isChecked()) {
-            notation_name = KEY_NOTATION_OPEN_KEY_MIXED;
-            notation_type = KeyUtils::OPEN_KEY_MIXED;
-        } else if (radioNotationLancelotMixed->isChecked()) {
-            notation_name = KEY_NOTATION_LANCELOT_MIXED;
-            notation_type = KeyUtils::LANCELOT_MIXED;
+        } else if (radioNotationOpenKeyTraditional->isChecked()) {
+            notation_name = KEY_NOTATION_OPEN_KEY_TRADITIONAL;
+            notation_type = KeyUtils::OPEN_KEY_TRADITIONAL;
+        } else if (radioNotationLancelotTraditional->isChecked()) {
+            notation_name = KEY_NOTATION_LANCELOT_TRADITIONAL;
+            notation_type = KeyUtils::LANCELOT_TRADITIONAL;
         } else if (radioNotationTraditional->isChecked()) {
             notation_name = KEY_NOTATION_TRADITIONAL;
             notation_type = KeyUtils::TRADITIONAL;
@@ -285,9 +285,9 @@ void DlgPrefKey::setNotationOpenKey(bool active) {
     }
 }
 
-void DlgPrefKey::setNotationOpenKeyMixed(bool active) {
+void DlgPrefKey::setNotationOpenKeyTraditional(bool active) {
     if (active) {
-        setNotation(KeyUtils::OPEN_KEY_MIXED);
+        setNotation(KeyUtils::OPEN_KEY_TRADITIONAL);
     }
 }
 
@@ -297,8 +297,8 @@ void DlgPrefKey::setNotationLancelot(bool active) {
     }
 }
 
-void DlgPrefKey::setNotationLancelotMixed(bool active) {
+void DlgPrefKey::setNotationLancelotTraditional(bool active) {
     if (active) {
-        setNotation(KeyUtils::LANCELOT_MIXED);
+        setNotation(KeyUtils::LANCELOT_TRADITIONAL);
     }
 }

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -79,12 +79,12 @@ DlgPrefKey::DlgPrefKey(QWidget* parent, UserSettingsPointer pConfig)
 
     connect(radioNotationOpenKey, SIGNAL(toggled(bool)),
             this, SLOT(setNotationOpenKey(bool)));
-    connect(radioNotationOpenKeyTraditional, SIGNAL(toggled(bool)),
-            this, SLOT(setNotationOpenKeyTraditional(bool)));
+    connect(radioNotationOpenKeyAndTraditional, SIGNAL(toggled(bool)),
+            this, SLOT(setNotationOpenKeyAndTraditional(bool)));
     connect(radioNotationLancelot, SIGNAL(toggled(bool)),
             this, SLOT(setNotationLancelot(bool)));
-    connect(radioNotationLancelotTraditional, SIGNAL(toggled(bool)),
-            this, SLOT(setNotationLancelotTraditional(bool)));
+    connect(radioNotationLancelotAndTraditional, SIGNAL(toggled(bool)),
+            this, SLOT(setNotationLancelotAndTraditional(bool)));
     connect(radioNotationTraditional, SIGNAL(toggled(bool)),
             this, SLOT(setNotationTraditional(bool)));
     connect(radioNotationCustom, SIGNAL(toggled(bool)),
@@ -107,14 +107,14 @@ void DlgPrefKey::loadSettings() {
         radioNotationOpenKey->setChecked(true);
         setNotationOpenKey(true);
     } else if (notation == KEY_NOTATION_OPEN_KEY_AND_TRADITIONAL) {
-        radioNotationOpenKeyTraditional->setChecked(true);
-        setNotationOpenKeyTraditional(true);
+        radioNotationOpenKeyAndTraditional->setChecked(true);
+        setNotationOpenKeyAndTraditional(true);
     } else if (notation == KEY_NOTATION_LANCELOT) {
         radioNotationLancelot->setChecked(true);
         setNotationLancelot(true);
     } else if (notation == KEY_NOTATION_LANCELOT_AND_TRADITIONAL) {
-        radioNotationLancelotTraditional->setChecked(true);
-        setNotationLancelotTraditional(true);
+        radioNotationLancelotAndTraditional->setChecked(true);
+        setNotationLancelotAndTraditional(true);
     } else if (notation == KEY_NOTATION_TRADITIONAL) {
         radioNotationTraditional->setChecked(true);
         setNotationTraditional(true);
@@ -202,10 +202,10 @@ void DlgPrefKey::slotApply() {
         if (radioNotationOpenKey->isChecked()) {
             notation_name = KEY_NOTATION_OPEN_KEY;
             notation_type = KeyUtils::OPEN_KEY;
-        } else if (radioNotationOpenKeyTraditional->isChecked()) {
+        } else if (radioNotationOpenKeyAndTraditional->isChecked()) {
             notation_name = KEY_NOTATION_OPEN_KEY_AND_TRADITIONAL;
             notation_type = KeyUtils::OPEN_KEY_AND_TRADITIONAL;
-        } else if (radioNotationLancelotTraditional->isChecked()) {
+        } else if (radioNotationLancelotAndTraditional->isChecked()) {
             notation_name = KEY_NOTATION_LANCELOT_AND_TRADITIONAL;
             notation_type = KeyUtils::LANCELOT_AND_TRADITIONAL;
         } else if (radioNotationTraditional->isChecked()) {
@@ -285,7 +285,7 @@ void DlgPrefKey::setNotationOpenKey(bool active) {
     }
 }
 
-void DlgPrefKey::setNotationOpenKeyTraditional(bool active) {
+void DlgPrefKey::setNotationOpenKeyAndTraditional(bool active) {
     if (active) {
         setNotation(KeyUtils::OPEN_KEY_AND_TRADITIONAL);
     }
@@ -297,7 +297,7 @@ void DlgPrefKey::setNotationLancelot(bool active) {
     }
 }
 
-void DlgPrefKey::setNotationLancelotTraditional(bool active) {
+void DlgPrefKey::setNotationLancelotAndTraditional(bool active) {
     if (active) {
         setNotation(KeyUtils::LANCELOT_AND_TRADITIONAL);
     }

--- a/src/preferences/dialog/dlgprefkey.h
+++ b/src/preferences/dialog/dlgprefkey.h
@@ -33,9 +33,9 @@ class DlgPrefKey : public DlgPreferencePage, Ui::DlgPrefKeyDlg {
 
     void setNotation(KeyUtils::KeyNotation notation);
     void setNotationOpenKey(bool);
-    void setNotationOpenKeyTraditional(bool);
+    void setNotationOpenKeyAndTraditional(bool);
     void setNotationLancelot(bool);
-    void setNotationLancelotTraditional(bool);
+    void setNotationLancelotAndTraditional(bool);
     void setNotationTraditional(bool);
     void setNotationCustom(bool);
 

--- a/src/preferences/dialog/dlgprefkey.h
+++ b/src/preferences/dialog/dlgprefkey.h
@@ -33,9 +33,9 @@ class DlgPrefKey : public DlgPreferencePage, Ui::DlgPrefKeyDlg {
 
     void setNotation(KeyUtils::KeyNotation notation);
     void setNotationOpenKey(bool);
-    void setNotationOpenKeyMixed(bool);
+    void setNotationOpenKeyTraditional(bool);
     void setNotationLancelot(bool);
-    void setNotationLancelotMixed(bool);
+    void setNotationLancelotTraditional(bool);
     void setNotationTraditional(bool);
     void setNotationCustom(bool);
 

--- a/src/preferences/dialog/dlgprefkey.h
+++ b/src/preferences/dialog/dlgprefkey.h
@@ -33,7 +33,9 @@ class DlgPrefKey : public DlgPreferencePage, Ui::DlgPrefKeyDlg {
 
     void setNotation(KeyUtils::KeyNotation notation);
     void setNotationOpenKey(bool);
+    void setNotationOpenKeyMixed(bool);
     void setNotationLancelot(bool);
+    void setNotationLancelotMixed(bool);
     void setNotationTraditional(bool);
     void setNotationCustom(bool);
 

--- a/src/preferences/dialog/dlgprefkeydlg.ui
+++ b/src/preferences/dialog/dlgprefkeydlg.ui
@@ -123,9 +123,23 @@ and allows you to pitch adjust them for harmonic mixing.</string>
          </widget>
         </item>
         <item>
+         <widget class="QRadioButton" name="radioNotationLancelotMixed">
+          <property name="text">
+            <string>Lancelot/Traditional</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QRadioButton" name="radioNotationOpenKey">
           <property name="text">
            <string>OpenKey</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioNotationOpenKeyMixed">
+          <property name="text">
+            <string>OpenKey/Traditional</string>
           </property>
          </widget>
         </item>

--- a/src/preferences/dialog/dlgprefkeydlg.ui
+++ b/src/preferences/dialog/dlgprefkeydlg.ui
@@ -123,7 +123,7 @@ and allows you to pitch adjust them for harmonic mixing.</string>
          </widget>
         </item>
         <item>
-         <widget class="QRadioButton" name="radioNotationLancelotTraditional">
+         <widget class="QRadioButton" name="radioNotationLancelotAndTraditional">
           <property name="text">
             <string>Lancelot/Traditional</string>
           </property>
@@ -137,7 +137,7 @@ and allows you to pitch adjust them for harmonic mixing.</string>
          </widget>
         </item>
         <item>
-         <widget class="QRadioButton" name="radioNotationOpenKeyTraditional">
+         <widget class="QRadioButton" name="radioNotationOpenKeyAndTraditional">
           <property name="text">
             <string>OpenKey/Traditional</string>
           </property>

--- a/src/preferences/dialog/dlgprefkeydlg.ui
+++ b/src/preferences/dialog/dlgprefkeydlg.ui
@@ -123,7 +123,7 @@ and allows you to pitch adjust them for harmonic mixing.</string>
          </widget>
         </item>
         <item>
-         <widget class="QRadioButton" name="radioNotationLancelotMixed">
+         <widget class="QRadioButton" name="radioNotationLancelotTraditional">
           <property name="text">
             <string>Lancelot/Traditional</string>
           </property>
@@ -137,7 +137,7 @@ and allows you to pitch adjust them for harmonic mixing.</string>
          </widget>
         </item>
         <item>
-         <widget class="QRadioButton" name="radioNotationOpenKeyMixed">
+         <widget class="QRadioButton" name="radioNotationOpenKeyTraditional">
           <property name="text">
             <string>OpenKey/Traditional</string>
           </property>

--- a/src/preferences/keydetectionsettings.h
+++ b/src/preferences/keydetectionsettings.h
@@ -20,7 +20,9 @@
 
 #define KEY_NOTATION "KeyNotation"
 #define KEY_NOTATION_OPEN_KEY "OpenKey"
+#define KEY_NOTATION_OPEN_KEY_AND_TRADITIONAL "OpenKey/Traditional"
 #define KEY_NOTATION_LANCELOT "Lancelot"
+#define KEY_NOTATION_LANCELOT_AND_TRADITIONAL "Lancelot/Traditional"
 #define KEY_NOTATION_TRADITIONAL "Traditional"
 #define KEY_NOTATION_CUSTOM "Custom"
 #define KEY_NOTATION_CUSTOM_PREFIX "CustomKeyNotation"

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -215,7 +215,7 @@ QString KeyUtils::keyToString(ChromaticKey key,
         bool major = keyIsMajor(key);
         int number = keyToOpenKeyNumber(key);
         return QString::number(number) + (major ? "d" : "m");
-    } else if (notation == OPEN_KEY_TRADITIONAL) {
+    } else if (notation == OPEN_KEY_AND_TRADITIONAL) {
         bool major = keyIsMajor(key);
         int number = keyToOpenKeyNumber(key);
         QString trad = s_traditionalKeyNames[static_cast<int>(key)];
@@ -224,7 +224,7 @@ QString KeyUtils::keyToString(ChromaticKey key,
         bool major = keyIsMajor(key);
         int number = openKeyNumberToLancelotNumber(keyToOpenKeyNumber(key));
         return QString::number(number) + (major ? "B" : "A");
-    } else if (notation == LANCELOT_TRADITIONAL) {
+    } else if (notation == LANCELOT_AND_TRADITIONAL) {
         bool major = keyIsMajor(key);
         int number = openKeyNumberToLancelotNumber(keyToOpenKeyNumber(key));
         QString trad = s_traditionalKeyNames[static_cast<int>(key)];

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -215,20 +215,20 @@ QString KeyUtils::keyToString(ChromaticKey key,
         bool major = keyIsMajor(key);
         int number = keyToOpenKeyNumber(key);
         return QString::number(number) + (major ? "d" : "m");
-    } else if (notation == OPEN_KEY_MIXED) {
+    } else if (notation == OPEN_KEY_TRADITIONAL) {
         bool major = keyIsMajor(key);
         int number = keyToOpenKeyNumber(key);
         QString trad = s_traditionalKeyNames[static_cast<int>(key)];
-        return QString::number(number) + (major ? "d" : "m") + "/" + trad;
+        return QString::number(number) + (major ? "d" : "m") + " (" + trad + ")";
     } else if (notation == LANCELOT) {
         bool major = keyIsMajor(key);
         int number = openKeyNumberToLancelotNumber(keyToOpenKeyNumber(key));
         return QString::number(number) + (major ? "B" : "A");
-    } else if (notation == LANCELOT_MIXED) {
+    } else if (notation == LANCELOT_TRADITIONAL) {
         bool major = keyIsMajor(key);
         int number = openKeyNumberToLancelotNumber(keyToOpenKeyNumber(key));
         QString trad = s_traditionalKeyNames[static_cast<int>(key)];
-        return QString::number(number) + (major ? "B" : "A") + "/" + trad;
+        return QString::number(number) + (major ? "B" : "A") + " (" + trad + ")";
     } else if (notation == TRADITIONAL) {
         return s_traditionalKeyNames[static_cast<int>(key)];
     }

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -215,10 +215,20 @@ QString KeyUtils::keyToString(ChromaticKey key,
         bool major = keyIsMajor(key);
         int number = keyToOpenKeyNumber(key);
         return QString::number(number) + (major ? "d" : "m");
+    } else if (notation == OPEN_KEY_MIXED) {
+        bool major = keyIsMajor(key);
+        int number = keyToOpenKeyNumber(key);
+        QString trad = s_traditionalKeyNames[static_cast<int>(key)];
+        return QString::number(number) + (major ? "d" : "m") + "/" + trad;
     } else if (notation == LANCELOT) {
         bool major = keyIsMajor(key);
         int number = openKeyNumberToLancelotNumber(keyToOpenKeyNumber(key));
         return QString::number(number) + (major ? "B" : "A");
+    } else if (notation == LANCELOT_MIXED) {
+        bool major = keyIsMajor(key);
+        int number = openKeyNumberToLancelotNumber(keyToOpenKeyNumber(key));
+        QString trad = s_traditionalKeyNames[static_cast<int>(key)];
+        return QString::number(number) + (major ? "B" : "A") + "/" + trad;
     } else if (notation == TRADITIONAL) {
         return s_traditionalKeyNames[static_cast<int>(key)];
     }

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -16,9 +16,9 @@ class KeyUtils {
         INVALID = 0,
         CUSTOM = 1,
         OPEN_KEY = 2,
-        OPEN_KEY_MIXED = 3,
+        OPEN_KEY_TRADITIONAL = 3,
         LANCELOT = 4,
-        LANCELOT_MIXED = 5,
+        LANCELOT_TRADITIONAL = 5,
         TRADITIONAL = 6,
         KEY_NOTATION_MAX
     };

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -16,9 +16,9 @@ class KeyUtils {
         INVALID = 0,
         CUSTOM = 1,
         OPEN_KEY = 2,
-        OPEN_KEY_TRADITIONAL = 3,
+        OPEN_KEY_AND_TRADITIONAL = 3,
         LANCELOT = 4,
-        LANCELOT_TRADITIONAL = 5,
+        LANCELOT_AND_TRADITIONAL = 5,
         TRADITIONAL = 6,
         KEY_NOTATION_MAX
     };

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -16,10 +16,10 @@ class KeyUtils {
         INVALID = 0,
         CUSTOM = 1,
         OPEN_KEY = 2,
-        OPEN_KEY_AND_TRADITIONAL = 3,
-        LANCELOT = 4,
-        LANCELOT_AND_TRADITIONAL = 5,
-        TRADITIONAL = 6,
+        LANCELOT = 3,
+        TRADITIONAL = 4,
+        OPEN_KEY_AND_TRADITIONAL = 5,
+        LANCELOT_AND_TRADITIONAL = 6,
         KEY_NOTATION_MAX
     };
 

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -16,8 +16,10 @@ class KeyUtils {
         INVALID = 0,
         CUSTOM = 1,
         OPEN_KEY = 2,
-        LANCELOT = 3,
-        TRADITIONAL = 4,
+        OPEN_KEY_MIXED = 3,
+        LANCELOT = 4,
+        LANCELOT_MIXED = 5,
+        TRADITIONAL = 6,
         KEY_NOTATION_MAX
     };
 

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -162,7 +162,7 @@ void Track::setTrackMetadata(
         setBpm(actualBpm.getValue());
     }
 
-    if (!newKey.isEmpty()) {
+    if (!newKey.isEmpty() && newKey != mixxx::track::io::key::INVALID) {
         setKeyText(newKey, mixxx::track::io::key::FILE_METADATA);
     }
 }

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -22,8 +22,7 @@ bool TrackRecord::updateGlobalKey(
         mixxx::track::io::key::ChromaticKey key,
         mixxx::track::io::key::Source keySource) {
     if (key == mixxx::track::io::key::INVALID) {
-        resetKeys();
-        return true;
+        return false;
     } else {
         Keys keys = KeyFactory::makeBasicKeys(key, keySource);
         if (m_keys.getGlobalKey() != keys.getGlobalKey()) {
@@ -39,8 +38,7 @@ bool TrackRecord::updateGlobalKeyText(
         mixxx::track::io::key::Source keySource) {
     Keys keys = KeyFactory::makeBasicKeysFromText(keyText, keySource);
     if (keys.getGlobalKey() == mixxx::track::io::key::INVALID) {
-        resetKeys();
-        return true;
+        return false;
     } else {
         if (m_keys.getGlobalKey() != keys.getGlobalKey()) {
             setKeys(keys);


### PR DESCRIPTION
This adds two mixed versions of key notation - an OpenKey/Traditional version, and a Lancelot/Traditional version.

I find these really useful because the OpenKey/Lancelot notation is nice for sorting and quickly finding tracks to mix with, while the traditional notation is nicer for finding tracks to mix with if you're planning on pitch shifting (e.g. you can pitch a 130 BPM track in E up to 138BPM in F, then mix with something near F at 140BPM).

Fundamentally this doesn't change any functionality, just gives some more default key notation options (I think - I haven't worked with C++ much.. needs review)
