### PR TITLE
Allow to disable the Crossfader

### DIFF
--- a/res/translations/mixxx_en.ts
+++ b/res/translations/mixxx_en.ts
@@ -4371,41 +4371,46 @@ Apply settings and continue?</translation>
     </message>
     <message>
         <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="26"/>
+        <source>Enable Crossfader</source>
+        <translation>Enable Crossfader</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="33"/>
         <source>Crossfader Curve</source>
         <translation>Crossfader Curve</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="38"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="45"/>
         <source>Slow fade/Fast cut (additive)</source>
         <translation>Slow fade/Fast cut (additive)</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="45"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="52"/>
         <source>Constant power</source>
         <translation>Constant power</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="58"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="65"/>
         <source>Mixing</source>
         <translation>Mixing</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="78"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="85"/>
         <source>Scratching</source>
         <translation>Scratching</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="117"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="124"/>
         <source>Linear</source>
         <translation>Linear</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="143"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="150"/>
         <source>Logarithmic</source>
         <translation>Logarithmic</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="199"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="206"/>
         <source>Reverse crossfader (Hamster Style)</source>
         <translation>Reverse crossfader (Hamster Style)</translation>
     </message>

--- a/res/translations/mixxx_en_GB.ts
+++ b/res/translations/mixxx_en_GB.ts
@@ -4369,41 +4369,46 @@ Apply settings and continue?</translation>
     </message>
     <message>
         <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="26"/>
+        <source>Enable Crossfader</source>
+        <translation>Enable Crossfader</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="33"/>
         <source>Crossfader Curve</source>
         <translation>Crossfader Curve</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="38"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="45"/>
         <source>Slow fade/Fast cut (additive)</source>
         <translation>Slow fade/Fast cut (additive)</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="45"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="52"/>
         <source>Constant power</source>
         <translation>Constant power</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="58"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="65"/>
         <source>Mixing</source>
         <translation>Mixing</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="78"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="85"/>
         <source>Scratching</source>
         <translation>Scratching</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="117"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="124"/>
         <source>Linear</source>
         <translation>Linear</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="143"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="150"/>
         <source>Logarithmic</source>
         <translation>Logarithmic</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="199"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="206"/>
         <source>Reverse crossfader (Hamster Style)</source>
         <translation>Reverse crossfader (Hamster Style)</translation>
     </message>

--- a/res/translations/mixxx_it.ts
+++ b/res/translations/mixxx_it.ts
@@ -4368,41 +4368,46 @@ Applicare la configurazione e continuare?</translation>
     </message>
     <message>
         <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="26"/>
+        <source>Enable Crossfader</source>
+        <translation>Abilita il crossfader</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="33"/>
         <source>Crossfader Curve</source>
         <translation>Curva del Crossfader</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="38"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="45"/>
         <source>Slow fade/Fast cut (additive)</source>
         <translation>Dissolvenza lenta/Taglio veloce (additivo)</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="45"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="52"/>
         <source>Constant power</source>
         <translation>Potenza Costante</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="58"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="65"/>
         <source>Mixing</source>
         <translation>Mixaggio</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="78"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="85"/>
         <source>Scratching</source>
         <translation>Scratching</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="117"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="124"/>
         <source>Linear</source>
         <translation>Lineare</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="143"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="150"/>
         <source>Logarithmic</source>
         <translation>Logaritmico</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="199"/>
+        <location filename="../../src/preferences/dialog/dlgprefcrossfaderdlg.ui" line="206"/>
         <source>Reverse crossfader (Hamster Style)</source>
         <translation>Crossfader inverso (Hamster style)</translation>
     </message>

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -156,6 +156,9 @@ EngineMaster::EngineMaster(UserSettingsPointer pConfig,
     m_pEngineSideChain = bEnableSidechain ? new EngineSideChain(pConfig) : NULL;
 
     // X-Fader Setup
+    m_pXFaderEnabled = new ControlPushButton(
+            ConfigKey(EngineXfader::kXfaderConfigKey, "xFaderEnabled"));
+    m_pXFaderEnabled->setButtonMode(ControlPushButton::TOGGLE);
     m_pXFaderMode = new ControlPushButton(
             ConfigKey(EngineXfader::kXfaderConfigKey, "xFaderMode"));
     m_pXFaderMode->setButtonMode(ControlPushButton::TOGGLE);
@@ -214,6 +217,7 @@ EngineMaster::~EngineMaster() {
     delete m_pXFaderCalibration;
     delete m_pXFaderCurve;
     delete m_pXFaderMode;
+    delete m_pXFaderEnabled;
 
     delete m_pMasterSync;
     delete m_pMasterSampleRate;
@@ -478,6 +482,12 @@ void EngineMaster::process(const int iBufferSize) {
                                 m_pXFaderMode->get(),
                                 m_pXFaderReverse->toBool(),
                                 &crossfaderLeftGain, &crossfaderRightGain);
+
+    // Check if crossfader has been enabled or disabled
+    if (!m_pXFaderEnabled->toBool()) {
+       crossfaderLeftGain = 0.5;
+       crossfaderRightGain = 0.5;
+    }
 
     // Make the mix for each crossfader orientation output bus.
     // m_masterGain takes care of applying the attenuation from

--- a/src/engine/enginemaster.h
+++ b/src/engine/enginemaster.h
@@ -327,6 +327,7 @@ class EngineMaster : public QObject, public AudioSource {
     ControlPotmeter* m_pCrossfader;
     ControlPotmeter* m_pHeadMix;
     ControlPotmeter* m_pBalance;
+    ControlPushButton* m_pXFaderEnabled;
     ControlPushButton* m_pXFaderMode;
     ControlPotmeter* m_pXFaderCurve;
     ControlPotmeter* m_pXFaderCalibration;

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -170,6 +170,10 @@ class AutoDJProcessor : public QObject {
     void controlSkipNext(double value);
 
   private:
+    // Store the Crossfader state before enabling AutoDJ so that the state can
+    // be restored when disabling AutoDJ
+    bool restoreCrossfaderState;
+ 
     // Gets or sets the crossfader position while normalizing it so that -1 is
     // all the way mixed to the left side and 1 is all the way mixed to the
     // right side. (prevents AutoDJ logic from having to check for hamster mode
@@ -202,6 +206,7 @@ class AutoDJProcessor : public QObject {
 
     QList<DeckAttributes*> m_decks;
 
+    ControlProxy* m_pCOCrossfaderEnabled;
     ControlProxy* m_pCOCrossfader;
     ControlProxy* m_pCOCrossfaderReverse;
 

--- a/src/preferences/dialog/dlgprefcrossfader.h
+++ b/src/preferences/dialog/dlgprefcrossfader.h
@@ -35,9 +35,13 @@ class DlgPrefCrossfader : public DlgPreferencePage, public Ui::DlgPrefCrossfader
 
     QGraphicsScene* m_pxfScene;
 
+    // X-fader state
+    bool m_xFaderEnabled;
+
     // X-fader values
     double m_xFaderMode, m_transform, m_cal;
 
+    ControlProxy m_enabled;
     ControlProxy m_mode;
     ControlProxy m_curve;
     ControlProxy m_calibration;

--- a/src/preferences/dialog/dlgprefcrossfaderdlg.ui
+++ b/src/preferences/dialog/dlgprefcrossfaderdlg.ui
@@ -20,6 +20,13 @@
    <string>Crossfader Preferences</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item row="0" column="0">
+    <widget class="QCheckBox" name="checkBoxEnabled">
+     <property name="text">
+      <string>Enable Crossfader</string>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -204,6 +211,7 @@
      <zorder>checkBoxReverse</zorder>
      <zorder>radioButtonConstantPower</zorder>
      <zorder>radioButtonAdditive</zorder>
+     <zorder>checkBoxEnabled</zorder>
     </widget>
    </item>
    <item>
@@ -223,6 +231,7 @@
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <tabstops>
+  <tabstop>checkBoxEnabled</tabstop>
   <tabstop>radioButtonAdditive</tabstop>
   <tabstop>radioButtonConstantPower</tabstop>
   <tabstop>SliderXFader</tabstop>


### PR DESCRIPTION
The Crossfader is not always used, also on most controllers (such as the
Hercules P32 DJ) its knob does not lock in the middle position to avoid
unwanted changes.

As a result it is possible that the Crossfader knob is moved involuntarily
away from its middle position during normal controller operation, causing
unwanted (deck) volume imbalances.

This patch adds an option (checkbox) to the Mixxx Graphical User Interface
so that it is possible to disable the Crossfader functionality (controller
mapping).

When enabling the AutoDJ functionality make sure to also re-enable the
Crossfader if it has been previously disabled (thanks to Daniel Schürmann
for raising this issue).

The translation for the label of the new GUI checkbox is provided for the
Italian language only (and English defaults).

The logic for setting the various other Crossfader options is also fixed
and made consistent to avoid bugs.

---
 res/translations/mixxx_en.ts                   |   19 +++---
 res/translations/mixxx_en_GB.ts                |   19 +++---
 res/translations/mixxx_it.ts                   |   21 ++++--
 src/engine/enginemaster.cpp                    |   10 +++
 src/engine/enginemaster.h                      |    1
 src/library/autodj/autodjprocessor.cpp         |   14 ++++
 src/library/autodj/autodjprocessor.h           |    5 +
 src/preferences/dialog/dlgprefcrossfader.cpp   |   77 ++++++++++++++++++-------
 src/preferences/dialog/dlgprefcrossfader.h     |    4 +
 src/preferences/dialog/dlgprefcrossfaderdlg.ui |    9 ++
 10 files changed, 136 insertions(+), 43 deletions(-)