### PR TITLE
Fix battery widget percentage display

### DIFF
--- a/src/widget/wbattery.cpp
+++ b/src/widget/wbattery.cpp
@@ -86,7 +86,7 @@ QString formatMinutes(int minutes) {
 
 int pixmapIndexFromPercentage(double dPercentage, int numPixmaps) {
     // See WDisplay::getActivePixmapIndex for more info on this.
-    int result = static_cast<int>(dPercentage * numPixmaps - 0.00001) / 100;
+    int result = static_cast<int>(dPercentage / 100.0 * numPixmaps);
     result = math_min(numPixmaps - 1, math_max(0, result));
     return result;
 }

--- a/src/widget/wbattery.cpp
+++ b/src/widget/wbattery.cpp
@@ -86,7 +86,7 @@ QString formatMinutes(int minutes) {
 
 int pixmapIndexFromPercentage(double dPercentage, int numPixmaps) {
     // See WDisplay::getActivePixmapIndex for more info on this.
-    int result = static_cast<int>(dPercentage * numPixmaps - 0.00001);
+    int result = static_cast<int>(dPercentage * numPixmaps - 0.00001) / 100;
     result = math_min(numPixmaps - 1, math_max(0, result));
     return result;
 }


### PR DESCRIPTION
Maybe I'm missing something.., I wonder if the current code works for anyone.
(I'm always seeing the 'full'-icon regardless of the battery status)