### PR TITLE
Latenight: add bpm to preview and sampler if track is loaded [2.1.6]

### DIFF
--- a/res/skins/LateNight/preview_deck.xml
+++ b/res/skins/LateNight/preview_deck.xml
@@ -47,6 +47,19 @@
                         <Group>[PreviewDeck1]</Group>
                         <Elide>right</Elide>
                       </Text>
+                      <Number>
+                        <TooltipId>visual_bpm</TooltipId>
+                        <Group>[PreviewDeck1]</Group>
+                        <!--CSS alignments not respected see bug lp:605530 , lets call <Alignment>-->
+                        <Alignment>left</Alignment>
+                        <Connection>
+                          <ConfigKey>[PreviewDeck1],visual_bpm</ConfigKey>
+                        </Connection>
+			<Connection>
+			  <ConfigKey>[PreviewDeck1],track_loaded</ConfigKey>
+			  <BindProperty>visible</BindProperty>
+			</Connection>
+                      </Number>
                     </Children>
                   </WidgetGroup>
                   <WidgetGroup>

--- a/res/skins/LateNight/sampler.xml
+++ b/res/skins/LateNight/sampler.xml
@@ -25,19 +25,19 @@
                 <Group><Variable name="group"/></Group>
                 <Elide>right</Elide>
               </TrackProperty>
-	            <Number>
-		            <TooltipId>visual_bpm</TooltipId>
-	              <Group>[Sampler<Variable name="samplernum"/>]</Group>
-	              <!--CSS alignments not respected see bug lp:605530 , lets call <Alignment>-->
-	              <Alignment>left</Alignment>
-	              <Connection>
-		              <ConfigKey>[Sampler<Variable name="samplernum"/>],visual_bpm</ConfigKey>
-		            </Connection>
-		            <Connection>
-		              <ConfigKey>[Sampler<Variable name="samplernum"/>],track_loaded</ConfigKey>
-		              <BindProperty>visible</BindProperty>
-		            </Connection>
-	            </Number>
+              <Number>
+                <TooltipId>visual_bpm</TooltipId>
+                <Group>[Sampler<Variable name="samplernum"/>]</Group>
+                <!--CSS alignments not respected see bug lp:605530 , lets call <Alignment>-->
+                <Alignment>left</Alignment>
+                <Connection>
+                  <ConfigKey>[Sampler<Variable name="samplernum"/>],visual_bpm</ConfigKey>
+                </Connection>
+                <Connection>
+                <ConfigKey>[Sampler<Variable name="samplernum"/>],track_loaded</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </Number>
             </Children>
           </WidgetGroup>
 

--- a/res/skins/LateNight/sampler.xml
+++ b/res/skins/LateNight/sampler.xml
@@ -25,6 +25,19 @@
                 <Group><Variable name="group"/></Group>
                 <Elide>right</Elide>
               </TrackProperty>
+	            <Number>
+		            <TooltipId>visual_bpm</TooltipId>
+	              <Group>[Sampler<Variable name="samplernum"/>]</Group>
+	              <!--CSS alignments not respected see bug lp:605530 , lets call <Alignment>-->
+	              <Alignment>left</Alignment>
+	              <Connection>
+		              <ConfigKey>[Sampler<Variable name="samplernum"/>],visual_bpm</ConfigKey>
+		            </Connection>
+		            <Connection>
+		              <ConfigKey>[Sampler<Variable name="samplernum"/>],track_loaded</ConfigKey>
+		              <BindProperty>visible</BindProperty>
+		            </Connection>
+	            </Number>
             </Children>
           </WidgetGroup>
 


### PR DESCRIPTION
add bpm to Latenight preview deck and samplers, bpm is only visible if a track is loaded, basically the same as  #1891 but for 2.1.
I hope this get's into 2.1.6 ?