### PR TITLE
Adding Practice mode

### DIFF
--- a/src/track/playcounter.cpp
+++ b/src/track/playcounter.cpp
@@ -3,7 +3,7 @@
 PlayCounter::PlayCounter(int timesPlayed)
         : m_iTimesPlayed(timesPlayed),
           m_bPlayed(false) {
-    m_pTrainingmodeEnabled = new ControlProxy("[TrainingMode]", "enabled");
+    m_pTrainingmodeEnabled = std::make_shared<ControlProxy>("[TrainingMode]", "enabled");
 }
 
 void PlayCounter::setPlayedAndUpdateTimesPlayed(bool bPlayed) {

--- a/src/track/playcounter.cpp
+++ b/src/track/playcounter.cpp
@@ -1,7 +1,20 @@
 #include "track/playcounter.h"
 
+PlayCounter::PlayCounter(int timesPlayed)
+        : m_iTimesPlayed(timesPlayed),
+          m_bPlayed(false) {
+    m_pTrainingmodeEnabled = new ControlProxy("[TrainingMode]", "enabled");
+}
 
 void PlayCounter::setPlayedAndUpdateTimesPlayed(bool bPlayed) {
+    // if we are in TrainingMode mode, the play count should not be changed
+    // so we can return here
+    bool trainingmode_enabled = m_pTrainingmodeEnabled->toBool();
+    if (trainingmode_enabled) {
+        m_bPlayed = bPlayed;
+        return;
+    }
+
     // This should never happen if the play counter is used
     // as intended! But since this class provides independent
     // setters for both members we need to check and re-establish
@@ -11,6 +24,7 @@ void PlayCounter::setPlayedAndUpdateTimesPlayed(bool bPlayed) {
         // not become negative!
         m_iTimesPlayed = 1;
     }
+
     if (bPlayed) {
         // Increment always
         ++m_iTimesPlayed;

--- a/src/track/playcounter.cpp
+++ b/src/track/playcounter.cpp
@@ -3,7 +3,7 @@
 PlayCounter::PlayCounter(int timesPlayed)
         : m_iTimesPlayed(timesPlayed),
           m_bPlayed(false) {
-    m_pPracticemodeEnabled = std::make_shared<ControlProxy>("[PracticeMode]", "enabled");
+    m_pPracticemodeEnabled = std::make_shared<ControlProxy>("[Library]", "practice_mode");
 }
 
 void PlayCounter::setPlayedAndUpdateTimesPlayed(bool bPlayed) {

--- a/src/track/playcounter.cpp
+++ b/src/track/playcounter.cpp
@@ -3,14 +3,14 @@
 PlayCounter::PlayCounter(int timesPlayed)
         : m_iTimesPlayed(timesPlayed),
           m_bPlayed(false) {
-    m_pTrainingmodeEnabled = std::make_shared<ControlProxy>("[TrainingMode]", "enabled");
+    m_pPracticemodeEnabled = std::make_shared<ControlProxy>("[PracticeMode]", "enabled");
 }
 
 void PlayCounter::setPlayedAndUpdateTimesPlayed(bool bPlayed) {
-    // if we are in TrainingMode mode, the play count should not be changed
+    // if we are in PracticeMode mode, the play count should not be changed
     // so we can return here
-    bool trainingmode_enabled = m_pTrainingmodeEnabled->toBool();
-    if (trainingmode_enabled) {
+    bool practicemode_enabled = m_pPracticemodeEnabled->toBool();
+    if (practicemode_enabled) {
         m_bPlayed = bPlayed;
         return;
     }

--- a/src/track/playcounter.cpp
+++ b/src/track/playcounter.cpp
@@ -9,8 +9,7 @@ PlayCounter::PlayCounter(int timesPlayed)
 void PlayCounter::setPlayedAndUpdateTimesPlayed(bool bPlayed) {
     // if we are in PracticeMode mode, the play count should not be changed
     // so we can return here
-    bool practicemode_enabled = m_pPracticemodeEnabled->toBool();
-    if (practicemode_enabled) {
+    if (m_pPracticemodeEnabled->toBool()) {
         m_bPlayed = bPlayed;
         return;
     }

--- a/src/track/playcounter.h
+++ b/src/track/playcounter.h
@@ -4,11 +4,13 @@
 #include "control/controlproxy.h"
 #include "util/assert.h"
 
+#include "util/memory.h"
+
 // Counts the total number of times a track has been played
 // and if the track has been played during the current session.
 class PlayCounter {
 public:
-  explicit PlayCounter(int timesPlayed = 0);
+    explicit PlayCounter(int timesPlayed = 0);
 
     // Sets total number of times a track has been played
     void setTimesPlayed(int iTimesPlayed) {
@@ -37,7 +39,7 @@ public:
 private:
     int m_iTimesPlayed;
     bool m_bPlayed;
-    ControlProxy* m_pTrainingmodeEnabled;
+    std::shared_ptr<ControlProxy> m_pTrainingmodeEnabled;
 };
 
 bool operator==(const PlayCounter& lhs, const PlayCounter& rhs);

--- a/src/track/playcounter.h
+++ b/src/track/playcounter.h
@@ -39,7 +39,7 @@ public:
 private:
     int m_iTimesPlayed;
     bool m_bPlayed;
-    std::shared_ptr<ControlProxy> m_pTrainingmodeEnabled;
+    std::shared_ptr<ControlProxy> m_pPracticemodeEnabled;
 };
 
 bool operator==(const PlayCounter& lhs, const PlayCounter& rhs);

--- a/src/track/playcounter.h
+++ b/src/track/playcounter.h
@@ -1,22 +1,19 @@
 #ifndef MIXXX_PLAYCOUNTER_H
 #define MIXXX_PLAYCOUNTER_H
 
+#include "control/controlproxy.h"
 #include "util/assert.h"
-
 
 // Counts the total number of times a track has been played
 // and if the track has been played during the current session.
 class PlayCounter {
 public:
-    explicit PlayCounter(int timesPlayed = 0):
-        m_iTimesPlayed(timesPlayed),
-        m_bPlayed(false) {
-    }
+  explicit PlayCounter(int timesPlayed = 0);
 
-    // Sets total number of times a track has been played
-    void setTimesPlayed(int iTimesPlayed) {
-        DEBUG_ASSERT(0 <= iTimesPlayed);
-        m_iTimesPlayed = iTimesPlayed;
+  // Sets total number of times a track has been played
+  void setTimesPlayed(int iTimesPlayed) {
+      DEBUG_ASSERT(0 <= iTimesPlayed);
+      m_iTimesPlayed = iTimesPlayed;
     }
     // Returns the total number of times a track has been played
     int getTimesPlayed() const {
@@ -40,6 +37,7 @@ public:
 private:
     int m_iTimesPlayed;
     bool m_bPlayed;
+    ControlProxy* m_pTrainingmodeEnabled;
 };
 
 bool operator==(const PlayCounter& lhs, const PlayCounter& rhs);

--- a/src/track/playcounter.h
+++ b/src/track/playcounter.h
@@ -10,10 +10,10 @@ class PlayCounter {
 public:
   explicit PlayCounter(int timesPlayed = 0);
 
-  // Sets total number of times a track has been played
-  void setTimesPlayed(int iTimesPlayed) {
-      DEBUG_ASSERT(0 <= iTimesPlayed);
-      m_iTimesPlayed = iTimesPlayed;
+    // Sets total number of times a track has been played
+    void setTimesPlayed(int iTimesPlayed) {
+        DEBUG_ASSERT(0 <= iTimesPlayed);
+        m_iTimesPlayed = iTimesPlayed;
     }
     // Returns the total number of times a track has been played
     int getTimesPlayed() const {

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -362,6 +362,18 @@ void WMainMenuBar::initialize() {
     pOptionsMenu->addAction(pOptionsBroadcasting);
 #endif
 
+    // TrainingMode
+    m_pConfigTrainingmodeEnabled = new ControlObject(ConfigKey("[TrainingMode]", "enabled"));
+    QString TrainingmodeTitle = tr("Enable Training Mode");
+    QString TrainingmodeText = tr("In training mode the play counter will not be increased");
+    auto pOptionsTrainingmode = new QAction(TrainingmodeTitle, this);
+    pOptionsTrainingmode->setCheckable(true);
+    pOptionsTrainingmode->setChecked(false);
+    pOptionsTrainingmode->setStatusTip(TrainingmodeText);
+    pOptionsTrainingmode->setWhatsThis(buildWhatsThis(TrainingmodeTitle, TrainingmodeText));
+    connect(pOptionsTrainingmode, SIGNAL(triggered(bool)), this, SLOT(toggleTrainingmode(bool)));
+    pOptionsMenu->addAction(pOptionsTrainingmode);
+
     pOptionsMenu->addSeparator();
 
     QString keyboardShortcutTitle = tr("Enable &Keyboard Shortcuts");
@@ -583,6 +595,10 @@ void WMainMenuBar::initialize() {
 
     pHelpMenu->addAction(pHelpAboutApp);
     addMenu(pHelpMenu);
+}
+
+void WMainMenuBar::toggleTrainingmode(bool toggle) {
+    m_pConfigTrainingmodeEnabled->set(toggle ? 1.0 : 0.0);
 }
 
 void WMainMenuBar::onLibraryScanStarted() {

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -363,7 +363,7 @@ void WMainMenuBar::initialize() {
 #endif
 
     // PracticeMode
-    m_pConfigPracticemodeEnabled = std::make_unique<ControlObject>(ConfigKey("[PracticeMode]", "enabled"));
+    m_pConfigPracticemodeEnabled = std::make_unique<ControlObject>(ConfigKey("[Library]", "practice_mode"));
     QString PracticemodeTitle = tr("Enable Practice Mode");
     QString PracticemodeText = tr("In practice mode the play counter will not be increased");
     auto pOptionsPracticemode = make_parented<QAction>(PracticemodeTitle, this);

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -362,17 +362,17 @@ void WMainMenuBar::initialize() {
     pOptionsMenu->addAction(pOptionsBroadcasting);
 #endif
 
-    // TrainingMode
-    m_pConfigTrainingmodeEnabled = std::make_unique<ControlObject>(ConfigKey("[TrainingMode]", "enabled"));
-    QString TrainingmodeTitle = tr("Enable Training Mode");
-    QString TrainingmodeText = tr("In training mode the play counter will not be increased");
-    auto pOptionsTrainingmode = make_parented<QAction>(TrainingmodeTitle, this);
-    pOptionsTrainingmode->setCheckable(true);
-    pOptionsTrainingmode->setChecked(false);
-    pOptionsTrainingmode->setStatusTip(TrainingmodeText);
-    pOptionsTrainingmode->setWhatsThis(buildWhatsThis(TrainingmodeTitle, TrainingmodeText));
-    connect(pOptionsTrainingmode, SIGNAL(triggered(bool)), this, SLOT(toggleTrainingmode(bool)));
-    pOptionsMenu->addAction(pOptionsTrainingmode);
+    // PracticeMode
+    m_pConfigPracticemodeEnabled = std::make_unique<ControlObject>(ConfigKey("[PracticeMode]", "enabled"));
+    QString PracticemodeTitle = tr("Enable Practice Mode");
+    QString PracticemodeText = tr("In practice mode the play counter will not be increased");
+    auto pOptionsPracticemode = make_parented<QAction>(PracticemodeTitle, this);
+    pOptionsPracticemode->setCheckable(true);
+    pOptionsPracticemode->setChecked(false);
+    pOptionsPracticemode->setStatusTip(PracticemodeText);
+    pOptionsPracticemode->setWhatsThis(buildWhatsThis(PracticemodeTitle, PracticemodeText));
+    connect(pOptionsPracticemode, SIGNAL(triggered(bool)), this, SLOT(togglePracticemode(bool)));
+    pOptionsMenu->addAction(pOptionsPracticemode);
 
     pOptionsMenu->addSeparator();
 
@@ -597,8 +597,8 @@ void WMainMenuBar::initialize() {
     addMenu(pHelpMenu);
 }
 
-void WMainMenuBar::toggleTrainingmode(bool toggle) {
-    m_pConfigTrainingmodeEnabled->set(toggle ? 1.0 : 0.0);
+void WMainMenuBar::togglePracticemode(bool toggle) {
+    m_pConfigPracticemodeEnabled->set(toggle ? 1.0 : 0.0);
 }
 
 void WMainMenuBar::onLibraryScanStarted() {

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -363,7 +363,7 @@ void WMainMenuBar::initialize() {
 #endif
 
     // TrainingMode
-    m_pConfigTrainingmodeEnabled = new ControlObject(ConfigKey("[TrainingMode]", "enabled"));
+    m_pConfigTrainingmodeEnabled = std::make_unique<ControlObject>(ConfigKey("[TrainingMode]", "enabled"));
     QString TrainingmodeTitle = tr("Enable Training Mode");
     QString TrainingmodeText = tr("In training mode the play counter will not be increased");
     auto pOptionsTrainingmode = make_parented<QAction>(TrainingmodeTitle, this);

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -67,14 +67,14 @@ WMainMenuBar::WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
 
 void WMainMenuBar::initialize() {
     // FILE MENU
-    QMenu* pFileMenu = make_parented<QMenu>(tr("&File"));
+    auto pFileMenu = make_parented<QMenu>(tr("&File"));
 
     QString loadTrackText = tr("Load Track to Deck &%1");
     QString loadTrackStatusText = tr("Loads a track in deck %1");
     QString openText = tr("Open");
     for (unsigned int deck = 0; deck < kMaxLoadToDeckActions; ++deck) {
         QString playerLoadStatusText = loadTrackStatusText.arg(QString::number(deck + 1));
-        QAction* pFileLoadSongToPlayer = make_parented<QAction>(
+        auto pFileLoadSongToPlayer = make_parented<QAction>(
             loadTrackText.arg(QString::number(deck + 1)), this);
 
         QString binding = m_pKbdConfig->getValue(
@@ -115,7 +115,7 @@ void WMainMenuBar::initialize() {
     addMenu(pFileMenu);
 
     // LIBRARY MENU
-    QMenu* pLibraryMenu = make_parented<QMenu>(tr("&Library"));
+    auto pLibraryMenu = make_parented<QMenu>(tr("&Library"));
 
     QString rescanTitle = tr("&Rescan Library");
     QString rescanText = tr("Rescans library folders for changes to tracks.");
@@ -283,10 +283,10 @@ void WMainMenuBar::initialize() {
     addMenu(pViewMenu);
 
     // OPTIONS MENU
-    QMenu* pOptionsMenu = make_parented<QMenu>(tr("&Options"));
+    auto pOptionsMenu = make_parented<QMenu>(tr("&Options"));
 
 #ifdef __VINYLCONTROL__
-    QMenu* pVinylControlMenu = make_parented<QMenu>(tr("&Vinyl Control"));
+    auto pVinylControlMenu = make_parented<QMenu>(tr("&Vinyl Control"));
     QString vinylControlText = tr(
             "Use timecoded vinyls on external turntables to control Mixxx");
 
@@ -416,7 +416,7 @@ void WMainMenuBar::initialize() {
 
     // DEVELOPER MENU
     if (CmdlineArgs::Instance().getDeveloper()) {
-        QMenu* pDeveloperMenu = make_parented<QMenu>(tr("&Developer"));
+        auto pDeveloperMenu = make_parented<QMenu>(tr("&Developer"));
 
         QString reloadSkinTitle = tr("&Reload Skin");
         QString reloadSkinText = tr("Reload the skin");
@@ -511,7 +511,7 @@ void WMainMenuBar::initialize() {
     addSeparator();
 
     // HELP MENU
-    QMenu* pHelpMenu = make_parented<QMenu>(tr("&Help"), this);
+    auto pHelpMenu = make_parented<QMenu>(tr("&Help"), this);
 
     QString externalLinkSuffix = " =>";
 

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -67,14 +67,14 @@ WMainMenuBar::WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
 
 void WMainMenuBar::initialize() {
     // FILE MENU
-    QMenu* pFileMenu = new QMenu(tr("&File"));
+    QMenu* pFileMenu = make_parented<QMenu>(tr("&File"));
 
     QString loadTrackText = tr("Load Track to Deck &%1");
     QString loadTrackStatusText = tr("Loads a track in deck %1");
     QString openText = tr("Open");
     for (unsigned int deck = 0; deck < kMaxLoadToDeckActions; ++deck) {
         QString playerLoadStatusText = loadTrackStatusText.arg(QString::number(deck + 1));
-        QAction* pFileLoadSongToPlayer = new QAction(
+        QAction* pFileLoadSongToPlayer = make_parented<QAction>(
             loadTrackText.arg(QString::number(deck + 1)), this);
 
         QString binding = m_pKbdConfig->getValue(
@@ -101,7 +101,7 @@ void WMainMenuBar::initialize() {
 
     QString quitTitle = tr("&Exit");
     QString quitText = tr("Quits Mixxx");
-    auto pFileQuit = new QAction(quitTitle, this);
+    auto pFileQuit = make_parented<QAction>(quitTitle, this);
     pFileQuit->setShortcut(
         QKeySequence(m_pKbdConfig->getValue(ConfigKey("[KeyboardShortcuts]", "FileMenu_Quit"),
                                                   tr("Ctrl+q"))));
@@ -115,11 +115,11 @@ void WMainMenuBar::initialize() {
     addMenu(pFileMenu);
 
     // LIBRARY MENU
-    QMenu* pLibraryMenu = new QMenu(tr("&Library"));
+    QMenu* pLibraryMenu = make_parented<QMenu>(tr("&Library"));
 
     QString rescanTitle = tr("&Rescan Library");
     QString rescanText = tr("Rescans library folders for changes to tracks.");
-    auto pLibraryRescan = new QAction(rescanTitle, this);
+    auto pLibraryRescan = make_parented<QAction>(rescanTitle, this);
     pLibraryRescan->setStatusTip(rescanText);
     pLibraryRescan->setWhatsThis(buildWhatsThis(rescanTitle, rescanText));
     pLibraryRescan->setCheckable(false);
@@ -134,7 +134,7 @@ void WMainMenuBar::initialize() {
 
     QString createPlaylistTitle = tr("Create &New Playlist");
     QString createPlaylistText = tr("Create a new playlist");
-    auto pLibraryCreatePlaylist = new QAction(createPlaylistTitle, this);
+    auto pLibraryCreatePlaylist = make_parented<QAction>(createPlaylistTitle, this);
     pLibraryCreatePlaylist->setShortcut(
         QKeySequence(m_pKbdConfig->getValue(
                 ConfigKey("[KeyboardShortcuts]", "LibraryMenu_NewPlaylist"),
@@ -148,7 +148,7 @@ void WMainMenuBar::initialize() {
 
     QString createCrateTitle = tr("Create New &Crate");
     QString createCrateText = tr("Create a new crate");
-    auto pLibraryCreateCrate = new QAction(createCrateTitle, this);
+    auto pLibraryCreateCrate = make_parented<QAction>(createCrateTitle, this);
     pLibraryCreateCrate->setShortcut(
         QKeySequence(m_pKbdConfig->getValue(ConfigKey("[KeyboardShortcuts]",
                                                   "LibraryMenu_NewCrate"),
@@ -168,14 +168,14 @@ void WMainMenuBar::initialize() {
     // Add an invisible suffix to the View item string so it doesn't string-equal "View" ,
     // and the magic menu items won't get injected.
     // https://bugs.launchpad.net/mixxx/+bug/1534292
-    QMenu* pViewMenu = new QMenu(tr("&View")+("\u200C"));
+    QMenu* pViewMenu = make_parented<QMenu>(tr("&View")+("\u200C"));
 
     // Skin Settings Menu
     QString mayNotBeSupported = tr("May not be supported on all skins.");
     QString showSkinSettingsTitle = tr("Show Skin Settings Menu");
     QString showSkinSettingsText = tr("Show the Skin Settings Menu of the currently selected Skin") +
             " " + mayNotBeSupported;
-    auto pViewShowSkinSettings = new QAction(showSkinSettingsTitle, this);
+    auto pViewShowSkinSettings = make_parented<QAction>(showSkinSettingsTitle, this);
     pViewShowSkinSettings->setCheckable(true);
     pViewShowSkinSettings->setShortcut(
         QKeySequence(m_pKbdConfig->getValue(
@@ -190,7 +190,7 @@ void WMainMenuBar::initialize() {
     QString showMicrophoneTitle = tr("Show Microphone Section");
     QString showMicrophoneText = tr("Show the microphone section of the Mixxx interface.") +
             " " + mayNotBeSupported;
-    auto pViewShowMicrophone = new QAction(showMicrophoneTitle, this);
+    auto pViewShowMicrophone = make_parented<QAction>(showMicrophoneTitle, this);
     pViewShowMicrophone->setCheckable(true);
     pViewShowMicrophone->setShortcut(
         QKeySequence(m_pKbdConfig->getValue(
@@ -205,7 +205,7 @@ void WMainMenuBar::initialize() {
     QString showVinylControlTitle = tr("Show Vinyl Control Section");
     QString showVinylControlText = tr("Show the vinyl control section of the Mixxx interface.") +
             " " + mayNotBeSupported;
-    auto pViewVinylControl = new QAction(showVinylControlTitle, this);
+    auto pViewVinylControl = make_parented<QAction>(showVinylControlTitle, this);
     pViewVinylControl->setCheckable(true);
     pViewVinylControl->setShortcut(
         QKeySequence(m_pKbdConfig->getValue(
@@ -220,7 +220,7 @@ void WMainMenuBar::initialize() {
     QString showPreviewDeckTitle = tr("Show Preview Deck");
     QString showPreviewDeckText = tr("Show the preview deck in the Mixxx interface.") +
             " " + mayNotBeSupported;
-    auto pViewShowPreviewDeck = new QAction(showPreviewDeckTitle, this);
+    auto pViewShowPreviewDeck = make_parented<QAction>(showPreviewDeckTitle, this);
     pViewShowPreviewDeck->setCheckable(true);
     pViewShowPreviewDeck->setShortcut(
         QKeySequence(m_pKbdConfig->getValue(
@@ -235,7 +235,7 @@ void WMainMenuBar::initialize() {
     QString showCoverArtTitle = tr("Show Cover Art");
     QString showCoverArtText = tr("Show cover art in the Mixxx interface.") +
             " " + mayNotBeSupported;
-    auto pViewShowCoverArt = new QAction(showCoverArtTitle, this);
+    auto pViewShowCoverArt = make_parented<QAction>(showCoverArtTitle, this);
     pViewShowCoverArt->setCheckable(true);
     pViewShowCoverArt->setShortcut(
         QKeySequence(m_pKbdConfig->getValue(
@@ -250,7 +250,7 @@ void WMainMenuBar::initialize() {
     QString maximizeLibraryTitle = tr("Maximize Library");
     QString maximizeLibraryText = tr("Maximize the track library to take up all the available screen space.") +
             " " + mayNotBeSupported;
-    auto pViewMaximizeLibrary = new QAction(maximizeLibraryTitle, this);
+    auto pViewMaximizeLibrary = make_parented<QAction>(maximizeLibraryTitle, this);
     pViewMaximizeLibrary->setCheckable(true);
     pViewMaximizeLibrary->setShortcut(
         QKeySequence(m_pKbdConfig->getValue(
@@ -267,7 +267,7 @@ void WMainMenuBar::initialize() {
 
     QString fullScreenTitle = tr("&Full Screen");
     QString fullScreenText = tr("Display Mixxx using the full screen");
-    auto pViewFullScreen = new QAction(fullScreenTitle, this);
+    auto pViewFullScreen = make_parented<QAction>(fullScreenTitle, this);
     pViewFullScreen->setShortcut(QKeySequence(QKeySequence::FullScreen));
     pViewFullScreen->setShortcutContext(Qt::ApplicationShortcut);
     pViewFullScreen->setCheckable(true);
@@ -283,16 +283,16 @@ void WMainMenuBar::initialize() {
     addMenu(pViewMenu);
 
     // OPTIONS MENU
-    QMenu* pOptionsMenu = new QMenu(tr("&Options"));
+    QMenu* pOptionsMenu = make_parented<QMenu>(tr("&Options"));
 
 #ifdef __VINYLCONTROL__
-    QMenu* pVinylControlMenu = new QMenu(tr("&Vinyl Control"));
+    QMenu* pVinylControlMenu = make_parented<QMenu>(tr("&Vinyl Control"));
     QString vinylControlText = tr(
             "Use timecoded vinyls on external turntables to control Mixxx");
 
     for (int i = 0; i < kMaximumVinylControlInputs; ++i) {
         QString vinylControlTitle = tr("Enable Vinyl Control &%1").arg(i + 1);
-        auto vc_checkbox = new QAction(vinylControlTitle, this);
+        auto vc_checkbox = make_parented<QAction>(vinylControlTitle, this);
         m_vinylControlEnabledActions.push_back(vc_checkbox);
 
         QString binding = m_pKbdConfig->getValue(
@@ -326,7 +326,7 @@ void WMainMenuBar::initialize() {
 
     QString recordTitle = tr("&Record Mix");
     QString recordText = tr("Record your mix to a file");
-    auto pOptionsRecord = new QAction(recordTitle, this);
+    auto pOptionsRecord = make_parented<QAction>(recordTitle, this);
     pOptionsRecord->setShortcut(
         QKeySequence(m_pKbdConfig->getValue(
                 ConfigKey("[KeyboardShortcuts]", "OptionsMenu_RecordMix"),
@@ -344,7 +344,7 @@ void WMainMenuBar::initialize() {
 #ifdef __BROADCAST__
     QString broadcastingTitle = tr("Enable Live &Broadcasting");
     QString broadcastingText = tr("Stream your mixes to a shoutcast or icecast server");
-    auto pOptionsBroadcasting = new QAction(broadcastingTitle, this);
+    auto pOptionsBroadcasting = make_parented<QAction>(broadcastingTitle, this);
     pOptionsBroadcasting->setShortcut(
             QKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]",
@@ -366,7 +366,7 @@ void WMainMenuBar::initialize() {
     m_pConfigTrainingmodeEnabled = new ControlObject(ConfigKey("[TrainingMode]", "enabled"));
     QString TrainingmodeTitle = tr("Enable Training Mode");
     QString TrainingmodeText = tr("In training mode the play counter will not be increased");
-    auto pOptionsTrainingmode = new QAction(TrainingmodeTitle, this);
+    auto pOptionsTrainingmode = make_parented<QAction>(TrainingmodeTitle, this);
     pOptionsTrainingmode->setCheckable(true);
     pOptionsTrainingmode->setChecked(false);
     pOptionsTrainingmode->setStatusTip(TrainingmodeText);
@@ -380,7 +380,7 @@ void WMainMenuBar::initialize() {
     QString keyboardShortcutText = tr("Toggles keyboard shortcuts on or off");
     bool keyboardShortcutsEnabled = m_pConfig->getValueString(
         ConfigKey("[Keyboard]", "Enabled")) == "1";
-    auto pOptionsKeyboard = new QAction(keyboardShortcutTitle, this);
+    auto pOptionsKeyboard = make_parented<QAction>(keyboardShortcutTitle, this);
     pOptionsKeyboard->setShortcut(
         QKeySequence(m_pKbdConfig->getValue(
                 ConfigKey("[KeyboardShortcuts]", "OptionsMenu_EnableShortcuts"),
@@ -399,7 +399,7 @@ void WMainMenuBar::initialize() {
 
     QString preferencesTitle = tr("&Preferences");
     QString preferencesText = tr("Change Mixxx settings (e.g. playback, MIDI, controls)");
-    auto pOptionsPreferences = new QAction(preferencesTitle, this);
+    auto pOptionsPreferences = make_parented<QAction>(preferencesTitle, this);
     pOptionsPreferences->setShortcut(
         QKeySequence(m_pKbdConfig->getValue(
                 ConfigKey("[KeyboardShortcuts]", "OptionsMenu_Preferences"),
@@ -416,11 +416,11 @@ void WMainMenuBar::initialize() {
 
     // DEVELOPER MENU
     if (CmdlineArgs::Instance().getDeveloper()) {
-        QMenu* pDeveloperMenu = new QMenu(tr("&Developer"));
+        QMenu* pDeveloperMenu = make_parented<QMenu>(tr("&Developer"));
 
         QString reloadSkinTitle = tr("&Reload Skin");
         QString reloadSkinText = tr("Reload the skin");
-        auto pDeveloperReloadSkin = new QAction(reloadSkinTitle, this);
+        auto pDeveloperReloadSkin = make_parented<QAction>(reloadSkinTitle, this);
         pDeveloperReloadSkin->setShortcut(
             QKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]", "OptionsMenu_ReloadSkin"),
@@ -434,7 +434,7 @@ void WMainMenuBar::initialize() {
 
         QString developerToolsTitle = tr("Developer &Tools");
         QString developerToolsText = tr("Opens the developer tools dialog");
-        auto pDeveloperTools = new QAction(developerToolsTitle, this);
+        auto pDeveloperTools = make_parented<QAction>(developerToolsTitle, this);
         pDeveloperTools->setShortcut(
             QKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperTools"),
@@ -453,7 +453,7 @@ void WMainMenuBar::initialize() {
         QString enableExperimentTitle = tr("Stats: &Experiment Bucket");
         QString enableExperimentToolsText = tr(
             "Enables experiment mode. Collects stats in the EXPERIMENT tracking bucket.");
-        auto pDeveloperStatsExperiment = new QAction(enableExperimentTitle, this);
+        auto pDeveloperStatsExperiment = make_parented<QAction>(enableExperimentTitle, this);
         pDeveloperStatsExperiment->setShortcut(
             QKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperStatsExperiment"),
@@ -471,7 +471,7 @@ void WMainMenuBar::initialize() {
         QString enableBaseTitle = tr("Stats: &Base Bucket");
         QString enableBaseToolsText = tr(
             "Enables base mode. Collects stats in the BASE tracking bucket.");
-        auto pDeveloperStatsBase = new QAction(enableBaseTitle, this);
+        auto pDeveloperStatsBase = make_parented<QAction>(enableBaseTitle, this);
         pDeveloperStatsBase->setShortcut(
             QKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperStatsBase"),
@@ -491,7 +491,7 @@ void WMainMenuBar::initialize() {
         QString scriptDebuggerText = tr("Enables the debugger during skin parsing");
         bool scriptDebuggerEnabled = m_pConfig->getValueString(
             ConfigKey("[ScriptDebugger]", "Enabled")) == "1";
-        auto pDeveloperDebugger = new QAction(scriptDebuggerTitle, this);
+        auto pDeveloperDebugger = make_parented<QAction>(scriptDebuggerTitle, this);
         pDeveloperDebugger->setShortcut(
             QKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]", "DeveloperMenu_EnableDebugger"),
@@ -511,13 +511,13 @@ void WMainMenuBar::initialize() {
     addSeparator();
 
     // HELP MENU
-    QMenu* pHelpMenu = new QMenu(tr("&Help"), this);
+    QMenu* pHelpMenu = make_parented<QMenu>(tr("&Help"), this);
 
     QString externalLinkSuffix = " =>";
 
     QString supportTitle = tr("&Community Support") + externalLinkSuffix;
     QString supportText = tr("Get help with Mixxx");
-    auto pHelpSupport = new QAction(supportTitle, this);
+    auto pHelpSupport = make_parented<QAction>(supportTitle, this);
     pHelpSupport->setStatusTip(supportText);
     pHelpSupport->setWhatsThis(buildWhatsThis(supportTitle, supportText));
     m_visitUrlMapper.setMapping(pHelpSupport, MIXXX_SUPPORT_URL);
@@ -548,7 +548,7 @@ void WMainMenuBar::initialize() {
 
     QString manualTitle = tr("&User Manual") + externalLinkSuffix;
     QString manualText = tr("Read the Mixxx user manual.");
-    auto pHelpManual = new QAction(manualTitle, this);
+    auto pHelpManual = make_parented<QAction>(manualTitle, this);
     pHelpManual->setStatusTip(manualText);
     pHelpManual->setWhatsThis(buildWhatsThis(manualTitle, manualText));
     m_visitUrlMapper.setMapping(pHelpManual, qManualUrl.toString());
@@ -557,7 +557,7 @@ void WMainMenuBar::initialize() {
 
     QString shortcutsTitle = tr("&Keyboard Shortcuts") + externalLinkSuffix;
     QString shortcutsText = tr("Speed up your workflow with keyboard shortcuts.");
-    auto pHelpShortcuts = new QAction(shortcutsTitle, this);
+    auto pHelpShortcuts = make_parented<QAction>(shortcutsTitle, this);
     pHelpShortcuts->setStatusTip(shortcutsText);
     pHelpShortcuts->setWhatsThis(buildWhatsThis(shortcutsTitle, shortcutsText));
     m_visitUrlMapper.setMapping(pHelpShortcuts, MIXXX_SHORTCUTS_URL);
@@ -566,7 +566,7 @@ void WMainMenuBar::initialize() {
 
     QString feedbackTitle = tr("Send Us &Feedback") + externalLinkSuffix;
     QString feedbackText = tr("Send feedback to the Mixxx team.");
-    auto pHelpFeedback = new QAction(feedbackTitle, this);
+    auto pHelpFeedback = make_parented<QAction>(feedbackTitle, this);
     pHelpFeedback->setStatusTip(feedbackText);
     pHelpFeedback->setWhatsThis(buildWhatsThis(feedbackTitle, feedbackText));
     m_visitUrlMapper.setMapping(pHelpFeedback, MIXXX_FEEDBACK_URL);
@@ -575,7 +575,7 @@ void WMainMenuBar::initialize() {
 
     QString translateTitle = tr("&Translate This Application") + externalLinkSuffix;
     QString translateText = tr("Help translate this application into your language.");
-    auto pHelpTranslation = new QAction(translateTitle, this);
+    auto pHelpTranslation = make_parented<QAction>(translateTitle, this);
     pHelpTranslation->setStatusTip(translateText);
     pHelpTranslation->setWhatsThis(buildWhatsThis(translateTitle, translateText));
     m_visitUrlMapper.setMapping(pHelpTranslation, MIXXX_TRANSLATION_URL);
@@ -586,7 +586,7 @@ void WMainMenuBar::initialize() {
 
     QString aboutTitle = tr("&About");
     QString aboutText = tr("About the application");
-    auto pHelpAboutApp = new QAction(aboutTitle, this);
+    auto pHelpAboutApp = make_parented<QAction>(aboutTitle, this);
     pHelpAboutApp->setStatusTip(aboutText);
     pHelpAboutApp->setWhatsThis(buildWhatsThis(aboutTitle, aboutText));
     pHelpAboutApp->setMenuRole(QAction::AboutRole);

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -8,6 +8,7 @@
 #include <QScopedPointer>
 #include <QSignalMapper>
 
+#include "control/controlobject.h"
 #include "control/controlproxy.h"
 #include "preferences/configobject.h"
 #include "preferences/usersettings.h"
@@ -79,6 +80,7 @@ class WMainMenuBar : public QMenuBar {
     void slotDeveloperStatsBase(bool enable);
     void slotDeveloperDebugger(bool toggle);
     void slotVisitUrl(const QString& url);
+    void toggleTrainingmode(bool toggle);
 
   private:
     void initialize();
@@ -86,6 +88,7 @@ class WMainMenuBar : public QMenuBar {
 
     UserSettingsPointer m_pConfig;
     ConfigObject<ConfigValueKbd>* m_pKbdConfig;
+    ControlObject* m_pConfigTrainingmodeEnabled;
     QSignalMapper m_loadToDeckMapper;
     QSignalMapper m_visitUrlMapper;
     QList<QAction*> m_loadToDeckActions;

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -13,6 +13,8 @@
 #include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 
+#include "util/memory.h"
+
 class VisibilityControlConnection : public QObject {
     Q_OBJECT
   public:
@@ -91,6 +93,7 @@ class WMainMenuBar : public QMenuBar {
     ControlObject* m_pConfigTrainingmodeEnabled;
     QSignalMapper m_loadToDeckMapper;
     QSignalMapper m_visitUrlMapper;
+    std::unique_ptr<ControlObject> m_pConfigTrainingmodeEnabled;
     QList<QAction*> m_loadToDeckActions;
     QSignalMapper m_vinylControlEnabledMapper;
     QList<QAction*> m_vinylControlEnabledActions;

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -82,7 +82,7 @@ class WMainMenuBar : public QMenuBar {
     void slotDeveloperStatsBase(bool enable);
     void slotDeveloperDebugger(bool toggle);
     void slotVisitUrl(const QString& url);
-    void toggleTrainingmode(bool toggle);
+    void togglePracticemode(bool toggle);
 
   private:
     void initialize();
@@ -93,7 +93,7 @@ class WMainMenuBar : public QMenuBar {
     ControlObject* m_pConfigTrainingmodeEnabled;
     QSignalMapper m_loadToDeckMapper;
     QSignalMapper m_visitUrlMapper;
-    std::unique_ptr<ControlObject> m_pConfigTrainingmodeEnabled;
+    std::unique_ptr<ControlObject> m_pConfigPracticemodeEnabled;
     QList<QAction*> m_loadToDeckActions;
     QSignalMapper m_vinylControlEnabledMapper;
     QList<QAction*> m_vinylControlEnabledActions;


### PR DESCRIPTION
This adds an training mode. This should enable you to train with your
database and improve, but do not add your training to the play count. As
the play count should be related to the count that I have played this
song on events/broadcasts.

The design is done in a way that uses the Mixxx's Control System
functionality to comunicate between the gui and the actual counter
implementation.

This is my first contribution to mixxx. So feel free to give me feedback.

Changes should be backwards compatible and original behavior is not changed, when training mode is disabled.