### PR TITLE
controllers/controlpickermenu: Fix reset controls not being used

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -862,7 +862,7 @@ void ControlPickerMenu::addPlayerControl(QString control, QString controlTitle,
         if (resetControlMenu) {
             QString resetTitle = QString("%1 (%2)").arg(controlTitle, m_resetStr);
             QString resetDescription = QString("%1 (%2)").arg(controlDescription, m_resetStr);
-            addSingleControl(group, control, resetTitle, resetDescription,
+            addSingleControl(group, resetControl, resetTitle, resetDescription,
                              controlMenu, prefix, prefix);
         }
     }
@@ -877,7 +877,7 @@ void ControlPickerMenu::addPlayerControl(QString control, QString controlTitle,
         if (resetControlMenu) {
             QString resetTitle = QString("%1 (%2)").arg(controlTitle, m_resetStr);
             QString resetDescription = QString("%1 (%2)").arg(controlDescription, m_resetStr);
-            addSingleControl(group, control, resetTitle, resetDescription,
+            addSingleControl(group, resetControl, resetTitle, resetDescription,
                              controlMenu, prefix, prefix);
         }
     }
@@ -892,7 +892,7 @@ void ControlPickerMenu::addPlayerControl(QString control, QString controlTitle,
         if (resetControlMenu) {
             QString resetTitle = QString("%1 (%2)").arg(controlTitle, m_resetStr);
             QString resetDescription = QString("%1 (%2)").arg(controlDescription, m_resetStr);
-            addSingleControl(group, control, resetTitle, resetDescription,
+            addSingleControl(group, resetControl, resetTitle, resetDescription,
                              controlMenu, prefix, prefix);
         }
     }
@@ -927,7 +927,7 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
             if (resetControlMenu) {
                 QString resetTitle = QString("%1 (%2)").arg(controlTitle, m_resetStr);
                 QString resetDescription = QString("%1 (%2)").arg(controlDescription, m_resetStr);
-                addSingleControl(group, control, resetTitle, resetDescription,
+                addSingleControl(group, resetControl, resetTitle, resetDescription,
                                  controlMenu, prefix, prefix);
             }
         }
@@ -944,7 +944,7 @@ void ControlPickerMenu::addMicrophoneAndAuxControl(QString control,
             if (resetControlMenu) {
                 QString resetTitle = QString("%1 (%2)").arg(controlTitle, m_resetStr);
                 QString resetDescription = QString("%1 (%2)").arg(controlDescription, m_resetStr);
-                addSingleControl(group, control, resetTitle, resetDescription,
+                addSingleControl(group, resetControl, resetTitle, resetDescription,
                                  controlMenu, prefix, prefix);
             }
         }


### PR DESCRIPTION
This fixes a regression introduced in commit
da199583da12f065b06d24a68d74947f0d5a08d5 which made the control picker
use the normal control instead of the _set_default one.