### PR TITLE
adapt visible Skin Settings in small Deck in Latenight

### DIFF
--- a/res/skins/LateNight/deck_small.xml
+++ b/res/skins/LateNight/deck_small.xml
@@ -49,7 +49,7 @@
                       <TrackProperty>
                         <TooltipId>track_title</TooltipId>
                         <ObjectName>TitleTextSmall</ObjectName>
-                        <Size>55me,20f</Size>
+                        <Size>100me,20f</Size>
                         <Property>title</Property>
                         <Alignment>left</Alignment>
                         <Elide>right</Elide>
@@ -59,7 +59,7 @@
                       <NumberPos>
                         <TooltipId>track_time</TooltipId>
                         <ObjectName>PlayPositionTextSmall</ObjectName>
-                        <Size>145f,20f</Size>
+                        <Size>e,20f</Size>
                         <Alignment>center</Alignment>
                         <Channel><Variable name="channum"/></Channel>
                         <Connection>

--- a/res/skins/LateNight/deck_small.xml
+++ b/res/skins/LateNight/deck_small.xml
@@ -5,8 +5,6 @@
     <SizePolicy>me,min</SizePolicy>
     <Children>
 
-      <WidgetGroup><Size>0me,5f</Size></WidgetGroup>
-
       <WidgetGroup>
         <ObjectName>DeckSmall<Variable name="channum" /></ObjectName>
         <Layout>horizontal</Layout>

--- a/res/skins/LateNight/deck_small.xml
+++ b/res/skins/LateNight/deck_small.xml
@@ -49,7 +49,7 @@
                       <TrackProperty>
                         <TooltipId>track_title</TooltipId>
                         <ObjectName>TitleTextSmall</ObjectName>
-                        <Size>100me,20f</Size>
+                        <Size>55me,20f</Size>
                         <Property>title</Property>
                         <Alignment>left</Alignment>
                         <Elide>right</Elide>
@@ -59,7 +59,7 @@
                       <NumberPos>
                         <TooltipId>track_time</TooltipId>
                         <ObjectName>PlayPositionTextSmall</ObjectName>
-                        <Size>50min,20f</Size>
+                        <Size>145f,20f</Size>
                         <Alignment>center</Alignment>
                         <Channel><Variable name="channum"/></Channel>
                         <Connection>

--- a/res/skins/LateNight/decks_small.xml
+++ b/res/skins/LateNight/decks_small.xml
@@ -4,10 +4,20 @@
     <Layout>vertical</Layout>
     <SizePolicy>me,max</SizePolicy>
     <Children>
+
+      <WidgetGroup>
+        <Size>0me,5f</Size>
+        <Connection>
+          <ConfigKey>[Master],maximize_library</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
       <WidgetGroup>
         <Layout>horizontal</Layout>
         <SizePolicy>me,min</SizePolicy>
         <Children>
+
           <Template src="skin:deck_small.xml">
             <SetVariable name="channum">1</SetVariable>
             <SetVariable name="signal_color">#E7C413</SetVariable>
@@ -37,9 +47,18 @@
       </WidgetGroup>
 
       <WidgetGroup>
+        <Size>0me,5f</Size>
+        <Connection>
+          <ConfigKey>[Skin],show_4decks</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
+      <WidgetGroup>
         <Layout>horizontal</Layout>
         <SizePolicy>me,min</SizePolicy>
         <Children>
+
           <Template src="skin:deck_small.xml">
             <SetVariable name="channum">3</SetVariable>
             <SetVariable name="signal_color">#09B2AE</SetVariable>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -48,6 +48,7 @@
       <attribute persist="true" config_key="[Skin],show_big_spinny_coverart">0</attribute>
       <attribute persist="true" config_key="[Vinylcontrol],show_vinylcontrol">0</attribute>
       <attribute persist="true" config_key="[Skin],show_rate_controls">1</attribute>
+      <attribute persist="true" config_key="[Skin],small_decks">0</attribute>
       <!-- Mixer -->
       <attribute persist="true" config_key="[Master],show_mixer">1</attribute>
       <attribute persist="true" config_key="[Skin],show_eq_knobs">1</attribute>
@@ -265,15 +266,34 @@
                       <Layout>vertical</Layout>
                       <SizePolicy>me,me</SizePolicy>
                       <Children>
-                        <WidgetGroup>
+
+                          <WidgetGroup>
+                            <Layout>horizontal</Layout>
+                            <SizePolicy>me,max</SizePolicy>
+                            <Children>
+                              <Template src="skin:decks_left.xml"/>
+                              <Template src="skin:mixer.xml"/>
+                              <Template src="skin:decks_right.xml"/>
+                            </Children>
+                            <Connection>
+                              <ConfigKey>[Skin],small_decks</ConfigKey>
+                              <Transform><Not/></Transform>
+                              <BindProperty>visible</BindProperty>
+                            </Connection>
+                          </WidgetGroup>
+                  
+                          <WidgetGroup>
                           <Layout>horizontal</Layout>
                           <SizePolicy>me,max</SizePolicy>
                           <Children>
-                            <Template src="skin:decks_left.xml"/>
-                            <Template src="skin:mixer.xml"/>
-                            <Template src="skin:decks_right.xml"/>
-                          </Children>
-                        </WidgetGroup>
+                            <Template src="skin:decks_small.xml"/>
+                            </Children>
+                            <Connection>
+                              <ConfigKey>[Skin],small_decks</ConfigKey>
+                              <BindProperty>visible</BindProperty>
+                            </Connection>
+                          </WidgetGroup>
+                          
                         <Template src="skin:fx_rack.xml"/>
                         <Template src="skin:samplers_rack.xml"/>
                         <Template src="skin:mic_aux_rack.xml"/>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -267,32 +267,32 @@
                       <SizePolicy>me,me</SizePolicy>
                       <Children>
 
-                          <WidgetGroup>
-                            <Layout>horizontal</Layout>
-                            <SizePolicy>me,max</SizePolicy>
-                            <Children>
-                              <Template src="skin:decks_left.xml"/>
-                              <Template src="skin:mixer.xml"/>
-                              <Template src="skin:decks_right.xml"/>
-                            </Children>
-                            <Connection>
-                              <ConfigKey>[Skin],small_decks</ConfigKey>
-                              <Transform><Not/></Transform>
-                              <BindProperty>visible</BindProperty>
-                            </Connection>
-                          </WidgetGroup>
-                  
-                          <WidgetGroup>
+                        <WidgetGroup>
                           <Layout>horizontal</Layout>
                           <SizePolicy>me,max</SizePolicy>
                           <Children>
-                            <Template src="skin:decks_small.xml"/>
-                            </Children>
-                            <Connection>
-                              <ConfigKey>[Skin],small_decks</ConfigKey>
-                              <BindProperty>visible</BindProperty>
-                            </Connection>
-                          </WidgetGroup>
+                            <Template src="skin:decks_left.xml"/>
+                            <Template src="skin:mixer.xml"/>
+                            <Template src="skin:decks_right.xml"/>
+                          </Children>
+                          <Connection>
+                            <ConfigKey>[Skin],small_decks</ConfigKey>
+                            <Transform><Not/></Transform>
+                            <BindProperty>visible</BindProperty>
+                          </Connection>
+                        </WidgetGroup>
+                
+                        <WidgetGroup>
+                        <Layout>horizontal</Layout>
+                        <SizePolicy>me,max</SizePolicy>
+                        <Children>
+                          <Template src="skin:decks_small.xml"/>
+                          </Children>
+                          <Connection>
+                            <ConfigKey>[Skin],small_decks</ConfigKey>
+                            <BindProperty>visible</BindProperty>
+                          </Connection>
+                        </WidgetGroup>
                           
                         <Template src="skin:fx_rack.xml"/>
                         <Template src="skin:samplers_rack.xml"/>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -59,27 +59,91 @@ Description:
                 <SetVariable name="Setting">[Skin],show_4decks</SetVariable>
               </Template>
 
-              <!-- 4/8 Hotcues toggle -->
+              <!-- Small Decks toggle -->
               <Template src="skin:skin_settings_button_2state.xml">
-                <SetVariable name="TooltipId">hotcue_toggle</SetVariable>
-                <SetVariable name="text">8 Hotcues</SetVariable>
-                <SetVariable name="Setting">[Skin],show_8_hotcues</SetVariable>
+                <SetVariable name="TooltipId">small_decks</SetVariable>
+                <SetVariable name="text">Small Decks</SetVariable>
+                <SetVariable name="Setting">[Skin],small_decks</SetVariable>
               </Template>
 
-              <!-- Rate Control toggle -->
-              <Template src="skin:skin_settings_button_2state.xml">
-                <SetVariable name="TooltipId">rate_toggle</SetVariable>
-                <SetVariable name="text">Rate Control</SetVariable>
-                <SetVariable name="Setting">[Skin],show_rate_controls</SetVariable>
-              </Template>
+              <WidgetGroup><!-- 4/8 Hotcues toggle -->
+                <Layout>stacked</Layout>
+                <Size>190f,17f</Size>
+                <Children>
+                  <!-- index 0 due to bug -->
+                  <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
 
-              <!-- Vinyl Control toggle -->
-              <Template src="skin:skin_settings_button_2state.xml">
-                <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
-                <SetVariable name="text">Vinyl Control</SetVariable>
-                <SetVariable name="Setting">[VinylControl],show_vinylcontrol</SetVariable>
-              </Template>
+                  <WidgetGroup><!-- translucent cover with Small Decks -->
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>vertical</Layout>
+                    <Size>190f,17f</Size>
+                    <Connection>
+                      <ConfigKey persist="true">[Skin],small_decks</ConfigKey>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
 
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="TooltipId">hotcue_toggle</SetVariable>
+                    <SetVariable name="text">8 Hotcues</SetVariable>
+                    <SetVariable name="Setting">[Skin],show_8_hotcues</SetVariable>
+                  </Template>
+
+                </Children>
+              </WidgetGroup><!-- 4/8 Hotcues toggle -->
+
+              <WidgetGroup><!-- Rate Control toggle -->
+                <Layout>stacked</Layout>
+                <Size>190f,17f</Size>
+                <Children>
+                  <!-- index 0 due to bug -->
+                  <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
+
+                  <WidgetGroup><!-- translucent cover with Small Decks -->
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>vertical</Layout>
+                    <Size>190f,17f</Size>
+                    <Connection>
+                      <ConfigKey persist="true">[Skin],small_decks</ConfigKey>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
+
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="TooltipId">rate_toggle</SetVariable>
+                    <SetVariable name="text">Rate Control</SetVariable>
+                    <SetVariable name="Setting">[Skin],show_rate_controls</SetVariable>
+                  </Template>
+
+                </Children>
+              </WidgetGroup><!-- Rate Control toggle -->
+
+              <WidgetGroup><!-- Vinyl Control toggle -->
+                <Layout>stacked</Layout>
+                <Size>190f,17f</Size>
+                <Children>
+                  <!-- index 0 due to bug -->
+                  <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
+
+                  <WidgetGroup><!-- translucent cover with Small Decks -->
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>vertical</Layout>
+                    <Size>190f,17f</Size>
+                    <Connection>
+                      <ConfigKey persist="true">[Skin],small_decks</ConfigKey>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
+
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
+                    <SetVariable name="text">Vinyl Control</SetVariable>
+                    <SetVariable name="Setting">[VinylControl],show_vinylcontrol</SetVariable>
+                  </Template>
+
+                </Children>
+              </WidgetGroup><!-- Vinyl Control toggle -->
+              
               <!-- Spinny -->
               <Template src="skin:skin_settings_button_2state.xml">
                 <SetVariable name="TooltipId">show_spinny</SetVariable>
@@ -89,17 +153,36 @@ Description:
 
               <!-- Cover Art -->
               <Template src="skin:skin_settings_button_2state.xml">
-                <SetVariable name="TooltipId">show_spinny</SetVariable>
+                <SetVariable name="TooltipId">coverart</SetVariable>
                 <SetVariable name="text">Cover Art</SetVariable>
                 <SetVariable name="Setting">[Skin],show_coverart</SetVariable>
               </Template>
 
-              <!-- Big Spinny -->
-              <Template src="skin:skin_settings_button_2state.xml">
-                <SetVariable name="TooltipId">show_spinny</SetVariable>
-                <SetVariable name="text">Big Spinny/Cover Art</SetVariable>
-                <SetVariable name="Setting">[Skin],show_big_spinny_coverart</SetVariable>
-              </Template>
+              <WidgetGroup> <!-- Big Spinny -->>
+                <Layout>stacked</Layout>
+                <Size>190f,17f</Size>
+                <Children>
+                  <!-- index 0 due to bug -->
+                  <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
+
+                  <WidgetGroup><!-- translucent cover with Small Decks -->
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>vertical</Layout>
+                    <Size>190f,17f</Size>
+                    <Connection>
+                      <ConfigKey persist="true">[Skin],small_decks</ConfigKey>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
+
+                  <Template src="skin:skin_settings_button_2state.xml">
+                    <SetVariable name="TooltipId">show_spinny</SetVariable>
+                    <SetVariable name="text">Big Spinny/Cover Art</SetVariable>
+                    <SetVariable name="Setting">[Skin],show_big_spinny_coverart</SetVariable>
+                  </Template>
+
+                </Children>
+              </WidgetGroup> <!-- Big Spinny -->             
 
             </Children>
           </WidgetGroup><!-- /Deck / General -->

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -218,6 +218,16 @@ Description:
                     </Connection>
                   </WidgetGroup>
 
+                  <WidgetGroup><!-- translucent cover with Small Decks -->
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>vertical</Layout>
+                    <Size>190f,17f</Size>
+                    <Connection>
+                      <ConfigKey persist="true">[Skin],small_decks</ConfigKey>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
+
                   <Template src="skin:skin_settings_button_2state.xml">
                     <SetVariable name="text">EQ Knobs</SetVariable>
                     <SetVariable name="Setting">[Skin],show_eq_knobs</SetVariable>
@@ -232,6 +242,16 @@ Description:
                 <Children>
                   <!-- index 0 due to bug -->
                   <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
+
+                  <WidgetGroup><!-- translucent cover with Small Decks -->
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>vertical</Layout>
+                    <Size>190f,17f</Size>
+                    <Connection>
+                      <ConfigKey persist="true">[Skin],small_decks</ConfigKey>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
 
                   <WidgetGroup><!-- translucent cover when Channel Mixer is hidden -->
                     <ObjectName>SubmenuCover</ObjectName>
@@ -258,6 +278,16 @@ Description:
                 <Children>
                   <!-- index 0 due to bug -->
                   <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
+
+                  <WidgetGroup><!-- translucent cover with Small Decks -->
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>vertical</Layout>
+                    <Size>190f,17f</Size>
+                    <Connection>
+                      <ConfigKey persist="true">[Skin],small_decks</ConfigKey>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
 
                   <WidgetGroup><!-- translucent cover when Channel Mixer is hidden -->
                     <ObjectName>SubmenuCover</ObjectName>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -49,6 +49,7 @@ WPushButton, QPushButton {
 #Deck3 #KeyText, #Deck4 #KeyText,
 WSearchLineEdit:focus,
 #LatencyLabel,
+biglibraryknoblabel,
 WTime {
   color: #eece33;
   font-weight: bold;
@@ -189,7 +190,8 @@ WTime {
   font-size: 13px/13px;
 }
 
-#LatencyLabel {
+#LatencyLabel,
+#biglibraryknoblabel {
   padding-bottom: 2px;
   font-size: 10px/10px;
 }

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -67,11 +67,114 @@
 
           <Template src="skin:button_2state_persist.xml">
             <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
-            <SetVariable name="Size">125f,24f</SetVariable>
-            <SetVariable name="state_0_text">Cover Art Library</SetVariable>
-            <SetVariable name="state_1_text">Cover Art Library</SetVariable>
+            <SetVariable name="Size">95f,24f</SetVariable>
+            <SetVariable name="state_0_text">Cover Art Lib</SetVariable>
+            <SetVariable name="state_1_text">Cover Art Lib</SetVariable>
             <SetVariable name="ConfigKey">[Library],show_coverart</SetVariable>
           </Template>
+
+          <WidgetGroup>
+            <SizePolicy>min,min</SizePolicy>
+            <Layout>horizontal</Layout>
+            <Alignment>center</Alignment>
+            <Children>
+              <WidgetGroup>
+                <Layout>horizontal</Layout>
+                <SizePolicy>me,min</SizePolicy>
+                <Children>
+                  <Template src="skin:knob_textless.xml">
+                    <SetVariable name="Size">28f,24f</SetVariable>
+                    <SetVariable name="Color">green</SetVariable>
+                    <SetVariable name="TooltipId">headMix</SetVariable>
+                    <SetVariable name="group">[Master]</SetVariable>
+                    <SetVariable name="control">headMix</SetVariable>
+                  </Template>
+
+                  <Label>
+                    <SizePolicy>min,min</SizePolicy>
+                     <ObjectName>biglibraryknoblabel</ObjectName>
+                    <Text>head mix</Text>
+                  </Label>
+
+                  <!-- Spacer -->
+                  <WidgetGroup>
+                    <Size>5,5</Size>
+                    <Children/>
+                  </WidgetGroup>
+
+                  <Template src="skin:knob_textless.xml">
+                    <SetVariable name="Size">28f,24f</SetVariable>
+                    <SetVariable name="Color">orange</SetVariable>
+                    <SetVariable name="TooltipId">headphone_gain</SetVariable>
+                    <SetVariable name="group">[Master]</SetVariable>
+                    <SetVariable name="control">headGain</SetVariable>
+                  </Template>
+
+                  <Label>
+                    <SizePolicy>min,min</SizePolicy>
+                     <ObjectName>biglibraryknoblabel</ObjectName>
+                    <Text>head</Text>
+                  </Label>
+
+                  <!-- Spacer -->
+                  <WidgetGroup>
+                    <Size>5,5</Size>
+                    <Children/>
+                  </WidgetGroup>
+
+                  <Template src="skin:button_2state.xml">
+                    <SetVariable name="TooltipId">headSplit</SetVariable>
+                    <SetVariable name="ObjectName">FxAssignButton</SetVariable>
+                    <SetVariable name="Size">64f,20f</SetVariable>
+                    <SetVariable name="state_0_text">Split Cue</SetVariable>
+                    <SetVariable name="state_1_text">Split Cue</SetVariable>
+                    <SetVariable name="ConfigKey">[Master],headSplit</SetVariable>
+                  </Template>
+
+                  <!-- Spacer -->
+                  <WidgetGroup>
+                    <Size>5,5</Size>
+                    <Children/>
+                  </WidgetGroup>
+
+                  <Template src="skin:knob_textless.xml">
+                    <SetVariable name="Size">28f,24f</SetVariable>
+                    <SetVariable name="Color">red</SetVariable>
+                    <SetVariable name="TooltipId">balance</SetVariable>
+                    <SetVariable name="group">[Master]</SetVariable>
+                    <SetVariable name="control">balance</SetVariable>
+                  </Template>
+
+                  <Label>
+                    <SizePolicy>min,min</SizePolicy>
+                     <ObjectName>biglibraryknoblabel</ObjectName>
+                    <Text>balance</Text>
+                  </Label>
+
+                  <!-- Spacer -->
+                  <WidgetGroup>
+                    <Size>5,5</Size>
+                    <Children/>
+                  </WidgetGroup>
+
+                  <Template src="skin:knob_textless.xml">
+                    <SetVariable name="Size">28f,24f</SetVariable>
+                    <SetVariable name="Color">orange</SetVariable>
+                    <SetVariable name="TooltipId">master_gain</SetVariable>
+                    <SetVariable name="group">[Master]</SetVariable>
+                    <SetVariable name="control">gain</SetVariable>
+                  </Template>
+
+                  <Label>
+                    <SizePolicy>min,min</SizePolicy>
+                    <ObjectName>biglibraryknoblabel</ObjectName>
+                    <Text>master</Text>
+                  </Label>
+
+                </Children>
+              </WidgetGroup>
+            </Children>
+          </WidgetGroup>
 
         </Children>
         <Connection>
@@ -128,19 +231,19 @@
             <SetVariable name="ConfigKey">[Microphone],show_microphone</SetVariable>
           </Template>
 
+          <!-- Spacer -->
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
+            <Size>me,min</Size>
+            <Children/>
+          </WidgetGroup>
+
         </Children>
         <Connection>
           <ConfigKey>[Master],maximize_library</ConfigKey>
           <Transform><Not/></Transform>
           <BindProperty>visible</BindProperty>
         </Connection>
-      </WidgetGroup>
-
-      <!-- Spacer -->
-      <WidgetGroup>
-        <Layout>horizontal</Layout>
-        <Size>me,min</Size>
-        <Children/>
       </WidgetGroup>
 
       <WidgetGroup><!-- Recording button & recording duration label -->

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -73,6 +73,68 @@
             <SetVariable name="ConfigKey">[Library],show_coverart</SetVariable>
           </Template>
 
+          <!-- Spacer -->
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
+            <Size>me,min</Size>
+            <Children/>
+          </WidgetGroup>
+
+        </Children>
+        <Connection>
+          <ConfigKey>[Master],maximize_library</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
+
+      <!-- Visible with normal Library -->
+      <WidgetGroup>
+        <SizePolicy>min,min</SizePolicy>
+        <Layout>horizontal</Layout>
+        <Children>
+
+          <WidgetGroup>
+            <ObjectName>ToolbarDivider</ObjectName>
+            <Size>13f,9min</Size>
+          </WidgetGroup>
+
+          <Template src="skin:button_2state_persist.xml">
+            <SetVariable name="TooltipId">show_mixer</SetVariable>
+            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
+            <SetVariable name="Size">48f,24f</SetVariable>
+            <SetVariable name="state_0_text">MIXER</SetVariable>
+            <SetVariable name="state_1_text">MIXER</SetVariable>
+            <SetVariable name="ConfigKey">[Master],show_mixer</SetVariable>
+          </Template>
+
+          <Template src="skin:button_2state_persist.xml">
+            <SetVariable name="TooltipId">show_effects</SetVariable>
+            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
+            <SetVariable name="Size">59f,24f</SetVariable>
+            <SetVariable name="state_0_text">EFFECTS</SetVariable>
+            <SetVariable name="state_1_text">EFFECTS</SetVariable>
+            <SetVariable name="ConfigKey">[EffectRack1],show</SetVariable>
+          </Template>
+
+          <Template src="skin:button_2state_persist.xml">
+            <SetVariable name="TooltipId">show_samplers</SetVariable>
+            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
+            <SetVariable name="Size">71f,24f</SetVariable>
+            <SetVariable name="state_0_text">SAMPLERS</SetVariable>
+            <SetVariable name="state_1_text">SAMPLERS</SetVariable>
+            <SetVariable name="ConfigKey">[Samplers],show_samplers</SetVariable>
+          </Template>
+
+          <Template src="skin:button_2state_persist.xml">
+            <SetVariable name="TooltipId">show_microphone</SetVariable>
+            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
+            <SetVariable name="Size">61f,24f</SetVariable>
+            <SetVariable name="state_0_text">MIC/AUX</SetVariable>
+            <SetVariable name="state_1_text">MIC/AUX</SetVariable>
+            <SetVariable name="ConfigKey">[Microphone],show_microphone</SetVariable>
+          </Template>
+
           <WidgetGroup>
             <SizePolicy>min,min</SizePolicy>
             <Layout>horizontal</Layout>
@@ -174,68 +236,22 @@
                 </Children>
               </WidgetGroup>
             </Children>
+            <Connection>
+              <ConfigKey>[Skin],small_decks</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
           </WidgetGroup>
-
-        </Children>
-        <Connection>
-          <ConfigKey>[Master],maximize_library</ConfigKey>
-          <BindProperty>visible</BindProperty>
-        </Connection>
-      </WidgetGroup>
-
-
-      <!-- Visible with normal Library -->
-      <WidgetGroup>
-        <SizePolicy>min,min</SizePolicy>
-        <Layout>horizontal</Layout>
-        <Children>
-
-          <WidgetGroup>
-            <ObjectName>ToolbarDivider</ObjectName>
-            <Size>13f,9min</Size>
-          </WidgetGroup>
-
-          <Template src="skin:button_2state_persist.xml">
-            <SetVariable name="TooltipId">show_mixer</SetVariable>
-            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
-            <SetVariable name="Size">48f,24f</SetVariable>
-            <SetVariable name="state_0_text">MIXER</SetVariable>
-            <SetVariable name="state_1_text">MIXER</SetVariable>
-            <SetVariable name="ConfigKey">[Master],show_mixer</SetVariable>
-          </Template>
-
-          <Template src="skin:button_2state_persist.xml">
-            <SetVariable name="TooltipId">show_effects</SetVariable>
-            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
-            <SetVariable name="Size">59f,24f</SetVariable>
-            <SetVariable name="state_0_text">EFFECTS</SetVariable>
-            <SetVariable name="state_1_text">EFFECTS</SetVariable>
-            <SetVariable name="ConfigKey">[EffectRack1],show</SetVariable>
-          </Template>
-
-          <Template src="skin:button_2state_persist.xml">
-            <SetVariable name="TooltipId">show_samplers</SetVariable>
-            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
-            <SetVariable name="Size">71f,24f</SetVariable>
-            <SetVariable name="state_0_text">SAMPLERS</SetVariable>
-            <SetVariable name="state_1_text">SAMPLERS</SetVariable>
-            <SetVariable name="ConfigKey">[Samplers],show_samplers</SetVariable>
-          </Template>
-
-          <Template src="skin:button_2state_persist.xml">
-            <SetVariable name="TooltipId">show_microphone</SetVariable>
-            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
-            <SetVariable name="Size">61f,24f</SetVariable>
-            <SetVariable name="state_0_text">MIC/AUX</SetVariable>
-            <SetVariable name="state_1_text">MIC/AUX</SetVariable>
-            <SetVariable name="ConfigKey">[Microphone],show_microphone</SetVariable>
-          </Template>
 
           <!-- Spacer -->
           <WidgetGroup>
             <Layout>horizontal</Layout>
             <Size>me,min</Size>
             <Children/>
+            <Connection>
+              <ConfigKey>[Skin],small_decks</ConfigKey>
+              <Transform><Not/></Transform>
+              <BindProperty>visible</BindProperty>
+            </Connection>
           </WidgetGroup>
 
         </Children>

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -13,7 +13,75 @@
         <SetVariable name="state_1_text">BIG LIBRARY</SetVariable>
         <SetVariable name="ConfigKey">[Master],maximize_library</SetVariable>
       </Template>
+      
+      <!-- Visible with Big Library -->
+      <WidgetGroup>
+        <SizePolicy>min,min</SizePolicy>
+        <Layout>horizontal</Layout>
+        <Children>
+          <WidgetGroup>
+            <ObjectName>ToolbarDivider</ObjectName>
+            <Size>13f,9min</Size>
+          </WidgetGroup>
 
+          <Template src="skin:button_2state_persist.xml">
+            <SetVariable name="TooltipId">toggle_4decks</SetVariable>
+            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
+            <SetVariable name="Size">60f,24f</SetVariable>
+            <SetVariable name="state_0_text">4 DECKS</SetVariable>
+            <SetVariable name="state_1_text">4 DECKS</SetVariable>
+            <SetVariable name="ConfigKey">[Skin],show_4decks</SetVariable>
+          </Template>
+
+          <Template src="skin:button_2state_persist.xml">
+            <SetVariable name="TooltipId">show_spinny</SetVariable>
+            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
+            <SetVariable name="Size">55f,24f</SetVariable>
+            <SetVariable name="state_0_text">SPINNY</SetVariable>
+            <SetVariable name="state_1_text">SPINNY</SetVariable>
+            <SetVariable name="ConfigKey">[Skin],show_spinnies</SetVariable>
+          </Template>
+
+          <Template src="skin:button_2state_persist.xml">
+            <SetVariable name="TooltipId">coverart</SetVariable>
+            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
+            <SetVariable name="Size">75f,24f</SetVariable>
+            <SetVariable name="state_0_text">COVER ART</SetVariable>
+            <SetVariable name="state_1_text">COVER ART</SetVariable>
+            <SetVariable name="ConfigKey">[Skin],show_coverart</SetVariable>
+          </Template>
+
+          <WidgetGroup>
+            <ObjectName>ToolbarDivider</ObjectName>
+            <Size>13f,9min</Size>
+          </WidgetGroup>
+
+          <Template src="skin:button_2state_persist.xml">
+            <SetVariable name="TooltipId">show_previewdeck</SetVariable>
+            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
+            <SetVariable name="Size">95f,24f</SetVariable>
+            <SetVariable name="state_0_text">Preview Deck</SetVariable>
+            <SetVariable name="state_1_text">Preview Deck</SetVariable>
+            <SetVariable name="ConfigKey">[PreviewDeck],show_previewdeck</SetVariable>
+          </Template>
+
+          <Template src="skin:button_2state_persist.xml">
+            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
+            <SetVariable name="Size">125f,24f</SetVariable>
+            <SetVariable name="state_0_text">Cover Art Library</SetVariable>
+            <SetVariable name="state_1_text">Cover Art Library</SetVariable>
+            <SetVariable name="ConfigKey">[Library],show_coverart</SetVariable>
+          </Template>
+
+        </Children>
+        <Connection>
+          <ConfigKey>[Master],maximize_library</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
+
+      <!-- Visible with normal Library -->
       <WidgetGroup>
         <SizePolicy>min,min</SizePolicy>
         <Layout>horizontal</Layout>
@@ -152,6 +220,11 @@
       <WidgetGroup>
         <ObjectName>ToolbarDivider</ObjectName>
         <Size>13f,9min</Size>
+        <Connection>
+          <ConfigKey>[Master],maximize_library</ConfigKey>
+          <Transform><Not/></Transform>
+          <BindProperty>visible</BindProperty>
+        </Connection>
       </WidgetGroup>
 
       <PushButton>
@@ -169,6 +242,11 @@
         </State>
         <Connection>
           <ConfigKey persist="true">[Master],skin_settings</ConfigKey>
+        </Connection>
+        <Connection>
+          <ConfigKey>[Master],maximize_library</ConfigKey>
+          <Transform><Not/></Transform>
+          <BindProperty>visible</BindProperty>
         </Connection>
       </PushButton>
 

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -19,59 +19,6 @@
         <SizePolicy>min,min</SizePolicy>
         <Layout>horizontal</Layout>
         <Children>
-          <WidgetGroup>
-            <ObjectName>ToolbarDivider</ObjectName>
-            <Size>13f,9min</Size>
-          </WidgetGroup>
-
-          <Template src="skin:button_2state_persist.xml">
-            <SetVariable name="TooltipId">toggle_4decks</SetVariable>
-            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
-            <SetVariable name="Size">60f,24f</SetVariable>
-            <SetVariable name="state_0_text">4 DECKS</SetVariable>
-            <SetVariable name="state_1_text">4 DECKS</SetVariable>
-            <SetVariable name="ConfigKey">[Skin],show_4decks</SetVariable>
-          </Template>
-
-          <Template src="skin:button_2state_persist.xml">
-            <SetVariable name="TooltipId">show_spinny</SetVariable>
-            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
-            <SetVariable name="Size">55f,24f</SetVariable>
-            <SetVariable name="state_0_text">SPINNY</SetVariable>
-            <SetVariable name="state_1_text">SPINNY</SetVariable>
-            <SetVariable name="ConfigKey">[Skin],show_spinnies</SetVariable>
-          </Template>
-
-          <Template src="skin:button_2state_persist.xml">
-            <SetVariable name="TooltipId">coverart</SetVariable>
-            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
-            <SetVariable name="Size">75f,24f</SetVariable>
-            <SetVariable name="state_0_text">COVER ART</SetVariable>
-            <SetVariable name="state_1_text">COVER ART</SetVariable>
-            <SetVariable name="ConfigKey">[Skin],show_coverart</SetVariable>
-          </Template>
-
-          <WidgetGroup>
-            <ObjectName>ToolbarDivider</ObjectName>
-            <Size>13f,9min</Size>
-          </WidgetGroup>
-
-          <Template src="skin:button_2state_persist.xml">
-            <SetVariable name="TooltipId">show_previewdeck</SetVariable>
-            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
-            <SetVariable name="Size">95f,24f</SetVariable>
-            <SetVariable name="state_0_text">Preview Deck</SetVariable>
-            <SetVariable name="state_1_text">Preview Deck</SetVariable>
-            <SetVariable name="ConfigKey">[PreviewDeck],show_previewdeck</SetVariable>
-          </Template>
-
-          <Template src="skin:button_2state_persist.xml">
-            <SetVariable name="ObjectName">GuiToggleButton</SetVariable>
-            <SetVariable name="Size">95f,24f</SetVariable>
-            <SetVariable name="state_0_text">Cover Art Lib</SetVariable>
-            <SetVariable name="state_1_text">Cover Art Lib</SetVariable>
-            <SetVariable name="ConfigKey">[Library],show_coverart</SetVariable>
-          </Template>
 
           <!-- Spacer -->
           <WidgetGroup>
@@ -86,7 +33,6 @@
           <BindProperty>visible</BindProperty>
         </Connection>
       </WidgetGroup>
-
 
       <!-- Visible with normal Library -->
       <WidgetGroup>

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -90,60 +90,6 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>me,min</SizePolicy>
                 <Children>
-                  <Template src="skin:knob_textless.xml">
-                    <SetVariable name="Size">28f,24f</SetVariable>
-                    <SetVariable name="Color">green</SetVariable>
-                    <SetVariable name="TooltipId">headMix</SetVariable>
-                    <SetVariable name="group">[Master]</SetVariable>
-                    <SetVariable name="control">headMix</SetVariable>
-                  </Template>
-
-                  <Label>
-                    <SizePolicy>min,min</SizePolicy>
-                     <ObjectName>biglibraryknoblabel</ObjectName>
-                    <Text>head mix</Text>
-                  </Label>
-
-                  <!-- Spacer -->
-                  <WidgetGroup>
-                    <Size>5,5</Size>
-                    <Children/>
-                  </WidgetGroup>
-
-                  <Template src="skin:knob_textless.xml">
-                    <SetVariable name="Size">28f,24f</SetVariable>
-                    <SetVariable name="Color">orange</SetVariable>
-                    <SetVariable name="TooltipId">headphone_gain</SetVariable>
-                    <SetVariable name="group">[Master]</SetVariable>
-                    <SetVariable name="control">headGain</SetVariable>
-                  </Template>
-
-                  <Label>
-                    <SizePolicy>min,min</SizePolicy>
-                     <ObjectName>biglibraryknoblabel</ObjectName>
-                    <Text>head</Text>
-                  </Label>
-
-                  <!-- Spacer -->
-                  <WidgetGroup>
-                    <Size>5,5</Size>
-                    <Children/>
-                  </WidgetGroup>
-
-                  <Template src="skin:button_2state.xml">
-                    <SetVariable name="TooltipId">headSplit</SetVariable>
-                    <SetVariable name="ObjectName">FxAssignButton</SetVariable>
-                    <SetVariable name="Size">64f,20f</SetVariable>
-                    <SetVariable name="state_0_text">Split Cue</SetVariable>
-                    <SetVariable name="state_1_text">Split Cue</SetVariable>
-                    <SetVariable name="ConfigKey">[Master],headSplit</SetVariable>
-                  </Template>
-
-                  <!-- Spacer -->
-                  <WidgetGroup>
-                    <Size>5,5</Size>
-                    <Children/>
-                  </WidgetGroup>
 
                   <Template src="skin:knob_textless.xml">
                     <SetVariable name="Size">28f,24f</SetVariable>


### PR DESCRIPTION
This PR:
-  adapts the visible Skin Settings in small Deck in Latenight
- makes small Deck usable as skin option
- adds smal knobs to the toolbar if small deck are used as skin option (not  with big library)

Further more I would like to add an eject and headphone button to the small decks.

What do you think about the different points?
![small_deck_skin_setting](https://user-images.githubusercontent.com/3403218/51867486-f4e9e780-234b-11e9-85b6-e201bbef5587.png)
![big_library_small_deck](https://user-images.githubusercontent.com/3403218/51867487-f4e9e780-234b-11e9-861d-eb5bccd6b8fe.png)
