### PR TITLE
Fix race condition when checking for external collections

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -491,9 +491,6 @@ void WTrackTableView::createActions() {
             this, SLOT(slotExportTrackMetadataIntoFileTags()));
 
     for (const auto& externalTrackCollection : m_pTrackCollectionManager->externalCollections()) {
-        if (!externalTrackCollection->isConnected()) {
-            continue; // skip
-        }
         UpdateExternalTrackCollection updateInExternalTrackCollection;
         updateInExternalTrackCollection.externalTrackCollection = externalTrackCollection;
         updateInExternalTrackCollection.action = new QAction(externalTrackCollection->name(), this);


### PR DESCRIPTION
The check was too early and sometimes the context menu action(s) wasn't shown at all. Now it is only disabled while not connected when opening the context menu.