### PR TITLE
Fix ConfigObject warnings and issues

### DIFF
--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -101,7 +101,7 @@ ConfigValueKbd::ConfigValueKbd(QString value)
           m_keys(ConfigValue::value) {
 }
 
-ConfigValueKbd::ConfigValueKbd(QKeySequence keys)
+ConfigValueKbd::ConfigValueKbd(const QKeySequence& keys)
         : m_keys(std::move(keys)) {
     QTextStream(&value) << m_keys.toString();
 }

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -96,11 +96,6 @@ ConfigValue::ConfigValue(double dValue)
     : value(QString::number(dValue)) {
 }
 
-ConfigValueKbd::ConfigValueKbd(QString value)
-        : ConfigValue(std::move(value)),
-          m_keys(ConfigValue::value) {
-}
-
 ConfigValueKbd::ConfigValueKbd(const QKeySequence& keys)
         : m_keys(std::move(keys)) {
     QTextStream(&value) << m_keys.toString();

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -81,32 +81,11 @@ QString computeSettingsPath(const QString& configFilename) {
 }
 
 }  // namespace
-
-ConfigKey::ConfigKey() {
-}
-
-ConfigKey::ConfigKey(const ConfigKey& key)
-    : group(key.group),
-      item(key.item) {
-}
-
-ConfigKey::ConfigKey(const QString& g, const QString& i)
-    : group(g),
-      item(i) {
-}
-
 // static
 ConfigKey ConfigKey::parseCommaSeparated(const QString& key) {
     int comma = key.indexOf(",");
     ConfigKey configKey(key.left(comma), key.mid(comma + 1));
     return configKey;
-}
-
-ConfigValue::ConfigValue() {
-}
-
-ConfigValue::ConfigValue(const QString& stValue)
-    : value(stValue) {
 }
 
 ConfigValue::ConfigValue(int iValue)
@@ -117,37 +96,14 @@ ConfigValue::ConfigValue(double dValue)
     : value(QString::number(dValue)) {
 }
 
-void ConfigValue::valCopy(const ConfigValue& configValue) {
-    value = configValue.value;
+ConfigValueKbd::ConfigValueKbd(QString value)
+        : ConfigValue(std::move(value)),
+          m_keys(ConfigValue::value) {
 }
 
-
-ConfigValueKbd::ConfigValueKbd() {
-}
-
-ConfigValueKbd::ConfigValueKbd(const QString& value)
-        : ConfigValue(value) {
-    m_qKey = QKeySequence(value);
-}
-
-ConfigValueKbd::ConfigValueKbd(const QKeySequence& key) {
-    m_qKey = key;
-    QTextStream(&value) << m_qKey.toString();
-    // qDebug() << "value" << value;
-}
-
-void ConfigValueKbd::valCopy(const ConfigValueKbd& v) {
-    m_qKey = v.m_qKey;
-    QTextStream(&value) << m_qKey.toString();
-}
-
-bool operator==(const ConfigValue& s1, const ConfigValue& s2) {
-    return (s1.value.toUpper() == s2.value.toUpper());
-}
-
-bool operator==(const ConfigValueKbd& s1, const ConfigValueKbd& s2) {
-    //qDebug() << s1.m_qKey << "==" << s2.m_qKey;
-    return (s1.m_qKey == s2.m_qKey);
+ConfigValueKbd::ConfigValueKbd(QKeySequence keys)
+        : m_keys(std::move(keys)) {
+    QTextStream(&value) << m_keys.toString();
 }
 
 template <class ValueType> ConfigObject<ValueType>::ConfigObject(const QString& file)
@@ -249,8 +205,7 @@ template <class ValueType> void ConfigObject<ValueType>::save() {
 
         QString grp = "";
 
-        typename QMap<ConfigKey, ValueType>::const_iterator i;
-        for (i = m_values.begin(); i != m_values.end(); ++i) {
+        for (auto i = m_values.constBegin(); i != m_values.constEnd(); ++i) {
             //qDebug() << "group:" << it.key().group << "item" << it.key().item << "val" << it.value()->value;
             if (i.key().group != grp) {
                 grp = i.key().group;
@@ -287,8 +242,7 @@ QMultiHash<ValueType, ConfigKey> ConfigObject<ValueType>::transpose() const {
     QReadLocker lock(&m_valuesLock);
 
     QMultiHash<ValueType, ConfigKey> transposedHash;
-    for (typename QMap<ConfigKey, ValueType>::const_iterator it =
-            m_values.begin(); it != m_values.end(); ++it) {
+    for (auto it = m_values.constBegin(); it != m_values.constEnd(); ++it) {
         transposedHash.insert(it.value(), it.key());
     }
     return transposedHash;

--- a/src/preferences/configobject.h
+++ b/src/preferences/configobject.h
@@ -106,7 +106,7 @@ class ConfigValueKbd : public ConfigValue {
     ConfigValueKbd() = default;
     ~ConfigValueKbd() override = default;
     explicit ConfigValueKbd(QString value);
-    explicit ConfigValueKbd(QKeySequence keys);
+    explicit ConfigValueKbd(const QKeySequence& keys);
     explicit ConfigValueKbd(const QDomNode) {
         reportFatalErrorAndQuit("ConfigValueKbd from QDomNode not implemented here");
     }

--- a/src/preferences/configobject.h
+++ b/src/preferences/configobject.h
@@ -105,7 +105,6 @@ class ConfigValueKbd : public ConfigValue {
   public:
     ConfigValueKbd() = default;
     ~ConfigValueKbd() override = default;
-    explicit ConfigValueKbd(QString value);
     explicit ConfigValueKbd(const QKeySequence& keys);
     explicit ConfigValueKbd(const QDomNode) {
         reportFatalErrorAndQuit("ConfigValueKbd from QDomNode not implemented here");

--- a/src/preferences/configobject.h
+++ b/src/preferences/configobject.h
@@ -9,46 +9,57 @@
 #include <QMetaType>
 #include <QReadWriteLock>
 
+#include "util/assert.h"
 #include "util/debug.h"
 
 // Class for the key for a specific configuration element. A key consists of a
 // group and an item.
-class ConfigKey {
+class ConfigKey final {
   public:
-    ConfigKey(); // is required for qMetaTypeConstructHelper()
-    ConfigKey(const ConfigKey& key);
-    ConfigKey(const QString& g, const QString& i);
+    ConfigKey() = default; // is required for qMetaTypeConstructHelper()
+    ConfigKey(QString group, QString item)
+            : group(std::move(group)),
+              item(std::move(item)) {
+    }
+
     static ConfigKey parseCommaSeparated(const QString& key);
 
-    inline bool isEmpty() const {
+    bool isEmpty() const {
         return group.isEmpty() && item.isEmpty();
     }
 
-    inline bool isNull() const {
+    bool isNull() const {
         return group.isNull() && item.isNull();
     }
 
-    // comparison function for ConfigKeys. Used by a QHash in ControlObject
-    friend inline bool operator==(const ConfigKey& lhs, const ConfigKey& rhs) {
-        return lhs.group == rhs.group && lhs.item == rhs.item;
-    }
-
-    // comparison function for ConfigKeys. Used by a QMap in ControlObject
-    friend inline bool operator<(const ConfigKey& lhs, const ConfigKey& rhs) {
-        int groupResult = lhs.group.compare(rhs.group);
-        if (groupResult == 0) {
-            return lhs.item < rhs.item;
-        }
-        return (groupResult < 0);
-    }
-    QString group, item;
+    QString group;
+    QString item;
 };
 Q_DECLARE_METATYPE(ConfigKey);
 
+// comparison function for ConfigKeys. Used by a QHash in ControlObject
+inline bool operator==(const ConfigKey& lhs, const ConfigKey& rhs) {
+    return lhs.group == rhs.group &&
+            lhs.item == rhs.item;
+}
+
+// comparison function for ConfigKeys. Used by a QHash in ControlObject
+inline bool operator!=(const ConfigKey& lhs, const ConfigKey& rhs) {
+    return !(lhs == rhs);
+}
+
+// comparison function for ConfigKeys. Used by a QMap in ControlObject
+inline bool operator<(const ConfigKey& lhs, const ConfigKey& rhs) {
+    int groupResult = lhs.group.compare(rhs.group);
+    if (groupResult == 0) {
+        return lhs.item < rhs.item;
+    }
+    return (groupResult < 0);
+}
 
 // stream operator function for trivial qDebug()ing of ConfigKeys
-inline QDebug operator<<(QDebug stream, const ConfigKey& c1) {
-    stream << c1.group << "," << c1.item;
+inline QDebug operator<<(QDebug stream, const ConfigKey& configKey) {
+    stream << configKey.group << "," << configKey.item;
     return stream;
 }
 
@@ -57,30 +68,34 @@ inline uint qHash(const ConfigKey& key) {
     return qHash(key.group) ^ qHash(key.item);
 }
 
-inline uint qHash(const QKeySequence& key) {
-    return qHash(key.toString());
-}
-
-
 // The value corresponding to a key. The basic value is a string, but can be
 // subclassed to more specific needs.
 class ConfigValue {
   public:
-    ConfigValue();
+    ConfigValue() = default;
+    virtual ~ConfigValue() = default;
     // Only allow non-explicit QString -> ConfigValue conversion for
     // convenience. All other types must be explicit.
-    ConfigValue(const QString& value);
+    ConfigValue(QString value)
+            : value(std::move(value)) {
+    }
     explicit ConfigValue(int value);
     explicit ConfigValue(double value);
-    explicit ConfigValue(const QDomNode& /* node */) {
+    explicit ConfigValue(const QDomNode&) {
         reportFatalErrorAndQuit("ConfigValue from QDomNode not implemented here");
     }
-    void valCopy(const ConfigValue& value);
     bool isNull() const { return value.isNull(); }
 
     QString value;
-    friend bool operator==(const ConfigValue& s1, const ConfigValue& s2);
 };
+
+inline bool operator==(const ConfigValue& lhs, const ConfigValue& rhs) {
+    return lhs.value.toUpper() == rhs.value.toUpper();
+}
+
+inline bool operator!=(const ConfigValue& lhs, const ConfigValue& rhs) {
+    return !(lhs == rhs);
+}
 
 inline uint qHash(const ConfigValue& key) {
     return qHash(key.value.toUpper());
@@ -88,17 +103,29 @@ inline uint qHash(const ConfigValue& key) {
 
 class ConfigValueKbd : public ConfigValue {
   public:
-    ConfigValueKbd();
-    explicit ConfigValueKbd(const QString& _value);
-    explicit ConfigValueKbd(const QKeySequence& key);
-    explicit ConfigValueKbd(const QDomNode& /* node */) {
+    ConfigValueKbd() = default;
+    ~ConfigValueKbd() override = default;
+    explicit ConfigValueKbd(QString value);
+    explicit ConfigValueKbd(QKeySequence keys);
+    explicit ConfigValueKbd(const QDomNode) {
         reportFatalErrorAndQuit("ConfigValueKbd from QDomNode not implemented here");
     }
-    void valCopy(const ConfigValueKbd& v);
-    friend bool operator==(const ConfigValueKbd& s1, const ConfigValueKbd& s2);
 
-    QKeySequence m_qKey;
+    friend bool operator==(const ConfigValueKbd& lhs, const ConfigValueKbd& rhs) {
+        // Both the key sequence and the value of the base class must be consistent!
+        // TODO(XXX): Fix this error prone design!!
+        DEBUG_ASSERT((lhs.m_keys == rhs.m_keys) ==
+                (static_cast<const ConfigValue&>(lhs) == static_cast<const ConfigValue&>(rhs)));
+        return lhs.m_keys == rhs.m_keys;
+    }
+
+   private:
+    QKeySequence m_keys;
 };
+
+inline bool operator!=(const ConfigValueKbd& lhs, const ConfigValueKbd& rhs) {
+    return !(lhs == rhs);
+}
 
 template <class ValueType> class ConfigObject {
   public:


### PR DESCRIPTION
- Fix GCC 9 warnings
- Inline pass-through constructors
- Add virtual destructor to ConfigValue
- Define both operator == and !=
- Delete unused functions
- Add TODO to fix the error-prone design of ConfigValueKbd