### PR TITLE
Fix race condition(s) while unloading/loading tracks

### DIFF
--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -221,7 +221,7 @@ void CachingReader::process() {
         DEBUG_ASSERT(m_state != State::Idle);
         auto pChunk = update.takeFromWorker();
         if (pChunk) {
-            // Response to a read request
+            // Result of a read request (with a chunk)
             DEBUG_ASSERT(
                     update.status == CHUNK_READ_SUCCESS ||
                     update.status == CHUNK_READ_EOF ||
@@ -252,6 +252,7 @@ void CachingReader::process() {
                         update.readableFrameIndexRange());
             }
         } else {
+            // State update (without a chunk)
             DEBUG_ASSERT(!m_mruCachingReaderChunk);
             DEBUG_ASSERT(!m_lruCachingReaderChunk);
             if (update.status == TRACK_LOADED) {

--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -231,9 +231,8 @@ void CachingReader::process() {
                 // All chunks have been freed before loading the next track!
                 DEBUG_ASSERT(!m_mruCachingReaderChunk);
                 DEBUG_ASSERT(!m_lruCachingReaderChunk);
-                // Discard all pending read requests for the previous track
-                // that are discarded by the worker before loading the next
-                // track.
+                // Discard all results from pending read requests for the
+                // previous track before the next track has been loaded.
                 freeChunk(pChunk);
                 continue;
             }

--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -201,13 +201,17 @@ CachingReaderChunkForOwner* CachingReader::lookupChunkAndFreshen(SINT chunkIndex
 }
 
 void CachingReader::newTrack(TrackPointer pTrack) {
+    // Feed the track to the worker as soon as possible
+    // to get ready while the reader switches its internal
+    // state. There are no race conditions, because the
+    // reader polls the worker.
     m_worker.newTrack(pTrack);
     m_worker.workReady();
     // Don't accept any new read requests until the current
     // track has been unloaded and the new track has been
-    // loaded!
+    // loaded.
     m_state = State::TrackLoading;
-    // Free all chunks with sample data from the current track
+    // Free all chunks with sample data from the current track.
     freeAllChunks();
 }
 

--- a/src/engine/cachingreader.h
+++ b/src/engine/cachingreader.h
@@ -124,7 +124,7 @@ class CachingReader : public QObject {
     // Thread-safe FIFOs for communication between the engine callback and
     // reader thread.
     FIFO<CachingReaderChunkReadRequest> m_chunkReadRequestFIFO;
-    FIFO<ReaderStatusUpdate> m_readerStatusFIFO;
+    FIFO<ReaderStatusUpdate> m_stateFIFO;
 
     // Looks for the provided chunk number in the index of in-memory chunks and
     // returns it if it is present. If not, returns nullptr. If it is present then
@@ -151,7 +151,12 @@ class CachingReader : public QObject {
     // Gets a chunk from the free list, frees the LRU CachingReaderChunk if none available.
     CachingReaderChunkForOwner* allocateChunkExpireLRU(SINT chunkIndex);
 
-    ReaderStatus m_readerStatus;
+    enum class State {
+        Idle,
+        TrackLoading,
+        TrackLoaded,
+    };
+    State m_state;
 
     // Keeps track of all CachingReaderChunks we've allocated.
     QVector<CachingReaderChunkForOwner*> m_chunks;

--- a/src/engine/cachingreaderworker.cpp
+++ b/src/engine/cachingreaderworker.cpp
@@ -122,19 +122,26 @@ void CachingReaderWorker::run() {
 }
 
 void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
-    ReaderStatusUpdate update;
-    update.init(TRACK_NOT_LOADED);
+    // Discard all pending read requests
+    CachingReaderChunkReadRequest request;
+    while (m_pChunkReadRequestFIFO->read(&request, 1) == 1) {
+        const auto update = ReaderStatusUpdate::readDiscarded(request.chunk);
+        m_pReaderStatusFIFO->writeBlocking(&update, 1);
+    }
+
+    // Unload the track
+    m_readableFrameIndexRange = mixxx::IndexRange();
+    m_pAudioSource.reset(); // Close open file handles
 
     if (!pTrack) {
-        // Unload track
-        m_pAudioSource.reset(); // Close open file handles
-        m_readableFrameIndexRange = mixxx::IndexRange();
+        // If no new track is available then we are done
+        const auto update = ReaderStatusUpdate::trackNotLoaded();
         m_pReaderStatusFIFO->writeBlocking(&update, 1);
         return;
     }
 
     // Emit that a new track is loading, stops the current track
-    emit(trackLoading());
+    emit trackLoading();
 
     QString filename = pTrack->getLocation();
     if (filename.isEmpty() || !pTrack->exists()) {
@@ -142,10 +149,11 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
                  << m_group
                  << "File not found"
                  << filename;
+        const auto update = ReaderStatusUpdate::trackNotLoaded();
         m_pReaderStatusFIFO->writeBlocking(&update, 1);
-        emit(trackLoadFailed(
+        emit trackLoadFailed(
             pTrack, QString("The file '%1' could not be found.")
-                    .arg(QDir::toNativeSeparators(filename))));
+                    .arg(QDir::toNativeSeparators(filename)));
         return;
     }
 
@@ -153,42 +161,50 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     config.setChannelCount(CachingReaderChunk::kChannels);
     m_pAudioSource = SoundSourceProxy(pTrack).openAudioSource(config);
     if (!m_pAudioSource) {
-        m_readableFrameIndexRange = mixxx::IndexRange();
         kLogger.warning()
                 << m_group
                 << "Failed to open file"
                 << filename;
+        const auto update = ReaderStatusUpdate::trackNotLoaded();
         m_pReaderStatusFIFO->writeBlocking(&update, 1);
-        emit(trackLoadFailed(
-            pTrack, QString("The file '%1' could not be loaded.").arg(filename)));
+        emit trackLoadFailed(
+            pTrack, QString("The file '%1' could not be loaded").arg(filename));
         return;
-    }
-
-    const SINT tempReadBufferSize = m_pAudioSource->frames2samples(CachingReaderChunk::kFrames);
-    if (m_tempReadBuffer.size() != tempReadBufferSize) {
-        mixxx::SampleBuffer(tempReadBufferSize).swap(m_tempReadBuffer);
     }
 
     // Initially assume that the complete content offered by audio source
     // is available for reading. Later if read errors occur this value will
     // be decreased to avoid repeated reading of corrupt audio data.
     m_readableFrameIndexRange = m_pAudioSource->frameIndexRange();
-
-    update.init(TRACK_LOADED, nullptr, m_pAudioSource->frameIndexRange());
-    m_pReaderStatusFIFO->writeBlocking(&update, 1);
-
-    // Clear the chunks to read list.
-    CachingReaderChunkReadRequest request;
-    while (m_pChunkReadRequestFIFO->read(&request, 1) == 1) {
-        update.init(CHUNK_READ_INVALID, request.chunk);
+    if (m_readableFrameIndexRange.empty()) {
+        m_pAudioSource.reset(); // Close open file handles
+        kLogger.warning()
+                << m_group
+                << "Failed to open empty file"
+                << filename;
+        const auto update = ReaderStatusUpdate::trackNotLoaded();
         m_pReaderStatusFIFO->writeBlocking(&update, 1);
+        emit trackLoadFailed(
+            pTrack, QString("The file '%1' is empty and could not be loaded").arg(filename));
+        return;
     }
+
+    // Adjust the internal buffer
+    const SINT tempReadBufferSize =
+            m_pAudioSource->frames2samples(CachingReaderChunk::kFrames);
+    if (m_tempReadBuffer.size() != tempReadBufferSize) {
+        mixxx::SampleBuffer(tempReadBufferSize).swap(m_tempReadBuffer);
+    }
+
+    const auto update =
+        ReaderStatusUpdate::trackLoaded(m_readableFrameIndexRange);
+    m_pReaderStatusFIFO->writeBlocking(&update, 1);
 
     // Emit that the track is loaded.
     const SINT sampleCount =
             CachingReaderChunk::frames2samples(
-                    m_pAudioSource->frameLength());
-    emit(trackLoaded(pTrack, m_pAudioSource->sampleRate(), sampleCount));
+                    m_readableFrameIndexRange.length());
+    emit trackLoaded(pTrack, m_pAudioSource->sampleRate(), sampleCount);
 }
 
 void CachingReaderWorker::quitWait() {

--- a/src/engine/cachingreaderworker.h
+++ b/src/engine/cachingreaderworker.h
@@ -26,9 +26,8 @@ typedef struct CachingReaderChunkReadRequest {
 } CachingReaderChunkReadRequest;
 
 enum ReaderStatus {
-    INVALID,
-    TRACK_NOT_LOADED,
     TRACK_LOADED,
+    TRACK_UNLOADED,
     CHUNK_READ_SUCCESS,
     CHUNK_READ_EOF,
     CHUNK_READ_INVALID,
@@ -72,7 +71,7 @@ typedef struct ReaderStatusUpdate {
 
     static ReaderStatusUpdate trackNotLoaded() {
         ReaderStatusUpdate update;
-        update.init(TRACK_NOT_LOADED, nullptr, mixxx::IndexRange());
+        update.init(TRACK_UNLOADED, nullptr, mixxx::IndexRange());
         return update;
     }
 

--- a/src/engine/cachingreaderworker.h
+++ b/src/engine/cachingreaderworker.h
@@ -31,7 +31,8 @@ enum ReaderStatus {
     TRACK_LOADED,
     CHUNK_READ_SUCCESS,
     CHUNK_READ_EOF,
-    CHUNK_READ_INVALID
+    CHUNK_READ_INVALID,
+    CHUNK_READ_DISCARDED, // response without frame index range!
 };
 
 // POD with trivial ctor/dtor/copy for passing through FIFO
@@ -45,13 +46,34 @@ typedef struct ReaderStatusUpdate {
     ReaderStatus status;
 
     void init(
-            ReaderStatus statusArg = INVALID,
-            CachingReaderChunk* chunkArg = nullptr,
-            const mixxx::IndexRange& readableFrameIndexRangeArg = mixxx::IndexRange()) {
+            ReaderStatus statusArg,
+            CachingReaderChunk* chunkArg,
+            const mixxx::IndexRange& readableFrameIndexRangeArg) {
         status = statusArg;
         chunk = chunkArg;
         readableFrameIndexRangeStart = readableFrameIndexRangeArg.start();
         readableFrameIndexRangeEnd = readableFrameIndexRangeArg.end();
+    }
+
+    static ReaderStatusUpdate readDiscarded(
+            CachingReaderChunk* chunk) {
+        ReaderStatusUpdate update;
+        update.init(CHUNK_READ_DISCARDED, chunk, mixxx::IndexRange());
+        return update;
+    }
+
+    static ReaderStatusUpdate trackLoaded(
+            const mixxx::IndexRange& readableFrameIndexRange) {
+        DEBUG_ASSERT(!readableFrameIndexRange.empty());
+        ReaderStatusUpdate update;
+        update.init(TRACK_LOADED, nullptr, readableFrameIndexRange);
+        return update;
+    }
+
+    static ReaderStatusUpdate trackNotLoaded() {
+        ReaderStatusUpdate update;
+        update.init(TRACK_NOT_LOADED, nullptr, mixxx::IndexRange());
+        return update;
     }
 
     CachingReaderChunkForOwner* takeFromWorker() {


### PR DESCRIPTION
**_I'm not able to reproduce the bug. Awaiting confirmation that this PR fixes the bug!_**

https://bugs.launchpad.net/mixxx/+bug/1845695

Not a single, but multiple potential race conditions and wrong ordering of responses while unloading and loading tracks!

Pending read requests are discarded when unloading a track. But their response arrived when the new track had already been loaded. This would reset the readable frame index range to empty and the new track plays with silence.

Also, the FIFO between the worker and the reader needs to be drained entirely when unloading a track. No new read requests must be accepted until the new track has been loaded.

I've added many debug assertions to detect any inconsistencies and wrong assumptions.