### PR TITLE
[WIP] Vinyl controls visibility tweaks

### DIFF
--- a/res/skins/Deere/vinylcontrol.xml
+++ b/res/skins/Deere/vinylcontrol.xml
@@ -4,69 +4,79 @@
     <Layout>horizontal</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
-
       <WidgetGroup>
-        <ObjectName>VinylControlsGrid</ObjectName>
-        <Layout>vertical</Layout>
+        <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
-          <Template src="skin:left_2state_button.xml">
-            <SetVariable name="TooltipId">vinylcontrol_enabled</SetVariable>
-            <SetVariable name="ObjectName">VinylToggleButtonUL</SetVariable>
-            <SetVariable name="MinimumSize">40,10</SetVariable>
-            <SetVariable name="MaximumSize">40,22</SetVariable>
-            <SetVariable name="SizePolicy">f,me</SetVariable>
-            <SetVariable name="state_0_text">Vinyl</SetVariable>
-            <SetVariable name="state_1_text">Vinyl</SetVariable>
-            <SetVariable name="left_connection_control"><Variable name="group"/>,vinylcontrol_enabled</SetVariable>
-          </Template>
 
-          <Template src="skin:left_3state_button.xml">
-            <SetVariable name="ObjectName">TristateButton</SetVariable>
-            <SetVariable name="MinimumSize">40,10</SetVariable>
-            <SetVariable name="MaximumSize">40,22</SetVariable>
-            <SetVariable name="SizePolicy">f,me</SetVariable>
-            <SetVariable name="state_0_text">ABS</SetVariable>
-            <SetVariable name="state_1_text">REL</SetVariable>
-            <SetVariable name="state_2_text">CONST</SetVariable>
-            <SetVariable name="left_connection_control"><Variable name="group"/>,vinylcontrol_mode</SetVariable>
-          </Template>
+          <WidgetGroup>
+            <ObjectName>VinylControlsGrid</ObjectName>
+            <Layout>vertical</Layout>
+            <SizePolicy>min,min</SizePolicy>
+            <Children>
+              <Template src="skin:left_2state_button.xml">
+                <SetVariable name="TooltipId">vinylcontrol_enabled</SetVariable>
+                <SetVariable name="ObjectName">VinylToggleButtonUL</SetVariable>
+                <SetVariable name="MinimumSize">40,10</SetVariable>
+                <SetVariable name="MaximumSize">40,22</SetVariable>
+                <SetVariable name="SizePolicy">f,me</SetVariable>
+                <SetVariable name="state_0_text">Vinyl</SetVariable>
+                <SetVariable name="state_1_text">Vinyl</SetVariable>
+                <SetVariable name="left_connection_control"><Variable name="group"/>,vinylcontrol_enabled</SetVariable>
+              </Template>
+
+              <Template src="skin:left_3state_button.xml">
+                <SetVariable name="ObjectName">TristateButton</SetVariable>
+                <SetVariable name="MinimumSize">40,10</SetVariable>
+                <SetVariable name="MaximumSize">40,22</SetVariable>
+                <SetVariable name="SizePolicy">f,me</SetVariable>
+                <SetVariable name="state_0_text">ABS</SetVariable>
+                <SetVariable name="state_1_text">REL</SetVariable>
+                <SetVariable name="state_2_text">CONST</SetVariable>
+                <SetVariable name="left_connection_control"><Variable name="group"/>,vinylcontrol_mode</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup>
+
+          <WidgetGroup>
+            <ObjectName>VinylControlsGrid</ObjectName>
+            <Layout>vertical</Layout>
+            <SizePolicy>min,min</SizePolicy>
+            <Children>
+              <Template src="skin:left_2state_button.xml">
+                <SetVariable name="TooltipId">passthrough_enabled</SetVariable>
+                <SetVariable name="ObjectName">VinylToggleButtonLL</SetVariable>
+                <SetVariable name="MinimumSize">40,10</SetVariable>
+                <SetVariable name="MaximumSize">40,22</SetVariable>
+                <SetVariable name="SizePolicy">f,me</SetVariable>
+                <SetVariable name="state_0_text">PASS</SetVariable>
+                <SetVariable name="state_1_text">PASS</SetVariable>
+                <SetVariable name="left_connection_control"><Variable name="group"/>,passthrough</SetVariable>
+              </Template>
+
+              <Template src="skin:left_3state_button.xml">
+                <SetVariable name="ObjectName">VinylCueButton</SetVariable>
+                <SetVariable name="TooltipId">vinylcontrol_cueing</SetVariable>
+                <SetVariable name="MinimumSize">40,10</SetVariable>
+                <SetVariable name="MaximumSize">40,22</SetVariable>
+                <SetVariable name="SizePolicy">f,me</SetVariable>
+                <SetVariable name="state_0_text">CUE</SetVariable>
+                <SetVariable name="state_1_text">CUE</SetVariable>
+                <SetVariable name="state_2_text">HOT</SetVariable>
+                <SetVariable name="left_connection_control"><Variable name="group"/>,vinylcontrol_cueing</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup>
+
         </Children>
+        <Connection>
+          <ConfigKey>[VinylControl],show_vinylcontrol</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
       </WidgetGroup>
-
-      <WidgetGroup>
-        <ObjectName>VinylControlsGrid</ObjectName>
-        <Layout>vertical</Layout>
-        <SizePolicy>min,min</SizePolicy>
-        <Children>
-          <Template src="skin:left_2state_button.xml">
-            <SetVariable name="TooltipId">passthrough_enabled</SetVariable>
-            <SetVariable name="ObjectName">VinylToggleButtonLL</SetVariable>
-            <SetVariable name="MinimumSize">40,10</SetVariable>
-            <SetVariable name="MaximumSize">40,22</SetVariable>
-            <SetVariable name="SizePolicy">f,me</SetVariable>
-            <SetVariable name="state_0_text">PASS</SetVariable>
-            <SetVariable name="state_1_text">PASS</SetVariable>
-            <SetVariable name="left_connection_control"><Variable name="group"/>,passthrough</SetVariable>
-          </Template>
-
-          <Template src="skin:left_3state_button.xml">
-            <SetVariable name="ObjectName">VinylCueButton</SetVariable>
-            <SetVariable name="TooltipId">vinylcontrol_cueing</SetVariable>
-            <SetVariable name="MinimumSize">40,10</SetVariable>
-            <SetVariable name="MaximumSize">40,22</SetVariable>
-            <SetVariable name="SizePolicy">f,me</SetVariable>
-            <SetVariable name="state_0_text">CUE</SetVariable>
-            <SetVariable name="state_1_text">CUE</SetVariable>
-            <SetVariable name="state_2_text">HOT</SetVariable>
-            <SetVariable name="left_connection_control"><Variable name="group"/>,vinylcontrol_cueing</SetVariable>
-          </Template>
-        </Children>
-      </WidgetGroup>
-
     </Children>
     <Connection>
-      <ConfigKey>[VinylControl],show_vinylcontrol</ConfigKey>
+      <ConfigKey><Variable name="group"/>,input_configured</ConfigKey>
       <BindProperty>visible</BindProperty>
     </Connection>
   </WidgetGroup>

--- a/res/skins/LateNight/deck_vinyl_controls.xml
+++ b/res/skins/LateNight/deck_vinyl_controls.xml
@@ -1,77 +1,87 @@
 <Template>
   <WidgetGroup>
-    <ObjectName>VinylControls</ObjectName>
     <Layout>horizontal</Layout>
     <SizePolicy>min,f</SizePolicy>
     <Children>
-
-      <StatusLight>
-        <ObjectName>VinylStatus</ObjectName>
-        <Size>18f,18f</Size>
-        <TooltipId>vinylcontrol_status</TooltipId>
-        <PathStatusLight0 scalemode="STRETCH_ASPECT">skin:/style_<Variable name="style_scheme"/>/vinyl_control_0.svg</PathStatusLight0>
-        <PathStatusLight1 scalemode="STRETCH_ASPECT">skin:/style_<Variable name="style_scheme"/>/vinyl_control_1.svg</PathStatusLight1>
-        <PathStatusLight2 scalemode="STRETCH_ASPECT">skin:/style_<Variable name="style_scheme"/>/vinyl_control_2.svg</PathStatusLight2>
-        <PathStatusLight3 scalemode="STRETCH_ASPECT">skin:/style_<Variable name="style_scheme"/>/vinyl_control_3.svg</PathStatusLight3>
-        <Connection>
-          <ConfigKey><Variable name="group"/>,vinylcontrol_status</ConfigKey>
-        </Connection>
-      </StatusLight>
-
-      <!-- increase margin -->
-      <WidgetGroup><Size>3f,0min</Size></WidgetGroup>
-
       <WidgetGroup>
-        <ObjectName>VinylButtons</ObjectName>
+        <ObjectName>VinylControls</ObjectName>
         <Layout>horizontal</Layout>
         <SizePolicy>min,f</SizePolicy>
         <Children>
-          <!-- &#8202; is a hack to push text labels to the left or right
-               because the kerning of some letters/numbers destroys the desired
-               effect of center 'Align' and 'text-alignment' -->
-          <Template src="skin:button_2state.xml">
-            <SetVariable name="TooltipId">vinylcontrol_enabled</SetVariable>
-            <SetVariable name="ObjectName">VinylButton</SetVariable>
-            <SetVariable name="Size">39f,20f</SetVariable>
-            <SetVariable name="state_0_text">&#8202;&#8202;VINYL</SetVariable>
-            <SetVariable name="state_1_text">&#8202;&#8202;VINYL</SetVariable>
-            <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_enabled</SetVariable>
-          </Template>
 
-          <Template src="skin:button_3state_persist.xml">
-            <SetVariable name="TooltipId">vinylcontrol_mode</SetVariable>
-            <SetVariable name="ObjectName">VinylTristateButton</SetVariable>
-            <SetVariable name="Size">42f,20f</SetVariable>
-            <SetVariable name="state_0_text">ABS</SetVariable>
-            <SetVariable name="state_1_text">REL</SetVariable>
-            <SetVariable name="state_2_text">&#8202;CONST</SetVariable>
-            <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_mode</SetVariable>
-          </Template>
+          <StatusLight>
+            <ObjectName>VinylStatus</ObjectName>
+            <Size>18f,18f</Size>
+            <TooltipId>vinylcontrol_status</TooltipId>
+            <PathStatusLight0 scalemode="STRETCH_ASPECT">skin:/style_<Variable name="style_scheme"/>/vinyl_control_0.svg</PathStatusLight0>
+            <PathStatusLight1 scalemode="STRETCH_ASPECT">skin:/style_<Variable name="style_scheme"/>/vinyl_control_1.svg</PathStatusLight1>
+            <PathStatusLight2 scalemode="STRETCH_ASPECT">skin:/style_<Variable name="style_scheme"/>/vinyl_control_2.svg</PathStatusLight2>
+            <PathStatusLight3 scalemode="STRETCH_ASPECT">skin:/style_<Variable name="style_scheme"/>/vinyl_control_3.svg</PathStatusLight3>
+            <Connection>
+              <ConfigKey><Variable name="group"/>,vinylcontrol_status</ConfigKey>
+            </Connection>
+          </StatusLight>
 
-          <Template src="skin:button_3state_persist.xml">
-            <SetVariable name="TooltipId">vinylcontrol_cueing</SetVariable>
-            <SetVariable name="ObjectName">VinylButton</SetVariable>
-            <SetVariable name="Size">28f,20f</SetVariable>
-            <SetVariable name="state_0_text">&#8202;CUE</SetVariable>
-            <SetVariable name="state_1_text">&#8202;CUE</SetVariable>
-            <SetVariable name="state_2_text">&#8202;HOT</SetVariable>
-            <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_cueing</SetVariable>
-          </Template>
+          <!-- increase margin -->
+          <WidgetGroup><Size>3f,0min</Size></WidgetGroup>
 
-          <Template src="skin:button_2state.xml">
-            <SetVariable name="TooltipId">passthrough_enabled</SetVariable>
-            <SetVariable name="ObjectName">VinylButton</SetVariable>
-            <SetVariable name="Size">33f,20f</SetVariable>
-            <SetVariable name="state_0_text">&#8202;PASS</SetVariable>
-            <SetVariable name="state_1_text">&#8202;PASS</SetVariable>
-            <SetVariable name="ConfigKey"><Variable name="group"/>,passthrough</SetVariable>
-          </Template>
+          <WidgetGroup>
+            <ObjectName>VinylButtons</ObjectName>
+            <Layout>horizontal</Layout>
+            <SizePolicy>min,f</SizePolicy>
+            <Children>
+              <!-- &#8202; is a hack to push text labels to the left or right
+                   because the kerning of some letters/numbers destroys the desired
+                   effect of center 'Align' and 'text-alignment' -->
+              <Template src="skin:button_2state.xml">
+                <SetVariable name="TooltipId">vinylcontrol_enabled</SetVariable>
+                <SetVariable name="ObjectName">VinylButton</SetVariable>
+                <SetVariable name="Size">39f,20f</SetVariable>
+                <SetVariable name="state_0_text">&#8202;&#8202;VINYL</SetVariable>
+                <SetVariable name="state_1_text">&#8202;&#8202;VINYL</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_enabled</SetVariable>
+              </Template>
+
+              <Template src="skin:button_3state_persist.xml">
+                <SetVariable name="TooltipId">vinylcontrol_mode</SetVariable>
+                <SetVariable name="ObjectName">VinylTristateButton</SetVariable>
+                <SetVariable name="Size">42f,20f</SetVariable>
+                <SetVariable name="state_0_text">ABS</SetVariable>
+                <SetVariable name="state_1_text">REL</SetVariable>
+                <SetVariable name="state_2_text">&#8202;CONST</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_mode</SetVariable>
+              </Template>
+
+              <Template src="skin:button_3state_persist.xml">
+                <SetVariable name="TooltipId">vinylcontrol_cueing</SetVariable>
+                <SetVariable name="ObjectName">VinylButton</SetVariable>
+                <SetVariable name="Size">28f,20f</SetVariable>
+                <SetVariable name="state_0_text">&#8202;CUE</SetVariable>
+                <SetVariable name="state_1_text">&#8202;CUE</SetVariable>
+                <SetVariable name="state_2_text">&#8202;HOT</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_cueing</SetVariable>
+              </Template>
+
+              <Template src="skin:button_2state.xml">
+                <SetVariable name="TooltipId">passthrough_enabled</SetVariable>
+                <SetVariable name="ObjectName">VinylButton</SetVariable>
+                <SetVariable name="Size">33f,20f</SetVariable>
+                <SetVariable name="state_0_text">&#8202;PASS</SetVariable>
+                <SetVariable name="state_1_text">&#8202;PASS</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="group"/>,passthrough</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup>
+
         </Children>
+        <Connection>
+          <ConfigKey persist="true">[VinylControl],show_vinylcontrol</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
       </WidgetGroup>
-
     </Children>
     <Connection>
-      <ConfigKey persist="true">[VinylControl],show_vinylcontrol</ConfigKey>
+      <ConfigKey><Variable name="group"/>,input_configured</ConfigKey>
       <BindProperty>visible</BindProperty>
     </Connection>
   </WidgetGroup>

--- a/res/skins/Shade/vinylcontrol.xml
+++ b/res/skins/Shade/vinylcontrol.xml
@@ -4,112 +4,122 @@
     <BackPath>style/style_bg_vinylcontrol.png</BackPath>
 		<Size>21,82</Size>
 		<Children>
-			<PushButton>
-				<TooltipId>vinylcontrol_status</TooltipId>
-				<NumberStates>2</NumberStates>
-				<State>
-					<Number>0</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol.png</Unpressed>
-				</State>
-				<State>
-					<Number>1</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_over.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_over.png</Unpressed>
-				</State>
-				<Pos>1,21</Pos>
-				<Connection>
-					<ConfigKey>[Channel<Variable name="channum"/>],vinylcontrol_enabled</ConfigKey>
-				</Connection>
-			</PushButton>
+	    <WidgetGroup>
+        <BackPath>style/style_bg_vinylcontrol.png</BackPath>
+		    <Size>21,82</Size>
+		    <Children>
+			    <PushButton>
+				    <TooltipId>vinylcontrol_status</TooltipId>
+				    <NumberStates>2</NumberStates>
+				    <State>
+					    <Number>0</Number>
+					    <Pressed>skin:/btn/btn_vinylcontrol.png</Pressed>
+					    <Unpressed>skin:/btn/btn_vinylcontrol.png</Unpressed>
+				    </State>
+				    <State>
+					    <Number>1</Number>
+					    <Pressed>skin:/btn/btn_vinylcontrol_over.png</Pressed>
+					    <Unpressed>skin:/btn/btn_vinylcontrol_over.png</Unpressed>
+				    </State>
+				    <Pos>1,21</Pos>
+				    <Connection>
+					    <ConfigKey>[Channel<Variable name="channum"/>],vinylcontrol_enabled</ConfigKey>
+				    </Connection>
+			    </PushButton>
 
-			<PushButton>
-				<TooltipId>vinylcontrol_status</TooltipId>
-				<NumberStates>2</NumberStates>
-				<State>
-					<Number>0</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_passthrough.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_passthrough.png</Unpressed>
-				</State>
-				<State>
-					<Number>1</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_passthrough_over.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_passthrough_over.png</Unpressed>
-				</State>
-				<Pos>1,1</Pos>
-				<Connection>
-					<ConfigKey>[Channel<Variable name="channum"/>],passthrough</ConfigKey>
-				</Connection>
-			</PushButton>
+			    <PushButton>
+				    <TooltipId>vinylcontrol_status</TooltipId>
+				    <NumberStates>2</NumberStates>
+				    <State>
+					    <Number>0</Number>
+					    <Pressed>skin:/btn/btn_vinylcontrol_passthrough.png</Pressed>
+					    <Unpressed>skin:/btn/btn_vinylcontrol_passthrough.png</Unpressed>
+				    </State>
+				    <State>
+					    <Number>1</Number>
+					    <Pressed>skin:/btn/btn_vinylcontrol_passthrough_over.png</Pressed>
+					    <Unpressed>skin:/btn/btn_vinylcontrol_passthrough_over.png</Unpressed>
+				    </State>
+				    <Pos>1,1</Pos>
+				    <Connection>
+					    <ConfigKey>[Channel<Variable name="channum"/>],passthrough</ConfigKey>
+				    </Connection>
+			    </PushButton>
 
-			<!--
-			**********************************************
-			Vinyl- Status
-			// Vinyl status indicators are inside the decks WidgetGroups
-			**********************************************
-			-->
+			    <!--
+			    **********************************************
+			    Vinyl- Status
+			    // Vinyl status indicators are inside the decks WidgetGroups
+			    **********************************************
+			    -->
 
-			**********************************************
-			Vinyl- Control Mode
-			**********************************************
+			    **********************************************
+			    Vinyl- Control Mode
+			    **********************************************
 
-			<PushButton>
-				<TooltipId>vinylcontrol_mode</TooltipId>
-				<NumberStates>3</NumberStates>
-				<State>
-					<Number>0</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_abs.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_abs.png</Unpressed>
-				</State>
-				<State>
-					<Number>1</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_rel.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_rel.png</Unpressed>
-				</State>
-				<State>
-					<Number>2</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_const.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_const.png</Unpressed>
-				</State>
-				<Pos>1,41</Pos>
-				<Connection>
-					<ConfigKey>[Channel<Variable name="channum"/>],vinylcontrol_mode</ConfigKey>
-				</Connection>
-			</PushButton>
+			    <PushButton>
+				    <TooltipId>vinylcontrol_mode</TooltipId>
+				    <NumberStates>3</NumberStates>
+				    <State>
+					    <Number>0</Number>
+					    <Pressed>skin:/btn/btn_vinylcontrol_abs.png</Pressed>
+					    <Unpressed>skin:/btn/btn_vinylcontrol_abs.png</Unpressed>
+				    </State>
+				    <State>
+					    <Number>1</Number>
+					    <Pressed>skin:/btn/btn_vinylcontrol_rel.png</Pressed>
+					    <Unpressed>skin:/btn/btn_vinylcontrol_rel.png</Unpressed>
+				    </State>
+				    <State>
+					    <Number>2</Number>
+					    <Pressed>skin:/btn/btn_vinylcontrol_const.png</Pressed>
+					    <Unpressed>skin:/btn/btn_vinylcontrol_const.png</Unpressed>
+				    </State>
+				    <Pos>1,41</Pos>
+				    <Connection>
+					    <ConfigKey>[Channel<Variable name="channum"/>],vinylcontrol_mode</ConfigKey>
+				    </Connection>
+			    </PushButton>
 
-			<!--
-			**********************************************
-			Vinyl- Cueing Mode
-			**********************************************
-			-->
+			    <!--
+			    **********************************************
+			    Vinyl- Cueing Mode
+			    **********************************************
+			    -->
 
-			<PushButton>
-				<TooltipId>vinylcontrol_cueing</TooltipId>
-				<NumberStates>3</NumberStates>
-				<State>
-					<Number>0</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_cue_off.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_cue_off.png</Unpressed>
-				</State>
-				<State>
-					<Number>1</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_cue_on.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_cue_on.png</Unpressed>
-				</State>
-				<State>
-					<Number>2</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_cue_hot.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_cue_hot.png</Unpressed>
-				</State>
-				<Pos>1,62</Pos>
-				<Connection>
-					<ConfigKey>[Channel<Variable name="channum"/>],vinylcontrol_cueing</ConfigKey>
-				</Connection>
-			</PushButton>
+			    <PushButton>
+				    <TooltipId>vinylcontrol_cueing</TooltipId>
+				    <NumberStates>3</NumberStates>
+				    <State>
+					    <Number>0</Number>
+					    <Pressed>skin:/btn/btn_vinylcontrol_cue_off.png</Pressed>
+					    <Unpressed>skin:/btn/btn_vinylcontrol_cue_off.png</Unpressed>
+				    </State>
+				    <State>
+					    <Number>1</Number>
+					    <Pressed>skin:/btn/btn_vinylcontrol_cue_on.png</Pressed>
+					    <Unpressed>skin:/btn/btn_vinylcontrol_cue_on.png</Unpressed>
+				    </State>
+				    <State>
+					    <Number>2</Number>
+					    <Pressed>skin:/btn/btn_vinylcontrol_cue_hot.png</Pressed>
+					    <Unpressed>skin:/btn/btn_vinylcontrol_cue_hot.png</Unpressed>
+				    </State>
+				    <Pos>1,62</Pos>
+				    <Connection>
+					    <ConfigKey>[Channel<Variable name="channum"/>],vinylcontrol_cueing</ConfigKey>
+				    </Connection>
+			    </PushButton>
 
+		    </Children>
+		    <Connection>
+			    <ConfigKey>[VinylControl],show_vinylcontrol</ConfigKey>
+			    <BindProperty>visible</BindProperty>
+		    </Connection>
+	    </WidgetGroup>
 		</Children>
 		<Connection>
-			<ConfigKey>[VinylControl],show_vinylcontrol</ConfigKey>
+			<ConfigKey>[Channel<Variable name="channum"/>],input_configured</ConfigKey>
 			<BindProperty>visible</BindProperty>
 		</Connection>
 	</WidgetGroup>

--- a/res/skins/Tango/deck_row_overview_left.xml
+++ b/res/skins/Tango/deck_row_overview_left.xml
@@ -29,50 +29,7 @@ Variables:
             <ObjectName>DeckOverviewSingleton<Variable name="chanNum"/></ObjectName>
           </SingletonContainer>
 
-          <WidgetGroup><ObjectName>Spacer0f</ObjectName><Size>1f,1min</Size></WidgetGroup>
-
           <Template src="skin:vinyl_controls_left.xml"/>
-
-          <WidgetGroup><!-- Vinyl Controls toggles -->
-            <Size>15f,50f</Size>
-            <Layout>vertical</Layout>
-            <Children>
-              <WidgetGroup><!-- Vinyl Controls toggle with passthrough -->
-                <Size>15f,50f</Size>
-                <Layout>horizontal</Layout>
-                <Children>
-                  <Template src="skin:button_2state.xml">
-                    <SetVariable name="ObjectName">VinylTogglerLeftPassthrough</SetVariable>
-                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
-                    <SetVariable name="Size">15f,50f</SetVariable>
-                    <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
-                  </Template>
-                </Children>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
-
-              <WidgetGroup><!-- Vinyl Controls toggle without passthrough -->
-                <Size>15f,50f</Size>
-                <Layout>horizontal</Layout>
-                <Children>
-                  <Template src="skin:button_2state.xml">
-                    <SetVariable name="ObjectName">VinylTogglerLeft</SetVariable>
-                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
-                    <SetVariable name="Size">15f,50f</SetVariable>
-                    <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
-                  </Template>
-                </Children>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-                  <Transform><Not/></Transform>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
-            </Children>
-          </WidgetGroup><!-- /Vinyl Controls toggles -->
 
           <!-- Small Cover/Spinny when explicitly set 'small' -->
           <WidgetGroup>

--- a/res/skins/Tango/deck_row_overview_right.xml
+++ b/res/skins/Tango/deck_row_overview_right.xml
@@ -18,13 +18,13 @@ Variables:
 <Template>
   <WidgetGroup>
     <ObjectName>Spacer0f</ObjectName>
-    <Layout>stacked</Layout>
-    <SizePolicy>me,f</SizePolicy>
+    <Layout>horizontal</Layout>
+    <Size>0me,50f</Size>
     <Children>
       <WidgetGroup>
         <ObjectName>DeckOverviewRow<Variable name="chanNum"/></ObjectName>
         <Layout>horizontal</Layout>
-        <SizePolicy>me,f</SizePolicy>
+        <SizePolicy>me,me</SizePolicy>
         <Children>
 
           <!-- Small Cover/Spinny when explicitly set 'small' -->
@@ -70,49 +70,6 @@ Variables:
               <BindProperty>visible</BindProperty>
             </Connection>
           </WidgetGroup><!-- / Small Cover/Spinny 2 -->
-
-          <WidgetGroup><!-- Vinyl Controls toggles -->
-            <Size>15f,50f</Size>
-            <Layout>vertical</Layout>
-            <Children>
-              <WidgetGroup><!-- Vinyl Controls toggle with passthrough -->
-                <Size>15f,50f</Size>
-                <Layout>horizontal</Layout>
-                <Children>
-                  <Template src="skin:button_2state.xml">
-                    <SetVariable name="ObjectName">VinylTogglerRightPassthrough</SetVariable>
-                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
-                    <SetVariable name="Size">15f,50f</SetVariable>
-                    <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
-                  </Template>
-                </Children>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
-
-              <WidgetGroup><!-- Vinyl Controls toggle without passthrough -->
-                <Size>15f,50f</Size>
-                <Layout>horizontal</Layout>
-                <Children>
-                  <Template src="skin:button_2state.xml">
-                    <SetVariable name="ObjectName">VinylTogglerRight</SetVariable>
-                    <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
-                    <SetVariable name="Size">15f,50f</SetVariable>
-                    <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
-                  </Template>
-                </Children>
-                <Connection>
-                  <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
-                  <Transform><Not/></Transform>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
-            </Children>
-          </WidgetGroup><!-- /Vinyl Controls toggles -->
-
-          <WidgetGroup><ObjectName>Spacer0f</ObjectName><Size>1f,1min</Size></WidgetGroup>
 
           <Template src="skin:vinyl_controls_right.xml"/>
 

--- a/res/skins/Tango/vinyl_controls_left.xml
+++ b/res/skins/Tango/vinyl_controls_left.xml
@@ -10,117 +10,172 @@ Variables:
 -->
 <Template>
   <WidgetGroup>
-    <ObjectName>Spacer0f</ObjectName>
-    <Layout>vertical</Layout>
+    <Layout>horizontal</Layout>
     <Size>-1max,50f</Size>
     <Children>
 
-      <!-- Vinyl / Passthrough -->
-      <WidgetGroup>
-        <Layout>horizontal</Layout>
-        <SizePolicy>min,min</SizePolicy>
+      <WidgetGroup><ObjectName>Spacer0f</ObjectName><Size>1f,1min</Size></WidgetGroup>
+
+      <WidgetGroup><!-- Vinyl Controls -->
+        <ObjectName>Spacer0f</ObjectName>
+        <Layout>vertical</Layout>
+        <Size>-1max,50f</Size>
         <Children>
 
-          <WidgetGroup><!-- Toggle Vinyl Control, statuslight underneath -->
-            <Layout>stacked</Layout>
+          <!-- Vinyl / Passthrough -->
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
             <SizePolicy>min,min</SizePolicy>
             <Children>
+
+              <WidgetGroup><!-- Toggle Vinyl Control, statuslight underneath -->
+                <Layout>stacked</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                  <Template src="skin:button_2state.xml">
+                    <SetVariable name="TooltipId">vinylcontrol_enabled</SetVariable>
+                    <SetVariable name="ObjectName">VinylControlButton</SetVariable>
+                    <SetVariable name="Size">40f,27f</SetVariable>
+                    <SetVariable name="state_0_text">VINYL</SetVariable>
+                    <SetVariable name="state_1_text">VINYL</SetVariable>
+                    <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_enabled</SetVariable>
+                    <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,vinylcontrol_status</SetVariable>
+                  </Template>
+
+                  <Template src="skin:statuslight_4state.xml">
+                    <SetVariable name="ObjectName">VinylControlStatus</SetVariable>
+                    <SetVariable name="Size">40f,27f</SetVariable>
+                    <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,vinylcontrol_status</SetVariable>
+                  </Template>
+                </Children>
+              </WidgetGroup><!-- /Toggle Vinyl Control, statuslight underneath -->
+
+              <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
+
               <Template src="skin:button_2state.xml">
-                <SetVariable name="TooltipId">vinylcontrol_enabled</SetVariable>
-                <SetVariable name="ObjectName">VinylControlButton</SetVariable>
+                <SetVariable name="TooltipId">passthrough_enabled</SetVariable>
+                <SetVariable name="ObjectName">PassthroughButton</SetVariable>
                 <SetVariable name="Size">40f,27f</SetVariable>
-                <SetVariable name="state_0_text">VINYL</SetVariable>
-                <SetVariable name="state_1_text">VINYL</SetVariable>
-                <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_enabled</SetVariable>
-                <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,vinylcontrol_status</SetVariable>
+                <SetVariable name="state_0_text">PASS</SetVariable>
+                <SetVariable name="state_1_text">PASS</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="group"/>,passthrough</SetVariable>
               </Template>
 
-              <Template src="skin:statuslight_4state.xml">
-                <SetVariable name="ObjectName">VinylControlStatus</SetVariable>
-                <SetVariable name="Size">40f,27f</SetVariable>
-                <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,vinylcontrol_status</SetVariable>
-              </Template>
+              <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
+
             </Children>
-          </WidgetGroup><!-- /Toggle Vinyl Control, statuslight underneath -->
-
-          <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
-
-          <Template src="skin:button_2state.xml">
-            <SetVariable name="TooltipId">passthrough_enabled</SetVariable>
-            <SetVariable name="ObjectName">PassthroughButton</SetVariable>
-            <SetVariable name="Size">40f,27f</SetVariable>
-            <SetVariable name="state_0_text">PASS</SetVariable>
-            <SetVariable name="state_1_text">PASS</SetVariable>
-            <SetVariable name="ConfigKey"><Variable name="group"/>,passthrough</SetVariable>
-          </Template>
-
-          <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
-
-        </Children>
-      </WidgetGroup><!-- Vinyl / Passthrough -->
-
-      <WidgetGroup><Size>1f,1f</Size></WidgetGroup>
-
-      <!-- Vinyl mode / Cue mode -->
-      <WidgetGroup>
-        <Layout>horizontal</Layout>
-        <SizePolicy>min,min</SizePolicy>
-        <Children>
-
-          <Template src="skin:button_3state_persist.xml">
-            <SetVariable name="TooltipId">vinylcontrol_mode</SetVariable>
-            <SetVariable name="ObjectName">VinylModeButton</SetVariable>
-            <SetVariable name="Size">40f,21f</SetVariable>
-            <SetVariable name="state_0_text">ABS</SetVariable>
-            <SetVariable name="state_1_text">REL</SetVariable>
-            <SetVariable name="state_2_text">CONST</SetVariable>
-            <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_mode</SetVariable>
-          </Template>
+          </WidgetGroup><!-- Vinyl / Passthrough -->
 
           <WidgetGroup><Size>1f,1f</Size></WidgetGroup>
 
-          <WidgetGroup><!-- Cue mode button with translucent cover -->
-            <Layout>stacked</Layout>
-            <Size>40f,21f</Size>
+          <!-- Vinyl mode / Cue mode -->
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
+            <SizePolicy>min,min</SizePolicy>
             <Children>
-              <!-- index 0 due to bug -->
-              <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
-
-              <!-- Block mouse when Vinyl control is not in RELATIVE mode -->
-              <WidgetGroup>
-                <TooltipId>vinylcontrol_cueing</TooltipId>
-                <ObjectName>SubmenuCover</ObjectName>
-                <Layout>vertical</Layout>
-                <Size>40f,21f</Size>
-                <Connection>
-                  <ConfigKey persist="true"><Variable name="group"/>,vinylcontrol_mode</ConfigKey>
-                  <Transform><IsEqual>1</IsEqual><Not/></Transform>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
 
               <Template src="skin:button_3state_persist.xml">
-                <SetVariable name="TooltipId">vinylcontrol_cueing</SetVariable>
+                <SetVariable name="TooltipId">vinylcontrol_mode</SetVariable>
                 <SetVariable name="ObjectName">VinylModeButton</SetVariable>
                 <SetVariable name="Size">40f,21f</SetVariable>
-                <SetVariable name="state_0_text">CUE</SetVariable>
-                <SetVariable name="state_1_text">CUE</SetVariable>
-                <SetVariable name="state_2_text">HOT</SetVariable>
-                <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_cueing</SetVariable>
+                <SetVariable name="state_0_text">ABS</SetVariable>
+                <SetVariable name="state_1_text">REL</SetVariable>
+                <SetVariable name="state_2_text">CONST</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_mode</SetVariable>
               </Template>
-            </Children>
-          </WidgetGroup><!-- /Cue mode button with translucent covers -->
 
-          <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
+              <WidgetGroup><Size>1f,1f</Size></WidgetGroup>
+
+              <WidgetGroup><!-- Cue mode button with translucent cover -->
+                <Layout>stacked</Layout>
+                <Size>40f,21f</Size>
+                <Children>
+                  <!-- index 0 due to bug -->
+                  <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
+
+                  <!-- Block mouse when Vinyl control is not in RELATIVE mode -->
+                  <WidgetGroup>
+                    <TooltipId>vinylcontrol_cueing</TooltipId>
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>vertical</Layout>
+                    <Size>40f,21f</Size>
+                    <Connection>
+                      <ConfigKey persist="true"><Variable name="group"/>,vinylcontrol_mode</ConfigKey>
+                      <Transform><IsEqual>1</IsEqual><Not/></Transform>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
+
+                  <Template src="skin:button_3state_persist.xml">
+                    <SetVariable name="TooltipId">vinylcontrol_cueing</SetVariable>
+                    <SetVariable name="ObjectName">VinylModeButton</SetVariable>
+                    <SetVariable name="Size">40f,21f</SetVariable>
+                    <SetVariable name="state_0_text">CUE</SetVariable>
+                    <SetVariable name="state_1_text">CUE</SetVariable>
+                    <SetVariable name="state_2_text">HOT</SetVariable>
+                    <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_cueing</SetVariable>
+                  </Template>
+                </Children>
+              </WidgetGroup><!-- /Cue mode button with translucent covers -->
+
+              <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
+
+            </Children>
+          </WidgetGroup> <!-- /Vinyl mode / Cue mode -->
+
+          <WidgetGroup><Size>1,1f</Size></WidgetGroup>
 
         </Children>
-      </WidgetGroup> <!-- /Vinyl mode / Cue mode -->
+        <Connection>
+          <ConfigKey persist="true">[Tango],vinylControlsDeck<Variable name="chanNum"/></ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup><!-- Vinyl Controls -->
 
-      <WidgetGroup><Size>1,1f</Size></WidgetGroup>
+      <WidgetGroup><!-- Vinyl Controls expand toggle -->
+        <Size>15f,50f</Size>
+        <Layout>vertical</Layout>
+        <Children>
+          <WidgetGroup><!-- with passthrough ON -->
+            <Size>15f,50f</Size>
+            <Layout>horizontal</Layout>
+            <Children>
+              <Template src="skin:button_2state.xml">
+                <SetVariable name="ObjectName">VinylTogglerLeftPassthrough</SetVariable>
+                <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
+                <SetVariable name="Size">15f,50f</SetVariable>
+                <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
+              </Template>
+            </Children>
+            <Connection>
+              <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup>
+
+          <WidgetGroup><!-- with passthrough OFF -->
+            <Size>15f,50f</Size>
+            <Layout>horizontal</Layout>
+            <Children>
+              <Template src="skin:button_2state.xml">
+                <SetVariable name="ObjectName">VinylTogglerLeft</SetVariable>
+                <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
+                <SetVariable name="Size">15f,50f</SetVariable>
+                <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
+              </Template>
+            </Children>
+            <Connection>
+              <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
+              <Transform><Not/></Transform>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup>
+        </Children>
+      </WidgetGroup><!-- /Vinyl Controls expand toggle -->
 
     </Children>
     <Connection>
-      <ConfigKey persist="true">[Tango],vinylControlsDeck<Variable name="chanNum"/></ConfigKey>
+      <ConfigKey><Variable name="group"/>,input_configured</ConfigKey>
       <BindProperty>visible</BindProperty>
     </Connection>
   </WidgetGroup>

--- a/res/skins/Tango/vinyl_controls_right.xml
+++ b/res/skins/Tango/vinyl_controls_right.xml
@@ -10,132 +10,187 @@ Variables:
 -->
 <Template>
   <WidgetGroup>
-    <ObjectName>Spacer0f</ObjectName>
-    <Layout>vertical</Layout>
+    <Layout>horizontal</Layout>
     <Size>-1max,50f</Size>
     <Children>
 
-      <WidgetGroup>
-        <Size>1min,1f</Size>
-        <Connection>
-          <ConfigKey persist="true">[Tango],symmetric_overviews</ConfigKey>
-          <Transform><Not/></Transform>
-          <BindProperty>visible</BindProperty>
-        </Connection>
-      </WidgetGroup>
-
-      <!-- Vinyl / Passthrough -->
-      <WidgetGroup>
-        <Layout>horizontal</Layout>
-        <SizePolicy>min,min</SizePolicy>
+      <WidgetGroup><!-- Vinyl Controls expand toggle -->
+        <Size>15f,50f</Size>
+        <Layout>vertical</Layout>
         <Children>
-
-          <WidgetGroup><!-- Toggle Vinyl Control, statuslight underneath -->
-            <Layout>stacked</Layout>
-            <SizePolicy>min,min</SizePolicy>
+          <WidgetGroup><!-- with passthrough ON -->
+            <Size>15f,50f</Size>
+            <Layout>horizontal</Layout>
             <Children>
               <Template src="skin:button_2state.xml">
-                <SetVariable name="TooltipId">vinylcontrol_enabled</SetVariable>
-                <SetVariable name="ObjectName">VinylControlButton</SetVariable>
-                <SetVariable name="Size">40f,27f</SetVariable>
-                <SetVariable name="state_0_text">VINYL</SetVariable>
-                <SetVariable name="state_1_text">VINYL</SetVariable>
-                <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_enabled</SetVariable>
-                <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,vinylcontrol_status</SetVariable>
-              </Template>
-
-              <Template src="skin:statuslight_4state.xml">
-                <SetVariable name="ObjectName">VinylControlStatus</SetVariable>
-                <SetVariable name="Size">40f,27f</SetVariable>
-                <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,vinylcontrol_status</SetVariable>
+                <SetVariable name="ObjectName">VinylTogglerRightPassthrough</SetVariable>
+                <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
+                <SetVariable name="Size">15f,50f</SetVariable>
+                <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
               </Template>
             </Children>
-          </WidgetGroup><!-- /Toggle Vinyl Control, statuslight underneath -->
+            <Connection>
+              <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup>
 
-          <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
-
-          <Template src="skin:button_2state.xml">
-            <SetVariable name="TooltipId">passthrough_enabled</SetVariable>
-            <SetVariable name="ObjectName">PassthroughButton</SetVariable>
-            <SetVariable name="Size">40f,27f</SetVariable>
-            <SetVariable name="state_0_text">PASS</SetVariable>
-            <SetVariable name="state_1_text">PASS</SetVariable>
-            <SetVariable name="ConfigKey"><Variable name="group"/>,passthrough</SetVariable>
-          </Template>
-
-          <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
-
+          <WidgetGroup><!-- with passthrough OFF -->
+            <Size>15f,50f</Size>
+            <Layout>horizontal</Layout>
+            <Children>
+              <Template src="skin:button_2state.xml">
+                <SetVariable name="ObjectName">VinylTogglerRight</SetVariable>
+                <SetVariable name="TooltipId">show_vinylcontrol</SetVariable>
+                <SetVariable name="Size">15f,50f</SetVariable>
+                <SetVariable name="ConfigKey">[Tango],vinylControlsDeck<Variable name="chanNum"/></SetVariable>
+              </Template>
+            </Children>
+            <Connection>
+              <ConfigKey><Variable name="group"/>,passthrough</ConfigKey>
+              <Transform><Not/></Transform>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup>
         </Children>
-      </WidgetGroup><!-- Vinyl / Passthrough -->
+      </WidgetGroup><!-- /Vinyl Controls expand toggle -->
 
-      <WidgetGroup><Size>1f,1f</Size></WidgetGroup>
+      <WidgetGroup><ObjectName>Spacer0f</ObjectName><Size>1f,1min</Size></WidgetGroup>
 
-      <!-- Vinyl mode / Cue mode -->
       <WidgetGroup>
-        <Layout>horizontal</Layout>
-        <SizePolicy>min,min</SizePolicy>
+        <ObjectName>Spacer0f</ObjectName>
+        <Layout>vertical</Layout>
+        <Size>-1max,50f</Size>
         <Children>
 
-          <Template src="skin:button_3state_persist.xml">
-            <SetVariable name="TooltipId">vinylcontrol_mode</SetVariable>
-            <SetVariable name="ObjectName">VinylModeButton</SetVariable>
-            <SetVariable name="Size">40f,21f</SetVariable>
-            <SetVariable name="state_0_text">ABS</SetVariable>
-            <SetVariable name="state_1_text">REL</SetVariable>
-            <SetVariable name="state_2_text">CONST</SetVariable>
-            <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_mode</SetVariable>
-          </Template>
+          <WidgetGroup>
+            <Size>1min,1f</Size>
+            <Connection>
+              <ConfigKey persist="true">[Tango],symmetric_overviews</ConfigKey>
+              <Transform><Not/></Transform>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup>
+
+          <!-- Vinyl / Passthrough -->
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
+            <SizePolicy>min,min</SizePolicy>
+            <Children>
+
+              <WidgetGroup><!-- Toggle Vinyl Control, statuslight underneath -->
+                <Layout>stacked</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                  <Template src="skin:button_2state.xml">
+                    <SetVariable name="TooltipId">vinylcontrol_enabled</SetVariable>
+                    <SetVariable name="ObjectName">VinylControlButton</SetVariable>
+                    <SetVariable name="Size">40f,27f</SetVariable>
+                    <SetVariable name="state_0_text">VINYL</SetVariable>
+                    <SetVariable name="state_1_text">VINYL</SetVariable>
+                    <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_enabled</SetVariable>
+                    <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,vinylcontrol_status</SetVariable>
+                  </Template>
+
+                  <Template src="skin:statuslight_4state.xml">
+                    <SetVariable name="ObjectName">VinylControlStatus</SetVariable>
+                    <SetVariable name="Size">40f,27f</SetVariable>
+                    <SetVariable name="ConfigKeyDisp"><Variable name="group"/>,vinylcontrol_status</SetVariable>
+                  </Template>
+                </Children>
+              </WidgetGroup><!-- /Toggle Vinyl Control, statuslight underneath -->
+
+              <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
+
+              <Template src="skin:button_2state.xml">
+                <SetVariable name="TooltipId">passthrough_enabled</SetVariable>
+                <SetVariable name="ObjectName">PassthroughButton</SetVariable>
+                <SetVariable name="Size">40f,27f</SetVariable>
+                <SetVariable name="state_0_text">PASS</SetVariable>
+                <SetVariable name="state_1_text">PASS</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="group"/>,passthrough</SetVariable>
+              </Template>
+
+              <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
+
+            </Children>
+          </WidgetGroup><!-- Vinyl / Passthrough -->
 
           <WidgetGroup><Size>1f,1f</Size></WidgetGroup>
 
-          <WidgetGroup><!-- Cue mode button with translucent cover -->
-            <Layout>stacked</Layout>
-            <Size>40f,21f</Size>
+          <!-- Vinyl mode / Cue mode -->
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
+            <SizePolicy>min,min</SizePolicy>
             <Children>
-              <!-- index 0 due to bug -->
-              <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
-
-              <!-- Block mouse when Vinyl control is not in RELATIVE mode -->
-              <WidgetGroup>
-                <TooltipId>vinylcontrol_cueing</TooltipId>
-                <ObjectName>SubmenuCover</ObjectName>
-                <Layout>vertical</Layout>
-                <Size>40f,21f</Size>
-                <Connection>
-                  <ConfigKey persist="true"><Variable name="group"/>,vinylcontrol_mode</ConfigKey>
-                  <Transform><IsEqual>1</IsEqual><Not/></Transform>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup>
 
               <Template src="skin:button_3state_persist.xml">
-                <SetVariable name="TooltipId">vinylcontrol_cueing</SetVariable>
+                <SetVariable name="TooltipId">vinylcontrol_mode</SetVariable>
                 <SetVariable name="ObjectName">VinylModeButton</SetVariable>
                 <SetVariable name="Size">40f,21f</SetVariable>
-                <SetVariable name="state_0_text">CUE</SetVariable>
-                <SetVariable name="state_1_text">CUE</SetVariable>
-                <SetVariable name="state_2_text">HOT</SetVariable>
-                <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_cueing</SetVariable>
+                <SetVariable name="state_0_text">ABS</SetVariable>
+                <SetVariable name="state_1_text">REL</SetVariable>
+                <SetVariable name="state_2_text">CONST</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_mode</SetVariable>
               </Template>
-            </Children>
-          </WidgetGroup><!-- /Cue mode button with translucent covers -->
 
-          <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
+              <WidgetGroup><Size>1f,1f</Size></WidgetGroup>
+
+              <WidgetGroup><!-- Cue mode button with translucent cover -->
+                <Layout>stacked</Layout>
+                <Size>40f,21f</Size>
+                <Children>
+                  <!-- index 0 due to bug -->
+                  <WidgetGroup><Size>0f,0f</Size></WidgetGroup>
+
+                  <!-- Block mouse when Vinyl control is not in RELATIVE mode -->
+                  <WidgetGroup>
+                    <TooltipId>vinylcontrol_cueing</TooltipId>
+                    <ObjectName>SubmenuCover</ObjectName>
+                    <Layout>vertical</Layout>
+                    <Size>40f,21f</Size>
+                    <Connection>
+                      <ConfigKey persist="true"><Variable name="group"/>,vinylcontrol_mode</ConfigKey>
+                      <Transform><IsEqual>1</IsEqual><Not/></Transform>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
+
+                  <Template src="skin:button_3state_persist.xml">
+                    <SetVariable name="TooltipId">vinylcontrol_cueing</SetVariable>
+                    <SetVariable name="ObjectName">VinylModeButton</SetVariable>
+                    <SetVariable name="Size">40f,21f</SetVariable>
+                    <SetVariable name="state_0_text">CUE</SetVariable>
+                    <SetVariable name="state_1_text">CUE</SetVariable>
+                    <SetVariable name="state_2_text">HOT</SetVariable>
+                    <SetVariable name="ConfigKey"><Variable name="group"/>,vinylcontrol_cueing</SetVariable>
+                  </Template>
+                </Children>
+              </WidgetGroup><!-- /Cue mode button with translucent covers -->
+
+              <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
+
+            </Children>
+          </WidgetGroup> <!-- /Vinyl mode / Cue mode -->
+
+          <WidgetGroup>
+            <Size>1min,1f</Size>
+            <Connection>
+              <ConfigKey persist="true">[Tango],symmetric_overviews</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup>
 
         </Children>
-      </WidgetGroup> <!-- /Vinyl mode / Cue mode -->
-
-      <WidgetGroup>
-        <Size>1min,1f</Size>
         <Connection>
-          <ConfigKey persist="true">[Tango],symmetric_overviews</ConfigKey>
+          <ConfigKey persist="true">[Tango],vinylControlsDeck<Variable name="chanNum"/></ConfigKey>
           <BindProperty>visible</BindProperty>
         </Connection>
       </WidgetGroup>
 
     </Children>
     <Connection>
-      <ConfigKey persist="true">[Tango],vinylControlsDeck<Variable name="chanNum"/></ConfigKey>
+      <ConfigKey><Variable name="group"/>,input_configured</ConfigKey>
       <BindProperty>visible</BindProperty>
     </Connection>
   </WidgetGroup>


### PR DESCRIPTION
picking up [PASS button](https://mixxx.zulipchat.com/#narrow/stream/109122-general/topic/PASS.20button) thread on Zulip

Show vinyl controls only when an audio device is set up for the respective deck.
First of all it hides useless GUI controls, and it prevents stopping decks when accidentially clicking Passthrough.

**Drawback:** no GUI feedback when `[VinylControl],show_vinylcontrol` is toggled without vinyl devices.

**Solution:** when there are no vinyl devices set up
**a)** disable **View > Show Vinyl Control Section** menu action
**b)** show Vinyl configuration popup when `[VinylControl],show_vinylcontrol` is enabled
Both require extra slot(s) and signals in mixxx.cpp and elsewhere for when the vinyl setup changes.

Opinions?