### PR TITLE
mixxx.py: add some new MIPS machine types

### DIFF
--- a/build/mixxx.py
+++ b/build/mixxx.py
@@ -46,7 +46,7 @@ class MixxxBuild(object):
             raise Exception("invalid target platform")
 
         if machine.lower() not in ['x86_64', 'x86', 'i686', 'i586',
-                                   'alpha', 'hppa', 'mips', 'mipsel', 's390',
+                                   'alpha', 'hppa', 's390',
                                    'sparc', 'ia64', 'armel', 'armhf', 'hurd-i386',
                                    'armv5tel', 'armv5tejl', 'armv6l', 'armv6hl',
                                    'armv7l', 'armv7hl', 'armv7hnl',
@@ -55,8 +55,11 @@ class MixxxBuild(object):
                                    'i486', 'i386', 'ppc', 'ppc64', 'powerpc',
                                    'powerpc64', 'powerpcspe', 's390x',
                                    'amd64', 'em64t', 'intel64', 'arm64',
-                                   'ppc64el', 'ppc64le', 'm68k', 'mips64',
-                                   'mips64el', 'mipsn32', 'mipsn32el',
+                                   'ppc64el', 'ppc64le', 'm68k', 
+                                   'mips', 'mipsel', 'mipsr6', 'mipsr6el',
+                                   'mips64', 'mips64r6', 'mips64el', 'mips64r6el', 
+                                   'mipsn32', 'mipsn32el', 'mipsn32r6', 'mipsn32r6el',
+                                   'mipsisa32r6', 'mipsisa32r6el', 'mipsisa64r6', 'mipsisa64r6el',
                                    'aarch64']:
             raise Exception("invalid machine type")
 


### PR DESCRIPTION
For MIPS r6, we add some new machine types，in Debian and upstream:
    'mips', 'mipsel', 'mipsr6', 'mipsr6el',
    'mips64', 'mips64r6', 'mips64el', 'mips64r6el', 
    'mipsn32', 'mipsn32el', 'mipsn32r6', 'mipsn32r6el',
    'mipsisa32r6', 'mipsisa32r6el', 'mipsisa64r6', 'mipsisa64r6el'