### PR TITLE
Encoding refactoring

### DIFF
--- a/src/encoder/encoder.cpp
+++ b/src/encoder/encoder.cpp
@@ -125,7 +125,7 @@ EncoderPointer EncoderFactory::getNewEncoder(Encoder::Format format,
     return pEncoder;
 }
 
-EncoderSettingsPointer EncoderFactory::getEncoderSettings(Encoder::Format format,
+EncoderRecordingSettingsPointer EncoderFactory::getEncoderRecordingSettings(Encoder::Format format,
     UserSettingsPointer pConfig) const
 {
     if (format.internalName == ENCODING_WAVE) {

--- a/src/encoder/encoder.cpp
+++ b/src/encoder/encoder.cpp
@@ -88,10 +88,10 @@ EncoderPointer EncoderFactory::getNewEncoder(Encoder::Format format,
     EncoderPointer pEncoder;
     if (format.internalName == ENCODING_WAVE) {
         pEncoder = std::make_shared<EncoderWave>(pCallback);
-        pEncoder->setEncoderSettings(EncoderWaveSettings(pConfig, format));
+        pEncoder->setEncoderSettings(EncoderWaveSettings(pConfig, format.internalName));
     } else if (format.internalName == ENCODING_AIFF) {
         pEncoder = std::make_shared<EncoderWave>(pCallback);
-        pEncoder->setEncoderSettings(EncoderWaveSettings(pConfig, format));
+        pEncoder->setEncoderSettings(EncoderWaveSettings(pConfig, format.internalName));
     } else if (format.internalName == ENCODING_FLAC) {
         pEncoder = std::make_shared<EncoderSndfileFlac>(pCallback);
         pEncoder->setEncoderSettings(EncoderFlacSettings(pConfig));
@@ -120,7 +120,7 @@ EncoderPointer EncoderFactory::getNewEncoder(Encoder::Format format,
         qWarning() << "Unsupported format requested! " << format.internalName;
         DEBUG_ASSERT(false);
         pEncoder = std::make_shared<EncoderWave>(pCallback);
-        pEncoder->setEncoderSettings(EncoderWaveSettings(pConfig, format));
+        pEncoder->setEncoderSettings(EncoderWaveSettings(pConfig, ENCODING_WAVE));
     }
     return pEncoder;
 }
@@ -129,9 +129,9 @@ EncoderSettingsPointer EncoderFactory::getEncoderSettings(Encoder::Format format
     UserSettingsPointer pConfig) const
 {
     if (format.internalName == ENCODING_WAVE) {
-        return std::make_shared<EncoderWaveSettings>(pConfig, format);
+        return std::make_shared<EncoderWaveSettings>(pConfig, format.internalName);
     } else if (format.internalName == ENCODING_AIFF) {
-        return std::make_shared<EncoderWaveSettings>(pConfig, format);
+        return std::make_shared<EncoderWaveSettings>(pConfig, format.internalName);
     } else if (format.internalName == ENCODING_FLAC) {
         return std::make_shared<EncoderFlacSettings>(pConfig);
     } else if (format.internalName == ENCODING_MP3) {
@@ -143,6 +143,6 @@ EncoderSettingsPointer EncoderFactory::getEncoderSettings(Encoder::Format format
     } else {
         qWarning() << "Unsupported format requested! " << format.internalName;
         DEBUG_ASSERT(false);
-        return std::make_shared<EncoderWaveSettings>(pConfig, format);
+        return std::make_shared<EncoderWaveSettings>(pConfig, ENCODING_WAVE);
     }
 }

--- a/src/encoder/encoder.cpp
+++ b/src/encoder/encoder.cpp
@@ -86,7 +86,7 @@ EncoderPointer EncoderFactory::createRecordingEncoder(
 }
 
 EncoderPointer EncoderFactory::createEncoder(
-        const EncoderSettingsPointer pSettings,
+        EncoderSettingsPointer pSettings,
         EncoderCallback* pCallback) const {
     EncoderPointer pEncoder;
     if (pSettings && pSettings->getFormat() == ENCODING_WAVE) {

--- a/src/encoder/encoder.h
+++ b/src/encoder/encoder.h
@@ -59,7 +59,7 @@ class EncoderFactory {
             UserSettingsPointer pConfig, 
             EncoderCallback* pCallback) const;
     EncoderPointer createEncoder(
-            const EncoderSettingsPointer pSettings, 
+            EncoderSettingsPointer pSettings,
             EncoderCallback* pCallback) const;
     EncoderRecordingSettingsPointer getEncoderRecordingSettings(
             Encoder::Format format,

--- a/src/encoder/encoder.h
+++ b/src/encoder/encoder.h
@@ -54,12 +54,16 @@ class EncoderFactory {
     const QList<Encoder::Format> getFormats() const;
     Encoder::Format getSelectedFormat(UserSettingsPointer pConfig) const;
     Encoder::Format getFormatFor(QString format) const;
-    EncoderPointer getNewEncoder(
-        UserSettingsPointer pConfig, EncoderCallback* pCallback) const;
-    EncoderPointer getNewEncoder(Encoder::Format format,
-        UserSettingsPointer pConfig, EncoderCallback* pCallback) const;
-    EncoderRecordingSettingsPointer getEncoderRecordingSettings(Encoder::Format format,
-        UserSettingsPointer pConfig) const;
+    EncoderPointer createRecordingEncoder(
+            Encoder::Format format,
+            UserSettingsPointer pConfig, 
+            EncoderCallback* pCallback) const;
+    EncoderPointer createEncoder(
+            const EncoderSettingsPointer pSettings, 
+            EncoderCallback* pCallback) const;
+    EncoderRecordingSettingsPointer getEncoderRecordingSettings(
+            Encoder::Format format,
+            UserSettingsPointer pConfig) const;
   private:
     static EncoderFactory factory;
     QList<Encoder::Format> m_formats;

--- a/src/encoder/encoder.h
+++ b/src/encoder/encoder.h
@@ -14,6 +14,7 @@
 #include "util/types.h"
 #include "preferences/usersettings.h"
 #include "encoder/encodersettings.h"
+#include "encoder/encoderrecordingsettings.h"
 #include "encoder/encodercallback.h"
 
 class Encoder {
@@ -57,7 +58,7 @@ class EncoderFactory {
         UserSettingsPointer pConfig, EncoderCallback* pCallback) const;
     EncoderPointer getNewEncoder(Encoder::Format format,
         UserSettingsPointer pConfig, EncoderCallback* pCallback) const;
-    EncoderSettingsPointer getEncoderSettings(Encoder::Format format,
+    EncoderRecordingSettingsPointer getEncoderRecordingSettings(Encoder::Format format,
         UserSettingsPointer pConfig) const;
   private:
     static EncoderFactory factory;

--- a/src/encoder/encoderbroadcastsettings.cpp
+++ b/src/encoder/encoderbroadcastsettings.cpp
@@ -56,3 +56,7 @@ EncoderSettings::ChannelMode EncoderBroadcastSettings::getChannelMode() const {
     }
 }
 
+QString EncoderBroadcastSettings::getFormat() const {
+    return m_pProfile->getFormat();
+}
+

--- a/src/encoder/encoderbroadcastsettings.cpp
+++ b/src/encoder/encoderbroadcastsettings.cpp
@@ -26,20 +26,9 @@ EncoderBroadcastSettings::EncoderBroadcastSettings(
     m_qualList.append(256);
     m_qualList.append(320);
 }
-EncoderBroadcastSettings::~EncoderBroadcastSettings() {
-}
 
 QList<int> EncoderBroadcastSettings::getQualityValues() const {
     return m_qualList;
-}
-
-void EncoderBroadcastSettings::setQualityByIndex(int qualityIndex) {
-    if (qualityIndex >= 0 && qualityIndex < m_qualList.size()) {
-        m_pProfile->setBitrate(m_qualList.at(qualityIndex));
-    } else {
-        qWarning() << "Invalid qualityIndex given to EncoderBroadcastSettings: " 
-            << qualityIndex << ". Ignoring it";
-    }
 }
 
 int EncoderBroadcastSettings::getQuality() const {

--- a/src/encoder/encoderbroadcastsettings.cpp
+++ b/src/encoder/encoderbroadcastsettings.cpp
@@ -33,16 +33,6 @@ QList<int> EncoderBroadcastSettings::getQualityValues() const {
     return m_qualList;
 }
 
-// Sets the value
-void EncoderBroadcastSettings::setQualityByValue(int qualityValue) {
-    if (m_qualList.contains(qualityValue)) {
-        m_pProfile->setBitrate(qualityValue);
-    } else {
-        qWarning() << "Invalid qualityValue given to EncoderBroadcastSettings: " 
-            << qualityValue << ". Ignoring it";
-    }
-}
-
 void EncoderBroadcastSettings::setQualityByIndex(int qualityIndex) {
     if (qualityIndex >= 0 && qualityIndex < m_qualList.size()) {
         m_pProfile->setBitrate(m_qualList.at(qualityIndex));
@@ -66,11 +56,6 @@ int EncoderBroadcastSettings::getQuality() const {
 
 int EncoderBroadcastSettings::getQualityIndex() const {
     return m_qualList.indexOf(getQuality());
-}
-
-void EncoderBroadcastSettings::setChannelMode(EncoderSettings::ChannelMode mode)
-{
-    m_pProfile->setChannels(static_cast<int>(mode));
 }
 
 EncoderSettings::ChannelMode EncoderBroadcastSettings::getChannelMode() const {

--- a/src/encoder/encoderbroadcastsettings.h
+++ b/src/encoder/encoderbroadcastsettings.h
@@ -24,6 +24,7 @@ class EncoderBroadcastSettings : public EncoderSettings {
     int getQuality() const override;
     int getQualityIndex() const override;
     ChannelMode getChannelMode() const override;
+    QString getFormat() const override;
 
   private:
     QList<int> m_qualList;

--- a/src/encoder/encoderbroadcastsettings.h
+++ b/src/encoder/encoderbroadcastsettings.h
@@ -9,26 +9,17 @@
 #ifndef ENCODERBROADCASTSETTINGS_H
 #define ENCODERBROADCASTSETTINGS_H
 
-#include "encoder/encoderrecordingsettings.h"
+#include "encoder/encodersettings.h"
 #include "encoder/encoder.h"
 #include "preferences/broadcastsettings.h"
 
-class EncoderBroadcastSettings : public EncoderRecordingSettings {
+class EncoderBroadcastSettings : public EncoderSettings {
   public:
-    EncoderBroadcastSettings(BroadcastProfilePtr profile);
-    virtual ~EncoderBroadcastSettings();
-
-    // Indicates that it uses the quality slider section of the preferences
-    bool usesQualitySlider() const override;
-    // Indicates that it uses the compression slider section of the preferences
-    bool usesCompressionSlider() const override;
-    // Indicates that it uses the radio button section of the preferences.
-    bool usesOptionGroups() const override;
+    explicit EncoderBroadcastSettings(BroadcastProfilePtr profile);
+    ~EncoderBroadcastSettings() override = default;
 
     // Returns the list of quality values that it supports, to assign them to the slider
     QList<int> getQualityValues() const override;
-    // Sets the quality value by its index
-    void setQualityByIndex(int qualityIndex) override;
     // Returns the current quality value
     int getQuality() const override;
     int getQualityIndex() const override;
@@ -38,18 +29,5 @@ class EncoderBroadcastSettings : public EncoderRecordingSettings {
     QList<int> m_qualList;
     BroadcastProfilePtr m_pProfile;
 };
-
-inline bool EncoderBroadcastSettings::usesQualitySlider() const
-{
-    return true;
-}
-inline bool EncoderBroadcastSettings::usesCompressionSlider() const
-{
-    return false;
-}
-inline bool EncoderBroadcastSettings::usesOptionGroups() const
-{
-    return false;
-}
 
 #endif // ENCODERBROADCASTSETTINGS_H

--- a/src/encoder/encoderbroadcastsettings.h
+++ b/src/encoder/encoderbroadcastsettings.h
@@ -27,14 +27,11 @@ class EncoderBroadcastSettings : public EncoderSettings {
 
     // Returns the list of quality values that it supports, to assign them to the slider
     QList<int> getQualityValues() const override;
-    // Sets the quality value by its value
-    void setQualityByValue(int qualityValue) override;
     // Sets the quality value by its index
     void setQualityByIndex(int qualityIndex) override;
     // Returns the current quality value
     int getQuality() const override;
     int getQualityIndex() const override;
-    void setChannelMode(ChannelMode mode) override;
     ChannelMode getChannelMode() const override;
 
   private:

--- a/src/encoder/encoderbroadcastsettings.h
+++ b/src/encoder/encoderbroadcastsettings.h
@@ -9,11 +9,11 @@
 #ifndef ENCODERBROADCASTSETTINGS_H
 #define ENCODERBROADCASTSETTINGS_H
 
-#include "encoder/encodersettings.h"
+#include "encoder/encoderrecordingsettings.h"
 #include "encoder/encoder.h"
 #include "preferences/broadcastsettings.h"
 
-class EncoderBroadcastSettings : public EncoderSettings {
+class EncoderBroadcastSettings : public EncoderRecordingSettings {
   public:
     EncoderBroadcastSettings(BroadcastProfilePtr profile);
     virtual ~EncoderBroadcastSettings();

--- a/src/encoder/encoderflacsettings.h
+++ b/src/encoder/encoderflacsettings.h
@@ -10,6 +10,7 @@
 
 #include "encoder/encoderrecordingsettings.h"
 #include "encoder/encoder.h"
+#include "recording/defs_recording.h"
 
 class EncoderFlacSettings : public EncoderRecordingSettings {
   public:
@@ -36,6 +37,11 @@ class EncoderFlacSettings : public EncoderRecordingSettings {
     // Return the selected option of the group. If it is a single-element option, 
     // 0 means disabled and 1 enabled.
     int getSelectedOption(QString groupCode) const override;
+
+    // Returns the format of this encoder settings.
+    QString getFormat() const override {
+        return ENCODING_FLAC;
+    }
 
     static const int DEFAULT_QUALITY_VALUE;
     static const QString BITS_GROUP;

--- a/src/encoder/encoderflacsettings.h
+++ b/src/encoder/encoderflacsettings.h
@@ -17,8 +17,6 @@ class EncoderFlacSettings : public EncoderRecordingSettings {
     EncoderFlacSettings(UserSettingsPointer pConfig);
     virtual ~EncoderFlacSettings();
 
-    // Indicates that it uses the quality slider section of the preferences
-    bool usesQualitySlider() const override;
     // Indicates that it uses the compression slider section of the preferences
     bool usesCompressionSlider() const override;
     // Indicates that it uses the radio button section of the preferences.
@@ -52,11 +50,6 @@ class EncoderFlacSettings : public EncoderRecordingSettings {
     UserSettingsPointer m_pConfig;
 };
 
-
-inline bool EncoderFlacSettings::usesQualitySlider() const
-{
-    return false;
-}
 inline bool EncoderFlacSettings::usesOptionGroups() const
 {
     return true;

--- a/src/encoder/encoderflacsettings.h
+++ b/src/encoder/encoderflacsettings.h
@@ -8,10 +8,10 @@
 #ifndef ENCODERFLACSETTINGS_H
 #define ENCODERFLACSETTINGS_H
 
-#include "encoder/encodersettings.h"
+#include "encoder/encoderrecordingsettings.h"
 #include "encoder/encoder.h"
 
-class EncoderFlacSettings : public EncoderSettings {
+class EncoderFlacSettings : public EncoderRecordingSettings {
   public:
     EncoderFlacSettings(UserSettingsPointer pConfig);
     virtual ~EncoderFlacSettings();

--- a/src/encoder/encodermp3settings.cpp
+++ b/src/encoder/encodermp3settings.cpp
@@ -63,18 +63,6 @@ QList<int> EncoderMp3Settings::getVBRQualityValues() const
     return m_qualVBRList;
 }
 
-// Sets the value
-void EncoderMp3Settings::setQualityByValue(int qualityValue) 
-{
-    if (m_qualList.contains(qualityValue)) {
-        m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "MP3_Quality"), 
-                ConfigValue(m_qualList.indexOf(qualityValue)));
-    } else {
-        qWarning() << "Invalid qualityValue given to EncoderMp3Settings: " 
-            << qualityValue << ". Ignoring it";
-    }
-}
-
 void EncoderMp3Settings::setQualityByIndex(int qualityIndex)
 {
     if (qualityIndex >= 0 && qualityIndex < m_qualList.size()) {

--- a/src/encoder/encodermp3settings.h
+++ b/src/encoder/encodermp3settings.h
@@ -10,6 +10,7 @@
 
 #include "encoder/encoderrecordingsettings.h"
 #include "encoder/encoder.h"
+#include "recording/defs_recording.h"
 
 class EncoderMp3Settings : public EncoderRecordingSettings {
   public:
@@ -39,6 +40,11 @@ class EncoderMp3Settings : public EncoderRecordingSettings {
     // Return the selected option of the group. If it is a single-element option, 
     // 0 means disabled and 1 enabled.
     int getSelectedOption(QString groupCode) const override;
+
+    // Returns the format of this encoder settings.
+    QString getFormat() const override {
+        return ENCODING_MP3;
+    }
 
     static const int DEFAULT_BITRATE_INDEX;
     static const QString ENCODING_MODE_GROUP;

--- a/src/encoder/encodermp3settings.h
+++ b/src/encoder/encodermp3settings.h
@@ -26,8 +26,6 @@ class EncoderMp3Settings : public EncoderSettings {
     // Returns the list of quality values that it supports, to assign them to the slider
     QList<int> getQualityValues() const override;
     QList<int> getVBRQualityValues() const;
-    // Sets the quality value by its value
-    void setQualityByValue(int qualityValue) override;
     // Sets the quality value by its index
     void setQualityByIndex(int qualityIndex) override;
     // Returns the current quality value

--- a/src/encoder/encodermp3settings.h
+++ b/src/encoder/encodermp3settings.h
@@ -8,10 +8,10 @@
 #ifndef ENCODERMP3SETTINGS_H
 #define ENCODERMP3SETTINGS_H
 
-#include "encoder/encodersettings.h"
+#include "encoder/encoderrecordingsettings.h"
 #include "encoder/encoder.h"
 
-class EncoderMp3Settings : public EncoderSettings {
+class EncoderMp3Settings : public EncoderRecordingSettings {
   public:
     EncoderMp3Settings(UserSettingsPointer m_pConfig);
     virtual ~EncoderMp3Settings();

--- a/src/encoder/encodermp3settings.h
+++ b/src/encoder/encodermp3settings.h
@@ -18,12 +18,13 @@ class EncoderMp3Settings : public EncoderRecordingSettings {
     virtual ~EncoderMp3Settings();
 
     // Indicates that it uses the quality slider section of the preferences
-    bool usesQualitySlider() const override;
-    // Indicates that it uses the compression slider section of the preferences
-    bool usesCompressionSlider() const override;
+    bool usesQualitySlider() const override {
+        return true;
+    }
     // Indicates that it uses the radio button section of the preferences.
-    bool usesOptionGroups() const override;
-
+    bool usesOptionGroups() const override {
+        return true;
+    }
     // Returns the list of quality values that it supports, to assign them to the slider
     QList<int> getQualityValues() const override;
     QList<int> getVBRQualityValues() const;
@@ -54,19 +55,5 @@ class EncoderMp3Settings : public EncoderRecordingSettings {
     QList<int> m_qualVBRList;
     UserSettingsPointer m_pConfig;
 };
-
-
-inline bool EncoderMp3Settings::usesQualitySlider() const
-{
-    return true;
-}
-inline bool EncoderMp3Settings::usesCompressionSlider() const
-{
-    return false;
-}
-inline bool EncoderMp3Settings::usesOptionGroups() const
-{
-    return true;
-}
 
 #endif // ENCODERMP3SETTINGS_H

--- a/src/encoder/encoderopussettings.cpp
+++ b/src/encoder/encoderopussettings.cpp
@@ -50,20 +50,6 @@ QList<int> EncoderOpusSettings::getQualityValues() const {
     return m_qualList;
 }
 
-void EncoderOpusSettings::setQualityByValue(int qualityValue) {
-    // Same behavior as Vorbis: Opus does not have a fixed set of
-    // bitrates, so we can accept any value.
-    int indexValue;
-    if (m_qualList.contains(qualityValue)) {
-        indexValue = m_qualList.indexOf(qualityValue);
-    } else {
-        // If we let the user write a bitrate value, this would allow to save such value.
-        indexValue = qualityValue;
-    }
-
-    m_pConfig->setValue<int>(ConfigKey(RECORDING_PREF_KEY, kQualityKey), indexValue);
-}
-
 void EncoderOpusSettings::setQualityByIndex(int qualityIndex) {
     if (qualityIndex >= 0 && qualityIndex < m_qualList.size()) {
         m_pConfig->setValue<int>(ConfigKey(RECORDING_PREF_KEY, kQualityKey), qualityIndex);

--- a/src/encoder/encoderopussettings.h
+++ b/src/encoder/encoderopussettings.h
@@ -32,8 +32,6 @@ class EncoderOpusSettings: public EncoderSettings {
 
     // Returns the list of quality values that it supports, to assign them to the slider
     QList<int> getQualityValues() const override;
-    // Sets the quality value by its value
-    void setQualityByValue(int qualityValue) override;
     // Sets the quality value by its index
     void setQualityByIndex(int qualityIndex) override;
     // Returns the current quality value

--- a/src/encoder/encoderopussettings.h
+++ b/src/encoder/encoderopussettings.h
@@ -6,6 +6,7 @@
 
 #include "encoder/encoderrecordingsettings.h"
 #include "encoder/encoder.h"
+#include "recording/defs_recording.h"
 
 #define OPUS_BITRATE_MODES_COUNT 3
 #define OPUS_BITRATE_CONSTRAINED_VBR 0
@@ -46,6 +47,11 @@ class EncoderOpusSettings: public EncoderRecordingSettings {
     // Return the selected option of the group. If it is a single-element option,
     // 0 means disabled and 1 enabled.
     int getSelectedOption(QString groupCode) const override;
+
+    // Returns the format of this encoder settings.
+    QString getFormat() const override {
+        return ENCODING_OPUS;
+    }
 
     static const QString BITRATE_MODE_GROUP;
 

--- a/src/encoder/encoderopussettings.h
+++ b/src/encoder/encoderopussettings.h
@@ -22,10 +22,7 @@ class EncoderOpusSettings: public EncoderRecordingSettings {
     bool usesQualitySlider() const override {
         return true;
     }
-    // Indicates that it uses the compression slider section of the preferences
-    bool usesCompressionSlider() const override {
-        return false;
-    }
+
     // Indicates that it uses the radio button section of the preferences.
     bool usesOptionGroups() const override {
         return true;

--- a/src/encoder/encoderopussettings.h
+++ b/src/encoder/encoderopussettings.h
@@ -4,7 +4,7 @@
 #ifndef ENCODER_ENCODEROPUSSETTINGS_H
 #define ENCODER_ENCODEROPUSSETTINGS_H
 
-#include "encoder/encodersettings.h"
+#include "encoder/encoderrecordingsettings.h"
 #include "encoder/encoder.h"
 
 #define OPUS_BITRATE_MODES_COUNT 3
@@ -12,7 +12,7 @@
 #define OPUS_BITRATE_CBR 1
 #define OPUS_BITRATE_VBR 2
 
-class EncoderOpusSettings: public EncoderSettings {
+class EncoderOpusSettings: public EncoderRecordingSettings {
   public:
     explicit EncoderOpusSettings(UserSettingsPointer pConfig);
     ~EncoderOpusSettings() override = default;

--- a/src/encoder/encoderrecordingsettings.h
+++ b/src/encoder/encoderrecordingsettings.h
@@ -1,25 +1,36 @@
 #pragma once
 
 #include "encoder/encodersettings.h"
+#include "util/assert.h"
 
 class EncoderRecordingSettings : public EncoderSettings {
   public:
     ~EncoderRecordingSettings() override = default;
 
     // Indicates that it uses the quality slider section of the preferences
-    virtual bool usesQualitySlider() const = 0;
+    virtual bool usesQualitySlider() const {
+        return false;
+    }
+
     // Indicates that it uses the compression slider section of the preferences
-    virtual bool usesCompressionSlider() const = 0;
+    virtual bool usesCompressionSlider() const {
+        return false;
+    }
+
     // Indicates that it uses the radio button section of the preferences.
-    virtual bool usesOptionGroups() const = 0;
+    virtual bool usesOptionGroups() const {
+        return false;
+    }
 
     virtual void setQualityByIndex(int qualityIndex) {
         Q_UNUSED(qualityIndex);
+        DEBUG_ASSERT(!"unimplemented");
     }
 
     // Sets the compression level
     virtual void setCompression(int compression) {
         Q_UNUSED(compression);
+        DEBUG_ASSERT(!"unimplemented");
     }
 
     // Selects the option by its index. If it is a single-element option, 
@@ -27,6 +38,7 @@ class EncoderRecordingSettings : public EncoderSettings {
     virtual void setGroupOption(QString groupCode, int optionIndex) {
         Q_UNUSED(groupCode);
         Q_UNUSED(optionIndex);
+        DEBUG_ASSERT(!"unimplemented");
     }
 };
 

--- a/src/encoder/encoderrecordingsettings.h
+++ b/src/encoder/encoderrecordingsettings.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "encoder/encodersettings.h"
+
+class EncoderRecordingSettings : public EncoderSettings {
+  public:
+    ~EncoderRecordingSettings() override = default;
+
+    // Indicates that it uses the quality slider section of the preferences
+    virtual bool usesQualitySlider() const = 0;
+    // Indicates that it uses the compression slider section of the preferences
+    virtual bool usesCompressionSlider() const = 0;
+    // Indicates that it uses the radio button section of the preferences.
+    virtual bool usesOptionGroups() const = 0;
+
+    virtual void setQualityByIndex(int qualityIndex) {
+        Q_UNUSED(qualityIndex);
+    }
+
+    // Sets the compression level
+    virtual void setCompression(int compression) {
+        Q_UNUSED(compression);
+    }
+
+    // Selects the option by its index. If it is a single-element option, 
+    // index 0 means disabled and 1 enabled.
+    virtual void setGroupOption(QString groupCode, int optionIndex) {
+        Q_UNUSED(groupCode);
+        Q_UNUSED(optionIndex);
+    }
+};
+
+typedef std::shared_ptr<EncoderRecordingSettings> EncoderRecordingSettingsPointer;
+

--- a/src/encoder/encodersettings.h
+++ b/src/encoder/encodersettings.h
@@ -28,21 +28,10 @@ class EncoderSettings {
             STEREO=2
         };
 
-    EncoderSettings() {}
-    virtual ~EncoderSettings() {}
-
-    // Indicates that it uses the quality slider section of the preferences
-    virtual bool usesQualitySlider() const = 0;
-    // Indicates that it uses the compression slider section of the preferences
-    virtual bool usesCompressionSlider() const = 0;
-    // Indicates that it uses the radio button section of the preferences.
-    virtual bool usesOptionGroups() const = 0;
+    virtual ~EncoderSettings() = default;
 
     // Returns the list of quality values supported, to assign them to the slider
     virtual QList<int> getQualityValues() const { return QList<int>(); }
-    // Sets the quality value by its value
-    // Sets the quality value by its index
-    virtual void setQualityByIndex(int qualityIndex) { Q_UNUSED(qualityIndex); }
     virtual int getQuality() const { return 0; }
     virtual int getQualityIndex() const { return 0; }
     // Returns the list of compression values supported, to assign them to the slider
@@ -54,9 +43,6 @@ class EncoderSettings {
     virtual QList<OptionsGroup> getOptionGroups() const { return QList<OptionsGroup>(); }
     // Selects the option by its index. If it is a single-element option, 
     // index 0 means disabled and 1 enabled.
-    virtual void setGroupOption(QString groupCode, int optionIndex) {
-        Q_UNUSED(groupCode);
-        Q_UNUSED(optionIndex); }
     // Return the selected option of the group. If it is a single-element option, 
     // 0 means disabled and 1 enabled.
     virtual int getSelectedOption(QString groupCode) const { Q_UNUSED(groupCode); return 0; }

--- a/src/encoder/encodersettings.h
+++ b/src/encoder/encodersettings.h
@@ -41,7 +41,6 @@ class EncoderSettings {
     // Returns the list of quality values supported, to assign them to the slider
     virtual QList<int> getQualityValues() const { return QList<int>(); }
     // Sets the quality value by its value
-    virtual void setQualityByValue(int qualityValue) { Q_UNUSED(qualityValue); }
     // Sets the quality value by its index
     virtual void setQualityByIndex(int qualityIndex) { Q_UNUSED(qualityIndex); }
     virtual int getQuality() const { return 0; }
@@ -55,13 +54,13 @@ class EncoderSettings {
     virtual QList<OptionsGroup> getOptionGroups() const { return QList<OptionsGroup>(); }
     // Selects the option by its index. If it is a single-element option, 
     // index 0 means disabled and 1 enabled.
-    virtual void setGroupOption(QString groupCode, int optionIndex) { 
-            Q_UNUSED(groupCode); Q_UNUSED(optionIndex); }
+    virtual void setGroupOption(QString groupCode, int optionIndex) {
+        Q_UNUSED(groupCode);
+        Q_UNUSED(optionIndex); }
     // Return the selected option of the group. If it is a single-element option, 
     // 0 means disabled and 1 enabled.
     virtual int getSelectedOption(QString groupCode) const { Q_UNUSED(groupCode); return 0; }
     
-    virtual void setChannelMode(ChannelMode mode) { Q_UNUSED(mode); }
     virtual ChannelMode getChannelMode() const { return ChannelMode::AUTOMATIC; }
 };
 

--- a/src/encoder/encodersettings.h
+++ b/src/encoder/encodersettings.h
@@ -48,6 +48,9 @@ class EncoderSettings {
     virtual int getSelectedOption(QString groupCode) const { Q_UNUSED(groupCode); return 0; }
     
     virtual ChannelMode getChannelMode() const { return ChannelMode::AUTOMATIC; }
+
+    // Returns the format subtype of this encoder settings.
+    virtual QString getFormat() const = 0;
 };
 
 typedef std::shared_ptr<EncoderSettings> EncoderSettingsPointer;

--- a/src/encoder/encodervorbissettings.cpp
+++ b/src/encoder/encodervorbissettings.cpp
@@ -37,19 +37,6 @@ QList<int> EncoderVorbisSettings::getQualityValues() const
 {
     return m_qualList;
 }
-// Sets the value
-void EncoderVorbisSettings::setQualityByValue(int qualityValue) 
-{
-    // Vorbis does not have a fixed set of bitrates, so we can accept any value.
-    int indexValue;
-    if (m_qualList.contains(qualityValue)) {
-        indexValue = m_qualList.indexOf(qualityValue);
-    } else {
-    // If we let the user write a bitrate value, this would allow to save such value.
-        indexValue = qualityValue;
-    }
-    m_pConfig->setValue<int>(ConfigKey(RECORDING_PREF_KEY, "OGG_Quality"), indexValue);
-}
 
 void EncoderVorbisSettings::setQualityByIndex(int qualityIndex)
 {
@@ -60,6 +47,7 @@ void EncoderVorbisSettings::setQualityByIndex(int qualityIndex)
             << qualityIndex << ". Ignoring it";
     }
 }
+
 int EncoderVorbisSettings::getQuality() const
 {
     int qualityIndex = m_pConfig->getValue(

--- a/src/encoder/encodervorbissettings.h
+++ b/src/encoder/encodervorbissettings.h
@@ -18,11 +18,14 @@ class EncoderVorbisSettings : public EncoderRecordingSettings {
     virtual ~EncoderVorbisSettings();
 
     // Indicates that it uses the quality slider section of the preferences
-    bool usesQualitySlider() const override;
-    // Indicates that it uses the compression slider section of the preferences
-    bool usesCompressionSlider() const override;
+    bool usesQualitySlider() const override {
+        return true;
+    }
+
     // Indicates that it uses the radio button section of the preferences.
-    bool usesOptionGroups() const override;
+    bool usesOptionGroups() const override{
+        return true;
+    }
 
     // Returns the list of quality values that it supports, to assign them to the slider
     QList<int> getQualityValues() const override;
@@ -42,18 +45,5 @@ class EncoderVorbisSettings : public EncoderRecordingSettings {
     UserSettingsPointer m_pConfig;
 };
 
-
-inline bool EncoderVorbisSettings::usesQualitySlider() const
-{
-    return true;
-}
-inline bool EncoderVorbisSettings::usesCompressionSlider() const
-{
-    return false;
-}
-inline bool EncoderVorbisSettings::usesOptionGroups() const
-{
-    return false;
-}
 
 #endif // ENCODERVORBISSETTINGS_H

--- a/src/encoder/encodervorbissettings.h
+++ b/src/encoder/encodervorbissettings.h
@@ -25,8 +25,6 @@ class EncoderVorbisSettings : public EncoderSettings {
 
     // Returns the list of quality values that it supports, to assign them to the slider
     QList<int> getQualityValues() const override;
-    // Sets the quality value by its value
-    void setQualityByValue(int qualityValue) override;
     // Sets the quality value by its index
     void setQualityByIndex(int qualityIndex) override;
     // Returns the current quality value

--- a/src/encoder/encodervorbissettings.h
+++ b/src/encoder/encodervorbissettings.h
@@ -10,6 +10,7 @@
 
 #include "encoder/encoderrecordingsettings.h"
 #include "encoder/encoder.h"
+#include "recording/defs_recording.h"
 
 class EncoderVorbisSettings : public EncoderRecordingSettings {
     public:
@@ -30,6 +31,11 @@ class EncoderVorbisSettings : public EncoderRecordingSettings {
     // Returns the current quality value
     int getQuality() const override;
     int getQualityIndex() const override;
+
+    // Returns the format of this encoder settings.
+    QString getFormat() const override {
+        return ENCODING_OGG;
+    }
 
   private:
     QList<int> m_qualList;

--- a/src/encoder/encodervorbissettings.h
+++ b/src/encoder/encodervorbissettings.h
@@ -8,10 +8,10 @@
 #ifndef ENCODERVORBISSETTINGS_H
 #define ENCODERVORBISSETTINGS_H
 
-#include "encoder/encodersettings.h"
+#include "encoder/encoderrecordingsettings.h"
 #include "encoder/encoder.h"
 
-class EncoderVorbisSettings : public EncoderSettings {
+class EncoderVorbisSettings : public EncoderRecordingSettings {
     public:
     EncoderVorbisSettings(UserSettingsPointer pConfig);
     virtual ~EncoderVorbisSettings();

--- a/src/encoder/encoderwave.cpp
+++ b/src/encoder/encoderwave.cpp
@@ -98,18 +98,15 @@ EncoderWave::~EncoderWave() {
     }
 }
 
-void EncoderWave::setEncoderSettings(const EncoderSettings& settings)
-{
+void EncoderWave::setEncoderSettings(const EncoderSettings& settings) {
     const EncoderWaveSettings& wavesettings = reinterpret_cast<const EncoderWaveSettings&>(settings);
-    Encoder::Format format = wavesettings.getFormat();
-    if (format.internalName == ENCODING_WAVE) {
+    QString format = wavesettings.getFormat();
+    if (format == ENCODING_WAVE) {
         m_sfInfo.format = SF_FORMAT_WAV;
-    }
-    else if (format.internalName == ENCODING_AIFF) {
+    } else if (format == ENCODING_AIFF) {
         m_sfInfo.format = SF_FORMAT_AIFF;
-    }
-    else {
-        qWarning() << "Unexpected Format when setting EncoderWave: " << format.internalName << ". Reverting to wav";
+    } else {
+        qWarning() << "Unexpected Format when setting EncoderWave: " << format << ". Reverting to wav";
         // Other possibly interesting formats
         // There is a n option for RF64 to automatically downgrade to RIFF WAV if less than 4GB using an
         // sf_command, so it could be interesting to use it in place of FORMAT_WAVE.

--- a/src/encoder/encoderwavesettings.cpp
+++ b/src/encoder/encoderwavesettings.cpp
@@ -9,17 +9,15 @@
  #include "recording/defs_recording.h"
  
 const QString EncoderWaveSettings::BITS_GROUP = "BITS";
- 
+
 EncoderWaveSettings::EncoderWaveSettings(UserSettingsPointer pConfig,
-        Encoder::Format format) :
-    m_pConfig(pConfig),
-    m_format(format)
-{
-    VERIFY_OR_DEBUG_ASSERT(m_format.internalName == ENCODING_WAVE
-            || m_format.internalName == ENCODING_AIFF) {
-        m_format = EncoderFactory::getFactory().getFormatFor(ENCODING_WAVE);
-        qWarning() << "EncoderWaveSettings setup with " << format.internalName
-        << ". This is an error! Changing it to " << m_format.internalName;
+        QString format)
+        : m_pConfig(pConfig),
+          m_format(std::move(format)) {
+    VERIFY_OR_DEBUG_ASSERT(m_format == ENCODING_WAVE || m_format == ENCODING_AIFF) {
+        m_format = ENCODING_WAVE;
+        qWarning() << "EncoderWaveSettings setup with " << m_format
+                   << ". This is an error! Changing it to " << m_format;
     }
     QList<QString> names;
     names.append(QObject::tr("16 bits"));
@@ -27,6 +25,7 @@ EncoderWaveSettings::EncoderWaveSettings(UserSettingsPointer pConfig,
     names.append(QObject::tr("32 bits float"));
     m_radioList.append(OptionsGroup(QObject::tr("Bit depth"), BITS_GROUP, names));
 }
+
 EncoderWaveSettings::~EncoderWaveSettings()
 {
     
@@ -49,8 +48,8 @@ void EncoderWaveSettings::setGroupOption(QString groupCode, int optionIndex)
             found=true;
             if (optionIndex < group.controlNames.size() || optionIndex == 1) {
                 m_pConfig->set(
-                    ConfigKey(RECORDING_PREF_KEY, m_format.internalName + "_" + groupCode),
-                    ConfigValue(optionIndex));
+                        ConfigKey(RECORDING_PREF_KEY, m_format + "_" + groupCode),
+                        ConfigValue(optionIndex));
             } else {
                 qWarning() << "Received an index out of range for: " 
                     << groupCode << ", index: " << optionIndex;
@@ -67,7 +66,7 @@ int EncoderWaveSettings::getSelectedOption(QString groupCode) const
 {
     bool found=false;
     int value = m_pConfig->getValue(
-        ConfigKey(RECORDING_PREF_KEY, m_format.internalName + "_" + groupCode), 0);
+            ConfigKey(RECORDING_PREF_KEY, m_format + "_" + groupCode), 0);
     for (const auto& group : m_radioList) {
         if (groupCode == group.groupCode) {
             found=true;

--- a/src/encoder/encoderwavesettings.h
+++ b/src/encoder/encoderwavesettings.h
@@ -14,7 +14,7 @@
 
 class EncoderWaveSettings : public EncoderSettings {
   public:
-    EncoderWaveSettings(UserSettingsPointer pConfig, Encoder::Format format);
+    EncoderWaveSettings(UserSettingsPointer pConfig, QString format);
     virtual ~EncoderWaveSettings();
 
     // Indicates that it uses the quality slider section of the preferences
@@ -42,7 +42,7 @@ class EncoderWaveSettings : public EncoderSettings {
     int getSelectedOption(QString groupCode) const override;
 
     // Returns the format subtype of this encoder settings.
-    Encoder::Format getFormat() const {
+    QString getFormat() const {
         return m_format;
     }
     
@@ -50,7 +50,7 @@ class EncoderWaveSettings : public EncoderSettings {
   private:
     QList<OptionsGroup> m_radioList;
     UserSettingsPointer m_pConfig;
-    Encoder::Format m_format;
+    QString m_format;
 };
 
 

--- a/src/encoder/encoderwavesettings.h
+++ b/src/encoder/encoderwavesettings.h
@@ -42,7 +42,7 @@ class EncoderWaveSettings : public EncoderRecordingSettings {
     int getSelectedOption(QString groupCode) const override;
 
     // Returns the format subtype of this encoder settings.
-    QString getFormat() const {
+    QString getFormat() const override{
         return m_format;
     }
     

--- a/src/encoder/encoderwavesettings.h
+++ b/src/encoder/encoderwavesettings.h
@@ -18,11 +18,19 @@ class EncoderWaveSettings : public EncoderSettings {
     virtual ~EncoderWaveSettings();
 
     // Indicates that it uses the quality slider section of the preferences
-    bool usesQualitySlider() const override;
+    bool usesQualitySlider() const override {
+        return false;
+    }
+
     // Indicates that it uses the compression slider section of the preferences
-    bool usesCompressionSlider() const override;
+    bool usesCompressionSlider() const override {
+        return false;
+    }
+
     // Indicates that it uses the radio button section of the preferences.
-    bool usesOptionGroups() const override;
+    bool usesOptionGroups() const override {
+        return true;
+    }
 
     // Returns the list of radio options to show to the user
     QList<OptionsGroup> getOptionGroups() const override;
@@ -34,7 +42,9 @@ class EncoderWaveSettings : public EncoderSettings {
     int getSelectedOption(QString groupCode) const override;
 
     // Returns the format subtype of this encoder settings.
-    Encoder::Format getFormat() const;
+    Encoder::Format getFormat() const {
+        return m_format;
+    }
     
     static const QString BITS_GROUP;
   private:
@@ -44,22 +54,10 @@ class EncoderWaveSettings : public EncoderSettings {
 };
 
 
-inline bool EncoderWaveSettings::usesQualitySlider() const
-{
-    return false;
-}
-inline bool EncoderWaveSettings::usesCompressionSlider() const
-{
-    return false;
-}
-inline bool EncoderWaveSettings::usesOptionGroups() const
-{
-    return true;
-}
 
-inline Encoder::Format EncoderWaveSettings::getFormat() const
-{
-    return m_format;
-}
+
+
+
+
 
 #endif // ENCODERWAVESETTINGS_H

--- a/src/encoder/encoderwavesettings.h
+++ b/src/encoder/encoderwavesettings.h
@@ -17,16 +17,6 @@ class EncoderWaveSettings : public EncoderRecordingSettings {
     EncoderWaveSettings(UserSettingsPointer pConfig, QString format);
     virtual ~EncoderWaveSettings();
 
-    // Indicates that it uses the quality slider section of the preferences
-    bool usesQualitySlider() const override {
-        return false;
-    }
-
-    // Indicates that it uses the compression slider section of the preferences
-    bool usesCompressionSlider() const override {
-        return false;
-    }
-
     // Indicates that it uses the radio button section of the preferences.
     bool usesOptionGroups() const override {
         return true;

--- a/src/encoder/encoderwavesettings.h
+++ b/src/encoder/encoderwavesettings.h
@@ -8,11 +8,11 @@
 #ifndef ENCODERWAVESETTINGS_H
 #define ENCODERWAVESETTINGS_H
 
-#include "encoder/encodersettings.h"
+#include "encoder/encoderrecordingsettings.h"
 #include "encoder/encoder.h"
 #include <QList>
 
-class EncoderWaveSettings : public EncoderSettings {
+class EncoderWaveSettings : public EncoderRecordingSettings {
   public:
     EncoderWaveSettings(UserSettingsPointer pConfig, QString format);
     virtual ~EncoderWaveSettings();

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -58,8 +58,9 @@ void EngineRecord::updateFromPreferences() {
     }
     Encoder::Format format = EncoderFactory::getFactory().getSelectedFormat(m_pConfig);
     m_encoding = format.internalName;
-    m_pEncoder = EncoderFactory::getFactory().getNewEncoder(format,  m_pConfig, this);
-    m_pEncoder->updateMetaData(m_baAuthor,m_baTitle,m_baAlbum);
+    m_pEncoder = EncoderFactory::getFactory().createRecordingEncoder(
+            format, m_pConfig, this);
+    m_pEncoder->updateMetaData(m_baAuthor, m_baTitle, m_baAlbum);
 
     QString errorMsg;
     if(m_pEncoder->initEncoder(m_sampleRate, errorMsg) < 0) {

--- a/src/engine/sidechain/shoutconnection.cpp
+++ b/src/engine/sidechain/shoutconnection.cpp
@@ -437,28 +437,10 @@ void ShoutConnection::updateFromPreferences() {
     }
 
     // Initialize m_encoder
-    EncoderBroadcastSettings broadcastSettings(m_pProfile);
-    if (m_format_is_mp3) {
-        m_encoder = EncoderFactory::getFactory().getNewEncoder(
-            EncoderFactory::getFactory().getFormatFor(ENCODING_MP3), m_pConfig, this);
-        m_encoder->setEncoderSettings(broadcastSettings);
-    } else if (m_format_is_ov) {
-        m_encoder = EncoderFactory::getFactory().getNewEncoder(
-            EncoderFactory::getFactory().getFormatFor(ENCODING_OGG), m_pConfig, this);
-        m_encoder->setEncoderSettings(broadcastSettings);
-    }
-#ifdef __OPUS__
-    else if (m_format_is_opus) {
-        m_encoder = EncoderFactory::getFactory().getNewEncoder(
-            EncoderFactory::getFactory().getFormatFor(ENCODING_OPUS), m_pConfig, this);
-    }
-#endif
-    else {
-        kLogger.warning() << "**** Unknown Encoder Format";
-        setState(NETWORKSTREAMWORKER_STATE_ERROR);
-        m_lastErrorStr = "Encoder format error";
-        return;
-    }
+    EncoderSettingsPointer pBroadcastSettings =
+            std::make_shared<EncoderBroadcastSettings>(m_pProfile);
+    m_encoder = EncoderFactory::getFactory().createEncoder(
+                    pBroadcastSettings, this);
 
     QString errorMsg;
     if(m_encoder->initEncoder(iMasterSamplerate, errorMsg) < 0) {

--- a/src/preferences/dialog/dlgprefrecord.cpp
+++ b/src/preferences/dialog/dlgprefrecord.cpp
@@ -61,7 +61,7 @@ DlgPrefRecord::DlgPrefRecord(QWidget* parent, UserSettingsPointer pConfig)
         m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "Encoding"),  ConfigValue(m_selFormat.internalName));
     }
 
-    setupEncoderUI(m_selFormat);
+    setupEncoderUI();
 
     // Setting Metadata
     loadMetaData();
@@ -160,7 +160,7 @@ void DlgPrefRecord::slotUpdate()
             break;
         }
     }
-    setupEncoderUI(m_selFormat);
+    setupEncoderUI();
 
     loadMetaData();
 
@@ -178,8 +178,9 @@ void DlgPrefRecord::slotUpdate()
 void DlgPrefRecord::slotResetToDefaults()
 {
     m_formatButtons.first()->setChecked(true);
-    setupEncoderUI(EncoderFactory::getFactory().getFormatFor(
-        m_formatButtons.first()->objectName()));
+    m_selFormat = EncoderFactory::getFactory().getFormatFor(
+            m_formatButtons.first()->objectName());
+    setupEncoderUI();
     // TODO (XXX): It would be better that a defaultSettings() method is added
     // to the EncoderSettings interface so that we know which option to set
     m_optionWidgets.first()->setChecked(true);
@@ -218,14 +219,13 @@ void DlgPrefRecord::slotFormatChanged()
 {
     QObject *senderObj = sender();
     m_selFormat = EncoderFactory::getFactory().getFormatFor(senderObj->objectName());
-    setupEncoderUI(m_selFormat);
+    setupEncoderUI();
 }
 
-void DlgPrefRecord::setupEncoderUI(Encoder::Format selformat)
-{
+void DlgPrefRecord::setupEncoderUI() {
     EncoderRecordingSettingsPointer settings =
             EncoderFactory::getFactory().getEncoderRecordingSettings(
-                    selformat, m_pConfig);
+                    m_selFormat, m_pConfig);
     if (settings->usesQualitySlider()) {
         LabelQuality->setVisible(true);
         SliderQuality->setVisible(true);

--- a/src/preferences/dialog/dlgprefrecord.cpp
+++ b/src/preferences/dialog/dlgprefrecord.cpp
@@ -223,7 +223,9 @@ void DlgPrefRecord::slotFormatChanged()
 
 void DlgPrefRecord::setupEncoderUI(Encoder::Format selformat)
 {
-    EncoderSettingsPointer settings = EncoderFactory::getFactory().getEncoderSettings(selformat, m_pConfig);
+    EncoderRecordingSettingsPointer settings =
+            EncoderFactory::getFactory().getEncoderRecordingSettings(
+                    selformat, m_pConfig);
     if (settings->usesQualitySlider()) {
         LabelQuality->setVisible(true);
         SliderQuality->setVisible(true);
@@ -304,9 +306,10 @@ void DlgPrefRecord::slotSliderQuality()
     // Settings are only stored when doing an apply so that "cancel" can actually cancel.
 }
 
-void DlgPrefRecord::updateTextQuality()
-{
-    EncoderSettingsPointer settings = EncoderFactory::getFactory().getEncoderSettings(m_selFormat, m_pConfig);
+void DlgPrefRecord::updateTextQuality() {
+    EncoderRecordingSettingsPointer settings =
+            EncoderFactory::getFactory().getEncoderRecordingSettings(
+                    m_selFormat, m_pConfig);
     int quality;
     // This should be handled somehow by the EncoderSettings classes, but currently
     // I don't have a clean way to do it
@@ -338,9 +341,11 @@ void DlgPrefRecord::slotSliderCompression()
     updateTextCompression();
     // Settings are only stored when doing an apply so that "cancel" can actually cancel.
 }
-void DlgPrefRecord::updateTextCompression()
-{
-    EncoderSettingsPointer settings = EncoderFactory::getFactory().getEncoderSettings(m_selFormat, m_pConfig);
+
+void DlgPrefRecord::updateTextCompression() {
+    EncoderRecordingSettingsPointer settings =
+            EncoderFactory::getFactory().getEncoderRecordingSettings(
+                    m_selFormat, m_pConfig);
     int quality = settings->getCompressionValues().at(SliderCompression->value());
     TextCompression->setText(QString::number(quality));
 }
@@ -349,7 +354,9 @@ void DlgPrefRecord::slotGroupChanged()
 {
     // On complex scenarios, one could want to enable or disable some controls when changing
     // these, but we don't have these needs now.
-    EncoderSettingsPointer settings = EncoderFactory::getFactory().getEncoderSettings(m_selFormat, m_pConfig);
+    EncoderRecordingSettingsPointer settings =
+            EncoderFactory::getFactory().getEncoderRecordingSettings(
+                    m_selFormat, m_pConfig);
     if (settings->usesQualitySlider()) {
         updateTextQuality();
     }
@@ -379,10 +386,11 @@ void DlgPrefRecord::saveMetaData()
     m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "Author"), ConfigValue(LineEditAuthor->text()));
     m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "Album"), ConfigValue(LineEditAlbum->text()));
 }
-void DlgPrefRecord::saveEncoding()
-{
-    EncoderSettingsPointer settings = EncoderFactory::getFactory().getEncoderSettings(m_selFormat, m_pConfig);
 
+void DlgPrefRecord::saveEncoding() {
+    EncoderRecordingSettingsPointer settings =
+            EncoderFactory::getFactory().getEncoderRecordingSettings(
+                    m_selFormat, m_pConfig);
     m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "Encoding"),
         ConfigValue(m_selFormat.internalName));
 

--- a/src/preferences/dialog/dlgprefrecord.h
+++ b/src/preferences/dialog/dlgprefrecord.h
@@ -42,7 +42,7 @@ class DlgPrefRecord : public DlgPreferencePage, public Ui::DlgPrefRecordDlg  {
     void retainSizeFor(QWidget* widget);
     inline void showWidget(QWidget* widget);
     inline void hideWidget(QWidget* widget);
-    void setupEncoderUI(Encoder::Format selformat);
+    void setupEncoderUI();
     void loadMetaData();
     void updateTextQuality();
     void updateTextCompression();


### PR DESCRIPTION
Currently all encoders are initialized with the recording preferences. 
For broadcast, the settings are overwritten with the actual settings. 
This PR fixes this, providing a better separation of Mixxx features. 