### PR TITLE
Roland DJ-505: Fix Pad Mode Switch Shift state

### DIFF
--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1111,6 +1111,11 @@ DJ505.PadSection.prototype.setPadMode = function (control) {
         return;
     }
 
+    // If we're switching away from or to a hardware-based mode (e.g. TR mode),
+    // the performance pad behaviour is hardcoded in the firmware and not
+    // controlled by Mixxx. These modes are represented by the value null.
+    // Hence, we only need to change LEDs and (dis-)connect components if
+    // this.currentMode or newMode is not null.
     if (this.currentMode) {
         // Disable the mode button LED of the currently active mode
         midi.sendShortMsg(0x94 + this.offset, this.currentMode.ledControl, 0x00);

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1111,12 +1111,11 @@ DJ505.PadSection.prototype.setPadMode = function (control) {
         return;
     }
 
-    var oldMode = this.currentMode;
-    if (oldMode) {
-        // Disable the mode button LED of the old mode
-        midi.sendShortMsg(0x94 + this.offset, oldMode.ledControl, 0x00);
+    if (this.currentMode) {
+        // Disable the mode button LED of the currently active mode
+        midi.sendShortMsg(0x94 + this.offset, this.currentMode.ledControl, 0x00);
 
-        oldMode.forEachComponent(function (component) {
+        this.currentMode.forEachComponent(function (component) {
             component.disconnect();
         });
     }

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1121,6 +1121,24 @@ DJ505.PadSection.prototype.setPadMode = function (control) {
     if (mode) {
         // Set new mode's LED
         midi.sendShortMsg(0x94 + this.offset, mode.ledControl, mode.color);
+
+        // Set the correct shift state for the new mode. For example, if the
+        // user is in HOT CUE mode and wants to switch to CUE LOOP mode, you
+        // need to press [SHIFT]+[HOT CUE]. Pressing [SHIFT] will make the HOT
+        // CUE mode pads become shifted.
+        // When you're in CUE LOOP mode and want to switch back to
+        // HOT CUE mode, the user need to press HOT CUE (without holding
+        // SHIFT). However, the HOT CUE mode pads are still shifted even though
+        // the user is not pressing [SHIFT] because they never got the unshift
+        // event (the [SHIFT] button was released in CUE LOOP mode, not in HOT
+        // CUE mode).
+        // Hence, it's necessary to set the correct shift state when switching
+        // modes.
+        if(this.isShifted) {
+            mode.shift();
+        } else {
+            mode.unshift();
+        }
         mode.forEachComponent(function (component) {
             component.connect();
             component.trigger();


### PR DESCRIPTION
This expects the `isShifted` attribute to be set correctly on the pad section `ComponentContainer` and therefore depends on PR #2266.