### PR TITLE
Roland DJ-505: Improve ROLL mode

### DIFF
--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -935,7 +935,7 @@ DJ505.PadColor = {
     CORAL:        0x0A,
     AZURE:        0x0B,
     TURQUOISE:    0x0C,
-    AQUAMARINE:   0x0C,
+    AQUAMARINE:   0x0D,
     GREEN:        0x0E,
     WHITE:        0x0F,
     DIM_MODIFIER: 0x10,

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1286,7 +1286,7 @@ DJ505.RollMode = function (deck, offset) {
             inKey: "beatlooproll_" + loopSize + "_activate",
             outConnect: false,
             on: this.color,
-            off: (loopSize === 4) ? DJ505.PadColor.APPLEGREEN : (this.color + DJ505.PadColor.DIM_MODIFIER),
+            off: (loopSize === 0.25) ? DJ505.PadColor.TURQUOISE : ((loopSize === 4) ? DJ505.PadColor.AQUAMARINE : (this.color + DJ505.PadColor.DIM_MODIFIER)),
         });
     }
     this.pads[4] = new components.Button({
@@ -1364,9 +1364,7 @@ DJ505.RollMode = function (deck, offset) {
         mode: this,
         input: function (channel, control, value, status, group) {
             if (value) {
-                if (this.mode.loopSize === 0.03125) {
-                    this.mode.setLoopSize(0.25);
-                } else {
+                if (this.mode.loopSize > this.mode.minSize) {
                     this.mode.setLoopSize(this.mode.loopSize / 2);
                 }
             }
@@ -1378,9 +1376,7 @@ DJ505.RollMode = function (deck, offset) {
         mode: this,
         input: function (channel, control, value, status, group) {
             if (value) {
-                if (this.mode.loopSize === 0.25) {
-                    this.mode.setLoopSize(0.03125);
-                } else {
+                if (this.mode.loopSize * 8 < this.mode.maxSize) {
                     this.mode.setLoopSize(this.mode.loopSize * 2);
                 }
             }
@@ -1396,7 +1392,7 @@ DJ505.RollMode.prototype.setLoopSize = function (loopSize) {
         padLoopSize = (this.loopSize * Math.pow(2, i));
         this.pads[i].inKey = "beatlooproll_" + padLoopSize + "_activate";
         this.pads[i].outKey = "beatloop_" + padLoopSize + "_enabled";
-        this.pads[i].off = (padLoopSize === 4) ? DJ505.PadColor.APPLEGREEN : (this.color + DJ505.PadColor.DIM_MODIFIER);
+        this.pads[i].off = (padLoopSize === 0.25) ? DJ505.PadColor.TURQUOISE : ((padLoopSize === 4) ? DJ505.PadColor.AQUAMARINE : (this.pads[i].color + DJ505.PadColor.DIM_MODIFIER));
     }
     this.reconnectComponents();
 };


### PR DESCRIPTION
This adds beatjump controls to the lower performance pads button row, like Serato does. It also improves the LED indicators (since Mixxx only has a single loop size setting, not a "window" of 4 sizes).