### PR TITLE
Spinny: draw playposition marker on top of ghost marker

### DIFF
--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -371,13 +371,6 @@ void WSpinny::render(VSyncThread* vSyncThread) {
         m_dGhostAngleLastPlaypos = m_dGhostAngleCurrentPlaypos;
     }
 
-    if (m_pFgImage && !m_pFgImage->isNull()) {
-        // Now rotate the image and draw it on the screen.
-        p.rotate(m_fAngle);
-        p.drawImage(-(m_fgImageScaled.width() / 2),
-                    -(m_fgImageScaled.height() / 2), m_fgImageScaled);
-    }
-
     if (paintGhost) {
         p.restore();
         p.save();
@@ -388,6 +381,13 @@ void WSpinny::render(VSyncThread* vSyncThread) {
         //Rotate back to the playback position (not the ghost position),
         //and draw the beat marks from there.
         p.restore();
+    }
+
+    if (m_pFgImage && !m_pFgImage->isNull()) {
+        // Now rotate the image and draw it on the screen.
+        p.rotate(m_fAngle);
+        p.drawImage(-(m_fgImageScaled.width() / 2),
+                    -(m_fgImageScaled.height() / 2), m_fgImageScaled);
     }
 }
 


### PR DESCRIPTION
https://bugs.launchpad.net/mixxx/+bug/1852880

because it feels more natural if the the audible, scratch-able playposition marker is on top, and the ghost marker is sweeping underneath.