### PR TITLE
Fix a race condition in controlvalue

### DIFF
--- a/src/control/controlvalue.h
+++ b/src/control/controlvalue.h
@@ -1,18 +1,17 @@
-#ifndef CONTROLVALUE_H
-#define CONTROLVALUE_H
+#pragma once
 
 #include <limits>
 
 #include <QAtomicInt>
 #include <QObject>
 
-#include "util/compatibility.h"
 #include "util/assert.h"
+#include "util/compatibility.h"
 
 // for lock free access, this value has to be >= the number of value using threads
 // value must be a fraction of an integer
-const int cRingSize = 8;
-// there are basicly unlimited readers allowed at each ring element
+const int cDefaultRingSize = 8;
+// there are basically unlimited readers allowed at each ring element
 // but we have to count them so max() is just fine.
 // NOTE(rryan): Wrapping max with parentheses avoids conflict with the max macro
 // defined in windows.h.
@@ -25,22 +24,27 @@ const int cReaderSlotCnt = (std::numeric_limits<int>::max)();
 // readers or a write is occurring. A write to the value will fail if
 // m_readerSlots is not equal to cReaderSlotCnt (e.g. there is an active
 // reader).
-template<typename T>
+template <typename T>
 class ControlRingValue {
   public:
-    ControlRingValue()
-        : m_value(T()),
-          m_readerSlots(cReaderSlotCnt) {
+    ControlRingValue() : m_readerSlots(cReaderSlotCnt) {
     }
 
+    // Tries to copy the stored value if a reader slot is available.
+    // This is operation can be repeated multiple times for the same
+    // slot, because the stored value is preserved.
     bool tryGet(T* value) const {
         // Read while consuming one readerSlot
-        bool hasSlot = (m_readerSlots.fetchAndAddAcquire(-1) > 0);
-        if (hasSlot) {
+        if (m_readerSlots.fetchAndAddAcquire(-1) > 0) {
             *value = m_value;
+            m_readerSlots.fetchAndAddRelease(1);
+            return true;
+        } else {
+            // Otherwise a writer is active. The writer will reset
+            // the counter in m_readerSlots when releasing the lock
+            // and we must not re-add the substracted value here!
+            return false;
         }
-        (void)m_readerSlots.fetchAndAddRelease(1);
-        return hasSlot;
     }
 
     bool trySet(const T& value) {
@@ -49,8 +53,9 @@ class ControlRingValue {
             m_value = value;
             m_readerSlots.fetchAndAddRelease(cReaderSlotCnt);
             return true;
+        } else {
+            return false;
         }
-        return false;
    }
 
   private:
@@ -64,22 +69,22 @@ class ControlRingValue {
 // ring-buffer of ControlRingValues and a read pointer and write pointer to
 // provide getValue()/setValue() methods which *sacrifice perfect consistency*
 // for the benefit of wait-free read/write access to a value.
-template<typename T, bool ATOMIC = false>
+template <typename T, int cRingSize, bool ATOMIC = false>
 class ControlValueAtomicBase {
   public:
     inline T getValue() const {
-        T value = T();
-        unsigned int index = static_cast<unsigned int>(load_atomic(m_readIndex)) % (cRingSize);
-        while (m_ring[index].tryGet(&value) == false) {
+        T value;
+        unsigned int index = static_cast<unsigned int>(load_atomic(m_readIndex)) % cRingSize;
+        while (!m_ring[index].tryGet(&value)) {
             // We are here if
             // 1) there are more then cReaderSlotCnt reader (get) reading the same value or
             // 2) the formerly current value is locked by a writer
             // Case 1 does not happen because we have enough (0x7fffffff) reader slots.
             // Case 2 happens when the a reader is delayed after reading the
-            // m_currentIndex and in the mean while a reader locks the formaly current value
+            // m_currentIndex and in the mean while a reader locks the formally current value
             // because it has written cRingSize times. Reading the less recent value will fix
-            // it because it is now actualy the current value.
-            index = (index - 1) % (cRingSize);
+            // it because it is now actually the current value.
+            index = (index - 1) % cRingSize;
         }
         return value;
     }
@@ -89,20 +94,17 @@ class ControlValueAtomicBase {
         // This test is const and will be mad only at compile time
         unsigned int index;
         do {
-            index = (unsigned int)m_writeIndex.fetchAndAddAcquire(1)
-                    % (cRingSize);
+            index = static_cast<unsigned int>(m_writeIndex.fetchAndAddAcquire(1)) % cRingSize;
             // This will be repeated if the value is locked
             // 1) by another writer writing at the same time or
             // 2) a delayed reader is still blocking the formerly current value
             // In both cases writing to the next value will fix it.
         } while (!m_ring[index].trySet(value));
-        m_readIndex = (int)index;
+        m_readIndex = index;
     }
 
   protected:
-    ControlValueAtomicBase()
-        : m_readIndex(0),
-          m_writeIndex(1) {
+    ControlValueAtomicBase() : m_readIndex(0), m_writeIndex(1) {
         // NOTE(rryan): Wrapping max with parentheses avoids conflict with the
         // max macro defined in windows.h.
         DEBUG_ASSERT(((std::numeric_limits<unsigned int>::max)() % cRingSize) == (cRingSize - 1));
@@ -119,7 +121,7 @@ class ControlValueAtomicBase {
 // Specialized template for types that are deemed to be atomic on the target
 // architecture. Instead of using a read/write ring to guarantee atomicity,
 // direct assignment/read of an aligned member variable is used.
-template<typename T>
+template <typename T>
 class ControlValueAtomicBase<T, true> {
   public:
     inline T getValue() const {
@@ -131,13 +133,11 @@ class ControlValueAtomicBase<T, true> {
     }
 
   protected:
-    ControlValueAtomicBase()
-            : m_value(T()) {
-    }
+    ControlValueAtomicBase() = default;
 
   private:
 #if defined(__GNUC__)
-    T m_value __attribute__ ((aligned(sizeof(void*))));
+    T m_value __attribute__((aligned(sizeof(void*))));
 #elif defined(_MSC_VER)
 #ifdef _WIN64
     T __declspec(align(8)) m_value;
@@ -154,14 +154,8 @@ class ControlValueAtomicBase<T, true> {
 // ControlValueAtomicBase to use. For types where sizeof(T) <= sizeof(void*),
 // the specialized implementation of ControlValueAtomicBase for types that are
 // atomic on the architecture is used.
-template<typename T>
-class ControlValueAtomic
-    : public ControlValueAtomicBase<T, sizeof(T) <= sizeof(void*)> {
+template <typename T, int cRingSize = cDefaultRingSize>
+class ControlValueAtomic : public ControlValueAtomicBase<T, cRingSize, sizeof(T) <= sizeof(void*)> {
   public:
-
-    ControlValueAtomic()
-        : ControlValueAtomicBase<T, sizeof(T) <= sizeof(void*)>() {
-    }
+    ControlValueAtomic() = default;
 };
-
-#endif /* CONTROLVALUE_H */


### PR DESCRIPTION
This is a cherry pick from c236956884e3c7b9a47536f98eb7eb5a126a26e4 by @uklotzde

If I got it right, the bug leads to unusable values in the ring buffer until all elements are unusable. 
So it will finally break Mixxx which shall be fixed soon.