### PR TITLE
Fix disappearing fader handles for Deere skin

### DIFF
--- a/res/skins/Deere/handle-crossfader-blue.svg
+++ b/res/skins/Deere/handle-crossfader-blue.svg
@@ -1,2 +1,6 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="svg2" width="80" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect id="rect4138" transform="scale(-1)" x="-75" y="-195" width="70" height="190" rx="10" ry="10" fill="#333" stroke="#e0e0e0" stroke-width="10"/><rect id="rect4151-3" transform="rotate(90)" x="22.134" y="-57.263" width="155.73" height="34.525" rx="2" ry="2" fill="#c5d11f"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="15" height="40" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <style/>
+ <path d="m3 1h9c1.108 0 2 0.892 2 2v34c0 1.108-0.892 2-2 2h-9c-1.108 0-2-0.892-2-2v-34c0-1.108 0.892-2 2-2z" fill="#333" stroke="#e0e0e0" stroke-width="2"/>
+ <path d="m4 35.589v-31.178c0-0.22768 0.21148-0.41097 0.47417-0.41097h6.0517c0.26269 0 0.47417 0.18329 0.47417 0.41097v31.178c0 0.22768-0.21148 0.41097-0.47417 0.41097h-6.0517c-0.26269 0-0.47417-0.18329-0.47417-0.41097z" fill="#378df7"/>
+</svg>

--- a/res/skins/Deere/handle-crossfader-grey.svg
+++ b/res/skins/Deere/handle-crossfader-grey.svg
@@ -1,2 +1,6 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="svg2" width="80" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect id="rect4138" transform="scale(-1)" x="-75" y="-195" width="70" height="190" rx="10" ry="10" fill="#333" stroke="#e0e0e0" stroke-width="10"/><rect id="rect4151-3" transform="rotate(90)" x="22.134" y="-57.263" width="155.73" height="34.525" rx="2" ry="2" fill="#939393"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="15" height="40" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <style/>
+ <path d="m3 1h9c1.108 0 2 0.892 2 2v34c0 1.108-0.892 2-2 2h-9c-1.108 0-2-0.892-2-2v-34c0-1.108 0.892-2 2-2z" fill="#333" stroke="#e0e0e0" stroke-width="2"/>
+ <path d="m4 35.589v-31.178c0-0.22768 0.21148-0.41097 0.47417-0.41097h6.0517c0.26269 0 0.47417 0.18329 0.47417 0.41097v31.178c0 0.22768-0.21148 0.41097-0.47417 0.41097h-6.0517c-0.26269 0-0.47417-0.18329-0.47417-0.41097z" fill="#939393"/>
+</svg>

--- a/res/skins/Deere/handle-crossfader-lime.svg
+++ b/res/skins/Deere/handle-crossfader-lime.svg
@@ -1,2 +1,6 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="svg2" width="80" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect id="rect4138" transform="scale(-1)" x="-75" y="-195" width="70" height="190" rx="10" ry="10" fill="#333" stroke="#e0e0e0" stroke-width="10"/><rect id="rect4151-3" transform="rotate(90)" x="22.134" y="-57.263" width="155.73" height="34.525" rx="2" ry="2" fill="#c5d11f"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="15" height="40" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <style/>
+ <path d="m3 1h9c1.108 0 2 0.892 2 2v34c0 1.108-0.892 2-2 2h-9c-1.108 0-2-0.892-2-2v-34c0-1.108 0.892-2 2-2z" fill="#333" stroke="#e0e0e0" stroke-width="2"/>
+ <path d="m4 35.589v-31.178c0-0.22768 0.21148-0.41097 0.47417-0.41097h6.0517c0.26269 0 0.47417 0.18329 0.47417 0.41097v31.178c0 0.22768-0.21148 0.41097-0.47417 0.41097h-6.0517c-0.26269 0-0.47417-0.18329-0.47417-0.41097z" fill="#c5d11f"/>
+</svg>

--- a/res/skins/Deere/handle-crossfader-orange.svg
+++ b/res/skins/Deere/handle-crossfader-orange.svg
@@ -1,2 +1,6 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="svg2" width="80" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect id="rect4138" transform="scale(-1)" x="-75" y="-195" width="70" height="190" rx="10" ry="10" fill="#333" stroke="#e0e0e0" stroke-width="10"/><rect id="rect4151-3" transform="rotate(90)" x="22.134" y="-57.263" width="155.73" height="34.525" rx="2" ry="2" fill="#ffb108"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="15" height="40" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <style/>
+ <path d="m3 1h9c1.108 0 2 0.892 2 2v34c0 1.108-0.892 2-2 2h-9c-1.108 0-2-0.892-2-2v-34c0-1.108 0.892-2 2-2z" fill="#333" stroke="#e0e0e0" stroke-width="2"/>
+ <path d="m4 35.589v-31.178c0-0.22768 0.21148-0.41097 0.47417-0.41097h6.0517c0.26269 0 0.47417 0.18329 0.47417 0.41097v31.178c0 0.22768-0.21148 0.41097-0.47417 0.41097h-6.0517c-0.26269 0-0.47417-0.18329-0.47417-0.41097z" fill="#ffb108"/>
+</svg>

--- a/res/skins/Deere/handle-vertical-blue.svg
+++ b/res/skins/Deere/handle-vertical-blue.svg
@@ -1,2 +1,6 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="svg2" width="200" height="75" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect id="rect4138" transform="rotate(-90)" x="-70" y="5" width="65" height="190" rx="10" ry="10" fill="#333" stroke="#e0e0e0" stroke-width="10"/><rect id="rect4151-3" transform="scale(-1)" x="-177.87" y="-52.263" width="155.73" height="29.525" rx="2" ry="2" fill="#378df7"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40" height="15" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <style/>
+ <path d="m1 12v-9c0-1.108 0.892-2 2-2h34c1.108 0 2 0.892 2 2v9c0 1.108-0.892 2-2 2h-34c-1.108 0-2-0.892-2-2z" fill="#333" stroke="#e0e0e0" stroke-width="2"/>
+ <path d="m35.589 11h-31.178c-0.22768 0-0.41097-0.21148-0.41097-0.47417v-6.0517c0-0.26269 0.18329-0.47417 0.41097-0.47417h31.178c0.22768 0 0.41097 0.21148 0.41097 0.47417v6.0517c0 0.26269-0.18329 0.47417-0.41097 0.47417z" fill="#378df7"/>
+</svg>

--- a/res/skins/Deere/handle-vertical-carmine.svg
+++ b/res/skins/Deere/handle-vertical-carmine.svg
@@ -1,2 +1,6 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="svg2" width="200" height="75" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect id="rect4138" transform="rotate(-90)" x="-70" y="5" width="65" height="190" rx="10" ry="10" fill="#333" stroke="#e0e0e0" stroke-width="10"/><rect id="rect4151-3" transform="scale(-1)" x="-177.87" y="-52.263" width="155.73" height="29.525" rx="2" ry="2" fill="#e02f00"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40" height="15" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <style/>
+ <path d="m1 12v-9c0-1.108 0.892-2 2-2h34c1.108 0 2 0.892 2 2v9c0 1.108-0.892 2-2 2h-34c-1.108 0-2-0.892-2-2z" fill="#333" stroke="#e0e0e0" stroke-width="2"/>
+ <path d="m35.589 11h-31.178c-0.22768 0-0.41097-0.21148-0.41097-0.47417v-6.0517c0-0.26269 0.18329-0.47417 0.41097-0.47417h31.178c0.22768 0 0.41097 0.21148 0.41097 0.47417v6.0517c0 0.26269-0.18329 0.47417-0.41097 0.47417z" fill="#e02f00"/>
+</svg>

--- a/res/skins/Deere/handle-vertical-grey.svg
+++ b/res/skins/Deere/handle-vertical-grey.svg
@@ -1,2 +1,6 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="svg2" width="200" height="75" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect id="rect4138" transform="rotate(-90)" x="-70" y="5" width="65" height="190" rx="10" ry="10" fill="#333" stroke="#e0e0e0" stroke-width="10"/><rect id="rect4151-3" transform="scale(-1)" x="-177.87" y="-52.263" width="155.73" height="29.525" rx="2" ry="2" fill="#939393"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40" height="15" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <style/>
+ <path d="m1 12v-9c0-1.108 0.892-2 2-2h34c1.108 0 2 0.892 2 2v9c0 1.108-0.892 2-2 2h-34c-1.108 0-2-0.892-2-2z" fill="#333" stroke="#e0e0e0" stroke-width="2"/>
+ <path d="m35.589 11h-31.178c-0.22768 0-0.41097-0.21148-0.41097-0.47417v-6.0517c0-0.26269 0.18329-0.47417 0.41097-0.47417h31.178c0.22768 0 0.41097 0.21148 0.41097 0.47417v6.0517c0 0.26269-0.18329 0.47417-0.41097 0.47417z" fill="#939393"/>
+</svg>

--- a/res/skins/Deere/handle-vertical-lime.svg
+++ b/res/skins/Deere/handle-vertical-lime.svg
@@ -1,2 +1,6 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="svg2" width="200" height="75" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect id="rect4138" transform="rotate(-90)" x="-70" y="5" width="65" height="190" rx="10" ry="10" fill="#333" stroke="#e0e0e0" stroke-width="10"/><rect id="rect4151-3" transform="scale(-1)" x="-177.87" y="-52.263" width="155.73" height="29.525" rx="2" ry="2" fill="#c5d11f"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40" height="15" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <style/>
+ <path d="m1 12v-9c0-1.108 0.892-2 2-2h34c1.108 0 2 0.892 2 2v9c0 1.108-0.892 2-2 2h-34c-1.108 0-2-0.892-2-2z" fill="#333" stroke="#e0e0e0" stroke-width="2"/>
+ <path d="m35.589 11h-31.178c-0.22768 0-0.41097-0.21148-0.41097-0.47417v-6.0517c0-0.26269 0.18329-0.47417 0.41097-0.47417h31.178c0.22768 0 0.41097 0.21148 0.41097 0.47417v6.0517c0 0.26269-0.18329 0.47417-0.41097 0.47417z" fill="#c5d11f"/>
+</svg>

--- a/res/skins/Deere/handle-vertical-orange.svg
+++ b/res/skins/Deere/handle-vertical-orange.svg
@@ -1,2 +1,6 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="svg2" width="200" height="75" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect id="rect4138" transform="rotate(-90)" x="-70" y="5" width="65" height="190" rx="10" ry="10" fill="#333" stroke="#e0e0e0" stroke-width="10"/><rect id="rect4151-3" transform="scale(-1)" x="-177.87" y="-52.263" width="155.73" height="29.525" rx="2" ry="2" fill="#e3ca1f"/><rect id="rect5888" transform="scale(-1)" x="-177.87" y="-52.263" width="155.73" height="29.525" rx="2" ry="2" fill="#ffb108"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40" height="15" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <style/>
+ <path d="m1 12v-9c0-1.108 0.892-2 2-2h34c1.108 0 2 0.892 2 2v9c0 1.108-0.892 2-2 2h-34c-1.108 0-2-0.892-2-2z" fill="#333" stroke="#e0e0e0" stroke-width="2"/>
+ <path d="m35.589 11h-31.178c-0.22768 0-0.41097-0.21148-0.41097-0.47417v-6.0517c0-0.26269 0.18329-0.47417 0.41097-0.47417h31.178c0.22768 0 0.41097 0.21148 0.41097 0.47417v6.0517c0 0.26269-0.18329 0.47417-0.41097 0.47417z" fill="#ffb108"/>
+</svg>

--- a/res/skins/Deere/handle-vertical-purple.svg
+++ b/res/skins/Deere/handle-vertical-purple.svg
@@ -1,2 +1,6 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="svg2" width="200" height="75" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect id="rect4138" transform="rotate(-90)" x="-70" y="5" width="65" height="190" rx="10" ry="10" fill="#333" stroke="#e0e0e0" stroke-width="10"/><rect id="rect4151-3" transform="scale(-1)" x="-177.87" y="-52.263" width="155.73" height="29.525" rx="2" ry="2" fill="#f2d440"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40" height="15" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <style/>
+ <path d="m1 12v-9c0-1.108 0.892-2 2-2h34c1.108 0 2 0.892 2 2v9c0 1.108-0.892 2-2 2h-34c-1.108 0-2-0.892-2-2z" fill="#333" stroke="#e0e0e0" stroke-width="2"/>
+ <path d="m35.589 11h-31.178c-0.22768 0-0.41097-0.21148-0.41097-0.47417v-6.0517c0-0.26269 0.18329-0.47417 0.41097-0.47417h31.178c0.22768 0 0.41097 0.21148 0.41097 0.47417v6.0517c0 0.26269-0.18329 0.47417-0.41097 0.47417z" fill="#f2d440"/>
+</svg>

--- a/res/skins/Deere/mixer.xml
+++ b/res/skins/Deere/mixer.xml
@@ -122,6 +122,7 @@
                   <SliderComposed>
                     <TooltipId>crossfader</TooltipId>
                     <Size>1me,40f</Size>
+                    <MaximumSize>200,40</MaximumSize>
                     <Slider scalemode="STRETCH">slider-crossfader.svg</Slider>
                     <Handle scalemode="STRETCH_ASPECT">handle-crossfader-orange.svg</Handle>
                     <Horizontal>true</Horizontal>

--- a/res/skins/Deere/slider-crossfader-AutoDJ.svg
+++ b/res/skins/Deere/slider-crossfader-AutoDJ.svg
@@ -1,1 +1,5 @@
-<svg id="svg2" width="180" height="40" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect id="rect2984" x="3.9767" y="12.759" width="172.05" height="14.483" color="#000000" fill="#f60"/><!-- marker lines every 5px --><!-- end marker --><!-- quarter marker --><!-- middle marker --><!-- quarter marker --><!-- end marker --></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="180" height="40" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <style/>
+ <rect x="1" y="12" width="178" height="16" color="#000000" fill="#f60"/>
+</svg>

--- a/res/skins/Deere/slider-crossfader.svg
+++ b/res/skins/Deere/slider-crossfader.svg
@@ -1,2 +1,6 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="svg2" width="180" height="40" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect id="rect4167" transform="rotate(90)" x="12.633" y="-176.2" width="14.734" height="172.4" rx=".92518" ry="1.0809" fill="none" stroke="#555" stroke-linecap="round" stroke-width="1.5"/><path id="path4175" d="m170.32 18.062h-160.64v3.875h160.64v-3.875z" fill="#222" stroke="#222" stroke-linecap="round" stroke-width="2.5"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="180" height="40" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <style/>
+ <rect x="1.75" y="12.75" width="176.5" height="14.5" rx="1" ry="1" fill="none" stroke="#555" stroke-linecap="round" stroke-width="1.5"/>
+ <path d="m6.4826 20h167.03z" fill="none" stroke="#222" stroke-width="6"/>
+</svg>

--- a/res/skins/Deere/slider-vertical.svg
+++ b/res/skins/Deere/slider-vertical.svg
@@ -1,2 +1,6 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="svg2" width="40" height="162" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect id="rect4167" x="12.633" y="1.25" width="14.734" height="159.5" rx="1" ry="1" fill="none" stroke="#555" stroke-linecap="round" stroke-width="1.5"/><path id="path4175" transform="translate(0,-9)" d="m18.062 15.688v148.62h3.875v-148.62h-3.875z" fill="#222" stroke="#222" stroke-linecap="round" stroke-width="2.5"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40" height="162" version="1.1" xmlns="http://www.w3.org/2000/svg">
+ <style/>
+ <rect x="12.75" y="1.75" width="14.5" height="158.5" rx="1" ry="1" fill="none" stroke="#555" stroke-linecap="round" stroke-width="1.5"/>
+ <path d="m20 156v-150z" fill="none" stroke="#222" stroke-width="6"/>
+</svg>


### PR DESCRIPTION
If linked against QT 5.14.0, the fader handles can become invisible, depending on the position of the handle. Fixes [lp:1857813](https://bugs.launchpad.net/mixxx/+bug/1857813)

Copying parts of my comments from launchpad.net:
> There was a svg viewport fix in 5.14 worth investigating
https://bugreports.qt.io/browse/QTBUG-70256

> Another aspect of the bug is that stretching images inside mixxx do not work as they used to be.
 As seen in OP´s video [#1](https://bugs.launchpad.net/mixxx/+bug/1857813/+attachment/5316231/+files/2019-12-29%2016-46-40.mkv). The crossfader slider stretch is off, compared with QT 5.13.

>  Also, at least on macOS, there are major performance issues with this specific QT version.
On my machine, mixxx is at 100% CPU even while idle, just trying to render images.

> It appears there have been some changes to the graphics stack .
https://wiki.qt.io/Qt_5.14_Release

 > As said, apparently there is an issue with mixxx internal STRETCH image function. The crossfader slider graphic ``slider-crossfader.svg`` does not stretch (expand) correct to the sliders widget size, but the ``slider-crossfader-AutoDJ.svg`` , active when using AUTODJ and defined in ``style.qss`` does.

**Post**:
<img width="359" alt="Screenshot 2020-01-17 at 12 02 05" src="https://user-images.githubusercontent.com/4525897/72611632-e9137e80-392a-11ea-99af-0e8315aeec63.png">

**Pre**:
<img width="359" alt="Screenshot 2020-01-17 at 12 18 46" src="https://user-images.githubusercontent.com/4525897/72611634-ec0e6f00-392a-11ea-9fff-1d69e402636e.png">
