### PR TITLE
Skins :: collapse unconfigured Mic/Aux units, add Add button to configure

### DIFF
--- a/res/skins/LateNight/aux_unit.xml
+++ b/res/skins/LateNight/aux_unit.xml
@@ -146,47 +146,112 @@
               </WidgetGroup>
 
             </Children>
+            <Connection>
+              <ConfigKey><Variable name="group"/>,enabled</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
           </WidgetGroup><!-- MicAuxInterior -->
 
           <!-- MicAuxMainControls * Label, Play, xfader orientation -->
+          <!-- needs an extra wrapper, otherwise (with <Connection> attached)
+              outer borders of MixAuxFrame won't show up -->
           <WidgetGroup>
-            <ObjectName>MicAuxFrame</ObjectName>
             <Layout>vertical</Layout>
             <SizePolicy>min,me</SizePolicy>
             <Children>
               <WidgetGroup>
-                <ObjectName>MicAuxMainControls</ObjectName>
+                <ObjectName>MicAuxFrame</ObjectName>
                 <Layout>vertical</Layout>
                 <SizePolicy>min,me</SizePolicy>
                 <Children>
-
-                  <Label>
-                    <ObjectName>MicAuxSubTitle</ObjectName>
-                    <Size>,17f</Size>
-                    <Text>Aux <Variable name="auxnum"/></Text>
-                    <Alignment>center</Alignment>
-                  </Label>
-
-                  <WidgetGroup><!-- PLAY -->
-                    <ObjectName>AuxPlayButton</ObjectName>
+                  <WidgetGroup>
+                    <ObjectName>MicAuxMainControls</ObjectName>
                     <Layout>vertical</Layout>
                     <SizePolicy>min,me</SizePolicy>
                     <Children>
-                      <Template src="skin:button_2state.xml">
-                        <SetVariable name="TooltipId">mute</SetVariable>
-                        <SetVariable name="Size">42f,24f</SetVariable>
-                        <SetVariable name="icon">aux_play</SetVariable>
-                        <SetVariable name="ConfigKey"><Variable name="group"/>,mute</SetVariable>
-                      </Template>
+
+                      <Label>
+                        <ObjectName>MicAuxSubTitle</ObjectName>
+                        <Size>,17f</Size>
+                        <Text>Aux <Variable name="auxnum"/></Text>
+                        <Alignment>center</Alignment>
+                      </Label>
+
+                      <WidgetGroup><!-- PLAY -->
+                        <ObjectName>MicAuxTalkPlayButton</ObjectName>
+                        <Layout>vertical</Layout>
+                        <SizePolicy>min,me</SizePolicy>
+                        <Children>
+                          <Template src="skin:button_2state.xml">
+                            <SetVariable name="TooltipId">mute</SetVariable>
+                            <SetVariable name="Size">42f,24f</SetVariable>
+                            <SetVariable name="icon">aux_play</SetVariable>
+                            <SetVariable name="ConfigKey"><Variable name="group"/>,mute</SetVariable>
+                          </Template>
+                        </Children>
+                      </WidgetGroup><!-- /PLAY -->
+
+                      <Template src="skin:button_xfader_aux.xml"/>
+
                     </Children>
-                  </WidgetGroup><!-- /PLAY -->
+                  </WidgetGroup>
+                </Children>
+              </WidgetGroup><!-- MicAuxFrame -->
+            </Children>
+            <Connection>
+              <ConfigKey><Variable name="group"/>,enabled</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup><!-- MicAuxMainControls * Label, Play, xfader orientation -->
 
-                  <Template src="skin:button_xfader_aux.xml"/>
+          <!-- Mic unconfigured: Label, Add button -->
+          <!-- also needs an extra wrapper, see MicAuxFrame -->
+          <WidgetGroup>
+            <Layout>vertical</Layout>
+            <SizePolicy>min,me</SizePolicy>
+            <Children>
+              <WidgetGroup>
+                <ObjectName>MicAuxFrameUnconfigured</ObjectName>
+                <Layout>vertical</Layout>
+                <SizePolicy>min,me</SizePolicy>
+                <Children>
+                  <WidgetGroup>
+                    <ObjectName>MicAuxMainControls</ObjectName>
+                    <Layout>vertical</Layout>
+                    <SizePolicy>min,me</SizePolicy>
+                    <Children>
 
+                      <Label>
+                        <ObjectName>MicAuxSubTitle</ObjectName>
+                        <Size>,17f</Size>
+                        <Text>Aux <Variable name="auxnum"/></Text>
+                        <Alignment>center</Alignment>
+                      </Label>
+
+                      <WidgetGroup><!-- select Mic sound device -->
+                        <ObjectName>AlignHCenter</ObjectName>
+                        <Layout>vertical</Layout>
+                        <Size>42f,32f</Size>
+                        <Children><!--
+                          <Template src="skin:button_1state.xml">
+                            <SetVariable name="Size">26f,26f</SetVariable>
+                            <SetVariable name="Icon">plus</SetVariable>
+                            <SetVariable name="ConfigKey">[Microphone],talkover</SetVariable>
+                          </Template>-->
+                        </Children>
+                      </WidgetGroup><!-- select Aux sound device -->
+
+                    </Children>
+                  </WidgetGroup>
                 </Children>
               </WidgetGroup>
             </Children>
-          </WidgetGroup><!-- MicAuxMainControls * Label, Play, xfader orientation -->
+            <Connection>
+              <ConfigKey><Variable name="group"/>,enabled</ConfigKey>
+              <Transform><Not/></Transform>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup><!-- Mic unconfigured: Label, Add button -->
 
         </Children>
       </WidgetGroup>

--- a/res/skins/LateNight/mic_unit.xml
+++ b/res/skins/LateNight/mic_unit.xml
@@ -146,48 +146,113 @@
               </WidgetGroup>
 
             </Children>
+            <Connection>
+              <ConfigKey><Variable name="group"/>,enabled</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
           </WidgetGroup><!-- MicAuxInterior -->
 
           <!-- MicAuxMainControls * Label, Play, xfader orientation -->
+          <!-- needs an extra wrapper, otherwise (with <Connection> attached)
+              outer borders of MixAuxFrame won't show up -->
           <WidgetGroup>
-            <ObjectName>MicAuxFrame</ObjectName>
             <Layout>vertical</Layout>
             <SizePolicy>min,me</SizePolicy>
             <Children>
               <WidgetGroup>
-                <ObjectName>MicAuxMainControls</ObjectName>
+                <ObjectName>MicAuxFrame</ObjectName>
                 <Layout>vertical</Layout>
                 <SizePolicy>min,me</SizePolicy>
                 <Children>
-
-                  <Label>
-                    <ObjectName>MicAuxSubTitle</ObjectName>
-                    <Size>,17f</Size>
-                    <Text>mic <Variable name="mic1hack"/><Variable name="micnum"/></Text>
-                    <Alignment>center</Alignment>
-                  </Label>
-
-                  <WidgetGroup><!-- PLAY -->
-                    <ObjectName>AuxPlayButton</ObjectName>
+                  <WidgetGroup>
+                    <ObjectName>MicAuxMainControls</ObjectName>
                     <Layout>vertical</Layout>
                     <SizePolicy>min,me</SizePolicy>
                     <Children>
-                      <Template src="skin:button_2state.xml">
-                        <SetVariable name="TooltipId">microphone_talkover</SetVariable>
-                        <SetVariable name="Size">42f,24f</SetVariable>
-                        <SetVariable name="icon">mic_talk</SetVariable>
-                        <SetVariable name="ConfigKey"><Variable name="group"/>,talkover</SetVariable>
-                      </Template>
-                    </Children>
-                  </WidgetGroup><!-- /PLAY -->
 
+                      <Label>
+                        <ObjectName>MicAuxSubTitle</ObjectName>
+                        <Size>,17f</Size>
+                        <Text>mic <Variable name="mic1hack"/><Variable name="micnum"/></Text>
+                        <Alignment>center</Alignment>
+                      </Label>
+
+                      <WidgetGroup><!-- TALK -->
+                        <ObjectName>AuxPlayButton</ObjectName>
+                        <Layout>vertical</Layout>
+                        <SizePolicy>min,me</SizePolicy>
+                        <Children>
+                          <Template src="skin:button_2state.xml">
+                            <SetVariable name="TooltipId">microphone_talkover</SetVariable>
+                            <SetVariable name="Size">42f,24f</SetVariable>
+                            <SetVariable name="icon">mic_talk</SetVariable>
+                            <SetVariable name="ConfigKey"><Variable name="group"/>,talkover</SetVariable>
+                          </Template>
+                        </Children>
+                      </WidgetGroup><!-- /TALK -->
+
+                    </Children>
+                  </WidgetGroup><!-- MicAuxMainControls -->
+                </Children>
+              </WidgetGroup><!-- MicAuxFrame -->
+            </Children>
+            <Connection>
+              <ConfigKey><Variable name="group"/>,enabled</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup><!-- MicAuxMainControls * Label, TALK -->
+
+          <!-- Mic unconfigured: Label, Add button -->
+          <!-- also needs an extra wrapper, see MicAuxFrame -->
+          <WidgetGroup>
+            <Layout>vertical</Layout>
+            <SizePolicy>min,me</SizePolicy>
+            <Children>
+              <WidgetGroup>
+                <ObjectName>MicAuxFrameUnconfigured</ObjectName>
+                <Layout>vertical</Layout>
+                <SizePolicy>min,me</SizePolicy>
+                <Children>
+                  <WidgetGroup>
+                    <ObjectName>MicAuxMainControls</ObjectName>
+                    <Layout>vertical</Layout>
+                    <SizePolicy>min,me</SizePolicy>
+                    <Children>
+
+                      <Label>
+                        <ObjectName>MicAuxSubTitle</ObjectName>
+                        <Size>,17f</Size>
+                        <Text>mic <Variable name="mic1hack"/><Variable name="micnum"/></Text>
+                        <Alignment>center</Alignment>
+                      </Label>
+
+                      <WidgetGroup><!-- select Mic sound device -->
+                        <ObjectName>AlignHCenter</ObjectName>
+                        <Layout>vertical</Layout>
+                        <Size>42f,32f</Size>
+                        <Children>
+                          <Template src="skin:button_1state.xml">
+                            <SetVariable name="Size">26f,26f</SetVariable>
+                            <SetVariable name="Icon">plus</SetVariable>
+                            <SetVariable name="ConfigKey"><Variable name="group"/>,talkover</SetVariable>
+                          </Template>
+                        </Children>
+                      </WidgetGroup><!-- select Mic sound device -->
+
+                    </Children>
+                  </WidgetGroup>
                 </Children>
               </WidgetGroup>
             </Children>
-          </WidgetGroup><!-- MicAuxMainControls * Label, Play, xfader orientation -->
+            <Connection>
+              <ConfigKey><Variable name="group"/>,enabled</ConfigKey>
+              <Transform><Not/></Transform>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup><!-- Mic unconfigured: Label, Add button -->
 
         </Children>
-      </WidgetGroup>
+      </WidgetGroup><!-- style/background_tile.png -->
     </Children>
-  </WidgetGroup>
+  </WidgetGroup><!-- MicAuxUnit -->
 </Template>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -86,6 +86,7 @@ WLibrary,
 #FxSlot3[highlight="0"],
 #SamplerButtons,
 #MicAuxFrame,
+#MicAuxFrameUnconfigured,
 WSearchLineEdit,
 #OverviewBox,
 #KeyText {
@@ -784,7 +785,7 @@ WCoverArt {
 }
 
 #RateButtons {
-  qproperty-layoutAlignment: 'AlignHCenter | AlignTop';
+  margin-left: 2px;
 }
 
 /***************** Loop Controls *****************/
@@ -1205,8 +1206,10 @@ WBeatSpinBox,
     }
   #MicAuxFrame {
     border-left: 0px;
-    border-top-right-radius: 0px;
+    border-bottom-left-radius: 0px;
     border-top-left-radius: 0px;
+  }
+  #MicAuxFrameUnconfigured {
   }
   #MicAuxMainControls {
     background-color: #1e1e1e;


### PR DESCRIPTION
After merge of #1755 it's time to unify the Mic/Aux interface in Deere, Tango & LateNight.

* replace tiny Mute button with proper Aux Play (master) button in Deere
* collapse uncofigured Mic/Aux units, always show them
* add Add button to collapsed Mic/Aux units that abuses `talkover` or `master` to open the Hardware preferences