### PR TITLE
enable beatloop activation directly after activating a hotcue

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1010,7 +1010,7 @@ void LoopingControl::updateBeatLoopingControls() {
 void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable) {
     // if a seek was queued in the engine buffer move the current sample to its position
     double p_seekPosition = 0;
-    if (getEngineBuffer()->isSeekQueued(&p_seekPosition)) {
+    if (getEngineBuffer()->getQueuedSeekPosition(&p_seekPosition)) {
         // seek position is already quantized if quantization is enabled
         m_currentSample.setValue(p_seekPosition);
     }

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -5,11 +5,12 @@
 #include <QtDebug>
 
 #include "control/controlobject.h"
-#include "preferences/usersettings.h"
 #include "control/controlpushbutton.h"
-#include "engine/controls/loopingcontrol.h"
 #include "engine/controls/bpmcontrol.h"
 #include "engine/controls/enginecontrol.h"
+#include "engine/controls/loopingcontrol.h"
+#include "engine/enginebuffer.h"
+#include "preferences/usersettings.h"
 #include "util/compatibility.h"
 #include "util/math.h"
 #include "util/sample.h"
@@ -478,6 +479,11 @@ double LoopingControl::getSyncPositionInsideLoop(double dRequestedPlaypos, doubl
         // prevents jumping in front of the loop if loop is smaller than adjustment
         adjustment = fmod(adjustment, loopSize);
 
+        // if the synced position is exactly the start of the loop we would end up at the exact end
+        // as this would disable the loop in notifySeek() replace it with the start of the loop
+        if (adjustment == 0) {
+            return loopSamples.start;
+        }
         return loopSamples.end - adjustment;
     }
 
@@ -818,7 +824,7 @@ void LoopingControl::notifySeek(double dNewPlaypos) {
     if (m_bLoopingEnabled) {
         // Disable loop when we jumping out, or over a catching loop,
         // using hot cues or waveform overview.
-        // Do not jump out of a loop if we adjust a phase (lp1743010)
+        // Jumping to the exact end of a loop is considered jumping out.
         if (currentSample >= loopSamples.start &&
                 currentSample <= loopSamples.end &&
                 dNewPlaypos < loopSamples.start) {
@@ -826,8 +832,8 @@ void LoopingControl::notifySeek(double dNewPlaypos) {
             setLoopingEnabled(false);
         }
         if (currentSample <= loopSamples.end &&
-                dNewPlaypos > loopSamples.end) {
-            // jumping out a loop or over a catching loop forward
+                dNewPlaypos >= loopSamples.end) {
+            // jumping out or to the exact end of a loop or over a catching loop forward
             setLoopingEnabled(false);
         }
     }
@@ -1002,6 +1008,13 @@ void LoopingControl::updateBeatLoopingControls() {
 }
 
 void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable) {
+    // if a seek was queued in the engine buffer move the current sample to its position
+    double p_seekPosition = 0;
+    if (getEngineBuffer()->isSeekQueued(&p_seekPosition)) {
+        // seek position is already quantized if quantization is enabled
+        m_currentSample.setValue(p_seekPosition);
+    }
+
     double maxBeatSize = s_dBeatSizes[sizeof(s_dBeatSizes)/sizeof(s_dBeatSizes[0]) - 1];
     double minBeatSize = s_dBeatSizes[0];
     if (beats < 0) {

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1286,9 +1286,14 @@ bool EngineBuffer::isTrackLoaded() {
     return false;
 }
 
-bool EngineBuffer::isSeekQueued(double* pSeekPosition) {
-    *pSeekPosition = m_queuedSeekPosition.getValue();
-    return m_iSeekQueued.load() != SEEK_NONE;
+bool EngineBuffer::getQueuedSeekPosition(double* pSeekPosition) {
+    bool isSeekQueued = m_iSeekQueued.loadAcquire() != SEEK_NONE;
+    if (isSeekQueued) {
+        *pSeekPosition = m_queuedSeekPosition.getValue();
+    } else {
+        *pSeekPosition = -1;
+    }
+    return isSeekQueued;
 }
 
 void EngineBuffer::slotEjectTrack(double v) {

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -141,6 +141,7 @@ class EngineBuffer : public EngineObject {
 
     QString getGroup();
     bool isTrackLoaded();
+    bool isSeekQueued(double* pSeekPosition);
     TrackPointer getLoadedTrack() const;
 
     double getExactPlayPos();

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -141,7 +141,9 @@ class EngineBuffer : public EngineObject {
 
     QString getGroup();
     bool isTrackLoaded();
-    bool isSeekQueued(double* pSeekPosition);
+    // return true if a seek is currently cueued but not yet processed, false otherwise
+    // if no seek was queued, the seek position is set to -1
+    bool getQueuedSeekPosition(double* pSeekPosition);
     TrackPointer getLoadedTrack() const;
 
     double getExactPlayPos();


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/mixxx/+bug/1464003 .
Basically the loopcontroller has to set the loop start position to the queued seek position before activating the loop.
Furthermore, when a hotcue that is at the end of an active loop is activated, also disable the loop instead of jumping back to the loop entry.
Replaces #2190 together with #2209