### PR TITLE
Add *.plist files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ build/wix/ProductID.wxi
 *.pdb
 lib/*/*.lib
 lib/*/lib/*.lib
+/*.plist
 
 lib/qtscript-bytearray/*.cc
 


### PR DESCRIPTION
This adds *.plist files to gitignore, since they are apparently autogenerated
during the build process.

A few files do reside in the repository and should probably not be
ignored:

    $ git ls-files | grep plist
    build/osx/entitlements.plist
    build/osx/product_definition.plist
    lib/gmock-1.7.0/gtest/xcode/Resources/Info.plist
    lib/gmock-1.7.0/gtest/xcode/Samples/FrameworkSample/Info.plist
    lib/gtest-1.7.0/xcode/Resources/Info.plist
    lib/gtest-1.7.0/xcode/Samples/FrameworkSample/Info.plist
    lib/hidapi-0.8.0-rc1/testgui/TestGUI.app.in/Contents/Info.plist

Hence, additional rules were added to make sure that *.plist files in
the build/ and lib/ directories are excluded from the gitignore pattern.