### PR TITLE
Deere64 :: fix hidden Mic FX buttons

### DIFF
--- a/res/skins/Deere/microphone.xml
+++ b/res/skins/Deere/microphone.xml
@@ -91,7 +91,6 @@
 
           <WidgetGroup>
             <ObjectName>ButtonGrid</ObjectName>
-            <SizePolicy>min,i</SizePolicy>
             <Layout>horizontal</Layout>
             <Children>
               <Template src="skin:fx_unit_group_assignment_button.xml">
@@ -108,7 +107,6 @@
           </WidgetGroup>
 
           <WidgetGroup>
-            <SizePolicy>min,i</SizePolicy>
             <Layout>horizontal</Layout>
             <Children>
               <Template src="skin:fx_unit_group_assignment_button.xml">


### PR DESCRIPTION
fixes https://bugs.launchpad.net/mixxx/+bug/1837716
"FX1/2 buttons missing Mic unit in Deere (64 samplers)"

I still have no idea why the buttons show up in Deere16 but not in Deere64, as both skins share the Mic unit template