### PR TITLE
Change quantization of intro/outro cues

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -466,9 +466,9 @@ void CueControl::loadCuesFromTrack() {
         double startPosition = pIntroCue->getPosition();
         double endPosition = pIntroCue->getEndPosition();
 
-        m_pIntroStartPosition->set(quantizeCuePoint(startPosition, QuantizeMode::PreviousBeat));
+        m_pIntroStartPosition->set(quantizeCuePoint(startPosition, QuantizeMode::ClosestBeat));
         m_pIntroStartEnabled->forceSet(startPosition == Cue::kNoPosition ? 0.0 : 1.0);
-        m_pIntroEndPosition->set(quantizeCuePoint(endPosition, QuantizeMode::NextBeat));
+        m_pIntroEndPosition->set(quantizeCuePoint(endPosition, QuantizeMode::ClosestBeat));
         m_pIntroEndEnabled->forceSet(endPosition == Cue::kNoPosition ? 0.0 : 1.0);
     } else {
         m_pIntroStartPosition->set(Cue::kNoPosition);
@@ -481,9 +481,9 @@ void CueControl::loadCuesFromTrack() {
         double startPosition = pOutroCue->getPosition();
         double endPosition = pOutroCue->getEndPosition();
 
-        m_pOutroStartPosition->set(quantizeCuePoint(startPosition, QuantizeMode::PreviousBeat));
+        m_pOutroStartPosition->set(quantizeCuePoint(startPosition, QuantizeMode::ClosestBeat));
         m_pOutroStartEnabled->forceSet(startPosition == Cue::kNoPosition ? 0.0 : 1.0);
-        m_pOutroEndPosition->set(quantizeCuePoint(endPosition, QuantizeMode::NextBeat));
+        m_pOutroEndPosition->set(quantizeCuePoint(endPosition, QuantizeMode::ClosestBeat));
         m_pOutroEndEnabled->forceSet(endPosition == Cue::kNoPosition ? 0.0 : 1.0);
     } else {
         m_pOutroStartPosition->set(Cue::kNoPosition);
@@ -1116,9 +1116,7 @@ void CueControl::introStartSet(double v) {
 
     QMutexLocker lock(&m_mutex);
 
-    // Quantize cue point to nearest beat before current position.
-    // Fall back to nearest beat after or current position.
-    double position = quantizeCurrentPosition(QuantizeMode::PreviousBeat);
+    double position = quantizeCurrentPosition(QuantizeMode::ClosestBeat);
 
     // Make sure user is not trying to place intro start cue on or after
     // other intro/outro cues.
@@ -1194,9 +1192,7 @@ void CueControl::introEndSet(double v) {
 
     QMutexLocker lock(&m_mutex);
 
-    // Quantize cue point to nearest beat after current position.
-    // Fall back to nearest beat before or current position.
-    double position = quantizeCurrentPosition(QuantizeMode::NextBeat);
+    double position = quantizeCurrentPosition(QuantizeMode::ClosestBeat);
 
     // Make sure user is not trying to place intro end cue on or before
     // intro start cue, or on or after outro start/end cue.
@@ -1272,9 +1268,7 @@ void CueControl::outroStartSet(double v) {
 
     QMutexLocker lock(&m_mutex);
 
-    // Quantize cue point to nearest beat before current position.
-    // Fall back to nearest beat after or current position.
-    double position = quantizeCurrentPosition(QuantizeMode::PreviousBeat);
+    double position = quantizeCurrentPosition(QuantizeMode::ClosestBeat);
 
     // Make sure user is not trying to place outro start cue on or before
     // intro end cue or on or after outro end cue.
@@ -1350,9 +1344,7 @@ void CueControl::outroEndSet(double v) {
 
     QMutexLocker lock(&m_mutex);
 
-    // Quantize cue point to nearest beat after current position.
-    // Fall back to nearest beat before or current position.
-    double position = quantizeCurrentPosition(QuantizeMode::NextBeat);
+    double position = quantizeCurrentPosition(QuantizeMode::ClosestBeat);
 
     // Make sure user is not trying to place outro end cue on or before
     // other intro/outro cues.

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -46,8 +46,6 @@ CueControl::CueControl(QString group,
             this, &CueControl::quantizeChanged,
             Qt::DirectConnection);
 
-    m_pPrevBeat = ControlObject::getControl(ConfigKey(group, "beat_prev"));
-    m_pNextBeat = ControlObject::getControl(ConfigKey(group, "beat_next"));
     m_pClosestBeat = ControlObject::getControl(ConfigKey(group, "beat_closest"));
 
     m_pCuePoint = new ControlObject(ConfigKey(group, "cue_point"));
@@ -466,9 +464,9 @@ void CueControl::loadCuesFromTrack() {
         double startPosition = pIntroCue->getPosition();
         double endPosition = pIntroCue->getEndPosition();
 
-        m_pIntroStartPosition->set(quantizeCuePoint(startPosition, QuantizeMode::ClosestBeat));
+        m_pIntroStartPosition->set(quantizeCuePoint(startPosition));
         m_pIntroStartEnabled->forceSet(startPosition == Cue::kNoPosition ? 0.0 : 1.0);
-        m_pIntroEndPosition->set(quantizeCuePoint(endPosition, QuantizeMode::ClosestBeat));
+        m_pIntroEndPosition->set(quantizeCuePoint(endPosition));
         m_pIntroEndEnabled->forceSet(endPosition == Cue::kNoPosition ? 0.0 : 1.0);
     } else {
         m_pIntroStartPosition->set(Cue::kNoPosition);
@@ -481,9 +479,9 @@ void CueControl::loadCuesFromTrack() {
         double startPosition = pOutroCue->getPosition();
         double endPosition = pOutroCue->getEndPosition();
 
-        m_pOutroStartPosition->set(quantizeCuePoint(startPosition, QuantizeMode::ClosestBeat));
+        m_pOutroStartPosition->set(quantizeCuePoint(startPosition));
         m_pOutroStartEnabled->forceSet(startPosition == Cue::kNoPosition ? 0.0 : 1.0);
-        m_pOutroEndPosition->set(quantizeCuePoint(endPosition, QuantizeMode::ClosestBeat));
+        m_pOutroEndPosition->set(quantizeCuePoint(endPosition));
         m_pOutroEndEnabled->forceSet(endPosition == Cue::kNoPosition ? 0.0 : 1.0);
     } else {
         m_pOutroStartPosition->set(Cue::kNoPosition);
@@ -494,7 +492,7 @@ void CueControl::loadCuesFromTrack() {
 
     if (pLoadCue) {
         double position = pLoadCue->getPosition();
-        m_pCuePoint->set(quantizeCuePoint(position, QuantizeMode::ClosestBeat));
+        m_pCuePoint->set(quantizeCuePoint(position));
     } else {
         m_pCuePoint->set(Cue::kNoPosition);
     }
@@ -570,10 +568,7 @@ void CueControl::hotcueSet(HotcueControl* pControl, double v) {
     hotcueClear(pControl, v);
 
     CuePointer pCue(m_pLoadedTrack->createAndAddCue());
-    double closestBeat = m_pClosestBeat->get();
-    double cuePosition =
-            (m_pQuantizeEnabled->toBool() && closestBeat != -1) ?
-                    closestBeat : getSampleOfTrack().current;
+    double cuePosition = getQuantizedCurrentPosition();
     pCue->setStartPosition(cuePosition);
     pCue->setHotCue(hotcue);
     pCue->setLabel("");
@@ -821,9 +816,8 @@ void CueControl::cueSet(double v) {
         return;
 
     QMutexLocker lock(&m_mutex);
-    double closestBeat = m_pClosestBeat->get();
-    double cue = (m_pQuantizeEnabled->toBool() && closestBeat != -1) ?
-            closestBeat : getSampleOfTrack().current;
+
+    double cue = getQuantizedCurrentPosition();
     m_pCuePoint->set(cue);
     TrackPointer pLoadedTrack = m_pLoadedTrack;
     lock.unlock();
@@ -1116,7 +1110,7 @@ void CueControl::introStartSet(double v) {
 
     QMutexLocker lock(&m_mutex);
 
-    double position = quantizeCurrentPosition(QuantizeMode::ClosestBeat);
+    double position = getQuantizedCurrentPosition();
 
     // Make sure user is not trying to place intro start cue on or after
     // other intro/outro cues.
@@ -1192,7 +1186,7 @@ void CueControl::introEndSet(double v) {
 
     QMutexLocker lock(&m_mutex);
 
-    double position = quantizeCurrentPosition(QuantizeMode::ClosestBeat);
+    double position = getQuantizedCurrentPosition();
 
     // Make sure user is not trying to place intro end cue on or before
     // intro start cue, or on or after outro start/end cue.
@@ -1268,7 +1262,7 @@ void CueControl::outroStartSet(double v) {
 
     QMutexLocker lock(&m_mutex);
 
-    double position = quantizeCurrentPosition(QuantizeMode::ClosestBeat);
+    double position = getQuantizedCurrentPosition();
 
     // Make sure user is not trying to place outro start cue on or before
     // intro end cue or on or after outro end cue.
@@ -1344,7 +1338,7 @@ void CueControl::outroEndSet(double v) {
 
     QMutexLocker lock(&m_mutex);
 
-    double position = quantizeCurrentPosition(QuantizeMode::ClosestBeat);
+    double position = getQuantizedCurrentPosition();
 
     // Make sure user is not trying to place outro end cue on or before
     // other intro/outro cues.
@@ -1575,7 +1569,7 @@ CueControl::TrackAt CueControl::getTrackAt() const {
     return TrackAt::ElseWhere;
 }
 
-double CueControl::quantizeCurrentPosition(QuantizeMode mode) {
+double CueControl::getQuantizedCurrentPosition() {
     SampleOfTrack sampleOfTrack = getSampleOfTrack();
     const double currentPos = sampleOfTrack.current;
     const double total = sampleOfTrack.total;
@@ -1585,46 +1579,15 @@ double CueControl::quantizeCurrentPosition(QuantizeMode mode) {
         return currentPos;
     }
 
-    if (mode == QuantizeMode::ClosestBeat) {
-        double closestBeat = m_pClosestBeat->get();
-        if (closestBeat != -1.0 && closestBeat <= total) {
-            return closestBeat;
-        }
-        return currentPos;
+    double closestBeat = m_pClosestBeat->get();
+    if (closestBeat != -1.0 && closestBeat <= total) {
+        return closestBeat;
     }
 
-    double prevBeat = m_pPrevBeat->get();
-    double nextBeat = m_pNextBeat->get();
-
-    if (mode == QuantizeMode::PreviousBeat) {
-        // Quantize to previous beat, fall back to next beat.
-        if (prevBeat != -1.0) {
-            return prevBeat;
-        }
-        if (nextBeat != -1.0 && nextBeat <= total) {
-            return nextBeat;
-        }
-        return currentPos;
-    }
-    if (mode == QuantizeMode::NextBeat) {
-        // use current position if we are already exactly on the grid,
-        // otherwise quantize to next beat, fall back to previous beat.
-        if (prevBeat == currentPos) {
-            return currentPos;
-        }
-        if (nextBeat != -1.0 && nextBeat <= total) {
-            return nextBeat;
-        }
-        if (prevBeat != -1.0) {
-            return prevBeat;
-        }
-        return currentPos;
-    }
-    DEBUG_ASSERT(!"PROGRAMMING ERROR: Invalid quantize mode");
     return currentPos;
 }
 
-double CueControl::quantizeCuePoint(double cuePos, QuantizeMode mode) {
+double CueControl::quantizeCuePoint(double cuePos) {
     // we need to use m_pTrackSamples here because SampleOfTrack
     // is set later by the engine and not during EngineBuffer::slotTrackLoaded
     const double total = m_pTrackSamples->get();
@@ -1643,42 +1606,11 @@ double CueControl::quantizeCuePoint(double cuePos, QuantizeMode mode) {
         return cuePos;
     }
 
-    if (mode == QuantizeMode::ClosestBeat) {
-        double closestBeat = pBeats->findClosestBeat(cuePos);
-        if (closestBeat != -1.0 && closestBeat <= total) {
-            return closestBeat;
-        }
-        return cuePos;
+    double closestBeat = pBeats->findClosestBeat(cuePos);
+    if (closestBeat != -1.0 && closestBeat <= total) {
+        return closestBeat;
     }
 
-    double prevBeat, nextBeat;
-    pBeats->findPrevNextBeats(cuePos, &prevBeat, &nextBeat);
-
-    if (mode == QuantizeMode::PreviousBeat) {
-        // Quantize to previous beat, fall back to next beat.
-        if (prevBeat != -1.0) {
-            return prevBeat;
-        }
-        if (nextBeat != -1.0 && nextBeat <= total) {
-            return nextBeat;
-        }
-        return cuePos;
-    }
-    if (mode == QuantizeMode::NextBeat) {
-        // use current cuePos if we are already exactly on the grid,
-        // otherwise quantize to next beat, fall back to previous beat.
-        if (prevBeat == cuePos) {
-            return cuePos;
-        }
-        if (nextBeat != -1.0 && nextBeat <= total) {
-            return nextBeat;
-        }
-        if (prevBeat != -1.0) {
-            return prevBeat;
-        }
-        return cuePos;
-    }
-    DEBUG_ASSERT(!"PROGRAMMING ERROR: Invalid quantize mode");
     return cuePos;
 }
 

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -36,7 +36,6 @@ enum class SeekOnLoadMode {
 
 inline SeekOnLoadMode seekOnLoadModeFromDouble(double value) {
     return static_cast<SeekOnLoadMode>(int(value));
-    ;
 }
 
 class HotcueControl : public QObject {
@@ -175,12 +174,6 @@ class CueControl : public EngineControl {
     void outroEndActivate(double v);
 
   private:
-    enum class QuantizeMode {
-        ClosestBeat,
-        PreviousBeat,
-        NextBeat,
-    };
-
     enum class TrackAt {
         Cue,
         End,
@@ -193,8 +186,8 @@ class CueControl : public EngineControl {
     void detachCue(HotcueControl* pControl);
     void loadCuesFromTrack();
     void reloadCuesFromTrack();
-    double quantizeCuePoint(double position, QuantizeMode mode);
-    double quantizeCurrentPosition(QuantizeMode mode);
+    double quantizeCuePoint(double position);
+    double getQuantizedCurrentPosition();
     TrackAt getTrackAt() const;
 
     bool m_bPreviewing;
@@ -202,8 +195,6 @@ class CueControl : public EngineControl {
     ControlObject* m_pStopButton;
     int m_iCurrentlyPreviewingHotcues;
     ControlObject* m_pQuantizeEnabled;
-    ControlObject* m_pPrevBeat;
-    ControlObject* m_pNextBeat;
     ControlObject* m_pClosestBeat;
     bool m_bypassCueSetByPlay;
 

--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -176,7 +176,7 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeEnabled) {
     auto pIntro = pTrack->createAndAddCue();
     pIntro->setType(Cue::Type::Intro);
     pIntro->setStartPosition(2.1 * beatLength);
-    pIntro->setEndPosition(3.3 * beatLength);
+    pIntro->setEndPosition(3.7 * beatLength);
 
     auto pOutro = pTrack->createAndAddCue();
     pOutro->setType(Cue::Type::Outro);


### PR DESCRIPTION
As discussed on [Zulip](https://mixxx.zulipchat.com/#narrow/stream/109122-general/topic/intro.2Foutro.20markers.20snap) some time ago, this PR makes intro/outro cues quantized to closest beat instead of previous/next beat.

Also, this PR unifies (and therefore de-duplicates) quantization of all cue points (main cue, hot cues and intro/outro cues).