### PR TITLE
[WIP] Reimplement #1652 - switchable time formats

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -654,7 +654,7 @@ QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
             if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DURATION)) {
                 int duration = value.toInt();
                 if (duration > 0) {
-                    value = mixxx::Duration::formatSeconds(duration);
+                    value = mixxx::Duration::formatTime(duration);
                 } else {
                     value = QString();
                 }

--- a/src/library/crate/cratesummary.h
+++ b/src/library/crate/cratesummary.h
@@ -34,7 +34,7 @@ public:
     }
     // Returns the duration formatted as a string H:MM:SS
     QString getTrackDurationText() const {
-        return mixxx::Duration::formatSeconds(getTrackDuration(), mixxx::Duration::Precision::SECONDS);
+        return mixxx::Duration::formatTime(getTrackDuration(), mixxx::Duration::Precision::SECONDS);
     }
 
 private:

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -20,7 +20,14 @@ namespace TrackTime {
     enum class DisplayMode {
         Elapsed,
         Remaining,
-        ElapsedAndRemaining,
+        ElapsedAndRemaining
+    };
+
+    enum class DisplayFormat {
+        TRADITIONAL,
+        SECOND,
+        KILO_SECOND,
+        HECTO_SECOND
     };
 }
 
@@ -67,6 +74,8 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     void slotRateRampingModeLinearButton(bool);
     void slotRateRampSensitivitySlider(int);
 
+    void slotTimeFormatChanged(double);
+
     void slotNumDecksChanged(double, bool initializing=false);
     void slotNumSamplersChanged(double, bool initializing=false);
 
@@ -85,6 +94,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
 
     UserSettingsPointer m_pConfig;
     ControlObject* m_pControlTrackTimeDisplay;
+    ControlObject* m_pControlTrackTimeFormat;
     ControlProxy* m_pNumDecks;
     ControlProxy* m_pNumSamplers;
     QList<ControlProxy*> m_cueControls;

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -20,6 +20,90 @@
       <string>Deck options</string>
      </property>
      <layout class="QGridLayout" name="GridLayout1">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+      <item row="3" column="0">
+       <widget class="QLabel" name="labelAutoCue">
+        <property name="text">
+         <string>Auto cue</string>
+        </property>
+        <property name="buddy">
+         <cstring>checkBoxSeekToCue</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelPositionDisplay">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="text">
+         <string>Track time display</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="buddy">
+         <cstring>radioButtonElapsed</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1" colspan="2">
+       <widget class="QCheckBox" name="checkBoxDisallowLoadToPlayingDeck">
+        <property name="text">
+         <string>Do not load tracks into playing decks</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1" colspan="2">
+       <widget class="QCheckBox" name="checkBoxSeekToCue">
+        <property name="toolTip">
+         <string>Automatically seeks to the first saved cue point on track load.
+            If none exists, seeks to the beginning of the track.</string>
+        </property>
+        <property name="text">
+         <string>Jump to main cue point on track load</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QRadioButton" name="radioButtonElapsed">
+          <property name="text">
+           <string>Elapsed</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupTrackTime</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioButtonRemaining">
+          <property name="text">
+           <string>Remaining</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupTrackTime</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioButtonElapsedAndRemaining">
+          <property name="text">
+           <string>Elapsed and Remaining</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupTrackTime</string>
+          </attribute>
+         </widget>
+        </item>
+       </layout>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="labelCueMode">
         <property name="text">
@@ -58,81 +142,7 @@ CUP mode:
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="labelPositionDisplay">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="font">
-         <font/>
-        </property>
-        <property name="text">
-         <string>Track time display</string>
-        </property>
-        <property name="wordWrap">
-         <bool>false</bool>
-        </property>
-        <property name="buddy">
-         <cstring>radioButtonElapsed</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QRadioButton" name="radioButtonElapsed">
-          <property name="text">
-           <string>Elapsed</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupTrackTime</string>
-          </attribute>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="radioButtonRemaining">
-          <property name="text">
-           <string>Remaining</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupTrackTime</string>
-          </attribute>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="radioButtonElapsedAndRemaining">
-          <property name="text">
-           <string>Elapsed and Remaining</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">buttonGroupTrackTime</string>
-          </attribute>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="labelAutoCue">
-        <property name="text">
-         <string>Auto cue</string>
-        </property>
-        <property name="buddy">
-         <cstring>checkBoxSeekToCue</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1" colspan="2">
-       <widget class="QCheckBox" name="checkBoxSeekToCue">
-        <property name="toolTip">
-         <string>Automatically seeks to the first saved cue point on track load.
-            If none exists, seeks to the beginning of the track.</string>
-        </property>
-        <property name="text">
-         <string>Jump to main cue point on track load</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="labelPlayingTrackProtection">
         <property name="text">
          <string>Playing track protection</string>
@@ -142,12 +152,15 @@ CUP mode:
         </property>
        </widget>
       </item>
-      <item row="3" column="1" colspan="2">
-       <widget class="QCheckBox" name="checkBoxDisallowLoadToPlayingDeck">
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelTimeDisplay">
         <property name="text">
-         <string>Do not load tracks into playing decks</string>
+         <string>Time Format</string>
         </property>
        </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="comboBoxTimeFormat"/>
       </item>
      </layout>
     </widget>
@@ -755,13 +768,13 @@ CUP mode:
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="buttonGroupKeyLockMode"/>
-  <buttongroup name="buttonGroupKeyUnlockMode"/>
   <buttongroup name="buttonGroupSpeedPitchReset">
    <property name="exclusive">
     <bool>false</bool>
    </property>
   </buttongroup>
+  <buttongroup name="buttonGroupKeyLockMode"/>
+  <buttongroup name="buttonGroupKeyUnlockMode"/>
   <buttongroup name="buttonGroupTrackTime"/>
   <buttongroup name="buttonGroupSpeedBendBehavior"/>
  </buttongroups>

--- a/src/test/durationutiltest.cpp
+++ b/src/test/durationutiltest.cpp
@@ -25,6 +25,23 @@ class DurationUtilTest : public testing::Test {
         }
     }
 
+    void formatTime(QString expectedMilliseconds, double dSeconds) {
+        ASSERT_LE(4, expectedMilliseconds.length()); // 3 digits + 1 decimal point
+        const QString actualSeconds =
+            mixxx::Duration::formatTime(dSeconds, mixxx::Duration::Precision::SECONDS);
+        const QString expectedSeconds =
+                adjustPrecision(expectedMilliseconds, mixxx::Duration::Precision::SECONDS);
+        EXPECT_EQ(expectedSeconds, actualSeconds);
+        const QString expectedCentiseconds =
+                adjustPrecision(expectedMilliseconds, mixxx::Duration::Precision::CENTISECONDS);
+        const QString actualCentiseconds =
+            mixxx::Duration::formatTime(dSeconds, mixxx::Duration::Precision::CENTISECONDS);
+        EXPECT_EQ(expectedCentiseconds, actualCentiseconds);
+        const QString actualMilliseconds =
+            mixxx::Duration::formatTime(dSeconds, mixxx::Duration::Precision::MILLISECONDS);
+        EXPECT_EQ(actualMilliseconds, actualMilliseconds);
+    }
+
     void formatSeconds(QString expectedMilliseconds, double dSeconds) {
         ASSERT_LE(4, expectedMilliseconds.length()); // 3 digits + 1 decimal point
         const QString actualSeconds =
@@ -41,24 +58,98 @@ class DurationUtilTest : public testing::Test {
             mixxx::Duration::formatSeconds(dSeconds, mixxx::Duration::Precision::MILLISECONDS);
         EXPECT_EQ(actualMilliseconds, actualMilliseconds);
     }
+
+    void formatKiloSeconds(QString expectedMilliseconds, double dSeconds) {
+        ASSERT_LE(4, expectedMilliseconds.length()); // 3 digits + 1 decimal point
+        const QString actualSeconds =
+            mixxx::Duration::formatKiloSeconds(dSeconds, mixxx::Duration::Precision::SECONDS);
+        const QString expectedSeconds =
+                adjustPrecision(expectedMilliseconds, mixxx::Duration::Precision::SECONDS);
+        EXPECT_EQ(expectedSeconds, actualSeconds);
+        const QString expectedCentiseconds =
+                adjustPrecision(expectedMilliseconds, mixxx::Duration::Precision::CENTISECONDS);
+        const QString actualCentiseconds =
+            mixxx::Duration::formatKiloSeconds(dSeconds, mixxx::Duration::Precision::CENTISECONDS);
+        EXPECT_EQ(expectedCentiseconds, actualCentiseconds);
+        const QString actualMilliseconds =
+            mixxx::Duration::formatKiloSeconds(dSeconds, mixxx::Duration::Precision::MILLISECONDS);
+        EXPECT_EQ(actualMilliseconds, actualMilliseconds);
+    }
+
+    void formatHectoSeconds(QString expectedMilliseconds, double dSeconds) {
+        ASSERT_LE(4, expectedMilliseconds.length()); // 3 digits + 1 decimal point
+        const QString actualSeconds =
+            mixxx::Duration::formatHectoSeconds(dSeconds, mixxx::Duration::Precision::SECONDS);
+        const QString expectedSeconds =
+                adjustPrecision(expectedMilliseconds, mixxx::Duration::Precision::SECONDS);
+        EXPECT_EQ(expectedSeconds, actualSeconds);
+        const QString expectedCentiseconds =
+                adjustPrecision(expectedMilliseconds, mixxx::Duration::Precision::CENTISECONDS);
+        const QString actualCentiseconds =
+            mixxx::Duration::formatHectoSeconds(dSeconds, mixxx::Duration::Precision::CENTISECONDS);
+        EXPECT_EQ(expectedCentiseconds, actualCentiseconds);
+        const QString actualMilliseconds =
+            mixxx::Duration::formatHectoSeconds(dSeconds, mixxx::Duration::Precision::MILLISECONDS);
+        EXPECT_EQ(actualMilliseconds, actualMilliseconds);
+    }
 };
 
 TEST_F(DurationUtilTest, FormatSecondsNegative) {
-    EXPECT_EQ("?", mixxx::Duration::formatSeconds(-1, mixxx::Duration::Precision::SECONDS));
-    EXPECT_EQ("?", mixxx::Duration::formatSeconds(-1, mixxx::Duration::Precision::CENTISECONDS));
-    EXPECT_EQ("?", mixxx::Duration::formatSeconds(-1, mixxx::Duration::Precision::MILLISECONDS));
+    EXPECT_EQ("?", mixxx::Duration::formatTime(-1, mixxx::Duration::Precision::SECONDS));
+    EXPECT_EQ("?", mixxx::Duration::formatTime(-1, mixxx::Duration::Precision::CENTISECONDS));
+    EXPECT_EQ("?", mixxx::Duration::formatTime(-1, mixxx::Duration::Precision::MILLISECONDS));
 }
 
-TEST_F(DurationUtilTest, FormatSeconds) {
-    formatSeconds("00:00.000", 0);
-    formatSeconds("00:01.000", 1);
-    formatSeconds("00:59.000", 59);
-    formatSeconds("01:00.000", 60);
-    formatSeconds("01:01.123", 61.1234);
-    formatSeconds("59:59.999", 3599.999);
-    formatSeconds("01:00:00.000", 3600);
-    formatSeconds("23:59:59.000", 24 * 3600 - 1);
-    formatSeconds("1d, 00:00:00.000", 24 * 3600);
+TEST_F(DurationUtilTest, formatTime) {
+    formatTime("00:00.000", 0);
+    formatTime("00:01.000", 1);
+    formatTime("00:59.000", 59);
+    formatTime("01:00.000", 60);
+    formatTime("01:01.123", 61.1234);
+    formatTime("59:59.999", 3599.999);
+    formatTime("01:00:00.000", 3600);
+    formatTime("23:59:59.000", 24 * 3600 - 1);
+    formatTime("24:00:00.000", 24 * 3600);
+    formatTime("24:00:01.000", 24 * 3600 + 1);
+    formatTime("25:00:01.000", 25 * 3600 + 1);
 }
+
+TEST_F(DurationUtilTest, formatSecond) {
+    formatSeconds("0.000", 0);
+    formatSeconds("1.000", 1);
+    formatSeconds("59.000", 59);
+    formatSeconds("60.000", 60);
+    formatSeconds("321.123", 321.1234);
+}
+
+
+TEST_F(DurationUtilTest, FormatKiloSeconds) {
+    formatKiloSeconds(QString::fromUtf8("0.000\u2009000"), 0);
+    formatKiloSeconds(QString::fromUtf8("0.001\u2009000"), 1);
+    formatKiloSeconds(QString::fromUtf8("0.001\u2009500"), 1.5);
+    formatKiloSeconds(QString::fromUtf8("0.001\u2009510"), 1.51);
+    formatKiloSeconds(QString::fromUtf8("0.001\u2009490"), 1.49);
+    formatKiloSeconds(QString::fromUtf8("0.059\u2009000"), 59);
+    formatKiloSeconds(QString::fromUtf8("0.060\u2009000"), 60);
+    formatKiloSeconds(QString::fromUtf8("0.061\u2009123"), 61.1234);
+    formatKiloSeconds(QString::fromUtf8("0.999\u2009990"), 999.99);
+    formatKiloSeconds(QString::fromUtf8("1.000\u2009000"), 1000.00);
+    formatKiloSeconds(QString::fromUtf8("86.400\u2009000"), 24 * 3600);
+}
+
+TEST_F(DurationUtilTest, FormatHectoSeconds) {
+    formatHectoSeconds(QString::fromUtf8("0\u231E00\u2009000"), 0);
+    formatHectoSeconds(QString::fromUtf8("0\u231E01\u2009000"), 1);
+    formatHectoSeconds(QString::fromUtf8("0\u231E01\u2009500"), 1.5);
+    formatHectoSeconds(QString::fromUtf8("0\u231E01\u2009510"), 1.51);
+    formatHectoSeconds(QString::fromUtf8("0\u231E01\u2009490"), 1.49);
+    formatHectoSeconds(QString::fromUtf8("0\u231E59\u2009000"), 59);
+    formatHectoSeconds(QString::fromUtf8("0\u231E60\u2009000"), 60);
+    formatHectoSeconds(QString::fromUtf8("0\u231E61\u2009123"), 61.1234);
+    formatHectoSeconds(QString::fromUtf8("9\u231E99\u2009990"), 999.99);
+    formatHectoSeconds(QString::fromUtf8("10\u231E00\u2009000"), 1000.00);
+    formatHectoSeconds(QString::fromUtf8("864\u231E00\u2009000"), 24 * 3600);
+}
+
 
 } // anonymous namespace

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -444,7 +444,7 @@ QString Track::getDurationText(mixxx::Duration::Precision precision) const {
     } else {
         duration = getDuration(DurationRounding::NONE);
     }
-    return mixxx::Duration::formatSeconds(duration, precision);
+    return mixxx::Duration::formatTime(duration, precision);
 }
 
 QString Track::getTitle() const {

--- a/src/util/duration.cpp
+++ b/src/util/duration.cpp
@@ -18,7 +18,9 @@ static const qint64 kSecondsPerDay = 24 * kSecondsPerHour;
 } // namespace
 
 // static
+// Unicode for thin space
 QChar DurationBase::kCentisecondSeparator = QChar(0x2009);
+// Unicode for bottom left corner
 QChar DurationBase::kHectosecondSeparator = QChar(0x231E);
 
 // static

--- a/src/util/duration.cpp
+++ b/src/util/duration.cpp
@@ -25,9 +25,9 @@ QChar DurationBase::kHectosecondSeparator = QChar(0x231E);
 
 // static
 QString DurationBase::formatTime(double dSeconds, Precision precision) {
-    if (dSeconds < 0.0) {
+    VERIFY_OR_DEBUG_ASSERT (dSeconds >= 0.0) {
         // negative durations are not supported
-        return "?";
+        // TODO:(XXX) Does this actually need to do anything?
     }
 
     const qint64 days = static_cast<qint64>(std::floor(dSeconds)) / kSecondsPerDay;
@@ -57,10 +57,11 @@ QString DurationBase::formatTime(double dSeconds, Precision precision) {
 }
 
 QString DurationBase::formatSeconds(double dSeconds, Precision precision) {
-    if (dSeconds < 0.0) {
+    VERIFY_OR_DEBUG_ASSERT (dSeconds >= 0.0) {
         // negative durations are not supported
-        return "?";
+        // TODO:(XXX) Does this actually need to do anything?
     }
+
     QString durationString;
 
     if (Precision::CENTISECONDS == precision) {
@@ -76,9 +77,9 @@ QString DurationBase::formatSeconds(double dSeconds, Precision precision) {
 
 // static
 QString DurationBase::formatKiloSeconds(double dSeconds, Precision precision) {
-    if (dSeconds < 0.0) {
+    VERIFY_OR_DEBUG_ASSERT (dSeconds >= 0.0) {
         // negative durations are not supported
-        return "?";
+        // TODO:(XXX) Does this actually need to do anything?
     }
 
     int kilos = (int)dSeconds / 1000;
@@ -103,9 +104,9 @@ QString DurationBase::formatKiloSeconds(double dSeconds, Precision precision) {
 
 // static
 QString DurationBase::formatHectoSeconds(double dSeconds, Precision precision) {
-    if (dSeconds < 0.0) {
+    VERIFY_OR_DEBUG_ASSERT (dSeconds >= 0.0) {
         // negative durations are not supported
-        return "?";
+        // TODO:(XXX) Does this actually need to do anything?
     }
 
     int hecto = (int)dSeconds / 100;

--- a/src/util/duration.cpp
+++ b/src/util/duration.cpp
@@ -18,7 +18,11 @@ static const qint64 kSecondsPerDay = 24 * kSecondsPerHour;
 } // namespace
 
 // static
-QString DurationBase::formatSeconds(double dSeconds, Precision precision) {
+QChar DurationBase::kCentisecondSeparator = QChar(0x2009);
+QChar DurationBase::kHectosecondSeparator = QChar(0x231E);
+
+// static
+QString DurationBase::formatTime(double dSeconds, Precision precision) {
     if (dSeconds < 0.0) {
         // negative durations are not supported
         return "?";
@@ -32,12 +36,86 @@ QString DurationBase::formatSeconds(double dSeconds, Precision precision) {
     QTime t = QTime(0, 0).addMSecs(dSeconds * kMillisPerSecond);
 
     QString formatString =
-            (days > 0 ? (QString::number(days) %
-                         QLatin1String("'d', ")) : QString()) %
-            QLatin1String(days > 0 || t.hour() > 0 ? "hh:mm:ss" : "mm:ss") %
+            QLatin1String(t.hour() > 0 && days < 1 ? "hh:mm:ss" : "mm:ss") %
             QLatin1String(Precision::SECONDS == precision ? "" : ".zzz");
 
     QString durationString = t.toString(formatString);
+    if (days > 0) {
+        durationString = QString("%1:").arg(days * 24 + t.hour()) % durationString;
+    }
+
+    // The format string gives us milliseconds but we want
+    // centiseconds. Slice one character off.
+    if (Precision::CENTISECONDS == precision) {
+        DEBUG_ASSERT(1 <= durationString.length());
+        durationString = durationString.left(durationString.length() - 1);
+    }
+
+    return durationString;
+}
+
+QString DurationBase::formatSeconds(double dSeconds, Precision precision) {
+    if (dSeconds < 0.0) {
+        // negative durations are not supported
+        return "?";
+    }
+    QString durationString;
+
+    if (Precision::CENTISECONDS == precision) {
+        durationString = QString("%1").arg(dSeconds,1,'f',2,'0');
+    } else if (Precision::MILLISECONDS == precision) {
+        durationString = QString("%1").arg(dSeconds,1,'f',3,'0');
+    } else {
+        durationString = QString("%1").arg(dSeconds,1,'f',0,'0');
+    }
+
+    return durationString;
+}
+
+// static
+QString DurationBase::formatKiloSeconds(double dSeconds, Precision precision) {
+    if (dSeconds < 0.0) {
+        // negative durations are not supported
+        return "?";
+    }
+
+    int kilos = (int)dSeconds / 1000;
+    double seconds = floor(fmod(dSeconds, 1000));
+    double subs = fmod(dSeconds, 1);
+
+    QString durationString =
+            QString("%1.%2").arg(kilos, 0, 10).arg(seconds, 3, 'f', 0, QLatin1Char('0'));
+    if (Precision::SECONDS != precision) {
+            durationString += kCentisecondSeparator % QString::number(subs, 'f', 3).right(3);
+    }
+
+    // The format string gives us milliseconds but we want
+    // centiseconds. Slice one character off.
+    if (Precision::CENTISECONDS == precision) {
+        DEBUG_ASSERT(1 <= durationString.length());
+        durationString = durationString.left(durationString.length() - 1);
+    }
+
+    return durationString;
+}
+
+// static
+QString DurationBase::formatHectoSeconds(double dSeconds, Precision precision) {
+    if (dSeconds < 0.0) {
+        // negative durations are not supported
+        return "?";
+    }
+
+    int hecto = (int)dSeconds / 100;
+    double seconds = floor(fmod(dSeconds, 100));
+    double subs = fmod(dSeconds, 1);
+
+    QString durationString =
+            QString("%1%2%3").arg(hecto, 0, 10).arg(kHectosecondSeparator).arg(seconds, 2, 'f', 0, QLatin1Char('0'));
+    if (Precision::SECONDS != precision) {
+            durationString += kCentisecondSeparator % QString::number(subs, 'f', 3).right(3);
+    }
+
 
     // The format string gives us milliseconds but we want
     // centiseconds. Slice one character off.

--- a/src/util/duration.h
+++ b/src/util/duration.h
@@ -70,7 +70,17 @@ class DurationBase {
 
     // The standard way of formatting a floating-point duration in seconds.
     // Used for display of track duration, etc.
+    static QString formatTime(
+            double dSeconds,
+            Precision precision = Precision::SECONDS);
+    // Alternative format for duration based on seconds
     static QString formatSeconds(
+            double dSeconds,
+            Precision precision = Precision::SECONDS);
+    static QString formatKiloSeconds(
+            double dSeconds,
+            Precision precision = Precision::SECONDS);
+    static QString formatHectoSeconds(
             double dSeconds,
             Precision precision = Precision::SECONDS);
 
@@ -79,6 +89,8 @@ class DurationBase {
     static constexpr qint64 kNanosPerSecond  = kMicrosPerSecond * 1000;
     static constexpr qint64 kNanosPerMilli   = kNanosPerSecond / 1000;
     static constexpr qint64 kNanosPerMicro   = kNanosPerMilli / 1000;
+    static QChar kCentisecondSeparator;
+    static QChar kHectosecondSeparator;
 
   protected:
     explicit DurationBase(qint64 durationNanos)

--- a/src/widget/wnumberpos.cpp
+++ b/src/widget/wnumberpos.cpp
@@ -27,7 +27,6 @@ WNumberPos::WNumberPos(const char* group, QWidget* parent)
     m_pTimeFormat->connectValueChanged(
             SLOT(slotSetTimeFormat(double)));
     slotSetTimeFormat(m_pTimeFormat->get());
-
 }
 
 void WNumberPos::mousePressEvent(QMouseEvent* pEvent) {

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -23,15 +23,18 @@ class WNumberPos : public WNumber {
     void slotSetTimeElapsed(double);
     void slotTimeRemainingUpdated(double);
     void slotSetDisplayMode(double);
+    void slotSetTimeFormat(double);
 
   private:
 
     TrackTime::DisplayMode m_displayMode;
+    TrackTime::DisplayFormat m_displayFormat;
 
     double m_dOldTimeElapsed;
     ControlProxy* m_pTimeElapsed;
     ControlProxy* m_pTimeRemaining;
     ControlProxy* m_pShowTrackTimeRemaining;
+    ControlProxy* m_pTimeFormat;
 };
 
 #endif

--- a/src/widget/wnumberpos.h
+++ b/src/widget/wnumberpos.h
@@ -12,6 +12,7 @@ class ControlProxy;
 
 class WNumberPos : public WNumber {
     Q_OBJECT
+
   public:
     explicit WNumberPos(const char *group, QWidget *parent=nullptr);
 


### PR DESCRIPTION
I've reapplied the changes from #1652 as I could not get that PR to build. I suspect it was changes to other bits of code in the changed files that created an issue, as this PR builds for me.

Things still outstanding:
* The review for the previous PR requested several `if` statements in src/util/duration.cpp be replaced with `VERIFY_OR_DEBUG_ASSERT`. When I attempted to apply these changes I got `Critical [Main]: DEBUG ASSERT: "dSeconds < 0.0" in function static QString mixxx::DurationBase::formatTime(double, mixxx::DurationBase::Precision) at src/util/duration.cpp:xx` errors at runtime. I don't know what to do about this.
* Choice of separator characters in src/util/duration.cpp. For centiseconds this is currently set to a thin space, for hectoseconds this is currently set to ⌞ (the unicode character for bottom left corner.) These aren't my choices and I wonder if we can't find some more logical ones.
* This request from ronso0:
> In my personal branch I've changed `mixxx::Duration::Precision::CENTISECONDS` to `...::SECONDS` in /src/widget/wnumberpos.cpp to get rid of the rather distracting centiseconds.
> 
> Can we add another format `hh:mm:ss` and maybe call it "Traditional, coarse"?

