### PR TITLE
attempt to fix Ubuntu package build

### DIFF
--- a/build/debian/rules
+++ b/build/debian/rules
@@ -33,6 +33,11 @@ MIXXX_SCONS_FLAGS += install_root=$(CURDIR)/debian/tmp/usr
 %:
 	dh $@ --parallel
 
+# dh_auto_configure will attempt to run cmake instead of scons
+# nothing needs to be done for the configure step; scons is run in the build step below
+override_dh_auto_configure:
+	:
+
 override_dh_auto_build:
 	scons $(MIXXX_SCONS_FLAGS)
 	docbook-to-man debian/mixxx.sgml > mixxx.1


### PR DESCRIPTION
Since CMake support has been merged, dh_auto_configure is trying
to use it automatically, but for 2.3 we are still using SCons.