### PR TITLE
LibFaadLoader for m4a without recompile 

### DIFF
--- a/build/features.py
+++ b/build/features.py
@@ -367,7 +367,7 @@ class ModPlug(Feature):
 class FAAD(Feature):
     def description(self):
         return "FAAD AAC audio file decoder plugin"
-        
+
     def default(self, build):
         return 1 if build.platform_is_linux else 0
 

--- a/build/features.py
+++ b/build/features.py
@@ -367,9 +367,12 @@ class ModPlug(Feature):
 class FAAD(Feature):
     def description(self):
         return "FAAD AAC audio file decoder plugin"
+        
+    def default(self, build):
+        return 1 if build.platform_is_linux else 0
 
     def enabled(self, build):
-        build.flags['faad'] = util.get_flags(build.env, 'faad', 0)
+        build.flags['faad'] = util.get_flags(build.env, 'faad', self.default(build))
         if int(build.flags['faad']):
             return True
         return False
@@ -392,14 +395,9 @@ class FAAD(Feature):
             raise Exception(
                 'Could not find libmp4, libmp4v2 or the libmp4v2 development headers.')
 
-        have_faad = conf.CheckLib(['faad', 'libfaad'])
-
-        if not have_faad:
-            raise Exception(
-                'Could not find libfaad or the libfaad development headers.')
-
     def sources(self, build):
-        return ['src/sources/soundsourcem4a.cpp']
+        return ['src/sources/soundsourcem4a.cpp',
+        		'src/sources/libfaadloader.cpp']
 
 
 class WavPack(Feature):

--- a/src/sources/libfaadloader.cpp
+++ b/src/sources/libfaadloader.cpp
@@ -30,6 +30,8 @@ LibFaadLoader::LibFaadLoader()
     // http://www.rarewares.org/aac-decoders.php
     libnames << "libfaad2.dll";
 #elif __APPLE__
+    // Firts try default location
+    libnames << "libfaad2.dylib";
     // Using Homebrew ('brew install faad2' command):
     libnames << "/usr/local/lib/libfaad2.dylib";
     // Using MacPorts ('sudo port install faad2' command):

--- a/src/sources/libfaadloader.cpp
+++ b/src/sources/libfaadloader.cpp
@@ -128,6 +128,9 @@ unsigned char LibFaadLoader::SetConfiguration(
     if (m_neAACDecSetConfiguration) {
         return m_neAACDecSetConfiguration(hDecoder, pConfig);
     }
+    // Return values:
+    // 0 – Error, invalid configuration.
+    // 1 – OK
     return 0;
 }
 
@@ -177,7 +180,7 @@ void* LibFaadLoader::Decode2(
                 ppSampleBuffer,
                 sampleBufferSize);
     }
-    return 0;
+    return nullptr;
 }
 
 char* LibFaadLoader::GetErrorMessage(unsigned char errcode) {

--- a/src/sources/libfaadloader.cpp
+++ b/src/sources/libfaadloader.cpp
@@ -101,7 +101,7 @@ LibFaadLoader::LibFaadLoader()
         m_pLibrary.reset();
         return;
     }
-    kLogger.debug() << "Successfully loaded faad2 library " << m_pLibrary->fileName();
+    kLogger.info() << "Successfully loaded library" << m_pLibrary->fileName();
 };
 
 bool LibFaadLoader::isLoaded() {

--- a/src/sources/libfaadloader.cpp
+++ b/src/sources/libfaadloader.cpp
@@ -1,4 +1,5 @@
 #include "sources/libfaadloader.h"
+#include "util/logger.h"
 
 namespace {
 

--- a/src/sources/libfaadloader.cpp
+++ b/src/sources/libfaadloader.cpp
@@ -33,18 +33,22 @@ LibFaadLoader::LibFaadLoader()
     libnames << "/usr/local/lib/libfaad2.dylib";
     // Using MacPorts ('sudo port install faad2' command):
     libnames << "/opt/local/lib/libfaad2.dylib";
+#else
+    DEBUG_ASSERT(!"OS not implementet");
+    return;
 #endif
+
     for (const auto& libname : libnames) {
+        m_pLibrary.reset();
         m_pLibrary = std::make_unique<QLibrary>(libname, 0);
-        if (!m_pLibrary->load()) {
-            m_pLibrary.reset();
-        } else {
+        if (m_pLibrary->load()) {
             break;
         }
     }
 
-    if (!m_pLibrary || !m_pLibrary->isLoaded()) {
+    if (!m_pLibrary->isLoaded()) {
         kLogger.warning() << "Failed to load " << libnames << ", " << m_pLibrary->errorString();
+        m_pLibrary.reset();
         return;
     }
 

--- a/src/sources/libfaadloader.cpp
+++ b/src/sources/libfaadloader.cpp
@@ -6,6 +6,12 @@ mixxx::Logger kLogger("LibFaadLoader");
 
 } // anonymous namespace
 
+// static
+LibFaadLoader* Instance() {
+    static LibFaadLoader libFaadLoader();
+    return &libFaadLoader;
+}
+
 LibFaadLoader::LibFaadLoader()
         : m_neAACDecOpen(nullptr),
           m_neAACDecGetCurrentConfiguration(nullptr),

--- a/src/sources/libfaadloader.cpp
+++ b/src/sources/libfaadloader.cpp
@@ -35,9 +35,11 @@ LibFaadLoader::LibFaadLoader()
     // Using MacPorts ('sudo port install faad2' command):
     libnames << "/opt/local/lib/libfaad2.dylib";
 #else
-    DEBUG_ASSERT(!"OS not implementet");
+    DEBUG_ASSERT(!"OS not implemented");
     return;
 #endif
+
+
 
     for (const auto& libname : libnames) {
         m_pLibrary.reset();

--- a/src/sources/libfaadloader.cpp
+++ b/src/sources/libfaadloader.cpp
@@ -91,32 +91,32 @@ LibFaadLoader::LibFaadLoader()
     kLogger.debug() << "Successfully loaded faad2 library " << m_pLibrary->fileName();
 };
 
-LibFaadLoader::NeAACDecHandle LibFaadLoader::NeAACDecOpen() {
+LibFaadLoader::Handle LibFaadLoader::Open() {
     if (m_neAACDecOpen) {
         return m_neAACDecOpen();
     }
     return nullptr;
 }
 
-LibFaadLoader::NeAACDecConfigurationPtr
-LibFaadLoader::NeAACDecGetCurrentConfiguration(NeAACDecHandle hDecoder) {
+LibFaadLoader::Configuration*
+LibFaadLoader::GetCurrentConfiguration(Handle hDecoder) {
     if (m_neAACDecGetCurrentConfiguration) {
         return m_neAACDecGetCurrentConfiguration(hDecoder);
     }
     return nullptr;
 }
 
-unsigned char LibFaadLoader::NeAACDecSetConfiguration(
-        NeAACDecHandle hDecoder, NeAACDecConfigurationPtr config) {
+unsigned char LibFaadLoader::SetConfiguration(
+        Handle hDecoder, Configuration* pConfig) {
     if (m_neAACDecSetConfiguration) {
-        return m_neAACDecSetConfiguration(hDecoder, config);
+        return m_neAACDecSetConfiguration(hDecoder, pConfig);
     }
     return 0;
 }
 
 // Init the library using a DecoderSpecificInfo
-char LibFaadLoader::NeAACDecInit2(
-        NeAACDecHandle hDecoder,
+char LibFaadLoader::Init2(
+        Handle hDecoder,
         unsigned char* pBuffer,
         unsigned long SizeOfDecoderSpecificInfo,
         unsigned long* pSamplerate,
@@ -132,21 +132,21 @@ char LibFaadLoader::NeAACDecInit2(
 
 }
 
-void LibFaadLoader::NeAACDecClose(NeAACDecHandle hDecoder) {
+void LibFaadLoader::Close(Handle hDecoder) {
     if (m_neAACDecClose) {
         m_neAACDecClose(hDecoder);
     }
 }
 
-void LibFaadLoader::NeAACDecPostSeekReset(NeAACDecHandle hDecoder, long frame) {
+void LibFaadLoader::PostSeekReset(Handle hDecoder, long frame) {
     if (m_neAACDecPostSeekReset) {
         m_neAACDecPostSeekReset(hDecoder, frame);
     }
 }
 
-void* LibFaadLoader::NeAACDecDecode2(
-        NeAACDecHandle hDecoder,
-        NeAACDecFrameInfo* pInfo,
+void* LibFaadLoader::Decode2(
+        Handle hDecoder,
+        FrameInfo* pInfo,
         unsigned char* pBuffer,
         unsigned long bufferSize,
         void** ppSampleBuffer,
@@ -163,7 +163,7 @@ void* LibFaadLoader::NeAACDecDecode2(
     return 0;
 }
 
-char* LibFaadLoader::NeAACDecGetErrorMessage(unsigned char errcode) {
+char* LibFaadLoader::GetErrorMessage(unsigned char errcode) {
     if (m_neAACDecGetErrorMessage) {
         return m_neAACDecGetErrorMessage(errcode);
     }

--- a/src/sources/libfaadloader.cpp
+++ b/src/sources/libfaadloader.cpp
@@ -153,8 +153,10 @@ char LibFaadLoader::Init2(
                 pSamplerate,
                 pChannels);
     }
-    return 0;
-
+    // Return values:
+    // < 0 – Error
+    // 0 - OK
+    return -1;
 }
 
 void LibFaadLoader::Close(Handle hDecoder) {

--- a/src/sources/libfaadloader.cpp
+++ b/src/sources/libfaadloader.cpp
@@ -7,8 +7,8 @@ mixxx::Logger kLogger("LibFaadLoader");
 } // anonymous namespace
 
 // static
-LibFaadLoader* Instance() {
-    static LibFaadLoader libFaadLoader();
+LibFaadLoader* LibFaadLoader::Instance() {
+    static LibFaadLoader libFaadLoader;
     return &libFaadLoader;
 }
 
@@ -96,6 +96,13 @@ LibFaadLoader::LibFaadLoader()
     }
     kLogger.debug() << "Successfully loaded faad2 library " << m_pLibrary->fileName();
 };
+
+bool LibFaadLoader::isLoaded() {
+    if (m_pLibrary) {
+        return m_pLibrary->isLoaded();
+    }
+    return false;
+}
 
 LibFaadLoader::Handle LibFaadLoader::Open() {
     if (m_neAACDecOpen) {

--- a/src/sources/libfaadloader.h
+++ b/src/sources/libfaadloader.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <QLibrary>
+
+#include "util/memory.h"
+#include "util/logger.h"
+
+// object types for AAC
+constexpr unsigned char MAIN = 1;
+constexpr unsigned char LC = 2;
+constexpr unsigned char SSR = 3;
+constexpr unsigned char LTP = 4;
+constexpr unsigned char HE_AAC = 5;
+constexpr unsigned char ER_LC = 17;
+constexpr unsigned char ER_LTP = 19;
+constexpr unsigned char LD = 23;
+constexpr unsigned char DRM_ER_LC = 27; // special object type for DRM
+
+// library output formats
+constexpr unsigned char FAAD_FMT_16BIT = 1;
+constexpr unsigned char FAAD_FMT_24BIT = 2;
+constexpr unsigned char FAAD_FMT_32BIT = 3;
+constexpr unsigned char FAAD_FMT_FLOAT = 4;
+constexpr unsigned char FAAD_FMT_FIXED = FAAD_FMT_FLOAT;
+constexpr unsigned char FAAD_FMT_DOUBLE = 5;
+
+class LibFaadLoader {
+  public:
+    typedef void* NeAACDecHandle;
+
+    typedef struct NeAACDecConfiguration
+    {
+        unsigned char defObjectType;
+        unsigned long defSampleRate;
+        unsigned char outputFormat;
+        unsigned char downMatrix;
+        unsigned char useOldADTSFormat;
+        unsigned char dontUpSampleImplicitSBR;
+    } NeAACDecConfiguration, *NeAACDecConfigurationPtr;
+
+    typedef struct NeAACDecFrameInfo
+    {
+        unsigned long bytesconsumed;
+        unsigned long samples;
+        unsigned char channels;
+        unsigned char error;
+        unsigned long samplerate;
+
+        // SBR: 0: off, 1: on; upsample, 2: on; downsampled, 3: off; upsampled
+        unsigned char sbr;
+
+        // MPEG-4 ObjectType
+        unsigned char object_type;
+
+        // AAC header type; MP4 will be signalled as RAW also
+        unsigned char header_type;
+
+        // multichannel configuration
+        unsigned char num_front_channels;
+        unsigned char num_side_channels;
+        unsigned char num_back_channels;
+        unsigned char num_lfe_channels;
+        unsigned char channel_position[64];
+
+        // PS: 0: off, 1: on
+        unsigned char ps;
+    } NeAACDecFrameInfo;
+
+    LibFaadLoader();
+
+    NeAACDecHandle NeAACDecOpen();
+
+    NeAACDecConfigurationPtr NeAACDecGetCurrentConfiguration(
+            NeAACDecHandle hDecoder);
+
+    unsigned char NeAACDecSetConfiguration(
+            NeAACDecHandle hDecoder, NeAACDecConfigurationPtr config);
+
+    // Init the library using a DecoderSpecificInfo
+    char NeAACDecInit2(
+            NeAACDecHandle hDecoder,
+            unsigned char* pBuffer,
+            unsigned long SizeOfDecoderSpecificInfo,
+            unsigned long* pSamplerate,
+            unsigned char* pChannels);
+
+    void NeAACDecClose(NeAACDecHandle hDecoder);
+
+    void NeAACDecPostSeekReset(NeAACDecHandle hDecoder, long frame);
+
+    void* NeAACDecDecode2(
+            NeAACDecHandle hDecoder,
+            NeAACDecFrameInfo* pInfo,
+            unsigned char* pBuffer,
+            unsigned long bufferSize,
+            void** ppSampleBuffer,
+            unsigned long sampleBufferSize);
+
+    char* NeAACDecGetErrorMessage(unsigned char errcode);
+
+
+  private:
+    std::unique_ptr<QLibrary> m_pLibrary;
+
+    typedef NeAACDecHandle (* NeAACDecOpen_t)();
+    NeAACDecOpen_t m_neAACDecOpen;
+
+    typedef NeAACDecConfigurationPtr (* NeAACDecGetCurrentConfiguration_t)(NeAACDecHandle);
+    NeAACDecGetCurrentConfiguration_t m_neAACDecGetCurrentConfiguration;
+
+    typedef unsigned char (* NeAACDecSetConfiguration_t)(
+            NeAACDecHandle, NeAACDecConfigurationPtr);
+    NeAACDecSetConfiguration_t m_neAACDecSetConfiguration;
+
+    typedef char (* NeAACDecInit2_t)(
+            NeAACDecHandle, unsigned char*,
+            unsigned long, unsigned long*, unsigned char* );
+    NeAACDecInit2_t m_neAACDecInit2;
+
+    typedef void (* NeAACDecClose_t)(NeAACDecHandle);
+    NeAACDecClose_t m_neAACDecClose;
+
+    typedef void (* NeAACDecPostSeekReset_t)(NeAACDecHandle, long);
+    NeAACDecPostSeekReset_t m_neAACDecPostSeekReset;
+
+    typedef void* (* NeAACDecDecode2_t)(
+            NeAACDecHandle, NeAACDecFrameInfo*, unsigned char*,
+            unsigned long, void**, unsigned long);
+    NeAACDecDecode2_t m_neAACDecDecode2;
+
+    typedef char* (* NeAACDecGetErrorMessage_t)(unsigned char);
+    NeAACDecGetErrorMessage_t m_neAACDecGetErrorMessage;
+
+};
+
+

--- a/src/sources/libfaadloader.h
+++ b/src/sources/libfaadloader.h
@@ -68,6 +68,8 @@ class LibFaadLoader {
 
     static LibFaadLoader* Instance();
 
+    bool isLoaded();
+
     Handle Open();
 
     Configuration* GetCurrentConfiguration(

--- a/src/sources/libfaadloader.h
+++ b/src/sources/libfaadloader.h
@@ -66,7 +66,7 @@ class LibFaadLoader {
         unsigned char ps;
     } FrameInfo;
 
-    LibFaadLoader();
+    static LibFaadLoader* Instance();
 
     Handle Open();
 
@@ -100,6 +100,8 @@ class LibFaadLoader {
 
 
   private:
+    LibFaadLoader();
+
     std::unique_ptr<QLibrary> m_pLibrary;
 
     typedef Handle (* NeAACDecOpen_t)();

--- a/src/sources/libfaadloader.h
+++ b/src/sources/libfaadloader.h
@@ -3,7 +3,6 @@
 #include <QLibrary>
 
 #include "util/memory.h"
-#include "util/logger.h"
 
 // object types for AAC
 constexpr unsigned char MAIN = 1;

--- a/src/sources/libfaadloader.h
+++ b/src/sources/libfaadloader.h
@@ -26,9 +26,9 @@ constexpr unsigned char FAAD_FMT_DOUBLE = 5;
 
 class LibFaadLoader {
   public:
-    typedef void* NeAACDecHandle;
+    typedef void* Handle;
 
-    typedef struct NeAACDecConfiguration
+    typedef struct
     {
         unsigned char defObjectType;
         unsigned long defSampleRate;
@@ -36,9 +36,9 @@ class LibFaadLoader {
         unsigned char downMatrix;
         unsigned char useOldADTSFormat;
         unsigned char dontUpSampleImplicitSBR;
-    } NeAACDecConfiguration, *NeAACDecConfigurationPtr;
+    } Configuration;
 
-    typedef struct NeAACDecFrameInfo
+    typedef struct
     {
         unsigned long bytesconsumed;
         unsigned long samples;
@@ -64,73 +64,72 @@ class LibFaadLoader {
 
         // PS: 0: off, 1: on
         unsigned char ps;
-    } NeAACDecFrameInfo;
+    } FrameInfo;
 
     LibFaadLoader();
 
-    NeAACDecHandle NeAACDecOpen();
+    Handle Open();
 
-    NeAACDecConfigurationPtr NeAACDecGetCurrentConfiguration(
-            NeAACDecHandle hDecoder);
+    Configuration* GetCurrentConfiguration(
+            Handle hDecoder);
 
-    unsigned char NeAACDecSetConfiguration(
-            NeAACDecHandle hDecoder, NeAACDecConfigurationPtr config);
+    unsigned char SetConfiguration(
+            Handle hDecoder, Configuration* config);
 
     // Init the library using a DecoderSpecificInfo
-    char NeAACDecInit2(
-            NeAACDecHandle hDecoder,
+    char Init2(
+            Handle hDecoder,
             unsigned char* pBuffer,
             unsigned long SizeOfDecoderSpecificInfo,
             unsigned long* pSamplerate,
             unsigned char* pChannels);
 
-    void NeAACDecClose(NeAACDecHandle hDecoder);
+    void Close(Handle hDecoder);
 
-    void NeAACDecPostSeekReset(NeAACDecHandle hDecoder, long frame);
+    void PostSeekReset(Handle hDecoder, long frame);
 
-    void* NeAACDecDecode2(
-            NeAACDecHandle hDecoder,
-            NeAACDecFrameInfo* pInfo,
+    void* Decode2(
+            Handle hDecoder,
+            FrameInfo* pInfo,
             unsigned char* pBuffer,
             unsigned long bufferSize,
             void** ppSampleBuffer,
             unsigned long sampleBufferSize);
 
-    char* NeAACDecGetErrorMessage(unsigned char errcode);
+    char* GetErrorMessage(unsigned char errcode);
 
 
   private:
     std::unique_ptr<QLibrary> m_pLibrary;
 
-    typedef NeAACDecHandle (* NeAACDecOpen_t)();
+    typedef Handle (* NeAACDecOpen_t)();
     NeAACDecOpen_t m_neAACDecOpen;
 
-    typedef NeAACDecConfigurationPtr (* NeAACDecGetCurrentConfiguration_t)(NeAACDecHandle);
+    typedef Configuration* (* NeAACDecGetCurrentConfiguration_t)(Handle);
     NeAACDecGetCurrentConfiguration_t m_neAACDecGetCurrentConfiguration;
 
     typedef unsigned char (* NeAACDecSetConfiguration_t)(
-            NeAACDecHandle, NeAACDecConfigurationPtr);
+            Handle, Configuration*);
     NeAACDecSetConfiguration_t m_neAACDecSetConfiguration;
 
     typedef char (* NeAACDecInit2_t)(
-            NeAACDecHandle, unsigned char*,
+            Handle, unsigned char*,
             unsigned long, unsigned long*, unsigned char* );
     NeAACDecInit2_t m_neAACDecInit2;
 
-    typedef void (* NeAACDecClose_t)(NeAACDecHandle);
+    typedef void (* NeAACDecClose_t)(Handle);
     NeAACDecClose_t m_neAACDecClose;
 
-    typedef void (* NeAACDecPostSeekReset_t)(NeAACDecHandle, long);
+    typedef void (* NeAACDecPostSeekReset_t)(Handle, long);
     NeAACDecPostSeekReset_t m_neAACDecPostSeekReset;
 
     typedef void* (* NeAACDecDecode2_t)(
-            NeAACDecHandle, NeAACDecFrameInfo*, unsigned char*,
+            Handle, FrameInfo*, unsigned char*,
             unsigned long, void**, unsigned long);
     NeAACDecDecode2_t m_neAACDecDecode2;
 
     typedef char* (* NeAACDecGetErrorMessage_t)(unsigned char);
     NeAACDecGetErrorMessage_t m_neAACDecGetErrorMessage;
-
 };
 
 

--- a/src/sources/libfaadloader.h
+++ b/src/sources/libfaadloader.h
@@ -103,6 +103,10 @@ class LibFaadLoader {
   private:
     LibFaadLoader();
 
+    LibFaadLoader(const LibFaadLoader &) = delete;
+    LibFaadLoader &operator=(const LibFaadLoader &) = delete;
+
+    // QLibrary is not copy-able
     std::unique_ptr<QLibrary> m_pLibrary;
 
     typedef Handle (* NeAACDecOpen_t)();

--- a/src/sources/soundsourcem4a.cpp
+++ b/src/sources/soundsourcem4a.cpp
@@ -162,7 +162,8 @@ SoundSourceM4A::SoundSourceM4A(const QUrl& url)
           m_hDecoder(nullptr),
           m_numberOfPrefetchSampleBlocks(0),
           m_curSampleBlockId(MP4_INVALID_SAMPLE_ID),
-          m_curFrameIndex(0) {
+          m_curFrameIndex(0),
+          m_pFaad(LibFaadLoader::Instance()) {
 }
 
 SoundSourceM4A::~SoundSourceM4A() {
@@ -259,12 +260,12 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(
 bool SoundSourceM4A::openDecoder() {
     DEBUG_ASSERT(m_hDecoder == nullptr); // not already opened
 
-    m_hDecoder = m_faad.Open();
+    m_hDecoder = m_pFaad->Open();
     if (m_hDecoder == nullptr) {
         kLogger.warning() << "Failed to open the AAC decoder!";
         return false;
     }
-    LibFaadLoader::Configuration* pDecoderConfig = m_faad.GetCurrentConfiguration(
+    LibFaadLoader::Configuration* pDecoderConfig = m_pFaad->GetCurrentConfiguration(
             m_hDecoder);
     pDecoderConfig->outputFormat = FAAD_FMT_FLOAT;
     if ((m_openParams.channelCount() == 1) ||
@@ -275,7 +276,7 @@ bool SoundSourceM4A::openDecoder() {
     }
 
     pDecoderConfig->defObjectType = LC;
-    if (!m_faad.SetConfiguration(m_hDecoder, pDecoderConfig)) {
+    if (!m_pFaad->SetConfiguration(m_hDecoder, pDecoderConfig)) {
         kLogger.warning() << "Failed to configure AAC decoder!";
         return false;
     }
@@ -285,14 +286,14 @@ bool SoundSourceM4A::openDecoder() {
     if (!MP4GetTrackESConfiguration(m_hFile, m_trackId, &configBuffer,
             &configBufferSize)) {
         // Failed to get mpeg-4 audio config... this is ok.
-        // NeAACDecInit2() will simply use default values instead.
+        // Init2() will simply use default values instead.
         kLogger.warning() << "Failed to read the MP4 audio configuration."
                 << "Continuing with default values.";
     }
 
     SAMPLERATE_TYPE sampleRate;
     unsigned char channelCount;
-    if (0 > m_faad.Init2(m_hDecoder, configBuffer, configBufferSize,
+    if (0 > m_pFaad->Init2(m_hDecoder, configBuffer, configBufferSize,
                     &sampleRate, &channelCount)) {
         free(configBuffer);
         kLogger.warning() << "Failed to initialize the AAC decoder!";
@@ -333,7 +334,7 @@ bool SoundSourceM4A::openDecoder() {
 
 void SoundSourceM4A::closeDecoder() {
     if (m_hDecoder != nullptr) {
-        m_faad.Close(m_hDecoder);
+        m_pFaad->Close(m_hDecoder);
         m_hDecoder = nullptr;
     }
 }
@@ -361,7 +362,7 @@ bool SoundSourceM4A::isValidSampleBlockId(MP4SampleId sampleBlockId) const {
 void SoundSourceM4A::restartDecoding(MP4SampleId sampleBlockId) {
     DEBUG_ASSERT(sampleBlockId >= kSampleBlockIdMin);
 
-    m_faad.PostSeekReset(m_hDecoder, sampleBlockId);
+    m_pFaad->PostSeekReset(m_hDecoder, sampleBlockId);
     m_curSampleBlockId = sampleBlockId;
     m_curFrameIndex = frameIndexMin() +
             (sampleBlockId - kSampleBlockIdMin) * m_framesPerSampleBlock;
@@ -484,7 +485,7 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
             break; // EOF
         }
 
-        // NOTE(uklotzde): The sample buffer for NeAACDecDecode2 has to
+        // NOTE(uklotzde): The sample buffer for Decode2 has to
         // be big enough for a whole block of decoded samples, which
         // contains up to m_framesPerSampleBlock frames. Otherwise
         // we need to use a temporary buffer.
@@ -508,7 +509,7 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
         DEBUG_ASSERT(decodeBufferCapacityMin <= decodeBufferCapacity);
 
         LibFaadLoader::FrameInfo decFrameInfo;
-        void* pDecodeResult = m_faad.Decode2(
+        void* pDecodeResult = m_pFaad->Decode2(
                 m_hDecoder, &decFrameInfo,
                 &m_inputBuffer[m_inputBufferOffset],
                 m_inputBufferLength,
@@ -518,7 +519,7 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
         if (0 != decFrameInfo.error) {
             kLogger.warning() << "AAC decoding error:"
                     << decFrameInfo.error
-                    << m_faad.GetErrorMessage(decFrameInfo.error)
+                    << m_pFaad->GetErrorMessage(decFrameInfo.error)
                     << getUrlString();
             break; // abort
         }

--- a/src/sources/soundsourcem4a.cpp
+++ b/src/sources/soundsourcem4a.cpp
@@ -601,8 +601,10 @@ QString SoundSourceProviderM4A::getName() const {
 
 QStringList SoundSourceProviderM4A::getSupportedFileExtensions() const {
     QStringList supportedFileExtensions;
-    supportedFileExtensions.append("m4a");
-    supportedFileExtensions.append("mp4");
+    if (LibFaadLoader::Instance()->isLoaded()) {
+        supportedFileExtensions.append("m4a");
+        supportedFileExtensions.append("mp4");
+    }
     return supportedFileExtensions;
 }
 

--- a/src/sources/soundsourcem4a.cpp
+++ b/src/sources/soundsourcem4a.cpp
@@ -259,12 +259,12 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(
 bool SoundSourceM4A::openDecoder() {
     DEBUG_ASSERT(m_hDecoder == nullptr); // not already opened
 
-    m_hDecoder = m_faad.NeAACDecOpen();
+    m_hDecoder = m_faad.Open();
     if (m_hDecoder == nullptr) {
         kLogger.warning() << "Failed to open the AAC decoder!";
         return false;
     }
-    LibFaadLoader::NeAACDecConfigurationPtr pDecoderConfig = m_faad.NeAACDecGetCurrentConfiguration(
+    LibFaadLoader::Configuration* pDecoderConfig = m_faad.GetCurrentConfiguration(
             m_hDecoder);
     pDecoderConfig->outputFormat = FAAD_FMT_FLOAT;
     if ((m_openParams.channelCount() == 1) ||
@@ -275,7 +275,7 @@ bool SoundSourceM4A::openDecoder() {
     }
 
     pDecoderConfig->defObjectType = LC;
-    if (!m_faad.NeAACDecSetConfiguration(m_hDecoder, pDecoderConfig)) {
+    if (!m_faad.SetConfiguration(m_hDecoder, pDecoderConfig)) {
         kLogger.warning() << "Failed to configure AAC decoder!";
         return false;
     }
@@ -292,7 +292,7 @@ bool SoundSourceM4A::openDecoder() {
 
     SAMPLERATE_TYPE sampleRate;
     unsigned char channelCount;
-    if (0 > m_faad.NeAACDecInit2(m_hDecoder, configBuffer, configBufferSize,
+    if (0 > m_faad.Init2(m_hDecoder, configBuffer, configBufferSize,
                     &sampleRate, &channelCount)) {
         free(configBuffer);
         kLogger.warning() << "Failed to initialize the AAC decoder!";
@@ -333,7 +333,7 @@ bool SoundSourceM4A::openDecoder() {
 
 void SoundSourceM4A::closeDecoder() {
     if (m_hDecoder != nullptr) {
-        m_faad.NeAACDecClose(m_hDecoder);
+        m_faad.Close(m_hDecoder);
         m_hDecoder = nullptr;
     }
 }
@@ -361,7 +361,7 @@ bool SoundSourceM4A::isValidSampleBlockId(MP4SampleId sampleBlockId) const {
 void SoundSourceM4A::restartDecoding(MP4SampleId sampleBlockId) {
     DEBUG_ASSERT(sampleBlockId >= kSampleBlockIdMin);
 
-    m_faad.NeAACDecPostSeekReset(m_hDecoder, sampleBlockId);
+    m_faad.PostSeekReset(m_hDecoder, sampleBlockId);
     m_curSampleBlockId = sampleBlockId;
     m_curFrameIndex = frameIndexMin() +
             (sampleBlockId - kSampleBlockIdMin) * m_framesPerSampleBlock;
@@ -507,8 +507,8 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
         }
         DEBUG_ASSERT(decodeBufferCapacityMin <= decodeBufferCapacity);
 
-        LibFaadLoader::NeAACDecFrameInfo decFrameInfo;
-        void* pDecodeResult = m_faad.NeAACDecDecode2(
+        LibFaadLoader::FrameInfo decFrameInfo;
+        void* pDecodeResult = m_faad.Decode2(
                 m_hDecoder, &decFrameInfo,
                 &m_inputBuffer[m_inputBufferOffset],
                 m_inputBufferLength,
@@ -518,7 +518,7 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
         if (0 != decFrameInfo.error) {
             kLogger.warning() << "AAC decoding error:"
                     << decFrameInfo.error
-                    << m_faad.NeAACDecGetErrorMessage(decFrameInfo.error)
+                    << m_faad.GetErrorMessage(decFrameInfo.error)
                     << getUrlString();
             break; // abort
         }

--- a/src/sources/soundsourcem4a.h
+++ b/src/sources/soundsourcem4a.h
@@ -54,7 +54,7 @@ class SoundSourceM4A: public SoundSource {
 
     OpenParams m_openParams;
 
-    LibFaadLoader::NeAACDecHandle m_hDecoder;
+    LibFaadLoader::Handle m_hDecoder;
     SINT m_numberOfPrefetchSampleBlocks;
     MP4SampleId m_curSampleBlockId;
 

--- a/src/sources/soundsourcem4a.h
+++ b/src/sources/soundsourcem4a.h
@@ -4,6 +4,8 @@
 #include "sources/soundsource.h"
 #include "sources/soundsourceprovider.h"
 
+#include "sources/libfaadloader.h"
+
 #include "util/readaheadsamplebuffer.h"
 
 #ifdef __MP4V2__
@@ -11,8 +13,6 @@
 #else
 #include <mp4.h>
 #endif
-
-#include <neaacdec.h>
 
 #include <vector>
 
@@ -54,13 +54,15 @@ class SoundSourceM4A: public SoundSource {
 
     OpenParams m_openParams;
 
-    NeAACDecHandle m_hDecoder;
+    LibFaadLoader::NeAACDecHandle m_hDecoder;
     SINT m_numberOfPrefetchSampleBlocks;
     MP4SampleId m_curSampleBlockId;
 
     ReadAheadSampleBuffer m_sampleBuffer;
 
     SINT m_curFrameIndex;
+
+    LibFaadLoader m_faad;
 };
 
 class SoundSourceProviderM4A: public SoundSourceProvider {

--- a/src/sources/soundsourcem4a.h
+++ b/src/sources/soundsourcem4a.h
@@ -62,7 +62,7 @@ class SoundSourceM4A: public SoundSource {
 
     SINT m_curFrameIndex;
 
-    LibFaadLoader m_faad;
+    LibFaadLoader* m_pFaad;
 };
 
 class SoundSourceProviderM4A: public SoundSourceProvider {


### PR DESCRIPTION
LibFaadLoader dynamic loads faad2 whenever it is found on the users system. 
This is allows to play m4a files without recompile on Linux. 

It is enabled by default on Linux only, because the other systems have their own solution. 
