### PR TITLE
[WIP] Improve icon quality in about dialog on high-dpi screens

### DIFF
--- a/src/dialog/dlgabout.cpp
+++ b/src/dialog/dlgabout.cpp
@@ -5,6 +5,9 @@
 DlgAbout::DlgAbout(QWidget* parent) : QDialog(parent), Ui::DlgAboutDlg() {
     setupUi(this);
 
+    mixxx_icon->load(QString(":/images/mixxx_icon.svg"));
+    mixxx_logo->load(QString(":/images/mixxx_logo.svg"));
+
     QString mixxxVersion = Version::version();
     QString buildBranch = Version::developmentBranch();
     QString buildRevision = Version::developmentRevision();

--- a/src/dialog/dlgaboutdlg.ui
+++ b/src/dialog/dlgaboutdlg.ui
@@ -29,43 +29,22 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="mixxx_icon">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
+      <widget class="QSvgWidget" name="mixxx_icon">
        <property name="maximumSize">
         <size>
-         <width>48</width>
-         <height>68</height>
+         <width>32</width>
+         <height>32</height>
         </size>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="../../res/mixxx.qrc">:/images/mixxx_icon.svg</pixmap>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="mixxx_logo">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
+      <widget class="QSvgWidget" name="mixxx_logo">
        <property name="maximumSize">
         <size>
          <width>170</width>
          <height>68</height>
         </size>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="../../res/mixxx.qrc">:/images/mixxx_logo.svg</pixmap>
-       </property>
-       <property name="scaledContents">
-        <bool>true</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
This just doubles the size of the svg (`<svg width="" height="" ..`).

To be honest, I don't think this is a great solution but it is consistent with the logo next to the icon which aready looks good.
Somehow, qt renders the svg in it's original size, and then scales the resulting bitmap. :(

Before:
![before](https://user-images.githubusercontent.com/20947558/64531502-fcc12f80-d30f-11e9-957a-469df9fdab93.png)

After:
![after](https://user-images.githubusercontent.com/20947558/64531517-03e83d80-d310-11e9-82c1-52c06c9f112a.png)


(The same icon is also used as window/desktop icon, I guess the svg size doesn't matter there)
