### PR TITLE
Change bpm sync right-click action to beatsync_tempo

### DIFF
--- a/res/skins/Deere/deck_tempo_column.xml
+++ b/res/skins/Deere/deck_tempo_column.xml
@@ -28,7 +28,7 @@
             <SetVariable name="state_1_pressed"></SetVariable>
             <SetVariable name="state_1_unpressed"></SetVariable>
             <SetVariable name="left_connection_control"><Variable name="group"/>,sync_enabled</SetVariable>
-            <SetVariable name="right_connection_control"><Variable name="group"/>,beatsync_phase</SetVariable>
+            <SetVariable name="right_connection_control"><Variable name="group"/>,beatsync_tempo</SetVariable>
           </Template>
 
           <WidgetGroup>

--- a/res/skins/LateNight/rate_controls.xml
+++ b/res/skins/LateNight/rate_controls.xml
@@ -191,7 +191,7 @@
             <SetVariable name="state_1_pressed">sync_overdown.svg</SetVariable>
             <SetVariable name="state_1_unpressed">sync_over.svg</SetVariable>
             <SetVariable name="ConfigKey"><Variable name="group"/>,sync_enabled</SetVariable>
-            <SetVariable name="ConfigKeyRight"><Variable name="group"/>,beatsync_phase</SetVariable>
+            <SetVariable name="ConfigKeyRight"><Variable name="group"/>,beatsync_tempo</SetVariable>
           </Template>
         </Children>
       </WidgetGroup>

--- a/res/skins/Shade/deck.xml
+++ b/res/skins/Shade/deck.xml
@@ -453,7 +453,7 @@
               <ButtonState>LeftButton</ButtonState>
             </Connection>
             <Connection>
-              <ConfigKey>[Channel<Variable name="channum"/>],beatsync_phase</ConfigKey>
+              <ConfigKey>[Channel<Variable name="channum"/>],beatsync_tempo</ConfigKey>
               <ButtonState>RightButton</ButtonState>
             </Connection>
           </PushButton>

--- a/res/skins/Tango/rate_pitch_key.xml
+++ b/res/skins/Tango/rate_pitch_key.xml
@@ -113,7 +113,7 @@ Variables:
                 <SetVariable name="ObjectName">SyncButtonOverlay</SetVariable>
                 <SetVariable name="Size">50f,18min</SetVariable>
                 <SetVariable name="ConfigKey"><Variable name="group"/>,sync_enabled</SetVariable>
-                <SetVariable name="ConfigKeyRight"><Variable name="group"/>,beatsync_phase</SetVariable>
+                <SetVariable name="ConfigKeyRight"><Variable name="group"/>,beatsync_tempo</SetVariable>
               </Template>
               <Number>
                 <ObjectName>BpmLabel</ObjectName>


### PR DESCRIPTION
As discussed briefly on Zulip - [BPM sync button left and right click](https://mixxx.zulipchat.com/#narrow/stream/109695-_support/topic/BPM.20sync.20button.20left.20and.20right.20click). This PR changes the right-click action for the bpm sync button to sync just the tempo, where previously it synced just the play position to align to the nearest beat. The user guide suggests the former is what is actually supposed to happen, and in any case this seems more intuitive - I can't see much of a use case for temporarily lining up the beats of two tracks at unmatched bpms.