### PR TITLE
WSearchLineEdit: Load and use "FgColor" from skin

### DIFF
--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -103,7 +103,7 @@ void WSearchLineEdit::setup(const QDomNode& node, const SkinContext& context) {
         } else {
             kLogger.warning()
                     << "Failed to parse foreground color"
-                    << bgColorName;
+                    << fgColorName;
         }
     }
     m_foregroundColor = WSkinColor::getCorrectColor(m_foregroundColor);


### PR DESCRIPTION
The code in WSearchLineEdit::setup() didn't make sense. "FgColor" was loaded but never actually used. I also added some checks and log messages.

I discovered this unrelated bug while searching for the source of [duplicate signals](https://mixxx.zulipchat.com/#narrow/stream/109171-development/subject/2.2E2.2E0.20release.20progress/near/151220435).