### PR TITLE
Improve libfaadloader portability

### DIFF
--- a/src/sources/libfaadloader.cpp
+++ b/src/sources/libfaadloader.cpp
@@ -24,9 +24,7 @@ LibFaadLoader::LibFaadLoader()
           m_neAACDecGetErrorMessage(nullptr) {
     // Load shared library
     QStringList libnames;
-#ifdef __LINUX__
-    libnames << "libfaad.so.2";
-#elif __WINDOWS__
+#ifdef __WINDOWS__
     // http://www.rarewares.org/aac-decoders.php
     libnames << "libfaad2.dll";
 #elif __APPLE__
@@ -37,8 +35,7 @@ LibFaadLoader::LibFaadLoader()
     // Using MacPorts ('sudo port install faad2' command):
     libnames << "/opt/local/lib/libfaad2.dylib";
 #else
-    DEBUG_ASSERT(!"OS not implemented");
-    return;
+    libnames << "libfaad.so";
 #endif
 
     for (const auto& libname : libnames) {


### PR DESCRIPTION
There is no need to restrict loading of `libfaad.so` to linux.
(The `.2` in `libfaad.so.2` should not be needed and is linux specific.)

If mixxx is compiled with 'faad=1' and libfaad.so is not available, a warning will be printed:
`Warning [Main]: LibFaadLoader - Failed to load  ("libfaad.so") ,  "Cannot load library libfaad.so: (File not found)"`