### PR TITLE
Deere :: add Key/BPM expansion indicators, put Key controls next to play position

### DIFF
--- a/res/skins/Deere/deck_text_row.xml
+++ b/res/skins/Deere/deck_text_row.xml
@@ -302,61 +302,67 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>me,max</SizePolicy>
                 <Children>
-                  <!-- We allow to hide track/artist info (aka AM-Mode) in the skin settings,
-                       display just a label with asterixes instead. -->
-                  <TrackProperty>
-                    <TooltipId>track_artist</TooltipId>
-                    <Property>artist</Property>
-                    <SizePolicy>me,min</SizePolicy>
-                    <Elide>right</Elide>
-                    <Group><Variable name="group"/></Group>
-                    <Connection>
-                      <ConfigKey>[Deere],show_track_info</ConfigKey>
-                      <BindProperty>visible</BindProperty>
-                    </Connection>
-                  </TrackProperty>
-
-                  <Label>
-                    <TooltipId>track_artist</TooltipId>
-                    <Size>me,min</Size>
-                    <ObjectName>HiddenTrackArtistInfo</ObjectName>
-                    <Text>***</Text>
-                    <Connection>
-                      <ConfigKey>[Deere],show_track_info</ConfigKey>
-                      <BindProperty>visible</BindProperty>
-                      <Transform>
-                        <Not/>
-                      </Transform>
-                    </Connection>
-                  </Label>
-
                   <WidgetGroup>
-                    <ObjectName>StarratingGutter</ObjectName>
                     <Layout>horizontal</Layout>
-                    <SizePolicy>min,min</SizePolicy>
+                    <SizePolicy>i,max</SizePolicy>
                     <Children>
-                      <StarRating>
-                        <TooltipId>starrating</TooltipId>
+                      <!-- We allow to hide track/artist info (aka AM-Mode) in the skin settings,
+                           display just a label with asterixes instead. -->
+                      <TrackProperty>
+                        <TooltipId>track_artist</TooltipId>
+                        <Property>artist</Property>
+                        <SizePolicy>me,min</SizePolicy>
+                        <Elide>right</Elide>
                         <Group><Variable name="group"/></Group>
-                      </StarRating>
-                    </Children>
-                    <Connection>
-                      <ConfigKey>[Deere],show_starrating</ConfigKey>
-                      <BindProperty>visible</BindProperty>
-                    </Connection>
-                  </WidgetGroup>
+                        <Connection>
+                          <ConfigKey>[Deere],show_track_info</ConfigKey>
+                          <BindProperty>visible</BindProperty>
+                        </Connection>
+                      </TrackProperty>
 
-                  <WidgetGroup>
-                    <ObjectName>PositionGutter</ObjectName>
-                    <Layout>horizontal</Layout>
-                    <SizePolicy>min,max</SizePolicy>
-                    <MinimumSize>70,20</MinimumSize>
-                    <MaximumSize>190,30</MaximumSize>
-                    <Children>
-                      <NumberPos>
-                        <TooltipId>track_time</TooltipId>
-                        <Group><Variable name="group"/></Group>
-                      </NumberPos>
+                      <Label>
+                        <TooltipId>track_artist</TooltipId>
+                        <Size>me,min</Size>
+                        <ObjectName>HiddenTrackArtistInfo</ObjectName>
+                        <Text>***</Text>
+                        <Connection>
+                          <ConfigKey>[Deere],show_track_info</ConfigKey>
+                          <BindProperty>visible</BindProperty>
+                          <Transform>
+                            <Not/>
+                          </Transform>
+                        </Connection>
+                      </Label>
+
+                      <WidgetGroup>
+                        <ObjectName>StarratingGutter</ObjectName>
+                        <Layout>horizontal</Layout>
+                        <SizePolicy>min,min</SizePolicy>
+                        <Children>
+                          <StarRating>
+                            <TooltipId>starrating</TooltipId>
+                            <Group><Variable name="group"/></Group>
+                          </StarRating>
+                        </Children>
+                        <Connection>
+                          <ConfigKey>[Deere],show_starrating</ConfigKey>
+                          <BindProperty>visible</BindProperty>
+                        </Connection>
+                      </WidgetGroup>
+
+                      <WidgetGroup>
+                        <ObjectName>PositionGutter</ObjectName>
+                        <Layout>horizontal</Layout>
+                        <SizePolicy>min,max</SizePolicy>
+                        <MinimumSize>70,20</MinimumSize>
+                        <MaximumSize>190,30</MaximumSize>
+                        <Children>
+                          <NumberPos>
+                            <TooltipId>track_time</TooltipId>
+                            <Group><Variable name="group"/></Group>
+                          </NumberPos>
+                        </Children>
+                      </WidgetGroup>
                     </Children>
                   </WidgetGroup>
                   <!-- Fake a click-able multi-state widget by stacking a

--- a/res/skins/Deere/deck_text_row.xml
+++ b/res/skins/Deere/deck_text_row.xml
@@ -76,189 +76,52 @@
                     </Connection>
                   </Label>
 
-                  <WidgetGroup>
-                    <ObjectName>BPMGutter</ObjectName>
-                    <Layout>horizontal</Layout>
-                    <SizePolicy>min,max</SizePolicy>
+                  <!-- Fake a click-able multi-state widget by stacking a
+                        transparent PushButton dummy (the trigger) on top of the
+                        individual WidgetGroups (the content). PushButton tracks
+                        the size of the active WidgetGroup and resizes. Notice
+                        that the trigger has the same TooltipId as the content.
+                        Description: BPM/Beatgrid edit widget -->
+                  <WidgetStack><!-- BpmEditRow -->
+                    <ObjectName>BpmKeyEditRow</ObjectName>
+                    <SizePolicy>max,</SizePolicy>
+                    <Style>
+                    </Style>
+                    <NextControl>[Deere],bpm_layout_next</NextControl>
+                    <PrevControl>[Deere],bpm_layout_prev</PrevControl>
                     <Children>
-                      <!-- Fake a click-able multi-state widget by stacking a
-                           transparent PushButton dummy (the trigger) on top of the
-                           individual WidgetGroups (the content). PushButton tracks
-                           the size of the active WidgetGroup and resizes. Notice
-                           that the trigger has the same TooltipId as the content.
-                           Description: Key edit widget -->
-                      <WidgetStack>
-                        <ObjectName>KeyEditRow</ObjectName>
-                        <SizePolicy>max,</SizePolicy>
-                        <Style>
-                        </Style>
-                        <NextControl>[Deere],key_layout_next</NextControl>
-                        <PrevControl>[Deere],key_layout_prev</PrevControl>
+                      <WidgetGroup><!-- BpmEditRowCollapsed -->
+                        <ObjectName>BpmKeyEditRowCollapsed</ObjectName>
+                        <Layout>stacked</Layout>
                         <Children>
-                          <WidgetGroup>
-                            <ObjectName>KeyEditRowCollapsed</ObjectName>
-                            <Layout>stacked</Layout>
-                            <Children>
-                              <PushButton>
-                                <ObjectName>KeyEditTrigger</ObjectName>
-                                <TooltipId>visual_key</TooltipId>
-                                <NumberStates>1</NumberStates>
-                                <State>
-                                  <Number>0</Number>
-                                  <!-- <Text>&#9998;</Text>
-                                  <Alignment>right</Alignment> -->
-                                  <Pressed scalemode="STRETCH"></Pressed>
-                                  <Unpressed scalemode="STRETCH"></Unpressed>
-                                </State>
-                                <Connection>
-                                  <ConfigKey>[Deere],key_layout_next</ConfigKey>
-                                </Connection>
-                              </PushButton>
-                              <Key>
-                                <ObjectName>KeyEditTriggerLabel</ObjectName>
-                                <MinimumSize>30,20</MinimumSize>
-                                <Group><Variable name="group"/></Group>
-                                <SizePolicy>min,</SizePolicy>
-                                <DisplayCents>false</DisplayCents>
-                                <Connection>
-                                  <ConfigKey><Variable name="group"/>,visual_key</ConfigKey>
-                                </Connection>
-                              </Key>
-                            </Children>
-                          </WidgetGroup>
+                          <PushButton>
+                            <ObjectName>BpmKeyEditTrigger</ObjectName>
+                            <TooltipId>visual_bpm</TooltipId>
+                            <NumberStates>1</NumberStates>
+                            <State>
+                              <Number>0</Number>
+                              <Pressed scalemode="STRETCH"></Pressed>
+                              <Unpressed scalemode="STRETCH"></Unpressed>
+                            </State>
+                            <Connection>
+                              <ConfigKey>[Deere],bpm_layout_next</ConfigKey>
+                            </Connection>
+                          </PushButton>
 
+                          <!-- We allow to hide the current BPM info in the skin settings,
+                                display just a label with asterixes instead.
+                                See https://bugs.launchpad.net/mixxx/+bug/722889 -->
                           <WidgetGroup>
-                            <ObjectName>KeyEditRowExpanded</ObjectName>
                             <Layout>horizontal</Layout>
                             <Children>
-                              <WidgetGroup>
-                                <ObjectName>KeyEditRowControls</ObjectName>
-                                <Layout>horizontal</Layout>
-                                <SizePolicy>p,me</SizePolicy>
-                                <MinimumSize>80,20</MinimumSize>
-                                <MaximumSize>120,30</MaximumSize>
-                                <Children>
-                                  <Template src="skin:left_right_1state_button.xml">
-                                    <SetVariable name="TooltipId">pitch_down</SetVariable>
-                                    <SetVariable name="ObjectName">PitchDownButton</SetVariable>
-                                    <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-                                    <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-                                    <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-                                    <SetVariable name="state_0_text"></SetVariable>
-                                    <SetVariable name="state_0_pressed">icon/ic_remove_48px.svg</SetVariable>
-                                    <SetVariable name="state_0_unpressed">icon/ic_remove_48px.svg</SetVariable>
-                                    <SetVariable name="left_connection_control"><Variable name="group"/>,pitch_down</SetVariable>
-                                    <SetVariable name="right_connection_control"><Variable name="group"/>,pitch_down_small</SetVariable>
-                                  </Template>
+                              <Label>
+                                <Size>10f,20f</Size>
+                                <ObjectName>BpmKeyInfoShow</ObjectName>
+                              </Label>
 
-                                  <Template src="skin:left_right_1state_button.xml">
-                                    <SetVariable name="TooltipId">pitch_up</SetVariable>
-                                    <SetVariable name="ObjectName">PitchUpButton</SetVariable>
-                                    <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-                                    <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-                                    <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-                                    <SetVariable name="state_0_text"></SetVariable>
-                                    <SetVariable name="state_0_pressed">icon/ic_add_48px.svg</SetVariable>
-                                    <SetVariable name="state_0_unpressed">icon/ic_add_48px.svg</SetVariable>
-                                    <SetVariable name="left_connection_control"><Variable name="group"/>,pitch_up</SetVariable>
-                                    <SetVariable name="right_connection_control"><Variable name="group"/>,pitch_up_small</SetVariable>
-                                  </Template>
-
-                                  <Template src="skin:left_right_1state_button.xml">
-                                    <SetVariable name="TooltipId">sync_reset_key</SetVariable>
-                                    <SetVariable name="ObjectName">SyncKeyButton</SetVariable>
-                                    <SetVariable name="MinimumSize">42,22</SetVariable>
-                                    <SetVariable name="MaximumSize">42,22</SetVariable>
-                                    <SetVariable name="SizePolicy">f,f</SetVariable>
-                                    <SetVariable name="state_0_text">Match</SetVariable>
-                                    <SetVariable name="state_0_pressed"></SetVariable>
-                                    <SetVariable name="state_0_unpressed"></SetVariable>
-                                    <SetVariable name="left_connection_control"><Variable name="group"/>,sync_key</SetVariable>
-                                    <SetVariable name="right_connection_control"><Variable name="group"/>,reset_key</SetVariable>
-                                  </Template>
-                                </Children>
-                              </WidgetGroup><!-- KeyEditRowControls -->
-
-                              <WidgetGroup>
-                                <!-- The key edit controls are aligned to the right because the key
-                                     widget widths can rapidly change, especially with traditional
-                                     notation selected in the preferences. The controls stay calm
-                                     this way. -->
-                                <Layout>stacked</Layout>
-                                <MinimumSize>60,</MinimumSize>
-                                <Children>
-                                  <PushButton>
-                                    <ObjectName>KeyEditTrigger</ObjectName>
-                                    <TooltipId>visual_key</TooltipId>
-                                    <NumberStates>1</NumberStates>
-                                    <State>
-                                      <Number>0</Number>
-                                      <!-- <Text>&#9998;</Text>
-                                      <Alignment>right</Alignment> -->
-                                      <Pressed scalemode="STRETCH"></Pressed>
-                                      <Unpressed scalemode="STRETCH"></Unpressed>
-                                    </State>
-                                    <Connection>
-                                      <ConfigKey>[Deere],key_layout_next</ConfigKey>
-                                    </Connection>
-                                  </PushButton>
-
-                                  <Key>
-                                    <ObjectName>KeyEditTriggerLabel</ObjectName>
-                                    <Group><Variable name="group"/></Group>
-                                    <SizePolicy>min,</SizePolicy>
-                                    <DisplayCents>true</DisplayCents>
-                                    <Connection>
-                                      <ConfigKey><Variable name="group"/>,visual_key</ConfigKey>
-                                    </Connection>
-                                  </Key>
-                                </Children>
-                              </WidgetGroup><!-- KeyEditTrigger -->
-                            </Children>
-                          </WidgetGroup><!-- KeyEditRowExpanded -->
-                        </Children>
-                      </WidgetStack><!-- KeyEditRow -->
-
-                      <!-- Fake a click-able multi-state widget by stacking a
-                           transparent PushButton dummy (the trigger) on top of the
-                           individual WidgetGroups (the content). PushButton tracks
-                           the size of the active WidgetGroup and resizes. Notice
-                           that the trigger has the same TooltipId as the content.
-                           Description: BPM/Beatgrid edit widget -->
-                      <WidgetStack>
-                        <ObjectName>BpmEditRow</ObjectName>
-                        <SizePolicy>max,</SizePolicy>
-                        <Style>
-                        </Style>
-                        <NextControl>[Deere],bpm_layout_next</NextControl>
-                        <PrevControl>[Deere],bpm_layout_prev</PrevControl>
-                        <Children>
-                          <WidgetGroup>
-                            <ObjectName>KeyEditRowCollapsed</ObjectName>
-                            <Layout>stacked</Layout>
-                            <Children>
-                              <PushButton>
-                                <ObjectName>BpmEditTrigger</ObjectName>
-                                <TooltipId>visual_bpm</TooltipId>
-                                <NumberStates>1</NumberStates>
-                                <State>
-                                  <Number>0</Number>
-                                  <!-- <Text>&#9998;</Text>
-                                  <Alignment>right</Alignment> -->
-                                  <Pressed scalemode="STRETCH"></Pressed>
-                                  <Unpressed scalemode="STRETCH"></Unpressed>
-                                </State>
-                                <Connection>
-                                  <ConfigKey>[Deere],bpm_layout_next</ConfigKey>
-                                </Connection>
-                              </PushButton>
-
-                              <!-- We allow to hide the current BPM info in the skin settings,
-                                   display just a label with asterixes instead.
-                                   See https://bugs.launchpad.net/mixxx/+bug/722889 -->
                               <NumberBpm>
-                                <ObjectName>BpmEditTriggerLabel</ObjectName>
-                                <MinimumSize>70,20</MinimumSize>
+                                <ObjectName>BpmKeyEditTriggerLabel</ObjectName>
+                                <MinimumSize>60,20</MinimumSize>
                                 <Group><Variable name="group"/></Group>
                                 <Alignment>right</Alignment>
                                 <Connection>
@@ -284,118 +147,128 @@
                                 </Connection>
                               </Label>
                             </Children>
-                          </WidgetGroup><!-- BpmEditTrigger -->
+                          </WidgetGroup>
+                        </Children>
+                      </WidgetGroup><!-- BpmEditTrigger -->
+
+                      <WidgetGroup><!-- BpmEditRowExpanded -->
+                        <ObjectName>BpmKeyEditRowExpanded</ObjectName>
+                        <Layout>horizontal</Layout>
+                        <Children>
+                          <WidgetGroup>
+                            <ObjectName>BpmKeyEditRowControls</ObjectName>
+                            <Layout>horizontal</Layout>
+                            <SizePolicy>p,me</SizePolicy>
+                            <MinimumSize>100,20</MinimumSize>
+                            <MaximumSize>180,30</MaximumSize>
+                            <Children>
+
+                              <Template src="skin:left_right_1state_button.xml">
+                                <SetVariable name="TooltipId">beats_adjust_faster</SetVariable>
+                                <SetVariable name="ObjectName">BeatsAdjustFasterButton</SetVariable>
+                                <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
+                                <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
+                                <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
+                                <SetVariable name="state_0_text"></SetVariable>
+                                <SetVariable name="state_0_pressed">icon/ic_beats_adjust_faster_48px.svg</SetVariable>
+                                <SetVariable name="state_0_unpressed">icon/ic_beats_adjust_faster_48px.svg</SetVariable>
+                                <SetVariable name="left_connection_control"><Variable name="group"/>,beats_adjust_faster</SetVariable>
+                              </Template>
+
+                              <Template src="skin:left_right_1state_button.xml">
+                                <SetVariable name="TooltipId">beats_adjust_slower</SetVariable>
+                                <SetVariable name="ObjectName">BeatsAdjustSlowerButton</SetVariable>
+                                <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
+                                <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
+                                <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
+                                <SetVariable name="state_0_text"></SetVariable>
+                                <SetVariable name="state_0_pressed">icon/ic_beats_adjust_slower_48px.svg</SetVariable>
+                                <SetVariable name="state_0_unpressed">icon/ic_beats_adjust_slower_48px.svg</SetVariable>
+                                <SetVariable name="left_connection_control"><Variable name="group"/>,beats_adjust_slower</SetVariable>
+                              </Template>
+
+                              <Template src="skin:left_right_1state_button.xml">
+                                <SetVariable name="TooltipId">beats_translate_earlier</SetVariable>
+                                <SetVariable name="ObjectName">BeatsTranslateEarlierButton</SetVariable>
+                                <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
+                                <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
+                                <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
+                                <SetVariable name="state_0_text"></SetVariable>
+                                <SetVariable name="state_0_pressed">icon/ic_beats_translate_earlier_48px.svg</SetVariable>
+                                <SetVariable name="state_0_unpressed">icon/ic_beats_translate_earlier_48px.svg</SetVariable>
+                                <SetVariable name="left_connection_control"><Variable name="group"/>,beats_translate_earlier</SetVariable>
+                              </Template>
+
+                              <Template src="skin:left_right_1state_button.xml">
+                                <SetVariable name="TooltipId">beats_translate_later</SetVariable>
+                                <SetVariable name="ObjectName">BeatsTranslateLaterButton</SetVariable>
+                                <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
+                                <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
+                                <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
+                                <SetVariable name="state_0_text"></SetVariable>
+                                <SetVariable name="state_0_pressed">icon/ic_beats_translate_later_48px.svg</SetVariable>
+                                <SetVariable name="state_0_unpressed">icon/ic_beats_translate_later_48px.svg</SetVariable>
+                                <SetVariable name="left_connection_control"><Variable name="group"/>,beats_translate_later</SetVariable>
+                              </Template>
+
+                              <Template src="skin:left_right_1state_button.xml">
+                                <SetVariable name="TooltipId">beats_translate_curpos</SetVariable>
+                                <SetVariable name="ObjectName">BeatsTranslateCurposButton</SetVariable>
+                                <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
+                                <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
+                                <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
+                                <SetVariable name="state_0_text"></SetVariable>
+                                <SetVariable name="state_0_pressed">icon/ic_beats_translate_curpos_48px.svg</SetVariable>
+                                <SetVariable name="state_0_unpressed">icon/ic_beats_translate_curpos_48px.svg</SetVariable>
+                                <SetVariable name="left_connection_control"><Variable name="group"/>,beats_translate_curpos</SetVariable>
+                                <SetVariable name="right_connection_control"><Variable name="group"/>,beats_translate_match_alignment</SetVariable>
+                              </Template>
+
+                              <PushButton>
+                                <TooltipId>bpm_tap</TooltipId>
+                                <MinimumSize>40,20</MinimumSize>
+                                <MaximumSize>60,30</MaximumSize>
+                                <NumberStates>1</NumberStates>
+                                <State>
+                                  <Number>0</Number>
+                                  <Text>TAP</Text>
+                                </State>
+                                <Connection>
+                                  <ConfigKey><Variable name="group"/>,bpm_tap</ConfigKey>
+                                  <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
+                                  <ButtonState>LeftButton</ButtonState>
+                                </Connection>
+                              </PushButton>
+                            </Children>
+                          </WidgetGroup>
 
                           <WidgetGroup>
-                            <ObjectName>BpmEditRowExpanded</ObjectName>
-                            <Layout>horizontal</Layout>
+                            <Layout>stacked</Layout>
                             <Children>
+                              <PushButton>
+                                <ObjectName>BpmKeyEditTrigger</ObjectName>
+                                <TooltipId>visual_bpm</TooltipId>
+                                <NumberStates>1</NumberStates>
+                                <State>
+                                  <Number>0</Number>
+                                  <Pressed scalemode="STRETCH"></Pressed>
+                                  <Unpressed scalemode="STRETCH"></Unpressed>
+                                </State>
+                                <Connection>
+                                  <ConfigKey>[Deere],bpm_layout_next</ConfigKey>
+                                </Connection>
+                              </PushButton>
+
                               <WidgetGroup>
-                                <ObjectName>BpmEditRowControls</ObjectName>
                                 <Layout>horizontal</Layout>
-                                <SizePolicy>p,me</SizePolicy>
-                                <MinimumSize>100,20</MinimumSize>
-                                <MaximumSize>180,30</MaximumSize>
                                 <Children>
-
-                                  <Template src="skin:left_right_1state_button.xml">
-                                    <SetVariable name="TooltipId">beats_adjust_faster</SetVariable>
-                                    <SetVariable name="ObjectName">BeatsAdjustFasterButton</SetVariable>
-                                    <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-                                    <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-                                    <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-                                    <SetVariable name="state_0_text"></SetVariable>
-                                    <SetVariable name="state_0_pressed">icon/ic_beats_adjust_faster_48px.svg</SetVariable>
-                                    <SetVariable name="state_0_unpressed">icon/ic_beats_adjust_faster_48px.svg</SetVariable>
-                                    <SetVariable name="left_connection_control"><Variable name="group"/>,beats_adjust_faster</SetVariable>
-                                  </Template>
-
-                                  <Template src="skin:left_right_1state_button.xml">
-                                    <SetVariable name="TooltipId">beats_adjust_slower</SetVariable>
-                                    <SetVariable name="ObjectName">BeatsAdjustSlowerButton</SetVariable>
-                                    <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-                                    <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-                                    <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-                                    <SetVariable name="state_0_text"></SetVariable>
-                                    <SetVariable name="state_0_pressed">icon/ic_beats_adjust_slower_48px.svg</SetVariable>
-                                    <SetVariable name="state_0_unpressed">icon/ic_beats_adjust_slower_48px.svg</SetVariable>
-                                    <SetVariable name="left_connection_control"><Variable name="group"/>,beats_adjust_slower</SetVariable>
-                                  </Template>
-
-                                  <Template src="skin:left_right_1state_button.xml">
-                                    <SetVariable name="TooltipId">beats_translate_earlier</SetVariable>
-                                    <SetVariable name="ObjectName">BeatsTranslateEarlierButton</SetVariable>
-                                    <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-                                    <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-                                    <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-                                    <SetVariable name="state_0_text"></SetVariable>
-                                    <SetVariable name="state_0_pressed">icon/ic_beats_translate_earlier_48px.svg</SetVariable>
-                                    <SetVariable name="state_0_unpressed">icon/ic_beats_translate_earlier_48px.svg</SetVariable>
-                                    <SetVariable name="left_connection_control"><Variable name="group"/>,beats_translate_earlier</SetVariable>
-                                  </Template>
-
-                                  <Template src="skin:left_right_1state_button.xml">
-                                    <SetVariable name="TooltipId">beats_translate_later</SetVariable>
-                                    <SetVariable name="ObjectName">BeatsTranslateLaterButton</SetVariable>
-                                    <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-                                    <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-                                    <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-                                    <SetVariable name="state_0_text"></SetVariable>
-                                    <SetVariable name="state_0_pressed">icon/ic_beats_translate_later_48px.svg</SetVariable>
-                                    <SetVariable name="state_0_unpressed">icon/ic_beats_translate_later_48px.svg</SetVariable>
-                                    <SetVariable name="left_connection_control"><Variable name="group"/>,beats_translate_later</SetVariable>
-                                  </Template>
-
-                                  <Template src="skin:left_right_1state_button.xml">
-                                    <SetVariable name="TooltipId">beats_translate_curpos</SetVariable>
-                                    <SetVariable name="ObjectName">BeatsTranslateCurposButton</SetVariable>
-                                    <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-                                    <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-                                    <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-                                    <SetVariable name="state_0_text"></SetVariable>
-                                    <SetVariable name="state_0_pressed">icon/ic_beats_translate_curpos_48px.svg</SetVariable>
-                                    <SetVariable name="state_0_unpressed">icon/ic_beats_translate_curpos_48px.svg</SetVariable>
-                                    <SetVariable name="left_connection_control"><Variable name="group"/>,beats_translate_curpos</SetVariable>
-                                    <SetVariable name="right_connection_control"><Variable name="group"/>,beats_translate_match_alignment</SetVariable>
-                                  </Template>
-
-                                  <PushButton>
-                                    <TooltipId>bpm_tap</TooltipId>
-                                    <MinimumSize>40,20</MinimumSize>
-                                    <MaximumSize>60,30</MaximumSize>
-                                    <NumberStates>1</NumberStates>
-                                    <State>
-                                      <Number>0</Number>
-                                      <Text>TAP</Text>
-                                    </State>
-                                    <Connection>
-                                      <ConfigKey><Variable name="group"/>,bpm_tap</ConfigKey>
-                                      <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
-                                      <ButtonState>LeftButton</ButtonState>
-                                    </Connection>
-                                  </PushButton>
-                                </Children>
-                              </WidgetGroup>
-
-                              <WidgetGroup>
-                                <Layout>stacked</Layout>
-                                <Children>
-                                  <PushButton>
-                                    <ObjectName>BpmEditTrigger</ObjectName>
-                                    <TooltipId>visual_bpm</TooltipId>
-                                    <NumberStates>1</NumberStates>
-                                    <State>
-                                      <Number>0</Number>
-                                      <Pressed scalemode="STRETCH"></Pressed>
-                                      <Unpressed scalemode="STRETCH"></Unpressed>
-                                    </State>
-                                    <Connection>
-                                      <ConfigKey>[Deere],bpm_layout_next</ConfigKey>
-                                    </Connection>
-                                  </PushButton>
+                                  <Label>
+                                    <Size>10f,20f</Size>
+                                    <ObjectName>BpmKeyInfoHide</ObjectName>
+                                  </Label>
 
                                   <NumberBpm>
-                                    <ObjectName>BpmEditTriggerLabel</ObjectName>
+                                    <ObjectName>BpmKeyEditTriggerLabel</ObjectName>
                                     <Group><Variable name="group"/></Group>
                                     <Alignment>right</Alignment>
                                     <Connection>
@@ -403,13 +276,14 @@
                                     </Connection>
                                   </NumberBpm>
                                 </Children>
-                              </WidgetGroup><!-- BpmEditTrigger -->
+                              </WidgetGroup>
+
                             </Children>
-                          </WidgetGroup><!-- BpmEditRowExpanded -->
+                          </WidgetGroup><!-- BpmEditTrigger -->
                         </Children>
-                      </WidgetStack><!-- BpmEditRow -->
+                      </WidgetGroup><!-- BpmEditRowExpanded -->
                     </Children>
-                  </WidgetGroup><!-- BPMGutter -->
+                  </WidgetStack><!-- BpmEditRow -->
                 </Children>
               </WidgetGroup><!-- TitleGutter -->
             </Children>
@@ -485,6 +359,160 @@
                       </NumberPos>
                     </Children>
                   </WidgetGroup>
+                  <!-- Fake a click-able multi-state widget by stacking a
+                        transparent PushButton dummy (the trigger) on top of the
+                        individual WidgetGroups (the content). PushButton tracks
+                        the size of the active WidgetGroup and resizes. Notice
+                        that the trigger has the same TooltipId as the content.
+                        Description: Key edit widget -->
+                  <WidgetStack><!-- KeyEditRow -->
+                    <ObjectName>BpmKeyEditRow</ObjectName>
+                    <SizePolicy>max,</SizePolicy>
+                    <NextControl>[Deere],key_layout_next</NextControl>
+                    <PrevControl>[Deere],key_layout_prev</PrevControl>
+                    <Children>
+                      <WidgetGroup><!-- KeyEditRowCollapsed -->
+                        <ObjectName>BpmKeyEditRowCollapsed</ObjectName>
+                        <Layout>stacked</Layout>
+                        <Children>
+                          <PushButton>
+                            <ObjectName>BpmKeyEditTrigger</ObjectName>
+                            <TooltipId>visual_key</TooltipId>
+                            <NumberStates>1</NumberStates>
+                            <State>
+                              <Number>0</Number>
+                              <Pressed scalemode="STRETCH"></Pressed>
+                              <Unpressed scalemode="STRETCH"></Unpressed>
+                            </State>
+                            <Connection>
+                              <ConfigKey>[Deere],key_layout_next</ConfigKey>
+                            </Connection>
+                          </PushButton>
+  
+                          <WidgetGroup>
+                            <Layout>horizontal</Layout>
+                            <Children>
+                              <Label>
+                                <Size>10f,20f</Size>
+                                <ObjectName>BpmKeyInfoShow</ObjectName>
+                              </Label>
+  
+                              <Key>
+                                <ObjectName>BpmKeyEditTriggerLabel</ObjectName>
+                                <MinimumSize>30,20</MinimumSize>
+                                <Group><Variable name="group"/></Group>
+                                <SizePolicy>min,</SizePolicy>
+                                <DisplayCents>false</DisplayCents>
+                                <Connection>
+                                  <ConfigKey><Variable name="group"/>,visual_key</ConfigKey>
+                                </Connection>
+                              </Key>
+                            </Children>
+                          </WidgetGroup>
+                        </Children>
+                      </WidgetGroup>
+  
+                      <WidgetGroup><!-- KeyEditRowExpanded -->
+                        <ObjectName>BpmKeyEditRowExpanded</ObjectName>
+                        <Layout>horizontal</Layout>
+                        <Children>
+                          <WidgetGroup>
+                            <ObjectName>BpmKeyEditRowControls</ObjectName>
+                            <Layout>horizontal</Layout>
+                            <SizePolicy>p,me</SizePolicy>
+                            <MinimumSize>80,20</MinimumSize>
+                            <MaximumSize>120,30</MaximumSize>
+                            <Children>
+                              <Template src="skin:left_right_1state_button.xml">
+                                <SetVariable name="TooltipId">pitch_down</SetVariable>
+                                <SetVariable name="ObjectName">PitchDownButton</SetVariable>
+                                <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
+                                <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
+                                <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
+                                <SetVariable name="state_0_text"></SetVariable>
+                                <SetVariable name="state_0_pressed">icon/ic_remove_48px.svg</SetVariable>
+                                <SetVariable name="state_0_unpressed">icon/ic_remove_48px.svg</SetVariable>
+                                <SetVariable name="left_connection_control"><Variable name="group"/>,pitch_down</SetVariable>
+                                <SetVariable name="right_connection_control"><Variable name="group"/>,pitch_down_small</SetVariable>
+                              </Template>
+  
+                              <Template src="skin:left_right_1state_button.xml">
+                                <SetVariable name="TooltipId">pitch_up</SetVariable>
+                                <SetVariable name="ObjectName">PitchUpButton</SetVariable>
+                                <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
+                                <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
+                                <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
+                                <SetVariable name="state_0_text"></SetVariable>
+                                <SetVariable name="state_0_pressed">icon/ic_add_48px.svg</SetVariable>
+                                <SetVariable name="state_0_unpressed">icon/ic_add_48px.svg</SetVariable>
+                                <SetVariable name="left_connection_control"><Variable name="group"/>,pitch_up</SetVariable>
+                                <SetVariable name="right_connection_control"><Variable name="group"/>,pitch_up_small</SetVariable>
+                              </Template>
+  
+                              <Template src="skin:left_right_1state_button.xml">
+                                <SetVariable name="TooltipId">sync_reset_key</SetVariable>
+                                <SetVariable name="ObjectName">SyncKeyButton</SetVariable>
+                                <SetVariable name="MinimumSize">42,22</SetVariable>
+                                <SetVariable name="MaximumSize">42,22</SetVariable>
+                                <SetVariable name="SizePolicy">f,f</SetVariable>
+                                <SetVariable name="state_0_text">Match</SetVariable>
+                                <SetVariable name="state_0_pressed"></SetVariable>
+                                <SetVariable name="state_0_unpressed"></SetVariable>
+                                <SetVariable name="left_connection_control"><Variable name="group"/>,sync_key</SetVariable>
+                                <SetVariable name="right_connection_control"><Variable name="group"/>,reset_key</SetVariable>
+                              </Template>
+                            </Children>
+                          </WidgetGroup><!-- KeyEditRowControls -->
+  
+                          <WidgetGroup>
+                            <!-- The key edit controls are aligned to the right because the key
+                                  widget widths can rapidly change, especially with traditional
+                                  notation selected in the preferences. The controls stay calm
+                                  this way. -->
+                            <Layout>stacked</Layout>
+                            <MinimumSize>60,</MinimumSize>
+                            <Children>
+                              <PushButton>
+                                <ObjectName>BpmKeyEditTrigger</ObjectName>
+                                <TooltipId>visual_key</TooltipId>
+                                <NumberStates>1</NumberStates>
+                                <State>
+                                  <Number>0</Number>
+                                  <!-- <Text>&#9998;</Text>
+                                  <Alignment>right</Alignment> -->
+                                  <Pressed scalemode="STRETCH"></Pressed>
+                                  <Unpressed scalemode="STRETCH"></Unpressed>
+                                </State>
+                                <Connection>
+                                  <ConfigKey>[Deere],key_layout_next</ConfigKey>
+                                </Connection>
+                              </PushButton>
+  
+                              <WidgetGroup>
+                                <Layout>horizontal</Layout>
+                                <Children>
+                                  <Label>
+                                    <Size>10f,20f</Size>
+                                    <ObjectName>BpmKeyInfoHide</ObjectName>
+                                  </Label>
+  
+                                  <Key>
+                                    <ObjectName>BpmKeyEditTriggerLabel</ObjectName>
+                                    <Group><Variable name="group"/></Group>
+                                    <SizePolicy>min,</SizePolicy>
+                                    <DisplayCents>true</DisplayCents>
+                                    <Connection>
+                                      <ConfigKey><Variable name="group"/>,visual_key</ConfigKey>
+                                    </Connection>
+                                  </Key>
+                                </Children>
+                              </WidgetGroup>
+                            </Children>
+                          </WidgetGroup><!-- KeyEditTrigger -->
+                        </Children>
+                      </WidgetGroup><!-- KeyEditRowExpanded -->
+                    </Children>
+                  </WidgetStack><!-- KeyEditRow -->
                 </Children>
               </WidgetGroup><!-- ArtistGutter -->
             </Children>

--- a/res/skins/Deere/icon/ic_chevron_left_24x48px.svg
+++ b/res/skins/Deere/icon/ic_chevron_left_24x48px.svg
@@ -1,0 +1,1 @@
+<svg id="svg2" width="24" height="48" version="1.1" viewBox="0 0 24 48" xmlns="http://www.w3.org/2000/svg"><path id="path4" d="m19.415 14.83-2.83-2.83-12 12 12 12 2.83-2.83-9.17-9.17z" fill="#d2d2d2"/></svg>

--- a/res/skins/Deere/icon/ic_chevron_right_24x48px.svg
+++ b/res/skins/Deere/icon/ic_chevron_right_24x48px.svg
@@ -1,0 +1,1 @@
+<svg id="svg2" width="24" height="48" version="1.1" viewBox="0 0 24 48" xmlns="http://www.w3.org/2000/svg"><path id="path4" d="m7.415 12-2.83 2.83 9.17 9.17-9.17 9.17 2.83 2.83 12-12z" fill="#d2d2d2"/></svg>

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -861,34 +861,38 @@ WBeatSpinBox,
   padding: 2px;
 }
 
+#PositionGutter {
+  margin-right: 4px;
+}
+
 /* Start editable widgets in decks */
-#BpmEditRowCollapsed:hover, #KeyEditRowCollapsed:hover,
-#BpmEditRowExpanded:hover, #KeyEditRowExpanded:hover,
+#BpmKeyEditRowCollapsed:hover,
+#BpmKeyEditRowExpanded:hover,
 #PositionGutter:hover, #StarratingGutter:hover {
   /* emphasize editable widgets on hover */
   border: 1px solid #FF6600;
   background-color: rgba(255, 102, 0, 128);
 }
-#BpmEditRowCollapsed, #KeyEditRowCollapsed {
+#BpmKeyEditRowCollapsed {
   qproperty-layoutAlignment: 'AlignCenter';
   /* emphasize active widget */
   border: 1px solid #666666;
 }
 
-#BpmEditRowExpanded, #KeyEditRowExpanded {
+#BpmKeyEditRowExpanded {
   /* emphasize active widget */
   border: 1px solid #FF6600;
   background: rgba(255, 102, 0, 64);
   color: #D6D6D6;
 }
 
-#BpmEditTrigger, #KeyEditTrigger {
+#BpmKeyEditTrigger {
   /* make trigger button transparent */
   background-color: none;
   border: none;
 }
 
-#BpmEditRowControls, #KeyEditRowControls {
+#BpmKeyEditRowControls {
   /* Make room between buttons */
   background-color: #333333;
   padding-left: 1px;
@@ -897,8 +901,16 @@ WBeatSpinBox,
   qproperty-layoutSpacing: 2;
 }
 
-#BpmEditTriggerLabel, #KeyEditTriggerLabel {
+#BpmKeyEditTriggerLabel {
   padding-right: 1px;
+}
+
+#BpmKeyInfoShow {
+  image: url(skin:/icon/ic_chevron_left_24x48px.svg) center center;
+}
+
+#BpmKeyInfoHide {
+  image: url(skin:/icon/ic_chevron_right_24x48px.svg) center center;
 }
 /* End editable widgets in decks */
 


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1800705

Either beatgrid or key controls can be expanded. They replace Stars and play position then.
I choose to expand downwards as horizontal expansion creates ugly situations i.e. if the track cover or the mixer incl. Kill buttons is visible. For the same reason Stars and play position are hidden. The preparation use case justifies hiding those IMO.

![deere-bpmkey-expansion_0](https://user-images.githubusercontent.com/5934199/47871055-4cd78780-de0b-11e8-88ae-0ab86a2a5f3d.png)
![deere-bpmkey-expansion_1](https://user-images.githubusercontent.com/5934199/47871020-30d3e600-de0b-11e8-9d06-e19a097a28f3.png)
![deere-bpmkey-expansion_2](https://user-images.githubusercontent.com/5934199/47871021-30d3e600-de0b-11e8-96ad-3b0bb03acfc6.png)

As soon as this would be merged I'll compact the SVGs.
