### PR TITLE
Set AA_UseHighDpiPixmaps attribute

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,6 +71,7 @@ int main(int argc, char * argv[]) {
     // This needs to be set before initializing the QApplication.
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 
     // Setting the organization name results in a QDesktopStorage::DataLocation


### PR DESCRIPTION
This fixes the standard button icons on my high-dpi screen.

Before:
![before](https://user-images.githubusercontent.com/20947558/64378733-9d240500-d02d-11e9-9e95-9b8d8ee0390a.png)

After:
![after](https://user-images.githubusercontent.com/20947558/64378743-a3b27c80-d02d-11e9-81d0-13fe20920d3f.png)

The attribute is documented here:
https://doc.qt.io/qt-5/qt.html

Hopefully, this does not have any side effects. ;)