### PR TITLE
Fix libebur128 compilation on OpenBSD by using internal queue.h

### DIFF
--- a/build/depends.py
+++ b/build/depends.py
@@ -501,7 +501,8 @@ class Ebur128Mit(Dependence):
         if not conf.CheckLib(['ebur128', 'libebur128']):
             self.INTERNAL_LINK = True;
             env.Append(CPPPATH=['#%s/ebur128' % self.INTERNAL_PATH])
-            if not conf.CheckHeader('sys/queue.h'):
+            import sys
+            if not conf.CheckHeader('sys/queue.h') or sys.platform.startswith('openbsd'):
                 env.Append(CPPPATH=['#%s/ebur128/queue' % self.INTERNAL_PATH])
 
 


### PR DESCRIPTION
libebur128 uses `STAILQ_*` which is not available on OpenBSD:
http://man.openbsd.org/queue
(NetBSD and FreeBSD are not affected)
