### PR TITLE
Fix QtKeychain incompatibility between Debian/Ubuntu and Fedora

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,8 @@ install:
   # NOTE(rryan): 2016-11-15 we are experiencing Travis timeouts for the OSX
   # build.  Turning off optimizations to see if that speeds up compile times.
   # TODO(rryan): localecompare doesn't work on Travis with qt5 for some reason.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export EXTRA_FLAGS="optimize=none asan=0 localecompare=0" ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export EXTRA_FLAGS="localecompare=1" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export EXTRA_FLAGS="optimize=none asan=0 localecompare=0 qtkeychain=0" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export EXTRA_FLAGS="localecompare=1 qtkeychain=1" ; fi
 
   ####
   # Common Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,8 @@ install:
   # NOTE(rryan): 2016-11-15 we are experiencing Travis timeouts for the OSX
   # build.  Turning off optimizations to see if that speeds up compile times.
   # TODO(rryan): localecompare doesn't work on Travis with qt5 for some reason.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export EXTRA_FLAGS="optimize=none asan=0 localecompare=0 qtkeychain=0" ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export EXTRA_FLAGS="localecompare=1 qtkeychain=1" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export EXTRA_FLAGS="optimize=none asan=0 localecompare=0" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export EXTRA_FLAGS="localecompare=1" ; fi
 
   ####
   # Common Build

--- a/build/depends.py
+++ b/build/depends.py
@@ -698,13 +698,9 @@ class Reverb(Dependence):
 
 class QtKeychain(Dependence):
     def configure(self, build, conf):
-        # Debian/Ubuntu: qtkeychain
-        # Fedora: qt5keychain
-        if conf.CheckLib(['qt5keychain']):
-            build.env.Append(CPPDEFINES='__QT5KEYCHAIN__')
-        elif not conf.CheckLib(['qtkeychain']):
+        if not conf.CheckLib(['qt5keychain']):
             raise Exception(
-                "Could not find qtkeychain/qt5keychain.")
+                "Could not find qt5keychain.")
 
 class MixxxCore(Feature):
 

--- a/build/depends.py
+++ b/build/depends.py
@@ -698,10 +698,13 @@ class Reverb(Dependence):
 
 class QtKeychain(Dependence):
     def configure(self, build, conf):
-        libs = ['qtkeychain']
-        if not conf.CheckLib(libs):
+        # Debian/Ubuntu: qtkeychain
+        # Fedora: qt5keychain
+        if conf.CheckLib(['qt5keychain']):
+            build.env.Append(CPPDEFINES='__QT5KEYCHAIN__')
+        elif not conf.CheckLib(['qtkeychain']):
             raise Exception(
-                "Could not find qtkeychain.")
+                "Could not find qtkeychain/qt5keychain.")
 
 class MixxxCore(Feature):
 

--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -10,9 +10,14 @@
 #include <QStringList>
 
 #ifdef __QTKEYCHAIN__
+#ifdef __QT5KEYCHAIN__
+// Library and include directory have been renamed in Fedora
+#include <qt5keychain/keychain.h>
+#else
 #include <qtkeychain/keychain.h>
+#endif // __QT5KEYCHAIN__
 using namespace QKeychain;
-#endif
+#endif // __QTKEYCHAIN__
 
 #include "broadcast/defs_broadcast.h"
 #include "defs_urls.h"

--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -10,12 +10,7 @@
 #include <QStringList>
 
 #ifdef __QTKEYCHAIN__
-#ifdef __QT5KEYCHAIN__
-// Library and include directory have been renamed in Fedora
 #include <qt5keychain/keychain.h>
-#else
-#include <qtkeychain/keychain.h>
-#endif // __QT5KEYCHAIN__
 using namespace QKeychain;
 #endif // __QTKEYCHAIN__
 


### PR DESCRIPTION
Fedora provides qtkeychain-devel (Qt4) and qtkeychain-qt5-devel (Qt5) using different library names and a renamed directory for the headers. For Debian/Ubuntu the package name qtkeychain[-dev] has been reused and now contains the Qt5 artefacts that share both names and locations of their Qt4 counterparts.

On Fedora we have to use qtkeychain-qt5-devel, otherwise Mixxx still depends on some Qt4 libraries when building with qtkeychain=1:

```
	libQtCore.so.4 => /usr/lib64/libQtCore.so.4 (0x00007fc935fcd000)
	libQtDBus.so.4 => /usr/lib64/libQtDBus.so.4 (0x00007fc935f3a000)
	libQtXml.so.4 => /usr/lib64/libQtXml.so.4 (0x00007fc935548000)
```

Additionally I enabled the _QtKeychain_ feature for our Linux CI build to test that the fix doesn't break the Debian/Ubuntu builds. I'm not sure if this is desired or not?