### PR TITLE
Roland DJ-505: Remove LOOP mode

### DIFF
--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1062,6 +1062,8 @@ DJ505.PadSection.prototype.controlToPadMode = function (control) {
     case DJ505.PadMode.ROLL:
         mode = this.modes.roll;
         break;
+    // FIXME: Although it might be possible to implement Slicer Mode, it would
+    // miss visual feedback: https://bugs.launchpad.net/mixxx/+bug/1828886
     //case DJ505.PadMode.SLICER:
     //    mode = this.modes.slicer;
     //    break;

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1044,6 +1044,9 @@ DJ505.PadSection.prototype.controlToPadMode = function (control) {
     case DJ505.PadMode.HOTCUE:
         mode = this.modes.hotcue;
         break;
+    // FIXME: Mixxx is currently missing support for Serato-style "flips",
+    // hence this mode can only be implemented if this feature is added:
+    // https://bugs.launchpad.net/mixxx/+bug/1768113
     //case DJ505.PadMode.FLIP:
     //    mode = this.modes.flip;
     //    break;

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1071,6 +1071,8 @@ DJ505.PadSection.prototype.controlToPadMode = function (control) {
     case DJ505.PadMode.VELOCITYSAMPLER:
         mode = this.modes.velocitysampler;
         break;
+    // FIXME: Loop mode can be added as soon as Saved Loops are
+    // implemented: https://bugs.launchpad.net/mixxx/+bug/692926
     //case DJ505.PadMode.LOOP:
     //    mode = this.modes.loop;
     //    break;

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1024,7 +1024,6 @@ DJ505.PadSection = function (deck, offset) {
         "hotcue": new DJ505.HotcueMode(deck, offset),
         "cueloop": new DJ505.CueLoopMode(deck, offset),
         "roll": new DJ505.RollMode(deck, offset),
-        "loop": new DJ505.LoopMode(deck, offset),
         "sampler": new DJ505.SamplerMode(deck, offset),
         "velocitysampler": new DJ505.VelocitySamplerMode(deck, offset),
         "pitchplay": new DJ505.PitchPlayMode(deck, offset),
@@ -1072,9 +1071,9 @@ DJ505.PadSection.prototype.controlToPadMode = function (control) {
     case DJ505.PadMode.VELOCITYSAMPLER:
         mode = this.modes.velocitysampler;
         break;
-    case DJ505.PadMode.LOOP:
-        mode = this.modes.loop;
-        break;
+    //case DJ505.PadMode.LOOP:
+    //    mode = this.modes.loop;
+    //    break;
     case DJ505.PadMode.PITCHPLAY:
         mode = this.modes.pitchplay;
         break;
@@ -1327,28 +1326,6 @@ DJ505.RollMode.prototype.setLoopSize = function (loopSize) {
     }
     this.reconnectComponents();
 };
-
-DJ505.LoopMode = function (deck, offset) {
-    components.ComponentContainer.call(this);
-    this.ledControl = DJ505.PadMode.ROLL;
-    this.color = DJ505.PadColor.GREEN;
-    this.pads = new components.ComponentContainer();
-    for (var i = 0; i <= 7; i++) {
-        this.pads[i] = new components.Button({
-            midi: [0x94 + offset, 0x14 + i],
-            sendShifted: true,
-            shiftControl: true,
-            shiftOffset: 8,
-            group: deck.currentDeck,
-            outKey: "beatloop_" + (0.03125 * Math.pow(2, i)) + "_enabled",
-            inKey: "beatloop_" + (0.03125 * Math.pow(2, i)) + "_toggle",
-            outConnect: false,
-            on: this.color,
-            off: this.color + DJ505.PadColor.DIM_MODIFIER,
-        });
-    }
-};
-DJ505.LoopMode.prototype = Object.create(components.ComponentContainer.prototype);
 
 DJ505.SamplerMode = function (deck, offset) {
     components.ComponentContainer.call(this);


### PR DESCRIPTION
In its current form, the LOOP mode is not really useful. It maps the
pads to normal beatloops of different sizes - similar to the ROLL mode.
I'm not using it at all, since the Loop Sections is much more
convenient. For people coming from Serato, this is quite unintuitive
since it behaves completely different from the expected Saved Loop mode.

Unfortunately, Mixxx does not have the ability to save loops yet [1].
However, if this feature is added at some point, we can easily add a
proper loop mode. By removing it now (before it becomes part of a Mixxx
release) we can avoid having to document the previous behaviour forever.

[1] https://bugs.launchpad.net/mixxx/+bug/692926