### PR TITLE
lp1840537: Enable (lib)modplug support on Linux by default

### DIFF
--- a/README
+++ b/README
@@ -39,6 +39,7 @@ Mixxx has the following dependencies:
 - libvorbis
 - libvorbisfile
 - libsndfile
+- libmodplug
 - libflac
 - libopus
 - libshout

--- a/build/debian/control
+++ b/build/debian/control
@@ -47,7 +47,8 @@ Build-Depends: debhelper (>= 9),
                libsoundtouch-dev,
                libhidapi-dev,
                libupower-glib-dev,
-               liblilv-dev
+               liblilv-dev,
+               libmodplug-dev
 Standards-Version: 3.9.8
 Homepage: http://www.mixxx.org/
 

--- a/build/features.py
+++ b/build/features.py
@@ -441,15 +441,19 @@ class ModPlug(Feature):
     def description(self):
         return "Modplug module decoder plugin"
 
+    def default(self, build):
+        return 1 if build.platform_is_linux else 0
+
     def enabled(self, build):
-        build.flags['modplug'] = util.get_flags(build.env, 'modplug', 0)
+        build.flags['modplug'] = util.get_flags(build.env, 'modplug', self.default(build))
         if int(build.flags['modplug']):
             return True
         return False
 
     def add_options(self, build, vars):
         vars.Add('modplug',
-                 'Set to 1 to enable libmodplug based module tracker support.', 0)
+                 'Set to 1 to enable libmodplug based module tracker support.',
+                 self.default(build))
 
     def configure(self, build, conf):
         if not self.enabled(build):


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1840537

What else needs to be done?

When merging to master we also need to update 2 different lines in default.nix!