### PR TITLE
lp1813413: Temporary workaround for QM key analyzer issues

### DIFF
--- a/src/analyzer/plugins/analyzerqueenmarykey.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarykey.cpp
@@ -1,5 +1,7 @@
 #include <dsp/keydetection/GetKeyMode.h>
 
+#include <QMutex>
+
 // Class header comes after library includes here since our preprocessor
 // definitions interfere with qm-dsp's headers.
 #include "analyzer/plugins/analyzerqueenmarykey.h"
@@ -17,6 +19,12 @@ constexpr int kChromaWindowLength = 10;
 
 // Tuning frequency of concert A in Hertz. Default value from VAMP plugin.
 constexpr int kTuningFrequencyHertz = 440;
+
+// NOTE(2019-01-26, uklotzde) Temporary workaround until multi-threading
+// issues when using the qm-dsp key detector have been solved. Synchronizes
+// all invocations of initialize()/process()/finalize().
+// See also: https://bugs.launchpad.net/mixxx/+bug/1813413
+QMutex s_mutex;
 
 }  // namespace
 
@@ -36,6 +44,8 @@ bool AnalyzerQueenMaryKey::initialize(int samplerate) {
                                               kChromaWindowLength, kChromaWindowLength);
     size_t windowSize = m_pKeyMode->getBlockSize();
     size_t stepSize = m_pKeyMode->getHopSize();
+
+    QMutexLocker locked(&s_mutex);
     return m_helper.initialize(
         windowSize, stepSize,
         [this](double* pWindow, size_t) {
@@ -65,14 +75,16 @@ bool AnalyzerQueenMaryKey::process(const CSAMPLE* pIn, const int iLen) {
     }
 
     const size_t numInputFrames = iLen / kAnalysisChannels;
-    bool result = m_helper.processStereoSamples(pIn, iLen);
+    QMutexLocker locked(&s_mutex);
+    const size_t numProcessedFrames = m_helper.processStereoSamples(pIn, iLen);
+    m_currentFrame += numProcessedFrames;
 
-    m_currentFrame += numInputFrames;
-    return result;
+    return numProcessedFrames == numInputFrames;
 }
 
 bool AnalyzerQueenMaryKey::finalize() {
     // TODO(rryan) do we need a flush?
+    QMutexLocker locked(&s_mutex);
     m_helper.finalize();
     m_pKeyMode.reset();
     return true;


### PR DESCRIPTION
This workaround only affects the QM key analyzer. Simply serializes/synchronizes all invocations of initialize()/process()/finalize() with a static mutex.

Now we have time to find the actual cause and users should no longer be affected by this critical bug!