### PR TITLE
keep table view when right-clicking different sidebar item

### DIFF
--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -295,7 +295,6 @@ void SidebarModel::rightClicked(const QPoint& globalPos, const QModelIndex& inde
     stopPressedUntilClickedTimer();
     if (index.isValid()) {
         if (index.internalPointer() == this) {
-            m_sFeatures[index.row()]->activate();
             m_sFeatures[index.row()]->onRightClick(globalPos);
         }
         else
@@ -303,7 +302,6 @@ void SidebarModel::rightClicked(const QPoint& globalPos, const QModelIndex& inde
             TreeItem* tree_item = (TreeItem*)index.internalPointer();
             if (tree_item) {
                 LibraryFeature* feature = tree_item->feature();
-                feature->activateChild(index);
                 feature->onRightClickChild(globalPos, index);
             }
         }


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1810810

fixes the right-click behaviour for the following scenario:
* listen to tracks from Tracks view
* find a track that inspires you to start a new playlist
* right-click any other library feature like Playlists or Crates
 (for example to create or rename a playlist/crate)
= tree item context menu opens, table view is kept

I don't notice any side effects. left-click and selection change with controller still activates the new feature view in the tracks table