### PR TITLE
Library: re-focus tracks table when scrolling with controller

### DIFF
--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -391,12 +391,14 @@ void LibraryControl::emitKeyEvent(QKeyEvent&& event) {
     // Ensure a valid library widget has the keyboard focus.
     // QApplication::focusWidget() is not sufficient here because it
     // would return any focussed widget like WOverview, WWaveform, QSpinBox
-    if (m_pLibraryWidget && !m_pLibraryWidget->hasFocus() &&
-            m_pSidebarWidget && !m_pSidebarWidget->hasFocus()) {
+    VERIFY_OR_DEBUG_ASSERT(m_pSidebarWidget && m_pLibraryWidget) {
+        return;
+    }
+    if (!m_pLibraryWidget->hasFocus() && !m_pSidebarWidget->hasFocus()) {
         setLibraryFocus();
     }
     auto focusWidget = QApplication::focusWidget();
-    if (!focusWidget) {
+    VERIFY_OR_DEBUG_ASSERT(focusWidget) {
         return;
     }
     // Send the event pointer to the currently focused widget
@@ -407,6 +409,9 @@ void LibraryControl::emitKeyEvent(QKeyEvent&& event) {
 
 void LibraryControl::setLibraryFocus() {
     // XXX: Set the focus of the library panel directly instead of sending tab from sidebar
+    VERIFY_OR_DEBUG_ASSERT(m_pSidebarWidget) {
+        return;
+    }
     m_pSidebarWidget->setFocus();
     QKeyEvent event(QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier);
     QApplication::sendEvent(m_pSidebarWidget, &event);

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -391,7 +391,10 @@ void LibraryControl::emitKeyEvent(QKeyEvent&& event) {
     // Ensure a valid library widget has the keyboard focus.
     // QApplication::focusWidget() is not sufficient here because it
     // would return any focussed widget like WOverview, WWaveform, QSpinBox
-    VERIFY_OR_DEBUG_ASSERT(m_pSidebarWidget && m_pLibraryWidget) {
+    VERIFY_OR_DEBUG_ASSERT(m_pSidebarWidget) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(m_pLibraryWidget) {
         return;
     }
     if (!m_pLibraryWidget->hasFocus() && !m_pSidebarWidget->hasFocus()) {


### PR DESCRIPTION
A first step to solve [lp:1673196 Controls for Library focus](https://bugs.launchpad.net/mixxx/+bug/1673196)

When currently no library widget has focus this ensures tracks table has focus after issueing
`[Library],Move/MoveUp/MoveDown`
`[Library],Scroll/ScrollUp/ScrollDown`
`[Library],MoveFocus/~Forward/~Backward`
This also allows to jump directly to the tracks table from the search box.

~~I also added some temp debug output to maybe also focus the lib table directly instead of first focusing the sidebar and sending Tab from there. Maybe I can do this with your help, otherwise I'll just revert that commit.~~

**EDIT**
it turned out emitKeyEvent would already take care of re-focussing the tracks table.
I rolled back my attempt and fixed that function instead.


Direct focus COs would handy for the multi-pane lib-redesign which store the previously focused lib widget.