### PR TITLE
Reloop TermnalMix 2/4: fix Sampler5-8 buttons

### DIFF
--- a/res/controllers/Reloop Terminal Mix 2-4.midi.xml
+++ b/res/controllers/Reloop Terminal Mix 2-4.midi.xml
@@ -636,7 +636,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler1]</group>
+        <group>[Sampler5]</group>
         <key>cue_gotoandplay</key>
         <status>0x90</status>
         <midino>0x1C</midino>
@@ -645,7 +645,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler2]</group>
+        <group>[Sampler6]</group>
         <key>cue_gotoandplay</key>
         <status>0x90</status>
         <midino>0x1D</midino>
@@ -654,7 +654,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler3]</group>
+        <group>[Sampler7]</group>
         <key>cue_gotoandplay</key>
         <status>0x90</status>
         <midino>0x1E</midino>
@@ -663,7 +663,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler4]</group>
+        <group>[Sampler8]</group>
         <key>cue_gotoandplay</key>
         <status>0x90</status>
         <midino>0x1F</midino>
@@ -708,7 +708,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler1]</group>
+        <group>[Sampler5]</group>
         <key>start_stop</key>
         <status>0x90</status>
         <midino>0x62</midino>
@@ -717,7 +717,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler2]</group>
+        <group>[Sampler6]</group>
         <key>start_stop</key>
         <status>0x90</status>
         <midino>0x63</midino>
@@ -726,7 +726,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler3]</group>
+        <group>[Sampler7]</group>
         <key>start_stop</key>
         <status>0x90</status>
         <midino>0x64</midino>
@@ -735,7 +735,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler4]</group>
+        <group>[Sampler8]</group>
         <key>start_stop</key>
         <status>0x90</status>
         <midino>0x65</midino>
@@ -1188,7 +1188,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler1]</group>
+        <group>[Sampler5]</group>
         <key>cue_gotoandplay</key>
         <status>0x91</status>
         <midino>0x1C</midino>
@@ -1197,7 +1197,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler2]</group>
+        <group>[Sampler6]</group>
         <key>cue_gotoandplay</key>
         <status>0x91</status>
         <midino>0x1D</midino>
@@ -1206,7 +1206,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler3]</group>
+        <group>[Sampler7]</group>
         <key>cue_gotoandplay</key>
         <status>0x91</status>
         <midino>0x1E</midino>
@@ -1215,7 +1215,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler4]</group>
+        <group>[Sampler8]</group>
         <key>cue_gotoandplay</key>
         <status>0x91</status>
         <midino>0x1F</midino>
@@ -1260,7 +1260,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler1]</group>
+        <group>[Sampler5]</group>
         <key>start_stop</key>
         <status>0x91</status>
         <midino>0x62</midino>
@@ -1269,7 +1269,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler2]</group>
+        <group>[Sampler6]</group>
         <key>start_stop</key>
         <status>0x91</status>
         <midino>0x63</midino>
@@ -1278,7 +1278,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler3]</group>
+        <group>[Sampler7]</group>
         <key>start_stop</key>
         <status>0x91</status>
         <midino>0x64</midino>
@@ -1287,7 +1287,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler4]</group>
+        <group>[Sampler8]</group>
         <key>start_stop</key>
         <status>0x91</status>
         <midino>0x65</midino>
@@ -1705,7 +1705,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler1]</group>
+        <group>[Sampler5]</group>
         <key>cue_gotoandplay</key>
         <status>0x92</status>
         <midino>0x1C</midino>
@@ -1714,7 +1714,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler2]</group>
+        <group>[Sampler6]</group>
         <key>cue_gotoandplay</key>
         <status>0x92</status>
         <midino>0x1D</midino>
@@ -1723,7 +1723,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler3]</group>
+        <group>[Sampler7]</group>
         <key>cue_gotoandplay</key>
         <status>0x92</status>
         <midino>0x1E</midino>
@@ -1732,7 +1732,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler4]</group>
+        <group>[Sampler8]</group>
         <key>cue_gotoandplay</key>
         <status>0x92</status>
         <midino>0x1F</midino>
@@ -1777,7 +1777,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler1]</group>
+        <group>[Sampler5]</group>
         <key>start_stop</key>
         <status>0x92</status>
         <midino>0x62</midino>
@@ -1786,7 +1786,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler2]</group>
+        <group>[Sampler6]</group>
         <key>start_stop</key>
         <status>0x92</status>
         <midino>0x63</midino>
@@ -1795,7 +1795,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler3]</group>
+        <group>[Sampler7]</group>
         <key>start_stop</key>
         <status>0x92</status>
         <midino>0x64</midino>
@@ -1804,7 +1804,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler4]</group>
+        <group>[Sampler8]</group>
         <key>start_stop</key>
         <status>0x92</status>
         <midino>0x65</midino>
@@ -2201,7 +2201,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler1]</group>
+        <group>[Sampler5]</group>
         <key>cue_gotoandplay</key>
         <status>0x93</status>
         <midino>0x1C</midino>
@@ -2210,7 +2210,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler2]</group>
+        <group>[Sampler6]</group>
         <key>cue_gotoandplay</key>
         <status>0x93</status>
         <midino>0x1D</midino>
@@ -2219,7 +2219,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler3]</group>
+        <group>[Sampler7]</group>
         <key>cue_gotoandplay</key>
         <status>0x93</status>
         <midino>0x1E</midino>
@@ -2228,7 +2228,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler4]</group>
+        <group>[Sampler8]</group>
         <key>cue_gotoandplay</key>
         <status>0x93</status>
         <midino>0x1F</midino>
@@ -2273,7 +2273,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler1]</group>
+        <group>[Sampler5]</group>
         <key>start_stop</key>
         <status>0x93</status>
         <midino>0x62</midino>
@@ -2282,7 +2282,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler2]</group>
+        <group>[Sampler6]</group>
         <key>start_stop</key>
         <status>0x93</status>
         <midino>0x63</midino>
@@ -2291,7 +2291,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler3]</group>
+        <group>[Sampler7]</group>
         <key>start_stop</key>
         <status>0x93</status>
         <midino>0x64</midino>
@@ -2300,7 +2300,7 @@ A complete 4-deck preset for a single Reloop Terminal Mix 2 or 4.
         </options>
       </control>
       <control>
-        <group>[Sampler4]</group>
+        <group>[Sampler8]</group>
         <key>start_stop</key>
         <status>0x93</status>
         <midino>0x65</midino>


### PR DESCRIPTION
fixes https://bugs.launchpad.net/mixxx/+bug/1846966

Sampler buttons 5-8 (Scissor icon) were still mapped to Samplers 1-4