### PR TITLE
link to keyboard map in Help menu, update manual links to 2.3 in master

### DIFF
--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -21,8 +21,8 @@
 #define MIXXX_SUPPORT_URL       "https://www.mixxx.org/support/"
 #define MIXXX_TRANSLATION_URL   "https://www.transifex.com/projects/p/mixxxdj/"
 #define MIXXX_FEEDBACK_URL      "https://goo.gl/forms/IHf3JK7Q9DXmExXc2"
-#define MIXXX_MANUAL_URL        "https://mixxx.org/manual/2.2"
-#define MIXXX_SHORTCUTS_URL     "https://mixxx.org/manual/2.2/chapters/appendix.html#keyboard-mapping-table"
+#define MIXXX_MANUAL_URL        "https://mixxx.org/manual/2.3"
+#define MIXXX_SHORTCUTS_URL     "https://mixxx.org/manual/2.3/en/chapters/controlling_mixxx.html#using-a-keyboard"
 #define MIXXX_MANUAL_FILENAME   "Mixxx-Manual.pdf"
 
 #endif


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1843647

* from Help menu, link to (graphical) keyboard map (7.2. Using a Keyboard) in the manual instead of the shortcut list chapter 16.2
* move "See also" link to graphical map above the shortcut list in chapter 16.2

I think this is much more helpful when accidentially hitting a hotkey while playing music because the picture is universal, while the link appearantly considers the chosen MiXXX language but of course not actual keyboard layout.

also check if we can safely restore the unicode character for hyperlinks
instead of ugly "=>" on all platforms.