### PR TITLE
Allow running multiple tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ jobs:
         CMAKEFLAGS_EXTRA="-DLOCALECOMPARE=OFF -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5/"
         DISPLAY=:99.0
         CMAKE_BUILD_PARALLEL_LEVEL=4
-        CTEST_PARALLEL_LEVEL=4
+        CTEST_PARALLEL_LEVEL=2
       before_install:
         - brew install ccache
         - export PATH="/usr/local/opt/ccache/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ jobs:
         CMAKEFLAGS_EXTRA="-DLOCALECOMPARE=OFF -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5/"
         DISPLAY=:99.0
         CMAKE_BUILD_PARALLEL_LEVEL=4
-        CTEST_PARALLEL_LEVEL=2
+        CTEST_PARALLEL_LEVEL=1
       before_install:
         - brew install ccache
         - export PATH="/usr/local/opt/ccache/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
       env: CMAKEFLAGS_EXTRA="-DLOCALECOMPARE=ON"
       before_install:
         - export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
+        - export CTEST_PARALLEL_LEVEL="$(nproc)"
         - export PATH="$HOME/.local/bin:$PATH"
         - pip install --user cmake
         - cmake --version
@@ -68,7 +69,7 @@ jobs:
         - sudo env "PATH=$PATH" cmake --build . --target install
       script:
         # Run tests and benchmarks
-        - cmake --build . --target test
+        - ctest
         - cmake --build . --target benchmark
 
     - name: OSX/clang/SCons build
@@ -123,6 +124,7 @@ jobs:
         CMAKEFLAGS_EXTRA="-DLOCALECOMPARE=OFF -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5/"
         DISPLAY=:99.0
         CMAKE_BUILD_PARALLEL_LEVEL=4
+        CTEST_PARALLEL_LEVEL=4
       before_install:
         - brew install ccache
         - export PATH="/usr/local/opt/ccache/bin:$PATH"
@@ -136,7 +138,7 @@ jobs:
         - sudo cmake --build . --target install
       script:
         # Run tests and benchmarks
-        - cmake --build . --target test
+        - ctest
         - cmake --build . --target benchmark
       before_cache:
         # Avoid indefinite cache growth

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -4,36 +4,6 @@
 
 namespace {
 
-bool QDir_removeRecursively(const QDir& dir) {
-    bool result = true;
-    if (dir.exists()) {
-        foreach (QFileInfo info, dir.entryInfoList(QDir::NoDotAndDotDot |
-                                                   QDir::System |
-                                                   QDir::Hidden  |
-                                                   QDir::AllDirs |
-                                                   QDir::Files,
-                                                   QDir::DirsFirst)) {
-            if (info.isDir()) {
-                // recursively
-                result = QDir_removeRecursively(QDir(info.absoluteFilePath()));
-            } else {
-                result = QFile::remove(info.absoluteFilePath());
-            }
-            if (!result) {
-                return result;
-            }
-        }
-        result = dir.rmdir(dir.absolutePath());
-    }
-    return result;
-}
-
-QString makeTestDir() {
-    QDir parent("src/test");
-    parent.mkdir("test_data");
-    return parent.absoluteFilePath("test_data");
-}
-
 QString makeTestConfigFile(const QString& path) {
     QFile test_cfg(path);
     test_cfg.open(QIODevice::ReadWrite);
@@ -60,11 +30,10 @@ MixxxTest::ApplicationScope::~ApplicationScope() {
     s_pApplication.reset();
 }
 
-MixxxTest::MixxxTest()
-        // This directory has to be deleted later to clean up the test env.
-        : m_testDataDir(makeTestDir()),
-          m_pConfig(new UserSettings(makeTestConfigFile(
-              m_testDataDir.filePath("test.cfg")))) {
+MixxxTest::MixxxTest() {
+    EXPECT_TRUE(m_testDataDir.isValid());
+    m_pConfig = UserSettingsPointer(new UserSettings(
+        makeTestConfigFile(getTestDataDir().filePath("test.cfg"))));
     ControlDoublePrivate::setUserConfig(m_pConfig);
 }
 
@@ -80,9 +49,4 @@ MixxxTest::~MixxxTest() {
         ConfigKey key = pCDP->getKey();
         delete pCDP->getCreatorCO();
     }
-
-    // recursively delete all config files used for the test.
-    // TODO(kain88) --
-    //     switch to use QDir::removeRecursively() once we switched to Qt5.
-    QDir_removeRecursively(m_testDataDir);
 }

--- a/src/test/mixxxtest.h
+++ b/src/test/mixxxtest.h
@@ -5,6 +5,7 @@
 
 #include <QDir>
 #include <QTemporaryFile>
+#include <QTemporaryDir>
 #include <QScopedPointer>
 
 #include "mixxxapplication.h"
@@ -61,13 +62,13 @@ class MixxxTest : public testing::Test {
     }
 
     QDir getTestDataDir() const {
-        return m_testDataDir;
+        return m_testDataDir.path();
     }
 
   private:
     static QScopedPointer<MixxxApplication> s_pApplication;
 
-    const QDir m_testDataDir;
+    QTemporaryDir m_testDataDir;
 
   protected:
     UserSettingsPointer m_pConfig;


### PR DESCRIPTION
On multi-core CPUs when can reduce the time necessary to run tests by running multiple in parallel.
Previously, this didn't work because each test used the same in-tree config directory. By switching to `QTemporaryDir`, this should now be possible.