### PR TITLE
[DONE] Add indication whether controller callback was successfully disconnected

### DIFF
--- a/src/control/controlobjectscript.cpp
+++ b/src/control/controlobjectscript.cpp
@@ -35,7 +35,7 @@ bool ControlObjectScript::addScriptConnection(const ScriptConnection& conn) {
     return true;
 }
 
-void ControlObjectScript::removeScriptConnection(const ScriptConnection& conn) {
+bool ControlObjectScript::removeScriptConnection(const ScriptConnection& conn) {
     bool success = m_scriptConnections.removeOne(conn);
     if (success) {
         controllerDebug("Disconnected (" +
@@ -53,6 +53,7 @@ void ControlObjectScript::removeScriptConnection(const ScriptConnection& conn) {
         disconnect(this, SIGNAL(trigger(double, QObject*)),
                 this, SLOT(slotValueChanged(double,QObject*)));
     }
+    return success;
 }
 
 void ControlObjectScript::disconnectAllConnectionsToFunction(const QScriptValue& function) {

--- a/src/control/controlobjectscript.h
+++ b/src/control/controlobjectscript.h
@@ -15,7 +15,7 @@ class ControlObjectScript : public ControlProxy {
 
     bool addScriptConnection(const ScriptConnection& conn);
 
-    void removeScriptConnection(const ScriptConnection& conn);
+    bool removeScriptConnection(const ScriptConnection& conn);
 
     // Required for legacy behavior of ControllerEngine::connectControl
     inline int countConnections() {

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -776,12 +776,9 @@ bool ControllerEngine::removeScriptConnection(const ScriptConnection connection)
 }
 
 bool ScriptConnectionInvokableWrapper::disconnect() {
-    bool success = m_scriptConnection.controllerEngine->removeScriptConnection(m_scriptConnection);
-    // set id to empty (falsy) string to indicate that the connection has been disconnected
-    if (success) {
-    	m_idString = "";
-    }
-    return success;
+    // if the removeScriptConnection succeeded, the connection has been successfully disconnected
+    m_isConnected = !m_scriptConnection.controllerEngine->removeScriptConnection(m_scriptConnection);
+    return m_isConnected;
 }
 
 /* -------- ------------------------------------------------------

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -764,19 +764,24 @@ void ScriptConnection::executeCallback(double value) const {
    Purpose: (Dis)connects a ScriptConnection
    Input:   the ScriptConnection to disconnect
    -------- ------------------------------------------------------ */
-void ControllerEngine::removeScriptConnection(const ScriptConnection connection) {
+bool ControllerEngine::removeScriptConnection(const ScriptConnection connection) {
     ControlObjectScript* coScript = getControlObjectScript(connection.key.group,
                                                            connection.key.item);
 
     if (m_pEngine == nullptr || coScript == nullptr) {
-        return;
+        return false;
     }
 
-    coScript->removeScriptConnection(connection);
+    return coScript->removeScriptConnection(connection);
 }
 
-void ScriptConnectionInvokableWrapper::disconnect() {
-    m_scriptConnection.controllerEngine->removeScriptConnection(m_scriptConnection);
+bool ScriptConnectionInvokableWrapper::disconnect() {
+    bool success = m_scriptConnection.controllerEngine->removeScriptConnection(m_scriptConnection);
+    // set id to empty (falsy) string to indicate that the connection has been disconnected
+    if (success) {
+    	m_idString = "";
+    }
+    return success;
 }
 
 /* -------- ------------------------------------------------------

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -777,7 +777,7 @@ bool ControllerEngine::removeScriptConnection(const ScriptConnection connection)
 
 bool ScriptConnectionInvokableWrapper::disconnect() {
     // if the removeScriptConnection succeeded, the connection has been successfully disconnected
-	bool success = m_scriptConnection.controllerEngine->removeScriptConnection(m_scriptConnection);
+    bool success = m_scriptConnection.controllerEngine->removeScriptConnection(m_scriptConnection);
     m_isConnected = !success;
     return success;
 }

--- a/src/controllers/controllerengine.cpp
+++ b/src/controllers/controllerengine.cpp
@@ -777,8 +777,9 @@ bool ControllerEngine::removeScriptConnection(const ScriptConnection connection)
 
 bool ScriptConnectionInvokableWrapper::disconnect() {
     // if the removeScriptConnection succeeded, the connection has been successfully disconnected
-    m_isConnected = !m_scriptConnection.controllerEngine->removeScriptConnection(m_scriptConnection);
-    return m_isConnected;
+	bool success = m_scriptConnection.controllerEngine->removeScriptConnection(m_scriptConnection);
+    m_isConnected = !success;
+    return success;
 }
 
 /* -------- ------------------------------------------------------

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -65,7 +65,7 @@ class ScriptConnectionInvokableWrapper : public QObject {
         m_idString = conn.id.toString();
     }
     const QString& readId() const { return m_idString; }
-    Q_INVOKABLE void disconnect();
+    Q_INVOKABLE bool disconnect();
     Q_INVOKABLE void trigger();
 
   private:
@@ -99,7 +99,7 @@ class ControllerEngine : public QObject {
     const QList<QString>& getScriptFunctionPrefixes() { return m_scriptFunctionPrefixes; };
 
     // Disconnect a ScriptConnection
-    void removeScriptConnection(const ScriptConnection conn);
+    bool removeScriptConnection(const ScriptConnection conn);
     void triggerScriptConnection(const ScriptConnection conn);
 
   protected:

--- a/src/controllers/controllerengine.h
+++ b/src/controllers/controllerengine.h
@@ -59,18 +59,22 @@ class ScriptConnectionInvokableWrapper : public QObject {
     //Q_PROPERTY(ConfigKey key READ key)
     // There's little use in exposing the function...
     //Q_PROPERTY(QScriptValue function READ function)
+    Q_PROPERTY(bool isConnected READ readIsConnected)
   public:
     ScriptConnectionInvokableWrapper(ScriptConnection conn) {
         m_scriptConnection = conn;
         m_idString = conn.id.toString();
+        m_isConnected = true;
     }
     const QString& readId() const { return m_idString; }
+    bool readIsConnected() const { return m_isConnected; }
     Q_INVOKABLE bool disconnect();
     Q_INVOKABLE void trigger();
 
   private:
     ScriptConnection m_scriptConnection;
     QString m_idString;
+    bool m_isConnected;
 };
 
 class ControllerEngine : public QObject {

--- a/src/test/controllerengine_test.cpp
+++ b/src/test/controllerengine_test.cpp
@@ -450,6 +450,32 @@ TEST_F(ControllerEngineTest, connectionObject_Disconnect) {
     // The counter should have been incremented exactly once.
     EXPECT_DOUBLE_EQ(1.0, pass->get());
 }
+TEST_F(ControllerEngineTest, connectionObject_reflectDisconnect) {
+    // Test that checks if disconnecting yields the appropriate feedback
+    auto co = std::make_unique<ControlObject>(ConfigKey("[Test]", "co"));
+    auto pass = std::make_unique<ControlObject>(ConfigKey("[Test]", "passed"));
+
+    ScopedTemporaryFile script(makeTemporaryFile(
+        "var reaction = function(success) { "
+        "  if (success) {"
+        "    var pass = engine.getValue('[Test]', 'passed');"
+        "    engine.setValue('[Test]', 'passed', pass + 1.0); "
+        "  }"
+        "};"
+        "var dummy_callback = function(value) {};"
+        "var connection = engine.makeConnection('[Test]', 'co', dummy_callback);"
+        "reaction(connection);"
+        "reaction(connection.isConnected);"
+        "var successful_disconnect = connection.disconnect();"
+        "reaction(successful_disconnect);"
+        "reaction(!connection.isConnected);"
+    ));
+    cEngine->evaluate(script->fileName());
+    EXPECT_FALSE(cEngine->hasErrors(script->fileName()));
+    application()->processEvents();
+    EXPECT_DOUBLE_EQ(4.0, pass->get());
+}
+
 
 TEST_F(ControllerEngineTest, connectionObject_DisconnectByPassingToConnectControl) {
     // Test that passing a connection object back to engine.connectControl
@@ -562,6 +588,7 @@ TEST_F(ControllerEngineTest, connectionObject_trigger) {
     // The counter should have been incremented exactly once.
     EXPECT_DOUBLE_EQ(1.0, counter->get());
 }
+
 
 TEST_F(ControllerEngineTest, connectionExecutesWithCorrectThisObject) {
     // Test that callback functions are executed with JavaScript's


### PR DESCRIPTION
While Mapping the NS6II, I encountered a problem where I had to check if the connection is already disconnected. 
The added code will set `connection.isConnected` to true/false accordingly. It will also return whether `connection.disconnect()` was successful.

TODO:
- [x] Add tests
- [x] Add Wiki Documentation