### PR TITLE
Tango :: fix hide/show connection of loop/jump controls row

### DIFF
--- a/res/skins/Tango/deck_row_loop_jump.xml
+++ b/res/skins/Tango/deck_row_loop_jump.xml
@@ -76,7 +76,7 @@ Variables:
 
     </Children>
     <Connection>
-      <ConfigKey>[Tango],loop_beatjump_controls</ConfigKey>
+      <ConfigKey>[Skin],show_loop_beatjump_controls</ConfigKey>
       <BindProperty>visible</BindProperty>
     </Connection>
   </WidgetGroup>


### PR DESCRIPTION
fix regression from #1930 (2.2) being merged to master:
loop/beatjump section could not be displayed via skin settings.