### PR TITLE
Initialize the global thread pool only once on application startup

### DIFF
--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -196,15 +196,6 @@ void ITunesFeature::activate(bool forceReload) {
             settings.setValue(ITDB_PATH_KEY, m_dbfile);
         }
         m_isActivated =  true;
-        // Usually the maximum number of threads
-        // is > 2 depending on the CPU cores
-        // Unfortunately, within VirtualBox
-        // the maximum number of allowed threads
-        // is 1 at all times We'll need to increase
-        // the number to > 1, otherwise importing the music collection
-        // takes place when the GUI threads terminates, i.e., on
-        // Mixxx shutdown.
-        QThreadPool::globalInstance()->setMaxThreadCount(4); //Tobias decided to use 4
         // Let a worker thread do the XML parsing
         m_future = QtConcurrent::run(this, &ITunesFeature::importLibrary);
         m_future_watcher.setFuture(m_future);

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -113,15 +113,6 @@ void RhythmboxFeature::activate() {
 
     if (!m_isActivated) {
         m_isActivated =  true;
-        // Usually the maximum number of threads
-        // is > 2 depending on the CPU cores
-        // Unfortunately, within VirtualBox
-        // the maximum number of allowed threads
-        // is 1 at all times We'll need to increase
-        // the number to > 1, otherwise importing the music collection
-        // takes place when the GUI threads terminates, i.e., on
-        // Mixxx shutdown.
-        QThreadPool::globalInstance()->setMaxThreadCount(4); //Tobias decided to use 4
         m_track_future = QtConcurrent::run(this, &RhythmboxFeature::importMusicCollection);
         m_track_watcher.setFuture(m_track_future);
         m_title = "(loading) Rhythmbox";

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -151,15 +151,6 @@ void TraktorFeature::activate() {
 
     if (!m_isActivated) {
         m_isActivated =  true;
-        // Usually the maximum number of threads
-        // is > 2 depending on the CPU cores
-        // Unfortunately, within VirtualBox
-        // the maximum number of allowed threads
-        // is 1 at all times We'll need to increase
-        // the number to > 1, otherwise importing the music collection
-        // takes place when the GUI threads terminates, i.e., on
-        // Mixxx shutdown.
-        QThreadPool::globalInstance()->setMaxThreadCount(4); //Tobias decided to use 4
         // Let a worker thread do the XML parsing
         m_future = QtConcurrent::run(this, &TraktorFeature::importLibrary,
                                      getTraktorMusicDatabase());

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -40,11 +40,11 @@ MixxxApplication::MixxxApplication(int& argc, char** argv)
           m_pTouchShift(NULL) {
     registerMetaTypes();
 
-    // Initialize the thread pool with at least 4 threads, even if
-    // less cores are available. These will be used for loading
-    // external libraries and other tasks.
+    // Increase the size of the global thread pool to at least
+    // 4 threads, even if less cores are available. These threads
+    // will be used for loading external libraries and other tasks.
     QThreadPool::globalInstance().setMaxThreadCount(
-            math_max(4, QThread::idealThreadCount()));
+            math_max(4, QThreadPool::globalInstance().maxThreadCount()));
 }
 
 MixxxApplication::~MixxxApplication() {

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -1,10 +1,12 @@
 #include <QtDebug>
 #include <QTouchEvent>
+#include <QThreadPool>
+
 #include "mixxxapplication.h"
 
-#include "library/crate/crateid.h"
 #include "control/controlproxy.h"
-#include "mixxx.h"
+#include "library/crate/crateid.h"
+#include "track/track.h"
 
 // When linking Qt statically on Windows we have to Q_IMPORT_PLUGIN all the
 // plugins we link in build/depends.py.
@@ -36,6 +38,11 @@ MixxxApplication::MixxxApplication(int& argc, char** argv)
           m_activeTouchButton(Qt::NoButton),
           m_pTouchShift(NULL) {
     registerMetaTypes();
+
+    // The global thread pool is initialized with the default
+    // number of treads. If a custom configuration is desired
+    // it should be done here before scheduling any tasks!
+    DEBUG_ASSERT(QThreadPool::globalInstance()->maxThreadCount() == QThread::idealThreadCount());
 }
 
 MixxxApplication::~MixxxApplication() {

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -43,8 +43,8 @@ MixxxApplication::MixxxApplication(int& argc, char** argv)
     // Increase the size of the global thread pool to at least
     // 4 threads, even if less cores are available. These threads
     // will be used for loading external libraries and other tasks.
-    QThreadPool::globalInstance().setMaxThreadCount(
-            math_max(4, QThreadPool::globalInstance().maxThreadCount()));
+    QThreadPool::globalInstance()->setMaxThreadCount(
+            math_max(4, QThreadPool::globalInstance()->maxThreadCount()));
 }
 
 MixxxApplication::~MixxxApplication() {

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -7,6 +7,7 @@
 #include "control/controlproxy.h"
 #include "library/crate/crateid.h"
 #include "track/track.h"
+#include "util/math.h"
 
 // When linking Qt statically on Windows we have to Q_IMPORT_PLUGIN all the
 // plugins we link in build/depends.py.
@@ -39,10 +40,11 @@ MixxxApplication::MixxxApplication(int& argc, char** argv)
           m_pTouchShift(NULL) {
     registerMetaTypes();
 
-    // The global thread pool is initialized with the default
-    // number of treads. If a custom configuration is desired
-    // it should be done here before scheduling any tasks!
-    DEBUG_ASSERT(QThreadPool::globalInstance()->maxThreadCount() == QThread::idealThreadCount());
+    // Initialize the thread pool with at least 4 threads, even if
+    // less cores are available. These will be used for loading
+    // external libraries and other tasks.
+    QThreadPool::globalInstance().setMaxThreadCount(
+            math_max(4, QThread::idealThreadCount()));
 }
 
 MixxxApplication::~MixxxApplication() {


### PR DESCRIPTION
Found this bad practice while reviewing PR #2119. The custom reconfiguration code needs to be removed from PR #2119, too!

The global thread pool should work as expected even when using only 1 worker thread. Those threads are independent of the main thread and they are not expected to block each other if one doesn't introduce any deadlock or livelock situations.