### PR TITLE
Fix analyzer framework

### DIFF
--- a/src/analyzer/analyzer.h
+++ b/src/analyzer/analyzer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "util/assert.h"
 #include "util/types.h"
 
 /*
@@ -44,7 +45,7 @@ class Analyzer {
 
 typedef std::unique_ptr<Analyzer> AnalyzerPtr;
 
-class AnalyzerWithState {
+class AnalyzerWithState final {
   public:
     explicit AnalyzerWithState(AnalyzerPtr analyzer)
             : m_analyzer(std::move(analyzer)),
@@ -53,6 +54,11 @@ class AnalyzerWithState {
     }
     AnalyzerWithState(const AnalyzerWithState&) = delete;
     AnalyzerWithState(AnalyzerWithState&&) = default;
+    ~AnalyzerWithState() {
+        VERIFY_OR_DEBUG_ASSERT(!m_active) {
+            m_analyzer->cleanup();
+        }
+    }
 
     bool isActive() const {
         return m_active;

--- a/src/analyzer/analyzer.h
+++ b/src/analyzer/analyzer.h
@@ -44,41 +44,41 @@ class Analyzer {
 
 typedef std::unique_ptr<Analyzer> AnalyzerPtr;
 
-class AnalyzerState {
+class AnalyzerWithState {
   public:
-    explicit AnalyzerState(AnalyzerPtr analyzer)
+    explicit AnalyzerWithState(AnalyzerPtr analyzer)
             : m_analyzer(std::move(analyzer)),
-              m_processing(false) {
+              m_continueAnalyzing(false) {
         DEBUG_ASSERT(m_analyzer);
     }
-    AnalyzerState(const AnalyzerState&) = delete;
-    AnalyzerState(AnalyzerState&&) = default;
+    AnalyzerWithState(const AnalyzerWithState&) = delete;
+    AnalyzerWithState(AnalyzerWithState&&) = default;
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) {
-        DEBUG_ASSERT(!m_processing);
-        m_processing = m_analyzer->initialize(tio, sampleRate, totalSamples);
-        return m_processing;
+        DEBUG_ASSERT(!m_continueAnalyzing);
+        m_continueAnalyzing = m_analyzer->initialize(tio, sampleRate, totalSamples);
+        return m_continueAnalyzing;
     }
 
     void process(const CSAMPLE* pIn, const int iLen) {
-        if (m_processing) {
-            m_processing = m_analyzer->process(pIn, iLen);
+        if (m_continueAnalyzing) {
+            m_continueAnalyzing = m_analyzer->process(pIn, iLen);
         }
     }
 
     void finalize(TrackPointer tio) {
-        if (m_processing) {
+        if (m_continueAnalyzing) {
             m_analyzer->finalize(tio);
-            m_processing = false;
+            m_continueAnalyzing = false;
         }
     }
 
     void cleanup() {
         m_analyzer->cleanup();
-        m_processing = false;
+        m_continueAnalyzing = false;
     }
 
   private:
     AnalyzerPtr m_analyzer;
-    bool m_processing;
+    bool m_continueAnalyzing;
 };

--- a/src/analyzer/analyzer.h
+++ b/src/analyzer/analyzer.h
@@ -1,5 +1,4 @@
-#ifndef ANALYZER_ANALYZER_H
-#define ANALYZER_ANALYZER_H
+#pragma once
 
 #include "util/types.h"
 
@@ -15,12 +14,28 @@
 
 class Analyzer {
   public:
-    virtual bool initialize(TrackPointer tio, int sampleRate, int totalSamples) = 0;
-    virtual bool isDisabledOrLoadStoredSuccess(TrackPointer tio) const = 0;
-    virtual void process(const CSAMPLE* pIn, const int iLen) = 0;
-    virtual void cleanup(TrackPointer tio) = 0;
-    virtual void finalize(TrackPointer tio) = 0;
     virtual ~Analyzer() = default;
-};
 
-#endif
+    // This method is supposed to:
+    //  1. Check if the track needs to be analyzed, otherwise return false.
+    //  2. Perform the initialization and return true on success.
+    //  3. If the initialization failed log the internal error and return false.
+    virtual bool initialize(TrackPointer tio, int sampleRate, int totalSamples) = 0;
+
+    /////////////////////////////////////////////////////////////////////////
+    // All following methods will only be invoked after initialize()
+    // returned true!
+    /////////////////////////////////////////////////////////////////////////
+
+    // Analyze the next chunk of audio samples.
+    virtual void process(const CSAMPLE* pIn, const int iLen) = 0;
+
+    // Update the track object with the analysis results after
+    // processing finished, i.e. all available audio samples have
+    // been processed.
+    virtual void finalize(TrackPointer tio) = 0;
+
+    // Discard any temporary results or free allocated memory after
+    // finalization.
+    virtual void cleanup(TrackPointer tio) = 0;
+};

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -172,7 +172,7 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer tio) const {
     return true;
 }
 
-bool AnalyzerBeats::process(const CSAMPLE *pIn, const int iLen) {
+bool AnalyzerBeats::processSamples(const CSAMPLE *pIn, const int iLen) {
     VERIFY_OR_DEBUG_ASSERT(m_pPlugin) {
         return false;
     }
@@ -182,14 +182,14 @@ bool AnalyzerBeats::process(const CSAMPLE *pIn, const int iLen) {
         return true; // silently ignore all remaining samples
     }
 
-    return m_pPlugin->process(pIn, iLen);
+    return m_pPlugin->processSamples(pIn, iLen);
 }
 
 void AnalyzerBeats::cleanup() {
     m_pPlugin.reset();
 }
 
-void AnalyzerBeats::finalize(TrackPointer tio) {
+void AnalyzerBeats::storeResults(TrackPointer tio) {
     VERIFY_OR_DEBUG_ASSERT(m_pPlugin) {
         return;
     }

--- a/src/analyzer/analyzerbeats.cpp
+++ b/src/analyzer/analyzerbeats.cpp
@@ -81,7 +81,8 @@ bool AnalyzerBeats::initialize(TrackPointer tio, int sampleRate, int totalSample
     // In fast analysis mode, skip processing after
     // kFastAnalysisSecondsToAnalyze seconds are analyzed.
     if (m_bPreferencesFastAnalysis) {
-        m_iMaxSamplesToProcess = mixxx::kFastAnalysisSecondsToAnalyze * m_iSampleRate * mixxx::kAnalysisChannels;
+        m_iMaxSamplesToProcess =
+                mixxx::kFastAnalysisSecondsToAnalyze * m_iSampleRate * mixxx::kAnalysisChannels;
     } else {
         m_iMaxSamplesToProcess = m_iTotalSamples;
     }
@@ -138,11 +139,16 @@ bool AnalyzerBeats::shouldAnalyze(TrackPointer tio) const {
         QString subVersion = pBeats->getSubVersion();
 
         QHash<QString, QString> extraVersionInfo = getExtraVersionInfo(
-                pluginID, m_bPreferencesFastAnalysis);
+                pluginID,
+                m_bPreferencesFastAnalysis);
         QString newVersion = BeatFactory::getPreferredVersion(
                 m_bPreferencesOffsetCorrection);
         QString newSubVersion = BeatFactory::getPreferredSubVersion(
-                m_bPreferencesFixedTempo, m_bPreferencesOffsetCorrection, iMinBpm, iMaxBpm, extraVersionInfo);
+                m_bPreferencesFixedTempo,
+                m_bPreferencesOffsetCorrection,
+                iMinBpm,
+                iMaxBpm,
+                extraVersionInfo);
 
         if (version == newVersion && subVersion == newSubVersion) {
             // If the version and settings have not changed then if the world is
@@ -199,7 +205,15 @@ void AnalyzerBeats::finalize(TrackPointer tio) {
         QHash<QString, QString> extraVersionInfo = getExtraVersionInfo(
                 m_pluginId, m_bPreferencesFastAnalysis);
         pBeats = BeatFactory::makePreferredBeats(
-                *tio, beats, extraVersionInfo, m_bPreferencesFixedTempo, m_bPreferencesOffsetCorrection, m_iSampleRate, m_iTotalSamples, m_iMinBpm, m_iMaxBpm);
+                *tio,
+                beats,
+                extraVersionInfo,
+                m_bPreferencesFixedTempo,
+                m_bPreferencesOffsetCorrection,
+                m_iSampleRate,
+                m_iTotalSamples,
+                m_iMinBpm,
+                m_iMaxBpm);
         qDebug() << "AnalyzerBeats plugin detected" << beats.size()
                  << "beats. Average BPM:" << (pBeats ? pBeats->getBpm() : 0.0);
     } else {

--- a/src/analyzer/analyzerbeats.h
+++ b/src/analyzer/analyzerbeats.h
@@ -27,12 +27,12 @@ class AnalyzerBeats: public Analyzer {
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    bool isDisabledOrLoadStoredSuccess(TrackPointer tio) const override;
     void process(const CSAMPLE *pIn, const int iLen) override;
     void cleanup(TrackPointer tio) override;
     void finalize(TrackPointer tio) override;
 
   private:
+    bool shouldAnalyze(TrackPointer tio) const;
     static QHash<QString, QString> getExtraVersionInfo(
         QString pluginId, bool bPreferencesFastAnalysis);
 

--- a/src/analyzer/analyzerbeats.h
+++ b/src/analyzer/analyzerbeats.h
@@ -17,7 +17,7 @@
 #include "preferences/usersettings.h"
 #include "util/memory.h"
 
-class AnalyzerBeats: public Analyzer {
+class AnalyzerBeats : public Analyzer {
   public:
     explicit AnalyzerBeats(
             UserSettingsPointer pConfig,
@@ -27,14 +27,14 @@ class AnalyzerBeats: public Analyzer {
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    void process(const CSAMPLE *pIn, const int iLen) override;
-    void cleanup(TrackPointer tio) override;
+    bool process(const CSAMPLE *pIn, const int iLen) override;
     void finalize(TrackPointer tio) override;
+    void cleanup() override;
 
   private:
     bool shouldAnalyze(TrackPointer tio) const;
     static QHash<QString, QString> getExtraVersionInfo(
-        QString pluginId, bool bPreferencesFastAnalysis);
+            QString pluginId, bool bPreferencesFastAnalysis);
 
     BeatDetectionSettings m_bpmSettings;
     std::unique_ptr<mixxx::AnalyzerBeatsPlugin> m_pPlugin;

--- a/src/analyzer/analyzerbeats.h
+++ b/src/analyzer/analyzerbeats.h
@@ -27,8 +27,8 @@ class AnalyzerBeats : public Analyzer {
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    bool process(const CSAMPLE *pIn, const int iLen) override;
-    void finalize(TrackPointer tio) override;
+    bool processSamples(const CSAMPLE *pIn, const int iLen) override;
+    void storeResults(TrackPointer tio) override;
     void cleanup() override;
 
   private:

--- a/src/analyzer/analyzerebur128.cpp
+++ b/src/analyzer/analyzerebur128.cpp
@@ -42,32 +42,32 @@ void AnalyzerEbur128::cleanup() {
     }
 }
 
-bool AnalyzerEbur128::process(const CSAMPLE *pIn, const int iLen) {
+bool AnalyzerEbur128::processSamples(const CSAMPLE *pIn, const int iLen) {
     VERIFY_OR_DEBUG_ASSERT(m_pState) {
         return false;
     }
-    ScopedTimer t("AnalyzerEbur128::process()");
+    ScopedTimer t("AnalyzerEbur128::processSamples()");
     size_t frames = iLen / 2;
     int e = ebur128_add_frames_float(m_pState, pIn, frames);
     VERIFY_OR_DEBUG_ASSERT(e == EBUR128_SUCCESS) {
-        qWarning() << "AnalyzerEbur128::process() failed with" << e;
+        qWarning() << "AnalyzerEbur128::processSamples() failed with" << e;
         return false;
     }
     return true;
 }
 
-void AnalyzerEbur128::finalize(TrackPointer tio) {
+void AnalyzerEbur128::storeResults(TrackPointer tio) {
     VERIFY_OR_DEBUG_ASSERT(m_pState) {
         return;
     }
     double averageLufs;
     int e = ebur128_loudness_global(m_pState, &averageLufs);
     VERIFY_OR_DEBUG_ASSERT(e == EBUR128_SUCCESS) {
-        qWarning() << "AnalyzerEbur128::finalize() failed with" << e;
+        qWarning() << "AnalyzerEbur128::storeResults() failed with" << e;
         return;
     }
     if (averageLufs == -HUGE_VAL || averageLufs == 0.0) {
-        qWarning() << "AnalyzerEbur128::finalize() averageLufs invalid:"
+        qWarning() << "AnalyzerEbur128::storeResults() averageLufs invalid:"
                    << averageLufs;
         return;
     }

--- a/src/analyzer/analyzerebur128.cpp
+++ b/src/analyzer/analyzerebur128.cpp
@@ -21,8 +21,10 @@ AnalyzerEbur128::~AnalyzerEbur128() {
 }
 
 bool AnalyzerEbur128::initialize(TrackPointer tio,
-        int sampleRate, int totalSamples) {
-    if (isDisabledOrLoadStoredSuccess(tio) || totalSamples == 0) {
+        int sampleRate,
+        int totalSamples) {
+    if (m_rgSettings.isAnalyzerDisabled(2, tio) || totalSamples == 0) {
+        qDebug() << "Skipping AnalyzerEbur128";
         return false;
     }
     if (!isInitialized()) {
@@ -31,10 +33,6 @@ bool AnalyzerEbur128::initialize(TrackPointer tio,
                 EBUR128_MODE_I);
     }
     return isInitialized();
-}
-
-bool AnalyzerEbur128::isDisabledOrLoadStoredSuccess(TrackPointer tio) const {
-    return m_rgSettings.isAnalyzerDisabled(2, tio);
 }
 
 void AnalyzerEbur128::cleanup() {

--- a/src/analyzer/analyzerebur128.h
+++ b/src/analyzer/analyzerebur128.h
@@ -16,7 +16,6 @@ class AnalyzerEbur128 : public Analyzer {
     }
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    bool isDisabledOrLoadStoredSuccess(TrackPointer tio) const override;
     void process(const CSAMPLE* pIn, const int iLen) override;
     void cleanup(TrackPointer tio) override;
     void finalize(TrackPointer tio) override;

--- a/src/analyzer/analyzerebur128.h
+++ b/src/analyzer/analyzerebur128.h
@@ -16,16 +16,11 @@ class AnalyzerEbur128 : public Analyzer {
     }
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    void process(const CSAMPLE* pIn, const int iLen) override;
-    void cleanup(TrackPointer tio) override;
+    bool process(const CSAMPLE* pIn, const int iLen) override;
     void finalize(TrackPointer tio) override;
+    void cleanup() override;
 
   private:
-    void cleanup();
-    bool isInitialized() const {
-        return m_pState != nullptr;
-    }
-
     ReplayGainSettings m_rgSettings;
     ebur128_state* m_pState;
 };

--- a/src/analyzer/analyzerebur128.h
+++ b/src/analyzer/analyzerebur128.h
@@ -16,8 +16,8 @@ class AnalyzerEbur128 : public Analyzer {
     }
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    bool process(const CSAMPLE* pIn, const int iLen) override;
-    void finalize(TrackPointer tio) override;
+    bool processSamples(const CSAMPLE* pIn, const int iLen) override;
+    void storeResults(TrackPointer tio) override;
     void cleanup() override;
 
   private:

--- a/src/analyzer/analyzergain.cpp
+++ b/src/analyzer/analyzergain.cpp
@@ -23,16 +23,13 @@ AnalyzerGain::~AnalyzerGain() {
 }
 
 bool AnalyzerGain::initialize(TrackPointer tio, int sampleRate, int totalSamples) {
-    if (isDisabledOrLoadStoredSuccess(tio) || totalSamples == 0) {
+    if (m_rgSettings.isAnalyzerDisabled(1, tio) || totalSamples == 0) {
+        qDebug() << "Skipping AnalyzerGain";
         return false;
     }
 
     m_initalized = m_pReplayGain->initialise((long)sampleRate, 2);
     return true;
-}
-
-bool AnalyzerGain::isDisabledOrLoadStoredSuccess(TrackPointer tio) const {
-    return m_rgSettings.isAnalyzerDisabled(1, tio);
 }
 
 void AnalyzerGain::cleanup(TrackPointer tio) {

--- a/src/analyzer/analyzergain.cpp
+++ b/src/analyzer/analyzergain.cpp
@@ -65,5 +65,5 @@ void AnalyzerGain::storeResults(TrackPointer tio) {
     mixxx::ReplayGain replayGain(tio->getReplayGain());
     replayGain.setRatio(db2ratio(fReplayGainOutput));
     tio->setReplayGain(replayGain);
-    qDebug() << "ReplayGain 1.0 result is" << fReplayGainOutput << "dB for" << tio->getFileInfo();
+    qDebug() << "ReplayGain 1.0 result is" << fReplayGainOutput << "dB for" << tio->getLocation();
 }

--- a/src/analyzer/analyzergain.cpp
+++ b/src/analyzer/analyzergain.cpp
@@ -33,7 +33,7 @@ bool AnalyzerGain::initialize(TrackPointer tio, int sampleRate, int totalSamples
 void AnalyzerGain::cleanup() {
 }
 
-bool AnalyzerGain::process(const CSAMPLE *pIn, const int iLen) {
+bool AnalyzerGain::processSamples(const CSAMPLE *pIn, const int iLen) {
     ScopedTimer t("AnalyzerGain::process()");
 
     int halfLength = static_cast<int>(iLen / 2);
@@ -49,7 +49,7 @@ bool AnalyzerGain::process(const CSAMPLE *pIn, const int iLen) {
     return m_pReplayGain->process(m_pLeftTempBuffer, m_pRightTempBuffer, halfLength);
 }
 
-void AnalyzerGain::finalize(TrackPointer tio) {
+void AnalyzerGain::storeResults(TrackPointer tio) {
     //TODO: We are going to store values as relative peaks so that "0" means that no replaygain has been evaluated.
     // This means that we are going to transform from dB to peaks and viceversa.
     // One may think to digg into replay_gain code and modify it so that

--- a/src/analyzer/analyzergain.h
+++ b/src/analyzer/analyzergain.h
@@ -23,12 +23,11 @@ class AnalyzerGain : public Analyzer {
     }
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    void process(const CSAMPLE* pIn, const int iLen) override;
-    void cleanup(TrackPointer tio) override;
+    bool process(const CSAMPLE* pIn, const int iLen) override;
     void finalize(TrackPointer tio) override;
+    void cleanup() override;
 
   private:
-    bool m_initalized;
     ReplayGainSettings m_rgSettings;
     CSAMPLE* m_pLeftTempBuffer;
     CSAMPLE* m_pRightTempBuffer;

--- a/src/analyzer/analyzergain.h
+++ b/src/analyzer/analyzergain.h
@@ -23,7 +23,6 @@ class AnalyzerGain : public Analyzer {
     }
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    bool isDisabledOrLoadStoredSuccess(TrackPointer tio) const override;
     void process(const CSAMPLE* pIn, const int iLen) override;
     void cleanup(TrackPointer tio) override;
     void finalize(TrackPointer tio) override;

--- a/src/analyzer/analyzergain.h
+++ b/src/analyzer/analyzergain.h
@@ -23,8 +23,8 @@ class AnalyzerGain : public Analyzer {
     }
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    bool process(const CSAMPLE* pIn, const int iLen) override;
-    void finalize(TrackPointer tio) override;
+    bool processSamples(const CSAMPLE* pIn, const int iLen) override;
+    void storeResults(TrackPointer tio) override;
     void cleanup() override;
 
   private:

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -111,7 +111,7 @@ bool AnalyzerKey::shouldAnalyze(TrackPointer tio) const {
     return true;
 }
 
-bool AnalyzerKey::process(const CSAMPLE *pIn, const int iLen) {
+bool AnalyzerKey::processSamples(const CSAMPLE *pIn, const int iLen) {
     VERIFY_OR_DEBUG_ASSERT(m_pPlugin) {
         return false;
     }
@@ -121,14 +121,14 @@ bool AnalyzerKey::process(const CSAMPLE *pIn, const int iLen) {
         return true; // silently ignore remaining samples
     }
 
-    return m_pPlugin->process(pIn, iLen);
+    return m_pPlugin->processSamples(pIn, iLen);
 }
 
 void AnalyzerKey::cleanup() {
     m_pPlugin.reset();
 }
 
-void AnalyzerKey::finalize(TrackPointer tio) {
+void AnalyzerKey::storeResults(TrackPointer tio) {
     VERIFY_OR_DEBUG_ASSERT(m_pPlugin) {
         return;
     }

--- a/src/analyzer/analyzerkey.h
+++ b/src/analyzer/analyzerkey.h
@@ -20,7 +20,6 @@ class AnalyzerKey : public Analyzer {
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    bool isDisabledOrLoadStoredSuccess(TrackPointer tio) const override;
     void process(const CSAMPLE *pIn, const int iLen) override;
     void finalize(TrackPointer tio) override;
     void cleanup(TrackPointer tio) override;
@@ -28,6 +27,8 @@ class AnalyzerKey : public Analyzer {
   private:
     static QHash<QString, QString> getExtraVersionInfo(
         QString pluginId, bool bPreferencesFastAnalysis);
+
+    bool shouldAnalyze(TrackPointer tio) const;
 
     KeyDetectionSettings m_keySettings;
     std::unique_ptr<mixxx::AnalyzerKeyPlugin> m_pPlugin;

--- a/src/analyzer/analyzerkey.h
+++ b/src/analyzer/analyzerkey.h
@@ -20,8 +20,8 @@ class AnalyzerKey : public Analyzer {
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    bool process(const CSAMPLE *pIn, const int iLen) override;
-    void finalize(TrackPointer tio) override;
+    bool processSamples(const CSAMPLE *pIn, const int iLen) override;
+    void storeResults(TrackPointer tio) override;
     void cleanup() override;
 
   private:

--- a/src/analyzer/analyzerkey.h
+++ b/src/analyzer/analyzerkey.h
@@ -20,13 +20,13 @@ class AnalyzerKey : public Analyzer {
     static QList<mixxx::AnalyzerPluginInfo> availablePlugins();
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    void process(const CSAMPLE *pIn, const int iLen) override;
+    bool process(const CSAMPLE *pIn, const int iLen) override;
     void finalize(TrackPointer tio) override;
-    void cleanup(TrackPointer tio) override;
+    void cleanup() override;
 
   private:
     static QHash<QString, QString> getExtraVersionInfo(
-        QString pluginId, bool bPreferencesFastAnalysis);
+            QString pluginId, bool bPreferencesFastAnalysis);
 
     bool shouldAnalyze(TrackPointer tio) const;
 

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -72,10 +72,6 @@ bool AnalyzerSilence::initialize(TrackPointer tio, int sampleRate, int totalSamp
     return true;
 }
 
-bool AnalyzerSilence::isDisabledOrLoadStoredSuccess(TrackPointer tio) const {
-    return !shouldAnalyze(tio);
-}
-
 void AnalyzerSilence::process(const CSAMPLE* pIn, const int iLen) {
     for (int i = 0; i < iLen; i += mixxx::kAnalysisChannels) {
         // Compute max of channels in this sample frame
@@ -119,8 +115,11 @@ void AnalyzerSilence::finalize(TrackPointer tio) {
         m_iSignalEnd = m_iFramesProcessed;
     }
 
+    double introStart = mixxx::kAnalysisChannels * m_iSignalStart;
+    double outroEnd = mixxx::kAnalysisChannels * m_iSignalEnd;
+
     if (shouldUpdateMainCue(tio->getCuePoint())) {
-        tio->setCuePoint(CuePosition(mixxx::kAnalysisChannels * m_iSignalStart, Cue::AUTOMATIC));
+        tio->setCuePoint(CuePosition(introStart, Cue::AUTOMATIC));
     }
 
     CuePointer pIntroCue = tio->findCueByType(Cue::INTRO);
@@ -128,10 +127,9 @@ void AnalyzerSilence::finalize(TrackPointer tio) {
         pIntroCue = tio->createAndAddCue();
         pIntroCue->setType(Cue::INTRO);
         pIntroCue->setSource(Cue::AUTOMATIC);
-        pIntroCue->setPosition(mixxx::kAnalysisChannels * m_iSignalStart);
-        pIntroCue->setLength(0.0);
-    } else if (pIntroCue->getSource() != Cue::MANUAL) {
-        pIntroCue->setPosition(mixxx::kAnalysisChannels * m_iSignalStart);
+    }
+    if (pIntroCue->getSource() != Cue::MANUAL) {
+        pIntroCue->setPosition(introStart);
         pIntroCue->setLength(0.0);
     }
 
@@ -140,10 +138,9 @@ void AnalyzerSilence::finalize(TrackPointer tio) {
         pOutroCue = tio->createAndAddCue();
         pOutroCue->setType(Cue::OUTRO);
         pOutroCue->setSource(Cue::AUTOMATIC);
+    }
+    if (pOutroCue->getSource() != Cue::MANUAL) {
         pOutroCue->setPosition(-1.0);
-        pOutroCue->setLength(mixxx::kAnalysisChannels * m_iSignalEnd);
-    } else if (pOutroCue->getSource() != Cue::MANUAL) {
-        pOutroCue->setPosition(-1.0);
-        pOutroCue->setLength(mixxx::kAnalysisChannels * m_iSignalEnd);
+        pOutroCue->setLength(outroEnd);
     }
 }

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -72,7 +72,7 @@ bool AnalyzerSilence::initialize(TrackPointer tio, int sampleRate, int totalSamp
     return true;
 }
 
-void AnalyzerSilence::process(const CSAMPLE* pIn, const int iLen) {
+bool AnalyzerSilence::process(const CSAMPLE* pIn, const int iLen) {
     for (int i = 0; i < iLen; i += mixxx::kAnalysisChannels) {
         // Compute max of channels in this sample frame
         CSAMPLE fMax = CSAMPLE_ZERO;
@@ -93,12 +93,11 @@ void AnalyzerSilence::process(const CSAMPLE* pIn, const int iLen) {
 
         m_bPrevSilence = bSilence;
     }
-
     m_iFramesProcessed += iLen / mixxx::kAnalysisChannels;
+    return true;
 }
 
-void AnalyzerSilence::cleanup(TrackPointer tio) {
-    Q_UNUSED(tio);
+void AnalyzerSilence::cleanup() {
 }
 
 void AnalyzerSilence::finalize(TrackPointer tio) {

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -72,7 +72,7 @@ bool AnalyzerSilence::initialize(TrackPointer tio, int sampleRate, int totalSamp
     return true;
 }
 
-bool AnalyzerSilence::process(const CSAMPLE* pIn, const int iLen) {
+bool AnalyzerSilence::processSamples(const CSAMPLE* pIn, const int iLen) {
     for (int i = 0; i < iLen; i += mixxx::kAnalysisChannels) {
         // Compute max of channels in this sample frame
         CSAMPLE fMax = CSAMPLE_ZERO;
@@ -100,7 +100,7 @@ bool AnalyzerSilence::process(const CSAMPLE* pIn, const int iLen) {
 void AnalyzerSilence::cleanup() {
 }
 
-void AnalyzerSilence::finalize(TrackPointer tio) {
+void AnalyzerSilence::storeResults(TrackPointer tio) {
     if (m_iSignalStart < 0) {
         m_iSignalStart = 0;
     }

--- a/src/analyzer/analyzersilence.h
+++ b/src/analyzer/analyzersilence.h
@@ -12,8 +12,8 @@ class AnalyzerSilence : public Analyzer {
     ~AnalyzerSilence() override = default;
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    bool process(const CSAMPLE* pIn, const int iLen) override;
-    void finalize(TrackPointer tio) override;
+    bool processSamples(const CSAMPLE* pIn, const int iLen) override;
+    void storeResults(TrackPointer tio) override;
     void cleanup() override;
 
   private:

--- a/src/analyzer/analyzersilence.h
+++ b/src/analyzer/analyzersilence.h
@@ -12,9 +12,9 @@ class AnalyzerSilence : public Analyzer {
     ~AnalyzerSilence() override = default;
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    void process(const CSAMPLE* pIn, const int iLen) override;
+    bool process(const CSAMPLE* pIn, const int iLen) override;
     void finalize(TrackPointer tio) override;
-    void cleanup(TrackPointer tio) override;
+    void cleanup() override;
 
   private:
     UserSettingsPointer m_pConfig;

--- a/src/analyzer/analyzersilence.h
+++ b/src/analyzer/analyzersilence.h
@@ -12,7 +12,6 @@ class AnalyzerSilence : public Analyzer {
     ~AnalyzerSilence() override = default;
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    bool isDisabledOrLoadStoredSuccess(TrackPointer tio) const override;
     void process(const CSAMPLE* pIn, const int iLen) override;
     void finalize(TrackPointer tio) override;
     void cleanup(TrackPointer tio) override;

--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -259,7 +259,7 @@ AnalyzerThread::AnalysisResult AnalyzerThread::analyzeAudioSource(
         if (readableSampleFrames.frameLength() == mixxx::kAnalysisFramesPerBlock) {
             // Complete chunk of audio samples has been read for analysis
             for (auto&& analyzer : m_analyzers) {
-                analyzer.process(
+                analyzer.processSamples(
                         readableSampleFrames.readableData(),
                         readableSampleFrames.readableLength());
             }

--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -165,13 +165,12 @@ void AnalyzerThread::doRun() {
                 emitBusyProgress(kAnalyzerProgressFinalizing);
                 // This takes around 3 sec on a Atom Netbook
                 for (auto&& analyzer : m_analyzers) {
-                    analyzer.finalize(m_currentTrack);
-                    analyzer.cleanup();
+                    analyzer.finish(m_currentTrack);
                 }
                 emitDoneProgress(kAnalyzerProgressDone);
             } else {
                 for (auto&& analyzer : m_analyzers) {
-                    analyzer.cleanup();
+                    analyzer.cancel();
                 }
                 emitDoneProgress(kAnalyzerProgressUnknown);
             }

--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -103,20 +103,20 @@ void AnalyzerThread::doRun() {
             return;
         }
         QSqlDatabase dbConnection = mixxx::DbConnectionPooled(m_dbConnectionPool);
-        m_analyzers.push_back(AnalyzerState(std::make_unique<AnalyzerWaveform>(m_pConfig, dbConnection)));
+        m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerWaveform>(m_pConfig, dbConnection)));
     }
     if (AnalyzerGain::isEnabled(ReplayGainSettings(m_pConfig))) {
-        m_analyzers.push_back(AnalyzerState(std::make_unique<AnalyzerGain>(m_pConfig)));
+        m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerGain>(m_pConfig)));
     }
     if (AnalyzerEbur128::isEnabled(ReplayGainSettings(m_pConfig))) {
-        m_analyzers.push_back(AnalyzerState(std::make_unique<AnalyzerEbur128>(m_pConfig)));
+        m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerEbur128>(m_pConfig)));
     }
     // BPM detection might be disabled in the config, but can be overridden
     // and enabled by explicitly setting the mode flag.
     const bool enforceBpmDetection = (m_modeFlags & AnalyzerModeFlags::WithBeats) != 0;
-    m_analyzers.push_back(AnalyzerState(std::make_unique<AnalyzerBeats>(m_pConfig, enforceBpmDetection)));
-    m_analyzers.push_back(AnalyzerState(std::make_unique<AnalyzerKey>(m_pConfig)));
-    m_analyzers.push_back(AnalyzerState(std::make_unique<AnalyzerSilence>(m_pConfig)));
+    m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerBeats>(m_pConfig, enforceBpmDetection)));
+    m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerKey>(m_pConfig)));
+    m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerSilence>(m_pConfig)));
     DEBUG_ASSERT(!m_analyzers.empty());
     kLogger.debug() << "Activated" << m_analyzers.size() << "analyzers";
 

--- a/src/analyzer/analyzerthread.h
+++ b/src/analyzer/analyzerthread.h
@@ -4,17 +4,16 @@
 
 #include "util/workerthread.h"
 
-#include "analyzer/analyzerprogress.h"
 #include "analyzer/analyzer.h"
+#include "analyzer/analyzerprogress.h"
 #include "preferences/usersettings.h"
 #include "sources/audiosource.h"
 #include "track/track.h"
 #include "util/db/dbconnectionpool.h"
-#include "util/performancetimer.h"
-#include "util/samplebuffer.h"
 #include "util/memory.h"
 #include "util/mpscfifo.h"
-
+#include "util/performancetimer.h"
+#include "util/samplebuffer.h"
 
 enum AnalyzerModeFlags {
     None = 0x00,
@@ -46,9 +45,9 @@ class AnalyzerThread : public WorkerThread {
     Q_OBJECT
 
   public:
-    typedef std::unique_ptr<AnalyzerThread, void(*)(AnalyzerThread*)> Pointer;
+    typedef std::unique_ptr<AnalyzerThread, void (*)(AnalyzerThread*)> Pointer;
     // Subclass that provides a default constructor and nothing else
-    class NullPointer: public Pointer {
+    class NullPointer : public Pointer {
       public:
         NullPointer();
     };
@@ -114,8 +113,7 @@ class AnalyzerThread : public WorkerThread {
     // Thread local: Only used in the constructor/destructor and within
     // run() by the worker thread.
 
-    typedef std::unique_ptr<Analyzer> AnalyzerPtr;
-    std::vector<AnalyzerPtr> m_analyzers;
+    std::vector<AnalyzerState> m_analyzers;
 
     mixxx::SampleBuffer m_sampleBuffer;
 

--- a/src/analyzer/analyzerthread.h
+++ b/src/analyzer/analyzerthread.h
@@ -113,7 +113,7 @@ class AnalyzerThread : public WorkerThread {
     // Thread local: Only used in the constructor/destructor and within
     // run() by the worker thread.
 
-    std::vector<AnalyzerState> m_analyzers;
+    std::vector<AnalyzerWithState> m_analyzers;
 
     mixxx::SampleBuffer m_sampleBuffer;
 

--- a/src/analyzer/analyzerwaveform.cpp
+++ b/src/analyzer/analyzerwaveform.cpp
@@ -167,7 +167,7 @@ void AnalyzerWaveform::destroyFilters() {
     }
 }
 
-bool AnalyzerWaveform::process(const CSAMPLE* buffer, const int bufferLength) {
+bool AnalyzerWaveform::processSamples(const CSAMPLE* buffer, const int bufferLength) {
     VERIFY_OR_DEBUG_ASSERT(m_waveform) {
         return false;
     }
@@ -263,7 +263,7 @@ void AnalyzerWaveform::cleanup() {
     m_waveformSummaryData = nullptr;
 }
 
-void AnalyzerWaveform::finalize(TrackPointer tio) {
+void AnalyzerWaveform::storeResults(TrackPointer tio) {
     // Force completion to waveform size
     if (m_waveform) {
         m_waveform->setSaveState(Waveform::SaveState::SavePending);

--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -143,9 +143,9 @@ class AnalyzerWaveform : public Analyzer {
     ~AnalyzerWaveform() override;
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    void process(const CSAMPLE* buffer, const int bufferLength) override;
-    void cleanup(TrackPointer tio) override;
+    bool process(const CSAMPLE* buffer, const int bufferLength) override;
     void finalize(TrackPointer tio) override;
+    void cleanup() override;
 
   private:
     bool shouldAnalyze(TrackPointer tio) const;

--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -7,10 +7,10 @@
 #include <limits>
 
 #include "analyzer/analyzer.h"
-#include "waveform/waveform.h"
 #include "library/dao/analysisdao.h"
 #include "util/math.h"
 #include "util/performancetimer.h"
+#include "waveform/waveform.h"
 
 //NOTS vrince some test to segment sound, to apply color in the waveform
 //#define TEST_HEAT_MAP
@@ -143,12 +143,13 @@ class AnalyzerWaveform : public Analyzer {
     ~AnalyzerWaveform() override;
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    bool isDisabledOrLoadStoredSuccess(TrackPointer tio) const override;
-    void process(const CSAMPLE *buffer, const int bufferLength) override;
+    void process(const CSAMPLE* buffer, const int bufferLength) override;
     void cleanup(TrackPointer tio) override;
     void finalize(TrackPointer tio) override;
 
   private:
+    bool shouldAnalyze(TrackPointer tio) const;
+
     void storeCurrentStridePower();
     void resetCurrentStride();
 
@@ -157,8 +158,6 @@ class AnalyzerWaveform : public Analyzer {
     void storeIfGreater(float* pDest, float source);
 
     mutable AnalysisDao m_analysisDao;
-
-    bool m_skipProcessing;
 
     WaveformPointer m_waveform;
     WaveformPointer m_waveformSummary;

--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -143,8 +143,8 @@ class AnalyzerWaveform : public Analyzer {
     ~AnalyzerWaveform() override;
 
     bool initialize(TrackPointer tio, int sampleRate, int totalSamples) override;
-    bool process(const CSAMPLE* buffer, const int bufferLength) override;
-    void finalize(TrackPointer tio) override;
+    bool processSamples(const CSAMPLE* buffer, const int bufferLength) override;
+    void storeResults(TrackPointer tio) override;
     void cleanup() override;
 
   private:

--- a/src/analyzer/plugins/analyzerplugin.h
+++ b/src/analyzer/plugins/analyzerplugin.h
@@ -11,9 +11,10 @@ namespace mixxx {
 
 struct AnalyzerPluginInfo {
     AnalyzerPluginInfo(const QString& id,
-                       const QString& author,
-                       const QString& name)
-            : id(id), author(author), name(name) { }
+            const QString& author,
+            const QString& name)
+            : id(id), author(author), name(name) {
+    }
     QString id;
     QString author;
     QString name;
@@ -35,7 +36,7 @@ class AnalyzerPlugin {
     virtual AnalyzerPluginInfo info() const = 0;
 
     virtual bool initialize(int samplerate) = 0;
-    virtual bool process(const CSAMPLE* pIn, const int iLen) = 0;
+    virtual bool processSamples(const CSAMPLE* pIn, const int iLen) = 0;
     virtual bool finalize() = 0;
 };
 
@@ -59,6 +60,6 @@ class AnalyzerKeyPlugin : public AnalyzerPlugin {
     virtual KeyChangeList getKeyChanges() const = 0;
 };
 
-}  // namespace mixxx
+} // namespace mixxx
 
 #endif /* ANALYZER_PLUGINS_ANALYZERPLUGIN_H */

--- a/src/analyzer/plugins/analyzerqueenmarybeats.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.cpp
@@ -27,7 +27,7 @@ DFConfig makeDetectionFunctionConfig() {
     return config;
 }
 
-}  // namespace
+} // namespace
 
 AnalyzerQueenMaryBeats::AnalyzerQueenMaryBeats()
         : m_iSampleRate(0) {
@@ -40,19 +40,19 @@ bool AnalyzerQueenMaryBeats::initialize(int samplerate) {
     m_detectionResults.clear();
     m_iSampleRate = samplerate;
     m_pDetectionFunction = std::make_unique<DetectionFunction>(
-        makeDetectionFunctionConfig());
+            makeDetectionFunctionConfig());
 
     m_helper.initialize(
-        kWindowSize, kStepSize, [this](double* pWindow, size_t) {
-            // TODO(rryan) reserve?
-            m_detectionResults.push_back(
-                m_pDetectionFunction->processTimeDomain(pWindow));
-            return true;
-        });
+            kWindowSize, kStepSize, [this](double* pWindow, size_t) {
+                // TODO(rryan) reserve?
+                m_detectionResults.push_back(
+                        m_pDetectionFunction->processTimeDomain(pWindow));
+                return true;
+            });
     return true;
 }
 
-bool AnalyzerQueenMaryBeats::process(const CSAMPLE* pIn, const int iLen) {
+bool AnalyzerQueenMaryBeats::processSamples(const CSAMPLE* pIn, const int iLen) {
     DEBUG_ASSERT(iLen == kAnalysisSamplesPerBlock);
     DEBUG_ASSERT(iLen % kAnalysisChannels == 0);
     if (!m_pDetectionFunction) {
@@ -105,4 +105,4 @@ bool AnalyzerQueenMaryBeats::finalize() {
     return true;
 }
 
-}  // namespace mixxx
+} // namespace mixxx

--- a/src/analyzer/plugins/analyzerqueenmarybeats.h
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.h
@@ -18,9 +18,9 @@ class AnalyzerQueenMaryBeats : public AnalyzerBeatsPlugin {
   public:
     static AnalyzerPluginInfo pluginInfo() {
         return AnalyzerPluginInfo(
-            "qm-tempotracker",
-            QObject::tr("Queen Mary University London"),
-            QObject::tr("Queen Mary Tempo and Beat Tracker"));
+                "qm-tempotracker",
+                QObject::tr("Queen Mary University London"),
+                QObject::tr("Queen Mary Tempo and Beat Tracker"));
     }
 
     AnalyzerQueenMaryBeats();
@@ -31,7 +31,7 @@ class AnalyzerQueenMaryBeats : public AnalyzerBeatsPlugin {
     }
 
     bool initialize(int samplerate) override;
-    bool process(const CSAMPLE* pIn, const int iLen) override;
+    bool processSamples(const CSAMPLE* pIn, const int iLen) override;
     bool finalize() override;
 
     bool supportsBeatTracking() const override {
@@ -50,6 +50,6 @@ class AnalyzerQueenMaryBeats : public AnalyzerBeatsPlugin {
     QVector<double> m_resultBeats;
 };
 
-}  // namespace mixxx
+} // namespace mixxx
 
 #endif /* ANALYZER_PLUGINS_ANALYZERQUEENMARYBEATS_H */

--- a/src/analyzer/plugins/analyzerqueenmarykey.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarykey.cpp
@@ -65,7 +65,7 @@ bool AnalyzerQueenMaryKey::initialize(int samplerate) {
             });
 }
 
-bool AnalyzerQueenMaryKey::process(const CSAMPLE* pIn, const int iLen) {
+bool AnalyzerQueenMaryKey::processSamples(const CSAMPLE* pIn, const int iLen) {
     DEBUG_ASSERT(iLen == kAnalysisSamplesPerBlock);
     DEBUG_ASSERT(iLen % kAnalysisChannels == 0);
 

--- a/src/analyzer/plugins/analyzerqueenmarykey.h
+++ b/src/analyzer/plugins/analyzerqueenmarykey.h
@@ -31,7 +31,7 @@ class AnalyzerQueenMaryKey : public AnalyzerKeyPlugin {
     }
 
     bool initialize(int samplerate) override;
-    bool process(const CSAMPLE* pIn, const int iLen) override;
+    bool processSamples(const CSAMPLE* pIn, const int iLen) override;
     bool finalize() override;
 
     KeyChangeList getKeyChanges() const override {

--- a/src/analyzer/plugins/analyzersoundtouchbeats.cpp
+++ b/src/analyzer/plugins/analyzersoundtouchbeats.cpp
@@ -7,12 +7,13 @@
 
 namespace mixxx {
 
-AnalyzerSoundTouchBeats::AnalyzerSoundTouchBeats() :
-        m_downmixBuffer(kAnalysisFramesPerBlock),
-        m_fResultBpm(0.0f) {
+AnalyzerSoundTouchBeats::AnalyzerSoundTouchBeats()
+        : m_downmixBuffer(kAnalysisFramesPerBlock),
+          m_fResultBpm(0.0f) {
 }
 
-AnalyzerSoundTouchBeats::~AnalyzerSoundTouchBeats() { }
+AnalyzerSoundTouchBeats::~AnalyzerSoundTouchBeats() {
+}
 
 bool AnalyzerSoundTouchBeats::initialize(int samplerate) {
     m_fResultBpm = 0.0f;
@@ -20,7 +21,7 @@ bool AnalyzerSoundTouchBeats::initialize(int samplerate) {
     return true;
 }
 
-bool AnalyzerSoundTouchBeats::process(const CSAMPLE* pIn, const int iLen) {
+bool AnalyzerSoundTouchBeats::processSamples(const CSAMPLE* pIn, const int iLen) {
     if (!m_pSoundTouch) {
         return false;
     }
@@ -47,4 +48,4 @@ bool AnalyzerSoundTouchBeats::finalize() {
     return true;
 }
 
-}  // namespace mixxx
+} // namespace mixxx

--- a/src/analyzer/plugins/analyzersoundtouchbeats.h
+++ b/src/analyzer/plugins/analyzersoundtouchbeats.h
@@ -9,7 +9,7 @@
 
 namespace soundtouch {
 class BPMDetect;
-}  // namespace soundtouch
+} // namespace soundtouch
 
 namespace mixxx {
 
@@ -17,9 +17,9 @@ class AnalyzerSoundTouchBeats : public AnalyzerBeatsPlugin {
   public:
     static AnalyzerPluginInfo pluginInfo() {
         return AnalyzerPluginInfo(
-            "mixxxbpmdetection",
-            "Olli Parviainen",
-            QObject::tr("SoundTouch BPM Detector (Legacy)"));
+                "mixxxbpmdetection",
+                "Olli Parviainen",
+                QObject::tr("SoundTouch BPM Detector (Legacy)"));
     }
 
     AnalyzerSoundTouchBeats();
@@ -30,7 +30,7 @@ class AnalyzerSoundTouchBeats : public AnalyzerBeatsPlugin {
     }
 
     bool initialize(int samplerate) override;
-    bool process(const CSAMPLE* pIn, const int iLen) override;
+    bool processSamples(const CSAMPLE* pIn, const int iLen) override;
     bool finalize() override;
 
     bool supportsBeatTracking() const override {
@@ -47,6 +47,6 @@ class AnalyzerSoundTouchBeats : public AnalyzerBeatsPlugin {
     float m_fResultBpm;
 };
 
-}  // namespace mixxx
+} // namespace mixxx
 
 #endif /* ANALYZER_PLUGINS_ANALYZERSOUNDTOUCHBEATS */

--- a/src/test/analyserwaveformtest.cpp
+++ b/src/test/analyserwaveformtest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
-#include <QtDebug>
 #include <QDir>
+#include <QtDebug>
 
 #include "test/mixxxtest.h"
 
@@ -8,19 +8,19 @@
 #include "library/dao/analysisdao.h"
 #include "track/track.h"
 
-#define BIGBUF_SIZE (1024 * 1024)  //Megabyte
-#define CANARY_SIZE (1024*4)
+#define BIGBUF_SIZE (1024 * 1024) //Megabyte
+#define CANARY_SIZE (1024 * 4)
 #define MAGIC_FLOAT 1234.567890f
 #define CANARY_FLOAT 0.0f
 
 namespace {
 
-class AnalyzerWaveformTest: public MixxxTest {
+class AnalyzerWaveformTest : public MixxxTest {
   protected:
     AnalyzerWaveformTest()
-      : aw(config(), QSqlDatabase()),
-        bigbuf(nullptr),
-        canaryBigBuf(nullptr) {
+            : aw(config(), QSqlDatabase()),
+              bigbuf(nullptr),
+              canaryBigBuf(nullptr) {
     }
 
     void SetUp() override {
@@ -34,18 +34,18 @@ class AnalyzerWaveformTest: public MixxxTest {
         //Memory layout for canaryBigBuf looks like
         //  [ canary | big buf | canary ]
 
-        canaryBigBuf = new CSAMPLE[BIGBUF_SIZE + 2*CANARY_SIZE];
+        canaryBigBuf = new CSAMPLE[BIGBUF_SIZE + 2 * CANARY_SIZE];
         for (int i = 0; i < CANARY_SIZE; i++)
             canaryBigBuf[i] = CANARY_FLOAT;
-        for (int i = CANARY_SIZE; i < CANARY_SIZE+BIGBUF_SIZE; i++)
+        for (int i = CANARY_SIZE; i < CANARY_SIZE + BIGBUF_SIZE; i++)
             canaryBigBuf[i] = MAGIC_FLOAT;
-        for (int i = CANARY_SIZE+BIGBUF_SIZE; i < 2*CANARY_SIZE+BIGBUF_SIZE; i++)
+        for (int i = CANARY_SIZE + BIGBUF_SIZE; i < 2 * CANARY_SIZE + BIGBUF_SIZE; i++)
             canaryBigBuf[i] = CANARY_FLOAT;
     }
 
     void TearDown() override {
-        delete [] bigbuf;
-        delete [] canaryBigBuf;
+        delete[] bigbuf;
+        delete[] canaryBigBuf;
     }
 
   protected:
@@ -58,8 +58,9 @@ class AnalyzerWaveformTest: public MixxxTest {
 //Test to make sure we don't modify the source buffer.
 TEST_F(AnalyzerWaveformTest, simpleAnalyze) {
     aw.initialize(tio, tio->getSampleRate(), BIGBUF_SIZE);
-    aw.process(bigbuf, BIGBUF_SIZE);
-    aw.finalize(tio);
+    aw.processSamples(bigbuf, BIGBUF_SIZE);
+    aw.storeResults(tio);
+    aw.cleanup();
     for (int i = 0; i < BIGBUF_SIZE; i++) {
         EXPECT_FLOAT_EQ(bigbuf[i], MAGIC_FLOAT);
     }
@@ -68,12 +69,13 @@ TEST_F(AnalyzerWaveformTest, simpleAnalyze) {
 //Basic test to make sure we don't step out of bounds.
 TEST_F(AnalyzerWaveformTest, canary) {
     aw.initialize(tio, tio->getSampleRate(), BIGBUF_SIZE);
-    aw.process(&canaryBigBuf[CANARY_SIZE], BIGBUF_SIZE);
-    aw.finalize(tio);
+    aw.processSamples(&canaryBigBuf[CANARY_SIZE], BIGBUF_SIZE);
+    aw.storeResults(tio);
+    aw.cleanup();
     for (int i = 0; i < CANARY_SIZE; i++) {
         EXPECT_FLOAT_EQ(canaryBigBuf[i], CANARY_FLOAT);
     }
-    for (int i = CANARY_SIZE+BIGBUF_SIZE; i < 2*CANARY_SIZE+BIGBUF_SIZE; i++) {
+    for (int i = CANARY_SIZE + BIGBUF_SIZE; i < 2 * CANARY_SIZE + BIGBUF_SIZE; i++) {
         EXPECT_FLOAT_EQ(canaryBigBuf[i], CANARY_FLOAT);
     }
 }
@@ -82,14 +84,15 @@ TEST_F(AnalyzerWaveformTest, canary) {
 //initialize(..) and process(..) is told to process more samples than that,
 //that we don't step out of bounds.
 TEST_F(AnalyzerWaveformTest, wrongTotalSamples) {
-    aw.initialize(tio, tio->getSampleRate(), BIGBUF_SIZE/2);
+    aw.initialize(tio, tio->getSampleRate(), BIGBUF_SIZE / 2);
     // Deliver double the expected samples
     int wrongTotalSamples = BIGBUF_SIZE;
-    int blockSize = 2*32768;
-    for (int i = CANARY_SIZE; i < CANARY_SIZE+wrongTotalSamples; i += blockSize) {
-        aw.process(&canaryBigBuf[i], blockSize);
+    int blockSize = 2 * 32768;
+    for (int i = CANARY_SIZE; i < CANARY_SIZE + wrongTotalSamples; i += blockSize) {
+        aw.processSamples(&canaryBigBuf[i], blockSize);
     }
-    aw.finalize(tio);
+    aw.storeResults(tio);
+    aw.cleanup();
     //Ensure the source buffer is intact
     for (int i = CANARY_SIZE; i < BIGBUF_SIZE; i++) {
         EXPECT_FLOAT_EQ(canaryBigBuf[i], MAGIC_FLOAT);
@@ -98,8 +101,8 @@ TEST_F(AnalyzerWaveformTest, wrongTotalSamples) {
     for (int i = 0; i < CANARY_SIZE; i++) {
         EXPECT_FLOAT_EQ(canaryBigBuf[i], CANARY_FLOAT);
     }
-    for (int i = CANARY_SIZE+BIGBUF_SIZE; i < 2*CANARY_SIZE+BIGBUF_SIZE; i++) {
+    for (int i = CANARY_SIZE + BIGBUF_SIZE; i < 2 * CANARY_SIZE + BIGBUF_SIZE; i++) {
         EXPECT_FLOAT_EQ(canaryBigBuf[i], CANARY_FLOAT);
     }
 }
-}
+} // namespace

--- a/src/test/analyzersilence_test.cpp
+++ b/src/test/analyzersilence_test.cpp
@@ -9,12 +9,12 @@ namespace {
 
 constexpr mixxx::AudioSignal::ChannelCount kChannelCount = mixxx::kEngineChannelCount;
 constexpr int kTrackLengthFrames = 100000;
-constexpr double kTonePitchHz = 1000.0;  // 1kHz
+constexpr double kTonePitchHz = 1000.0; // 1kHz
 
 class AnalyzerSilenceTest : public MixxxTest {
   protected:
     AnalyzerSilenceTest()
-        : analyzerSilence(config()) {
+            : analyzerSilence(config()) {
     }
 
     void SetUp() override {
@@ -26,20 +26,21 @@ class AnalyzerSilenceTest : public MixxxTest {
     }
 
     void TearDown() override {
-        delete [] pTrackSampleData;
+        delete[] pTrackSampleData;
     }
 
     void analyzeTrack() {
         analyzerSilence.initialize(pTrack, pTrack->getSampleRate(), nTrackSampleDataLength);
-        analyzerSilence.process(pTrackSampleData, nTrackSampleDataLength);
-        analyzerSilence.finalize(pTrack);
+        analyzerSilence.processSamples(pTrackSampleData, nTrackSampleDataLength);
+        analyzerSilence.storeResults(pTrack);
+        analyzerSilence.cleanup();
     }
 
   protected:
     AnalyzerSilence analyzerSilence;
     TrackPointer pTrack;
     CSAMPLE* pTrackSampleData;
-    int nTrackSampleDataLength;  // in samples
+    int nTrackSampleDataLength; // in samples
 };
 
 TEST_F(AnalyzerSilenceTest, SilenceTrack) {
@@ -172,19 +173,19 @@ TEST_F(AnalyzerSilenceTest, ToneTrackWithSilenceInTheMiddle) {
 TEST_F(AnalyzerSilenceTest, UpdateNonUserAdjustedCues) {
     int halfTrackLength = nTrackSampleDataLength / 2;
 
-    pTrack->setCuePoint(CuePosition(100, Cue::AUTOMATIC));  // Arbitrary value
+    pTrack->setCuePoint(CuePosition(100, Cue::AUTOMATIC)); // Arbitrary value
 
     CuePointer pIntroCue = pTrack->createAndAddCue();
     pIntroCue->setType(Cue::INTRO);
     pIntroCue->setSource(Cue::AUTOMATIC);
-    pIntroCue->setPosition(1000);  // Arbitrary value
+    pIntroCue->setPosition(1000); // Arbitrary value
     pIntroCue->setLength(0.0);
 
     CuePointer pOutroCue = pTrack->createAndAddCue();
     pOutroCue->setType(Cue::OUTRO);
     pOutroCue->setSource(Cue::AUTOMATIC);
     pOutroCue->setPosition(-1.0);
-    pOutroCue->setLength(9000);  // Arbitrary value
+    pOutroCue->setLength(9000); // Arbitrary value
 
     // Fill the first half with silence
     for (int i = 0; i < halfTrackLength; i++) {
@@ -218,14 +219,14 @@ TEST_F(AnalyzerSilenceTest, UpdateNonUserAdjustedRangeCues) {
     CuePointer pIntroCue = pTrack->createAndAddCue();
     pIntroCue->setType(Cue::INTRO);
     pIntroCue->setSource(Cue::AUTOMATIC);
-    pIntroCue->setPosition(1500.0);  // Arbitrary value
-    pIntroCue->setLength(1000.0);  // Arbitrary value
+    pIntroCue->setPosition(1500.0); // Arbitrary value
+    pIntroCue->setLength(1000.0);   // Arbitrary value
 
     CuePointer pOutroCue = pTrack->createAndAddCue();
     pOutroCue->setType(Cue::OUTRO);
     pOutroCue->setSource(Cue::AUTOMATIC);
-    pOutroCue->setPosition(9000.0);  // Arbitrary value
-    pOutroCue->setLength(1000.0);  // Arbitrary value
+    pOutroCue->setPosition(9000.0); // Arbitrary value
+    pOutroCue->setLength(1000.0);   // Arbitrary value
 
     // Fill the first third with silence
     for (int i = 0; i < thirdTrackLength; i++) {
@@ -300,4 +301,4 @@ TEST_F(AnalyzerSilenceTest, RespectUserEdits) {
     EXPECT_EQ(Cue::MANUAL, pOutroCue->getSource());
 }
 
-}
+} // namespace


### PR DESCRIPTION
~~This PR is based on #2145 and serves as a preview until #2145 has been merged. I wanted to separate those 2 PRs with a very different focus.~~ Rebased after #2145 has been merged

Invoking the method (with the unintuitive name) `Analyzer::isDisabledOrLoadStoredSuccess()` should have been called by the analyzer framework, but actually it wasn't. Instead some analyzers invoked it internally in `Analyzer::initialize()`, but not all did so. This causes unnecessary invocations of some analyzers. It turned out that this function is redundant and could be removed and merged into `Analyzer::initialize()`.

Further more `Analyzer::cleanup()` does not need a `Track` object, only `Analyzer::finalize()` does. The usage of those two very similar functions was inconsistent among different analyzers.

Finally I documented all the requirements and expectations for the pure virtual functions in the `Analyzer` base class.