### PR TITLE
fix some issues around broadcast profiles

### DIFF
--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -126,6 +126,10 @@ BroadcastProfilePtr BroadcastProfile::loadFromFile(
     return profile;
 }
 
+QString BroadcastProfile::getLastFilename() const {
+    return m_filename;
+}
+
 bool BroadcastProfile::equals(BroadcastProfilePtr other) {
     return ((getProfileName() == other->getProfileName())
             && valuesEquals(other));
@@ -268,6 +272,8 @@ bool BroadcastProfile::loadValues(const QString& filename) {
     if (doc.childNodes().size() < 1)
         return false;
 
+    m_filename = filename;
+
 #ifdef __QTKEYCHAIN__
     m_secureCredentials = (bool)XmlParse::selectNodeInt(doc, kSecureCredentials);
 #else
@@ -405,6 +411,7 @@ bool BroadcastProfile::save(const QString& filename) {
 
     QFile xmlFile(filename);
     if (xmlFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        m_filename = filename;
         QTextStream fileStream(&xmlFile);
         doc.save(fileStream, 4);
         xmlFile.close();

--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -50,6 +50,7 @@ const char* kNoDelayFirstReconnect = "NoDelayFirstReconnect";
 const char* kOggDynamicUpdate = "OggDynamicUpdate";
 const char* kPassword = "Password";
 const char* kPort = "Port";
+const char* kProfileName = "ProfileName";
 const char* kReconnectFirstDelay = "ReconnectFirstDelay";
 const char* kReconnectPeriod = "ReconnectPeriod";
 const char* kServertype = "Servertype";
@@ -275,6 +276,15 @@ bool BroadcastProfile::loadValues(const QString& filename) {
     m_secureCredentials = false;
 #endif
 
+    // ProfileName is special because it was not previously saved in the file.
+    // When loading old files, we need to use the file name (set in the
+    // constructor) as the profile name and only load it if present in the
+    // file.
+    QDomNode node = XmlParse::selectNode(doc, kProfileName);
+    if (!node.isNull()) {
+        m_profileName = node.toElement().text();
+    }
+
     m_enabled = (bool)XmlParse::selectNodeInt(doc, kEnabled);
 
     m_host = XmlParse::selectNodeQString(doc, kHost);
@@ -331,6 +341,8 @@ bool BroadcastProfile::loadValues(const QString& filename) {
 bool BroadcastProfile::save(const QString& filename) {
     QDomDocument doc(kDoctype);
     QDomElement docRoot = doc.createElement(kDocumentRoot);
+
+    XmlParse::addElement(doc, docRoot, kProfileName, m_profileName);
 
     XmlParse::addElement(doc, docRoot,
                          kSecureCredentials, QString::number((int)m_secureCredentials));

--- a/src/preferences/broadcastprofile.h
+++ b/src/preferences/broadcastprofile.h
@@ -37,6 +37,8 @@ class BroadcastProfile : public QObject {
     static bool validName(const QString& str);
     static QString stripForbiddenChars(const QString& str);
 
+    QString getLastFilename() const;
+
     void setConnectionStatus(int newState);
     int connectionStatus();
 
@@ -155,6 +157,8 @@ class BroadcastProfile : public QObject {
     void errorDialog(const QString& text, const QString& detailedError);
 
     bool m_secureCredentials;
+
+    QString m_filename;
 
     QString m_profileName;
     bool m_enabled;

--- a/src/preferences/broadcastsettings.cpp
+++ b/src/preferences/broadcastsettings.cpp
@@ -156,15 +156,6 @@ void BroadcastSettings::saveAll() {
     emit(profilesChanged());
 }
 
-void BroadcastSettings::deleteProfile(BroadcastProfilePtr profile) {
-    if (!profile)
-        return;
-
-    deleteFileForProfile(profile);
-    m_profiles.remove(profile->getProfileName());
-    emit(profileRemoved(profile));
-}
-
 void BroadcastSettings::onProfileNameChanged(QString oldName, QString newName) {
     if (!m_profiles.contains(oldName))
         return;

--- a/src/preferences/broadcastsettings.cpp
+++ b/src/preferences/broadcastsettings.cpp
@@ -132,11 +132,12 @@ bool BroadcastSettings::deleteFileForProfile(BroadcastProfilePtr profile) {
     if (!profile)
         return false;
 
-    return deleteFileForProfile(profile->getProfileName());
-}
+    QString filename = profile->getLastFilename();
+    if (filename.isEmpty()) {
+        filename = filePathForProfile(profile);
+    }
 
-bool BroadcastSettings::deleteFileForProfile(const QString& profileName) {
-    QFileInfo xmlFile(filePathForProfile(profileName));
+    QFileInfo xmlFile(filename);
     if (xmlFile.exists()) {
         return QFile::remove(xmlFile.absoluteFilePath());
     }
@@ -165,7 +166,7 @@ void BroadcastSettings::onProfileNameChanged(QString oldName, QString newName) {
         m_profiles.insert(newName, profile);
         emit(profileRenamed(oldName, profile));
 
-        deleteFileForProfile(oldName);
+        deleteFileForProfile(profile);
         saveProfile(profile);
     }
 }
@@ -196,7 +197,7 @@ void BroadcastSettings::applyModel(BroadcastSettingsModel* pModel) {
             // If profile exists in settings but not in the model,
             // remove the profile from the settings
             const auto removedProfile = *actualProfile;
-            deleteFileForProfile(profileName);
+            deleteFileForProfile(removedProfile);
             actualProfile = m_profiles.erase(actualProfile);
             emit(profileRemoved(removedProfile));
         } else {

--- a/src/preferences/broadcastsettings.cpp
+++ b/src/preferences/broadcastsettings.cpp
@@ -134,7 +134,8 @@ bool BroadcastSettings::deleteFileForProfile(BroadcastProfilePtr profile) {
 
     QString filename = profile->getLastFilename();
     if (filename.isEmpty()) {
-        filename = filePathForProfile(profile);
+        // no file was saved, there is no file to delete
+        return false;
     }
 
     QFileInfo xmlFile(filename);

--- a/src/preferences/broadcastsettings.cpp
+++ b/src/preferences/broadcastsettings.cpp
@@ -199,12 +199,17 @@ void BroadcastSettings::applyModel(BroadcastSettingsModel* pModel) {
     // TODO(Palakis): lock both lists against modifications while syncing
 
     // Step 1: find profiles to delete from the settings
-    for(const auto& actualProfile : m_profiles) {
-        QString profileName = actualProfile->getProfileName();
+    for(auto actualProfile = m_profiles.begin(); actualProfile != m_profiles.end();) {
+        QString profileName = (*actualProfile)->getProfileName();
         if (!pModel->getProfileByName(profileName)) {
             // If profile exists in settings but not in the model,
             // remove the profile from the settings
-            deleteProfile(actualProfile);
+            const auto removedProfile = *actualProfile;
+            deleteFileForProfile(profileName);
+            actualProfile = m_profiles.erase(actualProfile);
+            emit(profileRemoved(removedProfile));
+        } else {
+            ++actualProfile;
         }
     }
 

--- a/src/preferences/broadcastsettings.cpp
+++ b/src/preferences/broadcastsettings.cpp
@@ -191,7 +191,7 @@ void BroadcastSettings::applyModel(BroadcastSettingsModel* pModel) {
     // TODO(Palakis): lock both lists against modifications while syncing
 
     // Step 1: find profiles to delete from the settings
-    for(auto profileIter = m_profiles.begin(); profileIter != m_profiles.end();) {
+    for (auto profileIter = m_profiles.begin(); profileIter != m_profiles.end();) {
         QString profileName = (*profileIter)->getProfileName();
         if (!pModel->getProfileByName(profileName)) {
             // If profile exists in settings but not in the model,

--- a/src/preferences/broadcastsettings.cpp
+++ b/src/preferences/broadcastsettings.cpp
@@ -191,17 +191,17 @@ void BroadcastSettings::applyModel(BroadcastSettingsModel* pModel) {
     // TODO(Palakis): lock both lists against modifications while syncing
 
     // Step 1: find profiles to delete from the settings
-    for(auto actualProfile = m_profiles.begin(); actualProfile != m_profiles.end();) {
-        QString profileName = (*actualProfile)->getProfileName();
+    for(auto profileIter = m_profiles.begin(); profileIter != m_profiles.end();) {
+        QString profileName = (*profileIter)->getProfileName();
         if (!pModel->getProfileByName(profileName)) {
             // If profile exists in settings but not in the model,
             // remove the profile from the settings
-            const auto removedProfile = *actualProfile;
+            const auto removedProfile = *profileIter;
             deleteFileForProfile(removedProfile);
-            actualProfile = m_profiles.erase(actualProfile);
+            profileIter = m_profiles.erase(profileIter);
             emit(profileRemoved(removedProfile));
         } else {
-            ++actualProfile;
+            ++profileIter;
         }
     }
 

--- a/src/preferences/broadcastsettings.cpp
+++ b/src/preferences/broadcastsettings.cpp
@@ -112,7 +112,25 @@ bool BroadcastSettings::saveProfile(BroadcastProfilePtr profile) {
     if (!profile)
         return false;
 
-    return profile->save(filePathForProfile(profile));
+    QString filename = profile->getLastFilename();
+    if (filename.isEmpty()) {
+        // there was no previous filename, find an unused filename
+        for (int index = 0;; ++index) {
+            if (index > 0) {
+                // add an index to the file name to make it unique
+                filename = filePathForProfile(profile->getProfileName() + QString::number(index));
+            } else {
+                filename = filePathForProfile(profile->getProfileName());
+            }
+
+            QFileInfo fileInfo(filename);
+            if (!fileInfo.exists()) {
+                break;
+            }
+        }
+    }
+
+    return profile->save(filename);
 }
 
 QString BroadcastSettings::filePathForProfile(const QString& profileName) {

--- a/src/preferences/broadcastsettings.cpp
+++ b/src/preferences/broadcastsettings.cpp
@@ -95,19 +95,6 @@ bool BroadcastSettings::addProfile(BroadcastProfilePtr profile) {
     return true;
 }
 
-BroadcastProfilePtr BroadcastSettings::createProfile(const QString& profileName) {
-    QFileInfo xmlFile(filePathForProfile(profileName));
-
-    if (!xmlFile.exists()) {
-        BroadcastProfilePtr profile(new BroadcastProfile(profileName));
-        if (addProfile(profile)) {
-            saveProfile(profile);
-            return profile;
-        }
-    }
-    return BroadcastProfilePtr(nullptr);
-}
-
 bool BroadcastSettings::saveProfile(BroadcastProfilePtr profile) {
     if (!profile)
         return false;

--- a/src/preferences/broadcastsettings.h
+++ b/src/preferences/broadcastsettings.h
@@ -37,7 +37,6 @@ class BroadcastSettings : public QObject {
   private:
     void loadProfiles();
     bool addProfile(BroadcastProfilePtr profile);
-    void deleteProfile(BroadcastProfilePtr profile);
 
     QString filePathForProfile(BroadcastProfilePtr profile);
     QString filePathForProfile(const QString& profileName);

--- a/src/preferences/broadcastsettings.h
+++ b/src/preferences/broadcastsettings.h
@@ -18,7 +18,6 @@ class BroadcastSettings : public QObject {
 
     bool saveProfile(BroadcastProfilePtr profile);
     void saveAll();
-    BroadcastProfilePtr createProfile(const QString& profileName);
     QList<BroadcastProfilePtr> profiles();
     BroadcastProfilePtr profileAt(int index);
 

--- a/src/preferences/broadcastsettings.h
+++ b/src/preferences/broadcastsettings.h
@@ -41,7 +41,6 @@ class BroadcastSettings : public QObject {
     QString filePathForProfile(BroadcastProfilePtr profile);
     QString filePathForProfile(const QString& profileName);
     bool deleteFileForProfile(BroadcastProfilePtr profile);
-    bool deleteFileForProfile(const QString& profileName);
     QString getProfilesFolder();
 
     void loadLegacySettings(BroadcastProfilePtr profile);

--- a/src/test/broadcastprofile_test.cpp
+++ b/src/test/broadcastprofile_test.cpp
@@ -59,6 +59,25 @@ TEST(BroadcastProfileTest, SaveAndLoadXML) {
     ASSERT_TRUE(savedProfile->getStreamName() == streamName);
 }
 
+TEST(BroadcastProfileTest, SaveAndLoadXMLDotName) {
+    QString profileName("profile has a dot. (in the name)");
+
+    BroadcastProfile profile(profileName);
+
+    QString filename = profile.getProfileName() + QString(".bcp.xml");
+
+    // Call save() on a profile and assert it actually exists
+    QFile::remove(filename); // First, make sure it doesn't exists
+    profile.save(filename);
+    ASSERT_TRUE(QFile::exists(filename));
+
+    // Load XML file using static loadFromFile and assert
+    // the discriminating value is present
+    BroadcastProfilePtr savedProfile = BroadcastProfile::loadFromFile(filename);
+    ASSERT_NE(savedProfile, nullptr);
+    ASSERT_TRUE(savedProfile->getProfileName() == profileName);
+}
+
 TEST(BroadcastProfileTest, SetGetValues) {
     // For each attribute:
     // - use its setter to set a specific value

--- a/src/test/broadcastsettings_test.cpp
+++ b/src/test/broadcastsettings_test.cpp
@@ -67,4 +67,38 @@ TEST_F(BroadcastSettingsTest, ReuseExistingFile) {
     ASSERT_TRUE(pProfile->getLastFilename() == filename);
 }
 
+TEST_F(BroadcastSettingsTest, AddRemoveUpdateFromModel) {
+    QString name("Profile Name");
+    QString host("http://example.com");
+
+    BroadcastSettings settings(config());
+    BroadcastProfilePtr pProfile(new BroadcastProfile(name));
+    BroadcastSettingsModel model;
+
+    // add the profile to the model and apply the model to the settings
+    model.addProfileToModel(pProfile);
+    settings.applyModel(&model);
+    ASSERT_EQ(settings.profiles().size(), 1);
+
+    // make sure the profile was saved
+    QString filename = settings.profileAt(0)->getLastFilename();
+    ASSERT_TRUE(QFile::exists(filename));
+    ASSERT_TRUE(settings.profileAt(0)->getProfileName() == name);
+
+    // update the profile host and apply again
+    ASSERT_FALSE(settings.profileAt(0)->getHost() == host);
+    model.getProfileByName(name)->setHost(host);
+    settings.applyModel(&model);
+    ASSERT_EQ(settings.profiles().size(), 1);
+    ASSERT_TRUE(settings.profileAt(0)->getHost() == host);
+
+    // now remove the profile from the model and apply again
+    model.deleteProfileFromModel(pProfile);
+    settings.applyModel(&model);
+    ASSERT_EQ(settings.profiles().size(), 0);
+
+    // make sure the profile was removed
+    ASSERT_FALSE(QFile::exists(filename));
+}
+
 } // namespace

--- a/src/test/broadcastsettings_test.cpp
+++ b/src/test/broadcastsettings_test.cpp
@@ -1,0 +1,70 @@
+#include <QFile>
+#include <QString>
+
+#include "test/mixxxtest.h"
+#include "preferences/broadcastsettings.h"
+//#include "broadcast/defs_broadcast.h"
+//#include "defs_urls.h"
+
+namespace {
+
+class BroadcastSettingsTest : public MixxxTest {};
+
+TEST_F(BroadcastSettingsTest, SaveLoadAndRename) {
+    QString originalProfileName("Original Profile Name");
+    QString newProfileName("New Profile Name");
+
+    BroadcastSettings settings(config());
+    BroadcastProfilePtr pProfile(new BroadcastProfile(originalProfileName));
+    settings.saveProfile(pProfile);
+
+    // call saveProfile() and store the file name
+    settings.saveProfile(pProfile);
+    QString filename = pProfile->getLastFilename();
+
+    // rename the profile, the file name shouldn't change
+    QFile::remove(filename);
+    pProfile->setProfileName(newProfileName);
+    settings.saveProfile(pProfile);
+    EXPECT_TRUE(pProfile->getLastFilename() == filename);
+    ASSERT_TRUE(QFile::exists(filename));
+
+    // load XML file using static loadFromFile then save it again
+    pProfile = BroadcastProfile::loadFromFile(filename);
+    ASSERT_NE(pProfile, nullptr);
+    QFile::remove(filename);
+    settings.saveProfile(pProfile);
+    EXPECT_TRUE(pProfile->getLastFilename() == filename);
+    ASSERT_TRUE(QFile::exists(filename));
+}
+
+TEST_F(BroadcastSettingsTest, AvoidExistingFiles) {
+    QString name1("Profile? Name");
+    QString name2("Profile> Name");
+
+    BroadcastSettings settings(config());
+    BroadcastProfilePtr p1(new BroadcastProfile(name1));
+    BroadcastProfilePtr p2(new BroadcastProfile(name2));
+
+    // save both profiles and make sure they have different file names
+    settings.saveProfile(p1);
+    settings.saveProfile(p2);
+
+    ASSERT_FALSE(p1->getLastFilename() == p2->getLastFilename());
+}
+
+TEST_F(BroadcastSettingsTest, ReuseExistingFile) {
+    QString name("Profile Name");
+
+    BroadcastSettings settings(config());
+    BroadcastProfilePtr pProfile(new BroadcastProfile(name));
+
+    // save profile twice and make sure the name didn't change between saves
+    settings.saveProfile(pProfile);
+    QString filename = pProfile->getLastFilename();
+    settings.saveProfile(pProfile);
+
+    ASSERT_TRUE(pProfile->getLastFilename() == filename);
+}
+
+} // namespace


### PR DESCRIPTION
This fixes the following issues:
- crash when deleting profiles (introduced in 10ec4cb).
- proper handling of profiles with dot in the name
- proper handling of profiles with forbidden characters in the name

Previously the code assumed the profile name was stored in the xml file but this was not the case. This has been fixed. Additionally, the code would derive the file name from the profile name which doesn't work if the two don't match (like in the previously mentioned case with a `.` in the name). Now the filename is tracked separately.

There are still some edge cases that may cause unexpected behavior if a user previously had profiles with dots or special characters in the name. Specifically, the profile name in the GUI won't match the file name and it will be possible to have several profiles with the same name  (the last one loaded will be used). This should only happen if a user previously saved a profile with a dot (`.`) in the name. Going forward, any new or edited profiles should behave as expected.