### PR TITLE
Also show devices under /run/media/$USER on Linux

### DIFF
--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -288,32 +288,7 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, QModelIndex index
 namespace {
 // Get the list of devices (under "Removable Devices" section).
 QList<TreeItem*> getRemovableDevices(LibraryFeature* pFeature) {
-#if defined(__LINUX__)
-    // To get devices on Linux, we look for directories under /media and
-    // /run/media/$USER.
-    QFileInfoList devices;
-
-    // Add folders under /media to devices.
-    devices += QDir("/media").entryInfoList(
-        QDir::AllDirs | QDir::NoDotAndDotDot);
-
-    // Add folders under /run/media/$USER to devices.
-    QDir run_media_user_dir("/run/media/" + qgetenv("USER"));
-    devices += run_media_user_dir.entryInfoList(
-        QDir::AllDirs | QDir::NoDotAndDotDot);
-
-    // Convert devices into a QList<TreeItem*> for display.
-    QList<TreeItem*> ret;
-    foreach(QFileInfo device, devices) {
-        TreeItem* folder = new TreeItem(
-            pFeature,
-            device.fileName(),
-            device.filePath() + "/");
-        ret << folder;
-    }
-
-    return ret;
-#elif defined(__WINDOWS__)
+#if defined(__WINDOWS__)
     QList<TreeItem*> ret;
     // Repopulate drive list
     QFileInfoList drives = QDir::drives();
@@ -336,6 +311,31 @@ QList<TreeItem*> getRemovableDevices(LibraryFeature* pFeature) {
             display_path, // Displays C:
             drive.filePath()); // Displays C:/
         ret << driveLetter;
+    }
+
+    return ret;
+#elif defined(__LINUX__)
+    // To get devices on Linux, we look for directories under /media and
+    // /run/media/$USER.
+    QFileInfoList devices;
+
+    // Add folders under /media to devices.
+    devices += QDir("/media").entryInfoList(
+        QDir::AllDirs | QDir::NoDotAndDotDot);
+
+    // Add folders under /run/media/$USER to devices.
+    QDir run_media_user_dir("/run/media/" + qgetenv("USER"));
+    devices += run_media_user_dir.entryInfoList(
+        QDir::AllDirs | QDir::NoDotAndDotDot);
+
+    // Convert devices into a QList<TreeItem*> for display.
+    QList<TreeItem*> ret;
+    foreach(QFileInfo device, devices) {
+        TreeItem* folder = new TreeItem(
+            pFeature,
+            device.fileName(),
+            device.filePath() + "/");
+        ret << folder;
     }
 
     return ret;

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -91,21 +91,11 @@ BrowseFeature::BrowseFeature(QObject* parent,
     pRootItem->appendChild(tr("Devices"), "/Volumes/");
 #else  // LINUX
     TreeItem* devices_link = pRootItem->appendChild(tr("Removable Devices"), DEVICE_NODE);
-    // Look for directories under /media and /run/media/$USER.
-    QDir run_media_user_dir("/run/media/" + qgetenv("USER"));
-    qWarning() << "kerrick gah";
-    QFileInfoList devices =
-            QDir("/media").entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot)
-            + run_media_user_dir.entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot);
-
-    foreach(QFileInfo device, devices) {
-        qWarning() << "kerrick device " << device;
-        qWarning() << "kerrick fileName " << device.fileName();
-        qWarning() << "kerrick filePath " << device.filePath() + "/";
-        devices_link->appendChild(device.fileName(), device.filePath() + "/");
+    if (!getLinuxDevices().isEmpty()) {
+        devices_link->appendChild("dummy", "/dummy/");
     }
 
-    // show root directory on UNIX-based operating systems
+    // show root directory on Linux.
     pRootItem->appendChild(QDir::rootPath(), QDir::rootPath());
 #endif
 

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -285,7 +285,9 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, QModelIndex index
      onLazyChildExpandation(index);
 }
 
-QList<TreeItem*> BrowseFeature::getLinuxDevices() {
+namespace {
+// Get the list of devices (under "Removable Devices" section) on Linux.
+QList<TreeItem*> getLinuxRemovableDevices(LibraryFeature* pFeature) {
     // To get devices on Linux, we look for directories under /media and
     // /run/media/$USER.
     QFileInfoList devices;
@@ -303,13 +305,14 @@ QList<TreeItem*> BrowseFeature::getLinuxDevices() {
     QList<TreeItem*> ret;
     foreach(QFileInfo device, devices) {
         TreeItem* folder = new TreeItem(
-            this,
+            pFeature,
             device.fileName(),
             device.filePath() + "/");
         ret << folder;
     }
 
     return ret;
+}
 }
 
 // This is called whenever you double click or use the triangle symbol to expand
@@ -376,7 +379,7 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
 #elif defined(__APPLE__)
         DEBUG_ASSERT(!"Trying to process DEVICE_NODE on macOS");
 #else // LINUX
-        folders += getLinuxDevices();
+        folders += getLinuxRemovableDevices(this);
 #endif
     } else {
         // we assume that the path refers to a folder in the file system

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -90,10 +90,8 @@ BrowseFeature::BrowseFeature(QObject* parent,
     // /Volumes
     pRootItem->appendChild(tr("Devices"), "/Volumes/");
 #else  // LINUX
+    // DEVICE_NODE contents will be rendered lazily in onLazyChildExpandation.
     TreeItem* devices_link = pRootItem->appendChild(tr("Removable Devices"), DEVICE_NODE);
-    if (!getLinuxDevices().isEmpty()) {
-        devices_link->appendChild("dummy", "/dummy/");
-    }
 
     // show root directory on Linux.
     pRootItem->appendChild(QDir::rootPath(), QDir::rootPath());

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -361,23 +361,7 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
 #elif defined(__APPLE__)
         qWarning() << "Trying to process DEVICE_NODE on macOS; we shouldn't reach this point!";
 #else // LINUX
-        // Look for directories under /media and /run/media/$USER.
-        QDir run_media_user_dir("/run/media/" + qgetenv("USER"));
-        qWarning() << "kerrick gah";
-        QFileInfoList devices =
-                QDir("/media").entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot)
-                + run_media_user_dir.entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot);
-
-        foreach(QFileInfo device, devices) {
-            qWarning() << "kerrick device " << device;
-            qWarning() << "kerrick fileName " << device.fileName();
-            qWarning() << "kerrick filePath " << device.filePath() + "/";
-            TreeItem* folder = new TreeItem(
-                this,
-                device.fileName(),
-                device.filePath() + "/");
-            folders << folder;
-        }
+        folders += getLinuxDevices();
 #endif
     } else {
         // we assume that the path refers to a folder in the file system
@@ -508,4 +492,31 @@ QStringList BrowseFeature::getDefaultQuickLinks() const {
 
     qDebug() << "Default quick links:" << result;
     return result;
+}
+
+QList<TreeItem*> BrowseFeature::getLinuxDevices() {
+    // To get devices on Linux, we look for directories under /media and
+    // /run/media/$USER.
+    QFileInfoList devices;
+
+    // Add folders under /media to devices.
+    devices += QDir("/media").entryInfoList(
+        QDir::AllDirs | QDir::NoDotAndDotDot);
+
+    // Add folders under /run/media/$USER to devices.
+    QDir run_media_user_dir("/run/media/" + qgetenv("USER"));
+    devices += run_media_user_dir.entryInfoList(
+        QDir::AllDirs | QDir::NoDotAndDotDot);
+
+    // Convert devices into a QList<TreeItem*> for display.
+    QList<TreeItem*> ret;
+    foreach(QFileInfo device, devices) {
+        TreeItem* folder = new TreeItem(
+            this,
+            device.fileName(),
+            device.filePath() + "/");
+        ret << folder;
+    }
+
+    return ret;
 }

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -91,7 +91,7 @@ BrowseFeature::BrowseFeature(QObject* parent,
     pRootItem->appendChild(tr("Devices"), "/Volumes/");
 #else  // LINUX
     // DEVICE_NODE contents will be rendered lazily in onLazyChildExpandation.
-    TreeItem* devices_link = pRootItem->appendChild(tr("Removable Devices"), DEVICE_NODE);
+    pRootItem->appendChild(tr("Removable Devices"), DEVICE_NODE);
 
     // show root directory on Linux.
     pRootItem->appendChild(QDir::rootPath(), QDir::rootPath());

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -347,7 +347,7 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
             folders << driveLetter;
         }
 #elif defined(__APPLE__)
-        qWarning() << "Trying to process DEVICE_NODE on macOS; we shouldn't reach this point!";
+        DEBUG_ASSERT(!"Trying to process DEVICE_NODE on macOS");
 #else // LINUX
         folders += getLinuxDevices();
 #endif

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -90,7 +90,13 @@ BrowseFeature::BrowseFeature(QObject* parent,
     // /Volumes
     pRootItem->appendChild(tr("Devices"), "/Volumes/");
 #else  // LINUX
-    pRootItem->appendChild(tr("Removable Devices"), "/media/");
+    // On Linux, we look for files in /media and in /run/media/$USER.
+    TreeItem* devices_link = pRootItem->appendChild(tr("Removable Devices"), DEVICE_NODE);
+    QDir run_media_user_dir("/run/media/" + qgetenv("USER"));
+    QFileInfoList devices = QDir("/media").entryInfoList() + run_media_user_dir.entryInfoList();
+    foreach(QFileInfo device, devices) {
+        devices_link->appendChild(device.fileName(), device.filePath());
+    }
 
     // show root directory on UNIX-based operating systems
     pRootItem->appendChild(QDir::rootPath(), QDir::rootPath());

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -285,6 +285,33 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, QModelIndex index
      onLazyChildExpandation(index);
 }
 
+QList<TreeItem*> BrowseFeature::getLinuxDevices() {
+    // To get devices on Linux, we look for directories under /media and
+    // /run/media/$USER.
+    QFileInfoList devices;
+
+    // Add folders under /media to devices.
+    devices += QDir("/media").entryInfoList(
+        QDir::AllDirs | QDir::NoDotAndDotDot);
+
+    // Add folders under /run/media/$USER to devices.
+    QDir run_media_user_dir("/run/media/" + qgetenv("USER"));
+    devices += run_media_user_dir.entryInfoList(
+        QDir::AllDirs | QDir::NoDotAndDotDot);
+
+    // Convert devices into a QList<TreeItem*> for display.
+    QList<TreeItem*> ret;
+    foreach(QFileInfo device, devices) {
+        TreeItem* folder = new TreeItem(
+            this,
+            device.fileName(),
+            device.filePath() + "/");
+        ret << folder;
+    }
+
+    return ret;
+}
+
 // This is called whenever you double click or use the triangle symbol to expand
 // the subtree. The method will read the subfolders.
 void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
@@ -480,31 +507,4 @@ QStringList BrowseFeature::getDefaultQuickLinks() const {
 
     qDebug() << "Default quick links:" << result;
     return result;
-}
-
-QList<TreeItem*> BrowseFeature::getLinuxDevices() {
-    // To get devices on Linux, we look for directories under /media and
-    // /run/media/$USER.
-    QFileInfoList devices;
-
-    // Add folders under /media to devices.
-    devices += QDir("/media").entryInfoList(
-        QDir::AllDirs | QDir::NoDotAndDotDot);
-
-    // Add folders under /run/media/$USER to devices.
-    QDir run_media_user_dir("/run/media/" + qgetenv("USER"));
-    devices += run_media_user_dir.entryInfoList(
-        QDir::AllDirs | QDir::NoDotAndDotDot);
-
-    // Convert devices into a QList<TreeItem*> for display.
-    QList<TreeItem*> ret;
-    foreach(QFileInfo device, devices) {
-        TreeItem* folder = new TreeItem(
-            this,
-            device.fileName(),
-            device.filePath() + "/");
-        ret << folder;
-    }
-
-    return ret;
 }

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -285,9 +285,10 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, QModelIndex index
      onLazyChildExpandation(index);
 }
 
+#if defined(__LINUX__)
 namespace {
 // Get the list of devices (under "Removable Devices" section) on Linux.
-QList<TreeItem*> getLinuxRemovableDevices(LibraryFeature* pFeature) {
+QList<TreeItem*> getRemovableDevices(LibraryFeature* pFeature) {
     // To get devices on Linux, we look for directories under /media and
     // /run/media/$USER.
     QFileInfoList devices;
@@ -314,6 +315,7 @@ QList<TreeItem*> getLinuxRemovableDevices(LibraryFeature* pFeature) {
     return ret;
 }
 }
+#endif
 
 // This is called whenever you double click or use the triangle symbol to expand
 // the subtree. The method will read the subfolders.
@@ -379,7 +381,7 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
 #elif defined(__APPLE__)
         DEBUG_ASSERT(!"Trying to process DEVICE_NODE on macOS");
 #else // LINUX
-        folders += getLinuxRemovableDevices(this);
+        folders += getRemovableDevices(this);
 #endif
     } else {
         // we assume that the path refers to a folder in the file system

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -63,6 +63,8 @@ class BrowseFeature : public LibraryFeature {
     QStringList getDefaultQuickLinks() const;
     void saveQuickLinks();
     void loadQuickLinks();
+    // Get the list of devices (under "Removable Devices" section) on Linux.
+    QList<TreeItem*> getLinuxDevices();
 
     UserSettingsPointer m_pConfig;
     BrowseTableModel m_browseModel;

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -63,8 +63,6 @@ class BrowseFeature : public LibraryFeature {
     QStringList getDefaultQuickLinks() const;
     void saveQuickLinks();
     void loadQuickLinks();
-    // Get the list of devices (under "Removable Devices" section) on Linux.
-    QList<TreeItem*> getLinuxDevices();
 
     UserSettingsPointer m_pConfig;
     BrowseTableModel m_browseModel;


### PR DESCRIPTION
On Linux, show directories under both `/media` and `/run/media/$USER` in the "Removable Devices" drop-down menu.

udisks2, which some systems use, will auto-mount media into this folder instead of `/media`.