### PR TITLE
Fix debug assertion in AcoustidClient / Fetch multiple recordings from MusicBrainz

### DIFF
--- a/src/musicbrainz/acoustidclient.h
+++ b/src/musicbrainz/acoustidclient.h
@@ -47,7 +47,7 @@ class AcoustidClient : public QObject {
     void cancelAll();
 
   signals:
-    void finished(int id, const QString& mbid);
+    void finished(int id, QStringList mbRecordingIds);
     void networkError(int httpStatus, QString app, QString message, int code);
 
   private slots:

--- a/src/musicbrainz/acoustidclient.h
+++ b/src/musicbrainz/acoustidclient.h
@@ -51,12 +51,14 @@ class AcoustidClient : public QObject {
     void networkError(int httpStatus, QString app, QString message, int code);
 
   private slots:
-    void requestFinished();
+    void onReplyFinished();
 
   private:
+    void cancelPendingReply(QNetworkReply* reply);
+
     QNetworkAccessManager m_network;
     NetworkTimeouts m_timeouts;
-    QMap<QNetworkReply*, int> m_requests;
+    QMap<QNetworkReply*, int> m_pendingReplies;
 };
 
 #endif // ACOUSTIDCLIENT_H

--- a/src/musicbrainz/musicbrainzclient.cpp
+++ b/src/musicbrainz/musicbrainzclient.cpp
@@ -58,7 +58,7 @@ void MusicBrainzClient::start(int id, QStringList recordingIds) {
 void MusicBrainzClient::nextRequest(int id, Request request) {
     DEBUG_ASSERT(!m_requests.contains(id));
     if (request.recordingIds.isEmpty()) {
-        emit finished(id, std::move(request.results));
+        emit finished(id, uniqueResults(request.results));
         return;
     }
     const auto recordingId = request.recordingIds.takeFirst();

--- a/src/musicbrainz/musicbrainzclient.cpp
+++ b/src/musicbrainz/musicbrainzclient.cpp
@@ -17,13 +17,17 @@
 #include <QJsonDocument>
 
 #include "musicbrainz/musicbrainzclient.h"
+
+#include "util/logger.h"
 #include "util/version.h"
 #include "defs_urls.h"
 
 
 namespace {
 
-const QString kTrackUrl = "http://musicbrainz.org/ws/2/recording/";
+mixxx::Logger kLogger("MusicBrainzClient");
+
+const QString kRecordingUrl = "https://musicbrainz.org/ws/2/recording/";
 const QString kDateRegex = "^[12]\\d{3}";
 constexpr int kDefaultTimeout = 5000; // msec
 constexpr int kDefaultErrorCode = 0;
@@ -47,55 +51,75 @@ MusicBrainzClient::MusicBrainzClient(QObject* parent)
                    m_timeouts(kDefaultTimeout, this) {
 }
 
-void MusicBrainzClient::start(int id, const QString& mbid) {
-    typedef QPair<QString, QString> Param;
+void MusicBrainzClient::start(int id, QStringList recordingIds) {
+    nextRequest(id, Request(std::move(recordingIds)));
+}
 
+void MusicBrainzClient::nextRequest(int id, Request request) {
+    DEBUG_ASSERT(!m_requests.contains(id));
+    if (request.recordingIds.isEmpty()) {
+        emit finished(id, std::move(request.results));
+        return;
+    }
+    const auto recordingId = request.recordingIds.takeFirst();
+
+    typedef QPair<QString, QString> Param;
     QList<Param> parameters;
     parameters << Param("inc", "artists+releases+media");
 
+    QUrl url(kRecordingUrl + recordingId);
     QUrlQuery query;
     query.setQueryItems(parameters);
-    QUrl url(kTrackUrl + mbid);
     url.setQuery(query);
-    qDebug() << "MusicBrainzClient GET request:" << url.toString();
+    kLogger.debug()
+            << "GET request:"
+            << url.toString();
     QNetworkRequest req(url);
     // http://musicbrainz.org/doc/XML_Web_Service/Rate_Limiting#Provide_meaningful_User-Agent_strings
     QString mixxxMusicBrainzId(Version::applicationName() + "/" + Version::version() + " ( " + MIXXX_WEBSITE_URL + " )");
     // HTTP request headers must be latin1.
     req.setRawHeader("User-Agent", mixxxMusicBrainzId.toLatin1());
     QNetworkReply* reply = m_network.get(req);
-    connect(reply, &QNetworkReply::finished, this, &MusicBrainzClient::requestFinished);
-    m_requests[reply] = id;
-
+    m_requests[id] = std::move(request);
+    m_replies[reply] = id;
+    connect(reply, &QNetworkReply::finished, this, &MusicBrainzClient::replyFinished);
     m_timeouts.addReply(reply);
 }
 
 void MusicBrainzClient::cancel(int id) {
-    QNetworkReply* reply = m_requests.key(id);
-    m_requests.remove(reply);
-    delete reply;
-}
-
-void MusicBrainzClient::cancelAll() {
-    auto requests = m_requests;
-    m_requests.clear();
-    for (auto it = requests.constBegin();
-         it != requests.constEnd(); ++it) {
-        delete it.key();
+    m_requests.remove(id);
+    QNetworkReply* reply = m_replies.key(id);
+    if (reply) {
+        reply->abort();
     }
 }
 
-void MusicBrainzClient::requestFinished() {
+void MusicBrainzClient::cancelAll() {
+    m_requests.clear();
+    auto replies = m_replies;
+    m_replies.clear();
+    for (auto it = replies.constBegin();
+         it != replies.constEnd(); ++it) {
+        it.key()->abort();
+    }
+}
+
+void MusicBrainzClient::replyFinished() {
     QNetworkReply* reply = qobject_cast<QNetworkReply*>(sender());
-    if (!reply)
+    if (!reply) {
         return;
-
+    }
     reply->deleteLater();
-    if (!m_requests.contains(reply))
-        return;
 
-    int id = m_requests.take(reply);
-    ResultList ret;
+    if (!m_replies.contains(reply)) {
+        return;
+    }
+    int id = m_replies.take(reply);
+
+    if (!m_requests.contains(id)) {
+        return;
+    }
+    Request request = m_requests.take(id);
 
     int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     QTextStream textReader(reply);
@@ -147,7 +171,7 @@ void MusicBrainzClient::requestFinished() {
                 ResultList tracks = parseTrack(reader);
                 for (const Result& track: tracks) {
                     if (!track.m_title.isEmpty()) {
-                        ret << track;
+                        request.results << track;
                     }
                 }
             }
@@ -159,7 +183,7 @@ void MusicBrainzClient::requestFinished() {
         }
         }
     }
-    emit(finished(id, uniqueResults(ret)));
+    nextRequest(id, request);
 }
 
 MusicBrainzClient::ResultList MusicBrainzClient::parseTrack(QXmlStreamReader& reader) {

--- a/src/musicbrainz/musicbrainzclient.h
+++ b/src/musicbrainz/musicbrainzclient.h
@@ -68,7 +68,7 @@ class MusicBrainzClient : public QObject {
 
     // Starts a request and returns immediately.  finished() will be emitted
     // later with the same ID.
-    void start(int id, const QString& mbid);
+    void start(int id, QStringList recordingIds);
     static void consumeCurrentElement(QXmlStreamReader& reader);
 
     // Cancels the request with the given ID.  Finished() will never be emitted
@@ -85,7 +85,7 @@ class MusicBrainzClient : public QObject {
     void networkError(int httpStatus, QString app, QString message, int code);
 
   private slots:
-    void requestFinished();
+    void replyFinished();
 
   private:
     struct Release {
@@ -110,9 +110,25 @@ class MusicBrainzClient : public QObject {
     static ResultList uniqueResults(const ResultList& results);
 
   private:
+    struct Request final {
+        Request() = default;
+        Request(const Request&) = default;
+        Request(Request&&) = default;
+        Request& operator=(const Request&) = default;
+        Request& operator=(Request&&) = default;
+        explicit Request(QStringList recordingIds)
+                : recordingIds(recordingIds) {
+        }
+        QStringList recordingIds;
+        ResultList results;
+    };
+
+    void nextRequest(int id, Request request);
+
     QNetworkAccessManager m_network;
     NetworkTimeouts m_timeouts;
-    QMap<QNetworkReply*, int> m_requests;
+    QMap<int, Request> m_requests;
+    QMap<QNetworkReply*, int> m_replies;
 };
 
 inline uint qHash(const MusicBrainzClient::Result& result) {

--- a/src/musicbrainz/network.cpp
+++ b/src/musicbrainz/network.cpp
@@ -50,24 +50,35 @@ NetworkTimeouts::NetworkTimeouts(int timeout_msec, QObject* parent)
 }
 
 void NetworkTimeouts::addReply(QNetworkReply* reply) {
-    if (m_timers.contains(reply))
+    if (!reply->isRunning() || m_timers.contains(reply)) {
         return;
+    }
 
-    connect(reply, &QNetworkReply::destroyed, this, &NetworkTimeouts::replyFinished);
-    connect(reply, &QNetworkReply::finished, this, &NetworkTimeouts::replyFinished);
+    connect(reply, &QNetworkReply::destroyed, this, &NetworkTimeouts::replyFinishedOrDestroyed);
+    connect(reply, &QNetworkReply::finished, this, &NetworkTimeouts::replyFinishedOrDestroyed);
     m_timers[reply] = startTimer(m_timeout_msec);
 }
 
-void NetworkTimeouts::replyFinished() {
-    QNetworkReply* reply = qobject_cast<QNetworkReply*>(sender());
-    if (m_timers.contains(reply)) {
+void NetworkTimeouts::removeReply(QNetworkReply* reply) {
+    if (reply && m_timers.contains(reply)) {
         killTimer(m_timers.take(reply));
     }
 }
 
+void NetworkTimeouts::replyFinishedOrDestroyed() {
+    QNetworkReply* reply = qobject_cast<QNetworkReply*>(sender());
+    removeReply(reply);
+}
+
 void NetworkTimeouts::timerEvent(QTimerEvent* e) {
-    QNetworkReply* reply = m_timers.key(e->timerId());
-    if (reply) {
-      reply->abort();
+    const int timerId = e->timerId();
+    killTimer(timerId); // oneshot
+    QNetworkReply* reply = m_timers.key(timerId);
+    if (!reply) {
+        return;
+    }
+    m_timers.remove(reply);
+    if (reply->isRunning()) {
+        reply->abort();
     }
 }

--- a/src/musicbrainz/network.h
+++ b/src/musicbrainz/network.h
@@ -6,7 +6,7 @@
  *  as published by Sam Hocevar.                                             *
  *  See http://www.wtfpl.net/ for more details.                              *
  *****************************************************************************/
-    
+
 #ifndef NETWORK_H
 #define NETWORK_H
 
@@ -19,28 +19,29 @@ class NetworkAccessManager : public QNetworkAccessManager {
 
   public:
     NetworkAccessManager(QObject* parent = 0);
-  
+
   protected:
     QNetworkReply* createRequest(Operation op, const QNetworkRequest& request,
                                  QIODevice* outgoingData);
 };
-  
-  
+
+
 class NetworkTimeouts : public QObject {
     Q_OBJECT
-  
+
   public:
     NetworkTimeouts(int timeout_msec, QObject* parent = 0);
-  
+
     void addReply(QNetworkReply* reply);
+    void removeReply(QNetworkReply* reply);
     void setTimeout(int msec) { m_timeout_msec = msec; }
-  
+
   protected:
     void timerEvent(QTimerEvent* e);
-  
+
   private slots:
-    void replyFinished();
-  
+    void replyFinishedOrDestroyed();
+
   private:
     int m_timeout_msec;
     QMap<QNetworkReply*, int> m_timers;

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -22,7 +22,7 @@ TagFetcher::TagFetcher(QObject* parent)
             m_AcoustidClient(this),
             m_MusicbrainzClient(this) {
     connect(&m_AcoustidClient, &AcoustidClient::finished,
-            this, &TagFetcher::mbidFound);
+            this, &TagFetcher::mbRecordingIdsFound);
     connect(&m_MusicbrainzClient, &MusicBrainzClient::finished,
             this, &TagFetcher::tagsFetched);
     connect(&m_AcoustidClient, &AcoustidClient::networkError,
@@ -84,21 +84,21 @@ void TagFetcher::fingerprintFound(int index) {
     m_AcoustidClient.start(index, fingerprint, ptrack->getDurationInt());
 }
 
-void TagFetcher::mbidFound(int index, const QString& mbid) {
+void TagFetcher::mbRecordingIdsFound(int index, QStringList mbRecordingIds) {
     if (index >= m_tracks.count()) {
         return;
     }
 
     const TrackPointer pTrack = m_tracks[index];
 
-    if (mbid.isEmpty()) {
+    if (mbRecordingIds.isEmpty()) {
         emit(resultAvailable(pTrack, QList<TrackPointer>()));
         return;
     }
 
     emit fetchProgress(tr("Downloading Metadata"));
     //qDebug() << "start to fetch tags from MB";
-    m_MusicbrainzClient.start(index, mbid);
+    m_MusicbrainzClient.start(index, mbRecordingIds);
 }
 
 void TagFetcher::tagsFetched(int index, const MusicBrainzClient::ResultList& results) {

--- a/src/musicbrainz/tagfetcher.h
+++ b/src/musicbrainz/tagfetcher.h
@@ -40,7 +40,7 @@ class TagFetcher : public QObject {
 
   private slots:
     void fingerprintFound(int index);
-    void mbidFound(int index, const QString& mbid);
+    void mbRecordingIdsFound(int index, QStringList mbRecordingIds);
     void tagsFetched(int index, const MusicBrainzClient::ResultList& result);
 
   private:


### PR DESCRIPTION
Fix a debug assertion if the track is recognized (or not?), but no MusicBrainz recordings have been found. In this case the "recordings" key/value pair is missing, which previously triggered a debug assertion.