### PR TITLE
Enable beatloop activation directly after activating a hotcue

### DIFF
--- a/src/engine/controls/enginecontrol.cpp
+++ b/src/engine/controls/enginecontrol.cpp
@@ -85,9 +85,8 @@ void EngineControl::seek(double sample) {
     }
 }
 
-void EngineControl::notifySeek(double dNewPlaypos, bool adjustingPhase) {
+void EngineControl::notifySeek(double dNewPlaypos) {
     Q_UNUSED(dNewPlaypos);
-    Q_UNUSED(adjustingPhase);
 }
 
 EngineBuffer* EngineControl::pickSyncTarget() {

--- a/src/engine/controls/enginecontrol.cpp
+++ b/src/engine/controls/enginecontrol.cpp
@@ -85,9 +85,8 @@ void EngineControl::seek(double sample) {
     }
 }
 
-void EngineControl::notifySeek(double dNewPlaypos, double dSyncedNewPlayPos, bool adjustingPhase) {
+void EngineControl::notifySeek(double dNewPlaypos, bool adjustingPhase) {
     Q_UNUSED(dNewPlaypos);
-    Q_UNUSED(dSyncedNewPlayPos);
     Q_UNUSED(adjustingPhase);
 }
 

--- a/src/engine/controls/enginecontrol.cpp
+++ b/src/engine/controls/enginecontrol.cpp
@@ -85,8 +85,9 @@ void EngineControl::seek(double sample) {
     }
 }
 
-void EngineControl::notifySeek(double dNewPlaypos, bool adjustingPhase) {
+void EngineControl::notifySeek(double dNewPlaypos, double dSyncedNewPlayPos, bool adjustingPhase) {
     Q_UNUSED(dNewPlaypos);
+    Q_UNUSED(dSyncedNewPlayPos);
     Q_UNUSED(adjustingPhase);
 }
 

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -65,7 +65,7 @@ class EngineControl : public QObject {
     }
 
     // Called whenever a seek occurs to allow the EngineControl to respond.
-    virtual void notifySeek(double dNewPlaypo, bool adjustingPhase);
+    virtual void notifySeek(double dNewPlaypos);
     virtual void trackLoaded(TrackPointer pNewTrack);
 
   protected:

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -65,7 +65,7 @@ class EngineControl : public QObject {
     }
 
     // Called whenever a seek occurs to allow the EngineControl to respond.
-    virtual void notifySeek(double dNewPlaypos, double dSyncedNewPlayPos, bool adjustingPhase);
+    virtual void notifySeek(double dNewPlaypo, bool adjustingPhase);
     virtual void trackLoaded(TrackPointer pNewTrack);
 
   protected:

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -65,7 +65,7 @@ class EngineControl : public QObject {
     }
 
     // Called whenever a seek occurs to allow the EngineControl to respond.
-    virtual void notifySeek(double dNewPlaypo, bool adjustingPhase);
+    virtual void notifySeek(double dNewPlaypos, double dSyncedNewPlayPos, bool adjustingPhase);
     virtual void trackLoaded(TrackPointer pNewTrack);
 
   protected:

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -769,13 +769,12 @@ void LoopingControl::slotLoopEndPos(double pos) {
 }
 
 // This is called from the engine thread
-void LoopingControl::notifySeek(double dNewPlaypos, bool adjustingPhase) {
+void LoopingControl::notifySeek(double dNewPlaypos) {
     LoopSamples loopSamples = m_loopSamples.getValue();
     double currentSample = m_currentSample.getValue();
-    if (m_bLoopingEnabled && !adjustingPhase) {
+    if (m_bLoopingEnabled) {
         // Disable loop when we jumping out, or over a catching loop,
         // using hot cues or waveform overview.
-        // Do not jump out of a loop if we adjust a phase (lp1743010)
         if (currentSample >= loopSamples.start &&
                 currentSample <= loopSamples.end &&
                 dNewPlaypos < loopSamples.start) {

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -769,7 +769,7 @@ void LoopingControl::slotLoopEndPos(double pos) {
 }
 
 // This is called from the engine thread
-void LoopingControl::notifySeek(double dNewPlaypos, double dSyncedNewPlayPos, bool adjustingPhase) {
+void LoopingControl::notifySeek(double dNewPlaypos, bool adjustingPhase) {
     LoopSamples loopSamples = m_loopSamples.getValue();
     double currentSample = m_currentSample.getValue();
     if (m_bLoopingEnabled && !adjustingPhase) {

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -769,7 +769,7 @@ void LoopingControl::slotLoopEndPos(double pos) {
 }
 
 // This is called from the engine thread
-void LoopingControl::notifySeek(double dNewPlaypos, bool adjustingPhase) {
+void LoopingControl::notifySeek(double dNewPlaypos, double dSyncedNewPlayPos, bool adjustingPhase) {
     LoopSamples loopSamples = m_loopSamples.getValue();
     double currentSample = m_currentSample.getValue();
     if (m_bLoopingEnabled && !adjustingPhase) {

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -822,17 +822,34 @@ double LoopingControl::getSyncPositionInsideLoop(double dRequestedPlaypos, doubl
     }
 
     // the requested position is inside the loop (e.g hotcue at start)
+    double loopSize = loopSamples.end - loopSamples.start;
 
     // the synced position is in front of the loop
     // adjust the synced position to same amount in front of the loop end
     if (dSyncedPlayPos <= loopSamples.start) {
-        return loopSamples.end - (loopSamples.start - dSyncedPlayPos);
+        double adjustment = loopSamples.start - dSyncedPlayPos;
+
+        // if the adjustment is larger then the loop subtract N times the loopsize
+        // prevents jumping in front of the loop
+        // works like modulo on doubles
+        int numLoopsInAdjustment = adjustment / loopSize;
+        adjustment = adjustment - (numLoopsInAdjustment * loopSize);
+
+        return loopSamples.end - adjustment;
     }
 
     // the synced position is behind the loop
     // adjust the synced position to same amount behind the loop start
     if (dSyncedPlayPos >= loopSamples.end) {
-        return loopSamples.start + (dSyncedPlayPos - loopSamples.end);
+        double adjustment = dSyncedPlayPos - loopSamples.end;
+
+        // if the adjustment is larger then the loop subtract N times the loopsize
+        // prevents jumping behind the loop
+        // works like modulo on doubles
+        int numLoopsInAdjustment = adjustment / loopSize;
+        adjustment = adjustment - (numLoopsInAdjustment * loopSize);
+
+        return loopSamples.start + adjustment;
     }
 
     // both, requested and synced position are inside the loop -> do nothing

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -5,12 +5,12 @@
 #include <QtDebug>
 
 #include "control/controlobject.h"
-#include "preferences/usersettings.h"
 #include "control/controlpushbutton.h"
-#include "engine/enginebuffer.h"
-#include "engine/controls/loopingcontrol.h"
 #include "engine/controls/bpmcontrol.h"
 #include "engine/controls/enginecontrol.h"
+#include "engine/controls/loopingcontrol.h"
+#include "engine/enginebuffer.h"
+#include "preferences/usersettings.h"
 #include "util/compatibility.h"
 #include "util/math.h"
 #include "util/sample.h"
@@ -959,12 +959,11 @@ void LoopingControl::updateBeatLoopingControls() {
 }
 
 void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable) {
-
     // if a seek was queued in the engine buffer move the current sample to its position
-    ControlValueAtomic<double> seekPosition;
-    if(getEngineBuffer()->isSeekQueued(seekPosition)){
+    double p_seekPosition = 0;
+    if (getEngineBuffer()->isSeekQueued(&p_seekPosition)) {
         // seek position is already quantized if quantization is enabled
-        m_currentSample.setValue(seekPosition.getValue());
+        m_currentSample.setValue(p_seekPosition);
     }
 
     double maxBeatSize = s_dBeatSizes[sizeof(s_dBeatSizes)/sizeof(s_dBeatSizes[0]) - 1];

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -48,7 +48,7 @@ class LoopingControl : public EngineControl {
     // sample, if set.
     void hintReader(HintVector* pHintList) override;
 
-    void notifySeek(double dNewPlaypos, bool adjustingPhase) override;
+    void notifySeek(double dNewPlaypos) override;
 
     bool isLoopingEnabled();
     double getSyncPositionInsideLoop(double dRequestedPlaypos, double dSyncedPlayPos);

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -48,7 +48,7 @@ class LoopingControl : public EngineControl {
     // sample, if set.
     void hintReader(HintVector* pHintList) override;
 
-    void notifySeek(double dNewPlaypos, double dSyncedNewPlayPos, bool adjustingPhase) override;
+    void notifySeek(double dNewPlaypos, bool adjustingPhase) override;
 
     bool isLoopingEnabled();
 

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -48,7 +48,7 @@ class LoopingControl : public EngineControl {
     // sample, if set.
     void hintReader(HintVector* pHintList) override;
 
-    void notifySeek(double dNewPlaypos, bool adjustingPhase) override;
+    void notifySeek(double dNewPlaypos, double dSyncedNewPlayPos, bool adjustingPhase) override;
 
     bool isLoopingEnabled();
 

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -51,6 +51,7 @@ class LoopingControl : public EngineControl {
     void notifySeek(double dNewPlaypos, bool adjustingPhase) override;
 
     bool isLoopingEnabled();
+    double getSyncPositionInsideLoop(double dRequestedPlaypos, double dSyncedPlayPos);
 
   public slots:
     void slotLoopIn(double pressed);

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -553,7 +553,6 @@ void RateControl::resetRateTemp(void)
     setRateTemp(0.0);
 }
 
-void RateControl::notifySeek(double playPos, bool adjustingPhase) {
-    Q_UNUSED(adjustingPhase);
+void RateControl::notifySeek(double playPos) {
     m_pScratchController->notifySeek(playPos);
 }

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -553,7 +553,7 @@ void RateControl::resetRateTemp(void)
     setRateTemp(0.0);
 }
 
-void RateControl::notifySeek(double playPos, double dSyncedNewPlayPos, bool adjustingPhase) {
+void RateControl::notifySeek(double playPos, bool adjustingPhase) {
     Q_UNUSED(adjustingPhase);
-    m_pScratchController->notifySeek(dSyncedNewPlayPos);
+    m_pScratchController->notifySeek(playPos);
 }

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -553,7 +553,7 @@ void RateControl::resetRateTemp(void)
     setRateTemp(0.0);
 }
 
-void RateControl::notifySeek(double playPos, bool adjustingPhase) {
+void RateControl::notifySeek(double playPos, double dSyncedNewPlayPos, bool adjustingPhase) {
     Q_UNUSED(adjustingPhase);
-    m_pScratchController->notifySeek(playPos);
+    m_pScratchController->notifySeek(dSyncedNewPlayPos);
 }

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -77,7 +77,7 @@ public:
     // Set Rate Ramp Sensitivity
     static void setRateRampSensitivity(int);
     static int getRateRampSensitivity();
-    void notifySeek(double dNewPlaypos, bool adjustingPhase) override;
+    void notifySeek(double dNewPlaypos) override;
 
   public slots:
     void slotReverseRollActivate(double);

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -77,7 +77,7 @@ public:
     // Set Rate Ramp Sensitivity
     static void setRateRampSensitivity(int);
     static int getRateRampSensitivity();
-    void notifySeek(double dNewPlaypos, bool adjustingPhase) override;
+    void notifySeek(double dNewPlaypos, double dSyncedNewPlayPos, bool adjustingPhase) override;
 
   public slots:
     void slotReverseRollActivate(double);

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -77,7 +77,7 @@ public:
     // Set Rate Ramp Sensitivity
     static void setRateRampSensitivity(int);
     static int getRateRampSensitivity();
-    void notifySeek(double dNewPlaypos, double dSyncedNewPlayPos, bool adjustingPhase) override;
+    void notifySeek(double dNewPlaypos, bool adjustingPhase) override;
 
   public slots:
     void slotReverseRollActivate(double);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -430,7 +430,7 @@ void EngineBuffer::seekCloneBuffer(EngineBuffer* pOtherBuffer) {
 
 // WARNING: This method is not thread safe and must not be called from outside
 // the engine callback!
-void EngineBuffer::setNewPlaypos(double newpos, bool adjustingPhase) {
+void EngineBuffer::setNewPlaypos(double newpos) {
     //qDebug() << m_group << "engine new pos " << newpos;
 
     m_filepos_play = newpos;
@@ -449,7 +449,7 @@ void EngineBuffer::setNewPlaypos(double newpos, bool adjustingPhase) {
 
     // Must hold the engineLock while using m_engineControls
     for (const auto& pControl: qAsConst(m_engineControls)) {
-        pControl->notifySeek(m_filepos_play, adjustingPhase);
+        pControl->notifySeek(m_filepos_play);
     }
 
     verifyPlay(); // verify or update play button and indicator
@@ -1138,14 +1138,12 @@ void EngineBuffer::processSeek(bool paused) {
         seekType |= SEEK_PHASE;
     }
 
-    bool adjustingPhase = false;
     switch (seekType) {
         case SEEK_NONE:
             return;
         case SEEK_PHASE:
             // only adjust phase
             position = m_filepos_play;
-            adjustingPhase = true;
             break;
         case SEEK_STANDARD:
             if (m_pQuantize->toBool()) {
@@ -1171,7 +1169,7 @@ void EngineBuffer::processSeek(bool paused) {
     }
 
     if (position != m_filepos_play) {
-        setNewPlaypos(position, adjustingPhase);
+        setNewPlaypos(position);
     }
 }
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -430,10 +430,10 @@ void EngineBuffer::seekCloneBuffer(EngineBuffer* pOtherBuffer) {
 
 // WARNING: This method is not thread safe and must not be called from outside
 // the engine callback!
-void EngineBuffer::setNewPlaypos(double newpos, bool adjustingPhase) {
+void EngineBuffer::setNewPlaypos(double dNewPlayPos, double dSyncedNewPlayPos, bool adjustingPhase) {
     //qDebug() << m_group << "engine new pos " << newpos;
 
-    m_filepos_play = newpos;
+    m_filepos_play = dSyncedNewPlayPos;
 
     if (m_rate_old != 0.0) {
         // Before seeking, read extra buffer for crossfading
@@ -449,7 +449,7 @@ void EngineBuffer::setNewPlaypos(double newpos, bool adjustingPhase) {
 
     // Must hold the engineLock while using m_engineControls
     for (const auto& pControl: qAsConst(m_engineControls)) {
-        pControl->notifySeek(m_filepos_play, adjustingPhase);
+        pControl->notifySeek(dNewPlayPos, m_filepos_play, adjustingPhase);
     }
 
     verifyPlay(); // verify or update play button and indicator
@@ -1169,14 +1169,7 @@ void EngineBuffer::processSeek(bool paused) {
     }
 
     if (syncPosition != m_filepos_play) {
-        if (seekType & SEEK_PHASE) {
-            // inform controllers about the seek position itself
-            // and do the phase shift afterwards
-            // this prevents loops from getting disabled because the synced position is in front of the loop
-            setNewPlaypos(position, false);
-            adjustingPhase = true;
-        }
-        setNewPlaypos(syncPosition, adjustingPhase);
+        setNewPlaypos(position, syncPosition, adjustingPhase);
     }
 }
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1125,7 +1125,7 @@ void EngineBuffer::processSeek(bool paused) {
     // call anyway again.
 
     SeekRequests seekType = static_cast<SeekRequest>(
-            m_iSeekQueued.fetchAndStoreRelaxed(SEEK_NONE));
+            m_iSeekQueued.fetchAndStoreAcquire(SEEK_NONE));
     double position = m_queuedSeekPosition.getValue();
 
     // Don't allow the playposition to go past the end.
@@ -1163,20 +1163,15 @@ void EngineBuffer::processSeek(bool paused) {
             return;
     }
 
-    double syncPosition = position;
     if (!paused && (seekType & SEEK_PHASE)) {
+        double syncPosition = position;
+        double requestedPosition = position;
         syncPosition = m_pBpmControl->getNearestPositionInPhase(position, true, true);
+        position = m_pLoopingControl->getSyncPositionInsideLoop(requestedPosition, syncPosition);
     }
 
-    if (syncPosition != m_filepos_play) {
-        if (seekType & SEEK_PHASE) {
-            // inform controllers about the seek position itself
-            // and do the phase shift afterwards
-            // this prevents loops from getting disabled because the synced position is in front of the loop
-            setNewPlaypos(position, false);
-            adjustingPhase = true;
-        }
-        setNewPlaypos(syncPosition, adjustingPhase);
+    if (position != m_filepos_play) {
+        setNewPlaypos(position, adjustingPhase);
     }
 }
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1125,7 +1125,7 @@ void EngineBuffer::processSeek(bool paused) {
     // call anyway again.
 
     SeekRequests seekType = static_cast<SeekRequest>(
-            m_iSeekQueued.fetchAndStoreAcquire(SEEK_NONE));
+            m_iSeekQueued.loadAcquire());
     double position = m_queuedSeekPosition.getValue();
 
     // Don't allow the playposition to go past the end.
@@ -1171,6 +1171,7 @@ void EngineBuffer::processSeek(bool paused) {
     if (position != m_filepos_play) {
         setNewPlaypos(position);
     }
+    m_iSeekQueued.storeRelease(SEEK_NONE);
 }
 
 void EngineBuffer::postProcess(const int iBufferSize) {

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -231,7 +231,7 @@ class EngineBuffer : public EngineObject {
     void seekCloneBuffer(EngineBuffer* pOtherBuffer);
 
     // Reset buffer playpos and set file playpos.
-    void setNewPlaypos(double playpos, bool adjustingPhase);
+    void setNewPlaypos(double dNewPlayPos, double dSyncedNewPlayPos, bool adjustingPhase);
 
     void processSyncRequests();
     void processSeek(bool paused);

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -141,6 +141,7 @@ class EngineBuffer : public EngineObject {
 
     QString getGroup();
     bool isTrackLoaded();
+    bool isSeekQueued(ControlValueAtomic<double> &seekPos);
     TrackPointer getLoadedTrack() const;
 
     double getExactPlayPos();

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -231,7 +231,7 @@ class EngineBuffer : public EngineObject {
     void seekCloneBuffer(EngineBuffer* pOtherBuffer);
 
     // Reset buffer playpos and set file playpos.
-    void setNewPlaypos(double dNewPlayPos, double dSyncedNewPlayPos, bool adjustingPhase);
+    void setNewPlaypos(double playpos, bool adjustingPhase);
 
     void processSyncRequests();
     void processSeek(bool paused);

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -231,7 +231,7 @@ class EngineBuffer : public EngineObject {
     void seekCloneBuffer(EngineBuffer* pOtherBuffer);
 
     // Reset buffer playpos and set file playpos.
-    void setNewPlaypos(double playpos, bool adjustingPhase);
+    void setNewPlaypos(double playpos);
 
     void processSyncRequests();
     void processSeek(bool paused);

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -141,7 +141,7 @@ class EngineBuffer : public EngineObject {
 
     QString getGroup();
     bool isTrackLoaded();
-    bool isSeekQueued(ControlValueAtomic<double> &seekPos);
+    bool isSeekQueued(double* pSeekPosition);
     TrackPointer getLoadedTrack() const;
 
     double getExactPlayPos();

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -254,7 +254,7 @@ double ReadAheadManager::getFilePlaypositionFromLog(
         // (Not looping control)
         if (shouldNotifySeek) {
             if (m_pRateControl) {
-                m_pRateControl->notifySeek(entry.virtualPlaypositionStart, false);
+                m_pRateControl->notifySeek(entry.virtualPlaypositionStart);
             }
         }
 

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -254,7 +254,7 @@ double ReadAheadManager::getFilePlaypositionFromLog(
         // (Not looping control)
         if (shouldNotifySeek) {
             if (m_pRateControl) {
-                m_pRateControl->notifySeek(entry.virtualPlaypositionStart, 0, false);
+                m_pRateControl->notifySeek(entry.virtualPlaypositionStart, false);
             }
         }
 

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -254,7 +254,7 @@ double ReadAheadManager::getFilePlaypositionFromLog(
         // (Not looping control)
         if (shouldNotifySeek) {
             if (m_pRateControl) {
-                m_pRateControl->notifySeek(entry.virtualPlaypositionStart, false);
+                m_pRateControl->notifySeek(entry.virtualPlaypositionStart, 0, false);
             }
         }
 

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -56,9 +56,8 @@ class StubLoopControl : public LoopingControl {
         Q_UNUSED(pHintList);
     }
 
-    void notifySeek(double dNewPlaypos, bool adjustingPhase) override {
+    void notifySeek(double dNewPlaypos) override {
         Q_UNUSED(dNewPlaypos);
-        Q_UNUSED(adjustingPhase);
     }
 
     void trackLoaded(TrackPointer pTrack) override {

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -56,8 +56,9 @@ class StubLoopControl : public LoopingControl {
         Q_UNUSED(pHintList);
     }
 
-    void notifySeek(double dNewPlaypos, bool adjustingPhase) override {
+    void notifySeek(double dNewPlaypos, double dSyncedNewPlayPos, bool adjustingPhase) override {
         Q_UNUSED(dNewPlaypos);
+        Q_UNUSED(dSyncedNewPlayPos);
         Q_UNUSED(adjustingPhase);
     }
 

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -56,9 +56,8 @@ class StubLoopControl : public LoopingControl {
         Q_UNUSED(pHintList);
     }
 
-    void notifySeek(double dNewPlaypos, double dSyncedNewPlayPos, bool adjustingPhase) override {
+    void notifySeek(double dNewPlaypos, bool adjustingPhase) override {
         Q_UNUSED(dNewPlaypos);
-        Q_UNUSED(dSyncedNewPlayPos);
         Q_UNUSED(adjustingPhase);
     }
 


### PR DESCRIPTION
Fxes https://bugs.launchpad.net/mixxx/+bug/1464003 .
Basically the loopcontroller has to set the loop start position to the queued seek position before activating the loop.
Furthermore, when a hotcue that is at the end of an active loop is activated, also disable the loop instead of jumping back to the loop entry.