### PR TITLE
reduce number of sent midi messages for wheel leds

### DIFF
--- a/res/controllers/Pioneer-DDJ-SX-scripts.js
+++ b/res/controllers/Pioneer-DDJ-SX-scripts.js
@@ -14,10 +14,10 @@ var PioneerDDJSX = function() {};
 	Version: 		1.19, 05/01/2018
 	Description: 	Pioneer DDJ-SX Controller Mapping for Mixxx
     Source: 		http://github.com/DJMaxergy/mixxx/tree/pioneerDDJSX_mapping
-    
+
     Copyright (c) 2018 DJMaxergy, licensed under GPL version 2 or later
     Copyright (c) 2014-2015 various contributors, base for this mapping, licensed under MIT license
-    
+
     Contributors:
     - Michael Stahl (DG3NEC): original DDJ-SB2 mapping for Mixxx 2.0
     - Sophia Herzog: midiAutoDJ-scripts
@@ -26,31 +26,31 @@ var PioneerDDJSX = function() {};
       https://github.com/wingcom/Mixxx-Pioneer-DDJ-SB
     - Hilton Rudham: Pioneer DDJ-SR mapping
       https://github.com/hrudham/Mixxx-Pioneer-DDJ-SR
-      
+
     GPL license notice for current version:
     This program is free software; you can redistribute it and/or modify it under the terms of the
     GNU General Public License as published by the Free Software Foundation; either version 2
     of the License, or (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
     without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
     the GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License along with this program; if
     not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-    
-    
+
+
     MIT License for earlier versions:
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software
     and associated documentation files (the "Software"), to deal in the Software without
     restriction, including without limitation the rights to use, copy, modify, merge, publish,
     distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
     Software is furnished to do so, subject to the following conditions:
-    
+
     The above copyright notice and this permission notice shall be included in all copies or
     substantial portions of the Software.
-    
+
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
     BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -79,17 +79,17 @@ PioneerDDJSX.autoDJTickInterval = 1000;
 // Sets the maximum adjustment of BPM allowed for beats to sync if AutoDJ is enabled [BPM] (default: 10).
 PioneerDDJSX.autoDJMaxBpmAdjustment = 10;
 // If true, AutoDJ queue is being shuffled after skipping a track (default: false).
-// When using a fixed set of tracks without manual intervention, some tracks may be unreachable, 
+// When using a fixed set of tracks without manual intervention, some tracks may be unreachable,
 // due to having an unfortunate place in the queue ordering. This solves the issue.
 PioneerDDJSX.autoDJShuffleAfterSkip = false;
 
-// If true, by releasing rotary selector, 
+// If true, by releasing rotary selector,
 // track in preview player jumps forward to "jumpPreviewPosition"
-// (default: jumpPreviewEnabled = true, jumpPreviewPosition = 0.3). 
+// (default: jumpPreviewEnabled = true, jumpPreviewPosition = 0.3).
 PioneerDDJSX.jumpPreviewEnabled = true;
 PioneerDDJSX.jumpPreviewPosition = 0.3;
 
-// If true, pad press in SAMPLER-PAD-MODE repeatedly causes sampler to play 
+// If true, pad press in SAMPLER-PAD-MODE repeatedly causes sampler to play
 // loaded track from cue-point, else it causes to play loaded track from the beginning (default: false).
 PioneerDDJSX.samplerCueGotoAndPlay = false;
 
@@ -114,6 +114,7 @@ PioneerDDJSX.chFaderStart = [null, null, null, null];
 PioneerDDJSX.toggledBrake = [false, false, false, false];
 PioneerDDJSX.scratchMode = [true, true, true, true];
 PioneerDDJSX.wheelLedsBlinkStatus = [0, 0, 0, 0];
+PioneerDDJSX.wheelLedsPosition = [0, 0, 0, 0];
 PioneerDDJSX.setUpSpeedSliderRange = [0.08, 0.08, 0.08, 0.08];
 
 // PAD mode storage:
@@ -1570,7 +1571,7 @@ PioneerDDJSX.panelSelectButton = function(channel, control, value, status, group
 PioneerDDJSX.shiftPanelSelectButton = function(channel, control, value, status, group) {
     var channelGroup;
     PioneerDDJSX.shiftPanelSelectPressed = value ? true : false;
-    
+
     for (var index in PioneerDDJSX.fxUnitGroups) {
         if (PioneerDDJSX.fxUnitGroups.hasOwnProperty(index)) {
             if (PioneerDDJSX.fxUnitGroups[index] < 2) {
@@ -1846,7 +1847,13 @@ PioneerDDJSX.wheelLeds = function(value, group, control) {
         }
         PioneerDDJSX.wheelLedsBlinkStatus[deck]++;
     }
-    PioneerDDJSX.wheelLedControl(group, wheelPos);
+    wheelPos = parseInt(wheelPos);
+    // Only send midi message when the position is actually updated.
+    // Otherwise, the amount of messages may exceed the maximum rate at high position update rates.
+    if (PioneerDDJSX.wheelLedsPosition[deck] !== wheelPos) {
+      PioneerDDJSX.wheelLedControl(group, wheelPos);
+    }
+    PioneerDDJSX.wheelLedsPosition[deck] = wheelPos;
 };
 
 PioneerDDJSX.cueLed = function(value, group, control) {


### PR DESCRIPTION
I had the problem that the rate that midi messages are sent to the controller apparently exceeds the maximum when the audio buffer size is set lower than 10ms. It was caused by the "playposition" control that in the ddj-sx controller script updates the position of the wheel leds inside the jog wheel. Apparently, when the buffer size is reduced, the number of position updates increases.

What happens than can be seen in the following video. All controls react in a delayed behavior as soon as two decks are playing and updating the wheel leds.
https://projects.goddi.ddnss.eu/wp-content/uploads/delayed_behavior.mkv

Therefore, I adapted the DDJ-SX script such that a midi message is only sent when the position of the wheel leds is really changed. Thanks to @JosepMaJAZ  who pointed me towards the cause of the problem and the solution.