### PR TITLE
Qm rounding fix

### DIFF
--- a/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
+++ b/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
@@ -177,12 +177,11 @@ int GetKeyMode::process(double *PCMData)
 
     m_ChrPointer = m_Chroma->process( m_DecimatedBuffer );		
 
-	
-    // Move bins such that the centre of the base note is in the
-    // middle of its three bins :
-    // Added 21.11.07 by Chris Sutton based on debugging with Katy
-    // Noland + comparison with Matlab equivalent.
-    MathUtilities::circShift( m_ChrPointer, m_BPO, 1);
+    // The Cromagram has the center of C at bin 0, while the major
+    // and minor profiles have the center of C at 1. We want to have
+    // the correlation for C result also at 1.
+    // To achieve this we have to shift two times:
+    MathUtilities::circShift( m_ChrPointer, m_BPO, 2);
 /*
     std::cout << "raw chroma: ";
     for (int ii = 0; ii < m_BPO; ++ii) {
@@ -266,8 +265,10 @@ int GetKeyMode::process(double *PCMData)
   std::cout << std::endl;
 */
     double dummy;
-    // '1 +' because we number keys 1-24, not 0-23.
-    key = 1 + (int)ceil( (double)MathUtilities::getMax( m_Keys, 2* m_BPO, &dummy )/3 );
+    // m_Keys[1] is C center  1 / 3 + 1 = 1
+    // m_Keys[4] is D center  4 / 3 + 1 = 2
+    // '+ 1' because we number keys 1-24, not 0-23.
+    key = MathUtilities::getMax( m_Keys, 2* m_BPO, &dummy ) / 3 + 1;
 
 //    std::cout << "key pre-sorting: " << key << std::endl;
 

--- a/lib/qm-dsp/key_rounding.patch
+++ b/lib/qm-dsp/key_rounding.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp b/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
+index cf3580e..bf72b21 100644
+--- a/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
++++ b/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
+@@ -182,7 +182,7 @@ int GetKeyMode::process(double *PCMData)
+     // middle of its three bins :
+     // Added 21.11.07 by Chris Sutton based on debugging with Katy
+     // Noland + comparison with Matlab equivalent.
+-    MathUtilities::circShift( m_ChrPointer, m_BPO, 1);
++    MathUtilities::circShift( m_ChrPointer, m_BPO, 2);
+ /*
+     std::cout << "raw chroma: ";
+     for (int ii = 0; ii < m_BPO; ++ii) {
+@@ -266,8 +266,10 @@ int GetKeyMode::process(double *PCMData)
+   std::cout << std::endl;
+ */
+     double dummy;
+-    // '1 +' because we number keys 1-24, not 0-23.
+-    key = 1 + (int)ceil( (double)MathUtilities::getMax( m_Keys, 2* m_BPO, &dummy )/3 );
++    // m_Keys[1] is C center  1 / 3 + 1 = 1
++    // m_Keys[4] is D center  4 / 3 + 1 = 2
++    // '+ 1' because we number keys 1-24, not 0-23.
++    key = MathUtilities::getMax( m_Keys, 2* m_BPO, &dummy ) / 3 + 1;
+ 
+ //    std::cout << "key pre-sorting: " << key << std::endl;
+ 

--- a/lib/qm-dsp/key_rounding.patch
+++ b/lib/qm-dsp/key_rounding.patch
@@ -1,26 +1,34 @@
 diff --git a/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp b/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
-index cf3580e..bf72b21 100644
+index 55a1333..cf3580e 100644
 --- a/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
 +++ b/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
-@@ -182,7 +182,7 @@ int GetKeyMode::process(double *PCMData)
-     // middle of its three bins :
-     // Added 21.11.07 by Chris Sutton based on debugging with Katy
-     // Noland + comparison with Matlab equivalent.
--    MathUtilities::circShift( m_ChrPointer, m_BPO, 1);
-+    MathUtilities::circShift( m_ChrPointer, m_BPO, 2);
+@@ -177,11 +177,12 @@ int GetKeyMode::process(double *PCMData)
+ 
+     m_ChrPointer = m_Chroma->process( m_DecimatedBuffer );		
+ 
+-    // The Cromagram has the center of C at bin 0, while the major
+-    // and minor profiles have the center of C at 1. We want to have
+-    // the correlation for C result also at 1.
+-    // To achieve this we have to shift two times:
+-    MathUtilities::circShift( m_ChrPointer, m_BPO, 2);
++	
++    // Move bins such that the centre of the base note is in the
++    // middle of its three bins :
++    // Added 21.11.07 by Chris Sutton based on debugging with Katy
++    // Noland + comparison with Matlab equivalent.
++    MathUtilities::circShift( m_ChrPointer, m_BPO, 1);
  /*
      std::cout << "raw chroma: ";
      for (int ii = 0; ii < m_BPO; ++ii) {
-@@ -266,8 +266,10 @@ int GetKeyMode::process(double *PCMData)
+@@ -265,10 +266,8 @@ int GetKeyMode::process(double *PCMData)
    std::cout << std::endl;
  */
      double dummy;
--    // '1 +' because we number keys 1-24, not 0-23.
--    key = 1 + (int)ceil( (double)MathUtilities::getMax( m_Keys, 2* m_BPO, &dummy )/3 );
-+    // m_Keys[1] is C center  1 / 3 + 1 = 1
-+    // m_Keys[4] is D center  4 / 3 + 1 = 2
-+    // '+ 1' because we number keys 1-24, not 0-23.
-+    key = MathUtilities::getMax( m_Keys, 2* m_BPO, &dummy ) / 3 + 1;
+-    // m_Keys[1] is C center  1 / 3 + 1 = 1
+-    // m_Keys[4] is D center  4 / 3 + 1 = 2
+-    // '+ 1' because we number keys 1-24, not 0-23.
+-    key = MathUtilities::getMax( m_Keys, 2* m_BPO, &dummy ) / 3 + 1;
++    // '1 +' because we number keys 1-24, not 0-23.
++    key = 1 + (int)ceil( (double)MathUtilities::getMax( m_Keys, 2* m_BPO, &dummy )/3 );
  
  //    std::cout << "key pre-sorting: " << key << std::endl;
- 

--- a/src/analyzer/plugins/analyzerqueenmarykey.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarykey.cpp
@@ -49,14 +49,6 @@ bool AnalyzerQueenMaryKey::initialize(int samplerate) {
     return m_helper.initialize(
             windowSize, stepSize, [this](double* pWindow, size_t) {
                 int iKey = m_pKeyMode->process(pWindow);
-                // NOTE(uklotzde): Due to a rounding error in GetKeyMode::process()
-                // the Queen Mary analyzer v1.7.1 returns values in the range [1, 25]
-                // instead of [1, 24]. Instead of patching the original file GetKeyMode.cpp
-                // we compensate this error here to avoid losing the fix after reimporting
-                // the QM plugins!
-                if (iKey == 25) {
-                    iKey = 24;
-                }
 
                 VERIFY_OR_DEBUG_ASSERT(ChromaticKey_IsValid(iKey)) {
                     qWarning() << "No valid key detected in analyzed window:" << iKey;


### PR DESCRIPTION
Originally the chords and the chroma data have 3 bins per key and center at 1.

010|000|000| C-Chord 
595|000|000| Chroma
950|000|005| Result

This means the first correlation has a Maximum at 0. And will warp around if the maximum is slightly shifted by > 1/6 halve tone. 

To compensate this I have shiftet the chroma by one. 
010|000|000| C-Chord 
059|500|000| Chroma
595|000|000| Result

This way we have C without wrap around at 0, 1 and 2 and can use integer math to get the final key value.

This was tested with a B minor chord and a 440 Hz (A) and 523,25 Hz (C) sinus.

I have put a patch into the qm-dsp folder. 
