### PR TITLE
fix double -lvamp-hostsdk

### DIFF
--- a/build/features.py
+++ b/build/features.py
@@ -383,7 +383,6 @@ class Vamp(Feature):
             env.SConscript(env.File('SConscript', vamp_dir))
 
             build.env.Append(LIBPATH=self.INTERNAL_VAMP_PATH)
-            build.env.Append(LIBS=['vamp-hostsdk'])
 
         return ['src/analyzer/vamp/vampanalyzer.cpp',
                 'src/analyzer/vamp/vamppluginadapter.cpp',


### PR DESCRIPTION
testing https://github.com/mixxxdj/mixxx/pull/1926 I have noticed that we have no a double  -lvamp-hostsdk on the linker command line. 