### PR TITLE
Changes to make appveyor script usable for developers.

### DIFF
--- a/build/appveyor/build_mixxx.bat
+++ b/build/appveyor/build_mixxx.bat
@@ -120,8 +120,6 @@ call "%BUILDTOOLS_PATH%\%BUILDTOOLS_SCRIPT%" %COMPILER_X64% -vcvars_ver=%PARAM_V
 set MACHINE_TYPE=x86_64
 )
 
-REM Now build Mixxx.
-
 if %CONFIG_RELEASE% (
 set BUILD_TYPE=release
 ) else (
@@ -134,6 +132,7 @@ rem /EHsc Do not handle SEH in try / except blocks.
 set CXXFLAGS=/MP /FS /EHsc
 set CFLAGS=/MP /FS /EHsc
 
+REM Now build Mixxx.
 set PATH=%BIN_DIR%;%PATH%
 scons.py %SCONS_NUMBER_PROCESSORS% mixxx %PARAM_INSTALLER% toolchain=msvs winlib=%WINLIB_DIR% build=%BUILD_TYPE% staticlibs=1 staticqt=1 debug_assertions_fatal=1 verbose=0 machine=%MACHINE_TYPE% qtdir=%QTDIR% hss1394=1 mediafoundation=1 opus=1 localecompare=1 optimize=%PARAM_OPTIMIZE% virtualize=0 test=%PARAM_TEST% qt_sqlite_plugin=0 build_number_in_title_bar=0 bundle_pdbs=0
 
@@ -174,7 +173,6 @@ FOR %%Y IN (2019,2017) DO (
 )
 REM FOR
 EXIT /B 1
-
 
 :function_has_64bit
 FOR /F %%G IN ('dir "%BUILDTOOLS_PATH%\Tools\MSVC\%PARAM_VCVARSVER%*" /b /ad-h /o-n') DO (

--- a/build/appveyor/build_mixxx.bat
+++ b/build/appveyor/build_mixxx.bat
@@ -1,5 +1,5 @@
-@echo on
-SETLOCAL
+@echo off
+SETLOCAL ENABLEDELAYEDEXPANSION
 
 REM ==================================
 REM Path setup and  initial checks
@@ -14,38 +14,36 @@ SET "PROGRAMFILES_PATH=%ProgramFiles(x86)%"
 
 rem ====== Edit to suit your environment =========
 SET VCVERSION=141
-SET "MSVC_PATH=%PROGRAMFILES_PATH%\Microsoft Visual Studio\2017\Community\VC"
+SET PARAM_VCVARSVER=14.1
 SET "BUILDTOOLS_PATH=%PROGRAMFILES_PATH%\Microsoft Visual Studio\2017\BuildTools\VC"
 SET BUILDTOOLS_SCRIPT=Auxiliary\Build\vcvarsall.bat
 
-IF EXIST "%MSVC_PATH%" (
-echo Building with Microsoft Visual Studio 2017 Community Edition.
-SET "BUILDTOOLS_PATH=%MSVC_PATH%"
-) ELSE (
 IF EXIST "%BUILDTOOLS_PATH%" (
-echo Building with Microsoft Visual Studio 2017 Build Tools.
+echo Building with preconfigured path at: "%BUILDTOOLS_PATH%"
 ) ELSE (
+call :function_get_product
+IF ERRORLEVEL 1 (
 echo.
-echo Could not find "%MSVC_PATH%" nor "%BUILDTOOLS_PATH%".
-echo Edit the build_environment.bat file and/or install the required software
+echo Could not find "%BUILDTOOLS_PATH%" and the detection of product didn't work
+echo Edit the %~nx0 file and/or install the required software
 echo http://landinghub.visualstudio.com/visual-cpp-build-tools
 echo https://www.microsoft.com/en-us/download/details.aspx?id=8279
 exit /b 1
 )
-REM END EXIST BUILDTOOLS
+REM END NO PRODUCT
 )
-REM END EXIST MSVC_PATH
+REM END EXIST BUILDTOOLS_PATH
 
 REM Check whether we have a 64-bit compiler available.
-REM TODO(rryan): Remove hard-coding of compiler version in this path?
-IF EXIST "%BUILDTOOLS_PATH%\Tools\MSVC\14.15.26726\bin\Hostx64\x64\cl.exe" (
-echo Using 64-bit compiler.
-SET COMPILER_X86=amd64_x86
-SET COMPILER_X64=amd64
-) ELSE (
+call :function_has_64bit
+IF ERRORLEVEL 1 (
 echo Using 32-bit compiler.
 SET COMPILER_X86=x86
 SET COMPILER_X64=x86_amd64
+) ELSE (
+echo Using 64-bit compiler.
+SET COMPILER_X86=amd64_x86
+SET COMPILER_X64=amd64
 )
 
 REM ==================================
@@ -55,23 +53,42 @@ REM ^ is the escape character.
 if "%3" == "" (
   echo Missing parameters. Usage: ^(Note: keep same case and order^)
   echo.
-  echo build_mixxx.bat x64^|x86 debug^|release^|release-fastbuild ^<winlib-path^>
+  echo build_mixxx.bat x64^|x86 debug^|release^|release-fastbuild ^<winlib-path^> [skiptest] [skipinstaller]
   echo.
-  echo Example: build_mixxx.bat x64 release c:\mixxx\environments\msvc15-static-x86-release
+  echo skiptest means that we don't want to build and execute the mixxx-test.
+  echo skipinstaller means that we don't want to generate the installer after the build.
+  echo.
+  echo Example: build_mixxx.bat x64 release c:\mixxx\environments\2.3-j00013-x64-release-static-36f44bd2-minimal
   exit /b 1
 )
 
 set MACHINE_X86="%1" == "x86"
 if "%2" == "release" (
   set CONFIG_RELEASE=1==1
+  set PARAM_OPTIMIZE=portable
 )
 if "%2" == "release-fastbuild" (
   set CONFIG_RELEASE=1==1
+  set PARAM_OPTIMIZE=fastbuild
 )
 if "%2" == "debug" (
   set CONFIG_RELEASE=0==1
+  set PARAM_OPTIMIZE=portable
 )
-
+if "%4" == "skiptest" (
+  set PARAM_TEST=0
+) else (
+  set PARAM_TEST=1
+)
+if "%4" == "skipinstaller" (
+   set PARAM_INSTALLER=
+) else (
+    if "%5" == "skipinstaller" (
+       set PARAM_INSTALLER=
+    ) else (
+       set PARAM_INSTALLER=makerelease 
+    )
+)
 set WINLIB_DIR=%3
 
 SET BIN_DIR=%WINLIB_DIR%\bin
@@ -96,9 +113,11 @@ exit /b 1
 
 REM Everything prepared. Setup the compiler.
 if %MACHINE_X86% (
-call "%BUILDTOOLS_PATH%\%BUILDTOOLS_SCRIPT%" %COMPILER_X86%
+call "%BUILDTOOLS_PATH%\%BUILDTOOLS_SCRIPT%" %COMPILER_X86% -vcvars_ver=%PARAM_VCVARSVER%
+set MACHINE_TYPE=x86
 ) else (
-call "%BUILDTOOLS_PATH%\%BUILDTOOLS_SCRIPT%" %COMPILER_X64%
+call "%BUILDTOOLS_PATH%\%BUILDTOOLS_SCRIPT%" %COMPILER_X64% -vcvars_ver=%PARAM_VCVARSVER%
+set MACHINE_TYPE=x86_64
 )
 
 REM Now build Mixxx.
@@ -109,18 +128,6 @@ set BUILD_TYPE=release
 set BUILD_TYPE=debug
 )
 
-if %MACHINE_X86% (
-set MACHINE_TYPE=x86
-set DISTDIR=dist32
-) else (
-set MACHINE_TYPE=x86_64
-set DISTDIR=dist64
-)
-
-REM Clean up after old builds.
-REM del /q /f *.exe *.msi 2>NUL
-REM rmdir /s /q %DISTDIR%
-
 rem /MP Use all CPU cores.
 rem /FS force synchronous PDB writes (prevents PDB corruption with /MP)
 rem /EHsc Do not handle SEH in try / except blocks.
@@ -128,7 +135,7 @@ set CXXFLAGS=/MP /FS /EHsc
 set CFLAGS=/MP /FS /EHsc
 
 set PATH=%BIN_DIR%;%PATH%
-scons.py mixxx makerelease toolchain=msvs winlib=%WINLIB_DIR% build=%BUILD_TYPE% staticlibs=1 staticqt=1 debug_assertions_fatal=1 verbose=0 machine=%MACHINE_TYPE% qtdir=%QTDIR% hss1394=1 mediafoundation=1 opus=1 localecompare=1 optimize=fastbuild virtualize=0 test=1 qt_sqlite_plugin=0 build_number_in_title_bar=0 bundle_pdbs=0
+scons.py %SCONS_NUMBER_PROCESSORS% mixxx %PARAM_INSTALLER% toolchain=msvs winlib=%WINLIB_DIR% build=%BUILD_TYPE% staticlibs=1 staticqt=1 debug_assertions_fatal=1 verbose=0 machine=%MACHINE_TYPE% qtdir=%QTDIR% hss1394=1 mediafoundation=1 opus=1 localecompare=1 optimize=%PARAM_OPTIMIZE% virtualize=0 test=%PARAM_TEST% qt_sqlite_plugin=0 build_number_in_title_bar=0 bundle_pdbs=0
 
 IF ERRORLEVEL 1 (
 echo ==============================
@@ -144,3 +151,36 @@ exit /b 1
 echo Mixxx built successfully
 ENDLOCAL
 )
+EXIT 0
+
+:function_get_product
+FOR %%Y IN (2019,2017) DO (
+  FOR %%P IN (Community,Professional,Enterprise) DO (
+    SET "LOCAL_VS_PATH=%PROGRAMFILES_PATH%\Microsoft Visual Studio\%%Y\%%P\VC"
+    IF EXIST "!LOCAL_VS_PATH!" (
+      SET "BUILDTOOLS_PATH=!LOCAL_VS_PATH!"
+      ECHO Using Visual Studio %%Y %%P at: !LOCAL_VS_PATH!
+      EXIT /B 0
+    )
+  )
+  REM FOR
+  SET "LOCAL_BT_PATH=%PROGRAMFILES_PATH%\Microsoft Visual Studio\%%Y\BuildTools\VC"
+  IF EXIST "!LOCAL_BT_PATH!" (
+    SET "BUILDTOOLS_PATH=!LOCAL_BT_PATH!"
+    ECHO Using BuildTools %%Y at: !LOCAL_BT_PATH!
+    EXIT /B 0
+  )
+  REM BT
+)
+REM FOR
+EXIT /B 1
+
+
+:function_has_64bit
+FOR /F %%G IN ('dir "%BUILDTOOLS_PATH%\Tools\MSVC\%PARAM_VCVARSVER%*" /b /ad-h /o-n') DO (
+  set "LOCAL_64_CL=%BUILDTOOLS_PATH%\Tools\MSVC\%%G\bin\Hostx64\x64\cl.exe"
+  if EXIST "!LOCAL_64_CL!" (
+    EXIT /B 0
+  ) 
+)
+EXIT /B 1

--- a/build/appveyor/build_mixxx.bat
+++ b/build/appveyor/build_mixxx.bat
@@ -151,7 +151,7 @@ exit /b 1
 echo Mixxx built successfully
 ENDLOCAL
 )
-EXIT 0
+EXIT /b 0
 
 :function_get_product
 FOR %%Y IN (2019,2017) DO (

--- a/build/windows/install_buildenv.bat
+++ b/build/windows/install_buildenv.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-SETLOCAL
+SETLOCAL enableDelayedExpansion
 
 REM Base URL to download winlibs from.
 SET BASEURL=%1
@@ -22,7 +22,7 @@ IF NOT EXIST "%WINLIBS_PATH%\%WINLIB_NAME%" (
       where /q powershell
       if ERRORLEVEL 1 (
          echo Could not find 7z or 7za on the path, and powershell is not available. 
-         echo Either install http://7-zip.org
+         echo Either install http://7-zip.org and retry
          echo or download %BASEURL%/%WINLIB_NAME%.zip
          echo yourself and unzip it at %WINLIBS_PATH%
          ENDLOCAL && EXIT /b 1
@@ -39,15 +39,20 @@ IF NOT EXIST "%WINLIBS_PATH%\%WINLIB_NAME%" (
   echo Installing winlib %WINLIB_NAME%.
   CD "%WINLIBS_PATH%"
   echo ..Downloading %WINLIB_NAME%.zip
+  where /q curl
+  IF ERRORLEVEL 1 (
+    echo curl not found. Please download %WINLIB_NAME%.zip from %BASEURL%/ and unzip it yourself at %WINLIBS_PATH%
+    ENDLOCAL && EXIT /b 1
+  )
   curl -fsS -L -o %WINLIB_NAME%.zip %BASEURL%/%WINLIB_NAME%.zip
   IF ERRORLEVEL 1 ENDLOCAL && EXIT /b 1
   REM TODO(XXX) check fingerprint on zip file.
   echo ..unzipping %WINLIB_NAME%.zip
-  IF "%POWERSHELL%" == "powershell" (
+  IF "!POWERSHELL!" == "powershell" (
     powershell -Command "& {Expand-Archive \"%WINLIBS_PATH%/%WINLIB_NAME%.zip\" \"%WINLIBS_PATH%\\\"}"
     IF ERRORLEVEL 1 ENDLOCAL && EXIT /b 1
   ) ELSE (
-    %ZIP% x %WINLIB_NAME%.zip
+    !ZIP! x %WINLIB_NAME%.zip
     IF ERRORLEVEL 1 ENDLOCAL && EXIT /b 1
   )
   DEL %WINLIB_NAME%.zip

--- a/build/windows/install_buildenv.bat
+++ b/build/windows/install_buildenv.bat
@@ -10,55 +10,83 @@ SET WINLIB_NAME=%2
 REM The local directory to cache build environments in.
 SET WINLIBS_PATH=%3
 
-IF NOT EXIST "%WINLIBS_PATH%\%WINLIB_NAME%" (
-
-  REM Install build env base dir
-  IF NOT EXIST "%WINLIBS_PATH%" MKDIR "%WINLIBS_PATH%"
-
-  where /q 7za
-  IF ERRORLEVEL 1 (
-    where /q 7z
-    if ERRORLEVEL 1 (
-      where /q powershell
-      if ERRORLEVEL 1 (
-         echo Could not find 7z or 7za on the path, and powershell is not available. 
-         echo Either install http://7-zip.org and retry
-         echo or download %BASEURL%/%WINLIB_NAME%.zip
-         echo yourself and unzip it at %WINLIBS_PATH%
-         ENDLOCAL && EXIT /b 1
-      ) else (
-        set POWERSHELL=powershell
-      )
-    ) else (
-      set ZIP=7z
-    )
-  ) else (
-    set ZIP=7za
-  )
-
-  echo Installing winlib %WINLIB_NAME%.
-  CD "%WINLIBS_PATH%"
-  echo ..Downloading %WINLIB_NAME%.zip
-  where /q curl
-  IF ERRORLEVEL 1 (
-    echo curl not found. Please download %WINLIB_NAME%.zip from %BASEURL%/ and unzip it yourself at %WINLIBS_PATH%
-    ENDLOCAL && EXIT /b 1
-  )
-  curl -fsS -L -o %WINLIB_NAME%.zip %BASEURL%/%WINLIB_NAME%.zip
-  IF ERRORLEVEL 1 ENDLOCAL && EXIT /b 1
-  REM TODO(XXX) check fingerprint on zip file.
-  echo ..unzipping %WINLIB_NAME%.zip
-  IF "!POWERSHELL!" == "powershell" (
-    powershell -Command "& {Expand-Archive \"%WINLIBS_PATH%/%WINLIB_NAME%.zip\" \"%WINLIBS_PATH%\\\"}"
-    IF ERRORLEVEL 1 ENDLOCAL && EXIT /b 1
-  ) ELSE (
-    !ZIP! x %WINLIB_NAME%.zip
-    IF ERRORLEVEL 1 ENDLOCAL && EXIT /b 1
-  )
-  DEL %WINLIB_NAME%.zip
-) else (
+IF EXIST "%WINLIBS_PATH%\%WINLIB_NAME%" (
   echo %WINLIB_NAME% already exists at %WINLIBS_PATH%
   REM TODO(XXX) check fingerprint on build environment?
+  ENDLOCAL && EXIT /B 0
 )
 
+
+REM Install build env base dir
+IF NOT EXIST "%WINLIBS_PATH%" MKDIR "%WINLIBS_PATH%"
+
+where /q 7za
+IF ERRORLEVEL 1 (
+  where /q 7z
+  IF ERRORLEVEL 1 (
+    REM In case it is not present in PATH
+    IF EXIST "%PROGRAMFILES%\7-zip\7z.exe" (
+      set "ZIP=%PROGRAMFILES%\7-zip\7z.exe"
+    ) else (
+      call :get_powershell_version
+      IF !POWERSHELL! LSS 5 (
+        echo Could not find 7z or 7za on the path, and cannot use powershell ^(version !POWERSHELL!^)
+        echo Either install http://7-zip.org ^(and add it to the PATH^) and retry
+        echo or download %BASEURL%/%WINLIB_NAME%.zip
+        echo yourself and unzip it at %WINLIBS_PATH%
+        ENDLOCAL && EXIT /b 1
+      )
+    )
+  ) else (
+    set ZIP=7z
+  )
+) else (
+  set ZIP=7za
+)
+
+echo Installing winlib %WINLIB_NAME%.
+CD "%WINLIBS_PATH%"
+echo ..Downloading %WINLIB_NAME%.zip
+where /q curl
+IF ERRORLEVEL 1 (
+  call :get_powershell_version
+  IF !POWERSHELL! LSS 3 (
+    echo curl not found and cannot use powershell ^(version !POWERSHELL!^)
+    echo Please download %WINLIB_NAME%.zip 
+    echo from %BASEURL%/ 
+    echo and unzip it yourself at %WINLIBS_PATH%
+    ENDLOCAL && EXIT /b 1
+  ) else (
+    powershell -Command "& {Invoke-WebRequest -Uri %BASEURL%/%WINLIB_NAME%.zip -OutFile \"%WINLIBS_PATH%/%WINLIB_NAME%.zip\"}"
+    IF ERRORLEVEL 1 ENDLOCAL && EXIT /b 1
+  )
+) else (
+  curl -fsS -L -o %WINLIB_NAME%.zip %BASEURL%/%WINLIB_NAME%.zip
+  IF ERRORLEVEL 1 ENDLOCAL && EXIT /b 1
+)
+REM TODO(XXX) check fingerprint on zip file.
+
+
+echo ..unzipping %WINLIB_NAME%.zip
+IF "!ZIP!" NEQ "" (
+  "!ZIP!" x %WINLIB_NAME%.zip
+  IF ERRORLEVEL 1 ENDLOCAL && EXIT /b 1
+) ELSE (
+  powershell -Command "& {Expand-Archive \"%WINLIBS_PATH%/%WINLIB_NAME%.zip\" \"%WINLIBS_PATH%\\\"}"
+  IF ERRORLEVEL 1 ENDLOCAL && EXIT /b 1
+)
+DEL %WINLIB_NAME%.zip
+
 ENDLOCAL
+EXIT /B 0
+
+
+:get_powershell_version
+  where /q powershell
+  if ERRORLEVEL 1 (
+    set POWERSHELL=0
+  ) else (
+    REM DETECT powershell major version
+    FOR /F "tokens=* USEBACKQ" %%F IN (`powershell -Command "& {$PSVersionTable.PSVersion.Major}"`) DO ( set POWERSHELL=%%F )
+  )
+EXIT /B 1

--- a/build/windows/install_buildenv.bat
+++ b/build/windows/install_buildenv.bat
@@ -10,30 +10,46 @@ SET WINLIB_NAME=%2
 REM The local directory to cache build environments in.
 SET WINLIBS_PATH=%3
 
-REM Install build env base dir
-IF NOT EXIST "%WINLIBS_PATH%" MKDIR "%WINLIBS_PATH%"
-
-where /q 7za
-IF ERRORLEVEL 1 (
-  where /q 7z
-  if ERRORLEVEL 1 (
-    echo Could not find 7z or 7za on the path.
-    exit /b
-  ) else (
-    set ZIP=7z
-  )
-) else (
-  set ZIP=7za
-)
-
 IF NOT EXIST "%WINLIBS_PATH%\%WINLIB_NAME%" (
+
+  REM Install build env base dir
+  IF NOT EXIST "%WINLIBS_PATH%" MKDIR "%WINLIBS_PATH%"
+
+  where /q 7za
+  IF ERRORLEVEL 1 (
+    where /q 7z
+    if ERRORLEVEL 1 (
+      where /q powershell
+      if ERRORLEVEL 1 (
+         echo Could not find 7z or 7za on the path, and powershell is not available. 
+         echo Either install http://7-zip.org
+         echo or download %BASEURL%/%WINLIB_NAME%.zip
+         echo yourself and unzip it at %WINLIBS_PATH%
+         ENDLOCAL && EXIT /b 1
+      ) else (
+        set POWERSHELL=powershell
+      )
+    ) else (
+      set ZIP=7z
+    )
+  ) else (
+    set ZIP=7za
+  )
+
   echo Installing winlib %WINLIB_NAME%.
   CD "%WINLIBS_PATH%"
   echo ..Downloading %WINLIB_NAME%.zip
   curl -fsS -L -o %WINLIB_NAME%.zip %BASEURL%/%WINLIB_NAME%.zip
+  IF ERRORLEVEL 1 ENDLOCAL && EXIT /b 1
   REM TODO(XXX) check fingerprint on zip file.
   echo ..unzipping %WINLIB_NAME%.zip
-  %ZIP% x %WINLIB_NAME%.zip
+  IF "%POWERSHELL%" == "powershell" (
+    powershell -Command "& {Expand-Archive \"%WINLIBS_PATH%/%WINLIB_NAME%.zip\" \"%WINLIBS_PATH%\\\"}"
+    IF ERRORLEVEL 1 ENDLOCAL && EXIT /b 1
+  ) ELSE (
+    %ZIP% x %WINLIB_NAME%.zip
+    IF ERRORLEVEL 1 ENDLOCAL && EXIT /b 1
+  )
   DEL %WINLIB_NAME%.zip
 ) else (
   echo %WINLIB_NAME% already exists at %WINLIBS_PATH%

--- a/build/windows/install_buildenv.bat
+++ b/build/windows/install_buildenv.bat
@@ -16,7 +16,6 @@ IF EXIST "%WINLIBS_PATH%\%WINLIB_NAME%" (
   ENDLOCAL && EXIT /B 0
 )
 
-
 REM Install build env base dir
 IF NOT EXIST "%WINLIBS_PATH%" MKDIR "%WINLIBS_PATH%"
 
@@ -66,7 +65,6 @@ IF ERRORLEVEL 1 (
 )
 REM TODO(XXX) check fingerprint on zip file.
 
-
 echo ..unzipping %WINLIB_NAME%.zip
 IF "!ZIP!" NEQ "" (
   "!ZIP!" x %WINLIB_NAME%.zip
@@ -79,7 +77,6 @@ DEL %WINLIB_NAME%.zip
 
 ENDLOCAL
 EXIT /B 0
-
 
 :get_powershell_version
   where /q powershell


### PR DESCRIPTION
- Autodetect Visual Studio version, edition or buildtools. Default to predefined buildtools as before, prefer 2017 to 2019 and Enterprise to Professional to Community. Explicit parameter to make VC 2019 to use VC 2017 (14.1) compiler.
- Autodetect path of 64bit binaries so no hardcoded path anymore.
- Two new parameters to skip build and run tests and skip installer generation.
- Install_buildenv first checks if path exists before checking if platform has 7zip.
- Added alternative using powershell if 7zip not found.
This is all complemented with a simple build.cmd that calls these two scripts which will be placed on the wiki.