### PR TITLE
Library features: move buttons close to tree view

### DIFF
--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2331,18 +2331,26 @@ WLibrary QPushButton {
   QPushButton#btnUnhide {
     font-weight: bold;
   }
-  
-  /* 'Enable AutoDJ' button	*/
+
+  /* Colored highlight for action buttons:
+  - Purge
+  - Unhide buttons
+  - Enable AutoDJ
+  - Analyze	*/
+  QPushButton#btnPurge:hover,
+  QPushButton#btnUnhide:hover,
   QPushButton#pushButtonAutoDJ:hover,
-  QPushButton#pushButtonRecording:hover,
   QPushButton#pushButtonAnalyze:hover {
     border: 1px solid #ff6600;
   }
-  /* Push buttons at far right away from skin border	*/
+  
+  /* Increased margin for action buttons */
   QPushButton#pushButtonAutoDJ,
-  QPushButton#pushButtonRecording,
-  QPushButton#Analyze {
-    margin: 1px 9px 4px 1px;
+  QPushButton#pushButtonRecording {
+    margin: 1px 5px 4px 1px;
+  }
+  QPushButton#btnPurge {
+    margin: 1px 1px 4px 5px;
   }
   QPushButton#pushButtonRecording:unchecked {
     color: #888;

--- a/src/library/autodj/dlgautodj.ui
+++ b/src/library/autodj/dlgautodj.ui
@@ -47,49 +47,15 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="QPushButton" name="pushButtonShuffle">
+      <widget class="QPushButton" name="pushButtonAutoDJ">
        <property name="toolTip">
-        <string>Shuffle the content of the Auto DJ queue.</string>
+        <string>Turn Auto DJ on or off.</string>
        </property>
        <property name="text">
-        <string>Shuffle</string>
+        <string>Enable Auto DJ</string>
        </property>
        <property name="checkable">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonAddRandom">
-       <property name="toolTip">
-        <string>Adds a random track from track sources (crates) to the Auto DJ queue.
-If no track sources are configured, the track is added from the library instead.</string>
-       </property>
-       <property name="text">
-        <string>Add Random</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonSkipNext">
-       <property name="toolTip">
-        <string>Skip the next track in the Auto DJ queue.</string>
-       </property>
-       <property name="text">
-        <string>Skip Track</string>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonFadeNow">
-       <property name="toolTip">
-        <string>Trigger the transition to the next track.</string>
-       </property>
-       <property name="text">
-        <string>Fade Now</string>
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -126,6 +92,53 @@ If no track sources are configured, the track is added from the library instead.
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="pushButtonFadeNow">
+       <property name="toolTip">
+        <string>Trigger the transition to the next track.</string>
+       </property>
+       <property name="text">
+        <string>Fade Now</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonSkipNext">
+       <property name="toolTip">
+        <string>Skip the next track in the Auto DJ queue.</string>
+       </property>
+       <property name="text">
+        <string>Skip Track</string>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonShuffle">
+       <property name="toolTip">
+        <string>Shuffle the content of the Auto DJ queue.</string>
+       </property>
+       <property name="text">
+        <string>Shuffle</string>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonAddRandom">
+       <property name="toolTip">
+        <string>Adds a random track from track sources (crates) to the Auto DJ queue.
+If no track sources are configured, the track is added from the library instead.</string>
+       </property>
+       <property name="text">
+        <string>Add Random</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -142,19 +155,6 @@ If no track sources are configured, the track is added from the library instead.
       <widget class="QLabel" name="labelSelectionInfo">
        <property name="text">
         <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonAutoDJ">
-       <property name="toolTip">
-        <string>Turn Auto DJ on or off.</string>
-       </property>
-       <property name="text">
-        <string>Enable Auto DJ</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/src/library/dlganalysis.ui
+++ b/src/library/dlganalysis.ui
@@ -67,26 +67,6 @@
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="labelProgress">
-       <property name="text">
-        <string>Progress</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QPushButton" name="pushButtonSelectAll">
        <property name="toolTip">
         <string>Selects all tracks in the table below.</string>
@@ -105,6 +85,26 @@
         <string>Analyze</string>
        </property>
       </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelProgress">
+       <property name="text">
+        <string>Progress</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>

--- a/src/library/dlghidden.ui
+++ b/src/library/dlghidden.ui
@@ -47,19 +47,6 @@
       <number>0</number>
      </property>
      <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
       <widget class="QPushButton" name="btnSelect">
        <property name="toolTip">
         <string>Selects all tracks in the table below.</string>
@@ -97,6 +84,19 @@
         <bool>false</bool>
        </property>
       </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>

--- a/src/library/dlgmissing.ui
+++ b/src/library/dlgmissing.ui
@@ -47,19 +47,6 @@
       <number>0</number>
      </property>
      <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
       <widget class="QPushButton" name="btnSelect">
        <property name="toolTip">
         <string>Selects all tracks in the table below.</string>
@@ -81,6 +68,19 @@
         <bool>false</bool>
        </property>
       </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>

--- a/src/library/recording/dlgrecording.ui
+++ b/src/library/recording/dlgrecording.ui
@@ -47,6 +47,23 @@
       <number>0</number>
      </property>
      <item>
+      <widget class="QPushButton" name="pushButtonRecording">
+       <property name="text">
+        <string>Start Recording</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Status:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -58,23 +75,6 @@
         </size>
        </property>
       </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Status:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonRecording">
-       <property name="text">
-        <string>Start Recording</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
      </item>
     </layout>
    </item>


### PR DESCRIPTION

![lib-ux-impro](https://user-images.githubusercontent.com/5934199/49618376-a4dc4d80-f9b8-11e8-86a8-4877211b2067.png)
![lib-ux-impro2](https://user-images.githubusercontent.com/5934199/49618377-a6a61100-f9b8-11e8-8372-143a7653b50d.png)



I feel it makes more sense to have the library feature buttons (Enable AutoDJ, Analyze, Start Recording) closer to the currently focused area when coming from the tree pane.
I moved those buttons to th left to shorten the mouse cursor distance, especially on HD screens.

Before, the library feature buttons where at the far right above the tracks table.
Was there any strong reason to put them there? I'd say I'm a power user, and every time I use the Hidden or Missing feature I search the buttons. Maybe I'm just a slow learner...

I think it's worth using this fix for now (2.3, 2.4?). This might irritate users who got used to the current layout, but it's an improvement for all users. And it feels like a transition to the much better solution in the lib-redesing branch.