### PR TITLE
Fix analysis progress display

### DIFF
--- a/src/analyzer/trackanalysisscheduler.cpp
+++ b/src/analyzer/trackanalysisscheduler.cpp
@@ -198,20 +198,25 @@ void TrackAnalysisScheduler::onWorkerThreadProgress(
         break;
     case AnalyzerThreadState::Busy:
         DEBUG_ASSERT(trackId.isValid());
-        DEBUG_ASSERT(m_pendingTrackIds.find(trackId) != m_pendingTrackIds.end());
-        DEBUG_ASSERT(analyzerProgress != kAnalyzerProgressUnknown);
-        DEBUG_ASSERT(analyzerProgress < kAnalyzerProgressDone);
-        worker.onAnalyzerProgress(analyzerProgress);
-        emit trackProgress(trackId, analyzerProgress);
+        // Ignore delayed signals for tracks that are no longer pending
+        if (m_pendingTrackIds.find(trackId) != m_pendingTrackIds.end()) {
+            DEBUG_ASSERT(analyzerProgress != kAnalyzerProgressUnknown);
+            DEBUG_ASSERT(analyzerProgress < kAnalyzerProgressDone);
+            worker.onAnalyzerProgress(analyzerProgress);
+            emit trackProgress(trackId, analyzerProgress);
+        }
         break;
     case AnalyzerThreadState::Done:
         DEBUG_ASSERT(trackId.isValid());
-        DEBUG_ASSERT(m_pendingTrackIds.find(trackId) != m_pendingTrackIds.end());
-        DEBUG_ASSERT((analyzerProgress == kAnalyzerProgressDone) // success
-                || (analyzerProgress == kAnalyzerProgressUnknown)); // failure
-        m_pendingTrackIds.erase(trackId);
-        worker.onAnalyzerProgress(analyzerProgress);
-        emit trackProgress(trackId, analyzerProgress);
+        // Ignore delayed signals for tracks that are no longer pending
+        if (m_pendingTrackIds.find(trackId) != m_pendingTrackIds.end()) {
+            DEBUG_ASSERT(m_pendingTrackIds.find(trackId) != m_pendingTrackIds.end());
+            DEBUG_ASSERT((analyzerProgress == kAnalyzerProgressDone) // success
+                    || (analyzerProgress == kAnalyzerProgressUnknown)); // failure
+            m_pendingTrackIds.erase(trackId);
+            worker.onAnalyzerProgress(analyzerProgress);
+            emit trackProgress(trackId, analyzerProgress);
+        }
         break;
     case AnalyzerThreadState::Exit:
         DEBUG_ASSERT(!trackId.isValid());

--- a/src/analyzer/trackanalysisscheduler.cpp
+++ b/src/analyzer/trackanalysisscheduler.cpp
@@ -210,7 +210,6 @@ void TrackAnalysisScheduler::onWorkerThreadProgress(
         DEBUG_ASSERT(trackId.isValid());
         // Ignore delayed signals for tracks that are no longer pending
         if (m_pendingTrackIds.find(trackId) != m_pendingTrackIds.end()) {
-            DEBUG_ASSERT(m_pendingTrackIds.find(trackId) != m_pendingTrackIds.end());
             DEBUG_ASSERT((analyzerProgress == kAnalyzerProgressDone) // success
                     || (analyzerProgress == kAnalyzerProgressUnknown)); // failure
             m_pendingTrackIds.erase(trackId);

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -138,6 +138,8 @@ void AnalysisFeature::analyzeTracks(QList<TrackId> trackIds) {
 
         connect(m_pTrackAnalysisScheduler.get(), &TrackAnalysisScheduler::progress,
                 m_pAnalysisView, &DlgAnalysis::onTrackAnalysisSchedulerProgress);
+        connect(m_pTrackAnalysisScheduler.get(), &TrackAnalysisScheduler::finished,
+                m_pAnalysisView, &DlgAnalysis::onTrackAnalysisSchedulerFinished);
         connect(m_pTrackAnalysisScheduler.get(), &TrackAnalysisScheduler::progress,
                 this, &AnalysisFeature::onTrackAnalysisSchedulerProgress);
         connect(m_pTrackAnalysisScheduler.get(), &TrackAnalysisScheduler::finished,

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -178,6 +178,10 @@ void DlgAnalysis::onTrackAnalysisSchedulerProgress(
     }
 }
 
+void DlgAnalysis::onTrackAnalysisSchedulerFinished() {
+    slotAnalysisActive(false);
+}
+
 void DlgAnalysis::showRecentSongs() {
     m_pAnalysisLibraryTableModel->showRecentSongs();
 }

--- a/src/library/dlganalysis.h
+++ b/src/library/dlganalysis.h
@@ -43,6 +43,7 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
     void analyze();
     void slotAnalysisActive(bool bActive);
     void onTrackAnalysisSchedulerProgress(AnalyzerProgress analyzerProgress, int finishedCount, int totalCount);
+    void onTrackAnalysisSchedulerFinished();
     void showRecentSongs();
     void showAllSongs();
     void installEventFilter(QObject* pFilter);


### PR DESCRIPTION
Bug reported here: https://mixxx.zulipchat.com/#narrow/stream/109695-_support/topic/analysis.2C.20expected.20behavior.20when.20re-processing/near/167409630

I was not able to reproduce the bug, hopefully it is gone now!

- Added a missing signal slot connection to get notified when the analysis has finished
- Unrelated: Fixed a minor race condition due to queued signals that caused a debug assertion