### PR TITLE
start with a default broadcast profile for new profiles

### DIFF
--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -281,9 +281,6 @@ void DlgPrefBroadcast::btnCreateConnectionClicked() {
     } while(!existingProfile.isNull());
 
     BroadcastProfilePtr newProfile(new BroadcastProfile(newName));
-    if (m_pProfileListSelection) {
-        m_pProfileListSelection->copyValuesTo(newProfile);
-    }
     m_pSettingsModel->addProfileToModel(newProfile);
     selectConnectionRowByName(newProfile->getProfileName());
 }


### PR DESCRIPTION
Don't copy the selected profile, use the default profile when creating new profiles. A [forum user](https://mixxx.org/forums/viewtopic.php?f=3&t=12314) found this unintuitive and I agree with them. 

