### PR TITLE
shoutcast_internal always 0 bug in master 

### DIFF
--- a/build/features.py
+++ b/build/features.py
@@ -839,7 +839,7 @@ class LiveBroadcasting(Feature):
             # https://bugs.launchpad.net/mixxx/+bug/1833225
             if not conf.CheckForPKG('shout', '2.4.4'):
                 if conf.CheckForPKG('shout', '2.4.2'):
-                    print("System's libshout 2.4.2 suffers lp1833225, using internal shout_mixxx")
+                    print("System's libshout suffers lp1833225, using internal shout_mixxx")
                     build.flags['shoutcast_internal'] = 1
                 else:
                     print("(no) here is fine here we just don't want 2.4.2")

--- a/build/features.py
+++ b/build/features.py
@@ -828,12 +828,12 @@ class LiveBroadcasting(Feature):
         vars.Add('shoutcast_internal', 'Set to 1 to use internal libshout', 0)
 
     def configure(self, build, conf):
+        build.flags['shoutcast_internal'] = util.get_flags(build.env, 'shoutcast_internal', 0)
         if not self.enabled(build):
             return
 
         build.env.Append(CPPDEFINES='__BROADCAST__')
 
-        build.flags['shoutcast_internal'] = util.get_flags(build.env, 'shoutcast_internal', 0)
         if build.platform_is_linux and not int(build.flags['shoutcast_internal']):
             # Check if system lib is lower 2.4.2 or 2.4.3 and not suffering bug
             # https://bugs.launchpad.net/mixxx/+bug/1833225

--- a/build/features.py
+++ b/build/features.py
@@ -835,15 +835,11 @@ class LiveBroadcasting(Feature):
         build.env.Append(CPPDEFINES='__BROADCAST__')
 
         if build.platform_is_linux:
-            # Check if system lib is lower 2.4.2 or at least 2.4.4 and not suffering bug
+            # Check if system lib is lower at least 2.4.4 and not suffering bug
             # https://bugs.launchpad.net/mixxx/+bug/1833225
             if not conf.CheckForPKG('shout', '2.4.4'):
-                if conf.CheckForPKG('shout', '2.4.2'):
-                    print("System's libshout suffers lp1833225, using internal shout_mixxx")
-                    self.INTERNAL_LINK = True
-                else:
-                    print("(no) here is fine here we just don't want 2.4.2 or 2.4.3")
-
+                self.INTERNAL_LINK = True
+ 
         if not self.INTERNAL_LINK:
             self.INTERNAL_LINK = not conf.CheckLib(['libshout', 'shout'])
 

--- a/build/features.py
+++ b/build/features.py
@@ -814,6 +814,8 @@ class TestSuite(Feature):
 
 
 class LiveBroadcasting(Feature):
+    INTERNAL_LINK = False
+
     def description(self):
         return "Live Broadcasting Support"
 
@@ -825,34 +827,31 @@ class LiveBroadcasting(Feature):
 
     def add_options(self, build, vars):
         vars.Add('shoutcast', 'Set to 1 to enable live broadcasting support', 1)
-        vars.Add('shoutcast_internal', 'Set to 1 to use internal libshout', 0)
 
     def configure(self, build, conf):
-        build.flags['shoutcast_internal'] = util.get_flags(build.env, 'shoutcast_internal', 0)
         if not self.enabled(build):
             return
 
         build.env.Append(CPPDEFINES='__BROADCAST__')
 
-        if build.platform_is_linux and not int(build.flags['shoutcast_internal']):
+        if build.platform_is_linux:
             # Check if system lib is lower 2.4.2 or at least 2.4.4 and not suffering bug
             # https://bugs.launchpad.net/mixxx/+bug/1833225
             if not conf.CheckForPKG('shout', '2.4.4'):
                 if conf.CheckForPKG('shout', '2.4.2'):
                     print("System's libshout suffers lp1833225, using internal shout_mixxx")
-                    build.flags['shoutcast_internal'] = 1
+                    self.INTERNAL_LINK = True
                 else:
-                    print("(no) here is fine here we just don't want 2.4.2")
+                    print("(no) here is fine here we just don't want 2.4.2 or 2.4.3")
 
-        if int(build.flags['shoutcast_internal']):
+        if not self.INTERNAL_LINK:
+            self.INTERNAL_LINK = not conf.CheckLib(['libshout', 'shout'])
+
+        if self.INTERNAL_LINK:
+            print("Using internal shout_mixxx from lib/libshout")
             build.env.Append(CPPPATH='include')
             build.env.Append(CPPPATH='src')
             return
-
-        libshout_found = conf.CheckLib(['libshout', 'shout'])
-
-        if not libshout_found:
-            raise Exception('Could not find libshout or its development headers. Please install it or compile Mixxx without Shoutcast support using the shoutcast=0 flag.')
 
         if build.platform_is_windows and build.static_dependencies:
             conf.CheckLib('winmm')
@@ -860,7 +859,7 @@ class LiveBroadcasting(Feature):
             conf.CheckLib('gdi32')
 
     def sources(self, build):
-        if int(build.flags['shoutcast_internal']):
+        if self.INTERNAL_LINK:
             # Clone our main environment so we don't change any settings in the
             # Mixxx environment
             libshout_env = build.env.Clone()

--- a/build/features.py
+++ b/build/features.py
@@ -835,9 +835,9 @@ class LiveBroadcasting(Feature):
         build.env.Append(CPPDEFINES='__BROADCAST__')
 
         if build.platform_is_linux and not int(build.flags['shoutcast_internal']):
-            # Check if system lib is lower 2.4.2 or 2.4.3 and not suffering bug
+            # Check if system lib is lower 2.4.2 or at least 2.4.4 and not suffering bug
             # https://bugs.launchpad.net/mixxx/+bug/1833225
-            if not conf.CheckForPKG('shout', '2.4.3'):
+            if not conf.CheckForPKG('shout', '2.4.4'):
                 if conf.CheckForPKG('shout', '2.4.2'):
                     print("System's libshout 2.4.2 suffers lp1833225, using internal shout_mixxx")
                     build.flags['shoutcast_internal'] = 1


### PR DESCRIPTION
This is a alternative solution for a KeyError in `sources` when configure` is skipped:
https://github.com/mixxxdj/mixxx/commit/5a0e711f81541dd8e8b9e480cb0e9100d96e6feb

The commit is only in master so we must be remove it when merging 2.2 into master. 