### PR TITLE
Use snake_case for auto_hotcue_colors control object

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -551,7 +551,7 @@ void CueControl::hotcueSet(HotcueControl* pControl, double v) {
     // TODO(XXX) deal with spurious signals
     attachCue(pCue, hotcue);
 
-    if (getConfig()->getValue(ConfigKey("[Controls]", "AutoHotcueColors"), false)) {
+    if (getConfig()->getValue(ConfigKey("[Controls]", "auto_hotcue_colors"), false)) {
         const QList<PredefinedColorPointer> predefinedColors = Color::kPredefinedColorsSet.allColors;
         pCue->setColor(predefinedColors.at((hotcue % (predefinedColors.count() - 1)) + 1));
     };

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -166,7 +166,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget * parent, MixxxMainWindow * mixxx,
             this, SLOT(slotJumpToCueOnTrackLoadCheckbox(bool)));
 
     // Automatically assign a color to new hot cues
-    m_bAssignHotcueColors = m_pConfig->getValue(ConfigKey("[Controls]", "AutoHotcueColors"), false);
+    m_bAssignHotcueColors = m_pConfig->getValue(ConfigKey("[Controls]", "auto_hotcue_colors"), false);
     checkBoxAssignHotcueColors->setChecked(m_bAssignHotcueColors);
     connect(checkBoxAssignHotcueColors, SIGNAL(toggled(bool)),
             this, SLOT(slotAssignHotcueColorsCheckbox(bool)));
@@ -341,7 +341,7 @@ void DlgPrefDeck::slotUpdate() {
             ConfigKey("[Controls]", "CueRecall"), false));
 
     checkBoxAssignHotcueColors->setChecked(m_pConfig->getValue(
-            ConfigKey("[Controls]", "AutoHotcueColors"), false));
+            ConfigKey("[Controls]", "auto_hotcue_colors"), false));
 
     double deck1RateRange = m_rateRangeControls[0]->get();
     int index = ComboBoxRateRange->findData(static_cast<int>(deck1RateRange * 100));
@@ -579,7 +579,7 @@ void DlgPrefDeck::slotApply() {
                         !m_bDisallowTrackLoadToPlayingDeck);
 
     m_pConfig->setValue(ConfigKey("[Controls]", "CueRecall"), !m_bJumpToCueOnTrackLoad);
-    m_pConfig->setValue(ConfigKey("[Controls]", "AutoHotcueColors"), m_bAssignHotcueColors);
+    m_pConfig->setValue(ConfigKey("[Controls]", "auto_hotcue_colors"), m_bAssignHotcueColors);
 
     // Set rate range
     setRateRangeForAllDecks(m_iRateRangePercent);


### PR DESCRIPTION
[New controls should use snake_case by convention.](https://github.com/mixxxdj/mixxx/pull/2118#issuecomment-498126595) Since this particular control has been part of a Mixxx release yet, we can safely rename it.