### PR TITLE
trigger double load clone from PlayerManager instead of BaseTrackPlayer

### DIFF
--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -11,7 +11,6 @@
 #include "mixer/baseplayer.h"
 #include "track/track.h"
 #include "util/memory.h"
-#include "util/performancetimer.h"
 
 class EngineMaster;
 class ControlObject;
@@ -39,8 +38,8 @@ class BaseTrackPlayer : public BasePlayer {
 
   public slots:
     virtual void slotLoadTrack(TrackPointer pTrack, bool bPlay = false) = 0;
-    virtual void slotCloneChannel(EngineChannel* pChannel) = 0;
-    virtual void slotCloneDeck(const QString& group) = 0;
+    virtual void slotCloneFromGroup(const QString& group) = 0;
+    virtual void slotCloneDeck() = 0;
 
   signals:
     void newTrackLoaded(TrackPointer pLoadedTrack);
@@ -77,15 +76,15 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
 
   public slots:
     void slotLoadTrack(TrackPointer track, bool bPlay) final;
-    void slotCloneChannel(EngineChannel* pChannel) final;
-    void slotCloneDeck(const QString& group) final;
+    void slotCloneFromGroup(const QString& group) final;
+    void slotCloneDeck() final;
     void slotTrackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void slotLoadFailed(TrackPointer pTrack, QString reason);
     void slotSetReplayGain(mixxx::ReplayGain replayGain);
     void slotPlayToggled(double);
 
   private slots:
-    void slotLoadTrackInternal(TrackPointer pNewTrack, bool bPlay);
+    void slotCloneChannel(EngineChannel* pChannel);
     void slotCloneFromDeck(double deck);
     void slotPassthroughEnabled(double v);
     void slotVinylControlEnabled(double v);
@@ -109,7 +108,6 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     EngineDeck* m_pChannel;
     bool m_replaygainPending;
     EngineChannel* m_pChannelToCloneFrom;
-    PerformanceTimer m_cloneTimer;
 
     // Deck clone control
     std::unique_ptr<ControlObject> m_pCloneFromDeck;

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -78,6 +78,8 @@ PlayerManager::PlayerManager(UserSettingsPointer pConfig,
 
     // This is parented to the PlayerManager so does not need to be deleted
     m_pSamplerBank = new SamplerBank(this);
+
+    m_cloneTimer.start();
 }
 
 PlayerManager::~PlayerManager() {
@@ -564,7 +566,7 @@ void PlayerManager::slotCloneDeck(QString source_group, QString target_group) {
         return;
     }
 
-    pPlayer->slotCloneDeck(source_group);
+    pPlayer->slotCloneFromGroup(source_group);
 }
 
 void PlayerManager::slotLoadTrackToPlayer(TrackPointer pTrack, QString group, bool play) {
@@ -577,7 +579,15 @@ void PlayerManager::slotLoadTrackToPlayer(TrackPointer pTrack, QString group, bo
         return;
     }
 
-    pPlayer->slotLoadTrack(pTrack, play);
+    mixxx::Duration elapsed = m_cloneTimer.restart();
+    if (m_lastLoadedPlayer == group && elapsed < mixxx::Duration::fromSeconds(0.5)) {
+        // load pressed twice quickly, clone instead of loading
+        pPlayer->slotCloneDeck();
+    } else {
+        pPlayer->slotLoadTrack(pTrack, play);
+    }
+
+    m_lastLoadedPlayer = group;
 }
 
 void PlayerManager::slotLoadToPlayer(QString location, QString group) {

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -12,6 +12,7 @@
 #include "analyzer/trackanalysisscheduler.h"
 #include "preferences/usersettings.h"
 #include "track/track.h"
+#include "util/performancetimer.h"
 
 class Auxiliary;
 class BaseTrackPlayer;
@@ -249,6 +250,9 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
 
     // Used to protect access to PlayerManager state across threads.
     mutable QMutex m_mutex;
+
+    PerformanceTimer m_cloneTimer;
+    QString m_lastLoadedPlayer;
 
     UserSettingsPointer m_pConfig;
     SoundManager* m_pSoundManager;

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -77,8 +77,8 @@ class FakeDeck : public BaseTrackPlayer {
         play.set(bPlay);
     }
 
-    MOCK_METHOD1(slotCloneChannel, void(EngineChannel* pChannel));
-    MOCK_METHOD1(slotCloneDeck, void(const QString& group));
+    MOCK_METHOD1(slotCloneFromGroup, void(const QString& group));
+    MOCK_METHOD0(slotCloneDeck, void());
 
     TrackPointer loadedTrack;
     ControlLinPotmeter playposition;


### PR DESCRIPTION
This is arguably a better place to do it, and allows tests that rapidly load tracks to work properly.

This fixes a lingering issue from #1892.