### PR TITLE
Round BPM display value in library table

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -676,6 +676,11 @@ QVariant BaseSqlTableModel::data(const QModelIndex& index, int role) const {
                 QDateTime gmtDate = value.toDateTime();
                 gmtDate.setTimeSpec(Qt::UTC);
                 value = gmtDate.toLocalTime();
+            } else if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM)) {
+                if (role == Qt::DisplayRole) {
+                    value = value.toDouble() == 0.0
+                            ? "-" : QString("%1").arg(value.toDouble(), 0, 'f', 1);
+                }
             } else if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM_LOCK)) {
                 value = value.toBool();
             } else if (column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_YEAR)) {


### PR DESCRIPTION
This was discussed a while ago on Zulip. This PR rounds the BPM column in the library to 1dp. The tooltip will still show the value to 3dp, and the actual value is obviously unaffected.

Below is pre-edit comment where values were rounded to whole numbers - ignore:
> Before:
> <img width="817" alt="screenshot 2019-01-20 at 16 53 30" src="https://user-images.githubusercontent.com/36423450/51442400-1efc3380-1cd4-11e9-8d96-fd71afcbc603.png">
> 
> After:
> <img width="828" alt="screenshot 2019-01-20 at 16 53 59" src="https://user-images.githubusercontent.com/36423450/51442396-10ae1780-1cd4-11e9-9b4d-4b513305a9f8.png">
> 
> The only snag I can think of is that users unfamiliar with Mixxx might be caught out by the fact that [Mixxx's BPM detection doesn't always correctly identify tracks that are at whole BPMs](https://bugs.launchpad.net/mixxx/+bug/1796262/comments/7). This might mask some cases where the analyzed BPM value isn't quite right, which could have some knock-on effects for bpm sync.