### PR TITLE
lp1846971: Fix database inconsistencies caused by LibraryScanner

### DIFF
--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -120,11 +120,14 @@ void LibraryScanner::run() {
             return;
         }
 
+        // Clean up the database and fix inconsistencies from previous runs.
+        // See also: https://bugs.launchpad.net/mixxx/+bug/1846945
         {
             kLogger.info() << "Cleaning up database...";
             PerformanceTimer timer;
             timer.start();
-            auto numRows = execCleanupQuery(dbConnection, kDeleteOrphanedLibraryScannerDirectories);
+            auto numRows = execCleanupQuery(dbConnection,
+                    kDeleteOrphanedLibraryScannerDirectories);
             if (numRows < 0) {
                 kLogger.warning()
                         << "Failed to delete orphaned directory hashes";


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1846971

Mitigates serious bug reported in:
https://bugs.launchpad.net/mixxx/+bug/1603348
https://bugs.launchpad.net/mixxx/+bug/1846775 (very likely)
https://bugs.launchpad.net/mixxx/+bug/1846945 (marked as duplicate)

This is just a workaround and does not fix the actual cause for those inconsistencies! Restarting Mixxx and rescanning the library should discover the previously unreachable and ignored files.

Runs concurrently in the LibraryScanner thread and does not slow down the startup.