### PR TITLE
Library feautures: fix button spacing

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -468,14 +468,9 @@ WLibrary QLabel, WLibrary QRadioButton {
 }
 
 WLibrary QRadioButton::indicator {
-  margin: 0px 5px 0px 2px;
+  margin: 0px 0px 0px 2px;
   width: 18px;
   height: 18px;
-}
-
-/* Additional space for the first QRadionButton in the row */
-WLibrary QRadioButton#radioButtonRecentlyAdded {
-  margin: 9px 10px 6px 14px;
 }
 
 WLibrary QRadioButton::indicator:checked {
@@ -571,12 +566,8 @@ WLibrary QRadioButton::indicator:unchecked {
   outline: none;
 }
 
-/* Additional space for the first and the last QPushButton in the row */
-#DlgMissing > QPushButton#btnPurge,
-#DlgHidden > QPushButton#btnUnhide,
-#DlgAutoDJ > QPushButton#pushButtonAutoDJ,
-#DlgRecording > QPushButton#pushButtonRecording,
-#DlgAnalysis > QPushButton#pushButtonAnalyze {
+/* Space in between 'Enable AutoDJ' and transition time spinbox */
+#DlgAutoDJ > QPushButton#pushButtonAutoDJ {
   margin: 9px 12px 6px 3px;
 }
 

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -1772,11 +1772,6 @@ WLibrary QLabel {
   margin: 6px 3px 9px 3px;
 }
 
-/* Additional space for the first QRadionButton in the row */
-WLibrary QRadioButton#radioButtonRecentlyAdded {
-  margin: 9px 3px 6px 12px;
-}
-
 WLibrary QRadioButton::indicator:checked {
   background: url(skin:/buttons/btn_lib_radio_button_on.svg) center center;
 }
@@ -1816,18 +1811,14 @@ WLibrary QPushButton:!enabled {
   color: #666;
 }
 
-/* Additional space for the first QPushButton in the row */
-#DlgAutoDJ > QPushButton#pushButtonShuffle {
-  margin: 5px 3px 5px 12px;
+/* Space in between 'Enable AutoDJ' and transition time spinbox */
+QPushButton#pushButtonAutoDJ {
+  margin: 5px 17px 5px 3px;
 }
 
-/* Additional space for the last QPushButton in the row */
-#DlgMissing > QPushButton#btnPurge,
-#DlgHidden > QPushButton#btnUnhide,
-#DlgAutoDJ > QPushButton#pushButtonAutoDJ,
-#DlgRecording > QPushButton#pushButtonRecording,
-#DlgAnalysis > QPushButton#pushButtonAnalyze {
-  margin: 5px 17px 5px 3px;
+/* Space in between 'All' radio button and 'Select All' button */
+QPushButton#pushButtonSelectAll {
+  margin: 5px 3px 5px 12px;
 }
 
 #DlgAutoDJ > QPushButton:checked {

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -413,13 +413,11 @@ QLabel, QRadioButton {
 
 WLibrary { margin: 2px 3px 0px 0px; }
 
-/* Additional space for QRadionButtons */
-WLibrary QRadioButton { margin: 9px 3px 6px 3px; }
-/* Additional space for QLabels */
-WLibrary QLabel { margin: 6px 3px 9px 3px; }
-
-/* Additional space for the first QRadionButton in the row*/
-WLibrary QRadioButton#radioButtonRecentlyAdded { margin: 9px 3px 6px 12px; }
+WLibrary QRadioButton {
+  margin: 0px 3px 3px 3px;
+}
+/* Center QLabels */
+WLibrary QLabel { margin: 0px 3px 3px 0px; }
 
 WLibrary QRadioButton::indicator:checked {
   background: transparent url(skin:/btn/btn_lib_radio_button_on.svg) center center;
@@ -459,17 +457,27 @@ WLibrary QPushButton {
     color: #000;
     background-color: #F90562;
     }
-  /* 'Enable AutoDJ' button	*/
+  /* Hover highlight for action buttons	*/
   QPushButton#pushButtonAutoDJ:hover,
   QPushButton#pushButtonRecording:hover,
   QPushButton#pushButtonAnalyze:hover {
     border: 1px solid #F90562;
   }
-  /* Push 'Start/Stop Recording' button and
-    'Enable AutoDJ' button away from skin border	*/
-  QPushButton#pushButtonAutoDJ,
+  /* Space in between 'Enable AutoDJ' button and transition time spinbox	*/
+  QPushButton#pushButtonAutoDJ {
+    margin: 1px 12px 3px 1px;
+  }
+  /* Space in between 'Recording'	button and recording label */
   QPushButton#pushButtonRecording {
-    margin: 1px 20px 3px 1px;
+    margin: 1px 6px 3px 1px;
+  }
+  /* Space in between AutoDJ 'Fade'/'Skip' and 'Shuffle'/'Add Random' */
+  QPushButton#pushButtonSkipNext {
+    margin: 1px 12px 3px 1px;
+  }
+  /* Push 'Select All' button and away from radio buttons	*/
+  QPushButton#pushButtonSelectAll {
+    margin: 1px 2px 3px 10px;
   }
 
 


### PR DESCRIPTION
follow-up to #1934 

AutoDJ: group buttons
- Enable
- spinbox
- fade/skip (transport actions)
- shuffle/add random (playlist actions)

Only minor tweaks in the other features.

![lib-feature-buttons](https://user-images.githubusercontent.com/5934199/50514492-c6ec5b80-0a9e-11e9-92b1-7daa65a7966c.png)
