### PR TITLE
Don't hide tracks when adding to crates

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1824,7 +1824,7 @@ void WTrackTableView::addSelectionToNewCrate() {
             m_pTrackCollectionManager->internalCollection(), m_pConfig).createEmptyCrate();
 
     if (crateId.isValid()) {
-        m_pTrackCollectionManager->hideTracks(trackIds);
+        m_pTrackCollectionManager->unhideTracks(trackIds);
         m_pTrackCollectionManager->internalCollection()->addCrateTracks(crateId, trackIds);
     }
 


### PR DESCRIPTION
A nasty little bug slipped into master! This might have happened while resolving merge conflicts.