### PR TITLE
Minor metadata improvements

### DIFF
--- a/src/track/albuminfo.cpp
+++ b/src/track/albuminfo.cpp
@@ -4,6 +4,7 @@
 namespace mixxx {
 
 void AlbumInfo::resetUnsupportedValues() {
+#if defined(__EXTRA_METADATA__)
     setCopyright(QString());
     setLicense(QString());
     setMusicBrainzArtistId(QString());
@@ -11,23 +12,27 @@ void AlbumInfo::resetUnsupportedValues() {
     setMusicBrainzReleaseGroupId(QString());
     setRecordLabel(QString());
     setReplayGain(ReplayGain());
+#endif // __EXTRA_METADATA__
 }
 
 bool operator==(const AlbumInfo& lhs, const AlbumInfo& rhs) {
     return (lhs.getArtist() == rhs.getArtist()) &&
+#if defined(__EXTRA_METADATA__)
             (lhs.getCopyright() == rhs.getCopyright()) &&
             (lhs.getLicense() == rhs.getLicense()) &&
             (lhs.getMusicBrainzArtistId() == rhs.getMusicBrainzArtistId()) &&
-            (lhs.getMusicBrainzReleaseId() == rhs.getMusicBrainzReleaseId()) &&
             (lhs.getMusicBrainzReleaseGroupId() == rhs.getMusicBrainzReleaseGroupId()) &&
+            (lhs.getMusicBrainzReleaseId() == rhs.getMusicBrainzReleaseId()) &&
             (lhs.getRecordLabel() == rhs.getRecordLabel()) &&
             (lhs.getReplayGain() == rhs.getReplayGain()) &&
+#endif // __EXTRA_METADATA__
             (lhs.getTitle() == rhs.getTitle());
 }
 
 QDebug operator<<(QDebug dbg, const AlbumInfo& arg) {
     dbg << '{';
     arg.dbgArtist(dbg);
+#if defined(__EXTRA_METADATA__)
     arg.dbgCopyright(dbg);
     arg.dbgLicense(dbg);
     arg.dbgMusicBrainzArtistId(dbg);
@@ -35,6 +40,7 @@ QDebug operator<<(QDebug dbg, const AlbumInfo& arg) {
     arg.dbgMusicBrainzReleaseGroupId(dbg);
     arg.dbgRecordLabel(dbg);
     arg.dbgReplayGain(dbg);
+#endif // __EXTRA_METADATA__
     arg.dbgTitle(dbg);
     dbg << '}';
     return dbg;

--- a/src/track/albuminfo.h
+++ b/src/track/albuminfo.h
@@ -13,13 +13,15 @@ namespace mixxx {
 class AlbumInfo final {
     // Album and release properties (in alphabetical order)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    artist,                    Artist)
+#if defined(__EXTRA_METADATA__)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    copyright,                 Copyright)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    license,                   License)
     PROPERTY_SET_BYVAL_GET_BYREF(QUuid,      musicBrainzArtistId,       MusicBrainzArtistId)
-    PROPERTY_SET_BYVAL_GET_BYREF(QUuid,      musicBrainzReleaseId,      MusicBrainzReleaseId)
     PROPERTY_SET_BYVAL_GET_BYREF(QUuid,      musicBrainzReleaseGroupId, MusicBrainzReleaseGroupId)
+    PROPERTY_SET_BYVAL_GET_BYREF(QUuid,      musicBrainzReleaseId,      MusicBrainzReleaseId)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    recordLabel,               RecordLabel)
     PROPERTY_SET_BYVAL_GET_BYREF(ReplayGain, replayGain,                ReplayGain)
+#endif // __EXTRA_METADATA__
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    title,                     Title)
 
 public:
@@ -34,10 +36,12 @@ public:
     // TODO(XXX): Remove after all new fields have been added to the library
     void resetUnsupportedValues();
 
-    // Adjusts floating-point values to match their string representation
+    // Adjusts floating-point properties to match their string representation
     // in file tags to account for rounding errors.
     void normalizeBeforeExport() {
+#if defined(__EXTRA_METADATA__)
         refReplayGain().normalizeBeforeExport();
+#endif // __EXTRA_METADATA__
     }
 };
 

--- a/src/track/trackinfo.cpp
+++ b/src/track/trackinfo.cpp
@@ -4,6 +4,7 @@
 namespace mixxx {
 
 void TrackInfo::resetUnsupportedValues() {
+#if defined(__EXTRA_METADATA__)
     setConductor(QString());
     setDiscNumber(QString());
     setDiscTotal(QString());
@@ -21,6 +22,7 @@ void TrackInfo::resetUnsupportedValues() {
     setRemixer(QString());
     setSubtitle(QString());
     setWork(QString());
+#endif // __EXTRA_METADATA__
 }
 
 namespace {
@@ -67,15 +69,20 @@ bool operator==(const TrackInfo& lhs, const TrackInfo& rhs) {
             (lhs.getBpm() == rhs.getBpm()) &&
             (lhs.getComment() == rhs.getComment()) &&
             (lhs.getComposer() == rhs.getComposer()) &&
+#if defined(__EXTRA_METADATA__)
             (lhs.getConductor() == rhs.getConductor()) &&
             (lhs.getDiscNumber() == rhs.getDiscNumber()) &&
             (lhs.getDiscTotal() == rhs.getDiscTotal()) &&
             (lhs.getEncoder() == rhs.getEncoder()) &&
             (lhs.getEncoderSettings() == rhs.getEncoderSettings()) &&
+#endif // __EXTRA_METADATA__
             (lhs.getGenre() == rhs.getGenre()) &&
             (lhs.getGrouping() == rhs.getGrouping()) &&
+#if defined(__EXTRA_METADATA__)
             (lhs.getISRC() == rhs.getISRC()) &&
+#endif // __EXTRA_METADATA__
             (lhs.getKey() == rhs.getKey()) &&
+#if defined(__EXTRA_METADATA__)
             (lhs.getLanguage() == rhs.getLanguage()) &&
             (lhs.getLyricist() == rhs.getLyricist()) &&
             (lhs.getMood() == rhs.getMood()) &&
@@ -85,12 +92,17 @@ bool operator==(const TrackInfo& lhs, const TrackInfo& rhs) {
             (lhs.getMusicBrainzReleaseId() == rhs.getMusicBrainzReleaseId()) &&
             (lhs.getMusicBrainzWorkId() == rhs.getMusicBrainzWorkId()) &&
             (lhs.getRemixer() == rhs.getRemixer()) &&
+#endif // __EXTRA_METADATA__
             (lhs.getReplayGain() == rhs.getReplayGain()) &&
+#if defined(__EXTRA_METADATA__)
             (lhs.getSubtitle() == rhs.getSubtitle()) &&
+#endif // __EXTRA_METADATA__
             (lhs.getTitle() == rhs.getTitle()) &&
             (lhs.getTrackNumber() == rhs.getTrackNumber()) &&
             (lhs.getTrackTotal() == rhs.getTrackTotal()) &&
+#if defined(__EXTRA_METADATA__)
             (lhs.getWork() == rhs.getWork()) &&
+#endif // __EXTRA_METADATA__
             (lhs.getYear() == rhs.getYear());
 }
 
@@ -100,15 +112,20 @@ QDebug operator<<(QDebug dbg, const TrackInfo& arg) {
     arg.dbgBpm(dbg);
     arg.dbgComment(dbg);
     arg.dbgComposer(dbg);
+#if defined(__EXTRA_METADATA__)
     arg.dbgConductor(dbg);
     arg.dbgDiscNumber(dbg);
     arg.dbgDiscTotal(dbg);
     arg.dbgEncoder(dbg);
     arg.dbgEncoderSettings(dbg);
+#endif // __EXTRA_METADATA__
     arg.dbgGenre(dbg);
     arg.dbgGrouping(dbg);
+#if defined(__EXTRA_METADATA__)
     arg.dbgISRC(dbg);
+#endif // __EXTRA_METADATA__
     arg.dbgKey(dbg);
+#if defined(__EXTRA_METADATA__)
     arg.dbgLanguage(dbg);
     arg.dbgLyricist(dbg);
     arg.dbgMood(dbg);
@@ -118,12 +135,17 @@ QDebug operator<<(QDebug dbg, const TrackInfo& arg) {
     arg.dbgMusicBrainzReleaseId(dbg);
     arg.dbgMusicBrainzWorkId(dbg);
     arg.dbgRemixer(dbg);
+#endif // __EXTRA_METADATA__
     arg.dbgReplayGain(dbg);
+#if defined(__EXTRA_METADATA__)
     arg.dbgSubtitle(dbg);
+#endif // __EXTRA_METADATA__
     arg.dbgTitle(dbg);
     arg.dbgTrackNumber(dbg);
     arg.dbgTrackTotal(dbg);
+#if defined(__EXTRA_METADATA__)
     arg.dbgWork(dbg);
+#endif // __EXTRA_METADATA__
     arg.dbgYear(dbg);
     dbg << '}';
     return dbg;

--- a/src/track/trackinfo.h
+++ b/src/track/trackinfo.h
@@ -20,15 +20,20 @@ class TrackInfo final {
     PROPERTY_SET_BYVAL_GET_BYREF(Bpm,        bpm,                  Bpm)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    comment,              Comment)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    composer,             Composer)
+#if defined(__EXTRA_METADATA__)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    conductor,            Conductor)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    discNumber,           DiscNumber)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    discTotal,            DiscTotal)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    encoder,              Encoder)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    encoderSettings,      EncoderSettings)
+#endif // __EXTRA_METADATA__
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    genre,                Genre)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    grouping,             Grouping)
-    PROPERTY_SET_BYVAL_GET_BYREF(QString,    key,                  Key)
+#if defined(__EXTRA_METADATA__)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    isrc,                 ISRC)
+#endif // __EXTRA_METADATA__
+    PROPERTY_SET_BYVAL_GET_BYREF(QString,    key,                  Key)
+#if defined(__EXTRA_METADATA__)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    language,             Language)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    lyricist,             Lyricist)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    mood,                 Mood)
@@ -38,12 +43,17 @@ class TrackInfo final {
     PROPERTY_SET_BYVAL_GET_BYREF(QUuid,      musicBrainzReleaseId, MusicBrainzReleaseId)
     PROPERTY_SET_BYVAL_GET_BYREF(QUuid,      musicBrainzWorkId,    MusicBrainzWorkId)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    remixer,              Remixer)
+#endif // __EXTRA_METADATA__
     PROPERTY_SET_BYVAL_GET_BYREF(ReplayGain, replayGain,           ReplayGain)
+#if defined(__EXTRA_METADATA__)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    subtitle,             Subtitle)
+#endif // __EXTRA_METADATA__
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    title,                Title)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    trackNumber,          TrackNumber)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    trackTotal,           TrackTotal)
+#if defined(__EXTRA_METADATA__)
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    work,                 Work)
+#endif // __EXTRA_METADATA__
     PROPERTY_SET_BYVAL_GET_BYREF(QString,    year,                 Year) // = release date
 
 public:
@@ -63,7 +73,7 @@ public:
     // TODO(XXX): Remove after all new fields have been added to the library
     void resetUnsupportedValues();
 
-    // Adjusts floating-point values to match their string representation
+    // Adjusts floating-point properties to match their string representation
     // in file tags to account for rounding errors.
     void normalizeBeforeExport() {
         refBpm().normalizeBeforeExport();

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -242,7 +242,11 @@ inline QString formatBpm(const TrackMetadata& trackMetadata) {
 
 inline
 QString formatBpmInteger(const TrackMetadata& trackMetadata) {
-    return QString::number(Bpm::valueToInteger(trackMetadata.getTrackInfo().getBpm().getValue()));
+    if (trackMetadata.getTrackInfo().getBpm().hasValue()) {
+        return QString::number(Bpm::valueToInteger(trackMetadata.getTrackInfo().getBpm().getValue()));
+    } else {
+        return QString();
+    }
 }
 
 bool parseBpm(TrackMetadata* pTrackMetadata, QString sBpm) {

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -18,9 +18,9 @@ void TrackRecord::setKeys(const Keys& keys) {
 }
 
 bool TrackRecord::updateGlobalKey(
-        mixxx::track::io::key::ChromaticKey key,
-        mixxx::track::io::key::Source keySource) {
-    if (key == mixxx::track::io::key::INVALID) {
+        track::io::key::ChromaticKey key,
+        track::io::key::Source keySource) {
+    if (key == track::io::key::INVALID) {
         return false;
     } else {
         Keys keys = KeyFactory::makeBasicKeys(key, keySource);
@@ -34,9 +34,9 @@ bool TrackRecord::updateGlobalKey(
 
 bool TrackRecord::updateGlobalKeyText(
         const QString& keyText,
-        mixxx::track::io::key::Source keySource) {
+        track::io::key::Source keySource) {
     Keys keys = KeyFactory::makeBasicKeysFromText(keyText, keySource);
-    if (keys.getGlobalKey() == mixxx::track::io::key::INVALID) {
+    if (keys.getGlobalKey() == track::io::key::INVALID) {
         return false;
     } else {
         if (m_keys.getGlobalKey() != keys.getGlobalKey()) {

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -69,23 +69,23 @@ public:
         return m_keys;
     }
 
-    mixxx::track::io::key::ChromaticKey getGlobalKey() const {
+    track::io::key::ChromaticKey getGlobalKey() const {
         if (getKeys().isValid()) {
             return getKeys().getGlobalKey();
         } else {
-            return mixxx::track::io::key::INVALID;
+            return track::io::key::INVALID;
         }
     }
     bool updateGlobalKey(
-            mixxx::track::io::key::ChromaticKey key,
-            mixxx::track::io::key::Source keySource);
+            track::io::key::ChromaticKey key,
+            track::io::key::Source keySource);
 
     QString getGlobalKeyText() const {
         return KeyUtils::getGlobalKeyText(getKeys());
     }
     bool updateGlobalKeyText(
             const QString& keyText,
-            mixxx::track::io::key::Source keySource);
+            track::io::key::Source keySource);
 
 private:
     Keys m_keys;


### PR DESCRIPTION
Some minor fixes, mostly technical:

- Add missing #ifdefs to exclude all unused code that is dealing with the recently added (yet unsupported) tags
- Remove ID3v2 tags with invalid BPM = 0
- Remove obsolete namespace qualifiers in C++ code

### Outlook
The final step will merge the tags stored in the library with (yet) unsupported tags that are imported from the file directly **on load**. This allows to add new properties to the library step by step, migrations will become simpler and safer.

As a bonus *aoide* will receive all the metadata, even if it is not (yet) stored in the internal database. I just want to test this new approach for a while to ensure that we don't overwrite/remove any tags unintentionally or export tags more often than needed! Stay tuned...