### PR TITLE
Include wavpack/wavpack.h for WavpackContext

### DIFF
--- a/src/sources/soundsourcewv.cpp
+++ b/src/sources/soundsourcewv.cpp
@@ -64,17 +64,17 @@ SoundSource::OpenResult SoundSourceWV::tryOpen(
         return OpenResult::Failed;
     }
 
-    setChannelCount(WavpackGetReducedChannels(m_wpc));
-    setSampleRate(WavpackGetSampleRate(m_wpc));
+    setChannelCount(WavpackGetReducedChannels(static_cast<WavpackContext*>(m_wpc)));
+    setSampleRate(WavpackGetSampleRate(static_cast<WavpackContext*>(m_wpc)));
     initFrameIndexRangeOnce(
             mixxx::IndexRange::forward(
                     0,
-                    WavpackGetNumSamples(m_wpc)));
+                    WavpackGetNumSamples(static_cast<WavpackContext*>(m_wpc))));
 
-    if (WavpackGetMode(m_wpc) & MODE_FLOAT) {
+    if (WavpackGetMode(static_cast<WavpackContext*>(m_wpc)) & MODE_FLOAT) {
         m_sampleScaleFactor = CSAMPLE_PEAK;
     } else {
-        const int bitsPerSample = WavpackGetBitsPerSample(m_wpc);
+        const int bitsPerSample = WavpackGetBitsPerSample(static_cast<WavpackContext*>(m_wpc));
         if ((bitsPerSample >= 8) && (bitsPerSample <= 32)) {
             // Range of signed sample values: [-2 ^ (bitsPerSample - 1), 2 ^ (bitsPerSample - 1) - 1]
             const uint32_t absSamplePeak = 1u << (bitsPerSample - 1);
@@ -96,7 +96,7 @@ SoundSource::OpenResult SoundSourceWV::tryOpen(
 
 void SoundSourceWV::close() {
     if (m_wpc) {
-        WavpackCloseFile(m_wpc);
+        WavpackCloseFile(static_cast<WavpackContext*>(m_wpc));
         m_wpc = nullptr;
     }
     if (m_pWVFile) {
@@ -116,13 +116,13 @@ ReadableSampleFrames SoundSourceWV::readSampleFramesClamped(
     const SINT firstFrameIndex = writableSampleFrames.frameIndexRange().start();
 
     if (m_curFrameIndex != firstFrameIndex) {
-        if (WavpackSeekSample(m_wpc, firstFrameIndex)) {
+        if (WavpackSeekSample(static_cast<WavpackContext*>(m_wpc), firstFrameIndex)) {
             m_curFrameIndex = firstFrameIndex;
         } else {
             kLogger.warning()
                     << "Could not seek to first frame index"
                     << firstFrameIndex;
-            m_curFrameIndex = WavpackGetSampleIndex(m_wpc);
+            m_curFrameIndex = WavpackGetSampleIndex(static_cast<WavpackContext*>(m_wpc));
             return ReadableSampleFrames(IndexRange::between(m_curFrameIndex, m_curFrameIndex));
         }
     }
@@ -133,12 +133,12 @@ ReadableSampleFrames SoundSourceWV::readSampleFramesClamped(
     static_assert(sizeof(CSAMPLE) == sizeof(int32_t),
             "CSAMPLE and int32_t must have the same size");
     CSAMPLE* pOutputBuffer = writableSampleFrames.writableData();
-    SINT unpackCount = WavpackUnpackSamples(m_wpc,
+    SINT unpackCount = WavpackUnpackSamples(static_cast<WavpackContext*>(m_wpc),
             reinterpret_cast<int32_t*>(pOutputBuffer),
             numberOfFramesTotal);
     DEBUG_ASSERT(unpackCount >= 0);
     DEBUG_ASSERT(unpackCount <= numberOfFramesTotal);
-    if (!(WavpackGetMode(m_wpc) & MODE_FLOAT)) {
+    if (!(WavpackGetMode(static_cast<WavpackContext*>(m_wpc)) & MODE_FLOAT)) {
         // signed integer -> float
         const SINT sampleCount = frames2samples(unpackCount);
         for (SINT i = 0; i < sampleCount; ++i) {

--- a/src/sources/soundsourcewv.h
+++ b/src/sources/soundsourcewv.h
@@ -6,8 +6,6 @@
 
 class QFile;
 
-typedef void WavpackContext;
-
 namespace mixxx {
 
 class SoundSourceWV : public SoundSource {
@@ -35,7 +33,13 @@ class SoundSourceWV : public SoundSource {
             OpenMode mode,
             const OpenParams& params) override;
 
-    WavpackContext* m_wpc;
+    // A WavpackContext* type
+    // we cannot use the type directly, because it has 
+    // changing definitions with different wavpack.h versions. 
+    // wavpack.h can't be included here, bacause it has concurrent definitions 
+    // with other decoder's header.     
+    void* m_wpc;
+ 
     CSAMPLE m_sampleScaleFactor;
     QFile* m_pWVFile;
     QFile* m_pWVCFile;


### PR DESCRIPTION
Depending on the Wavpack version, WavpackContext is defined as "void" or "struct WavpackContext".
Clang build aborts with an error if that does not match which has happened here: 
https://github.com/mixxxdj/mixxx/pull/2414