### PR TITLE
Travis CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ jobs:
 
     - name: OSX/clang/SCons build
       os: osx
+      osx_image: xcode11
       compiler: clang
       cache:
         directories:
@@ -107,6 +108,7 @@ jobs:
 
     - name: OSX/clang/CMake build
       os: osx
+      osx_image: xcode11
       compiler: clang
       cache:
         ccache: true


### PR DESCRIPTION
This pins Xcode 11.0 for the OSX builds. It still does not fix the linker errors that are caused by SCons not finding `osx64_build/lib/gtest-1.7.0`. I have no idea what caused that.