### PR TITLE
Metadata tls fix

### DIFF
--- a/src/engine/sidechain/shoutconnection.cpp
+++ b/src/engine/sidechain/shoutconnection.cpp
@@ -186,16 +186,18 @@ void ShoutConnection::updateFromPreferences() {
     // strings to pass to libshout.
 
     QString codec = m_pProfile->getMetadataCharset();
-    QByteArray baCodec = codec.toLatin1();
-    m_pTextCodec = QTextCodec::codecForName(baCodec);
-    if (!m_pTextCodec) {
-        kLogger.warning()
-                << "Couldn't find broadcast metadata codec for codec:" << codec
-                << " defaulting to ISO-8859-1.";
+    if (!codec.isEmpty()) {
+        QByteArray baCodec = codec.toLatin1();
+        m_pTextCodec = QTextCodec::codecForName(baCodec);
+        if (!m_pTextCodec) {
+            kLogger.warning()
+                    << "Couldn't find broadcast metadata codec for codec:" << codec
+                    << " defaulting to ISO-8859-1.";
+        } else {
+            // Indicates our metadata is in the provided charset.
+            insertMetaData("charset",  baCodec.constData());
+        }
     }
-
-    // Indicates our metadata is in the provided charset.
-    shout_metadata_add(m_pShoutMetaData, "charset",  baCodec.constData());
 
     QString serverType = m_pProfile->getServertype();
 

--- a/src/engine/sidechain/shoutconnection.cpp
+++ b/src/engine/sidechain/shoutconnection.cpp
@@ -89,6 +89,16 @@ ShoutConnection::ShoutConnection(BroadcastProfilePtr profile,
         errorDialog(tr("Error setting non-blocking mode:"),
                 shout_get_error(m_pShout));
     }
+
+#ifdef SHOUT_TLS
+    // Libshout defaults to SHOUT_TLS_AUTO if build with SHOUT_TLS
+    // Sometimes autodetection fails, resulting into no metadata send
+    // https://bugs.launchpad.net/mixxx/+bug/1817395
+    if (shout_set_tls(m_pShout, SHOUT_TLS_DISABLED) != SHOUTERR_SUCCESS) {
+        errorDialog(tr("Error setting tls mode:"),
+                shout_get_error(m_pShout));
+    }
+#endif
 }
 
 ShoutConnection::~ShoutConnection() {

--- a/src/engine/sidechain/shoutconnection.h
+++ b/src/engine/sidechain/shoutconnection.h
@@ -116,6 +116,7 @@ class ShoutConnection
     bool waitForRetry();
 
     void tryReconnect();
+    void insertMetaData(const char *name, const char *value);
 
     QTextCodec* m_pTextCodec;
     TrackPointer m_pMetaData;


### PR DESCRIPTION
This PR fixes the "Metadata Not Send"  issue using a TLS enabled libshout build. 
It was tested and confirmed in https://github.com/mixxxdj/mixxx/pull/2040 

There is an underlying issue that tls auto detection fails. This could be fixed in a separate PR and probably requires altering the libshout code. 