### PR TITLE
Travis macOS fixes to improve timeouts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ before_install:
   # Virtual X, needed for analyzer waveform tests
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0         ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install scons portaudio libsndfile libogg libvorbis portmidi taglib libshout protobuf flac ffmpeg qt chromaprint rubberband libmodplug libid3tag libmad mp4v2 faad2 wavpack opusfile lilv; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
       compiler: gcc
 
     - os: osx
-      osx_image: xcode7.3
       compiler: clang
 # install dependencies
 addons:
@@ -53,10 +52,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0         ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
-  # Homebrew uses Python 3 now, and portmidi depends on Python 2 which triggers this bug:
-  # https://github.com/Homebrew/homebrew-core/issues/26358
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade python ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install scons portaudio libsndfile libogg libvorbis portmidi taglib libshout protobuf flac ffmpeg qt chromaprint rubberband fftw libmodplug libid3tag libmad mp4v2 faad2 wavpack opusfile lilv; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install scons portaudio libsndfile libogg libvorbis portmidi taglib libshout protobuf flac ffmpeg qt chromaprint rubberband libmodplug libid3tag libmad mp4v2 faad2 wavpack opusfile lilv; fi
 
 install:
   ####

--- a/build/depends.py
+++ b/build/depends.py
@@ -1453,7 +1453,10 @@ class MixxxCore(Feature):
             # Stuff you may have compiled by hand
             if os.path.isdir('/usr/local/include'):
                 build.env.Append(LIBPATH=['/usr/local/lib'])
-                build.env.Append(CPPPATH=['/usr/local/include'])
+                # Use -isystem instead of -I to avoid compiler warnings from
+                # system libraries. This cuts down on Mixxx's compilation output
+                # significantly when using Homebrew installed to /usr/local.
+                build.env.Append(CCFLAGS=['-isystem', '/usr/local/include'])
 
             # Non-standard libpaths for fink and certain (most?) darwin ports
             if os.path.isdir('/sw/include'):


### PR DESCRIPTION
* Use default XCode/macOS version (see commit for details).
* Cherry-pick acfd563211d00309f2a6542981f42161f835695e from master to reduce log verbosity.
* Don't run `brew update`, which usually takes 3-5 minutes. Homebrew is updated every time new VMs are published, which should be frequent enough for us.
* Remove `fftw` from dependencies. It's only needed on Linux and saves us installing `gcc`, which conflicts with some of Travis's built-in libraries on the VM.