### PR TITLE
Don't use QStylePainter in WSpinny. lp:1530720

### DIFF
--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -149,13 +149,6 @@ WTime {
   border-right: 1px solid #585858;
 }
 
-WSpinny {/*
-  This produces artifacts in spinny bg
-  background-color: rgba(1, 1, 1, 10);
-  This makes no difference, the spinny loads some default grey bg
-  background: none;*/
-}
-
 #VisualizationContainer {
   border: 1px solid #585858;
   border-top: 0px;

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -1907,10 +1907,6 @@ WTrackProperty#SamplerTitle_mini {
   margin-right: 3px;
 }
 
-#SpinnyMini {
-  background-color: transparent;
-}
-
 /*################################################################
  ######  Preview Deck  ##########################################
 ##############################################################*/
@@ -2338,7 +2334,7 @@ WLibrary QPushButton {
   QPushButton#btnUnhide {
     font-weight: bold;
   }
-  
+
   /* 'Enable AutoDJ' button	*/
   QPushButton#pushButtonAutoDJ:hover,
   QPushButton#pushButtonRecording:hover,

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -318,13 +318,10 @@ void WSpinny::render() {
                                         &m_dGhostAngleCurrentPlaypos);
     }
 
-    QStyleOption option;
-    option.initFrom(this);
-    QStylePainter p(this);
+    QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing);
     p.setRenderHint(QPainter::HighQualityAntialiasing);
     p.setRenderHint(QPainter::SmoothPixmapTransform);
-    p.drawPrimitive(QStyle::PE_Widget, option);
 
     if (m_pBgImage) {
         p.drawImage(rect(), *m_pBgImage, m_pBgImage->rect());


### PR DESCRIPTION
Cherry-picked from #1974, since I forgot about https://bugs.launchpad.net/bugs/1530720.

When I originally filed the bug, it only printed `QMacCGContext:: Unsupported painter devtype type 1` once, now it is quite spammy. I haven't tested whether the performance improvement in #1974 also applies to QGLWidget.

Using a QStylePainter on *any* QOpenGLWidget seems to introduce up to
a 10x rendering slowdown for *all* QOpenGLWidgets. We should probably
figure out how to style WSpinny without QSS to realize this savings.