### PR TITLE
Refesh exist state before loading the track. lp1800395

### DIFF
--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -204,7 +204,24 @@ QString Track::getCanonicalLocation() const {
     // (copy-on write). But operating on a single instance of QFileInfo
     // might not be thread-safe due to internal caching!
     QMutexLocker lock(&m_qMutex);
-    return TrackRef::canonicalLocation(m_fileInfo);
+
+    // Note: We return here the cached value that was calculated just after 
+    // init this Track object. This avoid repeady use of time 
+    // consuming file IO.
+    // We ignore the case when the user changes a symbolic link to 
+    // point a file to an other location, since this is a user action.
+    // We also don't care if a file disappears while Mixxx is running. Opening 
+    // a non-existent file is already handled and doesn't cause any malfunction.
+    QString loc = TrackRef::canonicalLocation(m_fileInfo);
+    if (loc.isEmpty()) {
+        // we see here an empty path because the file did not exist  
+        // when creating the track object.
+        // The user might have restored the track in the meanwhile.
+        // So try again it again. 
+        m_fileInfo.refresh();
+        QString loc = TrackRef::canonicalLocation(m_fileInfo);
+    }
+    return loc;
 }
 
 QString Track::getDirectory() const {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -206,7 +206,7 @@ QString Track::getCanonicalLocation() const {
     QMutexLocker lock(&m_qMutex);
 
     // Note: We return here the cached value that was calculated just after 
-    // init this Track object. This avoid repeady use of time 
+    // init this Track object. This avoid repeadly use of time 
     // consuming file IO.
     // We ignore the case when the user changes a symbolic link to 
     // point a file to an other location, since this is a user action.
@@ -219,7 +219,7 @@ QString Track::getCanonicalLocation() const {
         // The user might have restored the track in the meanwhile.
         // So try again it again. 
         m_fileInfo.refresh();
-        QString loc = TrackRef::canonicalLocation(m_fileInfo);
+        loc = TrackRef::canonicalLocation(m_fileInfo);
     }
     return loc;
 }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -205,8 +205,8 @@ QString Track::getCanonicalLocation() const {
     // might not be thread-safe due to internal caching!
     QMutexLocker lock(&m_qMutex);
 
-    // Note: We return here the cached value that was calculated just after 
-    // init this Track object. This avoid repeadly use of time 
+    // Note: We return here the cached value, that was calculated just after 
+    // init this Track object. This will avoid repeated use of the time 
     // consuming file IO.
     // We ignore the case when the user changes a symbolic link to 
     // point a file to an other location, since this is a user action.

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -359,7 +359,7 @@ class Track : public QObject {
     mutable QMutex m_qMutex;
 
     // The file
-    QFileInfo m_fileInfo;
+    mutable QFileInfo m_fileInfo;
 
     SecurityTokenPointer m_pSecurityToken;
 


### PR DESCRIPTION
This PR ensures that an existing track can be loaded even though it was not existing before. 
https://bugs.launchpad.net/mixxx/+bug/1800395

This can happen if the track is on a jump drive and the user has just inserted it. 
It fixes a regression from i think 2.0.

It was found while testing a https://bugs.launchpad.net/mixxx/+bug/1776949
Maybe it also fixes this.     