### PR TITLE
Fix inconsistent handling of empty index ranges and edge cases

### DIFF
--- a/src/test/indexrange_test.cpp
+++ b/src/test/indexrange_test.cpp
@@ -168,11 +168,15 @@ TEST_F(IndexRangeTest, equal) {
     EXPECT_FALSE(IndexRange::backward(-1, 3) != IndexRange::between(-1, -4));
     EXPECT_FALSE(IndexRange::between(-1, 3) == reverse(IndexRange::between(-1, 3)));
     EXPECT_TRUE(IndexRange::between(-1, 3) != reverse(IndexRange::between(-1, 3)));
+    EXPECT_FALSE(IndexRange::between(0, 0) == IndexRange::between(1, 1));
+    EXPECT_TRUE(IndexRange::between(0, 0) != IndexRange::between(1, 1));
 }
 
 TEST_F(IndexRangeTest, lessOrEqual) {
-    EXPECT_TRUE(IndexRange() <= IndexRange::between(-2, 2));
-    EXPECT_TRUE(IndexRange() <= IndexRange::between(2, -1));
+    EXPECT_FALSE(IndexRange::between(3, 3) <= IndexRange::between(-2, 2));
+    EXPECT_TRUE(IndexRange::between(0, 0) <= IndexRange::between(2, -1));
+    EXPECT_TRUE(IndexRange::between(2, 2) <= IndexRange::between(2, -1));
+    EXPECT_FALSE(IndexRange::between(-2, -2) <= IndexRange::between(2, -1));
     EXPECT_TRUE(IndexRange::between(-2, 1) <= IndexRange::between(-2, 2));
     EXPECT_TRUE(IndexRange::between(1, -2) <= IndexRange::between(2, -2));
     EXPECT_FALSE(IndexRange::between(-2, 1) <= IndexRange::between(-1, 2));
@@ -180,8 +184,10 @@ TEST_F(IndexRangeTest, lessOrEqual) {
     EXPECT_FALSE(IndexRange::between(-2, 1) <= IndexRange::between(0, 1));
     EXPECT_FALSE(IndexRange::between(-2, 1) <= IndexRange::between(1, 2));
     EXPECT_FALSE(IndexRange::between(-2, 1) <= IndexRange::between(1, 1));
-    EXPECT_TRUE(IndexRange::between(3, 3) <= IndexRange::between(-2, 1));
-    EXPECT_TRUE(IndexRange::between(3, 3) <= IndexRange::between(1, -2));
+    EXPECT_FALSE(IndexRange::between(3, 3) <= IndexRange::between(-2, 1));
+    EXPECT_FALSE(IndexRange::between(3, 3) <= IndexRange::between(1, -2));
+    EXPECT_TRUE(IndexRange::between(1, 1) <= IndexRange::between(-2, 1));
+    EXPECT_TRUE(IndexRange::between(1, 1) <= IndexRange::between(1, -2));
 }
 
 TEST_F(IndexRangeTest, greaterOrEqual) {
@@ -192,8 +198,10 @@ TEST_F(IndexRangeTest, greaterOrEqual) {
     EXPECT_FALSE(IndexRange::between(0, 1) >= IndexRange::between(-2, 1));
     EXPECT_FALSE(IndexRange::between(1, 2) >= IndexRange::between(-2, 1));
     EXPECT_FALSE(IndexRange::between(1, 1) >= IndexRange::between(-2, 1));
-    EXPECT_TRUE(IndexRange::between(-2, 1) >= IndexRange::between(3, 3));
-    EXPECT_TRUE(IndexRange::between(1, -2) >= IndexRange::between(3, 3));
+    EXPECT_FALSE(IndexRange::between(-2, 1) >= IndexRange::between(3, 3));
+    EXPECT_FALSE(IndexRange::between(1, -2) >= IndexRange::between(3, 3));
+    EXPECT_TRUE(IndexRange::between(-2, 1) >= IndexRange::between(1, 1));
+    EXPECT_TRUE(IndexRange::between(1, -2) >= IndexRange::between(1, 1));
 }
 
 TEST_F(IndexRangeTest, reverse) {
@@ -213,6 +221,14 @@ TEST_F(IndexRangeTest, intersect) {
     EXPECT_EQ(IndexRange::between(1, -1), intersect(IndexRange::between(1, -1), IndexRange::between(1, -1)));
     EXPECT_EQ(IndexRange::between(1, -1), intersect(IndexRange::between(2, -1), IndexRange::between(1, -2)));
     EXPECT_TRUE(intersect(IndexRange::between(-1, -2), IndexRange::between(2, 1)).empty());
+    EXPECT_EQ(IndexRange(), intersect(IndexRange::between(1, 2), IndexRange::between(3, 4)));
+    EXPECT_EQ(IndexRange(), intersect(IndexRange::between(-1, -2), IndexRange::between(-3, -4)));
+    EXPECT_EQ(IndexRange(), intersect(IndexRange(), IndexRange::between(1, 2)));
+    EXPECT_EQ(IndexRange(), intersect(IndexRange(), IndexRange::between(-1, -2)));
+    EXPECT_EQ(IndexRange::between(1, 1), intersect(IndexRange::between(1, 1), IndexRange::between(1, 1)));
+    EXPECT_EQ(IndexRange::between(-1, -1), intersect(IndexRange::between(-1, -1), IndexRange::between(-1, -1)));
+    EXPECT_EQ(IndexRange::between(1, 1), intersect(IndexRange::between(0, 1), IndexRange::between(1, 1)));
+    EXPECT_EQ(IndexRange::between(-1, -1), intersect(IndexRange::between(0, -1), IndexRange::between(-1, -1)));
 }
 
 TEST_F(IndexRangeTest, span) {
@@ -224,7 +240,14 @@ TEST_F(IndexRangeTest, span) {
     EXPECT_EQ(IndexRange::between(1, -1), span(IndexRange::between(1, -1), IndexRange::between(1, -1)));
     EXPECT_EQ(IndexRange::between(2, -2), span(IndexRange::between(1, -2), IndexRange::between(2, -1)));
     EXPECT_EQ(IndexRange::between(2, -2), span(IndexRange::between(-1, -2), IndexRange::between(2, 1)));
+    EXPECT_EQ(IndexRange::between(-1, 1), span(IndexRange::between(-1, 1), IndexRange::between(0, 0)));
+    EXPECT_EQ(IndexRange::between(-1, 1), span(IndexRange::between(0, 0), IndexRange::between(-1, 1)));
+    EXPECT_EQ(IndexRange::between(-1, 1), span(IndexRange::between(-1, 1), IndexRange::between(1, 1)));
+    EXPECT_EQ(IndexRange::between(-1, 1), span(IndexRange::between(1, 1), IndexRange::between(-1, 1)));
+    EXPECT_EQ(IndexRange::between(-1, 1), span(IndexRange::between(-1, 1), IndexRange::between(-1, -1)));
+    EXPECT_EQ(IndexRange::between(-1, 1), span(IndexRange::between(-1, -1), IndexRange::between(-1, 1)));
+    EXPECT_EQ(IndexRange::between(3, -1), span(IndexRange::between(1, -1), IndexRange::between(3, 3)));
+    EXPECT_EQ(IndexRange::between(1, -3), span(IndexRange::between(-3, -3), IndexRange::between(1, -1)));
 }
-
 
 } // namespace mixxx

--- a/src/util/indexrange.cpp
+++ b/src/util/indexrange.cpp
@@ -78,18 +78,18 @@ IndexRange intersect(IndexRange lhs, IndexRange rhs) {
             return IndexRange();
         }
     } else {
+        // Single point = empty range
+        DEBUG_ASSERT(lhs.empty());
         DEBUG_ASSERT(lhs.start() == lhs.end());
+        // Check if this point is located within the other range
+        // and then return it
         if (rhs.start() <= rhs.end()) {
-            const SINT start = std::max(lhs.start(), rhs.start());
-            const SINT end = std::min(lhs.end(), rhs.end());
-            if (start <= end) {
-                return IndexRange::between(start, end);
+            if (lhs.start() >= rhs.start() && lhs.end() <= rhs.end()) {
+                return lhs;
             }
         } else {
-            const SINT start = std::min(lhs.start(), rhs.start());
-            const SINT end = std::max(lhs.end(), rhs.end());
-            if (start >= end) {
-                return IndexRange::between(start, end);
+            if (lhs.start() <= rhs.start() && lhs.end() >= rhs.end()) {
+                return lhs;
             }
         }
     }
@@ -119,6 +119,8 @@ IndexRange span(IndexRange lhs, IndexRange rhs) {
             return IndexRange();
         }
     } else {
+        // Single point = empty range
+        DEBUG_ASSERT(lhs.empty());
         DEBUG_ASSERT(lhs.start() == lhs.end());
         if (rhs.start() <= rhs.end()) {
             const SINT start = std::min(lhs.start(), rhs.start());

--- a/src/util/indexrange.cpp
+++ b/src/util/indexrange.cpp
@@ -55,7 +55,7 @@ IndexRange reverse(IndexRange arg) {
 }
 
 IndexRange intersect(IndexRange lhs, IndexRange rhs) {
-    if (lhs.start() <= lhs.end()) {
+    if (lhs.start() < lhs.end()) {
         if (rhs.start() <= rhs.end()) {
             const SINT start = std::max(lhs.start(), rhs.start());
             const SINT end = std::min(lhs.end(), rhs.end());
@@ -63,9 +63,10 @@ IndexRange intersect(IndexRange lhs, IndexRange rhs) {
                 return IndexRange::between(start, end);
             }
         } else {
-            DEBUG_ASSERT(!"Cannot intersect index ranges with contrary orientations");
+            DEBUG_ASSERT(!"Cannot intersect index ranges with different orientations");
+            return IndexRange();
         }
-    } else {
+    } else if (lhs.start() > lhs.end()) {
         if (rhs.start() >= rhs.end()) {
             const SINT start = std::min(lhs.start(), rhs.start());
             const SINT end = std::max(lhs.end(), rhs.end());
@@ -73,33 +74,64 @@ IndexRange intersect(IndexRange lhs, IndexRange rhs) {
                 return IndexRange::between(start, end);
             }
         } else {
-            DEBUG_ASSERT(!"Cannot intersect index ranges with contrary orientations");
+            DEBUG_ASSERT(!"Cannot intersect index ranges with different orientations");
+            return IndexRange();
+        }
+    } else {
+        DEBUG_ASSERT(lhs.start() == lhs.end());
+        if (rhs.start() <= rhs.end()) {
+            const SINT start = std::max(lhs.start(), rhs.start());
+            const SINT end = std::min(lhs.end(), rhs.end());
+            if (start <= end) {
+                return IndexRange::between(start, end);
+            }
+        } else {
+            const SINT start = std::min(lhs.start(), rhs.start());
+            const SINT end = std::max(lhs.end(), rhs.end());
+            if (start >= end) {
+                return IndexRange::between(start, end);
+            }
         }
     }
+    // disconnected
     return IndexRange();
 }
 
 IndexRange span(IndexRange lhs, IndexRange rhs) {
-    if (lhs.start() <= lhs.end()) {
+    if (lhs.start() < lhs.end()) {
         if (rhs.start() <= rhs.end()) {
             const SINT start = std::min(lhs.start(), rhs.start());
             const SINT end = std::max(lhs.end(), rhs.end());
             DEBUG_ASSERT(start <= end);
             return IndexRange::between(start, end);
         } else {
-            DEBUG_ASSERT(!"Cannot span index ranges with contrary orientations");
+            DEBUG_ASSERT(!"Cannot span index ranges with different orientations");
+            return IndexRange();
         }
-    } else {
+    } else if (lhs.start() > lhs.end()) {
         if (rhs.start() >= rhs.end()) {
             const SINT start = std::max(lhs.start(), rhs.start());
             const SINT end = std::min(lhs.end(), rhs.end());
             DEBUG_ASSERT(start >= end);
             return IndexRange::between(start, end);
         } else {
-            DEBUG_ASSERT(!"Cannot span index ranges with contrary orientations");
+            DEBUG_ASSERT(!"Cannot span index ranges with different orientations");
+            return IndexRange();
+        }
+    } else {
+        DEBUG_ASSERT(lhs.start() == lhs.end());
+        if (rhs.start() <= rhs.end()) {
+            const SINT start = std::min(lhs.start(), rhs.start());
+            const SINT end = std::max(lhs.end(), rhs.end());
+            DEBUG_ASSERT(start <= end);
+            return IndexRange::between(start, end);
+        } else {
+            const SINT start = std::max(lhs.start(), rhs.start());
+            const SINT end = std::min(lhs.end(), rhs.end());
+            DEBUG_ASSERT(start >= end);
+            return IndexRange::between(start, end);
         }
     }
-    return IndexRange();
 }
 
 std::ostream& operator<<(std::ostream& os, IndexRange arg) {

--- a/src/util/indexrange.h
+++ b/src/util/indexrange.h
@@ -166,7 +166,7 @@ bool operator!=(IndexRange lhs, IndexRange rhs) {
 
 inline
 bool operator<=(IndexRange lhs, IndexRange rhs) {
-    return lhs.empty() || (intersect(lhs, rhs) == lhs);
+    return intersect(lhs, rhs) == lhs;
 }
 
 inline


### PR DESCRIPTION
While fixing another bug I noticed some inconsistencies when handling empty index ranges and when calculating the _intersection_ or _span_ if one or both of the arguments are empty (= single point).

Those edge cases doesn't seem to occur for any of our use cases, but nevertheless fixing them is recommended. New tests cover those edge cases now. Exhaustive testing is inevitable here!!

Also affects 2.2, but I'm afraid to touch foundational code. Better rely on extensive alpha/beta testing.