### PR TITLE
[WiP] GlobalTrackCache: Fix edge cases and tests

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -471,10 +471,7 @@ void Library::saveCachedTrack(Track* pTrack) noexcept {
     // It can produce dangerous signal loops if the track is still
     // sending signals while being saved!
     // See: https://bugs.launchpad.net/mixxx/+bug/1365708
-    // NOTE(uklotzde, 2018-02-03): Simply disconnecting all receivers
-    // doesn't seem to work reliably. Emitting the clean() signal from
-    // a track that is about to deleted may cause access violations!!
-    pTrack->blockSignals(true);
+    DEBUG_ASSERT(pTrack->signalsBlocked());
 
     // The metadata must be exported while the cache is locked to
     // ensure that we have exclusive (write) access on the file

--- a/src/test/globaltrackcache_test.cpp
+++ b/src/test/globaltrackcache_test.cpp
@@ -156,9 +156,13 @@ TEST_F(GlobalTrackCacheTest, concurrentDelete) {
 
         // lp1744550: Accessing the track from multiple threads is
         // required to cause a SIGSEGV
-        track->setArtist(track->getTitle());
+        track->setArtist(QString("Artist %1").arg(QString::number(i)));
 
         m_recentTrackPtr = std::move(track);
+
+        // Lookup the track again
+        track = GlobalTrackCacheLocker().lookupTrackById(trackId);
+        EXPECT_TRUE(static_cast<bool>(track));
     }
     m_recentTrackPtr.reset();
 

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -88,7 +88,20 @@ void deleteTrack(Track* plainPtr) {
                 << plainPtr;
     }
     DEBUG_ASSERT(plainPtr->signalsBlocked());
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    if (plainPtr->thread()->loopLevel() > 0) {
+        plainPtr->deleteLater();
+    } else {
+        // Delete track directly if no event loop is running.
+        // Otherwise no track objects would be deleted during
+        // a unit test that doesn't start an event loop. Invoking
+        // QCoreApplication::processEvents() periodically is not
+        // sufficient!
+        delete plainPtr;
+    }
+#else
     plainPtr->deleteLater();
+#endif
 }
 
 } // anonymous namespace

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -520,7 +520,7 @@ void GlobalTrackCache::resolve(
     // and will be deleted later within the event loop. But this
     // function might be called from any thread, even from worker
     // threads without an event loop. We need to move the newly
-    // created object to the target thread.
+    // created object to the main thread.
     deletingPtr->moveToThread(QApplication::instance()->thread());
 
     auto cacheEntryPtr = std::make_shared<GlobalTrackCacheEntry>(

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -543,12 +543,6 @@ void GlobalTrackCache::resolve(
                     std::move(pSecurityToken),
                     std::move(trackId)),
             deleteTrack);
-    // Track objects live together with the cache on the main thread
-    // and will be deleted later within the event loop. But this
-    // function might be called from any thread, even from worker
-    // threads without an event loop. We need to move the newly
-    // created object to the main thread.
-    deletingPtr->moveToThread(QApplication::instance()->thread());
 
     auto cacheEntryPtr = std::make_shared<GlobalTrackCacheEntry>(
             std::move(deletingPtr));
@@ -580,6 +574,14 @@ void GlobalTrackCache::resolve(
                 trackRef.getCanonicalLocation(),
                 cacheEntryPtr));
     }
+
+    // Track objects live together with the cache on the main thread
+    // and will be deleted later within the event loop. But this
+    // function might be called from any thread, even from worker
+    // threads without an event loop. We need to move the newly
+    // created object to the main thread.
+    savingPtr->moveToThread(QApplication::instance()->thread());
+
     pCacheResolver->initLookupResult(
             GlobalTrackCacheLookupResult::MISS,
             std::move(savingPtr),

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -36,8 +36,20 @@ TrackRef createTrackRef(const Track& track) {
 
 class EvictAndSaveFunctor {
   public:
-    explicit EvictAndSaveFunctor(GlobalTrackCacheEntryPointer cacheEntryPtr)
+    explicit EvictAndSaveFunctor(
+            GlobalTrackCacheEntryPointer cacheEntryPtr)
         : m_cacheEntryPtr(std::move(cacheEntryPtr)) {
+    }
+    // Disable copy constructor
+    // NOTE(uklotzde, 2019-09-21): Using the default copy constructor
+    // instead of move causes a memory leak and track objects are never
+    // deleted. But why???
+    EvictAndSaveFunctor(const EvictAndSaveFunctor&) = delete;
+    EvictAndSaveFunctor(EvictAndSaveFunctor&&) = default;
+    ~EvictAndSaveFunctor() {
+        // The stored pointer must have been consumed before
+        // the functor gets destroyed.
+        DEBUG_ASSERT(!m_cacheEntryPtr);
     }
 
     void operator()(Track* plainPtr) {

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -75,6 +75,7 @@ void deleteTrack(Track* plainPtr) {
                 << "Deleting"
                 << plainPtr;
     }
+    DEBUG_ASSERT(plainPtr->signalsBlocked());
     plainPtr->deleteLater();
 }
 
@@ -321,6 +322,18 @@ void GlobalTrackCache::relocateTracks(
     m_tracksByCanonicalLocation = std::move(relocatedTracksByCanonicalLocation);
 }
 
+void GlobalTrackCache::saveEvictedTrack(Track* plainPtr) const {
+    DEBUG_ASSERT(plainPtr);
+    // Disconnect all receivers and block signals before saving the
+    // track.
+    // NOTE(uklotzde, 2018-02-03): Simply disconnecting all receivers
+    // doesn't seem to work reliably. Emitting the clean() signal from
+    // a track that is about to deleted may cause access violations!!
+    plainPtr->disconnect();
+    plainPtr->blockSignals(true);
+    m_pSaver->saveCachedTrack(plainPtr);
+}
+
 void GlobalTrackCache::deactivate() {
     // Ideally the cache should be empty when destroyed.
     // But since this is difficult to achieve all remaining
@@ -331,7 +344,7 @@ void GlobalTrackCache::deactivate() {
     auto i = m_tracksById.begin();
     while (i != m_tracksById.end()) {
         Track* plainPtr= i->second->getPlainPtr();
-        m_pSaver->saveCachedTrack(plainPtr);
+        saveEvictedTrack(plainPtr);
         m_tracksByCanonicalLocation.erase(plainPtr->getCanonicalLocation());
         i = m_tracksById.erase(i);
     }
@@ -339,7 +352,7 @@ void GlobalTrackCache::deactivate() {
     auto j = m_tracksByCanonicalLocation.begin();
     while (j != m_tracksByCanonicalLocation.end()) {
         Track* plainPtr= j->second->getPlainPtr();
-        m_pSaver->saveCachedTrack(plainPtr);
+        saveEvictedTrack(plainPtr);
         j = m_tracksByCanonicalLocation.erase(j);
     }
 
@@ -420,6 +433,7 @@ TrackPointer GlobalTrackCache::revive(
                     << "Found alive track"
                     << entryPtr->getPlainPtr();
         }
+        DEBUG_ASSERT(!savingPtr->signalsBlocked());
         return savingPtr;
     }
 
@@ -438,6 +452,7 @@ TrackPointer GlobalTrackCache::revive(
     savingPtr = TrackPointer(entryPtr->getPlainPtr(),
             EvictAndSaveFunctor(entryPtr));
     entryPtr->init(savingPtr);
+    DEBUG_ASSERT(!savingPtr->signalsBlocked());
     return savingPtr;
 }
 
@@ -632,10 +647,10 @@ void GlobalTrackCache::evictAndSave(
     }
 
     DEBUG_ASSERT(!isCached(cacheEntryPtr->getPlainPtr()));
-    m_pSaver->saveCachedTrack(cacheEntryPtr->getPlainPtr());
+    saveEvictedTrack(cacheEntryPtr->getPlainPtr());
 
-    // here the cacheEntryPtr goes out of scope, the cache is deleted
-    // including the owned track
+    // here the cacheEntryPtr goes out of scope, the cache entry is
+    // deleted including the owned track
 }
 
 bool GlobalTrackCache::evict(Track* plainPtr) {

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -670,10 +670,6 @@ bool GlobalTrackCache::evict(Track* plainPtr) {
         }
     }
     DEBUG_ASSERT(!isCached(plainPtr));
-    // Don't erase the pointer from m_cachedTracks here, because
-    // this function is invoked from 2 different contexts. The
-    // caller is responsible for doing this. Until then the cache
-    // is inconsistent and verifyConsistency() is expected to fail.
     return evicted;
 }
 

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -211,7 +211,7 @@ private:
     void purgeTrackId(TrackId trackId);
 
     bool evict(Track* plainPtr);
-    bool isEvicted(Track* plainPtr) const;
+    bool isCached(Track* plainPtr) const;
 
     bool isEmpty() const;
 

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -162,7 +162,7 @@ private:
 class /*interface*/ GlobalTrackCacheSaver {
 private:
     friend class GlobalTrackCache;
-    virtual void saveCachedTrack(Track* pTrack) noexcept = 0;
+    virtual void saveCachedTrack(Track* plainPtr) noexcept = 0;
 
 protected:
     virtual ~GlobalTrackCacheSaver() {}
@@ -223,6 +223,8 @@ private:
     bool isEmpty() const;
 
     void deactivate();
+
+    void saveEvictedTrack(Track* plainPtr) const;
 
     // Managed by GlobalTrackCacheLocker
     mutable QMutex m_mutex;

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -43,8 +43,8 @@ class GlobalTrackCacheEntry final {
             std::unique_ptr<Track, void (&)(Track*)> deletingPtr)
         : m_deletingPtr(std::move(deletingPtr)) {
     }
-
     GlobalTrackCacheEntry(const GlobalTrackCacheEntry& other) = delete;
+    GlobalTrackCacheEntry(GlobalTrackCacheEntry&&) = default;
 
     void init(TrackWeakPointer savingWeakPtr) {
         // Uninitialized or expired

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -46,14 +46,21 @@ class GlobalTrackCacheEntry final {
 
     GlobalTrackCacheEntry(const GlobalTrackCacheEntry& other) = delete;
 
+    void init(TrackWeakPointer savingWeakPtr) {
+        // Uninitialized or expired
+        DEBUG_ASSERT(!m_savingWeakPtr.lock());
+        m_savingWeakPtr = std::move(savingWeakPtr);
+    }
+
     Track* getPlainPtr() const {
         return m_deletingPtr.get();
     }
-    const TrackWeakPointer& getSavingWeakPtr() const {
-        return m_savingWeakPtr;
+
+    TrackPointer lock() const {
+        return m_savingWeakPtr.lock();
     }
-    void setSavingWeakPtr(TrackWeakPointer savingWeakPtr) {
-        m_savingWeakPtr = std::move(savingWeakPtr);
+    bool expired() const {
+        return m_savingWeakPtr.expired();
     }
 
   private:


### PR DESCRIPTION
***No issues with GCC/G++ 9.2.1 using move ctor, but CI build requires copy ctor!?***

I still experience a crash caused by `GlobalTrackCache` once in a while when closing Mixxx. It happens very infrequently, mostly after loading just a single or a few tracks. These crashes may still be unsolved, nevertheless I discovered some other issues during my investigations:

- Updated or removed outdated comments
- Ensure that all cache items and functors are only moved, never copied
- Verify that functors are called only once (see also: move instead of copy)
- Fixed edge cases when evicting tracks that might occur due to expected race conditions
- Disconnect receivers and block signals in `GlobalTrackCache` instead of in the `Library` code.
- Fixed a memory leak in the concurrency test. Track objects were neither evicted nor deleted because no main event loop is executed! Note: `deleteLater()` is still not invoked even when calling `QCoreApplication::processEvents()` periodically! I have added a workaround for Qt >= 5.6.0 in the code, but this memory leak is still present for earlier versions (only in tests).