### PR TITLE
open cover art view on left click release

### DIFF
--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -231,13 +231,27 @@ void WCoverArt::mousePressEvent(QMouseEvent* event) {
     if (event->button() == Qt::RightButton && m_loadedTrack) { // show context-menu
         m_pMenu->setCoverArt(m_lastRequestedCover);
         m_pMenu->popup(event->globalPos());
-    } else if (event->button() == Qt::LeftButton) { // init/close fullsize cover
+    } else if (event->button() == Qt::LeftButton) {
+        // do nothing if left button is pressed,
+        // wait for button release
+        m_clickTimer.setSingleShot(true);
+        m_clickTimer.start(500);
+    }
+}
+
+void WCoverArt::mouseReleaseEvent(QMouseEvent* event) {
+    if (!m_bEnable) {
+        return;
+    }
+
+    if (event->button() == Qt::LeftButton && m_loadedTrack &&
+            m_clickTimer.isActive()) { // init/close fullsize cover
         if (m_pDlgFullSize->isVisible()) {
             m_pDlgFullSize->close();
         } else {
             m_pDlgFullSize->init(m_loadedTrack);
         }
-    }
+    } // else it was a long leftclick or a right click that's already been processed
 }
 
 void WCoverArt::mouseMoveEvent(QMouseEvent* event) {

--- a/src/widget/wcoverart.h
+++ b/src/widget/wcoverart.h
@@ -5,6 +5,7 @@
 #include <QDomNode>
 #include <QMouseEvent>
 #include <QWidget>
+#include <QTimer>
 
 #include "mixer/basetrackplayer.h"
 #include "preferences/usersettings.h"
@@ -47,6 +48,7 @@ class WCoverArt : public QWidget, public WBaseWidget, public TrackDropTarget {
     void paintEvent(QPaintEvent* /*unused*/) override;
     void resizeEvent(QResizeEvent* /*unused*/) override;
     void mousePressEvent(QMouseEvent* /*unused*/) override;
+    void mouseReleaseEvent(QMouseEvent* /*unused*/) override;
 
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
@@ -67,6 +69,7 @@ class WCoverArt : public QWidget, public WBaseWidget, public TrackDropTarget {
     CoverInfo m_lastRequestedCover;
     BaseTrackPlayer* m_pPlayer;
     DlgCoverArtFullSize* m_pDlgFullSize;
+    QTimer m_clickTimer;
 };
 
 #endif // WCOVERART_H


### PR DESCRIPTION
..instead of on button press.

This keeps the view clean when dragging a coverart widget to another deck, playlist etc.
https://bugs.launchpad.net/mixxx/+bug/1844730