### PR TITLE
only use WidgetRenderTimer on macOS

### DIFF
--- a/src/util/widgetrendertimer.h
+++ b/src/util/widgetrendertimer.h
@@ -22,6 +22,10 @@
 // timer invokes guiTick(), which is responsible for actually calling
 // QWidget::update(). When input arrives, we call inputActivity to attach the
 // timer. After 1 second of inactivity, we disconnect the timer.
+//
+// Ironically, using this class somehow causes severe lagginess on mouse input
+// with Windows, so use #ifdefs to only call activity() on macOS; just call
+// QWidget::update() for other operating systems.
 class WidgetRenderTimer : public QObject {
     Q_OBJECT
   public:

--- a/src/widget/slidereventhandler.h
+++ b/src/widget/slidereventhandler.h
@@ -145,7 +145,7 @@ class SliderEventHandler {
             // parents.
             if (newPos != m_dPos) {
                 m_dPos = newPos;
-                pWidget->inputActivity();
+                pWidget->update();
             }
         }
     }

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -47,5 +47,9 @@ void WKnob::wheelEvent(QWheelEvent* e) {
 }
 
 void WKnob::inputActivity() {
+#ifdef __APPLE__
     m_renderTimer.activity();
+#else
+    update();
+#endif
 }

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -137,5 +137,9 @@ void WKnobComposed::wheelEvent(QWheelEvent* e) {
 }
 
 void WKnobComposed::inputActivity() {
+#ifdef __APPLE__
     m_renderTimer.activity();
+#else
+    update();
+#endif
 }

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -84,7 +84,7 @@ void WKnobComposed::onConnectedControlChanged(double dParameter, double dValue) 
     // angle range? Right now it's just 1/100th of a degree.
     if (fabs(angle - m_dCurrentAngle) > 0.01) {
         // paintEvent updates m_dCurrentAngle
-        inputActivity();
+        update();
     }
 }
 

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -233,5 +233,9 @@ double WSliderComposed::calculateHandleLength() {
 }
 
 void WSliderComposed::inputActivity() {
+#ifdef __APPLE__
     m_renderTimer.activity();
+#else
+    update();
+#endif
 }


### PR DESCRIPTION
The change to use the WidgetRenderTimer was not needed to resolve
the laggy mouse input on macOS (#1809). It might be causing a regression
on Windows after keeping Mixxx running for a long time:
https://mixxx.org/forums/viewtopic.php?p=40256#p40256