### PR TITLE
GCC9 Follow-up

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -1358,7 +1358,7 @@ class MixxxCore(Feature):
             build.env.Append(CCFLAGS='-Wall')
             build.env.Append(CCFLAGS='-Wextra')
 
-            if build.compiler_is_gcc and build.compiler_major_version >= 9:
+            if build.compiler_is_gcc and build.gcc_major_version >= 9:
                 # Avoid many warnings from GCC 9 about implicitly defined copy assignment
                 # operators that are deprecated for classes with a user-provided copy
                 # constructor. This affects both Qt 5.12 and Mixxx.

--- a/build/depends.py
+++ b/build/depends.py
@@ -1362,7 +1362,7 @@ class MixxxCore(Feature):
                 # Avoid many warnings from GCC 9 about implicitly defined copy assignment
                 # operators that are deprecated for classes with a user-provided copy
                 # constructor. This affects both Qt 5.12 and Mixxx.
-                build.env.Append(CCFLAGS='-Wno-deprecated-copy')
+                build.env.Append(CXXFLAGS='-Wno-deprecated-copy')
 
             if build.compiler_is_clang:
                 # Quiet down Clang warnings about inconsistent use of override

--- a/build/mixxx.py
+++ b/build/mixxx.py
@@ -211,17 +211,18 @@ class MixxxBuild(object):
         self.compiler_is_gcc = 'gcc' in self.env['CC']
         self.compiler_is_clang = 'clang' in self.env['CC']
 
-        # Determine the major compiler version
-        if self.compiler_is_gcc or self.compiler_is_clang:
+        # Determine the major compiler version (only GCC)
+        if self.compiler_is_gcc:
+            self.gcc_major_version = None
             import subprocess
             process = subprocess.Popen([self.env['CC'], '-dumpversion'], stdout=subprocess.PIPE)
             (stdout, stderr) = process.communicate()
-            compiler_dump_version = stdout
+            gcc_version = stdout
             # If match is None we don't know the version.
-            if not compiler_dump_version is None:
-                version_split = compiler_dump_version.split('.')
+            if not gcc_version is None:
+                version_split = gcc_version.split('.')
                 if version_split:
-                    self.compiler_major_version = int(version_split[0])
+                    self.gcc_major_version = int(version_split[0])
 
         self.virtualize_build_dir()
 


### PR DESCRIPTION
Not sure if Clang builds on macOS are affected by aborting with a Python error (as reported in  #2101).

* CCFLAGS -> CXXFLAGS to avoid warnings when compiling C files
* Exclude from Clang builds that simply report an old GCC version (4.2.1 for 8.0.0)