### PR TITLE
Improve error handling for Musicbrainz lookups

### DIFF
--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -31,8 +31,8 @@ void DlgTagFetcher::init() {
             this, SLOT(fetchTagFinished(const TrackPointer,const QList<TrackPointer>&)));
     connect(&m_TagFetcher, SIGNAL(fetchProgress(QString)),
             this, SLOT(fetchTagProgress(QString)));
-    connect(&m_TagFetcher, SIGNAL(networkError(int, QString)),
-            this, SLOT(slotNetworkError(int, QString)));
+    connect(&m_TagFetcher, SIGNAL(networkError(int, QString, QString, int)),
+            this, SLOT(slotNetworkError(int, QString, QString, int)));
 
     // Resize columns, this can't be set in the ui file
     results->setColumnWidth(0, 50);  // Track column
@@ -110,11 +110,11 @@ void DlgTagFetcher::fetchTagFinished(const TrackPointer track,
     updateStack();
 }
 
-void DlgTagFetcher::slotNetworkError(int errorCode, QString app) {
-    m_networkError = errorCode==0 ?  FTWERROR : HTTPERROR;
+void DlgTagFetcher::slotNetworkError(int httpError, QString app, QString message, int code) {
+    m_networkError = httpError == 0 ?  FTWERROR : HTTPERROR;
     m_data.m_pending = false;
     QString httpStatusMessage = tr("HTTP Status: %1");
-    httpStatus->setText(httpStatusMessage.arg(errorCode));
+    httpStatus->setText(httpStatusMessage.arg(httpError));
     QString unknownError = tr("Mixxx can't connect to %1 for an unknown reason.");
     cantConnectMessage->setText(unknownError.arg(app));
     QString cantConnect = tr("Mixxx can't connect to %1.");

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -113,8 +113,9 @@ void DlgTagFetcher::fetchTagFinished(const TrackPointer track,
 void DlgTagFetcher::slotNetworkError(int httpError, QString app, QString message, int code) {
     m_networkError = httpError == 0 ?  FTWERROR : HTTPERROR;
     m_data.m_pending = false;
-    QString httpStatusMessage = tr("HTTP Status: %1");
-    httpStatus->setText(httpStatusMessage.arg(httpError));
+    QString strError = tr("HTTP Status: %1");
+    QString strCode = tr("Code: %1");
+    httpStatus->setText(strError.arg(httpError) + "\n" + strCode.arg(code) + "\n" + message);
     QString unknownError = tr("Mixxx can't connect to %1 for an unknown reason.");
     cantConnectMessage->setText(unknownError.arg(app));
     QString cantConnect = tr("Mixxx can't connect to %1.");

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -16,23 +16,23 @@ DlgTagFetcher::~DlgTagFetcher() {
 void DlgTagFetcher::init() {
     setupUi(this);
 
-    connect(btnApply, SIGNAL(clicked()),
-            this, SLOT(apply()));
-    connect(btnQuit, SIGNAL(clicked()),
-            this, SLOT(quit()));
-    connect(btnPrev, SIGNAL(clicked()),
-            this, SIGNAL(previous()));
-    connect(btnNext, SIGNAL(clicked()),
-            this, SIGNAL(next()));
-    connect(results, SIGNAL(currentItemChanged(QTreeWidgetItem*,QTreeWidgetItem*)),
-            this, SLOT(resultSelected()));
+    connect(btnApply, &QPushButton::clicked,
+            this, &DlgTagFetcher::apply);
+    connect(btnQuit, &QPushButton::clicked,
+            this, &DlgTagFetcher::quit);
+    connect(btnPrev, &QPushButton::clicked,
+            this, &DlgTagFetcher::previous);
+    connect(btnNext, &QPushButton::clicked,
+            this, &DlgTagFetcher::next);
+    connect(results, &QTreeWidget::currentItemChanged,
+            this, &DlgTagFetcher::resultSelected);
 
-    connect(&m_TagFetcher, SIGNAL(resultAvailable(const TrackPointer,const QList<TrackPointer>&)),
-            this, SLOT(fetchTagFinished(const TrackPointer,const QList<TrackPointer>&)));
-    connect(&m_TagFetcher, SIGNAL(fetchProgress(QString)),
-            this, SLOT(fetchTagProgress(QString)));
-    connect(&m_TagFetcher, SIGNAL(networkError(int, QString, QString, int)),
-            this, SLOT(slotNetworkError(int, QString, QString, int)));
+    connect(&m_TagFetcher, &TagFetcher::resultAvailable,
+            this, &DlgTagFetcher::fetchTagFinished);
+    connect(&m_TagFetcher, &TagFetcher::fetchProgress,
+            this, &DlgTagFetcher::fetchTagProgress);
+    connect(&m_TagFetcher, &TagFetcher::networkError,
+            this, &DlgTagFetcher::slotNetworkError);
 
     // Resize columns, this can't be set in the ui file
     results->setColumnWidth(0, 50);  // Track column
@@ -47,14 +47,16 @@ void DlgTagFetcher::loadTrack(const TrackPointer track) {
         return;
     }
     results->clear();
+    disconnect(track.get(), &Track::changed,
+            this, &DlgTagFetcher::updateTrackMetadata);
+
     m_track = track;
     m_data = Data();
     m_networkError = NOERROR;
     m_TagFetcher.startFetch(m_track);
 
-    disconnect(this, SLOT(updateTrackMetadata(Track*)));
-    connect(track.get(), SIGNAL(changed(Track*)),
-            this, SLOT(updateTrackMetadata(Track*)));
+    connect(track.get(), &Track::changed,
+            this, &DlgTagFetcher::updateTrackMetadata);
 
     updateStack();
 }

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -35,7 +35,7 @@ class DlgTagFetcher : public QDialog,  public Ui::DlgTagFetcher {
     void fetchTagFinished(const TrackPointer,const QList<TrackPointer>& tracks);
     void resultSelected();
     void fetchTagProgress(QString);
-    void slotNetworkError(int, QString);
+    void slotNetworkError(int httpStatus, QString app, QString message, int code);
     void apply();
     void quit();
 

--- a/src/library/dlgtagfetcher.ui
+++ b/src/library/dlgtagfetcher.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QStackedWidget" name="stack">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="results_page">
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -39,12 +39,6 @@
          <property name="rootIsDecorated">
           <bool>false</bool>
          </property>
-         <attribute name="headerDefaultSectionSize">
-          <number>150</number>
-         </attribute>
-         <attribute name="headerMinimumSectionSize">
-          <number>50</number>
-         </attribute>
          <attribute name="headerDefaultSectionSize">
           <number>150</number>
          </attribute>
@@ -253,8 +247,20 @@
          </item>
          <item>
           <widget class="QLabel" name="httpStatus">
+           <property name="maximumSize">
+            <size>
+             <width>600</width>
+             <height>300</height>
+            </size>
+           </property>
            <property name="text">
             <string notr="true">HTTP Status: %1</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextSelectableByMouse</set>
            </property>
           </widget>
          </item>

--- a/src/musicbrainz/acoustidclient.cpp
+++ b/src/musicbrainz/acoustidclient.cpp
@@ -42,7 +42,7 @@ void AcoustidClient::start(int id, const QString& fingerprint, int duration) {
     urlQuery.addQueryItem("meta", "recordingids");
     urlQuery.addQueryItem("fingerprint", fingerprint);
     // application/x-www-form-urlencoded request bodies must be percent encoded.
-    QByteArray body = QUrl::toPercentEncoding(urlQuery.query());
+    QByteArray body = urlQuery.query(QUrl::FullyEncoded).toLatin1();
 
     QUrl url(ACOUSTID_URL);
     QNetworkRequest req(url);

--- a/src/musicbrainz/acoustidclient.cpp
+++ b/src/musicbrainz/acoustidclient.cpp
@@ -91,7 +91,18 @@ void AcoustidClient::requestFinished() {
     const QByteArray body(reply->readAll());
     QXmlStreamReader reader(body);
 
-    if (status != 200) {
+    QString statusText;
+    while (!reader.atEnd()) {
+        if (reader.readNext() == QXmlStreamReader::StartElement) {
+            const QStringRef name = reader.name();
+            if (name == "status") {
+                statusText = reader.readElementText();
+                break;
+            }
+        }
+    }
+
+    if (status != 200 || statusText != "ok") {
         qDebug() << "AcoustIdClient POST reply status:" << status << "body:" << body;
         QString message;
         QString code;

--- a/src/musicbrainz/acoustidclient.cpp
+++ b/src/musicbrainz/acoustidclient.cpp
@@ -105,12 +105,14 @@ void AcoustidClient::requestFinished() {
         qDebug() << "AcoustIdClient POST reply status:" << status << "body:" << body;
         QString message;
         QString code;
-        while (!reader.atEnd()) {
+        while (!reader.atEnd() && (message.isEmpty() || code.isEmpty())) {
             if (reader.readNextStartElement()) {
                 const QStringRef name = reader.name();
                 if (name == "message") {
+                    DEBUG_ASSERT(name.isEmpty()); // fail if we have duplicated message elements. 
                     message = reader.readElementText();
                 } else if (name == "code") {
+                    DEBUG_ASSERT(code.isEmpty()); // fail if we have duplicated code elements. 
                     code = reader.readElementText();
                 }
             }
@@ -123,15 +125,15 @@ void AcoustidClient::requestFinished() {
 
     qDebug() << "AcoustIdClient POST reply status:" << status << "body:" << body;
 
-    QString ID;
-    while (!reader.atEnd()) {
+    QString resultId;
+    while (!reader.atEnd() && resultId.isEmpty()) {
         if (reader.readNextStartElement()
                 && reader.name()== "results") {
-            ID = parseResult(reader);
+            resultId = parseResult(reader);
         }
     }
 
-    emit(finished(id, ID));
+    emit(finished(id, resultId));
 }
 
 QString AcoustidClient::parseResult(QXmlStreamReader& reader) {

--- a/src/musicbrainz/acoustidclient.cpp
+++ b/src/musicbrainz/acoustidclient.cpp
@@ -53,7 +53,7 @@ void AcoustidClient::start(int id, const QString& fingerprint, int duration) {
              << "body:" << body;
 
     QNetworkReply* reply = m_network.post(req, gzipCompress(body));
-    connect(reply, SIGNAL(finished()), SLOT(requestFinished()));
+    connect(reply, &QNetworkReply::finished, this, &AcoustidClient::requestFinished);
     m_requests[reply] = id;
 
     m_timeouts.addReply(reply);

--- a/src/musicbrainz/acoustidclient.cpp
+++ b/src/musicbrainz/acoustidclient.cpp
@@ -92,12 +92,11 @@ void AcoustidClient::requestFinished() {
     QXmlStreamReader reader(body);
 
     QString statusText;
-    while (!reader.atEnd()) {
-        if (reader.readNext() == QXmlStreamReader::StartElement) {
+    while (!reader.atEnd() && statusText.isEmpty()) {
+        if (reader.readNextStartElement()) {
             const QStringRef name = reader.name();
             if (name == "status") {
                 statusText = reader.readElementText();
-                break;
             }
         }
     }
@@ -107,7 +106,7 @@ void AcoustidClient::requestFinished() {
         QString message;
         QString code;
         while (!reader.atEnd()) {
-            if (reader.readNext() == QXmlStreamReader::StartElement) {
+            if (reader.readNextStartElement()) {
                 const QStringRef name = reader.name();
                 if (name == "message") {
                     message = reader.readElementText();
@@ -126,7 +125,7 @@ void AcoustidClient::requestFinished() {
 
     QString ID;
     while (!reader.atEnd()) {
-        if (reader.readNext() == QXmlStreamReader::StartElement
+        if (reader.readNextStartElement()
                 && reader.name()== "results") {
             ID = parseResult(reader);
         }

--- a/src/musicbrainz/acoustidclient.cpp
+++ b/src/musicbrainz/acoustidclient.cpp
@@ -18,16 +18,20 @@
 #include "musicbrainz/gzip.h"
 #include "musicbrainz/network.h"
 
+namespace {
+
 // see API-KEY site here http://acoustid.org/application/496
 // I registered the KEY for version 1.12 -- kain88 (may 2013)
 const QString CLIENT_APIKEY = "czKxnkyO";
 const QString ACOUSTID_URL = "http://api.acoustid.org/v2/lookup";
-const int AcoustidClient::m_DefaultTimeout = 5000; // msec
+constexpr int kDefaultTimeout = 5000; // msec
+
+} // anonymous namespace
 
 AcoustidClient::AcoustidClient(QObject* parent)
               : QObject(parent),
                 m_network(this),
-                m_timeouts(m_DefaultTimeout, this) {
+                m_timeouts(kDefaultTimeout, this) {
 }
 
 void AcoustidClient::setTimeout(int msec) {

--- a/src/musicbrainz/acoustidclient.cpp
+++ b/src/musicbrainz/acoustidclient.cpp
@@ -92,7 +92,7 @@ void AcoustidClient::requestFinished() {
         qDebug() << "AcoustIdClient POST reply status:" << status << "body:" << body.readAll();
         emit(networkError(
              reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt(),
-             "AcoustID"));
+             "AcoustID", QString(), 0));
         return;
     }
 

--- a/src/musicbrainz/acoustidclient.h
+++ b/src/musicbrainz/acoustidclient.h
@@ -58,8 +58,6 @@ class AcoustidClient : public QObject {
     void requestFinished();
 
   private:
-    static const int m_DefaultTimeout;
-
     QNetworkAccessManager m_network;
     NetworkTimeouts m_timeouts;
     QMap<QNetworkReply*, int> m_requests;

--- a/src/musicbrainz/acoustidclient.h
+++ b/src/musicbrainz/acoustidclient.h
@@ -52,7 +52,7 @@ class AcoustidClient : public QObject {
 
   signals:
     void finished(int id, const QString& mbid);
-    void networkError(int, QString);
+    void networkError(int httpStatus, QString app, QString message, int code);
 
   private slots:
     void requestFinished();

--- a/src/musicbrainz/musicbrainzclient.cpp
+++ b/src/musicbrainz/musicbrainzclient.cpp
@@ -47,7 +47,7 @@ void MusicBrainzClient::start(int id, const QString& mbid) {
     // HTTP request headers must be latin1.
     req.setRawHeader("User-Agent", mixxxMusicBrainzId.toLatin1());
     QNetworkReply* reply = m_network.get(req);
-    connect(reply, SIGNAL(finished()), SLOT(requestFinished()));
+    connect(reply, &QNetworkReply::finished, this, &MusicBrainzClient::requestFinished);
     m_requests[reply] = id;
 
     m_timeouts.addReply(reply);

--- a/src/musicbrainz/musicbrainzclient.cpp
+++ b/src/musicbrainz/musicbrainzclient.cpp
@@ -98,7 +98,7 @@ void MusicBrainzClient::requestFinished() {
     if (status != 200 && status != 404) {
         emit(networkError(
              reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt(),
-             "MusicBrainz"));
+             "MusicBrainz", QString(), 0));
         return;
     }
 

--- a/src/musicbrainz/musicbrainzclient.h
+++ b/src/musicbrainz/musicbrainzclient.h
@@ -110,10 +110,6 @@ class MusicBrainzClient : public QObject {
     static ResultList uniqueResults(const ResultList& results);
 
   private:
-    static const QString m_TrackUrl;
-    static const QString m_DateRegex;
-    static const int m_DefaultTimeout;
-
     QNetworkAccessManager m_network;
     NetworkTimeouts m_timeouts;
     QMap<QNetworkReply*, int> m_requests;

--- a/src/musicbrainz/musicbrainzclient.h
+++ b/src/musicbrainz/musicbrainzclient.h
@@ -82,7 +82,7 @@ class MusicBrainzClient : public QObject {
   signals:
     // Finished signal emitted when fechting songs tags
     void finished(int id, const MusicBrainzClient::ResultList& result);
-    void networkError(int, QString);
+    void networkError(int httpStatus, QString app, QString message, int code);
 
   private slots:
     void requestFinished();

--- a/src/musicbrainz/network.cpp
+++ b/src/musicbrainz/network.cpp
@@ -53,8 +53,8 @@ void NetworkTimeouts::addReply(QNetworkReply* reply) {
     if (m_timers.contains(reply))
         return;
 
-    connect(reply, SIGNAL(destroyed()), SLOT(replyFinished()));
-    connect(reply, SIGNAL(finished()), SLOT(replyFinished()));
+    connect(reply, &QNetworkReply::destroyed, this, &NetworkTimeouts::replyFinished);
+    connect(reply, &QNetworkReply::finished, this, &NetworkTimeouts::replyFinished);
     m_timers[reply] = startTimer(m_timeout_msec);
 }
 

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -27,10 +27,10 @@ TagFetcher::TagFetcher(QObject* parent)
             this, SLOT(mbidFound(int,QString)));
     connect(&m_MusicbrainzClient, SIGNAL(finished(int,MusicBrainzClient::ResultList)),
             this, SLOT(tagsFetched(int,MusicBrainzClient::ResultList)));
-    connect(&m_AcoustidClient, SIGNAL(networkError(int, QString)),
-            this, SIGNAL(networkError(int, QString)));
-    connect(&m_MusicbrainzClient, SIGNAL(networkError(int, QString)),
-            this, SIGNAL(networkError(int, QString)));
+    connect(&m_AcoustidClient, SIGNAL(networkError(int, QString, QString, int)),
+            this, SIGNAL(networkError(int, QString, QString, int)));
+    connect(&m_MusicbrainzClient, SIGNAL(networkError(int, QString, QString, int)),
+            this, SIGNAL(networkError(int, QString, QString, int)));
 }
 
 QString TagFetcher::getFingerprint(const TrackPointer tio) {

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -23,14 +23,14 @@ TagFetcher::TagFetcher(QObject* parent)
             m_pFingerprintWatcher(NULL),
             m_AcoustidClient(this),
             m_MusicbrainzClient(this) {
-    connect(&m_AcoustidClient, SIGNAL(finished(int,QString)),
-            this, SLOT(mbidFound(int,QString)));
-    connect(&m_MusicbrainzClient, SIGNAL(finished(int,MusicBrainzClient::ResultList)),
-            this, SLOT(tagsFetched(int,MusicBrainzClient::ResultList)));
-    connect(&m_AcoustidClient, SIGNAL(networkError(int, QString, QString, int)),
-            this, SIGNAL(networkError(int, QString, QString, int)));
-    connect(&m_MusicbrainzClient, SIGNAL(networkError(int, QString, QString, int)),
-            this, SIGNAL(networkError(int, QString, QString, int)));
+    connect(&m_AcoustidClient, &AcoustidClient::finished,
+            this, &TagFetcher::mbidFound);
+    connect(&m_MusicbrainzClient, &MusicBrainzClient::finished,
+            this, &TagFetcher::tagsFetched);
+    connect(&m_AcoustidClient, &AcoustidClient::networkError,
+            this, &TagFetcher::networkError);
+    connect(&m_MusicbrainzClient, &MusicBrainzClient::networkError,
+            this, &TagFetcher::networkError);
 }
 
 QString TagFetcher::getFingerprint(const TrackPointer tio) {
@@ -47,10 +47,10 @@ void TagFetcher::startFetch(const TrackPointer track) {
     QFuture<QString> future = QtConcurrent::mapped(m_tracks, getFingerprint);
     m_pFingerprintWatcher = new QFutureWatcher<QString>(this);
     m_pFingerprintWatcher->setFuture(future);
-    connect(m_pFingerprintWatcher, SIGNAL(resultReadyAt(int)),
-            SLOT(fingerprintFound(int)));
+    connect(m_pFingerprintWatcher, &QFutureWatcher<QString>::resultReadyAt,
+            this, &TagFetcher::fingerprintFound);
 
-    foreach (const TrackPointer ptrack, m_tracks) {
+    for (const auto& ptrack: qAsConst(m_tracks)) {
         emit(fetchProgress(tr("Fingerprinting track")));
     }
 }

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -50,9 +50,7 @@ void TagFetcher::startFetch(const TrackPointer track) {
     connect(m_pFingerprintWatcher, &QFutureWatcher<QString>::resultReadyAt,
             this, &TagFetcher::fingerprintFound);
 
-    for (const auto& ptrack: qAsConst(m_tracks)) {
-        emit(fetchProgress(tr("Fingerprinting track")));
-    }
+    emit(fetchProgress(tr("Fingerprinting track")));
 }
 
 void TagFetcher::cancel() {

--- a/src/musicbrainz/tagfetcher.h
+++ b/src/musicbrainz/tagfetcher.h
@@ -36,7 +36,7 @@ class TagFetcher : public QObject {
     void resultAvailable(const TrackPointer originalTrack,
                          const QList<TrackPointer>& tracksGuessed);
     void fetchProgress(QString);
-    void networkError(int,QString);
+    void networkError(int httpStatus, QString app, QString message, int code);
 
   private slots:
     void fingerprintFound(int index);


### PR DESCRIPTION
This PR exposed the error messages received from the web services to the user. 
It fixes some wrong fall back messages that are currently displayed instead. 

