### PR TITLE
Delete workarounds for MS VisualStudio 2015 (and older)

### DIFF
--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -35,11 +35,8 @@ class CoverInfoRelative {
     CoverInfoRelative(const CoverInfoRelative&) = default;
     CoverInfoRelative& operator=(const CoverInfoRelative&) = default;
     virtual ~CoverInfoRelative() = default;
-// Visual Studio does not support default generated move constructors yet
-#if !defined(_MSC_VER) || _MSC_VER > 1900
     CoverInfoRelative(CoverInfoRelative&&) = default;
     CoverInfoRelative& operator=(CoverInfoRelative&&) = default;
-#endif
 
     Source source;
     Type type;
@@ -64,11 +61,8 @@ class CoverInfo : public CoverInfoRelative {
     CoverInfo(const CoverInfo&) = default;
     CoverInfo& operator=(const CoverInfo&) = default;
     virtual ~CoverInfo() override = default;
-// Visual Studio does not support default generated move constructors yet
-#if !defined(_MSC_VER) || _MSC_VER > 1900
     CoverInfo(CoverInfo&&) = default;
     CoverInfo& operator=(CoverInfo&&) = default;
-#endif
 
     QString trackLocation;
 };
@@ -92,11 +86,8 @@ class CoverArt : public CoverInfo {
     // all-default memory management
     CoverArt(const CoverArt&) = default;
     virtual ~CoverArt() override = default;
-// Visual Studio does not support default generated move constructors yet
-#if !defined(_MSC_VER) || _MSC_VER > 1900
     CoverArt(CoverArt&&) = default;
     CoverArt& operator=(CoverArt&&) = default;
-#endif
 
     // it is not a QPixmap, because it is not safe to use pixmaps 
     // outside the GUI thread

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -117,17 +117,7 @@ public:
                 TrackId trackId,
                 SecurityTokenPointer pSecurityToken = SecurityTokenPointer());
     GlobalTrackCacheResolver(const GlobalTrackCacheResolver&) = delete;
-#if !defined(_MSC_VER) && (_MSC_VER > 1900)
     GlobalTrackCacheResolver(GlobalTrackCacheResolver&&) = default;
-#else
-    // Visual Studio 2015 does not support default generated move constructors
-    GlobalTrackCacheResolver(GlobalTrackCacheResolver&& moveable)
-        : GlobalTrackCacheLocker(std::move(moveable)),
-          m_lookupResult(std::move(moveable.m_lookupResult)),
-          m_strongPtr(std::move(moveable.m_strongPtr)),
-          m_trackRef(std::move(moveable.m_trackRef)) {
-    }
-#endif
 
     GlobalTrackCacheLookupResult getLookupResult() const {
         return m_lookupResult;

--- a/src/util/db/dbconnectionpooler.h
+++ b/src/util/db/dbconnectionpooler.h
@@ -22,14 +22,7 @@ class DbConnectionPooler final {
     explicit DbConnectionPooler(
             DbConnectionPoolPtr pDbConnectionPool = DbConnectionPoolPtr());
     DbConnectionPooler(const DbConnectionPooler&) = delete;
-#if !defined(_MSC_VER) || _MSC_VER > 1900
     DbConnectionPooler(DbConnectionPooler&&) = default;
-#else
-    // Workaround for Visual Studio 2015 (and before)
-    DbConnectionPooler(DbConnectionPooler&& other)
-        : m_pDbConnectionPool(std::move(other.m_pDbConnectionPool)) {
-    }
-#endif
     ~DbConnectionPooler();
 
     // Checks if a thread-local connection has actually been created
@@ -39,15 +32,7 @@ class DbConnectionPooler final {
     }
 
     DbConnectionPooler& operator=(const DbConnectionPooler&) = delete;
-#if !defined(_MSC_VER) || _MSC_VER > 1900
     DbConnectionPooler& operator=(DbConnectionPooler&&) = default;
-#else
-    // Workaround for Visual Studio 2015 (and before)
-    DbConnectionPooler& operator=(DbConnectionPooler&& other) {
-        m_pDbConnectionPool = std::move(other.m_pDbConnectionPool);
-        return *this;
-    }
-#endif
 
   private:
     // Prevent heap allocation


### PR DESCRIPTION
Require MSVC 2017 or newer (_MSC_VER >= 1910):
* MS VisualStudio 2017 is used for the upcoming release Mixxx 2.3
* Precondition for enabling C++14 support