### PR TITLE
Remove "<EmitOnPressAndRelease>false</EmitOnPressAndRelease>" from skins

### DIFF
--- a/res/skins/Deere (64 Samplers)/skin_settings.xml
+++ b/res/skins/Deere (64 Samplers)/skin_settings.xml
@@ -39,8 +39,6 @@
             </State>
             <Connection>
               <ConfigKey>[Master],skin_settings</ConfigKey>
-              <!-- This is used to work around Bug 1795663 on OSX -->
-              <EmitOnPressAndRelease>false</EmitOnPressAndRelease>
               <ButtonState>LeftButton</ButtonState>
             </Connection>
           </PushButton>

--- a/res/skins/Deere/skin_settings.xml
+++ b/res/skins/Deere/skin_settings.xml
@@ -39,8 +39,6 @@
             </State>
             <Connection>
               <ConfigKey>[Master],skin_settings</ConfigKey>
-              <!-- This is used to work around Bug 1795663 on OSX -->
-              <EmitOnPressAndRelease>false</EmitOnPressAndRelease>
               <ButtonState>LeftButton</ButtonState>
             </Connection>
           </PushButton>

--- a/res/skins/Deere/tool_bar.xml
+++ b/res/skins/Deere/tool_bar.xml
@@ -434,7 +434,6 @@
                 </State>
                 <Connection>
                   <ConfigKey>[Master],skin_settings</ConfigKey>
-                  <EmitOnPressAndRelease>false</EmitOnPressAndRelease>
                   <ButtonState>LeftButton</ButtonState>
                 </Connection>
               </PushButton>

--- a/res/skins/Tango (64 Samplers)/skin_settings.xml
+++ b/res/skins/Tango (64 Samplers)/skin_settings.xml
@@ -40,8 +40,6 @@ Description:
                 <TooltipId>skin_settings</TooltipId>
                 <ObjectName>SkinSettingsClose</ObjectName>
                 <Size>20f,24f</Size>
-                <!-- This is used to work around Bug 1795663 on OSX -->
-                <EmitOnPressAndRelease>false</EmitOnPressAndRelease>
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>

--- a/res/skins/Tango/skin_settings.xml
+++ b/res/skins/Tango/skin_settings.xml
@@ -40,8 +40,6 @@ Description:
                 <TooltipId>skin_settings</TooltipId>
                 <ObjectName>SkinSettingsClose</ObjectName>
                 <Size>20f,24f</Size>
-                <!-- This is used to work around Bug 1795663 on OSX -->
-                <EmitOnPressAndRelease>false</EmitOnPressAndRelease>
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>

--- a/res/skins/Tango/topbar.xml
+++ b/res/skins/Tango/topbar.xml
@@ -335,8 +335,6 @@ Description:
                 <TooltipId>skin_settings</TooltipId>
                 <ObjectName>SkinSettingsToggler</ObjectName>
                 <Size>24f,24f</Size>
-                <!-- This is used to work around Bug 1795663 on OSX -->
-                <EmitOnPressAndRelease>false</EmitOnPressAndRelease>
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -2087,7 +2087,8 @@ void LegacySkinParser::setupConnections(const QDomNode& node, WBaseWidget* pWidg
                     emitOption = ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE;
                 } else {
                     SKIN_WARNING(con, *m_pContext)
-                            << "LegacySkinParser::setupConnections(): EmitOnPressAndRelease must not set false";
+                            << "LegacySkinParser::setupConnections():"
+                            << "Setting EmitOnPressAndRelease to false is not necessary.";
                 }
             } else {
                 // default:


### PR DESCRIPTION
These tags produce warnings like this:  
`
Warning [Main]: src/skin/legacyskinparser.cpp:2089 SKIN ERROR at skin:tool_bar.xml:435 <Connection>: LegacySkinParser::setup Connections(): EmitOnPressAndRelease must not set false`

The tags where (re)added in https://github.com/mixxxdj/mixxx/pull/1866. It looks like they are not needed anymore..