### PR TITLE
[macOS testing required] Fix cue shift/offset for SoundSourceCoreAudio

### DIFF
--- a/src/sources/soundsourcecoreaudio.cpp
+++ b/src/sources/soundsourcecoreaudio.cpp
@@ -272,12 +272,18 @@ QStringList SoundSourceProviderCoreAudio::getSupportedFileExtensions() const {
     supportedFileExtensions.append("m4a");
     supportedFileExtensions.append("mp3");
     supportedFileExtensions.append("mp2");
-    //Can add mp3, mp2, ac3, and others here if you want.
-    //See:
-    //  http://developer.apple.com/library/mac/documentation/MusicAudio/Reference/AudioFileConvertRef/Reference/reference.html#//apple_ref/doc/c_ref/AudioFileTypeID
-
-    //XXX: ... but make sure you implement handling for any new format in ParseHeader!!!!!! -- asantoni
+    // Can add mp3, mp2, ac3, and others here if you want:
+    // http://developer.apple.com/library/mac/documentation/MusicAudio/Reference/AudioFileConvertRef/Reference/reference.html#//apple_ref/doc/c_ref/AudioFileTypeID
     return supportedFileExtensions;
+}
+
+SoundSourceProviderPriority SoundSourceProviderCoreAudio::getPriorityHint(
+        const QString& /*supportedFileExtension*/) const {
+    // On macOS CoreAudio is used both for decoding MP3 and M4A files. Neither
+    // FFmpeg nor libMAD are enabled in the release builds. In order to avoid
+    // priority conflicts with libMAD when enabled in the future the priority
+    // of this SoundSource is set to HIGHER.
+    return SoundSourceProviderPriority::HIGHER;
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourcecoreaudio.h
+++ b/src/sources/soundsourcecoreaudio.h
@@ -1,9 +1,6 @@
-#ifndef SOUNDSOURCECOREAUDIO_H
-#define SOUNDSOURCECOREAUDIO_H
+#pragma once
 
-#include "sources/soundsourceprovider.h"
-
-#include "sources/v1/legacyaudiosourceadapter.h"
+#include <vector>
 
 #include <AudioToolbox/AudioToolbox.h>
 //In our tree at lib/apple/
@@ -19,6 +16,10 @@
 #include "AudioFormat.h"
 #include "CoreAudioTypes.h"
 #endif
+
+#include "sources/soundsourceprovider.h"
+
+#include "sources/v1/legacyaudiosourceadapter.h"
 
 namespace mixxx {
 
@@ -43,7 +44,9 @@ class SoundSourceCoreAudio : public SoundSource, public virtual /*implements*/ L
     ExtAudioFileRef m_audioFile;
     CAStreamBasicDescription m_inputFormat;
     CAStreamBasicDescription m_outputFormat;
-    SInt64 m_headerFrames;
+    SINT m_leadingFrames;
+    SINT m_seekPrefetchFrames;
+    std::vector<CSAMPLE> m_seekPrefetchBuffer;
 };
 
 class SoundSourceProviderCoreAudio : public SoundSourceProvider {
@@ -58,5 +61,3 @@ class SoundSourceProviderCoreAudio : public SoundSourceProvider {
 };
 
 } // namespace mixxx
-
-#endif // SOUNDSOURCECOREAUDIO_H

--- a/src/sources/soundsourcecoreaudio.h
+++ b/src/sources/soundsourcecoreaudio.h
@@ -55,6 +55,9 @@ class SoundSourceProviderCoreAudio : public SoundSourceProvider {
 
     QStringList getSupportedFileExtensions() const override;
 
+    SoundSourceProviderPriority getPriorityHint(
+            const QString& supportedFileExtension) const override;
+
     SoundSourcePointer newSoundSource(const QUrl& url) override {
         return newSoundSourceFromUrl<SoundSourceCoreAudio>(url);
     }


### PR DESCRIPTION
As discussed on Zulip: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Cue.20shift.2Foffset

All unit tests pass, but extensive manual testing is required! Existing cue points might be shifted for some MP3 files.

Related:
https://github.com/digital-dj-tools/dj-data-converter/issues/3