### PR TITLE
CO to change star rating with controller

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -808,8 +808,6 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     QString starsUpDescription = tr("Increase the track rating by one star");
     QString starsDownTitle = tr("Star Rating Down");
     QString starsDownDescription = tr("Decrease the track rating by one star");
-    QString starsChangeTitle = tr("Star Rating Up/Down");
-    QString starsChangeDescription = tr("Change the track rating by +/- one star");
     for (int i = 1; i <= iNumDecks; ++i) {
         addControl(QString("[Deck%1]").arg(i), "stars_up",
                    QString("%1: %2").arg(m_deckStr.arg(i), starsUpTitle),
@@ -817,9 +815,6 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
         addControl(QString("[Deck%1]").arg(i), "stars_down",
                    QString("%1: %2").arg(m_deckStr.arg(i), starsDownTitle),
                    QString("%1: %2").arg(m_deckStr.arg(i), starsDownDescription), guiMenu);
-        addControl(QString("[Deck%1]").arg(i), "stars_change",
-                   QString("%1: %2").arg(m_deckStr.arg(i), starsChangeTitle),
-                   QString("%1: %2").arg(m_deckStr.arg(i), starsChangeDescription), guiMenu);
     }
 }
 

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -805,26 +805,10 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addDeckControl("waveform_zoom_up", tr("Waveform Zoom Out"), tr("Zoom waveform out"), guiMenu);
 
     // Controls to change a deck's star rating
-    QString starsUpTitle = tr("Star Rating Up");
-    QString starsUpDescription = tr("Increase the track rating by one star");
-    QString starsDownTitle = tr("Star Rating Down");
-    QString starsDownDescription = tr("Decrease the track rating by one star");
-    for (int i = 1; i <= iNumDecks; ++i) {
-        addControl(QString("[Deck%1]").arg(i), "stars_up",
-                   QString("%1: %2").arg(m_deckStr.arg(i), starsUpTitle),
-                   QString("%1: %2").arg(m_deckStr.arg(i), starsUpDescription), guiMenu);
-        addControl(QString("[Deck%1]").arg(i), "stars_down",
-                   QString("%1: %2").arg(m_deckStr.arg(i), starsDownTitle),
-                   QString("%1: %2").arg(m_deckStr.arg(i), starsDownDescription), guiMenu);
-    }
-    for (int i = 1; i <= iNumPreviewDecks; ++i) {
-        addControl(QString("[PreviewDeck%1]").arg(i), "stars_up",
-                   QString("%1: %2").arg(m_deckStr.arg(i), starsUpTitle),
-                   QString("%1: %2").arg(m_deckStr.arg(i), starsUpDescription), guiMenu);
-        addControl(QString("[PreviewDeck%1]").arg(i), "stars_down",
-                   QString("%1: %2").arg(m_deckStr.arg(i), starsDownTitle),
-                   QString("%1: %2").arg(m_deckStr.arg(i), starsDownDescription), guiMenu);
-    }
+    addDeckAndPreviewDeckControl("stars_up", tr("Star Rating Up"),
+        tr("Increase the track rating by one star"), guiMenu);
+    addDeckAndPreviewDeckControl("stars_down", tr("Star Rating Down"),
+        tr("Decrease the track rating by one star"), guiMenu);
 }
 
 ControlPickerMenu::~ControlPickerMenu() {

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -802,6 +802,25 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addDeckControl("waveform_zoom", tr("Waveform Zoom"), tr("Waveform zoom"), guiMenu);
     addDeckControl("waveform_zoom_down", tr("Waveform Zoom In"), tr("Zoom waveform in"), guiMenu);
     addDeckControl("waveform_zoom_up", tr("Waveform Zoom Out"), tr("Zoom waveform out"), guiMenu);
+
+    // Controls to change a deck's star rating
+    QString starsUpTitle = tr("Star Rating Up");
+    QString starsUpDescription = tr("Increase the track rating by one star");
+    QString starsDownTitle = tr("Star Rating Down");
+    QString starsDownDescription = tr("Decrease the track rating by one star");
+    QString starsChangeTitle = tr("Star Rating Up/Down");
+    QString starsChangeDescription = tr("Change the track rating by +/- one star");
+    for (int i = 1; i <= iNumDecks; ++i) {
+        addControl(QString("[Deck%1]").arg(i), "stars_up",
+                   QString("%1: %2").arg(m_deckStr.arg(i), starsUpTitle),
+                   QString("%1: %2").arg(m_deckStr.arg(i), starsUpDescription), guiMenu);
+        addControl(QString("[Deck%1]").arg(i), "stars_down",
+                   QString("%1: %2").arg(m_deckStr.arg(i), starsDownTitle),
+                   QString("%1: %2").arg(m_deckStr.arg(i), starsDownDescription), guiMenu);
+        addControl(QString("[Deck%1]").arg(i), "stars_change",
+                   QString("%1: %2").arg(m_deckStr.arg(i), starsChangeTitle),
+                   QString("%1: %2").arg(m_deckStr.arg(i), starsChangeDescription), guiMenu);
+    }
 }
 
 ControlPickerMenu::~ControlPickerMenu() {

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -153,7 +153,6 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     QMenu* eqMenu = addSubmenu(tr("Equalizers"));
     const int kNumEqRacks = 1;
     const int iNumDecks = ControlObject::get(ConfigKey("[Master]", "num_decks"));
-    const int iNumPreviewDecks = ControlObject::get(ConfigKey("[Master]", "num_preview_decks"));
     for (int iRackNumber = 0; iRackNumber < kNumEqRacks; ++iRackNumber) {
         // TODO: Although there is a mode with 4-band EQs, it's not feasible
         // right now to add support for learning both it and regular 3-band eqs.

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -153,6 +153,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     QMenu* eqMenu = addSubmenu(tr("Equalizers"));
     const int kNumEqRacks = 1;
     const int iNumDecks = ControlObject::get(ConfigKey("[Master]", "num_decks"));
+    const int iNumPreviewDecks = ControlObject::get(ConfigKey("[Master]", "num_preview_decks"));
     for (int iRackNumber = 0; iRackNumber < kNumEqRacks; ++iRackNumber) {
         // TODO: Although there is a mode with 4-band EQs, it's not feasible
         // right now to add support for learning both it and regular 3-band eqs.
@@ -813,6 +814,14 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                    QString("%1: %2").arg(m_deckStr.arg(i), starsUpTitle),
                    QString("%1: %2").arg(m_deckStr.arg(i), starsUpDescription), guiMenu);
         addControl(QString("[Deck%1]").arg(i), "stars_down",
+                   QString("%1: %2").arg(m_deckStr.arg(i), starsDownTitle),
+                   QString("%1: %2").arg(m_deckStr.arg(i), starsDownDescription), guiMenu);
+    }
+    for (int i = 1; i <= iNumPreviewDecks; ++i) {
+        addControl(QString("[PreviewDeck%1]").arg(i), "stars_up",
+                   QString("%1: %2").arg(m_deckStr.arg(i), starsUpTitle),
+                   QString("%1: %2").arg(m_deckStr.arg(i), starsUpDescription), guiMenu);
+        addControl(QString("[PreviewDeck%1]").arg(i), "stars_down",
                    QString("%1: %2").arg(m_deckStr.arg(i), starsDownTitle),
                    QString("%1: %2").arg(m_deckStr.arg(i), starsDownDescription), guiMenu);
     }

--- a/src/library/starrating.cpp
+++ b/src/library/starrating.cpp
@@ -34,9 +34,6 @@ StarRating::StarRating(int starCount, int maxStarCount)
         //
         // understand those equations
         m_starPolygon << QPointF(0.5 + 0.5 * cos(0.8 * i * 3.14), 0.5 + 0.5 * sin(0.8 * i * 3.14));
-        float QPointFx = 0.5 + 0.5 * cos(0.8 * i * 3.14);
-        float QPointFy = 0.5 + 0.5 * sin(0.8 * i * 3.14);
-//        qDebug() << "Debug: star point #" << i << ": " << QPointFx << ", " << QPointFy;
     }
     // creates 5 points for a tiny diamond/rhombe (square turned by 45°)
     // why do we need 5 cusps here? 4 should suffice as the polygon is closed automatically for the star above..

--- a/src/library/starrating.cpp
+++ b/src/library/starrating.cpp
@@ -30,9 +30,9 @@ StarRating::StarRating(int starCount, int maxStarCount)
     m_starPolygon << QPointF(1.0, 0.5);
     for (int i = 1; i < 5; ++i) {
         // add QPointF 2-5 to polygon point array, equally distributed on a circumference.
-        // To create a star (not a pentagon) we need to connect every second point.
-        //
-        // understand those equations
+        // To create a star (not a pentagon) we need to connect every second of those points.
+        // This should actually give us a star that points up, but the drawn result points right.
+        // x-y axes are swapped?
         m_starPolygon << QPointF(0.5 + 0.5 * cos(0.8 * i * 3.14), 0.5 + 0.5 * sin(0.8 * i * 3.14));
     }
     // creates 5 points for a tiny diamond/rhombe (square turned by 45°)

--- a/src/library/starrating.cpp
+++ b/src/library/starrating.cpp
@@ -20,14 +20,26 @@
 #include "library/starrating.h"
 #include "util/math.h"
 
+// Magic number? Explain what this factor affects and how
 const int PaintingScaleFactor = 15;
 
 StarRating::StarRating(int starCount, int maxStarCount)
         : m_myStarCount(starCount),
           m_myMaxStarCount(maxStarCount) {
+    // 1st star cusp at 0° of the unit circle whose center is shifted to adapt the 0,0-based paint area
     m_starPolygon << QPointF(1.0, 0.5);
-    for (int i = 1; i < 5; ++i)
+    for (int i = 1; i < 5; ++i) {
+        // add QPointF 2-5 to polygon point array, equally distributed on a circumference.
+        // To create a star (not a pentagon) we need to connect every second point.
+        //
+        // understand those equations
         m_starPolygon << QPointF(0.5 + 0.5 * cos(0.8 * i * 3.14), 0.5 + 0.5 * sin(0.8 * i * 3.14));
+        float QPointFx = 0.5 + 0.5 * cos(0.8 * i * 3.14);
+        float QPointFy = 0.5 + 0.5 * sin(0.8 * i * 3.14);
+//        qDebug() << "Debug: star point #" << i << ": " << QPointFx << ", " << QPointFy;
+    }
+    // creates 5 points for a tiny diamond/rhombe (square turned by 45°)
+    // why do we need 5 cusps here? 4 should suffice as the polygon is closed automatically for the star above..
     m_diamondPolygon << QPointF(0.4, 0.5) << QPointF(0.5, 0.4) << QPointF(0.6, 0.5) << QPointF(0.5, 0.6) << QPointF(0.4, 0.5);
 }
 

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -10,6 +10,11 @@ WStarRating::WStarRating(QString group, QWidget* pParent)
           m_starRating(0,5),
           m_pGroup(group),
           m_focused(false) {
+  // Controls to change the star rating with controllers
+  m_pStarsUp = std::make_unique<ControlPushButton>(ConfigKey(group, "stars_up"));
+  m_pStarsDown = std::make_unique<ControlPushButton>(ConfigKey(group, "stars_down"));
+  connect(m_pStarsUp.get(), SIGNAL(valueChanged(double)),this, SLOT(slotStarsUp(double)));
+  connect(m_pStarsDown.get(), SIGNAL(valueChanged(double)),this, SLOT(slotStarsDown(double)));
 }
 
 void WStarRating::setup(const QDomNode& node, const SkinContext& context) {
@@ -84,6 +89,32 @@ void WStarRating::mouseMoveEvent(QMouseEvent *event) {
     if (star != m_starRating.starCount() && star != -1) {
         m_starRating.setStarCount(star);
         update();
+    }
+}
+
+void WStarRating::slotStarsUp(double v) {
+    if (!m_pCurrentTrack) {
+        return;
+    }
+    if (v > 0 && m_starRating.starCount() < m_starRating.maxStarCount()) {
+        int star = m_starRating.starCount() + 1;
+        qDebug() << "   stars " << m_starRating.starCount() << " > " << star;
+        m_starRating.setStarCount(star);
+        update();
+        m_pCurrentTrack->setRating(star);
+    }
+}
+
+void WStarRating::slotStarsDown(double v) {
+    if (!m_pCurrentTrack) {
+        return;
+    }
+    if (v > 0 && m_starRating.starCount() > 0) {
+        int star = m_starRating.starCount() - 1;
+        qDebug() << "   stars " << m_starRating.starCount() << " > " << star;
+        m_starRating.setStarCount(star);
+        update();
+        m_pCurrentTrack->setRating(star);
     }
 }
 

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -98,7 +98,6 @@ void WStarRating::slotStarsUp(double v) {
     }
     if (v > 0 && m_starRating.starCount() < m_starRating.maxStarCount()) {
         int star = m_starRating.starCount() + 1;
-        qDebug() << "   stars " << m_starRating.starCount() << " > " << star;
         m_starRating.setStarCount(star);
         update();
         m_pCurrentTrack->setRating(star);
@@ -111,7 +110,6 @@ void WStarRating::slotStarsDown(double v) {
     }
     if (v > 0 && m_starRating.starCount() > 0) {
         int star = m_starRating.starCount() - 1;
-        qDebug() << "   stars " << m_starRating.starCount() << " > " << star;
         m_starRating.setStarCount(star);
         update();
         m_pCurrentTrack->setRating(star);

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -11,6 +11,11 @@
 #include "library/starrating.h"
 #include "widget/wwidget.h"
 
+#include "control/controlpushbutton.h"
+
+class ControlObject;
+class ControlPushButton;
+
 class WStarRating : public WWidget {
     Q_OBJECT
   public:
@@ -24,6 +29,8 @@ class WStarRating : public WWidget {
 
   private slots:
     void updateRating(Track*);
+    void slotStarsUp(double v);
+    void slotStarsDown(double v);
 
   protected:
     void paintEvent(QPaintEvent* e) override;
@@ -41,6 +48,8 @@ class WStarRating : public WWidget {
     private:
         void updateRating();
         int starAtPosition(int x);
+        std::unique_ptr<ControlPushButton> m_pStarsUp;
+        std::unique_ptr<ControlPushButton> m_pStarsDown;
 };
 
 #endif /* WSTARRATING_H */


### PR DESCRIPTION
This introduces controls
`[ChannelN],stars_up`
`[ChannelN],stars_down`
`[PreviewDeckN],stars_up`
`[PreviewDeckN],stars_down`
to allow changing a deck's star rating with controllers.
[lp:1814096](https://bugs.launchpad.net/mixxx/+bug/1814096)

Is this the correct approach?
No interference with mouse-over, stars are set in decks' visual and in the library immediately.

**ToDo**
- [x] make strings translatable in Controller Wizard
- [x] add the controls for the preview deck(s)
- [x] group controls properly in Controller Wizard > User Interface
- [x] clean up/improve starrating.cpp comments on drawing the polygons

I have a working implementation for the Reloop TerminalMix2/4 mapping which I'll clean up and commit here, as well:
- press & hold a deck's Load button
- turn the Trax knob to increase/decrease the respective deck's rating