### PR TITLE
CMake: Set cmake_minimum_required version to 3.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,9 @@ jobs:
       # Ubuntu Xenial build prerequisites
       env: CMAKEFLAGS_EXTRA="-DLOCALECOMPARE=ON"
       before_install:
-        - sudo apt-get install -y cmake
         - export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
+        - export PATH="$HOME/.local/bin:$PATH"
+        - pip install --user cmake
         - cmake --version
         - ccache -s
       install:
@@ -64,7 +65,7 @@ jobs:
         - cd cmake_build
         - cmake -L $CMAKEFLAGS $CMAKEFLAGS_EXTRA ..
         - cmake --build .
-        - sudo cmake --build . --target install
+        - sudo env "PATH=$PATH" cmake --build . --target install
       script:
         # Run tests and benchmarks
         - cmake --build . --target test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.13.0)
 project(mixxx VERSION 2.3.0)
 set(CMAKE_PROJECT_HOMEPAGE_URL "https://www.mixxx.org")
 set(CMAKE_PROJECT_DESCRIPTION "Mixxx is Free DJ software that gives you everything you need to perform live mixes.")


### PR DESCRIPTION
We're currently using the target_link_options() command which has been
introduced in CMake 3.13:
https://cmake.org/cmake/help/v3.13/release/3.13.html?highlight=target_link_options#commands