### PR TITLE
Canonical URL/URI for track objects

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -20,7 +20,6 @@
 #include "track/trackmetadata.h"
 #include "util/db/dbconnection.h"
 #include "util/duration.h"
-#include "util/dnd.h"
 #include "util/assert.h"
 #include "util/performancetimer.h"
 
@@ -1094,7 +1093,7 @@ QMimeData* BaseSqlTableModel::mimeData(const QModelIndexList &indexes) const {
             continue;
         }
         rows.insert(index.row());
-        QUrl url = DragAndDropHelper::urlFromLocation(getTrackLocation(index));
+        QUrl url = TrackRef::locationUrl(getTrackLocation(index));
         if (!url.isValid()) {
             qDebug() << this << "ERROR: invalid url" << url;
             continue;

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -13,7 +13,6 @@
 #include "mixer/playermanager.h"
 #include "control/controlobject.h"
 #include "library/dao/trackdao.h"
-#include "util/dnd.h"
 
 BrowseTableModel::BrowseTableModel(QObject* parent,
                                    TrackCollection* pTrackCollection,
@@ -243,7 +242,7 @@ QMimeData* BrowseTableModel::mimeData(const QModelIndexList &indexes) const {
         if (index.isValid()) {
             if (!rows.contains(index.row())) {
                 rows.push_back(index.row());
-                QUrl url = DragAndDropHelper::urlFromLocation(getTrackLocation(index));
+                QUrl url = TrackRef::locationUrl(getTrackLocation(index));
                 if (!url.isValid()) {
                     qDebug() << "ERROR invalid url" << url;
                     continue;

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -222,6 +222,38 @@ QString Track::getCanonicalLocation() const {
     return loc;
 }
 
+QUrl Track::getLocationUrl() const {
+    // Copying QFileInfo is thread-safe due to "implicit sharing"
+    // (copy-on write). But operating on a single instance of QFileInfo
+    // might not be thread-safe due to internal caching!
+    QMutexLocker lock(&m_qMutex);
+    return TrackRef::locationUrl(m_fileInfo);
+}
+
+QUrl Track::getCanonicalLocationUrl() const {
+    // Copying QFileInfo is thread-safe due to "implicit sharing"
+    // (copy-on write). But operating on a single instance of QFileInfo
+    // might not be thread-safe due to internal caching!
+    QMutexLocker lock(&m_qMutex);
+    return TrackRef::canonicalLocationUrl(m_fileInfo);
+}
+
+QString Track::getLocationUri() const {
+    // Copying QFileInfo is thread-safe due to "implicit sharing"
+    // (copy-on write). But operating on a single instance of QFileInfo
+    // might not be thread-safe due to internal caching!
+    QMutexLocker lock(&m_qMutex);
+    return TrackRef::locationUri(m_fileInfo);
+}
+
+QString Track::getCanonicalLocationUri() const {
+    // Copying QFileInfo is thread-safe due to "implicit sharing"
+    // (copy-on write). But operating on a single instance of QFileInfo
+    // might not be thread-safe due to internal caching!
+    QMutexLocker lock(&m_qMutex);
+    return TrackRef::canonicalLocationUri(m_fileInfo);
+}
+
 QString Track::getDirectory() const {
     // Copying QFileInfo is thread-safe due to "implicit sharing"
     // (copy-on write). But operating on a single instance of QFileInfo

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -4,6 +4,7 @@
 #include <QList>
 #include <QMutex>
 #include <QObject>
+#include <QUrl>
 
 #include "track/beats.h"
 #include "track/cue.h"
@@ -20,6 +21,8 @@ class Track;
 
 typedef std::shared_ptr<Track> TrackPointer;
 typedef std::weak_ptr<Track> TrackWeakPointer;
+
+Q_DECLARE_METATYPE(TrackPointer);
 
 class Track : public QObject {
     Q_OBJECT
@@ -79,7 +82,11 @@ class Track : public QObject {
     // Accessors for various stats of the file on disk.
     // Returns absolute path to the file, including the filename.
     QString getLocation() const;
+    QUrl    getLocationUrl() const;
+    QString getLocationUri() const;
     QString getCanonicalLocation() const;
+    QUrl    getCanonicalLocationUrl() const;
+    QString getCanonicalLocationUri() const;
     // Returns the absolute path to the directory containing the file
     QString getDirectory() const;
     // Returns the name of the file.

--- a/src/track/trackref.cpp
+++ b/src/track/trackref.cpp
@@ -1,6 +1,50 @@
 #include "track/trackref.h"
 
 
+namespace {
+
+inline
+QUrl urlFromLocalFilePath(QString localFilePath) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    return QUrl::fromLocalFile(std::move(localFilePath));
+#else
+    if (localFilePath.isEmpty()) {
+        return QUrl();
+    } else {
+        return QUrl::fromLocalFile(std::move(localFilePath));
+    }
+#endif
+}
+
+inline
+QString uriFromUrl(const QUrl& url) {
+    return url.toEncoded(
+            QUrl::StripTrailingSlash |
+            QUrl::NormalizePathSegments);
+}
+
+} // anonymous namespace
+
+//static
+QUrl TrackRef::locationUrl(const QFileInfo& fileInfo) {
+    return urlFromLocalFilePath(location(fileInfo));
+}
+
+//static
+QUrl TrackRef::canonicalLocationUrl(const QFileInfo& fileInfo) {
+    return urlFromLocalFilePath(canonicalLocation(fileInfo));
+}
+
+//static
+QString TrackRef::locationUri(const QFileInfo& fileInfo) {
+    return uriFromUrl(locationUrl(fileInfo));
+}
+
+//static
+QString TrackRef::canonicalLocationUri(const QFileInfo& fileInfo) {
+    return uriFromUrl(canonicalLocationUrl(fileInfo));
+}
+
 bool TrackRef::verifyConsistency() const {
     // Class invariant: The location can only be set together with
     // at least one of the other members!

--- a/src/track/trackref.cpp
+++ b/src/track/trackref.cpp
@@ -4,14 +4,14 @@
 namespace {
 
 inline
-QUrl urlFromLocalFilePath(QString localFilePath) {
+QUrl urlFromLocalFilePath(const QString& localFilePath) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
-    return QUrl::fromLocalFile(std::move(localFilePath));
+    return QUrl::fromLocalFile(localFilePath);
 #else
     if (localFilePath.isEmpty()) {
         return QUrl();
     } else {
-        return QUrl::fromLocalFile(std::move(localFilePath));
+        return QUrl::fromLocalFile(localFilePath);
     }
 #endif
 }

--- a/src/track/trackref.cpp
+++ b/src/track/trackref.cpp
@@ -17,7 +17,7 @@ QUrl urlFromLocalFilePath(const QString& localFilePath) {
 }
 
 inline
-QString uriFromUrl(const QUrl& url) {
+QString urlToString(const QUrl& url) {
     return url.toEncoded(
             QUrl::StripTrailingSlash |
             QUrl::NormalizePathSegments);
@@ -37,12 +37,12 @@ QUrl TrackRef::canonicalLocationUrl(const QFileInfo& fileInfo) {
 
 //static
 QString TrackRef::locationUri(const QFileInfo& fileInfo) {
-    return uriFromUrl(locationUrl(fileInfo));
+    return urlToString(locationUrl(fileInfo));
 }
 
 //static
 QString TrackRef::canonicalLocationUri(const QFileInfo& fileInfo) {
-    return uriFromUrl(canonicalLocationUrl(fileInfo));
+    return urlToString(canonicalLocationUrl(fileInfo));
 }
 
 bool TrackRef::verifyConsistency() const {

--- a/src/track/trackref.h
+++ b/src/track/trackref.h
@@ -3,6 +3,7 @@
 
 
 #include <QFileInfo>
+#include <QUrl>
 
 #include "track/trackid.h"
 
@@ -28,6 +29,12 @@ public:
     static QString canonicalLocation(const QFileInfo& fileInfo) {
         return fileInfo.canonicalFilePath();
     }
+
+    static QUrl locationUrl(const QFileInfo& fileInfo);
+    static QUrl canonicalLocationUrl(const QFileInfo& fileInfo);
+
+    static QString locationUri(const QFileInfo& fileInfo);
+    static QString canonicalLocationUri(const QFileInfo& fileInfo);
 
     // Converts a QFileInfo and an optional TrackId into a TrackRef. This
     // involves obtaining the file-related track properties from QFileInfo


### PR DESCRIPTION
Consolidate the URL/URI handling for tracks:
- Remove URL code from `DragAndDropHelper`
- Remove URL code from `SoundSourceProxy`
- Let `TrackRef` handle the creation of URLs from `QFileInfo` and formatting of URIs

The URI is obtained by normalizing and formatting (percent-encoded) the `QUrl`. It soon becomes the new *track location* in aoide.

*Next step for a follow-up PR: Split the `QFileInfo`-related part from `TrackRef` into a separate class `TrackFile`. This will simplify our `Track` object, but will cause many small changes in dependent code.*