### PR TITLE
Tango / Deere :: Fix skin settings on OSX

### DIFF
--- a/res/skins/Deere/style-mac.qss
+++ b/res/skins/Deere/style-mac.qss
@@ -1,3 +1,12 @@
+/*  push skin settings Close button to the left so it's not in the same screen
+    position as the Open button.
+    fixes lp1795663 "settings panel disappears instantly after opening it in Tango & Deere skin"
+*/
+#SkinSettingsTop {
+  padding-right: 27px;
+}
+
+
 /* hack to hide the checkmark, otherwise text gets cut off
 on the right on Retina screens. This can only be done for macOS
 because it cuts off text on the left on KDE */

--- a/res/skins/Tango/style-mac.qss
+++ b/res/skins/Tango/style-mac.qss
@@ -1,3 +1,12 @@
+/*  push skin settings Close button to the left so it's not in the same screen
+    position as the Open button.
+    fixes lp1795663 "settings panel disappears instantly after opening it in Tango & Deere skin"
+*/
+#SkinSettingsHeader {
+  padding-right: 27px;
+}
+
+
 WEffectSelector QAbstractItemView {
   padding: 0px 0px 0px -20px;
 }


### PR DESCRIPTION
lp1795663 popped up again, previous fix from #1866 is not working.

move skin settings Close button left on OSX only, so it's not in the same screen position as the Open button.