### PR TITLE
Increase priority of reference decoders from DEFAULT to HIGHER

### DIFF
--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -547,4 +547,11 @@ QStringList SoundSourceProviderFLAC::getSupportedFileExtensions() const {
     return supportedFileExtensions;
 }
 
+SoundSourceProviderPriority SoundSourceProviderFLAC::getPriorityHint(
+        const QString& /*supportedFileExtension*/) const {
+    // This reference decoder is supposed to produce more accurate
+    // and reliable results than any other DEFAULT provider.
+    return SoundSourceProviderPriority::HIGHER;
+}
+
 } // namespace mixxx

--- a/src/sources/soundsourceflac.h
+++ b/src/sources/soundsourceflac.h
@@ -64,6 +64,9 @@ class SoundSourceProviderFLAC : public SoundSourceProvider {
 
     QStringList getSupportedFileExtensions() const override;
 
+    SoundSourceProviderPriority getPriorityHint(
+            const QString& supportedFileExtension) const override;
+
     SoundSourcePointer newSoundSource(const QUrl& url) override {
         return newSoundSourceFromUrl<SoundSourceFLAC>(url);
     }

--- a/src/sources/soundsourceoggvorbis.cpp
+++ b/src/sources/soundsourceoggvorbis.cpp
@@ -254,4 +254,11 @@ QStringList SoundSourceProviderOggVorbis::getSupportedFileExtensions() const {
     return supportedFileExtensions;
 }
 
+SoundSourceProviderPriority SoundSourceProviderOggVorbis::getPriorityHint(
+        const QString& /*supportedFileExtension*/) const {
+    // This reference decoder is supposed to produce more accurate
+    // and reliable results than any other DEFAULT provider.
+    return SoundSourceProviderPriority::HIGHER;
+}
+
 } // namespace mixxx

--- a/src/sources/soundsourceoggvorbis.h
+++ b/src/sources/soundsourceoggvorbis.h
@@ -46,6 +46,9 @@ class SoundSourceProviderOggVorbis : public SoundSourceProvider {
 
     QStringList getSupportedFileExtensions() const override;
 
+    SoundSourceProviderPriority getPriorityHint(
+            const QString& supportedFileExtension) const override;
+
     SoundSourcePointer newSoundSource(const QUrl &url) override {
         return newSoundSourceFromUrl<SoundSourceOggVorbis>(url);
     }

--- a/src/sources/soundsourceopus.cpp
+++ b/src/sources/soundsourceopus.cpp
@@ -379,4 +379,11 @@ QStringList SoundSourceProviderOpus::getSupportedFileExtensions() const {
     return supportedFileExtensions;
 }
 
+SoundSourceProviderPriority SoundSourceProviderOpus::getPriorityHint(
+        const QString& /*supportedFileExtension*/) const {
+    // This reference decoder is supposed to produce more accurate
+    // and reliable results than any other DEFAULT provider.
+    return SoundSourceProviderPriority::HIGHER;
+}
+
 } // namespace mixxx

--- a/src/sources/soundsourceopus.h
+++ b/src/sources/soundsourceopus.h
@@ -53,6 +53,9 @@ class SoundSourceProviderOpus : public SoundSourceProvider {
 
     QStringList getSupportedFileExtensions() const override;
 
+    SoundSourceProviderPriority getPriorityHint(
+            const QString& supportedFileExtension) const override;
+
     SoundSourcePointer newSoundSource(const QUrl& url) override {
         return newSoundSourceFromUrl<SoundSourceOpus>(url);
     }

--- a/src/sources/soundsourcewv.cpp
+++ b/src/sources/soundsourcewv.cpp
@@ -160,16 +160,6 @@ QString SoundSourceProviderWV::getName() const {
     return "WavPack";
 }
 
-QStringList SoundSourceProviderWV::getSupportedFileExtensions() const {
-    QStringList supportedFileExtensions;
-    supportedFileExtensions.append("wv");
-    return supportedFileExtensions;
-}
-
-SoundSourcePointer SoundSourceProviderWV::newSoundSource(const QUrl& url) {
-    return newSoundSourceFromUrl<SoundSourceWV>(url);
-}
-
 //static
 int32_t SoundSourceWV::ReadBytesCallback(void* id, void* data, int bcount) {
     QFile* pFile = static_cast<QFile*>(id);
@@ -251,6 +241,23 @@ int32_t SoundSourceWV::WriteBytesCallback(void* id, void* data, int32_t bcount) 
         return 0;
     }
     return (int32_t)pFile->write((char*)data, bcount);
+}
+
+QStringList SoundSourceProviderWV::getSupportedFileExtensions() const {
+    QStringList supportedFileExtensions;
+    supportedFileExtensions.append("wv");
+    return supportedFileExtensions;
+}
+
+SoundSourceProviderPriority SoundSourceProviderWV::getPriorityHint(
+        const QString& /*supportedFileExtension*/) const {
+    // This reference decoder is supposed to produce more accurate
+    // and reliable results than any other DEFAULT provider.
+    return SoundSourceProviderPriority::HIGHER;
+}
+
+SoundSourcePointer SoundSourceProviderWV::newSoundSource(const QUrl& url) {
+    return newSoundSourceFromUrl<SoundSourceWV>(url);
 }
 
 } // namespace mixxx

--- a/src/sources/soundsourcewv.h
+++ b/src/sources/soundsourcewv.h
@@ -49,6 +49,9 @@ class SoundSourceProviderWV : public SoundSourceProvider {
 
     QStringList getSupportedFileExtensions() const override;
 
+    SoundSourceProviderPriority getPriorityHint(
+            const QString& supportedFileExtension) const override;
+
     SoundSourcePointer newSoundSource(const QUrl& url) override;
 };
 


### PR DESCRIPTION
Ensure that the reference decoders for FLAC/OGG/OPUS get a higher priority than the default. This documents our assumption that these are considered more trustworthy than any other 3rd party implementation, unless we come to a different conclusion.

Effectively no changes at runtime, but now those previously implicit assumptions are documented.