### PR TITLE
Add extra_metadata flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ language: c++
 env:
   global:
     # For SCons builds
-    - SCONSFLAGS="test=1 mad=1 faad=1 opus=1 modplug=1 wv=1 hss1394=0 virtualize=0 debug_assertions_fatal=1 verbose=0"
+    - SCONSFLAGS="test=1 mad=1 faad=1 opus=1 modplug=1 wv=1 hss1394=0 extra_metadata=1 virtualize=0 debug_assertions_fatal=1 verbose=0"
     # For CMake builds
-    - CMAKEFLAGS="-DMAD=ON -DFAAD=ON -DOPUS=ON -DMODPLUG=ON -DWAVPACK=ON -DHSS1394=OFF"
+    - CMAKEFLAGS="-DMAD=ON -DFAAD=ON -DOPUS=ON -DMODPLUG=ON -DWAVPACK=ON -DHSS1394=OFF -DEXTRA_METADATA=ON"
     - GTEST_COLOR=1
     - CTEST_OUTPUT_ON_FAILURE=1
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1662,6 +1662,12 @@ if(COREAUDIO)
   target_include_directories(mixxx-lib SYSTEM PUBLIC lib/apple)
 endif()
 
+# Extra Metadata support
+option(EXTRA_METADATA "Extra Metadata support" OFF)
+if(EXTRA_METADATA)
+    target_compile_definitions(mixxx-lib PUBLIC __EXTRA_METADATA__)
+endif()
+
 # FAAD AAC audio file decoder plugin
 find_package(MP4)
 find_package(MP4v2)

--- a/SConstruct
+++ b/SConstruct
@@ -58,6 +58,7 @@ available_features = [features.Mad,
                       features.Lilv,
                       features.Battery,
                       features.QtKeychain,
+                      features.ExtraMetadata,
 
                       # "Features" of dubious quality
                       features.PerfTools,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ for:
 
   build_script:
     # ffmpeg=1 requires FFmpeg 4.0, but Ubuntu 18.04 still provides only FFmpeg 3.4.x
-    - scons -j4 test=1 mad=1 faad=1 opus=1 modplug=1 wv=1 hss1394=0 virtualize=0 debug_assertions_fatal=1 verbose=0 localecompare=1
+    - scons -j4 test=1 mad=1 faad=1 opus=1 modplug=1 wv=1 hss1394=0 extra_metadata=1 virtualize=0 debug_assertions_fatal=1 verbose=0 localecompare=1
 
   test_script:
     - xvfb-run -- ./mixxx-test --gtest_output=xml:test_results.xml

--- a/build/features.py
+++ b/build/features.py
@@ -6,6 +6,28 @@ from .mixxx import Feature
 import SCons.Script as SCons
 from . import depends
 
+
+class ExtraMetadata(Feature):
+    def description(self):
+        return "Extra Metadata support (experimental)"
+
+    def enabled(self, build):
+        build.flags['extra_metadata'] = util.get_flags(build.env, 'extra_metadata', 0)
+        if int(build.flags['extra_metadata']):
+            return True
+        return False
+
+    def add_options(self, build, vars):
+        vars.Add('extra_metadata',
+                     'Set to 1 to enable experimental extra metadata support.', 0)
+
+    def configure(self, build, conf):
+        build.env.Append(CPPDEFINES='__EXTRA_METADATA__')
+
+    def sources(self, build):
+        return []
+
+
 class HSS1394(Feature):
     def description(self):
         return "HSS1394 MIDI device support"


### PR DESCRIPTION
Adds an additional build flag and enable it for CI builds to ensure that there are no build-time errors in @uklotzde's metadata code.