### PR TITLE
pop up Spinny (with cover) context menu at click location

### DIFF
--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -632,7 +632,7 @@ void WSpinny::mousePressEvent(QMouseEvent * e) {
     } else {
         if (!m_loadedCover.isNull()) {
             m_pDlgCoverArt->init(m_loadedTrack);
-        } else if (!m_pDlgCoverArt->isVisible()) {
+        } else if (!m_pDlgCoverArt->isVisible() && m_bShowCover) {
             m_pCoverMenu->popup(e->globalPos());
         }
     }

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -633,7 +633,7 @@ void WSpinny::mousePressEvent(QMouseEvent * e) {
         if (!m_loadedCover.isNull()) {
             m_pDlgCoverArt->init(m_loadedTrack);
         } else if (!m_pDlgCoverArt->isVisible()) {
-            m_pCoverMenu->popup(e->pos());
+            m_pCoverMenu->popup(e->globalPos());
         }
     }
 }


### PR DESCRIPTION
fixes https://bugs.launchpad.net/mixxx/+bug/1852829
"spinny context menu (cover art menu actually) pops up at wrong place"

Additionally, the menu now opens only if the Spinny can actually show the cover (instantiated with `<ShowCover>true</ShowCover>`.
I'm not going to fix another inconsistency here which shows the cover menu on top of the Spinny when the cover is empty, but in the full-size cover if there IS a cover.