### PR TITLE
lp1776949: Encode file names correctly on macOS

### DIFF
--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -86,7 +86,7 @@ bool FolderTreeModel::directoryHasChildren(const QString& path) const {
     // http://stackoverflow.com/questions/2579948/checking-if-subfolders-exist-linux
 
     std::string dot("."), dotdot("..");
-    QByteArray ba = path.toLocal8Bit();
+    QByteArray ba = QFile::encodeName(path);
     DIR *directory = opendir(ba);
     int unknown_count = 0;
     int total_count = 0;

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -199,9 +199,9 @@ AVFormatContext* SoundSourceFFmpeg::openInputFile(
     const QByteArray qBAFilename(
             avformat_version() >= AV_VERSION_INT(52, 0, 0) ?
                     fileName.toUtf8() :
-                    fileName.toLocal8Bit());
+                    QFile::encodeName(fileName));
 #else
-    const QByteArray qBAFilename(fileName.toLocal8Bit());
+    const QByteArray qBAFilename(QFile::encodeName(fileName));
 #endif
 
     // Open input file and allocate/initialize AVFormatContext

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -97,7 +97,7 @@ SoundSourceOpus::importTrackMetadataAndCoverImage(
 #ifdef _WIN32
     QByteArray qBAFilename = getLocalFileName().toUtf8();
 #else
-    QByteArray qBAFilename = getLocalFileName().toLocal8Bit();
+    QByteArray qBAFilename = QFile::encodeName(getLocalFileName());
 #endif
 
     int errorCode = 0;
@@ -189,7 +189,7 @@ SoundSource::OpenResult SoundSourceOpus::tryOpen(
 #ifdef _WIN32
     QByteArray qBAFilename = getLocalFileName().toUtf8();
 #else
-    QByteArray qBAFilename = getLocalFileName().toLocal8Bit();
+    QByteArray qBAFilename = QFile::encodeName(getLocalFileName());
 #endif
 
     int errorCode = 0;

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -39,7 +39,7 @@ SoundSource::OpenResult SoundSourceSndFile::tryOpen(
         SFM_READ,
         &sfInfo);
 #else
-    m_pSndFile = sf_open(getLocalFileName().toLocal8Bit(), SFM_READ, &sfInfo);
+    m_pSndFile = sf_open(QFile::encodeName(getLocalFileName()), SFM_READ, &sfInfo);
 #endif
 
     switch (sf_error(m_pSndFile)) {

--- a/src/track/trackmetadatataglib.h
+++ b/src/track/trackmetadatataglib.h
@@ -23,6 +23,7 @@
     (TAGLIB_MAJOR_VERSION > 1) || ((TAGLIB_MAJOR_VERSION == 1) && (TAGLIB_MINOR_VERSION >= 10))
 
 #include <QImage>
+#include <QFile>
 
 #include "track/trackmetadata.h"
 
@@ -128,7 +129,7 @@ static_assert(sizeof(wchar_t) == sizeof(QChar), "wchar_t is not the same size th
 // Note: we cannot use QString::toStdWString since QT 4 is compiled with
 // '/Zc:wchar_t-' flag and QT 5 not
 #else
-#define TAGLIB_FILENAME_FROM_QSTRING(fileName) (fileName).toLocal8Bit().constData()
+#define TAGLIB_FILENAME_FROM_QSTRING(fileName) QFile::encodeName(fileName).constData()
 #endif // _WIN32
 
 // Some helper functions for backwards compatibility with older


### PR DESCRIPTION
[Lauchpad bug #1776949](https://bugs.launchpad.net/mixxx/+bug/1776949)
[Zulip topic](https://mixxx.zulipchat.com/#narrow/stream/109695-_support/topic/mixxx.20can't.20read.20special.20characters.20since.20Qt5)