### PR TITLE
allow skins to style sidebar context menus

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -1951,6 +1951,11 @@ QToolTip {
     color: #CCCCCC;
     border: 1px solid #CCCCCC;
 }
+
+QMenu {
+  background-color: green;
+  border: 1px solid orange;
+}
 /*
 
 #Deck1 {

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -47,6 +47,11 @@ QToolTip {
   border-radius: 2px;
 }
 
+QMenu {
+  background-color: green;
+  border: 1px solid orange;
+}
+
 WPushButton, QPushButton {
   font-size: 11px/12px;
 }

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -547,3 +547,8 @@ WLibrary QPushButton {
 #HotcueButton[highlight="8"] {
     background-color: #f2f2ff;
 }
+
+QMenu {
+  background-color: green;
+  border: 1px solid orange;
+}

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2089,6 +2089,11 @@ QToolTip {
   border: 1px solid #333;
 }
 
+QMenu {
+  background-color: green;
+  border: 1px solid orange;
+}
+
 #TEST {
   background-color: #451278;
 }

--- a/src/library/analysisfeature.cpp
+++ b/src/library/analysisfeature.cpp
@@ -81,7 +81,7 @@ QIcon AnalysisFeature::getIcon() {
     return m_icon;
 }
 
-void AnalysisFeature::bindWidget(WLibrary* libraryWidget,
+void AnalysisFeature::bindLibraryWidget(WLibrary* libraryWidget,
                                  KeyboardEventFilter* keyboard) {
     m_pAnalysisView = new DlgAnalysis(libraryWidget,
                                       m_pConfig,

--- a/src/library/analysisfeature.h
+++ b/src/library/analysisfeature.h
@@ -35,7 +35,7 @@ class AnalysisFeature : public LibraryFeature {
 
     bool dropAccept(QList<QUrl> urls, QObject* pSource);
     bool dragMoveAccept(QUrl url);
-    void bindWidget(WLibrary* libraryWidget,
+    void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard);
 
     TreeItemModel* getChildModel();

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -115,7 +115,7 @@ QIcon AutoDJFeature::getIcon() {
     return m_icon;
 }
 
-void AutoDJFeature::bindWidget(WLibrary* libraryWidget,
+void AutoDJFeature::bindLibraryWidget(WLibrary* libraryWidget,
                                KeyboardEventFilter* keyboard) {
     m_pAutoDJView = new DlgAutoDJ(libraryWidget,
                                   m_pConfig,

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -21,6 +21,7 @@
 #include "util/compatibility.h"
 #include "util/dnd.h"
 #include "widget/wlibrary.h"
+#include "widget/wlibrarysidebar.h"
 
 const QString AutoDJFeature::m_sAutoDJViewName = QString("Auto DJ");
 
@@ -147,6 +148,11 @@ void AutoDJFeature::bindLibraryWidget(WLibrary* libraryWidget,
             &DlgAutoDJ::addRandomButton,
             this,
             &AutoDJFeature::slotAddRandomTrack);
+}
+
+void AutoDJFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
+    // store the sidebar widget pointer for later use in onRightClickChild
+    m_pSidebarWidget = pSidebarWidget;
 }
 
 TreeItemModel* AutoDJFeature::getChildModel() {
@@ -285,10 +291,11 @@ void AutoDJFeature::constructCrateChildModel() {
 void AutoDJFeature::onRightClickChild(const QPoint& globalPos,
                                       QModelIndex index) {
     TreeItem* pClickedItem = static_cast<TreeItem*>(index.internalPointer());
+    QMenu menu(m_pSidebarWidget);
     if (m_pCratesTreeItem == pClickedItem) {
         // The "Crates" parent item was right-clicked.
         // Bring up the context menu.
-        QMenu crateMenu;
+        QMenu crateMenu(m_pSidebarWidget);
         crateMenu.setTitle(tr("Add Crate as Track Source"));
         CrateSelectResult nonAutoDjCrates(m_pTrackCollection->crates().selectAutoDjCrates(false));
         Crate crate;
@@ -301,16 +308,14 @@ void AutoDJFeature::onRightClickChild(const QPoint& globalPos,
             crateMenu.addAction(pAction.get());
             pAction.release();
         }
-        QMenu contextMenu;
-        contextMenu.addMenu(&crateMenu);
-        contextMenu.exec(globalPos);
+        menu.addMenu(&crateMenu);
+        menu.exec(globalPos);
     } else {
         // A crate child item was right-clicked.
         // Bring up the context menu.
         m_pRemoveCrateFromAutoDj->setData(pClickedItem->getData()); // the selected CrateId
-        QMenu contextMenu;
-        contextMenu.addAction(m_pRemoveCrateFromAutoDj);
-        contextMenu.exec(globalPos);
+        menu.addAction(m_pRemoveCrateFromAutoDj);
+        menu.exec(globalPos);
     }
 }
 

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -15,6 +15,7 @@
 #include <QPoint>
 #include <QAction>
 #include <QSignalMapper>
+#include <QPointer>
 
 #include "library/libraryfeature.h"
 #include "preferences/usersettings.h"
@@ -27,6 +28,7 @@ class Library;
 class PlayerManagerInterface;
 class TrackCollection;
 class AutoDJProcessor;
+class WLibrarySidebar;
 
 class AutoDJFeature : public LibraryFeature {
     Q_OBJECT
@@ -45,6 +47,7 @@ class AutoDJFeature : public LibraryFeature {
 
     void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard);
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget);
 
     TreeItemModel* getChildModel();
 
@@ -92,6 +95,7 @@ class AutoDJFeature : public LibraryFeature {
     QSignalMapper m_crateMapper;
 
     QIcon m_icon;
+    QPointer<WLibrarySidebar> m_pSidebarWidget;
 
   private slots:
     // Add a crate to the auto-DJ queue.

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -43,7 +43,7 @@ class AutoDJFeature : public LibraryFeature {
     bool dropAccept(QList<QUrl> urls, QObject* pSource);
     bool dragMoveAccept(QUrl url);
 
-    void bindWidget(WLibrary* libraryWidget,
+    void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard);
 
     TreeItemModel* getChildModel();

--- a/src/library/baseexternallibraryfeature.cpp
+++ b/src/library/baseexternallibraryfeature.cpp
@@ -3,6 +3,7 @@
 #include <QMenu>
 
 #include "library/basesqltablemodel.h"
+#include "widget/wlibrarysidebar.h"
 
 BaseExternalLibraryFeature::BaseExternalLibraryFeature(QObject* pParent,
                                                        TrackCollection* pCollection)
@@ -33,6 +34,11 @@ BaseExternalLibraryFeature::~BaseExternalLibraryFeature() {
     delete m_pImportAsMixxxPlaylistAction;
 }
 
+void BaseExternalLibraryFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
+    // store the sidebar widget pointer for later use in onRightClickChild
+    m_pSidebarWidget = pSidebarWidget;
+}
+
 void BaseExternalLibraryFeature::onRightClick(const QPoint& globalPos) {
     Q_UNUSED(globalPos);
     m_lastRightClickedIndex = QModelIndex();
@@ -41,9 +47,7 @@ void BaseExternalLibraryFeature::onRightClick(const QPoint& globalPos) {
 void BaseExternalLibraryFeature::onRightClickChild(const QPoint& globalPos, QModelIndex index) {
     //Save the model index so we can get it in the action slots...
     m_lastRightClickedIndex = index;
-
-    //Create the right-click menu
-    QMenu menu;
+    QMenu menu(m_pSidebarWidget);
     menu.addAction(m_pAddToAutoDJAction);
     menu.addAction(m_pAddToAutoDJTopAction);
     menu.addSeparator();

--- a/src/library/baseexternallibraryfeature.h
+++ b/src/library/baseexternallibraryfeature.h
@@ -3,11 +3,13 @@
 
 #include <QAction>
 #include <QModelIndex>
+#include <QPointer>
 
 #include "library/libraryfeature.h"
 
 class BaseSqlTableModel;
 class TrackCollection;
+class WLibrarySidebar;
 
 class BaseExternalLibraryFeature : public LibraryFeature {
     Q_OBJECT
@@ -16,6 +18,7 @@ class BaseExternalLibraryFeature : public LibraryFeature {
     virtual ~BaseExternalLibraryFeature();
 
   public slots:
+    virtual void bindSidebarWidget(WLibrarySidebar* pSidebarWidget);
     virtual void onRightClick(const QPoint& globalPos);
     virtual void onRightClickChild(const QPoint& globalPos, QModelIndex index);
 
@@ -43,6 +46,8 @@ class BaseExternalLibraryFeature : public LibraryFeature {
     QAction* m_pAddToAutoDJAction;
     QAction* m_pAddToAutoDJTopAction;
     QAction* m_pImportAsMixxxPlaylistAction;
+
+    QPointer<WLibrarySidebar> m_pSidebarWidget;
 };
 
 #endif // BASEEXTERNALLIBRARYFEATURE_H

--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -631,7 +631,7 @@ TreeItemModel* BasePlaylistFeature::getChildModel() {
     return &m_childModel;
 }
 
-void BasePlaylistFeature::bindWidget(WLibrary* libraryWidget,
+void BasePlaylistFeature::bindLibraryWidget(WLibrary* libraryWidget,
                                      KeyboardEventFilter* keyboard) {
     Q_UNUSED(keyboard);
     WLibraryTextBrowser* edit = new WLibraryTextBrowser(libraryWidget);

--- a/src/library/baseplaylistfeature.h
+++ b/src/library/baseplaylistfeature.h
@@ -33,7 +33,7 @@ class BasePlaylistFeature : public LibraryFeature {
 
     TreeItemModel* getChildModel();
 
-    void bindWidget(WLibrary* libraryWidget,
+    void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard);
 
   signals:

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -285,7 +285,12 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, QModelIndex index
 
     foreach (const QString& str, m_quickLinkList) {
         if (str == path) {
-             return;
+            // if path is a QuickLink:
+            // show remove action
+            menu.addAction(m_pRemoveQuickLinkAction);
+            menu.exec(globalPos);
+            onLazyChildExpandation(index);
+            return;
         }
      }
 

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -20,6 +20,7 @@
 #include "util/sandbox.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarytextbrowser.h"
+#include "widget/wlibrarysidebar.h"
 
 const QString kQuickLinksSeparator = "-+-";
 
@@ -226,6 +227,11 @@ void BrowseFeature::bindLibraryWidget(WLibrary* libraryWidget,
     libraryWidget->registerView("BROWSEHOME", edit);
 }
 
+void BrowseFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
+    // store the sidebar widget pointer for later use in onRightClickChild
+    m_pSidebarWidget = pSidebarWidget;
+}
+
 void BrowseFeature::activate() {
     emit(switchToView("BROWSEHOME"));
     emit disableSearch();
@@ -275,7 +281,7 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, QModelIndex index
         return;
     }
 
-    QMenu menu(NULL);
+    QMenu menu(m_pSidebarWidget);
     if (item->parent()->getData().toString() == QUICK_LINK_NODE) {
         menu.addAction(m_pRemoveQuickLinkAction);
         menu.exec(globalPos);

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -218,7 +218,7 @@ TreeItemModel* BrowseFeature::getChildModel() {
     return &m_childModel;
 }
 
-void BrowseFeature::bindWidget(WLibrary* libraryWidget,
+void BrowseFeature::bindLibraryWidget(WLibrary* libraryWidget,
                                KeyboardEventFilter* keyboard) {
     Q_UNUSED(keyboard);
     WLibraryTextBrowser* edit = new WLibraryTextBrowser(libraryWidget);

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -37,7 +37,7 @@ class BrowseFeature : public LibraryFeature {
     QVariant title();
     QIcon getIcon();
 
-    void bindWidget(WLibrary* libraryWidget,
+    void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard);
 
     TreeItemModel* getChildModel();

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -24,6 +24,7 @@
 
 class Library;
 class TrackCollection;
+class WLibrarySidebar;
 
 class BrowseFeature : public LibraryFeature {
     Q_OBJECT
@@ -39,6 +40,7 @@ class BrowseFeature : public LibraryFeature {
 
     void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard);
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget);
 
     TreeItemModel* getChildModel();
 
@@ -77,6 +79,7 @@ class BrowseFeature : public LibraryFeature {
     TreeItem* m_pQuickLinkItem;
     QStringList m_quickLinkList;
     QIcon m_icon;
+    QPointer<WLibrarySidebar> m_pSidebarWidget;
 };
 
 #endif // BROWSEFEATURE_H

--- a/src/library/crate/cratefeature.cpp
+++ b/src/library/crate/cratefeature.cpp
@@ -267,7 +267,7 @@ bool CrateFeature::dragMoveAcceptChild(const QModelIndex& index, QUrl url) {
         Parser::isPlaylistFilenameSupported(url.toLocalFile());
 }
 
-void CrateFeature::bindWidget(WLibrary* libraryWidget,
+void CrateFeature::bindLibraryWidget(WLibrary* libraryWidget,
                               KeyboardEventFilter* keyboard) {
     Q_UNUSED(keyboard);
     WLibraryTextBrowser* edit = new WLibraryTextBrowser(libraryWidget);

--- a/src/library/crate/cratefeature.cpp
+++ b/src/library/crate/cratefeature.cpp
@@ -22,6 +22,7 @@
 #include "sources/soundsourceproxy.h"
 
 #include "widget/wlibrary.h"
+#include "widget/wlibrarysidebar.h"
 #include "widget/wlibrarytextbrowser.h"
 
 #include "util/dnd.h"
@@ -280,6 +281,11 @@ void CrateFeature::bindLibraryWidget(WLibrary* libraryWidget,
     libraryWidget->registerView("CRATEHOME", edit);
 }
 
+void CrateFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
+    // store the sidebar widget pointer for later use in onRightClickChild
+    m_pSidebarWidget = pSidebarWidget;
+}
+
 TreeItemModel* CrateFeature::getChildModel() {
     return &m_childModel;
 }
@@ -334,7 +340,7 @@ bool CrateFeature::readLastRightClickedCrate(Crate* pCrate) const {
 
 void CrateFeature::onRightClick(const QPoint& globalPos) {
     m_lastRightClickedIndex = QModelIndex();
-    QMenu menu(NULL);
+    QMenu menu(m_pSidebarWidget);
     menu.addAction(m_pCreateCrateAction.get());
     menu.addSeparator();
     menu.addAction(m_pCreateImportPlaylistAction.get());
@@ -361,7 +367,7 @@ void CrateFeature::onRightClickChild(const QPoint& globalPos, QModelIndex index)
 
     m_pLockCrateAction->setText(crate.isLocked() ? tr("Unlock") : tr("Lock"));
 
-    QMenu menu(NULL);
+    QMenu menu(m_pSidebarWidget);
     menu.addAction(m_pCreateCrateAction.get());
     menu.addSeparator();
     menu.addAction(m_pRenameCrateAction.get());

--- a/src/library/crate/cratefeature.h
+++ b/src/library/crate/cratefeature.h
@@ -41,7 +41,7 @@ class CrateFeature : public LibraryFeature {
                          QObject* pSource) override;
     bool dragMoveAcceptChild(const QModelIndex& index, QUrl url) override;
 
-    void bindWidget(WLibrary* libraryWidget,
+    void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard) override;
 
     TreeItemModel* getChildModel() override;

--- a/src/library/crate/cratefeature.h
+++ b/src/library/crate/cratefeature.h
@@ -9,6 +9,7 @@
 #include <QUrl>
 #include <QIcon>
 #include <QPoint>
+#include <QPointer>
 
 #include "library/crate/cratetablemodel.h"
 
@@ -24,7 +25,7 @@
 // forward declaration(s)
 class Library;
 class TrackCollection;
-
+class WLibrarySidebar;
 
 class CrateFeature : public LibraryFeature {
     Q_OBJECT
@@ -43,6 +44,7 @@ class CrateFeature : public LibraryFeature {
 
     void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard) override;
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget);
 
     TreeItemModel* getChildModel() override;
 
@@ -121,6 +123,8 @@ class CrateFeature : public LibraryFeature {
     parented_ptr<QAction> m_pExportPlaylistAction;
     parented_ptr<QAction> m_pExportTrackFilesAction;
     parented_ptr<QAction> m_pAnalyzeCrateAction;
+
+    QPointer<WLibrarySidebar> m_pSidebarWidget;
 };
 
 

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -17,6 +17,7 @@
 #include "library/queryutil.h"
 #include "util/lcs.h"
 #include "util/sandbox.h"
+#include "widget/wlibrarysidebar.h"
 
 #ifdef __SQLITE3__
 #include <sqlite3.h>
@@ -146,6 +147,13 @@ QIcon ITunesFeature::getIcon() {
     return m_icon;
 }
 
+void ITunesFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
+    // store the sidebar widget pointer for later use in onRightClick()
+    m_pSidebarWidget = pSidebarWidget;
+    // send it to BaseExternalLibraryFeature for onRightClickChild()
+    BaseExternalLibraryFeature::bindSidebarWidget(pSidebarWidget);
+}
+
 void ITunesFeature::activate() {
     activate(false);
     emit(enableCoverArtDisplay(false));
@@ -226,7 +234,7 @@ TreeItemModel* ITunesFeature::getChildModel() {
 
 void ITunesFeature::onRightClick(const QPoint& globalPos) {
     BaseExternalLibraryFeature::onRightClick(globalPos);
-    QMenu menu;
+    QMenu menu(m_pSidebarWidget);
     QAction useDefault(tr("Use Default Library"), &menu);
     QAction chooseNew(tr("Choose Library..."), &menu);
     menu.addAction(&useDefault);

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -9,6 +9,7 @@
 #include <QFuture>
 #include <QtConcurrentRun>
 #include <QFutureWatcher>
+#include <QPointer>
 
 #include "library/baseexternallibraryfeature.h"
 #include "library/trackcollection.h"
@@ -17,6 +18,7 @@
 
 class BaseExternalTrackModel;
 class BaseExternalPlaylistModel;
+class WLibrarySidebar;
 
 class ITunesFeature : public BaseExternalLibraryFeature {
     Q_OBJECT
@@ -27,6 +29,7 @@ class ITunesFeature : public BaseExternalLibraryFeature {
 
     QVariant title();
     QIcon getIcon();
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget);
 
     TreeItemModel* getChildModel();
 
@@ -34,7 +37,7 @@ class ITunesFeature : public BaseExternalLibraryFeature {
     void activate();
     void activate(bool forceReload);
     void activateChild(const QModelIndex& index);
-    void onRightClick(const QPoint& globalPos);
+    void onRightClick(const QPoint& globalPos) override;
     void onTrackCollectionLoaded();
 
   private:
@@ -70,6 +73,7 @@ class ITunesFeature : public BaseExternalLibraryFeature {
     QString m_mixxxItunesRoot;
 
     QSharedPointer<BaseTrackCache> m_trackSource;
+    QPointer<WLibrarySidebar> m_pSidebarWidget;
     QIcon m_icon;
 };
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -299,9 +299,14 @@ void Library::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
             &Library::setTrackTableFont,
             pSidebarWidget,
             &WLibrarySidebar::slotSetFont);
+
+
+    for (const auto& feature : m_features) {
+        feature->bindSidebarWidget(pSidebarWidget);
+    }
 }
 
-void Library::bindWidget(WLibrary* pLibraryWidget,
+void Library::bindLibraryWidget(WLibrary* pLibraryWidget,
                          KeyboardEventFilter* pKeyboard) {
     WTrackTableView* pTrackTableView =
             new WTrackTableView(
@@ -348,12 +353,10 @@ void Library::bindWidget(WLibrary* pLibraryWidget,
             pTrackTableView,
             &WTrackTableView::setSelectedClick);
 
-    m_pLibraryControl->bindWidget(pLibraryWidget, pKeyboard);
+    m_pLibraryControl->bindLibraryWidget(pLibraryWidget, pKeyboard);
 
-    QListIterator<LibraryFeature*> feature_it(m_features);
-    while(feature_it.hasNext()) {
-        LibraryFeature* feature = feature_it.next();
-        feature->bindWidget(pLibraryWidget, pKeyboard);
+    for (const auto& feature : m_features) {
+        feature->bindLibraryWidget(pLibraryWidget, pKeyboard);
     }
 
     // Set the current font and row height on all the WTrackTableViews that were

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -11,23 +11,25 @@
 #include "mixer/playermanager.h"
 #include "library/library.h"
 #include "library/library_preferences.h"
+#include "library/librarycontrol.h"
 #include "library/libraryfeature.h"
 #include "library/librarytablemodel.h"
 #include "library/sidebarmodel.h"
 #include "library/trackcollection.h"
 #include "library/trackmodel.h"
+
+#include "library/autodj/autodjfeature.h"
+#include "library/banshee/bansheefeature.h"
 #include "library/browse/browsefeature.h"
 #include "library/crate/cratefeature.h"
-#include "library/rhythmbox/rhythmboxfeature.h"
-#include "library/banshee/bansheefeature.h"
-#include "library/recording/recordingfeature.h"
 #include "library/itunes/itunesfeature.h"
 #include "library/mixxxlibraryfeature.h"
-#include "library/autodj/autodjfeature.h"
 #include "library/playlistfeature.h"
-#include "library/traktor/traktorfeature.h"
-#include "library/librarycontrol.h"
+#include "library/recording/recordingfeature.h"
+#include "library/rhythmbox/rhythmboxfeature.h"
 #include "library/setlogfeature.h"
+#include "library/traktor/traktorfeature.h"
+
 #include "util/db/dbconnectionpooled.h"
 #include "util/sandbox.h"
 #include "util/logger.h"
@@ -135,6 +137,7 @@ Library::Library(
     addFeature(m_pPlaylistFeature);
     m_pCrateFeature = new CrateFeature(this, m_pTrackCollection, m_pConfig);
     addFeature(m_pCrateFeature);
+
     BrowseFeature* browseFeature = new BrowseFeature(
         this, pConfig, m_pTrackCollection, pRecordingManager);
     connect(browseFeature,
@@ -149,8 +152,8 @@ Library::Library(
             &LibraryScanner::scanFinished,
             browseFeature,
             &BrowseFeature::slotLibraryScanFinished);
-
     addFeature(browseFeature);
+
     addFeature(new RecordingFeature(this, pConfig, m_pTrackCollection, pRecordingManager));
     addFeature(new SetlogFeature(this, pConfig, m_pTrackCollection));
 

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -15,9 +15,8 @@
 #include "preferences/usersettings.h"
 #include "track/globaltrackcache.h"
 #include "recording/recordingmanager.h"
-#include "analysisfeature.h"
+#include "library/analysisfeature.h"
 #include "library/coverartcache.h"
-#include "library/setlogfeature.h"
 #include "library/scanner/libraryscanner.h"
 #include "util/db/dbconnectionpool.h"
 

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -2,7 +2,7 @@
 // Created 8/23/2009 by RJ Ryan (rryan@mit.edu)
 
 // A Library class is a container for all the model-side aspects of the library.
-// A library widget can be attached to the Library object by calling bindWidget.
+// A library widget can be attached to the Library object by calling bindLibraryWidget.
 
 #ifndef LIBRARY_H
 #define LIBRARY_H
@@ -64,7 +64,7 @@ class Library: public QObject,
         return *m_pTrackCollection;
     }
 
-    void bindWidget(WLibrary* libraryWidget,
+    void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* pKeyboard);
     void bindSidebarWidget(WLibrarySidebar* sidebarWidget);
 

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -301,7 +301,7 @@ void LibraryControl::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
             &LibraryControl::sidebarWidgetDeleted);
 }
 
-void LibraryControl::bindWidget(WLibrary* pLibraryWidget, KeyboardEventFilter* pKeyboard) {
+void LibraryControl::bindLibraryWidget(WLibrary* pLibraryWidget, KeyboardEventFilter* pKeyboard) {
     Q_UNUSED(pKeyboard);
     if (m_pLibraryWidget) {
         disconnect(m_pLibraryWidget, 0, this, 0);

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -40,7 +40,7 @@ class LibraryControl : public QObject {
     LibraryControl(Library* pLibrary);
     virtual ~LibraryControl();
 
-    void bindWidget(WLibrary* pLibrary, KeyboardEventFilter* pKeyboard);
+    void bindLibraryWidget(WLibrary* pLibrary, KeyboardEventFilter* pKeyboard);
     void bindSidebarWidget(WLibrarySidebar* pLibrarySidebar);
 
   public slots:

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -64,6 +64,7 @@ class LibraryFeature : public QObject {
     // Reimplement this to register custom views with the library widget.
     virtual void bindLibraryWidget(WLibrary* /* libraryWidget */,
                             KeyboardEventFilter* /* keyboard */) {}
+    virtual void bindSidebarWidget(WLibrarySidebar* /* sidebar widget */) {}
     virtual TreeItemModel* getChildModel() = 0;
 
     virtual bool hasTrackTable() {

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -62,7 +62,7 @@ class LibraryFeature : public QObject {
     }
 
     // Reimplement this to register custom views with the library widget.
-    virtual void bindWidget(WLibrary* /* libraryWidget */,
+    virtual void bindLibraryWidget(WLibrary* /* libraryWidget */,
                             KeyboardEventFilter* /* keyboard */) {}
     virtual TreeItemModel* getChildModel() = 0;
 

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -133,7 +133,7 @@ MixxxLibraryFeature::~MixxxLibraryFeature() {
     delete m_pLibraryTableModel;
 }
 
-void MixxxLibraryFeature::bindWidget(WLibrary* pLibraryWidget,
+void MixxxLibraryFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
                                      KeyboardEventFilter* pKeyboard) {
     m_pHiddenView = new DlgHidden(pLibraryWidget, m_pConfig, m_pLibrary,
                                   m_pTrackCollection, pKeyboard);

--- a/src/library/mixxxlibraryfeature.h
+++ b/src/library/mixxxlibraryfeature.h
@@ -39,7 +39,7 @@ class MixxxLibraryFeature : public LibraryFeature {
     bool dropAccept(QList<QUrl> urls, QObject* pSource);
     bool dragMoveAccept(QUrl url);
     TreeItemModel* getChildModel();
-    void bindWidget(WLibrary* pLibrary,
+    void bindLibraryWidget(WLibrary* pLibrary,
                     KeyboardEventFilter* pKeyboard);
 
     bool hasTrackTable() override {

--- a/src/library/playlistfeature.cpp
+++ b/src/library/playlistfeature.cpp
@@ -58,11 +58,14 @@ QIcon PlaylistFeature::getIcon() {
     return m_icon;
 }
 
+void PlaylistFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
+    // store the sidebar widget pointer for later use in onRightClickChild
+    m_pSidebarWidget = pSidebarWidget;
+}
+
 void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     m_lastRightClickedIndex = QModelIndex();
-
-    //Create the right-click menu
-    QMenu menu(NULL);
+    QMenu menu(m_pSidebarWidget);
     menu.addAction(m_pCreatePlaylistAction);
     menu.addSeparator();
     menu.addAction(m_pCreateImportPlaylistAction);
@@ -80,8 +83,7 @@ void PlaylistFeature::onRightClickChild(const QPoint& globalPos, QModelIndex ind
 
     m_pLockPlaylistAction->setText(locked ? tr("Unlock") : tr("Lock"));
 
-    //Create the right-click menu
-    QMenu menu(NULL);
+    QMenu menu(m_pSidebarWidget);
     menu.addAction(m_pCreatePlaylistAction);
     menu.addSeparator();
     menu.addAction(m_pAddToAutoDJAction);

--- a/src/library/playlistfeature.h
+++ b/src/library/playlistfeature.h
@@ -10,12 +10,14 @@
 #include <QUrl>
 #include <QObject>
 #include <QPoint>
+#include <QPointer>
 
 #include "library/baseplaylistfeature.h"
 #include "preferences/usersettings.h"
 
 class TrackCollection;
 class TreeItem;
+class WLibrarySidebar;
 
 class PlaylistFeature : public BasePlaylistFeature {
     Q_OBJECT
@@ -26,6 +28,8 @@ class PlaylistFeature : public BasePlaylistFeature {
 
     QVariant title();
     QIcon getIcon();
+
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget);
 
     bool dropAcceptChild(const QModelIndex& index, QList<QUrl> urls, QObject* pSource);
     bool dragMoveAcceptChild(const QModelIndex& index, QUrl url);
@@ -47,6 +51,7 @@ class PlaylistFeature : public BasePlaylistFeature {
   private:
     QString getRootViewHtml() const;
     QIcon m_icon;
+    QPointer<WLibrarySidebar> m_pSidebarWidget;
 };
 
 #endif /* PLAYLISTFEATURE_H */

--- a/src/library/recording/recordingfeature.cpp
+++ b/src/library/recording/recordingfeature.cpp
@@ -39,7 +39,7 @@ QIcon RecordingFeature::getIcon() {
 TreeItemModel* RecordingFeature::getChildModel() {
     return &m_childModel;
 }
-void RecordingFeature::bindWidget(WLibrary* pLibraryWidget,
+void RecordingFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
                                   KeyboardEventFilter *keyboard) {
     //The view will be deleted by LibraryWidget
     DlgRecording* pRecordingView = new DlgRecording(pLibraryWidget,

--- a/src/library/recording/recordingfeature.h
+++ b/src/library/recording/recordingfeature.h
@@ -29,7 +29,7 @@ class RecordingFeature : public LibraryFeature {
     QVariant title();
     QIcon getIcon();
 
-    void bindWidget(WLibrary* libraryWidget,
+    void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard);
 
     TreeItemModel* getChildModel();

--- a/src/library/setlogfeature.cpp
+++ b/src/library/setlogfeature.cpp
@@ -63,9 +63,9 @@ QIcon SetlogFeature::getIcon() {
     return m_icon;
 }
 
-void SetlogFeature::bindWidget(WLibrary* libraryWidget,
+void SetlogFeature::bindLibraryWidget(WLibrary* libraryWidget,
                                KeyboardEventFilter* keyboard) {
-    BasePlaylistFeature::bindWidget(libraryWidget,
+    BasePlaylistFeature::bindLibraryWidget(libraryWidget,
                                     keyboard);
     connect(&PlayerInfo::instance(),
             &PlayerInfo::currentPlayingTrackChanged,

--- a/src/library/setlogfeature.cpp
+++ b/src/library/setlogfeature.cpp
@@ -12,6 +12,7 @@
 #include "mixer/playermanager.h"
 #include "widget/wtracktableview.h"
 #include "widget/wlibrary.h"
+#include "widget/wlibrarysidebar.h"
 
 SetlogFeature::SetlogFeature(QObject* parent,
                              UserSettingsPointer pConfig,
@@ -75,6 +76,11 @@ void SetlogFeature::bindLibraryWidget(WLibrary* libraryWidget,
 
 }
 
+void SetlogFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
+    // store the sidebar widget pointer for later use in onRightClickChild
+    m_pSidebarWidget = pSidebarWidget;
+}
+
 void SetlogFeature::onRightClick(const QPoint& globalPos) {
     Q_UNUSED(globalPos);
     m_lastRightClickedIndex = QModelIndex();
@@ -89,9 +95,9 @@ void SetlogFeature::onRightClick(const QPoint& globalPos) {
 void SetlogFeature::onRightClickChild(const QPoint& globalPos, QModelIndex index) {
     //Save the model index so we can get it in the action slots...
     m_lastRightClickedIndex = index;
+
     QString playlistName = index.data().toString();
     int playlistId = m_playlistDao.getPlaylistIdFromName(playlistName);
-
 
     bool locked = m_playlistDao.isPlaylistLocked(playlistId);
     m_pDeletePlaylistAction->setEnabled(!locked);
@@ -100,13 +106,12 @@ void SetlogFeature::onRightClickChild(const QPoint& globalPos, QModelIndex index
 
     m_pLockPlaylistAction->setText(locked ? tr("Unlock") : tr("Lock"));
 
-
-    //Create the right-click menu
-    QMenu menu(NULL);
+    QMenu menu(m_pSidebarWidget);
     //menu.addAction(m_pCreatePlaylistAction);
     //menu.addSeparator();
     menu.addAction(m_pAddToAutoDJAction);
     menu.addAction(m_pAddToAutoDJTopAction);
+    menu.addSeparator();
     menu.addAction(m_pRenamePlaylistAction);
     if (playlistId != m_playlistId) {
         // Todays playlist should not be locked or deleted

--- a/src/library/setlogfeature.h
+++ b/src/library/setlogfeature.h
@@ -6,12 +6,14 @@
 #include <QLinkedList>
 #include <QSqlTableModel>
 #include <QAction>
+#include <QPointer>
 
 #include "library/baseplaylistfeature.h"
 #include "preferences/usersettings.h"
 
 class TrackCollection;
 class TreeItem;
+class WLibrarySidebar;
 
 class SetlogFeature : public BasePlaylistFeature {
     Q_OBJECT
@@ -25,6 +27,7 @@ public:
 
     virtual void bindLibraryWidget(WLibrary* libraryWidget,
                             KeyboardEventFilter* keyboard);
+    virtual void bindSidebarWidget(WLibrarySidebar* pSidebarWidget);
 
   public slots:
     void onRightClick(const QPoint& globalPos);
@@ -51,6 +54,7 @@ public:
     QAction* m_pGetNewPlaylist;
     int m_playlistId;
     WLibrary* m_libraryWidget;
+    QPointer<WLibrarySidebar> m_pSidebarWidget;
     QIcon m_icon;
 };
 

--- a/src/library/setlogfeature.h
+++ b/src/library/setlogfeature.h
@@ -23,7 +23,7 @@ public:
     QVariant title();
     QIcon getIcon();
 
-    virtual void bindWidget(WLibrary* libraryWidget,
+    virtual void bindLibraryWidget(WLibrary* libraryWidget,
                             KeyboardEventFilter* keyboard);
 
   public slots:

--- a/src/skin/legacyskinparser.cpp
+++ b/src/skin/legacyskinparser.cpp
@@ -1323,9 +1323,9 @@ QWidget* LegacySkinParser::parseLibrary(const QDomElement& node) {
     connect(m_pLibrary, SIGNAL(search(const QString&)),
             pLibraryWidget, SLOT(search(const QString&)));
 
-    m_pLibrary->bindWidget(pLibraryWidget, m_pKeyboard);
+    m_pLibrary->bindLibraryWidget(pLibraryWidget, m_pKeyboard);
 
-    // This must come after the bindWidget or we will not style any of the
+    // This must come after the bindLibraryWidget or we will not style any of the
     // LibraryView's because they have not been added yet.
     commonWidgetSetup(node, pLibraryWidget, false);
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1729,11 +1729,14 @@ void WTrackTableView::slotPopulateCrateMenu() {
         // with the mouse, but not with the keyboard. :focus works for the
         // keyboard but with the mouse, the last clicked item keeps the style
         // after the mouse cursor is moved to hover over another item.
-        pCheckBox->setStyleSheet(
-            QString("QCheckBox {color: %1;}").arg(
-                    pCheckBox->palette().text().color().name()) + "\n" +
-            QString("QCheckBox:hover {background-color: %1;}").arg(
-                    pCheckBox->palette().highlight().color().name()));
+
+        // ronso0 Disabling this stylesheet allows to override the OS style
+        // of the :hover and :focus state.
+//        pCheckBox->setStyleSheet(
+//            QString("QCheckBox {color: %1;}").arg(
+//                    pCheckBox->palette().text().color().name()) + "\n" +
+//            QString("QCheckBox:hover {background-color: %1;}").arg(
+//                    pCheckBox->palette().highlight().color().name()));
         pAction->setEnabled(!crate.isLocked());
         pAction->setDefaultWidget(pCheckBox.get());
 


### PR DESCRIPTION
c++ changes to complete #2337 **Skins :: adjust styles of skin context menus, tooltip** for the sidebar right-click menu which was previously not stylable via qss because it was created without a parent widget.
Now sidebar widget is passed to each library feature (that has a context menu) and used there as parent widget for creating the context menus.

I also added a right-click action for paths in In 'Computer' tree that are in QuickLinks. This allows to remove those paths from Quick Links easily when they were added accidentially.

**Lesson learned**:
> if within each feature the context menu is parented to `QApplication::focusWidget()` (which would be WLibrarySidebar as well) some issues arise:
>* menu pops up at wrong place (cursorPos relative to widget 0,0 + global cursorPos)
>* menu is cropped by parent widget's geometry
>* menu won't close on selection or when clicking any menu item or outside the menu

ToDo
- [ ] test with iTunes feature
- [ ] test with Traktor feature
- [x] test with Banshee feature
- [x] test with Rhythmbox feature
- [x] test after skin change / reload

Before merge
- [x] remove debug output
- [ ] remove example style from skins