### PR TITLE
Add CMake to Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,10 @@ jobs:
     - name: OSX/clang/SCons build
       os: osx
       compiler: clang
+      cache:
+        directories:
+          - $HOME/Library/Caches/Homebrew
+          - /usr/local/Homebrew
       # Workaround for bug in libopus's opus.h including <opus_multistream.h>
       # instead of <opus/opus_multistream.h>.
       # Virtual X (Xvfb) is needed for analyzer waveform tests
@@ -90,11 +94,22 @@ jobs:
         # lldb doesn't provide an easy way to exit 1 on error:
         # https://bugs.llvm.org/show_bug.cgi?id=27326
         - lldb ./mixxx-test --batch -o run -o quit -k 'thread backtrace all' -k "script import os; os._exit(1)"
+      before_cache:
+        # Avoid indefinite cache growth
+        - brew cleanup
+        # Cache only .git files under "/usr/local/Homebrew" so "brew update"
+        # does not take 5min every build
+        # Source: https://discourse.brew.sh/t/best-practice-for-homebrew-on-travis-brew-update-is-5min-to-build-time/5215/12
+        - find /usr/local/Homebrew \! -regex ".+\.git.+" -delete
 
     - name: OSX/clang/CMake build
       os: osx
       compiler: clang
-      cache: ccache
+      cache:
+        ccache: true
+        directories:
+          - $HOME/Library/Caches/Homebrew
+          - /usr/local/Homebrew
       # Workaround for bug in libopus's opus.h including <opus_multistream.h>
       # instead of <opus/opus_multistream.h>.
       # Virtual X (Xvfb) is needed for analyzer waveform tests
@@ -117,6 +132,13 @@ jobs:
         # Run tests and benchmarks
         - cmake --build . --target test
         - cmake --build . --target benchmark
+      before_cache:
+        # Avoid indefinite cache growth
+        - brew cleanup
+        # Cache only .git files under "/usr/local/Homebrew" so "brew update"
+        # does not take 5min every build
+        # Source: https://discourse.brew.sh/t/best-practice-for-homebrew-on-travis-brew-update-is-5min-to-build-time/5215/12
+        - find /usr/local/Homebrew \! -regex ".+\.git.+" -delete
 
 git:
   depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,10 @@ jobs:
       - export QTDIR="$(find /usr/local/Cellar/qt -d 1 | tail -n 1)"
       - echo "QTDIR=$QTDIR"
       install:
-        - scons -j "$(sysctl -n hw.ncpu)"
+        # We are hardcoding 4 threads here since "$(sysctl -n hw.ncpu)" only
+        # returns 2 and makes the travis job run into a timeout:
+        # https://docs.travis-ci.com/user/reference/overview/#virtualization-environments
+        - scons -j4
       script:
         # lldb doesn't provide an easy way to exit 1 on error:
         # https://bugs.llvm.org/show_bug.cgi?id=27326
@@ -116,8 +119,8 @@ jobs:
       env: >-
         CMAKEFLAGS_EXTRA="-DLOCALECOMPARE=OFF -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5/"
         DISPLAY=:99.0
+        CMAKE_BUILD_PARALLEL_LEVEL=4
       before_install:
-        - export CMAKE_BUILD_PARALLEL_LEVEL="$(sysctl -n hw.ncpu)"
         - brew install ccache
         - export PATH="/usr/local/opt/ccache/bin:$PATH"
         - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ language: c++
 env:
   global:
     - SCONS_MIXXX_COMMON_FLAGS="-j4 test=1 mad=1 faad=1 opus=1 modplug=1 wv=1 hss1394=0 virtualize=0 debug_assertions_fatal=1 verbose=0"
+    - CMAKE_MIXXX_COMMON_FLAGS="-DMAD=ON -DFAAD=ON -DOPUS=ON -DMODPLUG=ON -DWAVPACK=ON -DHSS1394=OFF"
+    - GTEST_COLOR=1
+    - CTEST_OUTPUT_ON_FAILURE=1
 
 jobs:
   include:
@@ -43,6 +46,29 @@ jobs:
         # https://bugs.launchpad.net/mixxx/+bug/1699689
         - ./mixxx-test
 
+    - name: Ubuntu/gcc/CMake build
+      os: linux
+      dist: xenial
+      compiler: gcc
+      cache: ccache
+      # Ubuntu Xenial build prerequisites
+      env: CMAKE_MIXXX_EXTRA_FLAGS="-DLOCALECOMPARE=ON"
+      before_install:
+        - sudo apt-get install -y cmake
+        - export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
+        - cmake --version
+        - ccache -s
+      install:
+        - mkdir cmake_build
+        - cd cmake_build
+        - cmake -L $CMAKE_MIXXX_COMMON_FLAGS $CMAKE_MIXXX_EXTRA_FLAGS ..
+        - cmake --build .
+        - sudo cmake --build . --target install
+      script:
+        # Run tests and benchmarks
+        - cmake --build . --target test
+        - cmake --build . --target benchmark
+
     - name: OSX/clang/SCons build
       os: osx
       compiler: clang
@@ -63,6 +89,32 @@ jobs:
         # lldb doesn't provide an easy way to exit 1 on error:
         # https://bugs.llvm.org/show_bug.cgi?id=27326
         - lldb ./mixxx-test --batch -o run -o quit -k 'thread backtrace all' -k "script import os; os._exit(1)"
+
+    - name: OSX/clang/CMake build
+      os: osx
+      compiler: clang
+      cache: ccache
+      # Workaround for bug in libopus's opus.h including <opus_multistream.h>
+      # instead of <opus/opus_multistream.h>.
+      # Virtual X (Xvfb) is needed for analyzer waveform tests
+      env: >-
+        CMAKE_MIXXX_EXTRA_FLAGS="-DLOCALECOMPARE=OFF -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5/"
+        DISPLAY=:99.0
+      before_install:
+        - export CMAKE_BUILD_PARALLEL_LEVEL="$(sysctl -n hw.ncpu)"
+        - export PATH="/usr/local/opt/ccache/bin:$PATH"
+        - cmake --version
+        - ccache -s
+      install:
+        - mkdir cmake_build
+        - cd cmake_build
+        - cmake -L $CMAKE_MIXXX_COMMON_FLAGS $CMAKE_MIXXX_EXTRA_FLAGS ..
+        - cmake --build .
+        - sudo cmake --build . --target install
+      script:
+        # Run tests and benchmarks
+        - cmake --build . --target test
+        - cmake --build . --target benchmark
 
 git:
   depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ jobs:
       compiler: gcc
       # Ubuntu Xenial build prerequisites
       env: SCONS_MIXXX_EXTRA_FLAGS="localecompare=1"
+      before_install:
+        - sudo apt-get install -y scons
       install:
         - scons $SCONS_MIXXX_COMMON_FLAGS $SCONS_MIXX_EXTRA_FLAGS
       script:
@@ -52,6 +54,7 @@ jobs:
         CXXFLAGS="-isystem /usr/local/include/opus"
         DISPLAY=:99.0
       before_install:
+      - brew install scons
       - export QTDIR="$(find /usr/local/Cellar/qt -d 1 | tail -n 1)"
       - echo "QTDIR=$QTDIR"
       install:
@@ -105,7 +108,6 @@ addons:
       - qt5-default
       - qtscript5-dev
       - qt5keychain-dev
-      - scons
   homebrew:
     update: true
     packages:
@@ -129,7 +131,6 @@ addons:
       - protobuf
       - qt5
       - rubberband
-      - scons
       - sound-touch
       - taglib
       - wavpack

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: c++
 # TODO(2019-07-21): Add "ffmpeg=1" if FFmpeg 4.x becomes available in Ubuntu
 env:
   global:
-    - COMMON_FLAGS="-j4 test=1 mad=1 faad=1 opus=1 modplug=1 wv=1 hss1394=0 virtualize=0 debug_assertions_fatal=1 verbose=0"
+    - SCONS_MIXXX_COMMON_FLAGS="-j4 test=1 mad=1 faad=1 opus=1 modplug=1 wv=1 hss1394=0 virtualize=0 debug_assertions_fatal=1 verbose=0"
 
 jobs:
   include:
@@ -27,21 +27,21 @@ jobs:
             - python3-setuptools
             - python3-wheel
 
-    - name: Ubuntu/gcc build
+    - name: Ubuntu/gcc/SCons build
       os: linux
       dist: xenial
       compiler: gcc
       # Ubuntu Xenial build prerequisites
-      env: EXTRA_FLAGS="localecompare=1"
+      env: SCONS_MIXXX_EXTRA_FLAGS="localecompare=1"
       install:
-        - scons $COMMON_FLAGS $EXTRA_FLAGS
+        - scons $SCONS_MIXXX_COMMON_FLAGS $SCONS_MIXX_EXTRA_FLAGS
       script:
         # NOTE(sblaisot): 2018-01-02 removing gdb wrapper on linux due to a bug in
         # return code in order to avoid having a successful build when a test fail.
         # https://bugs.launchpad.net/mixxx/+bug/1699689
         - ./mixxx-test
 
-    - name: OSX/clang build
+    - name: OSX/clang/SCons build
       os: osx
       compiler: clang
       # Workaround for bug in libopus's opus.h including <opus_multistream.h>
@@ -55,7 +55,7 @@ jobs:
       - export QTDIR="$(find /usr/local/Cellar/qt -d 1 | tail -n 1)"
       - echo "QTDIR=$QTDIR"
       install:
-        - scons $COMMON_FLAGS $EXTRA_FLAGS
+        - scons $SCONS_MIXXX_COMMON_FLAGS $SCONS_MIXXX_EXTRA_FLAGS
       script:
         # lldb doesn't provide an easy way to exit 1 on error:
         # https://bugs.llvm.org/show_bug.cgi?id=27326

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,7 @@ jobs:
         DISPLAY=:99.0
       before_install:
         - export CMAKE_BUILD_PARALLEL_LEVEL="$(sysctl -n hw.ncpu)"
+        - brew install ccache
         - export PATH="/usr/local/opt/ccache/bin:$PATH"
         - cmake --version
         - ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     # For SCons builds
     - SCONSFLAGS="test=1 mad=1 faad=1 opus=1 modplug=1 wv=1 hss1394=0 virtualize=0 debug_assertions_fatal=1 verbose=0"
     # For CMake builds
-    - CMAKE_MIXXX_COMMON_FLAGS="-DMAD=ON -DFAAD=ON -DOPUS=ON -DMODPLUG=ON -DWAVPACK=ON -DHSS1394=OFF"
+    - CMAKEFLAGS="-DMAD=ON -DFAAD=ON -DOPUS=ON -DMODPLUG=ON -DWAVPACK=ON -DHSS1394=OFF"
     - GTEST_COLOR=1
     - CTEST_OUTPUT_ON_FAILURE=1
 
@@ -53,7 +53,7 @@ jobs:
       compiler: gcc
       cache: ccache
       # Ubuntu Xenial build prerequisites
-      env: CMAKE_MIXXX_EXTRA_FLAGS="-DLOCALECOMPARE=ON"
+      env: CMAKEFLAGS_EXTRA="-DLOCALECOMPARE=ON"
       before_install:
         - sudo apt-get install -y cmake
         - export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
@@ -62,7 +62,7 @@ jobs:
       install:
         - mkdir cmake_build
         - cd cmake_build
-        - cmake -L $CMAKE_MIXXX_COMMON_FLAGS $CMAKE_MIXXX_EXTRA_FLAGS ..
+        - cmake -L $CMAKEFLAGS $CMAKEFLAGS_EXTRA ..
         - cmake --build .
         - sudo cmake --build . --target install
       script:
@@ -114,7 +114,7 @@ jobs:
       # instead of <opus/opus_multistream.h>.
       # Virtual X (Xvfb) is needed for analyzer waveform tests
       env: >-
-        CMAKE_MIXXX_EXTRA_FLAGS="-DLOCALECOMPARE=OFF -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5/"
+        CMAKEFLAGS_EXTRA="-DLOCALECOMPARE=OFF -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5/"
         DISPLAY=:99.0
       before_install:
         - export CMAKE_BUILD_PARALLEL_LEVEL="$(sysctl -n hw.ncpu)"
@@ -125,7 +125,7 @@ jobs:
       install:
         - mkdir cmake_build
         - cd cmake_build
-        - cmake -L $CMAKE_MIXXX_COMMON_FLAGS $CMAKE_MIXXX_EXTRA_FLAGS ..
+        - cmake -L $CMAKEFLAGS $CMAKEFLAGS_EXTRA ..
         - cmake --build .
         - sudo cmake --build . --target install
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ language: c++
 # TODO(2019-07-21): Add "ffmpeg=1" if FFmpeg 4.x becomes available in Ubuntu
 env:
   global:
-    - SCONS_MIXXX_COMMON_FLAGS="-j4 test=1 mad=1 faad=1 opus=1 modplug=1 wv=1 hss1394=0 virtualize=0 debug_assertions_fatal=1 verbose=0"
+    # For SCons builds
+    - SCONSFLAGS="test=1 mad=1 faad=1 opus=1 modplug=1 wv=1 hss1394=0 virtualize=0 debug_assertions_fatal=1 verbose=0"
+    # For CMake builds
     - CMAKE_MIXXX_COMMON_FLAGS="-DMAD=ON -DFAAD=ON -DOPUS=ON -DMODPLUG=ON -DWAVPACK=ON -DHSS1394=OFF"
     - GTEST_COLOR=1
     - CTEST_OUTPUT_ON_FAILURE=1
@@ -35,11 +37,10 @@ jobs:
       dist: xenial
       compiler: gcc
       # Ubuntu Xenial build prerequisites
-      env: SCONS_MIXXX_EXTRA_FLAGS="localecompare=1"
       before_install:
         - sudo apt-get install -y scons
       install:
-        - scons $SCONS_MIXXX_COMMON_FLAGS $SCONS_MIXX_EXTRA_FLAGS
+        - scons -j "$(nproc)" localecompare=1
       script:
         # NOTE(sblaisot): 2018-01-02 removing gdb wrapper on linux due to a bug in
         # return code in order to avoid having a successful build when a test fail.
@@ -84,7 +85,7 @@ jobs:
       - export QTDIR="$(find /usr/local/Cellar/qt -d 1 | tail -n 1)"
       - echo "QTDIR=$QTDIR"
       install:
-        - scons $SCONS_MIXXX_COMMON_FLAGS $SCONS_MIXXX_EXTRA_FLAGS
+        - scons -j "$(sysctl -n hw.ncpu)"
       script:
         # lldb doesn't provide an easy way to exit 1 on error:
         # https://bugs.llvm.org/show_bug.cgi?id=27326

--- a/src/test/globaltrackcache_test.cpp
+++ b/src/test/globaltrackcache_test.cpp
@@ -150,7 +150,10 @@ TEST_F(GlobalTrackCacheTest, concurrentDelete) {
     // lp1744550: A decent number of iterations is needed to reliably
     // reveal potential race conditions while evicting tracks from
     // the cache!
-    for (int i = 0; i < 250000; ++i) {
+    // NOTE(2019-12-14, uklotzde): On Travis and macOS executing 10_000
+    // iterations takes ~1 sec. In order to safely finish this test within
+    // the timeout limit of 30 sec. we use 20 * 10_000 = 200_000 iterations.
+    for (int i = 0; i < 200000; ++i) {
         m_recentTrackPtr.reset();
 
         TrackId trackId;


### PR DESCRIPTION
Unlike PR #2332, this does not replace SCons with CMake. Instead it adds CMake builds to the CI config but still keeps the SCons config as well.

This allows us to prevent breakage in either of those two build systems.