### PR TITLE
Exclude Transifex (.ts/.qm) and WiX (.po/.wxl) l10n files from local Git merges

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,15 @@
 # $ git config --global merge.ours.driver true
 #
 # Otherwise the settings in this file are ignored!
+#
+# Background: Localization files from external sources like
+# Transifex must not be merged between release branches and
+# should be ignore while merging! Instead those files are
+# updated by re-importing them manually from the external
+# source. This workflow is supported by configuring the merge
+# strategy for the local Git repository appropriately, i.e.
+# by excluding those files from merging and always keeping the
+# files from the current/target branch (= "ours").
 
 # Exclude Transifex files from merging
 /res/translations/*.ts merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# TODO
+# Execute the following command in your local project
+# directory to enable automatic merge resolution:
+#
+# $ git config --global merge.ours.driver true
+#
+# Otherwise the settings in this file are ignored!
+
+# Exclude Transifex files from merging
+/res/translations/*.ts merge=ours
+/res/translations/*.qm merge=ours
+
+# Exclude WiX translations from merging
+/build/wix/Localization/po/*.po merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -23,3 +23,4 @@
 
 # Exclude WiX translations from merging
 /build/wix/Localization/po/*.po merge=ours
+/build/wix/Localization/po/*.wxl merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,12 @@
-# TODO
 # Execute the following command in your local project
-# directory to enable automatic merge resolution:
+# directory to exclude localization files from merges
+# across branches:
 #
 # $ git config --global merge.ours.driver true
 #
-# Otherwise the settings in this file are ignored!
+# This command sets a shell script that is used for all
+# merge=ours files. In this case the script "true" does
+# not touch anything, just returns successful.
 #
 # Background: Localization files from external sources like
 # Transifex must not be merged between release branches and


### PR DESCRIPTION
As discussed on [Zulip](https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Translations.20on.20transifex/near/154472443)

Please verify if this is the correct way to simplify merging between different releases, e.g. from 2.1 to 2.2.