### PR TITLE
Work around performance issue with Qt 5.12 and PreviewButtonDelegate.

### DIFF
--- a/src/library/previewbuttondelegate.cpp
+++ b/src/library/previewbuttondelegate.cpp
@@ -25,17 +25,13 @@ PreviewButtonDelegate::PreviewButtonDelegate(QTableView* parent, int column)
     connect(this, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)),
             parent, SIGNAL(loadTrackToPlayer(TrackPointer, QString, bool)));
 
-    // The button needs to be parented to receive the parent styles
-    m_pButton = make_parented<QPushButton>(parent);
-    m_pButton->setObjectName("LibraryPreviewButton");
+    // The button needs to be parented to receive the parent styles.
+    m_pButton = make_parented<LibraryPreviewButton>(m_pTableView);
     m_pButton->setCheckable(true);
     m_pButton->setChecked(false);
-    // We need to hide the button that it is not painted by the QObject tree    
+
+    // We need to hide the button that it is not painted by the QObject tree
     m_pButton->hide();
-    // Set visible to stop resizing in the background 
-    // which may lead to a crash when already referenced by a painter obeject 
-    // during the render() call. 
-    m_pButton->setAttribute(Qt::WA_WState_Visible);
 
     connect(m_pTableView, SIGNAL(entered(QModelIndex)),
             this, SLOT(cellEntered(QModelIndex)));
@@ -48,8 +44,7 @@ QWidget* PreviewButtonDelegate::createEditor(QWidget* parent,
                                              const QStyleOptionViewItem& option,
                                              const QModelIndex& index) const {
     Q_UNUSED(option);
-    QPushButton* btn = new QPushButton(parent);
-    btn->setObjectName("LibraryPreviewButton");
+    QPushButton* btn = new LibraryPreviewButton(parent);
     btn->setCheckable(true);
     bool playing = m_pPreviewDeckPlay->toBool();
     // Check-state is whether the track is loaded (index.data()) and whether
@@ -77,8 +72,8 @@ void PreviewButtonDelegate::setModelData(QWidget* editor,
 }
 
 void PreviewButtonDelegate::paintItem(QPainter* painter,
-                                  const QStyleOptionViewItem& option,
-                                  const QModelIndex& index) const {
+                                      const QStyleOptionViewItem& option,
+                                      const QModelIndex& index) const {
     // Let the editor paint in this case
     if (index == m_currentEditedCellIndex) {
         return;
@@ -88,15 +83,24 @@ void PreviewButtonDelegate::paintItem(QPainter* painter,
         return;
     }
 
-    m_pButton->setGeometry(option.rect);
-    bool playing = m_pPreviewDeckPlay->toBool();
+    // We only need m_pButton to have the right width/height, since we are
+    // calling its render method directly. Every resize/translate of a widget
+    // causes Qt to flush the backing store, so we need to avoid this whenever
+    // possible.
+    if (option.rect.size() != m_pButton->size()) {
+        m_pButton->setFixedSize(option.rect.size());
+    }
+
     // Check-state is whether the track is loaded (index.data()) and whether
     // it's playing.
-    m_pButton->setChecked(index.data().toBool() && playing);
+    m_pButton->setChecked(index.data().toBool() && m_pPreviewDeckPlay->toBool());
 
-    // Render button at the desired position
+    // Render button at the desired position.
     painter->translate(option.rect.topLeft());
-    m_pButton->render(painter);
+
+    // Avoid QWidget::render and call the equivalent of QPushButton::paintEvent
+    // directly.
+    m_pButton->paint(painter);
 }
 
 void PreviewButtonDelegate::updateEditorGeometry(QWidget* editor,

--- a/src/library/previewbuttondelegate.h
+++ b/src/library/previewbuttondelegate.h
@@ -2,12 +2,36 @@
 #define PREVIEWBUTTONDELEGATE_H
 
 #include <QPushButton>
+#include <QStyleOptionButton>
 
 #include "library/tableitemdelegate.h"
 #include "track/track.h"
 #include "util/parented_ptr.h"
 
 class ControlProxy;
+
+// A QPushButton for rendering the library preview button within the
+// PreviewButtonDelegate.
+class LibraryPreviewButton : public QPushButton {
+    Q_OBJECT
+  public:
+    LibraryPreviewButton(QWidget* parent=nullptr) : QPushButton(parent) {
+        setObjectName("LibraryPreviewButton");
+    }
+    ~LibraryPreviewButton() = default;
+
+    void paint(QPainter* painter) {
+        // This matches the implementation of QPushButton::paintEvent, except it
+        // does not create a new QStylePainter, and it is simpler and more
+        // direct than QWidget::render(QPainter*, ...).
+        QStyleOptionButton option;
+        initStyleOption(&option);
+        auto pStyle = style();
+        if (pStyle) {
+            pStyle->drawControl(QStyle::CE_PushButton, &option, painter, this);
+        }
+    }
+};
 
 class PreviewButtonDelegate : public TableItemDelegate {
   Q_OBJECT
@@ -43,7 +67,7 @@ class PreviewButtonDelegate : public TableItemDelegate {
     QTableView* m_pTableView;
     ControlProxy* m_pPreviewDeckPlay;
     ControlProxy* m_pCueGotoAndPlay;
-    parented_ptr<QPushButton> m_pButton;
+    parented_ptr<LibraryPreviewButton> m_pButton;
     bool m_isOneCellInEditMode;
     QPersistentModelIndex m_currentEditedCellIndex;
     int m_column;

--- a/src/library/previewbuttondelegate.h
+++ b/src/library/previewbuttondelegate.h
@@ -18,7 +18,6 @@ class LibraryPreviewButton : public QPushButton {
     LibraryPreviewButton(QWidget* parent=nullptr) : QPushButton(parent) {
         setObjectName("LibraryPreviewButton");
     }
-    ~LibraryPreviewButton() = default;
 
     void paint(QPainter* painter) {
         // This matches the implementation of QPushButton::paintEvent, except it

--- a/src/library/tableitemdelegate.cpp
+++ b/src/library/tableitemdelegate.cpp
@@ -14,7 +14,7 @@ TableItemDelegate::~TableItemDelegate() {
 }
 
 void TableItemDelegate::paint(QPainter* painter,const QStyleOptionViewItem& option,
-                        const QModelIndex& index) const {
+                              const QModelIndex& index) const {
 
     painter->save();
 


### PR DESCRIPTION
[Launchpad Bug #1812763](https://bugs.launchpad.net/mixxx/+bug/1812763).

After upgrading to Qt 5.12, Mixxx idle CPU usage is high (99%) on
macOS. Profiling shows LibraryPreviewDelegate::paintItem as one of the hottest
functions. It appears to be related to calling QPushButton::setGeometry for each
row of the library. My workaround relies on the fact that we only need the
QPushButton size to be correct, not its position.

On macOS 10.13.6, CPU usage drops from 99% to 50% with this change
(and with #1994, idle usage drops to 15%).