### PR TITLE
Update controllerdebug.h to unqouted output for mixxx.log

### DIFF
--- a/src/controllers/controllerdebug.h
+++ b/src/controllers/controllerdebug.h
@@ -30,6 +30,21 @@ class ControllerDebug {
 // We prefix every log message with Logging::kControllerDebugPrefix so that we
 // can bypass the --logLevel commandline argument when --controllerDebug is
 // specified.
+//
+// In order of Bug #1797746, since transition to qt5 it is needed unquote the
+// output for mixxx.log with .noquote(), because in qt5 QDebug() is quoted by default.
+
+#if QT_VERSION > 0x050399
+
+#define controllerDebug(stream)       \
+{                                     \
+    if (ControllerDebug::enabled()) { \
+        QDebug(QtDebugMsg).noquote() << ControllerDebug::kLogMessagePrefix << stream; \
+    }                                 \
+}                                     \
+
+#else
+
 #define controllerDebug(stream)       \
 {                                     \
     if (ControllerDebug::enabled()) { \
@@ -37,4 +52,5 @@ class ControllerDebug {
     }                                 \
 }                                     \
 
+#endif
 #endif // CONTROLLERDEBUG_H


### PR DESCRIPTION
Since qt5, QDebug sems quoted by default. But for debugging we need unquoted output in mixxx.log