### PR TITLE
Load skins from user settings directory

### DIFF
--- a/src/skin/skinloader.cpp
+++ b/src/skin/skinloader.cpp
@@ -30,6 +30,13 @@ SkinLoader::~SkinLoader() {
 
 QList<QDir> SkinLoader::getSkinSearchPaths() const {
     QList<QDir> searchPaths;
+
+    // Add user skin path to search paths
+    QDir userSkinsPath(m_pConfig->getSettingsPath());
+    if (userSkinsPath.cd("skins")) {
+        searchPaths.append(userSkinsPath);
+    }
+
     // If we can't find the skins folder then we can't load a skin at all. This
     // is a critical error in the user's Mixxx installation.
     QDir skinsPath(m_pConfig->getResourcePath());


### PR DESCRIPTION
Make it possible to load skins from the settings directory (e.g. `~/.mixxx/skins/` on Linux). This allows skin development with a standard Mixxx installation and without messing around with system directories.