### PR TITLE
move waveforms between decks in Tango with 4 decks

### DIFF
--- a/res/skins/Tango/skin.xml
+++ b/res/skins/Tango/skin.xml
@@ -468,26 +468,29 @@
                       <Collapsible>0,0</Collapsible>
                       <Children>
 
-                        <WidgetGroup>
-                          <Layout>vertical</Layout>
-                          <SizePolicy>me,max</SizePolicy>
-                          <Children>
-                            <SingletonContainer>
-                              <ObjectName>Waveforms_Singleton</ObjectName>
-                            </SingletonContainer>
-                          </Children>
-                          <Connection>
-                            <ConfigKey persist="true">[Tango],stacked_waveforms</ConfigKey>
-                            <BindProperty>visible</BindProperty>
-                          </Connection>
-                        </WidgetGroup>
-
                         <WidgetGroup><!-- Decks + FX + Samplers + Library -->
                           <Layout>vertical</Layout>
                           <SizePolicy>me,min</SizePolicy>
                           <Children>
 
-                            <Template src="skin:../Tango/decks_12.xml"/>
+                            <!-- Show waveforms above decks with 2 decks, between
+                            decks with 4 decks. -->
+                            <WidgetGroup>
+                              <Layout>vertical</Layout>
+                              <SizePolicy>me,max</SizePolicy>
+                              <Children>
+                                <SingletonContainer>
+                                  <ObjectName>Waveforms_Singleton</ObjectName>
+                                </SingletonContainer>
+                              </Children>
+                              <Connection>
+                                <ConfigKey persist="true">[Skin],show_4decks</ConfigKey>
+                                <BindProperty>visible</BindProperty>
+                                <Transform><Not/></Transform>
+                              </Connection>
+                            </WidgetGroup>
+
+                            <Template src="skin:decks_12.xml"/>
 
                             <WidgetGroup>
                               <Layout>vertical</Layout>
@@ -503,7 +506,23 @@
                               </Connection>
                             </WidgetGroup>
 
-                            <Template src="skin:../Tango/decks_34.xml"/>
+                            <!-- Show waveforms above decks with 2 decks, between
+                            decks with 4 decks. -->
+                            <WidgetGroup>
+                              <Layout>vertical</Layout>
+                              <SizePolicy>me,max</SizePolicy>
+                              <Children>
+                                <SingletonContainer>
+                                  <ObjectName>Waveforms_Singleton</ObjectName>
+                                </SingletonContainer>
+                              </Children>
+                              <Connection>
+                                <ConfigKey persist="true">[Skin],show_4decks</ConfigKey>
+                                <BindProperty>visible</BindProperty>
+                              </Connection>
+                            </WidgetGroup>
+
+                            <Template src="skin:decks_34.xml"/>
 
                             <WidgetGroup>
                               <Layout>vertical</Layout>


### PR DESCRIPTION
After posting mockups for a future skin on [Zulip](https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/design.20brainstorming), I realized this simple change in Tango could make it easier to keep track of which waveform corresponds to which deck. The waveforms are kept above the decks in 2 deck mode.

I'm not certain this is a good idea yet, but I'll play with this for a while.
![Screenshot from 2019-08-14 18-44-31](https://user-images.githubusercontent.com/9455094/63063811-cbe20c00-bec3-11e9-82d6-a269afeb8b15.png)
