### PR TITLE
Strobe Widget 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1280,6 +1280,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/wsplitter.cpp
   src/widget/wstarrating.cpp
   src/widget/wstatuslight.cpp
+  src/widget/wstrobe.cpp
   src/widget/wtime.cpp
   src/widget/wtrackmenu.cpp
   src/widget/wtrackproperty.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1814,6 +1814,7 @@ add_library(
   src/widget/wsplitter.cpp
   src/widget/wstarrating.cpp
   src/widget/wstatuslight.cpp
+  src/widget/wstrobe.cpp
   src/widget/wtime.cpp
   src/widget/wtrackmenu.cpp
   src/widget/wtrackproperty.cpp

--- a/res/skins/Shade/Dot33Neg.svg
+++ b/res/skins/Shade/Dot33Neg.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="42"
+   height="23"
+   viewBox="0 0 42 23"
+   id="svg3336"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="Dot33Neg.svg">
+  <defs
+     id="defs3338" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="6.4638298"
+     inkscape:cx="17.439105"
+     inkscape:cy="-1.4285714"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1301"
+     inkscape:window-height="744"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata3341">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1029.3622)">
+    <rect
+       style="fill:#8d98a3;fill-opacity:1"
+       id="rect3335"
+       width="41.92561"
+       height="23.515471"
+       x="0"
+       y="1029.1561" />
+    <circle
+       style="fill:#000000;fill-opacity:1"
+       id="path3346"
+       cx="20.88545"
+       cy="1040.7592"
+       r="8.0447664" />
+  </g>
+</svg>

--- a/res/skins/Shade/Dot33Pos.svg
+++ b/res/skins/Shade/Dot33Pos.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="38"
+   height="23"
+   viewBox="0 0 38 23"
+   id="svg3336"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="Dot33Pos.svg">
+  <defs
+     id="defs3338" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="6.4638298"
+     inkscape:cx="17.593812"
+     inkscape:cy="-1.4285714"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1301"
+     inkscape:window-height="744"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata3341">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1029.3622)">
+    <rect
+       style="fill:#8d98a3;fill-opacity:1"
+       id="rect3335"
+       width="38.057934"
+       height="23.360764"
+       x="0"
+       y="1029.1561" />
+    <circle
+       style="fill:#000000;fill-opacity:1"
+       id="path3346"
+       cx="19.028965"
+       cy="1040.7592"
+       r="8.0447664" />
+  </g>
+</svg>

--- a/res/skins/Shade/Dot60Pos.svg
+++ b/res/skins/Shade/Dot60Pos.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="37"
+   height="23"
+   viewBox="0 0 37 23"
+   id="svg3336"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="Dot60Pos.svg">
+  <defs
+     id="defs3338" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="6.4638298"
+     inkscape:cx="17.439105"
+     inkscape:cy="-1.4285714"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1301"
+     inkscape:window-height="744"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata3341">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1029.3622)">
+    <rect
+       style="fill:#8d98a3;fill-opacity:1"
+       id="rect3334"
+       width="37.129692"
+       height="23.206057"
+       x="-0.15470704"
+       y="1029.3108" />
+    <circle
+       style="fill:#000000;fill-opacity:1"
+       id="path3346"
+       cx="18.564844"
+       cy="1040.7592"
+       r="8.0447664" />
+  </g>
+</svg>

--- a/res/skins/Shade/DotUnity.svg
+++ b/res/skins/Shade/DotUnity.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="40"
+   height="35"
+   viewBox="0 0 40 35"
+   id="svg3336"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="DotUnity.svg">
+  <defs
+     id="defs3338" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="6.4638298"
+     inkscape:cx="17.439105"
+     inkscape:cy="-1.4285714"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1301"
+     inkscape:window-height="744"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata3341">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1017.3622)">
+    <rect
+       style="fill:#8d98a3;fill-opacity:1"
+       id="rect3334"
+       width="40.069126"
+       height="34.809086"
+       x="0"
+       y="1017.5531" />
+    <circle
+       style="fill:#000000;fill-opacity:1"
+       id="path3405"
+       cx="19.802502"
+       cy="1034.7256"
+       r="12.531271" />
+  </g>
+</svg>

--- a/res/skins/Shade/deck.xml
+++ b/res/skins/Shade/deck.xml
@@ -79,6 +79,24 @@
                                 <Size>0e,23f</Size>
                                 <Elide>right</Elide>
                               </TrackProperty>
+                              <WidgetGroup>
+                               <Size>100f,15f</Size>
+                               <Children>
+                                 <Strobe>
+                                   <Size>100f,15f</Size>
+                                   <TooltipId>Strobe</TooltipId>
+                                   <Channel><Variable name="channum"/></Channel>
+                                   <PathDot60Pos>Dot60Pos.svg</PathDot60Pos>
+                                   <PathDot33Pos>Dot33Pos.svg</PathDot33Pos>
+                                   <PathDotUnity>DotUnity.svg</PathDotUnity>
+                                   <PathDot33Neg>Dot33Neg.svg</PathDot33Neg>
+                                 </Strobe>
+                               </Children>
+                               <Connection>
+                                 <ConfigKey>[Spinny<Variable name="channum"/>],show_spinny</ConfigKey>
+                                 <BindProperty>visible</BindProperty>
+                               </Connection>
+                              </WidgetGroup>
                               <PushButton>
                                 <TooltipId>eject</TooltipId>
                                 <NumberStates>1</NumberStates>
@@ -212,6 +230,15 @@
                                       <BindProperty>visible</BindProperty>
                                     </Connection>
                                   </WidgetGroup>
+                                  <Strobe>
+			                        <Size>160f,81f</Size>
+                                    <TooltipId>Strobe</TooltipId>
+                                    <Channel><Variable name="channum"/></Channel>
+                                    <PathDot60Pos>Dot60Pos.svg</PathDot60Pos>
+                                    <PathDot33Pos>Dot33Pos.svg</PathDot33Pos>
+                                    <PathDotUnity>DotUnity.svg</PathDotUnity>
+                                    <PathDot33Neg>Dot33Neg.svg</PathDot33Neg>
+                                  </Strobe>
                                   <Template src="skin:vinylcontrol.xml"/>
                                 </Children>
                               </WidgetGroup>

--- a/res/skins/Shade/deck.xml
+++ b/res/skins/Shade/deck.xml
@@ -79,6 +79,24 @@
                                 <Size>0e,23f</Size>
                                 <Elide>right</Elide>
                               </TrackProperty>
+                              <WidgetGroup>
+                               <Size>100f,15f</Size>
+                               <Children>
+                                 <Strobe>
+                                   <Size>100f,15f</Size>
+                                   <TooltipId>Strobe</TooltipId>
+                                   <Channel><Variable name="channum"/></Channel>
+                                   <PathDot60Pos>Dot60Pos.svg</PathDot60Pos>
+                                   <PathDot33Pos>Dot33Pos.svg</PathDot33Pos>
+                                   <PathDotUnity>DotUnity.svg</PathDotUnity>
+                                   <PathDot33Neg>Dot33Neg.svg</PathDot33Neg>
+                                 </Strobe>
+                               </Children>
+                               <Connection>
+                                 <ConfigKey>[Spinny<Variable name="channum"/>],show_spinny</ConfigKey>
+                                 <BindProperty>visible</BindProperty>
+                               </Connection>
+                              </WidgetGroup>
                               <PushButton>
                                 <TooltipId>eject</TooltipId>
                                 <NumberStates>1</NumberStates>
@@ -213,6 +231,15 @@
                                       <BindProperty>visible</BindProperty>
                                     </Connection>
                                   </WidgetGroup>
+                                  <Strobe>
+			                        <Size>160f,81f</Size>
+                                    <TooltipId>Strobe</TooltipId>
+                                    <Channel><Variable name="channum"/></Channel>
+                                    <PathDot60Pos>Dot60Pos.svg</PathDot60Pos>
+                                    <PathDot33Pos>Dot33Pos.svg</PathDot33Pos>
+                                    <PathDotUnity>DotUnity.svg</PathDotUnity>
+                                    <PathDot33Neg>Dot33Neg.svg</PathDot33Neg>
+                                  </Strobe>
                                   <Template src="skin:vinylcontrol.xml"/>
                                 </Children>
                               </WidgetGroup>

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -83,6 +83,7 @@
 #ifdef __STEM__
 #include "widget/wstemlabel.h"
 #endif
+#include "widget/wstrobe.h"
 #include "widget/wtime.h"
 #include "widget/wtrackproperty.h"
 #include "widget/wtrackwidgetgroup.h"
@@ -636,6 +637,8 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
         result = wrapWidget(parseEffectButtonParameterName(node));
     } else if (nodeName == "Spinny") {
         result = wrapWidget(parseSpinny(node));
+    } else if (nodeName == "Strobe") {
+        result = wrapWidget(parseStrobe(node));
     } else if (nodeName == "Time") {
         result = wrapWidget(parseLabelWidget<WTime>(node));
     } else if (nodeName == "RecordingDuration") {
@@ -1551,6 +1554,70 @@ QWidget* LegacySkinParser::parseVuMeter(const QDomElement& node) {
     pVuMeterWidget->Init();
 
     return pVuMeterWidget;
+}
+
+QWidget* LegacySkinParser::parseStrobe(const QDomElement& node) {
+#ifdef MIXXX_USE_QML
+    if (CmdlineArgs::Instance().isQml()) {
+        return nullptr;
+    }
+#endif
+    if (CmdlineArgs::Instance().getSafeMode()) {
+        WLabel* dummy = new WLabel(m_pParent);
+        //: Shown when Mixxx is running in safe mode.
+        dummy->setText(tr("Safe Mode Enabled"));
+        return dummy;
+    }
+
+    auto* pWaveformWidgetFactory = WaveformWidgetFactory::instance();
+
+    if (!pWaveformWidgetFactory->isOpenGlAvailable() &&
+            !pWaveformWidgetFactory->isOpenGlesAvailable()) {
+        WLabel* dummy = new WLabel(m_pParent);
+        //: Shown when Spinny can not be displayed. Please keep \n unchanged
+        dummy->setText(tr("No OpenGL\nsupport."));
+        return dummy;
+    }
+
+    QString group = lookupNodeGroup(node);
+    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
+    if (!pPlayer) {
+        SKIN_WARNING(node, *m_pContext, QStringLiteral("No player found for group: %1").arg(group));
+        return nullptr;
+    }
+    // Note: For some reasons on X11 we need to create the widget without a parent to avoid to
+    // create two platform windows (QXcbWindow) in QWidget::create() for this widget.
+    // This happens, because the QWidget::create() of a parent() will populate all children
+    // with platform windows q_createNativeChildrenAndSetParent() while another window is already
+    // under construction. The ID for the first window is not cleared and leads to a segfault
+    // during on shutdown. This has been tested with Qt 5.12.8 and 5.15.3
+    QWidget* pParent = (qApp->platformName() == QLatin1String("xcb")) ? nullptr : m_pParent;
+    WStrobe* pStrobe = new WStrobe(pParent, group, m_pConfig, pPlayer);
+    if (!pParent) {
+        // Widget was created without parent (see comment above), set it now
+        pStrobe->setParent(m_pParent);
+    }
+    commonWidgetSetup(node, pStrobe);
+
+    connect(pWaveformWidgetFactory,
+            &WaveformWidgetFactory::renderSpinnies,
+            pStrobe,
+            &WStrobe::render);
+    connect(pWaveformWidgetFactory,
+            &WaveformWidgetFactory::swapSpinnies,
+            pStrobe,
+            &WStrobe::swap);
+    connect(pStrobe,
+            &WStrobe::trackDropped,
+            m_pPlayerManager,
+            &PlayerManager::slotLoadLocationToPlayerMaybePlay);
+    connect(pStrobe, &WStrobe::cloneDeck, m_pPlayerManager, &PlayerManager::slotCloneDeck);
+
+    pStrobe->setup(node, *m_pContext);
+    pStrobe->installEventFilter(m_pKeyboard);
+    pStrobe->installEventFilter(m_pControllerManager->getControllerLearningEventFilter());
+    pStrobe->Init();
+    return pStrobe;
 }
 
 QWidget* LegacySkinParser::parseSearchBox(const QDomElement& node) {

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -111,6 +111,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     QWidget* parseVisual(const QDomElement& node);
     QWidget* parseOverview(const QDomElement& node);
     QWidget* parseSpinny(const QDomElement& node);
+    QWidget* parseStrobe(const QDomElement& node);
     QWidget* parseVuMeter(const QDomElement& node);
 
     // Library widgets.

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -120,6 +120,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     QWidget* parseVisual(const QDomElement& node);
     QWidget* parseOverview(const QDomElement& node);
     QWidget* parseSpinny(const QDomElement& node);
+    QWidget* parseStrobe(const QDomElement& node);
     QWidget* parseVuMeter(const QDomElement& node);
 
     // Library widgets.

--- a/src/widget/wstrobe.cpp
+++ b/src/widget/wstrobe.cpp
@@ -1,0 +1,330 @@
+#include "widget/wstrobe.h"
+
+#include <QApplication>
+#include <QMimeData>
+#include <QStylePainter>
+#include <QUrl>
+#include <QWindow>
+#include <QtDebug>
+
+#include "control/controlobject.h"
+#include "control/controlproxy.h"
+#include "library/coverartcache.h"
+#include "moc_wstrobe.cpp"
+#include "skin/legacy/skincontext.h"
+#include "util/dnd.h"
+#include "util/math.h"
+#include "vinylcontrol/vinylcontrol.h"
+#include "vinylcontrol/vinylcontrolmanager.h"
+#include "waveform/sharedglcontext.h"
+#include "waveform/visualplayposition.h"
+#include "waveform/vsyncthread.h"
+#include "wimagestore.h"
+
+namespace {
+
+constexpr double kBbigDotHeightFactor = 0.34;
+constexpr double kBigDotWidthFactor = 0.40;
+constexpr double kSmallDotHeightFactor = 0.23;
+// The dots per round are taken from a real turn table
+constexpr int kDotsPerRound60Pos = 203; // 93.98 %
+constexpr int kDotsPerRound33Pos = 209; // 96.76 %
+constexpr int kDotsPerRoundUnity = 216; // 100.00 %
+constexpr int kDotsPerRound33Neg = 223; // 103.24 %
+
+} // anonymous namespace
+
+WStrobe::WStrobe(
+        QWidget* pParent,
+        const QString& group,
+        UserSettingsPointer pConfig,
+        BaseTrackPlayer* pPlayer)
+        : WGLWidget(pParent),
+          WBaseWidget(this),
+          m_group(group),
+          m_pConfig(pConfig),
+          m_pPlay(nullptr),
+          m_pPlayPos(nullptr),
+          m_pVisualPlayPos(nullptr),
+          m_pTrackSamples(nullptr),
+          m_pTrackSampleRate(nullptr),
+          m_pScratchToggle(nullptr),
+          m_pScratchPos(nullptr),
+          m_pSignalEnabled(nullptr),
+          m_dInitialPos(0.),
+          m_iVinylInput(-1),
+          m_bVinylActive(false),
+          m_bSignalActive(true),
+          m_iVinylScopeSize(0),
+          m_fAngle(0.0f),
+          m_dAngleCurrentPlaypos(-1),
+          m_dGhostAngleCurrentPlaypos(-1),
+          m_dAngleLastPlaypos(-1),
+          m_iStartMouseX(-1),
+          m_iStartMouseY(-1),
+          m_iFullRotations(0),
+          m_dPrevTheta(0.),
+          m_dTheta(0.),
+          m_dRotationsPerSecond(100.0 / 3 / 60),
+          m_bClampFailedWarning(false),
+          m_pPlayer(pPlayer) {
+    // Drag and drop
+    setAcceptDrops(true);
+
+    if (m_pPlayer != nullptr) {
+        connect(m_pPlayer,
+                &BaseTrackPlayer::newTrackLoaded,
+                this,
+                &WStrobe::slotLoadTrack);
+        connect(m_pPlayer,
+                &BaseTrackPlayer::loadingTrack,
+                this,
+                &WStrobe::slotLoadingTrack);
+        // just in case a track is already loaded
+        slotLoadTrack(m_pPlayer->getLoadedTrack());
+    }
+
+    setAttribute(Qt::WA_NoSystemBackground);
+    setAttribute(Qt::WA_OpaquePaintEvent);
+
+#ifdef MIXXX_USE_QOPENGL
+    setTrackDropTarget(this);
+#endif
+}
+
+WStrobe::~WStrobe() {
+}
+
+void WStrobe::setup(const QDomNode& node, const SkinContext& context) {
+    // Set images
+    m_pDot60PosImage = WImageStore::getImage(
+            context.getPixmapSource(context.selectNode(node, "PathDot60Pos")),
+            context.getScaleFactor());
+    m_pDot33PosImage = WImageStore::getImage(
+            context.getPixmapSource(context.selectNode(node, "PathDot33Pos")),
+            context.getScaleFactor());
+    m_pDotUnityImage = WImageStore::getImage(
+            context.getPixmapSource(context.selectNode(node, "PathDotUnity")),
+            context.getScaleFactor());
+    m_pDot33NegImage = WImageStore::getImage(
+            context.getPixmapSource(context.selectNode(node, "PathDot33Neg")),
+            context.getScaleFactor());
+
+    m_pPlay = new ControlProxy(
+            m_group, "play", this);
+    m_pPlayPos = new ControlProxy(
+            m_group, "playposition", this);
+    m_pVisualPlayPos = VisualPlayPosition::getVisualPlayPosition(m_group);
+    m_pTrackSamples = new ControlProxy(
+            m_group, "track_samples", this);
+    m_pTrackSampleRate = new ControlProxy(
+            m_group, "track_samplerate", this);
+
+    m_pScratchToggle = new ControlProxy(
+            m_group, "scratch_position_enable", this);
+    m_pScratchPos = new ControlProxy(
+            m_group, "scratch_position", this);
+}
+
+void WStrobe::slotLoadTrack(TrackPointer pTrack) {
+    m_loadedTrack = pTrack;
+}
+
+void WStrobe::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pNewTrack);
+    Q_UNUSED(pOldTrack);
+    m_loadedTrack.reset();
+    update();
+}
+
+void WStrobe::paintEvent(QPaintEvent* e) {
+    Q_UNUSED(e);
+}
+
+void WStrobe::render(VSyncThread* vSyncThread) {
+    if (!shouldRender()) {
+        return;
+    }
+
+    if (!m_pVisualPlayPos.isNull() && vSyncThread) {
+        m_pVisualPlayPos->getPlaySlipAtNextVSync(
+                vSyncThread,
+                &m_dAngleCurrentPlaypos,
+                &m_dGhostAngleCurrentPlaypos);
+    }
+
+    if (m_dAngleCurrentPlaypos != m_dAngleLastPlaypos) {
+        m_fAngle = calculateAngle(m_dAngleCurrentPlaypos);
+        m_dAngleLastPlaypos = m_dAngleCurrentPlaypos;
+    }
+
+    qDebug() << m_fAngle << m_dAngleCurrentPlaypos;
+
+    QPainter p(paintDevice());
+    p.setRenderHint(QPainter::Antialiasing);
+    p.setRenderHint(QPainter::SmoothPixmapTransform);
+
+    double smallHight = height() * kSmallDotHeightFactor;
+    double bigHight = height() * kBbigDotHeightFactor;
+    double dot60PosWidth = height() *
+            kBigDotWidthFactor /
+            kDotsPerRoundUnity *
+            kDotsPerRound60Pos;
+    double dot33PosWidth = height() *
+            kBigDotWidthFactor /
+            kDotsPerRoundUnity *
+            kDotsPerRound33Pos;
+    double dotUnityWidth = height() *
+            kBigDotWidthFactor /
+            kDotsPerRoundUnity *
+            kDotsPerRoundUnity;
+    double dot33NegWidth = height() *
+            kBigDotWidthFactor /
+            kDotsPerRoundUnity *
+            kDotsPerRound33Neg;
+
+    double maxWidth = width();
+
+    qDebug() << m_fAngle;
+
+    // Calc how much of the left most dot is visible
+    double left = m_fAngle / 360 * kDotsPerRound60Pos;
+    left -= floor(left);
+    left = -1 - left;
+    left *= dot60PosWidth;
+    while (left < maxWidth) {
+        if (m_pDot60PosImage) {
+            p.drawImage(QRectF(left, 0.0, dot60PosWidth, smallHight),
+                    *m_pDot60PosImage,
+                    QRectF(m_pDot60PosImage->rect()));
+        }
+        left += dot60PosWidth;
+    }
+
+    // Calc how much of the left most dot is visible
+    left = m_fAngle / 360 * kDotsPerRound33Pos;
+    left -= floor(left);
+    left = -1 - left;
+    left *= dot33PosWidth;
+    // left = calculateOffset(m_dAngleCurrentPlaypos, 1.033) * dot33PosWidth;
+    while (left < maxWidth) {
+        if (m_pDot33PosImage) {
+            p.drawImage(QRectF(left, smallHight, dot33PosWidth, smallHight),
+                    *m_pDot33PosImage,
+                    QRectF(m_pDot33PosImage->rect()));
+        }
+        left += dot33PosWidth;
+    }
+
+    // Calc how much of the left most dot is visible
+    left = m_fAngle / 360 * kDotsPerRoundUnity;
+    left -= floor(left);
+    left = -1 - left;
+    left *= dotUnityWidth;
+    // left = calculateOffset(m_dAngleCurrentPlaypos, 1) * dotUnityWidth;
+    while (left < maxWidth) {
+        if (m_pDotUnityImage) {
+            p.drawImage(QRectF(left, smallHight * 2, dotUnityWidth, bigHight),
+                    *m_pDotUnityImage,
+                    QRectF(m_pDotUnityImage->rect()));
+        }
+        left += dotUnityWidth;
+    }
+
+    // Calc how much of the left most dot is visible
+    left = m_fAngle / 360 * kDotsPerRound33Neg;
+    left -= floor(left);
+    left = -1 - left;
+    left *= dot33NegWidth;
+    // left = calculateOffset(m_dAngleCurrentPlaypos, 0.967) * dot33NegWidth;
+    while (left < maxWidth) {
+        if (m_pDot33NegImage) {
+            p.drawImage(QRectF(left, smallHight * 2 + bigHight, dot33NegWidth, smallHight),
+                    *m_pDot33NegImage,
+                    QRectF(m_pDot33NegImage->rect()));
+        }
+        left += dot33NegWidth;
+    }
+}
+
+void WStrobe::swap() {
+    if (!shouldRender()) {
+        return;
+    }
+    makeCurrentIfNeeded();
+    swapBuffers();
+    doneCurrent();
+}
+
+double WStrobe::calculateAngle(double playpos) {
+    // Convert between a normalized playback position (0.0 - 1.0) and an angle
+    // in our polar coordinate system.
+    // Returns an angle clamped between -180 and 180 degrees.
+    double trackFrames = m_pTrackSamples->get() / 2;
+    double trackSampleRate = m_pTrackSampleRate->get();
+    if (util_isnan(playpos) || util_isnan(trackFrames) || util_isnan(trackSampleRate) ||
+            trackFrames <= 0 || trackSampleRate <= 0) {
+        return 0.0;
+    }
+
+    // Convert playpos to seconds.
+    double t = playpos * trackFrames / trackSampleRate;
+
+    // Bad samplerate or number of track samples.
+    if (util_isnan(t)) {
+        return 0.0;
+    }
+
+    // 33 RPM is approx. 0.5 rotations per second.
+    double angle = 360.0 * m_dRotationsPerSecond * t;
+    // Clamp within -180 and 180 degrees
+    // qDebug() << "pc:" << angle;
+    // angle = ((angle + 180) % 360.) - 180;
+    // modulo for doubles :)
+    const double originalAngle = angle;
+    if (angle > 0) {
+        int x = static_cast<int>((angle + 180) / 360);
+        angle = angle - (360 * x);
+    } else {
+        int x = static_cast<int>((angle - 180) / 360);
+        angle = angle - (360 * x);
+    }
+
+    if (angle <= -180 || angle > 180) {
+        // Only warn once per session. This can tank performance since it prints
+        // like crazy.
+        if (!m_bClampFailedWarning) {
+            qDebug() << "Angle clamping failed!" << t << originalAngle << "->" << angle
+                     << "Please file a bug or email mixxx-devel@lists.sourceforge.net";
+            m_bClampFailedWarning = true;
+        }
+        return 0.0;
+    }
+    return angle;
+}
+
+void WStrobe::showEvent(QShowEvent* event) {
+    WGLWidget::showEvent(event);
+}
+
+void WStrobe::hideEvent(QHideEvent* event) {
+    Q_UNUSED(event);
+    // fill with transparent black
+    m_qImage.fill(qRgba(0, 0, 0, 0));
+    WGLWidget::hideEvent(event);
+}
+
+bool WStrobe::event(QEvent* pEvent) {
+    if (pEvent->type() == QEvent::ToolTip) {
+        updateTooltip();
+    }
+    return WGLWidget::event(pEvent);
+}
+
+void WStrobe::dragEnterEvent(QDragEnterEvent* event) {
+    DragAndDropHelper::handleTrackDragEnterEvent(event, m_group, m_pConfig);
+}
+
+void WStrobe::dropEvent(QDropEvent* event) {
+    DragAndDropHelper::handleTrackDropEvent(event, *this, m_group, m_pConfig);
+}

--- a/src/widget/wstrobe.h
+++ b/src/widget/wstrobe.h
@@ -1,0 +1,101 @@
+
+#pragma once
+
+#include <QEvent>
+#include <QHideEvent>
+#include <QShowEvent>
+
+#include "library/dlgcoverartfullsize.h"
+#include "mixer/basetrackplayer.h"
+#include "preferences/usersettings.h"
+#include "track/track.h"
+#include "widget/trackdroptarget.h"
+#include "widget/wbasewidget.h"
+#include "widget/wglwidget.h"
+#include "widget/wwidget.h"
+
+class ControlProxy;
+class SkinContext;
+class VisualPlayPosition;
+class VinylControlManager;
+class VSyncThread;
+
+class WStrobe : public WGLWidget, public WBaseWidget, public TrackDropTarget {
+    Q_OBJECT
+  public:
+    WStrobe(
+            QWidget* pParent,
+            const QString& group,
+            UserSettingsPointer pConfig,
+            BaseTrackPlayer* pPlayer);
+    ~WStrobe() override;
+
+    void setup(const QDomNode& node, const SkinContext& context);
+    void dragEnterEvent(QDragEnterEvent* event) override;
+    void dropEvent(QDropEvent* event) override;
+
+  public slots:
+    void slotLoadTrack(TrackPointer);
+    void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
+    void render(VSyncThread* vSyncThread);
+    void swap();
+
+  signals:
+    void trackDropped(const QString& filename, const QString& group) override;
+    void cloneDeck(const QString& source_group, const QString& target_group) override;
+
+  protected:
+    // QWidget:
+    void paintEvent(QPaintEvent* /*unused*/) override;
+    void showEvent(QShowEvent* event) override;
+    void hideEvent(QHideEvent* event) override;
+    bool event(QEvent* pEvent) override;
+
+    QPixmap scaledCoverArt(const QPixmap& normal);
+
+  private:
+    double calculateAngle(double playpos);
+
+    QString m_group;
+    UserSettingsPointer m_pConfig;
+    std::shared_ptr<QImage> m_pDot60PosImage;
+    std::shared_ptr<QImage> m_pDot33PosImage;
+    std::shared_ptr<QImage> m_pDotUnityImage;
+    std::shared_ptr<QImage> m_pDot33NegImage;
+    QImage m_fgImageScaled;
+    std::shared_ptr<QImage> m_pGhostImage;
+    QImage m_ghostImageScaled;
+    ControlProxy* m_pPlay;
+    ControlProxy* m_pPlayPos;
+    QSharedPointer<VisualPlayPosition> m_pVisualPlayPos;
+    ControlProxy* m_pTrackSamples;
+    ControlProxy* m_pTrackSampleRate;
+    ControlProxy* m_pScratchToggle;
+    ControlProxy* m_pScratchPos;
+    ControlProxy* m_pSignalEnabled;
+
+    TrackPointer m_loadedTrack;
+
+    double m_dInitialPos;
+
+    int m_iVinylInput;
+    bool m_bVinylActive;
+    bool m_bSignalActive;
+    QImage m_qImage;
+    int m_iVinylScopeSize;
+
+    double m_fAngle; // Degrees
+    double m_dAngleCurrentPlaypos;
+    double m_dGhostAngleCurrentPlaypos;
+    double m_dAngleLastPlaypos;
+    int m_iStartMouseX;
+    int m_iStartMouseY;
+    int m_iFullRotations;
+    double m_dPrevTheta;
+    double m_dTheta;
+    // Speed of the vinyl rotation.
+    double m_dRotationsPerSecond;
+    bool m_bClampFailedWarning;
+
+    BaseTrackPlayer* m_pPlayer;
+};


### PR DESCRIPTION
This adds another moving widget to Mixxx. 

It was actually only a fun project, made during my waveform sync work. 
It makes it very obvious if the rendering is out of sync with the transport. 
It is not only an eye candy, it really works and used the screen refresh rate as strobe crystal frequency. 

I could imagine that this is might helpful for vinly DJs to feel at home. 
At least it is a unique widget among our competitors. 

Maybe a skin designer can make use of it designing a vinyl skin. 

![grafik](https://user-images.githubusercontent.com/1777442/57836442-00f59a00-77c1-11e9-91d1-08a99d0eba2f.png)

![Strobe-](https://user-images.githubusercontent.com/1777442/57836875-ec65d180-77c1-11e9-869d-f8f85b5aba99.png)



