### PR TITLE
Auto-format src/sources as proof of concept

### DIFF
--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -2,7 +2,6 @@
 
 #include "util/logger.h"
 
-
 namespace mixxx {
 
 namespace {

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -4,9 +4,8 @@
 
 #include "util/audiosignal.h"
 #include "util/indexrange.h"
-#include "util/samplebuffer.h"
 #include "util/memory.h"
-
+#include "util/samplebuffer.h"
 
 namespace mixxx {
 
@@ -15,7 +14,7 @@ class SampleFrames {
     SampleFrames() = default;
     explicit SampleFrames(
             IndexRange frameIndexRange)
-        : m_frameIndexRange(frameIndexRange) {
+            : m_frameIndexRange(frameIndexRange) {
     }
     /*non-virtual*/ ~SampleFrames() = default;
 
@@ -31,19 +30,18 @@ class SampleFrames {
     IndexRange m_frameIndexRange;
 };
 
-
 // Associates a range of frame indices with the corresponding
 // readable sample data as a slice in some sample buffer. The
 // memory is owned by the external sample buffer that must not
 // be modified or destroyed while reading sample data!
-class ReadableSampleFrames final: public SampleFrames {
+class ReadableSampleFrames final : public SampleFrames {
   public:
     ReadableSampleFrames() = default;
     explicit ReadableSampleFrames(
             IndexRange frameIndexRange,
             SampleBuffer::ReadableSlice readableSlice = SampleBuffer::ReadableSlice())
-          : SampleFrames(frameIndexRange),
-            m_readableSlice(readableSlice) {
+            : SampleFrames(frameIndexRange),
+              m_readableSlice(readableSlice) {
     }
     /*non-virtual*/ ~ReadableSampleFrames() = default;
 
@@ -67,19 +65,18 @@ class ReadableSampleFrames final: public SampleFrames {
     SampleBuffer::ReadableSlice m_readableSlice;
 };
 
-
 // Associates a range of frame indices with the corresponding
 // writable sample data as a slice in some sample buffer. The
 // memory is owned by the external sample buffer that must not
 // be modified or destroyed while writing sample data!
-class WritableSampleFrames final: public SampleFrames {
+class WritableSampleFrames final : public SampleFrames {
   public:
     WritableSampleFrames() = default;
     explicit WritableSampleFrames(
             IndexRange frameIndexRange,
             SampleBuffer::WritableSlice writableSlice = SampleBuffer::WritableSlice())
-          : SampleFrames(frameIndexRange),
-            m_writableSlice(writableSlice) {
+            : SampleFrames(frameIndexRange),
+              m_writableSlice(writableSlice) {
     }
     /*non-virtual*/ ~WritableSampleFrames() = default;
 
@@ -102,7 +99,6 @@ class WritableSampleFrames final: public SampleFrames {
   private:
     SampleBuffer::WritableSlice m_writableSlice;
 };
-
 
 class IAudioSourceReader {
   public:
@@ -132,7 +128,6 @@ class IAudioSourceReader {
     }
 };
 
-
 // Common base class for audio sources.
 //
 // Both the number of channels and the sample rate must
@@ -143,10 +138,9 @@ class IAudioSourceReader {
 //
 // Audio sources are implicitly opened upon creation and
 // closed upon destruction.
-class AudioSource: public UrlResource, public AudioSignal, public virtual /*implements*/ IAudioSourceReader {
+class AudioSource : public UrlResource, public AudioSignal, public virtual /*implements*/ IAudioSourceReader {
   public:
     virtual ~AudioSource() = default;
-
 
     // All sources are required to produce a signal of frames
     // where each frame contains samples from all channels that are
@@ -156,7 +150,6 @@ class AudioSource: public UrlResource, public AudioSignal, public virtual /*impl
     // for a stereo signal contains a pair of samples, one for the
     // left and right channel respectively.
     static constexpr SampleLayout kSampleLayout = SampleLayout::Interleaved;
-
 
     enum class OpenMode {
         // In Strict mode the opening operation should be aborted
@@ -191,10 +184,10 @@ class AudioSource: public UrlResource, public AudioSignal, public virtual /*impl
     class OpenParams : public AudioSignal {
       public:
         OpenParams()
-            : AudioSignal(kSampleLayout) {
+                : AudioSignal(kSampleLayout) {
         }
         OpenParams(ChannelCount channelCount, SampleRate sampleRate)
-            : AudioSignal(kSampleLayout, channelCount, sampleRate) {
+                : AudioSignal(kSampleLayout, channelCount, sampleRate) {
         }
 
         using AudioSignal::setChannelCount;
@@ -214,13 +207,11 @@ class AudioSource: public UrlResource, public AudioSignal, public virtual /*impl
             OpenMode mode,
             const OpenParams& params = OpenParams());
 
-
     // Closes the AudioSource and frees all resources.
     //
     // Might be called even if the AudioSource has never been
     // opened, has already been closed, or if opening has failed.
     virtual void close() = 0;
-
 
     // The total length of audio data is bounded and measured in frames.
     IndexRange frameIndexRange() const {
@@ -251,7 +242,6 @@ class AudioSource: public UrlResource, public AudioSignal, public virtual /*impl
         return m_frameIndexRange.clampIndex(frameIndex) == frameIndex;
     }
 
-
     // The actual duration in seconds.
     // Well defined only for valid files!
     inline bool hasDuration() const {
@@ -262,7 +252,6 @@ class AudioSource: public UrlResource, public AudioSignal, public virtual /*impl
         return double(frameLength()) / double(sampleRate());
     }
 
-
     // The bitrate is optional and measured in kbit/s (kbps).
     // It depends on the metadata and decoder if a value for the
     // bitrate is available.
@@ -271,10 +260,12 @@ class AudioSource: public UrlResource, public AudioSignal, public virtual /*impl
         static constexpr SINT kValueDefault = 0;
 
       public:
-        static constexpr const char* unit() { return "kbps"; }
+        static constexpr const char* unit() {
+            return "kbps";
+        }
 
         explicit constexpr Bitrate(SINT value = kValueDefault)
-            : m_value(value) {
+                : m_value(value) {
         }
 
         bool valid() const {
@@ -294,9 +285,7 @@ class AudioSource: public UrlResource, public AudioSignal, public virtual /*impl
         return m_bitrate;
     }
 
-
     bool verifyReadable() const override;
-
 
     ReadableSampleFrames readSampleFrames(
             WritableSampleFrames sampleFrames) {
@@ -369,8 +358,7 @@ class AudioSource: public UrlResource, public AudioSignal, public virtual /*impl
 
 typedef std::shared_ptr<AudioSource> AudioSourcePointer;
 
-inline
-QDebug operator<<(QDebug dbg, AudioSource::OpenMode openMode) {
+inline QDebug operator<<(QDebug dbg, AudioSource::OpenMode openMode) {
     switch (openMode) {
     case AudioSource::OpenMode::Strict:
         return dbg << "Strict";
@@ -382,8 +370,7 @@ QDebug operator<<(QDebug dbg, AudioSource::OpenMode openMode) {
     }
 }
 
-inline
-QDebug operator<<(QDebug dbg, AudioSource::OpenResult openResult) {
+inline QDebug operator<<(QDebug dbg, AudioSource::OpenResult openResult) {
     switch (openResult) {
     case AudioSource::OpenResult::Succeeded:
         return dbg << "Succeeded";

--- a/src/sources/audiosourcestereoproxy.cpp
+++ b/src/sources/audiosourcestereoproxy.cpp
@@ -1,8 +1,7 @@
 #include "sources/audiosourcestereoproxy.h"
 
-#include "util/sample.h"
 #include "util/logger.h"
-
+#include "util/sample.h"
 
 namespace mixxx {
 
@@ -15,28 +14,26 @@ const Logger kLogger("AudioSourceStereoProxy");
 AudioSourceStereoProxy::AudioSourceStereoProxy(
         AudioSourcePointer pAudioSource,
         SINT maxReadableFrames)
-    : AudioSource(*pAudioSource),
-      m_pAudioSource(std::move(pAudioSource)),
-      m_tempSampleBuffer(
-              (m_pAudioSource->channelCount() != 2) ?
-                      m_pAudioSource->frames2samples(maxReadableFrames) : 0),
-      m_tempWritableSlice(m_tempSampleBuffer) {
+        : AudioSource(*pAudioSource),
+          m_pAudioSource(std::move(pAudioSource)),
+          m_tempSampleBuffer(
+                  (m_pAudioSource->channelCount() != 2) ? m_pAudioSource->frames2samples(maxReadableFrames) : 0),
+          m_tempWritableSlice(m_tempSampleBuffer) {
     setChannelCount(2);
 }
 
 AudioSourceStereoProxy::AudioSourceStereoProxy(
         AudioSourcePointer pAudioSource,
         SampleBuffer::WritableSlice tempWritableSlice)
-    : AudioSource(*pAudioSource),
-      m_pAudioSource(std::move(pAudioSource)),
-      m_tempWritableSlice(std::move(tempWritableSlice)) {
+        : AudioSource(*pAudioSource),
+          m_pAudioSource(std::move(pAudioSource)),
+          m_tempWritableSlice(std::move(tempWritableSlice)) {
     setChannelCount(2);
 }
 
 namespace {
 
-inline
-bool isDisjunct(
+inline bool isDisjunct(
         const SampleBuffer::WritableSlice& slice1,
         const SampleBuffer::WritableSlice& slice2) {
     if (slice1.data() == slice2.data()) {
@@ -52,7 +49,7 @@ bool isDisjunct(
     }
 }
 
-}
+} // namespace
 
 ReadableSampleFrames AudioSourceStereoProxy::readSampleFramesClamped(
         WritableSampleFrames sampleFrames) {
@@ -119,4 +116,4 @@ ReadableSampleFrames AudioSourceStereoProxy::readSampleFramesClamped(
                     writableSlice.length()));
 }
 
-}
+} // namespace mixxx

--- a/src/sources/audiosourcestereoproxy.h
+++ b/src/sources/audiosourcestereoproxy.h
@@ -1,13 +1,11 @@
 #ifndef MIXXX_AUDIOSOURCESTEREOPROXY_H
 #define MIXXX_AUDIOSOURCESTEREOPROXY_H
 
-
 #include "sources/audiosource.h"
-
 
 namespace mixxx {
 
-class AudioSourceStereoProxy: public AudioSource {
+class AudioSourceStereoProxy : public AudioSource {
   public:
     static AudioSourcePointer create(
             AudioSourcePointer pAudioSource,
@@ -48,6 +46,5 @@ class AudioSourceStereoProxy: public AudioSource {
 };
 
 } // namespace mixxx
-
 
 #endif // MIXXX_AUDIOSOURCESTEREOPROXY_H

--- a/src/sources/audiosourcetrackproxy.h
+++ b/src/sources/audiosourcetrackproxy.h
@@ -1,11 +1,9 @@
 #ifndef MIXXX_AUDIOSOURCETRACKPROXY_H
 #define MIXXX_AUDIOSOURCETRACKPROXY_H
 
-
 #include "sources/audiosource.h"
 
 #include "track/track.h"
-
 
 namespace mixxx {
 
@@ -14,7 +12,7 @@ namespace mixxx {
 // accessing the corresponding file to avoid file
 // corruption when writing metadata while the file
 // is still in use.
-class AudioSourceTrackProxy: public AudioSource {
+class AudioSourceTrackProxy : public AudioSource {
   public:
     static AudioSourcePointer create(
             TrackPointer pTrack,
@@ -27,9 +25,9 @@ class AudioSourceTrackProxy: public AudioSource {
     AudioSourceTrackProxy(
             TrackPointer pTrack,
             AudioSourcePointer pAudioSource)
-        : AudioSource(*pAudioSource),
-          m_pTrack(std::move(pTrack)),
-          m_pAudioSource(std::move(pAudioSource)) {
+            : AudioSource(*pAudioSource),
+              m_pTrack(std::move(pTrack)),
+              m_pAudioSource(std::move(pAudioSource)) {
     }
 
     void close() override {
@@ -58,6 +56,5 @@ class AudioSourceTrackProxy: public AudioSource {
 };
 
 } // namespace mixxx
-
 
 #endif // MIXXX_AUDIOSOURCETRACKPROXY_H

--- a/src/sources/libfaadloader.cpp
+++ b/src/sources/libfaadloader.cpp
@@ -41,8 +41,6 @@ LibFaadLoader::LibFaadLoader()
     return;
 #endif
 
-
-
     for (const auto& libname : libnames) {
         m_pLibrary.reset();
         m_pLibrary = std::make_unique<QLibrary>(libname, 0);
@@ -74,15 +72,14 @@ LibFaadLoader::LibFaadLoader()
     m_neAACDecGetErrorMessage = reinterpret_cast<NeAACDecGetErrorMessage_t>(
             m_pLibrary->resolve("NeAACDecGetErrorMessage"));
 
-    if (    !m_neAACDecOpen ||
+    if (!m_neAACDecOpen ||
             !m_neAACDecGetCurrentConfiguration ||
             !m_neAACDecSetConfiguration ||
             !m_neAACDecInit2 ||
             !m_neAACDecClose ||
             !m_neAACDecPostSeekReset ||
             !m_neAACDecDecode2 ||
-            !m_neAACDecGetErrorMessage
-    ) {
+            !m_neAACDecGetErrorMessage) {
         kLogger.debug() << "NeAACDecOpen:" << m_neAACDecOpen;
         kLogger.debug() << "NeAACDecGetCurrentConfiguration:" << m_neAACDecGetCurrentConfiguration;
         kLogger.debug() << "NeAACDecSetConfiguration:" << m_neAACDecSetConfiguration;

--- a/src/sources/libfaadloader.h
+++ b/src/sources/libfaadloader.h
@@ -99,44 +99,39 @@ class LibFaadLoader {
 
     char* GetErrorMessage(unsigned char errcode);
 
-
   private:
     LibFaadLoader();
 
-    LibFaadLoader(const LibFaadLoader &) = delete;
-    LibFaadLoader &operator=(const LibFaadLoader &) = delete;
+    LibFaadLoader(const LibFaadLoader&) = delete;
+    LibFaadLoader& operator=(const LibFaadLoader&) = delete;
 
     // QLibrary is not copy-able
     std::unique_ptr<QLibrary> m_pLibrary;
 
-    typedef Handle (* NeAACDecOpen_t)();
+    typedef Handle (*NeAACDecOpen_t)();
     NeAACDecOpen_t m_neAACDecOpen;
 
-    typedef Configuration* (* NeAACDecGetCurrentConfiguration_t)(Handle);
+    typedef Configuration* (*NeAACDecGetCurrentConfiguration_t)(Handle);
     NeAACDecGetCurrentConfiguration_t m_neAACDecGetCurrentConfiguration;
 
-    typedef unsigned char (* NeAACDecSetConfiguration_t)(
+    typedef unsigned char (*NeAACDecSetConfiguration_t)(
             Handle, Configuration*);
     NeAACDecSetConfiguration_t m_neAACDecSetConfiguration;
 
-    typedef char (* NeAACDecInit2_t)(
-            Handle, unsigned char*,
-            unsigned long, unsigned long*, unsigned char* );
+    typedef char (*NeAACDecInit2_t)(
+            Handle, unsigned char*, unsigned long, unsigned long*, unsigned char*);
     NeAACDecInit2_t m_neAACDecInit2;
 
-    typedef void (* NeAACDecClose_t)(Handle);
+    typedef void (*NeAACDecClose_t)(Handle);
     NeAACDecClose_t m_neAACDecClose;
 
-    typedef void (* NeAACDecPostSeekReset_t)(Handle, long);
+    typedef void (*NeAACDecPostSeekReset_t)(Handle, long);
     NeAACDecPostSeekReset_t m_neAACDecPostSeekReset;
 
-    typedef void* (* NeAACDecDecode2_t)(
-            Handle, FrameInfo*, unsigned char*,
-            unsigned long, void**, unsigned long);
+    typedef void* (*NeAACDecDecode2_t)(
+            Handle, FrameInfo*, unsigned char*, unsigned long, void**, unsigned long);
     NeAACDecDecode2_t m_neAACDecDecode2;
 
-    typedef char* (* NeAACDecGetErrorMessage_t)(unsigned char);
+    typedef char* (*NeAACDecGetErrorMessage_t)(unsigned char);
     NeAACDecGetErrorMessage_t m_neAACDecGetErrorMessage;
 };
-
-

--- a/src/sources/metadatasource.h
+++ b/src/sources/metadatasource.h
@@ -8,7 +8,6 @@
 #include "track/trackmetadata.h"
 #include "util/memory.h"
 
-
 namespace mixxx {
 
 // API and abstract base class for parsing track metadata and
@@ -19,7 +18,8 @@ namespace mixxx {
 // and can be used for synchronization purposes.
 class MetadataSource {
   public:
-    virtual ~MetadataSource() {}
+    virtual ~MetadataSource() {
+    }
 
     enum class ImportResult {
         Succeeded,

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -13,9 +13,8 @@
 #if (TAGLIB_HAS_OPUSFILE)
 #include <taglib/opusfile.h>
 #endif
-#include <taglib/wavfile.h>
 #include <taglib/aifffile.h>
-
+#include <taglib/wavfile.h>
 
 namespace mixxx {
 
@@ -41,10 +40,10 @@ const QString kSafelyWritableOrigFileSuffix = "_orig";
 // http://paulbourke.net/dataformats/audio/
 //
 //
-class AiffFile: public TagLib::RIFF::AIFF::File {
+class AiffFile : public TagLib::RIFF::AIFF::File {
   public:
     explicit AiffFile(TagLib::FileName fileName)
-        : TagLib::RIFF::AIFF::File(fileName) {
+            : TagLib::RIFF::AIFF::File(fileName) {
     }
 
     bool importTrackMetadataFromTextChunks(TrackMetadata* pTrackMetadata) /*non-const*/ {
@@ -52,7 +51,7 @@ class AiffFile: public TagLib::RIFF::AIFF::File {
             return false; // nothing to do
         }
         bool imported = false;
-        for(unsigned int i = 0; i < chunkCount(); ++i) {
+        for (unsigned int i = 0; i < chunkCount(); ++i) {
             const TagLib::ByteVector chunkId(TagLib::RIFF::AIFF::File::chunkName(i));
             if (chunkId == "NAME") {
                 pTrackMetadata->refTrackInfo().setTitle(decodeChunkText(
@@ -112,9 +111,9 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
     }
     if (kLogger.traceEnabled()) {
         kLogger.trace() << "Importing"
-                << ((pTrackMetadata && pCoverImage) ? "track metadata and cover art" : (pTrackMetadata ? "track metadata" : "cover art"))
-                << "from file" << m_fileName
-                << "with type" << m_fileType;
+                        << ((pTrackMetadata && pCoverImage) ? "track metadata and cover art" : (pTrackMetadata ? "track metadata" : "cover art"))
+                        << "from file" << m_fileName
+                        << "with type" << m_fileType;
     }
 
     // Rationale: If a file contains different types of tags only
@@ -124,8 +123,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
     // is read and data in subsequent tags is ignored.
 
     switch (m_fileType) {
-    case taglib::FileType::MP3:
-    {
+    case taglib::FileType::MP3: {
         TagLib::MPEG::File file(TAGLIB_FILENAME_FROM_QSTRING(m_fileName));
         if (taglib::readAudioProperties(pTrackMetadata, file)) {
             const TagLib::ID3v2::Tag* pID3v2Tag =
@@ -153,8 +151,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         }
         break;
     }
-    case taglib::FileType::MP4:
-    {
+    case taglib::FileType::MP4: {
         TagLib::MP4::File file(TAGLIB_FILENAME_FROM_QSTRING(m_fileName));
         if (taglib::readAudioProperties(pTrackMetadata, file)) {
             const TagLib::MP4::Tag* pMP4Tag = file.tag();
@@ -173,8 +170,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         }
         break;
     }
-    case taglib::FileType::FLAC:
-    {
+    case taglib::FileType::FLAC: {
         TagLib::FLAC::File file(TAGLIB_FILENAME_FROM_QSTRING(m_fileName));
         // Read cover art directly from the file first. Will be
         // overwritten with cover art contained in on of the tags.
@@ -208,8 +204,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         }
         break;
     }
-    case taglib::FileType::OGG:
-    {
+    case taglib::FileType::OGG: {
         TagLib::Ogg::Vorbis::File file(TAGLIB_FILENAME_FROM_QSTRING(m_fileName));
         if (taglib::readAudioProperties(pTrackMetadata, file)) {
             TagLib::Ogg::XiphComment* pXiphComment = file.tag();
@@ -229,15 +224,14 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         break;
     }
 #if (TAGLIB_HAS_OPUSFILE)
-    case taglib::FileType::OPUS:
-    {
+    case taglib::FileType::OPUS: {
         TagLib::Ogg::Opus::File file(TAGLIB_FILENAME_FROM_QSTRING(m_fileName));
         if (taglib::readAudioProperties(pTrackMetadata, file)) {
             TagLib::Ogg::XiphComment* pXiphComment = file.tag();
             if (pXiphComment) {
                 taglib::importTrackMetadataFromVorbisCommentTag(pTrackMetadata, *pXiphComment);
                 taglib::importCoverImageFromVorbisCommentTag(pCoverImage, *pXiphComment);
-                 return afterImport(ImportResult::Succeeded);
+                return afterImport(ImportResult::Succeeded);
             } else {
                 // fallback
                 const TagLib::Tag* pTag(file.tag());
@@ -250,8 +244,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         break;
     }
 #endif // TAGLIB_HAS_OPUSFILE
-    case taglib::FileType::WV:
-    {
+    case taglib::FileType::WV: {
         TagLib::WavPack::File file(TAGLIB_FILENAME_FROM_QSTRING(m_fileName));
         if (taglib::readAudioProperties(pTrackMetadata, file)) {
             const TagLib::APE::Tag* pAPETag =
@@ -271,8 +264,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         }
         break;
     }
-    case taglib::FileType::WAV:
-    {
+    case taglib::FileType::WAV: {
         TagLib::RIFF::WAV::File file(TAGLIB_FILENAME_FROM_QSTRING(m_fileName));
         if (taglib::readAudioProperties(pTrackMetadata, file)) {
 #if (TAGLIB_HAS_WAV_ID3V2TAG)
@@ -296,8 +288,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         }
         break;
     }
-    case taglib::FileType::AIFF:
-    {
+    case taglib::FileType::AIFF: {
         AiffFile file(TAGLIB_FILENAME_FROM_QSTRING(m_fileName));
         if (taglib::readAudioProperties(pTrackMetadata, file)) {
 #if (TAGLIB_HAS_AIFF_HAS_ID3V2TAG)
@@ -320,9 +311,9 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
     }
     default:
         kLogger.warning()
-            << "Cannot import track metadata"
-            << "from file" << m_fileName
-            << "with unknown or unsupported type" << m_fileType;
+                << "Cannot import track metadata"
+                << "from file" << m_fileName
+                << "with unknown or unsupported type" << m_fileType;
         return afterImport(ImportResult::Failed);
     }
 
@@ -340,21 +331,23 @@ namespace {
 // Encapsulates subtle differences between TagLib::File::save()
 // and variants of this function in derived subclasses.
 class TagSaver {
-public:
-    virtual ~TagSaver() {}
+  public:
+    virtual ~TagSaver() {
+    }
 
     virtual bool hasModifiedTags() const = 0;
 
     virtual bool saveModifiedTags() = 0;
 };
 
-class MpegTagSaver: public TagSaver {
-public:
+class MpegTagSaver : public TagSaver {
+  public:
     MpegTagSaver(const QString& fileName, const TrackMetadata& trackMetadata)
-        : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
-          m_modifiedTagsBitmask(exportTrackMetadata(&m_file, trackMetadata)) {
+            : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
+              m_modifiedTagsBitmask(exportTrackMetadata(&m_file, trackMetadata)) {
     }
-    ~MpegTagSaver() override {}
+    ~MpegTagSaver() override {
+    }
 
     bool hasModifiedTags() const override {
         return m_modifiedTagsBitmask != TagLib::MPEG::File::NoTags;
@@ -368,7 +361,7 @@ public:
         return m_file.save(m_modifiedTagsBitmask);
     }
 
-private:
+  private:
     static int exportTrackMetadata(TagLib::MPEG::File* pFile, const TrackMetadata& trackMetadata) {
         int modifiedTagsBitmask = TagLib::MPEG::File::NoTags;
         if (pFile->isOpen()) {
@@ -394,13 +387,14 @@ private:
     int m_modifiedTagsBitmask;
 };
 
-class Mp4TagSaver: public TagSaver {
-public:
+class Mp4TagSaver : public TagSaver {
+  public:
     Mp4TagSaver(const QString& fileName, const TrackMetadata& trackMetadata)
-        : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
-          m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
+            : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
+              m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
     }
-    ~Mp4TagSaver() override {}
+    ~Mp4TagSaver() override {
+    }
 
     bool hasModifiedTags() const override {
         return m_modifiedTags;
@@ -410,23 +404,23 @@ public:
         return m_file.save();
     }
 
-private:
+  private:
     static bool exportTrackMetadata(TagLib::MP4::File* pFile, const TrackMetadata& trackMetadata) {
-        return pFile->isOpen()
-                && taglib::exportTrackMetadataIntoMP4Tag(pFile->tag(), trackMetadata);
+        return pFile->isOpen() && taglib::exportTrackMetadataIntoMP4Tag(pFile->tag(), trackMetadata);
     }
 
     TagLib::MP4::File m_file;
     bool m_modifiedTags;
 };
 
-class FlacTagSaver: public TagSaver {
-public:
+class FlacTagSaver : public TagSaver {
+  public:
     FlacTagSaver(const QString& fileName, const TrackMetadata& trackMetadata)
-        : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
-          m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
+            : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
+              m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
     }
-    ~FlacTagSaver() override {}
+    ~FlacTagSaver() override {
+    }
 
     bool hasModifiedTags() const override {
         return m_modifiedTags;
@@ -436,7 +430,7 @@ public:
         return m_file.save();
     }
 
-private:
+  private:
     static bool exportTrackMetadata(TagLib::FLAC::File* pFile, const TrackMetadata& trackMetadata) {
         bool modifiedTags = false;
         if (pFile->isOpen()) {
@@ -458,13 +452,14 @@ private:
     bool m_modifiedTags;
 };
 
-class OggTagSaver: public TagSaver {
-public:
+class OggTagSaver : public TagSaver {
+  public:
     OggTagSaver(const QString& fileName, const TrackMetadata& trackMetadata)
-        : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
-          m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
+            : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
+              m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
     }
-    ~OggTagSaver() override {}
+    ~OggTagSaver() override {
+    }
 
     bool hasModifiedTags() const override {
         return m_modifiedTags;
@@ -474,10 +469,9 @@ public:
         return m_file.save();
     }
 
-private:
+  private:
     static bool exportTrackMetadata(TagLib::Ogg::Vorbis::File* pFile, const TrackMetadata& trackMetadata) {
-        return pFile->isOpen()
-                && taglib::exportTrackMetadataIntoXiphComment(pFile->tag(), trackMetadata);
+        return pFile->isOpen() && taglib::exportTrackMetadataIntoXiphComment(pFile->tag(), trackMetadata);
     }
 
     TagLib::Ogg::Vorbis::File m_file;
@@ -485,13 +479,14 @@ private:
 };
 
 #if (TAGLIB_HAS_OPUSFILE)
-class OpusTagSaver: public TagSaver {
-public:
+class OpusTagSaver : public TagSaver {
+  public:
     OpusTagSaver(const QString& fileName, const TrackMetadata& trackMetadata)
-        : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
-          m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
+            : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
+              m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
     }
-    ~OpusTagSaver() override {}
+    ~OpusTagSaver() override {
+    }
 
     bool hasModifiedTags() const override {
         return m_modifiedTags;
@@ -501,10 +496,9 @@ public:
         return m_file.save();
     }
 
-private:
+  private:
     static bool exportTrackMetadata(TagLib::Ogg::Opus::File* pFile, const TrackMetadata& trackMetadata) {
-        return pFile->isOpen()
-                && taglib::exportTrackMetadataIntoXiphComment(pFile->tag(), trackMetadata);
+        return pFile->isOpen() && taglib::exportTrackMetadataIntoXiphComment(pFile->tag(), trackMetadata);
     }
 
     TagLib::Ogg::Opus::File m_file;
@@ -512,13 +506,14 @@ private:
 };
 #endif // TAGLIB_HAS_OPUSFILE
 
-class WavPackTagSaver: public TagSaver {
-public:
+class WavPackTagSaver : public TagSaver {
+  public:
     WavPackTagSaver(const QString& fileName, const TrackMetadata& trackMetadata)
-        : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
-          m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
+            : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
+              m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
     }
-    ~WavPackTagSaver() override {}
+    ~WavPackTagSaver() override {
+    }
 
     bool hasModifiedTags() const override {
         return m_modifiedTags;
@@ -528,10 +523,9 @@ public:
         return m_file.save();
     }
 
-private:
+  private:
     static bool exportTrackMetadata(TagLib::WavPack::File* pFile, const TrackMetadata& trackMetadata) {
-        return pFile->isOpen()
-                && taglib::exportTrackMetadataIntoAPETag(pFile->APETag(true), trackMetadata);
+        return pFile->isOpen() && taglib::exportTrackMetadataIntoAPETag(pFile->APETag(true), trackMetadata);
     }
 
     TagLib::WavPack::File m_file;
@@ -548,13 +542,14 @@ bool exportTrackMetadataIntoRIFFTag(TagLib::RIFF::Info::Tag* pTag, const TrackMe
     return true;
 }
 
-class WavTagSaver: public TagSaver {
-public:
+class WavTagSaver : public TagSaver {
+  public:
     WavTagSaver(const QString& fileName, const TrackMetadata& trackMetadata)
-        : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
-          m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
+            : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
+              m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
     }
-    ~WavTagSaver() override {}
+    ~WavTagSaver() override {
+    }
 
     bool hasModifiedTags() const override {
         return m_modifiedTags;
@@ -564,7 +559,7 @@ public:
         return m_file.save();
     }
 
-private:
+  private:
     static bool exportTrackMetadata(TagLib::RIFF::WAV::File* pFile, const TrackMetadata& trackMetadata) {
         bool modifiedTags = false;
         if (pFile->isOpen()) {
@@ -583,11 +578,11 @@ private:
     bool m_modifiedTags;
 };
 
-class AiffTagSaver: public TagSaver {
-public:
+class AiffTagSaver : public TagSaver {
+  public:
     AiffTagSaver(const QString& fileName, const TrackMetadata& trackMetadata)
-        : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
-          m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
+            : m_file(TAGLIB_FILENAME_FROM_QSTRING(fileName)),
+              m_modifiedTags(exportTrackMetadata(&m_file, trackMetadata)) {
     }
     ~AiffTagSaver() override {
     }
@@ -600,10 +595,9 @@ public:
         return m_file.save();
     }
 
-private:
+  private:
     static bool exportTrackMetadata(TagLib::RIFF::AIFF::File* pFile, const TrackMetadata& trackMetadata) {
-        return pFile->isOpen()
-                && taglib::exportTrackMetadataIntoID3v2Tag(pFile->tag(), trackMetadata);
+        return pFile->isOpen() && taglib::exportTrackMetadataIntoID3v2Tag(pFile->tag(), trackMetadata);
     }
 
     TagLib::RIFF::AIFF::File m_file;
@@ -743,9 +737,9 @@ class SafelyWritableFile final {
         if (oldFile.exists()) {
             if (!oldFile.remove()) {
                 kLogger.warning()
-                    << oldFile.errorString()
-                    << "- Failed to remove backup file after writing:"
-                    << oldFile.fileName();
+                        << oldFile.errorString()
+                        << "- Failed to remove backup file after writing:"
+                        << oldFile.fileName();
                 return false;
             }
         }
@@ -785,8 +779,8 @@ MetadataSourceTagLib::exportTrackMetadata(
     // identify files in the log file that might have caused a
     // crash while exporting metadata.
     kLogger.debug() << "Exporting track metadata"
-            << "into file" << m_fileName
-            << "with type" << m_fileType;
+                    << "into file" << m_fileName
+                    << "with type" << m_fileType;
 
     SafelyWritableFile safelyWritableFile(m_fileName, kExportTrackMetadataIntoTemporaryFile);
     if (!safelyWritableFile.isReady()) {
@@ -799,54 +793,46 @@ MetadataSourceTagLib::exportTrackMetadata(
 
     std::unique_ptr<TagSaver> pTagSaver;
     switch (m_fileType) {
-    case taglib::FileType::MP3:
-    {
+    case taglib::FileType::MP3: {
         pTagSaver = std::make_unique<MpegTagSaver>(safelyWritableFile.fileName(), trackMetadata);
         break;
     }
-    case taglib::FileType::MP4:
-    {
+    case taglib::FileType::MP4: {
         pTagSaver = std::make_unique<Mp4TagSaver>(safelyWritableFile.fileName(), trackMetadata);
         break;
     }
-    case taglib::FileType::FLAC:
-    {
+    case taglib::FileType::FLAC: {
         pTagSaver = std::make_unique<FlacTagSaver>(safelyWritableFile.fileName(), trackMetadata);
         break;
     }
-    case taglib::FileType::OGG:
-    {
+    case taglib::FileType::OGG: {
         pTagSaver = std::make_unique<OggTagSaver>(safelyWritableFile.fileName(), trackMetadata);
         break;
     }
 #if (TAGLIB_HAS_OPUSFILE)
-    case taglib::FileType::OPUS:
-    {
+    case taglib::FileType::OPUS: {
         pTagSaver = std::make_unique<OpusTagSaver>(safelyWritableFile.fileName(), trackMetadata);
         break;
     }
 #endif // TAGLIB_HAS_OPUSFILE
-    case taglib::FileType::WV:
-    {
+    case taglib::FileType::WV: {
         pTagSaver = std::make_unique<WavPackTagSaver>(safelyWritableFile.fileName(), trackMetadata);
         break;
     }
-    case taglib::FileType::WAV:
-    {
+    case taglib::FileType::WAV: {
         pTagSaver = std::make_unique<WavTagSaver>(safelyWritableFile.fileName(), trackMetadata);
         break;
     }
-    case taglib::FileType::AIFF:
-    {
+    case taglib::FileType::AIFF: {
         pTagSaver = std::make_unique<AiffTagSaver>(safelyWritableFile.fileName(), trackMetadata);
         break;
     }
     default:
         kLogger.warning()
-            << "Cannot export track metadata"
-            << "into file" << m_fileName
-            << "with unknown or unsupported type"
-            << m_fileType;
+                << "Cannot export track metadata"
+                << "into file" << m_fileName
+                << "with unknown or unsupported type"
+                << m_fileType;
         return afterExport(ExportResult::Unsupported);
     }
 

--- a/src/sources/metadatasourcetaglib.h
+++ b/src/sources/metadatasourcetaglib.h
@@ -4,22 +4,21 @@
 
 #include "track/trackmetadatataglib.h"
 
-
 namespace mixxx {
 
 // Universal default implementation of IMetadataSource using TagLib.
-class MetadataSourceTagLib: public MetadataSource {
+class MetadataSourceTagLib : public MetadataSource {
   public:
     explicit MetadataSourceTagLib(
             QString fileName)
-        : m_fileName(fileName),
-          m_fileType(taglib::getFileTypeFromFileName(fileName)) {
+            : m_fileName(fileName),
+              m_fileType(taglib::getFileTypeFromFileName(fileName)) {
     }
     MetadataSourceTagLib(
             QString fileName,
             taglib::FileType fileType)
-        : m_fileName(fileName),
-          m_fileType(fileType) {
+            : m_fileName(fileName),
+              m_fileType(fileType) {
     }
 
     std::pair<ImportResult, QDateTime> importTrackMetadataAndCoverImage(

--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -2,15 +2,13 @@
 
 #include "util/logger.h"
 
-
 namespace mixxx {
 
 namespace {
 
 const Logger kLogger("AudioSource");
 
-inline
-QUrl validateUrl(QUrl url) {
+inline QUrl validateUrl(QUrl url) {
     DEBUG_ASSERT(url.isValid());
     VERIFY_OR_DEBUG_ASSERT(url.isLocalFile()) {
         kLogger.warning()

--- a/src/sources/soundsource.h
+++ b/src/sources/soundsource.h
@@ -7,15 +7,13 @@
 
 #include "util/assert.h"
 
-
 namespace mixxx {
 
 // Base class for sound sources with a default implementation (Taglib)
 // for reading/writing metadata.
 class SoundSource
-    : public AudioSource,
-      public MetadataSourceTagLib {
-
+        : public AudioSource,
+          public MetadataSourceTagLib {
   public:
     static QString getFileExtensionFromUrl(QUrl url);
 
@@ -23,15 +21,15 @@ class SoundSource
         return m_type;
     }
 
-protected:
+  protected:
     // If no type is provided the file extension of the file referred
     // by the URL will be used as the type of the SoundSource.
     explicit SoundSource(QUrl url)
-        : SoundSource(url, getFileExtensionFromUrl(url)) {
+            : SoundSource(url, getFileExtensionFromUrl(url)) {
     }
     SoundSource(QUrl url, QString type);
 
-private:
+  private:
     QString m_type;
 };
 

--- a/src/sources/soundsourcecoreaudio.h
+++ b/src/sources/soundsourcecoreaudio.h
@@ -10,20 +10,20 @@
 #include "CAStreamBasicDescription.h"
 
 #if !defined(__COREAUDIO_USE_FLAT_INCLUDES__)
-#include <CoreServices/CoreServices.h>
-#include <CoreAudio/CoreAudioTypes.h>
 #include <AudioToolbox/AudioFile.h>
 #include <AudioToolbox/AudioFormat.h>
+#include <CoreAudio/CoreAudioTypes.h>
+#include <CoreServices/CoreServices.h>
 #else
-#include "CoreAudioTypes.h"
 #include "AudioFile.h"
 #include "AudioFormat.h"
+#include "CoreAudioTypes.h"
 #endif
 
 namespace mixxx {
 
-class SoundSourceCoreAudio: public SoundSource, public virtual /*implements*/ LegacyAudioSource, public LegacyAudioSourceAdapter {
-public:
+class SoundSourceCoreAudio : public SoundSource, public virtual /*implements*/ LegacyAudioSource, public LegacyAudioSourceAdapter {
+  public:
     explicit SoundSourceCoreAudio(QUrl url);
     ~SoundSourceCoreAudio() override;
 
@@ -34,7 +34,7 @@ public:
     SINT readSampleFrames(SINT numberOfFrames,
             CSAMPLE* sampleBuffer) override;
 
-private:
+  private:
     OpenResult tryOpen(
             OpenMode mode,
             const OpenParams& params) override;
@@ -46,8 +46,8 @@ private:
     SInt64 m_headerFrames;
 };
 
-class SoundSourceProviderCoreAudio: public SoundSourceProvider {
-public:
+class SoundSourceProviderCoreAudio : public SoundSourceProvider {
+  public:
     QString getName() const override;
 
     QStringList getSupportedFileExtensions() const override;
@@ -57,6 +57,6 @@ public:
     }
 };
 
-}  // namespace mixxx
+} // namespace mixxx
 
 #endif // SOUNDSOURCECOREAUDIO_H

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -32,8 +32,7 @@ void initFFmpegLib() {
 // More than 2 channels are currently not supported
 const SINT kMaxChannelCount = 2;
 
-inline
-AVMediaType getMediaTypeOfStream(AVStream* pStream) {
+inline AVMediaType getMediaTypeOfStream(AVStream* pStream) {
     return m_pAVStreamWrapper.getMediaTypeOfStream(pStream);
 }
 
@@ -53,25 +52,21 @@ AVStream* findFirstAudioStream(AVFormatContext* pFormatCtx) {
     return nullptr;
 }
 
-inline
-AVCodec* findDecoderForStream(AVStream* pStream) {
+inline AVCodec* findDecoderForStream(AVStream* pStream) {
     return m_pAVStreamWrapper.findDecoderForStream(pStream);
 }
 
-inline
-mixxx::AudioSignal::ChannelCount getChannelCountOfStream(AVStream* pStream) {
+inline mixxx::AudioSignal::ChannelCount getChannelCountOfStream(AVStream* pStream) {
     return mixxx::AudioSignal::ChannelCount(
             m_pAVStreamWrapper.getChannelCountOfStream(pStream));
 }
 
-inline
-mixxx::AudioSignal::SampleRate getSampleRateOfStream(AVStream* pStream) {
+inline mixxx::AudioSignal::SampleRate getSampleRateOfStream(AVStream* pStream) {
     return mixxx::AudioSignal::SampleRate(
             m_pAVStreamWrapper.getSampleRateOfStream(pStream));
 }
 
-inline
-bool getFrameIndexRangeOfStream(AVStream* pStream, mixxx::IndexRange* pFrameIndexRange) {
+inline bool getFrameIndexRangeOfStream(AVStream* pStream, mixxx::IndexRange* pFrameIndexRange) {
     // NOTE(uklotzde): Use 64-bit integer instead of floating point
     // calculations to minimize rounding errors
     DEBUG_ASSERT(pFrameIndexRange);
@@ -111,9 +106,8 @@ bool getFrameIndexRangeOfStream(AVStream* pStream, mixxx::IndexRange* pFrameInde
     return true;
 }
 
-inline
-AVSampleFormat getSampleFormatOfStream(AVStream* pStream) {
-  return m_pAVStreamWrapper.getSampleFormatOfStream(pStream);
+inline AVSampleFormat getSampleFormatOfStream(AVStream* pStream) {
+    return m_pAVStreamWrapper.getSampleFormatOfStream(pStream);
 }
 
 } // anonymous namespace
@@ -124,7 +118,7 @@ SoundSourceProviderFFmpeg::SoundSourceProviderFFmpeg() {
 
 QStringList SoundSourceProviderFFmpeg::getSupportedFileExtensions() const {
     QStringList list;
-    AVInputFormat *l_SInputFmt  = nullptr;
+    AVInputFormat* l_SInputFmt = nullptr;
 
     while ((l_SInputFmt = av_iformat_next(l_SInputFmt))) {
         if (l_SInputFmt->name == nullptr) {
@@ -136,8 +130,8 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileExtensions() const {
         if (!strcmp(l_SInputFmt->name, "ac3")) {
             list.append("ac3");
         } else if (!strcmp(l_SInputFmt->name, "aiff")) {
-                list.append("aif");
-                list.append("aiff");
+            list.append("aif");
+            list.append("aiff");
         } else if (!strcmp(l_SInputFmt->name, "caf")) {
             list.append("caf");
         } else if (!strcmp(l_SInputFmt->name, "flac")) {
@@ -154,7 +148,7 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileExtensions() const {
         } else if (!strcmp(l_SInputFmt->name, "aac")) {
             list.append("aac");
         } else if (!strcmp(l_SInputFmt->name, "opus") ||
-                   !strcmp(l_SInputFmt->name, "libopus")) {
+                !strcmp(l_SInputFmt->name, "libopus")) {
             list.append("opus");
         } else if (!strcmp(l_SInputFmt->name, "tak")) {
             list.append("tak");
@@ -163,7 +157,7 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileExtensions() const {
         } else if (!strcmp(l_SInputFmt->name, "wav")) {
             list.append("wav");
         } else if (!strcmp(l_SInputFmt->name, "wma") or
-                   !strcmp(l_SInputFmt->name, "xwma")) {
+                !strcmp(l_SInputFmt->name, "xwma")) {
             list.append("wma");
         } else if (!strcmp(l_SInputFmt->name, "wv")) {
             list.append("wv");
@@ -179,7 +173,7 @@ AVFormatContext* SoundSourceFFmpeg::openInputFile(
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55, 69, 0)
     // TODO(XXX): Why do we need to allocate and partially initialize
     // the AVFormatContext struct before opening the input file???
-    AVFormatContext *pInputFormatContext = avformat_alloc_context();
+    AVFormatContext* pInputFormatContext = avformat_alloc_context();
     if (pInputFormatContext == nullptr) {
         kLogger.warning()
                 << "avformat_alloc_context() failed";
@@ -188,7 +182,7 @@ AVFormatContext* SoundSourceFFmpeg::openInputFile(
     pInputFormatContext->max_analyze_duration = 999999999;
 #else
     // Will be allocated implicitly when opening the input file
-    AVFormatContext *pInputFormatContext = nullptr;
+    AVFormatContext* pInputFormatContext = nullptr;
 #endif
 
     // libav replaces open() with ff_win32_open() which accepts a
@@ -197,9 +191,7 @@ AVFormatContext* SoundSourceFFmpeg::openInputFile(
     // The old method defining an URL_PROTOCOL is deprecated
 #if defined(_WIN32) && !defined(__MINGW32CE__)
     const QByteArray qBAFilename(
-            avformat_version() >= AV_VERSION_INT(52, 0, 0) ?
-                    fileName.toUtf8() :
-                    QFile::encodeName(fileName));
+            avformat_version() >= AV_VERSION_INT(52, 0, 0) ? fileName.toUtf8() : QFile::encodeName(fileName));
 #else
     const QByteArray qBAFilename(QFile::encodeName(fileName));
 #endif
@@ -236,7 +228,7 @@ void SoundSourceFFmpeg::ClosableInputAVFormatContextPtr::close() {
 
 //static
 SoundSource::OpenResult SoundSourceFFmpeg::openAudioStream(
-        AVCodecContext* pCodecContext, AVCodec *pDecoder) {
+        AVCodecContext* pCodecContext, AVCodec* pDecoder) {
     DEBUG_ASSERT(pCodecContext != nullptr);
 
     const int avcodec_open2_result = avcodec_open2(pCodecContext, pDecoder, nullptr);
@@ -260,7 +252,7 @@ void SoundSourceFFmpeg::ClosableAVStreamPtr::take(AVStream** ppClosableStream) {
 
 void SoundSourceFFmpeg::ClosableAVStreamPtr::close() {
     if (m_pClosableStream != nullptr) {
-#if ! AVSTREAM_FROM_API_VERSION_3_1
+#if !AVSTREAM_FROM_API_VERSION_3_1
         const int avcodec_close_result = avcodec_close(m_pClosableStream->codec);
         if (avcodec_close_result != 0) {
             kLogger.warning()
@@ -292,18 +284,18 @@ void SoundSourceFFmpeg::ClosableAVCodecContextPtr::close() {
 #endif
 
 SoundSourceFFmpeg::SoundSourceFFmpeg(const QUrl& url)
-    : SoundSource(url),
-      m_pResample(nullptr),
-      m_currentMixxxFrameIndex(0),
-      m_bIsSeeked(false),
-      m_lCacheFramePos(0),
-      m_lCacheStartFrame(0),
-      m_lCacheEndFrame(0),
-      m_lCacheLastPos(0),
-      m_lLastStoredPos(0),
-      m_lStoreCount(0),
-      m_lStoredSeekPoint(-1),
-      m_SStoredJumpPoint(nullptr) {
+        : SoundSource(url),
+          m_pResample(nullptr),
+          m_currentMixxxFrameIndex(0),
+          m_bIsSeeked(false),
+          m_lCacheFramePos(0),
+          m_lCacheStartFrame(0),
+          m_lCacheEndFrame(0),
+          m_lCacheLastPos(0),
+          m_lLastStoredPos(0),
+          m_lStoreCount(0),
+          m_lStoredSeekPoint(-1),
+          m_SStoredJumpPoint(nullptr) {
 }
 
 SoundSourceFFmpeg::~SoundSourceFFmpeg() {
@@ -313,7 +305,7 @@ SoundSourceFFmpeg::~SoundSourceFFmpeg() {
 SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
         OpenMode /*mode*/,
         const OpenParams& /*config*/) {
-    AVFormatContext *pInputFormatContext =
+    AVFormatContext* pInputFormatContext =
             openInputFile(getLocalFileName());
     if (pInputFormatContext == nullptr) {
         kLogger.warning()
@@ -354,7 +346,7 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
     }
 
 #if AVSTREAM_FROM_API_VERSION_3_1
-    AVCodecContext *pCodecContext = avcodec_alloc_context3(pDecoder);
+    AVCodecContext* pCodecContext = avcodec_alloc_context3(pDecoder);
 
     if (pCodecContext == nullptr) {
         kLogger.warning()
@@ -364,7 +356,7 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
     }
 
     // Add stream parameters to context
-    if (avcodec_parameters_to_context(pCodecContext,pAudioStream->codecpar)) {
+    if (avcodec_parameters_to_context(pCodecContext, pAudioStream->codecpar)) {
         kLogger.warning()
                 << "Failed to find to set Code parameter for AVCodecContext"
                 << pAudioStream->index;
@@ -383,7 +375,6 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
 #else
     const OpenResult openAudioStreamResult = openAudioStream(pAudioStream->codec, pDecoder);
 #endif
-
 
     if (openAudioStreamResult != OpenResult::Succeeded) {
         return openAudioStreamResult; // early exit on any error
@@ -463,13 +454,13 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
     AVPacket l_SPacket;
     l_SPacket.data = nullptr;
     l_SPacket.size = 0;
-    AVFrame *l_pFrame = nullptr;
+    AVFrame* l_pFrame = nullptr;
     bool l_bStop = false;
-#if ! AVSTREAM_FROM_API_VERSION_3_1
+#if !AVSTREAM_FROM_API_VERSION_3_1
     int l_iFrameFinished = 0;
 #endif
-    struct ffmpegCacheObject *l_SObj = nullptr;
-    struct ffmpegCacheObject *l_SRmObj = nullptr;
+    struct ffmpegCacheObject* l_SObj = nullptr;
+    struct ffmpegCacheObject* l_SRmObj = nullptr;
     qint64 l_lLastPacketPos = -1;
     int l_iError = 0;
     int l_iFrameCount = 0;
@@ -488,7 +479,6 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
             avcodec_free_frame(&l_pFrame);
 #endif
             l_pFrame = nullptr;
-
         }
 
         if (l_bStop) {
@@ -517,15 +507,13 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
             // So then we use pts instead
             if (l_SPacket.stream_index == m_pAudioStream->index &&
                     (l_SPacket.pos >= 0 || l_SPacket.pos == -1)) {
-
                 // Codecs like Wavpack does it like this
                 // They work but you can say about position nothing
-                if (l_SPacket.pos == -1)
-                {
-                   l_SPacket.pos = l_SPacket.pts;
+                if (l_SPacket.pos == -1) {
+                    l_SPacket.pos = l_SPacket.pts;
                 }
                 if (m_lStoredSeekPoint > 0) {
-                    struct ffmpegLocationObject *l_STestObj = nullptr;
+                    struct ffmpegLocationObject* l_STestObj = nullptr;
                     if (m_SJumpPoints.size() > 0) {
                         l_STestObj = m_SJumpPoints.first();
 
@@ -555,12 +543,12 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
                 // AVERROR(EAGAIN) means that we need to feed more
                 // That we can decode Frame or Packet
                 if (l_iRet == AVERROR(EAGAIN)) {
-                  kLogger.warning() << "readFramesToCache: Need more packets to decode!";
-                  continue;
+                    kLogger.warning() << "readFramesToCache: Need more packets to decode!";
+                    continue;
                 }
 
                 if (l_iRet == AVERROR_EOF || l_iRet == AVERROR(EINVAL)) {
-                      kLogger.warning() << "readFramesToCache: Warning can't decode frame!";
+                    kLogger.warning() << "readFramesToCache: Warning can't decode frame!";
                 }
 
                 l_iRet = avcodec_receive_frame(m_pAudioContext, l_pFrame);
@@ -568,19 +556,18 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
                 // AVERROR(EAGAIN) means that we need to feed more
                 // That we can decode Frame or Packet
                 if (l_iRet == AVERROR(EAGAIN)) {
-                  kLogger.warning() << "readFramesToCache: Need more packets to decode!";
-                  continue;
+                    kLogger.warning() << "readFramesToCache: Need more packets to decode!";
+                    continue;
                 }
 
                 if (l_iRet == AVERROR_EOF || l_iRet == AVERROR(EINVAL)) {
-                      kLogger.warning() << "readFramesToCache: Warning can't decode frame!";
+                    kLogger.warning() << "readFramesToCache: Warning can't decode frame!";
                 }
 
                 if (l_iRet == AVERROR_EOF || l_iRet < 0) {
 #else
                 // Decode audio bytes (These can be S16P or FloatP [P is Planar])
-                l_iRet = avcodec_decode_audio4(m_pAudioStream->codec,l_pFrame,&l_iFrameFinished,
-                                               &l_SPacket);
+                l_iRet = avcodec_decode_audio4(m_pAudioStream->codec, l_pFrame, &l_iFrameFinished, &l_SPacket);
                 if (l_iRet <= 0) {
 #endif
                     // An error or EOF occurred,index break out and return what
@@ -590,7 +577,7 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
                     continue;
                 } else {
                     l_iRet = 0;
-                    l_SObj = (struct ffmpegCacheObject *)malloc(sizeof(struct ffmpegCacheObject));
+                    l_SObj = (struct ffmpegCacheObject*)malloc(sizeof(struct ffmpegCacheObject));
                     if (l_SObj == nullptr) {
                         kLogger.debug() << "readFramesToCache: Not enough memory!";
                         l_bStop = true;
@@ -632,7 +619,7 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
                         // too close each other. Mainly it's ugly compromise with MP3,MP4,OGG and WMA
                         // different codec frame sizes
                         if (m_lStoreCount == 32) {
-                            struct ffmpegLocationObject *l_STestObj = nullptr;
+                            struct ffmpegLocationObject* l_STestObj = nullptr;
 
                             if (m_SJumpPoints.size() > 0) {
                                 l_STestObj = m_SJumpPoints.last();
@@ -640,7 +627,7 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
                             // Check whether we have this jumppoint stored already or not
                             // We should have jumppoints below that pos
                             if (l_STestObj == nullptr || l_STestObj->pos < l_SPacket.pos) {
-                                struct ffmpegLocationObject  *l_SJmp = (struct ffmpegLocationObject  *)malloc(
+                                struct ffmpegLocationObject* l_SJmp = (struct ffmpegLocationObject*)malloc(
                                         sizeof(struct ffmpegLocationObject));
                                 m_lLastStoredPos = m_lCacheFramePos;
                                 l_SJmp->startFrame = m_lCacheFramePos;
@@ -657,8 +644,7 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
                     } else {
                         free(l_SObj);
                         l_SObj = nullptr;
-                        kLogger.debug() << "readFramesToCache: General error in audio decode:" <<
-                                 l_iRet;
+                        kLogger.debug() << "readFramesToCache: General error in audio decode:" << l_iRet;
                     }
                 }
 
@@ -678,12 +664,10 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
                 }
             }
 
-
         } else {
             kLogger.debug() << "readFramesToCache: Packet too big or File end";
             l_bStop = true;
         }
-
     }
 
     if (l_pFrame != nullptr) {
@@ -697,15 +681,13 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
         av_free(l_pFrame);
 // FFMPEG 1.0 - 2.1
 #else
-        avcodec_free_frame(&l_pFrame);
+    avcodec_free_frame(&l_pFrame);
 #endif
         l_pFrame = nullptr;
-
     }
 
     if (l_iFrameCount > 0) {
-        kLogger.debug() << "readFramesToCache(): Frame balance is not 0 it is: " <<
-                 l_iFrameCount;
+        kLogger.debug() << "readFramesToCache(): Frame balance is not 0 it is: " << l_iFrameCount;
     }
 
     if (m_SCache.isEmpty()) {
@@ -723,24 +705,22 @@ bool SoundSourceFFmpeg::readFramesToCache(unsigned int count, SINT offset) {
     } else {
         return false;
     }
-}
+} // namespace mixxx
 
-bool SoundSourceFFmpeg::getBytesFromCache(CSAMPLE* buffer, SINT offset,
-        SINT size) {
-    struct ffmpegCacheObject *l_SObj = nullptr;
+bool SoundSourceFFmpeg::getBytesFromCache(CSAMPLE* buffer, SINT offset, SINT size) {
+    struct ffmpegCacheObject* l_SObj = nullptr;
     qint32 l_lPos = 0;
     quint32 l_lLeft = AUDIOSOURCEFFMPEG_MIXXXFRAME_TO_BYTEOFFSET(size);
     quint32 l_lOffset = 0;
     quint32 l_lBytesToCopy = 0;
     bool l_bEndOfFile = false;
 
-    char *l_pBuffer = (char *)buffer;
+    char* l_pBuffer = (char*)buffer;
 
     // If cache is empty then return without crash.
     if (m_SCache.isEmpty()) {
         kLogger.debug() << "getBytesFromCache: Cache is empty can't return bytes";
-        if (l_pBuffer != nullptr)
-        {
+        if (l_pBuffer != nullptr) {
             memset(l_pBuffer, 0x00, l_lLeft);
         }
         return false;
@@ -835,12 +815,11 @@ bool SoundSourceFFmpeg::getBytesFromCache(CSAMPLE* buffer, SINT offset,
             // Okay somehow offset is bigger than our Cache object have bytes
             if (l_lOffset >= l_SObj->length) {
                 if ((l_lPos + 1) < m_SCache.size()) {
-                    l_SObj = m_SCache[++ l_lPos];
+                    l_SObj = m_SCache[++l_lPos];
                     continue;
                 } else {
                     kLogger.debug() << "getBytesFromCache: Buffer run out. Shouldn't happen!";
-                    if (l_pBuffer != nullptr)
-                    {
+                    if (l_pBuffer != nullptr) {
                         memset(l_pBuffer, 0x00, l_lLeft);
                     }
                     return false;
@@ -871,7 +850,7 @@ bool SoundSourceFFmpeg::getBytesFromCache(CSAMPLE* buffer, SINT offset,
             // If we have more items of cache use them
             // or after that just zero buffer..
             if ((l_lPos + 1) < m_SCache.size()) {
-                l_SObj = m_SCache[++ l_lPos];
+                l_SObj = m_SCache[++l_lPos];
             } else {
                 // With MP3 VBR length of audio is just a guess
                 // it's near good as it can get but it can be too long
@@ -891,14 +870,13 @@ bool SoundSourceFFmpeg::getBytesFromCache(CSAMPLE* buffer, SINT offset,
 
 ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
         WritableSampleFrames writableSampleFrames) {
-
     const SINT firstFrameIndex = writableSampleFrames.frameIndexRange().start();
 
     const SINT seekFrameIndex = firstFrameIndex;
     if ((m_currentMixxxFrameIndex != seekFrameIndex) || (m_SCache.size() == 0)) {
         int ret = 0;
         qint64 i = 0;
-        struct ffmpegLocationObject *l_STestObj = nullptr;
+        struct ffmpegLocationObject* l_STestObj = nullptr;
 
         if (seekFrameIndex < m_lCacheStartFrame) {
             // Seek to set (start of the stream which is FFmpeg frame 0)
@@ -912,11 +890,11 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
             // that is chosen because in WMA frames can be that big and if it's
             // smaller than the frame we are seeking we can get into error
             ret = avformat_seek_file(m_pInputFormatContext,
-                                     m_pAudioStream->index,
-                                     0,
-                                     0,
-                                     0xffff,
-                                     AVSEEK_FLAG_BACKWARD);
+                    m_pAudioStream->index,
+                    0,
+                    0,
+                    0xffff,
+                    AVSEEK_FLAG_BACKWARD);
 
             if (ret < 0) {
                 kLogger.warning() << "seek: Can't seek to 0 byte!";
@@ -929,7 +907,6 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
             m_lCacheLastPos = 0;
             m_lCacheFramePos = 0;
             m_lStoredSeekPoint = -1;
-
 
             // Try to find some jump point near to
             // where we are located so we don't needed
@@ -959,7 +936,7 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
                 // -1 one means we are seeking from current position and
                 // filling the cache
                 readFramesToCache((AUDIOSOURCEFFMPEG_CACHESIZE - 50),
-                                  AUDIOSOURCEFFMPEG_FILL_FROM_CURRENTPOS);
+                        AUDIOSOURCEFFMPEG_FILL_FROM_CURRENTPOS);
             }
         }
 
@@ -983,7 +960,8 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
     DEBUG_ASSERT(m_SCache.size() > 0);
     getBytesFromCache(
             writableSampleFrames.writableData(),
-            m_currentMixxxFrameIndex, numberOfFrames);
+            m_currentMixxxFrameIndex,
+            numberOfFrames);
     m_currentMixxxFrameIndex += numberOfFrames;
     m_bIsSeeked = false;
 

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -30,72 +30,71 @@ class EncoderFfmpegResample;
 
 namespace {
 
-  // Because 3.1 changed API how to access thigs in AVStream
-  // we'll separate this logic in own wrapper class
-  class AVStreamWrapper {
-    public:
-        virtual AVMediaType getMediaTypeOfStream(AVStream* pStream) = 0;
-        virtual AVCodec* findDecoderForStream(AVStream* pStream) = 0;
-        virtual SINT getChannelCountOfStream(AVStream* pStream) = 0;
-        virtual SINT getSampleRateOfStream(AVStream* pStream) = 0;
-        virtual AVSampleFormat getSampleFormatOfStream(AVStream* pStream) = 0;
-  };
+// Because 3.1 changed API how to access thigs in AVStream
+// we'll separate this logic in own wrapper class
+class AVStreamWrapper {
+  public:
+    virtual AVMediaType getMediaTypeOfStream(AVStream* pStream) = 0;
+    virtual AVCodec* findDecoderForStream(AVStream* pStream) = 0;
+    virtual SINT getChannelCountOfStream(AVStream* pStream) = 0;
+    virtual SINT getSampleRateOfStream(AVStream* pStream) = 0;
+    virtual AVSampleFormat getSampleFormatOfStream(AVStream* pStream) = 0;
+};
 
-  // Implement classes for version before 3.1 and after that
+// Implement classes for version before 3.1 and after that
 #if AVSTREAM_FROM_API_VERSION_3_1
-  // This is after version 3.1
-  class AVStreamWrapperImpl : public AVStreamWrapper {
-    public:
-        AVMediaType getMediaTypeOfStream(AVStream* pStream) {
-             return pStream->codecpar->codec_type;
-        }
+// This is after version 3.1
+class AVStreamWrapperImpl : public AVStreamWrapper {
+  public:
+    AVMediaType getMediaTypeOfStream(AVStream* pStream) {
+        return pStream->codecpar->codec_type;
+    }
 
-        AVCodec* findDecoderForStream(AVStream* pStream) {
-            return avcodec_find_decoder(pStream->codecpar->codec_id);
-        }
+    AVCodec* findDecoderForStream(AVStream* pStream) {
+        return avcodec_find_decoder(pStream->codecpar->codec_id);
+    }
 
-        SINT getChannelCountOfStream(AVStream* pStream) {
-            return pStream->codecpar->channels;
-        }
+    SINT getChannelCountOfStream(AVStream* pStream) {
+        return pStream->codecpar->channels;
+    }
 
-        SINT getSampleRateOfStream(AVStream* pStream) {
-            return pStream->codecpar->sample_rate;
-        }
+    SINT getSampleRateOfStream(AVStream* pStream) {
+        return pStream->codecpar->sample_rate;
+    }
 
-        AVSampleFormat getSampleFormatOfStream(AVStream* pStream) {
-            return (AVSampleFormat)pStream->codecpar->format;
-        }
-  };
+    AVSampleFormat getSampleFormatOfStream(AVStream* pStream) {
+        return (AVSampleFormat)pStream->codecpar->format;
+    }
+};
 #else
-  class AVStreamWrapperImpl : public AVStreamWrapper {
-    public:
-        AVMediaType getMediaTypeOfStream(AVStream* pStream) {
-             return pStream->codec->codec_type;
-        }
+class AVStreamWrapperImpl : public AVStreamWrapper {
+  public:
+    AVMediaType getMediaTypeOfStream(AVStream* pStream) {
+        return pStream->codec->codec_type;
+    }
 
-        AVCodec* findDecoderForStream(AVStream* pStream) {
-            return avcodec_find_decoder(pStream->codec->codec_id);
-        }
+    AVCodec* findDecoderForStream(AVStream* pStream) {
+        return avcodec_find_decoder(pStream->codec->codec_id);
+    }
 
-        SINT getChannelCountOfStream(AVStream* pStream) {
-            return pStream->codec->channels;
-        }
+    SINT getChannelCountOfStream(AVStream* pStream) {
+        return pStream->codec->channels;
+    }
 
-        SINT getSampleRateOfStream(AVStream* pStream) {
-            return pStream->codec->sample_rate;
-        }
+    SINT getSampleRateOfStream(AVStream* pStream) {
+        return pStream->codec->sample_rate;
+    }
 
-        AVSampleFormat getSampleFormatOfStream(AVStream* pStream) {
-            return pStream->codec->sample_fmt;
-        }
-  };
+    AVSampleFormat getSampleFormatOfStream(AVStream* pStream) {
+        return pStream->codec->sample_fmt;
+    }
+};
 #endif
 
-  //AVStreamWrapperImpl *m_pAVStreamWrapper = new AVStreamWrapperImpl();
-  AVStreamWrapperImpl m_pAVStreamWrapper;
+//AVStreamWrapperImpl *m_pAVStreamWrapper = new AVStreamWrapperImpl();
+AVStreamWrapperImpl m_pAVStreamWrapper;
 
-}
-
+} // namespace
 
 namespace mixxx {
 
@@ -108,10 +107,10 @@ struct ffmpegLocationObject {
 struct ffmpegCacheObject {
     SINT startFrame;
     SINT length;
-    quint8 *bytes;
+    quint8* bytes;
 };
 
-class SoundSourceFFmpeg: public SoundSource {
+class SoundSourceFFmpeg : public SoundSource {
   public:
     explicit SoundSourceFFmpeg(const QUrl& url);
     ~SoundSourceFFmpeg() override;
@@ -141,13 +140,13 @@ class SoundSourceFFmpeg: public SoundSource {
     // or implicitly by the destructor. The wrapper can only be
     // moved, copying is disabled.
     class ClosableInputAVFormatContextPtr final {
-    public:
+      public:
         explicit ClosableInputAVFormatContextPtr(AVFormatContext* pClosableInputFormatContext = nullptr)
-            : m_pClosableInputFormatContext(pClosableInputFormatContext) {
+                : m_pClosableInputFormatContext(pClosableInputFormatContext) {
         }
         explicit ClosableInputAVFormatContextPtr(const ClosableInputAVFormatContextPtr&) = delete;
         explicit ClosableInputAVFormatContextPtr(ClosableInputAVFormatContextPtr&& that)
-            : m_pClosableInputFormatContext(that.m_pClosableInputFormatContext) {
+                : m_pClosableInputFormatContext(that.m_pClosableInputFormatContext) {
             that.m_pClosableInputFormatContext = nullptr;
         }
         ~ClosableInputAVFormatContextPtr() {
@@ -165,28 +164,32 @@ class SoundSourceFFmpeg: public SoundSource {
         ClosableInputAVFormatContextPtr& operator=(const ClosableInputAVFormatContextPtr&) = delete;
         ClosableInputAVFormatContextPtr& operator=(ClosableInputAVFormatContextPtr&& that) = delete;
 
-        AVFormatContext* operator->() { return m_pClosableInputFormatContext; }
-        operator AVFormatContext*() { return m_pClosableInputFormatContext; }
+        AVFormatContext* operator->() {
+            return m_pClosableInputFormatContext;
+        }
+        operator AVFormatContext*() {
+            return m_pClosableInputFormatContext;
+        }
 
-    private:
+      private:
         AVFormatContext* m_pClosableInputFormatContext;
     };
     ClosableInputAVFormatContextPtr m_pInputFormatContext;
 
-    static OpenResult openAudioStream(AVCodecContext* pCodecContext, AVCodec *pDecoder);
+    static OpenResult openAudioStream(AVCodecContext* pCodecContext, AVCodec* pDecoder);
 
     // Takes ownership of an opened (audio) stream and ensures that
     // the corresponding AVStream is closed, either explicitly or
     // implicitly by the destructor. The wrapper can only be moved,
     // copying is disabled.
     class ClosableAVStreamPtr final {
-    public:
+      public:
         explicit ClosableAVStreamPtr(AVStream* pClosableStream = nullptr)
-            : m_pClosableStream(pClosableStream) {
+                : m_pClosableStream(pClosableStream) {
         }
         explicit ClosableAVStreamPtr(const ClosableAVStreamPtr&) = delete;
         explicit ClosableAVStreamPtr(ClosableAVStreamPtr&& that)
-            : m_pClosableStream(that.m_pClosableStream) {
+                : m_pClosableStream(that.m_pClosableStream) {
             that.m_pClosableStream = nullptr;
         }
         ~ClosableAVStreamPtr() {
@@ -203,14 +206,17 @@ class SoundSourceFFmpeg: public SoundSource {
         ClosableAVStreamPtr& operator=(const ClosableAVStreamPtr&) = delete;
         ClosableAVStreamPtr& operator=(ClosableAVStreamPtr&& that) = delete;
 
-        AVStream* operator->() { return m_pClosableStream; }
-        operator AVStream*() { return m_pClosableStream; }
+        AVStream* operator->() {
+            return m_pClosableStream;
+        }
+        operator AVStream*() {
+            return m_pClosableStream;
+        }
 
-    private:
+      private:
         AVStream* m_pClosableStream;
     };
     ClosableAVStreamPtr m_pAudioStream;
-
 
 #if AVSTREAM_FROM_API_VERSION_3_1
     // Takes ownership of an opened (audio) codec context and ensures that
@@ -221,13 +227,13 @@ class SoundSourceFFmpeg: public SoundSource {
     // This is prior new API changes made in FFMmpeg 3.1
     // before that we can use AVStream->codec to access AVCodecContext
     class ClosableAVCodecContextPtr final {
-    public:
+      public:
         explicit ClosableAVCodecContextPtr(AVCodecContext* pClosableContext = nullptr)
-            : m_pClosableContext(pClosableContext) {
+                : m_pClosableContext(pClosableContext) {
         }
         explicit ClosableAVCodecContextPtr(const ClosableAVCodecContextPtr&) = delete;
         explicit ClosableAVCodecContextPtr(ClosableAVCodecContextPtr&& that)
-            : m_pClosableContext(that.m_pClosableContext) {
+                : m_pClosableContext(that.m_pClosableContext) {
             that.m_pClosableContext = nullptr;
         }
         ~ClosableAVCodecContextPtr() {
@@ -244,10 +250,14 @@ class SoundSourceFFmpeg: public SoundSource {
         ClosableAVCodecContextPtr& operator=(const ClosableAVCodecContextPtr&) = delete;
         ClosableAVCodecContextPtr& operator=(ClosableAVCodecContextPtr&& that) = delete;
 
-        AVCodecContext* operator->() { return m_pClosableContext; }
-        operator AVCodecContext*() { return m_pClosableContext; }
+        AVCodecContext* operator->() {
+            return m_pClosableContext;
+        }
+        operator AVCodecContext*() {
+            return m_pClosableContext;
+        }
 
-    private:
+      private:
         AVCodecContext* m_pClosableContext;
     };
     ClosableAVCodecContextPtr m_pAudioContext;
@@ -263,15 +273,15 @@ class SoundSourceFFmpeg: public SoundSource {
     SINT m_lCacheStartFrame;
     SINT m_lCacheEndFrame;
     SINT m_lCacheLastPos;
-    QVector<struct ffmpegCacheObject  *> m_SCache;
-    QVector<struct ffmpegLocationObject  *> m_SJumpPoints;
+    QVector<struct ffmpegCacheObject*> m_SCache;
+    QVector<struct ffmpegLocationObject*> m_SJumpPoints;
     SINT m_lLastStoredPos;
     SINT m_lStoreCount;
     SINT m_lStoredSeekPoint;
-    struct ffmpegLocationObject *m_SStoredJumpPoint;
+    struct ffmpegLocationObject* m_SStoredJumpPoint;
 };
 
-class SoundSourceProviderFFmpeg: public SoundSourceProvider {
+class SoundSourceProviderFFmpeg : public SoundSourceProvider {
   public:
     SoundSourceProviderFFmpeg();
 

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -100,7 +100,17 @@ SoundSource::OpenResult SoundSourceFLAC::tryOpen(
     }
     FLAC__stream_decoder_set_md5_checking(m_decoder, false);
     const FLAC__StreamDecoderInitStatus initStatus(
-            FLAC__stream_decoder_init_stream(m_decoder, FLAC_read_cb, FLAC_seek_cb, FLAC_tell_cb, FLAC_length_cb, FLAC_eof_cb, FLAC_write_cb, FLAC_metadata_cb, FLAC_error_cb, this));
+            FLAC__stream_decoder_init_stream(
+                    m_decoder,
+                    FLAC_read_cb,
+                    FLAC_seek_cb,
+                    FLAC_tell_cb,
+                    FLAC_length_cb,
+                    FLAC_eof_cb,
+                    FLAC_write_cb,
+                    FLAC_metadata_cb,
+                    FLAC_error_cb,
+                    this));
     if (initStatus != FLAC__STREAM_DECODER_INIT_STATUS_OK) {
         kLogger.warning() << "Failed to initialize FLAC decoder:" << initStatus;
         return OpenResult::Failed;
@@ -192,7 +202,8 @@ ReadableSampleFrames SoundSourceFLAC::readSampleFramesClamped(
         DEBUG_ASSERT(m_curFrameIndex <= firstFrameIndex);
         const auto precedingFrames =
                 IndexRange::between(m_curFrameIndex, firstFrameIndex);
-        if (!precedingFrames.empty() && (precedingFrames != readSampleFramesClamped(WritableSampleFrames(precedingFrames)).frameIndexRange())) {
+        if (!precedingFrames.empty() &&
+                (precedingFrames != readSampleFramesClamped(WritableSampleFrames(precedingFrames)).frameIndexRange())) {
             kLogger.warning()
                     << "Failed to skip preceding frames"
                     << precedingFrames;
@@ -357,7 +368,8 @@ namespace {
 // get rid of the garbage in the most significant bits before scaling
 // to the range [-CSAMPLE_PEAK, CSAMPLE_PEAK - epsilon] with
 // epsilon = 1 / 2 ^ bitsPerSample.
-constexpr CSAMPLE kSampleScaleFactor = CSAMPLE_PEAK / (static_cast<FLAC__int32>(1) << std::numeric_limits<FLAC__int32>::digits);
+constexpr CSAMPLE kSampleScaleFactor = CSAMPLE_PEAK /
+        (static_cast<FLAC__int32>(1) << std::numeric_limits<FLAC__int32>::digits);
 
 inline CSAMPLE convertDecodedSample(FLAC__int32 decodedSample, int bitsPerSample) {
     DEBUG_ASSERT(std::numeric_limits<FLAC__int32>::is_signed);

--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -89,13 +89,16 @@ SoundSource::OpenResult SoundSourceFLAC::tryOpen(
         const OpenParams& /*config*/) {
     DEBUG_ASSERT(!m_file.isOpen());
     if (!m_file.open(QIODevice::ReadOnly)) {
-        kLogger.warning() << "Failed to open FLAC file:" << m_file.fileName();
+        kLogger.warning()
+                << "Failed to open FLAC file:"
+                << m_file.fileName();
         return OpenResult::Failed;
     }
 
     m_decoder = FLAC__stream_decoder_new();
     if (m_decoder == nullptr) {
-        kLogger.warning() << "Failed to create FLAC decoder!";
+        kLogger.warning()
+                << "Failed to create FLAC decoder!";
         return OpenResult::Failed;
     }
     FLAC__stream_decoder_set_md5_checking(m_decoder, false);
@@ -112,12 +115,15 @@ SoundSource::OpenResult SoundSourceFLAC::tryOpen(
                     FLAC_error_cb,
                     this));
     if (initStatus != FLAC__STREAM_DECODER_INIT_STATUS_OK) {
-        kLogger.warning() << "Failed to initialize FLAC decoder:" << initStatus;
+        kLogger.warning()
+                << "Failed to initialize FLAC decoder:"
+                << initStatus;
         return OpenResult::Failed;
     }
     if (!FLAC__stream_decoder_process_until_end_of_metadata(m_decoder)) {
-        kLogger.warning() << "Failed to process FLAC metadata:"
-                          << FLAC__stream_decoder_get_state(m_decoder);
+        kLogger.warning()
+                << "Failed to process FLAC metadata:"
+                << FLAC__stream_decoder_get_state(m_decoder);
         return OpenResult::Failed;
     }
 
@@ -325,8 +331,9 @@ FLAC__StreamDecoderSeekStatus SoundSourceFLAC::flacSeek(FLAC__uint64 absolute_by
     if (m_file.seek(absolute_byte_offset)) {
         return FLAC__STREAM_DECODER_SEEK_STATUS_OK;
     } else {
-        kLogger.warning() << "SoundSourceFLAC: An unrecoverable error occurred ("
-                          << m_file.fileName() << ")";
+        kLogger.warning()
+                << "SoundSourceFLAC: An unrecoverable error occurred ("
+                << m_file.fileName() << ")";
         return FLAC__STREAM_DECODER_SEEK_STATUS_ERROR;
     }
 }
@@ -382,22 +389,25 @@ FLAC__StreamDecoderWriteStatus SoundSourceFLAC::flacWrite(
         const FLAC__Frame* frame, const FLAC__int32* const buffer[]) {
     const SINT numChannels = frame->header.channels;
     if (channelCount() > numChannels) {
-        kLogger.warning() << "Corrupt or unsupported FLAC file:"
-                          << "Invalid number of channels in FLAC frame header"
-                          << frame->header.channels << "<>" << channelCount();
+        kLogger.warning()
+                << "Corrupt or unsupported FLAC file:"
+                << "Invalid number of channels in FLAC frame header"
+                << frame->header.channels << "<>" << channelCount();
         return FLAC__STREAM_DECODER_WRITE_STATUS_ABORT;
     }
     if (sampleRate() != SINT(frame->header.sample_rate)) {
-        kLogger.warning() << "Corrupt or unsupported FLAC file:"
-                          << "Invalid sample rate in FLAC frame header"
-                          << frame->header.sample_rate << "<>" << sampleRate();
+        kLogger.warning()
+                << "Corrupt or unsupported FLAC file:"
+                << "Invalid sample rate in FLAC frame header"
+                << frame->header.sample_rate << "<>" << sampleRate();
         return FLAC__STREAM_DECODER_WRITE_STATUS_ABORT;
     }
     const SINT numReadableFrames = frame->header.blocksize;
     if (numReadableFrames > m_maxBlocksize) {
-        kLogger.warning() << "Corrupt or unsupported FLAC file:"
-                          << "Block size in FLAC frame header exceeds the maximum block size"
-                          << frame->header.blocksize << ">" << m_maxBlocksize;
+        kLogger.warning()
+                << "Corrupt or unsupported FLAC file:"
+                << "Block size in FLAC frame header exceeds the maximum block size"
+                << frame->header.blocksize << ">" << m_maxBlocksize;
         return FLAC__STREAM_DECODER_WRITE_STATUS_ABORT;
     }
 
@@ -414,8 +424,9 @@ FLAC__StreamDecoderWriteStatus SoundSourceFLAC::flacWrite(
     const SINT numWritableFrames = samples2frames(writableSlice.length());
     DEBUG_ASSERT(numWritableFrames <= numReadableFrames);
     if (numWritableFrames < numReadableFrames) {
-        kLogger.warning() << "Sample buffer has not enough free space for all decoded FLAC samples:"
-                          << numWritableFrames << "<" << numReadableFrames;
+        kLogger.warning()
+                << "Sample buffer has not enough free space for all decoded FLAC samples:"
+                << numWritableFrames << "<" << numReadableFrames;
     }
 
     CSAMPLE* pSampleBuffer = writableSlice.data();
@@ -477,13 +488,15 @@ void SoundSourceFLAC::flacMetadata(const FLAC__StreamMetadata* metadata) {
         } else {
             // already set before -> check for consistency
             if (bitsPerSample != m_bitsPerSample) {
-                kLogger.warning() << "Unexpected bits per sample:"
-                                  << bitsPerSample << " <> " << m_bitsPerSample;
+                kLogger.warning()
+                        << "Unexpected bits per sample:"
+                        << bitsPerSample << " <> " << m_bitsPerSample;
             }
         }
         m_maxBlocksize = metadata->data.stream_info.max_blocksize;
         if (0 >= m_maxBlocksize) {
-            kLogger.warning() << "Invalid max. blocksize" << m_maxBlocksize;
+            kLogger.warning()
+                    << "Invalid max. blocksize" << m_maxBlocksize;
         }
         const SINT sampleBufferCapacity =
                 m_maxBlocksize * channelCount();
@@ -516,8 +529,9 @@ void SoundSourceFLAC::flacError(FLAC__StreamDecoderErrorStatus status) {
         error = "STREAM_DECODER_ERROR_STATUS_UNPARSEABLE_STREAM";
         break;
     }
-    kLogger.warning() << "FLAC decoding error" << error << "in file"
-                      << m_file.fileName();
+    kLogger.warning()
+            << "FLAC decoding error" << error
+            << "in file" << m_file.fileName();
     // not much else to do here... whatever function that initiated whatever
     // decoder method resulted in this error will return an error, and the caller
     // will bail. libFLAC docs say to not close the decoder here -- bkgood

--- a/src/sources/soundsourceflac.h
+++ b/src/sources/soundsourceflac.h
@@ -24,7 +24,7 @@ class SoundSourceFLAC final : public SoundSource {
     FLAC__StreamDecoderTellStatus flacTell(FLAC__uint64* offset);
     FLAC__StreamDecoderLengthStatus flacLength(FLAC__uint64* length);
     FLAC__bool flacEOF();
-    FLAC__StreamDecoderWriteStatus flacWrite(const FLAC__Frame *frame,
+    FLAC__StreamDecoderWriteStatus flacWrite(const FLAC__Frame* frame,
             const FLAC__int32* const buffer[]);
     void flacMetadata(const FLAC__StreamMetadata* metadata);
     void flacError(FLAC__StreamDecoderErrorStatus status);
@@ -40,7 +40,7 @@ class SoundSourceFLAC final : public SoundSource {
 
     QFile m_file;
 
-    FLAC__StreamDecoder *m_decoder;
+    FLAC__StreamDecoder* m_decoder;
     // misc bits about the flac format:
     // flac encodes from and decodes to LPCM in blocks, each block is made up of
     // subblocks (one for each chan)
@@ -58,7 +58,7 @@ class SoundSourceFLAC final : public SoundSource {
     SINT m_curFrameIndex;
 };
 
-class SoundSourceProviderFLAC: public SoundSourceProvider {
+class SoundSourceProviderFLAC : public SoundSourceProvider {
   public:
     QString getName() const override;
 

--- a/src/sources/soundsourcem4a.cpp
+++ b/src/sources/soundsourcem4a.cpp
@@ -1,11 +1,11 @@
 #include "sources/soundsourcem4a.h"
 
-#include "util/sample.h"
 #include "util/logger.h"
+#include "util/sample.h"
 
 #ifdef __WINDOWS__
-#include <io.h>
 #include <fcntl.h>
+#include <io.h>
 #endif
 
 #ifdef _MSC_VER
@@ -54,8 +54,7 @@ const MP4Duration kDefaultFramesPerSampleBlock = 1024;
 //   http://perso.telecom-paristech.fr/~dufourd/mpeg-4/tools.html
 const u_int32_t kMaxSampleBlockInputSizeLimit = (u_int32_t(1) << 24) - 1;
 
-inline
-u_int32_t getMaxTrackId(MP4FileHandle hFile) {
+inline u_int32_t getMaxTrackId(MP4FileHandle hFile) {
     // The maximum TrackId equals the number of all tracks
     // in an MP4 file. We pass nullptr and 0 as arguments
     // to avoid any type/subtype filtering at this point!
@@ -64,14 +63,12 @@ u_int32_t getMaxTrackId(MP4FileHandle hFile) {
     return MP4GetNumberOfTracks(hFile, nullptr, 0);
 }
 
-inline
-bool isValidTrackType(const char* trackType) {
+inline bool isValidTrackType(const char* trackType) {
     return (nullptr != trackType) &&
             MP4_IS_AUDIO_TRACK_TYPE(trackType);
 }
 
-inline
-bool isValidMediaDataName(const char* mediaDataName) {
+inline bool isValidMediaDataName(const char* mediaDataName) {
     return (nullptr != mediaDataName) &&
             (0 == strcasecmp(mediaDataName, "mp4a"));
 }
@@ -84,25 +81,25 @@ MP4TrackId findFirstAudioTrackId(MP4FileHandle hFile, const QString& fileName) {
         const char* trackType = MP4GetTrackType(hFile, trackId);
         if (!isValidTrackType(trackType)) {
             kLogger.warning() << "Unsupported track type"
-                    << QString((trackType == nullptr) ? "" : trackType);
+                              << QString((trackType == nullptr) ? "" : trackType);
             kLogger.warning() << "Skipping track"
-                    << trackId
-                    << "of"
-                    << maxTrackId
-                    << "in file"
-                    << fileName;
+                              << trackId
+                              << "of"
+                              << maxTrackId
+                              << "in file"
+                              << fileName;
             continue;
         }
         const char* mediaDataName = MP4GetTrackMediaDataName(hFile, trackId);
         if (!isValidMediaDataName(mediaDataName)) {
             kLogger.warning() << "Unsupported media data name"
-                    << QString((mediaDataName == nullptr) ? "" : mediaDataName);
+                              << QString((mediaDataName == nullptr) ? "" : mediaDataName);
             kLogger.warning() << "Skipping track"
-                    << trackId
-                    << "of"
-                    << maxTrackId
-                    << "in file"
-                    << fileName;
+                              << trackId
+                              << "of"
+                              << maxTrackId
+                              << "in file"
+                              << fileName;
             continue;
         }
         const u_int8_t audioType = MP4GetTrackEsdsObjectTypeId(hFile, trackId);
@@ -114,13 +111,13 @@ MP4TrackId findFirstAudioTrackId(MP4FileHandle hFile, const QString& fileName) {
                     return trackId;
                 } else {
                     kLogger.warning() << "Unsupported MPEG4 audio type"
-                            << int(mpeg4AudioType);
+                                      << int(mpeg4AudioType);
                     kLogger.warning() << "Skipping track"
-                            << trackId
-                            << "of"
-                            << maxTrackId
-                            << "in file"
-                            << fileName;
+                                      << trackId
+                                      << "of"
+                                      << maxTrackId
+                                      << "in file"
+                                      << fileName;
                     continue;
                 }
             } else {
@@ -128,22 +125,22 @@ MP4TrackId findFirstAudioTrackId(MP4FileHandle hFile, const QString& fileName) {
             }
         } else {
             kLogger.warning() << "Unsupported audio type"
-                    << int(audioType);
+                              << int(audioType);
             kLogger.warning() << "Skipping track"
-                    << trackId
-                    << "of"
-                    << maxTrackId
-                    << "in file"
-                    << fileName;
+                              << trackId
+                              << "of"
+                              << maxTrackId
+                              << "in file"
+                              << fileName;
             continue;
         }
         VERIFY_OR_DEBUG_ASSERT(!"unreachable code") {
             kLogger.warning() << "Skipping track"
-                    << trackId
-                    << "of"
-                    << maxTrackId
-                    << "in file"
-                    << fileName;
+                              << trackId
+                              << "of"
+                              << maxTrackId
+                              << "in file"
+                              << fileName;
         }
     }
     return MP4_INVALID_TRACK_ID;
@@ -202,19 +199,19 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(
     // can't currently handle these.
     m_framesPerSampleBlock = MP4GetTrackFixedSampleDuration(m_hFile, m_trackId);
     if (MP4_INVALID_DURATION == m_framesPerSampleBlock) {
-      kLogger.warning() << "Unable to determine the fixed sample duration of track"
-              << m_trackId << "in file" << getUrlString();
-      if (mode == OpenMode::Strict) {
-          // Abort and give another decoder with lower priority
-          // the chance to open the same file.
-          // Fixes https://bugs.launchpad.net/mixxx/+bug/1504113
-          return OpenResult::Aborted;
-      } else {
-          // Fallback: Use a default value
-          kLogger.warning() << "Fallback: Using a default sample duration of"
-                  << kDefaultFramesPerSampleBlock << "sample frames per block";
-          m_framesPerSampleBlock = kDefaultFramesPerSampleBlock;
-      }
+        kLogger.warning() << "Unable to determine the fixed sample duration of track"
+                          << m_trackId << "in file" << getUrlString();
+        if (mode == OpenMode::Strict) {
+            // Abort and give another decoder with lower priority
+            // the chance to open the same file.
+            // Fixes https://bugs.launchpad.net/mixxx/+bug/1504113
+            return OpenResult::Aborted;
+        } else {
+            // Fallback: Use a default value
+            kLogger.warning() << "Fallback: Using a default sample duration of"
+                              << kDefaultFramesPerSampleBlock << "sample frames per block";
+            m_framesPerSampleBlock = kDefaultFramesPerSampleBlock;
+        }
     }
 
     const MP4SampleId numberOfSamples =
@@ -231,7 +228,7 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(
             m_trackId);
     if (maxSampleBlockInputSize == 0) {
         kLogger.warning() << "Failed to read MP4 DecoderConfigDescriptor.bufferSizeDB:"
-                << getUrlString();
+                          << getUrlString();
         return OpenResult::Failed;
     }
     if (maxSampleBlockInputSize > kMaxSampleBlockInputSizeLimit) {
@@ -239,11 +236,11 @@ SoundSource::OpenResult SoundSourceM4A::tryOpen(
         // that returns 4278190742 when opening a corrupt file.
         // https://bugs.launchpad.net/mixxx/+bug/1594169
         kLogger.warning() << "MP4 DecoderConfigDescriptor.bufferSizeDB ="
-                << maxSampleBlockInputSize
-                << ">"
-                << kMaxSampleBlockInputSizeLimit
-                << "exceeds limit:"
-                << getUrlString();
+                          << maxSampleBlockInputSize
+                          << ">"
+                          << kMaxSampleBlockInputSizeLimit
+                          << "exceeds limit:"
+                          << getUrlString();
         return OpenResult::Aborted;
     }
     m_inputBuffer.resize(maxSampleBlockInputSize, 0);
@@ -283,18 +280,16 @@ bool SoundSourceM4A::openDecoder() {
 
     u_int8_t* configBuffer = nullptr;
     u_int32_t configBufferSize = 0;
-    if (!MP4GetTrackESConfiguration(m_hFile, m_trackId, &configBuffer,
-            &configBufferSize)) {
+    if (!MP4GetTrackESConfiguration(m_hFile, m_trackId, &configBuffer, &configBufferSize)) {
         // Failed to get mpeg-4 audio config... this is ok.
         // Init2() will simply use default values instead.
         kLogger.warning() << "Failed to read the MP4 audio configuration."
-                << "Continuing with default values.";
+                          << "Continuing with default values.";
     }
 
     SAMPLERATE_TYPE sampleRate;
     unsigned char channelCount;
-    if (0 > m_pFaad->Init2(m_hDecoder, configBuffer, configBufferSize,
-                    &sampleRate, &channelCount)) {
+    if (0 > m_pFaad->Init2(m_hDecoder, configBuffer, configBufferSize, &sampleRate, &channelCount)) {
         free(configBuffer);
         kLogger.warning() << "Failed to initialize the AAC decoder!";
         return false;
@@ -355,8 +350,7 @@ void SoundSourceM4A::close() {
 }
 
 bool SoundSourceM4A::isValidSampleBlockId(MP4SampleId sampleBlockId) const {
-    return (sampleBlockId >= kSampleBlockIdMin)
-            && (sampleBlockId <= m_maxSampleBlockId);
+    return (sampleBlockId >= kSampleBlockIdMin) && (sampleBlockId <= m_maxSampleBlockId);
 }
 
 void SoundSourceM4A::restartDecoding(MP4SampleId sampleBlockId) {
@@ -376,7 +370,6 @@ void SoundSourceM4A::restartDecoding(MP4SampleId sampleBlockId) {
 
 ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
         WritableSampleFrames writableSampleFrames) {
-
     const SINT firstFrameIndex = writableSampleFrames.frameIndexRange().start();
 
     if (m_curFrameIndex != firstFrameIndex) {
@@ -391,19 +384,16 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
             reopenDecoder();
         }
 
-        MP4SampleId sampleBlockId = kSampleBlockIdMin
-                + (firstFrameIndex / m_framesPerSampleBlock);
+        MP4SampleId sampleBlockId = kSampleBlockIdMin + (firstFrameIndex / m_framesPerSampleBlock);
         DEBUG_ASSERT(isValidSampleBlockId(sampleBlockId));
-        if ((firstFrameIndex < m_curFrameIndex) || // seeking backwards?
-                !isValidSampleBlockId(m_curSampleBlockId) || // invalid seek position?
-                (sampleBlockId
-                        > (m_curSampleBlockId + m_numberOfPrefetchSampleBlocks))) { // jumping forward?
+        if ((firstFrameIndex < m_curFrameIndex) ||                                         // seeking backwards?
+                !isValidSampleBlockId(m_curSampleBlockId) ||                               // invalid seek position?
+                (sampleBlockId > (m_curSampleBlockId + m_numberOfPrefetchSampleBlocks))) { // jumping forward?
             // Restart decoding one or more blocks of samples backwards
             // from the calculated starting block to avoid audible glitches.
             // Implementation note: The type MP4SampleId is unsigned so we
             // need to be careful when subtracting!
-            if ((kSampleBlockIdMin + m_numberOfPrefetchSampleBlocks)
-                    < sampleBlockId) {
+            if ((kSampleBlockIdMin + m_numberOfPrefetchSampleBlocks) < sampleBlockId) {
                 sampleBlockId -= m_numberOfPrefetchSampleBlocks;
             } else {
                 sampleBlockId = kSampleBlockIdMin;
@@ -416,9 +406,7 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
         DEBUG_ASSERT(m_curFrameIndex <= firstFrameIndex);
         const auto precedingFrames =
                 IndexRange::between(m_curFrameIndex, firstFrameIndex);
-        if (!precedingFrames.empty()
-                && (precedingFrames != readSampleFramesClamped(
-                        WritableSampleFrames(precedingFrames)).frameIndexRange())) {
+        if (!precedingFrames.empty() && (precedingFrames != readSampleFramesClamped(WritableSampleFrames(precedingFrames)).frameIndexRange())) {
             kLogger.warning()
                     << "Failed to skip preceding frames"
                     << precedingFrames;
@@ -436,7 +424,6 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
     SINT numberOfSamplesRemaining = numberOfSamplesTotal;
     SINT outputSampleOffset = 0;
     while (0 < numberOfSamplesRemaining) {
-
         if (!m_sampleBuffer.empty()) {
             // Consume previously decoded sample data
             const SampleBuffer::ReadableSlice readableSlice(
@@ -465,13 +452,13 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
                 // Read data for next sample block into input buffer
                 u_int8_t* pInputBuffer = &m_inputBuffer[0];
                 u_int32_t inputBufferLength = m_inputBuffer.size(); // in/out parameter
-                if (!MP4ReadSample(m_hFile, m_trackId, m_curSampleBlockId,
-                        &pInputBuffer, &inputBufferLength,
-                        nullptr, nullptr, nullptr, nullptr)) {
+                if (!MP4ReadSample(m_hFile, m_trackId, m_curSampleBlockId, &pInputBuffer, &inputBufferLength, nullptr, nullptr, nullptr, nullptr)) {
                     kLogger.warning()
                             << "Failed to read MP4 input data for sample block"
-                            << m_curSampleBlockId << "(" << "min ="
-                            << kSampleBlockIdMin << "," << "max ="
+                            << m_curSampleBlockId << "("
+                            << "min ="
+                            << kSampleBlockIdMin << ","
+                            << "max ="
                             << m_maxSampleBlockId << ")";
                     break; // abort
                 }
@@ -510,17 +497,13 @@ ReadableSampleFrames SoundSourceM4A::readSampleFramesClamped(
 
         LibFaadLoader::FrameInfo decFrameInfo;
         void* pDecodeResult = m_pFaad->Decode2(
-                m_hDecoder, &decFrameInfo,
-                &m_inputBuffer[m_inputBufferOffset],
-                m_inputBufferLength,
-                reinterpret_cast<void**>(&pDecodeBuffer),
-                decodeBufferCapacity * sizeof(*pDecodeBuffer));
+                m_hDecoder, &decFrameInfo, &m_inputBuffer[m_inputBufferOffset], m_inputBufferLength, reinterpret_cast<void**>(&pDecodeBuffer), decodeBufferCapacity * sizeof(*pDecodeBuffer));
         // Verify the decoding result
         if (0 != decFrameInfo.error) {
             kLogger.warning() << "AAC decoding error:"
-                    << decFrameInfo.error
-                    << m_pFaad->GetErrorMessage(decFrameInfo.error)
-                    << getUrlString();
+                              << decFrameInfo.error
+                              << m_pFaad->GetErrorMessage(decFrameInfo.error)
+                              << getUrlString();
             break; // abort
         }
         DEBUG_ASSERT(pDecodeResult == pDecodeBuffer); // verify the in/out parameter

--- a/src/sources/soundsourcem4a.h
+++ b/src/sources/soundsourcem4a.h
@@ -18,7 +18,7 @@
 
 namespace mixxx {
 
-class SoundSourceM4A: public SoundSource {
+class SoundSourceM4A : public SoundSource {
   public:
     explicit SoundSourceM4A(const QUrl& url);
     ~SoundSourceM4A() override;
@@ -65,8 +65,8 @@ class SoundSourceM4A: public SoundSource {
     LibFaadLoader* m_pFaad;
 };
 
-class SoundSourceProviderM4A: public SoundSourceProvider {
-public:
+class SoundSourceProviderM4A : public SoundSourceProvider {
+  public:
     QString getName() const override;
 
     QStringList getSupportedFileExtensions() const override;

--- a/src/sources/soundsourcemediafoundation.cpp
+++ b/src/sources/soundsourcemediafoundation.cpp
@@ -4,8 +4,8 @@
 #include <mferror.h>
 #include <propvarutil.h>
 
-#include "util/sample.h"
 #include "util/logger.h"
+#include "util/sample.h"
 
 namespace {
 
@@ -32,7 +32,8 @@ constexpr SINT kNumberOfPrefetchFrames = 2112;
 constexpr DWORD kStreamIndex = MF_SOURCE_READER_FIRST_AUDIO_STREAM;
 
 /** Microsoft examples use this snippet often. */
-template<class T> static void safeRelease(T **ppT) {
+template<class T>
+static void safeRelease(T** ppT) {
     if (*ppT) {
         (*ppT)->Release();
         *ppT = nullptr;
@@ -152,8 +153,7 @@ void SoundSourceMediaFoundation::seekSampleFrame(SINT frameIndex) {
                 samples2frames(m_sampleBuffer.readableLength()) +
                 2 * kNumberOfPrefetchFrames;
         if (skipFrames.length() <= skipFramesCountMax) {
-            if (skipFrames != readSampleFramesClamped(
-                    WritableSampleFrames(skipFrames)).frameIndexRange()) {
+            if (skipFrames != readSampleFramesClamped(WritableSampleFrames(skipFrames)).frameIndexRange()) {
                 kLogger.warning()
                         << "Failed to skip frames before decoding"
                         << skipFrames;
@@ -211,8 +211,7 @@ void SoundSourceMediaFoundation::seekSampleFrame(SINT frameIndex) {
                 // current position!
                 m_currentFrameIndex = kUnknownFrameIndex; // prevent further seeking
                 DEBUG_ASSERT(!isValidFrameIndex(m_currentFrameIndex));
-                if (skipFrames != readSampleFramesClamped(
-                        WritableSampleFrames(skipFrames)).frameIndexRange()) {
+                if (skipFrames != readSampleFramesClamped(WritableSampleFrames(skipFrames)).frameIndexRange()) {
                     kLogger.warning()
                             << "Failed to skip frames while seeking"
                             << skipFrames;
@@ -225,8 +224,7 @@ void SoundSourceMediaFoundation::seekSampleFrame(SINT frameIndex) {
                     // of SetCurrentPosition()
                     skipFrames = IndexRange::between(m_currentFrameIndex, frameIndex);
                     // Skip more samples if frameIndex has not yet been reached
-                    if (skipFrames != readSampleFramesClamped(
-                            WritableSampleFrames(skipFrames)).frameIndexRange()) {
+                    if (skipFrames != readSampleFramesClamped(WritableSampleFrames(skipFrames)).frameIndexRange()) {
                         kLogger.warning()
                                 << "Failed to skip frames while seeking"
                                 << skipFrames;
@@ -253,19 +251,18 @@ void SoundSourceMediaFoundation::seekSampleFrame(SINT frameIndex) {
 
 ReadableSampleFrames SoundSourceMediaFoundation::readSampleFramesClamped(
         WritableSampleFrames writableSampleFrames) {
-
     const SINT firstFrameIndex = writableSampleFrames.frameIndexRange().start();
     if (m_currentFrameIndex != kUnknownFrameIndex) {
         seekSampleFrame(firstFrameIndex);
         if (m_currentFrameIndex != firstFrameIndex) {
-             kLogger.warning()
+            kLogger.warning()
                     << "Failed to position reader at beginning of decoding range"
                     << writableSampleFrames.frameIndexRange();
-             // Abort
-             return ReadableSampleFrames(
-                     mixxx::IndexRange::between(
-                             m_currentFrameIndex,
-                             m_currentFrameIndex));
+            // Abort
+            return ReadableSampleFrames(
+                    mixxx::IndexRange::between(
+                            m_currentFrameIndex,
+                            m_currentFrameIndex));
         }
         DEBUG_ASSERT(m_currentFrameIndex == firstFrameIndex);
     } else {
@@ -283,8 +280,7 @@ ReadableSampleFrames SoundSourceMediaFoundation::readSampleFramesClamped(
         SampleBuffer::ReadableSlice readableSlice(
                 m_sampleBuffer.shrinkForReading(
                         frames2samples(numberOfFramesRemaining)));
-        DEBUG_ASSERT(readableSlice.length()
-                <= frames2samples(numberOfFramesRemaining));
+        DEBUG_ASSERT(readableSlice.length() <= frames2samples(numberOfFramesRemaining));
         if (readableSlice.length() > 0) {
             DEBUG_ASSERT(isValidFrameIndex(m_currentFrameIndex));
             DEBUG_ASSERT(m_currentFrameIndex < frameIndexMax());
@@ -336,7 +332,7 @@ ReadableSampleFrames SoundSourceMediaFoundation::readSampleFramesClamped(
                     << "-> abort and stop decoding";
             DEBUG_ASSERT(pSample == nullptr);
             safeRelease(&m_pSourceReader); // kill the reader
-            break; // abort
+            break;                         // abort
         } else if (dwFlags & MF_SOURCE_READERF_ENDOFSTREAM) {
             DEBUG_ASSERT(pSample == nullptr);
             break; // finished reading
@@ -402,7 +398,7 @@ ReadableSampleFrames SoundSourceMediaFoundation::readSampleFramesClamped(
         // Enlarge temporary buffer (if necessary)
         DEBUG_ASSERT((dwSampleTotalLengthInBytes % kBytesPerSample) == 0);
         SINT numberOfSamplesToBuffer =
-            dwSampleTotalLengthInBytes / kBytesPerSample;
+                dwSampleTotalLengthInBytes / kBytesPerSample;
         SINT sampleBufferCapacity = m_sampleBuffer.capacity();
         DEBUG_ASSERT(sampleBufferCapacity > 0);
         while (sampleBufferCapacity < numberOfSamplesToBuffer) {
@@ -509,7 +505,7 @@ namespace {
 
 bool configureMediaType(
         IMFSourceReader* pSourceReader,
-        SINT *pBitrate,
+        SINT* pBitrate,
         const AudioSource::OpenParams& params = AudioSource::OpenParams()) {
     DEBUG_ASSERT(pSourceReader);
     DEBUG_ASSERT(pBitrate);
@@ -521,7 +517,7 @@ bool configureMediaType(
             kStreamIndex, &pAudioType);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to get current media type from stream";
+                          << "failed to get current media type from stream";
         return false;
     }
 
@@ -530,7 +526,7 @@ bool configureMediaType(
     hr = pAudioType->GetUINT32(MF_MT_AUDIO_AVG_BYTES_PER_SECOND, &avgBytesPerSecond);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "error getting MF_MT_AUDIO_AVG_BYTES_PER_SECOND";
+                          << "error getting MF_MT_AUDIO_AVG_BYTES_PER_SECOND";
         safeRelease(&pAudioType);
         return false;
     }
@@ -539,7 +535,7 @@ bool configureMediaType(
     hr = pAudioType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Audio);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to set major type to audio";
+                          << "failed to set major type to audio";
         safeRelease(&pAudioType);
         return false;
     }
@@ -547,7 +543,7 @@ bool configureMediaType(
     hr = pAudioType->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_Float);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to set subtype format to float";
+                          << "failed to set subtype format to float";
         safeRelease(&pAudioType);
         return false;
     }
@@ -555,7 +551,7 @@ bool configureMediaType(
     hr = pAudioType->SetUINT32(MF_MT_ALL_SAMPLES_INDEPENDENT, true);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to set all samples independent";
+                          << "failed to set all samples independent";
         safeRelease(&pAudioType);
         return false;
     }
@@ -563,7 +559,7 @@ bool configureMediaType(
     hr = pAudioType->SetUINT32(MF_MT_FIXED_SIZE_SAMPLES, true);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to set fixed size samples";
+                          << "failed to set fixed size samples";
         safeRelease(&pAudioType);
         return false;
     }
@@ -572,8 +568,8 @@ bool configureMediaType(
             MF_MT_AUDIO_BITS_PER_SAMPLE, kBitsPerSample);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to set bits per sample:"
-                << kBitsPerSample;
+                          << "failed to set bits per sample:"
+                          << kBitsPerSample;
         safeRelease(&pAudioType);
         return false;
     }
@@ -583,8 +579,8 @@ bool configureMediaType(
             MF_MT_SAMPLE_SIZE, sampleSize);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to set sample size:"
-                << sampleSize;
+                          << "failed to set sample size:"
+                          << sampleSize;
         safeRelease(&pAudioType);
         return false;
     }
@@ -594,7 +590,7 @@ bool configureMediaType(
             MF_MT_AUDIO_NUM_CHANNELS, &numChannels);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to get actual number of channels";
+                          << "failed to get actual number of channels";
         safeRelease(&pAudioType);
         return false;
     }
@@ -605,8 +601,8 @@ bool configureMediaType(
                 MF_MT_AUDIO_NUM_CHANNELS, numChannels);
         if (FAILED(hr)) {
             kLogger.warning() << hr
-                    << "failed to set number of channels:"
-                    << numChannels;
+                              << "failed to set number of channels:"
+                              << numChannels;
             safeRelease(&pAudioType);
             return false;
         }
@@ -618,7 +614,7 @@ bool configureMediaType(
             MF_MT_AUDIO_SAMPLES_PER_SECOND, &samplesPerSecond);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to get samples per second";
+                          << "failed to get samples per second";
         safeRelease(&pAudioType);
         return false;
     }
@@ -629,8 +625,8 @@ bool configureMediaType(
                 MF_MT_AUDIO_SAMPLES_PER_SECOND, samplesPerSecond);
         if (FAILED(hr)) {
             kLogger.warning() << hr
-                    << "failed to set samples per second:"
-                    << samplesPerSecond;
+                              << "failed to set samples per second:"
+                              << samplesPerSecond;
             safeRelease(&pAudioType);
             return false;
         }
@@ -643,7 +639,7 @@ bool configureMediaType(
             kStreamIndex, nullptr, pAudioType);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to set media type";
+                          << "failed to set media type";
         safeRelease(&pAudioType);
         return false;
     }
@@ -676,7 +672,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const OpenParams& openPara
             MF_SOURCE_READER_ALL_STREAMS, false);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to deselect all streams";
+                          << "failed to deselect all streams";
         return false;
     }
 
@@ -684,7 +680,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const OpenParams& openPara
             kStreamIndex, true);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to select first audio stream";
+                          << "failed to select first audio stream";
         return false;
     }
 
@@ -704,7 +700,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const OpenParams& openPara
             kStreamIndex, &pAudioType);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to retrieve completed media type";
+                          << "failed to retrieve completed media type";
         safeRelease(&pAudioType);
         return false;
     }
@@ -714,7 +710,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const OpenParams& openPara
             kStreamIndex, true);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to select first audio stream (again)";
+                          << "failed to select first audio stream (again)";
         safeRelease(&pAudioType);
         return false;
     }
@@ -724,7 +720,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const OpenParams& openPara
             MF_MT_AUDIO_NUM_CHANNELS, &numChannels);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to get actual number of channels";
+                          << "failed to get actual number of channels";
         safeRelease(&pAudioType);
         return false;
     }
@@ -735,7 +731,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const OpenParams& openPara
             MF_MT_AUDIO_SAMPLES_PER_SECOND, &samplesPerSecond);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to get the actual sample rate";
+                          << "failed to get the actual sample rate";
         safeRelease(&pAudioType);
         return false;
     }
@@ -745,7 +741,7 @@ bool SoundSourceMediaFoundation::configureAudioStream(const OpenParams& openPara
     hr = pAudioType->GetUINT32(MF_MT_SAMPLE_SIZE, &leftoverBufferSizeInBytes);
     if (FAILED(hr)) {
         kLogger.warning() << hr
-                << "failed to get sample buffer size (in bytes)";
+                          << "failed to get sample buffer size (in bytes)";
         safeRelease(&pAudioType);
         return false;
     }
@@ -770,7 +766,8 @@ bool SoundSourceMediaFoundation::readProperties() {
 
     //Get the duration, provided as a 64-bit integer of 100-nanosecond units
     hr = m_pSourceReader->GetPresentationAttribute(MF_SOURCE_READER_MEDIASOURCE,
-        MF_PD_DURATION, &prop);
+            MF_PD_DURATION,
+            &prop);
     if (FAILED(hr)) {
         kLogger.warning() << "error getting duration";
         return false;

--- a/src/sources/soundsourcemediafoundation.h
+++ b/src/sources/soundsourcemediafoundation.h
@@ -1,13 +1,11 @@
 #ifndef MIXXX_SOUNDSOURCEMEDIAFOUNDATION_H
 #define MIXXX_SOUNDSOURCEMEDIAFOUNDATION_H
 
-
 #include <mfidl.h>
 #include <mfreadwrite.h>
 
 #include "sources/soundsourceprovider.h"
 #include "util/readaheadsamplebuffer.h"
-
 
 namespace mixxx {
 
@@ -16,14 +14,14 @@ class StreamUnitConverter final {
 
   public:
     StreamUnitConverter()
-        : m_pAudioSource(nullptr),
-          m_fromSampleFramesToStreamUnits(0),
-          m_fromStreamUnitsToSampleFrames(0) {
+            : m_pAudioSource(nullptr),
+              m_fromSampleFramesToStreamUnits(0),
+              m_fromStreamUnitsToSampleFrames(0) {
     }
     explicit StreamUnitConverter(const AudioSource* pAudioSource)
-        : m_pAudioSource(pAudioSource),
-          m_fromSampleFramesToStreamUnits(double(kStreamUnitsPerSecond) / double(pAudioSource->sampleRate())),
-          m_fromStreamUnitsToSampleFrames(double(pAudioSource->sampleRate()) / double(kStreamUnitsPerSecond)){
+            : m_pAudioSource(pAudioSource),
+              m_fromSampleFramesToStreamUnits(double(kStreamUnitsPerSecond) / double(pAudioSource->sampleRate())),
+              m_fromStreamUnitsToSampleFrames(double(pAudioSource->sampleRate()) / double(kStreamUnitsPerSecond)) {
         // The stream units should actually be much shorter than
         // sample frames to minimize jitter and rounding. Even a
         // frame at 192 kHz has a length of about 5000 ns >> 100 ns.
@@ -55,7 +53,7 @@ class StreamUnitConverter final {
     double m_fromStreamUnitsToSampleFrames;
 };
 
-class SoundSourceMediaFoundation: public SoundSource {
+class SoundSourceMediaFoundation : public SoundSource {
   public:
     explicit SoundSourceMediaFoundation(const QUrl& url);
     ~SoundSourceMediaFoundation() override;
@@ -88,7 +86,7 @@ class SoundSourceMediaFoundation: public SoundSource {
     ReadAheadSampleBuffer m_sampleBuffer;
 };
 
-class SoundSourceProviderMediaFoundation: public SoundSourceProvider {
+class SoundSourceProviderMediaFoundation : public SoundSourceProvider {
   public:
     QString getName() const override;
 
@@ -98,6 +96,5 @@ class SoundSourceProviderMediaFoundation: public SoundSourceProvider {
 };
 
 } // namespace mixxx
-
 
 #endif // MIXXX_SOUNDSOURCEMEDIAFOUNDATION_H

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -1,9 +1,9 @@
 #include "sources/soundsourcemodplug.h"
 
 #include "track/trackmetadata.h"
-#include "util/timer.h"
-#include "util/sample.h"
 #include "util/logger.h"
+#include "util/sample.h"
+#include "util/timer.h"
 
 #include <QFile>
 
@@ -50,7 +50,7 @@ unsigned int SoundSourceModPlug::s_bufferSizeLimit = 0;
 
 // reserve some static space for settings...
 void SoundSourceModPlug::configure(unsigned int bufferSizeLimit,
-        const ModPlug::ModPlug_Settings &settings) {
+        const ModPlug::ModPlug_Settings& settings) {
     s_bufferSizeLimit = bufferSizeLimit;
     ModPlug::ModPlug_SetSettings(&settings);
 }
@@ -158,10 +158,10 @@ SoundSource::OpenResult SoundSourceModPlug::tryOpen(
         }
     }
     kLogger.debug() << "Filled Sample buffer with " << m_sampleBuf.size()
-            << " samples.";
+                    << " samples.";
     kLogger.debug() << "Sample buffer has "
-            << m_sampleBuf.capacity() - m_sampleBuf.size()
-            << " samples unused capacity.";
+                    << m_sampleBuf.capacity() - m_sampleBuf.size()
+                    << " samples unused capacity.";
 
     setChannelCount(kChannelCount);
     setSampleRate(kSampleRate);

--- a/src/sources/soundsourcemodplug.h
+++ b/src/sources/soundsourcemodplug.h
@@ -14,15 +14,15 @@ namespace mixxx {
 // Class for reading tracker files using libmodplug.
 // The whole file is decoded at once and saved
 // in RAM to allow seeking and smooth operation in Mixxx.
-class SoundSourceModPlug: public SoundSource {
+class SoundSourceModPlug : public SoundSource {
   public:
-     static constexpr SINT kChannelCount = 2;
-     static constexpr SINT kSampleRate = 44100;
-     static constexpr SINT kBitsPerSample = 16;
+    static constexpr SINT kChannelCount = 2;
+    static constexpr SINT kSampleRate = 44100;
+    static constexpr SINT kBitsPerSample = 16;
 
     // apply settings for decoding
     static void configure(unsigned int bufferSizeLimit,
-            const ModPlug::ModPlug_Settings &settings);
+            const ModPlug::ModPlug_Settings& settings);
 
     explicit SoundSourceModPlug(const QUrl& url);
     ~SoundSourceModPlug() override;
@@ -44,15 +44,15 @@ class SoundSourceModPlug: public SoundSource {
 
     static unsigned int s_bufferSizeLimit; // max track buffer length (bytes)
 
-    ModPlug::ModPlugFile *m_pModFile; // modplug file descriptor
-    QByteArray m_fileBuf; // original module file data
+    ModPlug::ModPlugFile* m_pModFile; // modplug file descriptor
+    QByteArray m_fileBuf;             // original module file data
 
     typedef std::vector<SAMPLE> ModSampleBuffer;
     ModSampleBuffer m_sampleBuf;
 };
 
-class SoundSourceProviderModPlug: public SoundSourceProvider {
-public:
+class SoundSourceProviderModPlug : public SoundSourceProvider {
+  public:
     QString getName() const override;
 
     QStringList getSupportedFileExtensions() const override;

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -1,8 +1,8 @@
 #include "sources/soundsourcemp3.h"
 #include "sources/mp3decoding.h"
 
-#include "util/math.h"
 #include "util/logger.h"
+#include "util/math.h"
 
 #include <id3tag.h>
 
@@ -72,7 +72,6 @@ AudioSignal::SampleRate getSampleRateByIndex(int sampleRateIndex) {
     }
 }
 
-
 const CSAMPLE kMadScale = CSAMPLE_PEAK / CSAMPLE(MAD_F_ONE);
 
 inline CSAMPLE madScaleSampleValue(mad_fixed_t sampleValue) {
@@ -80,11 +79,10 @@ inline CSAMPLE madScaleSampleValue(mad_fixed_t sampleValue) {
 }
 
 // Optimization: Reserve initial capacity for seek frame list
-const SINT kMinutesPerFile = 10; // enough for the majority of files (tunable)
-const SINT kSecondsPerMinute = 60; // fixed
+const SINT kMinutesPerFile = 10;        // enough for the majority of files (tunable)
+const SINT kSecondsPerMinute = 60;      // fixed
 const SINT kMaxMp3FramesPerSecond = 39; // fixed: 1 MP3 frame = 26 ms -> ~ 1000 / 26
-const SINT kSeekFrameListCapacity = kMinutesPerFile
-        * kSecondsPerMinute * kMaxMp3FramesPerSecond;
+const SINT kSeekFrameListCapacity = kMinutesPerFile * kSecondsPerMinute * kMaxMp3FramesPerSecond;
 
 inline QString formatHeaderFlags(int headerFlags) {
     return QString("0x%1").arg(headerFlags, 4, 16, QLatin1Char('0'));
@@ -92,13 +90,13 @@ inline QString formatHeaderFlags(int headerFlags) {
 
 void logFrameHeader(QDebug logger, const mad_header& madHeader) {
     logger << "MP3 frame header |"
-            << "layer:" << madHeader.layer
-            << "mode:" << madHeader.mode
-            << "#channels:" << MAD_NCHANNELS(&madHeader)
-            << "#samples:" << MAD_NSBSAMPLES(&madHeader)
-            << "bitrate:" << madHeader.bitrate
-            << "samplerate:" << madHeader.samplerate
-            << "flags:" << formatHeaderFlags(madHeader.flags);
+           << "layer:" << madHeader.layer
+           << "mode:" << madHeader.mode
+           << "#channels:" << MAD_NCHANNELS(&madHeader)
+           << "#samples:" << MAD_NSBSAMPLES(&madHeader)
+           << "bitrate:" << madHeader.bitrate
+           << "samplerate:" << madHeader.samplerate
+           << "flags:" << formatHeaderFlags(madHeader.flags);
 }
 
 inline bool isRecoverableError(const mad_stream& madStream) {
@@ -128,14 +126,14 @@ bool decodeFrameHeader(
         if (isUnrecoverableError(*pMadStream)) {
             DEBUG_ASSERT(!isStreamValid(*pMadStream));
             kLogger.warning() << "Unrecoverable MP3 header decoding error:"
-                    << mad_stream_errorstr(pMadStream);
+                              << mad_stream_errorstr(pMadStream);
             return false;
         }
-    #ifndef QT_NO_DEBUG_OUTPUT
+#ifndef QT_NO_DEBUG_OUTPUT
         // Logging of MP3 frame headers should only be enabled
         // for debugging purposes.
         logFrameHeader(kLogger.debug(), *pMadHeader);
-    #endif
+#endif
         if (isRecoverableError(*pMadStream)) {
             if ((MAD_ERROR_LOSTSYNC == pMadStream->error) && skipId3Tag) {
                 long tagsize = id3_tag_query(pMadStream->this_frame,
@@ -149,7 +147,7 @@ bool decodeFrameHeader(
                 }
             }
             kLogger.warning() << "Recoverable MP3 header decoding error:"
-                    << mad_stream_errorstr(pMadStream);
+                              << mad_stream_errorstr(pMadStream);
             logFrameHeader(kLogger.warning(), *pMadHeader);
             return false;
         }
@@ -263,8 +261,8 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(
         const long madFrameLength = mad_timer_count(madHeader.duration, madUnits);
         if (0 >= madFrameLength) {
             kLogger.warning() << "Skipping MP3 frame with invalid length"
-                    << madFrameLength
-                    << "in:" << m_file.fileName();
+                              << madFrameLength
+                              << "in:" << m_file.fileName();
             // Skip frame
             continue;
         }
@@ -288,7 +286,7 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(
         const int sampleRateIndex = getIndexBySampleRate(SampleRate(madSampleRate));
         if (sampleRateIndex >= kSampleRateCount) {
             kLogger.warning() << "Invalid sample rate:" << m_file.fileName()
-                    << madSampleRate;
+                              << madSampleRate;
             // Abort
             mad_header_finish(&madHeader);
             return OpenResult::Failed;
@@ -320,7 +318,7 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(
         DEBUG_ASSERT(!MAD_RECOVERABLE(m_madStream.error));
         if (MAD_ERROR_BUFLEN != m_madStream.error) {
             kLogger.warning() << "Unrecoverable MP3 header error:"
-                    << mad_stream_errorstr(&m_madStream);
+                              << mad_stream_errorstr(&m_madStream);
             // Abort
             return OpenResult::Failed;
         }
@@ -329,7 +327,7 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(
     if (m_seekFrameList.empty()) {
         // This is not a working MP3 file.
         kLogger.warning() << "This is not a working MP3 file:"
-                << m_file.fileName();
+                          << m_file.fileName();
         // Abort
         return OpenResult::Failed;
     }
@@ -349,7 +347,7 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(
 
     if (differentRates > 1) {
         kLogger.warning() << "Differing sample rate in some headers:"
-                   << m_file.fileName();
+                          << m_file.fileName();
         for (int i = 0; i < kSampleRateCount; ++i) {
             if (0 < headerPerSampleRate[i]) {
                 kLogger.warning() << headerPerSampleRate[i] << "MP3 headers with sample rate" << getSampleRateByIndex(i);
@@ -448,8 +446,7 @@ void SoundSourceMp3::restartDecoding(
     }
 
     // Fill input buffer
-    mad_stream_buffer(&m_madStream, seekFrame.pInputData,
-            m_fileSize - (seekFrame.pInputData - m_pFileData));
+    mad_stream_buffer(&m_madStream, seekFrame.pInputData, m_fileSize - (seekFrame.pInputData - m_pFileData));
 
     if (frameIndexMin() < seekFrame.frameIndex) {
         // Muting is done here to eliminate potential pops/clicks
@@ -459,8 +456,7 @@ void SoundSourceMp3::restartDecoding(
         mad_synth_mute(&m_madSynth);
     }
 
-    if (decodeFrameHeader(&m_madFrame.header, &m_madStream, false)
-            && isStreamValid(m_madStream)) {
+    if (decodeFrameHeader(&m_madFrame.header, &m_madStream, false) && isStreamValid(m_madStream)) {
         m_curFrameIndex = seekFrame.frameIndex;
     } else {
         // Failure -> Seek to EOF
@@ -528,7 +524,6 @@ SINT SoundSourceMp3::findSeekFrameIndex(
 
 ReadableSampleFrames SoundSourceMp3::readSampleFramesClamped(
         WritableSampleFrames writableSampleFrames) {
-
     const SINT firstFrameIndex = writableSampleFrames.frameIndexRange().start();
 
     if ((m_curFrameIndex != firstFrameIndex)) {
@@ -539,8 +534,8 @@ ReadableSampleFrames SoundSourceMp3::readSampleFramesClamped(
         // some consistency checks
         DEBUG_ASSERT((curSeekFrameIndex >= seekFrameIndex) || (m_curFrameIndex < firstFrameIndex));
         DEBUG_ASSERT((curSeekFrameIndex <= seekFrameIndex) || (m_curFrameIndex > firstFrameIndex));
-        if ((frameIndexMax() <= m_curFrameIndex) || // out of range
-                (firstFrameIndex < m_curFrameIndex) || // seek backward
+        if ((frameIndexMax() <= m_curFrameIndex) ||                                    // out of range
+                (firstFrameIndex < m_curFrameIndex) ||                                 // seek backward
                 (seekFrameIndex > (curSeekFrameIndex + kMp3SeekFramePrefetchCount))) { // jump forward
 
             // Adjust the seek frame index for prefetching
@@ -562,9 +557,7 @@ ReadableSampleFrames SoundSourceMp3::readSampleFramesClamped(
         DEBUG_ASSERT(m_curFrameIndex <= firstFrameIndex);
         const auto precedingFrames =
                 IndexRange::between(m_curFrameIndex, firstFrameIndex);
-        if (!precedingFrames.empty()
-                && (precedingFrames != readSampleFramesClamped(
-                        WritableSampleFrames(precedingFrames)).frameIndexRange())) {
+        if (!precedingFrames.empty() && (precedingFrames != readSampleFramesClamped(WritableSampleFrames(precedingFrames)).frameIndexRange())) {
             kLogger.warning()
                     << "Failed to skip preceding frames"
                     << precedingFrames;
@@ -629,14 +622,14 @@ ReadableSampleFrames SoundSourceMp3::readSampleFramesClamped(
                         }
                         if (m_curFrameIndex < frameIndexMax()) {
                             kLogger.warning() << "Failed to decode the end of the MP3 stream"
-                                    << m_curFrameIndex << "<" << frameIndexMax();
+                                              << m_curFrameIndex << "<" << frameIndexMax();
                         }
                     }
                     break;
                 }
                 if (isUnrecoverableError(m_madStream)) {
                     kLogger.warning() << "Unrecoverable MP3 frame decoding error:"
-                            << mad_stream_errorstr(&m_madStream);
+                                      << mad_stream_errorstr(&m_madStream);
                     // Abort decoding
                     break;
                 }
@@ -654,7 +647,7 @@ ReadableSampleFrames SoundSourceMp3::readSampleFramesClamped(
                             }
                         } else {
                             kLogger.info() << "Recoverable MP3 frame decoding error:"
-                                    << mad_stream_errorstr(&m_madStream);
+                                           << mad_stream_errorstr(&m_madStream);
                         }
                     }
                     // Continue decoding
@@ -674,8 +667,8 @@ ReadableSampleFrames SoundSourceMp3::readSampleFramesClamped(
             const SINT madFrameChannelCount = MAD_NCHANNELS(&m_madFrame.header);
             if (madFrameChannelCount != channelCount()) {
                 kLogger.warning() << "MP3 frame header with mismatching number of channels"
-                        << madFrameChannelCount << "<>" << channelCount()
-                        << " - aborting";
+                                  << madFrameChannelCount << "<>" << channelCount()
+                                  << " - aborting";
                 abortReading = true;
             }
 #endif
@@ -683,11 +676,11 @@ ReadableSampleFrames SoundSourceMp3::readSampleFramesClamped(
             // Once decoded the frame is synthesized to PCM samples
             mad_synth_frame(&m_madSynth, &m_madFrame);
 #ifndef QT_NO_DEBUG_OUTPUT
-            const SINT madSynthSampleRate =  m_madSynth.pcm.samplerate;
+            const SINT madSynthSampleRate = m_madSynth.pcm.samplerate;
             if (madSynthSampleRate != sampleRate()) {
                 kLogger.warning() << "Reading MP3 data with different sample rate"
-                        << madSynthSampleRate << "<>" << sampleRate()
-                        << " - aborting";
+                                  << madSynthSampleRate << "<>" << sampleRate()
+                                  << " - aborting";
                 abortReading = true;
             }
 #endif
@@ -713,7 +706,7 @@ ReadableSampleFrames SoundSourceMp3::readSampleFramesClamped(
             DEBUG_ASSERT(madSynthChannelCount <= channelCount());
             if (madSynthChannelCount != channelCount()) {
                 kLogger.warning() << "Reading MP3 data with different number of channels"
-                        << madSynthChannelCount << "<>" << channelCount();
+                                  << madSynthChannelCount << "<>" << channelCount();
             }
             if (madSynthChannelCount == 1) {
                 // MP3 frame contains a mono signal

--- a/src/sources/soundsourcemp3.h
+++ b/src/sources/soundsourcemp3.h
@@ -50,7 +50,7 @@ class SoundSourceMp3 final : public SoundSource {
      */
     typedef std::vector<SeekFrameType> SeekFrameList;
     SeekFrameList m_seekFrameList; // ordered-by frameIndex
-    SINT m_avgSeekFrameCount; // avg. sample frames per MP3 frame
+    SINT m_avgSeekFrameCount;      // avg. sample frames per MP3 frame
 
     void addSeekFrame(SINT frameIndex, const unsigned char* pInputData);
 
@@ -75,7 +75,7 @@ class SoundSourceMp3 final : public SoundSource {
     std::vector<unsigned char> m_leftoverBuffer;
 };
 
-class SoundSourceProviderMp3: public SoundSourceProvider {
+class SoundSourceProviderMp3 : public SoundSourceProvider {
   public:
     QString getName() const override;
 

--- a/src/sources/soundsourceoggvorbis.cpp
+++ b/src/sources/soundsourceoggvorbis.cpp
@@ -16,17 +16,16 @@ const int kCurrentBitstreamLink = -1; // retrieve ... for the current bitstream
 
 // Parameter for ov_pcm_total()
 // See also: https://xiph.org/vorbis/doc/vorbisfile/ov_pcm_total.html
-const int kEntireBitstreamLink  = -1; // retrieve ... for the entire physical bitstream
+const int kEntireBitstreamLink = -1; // retrieve ... for the entire physical bitstream
 
 } // anonymous namespace
 
 //static
 ov_callbacks SoundSourceOggVorbis::s_callbacks = {
-    SoundSourceOggVorbis::ReadCallback,
-    SoundSourceOggVorbis::SeekCallback,
-    SoundSourceOggVorbis::CloseCallback,
-    SoundSourceOggVorbis::TellCallback
-};
+        SoundSourceOggVorbis::ReadCallback,
+        SoundSourceOggVorbis::SeekCallback,
+        SoundSourceOggVorbis::CloseCallback,
+        SoundSourceOggVorbis::TellCallback};
 
 SoundSourceOggVorbis::SoundSourceOggVorbis(const QUrl& url)
         : SoundSource(url, "ogg"),
@@ -57,13 +56,13 @@ SoundSource::OpenResult SoundSourceOggVorbis::tryOpen(
     case OV_ENOTVORBIS:
     case OV_EVERSION:
         kLogger.warning()
-            << "Unsupported format in"
-            << getUrlString();
+                << "Unsupported format in"
+                << getUrlString();
         return OpenResult::Aborted;
     default:
         kLogger.warning()
-            << "Failed to initialize decoder for"
-            << getUrlString();
+                << "Failed to initialize decoder for"
+                << getUrlString();
         return OpenResult::Failed;
     }
 
@@ -116,7 +115,6 @@ void SoundSourceOggVorbis::close() {
 
 ReadableSampleFrames SoundSourceOggVorbis::readSampleFramesClamped(
         WritableSampleFrames writableSampleFrames) {
-
     const SINT firstFrameIndex = writableSampleFrames.frameIndexRange().start();
 
     if (m_curFrameIndex != firstFrameIndex) {
@@ -152,8 +150,7 @@ ReadableSampleFrames SoundSourceOggVorbis::readSampleFramesClamped(
         // This is an exception from the rule not to any types with
         // differing sizes on different platforms.
         // https://bugs.launchpad.net/mixxx/+bug/1094143
-        const long readResult = ov_read_float(&m_vf, &pcmChannels,
-                numberOfFramesRemaining, &currentSection);
+        const long readResult = ov_read_float(&m_vf, &pcmChannels, numberOfFramesRemaining, &currentSection);
         if (0 < readResult) {
             m_curFrameIndex += readResult;
             if (pSampleBuffer) {
@@ -194,60 +191,57 @@ ReadableSampleFrames SoundSourceOggVorbis::readSampleFramesClamped(
                     std::min(writableSampleFrames.writableLength(), frames2samples(numberOfFrames))));
 }
 
-
 //static
-size_t SoundSourceOggVorbis::ReadCallback(void *ptr, size_t size, size_t nmemb,
-       void *datasource) {
-   if (!size || !nmemb) {
-       return 0;
-   }
-   QFile* pFile = static_cast<QFile*>(datasource);
-   if (!pFile) {
-       return 0;
-   }
+size_t SoundSourceOggVorbis::ReadCallback(void* ptr, size_t size, size_t nmemb, void* datasource) {
+    if (!size || !nmemb) {
+        return 0;
+    }
+    QFile* pFile = static_cast<QFile*>(datasource);
+    if (!pFile) {
+        return 0;
+    }
 
-   nmemb = math_min<size_t>((pFile->size() - pFile->pos()) / size, nmemb);
-   pFile->read((char*)ptr, nmemb * size);
-   return nmemb;
+    nmemb = math_min<size_t>((pFile->size() - pFile->pos()) / size, nmemb);
+    pFile->read((char*)ptr, nmemb * size);
+    return nmemb;
 }
 
 //static
-int SoundSourceOggVorbis::SeekCallback(void *datasource, ogg_int64_t offset,
-       int whence) {
-   QFile* pFile = static_cast<QFile*>(datasource);
-   if (!pFile) {
-       return 0;
-   }
+int SoundSourceOggVorbis::SeekCallback(void* datasource, ogg_int64_t offset, int whence) {
+    QFile* pFile = static_cast<QFile*>(datasource);
+    if (!pFile) {
+        return 0;
+    }
 
-   switch(whence) {
-   case SEEK_SET:
-       return pFile->seek(offset) ? 0 : -1;
-   case SEEK_CUR:
-       return pFile->seek(pFile->pos() + offset) ? 0 : -1;
-   case SEEK_END:
-       return pFile->seek(pFile->size() + offset) ? 0 : -1;
-   default:
-       return -1;
-   }
+    switch (whence) {
+    case SEEK_SET:
+        return pFile->seek(offset) ? 0 : -1;
+    case SEEK_CUR:
+        return pFile->seek(pFile->pos() + offset) ? 0 : -1;
+    case SEEK_END:
+        return pFile->seek(pFile->size() + offset) ? 0 : -1;
+    default:
+        return -1;
+    }
 }
 
 //static
 int SoundSourceOggVorbis::CloseCallback(void* datasource) {
-   QFile* pFile = static_cast<QFile*>(datasource);
-   if (!pFile) {
-       return 0;
-   }
-   pFile->close();
-   return 0;
+    QFile* pFile = static_cast<QFile*>(datasource);
+    if (!pFile) {
+        return 0;
+    }
+    pFile->close();
+    return 0;
 }
 
 //static
 long SoundSourceOggVorbis::TellCallback(void* datasource) {
-   QFile* pFile = static_cast<QFile*>(datasource);
-   if (!pFile) {
-       return 0;
-   }
-   return pFile->pos();
+    QFile* pFile = static_cast<QFile*>(datasource);
+    if (!pFile) {
+        return 0;
+    }
+    return pFile->pos();
 }
 
 QString SoundSourceProviderOggVorbis::getName() const {

--- a/src/sources/soundsourceoggvorbis.h
+++ b/src/sources/soundsourceoggvorbis.h
@@ -13,7 +13,7 @@ namespace mixxx {
 
 class SoundSourceOggVorbis final : public SoundSource {
   public:
-    explicit SoundSourceOggVorbis(const QUrl& url);
+    explicit SoundSourceOggVorbis(const QUrl &url);
     ~SoundSourceOggVorbis() override;
 
     void close() override;
@@ -25,10 +25,9 @@ class SoundSourceOggVorbis final : public SoundSource {
   private:
     OpenResult tryOpen(
             OpenMode mode,
-            const OpenParams& params) override;
+            const OpenParams &params) override;
 
-    static size_t ReadCallback(void *ptr, size_t size, size_t nmemb,
-            void *datasource);
+    static size_t ReadCallback(void *ptr, size_t size, size_t nmemb, void *datasource);
     static int SeekCallback(void *datasource, ogg_int64_t offset, int whence);
     static int CloseCallback(void *datasource);
     static long TellCallback(void *datasource);
@@ -41,13 +40,13 @@ class SoundSourceOggVorbis final : public SoundSource {
     SINT m_curFrameIndex;
 };
 
-class SoundSourceProviderOggVorbis: public SoundSourceProvider {
+class SoundSourceProviderOggVorbis : public SoundSourceProvider {
   public:
     QString getName() const override;
 
     QStringList getSupportedFileExtensions() const override;
 
-    SoundSourcePointer newSoundSource(const QUrl& url) override {
+    SoundSourcePointer newSoundSource(const QUrl &url) override {
         return newSoundSourceFromUrl<SoundSourceOggVorbis>(url);
     }
 };

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -29,10 +29,10 @@ constexpr int kCurrentStreamLink = -1; // get ... of the current (stream) link
 
 // Parameter for op_pcm_total() and op_bitrate()
 // See also: https://mf4.xiph.org/jenkins/view/opus/job/opusfile-unix/ws/doc/html/group__stream__info.html
-constexpr int kEntireStreamLink  = -1; // get ... of the whole/entire stream
+constexpr int kEntireStreamLink = -1; // get ... of the whole/entire stream
 
 class OggOpusFileOwner {
-public:
+  public:
     explicit OggOpusFileOwner(OggOpusFile* pFile)
             : m_pFile(pFile) {
     }
@@ -51,7 +51,8 @@ public:
         m_pFile = nullptr;
         return pFile;
     }
-private:
+
+  private:
     OggOpusFile* m_pFile;
 };
 
@@ -123,7 +124,7 @@ SoundSourceOpus::importTrackMetadataAndCoverImage(
             1000000 * dTotalFrames / pTrackMetadata->getSampleRate()));
 
 #ifndef TAGLIB_HAS_OPUSFILE
-    const OpusTags *l_ptrOpusTags = op_tags(pOggOpusFile, -1);
+    const OpusTags* l_ptrOpusTags = op_tags(pOggOpusFile, -1);
     bool hasDate = false;
     for (int i = 0; i < l_ptrOpusTags->comments; ++i) {
         QString l_SWholeTag = QString(l_ptrOpusTags->user_comments[i]);
@@ -273,7 +274,6 @@ void SoundSourceOpus::close() {
 
 ReadableSampleFrames SoundSourceOpus::readSampleFramesClamped(
         WritableSampleFrames writableSampleFrames) {
-
     const SINT firstFrameIndex = writableSampleFrames.frameIndexRange().start();
 
     if (m_curFrameIndex != firstFrameIndex) {
@@ -306,9 +306,7 @@ ReadableSampleFrames SoundSourceOpus::readSampleFramesClamped(
         DEBUG_ASSERT(m_curFrameIndex <= firstFrameIndex);
         const auto precedingFrames =
                 IndexRange::between(m_curFrameIndex, firstFrameIndex);
-        if (!precedingFrames.empty()
-                && (precedingFrames != readSampleFramesClamped(
-                        WritableSampleFrames(precedingFrames)).frameIndexRange())) {
+        if (!precedingFrames.empty() && (precedingFrames != readSampleFramesClamped(WritableSampleFrames(precedingFrames)).frameIndexRange())) {
             kLogger.warning()
                     << "Failed to skip preceding frames"
                     << precedingFrames;
@@ -356,7 +354,7 @@ ReadableSampleFrames SoundSourceOpus::readSampleFramesClamped(
             numberOfFramesRemaining -= readResult;
         } else {
             kLogger.warning() << "Failed to read sample data from OggOpus file:"
-                    << readResult;
+                              << readResult;
             break; // abort
         }
     }

--- a/src/sources/soundsourceopus.h
+++ b/src/sources/soundsourceopus.h
@@ -40,14 +40,14 @@ class SoundSourceOpus final : public SoundSource {
             OpenMode mode,
             const OpenParams& params) override;
 
-    OggOpusFile *m_pOggOpusFile;
+    OggOpusFile* m_pOggOpusFile;
 
     SampleBuffer m_prefetchSampleBuffer;
 
     SINT m_curFrameIndex;
 };
 
-class SoundSourceProviderOpus: public SoundSourceProvider {
+class SoundSourceProviderOpus : public SoundSourceProvider {
   public:
     QString getName() const override;
 

--- a/src/sources/soundsourceprovider.h
+++ b/src/sources/soundsourceprovider.h
@@ -26,8 +26,9 @@ enum class SoundSourceProviderPriority {
 // The implementation of a SoundSourceProvider must be thread-safe, because
 // a single instance might be accessed concurrently from different threads.
 class SoundSourceProvider {
-public:
-    virtual ~SoundSourceProvider() {}
+  public:
+    virtual ~SoundSourceProvider() {
+    }
 
     // A user-readable name that identifies this provider.
     virtual QString getName() const = 0;

--- a/src/sources/soundsourceproviderregistry.cpp
+++ b/src/sources/soundsourceproviderregistry.cpp
@@ -16,11 +16,11 @@ void SoundSourceProviderRegistry::registerProvider(
             pProvider->getSupportedFileExtensions());
     if (supportedFileExtensions.isEmpty()) {
         kLogger.warning() << "SoundSource provider"
-                << pProvider->getName()
-                << "does not support any file extensions";
+                          << pProvider->getName()
+                          << "does not support any file extensions";
         return; // abort registration
     }
-    for (const auto& fileExt: supportedFileExtensions) {
+    for (const auto& fileExt : supportedFileExtensions) {
         SoundSourceProviderPriority providerPriority(
                 pProvider->getPriorityHint(fileExt));
         registerProviderForFileExtension(
@@ -48,7 +48,7 @@ void SoundSourceProviderRegistry::addRegistrationForFileExtension(
 }
 
 void SoundSourceProviderRegistry::insertRegistration(
-        QList<SoundSourceProviderRegistration> *pRegistrations,
+        QList<SoundSourceProviderRegistration>* pRegistrations,
         SoundSourceProviderRegistration registration) {
     QList<SoundSourceProviderRegistration>::iterator listIter(
             pRegistrations->begin());
@@ -75,7 +75,7 @@ void SoundSourceProviderRegistry::deregisterProvider(
         const SoundSourceProviderPointer& pProvider) {
     const QStringList supportedFileExtensions(
             pProvider->getSupportedFileExtensions());
-    for (const auto& fileExt: supportedFileExtensions) {
+    for (const auto& fileExt : supportedFileExtensions) {
         deregisterProviderForFileExtension(fileExt, pProvider);
     }
 }
@@ -111,4 +111,4 @@ SoundSourceProviderRegistry::getRegistrationsForFileExtension(
     }
 }
 
-} // Mixxx
+} // namespace mixxx

--- a/src/sources/soundsourceproviderregistry.h
+++ b/src/sources/soundsourceproviderregistry.h
@@ -8,7 +8,7 @@
 namespace mixxx {
 
 class SoundSourceProviderRegistration {
-public:
+  public:
     const SoundSourceProviderPointer& getProvider() const {
         return m_pProvider;
     }
@@ -16,13 +16,13 @@ public:
         return m_providerPriority;
     }
 
-private:
+  private:
     friend class SoundSourceProviderRegistry;
     SoundSourceProviderRegistration(
             SoundSourceProviderPointer pProvider,
             SoundSourceProviderPriority providerPriority)
-        : m_pProvider(pProvider),
-          m_providerPriority(providerPriority) {
+            : m_pProvider(pProvider),
+              m_providerPriority(providerPriority) {
     }
 
     SoundSourceProviderPointer m_pProvider;
@@ -31,7 +31,7 @@ private:
 
 // Registry for SoundSourceProviders
 class SoundSourceProviderRegistry {
-public:
+  public:
     // Registers a provider for all supported file extensions
     // with their cooperative priority hint.
     void registerProvider(
@@ -63,7 +63,7 @@ public:
     QList<SoundSourceProviderRegistration> getRegistrationsForFileExtension(
             const QString& fileExtension) const;
 
-private:
+  private:
     void addRegistrationForFileExtension(
             const QString& fileExtension,
             SoundSourceProviderRegistration registration);

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -35,12 +35,12 @@
 #include "sources/soundsourcemediafoundation.h"
 #endif
 
-#include "library/coverartutils.h"
 #include "library/coverartcache.h"
+#include "library/coverartutils.h"
 #include "track/globaltrackcache.h"
 #include "util/cmdlineargs.h"
-#include "util/regex.h"
 #include "util/logger.h"
+#include "util/regex.h"
 
 //Static memory allocation
 /*static*/ mixxx::SoundSourceProviderRegistry SoundSourceProxy::s_soundSourceProviders;
@@ -119,7 +119,7 @@ void SoundSourceProxy::registerSoundSourceProviders() {
     s_soundSourceProviders.registerProvider(
             std::make_shared<mixxx::SoundSourceProviderCoreAudio>());
 #endif
-#ifdef  __MEDIAFOUNDATION__
+#ifdef __MEDIAFOUNDATION__
     s_soundSourceProviders.registerProvider(
             std::make_shared<mixxx::SoundSourceProviderMediaFoundation>());
 #endif
@@ -127,12 +127,12 @@ void SoundSourceProxy::registerSoundSourceProviders() {
     const QStringList supportedFileExtensions(
             s_soundSourceProviders.getRegisteredFileExtensions());
     if (kLogger.infoEnabled()) {
-        for (const auto &supportedFileExtension: supportedFileExtensions) {
+        for (const auto& supportedFileExtension : supportedFileExtensions) {
             kLogger.info() << "SoundSource providers for file extension" << supportedFileExtension;
             const QList<mixxx::SoundSourceProviderRegistration> registrationsForFileExtension(
                     s_soundSourceProviders.getRegistrationsForFileExtension(
                             supportedFileExtension));
-            for (const auto& registration: registrationsForFileExtension) {
+            for (const auto& registration : registrationsForFileExtension) {
                 kLogger.info() << " " << static_cast<int>(registration.getProviderPriority())
                                << ":" << registration.getProvider()->getName();
             }
@@ -141,7 +141,7 @@ void SoundSourceProxy::registerSoundSourceProviders() {
 
     // Turn the file extension list into a [ "*.mp3", "*.wav", ... ] style string list
     s_supportedFileNamePatterns.clear();
-    for (const auto& supportedFileExtension: supportedFileExtensions) {
+    for (const auto& supportedFileExtension : supportedFileExtensions) {
         s_supportedFileNamePatterns += QString("*.%1").arg(supportedFileExtension);
     }
 
@@ -197,7 +197,6 @@ SoundSourceProxy::findSoundSourceProviderRegistrations(
     return registrationsForFileExtension;
 }
 
-
 //static
 TrackPointer SoundSourceProxy::importTemporaryTrack(
         QFileInfo fileInfo,
@@ -243,18 +242,18 @@ SoundSourceProxy::exportTrackMetadataBeforeSaving(Track* pTrack) {
 
 SoundSourceProxy::SoundSourceProxy(
         TrackPointer pTrack)
-    : m_pTrack(std::move(pTrack)),
-      m_url(getCanonicalUrlForTrack(m_pTrack.get())),
-      m_soundSourceProviderRegistrations(findSoundSourceProviderRegistrations(m_url)),
-      m_soundSourceProviderRegistrationIndex(0) {
+        : m_pTrack(std::move(pTrack)),
+          m_url(getCanonicalUrlForTrack(m_pTrack.get())),
+          m_soundSourceProviderRegistrations(findSoundSourceProviderRegistrations(m_url)),
+          m_soundSourceProviderRegistrationIndex(0) {
     initSoundSource();
 }
 
 SoundSourceProxy::SoundSourceProxy(
         const QUrl& url)
-    : m_url(url),
-      m_soundSourceProviderRegistrations(findSoundSourceProviderRegistrations(m_url)),
-      m_soundSourceProviderRegistrationIndex(0) {
+        : m_url(url),
+          m_soundSourceProviderRegistrations(findSoundSourceProviderRegistrations(m_url)),
+          m_soundSourceProviderRegistrationIndex(0) {
     initSoundSource();
 }
 
@@ -284,7 +283,7 @@ void SoundSourceProxy::initSoundSource() {
         if (!pProvider) {
             if (!getUrl().isEmpty()) {
                 kLogger.warning() << "No SoundSourceProvider for file"
-                           << getUrl().toString();
+                                  << getUrl().toString();
             }
             // Failure
             return;
@@ -292,9 +291,9 @@ void SoundSourceProxy::initSoundSource() {
         m_pSoundSource = pProvider->newSoundSource(m_url);
         if (!m_pSoundSource) {
             kLogger.warning() << "SoundSourceProvider"
-                       << pProvider->getName()
-                       << "failed to create a SoundSource for file"
-                       << getUrl().toString();
+                              << pProvider->getName()
+                              << "failed to create a SoundSource for file"
+                              << getUrl().toString();
             // Switch to next provider...
             nextSoundSourceProvider();
             // ...and continue loop
@@ -302,47 +301,47 @@ void SoundSourceProxy::initSoundSource() {
         } else {
             if (kLogger.debugEnabled()) {
                 kLogger.debug() << "SoundSourceProvider"
-                         << pProvider->getName()
-                         << "created a SoundSource for file"
-                         << getUrl().toString()
-                         << "of type"
-                         << m_pSoundSource->getType();
+                                << pProvider->getName()
+                                << "created a SoundSource for file"
+                                << getUrl().toString()
+                                << "of type"
+                                << m_pSoundSource->getType();
             }
         }
     }
 }
 
 namespace {
-    // Parses artist/title from the file name and returns the file type.
-    // Assumes that the file name is written like: "artist - title.xxx"
-    // or "artist_-_title.xxx".
-    // This function does not overwrite any existing (non-empty) artist
-    // and title fields!
-    bool parseMetadataFromFileName(mixxx::TrackMetadata* pTrackMetadata, QString fileName) {
-        fileName.replace("_", " ");
-        QString titleWithFileType;
-        bool parsed = false;
-        if (fileName.count('-') == 1) {
-            if (pTrackMetadata->getTrackInfo().getArtist().isEmpty()) {
-                const QString artist(fileName.section('-', 0, 0).trimmed());
-                if (!artist.isEmpty()) {
-                    pTrackMetadata->refTrackInfo().setArtist(artist);
-                    parsed = true;
-                }
-            }
-            titleWithFileType = fileName.section('-', 1, 1).trimmed();
-        } else {
-            titleWithFileType = fileName.trimmed();
-        }
-        if (pTrackMetadata->getTrackInfo().getTitle().isEmpty()) {
-            const QString title(titleWithFileType.section('.', 0, -2).trimmed());
-            if (!title.isEmpty()) {
-                pTrackMetadata->refTrackInfo().setTitle(title);
+// Parses artist/title from the file name and returns the file type.
+// Assumes that the file name is written like: "artist - title.xxx"
+// or "artist_-_title.xxx".
+// This function does not overwrite any existing (non-empty) artist
+// and title fields!
+bool parseMetadataFromFileName(mixxx::TrackMetadata* pTrackMetadata, QString fileName) {
+    fileName.replace("_", " ");
+    QString titleWithFileType;
+    bool parsed = false;
+    if (fileName.count('-') == 1) {
+        if (pTrackMetadata->getTrackInfo().getArtist().isEmpty()) {
+            const QString artist(fileName.section('-', 0, 0).trimmed());
+            if (!artist.isEmpty()) {
+                pTrackMetadata->refTrackInfo().setArtist(artist);
                 parsed = true;
             }
         }
-        return parsed;
+        titleWithFileType = fileName.section('-', 1, 1).trimmed();
+    } else {
+        titleWithFileType = fileName.trimmed();
     }
+    if (pTrackMetadata->getTrackInfo().getTitle().isEmpty()) {
+        const QString title(titleWithFileType.section('.', 0, -2).trimmed());
+        if (!title.isEmpty()) {
+            pTrackMetadata->refTrackInfo().setTitle(title);
+            parsed = true;
+        }
+    }
+    return parsed;
+}
 } // anonymous namespace
 
 void SoundSourceProxy::updateTrackFromSource(
@@ -376,7 +375,7 @@ void SoundSourceProxy::updateTrackFromSource(
     // if the user did not explicitly choose to (re-)import metadata
     // explicitly from this file.
     if (metadataSynchronized &&
-        (importTrackMetadataMode == ImportTrackMetadataMode::Once)) {
+            (importTrackMetadataMode == ImportTrackMetadataMode::Once)) {
         if (kLogger.debugEnabled()) {
             kLogger.debug()
                     << "Skip importing of track metadata and embedded cover art from file"
@@ -522,21 +521,21 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSo
         // identify files in the log file that might have caused a
         // crash while importing metadata or decoding audio subsequently.
         kLogger.debug() << "Opening file"
-                << getUrl().toString()
-                << "with provider"
-                << getSoundSourceProvider()->getName()
-                << "using mode"
-                << openMode;
+                        << getUrl().toString()
+                        << "with provider"
+                        << getSoundSourceProvider()->getName()
+                        << "using mode"
+                        << openMode;
         const mixxx::SoundSource::OpenResult openResult =
                 m_pSoundSource->open(openMode, params);
         if ((openResult == mixxx::SoundSource::OpenResult::Aborted) ||
                 ((openMode == mixxx::SoundSource::OpenMode::Strict) && (openResult == mixxx::SoundSource::OpenResult::Failed))) {
             kLogger.warning() << "Unable to open file"
-                    << getUrl().toString()
-                    << "with provider"
-                    << getSoundSourceProvider()->getName()
-                    << "using mode"
-                    << openMode;
+                              << getUrl().toString()
+                              << "with provider"
+                              << getSoundSourceProvider()->getName()
+                              << "using mode"
+                              << openMode;
             // Continue with the next SoundSource provider
             nextSoundSourceProvider();
             if (!getSoundSourceProvider() && (openMode == mixxx::SoundSource::OpenMode::Strict)) {
@@ -554,7 +553,7 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSo
             DEBUG_ASSERT(m_pAudioSource);
             if (m_pAudioSource->frameIndexRange().empty()) {
                 kLogger.warning() << "File is empty"
-                           << getUrl().toString();
+                                  << getUrl().toString();
             }
             // Overwrite metadata with actual audio properties
             if (m_pTrack) {
@@ -573,9 +572,9 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSo
             }
         } else {
             kLogger.warning() << "Failed to open file"
-                       << getUrl().toString()
-                       << "with provider"
-                       << getSoundSourceProvider()->getName();
+                              << getUrl().toString()
+                              << "with provider"
+                              << getSoundSourceProvider()->getName();
             if (openResult == mixxx::SoundSource::OpenResult::Succeeded) {
                 m_pSoundSource->close(); // cleanup
             }
@@ -588,7 +587,7 @@ mixxx::AudioSourcePointer SoundSourceProxy::openAudioSource(const mixxx::AudioSo
     // All available providers have returned OpenResult::Aborted when
     // getting here. m_pSoundSource might already be invalid/null!
     kLogger.warning() << "Unable to decode file"
-            << getUrl().toString();
+                      << getUrl().toString();
     DEBUG_ASSERT(!m_pAudioSource);
     return m_pAudioSource;
 }
@@ -600,7 +599,7 @@ void SoundSourceProxy::closeAudioSource() {
         m_pAudioSource = mixxx::AudioSourcePointer();
         if (kLogger.debugEnabled()) {
             kLogger.debug() << "Closed AudioSource for file"
-                    << getUrl().toString();
+                            << getUrl().toString();
         }
     }
 }

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -5,7 +5,6 @@
 
 #include "sources/soundsourceproviderregistry.h"
 
-
 // Creates sound sources for tracks. Only intended to be used
 // in a narrow scope and not shareable between multiple threads!
 class SoundSourceProxy {

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -35,9 +35,9 @@ SoundSource::OpenResult SoundSourceSndFile::tryOpen(
     const ushort* const fileNameUtf16 = localFileName.utf16();
     static_assert(sizeof(wchar_t) == sizeof(ushort), "QString::utf16(): wchar_t and ushort have different sizes");
     m_pSndFile = sf_wchar_open(
-        reinterpret_cast<wchar_t*>(const_cast<ushort*>(fileNameUtf16)),
-        SFM_READ,
-        &sfInfo);
+            reinterpret_cast<wchar_t*>(const_cast<ushort*>(fileNameUtf16)),
+            SFM_READ,
+            &sfInfo);
 #else
     m_pSndFile = sf_open(QFile::encodeName(getLocalFileName()), SFM_READ, &sfInfo);
 #endif
@@ -57,8 +57,8 @@ SoundSource::OpenResult SoundSourceSndFile::tryOpen(
             return OpenResult::Aborted;
         } else {
             kLogger.warning() << "Error opening libsndfile file:"
-                    << getUrlString()
-                    << errorMsg;
+                              << getUrlString()
+                              << errorMsg;
             return OpenResult::Failed;
         }
     }
@@ -80,15 +80,14 @@ void SoundSourceSndFile::close() {
             m_curFrameIndex = frameIndexMin();
         } else {
             kLogger.warning() << "Failed to close file:" << closeResult
-                    << sf_strerror(m_pSndFile)
-                    << getUrlString();
+                              << sf_strerror(m_pSndFile)
+                              << getUrlString();
         }
     }
 }
 
 ReadableSampleFrames SoundSourceSndFile::readSampleFramesClamped(
         WritableSampleFrames writableSampleFrames) {
-
     const SINT firstFrameIndex = writableSampleFrames.frameIndexRange().start();
 
     if (m_curFrameIndex != firstFrameIndex) {
@@ -97,7 +96,7 @@ ReadableSampleFrames SoundSourceSndFile::readSampleFramesClamped(
             m_curFrameIndex = seekResult;
         } else {
             kLogger.warning() << "Failed to seek libsnd file:" << seekResult
-                    << sf_strerror(m_pSndFile);
+                              << sf_strerror(m_pSndFile);
             m_curFrameIndex = sf_seek(m_pSndFile, 0, SEEK_CUR);
             return ReadableSampleFrames(IndexRange::between(m_curFrameIndex, m_curFrameIndex));
         }
@@ -119,8 +118,8 @@ ReadableSampleFrames SoundSourceSndFile::readSampleFramesClamped(
                         frames2samples(readCount)));
     } else {
         kLogger.warning() << "Failed to read from libsnd file:"
-                << readCount
-                << sf_strerror(m_pSndFile);
+                          << readCount
+                          << sf_strerror(m_pSndFile);
         return ReadableSampleFrames(
                 IndexRange::between(
                         m_curFrameIndex,

--- a/src/sources/soundsourcesndfile.h
+++ b/src/sources/soundsourcesndfile.h
@@ -34,7 +34,7 @@ class SoundSourceSndFile final : public SoundSource {
     SINT m_curFrameIndex;
 };
 
-class SoundSourceProviderSndFile: public SoundSourceProvider {
+class SoundSourceProviderSndFile : public SoundSourceProvider {
   public:
     QString getName() const override;
 

--- a/src/sources/soundsourcewv.cpp
+++ b/src/sources/soundsourcewv.cpp
@@ -1,5 +1,5 @@
-#include <QFile>
 #include <wavpack/wavpack.h>
+#include <QFile>
 
 #include "sources/soundsourcewv.h"
 
@@ -12,15 +12,14 @@ namespace {
 const Logger kLogger("SoundSourceWV");
 
 static WavpackStreamReader s_streamReader = {
-    SoundSourceWV::ReadBytesCallback,
-    SoundSourceWV::GetPosCallback,
-    SoundSourceWV::SetPosAbsCallback,
-    SoundSourceWV::SetPosRelCallback,
-    SoundSourceWV::PushBackByteCallback,
-    SoundSourceWV::GetlengthCallback,
-    SoundSourceWV::CanSeekCallback,
-    SoundSourceWV::WriteBytesCallback
-};
+        SoundSourceWV::ReadBytesCallback,
+        SoundSourceWV::GetPosCallback,
+        SoundSourceWV::SetPosAbsCallback,
+        SoundSourceWV::SetPosRelCallback,
+        SoundSourceWV::PushBackByteCallback,
+        SoundSourceWV::GetlengthCallback,
+        SoundSourceWV::CanSeekCallback,
+        SoundSourceWV::WriteBytesCallback};
 
 } // anonymous namespace
 
@@ -59,8 +58,7 @@ SoundSource::OpenResult SoundSourceWV::tryOpen(
         m_pWVCFile = new QFile(correctionFileName);
         m_pWVCFile->open(QFile::ReadOnly);
     }
-    m_wpc = WavpackOpenFileInputEx(&s_streamReader, m_pWVFile, m_pWVCFile,
-            msg, openFlags, 0);
+    m_wpc = WavpackOpenFileInputEx(&s_streamReader, m_pWVFile, m_pWVCFile, msg, openFlags, 0);
     if (!m_wpc) {
         kLogger.warning() << "failed to open file : " << msg;
         return OpenResult::Failed;
@@ -115,7 +113,6 @@ void SoundSourceWV::close() {
 
 ReadableSampleFrames SoundSourceWV::readSampleFramesClamped(
         WritableSampleFrames writableSampleFrames) {
-
     const SINT firstFrameIndex = writableSampleFrames.frameIndexRange().start();
 
     if (m_curFrameIndex != firstFrameIndex) {
@@ -137,7 +134,8 @@ ReadableSampleFrames SoundSourceWV::readSampleFramesClamped(
             "CSAMPLE and int32_t must have the same size");
     CSAMPLE* pOutputBuffer = writableSampleFrames.writableData();
     SINT unpackCount = WavpackUnpackSamples(m_wpc,
-            reinterpret_cast<int32_t*>(pOutputBuffer), numberOfFramesTotal);
+            reinterpret_cast<int32_t*>(pOutputBuffer),
+            numberOfFramesTotal);
     DEBUG_ASSERT(unpackCount >= 0);
     DEBUG_ASSERT(unpackCount <= numberOfFramesTotal);
     if (!(WavpackGetMode(m_wpc) & MODE_FLOAT)) {
@@ -173,8 +171,7 @@ SoundSourcePointer SoundSourceProviderWV::newSoundSource(const QUrl& url) {
 }
 
 //static
-int32_t SoundSourceWV::ReadBytesCallback(void* id, void* data, int bcount)
-{
+int32_t SoundSourceWV::ReadBytesCallback(void* id, void* data, int bcount) {
     QFile* pFile = static_cast<QFile*>(id);
     if (!pFile) {
         return 0;
@@ -182,10 +179,8 @@ int32_t SoundSourceWV::ReadBytesCallback(void* id, void* data, int bcount)
     return pFile->read((char*)data, bcount);
 }
 
-
 // static
-uint32_t SoundSourceWV::GetPosCallback(void *id)
-{
+uint32_t SoundSourceWV::GetPosCallback(void* id) {
     QFile* pFile = static_cast<QFile*>(id);
     if (!pFile) {
         return 0;
@@ -194,8 +189,7 @@ uint32_t SoundSourceWV::GetPosCallback(void *id)
 }
 
 //static
-int SoundSourceWV::SetPosAbsCallback(void* id, unsigned int pos)
-{
+int SoundSourceWV::SetPosAbsCallback(void* id, unsigned int pos) {
     QFile* pFile = static_cast<QFile*>(id);
     if (!pFile) {
         return 0;
@@ -204,14 +198,13 @@ int SoundSourceWV::SetPosAbsCallback(void* id, unsigned int pos)
 }
 
 //static
-int SoundSourceWV::SetPosRelCallback(void *id, int delta, int mode)
-{
+int SoundSourceWV::SetPosRelCallback(void* id, int delta, int mode) {
     QFile* pFile = static_cast<QFile*>(id);
     if (!pFile) {
         return 0;
     }
 
-    switch(mode) {
+    switch (mode) {
     case SEEK_SET:
         return pFile->seek(delta) ? 0 : -1;
     case SEEK_CUR:
@@ -224,8 +217,7 @@ int SoundSourceWV::SetPosRelCallback(void *id, int delta, int mode)
 }
 
 //static
-int SoundSourceWV::PushBackByteCallback(void* id, int c)
-{
+int SoundSourceWV::PushBackByteCallback(void* id, int c) {
     QFile* pFile = static_cast<QFile*>(id);
     if (!pFile) {
         return 0;
@@ -235,8 +227,7 @@ int SoundSourceWV::PushBackByteCallback(void* id, int c)
 }
 
 //static
-uint32_t SoundSourceWV::GetlengthCallback(void* id)
-{
+uint32_t SoundSourceWV::GetlengthCallback(void* id) {
     QFile* pFile = static_cast<QFile*>(id);
     if (!pFile) {
         return 0;
@@ -245,8 +236,7 @@ uint32_t SoundSourceWV::GetlengthCallback(void* id)
 }
 
 //static
-int SoundSourceWV::CanSeekCallback(void *id)
-{
+int SoundSourceWV::CanSeekCallback(void* id) {
     QFile* pFile = static_cast<QFile*>(id);
     if (!pFile) {
         return 0;
@@ -255,8 +245,7 @@ int SoundSourceWV::CanSeekCallback(void *id)
 }
 
 //static
-int32_t SoundSourceWV::WriteBytesCallback(void* id, void* data, int32_t bcount)
-{
+int32_t SoundSourceWV::WriteBytesCallback(void* id, void* data, int32_t bcount) {
     QFile* pFile = static_cast<QFile*>(id);
     if (!pFile) {
         return 0;

--- a/src/sources/soundsourcewv.h
+++ b/src/sources/soundsourcewv.h
@@ -10,7 +10,7 @@ typedef void WavpackContext;
 
 namespace mixxx {
 
-class SoundSourceWV: public SoundSource {
+class SoundSourceWV : public SoundSource {
   public:
     static int32_t ReadBytesCallback(void* id, void* data, int bcount);
     static uint32_t GetPosCallback(void* id);
@@ -43,8 +43,8 @@ class SoundSourceWV: public SoundSource {
     SINT m_curFrameIndex;
 };
 
-class SoundSourceProviderWV: public SoundSourceProvider {
-public:
+class SoundSourceProviderWV : public SoundSourceProvider {
+  public:
     QString getName() const override;
 
     QStringList getSupportedFileExtensions() const override;
@@ -52,6 +52,6 @@ public:
     SoundSourcePointer newSoundSource(const QUrl& url) override;
 };
 
-}  // namespace mixxx
+} // namespace mixxx
 
 #endif // MIXXX_SOUNDSOURCEWV_H

--- a/src/sources/urlresource.h
+++ b/src/sources/urlresource.h
@@ -8,8 +8,9 @@
 namespace mixxx {
 
 class UrlResource {
-public:
-    virtual ~UrlResource() {}
+  public:
+    virtual ~UrlResource() {
+    }
 
     QUrl getUrl() const {
         return m_url;
@@ -18,9 +19,9 @@ public:
         return m_url.toString();
     }
 
-protected:
+  protected:
     explicit UrlResource(QUrl url)
-        : m_url(url) {
+            : m_url(url) {
     }
 
     inline bool isLocalFile() const {
@@ -36,7 +37,7 @@ protected:
         return m_url.toLocalFile();
     }
 
-private:
+  private:
     QUrl m_url;
 };
 

--- a/src/sources/v1/legacyaudiosource.h
+++ b/src/sources/v1/legacyaudiosource.h
@@ -3,7 +3,6 @@
 
 #include "util/types.h"
 
-
 namespace mixxx {
 
 // The legacy API that has been deprecated.
@@ -37,6 +36,5 @@ class LegacyAudioSource {
 };
 
 } // namespace mixxx
-
 
 #endif // MIXXX_LEGACYAUDIOSOURCE_H

--- a/src/sources/v1/legacyaudiosourceadapter.cpp
+++ b/src/sources/v1/legacyaudiosourceadapter.cpp
@@ -4,7 +4,6 @@
 
 #include "util/logger.h"
 
-
 namespace mixxx {
 
 namespace {
@@ -16,13 +15,12 @@ const Logger kLogger("LegacyAudioSourceAdapter");
 LegacyAudioSourceAdapter::LegacyAudioSourceAdapter(
         AudioSource* pOwner,
         LegacyAudioSource* pImpl)
-    : m_pOwner(pOwner),
-      m_pImpl(pImpl) {
+        : m_pOwner(pOwner),
+          m_pImpl(pImpl) {
 }
 
 ReadableSampleFrames LegacyAudioSourceAdapter::readSampleFramesClamped(
         WritableSampleFrames writableSampleFrames) {
-
     const SINT firstFrameIndex = writableSampleFrames.frameIndexRange().start();
 
     const SINT seekFrameIndex = m_pImpl->seekSampleFrame(firstFrameIndex);

--- a/src/sources/v1/legacyaudiosourceadapter.h
+++ b/src/sources/v1/legacyaudiosourceadapter.h
@@ -1,16 +1,14 @@
 #ifndef MIXXX_LEGACYAUDIOSOURCEADAPTER_H
 #define MIXXX_LEGACYAUDIOSOURCEADAPTER_H
 
-
 #include "sources/v1/legacyaudiosource.h"
 
 #include "sources/audiosource.h"
 
-
 namespace mixxx {
 
 // Only required for SoundSourceCoreAudio.
-class LegacyAudioSourceAdapter: public virtual /*implements*/ IAudioSourceReader {
+class LegacyAudioSourceAdapter : public virtual /*implements*/ IAudioSourceReader {
   public:
     LegacyAudioSourceAdapter(
             AudioSource* pOwner,
@@ -26,6 +24,5 @@ class LegacyAudioSourceAdapter: public virtual /*implements*/ IAudioSourceReader
 };
 
 } // namespace mixxx
-
 
 #endif // MIXXX_LEGACYAUDIOSOURCEADAPTER_H


### PR DESCRIPTION
***The intent of this PR is neither to start a mass-reformatting nor to encourage other contributors to reformat entire files. The only purpose is to validate and tune the ClangFormat settings on a broader but limited set of files.***

Since no one is currently supposed to work on the SoundSources I reformatted all the files in this folder to validate our new rules.

Overlong lines can be fixed and prevented by adding manual line breaks or splitting all arguments on separate lines. That's a consequence of not defining a maximum line length. With the current setting we minimize the reformatting, I would not recommend to change it (yet).

If you spot any unpleasant outcomes please report and we could try to tune the settings. I'm already very pleased with the results we get! The changes are minimal if the existing code closely followed our style guide.