### PR TITLE
Track metadata: Minor fixes

### DIFF
--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -78,12 +78,9 @@ class AiffFile : public TagLib::RIFF::AIFF::File {
     }
 };
 
+inline
 QDateTime getMetadataSynchronized(QFileInfo fileInfo) {
-    const QDateTime metadataSynchronized = fileInfo.lastModified();
-    VERIFY_OR_DEBUG_ASSERT(!metadataSynchronized.isNull()) {
-        return QDateTime::currentDateTimeUtc();
-    }
-    return metadataSynchronized;
+    return fileInfo.lastModified();
 }
 
 } // anonymous namespace

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -1133,8 +1133,10 @@ void importTrackMetadataFromID3v2Tag(
 
     const TagLib::ID3v2::Header* pHeader = tag.header();
     DEBUG_ASSERT(pHeader);
-        return; // abort
     if (!checkID3v2HeaderVersionSupported(*pHeader)) {
+        kLogger.warning() << "Legacy ID3v2 version - importing only basic tags";
+        importTrackMetadataFromTag(pTrackMetadata, tag);
+        return; // done
     }
 
     // Omit to read comments with the default implementation provided by
@@ -1863,7 +1865,9 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
     const TagLib::ID3v2::Header* pHeader = pTag->header();
     DEBUG_ASSERT(pHeader);
     if (!checkID3v2HeaderVersionSupported(*pHeader)) {
-        return false;
+        kLogger.warning() << "Legacy ID3v2 version - exporting only basic tags";
+        exportTrackMetadataIntoTag(pTag, trackMetadata);
+        return true; // done
     }
 
     // NOTE(uklotzde): Setting the comment for ID3v2 tags does

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -38,6 +38,17 @@ namespace {
 
 Logger kLogger("TagLib");
 
+bool checkID3v2HeaderVersion(const TagLib::ID3v2::Header& header) {
+    if (header.majorVersion() < 3) {
+        kLogger.warning() << QString("ID3v2.%1 is not supported")
+                                     .arg(QString::number(header.majorVersion()))
+                                     .toLatin1();
+        return false;
+    } else {
+        return true;
+    }
+}
+
 } // anonymous namespace
 
 namespace taglib {
@@ -1113,6 +1124,12 @@ void importTrackMetadataFromID3v2Tag(
         return; // nothing to do
     }
 
+    const TagLib::ID3v2::Header* pHeader = tag.header();
+    DEBUG_ASSERT(pHeader);
+    if (!checkID3v2HeaderVersion(*pHeader)) {
+        return; // abort
+    }
+
     // Omit to read comments with the default implementation provided by
     // TagLib. We are only interested in a CommentsFrame with an empty
     // description (see below). If no such CommentsFrame exists TagLib
@@ -1837,8 +1854,8 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
     }
 
     const TagLib::ID3v2::Header* pHeader = pTag->header();
-    if (!pHeader || (3 > pHeader->majorVersion())) {
-        // only ID3v2.3.x and higher (currently only ID3v2.4.x) are supported
+    DEBUG_ASSERT(pHeader);
+    if (!checkID3v2HeaderVersion(*pHeader)) {
         return false;
     }
 

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -42,6 +42,7 @@ Logger kLogger("TagLib");
 // exporting text frames. ID3v2.2 uses different frame identifiers,
 // i.e. only 3 instead of 4 characters.
 // https://en.wikipedia.org/wiki/ID3#ID3v2
+// http://id3.org/Developer%20Information
 const unsigned int kMinID3v2Version = 3;
 
 bool checkID3v2HeaderVersionSupported(const TagLib::ID3v2::Header& header) {


### PR DESCRIPTION
The next tiny steps to catch up with my aoide-related extensions and fixes, more to follow:

**ID3v2**
Restrict parsing of ID3v2 tags to version 2.3 and 2.4. We are not able to support version 2.2 that uses different character encodings and frames. This check was previously missing and could cause unexpected behavior. In this case, only the common default tags like _artist_, _title_, ... will be parsed.

**Missing files**
Missing files triggered a debug assertion when trying to write modified metadata. Fixed.