### PR TITLE
sync bpm edit fix Lp1808698  

### DIFF
--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -148,8 +148,7 @@ double BpmControl::getBpm() const {
     return m_pEngineBpm->get();
 }
 
-void BpmControl::slotFileBpmChanged(double bpm) {
-    Q_UNUSED(bpm);
+void BpmControl::slotFileBpmChanged(double file_bpm) {
     // Adjust the file-bpm with the current setting of the rate to get the
     // engine BPM. We only do this for SYNC_NONE decks because EngineSync will
     // set our BPM if the file BPM changes. See SyncControl::fileBpmChanged().
@@ -161,10 +160,10 @@ void BpmControl::slotFileBpmChanged(double bpm) {
         if (beats_bpm != -1) {
             m_pLocalBpm->set(beats_bpm);
         } else {
-            m_pLocalBpm->set(bpm);
+            m_pLocalBpm->set(file_bpm);
         }
     } else {
-        m_pLocalBpm->set(bpm);
+        m_pLocalBpm->set(file_bpm);
     }
     if (getSyncMode() == SYNC_NONE) {
         slotUpdateEngineBpm();
@@ -271,8 +270,8 @@ bool BpmControl::syncTempo() {
     double fOtherBpm = pOtherEngineBuffer->getBpm();
     double fOtherLocalBpm = pOtherEngineBuffer->getLocalBpm();
 
-    //qDebug() << "this" << "bpm" << fThisBpm << "filebpm" << fThisFileBpm;
-    //qDebug() << "other" << "bpm" << fOtherBpm << "filebpm" << fOtherFileBpm;
+    //qDebug() << "this" << "bpm" << fThisBpm << "filebpm" << fThisLocalBpm;
+    //qDebug() << "other" << "bpm" << fOtherBpm << "filebpm" << fOtherLocalBpm;
 
     ////////////////////////////////////////////////////////////////////////////
     // Rough proof of how syncing works -- rryan 3/2011

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -828,7 +828,7 @@ double BpmControl::updateLocalBpm() {
 double BpmControl::updateBeatDistance() {
     double beat_distance = getBeatDistance(getSampleOfTrack().current);
     m_pThisBeatDistance->set(beat_distance);
-    if (getSyncMode() <= SYNC_NONE) {
+    if (!isSynchronized()) {
         m_dUserOffset.setValue(0.0);
     }
     return beat_distance;

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -584,8 +584,11 @@ double BpmControl::getNearestPositionInPhase(
     if (!pBeats) {
         return dThisPosition;
     }
+
+    SyncMode syncMode = getSyncMode();
+
     // Master buffer is always in sync!
-    if (getSyncMode() == SYNC_MASTER) {
+    if (syncMode == SYNC_MASTER) {
         return dThisPosition;
     }
 
@@ -611,7 +614,7 @@ double BpmControl::getNearestPositionInPhase(
     }
 
     double dOtherBeatFraction;
-    if (getSyncMode() == SYNC_FOLLOWER) {
+    if (syncMode == SYNC_FOLLOWER) {
         // If we're a follower, it's easy to get the other beat fraction
         dOtherBeatFraction = m_dSyncTargetBeatDistance.getValue();
     } else {

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -825,7 +825,7 @@ double BpmControl::updateLocalBpm() {
 double BpmControl::updateBeatDistance() {
     double beat_distance = getBeatDistance(getSampleOfTrack().current);
     m_pThisBeatDistance->set(beat_distance);
-    if (getSyncMode() == SYNC_NONE) {
+    if (getSyncMode() <= SYNC_NONE) {
         m_dUserOffset.setValue(0.0);
     }
     return beat_distance;

--- a/src/engine/bpmcontrol.cpp
+++ b/src/engine/bpmcontrol.cpp
@@ -152,6 +152,7 @@ void BpmControl::slotFileBpmChanged(double file_bpm) {
     // Adjust the file-bpm with the current setting of the rate to get the
     // engine BPM. We only do this for SYNC_NONE decks because EngineSync will
     // set our BPM if the file BPM changes. See SyncControl::fileBpmChanged().
+    //qDebug() << "BpmControl::slotFileBpmChanged" << file_bpm;
     BeatsPointer pBeats = m_pBeats;
     if (pBeats) {
         const double beats_bpm =
@@ -164,9 +165,6 @@ void BpmControl::slotFileBpmChanged(double file_bpm) {
         }
     } else {
         m_pLocalBpm->set(file_bpm);
-    }
-    if (getSyncMode() == SYNC_NONE) {
-        slotUpdateEngineBpm();
     }
     resetSyncAdjustment();
 }

--- a/src/engine/bpmcontrol.h
+++ b/src/engine/bpmcontrol.h
@@ -93,6 +93,9 @@ class BpmControl : public EngineControl {
     SyncMode getSyncMode() const {
         return syncModeFromDouble(m_pSyncMode->get());
     }
+    inline bool isSynchronized() const {
+        return toSynchronized(getSyncMode());
+    }
     bool syncTempo();
     double calcSyncAdjustment(double my_percentage, bool userTweakingSync);
     double calcRateRatio() const;

--- a/src/engine/sync/basesyncablelistener.cpp
+++ b/src/engine/sync/basesyncablelistener.cpp
@@ -63,8 +63,7 @@ int BaseSyncableListener::playingSyncDeckCount() const {
     int playing_sync_decks = 0;
 
     foreach (const Syncable* pSyncable, m_syncables) {
-        SyncMode sync_mode = pSyncable->getSyncMode();
-        if (sync_mode <= SYNC_NONE) {
+        if (!pSyncable->isSynchronized()) {
             continue;
         }
 

--- a/src/engine/sync/basesyncablelistener.cpp
+++ b/src/engine/sync/basesyncablelistener.cpp
@@ -52,7 +52,7 @@ Syncable* BaseSyncableListener::getSyncableForGroup(const QString& group) {
 
 bool BaseSyncableListener::syncDeckExists() const {
     foreach (const Syncable* pSyncable, m_syncables) {
-        if (pSyncable->getSyncMode() != SYNC_NONE && pSyncable->getBaseBpm() > 0) {
+        if (pSyncable->getSyncMode() > SYNC_NONE && pSyncable->getBaseBpm() > 0) {
             return true;
         }
     }
@@ -64,7 +64,7 @@ int BaseSyncableListener::playingSyncDeckCount() const {
 
     foreach (const Syncable* pSyncable, m_syncables) {
         SyncMode sync_mode = pSyncable->getSyncMode();
-        if (sync_mode == SYNC_NONE) {
+        if (sync_mode <= SYNC_NONE) {
             continue;
         }
 
@@ -98,12 +98,13 @@ double BaseSyncableListener::masterBaseBpm() const {
 }
 
 void BaseSyncableListener::setMasterBpm(Syncable* pSource, double bpm) {
+    qDebug() << "BaseSyncableListener::setMasterBpm" << pSource << bpm;
     if (pSource != m_pInternalClock) {
         m_pInternalClock->setMasterBpm(bpm);
     }
     foreach (Syncable* pSyncable, m_syncables) {
         if (pSyncable == pSource ||
-                pSyncable->getSyncMode() == SYNC_NONE) {
+                pSyncable->getSyncMode() <= SYNC_NONE) {
             continue;
         }
         pSyncable->setMasterBpm(bpm);
@@ -116,7 +117,7 @@ void BaseSyncableListener::setMasterInstantaneousBpm(Syncable* pSource, double b
     }
     foreach (Syncable* pSyncable, m_syncables) {
         if (pSyncable == pSource ||
-                pSyncable->getSyncMode() == SYNC_NONE) {
+                pSyncable->getSyncMode() <= SYNC_NONE) {
             continue;
         }
         pSyncable->setInstantaneousBpm(bpm);
@@ -129,7 +130,7 @@ void BaseSyncableListener::setMasterBaseBpm(Syncable* pSource, double bpm) {
     }
     foreach (Syncable* pSyncable, m_syncables) {
         if (pSyncable == pSource ||
-                pSyncable->getSyncMode() == SYNC_NONE) {
+                pSyncable->getSyncMode() <= SYNC_NONE) {
             continue;
         }
         pSyncable->setMasterBaseBpm(bpm);
@@ -142,7 +143,7 @@ void BaseSyncableListener::setMasterBeatDistance(Syncable* pSource, double beat_
     }
     foreach (Syncable* pSyncable, m_syncables) {
         if (pSyncable == pSource ||
-                pSyncable->getSyncMode() == SYNC_NONE) {
+                pSyncable->getSyncMode() <= SYNC_NONE) {
             continue;
         }
         pSyncable->setMasterBeatDistance(beat_distance);
@@ -156,7 +157,7 @@ void BaseSyncableListener::setMasterParams(Syncable* pSource, double beat_distan
     }
     foreach (Syncable* pSyncable, m_syncables) {
         if (pSyncable == pSource ||
-                pSyncable->getSyncMode() == SYNC_NONE) {
+                pSyncable->getSyncMode() <= SYNC_NONE) {
             continue;
         }
         pSyncable->setMasterParams(beat_distance, base_bpm, bpm);
@@ -168,7 +169,7 @@ void BaseSyncableListener::checkUniquePlayingSyncable() {
     Syncable* unique_syncable = NULL;
     foreach (Syncable* pSyncable, m_syncables) {
         SyncMode sync_mode = pSyncable->getSyncMode();
-        if (sync_mode == SYNC_NONE) {
+        if (sync_mode <= SYNC_NONE) {
             continue;
         }
 

--- a/src/engine/sync/basesyncablelistener.cpp
+++ b/src/engine/sync/basesyncablelistener.cpp
@@ -63,11 +63,7 @@ int BaseSyncableListener::playingSyncDeckCount() const {
     int playing_sync_decks = 0;
 
     foreach (const Syncable* pSyncable, m_syncables) {
-        if (!pSyncable->isSynchronized()) {
-            continue;
-        }
-
-        if (pSyncable->isPlaying()) {
+        if (pSyncable->isSynchronized() && pSyncable->isPlaying()) {
             ++playing_sync_decks;
         }
     }

--- a/src/engine/sync/basesyncablelistener.cpp
+++ b/src/engine/sync/basesyncablelistener.cpp
@@ -52,7 +52,7 @@ Syncable* BaseSyncableListener::getSyncableForGroup(const QString& group) {
 
 bool BaseSyncableListener::syncDeckExists() const {
     foreach (const Syncable* pSyncable, m_syncables) {
-        if (pSyncable->getSyncMode() > SYNC_NONE && pSyncable->getBaseBpm() > 0) {
+        if (pSyncable->isSynchronized() && pSyncable->getBaseBpm() > 0) {
             return true;
         }
     }
@@ -104,7 +104,7 @@ void BaseSyncableListener::setMasterBpm(Syncable* pSource, double bpm) {
     }
     foreach (Syncable* pSyncable, m_syncables) {
         if (pSyncable == pSource ||
-                pSyncable->getSyncMode() <= SYNC_NONE) {
+                !pSyncable->isSynchronized()) {
             continue;
         }
         pSyncable->setMasterBpm(bpm);
@@ -117,7 +117,7 @@ void BaseSyncableListener::setMasterInstantaneousBpm(Syncable* pSource, double b
     }
     foreach (Syncable* pSyncable, m_syncables) {
         if (pSyncable == pSource ||
-                pSyncable->getSyncMode() <= SYNC_NONE) {
+                !pSyncable->isSynchronized()) {
             continue;
         }
         pSyncable->setInstantaneousBpm(bpm);
@@ -130,7 +130,7 @@ void BaseSyncableListener::setMasterBaseBpm(Syncable* pSource, double bpm) {
     }
     foreach (Syncable* pSyncable, m_syncables) {
         if (pSyncable == pSource ||
-                pSyncable->getSyncMode() <= SYNC_NONE) {
+                !pSyncable->isSynchronized()) {
             continue;
         }
         pSyncable->setMasterBaseBpm(bpm);
@@ -143,7 +143,7 @@ void BaseSyncableListener::setMasterBeatDistance(Syncable* pSource, double beat_
     }
     foreach (Syncable* pSyncable, m_syncables) {
         if (pSyncable == pSource ||
-                pSyncable->getSyncMode() <= SYNC_NONE) {
+                !pSyncable->isSynchronized()) {
             continue;
         }
         pSyncable->setMasterBeatDistance(beat_distance);
@@ -157,7 +157,7 @@ void BaseSyncableListener::setMasterParams(Syncable* pSource, double beat_distan
     }
     foreach (Syncable* pSyncable, m_syncables) {
         if (pSyncable == pSource ||
-                pSyncable->getSyncMode() <= SYNC_NONE) {
+                !pSyncable->isSynchronized()) {
             continue;
         }
         pSyncable->setMasterParams(beat_distance, base_bpm, bpm);
@@ -168,8 +168,7 @@ void BaseSyncableListener::checkUniquePlayingSyncable() {
     int playing_sync_decks = 0;
     Syncable* unique_syncable = NULL;
     foreach (Syncable* pSyncable, m_syncables) {
-        SyncMode sync_mode = pSyncable->getSyncMode();
-        if (sync_mode <= SYNC_NONE) {
+        if (!pSyncable->isSynchronized()) {
             continue;
         }
 

--- a/src/engine/sync/basesyncablelistener.h
+++ b/src/engine/sync/basesyncablelistener.h
@@ -10,7 +10,7 @@ class EngineChannel;
 class BaseSyncableListener : public SyncableListener {
   public:
     BaseSyncableListener(UserSettingsPointer pConfig);
-    virtual ~BaseSyncableListener();
+    ~BaseSyncableListener() override;
 
     void addSyncableDeck(Syncable* pSyncable);
     EngineChannel* getMaster() const;
@@ -22,24 +22,6 @@ class BaseSyncableListener : public SyncableListener {
     Syncable* getMasterSyncable() {
         return m_pMasterSyncable;
     }
-
-    // Used by Syncables to tell EngineSync it wants to be enabled in a
-    // specific mode. If the state change is accepted, EngineSync calls
-    // Syncable::notifySyncModeChanged.
-    virtual void requestSyncMode(Syncable* pSyncable, SyncMode state) = 0;
-
-    // Used by Syncables to tell EngineSync it wants to be enabled in any mode
-    // (master/follower).
-    virtual void requestEnableSync(Syncable* pSyncable, bool enabled) = 0;
-
-    // Syncables notify EngineSync directly about various events. EngineSync
-    // does not have a say in whether these succeed or not, they are simply
-    // notifications.
-    virtual void notifyBpmChanged(Syncable* pSyncable, double bpm, bool fileChanged=false) = 0;
-    virtual void notifyInstantaneousBpmChanged(Syncable* pSyncable, double bpm) = 0;
-    virtual void notifyBeatDistanceChanged(Syncable* pSyncable, double beatDistance) = 0;
-    virtual void notifyPlaying(Syncable* pSyncable, bool playing) = 0;
-    virtual void notifyTrackLoaded(Syncable* pSyncable, double suggested_bpm) = 0;
 
   protected:
     // Choices about master selection can hinge on if any decks have sync

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -250,19 +250,21 @@ void EngineSync::notifyScratching(Syncable* pSyncable, bool scratching) {
     Q_UNUSED(scratching);
 }
 
-void EngineSync::notifyBpmChanged(Syncable* pSyncable, double bpm, bool fromFile) {
-    //qDebug() << "EngineSync::notifyBpmChanged" << pSyncable->getGroup() << bpm
-    //         << fromFile;
+void EngineSync::notifyBpmChanged(Syncable* pSyncable, double bpm) {
+    //qDebug() << "EngineSync::notifyBpmChanged" << pSyncable->getGroup() << bpm;
 
-    SyncMode syncMode = pSyncable->getSyncMode();
-    if (syncMode == SYNC_NONE) {
-        return;
-    }
+    // Master Base BPM shouldn't be updated for every random deck that twiddles
+    // the rate.
+    setMasterBpm(pSyncable, bpm);
+}
+
+void EngineSync::notifyBpmChangedFromFile(Syncable* pSyncable, double bpm) {
+    //qDebug() << "EngineSync::notifyBpmChangedFromFile" << pSyncable->getGroup() << bpm;
 
     // EngineSyncTest.FollowerRateChange dictates this must not happen in general,
     // but it is required when the file BPM changes because it's not a true BPM
     // change, so we set the follower back to the master BPM.
-    if (syncMode == SYNC_FOLLOWER && fromFile) {
+    if (pSyncable->getSyncMode() == SYNC_FOLLOWER) {
         double mbaseBpm = masterBaseBpm();
         double mbpm = masterBpm();
         // TODO(owilliams): Figure out why the master bpm is getting set to

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -250,9 +250,9 @@ void EngineSync::notifyScratching(Syncable* pSyncable, bool scratching) {
     Q_UNUSED(scratching);
 }
 
-void EngineSync::notifyBpmChanged(Syncable* pSyncable, double bpm, bool fileChanged) {
+void EngineSync::notifyBpmChanged(Syncable* pSyncable, double bpm, bool fromFile) {
     //qDebug() << "EngineSync::notifyBpmChanged" << pSyncable->getGroup() << bpm
-    //         << fileChanged;
+    //         << fromFile;
 
     SyncMode syncMode = pSyncable->getSyncMode();
     if (syncMode == SYNC_NONE) {
@@ -262,7 +262,7 @@ void EngineSync::notifyBpmChanged(Syncable* pSyncable, double bpm, bool fileChan
     // EngineSyncTest.FollowerRateChange dictates this must not happen in general,
     // but it is required when the file BPM changes because it's not a true BPM
     // change, so we set the follower back to the master BPM.
-    if (syncMode == SYNC_FOLLOWER && fileChanged) {
+    if (syncMode == SYNC_FOLLOWER && fromFile) {
         double mbaseBpm = masterBaseBpm();
         double mbpm = masterBpm();
         // TODO(owilliams): Figure out why the master bpm is getting set to

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -401,7 +401,7 @@ bool EngineSync::otherSyncedPlaying(const QString& group) {
             }
             continue;
         }
-        if (theSyncable->isPlaying() && (isSynchonized)) {
+        if (theSyncable->isPlaying() && isSynchonized) {
             othersInSync = true;
         }
     }

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -96,7 +96,7 @@ void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
     //qDebug() << "EngineSync::requestEnableSync" << pSyncable->getGroup() << bEnabled;
     if (bEnabled) {
         // Already enabled?  Do nothing.
-        if (pSyncable->getSyncMode() > SYNC_NONE) {
+        if (pSyncable->isSynchronized()) {
             return;
         }
         bool foundPlayingDeck = false;
@@ -170,7 +170,7 @@ void EngineSync::requestEnableSync(Syncable* pSyncable, bool bEnabled) {
         }
     } else {
         // Already disabled?  Do nothing.
-        if (pSyncable->getSyncMode() <= SYNC_NONE) {
+        if (!pSyncable->isSynchronized()) {
             return;
         }
         deactivateSync(pSyncable);
@@ -182,7 +182,7 @@ void EngineSync::notifyPlaying(Syncable* pSyncable, bool playing) {
     Q_UNUSED(playing);
     //qDebug() << "EngineSync::notifyPlaying" << pSyncable->getGroup() << playing;
     // For now we don't care if the deck is now playing or stopping.
-    if (pSyncable->getSyncMode() <= SYNC_NONE) {
+    if (!pSyncable->isSynchronized()) {
         return;
     }
 
@@ -196,7 +196,7 @@ void EngineSync::notifyPlaying(Syncable* pSyncable, bool playing) {
         int playing_nonsync_decks = 0;
         foreach (Syncable* pOtherSyncable, m_syncables) {
             if (pOtherSyncable->isPlaying()) {
-                if (pOtherSyncable->getSyncMode() > SYNC_NONE) {
+                if (pOtherSyncable->isSynchronized()) {
                     uniqueSyncEnabled = pOtherSyncable;
                     ++playing_sync_decks;
                 } else {
@@ -231,7 +231,7 @@ void EngineSync::notifyTrackLoaded(Syncable* pSyncable, double suggested_bpm) {
         if (pOtherSyncable == pSyncable) {
             continue;
         }
-        if (pOtherSyncable->getSyncMode() > SYNC_NONE && pOtherSyncable->getBpm() != 0) {
+        if (pOtherSyncable->isSynchronized() && pOtherSyncable->getBpm() != 0) {
             sync_deck_exists = true;
             break;
         }
@@ -394,13 +394,14 @@ EngineChannel* EngineSync::pickNonSyncSyncTarget(EngineChannel* pDontPick) const
 bool EngineSync::otherSyncedPlaying(const QString& group) {
     bool othersInSync = false;
     for (Syncable* theSyncable : m_syncables) {
+        bool isSynchonized = theSyncable->isSynchronized();
         if (theSyncable->getGroup() == group) {
-            if (theSyncable->getSyncMode() <= SYNC_NONE) {
+            if (!isSynchonized) {
                 return false;
             }
             continue;
         }
-        if (theSyncable->isPlaying() && (theSyncable->getSyncMode() > SYNC_NONE)) {
+        if (theSyncable->isPlaying() && (isSynchonized)) {
             othersInSync = true;
         }
     }

--- a/src/engine/sync/enginesync.h
+++ b/src/engine/sync/enginesync.h
@@ -26,26 +26,26 @@
 class EngineSync : public BaseSyncableListener {
   public:
     explicit EngineSync(UserSettingsPointer pConfig);
-    virtual ~EngineSync();
+    ~EngineSync() override;
 
     // Used by Syncables to tell EngineSync it wants to be enabled in a
     // specific mode. If the state change is accepted, EngineSync calls
     // Syncable::notifySyncModeChanged.
-    void requestSyncMode(Syncable* pSyncable, SyncMode state);
+    void requestSyncMode(Syncable* pSyncable, SyncMode state) override;
 
     // Used by Syncables to tell EngineSync it wants to be enabled in any mode
     // (master/follower).
-    void requestEnableSync(Syncable* pSyncable, bool enabled);
+    void requestEnableSync(Syncable* pSyncable, bool enabled) override;
 
     // Syncables notify EngineSync directly about various events. EngineSync
     // does not have a say in whether these succeed or not, they are simply
     // notifications.
-    void notifyBpmChanged(Syncable* pSyncable, double bpm, bool fileChanged=false);
-    void notifyInstantaneousBpmChanged(Syncable* pSyncable, double bpm);
-    void notifyBeatDistanceChanged(Syncable* pSyncable, double beatDistance);
-    void notifyPlaying(Syncable* pSyncable, bool playing);
-    void notifyScratching(Syncable* pSyncable, bool scratching);
-    void notifyTrackLoaded(Syncable* pSyncable, double suggested_bpm);
+    void notifyBpmChanged(Syncable* pSyncable, double bpm, bool fileChanged) override;
+    void notifyInstantaneousBpmChanged(Syncable* pSyncable, double bpm) override;
+    void notifyBeatDistanceChanged(Syncable* pSyncable, double beatDistance) override;
+    void notifyPlaying(Syncable* pSyncable, bool playing) override;
+    void notifyScratching(Syncable* pSyncable, bool scratching) override;
+    void notifyTrackLoaded(Syncable* pSyncable, double suggested_bpm) override;
 
     // Used to pick a sync target for non-master-sync mode.
     EngineChannel* pickNonSyncSyncTarget(EngineChannel* pDontPick) const;

--- a/src/engine/sync/enginesync.h
+++ b/src/engine/sync/enginesync.h
@@ -40,7 +40,8 @@ class EngineSync : public BaseSyncableListener {
     // Syncables notify EngineSync directly about various events. EngineSync
     // does not have a say in whether these succeed or not, they are simply
     // notifications.
-    void notifyBpmChanged(Syncable* pSyncable, double bpm, bool fromFile) override;
+    void notifyBpmChanged(Syncable* pSyncable, double bpm) override;
+    void notifyBpmChangedFromFile(Syncable* pSyncable, double bpm) override;
     void notifyInstantaneousBpmChanged(Syncable* pSyncable, double bpm) override;
     void notifyBeatDistanceChanged(Syncable* pSyncable, double beatDistance) override;
     void notifyPlaying(Syncable* pSyncable, bool playing) override;

--- a/src/engine/sync/enginesync.h
+++ b/src/engine/sync/enginesync.h
@@ -40,7 +40,7 @@ class EngineSync : public BaseSyncableListener {
     // Syncables notify EngineSync directly about various events. EngineSync
     // does not have a say in whether these succeed or not, they are simply
     // notifications.
-    void notifyBpmChanged(Syncable* pSyncable, double bpm, bool fileChanged) override;
+    void notifyBpmChanged(Syncable* pSyncable, double bpm, bool fromFile) override;
     void notifyInstantaneousBpmChanged(Syncable* pSyncable, double bpm) override;
     void notifyBeatDistanceChanged(Syncable* pSyncable, double beatDistance) override;
     void notifyPlaying(Syncable* pSyncable, bool playing) override;

--- a/src/engine/sync/enginesync.h
+++ b/src/engine/sync/enginesync.h
@@ -41,7 +41,7 @@ class EngineSync : public BaseSyncableListener {
     // does not have a say in whether these succeed or not, they are simply
     // notifications.
     void notifyBpmChanged(Syncable* pSyncable, double bpm) override;
-    void notifyBpmChangedFromFile(Syncable* pSyncable, double bpm) override;
+    void requestBpmUpdate(Syncable* pSyncable, double bpm) override;
     void notifyInstantaneousBpmChanged(Syncable* pSyncable, double bpm) override;
     void notifyBeatDistanceChanged(Syncable* pSyncable, double beatDistance) override;
     void notifyPlaying(Syncable* pSyncable, bool playing) override;

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -131,7 +131,7 @@ void InternalClock::setMasterParams(double beatDistance, double baseBpm, double 
 
 void InternalClock::slotBpmChanged(double bpm) {
     updateBeatLength(m_iOldSampleRate, bpm);
-    if (getSyncMode() == SYNC_NONE) {
+    if (!isSynchronized()) {
         return;
     }
     m_pEngineSync->notifyBpmChanged(this, bpm);

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -131,7 +131,7 @@ void InternalClock::setMasterParams(double beatDistance, double baseBpm, double 
 
 void InternalClock::slotBpmChanged(double bpm) {
     updateBeatLength(m_iOldSampleRate, bpm);
-    m_pEngineSync->notifyBpmChanged(this, bpm);
+    m_pEngineSync->notifyBpmChanged(this, bpm, false);
 }
 
 void InternalClock::slotBeatDistanceChanged(double beat_distance) {

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -131,7 +131,10 @@ void InternalClock::setMasterParams(double beatDistance, double baseBpm, double 
 
 void InternalClock::slotBpmChanged(double bpm) {
     updateBeatLength(m_iOldSampleRate, bpm);
-    m_pEngineSync->notifyBpmChanged(this, bpm, false);
+    if (getSyncMode() == SYNC_NONE) {
+        return;
+    }
+    m_pEngineSync->notifyBpmChanged(this, bpm);
 }
 
 void InternalClock::slotBeatDistanceChanged(double beat_distance) {

--- a/src/engine/sync/syncable.h
+++ b/src/engine/sync/syncable.h
@@ -22,6 +22,10 @@ inline SyncMode syncModeFromDouble(double value) {
     return mode;
 }
 
+inline bool toSynchronized(SyncMode mode) {
+    return mode > SYNC_NONE;
+}
+
 class Syncable {
   public:
     virtual ~Syncable() { }
@@ -44,7 +48,7 @@ class Syncable {
     virtual SyncMode getSyncMode() const = 0;
 
     inline bool isSynchronized() const {
-        return getSyncMode() > SYNC_NONE;
+        return toSynchronized(getSyncMode());
     }
 
     // Only relevant for player Syncables.

--- a/src/engine/sync/syncable.h
+++ b/src/engine/sync/syncable.h
@@ -95,7 +95,7 @@ class SyncableListener {
     // A Syncable must never call notifyBpmChanged in response to a setMasterBpm()
     // call.
     virtual void notifyBpmChanged(Syncable* pSyncable, double bpm,
-                                  bool fileChanged) = 0;
+                                  bool fromFile) = 0;
 
     // Syncables notify EngineSync directly about various events. EngineSync
     // does not have a say in whether these succeed or not, they are simply

--- a/src/engine/sync/syncable.h
+++ b/src/engine/sync/syncable.h
@@ -95,7 +95,7 @@ class SyncableListener {
     // A Syncable must never call notifyBpmChanged in response to a setMasterBpm()
     // call.
     virtual void notifyBpmChanged(Syncable* pSyncable, double bpm) = 0;
-    virtual void notifyBpmChangedFromFile(Syncable* pSyncable, double bpm) = 0;
+    virtual void requestBpmUpdate(Syncable* pSyncable, double bpm) = 0;
 
     // Syncables notify EngineSync directly about various events. EngineSync
     // does not have a say in whether these succeed or not, they are simply

--- a/src/engine/sync/syncable.h
+++ b/src/engine/sync/syncable.h
@@ -43,6 +43,10 @@ class Syncable {
     // notifySyncModeChanged.
     virtual SyncMode getSyncMode() const = 0;
 
+    inline bool isSynchronized() const {
+        return getSyncMode() > SYNC_NONE;
+    }
+
     // Only relevant for player Syncables.
     virtual bool isPlaying() const = 0;
 

--- a/src/engine/sync/syncable.h
+++ b/src/engine/sync/syncable.h
@@ -81,13 +81,25 @@ class Syncable {
 
 class SyncableListener {
   public:
+    virtual ~SyncableListener() {}
+
+    // Used by Syncables to tell EngineSync it wants to be enabled in a
+    // specific mode. If the state change is accepted, EngineSync calls
+    // Syncable::notifySyncModeChanged.
     virtual void requestSyncMode(Syncable* pSyncable, SyncMode mode) = 0;
+
+    // Used by Syncables to tell EngineSync it wants to be enabled in any mode
+    // (master/follower).
     virtual void requestEnableSync(Syncable* pSyncable, bool enabled) = 0;
 
     // A Syncable must never call notifyBpmChanged in response to a setMasterBpm()
     // call.
     virtual void notifyBpmChanged(Syncable* pSyncable, double bpm,
-                                  bool fileChanged=false) = 0;
+                                  bool fileChanged) = 0;
+
+    // Syncables notify EngineSync directly about various events. EngineSync
+    // does not have a say in whether these succeed or not, they are simply
+    // notifications.
     virtual void notifyInstantaneousBpmChanged(Syncable* pSyncable, double bpm) = 0;
 
     // Notify Syncable that the Syncable's scratching state changed.
@@ -96,7 +108,7 @@ class SyncableListener {
     // A Syncable must never call notifyBeatDistanceChanged in respnse to a
     // setBeatDistance() call.
     virtual void notifyBeatDistanceChanged(
-        Syncable* pSyncable, double beatDistance) = 0;
+            Syncable* pSyncable, double beatDistance) = 0;
 
     virtual void notifyPlaying(Syncable* pSyncable, bool playing) = 0;
     // A syncable can notify that a track has been loaded, and passes in the bpm

--- a/src/engine/sync/syncable.h
+++ b/src/engine/sync/syncable.h
@@ -94,8 +94,8 @@ class SyncableListener {
 
     // A Syncable must never call notifyBpmChanged in response to a setMasterBpm()
     // call.
-    virtual void notifyBpmChanged(Syncable* pSyncable, double bpm,
-                                  bool fromFile) = 0;
+    virtual void notifyBpmChanged(Syncable* pSyncable, double bpm) = 0;
+    virtual void notifyBpmChangedFromFile(Syncable* pSyncable, double bpm) = 0;
 
     // Syncables notify EngineSync directly about various events. EngineSync
     // does not have a say in whether these succeed or not, they are simply

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -227,7 +227,7 @@ void SyncControl::setMasterBaseBpm(double bpm) {
 void SyncControl::setMasterBpm(double bpm) {
     //qDebug() << "SyncControl::setMasterBpm" << getGroup() << bpm;
 
-    if (getSyncMode() == SYNC_NONE) {
+    if (!isSynchronized()) {
         qDebug() << "WARNING: Logic Error: setBpm called on SYNC_NONE syncable.";
         return;
     }
@@ -324,7 +324,7 @@ void SyncControl::trackLoaded(TrackPointer pNewTrack) {
     }
     if (pNewTrack) {
         m_masterBpmAdjustFactor = kBpmUnity;
-        if (getSyncMode() != SYNC_NONE) {
+        if (isSynchronized()) {
             // Because of the order signals get processed, the file/local_bpm COs and
             // rate slider are not updated as soon as we need them, so do that now.
             m_pFileBpm->set(pNewTrack->getBpm());
@@ -351,7 +351,7 @@ void SyncControl::slotVinylControlChanged(double enabled) {
 }
 
 void SyncControl::slotPassthroughChanged(double enabled) {
-    if (enabled && getSyncMode() != SYNC_NONE) {
+    if (enabled && isSynchronized()) {
         // If passthrough was enabled and sync was on, disable it.
         m_pChannel->getEngineBuffer()->requestSyncMode(SYNC_NONE);
     }
@@ -458,7 +458,7 @@ void SyncControl::slotRateChanged() {
     const double rateRatio = calcRateRatio();
     double bpm = m_pLocalBpm ? m_pLocalBpm->get() * rateRatio : 0.0;
     //qDebug() << getGroup() << "SyncControl::slotRateChanged" << rate << bpm;
-    if (bpm > 0 && getSyncMode() != SYNC_NONE) {
+    if (bpm > 0 && isSynchronized()) {
         // When reporting our bpm, remove the multiplier so the masters all
         // think the followers have the same bpm.
         m_pEngineSync->notifyBpmChanged(this, bpm / m_masterBpmAdjustFactor);

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -431,7 +431,7 @@ void SyncControl::setLocalBpm(double local_bpm) {
         // master bpm, our bpm value is adopted.
         m_pEngineSync->requestBpmUpdate(this, bpm);
     } else {
-        // SYNC_MASTER
+        DEBUG_ASSERT(syncMode == SYNC_MASTER);
         m_pEngineSync->notifyBpmChanged(this, bpm);
     }
 }

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -423,7 +423,7 @@ void SyncControl::setLocalBpm(double local_bpm) {
     const double rateRatio = calcRateRatio();
     double bpm = local_bpm * rateRatio;
     m_pBpm->set(bpm);
-    m_pEngineSync->notifyBpmChanged(this, bpm, true);
+    m_pEngineSync->notifyBpmChangedFromFile(this, bpm);
 }
 
 void SyncControl::slotFileBpmChanged() {
@@ -448,10 +448,10 @@ void SyncControl::slotRateChanged() {
     const double rateRatio = calcRateRatio();
     double bpm = m_pLocalBpm ? m_pLocalBpm->get() * rateRatio : 0.0;
     //qDebug() << getGroup() << "SyncControl::slotRateChanged" << rate << bpm;
-    if (bpm > 0) {
+    if (bpm > 0 && getSyncMode() != SYNC_NONE) {
         // When reporting our bpm, remove the multiplier so the masters all
         // think the followers have the same bpm.
-        m_pEngineSync->notifyBpmChanged(this, bpm / m_masterBpmAdjustFactor, false);
+        m_pEngineSync->notifyBpmChanged(this, bpm / m_masterBpmAdjustFactor);
     }
 }
 

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -444,7 +444,7 @@ void SyncControl::slotFileBpmChanged() {
     // Note: bpmcontrol has updated local_bpm just before
     double local_bpm = m_pLocalBpm ? m_pLocalBpm->get() : 0.0;
 
-    if (getSyncMode() <= SYNC_NONE) {
+    if (!isSynchronized()) {
         const double rateRatio = calcRateRatio();
         double bpm = local_bpm * rateRatio;
         m_pBpm->set(bpm);

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -419,16 +419,6 @@ void SyncControl::setLocalBpm(double local_bpm) {
         return;
     }
 
-
-    if (local_bpm == 0 && m_pPlayButton->toBool()) {
-        // If the local bpm is suddenly zero and sync was active and we are playing,
-        // stick with the previous localbpm.
-        // I think this can only happen if the beatgrid is reset.
-        qWarning() << getGroup() << "Sync is already enabled on track with empty or zero bpm";
-        return;
-    }
-
-
     // FIXME: This recalculating of the rate is duplicated in bpmcontrol.
     const double rateRatio = calcRateRatio();
     double bpm = local_bpm * rateRatio;

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -113,7 +113,7 @@ class SyncControl : public EngineControl, public Syncable {
     // multiplier changes and we need to recalculate the target distance.
     double m_unmultipliedTargetBeatDistance;
     double m_beatDistance;
-    double m_prevLocalBpm;
+    ControlValueAtomic<double> m_prevLocalBpm;
 
     QScopedPointer<ControlPushButton> m_pSyncMode;
     QScopedPointer<ControlPushButton> m_pSyncMasterEnabled;

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -104,7 +104,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(QObject* pParent,
 
     m_pPreGain = std::make_unique<ControlProxy>(group, "pregain", this);
     // BPM of the current song
-    m_pBPM = std::make_unique<ControlProxy>(group, "file_bpm", this);
+    m_pFileBPM = std::make_unique<ControlProxy>(group, "file_bpm", this);
     m_pKey = std::make_unique<ControlProxy>(group, "file_key", this);
 
     m_pReplayGain = std::make_unique<ControlProxy>(group, "replaygain", this);
@@ -130,7 +130,7 @@ TrackPointer BaseTrackPlayerImpl::loadFakeTrack(bool bPlay, double filebpm) {
     if (m_pLoadedTrack) {
         // Listen for updates to the file's BPM
         connect(m_pLoadedTrack.get(), SIGNAL(bpmUpdated(double)),
-                m_pBPM.get(), SLOT(set(double)));
+                m_pFileBPM.get(), SLOT(set(double)));
 
         connect(m_pLoadedTrack.get(), SIGNAL(keyUpdated(double)),
                 m_pKey.get(), SLOT(set(double)));
@@ -228,7 +228,7 @@ TrackPointer BaseTrackPlayerImpl::unloadTrack() {
 
 void BaseTrackPlayerImpl::connectLoadedTrack() {
     connect(m_pLoadedTrack.get(), SIGNAL(bpmUpdated(double)),
-            m_pBPM.get(), SLOT(set(double)));
+            m_pFileBPM.get(), SLOT(set(double)));
     connect(m_pLoadedTrack.get(), SIGNAL(keyUpdated(double)),
             m_pKey.get(), SLOT(set(double)));
     connect(m_pLoadedTrack.get(), SIGNAL(ReplayGainUpdated(mixxx::ReplayGain)),
@@ -239,7 +239,7 @@ void BaseTrackPlayerImpl::disconnectLoadedTrack() {
     // WARNING: Never. Ever. call bare disconnect() on an object. Mixxx
     // relies on signals and slots to get tons of things done. Don't
     // randomly disconnect things.
-    disconnect(m_pLoadedTrack.get(), 0, m_pBPM.get(), 0);
+    disconnect(m_pLoadedTrack.get(), 0, m_pFileBPM.get(), 0);
     disconnect(m_pLoadedTrack.get(), 0, this, 0);
     disconnect(m_pLoadedTrack.get(), 0, m_pKey.get(), 0);
 }
@@ -296,7 +296,7 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
         // for all the widgets to change the track and update themselves.
         emit(loadingTrack(pNewTrack, pOldTrack));
         m_pDuration->set(0);
-        m_pBPM->set(0);
+        m_pFileBPM->set(0);
         m_pKey->set(0);
         setReplayGain(0);
         m_pLoopInPoint->set(kNoTrigger);
@@ -314,7 +314,7 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
 
         // Update the BPM and duration values that are stored in ControlObjects
         m_pDuration->set(m_pLoadedTrack->getDuration());
-        m_pBPM->set(m_pLoadedTrack->getBpm());
+        m_pFileBPM->set(m_pLoadedTrack->getBpm());
         m_pKey->set(m_pLoadedTrack->getKey());
         setReplayGain(m_pLoadedTrack->getReplayGain().getRatio());
 

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -114,7 +114,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
 
     // TODO() these COs are reconnected during runtime
     // This may lock the engine
-    std::unique_ptr<ControlProxy> m_pBPM;
+    std::unique_ptr<ControlProxy> m_pFileBPM;
     std::unique_ptr<ControlProxy> m_pKey;
 
     std::unique_ptr<ControlProxy> m_pReplayGain;

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -370,6 +370,7 @@ TEST_F(EngineSyncTest, RateChangeTest) {
     auto pFileBpm1 = std::make_unique<ControlProxy>(m_sGroup1, "file_bpm");
     pFileBpm1->set(160.0);
     EXPECT_FLOAT_EQ(160.0, ControlObject::getControl(ConfigKey(m_sGroup1, "file_bpm"))->get());
+    ProcessBuffer();
     EXPECT_FLOAT_EQ(160.0, ControlObject::getControl(ConfigKey(m_sInternalClockGroup, "bpm"))->get());
 
     // Set the rate of channel 1 to 1.2.


### PR DESCRIPTION
This fixes the issue that the follower deck changes tempo if you edit the beat grid. 
A test is in place confirming that the bug is fixed. 