### PR TITLE
Fix typos (mixx->mixxx)

### DIFF
--- a/res/controllers/DJ-Tech-Kontrol-One-scripts.js
+++ b/res/controllers/DJ-Tech-Kontrol-One-scripts.js
@@ -1221,7 +1221,7 @@ KONTROL1.getNoShiftNoModBankCode = function getNoShiftNoModBankCode() {//return 
     return outstr;
     };
 
-KONTROL1.getGroup = function getGroup(groupstr) {//return Mixx group
+KONTROL1.getGroup = function getGroup(groupstr) {//return Mixxx group
     if (KONTROL1.debug>2){print("##function: "+KONTROL1.getFunctionName())};
 
     var outstr;

--- a/res/controllers/Denon-MC3000-scripts.js
+++ b/res/controllers/Denon-MC3000-scripts.js
@@ -5,7 +5,7 @@
  *
  * 2012/05/11 V0.995 : first "good" version approuved and tested by me
  *
- * Special Thanks to the Programmers of Mixx and all the contributors
+ * Special Thanks to the Programmers of Mixxx and all the contributors
  *
  * Inspired primarily from Numark Total Control script file 
  *

--- a/res/controllers/Gemini-FirstMix-scripts.js
+++ b/res/controllers/Gemini-FirstMix-scripts.js
@@ -12,7 +12,7 @@
  * This works great except it marks the track as played. I don't see a Mixxx function to toggle the played state for tracks, so there's nothing I can do about that.
  * To see the sampler, click on the word "Sampler" above the main VU meters in the center of the Mixxx window.
  * 
- * EFX/fader knobs: Since the EFX function in Mixx is kinda useless (only a flanger effect that doesn't sound that different), the EFX knobs adjust the gain, 
+ * EFX/fader knobs: Since the EFX function in Mixxx is kinda useless (only a flanger effect that doesn't sound that different), the EFX knobs adjust the gain, 
  * the gain knobs to adjust the high fader and the treble knobs to adjust the mid fader. This way, you get high/mid/low faders.
  * 
  * EFX buttons & Master volume: The EFX buttons are mapped to send that deck to the headphones (a.k.a PFL function). The buttons light up to indicate PFL state.

--- a/res/controllers/Numark-DJ2Go-scripts.js
+++ b/res/controllers/Numark-DJ2Go-scripts.js
@@ -90,7 +90,7 @@ NumarkDJ2Go.deck = function(deckNum) {
 		var yesno = (engine.getValue(this.group, "track_samples") > 0)?true:false;
 		return yesno;
 	};
-	//Brake effect introduced in Mixx 1.11 	
+	//Brake effect introduced in Mixxx 1.11 	
 	this.brakeOn = function(factor) {
         	engine.brake(this.deckNum, true, factor);
 		this.braked= true;
@@ -616,7 +616,7 @@ NumarkDJ2Go.playLights = function(value, group, key) {
 		};
 };
 
-//Mixx's sync feature is not the same as VDJ, where syncing appears to
+//Mixxx's sync feature is not the same as VDJ, where syncing appears to
 //be continuously going on. Therefore less relevance with Mixxx to having a sync button
 //that illuminates. Have set it so that it flashes twice when pressed.
 NumarkDJ2Go.syncLights = function(value, group, key) {

--- a/src/engine/cachingreader/cachingreader.cpp
+++ b/src/engine/cachingreader/cachingreader.cpp
@@ -210,7 +210,7 @@ void CachingReader::newTrack(TrackPointer pTrack) {
     // emit(loadingTrack(pNewTrack, pOldTrack));
     // but the newTrack may change if we load a new track while the previous one
     // is still loading. This leads to inconsistent states for example a different
-    // track in the Mixx Title and the Deck label.
+    // track in the Mixxx Title and the Deck label.
     if (oldState == STATE_TRACK_LOADING &&
             newState == STATE_TRACK_LOADING) {
         kLogger.warning()


### PR DESCRIPTION
Fixes various cosmetic source comment typos. Similar relevant mixco typos have been merged upstream: https://github.com/arximboldi/mixco/commit/3dce9410e7ccd7a0144e579023cad6d1c700473e 