### PR TITLE
Add support for the battery widget on BSD systems (via upower)

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -120,9 +120,9 @@ class IOKit(Dependence):
         build.env.Append(LINKFLAGS='-framework IOKit')
 
 class UPower(Dependence):
-    """UPower is used to get battery measurements on Linux."""
+    """UPower is used to get battery measurements on Linux and BSD."""
     def configure(self, build, conf):
-        if not build.platform_is_linux:
+        if not build.platform_is_linux and not build.platform_is_bsd:
             return
         build.env.ParseConfig(
                 'pkg-config upower-glib --silence-errors --cflags --libs')

--- a/build/features.py
+++ b/build/features.py
@@ -1179,7 +1179,7 @@ class Battery(Feature):
             return ["src/util/battery/batterywindows.cpp"]
         elif build.platform_is_osx:
             return ["src/util/battery/batterymac.cpp"]
-        elif build.platform_is_linux:
+        elif build.platform_is_linux or build.platform_is_bsd:
             return ["src/util/battery/batterylinux.cpp"]
         else:
             raise Exception('Battery support is not implemented for the target platform.')

--- a/src/util/battery/battery.cpp
+++ b/src/util/battery/battery.cpp
@@ -3,12 +3,12 @@
 // Do not include platform-specific battery implementation unless we are built
 // with battery support (__BATTERY__).
 #ifdef __BATTERY__
-#ifdef Q_OS_LINUX
-#include "util/battery/batterylinux.h"
-#elif defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
 #include "util/battery/batterywindows.h"
 #elif defined(Q_OS_MAC)
 #include "util/battery/batterymac.h"
+#else
+#include "util/battery/batterylinux.h"
 #endif
 #endif
 #include "util/math.h"
@@ -31,12 +31,12 @@ Battery::~Battery() {
 
 Battery* Battery::getBattery(QObject* parent) {
 #ifdef __BATTERY__
-#ifdef Q_OS_LINUX
-    return new BatteryLinux(parent);
-#elif defined(Q_OS_WIN)
+#if defined(Q_OS_WIN)
     return new BatteryWindows(parent);
 #elif defined(Q_OS_MAC)
     return new BatteryMac(parent);
+#else
+    return new BatteryLinux(parent);
 #endif
 #else
     Q_UNUSED(parent);


### PR DESCRIPTION
upower is available on all major BSDs, so `batterlinux.cpp` can be used for them.