### PR TITLE
remove doubling "None" in effect selection

### DIFF
--- a/src/preferences/dialog/dlgprefeq.cpp
+++ b/src/preferences/dialog/dlgprefeq.cpp
@@ -231,10 +231,9 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
         }
         //: Displayed when no effect is selected
         box->addItem(tr("None"), QVariant(QString("")));
-        if (selectedEffectId.isNull()) {
+        if (selectedEffectId.isEmpty()) {
             currentIndex = availableEQEffects.size(); // selects "None"
-        }
-        if (currentIndex < 0 && !selectedEffectName.isEmpty()) {
+        } else if (currentIndex < 0 && !selectedEffectName.isEmpty() ) {
             // current selection is not part of the new list
             // So we need to add it
             box->addItem(selectedEffectName, QVariant(selectedEffectId));
@@ -261,10 +260,9 @@ void DlgPrefEQ::slotPopulateDeckEffectSelectors() {
         }
         //: Displayed when no effect is selected
         box->addItem(tr("None"), QVariant(QString("")));
-        if (selectedEffectId.isNull()) {
+        if (selectedEffectId.isEmpty()) {
             currentIndex = availableQuickEffects.size(); // selects "None"
-        }
-        if (currentIndex < 0 && !selectedEffectName.isEmpty()) {
+        } else if (currentIndex < 0 && !selectedEffectName.isEmpty()) {
             // current selection is not part of the new list
             // So we need to add it
             box->addItem(selectedEffectName, QVariant(selectedEffectId));


### PR DESCRIPTION
Remove the doubling "None" in the preferences -> equalizer -> effect list when "None" is already selected.
Fixes https://bugs.launchpad.net/mixxx/+bug/1824624.