### PR TITLE
Qt4 Dependencies: Replace 'qtkeychain' with 'qt5keychain'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ addons:
       - libqt5x11extras5-dev
       - scons
       - vamp-plugin-sdk
-      - qtkeychain-dev
+      - qt5keychain-dev
       - liblilv-dev
 before_install:
   # Virtual X, needed for analyzer waveform tests

--- a/build/depends.py
+++ b/build/depends.py
@@ -698,10 +698,10 @@ class Reverb(Dependence):
 
 class QtKeychain(Dependence):
     def configure(self, build, conf):
-        libs = ['qtkeychain']
+        libs = ['qt5keychain']
         if not conf.CheckLib(libs):
             raise Exception(
-                "Could not find qtkeychain.")
+                "Could not find qt5keychain.")
 
 class MixxxCore(Feature):
 

--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -10,7 +10,7 @@
 #include <QStringList>
 
 #ifdef __QTKEYCHAIN__
-#include <qtkeychain/keychain.h>
+#include <qt5keychain/keychain.h>
 using namespace QKeychain;
 #endif
 


### PR DESCRIPTION
Fedora provides qtkeychain-devel (Qt4) and qtkeychain-qt5-devel (Qt5) using different library names and a renamed directory for the headers. We have to use qtkeychain-qt5-devel, otherwise Mixxx still depends on some Qt4 libraries when building with `qtkeychain=1`!

```
	libQtCore.so.4 => /usr/lib64/libQtCore.so.4 (0x00007fc935fcd000)
	libQtDBus.so.4 => /usr/lib64/libQtDBus.so.4 (0x00007fc935f3a000)
	libQtXml.so.4 => /usr/lib64/libQtXml.so.4 (0x00007fc935548000)
```

For Debian/Ubuntu the package name qtkeychain[-dev] has been reused and now contains the Qt5 artefacts. Luckily changing the library name and #include directive from "qtkeychain" to "qt5keychain" is portable and works for both platforms, Debian/Ubuntu and Fedora.