### PR TITLE
Add debug message when loading a default keyboard mapping is successf…

### DIFF
--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -815,6 +815,7 @@ void MixxxMainWindow::initializeKeyboard() {
         QString defaultKeyboard = QString(resourcePath).append("keyboard/");
         defaultKeyboard += locale.name();
         defaultKeyboard += ".kbd.cfg";
+        qDebug() << "Found and will use default keyboard preset" << defaultKeyboard;
 
         if (!QFile::exists(defaultKeyboard)) {
             qDebug() << defaultKeyboard << " not found, using en_US.kbd.cfg";


### PR DESCRIPTION
…ul for the systems locale. This helps debugging keyboard mapping issues in developer mode, where previously was no info available to the user, which mapping was actually used.