### PR TITLE
lp1835635: Replace plain pointer / unique_ptr with parented_ptr

### DIFF
--- a/src/library/crate/cratefeature.cpp
+++ b/src/library/crate/cratefeature.cpp
@@ -62,47 +62,47 @@ CrateFeature::~CrateFeature() {
 }
 
 void CrateFeature::initActions() {
-    m_pCreateCrateAction = std::make_unique<QAction>(tr("Create New Crate"),this);
+    m_pCreateCrateAction = make_parented<QAction>(tr("Create New Crate"), this);
     connect(m_pCreateCrateAction.get(), SIGNAL(triggered()),
             this, SLOT(slotCreateCrate()));
 
-    m_pDeleteCrateAction = std::make_unique<QAction>(tr("Remove"),this);
+    m_pDeleteCrateAction = make_parented<QAction>(tr("Remove"), this);
     connect(m_pDeleteCrateAction.get(), SIGNAL(triggered()),
             this, SLOT(slotDeleteCrate()));
 
-    m_pRenameCrateAction = std::make_unique<QAction>(tr("Rename"),this);
+    m_pRenameCrateAction = make_parented<QAction>(tr("Rename"), this);
     connect(m_pRenameCrateAction.get(), SIGNAL(triggered()),
             this, SLOT(slotRenameCrate()));
 
-    m_pLockCrateAction = std::make_unique<QAction>(tr("Lock"),this);
+    m_pLockCrateAction = make_parented<QAction>(tr("Lock"), this);
     connect(m_pLockCrateAction.get(), SIGNAL(triggered()),
             this, SLOT(slotToggleCrateLock()));
 
-    m_pImportPlaylistAction = std::make_unique<QAction>(tr("Import Crate"),this);
+    m_pImportPlaylistAction = make_parented<QAction>(tr("Import Crate"), this);
     connect(m_pImportPlaylistAction.get(), SIGNAL(triggered()),
             this, SLOT(slotImportPlaylist()));
 
-    m_pCreateImportPlaylistAction = std::make_unique<QAction>(tr("Import Crate"), this);
+    m_pCreateImportPlaylistAction = make_parented<QAction>(tr("Import Crate"), this);
     connect(m_pCreateImportPlaylistAction.get(), SIGNAL(triggered()),
             this, SLOT(slotCreateImportCrate()));
 
-    m_pExportPlaylistAction = std::make_unique<QAction>(tr("Export Crate"), this);
+    m_pExportPlaylistAction = make_parented<QAction>(tr("Export Crate"), this);
     connect(m_pExportPlaylistAction.get(), SIGNAL(triggered()),
             this, SLOT(slotExportPlaylist()));
 
-    m_pExportTrackFilesAction = std::make_unique<QAction>(tr("Export Track Files"), this);
+    m_pExportTrackFilesAction = make_parented<QAction>(tr("Export Track Files"), this);
     connect(m_pExportTrackFilesAction.get(), SIGNAL(triggered()),
             this, SLOT(slotExportTrackFiles()));
 
-    m_pDuplicateCrateAction = std::make_unique<QAction>(tr("Duplicate"),this);
+    m_pDuplicateCrateAction = make_parented<QAction>(tr("Duplicate"), this);
     connect(m_pDuplicateCrateAction.get(), SIGNAL(triggered()),
             this, SLOT(slotDuplicateCrate()));
 
-    m_pAnalyzeCrateAction = std::make_unique<QAction>(tr("Analyze entire Crate"),this);
+    m_pAnalyzeCrateAction = make_parented<QAction>(tr("Analyze entire Crate"), this);
     connect(m_pAnalyzeCrateAction.get(), SIGNAL(triggered()),
             this, SLOT(slotAnalyzeCrate()));
 
-    m_pAutoDjTrackSourceAction = std::make_unique<QAction>(tr("Auto DJ Track Source"),this);
+    m_pAutoDjTrackSourceAction = make_parented<QAction>(tr("Auto DJ Track Source"), this);
     m_pAutoDjTrackSourceAction->setCheckable(true);
     connect(m_pAutoDjTrackSourceAction.get(), SIGNAL(changed()),
             this, SLOT(slotAutoDjTrackSourceChanged()));

--- a/src/library/crate/cratefeature.h
+++ b/src/library/crate/cratefeature.h
@@ -19,6 +19,8 @@
 
 #include "preferences/usersettings.h"
 
+#include "util/parented_ptr.h"
+
 // forward declaration(s)
 class Library;
 class TrackCollection;
@@ -108,21 +110,17 @@ class CrateFeature : public LibraryFeature {
     QModelIndex m_lastRightClickedIndex;
     TrackPointer m_pSelectedTrack;
 
-    // FIXME(XXX): std::unique_ptr is wrong! Qt takes ownership
-    // of these actions. Should be replaced with the appropriate
-    // variant of parented_ptr as soon as it becomes available.
-    // See also: https://github.com/mixxxdj/mixxx/pull/1161
-    std::unique_ptr<QAction> m_pCreateCrateAction;
-    std::unique_ptr<QAction> m_pDeleteCrateAction;
-    std::unique_ptr<QAction> m_pRenameCrateAction;
-    std::unique_ptr<QAction> m_pLockCrateAction;
-    std::unique_ptr<QAction> m_pDuplicateCrateAction;
-    std::unique_ptr<QAction> m_pAutoDjTrackSourceAction;
-    std::unique_ptr<QAction> m_pImportPlaylistAction;
-    std::unique_ptr<QAction> m_pCreateImportPlaylistAction;
-    std::unique_ptr<QAction> m_pExportPlaylistAction;
-    std::unique_ptr<QAction> m_pExportTrackFilesAction;
-    std::unique_ptr<QAction> m_pAnalyzeCrateAction;
+    parented_ptr<QAction> m_pCreateCrateAction;
+    parented_ptr<QAction> m_pDeleteCrateAction;
+    parented_ptr<QAction> m_pRenameCrateAction;
+    parented_ptr<QAction> m_pLockCrateAction;
+    parented_ptr<QAction> m_pDuplicateCrateAction;
+    parented_ptr<QAction> m_pAutoDjTrackSourceAction;
+    parented_ptr<QAction> m_pImportPlaylistAction;
+    parented_ptr<QAction> m_pCreateImportPlaylistAction;
+    parented_ptr<QAction> m_pExportPlaylistAction;
+    parented_ptr<QAction> m_pExportTrackFilesAction;
+    parented_ptr<QAction> m_pAnalyzeCrateAction;
 };
 
 

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -9,7 +9,7 @@
 DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlayer)
         : QDialog(parent),
           m_pPlayer(pPlayer),
-          m_pCoverMenu(new WCoverArtMenu(this)) {
+          m_pCoverMenu(make_parented<WCoverArtMenu>(this)) {
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache != nullptr) {
         connect(pCache, SIGNAL(coverFound(const QObject*,
@@ -34,12 +34,8 @@ DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlay
     setupUi(this);
 }
 
-DlgCoverArtFullSize::~DlgCoverArtFullSize() {
-    delete m_pCoverMenu;
-}
-
 void DlgCoverArtFullSize::init(TrackPointer pTrack) {
-    if (pTrack == nullptr) {
+    if (!pTrack) {
         return;
     }
     show();

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -1,5 +1,4 @@
-#ifndef DLGCOVERARTFULLSIZE_H
-#define DLGCOVERARTFULLSIZE_H
+#pragma once
 
 #include <QDialog>
 #include <QTimer>
@@ -10,14 +9,15 @@
 #include "mixer/basetrackplayer.h"
 #include "track/track.h"
 #include "widget/wcoverartmenu.h"
+#include "util/parented_ptr.h"
 
 class DlgCoverArtFullSize
         : public QDialog,
           public Ui::DlgCoverArtFullSize {
     Q_OBJECT
   public:
-    DlgCoverArtFullSize(QWidget* parent = nullptr, BaseTrackPlayer* pPlayer = nullptr);
-    virtual ~DlgCoverArtFullSize();
+    explicit DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlayer = nullptr);
+    ~DlgCoverArtFullSize() override = default;
 
     void init(TrackPointer pTrack);
     void mousePressEvent(QMouseEvent* event) override;
@@ -41,10 +41,8 @@ class DlgCoverArtFullSize
     QPixmap m_pixmap;
     TrackPointer m_pLoadedTrack;
     BaseTrackPlayer* m_pPlayer;
-    WCoverArtMenu* m_pCoverMenu;
+    parented_ptr<WCoverArtMenu> m_pCoverMenu;
     QTimer m_clickTimer;
     QPoint m_dragStartPosition;
     bool m_coverPressed;
 };
-
-#endif // DLGCOVERARTFULLSIZE_H

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -9,8 +9,8 @@ static const QSize s_labelDisplaySize = QSize(100, 100);
 
 WCoverArtLabel::WCoverArtLabel(QWidget* parent)
         : QLabel(parent),
-          m_pCoverMenu(new WCoverArtMenu(this)),
-          m_pDlgFullSize(new DlgCoverArtFullSize(this, nullptr)),
+          m_pCoverMenu(make_parented<WCoverArtMenu>(this)),
+          m_pDlgFullSize(make_parented<DlgCoverArtFullSize>(this)),
           m_defaultCover(CoverArtUtils::defaultCoverLocation()) {
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
     setFrameShape(QFrame::Box);
@@ -30,8 +30,7 @@ WCoverArtLabel::WCoverArtLabel(QWidget* parent)
 }
 
 WCoverArtLabel::~WCoverArtLabel() {
-    delete m_pCoverMenu;
-    delete m_pDlgFullSize;
+    // Nothing to do
 }
 
 void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,

--- a/src/widget/wcoverartlabel.h
+++ b/src/widget/wcoverartlabel.h
@@ -1,5 +1,4 @@
-#ifndef WCOVERARTLABEL_H
-#define WCOVERARTLABEL_H
+#pragma once
 
 #include <QLabel>
 #include <QMouseEvent>
@@ -8,6 +7,7 @@
 
 #include "track/track.h"
 #include "widget/wcoverartmenu.h"
+#include "util/parented_ptr.h"
 
 class DlgCoverArtFullSize;
 
@@ -15,7 +15,7 @@ class WCoverArtLabel : public QLabel {
     Q_OBJECT
   public:
     explicit WCoverArtLabel(QWidget* parent = nullptr);
-    ~WCoverArtLabel() override;
+    ~WCoverArtLabel() override; // Verifies that the base destructor is virtual
 
     void setCoverArt(const CoverInfo& coverInfo, QPixmap px);
     void loadTrack(TrackPointer pTrack);
@@ -33,9 +33,7 @@ class WCoverArtLabel : public QLabel {
   private:
     QPixmap m_loadedCover;
     TrackPointer m_pLoadedTrack;
-    WCoverArtMenu* m_pCoverMenu;
-    DlgCoverArtFullSize* m_pDlgFullSize;
+    parented_ptr<WCoverArtMenu> m_pCoverMenu;
+    parented_ptr<DlgCoverArtFullSize> m_pDlgFullSize;
     QPixmap m_defaultCover;
 };
-
-#endif // WCOVERARTLABEL_H


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1835635

Follow-up of #2215: The segfault seems to be caused by Qt 5.12.4, the code improvements are still helpful.

Build failed on 2.2, because the recent extensions and fixes of parented_ptr have not been backported.