### PR TITLE
fix scaling of cover art on high pixel density screens

### DIFF
--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -15,7 +15,7 @@ mixxx::Logger kLogger("CoverArtCache");
 
 QString pixmapCacheKey(quint16 hash, int width) {
     return QString("CoverArtCache_%1_%2")
-            .arg(QString::number(hash)).arg(width);
+            .arg(QString::number(hash), QString::number(width));
 }
 
 // The transformation mode when scaling images
@@ -26,9 +26,9 @@ inline QImage resizeImageWidth(const QImage& image, int width) {
     return image.scaledToWidth(width, kTransformationMode);
 }
 
-} // anonymous namespace
-
 const bool sDebug = false;
+
+} // anonymous namespace
 
 CoverArtCache::CoverArtCache() {
     // The initial QPixmapCache limit is 10MB.
@@ -80,6 +80,9 @@ QPixmap CoverArtCache::requestCover(const CoverInfo& requestInfo,
 
     QPixmap pixmap;
     if (QPixmapCache::find(cacheKey, &pixmap)) {
+        if (sDebug) {
+            kLogger.debug() << "CoverArtCache::requestCover cover found in cache" << requestInfo << signalWhenDone;
+        }
         if (signalWhenDone) {
             emit(coverFound(pRequestor, requestInfo, pixmap, true));
         }
@@ -93,6 +96,9 @@ QPixmap CoverArtCache::requestCover(const CoverInfo& requestInfo,
         return QPixmap();
     }
 
+    if (sDebug) {
+        kLogger.debug() << "CoverArtCache::requestCover starting future for" << requestInfo;
+    }
     m_runningRequests.insert(requestId);
     // The watcher will be deleted in coverLoaded()
     QFutureWatcher<FutureResult>* watcher = new QFutureWatcher<FutureResult>(this);

--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -107,7 +107,7 @@ void CoverArtDelegate::paintItem(QPainter *painter,
     info.hash = index.sibling(index.row(), m_iCoverHashColumn).data().toUInt();
     info.trackLocation = index.sibling(index.row(), m_iTrackLocationColumn).data().toString();
 
-    double scaleFactor = getDevicePixelRatioF(dynamic_cast<QWidget*>(parent()));
+    double scaleFactor = getDevicePixelRatioF(static_cast<QWidget*>(parent()));
     // We listen for updates via slotCoverFound above and signal to
     // BaseSqlTableModel when a row's cover is ready.
     QPixmap pixmap = pCache->requestCover(info, this, option.rect.width() * scaleFactor,

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -5,6 +5,7 @@
 #include "library/dlgcoverartfullsize.h"
 #include "library/coverartutils.h"
 #include "library/coverartcache.h"
+#include "util/compatibility.h"
 
 DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlayer)
         : QDialog(parent),
@@ -131,8 +132,9 @@ void DlgCoverArtFullSize::slotCoverFound(const QObject* pRequestor,
             dialogSize.scale(availableScreenSpace.width(), dialogSize.height(),
                              Qt::KeepAspectRatio);
         }
-        QPixmap resizedPixmap = m_pixmap.scaled(size(),
+        QPixmap resizedPixmap = m_pixmap.scaled(size() * getDevicePixelRatioF(this),
             Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        resizedPixmap.setDevicePixelRatio(getDevicePixelRatioF(this));
         coverArt->setPixmap(resizedPixmap);
         // center the window
         setGeometry(QStyle::alignedRect(
@@ -181,8 +183,9 @@ void DlgCoverArtFullSize::resizeEvent(QResizeEvent* event) {
         return;
     }
     // qDebug() << "DlgCoverArtFullSize::resizeEvent" << size();
-    QPixmap resizedPixmap = m_pixmap.scaled(size(),
+    QPixmap resizedPixmap = m_pixmap.scaled(size() * getDevicePixelRatioF(this),
         Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    resizedPixmap.setDevicePixelRatio(getDevicePixelRatioF(this));
     coverArt->setPixmap(resizedPixmap);
 }
 

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -10,6 +10,7 @@
 #include "track/beatfactory.h"
 #include "track/keyfactory.h"
 #include "track/keyutils.h"
+#include "util/compatibility.h"
 #include "util/duration.h"
 
 const int kFilterLength = 80;

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -12,6 +12,7 @@
 #include "library/coverartcache.h"
 #include "library/coverartutils.h"
 #include "library/dlgcoverartfullsize.h"
+#include "util/compatibility.h"
 #include "util/dnd.h"
 #include "util/math.h"
 
@@ -190,7 +191,11 @@ QPixmap WCoverArt::scaledCoverArt(const QPixmap& normal) {
     if (normal.isNull()) {
         return QPixmap();
     }
-    return normal.scaled(size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    QPixmap scaled;
+    scaled = normal.scaled(size() * getDevicePixelRatioF(this),
+            Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    scaled.setDevicePixelRatio(getDevicePixelRatioF(this));
+    return scaled;
 }
 
 void WCoverArt::paintEvent(QPaintEvent* /*unused*/) {

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -4,6 +4,7 @@
 
 #include "library/dlgcoverartfullsize.h"
 #include "library/coverartutils.h"
+#include "util/compatibility.h"
 
 static const QSize s_labelDisplaySize = QSize(100, 100);
 
@@ -23,7 +24,8 @@ WCoverArtLabel::WCoverArtLabel(QWidget* parent)
     connect(m_pCoverMenu, SIGNAL(reloadCoverArt()),
             this, SIGNAL(reloadCoverArt()));
 
-    m_defaultCover = m_defaultCover.scaled(s_labelDisplaySize,
+    m_defaultCover.setDevicePixelRatio(getDevicePixelRatioF(this));
+    m_defaultCover = m_defaultCover.scaled(s_labelDisplaySize * getDevicePixelRatioF(this),
                                            Qt::KeepAspectRatio,
                                            Qt::SmoothTransformation);
     setPixmap(m_defaultCover);
@@ -38,18 +40,18 @@ void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
                                  QPixmap px) {
     qDebug() << "WCoverArtLabel::setCoverArt" << coverInfo << px.size();
 
-    m_loadedCover = px;
+    m_loadedCover = px.scaled(s_labelDisplaySize * getDevicePixelRatioF(this),
+            Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    m_loadedCover.setDevicePixelRatio(getDevicePixelRatioF(this));
     m_pCoverMenu->setCoverArt(coverInfo);
 
-
-    if (px.isNull()) {
+    if (m_loadedCover.isNull()) {
         setPixmap(m_defaultCover);
     } else {
-        setPixmap(px.scaled(s_labelDisplaySize, Qt::KeepAspectRatio,
-                            Qt::SmoothTransformation));
+        setPixmap(m_loadedCover);
     }
 
-    QSize frameSize = pixmap()->size();
+    QSize frameSize = pixmap()->size() / getDevicePixelRatioF(this);
     frameSize += QSize(2,2); // margin
     setMinimumSize(frameSize);
     setMaximumSize(frameSize);

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -8,6 +8,7 @@
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
 #include "library/coverartcache.h"
+#include "util/compatibility.h"
 #include "util/dnd.h"
 #include "waveform/sharedglcontext.h"
 #include "util/math.h"
@@ -318,6 +319,8 @@ void WSpinny::render() {
                                         &m_dGhostAngleCurrentPlaypos);
     }
 
+    double scaleFactor = getDevicePixelRatioF(this);
+
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing);
     p.setRenderHint(QPainter::HighQualityAntialiasing);
@@ -329,8 +332,8 @@ void WSpinny::render() {
 
     if (m_bShowCover && !m_loadedCoverScaled.isNull()) {
         // Some covers aren't square, so center them.
-        int x = (width() - m_loadedCoverScaled.width()) / 2;
-        int y = (height() - m_loadedCoverScaled.height()) / 2;
+        int x = (width() - m_loadedCoverScaled.width() / scaleFactor) / 2;
+        int y = (height() - m_loadedCoverScaled.height() / scaleFactor) / 2;
         p.drawPixmap(x, y, m_loadedCoverScaled);
     }
 
@@ -403,7 +406,10 @@ QPixmap WSpinny::scaledCoverArt(const QPixmap& normal) {
     if (normal.isNull()) {
         return QPixmap();
     }
-    return normal.scaled(size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    QPixmap scaled = normal.scaled(size() * getDevicePixelRatioF(this),
+            Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    scaled.setDevicePixelRatio(getDevicePixelRatioF(this));
+    return scaled;
 }
 
 void WSpinny::resizeEvent(QResizeEvent* /*unused*/) {


### PR DESCRIPTION
Before, cover art images were getting scaled down to logical/device independent/1x pixel scale then automatically scaled up by the screen scale ratio which made them look blocky. By using QPixmap/QImage::setDevicePixelRatio and drawing QPixmaps/QImages at sizes scaled by the device pixel ratio, the cover art images only get scaled once to the size they are really shown at on screen.

Unfortunately there is a regression that somehow makes only one CoverArtDelegate show a cover at a time. I tried increasing the cache size by a factor of 100 and that made no difference. I would appreciate any hints where the problem might be with this.

Before:
![Screenshot from 2019-08-20 00-10-55](https://user-images.githubusercontent.com/9455094/63371754-53a79a80-c34a-11e9-8a06-93ea2054c215.png)
After:
![Screenshot from 2019-08-20 00-20-37](https://user-images.githubusercontent.com/9455094/63371828-733ec300-c34a-11e9-8fed-9b17239e1fa0.png)


Before:
![Screenshot from 2019-08-20 00-26-54](https://user-images.githubusercontent.com/9455094/63371814-691cc480-c34a-11e9-8942-dfc26ae257d7.png)

After:

![Screenshot from 2019-08-20 00-29-11](https://user-images.githubusercontent.com/9455094/63371848-79cd3a80-c34a-11e9-8a3b-7d9bfa3e50a1.png)

