### PR TITLE
fix library styles in 2.2

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -438,28 +438,15 @@ QTreeView::branch:open:!has-children:has-siblings:selected {
   background-color: #1F1F1F;
   border: 1px solid #1A1A1A;
 }
-/* transition time in Auto DJ tab */
-WLibrary QSpinBox {
-  min-height: 20px;
-  max-height: 20px;
-  min-width: 40px;
-  max-width: 40px;
-}
-
-#DlgAutoDJ QLabel {
-  font: 10px;
-}
-
-WLibrary QSpinBox:editable {
-  background: transparent;
-  color:#d2d2d2;
-}
+/* transition time in Auto DJ tab is styled pretty much the same as WBeatSpinBox above */
+#DlgAutoDJ QSpinBox {}
 
 /* Extra declaration for QRadionButton otherwise it shows up with wrong colors in Linux with Gnome */
 WLibrary QLabel, WLibrary QRadioButton {
   /* same as QTreeview */
   color: #d2d2d2;
   margin: 9px 10px 6px 0px;
+  font-size: 12px;
 }
 
 WLibrary QRadioButton::indicator {
@@ -491,7 +478,7 @@ WLibrary QRadioButton::indicator:unchecked {
   padding: 4px;
   color: #D2D2D2;
   background-color: #4B4B4B;
-  border: 1px solid #4B4B4B;
+  border: 0px solid #4B4B4B;
   border-radius: 2px;
   outline: none;
 }
@@ -626,6 +613,11 @@ QScrollBar::sub-line:horizontal, QScrollBar::sub-line:vertical {
   height: 0px;
   border: none;
 }
+/* Corner in between two scrollbars */
+QAbstractScrollArea::corner {
+  border-top: 1px solid #141414;
+  border-left: 1px solid #141414;
+}
 
 /*******************************************************************************
  ** END LIBRARY *****************************************************************
@@ -757,52 +749,59 @@ WWidget, QLabel {
   padding: 0px;
 }
 
-WBeatSpinBox {
+WBeatSpinBox,
+#DlgAutoDJ QSpinBox {
   color: #c1cabe;
   background-color: #1f1e1e;
   border: 1px solid #444342;
   border-radius: 3px;
-  padding: 2px;
   font: 15px;
-}
-
-  WBeatSpinBox:hover {
+  }
+  WBeatSpinBox {
+    padding: 2px;
+  }
+  #DlgAutoDJ QSpinBox {
+    padding: 1px 2px 2px 2px;
+    margin: 3px 0px 0px 2px;
+  }
+  WBeatSpinBox:hover,
+  #DlgAutoDJ QSpinBox:hover {
     border: 1px ridge #015d8d;
   }
-
-  WBeatSpinBox::down-button {
+  WBeatSpinBox::down-button,
+  #DlgAutoDJ QSpinBox::down-button {
     subcontrol-origin: border;
     subcontrol-position: bottom right; /* position at the top right corner */
     padding-right: 4px;
     padding-top: -3px;
     border: 0;
   }
-
-  WBeatSpinBox::down-arrow {
+  WBeatSpinBox::down-arrow,
+  #DlgAutoDJ QSpinBox::down-arrow {
     width: 9px;
     height: 7px;
     image: url(skin:/icon/ic_chevron_down_selector.svg);
   }
-
-  WBeatSpinBox::down-arrow:hover {
+  WBeatSpinBox::down-arrow:hover,
+  #DlgAutoDJ QSpinBox::down-arrow:hover {
     image: url(skin:/icon/ic_chevron_down_selector_hover.svg);
   }
-
-  WBeatSpinBox::up-button {
+  WBeatSpinBox::up-button,
+  #DlgAutoDJ QSpinBox::up-button {
     subcontrol-origin: border;
     subcontrol-position: top right; /* position at the top right corner */
     padding-right: 4px;
     padding-bottom: -3px;
     border: 0;
   }
-
-  WBeatSpinBox::up-arrow {
+  WBeatSpinBox::up-arrow,
+  #DlgAutoDJ QSpinBox::up-arrow {
     width: 9px;
     height: 7px;
     image: url(skin:/icon/ic_chevron_up_selector.svg);
   }
-
-  WBeatSpinBox::up-arrow:hover {
+  WBeatSpinBox::up-arrow:hover,
+  #DlgAutoDJ QSpinBox::up-arrow:hover {
     image: url(skin:/icon/ic_chevron_up_selector_hover.svg);
   }
 

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -1730,9 +1730,14 @@ QLabel, QRadioButton {
   color: #cfb32c;
 }
 
-/* Additional space for QRadionButtons and QLabels */
-WLibrary QRadioButton, WLibrary QLabel {
+/* Additional space for QRadionButtons */
+WLibrary QRadioButton {
   margin: 9px 3px 6px 3px;
+}
+
+/* Additional space for QLabels */
+WLibrary QLabel {
+  margin: 6px 3px 9px 3px;
 }
 
 /* Additional space for the first QRadionButton in the row */
@@ -1767,14 +1772,17 @@ WLibrary QRadioButton::indicator:unchecked {
                                stop:0 #252525,
                                stop:1 #0f0f0f);
   }
-  /* Interesting though: this WOULDN'T affect Preview & BPM button */
-  WLibrary QPushButton:hover,
-  WLibrary QPushButton:focus {
-    border: 1px solid #888;
-  }
-  WLibrary QPushButton:!enabled {
-    color: #666;
-  }
+  /* This wouldn't catch disabled buttons in LateNight...
+WLibrary QPushButton:!enabled {
+  color: #333;
+}*/
+#DlgMissing > QPushButton:!enabled,
+#DlgHidden > QPushButton:!enabled,
+#DlgAutoDJ > QPushButton:!enabled,
+#DlgRecording > QPushButton:!enabled,
+#DlgAnalysis > QPushButton:!enabled {
+  color: #666;
+}
 
 /* Additional space for the first QPushButton in the row */
 #DlgAutoDJ > QPushButton#pushButtonShuffle {

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -11,29 +11,47 @@
   font-size: 14px;
 }
 
-WBeatSpinBox {
+WBeatSpinBox,
+/* For some mysterious reason #DlgAutoDJ QSpinBox
+wouldn't style the respective spinbox in Shade (anymore),
+that's why we do it in another way here */
+#spinBoxTransition {
   color: #060613;
   background-color: #aab2b7;
-  border: 1px solid #060613;
-  padding: 0px;
   font: 13px;
+  padding: 0px;
 }
+WBeatSpinBox {
+  border: 1px solid #060613;
+}
+#spinBoxTransition {
+/* omitting the border definition miraculously makes the spinbox grow */
+/* 0px border OTOH makes the spinbox shrink disproportionately
+  border: 0px; */
+  border: 1px solid #72777A;
+  margin: 0px 0px 2px 1px;
+}
+/*
+QSpinBox:editable {
+  font-size: 10pt;
+  background: transparent;
+  color: #ACACAC; }
+QSpinBox { min-height: 20px; max-height: 20px;min-width: 40px; max-width: 40px;}*/
 
-WBeatSpinBox::up-button{
+WBeatSpinBox::up-button, 
+#spinBoxTransition::up-button {
   height: 9px;
-  border-style: solid;
-  border-color: #060613;
-  border-width: 0px 0px 0px 1px;
+  border-left: 1px solid #060613;
   image: url(skin:/btn/btn_spin_up.png) no-repeat;
 }
 
-WBeatSpinBox::down-button {
+WBeatSpinBox::down-button,
+#spinBoxTransition::down-button {
   height: 9px;
-  border-style: solid;
-  border-color: #060613;
-  border-width: 0px 0px 0px 1px;
+  border-left: 1px solid #060613;
   image: url(skin:/btn/btn_spin_down.png) no-repeat;
 }
+
 
 WEffectSelector {
   color: #060613;
@@ -366,11 +384,9 @@ In our case make sure that the "frame"-property in the corresponding dlgautodj.u
 The general rule when it comes to stylesheets is always to remember that if you style part of a widget, then you usually have to style all of it.
 */
 /* transition time in Auto DJ tab*/
-QSpinBox:editable {
-  font-size: 10pt;
-  background: transparent;
-  color: #ACACAC; }
-QSpinBox { min-height: 20px; max-height: 20px;min-width: 40px; max-width: 40px;}
+QSpinBox:editable,
+/* or addressed directly */
+#spinBoxTransition {}
 
 /* Cover Art*/
 WCoverArt {
@@ -397,8 +413,10 @@ QLabel, QRadioButton {
 
 WLibrary { margin: 2px 3px 0px 0px; }
 
-/* Additional space for QRadionButtons and QLabels*/
-WLibrary QRadioButton, WLibrary QLabel { margin: 9px 3px 6px 3px; }
+/* Additional space for QRadionButtons */
+WLibrary QRadioButton { margin: 9px 3px 6px 3px; }
+/* Additional space for QLabels */
+WLibrary QLabel { margin: 6px 3px 9px 3px; }
 
 /* Additional space for the first QRadionButton in the row*/
 WLibrary QRadioButton#radioButtonRecentlyAdded { margin: 9px 3px 6px 12px; }
@@ -424,13 +442,14 @@ WLibrary QPushButton {
   height: 22px;	*/
   color: #0f0f0f;
   margin: 1px 2px 3px 1px;
-  padding: 2px 4px 2px 4px;
+  padding: 1px 3px 0px 3px;
   background-color: #99A0A4;
   background-position: center;
-  border: 0px;
+  border: 1px solid #99A0A4;
   }
   WLibrary QPushButton:!enabled {
     background-color: #72777A;
+    border: 1px solid #72777A;
     }
   WLibrary QPushButton:unchecked {
     color: #888;

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -1029,9 +1029,6 @@ WBeatSpinBox,
     padding: -1px 3px -1px 3px;
     margin: 0px 17px 3px 7px;
   }
-  #DlgAutoDJ QLabel {
-    margin: 0px 0px 3px 2px;
-  }
   WBeatSpinBox:hover,
   #DlgAutoDJ QSpinBox:hover {
     border-color: #888;
@@ -2205,15 +2202,18 @@ QHeaderView {
       }
 
 /* Scroll bars */
+QScrollBar {
+  padding: 1px;
+}
 QScrollBar:horizontal {
   min-width: 12px;
-  height: 8px;
+  height: 10px;
   background: #000;
   border-radius: 2px;
   }
   QScrollBar:vertical {
     min-height: 12px;
-    width: 8px;
+    width: 10px;
     background: #000;
     border-radius: 2px;
     }
@@ -2222,7 +2222,7 @@ QScrollBar:horizontal {
   QScrollBar::sub-page {
     min-width: 15px;
     min-height: 15px;
-    background-color: #0f0f0f;
+    background-color: #000;
     }
   QScrollBar::handle:horizontal {
     min-width: 25px;
@@ -2250,6 +2250,11 @@ QScrollBar:horizontal {
   QScrollBar::sub-line:vertical {
     width: 0px;
     height: 0px;
+  }
+  /* Corner in between two scrollbars */
+  QAbstractScrollArea::corner {
+    background-color: #0f0f0f;
+    border: 0px;
   }
 
 /* Pushbuttons, a lot of them...
@@ -2295,7 +2300,8 @@ WLibrary QPushButton {
   height: 22px;	*/
   color: #ccc;
   border-radius: 2px;
-  margin: 1px 2px 5px 1px;
+  border: 1px solid #333;
+  margin: 1px 2px 4px 1px;
   padding: 3px 6px 3px 6px;
   background-color: #333;
   background-position: center;
@@ -2312,23 +2318,31 @@ WLibrary QPushButton {
     }
   WLibrary QPushButton:checked {
     color: #000;
-    font-weight: bold;
     background-color: #ff7b00;
     }
   WLibrary QPushButton:checked:hover {
     border: 1px solid #ff3f00;
     }
+  /* make library action buttons bold */
+  QPushButton#pushButtonAutoDJ,
+  QPushButton#pushButtonRecording,
+  QPushButton#pushButtonAnalyze,
+  QPushButton#btnPurge,
+  QPushButton#btnUnhide {
+    font-weight: bold;
+  }
+  
   /* 'Enable AutoDJ' button	*/
   QPushButton#pushButtonAutoDJ:hover,
   QPushButton#pushButtonRecording:hover,
   QPushButton#pushButtonAnalyze:hover {
     border: 1px solid #ff6600;
   }
-  /* Push 'Start/Stop Recording' button and
-    'Enable AutoDJ' button away from skin border	*/
+  /* Push buttons at far right away from skin border	*/
   QPushButton#pushButtonAutoDJ,
-  QPushButton#pushButtonRecording {
-    margin: 1px 9px 5px 1px;
+  QPushButton#pushButtonRecording,
+  QPushButton#Analyze {
+    margin: 1px 9px 4px 1px;
   }
   QPushButton#pushButtonRecording:unchecked {
     color: #888;
@@ -2338,9 +2352,22 @@ WLibrary QPushButton {
   QPushButton#pushButtonRecording:unchecked:hover,
   QPushButton#pushButtonRecording:checked {
     color: #dddddd;
-    font-weight: bold;
     background-color: #a90000;
     border: 1px solid #ca0000;
+  }
+
+  /* align/center AutoDJ transition label vertically with spinbox */
+  QLabel#labelTransitionAppendix {
+    margin: 0px 0px 5px 2px;
+  }
+  /* Push labels away from buttons at the right */
+  /* AutoDJ selction info */
+  QLabel#labelSelectionInfo,
+  /* Recording info */
+  #DlgRecording QLabel,
+  /* Analysis progress info */
+  QLabel#labelProgress {
+    margin: 0px 4px 5px 2px;
   }
 
   /* Entire BPM cell */


### PR DESCRIPTION
some labels and button borders in DlgRecording, DlgAutoDJ and DlgAnalysis were screwed up or offset.

**Deere & Shade**: adopt beatsize spinbox style for AutoDJ transition (I have the strange feeling I fixed this several times already...)
**LateNight**: add style for disabled buttons
**Tango**: make the scrollbars a bit wider

![lib-fix_deere](https://user-images.githubusercontent.com/5934199/47441266-0bfac580-d7b0-11e8-9ea6-38ac94760e7a.png)
![lib-fix_shade](https://user-images.githubusercontent.com/5934199/47441268-0bfac580-d7b0-11e8-842a-735f9955f71d.png)
![lib-fix_tango](https://user-images.githubusercontent.com/5934199/47443572-ede39400-d7b4-11e8-99cc-f345feca0c60.png)
![lib-fix_latenight](https://user-images.githubusercontent.com/5934199/47441267-0bfac580-d7b0-11e8-86bc-e0b9978147ba.png)
