### PR TITLE
allow for overlapping beatlooprolls

### DIFF
--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -851,7 +851,7 @@ void LoopingControl::slotBeatLoopActivateRoll(BeatLoopingControl* pBeatLoopContr
     m_pSlipEnabled->set(1);
     slotBeatLoop(pBeatLoopControl->getSize(), m_bLoopRollActive, true);
     m_bLoopRollActive = true;
-    m_activeLoopRolls.push(pBeatLoopControl);
+    m_activeLoopRolls.push(pBeatLoopControl->getSize());
 }
 
 void LoopingControl::slotBeatLoopDeactivate(BeatLoopingControl* pBeatLoopControl) {
@@ -861,7 +861,15 @@ void LoopingControl::slotBeatLoopDeactivate(BeatLoopingControl* pBeatLoopControl
 
 void LoopingControl::slotBeatLoopDeactivateRoll(BeatLoopingControl* pBeatLoopControl) {
     pBeatLoopControl->deactivate();
-    m_activeLoopRolls.removeAll(pBeatLoopControl);
+    const double size = pBeatLoopControl->getSize();
+    auto i = m_activeLoopRolls.begin();
+    while (i != m_activeLoopRolls.end()) {
+        if (size == *i) {
+            i = m_activeLoopRolls.erase(i);
+        } else {
+            ++i;
+        }
+    }
 
     // Make sure slip mode is not turned off if it was turned on
     // by something that was not a rolling beatloop.
@@ -873,7 +881,7 @@ void LoopingControl::slotBeatLoopDeactivateRoll(BeatLoopingControl* pBeatLoopCon
 
     // Return to the previous beatlooproll if necessary.
     if (!m_activeLoopRolls.empty()) {
-        slotBeatLoop(m_activeLoopRolls.top()->getSize(), m_bLoopRollActive, true);
+        slotBeatLoop(m_activeLoopRolls.top(), m_bLoopRollActive, true);
     }
 }
 

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -132,7 +132,7 @@ class LoopingControl : public EngineControl {
     bool m_bAdjustingLoopInOld;
     bool m_bAdjustingLoopOutOld;
     bool m_bLoopOutPressedWhileLoopDisabled;
-    QStack<BeatLoopingControl*> m_activeLoopRolls;
+    QStack<double> m_activeLoopRolls;
     ControlValueAtomic<LoopSamples> m_loopSamples;
     LoopSamples m_oldLoopSamples;
     ControlValueAtomic<double> m_currentSample;

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -6,6 +6,7 @@
 #define LOOPINGCONTROL_H
 
 #include <QObject>
+#include <QStack>
 
 #include "preferences/usersettings.h"
 #include "engine/enginecontrol.h"
@@ -131,6 +132,7 @@ class LoopingControl : public EngineControl {
     bool m_bAdjustingLoopInOld;
     bool m_bAdjustingLoopOutOld;
     bool m_bLoopOutPressedWhileLoopDisabled;
+    QStack<BeatLoopingControl*> m_activeLoopRolls;
     ControlValueAtomic<LoopSamples> m_loopSamples;
     LoopSamples m_oldLoopSamples;
     ControlValueAtomic<double> m_currentSample;

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -50,6 +50,7 @@ class LoopingControlTest : public MockedEngineBackendTest {
         m_pButtonBeatMoveBackward = std::make_unique<ControlProxy>(m_sGroup1, "loop_move_1_backward");
         m_pButtonBeatLoop2Activate = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_2_activate");
         m_pButtonBeatLoop4Activate = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_4_activate");
+        m_pBeatLoop1Enabled = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_1_enabled");
         m_pBeatLoop2Enabled = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_2_enabled");
         m_pBeatLoop4Enabled = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_4_enabled");
         m_pBeatLoop64Enabled = std::make_unique<ControlProxy>(m_sGroup1, "beatloop_64_enabled");
@@ -59,6 +60,9 @@ class LoopingControlTest : public MockedEngineBackendTest {
         m_pBeatJumpSize = std::make_unique<ControlProxy>(m_sGroup1, "beatjump_size");
         m_pButtonBeatJumpForward = std::make_unique<ControlProxy>(m_sGroup1, "beatjump_forward");
         m_pButtonBeatJumpBackward = std::make_unique<ControlProxy>(m_sGroup1, "beatjump_backward");
+        m_pButtonBeatLoopRoll1Activate = std::make_unique<ControlProxy>(m_sGroup1, "beatlooproll_1_activate");
+        m_pButtonBeatLoopRoll2Activate = std::make_unique<ControlProxy>(m_sGroup1, "beatlooproll_2_activate");
+        m_pButtonBeatLoopRoll4Activate = std::make_unique<ControlProxy>(m_sGroup1, "beatlooproll_4_activate");
     }
 
     bool isLoopEnabled() {
@@ -92,6 +96,7 @@ class LoopingControlTest : public MockedEngineBackendTest {
     std::unique_ptr<ControlProxy> m_pButtonBeatMoveBackward;
     std::unique_ptr<ControlProxy> m_pButtonBeatLoop2Activate;
     std::unique_ptr<ControlProxy> m_pButtonBeatLoop4Activate;
+    std::unique_ptr<ControlProxy> m_pBeatLoop1Enabled;
     std::unique_ptr<ControlProxy> m_pBeatLoop2Enabled;
     std::unique_ptr<ControlProxy> m_pBeatLoop4Enabled;
     std::unique_ptr<ControlProxy> m_pBeatLoop64Enabled;
@@ -101,6 +106,9 @@ class LoopingControlTest : public MockedEngineBackendTest {
     std::unique_ptr<ControlProxy> m_pBeatJumpSize;
     std::unique_ptr<ControlProxy> m_pButtonBeatJumpForward;
     std::unique_ptr<ControlProxy> m_pButtonBeatJumpBackward;
+    std::unique_ptr<ControlProxy> m_pButtonBeatLoopRoll1Activate;
+    std::unique_ptr<ControlProxy> m_pButtonBeatLoopRoll2Activate;
+    std::unique_ptr<ControlProxy> m_pButtonBeatLoopRoll4Activate;
 };
 
 TEST_F(LoopingControlTest, LoopSet) {
@@ -873,4 +881,110 @@ TEST_F(LoopingControlTest, LoopEscape) {
     // seek outside a loop should disable it
     seekToSampleAndProcess(50);
     EXPECT_FALSE(isLoopEnabled());
+}
+
+TEST_F(LoopingControlTest, BeatLoopRoll_Activation) {
+    m_pTrack1->setBpm(120.0);
+
+    m_pButtonBeatLoopRoll2Activate->set(1.0);
+    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_TRUE(m_pBeatLoop2Enabled->toBool());
+
+    m_pButtonBeatLoopRoll2Activate->set(0.0);
+    EXPECT_FALSE(m_pLoopEnabled->toBool());
+    EXPECT_FALSE(m_pBeatLoop2Enabled->toBool());
+}
+
+TEST_F(LoopingControlTest, BeatLoopRoll_Overlap) {
+    m_pTrack1->setBpm(120.0);
+
+    m_pButtonBeatLoopRoll2Activate->set(1.0);
+    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_TRUE(m_pBeatLoop2Enabled->toBool());
+
+    m_pButtonBeatLoopRoll4Activate->set(1.0);
+    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_TRUE(m_pBeatLoop4Enabled->toBool());
+    EXPECT_FALSE(m_pBeatLoop2Enabled->toBool());
+
+    m_pButtonBeatLoopRoll2Activate->set(0.0);
+    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_TRUE(m_pBeatLoop4Enabled->toBool());
+    EXPECT_FALSE(m_pBeatLoop2Enabled->toBool());
+
+    m_pButtonBeatLoopRoll4Activate->set(0.0);
+    EXPECT_FALSE(m_pLoopEnabled->toBool());
+    EXPECT_FALSE(m_pBeatLoop4Enabled->toBool());
+}
+
+TEST_F(LoopingControlTest, BeatLoopRoll_OverlapStackUnwind) {
+    m_pTrack1->setBpm(120.0);
+
+    // start a 2 beat loop roll
+    m_pButtonBeatLoopRoll2Activate->set(1.0);
+    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_TRUE(m_pBeatLoop2Enabled->toBool());
+
+    // start a 4 beat loop roll on top of the previous loop
+    m_pButtonBeatLoopRoll4Activate->set(1.0);
+    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_TRUE(m_pBeatLoop4Enabled->toBool());
+    EXPECT_FALSE(m_pBeatLoop2Enabled->toBool());
+
+    // start a 1 beat loop roll on top of the previous loop
+    m_pButtonBeatLoopRoll1Activate->set(1.0);
+    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_TRUE(m_pBeatLoop1Enabled->toBool());
+    EXPECT_FALSE(m_pBeatLoop4Enabled->toBool());
+
+    // stop the 4 beat loop roll, the 1 beat roll should continue
+    m_pButtonBeatLoopRoll4Activate->set(0.0);
+    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_TRUE(m_pBeatLoop1Enabled->toBool());
+
+    // stop the 1 beat loop roll, the 2 beat roll should continue
+    m_pButtonBeatLoopRoll1Activate->set(0.0);
+    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_TRUE(m_pBeatLoop2Enabled->toBool());
+    EXPECT_FALSE(m_pBeatLoop1Enabled->toBool());
+
+    // stop the 2 beat loop roll
+    m_pButtonBeatLoopRoll2Activate->set(0.0);
+    EXPECT_FALSE(m_pLoopEnabled->toBool());
+    EXPECT_FALSE(m_pBeatLoop2Enabled->toBool());
+}
+
+TEST_F(LoopingControlTest, BeatLoopRoll_StartPoint) {
+    m_pTrack1->setBpm(120.0);
+
+    // start a 4 beat loop roll, start point should be overriden to play position
+    m_pLoopStartPoint->slotSet(8);
+    m_pButtonBeatLoopRoll4Activate->set(1.0);
+    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_TRUE(m_pBeatLoop4Enabled->toBool());
+    EXPECT_EQ(0, m_pLoopStartPoint->get());
+
+    // move the start point, activate a 1 beat loop roll, new start point be preserved
+    m_pLoopStartPoint->slotSet(8);
+    m_pButtonBeatLoopRoll1Activate->set(1.0);
+    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_TRUE(m_pBeatLoop1Enabled->toBool());
+    EXPECT_EQ(8, m_pLoopStartPoint->get());
+
+    // end the 1 beat loop roll
+    m_pButtonBeatLoopRoll1Activate->set(0.0);
+    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_EQ(8, m_pLoopStartPoint->get());
+    EXPECT_TRUE(m_pBeatLoop4Enabled->toBool());
+
+    // end the 4 beat loop roll
+    m_pButtonBeatLoopRoll4Activate->set(0.0);
+    EXPECT_FALSE(m_pLoopEnabled->toBool());
+    EXPECT_FALSE(m_pBeatLoop4Enabled->toBool());
+
+    // new loop should start back at 0
+    m_pButtonBeatLoopRoll4Activate->set(1.0);
+    EXPECT_TRUE(m_pLoopEnabled->toBool());
+    EXPECT_TRUE(m_pBeatLoop4Enabled->toBool());
+    EXPECT_EQ(0, m_pLoopStartPoint->get());
 }


### PR DESCRIPTION
This is necessary if multiple beatlooproll keys are pressed on a controller. Previously, Mixxx would stop the loop roll if any keys were released. Now it tracks all active rolls and will activate the last active one that is still active (button still down) instead of deactivating all rolls. Additionally, if a loop roll is active, activating another beat loop roll will start the loop from the start of the current loop, instead the current play position.

I believe this loop roll behavior is more intuitive and natural.