### PR TITLE
add 'FxRack1_FxUnitN],controller_input_active' control to midi-components Fx mapping

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -759,6 +759,7 @@
                 }
                 delete this.previouslyFocusedEffect;
             }
+            engine.setValue(this.group, "controller_input_active", 0);
 
             this.group = '[EffectRack1_EffectUnit' + newNumber + ']';
 
@@ -774,6 +775,7 @@
                                                     this.onShowParametersChange);
                 this.showParametersConnection.trigger();
             }
+            engine.setValue(this.group, "controller_input_active", 1);
 
             // Do not enable soft takeover upon EffectUnit construction
             // so initial values can be loaded from knobs.

--- a/src/effects/effectchainslot.cpp
+++ b/src/effects/effectchainslot.cpp
@@ -77,6 +77,10 @@ EffectChainSlot::EffectChainSlot(EffectRack* pRack, const QString& group,
                                    ConfigKey(m_group, "show_focus"));
     m_pControlChainShowFocus->setButtonMode(ControlPushButton::TOGGLE);
 
+    m_pControlChainHasControllerFocus = new ControlPushButton(
+                                   ConfigKey(m_group, "controller_input_active"));
+    m_pControlChainHasControllerFocus->setButtonMode(ControlPushButton::TOGGLE);
+
     m_pControlChainShowParameters = new ControlPushButton(
                                         ConfigKey(m_group, "show_parameters"),
                                         true);
@@ -103,6 +107,7 @@ EffectChainSlot::~EffectChainSlot() {
     delete m_pControlChainNextPreset;
     delete m_pControlChainSelector;
     delete m_pControlChainShowFocus;
+    delete m_pControlChainHasControllerFocus;
     delete m_pControlChainShowParameters;
     delete m_pControlChainFocusedEffect;
 

--- a/src/effects/effectchainslot.h
+++ b/src/effects/effectchainslot.h
@@ -148,6 +148,7 @@ class EffectChainSlot : public QObject {
       object than the mapping.
     **/
     ControlPushButton* m_pControlChainShowFocus;
+    ControlPushButton* m_pControlChainHasControllerFocus;
     ControlPushButton* m_pControlChainShowParameters;
     ControlPushButton* m_pControlChainFocusedEffect;
 


### PR DESCRIPTION
~~`[EffectRack1_EffectUnitN],has_controller_focus`~~

`[EffectRack1_EffectUnitN],controller_input_active`
With a controller mapping that makes use of midi-components' to control 4 Fx units this allows to have a GUI indicator telling you which Fx units can currently controlled via MIDI.

I'm succesfully using this for a while now. This PR adds the C++ changes.

Before, with 4 collapsed Fx units, it was not possible to tell which unit is focused by controller, except by abusing the `[FxUnit],show_focus` control by initialising the Fx mapping with `allowFocusWhenParametersHidden` set to true.

https://bugs.launchpad.net/mixxx/+bug/1760316

I added a rudimentary indicator to Tango's collapsed Fx units for testing.
Like `[FxUnit],show_focus` this is invisible in skins if no controller is attached that uses the components Fx mapping.
![image](https://user-images.githubusercontent.com/5934199/66502338-50689980-eac5-11e9-91fb-12c835912543.png)