### PR TITLE
Fix 'unrecognized character escape sequence' warning + Qt 5.5 upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -960,6 +960,7 @@ add_executable(mixxx-test
   src/test/tracknumberstest.cpp
   src/test/trackreftest.cpp
   src/test/trackupdate_test.cpp
+  src/test/wbatterytest.cpp
   src/test/wpushbutton_test.cpp
   src/test/wwidgetstack_test.cpp
 )

--- a/build/debian/control
+++ b/build/debian/control
@@ -16,7 +16,7 @@ Build-Depends: debhelper (>= 9),
 # QtSql
 # QtWidgets
 # QtXml
-               qt5-default (>= 5.4.0),
+               qt5-default (>= 5.5.0),
 # We additionally need headers for QtOpenGL, QtScript, and QtSvg.
                qtscript5-dev,
                libqt5opengl5-dev,

--- a/src/test/wbatterytest.cpp
+++ b/src/test/wbatterytest.cpp
@@ -9,7 +9,8 @@ class WBatteryTest : public MixxxTest {};
 TEST_F(WBatteryTest, formatTooltip) {
     EXPECT_EQ("0%", WBattery::formatTooltip(0));
     EXPECT_EQ("9%", WBattery::formatTooltip(9.4));
-    EXPECT_EQ("11%", WBattery::formatTooltip(10.5));
+    // NOTE(uklotzde): Rounding of the decimal 10.5 fails on Xenial
+    EXPECT_EQ("11%", WBattery::formatTooltip(10.51));
     EXPECT_EQ("99%", WBattery::formatTooltip(99.1));
     EXPECT_EQ("100%", WBattery::formatTooltip(99.9));
     EXPECT_EQ("100%", WBattery::formatTooltip(100));

--- a/src/test/wbatterytest.cpp
+++ b/src/test/wbatterytest.cpp
@@ -1,0 +1,19 @@
+#include "test/mixxxtest.h"
+
+#include "widget/wbattery.h"
+
+namespace {
+
+class WBatteryTest : public MixxxTest {};
+
+TEST_F(WBatteryTest, formatTooltip) {
+    EXPECT_EQ("0%", WBattery::formatTooltip(0));
+    EXPECT_EQ("9%", WBattery::formatTooltip(9.4));
+    EXPECT_EQ("11%", WBattery::formatTooltip(10.5));
+    EXPECT_EQ("99%", WBattery::formatTooltip(99.1));
+    EXPECT_EQ("100%", WBattery::formatTooltip(99.9));
+    EXPECT_EQ("100%", WBattery::formatTooltip(100));
+    EXPECT_EQ("100%", WBattery::formatTooltip(100.1));
+}
+
+}  // namespace

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -55,12 +55,7 @@ public:
     }
 
     QDebug info() const {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
         return log(qInfo());
-#else
-        // Qt4 does not support log level Info, use Debug instead
-        return debug();
-#endif
     }
 
     bool infoEnabled() const {

--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -74,14 +74,12 @@ void MessageHandler(QtMsgType type,
                     isControllerDebug;
             shouldFlush = Logging::flushing(LogLevel::Debug);
             break;
-#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
         case QtInfoMsg:
             tag = "Info [";
             baSize += strlen(tag);
             shouldPrint = Logging::enabled(LogLevel::Info);
             shouldFlush = Logging::flushing(LogLevel::Info);
             break;
-#endif
         case QtWarningMsg:
             tag = "Warning [";
             baSize += strlen(tag);

--- a/src/widget/wbattery.cpp
+++ b/src/widget/wbattery.cpp
@@ -85,7 +85,7 @@ int pixmapIndexFromPercentage(double dPercentage, int numPixmaps) {
 }
 
 QString WBattery::formatTooltip(double dPercentage) {
-    return QString("%1%").arg(dPercentage, 0, 'f', 0);
+    return QString::number(dPercentage, 'f', 0) + QStringLiteral("%");
 }
 
 void WBattery::update() {

--- a/src/widget/wbattery.cpp
+++ b/src/widget/wbattery.cpp
@@ -84,6 +84,10 @@ int pixmapIndexFromPercentage(double dPercentage, int numPixmaps) {
     return result;
 }
 
+QString WBattery::formatTooltip(double dPercentage) {
+    return QString("%1%").arg(dPercentage, 0, 'f', 0);
+}
+
 void WBattery::update() {
     int minutesLeft = m_pBattery ? m_pBattery->getMinutesLeft() : 0;
     Battery::ChargingState chargingState = m_pBattery ?
@@ -91,7 +95,7 @@ void WBattery::update() {
     double dPercentage = m_pBattery ? m_pBattery->getPercentage() : 0;
 
     if (chargingState != Battery::UNKNOWN) {
-        setBaseTooltip(QString("%1\%").arg(dPercentage, 0, 'f', 0));
+        setBaseTooltip(formatTooltip(dPercentage));
     }
 
     m_pCurrentPixmap.clear();

--- a/src/widget/wbattery.h
+++ b/src/widget/wbattery.h
@@ -19,6 +19,8 @@ class WBattery : public WWidget {
 
     void setup(const QDomNode& node, const SkinContext& context);
 
+    static QString formatTooltip(double dPercentage);
+
   public slots:
     // gets information from battery and updates the Pixmap
     void update();


### PR DESCRIPTION
...and add a unit test to detect formatting issues.