### PR TITLE
Fix assertion when quantize a cue point near the end

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -1575,7 +1575,7 @@ double CueControl::getQuantizedCurrentPosition() {
     double currentPos = sampleOfTrack.current;
     const double total = sampleOfTrack.total;
 
-    // Note: currentPos can be passed the end of the track, in the padded
+    // Note: currentPos can be past the end of the track, in the padded
     // silence of the last buffer. This position might be not reachable in
     // a future runs, depending on the buffering.
     currentPos = math_min(currentPos, total);
@@ -1586,7 +1586,7 @@ double CueControl::getQuantizedCurrentPosition() {
     }
 
     double closestBeat = m_pClosestBeat->get();
-    // Note: closestBeat can be an interpolated beat passed the end of the track,
+    // Note: closestBeat can be an interpolated beat past the end of the track,
     // which cannot be reached.
     if (closestBeat != -1.0 && closestBeat <= total) {
         return closestBeat;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -947,6 +947,10 @@ void EngineBuffer::processTrackLocked(
                     m_pReadAheadManager->getFilePlaypositionFromLog(
                             m_filepos_play, samplesRead);
         }
+        // Note: The last buffer of a track is padded with silence.
+        // This silence is played together with the last samples in the last 
+        // callback and the m_filepos_play is advanced behind the end of the track. 
+          
         if (m_bCrossfadeReady) {
            SampleUtil::linearCrossfadeBuffers(
                     pOutput, m_pCrossfadeBuffer, pOutput, iBufferSize);


### PR DESCRIPTION
This fixes the false positive assertion:

```
Critical [Main]: DEBUG ASSERT: "cuePos <= total" in function double CueControl::quantizeCuePoint(double, CueControl::QuantizeMode) at /tmp/mixxx/src/engine/controls/cuecontrol.cpp:1641
```