### PR TITLE
[WIP] Enable Setting hotcue color via controlobject

### DIFF
--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -413,6 +413,48 @@ bpm.tapButton = function(deck) {
 //     print("Script: BPM="+average+" setting to "+fRateScale);
 }
 
+// color - Basic Object used for convient interface with the hotcue_color ControlObjects
+color = {
+  // member should be set directly but only in the [0;255] range.
+  red: 0,
+  green: 0,
+  blue: 0,
+  alpha: 255,
+}
+
+
+/* -------- ------------------------------------------------------
+      color.fromCO
+   Purpose: Setter that splits the combined colors into their components
+            and sets the color components in the object
+   Input:   combined color value
+   Output:  -
+   -------- ------------------------------------------------------ */
+
+color.fromCO = function(color) {
+    this.alpha = color >> 24 & 0xFF;
+    this.red = color >> 16 & 0xFF;
+    this.green = color >> 8 & 0xFF;
+    this.blue = color & 0xFF;
+}
+/* -------- ------------------------------------------------------
+      color.toCO
+   Purpose: Combines the colors back into a single value that
+            that could be used to set the MixxxControl value
+   Input:   -
+   Output:  struct containing the color components
+   -------- ------------------------------------------------------ */
+color.toCO = function() {
+  // javascript objects don't have "access control" and this object
+  // doesn't provide setters (interaction is supposed to be done via direct access)
+  // so this getter function sanitizes the values on export.
+  return (this.alpha % 255) << 24 +
+         (this.red  % 255) << 16 +
+         (this.green % 255) << 8 +
+         this. blue % 255;
+}
+
+
 // ----------------- Common regular expressions --------------------------
 script.samplerRegEx = /^\[Sampler(\d+)\]$/ ;
 script.channelRegEx = /^\[Channel(\d+)\]$/ ;

--- a/res/skins/Deere/deck_visual_row.xml
+++ b/res/skins/Deere/deck_visual_row.xml
@@ -26,8 +26,6 @@
         <SignalRGBHighColor></SignalRGBHighColor>
         <SignalRGBMidColor></SignalRGBMidColor>
         <SignalRGBLowColor></SignalRGBLowColor>
-        <Black>#00FFFF</Black>
-        <Yellow>#FF0000</Yellow>
         <SignalColor><Variable name="DeckSignalColor"/></SignalColor>
         <BeatColor>#ffffff</BeatColor>
         <PlayPosColor>#00FF00</PlayPosColor>

--- a/res/skins/Deere/deck_visual_row.xml
+++ b/res/skins/Deere/deck_visual_row.xml
@@ -26,6 +26,8 @@
         <SignalRGBHighColor></SignalRGBHighColor>
         <SignalRGBMidColor></SignalRGBMidColor>
         <SignalRGBLowColor></SignalRGBLowColor>
+        <Black>#00FFFF</Black>
+        <Yellow>#FF0000</Yellow>
         <SignalColor><Variable name="DeckSignalColor"/></SignalColor>
         <BeatColor>#ffffff</BeatColor>
         <PlayPosColor>#00FF00</PlayPosColor>

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -299,8 +299,6 @@ void CueControl::trackCuesUpdated() {
             } else {
                 // If the old hotcue is the same, then we only need to update
                 pControl->setPosition(pCue->getPosition());
-                // NOTE(Swiftb0y): I don't know if this is the smartest location to manage
-                // please suggest whether this should rather go somewhere else.
                 pControl->setColor(pCue->getColor());
             }
             // Add the hotcue to the list of active hotcues

--- a/src/engine/cuecontrol.h
+++ b/src/engine/cuecontrol.h
@@ -30,6 +30,8 @@ class HotcueControl : public QObject {
     void setCue(CuePointer pCue);
     void resetCue();
     void setPosition(double position);
+    void setColor(QColor newColor);
+    QColor getColor() const;
 
     // Used for caching the preview state of this hotcue control.
     inline bool isPreviewing() {
@@ -54,6 +56,7 @@ class HotcueControl : public QObject {
     void slotHotcueActivatePreview(double v);
     void slotHotcueClear(double v);
     void slotHotcuePositionChanged(double newPosition);
+    void slotHotcueColorChanged(double newColor);
 
   signals:
     void hotcueSet(HotcueControl* pHotcue, double v);
@@ -64,6 +67,7 @@ class HotcueControl : public QObject {
     void hotcueActivatePreview(HotcueControl* pHotcue, double v);
     void hotcueClear(HotcueControl* pHotcue, double v);
     void hotcuePositionChanged(HotcueControl* pHotcue, double newPosition);
+    void hotcueColorChanged(HotcueControl* pHotcue, double newColor);
     void hotcuePlay(double v);
 
   private:
@@ -76,6 +80,7 @@ class HotcueControl : public QObject {
     // Hotcue state controls
     ControlObject* m_hotcuePosition;
     ControlObject* m_hotcueEnabled;
+    ControlObject* m_hotcueColor;
     // Hotcue button controls
     ControlObject* m_hotcueSet;
     ControlObject* m_hotcueGoto;

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -397,15 +397,7 @@ void DlgTrackInfo::populateCues(TrackPointer pTrack) {
             const QModelIndex idx = colorComboBox->model()->index(i, 0);
             colorComboBox->model()->setData(idx, color, Qt::BackgroundColorRole);
             // TODO (Swiftb0y): put color choosing function into util/color.h
-            colorComboBox->setItemData(
-                    i,
-                    isDimmColor(
-                            color.red(),
-                            color.green(),
-                            color.blue()) ?
-                                    QColor(255,255,255,255) :
-                                    QColor(0,0,0,255),
-                    Qt::TextColorRole);
+            colorComboBox->setItemData(i, chooseContrastColor(color), Qt::TextColorRole);
 
         }
         QColor cueColor = pCue->getColor();

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -17,58 +17,6 @@
 const int kFilterLength = 80;
 const int kMinBpm = 30;
 
-// NOTE(Swiftb0y): Maybe this should be defined somewhere more global/logical?
-
-const static QList<QString> ColorNames = {
-     QObject::tr("Red"),
-     QObject::tr("Green"),
-     QObject::tr("Yellow"),
-     QObject::tr("Blue"),
-     QObject::tr("Orange"),
-     QObject::tr("Purple"),
-     QObject::tr("Cyan"),
-     QObject::tr("Magenta"),
-     QObject::tr("Lime"),
-     QObject::tr("Pink"),
-     QObject::tr("Teal"),
-     QObject::tr("Lavender"),
-     QObject::tr("Brown"),
-     QObject::tr("Beige"),
-     QObject::tr("Maroon"),
-     QObject::tr("Mint"),
-     QObject::tr("Olive"),
-     QObject::tr("Apricot"),
-     QObject::tr("Navy"),
-     QObject::tr("Grey"),
-     QObject::tr("White"),
-     QObject::tr("Black"),
-};
-
-const static QList<QColor> Colors = {
-     QColor("#E6194B"),
-     QColor("#3CB44B"),
-     QColor("#FFE119"),
-     QColor("#4363D8"),
-     QColor("#F58231"),
-     QColor("#911EB4"),
-     QColor("#42D4F4"),
-     QColor("#F032E6"),
-     QColor("#BFEF45"),
-     QColor("#FABEBE"),
-     QColor("#469990"),
-     QColor("#E6BEFF"),
-     QColor("#9A6324"),
-     QColor("#FFFAC8"),
-     QColor("#800000"),
-     QColor("#AAFFC3"),
-     QColor("#808000"),
-     QColor("#FFD8B1"),
-     QColor("#000075"),
-     QColor("#A9A9A9"),
-     QColor("#FFFFFF"),
-     QColor("#000000"),
-};
-
 // Maximum allowed interval between beats (calculated from kMinBpm).
 const mixxx::Duration kMaxInterval = mixxx::Duration::fromMillis(1000.0 * (60.0 / kMinBpm));
 
@@ -89,8 +37,6 @@ void DlgTrackInfo::init() {
 
     cueTable->hideColumn(0);
     coverBox->insertWidget(1, m_pWCoverArtLabel);
-
-    RELEASE_ASSERT(ColorNames.length() == Colors.length());
 
     connect(btnNext, SIGNAL(clicked()),
             this, SLOT(slotNext()));
@@ -391,17 +337,19 @@ void DlgTrackInfo::populateCues(TrackPointer pTrack) {
 
 
         QComboBox* colorComboBox = new QComboBox();
-        for (int i = 0 ; i < ColorNames.length() ;i++) {
-            const QColor color = Colors.at(i);
-            colorComboBox->addItem(ColorNames.at(i),color);
+        QList<QColor> predefinedColors = Color::predefinedColors();
+        for (int i = 0; i < predefinedColors.count(); i++) {
+            QColor color = predefinedColors.at(i);
+            colorComboBox->addItem(Color::displayName(color), color);
             const QModelIndex idx = colorComboBox->model()->index(i, 0);
             colorComboBox->model()->setData(idx, color, Qt::BackgroundColorRole);
-            // TODO (Swiftb0y): put color choosing function into util/color.h
-            colorComboBox->setItemData(i, chooseContrastColor(color), Qt::TextColorRole);
+            colorComboBox->setItemData(i, Color::chooseContrastColor(color), Qt::TextColorRole);
 
         }
         const QColor cueColor = pCue->getColor();
-        colorComboBox->setCurrentIndex(Colors.contains(cueColor) ? Colors.indexOf(cueColor) : 0);
+        colorComboBox->setCurrentIndex(predefinedColors.contains(cueColor)
+                ? predefinedColors.indexOf(cueColor)
+                : 0);
 
         m_cueMap[row] = pCue;
         cueTable->insertRow(row);
@@ -482,7 +430,8 @@ void DlgTrackInfo::saveTrack() {
 
         auto colorComboBox = qobject_cast<QComboBox*>(colorWidget);
         if (colorComboBox) {
-            const auto color = Colors.at(colorComboBox->currentIndex());
+            QList<QColor> predefinedColors = Color::predefinedColors();
+            QColor color = predefinedColors.at(colorComboBox->currentIndex());
             if (color.isValid()) {
                 pCue->setColor(color);
             }

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -400,7 +400,7 @@ void DlgTrackInfo::populateCues(TrackPointer pTrack) {
             colorComboBox->setItemData(i, chooseContrastColor(color), Qt::TextColorRole);
 
         }
-        QColor cueColor = pCue->getColor();
+        const QColor cueColor = pCue->getColor();
         colorComboBox->setCurrentIndex(Colors.contains(cueColor) ? Colors.indexOf(cueColor) : 0);
 
         m_cueMap[row] = pCue;
@@ -529,7 +529,6 @@ void DlgTrackInfo::unloadTrack(bool save) {
 }
 
 void DlgTrackInfo::clear() {
-
     disconnect(this, SLOT(updateTrackMetadata()));
     m_pLoadedTrack.reset();
 

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -337,7 +337,7 @@ void DlgTrackInfo::populateCues(TrackPointer pTrack) {
 
 
         QComboBox* colorComboBox = new QComboBox();
-        QList<QColor> predefinedColors = Color::predefinedColors();
+        const QList<QColor>& predefinedColors = Color::predefinedColors;
         for (int i = 0; i < predefinedColors.count(); i++) {
             QColor color = predefinedColors.at(i);
             colorComboBox->addItem(Color::displayName(color), color);
@@ -430,8 +430,7 @@ void DlgTrackInfo::saveTrack() {
 
         auto colorComboBox = qobject_cast<QComboBox*>(colorWidget);
         if (colorComboBox) {
-            QList<QColor> predefinedColors = Color::predefinedColors();
-            QColor color = predefinedColors.at(colorComboBox->currentIndex());
+            QColor color = Color::predefinedColors.at(colorComboBox->currentIndex());
             if (color.isValid()) {
                 pCue->setColor(color);
             }

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -387,7 +387,7 @@ void DlgTrackInfo::saveTrack() {
         QTableWidgetItem* colorItem = cueTable->item(row, 3);
         QTableWidgetItem* labelItem = cueTable->item(row, 4);
 
-        VERIFY_OR_DEBUG_ASSERT(!rowItem || !hotcueItem || !colorItem || !labelItem) {
+        VERIFY_OR_DEBUG_ASSERT(rowItem && hotcueItem && colorItem && labelItem) {
             qWarning() << "unable to retrieve cells from cueTable row";
             continue;
         }

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -387,8 +387,10 @@ void DlgTrackInfo::saveTrack() {
         QTableWidgetItem* colorItem = cueTable->item(row, 3);
         QTableWidgetItem* labelItem = cueTable->item(row, 4);
 
-        if (!rowItem || !hotcueItem || !colorItem|| !labelItem)
+        VERIFY_OR_DEBUG_ASSERT(!rowItem || !hotcueItem || !colorItem || !labelItem) {
+            qWarning() << "unable to retrieve cells from cueTable row";
             continue;
+        }
 
         int oldRow = rowItem->data(Qt::DisplayRole).toInt();
         CuePointer pCue(m_cueMap.value(oldRow, CuePointer()));

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -410,7 +410,7 @@ void DlgTrackInfo::saveTrack() {
 
         QVariant vHotCueColor = colorItem->data(Qt::DisplayRole);
         if (vHotcue.canConvert<QString>()) {
-            QString colorString = vHotcue.toString();
+            QString colorString = vHotCueColor.toString();
             auto color = QColor(colorString);
             if (color.isValid()) {
                 pCue->setColor(color);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -332,12 +332,15 @@ void DlgTrackInfo::populateCues(TrackPointer pTrack) {
         // Make the duration read only
         durationItem->setFlags(Qt::NoItemFlags);
 
+        QColor cueColor = pCue->getColor();
+
         m_cueMap[row] = pCue;
         cueTable->insertRow(row);
         cueTable->setItem(row, 0, new QTableWidgetItem(rowStr));
         cueTable->setItem(row, 1, durationItem);
         cueTable->setItem(row, 2, new QTableWidgetItem(hotcue));
-        cueTable->setItem(row, 3, new QTableWidgetItem(pCue->getLabel()));
+        cueTable->setItem(row, 3, new QTableWidgetItem(cueColor.name().toUpper()));
+        cueTable->setItem(row, 4, new QTableWidgetItem(pCue->getLabel()));
         row += 1;
     }
     cueTable->setSortingEnabled(true);
@@ -381,9 +384,10 @@ void DlgTrackInfo::saveTrack() {
     for (int row = 0; row < cueTable->rowCount(); ++row) {
         QTableWidgetItem* rowItem = cueTable->item(row, 0);
         QTableWidgetItem* hotcueItem = cueTable->item(row, 2);
-        QTableWidgetItem* labelItem = cueTable->item(row, 3);
+        QTableWidgetItem* colorItem = cueTable->item(row, 3);
+        QTableWidgetItem* labelItem = cueTable->item(row, 4);
 
-        if (!rowItem || !hotcueItem || !labelItem)
+        if (!rowItem || !hotcueItem || !colorItem|| !labelItem)
             continue;
 
         int oldRow = rowItem->data(Qt::DisplayRole).toInt();
@@ -402,6 +406,16 @@ void DlgTrackInfo::saveTrack() {
             pCue->setHotCue(iTableHotcue - 1);
         } else {
             pCue->setHotCue(-1);
+        }
+
+        QVariant vHotCueColor = colorItem->data(Qt::DisplayRole);
+        if (vHotcue.canConvert<QString>()) {
+            QString colorString = vHotcue.toString();
+            auto color = QColor(colorString);
+            if (color.isValid()) {
+                pCue->setColor(color);
+            }
+            // do nothing for now.
         }
 
         QString label = labelItem->data(Qt::DisplayRole).toString();

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -822,6 +822,11 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
          </column>
          <column>
           <property name="text">
+           <string>Color</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
            <string>Label</string>
           </property>
          </column>

--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -14,6 +14,7 @@
 
 #include "preferences/usersettings.h"
 #include "skin/pixmapsource.h"
+#include "util/color.h"
 #include "widget/wsingletoncontainer.h"
 #include "widget/wpixmapstore.h"
 
@@ -264,6 +265,18 @@ class SkinContext {
 
     double getScaleFactor() const {
         return m_scaleFactor;
+    }
+
+    ColorsRepresentation getCueColorsRepresentation(const QDomNode& node) const {
+        ColorsRepresentation colorsReprsentation = Color::defaultRepresentation;
+        for (QLatin1String colorName : Color::predefinedColorsNames) {
+            QColor representation = selectColor(node, "Cue" + colorName);
+            if (representation.isValid()) {
+                QColor originalColor = Color::predefinedColorFromName(colorName);
+                colorsReprsentation.setRepresentation(originalColor, representation);
+            }
+        }
+        return colorsReprsentation;
     }
 
   private:

--- a/src/util/color.h
+++ b/src/util/color.h
@@ -213,7 +213,7 @@ namespace Color {
 
     // Returns a new default colors representation, i.e. maps each default color to itself.
     // Stores the color's name() property, e.g. "#A9A9A9"
-    static std::unique_ptr<ColorsRepresentation> defaultRepresentation() {
+    static std::unique_ptr<ColorsRepresentation> makeDefaultRepresentation() {
         std::unique_ptr<ColorsRepresentation> representation = std::make_unique<ColorsRepresentation>();
         for (QColor color : predefinedColors()) {
             representation->setRepresentation(color, color);

--- a/src/util/color.h
+++ b/src/util/color.h
@@ -29,6 +29,7 @@ class ColorsRepresentation final {
     QHash<QString, QString> colorNameMap;
 };
 
+// These methods and properties are not thread-safe, use them only on the GUI thread
 namespace Color {
     static const QColor Red      = QColor("#E6194B");
     static const QColor Green    = QColor("#3CB44B");
@@ -54,63 +55,58 @@ namespace Color {
     static const QColor Black    = QColor("#000000");
 
     // Return a list with the predefined colors.
-    static QList<QColor> predefinedColors() {
-        return QList<QColor> {
-            Red,
-            Green,
-            Yellow,
-            Blue,
-            Orange,
-            Purple,
-            Cyan,
-            Magenta,
-            Lime,
-            Pink,
-            Teal,
-            Lavender,
-            Brown,
-            Beige,
-            Maroon,
-            Mint,
-            Olive,
-            Apricot,
-            Navy,
-            Grey,
-            White,
-            Black,
-        };
+    static const QList<QColor> predefinedColors {
+        Red,
+        Green,
+        Yellow,
+        Blue,
+        Orange,
+        Purple,
+        Cyan,
+        Magenta,
+        Lime,
+        Pink,
+        Teal,
+        Lavender,
+        Brown,
+        Beige,
+        Maroon,
+        Mint,
+        Olive,
+        Apricot,
+        Navy,
+        Grey,
+        White,
+        Black,
     };
 
     // Return a list with the internal names of the predefined colors.
-    static QList<QLatin1String> predefinedColorsNames() {
-        return QList<QLatin1String> {
-            QLatin1String("Red"),
-            QLatin1String("Green"),
-            QLatin1String("Yellow"),
-            QLatin1String("Blue"),
-            QLatin1String("Orange"),
-            QLatin1String("Purple"),
-            QLatin1String("Cyan"),
-            QLatin1String("Magenta"),
-            QLatin1String("Lime"),
-            QLatin1String("Pink"),
-            QLatin1String("Teal"),
-            QLatin1String("Lavender"),
-            QLatin1String("Brown"),
-            QLatin1String("Beige"),
-            QLatin1String("Maroon"),
-            QLatin1String("Mint"),
-            QLatin1String("Olive"),
-            QLatin1String("Apricot"),
-            QLatin1String("Navy"),
-            QLatin1String("Grey"),
-            QLatin1String("White"),
-            QLatin1String("Black"),
-        };
+    static const QList<QLatin1String> predefinedColorsNames {
+        QLatin1String("Red"),
+        QLatin1String("Green"),
+        QLatin1String("Yellow"),
+        QLatin1String("Blue"),
+        QLatin1String("Orange"),
+        QLatin1String("Purple"),
+        QLatin1String("Cyan"),
+        QLatin1String("Magenta"),
+        QLatin1String("Lime"),
+        QLatin1String("Pink"),
+        QLatin1String("Teal"),
+        QLatin1String("Lavender"),
+        QLatin1String("Brown"),
+        QLatin1String("Beige"),
+        QLatin1String("Maroon"),
+        QLatin1String("Mint"),
+        QLatin1String("Olive"),
+        QLatin1String("Apricot"),
+        QLatin1String("Navy"),
+        QLatin1String("Grey"),
+        QLatin1String("White"),
+        QLatin1String("Black"),
     };
 
     // Return a predefined color code from its internal name.
-    // TODO: use literals here
     static QColor predefinedColorFromName(QLatin1String name) {
         if (name == QLatin1String("Red")) {
             return Red;
@@ -215,7 +211,7 @@ namespace Color {
     // Stores the color's name() property, e.g. "#A9A9A9"
     static std::unique_ptr<ColorsRepresentation> makeDefaultRepresentation() {
         std::unique_ptr<ColorsRepresentation> representation = std::make_unique<ColorsRepresentation>();
-        for (QColor color : predefinedColors()) {
+        for (QColor color : predefinedColors) {
             representation->setRepresentation(color, color);
         }
         return representation;

--- a/src/util/color.h
+++ b/src/util/color.h
@@ -3,19 +3,50 @@
 
 #include "util/math.h"
 
+#include <QColor>
+
 #define BRIGHTNESS_TRESHOLD 130
 
 // algorithm by http://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
 // NOTE(Swiftb0y): please suggest if I should you use other methods
 // (like the W3C algorithm) or if this approach is to to performance hungry
+// NOTE: the author did not take alpha transparency into account!
 inline int brightness(int red, int green, int blue) {
-   return static_cast<int>(sqrtf(
-      red * red * .241 +
-      green * green * .691 +
-      blue * blue * .068));
+    return static_cast<int>(sqrtf(
+        red * red * .241 +
+        green * green * .691 +
+        blue * blue * .068)
+    );
 };
-inline bool isDimmColor(int red, int green, int blue) {
-    return brightness(red,green,blue) < BRIGHTNESS_TRESHOLD;
+
+inline int brightness(QColor color) {
+    return brightness(color.red(), color.green(), color.red());
 }
+
+inline bool isDimmColor(QColor color) {
+    qDebug() << color.name();
+    return brightness(color) < BRIGHTNESS_TRESHOLD;
+}
+
+// if the ColorToChooseBy is darker than the global threshold,
+// the Color from the second argument will be returned.
+
+inline QColor chooseColorByBrightnessB(bool precalculated, QColor dimmColor , QColor brightColor) {
+    return precalculated ? dimmColor : brightColor;
+}
+
+inline QColor chooseColorByBrightness(QColor ColorToChooseBy, QColor dimmColor , QColor brightColor) {
+    return chooseColorByBrightnessB(isDimmColor(ColorToChooseBy), dimmColor,  brightColor);
+}
+
+inline QColor chooseContrastColor(QColor colorToChooseBy) {
+    return chooseColorByBrightness(colorToChooseBy, QColor(255,255,255,255), QColor(0,0,0,255));
+}
+
+inline QColor chooseContrastColorB(bool precalculated) {
+    return chooseColorByBrightnessB(precalculated, QColor(255,255,255,255), QColor(0,0,0,255));
+}
+
+
 
 #endif /* COLOR_H */

--- a/src/util/color.h
+++ b/src/util/color.h
@@ -30,130 +30,131 @@ class ColorsRepresentation final {
 };
 
 namespace Color {
-    static const QString Red      = "#E6194B";
-    static const QString Green    = "#3CB44B";
-    static const QString Yellow   = "#FFE119";
-    static const QString Blue     = "#4363D8";
-    static const QString Orange   = "#F58231";
-    static const QString Purple   = "#911EB4";
-    static const QString Cyan     = "#42D4F4";
-    static const QString Magenta  = "#F032E6";
-    static const QString Lime     = "#BFEF45";
-    static const QString Pink     = "#FABEBE";
-    static const QString Teal     = "#469990";
-    static const QString Lavender = "#E6BEFF";
-    static const QString Brown    = "#9A6324";
-    static const QString Beige    = "#FFFAC8";
-    static const QString Maroon   = "#800000";
-    static const QString Mint     = "#AAFFC3";
-    static const QString Olive    = "#808000";
-    static const QString Apricot  = "#FFD8B1";
-    static const QString Navy     = "#000075";
-    static const QString Grey     = "#A9A9A9";
-    static const QString White    = "#FFFFFF";
-    static const QString Black    = "#000000";
+    static const QColor Red      = QColor("#E6194B");
+    static const QColor Green    = QColor("#3CB44B");
+    static const QColor Yellow   = QColor("#FFE119");
+    static const QColor Blue     = QColor("#4363D8");
+    static const QColor Orange   = QColor("#F58231");
+    static const QColor Purple   = QColor("#911EB4");
+    static const QColor Cyan     = QColor("#42D4F4");
+    static const QColor Magenta  = QColor("#F032E6");
+    static const QColor Lime     = QColor("#BFEF45");
+    static const QColor Pink     = QColor("#FABEBE");
+    static const QColor Teal     = QColor("#469990");
+    static const QColor Lavender = QColor("#E6BEFF");
+    static const QColor Brown    = QColor("#9A6324");
+    static const QColor Beige    = QColor("#FFFAC8");
+    static const QColor Maroon   = QColor("#800000");
+    static const QColor Mint     = QColor("#AAFFC3");
+    static const QColor Olive    = QColor("#808000");
+    static const QColor Apricot  = QColor("#FFD8B1");
+    static const QColor Navy     = QColor("#000075");
+    static const QColor Grey     = QColor("#A9A9A9");
+    static const QColor White    = QColor("#FFFFFF");
+    static const QColor Black    = QColor("#000000");
 
     // Return a list with the predefined colors.
     static QList<QColor> predefinedColors() {
         return QList<QColor> {
-            QColor(Red),
-            QColor(Green),
-            QColor(Yellow),
-            QColor(Blue),
-            QColor(Orange),
-            QColor(Purple),
-            QColor(Cyan),
-            QColor(Magenta),
-            QColor(Lime),
-            QColor(Pink),
-            QColor(Teal),
-            QColor(Lavender),
-            QColor(Brown),
-            QColor(Beige),
-            QColor(Maroon),
-            QColor(Mint),
-            QColor(Olive),
-            QColor(Apricot),
-            QColor(Navy),
-            QColor(Grey),
-            QColor(White),
-            QColor(Black),
+            Red,
+            Green,
+            Yellow,
+            Blue,
+            Orange,
+            Purple,
+            Cyan,
+            Magenta,
+            Lime,
+            Pink,
+            Teal,
+            Lavender,
+            Brown,
+            Beige,
+            Maroon,
+            Mint,
+            Olive,
+            Apricot,
+            Navy,
+            Grey,
+            White,
+            Black,
         };
     };
 
     // Return a list with the internal names of the predefined colors.
-    static QList<QString> predefinedColorsNames() {
-        return QList<QString> {
-            "Red",
-            "Green",
-            "Yellow",
-            "Blue",
-            "Orange",
-            "Purple",
-            "Cyan",
-            "Magenta",
-            "Lime",
-            "Pink",
-            "Teal",
-            "Lavender",
-            "Brown",
-            "Beige",
-            "Maroon",
-            "Mint",
-            "Olive",
-            "Apricot",
-            "Navy",
-            "Grey",
-            "White",
-            "Black",
+    static QList<QLatin1String> predefinedColorsNames() {
+        return QList<QLatin1String> {
+            QLatin1String("Red"),
+            QLatin1String("Green"),
+            QLatin1String("Yellow"),
+            QLatin1String("Blue"),
+            QLatin1String("Orange"),
+            QLatin1String("Purple"),
+            QLatin1String("Cyan"),
+            QLatin1String("Magenta"),
+            QLatin1String("Lime"),
+            QLatin1String("Pink"),
+            QLatin1String("Teal"),
+            QLatin1String("Lavender"),
+            QLatin1String("Brown"),
+            QLatin1String("Beige"),
+            QLatin1String("Maroon"),
+            QLatin1String("Mint"),
+            QLatin1String("Olive"),
+            QLatin1String("Apricot"),
+            QLatin1String("Navy"),
+            QLatin1String("Grey"),
+            QLatin1String("White"),
+            QLatin1String("Black"),
         };
     };
 
     // Return a predefined color code from its internal name.
-    static QString predefinedColorFromName(QString name) {
-        if (name == "Red") {
+    // TODO: use literals here
+    static QColor predefinedColorFromName(QLatin1String name) {
+        if (name == QLatin1String("Red")) {
             return Red;
-        } else if (name == "Green") {
+        } else if (name == QLatin1String("Green")) {
             return Green;
-        } else if (name == "Yellow") {
+        } else if (name == QLatin1String("Yellow")) {
             return Yellow;
-        } else if (name == "Blue") {
+        } else if (name == QLatin1String("Blue")) {
             return Blue;
-        } else if (name == "Orange") {
+        } else if (name == QLatin1String("Orange")) {
             return Orange;
-        } else if (name == "Purple") {
+        } else if (name == QLatin1String("Purple")) {
             return Purple;
-        } else if (name == "Cyan") {
+        } else if (name == QLatin1String("Cyan")) {
             return Cyan;
-        } else if (name == "Magenta") {
+        } else if (name == QLatin1String("Magenta")) {
             return Magenta;
-        } else if (name == "Lime") {
+        } else if (name == QLatin1String("Lime")) {
             return Lime;
-        } else if (name == "Pink") {
+        } else if (name == QLatin1String("Pink")) {
             return Pink;
-        } else if (name == "Teal") {
+        } else if (name == QLatin1String("Teal")) {
             return Teal;
-        } else if (name == "Lavender") {
+        } else if (name == QLatin1String("Lavender")) {
             return Lavender;
-        } else if (name == "Brown") {
+        } else if (name == QLatin1String("Brown")) {
             return Brown;
-        } else if (name == "Beige") {
+        } else if (name == QLatin1String("Beige")) {
             return Beige;
-        } else if (name == "Maroon") {
+        } else if (name == QLatin1String("Maroon")) {
             return Maroon;
-        } else if (name == "Mint") {
+        } else if (name == QLatin1String("Mint")) {
             return Mint;
-        } else if (name == "Olive") {
+        } else if (name == QLatin1String("Olive")) {
             return Olive;
-        } else if (name == "Apricot") {
+        } else if (name == QLatin1String("Apricot")) {
             return Apricot;
-        } else if (name == "Navy") {
+        } else if (name == QLatin1String("Navy")) {
             return Navy;
-        } else if (name == "Grey") {
+        } else if (name == QLatin1String("Grey")) {
             return Grey;
-        } else if (name == "White") {
+        } else if (name == QLatin1String("White")) {
             return White;
-        } else if (name == "Black") {
+        } else if (name == QLatin1String("Black")) {
             return Black;
         }
         return Black;
@@ -162,49 +163,49 @@ namespace Color {
     // Return the localized name of a predefined color.
     // Returns "Undefined Color" if color is not a predefined color.
     static QString displayName(QColor color) {
-        if (color.name().toUpper() == Red.toUpper()) {
+        if (color == Red) {
             return QObject::tr("Red");
-        } else if (color.name().toUpper() == Green.toUpper()) {
+        } else if (color == Green) {
             return QObject::tr("Green");
-        } else if (color.name().toUpper() == Yellow.toUpper()) {
+        } else if (color == Yellow) {
             return QObject::tr("Yellow");
-        } else if (color.name().toUpper() == Blue.toUpper()) {
+        } else if (color == Blue) {
             return QObject::tr("Blue");
-        } else if (color.name().toUpper() == Orange.toUpper()) {
+        } else if (color == Orange) {
             return QObject::tr("Orange");
-        } else if (color.name().toUpper() == Purple.toUpper()) {
+        } else if (color == Purple) {
             return QObject::tr("Purple");
-        } else if (color.name().toUpper() == Cyan.toUpper()) {
+        } else if (color == Cyan) {
             return QObject::tr("Cyan");
-        } else if (color.name().toUpper() == Magenta.toUpper()) {
+        } else if (color == Magenta) {
             return QObject::tr("Magenta");
-        } else if (color.name().toUpper() == Lime.toUpper()) {
+        } else if (color == Lime) {
             return QObject::tr("Lime");
-        } else if (color.name().toUpper() == Pink.toUpper()) {
+        } else if (color == Pink) {
             return QObject::tr("Pink");
-        } else if (color.name().toUpper() == Teal.toUpper()) {
+        } else if (color == Teal) {
             return QObject::tr("Teal");
-        } else if (color.name().toUpper() == Lavender.toUpper()) {
+        } else if (color == Lavender) {
             return QObject::tr("Lavender");
-        } else if (color.name().toUpper() == Brown.toUpper()) {
+        } else if (color == Brown) {
             return QObject::tr("Brown");
-        } else if (color.name().toUpper() == Beige.toUpper()) {
+        } else if (color == Beige) {
             return QObject::tr("Beige");
-        } else if (color.name().toUpper() == Maroon.toUpper()) {
+        } else if (color == Maroon) {
             return QObject::tr("Maroon");
-        } else if (color.name().toUpper() == Mint.toUpper()) {
+        } else if (color == Mint) {
             return QObject::tr("Mint");
-        } else if (color.name().toUpper() == Olive.toUpper()) {
+        } else if (color == Olive) {
             return QObject::tr("Olive");
-        } else if (color.name().toUpper() == Apricot.toUpper()) {
+        } else if (color == Apricot) {
             return QObject::tr("Apricot");
-        } else if (color.name().toUpper() == Navy.toUpper()) {
+        } else if (color == Navy){
             return QObject::tr("Navy");
-        } else if (color.name().toUpper() == Grey.toUpper()) {
+        } else if (color == Grey) {
             return QObject::tr("Grey");
-        } else if (color.name().toUpper() == White.toUpper()) {
+        } else if (color == White) {
             return QObject::tr("White");
-        } else if (color.name().toUpper() == Black.toUpper()) {
+        } else if (color == Black) {
             return QObject::tr("Black");
         }
         return QObject::tr("Undefined Color");

--- a/src/util/color.h
+++ b/src/util/color.h
@@ -1,0 +1,21 @@
+#ifndef COLOR_H
+#define COLOR_H
+
+#include "util/math.h"
+
+#define BRIGHTNESS_TRESHOLD 130
+
+// algorithm by http://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
+// NOTE(Swiftb0y): please suggest if I should you use other methods
+// (like the W3C algorithm) or if this approach is to to performance hungry
+inline int brightness(int red, int green, int blue) {
+   return static_cast<int>(sqrtf(
+      red * red * .241 +
+      green * green * .691 +
+      blue * blue * .068));
+};
+inline bool isDimmColor(int red, int green, int blue) {
+    return brightness(red,green,blue) < BRIGHTNESS_TRESHOLD;
+}
+
+#endif /* COLOR_H */

--- a/src/util/color.h
+++ b/src/util/color.h
@@ -2,51 +2,264 @@
 #define COLOR_H
 
 #include "util/math.h"
+#include "util/memory.h"
 
 #include <QColor>
+#include <QMap>
 
 #define BRIGHTNESS_TRESHOLD 130
 
-// algorithm by http://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
-// NOTE(Swiftb0y): please suggest if I should you use other methods
-// (like the W3C algorithm) or if this approach is to to performance hungry
-// NOTE: the author did not take alpha transparency into account!
-inline int brightness(int red, int green, int blue) {
-    return static_cast<int>(sqrtf(
-        red * red * .241 +
-        green * green * .691 +
-        blue * blue * .068)
-    );
+// Map the predefined colors to another color representation of them.
+class ColorsRepresentation final {
+  public:
+    // Set a color representation for a given color
+    void setRepresentation(QColor color, QColor representation) {
+        colorNameMap[color.name()] = representation.name();
+    }
+
+    // Returns the representation of a color
+    QColor map(QColor color) const {
+        if (colorNameMap.contains(color.name())) {
+            return QColor(colorNameMap[color.name()]);
+        }
+        return color;
+    }
+
+  private:
+    QHash<QString, QString> colorNameMap;
 };
 
-inline int brightness(QColor color) {
-    return brightness(color.red(), color.green(), color.red());
-}
+namespace Color {
+    static const QString Red      = "#E6194B";
+    static const QString Green    = "#3CB44B";
+    static const QString Yellow   = "#FFE119";
+    static const QString Blue     = "#4363D8";
+    static const QString Orange   = "#F58231";
+    static const QString Purple   = "#911EB4";
+    static const QString Cyan     = "#42D4F4";
+    static const QString Magenta  = "#F032E6";
+    static const QString Lime     = "#BFEF45";
+    static const QString Pink     = "#FABEBE";
+    static const QString Teal     = "#469990";
+    static const QString Lavender = "#E6BEFF";
+    static const QString Brown    = "#9A6324";
+    static const QString Beige    = "#FFFAC8";
+    static const QString Maroon   = "#800000";
+    static const QString Mint     = "#AAFFC3";
+    static const QString Olive    = "#808000";
+    static const QString Apricot  = "#FFD8B1";
+    static const QString Navy     = "#000075";
+    static const QString Grey     = "#A9A9A9";
+    static const QString White    = "#FFFFFF";
+    static const QString Black    = "#000000";
 
-inline bool isDimmColor(QColor color) {
-    qDebug() << color.name();
-    return brightness(color) < BRIGHTNESS_TRESHOLD;
-}
+    // Return a list with the predefined colors.
+    static QList<QColor> predefinedColors() {
+        return QList<QColor> {
+            QColor(Red),
+            QColor(Green),
+            QColor(Yellow),
+            QColor(Blue),
+            QColor(Orange),
+            QColor(Purple),
+            QColor(Cyan),
+            QColor(Magenta),
+            QColor(Lime),
+            QColor(Pink),
+            QColor(Teal),
+            QColor(Lavender),
+            QColor(Brown),
+            QColor(Beige),
+            QColor(Maroon),
+            QColor(Mint),
+            QColor(Olive),
+            QColor(Apricot),
+            QColor(Navy),
+            QColor(Grey),
+            QColor(White),
+            QColor(Black),
+        };
+    };
 
-// if the ColorToChooseBy is darker than the global threshold,
-// the Color from the second argument will be returned.
+    // Return a list with the internal names of the predefined colors.
+    static QList<QString> predefinedColorsNames() {
+        return QList<QString> {
+            "Red",
+            "Green",
+            "Yellow",
+            "Blue",
+            "Orange",
+            "Purple",
+            "Cyan",
+            "Magenta",
+            "Lime",
+            "Pink",
+            "Teal",
+            "Lavender",
+            "Brown",
+            "Beige",
+            "Maroon",
+            "Mint",
+            "Olive",
+            "Apricot",
+            "Navy",
+            "Grey",
+            "White",
+            "Black",
+        };
+    };
 
-inline QColor chooseColorByBrightnessB(bool precalculated, QColor dimmColor , QColor brightColor) {
-    return precalculated ? dimmColor : brightColor;
-}
+    // Return a predefined color code from its internal name.
+    static QString predefinedColorFromName(QString name) {
+        if (name == "Red") {
+            return Red;
+        } else if (name == "Green") {
+            return Green;
+        } else if (name == "Yellow") {
+            return Yellow;
+        } else if (name == "Blue") {
+            return Blue;
+        } else if (name == "Orange") {
+            return Orange;
+        } else if (name == "Purple") {
+            return Purple;
+        } else if (name == "Cyan") {
+            return Cyan;
+        } else if (name == "Magenta") {
+            return Magenta;
+        } else if (name == "Lime") {
+            return Lime;
+        } else if (name == "Pink") {
+            return Pink;
+        } else if (name == "Teal") {
+            return Teal;
+        } else if (name == "Lavender") {
+            return Lavender;
+        } else if (name == "Brown") {
+            return Brown;
+        } else if (name == "Beige") {
+            return Beige;
+        } else if (name == "Maroon") {
+            return Maroon;
+        } else if (name == "Mint") {
+            return Mint;
+        } else if (name == "Olive") {
+            return Olive;
+        } else if (name == "Apricot") {
+            return Apricot;
+        } else if (name == "Navy") {
+            return Navy;
+        } else if (name == "Grey") {
+            return Grey;
+        } else if (name == "White") {
+            return White;
+        } else if (name == "Black") {
+            return Black;
+        }
+        return Black;
+    };
 
-inline QColor chooseColorByBrightness(QColor ColorToChooseBy, QColor dimmColor , QColor brightColor) {
-    return chooseColorByBrightnessB(isDimmColor(ColorToChooseBy), dimmColor,  brightColor);
-}
+    // Return the localized name of a predefined color.
+    // Returns "Undefined Color" if color is not a predefined color.
+    static QString displayName(QColor color) {
+        if (color.name().toUpper() == Red.toUpper()) {
+            return QObject::tr("Red");
+        } else if (color.name().toUpper() == Green.toUpper()) {
+            return QObject::tr("Green");
+        } else if (color.name().toUpper() == Yellow.toUpper()) {
+            return QObject::tr("Yellow");
+        } else if (color.name().toUpper() == Blue.toUpper()) {
+            return QObject::tr("Blue");
+        } else if (color.name().toUpper() == Orange.toUpper()) {
+            return QObject::tr("Orange");
+        } else if (color.name().toUpper() == Purple.toUpper()) {
+            return QObject::tr("Purple");
+        } else if (color.name().toUpper() == Cyan.toUpper()) {
+            return QObject::tr("Cyan");
+        } else if (color.name().toUpper() == Magenta.toUpper()) {
+            return QObject::tr("Magenta");
+        } else if (color.name().toUpper() == Lime.toUpper()) {
+            return QObject::tr("Lime");
+        } else if (color.name().toUpper() == Pink.toUpper()) {
+            return QObject::tr("Pink");
+        } else if (color.name().toUpper() == Teal.toUpper()) {
+            return QObject::tr("Teal");
+        } else if (color.name().toUpper() == Lavender.toUpper()) {
+            return QObject::tr("Lavender");
+        } else if (color.name().toUpper() == Brown.toUpper()) {
+            return QObject::tr("Brown");
+        } else if (color.name().toUpper() == Beige.toUpper()) {
+            return QObject::tr("Beige");
+        } else if (color.name().toUpper() == Maroon.toUpper()) {
+            return QObject::tr("Maroon");
+        } else if (color.name().toUpper() == Mint.toUpper()) {
+            return QObject::tr("Mint");
+        } else if (color.name().toUpper() == Olive.toUpper()) {
+            return QObject::tr("Olive");
+        } else if (color.name().toUpper() == Apricot.toUpper()) {
+            return QObject::tr("Apricot");
+        } else if (color.name().toUpper() == Navy.toUpper()) {
+            return QObject::tr("Navy");
+        } else if (color.name().toUpper() == Grey.toUpper()) {
+            return QObject::tr("Grey");
+        } else if (color.name().toUpper() == White.toUpper()) {
+            return QObject::tr("White");
+        } else if (color.name().toUpper() == Black.toUpper()) {
+            return QObject::tr("Black");
+        }
+        return QObject::tr("Undefined Color");
+    };
 
-inline QColor chooseContrastColor(QColor colorToChooseBy) {
-    return chooseColorByBrightness(colorToChooseBy, QColor(255,255,255,255), QColor(0,0,0,255));
-}
+    // Returns a new default colors representation, i.e. maps each default color to itself.
+    // Stores the color's name() property, e.g. "#A9A9A9"
+    static std::unique_ptr<ColorsRepresentation> defaultRepresentation() {
+        std::unique_ptr<ColorsRepresentation> representation = std::make_unique<ColorsRepresentation>();
+        for (QColor color : predefinedColors()) {
+            representation->setRepresentation(color, color);
+        }
+        return representation;
+    }
 
-inline QColor chooseContrastColorB(bool precalculated) {
-    return chooseColorByBrightnessB(precalculated, QColor(255,255,255,255), QColor(0,0,0,255));
-}
 
+    // algorithm by http://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
+    // NOTE(Swiftb0y): please suggest if I should you use other methods
+    // (like the W3C algorithm) or if this approach is to to performance hungry
+    // NOTE: the author did not take alpha transparency into account!
+    static inline int brightness(int red, int green, int blue) {
+        return static_cast<int>(sqrtf(
+            red * red * .241 +
+            green * green * .691 +
+            blue * blue * .068)
+        );
+    };
 
+    static inline int brightness(QColor color) {
+        return brightness(color.red(), color.green(), color.red());
+    }
 
+    static inline bool isDimmColor(QColor color) {
+//        qDebug() << color.name();
+        return brightness(color) < BRIGHTNESS_TRESHOLD;
+    }
+
+    // if the ColorToChooseBy is darker than the global threshold,
+    // the Color from the second argument will be returned.
+
+    static inline QColor chooseColorByBrightnessB(bool precalculated, QColor dimmColor , QColor brightColor) {
+        return precalculated ? dimmColor : brightColor;
+    }
+
+    static inline QColor chooseColorByBrightness(QColor ColorToChooseBy, QColor dimmColor , QColor brightColor) {
+        return chooseColorByBrightnessB(isDimmColor(ColorToChooseBy), dimmColor,  brightColor);
+    }
+
+    static inline QColor chooseContrastColor(QColor colorToChooseBy) {
+        return chooseColorByBrightness(colorToChooseBy, QColor(255,255,255,255), QColor(0,0,0,255));
+    }
+
+    static inline QColor chooseContrastColorB(bool precalculated) {
+        return chooseColorByBrightnessB(precalculated, QColor(255,255,255,255), QColor(0,0,0,255));
+    }
+
+};
 #endif /* COLOR_H */

--- a/src/waveform/renderers/waveformmarkproperties.cpp
+++ b/src/waveform/renderers/waveformmarkproperties.cpp
@@ -47,7 +47,7 @@ WaveformMarkProperties::WaveformMarkProperties(const QDomNode& node,
                                                const WaveformSignalColors& signalColors,
                                                int hotCue) {
     m_color = context.selectString(node, "Color");
-    // TODO (Swiftb0y): get CuePointer and color for m_color instead of skin color.
+    // TODO (Swiftb0y): remove context.selectString because the color will be overriden by the cuepoints regardless
     if (!m_color.isValid()) {
         // As a fallback, grab the color from the parent's AxesColor
         m_color = signalColors.getAxesColor();

--- a/src/waveform/renderers/waveformmarkproperties.cpp
+++ b/src/waveform/renderers/waveformmarkproperties.cpp
@@ -47,6 +47,7 @@ WaveformMarkProperties::WaveformMarkProperties(const QDomNode& node,
                                                const WaveformSignalColors& signalColors,
                                                int hotCue) {
     m_color = context.selectString(node, "Color");
+    // TODO (Swiftb0y): get CuePointer and color for m_color instead of skin color.
     if (!m_color.isValid()) {
         // As a fallback, grab the color from the parent's AxesColor
         m_color = signalColors.getAxesColor();

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -376,7 +376,7 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
 void WaveformRenderMark::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
     m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
 
-    for (QLatin1String colorName : Color::predefinedColorsNames()) {
+    for (QLatin1String colorName : Color::predefinedColorsNames) {
         QColor representation = context.selectColor(node, "Cue" + colorName);
         if (representation.isValid()) {
             QColor originalColor = Color::predefinedColorFromName(colorName);

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -374,7 +374,7 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
 }
 
 void WaveformRenderMark::setupColorsRepresentation(const QDomNode& node, const SkinContext& context) {
-    m_pPredefinedColorsRepresentation = Color::defaultRepresentation();
+    m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
 
     for (QLatin1String colorName : Color::predefinedColorsNames()) {
         QColor representation = context.selectColor(node, colorName);

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -23,7 +23,7 @@ WaveformRenderMark::WaveformRenderMark(
 }
 
 void WaveformRenderMark::setup(const QDomNode& node, const SkinContext& context) {
-    setupCueColorsRepresentation(node, context);
+    m_predefinedColorsRepresentation = context.getCueColorsRepresentation(node);
     m_marks.setup(m_waveformRenderer->getGroup(), node, context,
                   *m_waveformRenderer->getWaveformSignalColors());
 }
@@ -370,17 +370,5 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
         painter.setPen(QColor(0,0,0,100));
         painter.drawLine(middle - 1, lineTop, middle - 1, lineBottom);
         painter.drawLine(middle + 1, lineTop, middle + 1, lineBottom);
-    }
-}
-
-void WaveformRenderMark::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
-    m_predefinedColorsRepresentation = Color::defaultRepresentation;
-
-    for (QLatin1String colorName : Color::predefinedColorsNames) {
-        QColor representation = context.selectColor(node, "Cue" + colorName);
-        if (representation.isValid()) {
-            QColor originalColor = Color::predefinedColorFromName(colorName);
-            m_predefinedColorsRepresentation.setRepresentation(originalColor, representation);
-        }
     }
 }

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -224,9 +224,10 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
         // Prepare colors for drawing of marker lines
         QColor lineColor = markProperties.m_color;
         lineColor.setAlpha(200);
-        QColor contrastLineColor =  (brightness(lineColor) < 130) ?
-                QColor(255,255,255,120) :
-                QColor(0,0,0,120);
+        bool markerBrightnessLow= isDimmColor(lineColor.red(),lineColor.green(),lineColor.blue());
+        QColor contrastLineColor =  markerBrightnessLow ?
+                QColor(255,255,255,180) :
+                QColor(0,0,0,180);
 
         // Draw marker lines
         if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
@@ -297,7 +298,7 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
         // Draw text
         painter.setBrush(QBrush(QColor(0,0,0,0)));
         painter.setFont(font);
-        painter.setPen(markProperties.m_textColor);
+        painter.setPen(markerBrightnessLow ? QColor(255,255,255,255) : QColor(0,0,0,255));
         painter.drawText(labelRect, Qt::AlignCenter, label);
     }
     else //no text draw triangle

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -110,7 +110,7 @@ void WaveformRenderMark::slotCuesUpdated() {
         }
 
         QString newLabel = pCue->getLabel();
-        QColor newColor = m_pPredefinedColorsRepresentation->map(pCue->getColor());
+        QColor newColor = m_predefinedColorsRepresentation.map(pCue->getColor());
 
         // Here we assume no two cues can have the same hotcue assigned,
         // because WaveformMarkSet stores one mark for each hotcue.
@@ -374,13 +374,13 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
 }
 
 void WaveformRenderMark::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
-    m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
+    m_predefinedColorsRepresentation = Color::defaultRepresentation;
 
     for (QLatin1String colorName : Color::predefinedColorsNames) {
         QColor representation = context.selectColor(node, "Cue" + colorName);
         if (representation.isValid()) {
             QColor originalColor = Color::predefinedColorFromName(colorName);
-            m_pPredefinedColorsRepresentation->setRepresentation(originalColor, representation);
+            m_predefinedColorsRepresentation.setRepresentation(originalColor, representation);
         }
     }
 }

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -376,11 +376,11 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
 void WaveformRenderMark::setupColorsRepresentation(const QDomNode& node, const SkinContext& context) {
     m_pPredefinedColorsRepresentation = Color::defaultRepresentation();
 
-    for (QString colorName : Color::predefinedColorsNames()) {
+    for (QLatin1String colorName : Color::predefinedColorsNames()) {
         QColor representation = context.selectColor(node, colorName);
         if (representation.isValid()) {
-            QString colorCode = Color::predefinedColorFromName(colorName);
-            m_pPredefinedColorsRepresentation->setRepresentation(colorCode, representation);
+            QColor originalColor = Color::predefinedColorFromName(colorName);
+            m_pPredefinedColorsRepresentation->setRepresentation(originalColor, representation);
         }
     }
 }

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -23,7 +23,7 @@ WaveformRenderMark::WaveformRenderMark(
 }
 
 void WaveformRenderMark::setup(const QDomNode& node, const SkinContext& context) {
-    setupColorsRepresentation(node, context);
+    setupCueColorsRepresentation(node, context);
     m_marks.setup(m_waveformRenderer->getGroup(), node, context,
                   *m_waveformRenderer->getWaveformSignalColors());
 }
@@ -373,7 +373,7 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
     }
 }
 
-void WaveformRenderMark::setupColorsRepresentation(const QDomNode& node, const SkinContext& context) {
+void WaveformRenderMark::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
     m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
 
     for (QLatin1String colorName : Color::predefinedColorsNames()) {

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -377,7 +377,7 @@ void WaveformRenderMark::setupCueColorsRepresentation(const QDomNode& node, cons
     m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
 
     for (QLatin1String colorName : Color::predefinedColorsNames()) {
-        QColor representation = context.selectColor(node, colorName);
+        QColor representation = context.selectColor(node, "Cue" + colorName);
         if (representation.isValid()) {
             QColor originalColor = Color::predefinedColorFromName(colorName);
             m_pPredefinedColorsRepresentation->setRepresentation(originalColor, representation);

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -224,7 +224,9 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
         // Prepare colors for drawing of marker lines
         QColor lineColor = markProperties.m_color;
         lineColor.setAlpha(200);
-        QColor contrastLineColor(0,0,0,120);
+        QColor contrastLineColor =  (brightness(lineColor) < 130) ?
+                QColor(255,255,255,120) :
+                QColor(0,0,0,120);
 
         // Draw marker lines
         if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -224,10 +224,9 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
         // Prepare colors for drawing of marker lines
         QColor lineColor = markProperties.m_color;
         lineColor.setAlpha(200);
-        bool markerBrightnessLow= isDimmColor(lineColor.red(),lineColor.green(),lineColor.blue());
-        QColor contrastLineColor =  markerBrightnessLow ?
-                QColor(255,255,255,180) :
-                QColor(0,0,0,180);
+        bool markerBrightnessLow= isDimmColor(lineColor);
+        QColor contrastLineColor =  chooseContrastColorB(markerBrightnessLow);
+        contrastLineColor.setAlpha(180);
 
         // Draw marker lines
         if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
@@ -298,7 +297,7 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
         // Draw text
         painter.setBrush(QBrush(QColor(0,0,0,0)));
         painter.setFont(font);
-        painter.setPen(markerBrightnessLow ? QColor(255,255,255,255) : QColor(0,0,0,255));
+        painter.setPen(chooseContrastColorB(markerBrightnessLow));
         painter.drawText(labelRect, Qt::AlignCenter, label);
     }
     else //no text draw triangle

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -33,7 +33,7 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
 
   private:
     void generateMarkImage(WaveformMark* pMark);
-    void setupColorsRepresentation(const QDomNode& node, const SkinContext& context);
+    void setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context);
 
     std::unique_ptr<ColorsRepresentation> m_pPredefinedColorsRepresentation;
 

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -5,7 +5,7 @@
 
 #include "skin/skincontext.h"
 #include "util/class.h"
-#include "util/math.h"
+#include "util/color.h"
 #include "waveform/renderers/waveformmarkset.h"
 #include "waveform/renderers/waveformrendererabstract.h"
 #include "library/dao/cue.h"
@@ -13,6 +13,7 @@
 
 class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
     Q_OBJECT
+
   public:
     explicit WaveformRenderMark(WaveformWidgetRenderer* waveformWidgetRenderer);
 
@@ -32,15 +33,7 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
 
   private:
     void generateMarkImage(WaveformMark* pMark);
-    // algorithm by http://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
-    // NOTE(Swiftb0y): please suggest if I should you use other methods
-    // (like the W3C algorithm) or if this approach is to to performance hungry
-    int brightness(QColor& c) {
-       return static_cast<int>(sqrtf(
-          c.red() * c.red() * .241 +
-          c.green() * c.green() * .691 +
-          c.blue() * c.blue() * .068));
-    };
+
     WaveformMarkSet m_marks;
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMark);
 };

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -35,7 +35,7 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
     void generateMarkImage(WaveformMark* pMark);
     void setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context);
 
-    std::unique_ptr<ColorsRepresentation> m_pPredefinedColorsRepresentation;
+    ColorsRepresentation m_predefinedColorsRepresentation;
 
     WaveformMarkSet m_marks;
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMark);

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -33,7 +33,6 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
 
   private:
     void generateMarkImage(WaveformMark* pMark);
-    void setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context);
 
     ColorsRepresentation m_predefinedColorsRepresentation;
 

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -5,6 +5,7 @@
 
 #include "skin/skincontext.h"
 #include "util/class.h"
+#include "util/math.h"
 #include "waveform/renderers/waveformmarkset.h"
 #include "waveform/renderers/waveformrendererabstract.h"
 #include "library/dao/cue.h"
@@ -31,7 +32,15 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
 
   private:
     void generateMarkImage(WaveformMark* pMark);
-
+    // algorithm by http://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
+    // NOTE(Swiftb0y): please suggest if I should you use other methods
+    // (like the W3C algorithm) or if this approach is to to performance hungry
+    int brightness(QColor& c) {
+       return static_cast<int>(sqrtf(
+          c.red() * c.red() * .241 +
+          c.green() * c.green() * .691 +
+          c.blue() * c.blue() * .068));
+    };
     WaveformMarkSet m_marks;
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMark);
 };

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -33,6 +33,9 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
 
   private:
     void generateMarkImage(WaveformMark* pMark);
+    void setupColorsRepresentation(const QDomNode& node, const SkinContext& context);
+
+    std::unique_ptr<ColorsRepresentation> m_pPredefinedColorsRepresentation;
 
     WaveformMarkSet m_marks;
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMark);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -85,7 +85,7 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
     }
 
     // setup hotcues and cue and loop(s)
-    setupCueColorsRepresentation(node, context);
+    m_predefinedColorsRepresentation = context.getCueColorsRepresentation(node);
     m_marks.setup(m_group, node, context, m_signalColors);
 
     for (const auto& pMark: m_marks) {
@@ -636,16 +636,4 @@ void WOverview::dropEvent(QDropEvent* event) {
         }
     }
     event->ignore();
-}
-
-void WOverview::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
-    m_predefinedColorsRepresentation = Color::defaultRepresentation;
-
-    for (QLatin1String colorName : Color::predefinedColorsNames) {
-        QColor representation = context.selectColor(node, "Cue" + colorName);
-        if (representation.isValid()) {
-            QColor originalColor = Color::predefinedColorFromName(colorName);
-            m_predefinedColorsRepresentation.setRepresentation(originalColor, representation);
-        }
-    }
 }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -639,7 +639,7 @@ void WOverview::setupCueColorsRepresentation(const QDomNode& node, const SkinCon
     m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
 
     for (QLatin1String colorName : Color::predefinedColorsNames()) {
-        QColor representation = context.selectColor(node, colorName);
+        QColor representation = context.selectColor(node, "Cue" + colorName);
         if (representation.isValid()) {
             QColor originalColor = Color::predefinedColorFromName(colorName);
             m_pPredefinedColorsRepresentation->setRepresentation(originalColor, representation);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -260,7 +260,6 @@ void WOverview::onMarkRangeChange(double /*v*/) {
 
 // currently only updates the mark color but it could be easily extended.
 void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
-
     for (CuePointer currentCue: loadedCues) {
         const WaveformMarkPointer currentMark = m_marks.getHotCueMark(currentCue->getHotCue());
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -270,7 +270,7 @@ void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
 
         if (currentMark && currentMark->isValid()) {
             WaveformMarkProperties markProperties = currentMark->getProperties();
-            const QColor newColor = m_pPredefinedColorsRepresentation->map(currentCue->getColor());
+            const QColor newColor = m_predefinedColorsRepresentation.map(currentCue->getColor());
 
             if (newColor != markProperties.m_color || newColor != markProperties.m_textColor) {
                 markProperties.m_color = newColor;
@@ -639,13 +639,13 @@ void WOverview::dropEvent(QDropEvent* event) {
 }
 
 void WOverview::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
-    m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
+    m_predefinedColorsRepresentation = Color::defaultRepresentation;
 
     for (QLatin1String colorName : Color::predefinedColorsNames) {
         QColor representation = context.selectColor(node, "Cue" + colorName);
         if (representation.isValid()) {
             QColor originalColor = Color::predefinedColorFromName(colorName);
-            m_pPredefinedColorsRepresentation->setRepresentation(originalColor, representation);
+            m_predefinedColorsRepresentation.setRepresentation(originalColor, representation);
         }
     }
 }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -641,7 +641,7 @@ void WOverview::dropEvent(QDropEvent* event) {
 void WOverview::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
     m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
 
-    for (QLatin1String colorName : Color::predefinedColorsNames()) {
+    for (QLatin1String colorName : Color::predefinedColorsNames) {
         QColor representation = context.selectColor(node, "Cue" + colorName);
         if (representation.isValid()) {
             QColor originalColor = Color::predefinedColorFromName(colorName);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -26,6 +26,7 @@
 #include "wskincolor.h"
 #include "widget/controlwidgetconnection.h"
 #include "track/track.h"
+#include "util/color.h"
 #include "util/math.h"
 #include "util/timer.h"
 #include "util/dnd.h"
@@ -84,6 +85,7 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
     }
 
     // setup hotcues and cue and loop(s)
+    setupCueColorsRepresentation(node, context);
     m_marks.setup(m_group, node, context, m_signalColors);
 
     for (const auto& pMark: m_marks) {
@@ -265,7 +267,7 @@ void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
 
         if (currentMark && currentMark->isValid()) {
             WaveformMarkProperties markProperties = currentMark->getProperties();
-            const QColor newColor = currentCue->getColor();
+            const QColor newColor = m_pPredefinedColorsRepresentation->map(currentCue->getColor());
 
             if (newColor != markProperties.m_color || newColor != markProperties.m_textColor) {
                 markProperties.m_color = newColor;
@@ -631,4 +633,16 @@ void WOverview::dropEvent(QDropEvent* event) {
         }
     }
     event->ignore();
+}
+
+void WOverview::setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context) {
+    m_pPredefinedColorsRepresentation = Color::makeDefaultRepresentation();
+
+    for (QLatin1String colorName : Color::predefinedColorsNames()) {
+        QColor representation = context.selectColor(node, colorName);
+        if (representation.isValid()) {
+            QColor originalColor = Color::predefinedColorFromName(colorName);
+            m_pPredefinedColorsRepresentation->setRepresentation(originalColor, representation);
+        }
+    }
 }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -269,7 +269,6 @@ void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
 
             if (newColor != markProperties.m_color || newColor != markProperties.m_textColor) {
                 markProperties.m_color = newColor;
-                markProperties.m_textColor = newColor;
                 currentMark->setProperties(markProperties);
             }
         }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -203,6 +203,9 @@ void WOverview::slotAnalyzerProgress(int progress) {
 void WOverview::slotTrackLoaded(TrackPointer pTrack) {
     DEBUG_ASSERT(m_pCurrentTrack == pTrack);
     m_trackLoaded = true;
+    if (m_pCurrentTrack) {
+        updateCues(m_pCurrentTrack->getCuePoints());
+    }
     update();
 }
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -260,20 +260,18 @@ void WOverview::onMarkRangeChange(double /*v*/) {
 
 // currently only updates the mark color but it could be easily extended.
 void WOverview::onTrackCueChange(void) {
-
     const QList<CuePointer> loadedCues = m_pCurrentTrack->getCuePoints();
 
     for (CuePointer currentCue: loadedCues) {
-
         const WaveformMarkPointer currentMark = m_marks.getHotCueMark(currentCue->getHotCue());
 
         if (currentMark && currentMark->isValid()) {
-
             WaveformMarkProperties markProperties = currentMark->getProperties();
             const QColor newColor = currentCue->getColor();
 
-            if (newColor != markProperties.m_color) {
+            if (newColor != markProperties.m_color || newColor != markProperties.m_textColor) {
                 markProperties.m_color = newColor;
+                markProperties.m_textColor = newColor;
                 currentMark->setProperties(markProperties);
             }
         }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -230,8 +230,8 @@ void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack)
                 this, SLOT(slotWaveformSummaryUpdated()));
         connect(pNewTrack.get(), SIGNAL(analyzerProgress(int)),
                 this, SLOT(slotAnalyzerProgress(int)));
-        connect(pNewTrack.get(), SIGNAL(cuesUpdated(void)),
-                this, SLOT(onTrackCueChange(void)));
+        connect(pNewTrack.get(), SIGNAL(cuesUpdated()),
+                this, SLOT(receiveCuesUpdated()));
 
         slotAnalyzerProgress(pNewTrack->getAnalyzerProgress());
     } else {
@@ -249,8 +249,8 @@ void WOverview::onEndOfTrackChange(double v) {
 
 void WOverview::onMarkChanged(double /*v*/) {
     //qDebug() << "WOverview::onMarkChanged()" << v;
-    onTrackCueChange();
-    //update();
+    updateCues(m_pCurrentTrack->getCuePoints());
+    update();
 }
 
 void WOverview::onMarkRangeChange(double /*v*/) {
@@ -259,8 +259,7 @@ void WOverview::onMarkRangeChange(double /*v*/) {
 }
 
 // currently only updates the mark color but it could be easily extended.
-void WOverview::onTrackCueChange(void) {
-    const QList<CuePointer> loadedCues = m_pCurrentTrack->getCuePoints();
+void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
 
     for (CuePointer currentCue: loadedCues) {
         const WaveformMarkPointer currentMark = m_marks.getHotCueMark(currentCue->getHotCue());
@@ -276,7 +275,12 @@ void WOverview::onTrackCueChange(void) {
             }
         }
     }
-    update();
+}
+
+// connecting the tracks cuesUpdated and onMarkChanged is not possible
+// due to the incompatible signatures. This is a "wrapper" workaround
+void WOverview::receiveCuesUpdated() {
+    onMarkChanged(0);
 }
 
 void WOverview::mouseMoveEvent(QMouseEvent* e) {

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -230,6 +230,8 @@ void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack)
                 this, SLOT(slotWaveformSummaryUpdated()));
         connect(pNewTrack.get(), SIGNAL(analyzerProgress(int)),
                 this, SLOT(slotAnalyzerProgress(int)));
+        connect(pNewTrack.get(), SIGNAL(cuesUpdated(void)),
+                this, SLOT(onTrackCueChange(void)));
 
         slotAnalyzerProgress(pNewTrack->getAnalyzerProgress());
     } else {
@@ -247,11 +249,35 @@ void WOverview::onEndOfTrackChange(double v) {
 
 void WOverview::onMarkChanged(double /*v*/) {
     //qDebug() << "WOverview::onMarkChanged()" << v;
-    update();
+    onTrackCueChange();
+    //update();
 }
 
 void WOverview::onMarkRangeChange(double /*v*/) {
     //qDebug() << "WOverview::onMarkRangeChange()" << v;
+    update();
+}
+
+// currently only updates the mark color but it could be easily extended.
+void WOverview::onTrackCueChange(void) {
+
+    const QList<CuePointer> loadedCues = m_pCurrentTrack->getCuePoints();
+
+    for (CuePointer currentCue: loadedCues) {
+
+        const WaveformMarkPointer currentMark = m_marks.getHotCueMark(currentCue->getHotCue());
+
+        if (currentMark && currentMark->isValid()) {
+
+            WaveformMarkProperties markProperties = currentMark->getProperties();
+            const QColor newColor = currentCue->getColor();
+
+            if (newColor != markProperties.m_color) {
+                markProperties.m_color = newColor;
+                currentMark->setProperties(markProperties);
+            }
+        }
+    }
     update();
 }
 

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -95,6 +95,7 @@ class WOverview : public WWidget {
     // Append the waveform overview pixmap according to available data in waveform
     virtual bool drawNextPixmapPart() = 0;
     void paintText(const QString &text, QPainter *painter);
+    void setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context);
     inline int valueToPosition(double value) const {
         return static_cast<int>(m_a * value - m_b);
     }
@@ -127,6 +128,7 @@ class WOverview : public WWidget {
     QColor m_qColorBackground;
     QColor m_endOfTrackColor;
 
+    std::unique_ptr<ColorsRepresentation> m_pPredefinedColorsRepresentation;
     WaveformMarkSet m_marks;
     std::vector<WaveformMarkRange> m_markRanges;
 

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -95,7 +95,6 @@ class WOverview : public WWidget {
     // Append the waveform overview pixmap according to available data in waveform
     virtual bool drawNextPixmapPart() = 0;
     void paintText(const QString &text, QPainter *painter);
-    void setupCueColorsRepresentation(const QDomNode& node, const SkinContext& context);
     inline int valueToPosition(double value) const {
         return static_cast<int>(m_a * value - m_b);
     }

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -128,7 +128,7 @@ class WOverview : public WWidget {
     QColor m_qColorBackground;
     QColor m_endOfTrackColor;
 
-    std::unique_ptr<ColorsRepresentation> m_pPredefinedColorsRepresentation;
+    ColorsRepresentation m_predefinedColorsRepresentation;
     WaveformMarkSet m_marks;
     std::vector<WaveformMarkRange> m_markRanges;
 

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -21,6 +21,8 @@
 #include "track/track.h"
 #include "widget/wwidget.h"
 
+#include "util/color.h"
+
 #include "waveform/renderers/waveformsignalcolors.h"
 #include "waveform/renderers/waveformmarkset.h"
 #include "waveform/renderers/waveformmarkrange.h"

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -84,7 +84,7 @@ class WOverview : public WWidget {
 
     void onMarkChanged(double v);
     void onMarkRangeChange(double v);
-    void onTrackCueChange(void);
+    void receiveCuesUpdated();
 
     void slotWaveformSummaryUpdated();
     void slotAnalyzerProgress(int progress);
@@ -99,6 +99,8 @@ class WOverview : public WWidget {
     inline double positionToValue(int position) const {
         return (static_cast<double>(position) + m_b) / m_a;
     }
+
+    void updateCues(const QList<CuePointer> &loadedCues);
 
     const QString m_group;
     UserSettingsPointer m_pConfig;

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -84,6 +84,7 @@ class WOverview : public WWidget {
 
     void onMarkChanged(double v);
     void onMarkRangeChange(double v);
+    void onTrackCueChange(void);
 
     void slotWaveformSummaryUpdated();
     void slotAnalyzerProgress(int progress);


### PR DESCRIPTION
This is my first attempt at exposing the the color feature of the hotcues to the UI. I want to base most of the Design choices on the work done by @ferranpujolcamins (https://drive.google.com/file/d/0Bw8dE5EyzDY6bk1WemUwWENlQlE/view) and the discussions in the zulip thread (https://mixxx.zulipchat.com/#narrow/stream/109122-general/topic/Colored.20Hotcues).

- [x] make color editable via the Cuepoints panel in the Track Properties.
- [x] let woverview reflect the color changes.
- [x] add a ControlObject for the color.
- [x] make contrastLineColor of Cuemarkers adapt to CueColor
- [x] invert color of waveformrendermark label textcolor based on contrast.
- [x] Convert QString of color to predefined QCombobox with pallete.
- [x] make CueColors overwritable by the skin
- [x] add Javascript utility methods for convient interface with the CO

I want to split any further tasks (like being able to configure the hotcueproperties directly within the skin) into seperate PRs.