### PR TITLE
Improve synchronization of track metadata and file tags

### DIFF
--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -5,6 +5,7 @@
 
 #include "library/coverartcache.h"
 #include "library/coverartutils.h"
+#include "util/compatibility.h"
 #include "util/logger.h"
 
 
@@ -201,15 +202,16 @@ void CoverArtCache::requestGuessCover(TrackPointer pTrack) {
 }
 
 void CoverArtCache::guessCover(TrackPointer pTrack) {
-    if (pTrack) {
-        if (kLogger.debugEnabled()) {
-            kLogger.debug()
-                    << "Guessing cover art for"
-                    << pTrack->getFileInfo();
-        }
-        CoverInfo cover = CoverArtUtils::guessCoverInfo(*pTrack);
-        pTrack->setCoverInfo(cover);
+    VERIFY_OR_DEBUG_ASSERT(pTrack) {
+        return;
     }
+    if (kLogger.debugEnabled()) {
+        kLogger.debug()
+                << "Guessing cover art for"
+                << pTrack->getFileInfo();
+    }
+    pTrack->setCoverInfo(
+            CoverArtUtils::guessCoverInfo(*pTrack));
 }
 
 void CoverArtCache::guessCovers(QList<TrackPointer> tracks) {
@@ -217,9 +219,9 @@ void CoverArtCache::guessCovers(QList<TrackPointer> tracks) {
         kLogger.debug()
                 << "Guessing cover art for"
                 << tracks.size()
-                << "tracks";
+                << "track(s)";
     }
-    foreach (TrackPointer pTrack, tracks) {
+    for (TrackPointer pTrack : qAsConst(tracks)) {
         guessCover(pTrack);
     }
 }

--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -211,7 +211,7 @@ void CoverArtCache::guessCover(TrackPointer pTrack) {
                 << pTrack->getFileInfo();
     }
     pTrack->setCoverInfo(
-            CoverArtUtils::guessCoverInfo(*pTrack));
+            CoverInfoGuesser().guessCoverInfoForTrack(*pTrack));
 }
 
 void CoverArtCache::guessCovers(QList<TrackPointer> tracks) {

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -81,10 +81,16 @@ QImage CoverArtUtils::loadCover(const CoverInfo& info) {
 
 //static
 CoverInfoRelative CoverArtUtils::guessCoverInfo(
-        const Track& track) {
+        const Track& track,
+        QImage embeddedCover) {
     const auto trackFile = track.getFileInfo();
 
-    QImage image = extractEmbeddedCover(trackFile, track.getSecurityToken());
+    QImage image;
+    if (embeddedCover.isNull()) {
+        image = extractEmbeddedCover(trackFile, track.getSecurityToken());
+    } else {
+        image = std::move(embeddedCover);
+    }
     if (!image.isNull()) {
         CoverInfoRelative coverInfo;
         coverInfo.source = CoverInfo::GUESSED;

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -51,13 +51,14 @@ class CoverArtUtils {
     };
 
     // Guesses the cover art for the provided track.
-    static CoverInfo guessCoverInfo(const Track& track);
+    static CoverInfoRelative guessCoverInfo(
+            const Track& track);
 
     static QLinkedList<QFileInfo> findPossibleCoversInFolder(
             const QString& folder);
 
     // Selects an appropriate cover file from provided list of image files.
-    static CoverInfo selectCoverArtForTrack(
+    static CoverInfoRelative selectCoverArtForTrack(
             const Track& track,
             const QLinkedList<QFileInfo>& covers);
 

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -1,18 +1,18 @@
-#ifndef COVERARTUTILS_H
-#define COVERARTUTILS_H
+#pragma once
 
 #include <QImage>
 #include <QString>
 #include <QStringList>
 #include <QSize>
 #include <QFileInfo>
-#include <QLinkedList>
+#include <QList>
 
 #include "track/track.h"
 #include "util/sandbox.h"
 
 class CoverInfo;
 class CoverInfoRelative;
+
 
 class CoverArtUtils {
   public:
@@ -51,21 +51,16 @@ class CoverArtUtils {
     };
 
     // Guesses the cover art for the provided track.
-    // If a non-null image is provided as an optional argument
-    // then this is assumed to contain the embedded cover art
-    // that has already been extracted from the track's file
-    // beforehand.
     static CoverInfoRelative guessCoverInfo(
-            const Track& track,
-            QImage embeddedCover = QImage());
+            const Track& track);
 
-    static QLinkedList<QFileInfo> findPossibleCoversInFolder(
+    static QList<QFileInfo> findPossibleCoversInFolder(
             const QString& folder);
 
     // Selects an appropriate cover file from provided list of image files.
     static CoverInfoRelative selectCoverArtForTrack(
             const Track& track,
-            const QLinkedList<QFileInfo>& covers);
+            const QList<QFileInfo>& covers);
 
     // Selects an appropriate cover file from provided list of image
     // files. Assumes a SecurityTokenPointer is held by the caller for all files
@@ -73,11 +68,30 @@ class CoverArtUtils {
     static CoverInfoRelative selectCoverArtForTrack(
             const TrackFile& trackFile,
             const QString& albumName,
-            const QLinkedList<QFileInfo>& covers);
+            const QList<QFileInfo>& covers);
 
 
   private:
     CoverArtUtils() {}
 };
 
-#endif /* COVERARTUTILS_H */
+// Stateful guessing of cover art by caching the possible
+// covers from the last visited folder.
+class CoverInfoGuesser {
+  public:
+    // Guesses the cover art for the provided track.
+    // An embedded cover must be extracted beforehand and provided.
+    CoverInfoRelative guessCoverInfo(
+            const TrackFile& trackFile,
+            const QString& albumName,
+            const QImage& embeddedCover);
+
+    // Extracts an embedded cover image if available and guesses
+    // the cover art for the provided track.
+    CoverInfoRelative guessCoverInfoForTrack(
+            const Track& track);
+
+  private:
+    QString m_cachedFolder;
+    QList<QFileInfo> m_cachedPossibleCoversInFolder;
+};

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -51,8 +51,13 @@ class CoverArtUtils {
     };
 
     // Guesses the cover art for the provided track.
+    // If a non-null image is provided as an optional argument
+    // then this is assumed to contain the embedded cover art
+    // that has already been extracted from the track's file
+    // beforehand.
     static CoverInfoRelative guessCoverInfo(
-            const Track& track);
+            const Track& track,
+            QImage embeddedCover = QImage());
 
     static QLinkedList<QFileInfo> findPossibleCoversInFolder(
             const QString& folder);

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1344,33 +1344,6 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
         SoundSourceProxy(pTrack).updateTrackFromSource();
     }
 
-    // Data migration: Reload track total from file tags if not initialized
-    // yet. The added column "tracktotal" has been initialized with the
-    // default value "//".
-    // See also: Schema revision 26 in schema.xml
-    if (pTrack->getTrackTotal() == "//") {
-        // Reload track total from file tags if the special track
-        // total migration value "//" indicates that the track total
-        // is missing and needs to be reloaded.
-        qDebug() << "Reloading value for 'tracktotal' once-only from file"
-                " to replace the default value introduced with a previous"
-                " schema upgrade";
-        mixxx::TrackMetadata trackMetadata;
-        if (SoundSourceProxy(pTrack).importTrackMetadata(&trackMetadata) == mixxx::MetadataSource::ImportResult::Succeeded) {
-            // Copy the track total from the temporary track object
-            pTrack->setTrackTotal(trackMetadata.getTrackInfo().getTrackTotal());
-            // Also set the track number if it is still empty due
-            // to insufficient parsing capabilities of Mixxx in
-            // previous versions.
-            if (!trackMetadata.getTrackInfo().getTrackNumber().isEmpty() && pTrack->getTrackNumber().isEmpty()) {
-                pTrack->setTrackNumber(trackMetadata.getTrackInfo().getTrackNumber());
-            }
-        } else {
-            qWarning() << "Failed to reload value for 'tracktotal' from file tags:"
-                    << trackLocation;
-        }
-    }
-
     // Listen to dirty and changed signals
     connect(pTrack.get(),
             &Track::dirty,

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -170,7 +170,8 @@ void DlgCoverArtFullSize::slotReloadCoverArt() {
         return;
     }
     slotCoverInfoSelected(
-            CoverArtUtils::guessCoverInfo(*m_pLoadedTrack));
+            CoverInfoGuesser().guessCoverInfoForTrack(
+                    *m_pLoadedTrack));
 }
 
 void DlgCoverArtFullSize::slotCoverInfoSelected(

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -166,18 +166,19 @@ void DlgCoverArtFullSize::slotCoverFound(const QObject* pRequestor,
 
 // slots to handle signals from the context menu
 void DlgCoverArtFullSize::slotReloadCoverArt() {
-    if (m_pLoadedTrack != nullptr) {
-        auto coverInfo =
-                CoverArtUtils::guessCoverInfo(*m_pLoadedTrack);
-        slotCoverInfoSelected(coverInfo);
+    if (!m_pLoadedTrack) {
+        return;
     }
+    slotCoverInfoSelected(
+            CoverArtUtils::guessCoverInfo(*m_pLoadedTrack));
 }
 
-void DlgCoverArtFullSize::slotCoverInfoSelected(const CoverInfoRelative& coverInfo) {
-    // qDebug() << "DlgCoverArtFullSize::slotCoverInfoSelected" << coverInfo;
-    if (m_pLoadedTrack != nullptr) {
-        m_pLoadedTrack->setCoverInfo(coverInfo);
+void DlgCoverArtFullSize::slotCoverInfoSelected(
+        const CoverInfoRelative& coverInfo) {
+    if (!m_pLoadedTrack) {
+        return;
     }
+    m_pLoadedTrack->setCoverInfo(coverInfo);
 }
 
 void DlgCoverArtFullSize::mousePressEvent(QMouseEvent* event) {

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -281,7 +281,9 @@ void DlgTrackInfo::slotReloadCoverArt() {
     VERIFY_OR_DEBUG_ASSERT(m_pLoadedTrack) {
         return;
     }
-    slotCoverInfoSelected(CoverArtUtils::guessCoverInfo(*m_pLoadedTrack));
+    slotCoverInfoSelected(
+            CoverInfoGuesser().guessCoverInfoForTrack(
+                    *m_pLoadedTrack));
 }
 
 void DlgTrackInfo::slotCoverInfoSelected(const CoverInfoRelative& coverInfo) {

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -281,9 +281,7 @@ void DlgTrackInfo::slotReloadCoverArt() {
     VERIFY_OR_DEBUG_ASSERT(m_pLoadedTrack) {
         return;
     }
-    CoverInfo coverInfo =
-            CoverArtUtils::guessCoverInfo(*m_pLoadedTrack);
-    slotCoverInfoSelected(coverInfo);
+    slotCoverInfoSelected(CoverArtUtils::guessCoverInfo(*m_pLoadedTrack));
 }
 
 void DlgTrackInfo::slotCoverInfoSelected(const CoverInfoRelative& coverInfo) {

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -26,12 +26,12 @@ Logger kLogger("MetadataSourceTagLib");
 const bool kExportTrackMetadataIntoTemporaryFile = true;
 
 // Appended to the original file name of the temporary file used for writing
-const QString kSafelyWritableTempFileSuffix = "_temp";
+const QString kSafelyWritableTempFileSuffix = QStringLiteral("_temp");
 
 // Appended to the original file name for renaming and before deleting this
 // file. Should not be longer than kSafelyWritableTempFileSuffix to avoid
 // potential failures caused by exceeded path length.
-const QString kSafelyWritableOrigFileSuffix = "_orig";
+const QString kSafelyWritableOrigFileSuffix = QStringLiteral("_orig");
 
 // Workaround for missing functionality in TagLib 1.11.x that
 // doesn't support to read text chunks from AIFF files.

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -438,30 +438,11 @@ void SoundSourceProxy::updateTrackFromSource(
 
     if (pCoverImg) {
         // If the pointer is not null then the cover art should be guessed
-        // from the embedded metadata
-        CoverInfoRelative coverInfoNew;
-        DEBUG_ASSERT(coverInfoNew.coverLocation.isNull());
-        if (pCoverImg->isNull()) {
-            // Cover art will be cleared
-            DEBUG_ASSERT(coverInfoNew.source == CoverInfo::UNKNOWN);
-            DEBUG_ASSERT(coverInfoNew.type == CoverInfo::NONE);
-            if (kLogger.debugEnabled()) {
-                kLogger.debug()
-                        << "No embedded cover art found in file"
-                        << getUrl().toString();
-            }
-        } else {
-            coverInfoNew.source = CoverInfo::GUESSED;
-            coverInfoNew.type = CoverInfo::METADATA;
-            // TODO(XXX) here we may introduce a duplicate hash code
-            coverInfoNew.hash = CoverArtUtils::calculateHash(coverImg);
-            if (kLogger.debugEnabled()) {
-                kLogger.debug()
-                        << "Embedded cover art found in file"
-                        << getUrl().toString();
-            }
-        }
-        m_pTrack->setCoverInfo(coverInfoNew);
+        auto coverInfo =
+                CoverArtUtils::guessCoverInfo(
+                        *m_pTrack, *pCoverImg);
+        DEBUG_ASSERT(coverInfo.source == CoverInfo::GUESSED);
+        m_pTrack->setCoverInfo(coverInfo);
     }
 }
 

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -342,9 +342,9 @@ void SoundSourceProxy::updateTrackFromSource(
     DEBUG_ASSERT(coverImg.isNull());
     QImage* pCoverImg = nullptr; // pointer also serves as a flag
     if (!mergeImportedMetadata) {
-        const CoverInfoRelative coverInfoOld = m_pTrack->getCoverInfo();
-        if (coverInfoOld.source == CoverInfo::USER_SELECTED &&
-                coverInfoOld.type == CoverInfo::FILE) {
+        const auto coverInfo = m_pTrack->getCoverInfo();
+        if (coverInfo.source == CoverInfo::USER_SELECTED &&
+                coverInfo.type == CoverInfo::FILE) {
             // Ignore embedded cover art
             if (kLogger.debugEnabled()) {
                 kLogger.debug()

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -439,8 +439,10 @@ void SoundSourceProxy::updateTrackFromSource(
     if (pCoverImg) {
         // If the pointer is not null then the cover art should be guessed
         auto coverInfo =
-                CoverArtUtils::guessCoverInfo(
-                        *m_pTrack, *pCoverImg);
+                CoverInfoGuesser().guessCoverInfo(
+                        m_pTrack->getFileInfo(),
+                        m_pTrack->getAlbum(),
+                        *pCoverImg);
         DEBUG_ASSERT(coverInfo.source == CoverInfo::GUESSED);
         m_pTrack->setCoverInfo(coverInfo);
     }

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -323,19 +323,16 @@ void SoundSourceProxy::updateTrackFromSource(
     // at all and this information would get lost entirely otherwise!
     mixxx::TrackMetadata trackMetadata;
     bool metadataSynchronized = false;
-    m_pTrack->getTrackMetadata(&trackMetadata, &metadataSynchronized);
+    m_pTrack->readTrackMetadata(&trackMetadata, &metadataSynchronized);
     // If the file tags have already been parsed at least once, the
     // existing track metadata should not be updated implicitly, i.e.
     // if the user did not explicitly choose to (re-)import metadata
     // explicitly from this file.
+    bool mergeImportedMetadata = false;
     if (metadataSynchronized &&
             (importTrackMetadataMode == ImportTrackMetadataMode::Once)) {
-        if (kLogger.debugEnabled()) {
-            kLogger.debug()
-                    << "Skip importing of track metadata and embedded cover art from file"
-                    << getUrl().toString();
-        }
-        return; // abort
+        // No (re-)import needed or desired, only merge missing properties
+        mergeImportedMetadata = true;
     }
 
     // Embedded cover art is imported together with the track's metadata.
@@ -343,24 +340,21 @@ void SoundSourceProxy::updateTrackFromSource(
     // track!
     QImage coverImg;
     DEBUG_ASSERT(coverImg.isNull());
-    QImage* pCoverImg; // pointer is also used as a flag
-    const CoverInfoRelative coverInfoOld = m_pTrack->getCoverInfo();
-    // Only re-import cover art if it is save to update, e.g. never
-    // discard a users's custom choice! We are using a whitelisting
-    // filter here that explicitly checks all valid preconditions
-    // when it is permissible to update/replace existing cover art.
-    if (((coverInfoOld.source == CoverInfo::UNKNOWN) || (coverInfoOld.source == CoverInfo::GUESSED)) &&
-            ((coverInfoOld.type == CoverInfo::NONE) || (coverInfoOld.type == CoverInfo::METADATA))) {
-        // Should import and update embedded cover art
-        pCoverImg = &coverImg;
-    } else {
-        if (kLogger.debugEnabled()) {
-            kLogger.debug()
-                    << "Skip importing of embedded cover art from file"
-                    << getUrl().toString();
+    QImage* pCoverImg = nullptr; // pointer also serves as a flag
+    if (!mergeImportedMetadata) {
+        const CoverInfoRelative coverInfoOld = m_pTrack->getCoverInfo();
+        if (coverInfoOld.source == CoverInfo::USER_SELECTED &&
+                coverInfoOld.type == CoverInfo::FILE) {
+            // Ignore embedded cover art
+            if (kLogger.debugEnabled()) {
+                kLogger.debug()
+                        << "Skip importing of embedded cover art from file"
+                        << getUrl().toString();
+            }
+        } else {
+            // (Re-)import embedded cover art
+            pCoverImg = &coverImg;
         }
-        // Skip import of embedded cover art
-        pCoverImg = nullptr;
     }
 
     // Parse the tags stored in the audio file
@@ -373,67 +367,74 @@ void SoundSourceProxy::updateTrackFromSource(
                 << (pCoverImg ? "and embedded cover art" : "")
                 << "from file"
                 << getUrl().toString();
-        // Continue for now, but the abort may follow shortly if the
-        // track already has metadata (see below)
     }
-    if (metadataSynchronized) {
-        // Metadata has been synchronized successfully at least
-        // once in the past. Only overwrite this information if
-        // new data has actually been imported, otherwise abort
-        // and preserve the existing data!
-        if (metadataImported.first != mixxx::MetadataSource::ImportResult::Succeeded) {
-            return; // abort
+
+    if (metadataImported.first != mixxx::MetadataSource::ImportResult::Succeeded) {
+        if (mergeImportedMetadata) {
+            // Nothing to do if no metadata imported
+            return;
+        } else if (trackMetadata.getTrackInfo().getTitle().trimmed().isEmpty()) {
+            // Only parse artist and title if both fields are empty to avoid
+            // inconsistencies. Otherwise the file name (without extension)
+            // is used as the title and the artist is unmodified.
+            //
+            // TODO(XXX): Disable splitting of artist/title in settings, i.e.
+            // optionally don't split even if both title and artist are empty?
+            // Some users might want to import the whole file name of untagged
+            // files as the title without splitting the artist:
+            //     https://www.mixxx.org/forums/viewtopic.php?f=3&t=12838
+            // NOTE(uklotzde, 2019-09-26): Whoever needs this should simply set
+            // splitArtistTitle = false here and compile their custom version!
+            // It is not worth extending the settings and injecting them into
+            // SoundSourceProxy for just a few people.
+            const bool splitArtistTitle =
+                    trackMetadata.getTrackInfo().getArtist().trimmed().isEmpty();
+            const auto trackFile = m_pTrack->getFileInfo();
+            kLogger.info()
+                    << "Parsing missing"
+                    << (splitArtistTitle ? "artist/title" : "title")
+                    << "from file name:"
+                    << trackFile;
+            if (trackMetadata.refTrackInfo().parseArtistTitleFromFileName(trackFile.fileName(), splitArtistTitle) &&
+                    metadataImported.second.isNull()) {
+                // Since this is also some kind of metadata import, we mark the
+                // track's metadata as synchronized with the time stamp of the file.
+                metadataImported.second = trackFile.fileLastModified();
+            }
         }
-        if (kLogger.debugEnabled()) {
-            kLogger.debug()
-                    << "Updating track metadata"
-                    << (pCoverImg ? "and embedded cover art" : "")
-                    << "from file"
-                    << getUrl().toString();
-        }
+    }
+
+    if (mergeImportedMetadata) {
+        // Partial import of properties that are not (yet) stored
+        // in the database
+        m_pTrack->mergeImportedMetadata(trackMetadata);
     } else {
-        DEBUG_ASSERT(pCoverImg);
-        if (kLogger.debugEnabled()) {
-            kLogger.debug()
-                    << "Initializing track metadata and embedded cover art from file"
-                    << getUrl().toString();
+        // Full import
+        if (metadataSynchronized) {
+            // Metadata has been synchronized successfully at least
+            // once in the past. Only overwrite this information if
+            // new data has actually been imported, otherwise abort
+            // and preserve the existing data!
+            if (metadataImported.first != mixxx::MetadataSource::ImportResult::Succeeded) {
+                return; // abort
+            }
+            if (kLogger.debugEnabled()) {
+                kLogger.debug()
+                        << "Updating track metadata"
+                        << (pCoverImg ? "and embedded cover art" : "")
+                        << "from file"
+                        << getUrl().toString();
+            }
+        } else {
+            DEBUG_ASSERT(pCoverImg);
+            if (kLogger.debugEnabled()) {
+                kLogger.debug()
+                        << "Initializing track metadata and embedded cover art from file"
+                        << getUrl().toString();
+            }
         }
+        m_pTrack->importMetadata(trackMetadata, metadataImported.second);
     }
-
-    // Fallback: If the title field is empty then try to populate title
-    // (and optionally artist) from the file name. This might happen if
-    // tags are unavailable, unreadable, or partially/completely missing.
-    if (trackMetadata.getTrackInfo().getTitle().trimmed().isEmpty()) {
-        // Only parse artist and title if both fields are empty to avoid
-        // inconsistencies. Otherwise the file name (without extension)
-        // is used as the title and the artist is unmodified.
-        //
-        // TODO(XXX): Disable splitting of artist/title in settings, i.e.
-        // optionally don't split even if both title and artist are empty?
-        // Some users might want to import the whole file name of untagged
-        // files as the title without splitting the artist:
-        //     https://www.mixxx.org/forums/viewtopic.php?f=3&t=12838
-        // NOTE(uklotzde, 2019-09-26): Whoever needs this should simply set
-        // splitArtistTitle = false here and compile their custom version!
-        // It is not worth extending the settings and injecting them into
-        // SoundSourceProxy for just a few people.
-        const bool splitArtistTitle =
-                trackMetadata.getTrackInfo().getArtist().trimmed().isEmpty();
-        const auto trackFile = m_pTrack->getFileInfo();
-        kLogger.info()
-                << "Parsing missing"
-                << (splitArtistTitle ? "artist/title" : "title")
-                << "from file name:"
-                << trackFile;
-        if (trackMetadata.refTrackInfo().parseArtistTitleFromFileName(trackFile.fileName(), splitArtistTitle) &&
-                metadataImported.second.isNull()) {
-            // Since this is also some kind of metadata import, we mark the
-            // track's metadata as synchronized with the time stamp of the file.
-            metadataImported.second = trackFile.fileLastModified();
-        }
-    }
-
-    m_pTrack->setTrackMetadata(trackMetadata, metadataImported.second);
 
     if (pCoverImg) {
         // If the pointer is not null then the cover art should be guessed

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -118,12 +118,11 @@ TEST_F(CoverArtUtilTest, searchImage) {
 
     TrackPointer pTrack(Track::newTemporary(kTrackLocationTest));
     QLinkedList<QFileInfo> covers;
-    CoverInfo res;
+    CoverInfoRelative res;
     // looking for cover in an empty directory
     res = CoverArtUtils::selectCoverArtForTrack(*pTrack, covers);
-    CoverInfo expected1;
+    CoverInfoRelative expected1;
     expected1.source = CoverInfo::GUESSED;
-    expected1.trackLocation = pTrack->getLocation();
     EXPECT_EQ(expected1, res);
 
     // Looking for a track with embedded cover.

--- a/src/test/coverartutils_test.cpp
+++ b/src/test/coverartutils_test.cpp
@@ -117,7 +117,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
     const QString kTrackLocationTest(kTestDir.absoluteFilePath("cover-test-png.mp3"));
 
     TrackPointer pTrack(Track::newTemporary(kTrackLocationTest));
-    QLinkedList<QFileInfo> covers;
+    QList<QFileInfo> covers;
     CoverInfoRelative res;
     // looking for cover in an empty directory
     res = CoverArtUtils::selectCoverArtForTrack(*pTrack, covers);
@@ -192,7 +192,7 @@ TEST_F(CoverArtUtilTest, searchImage) {
     extraCovers << cLoc_big3;
 
     // saving more covers using the preferred names in the right order
-    QLinkedList<QFileInfo> prefCovers;
+    QList<QFileInfo> prefCovers;
     // 1. track_filename.jpg
     QString cLoc_filename = QString(trackdir % "/cover-test." % qFormat);
     EXPECT_TRUE(img.scaled(500,500).save(cLoc_filename, format));

--- a/src/test/trackmetadata_test.cpp
+++ b/src/test/trackmetadata_test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "track/trackmetadata.h"
+#include "track/trackrecord.h"
 
 class TrackMetadataTest : public testing::Test {
 };
@@ -60,4 +60,168 @@ TEST_F(TrackMetadataTest, parseArtistTitleFromFileName) {
         EXPECT_EQ(QString(), trackInfo.getArtist());
         EXPECT_EQ("again - only_-_title _", trackInfo.getTitle());
     }
+}
+
+TEST_F(TrackMetadataTest, mergeImportedMetadata) {
+    // Existing track metadata (stored in the database) without extra properties
+    mixxx::TrackRecord oldTrackRecord;
+    mixxx::TrackMetadata& oldTrackMetadata = oldTrackRecord.refMetadata();
+    oldTrackMetadata.setBitrate(mixxx::AudioSource::Bitrate(100));
+    oldTrackMetadata.setChannels(mixxx::AudioSignal::ChannelCount(1));
+    oldTrackMetadata.setDuration(mixxx::Duration::fromSeconds(60));
+    oldTrackMetadata.setSampleRate(mixxx::AudioSignal::SampleRate(10000));
+    mixxx::TrackInfo& oldTrackInfo = oldTrackMetadata.refTrackInfo();
+    oldTrackInfo.setArtist("old artist");
+    oldTrackInfo.setBpm(mixxx::Bpm(100));
+    oldTrackInfo.setComment("old comment");
+    oldTrackInfo.setComposer("old composer");
+    oldTrackInfo.setGenre("old genre");
+    oldTrackInfo.setGrouping("old grouping");
+    oldTrackInfo.setKey("1A");
+    oldTrackInfo.setReplayGain(mixxx::ReplayGain(0.1, 1));
+    oldTrackInfo.setTitle("old title");
+    oldTrackInfo.setTrackNumber("1");
+    oldTrackInfo.setTrackTotal("10");
+    oldTrackInfo.setYear("2001-01-01");
+    mixxx::AlbumInfo& oldAlbumInfo = oldTrackMetadata.refAlbumInfo();
+    oldAlbumInfo.setArtist("old album artist");
+    oldAlbumInfo.setTitle("old album title");
+
+    // Imported track metadata (from file tags) with extra properties
+    mixxx::TrackMetadata newTrackMetadata;
+    newTrackMetadata.setBitrate(mixxx::AudioSource::Bitrate(200));
+    newTrackMetadata.setChannels(mixxx::AudioSignal::ChannelCount(2));
+    newTrackMetadata.setDuration(mixxx::Duration::fromSeconds(120));
+    newTrackMetadata.setSampleRate(mixxx::AudioSignal::SampleRate(20000));
+    mixxx::TrackInfo& newTrackInfo = newTrackMetadata.refTrackInfo();
+    newTrackInfo.setArtist("new artist");
+    newTrackInfo.setBpm(mixxx::Bpm(200));
+    newTrackInfo.setComment("new comment");
+    newTrackInfo.setComposer("new composer");
+#if defined(__EXTRA_METADATA__)
+    newTrackInfo.setConductor("new conductor");
+    newTrackInfo.setDiscNumber("1");
+    newTrackInfo.setDiscTotal("2");
+    newTrackInfo.setEncoder("encoder");
+    newTrackInfo.setEncoderSettings("encoder settings");
+#endif // __EXTRA_METADATA__
+    newTrackInfo.setGenre("new genre");
+    newTrackInfo.setGrouping("new grouping");
+#if defined(__EXTRA_METADATA__)
+    newTrackInfo.setISRC("isrc");
+#endif // __EXTRA_METADATA__
+    newTrackInfo.setKey("1A");
+#if defined(__EXTRA_METADATA__)
+    newTrackInfo.setLanguage("language");
+    newTrackInfo.setLyricist("lyricist");
+    newTrackInfo.setMood("mood");
+    newTrackInfo.setMovement("movement");
+    newTrackInfo.setMusicBrainzArtistId(QUuid("11111111-1111-1111-1111-111111111111"));
+    newTrackInfo.setMusicBrainzRecordingId(QUuid("22222222-2222-2222-2222-222222222222"));
+    newTrackInfo.setMusicBrainzReleaseId(QUuid("33333333-3333-3333-3333-333333333333"));
+    newTrackInfo.setMusicBrainzWorkId(QUuid("44444444-4444-4444-4444-444444444444"));
+    newTrackInfo.setRemixer("remixer");
+#endif // __EXTRA_METADATA__
+    newTrackInfo.setReplayGain(mixxx::ReplayGain(0.2, 2));
+    newTrackInfo.setTitle("new title");
+    newTrackInfo.setTrackNumber("2");
+    newTrackInfo.setTrackTotal("20");
+#if defined(__EXTRA_METADATA__)
+    newTrackInfo.setWork("work");
+#endif // __EXTRA_METADATA__
+    newTrackInfo.setYear("2002-02-02");
+    mixxx::AlbumInfo& newAlbumInfo = newTrackMetadata.refAlbumInfo();
+    newAlbumInfo.setArtist("new album artist");
+#if defined(__EXTRA_METADATA__)
+    newAlbumInfo.setCopyright("copyright");
+    newAlbumInfo.setLicense("license");
+    newAlbumInfo.setMusicBrainzArtistId(QUuid("55555555-5555-5555-5555-555555555555"));
+    newAlbumInfo.setMusicBrainzReleaseGroupId(QUuid("66666666-6666-6666-6666-666666666666"));
+    newAlbumInfo.setMusicBrainzReleaseId(QUuid("77777777-7777-7777-7777-777777777777"));
+    newAlbumInfo.setRecordLabel("copyright");
+    newAlbumInfo.setReplayGain(mixxx::ReplayGain(0.3, 3));
+#endif // __EXTRA_METADATA__
+    newAlbumInfo.setTitle("new album title");
+
+    mixxx::TrackRecord mergedTrackRecord = oldTrackRecord;
+    ASSERT_EQ(mergedTrackRecord.getMetadata(), oldTrackRecord.getMetadata());
+    ASSERT_NE(newTrackMetadata, oldTrackMetadata);
+    mergedTrackRecord.mergeImportedMetadata(newTrackMetadata);
+
+    mixxx::TrackMetadata& mergedTrackMetadata = mergedTrackRecord.refMetadata();
+    EXPECT_EQ(oldTrackMetadata.getBitrate(), mergedTrackMetadata.getBitrate());
+    EXPECT_EQ(oldTrackMetadata.getChannels(), mergedTrackMetadata.getChannels());
+    EXPECT_EQ(oldTrackMetadata.getDuration(), mergedTrackMetadata.getDuration());
+    EXPECT_EQ(oldTrackMetadata.getSampleRate(), mergedTrackMetadata.getSampleRate());
+    mixxx::TrackInfo& mergedTrackInfo = mergedTrackMetadata.refTrackInfo();
+    EXPECT_EQ(oldTrackInfo.getArtist(), mergedTrackInfo.getArtist());
+    EXPECT_EQ(oldTrackInfo.getBpm(), mergedTrackInfo.getBpm());
+    EXPECT_EQ(oldTrackInfo.getComment(), mergedTrackInfo.getComment());
+    EXPECT_EQ(oldTrackInfo.getComposer(), mergedTrackInfo.getComposer());
+#if defined(__EXTRA_METADATA__)
+    EXPECT_EQ(newTrackInfo.getConductor(), mergedTrackInfo.getConductor());
+    EXPECT_EQ(newTrackInfo.getDiscNumber(), mergedTrackInfo.getDiscNumber());
+    EXPECT_EQ(newTrackInfo.getDiscTotal(), mergedTrackInfo.getDiscTotal());
+    EXPECT_EQ(newTrackInfo.getEncoder(), mergedTrackInfo.getEncoder());
+    EXPECT_EQ(newTrackInfo.getEncoderSettings(), mergedTrackInfo.getEncoderSettings());
+#endif // __EXTRA_METADATA__
+    EXPECT_EQ(oldTrackInfo.getGenre(), mergedTrackInfo.getGenre());
+    EXPECT_EQ(oldTrackInfo.getGrouping(), mergedTrackInfo.getGrouping());
+#if defined(__EXTRA_METADATA__)
+    EXPECT_EQ(newTrackInfo.getISRC(), mergedTrackInfo.getISRC());
+#endif // __EXTRA_METADATA__
+    EXPECT_EQ(oldTrackInfo.getKey(), mergedTrackInfo.getKey());
+#if defined(__EXTRA_METADATA__)
+    EXPECT_EQ(newTrackInfo.getLanguage(), mergedTrackInfo.getLanguage());
+    EXPECT_EQ(newTrackInfo.getLyricist(), mergedTrackInfo.getLyricist());
+    EXPECT_EQ(newTrackInfo.getMood(), mergedTrackInfo.getMood());
+    EXPECT_EQ(newTrackInfo.getMovement(), mergedTrackInfo.getMovement());
+    EXPECT_EQ(newTrackInfo.getMusicBrainzArtistId(), mergedTrackInfo.getMusicBrainzArtistId());
+    EXPECT_EQ(newTrackInfo.getMusicBrainzRecordingId(), mergedTrackInfo.getMusicBrainzRecordingId());
+    EXPECT_EQ(newTrackInfo.getMusicBrainzReleaseId(), mergedTrackInfo.getMusicBrainzReleaseId());
+    EXPECT_EQ(newTrackInfo.getMusicBrainzWorkId(), mergedTrackInfo.getMusicBrainzWorkId());
+    EXPECT_EQ(newTrackInfo.getRemixer(), mergedTrackInfo.getRemixer());
+#endif // __EXTRA_METADATA__
+    EXPECT_EQ(oldTrackInfo.getReplayGain(), mergedTrackInfo.getReplayGain());
+    EXPECT_EQ(oldTrackInfo.getTitle(), mergedTrackInfo.getTitle());
+    EXPECT_EQ(oldTrackInfo.getTrackNumber(), mergedTrackInfo.getTrackNumber());
+    EXPECT_EQ(oldTrackInfo.getTrackTotal(), mergedTrackInfo.getTrackTotal());
+#if defined(__EXTRA_METADATA__)
+    EXPECT_EQ(newTrackInfo.getWork(), mergedTrackInfo.getWork());
+#endif // __EXTRA_METADATA__
+    EXPECT_EQ(oldTrackInfo.getYear(), mergedTrackInfo.getYear());
+    mixxx::AlbumInfo& mergedAlbumInfo = mergedTrackMetadata.refAlbumInfo();
+    EXPECT_EQ(oldAlbumInfo.getArtist(), mergedAlbumInfo.getArtist());
+#if defined(__EXTRA_METADATA__)
+    EXPECT_EQ(newAlbumInfo.getCopyright(), mergedAlbumInfo.getCopyright());
+    EXPECT_EQ(newAlbumInfo.getLicense(), mergedAlbumInfo.getLicense());
+    EXPECT_EQ(newAlbumInfo.getMusicBrainzArtistId(), mergedAlbumInfo.getMusicBrainzArtistId());
+    EXPECT_EQ(newAlbumInfo.getMusicBrainzReleaseGroupId(), mergedAlbumInfo.getMusicBrainzReleaseGroupId());
+    EXPECT_EQ(newAlbumInfo.getMusicBrainzReleaseId(), mergedAlbumInfo.getMusicBrainzReleaseId());
+    EXPECT_EQ(newAlbumInfo.getRecordLabel(), mergedAlbumInfo.getRecordLabel());
+    EXPECT_EQ(newAlbumInfo.getReplayGain(), mergedAlbumInfo.getReplayGain());
+#endif // __EXTRA_METADATA__
+    EXPECT_EQ(oldAlbumInfo.getTitle(), mergedAlbumInfo.getTitle());
+
+    // Check that all existing properties are preserved, even if empty or missing
+    mergedTrackInfo.setArtist("");
+    mergedTrackInfo.setTitle(QString());
+    mergedAlbumInfo.setArtist("");
+    mergedAlbumInfo.setTitle(QString());
+    mergedTrackRecord.mergeImportedMetadata(newTrackMetadata);
+    EXPECT_EQ(QString(""), mergedTrackInfo.getArtist());
+    EXPECT_EQ(QString(), mergedTrackInfo.getTitle());
+    EXPECT_EQ(QString(""), mergedAlbumInfo.getArtist());
+    EXPECT_EQ(QString(), mergedAlbumInfo.getTitle());
+
+    // Check that the placeholder for track total is replaced with the actual property
+    ASSERT_NE(mixxx::TrackRecord::kTrackTotalPlaceholder, newTrackInfo.getTrackTotal());
+    mergedTrackInfo.setTrackTotal(mixxx::TrackRecord::kTrackTotalPlaceholder);
+    mergedTrackRecord.mergeImportedMetadata(newTrackMetadata);
+    EXPECT_EQ(newTrackInfo.getTrackTotal(), mergedTrackInfo.getTrackTotal());
+    // ...but if track total is missing entirely it should be preserved
+    ASSERT_NE(QString(), newTrackInfo.getTrackTotal());
+    mergedTrackInfo.setTrackTotal(QString());
+    mergedTrackRecord.mergeImportedMetadata(newTrackMetadata);
+    EXPECT_EQ(QString(), mergedTrackInfo.getTrackTotal());
 }

--- a/src/test/trackupdate_test.cpp
+++ b/src/test/trackupdate_test.cpp
@@ -57,14 +57,14 @@ TEST_F(TrackUpdateTest, parseModifiedCleanOnce) {
     pTrack->markClean();
 
     mixxx::TrackMetadata trackMetadataBefore;
-    pTrack->getTrackMetadata(&trackMetadataBefore);
+    pTrack->readTrackMetadata(&trackMetadataBefore);
     auto coverInfoBefore = pTrack->getCoverInfo();
 
     SoundSourceProxy(pTrack).updateTrackFromSource(
             SoundSourceProxy::ImportTrackMetadataMode::Once);
 
     mixxx::TrackMetadata trackMetadataAfter;
-    pTrack->getTrackMetadata(&trackMetadataAfter);
+    pTrack->readTrackMetadata(&trackMetadataAfter);
     auto coverInfoAfter = pTrack->getCoverInfo();
 
     // Not updated
@@ -79,14 +79,14 @@ TEST_F(TrackUpdateTest, parseModifiedCleanAgainSkipCover) {
     pTrack->markClean();
 
     mixxx::TrackMetadata trackMetadataBefore;
-    pTrack->getTrackMetadata(&trackMetadataBefore);
+    pTrack->readTrackMetadata(&trackMetadataBefore);
     auto coverInfoBefore = pTrack->getCoverInfo();
 
     SoundSourceProxy(pTrack).updateTrackFromSource(
             SoundSourceProxy::ImportTrackMetadataMode::Again);
 
     mixxx::TrackMetadata trackMetadataAfter;
-    pTrack->getTrackMetadata(&trackMetadataAfter);
+    pTrack->readTrackMetadata(&trackMetadataAfter);
     auto coverInfoAfter = pTrack->getCoverInfo();
 
     // Updated
@@ -105,14 +105,14 @@ TEST_F(TrackUpdateTest, parseModifiedCleanAgainUpdateCover) {
     pTrack->markClean();
 
     mixxx::TrackMetadata trackMetadataBefore;
-    pTrack->getTrackMetadata(&trackMetadataBefore);
+    pTrack->readTrackMetadata(&trackMetadataBefore);
     auto coverInfoBefore = pTrack->getCoverInfo();
 
     SoundSourceProxy(pTrack).updateTrackFromSource(
             SoundSourceProxy::ImportTrackMetadataMode::Again);
 
     mixxx::TrackMetadata trackMetadataAfter;
-    pTrack->getTrackMetadata(&trackMetadataAfter);
+    pTrack->readTrackMetadata(&trackMetadataAfter);
     auto coverInfoAfter = pTrack->getCoverInfo();
 
     // Updated
@@ -126,14 +126,14 @@ TEST_F(TrackUpdateTest, parseModifiedDirtyAgain) {
     auto pTrack = newTestTrackParsedModified();
 
     mixxx::TrackMetadata trackMetadataBefore;
-    pTrack->getTrackMetadata(&trackMetadataBefore);
+    pTrack->readTrackMetadata(&trackMetadataBefore);
     auto coverInfoBefore = pTrack->getCoverInfo();
 
     SoundSourceProxy(pTrack).updateTrackFromSource(
             SoundSourceProxy::ImportTrackMetadataMode::Again);
 
     mixxx::TrackMetadata trackMetadataAfter;
-    pTrack->getTrackMetadata(&trackMetadataAfter);
+    pTrack->readTrackMetadata(&trackMetadataAfter);
     auto coverInfoAfter = pTrack->getCoverInfo();
 
     // Updated

--- a/src/track/albuminfo.cpp
+++ b/src/track/albuminfo.cpp
@@ -3,18 +3,6 @@
 
 namespace mixxx {
 
-void AlbumInfo::resetUnsupportedValues() {
-#if defined(__EXTRA_METADATA__)
-    setCopyright(QString());
-    setLicense(QString());
-    setMusicBrainzArtistId(QString());
-    setMusicBrainzReleaseId(QString());
-    setMusicBrainzReleaseGroupId(QString());
-    setRecordLabel(QString());
-    setReplayGain(ReplayGain());
-#endif // __EXTRA_METADATA__
-}
-
 bool operator==(const AlbumInfo& lhs, const AlbumInfo& rhs) {
     return (lhs.getArtist() == rhs.getArtist()) &&
 #if defined(__EXTRA_METADATA__)

--- a/src/track/albuminfo.h
+++ b/src/track/albuminfo.h
@@ -33,9 +33,6 @@ public:
     AlbumInfo& operator=(AlbumInfo&&) = default;
     AlbumInfo& operator=(const AlbumInfo&) = default;
 
-    // TODO(XXX): Remove after all new fields have been added to the library
-    void resetUnsupportedValues();
-
     // Adjusts floating-point properties to match their string representation
     // in file tags to account for rounding errors.
     void normalizeBeforeExport() {

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -61,13 +61,33 @@ public:
         return std::round(value);
     }
 
+    enum class Comparison {
+        Default, // full precision
+        Integer, // rounded
+        String, // stringified
+    };
+
+    bool compareEq(
+            const Bpm& bpm,
+            Comparison cmp = Comparison::Default) const {
+        switch (cmp) {
+        case Comparison::Integer:
+            return Bpm::valueToInteger(getValue()) == Bpm::valueToInteger(bpm.getValue());
+        case Comparison::String:
+            return Bpm::valueToString(getValue()) == Bpm::valueToString(bpm.getValue());
+        case Comparison::Default:
+        default:
+            return getValue() == bpm.getValue();
+        }
+    }
+
 private:
     double m_value;
 };
 
 inline
 bool operator==(const Bpm& lhs, const Bpm& rhs) {
-    return lhs.getValue() == rhs.getValue();
+    return lhs.compareEq(rhs);
 }
 
 inline

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -31,6 +31,9 @@ public:
     // fractional value the ID3 metadata is always detected as modified
     // and will be exported regardless if it has actually been modified
     // or not.
+    // TL;DR: If metadata export is enabled ID3 tags will be rewritten
+    // for all files with a fractional bpm values even if their metadata
+    // has not been modified.
     void normalizeBeforeExport() {
         m_value = normalizeValue(m_value);
     }

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -25,6 +25,12 @@ public:
 
     // Adjusts floating-point values to match their string representation
     // in file tags to account for rounding errors.
+    // NOTE(2019-02-19, uklotzde): The pre-normalization cannot prevent
+    // repeated export of metadata for files with ID3 tags that are only
+    // able to store the BPM value with integer precision! In case of a
+    // fractional value the ID3 metadata is always detected as modified
+    // and will be exported regardless if it has actually been modified
+    // or not.
     void normalizeBeforeExport() {
         m_value = normalizeValue(m_value);
     }

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -24,16 +24,13 @@ public:
     static double normalizeValue(double value);
 
     // Adjusts floating-point values to match their string representation
-    // in file tags to account for rounding errors.
-    // NOTE(2019-02-19, uklotzde): The pre-normalization cannot prevent
-    // repeated export of metadata for files with ID3 tags that are only
-    // able to store the BPM value with integer precision! In case of a
-    // fractional value the ID3 metadata is always detected as modified
-    // and will be exported regardless if it has actually been modified
-    // or not.
-    // TL;DR: If metadata export is enabled ID3 tags will be rewritten
-    // for all files with a fractional bpm values even if their metadata
-    // has not been modified.
+    // in file tags to account for rounding errors and false positives
+    // when checking for modifications.
+    // NOTE(2020-01-08, uklotzde): Since bpm values are stored with
+    // integer precision in ID3 tags, bpm values are only considered
+    // as modified if their rounded integer values differ. But even
+    // then this pre-normalization step should not be skipped to prevent
+    // fluttering values for other tag formats.
     void normalizeBeforeExport() {
         m_value = normalizeValue(m_value);
     }

--- a/src/track/seratomarkers2.h
+++ b/src/track/seratomarkers2.h
@@ -387,6 +387,10 @@ public:
         m_allocatedSize = size;
     }
 
+    bool isEmpty() const {
+        return m_entries.isEmpty();
+    }
+
     const QList<std::shared_ptr<SeratoMarkers2Entry>>& getEntries() const {
         return m_entries;
     }

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -979,8 +979,17 @@ ExportTrackMetadataResult Track::exportMetadata(
         // copy all extra properties that are not (yet) stored in the library before
         // checking for differences! If an export has been requested explicitly then
         // we will continue even if no differences are detected.
+        // NOTE(uklotzde, 2020-01-05): Detection of modified bpm values is restricted
+        // to integer precision to avoid re-exporting of unmodified ID3 tags in case
+        // of fractional bpm values. As a consequence small changes in bpm values
+        // cannot be detected and file tags with fractional values might not be
+        // updated as expected! In these edge cases users need to explicitly
+        // trigger the re-export of file tags or they could modify other metadata
+        // properties.
         if (!m_bMarkedForMetadataExport &&
-                !m_record.getMetadata().anyFileTagsModified(importedFromFile))  {
+                !m_record.getMetadata().anyFileTagsModified(
+                        importedFromFile,
+                        mixxx::Bpm::Comparison::Integer))  {
             // The file tags are in-sync with the track's metadata and don't need
             // to be updated.
             if (kLogger.debugEnabled()) {

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -240,9 +240,6 @@ class Track : public QObject {
     ConstWaveformPointer getWaveformSummary() const;
     void setWaveformSummary(ConstWaveformPointer pWaveform);
 
-    void setAnalyzerProgress(int progress);
-    int getAnalyzerProgress() const;
-
     // Get the track's main cue point
     CuePosition getCuePoint() const;
     // Set the track's main cue point

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -281,14 +281,18 @@ class Track : public QObject {
     quint16 getCoverHash() const;
 
     // Set/get track metadata and cover art (optional) all at once.
-    void setTrackMetadata(
-            mixxx::TrackMetadata trackMetadata,
+    void importMetadata(
+            mixxx::TrackMetadata importedMetadata,
             QDateTime metadataSynchronized);
-    void getTrackMetadata(
+    // Merge additional metadata that is not (yet) stored in the database
+    // and only available from file tags.
+    void mergeImportedMetadata(
+            const mixxx::TrackMetadata& importedMetadata);
+
+    void readTrackMetadata(
             mixxx::TrackMetadata* pTrackMetadata,
             bool* pMetadataSynchronized = nullptr) const;
-
-    void getTrackRecord(
+    void readTrackRecord(
             mixxx::TrackRecord* pTrackRecord,
             bool* pDirty = nullptr) const;
 

--- a/src/track/trackinfo.cpp
+++ b/src/track/trackinfo.cpp
@@ -42,47 +42,49 @@ bool TrackInfo::parseArtistTitleFromFileName(
     return modified;
 }
 
-bool operator==(const TrackInfo& lhs, const TrackInfo& rhs) {
-    return (lhs.getArtist() == rhs.getArtist()) &&
-            (lhs.getBpm() == rhs.getBpm()) &&
-            (lhs.getComment() == rhs.getComment()) &&
-            (lhs.getComposer() == rhs.getComposer()) &&
+bool TrackInfo::compareEq(
+        const TrackInfo& trackInfo,
+        Bpm::Comparison cmpBpm) const {
+    return (getArtist() == trackInfo.getArtist()) &&
+            getBpm().compareEq(trackInfo.getBpm(), cmpBpm) &&
+            (getComment() == trackInfo.getComment()) &&
+            (getComposer() == trackInfo.getComposer()) &&
 #if defined(__EXTRA_METADATA__)
-            (lhs.getConductor() == rhs.getConductor()) &&
-            (lhs.getDiscNumber() == rhs.getDiscNumber()) &&
-            (lhs.getDiscTotal() == rhs.getDiscTotal()) &&
-            (lhs.getEncoder() == rhs.getEncoder()) &&
-            (lhs.getEncoderSettings() == rhs.getEncoderSettings()) &&
+            (getConductor() == trackInfo.getConductor()) &&
+            (getDiscNumber() == trackInfo.getDiscNumber()) &&
+            (getDiscTotal() == trackInfo.getDiscTotal()) &&
+            (getEncoder() == trackInfo.getEncoder()) &&
+            (getEncoderSettings() == trackInfo.getEncoderSettings()) &&
 #endif // __EXTRA_METADATA__
-            (lhs.getGenre() == rhs.getGenre()) &&
-            (lhs.getGrouping() == rhs.getGrouping()) &&
+            (getGenre() == trackInfo.getGenre()) &&
+            (getGrouping() == trackInfo.getGrouping()) &&
 #if defined(__EXTRA_METADATA__)
-            (lhs.getISRC() == rhs.getISRC()) &&
+            (getISRC() == trackInfo.getISRC()) &&
 #endif // __EXTRA_METADATA__
-            (lhs.getKey() == rhs.getKey()) &&
+            (getKey() == trackInfo.getKey()) &&
 #if defined(__EXTRA_METADATA__)
-            (lhs.getLanguage() == rhs.getLanguage()) &&
-            (lhs.getLyricist() == rhs.getLyricist()) &&
-            (lhs.getMood() == rhs.getMood()) &&
-            (lhs.getMovement() == rhs.getMovement()) &&
-            (lhs.getMusicBrainzArtistId() == rhs.getMusicBrainzArtistId()) &&
-            (lhs.getMusicBrainzRecordingId() == rhs.getMusicBrainzRecordingId()) &&
-            (lhs.getMusicBrainzReleaseId() == rhs.getMusicBrainzReleaseId()) &&
-            (lhs.getMusicBrainzWorkId() == rhs.getMusicBrainzWorkId()) &&
-            (lhs.getRemixer() == rhs.getRemixer()) &&
+            (getLanguage() == trackInfo.getLanguage()) &&
+            (getLyricist() == trackInfo.getLyricist()) &&
+            (getMood() == trackInfo.getMood()) &&
+            (getMovement() == trackInfo.getMovement()) &&
+            (getMusicBrainzArtistId() == trackInfo.getMusicBrainzArtistId()) &&
+            (getMusicBrainzRecordingId() == trackInfo.getMusicBrainzRecordingId()) &&
+            (getMusicBrainzReleaseId() == trackInfo.getMusicBrainzReleaseId()) &&
+            (getMusicBrainzWorkId() == trackInfo.getMusicBrainzWorkId()) &&
+            (getRemixer() == trackInfo.getRemixer()) &&
 #endif // __EXTRA_METADATA__
-            (lhs.getReplayGain() == rhs.getReplayGain()) &&
+            (getReplayGain() == trackInfo.getReplayGain()) &&
 #if defined(__EXTRA_METADATA__)
-            (lhs.getSeratoMarkers2() == rhs.getSeratoMarkers2()) &&
-            (lhs.getSubtitle() == rhs.getSubtitle()) &&
+            (getSeratoMarkers2() == trackInfo.getSeratoMarkers2()) &&
+            (getSubtitle() == trackInfo.getSubtitle()) &&
 #endif // __EXTRA_METADATA__
-            (lhs.getTitle() == rhs.getTitle()) &&
-            (lhs.getTrackNumber() == rhs.getTrackNumber()) &&
-            (lhs.getTrackTotal() == rhs.getTrackTotal()) &&
+            (getTitle() == trackInfo.getTitle()) &&
+            (getTrackNumber() == trackInfo.getTrackNumber()) &&
+            (getTrackTotal() == trackInfo.getTrackTotal()) &&
 #if defined(__EXTRA_METADATA__)
-            (lhs.getWork() == rhs.getWork()) &&
+            (getWork() == trackInfo.getWork()) &&
 #endif // __EXTRA_METADATA__
-            (lhs.getYear() == rhs.getYear());
+            (getYear() == trackInfo.getYear());
 }
 
 QDebug operator<<(QDebug dbg, const TrackInfo& arg) {

--- a/src/track/trackinfo.cpp
+++ b/src/track/trackinfo.cpp
@@ -5,8 +5,8 @@ namespace mixxx {
 
 namespace {
 
-const QString kArtistTitleSeparatorWithSpaces = " - ";
-const QString kArtistTitleSeparator = "_-_";
+const QString kArtistTitleSeparatorWithSpaces = QStringLiteral(" - ");
+const QString kArtistTitleSeparator = QStringLiteral("_-_");
 
 const QChar kFileExtensionSeparator = '.';
 

--- a/src/track/trackinfo.cpp
+++ b/src/track/trackinfo.cpp
@@ -3,28 +3,6 @@
 
 namespace mixxx {
 
-void TrackInfo::resetUnsupportedValues() {
-#if defined(__EXTRA_METADATA__)
-    setConductor(QString());
-    setDiscNumber(QString());
-    setDiscTotal(QString());
-    setEncoder(QString());
-    setEncoderSettings(QString());
-    setISRC(QString());
-    setLanguage(QString());
-    setLyricist(QString());
-    setMood(QString());
-    setMovement(QString());
-    setMusicBrainzArtistId(QString());
-    setMusicBrainzRecordingId(QString());
-    setMusicBrainzReleaseId(QString());
-    setMusicBrainzWorkId(QString());
-    setRemixer(QString());
-    setSubtitle(QString());
-    setWork(QString());
-#endif // __EXTRA_METADATA__
-}
-
 namespace {
 
 const QString kArtistTitleSeparatorWithSpaces = " - ";

--- a/src/track/trackinfo.h
+++ b/src/track/trackinfo.h
@@ -78,9 +78,16 @@ public:
         refBpm().normalizeBeforeExport();
         refReplayGain().normalizeBeforeExport();
     }
+
+    bool compareEq(
+            const TrackInfo& trackInfo,
+            Bpm::Comparison cmpBpm = Bpm::Comparison::Default) const;
 };
 
-bool operator==(const TrackInfo& lhs, const TrackInfo& rhs);
+inline
+bool operator==(const TrackInfo& lhs, const TrackInfo& rhs) {
+    return lhs.compareEq(rhs);
+}
 
 inline
 bool operator!=(const TrackInfo& lhs, const TrackInfo& rhs) {

--- a/src/track/trackinfo.h
+++ b/src/track/trackinfo.h
@@ -72,9 +72,6 @@ public:
             QString fileName,
             bool splitArtistTitle);
 
-    // TODO(XXX): Remove after all new fields have been added to the library
-    void resetUnsupportedValues();
-
     // Adjusts floating-point properties to match their string representation
     // in file tags to account for rounding errors.
     void normalizeBeforeExport() {

--- a/src/track/trackmetadata.cpp
+++ b/src/track/trackmetadata.cpp
@@ -66,6 +66,21 @@ QString TrackMetadata::reformatYear(QString year) {
     return year.simplified();
 }
 
+void TrackMetadata::normalizeBeforeExport() {
+    refAlbumInfo().normalizeBeforeExport();
+    refTrackInfo().normalizeBeforeExport();
+}
+
+bool TrackMetadata::anyFileTagsModified(
+        const TrackMetadata& importedFromFile) const {
+    // NOTE(uklotzde): The read-only audio properties that are stored
+    // directly as members of this class might differ after they have
+    // been updated while decoding audio data. They are read-only and
+    // must not be considered when exporting metadata!
+    return getAlbumInfo() != importedFromFile.getAlbumInfo() ||
+            getTrackInfo() != importedFromFile.getTrackInfo();
+}
+
 bool operator==(const TrackMetadata& lhs, const TrackMetadata& rhs) {
     return (lhs.getAlbumInfo() == rhs.getAlbumInfo()) &&
             (lhs.getTrackInfo() == rhs.getTrackInfo()) &&

--- a/src/track/trackmetadata.cpp
+++ b/src/track/trackmetadata.cpp
@@ -72,13 +72,14 @@ void TrackMetadata::normalizeBeforeExport() {
 }
 
 bool TrackMetadata::anyFileTagsModified(
-        const TrackMetadata& importedFromFile) const {
+        const TrackMetadata& importedFromFile,
+        Bpm::Comparison cmpBpm) const {
     // NOTE(uklotzde): The read-only audio properties that are stored
     // directly as members of this class might differ after they have
     // been updated while decoding audio data. They are read-only and
     // must not be considered when exporting metadata!
     return getAlbumInfo() != importedFromFile.getAlbumInfo() ||
-            getTrackInfo() != importedFromFile.getTrackInfo();
+            !getTrackInfo().compareEq(importedFromFile.getTrackInfo(), cmpBpm);
 }
 
 bool operator==(const TrackMetadata& lhs, const TrackMetadata& rhs) {

--- a/src/track/trackmetadata.h
+++ b/src/track/trackmetadata.h
@@ -33,28 +33,14 @@ public:
     TrackMetadata& operator=(TrackMetadata&&) = default;
     TrackMetadata& operator=(const TrackMetadata&) = default;
 
-    // TODO(XXX): Remove after all new fields have been added to the library
-    void resetUnsupportedValues() {
-        refAlbumInfo().resetUnsupportedValues();
-        refTrackInfo().resetUnsupportedValues();
-    }
-
     // Adjusts floating-point values to match their string representation
     // in file tags to account for rounding errors.
-    void normalizeBeforeExport() {
-        refAlbumInfo().normalizeBeforeExport();
-        refTrackInfo().normalizeBeforeExport();
-    }
+    void normalizeBeforeExport();
 
-    // Compares the contents with metadata that has been freshly imported
-    // from a file.
-    bool hasBeenModifiedAfterImport(const TrackMetadata& importedFromFile) const {
-        // NOTE(uklotzde): The read-only audio properties might differ after
-        // they have been updated while decoding audio data. They are read-only
-        // and must not be considered when exporting metadata.
-        return (getAlbumInfo() != importedFromFile.getAlbumInfo()) ||
-                (getTrackInfo() != importedFromFile.getTrackInfo());
-    }
+    // Returns true if the current metadata differs from the imported metadata
+    // and needs to be exported. A result of false indicates that no export
+    // is needed.
+    bool anyFileTagsModified(const TrackMetadata& importedFromFile) const;
 
     // Parse an format date/time values according to ISO 8601
     static QDate parseDate(QString str) {

--- a/src/track/trackmetadata.h
+++ b/src/track/trackmetadata.h
@@ -40,7 +40,13 @@ public:
     // Returns true if the current metadata differs from the imported metadata
     // and needs to be exported. A result of false indicates that no export
     // is needed.
-    bool anyFileTagsModified(const TrackMetadata& importedFromFile) const;
+    // NOTE: Some tag formats like ID3v1/v2 only support integer precision
+    // for storing bpm values. To avoid re-exporting unmodified track metadata
+    // with fractional bpm values over and over again the comparison of bpm
+    // values should be restricted to integer.
+    bool anyFileTagsModified(
+            const TrackMetadata& importedFromFile,
+            Bpm::Comparison cmpBpm = Bpm::Comparison::Default) const;
 
     // Parse an format date/time values according to ISO 8601
     static QDate parseDate(QString str) {

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -66,6 +66,13 @@ bool checkID3v2HeaderVersionSupported(const TagLib::ID3v2::Header& header) {
     }
 }
 
+// Owners of ID3v2 UFID frames.
+// NOTE(uklotzde, 2019-09-28): This is the owner string for MusicBrainz
+// as written by MusicBrainz Picard 2.1.3 although the mapping table
+// doesn't mention any "http://" prefix.
+// See also: https://picard.musicbrainz.org/docs/mappings
+const QString kMusicBrainzOwner = "http://musicbrainz.org";
+
 } // anonymous namespace
 
 namespace taglib {
@@ -353,11 +360,6 @@ QString formatReplayGainPeak(const ReplayGain& replayGain) {
 }
 
 inline
-bool hasTrackPeak(const TrackMetadata& trackMetadata) {
-    return trackMetadata.getTrackInfo().getReplayGain().hasPeak();
-}
-
-inline
 QString formatTrackPeak(const TrackMetadata& trackMetadata) {
     return formatReplayGainPeak(trackMetadata.getTrackInfo().getReplayGain());
 }
@@ -390,11 +392,6 @@ bool parseTrackPeak(
 
 #if defined(__EXTRA_METADATA__)
 inline
-bool hasAlbumGain(const TrackMetadata& trackMetadata) {
-    return trackMetadata.getAlbumInfo().getReplayGain().hasRatio();
-}
-
-inline
 QString formatAlbumGain(const TrackMetadata& trackMetadata) {
     return formatReplayGainGain(trackMetadata.getAlbumInfo().getReplayGain());
 }
@@ -410,11 +407,6 @@ bool parseAlbumGain(
         pTrackMetadata->refAlbumInfo().setReplayGain(replayGain);
     }
     return isRatioValid;
-}
-
-inline
-bool hasAlbumPeak(const TrackMetadata& trackMetadata) {
-    return trackMetadata.getAlbumInfo().getReplayGain().hasPeak();
 }
 
 inline
@@ -633,47 +625,6 @@ QString readFirstUserTextIdentificationFrame(
     }
 }
 
-// Deletes all TXXX frame with the given description (case-insensitive).
-int removeUserTextIdentificationFrames(
-        TagLib::ID3v2::Tag* pTag,
-        const QString& description) {
-    DEBUG_ASSERT(pTag);
-    DEBUG_ASSERT(!description.isEmpty());
-    int count = 0;
-    bool repeat;
-    do {
-        repeat = false;
-        // Bind the const-ref result to avoid a local copy
-        const TagLib::ID3v2::FrameList& textFrames =
-                pTag->frameListMap()["TXXX"];
-        for (TagLib::ID3v2::FrameList::ConstIterator it(textFrames.begin());
-                it != textFrames.end(); ++it) {
-            auto pFrame =
-                    dynamic_cast<TagLib::ID3v2::UserTextIdentificationFrame*>(*it);
-            if (pFrame) {
-                const QString frameDescription(
-                        toQString(pFrame->description()));
-                if (0 == frameDescription.compare(
-                        description, Qt::CaseInsensitive)) {
-                    if (kLogger.debugEnabled()) {
-                        kLogger.debug()
-                                << "Removing ID3v2 TXXX frame:"
-                                << toQString(pFrame->description());
-                    }
-                    // After removing a frame the result of frameListMap()
-                    // is no longer valid!!
-                    pTag->removeFrame(pFrame, false); // remove an unowned frame
-                    ++count;
-                    // Exit and restart loop
-                    repeat = true;
-                    break;
-                }
-            }
-        }
-    } while (repeat);
-    return count;
-}
-
 #if defined(__EXTRA_METADATA__)
 // Finds the first UFID frame that with a matching owner (case-insensitive).
 // If multiple UFID frames with matching descriptions exist prefer the first
@@ -712,7 +663,6 @@ TagLib::ID3v2::UniqueFileIdentifierFrame* findFirstUniqueFileIdentifierFrame(
     return pFirstFrame;
 }
 
-inline
 QByteArray readFirstUniqueFileIdentifierFrame(
         const TagLib::ID3v2::Tag& tag,
         const QString& owner) {
@@ -800,6 +750,80 @@ void writeID3v2TextIdentificationFrame(
     }
 }
 
+void writeID3v2UserTextIdentificationFrame(
+        TagLib::ID3v2::Tag* pTag,
+        const QString& description,
+        const QString& text,
+        bool isNumericOrURL = false) {
+    TagLib::ID3v2::UserTextIdentificationFrame* pFrame =
+            findFirstUserTextIdentificationFrame(*pTag, description);
+    if (pFrame) {
+        // Modify existing frame
+        if (text.isEmpty()) {
+            // Purge empty frames
+            pTag->removeFrame(pFrame);
+        } else {
+            pFrame->setDescription(toTagLibString(description));
+            pFrame->setText(toTagLibString(text));
+        }
+    } else {
+        // Add a new (non-empty) frame
+        if (!text.isEmpty()) {
+            const TagLib::String::Type stringType =
+                    getID3v2StringType(*pTag, isNumericOrURL);
+            auto pFrame =
+                    std::make_unique<TagLib::ID3v2::UserTextIdentificationFrame>(stringType);
+            pFrame->setDescription(toTagLibString(description));
+            pFrame->setText(toTagLibString(text));
+            pTag->addFrame(pFrame.get());
+            // Now that the plain pointer in pFrame is owned and managed by
+            // pTag we need to release the ownership to avoid double deletion!
+            pFrame.release();
+        }
+    }
+}
+
+// Deletes all TXXX frame with the given description (case-insensitive).
+int removeUserTextIdentificationFrames(
+        TagLib::ID3v2::Tag* pTag,
+        const QString& description) {
+    DEBUG_ASSERT(pTag);
+    DEBUG_ASSERT(!description.isEmpty());
+    int count = 0;
+    bool repeat;
+    do {
+        repeat = false;
+        // Bind the const-ref result to avoid a local copy
+        const TagLib::ID3v2::FrameList& textFrames =
+                pTag->frameListMap()["TXXX"];
+        for (TagLib::ID3v2::FrameList::ConstIterator it(textFrames.begin());
+                it != textFrames.end(); ++it) {
+            auto pFrame =
+                    dynamic_cast<TagLib::ID3v2::UserTextIdentificationFrame*>(*it);
+            if (pFrame) {
+                const QString frameDescription(
+                        toQString(pFrame->description()));
+                if (0 == frameDescription.compare(
+                        description, Qt::CaseInsensitive)) {
+                    if (kLogger.debugEnabled()) {
+                        kLogger.debug()
+                                << "Removing ID3v2 TXXX frame:"
+                                << toQString(pFrame->description());
+                    }
+                    // After removing a frame the result of frameListMap()
+                    // is no longer valid!!
+                    pTag->removeFrame(pFrame, false); // remove an unowned frame
+                    ++count;
+                    // Exit and restart loop
+                    repeat = true;
+                    break;
+                }
+            }
+        }
+    } while (repeat);
+    return count;
+}
+
 void writeID3v2CommentsFrame(
         TagLib::ID3v2::Tag* pTag,
         const QString& text,
@@ -849,52 +873,7 @@ void writeID3v2CommentsFrameWithoutDescription(
     writeID3v2CommentsFrame(pTag, text, QString(), isNumericOrURL);
 }
 
-void writeID3v2UserTextIdentificationFrame(
-        TagLib::ID3v2::Tag* pTag,
-        const QString& description,
-        const QString& text,
-        bool isNumericOrURL = false) {
-    TagLib::ID3v2::UserTextIdentificationFrame* pFrame =
-            findFirstUserTextIdentificationFrame(*pTag, description);
-    if (pFrame) {
-        // Modify existing frame
-        if (text.isEmpty()) {
-            // Purge empty frames
-            pTag->removeFrame(pFrame);
-        } else {
-            pFrame->setDescription(toTagLibString(description));
-            pFrame->setText(toTagLibString(text));
-        }
-    } else {
-        // Add a new (non-empty) frame
-        if (!text.isEmpty()) {
-            const TagLib::String::Type stringType =
-                    getID3v2StringType(*pTag, isNumericOrURL);
-            auto pFrame =
-                    std::make_unique<TagLib::ID3v2::UserTextIdentificationFrame>(stringType);
-            pFrame->setDescription(toTagLibString(description));
-            pFrame->setText(toTagLibString(text));
-            pTag->addFrame(pFrame.get());
-            // Now that the plain pointer in pFrame is owned and managed by
-            // pTag we need to release the ownership to avoid double deletion!
-            pFrame.release();
-        }
-    }
-}
-
 #if defined(__EXTRA_METADATA__)
-bool writeID3v2TextIdentificationFrameStringIfNotNull(
-        TagLib::ID3v2::Tag* pTag,
-        const TagLib::ByteVector &id,
-        const QString& text) {
-    if (text.isNull()) {
-        return false;
-    } else {
-        writeID3v2TextIdentificationFrame(pTag, id, text);
-        return true;
-    }
-}
-
 void writeID3v2UniqueFileIdentifierFrame(
         TagLib::ID3v2::Tag* pTag,
         const QString& owner,
@@ -1585,7 +1564,7 @@ void importTrackMetadataFromID3v2Tag(
         pTrackMetadata->refTrackInfo().setMusicBrainzArtistId(QUuid(trackArtistId));
     }
     QByteArray trackRecordingId =
-            readFirstUniqueFileIdentifierFrame(tag, "http://musicbrainz.org");
+            readFirstUniqueFileIdentifierFrame(tag, kMusicBrainzOwner);
     if (!trackRecordingId.isEmpty()) {
         pTrackMetadata->refTrackInfo().setMusicBrainzRecordingId(QUuid(trackRecordingId));
     }
@@ -2381,11 +2360,11 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
                 "GRP1",
                 trackMetadata.getTrackInfo().getGrouping());
 #if defined(__EXTRA_METADATA__)
-        writeID3v2TextIdentificationFrameStringIfNotNull(
+        writeID3v2TextIdentificationFrame(
                 pTag,
                 "TIT1",
                 trackMetadata.getTrackInfo().getWork());
-        writeID3v2TextIdentificationFrameStringIfNotNull(
+        writeID3v2TextIdentificationFrame(
                 pTag,
                 "MVNM",
                 trackMetadata.getTrackInfo().getMovement());
@@ -2412,142 +2391,120 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
             "REPLAYGAIN_TRACK_GAIN",
             formatTrackGain(trackMetadata),
             true);
-    // NOTE(uklotzde, 2018-04-22): The analyzers currently doesn't
-    // calculate a peak value, so leave it untouched in the file if
-    // the value is invalid/absent. Otherwise the ID3 frame would
-    // be deleted.
-    if (hasTrackPeak(trackMetadata)) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "REPLAYGAIN_TRACK_PEAK",
-                formatTrackPeak(trackMetadata),
-                true);
-    }
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "REPLAYGAIN_TRACK_PEAK",
+            formatTrackPeak(trackMetadata),
+            true);
 
-    // TODO(XXX): The following tags have been added later and are currently
-    // not stored in the Mixxx library. Only write fields that have non-null
-    // values to preserve any existing file tags instead of removing them!
 #if defined(__EXTRA_METADATA__)
-    if (hasAlbumGain(trackMetadata)) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "REPLAYGAIN_ALBUM_GAIN",
-                formatAlbumGain(trackMetadata),
-                true);
-    }
-    if (hasAlbumPeak(trackMetadata)) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "REPLAYGAIN_ALBUM_PEAK",
-                formatAlbumPeak(trackMetadata),
-                true);
-    }
+    writeID3v2TextIdentificationFrame(pTag, "TPOS", TrackNumbers::joinStrings(
+            trackMetadata.getTrackInfo().getDiscNumber(),
+            trackMetadata.getTrackInfo().getDiscTotal()));
 
-    if (!trackMetadata.getTrackInfo().getMusicBrainzArtistId().isNull()) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "MusicBrainz Artist Id",
-                trackMetadata.getTrackInfo().getMusicBrainzArtistId().toString(),
-                false);
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzRecordingId().isNull()) {
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "REPLAYGAIN_ALBUM_GAIN",
+            formatAlbumGain(trackMetadata),
+            true);
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "REPLAYGAIN_ALBUM_PEAK",
+            formatAlbumPeak(trackMetadata),
+            true);
+
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "MusicBrainz Artist Id",
+            formatUuid(trackMetadata.getTrackInfo().getMusicBrainzArtistId()),
+            false);
+    {
         QByteArray identifier = trackMetadata.getTrackInfo().getMusicBrainzRecordingId().toByteArray();
         if (identifier.size() == 38) {
             // Strip leading/trailing curly braces
+            DEBUG_ASSERT(identifier.startsWith('{'));
+            DEBUG_ASSERT(identifier.endsWith('}'));
             identifier = identifier.mid(1, 36);
         }
         DEBUG_ASSERT(identifier.size() == 36);
         writeID3v2UniqueFileIdentifierFrame(
                 pTag,
-                "http://musicbrainz.org",
+                kMusicBrainzOwner,
                 identifier);
     }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzReleaseId().isNull()) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "MusicBrainz Release Track Id",
-                trackMetadata.getTrackInfo().getMusicBrainzReleaseId().toString(),
-                false);
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzWorkId().isNull()) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "MusicBrainz Work Id",
-                trackMetadata.getTrackInfo().getMusicBrainzWorkId().toString(),
-                false);
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzArtistId().isNull()) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "MusicBrainz Album Artist Id",
-                trackMetadata.getAlbumInfo().getMusicBrainzArtistId().toString(),
-                false);
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().isNull()) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "MusicBrainz Album Id",
-                trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().toString(),
-                false);
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().isNull()) {
-        writeID3v2UserTextIdentificationFrame(
-                pTag,
-                "MusicBrainz Release Group Id",
-                trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().toString(),
-                false);
-    }
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "MusicBrainz Release Track Id",
+            formatUuid(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()),
+            false);
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "MusicBrainz Work Id",
+            formatUuid(trackMetadata.getTrackInfo().getMusicBrainzWorkId()),
+            false);
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "MusicBrainz Album Artist Id",
+            formatUuid(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()),
+            false);
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "MusicBrainz Album Id",
+            formatUuid(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()),
+            false);
+    writeID3v2UserTextIdentificationFrame(
+            pTag,
+            "MusicBrainz Release Group Id",
+            formatUuid(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()),
+            false);
 
-    writeID3v2TextIdentificationFrameStringIfNotNull(pTag, "TPOS", TrackNumbers::joinStrings(
-            trackMetadata.getTrackInfo().getDiscNumber(),
-            trackMetadata.getTrackInfo().getDiscTotal()));
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TPE3",
             trackMetadata.getTrackInfo().getConductor());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TSRC",
             trackMetadata.getTrackInfo().getISRC());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TLAN",
             trackMetadata.getTrackInfo().getLanguage());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TEXT",
             trackMetadata.getTrackInfo().getLyricist());
     if (pHeader->majorVersion() >= 4) {
-        writeID3v2TextIdentificationFrameStringIfNotNull(
+        writeID3v2TextIdentificationFrame(
                 pTag,
                 "TMOO",
                 trackMetadata.getTrackInfo().getMood());
     }
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TCOP",
             trackMetadata.getAlbumInfo().getCopyright());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "WCOP",
             trackMetadata.getAlbumInfo().getLicense());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TPUB",
             trackMetadata.getAlbumInfo().getRecordLabel());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TPE4",
             trackMetadata.getTrackInfo().getRemixer());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TIT3",
             trackMetadata.getTrackInfo().getSubtitle());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TENC",
             trackMetadata.getTrackInfo().getEncoder());
-    writeID3v2TextIdentificationFrameStringIfNotNull(
+    writeID3v2TextIdentificationFrame(
             pTag,
             "TSSE",
             trackMetadata.getTrackInfo().getEncoderSettings());
@@ -2590,112 +2547,59 @@ bool exportTrackMetadataIntoAPETag(TagLib::APE::Tag* pTag, const TrackMetadata& 
 
     writeAPEItem(pTag, "REPLAYGAIN_TRACK_GAIN",
             toTagLibString(formatTrackGain(trackMetadata)));
-    // NOTE(uklotzde, 2018-04-22): The analyzers currently doesn't
-    // calculate a peak value, so leave it untouched in the file if
-    // the value is invalid/absent. Otherwise the APE item would be
-    // deleted.
-    if (hasTrackPeak(trackMetadata)) {
-        writeAPEItem(pTag, "REPLAYGAIN_TRACK_PEAK",
-                toTagLibString(formatTrackPeak(trackMetadata)));
-    }
+    writeAPEItem(pTag, "REPLAYGAIN_TRACK_PEAK",
+            toTagLibString(formatTrackPeak(trackMetadata)));
 
-    // TODO(XXX): The following tags have been added later and are currently
-    // not stored in the Mixxx library. Only write fields that have non-null
-    // values to preserve any existing file tags instead of removing them!
 #if defined(__EXTRA_METADATA__)
     auto discNumbers = TrackNumbers::joinStrings(
             trackMetadata.getTrackInfo().getDiscNumber(),
             trackMetadata.getTrackInfo().getDiscTotal());
-    if (!discNumbers.isNull()) {
-        writeAPEItem(pTag, "Disc", toTagLibString(discNumbers));
-    }
+    writeAPEItem(pTag, "Disc", toTagLibString(discNumbers));
 
-    if (hasAlbumGain(trackMetadata)) {
-        writeAPEItem(pTag, "REPLAYGAIN_ALBUM_GAIN",
-                toTagLibString(formatAlbumGain(trackMetadata)));
-    }
-    if (hasAlbumPeak(trackMetadata)) {
-        writeAPEItem(pTag, "REPLAYGAIN_ALBUM_PEAK",
-                toTagLibString(formatAlbumPeak(trackMetadata)));
-    }
+    writeAPEItem(pTag, "REPLAYGAIN_ALBUM_GAIN",
+            toTagLibString(formatAlbumGain(trackMetadata)));
+    writeAPEItem(pTag, "REPLAYGAIN_ALBUM_PEAK",
+            toTagLibString(formatAlbumPeak(trackMetadata)));
 
-    if (!trackMetadata.getTrackInfo().getMusicBrainzArtistId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_ARTISTID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzRecordingId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_TRACKID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzReleaseId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_RELEASETRACKID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzWorkId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_WORKID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzArtistId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_ALBUMARTISTID",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_ALBUMID",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().isNull()) {
-        writeAPEItem(pTag, "MUSICBRAINZ_RELEASEGROUPID",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().toString()));
-    }
+    writeAPEItem(pTag, "MUSICBRAINZ_ARTISTID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
+    writeAPEItem(pTag, "MUSICBRAINZ_TRACKID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
+    writeAPEItem(pTag, "MUSICBRAINZ_RELEASETRACKID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
+    writeAPEItem(pTag, "MUSICBRAINZ_WORKID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
+    writeAPEItem(pTag, "MUSICBRAINZ_ALBUMARTISTID",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
+    writeAPEItem(pTag, "MUSICBRAINZ_ALBUMID",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
+    writeAPEItem(pTag, "MUSICBRAINZ_RELEASEGROUPID",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
 
-    if (!trackMetadata.getTrackInfo().getConductor().isNull()) {
-        writeAPEItem(pTag, "Conductor",
-                toTagLibString(trackMetadata.getTrackInfo().getConductor()));
-    }
-    if (!trackMetadata.getTrackInfo().getISRC().isNull()) {
-        writeAPEItem(pTag, "ISRC",
-                toTagLibString(trackMetadata.getTrackInfo().getISRC()));
-    }
-    if (!trackMetadata.getTrackInfo().getLanguage().isNull()) {
-        writeAPEItem(pTag, "Language",
-                toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
-    }
-    if (!trackMetadata.getTrackInfo().getLyricist().isNull()) {
-        writeAPEItem(pTag, "Lyricist",
-                toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
-    }
-    if (!trackMetadata.getTrackInfo().getMood().isNull()) {
-        writeAPEItem(pTag, "Mood",
-                toTagLibString(trackMetadata.getTrackInfo().getMood()));
-    }
-    if (!trackMetadata.getAlbumInfo().getCopyright().isNull()) {
-        writeAPEItem(pTag, "Copyright",
-                toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
-    }
-    if (!trackMetadata.getAlbumInfo().getLicense().isNull()) {
-        writeAPEItem(pTag, "LICENSE",
-                toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
-    }
-    if (!trackMetadata.getAlbumInfo().getRecordLabel().isNull()) {
-        writeAPEItem(pTag, "Label",
-                toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
-    }
-    if (!trackMetadata.getTrackInfo().getRemixer().isNull()) {
-        writeAPEItem(pTag, "MixArtist",
-                toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
-    }
-    if (!trackMetadata.getTrackInfo().getSubtitle().isNull()) {
-        writeAPEItem(pTag, "Subtitle",
-                toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
-    }
-    if (!trackMetadata.getTrackInfo().getEncoder().isNull()) {
-        writeAPEItem(pTag, "EncodedBy",
-                toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
-    }
-    if (!trackMetadata.getTrackInfo().getEncoderSettings().isNull()) {
-        writeAPEItem(pTag, "EncoderSettings",
-                toTagLibString(trackMetadata.getTrackInfo().getEncoderSettings()));
-    }
+    writeAPEItem(pTag, "Conductor",
+            toTagLibString(trackMetadata.getTrackInfo().getConductor()));
+    writeAPEItem(pTag, "ISRC",
+            toTagLibString(trackMetadata.getTrackInfo().getISRC()));
+    writeAPEItem(pTag, "Language",
+            toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
+    writeAPEItem(pTag, "Lyricist",
+            toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
+    writeAPEItem(pTag, "Mood",
+            toTagLibString(trackMetadata.getTrackInfo().getMood()));
+    writeAPEItem(pTag, "Copyright",
+            toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
+    writeAPEItem(pTag, "LICENSE",
+            toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
+    writeAPEItem(pTag, "Label",
+            toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
+    writeAPEItem(pTag, "MixArtist",
+            toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
+    writeAPEItem(pTag, "Subtitle",
+            toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
+    writeAPEItem(pTag, "EncodedBy",
+            toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
+    writeAPEItem(pTag, "EncoderSettings",
+            toTagLibString(trackMetadata.getTrackInfo().getEncoderSettings()));
 #endif // __EXTRA_METADATA__
 
     return true;
@@ -2777,110 +2681,62 @@ bool exportTrackMetadataIntoXiphComment(TagLib::Ogg::XiphComment* pTag,
     // calculate a peak value, so leave it untouched in the file if
     // the value is invalid/absent. Otherwise the comment field would
     // be deleted.
-    if (hasTrackPeak(trackMetadata)) {
-        writeXiphCommentField(pTag, "REPLAYGAIN_TRACK_PEAK",
-                toTagLibString(formatTrackPeak(trackMetadata)));
-    }
+    writeXiphCommentField(pTag, "REPLAYGAIN_TRACK_PEAK",
+            toTagLibString(formatTrackPeak(trackMetadata)));
 
-    // TODO(XXX): The following tags have been added later and are currently
-    // not stored in the Mixxx library. Only write fields that have non-null
-    // values to preserve any existing file tags instead of removing them!
 #if defined(__EXTRA_METADATA__)
-    if (hasAlbumGain(trackMetadata)) {
-        writeXiphCommentField(pTag, "REPLAYGAIN_ALBUM_GAIN",
-                toTagLibString(formatAlbumGain(trackMetadata)));
-    }
-    if (hasAlbumPeak(trackMetadata)) {
-        writeXiphCommentField(pTag, "REPLAYGAIN_ALBUM_PEAK",
-                toTagLibString(formatAlbumPeak(trackMetadata)));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzArtistId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_ARTISTID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzRecordingId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_TRACKID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzReleaseId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_RELEASETRACKID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzWorkId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_WORKID",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzArtistId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_ALBUMARTISTID",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_ALBUMID",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().isNull()) {
-        writeXiphCommentField(pTag, "MUSICBRAINZ_RELEASEGROUPID",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getConductor().isNull()) {
-        writeXiphCommentField(pTag, "CONDUCTOR",
-                toTagLibString(trackMetadata.getTrackInfo().getConductor()));
-    }
-    if (!trackMetadata.getTrackInfo().getISRC().isNull()) {
-        writeXiphCommentField(pTag, "ISRC",
-                toTagLibString(trackMetadata.getTrackInfo().getISRC()));
-    }
-    if (!trackMetadata.getTrackInfo().getLanguage().isNull()) {
-        writeXiphCommentField(pTag, "LANGUAGE",
-                toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
-    }
-    if (!trackMetadata.getTrackInfo().getLyricist().isNull()) {
-        writeXiphCommentField(pTag, "LYRICIST",
-                toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
-    }
-    if (!trackMetadata.getTrackInfo().getMood().isNull()) {
-        writeXiphCommentField(pTag, "MOOD",
-                toTagLibString(trackMetadata.getTrackInfo().getMood()));
-    }
-    if (!trackMetadata.getAlbumInfo().getCopyright().isNull()) {
-        writeXiphCommentField(pTag, "COPYRIGHT",
-                toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
-    }
-    if (!trackMetadata.getAlbumInfo().getLicense().isNull()) {
-        writeXiphCommentField(pTag, "LICENSE",
-                toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
-    }
-    if (!trackMetadata.getAlbumInfo().getRecordLabel().isNull()) {
-        writeXiphCommentField(pTag, "LABEL",
-                toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
-    }
-    if (!trackMetadata.getTrackInfo().getRemixer().isNull()) {
-        writeXiphCommentField(pTag, "REMIXER",
-                toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
-    }
-    if (!trackMetadata.getTrackInfo().getSubtitle().isNull()) {
-        writeXiphCommentField(pTag, "SUBTITLE",
-                toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
-    }
-    if (!trackMetadata.getTrackInfo().getEncoder().isNull()) {
-        writeXiphCommentField(pTag, "ENCODEDBY",
-                toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
-    }
-    if (!trackMetadata.getTrackInfo().getEncoderSettings().isNull()) {
-        writeXiphCommentField(pTag, "ENCODERSETTINGS",
-                toTagLibString(trackMetadata.getTrackInfo().getEncoderSettings()));
-    }
-    if (!trackMetadata.getTrackInfo().getDiscNumber().isNull()) {
-        writeXiphCommentField(
-                pTag, "DISCNUMBER", toTagLibString(trackMetadata.getTrackInfo().getDiscNumber()));
-    }
     // According to https://wiki.xiph.org/Field_names "DISCTOTAL" is
     // the proposed field name, but some applications use "TOTALDISCS".
-    if (!trackMetadata.getTrackInfo().getDiscTotal().isNull()) {
-        const TagLib::String discTotal(toTagLibString(trackMetadata.getTrackInfo().getDiscTotal()));
-        writeXiphCommentField(pTag, "DISCTOTAL", discTotal);   // recommended field
-        updateXiphCommentField(pTag, "TOTALDISCS", discTotal); // alternative field
-    }
+    const TagLib::String discTotal(toTagLibString(trackMetadata.getTrackInfo().getDiscTotal()));
+    writeXiphCommentField(pTag, "DISCTOTAL", discTotal);   // recommended field
+    updateXiphCommentField(pTag, "TOTALDISCS", discTotal); // alternative field
+
+    writeXiphCommentField(pTag, "REPLAYGAIN_ALBUM_GAIN",
+            toTagLibString(formatAlbumGain(trackMetadata)));
+    writeXiphCommentField(pTag, "REPLAYGAIN_ALBUM_PEAK",
+            toTagLibString(formatAlbumPeak(trackMetadata)));
+
+    writeXiphCommentField(pTag, "MUSICBRAINZ_ARTISTID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
+    writeXiphCommentField(pTag, "MUSICBRAINZ_TRACKID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
+    writeXiphCommentField(pTag, "MUSICBRAINZ_RELEASETRACKID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
+    writeXiphCommentField(pTag, "MUSICBRAINZ_WORKID",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
+    writeXiphCommentField(pTag, "MUSICBRAINZ_ALBUMARTISTID",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
+    writeXiphCommentField(pTag, "MUSICBRAINZ_ALBUMID",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
+    writeXiphCommentField(pTag, "MUSICBRAINZ_RELEASEGROUPID",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
+
+    writeXiphCommentField(pTag, "CONDUCTOR",
+            toTagLibString(trackMetadata.getTrackInfo().getConductor()));
+    writeXiphCommentField(pTag, "ISRC",
+            toTagLibString(trackMetadata.getTrackInfo().getISRC()));
+    writeXiphCommentField(pTag, "LANGUAGE",
+            toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
+    writeXiphCommentField(pTag, "LYRICIST",
+            toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
+    writeXiphCommentField(pTag, "MOOD",
+            toTagLibString(trackMetadata.getTrackInfo().getMood()));
+    writeXiphCommentField(pTag, "COPYRIGHT",
+            toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
+    writeXiphCommentField(pTag, "LICENSE",
+            toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
+    writeXiphCommentField(pTag, "LABEL",
+            toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
+    writeXiphCommentField(pTag, "REMIXER",
+            toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
+    writeXiphCommentField(pTag, "SUBTITLE",
+            toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
+    writeXiphCommentField(pTag, "ENCODEDBY",
+            toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
+    writeXiphCommentField(pTag, "ENCODERSETTINGS",
+            toTagLibString(trackMetadata.getTrackInfo().getEncoderSettings()));
+    writeXiphCommentField(
+            pTag, "DISCNUMBER", toTagLibString(trackMetadata.getTrackInfo().getDiscNumber()));
 #endif // __EXTRA_METADATA__
 
     return true;
@@ -2942,18 +2798,9 @@ bool exportTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& 
 
     writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_track_gain",
             toTagLibString(formatTrackGain(trackMetadata)));
-    // NOTE(uklotzde, 2018-04-22): The analyzers currently doesn't
-    // calculate a peak value, so leave it untouched in the file if
-    // the value is invalid/absent. Otherwise the MP4 atom would be
-    // deleted.
-    if (hasTrackPeak(trackMetadata)) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_track_peak",
-                toTagLibString(formatTrackPeak(trackMetadata)));
-    }
+    writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_track_peak",
+            toTagLibString(formatTrackPeak(trackMetadata)));
 
-    // TODO(XXX): The following tags have been added later and are currently
-    // not stored in the Mixxx library. Only write fields that have non-null
-    // values to preserve any existing file tags instead of removing them!
 #if defined(__EXTRA_METADATA__)
     // Write disc number/total pair
     QString discNumberText;
@@ -2964,9 +2811,7 @@ bool exportTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& 
             trackMetadata.getTrackInfo().getDiscTotal(), &parsedDiscNumbers);
     switch (discParseResult) {
         case TrackNumbers::ParseResult::EMPTY:
-            // Preserve disc numbers in file and do NOT delete them
-            // if not already stored in the Mixxx database! Support
-            // for these fields have been added later.
+            pTag->itemListMap().erase("disk");
             break;
         case TrackNumbers::ParseResult::VALID:
             pTag->itemListMap()["disk"] =
@@ -2979,92 +2824,52 @@ bool exportTrackMetadataIntoMP4Tag(TagLib::MP4::Tag* pTag, const TrackMetadata& 
                                          trackMetadata.getTrackInfo().getDiscTotal());
     }
 
-    if (hasAlbumGain(trackMetadata)) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_album_gain",
-                toTagLibString(formatAlbumGain(trackMetadata)));
-    }
-    if (hasAlbumPeak(trackMetadata)) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_album_peak",
-                toTagLibString(formatAlbumPeak(trackMetadata)));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzArtistId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Artist Id",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzRecordingId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Track Id",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzReleaseId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Release Track Id",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getMusicBrainzWorkId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Work Id",
-                toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzArtistId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Album Artist Id",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Album Id",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId().toString()));
-    }
-    if (!trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Release Group Id",
-                toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId().toString()));
-    }
-    if (!trackMetadata.getTrackInfo().getConductor().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:CONDUCTOR",
-                toTagLibString(trackMetadata.getTrackInfo().getConductor()));
-    }
-    if (!trackMetadata.getTrackInfo().getISRC().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:ISRC",
-                toTagLibString(trackMetadata.getTrackInfo().getISRC()));
-    }
-    if (!trackMetadata.getTrackInfo().getLanguage().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:LANGUAGE",
-                toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
-    }
-    if (!trackMetadata.getTrackInfo().getLyricist().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:LYRICIST",
-                toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
-    }
-    if (!trackMetadata.getTrackInfo().getMood().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:MOOD",
-                toTagLibString(trackMetadata.getTrackInfo().getMood()));
-    }
-    if (!trackMetadata.getAlbumInfo().getCopyright().isNull()) {
-        writeMP4Atom(pTag, "cprt",
-                toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
-    }
-    if (!trackMetadata.getAlbumInfo().getLicense().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:LICENSE",
-                toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
-    }
-    if (!trackMetadata.getAlbumInfo().getRecordLabel().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:LABEL",
-                toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
-    }
-    if (!trackMetadata.getTrackInfo().getRemixer().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:REMIXER",
-                toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
-    }
-    if (!trackMetadata.getTrackInfo().getSubtitle().isNull()) {
-        writeMP4Atom(pTag, "----:com.apple.iTunes:SUBTITLE",
-                toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
-    }
-    if (!trackMetadata.getTrackInfo().getEncoder().isNull()) {
-        writeMP4Atom(pTag, "\251too",
-                toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
-    }
-    if (!trackMetadata.getTrackInfo().getWork().isNull()) {
-        writeMP4Atom(pTag, "\251wrk", toTagLibString(trackMetadata.getTrackInfo().getWork()));
-    }
-    if (!trackMetadata.getTrackInfo().getMovement().isNull()) {
-        writeMP4Atom(pTag, "\251mvn", toTagLibString(trackMetadata.getTrackInfo().getMovement()));
-    }
+    writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_album_gain",
+            toTagLibString(formatAlbumGain(trackMetadata)));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:replaygain_album_peak",
+            toTagLibString(formatAlbumPeak(trackMetadata)));
+
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Artist Id",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzArtistId()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Track Id",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzRecordingId()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Release Track Id",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzReleaseId()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Work Id",
+            toTagLibString(trackMetadata.getTrackInfo().getMusicBrainzWorkId()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Album Artist Id",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzArtistId()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Album Id",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseId()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MusicBrainz Release Group Id",
+            toTagLibString(trackMetadata.getAlbumInfo().getMusicBrainzReleaseGroupId()));
+
+    writeMP4Atom(pTag, "----:com.apple.iTunes:CONDUCTOR",
+            toTagLibString(trackMetadata.getTrackInfo().getConductor()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:ISRC",
+            toTagLibString(trackMetadata.getTrackInfo().getISRC()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:LANGUAGE",
+            toTagLibString(trackMetadata.getTrackInfo().getLanguage()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:LYRICIST",
+            toTagLibString(trackMetadata.getTrackInfo().getLyricist()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:MOOD",
+            toTagLibString(trackMetadata.getTrackInfo().getMood()));
+    writeMP4Atom(pTag, "cprt",
+            toTagLibString(trackMetadata.getAlbumInfo().getCopyright()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:LICENSE",
+            toTagLibString(trackMetadata.getAlbumInfo().getLicense()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:LABEL",
+            toTagLibString(trackMetadata.getAlbumInfo().getRecordLabel()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:REMIXER",
+            toTagLibString(trackMetadata.getTrackInfo().getRemixer()));
+    writeMP4Atom(pTag, "----:com.apple.iTunes:SUBTITLE",
+            toTagLibString(trackMetadata.getTrackInfo().getSubtitle()));
+    writeMP4Atom(pTag, "\251too",
+            toTagLibString(trackMetadata.getTrackInfo().getEncoder()));
+    writeMP4Atom(pTag, "\251wrk",
+            toTagLibString(trackMetadata.getTrackInfo().getWork()));
+    writeMP4Atom(pTag, "\251mvn",
+            toTagLibString(trackMetadata.getTrackInfo().getMovement()));
 #endif // __EXTRA_METADATA__
 
     return true;

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -2508,6 +2508,10 @@ bool exportTrackMetadataIntoID3v2Tag(TagLib::ID3v2::Tag* pTag,
             pTag,
             "TSSE",
             trackMetadata.getTrackInfo().getEncoderSettings());
+    writeID3v2GeneralEncapsulatedObjectFrame(
+            pTag,
+            "Serato Markers2",
+            trackMetadata.getTrackInfo().getSeratoMarkers2().data());
 #endif // __EXTRA_METADATA__
 
     return true;

--- a/src/track/trackmetadatataglib.cpp
+++ b/src/track/trackmetadatataglib.cpp
@@ -71,7 +71,7 @@ bool checkID3v2HeaderVersionSupported(const TagLib::ID3v2::Header& header) {
 // as written by MusicBrainz Picard 2.1.3 although the mapping table
 // doesn't mention any "http://" prefix.
 // See also: https://picard.musicbrainz.org/docs/mappings
-const QString kMusicBrainzOwner = "http://musicbrainz.org";
+const QString kMusicBrainzOwner = QStringLiteral("http://musicbrainz.org");
 
 } // anonymous namespace
 

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -5,6 +5,8 @@
 
 namespace mixxx {
 
+/*static*/ const QString TrackRecord::kTrackTotalPlaceholder = QStringLiteral("//");
+
 TrackRecord::TrackRecord(TrackId id)
         : m_id(std::move(id)),
           m_metadataSynchronized(false),
@@ -49,12 +51,6 @@ bool TrackRecord::updateGlobalKeyText(
 
 namespace {
 
-// Data migration: Reload track total from file tags if not initialized
-// yet. The added column "tracktotal" has been initialized with the
-// default value "//".
-// See also: Schema revision 26 in schema.xml
-const QString kReloadTrackTotal = QStringLiteral("//");
-
 void mergeReplayGainMetadataProperty(
         ReplayGain& mergedReplayGain,
         const ReplayGain& importedReplayGain) {
@@ -96,7 +92,7 @@ void TrackRecord::mergeImportedMetadata(
         const TrackMetadata& importedFromFile) {
     TrackInfo& mergedTrackInfo = refMetadata().refTrackInfo();
     const TrackInfo& importedTrackInfo = importedFromFile.getTrackInfo();
-    if (mergedTrackInfo.getTrackTotal() == kReloadTrackTotal) {
+    if (mergedTrackInfo.getTrackTotal() == kTrackTotalPlaceholder) {
         mergedTrackInfo.setTrackTotal(importedTrackInfo.getTrackTotal());
         // Also set the track number if it is still empty due
         // to insufficient parsing capabilities of Mixxx in

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -47,4 +47,85 @@ bool TrackRecord::updateGlobalKeyText(
     return false;
 }
 
+namespace {
+
+// Data migration: Reload track total from file tags if not initialized
+// yet. The added column "tracktotal" has been initialized with the
+// default value "//".
+// See also: Schema revision 26 in schema.xml
+const QString kReloadTrackTotal = "//";
+
+void mergeReplayGainMetadataProperty(
+        ReplayGain& mergedReplayGain,
+        const ReplayGain& importedReplayGain) {
+    // Preserve the values calculated by Mixxx and only merge missing
+    // values from the imported replay gain.
+    if (!mergedReplayGain.hasRatio()) {
+        mergedReplayGain.setRatio(importedReplayGain.getRatio());
+    }
+    if (!mergedReplayGain.hasPeak()) {
+        mergedReplayGain.setPeak(importedReplayGain.getPeak());
+    }
+}
+
+template<typename T>
+void mergeNullableMetadataProperty(
+        T& mergedProperty,
+        const T& importedProperty) {
+    if (mergedProperty.isNull()) {
+        mergedProperty = importedProperty;
+    }
+}
+
+} // anonymous namespace
+
+void TrackRecord::mergeImportedMetadata(
+        const TrackMetadata& importedFromFile) {
+    TrackInfo& mergedTrackInfo = refMetadata().refTrackInfo();
+    const TrackInfo& importedTrackInfo = importedFromFile.getTrackInfo();
+    if (mergedTrackInfo.getTrackTotal() == kReloadTrackTotal) {
+        mergedTrackInfo.setTrackTotal(importedTrackInfo.getTrackTotal());
+        // Also set the track number if it is still empty due
+        // to insufficient parsing capabilities of Mixxx in
+        // previous versions.
+        if (mergedTrackInfo.getTrackNumber().isEmpty() &&
+                !importedTrackInfo.getTrackNumber().isEmpty()) {
+            mergedTrackInfo.setTrackNumber(importedTrackInfo.getTrackNumber());
+        }
+    }
+#if defined(__EXTRA_METADATA__)
+    mergeNullableMetadataProperty(mergedTrackInfo.refConductor(), importedTrackInfo.getConductor());
+    mergeNullableMetadataProperty(mergedTrackInfo.refDiscNumber(), importedTrackInfo.getDiscNumber());
+    mergeNullableMetadataProperty(mergedTrackInfo.refDiscTotal(), importedTrackInfo.getDiscTotal());
+    mergeNullableMetadataProperty(mergedTrackInfo.refEncoder(), importedTrackInfo.getEncoder());
+    mergeNullableMetadataProperty(mergedTrackInfo.refEncoderSettings(), importedTrackInfo.getEncoderSettings());
+    mergeNullableMetadataProperty(mergedTrackInfo.refISRC(), importedTrackInfo.getISRC());
+    mergeNullableMetadataProperty(mergedTrackInfo.refLanguage(), importedTrackInfo.getLanguage());
+    mergeNullableMetadataProperty(mergedTrackInfo.refLyricist(), importedTrackInfo.getLyricist());
+    mergeNullableMetadataProperty(mergedTrackInfo.refMood(), importedTrackInfo.getMood());
+    mergeNullableMetadataProperty(mergedTrackInfo.refMovement(), importedTrackInfo.getMovement());
+    mergeNullableMetadataProperty(mergedTrackInfo.refMusicBrainzArtistId(), importedTrackInfo.getMusicBrainzArtistId());
+    mergeNullableMetadataProperty(mergedTrackInfo.refMusicBrainzRecordingId(), importedTrackInfo.getMusicBrainzRecordingId());
+    mergeNullableMetadataProperty(mergedTrackInfo.refMusicBrainzReleaseId(), importedTrackInfo.getMusicBrainzReleaseId());
+    mergeNullableMetadataProperty(mergedTrackInfo.refMusicBrainzWorkId(), importedTrackInfo.getMusicBrainzWorkId());
+    mergeNullableMetadataProperty(mergedTrackInfo.refRemixer(), importedTrackInfo.getRemixer());
+    mergeNullableMetadataProperty(mergedTrackInfo.refSubtitle(), importedTrackInfo.getSubtitle());
+    mergeNullableMetadataProperty(mergedTrackInfo.refWork(), importedTrackInfo.getWork());
+#endif // __EXTRA_METADATA__
+    AlbumInfo& mergedAlbumInfo = refMetadata().refAlbumInfo();
+    const AlbumInfo& importedAlbumInfo = importedFromFile.getAlbumInfo();
+#if defined(__EXTRA_METADATA__)
+    mergeReplayGainMetadataProperty(mergedAlbumInfo.refReplayGain(), importedAlbumInfo.getReplayGain());
+    mergeNullableMetadataProperty(mergedAlbumInfo.refCopyright(), importedAlbumInfo.getCopyright());
+    mergeNullableMetadataProperty(mergedAlbumInfo.refLicense(), importedAlbumInfo.getLicense());
+    mergeNullableMetadataProperty(mergedAlbumInfo.refMusicBrainzArtistId(), importedAlbumInfo.getMusicBrainzArtistId());
+    mergeNullableMetadataProperty(mergedAlbumInfo.refMusicBrainzReleaseGroupId(), importedAlbumInfo.getMusicBrainzReleaseGroupId());
+    mergeNullableMetadataProperty(mergedAlbumInfo.refMusicBrainzReleaseId(), importedAlbumInfo.getMusicBrainzReleaseId());
+    mergeNullableMetadataProperty(mergedAlbumInfo.refRecordLabel(), importedAlbumInfo.getRecordLabel());
+#else
+    Q_UNUSED(mergedAlbumInfo);
+    Q_UNUSED(importedAlbumInfo);
+#endif // __EXTRA_METADATA__
+}
+
 } //namespace mixxx

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -111,10 +111,8 @@ void TrackRecord::mergeImportedMetadata(
     mergeNullableMetadataProperty(mergedTrackInfo.refRemixer(), importedTrackInfo.getRemixer());
     mergeNullableMetadataProperty(mergedTrackInfo.refSubtitle(), importedTrackInfo.getSubtitle());
     mergeNullableMetadataProperty(mergedTrackInfo.refWork(), importedTrackInfo.getWork());
-#endif // __EXTRA_METADATA__
     AlbumInfo& mergedAlbumInfo = refMetadata().refAlbumInfo();
     const AlbumInfo& importedAlbumInfo = importedFromFile.getAlbumInfo();
-#if defined(__EXTRA_METADATA__)
     mergeReplayGainMetadataProperty(mergedAlbumInfo.refReplayGain(), importedAlbumInfo.getReplayGain());
     mergeNullableMetadataProperty(mergedAlbumInfo.refCopyright(), importedAlbumInfo.getCopyright());
     mergeNullableMetadataProperty(mergedAlbumInfo.refLicense(), importedAlbumInfo.getLicense());
@@ -122,9 +120,6 @@ void TrackRecord::mergeImportedMetadata(
     mergeNullableMetadataProperty(mergedAlbumInfo.refMusicBrainzReleaseGroupId(), importedAlbumInfo.getMusicBrainzReleaseGroupId());
     mergeNullableMetadataProperty(mergedAlbumInfo.refMusicBrainzReleaseId(), importedAlbumInfo.getMusicBrainzReleaseId());
     mergeNullableMetadataProperty(mergedAlbumInfo.refRecordLabel(), importedAlbumInfo.getRecordLabel());
-#else
-    Q_UNUSED(mergedAlbumInfo);
-    Q_UNUSED(importedAlbumInfo);
 #endif // __EXTRA_METADATA__
 }
 

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -68,8 +68,10 @@ void mergeReplayGainMetadataProperty(
     }
 }
 
+// This conditional copy operation only works for nullable properties
+// like QString or QUuid.
 template<typename T>
-void mergeNullableMetadataProperty(
+void copyIfNotNull(
         T& mergedProperty,
         const T& importedProperty) {
     if (mergedProperty.isNull()) {
@@ -94,32 +96,32 @@ void TrackRecord::mergeImportedMetadata(
         }
     }
 #if defined(__EXTRA_METADATA__)
-    mergeNullableMetadataProperty(mergedTrackInfo.refConductor(), importedTrackInfo.getConductor());
-    mergeNullableMetadataProperty(mergedTrackInfo.refDiscNumber(), importedTrackInfo.getDiscNumber());
-    mergeNullableMetadataProperty(mergedTrackInfo.refDiscTotal(), importedTrackInfo.getDiscTotal());
-    mergeNullableMetadataProperty(mergedTrackInfo.refEncoder(), importedTrackInfo.getEncoder());
-    mergeNullableMetadataProperty(mergedTrackInfo.refEncoderSettings(), importedTrackInfo.getEncoderSettings());
-    mergeNullableMetadataProperty(mergedTrackInfo.refISRC(), importedTrackInfo.getISRC());
-    mergeNullableMetadataProperty(mergedTrackInfo.refLanguage(), importedTrackInfo.getLanguage());
-    mergeNullableMetadataProperty(mergedTrackInfo.refLyricist(), importedTrackInfo.getLyricist());
-    mergeNullableMetadataProperty(mergedTrackInfo.refMood(), importedTrackInfo.getMood());
-    mergeNullableMetadataProperty(mergedTrackInfo.refMovement(), importedTrackInfo.getMovement());
-    mergeNullableMetadataProperty(mergedTrackInfo.refMusicBrainzArtistId(), importedTrackInfo.getMusicBrainzArtistId());
-    mergeNullableMetadataProperty(mergedTrackInfo.refMusicBrainzRecordingId(), importedTrackInfo.getMusicBrainzRecordingId());
-    mergeNullableMetadataProperty(mergedTrackInfo.refMusicBrainzReleaseId(), importedTrackInfo.getMusicBrainzReleaseId());
-    mergeNullableMetadataProperty(mergedTrackInfo.refMusicBrainzWorkId(), importedTrackInfo.getMusicBrainzWorkId());
-    mergeNullableMetadataProperty(mergedTrackInfo.refRemixer(), importedTrackInfo.getRemixer());
-    mergeNullableMetadataProperty(mergedTrackInfo.refSubtitle(), importedTrackInfo.getSubtitle());
-    mergeNullableMetadataProperty(mergedTrackInfo.refWork(), importedTrackInfo.getWork());
+    copyIfNotNull(mergedTrackInfo.refConductor(), importedTrackInfo.getConductor());
+    copyIfNotNull(mergedTrackInfo.refDiscNumber(), importedTrackInfo.getDiscNumber());
+    copyIfNotNull(mergedTrackInfo.refDiscTotal(), importedTrackInfo.getDiscTotal());
+    copyIfNotNull(mergedTrackInfo.refEncoder(), importedTrackInfo.getEncoder());
+    copyIfNotNull(mergedTrackInfo.refEncoderSettings(), importedTrackInfo.getEncoderSettings());
+    copyIfNotNull(mergedTrackInfo.refISRC(), importedTrackInfo.getISRC());
+    copyIfNotNull(mergedTrackInfo.refLanguage(), importedTrackInfo.getLanguage());
+    copyIfNotNull(mergedTrackInfo.refLyricist(), importedTrackInfo.getLyricist());
+    copyIfNotNull(mergedTrackInfo.refMood(), importedTrackInfo.getMood());
+    copyIfNotNull(mergedTrackInfo.refMovement(), importedTrackInfo.getMovement());
+    copyIfNotNull(mergedTrackInfo.refMusicBrainzArtistId(), importedTrackInfo.getMusicBrainzArtistId());
+    copyIfNotNull(mergedTrackInfo.refMusicBrainzRecordingId(), importedTrackInfo.getMusicBrainzRecordingId());
+    copyIfNotNull(mergedTrackInfo.refMusicBrainzReleaseId(), importedTrackInfo.getMusicBrainzReleaseId());
+    copyIfNotNull(mergedTrackInfo.refMusicBrainzWorkId(), importedTrackInfo.getMusicBrainzWorkId());
+    copyIfNotNull(mergedTrackInfo.refRemixer(), importedTrackInfo.getRemixer());
+    copyIfNotNull(mergedTrackInfo.refSubtitle(), importedTrackInfo.getSubtitle());
+    copyIfNotNull(mergedTrackInfo.refWork(), importedTrackInfo.getWork());
     AlbumInfo& mergedAlbumInfo = refMetadata().refAlbumInfo();
     const AlbumInfo& importedAlbumInfo = importedFromFile.getAlbumInfo();
     mergeReplayGainMetadataProperty(mergedAlbumInfo.refReplayGain(), importedAlbumInfo.getReplayGain());
-    mergeNullableMetadataProperty(mergedAlbumInfo.refCopyright(), importedAlbumInfo.getCopyright());
-    mergeNullableMetadataProperty(mergedAlbumInfo.refLicense(), importedAlbumInfo.getLicense());
-    mergeNullableMetadataProperty(mergedAlbumInfo.refMusicBrainzArtistId(), importedAlbumInfo.getMusicBrainzArtistId());
-    mergeNullableMetadataProperty(mergedAlbumInfo.refMusicBrainzReleaseGroupId(), importedAlbumInfo.getMusicBrainzReleaseGroupId());
-    mergeNullableMetadataProperty(mergedAlbumInfo.refMusicBrainzReleaseId(), importedAlbumInfo.getMusicBrainzReleaseId());
-    mergeNullableMetadataProperty(mergedAlbumInfo.refRecordLabel(), importedAlbumInfo.getRecordLabel());
+    copyIfNotNull(mergedAlbumInfo.refCopyright(), importedAlbumInfo.getCopyright());
+    copyIfNotNull(mergedAlbumInfo.refLicense(), importedAlbumInfo.getLicense());
+    copyIfNotNull(mergedAlbumInfo.refMusicBrainzArtistId(), importedAlbumInfo.getMusicBrainzArtistId());
+    copyIfNotNull(mergedAlbumInfo.refMusicBrainzReleaseGroupId(), importedAlbumInfo.getMusicBrainzReleaseGroupId());
+    copyIfNotNull(mergedAlbumInfo.refMusicBrainzReleaseId(), importedAlbumInfo.getMusicBrainzReleaseId());
+    copyIfNotNull(mergedAlbumInfo.refRecordLabel(), importedAlbumInfo.getRecordLabel());
 #endif // __EXTRA_METADATA__
 }
 

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -79,6 +79,17 @@ void copyIfNotNull(
     }
 }
 
+// This conditional copy operation only works for properties where
+// empty = missing.
+template<typename T>
+void copyIfNotEmpty(
+        T& mergedProperty,
+        const T& importedProperty) {
+    if (mergedProperty.isEmpty()) {
+        mergedProperty = importedProperty;
+    }
+}
+
 } // anonymous namespace
 
 void TrackRecord::mergeImportedMetadata(
@@ -111,6 +122,7 @@ void TrackRecord::mergeImportedMetadata(
     copyIfNotNull(mergedTrackInfo.refMusicBrainzReleaseId(), importedTrackInfo.getMusicBrainzReleaseId());
     copyIfNotNull(mergedTrackInfo.refMusicBrainzWorkId(), importedTrackInfo.getMusicBrainzWorkId());
     copyIfNotNull(mergedTrackInfo.refRemixer(), importedTrackInfo.getRemixer());
+    copyIfNotEmpty(mergedTrackInfo.refSeratoMarkers2(), importedTrackInfo.getSeratoMarkers2());
     copyIfNotNull(mergedTrackInfo.refSubtitle(), importedTrackInfo.getSubtitle());
     copyIfNotNull(mergedTrackInfo.refWork(), importedTrackInfo.getWork());
     AlbumInfo& mergedAlbumInfo = refMetadata().refAlbumInfo();

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -53,7 +53,7 @@ namespace {
 // yet. The added column "tracktotal" has been initialized with the
 // default value "//".
 // See also: Schema revision 26 in schema.xml
-const QString kReloadTrackTotal = "//";
+const QString kReloadTrackTotal = QStringLiteral("//");
 
 void mergeReplayGainMetadataProperty(
         ReplayGain& mergedReplayGain,

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -88,7 +88,7 @@ public:
             track::io::key::Source keySource);
 
     // Merge the current metadata from the file with the subset of metadata
-    // that is stored in the library. This is required to delete any tags
+    // that is stored in the library. This is required to NOT delete any tags
     // from the file that are not (yet) stored in the library database!
     void mergeImportedMetadata(
             const TrackMetadata& importedMetadata);

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -87,6 +87,12 @@ public:
             const QString& keyText,
             track::io::key::Source keySource);
 
+    // Merge the current metadata from the file with the subset of metadata
+    // that is stored in the library. This is required to delete any tags
+    // from the file that are not (yet) stored in the library database!
+    void mergeImportedMetadata(
+            const TrackMetadata& importedMetadata);
+
 private:
     Keys m_keys;
 };

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -49,6 +49,13 @@ class TrackRecord final {
     PROPERTY_SET_BYVAL_GET_BYREF(bool,        bpmLocked,      BpmLocked)
 
 public:
+    // Data migration: Reload track total from file tags if not initialized
+    // yet. The added column "tracktotal" has been initialized with the
+    // default value "//".
+    // See also: Schema revision 26 in schema.xml
+    // Public only for testing purposes!
+    static const QString kTrackTotalPlaceholder;
+
     explicit TrackRecord(TrackId id = TrackId());
     TrackRecord(TrackRecord&&) = default;
     TrackRecord(const TrackRecord&) = default;


### PR DESCRIPTION
This PR introduces a simpler, more robust, and extensible synchronization between track metadata that is stored in the database and file tags. We currently only store a subset of properties in the database.

I have used and tested this code for many weeks and didn't notice any issues or lost file tags. It is also needed for synchronization of tracks with external libraries like #2282 that store an extended set of metadata.

## Reorganization

- Remove special case handling of certain properties from *TagLib* code
- Remove special case handling of certain properties from `TrackInfo`/`AlbumInfo`/`TrackMetadata`
- Move tag migration code from `TrackDAO` into `TrackRecord`
- Move all code for merging imported file tags into `TrackRecord`

## Import

`SoundSourceProxy::updateTrackFromSource()`: Import and merge file tags when loading track objects on the fly. This will populate all missing fields that are not (yet) stored in the database.

## Export

`Track::exportMetadata()`: Import and merge file tags once again before exporting metadata into file tags. We have to reload the file tags anyway to check for differences as we already do now, because files should only be modified if differences are detected. Additional debug logs show both the existing and the modified metadata before writing file tags.