### PR TITLE
lp1782912: Fix and improve MP3 bitrate calculation

### DIFF
--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -361,9 +361,8 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(
     initFrameIndexRangeOnce(IndexRange::forward(0, m_curFrameIndex));
 
     // Calculate average values
-    if (m_seekFrameList.size() > 0) {
-        m_avgSeekFrameCount = frameLength() / m_seekFrameList.size();
-    }
+    DEBUG_ASSERT(m_seekFrameList.size() > 0); // see above
+    m_avgSeekFrameCount = frameLength() / m_seekFrameList.size();
     if (cntBitrate > 0) {
         const unsigned long avgBitrate = sumBitrate / cntBitrate;
         initBitrateOnce(avgBitrate / 1000);


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1782912

- ignore frames with invalid or missing bitrate for the calculation
- use a weighted average per sample frame instead of per MP3 frame