### PR TITLE
reset Mic ducking mode to 0 on start

### DIFF
--- a/res/skins/Deere (64 Samplers)/skin.xml
+++ b/res/skins/Deere (64 Samplers)/skin.xml
@@ -44,6 +44,8 @@
       <attribute persist="true" config_key="[Skin],sampler_row_7_expanded">0</attribute>
       <attribute persist="true" config_key="[Skin],sampler_row_8_expanded">0</attribute>
 
+      <!-- reset ducking mode on start to avoid effect master volume -->
+      <attribute config_key="[Master],talkoverDucking">0</attribute>
       <attribute persist="true" config_key="[Microphone],show_microphone">0</attribute>
       <!-- Library -->
       <attribute config_key="[Skin],show_library">1</attribute>

--- a/res/skins/Deere/skin.xml
+++ b/res/skins/Deere/skin.xml
@@ -39,6 +39,8 @@
       <attribute persist="true" config_key="[Skin],sampler_row_2_expanded">0</attribute>
 
       <attribute persist="true" config_key="[Microphone],show_microphone">0</attribute>
+      <!-- reset ducking mode on start to avoid effect master volume -->
+      <attribute config_key="[Master],talkoverDucking">0</attribute>
       <!-- Library -->
       <attribute config_key="[Skin],show_library">1</attribute>
       <attribute config_key="[Master],maximize_library">0</attribute>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -66,6 +66,8 @@
       <attribute persist="true" config_key="[PreviewDeck],show_previewdeck">0</attribute>
       <attribute persist="true" config_key="[Library],show_coverart">1</attribute>
 
+      <!-- reset ducking mode on start to avoid effect master volume -->
+      <attribute config_key="[Master],talkoverDucking">0</attribute>
       <attribute persist="true" config_key="[Microphone],show_microphone">0</attribute>
       <attribute config_key="[Master],skin_settings">0</attribute>
       <!--Disable hidden effect routing Buttons-->

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -68,6 +68,8 @@
       <attribute persist="true" config_key="[Skin],sampler_row_1_expanded">0</attribute>
       <attribute persist="true" config_key="[Skin],sampler_row_2_expanded">0</attribute>
       <attribute persist="false" config_key="[EffectRack1],show">0</attribute>
+      <!-- reset ducking mode on start to avoid effect master volume -->
+      <attribute config_key="[Master],talkoverDucking">0</attribute>
       <attribute persist="false" config_key="[Microphone],show_microphone">0</attribute>
       <attribute persist="true" config_key="[PreviewDeck],show_previewdeck">0</attribute>
       <attribute persist="true" config_key="[Library],show_coverart">0</attribute>

--- a/res/skins/Tango (64 Samplers)/skin.xml
+++ b/res/skins/Tango (64 Samplers)/skin.xml
@@ -93,6 +93,8 @@
       <attribute persist="true" config_key="[Skin],sampler_row_7_expanded">0</attribute>
       <attribute persist="true" config_key="[Skin],sampler_row_8_expanded">0</attribute>
 
+      <!-- reset ducking mode on start to avoid effect master volume -->
+      <attribute config_key="[Master],talkoverDucking">0</attribute>
       <attribute persist="true" config_key="[Microphone],show_microphone">0</attribute>
       <!-- Library -->
       <attribute config_key="[Master],maximize_library">0</attribute>

--- a/res/skins/Tango/skin.xml
+++ b/res/skins/Tango/skin.xml
@@ -87,6 +87,8 @@
       <attribute persist="true" config_key="[Skin],sampler_row_1_expanded">0</attribute>
       <attribute persist="true" config_key="[Skin],sampler_row_2_expanded">0</attribute>
 
+      <!-- reset ducking mode on start to avoid effect master volume -->
+      <attribute config_key="[Master],talkoverDucking">0</attribute>
       <attribute persist="true" config_key="[Microphone],show_microphone">0</attribute>
       <!-- Library -->
       <attribute config_key="[Master],maximize_library">0</attribute>


### PR DESCRIPTION
This will prevent Master volume from being affected by `[Master],talkoverDucking` after a restart.
I've wasted quite some time looking for the reason of Master volume being way too low, until I figurred it was due to ducking mode being set to `Manual`. The Mic section was hidden and I eventually noticed this when scrolling through mixxx.cfg

Is there any strong reason to not reset it?

related:
https://bugs.launchpad.net/mixxx/+bug/1394968
"Manual ducking can mute master output, even if no microphone is configured"