### PR TITLE
Remove runtime dynamic loading of libmp3lame in favor of compile-time linking.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
       - libid3tag0-dev
       - libmad0-dev
       - libmodplug-dev
+      - libmp3lame-dev
       - libmp4v2-dev
       - libopusfile-dev
       - libportmidi-dev
@@ -56,7 +57,7 @@ before_install:
   # Homebrew uses Python 3 now, and portmidi depends on Python 2 which triggers this bug:
   # https://github.com/Homebrew/homebrew-core/issues/26358
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade python ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install scons portaudio libsndfile libogg libvorbis portmidi taglib libshout protobuf flac ffmpeg qt chromaprint rubberband fftw libmodplug libid3tag libmad mp4v2 faad2 wavpack opusfile lilv; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install scons portaudio libsndfile libogg libvorbis portmidi taglib libshout protobuf flac ffmpeg qt chromaprint rubberband fftw libmodplug libid3tag libmad mp4v2 faad2 wavpack opusfile lilv lame; fi
 
 install:
   ####

--- a/build/depends.py
+++ b/build/depends.py
@@ -697,6 +697,11 @@ class QtKeychain(Dependence):
         if not conf.CheckLib(lib):
             raise Exception("Could not find %s." % lib)
 
+class LAME(Dependence):
+    def configure(self, build, conf):
+        if not conf.CheckLib(['libmp3lame', 'libmp3lame-static']):
+            raise Exception("Could not find libmp3lame.")
+
 class MixxxCore(Feature):
 
     def description(self):
@@ -1509,7 +1514,7 @@ class MixxxCore(Feature):
         return [SoundTouch, ReplayGain, Ebur128Mit, PortAudio, PortMIDI, Qt, TestHeaders,
                 FidLib, SndFile, FLAC, OggVorbis, OpenGL, TagLib, ProtoBuf,
                 Chromaprint, RubberBand, SecurityFramework, CoreServices, IOKit,
-                QtScriptByteArray, Reverb, FpClassify, PortAudioRingBuffer]
+                QtScriptByteArray, Reverb, FpClassify, PortAudioRingBuffer, LAME]
 
     def post_dependency_check_configure(self, build, conf):
         """Sets up additional things in the Environment that must happen

--- a/src/encoder/encodermp3.cpp
+++ b/src/encoder/encodermp3.cpp
@@ -1,19 +1,3 @@
-/****************************************************************************
-                   encodermp3.cpp  - mp3 encoder for mixxx
-                             -------------------
-    copyright            : (C) 2007 by Wesley Stessens
-                           (C) 2009 by Phillip Whelan (rewritten for mp3)
-                           (C) 2010 by Tobias Rafreider (fixes for broadcast, dynamic loading of lame_enc.dll, etc)
-
-    Libmp3lame API:
-    http://lame.cvs.sourceforge.net/viewvc/lame/lame/API?view=markup
-    http://lame.cvs.sourceforge.net/viewvc/lame/lame/include/lame.h?view=markup
-
-    Older BladeEncDll API:
-    http://lame.cvs.sourceforge.net/viewvc/lame/lame/Dll/BladeMP3EncDLL.h?view=markup
-
-*****************************************************************************/
-
 #include <QtDebug>
 #include <QObject>
 #include <limits.h>
@@ -21,7 +5,6 @@
 #include "encoder/encodermp3.h"
 #include "encoder/encodermp3settings.h"
 #include "encoder/encodercallback.h"
-#include "errordialoghandler.h"
 
 // Automatic thresholds for switching the encoder to mono
 // They have been chosen by testing and to keep the same number
@@ -38,221 +21,21 @@ const int EncoderMp3::MONO_VBR_OFFSET = 4;
 
 
 EncoderMp3::EncoderMp3(EncoderCallback* pCallback)
-  : m_lameFlags(nullptr),
-    m_bitrate(128),
-    m_bufferOut(nullptr),
-    m_bufferOutSize(0),
-    /*
-     * @ Author: Tobias Rafreider
-     * Nobody has initialized the field before my code review.  At runtime the
-     * Integer field was inialized by a large random value such that the
-     * following pointer fields were never initialized in the methods
-     * 'bufferOutGrow()' and 'bufferInGrow()' --> Valgrind shows invalid writes
-     * :-)
-     *
-     * m_bufferOut = (unsigned char *)realloc(m_bufferOut, size);
-     * m_bufferIn[0] = (float *)realloc(m_bufferIn[0], size * sizeof(float));
-     * m_bufferIn[1] = (float *)realloc(m_bufferIn[1], size * sizeof(float));
-     *
-     * This has solved many segfaults when using and even closing broadcast
-     * along with LAME.  This bug was detected by using Valgrind memory analyzer
-     *
-     */
-    m_bufferInSize(0),
-    m_pCallback(pCallback),
-    m_library(nullptr) {
-    m_bufferIn[0] = nullptr;
-    m_bufferIn[1] = nullptr;
-
-    //These are the function pointers for lame
-    lame_init = nullptr;
-    lame_set_num_channels = nullptr;
-    lame_set_in_samplerate = nullptr;
-    lame_set_out_samplerate = nullptr;
-    lame_close = nullptr;
-    lame_set_brate = nullptr;
-    lame_set_mode = nullptr;
-    lame_set_quality = nullptr;
-    lame_set_bWriteVbrTag = nullptr;
-    lame_encode_buffer_float = nullptr;
-    lame_init_params = nullptr;
-    lame_encode_flush = nullptr;
-    lame_set_VBR = nullptr;
-    lame_set_VBR_q = nullptr;
-    lame_set_VBR_quality = nullptr;
-    lame_set_VBR_mean_bitrate_kbps = nullptr;
-    lame_encode_buffer_interleaved_ieee_float = nullptr;
-    lame_get_lametag_frame = nullptr;
-
-    id3tag_init = nullptr;
-    id3tag_set_title = nullptr;
-    id3tag_set_artist = nullptr;
-    id3tag_set_album = nullptr;
-    id3tag_add_v2 = nullptr;
-
-    /*
-     * Load shared library
-     */
-    QStringList libnames;
-    QString libname = "";
-#ifdef __LINUX__
-    libnames << "mp3lame";
-#elif __WINDOWS__
-    libnames << "lame_enc.dll";
-    libnames << "libmp3lame.dll";
-#elif __APPLE__
-    libnames << "/usr/local/lib/libmp3lame.dylib";
-    //Using MacPorts (former DarwinPorts) results in ...
-    libnames << "/opt/local/lib/libmp3lame.dylib";
-#endif
-
-    for (const auto& libname : libnames) {
-        m_library = new QLibrary(libname, 0);
-        if (m_library->load()) {
-            qDebug() << "Successfully loaded encoder library " << libname;
-            break;
-        } else {
-            qWarning() << "Failed to load " << libname << ", " << m_library->errorString();
-        }
-        delete m_library;
-        m_library = nullptr;
-    }
-
-    if (!m_library || !m_library->isLoaded()) {
-        ErrorDialogProperties* props = ErrorDialogHandler::instance()->newDialogProperties();
-        props->setType(DLG_WARNING);
-        props->setTitle(QObject::tr("Encoder"));
-        QString missingCodec = QObject::tr("<html>Mixxx cannot record or stream in MP3 without the MP3 encoder &quot;lame&quot;. Due to licensing issues, we cannot include this with Mixxx. To record or stream in MP3, you must download <b>libmp3lame</b> and install it on your system. <p>See <a href='http://mixxx.org/wiki/doku.php/internet_broadcasting#%1'>Mixxx Wiki</a> for more information. </html>");
-
-#ifdef __LINUX__
-        missingCodec = missingCodec.arg("linux");
-#elif __WINDOWS__
-        missingCodec = missingCodec.arg("windows");
-#elif __APPLE__
-        missingCodec = missingCodec.arg("mac_osx");
-#endif
-        props->setText(missingCodec);
-        props->setKey(missingCodec);
-        ErrorDialogHandler::instance()->requestErrorDialog(props);
-        return;
-    }
-
-    typedef const char* (*get_lame_version__)(void);
-    get_lame_version__ get_lame_version = (get_lame_version__)m_library->resolve("get_lame_version");
-
-
-    // initialize function pointers
-    lame_init                   = (lame_init__)m_library->resolve("lame_init");
-    lame_set_num_channels       = (lame_set_num_channels__)m_library->resolve("lame_set_num_channels");
-    lame_set_in_samplerate      = (lame_set_in_samplerate__)m_library->resolve("lame_set_in_samplerate");
-    lame_set_out_samplerate     = (lame_set_out_samplerate__)m_library->resolve("lame_set_out_samplerate");
-    lame_close                  = (lame_close__)m_library->resolve("lame_close");
-    lame_set_brate              = (lame_set_brate__)m_library->resolve("lame_set_brate");
-    lame_set_mode               = (lame_set_mode__)m_library->resolve("lame_set_mode");
-    lame_set_quality            = (lame_set_quality__)m_library->resolve("lame_set_quality");
-    lame_set_bWriteVbrTag       = (lame_set_bWriteVbrTag__)m_library->resolve("lame_set_bWriteVbrTag");
-    lame_encode_buffer_float    = (lame_encode_buffer_float__)m_library->resolve("lame_encode_buffer_float");
-    lame_init_params            = (lame_init_params__)m_library->resolve("lame_init_params");
-    lame_encode_flush           = (lame_encode_flush__)m_library->resolve("lame_encode_flush");
-
-    lame_set_VBR                = (lame_set_VBR__)m_library->resolve("lame_set_VBR");
-    lame_set_VBR_q              = (lame_set_VBR_q__)m_library->resolve("lame_set_VBR_q");
-    lame_set_VBR_quality        = (lame_set_VBR_quality__)m_library->resolve("lame_set_VBR_quality");
-
-    lame_set_VBR_mean_bitrate_kbps =
-              (lame_set_VBR_mean_bitrate_kbps__)m_library->resolve("lame_set_VBR_mean_bitrate_kbps");
-    lame_encode_buffer_interleaved_ieee_float =
-              (lame_encode_buffer_interleaved_ieee_float__)m_library->resolve("lame_encode_buffer_interleaved_ieee_float");
-    lame_get_lametag_frame      = (lame_get_lametag_frame__)m_library->resolve("lame_get_lametag_frame");
-
-
-    id3tag_init                 = (id3tag_init__)m_library->resolve("id3tag_init");
-    id3tag_set_title            = (id3tag_set_title__)m_library->resolve("id3tag_set_title");
-    id3tag_set_artist           = (id3tag_set_artist__)m_library->resolve("id3tag_set_artist");
-    id3tag_set_album            = (id3tag_set_album__)m_library->resolve("id3tag_set_album");
-
-    id3tag_add_v2               = (id3tag_add_v2__)m_library->resolve("id3tag_add_v2");;
-
-    /*
-     * Check if all function pointers are not NULL
-     * Otherwise, the lame_enc.dll, libmp3lame.so or libmp3lame.mylib do not comply with the official header lame.h
-     * Indicates a modified lame version
-     *
-     * Should not happen on Linux, but many lame binaries for Windows are modified.
-     */
-    if (!lame_init ||
-        !lame_set_num_channels ||
-        !lame_set_in_samplerate ||
-        !lame_set_out_samplerate ||
-        !lame_close ||
-        !lame_set_brate ||
-        !lame_set_mode ||
-        !lame_set_quality ||
-        !lame_set_bWriteVbrTag ||
-        !lame_encode_buffer_float ||
-        !lame_init_params ||
-        !lame_encode_flush ||
-        !lame_set_VBR ||
-        !lame_set_VBR_q ||
-        !lame_set_VBR_mean_bitrate_kbps ||
-        !lame_get_lametag_frame ||
-        !get_lame_version ||
-        !id3tag_init ||
-        !id3tag_set_title ||
-        !id3tag_set_artist ||
-        !id3tag_set_album)
-    {
-        m_library->unload();
-        delete m_library;
-        m_library = nullptr;
-        //print qDebugs to detect which function pointers are null
-        qDebug() << "lame_init: " << lame_init;
-        qDebug() << "lame_set_num_channels: " << lame_set_num_channels;
-        qDebug() << "lame_set_in_samplerate: " << lame_set_in_samplerate;
-        qDebug() << "lame_set_out_samplerate: " << lame_set_out_samplerate;
-        qDebug() << "lame_close: " << lame_close;
-        qDebug() << "lame_set_brate " << lame_set_brate;
-        qDebug() << "lame_set_mode: " << lame_set_mode;
-        qDebug() << "lame_set_quality: " << lame_set_quality;
-        qDebug() << "lame_set_bWriteVbrTag: " << lame_set_bWriteVbrTag;
-        qDebug() << "lame_encode_buffer_float: " << lame_encode_buffer_float;
-        qDebug() << "lame_init_params: " << lame_init_params;
-        qDebug() << "lame_encode_flush: " << lame_encode_flush;
-        qDebug() << "lame_set_VBR: " << lame_set_VBR;
-        qDebug() << "lame_set_VBR_q: " << lame_set_VBR_q;
-        qDebug() << "lame_set_VBR_mean_bitrate_kbps: " << lame_set_VBR_mean_bitrate_kbps;
-        qDebug() << "get_lame_version: " << get_lame_version;
-        qDebug() << "id3tag_init: " << id3tag_init;
-        qDebug() << "id3tag_set_title : " << id3tag_set_title ;
-        qDebug() << "id3tag_set_artist: " << id3tag_set_artist;
-        qDebug() << "id3tag_set_album  " << id3tag_set_album ;
-
-        ErrorDialogProperties* props = ErrorDialogHandler::instance()->newDialogProperties();
-        props->setType(DLG_WARNING);
-        props->setTitle(QObject::tr("Encoder"));
-        QString key = QObject::tr("<html>Mixxx has detected that you use a modified version of libmp3lame. See <a href='http://mixxx.org/wiki/doku.php/internet_broadcasting'>Mixxx Wiki</a> for more information.</html>");
-        props->setText(key);
-        props->setKey(key);
-        ErrorDialogHandler::instance()->requestErrorDialog(props);
-        return;
-    }
-    qDebug() << "Loaded libmp3lame version " << get_lame_version();
-    qDebug() << "lame_set_VBR_quality: " << QString((lame_set_VBR_quality == nullptr) ? "missing" : "present")
-        << " lame_encode_buffer_interleaved_ieee_float: "
-        << QString((lame_encode_buffer_interleaved_ieee_float == nullptr) ? "missing" : "present")
-        << " id3tag_add_v2: " << QString((id3tag_add_v2 == nullptr) ? "missing" : "present");
+        : m_lameFlags(nullptr),
+          m_bitrate(128),
+          m_bufferOut(nullptr),
+          m_bufferOutSize(0),
+          m_bufferIn{nullptr, nullptr},
+          m_bufferInSize(0),
+          m_pCallback(pCallback) {
 }
 
-// Destructor
 EncoderMp3::~EncoderMp3() {
-    if (m_library != nullptr && m_library->isLoaded()) {
-        flush();
+    flush();
+    if (m_lameFlags != nullptr) {
         lame_close(m_lameFlags);
-        m_library->unload(); //unload dll, so, ...
-        qDebug() << "Unloaded libmp3lame ";
-        m_library = nullptr;
     }
-    //free requested buffers
+    // free requested buffers
     if (m_bufferIn[0] != nullptr)
         delete m_bufferIn[0];
     if (m_bufferIn[1] != nullptr)
@@ -261,8 +44,7 @@ EncoderMp3::~EncoderMp3() {
         delete m_bufferOut;
 }
 
-void EncoderMp3::setEncoderSettings(const EncoderSettings& settings)
-{
+void EncoderMp3::setEncoderSettings(const EncoderSettings& settings) {
     m_bitrate = settings.getQuality();
 
     int modeoption = settings.getSelectedOption(EncoderMp3Settings::ENCODING_MODE_GROUP);
@@ -286,41 +68,37 @@ void EncoderMp3::setEncoderSettings(const EncoderSettings& settings)
         }
     }
     // Check if the user has forced a stereo mode.
-    switch(settings.getChannelMode()) {
+    switch (settings.getChannelMode()) {
         case EncoderSettings::ChannelMode::MONO:  m_stereo_mode = MONO; break;
         case EncoderSettings::ChannelMode::STEREO: m_stereo_mode = JOINT_STEREO; break;
         default: break;
     }
 }
 
-/*
- * Grow the outBuffer if needed.
- */
-
 int EncoderMp3::bufferOutGrow(int size) {
-    if (m_bufferOutSize >= size)
+    if (m_bufferOutSize >= size) {
         return 0;
+    }
 
     m_bufferOut = (unsigned char *)realloc(m_bufferOut, size);
-    if (m_bufferOut == nullptr)
+    if (m_bufferOut == nullptr) {
         return -1;
+    }
 
     m_bufferOutSize = size;
     return 0;
 }
 
-/*
- * Grow the inBuffer(s) if needed.
- */
-
 int EncoderMp3::bufferInGrow(int size) {
-    if (m_bufferInSize >= size)
+    if (m_bufferInSize >= size) {
         return 0;
+    }
 
     m_bufferIn[0] = (float *)realloc(m_bufferIn[0], size * sizeof(float));
     m_bufferIn[1] = (float *)realloc(m_bufferIn[1], size * sizeof(float));
-    if ((m_bufferIn[0] == nullptr) || (m_bufferIn[1] == nullptr))
+    if ((m_bufferIn[0] == nullptr) || (m_bufferIn[1] == nullptr)) {
         return -1;
+    }
 
     m_bufferInSize = size;
     return 0;
@@ -329,11 +107,11 @@ int EncoderMp3::bufferInGrow(int size) {
 // Using this method requires to call method 'write()' or 'sendPackages()'
 // depending on which context you use the class (broadcast or recording to HDD)
 void EncoderMp3::flush() {
-    if (m_library == nullptr || !m_library->isLoaded())
+    if (m_lameFlags == nullptr) {
         return;
-    int rc = 0;
-    /**Flush also writes ID3 tags **/
-    rc = lame_encode_flush(m_lameFlags, m_bufferOut, m_bufferOutSize);
+    }
+    // Flush also writes ID3 tags.
+    int rc = lame_encode_flush(m_lameFlags, m_bufferOut, m_bufferOutSize);
     if (rc < 0) {
         return;
     }
@@ -351,8 +129,9 @@ void EncoderMp3::flush() {
 }
 
 void EncoderMp3::encodeBuffer(const CSAMPLE *samples, const int size) {
-    if (m_library == nullptr || !m_library->isLoaded())
+    if (m_lameFlags == nullptr) {
         return;
+    }
     int outsize = 0;
     int rc = 0;
 
@@ -383,15 +162,9 @@ void EncoderMp3::initStream() {
 
     m_bufferIn[0] = (float *)malloc(m_bufferOutSize * sizeof(float));
     m_bufferIn[1] = (float *)malloc(m_bufferOutSize * sizeof(float));
-    return;
 }
 
 int EncoderMp3::initEncoder(int samplerate, QString errorMessage) {
-    if (m_library == nullptr || !m_library->isLoaded()) {
-        errorMessage  = "MP3 recording is not supported. Lame could not be initialized";
-        return -1;
-    }
-
     unsigned long samplerate_in = samplerate;
     // samplerate_out 0 means "let LAME pick the appropriate one"
     unsigned long samplerate_out = (samplerate_in > 48000 ? 48000 : 0);
@@ -399,8 +172,8 @@ int EncoderMp3::initEncoder(int samplerate, QString errorMessage) {
     m_lameFlags = lame_init();
 
     if (m_lameFlags == nullptr) {
-        qDebug() << "Unable to initialize MP3";
-        errorMessage  = "MP3 recording is not supported. Lame could not be initialized";
+        qDebug() << "Unable to initialize lame";
+        errorMessage = "MP3 recording is not supported. Lame could not be initialized";
         return -1;
     }
 
@@ -441,10 +214,10 @@ int EncoderMp3::initEncoder(int samplerate, QString errorMessage) {
         id3tag_set_album(m_lameFlags,m_metaDataAlbum.toLatin1().constData());
     }
 
-    int ret;
-    if ((ret = lame_init_params(m_lameFlags)) < 0) {
+    int ret = lame_init_params(m_lameFlags);
+    if (ret < 0) {
         qDebug() << "Unable to initialize MP3 parameters. return code:" << ret;
-        errorMessage  = "MP3 recording is not supported. Lame could not be initialized.";
+        errorMessage = "MP3 recording is not supported. Lame could not be initialized.";
         return -1;
     }
 

--- a/src/encoder/encodermp3.h
+++ b/src/encoder/encodermp3.h
@@ -1,21 +1,10 @@
-/****************************************************************************
-                   encodermp3.h  - mp3 encoder for mixxx
-                             -------------------
-    copyright            : (C) 2007 by Wesley Stessens
-                           (C) 2009 by Phillip Whelan (rewritten for mp3)
-                           (C) 2010 by Tobias Rafreider (fixes for broadcast, dynamic loading of lame_enc.dll, etc)
- ***************************************************************************/
-
 #ifndef ENCODERMP3_H
 #define ENCODERMP3_H
 
-#include <QLibrary>
+#include <lame/lame.h>
 
 #include "util/types.h"
 #include "encoder/encoder.h"
-#include "track/track.h"
-
-class EncoderCallback;
 
 class EncoderMp3 : public Encoder {
   public:
@@ -23,7 +12,7 @@ class EncoderMp3 : public Encoder {
     static const int MONO_VBR_THRESHOLD;
     static const int MONO_VBR_OFFSET;
 
-    EncoderMp3(EncoderCallback* callback=NULL);
+    EncoderMp3(EncoderCallback* callback=nullptr);
     virtual ~EncoderMp3();
 
     int initEncoder(int samplerate, QString errorMessage) override;
@@ -37,115 +26,7 @@ class EncoderMp3 : public Encoder {
     int bufferOutGrow(int size);
     int bufferInGrow(int size);
 
-    // For lame
-    struct lame_global_struct;
-    typedef struct lame_global_struct lame_global_flags;
-    typedef lame_global_flags *lame_t;
-    lame_global_flags *m_lameFlags;
-    
-    
-    typedef enum vbr_mode_e {
-        vbr_off=0,
-        vbr_mt,               /* obsolete, same as vbr_mtrh */
-        vbr_rh,
-        vbr_abr,
-        vbr_mtrh,
-        vbr_max_indicator,    /* Don't use this! It's used for sanity checks.       */
-        vbr_default=vbr_mtrh    /* change this to change the default VBR mode of LAME */
-    } vbr_mode;
-
-    /* MPEG modes */
-    typedef enum MPEG_mode_e {
-        STEREO = 0,
-        JOINT_STEREO,
-        DUAL_CHANNEL,   /* LAME doesn't supports this! */
-        MONO,
-        NOT_SET,
-        MAX_INDICATOR   /* Don't use this! It's used for sanity checks. */
-    } MPEG_mode;
-
-    //Function pointer for lame
-    typedef lame_global_flags* (*lame_init__)(void);
-    typedef int (*lame_set_num_channels__)(lame_global_flags *, int);
-    typedef int (*lame_set_in_samplerate__)(lame_global_flags *, int);
-    typedef int (*lame_set_out_samplerate__)(lame_global_flags *, int);
-    typedef int (*lame_set_brate__)(lame_global_flags *, int);
-    typedef int (*lame_set_mode__)(lame_global_flags *, MPEG_mode);
-    typedef int (*lame_set_quality__)(lame_global_flags *, int);
-    typedef int (*lame_set_bWriteVbrTag__)(lame_global_flags *, int);
-    typedef int (*lame_init_params__)(lame_global_flags *);
-    typedef int (*lame_close__)(lame_global_flags *);
-    typedef int (*lame_encode_flush__)(
-        lame_global_flags *  gfp,               /* global context handle                 */
-        unsigned char*       mp3buf,            /* pointer to encoded MP3 stream         */
-        int                  size);             /* number of valid octets in this stream */
-    typedef int (*lame_encode_buffer_float__)(
-        lame_global_flags*  gfp,                /* global context handle         */
-        const float         buffer_l [],        /* PCM data for left channel     */
-        const float         buffer_r [],        /* PCM data for right channel    */
-        const int           nsamples,           /* number of samples per channel */
-        unsigned char*      mp3buf,             /* pointer to encoded MP3 stream */
-        const int           mp3buf_size );
-
-    // Types of VBR.  default = vbr_off = CBR
-    typedef int (*lame_set_VBR__)(lame_global_flags *, vbr_mode);
-
-    // VBR quality level.  0=highest  9=lowest
-    typedef int (*lame_set_VBR_q__)(lame_global_flags *, int);
-
-    // Since lame 3.98, else lame_set_VBR_q. Range [0..9.999] (four decimals)
-    typedef int (*lame_set_VBR_quality__)(lame_global_flags *, float);
-
-    // Ignored except for VBR=vbr_abr (ABR mode)
-    typedef int (*lame_set_VBR_mean_bitrate_kbps__)(lame_global_flags *, int);
-
-    // as lame_encode_buffer_float with +/- 1 full scale and interleaved
-    // These methods are present only in lame 3.99, so it's important to test for their presence
-    // and fallback to the non-ieee one if not present.
-    typedef int (*lame_encode_buffer_interleaved_ieee_float__)(
-            lame_t          gfp,
-            const float     pcm[],             /* PCM data for left and right */
-                                               /* channel, interleaved        */
-            const int       nsamples,
-            unsigned char * mp3buf,
-            const int       mp3buf_size);
-    typedef size_t (*lame_get_lametag_frame__)(
-        const lame_global_flags *, unsigned char* buffer, size_t size);
-
-    lame_init__                         lame_init;
-    lame_set_num_channels__             lame_set_num_channels;
-    lame_set_in_samplerate__            lame_set_in_samplerate;
-    lame_set_out_samplerate__           lame_set_out_samplerate;
-    lame_set_brate__                    lame_set_brate;
-    lame_set_mode__                     lame_set_mode;
-    lame_set_quality__                  lame_set_quality;
-    lame_set_bWriteVbrTag__             lame_set_bWriteVbrTag;
-    lame_init_params__                  lame_init_params;
-    lame_close__                        lame_close;
-    lame_encode_flush__                 lame_encode_flush;
-    lame_encode_buffer_float__          lame_encode_buffer_float;
-    lame_set_VBR__                      lame_set_VBR;
-    lame_set_VBR_q__                    lame_set_VBR_q;
-    lame_set_VBR_quality__              lame_set_VBR_quality;
-    lame_set_VBR_mean_bitrate_kbps__    lame_set_VBR_mean_bitrate_kbps;
-    lame_encode_buffer_interleaved_ieee_float__ lame_encode_buffer_interleaved_ieee_float;
-    lame_get_lametag_frame__            lame_get_lametag_frame;
-
-    // Function pointers for ID3 Tags
-    typedef void (*id3tag_init__)(lame_global_flags *);
-    typedef void (*id3tag_set_title__)(lame_global_flags *, const char* title);
-    typedef void (*id3tag_set_artist__)(lame_global_flags *, const char* artist);
-    typedef void (*id3tag_set_album__)(lame_global_flags *, const char* album);
-    // Since lame 3.98
-    // force addition of version 2 tag
-    typedef void (*id3tag_add_v2__)   (lame_t gfp);
-
-    id3tag_init__                       id3tag_init;
-    id3tag_set_title__                  id3tag_set_title;
-    id3tag_set_artist__                 id3tag_set_artist;
-    id3tag_set_album__                  id3tag_set_album;
-    id3tag_add_v2__                     id3tag_add_v2;
-
+    lame_t m_lameFlags;
     QString m_metaDataTitle;
     QString m_metaDataArtist;
     QString m_metaDataAlbum;
@@ -156,13 +37,10 @@ class EncoderMp3 : public Encoder {
     MPEG_mode_e m_stereo_mode;
     unsigned char *m_bufferOut;
     int m_bufferOutSize;
-    float *m_bufferIn[2];
+    float* m_bufferIn[2];
     int m_bufferInSize;
 
     EncoderCallback* m_pCallback;
-    TrackPointer m_pMetaData;
-    QLibrary* m_library;
-    QFile m_mp3file;
 };
 
 #endif

--- a/src/util/version.cpp
+++ b/src/util/version.cpp
@@ -22,6 +22,7 @@
 #undef WIN32
 #endif
 
+#include <lame/lame.h>
 #include <FLAC/format.h>
 #include <chromaprint.h>
 #include <rubberband/RubberBandStretcher.h>
@@ -126,7 +127,8 @@ QStringList Version::dependencyVersions() {
             // Should be accurate.
             << QString("libsndfile: %1").arg(sndfile_version)
             // The version of the FLAC headers Mixxx was compiled with.
-            << QString("FLAC: %1").arg(FLAC__VERSION_STRING);
+            << QString("FLAC: %1").arg(FLAC__VERSION_STRING)
+            << QString("libmp3lame: %1").arg(get_lame_version());
 
     return result;
 }


### PR DESCRIPTION
Fixes Launchpad Bug #1294128.