### PR TITLE
fix skin settings open/close button for OSX lp1795663

### DIFF
--- a/res/skins/Deere (64 Samplers)/skin_settings.xml
+++ b/res/skins/Deere (64 Samplers)/skin_settings.xml
@@ -18,20 +18,32 @@
             <SizePolicy>e,min</SizePolicy>
             <Text>Skin Settings</Text>
           </Label>
-          <Template src="skin:../Deere/left_2state_button.xml">
-            <SetVariable name="TooltipId">skin_settings</SetVariable>
-            <SetVariable name="ObjectName">SidebarShowHideSkinSettingsButton</SetVariable>
-            <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-            <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-            <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-            <SetVariable name="state_0_text"></SetVariable>
-            <SetVariable name="state_0_pressed">../Deere/icon/ic_clear_48px.svg</SetVariable>
-            <SetVariable name="state_0_unpressed">../Deere/icon/ic_clear_48px.svg</SetVariable>
-            <SetVariable name="state_1_text"></SetVariable>
-            <SetVariable name="state_1_pressed">../Deere/icon/ic_clear_48px.svg</SetVariable>
-            <SetVariable name="state_1_unpressed">../Deere/icon/ic_clear_48px.svg</SetVariable>
-            <SetVariable name="left_connection_control">[Master],skin_settings</SetVariable>
-          </Template>
+          <PushButton>
+            <TooltipId>skin_settings</TooltipId>
+            <ObjectName>SidebarShowHideSkinSettingsButton</ObjectName>
+            <MinimumSize><Variable name="SquareButtonMinimumSize"/></MinimumSize>
+            <MaximumSize><Variable name="SquareButtonMaximumSize"/></MaximumSize>
+            <SizePolicy><Variable name="SquareButtonSizePolicy"/></SizePolicy>
+            <NumberStates>2</NumberStates>
+            <State>
+              <Number>0</Number>
+              <Text><Variable name="state_0_text"/></Text>
+              <Pressed scalemode="STRETCH_ASPECT">../Deere/icon/ic_clear_48px.svg</Pressed>
+              <Unpressed scalemode="STRETCH_ASPECT">../Deere/icon/ic_clear_48px.svg</Unpressed>
+            </State>
+            <State>
+              <Number>1</Number>
+              <Text><Variable name="state_1_text"/></Text>
+              <Pressed scalemode="STRETCH_ASPECT">../Deere/icon/ic_clear_48px.svg</Pressed>
+              <Unpressed scalemode="STRETCH_ASPECT">../Deere/icon/ic_clear_48px.svg</Unpressed>
+            </State>
+            <Connection>
+              <ConfigKey>[Master],skin_settings</ConfigKey>
+              <!-- This is used to work around Bug 1795663 on OSX -->
+              <EmitOnPressAndRelease>false</EmitOnPressAndRelease>
+              <ButtonState>LeftButton</ButtonState>
+            </Connection>
+          </PushButton>
         </Children>
       </WidgetGroup>
 

--- a/res/skins/Deere/skin_settings.xml
+++ b/res/skins/Deere/skin_settings.xml
@@ -18,20 +18,32 @@
             <SizePolicy>e,min</SizePolicy>
             <Text>Skin Settings</Text>
           </Label>
-          <Template src="skin:left_2state_button.xml">
-            <SetVariable name="TooltipId">skin_settings</SetVariable>
-            <SetVariable name="ObjectName">SidebarShowHideSkinSettingsButton</SetVariable>
-            <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-            <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-            <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-            <SetVariable name="state_0_text"></SetVariable>
-            <SetVariable name="state_0_pressed">icon/ic_clear_48px.svg</SetVariable>
-            <SetVariable name="state_0_unpressed">icon/ic_clear_48px.svg</SetVariable>
-            <SetVariable name="state_1_text"></SetVariable>
-            <SetVariable name="state_1_pressed">icon/ic_clear_48px.svg</SetVariable>
-            <SetVariable name="state_1_unpressed">icon/ic_clear_48px.svg</SetVariable>
-            <SetVariable name="left_connection_control">[Master],skin_settings</SetVariable>
-          </Template>
+          <PushButton>
+            <TooltipId>skin_settings</TooltipId>
+            <ObjectName>SidebarShowHideSkinSettingsButton</ObjectName>
+            <MinimumSize><Variable name="SquareButtonMinimumSize"/></MinimumSize>
+            <MaximumSize><Variable name="SquareButtonMaximumSize"/></MaximumSize>
+            <SizePolicy><Variable name="SquareButtonSizePolicy"/></SizePolicy>
+            <NumberStates>2</NumberStates>
+            <State>
+              <Number>0</Number>
+              <Text><Variable name="state_0_text"/></Text>
+              <Pressed scalemode="STRETCH_ASPECT">icon/ic_clear_48px.svg</Pressed>
+              <Unpressed scalemode="STRETCH_ASPECT">icon/ic_clear_48px.svg</Unpressed>
+            </State>
+            <State>
+              <Number>1</Number>
+              <Text><Variable name="state_1_text"/></Text>
+              <Pressed scalemode="STRETCH_ASPECT">icon/ic_clear_48px.svg</Pressed>
+              <Unpressed scalemode="STRETCH_ASPECT">icon/ic_clear_48px.svg</Unpressed>
+            </State>
+            <Connection>
+              <ConfigKey>[Master],skin_settings</ConfigKey>
+              <!-- This is used to work around Bug 1795663 on OSX -->
+              <EmitOnPressAndRelease>false</EmitOnPressAndRelease>
+              <ButtonState>LeftButton</ButtonState>
+            </Connection>
+          </PushButton>
         </Children>
       </WidgetGroup>
 

--- a/res/skins/Deere/tool_bar.xml
+++ b/res/skins/Deere/tool_bar.xml
@@ -322,20 +322,31 @@
             <SizePolicy>min,min</SizePolicy>
             <Layout>horizontal</Layout>
             <Children>
-              <Template src="skin:left_2state_button.xml">
-                <SetVariable name="TooltipId">skin_settings</SetVariable>
-                <SetVariable name="ObjectName">ShowHideSkinSettingsButton</SetVariable>
-                <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-                <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-                <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-                <SetVariable name="state_0_text"></SetVariable>
-                <SetVariable name="state_0_pressed">icon/ic_settings_48px.svg</SetVariable>
-                <SetVariable name="state_0_unpressed">icon/ic_settings_48px.svg</SetVariable>
-                <SetVariable name="state_1_text"></SetVariable>
-                <SetVariable name="state_1_pressed">icon/ic_settings_48px.svg</SetVariable>
-                <SetVariable name="state_1_unpressed">icon/ic_settings_48px.svg</SetVariable>
-                <SetVariable name="left_connection_control">[Master],skin_settings</SetVariable>
-              </Template>
+              <PushButton>
+                <TooltipId>skin_settings</TooltipId>
+                <ObjectName>SidebarShowHideSkinSettingsButton</ObjectName>
+                <MinimumSize><Variable name="SquareButtonMinimumSize"/></MinimumSize>
+                <MaximumSize><Variable name="SquareButtonMaximumSize"/></MaximumSize>
+                <SizePolicy><Variable name="SquareButtonSizePolicy"/></SizePolicy>
+                <NumberStates>2</NumberStates>
+                <State>
+                  <Number>0</Number>
+                  <Text><Variable name="state_0_text"/></Text>
+                  <Pressed scalemode="STRETCH_ASPECT">icon/ic_settings_48px.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">icon/ic_settings_48px.svg</Unpressed>
+                </State>
+                <State>
+                  <Number>1</Number>
+                  <Text><Variable name="state_1_text"/></Text>
+                  <Pressed scalemode="STRETCH_ASPECT">icon/ic_settings_48px.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">icon/ic_settings_48px.svg</Unpressed>
+                </State>
+                <Connection>
+                  <ConfigKey>[Master],skin_settings</ConfigKey>
+                  <EmitOnPressAndRelease>false</EmitOnPressAndRelease>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+              </PushButton>
             </Children>
             <Connection>
               <ConfigKey>[Master],skin_settings</ConfigKey>

--- a/res/skins/Tango (64 Samplers)/skin_settings.xml
+++ b/res/skins/Tango (64 Samplers)/skin_settings.xml
@@ -36,12 +36,24 @@ Description:
               <!-- push Close button to far right -->
               <WidgetGroup><Size>1me,1me</Size></WidgetGroup>
 
-              <Template src="skin:../Tango/button_2state.xml">
-                <SetVariable name="TooltipId">skin_settings</SetVariable>
-                <SetVariable name="ObjectName">SkinSettingsClose</SetVariable>
-                <SetVariable name="Size">20f,24f</SetVariable>
-                <SetVariable name="ConfigKey">[Master],skin_settings</SetVariable>
-              </Template>
+              <PushButton>
+                <TooltipId>skin_settings</TooltipId>
+                <ObjectName>SkinSettingsClose</ObjectName>
+                <Size>20f,24f</Size>
+                <!-- This is used to work around Bug 1795663 on OSX -->
+                <EmitOnPressAndRelease>false</EmitOnPressAndRelease>
+                <NumberStates>2</NumberStates>
+                <State>
+                  <Number>0</Number>
+                </State>
+                <State>
+                  <Number>1</Number>
+                </State>
+                <Connection>
+                  <ConfigKey>[Master],skin_settings</ConfigKey>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+              </PushButton>
             </Children>
           </WidgetGroup>
 

--- a/res/skins/Tango/skin_settings.xml
+++ b/res/skins/Tango/skin_settings.xml
@@ -36,12 +36,24 @@ Description:
               <!-- push Close button to far right -->
               <WidgetGroup><Size>1me,1me</Size></WidgetGroup>
 
-              <Template src="skin:../Tango/button_2state.xml">
-                <SetVariable name="TooltipId">skin_settings</SetVariable>
-                <SetVariable name="ObjectName">SkinSettingsClose</SetVariable>
-                <SetVariable name="Size">20f,24f</SetVariable>
-                <SetVariable name="ConfigKey">[Master],skin_settings</SetVariable>
-              </Template>
+              <PushButton>
+                <TooltipId>skin_settings</TooltipId>
+                <ObjectName>SkinSettingsClose</ObjectName>
+                <Size>20f,24f</Size>
+                <!-- This is used to work around Bug 1795663 on OSX -->
+                <EmitOnPressAndRelease>false</EmitOnPressAndRelease>
+                <NumberStates>2</NumberStates>
+                <State>
+                  <Number>0</Number>
+                </State>
+                <State>
+                  <Number>1</Number>
+                </State>
+                <Connection>
+                  <ConfigKey>[Master],skin_settings</ConfigKey>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+              </PushButton>
             </Children>
           </WidgetGroup>
 

--- a/res/skins/Tango/topbar.xml
+++ b/res/skins/Tango/topbar.xml
@@ -333,12 +333,24 @@ Description:
             <Layout>vertical</Layout>
             <SizePolicy>min,min</SizePolicy>
             <Children>
-              <Template src="skin:button_2state.xml">
-                <SetVariable name="TooltipId">skin_settings</SetVariable>
-                <SetVariable name="ObjectName">SkinSettingsToggler</SetVariable>
-                <SetVariable name="Size">24f,24f</SetVariable>
-                <SetVariable name="ConfigKey">[Master],skin_settings</SetVariable>
-              </Template>
+              <PushButton>
+                <TooltipId>skin_settings</TooltipId>
+                <ObjectName>SkinSettingsToggler</ObjectName>
+                <Size>24f,24f</Size>
+                <!-- This is used to work around Bug 1795663 on OSX -->
+                <EmitOnPressAndRelease>false</EmitOnPressAndRelease>
+                <NumberStates>2</NumberStates>
+                <State>
+                  <Number>0</Number>
+                </State>
+                <State>
+                  <Number>1</Number>
+                </State>
+                <Connection>
+                  <ConfigKey>[Master],skin_settings</ConfigKey>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+              </PushButton>
             </Children>
             <Connection>
               <ConfigKey persist="true">[Master],skin_settings</ConfigKey>


### PR DESCRIPTION
on OSX the skin settings menu would close immediately after being opened if the trackpad button release event occurs on the open/close button. In Deere and Tango the Open button is in the same place (but another widget group) as the Close button.

This PR restores the expected behaviour it in 2.2 by using `<EmitOnPressAndRelease>false</EmitOnPressAndRelease>` for those buttons in Deere and Tango
[Bug 1795663](https://bugs.launchpad.net/mixxx/+bug/1795663)

**Edit**
as reported in launchpad, the bug seems to be fixed in master.