### PR TITLE
Hercules DJ Control Instinct: unmap headphone volume buttons

### DIFF
--- a/res/controllers/Hercules DJ Control Instinct.midi.xml
+++ b/res/controllers/Hercules DJ Control Instinct.midi.xml
@@ -790,16 +790,6 @@
                 </options>
             </control>
             <control>
-                <status>0x80</status>
-                <midino>0x41</midino>
-                <group>[Master]</group>
-                <key>headVolume</key>
-                <description></description>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
                 <status>0x90</status>
                 <midino>0x1f</midino>
                 <group>[Sampler2]</group>
@@ -1034,16 +1024,6 @@
                 <midino>0x39</midino>
                 <group>[Playlist]</group>
                 <key>SelectPrevPlaylist</key>
-                <description></description>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <status>0x90</status>
-                <midino>0x41</midino>
-                <group>[Master]</group>
-                <key>headVolume</key>
                 <description></description>
                 <options>
                     <normal/>


### PR DESCRIPTION
The headphone volume buttons control the hardware volume of the
headphone output. They should not be mapped to Mixxx's software
gain control. Also, mapping buttons to a knob is incorrect.
Reported by a user on the forum:
https://mixxx.org/forums/viewtopic.php?f=3&t=12340