### PR TITLE
bpm Delegate SpinBox Tweak

### DIFF
--- a/src/library/bpmdelegate.cpp
+++ b/src/library/bpmdelegate.cpp
@@ -21,7 +21,7 @@ class BpmEditorCreator : public QItemEditorCreatorBase {
         pBpmSpinbox->setFrame(false);
         pBpmSpinbox->setMinimum(0);
         pBpmSpinbox->setMaximum(1000);
-        pBpmSpinbox->setSingleStep(1e-8);
+        pBpmSpinbox->setSingleStep(1e-3);
         pBpmSpinbox->setDecimals(8);
         pBpmSpinbox->setObjectName("LibraryBPMSpinBox");
         return pBpmSpinbox;

--- a/src/library/bpmdelegate.h
+++ b/src/library/bpmdelegate.h
@@ -23,4 +23,4 @@ class BPMDelegate : public TableItemDelegate {
     QItemEditorFactory* m_pFactory;
 };
 
-#endif // BUTTONCOLUMNDELEGATE_H
+#endif // BPMDELEGATE_H


### PR DESCRIPTION
...and minor correction to comment at the end of bpmdelegate.h

The bpm SpinBox arrows currently modify the value by 1/100,000,000th of a bpm each time. This PR changes that to 1/1,000th of a bpm.

As discussed on [Zulip](https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/BPM.20spinbox.20in.20the.20library.20table.20view)