### PR TITLE
[WIP] Skins :: fix play indicator in all skins

### DIFF
--- a/res/skins/LateNight/deck_row_5_transportLoopJump.xml
+++ b/res/skins/LateNight/deck_row_5_transportLoopJump.xml
@@ -314,6 +314,7 @@
                 </Children>
               </WidgetGroup><!-- Reverse | Cue -->
 
+              <!-- Make play_indicator reliable in all Cue modes -->
               <Template src="skin:button_2state_right_display.xml">
                 <SetVariable name="TooltipId">play_cue_set</SetVariable>
                 <SetVariable name="ObjectName">PlayDeck</SetVariable>


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1855620

In https://github.com/mixxxdj/mixxx/pull/2342#issuecomment-562957300 we discovered the play indicator used for Cue blinking is sometimes not updated correctly.
Right now one button with two connections is used for that purpose in all skins which creates issues with how the Cue blinking affects the Play button.
For example in LateNight the 'pressed' icon is used for blinking (just a red background would be less irritating), and in Deere the Pause icon (confusing).
For Cue blinking, just the background color should change. 

I propose to use the existing pushbuttons, and add an indicator underneath (stacked layout) in order to separate the controls used and also have separate widgets for icons and background colors for the 'special case' of Cue blinking and play_from_cue:

a pushbutton on top takes care of the PLAY control & state (acually `[group],play_indicator`)
* transparent + play/unpressed icon when paused
* opaque + pause/pressed icon when playing

an indicator underneath shows Cue blinking and play_from_cue state with `[group],play`:
* solid, 'inactive' background when paused (no blinking Cue mode)
* covered by opaque Play button when deck is playing
* colored background when playing from Cue or when Cue blinking is applied

This is how I implemented it in Tango back then, and it works reliably.

Another aspect of https://bugs.launchpad.net/mixxx/+bug/1855620 is that the skin didn't receive the proper state of `cue_default` and `play_indicator` with Numark for example mode when Play was quickly pressed repeatedly (easily reproducable with LateNight). When Play is engaged the Cue point is immediately moved to the 'pause position' and `play_indicator` is toggled. It seems skins may miss an CO update when they're still busy painting the previous state with pxmaps and additional styles.