### PR TITLE
improve detection of sound hardware from configuration

### DIFF
--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -6,6 +6,7 @@
 #include "library/crate/crateid.h"
 #include "control/controlproxy.h"
 #include "mixxx.h"
+#include "soundio/soundmanagerutil.h"
 
 // When linking Qt statically on Windows we have to Q_IMPORT_PLUGIN all the
 // plugins we link in build/depends.py.
@@ -65,6 +66,8 @@ void MixxxApplication::registerMetaTypes() {
     qRegisterMetaType<mixxx::ReplayGain>("mixxx::ReplayGain");
     qRegisterMetaType<mixxx::Bpm>("mixxx::Bpm");
     qRegisterMetaType<mixxx::Duration>("mixxx::Duration");
+    qRegisterMetaType<SoundDeviceId>("SoundDeviceId");
+    QMetaType::registerComparators<SoundDeviceId>();
 }
 
 // Macs do not have touchscreens

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -205,11 +205,11 @@ void DlgPrefSound::slotUpdate() {
     // we change to this pane, we lose changed and unapplied settings
     // every time. There's no real way around this, just another argument
     // for a prefs rewrite -- bkgood
-    m_settingsModified = false;
     m_bSkipConfigClear = true;
     loadSettings();
     checkLatencyCompensation();
     m_bSkipConfigClear = false;
+    m_settingsModified = false;
 }
 
 /**

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -38,7 +38,8 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent, SoundManager* pSoundManager,
           m_settingsModified(false),
           m_bLatencyChanged(false),
           m_bSkipConfigClear(true),
-          m_loading(false) {
+          m_loading(false),
+          m_config(pSoundManager) {
     setupUi(this);
 
     connect(m_pSoundManager, SIGNAL(devicesUpdated()),
@@ -590,7 +591,7 @@ void DlgPrefSound::queryClicked() {
  * Slot called when the "Reset to Defaults" button is clicked.
  */
 void DlgPrefSound::slotResetToDefaults() {
-    SoundManagerConfig newConfig;
+    SoundManagerConfig newConfig(m_pSoundManager);
     newConfig.loadDefaults(m_pSoundManager, SoundManagerConfig::ALL);
     loadSettings(newConfig);
     keylockComboBox->setCurrentIndex(EngineBuffer::RUBBERBAND);

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -40,7 +40,7 @@ DlgPrefSoundItem::DlgPrefSoundItem(QWidget* parent, AudioPathType type,
     setupUi(this);
     typeLabel->setText(AudioPath::getTrStringFromType(type, index));
 
-    deviceComboBox->addItem(tr("None"), "None");
+    deviceComboBox->addItem(tr("None"), QVariant::fromValue(SoundDeviceId()));
     connect(deviceComboBox, SIGNAL(currentIndexChanged(int)),
             this, SLOT(deviceChanged(int)));
     connect(channelComboBox, SIGNAL(currentIndexChanged(int)),
@@ -83,7 +83,7 @@ void DlgPrefSoundItem::deviceChanged(int index) {
     channelComboBox->clear();
     SoundDeviceId selection = deviceComboBox->itemData(index).value<SoundDeviceId>();
     unsigned int numChannels = 0;
-    if (selection.name == "None") {
+    if (selection == SoundDeviceId()) {
         goto emitAndReturn;
     } else {
         for (const auto& pDevice: qAsConst(m_devices)) {
@@ -234,7 +234,7 @@ void DlgPrefSoundItem::reload() {
  */
 SoundDevicePointer DlgPrefSoundItem::getDevice() const {
     SoundDeviceId selection = deviceComboBox->itemData(deviceComboBox->currentIndex()).value<SoundDeviceId>();
-    if (selection.name == "None") {
+    if (selection == SoundDeviceId()) {
         return SoundDevicePointer();
     }
     for (const auto& pDevice: qAsConst(m_devices)) {

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -58,7 +58,7 @@ DlgPrefSoundItem::~DlgPrefSoundItem() {
  */
 void DlgPrefSoundItem::refreshDevices(const QList<SoundDevicePointer>& devices) {
     m_devices = devices;
-    QString oldDev = deviceComboBox->itemData(deviceComboBox->currentIndex()).toString();
+    SoundDeviceId oldDev = deviceComboBox->itemData(deviceComboBox->currentIndex()).value<SoundDeviceId>();
     deviceComboBox->setCurrentIndex(0);
     // not using combobox->clear means we can leave in "None" so it
     // doesn't flicker when you switch APIs... cleaner Mixxx :) bkgood
@@ -67,9 +67,9 @@ void DlgPrefSoundItem::refreshDevices(const QList<SoundDevicePointer>& devices) 
     }
     for (const auto& pDevice: qAsConst(m_devices)) {
         if (!hasSufficientChannels(*pDevice)) continue;
-        deviceComboBox->addItem(pDevice->getDisplayName(), pDevice->getInternalName());
+        deviceComboBox->addItem(pDevice->getDisplayName(), QVariant::fromValue(pDevice->getDeviceId()));
     }
-    int newIndex = deviceComboBox->findData(oldDev);
+    int newIndex = deviceComboBox->findData(QVariant::fromValue(oldDev));
     if (newIndex != -1) {
         deviceComboBox->setCurrentIndex(newIndex);
     }
@@ -81,13 +81,13 @@ void DlgPrefSoundItem::refreshDevices(const QList<SoundDevicePointer>& devices) 
  */
 void DlgPrefSoundItem::deviceChanged(int index) {
     channelComboBox->clear();
-    QString selection = deviceComboBox->itemData(index).toString();
+    SoundDeviceId selection = deviceComboBox->itemData(index).value<SoundDeviceId>();
     unsigned int numChannels = 0;
-    if (selection == "None") {
+    if (selection.name == "None") {
         goto emitAndReturn;
     } else {
         for (const auto& pDevice: qAsConst(m_devices)) {
-            if (pDevice->getInternalName() == selection) {
+            if (pDevice->getDeviceId() == selection) {
                 if (m_isInput) {
                     numChannels = pDevice->getNumInputChannels();
                 } else {
@@ -148,35 +148,31 @@ void DlgPrefSoundItem::channelChanged() {
  */
 void DlgPrefSoundItem::loadPath(const SoundManagerConfig &config) {
     if (m_isInput) {
-        QMultiHash<QString, AudioInput> inputs(config.getInputs());
-        foreach (QString devName, inputs.uniqueKeys()) {
-            foreach (AudioInput in, inputs.values(devName)) {
-                if (in.getType() == m_type && in.getIndex() == m_index) {
-                    setDevice(devName);
-                    setChannel(in.getChannelGroup().getChannelBase(),
-                               in.getChannelGroup().getChannelCount());
-                    return; // we're just using the first one found, leave
-                            // multiples to a more advanced dialog -- bkgood
-                }
+        QMultiHash<SoundDeviceId, AudioInput> inputs(config.getInputs());
+        QHashIterator<SoundDeviceId, AudioInput> it(inputs);
+        while (it.hasNext()) {
+            it.next();
+            if (it.value().getType() == m_type && it.value().getIndex() == m_index) {
+                setDevice(it.key());
+                setChannel(it.value().getChannelGroup().getChannelBase(),
+                            it.value().getChannelGroup().getChannelCount());
+                return;
             }
         }
     } else {
-        QMultiHash<QString, AudioOutput> outputs(config.getOutputs());
-        foreach (QString devName, outputs.uniqueKeys()) {
-            foreach (AudioOutput out, outputs.values(devName)) {
-                if (out.getType() == m_type && out.getIndex() == m_index) {
-                    setDevice(devName);
-                    setChannel(out.getChannelGroup().getChannelBase(),
-                               out.getChannelGroup().getChannelCount());
-                    return; // we're just using the first one found, leave
-                            // multiples to a more advanced dialog -- bkgood
-                }
+        QMultiHash<SoundDeviceId, AudioOutput> outputs(config.getOutputs());
+        QHashIterator<SoundDeviceId, AudioOutput> it(outputs);
+        while (it.hasNext()) {
+            it.next();
+            if (it.value().getType() == m_type && it.value().getIndex() == m_index) {
+                setDevice(it.key());
+                setChannel(it.value().getChannelGroup().getChannelBase(),
+                            it.value().getChannelGroup().getChannelCount());
+                return;
             }
         }
     }
-    // if we've gotten here without returning, we didn't find a path applicable
-    // to us so set some defaults -- bkgood
-    setDevice("None"); // this will blank the channel combo box
+    setDevice(SoundDeviceId()); // this will blank the channel combo box
 }
 
 /**
@@ -201,11 +197,11 @@ void DlgPrefSoundItem::writePath(SoundManagerConfig* config) const {
 
     if (m_isInput) {
         config->addInput(
-                pDevice->getInternalName(),
+                pDevice->getDeviceId(),
                 AudioInput(m_type, channelBase, channelCount, m_index));
     } else {
         config->addOutput(
-                pDevice->getInternalName(),
+                pDevice->getDeviceId(),
                 AudioOutput(m_type, channelBase, channelCount, m_index));
     }
 }
@@ -214,7 +210,7 @@ void DlgPrefSoundItem::writePath(SoundManagerConfig* config) const {
  * Slot called to tell the Item to save its selections for later use.
  */
 void DlgPrefSoundItem::save() {
-    m_savedDevice = deviceComboBox->itemData(deviceComboBox->currentIndex()).toString();
+    m_savedDevice = deviceComboBox->itemData(deviceComboBox->currentIndex()).value<SoundDeviceId>();
     m_savedChannel = channelComboBox->itemData(channelComboBox->currentIndex()).toPoint();
 }
 
@@ -222,7 +218,7 @@ void DlgPrefSoundItem::save() {
  * Slot called to reload Item with previously saved settings.
  */
 void DlgPrefSoundItem::reload() {
-    int newDevice = deviceComboBox->findData(m_savedDevice);
+    int newDevice = deviceComboBox->findData(QVariant::fromValue(m_savedDevice));
     if (newDevice > -1) {
         deviceComboBox->setCurrentIndex(newDevice);
     }
@@ -237,14 +233,13 @@ void DlgPrefSoundItem::reload() {
  * @returns pointer to SoundDevice, or NULL if the "None" option is selected.
  */
 SoundDevicePointer DlgPrefSoundItem::getDevice() const {
-    QString selection = deviceComboBox->itemData(deviceComboBox->currentIndex()).toString();
-    if (selection == "None") {
+    SoundDeviceId selection = deviceComboBox->itemData(deviceComboBox->currentIndex()).value<SoundDeviceId>();
+    if (selection.name == "None") {
         return SoundDevicePointer();
     }
     for (const auto& pDevice: qAsConst(m_devices)) {
-        qDebug() << "1" << pDevice->getDisplayName();
-        qDebug() << "2" << pDevice->getInternalName();
-        if (selection == pDevice->getInternalName()) {
+        if (selection == pDevice->getDeviceId()) {
+            //qDebug() << "DlgPrefSoundItem::getDevice" << pDevice->getDeviceId().debugName();
             return pDevice;
         }
     }
@@ -257,8 +252,9 @@ SoundDevicePointer DlgPrefSoundItem::getDevice() const {
  * Selects a device in the device combo box given a SoundDevice
  * internal name, or selects "None" if the device isn't found.
  */
-void DlgPrefSoundItem::setDevice(const QString &deviceName) {
-    int index = deviceComboBox->findData(deviceName);
+void DlgPrefSoundItem::setDevice(const SoundDeviceId& device) {
+    int index = deviceComboBox->findData(QVariant::fromValue(device));
+    //qDebug() << "DlgPrefSoundItem::setDevice" << device.debugName();
     if (index != -1) {
         m_inhibitSettingChanged = true;
         deviceComboBox->setCurrentIndex(index);

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -239,7 +239,7 @@ SoundDevicePointer DlgPrefSoundItem::getDevice() const {
     }
     for (const auto& pDevice: qAsConst(m_devices)) {
         if (selection == pDevice->getDeviceId()) {
-            //qDebug() << "DlgPrefSoundItem::getDevice" << pDevice->getDeviceId().debugName();
+            //qDebug() << "DlgPrefSoundItem::getDevice" << pDevice->getDeviceId();
             return pDevice;
         }
     }
@@ -254,7 +254,7 @@ SoundDevicePointer DlgPrefSoundItem::getDevice() const {
  */
 void DlgPrefSoundItem::setDevice(const SoundDeviceId& device) {
     int index = deviceComboBox->findData(QVariant::fromValue(device));
-    //qDebug() << "DlgPrefSoundItem::setDevice" << device.debugName();
+    //qDebug() << "DlgPrefSoundItem::setDevice" << device;
     if (index != -1) {
         m_inhibitSettingChanged = true;
         deviceComboBox->setCurrentIndex(index);

--- a/src/preferences/dialog/dlgprefsounditem.h
+++ b/src/preferences/dialog/dlgprefsounditem.h
@@ -54,7 +54,7 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
 
   private:
     SoundDevicePointer getDevice() const; // if this returns NULL, we don't have a valid AudioPath
-    void setDevice(const QString &deviceName);
+    void setDevice(const SoundDeviceId& device);
     void setChannel(unsigned int channelBase, unsigned int channels);
     int hasSufficientChannels(const SoundDevice& device) const;
 
@@ -62,7 +62,7 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     unsigned int m_index;
     QList<SoundDevicePointer> m_devices;
     bool m_isInput;
-    QString m_savedDevice;
+    SoundDeviceId m_savedDevice;
     // Because QVariant supports QPoint natively we use a QPoint to store the
     // channel info. x is the channel base and y is the channel count.
     QPoint m_savedChannel;

--- a/src/soundio/sounddevice.cpp
+++ b/src/soundio/sounddevice.cpp
@@ -29,7 +29,6 @@
 SoundDevice::SoundDevice(UserSettingsPointer config, SoundManager* sm)
         : m_pConfig(config),
           m_pSoundManager(sm),
-          m_strInternalName("Unknown Soundcard"),
           m_strDisplayName("Unknown Soundcard"),
           m_iNumOutputChannels(2),
           m_iNumInputChannels(2),
@@ -104,11 +103,7 @@ void SoundDevice::clearInputs() {
 }
 
 bool SoundDevice::operator==(const SoundDevice &other) const {
-    return this->getInternalName() == other.getInternalName();
-}
-
-bool SoundDevice::operator==(const QString &other) const {
-    return getInternalName() == other;
+    return m_deviceId == other.getDeviceId();
 }
 
 void SoundDevice::composeOutputBuffer(CSAMPLE* outputBuffer,

--- a/src/soundio/sounddevice.h
+++ b/src/soundio/sounddevice.h
@@ -25,6 +25,7 @@
 #include "preferences/usersettings.h"
 #include "soundio/sounddeviceerror.h"
 #include "soundio/sounddevice.h"
+#include "soundio/soundmanagerutil.h"
 
 class SoundDevice;
 class SoundManager;
@@ -40,8 +41,8 @@ class SoundDevice {
     SoundDevice(UserSettingsPointer config, SoundManager* sm);
     virtual ~SoundDevice();
 
-    inline const QString& getInternalName() const {
-        return m_strInternalName;
+    inline const SoundDeviceId& getDeviceId() const {
+        return m_deviceId;
     }
     inline const QString& getDisplayName() const {
         return m_strDisplayName;
@@ -88,11 +89,10 @@ class SoundDevice {
     void clearInputBuffer(const SINT framesToPush,
                           const SINT framesWriteOffset);
 
+    SoundDeviceId m_deviceId;
     UserSettingsPointer m_pConfig;
     // Pointer to the SoundManager object which we'll request audio from.
     SoundManager* m_pSoundManager;
-    // The name of the soundcard, used internally (may include the device ID)
-    QString m_strInternalName;
     // The name of the soundcard, as displayed to the user
     QString m_strDisplayName;
     // The number of output channels that the soundcard has

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -47,7 +47,7 @@ SoundDeviceNetwork::SoundDeviceNetwork(UserSettingsPointer config,
     // Setting parent class members:
     m_hostAPI = "Network stream";
     m_dSampleRate = 44100.0;
-    m_strInternalName = kNetworkDeviceInternalName;
+    m_deviceId.name = kNetworkDeviceInternalName;
     m_strDisplayName = QObject::tr("Network stream");
     m_iNumInputChannels = pNetworkStream->getNumInputChannels();
     m_iNumOutputChannels = pNetworkStream->getNumOutputChannels();
@@ -61,7 +61,7 @@ SoundDeviceNetwork::~SoundDeviceNetwork() {
 
 SoundDeviceError SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers) {
     Q_UNUSED(syncBuffers);
-    kLogger.debug() << "open:" << getInternalName();
+    kLogger.debug() << "open:" << m_deviceId.name;
 
     // Sample rate
     if (m_dSampleRate <= 0) {
@@ -414,7 +414,7 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
     updateCallbackEntryToDacTime();
 
     Trace trace("SoundDeviceNetwork::callbackProcessClkRef %1",
-                getInternalName());
+                m_deviceId.name);
 
 
     if (!m_denormals) {
@@ -453,7 +453,7 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
 
     {
         ScopedTimer t("SoundDevicePortAudio::callbackProcess prepare %1",
-                getInternalName());
+                m_deviceId.name);
         m_pSoundManager->onDeviceOutputCallback(m_framesPerBuffer);
     }
 

--- a/src/soundio/sounddevicenotfound.h
+++ b/src/soundio/sounddevicenotfound.h
@@ -15,10 +15,10 @@ class EngineNetworkStream;
 
 class SoundDeviceNotFound : public SoundDevice {
   public:
-    SoundDeviceNotFound(QString internalName)
+    SoundDeviceNotFound(QString name)
             : SoundDevice(UserSettingsPointer(), nullptr) {
-        m_strInternalName = internalName;
-        m_strDisplayName = internalName;
+        m_deviceId.name = name;
+        m_strDisplayName = name;
     }
 
     SoundDeviceError open(bool isClkRefDevice, int syncBuffers) override {

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -107,8 +107,7 @@ SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
     // Setting parent class members:
     m_hostAPI = Pa_GetHostApiInfo(deviceInfo->hostApi)->name;
     m_dSampleRate = deviceInfo->defaultSampleRate;
-    m_strInternalName = QString("%1, %2").arg(QString::number(m_devId),
-            deviceInfo->name);
+    m_strInternalName = deviceInfo->name;
     m_strDisplayName = QString::fromLocal8Bit(deviceInfo->name);
     m_iNumInputChannels = m_deviceInfo->maxInputChannels;
     m_iNumOutputChannels = m_deviceInfo->maxOutputChannels;

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -119,7 +119,7 @@ SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
         QRegularExpressionMatch match = alsaHwDeviceRegex.match(deviceInfo->name);
         if (match.hasMatch()) {
             m_deviceId.name = match.captured(1);
-            m_deviceId.alsaDeviceName = match.captured(3);
+            m_deviceId.alsaHwDevice = match.captured(3);
         } else {
             // Special ALSA devices like "default" and "pulse" do not match the regex
             m_deviceId.name = deviceInfo->name;

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -84,6 +84,8 @@ int paV19CallbackClkRef(const void *inputBuffer, void *outputBuffer,
             (const CSAMPLE*) inputBuffer, timeInfo, statusFlags);
 }
 
+const QRegularExpression kAlsaHwDeviceRegex("(.*) \\((plug)?(hw:(\\d)+(,(\\d)+))?\\)");
+
 } // anonymous namespace
 
 
@@ -115,8 +117,7 @@ SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
         // the name from the hw device allows for making the use of both pieces
         // of information in SoundManagerConfig::readFromDisk to minimize how
         // often users need to reconfigure their sound hardware.
-        QRegularExpression alsaHwDeviceRegex("(.*) \\((plug)?(hw:(\\d)+(,(\\d)+))?\\)");
-        QRegularExpressionMatch match = alsaHwDeviceRegex.match(deviceInfo->name);
+        QRegularExpressionMatch match = kAlsaHwDeviceRegex.match(deviceInfo->name);
         if (match.hasMatch()) {
             m_deviceId.name = match.captured(1);
             m_deviceId.alsaHwDevice = match.captured(3);

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -153,7 +153,7 @@ SoundDevicePortAudio::~SoundDevicePortAudio() {
 }
 
 SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers) {
-    qDebug() << "SoundDevicePortAudio::open()" << m_deviceId.debugName();
+    qDebug() << "SoundDevicePortAudio::open()" << m_deviceId;
     PaError err;
 
     if (m_audioOutputs.empty() && m_audioInputs.empty()) {
@@ -359,7 +359,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
         err = Pa_CloseStream(pStream);
         if (err != paNoError) {
             qWarning() << "PortAudio: Close stream error:"
-                       << Pa_GetErrorText(err) << m_deviceId.debugName();
+                       << Pa_GetErrorText(err) << m_deviceId;
         }
         return SOUNDDEVICE_ERROR_ERR;
     } else {
@@ -391,7 +391,7 @@ bool SoundDevicePortAudio::isOpen() const {
 }
 
 SoundDeviceError SoundDevicePortAudio::close() {
-    //qDebug() << "SoundDevicePortAudio::close()" << m_deviceId.debugName();
+    //qDebug() << "SoundDevicePortAudio::close()" << m_deviceId;
     PaStream* pStream = m_pStream;
     m_pStream = NULL;
     if (pStream) {
@@ -405,7 +405,7 @@ SoundDeviceError SoundDevicePortAudio::close() {
         // Real PaErrors are always negative.
         if (err < 0) {
             qWarning() << "PortAudio: Stream already stopped:"
-                       << Pa_GetErrorText(err) << m_deviceId.debugName();
+                       << Pa_GetErrorText(err) << m_deviceId;
             return SOUNDDEVICE_ERROR_ERR;
         }
 
@@ -421,7 +421,7 @@ SoundDeviceError SoundDevicePortAudio::close() {
 
         if (err != paNoError) {
             qWarning() << "PortAudio: Stop stream error:"
-                       << Pa_GetErrorText(err) << m_deviceId.debugName();
+                       << Pa_GetErrorText(err) << m_deviceId;
             return SOUNDDEVICE_ERROR_ERR;
         }
 
@@ -429,7 +429,7 @@ SoundDeviceError SoundDevicePortAudio::close() {
         err = Pa_CloseStream(pStream);
         if (err != paNoError) {
             qWarning() << "PortAudio: Close stream error:"
-                       << Pa_GetErrorText(err) << m_deviceId.debugName();
+                       << Pa_GetErrorText(err) << m_deviceId;
             return SOUNDDEVICE_ERROR_ERR;
         }
 
@@ -492,7 +492,7 @@ void SoundDevicePortAudio::readProcess() {
                         size1 / m_inputParams.channelCount);
                 CSAMPLE* lastFrame = &dataPtr1[size1 - m_inputParams.channelCount];
                 if (err == paInputOverflowed) {
-                    //qDebug() << "SoundDevicePortAudio::readProcess() Pa_ReadStream paInputOverflowed" << m_deviceId.debugName();
+                    //qDebug() << "SoundDevicePortAudio::readProcess() Pa_ReadStream paInputOverflowed" << m_deviceId;
                     m_pSoundManager->underflowHappened(12);
                 }
                 if (size2 > 0) {
@@ -500,7 +500,7 @@ void SoundDevicePortAudio::readProcess() {
                             size2 / m_inputParams.channelCount);
                     lastFrame = &dataPtr2[size2 - m_inputParams.channelCount];
                     if (err == paInputOverflowed) {
-                        //qDebug() << "SoundDevicePortAudio::readProcess() Pa_ReadStream paInputOverflowed" << m_deviceId.debugName();
+                        //qDebug() << "SoundDevicePortAudio::readProcess() Pa_ReadStream paInputOverflowed" << m_deviceId;
                         m_pSoundManager->underflowHappened(13);
                     }
                 }
@@ -516,7 +516,7 @@ void SoundDevicePortAudio::readProcess() {
                         if (err == paInputOverflowed) {
                             //qDebug()
                             //        << "SoundDevicePortAudio::readProcess() Pa_ReadStream paInputOverflowed"
-                            //        << m_deviceId.debugName();
+                            //        << m_deviceId;
                             m_pSoundManager->underflowHappened(14);
                         }
                     } else {
@@ -671,14 +671,14 @@ void SoundDevicePortAudio::writeProcess() {
                 PaError err = Pa_WriteStream(pStream, dataPtr1,
                         size1 / m_outputParams.channelCount);
                 if (err == paOutputUnderflowed) {
-                    //qDebug() << "SoundDevicePortAudio::writeProcess() Pa_ReadStream paOutputUnderflowed" << m_deviceId.debugName();
+                    //qDebug() << "SoundDevicePortAudio::writeProcess() Pa_ReadStream paOutputUnderflowed" << m_deviceId;
                     m_pSoundManager->underflowHappened(19);
                 }
                 if (size2 > 0) {
                     PaError err = Pa_WriteStream(pStream, dataPtr2,
                             size2 / m_outputParams.channelCount);
                     if (err == paOutputUnderflowed) {
-                        //qDebug() << "SoundDevicePortAudio::writeProcess() Pa_WriteStream paOutputUnderflowed" << m_deviceId.debugName();
+                        //qDebug() << "SoundDevicePortAudio::writeProcess() Pa_WriteStream paOutputUnderflowed" << m_deviceId;
                         m_pSoundManager->underflowHappened(20);
                     }
                 }
@@ -883,7 +883,7 @@ int SoundDevicePortAudio::callbackProcessClkRef(
     Trace trace("SoundDevicePortAudio::callbackProcessClkRef %1",
                 m_deviceId.debugName());
 
-    //qDebug() << "SoundDevicePortAudio::callbackProcess:" << m_deviceId.debugName();
+    //qDebug() << "SoundDevicePortAudio::callbackProcess:" << m_deviceId;
     // Turn on TimeCritical priority for the callback thread. If we are running
     // in Linux userland, for example, this will have no effect.
     if (!m_bSetThreadPriority) {

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -21,6 +21,7 @@
 #include <float.h>
 
 #include <QtDebug>
+#include <QRegularExpression>
 #include <QThread>
 
 #ifdef __LINUX__
@@ -90,10 +91,10 @@ int paV19CallbackClkRef(const void *inputBuffer, void *outputBuffer,
 SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
                                            SoundManager* sm,
                                            const PaDeviceInfo* deviceInfo,
-                                           unsigned int devIndex)
+                                           unsigned int devIndex,
+                                           QHash<PaHostApiIndex, PaHostApiTypeId> apiIndexToTypeId)
         : SoundDevice(config, sm),
           m_pStream(NULL),
-          m_devId(devIndex),
           m_deviceInfo(deviceInfo),
           m_outputFifo(NULL),
           m_inputFifo(NULL),
@@ -107,7 +108,26 @@ SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
     // Setting parent class members:
     m_hostAPI = Pa_GetHostApiInfo(deviceInfo->hostApi)->name;
     m_dSampleRate = deviceInfo->defaultSampleRate;
-    m_strInternalName = deviceInfo->name;
+    if (apiIndexToTypeId.value(deviceInfo->hostApi) == paALSA) {
+        // PortAudio gives the device name including the ALSA hw device. The
+        // ALSA hw device is an only somewhat reliable identifier; it may change
+        // when an audio interface is unplugged or Linux is restarted. Separating
+        // the name from the hw device allows for making the use of both pieces
+        // of information in SoundManagerConfig::readFromDisk to minimize how
+        // often users need to reconfigure their sound hardware.
+        QRegularExpression alsaHwDeviceRegex("(.*) \\((plug)?(hw:(\\d)+(,(\\d)+))?\\)");
+        QRegularExpressionMatch match = alsaHwDeviceRegex.match(deviceInfo->name);
+        if (match.hasMatch()) {
+            m_deviceId.name = match.captured(1);
+            m_deviceId.alsaDeviceName = match.captured(3);
+        } else {
+            // Special ALSA devices like "default" and "pulse" do not match the regex
+            m_deviceId.name = deviceInfo->name;
+        }
+    } else {
+        m_deviceId.name = deviceInfo->name;
+    }
+    m_deviceId.portAudioIndex = devIndex;
     m_strDisplayName = QString::fromLocal8Bit(deviceInfo->name);
     m_iNumInputChannels = m_deviceInfo->maxInputChannels;
     m_iNumOutputChannels = m_deviceInfo->maxOutputChannels;
@@ -133,7 +153,7 @@ SoundDevicePortAudio::~SoundDevicePortAudio() {
 }
 
 SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers) {
-    qDebug() << "SoundDevicePortAudio::open()" << getInternalName();
+    qDebug() << "SoundDevicePortAudio::open()" << m_deviceId.debugName();
     PaError err;
 
     if (m_audioOutputs.empty() && m_audioInputs.empty()) {
@@ -226,17 +246,17 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
     }
 
     //Fill out the rest of the info.
-    m_outputParams.device = m_devId;
+    m_outputParams.device = m_deviceId.portAudioIndex;
     m_outputParams.sampleFormat = paFloat32;
     m_outputParams.suggestedLatency = bufferMSec / 1000.0;
     m_outputParams.hostApiSpecificStreamInfo = NULL;
 
-    m_inputParams.device  = m_devId;
+    m_inputParams.device  = m_deviceId.portAudioIndex;
     m_inputParams.sampleFormat  = paFloat32;
     m_inputParams.suggestedLatency = bufferMSec / 1000.0;
     m_inputParams.hostApiSpecificStreamInfo = NULL;
 
-    qDebug() << "Opening stream with id" << m_devId;
+    qDebug() << "Opening stream with id" << m_deviceId.portAudioIndex;
 
     m_lastCallbackEntrytoDacSecs = bufferMSec / 1000.0;
 
@@ -339,7 +359,7 @@ SoundDeviceError SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffers
         err = Pa_CloseStream(pStream);
         if (err != paNoError) {
             qWarning() << "PortAudio: Close stream error:"
-                       << Pa_GetErrorText(err) << getInternalName();
+                       << Pa_GetErrorText(err) << m_deviceId.debugName();
         }
         return SOUNDDEVICE_ERROR_ERR;
     } else {
@@ -371,7 +391,7 @@ bool SoundDevicePortAudio::isOpen() const {
 }
 
 SoundDeviceError SoundDevicePortAudio::close() {
-    //qDebug() << "SoundDevicePortAudio::close()" << getInternalName();
+    //qDebug() << "SoundDevicePortAudio::close()" << m_deviceId.debugName();
     PaStream* pStream = m_pStream;
     m_pStream = NULL;
     if (pStream) {
@@ -385,7 +405,7 @@ SoundDeviceError SoundDevicePortAudio::close() {
         // Real PaErrors are always negative.
         if (err < 0) {
             qWarning() << "PortAudio: Stream already stopped:"
-                       << Pa_GetErrorText(err) << getInternalName();
+                       << Pa_GetErrorText(err) << m_deviceId.debugName();
             return SOUNDDEVICE_ERROR_ERR;
         }
 
@@ -401,7 +421,7 @@ SoundDeviceError SoundDevicePortAudio::close() {
 
         if (err != paNoError) {
             qWarning() << "PortAudio: Stop stream error:"
-                       << Pa_GetErrorText(err) << getInternalName();
+                       << Pa_GetErrorText(err) << m_deviceId.debugName();
             return SOUNDDEVICE_ERROR_ERR;
         }
 
@@ -409,7 +429,7 @@ SoundDeviceError SoundDevicePortAudio::close() {
         err = Pa_CloseStream(pStream);
         if (err != paNoError) {
             qWarning() << "PortAudio: Close stream error:"
-                       << Pa_GetErrorText(err) << getInternalName();
+                       << Pa_GetErrorText(err) << m_deviceId.debugName();
             return SOUNDDEVICE_ERROR_ERR;
         }
 
@@ -472,7 +492,7 @@ void SoundDevicePortAudio::readProcess() {
                         size1 / m_inputParams.channelCount);
                 CSAMPLE* lastFrame = &dataPtr1[size1 - m_inputParams.channelCount];
                 if (err == paInputOverflowed) {
-                    //qDebug() << "SoundDevicePortAudio::readProcess() Pa_ReadStream paInputOverflowed" << getInternalName();
+                    //qDebug() << "SoundDevicePortAudio::readProcess() Pa_ReadStream paInputOverflowed" << m_deviceId.debugName();
                     m_pSoundManager->underflowHappened(12);
                 }
                 if (size2 > 0) {
@@ -480,7 +500,7 @@ void SoundDevicePortAudio::readProcess() {
                             size2 / m_inputParams.channelCount);
                     lastFrame = &dataPtr2[size2 - m_inputParams.channelCount];
                     if (err == paInputOverflowed) {
-                        //qDebug() << "SoundDevicePortAudio::readProcess() Pa_ReadStream paInputOverflowed" << getInternalName();
+                        //qDebug() << "SoundDevicePortAudio::readProcess() Pa_ReadStream paInputOverflowed" << m_deviceId.debugName();
                         m_pSoundManager->underflowHappened(13);
                     }
                 }
@@ -496,7 +516,7 @@ void SoundDevicePortAudio::readProcess() {
                         if (err == paInputOverflowed) {
                             //qDebug()
                             //        << "SoundDevicePortAudio::readProcess() Pa_ReadStream paInputOverflowed"
-                            //        << getInternalName();
+                            //        << m_deviceId.debugName();
                             m_pSoundManager->underflowHappened(14);
                         }
                     } else {
@@ -651,14 +671,14 @@ void SoundDevicePortAudio::writeProcess() {
                 PaError err = Pa_WriteStream(pStream, dataPtr1,
                         size1 / m_outputParams.channelCount);
                 if (err == paOutputUnderflowed) {
-                    //qDebug() << "SoundDevicePortAudio::writeProcess() Pa_ReadStream paOutputUnderflowed" << getInternalName();
+                    //qDebug() << "SoundDevicePortAudio::writeProcess() Pa_ReadStream paOutputUnderflowed" << m_deviceId.debugName();
                     m_pSoundManager->underflowHappened(19);
                 }
                 if (size2 > 0) {
                     PaError err = Pa_WriteStream(pStream, dataPtr2,
                             size2 / m_outputParams.channelCount);
                     if (err == paOutputUnderflowed) {
-                        //qDebug() << "SoundDevicePortAudio::writeProcess() Pa_WriteStream paOutputUnderflowed" << getInternalName();
+                        //qDebug() << "SoundDevicePortAudio::writeProcess() Pa_WriteStream paOutputUnderflowed" << m_deviceId.debugName();
                         m_pSoundManager->underflowHappened(20);
                     }
                 }
@@ -674,7 +694,7 @@ int SoundDevicePortAudio::callbackProcessDrift(
         PaStreamCallbackFlags statusFlags) {
     Q_UNUSED(timeInfo);
     Trace trace("SoundDevicePortAudio::callbackProcessDrift %1",
-            getInternalName());
+            m_deviceId.debugName());
 
     if (statusFlags & (paOutputUnderflow | paInputOverflow)) {
         m_pSoundManager->underflowHappened(7);
@@ -806,7 +826,7 @@ int SoundDevicePortAudio::callbackProcess(const SINT framesPerBuffer,
         const PaStreamCallbackTimeInfo *timeInfo,
         PaStreamCallbackFlags statusFlags) {
     Q_UNUSED(timeInfo);
-    Trace trace("SoundDevicePortAudio::callbackProcess %1", getInternalName());
+    Trace trace("SoundDevicePortAudio::callbackProcess %1", m_deviceId.debugName());
 
     if (statusFlags & (paOutputUnderflow | paInputOverflow)) {
         m_pSoundManager->underflowHappened(1);
@@ -861,9 +881,9 @@ int SoundDevicePortAudio::callbackProcessClkRef(
     updateCallbackEntryToDacTime(timeInfo);
 
     Trace trace("SoundDevicePortAudio::callbackProcessClkRef %1",
-                getInternalName());
+                m_deviceId.debugName());
 
-    //qDebug() << "SoundDevicePortAudio::callbackProcess:" << getInternalName();
+    //qDebug() << "SoundDevicePortAudio::callbackProcess:" << m_deviceId.debugName();
     // Turn on TimeCritical priority for the callback thread. If we are running
     // in Linux userland, for example, this will have no effect.
     if (!m_bSetThreadPriority) {
@@ -928,7 +948,7 @@ int SoundDevicePortAudio::callbackProcessClkRef(
     // Send audio from the soundcard's input off to the SoundManager...
     if (in) {
         ScopedTimer t("SoundDevicePortAudio::callbackProcess input %1",
-                getInternalName());
+                m_deviceId.debugName());
         composeInputBuffer(in, framesPerBuffer, 0, m_inputParams.channelCount);
         m_pSoundManager->pushInputBuffers(m_audioInputs, m_framesPerBuffer);
     }
@@ -937,13 +957,13 @@ int SoundDevicePortAudio::callbackProcessClkRef(
 
     {
         ScopedTimer t("SoundDevicePortAudio::callbackProcess prepare %1",
-                getInternalName());
+                m_deviceId.debugName());
         m_pSoundManager->onDeviceOutputCallback(framesPerBuffer);
     }
 
     if (out) {
         ScopedTimer t("SoundDevicePortAudio::callbackProcess output %1",
-                getInternalName());
+                m_deviceId.debugName());
 
         if (m_outputParams.channelCount <= 0) {
             qWarning()

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -102,7 +102,6 @@ class SoundDevicePortAudio : public SoundDevice {
     int m_invalidTimeInfoCount;
     PerformanceTimer m_clkRefTimer;
     PaTime m_lastCallbackEntrytoDacSecs;
-
 };
 
 #endif

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -41,7 +41,7 @@ class SoundDevicePortAudio : public SoundDevice {
   public:
     SoundDevicePortAudio(UserSettingsPointer config,
                          SoundManager* sm, const PaDeviceInfo* deviceInfo,
-                         unsigned int devIndex);
+                         unsigned int devIndex, QHash<PaHostApiIndex, PaHostApiTypeId> apiIndexToTypeId);
     ~SoundDevicePortAudio() override;
 
     SoundDeviceError open(bool isClkRefDevice, int syncBuffers) override;
@@ -79,8 +79,6 @@ class SoundDevicePortAudio : public SoundDevice {
 
     // PortAudio stream for this device.
     PaStream* volatile m_pStream;
-    // PortAudio device index for this device.
-    PaDeviceIndex m_devId;
     // Struct containing information about this device. Don't free() it, it
     // belongs to PortAudio.
     const PaDeviceInfo* m_deviceInfo;

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -513,7 +513,7 @@ SoundDeviceError SoundManager::setupDevices() {
     qDebug() << outputDevicesOpened << "output sound devices opened";
     qDebug() << inputDevicesOpened << "input sound devices opened";
     for (const auto& device: devicesNotFound) {
-        qWarning() << device.debugName() << "not found";
+        qWarning() << device << "not found";
     }
 
     m_pControlObjectSoundStatusCO->set(

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -44,6 +44,7 @@
 #include "vinylcontrol/defs_vinylcontrol.h"
 
 #ifdef __PORTAUDIO__
+#include <portaudio.h>
 typedef PaError (*SetJackClientName)(const char *name);
 #endif
 
@@ -70,6 +71,7 @@ SoundManager::SoundManager(UserSettingsPointer pConfig,
           m_paInitialized(false),
           m_jackSampleRate(-1),
 #endif
+          m_config(this),
           m_pErrorDevice(NULL),
           m_underflowHappened(0) {
     // TODO(xxx) some of these ControlObject are not needed by soundmanager, or are unused here.
@@ -139,10 +141,14 @@ QList<SoundDevicePointer> SoundManager::getDeviceList(
     for (const auto& pDevice: m_devices) {
         // Skip devices that don't match the API, don't have input channels when
         // we want input devices, or don't have output channels when we want
-        // output devices.
+        // output devices. If searching for both input and output devices,
+        // make sure to include any devices that have >0 channels.
+        bool hasOutputs = pDevice->getNumOutputChannels() >= 0;
+        bool hasInputs = pDevice->getNumInputChannels() >= 0;
         if (pDevice->getHostAPI() != filterAPI ||
-                (bOutputDevices && pDevice->getNumOutputChannels() <= 0) ||
-                (bInputDevices && pDevice->getNumInputChannels() <= 0)) {
+                (bOutputDevices && !bInputDevices && !hasOutputs) ||
+                (bInputDevices && !bOutputDevices && !hasInputs) ||
+                (!hasInputs && !hasOutputs)) {
             continue;
         }
         filteredDeviceList.push_back(pDevice);
@@ -293,6 +299,18 @@ void SoundManager::queryDevicesPortaudio() {
         return;
     }
 
+    // PaDeviceInfo structs have a PaHostApiIndex member, but PortAudio
+    // unfortunately provides no good way to associate this with a persistent,
+    // unique identifier for the API. So, build a QHash to do that and pass
+    // it to the SoundDevicePortAudio constructor.
+    QHash<PaHostApiIndex, PaHostApiTypeId> paApiIndexToTypeId;
+    for (PaHostApiIndex i = 0; i < Pa_GetHostApiCount(); i++) {
+        const PaHostApiInfo* api = Pa_GetHostApiInfo(i);
+        if (api && QString(api->name) != "skeleton implementation") {
+            paApiIndexToTypeId.insert(i, api->type);
+        }
+    }
+
     const PaDeviceInfo* deviceInfo;
     for (int i = 0; i < iNumDevices; i++) {
         deviceInfo = Pa_GetDeviceInfo(i);
@@ -312,7 +330,7 @@ void SoundManager::queryDevicesPortaudio() {
             double  defaultSampleRate
          */
         auto currentDevice = SoundDevicePointer(new SoundDevicePortAudio(
-                m_pConfig, this, deviceInfo, i));
+                m_pConfig, this, deviceInfo, i, paApiIndexToTypeId));
         m_devices.push_back(currentDevice);
         if (!strcmp(Pa_GetHostApiInfo(deviceInfo->hostApi)->name,
                     MIXXX_PORTAUDIO_JACK_STRING)) {
@@ -366,7 +384,7 @@ SoundDeviceError SoundManager::setupDevices() {
 
     // load with all configured devices.
     // all found devices are removed below
-    QSet<QString> devicesNotFound = m_config.getDevices();
+    QSet<SoundDeviceId> devicesNotFound = m_config.getDevices();
 
     // pair is isInput, isOutput
     QList<DeviceMode> toOpen;
@@ -378,7 +396,7 @@ SoundDeviceError SoundManager::setupDevices() {
         pDevice->clearOutputs();
         m_pErrorDevice = pDevice;
         for (const auto& in:
-                 m_config.getInputs().values(pDevice->getInternalName())) {
+                 m_config.getInputs().values(pDevice->getDeviceId())) {
             mode.isInput = true;
             // TODO(bkgood) look into allocating this with the frames per
             // buffer value from SMConfig
@@ -401,10 +419,10 @@ SoundDeviceError SoundManager::setupDevices() {
             }
         }
         QList<AudioOutput> outputs =
-                m_config.getOutputs().values(pDevice->getInternalName());
+                m_config.getOutputs().values(pDevice->getDeviceId());
 
         // Statically connect the Network Device to the Sidechain
-        if (pDevice->getInternalName() == kNetworkDeviceInternalName) {
+        if (pDevice->getDeviceId().name == kNetworkDeviceInternalName) {
             AudioOutput out(AudioPath::RECORD_BROADCAST, 0, 2, 0);
             outputs.append(out);
             if (m_config.getForceNetworkClock()) {
@@ -414,7 +432,7 @@ SoundDeviceError SoundManager::setupDevices() {
 
         for (const auto& out: qAsConst(outputs)) {
             mode.isOutput = true;
-            if (pDevice->getInternalName() != kNetworkDeviceInternalName) {
+            if (pDevice->getDeviceId().name != kNetworkDeviceInternalName) {
                 haveOutput = true;
             }
             // following keeps us from asking for a channel buffer EngineMaster
@@ -476,7 +494,7 @@ SoundDeviceError SoundManager::setupDevices() {
         }
         err = pDevice->open(pNewMasterClockRef == pDevice, syncBuffers);
         if (err != SOUNDDEVICE_ERROR_OK) goto closeAndError;
-        devicesNotFound.remove(pDevice->getInternalName());
+        devicesNotFound.remove(pDevice->getDeviceId());
         if (mode.isOutput) {
             ++outputDevicesOpened;
         }
@@ -494,8 +512,8 @@ SoundDeviceError SoundManager::setupDevices() {
 
     qDebug() << outputDevicesOpened << "output sound devices opened";
     qDebug() << inputDevicesOpened << "input sound devices opened";
-    for (const auto& deviceName: devicesNotFound) {
-        qWarning() << deviceName << "not found";
+    for (const auto& device: devicesNotFound) {
+        qWarning() << device.debugName() << "not found";
     }
 
     m_pControlObjectSoundStatusCO->set(
@@ -508,7 +526,7 @@ SoundDeviceError SoundManager::setupDevices() {
         return SOUNDDEVICE_ERROR_OK;
     }
     m_pErrorDevice = SoundDevicePointer(
-            new SoundDeviceNotFound(*devicesNotFound.constBegin()));
+            new SoundDeviceNotFound(devicesNotFound.constBegin()->name));
     return SOUNDDEVICE_ERROR_DEVICE_COUNT;
 
 closeAndError:
@@ -578,7 +596,7 @@ SoundDeviceError SoundManager::setConfig(SoundManagerConfig config) {
 }
 
 void SoundManager::checkConfig() {
-    if (!m_config.checkAPI(*this)) {
+    if (!m_config.checkAPI()) {
         m_config.setAPI(SoundManagerConfig::kDefaultAPI);
         m_config.loadDefaults(this, SoundManagerConfig::API | SoundManagerConfig::DEVICES);
     }

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -95,7 +95,7 @@ bool SoundManagerConfig::readFromDisk() {
         if (deviceIdFromFile.name.isEmpty()) {
             continue;
         }
-        deviceIdFromFile.alsaDeviceName = devElement.attribute("alsaDeviceName");
+        deviceIdFromFile.alsaHwDevice = devElement.attribute("alsaHwDevice");
         deviceIdFromFile.portAudioIndex = devElement.attribute("portAudioIndex").toInt();
 
         int devicesMatchingByName = 0;
@@ -110,21 +110,21 @@ bool SoundManagerConfig::readFromDisk() {
             continue;
         } else if (devicesMatchingByName == 1) {
             // There is only one device with this name, so it is unambiguous
-            // which it is. Neither the alsaDeviceName nor portAudioIndex are
+            // which it is. Neither the alsaHwDevice nor portAudioIndex are
             // very reliable as persistent identifiers across restarts of Mixxx.
-            // Set deviceIdFromFile's alsaDeviceName and portAudioIndex to match
+            // Set deviceIdFromFile's alsaHwDevice and portAudioIndex to match
             // the hardwareDeviceId so operator== works for SoundDeviceId.
             for (const auto& soundDevice : soundDevices) {
                 SoundDeviceId hardwareDeviceId = soundDevice->getDeviceId();
                 if (hardwareDeviceId.name == deviceIdFromFile.name) {
-                    deviceIdFromFile.alsaDeviceName = hardwareDeviceId.alsaDeviceName;
+                    deviceIdFromFile.alsaHwDevice = hardwareDeviceId.alsaHwDevice;
                     deviceIdFromFile.portAudioIndex = hardwareDeviceId.portAudioIndex;
                 }
             }
         } else {
             // It is not clear which hardwareDeviceId corresponds to the device
             // listed in the configuration file using only the name.
-            if (!deviceIdFromFile.alsaDeviceName.isEmpty()) {
+            if (!deviceIdFromFile.alsaHwDevice.isEmpty()) {
                 // If using ALSA, attempt to match based on the ALSA device name.
                 // This is reliable between restarts of Mixxx until the user
                 // unplugs an audio interface or restarts Linux.
@@ -136,7 +136,7 @@ bool SoundManagerConfig::readFromDisk() {
                 for (const auto& soundDevice : soundDevices) {
                     SoundDeviceId hardwareDeviceId = soundDevice->getDeviceId();
                     if (hardwareDeviceId.name == deviceIdFromFile.name
-                            && hardwareDeviceId.alsaDeviceName == deviceIdFromFile.alsaDeviceName) {
+                            && hardwareDeviceId.alsaHwDevice == deviceIdFromFile.alsaHwDevice) {
                         deviceIdFromFile.portAudioIndex = hardwareDeviceId.portAudioIndex;
                     }
                 }
@@ -199,7 +199,7 @@ bool SoundManagerConfig::writeToDisk() const {
         devElement.setAttribute("name", deviceId.name);
         devElement.setAttribute("portAudioIndex", deviceId.portAudioIndex);
         if (m_api == MIXXX_PORTAUDIO_ALSA_STRING) {
-            devElement.setAttribute("alsaDeviceName", deviceId.alsaDeviceName);
+            devElement.setAttribute("alsaHwDevice", deviceId.alsaHwDevice);
         }
         for (const AudioInput& in : m_inputs.values(deviceId)) {
             QDomElement inElement(doc.createElement("input"));

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -31,7 +31,7 @@ class SoundManager;
 
 class SoundManagerConfig {
 public:
-    SoundManagerConfig(SoundManager* pSoundManager);
+    explicit SoundManagerConfig(SoundManager* pSoundManager);
 
     enum Defaults {
         API = (1 << 0),

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -31,6 +31,8 @@ class SoundManager;
 
 class SoundManagerConfig {
 public:
+    SoundManagerConfig(SoundManager* pSoundManager);
+
     enum Defaults {
         API = (1 << 0),
         DEVICES = (1 << 1),
@@ -51,7 +53,7 @@ public:
     bool writeToDisk() const;
     QString getAPI() const;
     void setAPI(const QString &api);
-    bool checkAPI(const SoundManager &soundManager);
+    bool checkAPI();
     unsigned int getSampleRate() const;
     void setSampleRate(unsigned int sampleRate);
     bool checkSampleRate(const SoundManager &soundManager);
@@ -61,7 +63,7 @@ public:
     unsigned int getDeckCount() const;
     void setDeckCount(unsigned int deckCount);
     void setCorrectDeckCount(int configuredDeckCount);
-    QSet<QString> getDevices() const;
+    QSet<SoundDeviceId> getDevices() const;
 
     unsigned int getAudioBufferSizeIndex() const;
     unsigned int getFramesPerBuffer() const;
@@ -72,10 +74,10 @@ public:
     void setSyncBuffers(unsigned int sampleRate);
     bool getForceNetworkClock() const;
     void setForceNetworkClock(bool force);
-    void addOutput(const QString &device, const AudioOutput &out);
-    void addInput(const QString &device, const AudioInput &in);
-    QMultiHash<QString, AudioOutput> getOutputs() const;
-    QMultiHash<QString, AudioInput> getInputs() const;
+    void addOutput(const SoundDeviceId &device, const AudioOutput &out);
+    void addInput(const SoundDeviceId &device, const AudioInput &in);
+    QMultiHash<SoundDeviceId, AudioOutput> getOutputs() const;
+    QMultiHash<SoundDeviceId, AudioInput> getInputs() const;
     void clearOutputs();
     void clearInputs();
     bool hasMicInputs();
@@ -95,9 +97,10 @@ private:
     unsigned int m_audioBufferSizeIndex;
     unsigned int m_syncBuffers;
     bool m_forceNetworkClock;
-    QMultiHash<QString, AudioOutput> m_outputs;
-    QMultiHash<QString, AudioInput> m_inputs;
+    QMultiHash<SoundDeviceId, AudioOutput> m_outputs;
+    QMultiHash<SoundDeviceId, AudioInput> m_inputs;
     int m_iNumMicInputs;
     bool m_bExternalRecordBroadcastConnected;
+    SoundManager* m_pSoundManager;
 };
 #endif

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -200,6 +200,8 @@ typedef AudioPath::AudioPathType AudioPathType;
 class SoundDeviceId {
   public:
     QString name;
+    // The "hw:X,Y" device name. Remains an empty string if not using ALSA
+    // or using a non-hw ALSA device such as "default" or "pulse".
     QString alsaHwDevice;
     int portAudioIndex;
 
@@ -210,10 +212,16 @@ class SoundDeviceId {
             return name + ", " + alsaHwDevice + ", " + QString::number(portAudioIndex);
         }
     }
-    SoundDeviceId() :
-        name(""), alsaHwDevice(""), portAudioIndex(-1) {};
+
+    SoundDeviceId()
+       : name(""),
+         alsaHwDevice(""),
+         portAudioIndex(-1) {};
 };
 
+// This must be registered with QMetaType::registerComparators for
+// QVariant::operator== to use it, which is required for QComboBox::findData to
+// work in DlgPrefSoundItem.
 inline bool operator==(const SoundDeviceId& lhs, const SoundDeviceId& rhs) {
     return lhs.name == rhs.name
             && lhs.alsaHwDevice == rhs.alsaHwDevice

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -203,8 +203,6 @@ class SoundDeviceId {
     QString alsaDeviceName;
     int portAudioIndex;
 
-    SoundDeviceId() : name(""), alsaDeviceName(""), portAudioIndex(-1) {};
-
     QString debugName() const {
         if (alsaDeviceName.isEmpty()) {
             return name + ", " + portAudioIndex;
@@ -212,6 +210,8 @@ class SoundDeviceId {
             return name + ", " + alsaDeviceName + ", " + QString::number(portAudioIndex);
         }
     }
+    SoundDeviceId() :
+        name(""), alsaDeviceName(""), portAudioIndex(-1) {};
 };
 
 inline bool operator==(const SoundDeviceId& lhs, const SoundDeviceId& rhs) {
@@ -229,6 +229,10 @@ Q_DECLARE_METATYPE(SoundDeviceId);
 
 inline unsigned int qHash(const SoundDeviceId& id) {
     return qHash(id.name) + qHash(id.alsaDeviceName) + id.portAudioIndex;
+}
+
+inline QDebug operator<<(QDebug dbg, const SoundDeviceId& soundDeviceId) {
+    return dbg << QString("SoundDeviceId(" + soundDeviceId.debugName() + ")");
 }
 
 // globals for QHash

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -197,6 +197,40 @@ public:
 
 typedef AudioPath::AudioPathType AudioPathType;
 
+class SoundDeviceId {
+  public:
+    QString name;
+    QString alsaDeviceName;
+    int portAudioIndex;
+
+    SoundDeviceId() : name(""), alsaDeviceName(""), portAudioIndex(-1) {};
+
+    QString debugName() const {
+        if (alsaDeviceName.isEmpty()) {
+            return name + ", " + portAudioIndex;
+        } else {
+            return name + ", " + alsaDeviceName + ", " + QString::number(portAudioIndex);
+        }
+    }
+};
+
+inline bool operator==(const SoundDeviceId& lhs, const SoundDeviceId& rhs) {
+    return lhs.name == rhs.name
+            && lhs.alsaDeviceName == rhs.alsaDeviceName
+            && lhs.portAudioIndex == rhs.portAudioIndex;
+}
+
+// There is not really a use case for this, but it is required for QMetaType::registerComparators.
+inline bool operator<(const SoundDeviceId& lhs, const SoundDeviceId& rhs) {
+    return lhs.portAudioIndex < rhs.portAudioIndex;
+}
+
+Q_DECLARE_METATYPE(SoundDeviceId);
+
+inline unsigned int qHash(const SoundDeviceId& id) {
+    return qHash(id.name) + qHash(id.alsaDeviceName) + id.portAudioIndex;
+}
+
 // globals for QHash
 unsigned int qHash(const ChannelGroup &group);
 unsigned int qHash(const AudioOutput &output);

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -214,9 +214,7 @@ class SoundDeviceId {
     }
 
     SoundDeviceId()
-       : name(""),
-         alsaHwDevice(""),
-         portAudioIndex(-1) {};
+       : portAudioIndex(-1) {}
 };
 
 // This must be registered with QMetaType::registerComparators for

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -200,23 +200,23 @@ typedef AudioPath::AudioPathType AudioPathType;
 class SoundDeviceId {
   public:
     QString name;
-    QString alsaDeviceName;
+    QString alsaHwDevice;
     int portAudioIndex;
 
     QString debugName() const {
-        if (alsaDeviceName.isEmpty()) {
+        if (alsaHwDevice.isEmpty()) {
             return name + ", " + portAudioIndex;
         } else {
-            return name + ", " + alsaDeviceName + ", " + QString::number(portAudioIndex);
+            return name + ", " + alsaHwDevice + ", " + QString::number(portAudioIndex);
         }
     }
     SoundDeviceId() :
-        name(""), alsaDeviceName(""), portAudioIndex(-1) {};
+        name(""), alsaHwDevice(""), portAudioIndex(-1) {};
 };
 
 inline bool operator==(const SoundDeviceId& lhs, const SoundDeviceId& rhs) {
     return lhs.name == rhs.name
-            && lhs.alsaDeviceName == rhs.alsaDeviceName
+            && lhs.alsaHwDevice == rhs.alsaHwDevice
             && lhs.portAudioIndex == rhs.portAudioIndex;
 }
 
@@ -228,7 +228,7 @@ inline bool operator<(const SoundDeviceId& lhs, const SoundDeviceId& rhs) {
 Q_DECLARE_METATYPE(SoundDeviceId);
 
 inline unsigned int qHash(const SoundDeviceId& id) {
-    return qHash(id.name) + qHash(id.alsaDeviceName) + id.portAudioIndex;
+    return qHash(id.name) + qHash(id.alsaHwDevice) + id.portAudioIndex;
 }
 
 inline QDebug operator<<(QDebug dbg, const SoundDeviceId& soundDeviceId) {


### PR DESCRIPTION
PortAudio provides no guarantees that the PaDeviceIndex for any device will be stable across restarts of Mixxx. Abusing the PaDeviceIndex as a persistent identifier caused Mixxx to falsely claim that audio interfaces were not available and annoyingly require the user to reconfigure all their sound I/O even when nothing about the available sound hardware actually changed. It is the responsibility of the sound API to provide persistent names for devices to PortAudio.

I have tested this with JACK and ALSA and it works as I expect.