### PR TITLE
skins/Shade: Remove unused qss declarations

### DIFF
--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -6,11 +6,6 @@
   background-position:center top;
 }
 
-#Deck WPushButton {
-  font-family: "Open Sans";
-  font-size: 14px;
-}
-
 #DeckRowSmall {
   padding: 3px 3px 2px 3px;
 }
@@ -244,10 +239,6 @@ QTreeView::item:!selected {
     border: 0px;
     border-radius: 2px; */
   }
-
-  #LibraryTimesPlayed::item {
-    color: #cfcfcf;
-    }
 
   /* Button in library "Preview" column */
   #LibraryPreviewButton {


### PR DESCRIPTION
Found with my [`qsscheck.py` script](https://gist.github.com/Holzhaus/145b7731246333e0aa65462bb3bba215):

```bash
$ ./qsscheck.py .
./res/skins/LateNight/style.qss:741:5: ParseError - expected ':'
./res/skins/LateNight/style.qss:1198:3: ParseError - expected ':'
./res/skins/Shade/style.qss:9:1: Unknown object name "#Deck"
./res/skins/Shade/style.qss:248:3: Unknown object name "#LibraryTimesPlayed"
```

Manual verification by grepping through the code did not yield any results, so it seems that this is not a false positive.

The parse errors in LateNight are already fixed in PR #2342.