### PR TITLE
 Explorer.exe: path file as third argument to fix open in Windows 7

### DIFF
--- a/src/util/desktophelper.cpp
+++ b/src/util/desktophelper.cpp
@@ -23,7 +23,7 @@ QString getSelectInFileBrowserCommand() {
 #if defined(Q_OS_MAC)
     return "open -R";
 #elif defined(Q_OS_WIN)
-    return "explorer.exe /select,\"%1\"";
+    return "explorer.exe /select,";
 #elif defined(Q_OS_LINUX)
     QProcess proc;
     QString output;
@@ -92,22 +92,12 @@ bool selectInXfce(const QString& path) {
 
 void selectViaCommand(const QString& path) {
     QStringList arguments = sSelectInFileBrowserCommand.split(" ");
-
-    #ifdef Q_OS_WIN
-    // The template string contains the sorrounding ""
-    // Embedded quotes and slashed are not allowed on Windows
-    arguments.last() = arguments.last().arg(
-            QDir::toNativeSeparators(path));
-    #else
     // No escaping required because QProcess bypasses the shell
-    arguments.append(path);
-    #endif
-
+    arguments.append(QDir::toNativeSeparators(path));
     QString program = arguments.takeFirst();
     qDebug() << "Calling:" << program << arguments;
     QProcess::startDetached(program, arguments);
 }
-
 
 } // anonymous namespace
 


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/mixxx/+bug/1805515