### PR TITLE
Fix some warnings

### DIFF
--- a/src/controllers/controlleroutputmappingtablemodel.h
+++ b/src/controllers/controlleroutputmappingtablemodel.h
@@ -35,7 +35,7 @@ class ControllerOutputMappingTableModel : public ControllerMappingTableModel {
     // QAbstractItemModel methods
     ////////////////////////////////////////////////////////////////////////////
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
-    int columnCount(const QModelIndex& parent = QModelIndex()) const;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
     bool setData(const QModelIndex& index, const QVariant& value,
                  int role = Qt::EditRole) override;

--- a/src/effects/builtin/loudnesscontoureffect.h
+++ b/src/effects/builtin/loudnesscontoureffect.h
@@ -47,7 +47,7 @@ class LoudnessContourEffect
                         const CSAMPLE* pInput, CSAMPLE *pOutput,
                         const mixxx::EngineParameters& bufferParameters,
                         const EffectEnableState enableState,
-                        const GroupFeatureState& groupFeatureState);
+                        const GroupFeatureState& groupFeatureState) override;
 
   private:
     LoudnessContourEffect(const LoudnessContourEffect&) = delete;

--- a/src/effects/builtin/threebandbiquadeqeffect.h
+++ b/src/effects/builtin/threebandbiquadeqeffect.h
@@ -58,7 +58,7 @@ class ThreeBandBiquadEQEffect : public EffectProcessorImpl<ThreeBandBiquadEQEffe
                         const CSAMPLE* pInput, CSAMPLE *pOutput,
                         const mixxx::EngineParameters& bufferParameters,
                         const EffectEnableState enableState,
-                        const GroupFeatureState& groupFeatureState);
+                        const GroupFeatureState& groupFeatureState) override;
 
   private:
     ThreeBandBiquadEQEffect(const ThreeBandBiquadEQEffect&) = delete;

--- a/src/effects/effectrack.h
+++ b/src/effects/effectrack.h
@@ -187,7 +187,7 @@ class QuickEffectRack : public PerGroupRack {
     }
 
     QString formatEffectSlotGroupString(const unsigned int iEffectSlotNumber,
-                                        const QString& group) const {
+                                        const QString& group) const override {
         return formatEffectSlotGroupString(getRackNumber(), iEffectSlotNumber,
                                            group);
     }
@@ -203,7 +203,7 @@ class QuickEffectRack : public PerGroupRack {
 
     virtual QString formatEffectChainSlotGroupForGroup(const unsigned int iRackNumber,
                                                        const unsigned int iChainSlotNumber,
-                                                       const QString& group) const {
+                                                       const QString& group) const override {
         Q_UNUSED(iChainSlotNumber);
         return formatEffectChainSlotGroupString(iRackNumber, group);
     }
@@ -239,7 +239,7 @@ class EqualizerRack : public PerGroupRack {
     }
 
     QString formatEffectSlotGroupString(const unsigned int iEffectSlotNumber,
-                                        const QString& group) const {
+                                        const QString& group) const override {
         return formatEffectSlotGroupString(getRackNumber(), iEffectSlotNumber,
                                            group);
     }
@@ -254,7 +254,7 @@ class EqualizerRack : public PerGroupRack {
                                           const QString& group) override;
     virtual QString formatEffectChainSlotGroupForGroup(const unsigned int iRackNumber,
                                                        const unsigned int iChainSlotNumber,
-                                                       const QString& group) const {
+                                                       const QString& group) const override {
         Q_UNUSED(iChainSlotNumber);
         return formatEffectChainSlotGroupString(iRackNumber, group);
     }

--- a/src/effects/effectrack.h
+++ b/src/effects/effectrack.h
@@ -201,9 +201,9 @@ class QuickEffectRack : public PerGroupRack {
     void configureEffectChainSlotForGroup(EffectChainSlotPointer pSlot,
                                           const QString& group) override;
 
-    virtual QString formatEffectChainSlotGroupForGroup(const unsigned int iRackNumber,
-                                                       const unsigned int iChainSlotNumber,
-                                                       const QString& group) const override {
+    QString formatEffectChainSlotGroupForGroup(const unsigned int iRackNumber,
+                                               const unsigned int iChainSlotNumber,
+                                               const QString& group) const override {
         Q_UNUSED(iChainSlotNumber);
         return formatEffectChainSlotGroupString(iRackNumber, group);
     }
@@ -252,9 +252,9 @@ class EqualizerRack : public PerGroupRack {
   protected:
     void configureEffectChainSlotForGroup(EffectChainSlotPointer pSlot,
                                           const QString& group) override;
-    virtual QString formatEffectChainSlotGroupForGroup(const unsigned int iRackNumber,
-                                                       const unsigned int iChainSlotNumber,
-                                                       const QString& group) const override {
+    QString formatEffectChainSlotGroupForGroup(const unsigned int iRackNumber,
+                                               const unsigned int iChainSlotNumber,
+                                               const QString& group) const override {
         Q_UNUSED(iChainSlotNumber);
         return formatEffectChainSlotGroupString(iRackNumber, group);
     }

--- a/src/effects/lv2/lv2manifest.h
+++ b/src/effects/lv2/lv2manifest.h
@@ -42,7 +42,6 @@ class LV2Manifest {
     float* m_maximum;
     float* m_default;
     Status m_status;
-    bool m_isValid;
 };
 
 #endif // LV2MANIFEST_H

--- a/src/encoder/encodervorbissettings.h
+++ b/src/encoder/encodervorbissettings.h
@@ -30,8 +30,8 @@ class EncoderVorbisSettings : public EncoderSettings {
     // Sets the quality value by its index
     void setQualityByIndex(int qualityIndex) override;
     // Returns the current quality value
-    virtual int getQuality() const override;
-    virtual int getQualityIndex() const override;
+    int getQuality() const override;
+    int getQualityIndex() const override;
 
   private:
     QList<int> m_qualList;

--- a/src/engine/sidechain/enginenetworkstream.cpp
+++ b/src/engine/sidechain/enginenetworkstream.cpp
@@ -44,8 +44,7 @@ EngineNetworkStream::EngineNetworkStream(int numOutputChannels,
       m_inputStreamStartTimeUs(-1),
       m_inputStreamFramesWritten(0),
       m_inputStreamFramesRead(0),
-      m_outputWorkers(BROADCAST_MAX_CONNECTIONS),
-      m_pInputWorker(nullptr) {
+      m_outputWorkers(BROADCAST_MAX_CONNECTIONS) {
     if (numInputChannels) {
         m_pInputFifo = new FIFO<CSAMPLE>(numInputChannels * kBufferFrames);
     }

--- a/src/engine/sidechain/enginenetworkstream.h
+++ b/src/engine/sidechain/enginenetworkstream.h
@@ -61,7 +61,6 @@ class EngineNetworkStream {
     // the workers are then performed on thread-safe QSharedPointers and not
     // onto the thread-unsafe QVector
     QVector<NetworkOutputStreamWorkerPtr> m_outputWorkers;
-    NetworkInputStreamWorker* m_pInputWorker;
 };
 
 #endif /* ENGINENETWORKSTREAM_H_ */

--- a/src/engine/sidechain/enginerecord.h
+++ b/src/engine/sidechain/enginerecord.h
@@ -26,8 +26,8 @@ class EngineRecord : public QObject, public EncoderCallback, public SideChainWor
     EngineRecord(UserSettingsPointer pConfig);
     virtual ~EngineRecord();
 
-    void process(const CSAMPLE* pBuffer, const int iBufferSize);
-    void shutdown() {}
+    void process(const CSAMPLE* pBuffer, const int iBufferSize) override;
+    void shutdown() override {}
 
     // writes compressed audio to file
     void write(const unsigned char *header, const unsigned char *body, int headerLen, int bodyLen) override;

--- a/src/engine/sidechain/networkinputstreamworker.cpp
+++ b/src/engine/sidechain/networkinputstreamworker.cpp
@@ -3,9 +3,7 @@
 
 #include <engine/sidechain/networkinputstreamworker.h>
 
-NetworkInputStreamWorker::NetworkInputStreamWorker()
-    : m_sampleRate(0),
-      m_numInputChannels(0) {
+NetworkInputStreamWorker::NetworkInputStreamWorker() {
 }
 
 NetworkInputStreamWorker::~NetworkInputStreamWorker() {

--- a/src/engine/sidechain/networkinputstreamworker.h
+++ b/src/engine/sidechain/networkinputstreamworker.h
@@ -13,10 +13,6 @@ class NetworkInputStreamWorker {
     virtual ~NetworkInputStreamWorker();
 
     void setSourceFifo(FIFO<CSAMPLE>* pFifo);
-
-  private:
-    double m_sampleRate;
-    int m_numInputChannels;
 };
 
 #endif // ENGINE_SIDECHAIN_NETWORKINPUTSTREAMWORKER_H

--- a/src/engine/sidechain/shoutconnection.h
+++ b/src/engine/sidechain/shoutconnection.h
@@ -41,9 +41,9 @@ class ShoutConnection
 
     // This is called by the Engine implementation for each sample. Encode and
     // send the stream, as well as check for metadata changes.
-    void process(const CSAMPLE* pBuffer, const int iBufferSize);
+    void process(const CSAMPLE* pBuffer, const int iBufferSize) override;
 
-    void shutdown() {
+    void shutdown() override {
     }
 
     // Called by the encoder in method 'encodebuffer()' to flush the stream to
@@ -62,11 +62,11 @@ class ShoutConnection
     bool isConnected();
     void applySettings();
 
-    virtual void outputAvailable();
-    virtual void setOutputFifo(QSharedPointer<FIFO<CSAMPLE>> pOutputFifo);
-    QSharedPointer<FIFO<CSAMPLE>> getOutputFifo();
-    virtual bool threadWaiting();
-    virtual void run();
+    virtual void outputAvailable() override;
+    virtual void setOutputFifo(QSharedPointer<FIFO<CSAMPLE>> pOutputFifo) override;
+    QSharedPointer<FIFO<CSAMPLE>> getOutputFifo() override;
+    virtual bool threadWaiting() override;
+    virtual void run() override;
 
     BroadcastProfilePtr profile() {
         return m_pProfile;

--- a/src/engine/sidechain/shoutconnection.h
+++ b/src/engine/sidechain/shoutconnection.h
@@ -62,11 +62,11 @@ class ShoutConnection
     bool isConnected();
     void applySettings();
 
-    virtual void outputAvailable() override;
-    virtual void setOutputFifo(QSharedPointer<FIFO<CSAMPLE>> pOutputFifo) override;
+    void outputAvailable() override;
+    void setOutputFifo(QSharedPointer<FIFO<CSAMPLE>> pOutputFifo) override;
     QSharedPointer<FIFO<CSAMPLE>> getOutputFifo() override;
-    virtual bool threadWaiting() override;
-    virtual void run() override;
+    bool threadWaiting() override;
+    void run() override;
 
     BroadcastProfilePtr profile() {
         return m_pProfile;

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -24,34 +24,34 @@ class SyncControl : public EngineControl, public Syncable {
                 EngineChannel* pChannel, SyncableListener* pEngineSync);
     ~SyncControl() override;
 
-    const QString& getGroup() const { return m_sGroup; }
-    EngineChannel* getChannel() const { return m_pChannel; }
-    double getBpm() const;
+    const QString& getGroup() const override { return m_sGroup; }
+    EngineChannel* getChannel() const override { return m_pChannel; }
+    double getBpm() const override;
 
-    SyncMode getSyncMode() const;
-    void notifySyncModeChanged(SyncMode mode);
-    void notifyOnlyPlayingSyncable();
-    void requestSync();
-    bool isPlaying() const;
+    SyncMode getSyncMode() const override;
+    void notifySyncModeChanged(SyncMode mode) override;
+    void notifyOnlyPlayingSyncable() override;
+    void requestSync() override;
+    bool isPlaying() const override;
 
-    double getBeatDistance() const;
+    double getBeatDistance() const override;
     void setBeatDistance(double beatDistance);
-    double getBaseBpm() const;
+    double getBaseBpm() const override;
     void setLocalBpm(double local_bpm);
 
     // Must never result in a call to
     // SyncableListener::notifyBeatDistanceChanged or signal loops could occur.
-    void setMasterBeatDistance(double beatDistance);
-    void setMasterBaseBpm(double);
+    void setMasterBeatDistance(double beatDistance) override;
+    void setMasterBaseBpm(double) override;
     // Must never result in a call to
     // SyncableListener::notifyBpmChanged or signal loops could occur.
-    void setMasterBpm(double bpm);
-    void setMasterParams(double beatDistance, double baseBpm, double bpm);
+    void setMasterBpm(double bpm) override;
+    void setMasterParams(double beatDistance, double baseBpm, double bpm) override;
 
     // Must never result in a call to
     // SyncableListener::notifyInstantaneousBpmChanged or signal loops could
     // occur.
-    void setInstantaneousBpm(double bpm);
+    void setInstantaneousBpm(double bpm) override;
 
     void setEngineControls(RateControl* pRateControl, BpmControl* pBpmControl);
 

--- a/src/library/analysisfeature.h
+++ b/src/library/analysisfeature.h
@@ -30,22 +30,22 @@ class AnalysisFeature : public LibraryFeature {
 
     void stop();
 
-    QVariant title();
-    QIcon getIcon();
+    QVariant title() override;
+    QIcon getIcon() override;
 
-    bool dropAccept(QList<QUrl> urls, QObject* pSource);
-    bool dragMoveAccept(QUrl url);
+    bool dropAccept(QList<QUrl> urls, QObject* pSource) override;
+    bool dragMoveAccept(QUrl url) override;
     void bindLibraryWidget(WLibrary* libraryWidget,
-                    KeyboardEventFilter* keyboard);
+                    KeyboardEventFilter* keyboard) override;
 
-    TreeItemModel* getChildModel();
+    TreeItemModel* getChildModel() override;
     void refreshLibraryModels();
 
   signals:
     void analysisActive(bool bActive);
 
   public slots:
-    void activate();
+    void activate() override;
     void analyzeTracks(QList<TrackId> trackIds);
 
     void suspendAnalysis();

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -207,7 +207,7 @@ void AutoDJFeature::slotCrateChanged(CrateId crateId) {
         for (int i = 0; i < m_crateList.length(); ++i) {
             if (m_crateList[i].getId() == crateId) {
                 QModelIndex parentIndex = m_childModel.index(0, 0);
-                QModelIndex childIndex = parentIndex.child(i, 0);
+                QModelIndex childIndex = m_childModel.index(i, 0, parentIndex);
                 m_childModel.setData(childIndex, crate.getName(), Qt::DisplayRole);
                 m_crateList[i] = crate;
                 return; // early exit

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -39,27 +39,27 @@ class AutoDJFeature : public LibraryFeature {
                   TrackCollection* pTrackCollection);
     virtual ~AutoDJFeature();
 
-    QVariant title();
-    QIcon getIcon();
+    QVariant title() override;
+    QIcon getIcon() override;
 
-    bool dropAccept(QList<QUrl> urls, QObject* pSource);
-    bool dragMoveAccept(QUrl url);
+    bool dropAccept(QList<QUrl> urls, QObject* pSource) override;
+    bool dragMoveAccept(QUrl url) override;
 
     void bindLibraryWidget(WLibrary* libraryWidget,
-                    KeyboardEventFilter* keyboard);
-    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget);
+                    KeyboardEventFilter* keyboard) override;
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
-    TreeItemModel* getChildModel();
+    TreeItemModel* getChildModel() override;
 
     bool hasTrackTable() override {
         return true;
     }
 
   public slots:
-    void activate();
+    void activate() override;
 
     // Temporary, until WCrateTableView can be written.
-    void onRightClickChild(const QPoint& globalPos, QModelIndex index);
+    void onRightClickChild(const QPoint& globalPos, QModelIndex index) override;
 
   private:
     UserSettingsPointer m_pConfig;

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -1,5 +1,6 @@
 // Created by RJ Ryan (rryan@mit.edu) 1/29/2010
 
+#include <algorithm>
 #include <QtDebug>
 #include <QUrl>
 
@@ -372,7 +373,7 @@ void BaseSqlTableModel::select() {
     // end so we can easily slice off rows that are no longer present. Stable
     // sort is necessary because the tracks may be in pre-sorted order so we
     // should not disturb that if we are only removing tracks.
-    qStableSort(rowInfos.begin(), rowInfos.end());
+    std::stable_sort(rowInfos.begin(), rowInfos.end());
 
     TrackId2Rows trackIdToRows;
     // We expect almost all rows to be valid and that only a few tracks

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -60,7 +60,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
 
     // calls readWriteFlags() by default, reimplement this if the child calls
     // should be readOnly
-    virtual Qt::ItemFlags flags(const QModelIndex &index) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
 
     ///////////////////////////////////////////////////////////////////////////
     // Inherited from TrackModel

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -60,7 +60,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
 
     // calls readWriteFlags() by default, reimplement this if the child calls
     // should be readOnly
-    virtual Qt::ItemFlags flags(const QModelIndex &index) const;
+    virtual Qt::ItemFlags flags(const QModelIndex &index) const override;
 
     ///////////////////////////////////////////////////////////////////////////
     // Inherited from TrackModel
@@ -85,7 +85,7 @@ class BaseSqlTableModel : public QAbstractTableModel, public TrackModel {
     bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
 
   public slots:
-    void select();
+    void select() override;
 
   protected:
     void setTable(const QString& tableName, const QString& trackIdColumn,

--- a/src/library/coverartdelegate.h
+++ b/src/library/coverartdelegate.h
@@ -19,7 +19,7 @@ class CoverArtDelegate : public TableItemDelegate {
 
     void paintItem(QPainter* painter,
                const QStyleOptionViewItem& option,
-               const QModelIndex& index) const;
+               const QModelIndex& index) const override;
 
   signals:
     void coverReadyForCell(int row, int column);

--- a/src/library/crate/cratefeature.h
+++ b/src/library/crate/cratefeature.h
@@ -44,7 +44,7 @@ class CrateFeature : public LibraryFeature {
 
     void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard) override;
-    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget);
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
     TreeItemModel* getChildModel() override;
 

--- a/src/library/dao/libraryhashdao.h
+++ b/src/library/dao/libraryhashdao.h
@@ -12,7 +12,7 @@ class LibraryHashDAO : public DAO {
   public:
     ~LibraryHashDAO() override {}
 
-    void initialize(const QSqlDatabase& database) {
+    void initialize(const QSqlDatabase& database) override {
         m_database = database;
     };
 

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -974,8 +974,20 @@ void PlaylistDAO::shuffleTracks(const int playlistId, const QList<int>& position
         //qDebug() << "Swapping tracks " << trackAPosition << " and " << trackBPosition;
         trackPositionIds.insert(trackAPosition, trackBId);
         trackPositionIds.insert(trackBPosition, trackAId);
+
+        // TODO: The following use of QList<T>::swap(int, int) is deprecated
+        // and should be replaced with QList<T>::swapItemsAt(int, int)
+        // However, the proposed alternative has just been introduced in Qt
+        // 5.13. Until the minimum required Qt version of Mixx is increased,
+        // we need a version check here.
+        #if (QT_VERSION < QT_VERSION_CHECK(5, 13, 0))
         newPositions.swap(newPositions.indexOf(trackAPosition),
                           newPositions.indexOf(trackBPosition));
+        #else
+        newPositions.swapItemsAt(newPositions.indexOf(trackAPosition),
+                                 newPositions.indexOf(trackBPosition));
+        #endif
+
         QString swapQuery = "UPDATE PlaylistTracks SET position=%1 "
                 "WHERE position=%2 AND playlist_id=%3";
         query.exec(swapQuery.arg(QString::number(-1),

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -51,7 +51,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     PlaylistDAO();
     ~PlaylistDAO() override {}
 
-    void initialize(const QSqlDatabase& database);
+    void initialize(const QSqlDatabase& database) override;
 
     // Create a playlist, fails with -1 if already exists
     int createPlaylist(const QString& name, const HiddenType type = PLHT_NOT_HIDDEN);

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -1,10 +1,13 @@
 #include <QDesktopWidget>
+#include <QRect>
+#include <QScreen>
 #include <QStyle>
 #include <QWheelEvent>
 
 #include "library/dlgcoverartfullsize.h"
 #include "library/coverartutils.h"
 #include "library/coverartcache.h"
+#include "util/compatibility.h"
 
 DlgCoverArtFullSize::DlgCoverArtFullSize(QWidget* parent, BaseTrackPlayer* pPlayer)
         : QDialog(parent),
@@ -130,8 +133,16 @@ void DlgCoverArtFullSize::slotCoverFound(const QObject* pRequestor,
         // whitespace appearing on the side when resizing a window whose
         // borders touch the edges of the screen.
         QSize dialogSize = m_pixmap.size();
-        const QSize availableScreenSpace =
-            QApplication::desktop()->availableGeometry().size() * 0.9;
+
+        const QScreen* primaryScreen = getPrimaryScreen();
+        QRect availableScreenGeometry;
+        if (primaryScreen) {
+            availableScreenGeometry = primaryScreen->availableGeometry();
+        } else {
+            qWarning() << "Assuming screen size of 800x600px.";
+            availableScreenGeometry = QRect(0, 0, 800, 600);
+        }
+        const QSize availableScreenSpace = availableScreenGeometry.size() * 0.9;
         if (dialogSize.height() > availableScreenSpace.height()) {
             dialogSize.scale(dialogSize.width(), availableScreenSpace.height(),
                              Qt::KeepAspectRatio);
@@ -142,12 +153,13 @@ void DlgCoverArtFullSize::slotCoverFound(const QObject* pRequestor,
         QPixmap resizedPixmap = m_pixmap.scaled(size(),
             Qt::KeepAspectRatio, Qt::SmoothTransformation);
         coverArt->setPixmap(resizedPixmap);
+
         // center the window
         setGeometry(QStyle::alignedRect(
                 Qt::LeftToRight,
                 Qt::AlignCenter,
                 dialogSize,
-                QApplication::desktop()->availableGeometry()));
+                availableScreenGeometry));
     }
 }
 

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -737,7 +737,7 @@ void ITunesFeature::parsePlaylist(QXmlStreamReader& xml, QSqlQuery& query_insert
 
                     bool success = query_insert_to_playlists.exec();
                     if (!success) {
-                        if (query_insert_to_playlists.lastError().number() == SQLITE_CONSTRAINT) {
+                        if (query_insert_to_playlists.lastError().nativeErrorCode() == QString::number(SQLITE_CONSTRAINT)) {
                             // We assume a duplicate Playlist name
                             playlistname += QString(" #%1").arg(playlist_id);
                             query_insert_to_playlists.bindValue(":name", playlistname );

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -41,7 +41,7 @@ class ITunesFeature : public BaseExternalLibraryFeature {
     void onTrackCollectionLoaded();
 
   private:
-    virtual BaseSqlTableModel* getPlaylistModelForPlaylist(QString playlist) override;
+    BaseSqlTableModel* getPlaylistModelForPlaylist(QString playlist) override;
     static QString getiTunesMusicPath();
     // returns the invisible rootItem for the sidebar model
     TreeItem* importLibrary();

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -27,21 +27,21 @@ class ITunesFeature : public BaseExternalLibraryFeature {
     virtual ~ITunesFeature();
     static bool isSupported();
 
-    QVariant title();
-    QIcon getIcon();
-    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget);
+    QVariant title() override;
+    QIcon getIcon() override;
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
-    TreeItemModel* getChildModel();
+    TreeItemModel* getChildModel() override;
 
   public slots:
-    void activate();
+    void activate() override;
     void activate(bool forceReload);
-    void activateChild(const QModelIndex& index);
+    void activateChild(const QModelIndex& index) override;
     void onRightClick(const QPoint& globalPos) override;
     void onTrackCollectionLoaded();
 
   private:
-    virtual BaseSqlTableModel* getPlaylistModelForPlaylist(QString playlist);
+    virtual BaseSqlTableModel* getPlaylistModelForPlaylist(QString playlist) override;
     static QString getiTunesMusicPath();
     // returns the invisible rootItem for the sidebar model
     TreeItem* importLibrary();

--- a/src/library/mixxxlibraryfeature.h
+++ b/src/library/mixxxlibraryfeature.h
@@ -34,21 +34,21 @@ class MixxxLibraryFeature : public LibraryFeature {
                         UserSettingsPointer pConfig);
     virtual ~MixxxLibraryFeature();
 
-    QVariant title();
-    QIcon getIcon();
-    bool dropAccept(QList<QUrl> urls, QObject* pSource);
-    bool dragMoveAccept(QUrl url);
-    TreeItemModel* getChildModel();
+    QVariant title() override;
+    QIcon getIcon() override;
+    bool dropAccept(QList<QUrl> urls, QObject* pSource) override;
+    bool dragMoveAccept(QUrl url) override;
+    TreeItemModel* getChildModel() override;
     void bindLibraryWidget(WLibrary* pLibrary,
-                    KeyboardEventFilter* pKeyboard);
+                    KeyboardEventFilter* pKeyboard) override;
 
     bool hasTrackTable() override {
         return true;
     }
 
   public slots:
-    void activate();
-    void activateChild(const QModelIndex& index);
+    void activate() override;
+    void activateChild(const QModelIndex& index) override;
     void refreshLibraryModels();
 
   private:

--- a/src/library/playlistfeature.h
+++ b/src/library/playlistfeature.h
@@ -26,22 +26,22 @@ class PlaylistFeature : public BasePlaylistFeature {
                     UserSettingsPointer pConfig);
     virtual ~PlaylistFeature();
 
-    QVariant title();
-    QIcon getIcon();
+    QVariant title() override;
+    QIcon getIcon() override;
 
-    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget);
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
-    bool dropAcceptChild(const QModelIndex& index, QList<QUrl> urls, QObject* pSource);
-    bool dragMoveAcceptChild(const QModelIndex& index, QUrl url);
+    bool dropAcceptChild(const QModelIndex& index, QList<QUrl> urls, QObject* pSource) override;
+    bool dragMoveAcceptChild(const QModelIndex& index, QUrl url) override;
 
   public slots:
-    void onRightClick(const QPoint& globalPos);
-    void onRightClickChild(const QPoint& globalPos, QModelIndex index);
+    void onRightClick(const QPoint& globalPos) override;
+    void onRightClickChild(const QPoint& globalPos, QModelIndex index) override;
 
   private slots:
-    void slotPlaylistTableChanged(int playlistId);
-    void slotPlaylistContentChanged(int playlistId);
-    void slotPlaylistTableRenamed(int playlistId, QString a_strName);
+    void slotPlaylistTableChanged(int playlistId) override;
+    void slotPlaylistContentChanged(int playlistId) override;
+    void slotPlaylistTableRenamed(int playlistId, QString a_strName) override;
 
  protected:
     QList<BasePlaylistFeature::IdAndLabel> createPlaylistLabels() override;
@@ -49,7 +49,7 @@ class PlaylistFeature : public BasePlaylistFeature {
     void decorateChild(TreeItem *pChild, int playlist_id) override;
 
   private:
-    QString getRootViewHtml() const;
+    QString getRootViewHtml() const override;
     QIcon m_icon;
     QPointer<WLibrarySidebar> m_pSidebarWidget;
 };

--- a/src/library/playlisttablemodel.h
+++ b/src/library/playlisttablemodel.h
@@ -18,7 +18,7 @@ class PlaylistTableModel : public BaseSqlTableModel {
 
     bool appendTrack(TrackId trackId);
     void moveTrack(const QModelIndex& sourceIndex,
-                   const QModelIndex& destIndex);
+                   const QModelIndex& destIndex) override;
     void removeTrack(const QModelIndex& index);
     void shuffleTracks(const QModelIndexList& shuffle, const QModelIndex& exclude);
 

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -57,7 +57,7 @@ class LibraryScanner : public QThread {
     void startScan();
 
   protected:
-    void run();
+    void run() override;
 
   public slots:
     void queueTask(ScannerTask* pTask);

--- a/src/library/setlogfeature.h
+++ b/src/library/setlogfeature.h
@@ -27,7 +27,7 @@ public:
 
     virtual void bindLibraryWidget(WLibrary* libraryWidget,
                             KeyboardEventFilter* keyboard) override;
-    virtual void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
   public slots:
     void onRightClick(const QPoint& globalPos) override;

--- a/src/library/setlogfeature.h
+++ b/src/library/setlogfeature.h
@@ -25,8 +25,8 @@ public:
     QVariant title() override;
     QIcon getIcon() override;
 
-    virtual void bindLibraryWidget(WLibrary* libraryWidget,
-                            KeyboardEventFilter* keyboard) override;
+    void bindLibraryWidget(WLibrary* libraryWidget,
+                           KeyboardEventFilter* keyboard) override;
     void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
   public slots:

--- a/src/library/setlogfeature.h
+++ b/src/library/setlogfeature.h
@@ -22,16 +22,16 @@ public:
                   TrackCollection* pTrackCollection);
     virtual ~SetlogFeature();
 
-    QVariant title();
-    QIcon getIcon();
+    QVariant title() override;
+    QIcon getIcon() override;
 
     virtual void bindLibraryWidget(WLibrary* libraryWidget,
-                            KeyboardEventFilter* keyboard);
-    virtual void bindSidebarWidget(WLibrarySidebar* pSidebarWidget);
+                            KeyboardEventFilter* keyboard) override;
+    virtual void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
   public slots:
-    void onRightClick(const QPoint& globalPos);
-    void onRightClickChild(const QPoint& globalPos, QModelIndex index);
+    void onRightClick(const QPoint& globalPos) override;
+    void onRightClickChild(const QPoint& globalPos, QModelIndex index) override;
     void slotJoinWithPrevious();
     void slotGetNewPlaylist();
 
@@ -42,12 +42,12 @@ public:
 
   private slots:
     void slotPlayingTrackChanged(TrackPointer currentPlayingTrack);
-    void slotPlaylistTableChanged(int playlistId);
-    void slotPlaylistContentChanged(int playlistId);
-    void slotPlaylistTableRenamed(int playlistId, QString a_strName);
+    void slotPlaylistTableChanged(int playlistId) override;
+    void slotPlaylistContentChanged(int playlistId) override;
+    void slotPlaylistTableRenamed(int playlistId, QString a_strName) override;
 
   private:
-    QString getRootViewHtml() const;
+    QString getRootViewHtml() const override;
 
     QLinkedList<TrackId> m_recentTracks;
     QAction* m_pJoinWithPreviousAction;

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -26,15 +26,15 @@ class SidebarModel : public QAbstractItemModel {
 
     // Required for QAbstractItemModel
     QModelIndex index(int row, int column,
-                      const QModelIndex& parent = QModelIndex()) const;
-    QModelIndex parent(const QModelIndex& index) const;
-    int rowCount(const QModelIndex& parent = QModelIndex()) const;
-    int columnCount(const QModelIndex& parent = QModelIndex()) const;
+                      const QModelIndex& parent = QModelIndex()) const override;
+    QModelIndex parent(const QModelIndex& index) const override;
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant data(const QModelIndex& index,
-                  int role = Qt::DisplayRole) const;
+                  int role = Qt::DisplayRole) const override;
     bool dropAccept(const QModelIndex& index, QList<QUrl> urls, QObject* pSource);
     bool dragMoveAccept(const QModelIndex& index, QUrl url);
-    virtual bool hasChildren(const QModelIndex& parent = QModelIndex()) const;
+    virtual bool hasChildren(const QModelIndex& parent = QModelIndex()) const override;
     bool hasTrackTable(const QModelIndex& index) const;
 
   public slots:

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -34,7 +34,7 @@ class SidebarModel : public QAbstractItemModel {
                   int role = Qt::DisplayRole) const override;
     bool dropAccept(const QModelIndex& index, QList<QUrl> urls, QObject* pSource);
     bool dragMoveAccept(const QModelIndex& index, QUrl url);
-    virtual bool hasChildren(const QModelIndex& parent = QModelIndex()) const override;
+    bool hasChildren(const QModelIndex& parent = QModelIndex()) const override;
     bool hasTrackTable(const QModelIndex& index) const;
 
   public slots:

--- a/src/mixxx.cpp
+++ b/src/mixxx.cpp
@@ -28,6 +28,7 @@
 #include <QGuiApplication>
 #include <QInputMethod>
 #include <QGLFormat>
+#include <QScreen>
 
 #include "dialog/dlgabout.h"
 #include "preferences/dialog/dlgpreferences.h"
@@ -73,6 +74,7 @@
 #include "skin/launchimage.h"
 #include "preferences/settingsmanager.h"
 #include "widget/wmainmenubar.h"
+#include "util/compatibility.h"
 #include "util/screensaver.h"
 #include "util/logger.h"
 #include "util/db/dbconnectionpooled.h"
@@ -1411,9 +1413,15 @@ void MixxxMainWindow::rebootMixxxView() {
         // Not all OSs and/or window managers keep the window inside of the screen, so force it.
         int newX = initPosition.x() + (initSize.width() - m_pWidgetParent->width()) / 2;
         int newY = initPosition.y() + (initSize.height() - m_pWidgetParent->height()) / 2;
-        newX = std::max(0, std::min(newX, QApplication::desktop()->screenGeometry().width() - m_pWidgetParent->width()));
-        newY = std::max(0, std::min(newY, QApplication::desktop()->screenGeometry().height() - m_pWidgetParent->height()));
-        move(newX,newY);
+
+        const QScreen* primaryScreen = getPrimaryScreen();
+        if (primaryScreen) {
+            newX = std::max(0, std::min(newX, primaryScreen->geometry().width() - m_pWidgetParent->width()));
+            newY = std::max(0, std::min(newY, primaryScreen->geometry().height() - m_pWidgetParent->height()));
+            move(newX,newY);
+        } else {
+            qWarning() << "Unable to move window inside screen borders.";
+        }
     }
 
     qDebug() << "rebootMixxxView DONE";

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -111,9 +111,9 @@ class MixxxMainWindow : public QMainWindow {
 
   protected:
     // Event filter to block certain events (eg. tooltips if tooltips are disabled)
-    virtual bool eventFilter(QObject *obj, QEvent *event) override;
-    virtual void closeEvent(QCloseEvent *event) override;
-    virtual bool event(QEvent* e) override;
+    bool eventFilter(QObject *obj, QEvent *event) override;
+    void closeEvent(QCloseEvent *event) override;
+    bool event(QEvent* e) override;
 
   private:
     void initialize(QApplication *app, const CmdlineArgs& args);

--- a/src/mixxx.h
+++ b/src/mixxx.h
@@ -111,9 +111,9 @@ class MixxxMainWindow : public QMainWindow {
 
   protected:
     // Event filter to block certain events (eg. tooltips if tooltips are disabled)
-    virtual bool eventFilter(QObject *obj, QEvent *event);
-    virtual void closeEvent(QCloseEvent *event);
-    virtual bool event(QEvent* e);
+    virtual bool eventFilter(QObject *obj, QEvent *event) override;
+    virtual void closeEvent(QCloseEvent *event) override;
+    virtual bool event(QEvent* e) override;
 
   private:
     void initialize(QApplication *app, const CmdlineArgs& args);

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -27,7 +27,6 @@ namespace {
 const char* kSettingsGroupHeader = "Settings for %1";
 const int kColumnEnabled = 0;
 const int kColumnName = 1;
-const int kColumnStatus = 2;
 const mixxx::Logger kLogger("DlgPrefBroadcast");
 }
 

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -23,6 +23,7 @@
 #include <QTabWidget>
 #include <QMoveEvent>
 #include <QResizeEvent>
+#include <QScreen>
 
 #include "preferences/dialog/dlgpreferences.h"
 
@@ -64,6 +65,7 @@
 #include "controllers/controllermanager.h"
 #include "skin/skinloader.h"
 #include "library/library.h"
+#include "util/compatibility.h"
 
 DlgPreferences::DlgPreferences(MixxxMainWindow * mixxx, SkinLoader* pSkinLoader,
                                SoundManager * soundman, PlayerManager* pPlayerManager,
@@ -402,8 +404,17 @@ void DlgPreferences::onShow() {
     }
     int newX = m_geometry[0].toInt();
     int newY = m_geometry[1].toInt();
-    newX = std::max(0, std::min(newX, QApplication::desktop()->screenGeometry().width()- m_geometry[2].toInt()));
-    newY = std::max(0, std::min(newY, QApplication::desktop()->screenGeometry().height() - m_geometry[3].toInt()));
+
+    const QScreen* primaryScreen = getPrimaryScreen();
+    QSize screenSpace;
+    if (primaryScreen) {
+        screenSpace = primaryScreen->geometry().size();
+    } else {
+        qWarning() << "Assuming screen size of 800x600px.";
+        screenSpace = QSize(800, 600);
+    }
+    newX = std::max(0, std::min(newX, screenSpace.width()- m_geometry[2].toInt()));
+    newY = std::max(0, std::min(newY, screenSpace.height() - m_geometry[3].toInt()));
     m_geometry[0] = QString::number(newX);
     m_geometry[1] = QString::number(newY);
 

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -32,12 +32,12 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
 
   public slots:
     // Common preference page slots.
-    void slotUpdate();
-    void slotShow();
-    void slotHide();
-    void slotResetToDefaults();
-    void slotApply();
-    void slotCancel();
+    void slotUpdate() override;
+    void slotShow() override;
+    void slotHide() override;
+    void slotResetToDefaults() override;
+    void slotApply() override;
+    void slotCancel() override;
 
     // Dialog to browse for music file directory
     void slotAddDir();

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -25,10 +25,6 @@ const int kNetworkLatencyFrames = 8192; // 185 ms @ 44100 Hz
 // Which results in case of ogg in a dynamic latency from 0.14 ms to to 185 ms
 // Now we have switched to a fixed latency of 8192 frames (stereo samples) =
 // which is 185 @ 44100 ms and twice the maximum of the max mixxx audio buffer
-const int kBufferFrames = kNetworkLatencyFrames * 4; // 743 ms @ 44100 Hz
-// normally * 2 is sufficient.
-// We allow to buffer two extra chunks for a CPU overload case, when
-// the broadcast thread is not scheduled in time.
 
 const mixxx::Logger kLogger("SoundDeviceNetwork");
 }

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -34,12 +34,10 @@ SoundDeviceNetwork::SoundDeviceNetwork(UserSettingsPointer config,
                                        QSharedPointer<EngineNetworkStream> pNetworkStream)
         : SoundDevice(config, sm),
           m_pNetworkStream(pNetworkStream),
-          m_outputDrift(false),
           m_inputDrift(false),
           m_framesSinceAudioLatencyUsageUpdate(0),
           m_denormals(false),
-          m_targetTime(0),
-          m_lastCallbackEntrytoDacSecs(0) {
+          m_targetTime(0) {
     // Setting parent class members:
     m_hostAPI = "Network stream";
     m_dSampleRate = 44100.0;

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -58,7 +58,6 @@ class SoundDeviceNetwork : public SoundDevice {
     QSharedPointer<EngineNetworkStream> m_pNetworkStream;
     std::unique_ptr<FIFO<CSAMPLE> > m_outputFifo;
     std::unique_ptr<FIFO<CSAMPLE> > m_inputFifo;
-    bool m_outputDrift;
     bool m_inputDrift;
 
     std::unique_ptr<ControlProxy> m_pMasterAudioLatencyUsage;
@@ -69,7 +68,6 @@ class SoundDeviceNetwork : public SoundDevice {
     bool m_denormals;
     qint64 m_targetTime;
     PerformanceTimer m_clkRefTimer;
-    double m_lastCallbackEntrytoDacSecs;
 };
 
 class SoundDeviceNetworkThread : public QThread {

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -33,43 +33,43 @@ class BeatGrid final : public Beats {
     // The following are all methods from the Beats interface, see method
     // comments in beats.h
 
-    virtual Beats::CapabilitiesFlags getCapabilities() const {
+    virtual Beats::CapabilitiesFlags getCapabilities() const override {
         return BEATSCAP_TRANSLATE | BEATSCAP_SCALE | BEATSCAP_SETBPM;
     }
 
-    virtual QByteArray toByteArray() const;
-    virtual BeatsPointer clone() const;
-    virtual QString getVersion() const;
-    virtual QString getSubVersion() const;
+    virtual QByteArray toByteArray() const override;
+    virtual BeatsPointer clone() const override;
+    virtual QString getVersion() const override;
+    virtual QString getSubVersion() const override;
     virtual void setSubVersion(QString subVersion);
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat calculations
     ////////////////////////////////////////////////////////////////////////////
 
-    virtual double findNextBeat(double dSamples) const;
-    virtual double findPrevBeat(double dSamples) const;
+    virtual double findNextBeat(double dSamples) const override;
+    virtual double findPrevBeat(double dSamples) const override;
     virtual bool findPrevNextBeats(double dSamples,
                                    double* dpPrevBeatSamples,
-                                   double* dpNextBeatSamples) const;
-    virtual double findClosestBeat(double dSamples) const;
-    virtual double findNthBeat(double dSamples, int n) const;
-    virtual std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const;
-    virtual bool hasBeatInRange(double startSample, double stopSample) const;
-    virtual double getBpm() const;
-    virtual double getBpmRange(double startSample, double stopSample) const;
-    virtual double getBpmAroundPosition(double curSample, int n) const;
+                                   double* dpNextBeatSamples) const override;
+    virtual double findClosestBeat(double dSamples) const override;
+    virtual double findNthBeat(double dSamples, int n) const override;
+    virtual std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const override;
+    virtual bool hasBeatInRange(double startSample, double stopSample) const override;
+    virtual double getBpm() const override;
+    virtual double getBpmRange(double startSample, double stopSample) const override;
+    virtual double getBpmAroundPosition(double curSample, int n) const override;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    virtual void addBeat(double dBeatSample);
-    virtual void removeBeat(double dBeatSample);
+    virtual void addBeat(double dBeatSample) override;
+    virtual void removeBeat(double dBeatSample) override;
     virtual void moveBeat(double dBeatSample, double dNewBeatSample);
-    virtual void translate(double dNumSamples);
-    virtual void scale(enum BPMScale scale);
-    virtual void setBpm(double dBpm);
+    virtual void translate(double dNumSamples) override;
+    virtual void scale(enum BPMScale scale) override;
+    virtual void setBpm(double dBpm) override;
 
   private:
     BeatGrid(const BeatGrid& other);

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -37,39 +37,39 @@ class BeatGrid final : public Beats {
         return BEATSCAP_TRANSLATE | BEATSCAP_SCALE | BEATSCAP_SETBPM;
     }
 
-    virtual QByteArray toByteArray() const override;
-    virtual BeatsPointer clone() const override;
-    virtual QString getVersion() const override;
-    virtual QString getSubVersion() const override;
+    QByteArray toByteArray() const override;
+    BeatsPointer clone() const override;
+    QString getVersion() const override;
+    QString getSubVersion() const override;
     virtual void setSubVersion(QString subVersion);
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat calculations
     ////////////////////////////////////////////////////////////////////////////
 
-    virtual double findNextBeat(double dSamples) const override;
-    virtual double findPrevBeat(double dSamples) const override;
+    double findNextBeat(double dSamples) const override;
+    double findPrevBeat(double dSamples) const override;
     virtual bool findPrevNextBeats(double dSamples,
                                    double* dpPrevBeatSamples,
                                    double* dpNextBeatSamples) const override;
-    virtual double findClosestBeat(double dSamples) const override;
-    virtual double findNthBeat(double dSamples, int n) const override;
-    virtual std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const override;
-    virtual bool hasBeatInRange(double startSample, double stopSample) const override;
-    virtual double getBpm() const override;
-    virtual double getBpmRange(double startSample, double stopSample) const override;
-    virtual double getBpmAroundPosition(double curSample, int n) const override;
+    double findClosestBeat(double dSamples) const override;
+    double findNthBeat(double dSamples, int n) const override;
+    std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const override;
+    bool hasBeatInRange(double startSample, double stopSample) const override;
+    double getBpm() const override;
+    double getBpmRange(double startSample, double stopSample) const override;
+    double getBpmAroundPosition(double curSample, int n) const override;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    virtual void addBeat(double dBeatSample) override;
-    virtual void removeBeat(double dBeatSample) override;
+    void addBeat(double dBeatSample) override;
+    void removeBeat(double dBeatSample) override;
     virtual void moveBeat(double dBeatSample, double dNewBeatSample);
-    virtual void translate(double dNumSamples) override;
-    virtual void scale(enum BPMScale scale) override;
-    virtual void setBpm(double dBpm) override;
+    void translate(double dNumSamples) override;
+    void scale(enum BPMScale scale) override;
+    void setBpm(double dBpm) override;
 
   private:
     BeatGrid(const BeatGrid& other);

--- a/src/track/beatgrid.h
+++ b/src/track/beatgrid.h
@@ -33,7 +33,7 @@ class BeatGrid final : public Beats {
     // The following are all methods from the Beats interface, see method
     // comments in beats.h
 
-    virtual Beats::CapabilitiesFlags getCapabilities() const override {
+    Beats::CapabilitiesFlags getCapabilities() const override {
         return BEATSCAP_TRANSLATE | BEATSCAP_SCALE | BEATSCAP_SETBPM;
     }
 
@@ -49,9 +49,9 @@ class BeatGrid final : public Beats {
 
     double findNextBeat(double dSamples) const override;
     double findPrevBeat(double dSamples) const override;
-    virtual bool findPrevNextBeats(double dSamples,
-                                   double* dpPrevBeatSamples,
-                                   double* dpNextBeatSamples) const override;
+    bool findPrevNextBeats(double dSamples,
+                           double* dpPrevBeatSamples,
+                           double* dpNextBeatSamples) const override;
     double findClosestBeat(double dSamples) const override;
     double findNthBeat(double dSamples, int n) const override;
     std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const override;

--- a/src/track/beatmap.cpp
+++ b/src/track/beatmap.cpp
@@ -5,6 +5,7 @@
  *      Author: vittorio
  */
 
+#include <algorithm>
 #include <QtDebug>
 #include <QtGlobal>
 #include <QMutexLocker>
@@ -206,7 +207,7 @@ double BeatMap::findNthBeat(double dSamples, int n) const {
 
     // it points at the first occurrence of beat or the next largest beat
     BeatList::const_iterator it =
-            qLowerBound(m_beats.constBegin(), m_beats.constEnd(), beat, BeatLessThan);
+            std::lower_bound(m_beats.constBegin(), m_beats.constEnd(), beat, BeatLessThan);
 
     // If the position is within 1/10th of a second of the next or previous
     // beat, pretend we are on that beat.
@@ -297,7 +298,7 @@ bool BeatMap::findPrevNextBeats(double dSamples,
 
     // it points at the first occurrence of beat or the next largest beat
     BeatList::const_iterator it =
-            qLowerBound(m_beats.constBegin(), m_beats.constEnd(), beat, BeatLessThan);
+            std::lower_bound(m_beats.constBegin(), m_beats.constEnd(), beat, BeatLessThan);
 
     // If the position is within 1/10th of a second of the next or previous
     // beat, pretend we are on that beat.
@@ -380,11 +381,11 @@ std::unique_ptr<BeatIterator> BeatMap::findBeats(double startSample, double stop
     stopBeat.set_frame_position(samplesToFrames(stopSample));
 
     BeatList::const_iterator curBeat =
-            qLowerBound(m_beats.constBegin(), m_beats.constEnd(),
+            std::lower_bound(m_beats.constBegin(), m_beats.constEnd(),
                         startBeat, BeatLessThan);
 
     BeatList::const_iterator lastBeat =
-            qUpperBound(m_beats.constBegin(), m_beats.constEnd(),
+            std::upper_bound(m_beats.constBegin(), m_beats.constEnd(),
                         stopBeat, BeatLessThan);
 
     if (curBeat >= lastBeat) {
@@ -457,7 +458,7 @@ void BeatMap::addBeat(double dBeatSample) {
     QMutexLocker locker(&m_mutex);
     Beat beat;
     beat.set_frame_position(samplesToFrames(dBeatSample));
-    BeatList::iterator it = qLowerBound(
+    BeatList::iterator it = std::lower_bound(
         m_beats.begin(), m_beats.end(), beat, BeatLessThan);
 
     // Don't insert a duplicate beat. TODO(XXX) determine what epsilon to
@@ -475,7 +476,7 @@ void BeatMap::removeBeat(double dBeatSample) {
     QMutexLocker locker(&m_mutex);
     Beat beat;
     beat.set_frame_position(samplesToFrames(dBeatSample));
-    BeatList::iterator it = qLowerBound(
+    BeatList::iterator it = std::lower_bound(
         m_beats.begin(), m_beats.end(), beat, BeatLessThan);
 
     // In case there are duplicates, remove every instance of dBeatSample
@@ -495,7 +496,7 @@ void BeatMap::moveBeat(double dBeatSample, double dNewBeatSample) {
     beat.set_frame_position(samplesToFrames(dBeatSample));
     newBeat.set_frame_position(samplesToFrames(dNewBeatSample));
 
-    BeatList::iterator it = qLowerBound(
+    BeatList::iterator it = std::lower_bound(
         m_beats.begin(), m_beats.end(), beat, BeatLessThan);
 
     // In case there are duplicates, remove every instance of dBeatSample
@@ -509,7 +510,7 @@ void BeatMap::moveBeat(double dBeatSample, double dNewBeatSample) {
     }
 
     // Now add a beat to dNewBeatSample
-    it = qLowerBound(m_beats.begin(), m_beats.end(), newBeat, BeatLessThan);
+    it = std::lower_bound(m_beats.begin(), m_beats.end(), newBeat, BeatLessThan);
     // TODO(XXX) beat epsilon
     if (it->frame_position() != newBeat.frame_position()) {
         m_beats.insert(it, newBeat);
@@ -732,10 +733,10 @@ double BeatMap::calculateBpm(const Beat& startBeat, const Beat& stopBeat) const 
     }
 
     BeatList::const_iterator curBeat =
-            qLowerBound(m_beats.constBegin(), m_beats.constEnd(), startBeat, BeatLessThan);
+            std::lower_bound(m_beats.constBegin(), m_beats.constEnd(), startBeat, BeatLessThan);
 
     BeatList::const_iterator lastBeat =
-            qUpperBound(m_beats.constBegin(), m_beats.constEnd(), stopBeat, BeatLessThan);
+            std::upper_bound(m_beats.constBegin(), m_beats.constEnd(), stopBeat, BeatLessThan);
 
     QVector<double> beatvect;
     for (; curBeat != lastBeat; ++curBeat) {

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -40,7 +40,7 @@ class BeatMap final : public Beats {
 
     // See method comments in beats.h
 
-    virtual Beats::CapabilitiesFlags getCapabilities() const override {
+    Beats::CapabilitiesFlags getCapabilities() const override {
         return BEATSCAP_TRANSLATE | BEATSCAP_SCALE | BEATSCAP_ADDREMOVE |
                 BEATSCAP_MOVEBEAT;
     }
@@ -57,9 +57,9 @@ class BeatMap final : public Beats {
 
     double findNextBeat(double dSamples) const override;
     double findPrevBeat(double dSamples) const override;
-    virtual bool findPrevNextBeats(double dSamples,
-                                   double* dpPrevBeatSamples,
-                                   double* dpNextBeatSamples) const override;
+    bool findPrevNextBeats(double dSamples,
+                           double* dpPrevBeatSamples,
+                           double* dpNextBeatSamples) const override;
     double findClosestBeat(double dSamples) const override;
     double findNthBeat(double dSamples, int n) const override;
     std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const override;

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -40,45 +40,45 @@ class BeatMap final : public Beats {
 
     // See method comments in beats.h
 
-    virtual Beats::CapabilitiesFlags getCapabilities() const {
+    virtual Beats::CapabilitiesFlags getCapabilities() const override {
         return BEATSCAP_TRANSLATE | BEATSCAP_SCALE | BEATSCAP_ADDREMOVE |
                 BEATSCAP_MOVEBEAT;
     }
 
-    virtual QByteArray toByteArray() const;
-    BeatsPointer clone() const;
-    virtual QString getVersion() const;
-    virtual QString getSubVersion() const;
+    virtual QByteArray toByteArray() const override;
+    BeatsPointer clone() const override;
+    virtual QString getVersion() const override;
+    virtual QString getSubVersion() const override;
     virtual void setSubVersion(QString subVersion);
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat calculations
     ////////////////////////////////////////////////////////////////////////////
 
-    virtual double findNextBeat(double dSamples) const;
-    virtual double findPrevBeat(double dSamples) const;
+    virtual double findNextBeat(double dSamples) const override;
+    virtual double findPrevBeat(double dSamples) const override;
     virtual bool findPrevNextBeats(double dSamples,
                                    double* dpPrevBeatSamples,
-                                   double* dpNextBeatSamples) const;
-    virtual double findClosestBeat(double dSamples) const;
-    virtual double findNthBeat(double dSamples, int n) const;
-    virtual std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const;
-    virtual bool hasBeatInRange(double startSample, double stopSample) const;
+                                   double* dpNextBeatSamples) const override;
+    virtual double findClosestBeat(double dSamples) const override;
+    virtual double findNthBeat(double dSamples, int n) const override;
+    virtual std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const override;
+    virtual bool hasBeatInRange(double startSample, double stopSample) const override;
 
-    virtual double getBpm() const;
-    virtual double getBpmRange(double startSample, double stopSample) const;
-    virtual double getBpmAroundPosition(double curSample, int n) const;
+    virtual double getBpm() const override;
+    virtual double getBpmRange(double startSample, double stopSample) const override;
+    virtual double getBpmAroundPosition(double curSample, int n) const override;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    virtual void addBeat(double dBeatSample);
-    virtual void removeBeat(double dBeatSample);
+    virtual void addBeat(double dBeatSample) override;
+    virtual void removeBeat(double dBeatSample) override;
     virtual void moveBeat(double dBeatSample, double dNewBeatSample);
-    virtual void translate(double dNumSamples);
-    virtual void scale(enum BPMScale scale);
-    virtual void setBpm(double dBpm);
+    virtual void translate(double dNumSamples) override;
+    virtual void scale(enum BPMScale scale) override;
+    virtual void setBpm(double dBpm) override;
 
   private:
     BeatMap(const BeatMap& other);

--- a/src/track/beatmap.h
+++ b/src/track/beatmap.h
@@ -45,40 +45,40 @@ class BeatMap final : public Beats {
                 BEATSCAP_MOVEBEAT;
     }
 
-    virtual QByteArray toByteArray() const override;
+    QByteArray toByteArray() const override;
     BeatsPointer clone() const override;
-    virtual QString getVersion() const override;
-    virtual QString getSubVersion() const override;
+    QString getVersion() const override;
+    QString getSubVersion() const override;
     virtual void setSubVersion(QString subVersion);
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat calculations
     ////////////////////////////////////////////////////////////////////////////
 
-    virtual double findNextBeat(double dSamples) const override;
-    virtual double findPrevBeat(double dSamples) const override;
+    double findNextBeat(double dSamples) const override;
+    double findPrevBeat(double dSamples) const override;
     virtual bool findPrevNextBeats(double dSamples,
                                    double* dpPrevBeatSamples,
                                    double* dpNextBeatSamples) const override;
-    virtual double findClosestBeat(double dSamples) const override;
-    virtual double findNthBeat(double dSamples, int n) const override;
-    virtual std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const override;
-    virtual bool hasBeatInRange(double startSample, double stopSample) const override;
+    double findClosestBeat(double dSamples) const override;
+    double findNthBeat(double dSamples, int n) const override;
+    std::unique_ptr<BeatIterator> findBeats(double startSample, double stopSample) const override;
+    bool hasBeatInRange(double startSample, double stopSample) const override;
 
-    virtual double getBpm() const override;
-    virtual double getBpmRange(double startSample, double stopSample) const override;
-    virtual double getBpmAroundPosition(double curSample, int n) const override;
+    double getBpm() const override;
+    double getBpmRange(double startSample, double stopSample) const override;
+    double getBpmAroundPosition(double curSample, int n) const override;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat mutations
     ////////////////////////////////////////////////////////////////////////////
 
-    virtual void addBeat(double dBeatSample) override;
-    virtual void removeBeat(double dBeatSample) override;
+    void addBeat(double dBeatSample) override;
+    void removeBeat(double dBeatSample) override;
     virtual void moveBeat(double dBeatSample, double dNewBeatSample);
-    virtual void translate(double dNumSamples) override;
-    virtual void scale(enum BPMScale scale) override;
-    virtual void setBpm(double dBpm) override;
+    void translate(double dNumSamples) override;
+    void scale(enum BPMScale scale) override;
+    void setBpm(double dBpm) override;
 
   private:
     BeatMap(const BeatMap& other);

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -5,6 +5,7 @@
  *      Author: vittorio
  */
 
+#include <algorithm>
 #include <QtDebug>
 #include <QString>
 #include <QList>
@@ -331,7 +332,7 @@ double BeatUtils::calculateOffset(
         int freq = 0;
         for (int i = 0; i < beats2.size(); i += 4) {
             double beats2_beat = beats2.at(i);
-            QVector<double>::const_iterator it = qUpperBound(
+            QVector<double>::const_iterator it = std::upper_bound(
                 beats1.constBegin(), beats1.constEnd(), beats2_beat);
             if (fabs(*it - beats2_beat - offset) <= beatLength1Epsilon) {
                 freq++;

--- a/src/util/compatibility.h
+++ b/src/util/compatibility.h
@@ -1,8 +1,14 @@
 #ifndef COMPATABILITY_H
 #define COMPATABILITY_H
 
+#include <QCoreApplication>
+#include <QGuiApplication>
+#include <QList>
+#include <QScreen>
 #include <QWindow>
 #include <QWidget>
+
+#include "util/assert.h"
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
 
@@ -72,6 +78,26 @@ inline qreal getDevicePixelRatioF(const QWidget* widget) {
 
     // return integer value as last resort
     return widget->devicePixelRatio();
+}
+
+inline QScreen* getPrimaryScreen() {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    QGuiApplication* app = static_cast<QGuiApplication*>(QCoreApplication::instance());
+    VERIFY_OR_DEBUG_ASSERT(app) {
+        qWarning() << "Unable to get applications QCoreApplication instance, cannot determine primary screen!";
+    } else {
+        return app->primaryScreen();
+    }
+#endif
+    const QList<QScreen*> screens = QGuiApplication::screens();
+    VERIFY_OR_DEBUG_ASSERT(!screens.isEmpty()) {
+        qWarning() << "No screens found, cannot determine primary screen!";
+    } else {
+        return screens.first();
+    }
+
+    // All attempts to find primary screen failed, return nullptr
+    return nullptr;
 }
 
 #endif /* COMPATABILITY_H */

--- a/src/util/desktophelper.cpp
+++ b/src/util/desktophelper.cpp
@@ -151,7 +151,7 @@ void DesktopHelper::openInFileBrowser(const QStringList& paths) {
         while (!dir.exists() && dirPath.size()) {
             // Note: dir.cdUp() does not work for not existing dirs
             dirPath = removeChildDir(dirPath);
-            dir = dirPath;
+            dir.setPath(dirPath);
         }
 
         // This function does not work for a non-existent directory!

--- a/src/util/fifo.h
+++ b/src/util/fifo.h
@@ -22,7 +22,6 @@ class FIFO {
             return;
         }
         m_data = new DataType[size];
-        memset(m_data, 0, sizeof(DataType) * size);
         PaUtil_InitializeRingBuffer(
                 &m_ringBuffer, sizeof(DataType), size, m_data);
     }

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -17,13 +17,13 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
   public:
     explicit WaveformRenderMark(WaveformWidgetRenderer* waveformWidgetRenderer);
 
-    virtual void setup(const QDomNode& node, const SkinContext& context);
-    virtual void draw(QPainter* painter, QPaintEvent* event);
+    virtual void setup(const QDomNode& node, const SkinContext& context) override;
+    virtual void draw(QPainter* painter, QPaintEvent* event) override;
 
     virtual void onResize() override;
 
     // Called when a new track is loaded.
-    virtual void onSetTrack();
+    virtual void onSetTrack() override;
 
   public slots:
     // Called when the loaded track's cues are added, deleted or modified and

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -17,13 +17,13 @@ class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
   public:
     explicit WaveformRenderMark(WaveformWidgetRenderer* waveformWidgetRenderer);
 
-    virtual void setup(const QDomNode& node, const SkinContext& context) override;
-    virtual void draw(QPainter* painter, QPaintEvent* event) override;
+    void setup(const QDomNode& node, const SkinContext& context) override;
+    void draw(QPainter* painter, QPaintEvent* event) override;
 
-    virtual void onResize() override;
+    void onResize() override;
 
     // Called when a new track is loaded.
-    virtual void onSetTrack() override;
+    void onSetTrack() override;
 
   public slots:
     // Called when the loaded track's cues are added, deleted or modified and

--- a/src/waveform/widgets/glslwaveformwidget.h
+++ b/src/waveform/widgets/glslwaveformwidget.h
@@ -14,7 +14,7 @@ class GLSLWaveformWidget : public QGLWidget, public WaveformWidgetAbstract {
                        bool rgbRenderer);
     ~GLSLWaveformWidget() override;
 
-    void resize(int width, int height);
+    void resize(int width, int height) override;
 
   protected:
     void castToQWidget() override;

--- a/src/widget/wcoverart.h
+++ b/src/widget/wcoverart.h
@@ -34,8 +34,8 @@ class WCoverArt : public QWidget, public WBaseWidget, public TrackDropTarget {
     void slotEnable(bool);
 
   signals:
-    void trackDropped(QString filename, QString group);
-    void cloneDeck(QString source_group, QString target_group);
+    void trackDropped(QString filename, QString group) override;
+    void cloneDeck(QString source_group, QString target_group) override;
 
   private slots:
     void slotCoverFound(const QObject* pRequestor,

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -1008,7 +1008,19 @@ void WOverview::paintText(const QString& text, QPainter* pPainter) {
     pPainter->setPen(lowColorPen);
     QFont font = pPainter->font();
     QFontMetrics fm(font);
+
+    // TODO: The following use of QFontMetrics::width(const QString&, int) const
+    // is deprecated and should be replaced with
+    // QFontMetrics::horizontalAdvance(const QString&, int) const. However, the
+    // proposed alternative has just been introduced in Qt 5.11.
+    // Until the minimum required Qt version of Mixx is increased, we need a
+    // version check here.
+    #if (QT_VERSION < QT_VERSION_CHECK(5, 11, 0))
     int textWidth = fm.width(text);
+    #else
+    int textWidth = fm.horizontalAdvance(text);
+    #endif
+
     if (textWidth > length()) {
         qreal pointSize = font.pointSizeF();
         pointSize = pointSize * (length() - 5 * m_scaleFactor) / textWidth;

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -47,8 +47,8 @@ class WOverview : public WWidget, public TrackDropTarget {
             AnalyzerProgress analyzerProgress);
 
   signals:
-    void trackDropped(QString filename, QString group);
-    void cloneDeck(QString source_group, QString target_group);
+    void trackDropped(QString filename, QString group) override;
+    void cloneDeck(QString source_group, QString target_group) override;
 
   protected:
     WOverview(

--- a/src/widget/wsingletoncontainer.h
+++ b/src/widget/wsingletoncontainer.h
@@ -58,7 +58,7 @@ class WSingletonContainer : public WWidgetGroup {
     // widget to the container.
     explicit WSingletonContainer(QWidget* pParent=nullptr);
 
-    virtual void setup(const QDomNode& node, const SkinContext& context);
+    virtual void setup(const QDomNode& node, const SkinContext& context) override;
 
   public slots:
     void showEvent(QShowEvent* event) override;

--- a/src/widget/wsingletoncontainer.h
+++ b/src/widget/wsingletoncontainer.h
@@ -58,7 +58,7 @@ class WSingletonContainer : public WWidgetGroup {
     // widget to the container.
     explicit WSingletonContainer(QWidget* pParent=nullptr);
 
-    virtual void setup(const QDomNode& node, const SkinContext& context) override;
+    void setup(const QDomNode& node, const SkinContext& context) override;
 
   public slots:
     void showEvent(QShowEvent* event) override;

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -58,8 +58,8 @@ class WSpinny : public QGLWidget, public WBaseWidget, public VinylSignalQualityL
 
 
   signals:
-    void trackDropped(QString filename, QString group);
-    void cloneDeck(QString source_group, QString target_group);
+    void trackDropped(QString filename, QString group) override;
+    void cloneDeck(QString source_group, QString target_group) override;
 
   protected:
     //QWidget:

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -19,8 +19,8 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
     void setup(const QDomNode& node, const SkinContext& context) override;
 
   signals:
-    void trackDropped(QString filename, QString group);
-    void cloneDeck(QString source_group, QString target_group);
+    void trackDropped(QString filename, QString group) override;
+    void cloneDeck(QString source_group, QString target_group) override;
 
   public slots:
     void slotTrackLoaded(TrackPointer track);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -277,7 +277,7 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel *model) {
     if (getTrackModel() == trackModel) {
         // Re-sort the table even if the track model is the same. This triggers
         // a select() if the table is dirty.
-        doSortByColumn(horizontalHeader()->sortIndicatorSection());
+        doSortByColumn(horizontalHeader()->sortIndicatorSection(), horizontalHeader()->sortIndicatorOrder());
         return;
     }else{
         newModel = trackModel;
@@ -1828,7 +1828,7 @@ void WTrackTableView::addSelectionToNewCrate() {
 
 }
 
-void WTrackTableView::doSortByColumn(int headerSection) {
+void WTrackTableView::doSortByColumn(int headerSection, Qt::SortOrder sortOrder) {
     TrackModel* trackModel = getTrackModel();
     QAbstractItemModel* itemModel = model();
 
@@ -1840,7 +1840,7 @@ void WTrackTableView::doSortByColumn(int headerSection) {
     const QList<TrackId> selectedTrackIds = getSelectedTrackIds();
     int savedHScrollBarPos = horizontalScrollBar()->value();
 
-    sortByColumn(headerSection);
+    sortByColumn(headerSection, sortOrder);
 
     QItemSelectionModel* currentSelection = selectionModel();
     currentSelection->reset(); // remove current selection
@@ -1907,7 +1907,7 @@ void WTrackTableView::applySorting() {
     horizontalHeader()->setSortIndicator(sortColumn, sortOrder);
 
     // in Qt5, we need to call it manually, which triggers finally the select()
-    doSortByColumn(sortColumn);
+    doSortByColumn(sortColumn, sortOrder);
 }
 
 void WTrackTableView::slotLockBpm() {

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -77,7 +77,7 @@ class WTrackTableView : public WLibraryTableView {
     void slotPopulateCrateMenu();
     void addSelectionToNewCrate();
     void loadSelectionToGroup(QString group, bool play = false);
-    void doSortByColumn(int headerSection);
+    void doSortByColumn(int headerSection, Qt::SortOrder sortOrder);
     void applySortingIfVisible();
     void applySorting();
     void slotLockBpm();

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -16,8 +16,8 @@ class WTrackText : public WLabel, public TrackDropTarget {
     WTrackText(const char* group, UserSettingsPointer pConfig, QWidget *pParent);
 
   signals:
-    void trackDropped(QString fileName, QString group);
-    void cloneDeck(QString source_group, QString target_group);
+    void trackDropped(QString fileName, QString group) override;
+    void cloneDeck(QString source_group, QString target_group) override;
 
   public slots:
     void slotTrackLoaded(TrackPointer track);

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -34,8 +34,8 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
     void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
 
 signals:
-    void trackDropped(QString filename, QString group);
-    void cloneDeck(QString source_group, QString target_group);
+    void trackDropped(QString filename, QString group) override;
+    void cloneDeck(QString source_group, QString target_group) override;
 
 public slots:
     void slotTrackLoaded(TrackPointer track);


### PR DESCRIPTION
This fixes a bunch of warnings.

| Warning                             | gcc 9.2.0 (master) | gcc 9.2.0 (this branch) | clang 9.0.0 (master) | clang 9.0.0 (this branch)
| ----------------------------------- | ------------ | ----------------- | -------------- | -------------------
| `[-Wclass-memaccess]`               | 1            |                   |                |
| `[-Wdeprecated-copy]`               | 1            | 1                 |                |
| `[-Wdeprecated-declarations]`       | 54           | 18                | 42             | 18
| `[-Winconsistent-missing-override]` |              |                   | 1237           |
| `[-Wrestrict]`                      | 13           | 13                |                |
| `[-Wunused-const-variable]`         |              |                   | 2              |
| `[-Wunused-private-field]`          |              |                   | 6              |

Number of warnings were determined using `$ grep -Po "^src/.*\K\[-W.*\]" stderr.log | sort | uniq -c`.

**EDIT:** Updated the stats above after some new commits (and now using SCons instead of CMake). This also fixes the `-Wclass-memaccess` warning now.

**EDIT 2:** Pushed some more changes, updated the stats above and also checked using clang. To check what warnings are actually generated, I removed the `-Wno-*` flags locally:
```diff
$ git diff
diff --git a/build/depends.py b/build/depends.py
index 3cab15e57b..16f8ba9930 100644
--- a/build/depends.py
+++ b/build/depends.py
@@ -1368,21 +1368,7 @@ class MixxxCore(Feature):
             build.env.Append(CCFLAGS='-Wall')
             build.env.Append(CCFLAGS='-Wextra')

-            if build.compiler_is_gcc and build.gcc_major_version >= 9:
-                # Avoid many warnings from GCC 9 about implicitly defined copy assignment
-                # operators that are deprecated for classes with a user-provided copy
-                # constructor. This affects both Qt 5.12 and Mixxx.
-                build.env.Append(CXXFLAGS='-Wno-deprecated-copy')
-
             if build.compiler_is_clang:
-                # Quiet down Clang warnings about inconsistent use of override
-                # keyword until Qt fixes qt_metacall.
-                build.env.Append(CCFLAGS='-Wno-inconsistent-missing-override')
-
-                # Do not warn about use of the deprecated 'register' keyword
-                # since it produces noise from libraries we depend on using it.
-                build.env.Append(CCFLAGS='-Wno-deprecated-register')
-
                 # Warn about implicit fallthrough.
                 build.env.Append(CCFLAGS='-Wimplicit-fallthrough')
```