### PR TITLE
Use QWidget::isVisible to determine whether to render non-QGLWidget waveform widgets.

### DIFF
--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -41,6 +41,12 @@ bool shouldRenderWaveform(WaveformWidgetAbstract* pWaveformWidget) {
     }
 
     auto glw = dynamic_cast<QGLWidget*>(pWaveformWidget->getWidget());
+    if (glw == nullptr) {
+        // Not a QGLWidget. We can simply use QWidget::isVisible.
+        auto qwidget = dynamic_cast<QWidget*>(pWaveformWidget->getWidget());
+        return qwidget != nullptr && qwidget->isVisible();
+    }
+
     if (glw == nullptr || !glw->isValid() || !glw->isVisible()) {
         return false;
     }


### PR DESCRIPTION
Fixes a bug where software-renderered waveform types do not work introduced in PR #1897.