### PR TITLE
Misc. typo and whitespace fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,19 +33,19 @@ Here is a quick summary of what is new in Mixxx 2.1.2:
 * Fix artifacts using more than 32 samplers lp1779559
 * store No EQ and Filter persistently lp1780479
 * Pad unreadable samples with silence on cache miss lp1777480
-* Fixing painting of preview coloumn for Qt5 builds lp1776555
+* Fixing painting of preview column for Qt5 builds lp1776555
 * LateNight: Fix play button right click lp1781829
-* LateNight: Added missing sort up/down buttons 
+* LateNight: Added missing sort up/down buttons
 * Fix sampler play button tooltips lp1779468
 * Shade: remove superfluid margins and padding in sampler.xml lp1773588
-* Deere: Fix background-color code 
+* Deere: Fix background-color code
 * ITunes: Don't stop import in case of duplicated Playlists lp1783493
 
 ==== 2.1.1 2018-06-13 ====
 After two month it is time to do a bugfix release of Mixxx 2.1.
 Here is a quick summary of what is new in Mixxx 2.1.1:
 
-* Require Soundtouch 2.0 to avoid segfault lp1577042 
+* Require Soundtouch 2.0 to avoid segfault lp1577042
 * Imrpoved Skins including library view fix lp1773709 lp1772202 lp1763953
 * Fix crash when importing ID3v2 APIC frames lp1774790
 * Synchronize execution of Vamp analyzers lp1743256
@@ -57,7 +57,7 @@ Here is a quick summary of what is new in Mixxx 2.1.1:
 * Fix memory leak when loading cover art lp1767068
 * Fix clearing of ReplayGain gain/ratio in file tags lp1766094
 * Fix crash when removing a quick link lp1510068
-* Fidlib: Thread-safe and reentrant generation of filters lp1765210 
+* Fidlib: Thread-safe and reentrant generation of filters lp1765210
 * Fix unresponsive scrolling through crates & playlists using encoder lp1719474
 * Swap default values for temp/perm rate changes lp1764254
 

--- a/src/encoder/encodervorbis.cpp
+++ b/src/encoder/encodervorbis.cpp
@@ -64,7 +64,7 @@ void EncoderVorbis::setEncoderSettings(const EncoderSettings& settings)
         case EncoderSettings::ChannelMode::MONO:  m_channels = 1; break;
         case EncoderSettings::ChannelMode::STEREO: m_channels = 2; break;
         case EncoderSettings::ChannelMode::AUTOMATIC: // fallthrough
-        default: 
+        default:
             if (m_bitrate > MONO_BITRATE_THRESHOLD ) {
                 m_channels = 2;
             }
@@ -211,7 +211,7 @@ void EncoderVorbis::initStream() {
     ogg_stream_packetin(&m_oggs, &headerComment);
     ogg_stream_packetin(&m_oggs, &headerCode);
 
-    // The encoder is now inialized. The encode method will start streaming by
+    // The encoder is now initialized. The encode method will start streaming by
     // sending the header first.
     m_header_write = true;
     m_bStreamInitialized = true;

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -957,7 +957,7 @@ TEST_F(LoopingControlTest, BeatLoopRoll_OverlapStackUnwind) {
 TEST_F(LoopingControlTest, BeatLoopRoll_StartPoint) {
     m_pTrack1->setBpm(120.0);
 
-    // start a 4 beat loop roll, start point should be overriden to play position
+    // start a 4 beat loop roll, start point should be overridden to play position
     m_pLoopStartPoint->slotSet(8);
     m_pButtonBeatLoopRoll4Activate->set(1.0);
     EXPECT_TRUE(m_pLoopEnabled->toBool());


### PR DESCRIPTION
Found via `codespell`