### PR TITLE
GlobalTrackCache: Fix edge cases and tests

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -438,7 +438,7 @@ void Library::setEditMedatataSelectedClick(bool enabled) {
     emit(setSelectedClick(enabled));
 }
 
-void Library::saveCachedTrack(Track* pTrack) noexcept {
+void Library::saveEvictedTrack(Track* pTrack) noexcept {
     // It can produce dangerous signal loops if the track is still
     // sending signals while being saved!
     // See: https://bugs.launchpad.net/mixxx/+bug/1365708

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -442,10 +442,7 @@ void Library::saveCachedTrack(Track* pTrack) noexcept {
     // It can produce dangerous signal loops if the track is still
     // sending signals while being saved!
     // See: https://bugs.launchpad.net/mixxx/+bug/1365708
-    // NOTE(uklotzde, 2018-02-03): Simply disconnecting all receivers
-    // doesn't seem to work reliably. Emitting the clean() signal from
-    // a track that is about to deleted may cause access violations!!
-    pTrack->blockSignals(true);
+    DEBUG_ASSERT(pTrack->signalsBlocked());
 
     // The metadata must be exported while the cache is locked to
     // ensure that we have exclusive (write) access on the file

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -126,7 +126,7 @@ class Library: public QObject,
 
   private:
     // Callback for GlobalTrackCache
-    void saveCachedTrack(Track* pTrack) noexcept override;
+    void saveEvictedTrack(Track* pTrack) noexcept override;
 
     const UserSettingsPointer m_pConfig;
 

--- a/src/test/globaltrackcache_test.cpp
+++ b/src/test/globaltrackcache_test.cpp
@@ -66,7 +66,7 @@ class TrackTitleThread: public QThread {
 
 class GlobalTrackCacheTest: public MixxxTest, public virtual GlobalTrackCacheSaver {
   public:
-    void saveCachedTrack(Track* pTrack) noexcept override {
+    void saveEvictedTrack(Track* pTrack) noexcept override {
         ASSERT_FALSE(pTrack == nullptr);
     }
 

--- a/src/test/globaltrackcache_test.cpp
+++ b/src/test/globaltrackcache_test.cpp
@@ -156,9 +156,13 @@ TEST_F(GlobalTrackCacheTest, concurrentDelete) {
 
         // lp1744550: Accessing the track from multiple threads is
         // required to cause a SIGSEGV
-        track->setArtist(track->getTitle());
+        track->setArtist(QString("Artist %1").arg(QString::number(i)));
 
         m_recentTrackPtr = std::move(track);
+
+        // Lookup the track again
+        track = GlobalTrackCacheLocker().lookupTrackById(trackId);
+        EXPECT_TRUE(static_cast<bool>(track));
     }
     m_recentTrackPtr.reset();
 

--- a/src/test/globaltrackcache_test.cpp
+++ b/src/test/globaltrackcache_test.cpp
@@ -51,7 +51,11 @@ class TrackTitleThread: public QThread {
             m_recentTrackPtr = std::move(track);
             ++loopCount;
         }
-        // If the cache is empty all references must have been dropped
+        // If the cache is empty all references must have been dropped.
+        // Why? m_recentTrackPtr is only valid if a pointer has been found
+        // in the cache during the previous cycle, i.e. the cache could not
+        // have been empty. In this case at least another loop cycle follow,
+        // and so on...
         ASSERT_TRUE(!m_recentTrackPtr);
         qDebug() << "Finished" << loopCount << " thread loops";
     }

--- a/src/test/globaltrackcache_test.cpp
+++ b/src/test/globaltrackcache_test.cpp
@@ -62,6 +62,12 @@ class TrackTitleThread: public QThread {
     std::atomic<bool> m_stop;
 };
 
+void deleteTrack(Track* pTrack) {
+    // Delete track objects directly in unit tests with
+    // no main event loop
+    delete pTrack;
+};
+
 } // anonymous namespace
 
 class GlobalTrackCacheTest: public MixxxTest, public virtual GlobalTrackCacheSaver {
@@ -72,7 +78,7 @@ class GlobalTrackCacheTest: public MixxxTest, public virtual GlobalTrackCacheSav
 
   protected:
     GlobalTrackCacheTest() {
-        GlobalTrackCache::createInstance(this);
+        GlobalTrackCache::createInstance(this, deleteTrack);
     }
     ~GlobalTrackCacheTest() {
         GlobalTrackCache::destroyInstance();

--- a/src/test/librarytest.cpp
+++ b/src/test/librarytest.cpp
@@ -1,0 +1,36 @@
+#include "test/librarytest.h"
+
+namespace {
+
+const bool kInMemoryDbConnection = true;
+
+void deleteTrack(Track* pTrack) {
+    // Delete track objects directly in unit tests with
+    // no main event loop
+    delete pTrack;
+};
+
+}
+
+LibraryTest::LibraryTest()
+    : m_mixxxDb(config(), kInMemoryDbConnection),
+      m_dbConnectionPooler(m_mixxxDb.connectionPool()),
+      m_dbConnection(mixxx::DbConnectionPooled(m_mixxxDb.connectionPool())),
+      m_pTrackCollection(std::make_unique<TrackCollection>(config())) {
+    MixxxDb::initDatabaseSchema(m_dbConnection);
+    m_pTrackCollection->connectDatabase(m_dbConnection);
+    GlobalTrackCache::createInstance(this, deleteTrack);
+}
+
+LibraryTest::~LibraryTest() {
+    m_pTrackCollection->disconnectDatabase();
+    m_pTrackCollection.reset();
+    // With the track collection all remaining track references
+    // should have been dropped before destroying the cache.
+    GlobalTrackCache::destroyInstance();
+}
+
+void LibraryTest::saveEvictedTrack(Track* pTrack) noexcept {
+    m_pTrackCollection->exportTrackMetadata(pTrack);
+    m_pTrackCollection->saveTrack(pTrack);
+}

--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -1,5 +1,6 @@
-#ifndef LIBRARYTEST_H
-#define LIBRARYTEST_H
+#pragma once
+
+#include <memory>
 
 #include "test/mixxxtest.h"
 
@@ -9,17 +10,15 @@
 #include "util/db/dbconnectionpooled.h"
 #include "track/globaltrackcache.h"
 
-namespace {
-    const bool kInMemoryDbConnection = true;
-} // anonymous namespace
+const bool kInMemoryDbConnection = true;
 
 class LibraryTest : public MixxxTest,
     public virtual /*implements*/ GlobalTrackCacheSaver {
 
   public:
     void saveCachedTrack(Track* pTrack) noexcept override {
-        m_trackCollection.exportTrackMetadata(pTrack);
-        m_trackCollection.saveTrack(pTrack);
+        m_trackCollection->exportTrackMetadata(pTrack);
+        m_trackCollection->saveTrack(pTrack);
     }
 
   protected:
@@ -27,14 +26,17 @@ class LibraryTest : public MixxxTest,
         : m_mixxxDb(config(), kInMemoryDbConnection),
           m_dbConnectionPooler(m_mixxxDb.connectionPool()),
           m_dbConnection(mixxx::DbConnectionPooled(m_mixxxDb.connectionPool())),
-          m_trackCollection(config()) {
+          m_trackCollection(std::make_unique<TrackCollection>(config())) {
         MixxxDb::initDatabaseSchema(m_dbConnection);
-        m_trackCollection.connectDatabase(m_dbConnection);
+        m_trackCollection->connectDatabase(m_dbConnection);
         GlobalTrackCache::createInstance(this);
     }
     ~LibraryTest() override {
+        m_trackCollection->disconnectDatabase();
+        m_trackCollection.reset();
+        // With the track collection all remaining track references
+        // should have been dropped before destroying the cache.
         GlobalTrackCache::destroyInstance();
-        m_trackCollection.disconnectDatabase();
     }
 
     mixxx::DbConnectionPoolPtr dbConnectionPool() const {
@@ -46,15 +48,12 @@ class LibraryTest : public MixxxTest,
     }
 
     TrackCollection* collection() {
-        return &m_trackCollection;
+        return m_trackCollection.get();
     }
 
   private:
     const MixxxDb m_mixxxDb;
     const mixxx::DbConnectionPooler m_dbConnectionPooler;
     QSqlDatabase m_dbConnection;
-    TrackCollection m_trackCollection;
+    std::unique_ptr<TrackCollection> m_trackCollection;
 };
-
-
-#endif /* LIBRARYTEST_H */

--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -26,14 +26,14 @@ class LibraryTest : public MixxxTest,
         : m_mixxxDb(config(), kInMemoryDbConnection),
           m_dbConnectionPooler(m_mixxxDb.connectionPool()),
           m_dbConnection(mixxx::DbConnectionPooled(m_mixxxDb.connectionPool())),
-          m_trackCollection(std::make_unique<TrackCollection>(config())) {
+          m_pTrackCollection(std::make_unique<TrackCollection>(config())) {
         MixxxDb::initDatabaseSchema(m_dbConnection);
-        m_trackCollection->connectDatabase(m_dbConnection);
+        m_pTrackCollection->connectDatabase(m_dbConnection);
         GlobalTrackCache::createInstance(this);
     }
     ~LibraryTest() override {
-        m_trackCollection->disconnectDatabase();
-        m_trackCollection.reset();
+        m_pTrackCollection->disconnectDatabase();
+        m_pTrackCollection.reset();
         // With the track collection all remaining track references
         // should have been dropped before destroying the cache.
         GlobalTrackCache::destroyInstance();
@@ -48,12 +48,12 @@ class LibraryTest : public MixxxTest,
     }
 
     TrackCollection* collection() {
-        return m_trackCollection.get();
+        return m_pTrackCollection.get();
     }
 
   private:
     const MixxxDb m_mixxxDb;
     const mixxx::DbConnectionPooler m_dbConnectionPooler;
     QSqlDatabase m_dbConnection;
-    std::unique_ptr<TrackCollection> m_trackCollection;
+    std::unique_ptr<TrackCollection> m_pTrackCollection;
 };

--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -16,9 +16,9 @@ class LibraryTest : public MixxxTest,
     public virtual /*implements*/ GlobalTrackCacheSaver {
 
   public:
-    void saveCachedTrack(Track* pTrack) noexcept override {
-        m_trackCollection->exportTrackMetadata(pTrack);
-        m_trackCollection->saveTrack(pTrack);
+    void saveEvictedTrack(Track* pTrack) noexcept override {
+        m_pTrackCollection->exportTrackMetadata(pTrack);
+        m_pTrackCollection->saveTrack(pTrack);
     }
 
   protected:

--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -10,34 +10,15 @@
 #include "util/db/dbconnectionpooled.h"
 #include "track/globaltrackcache.h"
 
-const bool kInMemoryDbConnection = true;
-
 class LibraryTest : public MixxxTest,
     public virtual /*implements*/ GlobalTrackCacheSaver {
 
   public:
-    void saveEvictedTrack(Track* pTrack) noexcept override {
-        m_pTrackCollection->exportTrackMetadata(pTrack);
-        m_pTrackCollection->saveTrack(pTrack);
-    }
+    void saveEvictedTrack(Track* pTrack) noexcept override;
 
   protected:
-    LibraryTest()
-        : m_mixxxDb(config(), kInMemoryDbConnection),
-          m_dbConnectionPooler(m_mixxxDb.connectionPool()),
-          m_dbConnection(mixxx::DbConnectionPooled(m_mixxxDb.connectionPool())),
-          m_pTrackCollection(std::make_unique<TrackCollection>(config())) {
-        MixxxDb::initDatabaseSchema(m_dbConnection);
-        m_pTrackCollection->connectDatabase(m_dbConnection);
-        GlobalTrackCache::createInstance(this);
-    }
-    ~LibraryTest() override {
-        m_pTrackCollection->disconnectDatabase();
-        m_pTrackCollection.reset();
-        // With the track collection all remaining track references
-        // should have been dropped before destroying the cache.
-        GlobalTrackCache::destroyInstance();
-    }
+    LibraryTest();
+    ~LibraryTest() override;
 
     mixxx::DbConnectionPoolPtr dbConnectionPool() const {
         return m_mixxxDb.connectionPool();

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -80,7 +80,20 @@ void deleteTrack(Track* plainPtr) {
                 << plainPtr;
     }
     DEBUG_ASSERT(plainPtr->signalsBlocked());
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    if (plainPtr->thread()->loopLevel() > 0) {
+        plainPtr->deleteLater();
+    } else {
+        // Delete track directly if no event loop is running.
+        // Otherwise no track objects would be deleted during
+        // a unit test that doesn't start an event loop. Invoking
+        // QCoreApplication::processEvents() periodically is not
+        // sufficient!
+        delete plainPtr;
+    }
+#else
     plainPtr->deleteLater();
+#endif
 }
 
 } // anonymous namespace

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -670,10 +670,6 @@ bool GlobalTrackCache::evict(Track* plainPtr) {
         }
     }
     DEBUG_ASSERT(!isCached(plainPtr));
-    // Don't erase the pointer from m_cachedTracks here, because
-    // this function is invoked from 2 different contexts. The
-    // caller is responsible for doing this. Until then the cache
-    // is inconsistent and verifyConsitency() is expected to fail.
     return evicted;
 }
 

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -345,16 +345,16 @@ void GlobalTrackCache::relocateTracks(
     m_tracksByCanonicalLocation = std::move(relocatedTracksByCanonicalLocation);
 }
 
-void GlobalTrackCache::saveEvictedTrack(Track* plainPtr) const {
-    DEBUG_ASSERT(plainPtr);
+void GlobalTrackCache::saveEvictedTrack(Track* pEvictedTrack) const {
+    DEBUG_ASSERT(pEvictedTrack);
     // Disconnect all receivers and block signals before saving the
     // track.
     // NOTE(uklotzde, 2018-02-03): Simply disconnecting all receivers
     // doesn't seem to work reliably. Emitting the clean() signal from
     // a track that is about to deleted may cause access violations!!
-    plainPtr->disconnect();
-    plainPtr->blockSignals(true);
-    m_pSaver->saveCachedTrack(plainPtr);
+    pEvictedTrack->disconnect();
+    pEvictedTrack->blockSignals(true);
+    m_pSaver->saveEvictedTrack(pEvictedTrack);
 }
 
 void GlobalTrackCache::deactivate() {

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -236,6 +236,11 @@ void GlobalTrackCache::createInstance(GlobalTrackCacheSaver* pDeleter) {
 //static
 void GlobalTrackCache::destroyInstance() {
     DEBUG_ASSERT(s_pInstance);
+    // Processing all pending events is required to evict all
+    // remaining references from the cache.
+    QCoreApplication::processEvents();
+    // Now the cache should be empty
+    DEBUG_ASSERT(GlobalTrackCacheLocker().isEmpty());
     GlobalTrackCache* pInstance = s_pInstance;
     // Reset the static/global pointer before entering the destructor
     s_pInstance = nullptr;

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -718,6 +718,7 @@ bool GlobalTrackCache::tryEvict(Track* plainPtr) {
         }
     }
     DEBUG_ASSERT(!isCached(plainPtr));
+    Q_UNUSED(notEvicted); // only used in debug assertion
     DEBUG_ASSERT(!(evicted && notEvicted));
     return evicted;
 }

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -520,7 +520,7 @@ void GlobalTrackCache::resolve(
     // and will be deleted later within the event loop. But this
     // function might be called from any thread, even from worker
     // threads without an event loop. We need to move the newly
-    // created object to the target thread.
+    // created object to the main thread.
     deletingPtr->moveToThread(QApplication::instance()->thread());
 
     auto cacheEntryPtr = std::make_shared<GlobalTrackCacheEntry>(

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -413,7 +413,7 @@ TrackPointer GlobalTrackCache::lookupByRef(
 TrackPointer GlobalTrackCache::revive(
         GlobalTrackCacheEntryPointer entryPtr) {
 
-    TrackPointer savingPtr = entryPtr->getSavingWeakPtr().lock();
+    TrackPointer savingPtr = entryPtr->lock();
     if (savingPtr) {
         if (traceLogEnabled()) {
             kLogger.trace()
@@ -433,11 +433,11 @@ TrackPointer GlobalTrackCache::revive(
                 << "Reviving zombie track"
                 << entryPtr->getPlainPtr();
     }
-    DEBUG_ASSERT(entryPtr->getSavingWeakPtr().expired());
+    DEBUG_ASSERT(entryPtr->expired());
 
     savingPtr = TrackPointer(entryPtr->getPlainPtr(),
             EvictAndSaveFunctor(entryPtr));
-    entryPtr->setSavingWeakPtr(savingPtr);
+    entryPtr->init(savingPtr);
     return savingPtr;
 }
 
@@ -528,7 +528,7 @@ void GlobalTrackCache::resolve(
     auto savingPtr = TrackPointer(
             cacheEntryPtr->getPlainPtr(),
             EvictAndSaveFunctor(cacheEntryPtr));
-    cacheEntryPtr->setSavingWeakPtr(savingPtr);
+    cacheEntryPtr->init(savingPtr);
 
     if (debugLogEnabled()) {
         kLogger.debug()
@@ -608,7 +608,7 @@ void GlobalTrackCache::evictAndSave(
 
     GlobalTrackCacheLocker cacheLocker;
 
-    if (!cacheEntryPtr->getSavingWeakPtr().expired()) {
+    if (!cacheEntryPtr->expired()) {
         // We have handed out (revived) this track again after our reference count
         // drops to zero and before acquire the lock at the beginning of this function
         if (debugLogEnabled()) {

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -536,12 +536,6 @@ void GlobalTrackCache::resolve(
                     std::move(pSecurityToken),
                     std::move(trackId)),
             deleteTrack);
-    // Track objects live together with the cache on the main thread
-    // and will be deleted later within the event loop. But this
-    // function might be called from any thread, even from worker
-    // threads without an event loop. We need to move the newly
-    // created object to the main thread.
-    deletingPtr->moveToThread(QApplication::instance()->thread());
 
     auto cacheEntryPtr = std::make_shared<GlobalTrackCacheEntry>(
             std::move(deletingPtr));
@@ -573,6 +567,14 @@ void GlobalTrackCache::resolve(
                 trackRef.getCanonicalLocation(),
                 cacheEntryPtr));
     }
+
+    // Track objects live together with the cache on the main thread
+    // and will be deleted later within the event loop. But this
+    // function might be called from any thread, even from worker
+    // threads without an event loop. We need to move the newly
+    // created object to the main thread.
+    savingPtr->moveToThread(QApplication::instance()->thread());
+
     pCacheResolver->initLookupResult(
             GlobalTrackCacheLookupResult::MISS,
             std::move(savingPtr),

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -172,7 +172,7 @@ private:
 class /*interface*/ GlobalTrackCacheSaver {
 private:
     friend class GlobalTrackCache;
-    virtual void saveCachedTrack(Track* plainPtr) noexcept = 0;
+    virtual void saveEvictedTrack(Track* pEvictedTrack) noexcept = 0;
 
 protected:
     virtual ~GlobalTrackCacheSaver() {}
@@ -234,7 +234,7 @@ private:
 
     void deactivate();
 
-    void saveEvictedTrack(Track* plainPtr) const;
+    void saveEvictedTrack(Track* pEvictedTrack) const;
 
     // Managed by GlobalTrackCacheLocker
     mutable QMutex m_mutex;

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -221,7 +221,7 @@ private:
     void purgeTrackId(TrackId trackId);
 
     bool evict(Track* plainPtr);
-    bool isEvicted(Track* plainPtr) const;
+    bool isCached(Track* plainPtr) const;
 
     bool isEmpty() const;
 

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -172,7 +172,7 @@ private:
 class /*interface*/ GlobalTrackCacheSaver {
 private:
     friend class GlobalTrackCache;
-    virtual void saveCachedTrack(Track* pTrack) noexcept = 0;
+    virtual void saveCachedTrack(Track* plainPtr) noexcept = 0;
 
 protected:
     virtual ~GlobalTrackCacheSaver() {}
@@ -233,6 +233,8 @@ private:
     bool isEmpty() const;
 
     void deactivate();
+
+    void saveEvictedTrack(Track* plainPtr) const;
 
     // Managed by GlobalTrackCacheLocker
     mutable QMutex m_mutex;

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -32,7 +32,7 @@ protected:
     virtual ~GlobalTrackCacheRelocator() {}
 };
 
-typedef void (*deleteTrackFn)(Track*);
+typedef void (*deleteTrackFn_t)(Track*);
 
 class GlobalTrackCacheEntry final {
     // We need to hold two shared pointers, the deletingPtr is
@@ -43,14 +43,14 @@ class GlobalTrackCacheEntry final {
   public:
     class TrackDeleter {
     public:
-        explicit TrackDeleter(deleteTrackFn deleteTrack = nullptr)
-                : m_deleteTrack(deleteTrack) {
+        explicit TrackDeleter(deleteTrackFn_t deleteTrackFn = nullptr)
+                : m_deleteTrackFn(deleteTrackFn) {
         }
 
         void operator()(Track* pTrack) const;
 
     private:
-        deleteTrackFn m_deleteTrack;
+        deleteTrackFn_t m_deleteTrackFn;
     };
 
     explicit GlobalTrackCacheEntry(
@@ -199,7 +199,7 @@ public:
     static void createInstance(
             GlobalTrackCacheSaver* pSaver,
             // A custom deleter is only needed for tests without an event loop!
-            deleteTrackFn deleteTrack = nullptr);
+            deleteTrackFn_t deleteTrackFn = nullptr);
     // NOTE(uklotzde, 2018-02-20): We decided not to destroy the singular
     // instance during shutdown, because we are not able to guarantee that
     // all track references have been released before. Instead the singular
@@ -220,7 +220,7 @@ private:
 
     GlobalTrackCache(
             GlobalTrackCacheSaver* pSaver,
-            deleteTrackFn deleteTrack);
+            deleteTrackFn_t deleteTrackFn);
     ~GlobalTrackCache();
 
     void relocateTracks(
@@ -260,7 +260,7 @@ private:
 
     GlobalTrackCacheSaver* m_pSaver;
 
-    deleteTrackFn m_deleteTrack;
+    deleteTrackFn_t m_deleteTrackFn;
 
     // This caches the unsaved Tracks by ID
     typedef std::unordered_map<TrackId, GlobalTrackCacheEntryPointer, TrackId::hash_fun_t> TracksById;

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -43,8 +43,8 @@ class GlobalTrackCacheEntry final {
             std::unique_ptr<Track, void (&)(Track*)> deletingPtr)
         : m_deletingPtr(std::move(deletingPtr)) {
     }
-
     GlobalTrackCacheEntry(const GlobalTrackCacheEntry& other) = delete;
+    GlobalTrackCacheEntry(GlobalTrackCacheEntry&&) = default;
 
     void init(TrackWeakPointer savingWeakPtr) {
         // Uninitialized or expired

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -246,7 +246,7 @@ private:
 
     void purgeTrackId(TrackId trackId);
 
-    bool evict(Track* plainPtr);
+    bool tryEvict(Track* plainPtr);
     bool isCached(Track* plainPtr) const;
 
     bool isEmpty() const;

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -46,14 +46,21 @@ class GlobalTrackCacheEntry final {
 
     GlobalTrackCacheEntry(const GlobalTrackCacheEntry& other) = delete;
 
+    void init(TrackWeakPointer savingWeakPtr) {
+        // Uninitialized or expired
+        DEBUG_ASSERT(!m_savingWeakPtr.lock());
+        m_savingWeakPtr = std::move(savingWeakPtr);
+    }
+
     Track* getPlainPtr() const {
         return m_deletingPtr.get();
     }
-    const TrackWeakPointer& getSavingWeakPtr() const {
-        return m_savingWeakPtr;
+
+    TrackPointer lock() const {
+        return m_savingWeakPtr.lock();
     }
-    void setSavingWeakPtr(TrackWeakPointer savingWeakPtr) {
-        m_savingWeakPtr = std::move(savingWeakPtr);
+    bool expired() const {
+        return m_savingWeakPtr.expired();
     }
 
   private:


### PR DESCRIPTION
I still experience a crash caused by GlobalTrackCache once in a while when closing Mixxx. It happens very infrequently, mostly after loading just a single or a few tracks. These crashes may still be unsolved, nevertheless I discovered some other issues during my investigations:

- Updated or removed outdated comments
- Ensure that all cache items are only moved, never copied
- Verify that functors are called only once
- Fixed edge cases when evicting tracks that might occur due to expected race conditions
- Disconnect receivers and block signals in GlobalTrackCache instead of in the Library code.
- Fixed a memory leak in the concurrency test. Track objects were neither evicted nor deleted because no main event loop is executed! Note: deleteLater() is still not invoked even when calling QCoreApplication::processEvents() periodically! I have added a workaround for Qt >= 5.6.0 in the code, but this memory leak is still present for earlier versions (only in tests).