### PR TITLE
Auto-format source code with clang-format (config file)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,7 +10,8 @@ ColumnLimit:  0
 ---
 Language:     Cpp
 AccessModifierOffset: -2
-AlignAfterOpenBracket: AlwaysBreak
+AlignAfterOpenBracket: DontAlign
+AlignOperands: false
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false

--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,10 @@ BasedOnStyle: Google
 IndentWidth:  4
 TabWidth:     8
 UseTab:       Never
-ColumnLimit:  100
+# NOTE(2019-02-23, uklotzde) The column limit has been set to 0
+# to avoid eagerly reformatting of the existing code base. This
+# may later be changed to 80-100 characters per line if desired.
+ColumnLimit:  0
 ---
 Language:     Cpp
 AccessModifierOffset: -2

--- a/.clang-format
+++ b/.clang-format
@@ -13,6 +13,8 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
+IndentCaseLabels: false
+ReflowComments: false
 SpacesBeforeTrailingComments: 1
 ---
 Language: JavaScript

--- a/.clang-format
+++ b/.clang-format
@@ -23,8 +23,10 @@ ReflowComments: false
 SpacesBeforeTrailingComments: 1
 ---
 Language: JavaScript
+# Don't format .js files yet
+DisableFormat: true
 ---
 Language: Proto
-# Don't format .proto files.
+# Don't format .proto files yet
 DisableFormat: true
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -14,6 +14,8 @@ AlignAfterOpenBracket: AlwaysBreak
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
+BinPackArguments: false
+BinPackParameters: false
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
 IndentCaseLabels: false

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,23 @@
+---
+BasedOnStyle: Google
+IndentWidth:  4
+TabWidth:     8
+UseTab:       Never
+ColumnLimit:  100
+---
+Language:     Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+SpacesBeforeTrailingComments: 1
+---
+Language: JavaScript
+---
+Language: Proto
+# Don't format .proto files.
+DisableFormat: true
+...

--- a/.clang-format
+++ b/.clang-format
@@ -21,7 +21,6 @@ ContinuationIndentWidth: 8
 IndentCaseLabels: false
 ReflowComments: false
 SpacesBeforeTrailingComments: 1
-SpaceBeforeRangeBasedForLoopColon: false
 ---
 Language: JavaScript
 ---

--- a/.clang-format
+++ b/.clang-format
@@ -21,6 +21,7 @@ ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
 IndentCaseLabels: false
 ReflowComments: false
+SpaceAfterTemplateKeyword: false
 SpacesBeforeTrailingComments: 1
 ---
 Language: JavaScript

--- a/.clang-format
+++ b/.clang-format
@@ -19,6 +19,7 @@ ContinuationIndentWidth: 8
 IndentCaseLabels: false
 ReflowComments: false
 SpacesBeforeTrailingComments: 1
+SpaceBeforeRangeBasedForLoopColon: false
 ---
 Language: JavaScript
 ---


### PR DESCRIPTION
I've created a minimal `.clang-format` file based on the _Google_ C++ style and our style guide. Only those options that differ from the default _Google_ C++ style are included to keep it short and concise.

This initial configuration file can be tuned and adapted while we gradually reformat more files. Options for other languages like Python and JavaScript can be added on demand. We don't need to reformat all files at once, since that would introduce many merge conflicts!

The `.clang-format` file is picked up by _VS Code_ when opening the project folder and I now get correctly formatted code when saving files after editing them :)