### PR TITLE
Sync to the loaded deck with the lowest index if no track is playing

### DIFF
--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -120,23 +120,24 @@ void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
                     continue;
                 }
 
-                double otherDeckBpm = pOtherSyncable->getBpm();
-                if (otherDeckBpm > 0.0) {
+                double otherBpm = pOtherSyncable->getBpm();
+                bool otherIsPlaying = pOtherSyncable->isPlaying();
+                if (otherBpm > 0.0) {
                     // If the requesting deck is playing, or we have already a
                     // non playing deck found, only watch out for playing decks.
                     if ((foundTargetBpm || pSyncable->isPlaying())
-                            && !pOtherSyncable->isPlaying()) {
+                            && !otherIsPlaying) {
                         continue;
                     }
                     foundTargetBpm = true;
-                    targetBpm = otherDeckBpm;
+                    targetBpm = otherBpm;
                     targetBaseBpm = pOtherSyncable->getBaseBpm();
                     targetBeatDistance = pOtherSyncable->getBeatDistance();
 
                     // If the other deck is playing we stop looking
                     // immediately. Otherwise continue looking for a playing
                     // deck with bpm > 0.0.
-                    if (pOtherSyncable->isPlaying()) {
+                    if (otherIsPlaying) {
                         foundPlayingDeck = true;
                         break;
                     }

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -123,7 +123,7 @@ void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
                 double otherDeckBpm = pOtherSyncable->getBpm();
                 if (otherDeckBpm > 0.0) {
                     // If the requesting deck is playing, or we have already a
-                    // non plaing deck found, only watch out for playing decks.
+                    // non playing deck found, only watch out for playing decks.
                     if ((foundTargetBpm || pSyncable->isPlaying())
                             && !pOtherSyncable->isPlaying()) {
                         continue;

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -110,32 +110,33 @@ void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
             double targetBeatDistance = 0.0;
             double targetBaseBpm = 0.0;
 
-            foreach (const Syncable* other_deck, m_syncables) {
-                if (other_deck == pSyncable) {
+            for (const auto& pOtherSyncable: m_syncables) {
+                if (pOtherSyncable == pSyncable) {
                     // skip this deck
                     continue;
                 }
-                if (!other_deck->getChannel()->isMasterEnabled()) {
+                if (!pOtherSyncable->getChannel()->isMasterEnabled()) {
                     // skip non-master decks, like preview decks.
                     continue;
                 }
 
-                double otherDeckBpm = other_deck->getBpm();
+                double otherDeckBpm = pOtherSyncable->getBpm();
                 if (otherDeckBpm > 0.0) {
-                    // If the requesting deck is playing, but the other deck
-                    // is not, do not sync.
-                    if (pSyncable->isPlaying() && !other_deck->isPlaying()) {
+                    // If the requesting deck is playing, or we have already a
+                    // non plaing deck found, only watch out for playing decks.
+                    if ((foundTargetBpm || pSyncable->isPlaying())
+                            && !pOtherSyncable->isPlaying()) {
                         continue;
                     }
                     foundTargetBpm = true;
                     targetBpm = otherDeckBpm;
-                    targetBaseBpm = other_deck->getBaseBpm();
-                    targetBeatDistance = other_deck->getBeatDistance();
+                    targetBaseBpm = pOtherSyncable->getBaseBpm();
+                    targetBeatDistance = pOtherSyncable->getBeatDistance();
 
                     // If the other deck is playing we stop looking
                     // immediately. Otherwise continue looking for a playing
                     // deck with bpm > 0.0.
-                    if (other_deck->isPlaying()) {
+                    if (pOtherSyncable->isPlaying()) {
                         foundPlayingDeck = true;
                         break;
                     }

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1320,29 +1320,43 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     EXPECT_LT(0.8, ControlObject::getControl(ConfigKey(m_sInternalClockGroup,
                                                        "beat_distance"))->get());
 
-    // But if there is a third deck that is sync-enabled, we match that.
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(0.0);
+    pButtonSyncEnabled1->set(0.0);
+    ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->set(getRateSliderValue(1.0));
+
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(0.0);
+    pButtonSyncEnabled2->set(0.0);
+    ControlObject::getControl(ConfigKey(m_sGroup2, "rate"))->set(getRateSliderValue(1.0));
+
+    // But if there is a third deck that is sync-enabled, we match that.
     auto pButtonSyncEnabled3 = std::make_unique<ControlProxy>(m_sGroup3, "sync_enabled");
     auto pFileBpm3 = std::make_unique<ControlProxy>(m_sGroup3, "file_bpm");
     ControlObject::getControl(ConfigKey(m_sGroup3, "beat_distance"))->set(0.6);
-    ControlObject::getControl(ConfigKey(m_sGroup3, "rate"))->set(getRateSliderValue(1.0));
     BeatsPointer pBeats3 = BeatFactory::makeBeatGrid(*m_pTrack3, 140, 0.0);
     m_pTrack3->setBeats(pBeats3);
     pFileBpm3->set(140.0);
-    pButtonSyncEnabled1->set(0.0);
-    ProcessBuffer();
-    pButtonSyncEnabled1->set(1.0);
+    // This will sync to the first deck here and not the second (lp1784185)
     pButtonSyncEnabled3->set(1.0);
+    ProcessBuffer();
+    EXPECT_FLOAT_EQ(130.0, ControlObject::getControl(ConfigKey(m_sGroup3, "bpm"))->get());
+    // revert that
+    ControlObject::getControl(ConfigKey(m_sGroup3, "rate"))->set(getRateSliderValue(1.0));
+    ProcessBuffer();
+    EXPECT_FLOAT_EQ(140.0, ControlObject::getControl(ConfigKey(m_sGroup3, "bpm"))->get());
+    // now we have Deck 3 with 140 bpm and sync enabled
+
+    pButtonSyncEnabled1->set(1.0);
+    ProcessBuffer();
 
     ControlObject::getControl(ConfigKey(m_sGroup3, "play"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "play"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     ProcessBuffer();
 
-    EXPECT_FLOAT_EQ(100.0,
+    // We expect Deck 1 is Deck 3 bpm
+    EXPECT_FLOAT_EQ(140.0,
                     ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
-    EXPECT_FLOAT_EQ(100.0, ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
+    EXPECT_FLOAT_EQ(140.0, ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
     // The exact beat distance will be one buffer past .6, but this is good
     // enough to confirm that it worked.
     EXPECT_GT(0.7, ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->get());

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1340,9 +1340,9 @@ TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "play"))->set(1.0);
     ProcessBuffer();
 
-    EXPECT_FLOAT_EQ(140.0,
+    EXPECT_FLOAT_EQ(100.0,
                     ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
-    EXPECT_FLOAT_EQ(140.0, ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
+    EXPECT_FLOAT_EQ(100.0, ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
     // The exact beat distance will be one buffer past .6, but this is good
     // enough to confirm that it worked.
     EXPECT_GT(0.7, ControlObject::getControl(ConfigKey(m_sGroup1, "beat_distance"))->get());


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/mixxx/+bug/1784185

I have targeted it to 2.1 because it has a limited scope and it has a test. 
The current behavior can be really annoying, if the last syncable it a sampler,  that was reloaded automatically from a last session 

