### PR TITLE
Fix debug assert in CachingReader

### DIFF
--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -211,8 +211,8 @@ void CachingReader::newTrack(TrackPointer pTrack) {
     // but the newTrack may change if we load a new track while the previous one
     // is still loading. This leads to inconsistent states for example a different
     // track in the Mixx Title and the Deck label.
-    if (oldState != STATE_TRACK_LOADING ||
-            newState != STATE_TRACK_LOADING) {
+    if (oldState == STATE_TRACK_LOADING &&
+            newState == STATE_TRACK_LOADING) {
         kLogger.warning()
                 << "Loading a new track while loading a track may lead to inconsistent states";
     }
@@ -223,7 +223,6 @@ void CachingReader::process() {
     ReaderStatusUpdate update;
     while (m_readerStatusUpdateFIFO.read(&update, 1) == 1) {
         auto pChunk = update.takeFromWorker();
-        qDebug() << "CachingReader::process()" << update.status;
         if (pChunk) {
             // Result of a read request (with a chunk)
             DEBUG_ASSERT(m_state.load() != STATE_IDLE);

--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -212,7 +212,6 @@ void CachingReader::newTrack(TrackPointer pTrack) {
         return;
     }
     m_worker.newTrack(std::move(pTrack));
-    m_worker.workReady();
 }
 
 void CachingReader::process() {

--- a/src/engine/cachingreader.cpp
+++ b/src/engine/cachingreader.cpp
@@ -216,6 +216,7 @@ void CachingReader::newTrack(TrackPointer pTrack) {
 void CachingReader::process() {
     ReaderStatusUpdate update;
     while (m_readerStatusUpdateFIFO.read(&update, 1) == 1) {
+        auto pChunk = update.takeFromWorker();
         if (pChunk) {
             DEBUG_ASSERT(m_state != State::Idle);
             // Result of a read request (with a chunk)

--- a/src/engine/cachingreader.h
+++ b/src/engine/cachingreader.h
@@ -4,9 +4,7 @@
 #ifndef ENGINE_CACHINGREADER_H
 #define ENGINE_CACHINGREADER_H
 
-#include <atomic>
-
-#include <QtDebug>
+#include <QAtomicInt>
 #include <QList>
 #include <QVector>
 #include <QLinkedList>
@@ -153,12 +151,13 @@ class CachingReader : public QObject {
     // Gets a chunk from the free list, frees the LRU CachingReaderChunk if none available.
     CachingReaderChunkForOwner* allocateChunkExpireLRU(SINT chunkIndex);
 
-    enum class State {
-        Idle,
-        TrackLoading,
-        TrackLoaded,
+    enum State {
+        STATE_IDLE,
+        STATE_TRACK_LOADING,
+        STATE_TRACK_UNLOADING,
+        STATE_TRACK_LOADED,
     };
-    std::atomic<State> m_state;
+    QAtomicInt m_state;
 
     // Keeps track of all CachingReaderChunks we've allocated.
     QVector<CachingReaderChunkForOwner*> m_chunks;

--- a/src/engine/cachingreader.h
+++ b/src/engine/cachingreader.h
@@ -78,9 +78,9 @@ class CachingReader : public QObject {
     // Construct a CachingReader with the given group.
     CachingReader(QString group,
                   UserSettingsPointer _config);
-    virtual ~CachingReader();
+    ~CachingReader() override;
 
-    virtual void process();
+    void process();
 
     enum class ReadResult {
         // No samples read and buffer untouched(!), try again later in case of a cache miss
@@ -101,12 +101,12 @@ class CachingReader : public QObject {
     // that is not in the cache. If any hints do request a chunk not in cache,
     // then wake the reader so that it can process them. Must only be called
     // from the engine callback.
-    virtual void hintAndMaybeWake(const HintVector& hintList);
+    void hintAndMaybeWake(const HintVector& hintList);
 
     // Request that the CachingReader load a new track. These requests are
     // processed in the work thread, so the reader must be woken up via wake()
     // for this to take effect.
-    virtual void newTrack(TrackPointer pTrack);
+    void newTrack(TrackPointer pTrack);
 
     void setScheduler(EngineWorkerScheduler* pScheduler) {
         m_worker.setScheduler(pScheduler);

--- a/src/engine/cachingreader.h
+++ b/src/engine/cachingreader.h
@@ -4,6 +4,8 @@
 #ifndef ENGINE_CACHINGREADER_H
 #define ENGINE_CACHINGREADER_H
 
+#include <atomic>
+
 #include <QtDebug>
 #include <QList>
 #include <QVector>
@@ -156,7 +158,7 @@ class CachingReader : public QObject {
         TrackLoading,
         TrackLoaded,
     };
-    State m_state;
+    std::atomic<State> m_state;
 
     // Keeps track of all CachingReaderChunks we've allocated.
     QVector<CachingReaderChunkForOwner*> m_chunks;

--- a/src/engine/cachingreader.h
+++ b/src/engine/cachingreader.h
@@ -126,7 +126,7 @@ class CachingReader : public QObject {
     // Thread-safe FIFOs for communication between the engine callback and
     // reader thread.
     FIFO<CachingReaderChunkReadRequest> m_chunkReadRequestFIFO;
-    FIFO<ReaderStatusUpdate> m_stateFIFO;
+    FIFO<ReaderStatusUpdate> m_readerStatusUpdateFIFO;
 
     // Looks for the provided chunk number in the index of in-memory chunks and
     // returns it if it is present. If not, returns nullptr. If it is present then

--- a/src/engine/cachingreaderworker.cpp
+++ b/src/engine/cachingreaderworker.cpp
@@ -135,7 +135,7 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
 
     if (!pTrack) {
         // If no new track is available then we are done
-        const auto update = ReaderStatusUpdate::trackNotLoaded();
+        const auto update = ReaderStatusUpdate::trackUnloaded();
         m_pReaderStatusFIFO->writeBlocking(&update, 1);
         return;
     }
@@ -149,7 +149,7 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
                  << m_group
                  << "File not found"
                  << filename;
-        const auto update = ReaderStatusUpdate::trackNotLoaded();
+        const auto update = ReaderStatusUpdate::trackUnloaded();
         m_pReaderStatusFIFO->writeBlocking(&update, 1);
         emit trackLoadFailed(
             pTrack, QString("The file '%1' could not be found.")
@@ -165,7 +165,7 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
                 << m_group
                 << "Failed to open file"
                 << filename;
-        const auto update = ReaderStatusUpdate::trackNotLoaded();
+        const auto update = ReaderStatusUpdate::trackUnloaded();
         m_pReaderStatusFIFO->writeBlocking(&update, 1);
         emit trackLoadFailed(
             pTrack, QString("The file '%1' could not be loaded").arg(filename));
@@ -182,7 +182,7 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
                 << m_group
                 << "Failed to open empty file"
                 << filename;
-        const auto update = ReaderStatusUpdate::trackNotLoaded();
+        const auto update = ReaderStatusUpdate::trackUnloaded();
         m_pReaderStatusFIFO->writeBlocking(&update, 1);
         emit trackLoadFailed(
             pTrack, QString("The file '%1' is empty and could not be loaded").arg(filename));

--- a/src/engine/cachingreaderworker.cpp
+++ b/src/engine/cachingreaderworker.cpp
@@ -143,9 +143,6 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     // Emit that a new track is loading, stops the current track
     emit trackLoading();
 
-    // Slows down track loading for debug
-    //QThread::sleep(10);
-
     QString filename = pTrack->getLocation();
     if (filename.isEmpty() || !pTrack->exists()) {
         kLogger.warning()

--- a/src/engine/cachingreaderworker.cpp
+++ b/src/engine/cachingreaderworker.cpp
@@ -29,9 +29,6 @@ CachingReaderWorker::CachingReaderWorker(
           m_stop(0) {
 }
 
-CachingReaderWorker::~CachingReaderWorker() {
-}
-
 ReaderStatusUpdate CachingReaderWorker::processReadRequest(
         const CachingReaderChunkReadRequest& request) {
     CachingReaderChunk* pChunk = request.chunk;

--- a/src/engine/cachingreaderworker.cpp
+++ b/src/engine/cachingreaderworker.cpp
@@ -143,6 +143,9 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
     // Emit that a new track is loading, stops the current track
     emit trackLoading();
 
+    // Slows down track loading for debug
+    //QThread::sleep(10);
+
     QString filename = pTrack->getLocation();
     if (filename.isEmpty() || !pTrack->exists()) {
         kLogger.warning()

--- a/src/engine/cachingreaderworker.cpp
+++ b/src/engine/cachingreaderworker.cpp
@@ -84,9 +84,12 @@ ReaderStatusUpdate CachingReaderWorker::processReadRequest(
 
 // WARNING: Always called from a different thread (GUI)
 void CachingReaderWorker::newTrack(TrackPointer pTrack) {
-    QMutexLocker locker(&m_newTrackMutex);
-    m_pNewTrack = pTrack;
-    m_newTrackAvailable = true;
+    {
+        QMutexLocker locker(&m_newTrackMutex);
+        m_pNewTrack = pTrack;
+        m_newTrackAvailable = true;
+    }
+    workReady();
 }
 
 void CachingReaderWorker::run() {

--- a/src/engine/cachingreaderworker.h
+++ b/src/engine/cachingreaderworker.h
@@ -69,7 +69,7 @@ typedef struct ReaderStatusUpdate {
         return update;
     }
 
-    static ReaderStatusUpdate trackNotLoaded() {
+    static ReaderStatusUpdate trackUnloaded() {
         ReaderStatusUpdate update;
         update.init(TRACK_UNLOADED, nullptr, mixxx::IndexRange());
         return update;

--- a/src/engine/cachingreaderworker.h
+++ b/src/engine/cachingreaderworker.h
@@ -101,14 +101,14 @@ class CachingReaderWorker : public EngineWorker {
     CachingReaderWorker(QString group,
             FIFO<CachingReaderChunkReadRequest>* pChunkReadRequestFIFO,
             FIFO<ReaderStatusUpdate>* pReaderStatusFIFO);
-    virtual ~CachingReaderWorker();
+    ~CachingReaderWorker() override = default;
 
     // Request to load a new track. wake() must be called afterwards.
-    virtual void newTrack(TrackPointer pTrack);
+    void newTrack(TrackPointer pTrack);
 
     // Run upkeep operations like loading tracks and reading from file. Run by a
     // thread pool via the EngineWorkerScheduler.
-    virtual void run();
+    void run() override;
 
     void quitWait();
 


### PR DESCRIPTION
I have finally managed to dig to the ground of the assertion and created a solution with a lower impact on the way. Sorry for the concurrent PR, but IMHO this is a best way the get a clear view on the issue for both of us. The consecutive track load fix of your PR is not included here. 

The issue was that the engine stops calling process when the deck is ejected. This is why the m_stateFIFO is not purged as originally assumed after unloading the old track but after loading the new track. This does not matter in the track change case, but is an issue when ejecting the track first. 
in this case the idle signal is delayed and overwrites the loading state leading to the assert violation. 

The fix now uses TRACK_LOADED and TRACK_UNLOADED as a border in the m_stateFIFO fifo to distinguish old chunks from new. 

I have also moved the freeAllChunks to the engine thread and call it whenever such a border appears.

 
