### PR TITLE
Fix battery widget with upower <= 0.99.7

### DIFF
--- a/src/util/battery/batterylinux.cpp
+++ b/src/util/battery/batterylinux.cpp
@@ -45,7 +45,7 @@ void BatteryLinux::read() {
     VERIFY_OR_DEBUG_ASSERT(devices) {
       return;
     }
-    devices = g_ptr_array_new_with_free_func((GDestroyNotify) g_object_unref);
+    g_ptr_array_set_free_func(devices, (GDestroyNotify) g_object_unref);
 #endif
 
     for (guint i = 0; i < devices->len; ++i) {


### PR DESCRIPTION
The should fix the "Battery status unknown" issue reported in #2161
(I have not tested this on ubuntu)