### PR TITLE
lp1842679: Fix caching of audio data

### DIFF
--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -28,8 +28,14 @@ const SINT kDefaultHintFrames = 1024;
 // version 2.2.2 for doesn't seem to be sufficient to prevent running
 // out of free chunks. Therefore we increased the number of cached
 // chunks to 256:
+//
 //     80 chunks ->  5120 KB =  5 MB
 //    256 chunks -> 16384 KB = 16 MB
+//
+// NOTE(uklotzde, 2019-09-05): Reduce this number to just few chunks
+// (kNumberOfCachedChunksInMemory = 1, 2, 3, ...) for testing purposes
+// to verify that the MRU/LRU cache works as expected. Even though
+// massive drop outs are expected to occur Mixxx should run reliably!
 const SINT kNumberOfCachedChunksInMemory = 256;
 
 } // anonymous namespace

--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -130,7 +130,6 @@ CachingReaderChunkForOwner* CachingReader::allocateChunk(SINT chunkIndex) {
     CachingReaderChunkForOwner* pChunk = m_freeChunks.takeFirst();
     pChunk->init(chunkIndex);
 
-    //kLogger.debug() << "Allocating chunk" << pChunk << pChunk->getIndex();
     m_allocatedCachingReaderChunks.insert(chunkIndex, pChunk);
 
     return pChunk;
@@ -237,9 +236,10 @@ CachingReader::ReadResult CachingReader::read(SINT startSample, SINT numSamples,
             // Refuse to read from an invalid number of samples
             (numSamples % CachingReaderChunk::kChannels == 0) && (numSamples >= 0)) {
         kLogger.critical()
-                << "read() invalid arguments:"
+                << "Invalid arguments for read():"
                 << "startSample =" << startSample
-                << "numSamples =" << numSamples;
+                << "numSamples =" << numSamples
+                << "reverse =" << reverse;
         return ReadResult::UNAVAILABLE;
     }
     VERIFY_OR_DEBUG_ASSERT(buffer) {
@@ -290,10 +290,12 @@ CachingReader::ReadResult CachingReader::read(SINT startSample, SINT numSamples,
                             remainingFrameIndexRange.start(),
                             m_readableFrameIndexRange.start());
             DEBUG_ASSERT(prerollFrameIndexRange.length() <= remainingFrameIndexRange.length());
-            kLogger.debug()
-                    << "Prepending"
-                    << prerollFrameIndexRange.length()
-                    << "frames of silence";
+            if (kLogger.traceEnabled()) {
+                kLogger.trace()
+                        << "Prepending"
+                        << prerollFrameIndexRange.length()
+                        << "frames of silence";
+            }
             const SINT prerollFrames = prerollFrameIndexRange.length();
             const SINT prerollSamples = CachingReaderChunk::frames2samples(prerollFrames);
             DEBUG_ASSERT(samplesRemaining >= prerollSamples);

--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -23,20 +23,19 @@ const SINT kDefaultHintFrames = 1024;
 // With CachingReaderChunk::kFrames = 8192 each chunk consumes
 // 8192 frames * 2 channels/frame * 4-bytes per sample = 65 kB.
 //
-// NOTE(2019-09-04): https://bugs.launchpad.net/mixxx/+bug/1842679
-// According to the linked bug report reserving only 80 chunks in
-// version 2.2.2 for doesn't seem to be sufficient to prevent running
-// out of free chunks. Therefore we increased the number of cached
-// chunks to 256:
-//
 //     80 chunks ->  5120 KB =  5 MB
-//    256 chunks -> 16384 KB = 16 MB
+//
+// Each deck (including sample decks) will use their own CachingReader.
+// Consequently the total memory required for all allocated chunks depends
+// on the number of decks. The amount of memory reserved for a single
+// CachingReader must be multiplied by the number of decks to calculate
+// the total amount!
 //
 // NOTE(uklotzde, 2019-09-05): Reduce this number to just few chunks
 // (kNumberOfCachedChunksInMemory = 1, 2, 3, ...) for testing purposes
 // to verify that the MRU/LRU cache works as expected. Even though
 // massive drop outs are expected to occur Mixxx should run reliably!
-const SINT kNumberOfCachedChunksInMemory = 256;
+const SINT kNumberOfCachedChunksInMemory = 80;
 
 } // anonymous namespace
 

--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -80,8 +80,16 @@ CachingReader::~CachingReader() {
     qDeleteAll(m_chunks);
 }
 
+void CachingReader::freeChunkFromList(CachingReaderChunkForOwner* pChunk) {
+    pChunk->removeFromList(
+            &m_mruCachingReaderChunk,
+            &m_lruCachingReaderChunk);
+    pChunk->free();
+    m_freeChunks.push_back(pChunk);
+}
+
 void CachingReader::freeChunk(CachingReaderChunkForOwner* pChunk) {
-    DEBUG_ASSERT(pChunk != nullptr);
+    DEBUG_ASSERT(pChunk);
     DEBUG_ASSERT(pChunk->getState() != CachingReaderChunkForOwner::READ_PENDING);
 
     const int removed = m_allocatedCachingReaderChunks.remove(pChunk->getIndex());
@@ -89,10 +97,7 @@ void CachingReader::freeChunk(CachingReaderChunkForOwner* pChunk) {
     // because sometime you free a chunk right after you allocated it.
     DEBUG_ASSERT(removed <= 1);
 
-    pChunk->removeFromList(
-            &m_mruCachingReaderChunk, &m_lruCachingReaderChunk);
-    pChunk->free();
-    m_freeChunks.push_back(pChunk);
+    freeChunkFromList(pChunk);
 }
 
 void CachingReader::freeAllChunks() {
@@ -104,15 +109,13 @@ void CachingReader::freeAllChunks() {
         }
 
         if (pChunk->getState() != CachingReaderChunkForOwner::FREE) {
-            pChunk->removeFromList(
-                    &m_mruCachingReaderChunk, &m_lruCachingReaderChunk);
-            pChunk->free();
-            m_freeChunks.push_back(pChunk);
+            freeChunkFromList(pChunk);
         }
     }
+    DEBUG_ASSERT(!m_mruCachingReaderChunk);
+    DEBUG_ASSERT(!m_lruCachingReaderChunk);
 
     m_allocatedCachingReaderChunks.clear();
-    m_mruCachingReaderChunk = nullptr;
 }
 
 CachingReaderChunkForOwner* CachingReader::allocateChunk(SINT chunkIndex) {
@@ -129,55 +132,53 @@ CachingReaderChunkForOwner* CachingReader::allocateChunk(SINT chunkIndex) {
 }
 
 CachingReaderChunkForOwner* CachingReader::allocateChunkExpireLRU(SINT chunkIndex) {
-    CachingReaderChunkForOwner* pChunk = allocateChunk(chunkIndex);
+    auto pChunk = allocateChunk(chunkIndex);
     if (!pChunk) {
-        if (m_lruCachingReaderChunk == nullptr) {
-            kLogger.warning() << "ERROR: No LRU chunk to free in allocateChunkExpireLRU.";
-            return nullptr;
+        if (m_lruCachingReaderChunk) {
+            freeChunk(m_lruCachingReaderChunk);
+            pChunk = allocateChunk(chunkIndex);
+        } else {
+            kLogger.warning() << "No cached LRU chunk available for freeing";
         }
-        freeChunk(m_lruCachingReaderChunk);
-        pChunk = allocateChunk(chunkIndex);
     }
-    //kLogger.debug() << "allocateChunkExpireLRU" << chunk << pChunk;
+    if (kLogger.traceEnabled()) {
+        kLogger.trace() << "allocateChunkExpireLRU" << chunkIndex << pChunk;
+    }
     return pChunk;
 }
 
 CachingReaderChunkForOwner* CachingReader::lookupChunk(SINT chunkIndex) {
     // Defaults to nullptr if it's not in the hash.
-    CachingReaderChunkForOwner* chunk = m_allocatedCachingReaderChunks.value(chunkIndex, nullptr);
-
-    // Make sure the allocated number matches the indexed chunk number.
-    DEBUG_ASSERT(chunk == nullptr || chunkIndex == chunk->getIndex());
-
-    return chunk;
+    auto pChunk = m_allocatedCachingReaderChunks.value(chunkIndex, nullptr);
+    DEBUG_ASSERT(!pChunk || pChunk->getIndex() == chunkIndex);
+    return pChunk;
 }
 
 void CachingReader::freshenChunk(CachingReaderChunkForOwner* pChunk) {
-    DEBUG_ASSERT(pChunk != nullptr);
-    DEBUG_ASSERT(pChunk->getState() != CachingReaderChunkForOwner::READ_PENDING);
-
-    // Remove the chunk from the LRU list
-    pChunk->removeFromList(&m_mruCachingReaderChunk, &m_lruCachingReaderChunk);
-
-    // Adjust the least-recently-used item before inserting the
-    // chunk as the new most-recently-used item.
-    if (m_lruCachingReaderChunk == nullptr) {
-        if (m_mruCachingReaderChunk == nullptr) {
-            m_lruCachingReaderChunk = pChunk;
-        } else {
-            m_lruCachingReaderChunk = m_mruCachingReaderChunk;
-        }
+    DEBUG_ASSERT(pChunk);
+    DEBUG_ASSERT(pChunk->getState() == CachingReaderChunkForOwner::READY);
+    if (kLogger.traceEnabled()) {
+        kLogger.trace()
+                << "freshenChunk()"
+                << pChunk->getIndex()
+                << pChunk;
     }
 
-    // Insert the chunk as the new most-recently-used item.
-    pChunk->insertIntoListBefore(m_mruCachingReaderChunk);
-    m_mruCachingReaderChunk = pChunk;
+    // Remove the chunk from the MRU/LRU list
+    pChunk->removeFromList(
+            &m_mruCachingReaderChunk,
+            &m_lruCachingReaderChunk);
+
+    // Reinsert has new head of MRU list
+    pChunk->insertIntoListBefore(
+            &m_mruCachingReaderChunk,
+            &m_lruCachingReaderChunk,
+            m_mruCachingReaderChunk);
 }
 
 CachingReaderChunkForOwner* CachingReader::lookupChunkAndFreshen(SINT chunkIndex) {
-    CachingReaderChunkForOwner* pChunk = lookupChunk(chunkIndex);
-    if (pChunk &&
-            (pChunk->getState() != CachingReaderChunkForOwner::READ_PENDING)) {
+    auto pChunk = lookupChunk(chunkIndex);
+    if (pChunk && (pChunk->getState() == CachingReaderChunkForOwner::READY)) {
         freshenChunk(pChunk);
     }
     return pChunk;
@@ -476,27 +477,33 @@ void CachingReader::hintAndMaybeWake(const HintVector& hintList) {
         const int lastChunkIndex = CachingReaderChunk::indexForFrame(readableFrameIndexRange.end() - 1);
         for (int chunkIndex = firstChunkIndex; chunkIndex <= lastChunkIndex; ++chunkIndex) {
             CachingReaderChunkForOwner* pChunk = lookupChunk(chunkIndex);
-            if (pChunk == nullptr) {
+            if (!pChunk) {
                 shouldWake = true;
                 pChunk = allocateChunkExpireLRU(chunkIndex);
-                if (pChunk == nullptr) {
-                    kLogger.warning() << "ERROR: Couldn't allocate spare CachingReaderChunk to make CachingReaderChunkReadRequest.";
+                if (!pChunk) {
+                    kLogger.warning()
+                            << "Failed to allocate chunk"
+                            << chunkIndex
+                            << "for read request";
                     continue;
                 }
                 // Do not insert the allocated chunk into the MRU/LRU list,
                 // because it will be handed over to the worker immediately
                 CachingReaderChunkReadRequest request;
                 request.giveToWorker(pChunk);
-                // kLogger.debug() << "Requesting read of chunk" << current << "into" << pChunk;
-                // kLogger.debug() << "Requesting read into " << request.chunk->data;
+                if (kLogger.traceEnabled()) {
+                    kLogger.trace()
+                            << "Requesting read of chunk"
+                            << request.chunk;
+                }
                 if (m_chunkReadRequestFIFO.write(&request, 1) != 1) {
-                    kLogger.warning() << "ERROR: Could not submit read request for "
-                             << chunkIndex;
+                    kLogger.warning()
+                            << "Failed to submit read request for chunk"
+                            << chunkIndex;
                     // Revoke the chunk from the worker and free it
                     pChunk->takeFromWorker();
                     freeChunk(pChunk);
                 }
-                //kLogger.debug() << "Checking chunk " << current << " shouldWake:" << shouldWake << " chunksToRead" << m_chunksToRead.size();
             } else if (pChunk->getState() == CachingReaderChunkForOwner::READY) {
                 // This will cause the chunk to be 'freshened' in the cache. The
                 // chunk will be moved to the end of the LRU list.

--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -38,8 +38,8 @@ const SINT kNumberOfCachedChunksInMemory = 256;
 CachingReader::CachingReader(QString group,
                              UserSettingsPointer config)
         : m_pConfig(config),
-          m_chunkReadRequestFIFO(1024),
-          m_readerStatusFIFO(1024),
+          m_chunkReadRequestFIFO(kNumberOfCachedChunksInMemory),
+          m_readerStatusFIFO(kNumberOfCachedChunksInMemory),
           m_readerStatus(INVALID),
           m_mruCachingReaderChunk(nullptr),
           m_lruCachingReaderChunk(nullptr),

--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -20,10 +20,17 @@ mixxx::Logger kLogger("CachingReader");
 // TODO() Do we suffer cache misses if we use an audio buffer of above 23 ms?
 const SINT kDefaultHintFrames = 1024;
 
-// currently CachingReaderWorker::kCachingReaderChunkLength is 65536 (0x10000);
-// For 80 chunks we need 5242880 (0x500000) bytes (5 MiB) of Memory
-//static
-const SINT kNumberOfCachedChunksInMemory = 80;
+// With CachingReaderChunk::kFrames = 8192 each chunk consumes
+// 8192 frames * 2 channels/frame * 4-bytes per sample = 65 kB.
+//
+// NOTE(2019-09-04): https://bugs.launchpad.net/mixxx/+bug/1842679
+// According to the linked bug report reserving only 80 chunks in
+// version 2.2.2 for doesn't seem to be sufficient to prevent running
+// out of free chunks. Therefore we increased the number of cached
+// chunks to 256:
+//     80 chunks ->  5120 KB =  5 MB
+//    256 chunks -> 16384 KB = 16 MB
+const SINT kNumberOfCachedChunksInMemory = 256;
 
 } // anonymous namespace
 

--- a/src/engine/cachingreader.h
+++ b/src/engine/cachingreader.h
@@ -140,6 +140,7 @@ class CachingReader : public QObject {
 
     // Returns a CachingReaderChunk to the free list
     void freeChunk(CachingReaderChunkForOwner* pChunk);
+    void freeChunkFromList(CachingReaderChunkForOwner* pChunk);
 
     // Returns all allocated chunks to the free list
     void freeAllChunks();

--- a/src/engine/cachingreaderchunk.cpp
+++ b/src/engine/cachingreaderchunk.cpp
@@ -126,22 +126,32 @@ CachingReaderChunkForOwner::~CachingReaderChunkForOwner() {
 }
 
 void CachingReaderChunkForOwner::init(SINT index) {
-    DEBUG_ASSERT(READ_PENDING != m_state);
+    // Must not be referenced in MRU/LRU list!
+    DEBUG_ASSERT(!m_pNext);
+    DEBUG_ASSERT(!m_pPrev);
+    // Must not be accessed by a worker!
+    DEBUG_ASSERT(m_state != READ_PENDING);
     CachingReaderChunk::init(index);
     m_state = READY;
 }
 
 void CachingReaderChunkForOwner::free() {
-    DEBUG_ASSERT(READ_PENDING != m_state);
+    // Must not be referenced in MRU/LRU list!
+    DEBUG_ASSERT(!m_pNext);
+    DEBUG_ASSERT(!m_pPrev);
+    // Must not be accessed by a worker!
+    DEBUG_ASSERT(m_state != READ_PENDING);
     CachingReaderChunk::init(kInvalidChunkIndex);
     m_state = FREE;
 }
 
 void CachingReaderChunkForOwner::insertIntoListBefore(
         CachingReaderChunkForOwner* pBefore) {
-    DEBUG_ASSERT(m_pNext == nullptr);
-    DEBUG_ASSERT(m_pPrev == nullptr);
-    DEBUG_ASSERT(m_state != READ_PENDING); // Must not be accessed by a worker!
+    // Must not be referenced in MRU/LRU list!
+    DEBUG_ASSERT(!m_pNext);
+    DEBUG_ASSERT(!m_pPrev);
+    // Must not be accessed by a worker!
+    DEBUG_ASSERT(m_state != READ_PENDING);
 
     m_pNext = pBefore;
     if (pBefore) {
@@ -157,6 +167,7 @@ void CachingReaderChunkForOwner::insertIntoListBefore(
 void CachingReaderChunkForOwner::removeFromList(
         CachingReaderChunkForOwner** ppHead,
         CachingReaderChunkForOwner** ppTail) {
+    DEBUG_ASSERT(m_pNext || m_pPrev);
     // Remove this chunk from the double-linked list...
     CachingReaderChunkForOwner* pNext = m_pNext;
     CachingReaderChunkForOwner* pPrev = m_pPrev;

--- a/src/engine/cachingreaderchunk.cpp
+++ b/src/engine/cachingreaderchunk.cpp
@@ -38,6 +38,7 @@ CachingReaderChunk::CachingReaderChunk(
 }
 
 void CachingReaderChunk::init(SINT index) {
+    DEBUG_ASSERT(m_index == kInvalidChunkIndex || index == kInvalidChunkIndex);
     m_index = index;
     m_bufferedSampleFrames.frameIndexRange() = mixxx::IndexRange();
 }
@@ -45,6 +46,7 @@ void CachingReaderChunk::init(SINT index) {
 // Frame index range of this chunk for the given audio source.
 mixxx::IndexRange CachingReaderChunk::frameIndexRange(
         const mixxx::AudioSourcePointer& pAudioSource) const {
+    DEBUG_ASSERT(m_index != kInvalidChunkIndex);
     if (!pAudioSource) {
         return mixxx::IndexRange();
     }
@@ -59,6 +61,7 @@ mixxx::IndexRange CachingReaderChunk::frameIndexRange(
 mixxx::IndexRange CachingReaderChunk::bufferSampleFrames(
         const mixxx::AudioSourcePointer& pAudioSource,
         mixxx::SampleBuffer::WritableSlice tempOutputBuffer) {
+    DEBUG_ASSERT(m_index != kInvalidChunkIndex);
     const auto sourceFrameIndexRange = frameIndexRange(pAudioSource);
     mixxx::AudioSourceStereoProxy audioSourceProxy(
             pAudioSource,
@@ -76,6 +79,7 @@ mixxx::IndexRange CachingReaderChunk::bufferSampleFrames(
 mixxx::IndexRange CachingReaderChunk::readBufferedSampleFrames(
         CSAMPLE* sampleBuffer,
         const mixxx::IndexRange& frameIndexRange) const {
+    DEBUG_ASSERT(m_index != kInvalidChunkIndex);
     const auto copyableFrameIndexRange =
             intersect(frameIndexRange, m_bufferedSampleFrames.frameIndexRange());
     if (!copyableFrameIndexRange.empty()) {
@@ -95,6 +99,7 @@ mixxx::IndexRange CachingReaderChunk::readBufferedSampleFrames(
 mixxx::IndexRange CachingReaderChunk::readBufferedSampleFramesReverse(
         CSAMPLE* reverseSampleBuffer,
         const mixxx::IndexRange& frameIndexRange) const {
+    DEBUG_ASSERT(m_index != kInvalidChunkIndex);
     const auto copyableFrameIndexRange =
             intersect(frameIndexRange, m_bufferedSampleFrames.frameIndexRange());
     if (!copyableFrameIndexRange.empty()) {
@@ -120,77 +125,123 @@ CachingReaderChunkForOwner::CachingReaderChunkForOwner(
 }
 
 void CachingReaderChunkForOwner::init(SINT index) {
+    // Must not be accessed by a worker!
+    DEBUG_ASSERT(m_state != READ_PENDING);
     // Must not be referenced in MRU/LRU list!
     DEBUG_ASSERT(!m_pNext);
     DEBUG_ASSERT(!m_pPrev);
-    // Must not be accessed by a worker!
-    DEBUG_ASSERT(m_state != READ_PENDING);
+
     CachingReaderChunk::init(index);
     m_state = READY;
 }
 
 void CachingReaderChunkForOwner::free() {
+    // Must not be accessed by a worker!
+    DEBUG_ASSERT(m_state != READ_PENDING);
     // Must not be referenced in MRU/LRU list!
     DEBUG_ASSERT(!m_pNext);
     DEBUG_ASSERT(!m_pPrev);
-    // Must not be accessed by a worker!
-    DEBUG_ASSERT(m_state != READ_PENDING);
+
     CachingReaderChunk::init(kInvalidChunkIndex);
     m_state = FREE;
 }
 
 void CachingReaderChunkForOwner::insertIntoListBefore(
+        CachingReaderChunkForOwner** ppHead,
+        CachingReaderChunkForOwner** ppTail,
         CachingReaderChunkForOwner* pBefore) {
-    // Must not be referenced in MRU/LRU list!
+    DEBUG_ASSERT(m_state == READY);
+    // Both head and tail need to be adjusted
+    DEBUG_ASSERT(ppHead);
+    DEBUG_ASSERT(ppTail);
+    // Cannot insert before itself
+    DEBUG_ASSERT(this != pBefore);
+    // Must not yet be referenced in MRU/LRU list
+    DEBUG_ASSERT(this != *ppHead);
+    DEBUG_ASSERT(this != *ppTail);
     DEBUG_ASSERT(!m_pNext);
     DEBUG_ASSERT(!m_pPrev);
-    // Must not be accessed by a worker!
-    DEBUG_ASSERT(m_state != READ_PENDING);
+    if (kLogger.traceEnabled()) {
+        kLogger.trace()
+                << "insertIntoListBefore()"
+                << this
+                << ppHead << *ppHead
+                << ppTail << *ppTail
+                << pBefore;
+    }
 
-    m_pNext = pBefore;
     if (pBefore) {
-        if (pBefore->m_pPrev) {
-            m_pPrev = pBefore->m_pPrev;
-            DEBUG_ASSERT(m_pPrev->m_pNext == pBefore);
+        // List must already contain one or more item, i.e. has both
+        // a head and a tail
+        DEBUG_ASSERT(*ppHead);
+        DEBUG_ASSERT(*ppTail);
+        m_pPrev = pBefore->m_pPrev;
+        pBefore->m_pPrev = this;
+        m_pNext = pBefore;
+        if (*ppHead == pBefore) {
+            // Replace head
+            *ppHead = this;
+        }
+    } else {
+        // Append as new tail
+        m_pPrev = *ppTail;
+        *ppTail = this;
+        if (m_pPrev) {
             m_pPrev->m_pNext = this;
         }
-        pBefore->m_pPrev = this;
+        if (!*ppHead) {
+            // Initialize new head if the list was empty before
+            *ppHead = this;
+        }
     }
 }
 
 void CachingReaderChunkForOwner::removeFromList(
         CachingReaderChunkForOwner** ppHead,
         CachingReaderChunkForOwner** ppTail) {
+    DEBUG_ASSERT(m_state == READY);
+    // Both head and tail need to be adjusted
     DEBUG_ASSERT(ppHead);
     DEBUG_ASSERT(ppTail);
-    if (!m_pPrev && !m_pNext) {
-        // Not in linked list -> nothing to do
-        return;
+    if (kLogger.traceEnabled()) {
+        kLogger.trace()
+                << "removeFromList()"
+                << this
+                << ppHead << *ppHead
+                << ppTail << *ppTail;
     }
 
-    // Remove this chunk from the double-linked list...
+    // Disconnect this chunk from the double-linked list
     const auto pPrev = m_pPrev;
     const auto pNext = m_pNext;
     m_pPrev = nullptr;
     m_pNext = nullptr;
 
-    // ...reconnect the adjacent list items and adjust head/tail
+    // Reconnect the adjacent list items and adjust head/tail if needed
     if (pPrev) {
         DEBUG_ASSERT(this == pPrev->m_pNext);
         pPrev->m_pNext = pNext;
     } else {
-        // No predecessor
-        DEBUG_ASSERT(this == *ppHead);
-        // pNext becomes the new head
-        *ppHead = pNext;
+        // Only the current head item doesn't have a predecessor
+        if (this == *ppHead) {
+            // pNext becomes the new head
+            *ppHead = pNext;
+        } else {
+            // Item was not part the list and must not have any successor
+            DEBUG_ASSERT(!pPrev);
+        }
     }
     if (pNext) {
         DEBUG_ASSERT(this == pNext->m_pPrev);
         pNext->m_pPrev = pPrev;
     } else {
-        // No successor
-        DEBUG_ASSERT(this == *ppTail);
-        // pPrev becomes the new tail
-        *ppTail = pPrev;
+        // Only the current tail item doesn't have a successor
+        if (this == *ppTail) {
+            // pPrev becomes the new tail
+            *ppTail = pPrev;
+        } else {
+            // Item was not part the list and must not have any predecessor
+            DEBUG_ASSERT(!pPrev);
+        }
     }
 }

--- a/src/engine/cachingreaderchunk.cpp
+++ b/src/engine/cachingreaderchunk.cpp
@@ -33,11 +33,8 @@ const SINT CachingReaderChunk::kSamples =
 CachingReaderChunk::CachingReaderChunk(
         mixxx::SampleBuffer::WritableSlice sampleBuffer)
         : m_index(kInvalidChunkIndex),
-          m_sampleBuffer(sampleBuffer) {
-    DEBUG_ASSERT(sampleBuffer.length() == kSamples);
-}
-
-CachingReaderChunk::~CachingReaderChunk() {
+          m_sampleBuffer(std::move(sampleBuffer)) {
+    DEBUG_ASSERT(m_sampleBuffer.length() == kSamples);
 }
 
 void CachingReaderChunk::init(SINT index) {
@@ -116,13 +113,10 @@ mixxx::IndexRange CachingReaderChunk::readBufferedSampleFramesReverse(
 
 CachingReaderChunkForOwner::CachingReaderChunkForOwner(
         mixxx::SampleBuffer::WritableSlice sampleBuffer)
-        : CachingReaderChunk(sampleBuffer),
+        : CachingReaderChunk(std::move(sampleBuffer)),
           m_state(FREE),
           m_pPrev(nullptr),
           m_pNext(nullptr) {
-}
-
-CachingReaderChunkForOwner::~CachingReaderChunkForOwner() {
 }
 
 void CachingReaderChunkForOwner::init(SINT index) {

--- a/src/engine/cachingreaderchunk.cpp
+++ b/src/engine/cachingreaderchunk.cpp
@@ -167,28 +167,36 @@ void CachingReaderChunkForOwner::insertIntoListBefore(
 void CachingReaderChunkForOwner::removeFromList(
         CachingReaderChunkForOwner** ppHead,
         CachingReaderChunkForOwner** ppTail) {
-    DEBUG_ASSERT(m_pNext || m_pPrev);
-    // Remove this chunk from the double-linked list...
-    CachingReaderChunkForOwner* pNext = m_pNext;
-    CachingReaderChunkForOwner* pPrev = m_pPrev;
-    m_pNext = nullptr;
-    m_pPrev = nullptr;
-
-    // ...reconnect the remaining list elements...
-    if (pNext) {
-        DEBUG_ASSERT(this == pNext->m_pPrev);
-        pNext->m_pPrev = pPrev;
+    DEBUG_ASSERT(ppHead);
+    DEBUG_ASSERT(ppTail);
+    if (!m_pPrev && !m_pNext) {
+        // Not in linked list -> nothing to do
+        return;
     }
+
+    // Remove this chunk from the double-linked list...
+    const auto pPrev = m_pPrev;
+    const auto pNext = m_pNext;
+    m_pPrev = nullptr;
+    m_pNext = nullptr;
+
+    // ...reconnect the adjacent list items and adjust head/tail
     if (pPrev) {
         DEBUG_ASSERT(this == pPrev->m_pNext);
         pPrev->m_pNext = pNext;
-    }
-
-    // ...and adjust head/tail.
-    if (ppHead && (this == *ppHead)) {
+    } else {
+        // No predecessor
+        DEBUG_ASSERT(this == *ppHead);
+        // pNext becomes the new head
         *ppHead = pNext;
     }
-    if (ppTail && (this == *ppTail)) {
+    if (pNext) {
+        DEBUG_ASSERT(this == pNext->m_pPrev);
+        pNext->m_pPrev = pPrev;
+    } else {
+        // No successor
+        DEBUG_ASSERT(this == *ppTail);
+        // pPrev becomes the new tail
         *ppTail = pPrev;
     }
 }

--- a/src/engine/cachingreaderchunk.h
+++ b/src/engine/cachingreaderchunk.h
@@ -67,7 +67,7 @@ public:
 protected:
     explicit CachingReaderChunk(
             mixxx::SampleBuffer::WritableSlice sampleBuffer);
-    virtual ~CachingReaderChunk();
+    virtual ~CachingReaderChunk() = default;
 
     void init(SINT index);
 
@@ -91,7 +91,7 @@ class CachingReaderChunkForOwner: public CachingReaderChunk {
 public:
     explicit CachingReaderChunkForOwner(
             mixxx::SampleBuffer::WritableSlice sampleBuffer);
-    ~CachingReaderChunkForOwner() override;
+    ~CachingReaderChunkForOwner() override = default;
 
     void init(SINT index);
     void free();

--- a/src/engine/cachingreaderchunk.h
+++ b/src/engine/cachingreaderchunk.h
@@ -108,24 +108,30 @@ public:
 
     // The state is controlled by the cache as the owner of each chunk!
     void giveToWorker() {
-        DEBUG_ASSERT(READY == m_state);
+        // Must not be referenced in MRU/LRU list!
+        DEBUG_ASSERT(!m_pPrev);
+        DEBUG_ASSERT(!m_pNext);
+        DEBUG_ASSERT(m_state == READY);
         m_state = READ_PENDING;
     }
     void takeFromWorker() {
-        DEBUG_ASSERT(READ_PENDING == m_state);
+        // Must not be referenced in MRU/LRU list!
+        DEBUG_ASSERT(!m_pPrev);
+        DEBUG_ASSERT(!m_pNext);
+        DEBUG_ASSERT(m_state == READ_PENDING);
         m_state = READY;
     }
 
     // Inserts a chunk into the double-linked list before the
-    // given chunk. If the list is currently empty simply pass
-    // pBefore = nullptr. Please note that if pBefore points to
-    // the head of the current list this chunk becomes the new
-    // head of the list.
+    // given chunk and adjusts the head/tail pointers. The
+    // chunk is inserted at the tail of the list if
+    // pBefore == nullptr.
     void insertIntoListBefore(
+            CachingReaderChunkForOwner** ppHead,
+            CachingReaderChunkForOwner** ppTail,
             CachingReaderChunkForOwner* pBefore);
-    // Removes a chunk from the double-linked list and optionally
-    // adjusts head/tail pointers. Pass ppHead/ppTail = nullptr if
-    // you prefer to adjust those pointers manually.
+    // Removes a chunk from the double-linked list and adjusts
+    // the head/tail pointers.
     void removeFromList(
             CachingReaderChunkForOwner** ppHead,
             CachingReaderChunkForOwner** ppTail);

--- a/src/util/fifo.h
+++ b/src/util/fifo.h
@@ -43,10 +43,8 @@ class FIFO {
     }
     void writeBlocking(const DataType* pData, int count) {
         int written = 0;
-        while (written != count) {
-            int i = write(pData, count);
-            pData += i;
-            written += i;
+        while (written < count) {
+            written += write(pData + written, count - written);
         }
     }
     int aquireWriteRegions(int count,


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1842679

~~Trying to mitigate the issue by reserving more chunks. The current number of chunks seems to be insufficient when using multiple decks including sample decks!~~ Reverted, my initial guess was wrong. But I found issues with the double-linked MRU/LRU list, at least some assertions failed. Fixed.

The comment was outdated, I updated it.