### PR TITLE
Numark DJ2Go re-enable note-off for deck A cue button

### DIFF
--- a/res/controllers/Numark DJ2Go.midi.xml
+++ b/res/controllers/Numark DJ2Go.midi.xml
@@ -209,7 +209,7 @@
 						<script-binding/>
 					</options>
 				</control>
-<!--				<control>
+				<control>
 					<group>[Channel1]</group>
 					<key>NumarkDJ2Go.cue</key>
 					<status>0x80</status>
@@ -217,7 +217,7 @@
                 			<options>
 						<script-binding/>
 					</options>
-				</control> -->
+				</control>
 				<control>
 					<group>[Channel1]</group>
 					<key>NumarkDJ2Go.play</key>


### PR DESCRIPTION
I don't know why the note-off for deck A cue button was disabled, but it breaks the hold-cue functionality of Mixxx cue setting and moreover, deck B has both note-on and note-off (and behaves normally) so the configuration was asymmetric anyway?