### PR TITLE
Better support for hotcue colors on controllers

### DIFF
--- a/res/controllers/CueColorsReference.svg
+++ b/res/controllers/CueColorsReference.svg
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="147.85291mm"
+   height="45.520004mm"
+   viewBox="0 0 523.88825 161.29135"
+   id="svg5342"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="MixxxCueButonReferenceColors.svg">
+  <defs
+     id="defs5344" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4"
+     inkscape:cx="233.31585"
+     inkscape:cy="55.043966"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1301"
+     inkscape:window-height="744"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5347">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-80.913025,-128.85937)">
+    <rect
+       style="fill:#000000;fill-opacity:1"
+       id="rect4190"
+       width="523.88824"
+       height="161.29135"
+       x="80.913025"
+       y="128.85938" />
+    <rect
+       style="fill:#c50a08;fill-opacity:1"
+       id="rect4194-4"
+       width="43.65509"
+       height="43.65509"
+       x="125.24433"
+       y="185.62653"
+       ry="15.006437" />
+    <rect
+       style="fill:#f2f2ff;fill-opacity:1"
+       id="rect4194-3-52"
+       width="43.65509"
+       height="43.65509"
+       x="509.30151"
+       y="185.62653"
+       ry="15.006437" />
+    <rect
+       style="fill:#af00cc;fill-opacity:1"
+       id="rect4194-35-4"
+       width="43.65509"
+       height="43.65509"
+       x="399.57092"
+       y="185.62653"
+       ry="15.006437" />
+    <rect
+       style="fill:#0044ff;fill-opacity:1"
+       id="rect4194-2-78"
+       width="43.65509"
+       height="43.65509"
+       x="344.7056"
+       y="185.62653"
+       ry="15.006437" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#aaaaaa;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="349.01254"
+       y="249.91223"
+       id="text4290-1"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4292-4"
+         x="349.01254"
+         y="249.91223"
+         style="font-size:12.5px">Blue</tspan></text>
+    <text
+       sodipodi:linespacing="125%"
+       id="text4294-9"
+       y="249.6925"
+       x="233.21382"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#aaaaaa;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="font-size:12.5px"
+         y="249.6925"
+         x="233.21382"
+         id="tspan4296-2"
+         sodipodi:role="line">Green</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#aaaaaa;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="128.89883"
+       y="249.91223"
+       id="text4298-0"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4300-6"
+         x="128.89883"
+         y="249.91223"
+         style="font-size:12.5px">Red</tspan></text>
+    <text
+       sodipodi:linespacing="125%"
+       id="text4302-8"
+       y="249.91223"
+       x="398.6676"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#aaaaaa;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="font-size:12.5px"
+         y="249.91223"
+         x="398.6676"
+         id="tspan4304-9"
+         sodipodi:role="line">Purple</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#aaaaaa;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="511.79907"
+       y="249.91223"
+       id="text4306-2"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4308-6"
+         x="511.79907"
+         y="249.91223"
+         style="font-size:12.5px">White</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#aaaaaa;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="460.72192"
+       y="249.91223"
+       id="text4310-6"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4312-4"
+         x="460.72192"
+         y="249.91223"
+         style="font-size:12.5px">Pink</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#aaaaaa;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="310.7919"
+       y="234.28723"
+       id="text4318-0"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4320-4"
+         x="310.7919"
+         y="234.28723"
+         style="font-size:12.5px;text-align:center;text-anchor:middle" /><tspan
+         sodipodi:role="line"
+         x="312.78165"
+         y="249.91223"
+         style="font-size:12.5px;text-align:center;text-anchor:middle"
+         id="tspan5283">Celeste </tspan><tspan
+         sodipodi:role="line"
+         x="310.7919"
+         y="265.53723"
+         style="font-size:12.5px;text-align:center;text-anchor:middle"
+         id="tspan5285">(Sky Blue)</tspan></text>
+    <text
+       sodipodi:linespacing="125%"
+       id="text4322-87"
+       y="249.91223"
+       x="177.43694"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#aaaaaa;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         style="font-size:12.5px"
+         y="249.91223"
+         x="177.43694"
+         id="tspan4324-1"
+         sodipodi:role="line">Yellow</tspan></text>
+    <rect
+       style="fill:#32be44;fill-opacity:1"
+       id="rect4194-70-0-5-2"
+       width="43.65509"
+       height="43.65509"
+       x="234.97496"
+       y="185.62653"
+       ry="15.006437" />
+    <rect
+       style="fill:#f8d200;fill-opacity:1"
+       id="rect4194-1-2-8-7"
+       width="43.65509"
+       height="43.65509"
+       x="180.10965"
+       y="185.62653"
+       ry="15.006437" />
+    <rect
+       style="fill:#42d4f4;fill-opacity:1"
+       id="rect4194-9-1-7-2"
+       width="43.65509"
+       height="43.65509"
+       x="289.84027"
+       y="185.62653"
+       ry="15.006437" />
+    <rect
+       style="fill:#fca6d7;fill-opacity:1"
+       id="rect4194-6-3-9-6"
+       width="43.65509"
+       height="43.65509"
+       x="454.43622"
+       y="185.62653"
+       ry="15.006437" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#aaaaaa;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="128.40016"
+       y="161.66425"
+       id="text4298-0-1"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4300-6-0"
+         x="128.40016"
+         y="161.66425"
+         style="font-size:12.5px">Mixxx Cue Button Reference Colors</tspan></text>
+  </g>
+</svg>

--- a/src/util/color/color.h
+++ b/src/util/color/color.h
@@ -38,7 +38,7 @@ namespace Color {
 
     // If the baseColor is darker than the global threshold,
     // returns a lighter color, otherwise returns a darker color.
-    static inline QColor chooseContrastColor(QColor baseColor) {
+    static QColor chooseContrastColor(QColor baseColor) {
         // Will produce a color that is 60% brighter.
         static const int iLighterFactor = 160;
         // We consider a hsv color dark if its value is <= 20% of max value

--- a/src/util/color/predefinedcolorsset.h
+++ b/src/util/color/predefinedcolorsset.h
@@ -19,37 +19,37 @@ class PredefinedColorsSet final {
         0
     );
     const PredefinedColorPointer red = std::make_shared<PredefinedColor>(
-        QColor("#FF0000"),
+        QColor("#E6194B"),
         QLatin1String("Red"),
         QObject::tr("Red"),
         1
     );
     const PredefinedColorPointer green = std::make_shared<PredefinedColor>(
-        QColor("#00FF00"),
+        QColor("#3CB44B"),
         QLatin1String("Green"),
         QObject::tr("Green"),
         2
     );
     const PredefinedColorPointer blue = std::make_shared<PredefinedColor>(
-        QColor("#0000FF"),
+        QColor("#4363D8"),
         QLatin1String("Blue"),
         QObject::tr("Blue"),
         3
     );
     const PredefinedColorPointer yellow = std::make_shared<PredefinedColor>(
-        QColor("#FFFF00"),
+        QColor("#FFE119"),
         QLatin1String("Yellow"),
         QObject::tr("Yellow"),
         4
     );
     const PredefinedColorPointer cyan = std::make_shared<PredefinedColor>(
-        QColor("#00FFFF"),
+        QColor("#42D4F4"),
         QLatin1String("Cyan"),
         QObject::tr("Cyan"),
         5
     );
     const PredefinedColorPointer magenta = std::make_shared<PredefinedColor>(
-        QColor("#FF00FF"),
+        QColor("#F032E6"),
         QLatin1String("Magenta"),
         QObject::tr("Magenta"),
         6

--- a/src/util/color/predefinedcolorsset.h
+++ b/src/util/color/predefinedcolorsset.h
@@ -19,49 +19,49 @@ class PredefinedColorsSet final {
         0
     );
     const PredefinedColorPointer red = std::make_shared<PredefinedColor>(
-        QColor("#E6194B"),
+        QColor("#c50a08"),
         QLatin1String("Red"),
         QObject::tr("Red"),
         1
     );
     const PredefinedColorPointer green = std::make_shared<PredefinedColor>(
-        QColor("#3CB44B"),
+        QColor("#32be44"),
         QLatin1String("Green"),
         QObject::tr("Green"),
         2
     );
     const PredefinedColorPointer blue = std::make_shared<PredefinedColor>(
-        QColor("#4363D8"),
+        QColor("#0044ff"),
         QLatin1String("Blue"),
         QObject::tr("Blue"),
         3
     );
     const PredefinedColorPointer yellow = std::make_shared<PredefinedColor>(
-        QColor("#FFE119"),
+        QColor("#f8d200"),
         QLatin1String("Yellow"),
         QObject::tr("Yellow"),
         4
     );
     const PredefinedColorPointer cyan = std::make_shared<PredefinedColor>(
-        QColor("#42D4F4"),
-        QLatin1String("Cyan"),
-        QObject::tr("Cyan"),
+        QColor("#42d4f4"),
+        QLatin1String("Celeste"),
+        QObject::tr("Celeste"),
         5
     );
     const PredefinedColorPointer magenta = std::make_shared<PredefinedColor>(
-        QColor("#F032E6"),
-        QLatin1String("Magenta"),
-        QObject::tr("Magenta"),
+        QColor("#af00cc"),
+        QLatin1String("Purple"),
+        QObject::tr("Purple"),
         6
     );
     const PredefinedColorPointer pink = std::make_shared<PredefinedColor>(
-        QColor("#FABEBE"),
+        QColor("#fca6d7"),
         QLatin1String("Pink"),
         QObject::tr("Pink"),
         7
     );
     const PredefinedColorPointer white = std::make_shared<PredefinedColor>(
-        QColor("#FFFFFF"),
+        QColor("#f2f2ff"),
         QLatin1String("White"),
         QObject::tr("White"),
         8

--- a/src/util/color/predefinedcolorsset.h
+++ b/src/util/color/predefinedcolorsset.h
@@ -60,17 +60,11 @@ class PredefinedColorsSet final {
         QObject::tr("Pink"),
         7
     );
-    const PredefinedColorPointer teal = std::make_shared<PredefinedColor>(
-        QColor("#469990"),
-        QLatin1String("Teal"),
-        QObject::tr("Teal"),
+    const PredefinedColorPointer white = std::make_shared<PredefinedColor>(
+        QColor("#FFFFFF"),
+        QLatin1String("White"),
+        QObject::tr("White"),
         8
-    );
-    const PredefinedColorPointer grey = std::make_shared<PredefinedColor>(
-        QColor("#A9A9A9"),
-        QLatin1String("Grey"),
-        QObject::tr("Grey"),
-        9
     );
 
     // The list of the predefined colors.
@@ -83,8 +77,7 @@ class PredefinedColorsSet final {
         cyan,
         magenta,
         pink,
-        teal,
-        grey,
+        white,
     };
 
     PredefinedColorsSet()

--- a/src/util/color/predefinedcolorsset.h
+++ b/src/util/color/predefinedcolorsset.h
@@ -19,37 +19,37 @@ class PredefinedColorsSet final {
         0
     );
     const PredefinedColorPointer red = std::make_shared<PredefinedColor>(
-        QColor("#E6194B"),
+        QColor("#FF0000"),
         QLatin1String("Red"),
         QObject::tr("Red"),
         1
     );
     const PredefinedColorPointer green = std::make_shared<PredefinedColor>(
-        QColor("#3CB44B"),
+        QColor("#00FF00"),
         QLatin1String("Green"),
         QObject::tr("Green"),
         2
     );
-    const PredefinedColorPointer yellow = std::make_shared<PredefinedColor>(
-        QColor("#FFE119"),
-        QLatin1String("Yellow"),
-        QObject::tr("Yellow"),
-        3
-    );
     const PredefinedColorPointer blue = std::make_shared<PredefinedColor>(
-        QColor("#4363D8"),
+        QColor("#0000FF"),
         QLatin1String("Blue"),
         QObject::tr("Blue"),
+        3
+    );
+    const PredefinedColorPointer yellow = std::make_shared<PredefinedColor>(
+        QColor("#FFFF00"),
+        QLatin1String("Yellow"),
+        QObject::tr("Yellow"),
         4
     );
     const PredefinedColorPointer cyan = std::make_shared<PredefinedColor>(
-        QColor("#42D4F4"),
+        QColor("#00FFFF"),
         QLatin1String("Cyan"),
         QObject::tr("Cyan"),
         5
     );
     const PredefinedColorPointer magenta = std::make_shared<PredefinedColor>(
-        QColor("#F032E6"),
+        QColor("#FF00FF"),
         QLatin1String("Magenta"),
         QObject::tr("Magenta"),
         6


### PR DESCRIPTION
**Remove Teal color**: It was a darkish color that I felt It didn't work very well on a controller.
**Replace Gray with white**: Same as above. White makes more sense.
~**Change default color representations**: I've changed the default rgba of the predefined colors to their pure primary or secondary shade. It's the most opinionated shade of the color and so the one that should be the default. I think it's also the most useful for a controller script in case it needs to be manipulated.
If this new defaults are not suitable for display on a screen we should address this by setting custom skin colors.~

**TODO**
- [x] Tune colors
- [ ] Add palette svg template