### PR TITLE
Enable (lib)modplug support on macOS by default

### DIFF
--- a/build/features.py
+++ b/build/features.py
@@ -442,7 +442,7 @@ class ModPlug(Feature):
         return "Modplug module decoder plugin"
 
     def default(self, build):
-        return 1 if build.platform_is_linux else 0
+        return 1 if build.platform_is_linux or build.platform_is_osx else 0
 
     def enabled(self, build):
         build.flags['modplug'] = util.get_flags(build.env, 'modplug', self.default(build))


### PR DESCRIPTION
follow up to #2244

Successfully builds locally with ``macOS 10.14.5 (18F203)``, anything to do about the build server? 
For master, Travis installs``libmodplug`` by [default](https://github.com/mixxxdj/mixxx/blob/master/.travis.yml#L69) .