### PR TITLE
Analysis: Fix and test MpscFifo

### DIFF
--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -85,6 +85,7 @@ AnalyzerThread::AnalyzerThread(
           m_dbConnectionPool(std::move(dbConnectionPool)),
           m_pConfig(std::move(pConfig)),
           m_modeFlags(modeFlags),
+          m_nextTrack(MpscFifoConcurrency::SingleProducer),
           m_sampleBuffer(mixxx::kAnalysisSamplesPerBlock),
           m_emittedState(AnalyzerThreadState::Void) {
     std::call_once(registerMetaTypesOnceFlag, registerMetaTypesOnce);

--- a/src/analyzer/analyzerthread.h
+++ b/src/analyzer/analyzerthread.h
@@ -105,7 +105,7 @@ class AnalyzerThread : public WorkerThread {
     // There is only one consumer (namely the worker thread) and one producer
     // (the host thread) for this value. A single value is written and read
     // in turn so the minimum capacity is sufficient.
-    MpscFifo<TrackPointer, 2> m_nextTrack;
+    MpscFifo<TrackPointer, 1> m_nextTrack;
 
     /////////////////////////////////////////////////////////////////////////
     // Thread local: Only used in the constructor/destructor and within

--- a/src/analyzer/analyzerthread.h
+++ b/src/analyzer/analyzerthread.h
@@ -103,8 +103,11 @@ class AnalyzerThread : public WorkerThread {
     // Thread-safe atomic values
 
     // There is only one consumer (namely the worker thread) and one producer
-    // (the host thread) for this value. A single value is written and read
-    // in turn so the minimum capacity is sufficient.
+    // (the host thread) for this value. A single value is written and then
+    // read so a lock-free FIFO with the minimum capacity is sufficient for
+    // safely exchanging data between two threads.
+    // NOTE(uklotzde, 2018-01-04): Ideally we would use std::atomic<TrackPointer>,
+    // for this purpose, which will become available in C++20.
     MpscFifo<TrackPointer, 1> m_nextTrack;
 
     /////////////////////////////////////////////////////////////////////////

--- a/src/analyzer/trackanalysisscheduler.h
+++ b/src/analyzer/trackanalysisscheduler.h
@@ -154,7 +154,6 @@ class TrackAnalysisScheduler : public QObject {
         AnalyzerProgress m_analyzerProgress;
     };
 
-    TrackPointer loadTrackById(TrackId trackId);
     bool submitNextTrack(Worker* worker);
     void emitProgressOrFinished();
 

--- a/src/test/mpscfifotest.cpp
+++ b/src/test/mpscfifotest.cpp
@@ -1,0 +1,167 @@
+#include <gtest/gtest.h>
+
+#include <QAtomicInt>
+#include <QSet>
+#include <QThread>
+#include <QtDebug>
+
+#include "util/mpscfifo.h"
+
+namespace {
+
+TEST(MpscFifoTest, CapacityOne) {
+    MpscFifo<int, 2> fifo;
+    int dequeued = -1;
+
+    EXPECT_TRUE(fifo.enqueue(1));
+    EXPECT_FALSE(fifo.enqueue(2));
+    EXPECT_FALSE(fifo.enqueue(2));
+    EXPECT_TRUE(fifo.dequeue(&dequeued));
+    EXPECT_EQ(1, dequeued);
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+
+    EXPECT_TRUE(fifo.enqueue(2));
+    EXPECT_FALSE(fifo.enqueue(3));
+    EXPECT_FALSE(fifo.enqueue(3));
+    EXPECT_TRUE(fifo.dequeue(&dequeued));
+    EXPECT_EQ(2, dequeued);
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+
+    EXPECT_TRUE(fifo.enqueue(3));
+    EXPECT_FALSE(fifo.enqueue(4));
+    EXPECT_FALSE(fifo.enqueue(4));
+    EXPECT_TRUE(fifo.dequeue(&dequeued));
+    EXPECT_EQ(3, dequeued);
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+}
+
+TEST(MpscFifoTest, CapacityTwo) {
+    MpscFifo<int, 3> fifo;
+    int dequeued = -1;
+
+    EXPECT_TRUE(fifo.enqueue(1));
+    EXPECT_TRUE(fifo.dequeue(&dequeued));
+    EXPECT_EQ(1, dequeued);
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+
+    EXPECT_TRUE(fifo.enqueue(2));
+    EXPECT_TRUE(fifo.dequeue(&dequeued));
+    EXPECT_EQ(2, dequeued);
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+
+    EXPECT_TRUE(fifo.enqueue(3));
+    EXPECT_TRUE(fifo.dequeue(&dequeued));
+    EXPECT_EQ(3, dequeued);
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+
+    EXPECT_TRUE(fifo.enqueue(4));
+    EXPECT_TRUE(fifo.dequeue(&dequeued));
+    EXPECT_EQ(4, dequeued);
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+
+    EXPECT_TRUE(fifo.enqueue(5));
+    EXPECT_TRUE(fifo.enqueue(6));
+    EXPECT_FALSE(fifo.enqueue(7));
+    EXPECT_TRUE(fifo.dequeue(&dequeued));
+    EXPECT_EQ(5, dequeued);
+    EXPECT_TRUE(fifo.dequeue(&dequeued));
+    EXPECT_EQ(6, dequeued);
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+
+    EXPECT_TRUE(fifo.enqueue(7));
+    EXPECT_TRUE(fifo.enqueue(8));
+    EXPECT_TRUE(fifo.dequeue(&dequeued));
+    EXPECT_EQ(7, dequeued);
+    EXPECT_TRUE(fifo.enqueue(9));
+    EXPECT_FALSE(fifo.enqueue(10));
+    EXPECT_TRUE(fifo.dequeue(&dequeued));
+    EXPECT_EQ(8, dequeued);
+    EXPECT_TRUE(fifo.enqueue(10));
+    EXPECT_TRUE(fifo.dequeue(&dequeued));
+    EXPECT_EQ(9, dequeued);
+    EXPECT_TRUE(fifo.dequeue(&dequeued));
+    EXPECT_EQ(10, dequeued);
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+}
+
+template<int capacity>
+class FifoWriter: public QThread {
+  public:
+    explicit FifoWriter(MpscFifo<int, capacity>* fifo, QAtomicInt* nextValue, int maxValue)
+        : m_fifo(fifo),
+          m_nextValue(nextValue),
+          m_maxValue(maxValue) {
+    }
+    virtual ~FifoWriter() = default;
+
+    void run() override {
+        for (;;) {
+            int nextEnqueued = m_nextValue->fetchAndAddOrdered(1);
+            ASSERT_GE(nextEnqueued, 0);
+            if (nextEnqueued >= m_maxValue) {
+                return;
+            }
+            while (!m_fifo->enqueue(nextEnqueued)) {
+                QThread::usleep(10);
+                // repeat and try again
+            }
+        }
+    }
+
+  private:
+    MpscFifo<int, capacity>* const m_fifo;
+    QAtomicInt* const m_nextValue;
+    const int m_maxValue;
+};
+
+TEST(MpscFifoTest, ConcurrentWriters) {
+    const int kCapacity = 20;
+    const int kMaxValue = 2000000;
+
+    MpscFifo<int, kCapacity> fifo;
+
+    QAtomicInt nextEnqueueValue(0);
+    FifoWriter<kCapacity> writer1(&fifo, &nextEnqueueValue, kMaxValue);
+    FifoWriter<kCapacity> writer2(&fifo, &nextEnqueueValue, kMaxValue);
+    FifoWriter<kCapacity> writer3(&fifo, &nextEnqueueValue, kMaxValue);
+
+    writer1.start();
+    writer2.start();
+    writer3.start();
+
+    // Values are enqueued slightly out-of-order and must be
+    // buffered and reordered by the reader to check their
+    // validity.
+    QSet<int> dequeuedBuffer;
+    int minValue = 0;
+    while (minValue < kMaxValue) {
+        int dequeued;
+        if (fifo.dequeue(&dequeued)) {
+            // Check that we haven't dequeued the same value twice!
+            ASSERT_GE(dequeued, minValue);
+            ASSERT_FALSE(dequeuedBuffer.contains(dequeued));
+            if (dequeued == minValue) {
+                ++minValue;
+                while (dequeuedBuffer.remove(minValue)) {
+                    ++minValue;
+                }
+            } else {
+                dequeuedBuffer.insert(dequeued);
+            }
+        }
+    }
+    int dequeued;
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+
+    writer1.wait();
+    writer2.wait();
+    writer3.wait();
+
+    EXPECT_TRUE(nextEnqueueValue.load() >= kMaxValue);
+    EXPECT_FALSE(fifo.dequeue(&dequeued));
+}
+
+}  // namespace

--- a/src/test/mpscfifotest.cpp
+++ b/src/test/mpscfifotest.cpp
@@ -10,7 +10,7 @@
 namespace {
 
 TEST(MpscFifoTest, CapacityOne) {
-    MpscFifo<int, 2> fifo;
+    MpscFifo<int, 1> fifo;
     int dequeued = -1;
 
     EXPECT_TRUE(fifo.enqueue(1));
@@ -39,7 +39,7 @@ TEST(MpscFifoTest, CapacityOne) {
 }
 
 TEST(MpscFifoTest, CapacityTwo) {
-    MpscFifo<int, 3> fifo;
+    MpscFifo<int, 2> fifo;
     int dequeued = -1;
 
     EXPECT_TRUE(fifo.enqueue(1));

--- a/src/test/mpscfifotest.cpp
+++ b/src/test/mpscfifotest.cpp
@@ -117,9 +117,12 @@ class FifoWriter: public QThread {
     const int m_maxValue;
 };
 
+// Using 500k values/rounds this test should take no longer
+// than 200 ms. If the test doesn't finish at all this will
+// also indicate a bug.
 TEST(MpscFifoTest, ConcurrentWriters) {
     const int kCapacity = 20;
-    const int kMaxValue = 2000000;
+    const int kMaxValue = 500000;
 
     MpscFifo<int, kCapacity> fifo;
 

--- a/src/util/mpscfifo.h
+++ b/src/util/mpscfifo.h
@@ -40,7 +40,7 @@ class MpscFifo {
             DEBUG_ASSERT(m_writeIndex >= 0);
             DEBUG_ASSERT(m_writeIndex <= capacity);
             m_buffer[m_writeIndex] = std::move(value);
-            m_writeIndex = nextIndex(m_writeIndex + 1);
+            m_writeIndex = nextIndex(m_writeIndex);
         }
         // Finally allow the reader to access the enqueued buffer slot
         m_readTokens.fetchAndAddRelease(-1);
@@ -58,7 +58,7 @@ class MpscFifo {
         DEBUG_ASSERT(m_readIndex >= 0);
         DEBUG_ASSERT(m_readIndex <= capacity);
         *value = std::move(m_buffer[m_readIndex]);
-        m_readIndex = nextIndex(m_readIndex + 1);
+        m_readIndex = nextIndex(m_readIndex);
         // Finally allow writers to overwrite the dequeued buffer slot
         m_writeTokens.fetchAndAddRelease(-1);
         return true;
@@ -66,7 +66,7 @@ class MpscFifo {
 
   private:
     static int nextIndex(int index) {
-        return index % (capacity + 1);
+        return (index + 1) % (capacity + 1);
     }
 
     // One additional slot is needed to decouple writers from the single reader

--- a/src/util/mpscfifo.h
+++ b/src/util/mpscfifo.h
@@ -1,66 +1,88 @@
 #pragma once
 
 #include <QAtomicInt>
+#include <QMutexLocker>
 
 #include "util/assert.h"
+#include "util/memory.h"
 
-// Lock-free FIFO for multiple producers/writers and a single(!) consumer/reader.
+enum class MpscFifoConcurrency {
+    SingleProducer,
+    MultipleProducers,
+};
+
+// FIFO for multiple producers/writers and a single consumer/reader. Reading
+// is lock-free while concurrent writers are synchronized by a mutex. The
+// mutex can be disabled by explicitly creating a single producer instance.
 template<typename T, int capacity>
 class MpscFifo {
   public:
-    MpscFifo()
-          : m_enqueueSize(0),
-            m_dequeueSize(0),
-            m_headIndex(0),
-            m_tailIndex(0) {
-        static_assert(capacity >= 2, "capacity too low");
+    explicit MpscFifo(
+            MpscFifoConcurrency concurrency = MpscFifoConcurrency::MultipleProducers)
+          : m_writeTokens(0),
+            m_readTokens(capacity),
+            m_writeMutex((concurrency == MpscFifoConcurrency::MultipleProducers) ? new QMutex : nullptr),
+            m_writeIndex(0),
+            m_readIndex(0) {
+        static_assert(capacity >= 1, "capacity too low");
+        static_assert((capacity + 1) > 0, "capacity too high");
     }
 
+    // Writers from multiple threads may enqueue items concurrently.
     bool enqueue(T value) {
-        if (m_enqueueSize.fetchAndAddAcquire(1) >= capacity) {
-            // Queue is full -> Restore size and abort
-            m_enqueueSize.fetchAndAddRelease(-1);
+        if (m_writeTokens.fetchAndAddAcquire(1) >= capacity) {
+            // No slots available for writing -> Undo changes and abort
+            m_writeTokens.fetchAndAddRelease(-1);
             return false;
-        } else {
-            int headIndex = m_headIndex.fetchAndAddAcquire(1);
-            DEBUG_ASSERT(headIndex >= 0);
-            m_buffer[headIndex % capacity] = std::move(value);
-            // Allow the reader to access the enqueued value
-            m_dequeueSize.fetchAndAddRelease(1);
-            return true;
         }
+        {
+            QMutexLocker locked(m_writeMutex.get());
+            DEBUG_ASSERT(m_writeIndex >= 0);
+            DEBUG_ASSERT(m_writeIndex <= capacity);
+            m_buffer[m_writeIndex] = std::move(value);
+            m_writeIndex = nextIndex(m_writeIndex + 1);
+        }
+        // Finally allow the reader to access the enqueued buffer slot
+        m_readTokens.fetchAndAddRelease(-1);
+        return true;
     }
 
+    // Only a single reader at a time is allowed to dequeue items.
+    // TODO(C++17): Use std::optional<T> as the return value
     bool dequeue(T* value) {
-        if (m_dequeueSize.fetchAndAddAcquire(-1) <= 0) {
-            // Queue is empty -> Restore size and abort
-            m_dequeueSize.fetchAndAddRelease(1);
+        if (m_readTokens.fetchAndAddAcquire(1) >= capacity) {
+            // No slots available for reading -> Undo changes and abort
+            m_readTokens.fetchAndAddRelease(-1);
             return false;
-        } else {
-            DEBUG_ASSERT(m_tailIndex >= 0);
-            DEBUG_ASSERT(m_tailIndex < capacity);
-            *value = std::move(m_buffer[m_tailIndex]);
-            if (++m_tailIndex >= capacity) {
-                m_tailIndex %= capacity;
-                // Prevent unlimited growth and overflow of m_headIndex which
-                // is already ahead of m_tailIndex.
-                int headIndex;
-                do {
-                    headIndex = m_headIndex.load();
-                    DEBUG_ASSERT(headIndex >= 0);
-                } while ((headIndex >= capacity) &&
-                        !m_headIndex.testAndSetOrdered(headIndex, headIndex % capacity));
-            }
-            // Allow the writer to overwrite the dequeued value
-            m_enqueueSize.fetchAndAddRelease(-1);
-            return true;
         }
+        DEBUG_ASSERT(m_readIndex >= 0);
+        DEBUG_ASSERT(m_readIndex <= capacity);
+        *value = std::move(m_buffer[m_readIndex]);
+        m_readIndex = nextIndex(m_readIndex + 1);
+        // Finally allow writers to overwrite the dequeued buffer slot
+        m_writeTokens.fetchAndAddRelease(-1);
+        return true;
     }
 
   private:
-    T m_buffer[capacity];
-    QAtomicInt m_enqueueSize;
-    QAtomicInt m_dequeueSize;
-    QAtomicInt m_headIndex;
-    int m_tailIndex;
+    static int nextIndex(int index) {
+        return index % (capacity + 1);
+    }
+
+    // One additional slot is needed to decouple writers from the single reader
+    T m_buffer[capacity + 1];
+
+    // Both writers and the reader have a different view on the utilization of
+    // the queue. The writers and readers respectively use acquire or release
+    // memory ordering semantics according to their role for lock-free
+    // coordination.
+    QAtomicInt m_writeTokens;
+    QAtomicInt m_readTokens;
+
+    // Only a single writer is allowed at a time. Otherwise stale reads may
+    // occur if a writer is delayed while accessing m_buffer!
+    std::unique_ptr<QMutex> m_writeMutex;
+
+    int m_writeIndex;
+    int m_readIndex;
 };

--- a/src/util/mpscfifo.h
+++ b/src/util/mpscfifo.h
@@ -21,11 +21,13 @@ class MpscFifo {
             MpscFifoConcurrency concurrency = MpscFifoConcurrency::MultipleProducers)
           : m_writeTokens(0),
             m_readTokens(capacity),
-            m_writeMutex((concurrency == MpscFifoConcurrency::MultipleProducers) ? new QMutex : nullptr),
             m_writeIndex(0),
             m_readIndex(0) {
         static_assert(capacity >= 1, "capacity too low");
         static_assert((capacity + 1) > 0, "capacity too high");
+        if (concurrency == MpscFifoConcurrency::MultipleProducers) {
+            m_writeMutex = std::make_unique<QMutex>();
+        }
     }
 
     // Writers from multiple threads may enqueue items concurrently.

--- a/src/util/mpscfifo.h
+++ b/src/util/mpscfifo.h
@@ -31,6 +31,10 @@ class MpscFifo {
     }
 
     // Writers from multiple threads may enqueue items concurrently.
+    // The argument is passed by value, because it is consumed by
+    // this operation on success. The situation that the queue is
+    // full and the operation fails by returning false is not expected
+    // to happen frequently.
     bool enqueue(T value) {
         if (m_writeTokens.fetchAndAddAcquire(1) >= capacity) {
             // No slots available for writing -> Undo changes and abort


### PR DESCRIPTION
This class didn't work as promised when using multiple producers. We currently only use a single producer.

The new version is simpler and uses a mutex for synchronizing multiple producers. Reading from the FIFO is always lock-free. With only a single producer even writing is lock-free. Various tests ensure that everything works as expected.