### PR TITLE
Re-add linker search directory 

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -476,6 +476,7 @@ class Qt(Dependence):
             libdir_path = Qt.find_framework_libdir(qtdir, qt5)
             if os.path.isdir(libdir_path):
                 build.env.Append(LINKFLAGS=['-Wl,-rpath,%s' % libdir_path])
+                build.env.Append(LINKFLAGS="-L" + libdir_path)
 
         # Mixxx requires C++11 support. Windows enables C++11 features by
         # default but Clang/GCC require a flag.


### PR DESCRIPTION
to fix regression from 5ba6519a7d2ec70228a3958cf1c626b65d2c66c4