### PR TITLE
Prevent pushbuttons with 'blocked' controls getting stuck pressed

### DIFF
--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -350,10 +350,10 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
         if (leftClick) {
             m_clickTimer.setSingleShot(true);
             m_clickTimer.start(ControlPushButtonBehavior::kPowerWindowTimeMillis);
+            m_bPressed = true;
 
             double emitValue = getControlParameterLeft() == 0.0 ? 1.0 : 0.0;
             setControlParameterLeftDown(emitValue);
-            m_bPressed = true;
             restyleAndRepaint();
         }
         // discharge right clicks here, because is used for latching in POWERWINDOW mode
@@ -374,6 +374,7 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
     }
 
     if (leftClick) {
+        m_bPressed = true;
         double emitValue;
         if (m_leftButtonMode == ControlPushButton::PUSH
                 || m_iNoStates == 1) {
@@ -391,7 +392,6 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
                 m_clickTimer.start(ControlPushButtonBehavior::kLongPressLatchingTimeMillis);
             }
         }
-        m_bPressed = true;
         setControlParameterLeftDown(emitValue);
         restyleAndRepaint();
     }
@@ -415,13 +415,13 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
     if (m_leftButtonMode == ControlPushButton::POWERWINDOW
             && m_iNoStates == 2) {
         if (leftClick) {
+            m_bPressed = false;
             const bool rightButtonDown = QApplication::mouseButtons() & Qt::RightButton;
             if (m_bPressed && !m_clickTimer.isActive() && !rightButtonDown) {
                 // Release button after timer, but not if right button is clicked
                 double emitValue = getControlParameterLeft() == 0.0 ? 1.0 : 0.0;
                 setControlParameterLeftUp(emitValue);
             }
-            m_bPressed = false;
         } else if (rightClick) {
             m_bPressed = false;
         }
@@ -443,6 +443,7 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
     }
 
     if (leftClick) {
+        m_bPressed = false;
         double emitValue = getControlParameterLeft();
         if (m_leftButtonMode == ControlPushButton::PUSH
                 || m_iNoStates == 1) {
@@ -459,7 +460,6 @@ void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
                 // Nothing special happens when releasing a normal toggle button
             }
         }
-        m_bPressed = false;
         setControlParameterLeftUp(emitValue);
         restyleAndRepaint();
     }

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -290,7 +290,9 @@ void WPushButton::onConnectedControlChanged(double dParameter, double dValue) {
     Q_UNUSED(dParameter);
     // Enums are not currently represented using parameter space so it doesn't
     // make sense to use the parameter here yet.
-    m_bPressed = (dValue == 1.0);
+    if (m_iNoStates == 1) {
+        m_bPressed = (dValue == 1.0);
+    }
 
     restyleAndRepaint();
 }
@@ -395,15 +397,27 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
     }
 }
 
+bool WPushButton::event(QEvent* e) {
+    if (e->type() == QEvent::WindowDeactivate) {
+        // if the window is deactivated while in pressed state
+        if (m_bPressed) {
+            m_bPressed = false;
+            restyleAndRepaint();
+        }
+    }
+    return QWidget::event(e);
+}
+
 void WPushButton::focusOutEvent(QFocusEvent* e) {
-    Q_UNUSED(e);
-    if (e->reason() != Qt::MouseFocusReason) {
+    qDebug() << "focusOutEvent" << e->reason();
+    if (m_bPressed && e->reason() != Qt::MouseFocusReason) {
         // Since we support multi touch there is no reason to reset
         // the pressed flag if the Primary touch point is moved to an
         // other widget
         m_bPressed = false;
         restyleAndRepaint();
     }
+    QWidget::focusOutEvent(e);
 }
 
 void WPushButton::mouseReleaseEvent(QMouseEvent * e) {

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -290,9 +290,7 @@ void WPushButton::onConnectedControlChanged(double dParameter, double dValue) {
     Q_UNUSED(dParameter);
     // Enums are not currently represented using parameter space so it doesn't
     // make sense to use the parameter here yet.
-    if (m_iNoStates == 1) {
-        m_bPressed = (dValue == 1.0);
-    }
+    m_bPressed = (dValue == 1.0);
 
     restyleAndRepaint();
 }

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -75,7 +75,8 @@ class WPushButton : public WWidget {
     void onConnectedControlChanged(double dParameter, double dValue) override;
 
   protected:
-    void paintEvent(QPaintEvent* /*unused*/) override;
+    bool event(QEvent* e) override;
+    void paintEvent(QPaintEvent* e) override;
     void mousePressEvent(QMouseEvent* e) override;
     void mouseReleaseEvent(QMouseEvent* e) override;
     void focusOutEvent(QFocusEvent* e) override;


### PR DESCRIPTION
When a disallowed click is performed, like enabling Passthrough, VinylControl or TalkOver with no respective device set up, the button release is not registered because modal message boxes block interaction with Mixxx main window, and the button is 'pressed' only after the message is closed and remains so. Noticed with Shade (colored button) and LateNight (3D effect).
* click Passthrough button
* `group,passthrough` is set `1`
* message pops up, blocks release event, `group,passthrough` is forced `0`
* close popup
* button is set 'pressed', no further control update

Solution:
* set the 'pressed' property before setting any control (which could enforce a popup)
* allow `onConnectedControlChanged` to update the 'pressed' property also for pushbutton with more than one state 

I didn't discover a regression, yet, so I'm curious why this limitation was installed in the first place.?

Maybe we could also use a special pushbutton widget or a different control connection for those buttons that checks if setting the control is allowed to be toggled **before** actually doing it, which would also prevent disallowed Passthrough stopping playing decks.
But IMO the fix proposed here is the easiest way to resolve this issue.