### PR TITLE
LateNight: fix borders in PreviewDeck

### DIFF
--- a/res/skins/LateNight/preview_deck.xml
+++ b/res/skins/LateNight/preview_deck.xml
@@ -55,10 +55,10 @@
                         <Connection>
                           <ConfigKey>[PreviewDeck1],visual_bpm</ConfigKey>
                         </Connection>
-			<Connection>
-			  <ConfigKey>[PreviewDeck1],track_loaded</ConfigKey>
-			  <BindProperty>visible</BindProperty>
-			</Connection>
+                        <Connection>
+                          <ConfigKey>[PreviewDeck1],track_loaded</ConfigKey>
+                          <BindProperty>visible</BindProperty>
+                        </Connection>
                       </Number>
                     </Children>
                   </WidgetGroup>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -928,13 +928,6 @@ WBeatSpinBox,
   margin: 2px;
 }
 
-#PreviewPlayOverview {
-  border: 1px solid #585858;
-  border-top: 0px;
-  border-left: 0px;
-  border-bottom: 0px;
-}
-
 #PreviewPlay {
   padding: 3px 1px 1px 3px;
   border-right: 1px solid #585858;


### PR DESCRIPTION
quick fix that removes the double border of the PrevDeck wave overview
(didn't properly add all changes to my previous PR)