### PR TITLE
Only create a QGLWidget if safeMode is not enabled.

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -379,9 +379,11 @@ void MixxxMainWindow::initialize(QApplication* pApp, const CmdlineArgs& args) {
 
     // Before creating the first skin we need to create a QGLWidget so that all
     // the QGLWidget's we create can use it as a shared QGLContext.
-    QGLWidget* pContextWidget = new QGLWidget(this);
-    pContextWidget->hide();
-    SharedGLContext::setWidget(pContextWidget);
+    if (!CmdlineArgs::Instance().getSafeMode()) {
+        QGLWidget* pContextWidget = new QGLWidget(this);
+        pContextWidget->hide();
+        SharedGLContext::setWidget(pContextWidget);
+    }
 
     launchProgress(63);
 


### PR DESCRIPTION
safeMode is intended to start Mixxx even when there are problems with OpenGL.
So, if safeMode is enabled, a QGLWidget should not be created, because it
initializes OpenGL.