### PR TITLE
Fix compiler warnings and improve error handling

### DIFF
--- a/src/effects/builtin/balanceeffect.cpp
+++ b/src/effects/builtin/balanceeffect.cpp
@@ -5,7 +5,6 @@
 namespace {
     const double kMaxCornerHz = 500;
     const double kMinCornerHz = 16;
-    const unsigned int kStartupSamplerate = 44100;
 } // anonymous namespace
 
 // static

--- a/src/effects/builtin/moogladder4filtereffect.cpp
+++ b/src/effects/builtin/moogladder4filtereffect.cpp
@@ -4,7 +4,6 @@
 
 static const double kMinCorner = 0.0003; // 13 Hz @ 44100
 static const double kMaxCorner = 0.5; // 22050 Hz @ 44100
-static const unsigned int kStartupSamplerate = 44100;
 
 // static
 QString MoogLadder4FilterEffect::getId() {

--- a/src/util/denormalsarezero.h
+++ b/src/util/denormalsarezero.h
@@ -1,6 +1,5 @@
 
-#ifndef DENORMALSAREZERO_H
-#define DENORMALSAREZERO_H
+#pragma once
 
 // This was copied from the gcc header pmmintrin.h which requires SSE3
 // According to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=21408
@@ -12,18 +11,29 @@
 // See: https://software.intel.com/en-us/articles/x87-and-sse-floating-point-assists-in-ia-32-flush-to-zero-ftz-and-denormals-are-zero-daz
 
 /* Additional bits in the MXCSR.  */
+#if !defined(_MM_DENORMALS_ZERO_MASK)
 #define _MM_DENORMALS_ZERO_MASK     0x0040
+#endif
+#if !defined(_MM_DENORMALS_ZERO_ON)
 #define _MM_DENORMALS_ZERO_ON       0x0040
+#endif
+#if !defined(_MM_DENORMALS_ZERO_OFF)
 #define _MM_DENORMALS_ZERO_OFF      0x0000
+#endif
 
 #ifdef __SSE__
 
 #include <xmmintrin.h>
 
+#if !defined(_MM_SET_DENORMALS_ZERO_MODE)
 #define _MM_SET_DENORMALS_ZERO_MODE(mode) \
   _mm_setcsr ((_mm_getcsr () & ~_MM_DENORMALS_ZERO_MASK) | (mode))
+#endif
+
+#if !defined(_MM_GET_DENORMALS_ZERO_MODE)
 #define _MM_GET_DENORMALS_ZERO_MODE() \
   (_mm_getcsr() & _MM_DENORMALS_ZERO_MASK)
+#endif
 
 #else
 
@@ -35,5 +45,3 @@
 #define _MM_GET_DENORMALS_ZERO_MODE()
 
 #endif
-
-#endif /* DENORMALSAREZERO_H */


### PR DESCRIPTION
During a rebuild I noticed that Clang complained about redefined macros in denormalsarezero.h. Even if GCC doesn't have any complaints, such a workaround should not redefine system definitions.

Improved error handling for MP3 files by actually using the previously unused constant the compiler complained about.