### PR TITLE
Ensure model is not empty before removing rows.

### DIFF
--- a/src/preferences/broadcastsettingsmodel.cpp
+++ b/src/preferences/broadcastsettingsmodel.cpp
@@ -19,9 +19,11 @@ void BroadcastSettingsModel::resetFromSettings(BroadcastSettingsPointer pSetting
         return;
     }
 
-    beginRemoveRows(QModelIndex(), 0, m_profiles.size()-1);
-    endRemoveRows();
-    m_profiles.clear();
+    if (!m_profiles.isEmpty()) {
+        beginRemoveRows(QModelIndex(), 0, m_profiles.size()-1);
+        endRemoveRows();
+        m_profiles.clear();
+    }
 
     for(BroadcastProfilePtr profile : pSettings->profiles()) {
         BroadcastProfilePtr copy = profile->valuesCopy();

--- a/src/preferences/effectsettingsmodel.cpp
+++ b/src/preferences/effectsettingsmodel.cpp
@@ -19,9 +19,11 @@ void EffectSettingsModel::resetFromEffectManager(EffectsManager* pEffectsManager
         return;
     }
 
-    beginRemoveRows(QModelIndex(), 0, m_profiles.size()-1);
-    endRemoveRows();
-    m_profiles.clear();
+    if (!m_profiles.isEmpty()) {
+        beginRemoveRows(QModelIndex(), 0, m_profiles.size()-1);
+        endRemoveRows();
+        m_profiles.clear();
+    }
 
     for (EffectManifestPointer pManifest : pEffectsManager->getAvailableEffectManifests()) {
         const bool visibility = pEffectsManager->getEffectVisibility(pManifest);


### PR DESCRIPTION
Code can call the reset functions at anytime such as here [dlgprefeffects.cpp] on construction. (https://github.com/mixxxdj/mixxx/blob/b973ac9de81d55185be37a91c2cf2f92ae4db023/src/preferences/dialog/dlgprefeffects.cpp#L15)
Signed-off-by: Edward Kigwana <edwardwwgk@gmail.com>