### PR TITLE
Refactoring: Attach WTrackTableView to Library instead of TrackCollection

### DIFF
--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -116,13 +116,14 @@ QIcon AutoDJFeature::getIcon() {
     return m_icon;
 }
 
-void AutoDJFeature::bindLibraryWidget(WLibrary* libraryWidget,
-                               KeyboardEventFilter* keyboard) {
-    m_pAutoDJView = new DlgAutoDJ(libraryWidget,
+void AutoDJFeature::bindLibraryWidget(
+        WLibrary* libraryWidget,
+        KeyboardEventFilter* keyboard) {
+    m_pAutoDJView = new DlgAutoDJ(
+            libraryWidget,
             m_pConfig,
             m_pLibrary,
             m_pAutoDJProcessor,
-            m_pTrackCollection,
             keyboard,
             libraryWidget->getShowButtonText());
     libraryWidget->registerView(m_sAutoDJViewName, m_pAutoDJView);

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -13,18 +13,18 @@ const char* kPreferenceGroupName = "[Auto DJ]";
 const char* kRepeatPlaylistPreference = "Requeue";
 } // anonymous namespace
 
-DlgAutoDJ::DlgAutoDJ(QWidget* parent,
+DlgAutoDJ::DlgAutoDJ(
+        QWidget* parent,
         UserSettingsPointer pConfig,
         Library* pLibrary,
         AutoDJProcessor* pProcessor,
-        TrackCollection* pTrackCollection,
         KeyboardEventFilter* pKeyboard,
         bool showButtonText)
         : QWidget(parent),
           Ui::DlgAutoDJ(),
           m_pAutoDJProcessor(pProcessor),
           // no sorting
-          m_pTrackTableView(new WTrackTableView(this, pConfig, pTrackCollection, false)),
+          m_pTrackTableView(new WTrackTableView(this, pConfig, pLibrary, false)),
           m_pAutoDJTableModel(nullptr),
           m_pConfig(pConfig),
           m_bShowButtonText(showButtonText) {

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -23,7 +23,6 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
             UserSettingsPointer pConfig,
             Library* pLibrary,
             AutoDJProcessor* pProcessor,
-            TrackCollection* pTrackCollection,
             KeyboardEventFilter* pKeyboard,
             bool showButtonText);
     ~DlgAutoDJ() override;

--- a/src/library/banshee/bansheefeature.cpp
+++ b/src/library/banshee/bansheefeature.cpp
@@ -17,7 +17,6 @@ BansheeFeature::BansheeFeature(QObject* parent,
                                TrackCollection* pTrackCollection,
                                UserSettingsPointer pConfig)
         : BaseExternalLibraryFeature(parent, pTrackCollection),
-          m_pTrackCollection(pTrackCollection),
           m_cancelImport(false),
           m_icon(":/images/library/ic_library_banshee.svg") {
     Q_UNUSED(pConfig);

--- a/src/library/banshee/bansheefeature.h
+++ b/src/library/banshee/bansheefeature.h
@@ -40,9 +40,8 @@ class BansheeFeature : public BaseExternalLibraryFeature {
     BansheePlaylistModel* m_pBansheePlaylistModel;
     TreeItemModel m_childModel;
     QStringList m_playlists;
-    TrackCollection* m_pTrackCollection;
-    //a new DB connection for the worker thread
 
+    //a new DB connection for the worker thread
     BansheeDbConnection m_connection;
 
     QSqlDatabase m_database;

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -99,7 +99,8 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     // Use this if you want a model that can be changed
     virtual Qt::ItemFlags readWriteFlags(const QModelIndex &index) const;
 
-    TrackCollection* m_pTrackCollection;
+    TrackCollection* const m_pTrackCollection;
+
     QSqlDatabase m_database;
 
     QString m_previewDeckGroup;

--- a/src/library/dlganalysis.cpp
+++ b/src/library/dlganalysis.cpp
@@ -15,13 +15,12 @@ DlgAnalysis::DlgAnalysis(QWidget* parent,
                        Library* pLibrary)
         : QWidget(parent),
           m_pConfig(pConfig),
-          m_pTrackCollection(&pLibrary->trackCollection()),
           m_bAnalysisActive(false) {
     setupUi(this);
     m_songsButtonGroup.addButton(radioButtonRecentlyAdded);
     m_songsButtonGroup.addButton(radioButtonAllSongs);
 
-    m_pAnalysisLibraryTableView = new WAnalysisLibraryTableView(this, pConfig, m_pTrackCollection);
+    m_pAnalysisLibraryTableView = new WAnalysisLibraryTableView(this, pConfig, pLibrary);
     connect(m_pAnalysisLibraryTableView,
             &WAnalysisLibraryTableView::loadTrack,
             this,
@@ -44,7 +43,7 @@ DlgAnalysis::DlgAnalysis(QWidget* parent,
         box->insertWidget(1, m_pAnalysisLibraryTableView);
     }
 
-    m_pAnalysisLibraryTableModel = new AnalysisLibraryTableModel(this, m_pTrackCollection);
+    m_pAnalysisLibraryTableModel = new AnalysisLibraryTableModel(this, &pLibrary->trackCollection());
     m_pAnalysisLibraryTableView->loadTrackModel(m_pAnalysisLibraryTableModel);
 
     connect(radioButtonRecentlyAdded,

--- a/src/library/dlganalysis.h
+++ b/src/library/dlganalysis.h
@@ -7,7 +7,6 @@
 #include "preferences/usersettings.h"
 #include "library/analysislibrarytablemodel.h"
 #include "library/libraryview.h"
-#include "library/trackcollection.h"
 #include "library/ui_dlganalysis.h"
 #include "analyzer/analyzerprogress.h"
 
@@ -58,7 +57,6 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
   private:
     //Note m_pTrackTablePlaceholder is defined in the .ui file
     UserSettingsPointer m_pConfig;
-    TrackCollection* m_pTrackCollection;
     bool m_bAnalysisActive;
     QButtonGroup m_songsButtonGroup;
     WAnalysisLibraryTableView* m_pAnalysisLibraryTableView;

--- a/src/library/dlghidden.cpp
+++ b/src/library/dlghidden.cpp
@@ -6,12 +6,12 @@
 #include "util/assert.h"
 
 DlgHidden::DlgHidden(QWidget* parent, UserSettingsPointer pConfig,
-                     Library* pLibrary, TrackCollection* pTrackCollection,
+                     Library* pLibrary,
                      KeyboardEventFilter* pKeyboard)
          : QWidget(parent),
            Ui::DlgHidden(),
            m_pTrackTableView(
-               new WTrackTableView(this, pConfig, pTrackCollection, false)) {
+               new WTrackTableView(this, pConfig, pLibrary, false)) {
     setupUi(this);
     m_pTrackTableView->installEventFilter(pKeyboard);
 

--- a/src/library/dlghidden.h
+++ b/src/library/dlghidden.h
@@ -5,7 +5,6 @@
 #include "preferences/usersettings.h"
 #include "library/library.h"
 #include "library/libraryview.h"
-#include "library/trackcollection.h"
 #include "controllers/keyboard/keyboardeventfilter.h"
 
 class WTrackTableView;
@@ -17,7 +16,7 @@ class DlgHidden : public QWidget, public Ui::DlgHidden, public LibraryView {
 
   public:
     DlgHidden(QWidget* parent, UserSettingsPointer pConfig,
-              Library* pLibrary, TrackCollection* pTrackCollection,
+              Library* pLibrary,
               KeyboardEventFilter* pKeyboard);
     ~DlgHidden() override;
 

--- a/src/library/dlgmissing.cpp
+++ b/src/library/dlgmissing.cpp
@@ -6,11 +6,11 @@
 
 DlgMissing::DlgMissing(QWidget* parent, UserSettingsPointer pConfig,
                        Library* pLibrary,
-                       TrackCollection* pTrackCollection, KeyboardEventFilter* pKeyboard)
+                       KeyboardEventFilter* pKeyboard)
          : QWidget(parent),
            Ui::DlgMissing(),
            m_pTrackTableView(
-               new WTrackTableView(this, pConfig, pTrackCollection, false)) {
+               new WTrackTableView(this, pConfig, pLibrary, false)) {
     setupUi(this);
     m_pTrackTableView->installEventFilter(pKeyboard);
 

--- a/src/library/dlgmissing.h
+++ b/src/library/dlgmissing.h
@@ -5,7 +5,6 @@
 #include "preferences/usersettings.h"
 #include "library/library.h"
 #include "library/libraryview.h"
-#include "library/trackcollection.h"
 #include "controllers/keyboard/keyboardeventfilter.h"
 
 class WTrackTableView;
@@ -16,7 +15,7 @@ class DlgMissing : public QWidget, public Ui::DlgMissing, public LibraryView {
 
   public:
     DlgMissing(QWidget* parent, UserSettingsPointer pConfig,
-               Library* pLibrary, TrackCollection* pTrackCollection,
+               Library* pLibrary,
                KeyboardEventFilter* pKeyboard);
     ~DlgMissing() override;
 

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -61,7 +61,6 @@ QString localhost_token() {
 
 ITunesFeature::ITunesFeature(QObject* parent, TrackCollection* pTrackCollection)
         : BaseExternalLibraryFeature(parent, pTrackCollection),
-          m_pTrackCollection(pTrackCollection),
           m_cancelImport(false),
           m_icon(":/images/library/ic_library_itunes.svg") {
     QString tableName = "itunes_library";

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -58,7 +58,6 @@ class ITunesFeature : public BaseExternalLibraryFeature {
     BaseExternalPlaylistModel* m_pITunesPlaylistModel;
     TreeItemModel m_childModel;
     QStringList m_playlists;
-    TrackCollection* m_pTrackCollection;
     // a new DB connection for the worker thread
     QSqlDatabase m_database;
     bool m_cancelImport;

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -315,9 +315,8 @@ void Library::bindLibraryWidget(WLibrary* pLibraryWidget,
             new WTrackTableView(
                     pLibraryWidget,
                     m_pConfig,
-                    m_pTrackCollection,
-                    true,
-                    m_externalTrackCollections);
+                    this,
+                    true);
     pTrackTableView->installEventFilter(pKeyboard);
     connect(this,
             &Library::showTrackModel,

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -63,6 +63,10 @@ class Library: public QObject,
         return *m_pTrackCollection;
     }
 
+    const QList<ExternalTrackCollection*>& externalTrackCollections() const {
+        return m_externalTrackCollections;
+    }
+
     void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* pKeyboard);
     void bindSidebarWidget(WLibrarySidebar* sidebarWidget);

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -136,7 +136,7 @@ MixxxLibraryFeature::~MixxxLibraryFeature() {
 void MixxxLibraryFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
                                      KeyboardEventFilter* pKeyboard) {
     m_pHiddenView = new DlgHidden(pLibraryWidget, m_pConfig, m_pLibrary,
-                                  m_pTrackCollection, pKeyboard);
+                                  pKeyboard);
     pLibraryWidget->registerView(kHiddenTitle, m_pHiddenView);
     connect(m_pHiddenView,
             &DlgHidden::trackSelected,
@@ -144,7 +144,7 @@ void MixxxLibraryFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
             &MixxxLibraryFeature::trackSelected);
 
     m_pMissingView = new DlgMissing(pLibraryWidget, m_pConfig, m_pLibrary,
-                                    m_pTrackCollection, pKeyboard);
+                                    pKeyboard);
     pLibraryWidget->registerView(kMissingTitle, m_pMissingView);
     connect(m_pMissingView,
             &DlgMissing::trackSelected,

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -20,7 +20,7 @@ DlgRecording::DlgRecording(QWidget* parent, UserSettingsPointer pConfig,
           m_durationRecordedStr("--:--"),
           m_pRecordingManager(pRecordingManager) {
     setupUi(this);
-    m_pTrackTableView = new WTrackTableView(this, pConfig, m_pTrackCollection, true);
+    m_pTrackTableView = new WTrackTableView(this, pConfig, pLibrary, true);
     m_pTrackTableView->installEventFilter(pKeyboard);
 
     connect(m_pTrackTableView,

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -12,7 +12,6 @@
 
 RhythmboxFeature::RhythmboxFeature(QObject* parent, TrackCollection* pTrackCollection)
         : BaseExternalLibraryFeature(parent, pTrackCollection),
-          m_pTrackCollection(pTrackCollection),
           m_cancelImport(false),
           m_icon(":/images/library/ic_library_rhythmbox.svg") {
     QString tableName = "rhythmbox_library";

--- a/src/library/rhythmbox/rhythmboxfeature.h
+++ b/src/library/rhythmbox/rhythmboxfeature.h
@@ -51,7 +51,6 @@ class RhythmboxFeature : public BaseExternalLibraryFeature {
     BaseExternalTrackModel* m_pRhythmboxTrackModel;
     BaseExternalPlaylistModel* m_pRhythmboxPlaylistModel;
 
-    TrackCollection* m_pTrackCollection;
     // new DB object because of threads
     QSqlDatabase m_database;
     bool m_isActivated;

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -63,7 +63,6 @@ bool TraktorPlaylistModel::isColumnHiddenByDefault(int column) {
 
 TraktorFeature::TraktorFeature(QObject* parent, TrackCollection* pTrackCollection)
         : BaseExternalLibraryFeature(parent, pTrackCollection),
-          m_pTrackCollection(pTrackCollection),
           m_cancelImport(false),
           m_icon(":/images/library/ic_library_traktor.svg") {
     QString tableName = "traktor_library";

--- a/src/library/traktor/traktorfeature.h
+++ b/src/library/traktor/traktorfeature.h
@@ -67,7 +67,6 @@ class TraktorFeature : public BaseExternalLibraryFeature {
     static QString getTraktorMusicDatabase();
     // private fields
     TreeItemModel m_childModel;
-    TrackCollection* m_pTrackCollection;
     // A separate db connection for the worker parsing thread
     QSqlDatabase m_database;
     TraktorTrackModel* m_pTraktorTableModel;

--- a/src/widget/wanalysislibrarytableview.cpp
+++ b/src/widget/wanalysislibrarytableview.cpp
@@ -3,8 +3,8 @@
 
 WAnalysisLibraryTableView::WAnalysisLibraryTableView(QWidget* parent,
                                                    UserSettingsPointer pConfig,
-                                                   TrackCollection* pTrackCollection)
-        : WTrackTableView(parent, pConfig, pTrackCollection, true) {
+                                                   Library* pLibrary)
+        : WTrackTableView(parent, pConfig, pLibrary, true) {
     setDragDropMode(QAbstractItemView::DragOnly);
     setDragEnabled(true); //Always enable drag for now (until we have a model that doesn't support this.)
 }

--- a/src/widget/wanalysislibrarytableview.h
+++ b/src/widget/wanalysislibrarytableview.h
@@ -6,13 +6,13 @@
 #include "preferences/usersettings.h"
 #include "widget/wtracktableview.h"
 
-class TrackCollection;
+class Library;
 
 class WAnalysisLibraryTableView : public WTrackTableView
 {
     public:
         WAnalysisLibraryTableView(QWidget* parent, UserSettingsPointer pConfig,
-                                 TrackCollection* pTrackCollection);
+                                 Library* pLibrary);
 
         void onSearch(const QString& text) override;
 };

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -6,18 +6,16 @@
 
 #include "preferences/usersettings.h"
 #include "control/controlproxy.h"
-#include "library/coverart.h"
-#include "library/dlgtagfetcher.h"
-#include "library/libraryview.h"
-#include "library/trackcollection.h"
+#include "library/dao/playlistdao.h"
 #include "library/trackmodel.h" // Can't forward declare enums
 #include "track/track.h"
 #include "util/duration.h"
 #include "widget/wlibrarytableview.h"
 
 class ControlProxy;
+class DlgTagFetcher;
 class DlgTrackInfo;
-class TrackCollection;
+class Library;
 class WCoverArtMenu;
 
 class ExternalTrackCollection;
@@ -32,9 +30,8 @@ class WTrackTableView : public WLibraryTableView {
     WTrackTableView(
             QWidget* parent,
             UserSettingsPointer pConfig,
-            TrackCollection* pTrackCollection,
-            bool sorting,
-            const QList<ExternalTrackCollection*>& externalTrackCollections = {});
+            Library* pLibrary,
+            bool sorting);
     ~WTrackTableView() override;
     void contextMenuEvent(QContextMenuEvent * event) override;
     void onSearch(const QString& text) override;
@@ -108,11 +105,11 @@ class WTrackTableView : public WLibraryTableView {
     void keyNotationChanged();
 
   private:
+    void createActions();
 
     void sendToAutoDJ(PlaylistDAO::AutoDJSendLoc loc);
     void showTrackInfo(QModelIndex index);
     void showDlgTagFetcher(QModelIndex index);
-    void createActions(const QList<ExternalTrackCollection*>& externalTrackCollections);
     void dragMoveEvent(QDragMoveEvent * event) override;
     void dragEnterEvent(QDragEnterEvent * event) override;
     void dropEvent(QDropEvent * event) override;
@@ -131,7 +128,7 @@ class WTrackTableView : public WLibraryTableView {
     bool modelHasCapabilities(TrackModel::CapabilitiesFlags capabilities) const;
 
     UserSettingsPointer m_pConfig;
-    TrackCollection* m_pTrackCollection;
+    Library* m_pLibrary;
 
     QSignalMapper m_loadTrackMapper;
 
@@ -139,7 +136,6 @@ class WTrackTableView : public WLibraryTableView {
     QScopedPointer<DlgTagFetcher> m_pTagFetcher;
 
     QModelIndex currentTrackInfoIndex;
-
 
     ControlProxy* m_pNumSamplers;
     ControlProxy* m_pNumDecks;


### PR DESCRIPTION
Cleanup after support for external track collections has been added. A straight-forward refactoring, no functional changes:

- It is a prerequisite for moving functionality that is independent of the internal database from `TrackCollection` up into `Library`
- Eliminates redundant constructor parameters in dependent classes

More to follow. The dependency hell around `TrackCollection` and `Library` is ridiculous and complicates any future enhancements.