### PR TITLE
LateNight :: fix beat_curpos icon & sampler Sync icon

### DIFF
--- a/res/skins/LateNight/sampler.xml
+++ b/res/skins/LateNight/sampler.xml
@@ -318,6 +318,7 @@
             <Children>
               <Template src="skin:button_1state_right.xml">
                 <SetVariable name="TooltipId">beatsync_beatsync_tempo</SetVariable>
+                <SetVariable name="Size">28f,26f</SetVariable>
                 <SetVariable name="state_0_pressed">sync_sampler_overdown.svg</SetVariable>
                 <SetVariable name="state_0_unpressed">sync_sampler.svg</SetVariable>
                 <SetVariable name="ConfigKey"><Variable name="group"/>,beatsync</SetVariable>

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -75,8 +75,8 @@
               <Template src="skin:button_1state_right.xml">
                 <SetVariable name="TooltipId">beats_translate_curpos</SetVariable>
                 <SetVariable name="ObjectName">BeatCurpos</SetVariable>
-                <SetVariable name="state_0_pressed">beat_curpos_large</SetVariable>
-                <SetVariable name="state_0_unpressed">beat_curpos_large_down</SetVariable>
+                <SetVariable name="state_0_pressed">beat_curpos_large_down</SetVariable>
+                <SetVariable name="state_0_unpressed">beat_curpos_large</SetVariable>
                 <SetVariable name="Size">26f,52f</SetVariable>
                 <SetVariable name="ConfigKey"><Variable name="group"/>,beats_translate_curpos</SetVariable>
                 <SetVariable name="ConfigKeyRight"><Variable name="group"/>,beats_translate_match_alignment</SetVariable>


### PR DESCRIPTION
something slippped through in the last LateNight PRs:
- un/pressed beat_curpos icon was swapped
- sampler Sync button was invisble due to missing <Size>