### PR TITLE
end-of-track warning border on top of 'played' overlay

### DIFF
--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -331,12 +331,8 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
     }
 
     if (m_pCurrentTrack) {
-        // Display viewer contour if end of track
+        // Draw background if end of track
         if (m_endOfTrack) {
-            painter.setOpacity(0.8);
-            painter.setPen(QPen(QBrush(m_endOfTrackColor), 1.5 * m_scaleFactor));
-            painter.setBrush(QColor(0,0,0,0));
-            painter.drawRect(rect().adjusted(0,0,-1,-1));
             painter.setOpacity(0.3);
             painter.setBrush(m_endOfTrackColor);
             painter.drawRect(rect().adjusted(1,1,-2,-2));
@@ -386,6 +382,15 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
                 } else {
                     painter.fillRect(0, 0, m_iPos, m_waveformImageScaled.height(), playedOverlayColor);
                 }
+            }
+
+            // Draw contour around waveform if end of track
+            if (m_endOfTrack) {
+                painter.setOpacity(0.8);
+                painter.setPen(QPen(QBrush(m_endOfTrackColor), 1.5 * m_scaleFactor));
+                painter.setBrush(QColor(0,0,0,0));
+                painter.drawRect(rect().adjusted(0,0,-1,-1));
+                painter.setOpacity(1);
             }
         }
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -383,15 +383,15 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
                     painter.fillRect(0, 0, m_iPos, m_waveformImageScaled.height(), playedOverlayColor);
                 }
             }
+        }
 
-            // Draw contour around waveform if end of track
-            if (m_endOfTrack) {
-                painter.setOpacity(0.8);
-                painter.setPen(QPen(QBrush(m_endOfTrackColor), 1.5 * m_scaleFactor));
-                painter.setBrush(QColor(0,0,0,0));
-                painter.drawRect(rect().adjusted(0,0,-1,-1));
-                painter.setOpacity(1);
-            }
+        // Draw contour around waveform if end of track
+        if (m_endOfTrack) {
+            painter.setOpacity(0.8);
+            painter.setPen(QPen(QBrush(m_endOfTrackColor), 1.5 * m_scaleFactor));
+            painter.setBrush(QColor(0,0,0,0));
+            painter.drawRect(rect().adjusted(0,0,-1,-1));
+            painter.setOpacity(1);
         }
 
         if ((m_analyzerProgress >= kAnalyzerProgressNone) &&


### PR DESCRIPTION
this gives the end-of-track warning more attention.
the warning rectangle is still under the waveform and the dimmed 'played' overlay.
https://bugs.launchpad.net/mixxx/+bug/1792797

before it was covered by the 'played' overlay which makes the warning easy to miss (in the overviews) with tracks longer than let's say 7 minutes as the warnign becomes really narrwo then.

For now I don't dare to move the blink code from the scrolling waveforms to the overview where it would be very useful, maybe more than in the scrolling waveforms.
I'd be glad if some could give me some hints.
I remember we already discussed this but I don't find that bug..