### PR TITLE
LateNight :: small fixes for FX containers

### DIFF
--- a/res/skins/LateNight/fx_slot.xml
+++ b/res/skins/LateNight/fx_slot.xml
@@ -85,12 +85,12 @@
 
           <WidgetGroup>
             <Layout>horizontal</Layout>
-            <MinimumSize>95,26</MinimumSize>
+            <MinimumSize>85,26</MinimumSize>
             <MaximumSize>150,26</MaximumSize>
             <SizePolicy>me,f</SizePolicy>
             <Children>
               <EffectSelector>
-                <MinimumSize>95,26</MinimumSize>
+                <MinimumSize>85,26</MinimumSize>
                 <MaximumSize>150,26</MaximumSize>
                 <SizePolicy>me,f</SizePolicy>
                 <EffectRack><Variable name="FxRack"/></EffectRack>

--- a/res/skins/LateNight/fx_unit_parameters_visible.xml
+++ b/res/skins/LateNight/fx_unit_parameters_visible.xml
@@ -13,7 +13,7 @@
   <WidgetGroup>
     <ObjectName>EffectUnit<Variable name="FxUnit"/></ObjectName>
     <Layout>vertical</Layout>
-    <SizePolicy>me,min</SizePolicy>
+    <Size>635me,170min</Size>
     <Children>
 
       <WidgetGroup><!-- Fx Parameters -->


### PR DESCRIPTION
- don't expand collapsed FX unit when expanding opposing unit
- make FX selector fit with Super knobs visible

small fixes only, no screenshot needed.
please test!