### PR TITLE
Eject crash fix 

### DIFF
--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -745,8 +745,7 @@ void BpmControl::slotUpdateRateSlider() {
     m_pRateSlider->set(dRateSlider);
 }
 
-void BpmControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
-    Q_UNUSED(pOldTrack);
+void BpmControl::trackLoaded(TrackPointer pNewTrack) {
     if (m_pTrack) {
         disconnect(m_pTrack.get(), SIGNAL(beatsUpdated()),
                    this, SLOT(slotUpdatedTrackBeats()));

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -32,6 +32,9 @@ BpmControl::BpmControl(QString group,
           m_dSyncInstantaneousBpm(0.0),
           m_dLastSyncAdjustment(1.0),
           m_sGroup(group) {
+    m_dSyncTargetBeatDistance.setValue(0.0);
+    m_dUserOffset.setValue(0.0);
+
     m_pPlayButton = new ControlProxy(group, "play", this);
     m_pReverseButton = new ControlProxy(group, "reverse", this);
     m_pRateSlider = new ControlProxy(group, "rate", this);
@@ -849,7 +852,8 @@ void BpmControl::resetSyncAdjustment() {
 
 void BpmControl::collectFeatures(GroupFeatureState* pGroupFeatures) const {
     // Without a beatgrid we don't know any beat details.
-    if (!m_pBeats) {
+    double dTrackSampleRate = getTrackSampleRate();
+    if (!dTrackSampleRate || !m_pBeats) {
         return;
     }
 
@@ -866,7 +870,7 @@ void BpmControl::collectFeatures(GroupFeatureState* pGroupFeatures) const {
 
         // Note: dThisBeatLength is fractional frames count * 2 (stereo samples)
         pGroupFeatures->beat_length_sec = dThisBeatLength / kSamplesPerFrame
-                / getTrackSampleRate() / calcRateRatio();
+                / dTrackSampleRate / calcRateRatio();
 
         pGroupFeatures->has_beat_fraction = true;
         pGroupFeatures->beat_fraction = dThisBeatFraction;

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -26,13 +26,12 @@ const SINT kSamplesPerFrame = 2;
 }
 
 BpmControl::BpmControl(QString group,
-                       UserSettingsPointer pConfig) :
-        EngineControl(group, pConfig),
-        m_dSyncTargetBeatDistance(0.0),
-        m_dSyncInstantaneousBpm(0.0),
-        m_dLastSyncAdjustment(1.0),
-        m_tapFilter(this, kFilterLength, kMaxInterval),
-        m_sGroup(group) {
+                       UserSettingsPointer pConfig)
+        : EngineControl(group, pConfig),
+          m_tapFilter(this, kFilterLength, kMaxInterval),
+          m_dSyncInstantaneousBpm(0.0),
+          m_dLastSyncAdjustment(1.0),
+          m_sGroup(group) {
     m_pPlayButton = new ControlProxy(group, "play", this);
     m_pReverseButton = new ControlProxy(group, "reverse", this);
     m_pRateSlider = new ControlProxy(group, "rate", this);
@@ -123,7 +122,7 @@ BpmControl::BpmControl(QString group,
 
     // Measures distance from last beat in percentage: 0.5 = half-beat away.
     m_pThisBeatDistance = new ControlProxy(group, "beat_distance", this);
-    m_pSyncMode = ControlObject::getControl(ConfigKey(group, "sync_mode"));
+    m_pSyncMode = new ControlProxy(group, "sync_mode", this);
 }
 
 BpmControl::~BpmControl() {
@@ -444,7 +443,7 @@ double BpmControl::calcSyncAdjustment(double my_percentage, bool userTweakingSyn
     // than modular 1.0 beat fractions. This will allow sync to work across loop
     // boundaries too.
 
-    double master_percentage = m_dSyncTargetBeatDistance;
+    double master_percentage = m_dSyncTargetBeatDistance.getValue();
     double shortest_distance = shortestPercentageChange(
         master_percentage, my_percentage);
 
@@ -578,7 +577,8 @@ bool BpmControl::getBeatContextNoLookup(
     return true;
 }
 
-double BpmControl::getNearestPositionInPhase(double dThisPosition, bool respectLoops, bool playing) {
+double BpmControl::getNearestPositionInPhase(
+        double dThisPosition, bool respectLoops, bool playing) {
     // Without a beatgrid, we don't know the phase offset.
     BeatsPointer pBeats = m_pBeats;
     if (!pBeats) {
@@ -613,7 +613,7 @@ double BpmControl::getNearestPositionInPhase(double dThisPosition, bool respectL
     double dOtherBeatFraction;
     if (getSyncMode() == SYNC_FOLLOWER) {
         // If we're a follower, it's easy to get the other beat fraction
-        dOtherBeatFraction = m_dSyncTargetBeatDistance;
+        dOtherBeatFraction = m_dSyncTargetBeatDistance.getValue();
     } else {
         // If not, we have to figure it out
         EngineBuffer* pOtherEngineBuffer = pickSyncTarget();
@@ -832,7 +832,7 @@ double BpmControl::updateBeatDistance() {
 }
 
 void BpmControl::setTargetBeatDistance(double beatDistance) {
-    m_dSyncTargetBeatDistance = beatDistance;
+    m_dSyncTargetBeatDistance.setValue(beatDistance);
 }
 
 void BpmControl::setInstantaneousBpm(double instantaneousBpm) {

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -150,7 +150,7 @@ class BpmControl : public EngineControl {
     QAtomicInt m_resetSyncAdjustment;
     ControlProxy* m_pSyncMode;
 
-    TapFilter m_tapFilter; // TODO: not threadsave
+    TapFilter m_tapFilter; // threadsave
 
     // used in the engine thread only
     double m_dSyncInstantaneousBpm;

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -144,23 +144,25 @@ class BpmControl : public EngineControl {
     // Button that translates beats to match another playing deck
     ControlPushButton* m_pBeatsTranslateMatchAlignment;
 
-    // Master Sync objects and values.
-    ControlObject* m_pSyncMode;
     ControlProxy* m_pThisBeatDistance;
-    double m_dSyncTargetBeatDistance;
+    ControlValueAtomic<double> m_dSyncTargetBeatDistance;
+    ControlValueAtomic<double> m_dUserOffset;
+    QAtomicInt m_resetSyncAdjustment;
+    ControlProxy* m_pSyncMode;
+
+    TapFilter m_tapFilter; // TODO: not threadsave
+
+    // used in the engine thread only
     double m_dSyncInstantaneousBpm;
     double m_dLastSyncAdjustment;
-    QAtomicInt m_resetSyncAdjustment;
-    FRIEND_TEST(EngineSyncTest, UserTweakBeatDistance);
-    ControlValueAtomic<double> m_dUserOffset;
-
-    TapFilter m_tapFilter;
 
     // objects below are written from an engine worker thread
     TrackPointer m_pTrack;
     BeatsPointer m_pBeats;
 
-    QString m_sGroup;
+    const QString m_sGroup;
+
+    FRIEND_TEST(EngineSyncTest, UserTweakBeatDistance);
 };
 
 

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -156,8 +156,9 @@ class BpmControl : public EngineControl {
 
     TapFilter m_tapFilter;
 
-    TrackPointer m_pTrack; // is witten from an engine worker thread
-    BeatsPointer m_pBeats; // is witten from an engine worker thread
+    // objects below are written from an engine worker thread
+    TrackPointer m_pTrack;
+    BeatsPointer m_pBeats;
 
     QString m_sGroup;
 };

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -70,9 +70,7 @@ class BpmControl : public EngineControl {
     // Example: shortestPercentageChange(0.99, 0.01) == 0.02
     static double shortestPercentageChange(const double& current_percentage,
                                            const double& target_percentage);
-
-  public slots:
-    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
+    void trackLoaded(TrackPointer pNewTrack) override;
 
   private slots:
     void slotFileBpmChanged(double);
@@ -158,7 +156,7 @@ class BpmControl : public EngineControl {
 
     TapFilter m_tapFilter;
 
-    TrackPointer m_pTrack;
+    TrackPointer m_pTrack; // is witten from an engine worker thread
     BeatsPointer m_pBeats;
 
     QString m_sGroup;

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -157,7 +157,7 @@ class BpmControl : public EngineControl {
     TapFilter m_tapFilter;
 
     TrackPointer m_pTrack; // is witten from an engine worker thread
-    BeatsPointer m_pBeats;
+    BeatsPointer m_pBeats; // is witten from an engine worker thread
 
     QString m_sGroup;
 };

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -150,9 +150,9 @@ class BpmControl : public EngineControl {
     double m_dSyncTargetBeatDistance;
     double m_dSyncInstantaneousBpm;
     double m_dLastSyncAdjustment;
-    bool m_resetSyncAdjustment;
+    QAtomicInt m_resetSyncAdjustment;
     FRIEND_TEST(EngineSyncTest, UserTweakBeatDistance);
-    double m_dUserOffset;
+    ControlValueAtomic<double> m_dUserOffset;
 
     TapFilter m_tapFilter;
 

--- a/src/engine/clockcontrol.cpp
+++ b/src/engine/clockcontrol.cpp
@@ -17,9 +17,7 @@ ClockControl::~ClockControl() {
     delete m_pCOSampleRate;
 }
 
-void ClockControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
-    Q_UNUSED(pOldTrack);
-
+void ClockControl::trackLoaded(TrackPointer pNewTrack) {
     // Clear on-beat control
     m_pCOBeatActive->set(0.0);
 

--- a/src/engine/clockcontrol.cpp
+++ b/src/engine/clockcontrol.cpp
@@ -45,10 +45,8 @@ void ClockControl::slotBeatsUpdated() {
 }
 
 void ClockControl::process(const double dRate,
-                             const double currentSample,
-                             const double totalSamples,
-                             const int iBuffersize) {
-    Q_UNUSED(totalSamples);
+                           const double currentSample,
+                           const int iBuffersize) {
     Q_UNUSED(iBuffersize);
     double samplerate = m_pCOSampleRate->get();
 

--- a/src/engine/clockcontrol.cpp
+++ b/src/engine/clockcontrol.cpp
@@ -17,6 +17,7 @@ ClockControl::~ClockControl() {
     delete m_pCOSampleRate;
 }
 
+// called from an engine worker thread
 void ClockControl::trackLoaded(TrackPointer pNewTrack) {
     // Clear on-beat control
     m_pCOBeatActive->set(0.0);
@@ -39,8 +40,9 @@ void ClockControl::trackLoaded(TrackPointer pNewTrack) {
 }
 
 void ClockControl::slotBeatsUpdated() {
-    if(m_pTrack) {
-        m_pBeats = m_pTrack->getBeats();
+    TrackPointer pTrack = m_pTrack;
+    if(pTrack) {
+        m_pBeats = pTrack->getBeats();
     }
 }
 
@@ -57,8 +59,9 @@ void ClockControl::process(const double dRate,
     // by the rate.
     const double blinkIntervalSamples = 2.0 * samplerate * (1.0 * dRate) * blinkSeconds;
 
-    if (m_pBeats) {
-        double closestBeat = m_pBeats->findClosestBeat(currentSample);
+    BeatsPointer pBeats = m_pBeats;
+    if (pBeats) {
+        double closestBeat = pBeats->findClosestBeat(currentSample);
         double distanceToClosestBeat = fabs(currentSample - closestBeat);
         m_pCOBeatActive->set(distanceToClosestBeat < blinkIntervalSamples / 2.0);
     }

--- a/src/engine/clockcontrol.h
+++ b/src/engine/clockcontrol.h
@@ -22,13 +22,13 @@ class ClockControl: public EngineControl {
                    const double totalSamples, const int iBufferSize) override;
 
   public slots:
-    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
+    void trackLoaded(TrackPointer pNewTrack) override;
     void slotBeatsUpdated();
 
   private:
     ControlObject* m_pCOBeatActive;
     ControlProxy* m_pCOSampleRate;
-    TrackPointer m_pTrack;
+    TrackPointer m_pTrack; // is witten from an engine worker thread
     BeatsPointer m_pBeats;
 };
 

--- a/src/engine/clockcontrol.h
+++ b/src/engine/clockcontrol.h
@@ -28,8 +28,10 @@ class ClockControl: public EngineControl {
   private:
     ControlObject* m_pCOBeatActive;
     ControlProxy* m_pCOSampleRate;
-    TrackPointer m_pTrack; // is witten from an engine worker thread
-    BeatsPointer m_pBeats; // is witten from an engine worker thread
+
+    // objects below are written from an engine worker thread
+    TrackPointer m_pTrack;
+    BeatsPointer m_pBeats;
 };
 
 #endif /* CLOCKCONTROL_H */

--- a/src/engine/clockcontrol.h
+++ b/src/engine/clockcontrol.h
@@ -19,7 +19,7 @@ class ClockControl: public EngineControl {
     ~ClockControl() override;
 
     void process(const double dRate, const double currentSample,
-                   const double totalSamples, const int iBufferSize) override;
+            const int iBufferSize) override;
 
   public slots:
     void trackLoaded(TrackPointer pNewTrack) override;

--- a/src/engine/clockcontrol.h
+++ b/src/engine/clockcontrol.h
@@ -29,7 +29,7 @@ class ClockControl: public EngineControl {
     ControlObject* m_pCOBeatActive;
     ControlProxy* m_pCOSampleRate;
     TrackPointer m_pTrack; // is witten from an engine worker thread
-    BeatsPointer m_pBeats;
+    BeatsPointer m_pBeats; // is witten from an engine worker thread
 };
 
 #endif /* CLOCKCONTROL_H */

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -187,10 +187,8 @@ void CueControl::detachCue(int hotCue) {
     pControl->resetCue();
 }
 
-void CueControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+void CueControl::trackLoaded(TrackPointer pNewTrack) {
     QMutexLocker lock(&m_mutex);
-
-    DEBUG_ASSERT(m_pLoadedTrack == pOldTrack);
     if (m_pLoadedTrack) {
         disconnect(m_pLoadedTrack.get(), 0, this, 0);
         for (int i = 0; i < m_iNumHotCues; ++i) {

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -332,7 +332,7 @@ void CueControl::hotcueSet(HotcueControl* pControl, double v) {
     double closestBeat = m_pClosestBeat->get();
     double cuePosition =
             (m_pQuantizeEnabled->toBool() && closestBeat != -1) ?
-                    closestBeat : getCurrentSample();
+                    closestBeat : getSampleOfTrack().current;
     pCue->setPosition(cuePosition);
     pCue->setHotCue(hotcue);
     pCue->setLabel("");
@@ -574,7 +574,7 @@ void CueControl::cueSet(double v) {
     QMutexLocker lock(&m_mutex);
     double closestBeat = m_pClosestBeat->get();
     double cue = (m_pQuantizeEnabled->toBool() && closestBeat != -1) ?
-            closestBeat : getCurrentSample();
+            closestBeat : getSampleOfTrack().current;
     m_pCuePoint->set(cue);
     TrackPointer pLoadedTrack = m_pLoadedTrack;
     lock.unlock();
@@ -665,6 +665,7 @@ void CueControl::cueCDJ(double v) {
 
     QMutexLocker lock(&m_mutex);
     const auto freely_playing = m_pPlay->toBool() && !getEngineBuffer()->getScratching();
+    TrackAt trackAt = getTrackAt();
 
     if (v) {
         if (m_iCurrentlyPreviewingHotcues) {
@@ -673,7 +674,7 @@ void CueControl::cueCDJ(double v) {
             m_bPreviewing = true;
             lock.unlock();
             seekAbs(m_pCuePoint->get());
-        } else if (freely_playing || atEndPosition()) {
+        } else if (freely_playing || trackAt == TrackAt::End) {
             // Jump to cue when playing or when at end position
 
             // Just in case.
@@ -684,7 +685,7 @@ void CueControl::cueCDJ(double v) {
             lock.unlock();
 
             seekAbs(m_pCuePoint->get());
-        } else if (isTrackAtCue()) {
+        } else if (trackAt == TrackAt::Cue) {
             // pause at cue point
             m_bPreviewing = true;
             m_pPlay->set(1.0);
@@ -731,6 +732,7 @@ void CueControl::cueDenon(double v) {
 
     QMutexLocker lock(&m_mutex);
     bool playing = (m_pPlay->toBool());
+    TrackAt trackAt = getTrackAt();
 
     if (v) {
         if (m_iCurrentlyPreviewingHotcues) {
@@ -739,7 +741,7 @@ void CueControl::cueDenon(double v) {
             m_bPreviewing = true;
             lock.unlock();
             seekAbs(m_pCuePoint->get());
-        } else if (!playing && isTrackAtCue()) {
+        } else if (!playing && trackAt == TrackAt::Cue) {
             // pause at cue point
             m_bPreviewing = true;
             m_pPlay->set(1.0);
@@ -775,6 +777,7 @@ void CueControl::cuePlay(double v) {
 
     QMutexLocker lock(&m_mutex);
     const auto freely_playing = m_pPlay->toBool() && !getEngineBuffer()->getScratching();
+    TrackAt trackAt = getTrackAt();
 
     // pressed
     if (v) {
@@ -786,7 +789,7 @@ void CueControl::cuePlay(double v) {
             lock.unlock();
 
             seekAbs(m_pCuePoint->get());
-        } else if (!isTrackAtCue() && getCurrentSample() <= getTotalSamples()) {
+        } else if (trackAt == TrackAt::ElseWhere) {
             // Pause not at cue point and not at end position
             cueSet(v);
             // Just in case.
@@ -800,11 +803,10 @@ void CueControl::cuePlay(double v) {
                 seekAbs(m_pCuePoint->get());
             }
         }
-    } else if (isTrackAtCue()){
+    } else if (trackAt == TrackAt::Cue){
         m_bPreviewing = false;
         m_pPlay->set(1.0);
         lock.unlock();
-
     }
 }
 
@@ -872,6 +874,8 @@ bool CueControl::updateIndicatorsAndModifyPlay(bool newPlay, bool playPossible) 
         }
     }
 
+    TrackAt trackAt = getTrackAt();
+
     if (!playPossible) {
         // play not possible
         newPlay = false;
@@ -885,7 +889,7 @@ bool CueControl::updateIndicatorsAndModifyPlay(bool newPlay, bool playPossible) 
         // Pause:
         m_pStopButton->set(1.0);
         if (cueMode == CUE_MODE_DENON) {
-            if (isTrackAtCue() || previewing) {
+            if (trackAt == TrackAt::Cue || previewing) {
                 m_pPlayIndicator->setBlinkValue(ControlIndicator::OFF);
             } else {
                 // Flashing indicates that a following play would move cue point
@@ -902,8 +906,7 @@ bool CueControl::updateIndicatorsAndModifyPlay(bool newPlay, bool playPossible) 
 
     if (cueMode != CUE_MODE_DENON && cueMode != CUE_MODE_NUMARK) {
         if (m_pCuePoint->get() != -1) {
-            if (newPlay == 0.0 && !isTrackAtCue() &&
-                    !atEndPosition()) {
+            if (newPlay == 0.0 && trackAt == TrackAt::ElseWhere) {
                 if (cueMode == CUE_MODE_MIXXX) {
                     // in Mixxx mode Cue Button is flashing slow if CUE will move Cue point
                     m_pCueIndicator->setBlinkValue(ControlIndicator::RATIO1TO1_500MS);
@@ -925,14 +928,16 @@ bool CueControl::updateIndicatorsAndModifyPlay(bool newPlay, bool playPossible) 
     return newPlay;
 }
 
+// called from the engine thread
 void CueControl::updateIndicators() {
     // No need for mutex lock because we are only touching COs.
     double cueMode = m_pCueMode->get();
+    TrackAt trackAt = getTrackAt();
 
     if (cueMode == CUE_MODE_DENON || cueMode == CUE_MODE_NUMARK) {
         // Cue button is only lit at cue point
         bool playing = m_pPlay->toBool();
-        if (isTrackAtCue()) {
+        if (trackAt == TrackAt::Cue) {
             // at cue point
             if (!playing) {
                 m_pCueIndicator->setBlinkValue(ControlIndicator::ON);
@@ -941,7 +946,7 @@ void CueControl::updateIndicators() {
         } else {
             m_pCueIndicator->setBlinkValue(ControlIndicator::OFF);
             if (!playing) {
-                if (!atEndPosition() && cueMode != CUE_MODE_NUMARK) {
+                if (trackAt != TrackAt::End && cueMode != CUE_MODE_NUMARK) {
                     // Play will move cue point
                     m_pPlayIndicator->setBlinkValue(ControlIndicator::RATIO1TO1_500MS);
                 } else {
@@ -956,24 +961,26 @@ void CueControl::updateIndicators() {
         if (!m_bPreviewing) {
             const auto freely_playing = m_pPlay->toBool() && !getEngineBuffer()->getScratching();
             if (!freely_playing) {
-                if (!isTrackAtCue()) {
-                    if (!atEndPosition()) {
-                        if (cueMode == CUE_MODE_MIXXX) {
-                            // in Mixxx mode Cue Button is flashing slow if CUE will move Cue point
-                            m_pCueIndicator->setBlinkValue(ControlIndicator::RATIO1TO1_500MS);
-                        } else if (cueMode == CUE_MODE_MIXXX_NO_BLINK) {
-                            m_pCueIndicator->setBlinkValue(ControlIndicator::OFF);
-                        } else {
-                            // in Pioneer mode Cue Button is flashing fast if CUE will move Cue point
-                            m_pCueIndicator->setBlinkValue(ControlIndicator::RATIO1TO1_250MS);
-                        }
-                    } else {
-                        // At track end
+                switch (trackAt) {
+                case TrackAt::ElseWhere:
+                    if (cueMode == CUE_MODE_MIXXX) {
+                        // in Mixxx mode Cue Button is flashing slow if CUE will move Cue point
+                        m_pCueIndicator->setBlinkValue(ControlIndicator::RATIO1TO1_500MS);
+                    } else if (cueMode == CUE_MODE_MIXXX_NO_BLINK) {
                         m_pCueIndicator->setBlinkValue(ControlIndicator::OFF);
+                    } else {
+                        // in Pioneer mode Cue Button is flashing fast if CUE will move Cue point
+                        m_pCueIndicator->setBlinkValue(ControlIndicator::RATIO1TO1_250MS);
                     }
-                } else if (m_pCuePoint->get() != -1) {
+                    break;
+                case TrackAt::End:
+                    // At track end
+                    m_pCueIndicator->setBlinkValue(ControlIndicator::OFF);
+                    break;
+                case TrackAt::Cue:
                     // Next Press is preview
                     m_pCueIndicator->setBlinkValue(ControlIndicator::ON);
+                    break;
                 }
             } else {
                 // Cue indicator should be off when freely playing
@@ -988,8 +995,16 @@ void CueControl::resetIndicators() {
     m_pPlayIndicator->setBlinkValue(ControlIndicator::OFF);
 }
 
-bool CueControl::isTrackAtCue() {
-    return (fabs(getCurrentSample() - m_pCuePoint->get()) < 1.0f);
+CueControl::TrackAt CueControl::getTrackAt() const {
+    SampleOfTrack sot = getSampleOfTrack();
+    if (sot.current >= sot.total) {
+        return TrackAt::End;
+    }
+    double cue = m_pCuePoint->get();
+    if (cue != -1 && fabs(sot.current - cue) < 1.0f) {
+        return TrackAt::Cue;
+    }
+    return TrackAt::ElseWhere;
 }
 
 bool CueControl::isPlayingByPlayButton() {

--- a/src/engine/cuecontrol.cpp
+++ b/src/engine/cuecontrol.cpp
@@ -983,6 +983,11 @@ void CueControl::updateIndicators() {
     }
 }
 
+void CueControl::resetIndicators() {
+    m_pCueIndicator->setBlinkValue(ControlIndicator::OFF);
+    m_pPlayIndicator->setBlinkValue(ControlIndicator::OFF);
+}
+
 bool CueControl::isTrackAtCue() {
     return (fabs(getCurrentSample() - m_pCuePoint->get()) < 1.0f);
 }

--- a/src/engine/cuecontrol.h
+++ b/src/engine/cuecontrol.h
@@ -164,7 +164,7 @@ class CueControl : public EngineControl {
     ControlProxy* m_pVinylControlEnabled;
     ControlProxy* m_pVinylControlMode;
 
-    TrackPointer m_pLoadedTrack; // is witten from an engine worker thread
+    TrackPointer m_pLoadedTrack; // is written from an engine worker thread
 
     // Tells us which controls map to which hotcue
     QMap<QObject*, int> m_controlMap;

--- a/src/engine/cuecontrol.h
+++ b/src/engine/cuecontrol.h
@@ -100,10 +100,8 @@ class CueControl : public EngineControl {
     bool updateIndicatorsAndModifyPlay(bool newPlay, bool playPossible);
     void updateIndicators();
     void resetIndicators();
-    bool isTrackAtCue();
     bool isPlayingByPlayButton();
     bool getPlayFlashingAtPause();
-
     void trackLoaded(TrackPointer pNewTrack) override;
 
   private slots:
@@ -131,10 +129,17 @@ class CueControl : public EngineControl {
     void playStutter(double v);
 
   private:
+    enum class TrackAt {
+        Cue,
+        End,
+        ElseWhere
+    };
+
     // These methods are not thread safe, only call them when the lock is held.
     void createControls();
     void attachCue(CuePointer pCue, int hotcueNumber);
     void detachCue(int hotcueNumber);
+    TrackAt getTrackAt() const;
 
     bool m_bPreviewing;
     ControlObject* m_pPlay;

--- a/src/engine/cuecontrol.h
+++ b/src/engine/cuecontrol.h
@@ -103,8 +103,7 @@ class CueControl : public EngineControl {
     bool isPlayingByPlayButton();
     bool getPlayFlashingAtPause();
 
-  public slots:
-    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
+    void trackLoaded(TrackPointer pNewTrack) override;
 
   private slots:
     void cueUpdated();
@@ -165,7 +164,7 @@ class CueControl : public EngineControl {
     ControlProxy* m_pVinylControlEnabled;
     ControlProxy* m_pVinylControlMode;
 
-    TrackPointer m_pLoadedTrack;
+    TrackPointer m_pLoadedTrack; // is witten from an engine worker thread
 
     // Tells us which controls map to which hotcue
     QMap<QObject*, int> m_controlMap;

--- a/src/engine/cuecontrol.h
+++ b/src/engine/cuecontrol.h
@@ -99,6 +99,7 @@ class CueControl : public EngineControl {
     virtual void hintReader(HintVector* pHintList) override;
     bool updateIndicatorsAndModifyPlay(bool newPlay, bool playPossible);
     void updateIndicators();
+    void resetIndicators();
     bool isTrackAtCue();
     bool isPlayingByPlayButton();
     bool getPlayFlashingAtPause();

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -501,7 +501,7 @@ void EngineBuffer::loadFakeTrack(TrackPointer pTrack, bool bPlay) {
     slotTrackLoaded(pTrack, pTrack->getSampleRate(),
                     pTrack->getSampleRate() * pTrack->getDurationInt());
     m_pSyncControl->setLocalBpm(pTrack->getBpm());
-    m_pSyncControl->trackLoaded(pTrack, TrackPointer());
+    m_pSyncControl->trackLoaded(pTrack);
 }
 
 // WARNING: Always called from the EngineWorker thread pool
@@ -1372,7 +1372,7 @@ void EngineBuffer::notifyTrackLoaded(
     // First inform engineControls directly
     // Note: we are still in a worker thread.
     for (const auto& pControl: m_engineControls) {
-        pControl->trackLoaded(pNewTrack, pOldTrack);
+        pControl->trackLoaded(pNewTrack);
     }
     // Inform BaseTrackPlayer via a queued connection
     emit(trackLoaded(pNewTrack, pOldTrack));

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -171,7 +171,7 @@ EngineBuffer::EngineBuffer(QString group, UserSettingsPointer pConfig,
     m_pRepeat = new ControlPushButton(ConfigKey(m_group, "repeat"));
     m_pRepeat->setButtonMode(ControlPushButton::TOGGLE);
 
-    m_pMasterSampleRate = new ControlProxy("[Master]", "samplerate", this);
+    m_pSampleRate = new ControlProxy("[Master]", "samplerate", this);
 
     m_pKeylockEngine = new ControlProxy("[Master]", "keylock_engine", this);
     m_pKeylockEngine->connectValueChanged(SLOT(slotKeylockEngineChanged(double)),
@@ -299,7 +299,7 @@ EngineBuffer::~EngineBuffer() {
 
     delete m_pSlipButton;
     delete m_pRepeat;
-    delete m_pMasterSampleRate;
+    delete m_pSampleRate;
 
     delete m_pTrackLoaded;
     delete m_pTrackSamples;
@@ -1031,7 +1031,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
     // - Set last sample value (m_fLastSampleValue) so that rampOut works? Other
     //   miscellaneous upkeep issues.
 
-    int sample_rate = static_cast<int>(m_pMasterSampleRate->get());
+    int sample_rate = static_cast<int>(m_pSampleRate->get());
 
     // If the sample rate has changed, force Rubberband to reset so that
     // it doesn't reallocate when the user engages keylock during playback.
@@ -1235,7 +1235,7 @@ void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
 
     // Update indicators that are only updated after every
     // sampleRate/kiUpdateRate samples processed.  (e.g. playposSlider)
-    if (m_iSamplesCalculated > (kSamplesPerFrame * m_pMasterSampleRate->get() / kiPlaypositionUpdateRate)) {
+    if (m_iSamplesCalculated > (kSamplesPerFrame * m_pSampleRate->get() / kiPlaypositionUpdateRate)) {
         const double samplePositionToSeconds = 1.0 / m_trackSampleRateOld
                 / kSamplesPerFrame / m_tempo_ratio_old;
         m_timeElapsed->set(m_filepos_play * samplePositionToSeconds);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -371,7 +371,7 @@ double EngineBuffer::getLocalBpm() {
 }
 
 void EngineBuffer::setEngineMaster(EngineMaster* pEngineMaster) {
-    for (const auto& pControl: m_engineControls) {
+    for (const auto& pControl: qAsConst(m_engineControls)) {
         pControl->setEngineMaster(pEngineMaster);
     }
 }
@@ -460,7 +460,7 @@ void EngineBuffer::setNewPlaypos(double newpos, bool adjustingPhase) {
     m_iSamplesCalculated = 1000000;
 
     // Must hold the engineLock while using m_engineControls
-    for (const auto& pControl: m_engineControls) {
+    for (const auto& pControl: qAsConst(m_engineControls)) {
         pControl->notifySeek(m_filepos_play, adjustingPhase);
     }
 
@@ -983,7 +983,7 @@ void EngineBuffer::processTrackLocked(
         }
     }
 
-    for (const auto& pControl: m_engineControls) {
+    for (const auto& pControl: qAsConst(m_engineControls)) {
         pControl->setCurrentSample(m_filepos_play, m_trackSamplesOld, m_trackSampleRateOld);
         pControl->process(rate, m_filepos_play, iBufferSize);
     }
@@ -1279,7 +1279,7 @@ void EngineBuffer::hintReader(const double dRate) {
         m_hintList.append(hint);
     }
 
-    for (const auto& pControl: m_engineControls) {
+    for (const auto& pControl: qAsConst(m_engineControls)) {
         pControl->hintReader(&m_hintList);
     }
     m_pReader->hintAndMaybeWake(m_hintList);
@@ -1373,7 +1373,7 @@ void EngineBuffer::notifyTrackLoaded(
         TrackPointer pNewTrack, TrackPointer pOldTrack) {
     // First inform engineControls directly
     // Note: we are still in a worker thread.
-    for (const auto& pControl: m_engineControls) {
+    for (const auto& pControl: qAsConst(m_engineControls)) {
         pControl->trackLoaded(pNewTrack);
     }
     // Inform BaseTrackPlayer via a queued connection

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -372,7 +372,7 @@ double EngineBuffer::getLocalBpm() {
 }
 
 void EngineBuffer::setEngineMaster(EngineMaster* pEngineMaster) {
-    foreach (EngineControl* pControl, m_engineControls) {
+    for (const auto& pControl: m_engineControls) {
         pControl->setEngineMaster(pEngineMaster);
     }
 }
@@ -461,9 +461,7 @@ void EngineBuffer::setNewPlaypos(double newpos, bool adjustingPhase) {
     m_iSamplesCalculated = 1000000;
 
     // Must hold the engineLock while using m_engineControls
-    for (QList<EngineControl*>::iterator it = m_engineControls.begin();
-         it != m_engineControls.end(); ++it) {
-        EngineControl *pControl = *it;
+    for (const auto& pControl: m_engineControls) {
         pControl->notifySeek(m_filepos_play, adjustingPhase);
     }
 
@@ -1020,9 +1018,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
             }
         }
 
-        QListIterator<EngineControl*> it(m_engineControls);
-        while (it.hasNext()) {
-            EngineControl* pControl = it.next();
+        for (const auto& pControl: m_engineControls) {
             pControl->setCurrentSample(m_filepos_play, m_trackSamplesOld);
             pControl->process(rate, m_filepos_play, m_trackSamplesOld, iBufferSize);
         }

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -171,8 +171,7 @@ EngineBuffer::EngineBuffer(QString group, UserSettingsPointer pConfig,
     m_pRepeat = new ControlPushButton(ConfigKey(m_group, "repeat"));
     m_pRepeat->setButtonMode(ControlPushButton::TOGGLE);
 
-    // Sample rate
-    m_pSampleRate = new ControlProxy("[Master]", "samplerate", this);
+    m_pMasterSampleRate = new ControlProxy("[Master]", "samplerate", this);
 
     m_pKeylockEngine = new ControlProxy("[Master]", "keylock_engine", this);
     m_pKeylockEngine->connectValueChanged(SLOT(slotKeylockEngineChanged(double)),
@@ -300,7 +299,7 @@ EngineBuffer::~EngineBuffer() {
 
     delete m_pSlipButton;
     delete m_pRepeat;
-    delete m_pSampleRate;
+    delete m_pMasterSampleRate;
 
     delete m_pTrackLoaded;
     delete m_pTrackSamples;
@@ -1038,7 +1037,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
     // - Set last sample value (m_fLastSampleValue) so that rampOut works? Other
     //   miscellaneous upkeep issues.
 
-    int sample_rate = static_cast<int>(m_pSampleRate->get());
+    int sample_rate = static_cast<int>(m_pMasterSampleRate->get());
 
     // If the sample rate has changed, force Rubberband to reset so that
     // it doesn't reallocate when the user engages keylock during playback.
@@ -1233,7 +1232,7 @@ void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
 
     // Update indicators that are only updated after every
     // sampleRate/kiUpdateRate samples processed.  (e.g. playposSlider)
-    if (m_iSamplesCalculated > (m_pSampleRate->get() / kiPlaypositionUpdateRate)) {
+    if (m_iSamplesCalculated > (kSamplesPerFrame * m_pMasterSampleRate->get() / kiPlaypositionUpdateRate)) {
         const double samplePositionToSeconds = 1.0 / m_trackSampleRateOld
                 / kSamplesPerFrame / m_tempo_ratio_old;
         m_timeElapsed->set(m_filepos_play * samplePositionToSeconds);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -985,7 +985,7 @@ void EngineBuffer::processTrackLocked(
 
     for (const auto& pControl: m_engineControls) {
         pControl->setCurrentSample(m_filepos_play, m_trackSamplesOld);
-        pControl->process(rate, m_filepos_play, m_trackSamplesOld, iBufferSize);
+        pControl->process(rate, m_filepos_play, iBufferSize);
     }
 
     m_scratching_old = is_scratching;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -984,7 +984,7 @@ void EngineBuffer::processTrackLocked(
     }
 
     for (const auto& pControl: m_engineControls) {
-        pControl->setCurrentSample(m_filepos_play, m_trackSamplesOld);
+        pControl->setCurrentSample(m_filepos_play, m_trackSamplesOld, m_trackSampleRateOld);
         pControl->process(rate, m_filepos_play, iBufferSize);
     }
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -53,14 +53,14 @@ EngineBuffer::EngineBuffer(QString group, UserSettingsPointer pConfig,
                            EngineChannel* pChannel, EngineMaster* pMixingEngine)
         : m_group(group),
           m_pConfig(pConfig),
-          m_pLoopingControl(NULL),
-          m_pSyncControl(NULL),
-          m_pVinylControlControl(NULL),
-          m_pRateControl(NULL),
-          m_pBpmControl(NULL),
-          m_pKeyControl(NULL),
-          m_pReadAheadManager(NULL),
-          m_pReader(NULL),
+          m_pLoopingControl(nullptr),
+          m_pSyncControl(nullptr),
+          m_pVinylControlControl(nullptr),
+          m_pRateControl(nullptr),
+          m_pBpmControl(nullptr),
+          m_pKeyControl(nullptr),
+          m_pReadAheadManager(nullptr),
+          m_pReader(nullptr),
           m_filepos_play(0.),
           m_speed_old(0),
           m_tempo_ratio_old(1.),
@@ -77,9 +77,9 @@ EngineBuffer::EngineBuffer(QString group, UserSettingsPointer pConfig,
           m_dSlipRate(1.0),
           m_slipEnabled(0),
           m_bSlipEnabledProcessing(false),
-          m_pRepeat(NULL),
-          m_startButton(NULL),
-          m_endButton(NULL),
+          m_pRepeat(nullptr),
+          m_startButton(nullptr),
+          m_endButton(nullptr),
           m_bScalerOverride(false),
           m_iSeekQueued(SEEK_NONE),
           m_iSeekPhaseQueued(0),
@@ -724,6 +724,304 @@ void EngineBuffer::slotKeylockEngineChanged(double dIndex) {
     }
 }
 
+void EngineBuffer::processTrackLocked(
+        CSAMPLE* pOutput, const int iBufferSize, int sample_rate) {
+    ScopedTimer t("EngineBuffer::process_pauselock");
+
+    double baserate = 0.0;
+    if (sample_rate > 0) {
+        baserate = ((double)m_trackSampleRateOld / sample_rate);
+    }
+
+    // Note: play is also active during cue preview
+    bool paused = !m_playButton->toBool();
+        KeyControl::PitchTempoRatio pitchTempoRatio = m_pKeyControl->getPitchTempoRatio();
+
+    // The pitch adjustment in Ratio (1.0 being normal
+    // pitch. 2.0 is a full octave shift up).
+    double pitchRatio = pitchTempoRatio.pitchRatio;
+    double tempoRatio = pitchTempoRatio.tempoRatio;
+    const bool keylock_enabled = pitchTempoRatio.keylock;
+
+    bool is_scratching = false;
+    bool is_reverse = false;
+
+    // Update the slipped position and seek if it was disabled.
+    processSlip(iBufferSize);
+    processSyncRequests();
+
+    // Note: This may effects the m_filepos_play, play, scaler and crossfade buffer
+    processSeek(paused);
+
+    // speed is the ratio between track-time and real-time
+    // (1.0 being normal rate. 2.0 plays at 2x speed -- 2 track seconds
+    // pass for every 1 real second). Depending on whether
+    // keylock is enabled, this is applied to either the rate or the tempo.
+    double speed = m_pRateControl->calculateSpeed(
+            baserate, tempoRatio, paused, iBufferSize, &is_scratching, &is_reverse);
+
+    // The cue indicator may change when scratch state is changed
+    if (is_scratching != m_scratching_old) {
+        m_pCueControl->updateIndicators();
+    }
+
+    bool useIndependentPitchAndTempoScaling = false;
+
+    // TODO(owen): Maybe change this so that rubberband doesn't disable
+    // keylock on scratch. (just check m_pScaleKeylock == m_pScaleST)
+    if (is_scratching || fabs(speed) > 1.9) {
+        // Scratching and high speeds with always disables keylock
+        // because Soundtouch sounds terrible in these conditions.  Rubberband
+        // sounds better, but still has some problems (it may reallocate in
+        // a party-crashing manner at extremely slow speeds).
+        // High seek speeds also disables keylock.  Our pitch slider could go
+        // to 90%, so that's the cutoff point.
+
+        // Force pitchRatio to the linear pitch set by speed
+        pitchRatio = speed;
+        // This is for the natural speed pitch found on turn tables
+    } else if (fabs(speed) < 0.1) {
+        // We have pre-allocated big buffers in Rubberband and Soundtouch for
+        // a minimum speed of 0.1. Slower speeds will re-allocate much bigger
+        // buffers which may cause underruns.
+        // Disable keylock under these conditions.
+
+        // Force pitchRatio to the linear pitch set by speed
+        pitchRatio = speed;
+    } else if (keylock_enabled) {
+        // always use IndependentPitchAndTempoScaling
+        // to avoid clicks when crossing the linear pitch
+        // in this case it is most likely that the user
+        // will have an non linear pitch
+        // Note: We have undesired noise when cossfading between scalers
+        useIndependentPitchAndTempoScaling = true;
+    } else {
+        // We might have have temporary speed change, so adjust pitch if not locked
+        // Note: This will not update key and tempo widgets
+        if (tempoRatio) {
+            pitchRatio *= (speed / tempoRatio);
+        }
+
+        // Check if we are off-linear (musical key has been adjusted
+        // independent from speed) to determine if the keylock scaler
+        // should be used even though keylock is disabled.
+        if (speed != 0.0) {
+            double offlinear = pitchRatio / speed;
+            if (offlinear > kLinearScalerElipsis ||
+                    offlinear < 1 / kLinearScalerElipsis) {
+                // only enable keylock scaler if pitch adjustment is at
+                // least 1 cent. Everything below is not hear-able.
+                useIndependentPitchAndTempoScaling = true;
+            }
+        }
+    }
+
+    if (speed != 0.0) {
+        // Do not switch scaler when we have no transport
+        enableIndependentPitchTempoScaling(useIndependentPitchAndTempoScaling,
+                iBufferSize);
+    } else if (m_speed_old && !is_scratching) {
+        // we are stopping, collect samples for fade out
+        readToCrossfadeBuffer(iBufferSize);
+        // Clear the scaler information
+        m_pScale->clear();
+    }
+
+    // How speed/tempo/pitch are related:
+    // Processing is done in two parts, the first part is calculated inside
+    // the KeyKontrol class and effects the visual key/pitch widgets.
+    // The Speed slider controls the tempoRatio and a speedSliderPitchRatio,
+    // the pitch amount caused by it.
+    // By default the speed slider controls pitch and tempo with the same
+    // value.
+    // If key lock is enabled, the speedSliderPitchRatio is decoupled from
+    // the speed slider (const).
+    //
+    // With preference mode KeylockMode = kLockOriginalKey
+    // the speedSliderPitchRatio is reset to 1 and back to the tempoRatio
+    // (natural vinyl Pitch) when keylock is disabled and enabled.
+    //
+    // With preference mode KeylockMode = kCurrentKey
+    // the speedSliderPitchRatio is not reseted when keylock is enabled.
+    // This mode allows to enable keylock
+    // while the track is already played. You can reset to the tracks
+    // original pitch by resetting the pitch knob to center. When disabling
+    // keylock the pitch is reset to the linear vinyl pitch.
+
+    // The Pitch knob turns if the speed slider is moved without keylock.
+    // This is useful to get always an analog impression of current pitch,
+    // and its distance to the original track pitch
+    //
+    // The Pitch_Adjust knob does not reflect the speedSliderPitchRatio.
+    // So it is is useful for controller mappings, because it is not
+    // changed by the speed slider or keylock.
+
+    // In the second part all other speed changing controls are processed.
+    // They may produce an additional pitch if keylock is disabled or
+    // override the pitch in scratching case.
+    // If pitch ratio and tempo ratio are equal, a linear scaler is used,
+    // otherwise tempo and pitch are processed individual
+
+    // If we were scratching, and scratching is over, and we're a follower,
+    // and we're quantized, and not paused,
+    // we need to sync phase or we'll be totally out of whack and the sync
+    // adjuster will kick in and push the track back in to sync with the
+    // master.
+    if (m_scratching_old && !is_scratching && m_pQuantize->toBool()
+            && m_pSyncControl->getSyncMode() == SYNC_FOLLOWER && !paused) {
+        // TODO() The resulting seek is processed in the following callback
+        // That is to late
+        requestSyncPhase();
+    }
+
+    double rate = 0;
+    // If the baserate, speed, or pitch has changed, we need to update the
+    // scaler. Also, if we have changed scalers then we need to update the
+    // scaler.
+    if (baserate != m_baserate_old || speed != m_speed_old ||
+            pitchRatio != m_pitch_old || tempoRatio != m_tempo_ratio_old ||
+            m_bScalerChanged) {
+        // The rate returned by the scale object can be different from the
+        // wanted rate!  Make sure new scaler has proper position. This also
+        // crossfades between the old scaler and new scaler to prevent
+        // clicks.
+
+        // Handle direction change.
+        // The linear scaler supports ramping though zero.
+        // This is used for scratching, but not for reverse
+        // For the other, crossfade forward and backward samples
+        if ((m_speed_old * speed < 0) &&  // Direction has changed!
+                (m_pScale != m_pScaleVinyl || // only m_pScaleLinear supports going though 0
+                       m_reverse_old != is_reverse)) { // no pitch change when reversing
+            //XXX: Trying to force RAMAN to read from correct
+            //     playpos when rate changes direction - Albert
+            readToCrossfadeBuffer(iBufferSize);
+            // Clear the scaler information
+            m_pScale->clear();
+        }
+
+        m_baserate_old = baserate;
+        m_speed_old = speed;
+        m_pitch_old = pitchRatio;
+        m_tempo_ratio_old = tempoRatio;
+        m_reverse_old = is_reverse;
+
+        // Now we need to update the scaler with the master sample rate, the
+        // base rate (ratio between sample rate of the source audio and the
+        // master samplerate), the deck speed, the pitch shift, and whether
+        // the deck speed should affect the pitch.
+
+            m_pScale->setScaleParameters(baserate,
+                                         &speed,
+                                         &pitchRatio);
+
+        // The way we treat rate inside of EngineBuffer is actually a
+        // description of "sample consumption rate" or percentage of samples
+        // consumed relative to playing back the track at its native sample
+        // rate and normal speed. pitch_adjust does not change the playback
+        // rate.
+        rate = baserate * speed;
+
+        // Scaler is up to date now.
+        m_bScalerChanged = false;
+    } else {
+        // Scaler did not need updating. By definition this means we are at
+        // our old rate.
+        rate = m_rate_old;
+    }
+
+    bool at_start = m_filepos_play <= 0;
+    bool at_end = m_filepos_play >= m_trackSamplesOld;
+    bool backwards = rate < 0;
+
+    bool bCurBufferPaused = false;
+    if (at_end && !backwards) {
+        // do not play past end
+        bCurBufferPaused = true;
+    } else if (rate == 0 && !is_scratching) {
+        // do not process samples if have no transport
+        // the linear scaler supports ramping down to 0
+        // this is used for pause by scratching only
+        bCurBufferPaused = true;
+    }
+
+    m_rate_old = rate;
+
+    // If the buffer is not paused, then scale the audio.
+    if (!bCurBufferPaused) {
+        // Perform scaling of Reader buffer into buffer.
+        double framesRead =
+                m_pScale->scaleBuffer(pOutput, iBufferSize);
+
+        // TODO(XXX): The result framesRead might not be an integer value.
+        // Converting to samples here does not make sense. All positional
+        // calculations should be done in frames instead of samples! Otherwise
+        // rounding errors might occur when converting from samples back to
+        // frames later.
+        double samplesRead = framesRead * kSamplesPerFrame;
+
+        if (m_bScalerOverride) {
+            // If testing, we don't have a real log so we fake the position.
+            m_filepos_play += samplesRead;
+        } else {
+            // Adjust filepos_play by the amount we processed.
+            m_filepos_play =
+                    m_pReadAheadManager->getFilePlaypositionFromLog(
+                            m_filepos_play, samplesRead);
+        }
+        if (m_bCrossfadeReady) {
+           SampleUtil::linearCrossfadeBuffers(
+                    pOutput, m_pCrossfadeBuffer, pOutput, iBufferSize);
+        }
+        // Note: we do not fade here if we pass the end or the start of
+        // the track in reverse direction
+        // because we assume that the track samples itself start and stop
+        // towards zero.
+        // If it turns out that ramping is required be aware that the end
+        // or start may pass in the middle of the buffer.
+    } else {
+        // Pause
+        if (m_bCrossfadeReady) {
+            // We don't ramp here, since EnginePregain handles fades
+            // from and to speed == 0
+            SampleUtil::copy(pOutput, m_pCrossfadeBuffer, iBufferSize);
+        } else {
+            SampleUtil::clear(pOutput, iBufferSize);
+        }
+    }
+
+    for (const auto& pControl: m_engineControls) {
+        pControl->setCurrentSample(m_filepos_play, m_trackSamplesOld);
+        pControl->process(rate, m_filepos_play, m_trackSamplesOld, iBufferSize);
+    }
+
+    m_scratching_old = is_scratching;
+
+    // Handle repeat mode
+    at_start = m_filepos_play <= 0;
+    at_end = m_filepos_play >= m_trackSamplesOld;
+
+    bool repeat_enabled = m_pRepeat->get() != 0.0;
+
+    bool end_of_track = //(at_start && backwards) ||
+            (at_end && !backwards);
+
+    // If playbutton is pressed, check if we are at start or end of track
+        if ((m_playButton->get() || (m_fwdButton->get() || m_backButton->get()))
+                && end_of_track) {
+        if (repeat_enabled) {
+            double fractionalPos = at_start ? 1.0 : 0;
+            doSeekFractional(fractionalPos, SEEK_STANDARD);
+        } else {
+            m_playButton->set(0.);
+        }
+    }
+
+    // Give the Reader hints as to which chunks of the current song we
+    // really care about. It will try very hard to keep these in memory
+    hintReader(rate);
+}
+
 void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
     // Bail if we receive a buffer size with incomplete sample frames. Assert in debug builds.
     VERIFY_OR_DEBUG_ASSERT((iBufferSize % kSamplesPerFrame) == 0) {
@@ -740,8 +1038,6 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
     // - Set last sample value (m_fLastSampleValue) so that rampOut works? Other
     //   miscellaneous upkeep issues.
 
-    bool bCurBufferPaused = false;
-    double rate = 0;
     int sample_rate = static_cast<int>(m_pSampleRate->get());
 
     // If the sample rate has changed, force Rubberband to reset so that
@@ -756,304 +1052,11 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
 
     bool bTrackLoading = load_atomic(m_iTrackLoading) != 0;
     if (!bTrackLoading && m_pause.tryLock()) {
-        ScopedTimer t("EngineBuffer::process_pauselock");
-
-        double baserate = 0.0;
-        if (sample_rate > 0) {
-            baserate = ((double)m_trackSampleRateOld / sample_rate);
-        }
-
-        // Note: play is also active during cue preview
-        bool paused = !m_playButton->toBool();
-        KeyControl::PitchTempoRatio pitchTempoRatio = m_pKeyControl->getPitchTempoRatio();
-
-        // The pitch adjustment in Ratio (1.0 being normal
-        // pitch. 2.0 is a full octave shift up).
-        double pitchRatio = pitchTempoRatio.pitchRatio;
-        double tempoRatio = pitchTempoRatio.tempoRatio;
-        const bool keylock_enabled = pitchTempoRatio.keylock;
-
-        bool is_scratching = false;
-        bool is_reverse = false;
-
-        // Update the slipped position and seek if it was disabled.
-        processSlip(iBufferSize);
-        processSyncRequests();
-
-        // Note: This may effects the m_filepos_play, play, scaler and crossfade buffer
-        processSeek(paused);
-
-        // speed is the ratio between track-time and real-time
-        // (1.0 being normal rate. 2.0 plays at 2x speed -- 2 track seconds
-        // pass for every 1 real second). Depending on whether
-        // keylock is enabled, this is applied to either the rate or the tempo.
-        double speed = m_pRateControl->calculateSpeed(
-                baserate, tempoRatio, paused, iBufferSize, &is_scratching, &is_reverse);
-
-        // The cue indicator may change when scratch state is changed
-        if (is_scratching != m_scratching_old) {
-            m_pCueControl->updateIndicators();
-        }
-
-        bool useIndependentPitchAndTempoScaling = false;
-
-        // TODO(owen): Maybe change this so that rubberband doesn't disable
-        // keylock on scratch. (just check m_pScaleKeylock == m_pScaleST)
-        if (is_scratching || fabs(speed) > 1.9) {
-            // Scratching and high speeds with always disables keylock
-            // because Soundtouch sounds terrible in these conditions.  Rubberband
-            // sounds better, but still has some problems (it may reallocate in
-            // a party-crashing manner at extremely slow speeds).
-            // High seek speeds also disables keylock.  Our pitch slider could go
-            // to 90%, so that's the cutoff point.
-
-            // Force pitchRatio to the linear pitch set by speed
-            pitchRatio = speed;
-            // This is for the natural speed pitch found on turn tables
-        } else if (fabs(speed) < 0.1) {
-            // We have pre-allocated big buffers in Rubberband and Soundtouch for
-            // a minimum speed of 0.1. Slower speeds will re-allocate much bigger
-            // buffers which may cause underruns.
-            // Disable keylock under these conditions.
-
-            // Force pitchRatio to the linear pitch set by speed
-            pitchRatio = speed;
-        } else if (keylock_enabled) {
-            // always use IndependentPitchAndTempoScaling
-            // to avoid clicks when crossing the linear pitch
-            // in this case it is most likely that the user
-            // will have an non linear pitch
-            // Note: We have undesired noise when cossfading between scalers
-            useIndependentPitchAndTempoScaling = true;
-        } else {
-            // We might have have temporary speed change, so adjust pitch if not locked
-            // Note: This will not update key and tempo widgets
-            if (tempoRatio) {
-                pitchRatio *= (speed / tempoRatio);
-            }
-
-            // Check if we are off-linear (musical key has been adjusted
-            // independent from speed) to determine if the keylock scaler
-            // should be used even though keylock is disabled.
-            if (speed != 0.0) {
-                double offlinear = pitchRatio / speed;
-                if (offlinear > kLinearScalerElipsis ||
-                        offlinear < 1 / kLinearScalerElipsis) {
-                    // only enable keylock scaler if pitch adjustment is at
-                    // least 1 cent. Everything below is not hear-able.
-                    useIndependentPitchAndTempoScaling = true;
-                }
-            }
-        }
-
-        if (speed != 0.0) {
-            // Do not switch scaler when we have no transport
-            enableIndependentPitchTempoScaling(useIndependentPitchAndTempoScaling,
-                                               iBufferSize);
-        } else if (m_speed_old && !is_scratching) {
-            // we are stopping, collect samples for fade out
-            readToCrossfadeBuffer(iBufferSize);
-            // Clear the scaler information
-            m_pScale->clear();
-        }
-
-        // How speed/tempo/pitch are related:
-        // Processing is done in two parts, the first part is calculated inside
-        // the KeyKontrol class and effects the visual key/pitch widgets.
-        // The Speed slider controls the tempoRatio and a speedSliderPitchRatio,
-        // the pitch amount caused by it.
-        // By default the speed slider controls pitch and tempo with the same
-        // value.
-        // If key lock is enabled, the speedSliderPitchRatio is decoupled from
-        // the speed slider (const).
-        //
-        // With preference mode KeylockMode = kLockOriginalKey
-        // the speedSliderPitchRatio is reset to 1 and back to the tempoRatio
-        // (natural vinyl Pitch) when keylock is disabled and enabled.
-        //
-        // With preference mode KeylockMode = kCurrentKey
-        // the speedSliderPitchRatio is not reseted when keylock is enabled.
-        // This mode allows to enable keylock
-        // while the track is already played. You can reset to the tracks
-        // original pitch by resetting the pitch knob to center. When disabling
-        // keylock the pitch is reset to the linear vinyl pitch.
-
-        // The Pitch knob turns if the speed slider is moved without keylock.
-        // This is useful to get always an analog impression of current pitch,
-        // and its distance to the original track pitch
-        //
-        // The Pitch_Adjust knob does not reflect the speedSliderPitchRatio.
-        // So it is is useful for controller mappings, because it is not
-        // changed by the speed slider or keylock.
-
-        // In the second part all other speed changing controls are processed.
-        // They may produce an additional pitch if keylock is disabled or
-        // override the pitch in scratching case.
-        // If pitch ratio and tempo ratio are equal, a linear scaler is used,
-        // otherwise tempo and pitch are processed individual
-
-        // If we were scratching, and scratching is over, and we're a follower,
-        // and we're quantized, and not paused,
-        // we need to sync phase or we'll be totally out of whack and the sync
-        // adjuster will kick in and push the track back in to sync with the
-        // master.
-        if (m_scratching_old && !is_scratching && m_pQuantize->toBool()
-                && m_pSyncControl->getSyncMode() == SYNC_FOLLOWER && !paused) {
-            // TODO() The resulting seek is processed in the following callback
-            // That is to late
-            requestSyncPhase();
-        }
-
-        // If the baserate, speed, or pitch has changed, we need to update the
-        // scaler. Also, if we have changed scalers then we need to update the
-        // scaler.
-        if (baserate != m_baserate_old || speed != m_speed_old ||
-                pitchRatio != m_pitch_old || tempoRatio != m_tempo_ratio_old ||
-                m_bScalerChanged) {
-            // The rate returned by the scale object can be different from the
-            // wanted rate!  Make sure new scaler has proper position. This also
-            // crossfades between the old scaler and new scaler to prevent
-            // clicks.
-
-            // Handle direction change.
-            // The linear scaler supports ramping though zero.
-            // This is used for scratching, but not for reverse
-            // For the other, crossfade forward and backward samples
-            if ((m_speed_old * speed < 0) &&  // Direction has changed!
-                    (m_pScale != m_pScaleVinyl || // only m_pScaleLinear supports going though 0
-                           m_reverse_old != is_reverse)) { // no pitch change when reversing
-                //XXX: Trying to force RAMAN to read from correct
-                //     playpos when rate changes direction - Albert
-                readToCrossfadeBuffer(iBufferSize);
-                // Clear the scaler information
-                m_pScale->clear();
-            }
-
-            m_baserate_old = baserate;
-            m_speed_old = speed;
-            m_pitch_old = pitchRatio;
-            m_tempo_ratio_old = tempoRatio;
-            m_reverse_old = is_reverse;
-
-            // Now we need to update the scaler with the master sample rate, the
-            // base rate (ratio between sample rate of the source audio and the
-            // master samplerate), the deck speed, the pitch shift, and whether
-            // the deck speed should affect the pitch.
-
-            m_pScale->setScaleParameters(baserate,
-                                         &speed,
-                                         &pitchRatio);
-
-            // The way we treat rate inside of EngineBuffer is actually a
-            // description of "sample consumption rate" or percentage of samples
-            // consumed relative to playing back the track at its native sample
-            // rate and normal speed. pitch_adjust does not change the playback
-            // rate.
-            rate = baserate * speed;
-
-            // Scaler is up to date now.
-            m_bScalerChanged = false;
-        } else {
-            // Scaler did not need updating. By definition this means we are at
-            // our old rate.
-            rate = m_rate_old;
-        }
-
-        bool at_start = m_filepos_play <= 0;
-        bool at_end = m_filepos_play >= m_trackSamplesOld;
-        bool backwards = rate < 0;
-
-        if (at_end && !backwards) {
-            // do not play past end
-            bCurBufferPaused = true;
-        } else if (rate == 0 && !is_scratching) {
-            // do not process samples if have no transport
-            // the linear scaler supports ramping down to 0
-            // this is used for pause by scratching only
-            bCurBufferPaused = true;
-        }
-
-        m_rate_old = rate;
-
-        // If the buffer is not paused, then scale the audio.
-        if (!bCurBufferPaused) {
-            // Perform scaling of Reader buffer into buffer.
-            double framesRead =
-                    m_pScale->scaleBuffer(pOutput, iBufferSize);
-
-            // TODO(XXX): The result framesRead might not be an integer value.
-            // Converting to samples here does not make sense. All positional
-            // calculations should be done in frames instead of samples! Otherwise
-            // rounding errors might occur when converting from samples back to
-            // frames later.
-            double samplesRead = framesRead * kSamplesPerFrame;
-
-            if (m_bScalerOverride) {
-                // If testing, we don't have a real log so we fake the position.
-                m_filepos_play += samplesRead;
-            } else {
-                // Adjust filepos_play by the amount we processed.
-                m_filepos_play =
-                        m_pReadAheadManager->getFilePlaypositionFromLog(
-                                m_filepos_play, samplesRead);
-            }
-            if (m_bCrossfadeReady) {
-                SampleUtil::linearCrossfadeBuffers(
-                        pOutput, m_pCrossfadeBuffer, pOutput, iBufferSize);
-            }
-            // Note: we do not fade here if we pass the end or the start of
-            // the track in reverse direction
-            // because we assume that the track samples itself start and stop
-            // towards zero.
-            // If it turns out that ramping is required be aware that the end
-            // or start may pass in the middle of the buffer.
-        } else {
-            // Pause
-            if (m_bCrossfadeReady) {
-                // We don't ramp here, since EnginePregain handles fades
-                // from and to speed == 0
-                SampleUtil::copy(pOutput, m_pCrossfadeBuffer, iBufferSize);
-            } else {
-                SampleUtil::clear(pOutput, iBufferSize);
-            }
-        }
-
-        for (const auto& pControl: m_engineControls) {
-            pControl->setCurrentSample(m_filepos_play, m_trackSamplesOld);
-            pControl->process(rate, m_filepos_play, m_trackSamplesOld, iBufferSize);
-        }
-
-        m_scratching_old = is_scratching;
-
-        // Handle repeat mode
-        at_start = m_filepos_play <= 0;
-        at_end = m_filepos_play >= m_trackSamplesOld;
-
-        bool repeat_enabled = m_pRepeat->get() != 0.0;
-
-        bool end_of_track = //(at_start && backwards) ||
-            (at_end && !backwards);
-
-        // If playbutton is pressed, check if we are at start or end of track
-        if ((m_playButton->get() || (m_fwdButton->get() || m_backButton->get()))
-                && end_of_track) {
-            if (repeat_enabled) {
-                double fractionalPos = at_start ? 1.0 : 0;
-                doSeekFractional(fractionalPos, SEEK_STANDARD);
-            } else {
-                m_playButton->set(0.);
-            }
-        }
-
-        // Give the Reader hints as to which chunks of the current song we
-        // really care about. It will try very hard to keep these in memory
-        hintReader(rate);
-
+        processTrackLocked(pOutput, iBufferSize, sample_rate);
         // release the pauselock
         m_pause.unlock();
-    } else { // if (!bTrackLoading && m_pause.tryLock()) {
+    } else {
         // We are loading a new Track
-        bCurBufferPaused = true;
 
         // Here the old track was playing and loading the new track is in
         // progress. We can't predict when it happens, so we are not able

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -561,7 +561,7 @@ void EngineBuffer::ejectTrack() {
     m_timeElapsed->set(0);
     m_timeRemaining->set(0);
     m_playposSlider->set(0);
-    m_pCueControl->updateIndicators();
+    m_pCueControl->resetIndicators();
     doSeekFractional(0.0, SEEK_EXACT);
     m_pause.unlock();
 
@@ -753,11 +753,6 @@ void EngineBuffer::processTrackLocked(
     double speed = m_pRateControl->calculateSpeed(
             baserate, tempoRatio, paused, iBufferSize, &is_scratching, &is_reverse);
 
-    // The cue indicator may change when scratch state is changed
-    if (is_scratching != m_scratching_old) {
-        m_pCueControl->updateIndicators();
-    }
-
     bool useIndependentPitchAndTempoScaling = false;
 
     // TODO(owen): Maybe change this so that rubberband doesn't disable
@@ -904,9 +899,9 @@ void EngineBuffer::processTrackLocked(
         // master samplerate), the deck speed, the pitch shift, and whether
         // the deck speed should affect the pitch.
 
-            m_pScale->setScaleParameters(baserate,
-                                         &speed,
-                                         &pitchRatio);
+        m_pScale->setScaleParameters(baserate,
+                                     &speed,
+                                     &pitchRatio);
 
         // The way we treat rate inside of EngineBuffer is actually a
         // description of "sample consumption rate" or percentage of samples

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -235,6 +235,7 @@ class EngineBuffer : public EngineObject {
 
     bool updateIndicatorsAndModifyPlay(bool newPlay);
     void verifyPlay();
+    void notifyTrackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
     // Holds the name of the control group
     QString m_group;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -342,7 +342,7 @@ class EngineBuffer : public EngineObject {
     ControlObject* m_timeElapsed;
     ControlObject* m_timeRemaining;
     ControlPotmeter* m_playposSlider;
-    ControlProxy* m_pMasterSampleRate;
+    ControlProxy* m_pSampleRate;
     ControlProxy* m_pKeylockEngine;
     ControlPushButton* m_pKeylock;
 

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -236,12 +236,13 @@ class EngineBuffer : public EngineObject {
     bool updateIndicatorsAndModifyPlay(bool newPlay);
     void verifyPlay();
     void notifyTrackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
+    void processTrackLocked(CSAMPLE* pOutput, const int iBufferSize, int sample_rate);
 
     // Holds the name of the control group
     QString m_group;
     UserSettingsPointer m_pConfig;
 
-    LoopingControl* m_pLoopingControl;
+    LoopingControl* m_pLoopingControl; // used for testes
     FRIEND_TEST(LoopingControlTest, LoopScale_HalvesLoop);
     FRIEND_TEST(LoopingControlTest, LoopMoveTest);
     FRIEND_TEST(LoopingControlTest, LoopResizeSeek);

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -305,7 +305,7 @@ class EngineBuffer : public EngineObject {
     int m_trackSamplesOld;
 
     // Copy of file sample rate
-    int m_trackSampleRateOld;
+    double m_trackSampleRateOld;
 
     // Mutex controlling weather the process function is in pause mode. This happens
     // during seek and loading of a new track

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -342,7 +342,7 @@ class EngineBuffer : public EngineObject {
     ControlObject* m_timeElapsed;
     ControlObject* m_timeRemaining;
     ControlPotmeter* m_playposSlider;
-    ControlProxy* m_pSampleRate;
+    ControlProxy* m_pMasterSampleRate;
     ControlProxy* m_pKeylockEngine;
     ControlPushButton* m_pKeylock;
 

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -29,9 +29,8 @@ void EngineControl::process(const double dRate,
     Q_UNUSED(iBufferSize);
 }
 
-void EngineControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+void EngineControl::trackLoaded(TrackPointer pNewTrack) {
     Q_UNUSED(pNewTrack);
-    Q_UNUSED(pOldTrack);
 }
 
 void EngineControl::hintReader(HintVector*) {

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -59,6 +59,10 @@ double EngineControl::getTotalSamples() const {
     return m_sampleOfTrack.getValue().total;
 }
 
+double EngineControl::getTrackSampleRate() const {
+    return m_sampleOfTrack.getValue().rate;
+}
+
 bool EngineControl::atEndPosition() const {
     SampleOfTrack sot = m_sampleOfTrack.getValue();
     return (sot.current >= sot.total);

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -21,11 +21,9 @@ EngineControl::~EngineControl() {
 
 void EngineControl::process(const double dRate,
                            const double dCurrentSample,
-                           const double dTotalSamples,
                            const int iBufferSize) {
     Q_UNUSED(dRate);
     Q_UNUSED(dCurrentSample);
-    Q_UNUSED(dTotalSamples);
     Q_UNUSED(iBufferSize);
 }
 

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -11,8 +11,8 @@ EngineControl::EngineControl(QString group,
                              UserSettingsPointer pConfig)
         : m_group(group),
           m_pConfig(pConfig),
-          m_pEngineMaster(NULL),
-          m_pEngineBuffer(NULL) {
+          m_pEngineMaster(nullptr),
+          m_pEngineBuffer(nullptr) {
     setCurrentSample(0.0, 0.0);
 }
 

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -51,23 +51,6 @@ void EngineControl::setCurrentSample(
     m_sampleOfTrack.setValue(sot);
 }
 
-double EngineControl::getCurrentSample() const {
-    return m_sampleOfTrack.getValue().current;
-}
-
-double EngineControl::getTotalSamples() const {
-    return m_sampleOfTrack.getValue().total;
-}
-
-double EngineControl::getTrackSampleRate() const {
-    return m_sampleOfTrack.getValue().rate;
-}
-
-bool EngineControl::atEndPosition() const {
-    SampleOfTrack sot = m_sampleOfTrack.getValue();
-    return (sot.current >= sot.total);
-}
-
 QString EngineControl::getGroup() const {
     return m_group;
 }

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -13,7 +13,7 @@ EngineControl::EngineControl(QString group,
           m_pConfig(pConfig),
           m_pEngineMaster(nullptr),
           m_pEngineBuffer(nullptr) {
-    setCurrentSample(0.0, 0.0);
+    setCurrentSample(0.0, 0.0, 0.0);
 }
 
 EngineControl::~EngineControl() {
@@ -42,10 +42,12 @@ void EngineControl::setEngineBuffer(EngineBuffer* pEngineBuffer) {
     m_pEngineBuffer = pEngineBuffer;
 }
 
-void EngineControl::setCurrentSample(const double dCurrentSample, const double dTotalSamples) {
+void EngineControl::setCurrentSample(
+        const double dCurrentSample, const double dTotalSamples, const double dTrackSampleRate) {
     SampleOfTrack sot;
     sot.current = dCurrentSample;
     sot.total = dTotalSamples;
+    sot.rate = dTrackSampleRate;
     m_sampleOfTrack.setValue(sot);
 }
 

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -53,7 +53,8 @@ class EngineControl : public QObject {
 
     virtual void setEngineMaster(EngineMaster* pEngineMaster);
     void setEngineBuffer(EngineBuffer* pEngineBuffer);
-    virtual void setCurrentSample(const double dCurrentSample, const double dTotalSamples);
+    virtual void setCurrentSample(const double dCurrentSample,
+            const double dTotalSamples, const double dTrackSampleRate);
     double getCurrentSample() const;
     double getTotalSamples() const;
     bool atEndPosition() const;
@@ -86,6 +87,7 @@ class EngineControl : public QObject {
     struct SampleOfTrack {
         double current;
         double total;
+        double rate;
     };
 
     ControlValueAtomic<SampleOfTrack> m_sampleOfTrack;

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -67,7 +67,7 @@ class EngineControl : public QObject {
 
     // Called whenever a seek occurs to allow the EngineControl to respond.
     virtual void notifySeek(double dNewPlaypo, bool adjustingPhase);
-    virtual void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
+    virtual void trackLoaded(TrackPointer pNewTrack);
 
   protected:
     void seek(double fractionalPosition);

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -67,8 +67,6 @@ class EngineControl : public QObject {
 
     // Called whenever a seek occurs to allow the EngineControl to respond.
     virtual void notifySeek(double dNewPlaypo, bool adjustingPhase);
-
-  public slots:
     virtual void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
   protected:

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -43,9 +43,8 @@ class EngineControl : public QObject {
     // EngineControl can perform any upkeep operations that are necessary during
     // this call.
     virtual void process(const double dRate,
-                           const double dCurrentSample,
-                           const double dTotalSamples,
-                           const int iBufferSize);
+                         const double dCurrentSample,
+                         const int iBufferSize);
 
     // hintReader allows the EngineControl to provide hints to the reader to
     // indicate that the given portion of a song is a potential imminent seek

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -57,6 +57,7 @@ class EngineControl : public QObject {
             const double dTotalSamples, const double dTrackSampleRate);
     double getCurrentSample() const;
     double getTotalSamples() const;
+    double getTrackSampleRate() const;
     bool atEndPosition() const;
     QString getGroup() const;
 

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -7,6 +7,8 @@
 #include <QObject>
 #include <QList>
 
+#include <gtest/gtest_prod.h>
+
 #include "preferences/usersettings.h"
 #include "track/track.h"
 #include "control/controlvalue.h"
@@ -55,10 +57,6 @@ class EngineControl : public QObject {
     void setEngineBuffer(EngineBuffer* pEngineBuffer);
     virtual void setCurrentSample(const double dCurrentSample,
             const double dTotalSamples, const double dTrackSampleRate);
-    double getCurrentSample() const;
-    double getTotalSamples() const;
-    double getTrackSampleRate() const;
-    bool atEndPosition() const;
     QString getGroup() const;
 
     // Called to collect player features for effects processing.
@@ -71,6 +69,15 @@ class EngineControl : public QObject {
     virtual void trackLoaded(TrackPointer pNewTrack);
 
   protected:
+    struct SampleOfTrack {
+        double current;
+        double total;
+        double rate;
+    };
+
+    SampleOfTrack getSampleOfTrack() const {
+        return m_sampleOfTrack.getValue();
+    }
     void seek(double fractionalPosition);
     void seekAbs(double sample);
     // Seek to an exact sample and don't allow quantizing adjustment.
@@ -85,15 +92,17 @@ class EngineControl : public QObject {
     UserSettingsPointer m_pConfig;
 
   private:
-    struct SampleOfTrack {
-        double current;
-        double total;
-        double rate;
-    };
-
     ControlValueAtomic<SampleOfTrack> m_sampleOfTrack;
     EngineMaster* m_pEngineMaster;
     EngineBuffer* m_pEngineBuffer;
+
+
+    FRIEND_TEST(LoopingControlTest, ReloopToggleButton_DoesNotJumpAhead);
+    FRIEND_TEST(LoopingControlTest, ReloopAndStopButton);
+    FRIEND_TEST(LoopingControlTest, LoopScale_HalvesLoop);
+    FRIEND_TEST(LoopingControlTest, LoopMoveTest);
+    FRIEND_TEST(LoopingControlTest, LoopResizeSeek);
+    FRIEND_TEST(LoopingControlTest, Beatjump_JumpsByBeats);
 };
 
 #endif /* ENGINECONTROL_H */

--- a/src/engine/keycontrol.h
+++ b/src/engine/keycontrol.h
@@ -66,14 +66,13 @@ class KeyControl : public EngineControl {
     ControlPushButton* m_keylockMode;
     ControlPushButton* m_keyunlockMode;
 
-    /** The current loaded file's detected key */
+    // The current loaded file's detected key
     ControlObject* m_pFileKey;
 
-    /** The current effective key of the engine */
+    // The current effective key of the engine
     ControlObject* m_pEngineKey;
     ControlPotmeter* m_pEngineKeyDistance;
 
-    TrackPointer m_pTrack;
     struct PitchTempoRatio m_pitchRateInfo;
     QAtomicInt m_updatePitchRequest;
     QAtomicInt m_updatePitchAdjustRequest;

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -801,9 +801,7 @@ void LoopingControl::setLoopingEnabled(bool enabled) {
     }
 }
 
-void LoopingControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
-    Q_UNUSED(pOldTrack);
-
+void LoopingControl::trackLoaded(TrackPointer pNewTrack) {
     if (m_pTrack) {
         disconnect(m_pTrack.get(), SIGNAL(beatsUpdated()),
                    this, SLOT(slotUpdatedTrackBeats()));

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -304,10 +304,8 @@ void LoopingControl::slotLoopDouble(double pressed) {
 }
 
 void LoopingControl::process(const double dRate,
-                               const double currentSample,
-                               const double totalSamples,
-                               const int iBufferSize) {
-    Q_UNUSED(totalSamples);
+                             const double currentSample,
+                             const int iBufferSize) {
     Q_UNUSED(iBufferSize);
     Q_UNUSED(dRate);
 

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -158,7 +158,7 @@ class LoopingControl : public EngineControl {
     QList<LoopMoveControl*> m_loopMoves;
 
     TrackPointer m_pTrack; // is witten from an engine worker thread
-    BeatsPointer m_pBeats;
+    BeatsPointer m_pBeats; // is witten from an engine worker thread
 };
 
 // Class for handling loop moves of a set size. This allows easy access from

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -157,8 +157,9 @@ class LoopingControl : public EngineControl {
     ControlObject* m_pCOLoopMove;
     QList<LoopMoveControl*> m_loopMoves;
 
-    TrackPointer m_pTrack; // is witten from an engine worker thread
-    BeatsPointer m_pBeats; // is witten from an engine worker thread
+    // objects below are written from an engine worker thread
+    TrackPointer m_pTrack;
+    BeatsPointer m_pBeats;
 };
 
 // Class for handling loop moves of a set size. This allows easy access from

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -60,7 +60,7 @@ class LoopingControl : public EngineControl {
     void slotReloopAndStop(double);
     void slotLoopStartPos(double);
     void slotLoopEndPos(double);
-    virtual void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
+    void trackLoaded(TrackPointer pNewTrack) override;
     void slotUpdatedTrackBeats();
 
     // Generate a loop of 'beats' length. It can also do fractions for a
@@ -158,7 +158,7 @@ class LoopingControl : public EngineControl {
     ControlObject* m_pCOLoopMove;
     QList<LoopMoveControl*> m_loopMoves;
 
-    TrackPointer m_pTrack;
+    TrackPointer m_pTrack; // is witten from an engine worker thread
     BeatsPointer m_pBeats;
 };
 

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -35,7 +35,6 @@ class LoopingControl : public EngineControl {
     // the sample that should be seeked to. Otherwise it returns currentSample.
     void process(const double dRate,
                    const double currentSample,
-                   const double totalSamples,
                    const int iBufferSize) override;
 
     // nextTrigger returns the sample at which the engine will be triggered to

--- a/src/engine/quantizecontrol.cpp
+++ b/src/engine/quantizecontrol.cpp
@@ -32,8 +32,7 @@ QuantizeControl::~QuantizeControl() {
     delete m_pCOClosestBeat;
 }
 
-void QuantizeControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
-    Q_UNUSED(pOldTrack);
+void QuantizeControl::trackLoaded(TrackPointer pNewTrack) {
     if (m_pTrack) {
         disconnect(m_pTrack.get(), SIGNAL(beatsUpdated()),
                 this, SLOT(slotBeatsUpdated()));

--- a/src/engine/quantizecontrol.cpp
+++ b/src/engine/quantizecontrol.cpp
@@ -60,15 +60,16 @@ void QuantizeControl::slotBeatsUpdated() {
     TrackPointer pTrack = m_pTrack;
     if (pTrack) {
         m_pBeats = pTrack->getBeats();
-        lookupBeatPositions(getCurrentSample());
-        updateClosestBeat(getCurrentSample());
+        double current = getSampleOfTrack().current;
+        lookupBeatPositions(current);
+        updateClosestBeat(current);
     }
 }
 
 void QuantizeControl::setCurrentSample(const double dCurrentSample,
                                        const double dTotalSamples,
                                        const double dTrackSampleRate) {
-    if (dCurrentSample == getCurrentSample()) {
+    if (dCurrentSample == getSampleOfTrack().current) {
         // No need to recalculate.
         return;
     }

--- a/src/engine/quantizecontrol.cpp
+++ b/src/engine/quantizecontrol.cpp
@@ -57,8 +57,9 @@ void QuantizeControl::trackLoaded(TrackPointer pNewTrack) {
 }
 
 void QuantizeControl::slotBeatsUpdated() {
-    if (m_pTrack) {
-        m_pBeats = m_pTrack->getBeats();
+    TrackPointer pTrack = m_pTrack;
+    if (pTrack) {
+        m_pBeats = pTrack->getBeats();
         lookupBeatPositions(getCurrentSample());
         updateClosestBeat(getCurrentSample());
     }
@@ -85,9 +86,10 @@ void QuantizeControl::setCurrentSample(const double dCurrentSample,
 }
 
 void QuantizeControl::lookupBeatPositions(double dCurrentSample) {
-    if (m_pBeats) {
+    BeatsPointer pBeats = m_pBeats;
+    if (pBeats) {
         double prevBeat, nextBeat;
-        m_pBeats->findPrevNextBeats(dCurrentSample, &prevBeat, &nextBeat);
+        pBeats->findPrevNextBeats(dCurrentSample, &prevBeat, &nextBeat);
         m_pCOPrevBeat->set(prevBeat);
         m_pCONextBeat->set(nextBeat);
     }

--- a/src/engine/quantizecontrol.cpp
+++ b/src/engine/quantizecontrol.cpp
@@ -65,13 +65,14 @@ void QuantizeControl::slotBeatsUpdated() {
 }
 
 void QuantizeControl::setCurrentSample(const double dCurrentSample,
-                                       const double dTotalSamples) {
+                                       const double dTotalSamples,
+                                       const double dTrackSampleRate) {
     if (dCurrentSample == getCurrentSample()) {
         // No need to recalculate.
         return;
     }
 
-    EngineControl::setCurrentSample(dCurrentSample, dTotalSamples);
+    EngineControl::setCurrentSample(dCurrentSample, dTotalSamples, dTrackSampleRate);
     // We only need to update the prev or next if the current sample is
     // out of range of the existing beat positions or if we've been forced to
     // do so.

--- a/src/engine/quantizecontrol.h
+++ b/src/engine/quantizecontrol.h
@@ -19,7 +19,7 @@ class QuantizeControl : public EngineControl {
     ~QuantizeControl() override;
 
     void setCurrentSample(const double dCurrentSample,
-            const double dTotalSamples) override;
+            const double dTotalSamples, const double dTrackSampleRate) override;
     void trackLoaded(TrackPointer pNewTrack) override;
 
   private slots:

--- a/src/engine/quantizecontrol.h
+++ b/src/engine/quantizecontrol.h
@@ -20,9 +20,7 @@ class QuantizeControl : public EngineControl {
 
     void setCurrentSample(const double dCurrentSample,
             const double dTotalSamples) override;
-
-  public slots:
-    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
+    void trackLoaded(TrackPointer pNewTrack) override;
 
   private slots:
     void slotBeatsUpdated();
@@ -39,7 +37,7 @@ class QuantizeControl : public EngineControl {
     ControlObject* m_pCOPrevBeat;
     ControlObject* m_pCOClosestBeat;
 
-    TrackPointer m_pTrack;
+    TrackPointer m_pTrack; // is witten from an engine worker thread
     BeatsPointer m_pBeats;
 };
 

--- a/src/engine/quantizecontrol.h
+++ b/src/engine/quantizecontrol.h
@@ -37,8 +37,9 @@ class QuantizeControl : public EngineControl {
     ControlObject* m_pCOPrevBeat;
     ControlObject* m_pCOClosestBeat;
 
-    TrackPointer m_pTrack; // is witten from an engine worker thread
-    BeatsPointer m_pBeats; // is witten from an engine worker thread
+    // objects below are written from an engine worker thread
+    TrackPointer m_pTrack;
+    BeatsPointer m_pBeats;
 };
 
 #endif // QUANTIZECONTROL_H

--- a/src/engine/quantizecontrol.h
+++ b/src/engine/quantizecontrol.h
@@ -38,7 +38,7 @@ class QuantizeControl : public EngineControl {
     ControlObject* m_pCOClosestBeat;
 
     TrackPointer m_pTrack; // is witten from an engine worker thread
-    BeatsPointer m_pBeats;
+    BeatsPointer m_pBeats; // is witten from an engine worker thread
 };
 
 #endif // QUANTIZECONTROL_H

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -484,7 +484,7 @@ double RateControl::calculateSpeed(double baserate, double speed, bool paused,
             }
         }
 
-        double currentSample = getCurrentSample();
+        double currentSample = getSampleOfTrack().current;
         m_pScratchController->process(currentSample, rate, iSamplesPerBuffer, baserate);
 
         // If waveform scratch is enabled, override all other controls

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -533,13 +533,11 @@ double RateControl::calculateSpeed(double baserate, double speed, bool paused,
 }
 
 void RateControl::process(const double rate,
-                            const double currentSample,
-                            const double totalSamples,
-                            const int bufferSamples)
+                          const double currentSample,
+                          const int bufferSamples)
 {
     Q_UNUSED(rate);
     Q_UNUSED(currentSample);
-    Q_UNUSED(totalSamples);
     /*
      * Code to handle temporary rate change buttons.
      *

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -35,7 +35,6 @@ RateControl::RateControl(QString group,
       m_ePbCurrent(0),
       m_ePbPressed(0),
       m_bTempStarted(false),
-      m_dTempRateChange(0.0),
       m_dRateTemp(0.0),
       m_eRampBackMode(RATERAMP_RAMPBACK_NONE),
       m_dRateTempRampbackChange(0.0) {

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -393,8 +393,7 @@ void RateControl::slotControlRateTempUpSmall(double)
     }
 }
 
-void RateControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
-    Q_UNUSED(pOldTrack);
+void RateControl::trackLoaded(TrackPointer pNewTrack) {
     m_pTrack = pNewTrack;
 }
 

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -393,10 +393,6 @@ void RateControl::slotControlRateTempUpSmall(double)
     }
 }
 
-void RateControl::trackLoaded(TrackPointer pNewTrack) {
-    m_pTrack = pNewTrack;
-}
-
 double RateControl::calcRateRatio() const {
     double rateRatio = 1.0 + m_pRateDir->get() * m_pRateRange->get() *
             m_pRateSlider->get();

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -18,10 +18,10 @@
 #include <QtDebug>
 
 // Static default values for rate buttons (percents)
-double RateControl::m_dTemporaryRateChangeCoarse;
-double RateControl::m_dTemporaryRateChangeFine;
-double RateControl::m_dPermanentRateChangeCoarse;
-double RateControl::m_dPermanentRateChangeFine;
+ControlValueAtomic<double> RateControl::m_dTemporaryRateChangeCoarse;
+ControlValueAtomic<double> RateControl::m_dTemporaryRateChangeFine;
+ControlValueAtomic<double> RateControl::m_dPermanentRateChangeCoarse;
+ControlValueAtomic<double> RateControl::m_dPermanentRateChangeFine;
 int RateControl::m_iRateRampSensitivity;
 RateControl::RampMode RateControl::m_eRateRampMode;
 
@@ -233,42 +233,42 @@ void RateControl::setRateRampSensitivity(int sense) {
 
 //static
 void RateControl::setTemporaryRateChangeCoarseAmount(double v) {
-    m_dTemporaryRateChangeCoarse = v;
+    m_dTemporaryRateChangeCoarse.setValue(v);
 }
 
 //static
 void RateControl::setTemporaryRateChangeFineAmount(double v) {
-    m_dTemporaryRateChangeFine = v;
+    m_dTemporaryRateChangeFine.setValue(v);
 }
 
 //static
 void RateControl::setPermanentRateChangeCoarseAmount(double v) {
-    m_dPermanentRateChangeCoarse = v;
+    m_dPermanentRateChangeCoarse.setValue(v);
 }
 
 //static
 void RateControl::setPermanentRateChangeFineAmount(double v) {
-    m_dPermanentRateChangeFine = v;
+    m_dPermanentRateChangeFine.setValue(v);
 }
 
 //static
 double RateControl::getTemporaryRateChangeCoarseAmount() {
-    return m_dTemporaryRateChangeCoarse;
+    return m_dTemporaryRateChangeCoarse.getValue();
 }
 
 //static
 double RateControl::getTemporaryRateChangeFineAmount() {
-    return m_dTemporaryRateChangeFine;
+    return m_dTemporaryRateChangeFine.getValue();
 }
 
 //static
 double RateControl::getPermanentRateChangeCoarseAmount() {
-    return m_dPermanentRateChangeCoarse;
+    return m_dPermanentRateChangeCoarse.getValue();
 }
 
 //static
 double RateControl::getPermanentRateChangeFineAmount() {
-    return m_dPermanentRateChangeFine;
+    return m_dPermanentRateChangeFine.getValue();
 }
 
 void RateControl::slotReverseRollActivate(double v) {
@@ -304,7 +304,7 @@ void RateControl::slotControlRatePermDown(double)
     // Adjusts temp rate down if button pressed
     if (buttonRatePermDown->get()) {
         m_pRateSlider->set(m_pRateSlider->get() -
-                           m_pRateDir->get() * m_dPermanentRateChangeCoarse / (100 * m_pRateRange->get()));
+                           m_pRateDir->get() * m_dPermanentRateChangeCoarse.getValue() / (100 * m_pRateRange->get()));
     }
 }
 
@@ -313,7 +313,7 @@ void RateControl::slotControlRatePermDownSmall(double)
     // Adjusts temp rate down if button pressed
     if (buttonRatePermDownSmall->get())
         m_pRateSlider->set(m_pRateSlider->get() -
-                           m_pRateDir->get() * m_dPermanentRateChangeFine / (100. * m_pRateRange->get()));
+                           m_pRateDir->get() * m_dPermanentRateChangeFine.getValue() / (100. * m_pRateRange->get()));
 }
 
 void RateControl::slotControlRatePermUp(double)
@@ -321,7 +321,7 @@ void RateControl::slotControlRatePermUp(double)
     // Adjusts temp rate up if button pressed
     if (buttonRatePermUp->get()) {
         m_pRateSlider->set(m_pRateSlider->get() +
-                           m_pRateDir->get() * m_dPermanentRateChangeCoarse / (100. * m_pRateRange->get()));
+                           m_pRateDir->get() * m_dPermanentRateChangeCoarse.getValue() / (100. * m_pRateRange->get()));
     }
 }
 
@@ -330,7 +330,7 @@ void RateControl::slotControlRatePermUpSmall(double)
     // Adjusts temp rate up if button pressed
     if (buttonRatePermUpSmall->get())
         m_pRateSlider->set(m_pRateSlider->get() +
-                           m_pRateDir->get() * m_dPermanentRateChangeFine / (100. * m_pRateRange->get()));
+                           m_pRateDir->get() * m_dPermanentRateChangeFine.getValue() / (100. * m_pRateRange->get()));
 }
 
 void RateControl::slotControlRateTempDown(double)
@@ -378,16 +378,12 @@ void RateControl::slotControlRateTempUp(double)
     }
 }
 
-void RateControl::slotControlRateTempUpSmall(double)
-{
+void RateControl::slotControlRateTempUpSmall(double) {
     // Set the state of the Temporary button. Logic is handled in ::process()
-    if (buttonRateTempUpSmall->get() && !(m_ePbPressed & RateControl::RATERAMP_UP))
-    {
+    if (buttonRateTempUpSmall->get() && !(m_ePbPressed & RateControl::RATERAMP_UP)){
         m_ePbPressed |= RateControl::RATERAMP_UP;
         m_ePbCurrent = RateControl::RATERAMP_UP;
-    }
-    else if (!buttonRateTempUpSmall->get())
-    {
+    } else if (!buttonRateTempUpSmall->get()) {
         m_ePbPressed &= ~RateControl::RATERAMP_UP;
         m_ePbCurrent = m_ePbPressed;
     }
@@ -564,9 +560,9 @@ void RateControl::process(const double rate,
                 return;
             }
 
-            double change = m_pRateDir->get() * m_dTemporaryRateChangeCoarse /
+            double change = m_pRateDir->get() * m_dTemporaryRateChangeCoarse.getValue() /
                                     (100. * range);
-            double csmall = m_pRateDir->get() * m_dTemporaryRateChangeFine /
+            double csmall = m_pRateDir->get() * m_dTemporaryRateChangeFine.getValue() /
                                     (100. * range);
 
             if (buttonRateTempUp->get())
@@ -578,7 +574,8 @@ void RateControl::process(const double rate,
             else if (buttonRateTempDownSmall->get())
                 subRateTemp(csmall);
         } else if (m_eRateRampMode == RampMode::Linear) {
-            m_dTemporaryRateChangeCoarse = ((double)latrate / ((double)m_iRateRampSensitivity / 100.));
+            m_dTemporaryRateChangeCoarse.setValue(
+                    ((double)latrate / ((double)m_iRateRampSensitivity / 100.)));
 
             if (m_eRampBackMode == RATERAMP_RAMPBACK_PERIOD)
                 m_dRateTempRampbackChange = 0.0;
@@ -590,9 +587,9 @@ void RateControl::process(const double rate,
         if (m_ePbCurrent) {
             // apply ramped pitchbending
             if (m_ePbCurrent == RateControl::RATERAMP_UP) {
-                addRateTemp(m_dTemporaryRateChangeCoarse);
+                addRateTemp(m_dTemporaryRateChangeCoarse.getValue());
             } else if (m_ePbCurrent == RateControl::RATERAMP_DOWN) {
-                subRateTemp(m_dTemporaryRateChangeCoarse);
+                subRateTemp(m_dTemporaryRateChangeCoarse.getValue());
             }
         } else if ((m_bTempStarted)
                 || ((m_eRampBackMode != RATERAMP_RAMPBACK_NONE)

--- a/src/engine/ratecontrol.h
+++ b/src/engine/ratecontrol.h
@@ -174,8 +174,6 @@ public:
 
     // This is true if we've already started to ramp the rate
     bool m_bTempStarted;
-    // Set to the rate change used for rate temp
-    double m_dTempRateChange;
     // Set the Temporary Rate Change Mode
     static RampMode m_eRateRampMode;
     // The Rate Temp Sensitivity, the higher it is the slower it gets

--- a/src/engine/ratecontrol.h
+++ b/src/engine/ratecontrol.h
@@ -105,7 +105,6 @@ public:
     void slotControlRateTempUpSmall(double);
     void slotControlFastForward(double);
     void slotControlFastBack(double);
-    void trackLoaded(TrackPointer pNewTrack) override;
 
   private:
     double getJogFactor() const;
@@ -161,8 +160,6 @@ public:
     Rotary* m_pJogFilter;
 
     ControlObject* m_pSampleRate;
-
-    TrackPointer m_pTrack; // is witten from an engine worker thread
 
     // For Master Sync
     BpmControl* m_pBpmControl;

--- a/src/engine/ratecontrol.h
+++ b/src/engine/ratecontrol.h
@@ -63,9 +63,8 @@ public:
     // Must be called during each callback of the audio thread so that
     // RateControl has a chance to update itself.
     void process(const double dRate,
-                   const double currentSample,
-                   const double totalSamples,
-                   const int bufferSamples) override;
+                 const double currentSample,
+                 const int bufferSamples) override;
     // Returns the current engine rate.  "reportScratching" is used to tell
     // the caller that the user is currently scratching, and this is used to
     // disable keylock.

--- a/src/engine/ratecontrol.h
+++ b/src/engine/ratecontrol.h
@@ -123,10 +123,10 @@ public:
     double getTempRate(void);
 
     // Values used when temp and perm rate buttons are pressed
-    static double m_dTemporaryRateChangeCoarse;
-    static double m_dTemporaryRateChangeFine;
-    static double m_dPermanentRateChangeCoarse;
-    static double m_dPermanentRateChangeFine;
+    static ControlValueAtomic<double> m_dTemporaryRateChangeCoarse;
+    static ControlValueAtomic<double> m_dTemporaryRateChangeFine;
+    static ControlValueAtomic<double> m_dPermanentRateChangeCoarse;
+    static ControlValueAtomic<double> m_dPermanentRateChangeFine;
 
     ControlPushButton *buttonRateTempDown;
     ControlPushButton *buttonRateTempDownSmall;

--- a/src/engine/ratecontrol.h
+++ b/src/engine/ratecontrol.h
@@ -106,7 +106,7 @@ public:
     void slotControlRateTempUpSmall(double);
     void slotControlFastForward(double);
     void slotControlFastBack(double);
-    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
+    void trackLoaded(TrackPointer pNewTrack) override;
 
   private:
     double getJogFactor() const;
@@ -163,7 +163,7 @@ public:
 
     ControlObject* m_pSampleRate;
 
-    TrackPointer m_pTrack;
+    TrackPointer m_pTrack; // is witten from an engine worker thread
 
     // For Master Sync
     BpmControl* m_pBpmControl;

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -317,8 +317,7 @@ void SyncControl::reportTrackPosition(double fractionalPlaypos) {
     }
 }
 
-void SyncControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
-    Q_UNUSED(pOldTrack);
+void SyncControl::trackLoaded(TrackPointer pNewTrack) {
     //qDebug() << getGroup() << "SyncControl::trackLoaded";
     if (getSyncMode() == SYNC_MASTER) {
         // If we change or remove a new track while master, hand off.

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -57,9 +57,7 @@ class SyncControl : public EngineControl, public Syncable {
 
     void reportTrackPosition(double fractionalPlaypos);
     void reportPlayerSpeed(double speed, bool scratching);
-
-  public slots:
-    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
+    void trackLoaded(TrackPointer pNewTrack) override;
 
   private slots:
     // Fired by changes in play.

--- a/src/engine/vinylcontrolcontrol.cpp
+++ b/src/engine/vinylcontrolcontrol.cpp
@@ -62,8 +62,7 @@ VinylControlControl::~VinylControlControl() {
     delete m_pControlVinylStatus;
 }
 
-void VinylControlControl::trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) {
-    Q_UNUSED(pOldTrack);
+void VinylControlControl::trackLoaded(TrackPointer pNewTrack) {
     m_pCurrentTrack = pNewTrack;
 }
 

--- a/src/engine/vinylcontrolcontrol.cpp
+++ b/src/engine/vinylcontrolcontrol.cpp
@@ -89,8 +89,7 @@ void VinylControlControl::slotControlVinylSeek(double fractionalPos) {
         return;
     }
 
-
-    double total_samples = getTotalSamples();
+    double total_samples = getSampleOfTrack().total;
     double new_playpos = round(fractionalPos * total_samples);
 
     if (m_pControlVinylEnabled->get() > 0.0 && m_pControlVinylMode->get() == MIXXX_VCMODE_RELATIVE) {

--- a/src/engine/vinylcontrolcontrol.cpp
+++ b/src/engine/vinylcontrolcontrol.cpp
@@ -63,7 +63,7 @@ VinylControlControl::~VinylControlControl() {
 }
 
 void VinylControlControl::trackLoaded(TrackPointer pNewTrack) {
-    m_pCurrentTrack = pNewTrack;
+    m_pTrack = pNewTrack;
 }
 
 void VinylControlControl::notifySeekQueued() {
@@ -84,7 +84,8 @@ void VinylControlControl::slotControlVinylSeek(double fractionalPos) {
     }
 
     // Do nothing if no track is loaded.
-    if (!m_pCurrentTrack) {
+    TrackPointer pTrack = m_pTrack;
+    if (!pTrack) {
         return;
     }
 
@@ -106,7 +107,7 @@ void VinylControlControl::slotControlVinylSeek(double fractionalPos) {
             return; // If off, do nothing.
         case MIXXX_RELATIVE_CUE_ONECUE:
             //if onecue, just seek to the regular cue
-            seekExact(m_pCurrentTrack->getCuePoint());
+            seekExact(pTrack->getCuePoint());
             return;
         case MIXXX_RELATIVE_CUE_HOTCUE:
             // Continue processing in this function.
@@ -119,7 +120,7 @@ void VinylControlControl::slotControlVinylSeek(double fractionalPos) {
         double shortest_distance = 0;
         int nearest_playpos = -1;
 
-        const QList<CuePointer> cuePoints(m_pCurrentTrack->getCuePoints());
+        const QList<CuePointer> cuePoints(pTrack->getCuePoints());
         QListIterator<CuePointer> it(cuePoints);
         while (it.hasNext()) {
             CuePointer pCue(it.next());

--- a/src/engine/vinylcontrolcontrol.h
+++ b/src/engine/vinylcontrolcontrol.h
@@ -18,10 +18,10 @@ class VinylControlControl : public EngineControl {
     void notifySeekQueued();
     bool isEnabled();
     bool isScratching();
+    void trackLoaded(TrackPointer pNewTrack) override;
 
   private slots:
     void slotControlVinylSeek(double fractionalPos);
-    void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack) override;
 
   private:
     ControlObject* m_pControlVinylRate;
@@ -35,7 +35,7 @@ class VinylControlControl : public EngineControl {
     ControlPushButton* m_pControlVinylCueing;
     ControlPushButton* m_pControlVinylSignalEnabled;
     ControlProxy* m_pPlayEnabled;
-    TrackPointer m_pCurrentTrack;
+    TrackPointer m_pCurrentTrack; // is witten from an engine worker thread
     bool m_bSeekRequested;
 };
 

--- a/src/engine/vinylcontrolcontrol.h
+++ b/src/engine/vinylcontrolcontrol.h
@@ -35,7 +35,7 @@ class VinylControlControl : public EngineControl {
     ControlPushButton* m_pControlVinylCueing;
     ControlPushButton* m_pControlVinylSignalEnabled;
     ControlProxy* m_pPlayEnabled;
-    TrackPointer m_pCurrentTrack; // is witten from an engine worker thread
+    TrackPointer m_pTrack; // is witten from an engine worker thread
     bool m_bSeekRequested;
 };
 

--- a/src/engine/vinylcontrolcontrol.h
+++ b/src/engine/vinylcontrolcontrol.h
@@ -35,7 +35,9 @@ class VinylControlControl : public EngineControl {
     ControlPushButton* m_pControlVinylCueing;
     ControlPushButton* m_pControlVinylSignalEnabled;
     ControlProxy* m_pPlayEnabled;
-    TrackPointer m_pTrack; // is witten from an engine worker thread
+
+    TrackPointer m_pTrack; // is written from an engine worker thread
+
     bool m_bSeekRequested;
 };
 

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1395,7 +1395,7 @@ TEST_F(EngineSyncTest, UserTweakBeatDistance) {
                                               "beat_distance"))->get());
     EXPECT_LT(difference, .00001);
 
-    EXPECT_FLOAT_EQ(0.0, m_pChannel1->getEngineBuffer()->m_pBpmControl->m_dUserOffset);
+    EXPECT_FLOAT_EQ(0.0, m_pChannel1->getEngineBuffer()->m_pBpmControl->m_dUserOffset.getValue());
 }
 
 TEST_F(EngineSyncTest, MasterBpmNeverZero) {

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -336,7 +336,7 @@ TEST_F(LoopingControlTest, ReloopToggleButton_DoesNotJumpAhead) {
     m_pButtonReloopToggle->slotSet(1);
     m_pButtonReloopToggle->slotSet(0);
     seekToSampleAndProcess(50);
-    EXPECT_LE(m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample(), m_pLoopStartPoint->get());
+    EXPECT_LE(m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current, m_pLoopStartPoint->get());
 }
 
 TEST_F(LoopingControlTest, ReloopAndStopButton) {
@@ -348,7 +348,7 @@ TEST_F(LoopingControlTest, ReloopAndStopButton) {
     m_pButtonReloopAndStop->slotSet(1);
     m_pButtonReloopAndStop->slotSet(0);
     ProcessBuffer();
-    EXPECT_EQ(m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample(), m_pLoopStartPoint->get());
+    EXPECT_EQ(m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current, m_pLoopStartPoint->get());
     EXPECT_TRUE(m_pLoopEnabled->toBool());
 }
 
@@ -375,7 +375,7 @@ TEST_F(LoopingControlTest, LoopScale_HalvesLoop) {
     seekToSampleAndProcess(1800);
     EXPECT_EQ(0, m_pLoopStartPoint->get());
     EXPECT_EQ(2000, m_pLoopEndPoint->get());
-    EXPECT_EQ(1800, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    EXPECT_EQ(1800, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current);
     EXPECT_FALSE(isLoopEnabled());
     m_pLoopScale->set(0.5);
     ProcessBuffer();
@@ -384,7 +384,7 @@ TEST_F(LoopingControlTest, LoopScale_HalvesLoop) {
 
     // The loop was not enabled so halving the loop should not move the playhead
     // even though it is outside the loop.
-    EXPECT_EQ(1800, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    EXPECT_EQ(1800, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current);
 
     m_pButtonReloopToggle->slotSet(1);
     EXPECT_TRUE(isLoopEnabled());
@@ -512,7 +512,7 @@ TEST_F(LoopingControlTest, LoopMoveTest) {
     EXPECT_TRUE(isLoopEnabled());
     EXPECT_EQ(0, m_pLoopStartPoint->get());
     EXPECT_EQ(300, m_pLoopEndPoint->get());
-    EXPECT_EQ(10, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    EXPECT_EQ(10, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current);
 
     // Move the loop out from under the playposition.
     m_pButtonBeatMoveForward->set(1.0);
@@ -522,7 +522,7 @@ TEST_F(LoopingControlTest, LoopMoveTest) {
     EXPECT_EQ(44400, m_pLoopEndPoint->get());
     ProcessBuffer();
     // Should seek to the corresponding offset within the moved loop
-    EXPECT_EQ(44110, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    EXPECT_EQ(44110, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current);
 
     // Move backward so that the current position is outside the new location of the loop
     m_pChannel1->getEngineBuffer()->queueNewPlaypos(44300, EngineBuffer::SEEK_STANDARD);
@@ -534,7 +534,7 @@ TEST_F(LoopingControlTest, LoopMoveTest) {
     EXPECT_NEAR(300, m_pLoopEndPoint->get(), kLoopPositionMaxAbsError);
     ProcessBuffer();
     EXPECT_NEAR(200,
-            m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample(),
+            m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current,
             kLoopPositionMaxAbsError);
 
      // Now repeat the test with looping disabled (should not affect the
@@ -550,7 +550,7 @@ TEST_F(LoopingControlTest, LoopMoveTest) {
     EXPECT_EQ(44400, m_pLoopEndPoint->get());
     // Should not seek inside the moved loop when the loop is disabled
     EXPECT_NEAR(200,
-            m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample(),
+            m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current,
             kLoopPositionMaxAbsError);
 
     // Move backward so that the current position is outside the new location of the loop
@@ -562,7 +562,7 @@ TEST_F(LoopingControlTest, LoopMoveTest) {
     EXPECT_EQ(0, m_pLoopStartPoint->get());
     EXPECT_NEAR(300, m_pLoopEndPoint->get(), kLoopPositionMaxAbsError);
     EXPECT_NEAR(500,
-            m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample(),
+            m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current,
             kLoopPositionMaxAbsError);
 }
 
@@ -582,7 +582,7 @@ TEST_F(LoopingControlTest, LoopResizeSeek) {
     EXPECT_TRUE(isLoopEnabled());
     EXPECT_EQ(0, m_pLoopStartPoint->get());
     EXPECT_EQ(600, m_pLoopEndPoint->get());
-    EXPECT_EQ(500, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    EXPECT_EQ(500, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current);
 
     // Activate a shorter loop
     m_pButtonBeatLoop2Activate->set(1.0);
@@ -594,7 +594,7 @@ TEST_F(LoopingControlTest, LoopResizeSeek) {
     EXPECT_EQ(0, m_pLoopStartPoint->get());
     EXPECT_EQ(450, m_pLoopEndPoint->get());
     ProcessBuffer();
-    EXPECT_EQ(50, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    EXPECT_EQ(50, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current);
 
     // But if looping is not enabled, no warping occurs.
     m_pLoopStartPoint->slotSet(0);
@@ -604,14 +604,14 @@ TEST_F(LoopingControlTest, LoopResizeSeek) {
     EXPECT_FALSE(isLoopEnabled());
     EXPECT_EQ(0, m_pLoopStartPoint->get());
     EXPECT_EQ(600, m_pLoopEndPoint->get());
-    EXPECT_EQ(500, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    EXPECT_EQ(500, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current);
 
     m_pButtonBeatLoop2Activate->set(1.0);
     ProcessBuffer();
 
     EXPECT_EQ(500, m_pLoopStartPoint->get());
     EXPECT_EQ(950, m_pLoopEndPoint->get());
-    EXPECT_EQ(500, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    EXPECT_EQ(500, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current);
 }
 
 TEST_F(LoopingControlTest, BeatLoopSize_SetAndToggle) {
@@ -789,11 +789,11 @@ TEST_F(LoopingControlTest, Beatjump_JumpsByBeats) {
     m_pButtonBeatJumpForward->set(1.0);
     m_pButtonBeatJumpForward->set(0.0);
     ProcessBuffer();
-    EXPECT_EQ(beatLength * 4, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    EXPECT_EQ(beatLength * 4, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current);
     m_pButtonBeatJumpBackward->set(1.0);
     m_pButtonBeatJumpBackward->set(0.0);
     ProcessBuffer();
-    EXPECT_EQ(0, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getCurrentSample());
+    EXPECT_EQ(0, m_pChannel1->getEngineBuffer()->m_pLoopingControl->getSampleOfTrack().current);
 }
 
 TEST_F(LoopingControlTest, Beatjump_MovesActiveLoop) {

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -61,10 +61,8 @@ class StubLoopControl : public LoopingControl {
         Q_UNUSED(adjustingPhase);
     }
 
-  public slots:
-    void trackLoaded(TrackPointer pTrack, TrackPointer pOldTrack) override {
+    void trackLoaded(TrackPointer pTrack) override {
         Q_UNUSED(pTrack);
-        Q_UNUSED(pOldTrack);
     }
 
   protected:

--- a/src/util/console.cpp
+++ b/src/util/console.cpp
@@ -177,7 +177,7 @@ Console::~Console() {
         }
     }
     if (m_shouldFreeConsole) {
-        // Note: The console has already witten the command on top of the output
+        // Note: The console has already written the command on top of the output
         // because it was originally released due to the /subsystem:windows flag.
         // We may send a fake "Enter" key here, using SendInput() to get a new
         // command prompt, but this executes a user entry unconditionally or has other

--- a/src/util/tapfilter.cpp
+++ b/src/util/tapfilter.cpp
@@ -14,7 +14,10 @@ void TapFilter::tap() {
     QMutexLocker locker(&m_mutex);
     mixxx::Duration elapsed = m_timer.restart();
     if (elapsed <= m_maxInterval) {
-        emit(tapped(m_mean.insert(elapsed.toDoubleMillis()), m_mean.size()));
+        double averageLength = m_mean.insert(elapsed.toDoubleMillis());
+        int numSamples = m_mean.size();
+        locker.unlock();
+        emit(tapped(averageLength, numSamples));
     } else {
         // Reset the filter
         m_mean.clear();

--- a/src/util/tapfilter.cpp
+++ b/src/util/tapfilter.cpp
@@ -11,6 +11,7 @@ TapFilter::~TapFilter() {
 }
 
 void TapFilter::tap() {
+    QMutexLocker locker(&m_mutex);
     mixxx::Duration elapsed = m_timer.restart();
     if (elapsed <= m_maxInterval) {
         emit(tapped(m_mean.insert(elapsed.toDoubleMillis()), m_mean.size()));

--- a/src/util/tapfilter.h
+++ b/src/util/tapfilter.h
@@ -2,6 +2,7 @@
 #define TAPFILTER_H
 
 #include <QObject>
+#include <QMutex>
 
 #include "util/duration.h"
 #include "util/movinginterquartilemean.h"
@@ -24,6 +25,7 @@ class TapFilter : public QObject {
     PerformanceTimer m_timer;
     MovingInterquartileMean m_mean;
     mixxx::Duration m_maxInterval;
+    QMutex m_mutex;
 };
 
 #endif /* TAPFILTER_H */


### PR DESCRIPTION
This PRs should fix some crashes that may occur during switching or ejecting tracks. 
https://bugs.launchpad.net/mixxx/+bug/1801874

The main fix is that we now that we obtain a strong reference to the track and beat pointers changed by the engine worker thread.  
I have also included some related changes that was helpful to have a clear look on the code during development.  