### PR TITLE
let Key widget display key, cents or both (or nothing)

### DIFF
--- a/res/skins/Deere/deck_text_row.xml
+++ b/res/skins/Deere/deck_text_row.xml
@@ -476,7 +476,7 @@
                                   notation selected in the preferences. The controls stay calm
                                   this way. -->
                             <Layout>stacked</Layout>
-                            <MinimumSize>60,</MinimumSize>
+                            <Size>100f,</Size>
                             <Children>
                               <PushButton>
                                 <ObjectName>BpmKeyEditTrigger</ObjectName>
@@ -484,8 +484,6 @@
                                 <NumberStates>1</NumberStates>
                                 <State>
                                   <Number>0</Number>
-                                  <!-- <Text>&#9998;</Text>
-                                  <Alignment>right</Alignment> -->
                                   <Pressed scalemode="STRETCH"></Pressed>
                                   <Unpressed scalemode="STRETCH"></Unpressed>
                                 </State>
@@ -495,7 +493,9 @@
                               </PushButton>
   
                               <WidgetGroup>
+                                <ObjectName>KeyDisplay</ObjectName>
                                 <Layout>horizontal</Layout>
+                                <Size>100f,-1min</Size>
                                 <Children>
                                   <Label>
                                     <Size>10f,20f</Size>
@@ -505,8 +505,23 @@
                                   <Key>
                                     <ObjectName>BpmKeyEditTriggerLabel</ObjectName>
                                     <Group><Variable name="group"/></Group>
-                                    <SizePolicy>min,</SizePolicy>
+                                    <SizePolicy>e,min</SizePolicy>
+                                    <DisplayKey>true</DisplayKey>
+                                    <DisplayCents>false</DisplayCents>
+                                    <Alignment>center</Alignment>
+                                    <Elide>right</Elide>
+                                    <Connection>
+                                      <ConfigKey><Variable name="group"/>,visual_key</ConfigKey>
+                                    </Connection>
+                                  </Key>
+  
+                                  <Key>
+                                    <ObjectName>BpmKeyEditTriggerLabel</ObjectName>
+                                    <Group><Variable name="group"/></Group>
+                                    <SizePolicy>min,min</SizePolicy>
+                                    <DisplayKey>false</DisplayKey>
                                     <DisplayCents>true</DisplayCents>
+                                    <Alignment>right</Alignment>
                                     <Connection>
                                       <ConfigKey><Variable name="group"/>,visual_key</ConfigKey>
                                     </Connection>

--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -35,7 +35,7 @@ void WKey::setValue(double dValue) {
         if (m_displayKey) {
             keyStr = KeyUtils::keyToString(key);
         }
-        else if (m_displayCents) {
+        if (m_displayCents) {
             double diff_cents = m_engineKeyDistance.get();
             int cents_to_display = static_cast<int>(diff_cents * 100);
             char sign = ' ';

--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -22,6 +22,7 @@ void WKey::onConnectedControlChanged(double dParameter, double dValue) {
 void WKey::setup(const QDomNode& node, const SkinContext& context) {
     WLabel::setup(node, context);
     m_displayCents = context.selectBool(node, "DisplayCents", false);
+    m_displayKey = context.selectBool(node, "DisplayKey", true);
 }
 
 void WKey::setValue(double dValue) {
@@ -30,8 +31,11 @@ void WKey::setValue(double dValue) {
             KeyUtils::keyFromNumericValue(dValue);
     if (key != mixxx::track::io::key::INVALID) {
         // Render this key with the user-provided notation.
-        QString keyStr = KeyUtils::keyToString(key);
-        if (m_displayCents) {
+        QString keyStr = "";
+        if (m_displayKey) {
+            keyStr = KeyUtils::keyToString(key);
+        }
+        else if (m_displayCents) {
             double diff_cents = m_engineKeyDistance.get();
             int cents_to_display = static_cast<int>(diff_cents * 100);
             char sign = ' ';

--- a/src/widget/wkey.h
+++ b/src/widget/wkey.h
@@ -22,6 +22,7 @@ class WKey : public WLabel  {
   private:
     double m_dOldValue;
     bool m_displayCents;
+    bool m_displayKey;
     ControlProxy m_preferencesUpdated;
     ControlProxy m_engineKeyDistance;
 };


### PR DESCRIPTION
this is supposed to fix the position of key +- buttons within the expanding key edit widget in Deere.
Before, those buttons where moving under the mouse cursor when the Key widget switches in between short<>long strings of key/cents.

This introduces a `<DisplayKey>` tag to use the WKey widget to display the key value only, cents only or both.
In Deere I used it to have two separate widgets for key and cents, with static overall width:
- cents string uses the space it needs
- key string fills remaining space, is aligned left and cut at the right
I choose a medium width for key/cents so OpenKey/Lancelot values don't look lonesome, and most single traditional values fit in nicely. Only double values like `D♯m/E♭m` are cropped.

Traditional notation:
![traditional](https://user-images.githubusercontent.com/5934199/49016328-12e96f00-f186-11e8-82d3-08fc8b00f61b.png)

OpenKey:
![openkey](https://user-images.githubusercontent.com/5934199/49016343-1bda4080-f186-11e8-9742-f21733d804e7.png)