### PR TITLE
add Cancel button to 'unconfigured Passthrough/Mic/VinylControl' pop-up

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1158,9 +1158,9 @@ void MixxxMainWindow::slotNoVinylControlInputConfigured() {
         this,
         Version::applicationName(),
         tr("There is no input device selected for this vinyl control.\n"
-           "Configure an input device in the sound hardware preferences now?"),
-        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
-    if (btn == QMessageBox::Yes) {
+           "Please select an input device in the sound hardware preferences first."),
+        QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel);
+    if (btn == QMessageBox::Ok) {
         m_pPrefDlg->show();
         m_pPrefDlg->showSoundHardwarePage();
     }
@@ -1171,9 +1171,9 @@ void MixxxMainWindow::slotNoDeckPassthroughInputConfigured() {
         this,
         Version::applicationName(),
         tr("There is no input device selected for this passthrough control.\n"
-           "Configure an input device in the sound hardware preferences now?"),
-        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
-    if (btn == QMessageBox::Yes) {
+           "Please select an input device in the sound hardware preferences first."),
+        QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel);
+    if (btn == QMessageBox::Ok) {
         m_pPrefDlg->show();
         m_pPrefDlg->showSoundHardwarePage();
     }
@@ -1184,9 +1184,9 @@ void MixxxMainWindow::slotNoMicrophoneInputConfigured() {
         this,
         Version::applicationName(),
         tr("There is no input device selected for this microphone.\n"
-           "Configure an input device in the sound hardware preferences now?"),
-        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
-    if (btn == QMessageBox::Yes) {
+           "Please select an input device in the sound hardware preferences first."),
+        QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel);
+    if (btn == QMessageBox::Ok) {
         m_pPrefDlg->show();
         m_pPrefDlg->showSoundHardwarePage();
     }

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -1154,36 +1154,42 @@ void MixxxMainWindow::slotOptionsPreferences() {
 }
 
 void MixxxMainWindow::slotNoVinylControlInputConfigured() {
-    QMessageBox::warning(
+    QMessageBox::StandardButton btn = QMessageBox::warning(
         this,
         Version::applicationName(),
         tr("There is no input device selected for this vinyl control.\n"
-           "Please select an input device in the sound hardware preferences first."),
-        QMessageBox::Ok, QMessageBox::Ok);
-    m_pPrefDlg->show();
-    m_pPrefDlg->showSoundHardwarePage();
+           "Configure an input device in the sound hardware preferences now?"),
+        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
+    if (btn == QMessageBox::Yes) {
+        m_pPrefDlg->show();
+        m_pPrefDlg->showSoundHardwarePage();
+    }
 }
 
 void MixxxMainWindow::slotNoDeckPassthroughInputConfigured() {
-    QMessageBox::warning(
+    QMessageBox::StandardButton btn = QMessageBox::warning(
         this,
         Version::applicationName(),
         tr("There is no input device selected for this passthrough control.\n"
-           "Please select an input device in the sound hardware preferences first."),
-        QMessageBox::Ok, QMessageBox::Ok);
-    m_pPrefDlg->show();
-    m_pPrefDlg->showSoundHardwarePage();
+           "Configure an input device in the sound hardware preferences now?"),
+        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
+    if (btn == QMessageBox::Yes) {
+        m_pPrefDlg->show();
+        m_pPrefDlg->showSoundHardwarePage();
+    }
 }
 
 void MixxxMainWindow::slotNoMicrophoneInputConfigured() {
-    QMessageBox::warning(
+    QMessageBox::StandardButton btn = QMessageBox::warning(
         this,
         Version::applicationName(),
         tr("There is no input device selected for this microphone.\n"
-           "Please select an input device in the sound hardware preferences first."),
-        QMessageBox::Ok, QMessageBox::Ok);
-    m_pPrefDlg->show();
-    m_pPrefDlg->showSoundHardwarePage();
+           "Configure an input device in the sound hardware preferences now?"),
+        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
+    if (btn == QMessageBox::Yes) {
+        m_pPrefDlg->show();
+        m_pPrefDlg->showSoundHardwarePage();
+    }
 }
 
 void MixxxMainWindow::slotChangedPlayingDeck(int deck) {


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1800521

- [x] 1 add Cancel button to warning pop-up
pushed back:
- [ ] 2 add warning to unconfigured Aux `[Aux],mute`/`[Aux],master` after #1755 
- [ ] 3 add warning to unconfigured Headphone `[...],pfl`/`[PreviewDeck],cue_gotoandplay`
