### PR TITLE
Use QCollator for sort library.

### DIFF
--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -730,7 +730,7 @@ int BaseTrackCache::compareColumnValues(int sortColumn, Qt::SortOrder sortOrder,
             result = 0;
         }
     } else {
-        result = val1.toString().localeAwareCompare(val2.toString());
+        result = m_collator.compare(val1.toString(), val2.toString());
     }
 
     // If we're in descending order, flip the comparison.

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -18,6 +18,7 @@
 #include "track/track.h"
 #include "util/class.h"
 #include "util/memory.h"
+#include "util/string.h"
 
 class SearchQueryParser;
 class QueryNode;
@@ -121,6 +122,8 @@ class BaseTrackCache : public QObject {
     const QString m_columnsJoined;
 
     const ColumnCache m_columnCache;
+
+    const StringCollator m_collator;
 
     QStringList m_searchColumns;
     QVector<int> m_searchColumnIndices;

--- a/src/util/db/dbconnection.cpp
+++ b/src/util/db/dbconnection.cpp
@@ -64,12 +64,6 @@ void removeDatabase(
     QSqlDatabase::removeDatabase(connectionName);
 }
 
-// The default comparison of strings for sorting.
-inline int compareLocaleAwareCaseInsensitive(
-        const QString& first, const QString& second) {
-    return QString::localeAwareCompare(first.toLower(), second.toLower());
-}
-
 void makeLatinLow(QChar* c, int count) {
     for (int i = 0; i < count; ++i) {
         if (c[i].decompositionTag() != QChar::NoDecomposition) {
@@ -181,13 +175,13 @@ int likeCompareInner(
 int sqliteStringCompareUTF16(void* pArg,
                              int len1, const void* data1,
                              int len2, const void* data2) {
-    Q_UNUSED(pArg);
+    QCollator* pCollator = reinterpret_cast<QCollator*>(pArg);
     // Construct a QString without copy
     QString string1 = QString::fromRawData(reinterpret_cast<const QChar*>(data1),
                                            len1 / sizeof(QChar));
     QString string2 = QString::fromRawData(reinterpret_cast<const QChar*>(data2),
                                            len2 / sizeof(QChar));
-    return compareLocaleAwareCaseInsensitive(string1, string2);
+    return pCollator->compare(string1, string2);
 }
 
 const char* const kLexicographicalCollationFunc = "mixxxLexicographicalCollationFunc";
@@ -234,7 +228,7 @@ void sqliteLike(sqlite3_context *context,
 
 #endif // __SQLITE3__
 
-bool initDatabase(QSqlDatabase database) {
+bool initDatabase(QSqlDatabase database, QCollator* pCollator) {
     DEBUG_ASSERT(database.isOpen());
 #ifdef __SQLITE3__
     QVariant v = database.driver()->handle();
@@ -260,7 +254,7 @@ bool initDatabase(QSqlDatabase database) {
                     handle,
                     kLexicographicalCollationFunc,
                     SQLITE_UTF16,
-                    nullptr,
+                    pCollator,
                     sqliteStringCompareUTF16);
     VERIFY_OR_DEBUG_ASSERT(result == SQLITE_OK) {
         kLogger.warning()
@@ -304,7 +298,9 @@ bool initDatabase(QSqlDatabase database) {
 DbConnection::DbConnection(
         const Params& params,
         const QString& connectionName)
-    : m_sqlDatabase(createDatabase(params, connectionName)) {
+    : m_sqlDatabase(createDatabase(params, connectionName)),
+      m_collator() {
+    m_collator.setCaseSensitivity(Qt::CaseInsensitive);
 }
 
 DbConnection::DbConnection(
@@ -331,7 +327,7 @@ bool DbConnection::open() {
                 << m_sqlDatabase.lastError();
         return false; // abort
     }
-    if (!initDatabase(m_sqlDatabase)) {
+    if (!initDatabase(m_sqlDatabase, &m_collator)) {
         kLogger.warning()
                 << "Failed to initialize database connection"
                 << *this;

--- a/src/util/db/dbconnection.cpp
+++ b/src/util/db/dbconnection.cpp
@@ -175,11 +175,11 @@ int likeCompareInner(
 int sqliteStringCompareUTF16(void* pArg,
                              int len1, const void* data1,
                              int len2, const void* data2) {
-    QCollator* pCollator = reinterpret_cast<QCollator*>(pArg);
+    StringCollator* pCollator = static_cast<StringCollator*>(pArg);
     // Construct a QString without copy
-    QString string1 = QString::fromRawData(reinterpret_cast<const QChar*>(data1),
+    QString string1 = QString::fromRawData(static_cast<const QChar*>(data1),
                                            len1 / sizeof(QChar));
-    QString string2 = QString::fromRawData(reinterpret_cast<const QChar*>(data2),
+    QString string2 = QString::fromRawData(static_cast<const QChar*>(data2),
                                            len2 / sizeof(QChar));
     return pCollator->compare(string1, string2);
 }
@@ -228,7 +228,7 @@ void sqliteLike(sqlite3_context *context,
 
 #endif // __SQLITE3__
 
-bool initDatabase(QSqlDatabase database, QCollator* pCollator) {
+bool initDatabase(QSqlDatabase database, StringCollator* pCollator) {
     DEBUG_ASSERT(database.isOpen());
 #ifdef __SQLITE3__
     QVariant v = database.driver()->handle();
@@ -298,9 +298,7 @@ bool initDatabase(QSqlDatabase database, QCollator* pCollator) {
 DbConnection::DbConnection(
         const Params& params,
         const QString& connectionName)
-    : m_sqlDatabase(createDatabase(params, connectionName)),
-      m_collator() {
-    m_collator.setCaseSensitivity(Qt::CaseInsensitive);
+    : m_sqlDatabase(createDatabase(params, connectionName)) {
 }
 
 DbConnection::DbConnection(

--- a/src/util/db/dbconnection.h
+++ b/src/util/db/dbconnection.h
@@ -3,10 +3,9 @@
 
 
 #include <QSqlDatabase>
-#include <QCollator>
-
 #include <QtDebug>
 
+#include "util/string.h"
 
 namespace mixxx {
 
@@ -64,7 +63,7 @@ class DbConnection final {
     DbConnection(const DbConnection&&) = delete;
 
     QSqlDatabase m_sqlDatabase;
-    QCollator m_collator;
+    StringCollator m_collator;
 };
 
 } // namespace mixxx

--- a/src/util/db/dbconnection.h
+++ b/src/util/db/dbconnection.h
@@ -3,6 +3,7 @@
 
 
 #include <QSqlDatabase>
+#include <QCollator>
 
 #include <QtDebug>
 
@@ -63,6 +64,7 @@ class DbConnection final {
     DbConnection(const DbConnection&&) = delete;
 
     QSqlDatabase m_sqlDatabase;
+    QCollator m_collator;
 };
 
 } // namespace mixxx

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -1,12 +1,29 @@
 #ifndef MIXXX_STRING_H
 #define MIXXX_STRING_H
 
+#include <QLocale>
+#include <QCollator>
 #include <QString>
+#include <QStringRef>
 
 // The default comparison of strings for sorting.
-inline int compareLocaleAwareCaseInsensitive(
-        const QString& first, const QString& second) {
-    return QString::localeAwareCompare(first.toLower(), second.toLower());
-}
+class StringCollator {
+  public:
+    explicit StringCollator(QLocale locale = QLocale())
+        : m_collator(std::move(locale)) {
+        m_collator.setCaseSensitivity(Qt::CaseInsensitive);
+    }
+
+    int compare(const QString& s1, const QString& s2) const {
+        return m_collator.compare(s1, s2);
+    }
+
+    int compare(const QStringRef& s1, const QStringRef& s2) const {
+        return m_collator.compare(s1, s2);
+    }
+
+  private:
+    QCollator m_collator;
+};
 
 #endif // MIXXX_STRING_H


### PR DESCRIPTION
This speeds up library access, because we don't need to make a deep copy when calling toLower().