### PR TITLE
Create a 'libmixxx.a' static library which mixxx and mixxx-test link.

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -1224,8 +1224,6 @@ class MixxxCore(Feature):
                    "util/autohidpi.cpp",
                    "util/screensaver.cpp",
                    "util/indexrange.cpp",
-
-                   '#res/mixxx.qrc'
                    ]
 
         proto_args = {

--- a/src/SConscript
+++ b/src/SConscript
@@ -32,6 +32,25 @@ Import('mixxxminimal_plugins')
 env = build.env
 flags = build.flags
 
+# Make a static library of all Mixxx's sources. This library will be linked into
+# both mixxx and mixxx-test.
+mixxx_lib = env.StaticLibrary('libmixxx',
+                              [source for source in sources
+                               if str(source) != 'main.cpp'])
+qt5 = depends.Qt.qt5_enabled(build)
+# mixxx.qrc must not be bundled into libmixxx.a since the linker will not link
+# it into the resulting binary unless it is on the link command-line explicitly
+# (it has no link-time symbols that are needed by anything in Mixxx).
+if qt5:
+        mixxx_qrc = env.StaticObject(env.Qrc5('qrc_mixxx', '#res/mixxx.qrc'))
+else:
+        mixxx_qrc = env.StaticObject(env.Qrc4('qrc_mixxx', '#res/mixxx.qrc'))
+# libmixxx.a needs to precede all other libraries so that symbols it requires
+# end up in the linker's list of unresolved symbols before other libraries are
+# searched for symbols.
+env.Prepend(LIBS=mixxx_lib)
+mixxx_main = env.StaticObject('main.cpp')
+
 #Tell SCons to build Mixxx
 #=========================
 if build.platform_is_windows:
@@ -65,17 +84,18 @@ if build.platform_is_windows:
         fo.write(''.join(str_list))
         fo.close()
 
+        mixxx_rc = env.RES('#src/mixxx.rc')
         mixxx_bin = env.Program('mixxx',
-                            [sources, env.RES('#src/mixxx.rc')],
-                            LINKCOM = [env['LINKCOM'], 'mt.exe -nologo -manifest ${TARGET}.manifest -outputresource:$TARGET;1'])
+                                [mixxx_main, mixxx_qrc, mixxx_rc],
+                                LINKCOM = [env['LINKCOM'], 'mt.exe -nologo -manifest ${TARGET}.manifest -outputresource:$TARGET;1'])
 elif build.platform_is_osx:
         # Bug #1258435: executable name must match CFBundleExecutable in the
         # Info.plist. For codesigned bundles it seems the CFBundleExecutable
         # must match the bundle name or else we SIGILL at startup (not sure
         # why).
-        mixxx_bin = env.Program('Mixxx', sources)
+        mixxx_bin = env.Program('Mixxx', [mixxx_main, mixxx_qrc])
 else:
-        mixxx_bin = env.Program('mixxx', sources)
+        mixxx_bin = env.Program('mixxx', [mixxx_main, mixxx_qrc])
 
 # Make sure mixxxminimal plugins are built before
 # mixxx_bin. This fixes a race where when building with multiple threads the
@@ -102,33 +122,28 @@ def define_test_targets(default=False):
         test_files = [test_env.StaticObject(filename)
                       if filename !='main.cpp' else filename
                       for filename in test_files]
-        mixxx_sources = [filename for filename in sources if filename != 'main.cpp']
-        test_sources = (test_files + mixxx_sources)
+        test_sources = test_files
 
-        env.Append(LIBPATH="#lib/gtest-1.7.0/lib")
-        env.Append(LIBS = 'gtest')
+        test_env.Append(LIBPATH="#lib/gtest-1.7.0/lib")
+        test_env.Append(LIBS=['gtest'])
 
-        env.Append(LIBPATH="#lib/gmock-1.7.0/lib")
-        env.Append(LIBS = 'gmock')
+        test_env.Append(LIBPATH="#lib/gmock-1.7.0/lib")
+        test_env.Append(LIBS=['gmock'])
 
-        env.Append(LIBPATH="#lib/benchmark/lib")
-        env.Append(LIBS = 'benchmark')
+        test_env.Append(LIBPATH="#lib/benchmark/lib")
+        test_env.Append(LIBS=['benchmark'])
 
         if build.platform_is_windows:
                 # For SHGetValueA in Google's benchmark library.
-                env.Append(LIBS = 'Shlwapi')
+                test_env.Append(LIBS=['Shlwapi'])
 
-                # TODO(rryan): Build Mixxx core as a shared object and link it
-                # into mixxx and mixxx-test. We could build both in different
-                # environments right now but then automoc and protoc get run in
-                # both environments which makes SCons unhappy.
                 # Currently both executables are built with /subsystem:windows
                 # and the console is attached manually
-                test_bin = env.Program(
-                        'mixxx-test', [test_sources, env.RES('#src/mixxx.rc')],
+                test_bin = test_env.Program(
+                        'mixxx-test', [test_sources, mixxx_qrc, mixxx_rc],
                         LINKCOM = [env['LINKCOM'], 'mt.exe -nologo -manifest ${TARGET}.manifest -outputresource:$TARGET;1'])
         else:
-                test_bin = env.Program(target='mixxx-test', source=test_sources)
+                test_bin = test_env.Program('mixxx-test', [test_sources, mixxx_qrc])
 
         if not build.platform_is_windows:
                 copy_test_bin = Command("../mixxx-test", test_bin, Copy("$TARGET", "$SOURCE"))
@@ -302,7 +317,6 @@ elif build.crosscompile and build.platform_is_windows and build.toolchain_is_gnu
         dll_files = Glob('#/../../mixxx-win%slib-crossmingw' % build.bitwidth)
 
 qt_modules = depends.Qt.enabled_modules(build)
-qt5 = depends.Qt.qt5_enabled(build)
 
 if build.platform_is_windows:
     suffix = 'd.dll' if build.build_is_debug else '.dll'


### PR DESCRIPTION
This should fix "duplicate environment" warnings we get on Windows and removes the dependency on gmock, gtest, and benchmark when building with `test=1`.

Fixes Bug #1151646.