### PR TITLE
Auto assign hotcue color

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -551,6 +551,11 @@ void CueControl::hotcueSet(HotcueControl* pControl, double v) {
     // TODO(XXX) deal with spurious signals
     attachCue(pCue, hotcue);
 
+    if (getConfig()->getValue(ConfigKey("[Controls]", "AutoHotcueColors"), false)) {
+        const QList<PredefinedColorPointer> predefinedColors = Color::kPredefinedColorsSet.allColors;
+        pCue->setColor(predefinedColors.at((hotcue % (predefinedColors.count() - 1)) + 1));
+    };
+
     // If quantize is enabled and we are not playing, jump to the cue point
     // since it's not necessarily where we currently are. TODO(XXX) is this
     // potentially invalid for vinyl control?

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -166,6 +166,12 @@ DlgPrefDeck::DlgPrefDeck(QWidget * parent, MixxxMainWindow * mixxx,
     connect(checkBoxSeekToCue, SIGNAL(toggled(bool)),
             this, SLOT(slotJumpToCueOnTrackLoadCheckbox(bool)));
 
+    // Automatically assign a color to new hot cues
+    m_bAssignHotcueColors = m_pConfig->getValue(ConfigKey("[Controls]", "AutoHotcueColors"), false);
+    checkBoxAssignHotcueColors->setChecked(m_bAssignHotcueColors);
+    connect(checkBoxAssignHotcueColors, SIGNAL(toggled(bool)),
+            this, SLOT(slotAssignHotcueColorsCheckbox(bool)));
+
     m_bRateInverted = m_pConfig->getValue(ConfigKey("[Controls]", "RateDir"), false);
     setRateDirectionForAllDecks(m_bRateInverted);
     checkBoxInvertSpeedSlider->setChecked(m_bRateInverted);
@@ -335,6 +341,9 @@ void DlgPrefDeck::slotUpdate() {
     checkBoxSeekToCue->setChecked(!m_pConfig->getValue(
             ConfigKey("[Controls]", "CueRecall"), false));
 
+    checkBoxAssignHotcueColors->setChecked(m_pConfig->getValue(
+            ConfigKey("[Controls]", "AutoHotcueColors"), false));
+
     double deck1RateRange = m_rateRangeControls[0]->get();
     int index = ComboBoxRateRange->findData(static_cast<int>(deck1RateRange * 100));
     if (index == -1) {
@@ -490,6 +499,10 @@ void DlgPrefDeck::slotJumpToCueOnTrackLoadCheckbox(bool checked) {
     m_bJumpToCueOnTrackLoad = checked;
 }
 
+void DlgPrefDeck::slotAssignHotcueColorsCheckbox(bool checked) {
+    m_bAssignHotcueColors = checked;
+}
+
 void DlgPrefDeck::slotSetTrackTimeDisplay(QAbstractButton* b) {
     if (b == radioButtonRemaining) {
         m_timeDisplayMode = TrackTime::DisplayMode::REMAINING;
@@ -567,6 +580,7 @@ void DlgPrefDeck::slotApply() {
                         !m_bDisallowTrackLoadToPlayingDeck);
 
     m_pConfig->setValue(ConfigKey("[Controls]", "CueRecall"), !m_bJumpToCueOnTrackLoad);
+    m_pConfig->setValue(ConfigKey("[Controls]", "AutoHotcueColors"), m_bAssignHotcueColors);
 
     // Set rate range
     setRateRangeForAllDecks(m_iRateRangePercent);

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -73,6 +73,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     void slotDisallowTrackLoadToPlayingDeckCheckbox(bool);
     void slotCueModeCombobox(int);
     void slotJumpToCueOnTrackLoadCheckbox(bool);
+    void slotAssignHotcueColorsCheckbox(bool);
     void slotRateRampingModeLinearButton(bool);
     void slotRateRampSensitivitySlider(int);
 
@@ -117,6 +118,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
 
     bool m_bDisallowTrackLoadToPlayingDeck;
     bool m_bJumpToCueOnTrackLoad;
+    bool m_bAssignHotcueColors;
 
     int m_iRateRangePercent;
     bool m_bRateInverted;

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -33,6 +33,16 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="labelAutoHotcueColors">
+        <property name="text">
+          <string>Auto hot cue colors</string>
+        </property>
+        <property name="buddy">
+         <cstring>checkBoxAssignHotcueColors</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="labelPositionDisplay">
         <property name="enabled">
@@ -52,7 +62,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1" colspan="2">
+      <item row="5" column="1" colspan="2">
        <widget class="QCheckBox" name="checkBoxDisallowLoadToPlayingDeck">
         <property name="text">
          <string>Do not load tracks into playing decks</string>
@@ -67,6 +77,17 @@
         </property>
         <property name="text">
          <string>Jump to main cue point on track load</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1" colspan="2">
+       <widget class="QCheckBox" name="checkBoxAssignHotcueColors">
+        <property name="toolTip">
+        <string>Automatically assigns a predefined color to a newly created hot cue point, based on
+            its index.</string>
+        </property>
+        <property name="text">
+         <string>Assign predefined colors to newly created hot cue points</string>
         </property>
        </widget>
       </item>
@@ -142,7 +163,7 @@ CUP mode:
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="labelPlayingTrackProtection">
         <property name="text">
          <string>Playing track protection</string>


### PR DESCRIPTION
This adds the ability to assign hotcue colors automatically (based on the index), similar to what Serato does.

Currently missing:
- [x] ~~Translations~~