### PR TITLE
skin/skincontext: Fix deprecated-copy warning for SkinContext class

### DIFF
--- a/src/skin/skincontext.h
+++ b/src/skin/skincontext.h
@@ -30,6 +30,8 @@ class SkinContext {
     SkinContext(const SkinContext& parent);
     virtual ~SkinContext();
 
+    SkinContext& operator=(const SkinContext& other) = default;
+
     // Gets a path relative to the skin path.
     QString makeSkinPath(const QString& relativePath) const {
         if (relativePath.isEmpty() || relativePath.startsWith("/")


### PR DESCRIPTION
Without this, the following warning occurs:

    In file included from src/waveform/waveformwidgetfactory.cpp:12:
    src/waveform/waveformwidgetfactory.h: In member function 'WaveformWidgetHolder& WaveformWidgetHolder::operator=(WaveformWidgetHolder&&)':
    src/waveform/waveformwidgetfactory.h:36:7: warning: implicitly-declared 'SkinContext& SkinContext::operator=(const SkinContext&)' is deprecated [-Wdeprecated-copy]
       36 | class WaveformWidgetHolder {
          |       ^~~~~~~~~~~~~~~~~~~~
    In file included from src/waveform/waveformwidgetfactory.h:12,
                     from src/waveform/waveformwidgetfactory.cpp:12:
    src/skin/skincontext.h:32:5: note: because 'SkinContext' has user-provided 'SkinContext::SkinContext(const SkinContext&)'
       32 |     SkinContext(const SkinContext& parent);
          |     ^~~~~~~~~~~
    src/waveform/waveformwidgetfactory.cpp: In member function 'bool WaveformWidgetFactory::setWaveformWidget(WWaveformViewer*, const QDomElement&, const SkinContext&)':
    src/waveform/waveformwidgetfactory.cpp:383:75: note: synthesized method 'WaveformWidgetHolder& WaveformWidgetHolder::operator=(WaveformWidgetHolder&&)' first required here
      383 |                 WaveformWidgetHolder(waveformWidget, viewer, node, context);
          |