### PR TITLE
Enforce a consistent pointer alignment (*/&) style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,6 +20,7 @@ BinPackParameters: false
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
 IndentCaseLabels: false
+DerivePointerAlignment: false
 ReflowComments: false
 SpaceAfterTemplateKeyword: false
 SpacesBeforeTrailingComments: 1

--- a/.clang-format
+++ b/.clang-format
@@ -8,6 +8,9 @@ UseTab:       Never
 # may later be changed to 80-100 characters per line if desired.
 ColumnLimit:  0
 ---
+# Customize only those options that differ from the base style!
+# Dumping the options of the base style for comparison:
+# clang-format -style=google -dump-config > .clang-format_google
 Language:     Cpp
 AccessModifierOffset: -2
 AlignAfterOpenBracket: DontAlign


### PR DESCRIPTION
To fix consistent violations as found in rekordboxfeature.cpp (#2119)

Reference: https://www.mixxx.org/wiki/doku.php/coding_guidelines#variables