### PR TITLE
Reintroduce M_FALLTHROUGH_INTENDED 

### DIFF
--- a/src/control/controlindicator.cpp
+++ b/src/control/controlindicator.cpp
@@ -35,10 +35,8 @@ void ControlIndicator::slotGuiTick50ms(double cpuTime) {
         case RATIO1TO1_250MS:
             toggle(0.25);
             break;
-        case OFF:
-            [[fallthrough]];
-        case ON:
-            [[fallthrough]];
+        case OFF: // fall through
+        case ON: // fall through
         default:
             // nothing to do
             break;

--- a/src/control/controlproxy.h
+++ b/src/control/controlproxy.h
@@ -7,6 +7,7 @@
 
 #include "control/control.h"
 #include "preferences/usersettings.h"
+#include "util/platform.h"
 
 // This class is the successor of ControlObjectThread. It should be used for
 // new code to avoid unnecessary locking during send if no slot is connected.
@@ -60,7 +61,7 @@ class ControlProxy : public QObject {
             break;
         case Qt::BlockingQueuedConnection:
             // We must not block the signal source by a blocking connection
-            [[fallthrough]];
+            M_FALLTHROUGH_INTENDED;
         default:
             DEBUG_ASSERT(false);
             return false;

--- a/src/encoder/encoderbroadcastsettings.cpp
+++ b/src/encoder/encoderbroadcastsettings.cpp
@@ -77,8 +77,7 @@ EncoderSettings::ChannelMode EncoderBroadcastSettings::getChannelMode() const {
     switch(m_pProfile->getChannels()) {
         case 1: return EncoderSettings::ChannelMode::MONO;
         case 2: return EncoderSettings::ChannelMode::STEREO;
-        case 0:
-        [[fallthrough]];
+        case 0: // fallthrough
         default: return EncoderSettings::ChannelMode::AUTOMATIC;
     }
 }

--- a/src/encoder/encodervorbis.cpp
+++ b/src/encoder/encodervorbis.cpp
@@ -63,8 +63,7 @@ void EncoderVorbis::setEncoderSettings(const EncoderSettings& settings)
     switch(settings.getChannelMode()) {
         case EncoderSettings::ChannelMode::MONO:  m_channels = 1; break;
         case EncoderSettings::ChannelMode::STEREO: m_channels = 2; break;
-        case EncoderSettings::ChannelMode::AUTOMATIC:
-            [[fallthrough]];
+        case EncoderSettings::ChannelMode::AUTOMATIC: // fallthrough
         default:
             if (m_bitrate > MONO_BITRATE_THRESHOLD ) {
                 m_channels = 2;

--- a/src/preferences/dialog/dlgprefvinyl.cpp
+++ b/src/preferences/dialog/dlgprefvinyl.cpp
@@ -27,6 +27,7 @@
 #include "vinylcontrol/defs_vinylcontrol.h"
 #include "vinylcontrol/vinylcontrolmanager.h"
 #include "defs_urls.h"
+#include "util/platform.h"
 
 DlgPrefVinyl::DlgPrefVinyl(QWidget * parent, VinylControlManager *pVCMan,
                            UserSettingsPointer  _config)
@@ -348,21 +349,21 @@ void DlgPrefVinyl::VinylTypeSlotApply()
         } else if (ComboBoxVinylSpeed4->currentText() == MIXXX_VINYL_SPEED_45) {
             m_COSpeeds[3]->set(MIXXX_VINYL_SPEED_45_NUM);
         }
-        [[fallthrough]];
+        M_FALLTHROUGH_INTENDED;
     case 3:
         if (ComboBoxVinylSpeed3->currentText() == MIXXX_VINYL_SPEED_33) {
             m_COSpeeds[2]->slotSet(MIXXX_VINYL_SPEED_33_NUM);
         } else if (ComboBoxVinylSpeed3->currentText() == MIXXX_VINYL_SPEED_45) {
             m_COSpeeds[2]->slotSet(MIXXX_VINYL_SPEED_45_NUM);
         }
-        [[fallthrough]];
+        M_FALLTHROUGH_INTENDED;
     case 2:
         if (ComboBoxVinylSpeed2->currentText() == MIXXX_VINYL_SPEED_33) {
             m_COSpeeds[1]->slotSet(MIXXX_VINYL_SPEED_33_NUM);
         } else if (ComboBoxVinylSpeed2->currentText() == MIXXX_VINYL_SPEED_45) {
             m_COSpeeds[1]->slotSet(MIXXX_VINYL_SPEED_45_NUM);
         }
-        [[fallthrough]];
+        M_FALLTHROUGH_INTENDED;
     case 1:
         if (ComboBoxVinylSpeed1->currentText() == MIXXX_VINYL_SPEED_33) {
             m_COSpeeds[0]->slotSet(MIXXX_VINYL_SPEED_33_NUM);

--- a/src/util/platform.h
+++ b/src/util/platform.h
@@ -23,4 +23,21 @@
 #error We do not support your compiler. Please email mixxx-devel@lists.sourceforge.net and tell us about your use case.
 #endif
 
+#if defined(__clang__) && defined(__has_warning)
+#if __has_feature(cxx_attributes) && __has_warning("-Wimplicit-fallthrough")
+#define M_FALLTHROUGH_INTENDED [[clang::fallthrough]]
+#endif
+#elif defined(__GNUC__) && __GNUC__ >= 7
+// Taken from https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-fallthrough_003d
+// We could also use a comment, but that would require ccache users to set the
+// keep_comments_cpp option. If we switch to C++17, we can use [[fallthough]].
+#define M_FALLTHROUGH_INTENDED __attribute__ ((fallthrough));
+#endif
+
+#ifndef M_FALLTHROUGH_INTENDED
+#define M_FALLTHROUGH_INTENDED \
+  do {                         \
+  } while (0)
+#endif
+
 #endif /* MIXXX_UTIL_PLATFORM_H */


### PR DESCRIPTION
macro for a warning free compilation on Ubuntu Trusty with clang 3.8 and g++ 5.4
It seems that [[fallthrough]] slipped in to late. :-(
