### PR TITLE
Fix deadlock when hid_read and hid_write are called at the same time

### DIFF
--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -16,8 +16,6 @@
 #include "controllers/controllerdebug.h"
 #include "util/time.h"
 
-#define HIDCONTROLLER_POLL_LIMIT 10
-
 HidController::HidController(const hid_device_info deviceInfo)
         : m_pHidDevice(NULL) {
     // Copy required variables from deviceInfo, which will be freed after
@@ -243,22 +241,17 @@ int HidController::close() {
 }
 
 bool HidController::poll() {
-    Trace hidRead("HidReader poll");
+    Trace hidRead("HidController poll");
 
-    for (int i = 0; i < HIDCONTROLLER_POLL_LIMIT; i++) {
-        int result = hid_read(m_pHidDevice, m_pPollData, sizeof(m_pPollData) / sizeof(m_pPollData[0]));
-        if (result == -1) {
-            return false;
-        } else if (result == 0) {
-            return true;
-        }
-
-        Trace process("HidReader process packet");
+    int result = hid_read(m_pHidDevice, m_pPollData, sizeof(m_pPollData) / sizeof(m_pPollData[0]));
+    if (result == -1) {
+        return false;
+    } else if (result > 0) {
+        Trace process("HidController process packet");
         QByteArray outData(reinterpret_cast<char*>(m_pPollData), result);
         receive(outData, mixxx::Time::elapsed());
     }
 
-    qDebug() << "Reached maximum poll loop iterations for HID device " << getName();
     return true;
 }
 

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -91,7 +91,7 @@ class HidController final : public Controller {
     hid_device* m_pHidDevice;
     HidControllerPreset m_preset;
 
-    unsigned char* m_pPollData;
+    unsigned char m_pPollData[255];
 };
 
 #endif

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -17,27 +17,6 @@
 #include "controllers/hid/hidcontrollerpresetfilehandler.h"
 #include "util/duration.h"
 
-class HidReader : public QThread {
-    Q_OBJECT
-  public:
-    HidReader(hid_device* device);
-    virtual ~HidReader();
-
-    void stop() {
-        m_stop = 1;
-    }
-
-  signals:
-    void incomingData(QByteArray data, mixxx::Duration timestamp);
-
-  protected:
-    void run();
-
-  private:
-    hid_device* m_pHidDevice;
-    QAtomicInt m_stop;
-};
-
 class HidController final : public Controller {
     Q_OBJECT
   public:
@@ -78,6 +57,9 @@ class HidController final : public Controller {
     int open() override;
     int close() override;
 
+    virtual bool poll() override;
+    virtual bool isPolling() const override;
+
   private:
     // For devices which only support a single report, reportID must be set to
     // 0x0.
@@ -107,8 +89,9 @@ class HidController final : public Controller {
 
     QString m_sUID;
     hid_device* m_pHidDevice;
-    HidReader* m_pReader;
     HidControllerPreset m_preset;
+
+    unsigned char* m_pPollData;
 };
 
 #endif

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -57,8 +57,8 @@ class HidController final : public Controller {
     int open() override;
     int close() override;
 
-    virtual bool poll() override;
-    virtual bool isPolling() const override;
+    bool poll() override;
+    bool isPolling() const override;
 
   private:
     // For devices which only support a single report, reportID must be set to


### PR DESCRIPTION
This fixes a problem where the controller thread would deadlock when `hid_read_timeout` and `hid_write` were called at the same time.

As discussed [on Zulip](https://mixxx.zulipchat.com/#narrow/stream/113295-controller-mapping/topic/Is.20shutdown.20called.20when.20reloading.20script.3F), this was fixed by removing `HidReader` in favor of using the `poll()` method so that HID reading runs on the same thread as writing.