### PR TITLE
preferences/dialog/dlgprefsound: Fix duplicate declaration of m_config

### DIFF
--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -114,7 +114,6 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     bool m_bLatencyChanged;
     bool m_bSkipConfigClear;
     bool m_loading;
-    SoundManagerConfig m_config;
 };
 
 #endif


### PR DESCRIPTION
Sorry, looks like #2327 broke the master branch due some merge conflict or something like that.