### PR TITLE
[WiP] Track metadata import/export

### DIFF
--- a/src/analyzer/trackanalysisscheduler.cpp
+++ b/src/analyzer/trackanalysisscheduler.cpp
@@ -275,7 +275,7 @@ bool TrackAnalysisScheduler::submitNextTrack(Worker* worker) {
         DEBUG_ASSERT(nextTrackId.isValid());
         if (nextTrackId.isValid()) {
             TrackPointer nextTrack =
-                    m_library->trackCollection().getTrackDAO().getTrack(nextTrackId);
+                    m_library->trackCollection().getTrackById(nextTrackId);
             if (nextTrack) {
                 if (m_pendingTrackIds.insert(nextTrackId).second) {
                     if (worker->submitNextTrack(std::move(nextTrack))) {

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -254,7 +254,7 @@ void AutoDJFeature::slotAddRandomTrack() {
             }
 
             if (randomTrackId.isValid()) {
-                pRandomTrack = m_pTrackCollection->getTrackDAO().getTrack(randomTrackId);
+                pRandomTrack = m_pTrackCollection->getTrackById(randomTrackId);
                 VERIFY_OR_DEBUG_ASSERT(pRandomTrack) {
                     qWarning() << "Track does not exist:"
                             << randomTrackId;

--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -315,8 +315,9 @@ TrackPointer BansheePlaylistModel::getTrack(const QModelIndex& index) const {
     }
 
     bool track_already_in_library = false;
-    TrackPointer pTrack = m_pTrackCollection->getTrackDAO()
-            .getOrAddTrack(location, true, &track_already_in_library);
+    TrackPointer pTrack = m_pTrackCollection->getOrAddTrack(
+            TrackRef::fromFileInfo(location),
+            &track_already_in_library);
 
     // If this track was not in the Mixxx library it is now added and will be
     // saved with the metadata from Banshee. If it was already in the library

--- a/src/library/baseexternalplaylistmodel.cpp
+++ b/src/library/baseexternalplaylistmodel.cpp
@@ -31,8 +31,9 @@ TrackPointer BaseExternalPlaylistModel::getTrack(const QModelIndex& index) const
     }
 
     bool track_already_in_library = false;
-    TrackPointer pTrack = m_pTrackCollection->getTrackDAO()
-            .getOrAddTrack(location, true, &track_already_in_library);
+    TrackPointer pTrack = m_pTrackCollection->getOrAddTrack(
+            TrackRef::fromFileInfo(location),
+            &track_already_in_library);
 
     // If this track was not in the Mixxx library it is now added and will be
     // saved with the metadata from iTunes. If it was already in the library

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -56,8 +56,9 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
     }
 
     bool track_already_in_library = false;
-    TrackPointer pTrack = m_pTrackCollection->getTrackDAO()
-            .getOrAddTrack(location, true, &track_already_in_library);
+    TrackPointer pTrack = m_pTrackCollection->getOrAddTrack(
+            TrackRef::fromFileInfo(location),
+            &track_already_in_library);
 
     if (pTrack) {
         // If this track was not in the Mixxx library it is now added and will be

--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -5,6 +5,7 @@
 #include <QFileInfo>
 #include <QStandardPaths>
 
+#include "library/dao/playlistdao.h"
 #include "library/export/trackexportwizard.h"
 #include "library/library.h"
 #include "library/parser.h"
@@ -26,7 +27,6 @@ BasePlaylistFeature::BasePlaylistFeature(QObject* parent,
         : LibraryFeature(pConfig, parent),
           m_pTrackCollection(pTrackCollection),
           m_playlistDao(pTrackCollection->getPlaylistDAO()),
-          m_trackDao(pTrackCollection->getTrackDAO()),
           m_pPlaylistTableModel(NULL),
           m_rootViewName(rootViewName) {
     m_pCreatePlaylistAction = new QAction(tr("Create New Playlist"),this);

--- a/src/library/baseplaylistfeature.h
+++ b/src/library/baseplaylistfeature.h
@@ -12,12 +12,11 @@
 #include <QString>
 
 #include "library/libraryfeature.h"
-#include "library/dao/playlistdao.h"
-#include "library/dao/trackdao.h"
 #include "track/track.h"
 
 class WLibrary;
 class KeyboardEventFilter;
+class PlaylistDAO;
 class PlaylistTableModel;
 class TrackCollection;
 class TreeItem;
@@ -89,7 +88,6 @@ class BasePlaylistFeature : public LibraryFeature {
 
     TrackCollection* m_pTrackCollection;
     PlaylistDAO &m_playlistDao;
-    TrackDAO &m_trackDao;
     PlaylistTableModel* m_pPlaylistTableModel;
     QAction *m_pCreatePlaylistAction;
     QAction *m_pDeletePlaylistAction;

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -843,7 +843,7 @@ bool BaseSqlTableModel::setData(
 
     // TODO(rryan) ugly and only works because the mixxx library tables are the
     // only ones that aren't read-only. This should be moved into BTC.
-    TrackPointer pTrack = m_pTrackCollection->getTrackDAO().getTrack(trackId);
+    TrackPointer pTrack = m_pTrackCollection->getTrackById(trackId);
     if (!pTrack) {
         return false;
     }
@@ -919,7 +919,7 @@ TrackId BaseSqlTableModel::getTrackId(const QModelIndex& index) const {
 }
 
 TrackPointer BaseSqlTableModel::getTrack(const QModelIndex& index) const {
-    return m_pTrackCollection->getTrackDAO().getTrack(getTrackId(index));
+    return m_pTrackCollection->getTrackById(getTrackId(index));
 }
 
 QString BaseSqlTableModel::getTrackLocation(const QModelIndex& index) const {

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -56,7 +56,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     //  Functions that might be reimplemented/overridden in derived classes
     ///////////////////////////////////////////////////////////////////////////
     //  This class also has protected variables that should be used in children
-    //  m_database, m_pTrackCollection, m_trackDAO
+    //  m_database, m_pTrackCollection
 
     // calls readWriteFlags() by default, reimplement this if the child calls
     // should be readOnly

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -30,7 +30,6 @@ BaseTrackCache::BaseTrackCache(TrackCollection* pTrackCollection,
           m_columnCache(columns),
           m_bIndexBuilt(false),
           m_bIsCaching(isCaching),
-          m_trackDAO(pTrackCollection->getTrackDAO()),
           m_database(pTrackCollection->database()),
           m_pQueryParser(new SearchQueryParser(pTrackCollection)) {
     m_searchColumns << "artist"

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -147,7 +147,6 @@ class BaseTrackCache : public QObject {
     bool m_bIndexBuilt;
     bool m_bIsCaching;
     QHash<TrackId, QVector<QVariant> > m_trackInfo;
-    TrackDAO& m_trackDAO;
     QSqlDatabase m_database;
     SearchQueryParser* m_pQueryParser;
     ControlProxy* m_pKeyNotationCP;

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -153,13 +153,13 @@ void BrowseTableModel::setPath(const MDir& path) {
 }
 
 TrackPointer BrowseTableModel::getTrack(const QModelIndex& index) const {
-    QString track_location = getTrackLocation(index);
-    if (m_pRecordingManager->getRecordingLocation() == track_location) {
+    QString trackLocation = getTrackLocation(index);
+    if (m_pRecordingManager->getRecordingLocation() == trackLocation) {
         QMessageBox::critical(
             0, tr("Mixxx Library"),
             tr("Could not load the following file because"
                " it is in use by Mixxx or another application.")
-            + "\n" +track_location);
+            + "\n" + trackLocation);
         return TrackPointer();
     }
     // NOTE(uklotzde, 2015-12-08): Accessing tracks from the browse view
@@ -170,8 +170,8 @@ TrackPointer BrowseTableModel::getTrack(const QModelIndex& index) const {
     // them edit the tracks in a way that persists across sessions
     // and we didn't want to edit the files on disk by default
     // unless the user opts in to that.
-    return m_pTrackCollection->getTrackDAO()
-            .getOrAddTrack(track_location, true, NULL);
+    return m_pTrackCollection->getOrAddTrack(
+            TrackRef::fromFileInfo(trackLocation));
 }
 
 QString BrowseTableModel::getTrackLocation(const QModelIndex& index) const {

--- a/src/library/dao/autodjcratesdao.cpp
+++ b/src/library/dao/autodjcratesdao.cpp
@@ -710,8 +710,8 @@ TrackId AutoDJCratesDAO::getRandomTrackIdFromAutoDj(int percentActive) {
 // Signaled by the track DAO when a track's information is updated.
 void AutoDJCratesDAO::slotTrackDirty(TrackId trackId) {
     // Update our record of the number of times played, if that changed.
-    TrackPointer pTrack = m_pTrackCollection->getTrackDAO().getTrack(trackId);
-    if (pTrack == NULL) {
+    TrackPointer pTrack = m_pTrackCollection->getTrackById(trackId);
+    if (!pTrack) {
         return;
     }
     const PlayCounter playCounter(pTrack->getPlayCounter());

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1745,7 +1745,7 @@ bool TrackDAO::detectMovedTracks(QList<QPair<TrackRef, TrackRef>>* pReplacedTrac
     return true;
 }
 
-void TrackDAO::markTracksAsMixxxDeleted(const QDir& rootDir) {
+void TrackDAO::hideAllTracks(const QDir& rootDir) {
     // Capture entries that start with the directory prefix dir.
     // dir needs to end in a slash otherwise we might match other
     // directories.

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1745,11 +1745,11 @@ bool TrackDAO::detectMovedTracks(QList<QPair<TrackRef, TrackRef>>* pReplacedTrac
     return true;
 }
 
-void TrackDAO::markTracksAsMixxxDeleted(const QString& dir) {
+void TrackDAO::markTracksAsMixxxDeleted(const QDir& rootDir) {
     // Capture entries that start with the directory prefix dir.
     // dir needs to end in a slash otherwise we might match other
     // directories.
-    QString likeClause = SqlLikeWildcardEscaper::apply(dir + "/", kSqlLikeMatchAll) + kSqlLikeMatchAll;
+    QString likeClause = SqlLikeWildcardEscaper::apply(rootDir.absolutePath() + "/", kSqlLikeMatchAll) + kSqlLikeMatchAll;
 
     QSqlQuery query(m_database);
     query.prepare(QString("SELECT library.id FROM library INNER JOIN track_locations "
@@ -1758,7 +1758,7 @@ void TrackDAO::markTracksAsMixxxDeleted(const QString& dir) {
                   .arg(SqlStringFormatter::format(m_database, likeClause), kSqlLikeMatchAll));
 
     if (!query.exec()) {
-        LOG_FAILED_QUERY(query) << "could not get tracks within directory:" << dir;
+        LOG_FAILED_QUERY(query) << "could not get tracks within directory:" << rootDir;
     }
 
     QStringList trackIds;

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1347,33 +1347,6 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
         SoundSourceProxy(pTrack).updateTrackFromSource();
     }
 
-    // Data migration: Reload track total from file tags if not initialized
-    // yet. The added column "tracktotal" has been initialized with the
-    // default value "//".
-    // See also: Schema revision 26 in schema.xml
-    if (pTrack->getTrackTotal() == "//") {
-        // Reload track total from file tags if the special track
-        // total migration value "//" indicates that the track total
-        // is missing and needs to be reloaded.
-        qDebug() << "Reloading value for 'tracktotal' once-only from file"
-                " to replace the default value introduced with a previous"
-                " schema upgrade";
-        mixxx::TrackMetadata trackMetadata;
-        if (SoundSourceProxy(pTrack).importTrackMetadata(&trackMetadata) == mixxx::MetadataSource::ImportResult::Succeeded) {
-            // Copy the track total from the temporary track object
-            pTrack->setTrackTotal(trackMetadata.getTrackInfo().getTrackTotal());
-            // Also set the track number if it is still empty due
-            // to insufficient parsing capabilities of Mixxx in
-            // previous versions.
-            if (!trackMetadata.getTrackInfo().getTrackNumber().isEmpty() && pTrack->getTrackNumber().isEmpty()) {
-                pTrack->setTrackNumber(trackMetadata.getTrackInfo().getTrackNumber());
-            }
-        } else {
-            qWarning() << "Failed to reload value for 'tracktotal' from file tags:"
-                    << trackLocation;
-        }
-    }
-
     // Listen to dirty and changed signals
     connect(pTrack.get(),
             &Track::dirty,

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -64,39 +64,12 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     TrackId addTracksAddTrack(const TrackPointer& pTrack, bool unremove);
     void addTracksFinish(bool rollback = false);
 
-    bool hideTracks(
-            const QList<TrackId>& trackIds);
-    void afterHidingTracks(
-            const QList<TrackId>& trackIds);
-
-    bool unhideTracks(
-            const QList<TrackId>& trackIds);
-    void afterUnhidingTracks(
-            const QList<TrackId>& trackIds);
-
-    bool onPurgingTracks(
-            const QList<TrackId>& trackIds);
-    void afterPurgingTracks(
-            const QList<TrackId>& trackIds);
-
-    void markTracksAsMixxxDeleted(const QString& dir);
-
-    // Scanning related calls. Should be elsewhere or private somehow.
-    void markTrackLocationsAsVerified(const QStringList& locations);
-    void markTracksInDirectoriesAsVerified(const QStringList& directories);
-    void invalidateTrackLocationsInLibrary();
-    void markUnverifiedTracksAsDeleted();
+    // Only used by friend class LibraryScanner, but public for testing!
     bool detectMovedTracks(QList<QPair<TrackRef, TrackRef>>* pReplacedTracks,
                           const QStringList& addedTracks,
                           volatile const bool* pCancel);
 
-    bool verifyRemainingTracks(
-            const QStringList& libraryRootDirs,
-            volatile const bool* pCancel);
-
-    void detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
-                                        QSet<TrackId>* pTracksChanged);
-
+    // Only used by friend class TrackCollection, but public for testing!
     void saveTrack(Track* pTrack);
 
   signals:
@@ -121,9 +94,9 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     void slotTrackClean(Track* pTrack);
 
   private:
+    friend class LibraryScanner;
     friend class TrackCollection;
 
-    // WARNING: Only call this from the main thread instance of TrackDAO.
     TrackPointer getTrackById(TrackId trackId) const;
 
     // Fetches trackLocation from the database or adds it. If searchForCoverArt
@@ -137,6 +110,36 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
                 bool* pAlreadyInLibrary = nullptr);
 
     bool updateTrack(Track* pTrack);
+
+    void hideAllTracks(const QDir& rootDir);
+
+    bool hideTracks(
+            const QList<TrackId>& trackIds);
+    void afterHidingTracks(
+            const QList<TrackId>& trackIds);
+
+    bool unhideTracks(
+            const QList<TrackId>& trackIds);
+    void afterUnhidingTracks(
+            const QList<TrackId>& trackIds);
+
+    bool onPurgingTracks(
+            const QList<TrackId>& trackIds);
+    void afterPurgingTracks(
+            const QList<TrackId>& trackIds);
+
+    // Scanning related calls.
+    void markTrackLocationsAsVerified(const QStringList& locations);
+    void markTracksInDirectoriesAsVerified(const QStringList& directories);
+    void invalidateTrackLocationsInLibrary();
+    void markUnverifiedTracksAsDeleted();
+
+    bool verifyRemainingTracks(
+            const QStringList& libraryRootDirs,
+            volatile const bool* pCancel);
+
+    void detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
+                                        QSet<TrackId>* pTracksChanged);
 
     // Callback for GlobalTrackCache
     TrackFile relocateCachedTrack(

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -52,9 +52,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             ResolveTrackIdFlags flags);
     QList<TrackId> getAllTrackIds(const QDir& rootDir);
 
-    // WARNING: Only call this from the main thread instance of TrackDAO.
-    TrackPointer getTrack(TrackId trackId) const;
-
     // Returns a set of all track locations in the library.
     QSet<QString> getTrackLocations();
     QString getTrackLocation(TrackId trackId);
@@ -81,16 +78,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             const QList<TrackId>& trackIds);
     void afterPurgingTracks(
             const QList<TrackId>& trackIds);
-
-    // Fetches trackLocation from the database or adds it. If searchForCoverArt
-    // is true, searches the track and its directory for cover art via
-    // asynchronous request to CoverArtCache. If adding or fetching the track
-    // fails, returns a transient TrackPointer for trackLocation. If
-    // pAlreadyInLibrary is non-NULL, sets it to whether trackLocation was
-    // already in the database.
-    TrackPointer getOrAddTrack(const QString& trackLocation,
-                               bool processCoverArt,
-                               bool* pAlreadyInLibrary);
 
     void markTracksAsMixxxDeleted(const QString& dir);
 
@@ -134,7 +121,20 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     void slotTrackClean(Track* pTrack);
 
   private:
-    TrackPointer getTrackFromDB(TrackId trackId) const;
+    friend class TrackCollection;
+
+    // WARNING: Only call this from the main thread instance of TrackDAO.
+    TrackPointer getTrackById(TrackId trackId) const;
+
+    // Fetches trackLocation from the database or adds it. If searchForCoverArt
+    // is true, searches the track and its directory for cover art via
+    // asynchronous request to CoverArtCache. If adding or fetching the track
+    // fails, returns a transient TrackPointer for trackLocation. If
+    // pAlreadyInLibrary is non-NULL, sets it to whether trackLocation was
+    // already in the database.
+    TrackPointer getOrAddTrackByLocation(
+                const QString& trackLocation,
+                bool* pAlreadyInLibrary = nullptr);
 
     bool updateTrack(Track* pTrack);
 

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -1,7 +1,7 @@
-#ifndef DLGTAGFETCHER_H
-#define DLGTAGFETCHER_H
+#pragma once
 
 #include <QDialog>
+#include <QList>
 #include <QTreeWidget>
 
 #include "library/ui_dlgtagfetcher.h"
@@ -12,19 +12,13 @@ class DlgTagFetcher : public QDialog,  public Ui::DlgTagFetcher {
   Q_OBJECT
 
   public:
-    DlgTagFetcher(QWidget *parent);
-    virtual ~DlgTagFetcher();
+    explicit DlgTagFetcher(QWidget *parent);
+    ~DlgTagFetcher() override = default;
 
     void init();
 
-    enum networkError {
-        NOERROR,
-        HTTPERROR,
-        FTWERROR
-    };
-
   public slots:
-    void loadTrack(const TrackPointer track);
+    void loadTrack(const TrackPointer& track);
     void updateTrackMetadata(Track* pTIO);
 
   signals:
@@ -35,7 +29,7 @@ class DlgTagFetcher : public QDialog,  public Ui::DlgTagFetcher {
     void fetchTagFinished(const TrackPointer,const QList<TrackPointer>& tracks);
     void resultSelected();
     void fetchTagProgress(QString);
-    void slotNetworkError(int httpStatus, QString app, QString message, int code);
+    void slotNetworkResult(int httpStatus, QString app, QString message, int code);
     void apply();
     void quit();
 
@@ -44,6 +38,11 @@ class DlgTagFetcher : public QDialog,  public Ui::DlgTagFetcher {
     void addDivider(const QString& text, QTreeWidget* parent) const;
     void addTrack(const TrackPointer track, int resultIndex,
                   QTreeWidget* parent) const;
+
+    TagFetcher m_tagFetcher;
+
+    TrackPointer m_track;
+
     struct Data {
         Data() : m_pending(true), m_selectedResult(-1) {}
 
@@ -51,12 +50,12 @@ class DlgTagFetcher : public QDialog,  public Ui::DlgTagFetcher {
         int m_selectedResult;
         QList<TrackPointer> m_results;
     };
-
-    TrackPointer m_track;
     Data m_data;
-    QString m_progress;
-    TagFetcher m_TagFetcher;
-    networkError m_networkError;
-};
 
-#endif // DLGTAGFETCHER_H
+    enum class NetworkResult {
+        Ok,
+        HttpError,
+        UnknownError,
+    };
+    NetworkResult m_networkResult;
+};

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -508,7 +508,7 @@ void Library::slotRequestRemoveDir(QString dir, RemovalType removalType) {
         case Library::HideTracks:
             // Mark all tracks in this directory as deleted but DON'T purge them
             // in case the user re-adds them manually.
-            m_pTrackCollection->getTrackDAO().markTracksAsMixxxDeleted(dir);
+            m_pTrackCollection->hideAllTracks(dir);
             break;
         case Library::PurgeTracks:
             // The user requested that we purge all metadata.

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -443,8 +443,8 @@ void Library::slotLoadTrack(TrackPointer pTrack) {
 }
 
 void Library::slotLoadLocationToPlayer(QString location, QString group) {
-    TrackPointer pTrack = m_pTrackCollection->getTrackDAO()
-            .getOrAddTrack(location, true, NULL);
+    auto trackRef = TrackRef::fromFileInfo(location);
+    TrackPointer pTrack = m_pTrackCollection->getOrAddTrack(trackRef);
     if (pTrack) {
         emit(loadTrackToPlayer(pTrack, group));
     }

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -91,7 +91,7 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
     BaseTrackCache* pBaseTrackCache = new BaseTrackCache(
             pTrackCollection, tableName, LIBRARYTABLE_ID, columns, true);
 
-    auto pTrackDAO = &pTrackCollection.getTrackDAO();
+    auto pTrackDAO = &pTrackCollection->getTrackDAO();
     connect(pTrackDAO,
             &TrackDAO::trackDirty,
             pBaseTrackCache,

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -30,7 +30,6 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
           m_pLibrary(pLibrary),
           m_pMissingView(NULL),
           m_pHiddenView(NULL),
-          m_trackDao(pTrackCollection->getTrackDAO()),
           m_pConfig(pConfig),
           m_pTrackCollection(pTrackCollection),
           m_icon(":/images/library/ic_library_tracks.svg") {
@@ -91,27 +90,29 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
 
     BaseTrackCache* pBaseTrackCache = new BaseTrackCache(
             pTrackCollection, tableName, LIBRARYTABLE_ID, columns, true);
-    connect(&m_trackDao,
+
+    auto pTrackDAO = &pTrackCollection.getTrackDAO();
+    connect(pTrackDAO,
             &TrackDAO::trackDirty,
             pBaseTrackCache,
             &BaseTrackCache::slotTrackDirty);
-    connect(&m_trackDao,
+    connect(pTrackDAO,
             &TrackDAO::trackClean,
             pBaseTrackCache,
             &BaseTrackCache::slotTrackClean);
-    connect(&m_trackDao,
+    connect(pTrackDAO,
             &TrackDAO::trackChanged,
             pBaseTrackCache,
             &BaseTrackCache::slotTrackChanged);
-    connect(&m_trackDao,
+    connect(pTrackDAO,
             &TrackDAO::tracksAdded,
             pBaseTrackCache,
             &BaseTrackCache::slotTracksAdded);
-    connect(&m_trackDao,
+    connect(pTrackDAO,
             &TrackDAO::tracksRemoved,
             pBaseTrackCache,
             &BaseTrackCache::slotTracksRemoved);
-    connect(&m_trackDao,
+    connect(pTrackDAO,
             &TrackDAO::dbTrackAdded,
             pBaseTrackCache,
             &BaseTrackCache::slotDbTrackAdded);

--- a/src/library/mixxxlibraryfeature.h
+++ b/src/library/mixxxlibraryfeature.h
@@ -60,7 +60,6 @@ class MixxxLibraryFeature : public LibraryFeature {
     DlgMissing* m_pMissingView;
     DlgHidden* m_pHiddenView;
     TreeItemModel m_childModel;
-    TrackDAO& m_trackDao;
     UserSettingsPointer m_pConfig;
     TrackCollection* m_pTrackCollection;
     QIcon m_icon;

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -1,19 +1,20 @@
+#include <QApplication>
 #include <QStringBuilder>
 #include <QThread>
-#include <QApplication>
 
 #include "library/trackcollection.h"
 
 #include "sources/soundsourceproxy.h"
 #include "track/globaltrackcache.h"
-#include "util/logger.h"
-#include "util/db/sqltransaction.h"
-
 #include "util/assert.h"
+#include "util/db/sqltransaction.h"
 #include "util/dnd.h"
+#include "util/logger.h"
 
 namespace {
-    mixxx::Logger kLogger("TrackCollection");
+
+mixxx::Logger kLogger("TrackCollection");
+
 } // anonymous namespace
 
 TrackCollection::TrackCollection(
@@ -216,6 +217,10 @@ bool TrackCollection::hideTracks(const QList<TrackId>& trackIds) {
     emit(crateSummaryChanged(modifiedCrateSummaries));
 
     return true;
+}
+
+void TrackCollection::hideAllTracks(const QDir& rootDir) {
+    m_trackDao.markTracksAsMixxxDeleted(rootDir);
 }
 
 bool TrackCollection::unhideTracks(const QList<TrackId>& trackIds) {

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -220,7 +220,7 @@ bool TrackCollection::hideTracks(const QList<TrackId>& trackIds) {
 }
 
 void TrackCollection::hideAllTracks(const QDir& rootDir) {
-    m_trackDao.markTracksAsMixxxDeleted(rootDir);
+    m_trackDao.hideAllTracks(rootDir);
 }
 
 bool TrackCollection::unhideTracks(const QList<TrackId>& trackIds) {

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -443,3 +443,26 @@ void TrackCollection::saveTrack(Track* pTrack) {
 
     m_trackDao.saveTrack(pTrack);
 }
+
+TrackPointer TrackCollection::getTrackById(
+        const TrackId& trackId) const {
+    return m_trackDao.getTrackById(trackId);
+}
+
+TrackPointer TrackCollection::getOrAddTrack(
+        const TrackRef& trackRef,
+        bool* pAlreadyInLibrary) {
+    TrackPointer pTrack;
+    if (trackRef.hasId()) {
+        pTrack = getTrackById(trackRef.getId());
+        if (pAlreadyInLibrary) {
+            *pAlreadyInLibrary = pTrack != nullptr;
+        }
+    }
+    if (!pTrack && trackRef.hasLocation()) {
+        pTrack = m_trackDao.getOrAddTrackByLocation(
+                trackRef.getLocation(),
+                pAlreadyInLibrary);
+    }
+    return pTrack;
+}

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -4,7 +4,6 @@
 
 #include "library/trackcollection.h"
 
-#include "sources/soundsourceproxy.h"
 #include "track/globaltrackcache.h"
 #include "util/assert.h"
 #include "util/db/sqltransaction.h"
@@ -424,23 +423,6 @@ bool TrackCollection::updateAutoDjCrate(
     }
     crate.setAutoDjSource(isAutoDjSource);
     return updateCrate(crate);
-}
-
-void TrackCollection::exportTrackMetadata(Track* pTrack) const {
-    DEBUG_ASSERT(pTrack);
-
-    // Write audio meta data, if explicitly requested by the user
-    // for individual tracks or enabled in the preferences for all
-    // tracks.
-    //
-    // This must be done before updating the database, because
-    // a timestamp is used to keep track of when metadata has been
-    // last synchronized. Exporting metadata will update this time
-    // stamp on the track object!
-    if (pTrack->isMarkedForMetadataExport() ||
-            (pTrack->isDirty() && m_pConfig && m_pConfig->getValueString(ConfigKey("[Library]","SyncTrackMetadataExport")).toInt() == 1)) {
-        SoundSourceProxy::exportTrackMetadataBeforeSaving(pTrack);
-    }
 }
 
 void TrackCollection::saveTrack(Track* pTrack) {

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -4,6 +4,7 @@
 
 #include "library/trackcollection.h"
 
+#include "library/basetrackcache.h"
 #include "track/globaltrackcache.h"
 #include "util/assert.h"
 #include "util/db/sqltransaction.h"
@@ -18,8 +19,7 @@ mixxx::Logger kLogger("TrackCollection");
 
 TrackCollection::TrackCollection(
         const UserSettingsPointer& pConfig)
-        : m_pConfig(pConfig),
-          m_analysisDao(pConfig),
+        : m_analysisDao(pConfig),
           m_trackDao(m_cueDao, m_playlistDao,
                      m_analysisDao, m_libraryHashDao, pConfig) {
 }

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -59,8 +59,6 @@ class TrackCollection : public QObject,
     }
     void setTrackSource(QSharedPointer<BaseTrackCache> pTrackSource);
 
-    void cancelLibraryScan();
-
     // This function returns a track ID of all file in the list not already visible,
     // it adds and unhides the tracks as well.
     QList<TrackId> resolveTrackIds(const QList<QFileInfo> &files,

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -114,8 +114,6 @@ class TrackCollection : public QObject,
     bool addDirectory(const QString& dir);
     void relocateDirectory(QString oldDir, QString newDir);
 
-    UserSettingsPointer m_pConfig;
-
     QSqlDatabase m_database;
 
     PlaylistDAO m_playlistDao;

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -1,12 +1,11 @@
-#ifndef TRACKCOLLECTION_H
-#define TRACKCOLLECTION_H
+#pragma once
 
+#include <QDir>
 #include <QList>
 #include <QSharedPointer>
 #include <QSqlDatabase>
 
 #include "preferences/usersettings.h"
-#include "library/basetrackcache.h"
 #include "library/crate/cratestorage.h"
 #include "library/dao/trackdao.h"
 #include "library/dao/cuedao.h"
@@ -15,11 +14,9 @@
 #include "library/dao/directorydao.h"
 #include "library/dao/libraryhashdao.h"
 
+class BaseTrackCache;
 
-// forward declaration(s)
-class Track;
-
-// Manages everything around tracks.
+// Manages the internal database.
 class TrackCollection : public QObject,
     public virtual /*implements*/ SqlStorage {
     Q_OBJECT
@@ -111,8 +108,12 @@ class TrackCollection : public QObject,
   private:
     friend class Library;
     friend class Upgrade;
+
+    void hideAllTracks(const QDir& rootDir);
+
     bool purgeTracks(const QList<TrackId>& trackIds);
     bool purgeAllTracks(const QDir& rootDir);
+
     bool addDirectory(const QString& dir);
     void relocateDirectory(QString oldDir, QString newDir);
 
@@ -130,5 +131,3 @@ class TrackCollection : public QObject,
 
     QSharedPointer<BaseTrackCache> m_pTrackSource;
 };
-
-#endif // TRACKCOLLECTION_H

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -81,14 +81,14 @@ class TrackCollection : public QObject,
 
     bool updateAutoDjCrate(CrateId crateId, bool isAutoDjSource);
 
+    // Might be called from any thread
+    void exportTrackMetadata(Track* pTrack) const;
+
     TrackPointer getTrackById(
             const TrackId& trackId) const;
     TrackPointer getOrAddTrack(
             const TrackRef& trackRef,
             bool* pAlreadyInLibrary = nullptr);
-
-    // Might be called from any thread
-    void exportTrackMetadata(Track* pTrack) const;
 
     // Must be called from the main thread
     void saveTrack(Track* pTrack);

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -81,9 +81,6 @@ class TrackCollection : public QObject,
 
     bool updateAutoDjCrate(CrateId crateId, bool isAutoDjSource);
 
-    // Might be called from any thread
-    void exportTrackMetadata(Track* pTrack) const;
-
     TrackPointer getTrackById(
             const TrackId& trackId) const;
     TrackPointer getOrAddTrack(

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -84,6 +84,12 @@ class TrackCollection : public QObject,
 
     bool updateAutoDjCrate(CrateId crateId, bool isAutoDjSource);
 
+    TrackPointer getTrackById(
+            const TrackId& trackId) const;
+    TrackPointer getOrAddTrack(
+            const TrackRef& trackRef,
+            bool* pAlreadyInLibrary = nullptr);
+
     // Might be called from any thread
     void exportTrackMetadata(Track* pTrack) const;
 

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -1,5 +1,4 @@
-#ifndef MIXXX_SOURCES_SOUNDSOURCEPROXY_H
-#define MIXXX_SOURCES_SOUNDSOURCEPROXY_H
+#pragma once
 
 #include "track/track.h"
 
@@ -108,7 +107,7 @@ class SoundSourceProxy {
     static QStringList s_supportedFileNamePatterns;
     static QRegExp s_supportedFileNamesRegex;
 
-    friend class TrackCollection;
+    friend class Library;
     static Track::ExportMetadataResult exportTrackMetadataBeforeSaving(Track* pTrack);
 
     // Special case: Construction from a url is needed
@@ -143,5 +142,3 @@ class SoundSourceProxy {
     // that keeps it alive.
     mixxx::AudioSourcePointer m_pAudioSource;
 };
-
-#endif // MIXXX_SOURCES_SOUNDSOURCEPROXY_H

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -606,7 +606,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped) {
 
     // Load the track and mark it playing (as the loadTrackToPlayer signal would
     // have connected to this eventually).
-    TrackPointer pTrack = collection()->getTrackDAO().getTrack(testId);
+    TrackPointer pTrack = collection()->getTrackById(testId);
     deck1.slotLoadTrack(pTrack, true);
 
     // Signal that the request to load pTrack succeeded.

--- a/src/test/librarytest.cpp
+++ b/src/test/librarytest.cpp
@@ -31,6 +31,5 @@ LibraryTest::~LibraryTest() {
 }
 
 void LibraryTest::saveEvictedTrack(Track* pTrack) noexcept {
-    m_pTrackCollection->exportTrackMetadata(pTrack);
     m_pTrackCollection->saveTrack(pTrack);
 }

--- a/src/test/trackupdate_test.cpp
+++ b/src/test/trackupdate_test.cpp
@@ -57,14 +57,14 @@ TEST_F(TrackUpdateTest, parseModifiedCleanOnce) {
     pTrack->markClean();
 
     mixxx::TrackMetadata trackMetadataBefore;
-    pTrack->getTrackMetadata(&trackMetadataBefore);
+    pTrack->readTrackMetadata(&trackMetadataBefore);
     auto coverInfoBefore = pTrack->getCoverInfo();
 
     SoundSourceProxy(pTrack).updateTrackFromSource(
             SoundSourceProxy::ImportTrackMetadataMode::Once);
 
     mixxx::TrackMetadata trackMetadataAfter;
-    pTrack->getTrackMetadata(&trackMetadataAfter);
+    pTrack->readTrackMetadata(&trackMetadataAfter);
     auto coverInfoAfter = pTrack->getCoverInfo();
 
     // Not updated
@@ -79,14 +79,14 @@ TEST_F(TrackUpdateTest, parseModifiedCleanAgainSkipCover) {
     pTrack->markClean();
 
     mixxx::TrackMetadata trackMetadataBefore;
-    pTrack->getTrackMetadata(&trackMetadataBefore);
+    pTrack->readTrackMetadata(&trackMetadataBefore);
     auto coverInfoBefore = pTrack->getCoverInfo();
 
     SoundSourceProxy(pTrack).updateTrackFromSource(
             SoundSourceProxy::ImportTrackMetadataMode::Again);
 
     mixxx::TrackMetadata trackMetadataAfter;
-    pTrack->getTrackMetadata(&trackMetadataAfter);
+    pTrack->readTrackMetadata(&trackMetadataAfter);
     auto coverInfoAfter = pTrack->getCoverInfo();
 
     // Updated
@@ -105,14 +105,14 @@ TEST_F(TrackUpdateTest, parseModifiedCleanAgainUpdateCover) {
     pTrack->markClean();
 
     mixxx::TrackMetadata trackMetadataBefore;
-    pTrack->getTrackMetadata(&trackMetadataBefore);
+    pTrack->readTrackMetadata(&trackMetadataBefore);
     auto coverInfoBefore = pTrack->getCoverInfo();
 
     SoundSourceProxy(pTrack).updateTrackFromSource(
             SoundSourceProxy::ImportTrackMetadataMode::Again);
 
     mixxx::TrackMetadata trackMetadataAfter;
-    pTrack->getTrackMetadata(&trackMetadataAfter);
+    pTrack->readTrackMetadata(&trackMetadataAfter);
     auto coverInfoAfter = pTrack->getCoverInfo();
 
     // Updated
@@ -126,14 +126,14 @@ TEST_F(TrackUpdateTest, parseModifiedDirtyAgain) {
     auto pTrack = newTestTrackParsedModified();
 
     mixxx::TrackMetadata trackMetadataBefore;
-    pTrack->getTrackMetadata(&trackMetadataBefore);
+    pTrack->readTrackMetadata(&trackMetadataBefore);
     auto coverInfoBefore = pTrack->getCoverInfo();
 
     SoundSourceProxy(pTrack).updateTrackFromSource(
             SoundSourceProxy::ImportTrackMetadataMode::Again);
 
     mixxx::TrackMetadata trackMetadataAfter;
-    pTrack->getTrackMetadata(&trackMetadataAfter);
+    pTrack->readTrackMetadata(&trackMetadataAfter);
     auto coverInfoAfter = pTrack->getCoverInfo();
 
     // Updated

--- a/src/track/albuminfo.cpp
+++ b/src/track/albuminfo.cpp
@@ -3,18 +3,6 @@
 
 namespace mixxx {
 
-void AlbumInfo::resetUnsupportedValues() {
-#if defined(__EXTRA_METADATA__)
-    setCopyright(QString());
-    setLicense(QString());
-    setMusicBrainzArtistId(QString());
-    setMusicBrainzReleaseId(QString());
-    setMusicBrainzReleaseGroupId(QString());
-    setRecordLabel(QString());
-    setReplayGain(ReplayGain());
-#endif // __EXTRA_METADATA__
-}
-
 bool operator==(const AlbumInfo& lhs, const AlbumInfo& rhs) {
     return (lhs.getArtist() == rhs.getArtist()) &&
 #if defined(__EXTRA_METADATA__)

--- a/src/track/albuminfo.h
+++ b/src/track/albuminfo.h
@@ -33,9 +33,6 @@ public:
     AlbumInfo& operator=(AlbumInfo&&) = default;
     AlbumInfo& operator=(const AlbumInfo&) = default;
 
-    // TODO(XXX): Remove after all new fields have been added to the library
-    void resetUnsupportedValues();
-
     // Adjusts floating-point properties to match their string representation
     // in file tags to account for rounding errors.
     void normalizeBeforeExport() {

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -25,6 +25,12 @@ public:
 
     // Adjusts floating-point values to match their string representation
     // in file tags to account for rounding errors.
+    // NOTE(2019-02-19, uklotzde): The pre-normalization cannot prevent
+    // repeated export of metadata for files with ID3 tags that are only
+    // able to store the BPM value with integer precision! In case of a
+    // fractional value the ID3 metadata is always detected as modified
+    // and will be exported regardless if it has actually been modified
+    // or not.
     void normalizeBeforeExport() {
         m_value = normalizeValue(m_value);
     }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1010,6 +1010,12 @@ Track::ExportMetadataResult Track::exportMetadata(
     // The track's metadata will be exported instantly. The export should
     // only be tried once so we reset the marker flag.
     m_bMarkedForMetadataExport = false;
+    kLogger.debug()
+            << "Old metadata (imported)"
+            << importedFromFile;
+    kLogger.debug()
+            << "New metadata (modified)"
+            << m_record.getMetadata();
     const auto trackMetadataExported =
             pMetadataSource->exportTrackMetadata(m_record.getMetadata());
     if (trackMetadataExported.first == mixxx::MetadataSource::ExportResult::Succeeded) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -121,13 +121,13 @@ void Track::relocate(
     // the updated location from the database.
 }
 
-void Track::setTrackMetadata(
-        mixxx::TrackMetadata trackMetadata,
+void Track::importMetadata(
+        mixxx::TrackMetadata importedMetadata,
         QDateTime metadataSynchronized) {
     // Safe some values that are needed after move assignment and unlocking(see below)
-    const auto newBpm = trackMetadata.getTrackInfo().getBpm();
-    const auto newKey = trackMetadata.getTrackInfo().getKey();
-    const auto newReplayGain = trackMetadata.getTrackInfo().getReplayGain();
+    const auto newBpm = importedMetadata.getTrackInfo().getBpm();
+    const auto newKey = importedMetadata.getTrackInfo().getKey();
+    const auto newReplayGain = importedMetadata.getTrackInfo().getReplayGain();
 
     {
         // enter locking scope
@@ -137,11 +137,11 @@ void Track::setTrackMetadata(
                 &m_record.refMetadataSynchronized(),
                 !metadataSynchronized.isNull());
         bool modifiedReplayGain = false;
-        if (m_record.getMetadata() != trackMetadata) {
+        if (m_record.getMetadata() != importedMetadata) {
             modifiedReplayGain =
                     (m_record.getMetadata().getTrackInfo().getReplayGain() != newReplayGain);
-            m_record.setMetadata(std::move(trackMetadata));
-            // Don't use trackMetadata after move assignment!!
+            m_record.setMetadata(std::move(importedMetadata));
+            // Don't use importedMetadata after move assignment!!
             modified = true;
         }
         if (modified) {
@@ -167,7 +167,13 @@ void Track::setTrackMetadata(
     }
 }
 
-void Track::getTrackMetadata(
+void Track::mergeImportedMetadata(
+        const mixxx::TrackMetadata& importedMetadata) {
+    QMutexLocker lock(&m_qMutex);
+    m_record.mergeImportedMetadata(importedMetadata);
+}
+
+void Track::readTrackMetadata(
         mixxx::TrackMetadata* pTrackMetadata,
         bool* pMetadataSynchronized) const {
     DEBUG_ASSERT(pTrackMetadata);
@@ -178,7 +184,7 @@ void Track::getTrackMetadata(
     }
 }
 
-void Track::getTrackRecord(
+void Track::readTrackRecord(
         mixxx::TrackRecord* pTrackRecord,
         bool* pDirty) const {
     DEBUG_ASSERT(pTrackRecord);
@@ -935,89 +941,71 @@ Track::ExportMetadataResult Track::exportMetadata(
     // be called after all references to the object have been dropped.
     // But it doesn't hurt much, so let's play it safe ;)
     QMutexLocker lock(&m_qMutex);
-    // Discard the values of all currently unsupported fields that are
-    // not stored in the library, yet. Those fields are already imported
-    // from file tags, but the database schema needs to be extended for
-    // storing them. Currently those fields will be empty/null when read
-    // from the database and must be ignored until the schema has been
-    // updated.
-    m_record.refMetadata().resetUnsupportedValues();
+    // TODO(XXX): m_record.getMetadataSynchronized() currently is a
+    // boolean flag, but it should become a time stamp in the future.
+    // We could take this time stamp and the file's last modification
+    // time stamp into account and might decide to skip importing
+    // the metadata again.
+    if (!m_bMarkedForMetadataExport && !m_record.getMetadataSynchronized()) {
+        // If the metadata has never been imported from file tags it
+        // must be exported explicitly once. This ensures that we don't
+        // overwrite existing file tags with completely different
+        // information.
+        kLogger.info()
+                << "Skip exporting of unsynchronized track metadata:"
+                << getLocation();
+        // abort
+        return ExportMetadataResult::Skipped;
+    }
     // Normalize metadata before exporting to adjust the precision of
     // floating values, ... Otherwise the following comparisons may
     // repeatedly indicate that values have changed only due to
     // rounding errors.
     m_record.refMetadata().normalizeBeforeExport();
-    if (!m_bMarkedForMetadataExport) {
-        // Perform some consistency checks if metadata is exported
-        // implicitly after a track has been modified and NOT explicitly
-        // requested by a user as indicated by this flag.
-        if (!m_record.getMetadataSynchronized()) {
-            // If the metadata has never been imported from file tags it
-            // must be exported explicitly once. This ensures that we don't
-            // overwrite existing file tags with completely different
-            // information.
-            kLogger.info()
-                    << "Skip exporting of unsynchronized track metadata:"
-                    << getLocation();
-            return ExportMetadataResult::Skipped;
-        }
-        // Check if the metadata has actually been modified. Otherwise
-        // we don't need to write it back. Exporting unmodified metadata
-        // would needlessly update the file's time stamp and should be
-        // avoided. Since we don't know in which state the file's metadata
-        // is we import it again into a temporary variable.
-        // TODO(XXX): m_record.getMetadataSynchronized() currently is a
-        // boolean flag, but it should become a time stamp in the future.
-        // We could take this time stamp and the file's last modification
-        // time stamp into // account and might decide to skip importing
-        // the metadata again.
-        mixxx::TrackMetadata importedFromFile;
-        if ((pMetadataSource->importTrackMetadataAndCoverImage(&importedFromFile, nullptr).first ==
-                mixxx::MetadataSource::ImportResult::Succeeded)) {
-            // Discard the values of all currently unsupported fields that are
-            // not stored in the library, yet. We have done the same with the track's
-            // current metadata to make the tags comparable (see above).
-            importedFromFile.resetUnsupportedValues();
-            // Account for floating-point rounding errors before exporting
-            // the BPM value. The imported value must be compared to the
-            // pre-normalized value for valid results.
-            // NOTE(2019-02-19, uklotzde): The pre-normalization cannot prevent
-            // repeated export of metadata for files with ID3 tags that are only
-            // able to store the BPM value with integer precision! In case of a
-            // fractional value the ID3 metadata is always detected as modified
-            // and will be exported regardless if it has actually been modified
-            // or not.
-            auto currentBpm = m_record.getMetadata().getTrackInfo().getBpm();
-            currentBpm.normalizeBeforeExport();
-            m_record.refMetadata().refTrackInfo().setBpm(currentBpm);
-            // Finally the track's current metadata and the imported/adjusted metadata
-            // can be compared for differences to decide whether the tags in the file
-            // would change if we perform the write operation. We are using a special
-            // comparison function that excludes all read-only audio properties which
-            // are stored in file tags, but may not be accurate. They can't be written
-            // anyway, so we must not take them into account here.
-            if (!m_record.getMetadata().hasBeenModifiedAfterImport(importedFromFile))  {
-                // The file tags are in-sync with the track's metadata and don't need
-                // to be updated.
-                if (kLogger.debugEnabled()) {
-                    kLogger.debug()
-                                << "Skip exporting of unmodified track metadata into file:"
-                                << getLocation();
-                }
-                return ExportMetadataResult::Skipped;
+    // Check if the metadata has actually been modified. Otherwise
+    // we don't need to write it back. Exporting unmodified metadata
+    // would needlessly update the file's time stamp and should be
+    // avoided. Since we don't know in which state the file's metadata
+    // is we import it again into a temporary variable.
+    mixxx::TrackMetadata importedFromFile;
+    if ((pMetadataSource->importTrackMetadataAndCoverImage(&importedFromFile, nullptr).first ==
+            mixxx::MetadataSource::ImportResult::Succeeded)) {
+        // Prevent overwriting any file tags that are not yet stored in the
+        // library database!
+        m_record.mergeImportedMetadata(importedFromFile);
+        // Finally the track's current metadata and the imported/adjusted metadata
+        // can be compared for differences to decide whether the tags in the file
+        // would change if we perform the write operation. This function will also
+        // copy all extra properties that are not (yet) stored in the library before
+        // checking for differences! If an export has been requested explicitly then
+        // we will continue even if no differences are detected.
+        if (!m_bMarkedForMetadataExport &&
+                !m_record.getMetadata().anyFileTagsModified(importedFromFile))  {
+            // The file tags are in-sync with the track's metadata and don't need
+            // to be updated.
+            if (kLogger.debugEnabled()) {
+                kLogger.debug()
+                            << "Skip exporting of unmodified track metadata into file:"
+                            << getLocation();
             }
-        } else {
-            // Something must be wrong with the file or it doesn't
-            // contain any file tags. We don't want to risk a failure
-            // during export and abort the operation for safety here.
-            // The user may decide to explicitly export the metadata.
-            kLogger.warning()
-                    << "Skip exporting of track metadata after import failed."
-                    << "Export of metadata must be triggered explicitly for this file:"
-                    << getLocation();
+            // abort
             return ExportMetadataResult::Skipped;
         }
-        // ...by continuing the file tags will be updated
+    } else {
+        // The file doesn't contain any tags yet or it might be missing, unreadable,
+        // or corrupt.
+        if (m_bMarkedForMetadataExport) {
+            kLogger.info()
+                    << "Adding or overwriting tags after failure to import tags from file:"
+                    << getLocation();
+            // ...and continue
+        } else {
+            kLogger.warning()
+                    << "Skip exporting of track metadata after failure to import tags from file:"
+                    << getLocation();
+            // abort
+            return ExportMetadataResult::Skipped;
+        }
     }
     // The track's metadata will be exported instantly. The export should
     // only be tried once so we reset the marker flag.

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -275,14 +275,18 @@ class Track : public QObject {
     quint16 getCoverHash() const;
 
     // Set/get track metadata and cover art (optional) all at once.
-    void setTrackMetadata(
-            mixxx::TrackMetadata trackMetadata,
+    void importMetadata(
+            mixxx::TrackMetadata importedMetadata,
             QDateTime metadataSynchronized);
-    void getTrackMetadata(
+    // Merge additional metadata that is not (yet) stored in the database
+    // and only available from file tags.
+    void mergeImportedMetadata(
+            const mixxx::TrackMetadata& importedMetadata);
+
+    void readTrackMetadata(
             mixxx::TrackMetadata* pTrackMetadata,
             bool* pMetadataSynchronized = nullptr) const;
-
-    void getTrackRecord(
+    void readTrackRecord(
             mixxx::TrackRecord* pTrackRecord,
             bool* pDirty = nullptr) const;
 

--- a/src/track/trackinfo.cpp
+++ b/src/track/trackinfo.cpp
@@ -3,28 +3,6 @@
 
 namespace mixxx {
 
-void TrackInfo::resetUnsupportedValues() {
-#if defined(__EXTRA_METADATA__)
-    setConductor(QString());
-    setDiscNumber(QString());
-    setDiscTotal(QString());
-    setEncoder(QString());
-    setEncoderSettings(QString());
-    setISRC(QString());
-    setLanguage(QString());
-    setLyricist(QString());
-    setMood(QString());
-    setMovement(QString());
-    setMusicBrainzArtistId(QString());
-    setMusicBrainzRecordingId(QString());
-    setMusicBrainzReleaseId(QString());
-    setMusicBrainzWorkId(QString());
-    setRemixer(QString());
-    setSubtitle(QString());
-    setWork(QString());
-#endif // __EXTRA_METADATA__
-}
-
 namespace {
 
 const QString kArtistTitleSeparatorWithSpaces = " - ";

--- a/src/track/trackinfo.h
+++ b/src/track/trackinfo.h
@@ -72,9 +72,6 @@ public:
             QString fileName,
             bool splitArtistTitle);
 
-    // TODO(XXX): Remove after all new fields have been added to the library
-    void resetUnsupportedValues();
-
     // Adjusts floating-point properties to match their string representation
     // in file tags to account for rounding errors.
     void normalizeBeforeExport() {

--- a/src/track/trackmetadata.cpp
+++ b/src/track/trackmetadata.cpp
@@ -66,6 +66,21 @@ QString TrackMetadata::reformatYear(QString year) {
     return year.simplified();
 }
 
+void TrackMetadata::normalizeBeforeExport() {
+    refAlbumInfo().normalizeBeforeExport();
+    refTrackInfo().normalizeBeforeExport();
+}
+
+bool TrackMetadata::anyFileTagsModified(
+        const TrackMetadata& importedFromFile) const {
+    // NOTE(uklotzde): The read-only audio properties that are stored
+    // directly as members of this class might differ after they have
+    // been updated while decoding audio data. They are read-only and
+    // must not be considered when exporting metadata!
+    return getAlbumInfo() != importedFromFile.getAlbumInfo() ||
+            getTrackInfo() != importedFromFile.getTrackInfo();
+}
+
 bool operator==(const TrackMetadata& lhs, const TrackMetadata& rhs) {
     return (lhs.getAlbumInfo() == rhs.getAlbumInfo()) &&
             (lhs.getTrackInfo() == rhs.getTrackInfo()) &&

--- a/src/track/trackmetadata.h
+++ b/src/track/trackmetadata.h
@@ -33,28 +33,14 @@ public:
     TrackMetadata& operator=(TrackMetadata&&) = default;
     TrackMetadata& operator=(const TrackMetadata&) = default;
 
-    // TODO(XXX): Remove after all new fields have been added to the library
-    void resetUnsupportedValues() {
-        refAlbumInfo().resetUnsupportedValues();
-        refTrackInfo().resetUnsupportedValues();
-    }
-
     // Adjusts floating-point values to match their string representation
     // in file tags to account for rounding errors.
-    void normalizeBeforeExport() {
-        refAlbumInfo().normalizeBeforeExport();
-        refTrackInfo().normalizeBeforeExport();
-    }
+    void normalizeBeforeExport();
 
-    // Compares the contents with metadata that has been freshly imported
-    // from a file.
-    bool hasBeenModifiedAfterImport(const TrackMetadata& importedFromFile) const {
-        // NOTE(uklotzde): The read-only audio properties might differ after
-        // they have been updated while decoding audio data. They are read-only
-        // and must not be considered when exporting metadata.
-        return (getAlbumInfo() != importedFromFile.getAlbumInfo()) ||
-                (getTrackInfo() != importedFromFile.getTrackInfo());
-    }
+    // Returns true if the current metadata differs from the imported metadata
+    // and needs to be exported. A result of false indicates that no export
+    // is needed.
+    bool anyFileTagsModified(const TrackMetadata& importedFromFile) const;
 
     // Parse an format date/time values according to ISO 8601
     static QDate parseDate(QString str) {

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -66,6 +66,13 @@ bool checkID3v2HeaderVersionSupported(const TagLib::ID3v2::Header& header) {
     }
 }
 
+// Owners of ID3v2 UFID frames.
+// NOTE(uklotzde, 2019-09-28): This is the owner string for MusicBrainz
+// as written by MusicBrainz Picard 2.1.3 although the mapping table
+// doesn't mention any "http://" prefix.
+// See also: https://picard.musicbrainz.org/docs/mappings
+const QString kMusicBrainzOwner = "http://musicbrainz.org";
+
 } // anonymous namespace
 
 namespace taglib {
@@ -353,11 +360,6 @@ QString formatReplayGainPeak(const ReplayGain& replayGain) {
 }
 
 inline
-bool hasTrackPeak(const TrackMetadata& trackMetadata) {
-    return trackMetadata.getTrackInfo().getReplayGain().hasPeak();
-}
-
-inline
 QString formatTrackPeak(const TrackMetadata& trackMetadata) {
     return formatReplayGainPeak(trackMetadata.getTrackInfo().getReplayGain());
 }
@@ -390,11 +392,6 @@ bool parseTrackPeak(
 
 #if defined(__EXTRA_METADATA__)
 inline
-bool hasAlbumGain(const TrackMetadata& trackMetadata) {
-    return trackMetadata.getAlbumInfo().getReplayGain().hasRatio();
-}
-
-inline
 QString formatAlbumGain(const TrackMetadata& trackMetadata) {
     return formatReplayGainGain(trackMetadata.getAlbumInfo().getReplayGain());
 }
@@ -410,11 +407,6 @@ bool parseAlbumGain(
         pTrackMetadata->refAlbumInfo().setReplayGain(replayGain);
     }
     return isRatioValid;
-}
-
-inline
-bool hasAlbumPeak(const TrackMetadata& trackMetadata) {
-    return trackMetadata.getAlbumInfo().getReplayGain().hasPeak();
 }
 
 inline
@@ -633,47 +625,6 @@ QString readFirstUserTextIdentificationFrame(
     }
 }
 
-// Deletes all TXXX frame with the given description (case-insensitive).
-int removeUserTextIdentificationFrames(
-        TagLib::ID3v2::Tag* pTag,
-        const QString& description) {
-    DEBUG_ASSERT(pTag);
-    DEBUG_ASSERT(!description.isEmpty());
-    int count = 0;
-    bool repeat;
-    do {
-        repeat = false;
-        // Bind the const-ref result to avoid a local copy
-        const TagLib::ID3v2::FrameList& textFrames =
-                pTag->frameListMap()["TXXX"];
-        for (TagLib::ID3v2::FrameList::ConstIterator it(textFrames.begin());
-                it != textFrames.end(); ++it) {
-            auto pFrame =
-                    dynamic_cast<TagLib::ID3v2::UserTextIdentificationFrame*>(*it);
-            if (pFrame) {
-                const QString frameDescription(
-                        toQString(pFrame->description()));
-                if (0 == frameDescription.compare(
-                        description, Qt::CaseInsensitive)) {
-                    if (kLogger.debugEnabled()) {
-                        kLogger.debug()
-                                << "Removing ID3v2 TXXX frame:"
-                                << toQString(pFrame->description());
-                    }
-                    // After removing a frame the result of frameListMap()
-                    // is no longer valid!!
-                    pTag->removeFrame(pFrame, false); // remove an unowned frame
-                    ++count;
-                    // Exit and restart loop
-                    repeat = true;
-                    break;
-                }
-            }
-        }
-    } while (repeat);
-    return count;
-}
-
 #if defined(__EXTRA_METADATA__)
 // Finds the first UFID frame that with a matching owner (case-insensitive).
 // If multiple UFID frames with matching descriptions exist prefer the first
@@ -712,7 +663,6 @@ TagLib::ID3v2::UniqueFileIdentifierFrame* findFirstUniqueFileIdentifierFrame(
     return pFirstFrame;
 }
 
-inline
 QByteArray readFirstUniqueFileIdentifierFrame(
         const TagLib::ID3v2::Tag& tag,
         const QString& owner) {
@@ -800,6 +750,80 @@ void writeID3v2TextIdentificationFrame(
     }
 }
 
+void writeID3v2UserTextIdentificationFrame(
+        TagLib::ID3v2::Tag* pTag,
+        const QString& description,
+        const QString& text,
+        bool isNumericOrURL = false) {
+    TagLib::ID3v2::UserTextIdentificationFrame* pFrame =
+            findFirstUserTextIdentificationFrame(*pTag, description);
+    if (pFrame) {
+        // Modify existing frame
+        if (text.isEmpty()) {
+            // Purge empty frames
+            pTag->removeFrame(pFrame);
+        } else {
+            pFrame->setDescription(toTagLibString(description));
+            pFrame->setText(toTagLibString(text));
+        }
+    } else {
+        // Add a new (non-empty) frame
+        if (!text.isEmpty()) {
+            const TagLib::String::Type stringType =
+                    getID3v2StringType(*pTag, isNumericOrURL);
+            auto pFrame =
+                    std::make_unique<TagLib::ID3v2::UserTextIdentificationFrame>(stringType);
+            pFrame->setDescription(toTagLibString(description));
+            pFrame->setText(toTagLibString(text));
+            pTag->addFrame(pFrame.get());
+            // Now that the plain pointer in pFrame is owned and managed by
+            // pTag we need to release the ownership to avoid double deletion!
+            pFrame.release();
+        }
+    }
+}
+
+// Deletes all TXXX frame with the given description (case-insensitive).
+int removeUserTextIdentificationFrames(
+        TagLib::ID3v2::Tag* pTag,
+        const QString& description) {
+    DEBUG_ASSERT(pTag);
+    DEBUG_ASSERT(!description.isEmpty());
+    int count = 0;
+    bool repeat;
+    do {
+        repeat = false;
+        // Bind the const-ref result to avoid a local copy
+        const TagLib::ID3v2::FrameList& textFrames =
+                pTag->frameListMap()["TXXX"];
+        for (TagLib::ID3v2::FrameList::ConstIterator it(textFrames.begin());
+                it != textFrames.end(); ++it) {
+            auto pFrame =
+                    dynamic_cast<TagLib::ID3v2::UserTextIdentificationFrame*>(*it);
+            if (pFrame) {
+                const QString frameDescription(
+                        toQString(pFrame->description()));
+                if (0 == frameDescription.compare(
+                        description, Qt::CaseInsensitive)) {
+                    if (kLogger.debugEnabled()) {
+                        kLogger.debug()
+                                << "Removing ID3v2 TXXX frame:"
+                                << toQString(pFrame->description());
+                    }
+                    // After removing a frame the result of frameListMap()
+                    // is no longer valid!!
+                    pTag->removeFrame(pFrame, false); // remove an unowned frame
+                    ++count;
+                    // Exit and restart loop
+                    repeat = true;
+                    break;
+                }
+            }
+        }
+    } while (repeat);
+    return count;
+}
+
 void writeID3v2CommentsFrame(
         TagLib::ID3v2::Tag* pTag,
         const QString& text,
@@ -849,52 +873,7 @@ void writeID3v2CommentsFrameWithoutDescription(
     writeID3v2CommentsFrame(pTag, text, QString(), isNumericOrURL);
 }
 
-void writeID3v2UserTextIdentificationFrame(
-        TagLib::ID3v2::Tag* pTag,
-        const QString& description,
-        const QString& text,
-        bool isNumericOrURL = false) {
-    TagLib::ID3v2::UserTextIdentificationFrame* pFrame =
-            findFirstUserTextIdentificationFrame(*pTag, description);
-    if (pFrame) {
-        // Modify existing frame
-        if (text.isEmpty()) {
-            // Purge empty frames
-            pTag->removeFrame(pFrame);
-        } else {
-            pFrame->setDescription(toTagLibString(description));
-            pFrame->setText(toTagLibString(text));
-        }
-    } else {
-        // Add a new (non-empty) frame
-        if (!text.isEmpty()) {
-            const TagLib::String::Type stringType =
-                    getID3v2StringType(*pTag, isNumericOrURL);
-            auto pFrame =
-                    std::make_unique<TagLib::ID3v2::UserTextIdentificationFrame>(stringType);
-            pFrame->setDescription(toTagLibString(description));
-            pFrame->setText(toTagLibString(text));
-            pTag->addFrame(pFrame.get());
-            // Now that the plain pointer in pFrame is owned and managed by
-            // pTag we need to release the ownership to avoid double deletion!
-            pFrame.release();
-        }
-    }
-}
-
 #if defined(__EXTRA_METADATA__)
-bool writeID3v2TextIdentificationFrameStringIfNotNull(
-        TagLib::ID3v2::Tag* pTag,
-        const TagLib::ByteVector &id,
-        const QString& text) {
-    if (text.isNull()) {
-        return false;
-    } else {
-        writeID3v2TextIdentificationFrame(pTag, id, text);
-        return true;
-    }
-}
-
 void writeID3v2UniqueFileIdentifierFrame(
         TagLib::ID3v2::Tag* pTag,
         const QString& owner,
@@ -1585,7 +1564,7 @@ void importTrackMetadataFromID3v2Tag(
         pTrackMetadata->refTrackInfo().setMusicBrainzArtistId(QUuid(trackArtistId));
     }
     QByteArray trackRecordingId =
-            readFirstUniqueFileIdentifierFrame(tag, "http://musicbrainz.org");
+            readFirstUniqueFileIdentifierFrame(tag, kMusicBrainzOwner);
     if (!trackRecordingId.isEmpty()) {
         pTrackMetadata->refTrackInfo().setMusicBrainzRecordingId(QUuid(trackRecordingId));
     }
@@ -2381,11 +2360,11 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
                 "GRP1",
                 trackMetadata.getTrackInfo().getGrouping());
 #if defined(__EXTRA_METADATA__)
-        writeID3v2TextIdentificationFrameStringIfNotNull(
+        writeID3v2TextIdentificationFrame(
                 pTag,
                 "TIT1",
                 trackMetadata.getTrackInfo().getWork());
-        writeID3v2TextIdentificationFrameStringIfNotNull(
+        writeID3v2TextIdentificationFrame(
                 pTag,
                 "MVNM",
                 trackMetadata.getTrackInfo().getMovement());
@@ -2412,142 +2391,120 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
             "REPLAYGAIN_TRACK_GAIN",
             formatTrackGain(trackMetadata),
             true);
-    // NOTE(uklotzde, 2018-04-22): The analyzers currently doesn't
-    // calculate a peak value, so leave it untouched in the file if
-    // the value is invalid/absent. Otherwise the ID3 frame would
-    // be deleted.
-    if (hasTrackPeak(trackMetadata)) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "REPLAYGAIN_TRACK_PEAK",
-                formatTrackPeak(trackMetadata),
-                true);
-    }
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "REPLAYGAIN_TRACK_PEAK",
+            formatTrackPeak(trackMetadata),
+            true);
 
-    // TODO(XXX): The following tags have been added later and are currently
-    // not stored in the Mixxx library. Only write fields that have non-null
-    // values to preserve any existing file tags instead of removing them!
 #if defined(__EXTRA_METADATA__)
-    if (hasAlbumGain(trackMetadata)) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "REPLAYGAIN_ALBUM_GAIN",
-                formatAlbumGain(trackMetadata),
-                true);
-    }
-    if (hasAlbumPeak(trackMetadata)) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "REPLAYGAIN_ALBUM_PEAK",
-                formatAlbumPeak(trackMetadata),
-                true);
-    }
+    writeID3v2TextIdentificationFrame(pTag, "TPOS", TrackNumbers::joinStrings(
+            trackMetadata.getTrackInfo().getDiscNumber(),
+            trackMetadata.getTrackInfo().getDiscTotal()));
 
-    if (!trackMetadata.getTrackInfo().getMusicBrainzArtistId().isNull()) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "MusicBrainz Artist Id",
-                trackMetadata.getTrackInfo().getMusicBrainzArtistId().toString(),
-                false);
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzRecordingId().isNull()) {
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "REPLAYGAIN_ALBUM_GAIN",
+            formatAlbumGain(trackMetadata),
+            true);
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "REPLAYGAIN_ALBUM_PEAK",
+            formatAlbumPeak(trackMetadata),
+            true);
+
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "MusicBrainz Artist Id",
+            formatUuid(trackMetadata.getTrackInfo().getMusicBrainzArtistId()),
+            false);
+    {
         QByteArray identifier = trackMetadata.getTrackInfo().getMusicBrainzRecordingId().toByteArray();
         if (identifier.size() == 38) {
             // Strip leading/trailing curly braces
+            DEBUG_ASSERT(identifier.startsWith('{'));
+            DEBUG_ASSERT(identifier.endsWith('}'));
             identifier = identifier.mid(1, 36);
         }
         DEBUG_ASSERT(identifier.size() == 36);
         writeID3v2UniqueFileIdentifierFrame(
                 pTag,
-                "http://musicbrainz.org",
+                kMusicBrainzOwner,
                 identifier);
     }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzReleaseId().isNull()) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "MusicBrainz Release Track Id",
-                trackMetadata.getTrackInfo().getMusicBrainzReleaseId().toString(),
-                false);
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzWorkId().isNull()) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "MusicBrainz Work Id",
-                trackMetadata.getTrackInfo().getMusicBrainzWorkId().toString(),
-                false);
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzArtistId().isNull()) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "MusicBrainz Album Artist Id",
-                trackMetadata.getAlbumInfo().getMusicBrainzArtistId().toString(),
-                false);
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().isNull()) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "MusicBrainz Album Id",
-                trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().toString(),
-                false);
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().isNull()) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "MusicBrainz Release Group Id",
-                trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().toString(),
-                false);
-    }
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "MusicBrainz Release Track Id",
+            formatUuid(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()),
+            false);
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "MusicBrainz Work Id",
+            formatUuid(trackMetadata.getTrackInfo().getMusicBrainzWorkId()),
+            false);
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "MusicBrainz Album Artist Id",
+            formatUuid(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()),
+            false);
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "MusicBrainz Album Id",
+            formatUuid(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()),
+            false);
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "MusicBrainz Release Group Id",
+            formatUuid(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()),
+            false);
 
-    writeID3v2TextIdentificationFrameStringIfNotNull(pTag, "TPOS", TrackNumbers::joinStrings(
-            trackMetadata.getTrackInfo().getDiscNumber(),
-            trackMetadata.getTrackInfo().getDiscTotal()));
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TPE3",
             trackMetadata.getTrackInfo().getConductor());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TSRC",
             trackMetadata.getTrackInfo().getISRC());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TLAN",
             trackMetadata.getTrackInfo().getLanguage());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TEXT",
             trackMetadata.getTrackInfo().getLyricist());
     if (pHeader->majorVersion() >= 4) {
-        writeID3v2TextIdentificationFrameStringIfNotNull(
+        writeID3v2TextIdentificationFrame(
                 pTag,
                 "TMOO",
                 trackMetadata.getTrackInfo().getMood());
     }
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TCOP",
             trackMetadata.getAlbumInfo().getCopyright());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "WCOP",
             trackMetadata.getAlbumInfo().getLicense());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TPUB",
             trackMetadata.getAlbumInfo().getRecordLabel());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TPE4",
             trackMetadata.getTrackInfo().getRemixer());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TIT3",
             trackMetadata.getTrackInfo().getSubtitle());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TENC",
             trackMetadata.getTrackInfo().getEncoder());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TSSE",
             trackMetadata.getTrackInfo().getEncoderSettings());
@@ -2590,112 +2547,59 @@ bool exportTrackMetadataIntoAPETag(TagLib::APE::Tag* pTag, const TrackMetadata& 
 
     writeAPEItem(pTag, "REPLAYGAIN_TRACK_GAIN",
             toTagLibString(formatTrackGain(trackMetadata)));
-    // NOTE(uklotzde, 2018-04-22): The analyzers currently doesn't
-    // calculate a peak value, so leave it untouched in the file if
-    // the value is invalid/absent. Otherwise the APE item would be
-    // deleted.
-    if (hasTrackPeak(trackMetadata)) {
-        writeAPEItem(pTag, "REPLAYGAIN_TRACK_PEAK",
-                toTagLibString(formatTrackPeak(trackMetadata)));
-    }
+    writeAPEItem(pTag, "REPLAYGAIN_TRACK_PEAK",
+            toTagLibString(formatTrackPeak(trackMetadata)));
 
-    // TODO(XXX): The following tags have been added later and are currently
-    // not stored in the Mixxx library. Only write fields that have non-null
-    // values to preserve any existing file tags instead of removing them!
 #if defined(__EXTRA_METADATA__)
     auto discNumbers = TrackNumbers::joinStrings(
             trackMetadata.getTrackInfo().getDiscNumber(),
             trackMetadata.getTrackInfo().getDiscTotal());
-    if (!discNumbers.isNull()) {
-        writeAPEItem(pTag, "Disc", toTagLibString(discNumbers));
-    }
+    writeAPEItem(pTag, "Disc", toTagLibString(discNumbers));
 
-    if (hasAlbumGain(trackMetadata)) {
-        writeAPEItem(pTag, "REPLAYGAIN_ALBUM_GAIN",
-                toTagLibString(formatAlbumGain(trackMetadata)));
-    }
-    if (hasAlbumPeak(trackMetadata)) {
-        writeAPEItem(pTag, "REPLAYGAIN_ALBUM_PEAK",
-                toTagLibString(formatAlbumPeak(trackMetadata)));
-    }
+    writeAPEItem(pTag, "REPLAYGAIN_ALBUM_GAIN",
+            toTagLibString(formatAlbumGain(trackMetadata)));
+    writeAPEItem(pTag, "REPLAYGAIN_ALBUM_PEAK",
+            toTagLibString(formatAlbumPeak(trackMetadata)));
 
-    if (!trackMetadata.getTrackInfo().getMusicBrainzArtistId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_ARTISTID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzRecordingId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_TRACKID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzReleaseId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_RELEASETRACKID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzWorkId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_WORKID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzArtistId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_ALBUMARTISTID",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_ALBUMID",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_RELEASEGROUPID",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().toString()));
-    }
+    writeAPEItem(pTag, "MUSICBRAINZ_ARTISTID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
+    writeAPEItem(pTag, "MUSICBRAINZ_TRACKID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
+    writeAPEItem(pTag, "MUSICBRAINZ_RELEASETRACKID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
+    writeAPEItem(pTag, "MUSICBRAINZ_WORKID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
+    writeAPEItem(pTag, "MUSICBRAINZ_ALBUMARTISTID",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
+    writeAPEItem(pTag, "MUSICBRAINZ_ALBUMID",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
+    writeAPEItem(pTag, "MUSICBRAINZ_RELEASEGROUPID",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
 
-    if (!trackMetadata.getTrackInfo().getConductor().isNull()) {
-        writeAPEItem(pTag, "Conductor",
-                toTagLibString(trackMetadata.getTrackInfo().getConductor()));
-    }
-    if (!trackMetadata.getTrackInfo().getISRC().isNull()) {
-        writeAPEItem(pTag, "ISRC",
-                toTagLibString(trackMetadata.getTrackInfo().getISRC()));
-    }
-    if (!trackMetadata.getTrackInfo().getLanguage().isNull()) {
-        writeAPEItem(pTag, "Language",
-                toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
-    }
-    if (!trackMetadata.getTrackInfo().getLyricist().isNull()) {
-        writeAPEItem(pTag, "Lyricist",
-                toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
-    }
-    if (!trackMetadata.getTrackInfo().getMood().isNull()) {
-        writeAPEItem(pTag, "Mood",
-                toTagLibString(trackMetadata.getTrackInfo().getMood()));
-    }
-    if (!trackMetadata.getAlbumInfo().getCopyright().isNull()) {
-        writeAPEItem(pTag, "Copyright",
-                toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
-    }
-    if (!trackMetadata.getAlbumInfo().getLicense().isNull()) {
-        writeAPEItem(pTag, "LICENSE",
-                toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
-    }
-    if (!trackMetadata.getAlbumInfo().getRecordLabel().isNull()) {
-        writeAPEItem(pTag, "Label",
-                toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
-    }
-    if (!trackMetadata.getTrackInfo().getRemixer().isNull()) {
-        writeAPEItem(pTag, "MixArtist",
-                toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
-    }
-    if (!trackMetadata.getTrackInfo().getSubtitle().isNull()) {
-        writeAPEItem(pTag, "Subtitle",
-                toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
-    }
-    if (!trackMetadata.getTrackInfo().getEncoder().isNull()) {
-        writeAPEItem(pTag, "EncodedBy",
-                toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
-    }
-    if (!trackMetadata.getTrackInfo().getEncoderSettings().isNull()) {
-        writeAPEItem(pTag, "EncoderSettings",
-                toTagLibString(trackMetadata.getTrackInfo().getEncoderSettings()));
-    }
+    writeAPEItem(pTag, "Conductor",
+            toTagLibString(trackMetadata.getTrackInfo().getConductor()));
+    writeAPEItem(pTag, "ISRC",
+            toTagLibString(trackMetadata.getTrackInfo().getISRC()));
+    writeAPEItem(pTag, "Language",
+            toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
+    writeAPEItem(pTag, "Lyricist",
+            toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
+    writeAPEItem(pTag, "Mood",
+            toTagLibString(trackMetadata.getTrackInfo().getMood()));
+    writeAPEItem(pTag, "Copyright",
+            toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
+    writeAPEItem(pTag, "LICENSE",
+            toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
+    writeAPEItem(pTag, "Label",
+            toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
+    writeAPEItem(pTag, "MixArtist",
+            toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
+    writeAPEItem(pTag, "Subtitle",
+            toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
+    writeAPEItem(pTag, "EncodedBy",
+            toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
+    writeAPEItem(pTag, "EncoderSettings",
+            toTagLibString(trackMetadata.getTrackInfo().getEncoderSettings()));
 #endif // __EXTRA_METADATA__
 
     return true;
@@ -2777,110 +2681,62 @@ bool exportTrackMetadataIntoXiphComment(TagLib::Ogg::XiphComment* pTag,
     // calculate a peak value, so leave it untouched in the file if
     // the value is invalid/absent. Otherwise the comment field would
     // be deleted.
-    if (hasTrackPeak(trackMetadata)) {
-        writeXiphCommentField(pTag, "REPLAYGAIN_TRACK_PEAK",
-                toTagLibString(formatTrackPeak(trackMetadata)));
-    }
+    writeXiphCommentField(pTag, "REPLAYGAIN_TRACK_PEAK",
+            toTagLibString(formatTrackPeak(trackMetadata)));
 
-    // TODO(XXX): The following tags have been added later and are currently
-    // not stored in the Mixxx library. Only write fields that have non-null
-    // values to preserve any existing file tags instead of removing them!
 #if defined(__EXTRA_METADATA__)
-    if (hasAlbumGain(trackMetadata)) {
-        writeXiphCommentField(pTag, "REPLAYGAIN_ALBUM_GAIN",
-                toTagLibString(formatAlbumGain(trackMetadata)));
-    }
-    if (hasAlbumPeak(trackMetadata)) {
-        writeXiphCommentField(pTag, "REPLAYGAIN_ALBUM_PEAK",
-                toTagLibString(formatAlbumPeak(trackMetadata)));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzArtistId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_ARTISTID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzRecordingId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_TRACKID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzReleaseId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_RELEASETRACKID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzWorkId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_WORKID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzArtistId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_ALBUMARTISTID",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_ALBUMID",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_RELEASEGROUPID",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getConductor().isNull()) {
-        writeXiphCommentField(pTag, "CONDUCTOR",
-                toTagLibString(trackMetadata.getTrackInfo().getConductor()));
-    }
-    if (!trackMetadata.getTrackInfo().getISRC().isNull()) {
-        writeXiphCommentField(pTag, "ISRC",
-                toTagLibString(trackMetadata.getTrackInfo().getISRC()));
-    }
-    if (!trackMetadata.getTrackInfo().getLanguage().isNull()) {
-        writeXiphCommentField(pTag, "LANGUAGE",
-                toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
-    }
-    if (!trackMetadata.getTrackInfo().getLyricist().isNull()) {
-        writeXiphCommentField(pTag, "LYRICIST",
-                toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
-    }
-    if (!trackMetadata.getTrackInfo().getMood().isNull()) {
-        writeXiphCommentField(pTag, "MOOD",
-                toTagLibString(trackMetadata.getTrackInfo().getMood()));
-    }
-    if (!trackMetadata.getAlbumInfo().getCopyright().isNull()) {
-        writeXiphCommentField(pTag, "COPYRIGHT",
-                toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
-    }
-    if (!trackMetadata.getAlbumInfo().getLicense().isNull()) {
-        writeXiphCommentField(pTag, "LICENSE",
-                toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
-    }
-    if (!trackMetadata.getAlbumInfo().getRecordLabel().isNull()) {
-        writeXiphCommentField(pTag, "LABEL",
-                toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
-    }
-    if (!trackMetadata.getTrackInfo().getRemixer().isNull()) {
-        writeXiphCommentField(pTag, "REMIXER",
-                toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
-    }
-    if (!trackMetadata.getTrackInfo().getSubtitle().isNull()) {
-        writeXiphCommentField(pTag, "SUBTITLE",
-                toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
-    }
-    if (!trackMetadata.getTrackInfo().getEncoder().isNull()) {
-        writeXiphCommentField(pTag, "ENCODEDBY",
-                toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
-    }
-    if (!trackMetadata.getTrackInfo().getEncoderSettings().isNull()) {
-        writeXiphCommentField(pTag, "ENCODERSETTINGS",
-                toTagLibString(trackMetadata.getTrackInfo().getEncoderSettings()));
-    }
-    if (!trackMetadata.getTrackInfo().getDiscNumber().isNull()) {
-        writeXiphCommentField(
-                pTag, "DISCNUMBER", toTagLibString(trackMetadata.getTrackInfo().getDiscNumber()));
-    }
     // According to https://wiki.xiph.org/Field_names "DISCTOTAL" is
     // the proposed field name, but some applications use "TOTALDISCS".
-    if (!trackMetadata.getTrackInfo().getDiscTotal().isNull()) {
-        const TagLib::String discTotal(toTagLibString(trackMetadata.getTrackInfo().getDiscTotal()));
-        writeXiphCommentField(pTag, "DISCTOTAL", discTotal);   // recommended field
-        updateXiphCommentField(pTag, "TOTALDISCS", discTotal); // alternative field
-    }
+    const TagLib::String discTotal(toTagLibString(trackMetadata.getTrackInfo().getDiscTotal()));
+    writeXiphCommentField(pTag, "DISCTOTAL", discTotal);   // recommended field
+    updateXiphCommentField(pTag, "TOTALDISCS", discTotal); // alternative field
+
+    writeXiphCommentField(pTag, "REPLAYGAIN_ALBUM_GAIN",
+            toTagLibString(formatAlbumGain(trackMetadata)));
+    writeXiphCommentField(pTag, "REPLAYGAIN_ALBUM_PEAK",
+            toTagLibString(formatAlbumPeak(trackMetadata)));
+
+    writeXiphCommentField(pTag, "MUSICBRAINZ_ARTISTID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
+    writeXiphCommentField(pTag, "MUSICBRAINZ_TRACKID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
+    writeXiphCommentField(pTag, "MUSICBRAINZ_RELEASETRACKID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
+    writeXiphCommentField(pTag, "MUSICBRAINZ_WORKID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
+    writeXiphCommentField(pTag, "MUSICBRAINZ_ALBUMARTISTID",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
+    writeXiphCommentField(pTag, "MUSICBRAINZ_ALBUMID",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
+    writeXiphCommentField(pTag, "MUSICBRAINZ_RELEASEGROUPID",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
+
+    writeXiphCommentField(pTag, "CONDUCTOR",
+            toTagLibString(trackMetadata.getTrackInfo().getConductor()));
+    writeXiphCommentField(pTag, "ISRC",
+            toTagLibString(trackMetadata.getTrackInfo().getISRC()));
+    writeXiphCommentField(pTag, "LANGUAGE",
+            toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
+    writeXiphCommentField(pTag, "LYRICIST",
+            toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
+    writeXiphCommentField(pTag, "MOOD",
+            toTagLibString(trackMetadata.getTrackInfo().getMood()));
+    writeXiphCommentField(pTag, "COPYRIGHT",
+            toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
+    writeXiphCommentField(pTag, "LICENSE",
+            toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
+    writeXiphCommentField(pTag, "LABEL",
+            toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
+    writeXiphCommentField(pTag, "REMIXER",
+            toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
+    writeXiphCommentField(pTag, "SUBTITLE",
+            toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
+    writeXiphCommentField(pTag, "ENCODEDBY",
+            toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
+    writeXiphCommentField(pTag, "ENCODERSETTINGS",
+            toTagLibString(trackMetadata.getTrackInfo().getEncoderSettings()));
+    writeXiphCommentField(
+            pTag, "DISCNUMBER", toTagLibString(trackMetadata.getTrackInfo().getDiscNumber()));
 #endif // __EXTRA_METADATA__
 
     return true;
@@ -2942,18 +2798,9 @@ bool exportTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& 
 
     writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_track_gain",
             toTagLibString(formatTrackGain(trackMetadata)));
-    // NOTE(uklotzde, 2018-04-22): The analyzers currently doesn't
-    // calculate a peak value, so leave it untouched in the file if
-    // the value is invalid/absent. Otherwise the MP4 atom would be
-    // deleted.
-    if (hasTrackPeak(trackMetadata)) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_track_peak",
-                toTagLibString(formatTrackPeak(trackMetadata)));
-    }
+    writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_track_peak",
+            toTagLibString(formatTrackPeak(trackMetadata)));
 
-    // TODO(XXX): The following tags have been added later and are currently
-    // not stored in the Mixxx library. Only write fields that have non-null
-    // values to preserve any existing file tags instead of removing them!
 #if defined(__EXTRA_METADATA__)
     // Write disc number/total pair
     QString discNumberText;
@@ -2964,9 +2811,7 @@ bool exportTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& 
             trackMetadata.getTrackInfo().getDiscTotal(), &parsedDiscNumbers);
     switch (discParseResult) {
         case TrackNumbers::ParseResult::EMPTY:
-            // Preserve disc numbers in file and do NOT delete them
-            // if not already stored in the Mixxx database! Support
-            // for these fields have been added later.
+            pTag->itemListMap().erase("disk");
             break;
         case TrackNumbers::ParseResult::VALID:
             pTag->itemListMap()["disk"] =
@@ -2979,92 +2824,52 @@ bool exportTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& 
                                          trackMetadata.getTrackInfo().getDiscTotal());
     }
 
-    if (hasAlbumGain(trackMetadata)) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_album_gain",
-                toTagLibString(formatAlbumGain(trackMetadata)));
-    }
-    if (hasAlbumPeak(trackMetadata)) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_album_peak",
-                toTagLibString(formatAlbumPeak(trackMetadata)));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzArtistId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Artist Id",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzRecordingId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Track Id",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzReleaseId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Release Track Id",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzWorkId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Work Id",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzArtistId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Album Artist Id",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Album Id",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Release Group Id",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getConductor().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:CONDUCTOR",
-                toTagLibString(trackMetadata.getTrackInfo().getConductor()));
-    }
-    if (!trackMetadata.getTrackInfo().getISRC().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:ISRC",
-                toTagLibString(trackMetadata.getTrackInfo().getISRC()));
-    }
-    if (!trackMetadata.getTrackInfo().getLanguage().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:LANGUAGE",
-                toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
-    }
-    if (!trackMetadata.getTrackInfo().getLyricist().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:LYRICIST",
-                toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
-    }
-    if (!trackMetadata.getTrackInfo().getMood().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MOOD",
-                toTagLibString(trackMetadata.getTrackInfo().getMood()));
-    }
-    if (!trackMetadata.getAlbumInfo().getCopyright().isNull()) {
-        writeMP4Atom(pTag, "cprt",
-                toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
-    }
-    if (!trackMetadata.getAlbumInfo().getLicense().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:LICENSE",
-                toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
-    }
-    if (!trackMetadata.getAlbumInfo().getRecordLabel().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:LABEL",
-                toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
-    }
-    if (!trackMetadata.getTrackInfo().getRemixer().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:REMIXER",
-                toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
-    }
-    if (!trackMetadata.getTrackInfo().getSubtitle().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:SUBTITLE",
-                toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
-    }
-    if (!trackMetadata.getTrackInfo().getEncoder().isNull()) {
-        writeMP4Atom(pTag, "\251too",
-                toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
-    }
-    if (!trackMetadata.getTrackInfo().getWork().isNull()) {
-        writeMP4Atom(pTag, "\251wrk", toTagLibString(trackMetadata.getTrackInfo().getWork()));
-    }
-    if (!trackMetadata.getTrackInfo().getMovement().isNull()) {
-        writeMP4Atom(pTag, "\251mvn", toTagLibString(trackMetadata.getTrackInfo().getMovement()));
-    }
+    writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_album_gain",
+            toTagLibString(formatAlbumGain(trackMetadata)));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_album_peak",
+            toTagLibString(formatAlbumPeak(trackMetadata)));
+
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Artist Id",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Track Id",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Release Track Id",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Work Id",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Album Artist Id",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Album Id",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Release Group Id",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
+
+    writeMP4Atom(pTag, "----:com.apple.iTunes:CONDUCTOR",
+            toTagLibString(trackMetadata.getTrackInfo().getConductor()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:ISRC",
+            toTagLibString(trackMetadata.getTrackInfo().getISRC()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:LANGUAGE",
+            toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:LYRICIST",
+            toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MOOD",
+            toTagLibString(trackMetadata.getTrackInfo().getMood()));
+    writeMP4Atom(pTag, "cprt",
+            toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:LICENSE",
+            toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:LABEL",
+            toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:REMIXER",
+            toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:SUBTITLE",
+            toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
+    writeMP4Atom(pTag, "\251too",
+            toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
+    writeMP4Atom(pTag, "\251wrk",
+            toTagLibString(trackMetadata.getTrackInfo().getWork()));
+    writeMP4Atom(pTag, "\251mvn",
+            toTagLibString(trackMetadata.getTrackInfo().getMovement()));
 #endif // __EXTRA_METADATA__
 
     return true;

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -47,4 +47,85 @@ bool TrackRecord::updateGlobalKeyText(
     return false;
 }
 
+namespace {
+
+// Data migration: Reload track total from file tags if not initialized
+// yet. The added column "tracktotal" has been initialized with the
+// default value "//".
+// See also: Schema revision 26 in schema.xml
+const QString kReloadTrackTotal = "//";
+
+void mergeReplayGainMetadataProperty(
+        ReplayGain& mergedReplayGain,
+        const ReplayGain& importedReplayGain) {
+    // Preserve the values calculated by Mixxx and only merge missing
+    // values from the imported replay gain.
+    if (!mergedReplayGain.hasRatio()) {
+        mergedReplayGain.setRatio(importedReplayGain.getRatio());
+    }
+    if (!mergedReplayGain.hasPeak()) {
+        mergedReplayGain.setPeak(importedReplayGain.getPeak());
+    }
+}
+
+template<typename T>
+void mergeNullableMetadataProperty(
+        T& mergedProperty,
+        const T& importedProperty) {
+    if (mergedProperty.isNull()) {
+        mergedProperty = importedProperty;
+    }
+}
+
+} // anonymous namespace
+
+void TrackRecord::mergeImportedMetadata(
+        const TrackMetadata& importedFromFile) {
+    TrackInfo& mergedTrackInfo = refMetadata().refTrackInfo();
+    const TrackInfo& importedTrackInfo = importedFromFile.getTrackInfo();
+    if (mergedTrackInfo.getTrackTotal() == kReloadTrackTotal) {
+        mergedTrackInfo.setTrackTotal(importedTrackInfo.getTrackTotal());
+        // Also set the track number if it is still empty due
+        // to insufficient parsing capabilities of Mixxx in
+        // previous versions.
+        if (mergedTrackInfo.getTrackNumber().isEmpty() &&
+                !importedTrackInfo.getTrackNumber().isEmpty()) {
+            mergedTrackInfo.setTrackNumber(importedTrackInfo.getTrackNumber());
+        }
+    }
+#if defined(__EXTRA_METADATA__)
+    mergeNullableMetadataProperty(mergedTrackInfo.refConductor(), importedTrackInfo.getConductor());
+    mergeNullableMetadataProperty(mergedTrackInfo.refDiscNumber(), importedTrackInfo.getDiscNumber());
+    mergeNullableMetadataProperty(mergedTrackInfo.refDiscTotal(), importedTrackInfo.getDiscTotal());
+    mergeNullableMetadataProperty(mergedTrackInfo.refEncoder(), importedTrackInfo.getEncoder());
+    mergeNullableMetadataProperty(mergedTrackInfo.refEncoderSettings(), importedTrackInfo.getEncoderSettings());
+    mergeNullableMetadataProperty(mergedTrackInfo.refISRC(), importedTrackInfo.getISRC());
+    mergeNullableMetadataProperty(mergedTrackInfo.refLanguage(), importedTrackInfo.getLanguage());
+    mergeNullableMetadataProperty(mergedTrackInfo.refLyricist(), importedTrackInfo.getLyricist());
+    mergeNullableMetadataProperty(mergedTrackInfo.refMood(), importedTrackInfo.getMood());
+    mergeNullableMetadataProperty(mergedTrackInfo.refMovement(), importedTrackInfo.getMovement());
+    mergeNullableMetadataProperty(mergedTrackInfo.refMusicBrainzArtistId(), importedTrackInfo.getMusicBrainzArtistId());
+    mergeNullableMetadataProperty(mergedTrackInfo.refMusicBrainzRecordingId(), importedTrackInfo.getMusicBrainzRecordingId());
+    mergeNullableMetadataProperty(mergedTrackInfo.refMusicBrainzReleaseId(), importedTrackInfo.getMusicBrainzReleaseId());
+    mergeNullableMetadataProperty(mergedTrackInfo.refMusicBrainzWorkId(), importedTrackInfo.getMusicBrainzWorkId());
+    mergeNullableMetadataProperty(mergedTrackInfo.refRemixer(), importedTrackInfo.getRemixer());
+    mergeNullableMetadataProperty(mergedTrackInfo.refSubtitle(), importedTrackInfo.getSubtitle());
+    mergeNullableMetadataProperty(mergedTrackInfo.refWork(), importedTrackInfo.getWork());
+#endif // __EXTRA_METADATA__
+    AlbumInfo& mergedAlbumInfo = refMetadata().refAlbumInfo();
+    const AlbumInfo& importedAlbumInfo = importedFromFile.getAlbumInfo();
+#if defined(__EXTRA_METADATA__)
+    mergeReplayGainMetadataProperty(mergedAlbumInfo.refReplayGain(), importedAlbumInfo.getReplayGain());
+    mergeNullableMetadataProperty(mergedAlbumInfo.refCopyright(), importedAlbumInfo.getCopyright());
+    mergeNullableMetadataProperty(mergedAlbumInfo.refLicense(), importedAlbumInfo.getLicense());
+    mergeNullableMetadataProperty(mergedAlbumInfo.refMusicBrainzArtistId(), importedAlbumInfo.getMusicBrainzArtistId());
+    mergeNullableMetadataProperty(mergedAlbumInfo.refMusicBrainzReleaseGroupId(), importedAlbumInfo.getMusicBrainzReleaseGroupId());
+    mergeNullableMetadataProperty(mergedAlbumInfo.refMusicBrainzReleaseId(), importedAlbumInfo.getMusicBrainzReleaseId());
+    mergeNullableMetadataProperty(mergedAlbumInfo.refRecordLabel(), importedAlbumInfo.getRecordLabel());
+#else
+    Q_UNUSED(mergedAlbumInfo);
+    Q_UNUSED(importedAlbumInfo);
+#endif // __EXTRA_METADATA__
+}
+
 } //namespace mixxx

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -87,6 +87,12 @@ public:
             const QString& keyText,
             track::io::key::Source keySource);
 
+    // Merge the current metadata from the file with the subset of metadata
+    // that is stored in the library. This is required to delete any tags
+    // from the file that are not (yet) stored in the library database!
+    void mergeImportedMetadata(
+            const TrackMetadata& importedMetadata);
+
 private:
     Keys m_keys;
 };


### PR DESCRIPTION
**Please ignore, out of date. Needs to be rebased on a set of library design changes with various fixes. I'm currently no longer able to maintain all my pending fixes and have put all new development tasks on hold.**

This PR introduces a simpler, more robust, and better maintainable mapping or synchronization between track metadata that is both stored in the database and in file tags. The code is still complicated, but it's a step in the right direction. It is also another prerequisite for #2282.

We currently only store a subset of properties in the database. Adding support for new fields in the future is non-trivial as we need to incrementally import the missing properties from file tags and must avoid to overwrite any existing file tags when exporting metadata.

The default value for newly added database fields is supposed to be NULL (= missing). A special case from the past is *total tracks* that has been initialized with "//". Those properties must be replaced with the corresponding file tags step by step whenever a track is loaded. 

When enabling `__EXTRA_METADATA__` track objects will also be populated with all properties that are available as file tags but are not (yet) stored in the database. The values stored in the database take precedence over imported file tags.

## Reorganization

- Remove special case handling of certain properties from TagLib code
- Remove special case handling of certain properties from TrackInfo/AlbumInfo/TrackMetadata
- Move tag migration code for *total tracks* from TrackDAO into TrackRecord
- Move all code for merging imported file tags into TrackRecord

## Import

`SoundSourceProxy::updateTrackFromSource()` Import and merge file tags when loading track objects. This will also populate all missing fields that are not (yet) stored in the database.

## Export

`Track::exportMetadata()` Import and merge file tags again before exporting metadata. Tags are only written if differences are detected to avoid modifying the corresponding file if not needed.