### PR TITLE
make cover art window draggable

### DIFF
--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -164,14 +164,38 @@ void DlgCoverArtFullSize::slotCoverInfoSelected(const CoverInfoRelative& coverIn
 }
 
 void DlgCoverArtFullSize::mousePressEvent(QMouseEvent* event) {
-    Q_UNUSED(event);
+    if (!m_pCoverMenu->isVisible() && event->button() == Qt::LeftButton) {
+        m_clickTimer.setSingleShot(true);
+        m_clickTimer.start(500);
+        m_coverPressed = true;
+        m_dragStartPosition = event->globalPos() - frameGeometry().topLeft();
+    }
+}
 
+void DlgCoverArtFullSize::mouseReleaseEvent(QMouseEvent* event) {
+    m_coverPressed = false;
     if (m_pCoverMenu->isVisible()) {
         return;
     }
 
     if (event->button() == Qt::LeftButton && isVisible()) {
-        close();
+        if (m_clickTimer.isActive()) {
+        // short press
+            close();
+        } else {
+        // long press
+            return;
+        }
+        event->accept();
+    }
+}
+
+void DlgCoverArtFullSize::mouseMoveEvent(QMouseEvent* event) {
+    if (m_coverPressed) {
+        move(event->globalPos() - m_dragStartPosition);
+        event->accept();
+    } else {
+        return;
     }
 }
 

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -2,6 +2,8 @@
 #define DLGCOVERARTFULLSIZE_H
 
 #include <QDialog>
+#include <QTimer>
+#include <QPoint>
 
 #include "library/ui_dlgcoverartfullsize.h"
 #include "library/coverart.h"
@@ -18,7 +20,9 @@ class DlgCoverArtFullSize
     virtual ~DlgCoverArtFullSize();
 
     void init(TrackPointer pTrack);
-    void mousePressEvent(QMouseEvent* /* unused */) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* ) override;
+    void mouseMoveEvent(QMouseEvent* ) override;
     void resizeEvent(QResizeEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
 
@@ -38,6 +42,9 @@ class DlgCoverArtFullSize
     TrackPointer m_pLoadedTrack;
     BaseTrackPlayer* m_pPlayer;
     WCoverArtMenu* m_pCoverMenu;
+    QTimer m_clickTimer;
+    QPoint m_dragStartPosition;
+    bool m_coverPressed;
 };
 
 #endif // DLGCOVERARTFULLSIZE_H


### PR DESCRIPTION
keep left mouse button pressed and move cursor to drag the Cover window.

it has bothered me having to aim for the window title bar to move the Cover window.
now it's super easy, still closes after short click. 