### PR TITLE
Follow-up: Use PainterScope everywhere

### DIFF
--- a/src/library/locationdelegate.cpp
+++ b/src/library/locationdelegate.cpp
@@ -11,9 +11,9 @@ void LocationDelegate::paintItem(
         QPainter* painter,
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const {
-    QString elidedLocation = option.fontMetrics.elidedText(
+    QString elidedText = option.fontMetrics.elidedText(
             index.data().toString(),
             Qt::ElideLeft,
             columnWidth(index));
-    painter->drawText(option.rect, Qt::AlignVCenter, elidedLocation);
+    painter->drawText(option.rect, Qt::AlignVCenter, elidedText);
 }

--- a/src/library/stareditor.cpp
+++ b/src/library/stareditor.cpp
@@ -28,6 +28,7 @@
 
 #include "library/stareditor.h"
 #include "library/starrating.h"
+#include "util/painterscope.h"
 
 /*
  * We enable mouse tracking on the widget so we can follow the cursor even
@@ -54,7 +55,8 @@ void StarEditor::renderHelper(QPainter* painter,
                               QTableView* pTableView,
                               const QStyleOptionViewItem& option,
                               StarRating* pStarRating) {
-    painter->save();
+    PainterScope painterScope(painter);
+
     painter->setClipRect(option.rect);
 
     if (pTableView != NULL) {
@@ -80,7 +82,6 @@ void StarEditor::renderHelper(QPainter* painter,
     }
 
     pStarRating->paint(painter, option.rect);
-    painter->restore();
 }
 
 void StarEditor::paintEvent(QPaintEvent*) {

--- a/src/library/tableitemdelegate.cpp
+++ b/src/library/tableitemdelegate.cpp
@@ -22,10 +22,14 @@ void TableItemDelegate::paint(
     // Set the palette appropriately based on whether the row is selected or
     // not. We also have to check if it is inactive or not and use the
     // appropriate ColorGroup.
-    QPalette::ColorGroup cg = option.state & QStyle::State_Enabled
-            ? QPalette::Normal : QPalette::Disabled;
-    if (cg == QPalette::Normal && !(option.state & QStyle::State_Active))
-        cg = QPalette::Inactive;
+    QPalette::ColorGroup cg = QPalette::Normal;
+    if (option.state & QStyle::State_Enabled) {
+        if (!(option.state & QStyle::State_Active)) {
+            cg = QPalette::Disabled;
+        }
+    } else {
+        cg = QPalette::Disabled;
+    }
 
     if (option.state & QStyle::State_Selected) {
         painter->setBrush(option.palette.color(cg, QPalette::HighlightedText));
@@ -36,7 +40,10 @@ void TableItemDelegate::paint(
     if (m_pTableView) {
         QStyle* style = m_pTableView->style();
         if (style) {
-            style->drawControl(QStyle::CE_ItemViewItem, &option, painter,
+            style->drawControl(
+                    QStyle::CE_ItemViewItem,
+                    &option,
+                    painter,
                     m_pTableView);
         }
     }

--- a/src/library/tableitemdelegate.cpp
+++ b/src/library/tableitemdelegate.cpp
@@ -3,6 +3,8 @@
 #include <QTableView>
 #include <QPainter>
 
+#include "util/painterscope.h"
+
 
 TableItemDelegate::TableItemDelegate(QTableView* pTableView)
         : QStyledItemDelegate(pTableView),
@@ -13,8 +15,7 @@ void TableItemDelegate::paint(
         QPainter* painter,
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const {
-
-    painter->save();
+    PainterScope painterScope(painter);
 
     painter->setClipRect(option.rect);
 
@@ -41,8 +42,6 @@ void TableItemDelegate::paint(
     }
 
     paintItem(painter, option, index);
-
-    painter->restore();
 }
 
 int TableItemDelegate::columnWidth(const QModelIndex &index) const {

--- a/src/util/painterscope.h
+++ b/src/util/painterscope.h
@@ -6,6 +6,8 @@
 
 #include <QPainter>
 
+#include "util/assert.h"
+
 // This class provides RAII style management of a QPainter properties.
 //
 // PainterScope will save the painter state on creation, and restore it

--- a/src/waveform/renderers/qtvsynctestrenderer.cpp
+++ b/src/waveform/renderers/qtvsynctestrenderer.cpp
@@ -3,6 +3,7 @@
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"
+#include "util/painterscope.h"
 #include "util/performancetimer.h"
 
 QtVSyncTestRenderer::QtVSyncTestRenderer(
@@ -51,7 +52,7 @@ void QtVSyncTestRenderer::draw(QPainter* pPainter, QPaintEvent* /*event*/) {
         return;
     }
 
-    pPainter->save();
+    PainterScope PainterScope(pPainter);
 
     auto brush = QBrush(Qt::SolidPattern);
     if (++m_drawcount & 1) {
@@ -64,6 +65,4 @@ void QtVSyncTestRenderer::draw(QPainter* pPainter, QPaintEvent* /*event*/) {
 
     pPainter->drawRect(0, 0, m_waveformRenderer->getWidth(),
             m_waveformRenderer->getHeight());
-
-    pPainter->restore();
 }

--- a/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
@@ -6,6 +6,7 @@
 #include "control/controlproxy.h"
 #include "track/track.h"
 #include "util/math.h"
+#include "util/painterscope.h"
 
 #include <QLineF>
 #include <QLinearGradient>
@@ -275,7 +276,7 @@ void QtWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
     if (!pTrack)
         return;
 
-    painter->save();
+    PainterScope PainterScope(painter);
 
     painter->setRenderHint(QPainter::Antialiasing);
     painter->resetTransform();
@@ -335,6 +336,4 @@ void QtWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
         painter->setBrush(m_highBrush);
     }
     painter->drawPolygon(&m_polygon[2][0], numberOfPoints);
-
-    painter->restore();
 }

--- a/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
@@ -7,6 +7,7 @@
 #include "widget/wwidget.h"
 #include "track/track.h"
 #include "util/math.h"
+#include "util/painterscope.h"
 
 #include <QLinearGradient>
 
@@ -58,7 +59,7 @@ void QtWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
         return;
     }
 
-    painter->save();
+    PainterScope PainterScope(painter);
 
     painter->setRenderHint(QPainter::Antialiasing);
     painter->resetTransform();
@@ -214,8 +215,6 @@ void QtWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
     painter->setBrush(m_brush);
 
     painter->drawPolygon(&m_polygon[0], m_polygon.size());
-
-    painter->restore();
 }
 
 void QtWaveformRendererSimpleSignal::onResize() {

--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -10,6 +10,7 @@
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "widget/wskincolor.h"
 #include "widget/wwidget.h"
+#include "util/painterscope.h"
 
 WaveformRenderBeat::WaveformRenderBeat(WaveformWidgetRenderer* waveformWidgetRenderer)
         : WaveformRendererAbstract(waveformWidgetRenderer) {
@@ -62,7 +63,8 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
         return;
     }
 
-    painter->save();
+    PainterScope PainterScope(painter);
+
     painter->setRenderHint(QPainter::Antialiasing);
 
     QPen beatPen(m_beatColor);
@@ -96,6 +98,4 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
 
     // Make sure to use constData to prevent detaches!
     painter->drawLines(m_beats.constData(), beatCount);
-
-    painter->restore();
 }

--- a/src/waveform/renderers/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/waveformrendererendoftrack.cpp
@@ -11,6 +11,7 @@
 #include "widget/wskincolor.h"
 #include "widget/wwidget.h"
 
+#include "util/painterscope.h"
 #include "util/timer.h"
 
 namespace {
@@ -74,7 +75,8 @@ void WaveformRendererEndOfTrack::draw(QPainter* painter,
     const double criticalIntensity = (remainingTimeTriggerSeconds - remainingTime) /
             remainingTimeTriggerSeconds;
 
-    painter->save();
+    PainterScope PainterScope(painter);
+
     painter->resetTransform();
     painter->setOpacity(0.5 * blinkIntensity);
     painter->setPen(m_pen);
@@ -90,7 +92,6 @@ void WaveformRendererEndOfTrack::draw(QPainter* painter,
     //painter->fillRect(m_waveformRenderer->getWidth()/2, 1,
     //        m_waveformRenderer->getWidth() - 2, m_waveformRenderer->getHeight() - 2,
     //        m_gradient);
-    painter->restore();
 }
 
 void WaveformRendererEndOfTrack::generateBackRects() {

--- a/src/waveform/renderers/waveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.cpp
@@ -8,6 +8,7 @@
 #include "track/track.h"
 #include "widget/wwidget.h"
 #include "util/math.h"
+#include "util/painterscope.h"
 
 WaveformRendererFilteredSignal::WaveformRendererFilteredSignal(
         WaveformWidgetRenderer* waveformWidgetRenderer)
@@ -49,7 +50,8 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
         return;
     }
 
-    painter->save();
+    PainterScope PainterScope(painter);
+
     painter->setRenderHints(QPainter::Antialiasing, false);
     painter->setRenderHints(QPainter::HighQualityAntialiasing, false);
     painter->setRenderHints(QPainter::SmoothPixmapTransform, false);
@@ -235,6 +237,4 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
     if (m_pHighKillControlObject && m_pHighKillControlObject->get() == 0.0) {
         painter->drawLines(&m_highLines[0], actualHighLineNumber);
     }
-
-    painter->restore();
 }

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -8,6 +8,7 @@
 #include "track/track.h"
 #include "widget/wwidget.h"
 #include "util/math.h"
+#include "util/painterscope.h"
 
 WaveformRendererHSV::WaveformRendererHSV(
         WaveformWidgetRenderer* waveformWidgetRenderer)
@@ -43,7 +44,8 @@ void WaveformRendererHSV::draw(QPainter* painter,
         return;
     }
 
-    painter->save();
+    PainterScope PainterScope(painter);
+
     painter->setRenderHints(QPainter::Antialiasing, false);
     painter->setRenderHints(QPainter::HighQualityAntialiasing, false);
     painter->setRenderHints(QPainter::SmoothPixmapTransform, false);
@@ -182,6 +184,4 @@ void WaveformRendererHSV::draw(QPainter* painter,
             }
         }
     }
-
-    painter->restore();
 }

--- a/src/waveform/renderers/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/waveformrendererpreroll.cpp
@@ -9,6 +9,7 @@
 #include "waveform/waveform.h"
 #include "widget/wskincolor.h"
 #include "widget/wwidget.h"
+#include "util/painterscope.h"
 
 WaveformRendererPreroll::WaveformRendererPreroll(WaveformWidgetRenderer* waveformWidgetRenderer)
   : WaveformRendererAbstract(waveformWidgetRenderer) {
@@ -51,7 +52,8 @@ void WaveformRendererPreroll::draw(QPainter* painter, QPaintEvent* event) {
         const float halfBreadth = m_waveformRenderer->getBreadth() / 2.0;
         const float halfPolyBreadth = m_waveformRenderer->getBreadth() / 5.0;
 
-        painter->save();
+        PainterScope PainterScope(painter);
+
         painter->setRenderHint(QPainter::Antialiasing);
         //painter->setRenderHint(QPainter::HighQualityAntialiasing);
         //painter->setBackgroundMode(Qt::TransparentMode);
@@ -81,7 +83,5 @@ void WaveformRendererPreroll::draw(QPainter* painter, QPaintEvent* event) {
             polygon.translate(-(polyLength + 1), 0);
             index -= (polyLength + 1) * samplesPerPixel;
         }
-
-        painter->restore();
     }
 }

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -8,6 +8,7 @@
 #include "track/track.h"
 #include "widget/wwidget.h"
 #include "util/math.h"
+#include "util/painterscope.h"
 
 WaveformRendererRGB::WaveformRendererRGB(
         WaveformWidgetRenderer* waveformWidgetRenderer)
@@ -42,7 +43,8 @@ void WaveformRendererRGB::draw(QPainter* painter,
         return;
     }
 
-    painter->save();
+    PainterScope PainterScope(painter);
+
     painter->setRenderHints(QPainter::Antialiasing, false);
     painter->setRenderHints(QPainter::HighQualityAntialiasing, false);
     painter->setRenderHints(QPainter::SmoothPixmapTransform, false);
@@ -176,6 +178,4 @@ void WaveformRendererRGB::draw(QPainter* painter,
             }
         }
     }
-
-    painter->restore();
 }

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -12,6 +12,7 @@
 #include "widget/wskincolor.h"
 #include "widget/wwidget.h"
 #include "widget/wimagestore.h"
+#include "util/painterscope.h"
 
 namespace {
     const int kMaxCueLabelLength = 23;
@@ -33,7 +34,7 @@ void WaveformRenderMark::setup(const QDomNode& node, const SkinContext& context)
 }
 
 void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
-    painter->save();
+    PainterScope PainterScope(painter);
 
     /*
     //DEBUG
@@ -82,8 +83,6 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
             }
         }
     }
-
-    painter->restore();
 }
 
 void WaveformRenderMark::onResize() {

--- a/src/waveform/renderers/waveformrendermarkrange.cpp
+++ b/src/waveform/renderers/waveformrendermarkrange.cpp
@@ -13,6 +13,7 @@
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "widget/wskincolor.h"
 #include "widget/wwidget.h"
+#include "util/painterscope.h"
 
 WaveformRenderMarkRange::WaveformRenderMarkRange(WaveformWidgetRenderer* waveformWidgetRenderer) :
     WaveformRendererAbstract(waveformWidgetRenderer) {
@@ -37,7 +38,7 @@ void WaveformRenderMarkRange::setup(const QDomNode& node, const SkinContext& con
 }
 
 void WaveformRenderMarkRange::draw(QPainter *painter, QPaintEvent * /*event*/) {
-    painter->save();
+    PainterScope PainterScope(painter);
 
     painter->setWorldMatrixEnabled(false);
 
@@ -82,8 +83,6 @@ void WaveformRenderMarkRange::draw(QPainter *painter, QPaintEvent * /*event*/) {
         }
         painter->drawImage(rect, *selectedImage, rect);
     }
-
-    painter->restore();
 }
 
 void WaveformRenderMarkRange::generateImages() {

--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -5,9 +5,11 @@
 #include <QString>
 #include <QtDebug>
 
+#include "skin/imgloader.h"
+
 #include "util/math.h"
 #include "util/memory.h"
-#include "skin/imgloader.h"
+#include "util/painterscope.h"
 
 // static
 Paintable::DrawMode Paintable::DrawModeFromString(const QString& str) {
@@ -244,12 +246,11 @@ void Paintable::drawInternal(const QRectF& targetRect, QPainter* pPainter,
             // entire SVG to the painter. We save/restore the QPainter in case
             // there is an existing clip region (I don't know of any Mixxx code
             // that uses one but we may in the future).
-            pPainter->save();
+            PainterScope PainterScope(pPainter);
             pPainter->setClipping(true);
             pPainter->setClipRect(targetRect);
             m_pSvg->setViewBox(sourceRect);
             m_pSvg->render(pPainter, targetRect);
-            pPainter->restore();
         }
     }
 }


### PR DESCRIPTION
- Use PainterScope everywhere instead of manually invoking QPainter::save() and QPainter::restore()
- Minor readability improvements in the recently changed table item delegates