### PR TITLE
Fixes Auto DJ going wild:  Lp1858340

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -246,20 +246,20 @@ void AutoDJProcessor::fadeNow() {
     pFromDeck->isFromDeck = true;
     pToDeck->isFromDeck = false;
 
-    const double fromDeckEndPosition = getEndPosition(pFromDeck);
-    const double toDeckEndPosition = getEndPosition(pToDeck);
+    const double fromDeckEndSecond = getEndSecond(pFromDeck);
+    const double toDeckEndSecond = getEndSecond(pToDeck);
     // Since the end position is measured in seconds from 0:00 it is also
     // the track duration. Use this alias for better readability.
-    const double fromDeckDuration = fromDeckEndPosition;
-    const double toDeckDuration = toDeckEndPosition;
+    const double fromDeckDuration = fromDeckEndSecond;
+    const double toDeckDuration = toDeckEndSecond;
     // playPosition() is in the range of 0..1
-    const double fromDeckCurrentPosition = fromDeckDuration * pFromDeck->playPosition();
-    const double toDeckCurrentPosition = toDeckDuration * pToDeck->playPosition();
+    const double fromDeckCurrentSecond = fromDeckDuration * pFromDeck->playPosition();
+    const double toDeckCurrentSecond = toDeckDuration * pToDeck->playPosition();
 
-    pFromDeck->fadeBeginPos = fromDeckCurrentPosition;
+    pFromDeck->fadeBeginPos = fromDeckCurrentSecond;
     // Do not seek to a calculated start point; start the to deck from wherever
     // it is if the user has seeked since loading the track.
-    pToDeck->startPos = toDeckCurrentPosition;
+    pToDeck->startPos = toDeckCurrentSecond;
 
     // If the user presses "Fade now", assume they want to fade *now*, not later.
     // So if the spinbox time is negative, do not insert silence.
@@ -273,15 +273,15 @@ void AutoDJProcessor::fadeNow() {
         // there and do not seek back to the intro start. If they have seeked
         // past the introEnd or the introEnd is not marked, fall back to the
         // spinbox time.
-        double outroEnd = getOutroEndPosition(pFromDeck);
-        double introEnd = getIntroEndPosition(pToDeck);
-        double introStart = getIntroStartPosition(pToDeck);
-        double timeUntilOutroEnd = outroEnd - fromDeckCurrentPosition;
+        double outroEnd = getOutroEndSecond(pFromDeck);
+        double introEnd = getIntroEndSecond(pToDeck);
+        double introStart = getIntroStartSecond(pToDeck);
+        double timeUntilOutroEnd = outroEnd - fromDeckCurrentSecond;
 
-        if (toDeckCurrentPosition >= introStart &&
-                toDeckCurrentPosition <= introEnd &&
+        if (toDeckCurrentSecond >= introStart &&
+                toDeckCurrentSecond <= introEnd &&
                 introEnd >= 0) {
-            double timeUntilIntroEnd = introEnd - toDeckCurrentPosition;
+            double timeUntilIntroEnd = introEnd - toDeckCurrentSecond;
             // The fade must end by the outro end at the latest.
             fadeTime = math_min(timeUntilIntroEnd, timeUntilOutroEnd);
         } else {
@@ -296,9 +296,9 @@ void AutoDJProcessor::fadeNow() {
         fadeTime = spinboxTime;
     }
 
-    double timeUntilEndOfFromTrack = fromDeckEndPosition - fromDeckCurrentPosition;
+    double timeUntilEndOfFromTrack = fromDeckEndSecond - fromDeckCurrentSecond;
     fadeTime = math_min(fadeTime, timeUntilEndOfFromTrack);
-    pFromDeck->fadeEndPos = fromDeckCurrentPosition + fadeTime;
+    pFromDeck->fadeEndPos = fromDeckCurrentSecond + fadeTime;
 
     // These are expected to be a fraction of the track length.
     pFromDeck->fadeBeginPos /= fromDeckDuration;
@@ -1022,47 +1022,47 @@ void AutoDJProcessor::playerOutroEndChanged(DeckAttributes* pAttributes, double 
     calculateTransition(fromDeck, getOtherDeck(fromDeck), false);
 }
 
-double AutoDJProcessor::getIntroStartPosition(DeckAttributes* pDeck) {
+double AutoDJProcessor::getIntroStartSecond(DeckAttributes* pDeck) {
     double introStartSample = pDeck->introStartPosition();
     if (introStartSample == Cue::kNoPosition) {
-        return getFirstSoundPosition(pDeck);
+        return getFirstSoundSecond(pDeck);
     }
     return samplePositionToSeconds(introStartSample, pDeck);
 }
 
-double AutoDJProcessor::getIntroEndPosition(DeckAttributes* pDeck) {
+double AutoDJProcessor::getIntroEndSecond(DeckAttributes* pDeck) {
     double introEndSample = pDeck->introEndPosition();
     if (introEndSample == Cue::kNoPosition) {
         // Assume a zero length intro if introEnd is not set.
         // The introStart is automatically placed by AnalyzerSilence, so use
         // that as a fallback if the user has not placed outroStart. If it has
         // not been placed, getIntroStartPosition will return 0:00.
-        return getIntroStartPosition(pDeck);
+        return getIntroStartSecond(pDeck);
     }
     return samplePositionToSeconds(introEndSample, pDeck);
 }
 
-double AutoDJProcessor::getOutroStartPosition(DeckAttributes* pDeck) {
+double AutoDJProcessor::getOutroStartSecond(DeckAttributes* pDeck) {
     double outroStartSample = pDeck->outroStartPosition();
     if (outroStartSample == Cue::kNoPosition) {
         // Assume a zero length outro if outroStart is not set.
         // The outroEnd is automatically placed by AnalyzerSilence, so use
         // that as a fallback if the user has not placed outroStart. If it has
         // not been placed, getOutroEndPosition will return the end of the track.
-        return getOutroEndPosition(pDeck);
+        return getOutroEndSecond(pDeck);
     }
     return samplePositionToSeconds(outroStartSample, pDeck);
 }
 
-double AutoDJProcessor::getOutroEndPosition(DeckAttributes* pDeck) {
+double AutoDJProcessor::getOutroEndSecond(DeckAttributes* pDeck) {
     double outroEndSample = pDeck->outroEndPosition();
     if (outroEndSample == Cue::kNoPosition) {
-        return getLastSoundPosition(pDeck);
+        return getLastSoundSecond(pDeck);
     }
     return samplePositionToSeconds(outroEndSample, pDeck);;
 }
 
-double AutoDJProcessor::getFirstSoundPosition(DeckAttributes* pDeck) {
+double AutoDJProcessor::getFirstSoundSecond(DeckAttributes* pDeck) {
     TrackPointer pTrack = pDeck->getLoadedTrack();
     if (!pTrack) {
         return 0.0;
@@ -1078,7 +1078,7 @@ double AutoDJProcessor::getFirstSoundPosition(DeckAttributes* pDeck) {
     return 0.0;
 }
 
-double AutoDJProcessor::getLastSoundPosition(DeckAttributes* pDeck) {
+double AutoDJProcessor::getLastSoundSecond(DeckAttributes* pDeck) {
     TrackPointer pTrack = pDeck->getLoadedTrack();
     if (!pTrack) {
         return 0.0;
@@ -1091,10 +1091,10 @@ double AutoDJProcessor::getLastSoundPosition(DeckAttributes* pDeck) {
             return samplePositionToSeconds(lastSound, pDeck);
         }
     }
-    return getEndPosition(pDeck);
+    return getEndSecond(pDeck);
 }
 
-double AutoDJProcessor::getEndPosition(DeckAttributes* pDeck) {
+double AutoDJProcessor::getEndSecond(DeckAttributes* pDeck) {
     TrackPointer pTrack = pDeck->getLoadedTrack();
     if (!pTrack) {
         return 0.0;
@@ -1133,8 +1133,8 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         return;
     }
 
-    const double fromDeckEndPosition = getEndPosition(pFromDeck);
-    const double toDeckEndPosition = getEndPosition(pToDeck);
+    const double fromDeckEndPosition = getEndSecond(pFromDeck);
+    const double toDeckEndPosition = getEndSecond(pToDeck);
     // Since the end position is measured in seconds from 0:00 it is also
     // the track duration. Use this alias for better readability.
     const double fromDeckDuration = fromDeckEndPosition;
@@ -1158,8 +1158,8 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
     // Within this function, the outro refers to the outro of the currently
     // playing track and the intro refers to the intro of the next track.
 
-    double outroEnd = getOutroEndPosition(pFromDeck);
-    double outroStart = getOutroStartPosition(pFromDeck);
+    double outroEnd = getOutroEndSecond(pFromDeck);
+    double outroStart = getOutroStartSecond(pFromDeck);
     const double fromDeckPosition = fromDeckDuration * pFromDeck->playPosition();
 
     VERIFY_OR_DEBUG_ASSERT(outroEnd <= fromDeckEndPosition) {
@@ -1176,26 +1176,26 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
     }
     double outroLength = outroEnd - outroStart;
 
-    double toDeckPosition = toDeckDuration * pToDeck->playPosition();
+    double toDeckPositionSeconds = toDeckDuration * pToDeck->playPosition();
     // Store here a possible fadeBeginPos for the transition after next
     // This is used to check if it will be possible or a re-cue is required.
     // here it is done for FullIntroOutro and FadeAtOutroStart.
     // It is adjusted below for the other modes.
-    pToDeck->fadeBeginPos = getOutroStartPosition(pToDeck);
-    pToDeck->fadeEndPos = getOutroEndPosition(pToDeck);
+    pToDeck->fadeBeginPos = getOutroStartSecond(pToDeck);
+    pToDeck->fadeEndPos = getOutroEndSecond(pToDeck);
 
     double introStart;
-    if (seekToStartPoint || toDeckPosition >= pToDeck->fadeBeginPos) {
+    if (seekToStartPoint || toDeckPositionSeconds >= pToDeck->fadeBeginPos) {
         // toDeckPosition >= pToDeck->fadeBeginPos happens when the
         // user has seeked or played the to track behind fadeBeginPos of
         // the fade after the next.
         // In this case we recue the track just before the transition.
-        introStart = getIntroStartPosition(pToDeck);
+        introStart = getIntroStartSecond(pToDeck);
     } else {
-        introStart = toDeckPosition;
+        introStart = toDeckPositionSeconds;
     }
 
-    double introEnd = getIntroEndPosition(pToDeck);
+    double introEnd = getIntroEndSecond(pToDeck);
     if (introEnd < introStart) {
         // introEnd is invalid. Assume a zero length intro.
         // The introStart is automatically placed by AnalyzerSilence, so use
@@ -1320,30 +1320,30 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         break;
     case TransitionMode::FixedSkipSilence: {
         double startPoint;
-        pToDeck->fadeBeginPos = getLastSoundPosition(pToDeck);
-        if (seekToStartPoint || toDeckPosition >= pToDeck->fadeBeginPos) {
+        pToDeck->fadeBeginPos = getLastSoundSecond(pToDeck);
+        if (seekToStartPoint || toDeckPositionSeconds >= pToDeck->fadeBeginPos) {
             // toDeckPosition >= pToDeck->fadeBeginPos happens when the
             // user has seeked or played the to track behind fadeBeginPos of
             // the fade after the next.
             // In this case we recue the track just before the transition.
-            startPoint = getFirstSoundPosition(pToDeck);
+            startPoint = getFirstSoundSecond(pToDeck);
         } else {
-            startPoint = toDeckPosition;
+            startPoint = toDeckPositionSeconds;
         }
-        useFixedFadeTime(pFromDeck, pToDeck, fromDeckPosition, getLastSoundPosition(pFromDeck), startPoint);
+        useFixedFadeTime(pFromDeck, pToDeck, fromDeckPosition, getLastSoundSecond(pFromDeck), startPoint);
     } break;
     case TransitionMode::FixedFullTrack:
     default: {
         double startPoint;
         pToDeck->fadeBeginPos = toDeckEndPosition;
-        if (seekToStartPoint || toDeckPosition >= pToDeck->fadeBeginPos) {
+        if (seekToStartPoint || toDeckPositionSeconds >= pToDeck->fadeBeginPos) {
             // toDeckPosition >= pToDeck->fadeBeginPos happens when the
             // user has seeked or played the to track behind fadeBeginPos of
             // the fade after the next.
             // In this case we recue the track just before the transition.
             startPoint = 0.0;
         } else {
-            startPoint = toDeckPosition;
+            startPoint = toDeckPositionSeconds;
         }
         useFixedFadeTime(pFromDeck, pToDeck, fromDeckPosition, fromDeckEndPosition, startPoint);
         }
@@ -1370,11 +1370,12 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
     }
 }
 
-void AutoDJProcessor::useFixedFadeTime(DeckAttributes* pFromDeck,
+void AutoDJProcessor::useFixedFadeTime(
+        DeckAttributes* pFromDeck,
         DeckAttributes* pToDeck,
-        double fromDeckPosition,
-        double fadeEndPosition,
-        double toDeckStartPosition) {
+        double fromDeckSecond,
+        double fadeEndSecond,
+        double toDeckStartSecond) {
     if (m_transitionTime > 0.0) {
         // Guard against the next track being too short. This transition must finish
         // before the next transition starts.
@@ -1383,32 +1384,32 @@ void AutoDJProcessor::useFixedFadeTime(DeckAttributes* pFromDeck,
             // no outro defined, the toDeck will also use the transition time
             toDeckOutroStart -= m_transitionTime;
         }
-        if (toDeckOutroStart <= toDeckStartPosition) {
+        if (toDeckOutroStart <= toDeckStartSecond) {
             // we are already too late
             // Check OutroEnd as alternative, which is for all transition mode
             // better than directly default to duration()
-            double end = getOutroEndPosition(pToDeck);
-            if (end <= toDeckStartPosition) {
-                end = getEndPosition(pToDeck);
-                VERIFY_OR_DEBUG_ASSERT(end > toDeckStartPosition) {
+            double end = getOutroEndSecond(pToDeck);
+            if (end <= toDeckStartSecond) {
+                end = getEndSecond(pToDeck);
+                VERIFY_OR_DEBUG_ASSERT(end > toDeckStartSecond) {
                     // as last resort move start point
                     // The caller makes sure that this never happens
-                    toDeckStartPosition = end - 1;
+                    toDeckStartSecond = end - 1;
                 }
             }
             // use the remaining time for fading
-            toDeckOutroStart = (end - toDeckStartPosition) / 2 + toDeckStartPosition;
+            toDeckOutroStart = (end - toDeckStartSecond) / 2 + toDeckStartSecond;
         }
-        double transitionTime = math_min(toDeckOutroStart - toDeckStartPosition,
+        double transitionTime = math_min(toDeckOutroStart - toDeckStartSecond,
                 m_transitionTime);
 
-        pFromDeck->fadeBeginPos = math_max(fadeEndPosition - transitionTime, fromDeckPosition);
-        pFromDeck->fadeEndPos = fadeEndPosition;
-        pToDeck->startPos = toDeckStartPosition;
+        pFromDeck->fadeBeginPos = math_max(fadeEndSecond - transitionTime, fromDeckSecond);
+        pFromDeck->fadeEndPos = fadeEndSecond;
+        pToDeck->startPos = toDeckStartSecond;
     } else {
-        pFromDeck->fadeBeginPos = fadeEndPosition;
-        pFromDeck->fadeEndPos = fadeEndPosition;
-        pToDeck->startPos = toDeckStartPosition + m_transitionTime;
+        pFromDeck->fadeBeginPos = fadeEndSecond;
+        pFromDeck->fadeEndPos = fadeEndSecond;
+        pToDeck->startPos = toDeckStartSecond + m_transitionTime;
     }
 }
 
@@ -1422,7 +1423,7 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
 
     // Since the end position is measured in seconds from 0:00 it is also
     // the track duration.
-    double duration = getEndPosition(pDeck);
+    double duration = getEndSecond(pDeck);
     if (duration < 0.2) {
         qWarning() << "Skip track with" << duration << "Duration"
                    << pTrack->getLocation();

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -252,6 +252,7 @@ void AutoDJProcessor::fadeNow() {
     // the track duration. Use this alias for better readability.
     const double fromDeckDuration = fromDeckEndPosition;
     const double toDeckDuration = toDeckEndPosition;
+    // playPosition() is in the range of 0..1
     const double fromDeckCurrentPosition = fromDeckDuration * pFromDeck->playPosition();
     const double toDeckCurrentPosition = toDeckDuration * pToDeck->playPosition();
 
@@ -300,9 +301,9 @@ void AutoDJProcessor::fadeNow() {
     pFromDeck->fadeEndPos = fromDeckCurrentPosition + fadeTime;
 
     // These are expected to be a fraction of the track length.
-    pFromDeck->fadeBeginPos /= fromDeckEndPosition;
-    pFromDeck->fadeEndPos /= fromDeckEndPosition;
-    pToDeck->startPos /= toDeckEndPosition;
+    pFromDeck->fadeBeginPos /= fromDeckDuration;
+    pFromDeck->fadeEndPos /= fromDeckDuration;
+    pToDeck->startPos /= toDeckDuration;
 
     VERIFY_OR_DEBUG_ASSERT(pFromDeck->fadeBeginPos <= 1) {
         pFromDeck->fadeBeginPos = 1;
@@ -1445,6 +1446,7 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
                     // which may calls the calculateTransition() again without seek = true;
                     pDeck->setPlayPosition(pDeck->startPos);
                 }
+                // we are her in the relative domain 0..1
                 if (!fromDeck->isPlaying() && fromDeck->playPosition() >= 1.0) {
                     // repeat a probably missed update
                     playerPositionChanged(fromDeck, 1.0);

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -247,13 +247,13 @@ class AutoDJProcessor : public QObject {
 
     // Following functions return seconds computed from samples or -1 if
     // track in deck has invalid sample rate (<= 0)
-    double getIntroStartPosition(DeckAttributes* pDeck);
-    double getIntroEndPosition(DeckAttributes* pDeck);
-    double getOutroStartPosition(DeckAttributes* pDeck);
-    double getOutroEndPosition(DeckAttributes* pDeck);
-    double getFirstSoundPosition(DeckAttributes* pDeck);
-    double getLastSoundPosition(DeckAttributes* pDeck);
-    double getEndPosition(DeckAttributes* pDeck);
+    double getIntroStartSecond(DeckAttributes* pDeck);
+    double getIntroEndSecond(DeckAttributes* pDeck);
+    double getOutroStartSecond(DeckAttributes* pDeck);
+    double getOutroEndSecond(DeckAttributes* pDeck);
+    double getFirstSoundSecond(DeckAttributes* pDeck);
+    double getLastSoundSecond(DeckAttributes* pDeck);
+    double getEndSecond(DeckAttributes* pDeck);
     double samplePositionToSeconds(double samplePosition, DeckAttributes* pDeck);
 
     TrackPointer getNextTrackFromQueue();
@@ -261,11 +261,12 @@ class AutoDJProcessor : public QObject {
     void calculateTransition(DeckAttributes* pFromDeck,
             DeckAttributes* pToDeck,
             bool seekToStartPoint);
-    void useFixedFadeTime(DeckAttributes* pFromDeck,
+    void useFixedFadeTime(
+            DeckAttributes* pFromDeck,
             DeckAttributes* pToDeck,
-            double fromDeckPosition,
-            double endPoint,
-            double startPoint);
+            double fromDeckSecond,
+            double fadeEndSecond,
+            double toDeckStartSecond);
     DeckAttributes* getOtherDeck(const DeckAttributes* pThisDeck);
     DeckAttributes* getFromDeck();
 

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -50,10 +50,6 @@ class DeckAttributes : public QObject {
         return m_playPos.get();
     }
 
-    double trackTime() const;
-
-    double timeElapsed() const;
-
     void setPlayPosition(double playpos) {
         m_playPos.set(playpos);
     }
@@ -86,8 +82,8 @@ class DeckAttributes : public QObject {
         return m_sampleRate.get();
     }
 
-    double trackDuration() const {
-        return m_duration.get();
+    double trackSamples() const {
+        return m_trackSamples.get();
     }
 
     double rateRatio() const {
@@ -138,8 +134,8 @@ class DeckAttributes : public QObject {
     ControlProxy m_introEndPos;
     ControlProxy m_outroStartPos;
     ControlProxy m_outroEndPos;
+    ControlProxy m_trackSamples;
     ControlProxy m_sampleRate;
-    ControlProxy m_duration;
     ControlProxy m_rateRatio;
     BaseTrackPlayer* m_pPlayer;
 };
@@ -257,6 +253,7 @@ class AutoDJProcessor : public QObject {
     double getOutroEndPosition(DeckAttributes* pDeck);
     double getFirstSoundPosition(DeckAttributes* pDeck);
     double getLastSoundPosition(DeckAttributes* pDeck);
+    double getEndPosition(DeckAttributes* pDeck);
     double samplePositionToSeconds(double samplePosition, DeckAttributes* pDeck);
 
     TrackPointer getNextTrackFromQueue();

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -39,7 +39,7 @@ class FakeDeck : public BaseTrackPlayer {
   public:
     FakeDeck(const QString& group)
             : BaseTrackPlayer(NULL, group),
-              duration(ConfigKey(group, "duration")),
+              trackSamples(ConfigKey(group, "track_samples")),
               samplerate(ConfigKey(group, "track_samplerate")),
               rateratio(ConfigKey(group, "rate_ratio"), true, false, false, 1.0),
               playposition(ConfigKey(group, "playposition"), 0.0, 1.0, 0, 0, true),
@@ -55,7 +55,7 @@ class FakeDeck : public BaseTrackPlayer {
 
     void fakeTrackLoadedEvent(TrackPointer pTrack) {
         loadedTrack = pTrack;
-        duration.set(pTrack->getDuration());
+        trackSamples.set(pTrack->getDuration() * pTrack->getSampleRate() * 2);
         samplerate.set(pTrack->getSampleRate());
         emit(newTrackLoaded(pTrack));
     }
@@ -85,7 +85,6 @@ class FakeDeck : public BaseTrackPlayer {
     // fakeTrackLoadFailedEvent.
     void slotLoadTrack(TrackPointer pTrack, bool bPlay) override {
         loadedTrack = pTrack;
-        duration.set(pTrack->getDuration());
         samplerate.set(pTrack->getSampleRate());
         play.set(bPlay);
     }
@@ -94,7 +93,7 @@ class FakeDeck : public BaseTrackPlayer {
     MOCK_METHOD0(slotCloneDeck, void());
 
     TrackPointer loadedTrack;
-    ControlObject duration;
+    ControlObject trackSamples;
     ControlObject samplerate;
     ControlObject rateratio;
     ControlLinPotmeter playposition;
@@ -1484,7 +1483,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_Pause_Transition) {
     deck2.slotLoadTrack(pTrack, false);
     deck2.fakeTrackLoadedEvent(pTrack);
 
-    // The newly loaded track should have been seeked back by the duration of transition.
+    // The newly loaded track should have been seeked back by the trackSamples of transition.
     EXPECT_DOUBLE_EQ(-0.1, deck2.playposition.get());
 
     // No change to the mode, crossfader or play states.


### PR DESCRIPTION
The issue was that we have calculated the track duration via different functions. 
This leads to different rounding issues making equal checks fail. 

This fixes https://bugs.launchpad.net/mixxx/+bug/1858340, a high priority bug, that is mandatory for the 2.3 release. 

In addition this also fixes an issue where AutoDJ stops on high system loads conditions. 
This was my first assumption for the root cause of this bug.  