### PR TITLE
allow track_loaded ControlObject to emit signals even when the value wasn't changed

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -189,7 +189,7 @@ EngineBuffer::EngineBuffer(QString group, UserSettingsPointer pConfig,
             this, SLOT(slotEjectTrack(double)),
             Qt::DirectConnection);
 
-    m_pTrackLoaded = new ControlObject(ConfigKey(m_group, "track_loaded"));
+    m_pTrackLoaded = new ControlObject(ConfigKey(m_group, "track_loaded"), false);
     m_pTrackLoaded->setReadOnly();
 
     // Quantization Controller for enabling and disabling the


### PR DESCRIPTION
Whenever a new Track gets loaded into a Deck, the Deck will update the ControlObject via `forceSet(1)`. ControlObjects are usually created with `bIgnoreNops=true` which causes them to omit sending `valueChanged` signals when the value didn't change. As the CO will only be set to 0 when explicitly ejecting the Track from the Deck.
I'd appreciate if this could get still merged in time in conjunction with #1815. (I wanted to split this change into a seperate PR because it's not specific to the mentioned mapping).