### PR TITLE
Fix overview mark opacity

### DIFF
--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -556,6 +556,7 @@ void WOverview::paintEvent(QPaintEvent * /*unused*/) {
                     } else {
                         line.setLine(0.0, markPosition, static_cast<float>(width()), markPosition);
                     }
+                    painter.setOpacity(1.0);
                     painter.setPen(shadowPen);
                     painter.drawLine(line);
 


### PR DESCRIPTION
When painting the cue points marks we reuse the painter we used
for the mark ranges, which is set have opacity < 1.
We now restore the opacity to the painter before painting the
cue point marks.