### PR TITLE
parented_ptr: Assert parent at destruction instead of construction

### DIFF
--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -2,83 +2,93 @@
 #define UTIL_PARENTED_PTR_H
 
 #include <QPointer>
+
 #include "util/assert.h"
+#include "util/memory.h"
 
 /**
  * Use this wrapper class to clearly represent a raw pointer that is owned by the QT object tree.
  * Objects which both derive from QObject AND have a parent object, have their lifetime governed by the QT object tree, 
  * and thus such pointers do not require a manual delete to free the heap memory when they go out of scope.
 **/
-template <typename T>
+template<typename T>
 class parented_ptr {
   public:
-    explicit parented_ptr(T* t) : m_pObject(t) {
-        DEBUG_ASSERT(t->parent() != nullptr);
+    parented_ptr() noexcept = default;
+
+    parented_ptr(nullptr_t) noexcept
+            : m_ptr{nullptr} {
     }
 
-    /* If U* is convertible to T* then we also want parented_ptr<U> convertible to parented_ptr<T> */
-    template <typename U>
-    parented_ptr(parented_ptr<U>&& u, typename std::enable_if<std::is_convertible<U*, T*>::value, void>::type * = 0)
-            : m_pObject(u.get()) {
-        DEBUG_ASSERT(u->parent() != nullptr);
+    explicit parented_ptr(T* t) noexcept
+            : m_ptr{t} {
     }
 
-#if defined(__GNUC__) && __GNUC__ < 5
-    // gcc 4.8 does not implicit use the typ conversion move constructor
-    // from above when returning form a function and use finally RVO.
-    // It requires
-    //return std::move(pObject)
-    // This hack avoids it:
-    template <typename U>
-    operator parented_ptr<U>() const {
-        static_assert(std::is_convertible<T*, U*>::value,
-                "No implicit conversion from T* to U* found.");
-        return parented_ptr<U>(this->get());
+    ~parented_ptr() noexcept {
+        if (m_ptr != nullptr) {
+            DEBUG_ASSERT(m_ptr->parent() != nullptr);
+        }
     }
-
-#endif
 
     // Delete copy constructor and copy assignment operator
     parented_ptr(const parented_ptr<T>&) = delete;
     parented_ptr& operator=(const parented_ptr<T>&) = delete;
 
-    parented_ptr() : m_pObject(nullptr) {}
-
-    ~parented_ptr() = default;
-
-    T* get() const {
-        return m_pObject;
-    }
-
-    T& operator* () const {
-        return *m_pObject;
-    }
-
-    T* operator-> () const {
-        return m_pObject;
-    }
-
-    operator bool() const {
-        return m_pObject != nullptr;
+    /*
+     * If U* is convertible to T* then we also want parented_ptr<U> convertible to parented_ptr<T>
+     */
+    template<
+            typename U,
+            typename = typename std::enable_if<std::is_convertible<U*, T*>::value, U>::type>
+    parented_ptr(parented_ptr<U>&& u) noexcept
+            : m_ptr{u.m_ptr} {
+        u.m_ptr = nullptr;
     }
 
     /*
      * If U* is convertible to T* then we also want parented_ptr<U> assignable to parented_ptr<T>
      * E.g. parented_ptr<Base> base = make_parented<Derived>(); should work as expected.
      */
-    template <typename U>
-    typename std::enable_if<std::is_convertible<U*, T*>::value, parented_ptr<T>&>::type
-            operator=(parented_ptr<U>&& p) {
-        m_pObject = p.get();
+    template<
+            typename U,
+            typename = typename std::enable_if<std::is_convertible<U*, T*>::value, U>::type>
+    parented_ptr& operator=(parented_ptr<U>&& u) noexcept {
+        m_ptr = u.m_ptr;
+        u.m_ptr = nullptr;
         return *this;
     }
 
+    parented_ptr& operator=(nullptr_t) noexcept {
+        m_ptr = nullptr;
+        return *this;
+    }
+
+    operator T*() const noexcept {
+        return m_ptr;
+    }
+
+    T* get() const noexcept {
+        return m_ptr;
+    }
+
+    T& operator*() const noexcept {
+        return *m_ptr;
+    }
+
+    T* operator->() const noexcept {
+        return m_ptr;
+    }
+
+    operator bool() const noexcept {
+        return m_ptr != nullptr;
+    }
+
     QPointer<T> toWeakRef() {
-        return m_pObject;
+        return m_ptr;
     }
 
   private:
-    T* m_pObject;
+    T* m_ptr;
 };
 
 namespace {
@@ -88,34 +98,41 @@ inline parented_ptr<T> make_parented(Args&&... args) {
     return parented_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
+template<typename T>
+inline parented_ptr<T> to_parented(std::unique_ptr<T>& u) noexcept {
+    // the DEBUG_ASSERT in the parented_ptr constructor will catch cases where the unique_ptr should
+    // not have been released
+    return parented_ptr<T>{u.release()};
+}
+
 // Comparison operator definitions
 template<typename T, typename U>
-inline bool operator== (const T* lhs, const parented_ptr<U>& rhs) {
+inline bool operator==(const T* lhs, const parented_ptr<U>& rhs) noexcept {
     return lhs == rhs.get();
 }
 
 template<typename T, typename U>
-inline bool operator== (const parented_ptr<T>& lhs, const U* rhs) {
+inline bool operator==(const parented_ptr<T>& lhs, const U* rhs) noexcept {
     return lhs.get() == rhs;
 }
 
 template<typename T, typename U>
-inline bool operator== (const parented_ptr<T>& lhs, const parented_ptr<U>& rhs) {
+inline bool operator==(const parented_ptr<T>& lhs, const parented_ptr<U>& rhs) noexcept {
     return lhs.get() == rhs.get();
 }
 
 template<typename T, typename U>
-inline bool operator!= (const T* lhs, const parented_ptr<U>& rhs) {
+inline bool operator!=(const T* lhs, const parented_ptr<U>& rhs) noexcept {
     return !(lhs == rhs.get());
 }
 
 template<typename T, typename U>
-inline bool operator!= (const parented_ptr<T>& lhs, const U* rhs) {
+inline bool operator!=(const parented_ptr<T>& lhs, const U* rhs) noexcept {
     return !(lhs.get() == rhs);
 }
 
 template<typename T, typename U>
-inline bool operator!= (const parented_ptr<T>& lhs, const parented_ptr<U>& rhs) {
+inline bool operator!=(const parented_ptr<T>& lhs, const parented_ptr<U>& rhs) noexcept {
     return !(lhs.get() == rhs.get());
 }
 

--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -1,10 +1,10 @@
 #ifndef UTIL_PARENTED_PTR_H
 #define UTIL_PARENTED_PTR_H
 
+#include <memory>
 #include <QPointer>
 
 #include "util/assert.h"
-#include "util/memory.h"
 
 /**
  * Use this wrapper class to clearly represent a raw pointer that is owned by the QT object tree.

--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -1,16 +1,18 @@
 #ifndef UTIL_PARENTED_PTR_H
 #define UTIL_PARENTED_PTR_H
 
-#include <memory>
 #include <QPointer>
+#include <memory>
 
 #include "util/assert.h"
 
-/**
- * Use this wrapper class to clearly represent a raw pointer that is owned by the QT object tree.
- * Objects which both derive from QObject AND have a parent object, have their lifetime governed by the QT object tree, 
- * and thus such pointers do not require a manual delete to free the heap memory when they go out of scope.
-**/
+// Use this wrapper class to clearly represent a raw pointer that is owned by the QT object tree.
+// Objects which both derive from QObject AND have a parent object, have their lifetime governed by
+// the QT object tree, and thus such pointers do not require a manual delete to free the heap memory
+// when they go out of scope.
+//
+// NOTE: A parented_ptr must not dangle! Therefore, the lifetime of the parent must exceed the
+// lifetime of the parented_ptr.
 template<typename T>
 class parented_ptr {
   public:

--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -14,7 +14,9 @@
 template<typename T>
 class parented_ptr {
   public:
-    parented_ptr() noexcept = default;
+    parented_ptr() noexcept
+            : m_ptr{nullptr} {
+    }
 
     parented_ptr(nullptr_t) noexcept
             : m_ptr{nullptr} {

--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -59,7 +59,7 @@ class parented_ptr {
     }
 
     parented_ptr& operator=(nullptr_t) noexcept {
-        m_ptr = nullptr;
+        parented_ptr{std::move(*this)}; // move *this into a temporary that gets destructed
         return *this;
     }
 

--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -34,9 +34,7 @@ class parented_ptr {
     parented_ptr(const parented_ptr<T>&) = delete;
     parented_ptr& operator=(const parented_ptr<T>&) = delete;
 
-    /*
-     * If U* is convertible to T* then we also want parented_ptr<U> convertible to parented_ptr<T>
-     */
+    // If U* is convertible to T* then parented_ptr<U> is convertible to parented_ptr<T>
     template<
             typename U,
             typename = typename std::enable_if<std::is_convertible<U*, T*>::value, U>::type>
@@ -45,10 +43,7 @@ class parented_ptr {
         u.m_ptr = nullptr;
     }
 
-    /*
-     * If U* is convertible to T* then we also want parented_ptr<U> assignable to parented_ptr<T>
-     * E.g. parented_ptr<Base> base = make_parented<Derived>(); should work as expected.
-     */
+    // If U* is convertible to T* then parented_ptr<U> is assignable to parented_ptr<T>
     template<
             typename U,
             typename = typename std::enable_if<std::is_convertible<U*, T*>::value, U>::type>
@@ -98,13 +93,14 @@ inline parented_ptr<T> make_parented(Args&&... args) {
     return parented_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
-/// A use case for this function is when giving an object owned by `std::unique_ptr` to a Qt
-/// function, that will make the object owned by the Qt object tree. Example:
-/// ```
-/// parent->someFunctionThatAddsAChild(to_parented(child))
-/// ```
-/// where `child` is a `std::unique_ptr`. After the call, the created `parented_ptr` will
-/// automatically be destructed such that the DEBUG_ASSERT for an existent parent is triggered.
+// A use case for this function is when giving an object owned by `std::unique_ptr` to a Qt
+// function, that will make the object owned by the Qt object tree. Example:
+// ```
+// parent->someFunctionThatAddsAChild(to_parented(child))
+// ```
+// where `child` is a `std::unique_ptr`. After the call, the created `parented_ptr` will
+// automatically be destructed such that the DEBUG_ASSERT that checks whether a parent exists is
+// triggered.
 template<typename T>
 inline parented_ptr<T> to_parented(std::unique_ptr<T>& u) noexcept {
     // the DEBUG_ASSERT in the parented_ptr constructor will catch cases where the unique_ptr should
@@ -112,7 +108,8 @@ inline parented_ptr<T> to_parented(std::unique_ptr<T>& u) noexcept {
     return parented_ptr<T>{u.release()};
 }
 
-// Comparison operator definitions
+// Comparison operator definitions:
+
 template<typename T, typename U>
 inline bool operator==(const T* lhs, const parented_ptr<U>& rhs) noexcept {
     return lhs == rhs.get();


### PR DESCRIPTION
Previously, `parented_ptr` asserted on construction that the pointed-to object has a parent. However, sometimes one wants to create an object and assign it to a parent later. The [recommendation](https://www.mixxx.org/wiki/doku.php/coding_guidelines#pointer_object_lifetime_ownership) was to create a `unique_ptr` `p` instead, later assign the object to a parent and then create a new variable using `make_parented(p.release())`.

This has however several drawbacks:

* There is a short period where the object is already assigned to a parent but still owned by a `unique_ptr`. This can lead to a double free.
* There are two pointers that and it depends on the code location which one is the correct one to access the object.
* It is inconvenient to use, because one has to write an extra line where the `unique_ptr` is released.

With this commit, `parented_ptr` asserts that the pointed-to object has a parent at the **destruction** of the `parented_ptr`. That means, that one can store the object using a `parented_ptr` a priori and there will be a warning (from the failing `DEBUG_ASSERT`) in case any object is leaked.

Optionally, in a future PR, this behaviour can even be changed so as to delete the object that is going to be leaked. That is, the `parented_ptr` destructor wouldn't only `DEBUG_ASSERT` that the pointed-to object has a parent, but it would also delete it otherwise.

Additional changes:

* Made `parented_ptr` implicitly convertible to a raw pointer. The reasons why the standard library types are not convertible to a raw pointer don't apply to `parented_ptr`. Regarding the insufficient usage of `parented_ptr` in Mixxx at the moment, making it implicitly convertible will make its adoption easier because less code has to be changed. (No `.get()` everywhere.)
* Added a constructor taking `nullptr_t`.
* Added `noexcept` where applicable.
* Formatted the code using `clang-format`.