### PR TITLE
Fix ``beatjump`` keyboard mapping controls not working reliable. This…

### DIFF
--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -73,9 +73,7 @@ reloop_andstop Shift+4
 beatloop_activate q
 beatlooproll_activate Shift+q
 loop_halve w
-beatjump_forward Shift+w
 loop_double e
-beatjump_backward Shift+e
 
 passthrough Ctrl+j
 vinylcontrol_mode Ctrl+Shift+Z
@@ -129,9 +127,7 @@ reloop_andstop Shift+9
 beatloop_activate u
 beatlooproll_activate Shift+u
 loop_halve i
-beatjump_forward Shift+i
 loop_double o
-beatjump_backward Shift+o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/da_DK.kbd.cfg
+++ b/res/keyboard/da_DK.kbd.cfg
@@ -73,9 +73,7 @@ reloop_andstop Shift+$
 beatloop_activate q
 beatlooproll_activate Shift+q
 loop_halve w
-beatjump_forward Shift+w
 loop_double e
-beatjump_backward Shift+e
 
 passthrough Ctrl+j
 vinylcontrol_mode Ctrl+Shift+Y
@@ -129,9 +127,7 @@ reloop_andstop Shift+)
 beatloop_activate u
 beatlooproll_activate Shift+u
 loop_halve i
-beatjump_forward Shift+i
 loop_double o
-beatjump_backward Shift+o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/de_CH.kbd.cfg
+++ b/res/keyboard/de_CH.kbd.cfg
@@ -73,9 +73,7 @@ reloop_andstop Shift+ç
 beatloop_activate q
 beatlooproll_activate Shift+q
 loop_halve w
-beatjump_forward Shift+w
 loop_double e
-beatjump_backward Shift+e
 
 passthrough Ctrl+j
 vinylcontrol_mode Ctrl+Shift+Z
@@ -129,9 +127,7 @@ reloop_andstop Shift+)
 beatloop_activate u
 beatlooproll_activate Shift+u
 loop_halve i
-beatjump_forward Shift+i
 loop_double o
-beatjump_backward Shift+o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/de_DE.kbd.cfg
+++ b/res/keyboard/de_DE.kbd.cfg
@@ -73,9 +73,7 @@ reloop_andstop Shift+$
 beatloop_activate q
 beatlooproll_activate Shift+q
 loop_halve w
-beatjump_forward Shift+w
 loop_double e
-beatjump_backward Shift+e
 
 passthrough Ctrl+j
 vinylcontrol_mode Ctrl+Shift+Z
@@ -129,9 +127,7 @@ reloop_andstop Shift+)
 beatloop_activate u
 beatlooproll_activate Shift+u
 loop_halve i
-beatjump_forward Shift+i
 loop_double o
-beatjump_backward Shift+o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/el_GR.kbd.cfg
+++ b/res/keyboard/el_GR.kbd.cfg
@@ -73,9 +73,7 @@ reloop_andstop Shift+$
 beatloop_activate ;
 beatlooproll_activate Shift+:
 loop_halve ς
-beatjump_forward Shift+΅
 loop_double ε
-beatjump_backward Shift+Ε
 
 passthrough Ctrl+ξ
 vinylcontrol_mode Ctrl+Shift+Υ
@@ -133,9 +131,7 @@ reloop_andstop Shift+(
 beatloop_activate θ
 beatlooproll_activate Shift+Θ
 loop_halve ι
-beatjump_forward Shift+Ι
 loop_double ο
-beatjump_backward Shift+Ο
 
 passthrough Ctrl+κ
 vinylcontrol_mode Ctrl+Shift+Θ

--- a/res/keyboard/en_US.kbd.cfg
+++ b/res/keyboard/en_US.kbd.cfg
@@ -73,9 +73,7 @@ reloop_andstop Shift+$
 beatloop_activate q
 beatlooproll_activate Shift+q
 loop_halve w
-beatjump_forward Shift+w
 loop_double e
-beatjump_backward Shift+e
 
 passthrough Ctrl+j
 vinylcontrol_mode Ctrl+Shift+Y
@@ -129,9 +127,7 @@ reloop_andstop Shift+(
 beatloop_activate u
 beatlooproll_activate Shift+u
 loop_halve i
-beatjump_forward Shift+i
 loop_double o
-beatjump_backward Shift+o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/es_ES.kbd.cfg
+++ b/res/keyboard/es_ES.kbd.cfg
@@ -73,9 +73,7 @@ reloop_andstop Shift+$
 beatloop_activate q
 beatlooproll_activate Shift+q
 loop_halve w
-beatjump_forward Shift+w
 loop_double e
-beatjump_backward Shift+e
 
 passthrough Ctrl+j
 vinylcontrol_mode Ctrl+Shift+Y
@@ -129,9 +127,7 @@ reloop_andstop Shift+(
 beatloop_activate u
 beatlooproll_activate Shift+u
 loop_halve i
-beatjump_forward Shift+i
 loop_double o
-beatjump_backward Shift+o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/fi_FI.kbd.cfg
+++ b/res/keyboard/fi_FI.kbd.cfg
@@ -73,9 +73,7 @@ reloop_andstop Shift+€
 beatloop_activate q
 beatlooproll_activate Shift+q
 loop_halve w
-beatjump_forward Shift+w
 loop_double e
-beatjump_backward Shift+e
 
 passthrough Ctrl+j
 vinylcontrol_mode Ctrl+Shift+Y
@@ -129,9 +127,7 @@ reloop_andstop Shift+)
 beatloop_activate u
 beatlooproll_activate Shift+u
 loop_halve i
-beatjump_forward Shift+i
 loop_double o
-beatjump_backward Shift+o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/fr_CH.kbd.cfg
+++ b/res/keyboard/fr_CH.kbd.cfg
@@ -73,9 +73,7 @@ reloop_andstop Shift+ç
 beatloop_activate q
 beatlooproll_activate Shift+q
 loop_halve w
-beatjump_forward Shift+w
 loop_double e
-beatjump_backward Shift+e
 
 passthrough Ctrl+j
 vinylcontrol_mode Ctrl+Shift+Z
@@ -129,9 +127,7 @@ reloop_andstop Shift+)
 beatloop_activate u
 beatlooproll_activate Shift+u
 loop_halve i
-beatjump_forward Shift+i
 loop_double o
-beatjump_backward Shift+o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -73,9 +73,7 @@ reloop_andstop Shift+4
 beatloop_activate a
 beatlooproll_activate Shift+A
 loop_halve z
-beatjump_forward Shift+Z
 loop_double e
-beatjump_backward Shift+E
 
 passthrough Ctrl+j
 vinylcontrol_mode Ctrl+Shift+Y
@@ -129,9 +127,7 @@ reloop_andstop Shift+9
 beatloop_activate u
 beatlooproll_activate Shift+u
 loop_halve i
-beatjump_forward Shift+i
 loop_double o
-beatjump_backward Shift+o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/it_IT.kbd.cfg
+++ b/res/keyboard/it_IT.kbd.cfg
@@ -73,9 +73,7 @@ reloop_andstop Shift+$
 beatloop_activate q
 beatlooproll_activate Shift+q
 loop_halve w
-beatjump_forward Shift+w
 loop_double e
-beatjump_backward Shift+e
 
 passthrough Ctrl+j
 vinylcontrol_mode Ctrl+Shift+Y
@@ -129,9 +127,7 @@ reloop_andstop Shift+)
 beatloop_activate u
 beatlooproll_activate Shift+u
 loop_halve i
-beatjump_forward Shift+i
 loop_double o
-beatjump_backward Shift+o
 
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U

--- a/res/keyboard/ru_RU.kbd.cfg
+++ b/res/keyboard/ru_RU.kbd.cfg
@@ -73,9 +73,7 @@ reloop_andstop Shift+%
 beatloop_activate й
 beatlooproll_activate Shift+Й
 loop_halve ц
-beatjump_forward Shift+Ц
 loop_double у
-beatjump_backward Shift+У
 
 passthrough Ctrl+о
 vinylcontrol_mode Ctrl+Shift+Н
@@ -129,9 +127,7 @@ reloop_andstop Shift+(
 beatloop_activate г
 beatlooproll_activate Shift+Г
 loop_halve ш
-beatjump_forward Shift+Ш
 loop_double щ
-beatjump_backward Shift+Щ
 
 passthrough Ctrl+л
 vinylcontrol_mode Ctrl+Shift+Г


### PR DESCRIPTION
… was due to double entries for beatjump controls, that slipped in in a previous commit.

https://bugs.launchpad.net/mixxx/+bug/1837554

Follow-up to #1950

This slipped in by accident. Originally my ( unsuccessful ) attempt was to assign ``beatjump_size``to the now deleted controls. If you come up with an idea to map ``beatjump_size`` , so we can scale the size up/down similar to ``loop_halve``or ``loop_double``, it would be nice to have.