### PR TITLE
Default settings: Store broadcast credentials as plain text

### DIFF
--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -219,11 +219,7 @@ void BroadcastProfile::copyValuesTo(BroadcastProfilePtr other) {
 }
 
 void BroadcastProfile::adoptDefaultValues() {
-#ifdef __QTKEYCHAIN__
-    m_secureCredentials = true;
-#else
     m_secureCredentials = false;
-#endif
     m_enabled = false;
 
     m_host = QString();


### PR DESCRIPTION
I get the following confusing error message when building Mixxx with QtKeychain and starting with a fresh profile:

![qtkeychain_error](https://user-images.githubusercontent.com/1474154/59282515-55c5ec80-8c69-11e9-8109-339243a1ff71.png)

This fix prevents the error and instead logs a warning. I have no idea what the correct behavior is supposed to do! Please accept this PR or fix it yourself, whoever knows the solution!