### PR TITLE
Knobs with arcs

### DIFF
--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -4,6 +4,7 @@
 
 #include "util/duration.h"
 #include "widget/wknobcomposed.h"
+#include "widget/wskincolor.h"
 
 WKnobComposed::WKnobComposed(QWidget* pParent)
         : WWidget(pParent),
@@ -48,7 +49,7 @@ void WKnobComposed::setup(const QDomNode& node, const SkinContext& context) {
     m_dArcThickness = context.selectDouble(node, "ArcThickness");
 
     if (m_dArcThickness > 0.0) {
-        m_arcColor = context.selectColor(node, "ArcColor");
+        m_arcColor = WSkinColor::getCorrectColor(context.selectColor(node, "ArcColor"));
         m_arcUnipolar = context.selectBool(node, "ArcUnipolar", false);
     }
 

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -45,9 +45,16 @@ void WKnobComposed::setup(const QDomNode& node, const SkinContext& context) {
     context.hasNodeSelectDouble(node, "MaxAngle", &m_dMaxAngle);
     context.hasNodeSelectDouble(node, "KnobCenterXOffset", &m_dKnobCenterXOffset);
     context.hasNodeSelectDouble(node, "KnobCenterYOffset", &m_dKnobCenterYOffset);
+    m_dArcThickness = context.selectDouble(node, "ArcThickness");
+
+    if (m_dArcThickness > 0.0) {
+        m_arcColor = context.selectColor(node, "ArcColor");
+        m_arcUnipolar = context.selectBool(node, "ArcUnipolar", false);
+    }
 
     m_dKnobCenterXOffset *= scaleFactor;
     m_dKnobCenterYOffset *= scaleFactor;
+    m_dArcThickness *= scaleFactor;
 }
 
 void WKnobComposed::clear() {
@@ -101,6 +108,16 @@ void WKnobComposed::paintEvent(QPaintEvent* e) {
         m_pPixmapBack->draw(rect(), &p, m_pPixmapBack->rect());
     }
 
+    if ((!m_pKnob.isNull() && !m_pKnob->isNull()) || m_dArcThickness > 0.0) {
+        // We update m_dCurrentAngle since onConnectedControlChanged uses it for
+        // no-op detection.
+        m_dCurrentAngle = m_dMinAngle + (m_dMaxAngle - m_dMinAngle) * getControlParameterDisplay();
+    }
+
+    if (m_dArcThickness > 0.0) {
+        drawArc(rect(), &p);
+    }
+
     QTransform transform;
     if (!m_pKnob.isNull() && !m_pKnob->isNull()) {
         qreal tx = m_dKnobCenterXOffset + width() / 2.0;
@@ -108,15 +125,27 @@ void WKnobComposed::paintEvent(QPaintEvent* e) {
         transform.translate(-tx, -ty);
         p.translate(tx, ty);
 
-        // We update m_dCurrentAngle since onConnectedControlChanged uses it for
-        // no-op detection.
-        m_dCurrentAngle = m_dMinAngle + (m_dMaxAngle - m_dMinAngle) * getControlParameterDisplay();
         p.rotate(m_dCurrentAngle);
 
         // Need to convert from QRect to a QRectF to avoid losing precision.
         QRectF targetRect = rect();
         m_pKnob->drawCentered(transform.mapRect(targetRect), &p,
                               m_pKnob->rect());
+    }
+}
+
+void WKnobComposed::drawArc(const QRectF& targetRect, QPainter* pPainter) {
+    QMargins margins = QMargins();
+    margins += m_dArcThickness / 2.0;
+    QRectF rect = targetRect.marginsRemoved(margins);
+    QPen pen = QPen(m_arcColor);
+    pen.setWidth(m_dArcThickness);
+    pen.setCapStyle(Qt::FlatCap);
+    pPainter->setPen(pen);
+    if (m_arcUnipolar) {
+        pPainter->drawArc(rect, 90 * 16 - m_dMinAngle * 16, (m_dCurrentAngle - m_dMinAngle) * -16);
+    } else {
+        pPainter->drawArc(rect, 90 * 16, m_dCurrentAngle * -16);
     }
 }
 

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -45,6 +45,9 @@ class WKnobComposed : public WWidget {
             PixmapSource source,
             Paintable::DrawMode mode,
             double scaleFactor);
+    void drawArc(
+            const QRectF& targetRect,
+            QPainter* pPainter);
 
     double m_dCurrentAngle;
     PaintablePointer m_pKnob;
@@ -54,6 +57,9 @@ class WKnobComposed : public WWidget {
     double m_dMaxAngle;
     double m_dKnobCenterXOffset;
     double m_dKnobCenterYOffset;
+    double m_dArcThickness;
+    QColor m_arcColor;
+    bool m_arcUnipolar;
     WidgetRenderTimer m_renderTimer;
 
     friend class KnobEventHandler<WKnobComposed>;


### PR DESCRIPTION
This PR makes it possible to draw the knob arcs programmatically.

**XML example:**
```xml
<KnobComposed>
  <Size>40f,40f</Size>
  <Knob>handle.svg</Knob>
  <BackPath>bg.svg</BackPath>
  <MinAngle>-135</MinAngle>
  <MaxAngle>135</MaxAngle>
  <ArcThickness>2</ArcThickness>
  <ArcColor>#ffffff</ArcColor>
  <ArcUnipolar>true</ArcUnipolar>
  <Connection>
    <ConfigKey>[Master],gain</ConfigKey>
  </Connection>
</KnobComposed>
```
where new nodes are:
ArcThickness, ArcColor and ArcUnipolar

**Demo:**

![mixxx-knob-arcs](https://user-images.githubusercontent.com/1945127/64646597-181b6000-d420-11e9-9c1f-4a70b52b7b33.gif)
