### PR TITLE
tweak scratch parameters for Mixtrack Platinum

### DIFF
--- a/res/controllers/Numark-Mixtrack-Platinum-scripts.js
+++ b/res/controllers/Numark-Mixtrack-Platinum-scripts.js
@@ -1230,7 +1230,7 @@ MixtrackPlatinum.scratchEnable = function (deck) {
     var alpha = 1.0/8;
     var beta = alpha/32;
 
-    engine.scratchEnable(deck, 1011, 33+1/3, alpha, beta);
+    engine.scratchEnable(deck, 1240, 33+1/3, alpha, beta);
     MixtrackPlatinum.stopScratchTimer(deck);
 };
 


### PR DESCRIPTION
The behavior here appears to have changed between 2.1 and 2.2. This new value tracks better with the actual location of the spinner.