### PR TITLE
keep the library focused when any deck controls or the overview are clicked

### DIFF
--- a/src/widget/weffectbuttonparameter.cpp
+++ b/src/widget/weffectbuttonparameter.cpp
@@ -26,5 +26,4 @@ void WEffectButtonParameter::setup(const QDomNode& node, const SkinContext& cont
         SKIN_WARNING(node, context)
                 << "EffectButtonParameter node could not attach to effect parameter";
     }
-    this->setFocusPolicy(Qt::NoFocus);
 }

--- a/src/widget/weffectbuttonparameter.cpp
+++ b/src/widget/weffectbuttonparameter.cpp
@@ -26,4 +26,5 @@ void WEffectButtonParameter::setup(const QDomNode& node, const SkinContext& cont
         SKIN_WARNING(node, context)
                 << "EffectButtonParameter node could not attach to effect parameter";
     }
+    this->setFocusPolicy(Qt::NoFocus);
 }

--- a/src/widget/weffectparameterknob.cpp
+++ b/src/widget/weffectparameterknob.cpp
@@ -10,6 +10,7 @@ void WEffectParameterKnob::setupEffectParameterSlot(const ConfigKey& configKey) 
         return;
     }
     setEffectParameterSlot(pParameterSlot);
+    this->setFocusPolicy(Qt::NoFocus);
 }
 
 void WEffectParameterKnob::setEffectParameterSlot(

--- a/src/widget/weffectparameterknob.cpp
+++ b/src/widget/weffectparameterknob.cpp
@@ -10,7 +10,7 @@ void WEffectParameterKnob::setupEffectParameterSlot(const ConfigKey& configKey) 
         return;
     }
     setEffectParameterSlot(pParameterSlot);
-    this->setFocusPolicy(Qt::NoFocus);
+    setFocusPolicy(Qt::NoFocus);
 }
 
 void WEffectParameterKnob::setEffectParameterSlot(

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -15,6 +15,7 @@ void WEffectParameterKnobComposed::setupEffectParameterSlot(const ConfigKey& con
         return;
     }
     setEffectParameterSlot(pParameterSlot);
+    this->setFocusPolicy(Qt::NoFocus);
 }
 
 void WEffectParameterKnobComposed::setEffectParameterSlot(

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -15,7 +15,7 @@ void WEffectParameterKnobComposed::setupEffectParameterSlot(const ConfigKey& con
         return;
     }
     setEffectParameterSlot(pParameterSlot);
-    this->setFocusPolicy(Qt::NoFocus);
+    setFocusPolicy(Qt::NoFocus);
 }
 
 void WEffectParameterKnobComposed::setEffectParameterSlot(

--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -17,6 +17,7 @@ void WEffectPushButton::setup(const QDomNode& node, const SkinContext& context) 
     m_pButtonMenu = new QMenu(this);
     connect(m_pButtonMenu, SIGNAL(triggered(QAction*)),
             this, SLOT(slotActionChosen(QAction*)));
+    this->setFocusPolicy(Qt::NoFocus);
 }
 
 void WEffectPushButton::setupEffectParameterSlot(const ConfigKey& configKey) {

--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -17,7 +17,7 @@ void WEffectPushButton::setup(const QDomNode& node, const SkinContext& context) 
     m_pButtonMenu = new QMenu(this);
     connect(m_pButtonMenu, SIGNAL(triggered(QAction*)),
             this, SLOT(slotActionChosen(QAction*)));
-    this->setFocusPolicy(Qt::NoFocus);
+    setFocusPolicy(Qt::NoFocus);
 }
 
 void WEffectPushButton::setupEffectParameterSlot(const ConfigKey& configKey) {

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -28,7 +28,7 @@ WKnob::WKnob(QWidget* pParent)
                         mixxx::Duration::fromSeconds(1)) {
     connect(&m_renderTimer, SIGNAL(update()),
             this, SLOT(update()));
-    this->setFocusPolicy(Qt::NoFocus);
+    setFocusPolicy(Qt::NoFocus);
 }
 
 void WKnob::mouseMoveEvent(QMouseEvent* e) {

--- a/src/widget/wknob.cpp
+++ b/src/widget/wknob.cpp
@@ -28,6 +28,7 @@ WKnob::WKnob(QWidget* pParent)
                         mixxx::Duration::fromSeconds(1)) {
     connect(&m_renderTimer, SIGNAL(update()),
             this, SLOT(update()));
+    this->setFocusPolicy(Qt::NoFocus);
 }
 
 void WKnob::mouseMoveEvent(QMouseEvent* e) {

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -56,6 +56,8 @@ void WKnobComposed::setup(const QDomNode& node, const SkinContext& context) {
     m_dKnobCenterXOffset *= scaleFactor;
     m_dKnobCenterYOffset *= scaleFactor;
     m_dArcThickness *= scaleFactor;
+
+    this->setFocusPolicy(Qt::NoFocus);
 }
 
 void WKnobComposed::clear() {

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -57,7 +57,7 @@ void WKnobComposed::setup(const QDomNode& node, const SkinContext& context) {
     m_dKnobCenterYOffset *= scaleFactor;
     m_dArcThickness *= scaleFactor;
 
-    this->setFocusPolicy(Qt::NoFocus);
+    setFocusPolicy(Qt::NoFocus);
 }
 
 void WKnobComposed::clear() {

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -167,6 +167,8 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
             }
         }
     }
+
+    this->setFocusPolicy(Qt::NoFocus);
 }
 
 void WOverview::onConnectedControlChanged(double dParameter, double dValue) {

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -168,7 +168,7 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
         }
     }
 
-    this->setFocusPolicy(Qt::NoFocus);
+    setFocusPolicy(Qt::NoFocus);
 }
 
 void WOverview::onConnectedControlChanged(double dParameter, double dValue) {

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -222,6 +222,8 @@ void WPushButton::setup(const QDomNode& node, const SkinContext& context) {
             rightConnection->setDirectionOption(ControlParameterWidgetConnection::DIR_FROM_WIDGET);
         }
     }
+
+    this->setFocusPolicy(Qt::NoFocus);
 }
 
 void WPushButton::setStates(int iStates) {

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -223,7 +223,7 @@ void WPushButton::setup(const QDomNode& node, const SkinContext& context) {
         }
     }
 
-    this->setFocusPolicy(Qt::NoFocus);
+    setFocusPolicy(Qt::NoFocus);
 }
 
 void WPushButton::setStates(int iStates) {

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -89,6 +89,8 @@ void WSliderComposed::setup(const QDomNode& node, const SkinContext& context) {
             }
         }
     }
+
+    this->setFocusPolicy(Qt::NoFocus);
 }
 
 void WSliderComposed::setSliderPixmap(PixmapSource sourceSlider,

--- a/src/widget/wslidercomposed.cpp
+++ b/src/widget/wslidercomposed.cpp
@@ -90,7 +90,7 @@ void WSliderComposed::setup(const QDomNode& node, const SkinContext& context) {
         }
     }
 
-    this->setFocusPolicy(Qt::NoFocus);
+    setFocusPolicy(Qt::NoFocus);
 }
 
 void WSliderComposed::setSliderPixmap(PixmapSource sourceSlider,

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -21,7 +21,7 @@ void WStarRating::setup(const QDomNode& node, const SkinContext& context) {
     Q_UNUSED(node);
     Q_UNUSED(context);
     setMouseTracking(true);
-    this->setFocusPolicy(Qt::NoFocus);
+    setFocusPolicy(Qt::NoFocus);
 }
 
 QSize WStarRating::sizeHint() const {

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -21,6 +21,7 @@ void WStarRating::setup(const QDomNode& node, const SkinContext& context) {
     Q_UNUSED(node);
     Q_UNUSED(context);
     setMouseTracking(true);
+    this->setFocusPolicy(Qt::NoFocus);
 }
 
 QSize WStarRating::sizeHint() const {

--- a/src/widget/wstatuslight.cpp
+++ b/src/widget/wstatuslight.cpp
@@ -66,6 +66,8 @@ void WStatusLight::setup(const QDomNode& node, const SkinContext& context) {
             m_pixmaps[i].clear();
         }
     }
+
+    this->setFocusPolicy(Qt::NoFocus);
 }
 
 void WStatusLight::setPixmap(int iState, PixmapSource source,

--- a/src/widget/wstatuslight.cpp
+++ b/src/widget/wstatuslight.cpp
@@ -67,7 +67,7 @@ void WStatusLight::setup(const QDomNode& node, const SkinContext& context) {
         }
     }
 
-    this->setFocusPolicy(Qt::NoFocus);
+    setFocusPolicy(Qt::NoFocus);
 }
 
 void WStatusLight::setPixmap(int iState, PixmapSource source,

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -90,6 +90,8 @@ void WVuMeter::setup(const QDomNode& node, const SkinContext& context) {
     if (m_iPeakFallTime < 1 || m_iPeakFallTime > 1000) {
         m_iPeakFallTime = DEFAULT_FALLTIME;
     }
+
+    this->setFocusPolicy(Qt::NoFocus);
 }
 
 void WVuMeter::setPixmapBackground(

--- a/src/widget/wvumeter.cpp
+++ b/src/widget/wvumeter.cpp
@@ -91,7 +91,7 @@ void WVuMeter::setup(const QDomNode& node, const SkinContext& context) {
         m_iPeakFallTime = DEFAULT_FALLTIME;
     }
 
-    this->setFocusPolicy(Qt::NoFocus);
+    setFocusPolicy(Qt::NoFocus);
 }
 
 void WVuMeter::setPixmapBackground(


### PR DESCRIPTION
trying to fix https://bugs.launchpad.net/mixxx/+bug/1259040
"Clicking on deck controls affects library keyboard focus"

I added 'setFocusPolicy(Qt::NoFocus);' to the setup slot of most interactive skin widgets, like it worked for the library Preview button in #2264 .
This allows to keep the library focused for keyboard interaction when any deck controls or the overview are clicked.

I didn't apply the fix to the effect selector or spinboxes because I don't overlook the consequences and IMO there's no point to keep the library focused when interacting with those widgets.

This is a quite naive attempt but it works for buttons, sliders, knobs ...
It's so simple that I just can't believe there are no side effects. What can could wrong?
Is there a better place to set the focus policy?
Can it safely be set in wbasewidget ?

**New behaviour:**
* click buttons, knobs, sliders, overview: library table/sidebar remains focused
* effect selector: library is re-focused when any effect wass selected
* beat size spinboxes accept focus as before