### PR TITLE
parented_ptr: [Bugfix] (non-narrowing) conversion

### DIFF
--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -88,6 +88,9 @@ class parented_ptr {
 
   private:
     T* m_ptr;
+
+    template<typename>
+    friend class parented_ptr;
 };
 
 namespace {


### PR DESCRIPTION
The (non-narrowing) conversion from a `parented_ptr<U>` to a `parented_ptr<T>` didn't work. This should (and does with this fix, as far as I tested it) however work if `U*` is implicitly convertible to `T*`.