### PR TITLE
lp1815305: Fix edge case when exporting track metadata

### DIFF
--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -787,6 +787,12 @@ MetadataSourceTagLib::exportTrackMetadata(
             << "with type" << m_fileType;
 
     SafelyWritableFile safelyWritableFile(m_fileName, kExportTrackMetadataIntoTemporaryFile);
+    if (safelyWritableFile.fileName().isEmpty()) {
+        kLogger.warning()
+                << "Unable to export track metadata into file"
+                << m_fileName;
+        return afterExport(ExportResult::Failed);
+    }
 
     std::unique_ptr<TagSaver> pTagSaver;
     switch (m_fileType) {

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -692,6 +692,10 @@ class SafelyWritableFile final {
         }
     }
 
+    bool isReady() const {
+        return !fileName().isEmpty();
+    }
+
     bool commit() {
         if (m_tempFileName.isNull()) {
             return true; // nothing to do
@@ -787,10 +791,11 @@ MetadataSourceTagLib::exportTrackMetadata(
             << "with type" << m_fileType;
 
     SafelyWritableFile safelyWritableFile(m_fileName, kExportTrackMetadataIntoTemporaryFile);
-    if (safelyWritableFile.fileName().isEmpty()) {
+    if (!safelyWritableFile.isReady()) {
         kLogger.warning()
                 << "Unable to export track metadata into file"
-                << m_fileName;
+                << m_fileName
+                << "- Please check file permissions and storage space";
         return afterExport(ExportResult::Failed);
     }
 

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -629,22 +629,53 @@ private:
  */
 class SafelyWritableFile final {
   public:
-    SafelyWritableFile(QString origFileName, bool useTemporaryFile)
-        : m_origFileName(std::move(origFileName)) {
+    SafelyWritableFile(QString origFileName, bool useTemporaryFile) {
+        // Both file names remain uninitialized until all prerequisite operations
+        // in the constructor have been completed successfully. Otherwise failure
+        // to create the temporary file will not be handled correctly!
+        // See also: https://bugs.launchpad.net/mixxx/+bug/1815305
+        DEBUG_ASSERT(m_origFileName.isNull());
         DEBUG_ASSERT(m_tempFileName.isNull());
         if (useTemporaryFile) {
-            QString tempFileName = m_origFileName + kSafelyWritableTempFileSuffix;
-            QFile origFile(m_origFileName);
-            if (origFile.copy(tempFileName)) {
-                m_tempFileName = std::move(tempFileName);
-            } else {
+            QString tempFileName = origFileName + kSafelyWritableTempFileSuffix;
+            QFile origFile(origFileName);
+            if (!origFile.copy(tempFileName)) {
                 kLogger.warning()
                         << origFile.errorString()
-                        << "- Failed to copy original into temporary file before writing:"
-                        << origFile.fileName()
+                        << "- Failed to clone original into temporary file before writing:"
+                        << origFileName
                         << "->"
                         << tempFileName;
+                // Abort constructor
+                return;
             }
+            QFile tempFile(tempFileName);
+            DEBUG_ASSERT(tempFile.exists());
+            // Both file sizes are expected to be equal after successfully
+            // copying the file contents.
+            VERIFY_OR_DEBUG_ASSERT(origFile.size() == tempFile.size()) {
+                kLogger.warning()
+                        << "Failed to verify size after cloning original into temporary file before writing:"
+                        << origFile.size()
+                        << "<>"
+                        << tempFile.size();
+                // Cleanup
+                if (tempFile.exists() && !tempFile.remove()) {
+                    kLogger.warning()
+                            << tempFile.errorString()
+                            << "- Failed to remove temporary file:"
+                            << tempFileName;
+                }
+                // Abort constructor
+                return;
+            }
+            // Successfully cloned original into temporary file for writing - finish initialization
+            m_origFileName = std::move(origFileName);
+            m_tempFileName = std::move(tempFileName);
+        } else {
+            // Directly write into original file - finish initialization
+            m_origFileName = std::move(origFileName);
+            DEBUG_ASSERT(m_tempFileName.isNull());
         }
     }
     ~SafelyWritableFile() {
@@ -653,6 +684,8 @@ class SafelyWritableFile final {
 
     const QString& fileName() const {
         if (m_tempFileName.isNull()) {
+            // If m_tempFileName has not been initialized then no temporary
+            // copy was requested in the constructor.
             return m_origFileName;
         } else {
             return m_tempFileName;

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -758,10 +758,7 @@ class SafelyWritableFile final {
             return; // nothing to do
         }
         QFile tempFile(m_tempFileName);
-        if (!tempFile.exists()) {
-            return; // nothing to do
-        }
-        if (!tempFile.remove()) {
+        if (tempFile.exists() && !tempFile.remove()) {
             kLogger.warning()
                     << tempFile.errorString()
                     << "- Failed to remove temporary file:"


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1815305

Unfortunately this bug also affects 2.1 and is considered critical. If the temporary file cannot be created then Mixxx will continue and write directly into the original file! Typical situation: The file system is almost full. In this case it is not unlikely that even writing into the original file may fail or abort, probably leaving a corrupt file behind.

The first commit contains the actual fix together with an additional consistency check for the resulting size of both files. The remaining changes are just minor improvements to improve code consistency and diagnostic messages.