### PR TITLE
Allen & Heath Xone K2 updates for 2.3

### DIFF
--- a/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
+++ b/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
@@ -263,21 +263,21 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
         unshift: function () {
             this.input = function (channel, control, value, status) {
                 direction = (value === 1) ? 1 : -1;
-                engine.setValue(this.group, "jog", direction);
+                var gain = engine.getValue(this.group, "pregain");
+                engine.setValue(this.group, "pregain", gain + 0.025 * direction);
             };
         },
         shift: function () {
             this.input = function (channel, control, value, status) {
                 direction = (value === 1) ? 1 : -1;
-                var pitch = engine.getValue(this.group, "pitch");
-                engine.setValue(this.group, "pitch", pitch + (.05 * direction));
+                engine.setValue(this.group, "jog", direction);
             };
         },
         supershift: function () {
             this.input = function (channel, control, value, status) {
                 direction = (value === 1) ? 1 : -1;
-                var gain = engine.getValue(this.group, "pregain");
-                engine.setValue(this.group, "pregain", gain + 0.025 * direction);
+                var pitch = engine.getValue(this.group, "pitch");
+                engine.setValue(this.group, "pitch", pitch + (.05 * direction));
             };
         },
     });
@@ -285,15 +285,15 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
     this.encoderPress = new components.Button({
         outKey: 'sync_enabled',
         unshift: function () {
+            this.inKey = 'pregain_set_one';
+            this.type = components.Button.prototype.types.push;
+        },
+        shift: function () {
             this.inKey = 'sync_enabled';
             this.type = components.Button.prototype.types.toggle;
         },
-        shift: function () {
-            this.inKey = 'reset_key';
-            this.type = components.Button.prototype.types.push;
-        },
         supershift: function () {
-            this.inKey = 'pregain_set_one';
+            this.inKey = 'reset_key';
             this.type = components.Button.prototype.types.push;
         },
     });

--- a/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
+++ b/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
@@ -222,7 +222,7 @@ components.Component.prototype.send =  function (value) {
         return;
     }
     // The LEDs are turned on with a Note On MIDI message (first nybble of first byte 9)
-    // and turned off with a Note Offf MIDI message (first nybble of first byte 8).
+    // and turned off with a Note Off MIDI message (first nybble of first byte 8).
     if (value > 0) {
         midi.sendShortMsg(this.midi[0] + 0x10, this.midi[1] + this.color, value);
     } else {

--- a/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
+++ b/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
@@ -17,8 +17,9 @@ XoneK2.layerButtonColors = {
     green: 0x14,
 }
 XoneK2.deckBottomButtonLayers = [
-    { name: 'loop', layerButtonNoteNumber: XoneK2.layerButtonColors.amber },
-    { name: 'hotcue', layerButtonNoteNumber: XoneK2.layerButtonColors.red } ];
+    { name: 'loop', layerButtonNoteNumber: XoneK2.layerButtonColors.green },
+    { name: 'intro_outro', layerButtonNoteNumber: XoneK2.layerButtonColors.amber },
+    { name: 'hotcue', layerButtonNoteNumber: XoneK2.layerButtonColors.red }, ];
 
 // Multiple K2s/K1s can be connected via X-Link and plugged in with one USB
 // cable. The MIDI messages of the controllers can be distinguished by setting
@@ -487,6 +488,48 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
         trigger: function() {
             this.send(this.on);
         },
+        color: XoneK2.color.amber,
+    });
+
+    this.bottomButtonLayers.intro_outro = new components.ComponentContainer();
+    this.bottomButtonLayers.intro_outro[1] = new components.Button({
+        unshift: function () {
+            this.inKey = 'intro_start_activate';
+        },
+        shift: function () {
+            this.inKey = 'intro_start_clear';
+        },
+        outKey: 'intro_start_enabled',
+        color: XoneK2.color.amber,
+    });
+    this.bottomButtonLayers.intro_outro[2] = new components.Button({
+        unshift: function () {
+            this.inKey = 'intro_end_activate';
+        },
+        shift: function () {
+            this.inKey = 'intro_end_clear';
+        },
+        outKey: 'intro_end_enabled',
+        color: XoneK2.color.amber,
+    });
+    this.bottomButtonLayers.intro_outro[3] = new components.Button({
+        unshift: function () {
+            this.inKey = 'outro_start_activate';
+        },
+        shift: function () {
+            this.inKey = 'outro_start_clear';
+        },
+        outKey: 'outro_start_enabled',
+        color: XoneK2.color.amber,
+    });
+    this.bottomButtonLayers.intro_outro[4] = new components.Button({
+        unshift: function () {
+            this.inKey = 'outro_end_activate';
+        },
+        shift: function () {
+            this.inKey = 'outro_end_clear';
+        },
+        outKey: 'outro_end_enabled',
         color: XoneK2.color.amber,
     });
 

--- a/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
+++ b/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
@@ -508,7 +508,10 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
         unshift: function () {
             this.inKey = this.cueName + '_activate';
             this.input = components.Button.prototype.input;
-            engine.setValue(this.group, 'rateSearch', 0);
+            // Avoid log spam on startup
+            if (this.group !== undefined) {
+                engine.setValue(this.group, 'rateSearch', 0);
+            }
         },
         shift: function () {
             this.input = function (channel, control, value, status) {

--- a/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
+++ b/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
@@ -450,11 +450,11 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
 
     this.bottomButtonLayers.loop[3] = new components.Button({
         unshift: function () {
-            this.inKey = 'beatjump_forward';
+            this.inKey = 'loop_double';
             this.input = components.Button.prototype.input;
         },
         shift: function () {
-            this.inKey = 'loop_double';
+            this.inKey = 'beatjump_forward';
             this.input = components.Button.prototype.input;
         },
         supershift: function () {
@@ -473,11 +473,11 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
 
     this.bottomButtonLayers.loop[4] = new components.Button({
         unshift: function () {
-            this.inKey = 'beatjump_backward';
+            this.inKey = 'loop_halve';
             this.input = components.Button.prototype.input;
         },
         shift: function () {
-            this.inKey = 'loop_halve';
+            this.inKey = 'beatjump_backward';
             this.input = components.Button.prototype.input;
         },
         supershift: function () {

--- a/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
+++ b/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
@@ -1,5 +1,8 @@
 var XoneK2 = {};
 
+XoneK2.seekRateFast = 3.0;
+XoneK2.seekRateSlow = 0.5;
+
 XoneK2.decksInMiddleMidiChannel = 0xE;
 XoneK2.effectsInMiddleMidiChannel = 0xD;
 XoneK2.decksOnLeftMidiChannel = 0xC;
@@ -491,55 +494,81 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
         color: XoneK2.color.amber,
     });
 
+    var CueOrSeekButton = function (options) {
+        if (options.cueName === undefined) {
+            print('ERROR! cueName not specified');
+        } else if (options.seekRate === undefined) {
+            print('ERROR! seekRate not specified');
+        }
+
+        this.outKey = options.cueName + '_enabled';
+        components.Button.call(this, options);
+    };
+    CueOrSeekButton.prototype = new components.Button({
+        unshift: function () {
+            this.inKey = this.cueName + '_activate';
+            this.input = components.Button.prototype.input;
+            engine.setValue(this.group, 'rateSearch', 0);
+        },
+        shift: function () {
+            this.input = function (channel, control, value, status) {
+                if (components.Button.prototype.isPress(channel, control, value, status)) {
+                    engine.setValue(this.group, 'rateSearch', this.seekRate);
+                } else {
+                    engine.setValue(this.group, 'rateSearch', 0);
+                }
+            };
+        },
+        supershift: function () {
+            this.inKey = this.cueName + '_clear';
+            this.input = components.Button.prototype.input;
+            engine.setValue(this.group, 'rateSearch', 0);
+        }
+    });
+
     this.bottomButtonLayers.intro_outro = new components.ComponentContainer();
-    this.bottomButtonLayers.intro_outro[1] = new components.Button({
-        unshift: function () {
-            this.inKey = 'intro_start_activate';
-        },
-        shift: function () {
-            this.inKey = 'intro_start_clear';
-        },
-        outKey: 'intro_start_enabled',
+    this.bottomButtonLayers.intro_outro[1] = new CueOrSeekButton({
+        cueName: "intro_start",
+        seekRate: XoneK2.seekRateFast,
         color: XoneK2.color.amber,
     });
-    this.bottomButtonLayers.intro_outro[2] = new components.Button({
-        unshift: function () {
-            this.inKey = 'intro_end_activate';
-        },
-        shift: function () {
-            this.inKey = 'intro_end_clear';
-        },
-        outKey: 'intro_end_enabled',
+    this.bottomButtonLayers.intro_outro[2] = new CueOrSeekButton({
+        cueName: "intro_end",
+        seekRate: -1 * XoneK2.seekRateFast,
         color: XoneK2.color.amber,
     });
-    this.bottomButtonLayers.intro_outro[3] = new components.Button({
-        unshift: function () {
-            this.inKey = 'outro_start_activate';
-        },
-        shift: function () {
-            this.inKey = 'outro_start_clear';
-        },
-        outKey: 'outro_start_enabled',
+    this.bottomButtonLayers.intro_outro[3] = new CueOrSeekButton({
+        cueName: "outro_start",
+        seekRate: XoneK2.seekRateSlow,
         color: XoneK2.color.amber,
     });
-    this.bottomButtonLayers.intro_outro[4] = new components.Button({
-        unshift: function () {
-            this.inKey = 'outro_end_activate';
-        },
-        shift: function () {
-            this.inKey = 'outro_end_clear';
-        },
-        outKey: 'outro_end_enabled',
+    this.bottomButtonLayers.intro_outro[4] = new CueOrSeekButton({
+        cueName: "outro_end",
+        seekRate: -1 * XoneK2.seekRateSlow,
         color: XoneK2.color.amber,
     });
 
     this.bottomButtonLayers.hotcue = new components.ComponentContainer();
-    for (var n = 1; n <= 4; ++n) {
-        this.bottomButtonLayers.hotcue[n] = new components.HotcueButton({
-            number: n,
-            color: XoneK2.color.red,
-        });
-    }
+    this.bottomButtonLayers.hotcue[1] = new CueOrSeekButton({
+        cueName: "hotcue_1",
+        seekRate: XoneK2.seekRateFast,
+        color: XoneK2.color.red,
+    });
+    this.bottomButtonLayers.hotcue[2] = new CueOrSeekButton({
+        cueName: "hotcue_2",
+        seekRate: -1 * XoneK2.seekRateFast,
+        color: XoneK2.color.red,
+    });
+    this.bottomButtonLayers.hotcue[3] = new CueOrSeekButton({
+        cueName: "hotcue_3",
+        seekRate: XoneK2.seekRateSlow,
+        color: XoneK2.color.red,
+    });
+    this.bottomButtonLayers.hotcue[4] = new CueOrSeekButton({
+        cueName: "hotcue_4",
+        seekRate: -1 * XoneK2.seekRateSlow,
+        color: XoneK2.color.red,
+    });
 
     var setGroup = function (component) {
         if (component.group === undefined) {

--- a/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
+++ b/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
@@ -416,7 +416,7 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
     // happen when iterating over the Deck with reconnectComponents.
     this.bottomButtonLayers = [];
 
-    var CueOrSeekButton = function (options) {
+    var CueAndSeekButton = function (options) {
         if (options.cueName === undefined) {
             print('ERROR! cueName not specified');
         } else if (options.seekRate === undefined) {
@@ -426,7 +426,7 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
         this.outKey = options.cueName + '_enabled';
         components.Button.call(this, options);
     };
-    CueOrSeekButton.prototype = new components.Button({
+    CueAndSeekButton.prototype = new components.Button({
         unshift: function () {
             this.inKey = this.cueName + '_activate';
             this.input = components.Button.prototype.input;
@@ -452,22 +452,22 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
     });
 
     this.bottomButtonLayers.intro_outro = new components.ComponentContainer();
-    this.bottomButtonLayers.intro_outro[1] = new CueOrSeekButton({
+    this.bottomButtonLayers.intro_outro[1] = new CueAndSeekButton({
         cueName: "intro_start",
         seekRate: XoneK2.seekRateFast,
         color: XoneK2.color.amber,
     });
-    this.bottomButtonLayers.intro_outro[2] = new CueOrSeekButton({
+    this.bottomButtonLayers.intro_outro[2] = new CueAndSeekButton({
         cueName: "intro_end",
         seekRate: -1 * XoneK2.seekRateFast,
         color: XoneK2.color.amber,
     });
-    this.bottomButtonLayers.intro_outro[3] = new CueOrSeekButton({
+    this.bottomButtonLayers.intro_outro[3] = new CueAndSeekButton({
         cueName: "outro_start",
         seekRate: XoneK2.seekRateSlow,
         color: XoneK2.color.amber,
     });
-    this.bottomButtonLayers.intro_outro[4] = new CueOrSeekButton({
+    this.bottomButtonLayers.intro_outro[4] = new CueAndSeekButton({
         cueName: "outro_end",
         seekRate: -1 * XoneK2.seekRateSlow,
         color: XoneK2.color.amber,
@@ -475,22 +475,22 @@ XoneK2.Deck = function (column, deckNumber, midiChannel) {
 
 
     this.bottomButtonLayers.hotcue = new components.ComponentContainer();
-    this.bottomButtonLayers.hotcue[1] = new CueOrSeekButton({
+    this.bottomButtonLayers.hotcue[1] = new CueAndSeekButton({
         cueName: "hotcue_1",
         seekRate: XoneK2.seekRateFast,
         color: XoneK2.color.red,
     });
-    this.bottomButtonLayers.hotcue[2] = new CueOrSeekButton({
+    this.bottomButtonLayers.hotcue[2] = new CueAndSeekButton({
         cueName: "hotcue_2",
         seekRate: -1 * XoneK2.seekRateFast,
         color: XoneK2.color.red,
     });
-    this.bottomButtonLayers.hotcue[3] = new CueOrSeekButton({
+    this.bottomButtonLayers.hotcue[3] = new CueAndSeekButton({
         cueName: "hotcue_3",
         seekRate: XoneK2.seekRateSlow,
         color: XoneK2.color.red,
     });
-    this.bottomButtonLayers.hotcue[4] = new CueOrSeekButton({
+    this.bottomButtonLayers.hotcue[4] = new CueAndSeekButton({
         cueName: "hotcue_4",
         seekRate: -1 * XoneK2.seekRateSlow,
         color: XoneK2.color.red,


### PR DESCRIPTION
1. Add a new layer for the bottom buttons for the new intro & outro cues. From top to bottom, they are mapped:

intro start
intro end
outro start
outro end

The buttons in this mode are amber when a cue is set. Pressing a button with shift unsets the cue, just like hotcues.

2. Remap the top encoder. In my experience, I have needed to adjust gain more often than use the jog function, so I swapped those. The encoder now works like this:

turn: gain adjust
turn + shift: jog
turn + supershift: key adjust
    
press: reset gain
press + shift: master sync
press + supershift: reset key

Feedback would be appreciated. @ferranpujolcamins, @ywwg 