### PR TITLE
WaveformRenderMark: fix scaling for high DPI screens

### DIFF
--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -57,7 +57,8 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
             if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
                 // NOTE: vRince I guess image width is odd to display the center on the exact line !
                 // external image should respect that ...
-                const int markHalfWidth = pMark->m_image.width() / 2.0;
+                const int markHalfWidth = pMark->m_image.width() / 2.0
+                        / m_waveformRenderer->getDevicePixelRatio();
 
                 // Check if the current point need to be displayed
                 if (currentMarkPoint > -markHalfWidth && currentMarkPoint < m_waveformRenderer->getWidth() + markHalfWidth) {
@@ -196,7 +197,10 @@ void WaveformRenderMark::generateMarkImage(WaveformMark* pMark) {
             height = 2 * labelRectHeight + 1;
         }
 
-        pMark->m_image = QImage(width, height, QImage::Format_ARGB32_Premultiplied);
+        pMark->m_image = QImage(width * m_waveformRenderer->getDevicePixelRatio(),
+                                height * m_waveformRenderer->getDevicePixelRatio(),
+                                QImage::Format_ARGB32_Premultiplied);
+        pMark->m_image.setDevicePixelRatio(m_waveformRenderer->getDevicePixelRatio());
 
         Qt::Alignment markAlignH = markProperties.m_align & Qt::AlignHorizontal_Mask;
         Qt::Alignment markAlignV = markProperties.m_align & Qt::AlignVertical_Mask;


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/9455094/67456792-6dd65100-f5f7-11e9-91e2-3901acc34a5f.png)


after:
![image](https://user-images.githubusercontent.com/9455094/67459303-d9bbb800-f5fd-11e9-9198-8741050c09e6.png)