### PR TITLE
Force findNthBeat to return mutliples of beatlength and adapt tests

### DIFF
--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -41,7 +41,7 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
     TrackPointer pTrack(Track::newTemporary());
 
     int sampleRate = 44100;
-    double bpm = 60.0;
+    double bpm = 60.1;
     const int kFrameSize = 2;
     pTrack->setBpm(bpm);
     pTrack->setSampleRate(sampleRate);
@@ -58,26 +58,26 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
     // findNthBeat should return exactly the current beat if we ask for 1 or
     // -1. For all other values, it should return n times the beat length.
     for (int i = 1; i < 20; ++i) {
-        EXPECT_EQ(position + beatLength*(i-1), pGrid->findNthBeat(position, i));
-        EXPECT_EQ(position + beatLength*(-i+1), pGrid->findNthBeat(position, -i));
+        EXPECT_DOUBLE_EQ(position + beatLength * (i - 1), pGrid->findNthBeat(position, i));
+        EXPECT_DOUBLE_EQ(position + beatLength * (-i + 1), pGrid->findNthBeat(position, -i));
     }
 
     // Also test prev/next beat calculation.
     double prevBeat, nextBeat;
     pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat);
-    EXPECT_EQ(position, prevBeat);
-    EXPECT_EQ(position + beatLength, nextBeat);
+    EXPECT_DOUBLE_EQ(position, prevBeat);
+    EXPECT_DOUBLE_EQ(position + beatLength, nextBeat);
 
     // Both previous and next beat should return the current position.
-    EXPECT_EQ(position, pGrid->findNextBeat(position));
-    EXPECT_EQ(position, pGrid->findPrevBeat(position));
+    EXPECT_DOUBLE_EQ(position, pGrid->findNextBeat(position));
+    EXPECT_DOUBLE_EQ(position, pGrid->findPrevBeat(position));
 }
 
 TEST(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     TrackPointer pTrack(Track::newTemporary());
 
     int sampleRate = 44100;
-    double bpm = 60.0;
+    double bpm = 60.1;
     const int kFrameSize = 2;
     pTrack->setBpm(bpm);
     pTrack->setSampleRate(sampleRate);
@@ -96,26 +96,26 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     // findNthBeat should return exactly the current beat if we ask for 1 or
     // -1. For all other values, it should return n times the beat length.
     for (int i = 1; i < 20; ++i) {
-        EXPECT_EQ(kClosestBeat + beatLength*(i-1), pGrid->findNthBeat(position, i));
-        EXPECT_EQ(kClosestBeat + beatLength*(-i+1), pGrid->findNthBeat(position, -i));
+        EXPECT_DOUBLE_EQ(kClosestBeat + beatLength * (i - 1), pGrid->findNthBeat(position, i));
+        EXPECT_DOUBLE_EQ(kClosestBeat + beatLength * (-i + 1), pGrid->findNthBeat(position, -i));
     }
 
     // Also test prev/next beat calculation.
     double prevBeat, nextBeat;
     pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat);
-    EXPECT_EQ(kClosestBeat, prevBeat);
-    EXPECT_EQ(kClosestBeat + beatLength, nextBeat);
+    EXPECT_DOUBLE_EQ(kClosestBeat, prevBeat);
+    EXPECT_DOUBLE_EQ(kClosestBeat + beatLength, nextBeat);
 
     // Both previous and next beat should return the closest beat.
-    EXPECT_EQ(kClosestBeat, pGrid->findNextBeat(position));
-    EXPECT_EQ(kClosestBeat, pGrid->findPrevBeat(position));
+    EXPECT_DOUBLE_EQ(kClosestBeat, pGrid->findNextBeat(position));
+    EXPECT_DOUBLE_EQ(kClosestBeat, pGrid->findPrevBeat(position));
 }
 
 TEST(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     TrackPointer pTrack(Track::newTemporary());
 
     int sampleRate = 44100;
-    double bpm = 60.0;
+    double bpm = 60.1;
     const int kFrameSize = 2;
     pTrack->setBpm(bpm);
     pTrack->setSampleRate(sampleRate);
@@ -134,25 +134,25 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     // findNthBeat should return exactly the current beat if we ask for 1 or
     // -1. For all other values, it should return n times the beat length.
     for (int i = 1; i < 20; ++i) {
-        EXPECT_EQ(kClosestBeat + beatLength*(i-1), pGrid->findNthBeat(position, i));
-        EXPECT_EQ(kClosestBeat + beatLength*(-i+1), pGrid->findNthBeat(position, -i));
+        EXPECT_DOUBLE_EQ(kClosestBeat + beatLength * (i - 1), pGrid->findNthBeat(position, i));
+        EXPECT_DOUBLE_EQ(kClosestBeat + beatLength * (-i + 1), pGrid->findNthBeat(position, -i));
     }
 
     // Also test prev/next beat calculation.
     double prevBeat, nextBeat;
     pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat);
-    EXPECT_EQ(kClosestBeat, prevBeat);
-    EXPECT_EQ(kClosestBeat + beatLength, nextBeat);
+    EXPECT_DOUBLE_EQ(kClosestBeat, prevBeat);
+    EXPECT_DOUBLE_EQ(kClosestBeat + beatLength, nextBeat);
 
     // Both previous and next beat should return the closest beat.
-    EXPECT_EQ(kClosestBeat, pGrid->findNextBeat(position));
-    EXPECT_EQ(kClosestBeat, pGrid->findPrevBeat(position));
+    EXPECT_DOUBLE_EQ(kClosestBeat, pGrid->findNextBeat(position));
+    EXPECT_DOUBLE_EQ(kClosestBeat, pGrid->findPrevBeat(position));
 }
 
 TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
     TrackPointer pTrack(Track::newTemporary());
     int sampleRate = 44100;
-    double bpm = 60.0;
+    double bpm = 60.1;
     const int kFrameSize = 2;
     pTrack->setBpm(bpm);
     pTrack->setSampleRate(sampleRate);

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1469,7 +1469,7 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
     // first test without quantisation
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
-    ASSERT_DOUBLE_EQ(0.025155996658969195, ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
+    ASSERT_DOUBLE_EQ(0.025154950869236584, ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
     pButtonSyncEnabled1->set(0.0);
 
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 1.0);
@@ -1478,7 +1478,7 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
     pButtonSyncEnabled1->set(1.0);
     ProcessBuffer();
 
-    ASSERT_DOUBLE_EQ(0.077604743399185772, ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
+    ASSERT_DOUBLE_EQ(0.07760393046107332, ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
     pButtonSyncEnabled1->set(0.0);
     ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 0.0);
     ProcessBuffer();
@@ -1487,7 +1487,7 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
     ProcessBuffer();
 
     // 0.11632139450713055 in case "beatsync_phase" fails
-    ASSERT_DOUBLE_EQ(0.11610813658949772, ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
+    ASSERT_DOUBLE_EQ(0.11610733182161753, ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
 
 
     ControlObject::set(ConfigKey(m_sGroup1, "beat_distance"), 0.2);
@@ -1498,7 +1498,7 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
 
     // these values were determined experimentally
     // 0.15480806100370784 in case quantize is enabled
-    ASSERT_DOUBLE_EQ(0.16263690384739582, ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
+    ASSERT_DOUBLE_EQ(0.16263416477702192, ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
 
     ProcessBuffer();
 
@@ -1508,7 +1508,7 @@ TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
 
     // these values were determined experimentally
     // 0.19933910991038406 in case quantize is disabled
-    ASSERT_DOUBLE_EQ(0.19350798541791794, ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
+    ASSERT_DOUBLE_EQ(0.1935071806500378, ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
 
 }
 
@@ -1527,7 +1527,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     ControlObject::set(ConfigKey(m_sGroup1, "playposition"), 0.2);
     ProcessBuffer();
 
-    ASSERT_DOUBLE_EQ(0.20464410501585786, ControlObject::get(ConfigKey(m_sGroup1, "playposition")));
+    ASSERT_DOUBLE_EQ(0.20464399092970517, ControlObject::get(ConfigKey(m_sGroup1, "playposition")));
 }
 
 TEST_F(EngineSyncTest, SyncWithoutBeatgrid) {
@@ -1592,7 +1592,7 @@ TEST_F(EngineSyncTest, QuantizeHotCueActivate) {
     ProcessBuffer();
 
     // the value was determined experimentally 
-    ASSERT_DOUBLE_EQ(0.11997394884298185, ControlObject::get(ConfigKey(m_sGroup2, "beat_distance")));
+    ASSERT_DOUBLE_EQ(0.1199697656840514, ControlObject::get(ConfigKey(m_sGroup2, "beat_distance")));
 
     pHotCueActivate->set(0.0);
     ProcessBuffer();

--- a/src/track/beatgrid.cpp
+++ b/src/track/beatgrid.cpp
@@ -178,14 +178,12 @@ double BeatGrid::findNthBeat(double dSamples, int n) const {
     const double kEpsilon = .01;
 
     if (fabs(nextBeat - beatFraction) < kEpsilon) {
-        beatFraction = nextBeat;
         // If we are going to pretend we were actually on nextBeat then prevBeat
         // needs to be re-calculated. Since it is floor(beatFraction), that's
         // the same as nextBeat.  We only use prevBeat so no need to increment
         // nextBeat.
         prevBeat = nextBeat;
     } else if (fabs(prevBeat - beatFraction) < kEpsilon) {
-        beatFraction = prevBeat;
         // If we are going to pretend we were actually on prevBeat then nextBeat
         // needs to be re-calculated. Since it is ceil(beatFraction), that's
         // the same as prevBeat.  We will only use nextBeat so no need to
@@ -206,10 +204,7 @@ double BeatGrid::findNthBeat(double dSamples, int n) const {
         n = n + 1;
     }
 
-    double dResult = floor(dClosestBeat + n * m_dBeatLength);
-    if (!even(static_cast<int>(dResult))) {
-        dResult--;
-    }
+    double dResult = dClosestBeat + n * m_dBeatLength;
     return dResult;
 }
 
@@ -246,14 +241,8 @@ bool BeatGrid::findPrevNextBeats(double dSamples,
         // And nextBeat needs to be incremented.
         ++nextBeat;
     }
-    *dpPrevBeatSamples = floor(prevBeat * dBeatLength + dFirstBeatSample);
-    *dpNextBeatSamples = floor(nextBeat * dBeatLength + dFirstBeatSample);
-    if (!even(static_cast<int>(*dpPrevBeatSamples))) {
-        --*dpPrevBeatSamples;
-    }
-    if (!even(static_cast<int>(*dpNextBeatSamples))) {
-        --*dpNextBeatSamples;
-    }
+    *dpPrevBeatSamples = prevBeat * dBeatLength + dFirstBeatSample;
+    *dpNextBeatSamples = nextBeat * dBeatLength + dFirstBeatSample;
     return true;
 }
 


### PR DESCRIPTION
This is a spinoff of #2186 . 
When using the findNextBeat-function (and associated functions), I noticed that the returned sample is not always a multitude of the beat length in samples, which is what I'd have expected and what the respective tests also seem to assume. This is particularly true for beatgrids with non-integer bpm.
I adapted the function to respect this again and adapted the test to be checking for an uneven bpm. This could break some other functions though, which is why I opened it in its own PR