### PR TITLE
fix empty overvew waveform after skin change

### DIFF
--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -228,6 +228,7 @@ void WOverview::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack)
 
         connect(pNewTrack.get(), SIGNAL(waveformSummaryUpdated()),
                 this, SLOT(slotWaveformSummaryUpdated()));
+        slotWaveformSummaryUpdated();
     } else {
         m_pCurrentTrack.reset();
         m_pWaveform.clear();


### PR DESCRIPTION
This should fix a bug found here:
https://github.com/mixxxdj/mixxx/pull/1933

The 2.2 branch is not effected. 