### PR TITLE
Set duration to "hh:mm:ss"-format when selecting multiple tracks in Auto-DJ-Library

### DIFF
--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -208,7 +208,7 @@ void DlgAutoDJ::updateSelectionInfo() {
     QString label;
 
     if (!indices.isEmpty()) {
-        label.append(mixxx::Duration::formatSeconds(duration));
+        label.append(mixxx::DurationBase::formatTime(duration));
         label.append(QString(" (%1)").arg(indices.size()));
         labelSelectionInfo->setToolTip(tr("Displays the duration and number of selected tracks."));
         labelSelectionInfo->setText(label);


### PR DESCRIPTION
Set shown duration to "hh:mm:ss"-format when selecting multiple tracks in Auto-DJ-Library.
This fixes https://bugs.launchpad.net/mixxx/+bug/1824653