### PR TITLE
Fix for bug 1793865

### DIFF
--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -355,7 +355,7 @@
               <item>
                <widget class="QPushButton" name="btnImportMetadataFromFile">
                 <property name="text">
-                 <string>Import Metadata from File</string>
+                 <string>Re-Import Metadata</string>
                 </property>
                </widget>
               </item>
@@ -618,8 +618,8 @@
            <item row="0" column="2">
             <widget class="QCheckBox" name="bpmConst">
              <property name="toolTip">
-              <string>Converts beats detected by the analyzer into a fixed-tempo beatgrid. 
-Use this setting if your tracks have a constant tempo (e.g. most electronic music). 
+              <string>Converts beats detected by the analyzer into a fixed-tempo beatgrid.
+Use this setting if your tracks have a constant tempo (e.g. most electronic music).
 Often results in higher quality beatgrids, but will not do well on tracks that have tempo shifts.</string>
              </property>
              <property name="text">


### PR DESCRIPTION
The pull request contains fix for the bug #1793865 which says " "Import Metadata from File" is ambigious ". I propose to change "Import Metadata from File" -> "Import Metadata from Audio File". 

Link to bug: ["Import Metadata from File" is ambigious](https://bugs.launchpad.net/mixxx/+bug/1793865)