### PR TITLE
lp1848887: Fix parsing of AcoustID response

### DIFF
--- a/src/musicbrainz/acoustidclient.cpp
+++ b/src/musicbrainz/acoustidclient.cpp
@@ -23,7 +23,7 @@ namespace {
 // see API-KEY site here http://acoustid.org/application/496
 // I registered the KEY for version 1.12 -- kain88 (may 2013)
 const QString CLIENT_APIKEY = "czKxnkyO";
-const QString ACOUSTID_URL = "http://api.acoustid.org/v2/lookup";
+const QString ACOUSTID_URL = "https://api.acoustid.org/v2/lookup";
 constexpr int kDefaultTimeout = 5000; // msec
 
 } // anonymous namespace
@@ -113,10 +113,10 @@ void AcoustidClient::requestFinished() {
             if (reader.readNextStartElement()) {
                 const QStringRef name = reader.name();
                 if (name == "message") {
-                    DEBUG_ASSERT(name.isEmpty()); // fail if we have duplicated message elements. 
+                    DEBUG_ASSERT(name.isEmpty()); // fail if we have duplicated message elements.
                     message = reader.readElementText();
                 } else if (name == "code") {
-                    DEBUG_ASSERT(code.isEmpty()); // fail if we have duplicated code elements. 
+                    DEBUG_ASSERT(code.isEmpty()); // fail if we have duplicated code elements.
                     code = reader.readElementText();
                 }
             }

--- a/src/musicbrainz/acoustidclient.h
+++ b/src/musicbrainz/acoustidclient.h
@@ -52,14 +52,12 @@ class AcoustidClient : public QObject {
 
   signals:
     void finished(int id, const QString& mbid);
-    void networkError(int, QString);
+    void networkError(int httpStatus, QString app, QString message, int code);
 
   private slots:
     void requestFinished();
 
   private:
-    static const int m_DefaultTimeout;
-
     QNetworkAccessManager m_network;
     NetworkTimeouts m_timeouts;
     QMap<QNetworkReply*, int> m_requests;

--- a/src/musicbrainz/acoustidclient.h
+++ b/src/musicbrainz/acoustidclient.h
@@ -17,8 +17,6 @@
 #include "musicbrainz/network.h"
 #include "track/track.h"
 
-class QXmlStreamReader;
-
 class AcoustidClient : public QObject {
   Q_OBJECT
 
@@ -47,8 +45,6 @@ class AcoustidClient : public QObject {
     // Cancels all requests.  Finished() will never be emitted for any pending
     // requests.
     void cancelAll();
-
-    QString parseResult(QXmlStreamReader& reader);
 
   signals:
     void finished(int id, const QString& mbid);


### PR DESCRIPTION
Instead of the recording id the track id was parsed and the implementation was dependent on the ordering of the elements, i.e. completely messed up.

- Backported master to 2.2
- Switched from HTTP to HTTPS
- Switched from XML to JSON
- Fixed parsing of AcoustID response

Handling a JSON response is much easier. XML doesn't provide any benefits without a schema and generated parser.