### PR TITLE
AppData: Replace HTTP with HTTPS in URLs

### DIFF
--- a/res/linux/mixxx.appdata.xml
+++ b/res/linux/mixxx.appdata.xml
@@ -38,14 +38,14 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image>http://www.mixxx.org/static/images/press_art/mixxx_200_deere_skin.png</image>
+      <image>https://www.mixxx.org/static/images/press_art/mixxx_200_deere_skin.png</image>
       <caption>Mixxx with the default Deere skin</caption>
     </screenshot>
   </screenshots>
-  <url type="homepage">http://mixxx.org</url>
-  <url type="bugtracker">https://bugs.launchpad.net/mixxx/</url>
-  <url type="donation">http://www.mixxx.org/support/</url>
-  <url type="help">http://www.mixxx.org/support/</url>
-  <url type="translate">https://www.transifex.com/mixxx-dj-software/public/</url>
+  <url type="homepage">https://mixxx.org</url>
+  <url type="bugtracker">https://bugs.launchpad.net/mixxx</url>
+  <url type="donation">https://www.mixxx.org/support</url>
+  <url type="help">https://www.mixxx.org/support</url>
+  <url type="translate">https://www.transifex.com/mixxx-dj-software/public</url>
   <update_contact>mixxx-devel@lists.sourceforge.net</update_contact>
 </component>


### PR DESCRIPTION
Some minor updates to fix warnings logged by `appstreamcli validate res/linux/mixxx.appdata.xml`.

Unfortunately, even after applying the *type = "desktop-application"* patch from Flathub to appdata.xml the RPM package of Mixxx still doesn't reappear in the Software Center of Fedora 31 (current package version: 2.2.2-4). Might be related to the fact that the fixed appdata.xml is only distributed as an update and the original version is still unsuitable. Installation via `dnf` CLI works though.