### PR TITLE
Quote Search fixes: lp1784141

### DIFF
--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -173,7 +173,7 @@ QString TextFilterNode::toSql() const {
     if (argument.size() > 0) {
         if (argument[argument.size() - 1].isSpace()) {
             // LIKE eats a tailing space. This can be avoided by adding a '_'
-            // that matches any following character.
+            // as a delimiter that matches any following character.
             argument.append('_');
         }
     }

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -158,10 +158,12 @@ bool TextFilterNode::match(const TrackPointer& pTrack) const {
 QString TextFilterNode::toSql() const {
     FieldEscaper escaper(m_database);
     QString argument = m_argument;
-    if (argument.right(1) == " ") {
-        // LIKE eats a tailing space. This can be avoided by adding "_" for any
-        // followng character
-        argument += "_";
+    if (argument.size() > 0) {
+        if (argument[argument.size() - 1].isSpace()) {
+            // LIKE eats a tailing space. This can be avoided by adding a '_'
+            // that matches any following character.
+            argument.append('_');
+        }
     }
     QString escapedArgument = escaper.escapeString(
             kSqlLikeMatchAll + argument + kSqlLikeMatchAll);

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -157,8 +157,14 @@ bool TextFilterNode::match(const TrackPointer& pTrack) const {
 
 QString TextFilterNode::toSql() const {
     FieldEscaper escaper(m_database);
-    QString escapedArgument = escaper.escapeString(kSqlLikeMatchAll + m_argument + kSqlLikeMatchAll);
-
+    QString argument = m_argument;
+    if (argument.right(1) == " ") {
+        // LIKE eats a tailing space. This can be avoided by adding "_" for any
+        // followng character
+        argument += "_";
+    }
+    QString escapedArgument = escaper.escapeString(
+            kSqlLikeMatchAll + argument + kSqlLikeMatchAll);
     QStringList searchClauses;
     for (const auto& sqlColumn: m_sqlColumns) {
         searchClauses << QString("%1 LIKE %2").arg(sqlColumn, escapedArgument);

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -172,7 +172,7 @@ QString TextFilterNode::toSql() const {
     QString argument = m_argument;
     if (argument.size() > 0) {
         if (argument[argument.size() - 1].isSpace()) {
-            // LIKE eats a tailing space. This can be avoided by adding a '_'
+            // LIKE eats a trailing space. This can be avoided by adding a '_'
             // as a delimiter that matches any following character.
             argument.append('_');
         }

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -76,11 +76,7 @@ class TextFilterNode : public QueryNode {
   public:
     TextFilterNode(const QSqlDatabase& database,
                    const QStringList& sqlColumns,
-                   const QString& argument)
-            : m_database(database),
-              m_sqlColumns(sqlColumns),
-              m_argument(argument) {
-    }
+                   const QString& argument);
 
     bool match(const TrackPointer& pTrack) const override;
     QString toSql() const override;

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -178,8 +178,9 @@ void SearchQueryParser::parseTokens(QStringList tokens,
             }
             // Don't trigger on a lone minus sign.
             if (!token.isEmpty()) {
+                QString argument = getTextArgument(token, &tokens);
                 pNode = std::make_unique<TextFilterNode>(
-                                m_pTrackCollection->database(), searchColumns, token);
+                                m_pTrackCollection->database(), searchColumns, argument);
             }
         }
         if (pNode) {

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -123,15 +123,16 @@ void SearchQueryParser::parseTokens(QStringList tokens,
         } else if (m_textFilterMatcher.indexIn(token) != -1) {
             QString field = m_textFilterMatcher.cap(1);
             QString argument = getTextArgument(
-                m_textFilterMatcher.cap(2), &tokens).trimmed();
+                    m_textFilterMatcher.cap(2), &tokens);
 
             if (!argument.isEmpty()) {
                 if (field == "crate") {
                     pNode = std::make_unique<CrateFilterNode>(
-                          &m_pTrackCollection->crates(), argument);
+                            &m_pTrackCollection->crates(), argument);
                 } else {
                     pNode = std::make_unique<TextFilterNode>(
-                          m_pTrackCollection->database(), m_fieldToSqlColumns[field], argument);
+                            m_pTrackCollection->database(),
+                            m_fieldToSqlColumns[field], argument);
                 }
             }
         } else if (m_numericFilterMatcher.indexIn(token) != -1) {
@@ -141,7 +142,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
 
             if (!argument.isEmpty()) {
                 pNode = std::make_unique<NumericFilterNode>(
-                     m_fieldToSqlColumns[field], argument);
+                        m_fieldToSqlColumns[field], argument);
             }
         } else if (m_specialFilterMatcher.indexIn(token) != -1) {
             bool fuzzy = token.startsWith(kFuzzyPrefix);

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -320,6 +320,17 @@ TEST_F(SearchQueryParserTest, TextFilterTailingSpace) {
     EXPECT_STREQ(
         qPrintable(QString("comment LIKE '%asdf _%'")),
         qPrintable(pQuery->toSql()));
+
+    // We allow to search for two consequitve spaces
+    auto pQuery2(
+        m_parser.parseQuery("comment:\"  \"", searchColumns, ""));
+
+    EXPECT_FALSE(pQuery2->match(pTrack));
+
+    EXPECT_STREQ(
+        qPrintable(QString("comment LIKE '%  _%'")),
+        qPrintable(pQuery2->toSql()));
+
 }
 
 TEST_F(SearchQueryParserTest, TextFilterNegation) {

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -260,6 +260,44 @@ TEST_F(SearchQueryParserTest, TextFilterAllowsSpace) {
         qPrintable(pQuery->toSql()));
 }
 
+TEST_F(SearchQueryParserTest, TextFilterQuotes) {
+    QStringList searchColumns;
+    searchColumns << "artist"
+                  << "album";
+
+    auto pQuery(
+        m_parser.parseQuery("comment:\"asdf ewe\"", searchColumns, ""));
+
+    TrackPointer pTrack(Track::newTemporary());
+    pTrack->setArtist("asdf");
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setComment("test ASDF ewetest");
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+        qPrintable(QString("comment LIKE '%asdf ewe%'")),
+        qPrintable(pQuery->toSql()));
+}
+
+TEST_F(SearchQueryParserTest, TextFilterTailingSpace) {
+    QStringList searchColumns;
+    searchColumns << "artist"
+                  << "album";
+
+    auto pQuery(
+        m_parser.parseQuery("comment:\"asdf \"", searchColumns, ""));
+
+    TrackPointer pTrack(Track::newTemporary());
+    pTrack->setArtist("asdf");
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setComment("test ASDF test");
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+        qPrintable(QString("comment LIKE '%asdf _%'")),
+        qPrintable(pQuery->toSql()));
+}
+
 TEST_F(SearchQueryParserTest, TextFilterNegation) {
     QStringList searchColumns;
     searchColumns << "artist"

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -330,7 +330,6 @@ TEST_F(SearchQueryParserTest, TextFilterTrailingSpace) {
     EXPECT_STREQ(
         qPrintable(QString("comment LIKE '%  _%'")),
         qPrintable(pQuery2->toSql()));
-
 }
 
 TEST_F(SearchQueryParserTest, TextFilterNegation) {

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -303,7 +303,7 @@ TEST_F(SearchQueryParserTest, TextFilterDecoration) {
         qPrintable(pQuery->toSql()));
 }
 
-TEST_F(SearchQueryParserTest, TextFilterTailingSpace) {
+TEST_F(SearchQueryParserTest, TextFilterTrailingSpace) {
     QStringList searchColumns;
     searchColumns << "artist"
                   << "album";

--- a/src/util/db/dbconnection.cpp
+++ b/src/util/db/dbconnection.cpp
@@ -73,7 +73,14 @@ inline int compareLocaleAwareCaseInsensitive(
 void makeLatinLow(QChar* c, int count) {
     for (int i = 0; i < count; ++i) {
         if (c[i].decompositionTag() != QChar::NoDecomposition) {
-            c[i] = c[i].decomposition()[0];
+            QString decomposition = c[i].decomposition();
+            if (!decomposition[0].isSpace())  {
+                // here we remove the decoration brom all characters.
+                // We want "o" matching "ó" and all other variants but we
+                // do not decompose decoration only characters like "˚" where
+                // the base character is a space
+                c[i] = c[i].decomposition()[0];
+            }
         }
         if (c[i].isUpper()) {
             c[i] = c[i].toLower();
@@ -88,11 +95,11 @@ const QChar kSqlLikeEscapeDefault = '\0';
 // false (0) if they are different.
 // This is the original sqlite3 icuLikeCompare rewritten for QChar
 int likeCompareInner(
-    const QChar* pattern, // LIKE pattern
-    int patternSize,
-    const QChar* string, // The string to compare against
-    int stringSize,
-    const QChar esc) { // The escape character
+        const QChar* pattern, // LIKE pattern
+        int patternSize,
+        const QChar* string, // The string to compare against
+        int stringSize,
+        const QChar esc) { // The escape character
 
     int iPattern = 0; // Current index in pattern
     int iString = 0; // Current index in string
@@ -374,6 +381,11 @@ int DbConnection::likeCompareLatinLow(
             pattern->data(), pattern->length(),
             string->data(), string->length(),
             esc);
+}
+
+//static
+void DbConnection::makeStringLatinLow(QString* string) {
+    makeLatinLow(string->data(), string->length());
 }
 
 QDebug operator<<(QDebug debug, const DbConnection& connection) {

--- a/src/util/db/dbconnection.cpp
+++ b/src/util/db/dbconnection.cpp
@@ -100,7 +100,6 @@ int likeCompareInner(
         const QChar* string, // The string to compare against
         int stringSize,
         const QChar esc) { // The escape character
-
     int iPattern = 0; // Current index in pattern
     int iString = 0; // Current index in string
 

--- a/src/util/db/dbconnection.h
+++ b/src/util/db/dbconnection.h
@@ -22,6 +22,8 @@ class DbConnection final {
         QString* string,
         QChar esc);
 
+    static void makeStringLatinLow(QString* string);
+
     struct Params {
         QString type;
         QString hostName;


### PR DESCRIPTION
Now we can search a quotes string like:

title:"My Love"
It finds "My Love", "My Love (Air Mix)" and "My Lover is Gone";

title:"My Love " <- tailing space
It finds only "My Love (Air Mix)"

This works also for all columns without "title:"
