### PR TITLE
Deere :: enlarge fx toggles

### DIFF
--- a/res/skins/Deere/effect_buttons.xml
+++ b/res/skins/Deere/effect_buttons.xml
@@ -10,6 +10,7 @@ Variables:
 <Template>
   <WidgetGroup>
     <ObjectName>EffectButtonControls</ObjectName>
+    <SizePolicy><Variable name="SizePolicy"/></SizePolicy>
     <Layout>horizontal</Layout>
     <Children>
       <Template src="skin:effect_focus_button.xml"/>
@@ -18,8 +19,8 @@ Variables:
         <SetVariable name="TooltipId">EffectSlot_enabled</SetVariable>
         <SetVariable name="ObjectName">EffectEnableButton</SetVariable>
         <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-        <SetVariable name="MaximumSize">60,22</SetVariable>
-        <SetVariable name="SizePolicy">me,f</SetVariable>
+        <SetVariable name="MaximumSize"><Variable name="EnableButtonMaxSize"/></SetVariable>
+        <SetVariable name="SizePolicy">me,me</SetVariable>
         <SetVariable name="left_connection_control">[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>_Effect<Variable name="Effect"/>],enabled</SetVariable>
       </Template>
 

--- a/res/skins/Deere/effect_buttons.xml
+++ b/res/skins/Deere/effect_buttons.xml
@@ -16,16 +16,10 @@ Variables:
 
       <Template src="skin:left_2state_button.xml">
         <SetVariable name="TooltipId">EffectSlot_enabled</SetVariable>
-        <SetVariable name="ObjectName"></SetVariable>
+        <SetVariable name="ObjectName">EffectEnableButton</SetVariable>
         <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
-        <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
-        <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>
-        <SetVariable name="state_0_text"></SetVariable>
-        <SetVariable name="state_0_pressed">icon/ic_power_48px.svg</SetVariable>
-        <SetVariable name="state_0_unpressed">icon/ic_power_48px.svg</SetVariable>
-        <SetVariable name="state_1_text"></SetVariable>
-        <SetVariable name="state_1_pressed">icon/ic_power_48px.svg</SetVariable>
-        <SetVariable name="state_1_unpressed">icon/ic_power_48px.svg</SetVariable>
+        <SetVariable name="MaximumSize">60,22</SetVariable>
+        <SetVariable name="SizePolicy">me,f</SetVariable>
         <SetVariable name="left_connection_control">[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>_Effect<Variable name="Effect"/>],enabled</SetVariable>
       </Template>
 

--- a/res/skins/Deere/effect_focus_button.xml
+++ b/res/skins/Deere/effect_focus_button.xml
@@ -10,6 +10,8 @@ Variables:
   <SetVariable name="EffectGroup">[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>]</SetVariable>
   <WidgetGroup>
     <ObjectName>EffectFocusButtonContainer</ObjectName>
+    <MaximumSize>15,15</MaximumSize>
+    <SizePolicy>min,min</SizePolicy>
     <Layout>vertical</Layout>
     <Children>
       <PushButton>

--- a/res/skins/Deere/effect_single_no_parameters.xml
+++ b/res/skins/Deere/effect_single_no_parameters.xml
@@ -23,7 +23,10 @@ Variables:
           <WidgetGroup>
             <Layout>horizontal</Layout>
             <Children>
-              <Template src="skin:effect_buttons.xml"/>
+              <Template src="skin:effect_buttons.xml">
+                <SetVariable name="SizePolicy">min,max</SetVariable>
+                <SetVariable name="EnableButtonMaxSize">60,22</SetVariable>
+              </Template>
               <Template src="skin:effect_meta_knob.xml"/>
             </Children>
           </WidgetGroup>
@@ -69,7 +72,10 @@ Variables:
           <WidgetGroup>
             <Layout>horizontal</Layout>
             <Children>
-              <Template src="skin:effect_buttons.xml"/>
+              <Template src="skin:effect_buttons.xml">
+                <SetVariable name="SizePolicy">min,max</SetVariable>
+                <SetVariable name="EnableButtonMaxSize">60,22</SetVariable>
+              </Template>
               <Template src="skin:effect_meta_knob.xml"/>
             </Children>
           </WidgetGroup>

--- a/res/skins/Deere/effect_single_with_parameters_row.xml
+++ b/res/skins/Deere/effect_single_with_parameters_row.xml
@@ -15,15 +15,19 @@ Variables:
     <Children>
       <WidgetGroup>
         <ObjectName>EffectUnitParameters</ObjectName>
-        <SizePolicy>me,min</SizePolicy>
+        <Size>-1me,42f</Size>
         <Layout>horizontal</Layout>
         <Children>
 
           <WidgetGroup>
             <ObjectName>EffectButtonContainer</ObjectName>
+            <SizePolicy>min,min</SizePolicy>
             <Layout>horizontal</Layout>
             <Children>
-              <Template src="skin:effect_buttons.xml"/>
+              <Template src="skin:effect_buttons.xml">
+                <SetVariable name="SizePolicy">max,min</SetVariable>
+                <SetVariable name="EnableButtonMaxSize">22,36</SetVariable>
+              </Template>
               <Template src="skin:effect_meta_knob.xml"/>
             </Children>
           </WidgetGroup>
@@ -39,55 +43,62 @@ Variables:
             <SizePolicy>min,f</SizePolicy>
           </EffectSelector>
 
-          <Template src="skin:effect_parameter_knob.xml">
-            <SetVariable name="EffectParameter">1</SetVariable>
-          </Template>
-          <Template src="skin:effect_parameter_knob.xml">
-            <SetVariable name="EffectParameter">2</SetVariable>
-          </Template>
-          <Template src="skin:effect_parameter_knob.xml">
-            <SetVariable name="EffectParameter">3</SetVariable>
-          </Template>
-          <Template src="skin:effect_parameter_knob.xml">
-            <SetVariable name="EffectParameter">4</SetVariable>
-          </Template>
-          <Template src="skin:effect_parameter_knob.xml">
-            <SetVariable name="EffectParameter">5</SetVariable>
-          </Template>
-          <Template src="skin:effect_parameter_knob.xml">
-            <SetVariable name="EffectParameter">6</SetVariable>
-          </Template>
-          <Template src="skin:effect_parameter_knob.xml">
-            <SetVariable name="EffectParameter">7</SetVariable>
-          </Template>
-          <Template src="skin:effect_parameter_knob.xml">
-            <SetVariable name="EffectParameter">8</SetVariable>
-          </Template>
+          <WidgetGroup>
+            <ObjectName>EffectParameterKnobsButtons</ObjectName>
+            <SizePolicy>me,min</SizePolicy>
+            <Layout>horizontal</Layout>
+            <Children>
+              <Template src="skin:effect_parameter_knob.xml">
+                <SetVariable name="EffectParameter">1</SetVariable>
+              </Template>
+              <Template src="skin:effect_parameter_knob.xml">
+                <SetVariable name="EffectParameter">2</SetVariable>
+              </Template>
+              <Template src="skin:effect_parameter_knob.xml">
+                <SetVariable name="EffectParameter">3</SetVariable>
+              </Template>
+              <Template src="skin:effect_parameter_knob.xml">
+                <SetVariable name="EffectParameter">4</SetVariable>
+              </Template>
+              <Template src="skin:effect_parameter_knob.xml">
+                <SetVariable name="EffectParameter">5</SetVariable>
+              </Template>
+              <Template src="skin:effect_parameter_knob.xml">
+                <SetVariable name="EffectParameter">6</SetVariable>
+              </Template>
+              <Template src="skin:effect_parameter_knob.xml">
+                <SetVariable name="EffectParameter">7</SetVariable>
+              </Template>
+              <Template src="skin:effect_parameter_knob.xml">
+                <SetVariable name="EffectParameter">8</SetVariable>
+              </Template>
 
-          <Template src="skin:effect_button_parameter.xml">
-            <SetVariable name="EffectButtonParameter">1</SetVariable>
-          </Template>
-          <Template src="skin:effect_button_parameter.xml">
-            <SetVariable name="EffectButtonParameter">2</SetVariable>
-          </Template>
-          <Template src="skin:effect_button_parameter.xml">
-            <SetVariable name="EffectButtonParameter">3</SetVariable>
-          </Template>
-          <Template src="skin:effect_button_parameter.xml">
-            <SetVariable name="EffectButtonParameter">4</SetVariable>
-          </Template>
-          <Template src="skin:effect_button_parameter.xml">
-            <SetVariable name="EffectButtonParameter">5</SetVariable>
-          </Template>
-          <Template src="skin:effect_button_parameter.xml">
-            <SetVariable name="EffectButtonParameter">6</SetVariable>
-          </Template>
-          <Template src="skin:effect_button_parameter.xml">
-            <SetVariable name="EffectButtonParameter">7</SetVariable>
-          </Template>
-          <Template src="skin:effect_button_parameter.xml">
-            <SetVariable name="EffectButtonParameter">8</SetVariable>
-          </Template>
+              <Template src="skin:effect_button_parameter.xml">
+                <SetVariable name="EffectButtonParameter">1</SetVariable>
+              </Template>
+              <Template src="skin:effect_button_parameter.xml">
+                <SetVariable name="EffectButtonParameter">2</SetVariable>
+              </Template>
+              <Template src="skin:effect_button_parameter.xml">
+                <SetVariable name="EffectButtonParameter">3</SetVariable>
+              </Template>
+              <Template src="skin:effect_button_parameter.xml">
+                <SetVariable name="EffectButtonParameter">4</SetVariable>
+              </Template>
+              <Template src="skin:effect_button_parameter.xml">
+                <SetVariable name="EffectButtonParameter">5</SetVariable>
+              </Template>
+              <Template src="skin:effect_button_parameter.xml">
+                <SetVariable name="EffectButtonParameter">6</SetVariable>
+              </Template>
+              <Template src="skin:effect_button_parameter.xml">
+                <SetVariable name="EffectButtonParameter">7</SetVariable>
+              </Template>
+              <Template src="skin:effect_button_parameter.xml">
+                <SetVariable name="EffectButtonParameter">8</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup>
         </Children>
       </WidgetGroup>
     </Children>

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -1107,6 +1107,10 @@ WBeatSpinBox,
   border: none;
 }
 
+#EffectEnableButton {
+  image: url(skin:/icon/ic_power_48px.svg) no-repeat center center;
+}
+
 WEffectSelector {
   color: #c1cabe;
   background-color: #444342;


### PR DESCRIPTION
Recently, I used Deere for the first time with 4 fx units and controller and I found it quite difficult to read the fx enable status at a glance as both the Meta knobs and the toggles are blue.
This enlarges the fx toggles.

Btw, I'd really love to implement the EffectSelector 'hack' from Tango (minimal combined toggle and drop-down) in the EffectSelector widget but am still lacking the skills to do so.

this PR / master
![deere-fx-coll](https://user-images.githubusercontent.com/5934199/53699680-512ca500-3deb-11e9-8d6e-235bf2f0fe0b.png)

![deere-fx-exp](https://user-images.githubusercontent.com/5934199/53699683-57228600-3deb-11e9-9682-86bf1f2ad3dc.png)

