### PR TITLE
Reinit playposition after sampler resize/show up. Fixing lp1744170

### DIFF
--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -579,6 +579,7 @@ void WOverview::resizeEvent(QResizeEvent * /*unused*/) {
 
     m_waveformImageScaled = QImage();
     m_diffGain = 0;
+    Init();
 }
 
 void WOverview::dragEnterEvent(QDragEnterEvent* event) {


### PR DESCRIPTION
Recalculate the playposition as position on the waveform overview whenever the size or visible state changes.  