### PR TITLE
fix high DPI scaling of RGB overview waveforms

### DIFF
--- a/src/util/compatibility.h
+++ b/src/util/compatibility.h
@@ -5,6 +5,8 @@
 #include <QAtomicPointer>
 #include <QStringList>
 #include <QApplication>
+#include <QWindow>
+#include <QWidget>
 
 #include <QLocale>
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
@@ -54,5 +56,23 @@ template <typename T>
 void qAsConst(const T &&) = delete;
 
 #endif
+
+
+inline qreal getDevicePixelRatioF(const QWidget* widget) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    return widget->devicePixelRatioF();
+#endif
+
+    // Crawl up to the window and return qreal value
+    QWindow* window = widget->window()->windowHandle();
+    if (window) {
+        return window->devicePixelRatio();
+    }
+
+    // return integer value as last resort
+    return widget->devicePixelRatio();
+}
+
+
 
 #endif /* COMPATABILITY_H */

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -77,7 +77,7 @@ class WaveformWidgetRenderer {
 
     int beatGridAlpha() const { return m_alphaBeatGrid; }
 
-    virtual void resize(int width, int height, float devicePixelRatio);
+    void resize(int width, int height, float devicePixelRatio);
     int getHeight() const { return m_height;}
     int getWidth() const { return m_width;}
     float getDevicePixelRatio() const { return m_devicePixelRatio; }

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -423,8 +423,6 @@ bool WaveformWidgetFactory::setWidgetTypeFromHandle(int handleIndex) {
     m_skipRender = true;
     //qDebug() << "recreate start";
 
-    const float devicePixelRatio = getDevicePixelRatio();
-
     //re-create/setup all waveform widgets
     for (int i = 0; i < m_waveformWidgetHolders.size(); i++) {
         WaveformWidgetHolder& holder = m_waveformWidgetHolders[i];
@@ -444,7 +442,7 @@ bool WaveformWidgetFactory::setWidgetTypeFromHandle(int handleIndex) {
         // resize() doesn't seem to get called on the widget. I think Qt skips
         // it since the size didn't change.
         //viewer->resize(viewer->size());
-        widget->resize(viewer->width(), viewer->height(), devicePixelRatio);
+        widget->resize(viewer->width(), viewer->height());
         widget->setTrack(pTrack);
         widget->getWidget()->show();
         viewer->update();
@@ -848,14 +846,4 @@ void WaveformWidgetFactory::startVSync(GuiTick* pGuiTick) {
 
 void WaveformWidgetFactory::getAvailableVSyncTypes(QList<QPair<int, QString > >* pList) {
     m_vsyncThread->getAvailableVSyncTypes(pList);
-}
-
-// static
-float WaveformWidgetFactory::getDevicePixelRatio() {
-    float devicePixelRatio = 1.0;
-    QWindow* pWindow = QGuiApplication::focusWindow();
-    if (pWindow != nullptr) {
-        devicePixelRatio = pWindow->devicePixelRatio();
-    }
-    return devicePixelRatio;
 }

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -113,11 +113,6 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
 
     WaveformWidgetType::Type autoChooseWidgetType() const;
 
-    // Returns the devicePixelRatio for the current window. This is the scaling
-    // factor between screen pixels and "device independent pixels". For
-    // example, on macOS with a retina display the ratio is 2.
-    static float getDevicePixelRatio();
-
   signals:
     void waveformUpdateTick();
     void waveformMeasured(float frameRate, int droppedFrames);

--- a/src/waveform/widgets/glslwaveformwidget.cpp
+++ b/src/waveform/widgets/glslwaveformwidget.cpp
@@ -85,11 +85,11 @@ mixxx::Duration GLSLWaveformWidget::render() {
     return t1; // return timer for painter setup
 }
 
-void GLSLWaveformWidget::resize(int width, int height, float devicePixelRatio) {
+void GLSLWaveformWidget::resize(int width, int height) {
     // NOTE: (vrince) this is needed since we allocation buffer on resize
     // and the Gl Context should be properly set
     makeCurrent();
-    WaveformWidgetAbstract::resize(width, height, devicePixelRatio);
+    WaveformWidgetAbstract::resize(width, height);
 }
 
 void GLSLWaveformWidget::mouseDoubleClickEvent(QMouseEvent *event) {

--- a/src/waveform/widgets/glslwaveformwidget.h
+++ b/src/waveform/widgets/glslwaveformwidget.h
@@ -14,7 +14,7 @@ class GLSLWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
                        bool rgbRenderer);
     ~GLSLWaveformWidget() override;
 
-    void resize(int width, int height, float devicePixelRatio) override;
+    void resize(int width, int height);
 
   protected:
     void castToQWidget() override;

--- a/src/waveform/widgets/waveformwidgetabstract.cpp
+++ b/src/waveform/widgets/waveformwidgetabstract.cpp
@@ -38,9 +38,11 @@ mixxx::Duration WaveformWidgetAbstract::render() {
     return mixxx::Duration();
 }
 
-void WaveformWidgetAbstract::resize(int width, int height, float devicePixelRatio) {
+void WaveformWidgetAbstract::resize(int width, int height) {
+    qreal devicePixelRatio = 1.0;
     if (m_widget) {
         m_widget->resize(width, height);
+        devicePixelRatio = getDevicePixelRatioF(m_widget);
     }
     WaveformWidgetRenderer::resize(width, height, devicePixelRatio);
 }

--- a/src/waveform/widgets/waveformwidgetabstract.h
+++ b/src/waveform/widgets/waveformwidgetabstract.h
@@ -32,7 +32,7 @@ class WaveformWidgetAbstract : public WaveformWidgetRenderer {
 
     virtual void preRender(VSyncThread* vsyncThread);
     virtual mixxx::Duration render();
-    virtual void resize(int width, int height, float devicePixelRatio) override;
+    virtual void resize(int width, int height);
 
   protected:
     QWidget* m_widget;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -39,6 +39,7 @@ WOverview::WOverview(const char *pGroup, UserSettingsPointer pConfig, QWidget* p
         m_pixmapDone(false),
         m_waveformPeak(-1.0),
         m_diffGain(0),
+        m_devicePixelRatio(1.0),
         m_group(pGroup),
         m_pConfig(pConfig),
         m_endOfTrack(false),
@@ -331,11 +332,7 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
                     // Rotate pixmap
                     croppedImage = croppedImage.transformed(QTransform(0, 1, 1, 0, 0, 0));
                 }
-                qreal devicePixelRatio = 1.0;
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-                devicePixelRatio = devicePixelRatioF();
-#endif
-                m_waveformImageScaled = croppedImage.scaled(size() * devicePixelRatio,
+                m_waveformImageScaled = croppedImage.scaled(size() * m_devicePixelRatio,
                                                             Qt::IgnoreAspectRatio,
                                                             Qt::SmoothTransformation);
                 m_diffGain = diffGain;
@@ -580,6 +577,8 @@ void WOverview::resizeEvent(QResizeEvent * /*unused*/) {
     // space.
     m_a = (length() - 1) / (one - zero);
     m_b = zero * m_a;
+
+    m_devicePixelRatio = getDevicePixelRatioF(this);
 
     m_waveformImageScaled = QImage();
     m_diffGain = 0;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -331,7 +331,8 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
                     // Rotate pixmap
                     croppedImage = croppedImage.transformed(QTransform(0, 1, 1, 0, 0, 0));
                 }
-                m_waveformImageScaled = croppedImage.scaled(size(), Qt::IgnoreAspectRatio,
+                m_waveformImageScaled = croppedImage.scaled(size() * devicePixelRatioF(),
+                                                            Qt::IgnoreAspectRatio,
                                                             Qt::SmoothTransformation);
                 m_diffGain = diffGain;
             }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -331,7 +331,11 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
                     // Rotate pixmap
                     croppedImage = croppedImage.transformed(QTransform(0, 1, 1, 0, 0, 0));
                 }
-                m_waveformImageScaled = croppedImage.scaled(size() * devicePixelRatioF(),
+                qreal devicePixelRatio = 1.0;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+                devicePixelRatio = devicePixelRatioF();
+#endif
+                m_waveformImageScaled = croppedImage.scaled(size() * devicePixelRatio,
                                                             Qt::IgnoreAspectRatio,
                                                             Qt::SmoothTransformation);
                 m_diffGain = diffGain;

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -79,6 +79,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     float m_waveformPeak;
 
     int m_diffGain;
+    qreal m_devicePixelRatio;
 
   private slots:
     void onEndOfTrackChange(double v);

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -28,16 +28,11 @@ bool WOverviewRGB::drawNextPixmapPart() {
         return false;
     }
 
-    qreal devicePixelRatio = 1.0;
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-    devicePixelRatio = devicePixelRatioF();
-#endif
-
     if (m_waveformSourceImage.isNull()) {
         // Waveform pixmap twice the height of the viewport to be scalable
         // by total_gain
         // We keep full range waveform data to scale it on paint
-        m_waveformSourceImage = QImage(dataSize / 2, 2 * 255 * devicePixelRatio,
+        m_waveformSourceImage = QImage(dataSize / 2, 2 * 255 * m_devicePixelRatio,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());
     }
@@ -96,7 +91,7 @@ bool WOverviewRGB::drawNextPixmapPart() {
         if (max > 0.0) {
             color.setRgbF(red / max, green / max, blue / max);
             painter.setPen(color);
-            painter.drawLine(QPointF(currentCompletion / 2, -left * devicePixelRatio),
+            painter.drawLine(QPointF(currentCompletion / 2, -left * m_devicePixelRatio),
                              QPointF(currentCompletion / 2, 0));
         }
 
@@ -116,7 +111,7 @@ bool WOverviewRGB::drawNextPixmapPart() {
             color.setRgbF(red / max, green / max, blue / max);
             painter.setPen(color);
             painter.drawLine(QPointF(currentCompletion / 2, 0),
-                             QPointF(currentCompletion / 2, right * devicePixelRatio));
+                             QPointF(currentCompletion / 2, right * m_devicePixelRatio));
         }
     }
 

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -28,11 +28,16 @@ bool WOverviewRGB::drawNextPixmapPart() {
         return false;
     }
 
+    qreal devicePixelRatio = 1.0;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    devicePixelRatio = devicePixelRatioF();
+#endif
+
     if (m_waveformSourceImage.isNull()) {
         // Waveform pixmap twice the height of the viewport to be scalable
         // by total_gain
         // We keep full range waveform data to scale it on paint
-        m_waveformSourceImage = QImage(dataSize / 2, 2 * 255 * devicePixelRatioF(),
+        m_waveformSourceImage = QImage(dataSize / 2, 2 * 255 * devicePixelRatio,
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());
     }
@@ -91,7 +96,7 @@ bool WOverviewRGB::drawNextPixmapPart() {
         if (max > 0.0) {
             color.setRgbF(red / max, green / max, blue / max);
             painter.setPen(color);
-            painter.drawLine(QPointF(currentCompletion / 2, -left * devicePixelRatioF()),
+            painter.drawLine(QPointF(currentCompletion / 2, -left * devicePixelRatio),
                              QPointF(currentCompletion / 2, 0));
         }
 
@@ -111,7 +116,7 @@ bool WOverviewRGB::drawNextPixmapPart() {
             color.setRgbF(red / max, green / max, blue / max);
             painter.setPen(color);
             painter.drawLine(QPointF(currentCompletion / 2, 0),
-                             QPointF(currentCompletion / 2, right * devicePixelRatioF()));
+                             QPointF(currentCompletion / 2, right * devicePixelRatio));
         }
     }
 

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -32,7 +32,7 @@ bool WOverviewRGB::drawNextPixmapPart() {
         // Waveform pixmap twice the height of the viewport to be scalable
         // by total_gain
         // We keep full range waveform data to scale it on paint
-        m_waveformSourceImage = QImage(dataSize / 2, 2 * 255,
+        m_waveformSourceImage = QImage(dataSize / 2, 2 * 255 * devicePixelRatioF(),
                 QImage::Format_ARGB32_Premultiplied);
         m_waveformSourceImage.fill(QColor(0, 0, 0, 0).value());
     }
@@ -91,7 +91,8 @@ bool WOverviewRGB::drawNextPixmapPart() {
         if (max > 0.0) {
             color.setRgbF(red / max, green / max, blue / max);
             painter.setPen(color);
-            painter.drawLine(currentCompletion / 2, -left, currentCompletion / 2, 0);
+            painter.drawLine(QPointF(currentCompletion / 2, -left * devicePixelRatioF()),
+                             QPointF(currentCompletion / 2, 0));
         }
 
         // Retrieve "raw" LMH values from waveform
@@ -109,7 +110,8 @@ bool WOverviewRGB::drawNextPixmapPart() {
         if (max > 0.0) {
             color.setRgbF(red / max, green / max, blue / max);
             painter.setPen(color);
-            painter.drawLine(currentCompletion / 2, 0, currentCompletion / 2, right);
+            painter.drawLine(QPointF(currentCompletion / 2, 0),
+                             QPointF(currentCompletion / 2, right * devicePixelRatioF()));
         }
     }
 

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -51,8 +51,7 @@ void WWaveformViewer::setup(const QDomNode& node, const SkinContext& context) {
 
 void WWaveformViewer::resizeEvent(QResizeEvent* /*event*/) {
     if (m_waveformWidget) {
-        m_waveformWidget->resize(width(), height(),
-                                 WaveformWidgetFactory::getDevicePixelRatio());
+        m_waveformWidget->resize(width(), height());
     }
 }
 


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/9455094/56709478-27a34200-66e7-11e9-80e4-514a7a3fcdd5.png)

after:
![image](https://user-images.githubusercontent.com/9455094/56709933-7651db80-66e9-11e9-92c3-d68c8c922450.png)

I was going to fix the Filtered and HSV overviews too, but they actually look okay already.