### PR TITLE
 Clamp parameter values to valid ranges in EffectParameter::setValue.

### DIFF
--- a/src/effects/effectparameter.cpp
+++ b/src/effects/effectparameter.cpp
@@ -112,8 +112,6 @@ void EffectParameter::setValue(double value) {
         qWarning() << debugString() << "WARNING: Value was outside of limits, clamped.";
     }
 
-    m_value = value;
-
     updateEngineState();
     emit(valueChanged(m_value));
 }


### PR DESCRIPTION
Fixes a conflict between f50ae9b4bf6227874684b69fd1dd1dfe618bd73c and
93f6573baaca339cdb81f1313244c16129fc49c4 that led to effect parameter
values not being clamped. Fixes LP Bug #1795234.