### PR TITLE
key notatinon changed fix Lp1813436

### DIFF
--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -73,8 +73,7 @@ DlgPreferences::DlgPreferences(MixxxMainWindow * mixxx, SkinLoader* pSkinLoader,
                                SettingsManager* pSettingsManager,
                                Library *pLibrary)
         : m_pConfig(pSettingsManager->settings()),
-          m_pageSizeHint(QSize(0, 0)),
-          m_preferencesUpdated(ConfigKey("[Preferences]", "updated"), false) {
+          m_pageSizeHint(QSize(0, 0)) {
 #ifndef __LILV__
     Q_UNUSED(pLV2Backend);
 #endif /* __LILV__ */
@@ -385,10 +384,6 @@ bool DlgPreferences::eventFilter(QObject* o, QEvent* e) {
 void DlgPreferences::onHide() {
     // Notify children that we are about to hide.
     emit(closeDlg());
-
-    // Notify other parts of Mixxx that the preferences window just saved and so
-    // preferences are likely changed.
-    m_preferencesUpdated.set(1);
 }
 
 void DlgPreferences::onShow() {

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -156,8 +156,6 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
 #endif
 
     QSize m_pageSizeHint;
-
-    ControlPushButton m_preferencesUpdated;
 };
 
 #endif

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -129,8 +129,8 @@ void DlgPrefKey::loadSettings() {
         }
     }
 
-    m_pKeyNotation->set(static_cast<double>(notation_type));
     KeyUtils::setNotation(notation);
+    m_pKeyNotation->set(static_cast<double>(notation_type));
 
     slotUpdate();
 }
@@ -224,8 +224,8 @@ void DlgPrefKey::slotApply() {
     }
 
     m_keySettings.setKeyNotation(notation_name);
-    m_pKeyNotation->set(static_cast<double>(notation_type));
     KeyUtils::setNotation(notation);
+    m_pKeyNotation->set(static_cast<double>(notation_type));
 }
 
 void DlgPrefKey::slotUpdate() {

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -91,34 +91,46 @@ DlgPrefKey::~DlgPrefKey() {
 }
 
 void DlgPrefKey::loadSettings() {
-    qDebug() << "DlgPrefKey::loadSettings";
     m_selectedAnalyzerId = m_keySettings.getKeyPluginId();
     qDebug() << "Key plugin ID:" << m_selectedAnalyzerId;
+
     m_bAnalyzerEnabled = m_keySettings.getKeyDetectionEnabled();
     m_bFastAnalysisEnabled = m_keySettings.getFastAnalysis();
     m_bReanalyzeEnabled = m_keySettings.getReanalyzeWhenSettingsChange();
 
-    QString notation = m_keySettings.getKeyNotation();
-    if (notation == KEY_NOTATION_OPEN_KEY) {
-        radioNotationOpenKey->setChecked(true);
-        setNotationOpenKey(true);
-    } else if (notation == KEY_NOTATION_LANCELOT) {
-        radioNotationLancelot->setChecked(true);
-        setNotationLancelot(true);
-    } else if (notation == KEY_NOTATION_TRADITIONAL) {
-        radioNotationTraditional->setChecked(true);
-        setNotationTraditional(true);
-    } else if (notation == KEY_NOTATION_CUSTOM) {
+    QString notation_name = m_keySettings.getKeyNotation();
+    KeyUtils::KeyNotation notation_type;
+    QMap<mixxx::track::io::key::ChromaticKey, QString> notation;
+    if (notation_name == KEY_NOTATION_CUSTOM) {
         radioNotationCustom->setChecked(true);
         for (auto it = m_keyLineEdits.constBegin();
-             it != m_keyLineEdits.constEnd(); ++it) {
+                it != m_keyLineEdits.constEnd(); ++it) {
             it.value()->setText(m_keySettings.getCustomKeyNotation(it.key()));
+            notation[it.key()] = it.value()->text();
         }
         setNotationCustom(true);
+        notation_type = KeyUtils::CUSTOM;
     } else {
-        radioNotationOpenKey->setChecked(true);
-        setNotationOpenKey(true);
+        if (notation_name == KEY_NOTATION_LANCELOT) {
+            radioNotationLancelot->setChecked(true);
+            notation_type = KeyUtils::LANCELOT;
+        } else if (notation_name == KEY_NOTATION_TRADITIONAL) {
+            radioNotationTraditional->setChecked(true);
+            notation_type = KeyUtils::TRADITIONAL;
+        } else { // KEY_NOTATION_OPEN_KEY and unknown names
+            radioNotationOpenKey->setChecked(true);
+            notation_type = KeyUtils::OPEN_KEY;
+        }
+
+        // This is just a handy way to iterate the keys. We don't use the
+        // QLineEdits.
+        for (auto it = m_keyLineEdits.constBegin(); it != m_keyLineEdits.constEnd(); ++it) {
+            notation[it.key()] = KeyUtils::keyToString(it.key(), notation_type);
+        }
     }
+
+    m_pKeyNotation->set(static_cast<double>(notation_type));
+    KeyUtils::setNotation(notation);
 
     slotUpdate();
 }
@@ -131,20 +143,22 @@ void DlgPrefKey::slotResetToDefaults() {
     m_bReanalyzeEnabled = m_keySettings.getReanalyzeWhenSettingsChangeDefault();
     m_selectedAnalyzerId = m_keySettings.getKeyPluginIdDefault();
 
+    KeyUtils::KeyNotation notation_type;
     QString defaultNotation = m_keySettings.getKeyNotationDefault();
     if (defaultNotation == KEY_NOTATION_LANCELOT) {
         radioNotationLancelot->setChecked(true);
-        setNotationLancelot(true);
+        notation_type = KeyUtils::LANCELOT;
     } else if (defaultNotation == KEY_NOTATION_OPEN_KEY) {
         radioNotationOpenKey->setChecked(true);
-        setNotationOpenKey(true);
+        notation_type = KeyUtils::OPEN_KEY;
     } else if (defaultNotation == KEY_NOTATION_TRADITIONAL) {
         radioNotationTraditional->setChecked(true);
-        setNotationTraditional(true);
+        notation_type = KeyUtils::TRADITIONAL;
     } else if (defaultNotation == KEY_NOTATION_CUSTOM) {
         radioNotationCustom->setChecked(true);
-        setNotationCustom(true);
+        notation_type = KeyUtils::CUSTOM;
     }
+    setNotationLancelot(notation_type);
 
     slotUpdate();
 }
@@ -178,17 +192,18 @@ void DlgPrefKey::slotApply() {
     m_keySettings.setFastAnalysis(m_bFastAnalysisEnabled);
     m_keySettings.setReanalyzeWhenSettingsChange(m_bReanalyzeEnabled);
 
+    QString notation_name;
+    KeyUtils::KeyNotation notation_type;
     QMap<mixxx::track::io::key::ChromaticKey, QString> notation;
     if (radioNotationCustom->isChecked()) {
-        m_keySettings.setKeyNotation(KEY_NOTATION_CUSTOM);
+        notation_name = KEY_NOTATION_CUSTOM;
+        notation_type = KeyUtils::CUSTOM;
         for (auto it = m_keyLineEdits.constBegin();
-             it != m_keyLineEdits.end(); ++it) {
+                it != m_keyLineEdits.end(); ++it) {
             notation[it.key()] = it.value()->text();
             m_keySettings.setCustomKeyNotation(it.key(), it.value()->text());
         }
     } else {
-        QString notation_name;
-        KeyUtils::KeyNotation notation_type;
         if (radioNotationOpenKey->isChecked()) {
             notation_name = KEY_NOTATION_OPEN_KEY;
             notation_type = KeyUtils::OPEN_KEY;
@@ -201,8 +216,6 @@ void DlgPrefKey::slotApply() {
             notation_type = KeyUtils::LANCELOT;
         }
 
-        m_keySettings.setKeyNotation(notation_name);
-
         // This is just a handy way to iterate the keys. We don't use the
         // QLineEdits.
         for (auto it = m_keyLineEdits.constBegin(); it != m_keyLineEdits.constEnd(); ++it) {
@@ -210,6 +223,8 @@ void DlgPrefKey::slotApply() {
         }
     }
 
+    m_keySettings.setKeyNotation(notation_name);
+    m_pKeyNotation->set(static_cast<double>(notation_type));
     KeyUtils::setNotation(notation);
 }
 
@@ -240,20 +255,18 @@ void DlgPrefKey::setNotationCustom(bool active) {
     }
 
     for (auto it = m_keyLineEdits.constBegin();
-         it != m_keyLineEdits.constEnd(); ++it) {
+            it != m_keyLineEdits.constEnd(); ++it) {
         it.value()->setEnabled(true);
     }
-    m_pKeyNotation->set(KeyUtils::CUSTOM);
     slotUpdate();
 }
 
 void DlgPrefKey::setNotation(KeyUtils::KeyNotation notation) {
     for (auto it = m_keyLineEdits.constBegin();
-         it != m_keyLineEdits.constEnd(); ++it) {
+            it != m_keyLineEdits.constEnd(); ++it) {
         it.value()->setText(KeyUtils::keyToString(it.key(), notation));
         it.value()->setEnabled(false);
     }
-    m_pKeyNotation->set(notation);
     slotUpdate();
 }
 

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -129,6 +129,7 @@ void DlgPrefKey::loadSettings() {
         }
     }
 
+    setNotation(notation_type);
     KeyUtils::setNotation(notation);
     m_pKeyNotation->set(static_cast<double>(notation_type));
 
@@ -148,17 +149,17 @@ void DlgPrefKey::slotResetToDefaults() {
     if (defaultNotation == KEY_NOTATION_LANCELOT) {
         radioNotationLancelot->setChecked(true);
         notation_type = KeyUtils::LANCELOT;
-    } else if (defaultNotation == KEY_NOTATION_OPEN_KEY) {
-        radioNotationOpenKey->setChecked(true);
-        notation_type = KeyUtils::OPEN_KEY;
     } else if (defaultNotation == KEY_NOTATION_TRADITIONAL) {
         radioNotationTraditional->setChecked(true);
         notation_type = KeyUtils::TRADITIONAL;
     } else if (defaultNotation == KEY_NOTATION_CUSTOM) {
         radioNotationCustom->setChecked(true);
         notation_type = KeyUtils::CUSTOM;
+    } else { // KEY_NOTATION_OPEN_KEY
+        radioNotationOpenKey->setChecked(true);
+        notation_type = KeyUtils::OPEN_KEY;
     }
-    setNotationLancelot(notation_type);
+    setNotation(notation_type);
 
     slotUpdate();
 }

--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -5,10 +5,10 @@
 WKey::WKey(const char* group, QWidget* pParent)
         : WLabel(pParent),
           m_dOldValue(0),
-          m_preferencesUpdated("[Preferences]", "updated", this),
+          m_pKeyNotation("[Library]", "key_notation", this),
           m_engineKeyDistance(group, "visual_key_distance", this) {
     setValue(m_dOldValue);
-    m_preferencesUpdated.connectValueChanged(this, &WKey::preferencesUpdated);
+    m_pKeyNotation.connectValueChanged(this, &WKey::keyNotationChanged);
     m_engineKeyDistance.connectValueChanged(this, &WKey::setCents);
 }
 
@@ -56,8 +56,6 @@ void WKey::setCents() {
     setValue(m_dOldValue);
 }
 
-void WKey::preferencesUpdated(double dValue) {
-    if (dValue > 0) {
-        setValue(m_dOldValue);
-    }
+void WKey::keyNotationChanged(double dValue) {
+    setValue(m_dOldValue);
 }

--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -57,5 +57,5 @@ void WKey::setCents() {
 }
 
 void WKey::keyNotationChanged(double dValue) {
-    setValue(m_dOldValue);
+    setValue(dValue);
 }

--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -5,10 +5,10 @@
 WKey::WKey(const char* group, QWidget* pParent)
         : WLabel(pParent),
           m_dOldValue(0),
-          m_pKeyNotation("[Library]", "key_notation", this),
+          m_keyNotation("[Library]", "key_notation", this),
           m_engineKeyDistance(group, "visual_key_distance", this) {
     setValue(m_dOldValue);
-    m_pKeyNotation.connectValueChanged(this, &WKey::keyNotationChanged);
+    m_keyNotation.connectValueChanged(this, &WKey::keyNotationChanged);
     m_engineKeyDistance.connectValueChanged(this, &WKey::setCents);
 }
 

--- a/src/widget/wkey.h
+++ b/src/widget/wkey.h
@@ -23,7 +23,7 @@ class WKey : public WLabel  {
     double m_dOldValue;
     bool m_displayCents;
     bool m_displayKey;
-    ControlProxy m_pKeyNotation;
+    ControlProxy m_keyNotation;
     ControlProxy m_engineKeyDistance;
 };
 

--- a/src/widget/wkey.h
+++ b/src/widget/wkey.h
@@ -16,14 +16,14 @@ class WKey : public WLabel  {
 
   private slots:
     void setValue(double dValue);
-    void preferencesUpdated(double dValue);
+    void keyNotationChanged(double dValue);
     void setCents();
 
   private:
     double m_dOldValue;
     bool m_displayCents;
     bool m_displayKey;
-    ControlProxy m_preferencesUpdated;
+    ControlProxy m_pKeyNotation;
     ControlProxy m_engineKeyDistance;
 };
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -124,6 +124,10 @@ WTrackTableView::WTrackTableView(QWidget * parent,
     m_pCOTGuiTick = new ControlProxy("[Master]", "guiTick50ms", this);
     m_pCOTGuiTick->connectValueChanged(this, &WTrackTableView::slotGuiTick50ms);
 
+    m_pKeyNotation = new ControlProxy("[Library]", "key_notation", this);
+    m_pCOTGuiTick->connectValueChanged(this, &WTrackTableView::keyNotationChanged);
+
+
     connect(this, SIGNAL(scrollValueChanged(int)),
             this, SLOT(slotScrollValueChanged(int)));
 
@@ -1990,3 +1994,9 @@ void WTrackTableView::restoreCurrentVScrollBarPos()
 {
     restoreVScrollBarPos(getTrackModel());
 }
+
+void WTrackTableView::keyNotationChanged()
+{
+    QWidget::update();
+}
+

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -93,6 +93,7 @@ class WTrackTableView : public WLibraryTableView {
 
     void slotTrackInfoClosed();
     void slotTagFetcherClosed();
+    void keyNotationChanged();
 
   private:
 
@@ -215,6 +216,7 @@ class WTrackTableView : public WLibraryTableView {
     bool m_bPlaylistMenuLoaded;
     bool m_bCrateMenuLoaded;
     ControlProxy* m_pCOTGuiTick;
+    ControlProxy* m_pKeyNotation;
 };
 
 #endif


### PR DESCRIPTION
This PR Fixes https://bugs.launchpad.net/mixxx/+bug/1813436 and other relates issue around propagating the selected key notation inside Mixxx. Now "[Library]", "key_notation" is used everywhere to signal key notation changes. 
