### PR TITLE
Fix wrong debug assertion

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1194,7 +1194,7 @@ void EngineBuffer::postProcess(const int iBufferSize) {
 }
 
 void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
-    VERIFY_OR_DEBUG_ASSERT(m_trackSampleRateOld && m_trackSamplesOld) {
+    VERIFY_OR_DEBUG_ASSERT(m_trackSampleRateOld && m_tempo_ratio_old) {
         // no track loaded, function not called in this case
         return;
     }


### PR DESCRIPTION
After starting Mixxx and loading the first track this debug assert fired:
```
Critical [Engine]: DEBUG ASSERT: "m_trackSampleRateOld && m_trackSamplesOld" in function void EngineBuffer::updateIndicators(double, int) at src/engine/enginebuffer.cpp:1197
```

Only happened once, I'm not able to reproduce it.