### PR TITLE
GL ES compatible Waveforms 

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -56,15 +56,12 @@ available_features = [features.Mad,
                       features.LocaleCompare,
                       features.Lilv,
                       features.Battery,
+                      features.QtKeychain,
 
                       # "Features" of dubious quality
                       features.PerfTools,
                       features.AsmLib,
-                      features.FFMPEG,
-
-                      # Experimental features
-                      features.OpenGLES,
-                      features.QtKeychain
+                      features.FFMPEG
                       ]
 
 build = mixxx.MixxxBuild(target, machine, build_type,

--- a/build/depends.py
+++ b/build/depends.py
@@ -1103,6 +1103,7 @@ class MixxxCore(Feature):
                    "src/waveform/renderers/waveformrendererrgb.cpp",
                    "src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp",
                    "src/waveform/renderers/qtwaveformrenderersimplesignal.cpp",
+                   "src/waveform/renderers/qtvsynctestrenderer.cpp",
 
                    "src/waveform/renderers/waveformsignalcolors.cpp",
 
@@ -1122,8 +1123,11 @@ class MixxxCore(Feature):
                    "src/waveform/widgets/softwarewaveformwidget.cpp",
                    "src/waveform/widgets/hsvwaveformwidget.cpp",
                    "src/waveform/widgets/rgbwaveformwidget.cpp",
+                   "src/waveform/widgets/qthsvwaveformwidget.cpp",
+                   "src/waveform/widgets/qtrgbwaveformwidget.cpp",
                    "src/waveform/widgets/qtwaveformwidget.cpp",
                    "src/waveform/widgets/qtsimplewaveformwidget.cpp",
+                   "src/waveform/widgets/qtvsynctestwidget.cpp",
                    "src/waveform/widgets/glwaveformwidget.cpp",
                    "src/waveform/widgets/glsimplewaveformwidget.cpp",
                    "src/waveform/widgets/glvsynctestwidget.cpp",

--- a/build/features.py
+++ b/build/features.py
@@ -6,26 +6,6 @@ from .mixxx import Feature
 import SCons.Script as SCons
 from . import depends
 
-class OpenGLES(Feature):
-    def description(self):
-        return "OpenGL-ES >= 2.0 support [Experimental]"
-
-    def enabled(self, build):
-        build.flags['opengles'] = util.get_flags(build.env, 'opengles', 0)
-        return int(build.flags['opengles'])
-
-    def add_options(self, build, vars):
-        vars.Add('opengles', 'Set to 1 to enable OpenGL-ES >= 2.0 support [Experimental]', 0)
-
-    def configure(self, build, conf):
-        if not self.enabled(build):
-            return
-        if build.flags['opengles']:
-            build.env.Append(CPPDEFINES='__OPENGLES__')
-
-    def sources(self, build):
-        return []
-
 class HSS1394(Feature):
     def description(self):
         return "HSS1394 MIDI device support"

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -15,6 +15,7 @@ GLSLWaveformRendererSignal::GLSLWaveformRendererSignal(WaveformWidgetRenderer* w
           m_bDumpPng(false),
           m_shadersValid(false),
           m_rgbShader(rgbShader) {
+    initializeOpenGLFunctions();
 }
 
 GLSLWaveformRendererSignal::~GLSLWaveformRendererSignal() {
@@ -138,8 +139,6 @@ void GLSLWaveformRendererSignal::createGeometry() {
         return;
     }
 
-#ifndef __OPENGLES__
-
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     glOrtho(-1.0, 1.0, -1.0, 1.0, -10.0, 10.0);
@@ -167,7 +166,6 @@ void GLSLWaveformRendererSignal::createGeometry() {
     }
     glEndList();
 
-#endif
 }
 
 void GLSLWaveformRendererSignal::createFrameBuffers() {
@@ -289,8 +287,6 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
     // lastVisualIndex = lastIndex + lastIndex%2;
 
     //qDebug() << "GAIN" << allGain << lowGain << midGain << highGain;
-
-#ifndef __OPENGLES__
 
     //paint into frame buffer
     {
@@ -445,8 +441,6 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
     glPopMatrix();
     glMatrixMode(GL_PROJECTION);
     glPopMatrix();
-
-#endif
 
     painter->endNativePainting();
 }

--- a/src/waveform/renderers/glslwaveformrenderersignal.h
+++ b/src/waveform/renderers/glslwaveformrenderersignal.h
@@ -4,12 +4,15 @@
 #include <QGLFramebufferObject>
 #include <QGLShaderProgram>
 #include <QtOpenGL>
+#include <QOpenGLFunctions_2_1>
 
 #include "track/track.h"
 #include "util/memory.h"
 #include "waveform/renderers/waveformrenderersignalbase.h"
 
-class GLSLWaveformRendererSignal : public QObject, public WaveformRendererSignalBase {
+class GLSLWaveformRendererSignal: public QObject,
+        public WaveformRendererSignalBase,
+        protected QOpenGLFunctions_2_1 {
     Q_OBJECT
   public:
     GLSLWaveformRendererSignal(WaveformWidgetRenderer* waveformWidgetRenderer,
@@ -51,12 +54,14 @@ class GLSLWaveformRendererSignal : public QObject, public WaveformRendererSignal
     std::unique_ptr<QGLShaderProgram> m_frameShaderProgram;
 };
 
-class GLSLWaveformRendererFilteredSignal : public GLSLWaveformRendererSignal {
-  public:
+class GLSLWaveformRendererFilteredSignal: public GLSLWaveformRendererSignal {
+public:
     GLSLWaveformRendererFilteredSignal(
-        WaveformWidgetRenderer* waveformWidgetRenderer)
-        : GLSLWaveformRendererSignal(waveformWidgetRenderer, false) {}
-    ~GLSLWaveformRendererFilteredSignal() override {}
+            WaveformWidgetRenderer* waveformWidgetRenderer) :
+            GLSLWaveformRendererSignal(waveformWidgetRenderer, false) {
+    }
+    ~GLSLWaveformRendererFilteredSignal() override {
+    }
 };
 
 class GLSLWaveformRendererRGBSignal : public GLSLWaveformRendererSignal {

--- a/src/waveform/renderers/glvsynctestrenderer.cpp
+++ b/src/waveform/renderers/glvsynctestrenderer.cpp
@@ -1,5 +1,3 @@
-#include <qgl.h>
-
 #include "waveform/renderers/glvsynctestrenderer.h"
 
 #include "waveform/renderers/waveformwidgetrenderer.h"
@@ -11,6 +9,7 @@ GLVSyncTestRenderer::GLVSyncTestRenderer(
         WaveformWidgetRenderer* waveformWidgetRenderer)
     : WaveformRendererSignalBase(waveformWidgetRenderer),
       m_drawcount(0) {
+    initializeOpenGLFunctions();
 }
 
 GLVSyncTestRenderer::~GLVSyncTestRenderer() {
@@ -72,8 +71,6 @@ void GLVSyncTestRenderer::draw(QPainter* painter, QPaintEvent* /*event*/) {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-#ifndef __OPENGLES__
-
     //t7 = timer.restart(); // 5,770 ns
 
     glMatrixMode(GL_PROJECTION);
@@ -118,8 +115,6 @@ void GLVSyncTestRenderer::draw(QPainter* painter, QPaintEvent* /*event*/) {
     glPopMatrix();
     glMatrixMode(GL_PROJECTION);
     glPopMatrix();
-
-#endif
 
     //t12 = timer.restart(); // 22,426 ns
     painter->endNativePainting();

--- a/src/waveform/renderers/glvsynctestrenderer.h
+++ b/src/waveform/renderers/glvsynctestrenderer.h
@@ -1,18 +1,22 @@
 #ifndef GLVSYNCTESTRENDERER_H
 #define GLVSYNCTESTRENDERER_H
 
+#include <QOpenGLFunctions_2_1>
+
 #include "waveformrenderersignalbase.h"
 
 class ControlObject;
 
-class GLVSyncTestRenderer : public WaveformRendererSignalBase {
-  public:
-    explicit GLVSyncTestRenderer(WaveformWidgetRenderer* waveformWidgetRenderer);
+class GLVSyncTestRenderer: public WaveformRendererSignalBase,
+        protected QOpenGLFunctions_2_1 {
+public:
+    explicit GLVSyncTestRenderer(
+            WaveformWidgetRenderer* waveformWidgetRenderer);
     virtual ~GLVSyncTestRenderer();
 
     virtual void onSetup(const QDomNode &node);
     virtual void draw(QPainter* painter, QPaintEvent* event);
-  private:
+private:
     int m_drawcount;
 };
 

--- a/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
@@ -7,12 +7,10 @@
 
 #include <QDomNode>
 
-#include <qgl.h>
-
 GLWaveformRendererFilteredSignal::GLWaveformRendererFilteredSignal(
         WaveformWidgetRenderer* waveformWidgetRenderer)
-    : WaveformRendererSignalBase(waveformWidgetRenderer) {
-
+        : WaveformRendererSignalBase(waveformWidgetRenderer) {
+    initializeOpenGLFunctions();
 }
 
 GLWaveformRendererFilteredSignal::~GLWaveformRendererFilteredSignal() {
@@ -64,8 +62,6 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
     getGains(&allGain, &lowGain, &midGain, &highGain);
-
-#ifndef __OPENGLES__
 
     if (m_alignment == Qt::AlignCenter) {
         glMatrixMode(GL_PROJECTION);
@@ -224,8 +220,6 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
     glPopMatrix();
     glMatrixMode(GL_PROJECTION);
     glPopMatrix();
-
-#endif
 
     painter->endNativePainting();
 }

--- a/src/waveform/renderers/glwaveformrendererfilteredsignal.h
+++ b/src/waveform/renderers/glwaveformrendererfilteredsignal.h
@@ -1,13 +1,17 @@
 #ifndef GLWAVEFROMRENDERERFILTEREDSIGNAL_H
 #define GLWAVEFROMRENDERERFILTEREDSIGNAL_H
 
+#include <QOpenGLFunctions_2_1>
+
 #include "waveformrenderersignalbase.h"
 
 class ControlObject;
 
-class GLWaveformRendererFilteredSignal : public WaveformRendererSignalBase {
-  public:
-    explicit GLWaveformRendererFilteredSignal(WaveformWidgetRenderer* waveformWidgetRenderer);
+class GLWaveformRendererFilteredSignal: public WaveformRendererSignalBase,
+        protected QOpenGLFunctions_2_1 {
+public:
+    explicit GLWaveformRendererFilteredSignal(
+            WaveformWidgetRenderer* waveformWidgetRenderer);
     virtual ~GLWaveformRendererFilteredSignal();
 
     virtual void onSetup(const QDomNode &node);

--- a/src/waveform/renderers/glwaveformrendererrgb.cpp
+++ b/src/waveform/renderers/glwaveformrendererrgb.cpp
@@ -1,5 +1,3 @@
-#include <qgl.h>
-
 #include "glwaveformrendererrgb.h"
 #include "waveformwidgetrenderer.h"
 #include "waveform/waveform.h"
@@ -10,8 +8,8 @@
 
 GLWaveformRendererRGB::GLWaveformRendererRGB(
         WaveformWidgetRenderer* waveformWidgetRenderer)
-    : WaveformRendererSignalBase(waveformWidgetRenderer) {
-
+        : WaveformRendererSignalBase(waveformWidgetRenderer) {
+    initializeOpenGLFunctions();
 }
 
 GLWaveformRendererRGB::~GLWaveformRendererRGB() {
@@ -62,8 +60,6 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
     getGains(&allGain, &lowGain, &midGain, &highGain);
 
     const float kHeightScaleFactor = 255.0 / sqrtf(255 * 255 * 3);
-
-#ifndef __OPENGLES__
 
     if (m_alignment == Qt::AlignCenter) {
         glMatrixMode(GL_PROJECTION);
@@ -193,8 +189,6 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
     glPopMatrix();
     glMatrixMode(GL_PROJECTION);
     glPopMatrix();
-
-#endif
 
     painter->endNativePainting();
 }

--- a/src/waveform/renderers/glwaveformrendererrgb.h
+++ b/src/waveform/renderers/glwaveformrendererrgb.h
@@ -1,13 +1,17 @@
 #ifndef GLWAVEFORMRENDERERRGB_H
 #define GLWAVEFORMRENDERERRGB_H
 
+#include <QOpenGLFunctions_2_1>
+
 #include "waveformrenderersignalbase.h"
 
 class ControlObject;
 
-class GLWaveformRendererRGB : public WaveformRendererSignalBase {
+class GLWaveformRendererRGB: public WaveformRendererSignalBase,
+        protected QOpenGLFunctions_2_1 {
   public:
-    explicit GLWaveformRendererRGB(WaveformWidgetRenderer* waveformWidgetRenderer);
+    explicit GLWaveformRendererRGB(
+            WaveformWidgetRenderer* waveformWidgetRenderer);
     virtual ~GLWaveformRendererRGB();
 
     virtual void onSetup(const QDomNode& node);

--- a/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
@@ -6,12 +6,11 @@
 #include "waveform/waveformwidgetfactory.h"
 #include "util/math.h"
 
-#include <qgl.h>
 
 GLWaveformRendererSimpleSignal::GLWaveformRendererSimpleSignal(
         WaveformWidgetRenderer* waveformWidgetRenderer)
-    : WaveformRendererSignalBase(waveformWidgetRenderer) {
-
+        : WaveformRendererSignalBase(waveformWidgetRenderer) {
+    initializeOpenGLFunctions();
 }
 
 GLWaveformRendererSimpleSignal::~GLWaveformRendererSimpleSignal() {
@@ -59,8 +58,6 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
 
     // Reset device for native painting
     painter->beginNativePainting();
-
-#ifndef __OPENGLES__
 
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -158,8 +155,6 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
     glPopMatrix();
     glMatrixMode(GL_PROJECTION);
     glPopMatrix();
-
-#endif
 
     painter->endNativePainting();
 }

--- a/src/waveform/renderers/glwaveformrenderersimplesignal.h
+++ b/src/waveform/renderers/glwaveformrenderersimplesignal.h
@@ -1,11 +1,13 @@
 #ifndef GLWAVEFORMRENDERERSIMPLESIGNAL_H
 #define GLWAVEFORMRENDERERSIMPLESIGNAL_H
 
+#include <QOpenGLFunctions_2_1>
+
 #include "waveformrenderersignalbase.h"
 
 class ControlObject;
 
-class GLWaveformRendererSimpleSignal : public WaveformRendererSignalBase {
+class GLWaveformRendererSimpleSignal : public WaveformRendererSignalBase, protected QOpenGLFunctions_2_1 {
 public:
     explicit GLWaveformRendererSimpleSignal(WaveformWidgetRenderer* waveformWidgetRenderer);
     virtual ~GLWaveformRendererSimpleSignal();

--- a/src/waveform/renderers/qtvsynctestrenderer.cpp
+++ b/src/waveform/renderers/qtvsynctestrenderer.cpp
@@ -1,0 +1,69 @@
+#include "waveform/renderers/qtvsynctestrenderer.h"
+
+#include "waveform/renderers/waveformwidgetrenderer.h"
+#include "waveform/waveform.h"
+#include "waveform/waveformwidgetfactory.h"
+#include "util/performancetimer.h"
+
+QtVSyncTestRenderer::QtVSyncTestRenderer(
+        WaveformWidgetRenderer* waveformWidgetRenderer)
+    : WaveformRendererSignalBase(waveformWidgetRenderer),
+      m_drawcount(0) {
+}
+
+QtVSyncTestRenderer::~QtVSyncTestRenderer() {
+}
+
+void QtVSyncTestRenderer::onSetup(const QDomNode& node) {
+    Q_UNUSED(node);
+}
+
+inline void setPoint(QPointF& point, qreal x, qreal y) {
+    point.setX(x);
+    point.setY(y);
+}
+
+void QtVSyncTestRenderer::draw(QPainter* pPainter, QPaintEvent* /*event*/) {
+
+    PerformanceTimer timer;
+    //mixxx::Duration t5, t6, t7, t8, t9, t10, t11, t12, t13;
+
+
+    timer.start();
+
+    TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
+    if (!pTrack) {
+        return;
+    }
+
+    ConstWaveformPointer waveform = pTrack->getWaveform();
+    if (waveform.isNull()) {
+        return;
+    }
+
+    const int dataSize = waveform->getDataSize();
+    if (dataSize <= 1) {
+        return;
+    }
+
+    const WaveformData* data = waveform->data();
+    if (data == NULL) {
+        return;
+    }
+
+    pPainter->save();
+
+    auto brush = QBrush(Qt::SolidPattern);
+    if (++m_drawcount & 1) {
+        brush.setColor(QColor(255, 255, 255));
+    } else {
+        brush.setColor(QColor(255, 0, 0));
+    }
+
+    pPainter->setBrush(brush);
+
+    pPainter->drawRect(0, 0, m_waveformRenderer->getWidth(),
+            m_waveformRenderer->getHeight());
+
+    pPainter->restore();
+}

--- a/src/waveform/renderers/qtvsynctestrenderer.h
+++ b/src/waveform/renderers/qtvsynctestrenderer.h
@@ -1,0 +1,19 @@
+#ifndef QTVSYNCTESTRENDERER_H
+#define QTVSYNCTESTRENDERER_H
+
+#include "waveformrenderersignalbase.h"
+
+class ControlObject;
+
+class QtVSyncTestRenderer : public WaveformRendererSignalBase {
+  public:
+    explicit QtVSyncTestRenderer(WaveformWidgetRenderer* waveformWidgetRenderer);
+    virtual ~QtVSyncTestRenderer();
+
+    virtual void onSetup(const QDomNode &node);
+    virtual void draw(QPainter* painter, QPaintEvent* event);
+  private:
+    int m_drawcount;
+};
+
+#endif // QTVSYNCTESTRENDERER_H

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -24,6 +24,7 @@
 #include "waveform/widgets/qtsimplewaveformwidget.h"
 #include "waveform/widgets/glslwaveformwidget.h"
 #include "waveform/widgets/glvsynctestwidget.h"
+#include "waveform/widgets/qtvsynctestwidget.h"
 #include "waveform/widgets/waveformwidgetabstract.h"
 #include "widget/wwaveformviewer.h"
 #include "waveform/guitick.h"
@@ -812,6 +813,13 @@ void WaveformWidgetFactory::evaluateWidgets() {
             useOpenGLShaders = GLRGBWaveformWidget::useOpenGLShaders();
             developerOnly = GLRGBWaveformWidget::developerOnly();
             break;
+        case WaveformWidgetType::QtVSyncTest:
+            widgetName = QtVSyncTestWidget::getWaveformWidgetName();
+            useOpenGl = QtVSyncTestWidget::useOpenGl();
+            useOpenGles =  QtVSyncTestWidget::useOpenGles();
+            useOpenGLShaders = QtVSyncTestWidget::useOpenGLShaders();
+            developerOnly = QtVSyncTestWidget::developerOnly();
+            break;
         default:
             DEBUG_ASSERT(!"Unexpected WaveformWidgetType");
             continue;
@@ -905,6 +913,9 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createWaveformWidget(
             break;
         case WaveformWidgetType::GLVSyncTest:
             widget = new GLVSyncTestWidget(viewer->getGroup(), viewer);
+            break;
+        case WaveformWidgetType::QtVSyncTest:
+            widget = new QtVSyncTestWidget(viewer->getGroup(), viewer);
             break;
         default:
         //case WaveformWidgetType::SoftwareSimpleWaveform: TODO: (vrince)

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -17,6 +17,8 @@
 #include "waveform/widgets/softwarewaveformwidget.h"
 #include "waveform/widgets/hsvwaveformwidget.h"
 #include "waveform/widgets/rgbwaveformwidget.h"
+#include "waveform/widgets/qthsvwaveformwidget.h"
+#include "waveform/widgets/qtrgbwaveformwidget.h"
 #include "waveform/widgets/glrgbwaveformwidget.h"
 #include "waveform/widgets/glwaveformwidget.h"
 #include "waveform/widgets/glsimplewaveformwidget.h"
@@ -820,6 +822,20 @@ void WaveformWidgetFactory::evaluateWidgets() {
             useOpenGLShaders = QtVSyncTestWidget::useOpenGLShaders();
             developerOnly = QtVSyncTestWidget::developerOnly();
             break;
+        case WaveformWidgetType::QtHSVWaveform:
+            widgetName = QtHSVWaveformWidget::getWaveformWidgetName();
+            useOpenGl = QtHSVWaveformWidget::useOpenGl();
+            useOpenGles = QtHSVWaveformWidget::useOpenGles();
+            useOpenGLShaders = QtHSVWaveformWidget::useOpenGLShaders();
+            developerOnly = QtHSVWaveformWidget::developerOnly();
+            break;
+        case WaveformWidgetType::QtRGBWaveform:
+            widgetName = QtRGBWaveformWidget::getWaveformWidgetName();
+            useOpenGl = QtRGBWaveformWidget::useOpenGl();
+            useOpenGles = QtRGBWaveformWidget::useOpenGles();
+            useOpenGLShaders = QtRGBWaveformWidget::useOpenGLShaders();
+            developerOnly = QtRGBWaveformWidget::developerOnly();
+            break;
         default:
             DEBUG_ASSERT(!"Unexpected WaveformWidgetType");
             continue;
@@ -916,6 +932,12 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createWaveformWidget(
             break;
         case WaveformWidgetType::QtVSyncTest:
             widget = new QtVSyncTestWidget(viewer->getGroup(), viewer);
+            break;
+        case WaveformWidgetType::QtHSVWaveform:
+            widget = new QtHSVWaveformWidget(viewer->getGroup(), viewer);
+            break;
+        case WaveformWidgetType::QtRGBWaveform:
+            widget = new QtRGBWaveformWidget(viewer->getGroup(), viewer);
             break;
         default:
         //case WaveformWidgetType::SoftwareSimpleWaveform: TODO: (vrince)

--- a/src/waveform/widgets/glrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/glrgbwaveformwidget.cpp
@@ -16,6 +16,13 @@ GLRGBWaveformWidget::GLRGBWaveformWidget(const char* group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
 
+    qDebug() << "Created QGLWidget. Context"
+             << "Valid:" << context()->isValid()
+             << "Sharing:" << context()->isSharing();
+    if (QGLContext::currentContext() != context()) {
+        makeCurrent();
+    }
+
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
@@ -29,12 +36,6 @@ GLRGBWaveformWidget::GLRGBWaveformWidget(const char* group, QWidget* parent)
 
     setAutoBufferSwap(false);
 
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
-    if (QGLContext::currentContext() != context()) {
-        makeCurrent();
-    }
     m_initSuccess = init();
 }
 

--- a/src/waveform/widgets/glsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/glsimplewaveformwidget.cpp
@@ -18,6 +18,13 @@
 GLSimpleWaveformWidget::GLSimpleWaveformWidget(const char* group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
+    qDebug() << "Created QGLWidget. Context"
+             << "Valid:" << context()->isValid()
+             << "Sharing:" << context()->isSharing();
+    if (QGLContext::currentContext() != context()) {
+        makeCurrent();
+    }
+
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
@@ -31,12 +38,6 @@ GLSimpleWaveformWidget::GLSimpleWaveformWidget(const char* group, QWidget* paren
 
     setAutoBufferSwap(false);
 
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
-    if (QGLContext::currentContext() != context()) {
-        makeCurrent();
-    }
     m_initSuccess = init();
 }
 

--- a/src/waveform/widgets/glslwaveformwidget.cpp
+++ b/src/waveform/widgets/glslwaveformwidget.cpp
@@ -28,6 +28,13 @@ GLSLWaveformWidget::GLSLWaveformWidget(const char* group, QWidget* parent,
                                        bool rgbRenderer)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
+    qDebug() << "Created QGLWidget. Context"
+             << "Valid:" << context()->isValid()
+             << "Sharing:" << context()->isSharing();
+    if (QGLContext::currentContext() != context()) {
+        makeCurrent();
+    }
+
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
@@ -45,14 +52,6 @@ GLSLWaveformWidget::GLSLWaveformWidget(const char* group, QWidget* parent,
 
     setAutoBufferSwap(false);
 
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
-
-    // Initialization requires activating our context.
-    if (QGLContext::currentContext() != context()) {
-        makeCurrent();
-    }
     m_initSuccess = init();
 }
 

--- a/src/waveform/widgets/glvsynctestwidget.cpp
+++ b/src/waveform/widgets/glvsynctestwidget.cpp
@@ -18,6 +18,12 @@
 GLVSyncTestWidget::GLVSyncTestWidget(const char* group, QWidget* parent)
     : QGLWidget(parent, SharedGLContext::getWidget()),
       WaveformWidgetAbstract(group) {
+    qDebug() << "Created QGLWidget. Context"
+             << "Valid:" << context()->isValid()
+             << "Sharing:" << context()->isSharing();
+    if (QGLContext::currentContext() != context()) {
+        makeCurrent();
+    }
 
     addRenderer<WaveformRenderBackground>(); // 172 µs
 //    addRenderer<WaveformRendererEndOfTrack>(); // 677 µs 1145 µs (active)
@@ -32,9 +38,6 @@ GLVSyncTestWidget::GLVSyncTestWidget(const char* group, QWidget* parent)
 
     setAutoBufferSwap(false);
 
-    if (QGLContext::currentContext() != context()) {
-        makeCurrent();
-    }
     m_initSuccess = init();
     qDebug() << "GLVSyncTestWidget.isSharing() =" << isSharing();
 }

--- a/src/waveform/widgets/glwaveformwidget.cpp
+++ b/src/waveform/widgets/glwaveformwidget.cpp
@@ -18,6 +18,12 @@
 GLWaveformWidget::GLWaveformWidget(const char* group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
+    qDebug() << "Created QGLWidget. Context"
+             << "Valid:" << context()->isValid()
+             << "Sharing:" << context()->isSharing();
+    if (QGLContext::currentContext() != context()) {
+        makeCurrent();
+    }
 
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
@@ -32,12 +38,6 @@ GLWaveformWidget::GLWaveformWidget(const char* group, QWidget* parent)
 
     setAutoBufferSwap(false);
 
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
-    if (QGLContext::currentContext() != context()) {
-        makeCurrent();
-    }
     m_initSuccess = init();
 }
 

--- a/src/waveform/widgets/qthsvwaveformwidget.cpp
+++ b/src/waveform/widgets/qthsvwaveformwidget.cpp
@@ -1,0 +1,57 @@
+#include <QPainter>
+#include <QGLContext>
+#include <QtDebug>
+
+#include "waveform/widgets/qthsvwaveformwidget.h"
+
+#include "waveform/renderers/waveformwidgetrenderer.h"
+#include "waveform/renderers/waveformrenderbackground.h"
+#include "waveform/renderers/waveformrendermark.h"
+#include "waveform/renderers/waveformrendermarkrange.h"
+#include "waveform/renderers/waveformrendererhsv.h"
+#include "waveform/renderers/waveformrendererpreroll.h"
+#include "waveform/renderers/waveformrendererendoftrack.h"
+#include "waveform/renderers/waveformrenderbeat.h"
+
+QtHSVWaveformWidget::QtHSVWaveformWidget(const char* group, QWidget* parent)
+    : QGLWidget(parent),
+      WaveformWidgetAbstract(group) {
+    addRenderer<WaveformRenderBackground>();
+    addRenderer<WaveformRendererEndOfTrack>();
+    addRenderer<WaveformRendererPreroll>();
+    addRenderer<WaveformRenderMarkRange>();
+    addRenderer<WaveformRendererHSV>();
+    addRenderer<WaveformRenderBeat>();
+    addRenderer<WaveformRenderMark>();
+
+    setAttribute(Qt::WA_NoSystemBackground);
+    setAttribute(Qt::WA_OpaquePaintEvent);
+
+    m_initSuccess = init();
+}
+
+QtHSVWaveformWidget::~QtHSVWaveformWidget() {
+}
+
+void QtHSVWaveformWidget::castToQWidget() {
+    m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
+}
+
+void QtHSVWaveformWidget::paintEvent(QPaintEvent* event) {
+    Q_UNUSED(event);
+}
+
+mixxx::Duration QtHSVWaveformWidget::render() {
+    PerformanceTimer timer;
+    mixxx::Duration t1;
+    //mixxx::Duration t2, t3;
+    timer.start();
+    // QPainter makes QGLContext::currentContext() == context()
+    // this may delayed until previous buffer swap finished
+    QPainter painter(this);
+    t1 = timer.restart();
+    draw(&painter, NULL);
+    //t2 = timer.restart();
+    //qDebug() << "QtHSVWaveformWidget "<< t1 << t2;
+    return t1; // return timer for painter setup
+}

--- a/src/waveform/widgets/qthsvwaveformwidget.h
+++ b/src/waveform/widgets/qthsvwaveformwidget.h
@@ -1,0 +1,31 @@
+#ifndef QTHSVWAVEFORMWIDGET_H
+#define QTHSVWAVEFORMWIDGET_H
+
+#include <QGLWidget>
+
+#include "waveformwidgetabstract.h"
+
+class QtHSVWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
+    Q_OBJECT
+  public:
+    virtual ~QtHSVWaveformWidget();
+
+    virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::QtHSVWaveform; }
+
+    static inline QString getWaveformWidgetName() { return tr("HSV") + " - Qt"; }
+    static inline bool useOpenGl() { return true; }
+    static inline bool useOpenGles() { return true; }
+    static inline bool useOpenGLShaders() { return false; }
+    static inline bool developerOnly() { return false; }
+
+  protected:
+    virtual void castToQWidget();
+    virtual void paintEvent(QPaintEvent* event);
+    virtual mixxx::Duration render();
+
+  private:
+    QtHSVWaveformWidget(const char* group, QWidget* parent);
+    friend class WaveformWidgetFactory;
+};
+
+#endif // QTHSVWAVEFORMWIDGET_H

--- a/src/waveform/widgets/qtrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/qtrgbwaveformwidget.cpp
@@ -17,6 +17,13 @@
 QtRGBWaveformWidget::QtRGBWaveformWidget(const char* group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
+    qDebug() << "Created QGLWidget. Context"
+             << "Valid:" << context()->isValid()
+             << "Sharing:" << context()->isSharing();
+    if (QGLContext::currentContext() != context()) {
+        makeCurrent();
+    }
+
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
@@ -30,12 +37,6 @@ QtRGBWaveformWidget::QtRGBWaveformWidget(const char* group, QWidget* parent)
 
     setAutoBufferSwap(false);
 
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
-    if (QGLContext::currentContext() != context()) {
-        makeCurrent();
-    }
     m_initSuccess = init();
 }
 

--- a/src/waveform/widgets/qtrgbwaveformwidget.cpp
+++ b/src/waveform/widgets/qtrgbwaveformwidget.cpp
@@ -1,0 +1,66 @@
+#include <QPainter>
+#include <QGLContext>
+#include <QtDebug>
+
+#include "waveform/widgets/qtrgbwaveformwidget.h"
+
+#include "waveform/renderers/waveformwidgetrenderer.h"
+#include "waveform/renderers/waveformrenderbackground.h"
+#include "waveform/renderers/waveformrendermark.h"
+#include "waveform/renderers/waveformrendermarkrange.h"
+#include "waveform/renderers/waveformrendererrgb.h"
+#include "waveform/renderers/waveformrendererpreroll.h"
+#include "waveform/renderers/waveformrendererendoftrack.h"
+#include "waveform/renderers/waveformrenderbeat.h"
+#include "waveform/sharedglcontext.h"
+
+QtRGBWaveformWidget::QtRGBWaveformWidget(const char* group, QWidget* parent)
+        : QGLWidget(parent, SharedGLContext::getWidget()),
+          WaveformWidgetAbstract(group) {
+    addRenderer<WaveformRenderBackground>();
+    addRenderer<WaveformRendererEndOfTrack>();
+    addRenderer<WaveformRendererPreroll>();
+    addRenderer<WaveformRenderMarkRange>();
+    addRenderer<WaveformRendererRGB>();
+    addRenderer<WaveformRenderBeat>();
+    addRenderer<WaveformRenderMark>();
+
+    setAttribute(Qt::WA_NoSystemBackground);
+    setAttribute(Qt::WA_OpaquePaintEvent);
+
+    setAutoBufferSwap(false);
+
+    qDebug() << "Created QGLWidget. Context"
+             << "Valid:" << context()->isValid()
+             << "Sharing:" << context()->isSharing();
+    if (QGLContext::currentContext() != context()) {
+        makeCurrent();
+    }
+    m_initSuccess = init();
+}
+
+QtRGBWaveformWidget::~QtRGBWaveformWidget() {
+}
+
+void QtRGBWaveformWidget::castToQWidget() {
+    m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
+}
+
+void QtRGBWaveformWidget::paintEvent(QPaintEvent* event) {
+    Q_UNUSED(event);
+}
+
+mixxx::Duration QtRGBWaveformWidget::render() {
+    PerformanceTimer timer;
+    mixxx::Duration t1;
+    //mixxx::Duration t2, t3;
+    timer.start();
+    // QPainter makes QGLContext::currentContext() == context()
+    // this may delayed until previous buffer swap finished
+    QPainter painter(this);
+    t1 = timer.restart();
+    draw(&painter, NULL);
+    //t2 = timer.restart();
+    //qDebug() << "GLVSyncTestWidget "<< t1 << t2;
+    return t1; // return timer for painter setup
+}

--- a/src/waveform/widgets/qtrgbwaveformwidget.h
+++ b/src/waveform/widgets/qtrgbwaveformwidget.h
@@ -1,0 +1,31 @@
+#ifndef QTRGBWAVEFORMWIDGET_H
+#define QTRGBWAVEFORMWIDGET_H
+
+#include <QGLWidget>
+
+#include "waveformwidgetabstract.h"
+
+class QtRGBWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
+    Q_OBJECT
+  public:
+    virtual ~QtRGBWaveformWidget();
+
+    virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::QtRGBWaveform; }
+
+    static inline QString getWaveformWidgetName() { return tr("RGB") + " - Qt"; }
+    static inline bool useOpenGl() { return true; }
+    static inline bool useOpenGles() { return true; }
+    static inline bool useOpenGLShaders() { return false; }
+    static inline bool developerOnly() { return false; }
+
+  protected:
+    virtual void castToQWidget();
+    virtual void paintEvent(QPaintEvent* event);
+    virtual mixxx::Duration render();
+
+  private:
+    QtRGBWaveformWidget(const char* group, QWidget* parent);
+    friend class WaveformWidgetFactory;
+};
+
+#endif // QTRGBWAVEFORMWIDGET_H

--- a/src/waveform/widgets/qtsimplewaveformwidget.cpp
+++ b/src/waveform/widgets/qtsimplewaveformwidget.cpp
@@ -18,6 +18,13 @@
 QtSimpleWaveformWidget::QtSimpleWaveformWidget(const char* group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
+    qDebug() << "Created QGLWidget. Context"
+             << "Valid:" << context()->isValid()
+             << "Sharing:" << context()->isSharing();
+    if (QGLContext::currentContext() != context()) {
+        makeCurrent();
+    }
+
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
@@ -31,12 +38,6 @@ QtSimpleWaveformWidget::QtSimpleWaveformWidget(const char* group, QWidget* paren
 
     setAutoBufferSwap(false);
 
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
-    if (QGLContext::currentContext() != context()) {
-        makeCurrent();
-    }
     m_initSuccess = init();
 }
 

--- a/src/waveform/widgets/qtvsynctestwidget.cpp
+++ b/src/waveform/widgets/qtvsynctestwidget.cpp
@@ -19,6 +19,12 @@
 QtVSyncTestWidget::QtVSyncTestWidget(const char* group, QWidget* parent)
     : QGLWidget(parent, SharedGLContext::getWidget()),
       WaveformWidgetAbstract(group) {
+    qDebug() << "Created QGLWidget. Context"
+             << "Valid:" << context()->isValid()
+             << "Sharing:" << context()->isSharing();
+    if (QGLContext::currentContext() != context()) {
+        makeCurrent();
+    }
 
     addRenderer<QtVSyncTestRenderer>();
 
@@ -27,12 +33,6 @@ QtVSyncTestWidget::QtVSyncTestWidget(const char* group, QWidget* parent)
 
     setAutoBufferSwap(false);
 
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
-    if (QGLContext::currentContext() != context()) {
-        makeCurrent();
-    }
     m_initSuccess = init();
 }
 

--- a/src/waveform/widgets/qtvsynctestwidget.cpp
+++ b/src/waveform/widgets/qtvsynctestwidget.cpp
@@ -1,0 +1,63 @@
+#include <QPainter>
+#include <QGLContext>
+#include <QtDebug>
+
+#include "waveform/widgets/qtvsynctestwidget.h"
+
+#include "waveform/sharedglcontext.h"
+#include "waveform/renderers/waveformwidgetrenderer.h"
+#include "waveform/renderers/waveformrenderbackground.h"
+#include "waveform/renderers/qtvsynctestrenderer.h"
+#include "waveform/renderers/waveformrendererpreroll.h"
+#include "waveform/renderers/waveformrendermark.h"
+#include "waveform/renderers/waveformrendermarkrange.h"
+#include "waveform/renderers/waveformrendererendoftrack.h"
+#include "waveform/renderers/waveformrenderbeat.h"
+
+#include "util/performancetimer.h"
+
+QtVSyncTestWidget::QtVSyncTestWidget(const char* group, QWidget* parent)
+    : QGLWidget(parent, SharedGLContext::getWidget()),
+      WaveformWidgetAbstract(group) {
+
+    addRenderer<QtVSyncTestRenderer>();
+
+    setAttribute(Qt::WA_NoSystemBackground);
+    setAttribute(Qt::WA_OpaquePaintEvent);
+
+    setAutoBufferSwap(false);
+
+    qDebug() << "Created QGLWidget. Context"
+             << "Valid:" << context()->isValid()
+             << "Sharing:" << context()->isSharing();
+    if (QGLContext::currentContext() != context()) {
+        makeCurrent();
+    }
+    m_initSuccess = init();
+}
+
+QtVSyncTestWidget::~QtVSyncTestWidget() {
+}
+
+void QtVSyncTestWidget::castToQWidget() {
+    m_widget = static_cast<QWidget*>(static_cast<QGLWidget*>(this));
+}
+
+void QtVSyncTestWidget::paintEvent(QPaintEvent* event) {
+    Q_UNUSED(event);
+}
+
+mixxx::Duration QtVSyncTestWidget::render() {
+    PerformanceTimer timer;
+    mixxx::Duration t1;
+    //mixxx::Duration t2, t3;
+    timer.start();
+    // QPainter makes QGLContext::currentContext() == context()
+    // this may delayed until previous buffer swap finished
+    QPainter painter(this);
+    t1 = timer.restart();
+    draw(&painter, NULL);
+    //t2 = timer.restart();
+    //qDebug() << "GLVSyncTestWidget "<< t1 << t2;
+    return t1; // return timer for painter setup
+}

--- a/src/waveform/widgets/qtvsynctestwidget.h
+++ b/src/waveform/widgets/qtvsynctestwidget.h
@@ -1,0 +1,31 @@
+#ifndef QTVSYNCTESTWIDGET_H
+#define QTVSYNCTESTWIDGET_H
+
+#include <QGLWidget>
+
+#include "waveformwidgetabstract.h"
+
+class QtVSyncTestWidget : public QGLWidget, public WaveformWidgetAbstract {
+    Q_OBJECT
+  public:
+    QtVSyncTestWidget(const char* group, QWidget* parent);
+    virtual ~QtVSyncTestWidget();
+
+    virtual WaveformWidgetType::Type getType() const { return WaveformWidgetType::QtVSyncTest; }
+
+    static inline QString getWaveformWidgetName() { return tr("VSyncTest") + " - Qt"; }
+    static inline bool useOpenGl() { return true; }
+    static inline bool useOpenGles() { return true; }
+    static inline bool useOpenGLShaders() { return false; }
+    static inline bool developerOnly() { return true; }
+
+  protected:
+    virtual void castToQWidget();
+    virtual void paintEvent(QPaintEvent* event);
+    virtual mixxx::Duration render();
+
+  private:
+    friend class WaveformWidgetFactory;
+};
+
+#endif // QTVSYNCTESTWIDGET_H

--- a/src/waveform/widgets/qtwaveformwidget.cpp
+++ b/src/waveform/widgets/qtwaveformwidget.cpp
@@ -19,6 +19,13 @@
 QtWaveformWidget::QtWaveformWidget(const char* group, QWidget* parent)
         : QGLWidget(parent, SharedGLContext::getWidget()),
           WaveformWidgetAbstract(group) {
+    qDebug() << "Created QGLWidget. Context"
+             << "Valid:" << context()->isValid()
+             << "Sharing:" << context()->isSharing();
+    if (QGLContext::currentContext() != context()) {
+        makeCurrent();
+    }
+
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
@@ -32,12 +39,6 @@ QtWaveformWidget::QtWaveformWidget(const char* group, QWidget* parent)
 
     setAutoBufferSwap(false);
 
-    qDebug() << "Created QGLWidget. Context"
-             << "Valid:" << context()->isValid()
-             << "Sharing:" << context()->isSharing();
-    if (QGLContext::currentContext() != context()) {
-        makeCurrent();
-    }
     m_initSuccess = init();
 }
 

--- a/src/waveform/widgets/waveformwidgettype.h
+++ b/src/waveform/widgets/waveformwidgettype.h
@@ -4,6 +4,8 @@
 class WaveformWidgetType {
   public:
     enum Type {
+        // The order must not be changed because the waveforms are refrerenced
+        // from the sotred preferences by a number.
         EmptyWaveform = 0,
         SoftwareSimpleWaveform, //TODO
         SoftwareWaveform,
@@ -18,6 +20,8 @@ class WaveformWidgetType {
         GLRGBWaveform,
         GLSLRGBWaveform,
         QtVSyncTest,
+        QtHSVWaveform,
+        QtRGBWaveform,
         Count_WaveformwidgetType // Also used as invalid value
     };
 };

--- a/src/waveform/widgets/waveformwidgettype.h
+++ b/src/waveform/widgets/waveformwidgettype.h
@@ -17,6 +17,7 @@ class WaveformWidgetType {
         RGBWaveform,
         GLRGBWaveform,
         GLSLRGBWaveform,
+        QtVSyncTest,
         Count_WaveformwidgetType // Also used as invalid value
     };
 };

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -68,6 +68,9 @@ WSpinny::WSpinny(QWidget* parent, const QString& group,
     qDebug() << "WSpinny(): Created QGLWidget, Context"
              << "Valid:" << context()->isValid()
              << "Sharing:" << context()->isSharing();
+    if (QGLContext::currentContext() != context()) {
+        makeCurrent();
+    }
 
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache != nullptr) {


### PR DESCRIPTION
This introduces the waveforms:  
RGB - QT (GL ES) 
HSV - QT (GL ES)
VSynctest -QT (GL ES) 

I am not sure if that can be treated as a Bug-Fix for https://bugs.launchpad.net/mixxx/+bug/1825461
and suiting for 2.2.2 or is this a new feature for master . 

This PR is on top of https://github.com/mixxxdj/mixxx/pull/2088 which should be merged first. 