### PR TITLE
.eslintrc.json: Add rule for indentation style

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     "func-style": ["error", "expression", {
         "allowArrowFunctions": true
     }],
+    "indent": ["warn", 4],
     "key-spacing": "warn",
     "keyword-spacing": "warn",
     "linebreak-style": ["warn", "unix"],


### PR DESCRIPTION
Just checked a controller script PR that used tabs and realized that eslint does not enforce an indentation style. I'd guessed that this is part of the "eslint:recommended" ruleset, but apparently it isn't.