### PR TITLE
Follow-up #2196: Remove obsolete debug assertion

### DIFF
--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -119,9 +119,6 @@ void QuantizeControl::updateClosestBeat(double dCurrentSample) {
         double currentClosestBeat =
                 (nextBeat - dCurrentSample > dCurrentSample - prevBeat) ?
                         prevBeat : nextBeat;
-        VERIFY_OR_DEBUG_ASSERT(even(static_cast<int>(currentClosestBeat))) {
-            currentClosestBeat--;
-        }
         if (closestBeat != currentClosestBeat) {
             m_pCOClosestBeat->set(currentClosestBeat);
         }

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -6,6 +6,8 @@
 
 namespace {
 
+const double kMaxBeatError = 1e-9;
+
 TEST(BeatGridTest, Scale) {
     TrackPointer pTrack(Track::newTemporary());
 
@@ -58,19 +60,19 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
     // findNthBeat should return exactly the current beat if we ask for 1 or
     // -1. For all other values, it should return n times the beat length.
     for (int i = 1; i < 20; ++i) {
-        EXPECT_DOUBLE_EQ(position + beatLength * (i - 1), pGrid->findNthBeat(position, i));
-        EXPECT_DOUBLE_EQ(position + beatLength * (-i + 1), pGrid->findNthBeat(position, -i));
+        EXPECT_NEAR(position + beatLength * (i - 1), pGrid->findNthBeat(position, i), kMaxBeatError);
+        EXPECT_NEAR(position + beatLength * (-i + 1), pGrid->findNthBeat(position, -i), kMaxBeatError);
     }
 
     // Also test prev/next beat calculation.
     double prevBeat, nextBeat;
     pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat);
-    EXPECT_DOUBLE_EQ(position, prevBeat);
-    EXPECT_DOUBLE_EQ(position + beatLength, nextBeat);
+    EXPECT_NEAR(position, prevBeat, kMaxBeatError);
+    EXPECT_NEAR(position + beatLength, nextBeat, kMaxBeatError);
 
     // Both previous and next beat should return the current position.
-    EXPECT_DOUBLE_EQ(position, pGrid->findNextBeat(position));
-    EXPECT_DOUBLE_EQ(position, pGrid->findPrevBeat(position));
+    EXPECT_NEAR(position, pGrid->findNextBeat(position), kMaxBeatError);
+    EXPECT_NEAR(position, pGrid->findPrevBeat(position), kMaxBeatError);
 }
 
 TEST(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
@@ -96,19 +98,19 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_BeforeEpsilon) {
     // findNthBeat should return exactly the current beat if we ask for 1 or
     // -1. For all other values, it should return n times the beat length.
     for (int i = 1; i < 20; ++i) {
-        EXPECT_DOUBLE_EQ(kClosestBeat + beatLength * (i - 1), pGrid->findNthBeat(position, i));
-        EXPECT_DOUBLE_EQ(kClosestBeat + beatLength * (-i + 1), pGrid->findNthBeat(position, -i));
+        EXPECT_NEAR(kClosestBeat + beatLength * (i - 1), pGrid->findNthBeat(position, i), kMaxBeatError);
+        EXPECT_NEAR(kClosestBeat + beatLength * (-i + 1), pGrid->findNthBeat(position, -i), kMaxBeatError);
     }
 
     // Also test prev/next beat calculation.
     double prevBeat, nextBeat;
     pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat);
-    EXPECT_DOUBLE_EQ(kClosestBeat, prevBeat);
-    EXPECT_DOUBLE_EQ(kClosestBeat + beatLength, nextBeat);
+    EXPECT_NEAR(kClosestBeat, prevBeat, kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat + beatLength, nextBeat, kMaxBeatError);
 
     // Both previous and next beat should return the closest beat.
-    EXPECT_DOUBLE_EQ(kClosestBeat, pGrid->findNextBeat(position));
-    EXPECT_DOUBLE_EQ(kClosestBeat, pGrid->findPrevBeat(position));
+    EXPECT_NEAR(kClosestBeat, pGrid->findNextBeat(position), kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat, pGrid->findPrevBeat(position), kMaxBeatError);
 }
 
 TEST(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
@@ -134,19 +136,19 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat_AfterEpsilon) {
     // findNthBeat should return exactly the current beat if we ask for 1 or
     // -1. For all other values, it should return n times the beat length.
     for (int i = 1; i < 20; ++i) {
-        EXPECT_DOUBLE_EQ(kClosestBeat + beatLength * (i - 1), pGrid->findNthBeat(position, i));
-        EXPECT_DOUBLE_EQ(kClosestBeat + beatLength * (-i + 1), pGrid->findNthBeat(position, -i));
+        EXPECT_NEAR(kClosestBeat + beatLength * (i - 1), pGrid->findNthBeat(position, i), kMaxBeatError);
+        EXPECT_NEAR(kClosestBeat + beatLength * (-i + 1), pGrid->findNthBeat(position, -i), kMaxBeatError);
     }
 
     // Also test prev/next beat calculation.
     double prevBeat, nextBeat;
     pGrid->findPrevNextBeats(position, &prevBeat, &nextBeat);
-    EXPECT_DOUBLE_EQ(kClosestBeat, prevBeat);
-    EXPECT_DOUBLE_EQ(kClosestBeat + beatLength, nextBeat);
+    EXPECT_NEAR(kClosestBeat, prevBeat, kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat + beatLength, nextBeat, kMaxBeatError);
 
     // Both previous and next beat should return the closest beat.
-    EXPECT_DOUBLE_EQ(kClosestBeat, pGrid->findNextBeat(position));
-    EXPECT_DOUBLE_EQ(kClosestBeat, pGrid->findPrevBeat(position));
+    EXPECT_NEAR(kClosestBeat, pGrid->findNextBeat(position), kMaxBeatError);
+    EXPECT_NEAR(kClosestBeat, pGrid->findPrevBeat(position), kMaxBeatError);
 }
 
 TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
@@ -172,15 +174,15 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
     // findNthBeat should return multiples of beats starting from the next or
     // previous beat, depending on whether N is positive or negative.
     for (int i = 1; i < 20; ++i) {
-        EXPECT_DOUBLE_EQ(nextBeat + beatLength*(i-1), pGrid->findNthBeat(position, i));
-        EXPECT_DOUBLE_EQ(previousBeat + beatLength*(-i+1), pGrid->findNthBeat(position, -i));
+        EXPECT_NEAR(nextBeat + beatLength*(i-1), pGrid->findNthBeat(position, i), kMaxBeatError);
+        EXPECT_NEAR(previousBeat + beatLength*(-i+1), pGrid->findNthBeat(position, -i), kMaxBeatError);
     }
 
     // Also test prev/next beat calculation
     double foundPrevBeat, foundNextBeat;
     pGrid->findPrevNextBeats(position, &foundPrevBeat, &foundNextBeat);
-    EXPECT_DOUBLE_EQ(previousBeat, foundPrevBeat);
-    EXPECT_DOUBLE_EQ(nextBeat, foundNextBeat);
+    EXPECT_NEAR(previousBeat, foundPrevBeat, kMaxBeatError);
+    EXPECT_NEAR(nextBeat, foundNextBeat, kMaxBeatError);
 }
 
 }  // namespace

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -172,15 +172,15 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
     // findNthBeat should return multiples of beats starting from the next or
     // previous beat, depending on whether N is positive or negative.
     for (int i = 1; i < 20; ++i) {
-        EXPECT_EQ(nextBeat + beatLength*(i-1), pGrid->findNthBeat(position, i));
-        EXPECT_EQ(previousBeat + beatLength*(-i+1), pGrid->findNthBeat(position, -i));
+        EXPECT_DOUBLE_EQ(nextBeat + beatLength*(i-1), pGrid->findNthBeat(position, i));
+        EXPECT_DOUBLE_EQ(previousBeat + beatLength*(-i+1), pGrid->findNthBeat(position, -i));
     }
 
     // Also test prev/next beat calculation
     double foundPrevBeat, foundNextBeat;
     pGrid->findPrevNextBeats(position, &foundPrevBeat, &foundNextBeat);
-    EXPECT_EQ(previousBeat, foundPrevBeat);
-    EXPECT_EQ(nextBeat, foundNextBeat);
+    EXPECT_DOUBLE_EQ(previousBeat, foundPrevBeat);
+    EXPECT_DOUBLE_EQ(nextBeat, foundNextBeat);
 }
 
 }  // namespace


### PR DESCRIPTION
The debug assertions seems to be obsolete now. It is violated by the changes in #2196.