### PR TITLE
Roland DJ-505: Improve CUE LOOP mode and add some minor fixes

### DIFF
--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1233,26 +1233,26 @@ DJ505.HotcueMode = function (deck, offset) {
     this.paramMinusButton = new components.Button({
         midi: [0x94 + offset, 0x28],
         mode: this,
-        outKey: "beats_translate_earlier",
-        inKey: "beats_translate_earlier",
+        outKey: "hotcue_focus_color_prev",
+        inKey: "hotcue_focus_color_prev",
     });
     this.paramPlusButton = new components.Button({
         midi: [0x94 + offset, 0x29],
         mode: this,
-        outKey: "beats_translate_later",
-        inKey: "beats_translate_later",
+        outKey: "hotcue_focus_color_next",
+        inKey: "hotcue_focus_color_next",
     });
     this.param2MinusButton = new components.Button({
         midi: [0x94 + offset, 0x2A],
         mode: this,
-        outKey: "hotcue_focus_color_prev",
-        inKey: "hotcue_focus_color_prev",
+        outKey: "beats_translate_earlier",
+        inKey: "beats_translate_earlier",
     });
     this.param2PlusButton = new components.Button({
         midi: [0x94 + offset, 0x2B],
         mode: this,
-        outKey: "hotcue_focus_color_next",
-        inKey: "hotcue_focus_color_next",
+        outKey: "beats_translate_later",
+        inKey: "beats_translate_later",
     });
 };
 DJ505.HotcueMode.prototype = Object.create(components.ComponentContainer.prototype);

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1372,6 +1372,19 @@ DJ505.CueLoopMode = function (deck, offset) {
     for (var n = 0; n <= 7; n++) {
         this.pads[n] = new this.PerformancePad(n);
     }
+
+    this.paramMinusButton = new components.Button({
+        midi: [0x94 + offset, 0x28],
+        group: deck.currentDeck,
+        outKey: "loop_halve",
+        inKey: "loop_halve",
+    });
+    this.paramPlusButton = new components.Button({
+        midi: [0x94 + offset, 0x29],
+        group: deck.currentDeck,
+        outKey: "loop_double",
+        inKey: "loop_double",
+    });
 };
 DJ505.CueLoopMode.prototype = Object.create(components.ComponentContainer.prototype);
 

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1124,24 +1124,20 @@ DJ505.PadSection.prototype.paramButtonPressed = function (channel, control, valu
     switch(control) {
         case 0x2A: // PARAMETER 2 -
             if (this.currentMode.param2MinusButton) {
-                print('param2-');
                 button = this.currentMode.param2MinusButton;
                 break;
             }
             /* falls through */
         case 0x28: // PARAMETER -
-            print('param-');
             button = this.currentMode.paramMinusButton;
             break;
         case 0x2B: // PARAMETER 2 +
             if (this.currentMode.param2PlusButton) {
-                print('param2+');
                 button = this.currentMode.param2PlusButton;
                 break;
             }
             /* falls through */
         case 0x29: // PARAMETER +
-            print('param+');
             button = this.currentMode.paramPlusButton;
             break;
     }

--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -1228,25 +1228,25 @@ DJ505.HotcueMode = function (deck, offset) {
     }
     this.paramMinusButton = new components.Button({
         midi: [0x94 + offset, 0x28],
-        mode: this,
+        group: deck.currentDeck,
         outKey: "hotcue_focus_color_prev",
         inKey: "hotcue_focus_color_prev",
     });
     this.paramPlusButton = new components.Button({
         midi: [0x94 + offset, 0x29],
-        mode: this,
+        group: deck.currentDeck,
         outKey: "hotcue_focus_color_next",
         inKey: "hotcue_focus_color_next",
     });
     this.param2MinusButton = new components.Button({
         midi: [0x94 + offset, 0x2A],
-        mode: this,
+        group: deck.currentDeck,
         outKey: "beats_translate_earlier",
         inKey: "beats_translate_earlier",
     });
     this.param2PlusButton = new components.Button({
         midi: [0x94 + offset, 0x2B],
-        mode: this,
+        group: deck.currentDeck,
         outKey: "beats_translate_later",
         inKey: "beats_translate_later",
     });


### PR DESCRIPTION
Fixes:
- Switch PARAM 1/2 buttons in hotcue mode (setting cue colors is much more common than fine-tuning the beatgrid)
- Remove leftover print() calls

Reworked CUE LOOP mode:
- Use PARAM 1 +/- to change loop size
- Add support for displaying hotcue colors in this mode, too
- Pressing a pad repeatedly will always jump to the beginning of the loop,
not toggle it. Toggling can be done using the LOOP ACTIVE button
instead.
- Pressing a pad while holding shift will now clear the hotcue (like in
regular HOT CUE mode).
- The new behaviour does make more sense and is also more similar to how the
controller behaves with Serato.