### PR TITLE
numark mixtrack 3: don't change FX level when moving beatgrid

### DIFF
--- a/res/controllers/Numark-Mixtrack-3-scripts.js
+++ b/res/controllers/Numark-Mixtrack-3-scripts.js
@@ -1765,7 +1765,7 @@ NumarkMixtrack3.BeatKnob = function(channel, control, value, status, group) {
 
 
     // direct interaction with knob, without any button combination
-    if (!deck.PADMode && !deck.shiftKey) {
+    if (!deck.PADMode && !deck.shiftKey && !deck.TapDown) {
         var mixValue = engine.getParameter("[EffectRack1_EffectUnit" + deck.decknum + "]", "mix");
         engine.setParameter("[EffectRack1_EffectUnit" + deck.decknum + "]", "mix", mixValue + increment);
     }


### PR DESCRIPTION
controller mapping bugfix for Numark Mixtrack Pro 3: when moving the beatgrid forward or backward with TAP + FX level, it has the buggy side effect of changing the FX level. This commit fixes that.