### PR TITLE
Improve error message if libSoundTouch dev components are missing

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -511,6 +511,9 @@ class SoundTouch(Dependence):
             # Try using system lib
             if conf.CheckForPKG('soundtouch', '2.0.0'):
                 # System Lib found
+                if not conf.CheckLib(['soundtouch', 'libsoundtouch', 'libSoundTouch']):
+                    raise Exception(
+                        "Could not find libSoundTouch or its development headers.")
                 build.env.ParseConfig('pkg-config soundtouch --silence-errors --cflags --libs')
                 self.INTERNAL_LINK = False
 

--- a/build/depends.py
+++ b/build/depends.py
@@ -511,7 +511,7 @@ class SoundTouch(Dependence):
             # Try using system lib
             if conf.CheckForPKG('soundtouch', '2.0.0'):
                 # System Lib found
-                if not conf.CheckLib(['soundtouch', 'libsoundtouch', 'libSoundTouch']):
+                if not conf.CheckLib(['SoundTouch']):
                     raise Exception(
                         "Could not find libSoundTouch or its development headers.")
                 build.env.ParseConfig('pkg-config soundtouch --silence-errors --cflags --libs')


### PR DESCRIPTION
As reported here:
https://mixxx.zulipchat.com/#narrow/stream/109695-_support/subject/Weird.20python-y.20error/near/154393983

If the system version matches, but the development components are not installed should to inform the user about this fact. Falling back to using the bundled version is not recommended in this case.