### PR TITLE
Fix battery tooltip text when minutesLeft is unknown

### DIFF
--- a/src/util/battery/battery.h
+++ b/src/util/battery/battery.h
@@ -6,6 +6,7 @@
 class Battery : public QObject {
     Q_OBJECT
   public:
+    static constexpr int TIME_UNKNOWN = -1;
     enum ChargingState {
         UNKNOWN,
         DISCHARGING,

--- a/src/util/battery/batterylinux.cpp
+++ b/src/util/battery/batterylinux.cpp
@@ -14,7 +14,7 @@ BatteryLinux::~BatteryLinux() {
 }
 
 void BatteryLinux::read() {
-    m_iMinutesLeft = 0;
+    m_iMinutesLeft = -1;
     m_dPercentage = 0.0;
     m_chargingState = Battery::UNKNOWN;
 
@@ -89,9 +89,11 @@ void BatteryLinux::read() {
         }
 
         m_dPercentage = percentage;
-        if (m_chargingState == CHARGING) {
+
+        // upower tells us the remainging time in seconds (0 if unknown)
+        if (m_chargingState == CHARGING && timeToFull > 0) {
           m_iMinutesLeft = timeToFull / 60;
-        } else if (m_chargingState == DISCHARGING) {
+        } else if (m_chargingState == DISCHARGING && timeToEmpty > 0) {
           m_iMinutesLeft = timeToEmpty / 60;
         }
         break;

--- a/src/util/battery/batterylinux.cpp
+++ b/src/util/battery/batterylinux.cpp
@@ -14,7 +14,7 @@ BatteryLinux::~BatteryLinux() {
 }
 
 void BatteryLinux::read() {
-    m_iMinutesLeft = -1;
+    m_iMinutesLeft = Battery::TIME_UNKNOWN;
     m_dPercentage = 0.0;
     m_chargingState = Battery::UNKNOWN;
 

--- a/src/util/battery/batterymac.cpp
+++ b/src/util/battery/batterymac.cpp
@@ -16,7 +16,7 @@ BatteryMac::~BatteryMac() {
 }
 
 void BatteryMac::read() {
-    m_iMinutesLeft = 0;
+    m_iMinutesLeft = -1;
     m_dPercentage = 0.0;
     m_chargingState = Battery::UNKNOWN;
 
@@ -125,7 +125,7 @@ void BatteryMac::read() {
             m_chargingState = DISCHARGING;
         }
 
-        if (minutes_left != -1) {
+        if (minutes_left >= 0) {
             m_iMinutesLeft = minutes_left;
         }
 

--- a/src/util/battery/batterymac.cpp
+++ b/src/util/battery/batterymac.cpp
@@ -16,7 +16,7 @@ BatteryMac::~BatteryMac() {
 }
 
 void BatteryMac::read() {
-    m_iMinutesLeft = -1;
+    m_iMinutesLeft = Battery::TIME_UNKNOWN;
     m_dPercentage = 0.0;
     m_chargingState = Battery::UNKNOWN;
 

--- a/src/util/battery/batterywindows.cpp
+++ b/src/util/battery/batterywindows.cpp
@@ -15,9 +15,10 @@ BatteryWindows::~BatteryWindows() {
 }
 
 void BatteryWindows::read() {
-    m_iMinutesLeft = 0;
+    m_iMinutesLeft = -1;
     m_dPercentage = 0.0;
     m_chargingState = Battery::UNKNOWN;
+    int seconds_left;
 
     // SYSTEM_POWER_STATUS doc
     // http://msdn.microsoft.com/en-us/library/windows/desktop/aa373232(v=vs.85).aspx
@@ -39,8 +40,11 @@ void BatteryWindows::read() {
         if (m_dPercentage > 99) {
             m_chargingState = Battery::CHARGED;
         }
-        // windows tells us the remainging time in seconds
-        m_iMinutesLeft = static_cast<int>(spsPwr.BatteryLifeTime) / 60;
+        // windows tells us the remainging time in seconds (-1 if unknown)
+        seconds_left = static_cast<int>(spsPwr.BatteryLifeTime);
+        if (seconds_left >= 0) {
+            m_iMinutesLeft = seconds_left / 60;
+        }
     }
 
     // QString bat = "unknown";

--- a/src/util/battery/batterywindows.cpp
+++ b/src/util/battery/batterywindows.cpp
@@ -15,10 +15,9 @@ BatteryWindows::~BatteryWindows() {
 }
 
 void BatteryWindows::read() {
-    m_iMinutesLeft = -1;
+    m_iMinutesLeft = Battery::TIME_UNKNOWN;
     m_dPercentage = 0.0;
     m_chargingState = Battery::UNKNOWN;
-    int seconds_left;
 
     // SYSTEM_POWER_STATUS doc
     // http://msdn.microsoft.com/en-us/library/windows/desktop/aa373232(v=vs.85).aspx
@@ -41,7 +40,7 @@ void BatteryWindows::read() {
             m_chargingState = Battery::CHARGED;
         }
         // windows tells us the remainging time in seconds (-1 if unknown)
-        seconds_left = static_cast<int>(spsPwr.BatteryLifeTime);
+        int seconds_left = static_cast<int>(spsPwr.BatteryLifeTime);
         if (seconds_left >= 0) {
             m_iMinutesLeft = seconds_left / 60;
         }

--- a/src/widget/wbattery.cpp
+++ b/src/widget/wbattery.cpp
@@ -105,7 +105,7 @@ void WBattery::update() {
                     pixmapIndexFromPercentage(dPercentage,
                                               m_chargingPixmaps.size())];
             }
-            if (minutesLeft == -1) {
+            if (minutesLeft == Battery::TIME_UNKNOWN) {
                 setBaseTooltip(tr("Time until charged unknown."));
             } else {
                 setBaseTooltip(tr("Time until charged: %1")
@@ -118,7 +118,7 @@ void WBattery::update() {
                     pixmapIndexFromPercentage(dPercentage,
                                               m_dischargingPixmaps.size())];
             }
-            if (minutesLeft == -1) {
+            if (minutesLeft == Battery::TIME_UNKNOWN) {
                 setBaseTooltip(tr("Time left unknown."));
             } else {
                 setBaseTooltip(tr("Time left: %1")


### PR DESCRIPTION
Currently, the tooltip says "Time until charged: 0" or "Time left: 0" when the time is actually unknown.

The change makes all versions of the util return `-1` if `minutesLeft` is unknown.
In src/widget/wbattery.cpp, we have:
```
if (minutesLeft == -1) {
    setBaseTooltip(tr("Time until charged unknown."));
}
```

(minutesLeft can be 0 if the time is less than an minute)

Note that upower returns `0` for unknown:
https://upower.freedesktop.org/docs/Device.html#Device:TimeToEmpty
Windows uses `-1`:
https://docs.microsoft.com/en-us/windows/desktop/api/winbase/ns-winbase-_system_power_status
On OSX, the property is optional and not set when unknown (i guess).