### PR TITLE
Force components.SamplerButton volume to max when not velocity sensitive

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -320,13 +320,6 @@
                     if (engine.getValue(this.group, 'track_loaded') === 0) {
                         engine.setValue(this.group, 'LoadSelectedTrack', 1);
                     } else {
-                        engine.setValue(
-                            this.group, 
-                            'volume',
-                            this.volumeByVelocity ?
-                                this.inValueScale(value) :
-                                1
-                        );
                         engine.setValue(this.group, 'cue_gotoandplay', 1);
                     }
                 }
@@ -378,6 +371,15 @@
             }
             if (this.looping !== undefined) {
                 this.connections[2] = engine.connectControl(this.group, 'repeat', this.output);
+            }
+        },
+        disconnect: function () {
+            // reset volume to initial volume
+            engine.setParameter(this.group,"volume",1);
+            if (this.connections[0] !== undefined) {
+                this.connections.forEach(function (conn) {
+                    conn.disconnect();
+                });
             }
         },
         outKey: null, // hack to get Component constructor to call connect()

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -320,9 +320,13 @@
                     if (engine.getValue(this.group, 'track_loaded') === 0) {
                         engine.setValue(this.group, 'LoadSelectedTrack', 1);
                     } else {
-                        if (this.volumeByVelocity) {
-                            engine.setValue(this.group, 'volume', this.inValueScale(value));
-                        }
+                        engine.setValue(
+                            this.group, 
+                            'volume',
+                            this.volumeByVelocity ?
+                                this.inValueScale(value) :
+                                1
+                        );
                         engine.setValue(this.group, 'cue_gotoandplay', 1);
                     }
                 }


### PR DESCRIPTION
Obvious Issue from the last samplerbutton change: When you disable the velocity sensitive feature, the deck is stuck at the volume it last played at. In the first commit I am forcing the volume to 1 whenever the unit gets triggered. In the second commit I am proposing a different solution where I reset value only when the button gets disconnected from the unit. I am not sure which solution is better so I am proposing both. I'd revert the solution we don't want once we decided.