### PR TITLE
set NoFocus policy to Preview button to keep table focus border

### DIFF
--- a/src/library/previewbuttondelegate.cpp
+++ b/src/library/previewbuttondelegate.cpp
@@ -48,8 +48,9 @@ QWidget* PreviewButtonDelegate::createEditor(QWidget* parent,
     btn->setCheckable(true);
     // Prevent being focused by Tab key or emulated Tab sent by library controls
     // Avoids a Tab loop caused by setLibraryFocus() when the mouse pointer
-    // is above the button: Prev.btn > Table > Prev.btn > ...
-    btn->setFocusPolicy(Qt::ClickFocus);
+    // is above the button (Prev.btn > Table > Prev.btn > ...) and also
+    // keeps the table focus border when the hovered button's row is selected
+    btn->setFocusPolicy(Qt::NoFocus);
     bool playing = m_pPreviewDeckPlay->toBool();
     // Check-state is whether the track is loaded (index.data()) and whether
     // it's playing.


### PR DESCRIPTION
continuation of #2251 

with `ClickFocus` the  tab loop is prevented, but in some library features the tracks table border focus border would disappear when the line with a hovered Preview button is selected with keyboard or controller.

`NoFocus` this is avoided and also the ugly OS focus style doesn't appear anymore.