### PR TITLE
lp1795023: Missing "Reset Key" in track context menu

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -503,9 +503,9 @@ void WTrackTableView::createActions() {
     connect(m_pClearLoopAction, SIGNAL(triggered()),
             this, SLOT(slotClearLoop()));
 
-    m_pClearKeysAction = new QAction(tr("Key(s)"), this);
-    connect(m_pClearKeysAction, SIGNAL(triggered()),
-            this, SLOT(slotClearKeys()));
+    m_pClearKeyAction = new QAction(tr("Key"), this);
+    connect(m_pClearKeyAction, SIGNAL(triggered()),
+            this, SLOT(slotClearKey()));
 
     m_pClearReplayGainAction = new QAction(tr("ReplayGain"), this);
     connect(m_pClearReplayGainAction, SIGNAL(triggered()),
@@ -935,7 +935,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
         //m_pClearMetadataMenu->addAction(m_pClearMainCueAction);
         m_pClearMetadataMenu->addAction(m_pClearHotCuesAction);
         //m_pClearMetadataMenu->addAction(m_pClearLoopAction);
-        m_pClearMetadataMenu->addAction(m_pClearKeysAction);
+        m_pClearMetadataMenu->addAction(m_pClearKeyAction);
         m_pClearMetadataMenu->addAction(m_pClearReplayGainAction);
         m_pClearMetadataMenu->addAction(m_pClearWaveformAction);
         m_pClearMetadataMenu->addSeparator();
@@ -1883,7 +1883,7 @@ void WTrackTableView::slotClearLoop() {
     }
 }
 
-void WTrackTableView::slotClearKeys() {
+void WTrackTableView::slotClearKey() {
     QModelIndexList indices = selectionModel()->selectedRows();
     TrackModel* trackModel = getTrackModel();
 
@@ -1939,7 +1939,7 @@ void WTrackTableView::slotClearAllMetadata() {
     slotClearMainCue();
     slotClearHotCues();
     slotClearLoop();
-    slotClearKeys();
+    slotClearKey();
     slotClearReplayGain();
     slotClearWaveform();
 }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -503,6 +503,10 @@ void WTrackTableView::createActions() {
     connect(m_pClearLoopAction, SIGNAL(triggered()),
             this, SLOT(slotClearLoop()));
 
+    m_pClearKeysAction = new QAction(tr("Key(s)"), this);
+    connect(m_pClearKeysAction, SIGNAL(triggered()),
+            this, SLOT(slotClearKeys()));
+
     m_pClearReplayGainAction = new QAction(tr("ReplayGain"), this);
     connect(m_pClearReplayGainAction, SIGNAL(triggered()),
             this, SLOT(slotClearReplayGain()));
@@ -931,6 +935,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
         //m_pClearMetadataMenu->addAction(m_pClearMainCueAction);
         m_pClearMetadataMenu->addAction(m_pClearHotCuesAction);
         //m_pClearMetadataMenu->addAction(m_pClearLoopAction);
+        m_pClearMetadataMenu->addAction(m_pClearKeysAction);
         m_pClearMetadataMenu->addAction(m_pClearReplayGainAction);
         m_pClearMetadataMenu->addAction(m_pClearWaveformAction);
         m_pClearMetadataMenu->addSeparator();
@@ -1878,6 +1883,22 @@ void WTrackTableView::slotClearLoop() {
     }
 }
 
+void WTrackTableView::slotClearKeys() {
+    QModelIndexList indices = selectionModel()->selectedRows();
+    TrackModel* trackModel = getTrackModel();
+
+    if (trackModel == nullptr) {
+        return;
+    }
+
+    for (const QModelIndex& index : indices) {
+        TrackPointer pTrack = trackModel->getTrack(index);
+        if (pTrack) {
+            pTrack->resetKeys();
+        }
+    }
+}
+
 void WTrackTableView::slotClearReplayGain() {
     QModelIndexList indices = selectionModel()->selectedRows();
     TrackModel* trackModel = getTrackModel();
@@ -1918,6 +1939,7 @@ void WTrackTableView::slotClearAllMetadata() {
     slotClearMainCue();
     slotClearHotCues();
     slotClearLoop();
+    slotClearKeys();
     slotClearReplayGain();
     slotClearWaveform();
 }

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -80,6 +80,7 @@ class WTrackTableView : public WLibraryTableView {
     void slotClearMainCue();
     void slotClearHotCues();
     void slotClearLoop();
+    void slotClearKeys();
     void slotClearReplayGain();
     void slotClearWaveform();
     void slotClearAllMetadata();
@@ -193,6 +194,7 @@ class WTrackTableView : public WLibraryTableView {
     QAction* m_pClearHotCuesAction;
     QAction* m_pClearLoopAction;
     QAction* m_pClearWaveformAction;
+    QAction* m_pClearKeysAction;
     QAction* m_pClearReplayGainAction;
     QAction* m_pClearAllMetadataAction;
 

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -80,7 +80,7 @@ class WTrackTableView : public WLibraryTableView {
     void slotClearMainCue();
     void slotClearHotCues();
     void slotClearLoop();
-    void slotClearKeys();
+    void slotClearKey();
     void slotClearReplayGain();
     void slotClearWaveform();
     void slotClearAllMetadata();
@@ -194,7 +194,7 @@ class WTrackTableView : public WLibraryTableView {
     QAction* m_pClearHotCuesAction;
     QAction* m_pClearLoopAction;
     QAction* m_pClearWaveformAction;
-    QAction* m_pClearKeysAction;
+    QAction* m_pClearKeyAction;
     QAction* m_pClearReplayGainAction;
     QAction* m_pClearAllMetadataAction;
 


### PR DESCRIPTION
Add menu entry for resetting musical key(s).

Needed for conveniently testing https://bugs.launchpad.net/mixxx/+bug/1813413. Still using Qt4 SIGNAL/SLOT macros for a minimal change set. The migration to Qt5 should be done separately for consistency.