### PR TITLE
Beatloops snap to the closest (fractional) beat in quantized mode LP1752133

### DIFF
--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -129,6 +129,7 @@ class LoopingControl : public EngineControl {
     ControlPushButton* m_pLoopHalveButton;
     ControlPushButton* m_pLoopDoubleButton;
     ControlObject* m_pSlipEnabled;
+    ControlObject* m_pCOReverse;
     ControlObject* m_pPlayButton;
 
     bool m_bLoopingEnabled;

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -8,11 +8,12 @@
 #include <QObject>
 #include <QStack>
 
-#include "preferences/usersettings.h"
-#include "engine/controls/enginecontrol.h"
-#include "track/track.h"
-#include "track/beats.h"
 #include "control/controlvalue.h"
+#include "engine/controls/enginecontrol.h"
+#include "engine/controls/ratecontrol.h"
+#include "preferences/usersettings.h"
+#include "track/beats.h"
+#include "track/track.h"
 
 #define MINIMUM_AUDIBLE_LOOP_SIZE   300  // In samples
 
@@ -50,7 +51,7 @@ class LoopingControl : public EngineControl {
     double getSyncPositionInsideLoop(double dRequestedPlaypos, double dSyncedPlayPos);
 
     void notifySeek(double dNewPlaypos) override;
-
+    void setRateControl(RateControl* rateControl);
     bool isLoopingEnabled();
 
   public slots:
@@ -129,7 +130,7 @@ class LoopingControl : public EngineControl {
     ControlPushButton* m_pLoopHalveButton;
     ControlPushButton* m_pLoopDoubleButton;
     ControlObject* m_pSlipEnabled;
-    ControlObject* m_pCOReverse;
+    RateControl* m_pRateControl;
     ControlObject* m_pPlayButton;
 
     bool m_bLoopingEnabled;

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -556,3 +556,10 @@ void RateControl::resetRateTemp(void)
 void RateControl::notifySeek(double playPos) {
     m_pScratchController->notifySeek(playPos);
 }
+
+bool RateControl::isReverseButtonPressed() {
+    if (m_pReverseButton) {
+        return m_pReverseButton->toBool();
+    }
+    return false;
+}

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -78,6 +78,7 @@ public:
     static void setRateRampSensitivity(int);
     static int getRateRampSensitivity();
     void notifySeek(double dNewPlaypos) override;
+    bool isReverseButtonPressed();
 
   public slots:
     void slotReverseRollActivate(double);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -181,6 +181,11 @@ EngineBuffer::EngineBuffer(const QString& group, UserSettingsPointer pConfig,
     // beats.
     QuantizeControl* quantize_control = new QuantizeControl(group, pConfig);
 
+    // Rate Controller must be created before Looping Controller for the Reverse Button to be created
+    m_pRateControl = new RateControl(group, pConfig);
+    // Add the Rate Controller
+    addControl(m_pRateControl);
+
     // Create the Loop Controller
     m_pLoopingControl = new LoopingControl(group, pConfig);
     addControl(m_pLoopingControl);
@@ -198,9 +203,6 @@ EngineBuffer::EngineBuffer(const QString& group, UserSettingsPointer pConfig,
     addControl(m_pVinylControlControl);
 #endif
 
-    m_pRateControl = new RateControl(group, pConfig);
-    // Add the Rate Controller
-    addControl(m_pRateControl);
 
     // Create the BPM Controller
     m_pBpmControl = new BpmControl(group, pConfig);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -180,18 +180,12 @@ EngineBuffer::EngineBuffer(const QString& group, UserSettingsPointer pConfig,
     // quantization (alignment) of loop in/out positions and (hot)cues with
     // beats.
     QuantizeControl* quantize_control = new QuantizeControl(group, pConfig);
-
-    // Rate Controller must be created before Looping Controller for the Reverse Button to be created
-    m_pRateControl = new RateControl(group, pConfig);
-    // Add the Rate Controller
-    addControl(m_pRateControl);
+    addControl(quantize_control);
+    m_pQuantize = ControlObject::getControl(ConfigKey(group, "quantize"));
 
     // Create the Loop Controller
     m_pLoopingControl = new LoopingControl(group, pConfig);
     addControl(m_pLoopingControl);
-
-    addControl(quantize_control);
-    m_pQuantize = ControlObject::getControl(ConfigKey(group, "quantize"));
 
     m_pEngineSync = pMixingEngine->getEngineSync();
 
@@ -203,6 +197,12 @@ EngineBuffer::EngineBuffer(const QString& group, UserSettingsPointer pConfig,
     addControl(m_pVinylControlControl);
 #endif
 
+    // Create the Rate Controller
+    m_pRateControl = new RateControl(group, pConfig);
+    // Add the Rate Controller
+    addControl(m_pRateControl);
+    // Looping Control needs Rate Control for Reverse Button
+    m_pLoopingControl->setRateControl(m_pRateControl);
 
     // Create the BPM Controller
     m_pBpmControl = new BpmControl(group, pConfig);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -532,6 +532,10 @@ TrackPointer EngineBuffer::getLoadedTrack() const {
     return m_pCurrentTrack;
 }
 
+bool EngineBuffer::isReverse() {
+    return m_reverse_old;
+}
+
 void EngineBuffer::ejectTrack() {
     // clear track values in any case, this may fix Bug #1450424
     //qDebug() << "EngineBuffer::ejectTrack()";

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -146,6 +146,8 @@ class EngineBuffer : public EngineObject {
     bool getQueuedSeekPosition(double* pSeekPosition);
     TrackPointer getLoadedTrack() const;
 
+    bool isReverse();
+
     double getExactPlayPos();
     double getVisualPlayPos();
     double getTrackSamples();


### PR DESCRIPTION
Quantized beat loops always started on the previous beat while loop in and loop out markers snapped to the closest beat. Now both snap to the closest beat. If the closest beat is ahead of the current play position a catching loop is generated.

Fixes https://bugs.launchpad.net/mixxx/+bug/1752133