### PR TITLE
Refactor loading of tracks from database

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1408,9 +1408,9 @@ TrackId TrackDAO::getTrackIdByRef(
     }
     {
         GlobalTrackCacheLocker cacheLocker;
-        const auto track = cacheLocker.lookupTrackByRef(trackRef);
-        if (track) {
-            return track->getId();
+        const auto pTrack = cacheLocker.lookupTrackByRef(trackRef);
+        if (pTrack) {
+            return pTrack->getId();
         }
     }
     return getTrackIdByLocation(trackRef.getLocation());
@@ -1423,9 +1423,9 @@ TrackPointer TrackDAO::getTrackByRef(
     }
     {
         GlobalTrackCacheLocker cacheLocker;
-        auto track = cacheLocker.lookupTrackByRef(trackRef);
-        if (track) {
-            return track;
+        auto pTrack = cacheLocker.lookupTrackByRef(trackRef);
+        if (pTrack) {
+            return pTrack;
         }
     }
     auto trackId = trackRef.getId();

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -2023,7 +2023,6 @@ TrackPointer TrackDAO::getOrAddTrack(
 
     DEBUG_ASSERT(trackRef.hasLocation());
     addTracksPrepare();
-    const auto trackLocation = trackRef.getLocation();
     const auto pTrack = addTracksAddFile(trackRef.getLocation(), true);
     addTracksFinish(!pTrack);
     if (!pTrack) {

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -116,7 +116,10 @@ TrackId TrackDAO::getTrackIdByLocation(const QString& location) const {
     }
 
     QSqlQuery query(m_database);
-    query.prepare("SELECT library.id FROM library INNER JOIN track_locations ON library.location = track_locations.id WHERE track_locations.location=:location");
+    query.prepare(
+            "SELECT library.id FROM library "
+            "INNER JOIN track_locations ON library.location = track_locations.id "
+            "WHERE track_locations.location=:location");
     query.bindValue(":location", location);
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
@@ -205,7 +208,11 @@ QList<TrackId> TrackDAO::resolveTrackIds(
         }
         DEBUG_ASSERT(trackIds.size() <= trackFiles.size());
         if (trackIds.size() < trackFiles.size()) {
-            qDebug() << "TrackDAO::getTrackIds(): Found only" << trackIds.size() << "of" << trackFiles.size() << "tracks in library";
+            qDebug() << "TrackDAO::getTrackIds(): Found only"
+                    << trackIds.size()
+                    << "of"
+                    << trackFiles.size()
+                    << "tracks in library";
         }
     } else {
         LOG_FAILED_QUERY(query);

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -110,35 +110,32 @@ void TrackDAO::finish() {
     transaction.commit();
 }
 
-/** Retrieve the track id for the track that's located at "location" on disk.
-    @return the track id for the track located at location, or -1 if the track
-            is not in the database.
-*/
-TrackId TrackDAO::getTrackId(const QString& absoluteFilePath) const {
-
-    TrackId trackId;
-
-    QSqlQuery query(m_database);
-    query.prepare("SELECT library.id FROM library INNER JOIN track_locations ON library.location = track_locations.id WHERE track_locations.location=:location");
-    query.bindValue(":location", absoluteFilePath);
-    if (query.exec()) {
-        if (query.next()) {
-            trackId = TrackId(query.value(query.record().indexOf("id")));
-        } else {
-            qDebug() << "TrackDAO::getTrackId(): Track location not found in library:" << absoluteFilePath;
-        }
-    } else {
-        LOG_FAILED_QUERY(query);
+TrackId TrackDAO::getTrackIdByLocation(const QString& location) const {
+    if (location.isEmpty()) {
         return TrackId();
     }
 
+    QSqlQuery query(m_database);
+    query.prepare("SELECT library.id FROM library INNER JOIN track_locations ON library.location = track_locations.id WHERE track_locations.location=:location");
+    query.bindValue(":location", location);
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query);
+        return TrackId();
+    }
+    if (!query.next()) {
+        qDebug() << "TrackDAO::getTrackId(): Track location not found in library:" << location;
+        return TrackId();
+    }
+    const auto trackId = TrackId(query.value(query.record().indexOf("id")));
+    DEBUG_ASSERT(trackId.isValid());
     return trackId;
 }
 
-QList<TrackId> TrackDAO::resolveTrackIds(const QList<QFileInfo>& files,
+QList<TrackId> TrackDAO::resolveTrackIds(
+        const QList<TrackFile>& trackFiles,
         ResolveTrackIdFlags flags) {
     QList<TrackId> trackIds;
-    trackIds.reserve(files.size());
+    trackIds.reserve(trackFiles.size());
 
     // Create a temporary database of the paths of all the imported tracks.
     QSqlQuery query(m_database);
@@ -151,9 +148,9 @@ QList<TrackId> TrackDAO::resolveTrackIds(const QList<QFileInfo>& files,
     }
 
     QStringList pathList;
-    pathList.reserve(files.size());
-    for (const auto& file: files) {
-        pathList << "(" + SqlStringFormatter::format(m_database, file.absoluteFilePath()) + ")";
+    pathList.reserve(trackFiles.size());
+    for (const auto& trackFile: trackFiles) {
+        pathList << "(" + SqlStringFormatter::format(m_database, trackFile.location()) + ")";
     }
 
     // Add all the track paths temporary to this database.
@@ -206,9 +203,9 @@ QList<TrackId> TrackDAO::resolveTrackIds(const QList<QFileInfo>& files,
         while (query.next()) {
             trackIds.append(TrackId(query.value(idColumn)));
         }
-        DEBUG_ASSERT(trackIds.size() <= files.size());
-        if (trackIds.size() < files.size()) {
-            qDebug() << "TrackDAO::getTrackIds(): Found only" << trackIds.size() << "of" << files.size() << "tracks in library";
+        DEBUG_ASSERT(trackIds.size() <= trackFiles.size());
+        if (trackIds.size() < trackFiles.size()) {
+            qDebug() << "TrackDAO::getTrackIds(): Found only" << trackIds.size() << "of" << trackFiles.size() << "tracks in library";
         }
     } else {
         LOG_FAILED_QUERY(query);
@@ -1397,6 +1394,44 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
     return pTrack;
 }
 
+TrackId TrackDAO::getTrackIdByRef(
+        const TrackRef& trackRef) const {
+    if (trackRef.getId().isValid()) {
+        return trackRef.getId();
+    }
+    {
+        GlobalTrackCacheLocker cacheLocker;
+        const auto track = cacheLocker.lookupTrackByRef(trackRef);
+        if (track) {
+            return track->getId();
+        }
+    }
+    return getTrackIdByLocation(trackRef.getLocation());
+}
+
+TrackPointer TrackDAO::getTrackByRef(
+        const TrackRef& trackRef) const {
+    if (!trackRef.isValid()) {
+        return TrackPointer();
+    }
+    {
+        GlobalTrackCacheLocker cacheLocker;
+        auto track = cacheLocker.lookupTrackByRef(trackRef);
+        if (track) {
+            return track;
+        }
+    }
+    auto trackId = trackRef.getId();
+    if (!trackId.isValid()) {
+        trackId = getTrackIdByLocation(trackRef.getLocation());
+    }
+    if (!trackId.isValid()) {
+        qWarning() << "Track not found:" << trackRef;
+        return TrackPointer();
+    }
+    return getTrackById(trackId);
+}
+
 // Saves a track's info back to the database
 bool TrackDAO::updateTrack(Track* pTrack) {
     const TrackId trackId = pTrack->getId();
@@ -1962,39 +1997,51 @@ void TrackDAO::detectCoverArtForTracksWithoutCover(volatile const bool* pCancel,
     }
 }
 
-TrackPointer TrackDAO::getOrAddTrackByLocation(
-        const QString& trackLocation,
+TrackPointer TrackDAO::getOrAddTrack(
+        const TrackRef& trackRef,
         bool* pAlreadyInLibrary) {
-    const TrackId trackId = getTrackId(trackLocation);
-    if (pAlreadyInLibrary) {
-        *pAlreadyInLibrary = trackId.isValid();
+    if (!trackRef.isValid()) {
+        return TrackPointer();
     }
 
-    TrackPointer pTrack;
+    const TrackId trackId = getTrackIdByRef(trackRef);
     if (trackId.isValid()) {
-        pTrack = getTrackById(trackId);
-        if (!pTrack) {
-            qWarning() << "Failed to load track"
-                    << trackLocation;
+        const auto pTrack = getTrackById(trackId);
+        if (pTrack) {
+            if (pAlreadyInLibrary) {
+                *pAlreadyInLibrary = true;
+            }
             return pTrack;
         }
-    } else {
-        // Add Track to library -- unremove if it was previously removed.
-        addTracksPrepare();
-        pTrack = addTracksAddFile(trackLocation, true);
-        addTracksFinish(!pTrack);
-        if (!pTrack) {
-            qWarning() << "Failed to add track"
-                    << trackLocation;
-            return pTrack;
+        if (!trackRef.hasLocation()) {
+            qWarning()
+                    << "Failed to get track"
+                    << trackRef;
+            return TrackPointer();
         }
-        // If the track wasn't in the library already then it has not yet
-        // been checked for cover art.
-        CoverArtCache* pCache = CoverArtCache::instance();
-        if (pCache) {
-            // Process cover art asynchronously
-            pCache->requestGuessCover(pTrack);
-        }
+    }
+
+    DEBUG_ASSERT(trackRef.hasLocation());
+    addTracksPrepare();
+    const auto trackLocation = trackRef.getLocation();
+    const auto pTrack = addTracksAddFile(trackRef.getLocation(), true);
+    addTracksFinish(!pTrack);
+    if (!pTrack) {
+        qWarning()
+                << "Failed to add track"
+                << trackRef;
+        return TrackPointer();
+    }
+    if (pAlreadyInLibrary) {
+        *pAlreadyInLibrary = false;
+    }
+
+    // If the track wasn't in the library already then it has not yet
+    // been checked for cover art.
+    CoverArtCache* pCache = CoverArtCache::instance();
+    if (pCache) {
+        // Process cover art asynchronously
+        pCache->requestGuessCover(pTrack);
     }
 
     return pTrack;

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -47,10 +47,17 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     }
     void finish();
 
-    TrackId getTrackId(const QString& absoluteFilePath) const;
-    QList<TrackId> resolveTrackIds(const QList<QFileInfo> &files,
-            ResolveTrackIdFlags flags);
-    QList<TrackId> getAllTrackIds(const QDir& rootDir);
+    QList<TrackId> resolveTrackIds(
+            const QList<TrackFile> &trackFiles,
+            ResolveTrackIdFlags flags = ResolveTrackIdFlag::ResolveOnly);
+
+    TrackId getTrackIdByRef(
+            const TrackRef& trackRef) const;
+    QList<TrackId> getAllTrackIds(
+            const QDir& rootDir);
+
+    TrackPointer getTrackByRef(
+            const TrackRef& trackRef) const;
 
     // Returns a set of all track locations in the library.
     QSet<QString> getTrackLocations();
@@ -90,16 +97,18 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     friend class LibraryScanner;
     friend class TrackCollection;
 
-    TrackPointer getTrackById(TrackId trackId) const;
+    TrackId getTrackIdByLocation(
+            const QString& location) const;
+    TrackPointer getTrackById(
+            TrackId trackId) const;
 
-    // Fetches trackLocation from the database or adds it. If searchForCoverArt
-    // is true, searches the track and its directory for cover art via
-    // asynchronous request to CoverArtCache. If adding or fetching the track
-    // fails, returns a transient TrackPointer for trackLocation. If
-    // pAlreadyInLibrary is non-NULL, sets it to whether trackLocation was
-    // already in the database.
-    TrackPointer getOrAddTrackByLocation(
-            const QString& trackLocation,
+    // Loads a track from the database (by id if available, otherwise by location)
+    // or adds it if not found in case the location is known. The (optional) out
+    // parameter is set if the track has been found (-> true) or added (-> false).
+    // Asynchronously imports cover art for newly added tracks. On failure a nullptr
+    // is returned and pAlreadyInLibrary is left untouched.
+    TrackPointer getOrAddTrack(
+            const TrackRef& trackRef,
             bool* pAlreadyInLibrary = nullptr);
 
     void addTracksPrepare();

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -144,8 +144,9 @@ void TrackCollection::relocateDirectory(QString oldDir, QString newDir) {
 }
 
 QList<TrackId> TrackCollection::resolveTrackIds(
-        const QList<QFileInfo>& files, TrackDAO::ResolveTrackIdFlags flags) {
-    QList<TrackId> trackIds = m_trackDao.resolveTrackIds(files, flags);
+        const QList<TrackFile>& trackFiles,
+        TrackDAO::ResolveTrackIdFlags flags) {
+    QList<TrackId> trackIds = m_trackDao.resolveTrackIds(trackFiles, flags);
     if (flags & TrackDAO::ResolveTrackIdFlag::UnhideHidden) {
         unhideTracks(trackIds);
     }
@@ -154,7 +155,7 @@ QList<TrackId> TrackCollection::resolveTrackIds(
 
 QList<TrackId> TrackCollection::resolveTrackIdsFromUrls(
         const QList<QUrl>& urls, bool addMissing) {
-    QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
+    QList<TrackFile> files = DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
     if (files.isEmpty()) {
         return QList<TrackId>();
     }
@@ -169,18 +170,15 @@ QList<TrackId> TrackCollection::resolveTrackIdsFromUrls(
 
 QList<TrackId> TrackCollection::resolveTrackIdsFromLocations(
         const QList<QString>& locations) {
-    QList<QFileInfo> fileInfoList;
-    foreach(QString fileLocation, locations) {
-        QFileInfo fileInfo(fileLocation);
-        fileInfoList.append(fileInfo);
+    QList<TrackFile> trackFiles;
+    trackFiles.reserve(locations.size());
+    for (const QString& location : locations) {
+        trackFiles.append(TrackFile(location));
     }
-    return resolveTrackIds(fileInfoList,
+    return resolveTrackIds(trackFiles,
             TrackDAO::ResolveTrackIdFlag::UnhideHidden
                     | TrackDAO::ResolveTrackIdFlag::AddMissing);
 }
-
-QList<TrackId> resolveTrackIdsFromUrls(const QList<QUrl>& urls,
-        TrackDAO::ResolveTrackIdFlags flags);
 
 bool TrackCollection::hideTracks(const QList<TrackId>& trackIds) {
     DEBUG_ASSERT(QApplication::instance()->thread() == QThread::currentThread());
@@ -461,26 +459,24 @@ void TrackCollection::saveTrack(Track* pTrack) {
 }
 
 TrackPointer TrackCollection::getTrackById(
-        const TrackId& trackId) const {
+        TrackId trackId) const {
     return m_trackDao.getTrackById(trackId);
+}
+
+TrackPointer TrackCollection::getTrackByRef(
+        const TrackRef& trackRef) const {
+    return m_trackDao.getTrackByRef(trackRef);
+}
+
+TrackId TrackCollection::getTrackIdByRef(
+        const TrackRef& trackRef) const {
+    return m_trackDao.getTrackIdByRef(trackRef);
 }
 
 TrackPointer TrackCollection::getOrAddTrack(
         const TrackRef& trackRef,
         bool* pAlreadyInLibrary) {
-    TrackPointer pTrack;
-    if (trackRef.hasId()) {
-        pTrack = getTrackById(trackRef.getId());
-        if (pAlreadyInLibrary) {
-            *pAlreadyInLibrary = pTrack != nullptr;
-        }
-    }
-    if (!pTrack && trackRef.hasLocation()) {
-        pTrack = m_trackDao.getOrAddTrackByLocation(
-                trackRef.getLocation(),
-                pAlreadyInLibrary);
-    }
-    return pTrack;
+    return m_trackDao.getOrAddTrack(trackRef, pAlreadyInLibrary);
 }
 
 TrackId TrackCollection::addTrack(

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -65,9 +65,11 @@ class TrackCollection : public QObject,
 
     // This function returns a track ID of all file in the list not already visible,
     // it adds and unhides the tracks as well.
-    QList<TrackId> resolveTrackIds(const QList<QFileInfo> &files,
+    QList<TrackId> resolveTrackIds(
+            const QList<TrackFile> &trackFiles,
             TrackDAO::ResolveTrackIdFlags flags);
-    QList<TrackId> resolveTrackIdsFromUrls(const QList<QUrl>& urls,
+    QList<TrackId> resolveTrackIdsFromUrls(
+            const QList<QUrl>& urls,
             bool addMissing);
     QList<TrackId> resolveTrackIdsFromLocations(
             const QList<QString>& locations);
@@ -81,7 +83,12 @@ class TrackCollection : public QObject,
     bool updateAutoDjCrate(CrateId crateId, bool isAutoDjSource);
 
     TrackPointer getTrackById(
-            const TrackId& trackId) const;
+            TrackId trackId) const;
+
+    TrackPointer getTrackByRef(
+            const TrackRef& trackRef) const;
+    TrackId getTrackIdByRef(
+            const TrackRef& trackRef) const;
 
     // Only public for tests
     TrackPointer getOrAddTrack(

--- a/src/track/trackref.h
+++ b/src/track/trackref.h
@@ -10,7 +10,7 @@
 //
 // This class is intended to be used as a simple, almost immutable
 // value object. Only the id can be set once.
-class TrackRef {
+class TrackRef final {
 public:
     // Converts a TrackFile and an optional TrackId into a TrackRef. This
     // involves obtaining the file-related track properties from QFileInfo
@@ -76,6 +76,7 @@ public:
     bool isValid() const {
         return hasId() || hasCanonicalLocation();
     }
+
 protected:
     // Initializing constructor
     TrackRef(

--- a/src/util/dnd.h
+++ b/src/util/dnd.h
@@ -2,7 +2,6 @@
 
 #include <QDrag>
 #include <QDropEvent>
-#include <QFileInfo>
 #include <QList>
 #include <QMimeData>
 #include <QString>
@@ -16,7 +15,7 @@ class DragAndDropHelper final {
   public:
     DragAndDropHelper() = delete;
 
-    static QList<QFileInfo> supportedTracksFromUrls(
+    static QList<TrackFile> supportedTracksFromUrls(
             const QList<QUrl>& urls,
             bool firstOnly,
             bool acceptPlaylists);

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -44,7 +44,7 @@ void WLibrarySidebar::dragEnterEvent(QDragEnterEvent * event) {
         // drag so for now we accept all drags. Since almost every
         // LibraryFeature accepts all files in the drop and accepts playlist
         // drops we default to those flags to DragAndDropHelper.
-        QList<QFileInfo> files = DragAndDropHelper::supportedTracksFromUrls(
+        QList<TrackFile> files = DragAndDropHelper::supportedTracksFromUrls(
                 event->mimeData()->urls(), false, true);
         if (!files.isEmpty()) {
             event->acceptProposedAction();

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -70,7 +70,7 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
     // rejected -- rryan 3/2011
     QTreeView::dragMoveEvent(event);
     if (event->mimeData()->hasUrls()) {
-        QList<QUrl> urls(event->mimeData()->urls());
+        const QList<QUrl> urls = event->mimeData()->urls();
         // Drag and drop within this widget
         if ((event->source() == this)
                 && (event->possibleActions() & Qt::MoveAction)) {
@@ -139,7 +139,7 @@ void WLibrarySidebar::dropEvent(QDropEvent * event) {
                 QModelIndex destIndex = indexAt(event->pos());
                 // event->source() will return NULL if something is dropped from
                 // a different application
-                QList<QUrl> urls(event->mimeData()->urls());
+                const QList<QUrl> urls = event->mimeData()->urls();
                 if (sidebarModel->dropAccept(destIndex, urls, event->source())) {
                     event->acceptProposedAction();
                 } else {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1351,12 +1351,12 @@ void WTrackTableView::dropEvent(QDropEvent * event) {
         this->selectionModel()->clear();
 
         // Add all the dropped URLs/tracks to the track model (playlist/crate)
-        QList<QFileInfo> fileList = DragAndDropHelper::supportedTracksFromUrls(
+        QList<TrackFile> trackFiles = DragAndDropHelper::supportedTracksFromUrls(
             event->mimeData()->urls(), false, true);
 
         QList<QString> fileLocationList;
-        for (const QFileInfo& fileInfo : fileList) {
-            fileLocationList.append(TrackFile(fileInfo).location());
+        for (const TrackFile& trackFile : trackFiles) {
+            fileLocationList.append(trackFile.location());
         }
 
         // Drag-and-drop from an external application


### PR DESCRIPTION
Another refactoring that consolidates various functions for loading tracks from the internal database:
- Use `TrackFile` instead of `QFileInfo` for track locations
- Use `TrackRef` containing either a `TrackId` or a file path (`TrackFile`) with the location
- Use differing functions names to better distinguish overloaded functions
- Fixed outdated comments

The utility classes `TrackFile` and `TrackRef` improve type-safety and ensure correct conversion between `QUrl` <-> `QFileInfo` <-> `QSting` when dealing with for *track locations*.

Not all variants are currently used, but are required for the integration of *aoide* as an external library.

Preview: The next PR will finally fix the metadata handling (import/export) for tracks and allow to support additional fields that are only stored in file tags but not (yet) in the database.