### PR TITLE
Thread save key detect

### DIFF
--- a/lib/qm-dsp/dsp/keydetection/GetKeyMode.h
+++ b/lib/qm-dsp/dsp/keydetection/GetKeyMode.h
@@ -27,7 +27,7 @@ public:
 
 	int process( double* PCMData );
 
-	double krumCorr( double *pData, const double *pProfileNorm, unsigned int length );
+	double krumCorr( const double *pDataNorm, const double *pProfileNorm, unsigned int length );
 
 	unsigned int getBlockSize() { return m_ChromaFrameSize*m_DecimationFactor; }
 	unsigned int getHopSize() { return m_ChromaHopSize*m_DecimationFactor; }

--- a/lib/qm-dsp/dsp/keydetection/GetKeyMode.h
+++ b/lib/qm-dsp/dsp/keydetection/GetKeyMode.h
@@ -27,7 +27,8 @@ public:
 
 	int process( double* PCMData );
 
-	double krumCorr( const double *pDataNorm, const double *pProfileNorm, unsigned int length );
+	double krumCorr(
+	        const double *pDataNorm, const double *pProfileNorm, int shiftProfile, unsigned int length );
 
 	unsigned int getBlockSize() { return m_ChromaFrameSize*m_DecimationFactor; }
 	unsigned int getHopSize() { return m_ChromaHopSize*m_DecimationFactor; }

--- a/lib/qm-dsp/dsp/keydetection/GetKeyMode.h
+++ b/lib/qm-dsp/dsp/keydetection/GetKeyMode.h
@@ -27,7 +27,7 @@ public:
 
 	int process( double* PCMData );
 
-	double krumCorr( double* pData1, double* pData2, unsigned int length );
+	double krumCorr( double *pData, const double *pProfileNorm, unsigned int length );
 
 	unsigned int getBlockSize() { return m_ChromaFrameSize*m_DecimationFactor; }
 	unsigned int getHopSize() { return m_ChromaHopSize*m_DecimationFactor; }
@@ -79,6 +79,8 @@ protected:
 	double* m_ChromaBuffer;
 	double* m_MeanHPCP;
 
+	double* m_MajProfileNorm;
+	double* m_MinProfileNorm;
 	double* m_MajCorr;
 	double* m_MinCorr;
 	double* m_Keys;

--- a/lib/qm-dsp/dsp/keydetection/GetKeyMode.h
+++ b/lib/qm-dsp/dsp/keydetection/GetKeyMode.h
@@ -38,7 +38,7 @@ public:
 
 	double* getMeanHPCP() { return m_MeanHPCP; }
 
-	double *getKeyStrengths() { return m_keyStrengths; }
+	double* getKeyStrengths();
 
 	bool isModeMinor( int key ); 
 
@@ -84,7 +84,6 @@ protected:
 	double* m_MinProfileNorm;
 	double* m_MajCorr;
 	double* m_MinCorr;
-	double* m_Keys;
 	int* m_MedianFilterBuffer;
 	int* m_SortedBuffer;
 


### PR DESCRIPTION
This fixes that a global buffers is used from the key detector object. Now every object used is own instance. 

This PR also removes some intermediate buffers.

Currently we don't even need to copy the buffer locally if we store the  but I have kept using it, because I do not want to alter the numbers from the original profiles which are taken from an academic paper. 