### PR TITLE
Tango :: scaling fixes for sliders

### DIFF
--- a/res/skins/Tango/mixer_channel_left.xml
+++ b/res/skins/Tango/mixer_channel_left.xml
@@ -66,10 +66,11 @@ Variables:
         <SizePolicy>f,min</SizePolicy>
         <Children>
           <SliderComposed><!-- Volume slider -->
+            <Size>34f,103f</Size>
             <ObjectName>VolumeSlider</ObjectName>
             <TooltipId>channel_volume</TooltipId>
-            <Slider>knobs_sliders/volume_scale.svg</Slider>
-            <Handle>knobs_sliders/volume_handle.svg</Handle>
+            <Slider scalemode="STRETCH_ASPECT">knobs_sliders/volume_scale.svg</Slider>
+            <Handle scalemode="STRETCH_ASPECT">knobs_sliders/volume_handle.svg</Handle>
             <Horizontal>false</Horizontal>
             <Connection>
               <ConfigKey><Variable name="group"/>,volume</ConfigKey>

--- a/res/skins/Tango/mixer_channel_right.xml
+++ b/res/skins/Tango/mixer_channel_right.xml
@@ -54,10 +54,11 @@ Variables:
         <SizePolicy>f,min</SizePolicy>
         <Children>
           <SliderComposed><!-- Volume slider -->
+            <Size>34f,103f</Size>
             <ObjectName>VolumeSlider</ObjectName>
             <TooltipId>channel_volume</TooltipId>
-            <Slider>knobs_sliders/volume_scale.svg</Slider>
-            <Handle>knobs_sliders/volume_handle.svg</Handle>
+            <Slider scalemode="STRETCH_ASPECT">knobs_sliders/volume_scale.svg</Slider>
+            <Handle scalemode="STRETCH_ASPECT">knobs_sliders/volume_handle.svg</Handle>
             <Horizontal>false</Horizontal>
             <Connection>
               <ConfigKey><Variable name="group"/>,volume</ConfigKey>

--- a/res/skins/Tango/mixer_headphone.xml
+++ b/res/skins/Tango/mixer_headphone.xml
@@ -73,9 +73,9 @@ Description:
               <SliderComposed>
                 <TooltipId>headMix</TooltipId>
                 <ObjectName>MixerbarSlider</ObjectName>
-                <SizePolicy>min,min</SizePolicy>
-                <Handle>knobs_sliders/headMix_handle.svg</Handle>
-                <Slider>knobs_sliders/headMix_scale.svg</Slider>
+                <Size>50f,24f</Size>
+                <Handle scalemode="STRETCH_ASPECT">knobs_sliders/headMix_handle.svg</Handle>
+                <Slider scalemode="STRETCH_ASPECT">knobs_sliders/headMix_scale.svg</Slider>
                 <Horizontal>true</Horizontal>
                 <Connection>
                   <ConfigKey>[Master],headMix</ConfigKey>

--- a/res/skins/Tango/mixer_master.xml
+++ b/res/skins/Tango/mixer_master.xml
@@ -60,9 +60,9 @@ Description:
       <SliderComposed>
         <TooltipId>balance</TooltipId>
         <ObjectName>MixerbarSlider</ObjectName>
-        <SizePolicy>min,min</SizePolicy>
-        <Handle>knobs_sliders/balance_handle.svg</Handle>
-        <Slider>knobs_sliders/balance_scale.svg</Slider>
+        <Size>50f,24f</Size>
+        <Handle scalemode="STRETCH_ASPECT">knobs_sliders/balance_handle.svg</Handle>
+        <Slider scalemode="STRETCH_ASPECT">knobs_sliders/balance_scale.svg</Slider>
         <Horizontal>true</Horizontal>
         <Connection>
           <ConfigKey>[Master],balance</ConfigKey>

--- a/res/skins/Tango/rate_pitch_key.xml
+++ b/res/skins/Tango/rate_pitch_key.xml
@@ -169,7 +169,7 @@ Variables:
             <MaximumSize>50,136</MaximumSize>
             <SizePolicy>f,me</SizePolicy>
             <TooltipId>rate</TooltipId>
-            <Handle>knobs_sliders/pitch_handle.svg</Handle>
+            <Handle scalemode="STRETCH_ASPECT">knobs_sliders/pitch_handle.svg</Handle>
             <Slider scalemode="STRETCH">knobs_sliders/pitch_scale.svg</Slider>
             <Horizontal>false</Horizontal>
             <Connection>

--- a/res/skins/Tango/sampler.xml
+++ b/res/skins/Tango/sampler.xml
@@ -239,8 +239,8 @@ Variables:
             <ObjectName>SamplerPitchSlider</ObjectName>
             <TooltipId>rate</TooltipId>
             <Size>20f,54f</Size>
-            <Handle>knobs_sliders/pitch_sampler_handle.svg</Handle>
-            <Slider>knobs_sliders/pitch_sampler_scale.svg</Slider>
+            <Handle scalemode="STRETCH_ASPECT">knobs_sliders/pitch_sampler_handle.svg</Handle>
+            <Slider scalemode="STRETCH_ASPECT">knobs_sliders/pitch_sampler_scale.svg</Slider>
             <Horizontal>false</Horizontal>
             <Connection>
               <ConfigKey><Variable name="group"/>,rate</ConfigKey>

--- a/res/skins/Tango/spinny_cover_maxi.xml
+++ b/res/skins/Tango/spinny_cover_maxi.xml
@@ -74,7 +74,7 @@ Variables:
                 <TooltipId>coverart</TooltipId>
                 <Size>111f,111f</Size>
                 <Group><Variable name="group"/></Group>
-                <DefaultCover>skin:/graphics/cover_default.svg</DefaultCover>
+                <DefaultCover scalemode="STRETCH_ASPECT">skin:/graphics/cover_default.svg</DefaultCover>
                 <Connection>
                   <ConfigKey persist="true">[Skin],show_coverart</ConfigKey>
                   <BindProperty>visible</BindProperty>

--- a/res/skins/Tango/spinny_cover_mini.xml
+++ b/res/skins/Tango/spinny_cover_mini.xml
@@ -66,7 +66,7 @@ Variables:
             <TooltipId>coverart</TooltipId>
             <Size>40me,40me</Size>
             <Group>[Channel<Variable name="chanNum"/>]</Group>
-            <DefaultCover>skin:/graphics/cover_default_mini_<Variable name="SpinnyCoverColor"/>.svg</DefaultCover>
+            <DefaultCover scalemode="STRETCH_ASPECT">skin:/graphics/cover_default_mini_<Variable name="SpinnyCoverColor"/>.svg</DefaultCover>
             <Connection>
               <ConfigKey persist="true">[Skin],show_coverart</ConfigKey>
               <BindProperty>visible</BindProperty>

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -1233,12 +1233,8 @@ WBeatSpinBox,
   font-weight: bold;
   text-align: center;
   padding-top: 1px;
-  }
-  #BpmLabel {
-    background-color: #252525;
-  }
-  #BpmLabelMini {
-    background-color: #252525;
+  background-color: #252525;
+  border-radius: 2px;
   }
   #SyncButtonOverlay[displayValue="0"]:hover,
   #SyncButtonOverlayMini[displayValue="0"]:hover {

--- a/res/skins/Tango/topbar.xml
+++ b/res/skins/Tango/topbar.xml
@@ -104,8 +104,9 @@ Description:
 		                <Children>
 		                  <SliderComposed>
 		                    <TooltipId>crossfader</TooltipId>
-		                    <Handle>knobs_sliders/crossfader_handle.svg</Handle>
-		                    <Slider>knobs_sliders/crossfader_scale.svg</Slider>
+		                    <Size>108f,28f</Size>
+		                    <Handle scalemode="STRETCH_ASPECT">knobs_sliders/crossfader_handle.svg</Handle>
+		                    <Slider scalemode="STRETCH_ASPECT">knobs_sliders/crossfader_scale.svg</Slider>
 		                    <Horizontal>true</Horizontal>
 		                    <Connection>
 		                      <ConfigKey>[Master],crossfader</ConfigKey>


### PR DESCRIPTION
before sliders looked blurry because the original graphics were zoomed but not scaled.
`scalemode="STRETCH_ASPECT"` fixed it