### PR TITLE
Tango :: loop jump fixes

### DIFF
--- a/res/skins/Tango/deck_row_loop_jump.xml
+++ b/res/skins/Tango/deck_row_loop_jump.xml
@@ -13,7 +13,6 @@ Variables:
     <Layout>vertical</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
-      <WidgetGroup><ObjectName>Spacer0f</ObjectName><Size>0me,1f</Size></WidgetGroup>
 
       <WidgetGroup>
         <Layout>stacked</Layout>

--- a/res/skins/Tango/jump_controls.xml
+++ b/res/skins/Tango/jump_controls.xml
@@ -10,10 +10,7 @@ Variables:
     <Layout>vertical</Layout>
     <Children>
 
-      <WidgetGroup>
-        <ObjectName>Spacer1e</ObjectName>
-        <Size>1min,2f</Size>
-      </WidgetGroup>
+      <WidgetGroup><ObjectName>Spacer1e</ObjectName><Size>1min,3f</Size></WidgetGroup>
 
       <WidgetGroup><!-- Beatjump controls -->
         <ObjectName>LoopBeatJumpContainer</ObjectName>

--- a/res/skins/Tango/jump_controls.xml
+++ b/res/skins/Tango/jump_controls.xml
@@ -53,10 +53,18 @@ Variables:
 
           <WidgetGroup><Size>3f,1min</Size></WidgetGroup>
 
-          <BeatSpinBox>
-            <TooltipId>beatjump_size</TooltipId>
-            <Value><Variable name="group"/>,beatjump_size</Value>
-          </BeatSpinBox>
+
+          <WidgetGroup>
+            <ObjectName>AlignLeft</ObjectName>
+            <Layout>horizontal</Layout>
+            <Size>68f,22f</Size>
+            <Children>
+              <BeatSpinBox>
+                <TooltipId>beatjump_size</TooltipId>
+                <Value><Variable name="group"/>,beatjump_size</Value>
+              </BeatSpinBox>
+            </Children>
+          </WidgetGroup>
 
           <WidgetGroup><Size>3f,1min</Size></WidgetGroup>
         </Children>

--- a/res/skins/Tango/loop_controls.xml
+++ b/res/skins/Tango/loop_controls.xml
@@ -48,7 +48,6 @@ Variables:
             </Children>
           </WidgetGroup>
 
-
           <WidgetGroup><Size>3f,1min</Size></WidgetGroup>
 
           <WidgetGroup>

--- a/res/skins/Tango/loop_controls.xml
+++ b/res/skins/Tango/loop_controls.xml
@@ -11,10 +11,7 @@ Variables:
     <SizePolicy>max,min</SizePolicy>
     <Children>
 
-      <WidgetGroup>
-        <ObjectName>Spacer1e</ObjectName>
-        <Size>1min,2f</Size>
-      </WidgetGroup>
+      <WidgetGroup><ObjectName>Spacer1e</ObjectName><Size>1min,3f</Size></WidgetGroup>
 
       <WidgetGroup><!-- Beatloop controls -->
         <ObjectName>LoopBeatJumpContainer</ObjectName>


### PR DESCRIPTION
* keep size of beatjump spinbox with scale factors >1
 (wrapped in fixed-size container like loop spinbox)
* remove dark line above jump/loop controls row