### PR TITLE
Add @rpath support to osx/otool.py.

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -470,20 +470,12 @@ class Qt(Dependence):
                         os.path.join(build.env['QTDIR'],'plugins/sqldrivers')])
                     build.env.Append(LIBS = 'qsqlite')
 
-
-
-        # Set the rpath for linux/bsd/osx.
-        # This is not supported on OS X before the 10.5 SDK.
-        using_104_sdk = (str(build.env["CCFLAGS"]).find("10.4") >= 0)
-        compiling_on_104 = False
-        if build.platform_is_osx:
-            compiling_on_104 = (
-                os.popen('sw_vers').readlines()[1].find('10.4') >= 0)
-        if not build.platform_is_windows and not (using_104_sdk or compiling_on_104):
+        # Set the rpath for linux/bsd/macOS.
+        if not build.platform_is_windows:
             qtdir = build.env['QTDIR']
-            framework_path = Qt.find_framework_libdir(qtdir, qt5)
-            if os.path.isdir(framework_path):
-                build.env.Append(LINKFLAGS="-L" + framework_path)
+            libdir_path = Qt.find_framework_libdir(qtdir, qt5)
+            if os.path.isdir(libdir_path):
+                build.env.Append(LINKFLAGS=['-Wl,-rpath,%s' % libdir_path])
 
         # Mixxx requires C++11 support. Windows enables C++11 features by
         # default but Clang/GCC require a flag.

--- a/build/osx/OSConsX.py
+++ b/build/osx/OSConsX.py
@@ -246,6 +246,8 @@ def build_app(target, source, env):
     locals = {} # [ref] => (absolute_path, embedded_path) (ref is the original reference from looking at otool -L; we use this to decide if two libs are the same)
 
     #XXX it would be handy if embed_dependencies returned the otool list for each ref it reads..
+    binary_rpaths = otool.rpaths(str(binary))
+    otool_local_paths = binary_rpaths + otool_local_paths
     for ref, path in otool.embed_dependencies(str(binary), LOCAL=otool_local_paths, SYSTEM=otool_system_paths):
         locals[ref] = (path, embed_lib(path))
 

--- a/build/osx/golden_environment
+++ b/build/osx/golden_environment
@@ -1,1 +1,1 @@
-2.2-j00015-fdff837e-osx10.11-x86_64-release
+2.3-j00001-6fe69c4-osx10.11-x86_64-release

--- a/build/osx/otool.py
+++ b/build/osx/otool.py
@@ -146,19 +146,19 @@ def embed_dependencies(binary,
 		#todo: this would make sense as a separate function, but the @ case would be awkward to handle and it's iffy about what it should
 		if e.startswith('/'):
 			p = e
-		elif e.startswith('@'): #it's a relative load path
+		elif e.startswith('@') and not e.startswith('@rpath'): #it's a relative load path
 			raise Exception("Unable to make heads nor tails, sah, of install name '%s'. Relative paths are for already-bundled binaries, this function does not support them." % e)
 		else:
 			#experiments show that giving an unspecified path is asking dyld(1) to find the library for us. This covers that case.
 			#i will not do further experiments to figure out what dyld(1)'s specific search algorithm is (whether it looks at frameworks separate from dylibs) because that's not the public interface
-
+                        e_stripped = e.replace('@rpath/', '') if e.startswith('@rpath/') else e
 			for P in ['']+LOCAL+SYSTEM: #XXX should local have priority over system or vice versa? (also, '' is the handle the relative case)
-				p = os.path.abspath(os.path.join(P, e))
+				p = os.path.abspath(os.path.join(P, e_stripped))
 				#print("SEARCHING IN LIBPATH; TRYING", p)
 				if os.path.exists(p):
 					break
 			else:
-				p = e #fallthrough to the exception below #XXX icky bad logic, there must be a way to avoid saying exists() twice
+				p = e_stripped #fallthrough to the exception below #XXX icky bad logic, there must be a way to avoid saying exists() twice
 
 		if not os.path.exists(p):
 			raise Exception("Dependent library '%s' not found. Make sure it is installed." % e)

--- a/build/osx/otool.py
+++ b/build/osx/otool.py
@@ -1,5 +1,6 @@
 
 import os
+import subprocess
 
 #This page is REALLY USEFUL: http://www.cocoadev.com/index.pl?ApplicationLinking
 #question: why do dylibs embed their install name in themselves? that would seem to imply the system keeps a cache of all the "install names", but that's not what the docs seem to say.
@@ -195,3 +196,21 @@ def change_ref(binary, orig, new):
 #
 
 #keywords: @executable_path, @loader_path, @rpath. TODO: document these.
+
+def rpaths(binary):
+        """Returns a list of the LC_RPATH load commands in the provided binary."""
+        print("otool(%s)" % binary)
+        p = subprocess.Popen(['otool', '-l', binary],
+                             stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+
+        lines = stdout.split('\n')
+        rpaths = []
+        for i, line in enumerate(lines):
+                if line.strip() == 'cmd LC_RPATH':
+                        path_line = lines[i + 2].strip().replace('path ', '')
+                        path_line = path_line[:path_line.rindex('(') - 1]
+                        rpaths.append(path_line)
+        return rpaths


### PR DESCRIPTION
Allows the use of relocatable Mixxx macOS environments.