### PR TITLE
Components JS HotcueColor integration

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -313,7 +313,7 @@
             if (this.colorIdKey !== undefined) {
                 return color.predefinedColorFromId(engine.getValue(this.group,this.colorIdKey));
             } else {
-                return false;
+                return null;
             }
         },
         output: function(value) {
@@ -332,7 +332,7 @@
                     return;
                 }
                 if (this.sendRGB === undefined) {
-                    print("ERROR: no custom method for sending rgb defined!");
+                    print("ERROR: no function defined for sending RGB colors");
                     return;
                 }
                 this.sendRGB(color);

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -303,53 +303,53 @@
         },
     });
 
-    var HotcueColorButton = function (options) {
-      if (options.sendRGB === undefined && options.colors === undefined) {
-        print("ERROR: no color palette or sendRGB method defined");
-        return;
-      }
-      if (options.colors === undefined) {
-          options.colors = color.predefinedColorsList();
-      }
-      this.colorIdKey = 'hotcue_' + options.number + '_color_id';
-      HotcueButton.call(this, options);
+    var HotcueColorButton = function(options) {
+        if (options.sendRGB === undefined && options.colors === undefined) {
+            print("ERROR: no color palette or sendRGB method defined");
+            return;
+        }
+        if (options.colors === undefined) {
+            options.colors = color.predefinedColorsList();
+        }
+        this.colorIdKey = 'hotcue_' + options.number + '_color_id';
+        HotcueButton.call(this, options);
     }
     HotcueColorButton.prototype = new HotcueButton({
-      getColor: function () {
-        return color.jsColorFrom(engine.getValue(this.group,this.colorIdKey))
-      },
-      output: function (value) {
-        if (value > 0) {
-            var id = engine.getValue(this.group,this.colorIdKey)
-            var color = this.colors[id]
-            if (color instanceof Array) {
-                if (color.length !== 3) {
-                    print("ERROR: invalid color array for id: "+id);
-                    return;
+        getColor: function() {
+            return color.jsColorFrom(engine.getValue(this.group, this.colorIdKey))
+        },
+        output: function(value) {
+            if (value > 0) {
+                var id = engine.getValue(this.group, this.colorIdKey)
+                var color = this.colors[id]
+                if (color instanceof Array) {
+                    if (color.length !== 3) {
+                        print("ERROR: invalid color array for id: " + id);
+                        return;
+                    }
+                    if (this.sendRGB === undefined) {
+                        print("ERROR: no custom method for sending rgb defined!");
+                        return;
+                    }
+                    this.sendRGB(color);
+                } else if (typeof color === 'number') {
+                    this.send(color);
                 }
-                if (this.sendRGB === undefined) {
-                    print("ERROR: no custom method for sending rgb defined!");
-                    return;
-                }
-                this.sendRGB(color);
-            } else if (typeof color === 'number') {
-                this.send(color);
+            } else {
+                this.send(this.off);
             }
-        } else {
-          this.send(this.off);
-        }
-      },
-      connect: function () {
-        if (undefined !== this.group &&
-            undefined !== this.outKey &&
-            undefined !== this.output &&
-            typeof this.output === 'function') {
-            this.connections[0] = engine.makeConnection(this.group, this.outKey, this.output);
-        }
-        if (undefined !== this.group) {
-            this.connections[1] = engine.makeConnection(this.group, this.colorIdKey, this.output);
-        }
-      },
+        },
+        connect: function() {
+            if (undefined !== this.group &&
+                undefined !== this.outKey &&
+                undefined !== this.output &&
+                typeof this.output === 'function') {
+                this.connections[0] = engine.makeConnection(this.group, this.outKey, this.output);
+            }
+            if (undefined !== this.group) {
+                this.connections[1] = engine.makeConnection(this.group, this.colorIdKey, this.output);
+            }
+        },
     });
     var SamplerButton = function (options) {
         if (options.number === undefined) {

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -316,7 +316,7 @@
     }
     HotcueColorButton.prototype = new HotcueButton({
         getColor: function() {
-            return color.jsColorFrom(engine.getValue(this.group, this.colorIdKey))
+            return color.predefinedColorFromId(engine.getValue(this.group, this.colorIdKey));
         },
         output: function(value) {
             if (value > 0) {

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -316,6 +316,10 @@
         },
         output: function(value) {
             var outval = this.outValueScale(value);
+            // WARNING: outputColor only handles hotcueColors
+            // and there is no hotcueColor for turning the controller
+            // off. so s`send()` is responsible for turning the 
+            // actual LED off.
             if (this.colorIdKey !== undefined && outval !== this.off) {
                 this.outputColor(engine.getValue(this.group, this.colorIdKey));
             } else {

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -317,8 +317,8 @@
         output: function(value) {
             var outval = this.outValueScale(value);
             // WARNING: outputColor only handles hotcueColors
-            // and there is no hotcueColor for turning the controller
-            // off. so s`send()` is responsible for turning the 
+            // and there is no hotcueColor for turning the LED
+            // off. So the `send()` function is responsible for turning the 
             // actual LED off.
             if (this.colorIdKey !== undefined && outval !== this.off) {
                 this.outputColor(engine.getValue(this.group, this.colorIdKey));

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -312,7 +312,6 @@
           options.colors = color.predefinedColorsList();
       }
       this.colorIdKey = 'hotcue_' + options.number + '_color_id';
-      print(this.colorIdKey);
       HotcueButton.call(this, options);
     }
     HotcueColorButton.prototype = new HotcueButton({
@@ -322,14 +321,14 @@
       output: function (value) {
         if (value > 0) {
             var id = engine.getValue(this.group,this.colorIdKey)
-            var color = options.colors[id]
+            var color = this.colors[id]
             if (color instanceof Array) {
                 if (color.length !== 3) {
-                    print("invalid color array for id: "+id);
+                    print("ERROR: invalid color array for id: "+id);
                     return;
                 }
                 if (this.sendRGB === undefined) {
-                    print("no custom method for sending rgb defined!");
+                    print("ERROR: no custom method for sending rgb defined!");
                     return;
                 }
                 this.sendRGB(color);

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -291,9 +291,7 @@
             return;
         }
         if (options.colors !== undefined || options.sendRGB !== undefined) {
-
             this.colorIdKey = 'hotcue_' + options.number + '_color_id';
-
             if (options.colors === undefined) {
                 options.colors = color.predefinedColorsList();
             }
@@ -343,11 +341,11 @@
         connect: function() {
             Button.prototype.connect.call(this); // call parent connect
             if (undefined !== this.group && this.colorIdKey !== undefined) {
-                this.connections.push(engine.makeConnection(this.group, this.colorIdKey, function (id) {
+                this.connections[1] = engine.makeConnection(this.group, this.colorIdKey, function (id) {
                     if (engine.getValue(this.group,this.outKey)) {
                         this.outputColor(id);
                     }
-                }));
+                });
             }
         },
     });


### PR DESCRIPTION
I am trying to natively integrate the hotcue colors feature into components js. It's not nearly finished yet but I need some help so I decided to open this PR prematurely. For some reason, the custom `connect` method doesn't get called. The sampler buttons use a hack and set the outKey to null which causes `connect` to get called but I don't understand why that works...

SampleCode: 
```javascript
var TEST = {};

TEST.btn1 = new components.HotcueColorButton({
  midi: [0x90,0x01],
  number: 1,
  colors: [1,2,3,4,5,6,7,8,9],
});
TEST.btn2 = new components.HotcueColorButton({
  midi: [0x90,0x02],
  number: 2,
  sendRGB: function (color) {
    var msg = [12,34,56,color.red>>1,color.green>>1,color.blue>>1]
    midi.sendSysexMsg(msg,msg.length);
  }
});
TEST.btn3 = new components.HotcueColorButton({
  midi: [0x90,0x03],
  number: 3,
  colors: [{red:1,green:2,blue:3},{red:4,green:5,blue:6}],
  sendRGB: function (color) {
    var msg = [12,34,56,color.red>>1,color.green>>1,color.blue>>1]
    midi.sendSysexMsg(msg,msg.length);
  }
});
```
 * If you want to set the color on the controller by a midi value, you can define an array with the corresponding colors (their index correspond to the color id) (see `TEST.btn1`).
 * if the controller supports setting the colors directly, you can define a method (`sendRGB`) which is a custom send function for translating the color and sending it out via sysex (see `TEST.btn2`).
It will not perform any translation of the color and use the color codes of the predefined colors list.
 * If you need a convert the predifined colors into custom rgb components, you can do it like outlined in `TEST.btn3`)