### PR TITLE
lp1794993: Fix crash for files that can't be opened (Chromaprint)

### DIFF
--- a/src/musicbrainz/chromaprinter.cpp
+++ b/src/musicbrainz/chromaprinter.cpp
@@ -110,8 +110,7 @@ QString ChromaPrinter::getFingerprint(TrackPointer pTrack) {
     if (!pAudioSource) {
         qDebug()
                 << "Failed to open file for fingerprinting"
-                << pTrack->getLocation()
-                << *pAudioSource;
+                << pTrack->getLocation();
         return QString();
     }
 


### PR DESCRIPTION
Probably a copy&paste error :grimacing:

https://bugs.launchpad.net/mixxx/+bug/1794993

**This fix has to be promoted to both *2.2* and *master*!**