### PR TITLE
Valgrind: Avoid memory leak warnings on exit

### DIFF
--- a/src/analyzer/trackanalysisscheduler.cpp
+++ b/src/analyzer/trackanalysisscheduler.cpp
@@ -1,5 +1,7 @@
 #include "analyzer/trackanalysisscheduler.h"
 
+#include <QCoreApplication>
+
 #include "library/library.h"
 #include "library/trackcollection.h"
 
@@ -19,8 +21,11 @@ void deleteTrackAnalysisScheduler(TrackAnalysisScheduler* plainPtr) {
     if (plainPtr) {
         // Trigger stop
         plainPtr->stop();
-        // Release ownership and let Qt delete the queue later
-        plainPtr->deleteLater();
+        if (QCoreApplication::instance()->thread()->loopLevel() > 0) {
+            plainPtr->deleteLater();
+        } else {
+            delete plainPtr;
+        }
     }
 }
 

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -74,7 +74,11 @@ void deleteTrack(Track* plainPtr) {
                 << "Deleting"
                 << plainPtr;
     }
-    plainPtr->deleteLater();
+    if (QCoreApplication::instance()->thread()->loopLevel() > 0) {
+        plainPtr->deleteLater();
+    } else {
+        delete plainPtr;
+    }
 }
 
 } // anonymous namespace
@@ -216,7 +220,11 @@ void GlobalTrackCache::destroyInstance() {
     // Reset the static/global pointer before entering the destructor
     s_pInstance = nullptr;
     // Delete the singular instance
-    pInstance->deleteLater();
+    if (QCoreApplication::instance()->thread()->loopLevel() > 0) {
+        pInstance->deleteLater();
+    } else {
+        delete pInstance;
+    }
 }
 
 //static

--- a/src/util/workerthread.h
+++ b/src/util/workerthread.h
@@ -31,13 +31,11 @@ class WorkerThread : public QThread {
   public:
     explicit WorkerThread(
             const QString& name = QString());
-    // The destructor must be triggered by calling deleteLater() to
-    // ensure that the thread has already finished and is not running
-    // while destroyed! Connect finished() to deleteAfter() and then
-    // call stop() on the running worker thread explicitly to trigger
-    // the destruction. Use deleteAfterFinished() for this purpose.
     ~WorkerThread() override;
 
+    // Use this function to safely delete instances of this class
+    // to ensure that the worker thread has been finished before
+    // actually deleting it.
     void deleteAfterFinished();
 
     const QString& name() const {


### PR DESCRIPTION
Valgrind logs misleading memory leak warnings when exiting the application. Some QObjects scheduled for deferred deletion are actually not deleted after exiting the main event loop.

http://doc.qt.io/qt-5/qobject.html#deleteLater
> If deleteLater() is called after the main event loop has stopped, the object will not be deleted.