### PR TITLE
fix disable loop on hotcue press

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1177,9 +1177,8 @@ void EngineBuffer::processSeek(bool paused) {
     }
 
     if (!paused && (seekType & SEEK_PHASE)) {
-        double syncPosition = position;
         double requestedPosition = position;
-        syncPosition = m_pBpmControl->getNearestPositionInPhase(position, true, true);
+        double syncPosition = m_pBpmControl->getNearestPositionInPhase(position, true, true);
         position = m_pLoopingControl->getSyncPositionInsideLoop(requestedPosition, syncPosition);
     }
     if (position != m_filepos_play) {

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -228,7 +228,7 @@ class EngineBuffer : public EngineObject {
     void readToCrossfadeBuffer(const int iBufferSize);
 
     // Reset buffer playpos and set file playpos.
-    void setNewPlaypos(double playpos, bool adjustingPhase);
+    void setNewPlaypos(double playpos);
 
     void processSyncRequests();
     void processSeek(bool paused);

--- a/src/engine/enginecontrol.cpp
+++ b/src/engine/enginecontrol.cpp
@@ -85,9 +85,8 @@ void EngineControl::seek(double sample) {
     }
 }
 
-void EngineControl::notifySeek(double dNewPlaypos, bool adjustingPhase) {
+void EngineControl::notifySeek(double dNewPlaypos) {
     Q_UNUSED(dNewPlaypos);
-    Q_UNUSED(adjustingPhase);
 }
 
 EngineBuffer* EngineControl::pickSyncTarget() {

--- a/src/engine/enginecontrol.h
+++ b/src/engine/enginecontrol.h
@@ -65,7 +65,7 @@ class EngineControl : public QObject {
     }
 
     // Called whenever a seek occurs to allow the EngineControl to respond.
-    virtual void notifySeek(double dNewPlaypo, bool adjustingPhase);
+    virtual void notifySeek(double dNewPlaypos);
     virtual void trackLoaded(TrackPointer pNewTrack);
 
   protected:

--- a/src/engine/loopingcontrol.cpp
+++ b/src/engine/loopingcontrol.cpp
@@ -461,7 +461,8 @@ double LoopingControl::getSyncPositionInsideLoop(double dRequestedPlaypos, doubl
     LoopSamples loopSamples = m_loopSamples.getValue();
 
     // if the request itself is outside loop do nothing
-    // loop will be disabled later by notifySeek(...)
+    // loop will be disabled later by notifySeek(...) as is was explicitly requested by the user
+    // if the requested position is the exact end of a loop it should also be disabled later by notifySeek(...)
     if (dRequestedPlaypos < loopSamples.start || dRequestedPlaypos >= loopSamples.end) {
         return dSyncedPlayPos;
     }
@@ -471,7 +472,7 @@ double LoopingControl::getSyncPositionInsideLoop(double dRequestedPlaypos, doubl
 
     // the synced position is in front of the loop
     // adjust the synced position to same amount in front of the loop end
-    if (dSyncedPlayPos <= loopSamples.start) {
+    if (dSyncedPlayPos < loopSamples.start) {
         double adjustment = loopSamples.start - dSyncedPlayPos;
 
         // prevents jumping in front of the loop if loop is smaller than adjustment

--- a/src/engine/loopingcontrol.h
+++ b/src/engine/loopingcontrol.h
@@ -46,8 +46,9 @@ class LoopingControl : public EngineControl {
     // hintReader will add to hintList hints both the loop in and loop out
     // sample, if set.
     void hintReader(HintVector* pHintList) override;
+    double getSyncPositionInsideLoop(double dRequestedPlaypos, double dSyncedPlayPos);
 
-    void notifySeek(double dNewPlaypos, bool adjustingPhase) override;
+    void notifySeek(double dNewPlaypos) override;
 
   public slots:
     void slotLoopIn(double pressed);

--- a/src/engine/ratecontrol.cpp
+++ b/src/engine/ratecontrol.cpp
@@ -553,7 +553,6 @@ void RateControl::resetRateTemp(void)
     setRateTemp(0.0);
 }
 
-void RateControl::notifySeek(double playPos, bool adjustingPhase) {
-    Q_UNUSED(adjustingPhase);
+void RateControl::notifySeek(double playPos) {
     m_pScratchController->notifySeek(playPos);
 }

--- a/src/engine/ratecontrol.h
+++ b/src/engine/ratecontrol.h
@@ -77,7 +77,7 @@ public:
     // Set Rate Ramp Sensitivity
     static void setRateRampSensitivity(int);
     static int getRateRampSensitivity();
-    void notifySeek(double dNewPlaypos, bool adjustingPhase) override;
+    void notifySeek(double dNewPlaypos) override;
 
   public slots:
     void slotReverseRollActivate(double);

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -254,7 +254,7 @@ double ReadAheadManager::getFilePlaypositionFromLog(
         // (Not looping control)
         if (shouldNotifySeek) {
             if (m_pRateControl) {
-                m_pRateControl->notifySeek(entry.virtualPlaypositionStart, false);
+                m_pRateControl->notifySeek(entry.virtualPlaypositionStart);
             }
         }
 

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -56,9 +56,8 @@ class StubLoopControl : public LoopingControl {
         Q_UNUSED(pHintList);
     }
 
-    void notifySeek(double dNewPlaypos, bool adjustingPhase) override {
+    void notifySeek(double dNewPlaypos) override {
         Q_UNUSED(dNewPlaypos);
-        Q_UNUSED(adjustingPhase);
     }
 
     void trackLoaded(TrackPointer pTrack) override {


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/mixxx/+bug/1778246 by calculating a synchronized position inside an active loop if a seek is processed