### PR TITLE
Render WKnob, WKnobComposed and WSliderComposed using the GuiTick timer. Bug #1793015

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -1231,6 +1231,7 @@ class MixxxCore(Feature):
                    "util/autohidpi.cpp",
                    "util/screensaver.cpp",
                    "util/indexrange.cpp",
+                   "util/widgetrendertimer.cpp",
 
                    '#res/mixxx.qrc'
                    ]

--- a/src/util/timer.cpp
+++ b/src/util/timer.cpp
@@ -83,19 +83,20 @@ GuiTickTimer::GuiTickTimer(QObject* pParent)
           m_pGuiTick50ms(new ControlProxy(
               "[Master]", "guiTick50ms", this)),
           m_bActive(false) {
-    m_pGuiTick50ms->connectValueChanged(SLOT(slotGuiTick50ms(double)));
 }
 
 GuiTickTimer::~GuiTickTimer() {
 }
 
 void GuiTickTimer::start(mixxx::Duration duration) {
+    m_pGuiTick50ms->connectValueChanged(SLOT(slotGuiTick50ms(double)));
     m_interval = duration;
     m_elapsed = mixxx::Duration::fromSeconds(0);
     m_bActive = true;
 }
 
 void GuiTickTimer::stop() {
+    m_pGuiTick50ms->disconnect();
     m_bActive = false;
     m_interval = mixxx::Duration::fromSeconds(0);
     m_elapsed = mixxx::Duration::fromSeconds(0);

--- a/src/util/timer.cpp
+++ b/src/util/timer.cpp
@@ -80,8 +80,8 @@ mixxx::Duration SuspendableTimer::elapsed(bool report) {
 
 GuiTickTimer::GuiTickTimer(QObject* pParent)
         : QObject(pParent),
-          m_pGuiTick50ms(new ControlProxy(
-              "[Master]", "guiTick50ms", this)),
+          m_pGuiTick20ms(std::make_unique<ControlProxy>(
+              "[Master]", "guiTick20ms", this)),
           m_bActive(false) {
 }
 
@@ -89,22 +89,22 @@ GuiTickTimer::~GuiTickTimer() {
 }
 
 void GuiTickTimer::start(mixxx::Duration duration) {
-    m_pGuiTick50ms->connectValueChanged(SLOT(slotGuiTick50ms(double)));
+    m_pGuiTick20ms->connectValueChanged(SLOT(slotGuiTick20ms(double)));
     m_interval = duration;
     m_elapsed = mixxx::Duration::fromSeconds(0);
     m_bActive = true;
 }
 
 void GuiTickTimer::stop() {
-    m_pGuiTick50ms->disconnect();
+    m_pGuiTick20ms->disconnect();
     m_bActive = false;
     m_interval = mixxx::Duration::fromSeconds(0);
     m_elapsed = mixxx::Duration::fromSeconds(0);
 }
 
-void GuiTickTimer::slotGuiTick50ms(double) {
+void GuiTickTimer::slotGuiTick20ms(double) {
     if (m_bActive) {
-        m_elapsed += mixxx::Duration::fromMillis(50);
+        m_elapsed += mixxx::Duration::fromMillis(20);
         if (m_elapsed >= m_interval) {
             m_elapsed = mixxx::Duration::fromSeconds(0);
             emit(timeout());

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -119,7 +119,7 @@ class GuiTickTimer : public QObject {
     virtual ~GuiTickTimer();
 
     void start(mixxx::Duration interval);
-    bool started() const { return m_bActive; }
+    bool isActive() const { return m_bActive; }
     void stop();
 
   signals:

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -2,13 +2,13 @@
 #define UTIL_TIMER_H
 
 #include <QObject>
-#include <QScopedPointer>
 
 #include "control/controlproxy.h"
-#include "util/stat.h"
-#include "util/performancetimer.h"
 #include "util/cmdlineargs.h"
 #include "util/duration.h"
+#include "util/memory.h"
+#include "util/performancetimer.h"
+#include "util/stat.h"
 
 const Stat::ComputeFlags kDefaultComputeFlags = Stat::COUNT | Stat::SUM | Stat::AVERAGE |
         Stat::MAX | Stat::MIN | Stat::SAMPLE_VARIANCE;
@@ -110,7 +110,7 @@ class ScopedTimer {
     bool m_cancel;
 };
 
-// A timer that provides a similar API to QTimer but uses the GuiTick 50ms
+// A timer that provides a similar API to QTimer but uses the GuiTick 20ms
 // signal provided by the VsyncThread.
 class GuiTickTimer : public QObject {
     Q_OBJECT
@@ -126,10 +126,10 @@ class GuiTickTimer : public QObject {
     void timeout();
 
   private slots:
-    void slotGuiTick50ms(double v);
+    void slotGuiTick20ms(double v);
 
   private:
-    QScopedPointer<ControlProxy> m_pGuiTick50ms;
+    std::unique_ptr<ControlProxy> m_pGuiTick20ms;
     mixxx::Duration m_interval;
     mixxx::Duration m_elapsed;
     bool m_bActive;

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -6,7 +6,7 @@
 #include "control/controlproxy.h"
 #include "util/cmdlineargs.h"
 #include "util/duration.h"
-#include "util/memory.h"
+#include "util/parented_ptr.h"
 #include "util/performancetimer.h"
 #include "util/stat.h"
 
@@ -110,13 +110,13 @@ class ScopedTimer {
     bool m_cancel;
 };
 
-// A timer that provides a similar API to QTimer but uses the GuiTick 20ms
-// signal provided by the VsyncThread.
+// A timer that provides a similar API to QTimer but uses render events from the
+// VSyncThread as its source of timing events. This means the timer cannot fire
+// at a rate faster than the user's configured waveform FPS.
 class GuiTickTimer : public QObject {
     Q_OBJECT
   public:
     GuiTickTimer(QObject* pParent);
-    virtual ~GuiTickTimer();
 
     void start(mixxx::Duration interval);
     bool isActive() const { return m_bActive; }
@@ -126,12 +126,12 @@ class GuiTickTimer : public QObject {
     void timeout();
 
   private slots:
-    void slotGuiTick20ms(double v);
+    void slotGuiTick(double v);
 
   private:
-    std::unique_ptr<ControlProxy> m_pGuiTick20ms;
+    parented_ptr<ControlProxy> m_pGuiTick;
     mixxx::Duration m_interval;
-    mixxx::Duration m_elapsed;
+    mixxx::Duration m_lastUpdate;
     bool m_bActive;
 };
 

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -119,6 +119,7 @@ class GuiTickTimer : public QObject {
     virtual ~GuiTickTimer();
 
     void start(mixxx::Duration interval);
+    bool started() const { return m_bActive; }
     void stop();
 
   signals:

--- a/src/util/widgetrendertimer.cpp
+++ b/src/util/widgetrendertimer.cpp
@@ -13,7 +13,7 @@ WidgetRenderTimer::WidgetRenderTimer(mixxx::Duration renderFrequency,
 
 void WidgetRenderTimer::guiTick() {
     mixxx::Duration now = mixxx::Time::elapsed();
-    if (now - m_lastActivity > mixxx::Duration::fromSeconds(1)) {
+    if (now - m_lastActivity > m_inactivityTimeout) {
         m_guiTickTimer.stop();
     }
     if (m_lastActivity > m_lastRender) {
@@ -35,6 +35,6 @@ void WidgetRenderTimer::activity() {
     // inactivity, we disconnect the timer.
     m_lastActivity = mixxx::Time::elapsed();
     if (!m_guiTickTimer.isActive()) {
-        m_guiTickTimer.start(mixxx::Duration::fromMillis(20));
+        m_guiTickTimer.start(m_renderFrequency);
     }
 }

--- a/src/util/widgetrendertimer.cpp
+++ b/src/util/widgetrendertimer.cpp
@@ -23,16 +23,6 @@ void WidgetRenderTimer::guiTick() {
 }
 
 void WidgetRenderTimer::activity() {
-    // Bug #1793015: With Qt 4, we would simply call QWidget::update in response
-    // to input events that required re-rendering widgets, relying on Qt to
-    // batch them together and deliver them at a reasonable frequency. On macOS,
-    // the behavior of QWidget::update in Qt 5 seems to have changed such that
-    // render events happen much more frequently than they used to. To address
-    // this, we instead use a downsampling timer attached to the VSyncThread's
-    // render ticks for the waveform renderers. The timer invokes guiTick(),
-    // which is responsible for actually calling QWidget::update(). When input
-    // arrives, we call inputActivity to attach the timer. After 1 second of
-    // inactivity, we disconnect the timer.
     m_lastActivity = mixxx::Time::elapsed();
     if (!m_guiTickTimer.isActive()) {
         m_guiTickTimer.start(m_renderFrequency);

--- a/src/util/widgetrendertimer.cpp
+++ b/src/util/widgetrendertimer.cpp
@@ -1,0 +1,40 @@
+#include "util/widgetrendertimer.h"
+
+#include "util/time.h"
+
+WidgetRenderTimer::WidgetRenderTimer(mixxx::Duration renderFrequency,
+                                     mixxx::Duration inactivityTimeout)
+        :  m_renderFrequency(renderFrequency),
+           m_inactivityTimeout(inactivityTimeout),
+           m_guiTickTimer(this) {
+    connect(&m_guiTickTimer, SIGNAL(timeout()),
+            this, SLOT(guiTick()));
+}
+
+void WidgetRenderTimer::guiTick() {
+    mixxx::Duration now = mixxx::Time::elapsed();
+    if (now - m_lastActivity > mixxx::Duration::fromSeconds(1)) {
+        m_guiTickTimer.stop();
+    }
+    if (m_lastActivity > m_lastRender) {
+        m_lastRender = m_lastActivity;
+        emit(update());
+    }
+}
+
+void WidgetRenderTimer::activity() {
+    // Bug #1793015: With Qt 4, we would simply call QWidget::update in response
+    // to input events that required re-rendering widgets, relying on Qt to
+    // batch them together and deliver them at a reasonable frequency. On macOS,
+    // the behavior of QWidget::update in Qt 5 seems to have changed such that
+    // render events happen much more frequently than they used to. To address
+    // this, we instead use a downsampling timer attached to the VSyncThread's
+    // render ticks for the waveform renderers. The timer invokes guiTick(),
+    // which is responsible for actually calling QWidget::update(). When input
+    // arrives, we call inputActivity to attach the timer. After 1 second of
+    // inactivity, we disconnect the timer.
+    m_lastActivity = mixxx::Time::elapsed();
+    if (!m_guiTickTimer.isActive()) {
+        m_guiTickTimer.start(mixxx::Duration::fromMillis(20));
+    }
+}

--- a/src/util/widgetrendertimer.cpp
+++ b/src/util/widgetrendertimer.cpp
@@ -4,9 +4,9 @@
 
 WidgetRenderTimer::WidgetRenderTimer(mixxx::Duration renderFrequency,
                                      mixxx::Duration inactivityTimeout)
-        :  m_renderFrequency(renderFrequency),
-           m_inactivityTimeout(inactivityTimeout),
-           m_guiTickTimer(this) {
+        : m_renderFrequency(renderFrequency),
+          m_inactivityTimeout(inactivityTimeout),
+          m_guiTickTimer(this) {
     connect(&m_guiTickTimer, SIGNAL(timeout()),
             this, SLOT(guiTick()));
 }

--- a/src/util/widgetrendertimer.h
+++ b/src/util/widgetrendertimer.h
@@ -12,8 +12,8 @@
 // - inactivityTimeout: The timeout after which the widget's render timer is
 //   deactivated.
 //
-// This class was created in response to Bug #1793015. With Qt 4, we would
-// simply call QWidget::update in response to input events that required
+// This class was created in response to Launchpad Bug #1793015. With Qt 4, we
+// would simply call QWidget::update in response to input events that required
 // re-rendering widgets, relying on Qt to batch them together and deliver them
 // at a reasonable frequency. On macOS, the behavior of QWidget::update in Qt 5
 // seems to have changed such that render events happen much more frequently

--- a/src/util/widgetrendertimer.h
+++ b/src/util/widgetrendertimer.h
@@ -5,17 +5,30 @@
 #include "util/duration.h"
 #include "util/timer.h"
 
+// A helper class for rendering widgets on a timer when they need updating.
+// Prevents calling QWidget::update too quickly. Controlled by two parameters:
+// - renderFrequency: The frequency to render the widget at in response
+//   to updates.
+// - inactivityTimeout: The timeout after which the widget's render timer is
+//   deactivated.
 class WidgetRenderTimer : public QObject {
     Q_OBJECT
   public:
     WidgetRenderTimer(mixxx::Duration renderFrequency,
                       mixxx::Duration inactivityTimeout);
+
+    // Call this method whenever the widget's state has changed such that a
+    // re-render is necessary.
     void activity();
 
   signals:
+    // Emitted when the widget should actually render. Connect this signal to
+    // QWidget::update or QWidget::repaint.
     void update();
 
   private slots:
+    // Called when the internal GuiTickTimer's timeout is elapsed. Decides
+    // whether the widget should render in response to this timer tick.
     void guiTick();
 
   private:

--- a/src/util/widgetrendertimer.h
+++ b/src/util/widgetrendertimer.h
@@ -11,6 +11,17 @@
 //   to updates.
 // - inactivityTimeout: The timeout after which the widget's render timer is
 //   deactivated.
+//
+// This class was created in response to Bug #1793015. With Qt 4, we would
+// simply call QWidget::update in response to input events that required
+// re-rendering widgets, relying on Qt to batch them together and deliver them
+// at a reasonable frequency. On macOS, the behavior of QWidget::update in Qt 5
+// seems to have changed such that render events happen much more frequently
+// than they used to. To address this, we instead use a downsampling timer
+// attached to the VSyncThread's render ticks for the waveform renderers. The
+// timer invokes guiTick(), which is responsible for actually calling
+// QWidget::update(). When input arrives, we call inputActivity to attach the
+// timer. After 1 second of inactivity, we disconnect the timer.
 class WidgetRenderTimer : public QObject {
     Q_OBJECT
   public:

--- a/src/util/widgetrendertimer.h
+++ b/src/util/widgetrendertimer.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QObject>
+
+#include "util/duration.h"
+#include "util/timer.h"
+
+class WidgetRenderTimer : public QObject {
+    Q_OBJECT
+  public:
+    WidgetRenderTimer(mixxx::Duration renderFrequency,
+                      mixxx::Duration inactivityTimeout);
+    void activity();
+
+  signals:
+    void update();
+
+  private slots:
+    void guiTick();
+
+  private:
+    const mixxx::Duration m_renderFrequency;
+    const mixxx::Duration m_inactivityTimeout;
+    GuiTickTimer m_guiTickTimer;
+    mixxx::Duration m_lastActivity;
+    mixxx::Duration m_lastRender;
+};

--- a/src/waveform/guitick.cpp
+++ b/src/waveform/guitick.cpp
@@ -1,18 +1,14 @@
 #include <QTimer>
 
-#include "guitick.h"
+#include "waveform/guitick.h"
 #include "control/controlobject.h"
 
 GuiTick::GuiTick(QObject* pParent)
         : QObject(pParent) {
-     m_pCOGuiTickTime = new ControlObject(ConfigKey("[Master]", "guiTickTime"));
-     m_pCOGuiTick50ms = new ControlObject(ConfigKey("[Master]", "guiTick50ms"));
-     m_cpuTimer.start();
-}
-
-GuiTick::~GuiTick() {
-    delete m_pCOGuiTickTime;
-    delete m_pCOGuiTick50ms;
+    m_pCOGuiTickTime = std::make_unique<ControlObject>(ConfigKey("[Master]", "guiTickTime"));
+    m_pCOGuiTick20ms = std::make_unique<ControlObject>(ConfigKey("[Master]", "guiTick20ms"));
+    m_pCOGuiTick50ms = std::make_unique<ControlObject>(ConfigKey("[Master]", "guiTick50ms"));
+    m_cpuTimer.start();
 }
 
 // this is called from the VSyncThread
@@ -22,8 +18,12 @@ void GuiTick::process() {
     double cpuTimeLastTickSeconds = m_cpuTimeLastTick.toDoubleSeconds();
     m_pCOGuiTickTime->set(cpuTimeLastTickSeconds);
 
-    if (m_cpuTimeLastTick - m_lastUpdateTime >= mixxx::Duration::fromMillis(20)) {
-        m_lastUpdateTime = m_cpuTimeLastTick;
+    if (m_cpuTimeLastTick - m_lastUpdateTime20ms >= mixxx::Duration::fromMillis(20)) {
+        m_lastUpdateTime20ms = m_cpuTimeLastTick;
+        m_pCOGuiTick20ms->set(cpuTimeLastTickSeconds);
+    }
+    if (m_cpuTimeLastTick - m_lastUpdateTime50ms >= mixxx::Duration::fromMillis(50)) {
+        m_lastUpdateTime50ms = m_cpuTimeLastTick;
         m_pCOGuiTick50ms->set(cpuTimeLastTickSeconds);
     }
 }

--- a/src/waveform/guitick.cpp
+++ b/src/waveform/guitick.cpp
@@ -22,7 +22,7 @@ void GuiTick::process() {
     double cpuTimeLastTickSeconds = m_cpuTimeLastTick.toDoubleSeconds();
     m_pCOGuiTickTime->set(cpuTimeLastTickSeconds);
 
-    if (m_cpuTimeLastTick - m_lastUpdateTime >= mixxx::Duration::fromMillis(50)) {
+    if (m_cpuTimeLastTick - m_lastUpdateTime >= mixxx::Duration::fromMillis(20)) {
         m_lastUpdateTime = m_cpuTimeLastTick;
         m_pCOGuiTick50ms->set(cpuTimeLastTickSeconds);
     }

--- a/src/waveform/guitick.cpp
+++ b/src/waveform/guitick.cpp
@@ -6,7 +6,6 @@
 GuiTick::GuiTick(QObject* pParent)
         : QObject(pParent) {
     m_pCOGuiTickTime = std::make_unique<ControlObject>(ConfigKey("[Master]", "guiTickTime"));
-    m_pCOGuiTick20ms = std::make_unique<ControlObject>(ConfigKey("[Master]", "guiTick20ms"));
     m_pCOGuiTick50ms = std::make_unique<ControlObject>(ConfigKey("[Master]", "guiTick50ms"));
     m_cpuTimer.start();
 }
@@ -18,12 +17,8 @@ void GuiTick::process() {
     double cpuTimeLastTickSeconds = m_cpuTimeLastTick.toDoubleSeconds();
     m_pCOGuiTickTime->set(cpuTimeLastTickSeconds);
 
-    if (m_cpuTimeLastTick - m_lastUpdateTime20ms >= mixxx::Duration::fromMillis(20)) {
-        m_lastUpdateTime20ms = m_cpuTimeLastTick;
-        m_pCOGuiTick20ms->set(cpuTimeLastTickSeconds);
-    }
-    if (m_cpuTimeLastTick - m_lastUpdateTime50ms >= mixxx::Duration::fromMillis(50)) {
-        m_lastUpdateTime50ms = m_cpuTimeLastTick;
+    if (m_cpuTimeLastTick - m_lastUpdateTime >= mixxx::Duration::fromMillis(50)) {
+        m_lastUpdateTime = m_cpuTimeLastTick;
         m_pCOGuiTick50ms->set(cpuTimeLastTickSeconds);
     }
 }

--- a/src/waveform/guitick.h
+++ b/src/waveform/guitick.h
@@ -3,23 +3,25 @@
 
 #include <QObject>
 
+#include "control/controlobject.h"
 #include "util/duration.h"
+#include "util/memory.h"
 #include "util/performancetimer.h"
-
-class ControlObject;
 
 class GuiTick : public QObject {
     Q_OBJECT
   public:
     GuiTick(QObject* pParent = NULL);
-    ~GuiTick();
+    ~GuiTick() = default;
     void process();
 
   private:
-    ControlObject* m_pCOGuiTickTime;
-    ControlObject* m_pCOGuiTick50ms;
+    std::unique_ptr<ControlObject> m_pCOGuiTickTime;
+    std::unique_ptr<ControlObject> m_pCOGuiTick20ms;
+    std::unique_ptr<ControlObject> m_pCOGuiTick50ms;
     PerformanceTimer m_cpuTimer;
-    mixxx::Duration m_lastUpdateTime;
+    mixxx::Duration m_lastUpdateTime20ms;
+    mixxx::Duration m_lastUpdateTime50ms;
     mixxx::Duration m_cpuTimeLastTick;
 };
 

--- a/src/waveform/guitick.h
+++ b/src/waveform/guitick.h
@@ -18,11 +18,9 @@ class GuiTick : public QObject {
 
   private:
     std::unique_ptr<ControlObject> m_pCOGuiTickTime;
-    std::unique_ptr<ControlObject> m_pCOGuiTick20ms;
     std::unique_ptr<ControlObject> m_pCOGuiTick50ms;
     PerformanceTimer m_cpuTimer;
-    mixxx::Duration m_lastUpdateTime20ms;
-    mixxx::Duration m_lastUpdateTime50ms;
+    mixxx::Duration m_lastUpdateTime;
     mixxx::Duration m_cpuTimeLastTick;
 };
 

--- a/src/waveform/guitick.h
+++ b/src/waveform/guitick.h
@@ -8,11 +8,12 @@
 #include "util/memory.h"
 #include "util/performancetimer.h"
 
+// A helper class that manages the "guiTickTime" COs, that drive updates of the
+// GUI from the VsyncThread at the user's configured FPS (possibly downsampled).
 class GuiTick : public QObject {
     Q_OBJECT
   public:
     GuiTick(QObject* pParent = NULL);
-    ~GuiTick() = default;
     void process();
 
   private:

--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -43,7 +43,7 @@ class KnobEventHandler {
             QCursor::setPos(m_startPos);
             double value = valueFromMouseEvent(pWidget, e);
             pWidget->setControlParameterDown(value);
-            pWidget->update();
+            pWidget->inputActivity();
         }
     }
 
@@ -72,7 +72,7 @@ class KnobEventHandler {
                 QApplication::restoreOverrideCursor();
                 value = valueFromMouseEvent(pWidget, e);
                 pWidget->setControlParameterUp(value);
-                pWidget->update();
+                pWidget->inputActivity();
                 break;
             case Qt::RightButton:
                 m_bRightButtonPressed = false;
@@ -80,7 +80,6 @@ class KnobEventHandler {
             default:
                 break;
         }
-        pWidget->update();
     }
 
     void wheelEvent(T* pWidget, QWheelEvent* e) {
@@ -92,7 +91,7 @@ class KnobEventHandler {
         newValue = math_clamp(newValue, 0.0, 1.0);
 
         pWidget->setControlParameter(newValue);
-        pWidget->update();
+        pWidget->inputActivity();
         e->accept();
     }
 

--- a/src/widget/slidereventhandler.h
+++ b/src/widget/slidereventhandler.h
@@ -66,7 +66,7 @@ class SliderEventHandler {
             }
 
             // Update display
-            pWidget->update();
+            pWidget->inputActivity();
         }
     }
 
@@ -113,7 +113,7 @@ class SliderEventHandler {
 
         pWidget->setControlParameter(newParameter);
         onConnectedControlChanged(pWidget, newParameter);
-        pWidget->update();
+        pWidget->inputActivity();
         e->accept();
     }
 
@@ -145,7 +145,7 @@ class SliderEventHandler {
             // parents.
             if (newPos != m_dPos) {
                 m_dPos = newPos;
-                pWidget->update();
+                pWidget->inputActivity();
             }
         }
     }

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -57,6 +57,16 @@ void WKnob::guiTick() {
 }
 
 void WKnob::inputActivity() {
+    // Bug #1793015: Previously we would simply call QWidget::update in response
+    // to input events that required re-rendering widgets, relying on Qt to
+    // batch them together and deliver them at a reasonable frequency. On macOS,
+    // the behavior of QWidget::update seems to have changed such that render
+    // events happen much more frequently than they used to. To address this, we
+    // instead use a downsampling timer attached to the VSyncThread's render
+    // ticks for the waveform renderers. The timer invokes guiTick(), which is
+    // responsible for actually calling QWidget::update(). When input arrives,
+    // we call inputActivity to attach the timer. After 1 second of inactivity,
+    // we disconnect the timer.
     m_lastActivity = mixxx::Time::elapsed();
     if (!m_guiTickTimer.isActive()) {
         m_guiTickTimer.start(mixxx::Duration::fromMillis(20));

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -50,12 +50,15 @@ void WKnob::guiTick() {
     if (now - m_lastActivity > mixxx::Duration::fromSeconds(1)) {
         m_guiTickTimer.stop();
     }
-    update();
+    if (m_lastActivity > m_lastRender) {
+        update();
+        m_lastRender = m_lastActivity;
+    }
 }
 
 void WKnob::inputActivity() {
     m_lastActivity = mixxx::Time::elapsed();
-    if (!m_guiTickTimer.started()) {
+    if (!m_guiTickTimer.isActive()) {
         m_guiTickTimer.start(mixxx::Duration::fromMillis(20));
     }
 }

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -57,16 +57,16 @@ void WKnob::guiTick() {
 }
 
 void WKnob::inputActivity() {
-    // Bug #1793015: Previously we would simply call QWidget::update in response
+    // Bug #1793015: With Qt 4, we would simply call QWidget::update in response
     // to input events that required re-rendering widgets, relying on Qt to
     // batch them together and deliver them at a reasonable frequency. On macOS,
-    // the behavior of QWidget::update seems to have changed such that render
-    // events happen much more frequently than they used to. To address this, we
-    // instead use a downsampling timer attached to the VSyncThread's render
-    // ticks for the waveform renderers. The timer invokes guiTick(), which is
-    // responsible for actually calling QWidget::update(). When input arrives,
-    // we call inputActivity to attach the timer. After 1 second of inactivity,
-    // we disconnect the timer.
+    // the behavior of QWidget::update in Qt 5 seems to have changed such that
+    // render events happen much more frequently than they used to. To address
+    // this, we instead use a downsampling timer attached to the VSyncThread's
+    // render ticks for the waveform renderers. The timer invokes guiTick(),
+    // which is responsible for actually calling QWidget::update(). When input
+    // arrives, we call inputActivity to attach the timer. After 1 second of
+    // inactivity, we disconnect the timer.
     m_lastActivity = mixxx::Time::elapsed();
     if (!m_guiTickTimer.isActive()) {
         m_guiTickTimer.start(mixxx::Duration::fromMillis(20));

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -19,14 +19,15 @@
 #include <QMouseEvent>
 #include <QWheelEvent>
 
-#include "util/time.h"
+#include "util/duration.h"
 #include "widget/wknob.h"
 
 WKnob::WKnob(QWidget* pParent)
         : WDisplay(pParent),
-          m_guiTickTimer(this) {
-    connect(&m_guiTickTimer, SIGNAL(timeout()),
-            this, SLOT(guiTick()));
+          m_renderTimer(mixxx::Duration::fromMillis(20),
+                        mixxx::Duration::fromSeconds(1)) {
+    connect(&m_renderTimer, SIGNAL(update()),
+            this, SLOT(update()));
 }
 
 void WKnob::mouseMoveEvent(QMouseEvent* e) {
@@ -45,30 +46,6 @@ void WKnob::wheelEvent(QWheelEvent* e) {
     m_handler.wheelEvent(this, e);
 }
 
-void WKnob::guiTick() {
-    mixxx::Duration now = mixxx::Time::elapsed();
-    if (now - m_lastActivity > mixxx::Duration::fromSeconds(1)) {
-        m_guiTickTimer.stop();
-    }
-    if (m_lastActivity > m_lastRender) {
-        update();
-        m_lastRender = m_lastActivity;
-    }
-}
-
 void WKnob::inputActivity() {
-    // Bug #1793015: With Qt 4, we would simply call QWidget::update in response
-    // to input events that required re-rendering widgets, relying on Qt to
-    // batch them together and deliver them at a reasonable frequency. On macOS,
-    // the behavior of QWidget::update in Qt 5 seems to have changed such that
-    // render events happen much more frequently than they used to. To address
-    // this, we instead use a downsampling timer attached to the VSyncThread's
-    // render ticks for the waveform renderers. The timer invokes guiTick(),
-    // which is responsible for actually calling QWidget::update(). When input
-    // arrives, we call inputActivity to attach the timer. After 1 second of
-    // inactivity, we disconnect the timer.
-    m_lastActivity = mixxx::Time::elapsed();
-    if (!m_guiTickTimer.isActive()) {
-        m_guiTickTimer.start(mixxx::Duration::fromMillis(20));
-    }
+    m_renderTimer.activity();
 }

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -19,10 +19,14 @@
 #include <QMouseEvent>
 #include <QWheelEvent>
 
+#include "util/time.h"
 #include "widget/wknob.h"
 
 WKnob::WKnob(QWidget* pParent)
-        : WDisplay(pParent) {
+        : WDisplay(pParent),
+          m_guiTickTimer(this) {
+    connect(&m_guiTickTimer, SIGNAL(timeout()),
+            this, SLOT(guiTick()));
 }
 
 void WKnob::mouseMoveEvent(QMouseEvent* e) {
@@ -39,4 +43,19 @@ void WKnob::mouseReleaseEvent(QMouseEvent* e) {
 
 void WKnob::wheelEvent(QWheelEvent* e) {
     m_handler.wheelEvent(this, e);
+}
+
+void WKnob::guiTick() {
+    mixxx::Duration now = mixxx::Time::elapsed();
+    if (now - m_lastActivity > mixxx::Duration::fromSeconds(1)) {
+        m_guiTickTimer.stop();
+    }
+    update();
+}
+
+void WKnob::inputActivity() {
+    m_lastActivity = mixxx::Time::elapsed();
+    if (!m_guiTickTimer.started()) {
+        m_guiTickTimer.start(mixxx::Duration::fromMillis(20));
+    }
 }

--- a/src/widget/wknob.h
+++ b/src/widget/wknob.h
@@ -7,6 +7,7 @@
 #include <QMouseEvent>
 #include <QWheelEvent>
 
+#include "util/timer.h"
 #include "widget/wdisplay.h"
 #include "widget/knobeventhandler.h"
 
@@ -25,7 +26,14 @@ class WKnob : public WDisplay {
     void mousePressEvent(QMouseEvent *e) override;
     void mouseReleaseEvent(QMouseEvent *e) override;
 
+    void inputActivity();
+  private slots:
+    void guiTick();
+
   private:
+    GuiTickTimer m_guiTickTimer;
+    mixxx::Duration m_lastActivity;
+
     KnobEventHandler<WKnob> m_handler;
     friend class KnobEventHandler<WKnob>;
 };

--- a/src/widget/wknob.h
+++ b/src/widget/wknob.h
@@ -33,6 +33,7 @@ class WKnob : public WDisplay {
   private:
     GuiTickTimer m_guiTickTimer;
     mixxx::Duration m_lastActivity;
+    mixxx::Duration m_lastRender;
 
     KnobEventHandler<WKnob> m_handler;
     friend class KnobEventHandler<WKnob>;

--- a/src/widget/wknob.h
+++ b/src/widget/wknob.h
@@ -7,7 +7,7 @@
 #include <QMouseEvent>
 #include <QWheelEvent>
 
-#include "util/timer.h"
+#include "util/widgetrendertimer.h"
 #include "widget/wdisplay.h"
 #include "widget/knobeventhandler.h"
 
@@ -25,15 +25,10 @@ class WKnob : public WDisplay {
     void mouseMoveEvent(QMouseEvent *e) override;
     void mousePressEvent(QMouseEvent *e) override;
     void mouseReleaseEvent(QMouseEvent *e) override;
-
     void inputActivity();
-  private slots:
-    void guiTick();
 
   private:
-    GuiTickTimer m_guiTickTimer;
-    mixxx::Duration m_lastActivity;
-    mixxx::Duration m_lastRender;
+    WidgetRenderTimer m_renderTimer;
 
     KnobEventHandler<WKnob> m_handler;
     friend class KnobEventHandler<WKnob>;

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -140,12 +140,15 @@ void WKnobComposed::guiTick() {
     if (now - m_lastActivity > mixxx::Duration::fromSeconds(1)) {
         m_guiTickTimer.stop();
     }
-    update();
+    if (m_lastActivity > m_lastRender) {
+        update();
+        m_lastRender = m_lastActivity;
+    }
 }
 
 void WKnobComposed::inputActivity() {
     m_lastActivity = mixxx::Time::elapsed();
-    if (!m_guiTickTimer.started()) {
+    if (!m_guiTickTimer.isActive()) {
         m_guiTickTimer.start(mixxx::Duration::fromMillis(20));
     }
 }

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -147,6 +147,16 @@ void WKnobComposed::guiTick() {
 }
 
 void WKnobComposed::inputActivity() {
+    // Bug #1793015: Previously we would simply call QWidget::update in response
+    // to input events that required re-rendering widgets, relying on Qt to
+    // batch them together and deliver them at a reasonable frequency. On macOS,
+    // the behavior of QWidget::update seems to have changed such that render
+    // events happen much more frequently than they used to. To address this, we
+    // instead use a downsampling timer attached to the VSyncThread's render
+    // ticks for the waveform renderers. The timer invokes guiTick(), which is
+    // responsible for actually calling QWidget::update(). When input arrives,
+    // we call inputActivity to attach the timer. After 1 second of inactivity,
+    // we disconnect the timer.
     m_lastActivity = mixxx::Time::elapsed();
     if (!m_guiTickTimer.isActive()) {
         m_guiTickTimer.start(mixxx::Duration::fromMillis(20));

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -13,7 +13,7 @@ WKnobComposed::WKnobComposed(QWidget* pParent)
           m_dKnobCenterXOffset(0),
           m_dKnobCenterYOffset(0),
           m_renderTimer(mixxx::Duration::fromMillis(20),
-                    mixxx::Duration::fromSeconds(1)) {
+                        mixxx::Duration::fromSeconds(1)) {
     connect(&m_renderTimer, SIGNAL(update()),
             this, SLOT(update()));
 }

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -147,16 +147,16 @@ void WKnobComposed::guiTick() {
 }
 
 void WKnobComposed::inputActivity() {
-    // Bug #1793015: Previously we would simply call QWidget::update in response
+    // Bug #1793015: With Qt 4, we would simply call QWidget::update in response
     // to input events that required re-rendering widgets, relying on Qt to
     // batch them together and deliver them at a reasonable frequency. On macOS,
-    // the behavior of QWidget::update seems to have changed such that render
-    // events happen much more frequently than they used to. To address this, we
-    // instead use a downsampling timer attached to the VSyncThread's render
-    // ticks for the waveform renderers. The timer invokes guiTick(), which is
-    // responsible for actually calling QWidget::update(). When input arrives,
-    // we call inputActivity to attach the timer. After 1 second of inactivity,
-    // we disconnect the timer.
+    // the behavior of QWidget::update in Qt 5 seems to have changed such that
+    // render events happen much more frequently than they used to. To address
+    // this, we instead use a downsampling timer attached to the VSyncThread's
+    // render ticks for the waveform renderers. The timer invokes guiTick(),
+    // which is responsible for actually calling QWidget::update(). When input
+    // arrives, we call inputActivity to attach the timer. After 1 second of
+    // inactivity, we disconnect the timer.
     m_lastActivity = mixxx::Time::elapsed();
     if (!m_guiTickTimer.isActive()) {
         m_guiTickTimer.start(mixxx::Duration::fromMillis(20));

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -7,7 +7,7 @@
 #include <QWheelEvent>
 
 #include "skin/skincontext.h"
-#include "util/timer.h"
+#include "util/widgetrendertimer.h"
 #include "widget/wwidget.h"
 #include "widget/knobeventhandler.h"
 #include "widget/wpixmapstore.h"
@@ -34,9 +34,6 @@ class WKnobComposed : public WWidget {
     void mouseReleaseEvent(QMouseEvent *e) override;
     void paintEvent(QPaintEvent* /*unused*/) override;
 
-  private slots:
-    void guiTick();
-
   private:
     void inputActivity();
     void clear();
@@ -57,9 +54,7 @@ class WKnobComposed : public WWidget {
     double m_dMaxAngle;
     double m_dKnobCenterXOffset;
     double m_dKnobCenterYOffset;
-    GuiTickTimer m_guiTickTimer;
-    mixxx::Duration m_lastActivity;
-    mixxx::Duration m_lastRender;
+    WidgetRenderTimer m_renderTimer;
 
     friend class KnobEventHandler<WKnobComposed>;
 };

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -6,11 +6,12 @@
 #include <QMouseEvent>
 #include <QWheelEvent>
 
+#include "skin/skincontext.h"
+#include "util/timer.h"
 #include "widget/wwidget.h"
 #include "widget/knobeventhandler.h"
 #include "widget/wpixmapstore.h"
 #include "widget/wimagestore.h"
-#include "skin/skincontext.h"
 
 // This is used for knobs, if the knob value can be displayed
 // by rotating a single SVG image.
@@ -33,7 +34,11 @@ class WKnobComposed : public WWidget {
     void mouseReleaseEvent(QMouseEvent *e) override;
     void paintEvent(QPaintEvent* /*unused*/) override;
 
+  private slots:
+    void guiTick();
+
   private:
+    void inputActivity();
     void clear();
     void setPixmapBackground(
             PixmapSource source,
@@ -52,6 +57,9 @@ class WKnobComposed : public WWidget {
     double m_dMaxAngle;
     double m_dKnobCenterXOffset;
     double m_dKnobCenterYOffset;
+    GuiTickTimer m_guiTickTimer;
+    mixxx::Duration m_lastActivity;
+
     friend class KnobEventHandler<WKnobComposed>;
 };
 

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -59,6 +59,7 @@ class WKnobComposed : public WWidget {
     double m_dKnobCenterYOffset;
     GuiTickTimer m_guiTickTimer;
     mixxx::Duration m_lastActivity;
+    mixxx::Duration m_lastRender;
 
     friend class KnobEventHandler<WKnobComposed>;
 };

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -243,16 +243,16 @@ void WSliderComposed::guiTick() {
 }
 
 void WSliderComposed::inputActivity() {
-    // Bug #1793015: Previously we would simply call QWidget::update in response
+    // Bug #1793015: With Qt 4, we would simply call QWidget::update in response
     // to input events that required re-rendering widgets, relying on Qt to
     // batch them together and deliver them at a reasonable frequency. On macOS,
-    // the behavior of QWidget::update seems to have changed such that render
-    // events happen much more frequently than they used to. To address this, we
-    // instead use a downsampling timer attached to the VSyncThread's render
-    // ticks for the waveform renderers. The timer invokes guiTick(), which is
-    // responsible for actually calling QWidget::update(). When input arrives,
-    // we call inputActivity to attach the timer. After 1 second of inactivity,
-    // we disconnect the timer.
+    // the behavior of QWidget::update in Qt 5 seems to have changed such that
+    // render events happen much more frequently than they used to. To address
+    // this, we instead use a downsampling timer attached to the VSyncThread's
+    // render ticks for the waveform renderers. The timer invokes guiTick(),
+    // which is responsible for actually calling QWidget::update(). When input
+    // arrives, we call inputActivity to attach the timer. After 1 second of
+    // inactivity, we disconnect the timer.
     m_lastActivity = mixxx::Time::elapsed();
     if (!m_guiTickTimer.isActive()) {
         m_guiTickTimer.start(mixxx::Duration::fromMillis(20));

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -24,8 +24,8 @@
 #include "widget/controlwidgetconnection.h"
 #include "widget/wpixmapstore.h"
 #include "util/debug.h"
+#include "util/duration.h"
 #include "util/math.h"
-#include "util/time.h"
 
 WSliderComposed::WSliderComposed(QWidget * parent)
     : WWidget(parent),
@@ -35,9 +35,10 @@ WSliderComposed::WSliderComposed(QWidget * parent)
       m_bHorizontal(false),
       m_pSlider(nullptr),
       m_pHandle(nullptr),
-      m_guiTickTimer(this) {
-    connect(&m_guiTickTimer, SIGNAL(timeout()),
-            this, SLOT(guiTick()));
+      m_renderTimer(mixxx::Duration::fromMillis(20),
+                    mixxx::Duration::fromSeconds(1)) {
+    connect(&m_renderTimer, SIGNAL(update()),
+            this, SLOT(update()));
 }
 
 WSliderComposed::~WSliderComposed() {
@@ -231,30 +232,6 @@ double WSliderComposed::calculateHandleLength() {
     return 0;
 }
 
-void WSliderComposed::guiTick() {
-    mixxx::Duration now = mixxx::Time::elapsed();
-    if (now - m_lastActivity > mixxx::Duration::fromSeconds(1)) {
-        m_guiTickTimer.stop();
-    }
-    if (m_lastActivity > m_lastRender) {
-        update();
-        m_lastRender = m_lastActivity;
-    }
-}
-
 void WSliderComposed::inputActivity() {
-    // Bug #1793015: With Qt 4, we would simply call QWidget::update in response
-    // to input events that required re-rendering widgets, relying on Qt to
-    // batch them together and deliver them at a reasonable frequency. On macOS,
-    // the behavior of QWidget::update in Qt 5 seems to have changed such that
-    // render events happen much more frequently than they used to. To address
-    // this, we instead use a downsampling timer attached to the VSyncThread's
-    // render ticks for the waveform renderers. The timer invokes guiTick(),
-    // which is responsible for actually calling QWidget::update(). When input
-    // arrives, we call inputActivity to attach the timer. After 1 second of
-    // inactivity, we disconnect the timer.
-    m_lastActivity = mixxx::Time::elapsed();
-    if (!m_guiTickTimer.isActive()) {
-        m_guiTickTimer.start(mixxx::Duration::fromMillis(20));
-    }
+    m_renderTimer.activity();
 }

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -236,12 +236,15 @@ void WSliderComposed::guiTick() {
     if (now - m_lastActivity > mixxx::Duration::fromSeconds(1)) {
         m_guiTickTimer.stop();
     }
-    update();
+    if (m_lastActivity > m_lastRender) {
+        update();
+        m_lastRender = m_lastActivity;
+    }
 }
 
 void WSliderComposed::inputActivity() {
     m_lastActivity = mixxx::Time::elapsed();
-    if (!m_guiTickTimer.started()) {
+    if (!m_guiTickTimer.isActive()) {
         m_guiTickTimer.start(mixxx::Duration::fromMillis(20));
     }
 }

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -25,6 +25,7 @@
 #include "widget/wpixmapstore.h"
 #include "util/debug.h"
 #include "util/math.h"
+#include "util/time.h"
 
 WSliderComposed::WSliderComposed(QWidget * parent)
     : WWidget(parent),
@@ -33,7 +34,10 @@ WSliderComposed::WSliderComposed(QWidget * parent)
       m_dSliderLength(0.0),
       m_bHorizontal(false),
       m_pSlider(nullptr),
-      m_pHandle(nullptr) {
+      m_pHandle(nullptr),
+      m_guiTickTimer(this) {
+    connect(&m_guiTickTimer, SIGNAL(timeout()),
+            this, SLOT(guiTick()));
 }
 
 WSliderComposed::~WSliderComposed() {
@@ -225,4 +229,19 @@ double WSliderComposed::calculateHandleLength() {
         }
     }
     return 0;
+}
+
+void WSliderComposed::guiTick() {
+    mixxx::Duration now = mixxx::Time::elapsed();
+    if (now - m_lastActivity > mixxx::Duration::fromSeconds(1)) {
+        m_guiTickTimer.stop();
+    }
+    update();
+}
+
+void WSliderComposed::inputActivity() {
+    m_lastActivity = mixxx::Time::elapsed();
+    if (!m_guiTickTimer.started()) {
+        m_guiTickTimer.start(mixxx::Duration::fromMillis(20));
+    }
 }

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -243,6 +243,16 @@ void WSliderComposed::guiTick() {
 }
 
 void WSliderComposed::inputActivity() {
+    // Bug #1793015: Previously we would simply call QWidget::update in response
+    // to input events that required re-rendering widgets, relying on Qt to
+    // batch them together and deliver them at a reasonable frequency. On macOS,
+    // the behavior of QWidget::update seems to have changed such that render
+    // events happen much more frequently than they used to. To address this, we
+    // instead use a downsampling timer attached to the VSyncThread's render
+    // ticks for the waveform renderers. The timer invokes guiTick(), which is
+    // responsible for actually calling QWidget::update(). When input arrives,
+    // we call inputActivity to attach the timer. After 1 second of inactivity,
+    // we disconnect the timer.
     m_lastActivity = mixxx::Time::elapsed();
     if (!m_guiTickTimer.isActive()) {
         m_guiTickTimer.start(mixxx::Duration::fromMillis(20));

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -26,10 +26,11 @@
 #include <QMouseEvent>
 #include <QResizeEvent>
 
+#include "skin/skincontext.h"
+#include "util/timer.h"
 #include "widget/slidereventhandler.h"
 #include "widget/wwidget.h"
 #include "widget/wpixmapstore.h"
-#include "skin/skincontext.h"
 
 /**
   * A widget for a slider composed of a background pixmap and a handle.
@@ -54,10 +55,12 @@ class WSliderComposed : public WWidget  {
             Paintable::DrawMode mode,
             double scaleFactor);
     inline bool isHorizontal() const { return m_bHorizontal; };
+    void inputActivity();
 
   public slots:
     void onConnectedControlChanged(double dParameter, double dValue) override;
     void fillDebugTooltip(QStringList* debug) override;
+    void guiTick();
 
   protected:
     void mouseMoveEvent(QMouseEvent* e) override;
@@ -84,6 +87,8 @@ class WSliderComposed : public WWidget  {
     // Pointer to pixmap of the handle
     PaintablePointer m_pHandle;
     SliderEventHandler<WSliderComposed> m_handler;
+    GuiTickTimer m_guiTickTimer;
+    mixxx::Duration m_lastActivity;
 
     friend class SliderEventHandler<WSliderComposed>;
 };

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -89,6 +89,7 @@ class WSliderComposed : public WWidget  {
     SliderEventHandler<WSliderComposed> m_handler;
     GuiTickTimer m_guiTickTimer;
     mixxx::Duration m_lastActivity;
+    mixxx::Duration m_lastRender;
 
     friend class SliderEventHandler<WSliderComposed>;
 };

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -27,7 +27,7 @@
 #include <QResizeEvent>
 
 #include "skin/skincontext.h"
-#include "util/timer.h"
+#include "util/widgetrendertimer.h"
 #include "widget/slidereventhandler.h"
 #include "widget/wwidget.h"
 #include "widget/wpixmapstore.h"
@@ -60,7 +60,6 @@ class WSliderComposed : public WWidget  {
   public slots:
     void onConnectedControlChanged(double dParameter, double dValue) override;
     void fillDebugTooltip(QStringList* debug) override;
-    void guiTick();
 
   protected:
     void mouseMoveEvent(QMouseEvent* e) override;
@@ -87,9 +86,7 @@ class WSliderComposed : public WWidget  {
     // Pointer to pixmap of the handle
     PaintablePointer m_pHandle;
     SliderEventHandler<WSliderComposed> m_handler;
-    GuiTickTimer m_guiTickTimer;
-    mixxx::Duration m_lastActivity;
-    mixxx::Duration m_lastRender;
+    WidgetRenderTimer m_renderTimer;
 
     friend class SliderEventHandler<WSliderComposed>;
 };


### PR DESCRIPTION
This is a dirty hack that attaches WKnobComposed updates to the GUI tick timer instead of triggering an update by calling `QWidget::update`on every mouse event.