### PR TITLE
Skip AnalyzerSilence if intro/outro cues exist

### DIFF
--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -57,9 +57,12 @@ AnalyzerSilence::AnalyzerSilence(UserSettingsPointer pConfig)
 }
 
 bool AnalyzerSilence::initialize(TrackPointer tio, int sampleRate, int totalSamples) {
-    Q_UNUSED(tio);
     Q_UNUSED(sampleRate);
     Q_UNUSED(totalSamples);
+
+    if (!shouldAnalyze(tio)) {
+        return false;
+    }
 
     m_iFramesProcessed = 0;
     m_bPrevSilence = true;

--- a/src/analyzer/analyzersilence.h
+++ b/src/analyzer/analyzersilence.h
@@ -18,8 +18,6 @@ class AnalyzerSilence : public Analyzer {
     void cleanup(TrackPointer tio) override;
 
   private:
-    static bool shouldUpdateCue(CuePosition cuePosition);
-
     UserSettingsPointer m_pConfig;
     float m_fThreshold;
     int m_iFramesProcessed;


### PR DESCRIPTION
This fixes the first and most obvious flaw I found.

The intro/outro cues are re-analyzed even if they have already been set by the analyzer. Both cues must be set manually to skip the analyzer.

Now the track is only processed if at least one of the intro start or outro end cues are settable. The main cue point must not be considered for this decision. It is only set conditionally if the intro start cue is also set.

@ninomp Please verify!

...a bigger refactoring of the Analyzer interface and framework will follow. Not only `AnalyzerSilence` is executed more frequently than it should.