### PR TITLE
allow longpress temporary toggle also for OFF state of POWERWINDOW mode

### DIFF
--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -351,8 +351,8 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
             m_clickTimer.setSingleShot(true);
             m_clickTimer.start(ControlPushButtonBehavior::kPowerWindowTimeMillis);
 
-            double value = getControlParameterLeft() == 0.0 ? 1.0 : 0.0;
-            setControlParameterLeftDown(value);
+            double emitValue = getControlParameterLeft() == 0.0 ? 1.0 : 0.0;
+            setControlParameterLeftDown(emitValue);
             m_bPressed = true;
             restyleAndRepaint();
         }
@@ -418,8 +418,8 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
             const bool rightButtonDown = QApplication::mouseButtons() & Qt::RightButton;
             if (m_bPressed && !m_clickTimer.isActive() && !rightButtonDown) {
                 // Release button after timer, but not if right button is clicked
-                double value = getControlParameterLeft() == 0.0 ? 1.0 : 0.0;
-                setControlParameterLeftUp(value);
+                double emitValue = getControlParameterLeft() == 0.0 ? 1.0 : 0.0;
+                setControlParameterLeftUp(emitValue);
             }
             m_bPressed = false;
         } else if (rightClick) {

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -348,12 +348,12 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
     if (m_leftButtonMode == ControlPushButton::POWERWINDOW
             && m_iNoStates == 2) {
         if (leftClick) {
-            if (getControlParameterLeft() == 0.0) {
-                m_clickTimer.setSingleShot(true);
-                m_clickTimer.start(ControlPushButtonBehavior::kPowerWindowTimeMillis);
-            }
+            m_clickTimer.setSingleShot(true);
+            m_clickTimer.start(ControlPushButtonBehavior::kPowerWindowTimeMillis);
+
+            double value = getControlParameterLeft() == 0.0 ? 1.0 : 0.0;
+            setControlParameterLeftDown(value);
             m_bPressed = true;
-            setControlParameterLeftDown(1.0);
             restyleAndRepaint();
         }
         // discharge right clicks here, because is used for latching in POWERWINDOW mode
@@ -418,7 +418,8 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
             const bool rightButtonDown = QApplication::mouseButtons() & Qt::RightButton;
             if (m_bPressed && !m_clickTimer.isActive() && !rightButtonDown) {
                 // Release button after timer, but not if right button is clicked
-                setControlParameterLeftUp(0.0);
+                double value = getControlParameterLeft() == 0.0 ? 1.0 : 0.0;
+                setControlParameterLeftUp(value);
             }
             m_bPressed = false;
         } else if (rightClick) {
@@ -430,7 +431,7 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
 
     if (rightClick) {
         // This is the secondary clickButton function,
-        // due the leak of visual feedback we do not allow a toggle
+        // due the lack of visual feedback we do not allow a toggle
         // function
         m_bPressed = false;
         if (m_rightButtonMode == ControlPushButton::PUSH


### PR DESCRIPTION
[lp1824682](https://bugs.launchpad.net/mixxx/+bug/1824682)

allows to temparily toggle the state of POWERWINDOW pushbuttons also when they're currently enabled.

Example:
temporarily disable the QuickEffect with longpress