### PR TITLE
Analysis: Adjust audio stream length/range if inaccurate or on errors

### DIFF
--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -84,7 +84,7 @@ AnalyzerThread::AnalyzerThread(
           m_pConfig(std::move(pConfig)),
           m_modeFlags(modeFlags),
           m_nextTrack(MpscFifoConcurrency::SingleProducer),
-          m_sampleBuffer(mixxx::kAnalysisSamplesPerBlock),
+          m_sampleBuffer(mixxx::kAnalysisSamplesPerChunk),
           m_emittedState(AnalyzerThreadState::Void) {
     std::call_once(registerMetaTypesOnceFlag, registerMetaTypesOnce);
 }
@@ -224,7 +224,7 @@ AnalyzerThread::AnalysisResult AnalyzerThread::analyzeAudioSource(
 
     mixxx::AudioSourceStereoProxy audioSourceProxy(
             audioSource,
-            mixxx::kAnalysisFramesPerBlock);
+            mixxx::kAnalysisFramesPerChunk);
     DEBUG_ASSERT(audioSourceProxy.channelCount() == mixxx::kAnalysisChannels);
 
     // Analysis starts now
@@ -242,7 +242,7 @@ AnalyzerThread::AnalysisResult AnalyzerThread::analyzeAudioSource(
         // 1st step: Decode next chunk of audio data
         auto inputFrameIndexRange =
                 remainingFrames.splitAndShrinkFront(
-                        math_min(mixxx::kAnalysisFramesPerBlock, remainingFrames.length()));
+                        math_min(mixxx::kAnalysisFramesPerChunk, remainingFrames.length()));
         DEBUG_ASSERT(!inputFrameIndexRange.empty());
         const auto readableSampleFrames =
                 audioSourceProxy.readSampleFrames(

--- a/src/analyzer/analyzerthread.h
+++ b/src/analyzer/analyzerthread.h
@@ -125,8 +125,7 @@ class AnalyzerThread : public WorkerThread {
 
     enum class AnalysisResult {
         Pending,
-        Partial,
-        Complete,
+        Finished,
         Cancelled,
     };
     AnalysisResult analyzeAudioSource(

--- a/src/analyzer/constants.h
+++ b/src/analyzer/constants.h
@@ -10,9 +10,9 @@ namespace mixxx {
 // seems to do fine. Signal processing during analysis uses the same,
 // fixed number of channels like the engine does, usually 2 = stereo.
 constexpr mixxx::AudioSignal::ChannelCount kAnalysisChannels = mixxx::kEngineChannelCount;
-constexpr SINT kAnalysisFramesPerBlock = 4096;
-constexpr SINT kAnalysisSamplesPerBlock =
-        kAnalysisFramesPerBlock * kAnalysisChannels;
+constexpr SINT kAnalysisFramesPerChunk = 4096;
+constexpr SINT kAnalysisSamplesPerChunk =
+        kAnalysisFramesPerChunk * kAnalysisChannels;
 
 // Only analyze the first minute in fast-analysis mode.
 constexpr int kFastAnalysisSecondsToAnalyze = 60;

--- a/src/analyzer/plugins/analyzersoundtouchbeats.cpp
+++ b/src/analyzer/plugins/analyzersoundtouchbeats.cpp
@@ -8,7 +8,7 @@
 namespace mixxx {
 
 AnalyzerSoundTouchBeats::AnalyzerSoundTouchBeats()
-        : m_downmixBuffer(kAnalysisFramesPerBlock),
+        : m_downmixBuffer(kAnalysisFramesPerChunk), // mono, i.e. 1 sample per frame
           m_fResultBpm(0.0f) {
 }
 

--- a/src/engine/cachingreader/cachingreaderchunk.cpp
+++ b/src/engine/cachingreader/cachingreaderchunk.cpp
@@ -72,7 +72,8 @@ mixxx::IndexRange CachingReaderChunk::bufferSampleFrames(
                     mixxx::WritableSampleFrames(
                             sourceFrameIndexRange,
                             mixxx::SampleBuffer::WritableSlice(m_sampleBuffer)));
-    DEBUG_ASSERT(m_bufferedSampleFrames.frameIndexRange() <= sourceFrameIndexRange);
+    DEBUG_ASSERT(m_bufferedSampleFrames.frameIndexRange().empty() ||
+            m_bufferedSampleFrames.frameIndexRange() <= sourceFrameIndexRange);
     return m_bufferedSampleFrames.frameIndexRange();
 }
 

--- a/src/engine/cachingreader/cachingreaderworker.cpp
+++ b/src/engine/cachingreader/cachingreaderworker.cpp
@@ -37,48 +37,37 @@ ReaderStatusUpdate CachingReaderWorker::processReadRequest(
     // Before trying to read any data we need to check if the audio source
     // is available and if any audio data that is needed by the chunk is
     // actually available.
-    const auto chunkFrameIndexRange = pChunk->frameIndexRange(m_pAudioSource);
-    if (intersect(chunkFrameIndexRange, m_readableFrameIndexRange).empty()) {
+    auto chunkFrameIndexRange = pChunk->frameIndexRange(m_pAudioSource);
+    DEBUG_ASSERT(chunkFrameIndexRange <= m_pAudioSource->frameIndexRange());
+    if (chunkFrameIndexRange.empty()) {
         ReaderStatusUpdate result;
-        result.init(CHUNK_READ_INVALID, pChunk, m_readableFrameIndexRange);
+        result.init(CHUNK_READ_INVALID, pChunk, m_pAudioSource->frameIndexRange());
         return result;
     }
 
     // Try to read the data required for the chunk from the audio source
-    // and adjust the max. readable frame index if decoding errors occur.
     const mixxx::IndexRange bufferedFrameIndexRange = pChunk->bufferSampleFrames(
             m_pAudioSource,
             mixxx::SampleBuffer::WritableSlice(m_tempReadBuffer));
+    DEBUG_ASSERT(bufferedFrameIndexRange <= m_pAudioSource->frameIndexRange());
+    // The readable frame range might have changed
+    chunkFrameIndexRange = intersect(chunkFrameIndexRange, m_pAudioSource->frameIndexRange());
+    DEBUG_ASSERT(bufferedFrameIndexRange <= chunkFrameIndexRange);
+
     ReaderStatus status = bufferedFrameIndexRange.empty() ? CHUNK_READ_EOF : CHUNK_READ_SUCCESS;
-    if (chunkFrameIndexRange != bufferedFrameIndexRange) {
+    if (bufferedFrameIndexRange != chunkFrameIndexRange) {
         kLogger.warning()
                 << m_group
                 << "Failed to read chunk samples for frame index range:"
-                << "actual =" << bufferedFrameIndexRange
-                << ", expected =" << chunkFrameIndexRange;
+                << "expected =" << chunkFrameIndexRange
+                << ", actual =" << bufferedFrameIndexRange;
         if (bufferedFrameIndexRange.empty()) {
-            // Adjust upper bound: Consider all audio data following
-            // the read position until the end as unreadable
-            m_readableFrameIndexRange.shrinkBack(m_readableFrameIndexRange.end() - chunkFrameIndexRange.start());
-            status = CHUNK_READ_INVALID; // not EOF (see above)
-        } else {
-            // Adjust lower bound of readable audio data
-            if (chunkFrameIndexRange.start() < bufferedFrameIndexRange.start()) {
-                m_readableFrameIndexRange.shrinkFront(bufferedFrameIndexRange.start() - m_readableFrameIndexRange.start());
-            }
-            // Adjust upper bound of readable audio data
-            if (chunkFrameIndexRange.end() > bufferedFrameIndexRange.end()) {
-                m_readableFrameIndexRange.shrinkBack(m_readableFrameIndexRange.end() - bufferedFrameIndexRange.end());
-            }
+            status = CHUNK_READ_INVALID; // overwrite EOF (see above)
         }
-        kLogger.warning()
-                << "Readable frames in audio source reduced to"
-                << m_readableFrameIndexRange
-                << "from originally"
-                << m_pAudioSource->frameIndexRange();
     }
+
     ReaderStatusUpdate result;
-    result.init(status, pChunk, m_readableFrameIndexRange);
+    result.init(status, pChunk, m_pAudioSource->frameIndexRange());
     return result;
 }
 
@@ -130,7 +119,6 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     }
 
     // Unload the track
-    m_readableFrameIndexRange = mixxx::IndexRange();
     m_pAudioSource.reset(); // Close open file handles
 
     if (!pTrack) {
@@ -175,8 +163,7 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     // Initially assume that the complete content offered by audio source
     // is available for reading. Later if read errors occur this value will
     // be decreased to avoid repeated reading of corrupt audio data.
-    m_readableFrameIndexRange = m_pAudioSource->frameIndexRange();
-    if (m_readableFrameIndexRange.empty()) {
+    if (m_pAudioSource->frameIndexRange().empty()) {
         m_pAudioSource.reset(); // Close open file handles
         kLogger.warning()
                 << m_group
@@ -197,13 +184,14 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     }
 
     const auto update =
-        ReaderStatusUpdate::trackLoaded(m_readableFrameIndexRange);
+            ReaderStatusUpdate::trackLoaded(
+                m_pAudioSource->frameIndexRange());
     m_pReaderStatusFIFO->writeBlocking(&update, 1);
 
     // Emit that the track is loaded.
     const SINT sampleCount =
             CachingReaderChunk::frames2samples(
-                    m_readableFrameIndexRange.length());
+                    m_pAudioSource->frameLength());
     emit trackLoaded(pTrack, m_pAudioSource->sampleRate(), sampleCount);
 }
 

--- a/src/engine/cachingreader/cachingreaderworker.cpp
+++ b/src/engine/cachingreader/cachingreaderworker.cpp
@@ -38,10 +38,12 @@ ReaderStatusUpdate CachingReaderWorker::processReadRequest(
     // is available and if any audio data that is needed by the chunk is
     // actually available.
     auto chunkFrameIndexRange = pChunk->frameIndexRange(m_pAudioSource);
-    DEBUG_ASSERT(chunkFrameIndexRange <= m_pAudioSource->frameIndexRange());
+    DEBUG_ASSERT(!m_pAudioSource ||
+            chunkFrameIndexRange <= m_pAudioSource->frameIndexRange());
     if (chunkFrameIndexRange.empty()) {
         ReaderStatusUpdate result;
-        result.init(CHUNK_READ_INVALID, pChunk, m_pAudioSource->frameIndexRange());
+        result.init(CHUNK_READ_INVALID, pChunk,
+                m_pAudioSource ? m_pAudioSource->frameIndexRange() : mixxx::IndexRange());
         return result;
     }
 
@@ -49,7 +51,8 @@ ReaderStatusUpdate CachingReaderWorker::processReadRequest(
     const mixxx::IndexRange bufferedFrameIndexRange = pChunk->bufferSampleFrames(
             m_pAudioSource,
             mixxx::SampleBuffer::WritableSlice(m_tempReadBuffer));
-    DEBUG_ASSERT(bufferedFrameIndexRange <= m_pAudioSource->frameIndexRange());
+    DEBUG_ASSERT(!m_pAudioSource ||
+            bufferedFrameIndexRange <= m_pAudioSource->frameIndexRange());
     // The readable frame range might have changed
     chunkFrameIndexRange = intersect(chunkFrameIndexRange, m_pAudioSource->frameIndexRange());
     DEBUG_ASSERT(bufferedFrameIndexRange <= chunkFrameIndexRange);
@@ -67,7 +70,8 @@ ReaderStatusUpdate CachingReaderWorker::processReadRequest(
     }
 
     ReaderStatusUpdate result;
-    result.init(status, pChunk, m_pAudioSource->frameIndexRange());
+    result.init(status, pChunk,
+            m_pAudioSource ? m_pAudioSource->frameIndexRange() : mixxx::IndexRange());
     return result;
 }
 

--- a/src/engine/cachingreader/cachingreaderworker.cpp
+++ b/src/engine/cachingreader/cachingreaderworker.cpp
@@ -55,7 +55,8 @@ ReaderStatusUpdate CachingReaderWorker::processReadRequest(
             bufferedFrameIndexRange <= m_pAudioSource->frameIndexRange());
     // The readable frame range might have changed
     chunkFrameIndexRange = intersect(chunkFrameIndexRange, m_pAudioSource->frameIndexRange());
-    DEBUG_ASSERT(bufferedFrameIndexRange <= chunkFrameIndexRange);
+    DEBUG_ASSERT(bufferedFrameIndexRange.empty() ||
+            bufferedFrameIndexRange <= chunkFrameIndexRange);
 
     ReaderStatus status = bufferedFrameIndexRange.empty() ? CHUNK_READ_EOF : CHUNK_READ_SUCCESS;
     if (bufferedFrameIndexRange != chunkFrameIndexRange) {

--- a/src/engine/cachingreader/cachingreaderworker.h
+++ b/src/engine/cachingreader/cachingreaderworker.h
@@ -146,13 +146,6 @@ class CachingReaderWorker : public EngineWorker {
     // before conversion to a stereo signal.
     mixxx::SampleBuffer m_tempReadBuffer;
 
-    // The maximum readable frame index of the AudioSource. Might
-    // be adjusted when decoding errors occur to prevent reading
-    // the same chunk(s) over and over again.
-    // This frame index references the frame that follows the
-    // last frame with readable sample data.
-    mixxx::IndexRange m_readableFrameIndexRange;
-
     QAtomicInt m_stop;
 };
 

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -134,4 +134,61 @@ WritableSampleFrames AudioSource::clampWritableSampleFrames(
                     frames2samples(writableFrameIndexRange.length())));
 }
 
+ReadableSampleFrames AudioSource::readSampleFrames(
+        WritableSampleFrames sampleFrames) {
+    const auto writable =
+            clampWritableSampleFrames(sampleFrames);
+    if (writable.frameIndexRange().empty()) {
+        // result is empty
+        return ReadableSampleFrames(writable.frameIndexRange());
+    } else {
+        // forward clamped request
+        ReadableSampleFrames readable = readSampleFramesClamped(writable);
+        DEBUG_ASSERT(readable.frameIndexRange() <= writable.frameIndexRange());
+        if (readable.frameIndexRange() != writable.frameIndexRange()) {
+            kLogger.warning()
+                    << "Failed to read sample frames:"
+                    << "expected =" << writable.frameIndexRange()
+                    << ", actual =" << readable.frameIndexRange();
+            auto shrinkedFrameIndexRange = m_frameIndexRange;
+            if (readable.frameIndexRange().empty()) {
+                // Adjust upper bound: Consider all audio data following
+                // the read position until the end as unreadable
+                shrinkedFrameIndexRange.shrinkBack(
+                        shrinkedFrameIndexRange.end() - writable.frameIndexRange().start());
+            } else {
+                // Adjust lower bound of readable audio data
+                if (writable.frameIndexRange().start() < readable.frameIndexRange().start()) {
+                    shrinkedFrameIndexRange.shrinkFront(
+                            readable.frameIndexRange().start() - shrinkedFrameIndexRange.start());
+                }
+                // Adjust upper bound of readable audio data
+                if (writable.frameIndexRange().end() > readable.frameIndexRange().end()) {
+                    shrinkedFrameIndexRange.shrinkBack(
+                            shrinkedFrameIndexRange.end() - readable.frameIndexRange().end());
+                }
+            }
+            DEBUG_ASSERT(shrinkedFrameIndexRange < m_frameIndexRange);
+            kLogger.info()
+                    << "Shrinking readable frame index range:"
+                    << "before =" << m_frameIndexRange
+                    << ", after =" << shrinkedFrameIndexRange;
+            // Propagate the adjustments to all participants in the
+            // inheritance hierarchy.
+            // NOTE(2019-08-31, uklotzde): This is an ugly hack to overcome
+            // the previous assumption that the frame index range is immutable
+            // for the whole lifetime of an AudioSource. As we know now it is
+            // not and for a future re-design we need to account for this fact!!
+            adjustFrameIndexRange(shrinkedFrameIndexRange);
+        }
+        return readable;
+    }
+}
+
+void AudioSource::adjustFrameIndexRange(
+        IndexRange frameIndexRange) {
+    DEBUG_ASSERT(frameIndexRange <= m_frameIndexRange);
+    m_frameIndexRange = frameIndexRange;
+}
+
 } // namespace mixxx

--- a/src/sources/audiosource.cpp
+++ b/src/sources/audiosource.cpp
@@ -144,7 +144,8 @@ ReadableSampleFrames AudioSource::readSampleFrames(
     } else {
         // forward clamped request
         ReadableSampleFrames readable = readSampleFramesClamped(writable);
-        DEBUG_ASSERT(readable.frameIndexRange() <= writable.frameIndexRange());
+        DEBUG_ASSERT(readable.frameIndexRange().empty() ||
+                readable.frameIndexRange() <= writable.frameIndexRange());
         if (readable.frameIndexRange() != writable.frameIndexRange()) {
             kLogger.warning()
                     << "Failed to read sample frames:"

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -288,19 +288,7 @@ class AudioSource : public UrlResource, public AudioSignal, public virtual /*imp
     bool verifyReadable() const override;
 
     ReadableSampleFrames readSampleFrames(
-            WritableSampleFrames sampleFrames) {
-        const auto sampleFramesFramesClamped =
-                clampWritableSampleFrames(sampleFrames);
-        if (sampleFramesFramesClamped.frameIndexRange().empty()) {
-            // result is empty
-            return ReadableSampleFrames(
-                    sampleFramesFramesClamped.frameIndexRange());
-        } else {
-            // forward clamped request
-            return readSampleFramesClamped(
-                    sampleFramesFramesClamped);
-        }
-    }
+            WritableSampleFrames sampleFrames);
 
   protected:
     explicit AudioSource(QUrl url);
@@ -308,6 +296,18 @@ class AudioSource : public UrlResource, public AudioSignal, public virtual /*imp
 
     bool initFrameIndexRangeOnce(
             IndexRange frameIndexRange);
+    // The frame index range needs to be adjusted while
+    // reading. This virtual function is an ugly hack!!!
+    // It needs to be overridden in derived proxy classes
+    // that wrap a pointer to the actual audio source and
+    // delegate to that.
+    virtual void adjustFrameIndexRange(
+            IndexRange frameIndexRange);
+    static void adjustFrameIndexRangeOn(
+            AudioSource& that,
+            IndexRange frameIndexRange) {
+        that.adjustFrameIndexRange(frameIndexRange);
+    }
 
     bool initBitrateOnce(Bitrate bitrate);
     bool initBitrateOnce(SINT bitrate) {

--- a/src/sources/audiosourcestereoproxy.cpp
+++ b/src/sources/audiosourcestereoproxy.cpp
@@ -116,4 +116,11 @@ ReadableSampleFrames AudioSourceStereoProxy::readSampleFramesClamped(
                     writableSlice.length()));
 }
 
+void AudioSourceStereoProxy::adjustFrameIndexRange(
+        IndexRange frameIndexRange) {
+    // Ugly hack to keep both sources (inherited base + delegate) in sync!
+    AudioSource::adjustFrameIndexRange(frameIndexRange);
+    adjustFrameIndexRangeOn(*m_pAudioSource, frameIndexRange);
+}
+
 } // namespace mixxx

--- a/src/sources/audiosourcestereoproxy.h
+++ b/src/sources/audiosourcestereoproxy.h
@@ -39,6 +39,9 @@ class AudioSourceStereoProxy : public AudioSource {
     ReadableSampleFrames readSampleFramesClamped(
             WritableSampleFrames writableSampleFrames) override;
 
+    void adjustFrameIndexRange(
+            IndexRange frameIndexRange) override;
+
   private:
     AudioSourcePointer m_pAudioSource;
     SampleBuffer m_tempSampleBuffer;

--- a/src/sources/audiosourcetrackproxy.h
+++ b/src/sources/audiosourcetrackproxy.h
@@ -46,6 +46,13 @@ class AudioSourceTrackProxy : public AudioSource {
         return readSampleFramesClampedOn(*m_pAudioSource, sampleFrames);
     }
 
+    void adjustFrameIndexRange(
+            IndexRange frameIndexRange) override {
+        // Ugly hack to keep both sources (inherited base + delegate) in sync!
+        AudioSource::adjustFrameIndexRange(frameIndexRange);
+        adjustFrameIndexRangeOn(*m_pAudioSource, frameIndexRange);
+    }
+
   private:
     TrackPointer m_pTrack;
     // The audio source must be closed before releasing the track


### PR DESCRIPTION
An inaccurate (too long) audio stream length is not uncommon, ~~especially when decoding MP3 with FFmpeg.~~ This mainly happens when decoding corrupt files that end prematurely, or when decoding some M4A files with FFmpeg where the initial offset (`start_time`) is not available.

We already adjust the readable length in `CachingReaderWorker`, but this is insufficient! It has to be done directly in `AudioSource`. Otherwise, separate consumers of audio data like the analysis that directly access `AudioSource` don't benefit from this adjustment and error handling.

I detected this issue when trying to fix an analysis bug that caused a warning and skipped the final, partial chunk of data. This is fixed by the second commit, taking into account the now correctly adjusted audio source length.

**Update**
Fixing this bug turned out much more difficult than expected, because the design of our AudioSource is insufficient. The assumption was that the `m_frameIndexRange` member is almost immutable, i.e. only initialized once. I had to introduce an ugly hack to overcome this limitation, but at least it is well documented.