### PR TITLE
Deere :: fix font size of library header

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -270,7 +270,7 @@ QHeaderView {
 }
 
 QHeaderView::section {
-  font-size: 10pt;
+  font-size: 12px/14px;
   font-weight: normal;
   padding: 2px;
   background: #1A1A1A;
@@ -281,7 +281,7 @@ QHeaderView::section {
 }
 
 QHeaderView::section:selected {
-  font-size: 10pt;
+  font-size: 12px/14px;
   font-weight: bold;
   padding: 2px;
   background: #1A1A1A;


### PR DESCRIPTION
in https://bugs.launchpad.net/mixxx/+bug/1800577 inoticed the library's header seems to be the only text field that doesn't scale correctly.
before: 10pt
now: 12px/14px

@Be-ing can you confirm it works on you 4k screen?