### PR TITLE
Fix property name in DlgPrefAutoDJDlg

### DIFF
--- a/src/preferences/dialog/dlgprefautodjdlg.ui
+++ b/src/preferences/dialog/dlgprefautodjdlg.ui
@@ -75,7 +75,7 @@
         <string>Enable random track addition to queue</string>
        </property>
        <property name="buddy">
-        <cstring>ComboBoxAutoDjRequeue</cstring>
+        <cstring>ComboBoxAutoDjRandomQueue</cstring>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Warning message in the build logs