### PR TITLE
Macos view menu cleanup

### DIFF
--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -48,13 +48,6 @@ QString showPreferencesKeyBinding() {
 #endif
 }
 
-QString fullScreenDefaultKeyBinding() {
-#ifdef __APPLE__
-    return QObject::tr("Ctrl+Shift+F");
-#else
-    return QObject::tr("F11");
-#endif
-}
 
 }  // namespace
 
@@ -275,10 +268,7 @@ void WMainMenuBar::initialize() {
     QString fullScreenTitle = tr("&Full Screen");
     QString fullScreenText = tr("Display Mixxx using the full screen");
     auto pViewFullScreen = new QAction(fullScreenTitle, this);
-    pViewFullScreen->setShortcut(
-        QKeySequence(m_pKbdConfig->getValue(
-                ConfigKey("[KeyboardShortcuts]", "ViewMenu_Fullscreen"),
-                fullScreenDefaultKeyBinding())));
+    pViewFullScreen->setShortcut(QKeySequence(QKeySequence::FullScreen));
     pViewFullScreen->setShortcutContext(Qt::ApplicationShortcut);
     pViewFullScreen->setCheckable(true);
     pViewFullScreen->setChecked(false);

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -170,7 +170,12 @@ void WMainMenuBar::initialize() {
     addMenu(pLibraryMenu);
 
     // VIEW MENU
-    QMenu* pViewMenu = new QMenu(tr("&View"));
+    // Note: On macOS 10.11 ff. we have to deal with "automagic" menu items,
+    // when ever a menu "View" is present. QT (as of 5.12.3) does not handle this for us.
+    // Add an invisible suffix to the View item string so it doesn't string-equal "View" ,
+    // and the magic menu items won't get injected.
+    // https://bugs.launchpad.net/mixxx/+bug/1534292
+    QMenu* pViewMenu = new QMenu(tr("&View")+("\u200C"));
 
     // Skin Settings Menu
     QString mayNotBeSupported = tr("May not be supported on all skins.");


### PR DESCRIPTION
Attempt to fix 
* [macOS full screen shortcut should change according to standard](https://bugs.launchpad.net/mixxx/+bug/1815334)
* [OSX 10.11: "Enter Full Screen" automatically added to View menu]( https://bugs.launchpad.net/mixxx/+bug/1534292)

**Post-fix**
![post](https://user-images.githubusercontent.com/4525897/59662578-8b109400-91ad-11e9-82ec-d2cd540f70a4.png)
**Pre-fix**
![pre](https://user-images.githubusercontent.com/4525897/59662586-906dde80-91ad-11e9-96e0-19a72f1d480c.png)


Tested on macos 10.14.5 (18F203). The shortcut change affects other platforms as well, so please test if it still displays the correct standard shortcut for your OS. 

This goes along with #1950 , also ready to test.