### PR TITLE
Library controller navigation fixes & enhancements

### DIFF
--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -2040,7 +2040,8 @@ WLibrary,
 }
 
 #LibraryContainer QTableView:focus,
-#LibraryContainer QTreeView:focus {
+#LibraryContainer QTreeView:focus,
+#LibraryContainer QTextBrowser:focus {
   border: 1px solid #ff6600;
 }
 

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -356,5 +356,5 @@ void DlgAutoDJ::updateSelectionInfo() {
 }
 
 bool DlgAutoDJ::hasFocus() const {
-    return QWidget::hasFocus();
+    return m_pTrackTableView->hasFocus();
 }

--- a/src/library/autodj/dlgautodj.ui
+++ b/src/library/autodj/dlgautodj.ui
@@ -57,6 +57,9 @@
        <property name="checkable">
         <bool>true</bool>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
       </widget>
      </item>
      <item>
@@ -83,6 +86,9 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
       </widget>
      </item>
      <item>
@@ -96,10 +102,17 @@
        <property name="checkable">
         <bool>false</bool>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="fadeModeCombobox"/>
+      <widget class="QComboBox" name="fadeModeCombobox">
+       <property name="focusPolicy">
+        <enum>Qt::ClickFocus</enum>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QSpinBox" name="spinBoxTransition">
@@ -117,6 +130,9 @@
        </property>
        <property name="minimum">
         <number>-9</number>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::ClickFocus</enum>
        </property>
       </widget>
      </item>
@@ -154,6 +170,9 @@
        <property name="checkable">
         <bool>false</bool>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
       </widget>
      </item>
      <item>
@@ -163,6 +182,9 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
        </property>
       </widget>
      </item>
@@ -176,6 +198,9 @@
        </property>
        <property name="checkable">
         <bool>true</bool>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
        </property>
       </widget>
      </item>

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -97,7 +97,7 @@ void DlgAnalysis::onShow() {
 }
 
 bool DlgAnalysis::hasFocus() const {
-    return QWidget::hasFocus();
+    return m_pAnalysisLibraryTableView->hasFocus();
 }
 
 void DlgAnalysis::onSearch(const QString& text) {

--- a/src/library/dlganalysis.ui
+++ b/src/library/dlganalysis.ui
@@ -54,6 +54,9 @@
        <property name="text">
         <string>New</string>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
       </widget>
      </item>
      <item>
@@ -63,6 +66,9 @@
        </property>
        <property name="text">
         <string>All</string>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
        </property>
       </widget>
      </item>
@@ -74,6 +80,9 @@
        <property name="text">
         <string>Select All</string>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
       </widget>
      </item>
      <item>
@@ -83,6 +92,9 @@
        </property>
        <property name="text">
         <string>Analyze</string>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
        </property>
       </widget>
      </item>

--- a/src/library/dlghidden.cpp
+++ b/src/library/dlghidden.cpp
@@ -112,5 +112,5 @@ void DlgHidden::selectionChanged(const QItemSelection &selected,
 }
 
 bool DlgHidden::hasFocus() const {
-    return QWidget::hasFocus();
+    return m_pTrackTableView->hasFocus();
 }

--- a/src/library/dlghidden.ui
+++ b/src/library/dlghidden.ui
@@ -54,6 +54,9 @@
        <property name="text">
         <string>Select All</string>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
       </widget>
      </item>
      <item>
@@ -66,6 +69,9 @@
        </property>
        <property name="checkable">
         <bool>false</bool>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
        </property>
       </widget>
      </item>
@@ -82,6 +88,9 @@
        </property>
        <property name="checkable">
         <bool>false</bool>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
        </property>
       </widget>
      </item>

--- a/src/library/dlgmissing.cpp
+++ b/src/library/dlgmissing.cpp
@@ -81,5 +81,5 @@ void DlgMissing::selectionChanged(const QItemSelection &selected,
 }
 
 bool DlgMissing::hasFocus() const {
-    return QWidget::hasFocus();
+    return m_pTrackTableView->hasFocus();
 }

--- a/src/library/dlgmissing.ui
+++ b/src/library/dlgmissing.ui
@@ -54,6 +54,9 @@
        <property name="text">
         <string>Select All</string>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
       </widget>
      </item>
      <item>
@@ -66,6 +69,9 @@
        </property>
        <property name="checkable">
         <bool>false</bool>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
        </property>
       </widget>
      </item>

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -241,6 +241,10 @@ void Library::bindSearchboxWidget(WSearchLineEdit* pSearchboxWidget) {
             &Library::restoreSearch,
             pSearchboxWidget,
             &WSearchLineEdit::restoreSearch);
+    connect(m_pLibraryControl,
+            &LibraryControl::clearSearch,
+            pSearchboxWidget,
+            &WSearchLineEdit::clearSearch);
     connect(this,
             &Library::setTrackTableFont,
             pSearchboxWidget,

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -13,6 +13,7 @@ class Library;
 class LibraryControl;
 class WLibrary;
 class WLibrarySidebar;
+class WSearchLineEdit;
 class KeyboardEventFilter;
 
 class LoadToGroupController : public QObject {
@@ -42,14 +43,18 @@ class LibraryControl : public QObject {
 
     void bindLibraryWidget(WLibrary* pLibrary, KeyboardEventFilter* pKeyboard);
     void bindSidebarWidget(WLibrarySidebar* pLibrarySidebar);
+    void bindSearchboxWidget(WSearchLineEdit* pSearchbox);
 
   public slots:
     // Deprecated navigation slots
     void slotLoadSelectedTrackToGroup(QString group, bool play);
+  signals:
+    void clearSearch();
 
   private slots:
     void libraryWidgetDeleted();
     void sidebarWidgetDeleted();
+    void searchboxWidgetDeleted();
 
     void slotMoveUp(double);
     void slotMoveDown(double);
@@ -95,7 +100,9 @@ class LibraryControl : public QObject {
     // Simulate pressing a key on the keyboard
     void emitKeyEvent(QKeyEvent&& event);
     // Give the keyboard focus to the main library pane
-    void setLibraryFocus();
+    void focusLibraryView();
+    // Test if the main library feature has focus
+    bool libraryViewHasFocus();
 
     // Controls to navigate vertically within currently focused widget (up/down buttons)
     std::unique_ptr<ControlPushButton> m_pMoveUp;
@@ -147,6 +154,7 @@ class LibraryControl : public QObject {
     // Library widgets
     WLibrary* m_pLibraryWidget;
     WLibrarySidebar* m_pSidebarWidget;
+    WSearchLineEdit* m_pSearchbox;
 
     // Other variables
     ControlProxy m_numDecks;

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -90,7 +90,7 @@ void DlgRecording::onShow() {
 }
 
 bool DlgRecording::hasFocus() const {
-    return QWidget::hasFocus();
+    return m_pTrackTableView->hasFocus();
 }
 
 void DlgRecording::refreshBrowseModel() {

--- a/src/library/recording/dlgrecording.ui
+++ b/src/library/recording/dlgrecording.ui
@@ -48,6 +48,9 @@
      </property>
      <item>
       <widget class="QPushButton" name="pushButtonRecording">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
        <property name="text">
         <string>Start Recording</string>
        </property>

--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -72,6 +72,9 @@ WSearchLineEdit::WSearchLineEdit(QWidget* pParent)
             this,
             &WSearchLineEdit::clearSearch);
 
+    // This prevents the searchbox from being focused by Tab key (real or emulated)
+    // so it is skipped when using the library controls 'MoveFocus[...]'
+    // The Clear button can still be focused by Tab.
     setFocusPolicy(Qt::ClickFocus);
     QShortcut* setFocusShortcut = new QShortcut(QKeySequence(tr("Ctrl+F", "Search|Focus")), this);
     connect(setFocusShortcut,

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -45,12 +45,12 @@ class WSearchLineEdit : public QLineEdit, public WBaseWidget {
     void restoreSearch(const QString& text);
     void disableSearch();
     void slotSetFont(const QFont& font);
+    void clearSearch();
 
   private slots:
     void setShortcutFocus();
     void updateText(const QString& text);
 
-    void clearSearch();
     void triggerSearch();
 
   private:


### PR DESCRIPTION
I attempt to clean up my outdated previous PR to clear search via controllers with [Library],GoToItem, as well as some small improvements for library controller navigation.

_reworked and rebased since noone reviewed it anyways so far_
I hope the commits are easy to review because I think this solves some issues with basic Library navigation that would ease the library/controller UX in 2.3

https://bugs.launchpad.net/mixxx/+bug/1840541

**don't allow to focus Library feature buttons**
... in Recording, AutoDJ, Analysis, Hidden or Missing neither with `Tab` key on keyboard nor `[Library]MoveFocus...` to always see the focus indicating border on the sidebar or tracks table.
There's no point in having those focused as there's no way to trigger them, neither from keyboard or controllers. For AutoDJ and Recording there are keyboard shortcuts.

**fix hasFocus()**
... in DlgRecording, DlgAutoDJ, DlgAnalysis, DlgHidden and DlgMissing to prevent 'refocus Library' calls there before issuing a move/scroll command.

**Prevent focus from getting stuck at Clear button**
_In master_, the focus can be moved to the Clear button with `[Library],MoveFocus[Backward, Forward]` (when there is an active search). Then, `MoveFocusForward` would do nothing because behind the scenes library control tests if the sidebar or tracks table have focus; if false it would try to re-focus the tracks table: focus the sidebar > emulate Tab > then send the MoveFocus Tab = we end up at the Clear button again. With `MoveFocus, -1` it would jump between sidebar and Clear button.
_Now_, the focus controls always send a Tab key no matter which widget has focus.

**Clear Search from controller**
Clear the seach with `[Library],GoToItem` when either the searchbox or the Clear button has focus.

ToDo
- [ ] clean up, remove debug output
- [x] remove focusAnalysis()
- [x] resolve conflicts
- [ ] add some skin feedback: dim border for WTextBrowser, ...