### PR TITLE
don't try and set bpm on invalid m_pBeats pointers

### DIFF
--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -219,10 +219,14 @@ void BpmControl::slotTapFilter(double averageLength, int numSamples) {
     if (numSamples < 4)
         return;
 
+    auto pBeats = m_pBeats;
+    if (!pBeats)
+        return;
+
     // (60 seconds per minute) * (1000 milliseconds per second) / (X millis per
     // beat) = Y beats/minute
     double averageBpm = 60.0 * 1000.0 / averageLength / calcRateRatio();
-    m_pBeats->setBpm(averageBpm);
+    pBeats->setBpm(averageBpm);
 }
 
 void BpmControl::slotControlBeatSyncPhase(double v) {


### PR DESCRIPTION
If no track is loaded and the user presses the bpm_tap button, mixxx will crash. I didn't test this, or write a unit test for it. Scons has suddenly started complaining my compiler does not support c++11, but it looks like this is the cause of the crash.

https://bugs.launchpad.net/mixxx/+bug/1801844