### PR TITLE
Allow building Mixxx against a different macOS SDK using the sysroot= parameter.

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -83,7 +83,7 @@ class SecurityFramework(Dependence):
     def configure(self, build, conf):
         if not build.platform_is_osx:
             return
-        build.env.Append(CPPPATH='/System/Library/Frameworks/Security.framework/Headers/')
+        build.env.Append(CPPPATH=build.env['OSX_SYSROOT'] + '/System/Library/Frameworks/Security.framework/Headers/')
         build.env.Append(LINKFLAGS='-framework Security')
 
 
@@ -91,7 +91,7 @@ class CoreServices(Dependence):
     def configure(self, build, conf):
         if not build.platform_is_osx:
             return
-        build.env.Append(CPPPATH='/System/Library/Frameworks/CoreServices.framework/Headers/')
+        build.env.Append(CPPPATH=build.env['OSX_SYSROOT'] + '/System/Library/Frameworks/CoreServices.framework/Headers/')
         build.env.Append(LINKFLAGS='-framework CoreServices')
 
 class IOKit(Dependence):
@@ -100,7 +100,7 @@ class IOKit(Dependence):
         if not build.platform_is_osx:
             return
         build.env.Append(
-            CPPPATH='/System/Library/Frameworks/IOKit.framework/Headers/')
+            CPPPATH=build.env['OSX_SYSROOT'] + '/System/Library/Frameworks/IOKit.framework/Headers/')
         build.env.Append(LINKFLAGS='-framework IOKit')
 
 class UPower(Dependence):

--- a/build/mixxx.py
+++ b/build/mixxx.py
@@ -323,11 +323,13 @@ class MixxxBuild(object):
         sysroot = Script.ARGUMENTS.get('sysroot', '')
         if sysroot:
             self.env.Append(CCFLAGS=['-isysroot', sysroot])
+            self.env.Append(LINKFLAGS=['-isysroot', sysroot, '-Wl,-syslibroot,' + sysroot])
+            self.env.Append(OSX_SYSROOT=sysroot)
 
         # If no sysroot was specified, pick one automatically. The only platform
         # we pick one automatically on is OS X.
         if self.platform_is_osx:
-            if '-isysroot' in self.env['CXXFLAGS'] or '-isysroot' in self.env['CFLAGS']:
+            if '-isysroot' in self.env['CXXFLAGS'] or '-isysroot' in self.env['CFLAGS'] or '-isysroot' in self.env['CCFLAGS']:
                 print("Skipping OS X automatic sysroot selection because -isysroot is in your CCFLAGS.")
                 return
 
@@ -372,6 +374,7 @@ class MixxxBuild(object):
                     ]
                     self.env.Append(CCFLAGS=common_flags)
                     self.env.Append(LINKFLAGS=common_flags + link_flags)
+                    self.env.Append(OSX_SYSROOT=sdk_path)
                     return
 
                 print("Could not find a supported Mac OS X SDK.")

--- a/build/qt4.py
+++ b/build/qt4.py
@@ -950,7 +950,7 @@ def enable_modules(self, modules, debug=False, crosscompiling=False, staticdeps=
 # port qt4-mac:
                 self.Append(LIBS=module)
         if 'QtOpenGL' in modules:
-            self.AppendUnique(LINKFLAGS="-F/System/Library/Frameworks")
+            self.AppendUnique(LINKFLAGS=("-F" + build.env['OSX_SYSROOT'] + "/System/Library/Frameworks"))
             self.Append(LINKFLAGS=['-framework', 'AGL']) #TODO ughly kludge to avoid quotes
             self.Append(LINKFLAGS=['-framework', 'OpenGL'])
         self["QT4_MOCCPPPATH"] = self["CPPPATH"]

--- a/build/qt5.py
+++ b/build/qt5.py
@@ -1007,7 +1007,7 @@ def enable_modules(self, modules, debug=False, crosscompiling=False, staticdeps=
 # port qt5-mac:
                 self.Append(LIBS=module)
         if 'QtOpenGL' in modules:
-            self.AppendUnique(LINKFLAGS="-F/System/Library/Frameworks")
+            self.AppendUnique(LINKFLAGS=("-F" + build.env['OSX_SYSROOT'] + "/System/Library/Frameworks"))
             self.Append(LINKFLAGS=['-framework', 'AGL']) #TODO ughly kludge to avoid quotes
             self.Append(LINKFLAGS=['-framework', 'OpenGL'])
         self["QT5_MOCCPPPATH"] = self["CPPPATH"]

--- a/src/SConscript
+++ b/src/SConscript
@@ -505,7 +505,7 @@ if build.platform_is_osx and 'bundle' in COMMAND_LINE_TARGETS:
                              "/usr/local/lib",
                              "/opt/local/lib",
                              "/sw/local/lib"]
-        otool_system_paths = ["/System/Library/Frameworks",
+        otool_system_paths = [build.env['OSX_SYSROOT'] + "/System/Library/Frameworks",
                               "/Network/Library/Frameworks",
                               "/usr/lib"]
         mixxx_osxlib_path = SCons.ARGUMENTS.get('osxlib', None)


### PR DESCRIPTION
Currently, `sysroot=` is accepted and added into the `CCFLAGS`, but subsequently the code fails to detect an existing sysroot in `CCFLAGS` (checking only in `CFLAGS` and `CXXFLAGS`) and adds its own detected SDK to the list, too. This patch corrects this.

Then, other parts of the code add direct links into `/System`, regardless of which SDK was selected. This patch changes that to include from the `./System` of the selected SDK. Using this, Mixxx builds against the 10.13 SDK on my 10.14 machine, fixing graphical issues I'm having.

Disclaimer: This has not been tested well yet, only against the 10.13 SDK on my 10.14 machine, not even against its default SDK without supplying the `sysroot=` option.