### PR TITLE
Fix quantize seeks if only  one deck is playing

### DIFF
--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -614,16 +614,18 @@ double BpmControl::getNearestPositionInPhase(double dThisPosition, bool respectL
     } else {
         // If not, we have to figure it out
         EngineBuffer* pOtherEngineBuffer = pickSyncTarget();
-        if (pOtherEngineBuffer == NULL) {
-            return dThisPosition;
+        if (playing) {
+            if (!pOtherEngineBuffer || pOtherEngineBuffer->getSpeed() == 0.0) {
+                // "this" track is playing, or just starting
+                // only match phase if the sync target is playing as well
+                // else use the previouse phase of "this" track before the seek
+                pOtherEngineBuffer = getEngineBuffer();
+            }
         }
 
-        if (playing) {
-            // "this" track is playing, or just starting
-            // only match phase if the sync target is playing as well
-            if (pOtherEngineBuffer->getSpeed() == 0.0) {
-                return dThisPosition;
-            }
+        if (!pOtherEngineBuffer) {
+            // no suitable sync buffer found
+            return dThisPosition;
         }
 
         TrackPointer otherTrack = pOtherEngineBuffer->getLoadedTrack();

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1499,6 +1499,23 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
 
 }
 
+TEST_F(EngineSyncTest, SeekStayInPhase) {
+    ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);
+
+    auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
+    ControlObject::set(ConfigKey(m_sGroup1, "beat_distance"), 0.2);
+    pFileBpm1->set(130.0);
+    BeatsPointer pBeats1 = BeatFactory::makeBeatGrid(*m_pTrack1, 130, 0.0);
+    m_pTrack1->setBeats(pBeats1);
+
+    ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
+    ProcessBuffer();
+
+    ControlObject::set(ConfigKey(m_sGroup1, "playposition"), 0.2);
+    ProcessBuffer();
+
+    ASSERT_DOUBLE_EQ(0.20464410501585786, ControlObject::get(ConfigKey(m_sGroup1, "playposition")));
+}
 
 TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
     // this tests bug lp1783020, notresetting rate when other deck has no beatgrid


### PR DESCRIPTION
This fixes seeking via the waveform overview with quantize enabled and only one deck playing.
Without this patch the track jumps out of phase. Now it stays in phase. 

A test is also in place.    