### PR TITLE
Refactoring: Reduce dependencies on TrackDAO

### DIFF
--- a/src/analyzer/trackanalysisscheduler.cpp
+++ b/src/analyzer/trackanalysisscheduler.cpp
@@ -275,7 +275,7 @@ bool TrackAnalysisScheduler::submitNextTrack(Worker* worker) {
         DEBUG_ASSERT(nextTrackId.isValid());
         if (nextTrackId.isValid()) {
             TrackPointer nextTrack =
-                    m_library->trackCollection().getTrackDAO().getTrack(nextTrackId);
+                    m_library->trackCollection().getTrackById(nextTrackId);
             if (nextTrack) {
                 if (m_pendingTrackIds.insert(nextTrackId).second) {
                     if (worker->submitNextTrack(std::move(nextTrack))) {

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -254,7 +254,7 @@ void AutoDJFeature::slotAddRandomTrack() {
             }
 
             if (randomTrackId.isValid()) {
-                pRandomTrack = m_pTrackCollection->getTrackDAO().getTrack(randomTrackId);
+                pRandomTrack = m_pTrackCollection->getTrackById(randomTrackId);
                 VERIFY_OR_DEBUG_ASSERT(pRandomTrack) {
                     qWarning() << "Track does not exist:"
                             << randomTrackId;

--- a/src/library/banshee/bansheeplaylistmodel.cpp
+++ b/src/library/banshee/bansheeplaylistmodel.cpp
@@ -315,8 +315,9 @@ TrackPointer BansheePlaylistModel::getTrack(const QModelIndex& index) const {
     }
 
     bool track_already_in_library = false;
-    TrackPointer pTrack = m_pTrackCollection->getTrackDAO()
-            .getOrAddTrack(location, true, &track_already_in_library);
+    TrackPointer pTrack = m_pTrackCollection->getOrAddTrack(
+            TrackRef::fromFileInfo(location),
+            &track_already_in_library);
 
     // If this track was not in the Mixxx library it is now added and will be
     // saved with the metadata from Banshee. If it was already in the library

--- a/src/library/baseexternalplaylistmodel.cpp
+++ b/src/library/baseexternalplaylistmodel.cpp
@@ -31,8 +31,9 @@ TrackPointer BaseExternalPlaylistModel::getTrack(const QModelIndex& index) const
     }
 
     bool track_already_in_library = false;
-    TrackPointer pTrack = m_pTrackCollection->getTrackDAO()
-            .getOrAddTrack(location, true, &track_already_in_library);
+    TrackPointer pTrack = m_pTrackCollection->getOrAddTrack(
+            TrackRef::fromFileInfo(location),
+            &track_already_in_library);
 
     // If this track was not in the Mixxx library it is now added and will be
     // saved with the metadata from iTunes. If it was already in the library

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -56,8 +56,9 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
     }
 
     bool track_already_in_library = false;
-    TrackPointer pTrack = m_pTrackCollection->getTrackDAO()
-            .getOrAddTrack(location, true, &track_already_in_library);
+    TrackPointer pTrack = m_pTrackCollection->getOrAddTrack(
+            TrackRef::fromFileInfo(location),
+            &track_already_in_library);
 
     if (pTrack) {
         // If this track was not in the Mixxx library it is now added and will be

--- a/src/library/baseplaylistfeature.cpp
+++ b/src/library/baseplaylistfeature.cpp
@@ -5,6 +5,7 @@
 #include <QFileInfo>
 #include <QStandardPaths>
 
+#include "library/dao/playlistdao.h"
 #include "library/export/trackexportwizard.h"
 #include "library/library.h"
 #include "library/parser.h"
@@ -26,7 +27,6 @@ BasePlaylistFeature::BasePlaylistFeature(QObject* parent,
         : LibraryFeature(pConfig, parent),
           m_pTrackCollection(pTrackCollection),
           m_playlistDao(pTrackCollection->getPlaylistDAO()),
-          m_trackDao(pTrackCollection->getTrackDAO()),
           m_pPlaylistTableModel(NULL),
           m_rootViewName(rootViewName) {
     m_pCreatePlaylistAction = new QAction(tr("Create New Playlist"),this);

--- a/src/library/baseplaylistfeature.h
+++ b/src/library/baseplaylistfeature.h
@@ -12,12 +12,11 @@
 #include <QString>
 
 #include "library/libraryfeature.h"
-#include "library/dao/playlistdao.h"
-#include "library/dao/trackdao.h"
 #include "track/track.h"
 
 class WLibrary;
 class KeyboardEventFilter;
+class PlaylistDAO;
 class PlaylistTableModel;
 class TrackCollection;
 class TreeItem;
@@ -89,7 +88,6 @@ class BasePlaylistFeature : public LibraryFeature {
 
     TrackCollection* m_pTrackCollection;
     PlaylistDAO &m_playlistDao;
-    TrackDAO &m_trackDao;
     PlaylistTableModel* m_pPlaylistTableModel;
     QAction *m_pCreatePlaylistAction;
     QAction *m_pDeletePlaylistAction;

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -843,7 +843,7 @@ bool BaseSqlTableModel::setData(
 
     // TODO(rryan) ugly and only works because the mixxx library tables are the
     // only ones that aren't read-only. This should be moved into BTC.
-    TrackPointer pTrack = m_pTrackCollection->getTrackDAO().getTrack(trackId);
+    TrackPointer pTrack = m_pTrackCollection->getTrackById(trackId);
     if (!pTrack) {
         return false;
     }
@@ -919,7 +919,7 @@ TrackId BaseSqlTableModel::getTrackId(const QModelIndex& index) const {
 }
 
 TrackPointer BaseSqlTableModel::getTrack(const QModelIndex& index) const {
-    return m_pTrackCollection->getTrackDAO().getTrack(getTrackId(index));
+    return m_pTrackCollection->getTrackById(getTrackId(index));
 }
 
 QString BaseSqlTableModel::getTrackLocation(const QModelIndex& index) const {

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -56,7 +56,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     //  Functions that might be reimplemented/overridden in derived classes
     ///////////////////////////////////////////////////////////////////////////
     //  This class also has protected variables that should be used in children
-    //  m_database, m_pTrackCollection, m_trackDAO
+    //  m_database, m_pTrackCollection
 
     // calls readWriteFlags() by default, reimplement this if the child calls
     // should be readOnly

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -30,7 +30,6 @@ BaseTrackCache::BaseTrackCache(TrackCollection* pTrackCollection,
           m_columnCache(columns),
           m_bIndexBuilt(false),
           m_bIsCaching(isCaching),
-          m_trackDAO(pTrackCollection->getTrackDAO()),
           m_database(pTrackCollection->database()),
           m_pQueryParser(new SearchQueryParser(pTrackCollection)) {
     m_searchColumns << "artist"

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -147,7 +147,6 @@ class BaseTrackCache : public QObject {
     bool m_bIndexBuilt;
     bool m_bIsCaching;
     QHash<TrackId, QVector<QVariant> > m_trackInfo;
-    TrackDAO& m_trackDAO;
     QSqlDatabase m_database;
     SearchQueryParser* m_pQueryParser;
     ControlProxy* m_pKeyNotationCP;

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -153,13 +153,13 @@ void BrowseTableModel::setPath(const MDir& path) {
 }
 
 TrackPointer BrowseTableModel::getTrack(const QModelIndex& index) const {
-    QString track_location = getTrackLocation(index);
-    if (m_pRecordingManager->getRecordingLocation() == track_location) {
+    QString trackLocation = getTrackLocation(index);
+    if (m_pRecordingManager->getRecordingLocation() == trackLocation) {
         QMessageBox::critical(
             0, tr("Mixxx Library"),
             tr("Could not load the following file because"
                " it is in use by Mixxx or another application.")
-            + "\n" +track_location);
+            + "\n" + trackLocation);
         return TrackPointer();
     }
     // NOTE(uklotzde, 2015-12-08): Accessing tracks from the browse view
@@ -170,8 +170,8 @@ TrackPointer BrowseTableModel::getTrack(const QModelIndex& index) const {
     // them edit the tracks in a way that persists across sessions
     // and we didn't want to edit the files on disk by default
     // unless the user opts in to that.
-    return m_pTrackCollection->getTrackDAO()
-            .getOrAddTrack(track_location, true, NULL);
+    return m_pTrackCollection->getOrAddTrack(
+            TrackRef::fromFileInfo(trackLocation));
 }
 
 QString BrowseTableModel::getTrackLocation(const QModelIndex& index) const {

--- a/src/library/dao/autodjcratesdao.cpp
+++ b/src/library/dao/autodjcratesdao.cpp
@@ -710,8 +710,8 @@ TrackId AutoDJCratesDAO::getRandomTrackIdFromAutoDj(int percentActive) {
 // Signaled by the track DAO when a track's information is updated.
 void AutoDJCratesDAO::slotTrackDirty(TrackId trackId) {
     // Update our record of the number of times played, if that changed.
-    TrackPointer pTrack = m_pTrackCollection->getTrackDAO().getTrack(trackId);
-    if (pTrack == NULL) {
+    TrackPointer pTrack = m_pTrackCollection->getTrackById(trackId);
+    if (!pTrack) {
         return;
     }
     const PlayCounter playCounter(pTrack->getPlayCounter());

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1745,7 +1745,7 @@ bool TrackDAO::detectMovedTracks(QList<QPair<TrackRef, TrackRef>>* pReplacedTrac
     return true;
 }
 
-void TrackDAO::markTracksAsMixxxDeleted(const QDir& rootDir) {
+void TrackDAO::hideAllTracks(const QDir& rootDir) {
     // Capture entries that start with the directory prefix dir.
     // dir needs to end in a slash otherwise we might match other
     // directories.

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1745,11 +1745,11 @@ bool TrackDAO::detectMovedTracks(QList<QPair<TrackRef, TrackRef>>* pReplacedTrac
     return true;
 }
 
-void TrackDAO::markTracksAsMixxxDeleted(const QString& dir) {
+void TrackDAO::markTracksAsMixxxDeleted(const QDir& rootDir) {
     // Capture entries that start with the directory prefix dir.
     // dir needs to end in a slash otherwise we might match other
     // directories.
-    QString likeClause = SqlLikeWildcardEscaper::apply(dir + "/", kSqlLikeMatchAll) + kSqlLikeMatchAll;
+    QString likeClause = SqlLikeWildcardEscaper::apply(rootDir.absolutePath() + "/", kSqlLikeMatchAll) + kSqlLikeMatchAll;
 
     QSqlQuery query(m_database);
     query.prepare(QString("SELECT library.id FROM library INNER JOIN track_locations "
@@ -1758,7 +1758,7 @@ void TrackDAO::markTracksAsMixxxDeleted(const QString& dir) {
                   .arg(SqlStringFormatter::format(m_database, likeClause), kSqlLikeMatchAll));
 
     if (!query.exec()) {
-        LOG_FAILED_QUERY(query) << "could not get tracks within directory:" << dir;
+        LOG_FAILED_QUERY(query) << "could not get tracks within directory:" << rootDir;
     }
 
     QStringList trackIds;

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -64,39 +64,12 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     TrackId addTracksAddTrack(const TrackPointer& pTrack, bool unremove);
     void addTracksFinish(bool rollback = false);
 
-    bool hideTracks(
-            const QList<TrackId>& trackIds);
-    void afterHidingTracks(
-            const QList<TrackId>& trackIds);
-
-    bool unhideTracks(
-            const QList<TrackId>& trackIds);
-    void afterUnhidingTracks(
-            const QList<TrackId>& trackIds);
-
-    bool onPurgingTracks(
-            const QList<TrackId>& trackIds);
-    void afterPurgingTracks(
-            const QList<TrackId>& trackIds);
-
-    void markTracksAsMixxxDeleted(const QString& dir);
-
-    // Scanning related calls. Should be elsewhere or private somehow.
-    void markTrackLocationsAsVerified(const QStringList& locations);
-    void markTracksInDirectoriesAsVerified(const QStringList& directories);
-    void invalidateTrackLocationsInLibrary();
-    void markUnverifiedTracksAsDeleted();
+    // Only used by friend class LibraryScanner, but public for testing!
     bool detectMovedTracks(QList<QPair<TrackRef, TrackRef>>* pReplacedTracks,
                           const QStringList& addedTracks,
                           volatile const bool* pCancel);
 
-    bool verifyRemainingTracks(
-            const QStringList& libraryRootDirs,
-            volatile const bool* pCancel);
-
-    void detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
-                                        QSet<TrackId>* pTracksChanged);
-
+    // Only used by friend class TrackCollection, but public for testing!
     void saveTrack(Track* pTrack);
 
   signals:
@@ -121,9 +94,9 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     void slotTrackClean(Track* pTrack);
 
   private:
+    friend class LibraryScanner;
     friend class TrackCollection;
 
-    // WARNING: Only call this from the main thread instance of TrackDAO.
     TrackPointer getTrackById(TrackId trackId) const;
 
     // Fetches trackLocation from the database or adds it. If searchForCoverArt
@@ -137,6 +110,36 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
                 bool* pAlreadyInLibrary = nullptr);
 
     bool updateTrack(Track* pTrack);
+
+    void hideAllTracks(const QDir& rootDir);
+
+    bool hideTracks(
+            const QList<TrackId>& trackIds);
+    void afterHidingTracks(
+            const QList<TrackId>& trackIds);
+
+    bool unhideTracks(
+            const QList<TrackId>& trackIds);
+    void afterUnhidingTracks(
+            const QList<TrackId>& trackIds);
+
+    bool onPurgingTracks(
+            const QList<TrackId>& trackIds);
+    void afterPurgingTracks(
+            const QList<TrackId>& trackIds);
+
+    // Scanning related calls.
+    void markTrackLocationsAsVerified(const QStringList& locations);
+    void markTracksInDirectoriesAsVerified(const QStringList& directories);
+    void invalidateTrackLocationsInLibrary();
+    void markUnverifiedTracksAsDeleted();
+
+    bool verifyRemainingTracks(
+            const QStringList& libraryRootDirs,
+            volatile const bool* pCancel);
+
+    void detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
+                                        QSet<TrackId>* pTracksChanged);
 
     // Callback for GlobalTrackCache
     TrackFile relocateCachedTrack(

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -52,9 +52,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             ResolveTrackIdFlags flags);
     QList<TrackId> getAllTrackIds(const QDir& rootDir);
 
-    // WARNING: Only call this from the main thread instance of TrackDAO.
-    TrackPointer getTrack(TrackId trackId) const;
-
     // Returns a set of all track locations in the library.
     QSet<QString> getTrackLocations();
     QString getTrackLocation(TrackId trackId);
@@ -81,16 +78,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             const QList<TrackId>& trackIds);
     void afterPurgingTracks(
             const QList<TrackId>& trackIds);
-
-    // Fetches trackLocation from the database or adds it. If searchForCoverArt
-    // is true, searches the track and its directory for cover art via
-    // asynchronous request to CoverArtCache. If adding or fetching the track
-    // fails, returns a transient TrackPointer for trackLocation. If
-    // pAlreadyInLibrary is non-NULL, sets it to whether trackLocation was
-    // already in the database.
-    TrackPointer getOrAddTrack(const QString& trackLocation,
-                               bool processCoverArt,
-                               bool* pAlreadyInLibrary);
 
     void markTracksAsMixxxDeleted(const QString& dir);
 
@@ -134,7 +121,20 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     void slotTrackClean(Track* pTrack);
 
   private:
-    TrackPointer getTrackFromDB(TrackId trackId) const;
+    friend class TrackCollection;
+
+    // WARNING: Only call this from the main thread instance of TrackDAO.
+    TrackPointer getTrackById(TrackId trackId) const;
+
+    // Fetches trackLocation from the database or adds it. If searchForCoverArt
+    // is true, searches the track and its directory for cover art via
+    // asynchronous request to CoverArtCache. If adding or fetching the track
+    // fails, returns a transient TrackPointer for trackLocation. If
+    // pAlreadyInLibrary is non-NULL, sets it to whether trackLocation was
+    // already in the database.
+    TrackPointer getOrAddTrackByLocation(
+                const QString& trackLocation,
+                bool* pAlreadyInLibrary = nullptr);
 
     bool updateTrack(Track* pTrack);
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -508,7 +508,7 @@ void Library::slotRequestRemoveDir(QString dir, RemovalType removalType) {
         case Library::HideTracks:
             // Mark all tracks in this directory as deleted but DON'T purge them
             // in case the user re-adds them manually.
-            m_pTrackCollection->getTrackDAO().markTracksAsMixxxDeleted(dir);
+            m_pTrackCollection->hideAllTracks(dir);
             break;
         case Library::PurgeTracks:
             // The user requested that we purge all metadata.

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -443,8 +443,8 @@ void Library::slotLoadTrack(TrackPointer pTrack) {
 }
 
 void Library::slotLoadLocationToPlayer(QString location, QString group) {
-    TrackPointer pTrack = m_pTrackCollection->getTrackDAO()
-            .getOrAddTrack(location, true, NULL);
+    auto trackRef = TrackRef::fromFileInfo(location);
+    TrackPointer pTrack = m_pTrackCollection->getOrAddTrack(trackRef);
     if (pTrack) {
         emit(loadTrackToPlayer(pTrack, group));
     }

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -91,7 +91,7 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
     BaseTrackCache* pBaseTrackCache = new BaseTrackCache(
             pTrackCollection, tableName, LIBRARYTABLE_ID, columns, true);
 
-    auto pTrackDAO = &pTrackCollection.getTrackDAO();
+    auto pTrackDAO = &pTrackCollection->getTrackDAO();
     connect(pTrackDAO,
             &TrackDAO::trackDirty,
             pBaseTrackCache,

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -30,7 +30,6 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
           m_pLibrary(pLibrary),
           m_pMissingView(NULL),
           m_pHiddenView(NULL),
-          m_trackDao(pTrackCollection->getTrackDAO()),
           m_pConfig(pConfig),
           m_pTrackCollection(pTrackCollection),
           m_icon(":/images/library/ic_library_tracks.svg") {
@@ -91,27 +90,29 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
 
     BaseTrackCache* pBaseTrackCache = new BaseTrackCache(
             pTrackCollection, tableName, LIBRARYTABLE_ID, columns, true);
-    connect(&m_trackDao,
+
+    auto pTrackDAO = &pTrackCollection.getTrackDAO();
+    connect(pTrackDAO,
             &TrackDAO::trackDirty,
             pBaseTrackCache,
             &BaseTrackCache::slotTrackDirty);
-    connect(&m_trackDao,
+    connect(pTrackDAO,
             &TrackDAO::trackClean,
             pBaseTrackCache,
             &BaseTrackCache::slotTrackClean);
-    connect(&m_trackDao,
+    connect(pTrackDAO,
             &TrackDAO::trackChanged,
             pBaseTrackCache,
             &BaseTrackCache::slotTrackChanged);
-    connect(&m_trackDao,
+    connect(pTrackDAO,
             &TrackDAO::tracksAdded,
             pBaseTrackCache,
             &BaseTrackCache::slotTracksAdded);
-    connect(&m_trackDao,
+    connect(pTrackDAO,
             &TrackDAO::tracksRemoved,
             pBaseTrackCache,
             &BaseTrackCache::slotTracksRemoved);
-    connect(&m_trackDao,
+    connect(pTrackDAO,
             &TrackDAO::dbTrackAdded,
             pBaseTrackCache,
             &BaseTrackCache::slotDbTrackAdded);

--- a/src/library/mixxxlibraryfeature.h
+++ b/src/library/mixxxlibraryfeature.h
@@ -60,7 +60,6 @@ class MixxxLibraryFeature : public LibraryFeature {
     DlgMissing* m_pMissingView;
     DlgHidden* m_pHiddenView;
     TreeItemModel m_childModel;
-    TrackDAO& m_trackDao;
     UserSettingsPointer m_pConfig;
     TrackCollection* m_pTrackCollection;
     QIcon m_icon;

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -1,19 +1,20 @@
+#include <QApplication>
 #include <QStringBuilder>
 #include <QThread>
-#include <QApplication>
 
 #include "library/trackcollection.h"
 
 #include "sources/soundsourceproxy.h"
 #include "track/globaltrackcache.h"
-#include "util/logger.h"
-#include "util/db/sqltransaction.h"
-
 #include "util/assert.h"
+#include "util/db/sqltransaction.h"
 #include "util/dnd.h"
+#include "util/logger.h"
 
 namespace {
-    mixxx::Logger kLogger("TrackCollection");
+
+mixxx::Logger kLogger("TrackCollection");
+
 } // anonymous namespace
 
 TrackCollection::TrackCollection(
@@ -216,6 +217,10 @@ bool TrackCollection::hideTracks(const QList<TrackId>& trackIds) {
     emit(crateSummaryChanged(modifiedCrateSummaries));
 
     return true;
+}
+
+void TrackCollection::hideAllTracks(const QDir& rootDir) {
+    m_trackDao.markTracksAsMixxxDeleted(rootDir);
 }
 
 bool TrackCollection::unhideTracks(const QList<TrackId>& trackIds) {

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -220,7 +220,7 @@ bool TrackCollection::hideTracks(const QList<TrackId>& trackIds) {
 }
 
 void TrackCollection::hideAllTracks(const QDir& rootDir) {
-    m_trackDao.markTracksAsMixxxDeleted(rootDir);
+    m_trackDao.hideAllTracks(rootDir);
 }
 
 bool TrackCollection::unhideTracks(const QList<TrackId>& trackIds) {

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -443,3 +443,26 @@ void TrackCollection::saveTrack(Track* pTrack) {
 
     m_trackDao.saveTrack(pTrack);
 }
+
+TrackPointer TrackCollection::getTrackById(
+        const TrackId& trackId) const {
+    return m_trackDao.getTrackById(trackId);
+}
+
+TrackPointer TrackCollection::getOrAddTrack(
+        const TrackRef& trackRef,
+        bool* pAlreadyInLibrary) {
+    TrackPointer pTrack;
+    if (trackRef.hasId()) {
+        pTrack = getTrackById(trackRef.getId());
+        if (pAlreadyInLibrary) {
+            *pAlreadyInLibrary = pTrack != nullptr;
+        }
+    }
+    if (!pTrack && trackRef.hasLocation()) {
+        pTrack = m_trackDao.getOrAddTrackByLocation(
+                trackRef.getLocation(),
+                pAlreadyInLibrary);
+    }
+    return pTrack;
+}

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -1,12 +1,11 @@
-#ifndef TRACKCOLLECTION_H
-#define TRACKCOLLECTION_H
+#pragma once
 
+#include <QDir>
 #include <QList>
 #include <QSharedPointer>
 #include <QSqlDatabase>
 
 #include "preferences/usersettings.h"
-#include "library/basetrackcache.h"
 #include "library/crate/cratestorage.h"
 #include "library/dao/trackdao.h"
 #include "library/dao/cuedao.h"
@@ -15,11 +14,9 @@
 #include "library/dao/directorydao.h"
 #include "library/dao/libraryhashdao.h"
 
+class BaseTrackCache;
 
-// forward declaration(s)
-class Track;
-
-// Manages everything around tracks.
+// Manages the internal database.
 class TrackCollection : public QObject,
     public virtual /*implements*/ SqlStorage {
     Q_OBJECT
@@ -111,8 +108,12 @@ class TrackCollection : public QObject,
   private:
     friend class Library;
     friend class Upgrade;
+
+    void hideAllTracks(const QDir& rootDir);
+
     bool purgeTracks(const QList<TrackId>& trackIds);
     bool purgeAllTracks(const QDir& rootDir);
+
     bool addDirectory(const QString& dir);
     void relocateDirectory(QString oldDir, QString newDir);
 
@@ -130,5 +131,3 @@ class TrackCollection : public QObject,
 
     QSharedPointer<BaseTrackCache> m_pTrackSource;
 };
-
-#endif // TRACKCOLLECTION_H

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -81,14 +81,14 @@ class TrackCollection : public QObject,
 
     bool updateAutoDjCrate(CrateId crateId, bool isAutoDjSource);
 
+    // Might be called from any thread
+    void exportTrackMetadata(Track* pTrack) const;
+
     TrackPointer getTrackById(
             const TrackId& trackId) const;
     TrackPointer getOrAddTrack(
             const TrackRef& trackRef,
             bool* pAlreadyInLibrary = nullptr);
-
-    // Might be called from any thread
-    void exportTrackMetadata(Track* pTrack) const;
 
     // Must be called from the main thread
     void saveTrack(Track* pTrack);

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -84,6 +84,12 @@ class TrackCollection : public QObject,
 
     bool updateAutoDjCrate(CrateId crateId, bool isAutoDjSource);
 
+    TrackPointer getTrackById(
+            const TrackId& trackId) const;
+    TrackPointer getOrAddTrack(
+            const TrackRef& trackRef,
+            bool* pAlreadyInLibrary = nullptr);
+
     // Might be called from any thread
     void exportTrackMetadata(Track* pTrack) const;
 

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -606,7 +606,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped) {
 
     // Load the track and mark it playing (as the loadTrackToPlayer signal would
     // have connected to this eventually).
-    TrackPointer pTrack = collection()->getTrackDAO().getTrack(testId);
+    TrackPointer pTrack = collection()->getTrackById(testId);
     deck1.slotLoadTrack(pTrack, true);
 
     // Signal that the request to load pTrack succeeded.


### PR DESCRIPTION
Another attempt to reduce some dependencies within the library. `TrackDAO` should primarily be accessed by `TrackCollection` or `LibraryScanner`.

No functional changes, except:
- The `processCoverArt` parameter was redundant as `true` was the only value that was passed